### PR TITLE
Given a tiny timeout, NewStream could timeout before a stream is created...

### DIFF
--- a/rpc/transport/http2_server_transport.go
+++ b/rpc/transport/http2_server_transport.go
@@ -43,11 +43,11 @@ import (
 	"strconv"
 	"sync"
 
+	"github.com/bradfitz/http2"
+	"github.com/bradfitz/http2/hpack"
 	"github.com/google/grpc-go/rpc/codes"
 	"github.com/google/grpc-go/rpc/metadata"
 	"golang.org/x/net/context"
-	"github.com/bradfitz/http2/hpack"
-	"github.com/bradfitz/http2"
 )
 
 // http2Server implements the ServerTransport interface with HTTP2.

--- a/rpc/transport/http_util.go
+++ b/rpc/transport/http_util.go
@@ -39,10 +39,10 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/bradfitz/http2"
+	"github.com/bradfitz/http2/hpack"
 	"github.com/google/grpc-go/rpc/codes"
 	"github.com/google/grpc-go/rpc/metadata"
-	"github.com/bradfitz/http2/hpack"
-	"github.com/bradfitz/http2"
 )
 
 const (


### PR DESCRIPTION
.... In

that case we must not call hpack.Encoder.WriteField because hpack.Encoder is
stateful.
