### PR TITLE
Add import comments to grpc packages.

### DIFF
--- a/codes/codes.go
+++ b/codes/codes.go
@@ -33,7 +33,7 @@
 
 // Package codes defines the canonical error codes used by gRPC. It is
 // consistent across various languages.
-package codes
+package codes // import "google.golang.org/grpc/codes"
 
 // A Code is an unsigned 32-bit error code as defined in the gRPC spec.
 type Code uint32

--- a/credentials/credentials.go
+++ b/credentials/credentials.go
@@ -32,7 +32,7 @@
  */
 
 // Package credentials implements various credentials supported by gRPC library.
-package credentials
+package credentials // import "google.golang.org/grpc/credentials"
 
 import (
 	"crypto/tls"

--- a/doc.go
+++ b/doc.go
@@ -3,4 +3,4 @@ Package grpc implements an RPC system called gRPC.
 
 See https://github.com/grpc/grpc for more information about gRPC.
 */
-package grpc
+package grpc // import "google.golang.org/grpc"

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -32,7 +32,7 @@
  */
 
 // Package metadata define the structure of the metadata supported by gRPC library.
-package metadata
+package metadata // import "google.golang.org/grpc/metadata"
 
 import (
 	"encoding/base64"

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -35,7 +35,7 @@
 Package transport defines and implements message oriented communication channel
 to complete various transactions (e.g., an RPC).
 */
-package transport
+package transport // import "google.golang.org/grpc/transport"
 
 import (
 	"bytes"
@@ -44,10 +44,10 @@ import (
 	"net"
 	"sync"
 
+	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/metadata"
-	"golang.org/x/net/context"
 )
 
 // recvMsg represents the received msg from the transport. All transport


### PR DESCRIPTION
This enforces that these packages are used with these import paths.
See http://golang.org/cmd/go/#hdr-Import_path_checking for documentation.
