### PR TITLE
Make error conveyance more idiomatic.

### DIFF
--- a/call.go
+++ b/call.go
@@ -83,7 +83,7 @@ func sendRPC(ctx context.Context, callHdr *transport.CallHdr, t transport.Client
 	// TODO(zhaoq): Support compression.
 	outBuf, err := encode(args, compressionNone)
 	if err != nil {
-		return nil, transport.StreamErrorf(codes.Internal, "%v", err)
+		return nil, transport.StreamErrorf(codes.Internal, "grpc: %v", err)
 	}
 	err = t.Write(stream, outBuf, opts)
 	if err != nil {

--- a/credentials/credentials.go
+++ b/credentials/credentials.go
@@ -235,4 +235,3 @@ func NewServiceAccountFromFile(keyFile string, scope ...string) (Credentials, er
 	}
 	return NewServiceAccountFromKey(jsonKey, scope...)
 }
-

--- a/interop/client/client.go
+++ b/interop/client/client.go
@@ -193,7 +193,7 @@ func doPingPong(tc testpb.TestServiceClient) {
 	var index int
 	for index < len(reqSizes) {
 		respParam := []*testpb.ResponseParameters{
-			&testpb.ResponseParameters{
+			{
 				Size: proto.Int32(int32(respSizes[index])),
 			},
 		}

--- a/rpc_util.go
+++ b/rpc_util.go
@@ -165,10 +165,10 @@ func recvProto(p *parser, m proto.Message) error {
 	switch pf {
 	case compressionNone:
 		if err := proto.Unmarshal(d, m); err != nil {
-			return Errorf(codes.Internal, "%v", err)
+			return Errorf(codes.Internal, "grpc: %v", err)
 		}
 	default:
-		return Errorf(codes.Internal, "compression is not supported yet.")
+		return Errorf(codes.Internal, "gprc: compression is not supported yet.")
 	}
 	return nil
 }
@@ -219,7 +219,7 @@ func toRPCErr(err error) error {
 			desc: e.Desc,
 		}
 	}
-	return Errorf(codes.Unknown, "failed to convert %v to rpcErr", err)
+	return Errorf(codes.Unknown, "grpc: failed to convert %v to rpcErr", err)
 }
 
 // convertCode converts a standard Go error into its canonical code. Note that

--- a/stream.go
+++ b/stream.go
@@ -153,7 +153,7 @@ func (cs *clientStream) SendProto(m proto.Message) (err error) {
 	}()
 	out, err := encode(m, compressionNone)
 	if err != nil {
-		return transport.StreamErrorf(codes.Internal, "%v", err)
+		return transport.StreamErrorf(codes.Internal, "grpc: %v", err)
 	}
 	return cs.t.Write(cs.s, out, &transport.Options{Last: false})
 }
@@ -167,7 +167,7 @@ func (cs *clientStream) RecvProto(m proto.Message) (err error) {
 		// Special handling for client streaming rpc.
 		if err = recvProto(cs.p, m); err != io.EOF {
 			cs.t.CloseStream(cs.s, err)
-			return fmt.Errorf("gRPC client streaming protocol violation: %v, want <EOF>", err)
+			return fmt.Errorf("grpc: client streaming protocol violation: %v, want <EOF>", err)
 		}
 	}
 	if _, ok := err.(transport.ConnectionError); !ok {
@@ -235,7 +235,7 @@ func (ss *serverStream) SetTrailer(md metadata.MD) {
 func (ss *serverStream) SendProto(m proto.Message) error {
 	out, err := encode(m, compressionNone)
 	if err != nil {
-		err = transport.StreamErrorf(codes.Internal, "%v", err)
+		err = transport.StreamErrorf(codes.Internal, "grpc: %v", err)
 		return err
 	}
 	return ss.t.Write(ss.s, out, &transport.Options{Last: false})

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -388,7 +388,7 @@ func TestPingPong(t *testing.T) {
 	var index int
 	for index < len(reqSizes) {
 		respParam := []*testpb.ResponseParameters{
-			&testpb.ResponseParameters{
+			{
 				Size: proto.Int32(int32(respSizes[index])),
 			},
 		}
@@ -443,7 +443,7 @@ func TestMetadataStreamingRPC(t *testing.T) {
 		var index int
 		for index < len(reqSizes) {
 			respParam := []*testpb.ResponseParameters{
-				&testpb.ResponseParameters{
+				{
 					Size: proto.Int32(int32(respSizes[index])),
 				},
 			}

--- a/transport/http_util.go
+++ b/transport/http_util.go
@@ -138,7 +138,7 @@ func newHPACKDecoder() *hpackDecoder {
 		case "grpc-status":
 			code, err := strconv.Atoi(f.Value)
 			if err != nil {
-				d.err = StreamErrorf(codes.Internal, "malformed grpc-status: %v", err)
+				d.err = StreamErrorf(codes.Internal, "grpc/transport: malformed grpc-status: %v", err)
 				return
 			}
 			d.state.statusCode = codes.Code(code)
@@ -149,7 +149,7 @@ func newHPACKDecoder() *hpackDecoder {
 			var err error
 			d.state.timeout, err = timeoutDecode(f.Value)
 			if err != nil {
-				d.err = StreamErrorf(codes.Internal, "malformed time-out: %v", err)
+				d.err = StreamErrorf(codes.Internal, "grpc/transport: malformed time-out: %v", err)
 				return
 			}
 		case ":path":
@@ -175,12 +175,12 @@ func (d *hpackDecoder) decodeClientHTTP2Headers(s *Stream, frame headerFrame) (e
 	d.err = nil
 	_, err = d.h.Write(frame.HeaderBlockFragment())
 	if err != nil {
-		err = StreamErrorf(codes.Internal, "HPACK header decode error: %v", err)
+		err = StreamErrorf(codes.Internal, "grpc/transport: HPACK header decode error: %v", err)
 	}
 
 	if frame.HeadersEnded() {
 		if closeErr := d.h.Close(); closeErr != nil && err == nil {
-			err = StreamErrorf(codes.Internal, "HPACK decoder close error: %v", closeErr)
+			err = StreamErrorf(codes.Internal, "grpc/transport: HPACK decoder close error: %v", closeErr)
 		}
 		endHeaders = true
 	}
@@ -195,12 +195,12 @@ func (d *hpackDecoder) decodeServerHTTP2Headers(s *Stream, frame headerFrame) (e
 	d.err = nil
 	_, err = d.h.Write(frame.HeaderBlockFragment())
 	if err != nil {
-		err = StreamErrorf(codes.Internal, "HPACK header decode error: %v", err)
+		err = StreamErrorf(codes.Internal, "grpc/transport: HPACK header decode error: %v", err)
 	}
 
 	if frame.HeadersEnded() {
 		if closeErr := d.h.Close(); closeErr != nil && err == nil {
-			err = StreamErrorf(codes.Internal, "HPACK decoder close error: %v", closeErr)
+			err = StreamErrorf(codes.Internal, "grpc/transport: HPACK decoder close error: %v", closeErr)
 		}
 		endHeaders = true
 	}
@@ -276,12 +276,12 @@ func timeoutEncode(t time.Duration) string {
 func timeoutDecode(s string) (time.Duration, error) {
 	size := len(s)
 	if size < 2 {
-		return 0, fmt.Errorf("timeout string is too short: %q", s)
+		return 0, fmt.Errorf("grpc/transport: timeout string is too short: %q", s)
 	}
 	unit := timeoutUnit(s[size-1])
 	d, ok := timeoutUnitToDuration(unit)
 	if !ok {
-		return 0, fmt.Errorf("timeout unit is not recognized: %q", s)
+		return 0, fmt.Errorf("grpc/transport: timeout unit is not recognized: %q", s)
 	}
 	t, err := strconv.ParseInt(s[:size-1], 10, 64)
 	if err != nil {

--- a/transport/http_util_test.go
+++ b/transport/http_util_test.go
@@ -75,9 +75,9 @@ func TestTimeoutDecode(t *testing.T) {
 		err error
 	}{
 		{"1234S", time.Second * 1234, nil},
-		{"1234x", 0, fmt.Errorf("timeout unit is not recognized: %q", "1234x")},
-		{"1", 0, fmt.Errorf("timeout string is too short: %q", "1")},
-		{"", 0, fmt.Errorf("timeout string is too short: %q", "")},
+		{"1234x", 0, fmt.Errorf("grpc/transport: timeout unit is not recognized: %q", "1234x")},
+		{"1", 0, fmt.Errorf("grpc/transport: timeout string is too short: %q", "1")},
+		{"", 0, fmt.Errorf("grpc/transport: timeout string is too short: %q", "")},
 	} {
 		d, err := timeoutDecode(test.s)
 		if d != test.d || fmt.Sprint(err) != fmt.Sprint(test.err) {

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -39,6 +39,7 @@ package transport // import "google.golang.org/grpc/transport"
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -244,13 +245,17 @@ func (s *Stream) StatusDesc() string {
 	return s.statusDesc
 }
 
+// ErrIllegalTrailerSet indicates that the trailer has already been set or it
+// is too late to do so.
+var ErrIllegalTrailerSet = errors.New("grpc/transport: trailer has been set")
+
 // SetTrailer sets the trailer metadata which will be sent with the RPC status
 // by the server. This can only be called at most once. Server side only.
 func (s *Stream) SetTrailer(md metadata.MD) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.trailer != nil {
-		return fmt.Errorf("transport: Trailer has been set")
+		return ErrIllegalTrailerSet
 	}
 	s.trailer = md.Copy()
 	return nil

--- a/transport/transport_test.go
+++ b/transport/transport_test.go
@@ -45,9 +45,9 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
-	"golang.org/x/net/context"
 )
 
 type server struct {


### PR DESCRIPTION
This commit applies two bulk changes to the grpc error reporting
mechanisms:

(1.) Error strings for errors that originate within grpc are prefixed
    with the package name for better clarity for where they originate
    since they could percolate up in the users call chains to the
    originator.

(2.) Errors that are, in fact, singletons have been converted from
    fmt.Errorf to errors.New and assigned as package-level variables.
    This bodes particularly well for enabling API customers to elect to
    handle these errors upon receipt via equality comparison.  This had
    been previous impossible with the original API.

Supplementarily, `gofmt -w -s=true` has been run on the repository to
cleanup residual defects, and it has detected and repaired a few.

TEST=Manual go test ./...

/CC: @iamqizhao 
