### PR TITLE
Gracefully deny supplemental transport shutdowns.

### DIFF
--- a/transport/http2_client.go
+++ b/transport/http2_client.go
@@ -35,6 +35,7 @@ package transport
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"log"
 	"math"
@@ -315,6 +316,10 @@ func (t *http2Client) CloseStream(s *Stream, err error) {
 // accessed any more.
 func (t *http2Client) Close() (err error) {
 	t.mu.Lock()
+	if t.state == closing {
+		t.mu.Unlock()
+		return errors.New("transport: Close() was already called")
+	}
 	t.state = closing
 	t.mu.Unlock()
 	close(t.shutdownChan)

--- a/transport/http2_server.go
+++ b/transport/http2_server.go
@@ -79,7 +79,7 @@ type http2Server struct {
 	// sendQuotaPool provides flow control to outbound message.
 	sendQuotaPool *quotaPool
 
-	mu            sync.Mutex
+	mu            sync.Mutex // guard the following
 	state         transportState
 	activeStreams map[uint32]*Stream
 	// Inbound quota for flow control
@@ -570,7 +570,7 @@ func (t *http2Server) Close() (err error) {
 	t.mu.Lock()
 	if t.state == closing {
 		t.mu.Unlock()
-		return
+		return errors.New("transport: Close() was already called")
 	}
 	t.state = closing
 	streams := t.activeStreams

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -186,7 +186,7 @@ type Stream struct {
 	// The key-value map of trailer metadata.
 	trailer metadata.MD
 
-	mu sync.RWMutex
+	mu sync.RWMutex // guard the following
 	// headerOK becomes true from the first header is about to send.
 	headerOk bool
 	state    streamState


### PR DESCRIPTION
This commit ensures that transport shutdowns do not panic on
supplemental shutdowns, even if users should not attempt multiple
shutdowns.  This is done to make the surface for users a little more
forgiving.

The _transport suffix in these implementation filenames are dropped
since they are already part of the transport package, which makes
the specification both redundant and adds stutter.

TEST=`go test ./...`
