### PR TITLE
Remove explicit Go version from Travis config.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 language: go
 
-go:
-  - 1.4
-
 install:
   - export GOPATH="$HOME/gopath"
   - mkdir -p "$GOPATH/src/google.golang.org"


### PR DESCRIPTION
The `language: go` statement already selects the latest stable release of Go.