### PR TITLE
Add timeout grpcDial option.

### DIFF
--- a/clientconn.go
+++ b/clientconn.go
@@ -84,9 +84,9 @@ func WithPerRPCCredentials(creds credentials.Credentials) DialOption {
 
 // WithTimeout returns a DialOption which configures a timeout duration
 // for dialing or reconnecting.
-func WithTimeout(t time.Duration) DialOption {
+func WithTimeout(d time.Duration) DialOption {
 	return func(o *dialOptions) {
-		o.timeout = t
+		o.timeout = d
 	}
 }
 

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -194,13 +194,12 @@ func (s *testServer) HalfDuplexCall(stream testpb.TestService_HalfDuplexCallServ
 const tlsDir = "testdata/"
 
 func TestDialTimeout(t *testing.T) {
-	conn, err := grpc.Dial("localhost:0",
-		grpc.WithTimeout(time.Duration(5*time.Microsecond)))
+	conn, err := grpc.Dial("localhost:0", grpc.WithTimeout(5*time.Microsecond))
 	if err == nil {
 		conn.Close()
 	}
 	if err != grpc.ErrTimeout {
-		t.Fatalf("Dial should have returned a timeout error.")
+		t.Fatalf("Expected %v, got %v", grpc.ErrTimeout, err)
 	}
 }
 

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -194,18 +194,7 @@ func (s *testServer) HalfDuplexCall(stream testpb.TestService_HalfDuplexCallServ
 const tlsDir = "testdata/"
 
 func TestDialTimeout(t *testing.T) {
-	lis, err := net.Listen("tcp", ":0")
-	if err != nil {
-		log.Fatalf("Failed to listen: %v", err)
-	}
-	defer lis.Close()
-	_, port, err := net.SplitHostPort(lis.Addr().String())
-	if err != nil {
-		log.Fatalf("Failed to parse listener address: %v", err)
-	}
-	addr := "localhost:" + port
-	lis.Close() // Force lis to close before we connect.
-	conn, err := grpc.Dial(addr, grpc.WithTimeout(time.Millisecond))
+	conn, err := grpc.Dial("Non-Existent.Server:80", grpc.WithTimeout(time.Microsecond))
 	if err == nil {
 		conn.Close()
 	}

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -193,6 +193,17 @@ func (s *testServer) HalfDuplexCall(stream testpb.TestService_HalfDuplexCallServ
 
 const tlsDir = "testdata/"
 
+func TestDialTimeout(t *testing.T) {
+	conn, err := grpc.Dial("localhost:0",
+		grpc.WithTimeout(time.Duration(5*time.Microsecond)))
+	if err == nil {
+		conn.Close()
+	}
+	if err != grpc.ErrTimeout {
+		t.Fatalf("Dial should have returned a timeout error.")
+	}
+}
+
 func setUp(useTLS bool, maxStream uint32) (s *grpc.Server, tc testpb.TestServiceClient) {
 	lis, err := net.Listen("tcp", ":0")
 	if err != nil {

--- a/transport/http2_server.go
+++ b/transport/http2_server.go
@@ -386,7 +386,7 @@ func (t *http2Server) writeHeaders(s *Stream, b *bytes.Buffer, endStream bool) e
 		}
 		if err != nil {
 			t.Close()
-			return ConnectionErrorf("transport: %v", err)
+			return ConnectionErrorf(err, "transport: %v", err)
 		}
 	}
 	return nil
@@ -476,7 +476,7 @@ func (t *http2Server) Write(s *Stream, data []byte, opts *Options) error {
 		}
 		if err := t.framer.WriteHeaders(p); err != nil {
 			t.Close()
-			return ConnectionErrorf("transport: %v", err)
+			return ConnectionErrorf(err, "transport: %v", err)
 		}
 		t.writableChan <- 0
 	}
@@ -524,7 +524,7 @@ func (t *http2Server) Write(s *Stream, data []byte, opts *Options) error {
 		}
 		if err := t.framer.WriteData(s.id, false, p); err != nil {
 			t.Close()
-			return ConnectionErrorf("transport: %v", err)
+			return ConnectionErrorf(err, "transport: %v", err)
 		}
 		t.writableChan <- 0
 	}


### PR DESCRIPTION
In addition to being triggered normally, the timeout will also be
triggered if the next backoff cycle would have taken us beyond its
boundry.

Also includes limited support for sensing temporary and permanent
network errors. In the case of a permanent error, fail immediately.

Closes #76 