### PR TITLE
Introduce grpc.Formatter abstraction to support non-protobuf IDL relatively easily.

### DIFF
--- a/call.go
+++ b/call.go
@@ -37,7 +37,6 @@ import (
 	"io"
 	"net"
 
-	"github.com/golang/protobuf/proto"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
@@ -48,7 +47,7 @@ import (
 // On error, it returns the error and indicates whether the call should be retried.
 //
 // TODO(zhaoq): Check whether the received message sequence is valid.
-func recv(t transport.ClientTransport, c *callInfo, stream *transport.Stream, reply proto.Message) error {
+func recv(t transport.ClientTransport, c *callInfo, stream *transport.Stream, reply Formatter) error {
 	// Try to acquire header metadata from the server if there is any.
 	var err error
 	c.headerMD, err = stream.Header()
@@ -57,7 +56,7 @@ func recv(t transport.ClientTransport, c *callInfo, stream *transport.Stream, re
 	}
 	p := &parser{s: stream}
 	for {
-		if err = recvProto(p, reply); err != nil {
+		if err = recvMsg(p, reply); err != nil {
 			if err == io.EOF {
 				break
 			}
@@ -69,7 +68,7 @@ func recv(t transport.ClientTransport, c *callInfo, stream *transport.Stream, re
 }
 
 // sendRPC writes out various information of an RPC such as Context and Message.
-func sendRPC(ctx context.Context, callHdr *transport.CallHdr, t transport.ClientTransport, args proto.Message, opts *transport.Options) (_ *transport.Stream, err error) {
+func sendRPC(ctx context.Context, callHdr *transport.CallHdr, t transport.ClientTransport, args Formatter, opts *transport.Options) (_ *transport.Stream, err error) {
 	stream, err := t.NewStream(ctx, callHdr)
 	if err != nil {
 		return nil, err
@@ -103,7 +102,8 @@ type callInfo struct {
 
 // Invoke is called by the generated code. It sends the RPC request on the
 // wire and returns after response is received.
-func Invoke(ctx context.Context, method string, args, reply proto.Message, cc *ClientConn, opts ...CallOption) error {
+func Invoke(ctx context.Context, method string, args, reply Formatter, cc *ClientConn, opts ...CallOption) error {
+
 	var c callInfo
 	for _, o := range opts {
 		if err := o.before(&c); err != nil {

--- a/call.go
+++ b/call.go
@@ -47,7 +47,7 @@ import (
 // On error, it returns the error and indicates whether the call should be retried.
 //
 // TODO(zhaoq): Check whether the received message sequence is valid.
-func recv(t transport.ClientTransport, c *callInfo, stream *transport.Stream, reply Formatter) error {
+func recv(t transport.ClientTransport, c *callInfo, stream *transport.Stream, reply Marshaler) error {
 	// Try to acquire header metadata from the server if there is any.
 	var err error
 	c.headerMD, err = stream.Header()
@@ -68,7 +68,7 @@ func recv(t transport.ClientTransport, c *callInfo, stream *transport.Stream, re
 }
 
 // sendRPC writes out various information of an RPC such as Context and Message.
-func sendRPC(ctx context.Context, callHdr *transport.CallHdr, t transport.ClientTransport, args Formatter, opts *transport.Options) (_ *transport.Stream, err error) {
+func sendRPC(ctx context.Context, callHdr *transport.CallHdr, t transport.ClientTransport, args Marshaler, opts *transport.Options) (_ *transport.Stream, err error) {
 	stream, err := t.NewStream(ctx, callHdr)
 	if err != nil {
 		return nil, err
@@ -102,7 +102,7 @@ type callInfo struct {
 
 // Invoke is called by the generated code. It sends the RPC request on the
 // wire and returns after response is received.
-func Invoke(ctx context.Context, method string, args, reply Formatter, cc *ClientConn, opts ...CallOption) error {
+func Invoke(ctx context.Context, method string, args, reply Marshaler, cc *ClientConn, opts ...CallOption) error {
 
 	var c callInfo
 	for _, o := range opts {

--- a/formatter.go
+++ b/formatter.go
@@ -1,9 +1,44 @@
+/*
+ *
+ * Copyright 2014, Google Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
 package grpc
 
 import (
 	"github.com/golang/protobuf/proto"
 )
 
+// Formatter is an abstraction over message marshaling and unmarshaling in order
+// to support various message formats.
 type Formatter interface {
 	marshal() ([]byte, error)
 	unmarshal(buf []byte) error
@@ -24,6 +59,7 @@ func (m *protoMessage) unmarshal(buf []byte) error {
 	return proto.Unmarshal(buf, m.Message)
 }
 
+// NewProtoMessageFormatter creates a formatter for protobuf message marshaling and unmarshaling.
 func NewProtoMessageFormatter(m proto.Message) Formatter {
 	return &protoMessage{m}
 }

--- a/formatter.go
+++ b/formatter.go
@@ -1,0 +1,29 @@
+package grpc
+
+import (
+	"github.com/golang/protobuf/proto"
+)
+
+type Formatter interface {
+	marshal() ([]byte, error)
+	unmarshal(buf []byte) error
+}
+
+type protoMessage struct {
+	proto.Message
+}
+
+func (m *protoMessage) marshal() ([]byte, error) {
+	if m.Message == nil {
+		return nil, nil
+	}
+	return proto.Marshal(m.Message)
+}
+
+func (m *protoMessage) unmarshal(buf []byte) error {
+	return proto.Unmarshal(buf, m.Message)
+}
+
+func NewProtoMessageFormatter(m proto.Message) Formatter {
+	return &protoMessage{m}
+}

--- a/marshaler.go
+++ b/marshaler.go
@@ -37,9 +37,9 @@ import (
 	"github.com/golang/protobuf/proto"
 )
 
-// Formatter is an abstraction over message marshaling and unmarshaling in order
+// Marshaler is an abstraction over message marshaling and unmarshaling in order
 // to support various message formats.
-type Formatter interface {
+type Marshaler interface {
 	marshal() ([]byte, error)
 	unmarshal(buf []byte) error
 }
@@ -59,7 +59,7 @@ func (m *protoMessage) unmarshal(buf []byte) error {
 	return proto.Unmarshal(buf, m.Message)
 }
 
-// NewProtoMessageFormatter creates a formatter for protobuf message marshaling and unmarshaling.
-func NewProtoMessageFormatter(m proto.Message) Formatter {
+// NewProtoMessageMarshaler creates a formatter for protobuf message marshaling and unmarshaling.
+func NewProtoMessageMarshaler(m proto.Message) Marshaler {
 	return &protoMessage{m}
 }

--- a/rpc_util.go
+++ b/rpc_util.go
@@ -146,14 +146,14 @@ func encode(msg Marshaler, pf payloadFormat) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-func recvMsg(p *parser, f Marshaler) error {
+func recvMsg(p *parser, m Marshaler) error {
 	pf, d, err := p.recvMsg()
 	if err != nil {
 		return err
 	}
 	switch pf {
 	case compressionNone:
-		if err := f.unmarshal(d); err != nil {
+		if err := m.unmarshal(d); err != nil {
 			return Errorf(codes.Internal, "grpc: %v", err)
 		}
 	default:

--- a/rpc_util.go
+++ b/rpc_util.go
@@ -42,7 +42,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/golang/protobuf/proto"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
@@ -131,36 +130,30 @@ func (p *parser) recvMsg() (pf payloadFormat, msg []byte, err error) {
 
 // encode serializes msg and prepends the message header. If msg is nil, it
 // generates the message header of 0 message length.
-func encode(msg proto.Message, pf payloadFormat) ([]byte, error) {
+func encode(msg Formatter, pf payloadFormat) ([]byte, error) {
 	var buf bytes.Buffer
 	// Write message fixed header.
 	buf.WriteByte(uint8(pf))
-	var b []byte
-	var length uint32
-	if msg != nil {
-		var err error
-		// TODO(zhaoq): optimize to reduce memory alloc and copying.
-		b, err = proto.Marshal(msg)
-		if err != nil {
-			return nil, err
-		}
-		length = uint32(len(b))
+	// TODO(zhaoq): optimize to reduce memory alloc and copying.
+	b, err := msg.marshal()
+	if err != nil {
+		return nil, err
 	}
 	var szHdr [4]byte
-	binary.BigEndian.PutUint32(szHdr[:], length)
+	binary.BigEndian.PutUint32(szHdr[:], uint32(len(b)))
 	buf.Write(szHdr[:])
 	buf.Write(b)
 	return buf.Bytes(), nil
 }
 
-func recvProto(p *parser, m proto.Message) error {
+func recvMsg(p *parser, f Formatter) error {
 	pf, d, err := p.recvMsg()
 	if err != nil {
 		return err
 	}
 	switch pf {
 	case compressionNone:
-		if err := proto.Unmarshal(d, m); err != nil {
+		if err := f.unmarshal(d); err != nil {
 			return Errorf(codes.Internal, "grpc: %v", err)
 		}
 	default:

--- a/rpc_util.go
+++ b/rpc_util.go
@@ -130,7 +130,7 @@ func (p *parser) recvMsg() (pf payloadFormat, msg []byte, err error) {
 
 // encode serializes msg and prepends the message header. If msg is nil, it
 // generates the message header of 0 message length.
-func encode(msg Formatter, pf payloadFormat) ([]byte, error) {
+func encode(msg Marshaler, pf payloadFormat) ([]byte, error) {
 	var buf bytes.Buffer
 	// Write message fixed header.
 	buf.WriteByte(uint8(pf))
@@ -146,7 +146,7 @@ func encode(msg Formatter, pf payloadFormat) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-func recvMsg(p *parser, f Formatter) error {
+func recvMsg(p *parser, f Marshaler) error {
 	pf, d, err := p.recvMsg()
 	if err != nil {
 		return err

--- a/rpc_util_test.go
+++ b/rpc_util_test.go
@@ -112,7 +112,8 @@ func TestEncode(t *testing.T) {
 	}{
 		{nil, compressionNone, []byte{0, 0, 0, 0, 0}, nil},
 	} {
-		b, err := encode(test.msg, test.pt)
+		pm := &protoMessage{test.msg}
+		b, err := encode(pm, test.pt)
 		if err != test.err || !bytes.Equal(b, test.b) {
 			t.Fatalf("encode(_, %d) = %v, %v\nwant %v, %v", test.pt, b, err, test.b, test.err)
 		}
@@ -175,7 +176,7 @@ func TestBackoff(t *testing.T) {
 // bmEncode benchmarks encoding a Protocol Buffer message containing mSize
 // bytes.
 func bmEncode(b *testing.B, mSize int) {
-	msg := &perfpb.Buffer{Body: make([]byte, mSize)}
+	msg := &protoMessage{&perfpb.Buffer{Body: make([]byte, mSize)}}
 	encoded, _ := encode(msg, compressionNone)
 	encodedSz := int64(len(encoded))
 	b.ReportAllocs()

--- a/rpc_util_test.go
+++ b/rpc_util_test.go
@@ -112,7 +112,7 @@ func TestEncode(t *testing.T) {
 	}{
 		{nil, compressionNone, []byte{0, 0, 0, 0, 0}, nil},
 	} {
-		pm := &protoMessage{test.msg}
+		pm := NewProtoMessageFormatter(test.msg)
 		b, err := encode(pm, test.pt)
 		if err != test.err || !bytes.Equal(b, test.b) {
 			t.Fatalf("encode(_, %d) = %v, %v\nwant %v, %v", test.pt, b, err, test.b, test.err)
@@ -176,7 +176,7 @@ func TestBackoff(t *testing.T) {
 // bmEncode benchmarks encoding a Protocol Buffer message containing mSize
 // bytes.
 func bmEncode(b *testing.B, mSize int) {
-	msg := &protoMessage{&perfpb.Buffer{Body: make([]byte, mSize)}}
+	msg := NewProtoMessageFormatter(&perfpb.Buffer{Body: make([]byte, mSize)})
 	encoded, _ := encode(msg, compressionNone)
 	encodedSz := int64(len(encoded))
 	b.ReportAllocs()

--- a/rpc_util_test.go
+++ b/rpc_util_test.go
@@ -112,7 +112,7 @@ func TestEncode(t *testing.T) {
 	}{
 		{nil, compressionNone, []byte{0, 0, 0, 0, 0}, nil},
 	} {
-		pm := NewProtoMessageFormatter(test.msg)
+		pm := NewProtoMessageMarshaler(test.msg)
 		b, err := encode(pm, test.pt)
 		if err != test.err || !bytes.Equal(b, test.b) {
 			t.Fatalf("encode(_, %d) = %v, %v\nwant %v, %v", test.pt, b, err, test.b, test.err)
@@ -176,7 +176,7 @@ func TestBackoff(t *testing.T) {
 // bmEncode benchmarks encoding a Protocol Buffer message containing mSize
 // bytes.
 func bmEncode(b *testing.B, mSize int) {
-	msg := NewProtoMessageFormatter(&perfpb.Buffer{Body: make([]byte, mSize)})
+	msg := NewProtoMessageMarshaler(&perfpb.Buffer{Body: make([]byte, mSize)})
 	encoded, _ := encode(msg, compressionNone)
 	encodedSz := int64(len(encoded))
 	b.ReportAllocs()

--- a/server.go
+++ b/server.go
@@ -49,7 +49,7 @@ import (
 	"google.golang.org/grpc/transport"
 )
 
-type methodHandler func(srv interface{}, ctx context.Context, buf []byte) (Formatter, error)
+type methodHandler func(srv interface{}, ctx context.Context, buf []byte) (Marshaler, error)
 
 // MethodDesc represents an RPC service's method specification.
 type MethodDesc struct {
@@ -202,7 +202,7 @@ func (s *Server) Serve(lis net.Listener) error {
 	}
 }
 
-func (s *Server) send(t transport.ServerTransport, stream *transport.Stream, f Formatter, pf payloadFormat, opts *transport.Options) error {
+func (s *Server) send(t transport.ServerTransport, stream *transport.Stream, f Marshaler, pf payloadFormat, opts *transport.Options) error {
 	p, err := encode(f, pf)
 	if err != nil {
 		// This typically indicates a fatal issue (e.g., memory

--- a/server.go
+++ b/server.go
@@ -43,14 +43,13 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/golang/protobuf/proto"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/transport"
 )
 
-type methodHandler func(srv interface{}, ctx context.Context, buf []byte) (proto.Message, error)
+type methodHandler func(srv interface{}, ctx context.Context, buf []byte) (Formatter, error)
 
 // MethodDesc represents an RPC service's method specification.
 type MethodDesc struct {
@@ -203,8 +202,8 @@ func (s *Server) Serve(lis net.Listener) error {
 	}
 }
 
-func (s *Server) sendProto(t transport.ServerTransport, stream *transport.Stream, msg proto.Message, pf payloadFormat, opts *transport.Options) error {
-	p, err := encode(msg, pf)
+func (s *Server) sendProto(t transport.ServerTransport, stream *transport.Stream, f Formatter, pf payloadFormat, opts *transport.Options) error {
+	p, err := encode(f, pf)
 	if err != nil {
 		// This typically indicates a fatal issue (e.g., memory
 		// corruption or hardware faults) the application program

--- a/server.go
+++ b/server.go
@@ -202,7 +202,7 @@ func (s *Server) Serve(lis net.Listener) error {
 	}
 }
 
-func (s *Server) sendProto(t transport.ServerTransport, stream *transport.Stream, f Formatter, pf payloadFormat, opts *transport.Options) error {
+func (s *Server) send(t transport.ServerTransport, stream *transport.Stream, f Formatter, pf payloadFormat, opts *transport.Options) error {
 	p, err := encode(f, pf)
 	if err != nil {
 		// This typically indicates a fatal issue (e.g., memory
@@ -260,7 +260,7 @@ func (s *Server) processUnaryRPC(t transport.ServerTransport, stream *transport.
 				Last:  true,
 				Delay: false,
 			}
-			if err := s.sendProto(t, stream, reply, compressionNone, opts); err != nil {
+			if err := s.send(t, stream, reply, compressionNone, opts); err != nil {
 				if _, ok := err.(transport.ConnectionError); ok {
 					return
 				}

--- a/server.go
+++ b/server.go
@@ -202,8 +202,8 @@ func (s *Server) Serve(lis net.Listener) error {
 	}
 }
 
-func (s *Server) send(t transport.ServerTransport, stream *transport.Stream, f Marshaler, pf payloadFormat, opts *transport.Options) error {
-	p, err := encode(f, pf)
+func (s *Server) send(t transport.ServerTransport, stream *transport.Stream, m Marshaler, pf payloadFormat, opts *transport.Options) error {
+	p, err := encode(m, pf)
 	if err != nil {
 		// This typically indicates a fatal issue (e.g., memory
 		// corruption or hardware faults) the application program

--- a/stream.go
+++ b/stream.go
@@ -38,7 +38,6 @@ import (
 	"io"
 	"net"
 
-	"github.com/golang/protobuf/proto"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
@@ -66,12 +65,12 @@ type Stream interface {
 	// On error, it aborts the stream and returns an RPC status on client
 	// side. On server side, it simply returns the error to the caller.
 	// SendProto is called by generated code.
-	SendProto(m proto.Message) error
+	SendProto(f Formatter) error
 	// RecvProto blocks until it receives a proto message or the stream is
 	// done. On client side, it returns io.EOF when the stream is done. On
 	// any other error, it aborts the streama nd returns an RPC status. On
 	// server side, it simply returns the error to the caller.
-	RecvProto(m proto.Message) error
+	RecvProto(f Formatter) error
 }
 
 // ClientStream defines the interface a client stream has to satify.
@@ -146,7 +145,7 @@ func (cs *clientStream) Trailer() metadata.MD {
 	return cs.s.Trailer()
 }
 
-func (cs *clientStream) SendProto(m proto.Message) (err error) {
+func (cs *clientStream) SendProto(m Formatter) (err error) {
 	defer func() {
 		if err == nil || err == io.EOF {
 			return
@@ -163,14 +162,14 @@ func (cs *clientStream) SendProto(m proto.Message) (err error) {
 	return cs.t.Write(cs.s, out, &transport.Options{Last: false})
 }
 
-func (cs *clientStream) RecvProto(m proto.Message) (err error) {
-	err = recvProto(cs.p, m)
+func (cs *clientStream) RecvProto(m Formatter) (err error) {
+	err = recvMsg(cs.p, m)
 	if err == nil {
 		if !cs.desc.ClientStreams || cs.desc.ServerStreams {
 			return
 		}
 		// Special handling for client streaming rpc.
-		err = recvProto(cs.p, m)
+		err = recvMsg(cs.p, m)
 		cs.t.CloseStream(cs.s, err)
 		if err == nil {
 			return toRPCErr(errors.New("grpc: client streaming protocol violation: get <nil>, want <EOF>"))
@@ -245,7 +244,7 @@ func (ss *serverStream) SetTrailer(md metadata.MD) {
 	return
 }
 
-func (ss *serverStream) SendProto(m proto.Message) error {
+func (ss *serverStream) SendProto(m Formatter) error {
 	out, err := encode(m, compressionNone)
 	if err != nil {
 		err = transport.StreamErrorf(codes.Internal, "grpc: %v", err)
@@ -254,6 +253,6 @@ func (ss *serverStream) SendProto(m proto.Message) error {
 	return ss.t.Write(ss.s, out, &transport.Options{Last: false})
 }
 
-func (ss *serverStream) RecvProto(m proto.Message) error {
-	return recvProto(ss.p, m)
+func (ss *serverStream) RecvProto(m Formatter) error {
+	return recvMsg(ss.p, m)
 }

--- a/stream.go
+++ b/stream.go
@@ -65,12 +65,12 @@ type Stream interface {
 	// On error, it aborts the stream and returns an RPC status on client
 	// side. On server side, it simply returns the error to the caller.
 	// SendMessage is called by generated code.
-	SendMessage(f Marshaler) error
+	SendMessage(m Marshaler) error
 	// RecvMessage blocks until it receives a proto message or the stream is
 	// done. On client side, it returns io.EOF when the stream is done. On
 	// any other error, it aborts the streama nd returns an RPC status. On
 	// server side, it simply returns the error to the caller.
-	RecvMessage(f Marshaler) error
+	RecvMessage(m Marshaler) error
 }
 
 // ClientStream defines the interface a client stream has to satify.

--- a/stream.go
+++ b/stream.go
@@ -60,17 +60,17 @@ type StreamDesc struct {
 type Stream interface {
 	// Context returns the context for this stream.
 	Context() context.Context
-	// SendProto blocks until it sends m, the stream is done or the stream
+	// SendMessage blocks until it sends m, the stream is done or the stream
 	// breaks.
 	// On error, it aborts the stream and returns an RPC status on client
 	// side. On server side, it simply returns the error to the caller.
-	// SendProto is called by generated code.
-	SendProto(f Formatter) error
-	// RecvProto blocks until it receives a proto message or the stream is
+	// SendMessage is called by generated code.
+	SendMessage(f Formatter) error
+	// RecvMessage blocks until it receives a proto message or the stream is
 	// done. On client side, it returns io.EOF when the stream is done. On
 	// any other error, it aborts the streama nd returns an RPC status. On
 	// server side, it simply returns the error to the caller.
-	RecvProto(f Formatter) error
+	RecvMessage(f Formatter) error
 }
 
 // ClientStream defines the interface a client stream has to satify.
@@ -145,7 +145,7 @@ func (cs *clientStream) Trailer() metadata.MD {
 	return cs.s.Trailer()
 }
 
-func (cs *clientStream) SendProto(m Formatter) (err error) {
+func (cs *clientStream) SendMessage(m Formatter) (err error) {
 	defer func() {
 		if err == nil || err == io.EOF {
 			return
@@ -162,7 +162,7 @@ func (cs *clientStream) SendProto(m Formatter) (err error) {
 	return cs.t.Write(cs.s, out, &transport.Options{Last: false})
 }
 
-func (cs *clientStream) RecvProto(m Formatter) (err error) {
+func (cs *clientStream) RecvMessage(m Formatter) (err error) {
 	err = recvMsg(cs.p, m)
 	if err == nil {
 		if !cs.desc.ClientStreams || cs.desc.ServerStreams {
@@ -210,8 +210,8 @@ func (cs *clientStream) CloseSend() (err error) {
 // ServerStream defines the interface a server stream has to satisfy.
 type ServerStream interface {
 	// SendHeader sends the header metadata. It should not be called
-	// after SendProto. It fails if called multiple times or if
-	// called after SendProto.
+	// after Send. It fails if called multiple times or if
+	// called after Send.
 	SendHeader(metadata.MD) error
 	// SetTrailer sets the trailer metadata which will be sent with the
 	// RPC status.
@@ -244,7 +244,7 @@ func (ss *serverStream) SetTrailer(md metadata.MD) {
 	return
 }
 
-func (ss *serverStream) SendProto(m Formatter) error {
+func (ss *serverStream) SendMessage(m Formatter) error {
 	out, err := encode(m, compressionNone)
 	if err != nil {
 		err = transport.StreamErrorf(codes.Internal, "grpc: %v", err)
@@ -253,6 +253,6 @@ func (ss *serverStream) SendProto(m Formatter) error {
 	return ss.t.Write(ss.s, out, &transport.Options{Last: false})
 }
 
-func (ss *serverStream) RecvProto(m Formatter) error {
+func (ss *serverStream) RecvMessage(m Formatter) error {
 	return recvMsg(ss.p, m)
 }

--- a/stream.go
+++ b/stream.go
@@ -65,12 +65,12 @@ type Stream interface {
 	// On error, it aborts the stream and returns an RPC status on client
 	// side. On server side, it simply returns the error to the caller.
 	// SendMessage is called by generated code.
-	SendMessage(f Formatter) error
+	SendMessage(f Marshaler) error
 	// RecvMessage blocks until it receives a proto message or the stream is
 	// done. On client side, it returns io.EOF when the stream is done. On
 	// any other error, it aborts the streama nd returns an RPC status. On
 	// server side, it simply returns the error to the caller.
-	RecvMessage(f Formatter) error
+	RecvMessage(f Marshaler) error
 }
 
 // ClientStream defines the interface a client stream has to satify.
@@ -145,7 +145,7 @@ func (cs *clientStream) Trailer() metadata.MD {
 	return cs.s.Trailer()
 }
 
-func (cs *clientStream) SendMessage(m Formatter) (err error) {
+func (cs *clientStream) SendMessage(m Marshaler) (err error) {
 	defer func() {
 		if err == nil || err == io.EOF {
 			return
@@ -162,7 +162,7 @@ func (cs *clientStream) SendMessage(m Formatter) (err error) {
 	return cs.t.Write(cs.s, out, &transport.Options{Last: false})
 }
 
-func (cs *clientStream) RecvMessage(m Formatter) (err error) {
+func (cs *clientStream) RecvMessage(m Marshaler) (err error) {
 	err = recvMsg(cs.p, m)
 	if err == nil {
 		if !cs.desc.ClientStreams || cs.desc.ServerStreams {
@@ -244,7 +244,7 @@ func (ss *serverStream) SetTrailer(md metadata.MD) {
 	return
 }
 
-func (ss *serverStream) SendMessage(m Formatter) error {
+func (ss *serverStream) SendMessage(m Marshaler) error {
 	out, err := encode(m, compressionNone)
 	if err != nil {
 		err = transport.StreamErrorf(codes.Internal, "grpc: %v", err)
@@ -253,6 +253,6 @@ func (ss *serverStream) SendMessage(m Formatter) error {
 	return ss.t.Write(ss.s, out, &transport.Options{Last: false})
 }
 
-func (ss *serverStream) RecvMessage(m Formatter) error {
+func (ss *serverStream) RecvMessage(m Marshaler) error {
 	return recvMsg(ss.p, m)
 }

--- a/test/grpc_testing/test.pb.go
+++ b/test/grpc_testing/test.pb.go
@@ -388,7 +388,7 @@ func (c *testServiceClient) StreamingOutputCall(ctx context.Context, in *Streami
 		return nil, err
 	}
 	x := &testServiceStreamingOutputCallClient{stream}
-	if err := x.ClientStream.SendProto(grpc.NewProtoMessageFormatter(in)); err != nil {
+	if err := x.ClientStream.SendMessage(grpc.NewProtoMessageFormatter(in)); err != nil {
 		return nil, err
 	}
 	if err := x.ClientStream.CloseSend(); err != nil {
@@ -408,7 +408,7 @@ type testServiceStreamingOutputCallClient struct {
 
 func (x *testServiceStreamingOutputCallClient) Recv() (*StreamingOutputCallResponse, error) {
 	m := new(StreamingOutputCallResponse)
-	if err := x.ClientStream.RecvProto(grpc.NewProtoMessageFormatter(m)); err != nil {
+	if err := x.ClientStream.RecvMessage(grpc.NewProtoMessageFormatter(m)); err != nil {
 		return nil, err
 	}
 	return m, nil
@@ -434,7 +434,7 @@ type testServiceStreamingInputCallClient struct {
 }
 
 func (x *testServiceStreamingInputCallClient) Send(m *StreamingInputCallRequest) error {
-	return x.ClientStream.SendProto(grpc.NewProtoMessageFormatter(m))
+	return x.ClientStream.SendMessage(grpc.NewProtoMessageFormatter(m))
 }
 
 func (x *testServiceStreamingInputCallClient) CloseAndRecv() (*StreamingInputCallResponse, error) {
@@ -442,7 +442,7 @@ func (x *testServiceStreamingInputCallClient) CloseAndRecv() (*StreamingInputCal
 		return nil, err
 	}
 	m := new(StreamingInputCallResponse)
-	if err := x.ClientStream.RecvProto(grpc.NewProtoMessageFormatter(m)); err != nil {
+	if err := x.ClientStream.RecvMessage(grpc.NewProtoMessageFormatter(m)); err != nil {
 		return nil, err
 	}
 	return m, nil
@@ -468,12 +468,12 @@ type testServiceFullDuplexCallClient struct {
 }
 
 func (x *testServiceFullDuplexCallClient) Send(m *StreamingOutputCallRequest) error {
-	return x.ClientStream.SendProto(grpc.NewProtoMessageFormatter(m))
+	return x.ClientStream.SendMessage(grpc.NewProtoMessageFormatter(m))
 }
 
 func (x *testServiceFullDuplexCallClient) Recv() (*StreamingOutputCallResponse, error) {
 	m := new(StreamingOutputCallResponse)
-	if err := x.ClientStream.RecvProto(grpc.NewProtoMessageFormatter(m)); err != nil {
+	if err := x.ClientStream.RecvMessage(grpc.NewProtoMessageFormatter(m)); err != nil {
 		return nil, err
 	}
 	return m, nil
@@ -499,12 +499,12 @@ type testServiceHalfDuplexCallClient struct {
 }
 
 func (x *testServiceHalfDuplexCallClient) Send(m *StreamingOutputCallRequest) error {
-	return x.ClientStream.SendProto(grpc.NewProtoMessageFormatter(m))
+	return x.ClientStream.SendMessage(grpc.NewProtoMessageFormatter(m))
 }
 
 func (x *testServiceHalfDuplexCallClient) Recv() (*StreamingOutputCallResponse, error) {
 	m := new(StreamingOutputCallResponse)
-	if err := x.ClientStream.RecvProto(grpc.NewProtoMessageFormatter(m)); err != nil {
+	if err := x.ClientStream.RecvMessage(grpc.NewProtoMessageFormatter(m)); err != nil {
 		return nil, err
 	}
 	return m, nil
@@ -565,7 +565,7 @@ func _TestService_UnaryCall_Handler(srv interface{}, ctx context.Context, buf []
 
 func _TestService_StreamingOutputCall_Handler(srv interface{}, stream grpc.ServerStream) error {
 	m := new(StreamingOutputCallRequest)
-	if err := stream.RecvProto(grpc.NewProtoMessageFormatter(m)); err != nil {
+	if err := stream.RecvMessage(grpc.NewProtoMessageFormatter(m)); err != nil {
 		return err
 	}
 	return srv.(TestServiceServer).StreamingOutputCall(m, &testServiceStreamingOutputCallServer{stream})
@@ -581,7 +581,7 @@ type testServiceStreamingOutputCallServer struct {
 }
 
 func (x *testServiceStreamingOutputCallServer) Send(m *StreamingOutputCallResponse) error {
-	return x.ServerStream.SendProto(grpc.NewProtoMessageFormatter(m))
+	return x.ServerStream.SendMessage(grpc.NewProtoMessageFormatter(m))
 }
 
 func _TestService_StreamingInputCall_Handler(srv interface{}, stream grpc.ServerStream) error {
@@ -599,12 +599,12 @@ type testServiceStreamingInputCallServer struct {
 }
 
 func (x *testServiceStreamingInputCallServer) SendAndClose(m *StreamingInputCallResponse) error {
-	return x.ServerStream.SendProto(grpc.NewProtoMessageFormatter(m))
+	return x.ServerStream.SendMessage(grpc.NewProtoMessageFormatter(m))
 }
 
 func (x *testServiceStreamingInputCallServer) Recv() (*StreamingInputCallRequest, error) {
 	m := new(StreamingInputCallRequest)
-	if err := x.ServerStream.RecvProto(grpc.NewProtoMessageFormatter(m)); err != nil {
+	if err := x.ServerStream.RecvMessage(grpc.NewProtoMessageFormatter(m)); err != nil {
 		return nil, err
 	}
 	return m, nil
@@ -625,12 +625,12 @@ type testServiceFullDuplexCallServer struct {
 }
 
 func (x *testServiceFullDuplexCallServer) Send(m *StreamingOutputCallResponse) error {
-	return x.ServerStream.SendProto(grpc.NewProtoMessageFormatter(m))
+	return x.ServerStream.SendMessage(grpc.NewProtoMessageFormatter(m))
 }
 
 func (x *testServiceFullDuplexCallServer) Recv() (*StreamingOutputCallRequest, error) {
 	m := new(StreamingOutputCallRequest)
-	if err := x.ServerStream.RecvProto(grpc.NewProtoMessageFormatter(m)); err != nil {
+	if err := x.ServerStream.RecvMessage(grpc.NewProtoMessageFormatter(m)); err != nil {
 		return nil, err
 	}
 	return m, nil
@@ -651,12 +651,12 @@ type testServiceHalfDuplexCallServer struct {
 }
 
 func (x *testServiceHalfDuplexCallServer) Send(m *StreamingOutputCallResponse) error {
-	return x.ServerStream.SendProto(grpc.NewProtoMessageFormatter(m))
+	return x.ServerStream.SendMessage(grpc.NewProtoMessageFormatter(m))
 }
 
 func (x *testServiceHalfDuplexCallServer) Recv() (*StreamingOutputCallRequest, error) {
 	m := new(StreamingOutputCallRequest)
-	if err := x.ServerStream.RecvProto(grpc.NewProtoMessageFormatter(m)); err != nil {
+	if err := x.ServerStream.RecvMessage(grpc.NewProtoMessageFormatter(m)); err != nil {
 		return nil, err
 	}
 	return m, nil

--- a/test/grpc_testing/test.pb.go
+++ b/test/grpc_testing/test.pb.go
@@ -366,7 +366,7 @@ func NewTestServiceClient(cc *grpc.ClientConn) TestServiceClient {
 
 func (c *testServiceClient) EmptyCall(ctx context.Context, in *Empty, opts ...grpc.CallOption) (*Empty, error) {
 	out := new(Empty)
-	err := grpc.Invoke(ctx, "/grpc.testing.TestService/EmptyCall", grpc.NewProtoMessageFormatter(in), grpc.NewProtoMessageFormatter(out), c.cc, opts...)
+	err := grpc.Invoke(ctx, "/grpc.testing.TestService/EmptyCall", grpc.NewProtoMessageMarshaler(in), grpc.NewProtoMessageMarshaler(out), c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -375,7 +375,7 @@ func (c *testServiceClient) EmptyCall(ctx context.Context, in *Empty, opts ...gr
 
 func (c *testServiceClient) UnaryCall(ctx context.Context, in *SimpleRequest, opts ...grpc.CallOption) (*SimpleResponse, error) {
 	out := new(SimpleResponse)
-	err := grpc.Invoke(ctx, "/grpc.testing.TestService/UnaryCall", grpc.NewProtoMessageFormatter(in), grpc.NewProtoMessageFormatter(out), c.cc, opts...)
+	err := grpc.Invoke(ctx, "/grpc.testing.TestService/UnaryCall", grpc.NewProtoMessageMarshaler(in), grpc.NewProtoMessageMarshaler(out), c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -388,7 +388,7 @@ func (c *testServiceClient) StreamingOutputCall(ctx context.Context, in *Streami
 		return nil, err
 	}
 	x := &testServiceStreamingOutputCallClient{stream}
-	if err := x.ClientStream.SendMessage(grpc.NewProtoMessageFormatter(in)); err != nil {
+	if err := x.ClientStream.SendMessage(grpc.NewProtoMessageMarshaler(in)); err != nil {
 		return nil, err
 	}
 	if err := x.ClientStream.CloseSend(); err != nil {
@@ -408,7 +408,7 @@ type testServiceStreamingOutputCallClient struct {
 
 func (x *testServiceStreamingOutputCallClient) Recv() (*StreamingOutputCallResponse, error) {
 	m := new(StreamingOutputCallResponse)
-	if err := x.ClientStream.RecvMessage(grpc.NewProtoMessageFormatter(m)); err != nil {
+	if err := x.ClientStream.RecvMessage(grpc.NewProtoMessageMarshaler(m)); err != nil {
 		return nil, err
 	}
 	return m, nil
@@ -434,7 +434,7 @@ type testServiceStreamingInputCallClient struct {
 }
 
 func (x *testServiceStreamingInputCallClient) Send(m *StreamingInputCallRequest) error {
-	return x.ClientStream.SendMessage(grpc.NewProtoMessageFormatter(m))
+	return x.ClientStream.SendMessage(grpc.NewProtoMessageMarshaler(m))
 }
 
 func (x *testServiceStreamingInputCallClient) CloseAndRecv() (*StreamingInputCallResponse, error) {
@@ -442,7 +442,7 @@ func (x *testServiceStreamingInputCallClient) CloseAndRecv() (*StreamingInputCal
 		return nil, err
 	}
 	m := new(StreamingInputCallResponse)
-	if err := x.ClientStream.RecvMessage(grpc.NewProtoMessageFormatter(m)); err != nil {
+	if err := x.ClientStream.RecvMessage(grpc.NewProtoMessageMarshaler(m)); err != nil {
 		return nil, err
 	}
 	return m, nil
@@ -468,12 +468,12 @@ type testServiceFullDuplexCallClient struct {
 }
 
 func (x *testServiceFullDuplexCallClient) Send(m *StreamingOutputCallRequest) error {
-	return x.ClientStream.SendMessage(grpc.NewProtoMessageFormatter(m))
+	return x.ClientStream.SendMessage(grpc.NewProtoMessageMarshaler(m))
 }
 
 func (x *testServiceFullDuplexCallClient) Recv() (*StreamingOutputCallResponse, error) {
 	m := new(StreamingOutputCallResponse)
-	if err := x.ClientStream.RecvMessage(grpc.NewProtoMessageFormatter(m)); err != nil {
+	if err := x.ClientStream.RecvMessage(grpc.NewProtoMessageMarshaler(m)); err != nil {
 		return nil, err
 	}
 	return m, nil
@@ -499,12 +499,12 @@ type testServiceHalfDuplexCallClient struct {
 }
 
 func (x *testServiceHalfDuplexCallClient) Send(m *StreamingOutputCallRequest) error {
-	return x.ClientStream.SendMessage(grpc.NewProtoMessageFormatter(m))
+	return x.ClientStream.SendMessage(grpc.NewProtoMessageMarshaler(m))
 }
 
 func (x *testServiceHalfDuplexCallClient) Recv() (*StreamingOutputCallResponse, error) {
 	m := new(StreamingOutputCallResponse)
-	if err := x.ClientStream.RecvMessage(grpc.NewProtoMessageFormatter(m)); err != nil {
+	if err := x.ClientStream.RecvMessage(grpc.NewProtoMessageMarshaler(m)); err != nil {
 		return nil, err
 	}
 	return m, nil
@@ -539,7 +539,7 @@ func RegisterTestServiceServer(s *grpc.Server, srv TestServiceServer) {
 	s.RegisterService(&_TestService_serviceDesc, srv)
 }
 
-func _TestService_EmptyCall_Handler(srv interface{}, ctx context.Context, buf []byte) (grpc.Formatter, error) {
+func _TestService_EmptyCall_Handler(srv interface{}, ctx context.Context, buf []byte) (grpc.Marshaler, error) {
 	in := new(Empty)
 	if err := proto.Unmarshal(buf, in); err != nil {
 		return nil, err
@@ -548,10 +548,10 @@ func _TestService_EmptyCall_Handler(srv interface{}, ctx context.Context, buf []
 	if err != nil {
 		return nil, err
 	}
-	return grpc.NewProtoMessageFormatter(out), nil
+	return grpc.NewProtoMessageMarshaler(out), nil
 }
 
-func _TestService_UnaryCall_Handler(srv interface{}, ctx context.Context, buf []byte) (grpc.Formatter, error) {
+func _TestService_UnaryCall_Handler(srv interface{}, ctx context.Context, buf []byte) (grpc.Marshaler, error) {
 	in := new(SimpleRequest)
 	if err := proto.Unmarshal(buf, in); err != nil {
 		return nil, err
@@ -560,12 +560,12 @@ func _TestService_UnaryCall_Handler(srv interface{}, ctx context.Context, buf []
 	if err != nil {
 		return nil, err
 	}
-	return grpc.NewProtoMessageFormatter(out), nil
+	return grpc.NewProtoMessageMarshaler(out), nil
 }
 
 func _TestService_StreamingOutputCall_Handler(srv interface{}, stream grpc.ServerStream) error {
 	m := new(StreamingOutputCallRequest)
-	if err := stream.RecvMessage(grpc.NewProtoMessageFormatter(m)); err != nil {
+	if err := stream.RecvMessage(grpc.NewProtoMessageMarshaler(m)); err != nil {
 		return err
 	}
 	return srv.(TestServiceServer).StreamingOutputCall(m, &testServiceStreamingOutputCallServer{stream})
@@ -581,7 +581,7 @@ type testServiceStreamingOutputCallServer struct {
 }
 
 func (x *testServiceStreamingOutputCallServer) Send(m *StreamingOutputCallResponse) error {
-	return x.ServerStream.SendMessage(grpc.NewProtoMessageFormatter(m))
+	return x.ServerStream.SendMessage(grpc.NewProtoMessageMarshaler(m))
 }
 
 func _TestService_StreamingInputCall_Handler(srv interface{}, stream grpc.ServerStream) error {
@@ -599,12 +599,12 @@ type testServiceStreamingInputCallServer struct {
 }
 
 func (x *testServiceStreamingInputCallServer) SendAndClose(m *StreamingInputCallResponse) error {
-	return x.ServerStream.SendMessage(grpc.NewProtoMessageFormatter(m))
+	return x.ServerStream.SendMessage(grpc.NewProtoMessageMarshaler(m))
 }
 
 func (x *testServiceStreamingInputCallServer) Recv() (*StreamingInputCallRequest, error) {
 	m := new(StreamingInputCallRequest)
-	if err := x.ServerStream.RecvMessage(grpc.NewProtoMessageFormatter(m)); err != nil {
+	if err := x.ServerStream.RecvMessage(grpc.NewProtoMessageMarshaler(m)); err != nil {
 		return nil, err
 	}
 	return m, nil
@@ -625,12 +625,12 @@ type testServiceFullDuplexCallServer struct {
 }
 
 func (x *testServiceFullDuplexCallServer) Send(m *StreamingOutputCallResponse) error {
-	return x.ServerStream.SendMessage(grpc.NewProtoMessageFormatter(m))
+	return x.ServerStream.SendMessage(grpc.NewProtoMessageMarshaler(m))
 }
 
 func (x *testServiceFullDuplexCallServer) Recv() (*StreamingOutputCallRequest, error) {
 	m := new(StreamingOutputCallRequest)
-	if err := x.ServerStream.RecvMessage(grpc.NewProtoMessageFormatter(m)); err != nil {
+	if err := x.ServerStream.RecvMessage(grpc.NewProtoMessageMarshaler(m)); err != nil {
 		return nil, err
 	}
 	return m, nil
@@ -651,12 +651,12 @@ type testServiceHalfDuplexCallServer struct {
 }
 
 func (x *testServiceHalfDuplexCallServer) Send(m *StreamingOutputCallResponse) error {
-	return x.ServerStream.SendMessage(grpc.NewProtoMessageFormatter(m))
+	return x.ServerStream.SendMessage(grpc.NewProtoMessageMarshaler(m))
 }
 
 func (x *testServiceHalfDuplexCallServer) Recv() (*StreamingOutputCallRequest, error) {
 	m := new(StreamingOutputCallRequest)
-	if err := x.ServerStream.RecvMessage(grpc.NewProtoMessageFormatter(m)); err != nil {
+	if err := x.ServerStream.RecvMessage(grpc.NewProtoMessageMarshaler(m)); err != nil {
 		return nil, err
 	}
 	return m, nil

--- a/test/grpc_testing/test.pb.go
+++ b/test/grpc_testing/test.pb.go
@@ -366,7 +366,7 @@ func NewTestServiceClient(cc *grpc.ClientConn) TestServiceClient {
 
 func (c *testServiceClient) EmptyCall(ctx context.Context, in *Empty, opts ...grpc.CallOption) (*Empty, error) {
 	out := new(Empty)
-	err := grpc.Invoke(ctx, "/grpc.testing.TestService/EmptyCall", in, out, c.cc, opts...)
+	err := grpc.Invoke(ctx, "/grpc.testing.TestService/EmptyCall", grpc.NewProtoMessageFormatter(in), grpc.NewProtoMessageFormatter(out), c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -375,7 +375,7 @@ func (c *testServiceClient) EmptyCall(ctx context.Context, in *Empty, opts ...gr
 
 func (c *testServiceClient) UnaryCall(ctx context.Context, in *SimpleRequest, opts ...grpc.CallOption) (*SimpleResponse, error) {
 	out := new(SimpleResponse)
-	err := grpc.Invoke(ctx, "/grpc.testing.TestService/UnaryCall", in, out, c.cc, opts...)
+	err := grpc.Invoke(ctx, "/grpc.testing.TestService/UnaryCall", grpc.NewProtoMessageFormatter(in), grpc.NewProtoMessageFormatter(out), c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -388,7 +388,7 @@ func (c *testServiceClient) StreamingOutputCall(ctx context.Context, in *Streami
 		return nil, err
 	}
 	x := &testServiceStreamingOutputCallClient{stream}
-	if err := x.ClientStream.SendProto(in); err != nil {
+	if err := x.ClientStream.SendProto(grpc.NewProtoMessageFormatter(in)); err != nil {
 		return nil, err
 	}
 	if err := x.ClientStream.CloseSend(); err != nil {
@@ -408,7 +408,7 @@ type testServiceStreamingOutputCallClient struct {
 
 func (x *testServiceStreamingOutputCallClient) Recv() (*StreamingOutputCallResponse, error) {
 	m := new(StreamingOutputCallResponse)
-	if err := x.ClientStream.RecvProto(m); err != nil {
+	if err := x.ClientStream.RecvProto(grpc.NewProtoMessageFormatter(m)); err != nil {
 		return nil, err
 	}
 	return m, nil
@@ -434,7 +434,7 @@ type testServiceStreamingInputCallClient struct {
 }
 
 func (x *testServiceStreamingInputCallClient) Send(m *StreamingInputCallRequest) error {
-	return x.ClientStream.SendProto(m)
+	return x.ClientStream.SendProto(grpc.NewProtoMessageFormatter(m))
 }
 
 func (x *testServiceStreamingInputCallClient) CloseAndRecv() (*StreamingInputCallResponse, error) {
@@ -442,7 +442,7 @@ func (x *testServiceStreamingInputCallClient) CloseAndRecv() (*StreamingInputCal
 		return nil, err
 	}
 	m := new(StreamingInputCallResponse)
-	if err := x.ClientStream.RecvProto(m); err != nil {
+	if err := x.ClientStream.RecvProto(grpc.NewProtoMessageFormatter(m)); err != nil {
 		return nil, err
 	}
 	return m, nil
@@ -468,12 +468,12 @@ type testServiceFullDuplexCallClient struct {
 }
 
 func (x *testServiceFullDuplexCallClient) Send(m *StreamingOutputCallRequest) error {
-	return x.ClientStream.SendProto(m)
+	return x.ClientStream.SendProto(grpc.NewProtoMessageFormatter(m))
 }
 
 func (x *testServiceFullDuplexCallClient) Recv() (*StreamingOutputCallResponse, error) {
 	m := new(StreamingOutputCallResponse)
-	if err := x.ClientStream.RecvProto(m); err != nil {
+	if err := x.ClientStream.RecvProto(grpc.NewProtoMessageFormatter(m)); err != nil {
 		return nil, err
 	}
 	return m, nil
@@ -499,12 +499,12 @@ type testServiceHalfDuplexCallClient struct {
 }
 
 func (x *testServiceHalfDuplexCallClient) Send(m *StreamingOutputCallRequest) error {
-	return x.ClientStream.SendProto(m)
+	return x.ClientStream.SendProto(grpc.NewProtoMessageFormatter(m))
 }
 
 func (x *testServiceHalfDuplexCallClient) Recv() (*StreamingOutputCallResponse, error) {
 	m := new(StreamingOutputCallResponse)
-	if err := x.ClientStream.RecvProto(m); err != nil {
+	if err := x.ClientStream.RecvProto(grpc.NewProtoMessageFormatter(m)); err != nil {
 		return nil, err
 	}
 	return m, nil
@@ -539,7 +539,7 @@ func RegisterTestServiceServer(s *grpc.Server, srv TestServiceServer) {
 	s.RegisterService(&_TestService_serviceDesc, srv)
 }
 
-func _TestService_EmptyCall_Handler(srv interface{}, ctx context.Context, buf []byte) (proto.Message, error) {
+func _TestService_EmptyCall_Handler(srv interface{}, ctx context.Context, buf []byte) (grpc.Formatter, error) {
 	in := new(Empty)
 	if err := proto.Unmarshal(buf, in); err != nil {
 		return nil, err
@@ -548,10 +548,10 @@ func _TestService_EmptyCall_Handler(srv interface{}, ctx context.Context, buf []
 	if err != nil {
 		return nil, err
 	}
-	return out, nil
+	return grpc.NewProtoMessageFormatter(out), nil
 }
 
-func _TestService_UnaryCall_Handler(srv interface{}, ctx context.Context, buf []byte) (proto.Message, error) {
+func _TestService_UnaryCall_Handler(srv interface{}, ctx context.Context, buf []byte) (grpc.Formatter, error) {
 	in := new(SimpleRequest)
 	if err := proto.Unmarshal(buf, in); err != nil {
 		return nil, err
@@ -560,12 +560,12 @@ func _TestService_UnaryCall_Handler(srv interface{}, ctx context.Context, buf []
 	if err != nil {
 		return nil, err
 	}
-	return out, nil
+	return grpc.NewProtoMessageFormatter(out), nil
 }
 
 func _TestService_StreamingOutputCall_Handler(srv interface{}, stream grpc.ServerStream) error {
 	m := new(StreamingOutputCallRequest)
-	if err := stream.RecvProto(m); err != nil {
+	if err := stream.RecvProto(grpc.NewProtoMessageFormatter(m)); err != nil {
 		return err
 	}
 	return srv.(TestServiceServer).StreamingOutputCall(m, &testServiceStreamingOutputCallServer{stream})
@@ -581,7 +581,7 @@ type testServiceStreamingOutputCallServer struct {
 }
 
 func (x *testServiceStreamingOutputCallServer) Send(m *StreamingOutputCallResponse) error {
-	return x.ServerStream.SendProto(m)
+	return x.ServerStream.SendProto(grpc.NewProtoMessageFormatter(m))
 }
 
 func _TestService_StreamingInputCall_Handler(srv interface{}, stream grpc.ServerStream) error {
@@ -599,12 +599,12 @@ type testServiceStreamingInputCallServer struct {
 }
 
 func (x *testServiceStreamingInputCallServer) SendAndClose(m *StreamingInputCallResponse) error {
-	return x.ServerStream.SendProto(m)
+	return x.ServerStream.SendProto(grpc.NewProtoMessageFormatter(m))
 }
 
 func (x *testServiceStreamingInputCallServer) Recv() (*StreamingInputCallRequest, error) {
 	m := new(StreamingInputCallRequest)
-	if err := x.ServerStream.RecvProto(m); err != nil {
+	if err := x.ServerStream.RecvProto(grpc.NewProtoMessageFormatter(m)); err != nil {
 		return nil, err
 	}
 	return m, nil
@@ -625,12 +625,12 @@ type testServiceFullDuplexCallServer struct {
 }
 
 func (x *testServiceFullDuplexCallServer) Send(m *StreamingOutputCallResponse) error {
-	return x.ServerStream.SendProto(m)
+	return x.ServerStream.SendProto(grpc.NewProtoMessageFormatter(m))
 }
 
 func (x *testServiceFullDuplexCallServer) Recv() (*StreamingOutputCallRequest, error) {
 	m := new(StreamingOutputCallRequest)
-	if err := x.ServerStream.RecvProto(m); err != nil {
+	if err := x.ServerStream.RecvProto(grpc.NewProtoMessageFormatter(m)); err != nil {
 		return nil, err
 	}
 	return m, nil
@@ -651,12 +651,12 @@ type testServiceHalfDuplexCallServer struct {
 }
 
 func (x *testServiceHalfDuplexCallServer) Send(m *StreamingOutputCallResponse) error {
-	return x.ServerStream.SendProto(m)
+	return x.ServerStream.SendProto(grpc.NewProtoMessageFormatter(m))
 }
 
 func (x *testServiceHalfDuplexCallServer) Recv() (*StreamingOutputCallRequest, error) {
 	m := new(StreamingOutputCallRequest)
-	if err := x.ServerStream.RecvProto(m); err != nil {
+	if err := x.ServerStream.RecvProto(grpc.NewProtoMessageFormatter(m)); err != nil {
 		return nil, err
 	}
 	return m, nil


### PR DESCRIPTION
The generated code for interop has not been updated. Will do after we reach the agreement.