### PR TITLE
credentials: rename Credentials to Retriever

### DIFF
--- a/clientconn.go
+++ b/clientconn.go
@@ -68,7 +68,7 @@ func WithTransportCredentials(creds credentials.TransportAuthenticator) DialOpti
 
 // WithPerRPCCredentials returns a DialOption which sets
 // credentials which will place auth state on each outbound RPC.
-func WithPerRPCCredentials(creds credentials.Credentials) DialOption {
+func WithPerRPCCredentials(creds credentials.Retriever) DialOption {
 	return func(o *transport.DialOptions) {
 		o.AuthOptions = append(o.AuthOptions, creds)
 	}
@@ -156,7 +156,7 @@ func (cc *ClientConn) resetTransport(closeTransport bool) error {
 		if err != nil {
 			sleepTime := backoff(retries)
 			// Fail early before falling into sleep.
-			if cc.dopts.Timeout > 0 && cc.dopts.Timeout < sleepTime + time.Since(start) {
+			if cc.dopts.Timeout > 0 && cc.dopts.Timeout < sleepTime+time.Since(start) {
 				cc.Close()
 				return ErrClientConnTimeout
 			}

--- a/transport/http2_client.go
+++ b/transport/http2_client.go
@@ -82,7 +82,7 @@ type http2Client struct {
 	// The scheme used: https if TLS is on, http otherwise.
 	scheme string
 
-	authCreds []credentials.Credentials
+	authCreds []credentials.Retriever
 
 	mu            sync.Mutex     // guard the following variables
 	state         transportState // the state of underlying connection
@@ -218,7 +218,7 @@ func (t *http2Client) NewStream(ctx context.Context, callHdr *CallHdr) (_ *Strea
 	t.hEnc.WriteField(hpack.HeaderField{Name: "content-type", Value: "application/grpc"})
 	t.hEnc.WriteField(hpack.HeaderField{Name: "te", Value: "trailers"})
 	for _, c := range t.authCreds {
-		m, err := c.GetRequestMetadata(ctx)
+		m, err := c.Retrieve(ctx)
 		select {
 		case <-ctx.Done():
 			return nil, ContextErr(ctx.Err())

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -314,7 +314,7 @@ func NewServerTransport(protocol string, conn net.Conn, maxStreams uint32) (Serv
 // DialOptions covers all relevant options for dialing a server.
 type DialOptions struct {
 	Protocol    string
-	AuthOptions []credentials.Credentials
+	AuthOptions []credentials.Retriever
 	Timeout     time.Duration
 }
 

--- a/transport/transport_test.go
+++ b/transport/transport_test.go
@@ -182,7 +182,7 @@ func setUp(t *testing.T, useTLS bool, port int, maxStreams uint32, suspend bool)
 			t.Fatalf("Failed to create credentials %v", err)
 		}
 		dopts := DialOptions{
-			AuthOptions: []credentials.Credentials{creds},
+			AuthOptions: []credentials.Retriever{creds},
 		}
 		ct, connErr = NewClientTransport(addr, &dopts)
 	} else {


### PR DESCRIPTION
In Go, an interface name should explain the action that is done by the implementers of the interface. Credentials are retrieving Credentials for the current context.