### PR TITLE
Performance Optimization part 1

### DIFF
--- a/transport/control.go
+++ b/transport/control.go
@@ -78,6 +78,13 @@ func (resetStream) isItem() bool {
 	return true
 }
 
+type flushIO struct {
+}
+
+func (flushIO) isItem() bool {
+	return true
+}
+
 // quotaPool is a pool which accumulates the quota and sends it to acquire()
 // when it is available.
 type quotaPool struct {

--- a/transport/http2_server.go
+++ b/transport/http2_server.go
@@ -66,7 +66,7 @@ type http2Server struct {
 	// Blocking operations should select on shutdownChan to avoid
 	// blocking forever after Close.
 	shutdownChan chan struct{}
-	framer       *http2.Framer
+	framer       *framer
 	hBuf         *bytes.Buffer  // the buffer for HPACK encoding
 	hEnc         *hpack.Encoder // HPACK encoder
 
@@ -88,15 +88,15 @@ type http2Server struct {
 // newHTTP2Server constructs a ServerTransport based on HTTP2. ConnectionError is
 // returned if something goes wrong.
 func newHTTP2Server(conn net.Conn, maxStreams uint32) (_ ServerTransport, err error) {
-	framer := http2.NewFramer(conn, conn)
+	framer := newFramer(conn)
 	// Send initial settings as connection preface to client.
 	// TODO(zhaoq): Have a better way to signal "no limit" because 0 is
 	// permitted in the HTTP2 spec.
 	if maxStreams == 0 {
-		err = framer.WriteSettings()
+		err = framer.writeSettings(true)
 		maxStreams = math.MaxUint32
 	} else {
-		err = framer.WriteSettings(http2.Setting{http2.SettingMaxConcurrentStreams, maxStreams})
+		err = framer.writeSettings(true, http2.Setting{http2.SettingMaxConcurrentStreams, maxStreams})
 	}
 	if err != nil {
 		return
@@ -203,7 +203,7 @@ func (t *http2Server) HandleStreams(handle func(*Stream)) {
 		return
 	}
 
-	frame, err := t.framer.ReadFrame()
+	frame, err := t.framer.readFrame()
 	if err != nil {
 		log.Printf("transport: http2Server.HandleStreams failed to read frame: %v", err)
 		t.Close()
@@ -222,7 +222,7 @@ func (t *http2Server) HandleStreams(handle func(*Stream)) {
 	var wg sync.WaitGroup
 	defer wg.Wait()
 	for {
-		frame, err := t.framer.ReadFrame()
+		frame, err := t.framer.readFrame()
 		if err != nil {
 			t.Close()
 			return
@@ -380,10 +380,10 @@ func (t *http2Server) writeHeaders(s *Stream, b *bytes.Buffer, endStream bool) e
 				EndStream:     endStream,
 				EndHeaders:    endHeaders,
 			}
-			err = t.framer.WriteHeaders(p)
+			err = t.framer.writeHeaders(endHeaders, p)
 			first = false
 		} else {
-			err = t.framer.WriteContinuation(s.id, endHeaders, b.Next(size))
+			err = t.framer.writeContinuation(endHeaders, s.id, endHeaders, b.Next(size))
 		}
 		if err != nil {
 			t.Close()
@@ -475,7 +475,7 @@ func (t *http2Server) Write(s *Stream, data []byte, opts *Options) error {
 			BlockFragment: t.hBuf.Bytes(),
 			EndHeaders:    true,
 		}
-		if err := t.framer.WriteHeaders(p); err != nil {
+		if err := t.framer.writeHeaders(false, p); err != nil {
 			t.Close()
 			return ConnectionErrorf("transport: %v", err)
 		}
@@ -518,14 +518,25 @@ func (t *http2Server) Write(s *Stream, data []byte, opts *Options) error {
 			// Overbooked transport quota. Return it back.
 			t.sendQuotaPool.add(tq - ps)
 		}
+		t.framer.adjustNumWriters(1)
 		// Got some quota. Try to acquire writing privilege on the
 		// transport.
 		if _, err := wait(s.ctx, t.shutdownChan, t.writableChan); err != nil {
+			if t.framer.adjustNumWriters(-1) == 0 {
+				t.controlBuf.put(&flushIO{})
+			}
 			return err
 		}
-		if err := t.framer.WriteData(s.id, false, p); err != nil {
+		var forceFlush bool
+		if r.Len() == 0 && t.framer.adjustNumWriters(0) == 1 && !opts.Last {
+			forceFlush = true
+		}
+		if err := t.framer.writeData(forceFlush, s.id, false, p); err != nil {
 			t.Close()
 			return ConnectionErrorf("transport: %v", err)
+		}
+		if t.framer.adjustNumWriters(-1) == 0 {
+			t.framer.flushWrite()
 		}
 		t.writableChan <- 0
 	}
@@ -543,11 +554,13 @@ func (t *http2Server) controller() {
 			case <-t.writableChan:
 				switch i := i.(type) {
 				case *windowUpdate:
-					t.framer.WriteWindowUpdate(i.streamID, i.increment)
+					t.framer.writeWindowUpdate(true, i.streamID, i.increment)
 				case *settings:
-					t.framer.WriteSettings(http2.Setting{i.id, i.val})
+					t.framer.writeSettings(true, http2.Setting{i.id, i.val})
 				case *resetStream:
-					t.framer.WriteRSTStream(i.streamID, i.code)
+					t.framer.writeRSTStream(true, i.streamID, i.code)
+				case *flushIO:
+					t.framer.flushWrite()
 				default:
 					log.Printf("transport: http2Server.controller got unexpected item type %v\n", i)
 				}

--- a/transport/http_util.go
+++ b/transport/http_util.go
@@ -34,9 +34,13 @@
 package transport
 
 import (
+	"bufio"
 	"fmt"
+	"io"
 	"log"
+	"net"
 	"strconv"
+	"sync/atomic"
 	"time"
 
 	"github.com/bradfitz/http2"
@@ -50,6 +54,8 @@ const (
 	http2MaxFrameLen = 16384 // 16KB frame
 	// http://http2.github.io/http2-spec/#SettingValues
 	http2InitHeaderTableSize = 4096
+	// http2IOBufSize specifies the buffer size for sending frames.
+	http2IOBufSize           = 32 * 1024
 )
 
 var (
@@ -287,4 +293,145 @@ func timeoutDecode(s string) (time.Duration, error) {
 		return 0, err
 	}
 	return d * time.Duration(t), nil
+}
+
+type framer struct {
+	numWriters int32
+	reader     io.Reader
+	writer     *bufio.Writer
+	fr         *http2.Framer
+}
+
+func newFramer(conn net.Conn) *framer {
+	f := &framer{
+		reader: conn,
+		writer: bufio.NewWriterSize(conn, http2IOBufSize),
+	}
+	f.fr = http2.NewFramer(f.writer, f.reader)
+	return f
+}
+
+func (f *framer) adjustNumWriters(i int32) int32 {
+	return atomic.AddInt32(&f.numWriters, i)
+}
+
+// The following writeXXX functions can only be called when the caller gets
+// unblocked from writableChan channel (i.e., owns the privilege to write).
+
+func (f *framer) writeContinuation(forceFlush bool, streamID uint32, endHeaders bool, headerBlockFragment []byte) error {
+	if err := f.fr.WriteContinuation(streamID, endHeaders, headerBlockFragment); err != nil {
+		return err
+	}
+	if forceFlush {
+		return f.writer.Flush()
+	}
+	return nil
+}
+
+func (f *framer) writeData(forceFlush bool, streamID uint32, endStream bool, data []byte) error {
+	if err := f.fr.WriteData(streamID, endStream, data); err != nil {
+		return err
+	}
+	if forceFlush {
+		return f.writer.Flush()
+	}
+	return nil
+}
+
+func (f *framer) writeGoAway(forceFlush bool, maxStreamID uint32, code http2.ErrCode, debugData []byte) error {
+	if err := f.fr.WriteGoAway(maxStreamID, code, debugData); err != nil {
+		return err
+	}
+	if forceFlush {
+		return f.writer.Flush()
+	}
+	return nil
+}
+
+func (f *framer) writeHeaders(forceFlush bool, p http2.HeadersFrameParam) error {
+	if err := f.fr.WriteHeaders(p); err != nil {
+		return err
+	}
+	if forceFlush {
+		return f.writer.Flush()
+	}
+	return nil
+}
+
+func (f *framer) writePing(forceFlush, ack bool, data [8]byte) error {
+	if err := f.fr.WritePing(ack, data); err != nil {
+		return err
+	}
+	if forceFlush {
+		return f.writer.Flush()
+	}
+	return nil
+}
+
+func (f *framer) writePriority(forceFlush bool, streamID uint32, p http2.PriorityParam) error {
+	if err := f.fr.WritePriority(streamID, p); err != nil {
+		return err
+	}
+	if forceFlush {
+		return f.writer.Flush()
+	}
+	return nil
+}
+
+func (f *framer) writePushPromise(forceFlush bool, p http2.PushPromiseParam) error {
+	if err := f.fr.WritePushPromise(p); err != nil {
+		return err
+	}
+	if forceFlush {
+		return f.writer.Flush()
+	}
+	return nil
+}
+
+func (f *framer) writeRSTStream(forceFlush bool, streamID uint32, code http2.ErrCode) error {
+	if err := f.fr.WriteRSTStream(streamID, code); err != nil {
+		return err
+	}
+	if forceFlush {
+		return f.writer.Flush()
+	}
+	return nil
+}
+
+func (f *framer) writeSettings(forceFlush bool, settings ...http2.Setting) error {
+	if err := f.fr.WriteSettings(settings...); err != nil {
+		return err
+	}
+	if forceFlush {
+		return f.writer.Flush()
+	}
+	return nil
+}
+
+func (f *framer) writeSettingsAck(forceFlush bool) error {
+	if err := f.fr.WriteSettingsAck(); err != nil {
+		return err
+	}
+	if forceFlush {
+		return f.writer.Flush()
+	}
+	return nil
+}
+
+func (f *framer) writeWindowUpdate(forceFlush bool, streamID, incr uint32) error {
+	if err := f.fr.WriteWindowUpdate(streamID, incr); err != nil {
+		return err
+	}
+	if forceFlush {
+		return f.writer.Flush()
+	}
+	return nil
+}
+
+func (f *framer) flushWrite() error {
+	return f.writer.Flush()
+}
+
+func (f *framer) readFrame() (http2.Frame, error) {
+	return f.fr.ReadFrame()
 }


### PR DESCRIPTION
i) reduce write syscalls
go test -bench=. -cpu 1 -benchtime=20s
benchmark                    old ns/op     new ns/op     delta
BenchmarkClientSmallc1       129295        113599        -12.14%
BenchmarkClientSmallc8       107566        95731         -11.00%
BenchmarkClientSmallc64      115366        102583        -11.08%
BenchmarkClientSmallc512     106814        103891        -2.74%

ii) batch writs from different Goroutines if possible
go test -bench=. -cpu 4 -benchtime=20s
benchmark                      old ns/op     new ns/op     delta
BenchmarkClientSmallc1-4       269609        293830        +8.98%
BenchmarkClientSmallc8-4       49062         39327         -19.84%
BenchmarkClientSmallc64-4      46062         32099         -30.31%
BenchmarkClientSmallc512-4     53862         37108         -31.11%

It is worth further investigation on the slowdown when there are 4 processors and only 1 Goroutine even though it is not a common use case. My speculation is that the io batching leads to more thread switches.