### PR TITLE
Add back-off logic to transportMonitor's reconnect.

### DIFF
--- a/clientconn.go
+++ b/clientconn.go
@@ -214,7 +214,6 @@ func (cc *ClientConn) transportMonitor() {
 				<-nextRetry
 				retries += 1
 			}
-			nextRetry = time.After(backoff(retries))
 
 			if err := cc.resetTransport(true); err != nil {
 				// The channel is closing.
@@ -222,7 +221,8 @@ func (cc *ClientConn) transportMonitor() {
 				log.Printf("grpc: ClientConn.transportMonitor exits due to: %v", err)
 				return
 			}
-			continue
+
+			nextRetry = time.After(backoff(retries))
 		}
 	}
 }

--- a/clientconn.go
+++ b/clientconn.go
@@ -188,13 +188,34 @@ func (cc *ClientConn) resetTransport(closeTransport bool) error {
 // Run in a goroutine to track the error in transport and create the
 // new transport if an error happens. It returns when the channel is closing.
 func (cc *ClientConn) transportMonitor() {
+	retries := 0
+	// To rate-limit reconnects, transportMonitor will not reconnect until
+	// nextRetry passes. As transportMonitor is called after initial connect,
+	// even the first reconnect should wait.
+	nextRetry := time.After(backoff(retries))
+
 	for {
 		select {
 		// shutdownChan is needed to detect the channel teardown when
 		// the ClientConn is idle (i.e., no RPC in flight).
 		case <-cc.shutdownChan:
 			return
+
+		case <-nextRetry:
+			// If nextRetry passes without the transport failing, the
+			// connection is assumed to be good and retries resets back to
+			// zero.
+			nextRetry = nil
+			retries = 0
+
 		case <-cc.transport.Error():
+			if nextRetry != nil {
+				// nextRetry has not passed yet, so wait and back-off.
+				<-nextRetry
+				retries += 1
+			}
+			nextRetry = time.After(backoff(retries))
+
 			if err := cc.resetTransport(true); err != nil {
 				// The channel is closing.
 				// TODO(zhaoq): Record the error with glog.V.


### PR DESCRIPTION
This fixes my problems from #120.

I considered using sleeps and times instead of time.After, as I thought that
might be more efficient. However, this version using time.After looks far nicer
and is easier to understand.

Let me know what you think and/or how this PR could be improved!