### PR TITLE
add separate variables for connection window update for fine tunning the...

### DIFF
--- a/transport/control.go
+++ b/transport/control.go
@@ -42,10 +42,12 @@ import (
 // TODO(zhaoq): Make the following configurable.
 const (
 	// The initial window size for flow control.
-	initialWindowSize = 65535
+	initialWindowSize = 65535  // for an RPC
+	initialConnWindowSize = 1024 * 1024  // for a connection
 	// Window update is only sent when the inbound quota reaches
 	// this threshold. Used to reduce the flow control traffic.
-	windowUpdateThreshold = 16384
+	windowUpdateThreshold = 16384  // for an RPC
+	connWindowUpdateThreshold = 1024 * 256  // for a connection
 )
 
 // The following defines various control items which could flow through


### PR DESCRIPTION
... performance of flow control; set initial connection window size to 1MB which is used in Java and C also