### PR TITLE
Fix an ordering issue of creds

### DIFF
--- a/transport/http2_client.go
+++ b/transport/http2_client.go
@@ -198,14 +198,11 @@ func (t *http2Client) NewStream(ctx context.Context, callHdr *CallHdr) (_ *Strea
 			return nil, ContextErr(context.DeadlineExceeded)
 		}
 	}
-	var authData map[string]string
+	authData := make(map[string]string)
 	for _, c := range t.authCreds {
 		data, err := c.GetRequestMetadata(ctx)
 		if err != nil {
 			return nil, StreamErrorf(codes.InvalidArgument, "transport: %v", err)
-		}
-		if authData == nil && data != nil {
-			authData = make(map[string]string)
 		}
 		for k, v := range data {
 			authData[k] = v

--- a/transport/http2_client.go
+++ b/transport/http2_client.go
@@ -198,6 +198,19 @@ func (t *http2Client) NewStream(ctx context.Context, callHdr *CallHdr) (_ *Strea
 			return nil, ContextErr(context.DeadlineExceeded)
 		}
 	}
+	var authData map[string]string
+	for _, c := range t.authCreds {
+		data, err := c.GetRequestMetadata(ctx)
+		if err != nil {
+			return nil, StreamErrorf(codes.InvalidArgument, "transport: %v", err)
+		}
+		if authData == nil && data != nil {
+			authData = make(map[string]string)
+		}
+		for k, v := range data {
+			authData[k] = v
+		}
+	}
 	if _, err := wait(ctx, t.shutdownChan, t.writableChan); err != nil {
 		return nil, err
 	}
@@ -214,13 +227,8 @@ func (t *http2Client) NewStream(ctx context.Context, callHdr *CallHdr) (_ *Strea
 	if timeout > 0 {
 		t.hEnc.WriteField(hpack.HeaderField{Name: "grpc-timeout", Value: timeoutEncode(timeout)})
 	}
-	for _, c := range t.authCreds {
-		if authData, err := c.GetRequestMetadata(ctx); err != nil {
-			return nil, StreamErrorf(codes.InvalidArgument, "transport: %v", err)
-		}
-		for k, v := range authData {
-			t.hEnc.WriteField(hpack.HeaderField{Name: k, Value: v})
-		}
+	for k, v := range authData {
+		t.hEnc.WriteField(hpack.HeaderField{Name: k, Value: v})
 	}
 	var (
 		hasMD      bool


### PR DESCRIPTION
This fix uses the last value to overwrite the previous values if the key is same. will revisit whether this is the prosper behavior.