### PR TITLE
Revert "remove restoreConn because it is not needed"

### DIFF
--- a/transport/control.go
+++ b/transport/control.go
@@ -209,3 +209,23 @@ func (f *inFlow) onRead(n uint32) uint32 {
 	}
 	return 0
 }
+
+// restoreConn is invoked when a stream is terminated. It removes its stake in
+// the connection-level flow and resets its own state.
+func (f *inFlow) restoreConn() uint32 {
+	if f.conn == nil {
+		return 0
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	ret := f.pendingData
+	f.conn.mu.Lock()
+	f.conn.pendingData -= ret
+	if f.conn.pendingUpdate > f.conn.pendingData {
+		f.conn.pendingUpdate = f.conn.pendingData
+	}
+	f.conn.mu.Unlock()
+	f.pendingData = 0
+	f.pendingUpdate = 0
+	return ret
+}

--- a/transport/http2_client.go
+++ b/transport/http2_client.go
@@ -312,6 +312,9 @@ func (t *http2Client) CloseStream(s *Stream, err error) {
 	delete(t.activeStreams, s.id)
 	t.mu.Unlock()
 	s.mu.Lock()
+	if q := s.fc.restoreConn(); q > 0 {
+		t.controlBuf.put(&windowUpdate{0, q})
+	}
 	if s.state == streamDone {
 		s.mu.Unlock()
 		return

--- a/transport/http2_server.go
+++ b/transport/http2_server.go
@@ -648,6 +648,9 @@ func (t *http2Server) closeStream(s *Stream) {
 	t.mu.Lock()
 	delete(t.activeStreams, s.id)
 	t.mu.Unlock()
+	if q := s.fc.restoreConn(); q > 0 {
+		t.controlBuf.put(&windowUpdate{0, q})
+	}
 	s.mu.Lock()
 	if s.state == streamDone {
 		s.mu.Unlock()


### PR DESCRIPTION
Reverts grpc/grpc-go#160

It is still needed in some cases. But there is an issue here which will be fixed in another pull request shortly.