### PR TITLE
logs.Logger interface

### DIFF
--- a/benchmark/benchmark_test.go
+++ b/benchmark/benchmark_test.go
@@ -8,14 +8,19 @@ import (
 
 	"google.golang.org/grpc/benchmark/stats"
 	testpb "google.golang.org/grpc/interop/grpc_testing"
+	"google.golang.org/grpc/logs"
+)
+
+var (
+	logger = logs.DefaultLogger
 )
 
 func run(b *testing.B, maxConcurrentCalls int, caller func(testpb.TestServiceClient)) {
 	s := stats.AddStats(b, 38)
 	b.StopTimer()
-	target, stopper := StartServer()
+	target, stopper := StartServer(logger)
 	defer stopper()
-	conn := NewClientConn(target)
+	conn := NewClientConn(target, logger)
 	tc := testpb.NewTestServiceClient(conn)
 
 	// Warm up connection.
@@ -55,7 +60,7 @@ func run(b *testing.B, maxConcurrentCalls int, caller func(testpb.TestServiceCli
 }
 
 func smallCaller(client testpb.TestServiceClient) {
-	DoUnaryCall(client, 1, 1)
+	DoUnaryCall(client, 1, 1, logger)
 }
 
 func BenchmarkClientSmallc1(b *testing.B) {

--- a/benchmark/server/main.go
+++ b/benchmark/server/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"flag"
-	"log"
 	"math"
 	"net"
 	"net/http"
@@ -10,10 +9,12 @@ import (
 	"time"
 
 	"google.golang.org/grpc/benchmark"
+	"google.golang.org/grpc/logs"
 )
 
 var (
 	duration = flag.Int("duration", math.MaxInt32, "The duration in seconds to run the benchmark server")
+	logger   = logs.DefaultLogger
 )
 
 func main() {
@@ -21,15 +22,15 @@ func main() {
 	go func() {
 		lis, err := net.Listen("tcp", ":0")
 		if err != nil {
-			log.Fatalf("Failed to listen: %v", err)
+			logger.Fatalf("Failed to listen: %v", err)
 		}
-		log.Println("Server profiling address: ", lis.Addr().String())
+		logger.Println("Server profiling address: ", lis.Addr().String())
 		if err := http.Serve(lis, nil); err != nil {
-			log.Fatalf("Failed to serve: %v", err)
+			logger.Fatalf("Failed to serve: %v", err)
 		}
 	}()
-	addr, stopper := benchmark.StartServer()
-	log.Println("Server Address: ", addr)
+	addr, stopper := benchmark.StartServer(logger)
+	logger.Println("Server Address: ", addr)
 	<-time.After(time.Duration(*duration) * time.Second)
 	stopper()
 }

--- a/examples/route_guide/client/client.go
+++ b/examples/route_guide/client/client.go
@@ -40,7 +40,6 @@ package main
 import (
 	"flag"
 	"io"
-	"log"
 	"math/rand"
 	"time"
 
@@ -48,6 +47,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	pb "google.golang.org/grpc/examples/route_guide/proto"
+	"google.golang.org/grpc/logs"
 )
 
 var (
@@ -55,24 +55,25 @@ var (
 	caFile             = flag.String("ca_file", "testdata/ca.pem", "The file containning the CA root cert file")
 	serverAddr         = flag.String("server_addr", "127.0.0.1:10000", "The server address in the format of host:port")
 	serverHostOverride = flag.String("server_host_override", "x.test.youtube.com", "The server name use to verify the hostname returned by TLS handshake")
+	logger             = logs.DefaultLogger
 )
 
 // printFeature gets the feature for the given point.
 func printFeature(client pb.RouteGuideClient, point *pb.Point) {
-	log.Printf("Getting feature for point (%d, %d)", point.Latitude, point.Longitude)
+	logger.Printf("Getting feature for point (%d, %d)", point.Latitude, point.Longitude)
 	feature, err := client.GetFeature(context.Background(), point)
 	if err != nil {
-		log.Fatalf("%v.GetFeatures(_) = _, %v: ", client, err)
+		logger.Fatalf("%v.GetFeatures(_) = _, %v: ", client, err)
 	}
-	log.Println(feature)
+	logger.Println(feature)
 }
 
 // printFeatures lists all the features within the given bounding Rectangle.
 func printFeatures(client pb.RouteGuideClient, rect *pb.Rectangle) {
-	log.Printf("Looking for features within %v", rect)
+	logger.Printf("Looking for features within %v", rect)
 	stream, err := client.ListFeatures(context.Background(), rect)
 	if err != nil {
-		log.Fatalf("%v.ListFeatures(_) = _, %v", client, err)
+		logger.Fatalf("%v.ListFeatures(_) = _, %v", client, err)
 	}
 	for {
 		feature, err := stream.Recv()
@@ -80,9 +81,9 @@ func printFeatures(client pb.RouteGuideClient, rect *pb.Rectangle) {
 			break
 		}
 		if err != nil {
-			log.Fatalf("%v.ListFeatures(_) = _, %v", client, err)
+			logger.Fatalf("%v.ListFeatures(_) = _, %v", client, err)
 		}
-		log.Println(feature)
+		logger.Println(feature)
 	}
 }
 
@@ -95,21 +96,21 @@ func runRecordRoute(client pb.RouteGuideClient) {
 	for i := 0; i < pointCount; i++ {
 		points = append(points, randomPoint(r))
 	}
-	log.Printf("Traversing %d points.", len(points))
+	logger.Printf("Traversing %d points.", len(points))
 	stream, err := client.RecordRoute(context.Background())
 	if err != nil {
-		log.Fatalf("%v.RecordRoute(_) = _, %v", client, err)
+		logger.Fatalf("%v.RecordRoute(_) = _, %v", client, err)
 	}
 	for _, point := range points {
 		if err := stream.Send(point); err != nil {
-			log.Fatalf("%v.Send(%v) = %v", stream, point, err)
+			logger.Fatalf("%v.Send(%v) = %v", stream, point, err)
 		}
 	}
 	reply, err := stream.CloseAndRecv()
 	if err != nil {
-		log.Fatalf("%v.CloseAndRecv() got error %v, want %v", stream, err, nil)
+		logger.Fatalf("%v.CloseAndRecv() got error %v, want %v", stream, err, nil)
 	}
-	log.Printf("Route summary: %v", reply)
+	logger.Printf("Route summary: %v", reply)
 }
 
 // runRouteChat receives a sequence of route notes, while sending notes for various locations.
@@ -124,7 +125,7 @@ func runRouteChat(client pb.RouteGuideClient) {
 	}
 	stream, err := client.RouteChat(context.Background())
 	if err != nil {
-		log.Fatalf("%v.RouteChat(_) = _, %v", client, err)
+		logger.Fatalf("%v.RouteChat(_) = _, %v", client, err)
 	}
 	waitc := make(chan struct{})
 	go func() {
@@ -136,14 +137,14 @@ func runRouteChat(client pb.RouteGuideClient) {
 				return
 			}
 			if err != nil {
-				log.Fatalf("Failed to receive a note : %v", err)
+				logger.Fatalf("Failed to receive a note : %v", err)
 			}
-			log.Printf("Got message %s at point(%d, %d)", in.Message, in.Location.Latitude, in.Location.Longitude)
+			logger.Printf("Got message %s at point(%d, %d)", in.Message, in.Location.Latitude, in.Location.Longitude)
 		}
 	}()
 	for _, note := range notes {
 		if err := stream.Send(note); err != nil {
-			log.Fatalf("Failed to send a note: %v", err)
+			logger.Fatalf("Failed to send a note: %v", err)
 		}
 	}
 	stream.CloseSend()
@@ -169,7 +170,7 @@ func main() {
 			var err error
 			creds, err = credentials.NewClientTLSFromFile(*caFile, sn)
 			if err != nil {
-				log.Fatalf("Failed to create TLS credentials %v", err)
+				logger.Fatalf("Failed to create TLS credentials %v", err)
 			}
 		} else {
 			creds = credentials.NewClientTLSFromCert(nil, sn)
@@ -178,7 +179,7 @@ func main() {
 	}
 	conn, err := grpc.Dial(*serverAddr, opts...)
 	if err != nil {
-		log.Fatalf("fail to dial: %v", err)
+		logger.Fatalf("fail to dial: %v", err)
 	}
 	defer conn.Close()
 	client := pb.NewRouteGuideClient(conn)

--- a/interop/server/server.go
+++ b/interop/server/server.go
@@ -37,7 +37,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"log"
 	"net"
 	"strconv"
 	"time"
@@ -47,6 +46,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	testpb "google.golang.org/grpc/interop/grpc_testing"
+	"google.golang.org/grpc/logs"
 )
 
 var (
@@ -54,6 +54,7 @@ var (
 	certFile = flag.String("tls_cert_file", "testdata/server1.pem", "The TLS cert file")
 	keyFile  = flag.String("tls_key_file", "testdata/server1.key", "The TLS key file")
 	port     = flag.Int("port", 10000, "The server port")
+	logger   = logs.DefaultLogger
 )
 
 type testServer struct {
@@ -193,14 +194,14 @@ func main() {
 	p := strconv.Itoa(*port)
 	lis, err := net.Listen("tcp", ":"+p)
 	if err != nil {
-		log.Fatalf("failed to listen: %v", err)
+		logger.Fatalf("failed to listen: %v", err)
 	}
 	server := grpc.NewServer()
 	testpb.RegisterTestServiceServer(server, &testServer{})
 	if *useTLS {
 		creds, err := credentials.NewServerTLSFromFile(*certFile, *keyFile)
 		if err != nil {
-			log.Fatalf("Failed to generate credentials %v", err)
+			logger.Fatalf("Failed to generate credentials %v", err)
 		}
 		server.Serve(creds.NewListener(lis))
 	} else {

--- a/logs/logger.go
+++ b/logs/logger.go
@@ -39,11 +39,16 @@ package logs // import "google.golang.org/grpc/logs"
 import (
 	"log"
 	"os"
+
+	"github.com/golang/glog"
 )
 
 var (
-	// DefaultLogger is the default Logger used.
-	DefaultLogger = log.New(os.Stdout, "", log.LstdFlags)
+	// DefaultLogger is the default Logger used. It uses glog.
+	DefaultLogger = &glogger{}
+
+	// StdLogger is a Logger that uses golang's standard logger.
+	StdLogger = log.New(os.Stdout, "", log.LstdFlags)
 )
 
 // Logger mimics golang's standard Logger as an interface.
@@ -54,4 +59,30 @@ type Logger interface {
 	Print(args ...interface{})
 	Printf(format string, args ...interface{})
 	Println(args ...interface{})
+}
+
+type glogger struct{}
+
+func (g *glogger) Fatal(args ...interface{}) {
+	glog.Fatal(args...)
+}
+
+func (g *glogger) Fatalf(format string, args ...interface{}) {
+	glog.Fatalf(format, args...)
+}
+
+func (g *glogger) Fatalln(args ...interface{}) {
+	glog.Fatalln(args...)
+}
+
+func (g *glogger) Print(args ...interface{}) {
+	glog.Info(args...)
+}
+
+func (g *glogger) Printf(format string, args ...interface{}) {
+	glog.Infof(format, args...)
+}
+
+func (g *glogger) Println(args ...interface{}) {
+	glog.Infoln(args...)
 }

--- a/logs/logger.go
+++ b/logs/logger.go
@@ -1,0 +1,57 @@
+/*
+ *
+ * Copyright 2015, Google Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+/*
+Package logs defines logginf for grpc.
+*/
+package logs // import "google.golang.org/grpc/logs"
+
+import (
+	"log"
+	"os"
+)
+
+var (
+	// DefaultLogger is the default Logger used.
+	DefaultLogger = log.New(os.Stdout, "", log.LstdFlags)
+)
+
+// Logger mimics golang's standard Logger as an interface.
+type Logger interface {
+	Fatal(args ...interface{})
+	Fatalf(format string, args ...interface{})
+	Fatalln(args ...interface{})
+	Print(args ...interface{})
+	Printf(format string, args ...interface{})
+	Println(args ...interface{})
+}

--- a/transport/http2_server.go
+++ b/transport/http2_server.go
@@ -37,7 +37,6 @@ import (
 	"bytes"
 	"errors"
 	"io"
-	"log"
 	"math"
 	"net"
 	"strconv"
@@ -47,6 +46,7 @@ import (
 	"github.com/bradfitz/http2/hpack"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/logs"
 	"google.golang.org/grpc/metadata"
 )
 
@@ -84,11 +84,12 @@ type http2Server struct {
 	activeStreams map[uint32]*Stream
 	// the per-stream outbound flow control window size set by the peer.
 	streamSendQuota uint32
+	logger          logs.Logger
 }
 
 // newHTTP2Server constructs a ServerTransport based on HTTP2. ConnectionError is
 // returned if something goes wrong.
-func newHTTP2Server(conn net.Conn, maxStreams uint32) (_ ServerTransport, err error) {
+func newHTTP2Server(conn net.Conn, maxStreams uint32, logger logs.Logger) (_ ServerTransport, err error) {
 	framer := newFramer(conn)
 	// Send initial settings as connection preface to client.
 	// TODO(zhaoq): Have a better way to signal "no limit" because 0 is
@@ -128,6 +129,7 @@ func newHTTP2Server(conn net.Conn, maxStreams uint32) (_ ServerTransport, err er
 		shutdownChan:    make(chan struct{}),
 		activeStreams:   make(map[uint32]*Stream),
 		streamSendQuota: defaultWindowSize,
+		logger:          logger,
 	}
 	go t.controller()
 	t.writableChan <- 0
@@ -149,7 +151,7 @@ func (t *http2Server) operateHeaders(hDec *hpackDecoder, s *Stream, frame header
 		return nil
 	}
 	if err != nil {
-		log.Printf("transport: http2Server.operateHeader found %v", err)
+		t.logger.Printf("transport: http2Server.operateHeader found %v", err)
 		if se, ok := err.(StreamError); ok {
 			t.controlBuf.put(&resetStream{s.id, statusCodeConvTab[se.Code]})
 		}
@@ -186,7 +188,7 @@ func (t *http2Server) operateHeaders(hDec *hpackDecoder, s *Stream, frame header
 	// Cache the current stream to the context so that the server application
 	// can find out. Required when the server wants to send some metadata
 	// back to the client (unary call only).
-	s.ctx = newContextWithStream(s.ctx, s)
+	s.ctx = newContextWithStreamAndLogger(s.ctx, s, nil)
 	// Attach the received metadata to the context.
 	if len(hDec.state.mdata) > 0 {
 		s.ctx = metadata.NewContext(s.ctx, hDec.state.mdata)
@@ -212,31 +214,31 @@ func (t *http2Server) HandleStreams(handle func(*Stream)) {
 	// Check the validity of client preface.
 	preface := make([]byte, len(clientPreface))
 	if _, err := io.ReadFull(t.conn, preface); err != nil {
-		log.Printf("transport: http2Server.HandleStreams failed to receive the preface from client: %v", err)
+		t.logger.Printf("transport: http2Server.HandleStreams failed to receive the preface from client: %v", err)
 		t.Close()
 		return
 	}
 	if !bytes.Equal(preface, clientPreface) {
-		log.Printf("transport: http2Server.HandleStreams received bogus greeting from client: %q", preface)
+		t.logger.Printf("transport: http2Server.HandleStreams received bogus greeting from client: %q", preface)
 		t.Close()
 		return
 	}
 
 	frame, err := t.framer.readFrame()
 	if err != nil {
-		log.Printf("transport: http2Server.HandleStreams failed to read frame: %v", err)
+		t.logger.Printf("transport: http2Server.HandleStreams failed to read frame: %v", err)
 		t.Close()
 		return
 	}
 	sf, ok := frame.(*http2.SettingsFrame)
 	if !ok {
-		log.Printf("transport: http2Server.HandleStreams saw invalid preface type %T from client", frame)
+		t.logger.Printf("transport: http2Server.HandleStreams saw invalid preface type %T from client", frame)
 		t.Close()
 		return
 	}
 	t.handleSettings(sf)
 
-	hDec := newHPACKDecoder()
+	hDec := newHPACKDecoder(t.logger)
 	var curStream *Stream
 	var wg sync.WaitGroup
 	defer wg.Wait()
@@ -251,7 +253,7 @@ func (t *http2Server) HandleStreams(handle func(*Stream)) {
 			id := frame.Header().StreamID
 			if id%2 != 1 || id <= t.maxStreamID {
 				// illegal gRPC stream id.
-				log.Println("transport: http2Server.HandleStreams received an illegal stream id: ", id)
+				t.logger.Println("transport: http2Server.HandleStreams received an illegal stream id: ", id)
 				t.Close()
 				break
 			}
@@ -284,7 +286,7 @@ func (t *http2Server) HandleStreams(handle func(*Stream)) {
 		case *http2.GoAwayFrame:
 			break
 		default:
-			log.Printf("transport: http2Server.HandleStreams found unhandled frame type %v.", frame)
+			t.logger.Printf("transport: http2Server.HandleStreams found unhandled frame type %v.", frame)
 		}
 	}
 }
@@ -326,7 +328,7 @@ func (t *http2Server) handleData(f *http2.DataFrame) {
 	size := len(f.Data())
 	if err := s.fc.onData(uint32(size)); err != nil {
 		if _, ok := err.(ConnectionError); ok {
-			log.Printf("transport: http2Server %v", err)
+			t.logger.Printf("transport: http2Server %v", err)
 			t.Close()
 			return
 		}
@@ -611,7 +613,7 @@ func (t *http2Server) controller() {
 					// meaningful content when this is actually in use.
 					t.framer.writePing(true, i.ack, [8]byte{})
 				default:
-					log.Printf("transport: http2Server.controller got unexpected item type %v\n", i)
+					t.logger.Printf("transport: http2Server.controller got unexpected item type %v\n", i)
 				}
 				t.writableChan <- 0
 				continue

--- a/transport/http_util.go
+++ b/transport/http_util.go
@@ -37,7 +37,6 @@ import (
 	"bufio"
 	"fmt"
 	"io"
-	"log"
 	"net"
 	"strconv"
 	"sync/atomic"
@@ -46,6 +45,7 @@ import (
 	"github.com/bradfitz/http2"
 	"github.com/bradfitz/http2/hpack"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/logs"
 	"google.golang.org/grpc/metadata"
 )
 
@@ -136,7 +136,7 @@ func isReservedHeader(hdr string) bool {
 	}
 }
 
-func newHPACKDecoder() *hpackDecoder {
+func newHPACKDecoder(logger logs.Logger) *hpackDecoder {
 	d := &hpackDecoder{}
 	d.h = hpack.NewDecoder(http2InitHeaderTableSize, func(f hpack.HeaderField) {
 		switch f.Name {
@@ -166,7 +166,7 @@ func newHPACKDecoder() *hpackDecoder {
 				}
 				k, v, err := metadata.DecodeKeyValue(f.Name, f.Value)
 				if err != nil {
-					log.Printf("Failed to decode (%q, %q): %v", f.Name, f.Value, err)
+					logger.Printf("Failed to decode (%q, %q): %v", f.Name, f.Value, err)
 					return
 				}
 				d.state.mdata[k] = v


### PR DESCRIPTION
When running gRPC within go code, many times you want to use a custom logger (for example, logrus, or my [ledge](https://github.com/peter-edge/go-ledge)) that does separate handling of log entries. Golang's standard logger is unfortunately not an interface, but there have been [attempts](https://github.com/Sirupsen/logrus/blob/aaf92c95712104318fc35409745f1533aa5ff327/logrus.go#L82) to wrap the logger in an interface.

In this PR, I add a minimal Logger interface that covers existing log calls in grpc-go, and convert all code to use it. I also add a DialOption and ServerOption for the logger. In the tests and main classes, I convert the code to use the logs.DefaultLogger so that the codebase gets in the habit of having a Logger object always used, as opposed to the global funcs.

This will allow gRPC logs to be sent to other places in applications that use separate logging.