### PR TITLE
separate connection setup and security handshake on server

### DIFF
--- a/clientconn.go
+++ b/clientconn.go
@@ -107,11 +107,11 @@ func WithDialer(f func(addr string, timeout time.Duration) (net.Conn, error)) Di
 // WithHandshaker returns a DialOption that specifies a function to perform some handshaking
 // with the server. It is typically used to negotiate the wire protocol version and security
 // protocol with the server.
-func WithHandshaker(h func(conn net.Conn) (credentials.TransportAuthenticator, error)) DialOption {
-	return func(o *dialOptions) {
-		o.copts.Handshaker = h
-	}
-}
+//func WithHandshaker(h func(conn net.Conn) (credentials.TransportAuthenticator, error)) DialOption {
+//	return func(o *dialOptions) {
+//		o.copts.Handshaker = h
+//	}
+//}
 
 // Dial creates a client connection the given target.
 // TODO(zhaoq): Have an option to make Dial return immediately without waiting

--- a/clientconn.go
+++ b/clientconn.go
@@ -104,15 +104,6 @@ func WithDialer(f func(addr string, timeout time.Duration) (net.Conn, error)) Di
 	}
 }
 
-// WithHandshaker returns a DialOption that specifies a function to perform some handshaking
-// with the server. It is typically used to negotiate the wire protocol version and security
-// protocol with the server.
-//func WithHandshaker(h func(conn net.Conn) (credentials.TransportAuthenticator, error)) DialOption {
-//	return func(o *dialOptions) {
-//		o.copts.Handshaker = h
-//	}
-//}
-
 // Dial creates a client connection the given target.
 // TODO(zhaoq): Have an option to make Dial return immediately without waiting
 // for connection to complete.

--- a/credentials/credentials.go
+++ b/credentials/credentials.go
@@ -89,9 +89,6 @@ type TransportAuthenticator interface {
 	ClientHandshake(addr string, rawConn net.Conn, timeout time.Duration) (net.Conn, error)
 	// ServerHandshake does the authentication handshake for servers.
 	ServerHandshake(rawConn net.Conn) (net.Conn, error)
-	// NewListener creates a listener which accepts connections with requested
-	// authentication handshake.
-	//NewListener(lis net.Listener) net.Listener
 	// Info provides the ProtocolInfo of this TransportAuthenticator.
 	Info() ProtocolInfo
 	Credentials

--- a/examples/route_guide/server/server.go
+++ b/examples/route_guide/server/server.go
@@ -225,15 +225,15 @@ func main() {
 	if err != nil {
 		grpclog.Fatalf("failed to listen: %v", err)
 	}
-	grpcServer := grpc.NewServer()
-	pb.RegisterRouteGuideServer(grpcServer, newServer())
+	var opts []grpc.ServerOption
 	if *tls {
 		creds, err := credentials.NewServerTLSFromFile(*certFile, *keyFile)
 		if err != nil {
 			grpclog.Fatalf("Failed to generate credentials %v", err)
 		}
-		grpcServer.Serve(creds.NewListener(lis))
-	} else {
-		grpcServer.Serve(lis)
+		opts = []grpc.ServerOption{grpc.Creds(creds)}
 	}
+	grpcServer := grpc.NewServer(opts...)
+	pb.RegisterRouteGuideServer(grpcServer, newServer())
+	grpcServer.Serve(lis)
 }

--- a/grpc-auth-support.md
+++ b/grpc-auth-support.md
@@ -15,6 +15,8 @@ creds, err := credentials.NewServerTLSFromFile(certFile, keyFile)
 if err != nil {
   log.Fatalf("Failed to generate credentials %v", err)
 }
+server := grpc.NewServer(grpc.Creds(creds))
+...
 server.Serve(creds.NewListener(lis))
 ```
 

--- a/interop/server/server.go
+++ b/interop/server/server.go
@@ -195,15 +195,15 @@ func main() {
 	if err != nil {
 		grpclog.Fatalf("failed to listen: %v", err)
 	}
-	server := grpc.NewServer()
-	testpb.RegisterTestServiceServer(server, &testServer{})
+	var opts []grpc.ServerOption
 	if *useTLS {
 		creds, err := credentials.NewServerTLSFromFile(*certFile, *keyFile)
 		if err != nil {
 			grpclog.Fatalf("Failed to generate credentials %v", err)
 		}
-		server.Serve(creds.NewListener(lis))
-	} else {
-		server.Serve(lis)
+		opts = []grpc.ServerOption{grpc.Creds(creds)}
 	}
+	server := grpc.NewServer(opts...)
+	testpb.RegisterTestServiceServer(server, &testServer{})
+	server.Serve(lis)
 }

--- a/transport/http2_client.go
+++ b/transport/http2_client.go
@@ -111,17 +111,6 @@ func newHTTP2Client(addr string, opts *ConnectOptions) (_ ClientTransport, err e
 	if connErr != nil {
 		return nil, ConnectionErrorf("transport: %v", connErr)
 	}
-	// Perform handshake if opts.Handshaker is set.
-	if opts.Handshaker != nil {
-		auth, err := opts.Handshaker(conn)
-		if err != nil {
-			return nil, ConnectionErrorf("transport: handshaking failed %v", err)
-		}
-		// Prepend the resulting authenticator to opts.AuthOptions.
-		if auth != nil {
-			opts.AuthOptions = append([]credentials.Credentials{auth}, opts.AuthOptions...)
-		}
-	}
 	for _, c := range opts.AuthOptions {
 		if ccreds, ok := c.(credentials.TransportAuthenticator); ok {
 			scheme = "https"
@@ -132,7 +121,7 @@ func newHTTP2Client(addr string, opts *ConnectOptions) (_ ClientTransport, err e
 			if timeout > 0 {
 				timeout -= time.Since(startT)
 			}
-			conn, connErr = ccreds.Handshake(addr, conn, timeout)
+			conn, connErr = ccreds.ClientHandshake(addr, conn, timeout)
 			break
 		}
 	}

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -316,7 +316,6 @@ func NewServerTransport(protocol string, conn net.Conn, maxStreams uint32) (Serv
 // ConnectOptions covers all relevant options for dialing a server.
 type ConnectOptions struct {
 	Dialer      func(string, time.Duration) (net.Conn, error)
-	Handshaker  func(conn net.Conn) (credentials.TransportAuthenticator, error)
 	AuthOptions []credentials.Credentials
 	Timeout     time.Duration
 }


### PR DESCRIPTION
i) reverted the previous handshaker change which is not well-shaped;
ii) separate connection setup and security handshake on server to bring more flexbility, leading to breaking credential API change.