### PR TITLE
Run benchmark server on localhost interface only.

### DIFF
--- a/benchmark/benchmark.go
+++ b/benchmark/benchmark.go
@@ -92,10 +92,11 @@ func (s *testServer) StreamingCall(stream testpb.TestService_StreamingCallServer
 	}
 }
 
-// StartServer starts a gRPC server serving a benchmark service. It returns its
-// listen address and a function to stop the server.
-func StartServer() (string, func()) {
-	lis, err := net.Listen("tcp", ":0")
+// StartServer starts a gRPC server serving a benchmark service on the given
+// address, which may be something like "localhost:0". It returns its listen
+// address and a function to stop the server.
+func StartServer(addr string) (string, func()) {
+	lis, err := net.Listen("tcp", addr)
 	if err != nil {
 		grpclog.Fatalf("Failed to listen: %v", err)
 	}

--- a/benchmark/benchmark_test.go
+++ b/benchmark/benchmark_test.go
@@ -15,7 +15,7 @@ import (
 func runUnary(b *testing.B, maxConcurrentCalls int) {
 	s := stats.AddStats(b, 38)
 	b.StopTimer()
-	target, stopper := StartServer()
+	target, stopper := StartServer("localhost:0")
 	defer stopper()
 	conn := NewClientConn(target)
 	tc := testpb.NewTestServiceClient(conn)
@@ -58,7 +58,7 @@ func runUnary(b *testing.B, maxConcurrentCalls int) {
 func runStream(b *testing.B, maxConcurrentCalls int) {
 	s := stats.AddStats(b, 38)
 	b.StopTimer()
-	target, stopper := StartServer()
+	target, stopper := StartServer("localhost:0")
 	defer stopper()
 	conn := NewClientConn(target)
 	tc := testpb.NewTestServiceClient(conn)

--- a/benchmark/server/main.go
+++ b/benchmark/server/main.go
@@ -28,7 +28,7 @@ func main() {
 			grpclog.Fatalf("Failed to serve: %v", err)
 		}
 	}()
-	addr, stopper := benchmark.StartServer()
+	addr, stopper := benchmark.StartServer(":0") // listen on all interfaces
 	grpclog.Println("Server Address: ", addr)
 	<-time.After(time.Duration(*duration) * time.Second)
 	stopper()


### PR DESCRIPTION
This avoids triggering firewall warnings on OS X,
and it's generally safer too.