### PR TITLE
Honor END_STREAM flags in HTTP/2 Data frames.

### DIFF
--- a/transport/http2_client.go
+++ b/transport/http2_client.go
@@ -473,15 +473,7 @@ func (t *http2Client) Write(s *Stream, data []byte, opts *Options) error {
 	if !opts.Last {
 		return nil
 	}
-	s.mu.Lock()
-	if s.state != streamDone {
-		if s.state == streamReadDone {
-			s.state = streamDone
-		} else {
-			s.state = streamWriteDone
-		}
-	}
-	s.mu.Unlock()
+	s.writeClosed()
 	return nil
 }
 
@@ -544,13 +536,7 @@ func (t *http2Client) handleData(f *http2.DataFrame) {
 	s.write(recvMsg{data: data})
 
 	if f.FrameHeader.Flags.Has(http2.FlagDataEndStream) {
-		s.mu.Lock()
-		if (s.state == streamWriteDone) {
-			s.state = streamDone
-		} else {
-			s.state = streamReadDone
-		}
-		s.mu.Unlock()
+		s.readClosed()
 		s.write(recvMsg{err: io.EOF})
 	}
 }

--- a/transport/http2_server.go
+++ b/transport/http2_server.go
@@ -340,15 +340,7 @@ func (t *http2Server) handleData(f *http2.DataFrame) {
 	s.write(recvMsg{data: data})
 	if f.Header().Flags.Has(http2.FlagDataEndStream) {
 		// Received the end of stream from the client.
-		s.mu.Lock()
-		if s.state != streamDone {
-			if s.state == streamWriteDone {
-				s.state = streamDone
-			} else {
-				s.state = streamReadDone
-			}
-		}
-		s.mu.Unlock()
+		s.readClosed()
 		s.write(recvMsg{err: io.EOF})
 	}
 }


### PR DESCRIPTION
Without this, "broken deployments" that do not send trailers after their
response will cause Go clients to hang indefinitely (until a client-side
timeout or server-side slowloris protection kills the connection).

See the diagram at https://httpwg.github.io/specs/rfc7540.html#StreamStates and
the Data frame specification at https://httpwg.github.io/specs/rfc7540.html#DATA
for the relevant HTTP/2 specification.  See
https://github.com/grpc/grpc-common/blob/master/PROTOCOL-HTTP2.md#responses
for the specification that clients must be prepared for servers to omit
the trailers.