### PR TITLE
Honor END_STREAM flags in HTTP/2 Data frames.

### DIFF
--- a/transport/http2_client.go
+++ b/transport/http2_client.go
@@ -543,6 +543,8 @@ func (t *http2Client) handleData(f *http2.DataFrame) {
 	copy(data, f.Data())
 	s.write(recvMsg{data: data})
 
+	// The server has closed the stream without sending trailers.  Record that
+	// the read direction is closed, and set the status appropriately.
 	if f.FrameHeader.Flags.Has(http2.FlagDataEndStream) {
 		s.mu.Lock()
 		if (s.state == streamWriteDone) {
@@ -550,6 +552,8 @@ func (t *http2Client) handleData(f *http2.DataFrame) {
 		} else {
 			s.state = streamReadDone
 		}
+		s.statusCode = codes.Internal
+		s.statusDesc = "server closed the stream without sending trailers"
 		s.mu.Unlock()
 		s.write(recvMsg{err: io.EOF})
 	}


### PR DESCRIPTION
Without this, "broken deployments" that do not send trailers after their
response will cause Go clients to hang indefinitely (until a client-side
timeout or server-side slowloris protection kills the connection).

See the diagram at https://httpwg.github.io/specs/rfc7540.html#StreamStates and
the Data frame specification at https://httpwg.github.io/specs/rfc7540.html#DATA
for the relevant HTTP/2 specification.  See
https://github.com/grpc/grpc-common/blob/master/PROTOCOL-HTTP2.md#responses
for the specification that clients must be prepared for servers to omit
the trailers.