### PR TITLE
Close the header channel if a stream is reset while waiting for headers.

### DIFF
--- a/transport/http2_client.go
+++ b/transport/http2_client.go
@@ -578,6 +578,10 @@ func (t *http2Client) handleRSTStream(f *http2.RSTStreamFrame) {
 		return
 	}
 	s.state = streamDone
+	if !s.headerDone {
+		close(s.headerChan)
+		s.headerDone = true
+	}
 	s.statusCode, ok = http2RSTErrConvTab[http2.ErrCode(f.ErrCode)]
 	if !ok {
 		grpclog.Println("transport: http2Client.handleRSTStream found no mapped gRPC status for the received http2 error ", f.ErrCode)


### PR DESCRIPTION
Previously client calls would block indefinitely on the header channel, until the context was cancelled or the connection was terminated.

Fixes #261.