### PR TITLE
Instrumentation hooks and Prometheus metrics

### DIFF
--- a/call.go
+++ b/call.go
@@ -42,6 +42,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/transport"
+	"google.golang.org/grpc/monitoring"
 )
 
 // recvResponse receives and parses an RPC response.
@@ -111,6 +112,7 @@ func Invoke(ctx context.Context, method string, args, reply interface{}, cc *Cli
 			return toRPCErr(err)
 		}
 	}
+	rpcMonitor := cc.dopts.monitor.NewForRpc(monitoring.Unary, method)
 	defer func() {
 		for _, o := range opts {
 			o.after(&c)
@@ -147,6 +149,7 @@ func Invoke(ctx context.Context, method string, args, reply interface{}, cc *Cli
 		)
 		// TODO(zhaoq): Need a formal spec of retry strategy for non-failfast rpcs.
 		if lastErr != nil && c.failFast {
+			rpcMonitor.Erred(lastErr)
 			return toRPCErr(lastErr)
 		}
 		callHdr := &transport.CallHdr{
@@ -157,8 +160,10 @@ func Invoke(ctx context.Context, method string, args, reply interface{}, cc *Cli
 		if err != nil {
 			if lastErr != nil {
 				// This was a retry; return the error from the last attempt.
+				rpcMonitor.Erred(err)
 				return toRPCErr(lastErr)
 			}
+			rpcMonitor.Erred(err)
 			return toRPCErr(err)
 		}
 		if c.traceInfo.tr != nil {
@@ -171,8 +176,10 @@ func Invoke(ctx context.Context, method string, args, reply interface{}, cc *Cli
 				continue
 			}
 			if lastErr != nil {
+				rpcMonitor.Erred(lastErr)
 				return toRPCErr(lastErr)
 			}
+			rpcMonitor.Erred(err)
 			return toRPCErr(err)
 		}
 		// Receive the response
@@ -185,8 +192,10 @@ func Invoke(ctx context.Context, method string, args, reply interface{}, cc *Cli
 		}
 		t.CloseStream(stream, lastErr)
 		if lastErr != nil {
+			rpcMonitor.Erred(lastErr)
 			return toRPCErr(lastErr)
 		}
+		rpcMonitor.Handled(stream.StatusCode(), stream.StatusDesc())
 		return Errorf(stream.StatusCode(), stream.StatusDesc())
 	}
 }

--- a/clientconn.go
+++ b/clientconn.go
@@ -46,6 +46,7 @@ import (
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/grpclog"
 	"google.golang.org/grpc/transport"
+	"google.golang.org/grpc/monitoring"
 )
 
 var (
@@ -77,6 +78,7 @@ type dialOptions struct {
 	block    bool
 	insecure bool
 	copts    transport.ConnectOptions
+	monitor	monitoring.RpcMonitor
 }
 
 // DialOption configures how we set up the connection.
@@ -141,6 +143,13 @@ func WithUserAgent(s string) DialOption {
 	}
 }
 
+// WithMonitoring returns a DialOption which sets the monitoring to use for this connection..
+func WithMonitoring(m monitoring.RpcMonitor) DialOption {
+	return func(o *dialOptions) {
+		o.monitor = m
+	}
+}
+
 // Dial creates a client connection the given target.
 func Dial(target string, opts ...DialOption) (*ClientConn, error) {
 	cc := &ClientConn{
@@ -155,6 +164,10 @@ func Dial(target string, opts ...DialOption) (*ClientConn, error) {
 	}
 	if cc.dopts.picker == nil {
 		cc.dopts.picker = &unicastPicker{}
+	}
+	if cc.dopts.monitor == nil {
+		// Set the default to a no-op monitor.
+		cc.dopts.monitor = &monitoring.NoOpMonitor{}
 	}
 	if err := cc.dopts.picker.Init(cc); err != nil {
 		return nil, err

--- a/monitoring/monitoring.go
+++ b/monitoring/monitoring.go
@@ -1,0 +1,48 @@
+package monitoring
+
+import (
+	"google.golang.org/grpc/codes"
+)
+
+type RpcType string
+
+const (
+	Unary     RpcType = "unary"
+	Streaming RpcType = "streaming"
+)
+
+// RpcMonitor is a per-RPC datastructure.
+type PerRpcMonitor interface {
+	// ReceivedMessage is called on every stream message received by the monitor.
+	ReceivedMessage()
+
+	// SentMessage is called on every stream message sent by the monitor.
+	SentMessage()
+
+	// Handled is called whenever the RPC handling completes (with OK or AppError).
+	Handled(code codes.Code, description string)
+
+	// Erred is called whenever the RPC failed due to RPC-layer errors.
+	Erred(err error)
+}
+
+// ServerMonitor allocates new per-RPC monitors on the server side.
+type RpcMonitor interface {
+	// NewForRpc allocates a new per-RPC monitor, also signifying the start of an RPC call.
+	NewForRpc(rpcType RpcType, fullMethod string) PerRpcMonitor
+}
+
+// NoOpMonitor is both a Client- and Server-side RpcMonitor that does nothing, for no allocations.
+type NoOpMonitor struct{}
+
+func (m *NoOpMonitor) NewForRpc(RpcType, string) PerRpcMonitor {
+	return m
+}
+
+func (*NoOpMonitor) ReceivedMessage() {}
+
+func (*NoOpMonitor) SentMessage() {}
+
+func (*NoOpMonitor) Handled(code codes.Code, description string) {}
+
+func (*NoOpMonitor) Erred(err error) {}

--- a/monitoring/prometheus/prometheus.go
+++ b/monitoring/prometheus/prometheus.go
@@ -1,0 +1,195 @@
+package prometheus
+
+import (
+	"strings"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/monitoring"
+	"google.golang.org/grpc/transport"
+
+	prom "github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	serverStartedCounter = prom.NewCounterVec(
+		prom.CounterOpts{
+			Namespace: "grpc",
+			Subsystem: "server",
+			Name:      "rpc_started_total",
+			Help:      "Total number of RPCs started by the server.",
+		}, []string{"type", "service", "method"})
+
+	serverStreamMsgReceived = prom.NewCounterVec(
+		prom.CounterOpts{
+			Namespace: "grpc",
+			Subsystem: "server",
+			Name:      "rpc_msg_received_total",
+			Help:      "Total number of RPC stream messages received on the server.",
+		}, []string{"type", "service", "method"})
+
+	serverStreamMsgSent = prom.NewCounterVec(
+		prom.CounterOpts{
+			Namespace: "grpc",
+			Subsystem: "server",
+			Name:      "rpc_msg_sent_total",
+			Help:      "Total number of RPC stream messages sent by the server.",
+		}, []string{"type", "service", "method"})
+
+	serverHandledHistogram = prom.NewHistogramVec(
+		prom.HistogramOpts{
+			Namespace: "grpc",
+			Subsystem: "server",
+			Name:      "rpc_handled",
+			Help:      "Histogram of response latency of RPC that had been application-level handled by the server.",
+			Buckets:   prom.DefBuckets,
+		}, []string{"type", "service", "method", "code"})
+
+	serverErred = prom.NewCounterVec(
+		prom.CounterOpts{
+			Namespace: "grpc",
+			Subsystem: "server",
+			Name:      "rpc_erred_total",
+			Help:      "Total number of RPC that had failed on the RPC layer on the server.",
+		}, []string{"type", "service", "method", "error"})
+
+
+	clientStartedCounter = prom.NewCounterVec(
+		prom.CounterOpts{
+			Namespace: "grpc",
+			Subsystem: "client",
+			Name:      "rpc_started_total",
+			Help:      "Total number of RPCs started by the client.",
+		}, []string{"type", "service", "method"})
+
+	clientStreamMsgReceived = prom.NewCounterVec(
+		prom.CounterOpts{
+			Namespace: "grpc",
+			Subsystem: "client",
+			Name:      "rpc_msg_received_total",
+			Help:      "Total number of RPC stream messages received by the client.",
+		}, []string{"type", "service", "method"})
+
+	clientStreamMsgSent = prom.NewCounterVec(
+		prom.CounterOpts{
+			Namespace: "grpc",
+			Subsystem: "client",
+			Name:      "rpc_msg_sent_total",
+			Help:      "Total number of RPC stream messages sent by the client.",
+		}, []string{"type", "service", "method"})
+
+	clientHandledHistogram = prom.NewHistogramVec(
+		prom.HistogramOpts{
+			Namespace: "grpc",
+			Subsystem: "client",
+			Name:      "rpc_handled",
+			Help:      "Histogram of of RPC latency on the client side",
+			Buckets:   prom.DefBuckets,
+		}, []string{"type", "service", "method", "code"})
+
+	clientErred = prom.NewCounterVec(
+		prom.CounterOpts{
+			Namespace: "grpc",
+			Subsystem: "client",
+			Name:      "rpc_erred_total",
+			Help:      "Total number of RPC that had failed on the RPC layer on the client.",
+		}, []string{"type", "service", "method", "error"})	
+)
+
+func init() {
+	prom.MustRegister(serverStartedCounter)
+	prom.MustRegister(serverStreamMsgReceived)
+	prom.MustRegister(serverStreamMsgSent)
+	prom.MustRegister(serverHandledHistogram)
+	prom.MustRegister(serverErred)
+	prom.MustRegister(clientStartedCounter)
+	prom.MustRegister(clientStreamMsgReceived)
+	prom.MustRegister(clientStreamMsgSent)
+	prom.MustRegister(clientHandledHistogram)
+	prom.MustRegister(clientErred)
+}
+
+type ServerMonitor struct {
+}
+
+func (m *ServerMonitor) NewForRpc(rpcType monitoring.RpcType, fullMethod string) monitoring.PerRpcMonitor {
+	r := &serverRpcMonitor{rpcType: rpcType, startTime: time.Now()}
+	r.serviceName, r.methodName = splitMethodName(fullMethod)
+	serverStartedCounter.WithLabelValues(string(r.rpcType), r.serviceName, r.methodName).Inc()
+	return r
+}
+
+type serverRpcMonitor struct {
+	rpcType     monitoring.RpcType
+	serviceName string
+	methodName  string
+	startTime   time.Time
+}
+
+func (r *serverRpcMonitor) ReceivedMessage() {
+	serverStreamMsgReceived.WithLabelValues(string(r.rpcType), r.serviceName, r.methodName).Inc()
+}
+
+func (r *serverRpcMonitor) SentMessage() {
+	serverStreamMsgSent.WithLabelValues(string(r.rpcType), r.serviceName, r.methodName).Inc()
+}
+
+func (r *serverRpcMonitor) Handled(code codes.Code, description string) {
+	serverHandledHistogram.WithLabelValues(string(r.rpcType), r.serviceName, r.methodName, code.String()).Observe(time.Since(r.startTime).Seconds())
+}
+
+func (r *serverRpcMonitor) Erred(err error) {
+	serverErred.WithLabelValues(string(r.rpcType), r.serviceName, r.methodName, errorType(err)).Inc()
+}
+
+type ClientMonitor struct {
+}
+
+func (m *ClientMonitor) NewForRpc(rpcType monitoring.RpcType, fullMethod string) monitoring.PerRpcMonitor {
+	r := &clientRpcMonitor{rpcType: rpcType, startTime: time.Now()}
+	r.serviceName, r.methodName = splitMethodName(fullMethod)
+	clientStartedCounter.WithLabelValues(string(r.rpcType), r.serviceName, r.methodName).Inc()
+	return r
+}
+
+type clientRpcMonitor struct {
+	rpcType     monitoring.RpcType
+	serviceName string
+	methodName  string
+	startTime   time.Time
+}
+
+func (r *clientRpcMonitor) ReceivedMessage() {
+	clientStreamMsgReceived.WithLabelValues(string(r.rpcType), r.serviceName, r.methodName).Inc()
+}
+
+func (r *clientRpcMonitor) SentMessage() {
+	clientStreamMsgSent.WithLabelValues(string(r.rpcType), r.serviceName, r.methodName).Inc()
+}
+
+func (r *clientRpcMonitor) Handled(code codes.Code, description string) {
+	clientHandledHistogram.WithLabelValues(string(r.rpcType), r.serviceName, r.methodName, code.String()).Observe(time.Since(r.startTime).Seconds())
+}
+
+func (r *clientRpcMonitor) Erred(err error) {
+	clientErred.WithLabelValues(string(r.rpcType), r.serviceName, r.methodName, errorType(err)).Inc()
+}
+
+func splitMethodName(fullMethodName string) (string, string) {
+	fullMethodName = strings.TrimPrefix(fullMethodName, "/") // remove leading slash
+	if i := strings.Index(fullMethodName, "/"); i >= 0 {
+		return fullMethodName[:i], fullMethodName[i+1:]
+	}
+	return "unknown", "unknown"
+}
+
+func errorType(err error) string {
+	switch err.(type) {
+	case transport.ConnectionError:
+		return "ConnectionError"
+	case transport.StreamError:
+		return "StreamError"
+	default:
+		return "Unknown"
+	}
+}

--- a/stream.go
+++ b/stream.go
@@ -44,6 +44,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/transport"
+	"google.golang.org/grpc/monitoring"
 )
 
 type streamHandler func(srv interface{}, stream ServerStream) error
@@ -100,10 +101,13 @@ func NewClientStream(ctx context.Context, desc *StreamDesc, cc *ClientConn, meth
 		t   transport.ClientTransport
 		err error
 	)
+	monitor := cc.dopts.monitor.NewForRpc(monitoring.Streaming, method)
 	t, err = cc.dopts.picker.Pick(ctx)
 	if err != nil {
+		monitor.Erred(err)
 		return nil, toRPCErr(err)
 	}
+
 	// TODO(zhaoq): CallOption is omitted. Add support when it is needed.
 	callHdr := &transport.CallHdr{
 		Host:   cc.authority,
@@ -113,6 +117,7 @@ func NewClientStream(ctx context.Context, desc *StreamDesc, cc *ClientConn, meth
 		desc:    desc,
 		codec:   cc.dopts.codec,
 		tracing: EnableTracing,
+		monitor: monitor,
 	}
 	if cs.tracing {
 		cs.trInfo.tr = trace.New("grpc.Sent."+methodFamily(method), method)
@@ -125,6 +130,7 @@ func NewClientStream(ctx context.Context, desc *StreamDesc, cc *ClientConn, meth
 	}
 	s, err := t.NewStream(ctx, callHdr)
 	if err != nil {
+		cs.monitor.Erred(err)
 		return nil, toRPCErr(err)
 	}
 	cs.t = t
@@ -140,6 +146,7 @@ type clientStream struct {
 	p     *parser
 	desc  *StreamDesc
 	codec Codec
+	monitor    monitoring.PerRpcMonitor
 
 	tracing bool // set to EnableTracing when the clientStream is created.
 
@@ -177,6 +184,9 @@ func (cs *clientStream) SendMsg(m interface{}) (err error) {
 	}
 	defer func() {
 		if err == nil || err == io.EOF {
+			if err == nil {
+				cs.monitor.SentMessage()
+			}
 			return
 		}
 		if _, ok := err.(transport.ConnectionError); !ok {
@@ -196,7 +206,15 @@ func (cs *clientStream) RecvMsg(m interface{}) (err error) {
 	defer func() {
 		// err != nil indicates the termination of the stream.
 		if err != nil {
+			if rErr, ok := err.(rpcError); ok {
+				cs.monitor.Handled(rErr.code, rErr.desc)
+			} else if err != io.EOF {
+				cs.monitor.Erred(err)
+				err = toRPCErr(err)
+			}
 			cs.finish(err)
+		} else {
+			cs.monitor.ReceivedMessage()
 		}
 	}()
 	if err == nil {
@@ -214,7 +232,7 @@ func (cs *clientStream) RecvMsg(m interface{}) (err error) {
 		err = recv(cs.p, cs.codec, m)
 		cs.t.CloseStream(cs.s, err)
 		if err == nil {
-			return toRPCErr(errors.New("grpc: client streaming protocol violation: get <nil>, want <EOF>"))
+			return errors.New("grpc: client streaming protocol violation: get <nil>, want <EOF>")
 		}
 		if err == io.EOF {
 			if cs.s.StatusCode() == codes.OK {
@@ -222,19 +240,20 @@ func (cs *clientStream) RecvMsg(m interface{}) (err error) {
 			}
 			return Errorf(cs.s.StatusCode(), cs.s.StatusDesc())
 		}
-		return toRPCErr(err)
+		return err
 	}
 	if _, ok := err.(transport.ConnectionError); !ok {
 		cs.t.CloseStream(cs.s, err)
 	}
 	if err == io.EOF {
 		if cs.s.StatusCode() == codes.OK {
+			cs.monitor.Handled(codes.OK, "")
 			// Returns io.EOF to indicate the end of the stream.
 			return
 		}
 		return Errorf(cs.s.StatusCode(), cs.s.StatusDesc())
 	}
-	return toRPCErr(err)
+	return err
 }
 
 func (cs *clientStream) CloseSend() (err error) {
@@ -287,6 +306,7 @@ type serverStream struct {
 	codec      Codec
 	statusCode codes.Code
 	statusDesc string
+	monitor    monitoring.PerRpcMonitor
 	trInfo     *traceInfo
 
 	mu sync.Mutex // protects trInfo.tr after the service handler runs.
@@ -310,6 +330,9 @@ func (ss *serverStream) SetTrailer(md metadata.MD) {
 
 func (ss *serverStream) SendMsg(m interface{}) (err error) {
 	defer func() {
+		if err != nil {
+			ss.monitor.SentMessage()
+		}
 		if ss.trInfo != nil {
 			ss.mu.Lock()
 			if ss.trInfo.tr != nil {
@@ -333,6 +356,9 @@ func (ss *serverStream) SendMsg(m interface{}) (err error) {
 
 func (ss *serverStream) RecvMsg(m interface{}) (err error) {
 	defer func() {
+		if err != nil {
+			ss.monitor.ReceivedMessage()
+		}
 		if ss.trInfo != nil {
 			ss.mu.Lock()
 			if ss.trInfo.tr != nil {


### PR DESCRIPTION
Implements a simple callback-based instrumentation hooks for gRPC. The choice of instrumentation is made through `server.options` and `clinetconn.DialOption`, leaving the user in full control. The default implementation is a No-Op, incurring no overhead.

The Prometheus implementation counts:
 * number of started RPCs (to be able to see RPCs in flight)
 * number of fully handled RPCs (to the app layer) with breakdown by `statusCode`, including latency measurements
 * number of erred RPCs in the RPC-layer
 * number of sent/received messages for `streaming` RPCS

The serverside screenshot of the `metrics` page of prometheus showign both `streaming` and `unary` rpcs is in the related bug: https://github.com/grpc/grpc-go/issues/240

Input needed:
 * naming for prometheus
 * testing?