### PR TITLE
Insecure ClientConn made explicit

### DIFF
--- a/benchmark/benchmark.go
+++ b/benchmark/benchmark.go
@@ -139,7 +139,7 @@ func DoStreamingRoundTrip(tc testpb.TestServiceClient, stream testpb.TestService
 
 // NewClientConn creates a gRPC client connection to addr.
 func NewClientConn(addr string) *grpc.ClientConn {
-	conn, err := grpc.Dial(addr)
+	conn, err := grpc.Dial(addr, grpc.WithInsecure())
 	if err != nil {
 		grpclog.Fatalf("NewClientConn(%q) failed to create a ClientConn %v", addr, err)
 	}

--- a/examples/route_guide/client/client.go
+++ b/examples/route_guide/client/client.go
@@ -175,6 +175,8 @@ func main() {
 			creds = credentials.NewClientTLSFromCert(nil, sn)
 		}
 		opts = append(opts, grpc.WithTransportCredentials(creds))
+	} else {
+		opts = append(opts, grpc.WithInsecure())
 	}
 	conn, err := grpc.Dial(*serverAddr, opts...)
 	if err != nil {

--- a/interop/client/client.go
+++ b/interop/client/client.go
@@ -522,6 +522,8 @@ func main() {
 		} else if *testCase == "oauth2_auth_token" {
 			opts = append(opts, grpc.WithPerRPCCredentials(oauth.NewOauthAccess(getToken())))
 		}
+	} else {
+		opts = append(opts, grpc.WithInsecure())
 	}
 	conn, err := grpc.Dial(serverAddr, opts...)
 	if err != nil {

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -237,7 +237,7 @@ func (s *testServer) HalfDuplexCall(stream testpb.TestService_HalfDuplexCallServ
 const tlsDir = "testdata/"
 
 func TestDialTimeout(t *testing.T) {
-	conn, err := grpc.Dial("Non-Existent.Server:80", grpc.WithTimeout(time.Millisecond), grpc.WithBlock())
+	conn, err := grpc.Dial("Non-Existent.Server:80", grpc.WithTimeout(time.Millisecond), grpc.WithBlock(), grpc.WithInsecure())
 	if err == nil {
 		conn.Close()
 	}
@@ -251,7 +251,7 @@ func TestTLSDialTimeout(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create credentials %v", err)
 	}
-	conn, err := grpc.Dial("Non-Existent.Server:80", grpc.WithTransportCredentials(creds), grpc.WithTimeout(time.Millisecond), grpc.WithBlock())
+	conn, err := grpc.Dial("Non-Existent.Server:80", grpc.WithTransportCredentials(creds), grpc.WithTimeout(time.Millisecond), grpc.WithBlock(), grpc.WithInsecure())
 	if err == nil {
 		conn.Close()
 	}
@@ -270,7 +270,7 @@ func TestReconnectTimeout(t *testing.T) {
 		t.Fatalf("Failed to parse listener address: %v", err)
 	}
 	addr := "localhost:" + port
-	conn, err := grpc.Dial(addr, grpc.WithTimeout(5*time.Second), grpc.WithBlock())
+	conn, err := grpc.Dial(addr, grpc.WithTimeout(5*time.Second), grpc.WithBlock(), grpc.WithInsecure())
 	if err != nil {
 		t.Fatalf("Failed to dial to the server %q: %v", addr, err)
 	}
@@ -357,7 +357,7 @@ func setUp(hs *health.HealthServer, maxStream uint32, ua string, e env) (s *grpc
 		}
 		cc, err = grpc.Dial(addr, grpc.WithTransportCredentials(creds), grpc.WithDialer(e.dialer), grpc.WithUserAgent(ua))
 	} else {
-		cc, err = grpc.Dial(addr, grpc.WithDialer(e.dialer), grpc.WithUserAgent(ua))
+		cc, err = grpc.Dial(addr, grpc.WithDialer(e.dialer), grpc.WithInsecure(), grpc.WithUserAgent(ua))
 	}
 	if err != nil {
 		grpclog.Fatalf("Dial(%q) = %v", addr, err)


### PR DESCRIPTION
users have to set grpc.WithInsecure() DialOption when they want an insecure ClientConn. Fixes #307 