### PR TITLE
[IMPORTANT] Fail ClientConn creation if users try to transmit oauth2 token on a insecure connection.

### DIFF
--- a/clientconn.go
+++ b/clientconn.go
@@ -57,7 +57,7 @@ var (
 	// ErrCredentialsMisuse indicates that users want to transmit security infomation
 	// (e.g., oauth2 token) which requires secure connection on an insecure
 	// connection.
-	ErrCredentailsMisuse = errors.New("grpc: the credentials require transport level security (use grpc.WithTransportAuthenticator() to set)")
+	ErrCredentialsMisuse = errors.New("grpc: the credentials require transport level security (use grpc.WithTransportAuthenticator() to set)")
 	// ErrClientConnClosing indicates that the operation is illegal because
 	// the session is closing.
 	ErrClientConnClosing = errors.New("grpc: the client connection is closing")
@@ -165,7 +165,7 @@ func Dial(target string, opts ...DialOption) (*ClientConn, error) {
 	} else {
 		for _, c := range cc.dopts.copts.AuthOptions {
 			if c.RequireTransportSecurity() {
-				return nil, ErrCredentailsMisuse
+				return nil, ErrCredentialsMisuse
 			}
 		}
 	}

--- a/clientconn.go
+++ b/clientconn.go
@@ -54,6 +54,10 @@ var (
 	// being set for ClientConn. Users should either set one or explicityly
 	// call WithInsecure DialOption to disable security.
 	ErrNoTransportSecurity = errors.New("grpc: no transport security set (use grpc.WithInsecure() explicitly or set credentials)")
+	// ErrCredentialsMisuse indicates that users want to transmit security infomation
+	// (e.g., oauth2 token) which requires secure connection on an insecure
+	// connection.
+	ErrCredentailsMisuse = errors.New("grpc: the credentials require transport level security (use grpc.WithTransportAuthenticator() to set)")
 	// ErrClientConnClosing indicates that the operation is illegal because
 	// the session is closing.
 	ErrClientConnClosing = errors.New("grpc: the client connection is closing")
@@ -157,6 +161,12 @@ func Dial(target string, opts ...DialOption) (*ClientConn, error) {
 		}
 		if !ok {
 			return nil, ErrNoTransportSecurity
+		}
+	} else {
+		for _, c := range cc.dopts.copts.AuthOptions {
+			if c.RequireTransportSecurity() {
+				return nil, ErrCredentailsMisuse
+			}
 		}
 	}
 	colonPos := strings.LastIndex(target, ":")

--- a/credentials/credentials.go
+++ b/credentials/credentials.go
@@ -65,7 +65,8 @@ type Credentials interface {
 	// TODO(zhaoq): Define the set of the qualified keys instead of leaving
 	// it as an arbitrary string.
 	GetRequestMetadata(ctx context.Context) (map[string]string, error)
-	// RequireTransport indicates whether the credentails requires transport security.
+	// RequireTransportSecurity indicates whether the credentails requires
+	// transport security.
 	RequireTransportSecurity() bool
 }
 

--- a/credentials/credentials.go
+++ b/credentials/credentials.go
@@ -65,6 +65,8 @@ type Credentials interface {
 	// TODO(zhaoq): Define the set of the qualified keys instead of leaving
 	// it as an arbitrary string.
 	GetRequestMetadata(ctx context.Context) (map[string]string, error)
+	// RequireTransport indicates whether the credentails requires transport security.
+	RequireTransportSecurity() bool
 }
 
 // ProtocolInfo provides information regarding the gRPC wire protocol version,
@@ -139,6 +141,10 @@ func (c tlsCreds) Info() ProtocolInfo {
 // metadata.
 func (c *tlsCreds) GetRequestMetadata(ctx context.Context) (map[string]string, error) {
 	return nil, nil
+}
+
+func (c *tlsCreds) RequireTransportSecurity() bool {
+	return true
 }
 
 type timeoutError struct{}

--- a/credentials/oauth/oauth.go
+++ b/credentials/oauth/oauth.go
@@ -61,6 +61,10 @@ func (ts TokenSource) GetRequestMetadata(ctx context.Context) (map[string]string
 	}, nil
 }
 
+func (ts TokenSource) RequireTransportSecurity() bool {
+	return true
+}
+
 type jwtAccess struct {
 	ts oauth2.TokenSource
 }
@@ -91,6 +95,10 @@ func (j jwtAccess) GetRequestMetadata(ctx context.Context) (map[string]string, e
 	}, nil
 }
 
+func (ts jwtAccess) RequireTransportSecurity() bool {
+	return true
+}
+
 // oauthAccess supplies credentials from a given token.
 type oauthAccess struct {
 	token oauth2.Token
@@ -105,6 +113,10 @@ func (oa oauthAccess) GetRequestMetadata(ctx context.Context) (map[string]string
 	return map[string]string{
 		"authorization": oa.token.TokenType + " " + oa.token.AccessToken,
 	}, nil
+}
+
+func (oa jwtAccess) RequireTransportSecurity() bool {
+	return true
 }
 
 // NewComputeEngine constructs the credentials that fetches access tokens from
@@ -128,6 +140,10 @@ func (s serviceAccount) GetRequestMetadata(ctx context.Context) (map[string]stri
 	return map[string]string{
 		"authorization": token.TokenType + " " + token.AccessToken,
 	}, nil
+}
+
+func (s serviceAccount) RequireTransportSecurity() bool {
+	return true
 }
 
 // NewServiceAccountFromKey constructs the credentials using the JSON key slice

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -251,7 +251,7 @@ func TestTLSDialTimeout(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create credentials %v", err)
 	}
-	conn, err := grpc.Dial("Non-Existent.Server:80", grpc.WithTransportCredentials(creds), grpc.WithTimeout(time.Millisecond), grpc.WithBlock(), grpc.WithInsecure())
+	conn, err := grpc.Dial("Non-Existent.Server:80", grpc.WithTransportCredentials(creds), grpc.WithTimeout(time.Millisecond), grpc.WithBlock())
 	if err == nil {
 		conn.Close()
 	}


### PR DESCRIPTION
i) If you send oauth2 token via the credentials defined in credentials/oauth/oauth.go on a insecure ClientConn, you will get the runtime error grpc.ErrCredentialsMisuse. This is misuse;
ii) If you wrote your own custom credentials impl, you will get compilation failure because a new RequireTransportSecurity is added in this PR.