### PR TITLE
change grpclog to use structured logging

### DIFF
--- a/benchmark/benchmark.go
+++ b/benchmark/benchmark.go
@@ -49,15 +49,15 @@ import (
 
 func newPayload(t testpb.PayloadType, size int) *testpb.Payload {
 	if size < 0 {
-		grpclog.Fatalf("Requested a response with invalid length %d", size)
+		grpclog.With("size", size).Fatal("Requested a response with invalid length")
 	}
 	body := make([]byte, size)
 	switch t {
 	case testpb.PayloadType_COMPRESSABLE:
 	case testpb.PayloadType_UNCOMPRESSABLE:
-		grpclog.Fatalf("PayloadType UNCOMPRESSABLE is not supported")
+		grpclog.Fatal("PayloadType UNCOMPRESSABLE is not supported")
 	default:
-		grpclog.Fatalf("Unsupported payload type: %d", t)
+		grpclog.With("t", t).Fatal("Unsupported payload type")
 	}
 	return &testpb.Payload{
 		Type: t,
@@ -98,7 +98,7 @@ func (s *testServer) StreamingCall(stream testpb.TestService_StreamingCallServer
 func StartServer(addr string) (string, func()) {
 	lis, err := net.Listen("tcp", addr)
 	if err != nil {
-		grpclog.Fatalf("Failed to listen: %v", err)
+		grpclog.Err(err).Fatal("Failed to listen")
 	}
 	s := grpc.NewServer(grpc.MaxConcurrentStreams(math.MaxUint32))
 	testpb.RegisterTestServiceServer(s, &testServer{})
@@ -117,7 +117,7 @@ func DoUnaryCall(tc testpb.TestServiceClient, reqSize, respSize int) {
 		Payload:      pl,
 	}
 	if _, err := tc.UnaryCall(context.Background(), req); err != nil {
-		grpclog.Fatal("/TestService/UnaryCall RPC failed: ", err)
+		grpclog.Err(err).Fatal("/TestService/UnaryCall RPC failed")
 	}
 }
 
@@ -130,10 +130,10 @@ func DoStreamingRoundTrip(tc testpb.TestServiceClient, stream testpb.TestService
 		Payload:      pl,
 	}
 	if err := stream.Send(req); err != nil {
-		grpclog.Fatalf("StreamingCall(_).Send: %v", err)
+		grpclog.Err(err).Fatal("StreamingCall(_).Send")
 	}
 	if _, err := stream.Recv(); err != nil {
-		grpclog.Fatalf("StreamingCall(_).Recv: %v", err)
+		grpclog.Err(err).Fatal("StreamingCall(_).Recv")
 	}
 }
 
@@ -141,7 +141,7 @@ func DoStreamingRoundTrip(tc testpb.TestServiceClient, stream testpb.TestService
 func NewClientConn(addr string) *grpc.ClientConn {
 	conn, err := grpc.Dial(addr, grpc.WithInsecure())
 	if err != nil {
-		grpclog.Fatalf("NewClientConn(%q) failed to create a ClientConn %v", addr, err)
+		grpclog.Err(err).With("addr", addr).Fatal("NewClientConn(addr) failed to create a ClientConn")
 	}
 	return conn
 }

--- a/benchmark/benchmark_test.go
+++ b/benchmark/benchmark_test.go
@@ -67,7 +67,7 @@ func runStream(b *testing.B, maxConcurrentCalls int) {
 	// Warm up connection.
 	stream, err := tc.StreamingCall(context.Background())
 	if err != nil {
-		grpclog.Fatalf("%v.StreamingCall(_) = _, %v", tc, err)
+		grpclog.Err(err).With("tc", tc).Fatal("StreamingCall(_)")
 	}
 	for i := 0; i < 10; i++ {
 		streamCaller(tc, stream)
@@ -85,7 +85,7 @@ func runStream(b *testing.B, maxConcurrentCalls int) {
 		go func() {
 			stream, err := tc.StreamingCall(context.Background())
 			if err != nil {
-				grpclog.Fatalf("%v.StreamingCall(_) = _, %v", tc, err)
+				grpclog.Err(err).With("tc", tc).Fatal("StreamingCall(_)")
 			}
 			for _ = range ch {
 				start := time.Now()

--- a/benchmark/client/main.go
+++ b/benchmark/client/main.go
@@ -86,7 +86,7 @@ func closeLoopUnary() {
 	close(ch)
 	wg.Wait()
 	conn.Close()
-	grpclog.Println(s.String())
+	grpclog.Print(s.String())
 
 }
 
@@ -94,7 +94,7 @@ func closeLoopStream() {
 	s, conn, tc := buildConnection()
 	stream, err := tc.StreamingCall(context.Background())
 	if err != nil {
-		grpclog.Fatalf("%v.StreamingCall(_) = _, %v", tc, err)
+		grpclog.Err(err).With("tc", tc).Fatal("StreamingCall(_)")
 	}
 	for i := 0; i < 100; i++ {
 		streamCaller(tc, stream)
@@ -136,7 +136,7 @@ func closeLoopStream() {
 	close(ch)
 	wg.Wait()
 	conn.Close()
-	grpclog.Println(s.String())
+	grpclog.Print(s.String())
 }
 
 func main() {
@@ -145,11 +145,12 @@ func main() {
 	go func() {
 		lis, err := net.Listen("tcp", ":0")
 		if err != nil {
-			grpclog.Fatalf("Failed to listen: %v", err)
+			grpclog.Err(err).Fatal("Failed to listen")
 		}
-		grpclog.Println("Client profiling address: ", lis.Addr().String())
+		log := grpclog.With("addr", lis.Addr())
+		log.Print("Client profiling address")
 		if err := http.Serve(lis, nil); err != nil {
-			grpclog.Fatalf("Failed to serve: %v", err)
+			log.Err(err).Fatal("Failed to serve")
 		}
 	}()
 	switch *rpcType {

--- a/benchmark/server/main.go
+++ b/benchmark/server/main.go
@@ -21,15 +21,15 @@ func main() {
 	go func() {
 		lis, err := net.Listen("tcp", ":0")
 		if err != nil {
-			grpclog.Fatalf("Failed to listen: %v", err)
+			grpclog.Err(err).Fatal("Failed to listen")
 		}
-		grpclog.Println("Server profiling address: ", lis.Addr().String())
+		grpclog.With("addr", lis.Addr()).Print("Server profiling")
 		if err := http.Serve(lis, nil); err != nil {
-			grpclog.Fatalf("Failed to serve: %v", err)
+			grpclog.Err(err).Fatal("Failed to serve")
 		}
 	}()
 	addr, stopper := benchmark.StartServer(":0") // listen on all interfaces
-	grpclog.Println("Server Address: ", addr)
+	grpclog.With("addr", addr).Print("Server benchmark")
 	<-time.After(time.Duration(*duration) * time.Second)
 	stopper()
 }

--- a/clientconn.go
+++ b/clientconn.go
@@ -190,7 +190,7 @@ func Dial(target string, opts ...DialOption) (*ClientConn, error) {
 		// Start a goroutine connecting to the server asynchronously.
 		go func() {
 			if err := cc.resetTransport(false); err != nil {
-				grpclog.Printf("Failed to dial %s: %v; please retry.", target, err)
+				grpclog.Err(err).With("target", target).Print("failed to dial, please retry")
 				cc.Close()
 				return
 			}
@@ -353,7 +353,7 @@ func (cc *ClientConn) resetTransport(closeTransport bool) error {
 			closeTransport = false
 			time.Sleep(sleepTime)
 			retries++
-			grpclog.Printf("grpc: ClientConn.resetTransport failed to create client transport: %v; Reconnecting to %q", err, cc.target)
+			grpclog.Err(err).With("target", cc.target).Print("ClientConn.resetTransport failed to create client transport, reconnecting")
 			continue
 		}
 		cc.mu.Lock()
@@ -392,7 +392,7 @@ func (cc *ClientConn) transportMonitor() {
 			cc.mu.Unlock()
 			if err := cc.resetTransport(true); err != nil {
 				// The ClientConn is closing.
-				grpclog.Printf("grpc: ClientConn.transportMonitor exits due to: %v", err)
+				grpclog.Err(err).Print("ClientConn.transportMonitor exits")
 				return
 			}
 			continue

--- a/examples/route_guide/server/server.go
+++ b/examples/route_guide/server/server.go
@@ -159,10 +159,10 @@ func (s *routeGuideServer) RouteChat(stream pb.RouteGuide_RouteChatServer) error
 func (s *routeGuideServer) loadFeatures(filePath string) {
 	file, err := ioutil.ReadFile(filePath)
 	if err != nil {
-		grpclog.Fatalf("Failed to load default features: %v", err)
+		grpclog.Err(err).Fatal("Failed to load default features")
 	}
 	if err := json.Unmarshal(file, &s.savedFeatures); err != nil {
-		grpclog.Fatalf("Failed to load default features: %v", err)
+		grpclog.Err(err).Fatal("Failed to load default features")
 	}
 }
 
@@ -223,13 +223,13 @@ func main() {
 	flag.Parse()
 	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", *port))
 	if err != nil {
-		grpclog.Fatalf("failed to listen: %v", err)
+		grpclog.Err(err).Fatal("failed to listen")
 	}
 	var opts []grpc.ServerOption
 	if *tls {
 		creds, err := credentials.NewServerTLSFromFile(*certFile, *keyFile)
 		if err != nil {
-			grpclog.Fatalf("Failed to generate credentials %v", err)
+			grpclog.Err(err).Fatal("failed to generate credentials")
 		}
 		opts = []grpc.ServerOption{grpc.Creds(creds)}
 	}

--- a/grpclog/logger.go
+++ b/grpclog/logger.go
@@ -37,21 +37,85 @@ Package grpclog defines logging for grpc.
 package grpclog // import "google.golang.org/grpc/grpclog"
 
 import (
-	"log"
+	"fmt"
+	"io"
 	"os"
+	"strings"
+	"sync"
+	"time"
 )
 
-// Use golang's standard logger by default.
-var logger Logger = log.New(os.Stderr, "", log.LstdFlags)
+type logfmt struct {
+	kvs [][2]string
+	out io.Writer
+	mu  sync.Mutex
+}
 
-// Logger mimics golang's standard Logger as an interface.
+func (l *logfmt) Print(msg string) {
+	l.print("info", msg)
+}
+
+func (l *logfmt) Fatal(msg string) {
+	defer os.Exit(1)
+	l.print("fatal", msg)
+}
+
+func (l *logfmt) print(lvl, msg string) {
+	now := time.Now().Format(time.RFC3339Nano)
+	msg = strings.TrimSuffix(msg, "\n")
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	fmt.Fprintf(l.out, `"time"=%q "lvl"=%q "msg"=%q`, now, lvl, msg)
+	for _, kv := range l.kvs {
+		fmt.Fprintf(l.out, " %q=%q", kv[0], kv[1])
+	}
+	l.out.Write([]byte{'\n'})
+}
+
+func (l *logfmt) Err(err error) Logger {
+	return l.With("err", err)
+}
+
+func (l *logfmt) With(keyvals ...interface{}) Logger {
+	if len(keyvals) == 0 {
+		return l
+	}
+	if len(keyvals)%2 != 0 {
+		keyvals = append(keyvals, "<MISSING VALUE>")
+	}
+	kvs := make([][2]string, len(l.kvs), len(l.kvs)+len(keyvals)/2)
+	copy(kvs, l.kvs)
+	for i := 0; i < len(keyvals); i += 2 {
+		k := keyvals[i].(string)
+		switch v := keyvals[i+1].(type) {
+		case string:
+			kvs = append(kvs, [2]string{k, v})
+		case []byte:
+			kvs = append(kvs, [2]string{k, fmt.Sprintf("%x", v)})
+		case fmt.Stringer:
+			kvs = append(kvs, [2]string{k, v.String()})
+		case fmt.GoStringer:
+			kvs = append(kvs, [2]string{k, v.GoString()})
+		case interface {
+			Error() string
+		}:
+			kvs = append(kvs, [2]string{k, v.Error()})
+		default:
+			kvs = append(kvs, [2]string{k, fmt.Sprintf("%#v", v)})
+		}
+	}
+	return &logfmt{kvs: kvs, out: l.out, mu: l.mu}
+}
+
+// Use a logfmt logger by default.
+var logger Logger = &logfmt{out: os.Stderr}
+
+// Logger is a minimal interface for a structured logger.
 type Logger interface {
-	Fatal(args ...interface{})
-	Fatalf(format string, args ...interface{})
-	Fatalln(args ...interface{})
-	Print(args ...interface{})
-	Printf(format string, args ...interface{})
-	Println(args ...interface{})
+	Err(err error) Logger
+	With(keyvals ...interface{}) Logger
+	Fatal(msg string)
+	Print(msg string)
 }
 
 // SetLogger sets the logger that is used in grpc.
@@ -59,32 +123,23 @@ func SetLogger(l Logger) {
 	logger = l
 }
 
+// Err is the equivalent of With("err", err).
+func Err(err error) Logger {
+	return logger.Err(err)
+}
+
+// With appends a set of key-values to a logger. The key-values will
+// be logged everytime the subsequent logger emits a message.
+func With(keyvals ...interface{}) Logger {
+	return logger.With(keyvals...)
+}
+
 // Fatal is equivalent to Print() followed by a call to os.Exit() with a non-zero exit code.
-func Fatal(args ...interface{}) {
-	logger.Fatal(args...)
+func Fatal(msg string) {
+	logger.Fatal(msg)
 }
 
-// Fatalf is equivalent to Printf() followed by a call to os.Exit() with a non-zero exit code.
-func Fatalf(format string, args ...interface{}) {
-	logger.Fatalf(format, args...)
-}
-
-// Fatalln is equivalent to Println() followed by a call to os.Exit()) with a non-zero exit code.
-func Fatalln(args ...interface{}) {
-	logger.Fatalln(args...)
-}
-
-// Print prints to the logger. Arguments are handled in the manner of fmt.Print.
-func Print(args ...interface{}) {
-	logger.Print(args...)
-}
-
-// Printf prints to the logger. Arguments are handled in the manner of fmt.Printf.
-func Printf(format string, args ...interface{}) {
-	logger.Printf(format, args...)
-}
-
-// Println prints to the logger. Arguments are handled in the manner of fmt.Println.
-func Println(args ...interface{}) {
-	logger.Println(args...)
+// Print prints to the logger.
+func Print(msg string) {
+	logger.Print(msg)
 }

--- a/grpclog/logger_test.go
+++ b/grpclog/logger_test.go
@@ -1,0 +1,121 @@
+/*
+ *
+ * Copyright 2015, Google Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+package grpclog
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func testLogger(t testing.TB, testCase func(l Logger), wantContains ...string) {
+	buf := new(bytes.Buffer)
+	testCase(&logfmt{out: buf})
+	got := buf.String()
+	for _, want := range wantContains {
+		if !strings.Contains(got, "time") {
+			t.Fatalf("no time set in %q", got)
+		}
+		if !strings.Contains(got, want) {
+			t.Errorf("want=%q", want)
+			t.Errorf("got =%q", got)
+			t.Fatal("want string to contains")
+		}
+	}
+}
+
+func TestPlainLog(t *testing.T) {
+	testLogger(t, func(l Logger) {
+		l.Print("hello world")
+	}, `"msg"="hello world"`+"\n")
+}
+
+func TestSuperfluousNewline(t *testing.T) {
+	testLogger(t, func(l Logger) {
+		l.Print("hello world\n")
+	}, `"msg"="hello world"`+"\n")
+}
+
+func TestNewLinesLog(t *testing.T) {
+	testLogger(t, func(l Logger) {
+		l.Print("hello world")
+		l.Print("bonjour le monde")
+	},
+		`"msg"="hello world"`+"\n",
+		`"msg"="bonjour le monde"`+"\n",
+	)
+}
+
+func TestManyLinesLog(t *testing.T) {
+	testLogger(t, func(l Logger) {
+		l.Print("hello world")
+		l.Print("bonjour le monde")
+	},
+		`"lvl"="info" "msg"="hello world"`+"\n",
+		`"lvl"="info" "msg"="bonjour le monde"`+"\n",
+	)
+}
+
+func TestLinesLogWithFields(t *testing.T) {
+	testLogger(t, func(l Logger) {
+		l.Print("hello world")
+		annotated := l.With("herp", "derp")
+		annotated.Print("bonjour le monde")
+		annotated.Print("foobar")
+		l.Print("foobaz")
+	},
+		`"lvl"="info" "msg"="hello world"`+"\n",
+		`"lvl"="info" "msg"="bonjour le monde" "herp"="derp"`+"\n",
+		`"lvl"="info" "msg"="foobar" "herp"="derp"`+"\n",
+		`"lvl"="info" "msg"="foobaz"`+"\n",
+	)
+}
+
+func TestLinesLogWithNestedFields(t *testing.T) {
+	testLogger(t, func(l Logger) {
+		l.Print("hello world")
+		annotated := l.With("herp", "derp")
+		annotated.Print("bonjour le monde")
+		superannotated := annotated.With("derp?", "herp!")
+		annotated.Print("foobar")
+		superannotated.Print("ho lala!")
+		l.Print("foobaz")
+	},
+		`"lvl"="info" "msg"="hello world"`+"\n",
+		`"lvl"="info" "msg"="bonjour le monde" "herp"="derp"`+"\n",
+		`"lvl"="info" "msg"="foobar" "herp"="derp"`+"\n",
+		`"lvl"="info" "msg"="ho lala!" "herp"="derp" "derp?"="herp!"`+"\n",
+		`"lvl"="info" "msg"="foobaz"`+"\n",
+	)
+}

--- a/interop/server/server.go
+++ b/interop/server/server.go
@@ -193,13 +193,13 @@ func main() {
 	p := strconv.Itoa(*port)
 	lis, err := net.Listen("tcp", ":"+p)
 	if err != nil {
-		grpclog.Fatalf("failed to listen: %v", err)
+		grpclog.Err(err).Fatal("Failed to listen")
 	}
 	var opts []grpc.ServerOption
 	if *useTLS {
 		creds, err := credentials.NewServerTLSFromFile(*certFile, *keyFile)
 		if err != nil {
-			grpclog.Fatalf("Failed to generate credentials %v", err)
+			grpclog.Err(err).Fatal("Failed to generate credentials")
 		}
 		opts = []grpc.ServerOption{grpc.Creds(creds)}
 	}

--- a/transport/http2_server.go
+++ b/transport/http2_server.go
@@ -57,6 +57,8 @@ var ErrIllegalHeaderWrite = errors.New("transport: the stream is done or WriteHe
 
 // http2Server implements the ServerTransport interface with HTTP2.
 type http2Server struct {
+	log grpclog.Logger
+
 	conn        net.Conn
 	maxStreamID uint32               // max stream ID ever seen
 	authInfo    credentials.AuthInfo // auth info about the connection
@@ -115,6 +117,7 @@ func newHTTP2Server(conn net.Conn, maxStreams uint32, authInfo credentials.AuthI
 	}
 	var buf bytes.Buffer
 	t := &http2Server{
+		log:             grpclog.With("src", "transport"),
 		conn:            conn,
 		authInfo:        authInfo,
 		framer:          framer,
@@ -150,7 +153,7 @@ func (t *http2Server) operateHeaders(hDec *hpackDecoder, s *Stream, frame header
 		return nil
 	}
 	if err != nil {
-		grpclog.Printf("transport: http2Server.operateHeader found %v", err)
+		t.log.Err(err).Print("http2Server.operateHeader found")
 		if se, ok := err.(StreamError); ok {
 			t.controlBuf.put(&resetStream{s.id, statusCodeConvTab[se.Code]})
 		}
@@ -217,25 +220,25 @@ func (t *http2Server) HandleStreams(handle func(*Stream)) {
 	// Check the validity of client preface.
 	preface := make([]byte, len(clientPreface))
 	if _, err := io.ReadFull(t.conn, preface); err != nil {
-		grpclog.Printf("transport: http2Server.HandleStreams failed to receive the preface from client: %v", err)
+		t.log.Err(err).Print("http2Server.HandleStreams failed to receive the preface from client")
 		t.Close()
 		return
 	}
 	if !bytes.Equal(preface, clientPreface) {
-		grpclog.Printf("transport: http2Server.HandleStreams received bogus greeting from client: %q", preface)
+		t.log.With("preface", preface).Print("http2Server.HandleStreams received bogus greeting from client")
 		t.Close()
 		return
 	}
 
 	frame, err := t.framer.readFrame()
 	if err != nil {
-		grpclog.Printf("transport: http2Server.HandleStreams failed to read frame: %v", err)
+		t.log.Err(err).Print("http2Server.HandleStreams failed to read frame")
 		t.Close()
 		return
 	}
 	sf, ok := frame.(*http2.SettingsFrame)
 	if !ok {
-		grpclog.Printf("transport: http2Server.HandleStreams saw invalid preface type %T from client", frame)
+		t.log.With("frame", frame).Print("http2Server.HandleStreams saw invalid preface type from client")
 		t.Close()
 		return
 	}
@@ -256,7 +259,7 @@ func (t *http2Server) HandleStreams(handle func(*Stream)) {
 			id := frame.Header().StreamID
 			if id%2 != 1 || id <= t.maxStreamID {
 				// illegal gRPC stream id.
-				grpclog.Println("transport: http2Server.HandleStreams received an illegal stream id: ", id)
+				t.log.With("id", id).Print("http2Server.HandleStreams received an illegal stream id")
 				t.Close()
 				break
 			}
@@ -289,7 +292,7 @@ func (t *http2Server) HandleStreams(handle func(*Stream)) {
 		case *http2.GoAwayFrame:
 			break
 		default:
-			grpclog.Printf("transport: http2Server.HandleStreams found unhandled frame type %v.", frame)
+			t.log.With("frame", frame).Print("http2Server.HandleStreams found unhandled frame type")
 		}
 	}
 }
@@ -332,7 +335,7 @@ func (t *http2Server) handleData(f *http2.DataFrame) {
 	if size > 0 {
 		if err := s.fc.onData(uint32(size)); err != nil {
 			if _, ok := err.(ConnectionError); ok {
-				grpclog.Printf("transport: http2Server %v", err)
+				t.log.Err(err).Print("http2Server connection error")
 				t.Close()
 				return
 			}
@@ -632,7 +635,7 @@ func (t *http2Server) controller() {
 					// meaningful content when this is actually in use.
 					t.framer.writePing(true, i.ack, [8]byte{})
 				default:
-					grpclog.Printf("transport: http2Server.controller got unexpected item type %v\n", i)
+					t.log.With("item_type", i).Print("http2Server.controller got unexpected item type")
 				}
 				t.writableChan <- 0
 				continue

--- a/transport/http_util.go
+++ b/transport/http_util.go
@@ -175,7 +175,7 @@ func newHPACKDecoder() *hpackDecoder {
 				}
 				k, v, err := metadata.DecodeKeyValue(f.Name, f.Value)
 				if err != nil {
-					grpclog.Printf("Failed to decode (%q, %q): %v", f.Name, f.Value, err)
+					grpclog.Err(err).With("name", f.Name, "value", f.Value).Print("failed to decode")
 					return
 				}
 				d.state.mdata[k] = append(d.state.mdata[k], v)

--- a/transport/transport_test.go
+++ b/transport/transport_test.go
@@ -91,7 +91,7 @@ func (h *testStreamHandler) handleStream(s *Stream) {
 		if err == ErrConnClosing {
 			return
 		}
-		grpclog.Fatalf("handleStream got error: %v, want <nil>; result: %v, want %v", err, p, req)
+		grpclog.Err(err).With("result", p, "want", req).Fatal("handleStream got error")
 	}
 	// send a response back to the client.
 	h.t.Write(s, resp, &Options{})
@@ -107,7 +107,7 @@ func (h *testStreamHandler) handleStreamSuspension(s *Stream) {
 func (h *testStreamHandler) handleStreamMisbehave(s *Stream) {
 	conn, ok := s.ServerTransport().(*http2Server)
 	if !ok {
-		grpclog.Fatalf("Failed to convert %v to *http2Server", s.ServerTransport())
+		grpclog.With("srv_transport", s.ServerTransport()).Fatal("Failed to convert to *http2Server")
 	}
 	size := 1
 	if s.Method() == "foo.MaxFrame" {
@@ -135,11 +135,11 @@ func (s *server) start(port int, maxStreams uint32, ht hType) {
 		s.lis, err = net.Listen("tcp", ":"+strconv.Itoa(port))
 	}
 	if err != nil {
-		grpclog.Fatalf("failed to listen: %v", err)
+		grpclog.Err(err).Fatal("failed to listen")
 	}
 	_, p, err := net.SplitHostPort(s.lis.Addr().String())
 	if err != nil {
-		grpclog.Fatalf("failed to parse listener address: %v", err)
+		grpclog.Err(err).Fatal("failed to parse listener address")
 	}
 	s.port = p
 	s.conns = make(map[ServerTransport]bool)


### PR DESCRIPTION
I took a stab at changing all the log sites to use structured logging, with a pluggable interface. I didn't want to pull existing implementations (like [logrus][] or [go-kit/log]) to avoid adding dependencies. There are many places, like in tests, where `grpclog` was used and I think a better use would be to pass around a `testing.TB` handle, but I didn't do that change to avoid mixing concerns in 1 PR.

Relates to #289.

I signed the CLA.

[logrus]:https://github.com/Sirupsen/logrus
[go-kit/log]:https://github.com/go-kit/kit/tree/master/log