### PR TITLE
Fixed README.md

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -20,8 +20,8 @@ INSTALL
 -------
 
 ```sh
-$ go get -u github.com/grpc/grpc-go/examples/greeter_client
-$ go get -u github.com/grpc/grpc-go/examples/greeter_server
+$ go get -u github.com/grpc/grpc-go/examples/helloworld/greeter_client
+$ go get -u github.com/grpc/grpc-go/examples/helloworld/greeter_server
 ```
 
 TRY IT!


### PR DESCRIPTION
Fixed the install instructions for the examples as it was left unchanged after a folder restructuring, making installing not work.