### PR TITLE
Proposal: gprc.intercept.intercept ServiceOption/MethodOption

### DIFF
--- a/examples/intercept/example/example.proto
+++ b/examples/intercept/example/example.proto
@@ -1,0 +1,27 @@
+syntax = "proto3";
+
+import "examples/intercept/intercept.proto";
+
+package example;
+
+message Foo {
+  uint64 one = 1;
+  string two = 2;
+}
+
+message Bar {
+  uint64 one = 1;
+  string two = 2;
+}
+
+service Api {
+  option (grpc.intercept.intercept) = grpc.intercept.INTERCEPT_TYPE_UNARY;
+  // this method will be intercepted since INTERCEPT_TYPE_UNARY is set on the service.
+  rpc One(Foo) returns (Bar) {}
+  // this method will not be intercepted since no_intercept is set.
+  rpc Two(Foo) returns (Bar) { option (grpc.intercept.no_intercept) = true; }
+  // this method will not be intercepted since only INTERCEPT_TYPE_UNARY is set.
+  rpc Three(stream One) returns (Bar) {}
+  // this method will be intercepted since intercept is set.
+  rpc Four(One) returns (stream Bar) { option (grpc.intercept.intercept) = true; }
+}

--- a/examples/intercept/intercept.proto
+++ b/examples/intercept/intercept.proto
@@ -1,0 +1,33 @@
+syntax = "proto3";
+
+import "google/protobuf/descriptor.proto";
+
+package grpc.intercept;
+
+// InterceptType denotes which methods to intercept on a service.
+enum InterceptType {
+  // Placeholder for null.
+  INTERCEPT_TYPE_NONE = 0;
+  // Only intercept unary methods.
+  INTERCEPT_TYPE_UNARY = 1;
+  // Only intercept streaming methods.
+  INTERCEPT_TYPE_STREAMING = 2;
+  // Intercept all methods.
+  INTERCEPT_TYPE_ALL = 3;
+}
+
+extend google.protobuf.ServiceOptions {
+  // intercept denotes to intercept all methods of the given type.
+  InterceptType intercept = 78901234;
+}
+
+extend google.protobuf.MethodOptions {
+  // intercept denotes to intercept this specific method.
+  // This is redundant if the intercept field on ServiceOptions
+  // is already set to intercept this method.
+  bool intercept = 78901235;
+  // no_intercept denotes to not intercept this specific method.
+  // This is only relevant if the intercept field on ServiceOptions
+  // is set to otherwise intercept this method.
+  bool no_intercept = 78901236;
+}

--- a/server.go
+++ b/server.go
@@ -41,6 +41,9 @@ import (
 	"reflect"
 	"strings"
 	"sync"
+	"time"
+
+	"github.com/golang/protobuf/proto"
 
 	"golang.org/x/net/context"
 	"golang.org/x/net/trace"
@@ -53,10 +56,21 @@ import (
 
 type methodHandler func(srv interface{}, ctx context.Context, codec Codec, buf []byte) (interface{}, error)
 
+// Interceptor intercepts RPC method calls.
+type Interceptor interface {
+	Intercept(
+		methodName string,
+		request proto.Message,
+		response proto.Message,
+		duration time.Duration,
+	) error
+}
+
 // MethodDesc represents an RPC service's method specification.
 type MethodDesc struct {
 	MethodName string
 	Handler    methodHandler
+	Intercept  bool
 }
 
 // ServiceDesc represents an RPC service's specification.
@@ -90,6 +104,7 @@ type options struct {
 	creds                credentials.Credentials
 	codec                Codec
 	maxConcurrentStreams uint32
+	interceptors         []Interceptor
 }
 
 // A ServerOption sets options.
@@ -117,10 +132,18 @@ func Creds(c credentials.Credentials) ServerOption {
 	}
 }
 
+// WithInterceptor returns a ServerOptions that adds the given interceptor.
+func WithInterceptor(i Interceptor) ServerOption {
+	return func(o *options) {
+		o.interceptors = append(o.interceptors, i)
+	}
+}
+
 // NewServer creates a gRPC server which has no service registered and has not
 // started to accept requests yet.
 func NewServer(opt ...ServerOption) *Server {
 	var opts options
+	opts.interceptors = make([]Interceptor, 0)
 	for _, o := range opt {
 		o(&opts)
 	}

--- a/server.go
+++ b/server.go
@@ -43,8 +43,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/golang/protobuf/proto"
-
 	"golang.org/x/net/context"
 	"golang.org/x/net/trace"
 	"google.golang.org/grpc/codes"
@@ -60,11 +58,11 @@ type methodHandler func(srv interface{}, ctx context.Context, codec Codec, buf [
 type Interceptor interface {
 	Intercept(
 		methodName string,
-		request proto.Message,
-		response proto.Message,
+		request interface{},
+		response interface{},
 		err error,
 		duration time.Duration,
-	) error
+	)
 }
 
 // MethodDesc represents an RPC service's method specification.

--- a/server.go
+++ b/server.go
@@ -62,6 +62,7 @@ type Interceptor interface {
 		methodName string,
 		request proto.Message,
 		response proto.Message,
+		err error,
 		duration time.Duration,
 	) error
 }

--- a/stream.go
+++ b/stream.go
@@ -56,6 +56,7 @@ type StreamDesc struct {
 	// At least one of these is true.
 	ServerStreams bool
 	ClientStreams bool
+	Intercept     bool
 }
 
 // Stream defines the common interface a client or server stream has to satisfy.


### PR DESCRIPTION
This is a proposal, not actual mergeable code.

A lot of the time, I find myself wishing I could have method interceptors server-side for every RPC call I make. gRPC has a lot of concentration on round-trip time, which is good, but a lot of applications might want to do things (like custom logging/metrics) for each method, in ways that would not be appropriate to merge into the main stream. In Java/Guice world, this would not be as tough, as you could bind a method interceptor at runtime using annotations, but golang doesn't really have an equivalent. This is a proposal to add a google.protobuf.ServiceOption, and two google.protobuf.MethodOptions, that denote whether methods can be intercepted, along with a golang Interface to represent an interceptor.

Below is the general concept, including the actual proposed options and an example. Instead of the intercept package, this could just be the grpc package, so there's no redundancy in the package and option names. What would happen is the protoc-gen-go compiler would need some changing, so (taking an example from https://github.com/pachyderm/pachyderm/blob/c25d2ccec5a0ed7f396b61d1bec62e835db1fbf6/src/pfs/pfs.pb.go#L840), this would go from:

```go
func _Api_RepoCreate_Handler(srv interface{}, ctx context.Context, codec grpc.Codec, buf []byte) (interface{}, error) {
	in := new(RepoCreateRequest)
	if err := codec.Unmarshal(buf, in); err != nil {
		return nil, err
	}
	out, err := srv.(ApiServer).RepoCreate(ctx, in)
	if err != nil {
		return nil, err
	}
	return out, nil
}
```

to:

```go
func _Api_RepoCreate_Handler(srv interface{}, ctx context.Context, codec grpc.Codec, buf []byte, interceptors ...grpc.Interceptor) (out interface{}, err error) {
	var in *RepoCreateRequest
	if len(interceptors) != 0 {
		start := time.Now()
		defer func() {
			for _, interceptor := range interceptors {
				interceptor.Intercept("pfs.RepoCreate", in, out, err, time.Since(start))
			}
		}()
	}
	in = new(RepoCreateRequest)
	if err = codec.Unmarshal(buf, in); err != nil {
		return nil, err
	}
	out, err = srv.(ApiServer).RepoCreate(ctx, in)
	if err != nil {
		return nil, err
	}
	return out, nil
}
```

There are other ways to do this. You don't need to use protocol buffer ServiceOptions/MethodOptions, and have all the logic in the golang code. I played that fork for a while though and this ended up making more sense.

Any thoughts?