### PR TITLE
Updated the path on the last command

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -53,5 +53,5 @@ OPTIONAL - Rebuilding the generated code
 $ go get -a github.com/golang/protobuf/protoc-gen-go
 $
 $ # from this dir; invoke protoc
-$ protoc -I ./helloworld/proto/ ./helloworld/proto/helloworld.proto --go_out=plugins=grpc:helloworld
+$  protoc -I ./helloworld/helloworld/ ./helloworld/helloworld/helloworld.proto --go_out=plugins=grpc:helloworld
 ```


### PR DESCRIPTION
The last command seems to reflect the path used on the first public commit (which the helloworld.proto file was under  examples/helloworld/proto directory and then it was moved to examples/helloworld/helloworld/helloworld.proto)