### PR TITLE
grpc: make trace.FromContext work, and record handler status in traces

### DIFF
--- a/server.go
+++ b/server.go
@@ -319,7 +319,9 @@ func (s *Server) processUnaryRPC(t transport.ServerTransport, stream *transport.
 			return err
 		}
 		if traceInfo.tr != nil {
-			traceInfo.tr.LazyLog(&payload{sent: false, msg: req}, true)
+			// TODO: set payload.msg to something that
+			// prints usefully with %s; req is a []byte.
+			traceInfo.tr.LazyLog(&payload{sent: false}, true)
 		}
 		switch pf {
 		case compressionNone:

--- a/stream.go
+++ b/stream.go
@@ -279,13 +279,13 @@ type ServerStream interface {
 type serverStream struct {
 	t          transport.ServerTransport
 	s          *transport.Stream
+	ctx        context.Context // provides trace.FromContext when tracing
 	p          *parser
 	codec      Codec
 	statusCode codes.Code
 	statusDesc string
 
-	tracing bool            // set to EnableTracing when the serverStream is created.
-	ctx     context.Context // provides trace.FromContext when tracing
+	tracing bool // set to EnableTracing when the serverStream is created.
 
 	mu sync.Mutex // protects traceInfo
 	// traceInfo.tr is set when the serverStream is created (if EnableTracing is true),

--- a/trace.go
+++ b/trace.go
@@ -114,3 +114,7 @@ type fmtStringer struct {
 func (f *fmtStringer) String() string {
 	return fmt.Sprintf(f.format, f.a...)
 }
+
+type stringer string
+
+func (s stringer) String() string { return string(s) }


### PR DESCRIPTION
Record the description of the status returned by server RPC
handlers in request traces, and mark the trace as an error if the
status is not OK.

Install the trace into the Context passed to server handlers using
trace.NewContext, so that code in the server handlers can annotate the
trace using trace.FromContext.