### PR TITLE
Switch from github.com/bradfitz/http2 to golang.org/x/net/http2.

### DIFF
--- a/transport/control.go
+++ b/transport/control.go
@@ -37,7 +37,7 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/bradfitz/http2"
+	"golang.org/x/net/http2"
 )
 
 const (

--- a/transport/http2_client.go
+++ b/transport/http2_client.go
@@ -43,9 +43,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/bradfitz/http2"
-	"github.com/bradfitz/http2/hpack"
 	"golang.org/x/net/context"
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/hpack"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/grpclog"

--- a/transport/http2_server.go
+++ b/transport/http2_server.go
@@ -42,9 +42,9 @@ import (
 	"strconv"
 	"sync"
 
-	"github.com/bradfitz/http2"
-	"github.com/bradfitz/http2/hpack"
 	"golang.org/x/net/context"
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/hpack"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/grpclog"

--- a/transport/http_util.go
+++ b/transport/http_util.go
@@ -43,8 +43,8 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/bradfitz/http2"
-	"github.com/bradfitz/http2/hpack"
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/hpack"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/grpclog"
 	"google.golang.org/grpc/metadata"
@@ -143,10 +143,10 @@ func newHPACKDecoder() *hpackDecoder {
 		case "content-type":
 			// TODO(zhaoq): Tentatively disable the check until a bug is fixed.
 			/*
-			if !strings.Contains(f.Value, "application/grpc") {
-				d.err = StreamErrorf(codes.FailedPrecondition, "transport: received the unexpected header")
-				return
-			}
+				if !strings.Contains(f.Value, "application/grpc") {
+					d.err = StreamErrorf(codes.FailedPrecondition, "transport: received the unexpected header")
+					return
+				}
 			*/
 		case "grpc-status":
 			code, err := strconv.Atoi(f.Value)

--- a/transport/transport_test.go
+++ b/transport/transport_test.go
@@ -44,8 +44,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/bradfitz/http2"
 	"golang.org/x/net/context"
+	"golang.org/x/net/http2"
 	"google.golang.org/grpc/codes"
 )
 


### PR DESCRIPTION
The latter is now the official HTTP2 package for Go.

@bradfitz