### PR TITLE
fix difference between unitary and stream codec error handling

### DIFF
--- a/rpc_util.go
+++ b/rpc_util.go
@@ -187,8 +187,11 @@ func recv(p *parser, c Codec, m interface{}) error {
 	switch pf {
 	case compressionNone:
 		if err := c.Unmarshal(d, m); err != nil {
-			return Errorf(codes.Internal, "grpc: %v", err)
-		}
+			if rErr, ok := err.(rpcError); ok {
+				return rErr
+			} else {
+				return Errorf(codes.Internal, "grpc: %v", err)
+			}
 	default:
 		return Errorf(codes.Internal, "gprc: compression is not supported yet.")
 	}


### PR DESCRIPTION
Fixes a discrepancy between how unitary-unitary and streaming RPCs handle `codec.Unmarshal` errors:

https://github.com/grpc/grpc-go/issues/371 