### PR TITLE
Revert "fix difference between unitary and stream codec error handling"

### DIFF
--- a/rpc_util.go
+++ b/rpc_util.go
@@ -187,11 +187,8 @@ func recv(p *parser, c Codec, m interface{}) error {
 	switch pf {
 	case compressionNone:
 		if err := c.Unmarshal(d, m); err != nil {
-			if rErr, ok := err.(rpcError); ok {
-				return rErr
-			} else {
-				return Errorf(codes.Internal, "grpc: %v", err)
-			}
+			return Errorf(codes.Internal, "grpc: %v", err)
+		}
 	default:
 		return Errorf(codes.Internal, "gprc: compression is not supported yet.")
 	}


### PR DESCRIPTION
Reverts grpc/grpc-go#372