### PR TITLE
fix compilation error in recv

### DIFF
--- a/rpc_util.go
+++ b/rpc_util.go
@@ -192,6 +192,7 @@ func recv(p *parser, c Codec, m interface{}) error {
 			} else {
 				return Errorf(codes.Internal, "grpc: %v", err)
 			}
+		}
 	default:
 		return Errorf(codes.Internal, "gprc: compression is not supported yet.")
 	}


### PR DESCRIPTION
https://github.com/grpc/grpc-go/pull/372 introduced a compilation error, this fixes it.