### PR TITLE
Avoid some allocations in recvMsg

### DIFF
--- a/rpc_util.go
+++ b/rpc_util.go
@@ -145,7 +145,7 @@ func (p *parser) recvMsg() (pf payloadFormat, msg []byte, err error) {
 		return 0, nil, err
 	}
 
-	hdr.T = payloadFormat(uint8(buf[0]))
+	hdr.T = payloadFormat(buf[0])
 	hdr.Length = binary.BigEndian.Uint32(buf[1:])
 
 	if hdr.Length == 0 {

--- a/rpc_util.go
+++ b/rpc_util.go
@@ -138,15 +138,18 @@ type msgFixedHeader struct {
 // EOF is returned with nil msg and 0 pf if the entire stream is done. Other
 // non-nil error is returned if something is wrong on reading.
 func (p *parser) recvMsg() (pf payloadFormat, msg []byte, err error) {
+	const headerSize = 5
+	const formatIndex = 1
+
 	var hdr msgFixedHeader
-	var buf [5]byte
+	var buf [headerSize]byte
 
 	if _, err := io.ReadFull(p.s, buf[:]); err != nil {
 		return 0, nil, err
 	}
 
-	hdr.T = payloadFormat(buf[0])
-	hdr.Length = binary.BigEndian.Uint32(buf[1:])
+	hdr.T = payloadFormat(buf[formatIndex])
+	hdr.Length = binary.BigEndian.Uint32(buf[formatIndex:])
 
 	if hdr.Length == 0 {
 		return hdr.T, nil, nil

--- a/rpc_util.go
+++ b/rpc_util.go
@@ -138,8 +138,10 @@ type msgFixedHeader struct {
 // EOF is returned with nil msg and 0 pf if the entire stream is done. Other
 // non-nil error is returned if something is wrong on reading.
 func (p *parser) recvMsg() (pf payloadFormat, msg []byte, err error) {
-	const headerSize = 5
-	const formatIndex = 1
+	const (
+		headerSize  = 5
+		formatIndex = 1
+	)
 
 	var hdr msgFixedHeader
 	var buf [headerSize]byte

--- a/rpc_util.go
+++ b/rpc_util.go
@@ -139,9 +139,15 @@ type msgFixedHeader struct {
 // non-nil error is returned if something is wrong on reading.
 func (p *parser) recvMsg() (pf payloadFormat, msg []byte, err error) {
 	var hdr msgFixedHeader
-	if err := binary.Read(p.s, binary.BigEndian, &hdr); err != nil {
+	var buf [5]byte
+
+	if _, err := io.ReadFull(p.s, buf[:]); err != nil {
 		return 0, nil, err
 	}
+
+	hdr.T = payloadFormat(uint8(buf[0]))
+	hdr.Length = binary.BigEndian.Uint32(buf[1:])
+
 	if hdr.Length == 0 {
 		return hdr.T, nil, nil
 	}


### PR DESCRIPTION
Reading the header by hand avoids some allocations and improves the
performance of recvMsg.

Updated benchmarks:

```
benchmark                              old ns/op     new ns/op     delta
BenchmarkClientStreamc1-8              121497        128525        +5.78%
BenchmarkClientStreamc8-8              20963         20454         -2.43%
BenchmarkClientStreamc64-8             12370         11980         -3.15%
BenchmarkClientStreamc512-8            13542         13152         -2.88%
BenchmarkClientUnaryc1-8               240343        237528        -1.17%
BenchmarkClientUnaryc8-8               46075         44415         -3.60%
BenchmarkClientUnaryc64-8              32634         33386         +2.30%
BenchmarkClientUnaryc512-8             33065         32732         -1.01%
BenchmarkClientStreamNoTracec1-8       115481        93490         -19.04%
BenchmarkClientStreamNoTracec8-8       20309         20031         -1.37%
BenchmarkClientStreamNoTracec64-8      11684         11413         -2.32%
BenchmarkClientStreamNoTracec512-8     12805         12218         -4.58%
BenchmarkClientUnaryNoTracec1-8        226422        221111        -2.35%
BenchmarkClientUnaryNoTracec8-8        41646         41079         -1.36%
BenchmarkClientUnaryNoTracec64-8       29446         28662         -2.66%
BenchmarkClientUnaryNoTracec512-8      29964         29044         -3.07%

benchmark                              old allocs     new allocs     delta
BenchmarkClientStreamc1-8              46             41             -10.87%
BenchmarkClientStreamc8-8              47             41             -12.77%
BenchmarkClientStreamc64-8             46             41             -10.87%
BenchmarkClientStreamc512-8            46             40             -13.04%
BenchmarkClientUnaryc1-8               100            91             -9.00%
BenchmarkClientUnaryc8-8               101            92             -8.91%
BenchmarkClientUnaryc64-8              100            91             -9.00%
BenchmarkClientUnaryc512-8             100            91             -9.00%
BenchmarkClientStreamNoTracec1-8       43             37             -13.95%
BenchmarkClientStreamNoTracec8-8       43             37             -13.95%
BenchmarkClientStreamNoTracec64-8      43             37             -13.95%
BenchmarkClientStreamNoTracec512-8     42             36             -14.29%
BenchmarkClientUnaryNoTracec1-8        87             78             -10.34%
BenchmarkClientUnaryNoTracec8-8        88             78             -11.36%
BenchmarkClientUnaryNoTracec64-8       87             78             -10.34%
BenchmarkClientUnaryNoTracec512-8      87             78             -10.34%

benchmark                              old bytes     new bytes     delta
BenchmarkClientStreamc1-8              2015          1920          -4.71%
BenchmarkClientStreamc8-8              2046          1950          -4.69%
BenchmarkClientStreamc64-8             2044          1948          -4.70%
BenchmarkClientStreamc512-8            2053          1957          -4.68%
BenchmarkClientUnaryc1-8               5983          5838          -2.42%
BenchmarkClientUnaryc8-8               5985          5841          -2.41%
BenchmarkClientUnaryc64-8              6010          5866          -2.40%
BenchmarkClientUnaryc512-8             5949          5809          -2.35%
BenchmarkClientStreamNoTracec1-8       1887          1791          -5.09%
BenchmarkClientStreamNoTracec8-8       1917          1821          -5.01%
BenchmarkClientStreamNoTracec64-8      1928          1832          -4.98%
BenchmarkClientStreamNoTracec512-8     1923          1828          -4.94%
BenchmarkClientUnaryNoTracec1-8        4303          4159          -3.35%
BenchmarkClientUnaryNoTracec8-8        4304          4160          -3.35%
BenchmarkClientUnaryNoTracec64-8       4330          4186          -3.33%
BenchmarkClientUnaryNoTracec512-8      4280          4139          -3.29%
```