### PR TITLE
Remove an allocation when encoding messages

### DIFF
--- a/rpc_util.go
+++ b/rpc_util.go
@@ -183,7 +183,7 @@ func encode(c Codec, msg interface{}, pf payloadFormat) ([]byte, error) {
 
 	// Write payload format
 	buf[0] = byte(pf)
-	// Write length of msg into buf
+	// Write length of b into buf
 	binary.BigEndian.PutUint32(buf[1:], length)
 	// Copy encoded msg to buf
 	copy(buf[5:], b)

--- a/rpc_util.go
+++ b/rpc_util.go
@@ -160,7 +160,7 @@ func (p *parser) recvMsg() (pf payloadFormat, msg []byte, err error) {
 // generates the message header of 0 message length.
 func encode(c Codec, msg interface{}, pf payloadFormat) ([]byte, error) {
 	var b []byte
-	var length uint32
+	var length uint
 	if msg != nil {
 		var err error
 		// TODO(zhaoq): optimize to reduce memory alloc and copying.
@@ -168,7 +168,7 @@ func encode(c Codec, msg interface{}, pf payloadFormat) ([]byte, error) {
 		if err != nil {
 			return nil, err
 		}
-		length = uint32(len(b))
+		length = uint(len(b))
 	}
 	if length > math.MaxUint32 {
 		return nil, Errorf(codes.InvalidArgument, "grpc: message too large (%d bytes)", length)
@@ -184,7 +184,7 @@ func encode(c Codec, msg interface{}, pf payloadFormat) ([]byte, error) {
 	// Write payload format
 	buf[0] = byte(pf)
 	// Write length of b into buf
-	binary.BigEndian.PutUint32(buf[1:], length)
+	binary.BigEndian.PutUint32(buf[1:], uint32(length))
 	// Copy encoded msg to buf
 	copy(buf[5:], b)
 


### PR DESCRIPTION
The old code for encode used a bytes.Buffer, causing an unnecessary allocation. The new code allocates a raw []byte with the proper length and writes directly into it.

```
benchmark                   old ns/op     new ns/op     delta
BenchmarkEncode1B-8         1119          1060          -5.27%
BenchmarkEncode1KiB-8       3455          2104          -39.10%
BenchmarkEncode8KiB-8       10986         10266         -6.55%
BenchmarkEncode64KiB-8      83889         76763         -8.49%
BenchmarkEncode512KiB-8     719323        656051        -8.80%
BenchmarkEncode1MiB-8       1499583       1466814       -2.19%

benchmark                   old MB/s     new MB/s     speedup
BenchmarkEncode1B-8         7.15         7.54         1.05x
BenchmarkEncode1KiB-8       298.63       490.41       1.64x
BenchmarkEncode8KiB-8       746.34       798.70       1.07x
BenchmarkEncode64KiB-8      781.32       853.86       1.09x
BenchmarkEncode512KiB-8     728.88       799.17       1.10x
BenchmarkEncode1MiB-8       699.25       714.87       1.02x

benchmark                   old allocs     new allocs     delta
BenchmarkEncode1B-8         3              3              +0.00%
BenchmarkEncode1KiB-8       5              4              -20.00%
BenchmarkEncode8KiB-8       5              4              -20.00%
BenchmarkEncode64KiB-8      5              4              -20.00%
BenchmarkEncode512KiB-8     5              4              -20.00%
BenchmarkEncode1MiB-8       6              5              -16.67%

benchmark                   old bytes     new bytes     delta
BenchmarkEncode1B-8         336           240           -28.57%
BenchmarkEncode1KiB-8       2768          2528          -8.67%
BenchmarkEncode8KiB-8       17232         17120         -0.65%
BenchmarkEncode64KiB-8      147797        147684        -0.08%
BenchmarkEncode512KiB-8     1065336       1065217       -0.01%
BenchmarkEncode1MiB-8       2113965       2113848       -0.01%
```