### PR TITLE
cleanup references to `Picker` through `dopts`

### DIFF
--- a/call.go
+++ b/call.go
@@ -153,7 +153,7 @@ func Invoke(ctx context.Context, method string, args, reply interface{}, cc *Cli
 			Host:   cc.authority,
 			Method: method,
 		}
-		t, err = cc.dopts.picker.Pick(ctx)
+		t, err = cc.Picker().Pick(ctx)
 		if err != nil {
 			if lastErr != nil {
 				// This was a retry; return the error from the last attempt.

--- a/clientconn.go
+++ b/clientconn.go
@@ -210,19 +210,24 @@ type ClientConn struct {
 // State returns the connectivity state of cc.
 // This is EXPERIMENTAL API.
 func (cc *ClientConn) State() ConnectivityState {
-	return cc.dopts.picker.State()
+	return cc.Picker().State()
 }
 
 // WaitForStateChange blocks until the state changes to something other than the sourceState
 // or timeout fires on cc. It returns false if timeout fires, and true otherwise.
 // This is EXPERIMENTAL API.
 func (cc *ClientConn) WaitForStateChange(timeout time.Duration, sourceState ConnectivityState) bool {
-	return cc.dopts.picker.WaitForStateChange(timeout, sourceState)
+	return cc.Picker().WaitForStateChange(timeout, sourceState)
 }
 
 // Close starts to tear down the ClientConn.
 func (cc *ClientConn) Close() error {
-	return cc.dopts.picker.Close()
+	return cc.Picker().Close()
+}
+
+// Picker returns the picker of the connection.
+func (cc *ClientConn) Picker() Picker {
+	return cc.dopts.picker
 }
 
 // Conn is a client connection to a single destination.

--- a/stream.go
+++ b/stream.go
@@ -100,7 +100,7 @@ func NewClientStream(ctx context.Context, desc *StreamDesc, cc *ClientConn, meth
 		t   transport.ClientTransport
 		err error
 	)
-	t, err = cc.dopts.picker.Pick(ctx)
+	t, err = cc.Picker().Pick(ctx)
 	if err != nil {
 		return nil, toRPCErr(err)
 	}


### PR DESCRIPTION
While working on a Reverse Proxy for gRPC (https://github.com/mwitkow-io/grpc-proxy) I stumbled with the problem of getting a new `ClientTransport` and a new `ClientStream` in raw form.
That's because the Reverse Proxy skips framing and only operates on metadata of the call.

One of the ways to do it was to expose the `Picker` as an interface of `ClientConn`, which this CL is.
Alternatively, a `NewTransport` method could be added to `ClientConn` that hides the Picker completely.