### PR TITLE
removed automatic push to coveralls fixes grpc/grpc-go#436

### DIFF
--- a/coverage.sh
+++ b/coverage.sh
@@ -29,7 +29,6 @@ push_to_coveralls() {
 
 generate_cover_data $(go list ./...)
 show_cover_report func
-push_to_coveralls
 case "$1" in
 "")
     ;;


### PR DESCRIPTION
Push to coveralls should only happen if option ```--coveralls``` is set.