### PR TITLE
Expose peer address to RPC handler

### DIFF
--- a/transport/http2_client.go
+++ b/transport/http2_client.go
@@ -242,6 +242,9 @@ func (t *http2Client) NewStream(ctx context.Context, callHdr *CallHdr) (_ *Strea
 	if t.authInfo != nil {
 		ctx = credentials.NewContext(ctx, t.authInfo)
 	}
+
+	ctx = newContextWithPeer(ctx, t.makePeer())
+
 	authData := make(map[string]string)
 	for _, c := range t.authCreds {
 		// Construct URI required to get auth request metadata.
@@ -857,4 +860,8 @@ func (t *http2Client) notifyError(err error) {
 		close(t.errorChan)
 		grpclog.Printf("transport: http2Client.notifyError got notified that the client transport was broken %v.", err)
 	}
+}
+
+func (t *http2Client) makePeer() Peer {
+	return Peer{Addr: t.conn.RemoteAddr()}
 }

--- a/transport/http2_server.go
+++ b/transport/http2_server.go
@@ -168,6 +168,9 @@ func (t *http2Server) operateHeaders(hDec *hpackDecoder, s *Stream, frame header
 	} else {
 		s.ctx, s.cancel = context.WithCancel(context.TODO())
 	}
+
+	s.ctx = newContextWithPeer(s.ctx, t.makePeer())
+
 	// Attach Auth info if there is any.
 	if t.authInfo != nil {
 		s.ctx = credentials.NewContext(s.ctx, t.authInfo)
@@ -691,4 +694,8 @@ func (t *http2Server) closeStream(s *Stream) {
 
 func (t *http2Server) RemoteAddr() net.Addr {
 	return t.conn.RemoteAddr()
+}
+
+func (t *http2Server) makePeer() Peer {
+	return Peer{Addr: t.RemoteAddr()}
 }

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -303,6 +303,24 @@ func StreamFromContext(ctx context.Context) (s *Stream, ok bool) {
 	return
 }
 
+// Peer connection info
+type Peer struct {
+	Addr net.Addr
+}
+
+type peerCtxKey struct{}
+
+// Save peer info in a new context and return it
+func newContextWithPeer(ctx context.Context, peer Peer) context.Context {
+	return context.WithValue(ctx, peerCtxKey{}, peer)
+}
+
+// PeerFromContext retrieves the peer information from ctx
+func PeerFromContext(ctx context.Context) (peer Peer, ok bool) {
+	peer, ok = ctx.Value(peerCtxKey{}).(Peer)
+	return
+}
+
 // state of transport
 type transportState int
 

--- a/transport/transport_test.go
+++ b/transport/transport_test.go
@@ -657,3 +657,12 @@ func TestStreamContext(t *testing.T) {
 		t.Fatalf("GetStreamFromContext(%v) = %v, %t, want: %v, true", ctx, *s, ok, expectedStream)
 	}
 }
+
+func TestPeerContext(t *testing.T) {
+	expected := Peer{}
+	ctx := newContextWithPeer(context.Background(), expected)
+	p, ok := PeerFromContext(ctx)
+	if !ok || !reflect.DeepEqual(expected, p) {
+		t.Fatalf("PeerFromContext(%v) = %v, %t, want: %v, true", ctx, p, ok, expected)
+	}
+}


### PR DESCRIPTION
Quick-fix solution to expose peer address.  Addresses #334

Note: it might be a better to use the socket peer addr only if there is no `forwarded` or `x-forwarded-for` header captured in metadata, but it's not clear to me what the semantics should be.