### PR TITLE
Expose peer info on server side

### DIFF
--- a/credentials/credentials.go
+++ b/credentials/credentials.go
@@ -87,20 +87,6 @@ type AuthInfo interface {
 	AuthType() string
 }
 
-/*
-type authInfoKey struct{}
-
-// NewContext creates a new context with authInfo attached.
-func NewContext(ctx context.Context, authInfo AuthInfo) context.Context {
-	return context.WithValue(ctx, authInfoKey{}, authInfo)
-}
-
-// FromContext returns the authInfo in ctx if it exists.
-func FromContext(ctx context.Context) (authInfo AuthInfo, ok bool) {
-	authInfo, ok = ctx.Value(authInfoKey{}).(AuthInfo)
-	return
-}
-*/
 // TransportAuthenticator defines the common interface for all the live gRPC wire
 // protocols and supported transport security protocols (e.g., TLS, SSL).
 type TransportAuthenticator interface {

--- a/credentials/credentials.go
+++ b/credentials/credentials.go
@@ -87,6 +87,7 @@ type AuthInfo interface {
 	AuthType() string
 }
 
+/*
 type authInfoKey struct{}
 
 // NewContext creates a new context with authInfo attached.
@@ -99,7 +100,7 @@ func FromContext(ctx context.Context) (authInfo AuthInfo, ok bool) {
 	authInfo, ok = ctx.Value(authInfoKey{}).(AuthInfo)
 	return
 }
-
+*/
 // TransportAuthenticator defines the common interface for all the live gRPC wire
 // protocols and supported transport security protocols (e.g., TLS, SSL).
 type TransportAuthenticator interface {

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -44,7 +44,10 @@ import (
 
 // Peer contains the information of the peer for an RPC.
 type Peer struct {
-	Address  net.Addr
+	// Addr is the peer address.
+	Addr net.Addr
+	// AuthInfo is the authentication information of the transport.
+	// It is nil if there is no transport security being used.
 	AuthInfo credentials.AuthInfo
 }
 

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -31,7 +31,8 @@
  *
  */
 
-// Package peer contains all the peer information of an RPC.
+// Package peer defines various peer information associated with RPCs and
+// corresponding utils.
 package peer
 
 import (

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -1,0 +1,61 @@
+/*
+ *
+ * Copyright 2014, Google Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+// Package peer contains all the peer information of an RPC.
+package peer
+
+import (
+	"net"
+
+	"golang.org/x/net/context"
+	"google.golang.org/grpc/credentials"
+)
+
+// Peer contains the information of the peer for an RPC.
+type Peer struct {
+	Address net.Addr
+	AuthInfo credentials.AuthInfo
+}
+
+type peerKey struct{}
+
+// NewContext creates a new context with peer information attached.
+func NewContext(ctx context.Context, p *Peer) context.Context {
+	return context.WithValue(ctx, peerKey{}, p)
+}
+
+// FromContext returns the peer information in ctx if it exists.
+func FromContext(ctx context.Context) (p *Peer, ok bool) {
+	p, ok = ctx.Value(peerKey{}).(*Peer)
+	return
+}

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -44,7 +44,7 @@ import (
 
 // Peer contains the information of the peer for an RPC.
 type Peer struct {
-	Address net.Addr
+	Address  net.Addr
 	AuthInfo credentials.AuthInfo
 }
 

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -113,7 +113,10 @@ func (s *testServer) UnaryCall(ctx context.Context, in *testpb.SimpleRequest) (*
 	}
 	pr, ok := peer.FromContext(ctx)
 	if !ok {
-		return nil, fmt.Errorf("Failed to get peer from ctx.")
+		return nil, fmt.Errorf("failed to get peer from ctx")
+	}
+	if pr.Addr == net.Addr(nil) {
+		return nil, fmt.Errorf("failed to get peer address")
 	}
 	if s.security != "" {
 		// Check Auth info

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -53,6 +53,7 @@ import (
 	"google.golang.org/grpc/health"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1alpha"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/peer"
 	testpb "google.golang.org/grpc/test/grpc_testing"
 )
 
@@ -110,14 +111,14 @@ func (s *testServer) UnaryCall(ctx context.Context, in *testpb.SimpleRequest) (*
 		}
 		grpc.SetTrailer(ctx, md)
 	}
+	pr, ok := peer.FromContext(ctx)
+	if !ok {
+		return nil, fmt.Errorf("Failed to get peer from ctx.")
+	}
 	if s.security != "" {
 		// Check Auth info
-		authInfo, ok := credentials.FromContext(ctx)
-		if !ok {
-			return nil, fmt.Errorf("Failed to get AuthInfo from ctx.")
-		}
 		var authType, serverName string
-		switch info := authInfo.(type) {
+		switch info := pr.AuthInfo.(type) {
 		case credentials.TLSInfo:
 			authType = info.AuthType()
 			serverName = info.State.ServerName

--- a/transport/http2_client.go
+++ b/transport/http2_client.go
@@ -240,7 +240,7 @@ func (t *http2Client) NewStream(ctx context.Context, callHdr *CallHdr) (_ *Strea
 		}
 	}
 	pr := &peer.Peer{
-		Address: t.conn.RemoteAddr(),
+		Addr: t.conn.RemoteAddr(),
 	}
 	// Attach Auth info if there is any.
 	if t.authInfo != nil {

--- a/transport/http2_client.go
+++ b/transport/http2_client.go
@@ -50,6 +50,7 @@ import (
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/grpclog"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/peer"
 )
 
 // http2Client implements the ClientTransport interface with HTTP2.
@@ -238,10 +239,15 @@ func (t *http2Client) NewStream(ctx context.Context, callHdr *CallHdr) (_ *Strea
 			return nil, ContextErr(context.DeadlineExceeded)
 		}
 	}
+	pr := &peer.Peer{
+		Address: t.conn.RemoteAddr(),
+	}
 	// Attach Auth info if there is any.
 	if t.authInfo != nil {
-		ctx = credentials.NewContext(ctx, t.authInfo)
+		pr.AuthInfo = t.authInfo
+		//ctx = credentials.NewContext(ctx, t.authInfo)
 	}
+	ctx = peer.NewContext(ctx, pr)
 	authData := make(map[string]string)
 	for _, c := range t.authCreds {
 		// Construct URI required to get auth request metadata.

--- a/transport/http2_client.go
+++ b/transport/http2_client.go
@@ -245,7 +245,6 @@ func (t *http2Client) NewStream(ctx context.Context, callHdr *CallHdr) (_ *Strea
 	// Attach Auth info if there is any.
 	if t.authInfo != nil {
 		pr.AuthInfo = t.authInfo
-		//ctx = credentials.NewContext(ctx, t.authInfo)
 	}
 	ctx = peer.NewContext(ctx, pr)
 	authData := make(map[string]string)

--- a/transport/http2_server.go
+++ b/transport/http2_server.go
@@ -49,6 +49,7 @@ import (
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/grpclog"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/peer"
 )
 
 // ErrIllegalHeaderWrite indicates that setting header is illegal because of
@@ -168,10 +169,15 @@ func (t *http2Server) operateHeaders(hDec *hpackDecoder, s *Stream, frame header
 	} else {
 		s.ctx, s.cancel = context.WithCancel(context.TODO())
 	}
+	pr := &peer.Peer{
+		Address: t.conn.RemoteAddr(),
+	}
 	// Attach Auth info if there is any.
 	if t.authInfo != nil {
-		s.ctx = credentials.NewContext(s.ctx, t.authInfo)
+		pr.AuthInfo = t.authInfo
+		//s.ctx = credentials.NewContext(s.ctx, t.authInfo)
 	}
+	s.ctx = peer.NewContext(s.ctx, pr)
 	// Cache the current stream to the context so that the server application
 	// can find out. Required when the server wants to send some metadata
 	// back to the client (unary call only).

--- a/transport/http2_server.go
+++ b/transport/http2_server.go
@@ -175,7 +175,6 @@ func (t *http2Server) operateHeaders(hDec *hpackDecoder, s *Stream, frame header
 	// Attach Auth info if there is any.
 	if t.authInfo != nil {
 		pr.AuthInfo = t.authInfo
-		//s.ctx = credentials.NewContext(s.ctx, t.authInfo)
 	}
 	s.ctx = peer.NewContext(s.ctx, pr)
 	// Cache the current stream to the context so that the server application

--- a/transport/http2_server.go
+++ b/transport/http2_server.go
@@ -170,7 +170,7 @@ func (t *http2Server) operateHeaders(hDec *hpackDecoder, s *Stream, frame header
 		s.ctx, s.cancel = context.WithCancel(context.TODO())
 	}
 	pr := &peer.Peer{
-		Address: t.conn.RemoteAddr(),
+		Addr: t.conn.RemoteAddr(),
 	}
 	// Attach Auth info if there is any.
 	if t.authInfo != nil {


### PR DESCRIPTION
Note that this PR removes credentials.NewContext(...) and credentials.FromContext(...) by placing AuthInfo as a member of peer info. If you use these APIs, please switch to the new one (end2end test in this PR serves as an example.).