### PR TITLE
Fix the link to protoc installation instructions.

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -43,7 +43,7 @@ $ greeter_client
 OPTIONAL - Rebuilding the generated code
 ----------------------------------------
 
-1 First [install protoc](https://github.com/google/protobuf/blob/master/INSTALL.txt)
+1 First [install protoc](https://github.com/google/protobuf/blob/master/README.md)
   - For now, this needs to be installed from source
   - This is will change once proto3 is officially released
 


### PR DESCRIPTION
To install protoc, users should follow instructions in the README.md
file (INSTALL.txt has been removed because it misses crucial info
and confuses users).