### PR TITLE
Prepare for adding a compatibility marker to proto generated code.

### DIFF
--- a/rpc_util.go
+++ b/rpc_util.go
@@ -442,3 +442,11 @@ func backoff(retries int) (t time.Duration) {
 	}
 	return time.Duration(backoff)
 }
+
+// SupportPackageIsVersion1 is referenced from generated protocol buffer files
+// to assert that that code is compatible with this version of the grpc package.
+//
+// This constant may be renamed in the future if a change in the generated code
+// requires a synchronised update of grpc-go and protoc-gen-go. This constant
+// should not be referenced from any other code.
+const SupportPackageIsVersion1 = true


### PR DESCRIPTION
This will assert at build time that the generated code is compatible
with the grpc package that it is linked to. A future change in the
grpc plugin for protoc-gen-go will generate a line like
	const _ = grpc.SupportPackageIsVersion1

This constant will be renamed in the future when incompatible changes
are made that require synchronised updates to grpc and protoc-gen-go.