### PR TITLE
Add logrus, log15, lion as internal options for grpclog

### DIFF
--- a/grpclog/lion/lion.go
+++ b/grpclog/lion/lion.go
@@ -37,7 +37,7 @@ https://go.pedge.io/lion
 
 To set the lion Root Logger as the logger, do a blank import:
 
-	import _ "google.golang.org/grpc/grpglog/lion"
+	import _ "google.golang.org/grpc/grpclog/lion"
 
 To set another lion Logger as the logger:
 

--- a/grpclog/lion/lion.go
+++ b/grpclog/lion/lion.go
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2016, Google Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+/*
+Package grpclion defines lion-based logging for grpc.
+
+https://go.pedge.io/lion
+
+To set the lion Root Logger as the logger, do a blank import:
+
+	import _ "google.golang.org/grpc/grpglog/lion"
+
+To set another lion Logger as the logger:
+
+	grpclog.SetLogger(grpclion.NewLogger(lionLogger))
+*/
+package grpclion
+
+import (
+	"go.pedge.io/lion"
+	"google.golang.org/grpc/grpclog"
+)
+
+func init() {
+	grpclog.SetLogger(NewLogger(lion.GlobalLogger()))
+}
+
+// NewLogger returns a new gprclog.Logger that wraps a lion.Logger.
+func NewLogger(lionLogger lion.Logger) grpclog.Logger {
+	return &logger{lionLogger}
+}
+
+type logger struct {
+	lion.Logger
+}
+
+func (l *logger) Fatal(args ...interface{}) {
+	l.Logger.Fatalln(args...)
+}
+
+func (l *logger) Print(args ...interface{}) {
+	l.Logger.Println(args...)
+}

--- a/grpclog/log15/log15.go
+++ b/grpclog/log15/log15.go
@@ -37,7 +37,7 @@ https://gopkg.in/inconshreveable/log15.v2
 
 To set the log15 Root Logger as the logger, do a blank import:
 
-	import _ "google.golang.org/grpc/grpglog/log15"
+	import _ "google.golang.org/grpc/grpclog/log15"
 
 To set another log15 Logger as the logger:
 

--- a/grpclog/log15/log15.go
+++ b/grpclog/log15/log15.go
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2016, Google Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+/*
+Package grpclog15 defines log15-based logging for grpc.
+
+https://gopkg.in/inconshreveable/log15.v2
+
+To set the log15 Root Logger as the logger, do a blank import:
+
+	import _ "google.golang.org/grpc/grpglog/log15"
+
+To set another log15 Logger as the logger:
+
+	grpclog.SetLogger(grpclog15.NewLogger(log15Logger))
+*/
+package grpclog15
+
+import (
+	"fmt"
+	"os"
+
+	"google.golang.org/grpc/grpclog"
+	"gopkg.in/inconshreveable/log15.v2"
+)
+
+func init() {
+	grpclog.SetLogger(NewLogger(log15.Root()))
+}
+
+// NewLogger returns a new gprclog.Logger that wraps a log15.Logger.
+func NewLogger(log15Logger log15.Logger) grpclog.Logger {
+	return &logger{log15Logger}
+}
+
+type logger struct {
+	log15.Logger
+}
+
+func (l *logger) Fatal(args ...interface{}) {
+	l.Logger.Crit(fmt.Sprint(args...))
+	os.Exit(1)
+}
+
+func (l *logger) Fatalf(format string, args ...interface{}) {
+	l.Logger.Crit(fmt.Sprintf(format, args...))
+	os.Exit(1)
+}
+
+func (l *logger) Fatalln(args ...interface{}) {
+	l.Logger.Crit(fmt.Sprintln(args...))
+	os.Exit(1)
+}
+
+func (l *logger) Print(args ...interface{}) {
+	l.Logger.Info(fmt.Sprint(args...))
+}
+
+func (l *logger) Printf(format string, args ...interface{}) {
+	l.Logger.Info(fmt.Sprintf(format, args...))
+}
+
+func (l *logger) Println(args ...interface{}) {
+	l.Logger.Info(fmt.Sprintln(args...))
+}

--- a/grpclog/logrus/logrus.go
+++ b/grpclog/logrus/logrus.go
@@ -37,7 +37,7 @@ https://github.com/Sirupsen/logrus
 
 To set the logrus StandardLogger as the logger, do a blank import:
 
-	import _ "google.golang.org/grpc/grpglog/logrus"
+	import _ "google.golang.org/grpc/grpclog/logrus"
 
 To set another logrus Logger as the logger:
 

--- a/grpclog/logrus/logrus.go
+++ b/grpclog/logrus/logrus.go
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2016, Google Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+/*
+Package grpclogrus defines logrus-based logging for grpc.
+
+https://github.com/Sirupsen/logrus
+
+To set the logrus StandardLogger as the logger, do a blank import:
+
+	import _ "google.golang.org/grpc/grpglog/logrus"
+
+To set another logrus Logger as the logger:
+
+	grpclog.SetLogger(logrusLogger)
+*/
+package grpclogrus
+
+import (
+	"github.com/Sirupsen/logrus"
+	"google.golang.org/grpc/grpclog"
+)
+
+func init() {
+	grpclog.SetLogger(logrus.StandardLogger())
+}


### PR DESCRIPTION
Signed-off-by: Peter Edge <peter.edge@gmail.com>

I'm not sure if this violates the no-external-dependencies requirement, but thought I would send this over as it might help some others. We're also discussing grpclog for grpc-gateway in https://github.com/gengo/grpc-gateway/issues/92, and this would add a couple more packages.

Modeled after https://go.pedge.io/dlog