### PR TITLE
test: shorten goroutine-heavy test in race mode

### DIFF
--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -68,6 +68,8 @@ var (
 	testAppUA = "myApp1/1.0 myApp2/0.9"
 )
 
+var raceMode bool // set by race_test.go in race mode
+
 type testServer struct {
 	security string // indicate the authentication protocol used by this server.
 }
@@ -758,6 +760,15 @@ func testRetry(t *testing.T, e env) {
 
 	numRPC := 1000
 	rpcSpacing := 2 * time.Millisecond
+	if raceMode {
+		// The race detector has a limit on how many goroutines it can track.
+		// This test is near the upper limit, and goes over the limit
+		// depending on the environment (the http.Handler environment uses
+		// more goroutines)
+		t.Logf("Shortening test in race mode.")
+		numRPC /= 2
+		rpcSpacing *= 2
+	}
 
 	wg.Add(1)
 	go func() {

--- a/test/race_test.go
+++ b/test/race_test.go
@@ -1,0 +1,39 @@
+// +build race
+
+/*
+ * Copyright 2016, Google Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+package grpc_test
+
+func init() {
+	raceMode = true
+}


### PR DESCRIPTION
The go race detector has a limit on how many goroutines it can track.
This test is only barely acceptable and the presence of any new
goroutines push it over the edge. Shorten this test is race mode.