### PR TITLE
Convert http2.StreamError to transport.StreamError in the handler transport impl

### DIFF
--- a/clientconn.go
+++ b/clientconn.go
@@ -539,8 +539,9 @@ func (cc *Conn) Wait(ctx context.Context) (transport.ClientTransport, error) {
 			cc.mu.Unlock()
 			return nil, ErrClientConnClosing
 		case cc.state == Ready:
+			ct := cc.transport
 			cc.mu.Unlock()
-			return cc.transport, nil
+			return ct, nil
 		default:
 			ready := cc.ready
 			if ready == nil {


### PR DESCRIPTION
fixes the flaky tests observed at https://travis-ci.org/grpc/grpc-go/builds/108934236.