### PR TITLE
Disable the code coverage checker.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,3 @@ install:
 
 script:
   - make test testrace
-  - make coverage


### PR DESCRIPTION
It's too noisy and not worth it. I don't like encouraging the code
coverage game, wherein people write bad tests to get points.
It's annoying to get a red X in the PR status when coverage dropped
by 1 line or 0.4%.

Good code review should be sufficient to verify we have both tests
and good tests.