### PR TITLE
Use a bufio.Reader for input.

### DIFF
--- a/transport/http_util.go
+++ b/transport/http_util.go
@@ -272,7 +272,7 @@ type framer struct {
 
 func newFramer(conn net.Conn) *framer {
 	f := &framer{
-		reader: conn,
+		reader: bufio.NewReaderSize(conn, http2IOBufSize),
 		writer: bufio.NewWriterSize(conn, http2IOBufSize),
 	}
 	f.fr = http2.NewFramer(f.writer, f.reader)


### PR DESCRIPTION
This reduces the number of system calls for reading network data,
providing a nice speedup when there are concurrent RPCs.

```
name                       old time/op    new time/op    delta
ClientStreamc1-8             37.4µs ± 1%    35.6µs ± 1%   -4.75%         (p=0.000 n=10+9)
ClientStreamc8-8             16.2µs ± 8%    14.7µs ± 2%   -9.28%        (p=0.000 n=10+10)
ClientStreamc64-8            12.5µs ± 2%    12.4µs ± 2%     ~            (p=0.590 n=9+10)
ClientStreamc512-8           13.7µs ± 2%    13.4µs ± 3%   -2.40%        (p=0.011 n=10+10)
ClientUnaryc1-8              88.4µs ± 1%    86.9µs ± 0%   -1.71%         (p=0.000 n=9+10)
ClientUnaryc8-8              41.9µs ± 1%    36.7µs ± 2%  -12.44%        (p=0.000 n=10+10)
ClientUnaryc64-8             27.8µs ± 1%    23.9µs ± 2%  -14.02%         (p=0.000 n=8+10)
ClientUnaryc512-8            27.4µs ± 1%    25.1µs ± 1%   -8.59%        (p=0.000 n=10+10)
ClientStreamNoTracec1-8      35.9µs ± 1%    35.2µs ± 1%   -1.98%         (p=0.000 n=10+9)
ClientStreamNoTracec8-8      16.4µs ± 3%    14.5µs ± 1%  -11.11%         (p=0.000 n=8+10)
ClientStreamNoTracec64-8     12.2µs ± 2%    12.4µs ± 2%     ~           (p=0.089 n=10+10)
ClientStreamNoTracec512-8    13.4µs ± 3%    13.4µs ± 2%     ~            (p=0.780 n=10+9)
ClientUnaryNoTracec1-8       80.4µs ± 1%    74.3µs ± 1%   -7.54%        (p=0.000 n=10+10)
ClientUnaryNoTracec8-8       38.5µs ± 6%    34.4µs ± 3%  -10.60%        (p=0.000 n=10+10)
ClientUnaryNoTracec64-8      25.9µs ± 0%    21.3µs ± 2%  -17.71%         (p=0.000 n=9+10)
ClientUnaryNoTracec512-8     26.0µs ± 1%    19.5µs ± 3%  -24.96%        (p=0.000 n=10+10)
```