### PR TITLE
Don't treat StatusDesc() as a format string.

### DIFF
--- a/call.go
+++ b/call.go
@@ -185,6 +185,6 @@ func Invoke(ctx context.Context, method string, args, reply interface{}, cc *Cli
 		if lastErr != nil {
 			return toRPCErr(lastErr)
 		}
-		return Errorf(stream.StatusCode(), stream.StatusDesc())
+		return Errorf(stream.StatusCode(), "%s", stream.StatusDesc())
 	}
 }

--- a/stream.go
+++ b/stream.go
@@ -257,7 +257,7 @@ func (cs *clientStream) RecvMsg(m interface{}) (err error) {
 				cs.finish(err)
 				return nil
 			}
-			return Errorf(cs.s.StatusCode(), cs.s.StatusDesc())
+			return Errorf(cs.s.StatusCode(), "%s", cs.s.StatusDesc())
 		}
 		return toRPCErr(err)
 	}
@@ -269,7 +269,7 @@ func (cs *clientStream) RecvMsg(m interface{}) (err error) {
 			// Returns io.EOF to indicate the end of the stream.
 			return
 		}
-		return Errorf(cs.s.StatusCode(), cs.s.StatusDesc())
+		return Errorf(cs.s.StatusCode(), "%s", cs.s.StatusDesc())
 	}
 	return toRPCErr(err)
 }


### PR DESCRIPTION
For example, if the error message contains "%v", then passing
StatusDesc() as the format string to Errorf() will replace "%v" with
"%!v(MISSING)".