### PR TITLE
travis: build against go1.5.3, go1.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: go
 
+go:
+  - 1.5.3
+  - 1.6
+
 before_install:
   - go get github.com/axw/gocov/gocov
   - go get github.com/mattn/goveralls


### PR DESCRIPTION
Currently, grpc-go is only built against go 1.4.x.