### PR TITLE
Base64 encode statusDesc to fix errors sent from server.

### DIFF
--- a/transport/handler_server.go
+++ b/transport/handler_server.go
@@ -38,6 +38,7 @@
 package transport
 
 import (
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"io"
@@ -192,7 +193,7 @@ func (ht *serverHandlerTransport) WriteStatus(s *Stream, statusCode codes.Code, 
 		h := ht.rw.Header()
 		h.Set("Grpc-Status", fmt.Sprintf("%d", statusCode))
 		if statusDesc != "" {
-			h.Set("Grpc-Message", statusDesc)
+			h.Set("Grpc-Message-Bin", base64.StdEncoding.EncodeToString([]byte(statusDesc)))
 		}
 		if md := s.Trailer(); len(md) > 0 {
 			for k, vv := range md {
@@ -227,7 +228,7 @@ func (ht *serverHandlerTransport) writeCommonHeaders(s *Stream) {
 	// See https://golang.org/pkg/net/http/#ResponseWriter
 	// and https://golang.org/pkg/net/http/#example_ResponseWriter_trailers
 	h.Add("Trailer", "Grpc-Status")
-	h.Add("Trailer", "Grpc-Message")
+	h.Add("Trailer", "Grpc-Message-Bin")
 
 	if s.sendCompress != "" {
 		h.Set("Grpc-Encoding", s.sendCompress)

--- a/transport/handler_server_test.go
+++ b/transport/handler_server_test.go
@@ -33,6 +33,7 @@
 package transport
 
 import (
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"io"
@@ -304,7 +305,7 @@ func TestHandlerTransport_HandleStreams(t *testing.T) {
 	wantHeader := http.Header{
 		"Date":         nil,
 		"Content-Type": {"application/grpc"},
-		"Trailer":      {"Grpc-Status", "Grpc-Message"},
+		"Trailer":      {"Grpc-Status", "Grpc-Message-Bin"},
 		"Grpc-Status":  {"0"},
 	}
 	if !reflect.DeepEqual(st.rw.HeaderMap, wantHeader) {
@@ -329,11 +330,11 @@ func handleStreamCloseBodyTest(t *testing.T, statusCode codes.Code, msg string) 
 	}
 	st.ht.HandleStreams(func(s *Stream) { go handleStream(s) })
 	wantHeader := http.Header{
-		"Date":         nil,
-		"Content-Type": {"application/grpc"},
-		"Trailer":      {"Grpc-Status", "Grpc-Message"},
-		"Grpc-Status":  {fmt.Sprint(uint32(statusCode))},
-		"Grpc-Message": {msg},
+		"Date":             nil,
+		"Content-Type":     {"application/grpc"},
+		"Trailer":          {"Grpc-Status", "Grpc-Message-Bin"},
+		"Grpc-Status":      {fmt.Sprint(uint32(statusCode))},
+		"Grpc-Message-Bin": {base64.StdEncoding.EncodeToString([]byte(msg))},
 	}
 	if !reflect.DeepEqual(st.rw.HeaderMap, wantHeader) {
 		t.Errorf("Header+Trailer mismatch.\n got: %#v\nwant: %#v", st.rw.HeaderMap, wantHeader)
@@ -377,11 +378,11 @@ func TestHandlerTransport_HandleStreams_Timeout(t *testing.T) {
 	}
 	ht.HandleStreams(func(s *Stream) { go runStream(s) })
 	wantHeader := http.Header{
-		"Date":         nil,
-		"Content-Type": {"application/grpc"},
-		"Trailer":      {"Grpc-Status", "Grpc-Message"},
-		"Grpc-Status":  {"4"},
-		"Grpc-Message": {"too slow"},
+		"Date":             nil,
+		"Content-Type":     {"application/grpc"},
+		"Trailer":          {"Grpc-Status", "Grpc-Message-Bin"},
+		"Grpc-Status":      {"4"},
+		"Grpc-Message-Bin": {base64.StdEncoding.EncodeToString([]byte("too slow"))},
 	}
 	if !reflect.DeepEqual(rw.HeaderMap, wantHeader) {
 		t.Errorf("Header+Trailer Map mismatch.\n got: %#v\nwant: %#v", rw.HeaderMap, wantHeader)

--- a/transport/http2_server.go
+++ b/transport/http2_server.go
@@ -35,6 +35,7 @@ package transport
 
 import (
 	"bytes"
+	"encoding/base64"
 	"errors"
 	"io"
 	"math"
@@ -485,7 +486,11 @@ func (t *http2Server) WriteStatus(s *Stream, statusCode codes.Code, statusDesc s
 			Name:  "grpc-status",
 			Value: strconv.Itoa(int(statusCode)),
 		})
-	t.hEnc.WriteField(hpack.HeaderField{Name: "grpc-message", Value: statusDesc})
+	value := ""
+	if statusDesc != "" {
+		value = base64.StdEncoding.EncodeToString([]byte(statusDesc))
+	}
+	t.hEnc.WriteField(hpack.HeaderField{Name: "grpc-message", Value: value})
 	// Attach the trailer metadata.
 	for k, v := range s.trailer {
 		for _, entry := range v {

--- a/transport/http_util.go
+++ b/transport/http_util.go
@@ -35,6 +35,7 @@ package transport
 
 import (
 	"bufio"
+	"encoding/base64"
 	"fmt"
 	"io"
 	"net"
@@ -149,7 +150,14 @@ func (d *decodeState) processHeaderField(f hpack.HeaderField) {
 		}
 		d.statusCode = codes.Code(code)
 	case "grpc-message":
-		d.statusDesc = f.Value
+		if f.Value != "" {
+			statusDescBytes, err := base64.StdEncoding.DecodeString(f.Value)
+			if err != nil {
+				d.setErr(StreamErrorf(codes.Internal, "transport: could not base64 decode grpc-message: %v", err))
+				return
+			}
+			d.statusDesc = string(statusDescBytes)
+		}
 	case "grpc-timeout":
 		d.timeoutSet = true
 		var err error

--- a/transport/http_util.go
+++ b/transport/http_util.go
@@ -117,7 +117,7 @@ func isReservedHeader(hdr string) bool {
 	case "content-type",
 		"grpc-message-type",
 		"grpc-encoding",
-		"grpc-message",
+		"grpc-message-bin",
 		"grpc-status",
 		"grpc-timeout",
 		"te":
@@ -153,7 +153,7 @@ func (d *decodeState) processHeaderField(f hpack.HeaderField) {
 		if f.Value != "" {
 			statusDescBytes, err := base64.StdEncoding.DecodeString(f.Value)
 			if err != nil {
-				d.setErr(StreamErrorf(codes.Internal, "transport: could not base64 decode grpc-message: %v", err))
+				d.setErr(StreamErrorf(codes.Internal, "transport: could not base64 decode grpc-message-bin: %v", err))
 				return
 			}
 			d.statusDesc = string(statusDescBytes)

--- a/transport/transport_test.go
+++ b/transport/transport_test.go
@@ -708,7 +708,7 @@ func TestIsReservedHeader(t *testing.T) {
 		{"content-type", true},
 		{"grpc-message-type", true},
 		{"grpc-encoding", true},
-		{"grpc-message", true},
+		{"grpc-message-bin", true},
 		{"grpc-status", true},
 		{"grpc-timeout", true},
 		{"te", true},


### PR DESCRIPTION
Signed-off-by: Peter Edge <peter.edge@gmail.com>

Fixes https://github.com/grpc/grpc-go/issues/576, https://github.com/grpc/grpc-go/issues/606