### PR TITLE
transport: replace isItem with a marker method

### DIFF
--- a/transport/control.go
+++ b/transport/control.go
@@ -56,43 +56,33 @@ type windowUpdate struct {
 	increment uint32
 }
 
-func (windowUpdate) isItem() bool {
-	return true
-}
+func (*windowUpdate) item() {}
 
 type settings struct {
 	ack bool
 	ss  []http2.Setting
 }
 
-func (settings) isItem() bool {
-	return true
-}
+func (*settings) item() {}
 
 type resetStream struct {
 	streamID uint32
 	code     http2.ErrCode
 }
 
-func (resetStream) isItem() bool {
-	return true
-}
+func (*resetStream) item() {}
 
 type flushIO struct {
 }
 
-func (flushIO) isItem() bool {
-	return true
-}
+func (*flushIO) item() {}
 
 type ping struct {
 	ack  bool
 	data [8]byte
 }
 
-func (ping) isItem() bool {
-	return true
-}
+func (*ping) item() {}
 
 // quotaPool is a pool which accumulates the quota and sends it to acquire()
 // when it is available.

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -63,13 +63,11 @@ type recvMsg struct {
 	err error
 }
 
-func (recvMsg) isItem() bool {
-	return true
-}
+func (*recvMsg) item() {}
 
 // All items in an out of a recvBuffer should be the same type.
 type item interface {
-	isItem() bool
+	item()
 }
 
 // recvBuffer is an unbounded channel of item.


### PR DESCRIPTION
Also changes the receivers to pointers because:
- Implementing an interface using value receivers causes both pointers
and values to implement that interface; implementing an interface using
pointer receivers causes only pointers to implement the interface,
thereby providing better type safety.
- Wrapping any value other than an empty struct in an interface causes
the value to be heap-allocated; no additional allocations are therefore
caused by this change.