### PR TITLE
remove unnecessary comment on invoke/sendmsg

### DIFF
--- a/call.go
+++ b/call.go
@@ -97,8 +97,9 @@ func sendRequest(ctx context.Context, codec Codec, compressor Compressor, callHd
 	return stream, nil
 }
 
-// Invoke is called by the generated code. It sends the RPC request on the
-// wire and returns after response is received.
+// Invoke sends the RPC request on the wire and returns after response is received.
+// Invoke is called by generated code. Also users can call Invoke directly when it
+// is really needed in their use cases.
 func Invoke(ctx context.Context, method string, args, reply interface{}, cc *ClientConn, opts ...CallOption) (err error) {
 	var c callInfo
 	for _, o := range opts {

--- a/stream.go
+++ b/stream.go
@@ -67,7 +67,8 @@ type Stream interface {
 	// breaks.
 	// On error, it aborts the stream and returns an RPC status on client
 	// side. On server side, it simply returns the error to the caller.
-	// SendMsg is called by generated code.
+	// SendMsg is called by generated code. Also Users can call SendMsg
+	// directly when it is really needed in their use cases.
 	SendMsg(m interface{}) error
 	// RecvMsg blocks until it receives a message or the stream is
 	// done. On client side, it returns io.EOF when the stream is done. On


### PR DESCRIPTION
Both Invoke and SendMsg are stable API. And users can call them directly for various reasons (bypass encoding by sending a []byte as interface for example).

The `x is called by the generated code` comment is kind of misleading. It makes users to feel these funcs are designed to be called by generated code only.