### PR TITLE
transport: do not create a Stream on a canceled context

### DIFF
--- a/call_test.go
+++ b/call_test.go
@@ -54,6 +54,7 @@ var (
 	expectedResponse = "pong"
 	weirdError       = "format verbs: %v%s"
 	sizeLargeErr     = 1024 * 1024
+	canceled         = 0
 )
 
 type testCodec struct {
@@ -98,6 +99,11 @@ func (h *testStreamHandler) handleStream(t *testing.T, s *transport.Stream) {
 		}
 		if v == "weird error" {
 			h.t.WriteStatus(s, codes.Internal, weirdError)
+			return
+		}
+		if v == "canceled" {
+			canceled++
+			h.t.WriteStatus(s, codes.Internal, "")
 			return
 		}
 		if v != expectedRequest {
@@ -240,6 +246,23 @@ func TestInvokeErrorSpecialChars(t *testing.T) {
 	}
 	if got, want := ErrorDesc(err), weirdError; got != want {
 		t.Fatalf("grpc.Invoke(_, _, _, _, _) error = %q, want %q", got, want)
+	}
+	cc.Close()
+	server.stop()
+}
+
+// TestInvokeCancel checks that an Invoke with a canceled context is not sent.
+func TestInvokeCancel(t *testing.T) {
+	server, cc := setUp(t, 0, math.MaxUint32)
+	var reply string
+	req := "canceled"
+	for i := 0; i < 100; i++ {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		Invoke(ctx, "/foo/bar", &req, &reply, cc)
+	}
+	if canceled != 0 {
+		t.Fatalf("received %d of 100 canceled requests", canceled)
 	}
 	cc.Close()
 	server.stop()

--- a/transport/http2_client.go
+++ b/transport/http2_client.go
@@ -236,9 +236,9 @@ func (t *http2Client) NewStream(ctx context.Context, callHdr *CallHdr) (_ *Strea
 	var timeout time.Duration
 	if dl, ok := ctx.Deadline(); ok {
 		timeout = dl.Sub(time.Now())
-		if timeout <= 0 {
-			return nil, ContextErr(context.DeadlineExceeded)
-		}
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, ContextErr(err)
 	}
 	pr := &peer.Peer{
 		Addr: t.conn.RemoteAddr(),


### PR DESCRIPTION
Occasionally Invoke() would let a message slip through when the context
is already canceled.