### PR TITLE
make setDefault(...) non-member function

### DIFF
--- a/backoff.go
+++ b/backoff.go
@@ -49,7 +49,7 @@ type BackoffConfig struct {
 	jitter float64
 }
 
-func (bc *BackoffConfig) setDefaults() {
+func setDefaults(bc *BackoffConfig) {
 	md := bc.MaxDelay
 	*bc = DefaultBackoffConfig
 
@@ -58,7 +58,7 @@ func (bc *BackoffConfig) setDefaults() {
 	}
 }
 
-func (bc *BackoffConfig) backoff(retries int) (t time.Duration) {
+func (bc BackoffConfig) backoff(retries int) (t time.Duration) {
 	if retries == 0 {
 		return bc.baseDelay
 	}

--- a/backoff.go
+++ b/backoff.go
@@ -58,7 +58,7 @@ func (bc *BackoffConfig) setDefaults() {
 	}
 }
 
-func (bc BackoffConfig) backoff(retries int) (t time.Duration) {
+func (bc *BackoffConfig) backoff(retries int) (t time.Duration) {
 	if retries == 0 {
 		return bc.baseDelay
 	}

--- a/backoff_test.go
+++ b/backoff_test.go
@@ -4,7 +4,7 @@ import "testing"
 
 func TestBackoffConfigDefaults(t *testing.T) {
 	b := BackoffConfig{}
-	b.setDefaults()
+	setDefaults(&b)
 	if b != DefaultBackoffConfig {
 		t.Fatalf("expected BackoffConfig to pickup default parameters: %v != %v", b, DefaultBackoffConfig)
 	}

--- a/clientconn.go
+++ b/clientconn.go
@@ -129,7 +129,7 @@ func WithBackoffMaxDelay(md time.Duration) DialOption {
 func WithBackoffConfig(b BackoffConfig) DialOption {
 	// Set defaults to ensure that provided BackoffConfig is valid and
 	// unexported fields get default values.
-	b.setDefaults()
+	setDefaults(&b)
 	return withBackoff(b)
 }
 

--- a/clientconn_test.go
+++ b/clientconn_test.go
@@ -88,14 +88,14 @@ func TestWithBackoffConfigDefault(t *testing.T) {
 func TestWithBackoffConfig(t *testing.T) {
 	b := BackoffConfig{MaxDelay: DefaultBackoffConfig.MaxDelay / 2}
 	expected := b
-	expected.setDefaults() // defaults should be set
+	setDefaults(&expected) // defaults should be set
 	testBackoffConfigSet(t, &expected, WithBackoffConfig(b))
 }
 
 func TestWithBackoffMaxDelay(t *testing.T) {
 	md := DefaultBackoffConfig.MaxDelay / 2
 	expected := BackoffConfig{MaxDelay: md}
-	expected.setDefaults()
+	setDefaults(&expected)
 	testBackoffConfigSet(t, &expected, WithBackoffMaxDelay(md))
 }
 


### PR DESCRIPTION
so that we can keep the receiver consistency of method.

quoted from https://golang.org/doc/faq#methods_on_values_or_pointers

_"Next is consistency. If some of the methods of the type must have pointer receivers, the rest should too, so the method set is consistent regardless of how the type is used. See the section on method sets for details."_

