### PR TITLE
Add ServerStream.SetContextMetadata method

### DIFF
--- a/stream.go
+++ b/stream.go
@@ -332,6 +332,9 @@ type ServerStream interface {
 	// SetTrailer sets the trailer metadata which will be sent with the
 	// RPC status.
 	SetTrailer(metadata.MD)
+	// SetContextMetadata sets the stream context metadata that will be
+	// available on server side.
+	SetContextMetadata(metadata.MD)
 	Stream
 }
 
@@ -353,6 +356,10 @@ type serverStream struct {
 
 func (ss *serverStream) Context() context.Context {
 	return ss.s.Context()
+}
+
+func (ss *serverStream) SetContextMetadata(md metadata.MD) {
+	ss.s.SetContextMetadata(md)
 }
 
 func (ss *serverStream) SendHeader(md metadata.MD) error {

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -251,6 +251,10 @@ func (s *Stream) TraceContext(tr trace.Trace) {
 	s.ctx = trace.NewContext(s.ctx, tr)
 }
 
+func (s *Stream) SetContextMetadata(md metadata.MD) {
+	s.ctx = metadata.NewContext(s.ctx, md)
+}
+
 // Method returns the method for the stream.
 func (s *Stream) Method() string {
 	return s.method


### PR DESCRIPTION
To add feature parity between StreamServerInterceptor and UnaryInterceptor way of passing additional metadata to the handler for stream method is needed.

I've added ServerStream.SetContextMetadata which delegates to transport.Stream.SetContextMetadata method to set the metadata.

In my case i use it in custom interceptor to pass decoded JWT Subject information to handler.