### PR TITLE
Documentation: fix metadata.FromContext example

### DIFF
--- a/Documentation/grpc-metadata.md
+++ b/Documentation/grpc-metadata.md
@@ -70,7 +70,8 @@ Metadata can be retrieved from context using `FromContext`:
 
 ```go
 func (s *server) SomeRPC(ctx context.Context, in *pb.SomeRequest) (*pb.SomeResponse, err) {
-    md := metadata.FromContext(ctx)
+    md, ok := metadata.FromContext(ctx)
+    // do something with metadata
 }
 ```
 


### PR DESCRIPTION
metadata.FromContext returns additional boolean value.
This fixes the example in metadata documentation.