### PR TITLE
add `UnknownServiceHandler`, a way to customize unknown service handling

### DIFF
--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -1228,7 +1228,7 @@ func testHealthCheckOff(t *testing.T, e env) {
 	te := newTest(t, e)
 	te.startServer(&testServer{security: e.security})
 	defer te.tearDown()
-	want := grpc.Errorf(codes.Unimplemented, "unknown service grpc.health.v1.Health")
+	want := grpc.Errorf(codes.Unimplemented, "unknown method /grpc.health.v1.Health/Check")
 	if _, err := healthCheck(1*time.Second, te.clientConn(), ""); !equalErrors(err, want) {
 		t.Fatalf("Health/Check(_, _) = _, %v, want _, %v", err, want)
 	}


### PR DESCRIPTION
This adds an "Unknown" handler, which makes it significantly easier for users to add their own erro handling.

We use the code in two ways:
- to have custom logging of `User-Agent` strings for clients that hit APIs that don't exist (really useful for detecting backwards compat breakage)
- to implement https://github.com/mwitkow/grpc-proxy logic

While other users may not be interested in the proxy, I do believe that the first use case is very useful for many people. 
