### PR TITLE
Make RpcError exported

### DIFF
--- a/call_test.go
+++ b/call_test.go
@@ -225,7 +225,7 @@ func TestInvokeLargeErr(t *testing.T) {
 	var reply string
 	req := "hello"
 	err := Invoke(context.Background(), "/foo/bar", &req, &reply, cc)
-	if _, ok := err.(rpcError); !ok {
+	if _, ok := err.(RpcError); !ok {
 		t.Fatalf("grpc.Invoke(_, _, _, _, _) receives non rpc error.")
 	}
 	if Code(err) != codes.Internal || len(ErrorDesc(err)) != sizeLargeErr {
@@ -241,7 +241,7 @@ func TestInvokeErrorSpecialChars(t *testing.T) {
 	var reply string
 	req := "weird error"
 	err := Invoke(context.Background(), "/foo/bar", &req, &reply, cc)
-	if _, ok := err.(rpcError); !ok {
+	if _, ok := err.(RpcError); !ok {
 		t.Fatalf("grpc.Invoke(_, _, _, _, _) receives non rpc error.")
 	}
 	if got, want := ErrorDesc(err), weirdError; got != want {

--- a/rpc_util.go
+++ b/rpc_util.go
@@ -313,14 +313,14 @@ func recv(p *parser, c Codec, s *transport.Stream, dc Decompressor, m interface{
 	return nil
 }
 
-// rpcError defines the status from an RPC.
-type rpcError struct {
-	code codes.Code
-	desc string
+// RpcError defines the status from an RPC.
+type RpcError struct {
+	Code codes.Code
+	Desc string
 }
 
-func (e rpcError) Error() string {
-	return fmt.Sprintf("rpc error: code = %d desc = %s", e.code, e.desc)
+func (e RpcError) Error() string {
+	return fmt.Sprintf("rpc error: code = %d desc = %s", e.Code, e.Desc)
 }
 
 // Code returns the error code for err if it was produced by the rpc system.
@@ -329,8 +329,8 @@ func Code(err error) codes.Code {
 	if err == nil {
 		return codes.OK
 	}
-	if e, ok := err.(rpcError); ok {
-		return e.code
+	if e, ok := err.(RpcError); ok {
+		return e.Code
 	}
 	return codes.Unknown
 }
@@ -341,8 +341,8 @@ func ErrorDesc(err error) string {
 	if err == nil {
 		return ""
 	}
-	if e, ok := err.(rpcError); ok {
-		return e.desc
+	if e, ok := err.(RpcError); ok {
+		return e.Desc
 	}
 	return err.Error()
 }
@@ -353,26 +353,26 @@ func Errorf(c codes.Code, format string, a ...interface{}) error {
 	if c == codes.OK {
 		return nil
 	}
-	return rpcError{
-		code: c,
-		desc: fmt.Sprintf(format, a...),
+	return RpcError{
+		Code: c,
+		Desc: fmt.Sprintf(format, a...),
 	}
 }
 
-// toRPCErr converts an error into a rpcError.
+// toRPCErr converts an error into a RpcError.
 func toRPCErr(err error) error {
 	switch e := err.(type) {
-	case rpcError:
+	case RpcError:
 		return err
 	case transport.StreamError:
-		return rpcError{
-			code: e.Code,
-			desc: e.Desc,
+		return RpcError{
+			Code: e.Code,
+			Desc: e.Desc,
 		}
 	case transport.ConnectionError:
-		return rpcError{
-			code: codes.Internal,
-			desc: e.Desc,
+		return RpcError{
+			Code: codes.Internal,
+			Desc: e.Desc,
 		}
 	}
 	return Errorf(codes.Unknown, "%v", err)

--- a/server.go
+++ b/server.go
@@ -521,9 +521,9 @@ func (s *Server) processUnaryRPC(t transport.ServerTransport, stream *transport.
 		}
 		reply, appErr := md.Handler(srv.server, stream.Context(), df, s.opts.unaryInt)
 		if appErr != nil {
-			if err, ok := appErr.(rpcError); ok {
-				statusCode = err.code
-				statusDesc = err.desc
+			if err, ok := appErr.(RpcError); ok {
+				statusCode = err.Code
+				statusDesc = err.Desc
 			} else {
 				statusCode = convertCode(appErr)
 				statusDesc = appErr.Error()
@@ -609,9 +609,9 @@ func (s *Server) processStreamingRPC(t transport.ServerTransport, stream *transp
 		appErr = s.opts.streamInt(srv.server, ss, info, sd.Handler)
 	}
 	if appErr != nil {
-		if err, ok := appErr.(rpcError); ok {
-			ss.statusCode = err.code
-			ss.statusDesc = err.desc
+		if err, ok := appErr.(RpcError); ok {
+			ss.statusCode = err.Code
+			ss.statusDesc = err.Desc
 		} else if err, ok := appErr.(transport.StreamError); ok {
 			ss.statusCode = err.Code
 			ss.statusDesc = err.Desc


### PR DESCRIPTION
To allow RPC handlers returning meaningful standard GRPC status codes,
such as UNAVAILABLE etc, instead of relying on non-exported mapping
function convertCode.