### PR TITLE
Include codes.DeadlineExceeded code in connection timeout error.

### DIFF
--- a/clientconn.go
+++ b/clientconn.go
@@ -64,7 +64,7 @@ var (
 	errCredentialsMisuse = errors.New("grpc: the credentials require transport level security (use grpc.WithTransportAuthenticator() to set)")
 	// errClientConnTimeout indicates that the connection could not be
 	// established or re-established within the specified timeout.
-	errClientConnTimeout = errors.New("grpc: timed out trying to connect")
+	errClientConnTimeout = Errorf(codes.DeadlineExceeded, "grpc: timed out trying to connect")
 	// errNetworkIP indicates that the connection is down due to some network I/O error.
 	errNetworkIO = errors.New("grpc: failed with network I/O error")
 	// errConnDrain indicates that the connection starts to be drained and does not accept any new RPCs.


### PR DESCRIPTION
Before this change, some timeout errors returned by gRPC did include
the DeadlineExceeded code. But this was not the case for connection
timeout errors. In order to detect a timeout, an application had to
check for both conditions: a) DeadlineExceeded or b) was the static
connect timeout error returned.

By adding the DeadlineExceeded code to the connect timeout error as well
application code now can be simplified.

@iamqizhao 