### PR TITLE
Fix GRPC starving.

### DIFF
--- a/transport/http2_server.go
+++ b/transport/http2_server.go
@@ -308,9 +308,6 @@ func (t *http2Server) updateWindow(s *Stream, n uint32) {
 	if s.state == streamDone {
 		return
 	}
-	if w := t.fc.onRead(n); w > 0 {
-		t.controlBuf.put(&windowUpdate{0, w})
-	}
 	if w := s.fc.onRead(n); w > 0 {
 		t.controlBuf.put(&windowUpdate{s.id, w})
 	}
@@ -367,6 +364,9 @@ func (t *http2Server) handleData(f *http2.DataFrame) {
 		}
 		s.mu.Unlock()
 		s.write(recvMsg{err: io.EOF})
+	}
+	if w := t.fc.onRead(uint32(size)); w > 0 {
+		t.controlBuf.put(&windowUpdate{0, w})
 	}
 }
 


### PR DESCRIPTION
The transport may be out of capacity due to all capacity is assigned to
blocked streams. The library should return the capacity after it
processes a frame, no matter it's handled by usercode or not.

A proof of concept can be found at:
https://github.com/robertabcd/grpcstarve

Note: Haven't look thoroughly to the code. Not sure if the fix is architectural elegant or conforms to HTTP/2 spec.