### PR TITLE
[Notice] Change the semantics of grpc.WithTimeout DialOption

### DIFF
--- a/clientconn.go
+++ b/clientconn.go
@@ -183,9 +183,8 @@ func WithPerRPCCredentials(creds credentials.Credentials) DialOption {
 	}
 }
 
-// WithTimeout returns a DialOption that configures a timeout for creating a ClientConn
-// and dialing the corresponding network connections when calling Dial(...). This is
-// valid if and only if WithBlock() is present.
+// WithTimeout returns a DialOption that configures a timeout for dialing a ClientConn
+// initially. This is valid if and only if WithBlock() is present.
 func WithTimeout(d time.Duration) DialOption {
 	return func(o *dialOptions) {
 		o.timeout = d

--- a/clientconn.go
+++ b/clientconn.go
@@ -53,6 +53,9 @@ var (
 	// ErrClientConnClosing indicates that the operation is illegal because
 	// the ClientConn is closing.
 	ErrClientConnClosing = errors.New("grpc: the client connection is closing")
+	// ErrClientConnTimeout indicates that the ClientConn cannot establish the
+	// underlying connections within the specified timeout.
+	ErrClientConnTimeout = errors.New("grpc: timed out when dialing")
 
 	// errNoTransportSecurity indicates that there is no transport security
 	// being set for ClientConn. Users should either set one or explicitly
@@ -62,9 +65,6 @@ var (
 	// (e.g., oauth2 token) which requires secure connection on an insecure
 	// connection.
 	errCredentialsMisuse = errors.New("grpc: the credentials require transport level security (use grpc.WithTransportAuthenticator() to set)")
-	// errClientConnTimeout indicates that the connection could not be
-	// established or re-established within the specified timeout.
-	errClientConnTimeout = errors.New("grpc: timed out trying to connect")
 	// errNetworkIP indicates that the connection is down due to some network I/O error.
 	errNetworkIO = errors.New("grpc: failed with network I/O error")
 	// errConnDrain indicates that the connection starts to be drained and does not accept any new RPCs.
@@ -85,6 +85,7 @@ type dialOptions struct {
 	balancer Balancer
 	block    bool
 	insecure bool
+	timeout  time.Duration
 	copts    transport.ConnectOptions
 }
 
@@ -182,10 +183,12 @@ func WithPerRPCCredentials(creds credentials.Credentials) DialOption {
 	}
 }
 
-// WithTimeout returns a DialOption that configures a timeout for dialing a client connection.
+// WithTimeout returns a DialOption that configures a timeout for creating a ClientConn
+// and dialing the corresponding network connections when calling Dial(...). This is
+// valid if and only if WithBlock() is present.
 func WithTimeout(d time.Duration) DialOption {
 	return func(o *dialOptions) {
-		o.copts.Timeout = d
+		o.timeout = d
 	}
 }
 
@@ -229,25 +232,46 @@ func Dial(target string, opts ...DialOption) (*ClientConn, error) {
 		return nil, err
 	}
 	ch := cc.balancer.Notify()
+	var (
+		ok    bool
+		addrs []Address
+	)
 	if ch == nil {
 		// There is no name resolver installed.
-		addr := Address{Addr: target}
-		if err := cc.newAddrConn(addr, false); err != nil {
-			return nil, err
-		}
+		addrs = append(addrs, Address{Addr: target})
 	} else {
-		addrs, ok := <-ch
+		addrs, ok = <-ch
 		if !ok || len(addrs) == 0 {
 			return nil, fmt.Errorf("grpc: there is no address available to dial")
 		}
+	}
+	waitC := make(chan error)
+	go func() {
 		for _, a := range addrs {
 			if err := cc.newAddrConn(a, false); err != nil {
-				return nil, err
+				waitC <- err
+				return
 			}
 		}
+		close(waitC)
+	}()
+	var timeoutCh <-chan time.Time
+	if cc.dopts.timeout > 0 {
+		timeoutCh = time.After(cc.dopts.timeout)
+	}
+	select {
+	case err := <-waitC:
+		if err != nil {
+			cc.Close()
+			return nil, err
+		}
+	case <-timeoutCh:
+		cc.Close()
+		return nil, ErrClientConnTimeout
+	}
+	if ok {
 		go cc.lbWatcher()
 	}
-
 	colonPos := strings.LastIndex(target, ":")
 	if colonPos == -1 {
 		colonPos = len(target)
@@ -517,7 +541,6 @@ func (ac *addrConn) waitForStateChange(ctx context.Context, sourceState Connecti
 
 func (ac *addrConn) resetTransport(closeTransport bool) error {
 	var retries int
-	start := time.Now()
 	for {
 		ac.mu.Lock()
 		ac.printf("connecting")
@@ -537,29 +560,13 @@ func (ac *addrConn) resetTransport(closeTransport bool) error {
 		if closeTransport && t != nil {
 			t.Close()
 		}
-		// Adjust timeout for the current try.
-		copts := ac.dopts.copts
-		if copts.Timeout < 0 {
-			ac.tearDown(errClientConnTimeout)
-			return errClientConnTimeout
-		}
-		if copts.Timeout > 0 {
-			copts.Timeout -= time.Since(start)
-			if copts.Timeout <= 0 {
-				ac.tearDown(errClientConnTimeout)
-				return errClientConnTimeout
-			}
-		}
 		sleepTime := ac.dopts.bs.backoff(retries)
-		timeout := sleepTime
-		if timeout < minConnectTimeout {
-			timeout = minConnectTimeout
-		}
-		if copts.Timeout == 0 || copts.Timeout > timeout {
-			copts.Timeout = timeout
+		ac.dopts.copts.Timeout = sleepTime
+		if sleepTime < minConnectTimeout {
+			ac.dopts.copts.Timeout = minConnectTimeout
 		}
 		connectTime := time.Now()
-		newTransport, err := transport.NewClientTransport(ac.addr.Addr, &copts)
+		newTransport, err := transport.NewClientTransport(ac.addr.Addr, &ac.dopts.copts)
 		if err != nil {
 			ac.mu.Lock()
 			if ac.state == Shutdown {
@@ -578,14 +585,6 @@ func (ac *addrConn) resetTransport(closeTransport bool) error {
 			sleepTime -= time.Since(connectTime)
 			if sleepTime < 0 {
 				sleepTime = 0
-			}
-			// Fail early before falling into sleep.
-			if ac.dopts.copts.Timeout > 0 && ac.dopts.copts.Timeout < sleepTime+time.Since(start) {
-				ac.mu.Lock()
-				ac.errorf("connection timeout")
-				ac.mu.Unlock()
-				ac.tearDown(errClientConnTimeout)
-				return errClientConnTimeout
 			}
 			closeTransport = false
 			select {

--- a/clientconn_test.go
+++ b/clientconn_test.go
@@ -47,8 +47,8 @@ func TestDialTimeout(t *testing.T) {
 	if err == nil {
 		conn.Close()
 	}
-	if err != errClientConnTimeout {
-		t.Fatalf("Dial(_, _) = %v, %v, want %v", conn, err, errClientConnTimeout)
+	if err != ErrClientConnTimeout {
+		t.Fatalf("Dial(_, _) = %v, %v, want %v", conn, err, ErrClientConnTimeout)
 	}
 }
 
@@ -61,8 +61,8 @@ func TestTLSDialTimeout(t *testing.T) {
 	if err == nil {
 		conn.Close()
 	}
-	if err != errClientConnTimeout {
-		t.Fatalf("grpc.Dial(_, _) = %v, %v, want %v", conn, err, errClientConnTimeout)
+	if err != ErrClientConnTimeout {
+		t.Fatalf("grpc.Dial(_, _) = %v, %v, want %v", conn, err, ErrClientConnTimeout)
 	}
 }
 

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -338,7 +338,8 @@ type ConnectOptions struct {
 	Dialer func(string, time.Duration) (net.Conn, error)
 	// AuthOptions stores the credentials required to setup a client connection and/or issue RPCs.
 	AuthOptions []credentials.Credentials
-	Timeout     time.Duration
+	// Timeout specifies the timeout for dialing a ClientTransport.
+	Timeout time.Duration
 }
 
 // NewClientTransport establishes the transport with the required ConnectOptions

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -338,8 +338,7 @@ type ConnectOptions struct {
 	Dialer func(string, time.Duration) (net.Conn, error)
 	// AuthOptions stores the credentials required to setup a client connection and/or issue RPCs.
 	AuthOptions []credentials.Credentials
-	// Timeout specifies the timeout for dialing a client connection.
-	Timeout time.Duration
+	Timeout     time.Duration
 }
 
 // NewClientTransport establishes the transport with the required ConnectOptions


### PR DESCRIPTION
Currently a grpc.ClientConn may have multiple underlying connections, which makes the former timeout semantics undefined when reconnecting. This pull request changed the semantics by applying the timeout set by grpc.WithTimeout to the initial ClientConn dialing only.

fixes #694 