### PR TITLE
Run protoc on proto files in same package together

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,8 @@ proto:
 		exit 1; \
 	fi
 	go get -u -v github.com/golang/protobuf/protoc-gen-go
-	for file in $$(git ls-files '*.proto'); do \
-		protoc -I $$(dirname $$file) --go_out=plugins=grpc:$$(dirname $$file) $$file; \
+	for dir in $$(git ls-files '*.proto' | xargs -n1 dirname | uniq); do \
+		protoc -I $$dir --go_out=plugins=grpc:$$dir $$dir/*.proto; \
 	done
 
 test: testdeps


### PR DESCRIPTION
`a.proto` and `b.proto` are in the same package, they should be compiled together.

Before this change:
```
protoc -I path/to/proto --go_out=plugins=grpc:path/to/proto path/to/proto/a.proto
protoc -I path/to/proto --go_out=plugins=grpc:path/to/proto path/to/proto/b.proto
```

After:
```
protoc -I path/to/proto --go_out=plugins=grpc:path/to/proto path/to/proto/*.proto
```
