### PR TITLE
server: close only non-closed listeners

### DIFF
--- a/server.go
+++ b/server.go
@@ -320,9 +320,11 @@ func (s *Server) Serve(lis net.Listener) error {
 	s.lis[lis] = true
 	s.mu.Unlock()
 	defer func() {
-		lis.Close()
 		s.mu.Lock()
-		delete(s.lis, lis)
+		if s.lis != nil && s.lis[lis] {
+			lis.Close()
+			delete(s.lis, lis)
+		}
 		s.mu.Unlock()
 	}()
 	for {


### PR DESCRIPTION
The listener can be closed twice: in Close and in Serve. It might lead to
pretty bad things, for example, https://golang.org/src/net/unixsock_posix.go#L340
can delete a file which created by another listener.