### PR TITLE
Return error on bad certificates

### DIFF
--- a/call.go
+++ b/call.go
@@ -190,11 +190,8 @@ func Invoke(ctx context.Context, method string, args, reply interface{}, cc *Cli
 			// Retry a non-failfast RPC when
 			// i) there is a connection error; or
 			// ii) the server started to drain before this RPC was initiated.
-			if e, ok := err.(transport.ConnectionError); ok || err == transport.ErrStreamDrain {
+			if _, ok := err.(transport.ConnectionError); ok || err == transport.ErrStreamDrain {
 				if c.failFast {
-					return toRPCErr(err)
-				}
-				if ok && !e.Temporary() {
 					return toRPCErr(err)
 				}
 				continue
@@ -207,16 +204,7 @@ func Invoke(ctx context.Context, method string, args, reply interface{}, cc *Cli
 				put()
 				put = nil
 			}
-			if e, ok := err.(transport.ConnectionError); ok {
-				if c.failFast {
-					return toRPCErr(err)
-				}
-				if !e.Temporary() {
-					return toRPCErr(err)
-				}
-				continue
-			}
-			if err == transport.ErrStreamDrain {
+			if _, ok := err.(transport.ConnectionError); ok || err == transport.ErrStreamDrain {
 				if c.failFast {
 					return toRPCErr(err)
 				}

--- a/call.go
+++ b/call.go
@@ -84,7 +84,8 @@ func sendRequest(ctx context.Context, codec Codec, compressor Compressor, callHd
 	}
 	defer func() {
 		if err != nil {
-			if e, ok := err.(transport.ConnectionError); !ok || !e.Temporary() {
+			// If err is connection error, t will be closed, no need to close stream here.
+			if _, ok := err.(transport.ConnectionError); !ok {
 				t.CloseStream(stream, err)
 			}
 		}

--- a/clientconn.go
+++ b/clientconn.go
@@ -501,7 +501,7 @@ func (cc *ClientConn) getTransport(ctx context.Context, opts BalancerGetOptions)
 		if put != nil {
 			put()
 		}
-		return nil, nil, Errorf(codes.Internal, "grpc: failed to find the transport to send the rpc")
+		return nil, nil, errConnClosing
 	}
 	t, err := ac.wait(ctx, !opts.BlockingWait)
 	if err != nil {

--- a/clientconn.go
+++ b/clientconn.go
@@ -605,6 +605,9 @@ func (ac *addrConn) resetTransport(closeTransport bool) error {
 		if err != nil {
 			cancel()
 
+			if e, ok := err.(transport.ConnectionError); ok && !e.Temporary() {
+				return fmt.Errorf("failed to create client transport: %v", err)
+			}
 			ac.mu.Lock()
 			if ac.state == Shutdown {
 				// ac.tearDown(...) has been invoked.

--- a/clientconn.go
+++ b/clientconn.go
@@ -435,7 +435,10 @@ func (cc *ClientConn) resetAddrConn(addr Address, skipWait bool, tearDownErr err
 				ac.cc.mu.Unlock()
 				ac.tearDown(err)
 			}
-			return fmt.Errorf("failed to create transport: %v", err)
+			if e, ok := err.(transport.ConnectionError); ok && !e.Temporary() {
+				return e.OriginalError()
+			}
+			return err
 		}
 		// Start to monitor the error status of transport.
 		go ac.transportMonitor()

--- a/stream.go
+++ b/stream.go
@@ -166,14 +166,7 @@ func NewClientStream(ctx context.Context, desc *StreamDesc, cc *ClientConn, meth
 				put()
 				put = nil
 			}
-			if e, ok := err.(transport.ConnectionError); ok || err == transport.ErrStreamDrain {
-				if c.failFast || e.Temporary() {
-					cs.finish(err)
-					return nil, toRPCErr(err)
-				}
-				continue
-			}
-			if err == transport.ErrStreamDrain {
+			if _, ok := err.(transport.ConnectionError); ok || err == transport.ErrStreamDrain {
 				if c.failFast {
 					cs.finish(err)
 					return nil, toRPCErr(err)

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -2275,10 +2275,12 @@ func testClientRequestBodyError_Cancel_StreamingInput(t *testing.T, e env) {
 
 const clientAlwaysFailCredErrorMsg = "clientAlwaysFailCred always fails"
 
+var clientAlwaysFailCredError = errors.New(clientAlwaysFailCredErrorMsg)
+
 type clientAlwaysFailCred struct{}
 
 func (c clientAlwaysFailCred) ClientHandshake(addr string, rawConn net.Conn, timeout time.Duration) (_ net.Conn, _ credentials.AuthInfo, err error) {
-	return nil, nil, errors.New(clientAlwaysFailCredErrorMsg)
+	return nil, nil, clientAlwaysFailCredError
 }
 func (c clientAlwaysFailCred) ServerHandshake(rawConn net.Conn) (net.Conn, credentials.AuthInfo, error) {
 	return rawConn, nil, nil
@@ -2298,8 +2300,8 @@ func TestDialWithBlockErrorOnBadCertificates(t *testing.T) {
 	)
 	opts = append(opts, grpc.WithTransportCredentials(clientAlwaysFailCred{}), grpc.WithBlock())
 	te.cc, err = grpc.Dial(te.srvAddr, opts...)
-	if !strings.Contains(err.Error(), clientAlwaysFailCredErrorMsg) {
-		te.t.Fatalf("Dial(%q) = %v, want err.Error() contains %q", te.srvAddr, err, clientAlwaysFailCredErrorMsg)
+	if err != clientAlwaysFailCredError {
+		te.t.Fatalf("Dial(%q) = %v, want %v", te.srvAddr, err, clientAlwaysFailCredError)
 	}
 }
 

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -2284,7 +2284,7 @@ var clientAlwaysFailCredError = errors.New(clientAlwaysFailCredErrorMsg)
 
 type clientAlwaysFailCred struct{}
 
-func (c clientAlwaysFailCred) ClientHandshake(addr string, rawConn net.Conn, timeout time.Duration) (_ net.Conn, _ credentials.AuthInfo, err error) {
+func (c clientAlwaysFailCred) ClientHandshake(ctx context.Context, addr string, rawConn net.Conn) (net.Conn, credentials.AuthInfo, error) {
 	return nil, nil, clientAlwaysFailCredError
 }
 func (c clientAlwaysFailCred) ServerHandshake(rawConn net.Conn) (net.Conn, credentials.AuthInfo, error) {

--- a/transport/http2_client.go
+++ b/transport/http2_client.go
@@ -774,7 +774,7 @@ func (t *http2Client) handleGoAway(f *http2.GoAwayFrame) {
 	if t.state == reachable || t.state == draining {
 		if f.LastStreamID > 0 && f.LastStreamID%2 != 1 {
 			t.mu.Unlock()
-			t.notifyError(ConnectionErrorf("received illegal http2 GOAWAY frame: stream ID %d is even", f.LastStreamID))
+			t.notifyError(ConnectionErrorf(true, nil, "received illegal http2 GOAWAY frame: stream ID %d is even", f.LastStreamID))
 			return
 		}
 		select {
@@ -783,7 +783,7 @@ func (t *http2Client) handleGoAway(f *http2.GoAwayFrame) {
 			// t.goAway has been closed (i.e.,multiple GoAways).
 			if id < f.LastStreamID {
 				t.mu.Unlock()
-				t.notifyError(ConnectionErrorf("received illegal http2 GOAWAY frame: previously recv GOAWAY frame with LastStramID %d, currently recv %d", id, f.LastStreamID))
+				t.notifyError(ConnectionErrorf(true, nil, "received illegal http2 GOAWAY frame: previously recv GOAWAY frame with LastStramID %d, currently recv %d", id, f.LastStreamID))
 				return
 			}
 			t.prevGoAwayID = id

--- a/transport/http2_client.go
+++ b/transport/http2_client.go
@@ -121,7 +121,7 @@ func newHTTP2Client(ctx context.Context, addr string, opts ConnectOptions) (_ Cl
 	scheme := "http"
 	conn, connErr := dial(opts.Dialer, ctx, addr)
 	if connErr != nil {
-		return nil, ConnectionErrorf(true, "transport: %v", connErr)
+		return nil, ConnectionErrorf(true, connErr, "transport: %v", connErr)
 	}
 	var authInfo credentials.AuthInfo
 	if creds := opts.TransportCredentials; creds != nil {
@@ -130,7 +130,7 @@ func newHTTP2Client(ctx context.Context, addr string, opts ConnectOptions) (_ Cl
 	}
 	if connErr != nil {
 		// Credentials handshake error is not a temporary error.
-		return nil, ConnectionErrorf(false, "transport: %v", connErr)
+		return nil, ConnectionErrorf(false, connErr, "transport: %v", connErr)
 	}
 	defer func() {
 		if err != nil {
@@ -174,11 +174,11 @@ func newHTTP2Client(ctx context.Context, addr string, opts ConnectOptions) (_ Cl
 	n, err := t.conn.Write(clientPreface)
 	if err != nil {
 		t.Close()
-		return nil, ConnectionErrorf(true, "transport: %v", err)
+		return nil, ConnectionErrorf(true, err, "transport: %v", err)
 	}
 	if n != len(clientPreface) {
 		t.Close()
-		return nil, ConnectionErrorf(true, "transport: preface mismatch, wrote %d bytes; want %d", n, len(clientPreface))
+		return nil, ConnectionErrorf(true, err, "transport: preface mismatch, wrote %d bytes; want %d", n, len(clientPreface))
 	}
 	if initialWindowSize != defaultWindowSize {
 		err = t.framer.writeSettings(true, http2.Setting{
@@ -190,13 +190,13 @@ func newHTTP2Client(ctx context.Context, addr string, opts ConnectOptions) (_ Cl
 	}
 	if err != nil {
 		t.Close()
-		return nil, ConnectionErrorf(true, "transport: %v", err)
+		return nil, ConnectionErrorf(true, err, "transport: %v", err)
 	}
 	// Adjust the connection flow control window if needed.
 	if delta := uint32(initialConnWindowSize - defaultWindowSize); delta > 0 {
 		if err := t.framer.writeWindowUpdate(true, 0, delta); err != nil {
 			t.Close()
-			return nil, ConnectionErrorf(true, "transport: %v", err)
+			return nil, ConnectionErrorf(true, err, "transport: %v", err)
 		}
 	}
 	go t.controller()
@@ -406,7 +406,7 @@ func (t *http2Client) NewStream(ctx context.Context, callHdr *CallHdr) (_ *Strea
 		}
 		if err != nil {
 			t.notifyError(err)
-			return nil, ConnectionErrorf(true, "transport: %v", err)
+			return nil, ConnectionErrorf(true, err, "transport: %v", err)
 		}
 	}
 	t.writableChan <- 0
@@ -620,7 +620,7 @@ func (t *http2Client) Write(s *Stream, data []byte, opts *Options) error {
 		// invoked.
 		if err := t.framer.writeData(forceFlush, s.id, endStream, p); err != nil {
 			t.notifyError(err)
-			return ConnectionErrorf(true, "transport: %v", err)
+			return ConnectionErrorf(true, err, "transport: %v", err)
 		}
 		if t.framer.adjustNumWriters(-1) == 0 {
 			t.framer.flushWrite()
@@ -668,7 +668,7 @@ func (t *http2Client) updateWindow(s *Stream, n uint32) {
 func (t *http2Client) handleData(f *http2.DataFrame) {
 	size := len(f.Data())
 	if err := t.fc.onData(uint32(size)); err != nil {
-		t.notifyError(ConnectionErrorf(true, "%v", err))
+		t.notifyError(ConnectionErrorf(true, err, "%v", err))
 		return
 	}
 	// Select the right stream to dispatch.

--- a/transport/http2_server.go
+++ b/transport/http2_server.go
@@ -111,12 +111,12 @@ func newHTTP2Server(conn net.Conn, maxStreams uint32, authInfo credentials.AuthI
 			Val: uint32(initialWindowSize)})
 	}
 	if err := framer.writeSettings(true, settings...); err != nil {
-		return nil, ConnectionErrorf(true, "transport: %v", err)
+		return nil, ConnectionErrorf(true, err, "transport: %v", err)
 	}
 	// Adjust the connection flow control window if needed.
 	if delta := uint32(initialConnWindowSize - defaultWindowSize); delta > 0 {
 		if err := framer.writeWindowUpdate(true, 0, delta); err != nil {
-			return nil, ConnectionErrorf(true, "transport: %v", err)
+			return nil, ConnectionErrorf(true, err, "transport: %v", err)
 		}
 	}
 	var buf bytes.Buffer
@@ -448,7 +448,7 @@ func (t *http2Server) writeHeaders(s *Stream, b *bytes.Buffer, endStream bool) e
 		}
 		if err != nil {
 			t.Close()
-			return ConnectionErrorf(true, "transport: %v", err)
+			return ConnectionErrorf(true, err, "transport: %v", err)
 		}
 	}
 	return nil
@@ -568,7 +568,7 @@ func (t *http2Server) Write(s *Stream, data []byte, opts *Options) error {
 		}
 		if err := t.framer.writeHeaders(false, p); err != nil {
 			t.Close()
-			return ConnectionErrorf(true, "transport: %v", err)
+			return ConnectionErrorf(true, err, "transport: %v", err)
 		}
 		t.writableChan <- 0
 	}
@@ -642,7 +642,7 @@ func (t *http2Server) Write(s *Stream, data []byte, opts *Options) error {
 		}
 		if err := t.framer.writeData(forceFlush, s.id, false, p); err != nil {
 			t.Close()
-			return ConnectionErrorf(true, "transport: %v", err)
+			return ConnectionErrorf(true, err, "transport: %v", err)
 		}
 		if t.framer.adjustNumWriters(-1) == 0 {
 			t.framer.flushWrite()

--- a/transport/http2_server.go
+++ b/transport/http2_server.go
@@ -111,12 +111,12 @@ func newHTTP2Server(conn net.Conn, maxStreams uint32, authInfo credentials.AuthI
 			Val: uint32(initialWindowSize)})
 	}
 	if err := framer.writeSettings(true, settings...); err != nil {
-		return nil, ConnectionErrorf("transport: %v", err)
+		return nil, ConnectionErrorf(true, "transport: %v", err)
 	}
 	// Adjust the connection flow control window if needed.
 	if delta := uint32(initialConnWindowSize - defaultWindowSize); delta > 0 {
 		if err := framer.writeWindowUpdate(true, 0, delta); err != nil {
-			return nil, ConnectionErrorf("transport: %v", err)
+			return nil, ConnectionErrorf(true, "transport: %v", err)
 		}
 	}
 	var buf bytes.Buffer
@@ -448,7 +448,7 @@ func (t *http2Server) writeHeaders(s *Stream, b *bytes.Buffer, endStream bool) e
 		}
 		if err != nil {
 			t.Close()
-			return ConnectionErrorf("transport: %v", err)
+			return ConnectionErrorf(true, "transport: %v", err)
 		}
 	}
 	return nil
@@ -568,7 +568,7 @@ func (t *http2Server) Write(s *Stream, data []byte, opts *Options) error {
 		}
 		if err := t.framer.writeHeaders(false, p); err != nil {
 			t.Close()
-			return ConnectionErrorf("transport: %v", err)
+			return ConnectionErrorf(true, "transport: %v", err)
 		}
 		t.writableChan <- 0
 	}
@@ -642,7 +642,7 @@ func (t *http2Server) Write(s *Stream, data []byte, opts *Options) error {
 		}
 		if err := t.framer.writeData(forceFlush, s.id, false, p); err != nil {
 			t.Close()
-			return ConnectionErrorf("transport: %v", err)
+			return ConnectionErrorf(true, "transport: %v", err)
 		}
 		if t.framer.adjustNumWriters(-1) == 0 {
 			t.framer.flushWrite()

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -485,18 +485,20 @@ func StreamErrorf(c codes.Code, format string, a ...interface{}) StreamError {
 }
 
 // ConnectionErrorf creates an ConnectionError with the specified error description.
-func ConnectionErrorf(temp bool, format string, a ...interface{}) ConnectionError {
+func ConnectionErrorf(temp bool, e error, format string, a ...interface{}) ConnectionError {
 	return ConnectionError{
-		Desc: fmt.Sprintf(format, a...),
-		temp: temp,
+		Desc:    fmt.Sprintf(format, a...),
+		temp:    temp,
+		origErr: e,
 	}
 }
 
 // ConnectionError is an error that results in the termination of the
 // entire connection and the retry of all the active streams.
 type ConnectionError struct {
-	Desc string
-	temp bool
+	Desc    string
+	temp    bool
+	origErr error
 }
 
 func (e ConnectionError) Error() string {
@@ -506,6 +508,11 @@ func (e ConnectionError) Error() string {
 // Temporary indicates if this connection error is temporary or fatal.
 func (e ConnectionError) Temporary() bool {
 	return e.temp
+}
+
+// OriginalError returns the original error of this connection error.
+func (e ConnectionError) OriginalError() error {
+	return e.origErr
 }
 
 var (

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -512,6 +512,11 @@ func (e ConnectionError) Temporary() bool {
 
 // OriginalError returns the original error of this connection error.
 func (e ConnectionError) OriginalError() error {
+	// Never return nil error here.
+	// If original error is nil, return itself.
+	if e.origErr == nil {
+		return e
+	}
 	return e.origErr
 }
 

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -487,18 +487,18 @@ func StreamErrorf(c codes.Code, format string, a ...interface{}) StreamError {
 // ConnectionErrorf creates an ConnectionError with the specified error description.
 func ConnectionErrorf(temp bool, e error, format string, a ...interface{}) ConnectionError {
 	return ConnectionError{
-		Desc:    fmt.Sprintf(format, a...),
-		temp:    temp,
-		origErr: e,
+		Desc: fmt.Sprintf(format, a...),
+		temp: temp,
+		err:  e,
 	}
 }
 
 // ConnectionError is an error that results in the termination of the
 // entire connection and the retry of all the active streams.
 type ConnectionError struct {
-	Desc    string
-	temp    bool
-	origErr error
+	Desc string
+	temp bool
+	err  error
 }
 
 func (e ConnectionError) Error() string {
@@ -510,14 +510,14 @@ func (e ConnectionError) Temporary() bool {
 	return e.temp
 }
 
-// OriginalError returns the original error of this connection error.
-func (e ConnectionError) OriginalError() error {
+// Origin returns the original error of this connection error.
+func (e ConnectionError) Origin() error {
 	// Never return nil error here.
-	// If original error is nil, return itself.
-	if e.origErr == nil {
+	// If the original error is nil, return itself.
+	if e.err == nil {
 		return e
 	}
-	return e.origErr
+	return e.err
 }
 
 var (

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -485,9 +485,10 @@ func StreamErrorf(c codes.Code, format string, a ...interface{}) StreamError {
 }
 
 // ConnectionErrorf creates an ConnectionError with the specified error description.
-func ConnectionErrorf(format string, a ...interface{}) ConnectionError {
+func ConnectionErrorf(temp bool, format string, a ...interface{}) ConnectionError {
 	return ConnectionError{
 		Desc: fmt.Sprintf(format, a...),
+		temp: temp,
 	}
 }
 
@@ -495,15 +496,21 @@ func ConnectionErrorf(format string, a ...interface{}) ConnectionError {
 // entire connection and the retry of all the active streams.
 type ConnectionError struct {
 	Desc string
+	temp bool
 }
 
 func (e ConnectionError) Error() string {
 	return fmt.Sprintf("connection error: desc = %q", e.Desc)
 }
 
+// Temporary indicates if this connection error is temporary or fatal.
+func (e ConnectionError) Temporary() bool {
+	return e.temp
+}
+
 var (
 	// ErrConnClosing indicates that the transport is closing.
-	ErrConnClosing = ConnectionError{Desc: "transport is closing"}
+	ErrConnClosing = ConnectionError{Desc: "transport is closing", temp: true}
 	// ErrStreamDrain indicates that the stream is rejected by the server because
 	// the server stops accepting new RPCs.
 	ErrStreamDrain = StreamErrorf(codes.Unavailable, "the server stops accepting new RPCs")


### PR DESCRIPTION
fixes #622 
 - `Dial()` with `withblock()` will return error.
  - In the case of bad certificates, it will return the original error received from creds
 - `FailFast` RPCs will return an RPC error (containing error string received from creds)
 - `Non-FailFast` RPCs
  - If balancer is not provided, will return an RPC error (containing error string received from creds)
  - If balancer is provided, will block until timeout