### PR TITLE
Stop go tool from complaining about no buildable files.

### DIFF
--- a/test/nop.go
+++ b/test/nop.go
@@ -1,0 +1,2 @@
+// This file stops the go tool from complaining about no buildable files.
+package grpc


### PR DESCRIPTION
I got the following error when building grpc. Adding a file fixes it.

```
sbunce@obsidian:~/go/src/local$ go install google.golang.org/grpc...
go build google.golang.org/grpc/test: no buildable Go source files in /home/sbunce/go/src/google.golang.org/grpc/test
sbunce@obsidian:~/go/src/local$ echo $?
1
```
