### PR TITLE
WithDialer doesn't support cancellation

### DIFF
--- a/clientconn.go
+++ b/clientconn.go
@@ -196,9 +196,11 @@ func WithTimeout(d time.Duration) DialOption {
 }
 
 // WithDialer returns a DialOption that specifies a function to use for dialing network addresses.
-func WithDialer(f func(string, time.Duration, <-chan struct{}) (net.Conn, error)) DialOption {
+func WithDialer(f func(string, time.Duration) (net.Conn, error)) DialOption {
 	return func(o *dialOptions) {
-		o.copts.Dialer = f
+		o.copts.Dialer = func(addr string, timeout time.Duration, _ <-chan struct{}) (net.Conn, error) {
+			return f(addr, timeout)
+		}
 	}
 }
 

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -314,13 +314,7 @@ func (e env) runnable() bool {
 	return true
 }
 
-func (e env) dialer(addr string, timeout time.Duration, cancel <-chan struct{}) (net.Conn, error) {
-	// NB: Go 1.6 added a Cancel field on net.Dialer, which would allow this
-	// to be written as
-	//
-	// `(&net.Dialer{Cancel: cancel, Timeout: timeout}).Dial(e.network, addr)`
-	//
-	// but that would break compatibility with earlier Go versions.
+func (e env) dialer(addr string, timeout time.Duration) (net.Conn, error) {
 	return net.DialTimeout(e.network, addr, timeout)
 }
 
@@ -511,7 +505,7 @@ func (te *test) declareLogNoise(phrases ...string) {
 }
 
 func (te *test) withServerTester(fn func(st *serverTester)) {
-	c, err := te.e.dialer(te.srvAddr, 10*time.Second, nil)
+	c, err := te.e.dialer(te.srvAddr, 10*time.Second)
 	if err != nil {
 		te.t.Fatal(err)
 	}


### PR DESCRIPTION
This maintains cancellation for the default dialer, but external users
will have to opt in via a future API.

@broady @iamqizhao 