### PR TITLE
Plumb context into ClientConn dialing and ClientHandshake of credentials.

### DIFF
--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -537,9 +537,8 @@ func testTimeoutOnDeadServer(t *testing.T, e env) {
 	te.userAgent = testAppUA
 	te.declareLogNoise(
 		"transport: http2Client.notifyError got notified that the client transport was broken EOF",
-		"grpc: Conn.transportMonitor exits due to: grpc: the client connection is closing",
-		"grpc: Conn.resetTransport failed to create client transport: connection error",
-		"grpc: Conn.resetTransport failed to create client transport: connection error: desc = \"transport: dial unix",
+		"grpc: addrConn.transportMonitor exits due to: grpc: the connection is closing",
+		"grpc: addrConn.resetTransport failed to create client transport: connection error",
 	)
 	te.startServer(&testServer{security: e.security})
 	defer te.tearDown()
@@ -636,9 +635,8 @@ func testServerGoAwayPendingRPC(t *testing.T, e env) {
 	te.userAgent = testAppUA
 	te.declareLogNoise(
 		"transport: http2Client.notifyError got notified that the client transport was broken EOF",
-		"grpc: Conn.transportMonitor exits due to: grpc: the client connection is closing",
-		"grpc: Conn.resetTransport failed to create client transport: connection error",
-		"grpc: Conn.resetTransport failed to create client transport: connection error: desc = \"transport: dial unix",
+		"grpc: addrConn.transportMonitor exits due to: grpc: the connection is closing",
+		"grpc: addrConn.resetTransport failed to create client transport: connection error",
 	)
 	te.startServer(&testServer{security: e.security})
 	defer te.tearDown()
@@ -708,9 +706,8 @@ func testConcurrentClientConnCloseAndServerGoAway(t *testing.T, e env) {
 	te.userAgent = testAppUA
 	te.declareLogNoise(
 		"transport: http2Client.notifyError got notified that the client transport was broken EOF",
-		"grpc: Conn.transportMonitor exits due to: grpc: the client connection is closing",
-		"grpc: Conn.resetTransport failed to create client transport: connection error",
-		"grpc: Conn.resetTransport failed to create client transport: connection error: desc = \"transport: dial unix",
+		"grpc: addrConn.transportMonitor exits due to: grpc: the connection is closing",
+		"grpc: addrConn.resetTransport failed to create client transport: connection error",
 	)
 	te.startServer(&testServer{security: e.security})
 	defer te.tearDown()
@@ -747,9 +744,8 @@ func testConcurrentServerStopAndGoAway(t *testing.T, e env) {
 	te.userAgent = testAppUA
 	te.declareLogNoise(
 		"transport: http2Client.notifyError got notified that the client transport was broken EOF",
-		"grpc: Conn.transportMonitor exits due to: grpc: the client connection is closing",
-		"grpc: Conn.resetTransport failed to create client transport: connection error",
-		"grpc: Conn.resetTransport failed to create client transport: connection error: desc = \"transport: dial unix",
+		"grpc: addrConn.transportMonitor exits due to: grpc: the connection is closing",
+		"grpc: addrConn.resetTransport failed to create client transport: connection error",
 	)
 	te.startServer(&testServer{security: e.security})
 	defer te.tearDown()
@@ -814,9 +810,8 @@ func testFailFast(t *testing.T, e env) {
 	te.userAgent = testAppUA
 	te.declareLogNoise(
 		"transport: http2Client.notifyError got notified that the client transport was broken EOF",
-		"grpc: Conn.transportMonitor exits due to: grpc: the client connection is closing",
-		"grpc: Conn.resetTransport failed to create client transport: connection error",
-		"grpc: Conn.resetTransport failed to create client transport: connection error: desc = \"transport: dial unix",
+		"grpc: addrConn.transportMonitor exits due to: grpc: the connection is closing",
+		"grpc: addrConn.resetTransport failed to create client transport: connection error",
 	)
 	te.startServer(&testServer{security: e.security})
 	defer te.tearDown()
@@ -1851,7 +1846,7 @@ func testExceedMaxStreamsLimit(t *testing.T, e env) {
 	te.declareLogNoise(
 		"http2Client.notifyError got notified that the client transport was broken",
 		"Conn.resetTransport failed to create client transport",
-		"grpc: the client connection is closing",
+		"grpc: the connection is closing",
 	)
 	te.maxStream = 1 // Only allows 1 live stream per server transport.
 	te.startServer(&testServer{security: e.security})
@@ -1892,7 +1887,7 @@ func testStreamsQuotaRecovery(t *testing.T, e env) {
 	te.declareLogNoise(
 		"http2Client.notifyError got notified that the client transport was broken",
 		"Conn.resetTransport failed to create client transport",
-		"grpc: the client connection is closing",
+		"grpc: the connection is closing",
 	)
 	te.maxStream = 1 // Allows 1 live stream.
 	te.startServer(&testServer{security: e.security})

--- a/transport/go16.go
+++ b/transport/go16.go
@@ -1,7 +1,7 @@
-// +build go1.6
+// +build go1.6,!go1.7
 
 /*
- * Copyright 2014, Google Inc.
+ * Copyright 2016, Google Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -36,10 +36,11 @@ package transport
 
 import (
 	"net"
-	"time"
+
+	"golang.org/x/net/context"
 )
 
-// newDialer constructs a net.Dialer.
-func newDialer(timeout time.Duration, cancel <-chan struct{}) *net.Dialer {
-	return &net.Dialer{Cancel: cancel, Timeout: timeout}
+// dialContext connects to the address on the named network.
+func dialContext(ctx context.Context, network, address string) (net.Conn, error) {
+	return (&net.Dialer{Cancel: ctx.Done()}).Dial(network, address)
 }

--- a/transport/go17.go
+++ b/transport/go17.go
@@ -1,4 +1,4 @@
-// +build !go1.6
+// +build go1.7
 
 /*
  * Copyright 2016, Google Inc.
@@ -36,16 +36,11 @@ package transport
 
 import (
 	"net"
-	"time"
 
 	"golang.org/x/net/context"
 )
 
 // dialContext connects to the address on the named network.
 func dialContext(ctx context.Context, network, address string) (net.Conn, error) {
-	var dialer net.Dialer
-	if deadline, ok := ctx.Deadline(); ok {
-		dialer.Timeout = deadline.Sub(time.Now())
-	}
-	return dialer.Dial(network, address)
+	return (&net.Dialer{}).DialContext(ctx, network, address)
 }

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -44,7 +44,6 @@ import (
 	"io"
 	"net"
 	"sync"
-	"time"
 
 	"golang.org/x/net/context"
 	"golang.org/x/net/trace"
@@ -355,22 +354,18 @@ func NewServerTransport(protocol string, conn net.Conn, maxStreams uint32, authI
 type ConnectOptions struct {
 	// UserAgent is the application user agent.
 	UserAgent string
-	// Cancel is closed to indicate that dialing should be cancelled.
-	Cancel chan struct{}
 	// Dialer specifies how to dial a network address.
-	Dialer func(string, time.Duration, <-chan struct{}) (net.Conn, error)
+	Dialer func(context.Context, string) (net.Conn, error)
 	// PerRPCCredentials stores the PerRPCCredentials required to issue RPCs.
 	PerRPCCredentials []credentials.PerRPCCredentials
 	// TransportCredentials stores the Authenticator required to setup a client connection.
 	TransportCredentials credentials.TransportCredentials
-	// Timeout specifies the timeout for dialing a ClientTransport.
-	Timeout time.Duration
 }
 
 // NewClientTransport establishes the transport with the required ConnectOptions
 // and returns it to the caller.
-func NewClientTransport(target string, opts ConnectOptions) (ClientTransport, error) {
-	return newHTTP2Client(target, opts)
+func NewClientTransport(ctx context.Context, target string, opts ConnectOptions) (ClientTransport, error) {
+	return newHTTP2Client(ctx, target, opts)
 }
 
 // Options provides additional hints and information for message

--- a/transport/transport_test.go
+++ b/transport/transport_test.go
@@ -228,7 +228,7 @@ func setUp(t *testing.T, port int, maxStreams uint32, ht hType) (*server, Client
 		ct      ClientTransport
 		connErr error
 	)
-	ct, connErr = NewClientTransport(addr, ConnectOptions{})
+	ct, connErr = NewClientTransport(context.Background(), addr, ConnectOptions{})
 	if connErr != nil {
 		t.Fatalf("failed to create transport: %v", connErr)
 	}


### PR DESCRIPTION
This is a minor breaking change to `TransportCredentials`, however
it should not be a problem in practice as not many users are using
custom implementations. In particular, users of `NewTLS` will not
be affected.

This change also replaces the earlier `Timeout` and` Cancel` fields
with a `context.Context`, which is plumbed all the way down from
`grpc.Dial`, laying the ground work for a user-provided context.

Originally motivated by https://github.com/cockroachdb/cockroach/issues/7793.