### PR TITLE
fix some bugs

### DIFF
--- a/transport/transport.go
+++ b/transport/transport.go
@@ -559,6 +559,12 @@ func wait(ctx context.Context, done, goAway, closing <-chan struct{}, proceed <-
 	case <-closing:
 		return 0, ErrConnClosing
 	case i := <-proceed:
+		// User cancellation has precedence.
+		select {
+		case <-ctx.Done():
+			return 0, ContextErr(ctx.Err())
+		default:
+		}
 		return i, nil
 	}
 }

--- a/transport/transport_test.go
+++ b/transport/transport_test.go
@@ -553,6 +553,7 @@ func TestServerContextCanceledOnClosedConnection(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatalf("Failed to cancel the context of the sever side stream.")
 	}
+	server.stop()
 }
 
 func TestServerWithMisbehavedClient(t *testing.T) {


### PR DESCRIPTION
 - Add server.stop() to one transport test
 - Prioritize ctx.Done() in wait() (so that canceled rpcs will show timeout errors)