### PR TITLE
Revert "fix some bugs"

### DIFF
--- a/transport/transport.go
+++ b/transport/transport.go
@@ -559,12 +559,6 @@ func wait(ctx context.Context, done, goAway, closing <-chan struct{}, proceed <-
 	case <-closing:
 		return 0, ErrConnClosing
 	case i := <-proceed:
-		// User cancellation has precedence.
-		select {
-		case <-ctx.Done():
-			return 0, ContextErr(ctx.Err())
-		default:
-		}
 		return i, nil
 	}
 }

--- a/transport/transport_test.go
+++ b/transport/transport_test.go
@@ -553,7 +553,6 @@ func TestServerContextCanceledOnClosedConnection(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatalf("Failed to cancel the context of the sever side stream.")
 	}
-	server.stop()
 }
 
 func TestServerWithMisbehavedClient(t *testing.T) {


### PR DESCRIPTION
Reverts grpc/grpc-go#799

The change for prioritizing ctx.Done() in proceed is incorrect.  I will have a new PR to replace this one.