### PR TITLE
Fix #804

### DIFF
--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -613,9 +613,9 @@ func testServerGoAway(t *testing.T, e env) {
 		}
 		break
 	}
-	// A new RPC should fail with Unavailable error.
-	if _, err := tc.EmptyCall(context.Background(), &testpb.Empty{}); err == nil || grpc.Code(err) != codes.Unavailable {
-		t.Fatalf("TestService/EmptyCall(_, _) = _, %v, want _, error code: %d", err, codes.Unavailable)
+	// A new RPC should fail.
+	if _, err := tc.EmptyCall(context.Background(), &testpb.Empty{}); grpc.Code(err) != codes.Unavailable && grpc.Code(err) != codes.Internal {
+		t.Fatalf("TestService/EmptyCall(_, _) = _, %v, want _, %s or %s", err, codes.Unavailable, codes.Internal)
 	}
 	<-ch
 	awaitNewConnLogOutput()


### PR DESCRIPTION
When http2Client.GracefulClose is running, the server may already finish all the rpcs in flight and close the connection. In this case, GracefulClose needs to close the transport.

fixes #804 