### PR TITLE
Retry transport creation when ClientHandshake returns EOF

### DIFF
--- a/transport/http2_client.go
+++ b/transport/http2_client.go
@@ -129,8 +129,9 @@ func newHTTP2Client(ctx context.Context, addr string, opts ConnectOptions) (_ Cl
 		conn, authInfo, connErr = creds.ClientHandshake(ctx, addr, conn)
 	}
 	if connErr != nil {
-		// Credentials handshake error is not a temporary error.
-		return nil, ConnectionErrorf(false, connErr, "transport: %v", connErr)
+		// Credentials handshake error is not a temporary error (unless the error
+		// was the connection closing).
+		return nil, ConnectionErrorf(connErr == io.EOF, connErr, "transport: %v", connErr)
 	}
 	defer func() {
 		if err != nil {


### PR DESCRIPTION
I'm not sure if this fix is the right approach, but it fixes the issue we're seeing with our test. I'm happy to add a grpc-specific test if someone can point me towards similar tests that I can base a new one on. 