### PR TITLE
Implement DialContext to afford caller option of managing cancelation

### DIFF
--- a/clientconn.go
+++ b/clientconn.go
@@ -214,9 +214,14 @@ func WithUserAgent(s string) DialOption {
 	}
 }
 
-// Dial creates a client connection the given target.
+// Dial creates a client connection to the given target.
 func Dial(target string, opts ...DialOption) (*ClientConn, error) {
-	ctx := context.Background()
+	return DialContext(context.Background(), target, opts...)
+}
+
+// DialContext creates a client connection to the given target
+// using the supplied context.
+func DialContext(ctx context.Context, target string, opts ...DialOption) (*ClientConn, error) {
 	cc := &ClientConn{
 		target: target,
 		conns:  make(map[Address]*addrConn),

--- a/clientconn_test.go
+++ b/clientconn_test.go
@@ -37,6 +37,8 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/oauth"
 )
@@ -64,6 +66,18 @@ func TestTLSDialTimeout(t *testing.T) {
 	}
 	if err != ErrClientConnTimeout {
 		t.Fatalf("grpc.Dial(_, _) = %v, %v, want %v", conn, err, ErrClientConnTimeout)
+	}
+}
+
+func TestDialContextCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	go cancel()
+	conn, err := DialContext(ctx, "Non-Existent.Server:80", WithBlock(), WithInsecure())
+	if err == nil {
+		conn.Close()
+	}
+	if err != context.Canceled {
+		t.Fatalf("DialContext(_, _) = %v, %v, want %v", conn, err, context.Canceled)
 	}
 }
 


### PR DESCRIPTION
This change is motivated by work on CockroachDB – we need to have control of cancelation for dialing using `WithBlock`.

+cc @tamird 