### PR TITLE
clientconn: return ctx.Err() on getTransport failure if non-nil

### DIFF
--- a/call_test.go
+++ b/call_test.go
@@ -276,3 +276,19 @@ func TestInvokeCancel(t *testing.T) {
 	cc.Close()
 	server.stop()
 }
+
+// TestInvokeCancelClosedNoFail checks that a canceled Invoke with FailFast=false
+// on a closed client will terminate.
+func TestInvokeCancelClosedNoFailFast(t *testing.T) {
+	server, cc := setUp(t, 0, math.MaxUint32)
+	var reply string
+	cc.Close()
+	req := "hello"
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := Invoke(ctx, "/foo/bar", &req, &reply, cc, FailFast(false))
+	if err == nil {
+		t.Fatalf("canceled invoke on closed connection should fail")
+	}
+	server.stop()
+}

--- a/clientconn.go
+++ b/clientconn.go
@@ -506,6 +506,9 @@ func (cc *ClientConn) getTransport(ctx context.Context, opts BalancerGetOptions)
 		if put != nil {
 			put()
 		}
+		if ctx.Err() != nil {
+			return nil, nil, toRPCErr(ctx.Err())
+		}
 		return nil, nil, errConnClosing
 	}
 	t, err := ac.wait(ctx, cc.dopts.balancer != nil, !opts.BlockingWait)


### PR DESCRIPTION
Otherwise, closing the client with FailFast=false causes outstanding RPCs to
spin forever.

/cc @gyuho