### PR TITLE
Retry transport creation on timeouts

### DIFF
--- a/backoff.go
+++ b/backoff.go
@@ -10,7 +10,7 @@ import (
 var (
 	DefaultBackoffConfig = BackoffConfig{
 		MaxDelay:  120 * time.Second,
-		baseDelay: 1.0 * time.Second,
+		BaseDelay: 1.0 * time.Second,
 		factor:    1.6,
 		jitter:    0.2,
 	}
@@ -38,9 +38,9 @@ type BackoffConfig struct {
 	// gRPC decides to allow more interesting backoff strategies, these fields
 	// may be opened up in the future.
 
-	// baseDelay is the amount of time to wait before retrying after the first
+	// BaseDelay is the amount of time to wait before retrying after the first
 	// failure.
-	baseDelay time.Duration
+	BaseDelay time.Duration
 
 	// factor is applied to the backoff after each retry.
 	factor float64
@@ -60,9 +60,9 @@ func setDefaults(bc *BackoffConfig) {
 
 func (bc BackoffConfig) backoff(retries int) (t time.Duration) {
 	if retries == 0 {
-		return bc.baseDelay
+		return bc.BaseDelay
 	}
-	backoff, max := float64(bc.baseDelay), float64(bc.MaxDelay)
+	backoff, max := float64(bc.BaseDelay), float64(bc.MaxDelay)
 	for backoff < max && retries > 0 {
 		backoff *= bc.factor
 		retries--

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -34,6 +34,8 @@
 // the godoc of the top-level grpc package.
 package internal
 
+import "time"
+
 // TestingCloseConns closes all existing transports but keeps
 // grpcServer.lis accepting new connections.
 //
@@ -47,3 +49,6 @@ var TestingCloseConns func(grpcServer interface{})
 // The provided grpcServer must be of type *grpc.Server. It is untyped
 // for circular dependency reasons.
 var TestingUseHandlerImpl func(grpcServer interface{})
+
+// TestingSetMinConnectTimeout allows setting the connection timeout in tests.
+var TestingSetMinConnectTimeout func(time.Duration) func()

--- a/server.go
+++ b/server.go
@@ -849,6 +849,11 @@ func init() {
 	internal.TestingUseHandlerImpl = func(arg interface{}) {
 		arg.(*Server).opts.useHandlerImpl = true
 	}
+	internal.TestingSetMinConnectTimeout = func(timeout time.Duration) func() {
+		before := minConnectTimeout
+		minConnectTimeout = timeout
+		return func() { minConnectTimeout = before }
+	}
 }
 
 // testingCloseConns closes all existing transports but keeps s.lis


### PR DESCRIPTION
 If there is a timeout during the TLS handshake (which is done under
 the same context as the Dial, with a hard-coded 20 second timeout),
 it will be treated as a permanent error, and all future fail-fast
 RPCs will return this error immediately. No further attempts to
 connect will be made unless the ClientConn is closed.

See https://github.com/cockroachdb/cockroach/issues/8694.