### PR TITLE
Detach user-passed context (via DialContext(...)) with the context of ClientConn

### DIFF
--- a/clientconn.go
+++ b/clientconn.go
@@ -224,6 +224,7 @@ func Dial(target string, opts ...DialOption) (*ClientConn, error) {
 // cancel or expire the pending connecting. Once this function returns, the
 // cancellation and expiration of ctx will be noop. Users should call ClientConn.Close
 // to terminate all the pending operations after this function returns.
+// This is the EXPERIMENTAL API.
 func DialContext(ctx context.Context, target string, opts ...DialOption) (*ClientConn, error) {
 	cc := &ClientConn{
 		target: target,
@@ -242,8 +243,6 @@ func DialContext(ctx context.Context, target string, opts ...DialOption) (*Clien
 				cc.Close()
 			default:
 			}
-		case <-cc.ctx.Done():
-			// ClientConn.Close has been called.
 		}
 	}()
 
@@ -296,6 +295,8 @@ func DialContext(ctx context.Context, target string, opts ...DialOption) (*Clien
 		timeoutCh = time.After(cc.dopts.timeout)
 	}
 	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
 	case err := <-waitC:
 		if err != nil {
 			cc.Close()

--- a/clientconn.go
+++ b/clientconn.go
@@ -298,13 +298,15 @@ func DialContext(ctx context.Context, target string, opts ...DialOption) (*Clien
 	case <-ctx.Done():
 		return nil, ctx.Err()
 	case err := <-waitC:
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
 		if err != nil {
 			cc.Close()
 			return nil, err
 		}
-	case <-cc.ctx.Done():
-		cc.Close()
-		return nil, cc.ctx.Err()
 	case <-timeoutCh:
 		cc.Close()
 		return nil, ErrClientConnTimeout

--- a/clientconn_test.go
+++ b/clientconn_test.go
@@ -72,8 +72,8 @@ func TestTLSDialTimeout(t *testing.T) {
 func TestDialContextCancel(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	if _, err := DialContext(ctx, "Non-Existent.Server:80", WithBlock(), WithInsecure()); err != context.Canceled && err != ErrClientConnClosing {
-		t.Fatalf("grpc.DialContext(%v, _) = _, %v, want _, %v or %v", ctx, err, context.Canceled, ErrClientConnClosing)
+	if _, err := DialContext(ctx, "Non-Existent.Server:80", WithBlock(), WithInsecure()); err != context.Canceled {
+		t.Fatalf("grpc.DialContext(%v, _) = _, %v, want _, %v", ctx, err, context.Canceled)
 	}
 }
 

--- a/clientconn_test.go
+++ b/clientconn_test.go
@@ -71,13 +71,9 @@ func TestTLSDialTimeout(t *testing.T) {
 
 func TestDialContextCancel(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	go cancel()
-	conn, err := DialContext(ctx, "Non-Existent.Server:80", WithBlock(), WithInsecure())
-	if err == nil {
-		conn.Close()
-	}
-	if err != context.Canceled {
-		t.Fatalf("DialContext(_, _) = %v, %v, want %v", conn, err, context.Canceled)
+	cancel()
+	if _, err := DialContext(ctx, "Non-Existent.Server:80", WithBlock(), WithInsecure()); err != context.Canceled && err != ErrClientConnClosing {
+		t.Fatalf("grpc.DialContext(%v, _) = _, %v, want _, %v or %v", ctx, err, context.Canceled, ErrClientConnClosing)
 	}
 }
 


### PR DESCRIPTION
fixes #856

@MakMukhi will add the tests in another pull request.