### PR TITLE
Add an err logging to testFailFast

### DIFF
--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -836,9 +836,11 @@ func testFailFast(t *testing.T, e env) {
 	te.srv.Stop()
 	// Loop until the server teardown is propagated to the client.
 	for {
-		if _, err := tc.EmptyCall(context.Background(), &testpb.Empty{}); grpc.Code(err) == codes.Unavailable {
+		_, err := tc.EmptyCall(context.Background(), &testpb.Empty{})
+		if grpc.Code(err) == codes.Unavailable {
 			break
 		}
+		grpclog.Println("%v.EmptyCall(_, _) = _, %v", err)
 		time.Sleep(10 * time.Millisecond)
 	}
 	// The client keeps reconnecting and ongoing fail-fast RPCs should fail with code.Unavailable.

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -840,7 +840,7 @@ func testFailFast(t *testing.T, e env) {
 		if grpc.Code(err) == codes.Unavailable {
 			break
 		}
-		grpclog.Println("%v.EmptyCall(_, _) = _, %v", err)
+		grpclog.Printf("%v.EmptyCall(_, _) = _, %v", err)
 		time.Sleep(10 * time.Millisecond)
 	}
 	// The client keeps reconnecting and ongoing fail-fast RPCs should fail with code.Unavailable.

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -840,7 +840,7 @@ func testFailFast(t *testing.T, e env) {
 		if grpc.Code(err) == codes.Unavailable {
 			break
 		}
-		fmt.Printf("%v.EmptyCall(_, _) = _, %v", err)
+		fmt.Printf("%v.EmptyCall(_, _) = _, %v", tc, err)
 		time.Sleep(10 * time.Millisecond)
 	}
 	// The client keeps reconnecting and ongoing fail-fast RPCs should fail with code.Unavailable.

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -840,7 +840,7 @@ func testFailFast(t *testing.T, e env) {
 		if grpc.Code(err) == codes.Unavailable {
 			break
 		}
-		grpclog.Printf("%v.EmptyCall(_, _) = _, %v", err)
+		fmt.Printf("%v.EmptyCall(_, _) = _, %v", err)
 		time.Sleep(10 * time.Millisecond)
 	}
 	// The client keeps reconnecting and ongoing fail-fast RPCs should fail with code.Unavailable.


### PR DESCRIPTION
provide the info for debugging potential flakiness.