### PR TITLE
Close headerChan if processHeaderField sets error

### DIFF
--- a/transport/http2_client.go
+++ b/transport/http2_client.go
@@ -852,6 +852,12 @@ func (t *http2Client) operateHeaders(frame *http2.MetaHeadersFrame) {
 		state.processHeaderField(hf)
 	}
 	if state.err != nil {
+		s.mu.Lock()
+		if !s.headerDone {
+			close(s.headerChan)
+			s.headerDone = true
+		}
+		s.mu.Unlock()
 		s.write(recvMsg{err: state.err})
 		// Something wrong. Stops reading even when there is remaining.
 		return

--- a/transport/transport_test.go
+++ b/transport/transport_test.go
@@ -40,12 +40,14 @@ import (
 	"math"
 	"net"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	"golang.org/x/net/context"
 	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/hpack"
 	"google.golang.org/grpc/codes"
 )
 
@@ -58,14 +60,15 @@ type server struct {
 }
 
 var (
-	expectedRequest       = []byte("ping")
-	expectedResponse      = []byte("pong")
-	expectedRequestLarge  = make([]byte, initialWindowSize*2)
-	expectedResponseLarge = make([]byte, initialWindowSize*2)
+	expectedRequest            = []byte("ping")
+	expectedResponse           = []byte("pong")
+	expectedRequestLarge       = make([]byte, initialWindowSize*2)
+	expectedResponseLarge      = make([]byte, initialWindowSize*2)
+	expectedInvalidHeaderField = "invalid/content-type"
 )
 
 type testStreamHandler struct {
-	t ServerTransport
+	t *http2Server
 }
 
 type hType int
@@ -75,6 +78,7 @@ const (
 	suspended
 	misbehaved
 	encodingRequiredStatus
+	invalidHeaderField
 )
 
 func (h *testStreamHandler) handleStream(t *testing.T, s *Stream) {
@@ -140,6 +144,16 @@ func (h *testStreamHandler) handleStreamEncodingRequiredStatus(t *testing.T, s *
 	h.t.WriteStatus(s, encodingTestStatusCode, encodingTestStatusDesc)
 }
 
+func (h *testStreamHandler) handleStreamInvalidHeaderField(t *testing.T, s *Stream) {
+	<-h.t.writableChan
+	h.t.hBuf.Reset()
+	h.t.hEnc.WriteField(hpack.HeaderField{Name: "content-type", Value: expectedInvalidHeaderField})
+	if err := h.t.writeHeaders(s, h.t.hBuf, false); err != nil {
+		t.Fatalf("Failed to write headers: %v", err)
+	}
+	h.t.writableChan <- 0
+}
+
 // start starts server. Other goroutines should block on s.readyChan for further operations.
 func (s *server) start(t *testing.T, port int, maxStreams uint32, ht hType) {
 	var err error
@@ -177,7 +191,7 @@ func (s *server) start(t *testing.T, port int, maxStreams uint32, ht hType) {
 		}
 		s.conns[transport] = true
 		s.mu.Unlock()
-		h := &testStreamHandler{transport}
+		h := &testStreamHandler{transport.(*http2Server)}
 		switch ht {
 		case suspended:
 			go transport.HandleStreams(h.handleStreamSuspension)
@@ -188,6 +202,10 @@ func (s *server) start(t *testing.T, port int, maxStreams uint32, ht hType) {
 		case encodingRequiredStatus:
 			go transport.HandleStreams(func(s *Stream) {
 				go h.handleStreamEncodingRequiredStatus(t, s)
+			})
+		case invalidHeaderField:
+			go transport.HandleStreams(func(s *Stream) {
+				go h.handleStreamInvalidHeaderField(t, s)
 			})
 		default:
 			go transport.HandleStreams(func(s *Stream) {
@@ -747,6 +765,32 @@ func TestEncodingRequiredStatus(t *testing.T) {
 	}
 	if s.StatusCode() != encodingTestStatusCode || s.StatusDesc() != encodingTestStatusDesc {
 		t.Fatalf("stream with status code %d, status desc %v, want %d, %v", s.StatusCode(), s.StatusDesc(), encodingTestStatusCode, encodingTestStatusDesc)
+	}
+	ct.Close()
+	server.stop()
+}
+
+func TestInvalidHeaderField(t *testing.T) {
+	server, ct := setUp(t, 0, math.MaxUint32, invalidHeaderField)
+	callHdr := &CallHdr{
+		Host:   "localhost",
+		Method: "foo",
+	}
+	s, err := ct.NewStream(context.Background(), callHdr)
+	if err != nil {
+		return
+	}
+	opts := Options{
+		Last:  true,
+		Delay: false,
+	}
+	if err := ct.Write(s, expectedRequest, &opts); err != nil && err != io.EOF {
+		t.Fatalf("Failed to write the request: %v", err)
+	}
+	p := make([]byte, http2MaxFrameLen)
+	_, err = s.dec.Read(p)
+	if se, ok := err.(StreamError); !ok || se.Code != codes.FailedPrecondition || !strings.Contains(err.Error(), expectedInvalidHeaderField) {
+		t.Fatalf("Read got error %v, want error with code %s and contains %q", err, codes.FailedPrecondition, expectedInvalidHeaderField)
 	}
 	ct.Close()
 	server.stop()


### PR DESCRIPTION
If a client receives an invalid header (invalid content-type for example), the client should fail immediately with an error (error code FailedPrecondition in the case of invalid content-type).