### PR TITLE
[API revision] Change TransportCredentials interface

### DIFF
--- a/credentials/credentials_test.go
+++ b/credentials/credentials_test.go
@@ -1,0 +1,61 @@
+/*
+ *
+ * Copyright 2016, Google Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+package credentials
+
+import (
+	"testing"
+)
+
+func TestTLSOverrideServerName(t *testing.T) {
+	expectedServerName := "server.name"
+	c := NewTLS(nil)
+	c.OverrideServerName(expectedServerName)
+	if c.Info().ServerName != expectedServerName {
+		t.Fatalf("c.Info().ServerName = %v, want %v", c.Info().ServerName, expectedServerName)
+	}
+}
+
+func TestTLSClone(t *testing.T) {
+	expectedServerName := "server.name"
+	c := NewTLS(nil)
+	c.OverrideServerName(expectedServerName)
+	cc := c.Clone()
+	if cc.Info().ServerName != expectedServerName {
+		t.Fatalf("cc.Info().ServerName = %v, want %v", cc.Info().ServerName, expectedServerName)
+	}
+	cc.OverrideServerName("")
+	if c.Info().ServerName != expectedServerName {
+		t.Fatalf("Change in clone should not affect the original, c.Info().ServerName = %v, want %v", c.Info().ServerName, expectedServerName)
+	}
+}

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -2450,6 +2450,12 @@ func (c clientAlwaysFailCred) ServerHandshake(rawConn net.Conn) (net.Conn, crede
 func (c clientAlwaysFailCred) Info() credentials.ProtocolInfo {
 	return credentials.ProtocolInfo{}
 }
+func (c clientAlwaysFailCred) Clone() credentials.TransportCredentials {
+	return nil
+}
+func (c clientAlwaysFailCred) OverrideServerName(s string) error {
+	return nil
+}
 
 func TestDialWithBlockErrorOnBadCertificates(t *testing.T) {
 	te := newTest(t, env{name: "bad-cred", network: "tcp", security: "clientAlwaysFailCred", balancer: true})
@@ -2520,6 +2526,12 @@ func (c *clientTimeoutCreds) ServerHandshake(rawConn net.Conn) (net.Conn, creden
 func (c *clientTimeoutCreds) Info() credentials.ProtocolInfo {
 	return credentials.ProtocolInfo{}
 }
+func (c *clientTimeoutCreds) Clone() credentials.TransportCredentials {
+	return nil
+}
+func (c *clientTimeoutCreds) OverrideServerName(s string) error {
+	return nil
+}
 
 func TestNonFailFastRPCSucceedOnTimeoutCreds(t *testing.T) {
 	te := newTest(t, env{name: "timeout-cred", network: "tcp", security: "clientTimeoutCreds", balancer: false})
@@ -2555,6 +2567,12 @@ func (c *serverDispatchCred) ServerHandshake(rawConn net.Conn) (net.Conn, creden
 }
 func (c *serverDispatchCred) Info() credentials.ProtocolInfo {
 	return credentials.ProtocolInfo{}
+}
+func (c *serverDispatchCred) Clone() credentials.TransportCredentials {
+	return nil
+}
+func (c *serverDispatchCred) OverrideServerName(s string) error {
+	return nil
 }
 func (c *serverDispatchCred) getRawConn() net.Conn {
 	<-c.ready


### PR DESCRIPTION
Add two functions `Clone()` and `OverrideServerName()` to the interface `TransportCredentials`.
This change should have no influence if you don't implement your custom credentials.

This is in preparation for grpclb.