### PR TITLE
Add metadata.Join

### DIFF
--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -117,10 +117,14 @@ func (md MD) Len() int {
 
 // Copy returns a copy of md.
 func (md MD) Copy() MD {
+	return join(md)
+}
+
+func join(mds ...MD) MD {
 	out := MD{}
-	for k, v := range md {
-		for _, i := range v {
-			out[k] = append(out[k], i)
+	for _, md := range mds {
+		for k, v := range md {
+			out[k] = append(out[k], v...)
 		}
 	}
 	return out
@@ -130,6 +134,9 @@ type mdKey struct{}
 
 // NewContext creates a new context with md attached.
 func NewContext(ctx context.Context, md MD) context.Context {
+	if old, ok := FromContext(ctx); ok {
+		return context.WithValue(ctx, mdKey{}, join(old, md))
+	}
 	return context.WithValue(ctx, mdKey{}, md)
 }
 

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -117,10 +117,13 @@ func (md MD) Len() int {
 
 // Copy returns a copy of md.
 func (md MD) Copy() MD {
-	return join(md)
+	return Join(md)
 }
 
-func join(mds ...MD) MD {
+// Join joins any number of MDs into a single MD.
+// The order of values for each key is determined by the order in which
+// the MDs containing those values are presented to Join.
+func Join(mds ...MD) MD {
 	out := MD{}
 	for _, md := range mds {
 		for k, v := range md {
@@ -134,9 +137,6 @@ type mdKey struct{}
 
 // NewContext creates a new context with md attached.
 func NewContext(ctx context.Context, md MD) context.Context {
-	if old, ok := FromContext(ctx); ok {
-		return context.WithValue(ctx, mdKey{}, join(old, md))
-	}
 	return context.WithValue(ctx, mdKey{}, md)
 }
 

--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -36,8 +36,6 @@ package metadata
 import (
 	"reflect"
 	"testing"
-
-	"golang.org/x/net/context"
 )
 
 const binaryValue = string(128)
@@ -123,24 +121,18 @@ func TestCopy(t *testing.T) {
 	}
 }
 
-func TestContext(t *testing.T) {
-	ctx := context.Background()
-	if md, ok := FromContext(ctx); len(md) != 0 || ok {
-		t.Errorf("found (%v, %t), want (%v, %t)", md, ok, nil, false)
-	}
-
+func TestJoin(t *testing.T) {
 	for _, test := range []struct {
-		add, want MD
+		mds  []MD
+		want MD
 	}{
-		{Pairs("foo", "bar"), Pairs("foo", "bar")},
-		{Pairs("foo", "baz"), Pairs("foo", "bar", "foo", "baz")},
-		{Pairs("zip", "zap"), Pairs("foo", "bar", "foo", "baz", "zip", "zap")},
+		{[]MD{}, MD{}},
+		{[]MD{Pairs("foo", "bar")}, Pairs("foo", "bar")},
+		{[]MD{Pairs("foo", "bar"), Pairs("foo", "baz")}, Pairs("foo", "bar", "foo", "baz")},
+		{[]MD{Pairs("foo", "bar"), Pairs("foo", "baz"), Pairs("zip", "zap")}, Pairs("foo", "bar", "foo", "baz", "zip", "zap")},
 	} {
-		ctx = NewContext(ctx, test.add)
-		md, ok := FromContext(ctx)
-		if !ok {
-			t.Errorf("context missing metadata after adding %v", test.add)
-		} else if !reflect.DeepEqual(md, test.want) {
+		md := Join(test.mds...)
+		if !reflect.DeepEqual(md, test.want) {
 			t.Errorf("context's metadata is %v, want %v", md, test.want)
 		}
 	}


### PR DESCRIPTION
Previously metadata.NewContext(ctx, md) replaces whatever metadata in
ctx with md.
This patch merges the old metadata with md before returning the new
context.

Fixes #902.