### PR TITLE
get more metrics from go benchmark servers

### DIFF
--- a/benchmark/worker/benchmark_client.go
+++ b/benchmark/worker/benchmark_client.go
@@ -37,8 +37,8 @@ import (
 	"math"
 	"runtime"
 	"sync"
-	"time"
 	"syscall"
+	"time"
 
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"

--- a/benchmark/worker/benchmark_client.go
+++ b/benchmark/worker/benchmark_client.go
@@ -355,7 +355,7 @@ func (bc *benchmarkClient) doCloseLoopStreaming(conns []*grpc.ClientConn, rpcCou
 // getStats returns the stats for benchmark client.
 // It resets lastResetTime and all histograms if argument reset is true.
 func (bc *benchmarkClient) getStats(reset bool) *testpb.ClientStats {
-	var timeElapsed, elapsedUserCPU, elapsedSystemCPU float64
+	var timeElapsed, elapseUtime, elapseStime float64
 	mergedHistogram := stats.NewHistogram(bc.histogramOptions)
 	latestRusage := new(syscall.Rusage)
 
@@ -373,7 +373,7 @@ func (bc *benchmarkClient) getStats(reset bool) *testpb.ClientStats {
 
 		timeElapsed = time.Since(bc.lastResetTime).Seconds()
 		syscall.Getrusage(syscall.RUSAGE_SELF, latestRusage)
-		elapsedUserCPU, elapsedSystemCPU = cpuTimeDiff(bc.rusageLastReset, latestRusage)
+		elapseUtime, elapseStime = cpuTimeDiff(bc.rusageLastReset, latestRusage)
 
 		bc.rusageLastReset = latestRusage
 		bc.lastResetTime = time.Now()
@@ -385,7 +385,7 @@ func (bc *benchmarkClient) getStats(reset bool) *testpb.ClientStats {
 
 		timeElapsed = time.Since(bc.lastResetTime).Seconds()
 		syscall.Getrusage(syscall.RUSAGE_SELF, latestRusage)
-		elapsedUserCPU, elapsedSystemCPU = cpuTimeDiff(bc.rusageLastReset, latestRusage)
+		elapseUtime, elapseStime = cpuTimeDiff(bc.rusageLastReset, latestRusage)
 	}
 
 	b := make([]uint32, len(mergedHistogram.Buckets), len(mergedHistogram.Buckets))
@@ -402,8 +402,8 @@ func (bc *benchmarkClient) getStats(reset bool) *testpb.ClientStats {
 			Count:        float64(mergedHistogram.Count),
 		},
 		TimeElapsed: timeElapsed,
-		TimeUser:    elapsedUserCPU,
-		TimeSystem:  elapsedSystemCPU,
+		TimeUser:    elapseUtime,
+		TimeSystem:  elapseStime,
 	}
 }
 

--- a/benchmark/worker/benchmark_server.go
+++ b/benchmark/worker/benchmark_server.go
@@ -175,18 +175,18 @@ func startBenchmarkServer(config *testpb.ServerConfig, serverPort int) (*benchma
 func (bs *benchmarkServer) getStats(reset bool) *testpb.ServerStats {
 	bs.mu.RLock()
 	defer bs.mu.RUnlock()
-	timeElapsed := time.Since(bs.lastResetTime).Seconds()
+	wallTimeElapsed := time.Since(bs.lastResetTime).Seconds()
 	rusageLatest := new(syscall.Rusage)
 	syscall.Getrusage(syscall.RUSAGE_SELF, rusageLatest)
-	elapsedUtime, elapsedStime := cpuTimeDiff(bs.rusageLastReset, rusageLatest)
+	uTimeElapsed, sTimeElapsed := cpuTimeDiff(bs.rusageLastReset, rusageLatest)
 
 	if reset {
 		bs.lastResetTime = time.Now()
 		bs.rusageLastReset = rusageLatest
 	}
 	return &testpb.ServerStats{
-		TimeElapsed: timeElapsed,
-		TimeUser:    elapsedUtime,
-		TimeSystem:  elapsedStime,
+		TimeElapsed: wallTimeElapsed,
+		TimeUser:    uTimeElapsed,
+		TimeSystem:  sTimeElapsed,
 	}
 }

--- a/benchmark/worker/benchmark_server.go
+++ b/benchmark/worker/benchmark_server.go
@@ -38,8 +38,8 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"time"
 	"syscall"
+	"time"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/benchmark"
@@ -56,12 +56,12 @@ var (
 )
 
 type benchmarkServer struct {
-	port             int
-	cores            int
-	closeFunc        func()
-	mu               sync.RWMutex
-	lastResetTime    time.Time
-	rusageLastReset  *syscall.Rusage
+	port            int
+	cores           int
+	closeFunc       func()
+	mu              sync.RWMutex
+	lastResetTime   time.Time
+	rusageLastReset *syscall.Rusage
 }
 
 func printServerConfig(config *testpb.ServerConfig) {
@@ -181,7 +181,7 @@ func (bs *benchmarkServer) getStats(reset bool) *testpb.ServerStats {
 	}
 	return &testpb.ServerStats{
 		TimeElapsed: timeElapsed,
-		TimeUser: elapsedUserCPU,
-		TimeSystem: elapsedSystemCPU,
+		TimeUser:    elapsedUserCPU,
+		TimeSystem:  elapsedSystemCPU,
 	}
 }

--- a/benchmark/worker/main.go
+++ b/benchmark/worker/main.go
@@ -38,6 +38,8 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"net/http"
+	_ "net/http/pprof"
 	"runtime"
 	"strconv"
 	"time"
@@ -50,8 +52,10 @@ import (
 )
 
 var (
-	driverPort = flag.Int("driver_port", 10000, "port for communication with driver")
-	serverPort = flag.Int("server_port", 0, "port for benchmark server if not specified by server config message")
+	driverPort    = flag.Int("driver_port", 10000, "port for communication with driver")
+	serverPort    = flag.Int("server_port", 0, "port for benchmark server if not specified by server config message")
+	pprofPort     = flag.Int("pprof_port", 6060, "port for pprof debug server to listen on")
+	blockProfRate = flag.Int("block_prof_rate", 0, "fraction of goroutine blocking events to report in blocking profile")
 )
 
 type byteBufCodec struct {
@@ -225,6 +229,13 @@ func main() {
 		// TODO revise this once server graceful stop is supported in gRPC.
 		time.Sleep(time.Second)
 		s.Stop()
+	}()
+
+	runtime.SetBlockProfileRate(*blockProfRate)
+
+	go func() {
+		grpclog.Println("Starting pprof server on port " + strconv.FormatInt(int64(*pprofPort), 10))
+		grpclog.Println(http.ListenAndServe("localhost:"+strconv.FormatInt(int64(*pprofPort), 10), nil))
 	}()
 
 	s.Serve(lis)

--- a/benchmark/worker/main.go
+++ b/benchmark/worker/main.go
@@ -54,7 +54,7 @@ import (
 var (
 	driverPort    = flag.Int("driver_port", 10000, "port for communication with driver")
 	serverPort    = flag.Int("server_port", 0, "port for benchmark server if not specified by server config message")
-	pprofPort     = flag.Int("pprof_port", 6060, "port for pprof debug server to listen on")
+	pprofPort     = flag.Int("pprof_port", -1, "Port for pprof debug server to listen on. Pprof server doesn't start if unset")
 	blockProfRate = flag.Int("block_prof_rate", 0, "fraction of goroutine blocking events to report in blocking profile")
 )
 
@@ -233,10 +233,12 @@ func main() {
 
 	runtime.SetBlockProfileRate(*blockProfRate)
 
-	go func() {
-		grpclog.Println("Starting pprof server on port " + strconv.FormatInt(int64(*pprofPort), 10))
-		grpclog.Println(http.ListenAndServe("localhost:"+strconv.FormatInt(int64(*pprofPort), 10), nil))
-	}()
+	if *pprofPort >= 0 {
+		go func() {
+			grpclog.Println("Starting pprof server on port " + strconv.Itoa(*pprofPort))
+			grpclog.Println(http.ListenAndServe("localhost:"+strconv.Itoa(*pprofPort), nil))
+		}()
+	}
 
 	s.Serve(lis)
 }

--- a/benchmark/worker/util.go
+++ b/benchmark/worker/util.go
@@ -54,15 +54,17 @@ func abs(rel string) string {
 }
 
 func cpuTimeDiff(first *syscall.Rusage, latest *syscall.Rusage) (float64, float64) {
-	var utimeDiffSec = latest.Utime.Sec - first.Utime.Sec
-	var utimeDiffMicro = latest.Utime.Usec - first.Utime.Usec
-	var stimeDiffSec = latest.Stime.Sec - first.Stime.Sec
-	var stimeDiffMicro = latest.Stime.Usec - first.Stime.Usec
+	var (
+		utimeDiffs  = latest.Utime.Sec - first.Utime.Sec
+		utimeDiffus = latest.Utime.Usec - first.Utime.Usec
+		stimeDiffs  = latest.Stime.Sec - first.Stime.Sec
+		stimeDiffus = latest.Stime.Usec - first.Stime.Usec
+	)
 
-	var elapsedUserCPU = float64(utimeDiffSec) + float64(utimeDiffMicro)*1.0e-6
-	var elapsedSystemCPU = float64(stimeDiffSec) + float64(stimeDiffMicro)*1.0e-6
+	elapseUtime := float64(utimeDiffs) + float64(utimeDiffus)*1.0e-6
+	elapseStime := float64(stimeDiffs) + float64(stimeDiffus)*1.0e-6
 
-	return elapsedUserCPU, elapsedSystemCPU
+	return elapseUtime, elapseStime
 }
 
 func goPackagePath(pkg string) (path string, err error) {

--- a/benchmark/worker/util.go
+++ b/benchmark/worker/util.go
@@ -59,8 +59,8 @@ func cpuTimeDiff(first *syscall.Rusage, latest *syscall.Rusage) (float64, float6
 	var stimeDiffSec = latest.Stime.Sec - first.Stime.Sec
 	var stimeDiffMicro = latest.Stime.Usec - first.Stime.Usec
 
-	var elapsedUserCPU = float64(utimeDiffSec) + float64(utimeDiffMicro) * 1.0e-6
-	var elapsedSystemCPU = float64(stimeDiffSec) + float64(stimeDiffMicro) * 1.0e-6
+	var elapsedUserCPU = float64(utimeDiffSec) + float64(utimeDiffMicro)*1.0e-6
+	var elapsedSystemCPU = float64(stimeDiffSec) + float64(stimeDiffMicro)*1.0e-6
 
 	return elapsedUserCPU, elapsedSystemCPU
 }

--- a/benchmark/worker/util.go
+++ b/benchmark/worker/util.go
@@ -36,6 +36,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"syscall"
 )
 
 // abs returns the absolute path the given relative file or directory path,
@@ -50,6 +51,18 @@ func abs(rel string) string {
 		log.Fatalf("Error finding google.golang.org/grpc/testdata directory: %v", err)
 	}
 	return filepath.Join(v, rel)
+}
+
+func cpuTimeDiff(first *syscall.Rusage, latest *syscall.Rusage) (float64, float64) {
+	var utimeDiffSec = latest.Utime.Sec - first.Utime.Sec
+	var utimeDiffMicro = latest.Utime.Usec - first.Utime.Usec
+	var stimeDiffSec = latest.Stime.Sec - first.Stime.Sec
+	var stimeDiffMicro = latest.Stime.Usec - first.Stime.Usec
+
+	var elapsedUserCPU = float64(utimeDiffSec) + float64(utimeDiffMicro) * 1.0e-6
+	var elapsedSystemCPU = float64(stimeDiffSec) + float64(stimeDiffMicro) * 1.0e-6
+
+	return elapsedUserCPU, elapsedSystemCPU
 }
 
 func goPackagePath(pkg string) (path string, err error) {

--- a/benchmark/worker/util.go
+++ b/benchmark/worker/util.go
@@ -61,10 +61,10 @@ func cpuTimeDiff(first *syscall.Rusage, latest *syscall.Rusage) (float64, float6
 		stimeDiffus = latest.Stime.Usec - first.Stime.Usec
 	)
 
-	elapseUtime := float64(utimeDiffs) + float64(utimeDiffus)*1.0e-6
-	elapseStime := float64(stimeDiffs) + float64(stimeDiffus)*1.0e-6
+	uTimeElapsed := float64(utimeDiffs) + float64(utimeDiffus)*1.0e-6
+	sTimeElapsed := float64(stimeDiffs) + float64(stimeDiffus)*1.0e-6
 
-	return elapseUtime, elapseStime
+	return uTimeElapsed, sTimeElapsed
 }
 
 func goPackagePath(pkg string) (path string, err error) {


### PR DESCRIPTION
Adds user and system cpu time to go benchmarks. A run that shows the number results is scheduled in https://grpc-testing.appspot.com/job/gRPC_performance_adhoc/

The results I got locally showed a lot more cpu spent on the client. cc @ctiller 
