### PR TITLE
Skip golint in go 1.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,12 @@ go:
 go_import_path: google.golang.org/grpc
 
 before_install:
-  - go get -u golang.org/x/tools/cmd/goimports github.com/golang/lint/golint github.com/axw/gocov/gocov github.com/mattn/goveralls golang.org/x/tools/cmd/cover
+  - if [[ $TRAVIS_GO_VERSION != 1.5* ]]; then go get github.com/golang/lint/golint; fi
+  - go get -u golang.org/x/tools/cmd/goimports github.com/axw/gocov/gocov github.com/mattn/goveralls golang.org/x/tools/cmd/cover
 
 script:
   - '! gofmt -s -d -l . 2>&1 | read'
   - '! goimports -l . | read'
-  - '! golint ./... | grep -vE "(_string|\.pb)\.go:"'
+  - 'if [[ $TRAVIS_GO_VERSION != 1.5* ]]; then ! golint ./... | grep -vE "(_string|\.pb)\.go:"; fi'
   - '! go tool vet -all . 2>&1 | grep -vE "constant [0-9]+ not a string in call to Errorf" | grep -vF .pb.go:' # https://github.com/golang/protobuf/issues/214
   - make test testrace


### PR DESCRIPTION
golint stopped supporting go1.5
https://github.com/golang/lint/issues/246