### PR TITLE
Add an error handling to "greeter_server"

### DIFF
--- a/examples/helloworld/greeter_server/main.go
+++ b/examples/helloworld/greeter_server/main.go
@@ -61,5 +61,7 @@ func main() {
 	}
 	s := grpc.NewServer()
 	pb.RegisterGreeterServer(s, &server{})
-	s.Serve(lis)
+	if err := s.Serve(lis); err != nil {
+		log.Fatalf("failed to serve: %v", err)
+	}
 }


### PR DESCRIPTION
Added an error handling to `examples/helloworld/greeter_server/main.go` because `*grpc.Server`'s `Serve` method returns an error and it should be handled.