### PR TITLE
Removed the unused named return parameter from `BackoffConfig`'s `backoff` method

### DIFF
--- a/backoff.go
+++ b/backoff.go
@@ -58,7 +58,7 @@ func setDefaults(bc *BackoffConfig) {
 	}
 }
 
-func (bc BackoffConfig) backoff(retries int) (t time.Duration) {
+func (bc BackoffConfig) backoff(retries int) time.Duration {
 	if retries == 0 {
 		return bc.baseDelay
 	}


### PR DESCRIPTION
Removed the unused named return parameter from `BackoffConfig`'s `backoff` method.