### PR TITLE
Make concurrent Server.GracefulStop calls all behave equivalently

### DIFF
--- a/server.go
+++ b/server.go
@@ -527,7 +527,7 @@ func (s *Server) removeConn(c io.Closer) {
 	defer s.mu.Unlock()
 	if s.conns != nil {
 		delete(s.conns, c)
-		s.cv.Signal()
+		s.cv.Broadcast()
 	}
 }
 
@@ -828,7 +828,7 @@ func (s *Server) Stop() {
 	st := s.conns
 	s.conns = nil
 	// interrupt GracefulStop if Stop and GracefulStop are called concurrently.
-	s.cv.Signal()
+	s.cv.Broadcast()
 	s.mu.Unlock()
 
 	for lis := range listeners {
@@ -852,7 +852,7 @@ func (s *Server) Stop() {
 func (s *Server) GracefulStop() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if s.drain == true || s.conns == nil {
+	if s.conns == nil {
 		return
 	}
 	s.drain = true

--- a/server.go
+++ b/server.go
@@ -855,14 +855,16 @@ func (s *Server) GracefulStop() {
 	if s.conns == nil {
 		return
 	}
-	s.drain = true
 	for lis := range s.lis {
 		lis.Close()
 	}
 	s.lis = nil
 	s.cancel()
-	for c := range s.conns {
-		c.(transport.ServerTransport).Drain()
+	if !s.drain {
+		for c := range s.conns {
+			c.(transport.ServerTransport).Drain()
+		}
+		s.drain = true
 	}
 	for len(s.conns) != 0 {
 		s.cv.Wait()


### PR DESCRIPTION
replaces #903

This PR lets all concurrent GracefulStop calls proceed to the Wait, and ensures they are all woken up when the server is stopped.