### PR TITLE
Disable handler-tls in end2end tests

### DIFF
--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -378,7 +378,8 @@ var (
 	unixTLSEnv    = env{name: "unix-tls", network: "unix", security: "tls", balancer: true}
 	handlerEnv    = env{name: "handler-tls", network: "tcp", security: "tls", httpHandler: true, balancer: true}
 	noBalancerEnv = env{name: "no-balancer", network: "tcp", security: "tls", balancer: false}
-	allEnv        = []env{tcpClearEnv, tcpTLSEnv, unixClearEnv, unixTLSEnv, handlerEnv, noBalancerEnv}
+	// TODO add handlerEnv back when ServeHTTP is stable.
+	allEnv = []env{tcpClearEnv, tcpTLSEnv, unixClearEnv, unixTLSEnv /*handlerEnv,*/, noBalancerEnv}
 )
 
 var onlyEnv = flag.String("only_env", "", "If non-empty, one of 'tcp-clear', 'tcp-tls', 'unix-clear', 'unix-tls', or 'handler-tls' to only run the tests for that environment. Empty means all.")


### PR DESCRIPTION
Some end2end tests using ServeHTTP failed with DATA RACE:
https://travis-ci.org/grpc/grpc-go/jobs/169080239
https://travis-ci.org/grpc/grpc-go/jobs/169080240
https://travis-ci.org/grpc/grpc-go/jobs/169080236
probably due to the recent change https://github.com/golang/net/commit/3bafa3320efdf0c95d056586aa9abdd05ad72ee1

It seems http2 package is not stable enough.
Disable tests for ServeHTTP in end2end tests until it's stable.