### PR TITLE
change protoCodec to use a protobuf buffer and reuse on marshalling

### DIFF
--- a/clientconn.go
+++ b/clientconn.go
@@ -265,7 +265,7 @@ func DialContext(ctx context.Context, target string, opts ...DialOption) (conn *
 
 	// Set defaults.
 	if cc.dopts.codec == nil {
-		cc.dopts.codec = protoCodec{}
+		cc.dopts.codec = NewProtoCodec()
 	}
 	if cc.dopts.bs == nil {
 		cc.dopts.bs = DefaultBackoffConfig

--- a/server.go
+++ b/server.go
@@ -196,7 +196,7 @@ func NewServer(opt ...ServerOption) *Server {
 	}
 	if opts.codec == nil {
 		// Set the default codec.
-		opts.codec = protoCodec{}
+		opts.codec = NewProtoCodec()
 	}
 	s := &Server{
 		lis:   make(map[net.Listener]bool),
@@ -685,11 +685,18 @@ func (s *Server) processStreamingRPC(t transport.ServerTransport, stream *transp
 	if s.opts.cp != nil {
 		stream.SetSendCompress(s.opts.cp.Type())
 	}
+	var newCD Codec
+	switch s.opts.codec.(type) {
+	case *protoCodec:
+		newCD = NewProtoCodec()
+	default:
+		newCD = s.opts.codec
+	}
 	ss := &serverStream{
 		t:          t,
 		s:          stream,
 		p:          &parser{r: stream},
-		codec:      s.opts.codec,
+		codec:      newCD,
 		cp:         s.opts.cp,
 		dc:         s.opts.dc,
 		maxMsgSize: s.opts.maxMsgSize,

--- a/stream.go
+++ b/stream.go
@@ -179,11 +179,18 @@ func newClientStream(ctx context.Context, desc *StreamDesc, cc *ClientConn, meth
 		}
 		break
 	}
+	var newCD Codec
+	switch cc.dopts.codec.(type) {
+	case *protoCodec:
+		newCD = NewProtoCodec()
+	default:
+		newCD = cc.dopts.codec
+	}
 	cs := &clientStream{
 		opts:  opts,
 		c:     c,
 		desc:  desc,
-		codec: cc.dopts.codec,
+		codec: newCD,
 		cp:    cc.dopts.cp,
 		dc:    cc.dopts.dc,
 
@@ -305,7 +312,8 @@ func (cs *clientStream) SendMsg(m interface{}) (err error) {
 	if err != nil {
 		return Errorf(codes.Internal, "grpc: %v", err)
 	}
-	return cs.t.Write(cs.s, out, &transport.Options{Last: false})
+	err = cs.t.Write(cs.s, out, &transport.Options{Last: false})
+	return err
 }
 
 func (cs *clientStream) RecvMsg(m interface{}) (err error) {


### PR DESCRIPTION
Note this is not ready to be merged as of now.
This a first proposal for using protobuf "Buffers" in order to use go-protobuf more efficiently. It's incomplete as of now, this is mostly just to see the perf results.

This changes the internal and default "protoCodec" Codec to use a `proto.Buffer` type. Instead of using a global cache for buffers to pass to the unmarshaller, each stream just tries to reuse the buffer it last used, which prevents contention and keeps code around the buffer lifetimes a bit simpler.

It's incomplete as of now, not all tests are passing with the current state, but it works for streaming.

Mostly, the benefits of this appear to be much fewer memory allocations and GC runs, and I'm guessing better locality. 

Profiles and benchmark results:

The main difference can be seen in the allocation totals over the 30 second benchmark period (runign the protobuf secure streaming test):

For the baseline:
* note the ~9GB allocated in proto.Marshal and proto.UnmarshalMerge
<sub>
```
15742.53MB of 15773.10MB total (99.81%)
Dropped 75 nodes (cum <= 78.87MB)
      flat  flat%   sum%        cum   cum%
 4513.90MB 28.62% 28.62%  4681.40MB 29.68%  github.com/golang/protobuf/proto.Marshal
 4419.88MB 28.02% 56.64%  5088.90MB 32.26%  github.com/golang/protobuf/proto.UnmarshalMerge
 1066.05MB  6.76% 63.40%  1066.05MB  6.76%  google.golang.org/grpc/transport.(*recvBufferReader).Read
 1041.55MB  6.60% 70.00%  1041.55MB  6.60%  golang.org/x/net/http2.parseDataFrame
 1017.55MB  6.45% 76.45% 13544.44MB 85.87%  google.golang.org/grpc/benchmark.(*testServer).StreamingCall
  994.05MB  6.30% 82.75%   994.05MB  6.30%  google.golang.org/grpc/transport.(*Stream).write
  674.52MB  4.28% 87.03%   674.52MB  4.28%  google.golang.org/grpc/benchmark.newPayload
  669.02MB  4.24% 91.27%   669.02MB  4.24%  reflect.unsafe_New
  658.52MB  4.17% 95.45%  6815.47MB 43.21%  google.golang.org/grpc/benchmark/grpc_testing.(*benchmarkServiceStreamingCallServer).Recv
     182MB  1.15% 96.60%  5036.90MB 31.93%  google.golang.org/grpc.(*serverStream).SendMsg
     168MB  1.07% 97.67%  1162.05MB  7.37%  google.golang.org/grpc/transport.(*http2Server).handleData
  167.50MB  1.06% 98.73%   167.50MB  1.06%  github.com/golang/protobuf/proto.(*Buffer).enc_struct_message
     167MB  1.06% 99.79%  4848.40MB 30.74%  google.golang.org/grpc.encode
    1.50MB 0.0095% 99.80% 13545.94MB 85.88%  google.golang.org/grpc.(*Server).processStreamingRPC
    1.50MB 0.0095% 99.81%  1068.05MB  6.77%  google.golang.org/grpc.(*parser).recvMsg
```
</sub>

After using protobuf Buffers:
* the total allocation drops by aroud 6-7GB. It appears to completely remove allocations from within protobuf. 
<sub>
```
8393.32MB of 8423.89MB total (99.64%)
Dropped 64 nodes (cum <= 42.12MB)
      flat  flat%   sum%        cum   cum%
 1277.06MB 15.16% 15.16%  1277.06MB 15.16%  google.golang.org/grpc/transport.(*Stream).write
 1248.06MB 14.82% 29.98%  1248.06MB 14.82%  google.golang.org/grpc/transport.(*recvBufferReader).Read
 1238.06MB 14.70% 44.67%  1238.06MB 14.70%  golang.org/x/net/http2.parseDataFrame
 1224.56MB 14.54% 59.21%  5672.20MB 67.33%  google.golang.org/grpc/benchmark.(*testServer).StreamingCall
  861.03MB 10.22% 69.43%   861.03MB 10.22%  reflect.unsafe_New
  846.03MB 10.04% 79.47%  2955.11MB 35.08%  google.golang.org/grpc/benchmark/grpc_testing.(*benchmarkServiceStreamingCallServer).Recv
  828.03MB  9.83% 89.30%   828.03MB  9.83%  google.golang.org/grpc/benchmark.newPayload
     227MB  2.69% 92.00%      227MB  2.69%  github.com/golang/protobuf/proto.(*Buffer).enc_len_thing
     220MB  2.61% 94.61%   664.51MB  7.89%  google.golang.org/grpc.(*serverStream).SendMsg
  212.50MB  2.52% 97.13%   439.51MB  5.22%  google.golang.org/grpc.encode
  208.50MB  2.48% 99.61%  1485.56MB 17.64%  google.golang.org/grpc/transport.(*http2Server).handleData
       2MB 0.024% 99.63%  5674.70MB 67.36%  google.golang.org/grpc.(*Server).processStreamingRPC
    0.50MB 0.0059% 99.64%  5672.70MB 67.34%  google.golang.org/grpc/benchmark/grpc_testing._BenchmarkService_StreamingCall_Handler
```
</sub>

Not shared here are some logs from benchmark runs with GC trace on. But from them, the total number of GC runs during the 30 second benchmark period on the server reduces from around 650 runs to about 300 runs.

On benchmark runs with 2 clients and 1 server, using 32 core machines in the same zone, this appears to improve the throughput for the "protobuf secure streaming" test beyond noise and by about 20% (raises from being steady around mid 600K qps to upper 700K qps with this specific setup). I suspect this throughput increase is the reason for the about proportional increased allocation from functions like  `golang.org/x/net/http2.parseDataFrame`, from ~1Kb to ~1.2Kb.

cc @iamqizhao @ctiller 
cc @carl-mastrangelo for protobuf usage
