### PR TITLE
update pre-generated code and server reflection code to comply with the change to the grpc g…

### DIFF
--- a/benchmark/grpc_testing/services.pb.go
+++ b/benchmark/grpc_testing/services.pb.go
@@ -161,7 +161,7 @@ var _BenchmarkService_serviceDesc = grpc.ServiceDesc{
 			ClientStreams: true,
 		},
 	},
-	Metadata: fileDescriptor3,
+	Metadata: "services.proto",
 }
 
 // Client API for WorkerService service
@@ -417,7 +417,7 @@ var _WorkerService_serviceDesc = grpc.ServiceDesc{
 			ClientStreams: true,
 		},
 	},
-	Metadata: fileDescriptor3,
+	Metadata: "services.proto",
 }
 
 func init() { proto.RegisterFile("services.proto", fileDescriptor3) }

--- a/benchmark/grpc_testing/services.pb.go
+++ b/benchmark/grpc_testing/services.pb.go
@@ -24,7 +24,7 @@ var _ grpc.ClientConn
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the grpc package it is being compiled against.
-const _ = grpc.SupportPackageIsVersion3
+const _ = grpc.SupportPackageIsVersion4
 
 // Client API for BenchmarkService service
 

--- a/examples/helloworld/helloworld/helloworld.pb.go
+++ b/examples/helloworld/helloworld/helloworld.pb.go
@@ -65,7 +65,7 @@ var _ grpc.ClientConn
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the grpc package it is being compiled against.
-const _ = grpc.SupportPackageIsVersion3
+const _ = grpc.SupportPackageIsVersion4
 
 // Client API for Greeter service
 

--- a/examples/helloworld/helloworld/helloworld.pb.go
+++ b/examples/helloworld/helloworld/helloworld.pb.go
@@ -130,7 +130,7 @@ var _Greeter_serviceDesc = grpc.ServiceDesc{
 		},
 	},
 	Streams:  []grpc.StreamDesc{},
-	Metadata: fileDescriptor0,
+	Metadata: "helloworld.proto",
 }
 
 func init() { proto.RegisterFile("helloworld.proto", fileDescriptor0) }

--- a/examples/route_guide/routeguide/route_guide.pb.go
+++ b/examples/route_guide/routeguide/route_guide.pb.go
@@ -452,7 +452,7 @@ var _RouteGuide_serviceDesc = grpc.ServiceDesc{
 			ClientStreams: true,
 		},
 	},
-	Metadata: fileDescriptor0,
+	Metadata: "route_guide.proto",
 }
 
 func init() { proto.RegisterFile("route_guide.proto", fileDescriptor0) }

--- a/examples/route_guide/routeguide/route_guide.pb.go
+++ b/examples/route_guide/routeguide/route_guide.pb.go
@@ -156,7 +156,7 @@ var _ grpc.ClientConn
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the grpc package it is being compiled against.
-const _ = grpc.SupportPackageIsVersion3
+const _ = grpc.SupportPackageIsVersion4
 
 // Client API for RouteGuide service
 

--- a/grpclb/grpc_lb_v1/grpclb.pb.go
+++ b/grpclb/grpc_lb_v1/grpclb.pb.go
@@ -517,7 +517,7 @@ var _LoadBalancer_serviceDesc = grpc.ServiceDesc{
 			ClientStreams: true,
 		},
 	},
-	Metadata: fileDescriptor0,
+	Metadata: "grpclb.proto",
 }
 
 func init() { proto.RegisterFile("grpclb.proto", fileDescriptor0) }

--- a/grpclb/grpc_lb_v1/grpclb.pb.go
+++ b/grpclb/grpc_lb_v1/grpclb.pb.go
@@ -420,7 +420,7 @@ var _ grpc.ClientConn
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the grpc package it is being compiled against.
-const _ = grpc.SupportPackageIsVersion3
+const _ = grpc.SupportPackageIsVersion4
 
 // Client API for LoadBalancer service
 

--- a/health/grpc_health_v1/health.pb.go
+++ b/health/grpc_health_v1/health.pb.go
@@ -153,7 +153,7 @@ var _Health_serviceDesc = grpc.ServiceDesc{
 		},
 	},
 	Streams:  []grpc.StreamDesc{},
-	Metadata: fileDescriptor0,
+	Metadata: "health.proto",
 }
 
 func init() { proto.RegisterFile("health.proto", fileDescriptor0) }

--- a/health/grpc_health_v1/health.pb.go
+++ b/health/grpc_health_v1/health.pb.go
@@ -90,7 +90,7 @@ var _ grpc.ClientConn
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the grpc package it is being compiled against.
-const _ = grpc.SupportPackageIsVersion3
+const _ = grpc.SupportPackageIsVersion4
 
 // Client API for Health service
 

--- a/interop/grpc_testing/test.pb.go
+++ b/interop/grpc_testing/test.pb.go
@@ -789,7 +789,7 @@ var _TestService_serviceDesc = grpc.ServiceDesc{
 			ClientStreams: true,
 		},
 	},
-	Metadata: fileDescriptor0,
+	Metadata: "test.proto",
 }
 
 func init() { proto.RegisterFile("test.proto", fileDescriptor0) }

--- a/interop/grpc_testing/test.pb.go
+++ b/interop/grpc_testing/test.pb.go
@@ -407,7 +407,7 @@ var _ grpc.ClientConn
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the grpc package it is being compiled against.
-const _ = grpc.SupportPackageIsVersion3
+const _ = grpc.SupportPackageIsVersion4
 
 // Client API for TestService service
 

--- a/reflection/grpc_reflection_v1alpha/reflection.pb.go
+++ b/reflection/grpc_reflection_v1alpha/reflection.pb.go
@@ -544,7 +544,7 @@ var _ grpc.ClientConn
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the grpc package it is being compiled against.
-const _ = grpc.SupportPackageIsVersion3
+const _ = grpc.SupportPackageIsVersion4
 
 // Client API for ServerReflection service
 

--- a/reflection/grpc_reflection_v1alpha/reflection.pb.go
+++ b/reflection/grpc_reflection_v1alpha/reflection.pb.go
@@ -643,7 +643,7 @@ var _ServerReflection_serviceDesc = grpc.ServiceDesc{
 			ClientStreams: true,
 		},
 	},
-	Metadata: fileDescriptor0,
+	Metadata: "reflection.proto",
 }
 
 func init() { proto.RegisterFile("reflection.proto", fileDescriptor0) }

--- a/reflection/grpc_testing/test.pb.go
+++ b/reflection/grpc_testing/test.pb.go
@@ -66,7 +66,7 @@ var _ grpc.ClientConn
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the grpc package it is being compiled against.
-const _ = grpc.SupportPackageIsVersion3
+const _ = grpc.SupportPackageIsVersion4
 
 // Client API for SearchService service
 

--- a/reflection/grpc_testing/test.pb.go
+++ b/reflection/grpc_testing/test.pb.go
@@ -195,7 +195,7 @@ var _SearchService_serviceDesc = grpc.ServiceDesc{
 			ClientStreams: true,
 		},
 	},
-	Metadata: fileDescriptor2,
+	Metadata: "test.proto",
 }
 
 func init() { proto.RegisterFile("test.proto", fileDescriptor2) }

--- a/reflection/serverreflection.go
+++ b/reflection/serverreflection.go
@@ -251,11 +251,12 @@ func (s *serverReflectionServer) fileDescEncodingContainingSymbol(name string) (
 		}
 
 		// Metadata not valid.
-		enc, ok := meta.([]byte)
+		fileNameForMeta, ok := meta.(string)
 		if !ok {
 			return nil, fmt.Errorf("invalid file descriptor for symbol: %v", name)
 		}
 
+		enc := proto.FileDescriptor(fileNameForMeta)
 		fd, err = s.decodeFileDesc(enc)
 		if err != nil {
 			return nil, err

--- a/rpc_util.go
+++ b/rpc_util.go
@@ -448,10 +448,10 @@ func convertCode(err error) codes.Code {
 	return codes.Unknown
 }
 
-// SupportPackageIsVersion3 is referenced from generated protocol buffer files
+// SupportPackageIsVersion4 is referenced from generated protocol buffer files
 // to assert that that code is compatible with this version of the grpc package.
 //
 // This constant may be renamed in the future if a change in the generated code
 // requires a synchronised update of grpc-go and protoc-gen-go. This constant
 // should not be referenced from any other code.
-const SupportPackageIsVersion3 = true
+const SupportPackageIsVersion4 = true

--- a/stress/grpc_testing/metrics.pb.go
+++ b/stress/grpc_testing/metrics.pb.go
@@ -335,7 +335,7 @@ var _MetricsService_serviceDesc = grpc.ServiceDesc{
 			ServerStreams: true,
 		},
 	},
-	Metadata: fileDescriptor0,
+	Metadata: "metrics.proto",
 }
 
 func init() { proto.RegisterFile("metrics.proto", fileDescriptor0) }

--- a/stress/grpc_testing/metrics.pb.go
+++ b/stress/grpc_testing/metrics.pb.go
@@ -205,7 +205,7 @@ var _ grpc.ClientConn
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the grpc package it is being compiled against.
-const _ = grpc.SupportPackageIsVersion3
+const _ = grpc.SupportPackageIsVersion4
 
 // Client API for MetricsService service
 

--- a/test/grpc_testing/test.pb.go
+++ b/test/grpc_testing/test.pb.go
@@ -742,7 +742,7 @@ var _TestService_serviceDesc = grpc.ServiceDesc{
 			ClientStreams: true,
 		},
 	},
-	Metadata: fileDescriptor0,
+	Metadata: "test.proto",
 }
 
 func init() { proto.RegisterFile("test.proto", fileDescriptor0) }

--- a/test/grpc_testing/test.pb.go
+++ b/test/grpc_testing/test.pb.go
@@ -360,7 +360,7 @@ var _ grpc.ClientConn
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the grpc package it is being compiled against.
-const _ = grpc.SupportPackageIsVersion3
+const _ = grpc.SupportPackageIsVersion4
 
 // Client API for TestService service
 


### PR DESCRIPTION
…enerator

gRPC code generator will be updated to produce code such that the Metadata field on service description will now be the proto file name instead of File Descriptor.
This would require the server reflection code to be updated to use this file name to look up the file descriptor.
This PR also updates pre-generated code to comply with the aforementioned generator changes. 
Changes to the generator: https://github.com/golang/protobuf/commit/09b5638faf9cc5d6d0230ab90fd7e2b5a15d19ea