### PR TITLE
Proto buf per conn pool

### DIFF
--- a/benchmark/worker/main.go
+++ b/benchmark/worker/main.go
@@ -37,10 +37,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"log"
 	"net"
-	"net/http"
-	_ "net/http/pprof"
 	"runtime"
 	"strconv"
 	"time"
@@ -53,9 +50,8 @@ import (
 )
 
 var (
-	driverPort    = flag.Int("driver_port", 10000, "port for communication with driver")
-	serverPort    = flag.Int("server_port", 0, "port for benchmark server if not specified by server config message")
-	blockProfRate = flag.Int("block_prof_rate", 0, "port for benchmark server if not specified by server config message")
+	driverPort = flag.Int("driver_port", 10000, "port for communication with driver")
+	serverPort = flag.Int("server_port", 0, "port for benchmark server if not specified by server config message")
 )
 
 type byteBufCodec struct {
@@ -90,7 +86,6 @@ type workerServer struct {
 }
 
 func (s *workerServer) RunServer(stream testpb.WorkerService_RunServerServer) error {
-	runtime.SetBlockProfileRate(*blockProfRate)
 	var bs *benchmarkServer
 	defer func() {
 		// Close benchmark server when stream ends.
@@ -230,10 +225,6 @@ func main() {
 		// TODO revise this once server graceful stop is supported in gRPC.
 		time.Sleep(time.Second)
 		s.Stop()
-	}()
-
-	go func() {
-		log.Println(http.ListenAndServe("localhost:6060", nil))
 	}()
 
 	s.Serve(lis)

--- a/call.go
+++ b/call.go
@@ -72,7 +72,7 @@ func recvResponse(ctx context.Context, dopts dialOptions, t transport.ClientTran
 		}
 	}
 	for {
-		if err = recv(p, dopts.codec, stream, dopts.dc, reply, math.MaxInt32, inPayload); err != nil {
+		if err = recv(p, stream.GetCodec().(Codec), stream, dopts.dc, reply, math.MaxInt32, inPayload); err != nil {
 			if err == io.EOF {
 				break
 			}
@@ -89,7 +89,7 @@ func recvResponse(ctx context.Context, dopts dialOptions, t transport.ClientTran
 }
 
 // sendRequest writes out various information of an RPC such as Context and Message.
-func sendRequest(ctx context.Context, codec Codec, compressor Compressor, callHdr *transport.CallHdr, t transport.ClientTransport, args interface{}, opts *transport.Options) (_ *transport.Stream, err error) {
+func sendRequest(ctx context.Context, compressor Compressor, callHdr *transport.CallHdr, t transport.ClientTransport, args interface{}, opts *transport.Options) (_ *transport.Stream, err error) {
 	stream, err := t.NewStream(ctx, callHdr)
 	if err != nil {
 		return nil, err
@@ -114,7 +114,7 @@ func sendRequest(ctx context.Context, codec Codec, compressor Compressor, callHd
 			Client: true,
 		}
 	}
-	outBuf, err := encode(codec, args, compressor, cbuf, outPayload)
+	outBuf, err := encode(stream.GetCodec().(Codec), args, compressor, cbuf, outPayload)
 	if err != nil {
 		return nil, Errorf(codes.Internal, "grpc: %v", err)
 	}
@@ -231,7 +231,7 @@ func invoke(ctx context.Context, method string, args, reply interface{}, cc *Cli
 		if c.traceInfo.tr != nil {
 			c.traceInfo.tr.LazyLog(&payload{sent: true, msg: args}, true)
 		}
-		stream, err = sendRequest(ctx, cc.dopts.codec, cc.dopts.cp, callHdr, t, args, topts)
+		stream, err = sendRequest(ctx, cc.dopts.cp, callHdr, t, args, topts)
 		if err != nil {
 			if put != nil {
 				put()

--- a/call_test.go
+++ b/call_test.go
@@ -93,7 +93,7 @@ func (h *testStreamHandler) handleStream(t *testing.T, s *transport.Stream) {
 			return
 		}
 		var v string
-		codec := testCodec{}
+		codec := s.GetCodec().(Codec)
 		if err := codec.Unmarshal(req, &v); err != nil {
 			t.Errorf("Failed to unmarshal the received message: %v", err)
 			return
@@ -118,7 +118,7 @@ func (h *testStreamHandler) handleStream(t *testing.T, s *transport.Stream) {
 		}
 	}
 	// send a response back to end the stream.
-	reply, err := encode(testCodec{}, &expectedResponse, nil, nil, nil)
+	reply, err := encode(s.GetCodec().(Codec), &expectedResponse, nil, nil, nil)
 	if err != nil {
 		t.Errorf("Failed to encode the response: %v", err)
 		return
@@ -159,6 +159,7 @@ func (s *server) start(t *testing.T, port int, maxStreams uint32) {
 	s.port = p
 	s.conns = make(map[transport.ServerTransport]bool)
 	s.startedErr <- nil
+	codecProviderCreator := newGenericCodecProviderCreator(testCodec{})
 	for {
 		conn, err := s.lis.Accept()
 		if err != nil {
@@ -167,7 +168,8 @@ func (s *server) start(t *testing.T, port int, maxStreams uint32) {
 		config := &transport.ServerConfig{
 			MaxStreams: maxStreams,
 		}
-		st, err := transport.NewServerTransport("http2", conn, config)
+		st, err := transport.NewServerTransport("http2", conn, config, codecProviderCreator.onNewTransport())
+
 		if err != nil {
 			continue
 		}

--- a/clientconn.go
+++ b/clientconn.go
@@ -387,8 +387,8 @@ type ClientConn struct {
 	authority string
 	dopts     dialOptions
 
-	mu                  sync.RWMutex
-	conns               map[Address]*addrConn
+	mu                   sync.RWMutex
+	conns                map[Address]*addrConn
 	codecProviderCreator codecProviderCreator
 }
 

--- a/clientconn.go
+++ b/clientconn.go
@@ -267,7 +267,9 @@ func DialContext(ctx context.Context, target string, opts ...DialOption) (conn *
 
 	// Set defaults.
 	if cc.dopts.codec == nil {
-		cc.dopts.codec = protoCodec{}
+		cc.codecProviderCreator = newProtoCodecProviderCreator()
+	} else {
+		cc.codecProviderCreator = newGenericCodecProviderCreator(cc.dopts.codec)
 	}
 	if cc.dopts.bs == nil {
 		cc.dopts.bs = DefaultBackoffConfig
@@ -385,8 +387,9 @@ type ClientConn struct {
 	authority string
 	dopts     dialOptions
 
-	mu    sync.RWMutex
-	conns map[Address]*addrConn
+	mu                  sync.RWMutex
+	conns               map[Address]*addrConn
+	codecProviderCreator codecProviderCreator
 }
 
 func (cc *ClientConn) lbWatcher() {
@@ -690,7 +693,9 @@ func (ac *addrConn) resetTransport(closeTransport bool) error {
 			Addr:     ac.addr.Addr,
 			Metadata: ac.addr.Metadata,
 		}
-		newTransport, err := transport.NewClientTransport(ctx, sinfo, ac.dopts.copts)
+		getCodec := ac.cc.codecProviderCreator.onNewTransport()
+
+		newTransport, err := transport.NewClientTransport(ctx, sinfo, ac.dopts.copts, getCodec)
 		if err != nil {
 			cancel()
 

--- a/codec.go
+++ b/codec.go
@@ -1,0 +1,298 @@
+/*
+ *
+ * Copyright 2014, Google Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+/*
+Package transport defines and implements message oriented communication channel
+to complete various transactions (e.g., an RPC).
+*/
+package grpc
+
+import (
+	"sync"
+	"sync/atomic"
+
+	"github.com/golang/protobuf/proto"
+)
+
+// Codec defines the interface gRPC uses to encode and decode messages.
+type Codec interface {
+	// Marshal returns the wire format of v.
+	Marshal(v interface{}) ([]byte, error)
+	// Unmarshal parses the wire format into v.
+	Unmarshal(data []byte, v interface{}) error
+	// String returns the name of the Codec implementation. The returned
+	// string will be used as part of content type in transmission.
+	String() string
+}
+
+type codecProvider interface {
+	// Provides a new stream with a codec to be used for it's lifetime
+	getCodec() Codec
+}
+
+type codecProviderCreator interface {
+	// Provides a codecProvider to be used by a connection/transport.
+	// This can control the scope of codec pools, e.g. global, per-conn, none
+	onNewTransport() func() interface{}
+}
+
+// protoCodec is a Codec implementation with protobuf. It is the default codec for gRPC.
+type protoCodec struct {
+	marshalPool   *marshalBufCache
+	unmarshalPool *bufCache
+}
+
+func (p protoCodec) Marshal(v interface{}) ([]byte, error) {
+	var protoMsg = v.(proto.Message)
+	var sizeNeeded = proto.Size(protoMsg)
+	var currentSlice []byte
+
+	mb := p.marshalPool.marshalBufAlloc()
+	buffer := mb.buffer
+
+	if mb.lastSlice != nil && sizeNeeded <= len(mb.lastSlice) {
+		currentSlice = mb.lastSlice
+	} else {
+		currentSlice = make([]byte, sizeNeeded)
+	}
+	buffer.SetBuf(currentSlice)
+	buffer.Reset()
+	err := buffer.Marshal(protoMsg)
+	if err != nil {
+		return nil, err
+	}
+	out := buffer.Bytes()
+	buffer.SetBuf(nil)
+	mb.lastSlice = currentSlice
+	p.marshalPool.marshalBufFree(mb)
+	return out, err
+}
+
+func (p protoCodec) Unmarshal(data []byte, v interface{}) error {
+	buffer := p.unmarshalPool.bufAlloc()
+	buffer.SetBuf(data)
+	err := buffer.Unmarshal(v.(proto.Message))
+	buffer.SetBuf(nil)
+	p.unmarshalPool.bufFree(buffer)
+	return err
+}
+
+func (protoCodec) String() string {
+	return "proto"
+}
+
+// The protoCodec per-stream creators, and per-transport creator "providers"
+// are meant to handle pooling of protoCodec structs and their buffers.
+// The current goal is to keep a pool of buffers per transport connection,
+// to be used on its streams.
+type protoCodecProvider struct {
+	marshalPool   *marshalBufCache
+	unmarshalPool *bufCache
+}
+
+func (c protoCodecProvider) getCodec() Codec {
+	return &protoCodec{
+		marshalPool:   c.marshalPool,
+		unmarshalPool: c.unmarshalPool,
+	}
+}
+
+type protoCodecProviderCreator struct {
+}
+
+// Called when a new connection is made. Sets up the pool to be used by
+// that connection, for its streams
+func (c protoCodecProviderCreator) onNewTransport() func() interface{} {
+	marshalPool := &marshalBufCache{
+		cache: &ringCache{},
+	}
+	unmarshalPool := &bufCache{
+		cache: &ringCache{},
+	}
+
+	provider := &protoCodecProvider{
+		marshalPool:   marshalPool,
+		unmarshalPool: unmarshalPool,
+	}
+
+	return func() interface{} { return provider.getCodec() }
+}
+
+func newProtoCodecProviderCreator() codecProviderCreator {
+	return &protoCodecProviderCreator{}
+}
+
+// Keeps a buffer used for marshalling, and can also holds on to the last
+// byte slice used for marshalling for reuse
+type marshalBuffer struct {
+	buffer    *proto.Buffer
+	lastSlice []byte
+}
+
+func newMarshalBuffer() *marshalBuffer {
+	return &marshalBuffer{
+		buffer: &proto.Buffer{},
+	}
+}
+
+// generic codec used with user-supplied codec.
+// These are used in the same way as the default protoCodec providers,
+// but result in the single user-supplied codec being used on every
+// connection/stream.
+type genericCodecProvider struct {
+	codec Codec
+}
+
+func (c genericCodecProvider) getCodec() Codec {
+	return c.codec
+}
+
+type genericCodecProviderCreator struct {
+	codec Codec
+}
+
+func (c genericCodecProviderCreator) onNewTransport() func() interface{} {
+	provider := &genericCodecProvider {
+		codec: c.codec,
+	}
+
+	return func() interface{} { return provider.getCodec() }
+}
+
+func newGenericCodecProviderCreator(codec Codec) codecProviderCreator {
+	return &genericCodecProviderCreator{
+		codec: codec,
+	}
+}
+
+type ringCache struct {
+	// The ring holds entries in the indexes i%maxPerRing for i in [readIndex, writeIndex).
+	// If readIndex == writeIndex, there is nothing in the ring.
+	// If readIndex+maxPerRing == writeIndex, the ring is full.
+	// The readIndex and writeIndex are atomic values used for synchronization:
+	// the readIndex must be incremented only after removing ring[readIndex%maxPerRing],
+	// because the increment makes that location available for writing,
+	// and the writeIndex must be incremented only after adding ring[writeIndex%maxPerRing],
+	// because the increment makes that location available for reading.
+	// Although the reader and writer communicate via atomic operations,
+	// it is only safe for one such reader and one such writer to be doing
+	// these operations. Readers synchronize on readMu to ensure that
+	// there is only one active reader at a time, and similarly writers synchronize
+	// on writeMu to ensure that there is only one active writer at a time.
+	// Using uint64 for index in order to assume there will never be any overflow.
+	ring       [maxPerRing]interface{}
+	readMu     sync.Mutex
+	readIndex  uint64
+	writeMu    sync.Mutex
+	writeIndex uint64
+}
+
+const maxPerRing = 300
+
+// push pushes the object into the buffer if possible.
+// It reports whether the message was stored into the buffer.
+// (If not, the buffer was full.)
+func (s *ringCache) push(m interface{}) bool {
+	i := atomic.LoadUint64(&s.writeIndex)
+	if i-atomic.LoadUint64(&s.readIndex) >= maxPerRing {
+		return false
+	}
+	s.writeMu.Lock()
+	i = atomic.LoadUint64(&s.writeIndex)
+	if i-atomic.LoadUint64(&s.readIndex) >= maxPerRing {
+		s.writeMu.Unlock()
+		return false
+	}
+	s.ring[i%maxPerRing] = m
+	atomic.StoreUint64(&s.writeIndex, i+1)
+	s.writeMu.Unlock()
+	return true
+}
+
+// pop takes out and returns the object from the ring buffer.
+// It returns nil if the buffer is empty.
+func (s *ringCache) pop() interface{} {
+	i := atomic.LoadUint64(&s.readIndex)
+	if i == atomic.LoadUint64(&s.writeIndex) {
+		return nil
+	}
+	s.readMu.Lock()
+	i = atomic.LoadUint64(&s.readIndex)
+	if i == atomic.LoadUint64(&s.writeIndex) {
+		s.readMu.Unlock()
+		return nil
+	}
+	m := s.ring[i%maxPerRing]
+	s.ring[i%maxPerRing] = nil
+	atomic.StoreUint64(&s.readIndex, i+1)
+	s.readMu.Unlock()
+	return m
+}
+
+type marshalBufCache struct {
+	cache *ringCache
+}
+
+func (mb *marshalBufCache) marshalBufAlloc() *marshalBuffer {
+	m := mb.cache.pop()
+	if m == nil {
+		m = newMarshalBuffer()
+	}
+	return m.(*marshalBuffer)
+}
+
+func (s *marshalBufCache) marshalBufFree(mp *marshalBuffer) {
+	if mp == nil {
+		panic("invalid")
+	}
+	s.cache.push(mp)
+}
+
+type bufCache struct {
+	cache *ringCache
+}
+
+func (bc *bufCache) bufAlloc() *proto.Buffer {
+	m := bc.cache.pop()
+	if m == nil {
+		m = &proto.Buffer{}
+	}
+	return m.(*proto.Buffer)
+}
+
+func (s *bufCache) bufFree(mp *proto.Buffer) {
+	if mp == nil {
+		return
+	}
+	s.cache.push(mp)
+}

--- a/codec.go
+++ b/codec.go
@@ -147,7 +147,7 @@ func (c protoCodecProviderCreator) onNewTransport() func() interface{} {
 	return func() interface{} { return provider.getCodec() }
 }
 
-func newProtoCodecProviderCreator() codecProviderCreator {
+func newProtoCodecProviderCreator() *protoCodecProviderCreator {
 	return &protoCodecProviderCreator{}
 }
 
@@ -188,7 +188,7 @@ func (c genericCodecProviderCreator) onNewTransport() func() interface{} {
 	return func() interface{} { return provider.getCodec() }
 }
 
-func newGenericCodecProviderCreator(codec Codec) codecProviderCreator {
+func newGenericCodecProviderCreator(codec Codec) *genericCodecProviderCreator {
 	return &genericCodecProviderCreator{
 		codec: codec,
 	}

--- a/codec.go
+++ b/codec.go
@@ -263,19 +263,19 @@ type marshalBufCache struct {
 	cache *ringCache
 }
 
-func (mb *marshalBufCache) marshalBufAlloc() *marshalBuffer {
-	m := mb.cache.pop()
-	if m == nil {
-		m = newMarshalBuffer()
+func (c *marshalBufCache) marshalBufAlloc() *marshalBuffer {
+	mb := c.cache.pop()
+	if mb == nil {
+		mb = newMarshalBuffer()
 	}
-	return m.(*marshalBuffer)
+	return mb.(*marshalBuffer)
 }
 
-func (s *marshalBufCache) marshalBufFree(mp *marshalBuffer) {
-	if mp == nil {
+func (c *marshalBufCache) marshalBufFree(mb *marshalBuffer) {
+	if mb == nil {
 		panic("freeing a nil marshalBuffer")
 	}
-	s.cache.push(mp)
+	c.cache.push(mb)
 }
 
 type bufCache struct {
@@ -283,16 +283,16 @@ type bufCache struct {
 }
 
 func (bc *bufCache) bufAlloc() *proto.Buffer {
-	m := bc.cache.pop()
-	if m == nil {
-		m = &proto.Buffer{}
+	pb := bc.cache.pop()
+	if pb == nil {
+		pb = &proto.Buffer{}
 	}
-	return m.(*proto.Buffer)
+	return pb.(*proto.Buffer)
 }
 
-func (s *bufCache) bufFree(mp *proto.Buffer) {
-	if mp == nil {
+func (bc *bufCache) bufFree(pb *proto.Buffer) {
+	if pb == nil {
 		panic("freeing a nil proto.Buffer")
 	}
-	s.cache.push(mp)
+	bc.cache.push(pb)
 }

--- a/codec_test.go
+++ b/codec_test.go
@@ -1,0 +1,54 @@
+/*
+ *
+ * Copyright 2014, Google Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+package grpc
+
+import (
+	"testing"
+)
+
+// The genericCodecProvider needs to hand out the original codec passed in,
+// testing here with pointer comparison
+func TestGenericCodecCreatesTheSameCodecProvided(t *testing.T) {
+	origCodec := &testCodec{}
+	codecProviderCreator := newGenericCodecProviderCreator(origCodec)
+	for i := 0; i < 10; i++ {
+		getCodec := codecProviderCreator.onNewTransport()
+		for k := 0; k < 10; k++ {
+			codec := getCodec()
+			if codec != origCodec {
+				t.Fatalf("generic codec should provide the codec on construction")
+			}
+		}
+	}
+}

--- a/codec_test.go
+++ b/codec_test.go
@@ -34,12 +34,48 @@
 package grpc
 
 import (
+	"sync"
 	"testing"
+
+	"google.golang.org/grpc/test/codec_perf"
 )
+
+func newProtoCodec() Codec {
+	protoCodecProviderCreator := newProtoCodecProviderCreator()
+	getCodec := protoCodecProviderCreator.onNewTransport()
+	return getCodec().(Codec)
+}
+
+func marshalAndUnmarshal(protoCodec Codec, t *testing.T) {
+	expectedBody := []byte{1, 2, 3}
+
+	original := &codec_perf.Buffer{}
+	original.Body = expectedBody
+
+	var marshalledBytes []byte
+	deserialized := &codec_perf.Buffer{}
+	var err error
+
+	if marshalledBytes, err = protoCodec.Marshal(original); err != nil {
+		t.Fatalf("protoCodec.Marshal(_) returned an error")
+	}
+
+	if err := protoCodec.Unmarshal(marshalledBytes, deserialized); err != nil {
+		t.Fatalf("protoCodec.Unmarshal(_) returned an error")
+	}
+
+	result := deserialized.GetBody()
+
+	for i, v := range result {
+		if expectedBody[i] != v {
+			t.Fatalf("expected slice differs from result")
+		}
+	}
+}
 
 // The genericCodecProvider needs to hand out the original codec passed in,
 // testing here with pointer comparison
-func TestGenericCodecCreatesTheSameCodecProvided(t *testing.T) {
+func TestGenericCodecProviderCreatorCreatesTheSameCodecProvided(t *testing.T) {
 	origCodec := &testCodec{}
 	codecProviderCreator := newGenericCodecProviderCreator(origCodec)
 	for i := 0; i < 10; i++ {
@@ -49,6 +85,88 @@ func TestGenericCodecCreatesTheSameCodecProvided(t *testing.T) {
 			if codec != origCodec {
 				t.Fatalf("generic codec should provide the codec on construction")
 			}
+		}
+	}
+}
+
+func TestBasicProtoCodecMarshalAndUnmarshal(t *testing.T) {
+	marshalAndUnmarshal(newProtoCodec(), t)
+}
+
+func TestConcurrentUsageOfProtoCodec(t *testing.T) {
+	numProviderCreators := 5
+	numCodecFuncsPerProvider := 5
+	numCodecsPerGetCodecFunc := 100
+	providerCreators := make([]*protoCodecProviderCreator, numProviderCreators)
+	getCodecFuncs := make([]func() interface{}, numCodecFuncsPerProvider*numProviderCreators)
+	var wg sync.WaitGroup
+
+	for i := 0; i < numProviderCreators; i++ {
+		p := newProtoCodecProviderCreator()
+		providerCreators[i] = p
+
+		for k := 0; k < numCodecFuncsPerProvider; k++ {
+			getCodecFuncs[i*numCodecFuncsPerProvider+k] = p.onNewTransport()
+		}
+	}
+
+	for getCodecIndex := 0; getCodecIndex < len(getCodecFuncs); getCodecIndex++ {
+		// Create and use codecs from the getCodec func concurrently. Attempt
+		// to use the shared pool beyond its capacity
+		for i := 0; i < numCodecsPerGetCodecFunc; i++ {
+			var codec Codec
+			if codec = getCodecFuncs[getCodecIndex]().(Codec); codec == nil {
+				t.Fatalf("nil Codec returned from getCodec func")
+			}
+			wg.Add(1)
+			go func(codec Codec) {
+				for k := 0; k < maxPerRing*2; k++ {
+					marshalAndUnmarshal(codec, t)
+				}
+				wg.Add(-1)
+			}(codec)
+		}
+	}
+
+	wg.Wait()
+}
+
+func TestRingCacheBehaviorAndUseBeyondCapacity(t *testing.T) {
+	cache := &ringCache{}
+	objects := make([]interface{}, maxPerRing*2)
+
+	// popping when empty should return nil
+	for i := 0; i < 10; i++ {
+		if res := cache.pop(); res != nil {
+			t.Fatalf("cache.pop() expected to return nil")
+		}
+	}
+
+	// pushing should return a value indicating whether
+	// the item was pushed onto the stack of discarded
+	for i := 0; i < cap(objects); i++ {
+		objects[i] = &i
+		expectedPushResult := true
+		if i >= maxPerRing {
+			expectedPushResult = false
+		}
+		if cache.push(&i) != expectedPushResult {
+			t.Fatalf("unexpected result of pushing onto ring cache")
+		}
+	}
+
+	// the first "maxPerRing" pushes should have been saved onto the stack
+	for i := maxPerRing - 1; i >= 0; i-- {
+		if objects[i] != cache.pop() {
+			t.Fatalf("unexpected result of popping from ring cache")
+		}
+	}
+
+	// after popping everything, the cache should be empty and further
+	// pops should return nil
+	for i := 0; i < 10; i++ {
+		if res := cache.pop(); res != nil {
+			t.Fatalf("cache.pop() expected to return nil")
 		}
 	}
 }

--- a/rpc_util.go
+++ b/rpc_util.go
@@ -44,39 +44,12 @@ import (
 	"os"
 	"time"
 
-	"github.com/golang/protobuf/proto"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/stats"
 	"google.golang.org/grpc/transport"
 )
-
-// Codec defines the interface gRPC uses to encode and decode messages.
-type Codec interface {
-	// Marshal returns the wire format of v.
-	Marshal(v interface{}) ([]byte, error)
-	// Unmarshal parses the wire format into v.
-	Unmarshal(data []byte, v interface{}) error
-	// String returns the name of the Codec implementation. The returned
-	// string will be used as part of content type in transmission.
-	String() string
-}
-
-// protoCodec is a Codec implementation with protobuf. It is the default codec for gRPC.
-type protoCodec struct{}
-
-func (protoCodec) Marshal(v interface{}) ([]byte, error) {
-	return proto.Marshal(v.(proto.Message))
-}
-
-func (protoCodec) Unmarshal(data []byte, v interface{}) error {
-	return proto.Unmarshal(data, v.(proto.Message))
-}
-
-func (protoCodec) String() string {
-	return "proto"
-}
 
 // Compressor defines the interface gRPC uses to compress a message.
 type Compressor interface {

--- a/server.go
+++ b/server.go
@@ -99,9 +99,9 @@ type Server struct {
 	cancel context.CancelFunc
 	// A CondVar to let GracefulStop() blocks until all the pending RPCs are finished
 	// and all the transport goes away.
-	cv                  *sync.Cond
-	m                   map[string]*service // service name -> service info
-	events              trace.EventLog
+	cv                   *sync.Cond
+	m                    map[string]*service // service name -> service info
+	events               trace.EventLog
 	codecProviderCreator codecProviderCreator
 }
 
@@ -217,10 +217,10 @@ func NewServer(opt ...ServerOption) *Server {
 		codecProviderCreator = newGenericCodecProviderCreator(opts.codec)
 	}
 	s := &Server{
-		lis:                 make(map[net.Listener]bool),
-		opts:                opts,
-		conns:               make(map[io.Closer]bool),
-		m:                   make(map[string]*service),
+		lis:                  make(map[net.Listener]bool),
+		opts:                 opts,
+		conns:                make(map[io.Closer]bool),
+		m:                    make(map[string]*service),
 		codecProviderCreator: codecProviderCreator,
 	}
 	s.cv = sync.NewCond(&s.mu)

--- a/server.go
+++ b/server.go
@@ -446,7 +446,7 @@ func (s *Server) serveHTTP2Transport(c net.Conn, authInfo credentials.AuthInfo) 
 		AuthInfo:    authInfo,
 		InTapHandle: s.opts.inTapHandle,
 	}
-	getCodec := s.codecCreatorCreator.onNewTransport()
+	getCodec := s.codecProviderCreator.onNewTransport()
 	st, err := transport.NewServerTransport("http2", c, config, getCodec)
 	if err != nil {
 		s.mu.Lock()

--- a/server.go
+++ b/server.go
@@ -1,5 +1,5 @@
 /*
- *
+
  * Copyright 2014, Google Inc.
  * All rights reserved.
  *
@@ -99,9 +99,10 @@ type Server struct {
 	cancel context.CancelFunc
 	// A CondVar to let GracefulStop() blocks until all the pending RPCs are finished
 	// and all the transport goes away.
-	cv     *sync.Cond
-	m      map[string]*service // service name -> service info
-	events trace.EventLog
+	cv                  *sync.Cond
+	m                   map[string]*service // service name -> service info
+	events              trace.EventLog
+	codecCreatorCreator codecProviderCreator
 }
 
 type options struct {
@@ -208,15 +209,19 @@ func NewServer(opt ...ServerOption) *Server {
 	for _, o := range opt {
 		o(&opts)
 	}
+	var codecCreatorCreator codecProviderCreator
 	if opts.codec == nil {
 		// Set the default codec.
-		opts.codec = protoCodec{}
+		codecCreatorCreator = newProtoCodecProviderCreator()
+	} else {
+		codecCreatorCreator = newGenericCodecProviderCreator(opts.codec)
 	}
 	s := &Server{
-		lis:   make(map[net.Listener]bool),
-		opts:  opts,
-		conns: make(map[io.Closer]bool),
-		m:     make(map[string]*service),
+		lis:                 make(map[net.Listener]bool),
+		opts:                opts,
+		conns:               make(map[io.Closer]bool),
+		m:                   make(map[string]*service),
+		codecCreatorCreator: codecCreatorCreator,
 	}
 	s.cv = sync.NewCond(&s.mu)
 	s.ctx, s.cancel = context.WithCancel(context.Background())
@@ -441,7 +446,8 @@ func (s *Server) serveHTTP2Transport(c net.Conn, authInfo credentials.AuthInfo) 
 		AuthInfo:    authInfo,
 		InTapHandle: s.opts.inTapHandle,
 	}
-	st, err := transport.NewServerTransport("http2", c, config)
+	getCodec := s.codecCreatorCreator.onNewTransport()
+	st, err := transport.NewServerTransport("http2", c, config, getCodec)
 	if err != nil {
 		s.mu.Lock()
 		s.errorf("NewServerTransport(%q) failed: %v", c.RemoteAddr(), err)
@@ -506,7 +512,9 @@ func (s *Server) serveUsingHandler(conn net.Conn) {
 }
 
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	st, err := transport.NewServerHandlerTransport(w, r)
+	getCodec := s.codecCreatorCreator.onNewTransport()
+
+	st, err := transport.NewServerHandlerTransport(w, r, getCodec)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -569,7 +577,7 @@ func (s *Server) sendResponse(t transport.ServerTransport, stream *transport.Str
 	if stats.On() {
 		outPayload = &stats.OutPayload{}
 	}
-	p, err := encode(s.opts.codec, msg, cp, cbuf, outPayload)
+	p, err := encode(stream.GetCodec().(Codec), msg, cp, cbuf, outPayload)
 	if err != nil {
 		// This typically indicates a fatal issue (e.g., memory
 		// corruption or hardware faults) the application program
@@ -691,7 +699,7 @@ func (s *Server) processUnaryRPC(t transport.ServerTransport, stream *transport.
 				statusCode = codes.Internal
 				statusDesc = fmt.Sprintf("grpc: server received a message of %d bytes exceeding %d limit", len(req), s.opts.maxMsgSize)
 			}
-			if err := s.opts.codec.Unmarshal(req, v); err != nil {
+			if err := stream.GetCodec().(Codec).Unmarshal(req, v); err != nil {
 				return err
 			}
 			if inPayload != nil {
@@ -779,7 +787,6 @@ func (s *Server) processStreamingRPC(t transport.ServerTransport, stream *transp
 		t:          t,
 		s:          stream,
 		p:          &parser{r: stream},
-		codec:      s.opts.codec,
 		cp:         s.opts.cp,
 		dc:         s.opts.dc,
 		maxMsgSize: s.opts.maxMsgSize,

--- a/transport/handler_server_test.go
+++ b/transport/handler_server_test.go
@@ -48,6 +48,10 @@ import (
 	"google.golang.org/grpc/metadata"
 )
 
+func noOpGetCodec() interface{} { 
+	return nil 
+}
+
 func TestHandlerTransport_NewServerHandlerTransport(t *testing.T) {
 	type testCase struct {
 		name    string
@@ -225,7 +229,7 @@ func TestHandlerTransport_NewServerHandlerTransport(t *testing.T) {
 		if tt.modrw != nil {
 			rw = tt.modrw(rw)
 		}
-		got, gotErr := NewServerHandlerTransport(rw, tt.req)
+		got, gotErr := NewServerHandlerTransport(rw, tt.req, noOpGetCodec)
 		if (gotErr != nil) != (tt.wantErr != "") || (gotErr != nil && gotErr.Error() != tt.wantErr) {
 			t.Errorf("%s: error = %v; want %q", tt.name, gotErr, tt.wantErr)
 			continue
@@ -279,7 +283,7 @@ func newHandleStreamTest(t *testing.T) *handleStreamTest {
 		Body:       bodyr,
 	}
 	rw := newTestHandlerResponseWriter().(testHandlerResponseWriter)
-	ht, err := NewServerHandlerTransport(rw, req)
+	ht, err := NewServerHandlerTransport(rw, req, noOpGetCodec)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -362,7 +366,7 @@ func TestHandlerTransport_HandleStreams_Timeout(t *testing.T) {
 		Body:       bodyr,
 	}
 	rw := newTestHandlerResponseWriter().(testHandlerResponseWriter)
-	ht, err := NewServerHandlerTransport(rw, req)
+	ht, err := NewServerHandlerTransport(rw, req, noOpGetCodec)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/transport/handler_server_test.go
+++ b/transport/handler_server_test.go
@@ -48,8 +48,8 @@ import (
 	"google.golang.org/grpc/metadata"
 )
 
-func noOpGetCodec() interface{} { 
-	return nil 
+func noOpGetCodec() interface{} {
+	return nil
 }
 
 func TestHandlerTransport_NewServerHandlerTransport(t *testing.T) {

--- a/transport/http2_client.go
+++ b/transport/http2_client.go
@@ -109,6 +109,11 @@ type http2Client struct {
 	goAwayID uint32
 	// prevGoAway ID records the Last-Stream-ID in the previous GOAway frame.
 	prevGoAwayID uint32
+	getCodec     func() interface{}
+}
+
+func (t *http2Client) GetCodec() interface{} {
+	return t.getCodec()
 }
 
 func dial(ctx context.Context, fn func(context.Context, string) (net.Conn, error), addr string) (net.Conn, error) {
@@ -149,7 +154,7 @@ func isTemporary(err error) bool {
 // newHTTP2Client constructs a connected ClientTransport to addr based on HTTP2
 // and starts to receive messages on it. Non-nil error returns if construction
 // fails.
-func newHTTP2Client(ctx context.Context, addr TargetInfo, opts ConnectOptions) (_ ClientTransport, err error) {
+func newHTTP2Client(ctx context.Context, addr TargetInfo, opts ConnectOptions, getCodec func() interface{}) (_ ClientTransport, err error) {
 	scheme := "http"
 	conn, err := dial(ctx, opts.Dialer, addr.Addr)
 	if err != nil {
@@ -203,6 +208,7 @@ func newHTTP2Client(ctx context.Context, addr TargetInfo, opts ConnectOptions) (
 		creds:           opts.PerRPCCredentials,
 		maxStreams:      math.MaxInt32,
 		streamSendQuota: defaultWindowSize,
+		getCodec:        getCodec,
 	}
 	// Start the reader goroutine for incoming message. Each transport has
 	// a dedicated goroutine which reads HTTP2 frame from network. Then it
@@ -254,6 +260,7 @@ func (t *http2Client) newStream(ctx context.Context, callHdr *CallHdr) *Stream {
 		fc:            &inFlow{limit: initialWindowSize},
 		sendQuotaPool: newQuotaPool(int(t.streamSendQuota)),
 		headerChan:    make(chan struct{}),
+		codec:         t.GetCodec(),
 	}
 	t.nextID += 2
 	s.windowHandler = func(n int) {

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -212,6 +212,14 @@ type Stream struct {
 	// the status received from the server.
 	statusCode codes.Code
 	statusDesc string
+	codec      interface{}
+}
+
+func (s *Stream) GetCodec() interface{} {
+	if s.codec == nil {
+		panic("codec unset")
+	}
+	return s.codec
 }
 
 // RecvCompress returns the compression algorithm applied to the inbound
@@ -364,8 +372,8 @@ type ServerConfig struct {
 
 // NewServerTransport creates a ServerTransport with conn or non-nil error
 // if it fails.
-func NewServerTransport(protocol string, conn net.Conn, config *ServerConfig) (ServerTransport, error) {
-	return newHTTP2Server(conn, config)
+func NewServerTransport(protocol string, conn net.Conn, config *ServerConfig, getCodec func() interface{}) (ServerTransport, error) {
+	return newHTTP2Server(conn, config, getCodec)
 }
 
 // ConnectOptions covers all relevant options for communicating with the server.
@@ -388,8 +396,8 @@ type TargetInfo struct {
 
 // NewClientTransport establishes the transport with the required ConnectOptions
 // and returns it to the caller.
-func NewClientTransport(ctx context.Context, target TargetInfo, opts ConnectOptions) (ClientTransport, error) {
-	return newHTTP2Client(ctx, target, opts)
+func NewClientTransport(ctx context.Context, target TargetInfo, opts ConnectOptions, getCodec func() interface{}) (ClientTransport, error) {
+	return newHTTP2Client(ctx, target, opts, getCodec)
 }
 
 // Options provides additional hints and information for message
@@ -464,6 +472,11 @@ type ClientTransport interface {
 	// receives the draining signal from the server (e.g., GOAWAY frame in
 	// HTTP/2).
 	GoAway() <-chan struct{}
+
+	// Get the Codec for this transport. Codec isn't available from transport
+	// package, but it needs to be accessible after getting initialized
+	// for the stream, by the connection.
+	GetCodec() interface{}
 }
 
 // ServerTransport is the common interface for all gRPC server-side transport
@@ -498,6 +511,8 @@ type ServerTransport interface {
 
 	// Drain notifies the client this ServerTransport stops accepting new RPCs.
 	Drain()
+
+	GetCodec() interface{}
 }
 
 // streamErrorf creates an StreamError with the specified error code and description.

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -215,6 +215,9 @@ type Stream struct {
 	codec      interface{}
 }
 
+// GetCodec gets the Codec for this stream. The transport package doesn't know
+// about Codecs, but code in the grpc package needs to get the Codec from
+// the transport.Stream, so this returns interface{} instead of Codec
 func (s *Stream) GetCodec() interface{} {
 	if s.codec == nil {
 		panic("codec unset")
@@ -512,6 +515,9 @@ type ServerTransport interface {
 	// Drain notifies the client this ServerTransport stops accepting new RPCs.
 	Drain()
 
+	// Get the Codec for this transport. Codec isn't available from transport
+	// package, but it needs to be accessible after getting initialized
+	// for the stream, by the connection.
 	GetCodec() interface{}
 }
 

--- a/transport/transport_test.go
+++ b/transport/transport_test.go
@@ -182,7 +182,7 @@ func (s *server) start(t *testing.T, port int, maxStreams uint32, ht hType) {
 		config := &ServerConfig{
 			MaxStreams: maxStreams,
 		}
-		transport, err := NewServerTransport("http2", conn, config)
+		transport, err := NewServerTransport("http2", conn, config, noOpGetCodec)
 		if err != nil {
 			return
 		}
@@ -262,7 +262,7 @@ func setUp(t *testing.T, port int, maxStreams uint32, ht hType) (*server, Client
 	target := TargetInfo{
 		Addr: addr,
 	}
-	ct, connErr = NewClientTransport(context.Background(), target, ConnectOptions{})
+	ct, connErr = NewClientTransport(context.Background(), target, ConnectOptions{}, noOpGetCodec)
 	if connErr != nil {
 		t.Fatalf("failed to create transport: %v", connErr)
 	}


### PR DESCRIPTION
Redo of https://github.com/grpc/grpc-go/pull/939

Cuts down on memory usage a lot and seems to improve QPS around 15-20% on protobuf streaming benchmarks.

main changes:
Moved Codec interface, and some Codec specific code including pools, to "codec.go"
Changes around transport and stream initialization, in order to setup per-connection pools for the protoCodecs.
Attaching Codec object to "transport.Stream", where it's initialized.

cc @ctiller @carl-mastrangelo 
