### PR TITLE
Combine flushes between headers and messages where possible

### DIFF
--- a/call_test.go
+++ b/call_test.go
@@ -99,21 +99,21 @@ func (h *testStreamHandler) handleStream(t *testing.T, s *transport.Stream) {
 			return
 		}
 		if v == "weird error" {
-			h.t.WriteStatus(s, codes.Internal, weirdError)
+			h.t.WriteStatus(s, codes.Internal, weirdError, transport.Options{})
 			return
 		}
 		if v == "canceled" {
 			canceled++
-			h.t.WriteStatus(s, codes.Internal, "")
+			h.t.WriteStatus(s, codes.Internal, "", transport.Options{})
 			return
 		}
 		if v == "port" {
-			h.t.WriteStatus(s, codes.Internal, h.port)
+			h.t.WriteStatus(s, codes.Internal, h.port, transport.Options{})
 			return
 		}
 
 		if v != expectedRequest {
-			h.t.WriteStatus(s, codes.Internal, strings.Repeat("A", sizeLargeErr))
+			h.t.WriteStatus(s, codes.Internal, strings.Repeat("A", sizeLargeErr), transport.Options{})
 			return
 		}
 	}
@@ -124,7 +124,7 @@ func (h *testStreamHandler) handleStream(t *testing.T, s *transport.Stream) {
 		return
 	}
 	h.t.Write(s, reply, &transport.Options{})
-	h.t.WriteStatus(s, codes.OK, "")
+	h.t.WriteStatus(s, codes.OK, "", transport.Options{})
 }
 
 type server struct {

--- a/stream.go
+++ b/stream.go
@@ -540,7 +540,7 @@ func (ss *serverStream) SetHeader(md metadata.MD) error {
 }
 
 func (ss *serverStream) SendHeader(md metadata.MD) error {
-	return ss.t.WriteHeader(ss.s, md)
+	return ss.t.WriteHeader(ss.s, md, transport.Options{})
 }
 
 func (ss *serverStream) SetTrailer(md metadata.MD) {
@@ -580,7 +580,7 @@ func (ss *serverStream) SendMsg(m interface{}) (err error) {
 		err = Errorf(codes.Internal, "grpc: %v", err)
 		return err
 	}
-	if err := ss.t.Write(ss.s, out, &transport.Options{Last: false}); err != nil {
+	if err := ss.t.Write(ss.s, out, &transport.Options{Last: false, Delay: false}); err != nil {
 		return toRPCErr(err)
 	}
 	if outPayload != nil {

--- a/transport/handler_server_test.go
+++ b/transport/handler_server_test.go
@@ -298,7 +298,7 @@ func TestHandlerTransport_HandleStreams(t *testing.T) {
 			t.Errorf("stream method = %q; want %q", s.method, want)
 		}
 		st.bodyw.Close() // no body
-		st.ht.WriteStatus(s, codes.OK, "")
+		st.ht.WriteStatus(s, codes.OK, "", Options{})
 	}
 	st.ht.HandleStreams(
 		func(s *Stream) { go handleStream(s) },
@@ -328,7 +328,7 @@ func TestHandlerTransport_HandleStreams_InvalidArgument(t *testing.T) {
 func handleStreamCloseBodyTest(t *testing.T, statusCode codes.Code, msg string) {
 	st := newHandleStreamTest(t)
 	handleStream := func(s *Stream) {
-		st.ht.WriteStatus(s, statusCode, msg)
+		st.ht.WriteStatus(s, statusCode, msg, Options{})
 	}
 	st.ht.HandleStreams(
 		func(s *Stream) { go handleStream(s) },
@@ -379,7 +379,7 @@ func TestHandlerTransport_HandleStreams_Timeout(t *testing.T) {
 			t.Errorf("ctx.Err = %v; want %v", err, context.DeadlineExceeded)
 			return
 		}
-		ht.WriteStatus(s, codes.DeadlineExceeded, "too slow")
+		ht.WriteStatus(s, codes.DeadlineExceeded, "too slow", Options{})
 	}
 	ht.HandleStreams(
 		func(s *Stream) { go runStream(s) },

--- a/transport/http2_client.go
+++ b/transport/http2_client.go
@@ -92,7 +92,8 @@ type http2Client struct {
 	// sendQuotaPool provides flow control to outbound message.
 	sendQuotaPool *quotaPool
 	// streamsQuota limits the max number of concurrent streams.
-	streamsQuota *quotaPool
+	streamsQuota             *quotaPool
+	streamsInboundWindowSize uint32
 
 	// The scheme used: https if TLS is on, http otherwise.
 	scheme string
@@ -112,6 +113,8 @@ type http2Client struct {
 	goAwayID uint32
 	// prevGoAway ID records the Last-Stream-ID in the previous GOAway frame.
 	prevGoAwayID uint32
+
+	settingsAckRecvd chan int
 }
 
 func dial(ctx context.Context, fn func(context.Context, string) (net.Conn, error), addr string) (net.Conn, error) {
@@ -193,24 +196,26 @@ func newHTTP2Client(ctx context.Context, addr TargetInfo, opts ConnectOptions) (
 		localAddr:  conn.LocalAddr(),
 		authInfo:   authInfo,
 		// The client initiated stream id is odd starting from 1.
-		nextID:          1,
-		writableChan:    make(chan int, 1),
-		shutdownChan:    make(chan struct{}),
-		errorChan:       make(chan struct{}),
-		goAway:          make(chan struct{}),
-		framer:          newFramer(conn),
-		hBuf:            &buf,
-		hEnc:            hpack.NewEncoder(&buf),
-		controlBuf:      newRecvBuffer(),
-		fc:              &inFlow{limit: initialConnWindowSize},
-		sendQuotaPool:   newQuotaPool(defaultWindowSize),
-		scheme:          scheme,
-		state:           reachable,
-		activeStreams:   make(map[uint32]*Stream),
-		creds:           opts.PerRPCCredentials,
-		maxStreams:      math.MaxInt32,
-		streamSendQuota: defaultWindowSize,
-		statsHandler:    opts.StatsHandler,
+		nextID:                   1,
+		writableChan:             make(chan int, 1),
+		shutdownChan:             make(chan struct{}),
+		errorChan:                make(chan struct{}),
+		goAway:                   make(chan struct{}),
+		framer:                   newFramer(conn),
+		hBuf:                     &buf,
+		hEnc:                     hpack.NewEncoder(&buf),
+		controlBuf:               newRecvBuffer(),
+		fc:                       &inFlow{limit: initialConnWindowSize},
+		sendQuotaPool:            newQuotaPool(defaultWindowSize),
+		scheme:                   scheme,
+		state:                    reachable,
+		activeStreams:            make(map[uint32]*Stream),
+		creds:                    opts.PerRPCCredentials,
+		maxStreams:               math.MaxInt32,
+		streamSendQuota:          defaultWindowSize,
+		statsHandler:             opts.StatsHandler,
+		streamsInboundWindowSize: initialWindowSize,
+		settingsAckRecvd:         make(chan int, 1),
 	}
 	if t.statsHandler != nil {
 		t.ctx = t.statsHandler.TagConn(t.ctx, &stats.ConnTagInfo{
@@ -269,7 +274,7 @@ func (t *http2Client) newStream(ctx context.Context, callHdr *CallHdr) *Stream {
 		method:        callHdr.Method,
 		sendCompress:  callHdr.SendCompress,
 		buf:           newRecvBuffer(),
-		fc:            &inFlow{limit: initialWindowSize},
+		fc:            &inFlow{limit: t.streamsInboundWindowSize},
 		sendQuotaPool: newQuotaPool(int(t.streamSendQuota)),
 		headerChan:    make(chan struct{}),
 	}
@@ -828,6 +833,10 @@ func (t *http2Client) handleRSTStream(f *http2.RSTStreamFrame) {
 
 func (t *http2Client) handleSettings(f *http2.SettingsFrame) {
 	if f.IsAck() {
+		select {
+		case t.settingsAckRecvd <- 0:
+		default:
+		}
 		return
 	}
 	var ss []http2.Setting
@@ -840,7 +849,7 @@ func (t *http2Client) handleSettings(f *http2.SettingsFrame) {
 }
 
 func (t *http2Client) handlePing(f *http2.PingFrame) {
-	if f.IsAck() { // Do nothing.
+	if f.IsAck() { // Do nothing
 		return
 	}
 	pingAck := &ping{ack: true}

--- a/transport/http2_server.go
+++ b/transport/http2_server.go
@@ -41,6 +41,7 @@ import (
 	"net"
 	"strconv"
 	"sync"
+	"sync/atomic"
 
 	"golang.org/x/net/context"
 	"golang.org/x/net/http2"
@@ -94,7 +95,12 @@ type http2Server struct {
 	state         transportState
 	activeStreams map[uint32]*Stream
 	// the per-stream outbound flow control window size set by the peer.
-	streamSendQuota uint32
+	streamSendQuota         uint32
+	numCompletingUnaryCalls int32
+}
+
+func (t *http2Server) AdjustNumCompletingUnaryCalls(count int32) int32 {
+	return atomic.AddInt32(&t.numCompletingUnaryCalls, count)
 }
 
 // newHTTP2Server constructs a ServerTransport based on HTTP2. ConnectionError is
@@ -472,7 +478,7 @@ func (t *http2Server) handleWindowUpdate(f *http2.WindowUpdateFrame) {
 	}
 }
 
-func (t *http2Server) writeHeaders(s *Stream, b *bytes.Buffer, endStream bool) error {
+func (t *http2Server) writeHeaders(s *Stream, b *bytes.Buffer, endStream bool, opts Options) error {
 	first := true
 	endHeaders := false
 	var err error
@@ -484,6 +490,10 @@ func (t *http2Server) writeHeaders(s *Stream, b *bytes.Buffer, endStream bool) e
 		} else {
 			endHeaders = true
 		}
+		var forceFlush bool
+		if endHeaders && !opts.Delay {
+			forceFlush = true
+		}
 		if first {
 			p := http2.HeadersFrameParam{
 				StreamID:      s.id,
@@ -491,10 +501,10 @@ func (t *http2Server) writeHeaders(s *Stream, b *bytes.Buffer, endStream bool) e
 				EndStream:     endStream,
 				EndHeaders:    endHeaders,
 			}
-			err = t.framer.writeHeaders(endHeaders, p)
+			err = t.framer.writeHeaders(forceFlush, p)
 			first = false
 		} else {
-			err = t.framer.writeContinuation(endHeaders, s.id, endHeaders, b.Next(size))
+			err = t.framer.writeContinuation(forceFlush, s.id, endHeaders, b.Next(size))
 		}
 		if err != nil {
 			t.Close()
@@ -505,7 +515,7 @@ func (t *http2Server) writeHeaders(s *Stream, b *bytes.Buffer, endStream bool) e
 }
 
 // WriteHeader sends the header metedata md back to the client.
-func (t *http2Server) WriteHeader(s *Stream, md metadata.MD) error {
+func (t *http2Server) WriteHeader(s *Stream, md metadata.MD, opts Options) error {
 	s.mu.Lock()
 	if s.headerOk || s.state == streamDone {
 		s.mu.Unlock()
@@ -540,7 +550,7 @@ func (t *http2Server) WriteHeader(s *Stream, md metadata.MD) error {
 		}
 	}
 	bufLen := t.hBuf.Len()
-	if err := t.writeHeaders(s, t.hBuf, false); err != nil {
+	if err := t.writeHeaders(s, t.hBuf, false, opts); err != nil {
 		return err
 	}
 	if t.stats != nil {
@@ -557,7 +567,7 @@ func (t *http2Server) WriteHeader(s *Stream, md metadata.MD) error {
 // There is no further I/O operations being able to perform on this stream.
 // TODO(zhaoq): Now it indicates the end of entire stream. Revisit if early
 // OK is adopted.
-func (t *http2Server) WriteStatus(s *Stream, statusCode codes.Code, statusDesc string) error {
+func (t *http2Server) WriteStatus(s *Stream, statusCode codes.Code, statusDesc string, opts Options) error {
 	var headersSent, hasHeader bool
 	s.mu.Lock()
 	if s.state == streamDone {
@@ -573,7 +583,8 @@ func (t *http2Server) WriteStatus(s *Stream, statusCode codes.Code, statusDesc s
 	s.mu.Unlock()
 
 	if !headersSent && hasHeader {
-		t.WriteHeader(s, nil)
+		// Wait on writing the status until flushing
+		t.WriteHeader(s, nil, Options{Delay: true})
 		headersSent = true
 	}
 
@@ -602,7 +613,7 @@ func (t *http2Server) WriteStatus(s *Stream, statusCode codes.Code, statusDesc s
 		}
 	}
 	bufLen := t.hBuf.Len()
-	if err := t.writeHeaders(s, t.hBuf, true); err != nil {
+	if err := t.writeHeaders(s, t.hBuf, true, opts); err != nil {
 		t.Close()
 		return err
 	}
@@ -632,7 +643,9 @@ func (t *http2Server) Write(s *Stream, data []byte, opts *Options) error {
 	}
 	s.mu.Unlock()
 	if writeHeaderFrame {
-		t.WriteHeader(s, nil)
+		// Let metadata and messages get combined to one buffer flush if possible.
+		// But use the options because we might need to flush with streaming calls.
+		t.WriteHeader(s, nil, *opts)
 	}
 	r := bytes.NewBuffer(data)
 	for {
@@ -650,6 +663,7 @@ func (t *http2Server) Write(s *Stream, data []byte, opts *Options) error {
 		if err != nil {
 			return err
 		}
+		ignoreDelayFlag := false
 		if sq < size {
 			size = sq
 		}
@@ -658,6 +672,15 @@ func (t *http2Server) Write(s *Stream, data []byte, opts *Options) error {
 		}
 		p := r.Next(size)
 		ps := len(p)
+		if sq-ps <= int(t.streamSendQuota/2) || tq-ps <= int(t.streamSendQuota/2) {
+			// The Delay flag can help to do larger batches of
+			// write flushes, but it could cause deadlock
+			// if quota gets used up without a flush.
+			// Any threshold >= 0 avoids deadlock, but the
+			// t.streamSendQuota/2 threshold can keep window
+			// updates and data frames async.
+			ignoreDelayFlag = true
+		}
 		if ps < sq {
 			// Overbooked stream quota. Return it back.
 			s.sendQuotaPool.add(sq - ps)
@@ -694,19 +717,23 @@ func (t *http2Server) Write(s *Stream, data []byte, opts *Options) error {
 		default:
 		}
 		var forceFlush bool
+		// Don't flush at all if the delay flag was set
 		if r.Len() == 0 && t.framer.adjustNumWriters(0) == 1 && !opts.Last {
-			forceFlush = true
+			if ignoreDelayFlag || !opts.Delay {
+				forceFlush = true
+			}
 		}
 		if err := t.framer.writeData(forceFlush, s.id, false, p); err != nil {
 			t.Close()
 			return connectionErrorf(true, err, "transport: %v", err)
 		}
 		if t.framer.adjustNumWriters(-1) == 0 {
-			t.framer.flushWrite()
+			if ignoreDelayFlag || !opts.Delay {
+				t.framer.flushWrite()
+			}
 		}
 		t.writableChan <- 0
 	}
-
 }
 
 func (t *http2Server) applySettings(ss []http2.Setting) {

--- a/transport/http_util.go
+++ b/transport/http_util.go
@@ -475,7 +475,10 @@ func (f *framer) writeSettings(forceFlush bool, settings ...http2.Setting) error
 		return err
 	}
 	if forceFlush {
-		return f.writer.Flush()
+		if err := f.writer.Flush(); err != nil {
+			return err
+		}
+		return nil
 	}
 	return nil
 }

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -1,5 +1,4 @@
 /*
- *
  * Copyright 2014, Google Inc.
  * All rights reserved.
  *
@@ -483,7 +482,7 @@ type ServerTransport interface {
 
 	// WriteHeader sends the header metadata for the given stream.
 	// WriteHeader may not be called on all streams.
-	WriteHeader(s *Stream, md metadata.MD) error
+	WriteHeader(s *Stream, md metadata.MD, opts Options) error
 
 	// Write sends the data for the given stream.
 	// Write may not be called on all streams.
@@ -492,7 +491,7 @@ type ServerTransport interface {
 	// WriteStatus sends the status of a stream to the client.
 	// WriteStatus is the final call made on a stream and always
 	// occurs.
-	WriteStatus(s *Stream, statusCode codes.Code, statusDesc string) error
+	WriteStatus(s *Stream, statusCode codes.Code, statusDesc string, opts Options) error
 
 	// Close tears down the transport. Once it is called, the transport
 	// should not be accessed any more. All the pending streams and their
@@ -504,6 +503,10 @@ type ServerTransport interface {
 
 	// Drain notifies the client this ServerTransport stops accepting new RPCs.
 	Drain()
+
+	// Used from the server to keep track of concurrently completing unary
+	// calls, in order to get better batching
+	AdjustNumCompletingUnaryCalls(amount int32) int32
 }
 
 // streamErrorf creates an StreamError with the specified error code and description.


### PR DESCRIPTION
Combines the metadata, message, and status into one flush on unary responses, and combines some flushes of overlapping responses too. Seen good QPS results when this is combined with https://github.com/grpc/grpc-go/pull/955