### PR TITLE
Fix panic 'close of closed channel' when there is no address available to dial.

### DIFF
--- a/balancer.go
+++ b/balancer.go
@@ -395,6 +395,7 @@ func (rr *roundRobin) Close() error {
 	}
 	if rr.addrCh != nil {
 		close(rr.addrCh)
+		rr.addrCh = nil
 	}
 	return nil
 }


### PR DESCRIPTION
Fix panic 'close of closed channel' when there is no address available to dial.