### PR TITLE
metadata: provide read abstraction

### DIFF
--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -46,11 +46,14 @@ const (
 	binHdrSuffix = "-bin"
 )
 
+// encodeKey canonicalizes a key value qualified for transmission via gRPC.
+// TODO(zhaoq): Maybe check if k is ASCII also.
+func encodeKey(k string) string { return strings.ToLower(k) }
+
 // encodeKeyValue encodes key and value qualified for transmission via gRPC.
 // Transmitting binary headers violates HTTP/2 spec.
-// TODO(zhaoq): Maybe check if k is ASCII also.
 func encodeKeyValue(k, v string) (string, string) {
-	k = strings.ToLower(k)
+	k = encodeKey(k)
 	if strings.HasSuffix(k, binHdrSuffix) {
 		val := base64.StdEncoding.EncodeToString([]byte(v))
 		v = string(val)
@@ -89,6 +92,12 @@ func New(m map[string]string) MD {
 		md[key] = append(md[key], val)
 	}
 	return md
+}
+
+// Vals retrieves the values for the given metadata key
+func (md MD) Vals(k string) ([]string, bool) {
+	vals, ok := md[encodeKey(k)]
+	return vals, ok
 }
 
 // Pairs returns an MD formed by the mapping of key, value ...

--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -84,6 +84,28 @@ func TestDecodeKeyValue(t *testing.T) {
 	}
 }
 
+func TestVals(t *testing.T) {
+	for _, test := range []struct {
+		key, val string
+	}{
+		{"key", "val0"},
+		{"Key", "val1"},
+		{"KEY", "val2"},
+	} {
+		md := Pairs(test.key, test.val)
+		vals, ok := md.Vals(test.key)
+		if !ok {
+			t.Fatalf("md.Vals(%s) could not retrieve slice of vals, expected slice", test.key)
+		}
+		if len(vals) != 1 {
+			t.Fatalf("md.Vals(%s) has length %d, want slice of length 1", test.key, len(vals))
+		}
+		if vals[0] != test.val {
+			t.Fatalf("md.Vals(%s) = [%s], want [%s]", test.key, vals[0], test.val)
+		}
+	}
+}
+
 func TestPairsMD(t *testing.T) {
 	for _, test := range []struct {
 		// input


### PR DESCRIPTION
the metadata package provides a handful of facilities for creating `metadata.MD` values, namely the [`metadata.New`](https://github.com/grpc/grpc-go/blob/c7bdf3912d878994614eb32b7b96158f227417a7/metadata/metadata.go#L84-L92) and [`metadata.Pairs`](https://github.com/grpc/grpc-go/blob/c7bdf3912d878994614eb32b7b96158f227417a7/metadata/metadata.go#L94-L111) functions. Both of these functions transparently encode the keys that are provided in order to (theoretically) ensure that they are valid http/2 header keys.

e.g.:

```go
md := metadata.Pairs("GreatGoodFineKey", "a wonderful value")
fmt.Println(md) // map[greatgoodfinekey:[a wonderful value]]
```

Right now, the key is simply run through `strings.ToLower` [here](https://github.com/grpc/grpc-go/blob/c7bdf3912d878994614eb32b7b96158f227417a7/metadata/metadata.go#L53). For an author to reliably read back these values, they must be aware of the encoding scheme. Attempting to read back the value using the key that was used to write the value (`"GreatGoodFineKey"`) would result in a miss:

```go
fmt.Println(md["GreatGoodFineKey"]) // []
```

There is currently no corresponding read-time abstraction that would allow a developer to reliably read the values for a given key without having to know and apply the key encoding scheme (`strings.ToLower`) in advance. Since this key encoding scheme is likely to change, the asymmetry of the abstraction will only become more cumbersome; any changes to the encoding scheme found within the unexported function [`encodeKeyValue`](https://github.com/grpc/grpc-go/blob/c7bdf3912d878994614eb32b7b96158f227417a7/metadata/metadata.go#L52-L59) could silently break projects that read data from `metadata.MD` values directly. It's notable that the net/http package's definition for http.Header avoids similar pitfalls.

Some read-time abstraction for reading the contents of `metadata.MD` values should be provided.

Attached is a pull request with an option for how this could be handled. I'd be just as happy if the pull request was declined but some other appropriate reliable read mechanism was introduced.

Proposed change is to introduce a corresponding `Vals` method on the `metadata.MD` type, such that the following would hold:

```go
md := metadata.Pairs("GreatGoodFineKey", "a wonderful value")
fmt.Println(md)
vals, _ := md.Vals("GreatGoodFineKey")
fmt.Println(vals) // [a wonderful value]
```

Proposed `Vals` method uses the comma-ok idiom to indicate a metadata key is set with an empty list, since according to [rfc 2616](https://www.w3.org/Protocols/rfc2616/rfc2616-sec2.html#sec2.1) a header can have a key present with zero values. I'm not sure why this is useful or if it's valid in http/2 or as a gRPC metadata key, so it's possible that I'm misinformed here.
