### PR TITLE
FIX: use /usr/bin/env bash in shebang

### DIFF
--- a/codegen.sh
+++ b/codegen.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script serves as an example to demonstrate how to generate the gRPC-Go
 # interface and the related messages from .proto file.

--- a/coverage.sh
+++ b/coverage.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
 
 set -e
 


### PR DESCRIPTION
FIX: grpc/grpc-go#1023