### PR TITLE
Use codes.Code.String() rather than logging integers

### DIFF
--- a/rpc_util.go
+++ b/rpc_util.go
@@ -377,7 +377,7 @@ type rpcError struct {
 }
 
 func (e *rpcError) Error() string {
-	return fmt.Sprintf("rpc error: code = %d desc = %s", e.code, e.desc)
+	return fmt.Sprintf("rpc error: code = %s desc = %s", e.code, e.desc)
 }
 
 // Code returns the error code for err if it was produced by the rpc system.

--- a/transport/handler_server_test.go
+++ b/transport/handler_server_test.go
@@ -188,7 +188,7 @@ func TestHandlerTransport_NewServerHandlerTransport(t *testing.T) {
 				},
 				RequestURI: "/service/foo.bar",
 			},
-			wantErr: `stream error: code = 13 desc = "malformed time-out: transport: timeout unit is not recognized: \"tomorrow\""`,
+			wantErr: `stream error: code = Internal desc = "malformed time-out: transport: timeout unit is not recognized: \"tomorrow\""`,
 		},
 		{
 			name: "with metadata",

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -568,7 +568,7 @@ type StreamError struct {
 }
 
 func (e StreamError) Error() string {
-	return fmt.Sprintf("stream error: code = %d desc = %q", e.Code, e.Desc)
+	return fmt.Sprintf("stream error: code = %s desc = %q", e.Code, e.Desc)
 }
 
 // ContextErr converts the error from context package into a StreamError.


### PR DESCRIPTION
This produces better human-readable error messages.