### PR TITLE
remove proto object allocs on streaming benchmark server

### DIFF
--- a/benchmark/benchmark.go
+++ b/benchmark/benchmark.go
@@ -81,8 +81,9 @@ func (s *testServer) UnaryCall(ctx context.Context, in *testpb.SimpleRequest) (*
 }
 
 func (s *testServer) StreamingCall(stream testpb.BenchmarkService_StreamingCallServer) error {
-	response := new(testpb.SimpleResponse)
-	payload := new(testpb.Payload)
+	response := &testpb.SimpleResponse{
+		Payload: new(testpb.Payload),
+	}
 	in := new(testpb.SimpleRequest)
 	for {
 		// use ServerStream directly to reuse the same testpb.SimpleRequest object
@@ -94,8 +95,7 @@ func (s *testServer) StreamingCall(stream testpb.BenchmarkService_StreamingCallS
 		if err != nil {
 			return err
 		}
-		setPayload(payload, in.ResponseType, int(in.ResponseSize))
-		response.Payload = payload
+		setPayload(response.Payload, in.ResponseType, int(in.ResponseSize))
 		if err := stream.Send(response); err != nil {
 			return err
 		}

--- a/benchmark/benchmark.go
+++ b/benchmark/benchmark.go
@@ -47,7 +47,7 @@ import (
 	"google.golang.org/grpc/grpclog"
 )
 
-// allows reuse of the same testpb.Payload object
+// Allows reuse of the same testpb.Payload object.
 func setPayload(p *testpb.Payload, t testpb.PayloadType, size int) {
 	if size < 0 {
 		grpclog.Fatalf("Requested a response with invalid length %d", size)

--- a/benchmark/benchmark.go
+++ b/benchmark/benchmark.go
@@ -47,7 +47,8 @@ import (
 	"google.golang.org/grpc/grpclog"
 )
 
-func newPayload(t testpb.PayloadType, size int) *testpb.Payload {
+// allows reuse of the same testpb.Payload object
+func setPayload(p *testpb.Payload, t testpb.PayloadType, size int) {
 	if size < 0 {
 		grpclog.Fatalf("Requested a response with invalid length %d", size)
 	}
@@ -59,10 +60,15 @@ func newPayload(t testpb.PayloadType, size int) *testpb.Payload {
 	default:
 		grpclog.Fatalf("Unsupported payload type: %d", t)
 	}
-	return &testpb.Payload{
-		Type: t,
-		Body: body,
-	}
+	p.Type = t
+	p.Body = body
+	return
+}
+
+func newPayload(t testpb.PayloadType, size int) *testpb.Payload {
+	p := new(testpb.Payload)
+	setPayload(p, t, size)
+	return p
 }
 
 type testServer struct {
@@ -75,8 +81,12 @@ func (s *testServer) UnaryCall(ctx context.Context, in *testpb.SimpleRequest) (*
 }
 
 func (s *testServer) StreamingCall(stream testpb.BenchmarkService_StreamingCallServer) error {
+	response := new(testpb.SimpleResponse)
+	payload := new(testpb.Payload)
+	in := new(testpb.SimpleRequest)
 	for {
-		in, err := stream.Recv()
+		// use ServerStream directly to reuse the same testpb.SimpleRequest object
+		err := stream.(grpc.ServerStream).RecvMsg(in)
 		if err == io.EOF {
 			// read done.
 			return nil
@@ -84,9 +94,9 @@ func (s *testServer) StreamingCall(stream testpb.BenchmarkService_StreamingCallS
 		if err != nil {
 			return err
 		}
-		if err := stream.Send(&testpb.SimpleResponse{
-			Payload: newPayload(in.ResponseType, int(in.ResponseSize)),
-		}); err != nil {
+		setPayload(payload, in.ResponseType, int(in.ResponseSize))
+		response.Payload = payload
+		if err := stream.Send(response); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
after https://github.com/grpc/grpc-go/pull/940 and https://github.com/grpc/grpc-go/pull/1010
Protobuf streaming QPS test server's memory alloc profile looks like:

(showing functions that alloc a significant amount of flat memory)
(two 32-core master clients to one 32 core server with #940 and #1010 on top of latest master, QPS was 736K)  
```
6978.25MB of 7017.41MB total (99.44%)
Dropped 89 nodes (cum <= 35.09MB)
      flat  flat%   sum%        cum   cum%
 1208.06MB 17.22% 17.22%  1208.06MB 17.22%  golang.org/x/net/http2.parseDataFrame
 1188.05MB 16.93% 34.15%  4376.64MB 62.37%  google.golang.org/grpc/benchmark.(*testServer).StreamingCall
 1184.55MB 16.88% 51.03%  1184.55MB 16.88%  google.golang.org/grpc/transport.(*Stream).write
  815.52MB 11.62% 62.65%  1628.05MB 23.20%  google.golang.org/grpc/benchmark/grpc_testing.(*benchmarkServiceStreamingCallServer).Recv
  812.02MB 11.57% 74.22%   812.02MB 11.57%  reflect.unsafe_New
  785.02MB 11.19% 85.41%   785.02MB 11.19%  google.golang.org/grpc/benchmark.newPayload
  384.01MB  5.47% 90.88%   768.01MB 10.94%  google.golang.org/grpc.encode
  372.51MB  5.31% 96.19%   372.51MB  5.31%  github.com/golang/protobuf/proto.(*Buffer).enc_len_thing
     216MB  3.08% 99.26%  1400.56MB 19.96%  google.golang.org/grpc/transport.(*http2Server).handleData
   11.50MB  0.16% 99.43%   384.01MB  5.47%  google.golang.org/grpc.protoCodec.Marshal
       1MB 0.014% 99.44%  4377.64MB 62.38%  google.golang.org/grpc.(*Server).processStreamingRPC
```

A large amount of the total allocation is from within the server-side benchmark:
(https://github.com/grpc/grpc-go/blob/master/benchmark/benchmark.go)
```
1188.05MB 16.93% 34.15%  4376.64MB 62.37%  google.golang.org/grpc/benchmark.(*testServer).StreamingCall
...
815.52MB 11.62% 62.65%  1628.05MB 23.20%  google.golang.org/grpc/benchmark/grpc_testing.(*benchmarkServiceStreamingCallServer).Recv
...
  785.02MB 11.19% 85.41%   785.02MB 11.19%  google.golang.org/grpc/benchmark.newPayload
```

These can be removed by reusing the same protobuf objects in the streaming test.

Changing `newPayload` to `setPayload`, and using the `(grpc.Stream).RecvMsg(&object)`, the memory alloc profile on the server looks like:

(still showing functions allocating a significant amount of flat memory)
(same two clients against one 32 core server with #940, #1010, and this change on top of latest master, QPS goes up to 817K on this run)
```
3753.14MB of 3781.74MB total (99.24%)
Dropped 77 nodes (cum <= 18.91MB)
      flat  flat%   sum%        cum   cum%
 1342.06MB 35.49% 35.49%  1342.06MB 35.49%  google.golang.org/grpc/transport.(*Stream).write
 1328.56MB 35.13% 70.62%  1328.56MB 35.13%  golang.org/x/net/http2.parseDataFrame
  428.01MB 11.32% 81.94%   428.01MB 11.32%  github.com/golang/protobuf/proto.(*Buffer).enc_len_thing
  427.01MB 11.29% 93.23%   864.51MB 22.86%  google.golang.org/grpc.encode
  217.50MB  5.75% 98.98%  1559.56MB 41.24%  google.golang.org/grpc/transport.(*http2Server).handleData
    9.50MB  0.25% 99.23%   437.51MB 11.57%  google.golang.org/grpc.protoCodec.Marshal
    0.50MB 0.013% 99.24%   866.51MB 22.91%  google.golang.org/grpc.(*Server).processStreamingRPC
```

so seeing ~3GB allocated from within benchmark removed, QPS increase about 10%.

this is a change only to the benchmark test itself, but I'm thinking this makes sense as a way to use the grpc-go API. But PLMK.

