### PR TITLE
change objects in recvBuffer queue from interface to concrete type to reduce allocs

### DIFF
--- a/transport/handler_server.go
+++ b/transport/handler_server.go
@@ -345,11 +345,11 @@ func (ht *serverHandlerTransport) HandleStreams(startStream func(*Stream), trace
 		for buf := make([]byte, readSize); ; {
 			n, err := req.Body.Read(buf)
 			if n > 0 {
-				s.buf.put(&recvMsg{data: buf[:n:n]})
+				s.buf.put(recvMsg{data: buf[:n:n]})
 				buf = buf[n:]
 			}
 			if err != nil {
-				s.buf.put(&recvMsg{err: mapRecvMsgError(err)})
+				s.buf.put(recvMsg{err: mapRecvMsgError(err)})
 				return
 			}
 			if len(buf) == 0 {

--- a/transport/http2_client.go
+++ b/transport/http2_client.go
@@ -91,7 +91,7 @@ type http2Client struct {
 
 	// controlBuf delivers all the control related tasks (e.g., window
 	// updates, reset streams, and various settings) to the controller.
-	controlBuf *recvBuffer
+	controlBuf *controlBuffer
 	fc         *inFlow
 	// sendQuotaPool provides flow control to outbound message.
 	sendQuotaPool *quotaPool
@@ -230,7 +230,7 @@ func newHTTP2Client(ctx context.Context, addr TargetInfo, opts ConnectOptions) (
 		framer:            newFramer(conn),
 		hBuf:              &buf,
 		hEnc:              hpack.NewEncoder(&buf),
-		controlBuf:        newRecvBuffer(),
+		controlBuf:        newControlBuffer(),
 		fc:                &inFlow{limit: uint32(icwz)},
 		sendQuotaPool:     newQuotaPool(defaultWindowSize),
 		scheme:            scheme,

--- a/transport/http2_server.go
+++ b/transport/http2_server.go
@@ -89,7 +89,7 @@ type http2Server struct {
 	maxStreams uint32
 	// controlBuf delivers all the control related tasks (e.g., window
 	// updates, reset streams, and various settings) to the controller.
-	controlBuf *recvBuffer
+	controlBuf *controlBuffer
 	fc         *inFlow
 	// sendQuotaPool provides flow control to outbound message.
 	sendQuotaPool *quotaPool
@@ -200,7 +200,7 @@ func newHTTP2Server(conn net.Conn, config *ServerConfig) (_ ServerTransport, err
 		hEnc:              hpack.NewEncoder(&buf),
 		maxStreams:        maxStreams,
 		inTapHandle:       config.InTapHandle,
-		controlBuf:        newRecvBuffer(),
+		controlBuf:        newControlBuffer(),
 		fc:                &inFlow{limit: uint32(icwz)},
 		sendQuotaPool:     newQuotaPool(defaultWindowSize),
 		state:             reachable,

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -102,8 +102,7 @@ func (b *recvBuffer) load() {
 	if len(b.backlog) > 0 {
 		select {
 		case b.c <- b.backlog[0]:
-			b.backlog[0].data = nil
-			b.backlog[0].err = nil
+			b.backlog[0] = recvMsg{}
 			b.backlog = b.backlog[1:]
 		default:
 		}

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -65,28 +65,25 @@ type recvMsg struct {
 	err error
 }
 
-func (*recvMsg) item() {}
-
-// All items in an out of a recvBuffer should be the same type.
-type item interface {
-	item()
-}
-
-// recvBuffer is an unbounded channel of item.
+// recvBuffer is an unbounded channel of recvMsg structs.
+// Note recvBuffer differs from controlBuffer only in that recvBuffer
+// holds a channel of only recvMsg structs instead of objects implementing "item" interface.
+// recvBuffer is written to much more often than
+// controlBuffer and using strict recvMsg structs helps avoid allocation in "recvBuffer.put"
 type recvBuffer struct {
-	c       chan item
+	c       chan recvMsg
 	mu      sync.Mutex
-	backlog []item
+	backlog []recvMsg
 }
 
 func newRecvBuffer() *recvBuffer {
 	b := &recvBuffer{
-		c: make(chan item, 1),
+		c: make(chan recvMsg, 1),
 	}
 	return b
 }
 
-func (b *recvBuffer) put(r item) {
+func (b *recvBuffer) put(r recvMsg) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	if len(b.backlog) == 0 {
@@ -105,18 +102,19 @@ func (b *recvBuffer) load() {
 	if len(b.backlog) > 0 {
 		select {
 		case b.c <- b.backlog[0]:
-			b.backlog[0] = nil
+			b.backlog[0].data = nil
+			b.backlog[0].err = nil
 			b.backlog = b.backlog[1:]
 		default:
 		}
 	}
 }
 
-// get returns the channel that receives an item in the buffer.
+// get returns the channel that receives a recvMsg in the buffer.
 //
-// Upon receipt of an item, the caller should call load to send another
-// item onto the channel if there is any.
-func (b *recvBuffer) get() <-chan item {
+// Upon receipt of a recvMsg, the caller should call load to send another
+// recvMsg onto the channel if there is any.
+func (b *recvBuffer) get() <-chan recvMsg {
 	return b.c
 }
 
@@ -147,15 +145,67 @@ func (r *recvBufferReader) Read(p []byte) (n int, err error) {
 		return 0, ContextErr(r.ctx.Err())
 	case <-r.goAway:
 		return 0, ErrStreamDrain
-	case i := <-r.recv.get():
+	case m := <-r.recv.get():
 		r.recv.load()
-		m := i.(*recvMsg)
 		if m.err != nil {
 			return 0, m.err
 		}
 		r.last = bytes.NewReader(m.data)
 		return r.last.Read(p)
 	}
+}
+
+// All items in an out of a controlBuffer should be the same type.
+type item interface {
+	item()
+}
+
+// controlBuffer is an unbounded channel of item.
+type controlBuffer struct {
+	c       chan item
+	mu      sync.Mutex
+	backlog []item
+}
+
+func newControlBuffer() *controlBuffer {
+	b := &controlBuffer{
+		c: make(chan item, 1),
+	}
+	return b
+}
+
+func (b *controlBuffer) put(r item) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if len(b.backlog) == 0 {
+		select {
+		case b.c <- r:
+			return
+		default:
+		}
+	}
+	b.backlog = append(b.backlog, r)
+}
+
+func (b *controlBuffer) load() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if len(b.backlog) > 0 {
+		select {
+		case b.c <- b.backlog[0]:
+			b.backlog[0] = nil
+			b.backlog = b.backlog[1:]
+		default:
+		}
+	}
+}
+
+// get returns the channel that receives an item in the buffer.
+//
+// Upon receipt of an item, the caller should call load to send another
+// item onto the channel if there is any.
+func (b *controlBuffer) get() <-chan item {
+	return b.c
 }
 
 type streamState uint8
@@ -317,7 +367,7 @@ func (s *Stream) SetTrailer(md metadata.MD) error {
 }
 
 func (s *Stream) write(m recvMsg) {
-	s.buf.put(&m)
+	s.buf.put(m)
 }
 
 // Read reads all the data available for this Stream from the transport and


### PR DESCRIPTION
This removes the next largest remaining source of total allocs and appears to make a slight ~2.5-3% QPS improvement after #940, #1010, and #1028.

Based off of the server protobuf streaming QPS test memory profile with the combined changes, shown in #1028, the allocation in:
```
1342.06MB 35.49% 35.49%  1342.06MB 35.49%  google.golang.org/grpc/transport.(*Stream).write
```
looks to be from allocating recvMsg structs onto the heap and passing their reference onto the buffer in 
https://github.com/grpc/grpc-go/blob/master/transport/transport.go#L316
 
Changing the channel recvBuffer to pass by the struct onto the buffer by value, on top of the combined changes in #940, #1010, and #1028, memory profile looks like:

(same testing environment as in #1028)

```
2475.08MB of 2501.20MB total (98.96%)
Dropped 88 nodes (cum <= 12.51MB)
      flat  flat%   sum%        cum   cum%
 1330.56MB 53.20% 53.20%  1330.56MB 53.20%  golang.org/x/net/http2.parseDataFrame
  463.51MB 18.53% 71.73%   928.51MB 37.12%  google.golang.org/grpc.encode
  456.01MB 18.23% 89.96%   456.01MB 18.23%  github.com/golang/protobuf/proto.(*Buffer).enc_len_thing
     214MB  8.56% 98.52%      214MB  8.56%  google.golang.org/grpc/transport.(*http2Server).handleData
       9MB  0.36% 98.88%   465.01MB 18.59%  google.golang.org/grpc.protoCodec.Marshal
       2MB  0.08% 98.96%   934.51MB 37.36%  google.golang.org/grpc.(*Server).processStreamingRPC

```
(total allocation goes from ~3.7GB to ~2.5GB)

QPS roughly goes from ~816K (with combined memory reduces so far) to ~840K on sequential runs.