### PR TITLE
Remove defer in recv msg reader

### DIFF
--- a/transport/transport.go
+++ b/transport/transport.go
@@ -116,7 +116,11 @@ func (r *recvBufferReader) Read(p []byte) (n int, err error) {
 	if r.err != nil {
 		return 0, r.err
 	}
-	defer func() { r.err = err }()
+	n, r.err = r.read(p)
+	return n, r.err
+}
+
+func (r *recvBufferReader) read(p []byte) (n int, err error) {
 	if r.last != nil && len(r.last) > 0 {
 		// Read remaining data left in last call.
 		copied := copy(p, r.last)


### PR DESCRIPTION
based on https://github.com/grpc/grpc-go/pull/940 

this is also a minor improvement that seems visible on top of everything in #1029. 

appears to make ~5% further improvement on the protobuf streaming QPS test. (seeing QPS increase from ~840K to ~880K).

There's not seeing a dramatic change in the profile (multiple defers elsewhere), but the the cum cpu clock in `runtime.defferreturn` gets reduced from about ~4.5-5% to ~3.5-4%

seems easy to remove this in the `recvBuffer.read` since there's no locking involved.

