### PR TITLE
transport: consume per-stream inflow windows ahead of time - large speedup for big messages

### DIFF
--- a/rpc_util.go
+++ b/rpc_util.go
@@ -221,7 +221,7 @@ type parser struct {
 	// r is the underlying reader.
 	// See the comment on recvMsg for the permissible
 	// error types.
-	r io.Reader
+	r transport.FullReader
 
 	// The header of a gRPC message. Find more detail
 	// at http://www.grpc.io/docs/guides/wire.html.
@@ -242,7 +242,7 @@ type parser struct {
 // that the underlying io.Reader must not return an incompatible
 // error.
 func (p *parser) recvMsg(maxMsgSize int) (pf payloadFormat, msg []byte, err error) {
-	if _, err := io.ReadFull(p.r, p.header[:]); err != nil {
+	if _, err := p.r.ReadFull(p.header[:]); err != nil {
 		return 0, nil, err
 	}
 
@@ -258,7 +258,7 @@ func (p *parser) recvMsg(maxMsgSize int) (pf payloadFormat, msg []byte, err erro
 	// TODO(bradfitz,zhaoq): garbage. reuse buffer after proto decoding instead
 	// of making it for each message:
 	msg = make([]byte, int(length))
-	if _, err := io.ReadFull(p.r, msg); err != nil {
+	if _, err := p.r.ReadFull(msg); err != nil {
 		if err == io.EOF {
 			err = io.ErrUnexpectedEOF
 		}

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -2415,7 +2415,7 @@ func TestServerStreaming(t *testing.T) {
 }
 
 func testServerStreaming(t *testing.T, e env, serverRespSizes []int) {
-	const streamingCallTimeout = time.Second * 60
+	const streamingCallTimeout = time.Second * 3 * 60
 
 	te := newTest(t, e)
 	te.startServer(&testServer{security: e.security})
@@ -2614,7 +2614,7 @@ func TestClientStreaming(t *testing.T) {
 }
 
 func testClientStreaming(t *testing.T, e env, clientReqSizes []int) {
-	const streamingCallTimeout = time.Second * 60
+	const streamingCallTimeout = time.Second * 3 * 60
 
 	te := newTest(t, e)
 	te.startServer(&testServer{security: e.security})

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -431,6 +431,7 @@ type test struct {
 	// Configurable knobs, after newTest returns:
 	testServer        testpb.TestServiceServer // nil means none
 	healthServer      *health.Server           // nil means disabled
+	byteBufServer     *byteBufServer           // nil means disabled
 	maxStream         uint32
 	tapHandle         tap.ServerInHandle
 	maxMsgSize        int
@@ -443,6 +444,7 @@ type test struct {
 	streamServerInt   grpc.StreamServerInterceptor
 	unknownHandler    grpc.StreamHandler
 	sc                <-chan grpc.ServiceConfig
+	customCodec       grpc.Codec // nil means none chosen
 
 	// srv and srvAddr are set once startServer is called.
 	srv     *grpc.Server
@@ -532,6 +534,9 @@ func (te *test) startServer(ts testpb.TestServiceServer) {
 	case "clientTimeoutCreds":
 		sopts = append(sopts, grpc.Creds(&clientTimeoutCreds{}))
 	}
+	if te.customCodec != nil {
+		sopts = append(sopts, grpc.CustomCodec(te.customCodec))
+	}
 	s := grpc.NewServer(sopts...)
 	te.srv = s
 	if te.e.httpHandler {
@@ -542,6 +547,9 @@ func (te *test) startServer(ts testpb.TestServiceServer) {
 	}
 	if te.testServer != nil {
 		testpb.RegisterTestServiceServer(s, te.testServer)
+	}
+	if te.byteBufServer != nil {
+		s.RegisterService(&_ByteBufTestService_serviceDesc, te.byteBufServer)
 	}
 	addr := la
 	switch te.e.network {
@@ -602,6 +610,9 @@ func (te *test) clientConn() *grpc.ClientConn {
 	}
 	if te.e.balancer {
 		opts = append(opts, grpc.WithBalancer(grpc.RoundRobin(nil)))
+	}
+	if te.customCodec != nil {
+		opts = append(opts, grpc.WithCodec(te.customCodec))
 	}
 	var err error
 	te.cc, err = grpc.Dial(te.srvAddr, opts...)
@@ -3713,4 +3724,235 @@ func (fw *filterWriter) Write(p []byte) (n int, err error) {
 		}
 	}
 	return fw.dst.Write(p)
+}
+
+var _ByteBufTestService_serviceDesc = grpc.ServiceDesc{
+	ServiceName: "grpc.testing.ByteBufTestService",
+	HandlerType: (*ByteBufTestServiceServer)(nil),
+	Methods: []grpc.MethodDesc{},
+	Streams: []grpc.StreamDesc{
+		{
+			StreamName:    "StreamingInputCall",
+			Handler:       _ByteBufTestService_StreamingInputCall_Handler,
+			ClientStreams: true,
+		},
+		{
+			StreamName:    "StreamingOutputCall",
+			Handler:       _ByteBufTestService_StreamingOutputCall_Handler,
+			ServerStreams: true,
+		},
+	},
+	Metadata: "services.proto",
+}
+
+type ByteBufTestServiceServer interface {
+	// A stream of requests followed by a single response.
+	StreamingInputCall(grpc.ServerStream) error
+	// A single request followed by a stream of responses.
+	StreamingOutputCall(*[]byte, grpc.ServerStream) error
+}
+
+func _ByteBufTestService_StreamingInputCall_Handler(srv interface{}, stream grpc.ServerStream) error {
+	return srv.(ByteBufTestServiceServer).StreamingInputCall(stream)
+}
+
+func _ByteBufTestService_StreamingOutputCall_Handler(srv interface{}, stream grpc.ServerStream) error {
+	m := make([]byte, 0)
+	if err := stream.RecvMsg(&m); err != nil {
+		return err
+	}
+	return srv.(ByteBufTestServiceServer).StreamingOutputCall(&m, stream)
+}
+
+type byteBufCodec struct {
+}
+
+func (byteBufCodec) Marshal(v interface{}) ([]byte, error) {
+	b, ok := v.(*[]byte)
+	if !ok {
+		return nil, fmt.Errorf("failed to marshal: %v is not type of *[]byte", v)
+	}
+	return *b, nil
+}
+
+func (byteBufCodec) Unmarshal(data []byte, v interface{}) error {
+	b, ok := v.(*[]byte)
+	if !ok {
+		return fmt.Errorf("failed to marshal: %v is not type of *[]byte", v)
+	}
+	*b = data
+	return nil
+}
+
+func (byteBufCodec) String() string {
+	return "bytebuffer"
+}
+
+type byteBufServer struct {
+	te           *test
+	respSizes    []int
+	reqSizes     []int
+}
+
+func (s *byteBufServer) StreamingInputCall(stream grpc.ServerStream) error {
+	in := make([]byte, 0)
+
+	for _, size := range s.reqSizes {
+		var in []byte
+		err := stream.RecvMsg(&in)
+		if err != nil {
+			s.te.t.Fatal(err)
+		}
+		if len(in) != size {
+			s.te.t.Fatal("received grpc message length %v; want %v", len(in), size)
+		}
+	}
+
+	if err := stream.RecvMsg(&in); err != io.EOF {
+		s.te.t.Fatal("expected EOF; got %v", err)
+		return err
+	}
+
+	out := make([]byte, 0)
+
+	if err := stream.SendMsg(&out); err != nil {
+		s.te.t.Fatal(err)
+	}
+	return nil
+}
+
+func (s *byteBufServer) StreamingOutputCall(in *[]byte, stream grpc.ServerStream) error {
+	for _, size := range s.respSizes {
+		out := make([]byte, size)
+		if err := stream.SendMsg(&out); err != nil {
+			s.te.t.Fatal(err)
+		}
+	}
+	return nil
+}
+
+func byteBufStreamingTestPayloadSizes() [][]int {
+	reqSizes := [][]int{}
+
+	// send 1M zero byte "grpc messages", (total of ~5M total grpc bytes due to 5 byte headers).
+	numZeroBytePayloads := 1 << 20
+	zeroBytePayloads := []int{}
+	for i := 0; i < numZeroBytePayloads; i++ {
+		zeroBytePayloads = append(zeroBytePayloads, 0)
+	}
+	reqSizes = append(reqSizes, zeroBytePayloads)
+
+	return reqSizes
+}
+
+func TestByteBufServerStreaming(t *testing.T) {
+	defer leakCheck(t)()
+
+	respSizes := byteBufStreamingTestPayloadSizes()
+
+	for _, sizes := range respSizes {
+		testByteBufServerStreaming(t, sizes)
+	}
+}
+
+func testByteBufServerStreaming(t *testing.T, respSizes []int) {
+	const timeout = time.Second * 5 * 60
+
+	te := newTest(t, tcpClearEnv)
+
+	b := &byteBufServer{
+		te:        te,
+		respSizes: respSizes,
+	}
+	te.byteBufServer = b
+	te.customCodec = &byteBufCodec{}
+	te.startServer(nil)
+	defer te.tearDown()
+	cc := te.clientConn()
+
+	req := make([]byte, 0)
+	ctx, _ := context.WithTimeout(context.Background(), timeout)
+	stream, err := doByteBufStreamingOutputCall(cc, ctx, &req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var in []byte
+	for _, size := range respSizes {
+		err := stream.RecvMsg(&in)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(in) != size {
+			t.Fatalf("received grpc message length %v; want %v", len(in), size)
+		}
+	}
+
+	if err := stream.RecvMsg(&in); err != io.EOF {
+		t.Fatalf("expected EOF; got %v", err)
+	}
+}
+
+func TestByteBufClientStreaming(t *testing.T) {
+	defer leakCheck(t)()
+
+	respSizes := byteBufStreamingTestPayloadSizes()
+
+	for _, sizes := range respSizes {
+		testByteBufClientStreaming(t, sizes)
+	}
+}
+
+func testByteBufClientStreaming(t *testing.T, reqSizes []int) {
+	const msgSize = 0
+	const timeout = time.Second * 5 * 60
+
+	te := newTest(t, tcpClearEnv)
+
+	b := &byteBufServer{
+		te:        te,
+		reqSizes: reqSizes,
+	}
+	te.byteBufServer = b
+	te.customCodec = &byteBufCodec{}
+	te.startServer(nil)
+	defer te.tearDown()
+	cc := te.clientConn()
+
+	req := make([]byte, msgSize)
+	ctx, _ := context.WithTimeout(context.Background(), timeout)
+	stream, err := doByteBufStreamingOutputCall(cc, ctx, &req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, size := range reqSizes {
+		in := make([]byte, size)
+		err := stream.SendMsg(&in)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := stream.CloseSend(); err != nil {
+		t.Fatal(err)
+	}
+
+	var in []byte
+	if err := stream.RecvMsg(&in); err != io.EOF {
+		t.Fatal(err)
+	}
+}
+
+func doByteBufStreamingOutputCall(cc *grpc.ClientConn, ctx context.Context, in *[]byte, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+	stream, err := grpc.NewClientStream(ctx, &_ByteBufTestService_serviceDesc.Streams[1], cc, "/grpc.testing.ByteBufTestService/StreamingOutputCall", opts...)
+	if err != nil {
+		return nil, err
+	}
+	if err := stream.SendMsg(in); err != nil {
+		return nil, err
+	}
+	if err := stream.CloseSend(); err != nil {
+		return nil, err
+	}
+	return stream, nil
 }

--- a/test/servertester_test.go
+++ b/test/servertester_test.go
@@ -282,6 +282,12 @@ func (st *serverTester) writeData(streamID uint32, endStream bool, data []byte) 
 	}
 }
 
+func (st *serverTester) writeDataPadded(streamID uint32, endStream bool, data, padding []byte) {
+	if err := st.fr.WriteDataPadded(streamID, endStream, data, padding); err != nil {
+		st.t.Fatalf("Error writing DATA with padding: %v", err)
+	}
+}
+
 func (st *serverTester) writeRSTStream(streamID uint32, code http2.ErrCode) {
 	if err := st.fr.WriteRSTStream(streamID, code); err != nil {
 		st.t.Fatalf("Error writing RST_STREAM: %v", err)

--- a/transport/control.go
+++ b/transport/control.go
@@ -196,8 +196,8 @@ func (f *inFlow) onData(n uint32) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.pendingData += n
-	// ASSERT(f.pendingUpdate >= f.loanedWindowSpace)
-	if f.pendingData+f.pendingUpdate-f.loanedWindowSpace > f.limit {
+	// allow going over the "limit" if there's outstanding "loanedWindowSpace"
+	if f.pendingData+f.pendingUpdate > f.limit+f.loanedWindowSpace {
 		return fmt.Errorf("received %d-bytes data exceeding the limit %d bytes", f.pendingData+f.pendingUpdate, f.limit+f.loanedWindowSpace)
 	}
 	return nil

--- a/transport/http_util.go
+++ b/transport/http_util.go
@@ -495,9 +495,6 @@ func (f *framer) writeSettingsAck(forceFlush bool) error {
 }
 
 func (f *framer) writeWindowUpdate(forceFlush bool, streamID, incr uint32) error {
-	if incr > http2MaxWindowUpdate {
-		grpclog.Fatalf("attempted window update too large. have %v; max is %v", incr, http2MaxWindowUpdate)
-	}
 	if err := f.fr.WriteWindowUpdate(streamID, incr); err != nil {
 		return err
 	}

--- a/transport/http_util.go
+++ b/transport/http_util.go
@@ -495,6 +495,9 @@ func (f *framer) writeSettingsAck(forceFlush bool) error {
 }
 
 func (f *framer) writeWindowUpdate(forceFlush bool, streamID, incr uint32) error {
+	if incr > http2MaxWindowUpdate {
+		grpclog.Fatalf("attempted window update too large. have %v; max is %v", incr, http2MaxWindowUpdate)
+	}
 	if err := f.fr.WriteWindowUpdate(streamID, incr); err != nil {
 		return err
 	}

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -269,8 +269,9 @@ func (s *Stream) ReadFull(p []byte) (n int, err error) {
 	if s.readFullErr != nil {
 		return 0, s.readFullErr
 	}
-	defer func() { s.readFullErr = err }()
-	return io.ReadFull(s.streamReader, p)
+	n, err = io.ReadFull(s.streamReader, p)
+	s.readFullErr = err
+	return n, err
 }
 
 type streamWindowSpaceLoaningReader struct {
@@ -285,10 +286,11 @@ func (r *streamWindowSpaceLoaningReader) Read(p []byte) (n int, err error) {
 	if r.readFullErr != nil {
 		return 0, r.readFullErr
 	}
-	defer func() { r.readFullErr = err }()
 	committedReadAmount := min(maxSingleStreamWindowUpdate, uint32(len(p)))
 	r.loanSpaceInStreamWindow(committedReadAmount)
-	return io.ReadFull(r.wr, p[:committedReadAmount])
+	n, err = io.ReadFull(r.wr, p[:committedReadAmount])
+	r.readFullErr = err
+	return n, err
 }
 
 type connAndStreamWindowConsumingReader struct {

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -48,6 +48,7 @@ import (
 	"golang.org/x/net/http2"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/grpclog"
 	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/stats"
@@ -189,14 +190,12 @@ type Stream struct {
 	recvCompress string
 	sendCompress string
 	buf          *recvBuffer
-	dec          io.Reader
 	fc           *inFlow
 	recvQuota    uint32
 	// The accumulated inbound quota pending for window update.
-	updateQuota uint32
-	// The handler to control the window update procedure for both this
-	// particular stream and the associated transport.
-	windowHandler func(int)
+	updateQuota  uint32
+	readFullErr  error
+	streamReader io.Reader
 
 	sendQuotaPool *quotaPool
 	// Close headerChan to indicate the end of reception of header metadata.
@@ -220,6 +219,94 @@ type Stream struct {
 	rstStream bool
 	// rstError is the error that needs to be sent along with the RST_STREAM frame.
 	rstError http2.ErrCode
+}
+
+func (s *Stream) setClientStreamReader(consumeConnAndStreamWindows func(uint32), loanSpaceInStreamWindow func(uint32)) {
+	if s.ctx == nil || s.goAway == nil || s.buf == nil {
+		grpclog.Fatalf("Uninitialized stream. s.ctx == nil: %v; s.goAway == nil: %v; s.buf == nil: %v", s.ctx == nil, s.goAway == nil, s.buf == nil)
+	}
+	s.setStreamReader(consumeConnAndStreamWindows, loanSpaceInStreamWindow)
+}
+
+func (s *Stream) setServerStreamReader(consumeConnAndStreamWindows func(uint32), loanSpaceInStreamWindow func(uint32)) {
+	if s.ctx == nil || s.buf == nil {
+		grpclog.Fatalf("Uninitialized stream. s.ctx == nil: %v; s.buf == nil: %v", s.ctx == nil, s.buf == nil)
+	}
+	if s.goAway != nil {
+		grpclog.Fatalf("Unexpected initialization of s.goAway; got %v; want nil", s.goAway)
+	}
+	s.setStreamReader(consumeConnAndStreamWindows, loanSpaceInStreamWindow)
+}
+
+func (s *Stream) setStreamReader(consumeConnAndStreamWindows func(uint32), loanSpaceInStreamWindow func(uint32)) {
+	s.streamReader = &streamWindowSpaceLoaningReader{
+		loanSpaceInStreamWindow: loanSpaceInStreamWindow,
+		wr: &connAndStreamWindowConsumingReader{
+			dec: &recvBufferReader{
+				ctx:    s.ctx,
+				goAway: s.goAway,
+				recv:   s.buf,
+			},
+			consumeConnAndStreamWindows: consumeConnAndStreamWindows,
+		},
+	}
+}
+
+// FullReader makes complete reads into p.
+type FullReader interface {
+	// This Read function blocks until either the len(p) bytes have been read
+	// into p, or until an error occurs.
+	// It's meant to mimick the semantics of the standard libraries io.ReadFull(_, p)
+	// Note that err == nil iff n == len(p).
+	ReadFull(p []byte) (int, error)
+}
+
+// ReadFull reads bytes from the stream and manages flow control as needed.
+// Also note that an error returned by this function indicates an error
+// in the underlying stream, and future calls to Read will continue to
+// return that same error.
+func (s *Stream) ReadFull(p []byte) (n int, err error) {
+	if s.readFullErr != nil {
+		return 0, s.readFullErr
+	}
+	defer func() { s.readFullErr = err }()
+	return io.ReadFull(s.streamReader, p)
+}
+
+type streamWindowSpaceLoaningReader struct {
+	// The handler to control the window update procedure for both this
+	// particular stream and the associated transport.
+	loanSpaceInStreamWindow func(uint32)
+	wr                      *connAndStreamWindowConsumingReader
+	readFullErr             error
+}
+
+func (r *streamWindowSpaceLoaningReader) Read(p []byte) (n int, err error) {
+	if r.readFullErr != nil {
+		return 0, r.readFullErr
+	}
+	defer func() { r.readFullErr = err }()
+	committedReadAmount := min(maxSingleStreamWindowUpdate, uint32(len(p)))
+	r.loanSpaceInStreamWindow(committedReadAmount)
+	return io.ReadFull(r.wr, p[:committedReadAmount])
+}
+
+type connAndStreamWindowConsumingReader struct {
+	dec                         io.Reader
+	consumeConnAndStreamWindows func(uint32)
+}
+
+// Read reads all the data available for this Stream from the transport and
+// passes them into the decoder, which converts them into a gRPC message stream.
+// The error is io.EOF when the stream is done or another non-nil error if
+// the stream broke.
+func (s *connAndStreamWindowConsumingReader) Read(p []byte) (n int, err error) {
+	n, err = s.dec.Read(p)
+	if err != nil {
+		return
+	}
+	s.consumeConnAndStreamWindows(uint32(n))
+	return
 }
 
 // RecvCompress returns the compression algorithm applied to the inbound
@@ -318,19 +405,6 @@ func (s *Stream) SetTrailer(md metadata.MD) error {
 
 func (s *Stream) write(m recvMsg) {
 	s.buf.put(&m)
-}
-
-// Read reads all the data available for this Stream from the transport and
-// passes them into the decoder, which converts them into a gRPC message stream.
-// The error is io.EOF when the stream is done or another non-nil error if
-// the stream broke.
-func (s *Stream) Read(p []byte) (n int, err error) {
-	n, err = s.dec.Read(p)
-	if err != nil {
-		return
-	}
-	s.windowHandler(n)
-	return
 }
 
 // finish sets the stream's state and status, and closes the done channel.

--- a/transport/transport_test.go
+++ b/transport/transport_test.go
@@ -35,6 +35,7 @@ package transport
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -82,6 +83,8 @@ const (
 	misbehaved
 	encodingRequiredStatus
 	invalidHeaderField
+	delayBeginRead
+	delayBeginWrite
 )
 
 func (h *testStreamHandler) handleStream(t *testing.T, s *Stream) {
@@ -92,7 +95,7 @@ func (h *testStreamHandler) handleStream(t *testing.T, s *Stream) {
 		resp = expectedResponseLarge
 	}
 	p := make([]byte, len(req))
-	_, err := io.ReadFull(s, p)
+	_, err := s.ReadFull(p)
 	if err != nil {
 		return
 	}
@@ -100,6 +103,56 @@ func (h *testStreamHandler) handleStream(t *testing.T, s *Stream) {
 		t.Fatalf("handleStream got %v, want %v", p, req)
 	}
 	// send a response back to the client.
+	h.t.Write(s, resp, &Options{})
+	// send the trailer to end the stream.
+	h.t.WriteStatus(s, status.New(codes.OK, ""))
+}
+
+func (h *testStreamHandler) handleStreamDelayBeginRead(t *testing.T, s *Stream) {
+	req := expectedRequest
+	resp := expectedResponse
+	if s.Method() == "foo.Large" {
+		req = expectedRequestLarge
+		resp = expectedResponseLarge
+	}
+	p := make([]byte, len(req))
+
+	// Wait before reading. Give time to client to start sending
+	// before server starts reading.
+	time.Sleep(2 * time.Second)
+	_, err := s.ReadFull(p)
+	if err != nil {
+		return
+	}
+
+	if !bytes.Equal(p, req) {
+		t.Fatalf("handleStream got %v, want %v", p, req)
+	}
+	// send a response back to the client.
+	h.t.Write(s, resp, &Options{})
+	// send the trailer to end the stream.
+	h.t.WriteStatus(s, status.New(codes.OK, ""))
+}
+
+func (h *testStreamHandler) handleStreamDelayBeginWrite(t *testing.T, s *Stream) {
+	req := expectedRequest
+	resp := expectedResponse
+	if s.Method() == "foo.Large" {
+		req = expectedRequestLarge
+		resp = expectedResponseLarge
+	}
+	p := make([]byte, len(req))
+	_, err := s.ReadFull(p)
+	if err != nil {
+		return
+	}
+	if !bytes.Equal(p, req) {
+		t.Fatalf("handleStream got %v, want %v", p, req)
+	}
+
+	// Wait before sending. Give time to client to start reading
+	// before server starts sending.
+	time.Sleep(2 * time.Second)
 	h.t.Write(s, resp, &Options{})
 	// send the trailer to end the stream.
 	h.t.WriteStatus(s, status.New(codes.OK, ""))
@@ -216,6 +269,18 @@ func (s *server) start(t *testing.T, port int, serverConfig *ServerConfig, ht hT
 		case invalidHeaderField:
 			go transport.HandleStreams(func(s *Stream) {
 				go h.handleStreamInvalidHeaderField(t, s)
+			}, func(ctx context.Context, method string) context.Context {
+				return ctx
+			})
+		case delayBeginRead:
+			go transport.HandleStreams(func(s *Stream) {
+				go h.handleStreamDelayBeginRead(t, s)
+			}, func(ctx context.Context, method string) context.Context {
+				return ctx
+			})
+		case delayBeginWrite:
+			go transport.HandleStreams(func(s *Stream) {
+				go h.handleStreamDelayBeginWrite(t, s)
 			}, func(ctx context.Context, method string) context.Context {
 				return ctx
 			})
@@ -694,11 +759,11 @@ func TestClientSendAndReceive(t *testing.T) {
 		t.Fatalf("failed to send data: %v", err)
 	}
 	p := make([]byte, len(expectedResponse))
-	_, recvErr := io.ReadFull(s1, p)
+	_, recvErr := s1.ReadFull(p)
 	if recvErr != nil || !bytes.Equal(p, expectedResponse) {
 		t.Fatalf("Error: %v, want <nil>; Result: %v, want %v", recvErr, p, expectedResponse)
 	}
-	_, recvErr = io.ReadFull(s1, p)
+	_, recvErr = s1.ReadFull(p)
 	if recvErr != io.EOF {
 		t.Fatalf("Error: %v; want <EOF>", recvErr)
 	}
@@ -734,9 +799,9 @@ func performOneRPC(ct ClientTransport) {
 		//
 		// Read response
 		p := make([]byte, len(expectedResponse))
-		io.ReadFull(s, p)
+		s.ReadFull(p)
 		// Read io.EOF
-		io.ReadFull(s, p)
+		s.ReadFull(p)
 	}
 }
 
@@ -775,10 +840,82 @@ func TestLargeMessage(t *testing.T) {
 				t.Errorf("%v.Write(_, _, _) = %v, want  <nil>", ct, err)
 			}
 			p := make([]byte, len(expectedResponseLarge))
-			if _, err := io.ReadFull(s, p); err != nil || !bytes.Equal(p, expectedResponseLarge) {
-				t.Errorf("io.ReadFull(_, %v) = _, %v, want %v, <nil>", err, p, expectedResponse)
+			if _, err := s.ReadFull(p); err != nil || !bytes.Equal(p, expectedResponseLarge) {
+				t.Errorf("io.ReadFull(%v) = _, %v, want %v, <nil>", err, p, expectedResponse)
 			}
-			if _, err = io.ReadFull(s, p); err != io.EOF {
+			if _, err = s.ReadFull(p); err != io.EOF {
+				t.Errorf("Failed to complete the stream %v; want <EOF>", err)
+			}
+		}()
+	}
+	wg.Wait()
+	ct.Close()
+	server.stop()
+}
+
+// Try to catch issues in flow control that depend on data arrival/read order
+func TestLargeMessageDelayBeginRead(t *testing.T) {
+	server, ct := setUp(t, 0, math.MaxUint32, delayBeginRead)
+	callHdr := &CallHdr{
+		Host:   "localhost",
+		Method: "foo.Large",
+	}
+	var wg sync.WaitGroup
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			s, err := ct.NewStream(context.Background(), callHdr)
+			if err != nil {
+				t.Errorf("%v.NewStream(_, _) = _, %v, want _, <nil>", ct, err)
+			}
+			if err := ct.Write(s, expectedRequestLarge, &Options{Last: true, Delay: false}); err != nil && err != io.EOF {
+				t.Errorf("%v.Write(_, _, _) = %v, want  <nil>", ct, err)
+			}
+			p := make([]byte, len(expectedResponseLarge))
+
+			// Give time to server to begin sending before client starts reading.
+			time.Sleep(2 * time.Second)
+			if _, err := s.ReadFull(p); err != nil || !bytes.Equal(p, expectedResponseLarge) {
+				t.Errorf("io.ReadFull(%v) = _, %v, want %v, <nil>", err, p, expectedResponse)
+			}
+			if _, err = s.ReadFull(p); err != io.EOF {
+				t.Errorf("Failed to complete the stream %v; want <EOF>", err)
+			}
+		}()
+	}
+	wg.Wait()
+	ct.Close()
+	server.stop()
+}
+
+// Try to catch issues in flow control that depend on data arrival/read order
+func TestLargeMessageDelayBeginWrite(t *testing.T) {
+	server, ct := setUp(t, 0, math.MaxUint32, delayBeginWrite)
+	callHdr := &CallHdr{
+		Host:   "localhost",
+		Method: "foo.Large",
+	}
+	var wg sync.WaitGroup
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			s, err := ct.NewStream(context.Background(), callHdr)
+			if err != nil {
+				t.Errorf("%v.NewStream(_, _) = _, %v, want _, <nil>", ct, err)
+			}
+
+			// Give time to server to start reading before client starts sending.
+			time.Sleep(2 * time.Second)
+			if err := ct.Write(s, expectedRequestLarge, &Options{Last: true, Delay: false}); err != nil && err != io.EOF {
+				t.Errorf("%v.Write(_, _, _) = %v, want  <nil>", ct, err)
+			}
+			p := make([]byte, len(expectedResponseLarge))
+			if _, err := s.ReadFull(p); err != nil || !bytes.Equal(p, expectedResponseLarge) {
+				t.Errorf("io.ReadFull(%v) = _, %v, want %v, <nil>", err, p, expectedResponse)
+			}
+			if _, err = s.ReadFull(p); err != io.EOF {
 				t.Errorf("Failed to complete the stream %v; want <EOF>", err)
 			}
 		}()
@@ -821,10 +958,10 @@ func TestGracefulClose(t *testing.T) {
 		t.Fatalf("%v.Write(_, _, _) = %v, want  <nil>", ct, err)
 	}
 	p := make([]byte, len(expectedResponse))
-	if _, err := io.ReadFull(s, p); err != nil || !bytes.Equal(p, expectedResponse) {
-		t.Fatalf("io.ReadFull(_, %v) = _, %v, want %v, <nil>", err, p, expectedResponse)
+	if _, err := s.ReadFull(p); err != nil || !bytes.Equal(p, expectedResponse) {
+		t.Fatalf("io.ReadFull(%v) = _, %v, want %v, <nil>", err, p, expectedResponse)
 	}
-	if _, err = io.ReadFull(s, p); err != io.EOF {
+	if _, err = s.ReadFull(p); err != io.EOF {
 		t.Fatalf("Failed to complete the stream %v; want <EOF>", err)
 	}
 	wg.Wait()
@@ -1072,7 +1209,7 @@ func TestServerWithMisbehavedClient(t *testing.T) {
 	}
 	// Server sent a resetStream for s already.
 	code := http2ErrConvTab[http2.ErrCodeFlowControl]
-	if _, err := io.ReadFull(s, make([]byte, 1)); err != io.EOF {
+	if _, err := s.ReadFull(make([]byte, 1)); err != io.EOF {
 		t.Fatalf("%v got err %v want <EOF>", s, err)
 	}
 	if s.status.Code() != code {
@@ -1120,10 +1257,12 @@ func TestClientWithMisbehavedServer(t *testing.T) {
 	if err := ct.Write(s, d, &Options{Last: true, Delay: false}); err != nil && err != io.EOF {
 		t.Fatalf("Failed to write: %v", err)
 	}
+	// reflect to get the inner recvBufferReader, which reads without doing window updates
+	recvBufferReader := s.streamReader.(*streamWindowSpaceLoaningReader).wr.dec
 	// Read without window update.
 	for {
 		p := make([]byte, http2MaxFrameLen)
-		if _, err = s.dec.Read(p); err != nil {
+		if _, err = recvBufferReader.Read(p); err != nil {
 			break
 		}
 	}
@@ -1182,7 +1321,9 @@ func TestEncodingRequiredStatus(t *testing.T) {
 		t.Fatalf("Failed to write the request: %v", err)
 	}
 	p := make([]byte, http2MaxFrameLen)
-	if _, err := s.dec.Read(p); err != io.EOF {
+	// reflect to get the plain recvBufferReader from the stream's stream reader, which doesn't do window updates
+	recvBufferReader := s.streamReader.(*streamWindowSpaceLoaningReader).wr.dec
+	if _, err := recvBufferReader.Read(p); err != io.EOF {
 		t.Fatalf("Read got error %v, want %v", err, io.EOF)
 	}
 	if !reflect.DeepEqual(s.Status(), encodingTestStatus) {
@@ -1210,7 +1351,8 @@ func TestInvalidHeaderField(t *testing.T) {
 		t.Fatalf("Failed to write the request: %v", err)
 	}
 	p := make([]byte, http2MaxFrameLen)
-	_, err = s.dec.Read(p)
+	// reflect to get the inner recvBufferReader, which reads without doing window updates
+	_, err = s.streamReader.(*streamWindowSpaceLoaningReader).wr.dec.Read(p)
 	if se, ok := err.(StreamError); !ok || se.Code != codes.FailedPrecondition || !strings.Contains(err.Error(), expectedInvalidHeaderField) {
 		t.Fatalf("Read got error %v, want error with code %s and contains %q", err, codes.FailedPrecondition, expectedInvalidHeaderField)
 	}
@@ -1263,6 +1405,46 @@ func TestContextErr(t *testing.T) {
 		err := ContextErr(test.errIn)
 		if err != test.errOut {
 			t.Fatalf("ContextErr{%v} = %v \nwant %v", test.errIn, err, test.errOut)
+		}
+	}
+}
+
+// If any error occurs on a call to Stream.ReadFull, future calls
+// should continue to return that same error.
+func TestReadFullGivesSameErrorAfterAnyErrorOccurs(t *testing.T) {
+	testRecvBuffer := newRecvBuffer()
+	s := &Stream{
+		ctx:    context.Background(),
+		goAway: make(chan struct{}),
+		buf:    testRecvBuffer,
+	}
+	s.setClientStreamReader(func(uint32) {}, func(uint32) {})
+
+	testData := make([]byte, 1)
+	testData[0] = 5
+	testErr := errors.New("test error")
+	s.write(recvMsg{data: testData, err: testErr})
+
+	inBuf := make([]byte, 1)
+	actualCount, actualErr := s.ReadFull(inBuf)
+	if actualCount != 0 {
+		t.Errorf("actualCount, _ := io.ReadFull(_) differs; want %v; got %v", 0, actualCount)
+	}
+	if actualErr.Error() != testErr.Error() {
+		t.Errorf("_ , actualErr := io.ReadFull(_) differs; want actualErr.Error() to be %v; got %v", testErr.Error(), actualErr.Error())
+	}
+
+	s.write(recvMsg{data: testData, err: nil})
+	s.write(recvMsg{data: testData, err: errors.New("different error from first")})
+
+	for i := 0; i < 2; i++ {
+		inBuf := make([]byte, 1)
+		actualCount, actualErr := s.ReadFull(inBuf)
+		if actualCount != 0 {
+			t.Errorf("actualCount, _ := io.ReadFull(_) differs; want %v; got %v", 0, actualCount)
+		}
+		if actualErr.Error() != testErr.Error() {
+			t.Errorf("_ , actualErr := io.ReadFull(_) differs; want actualErr.Error() to be %v; got %v", testErr.Error(), actualErr.Error())
 		}
 	}
 }


### PR DESCRIPTION
This is one solution to the problem with grpc vs. http1 that was noticed in https://github.com/grpc/grpc-go/issues/1043. (fixed 64K window causing too many round trips for large messages).

Consumes inflow stream windows based off of requested read size (so e.g., gives stream window update of 2M for 2M grpc message before reading it in, but doesn't change connection window).

This technique used in C-core? cc @ctiller.

Can have big speedup for large messages (e.g, ~10s for 2M request/response down to ~1s, with 150ms RTT).

AFAICS `Stream.Read` isn't safe to do this with since `io.Read` could be called repeatedly - possible to do but to me a rename seems safer... So this changes transport package to expose `Stream.ReadFull(_)`, which tries to be equivalent to current `io.ReadFull("stream", _)`