### PR TITLE
Support proxy

### DIFF
--- a/clientconn.go
+++ b/clientconn.go
@@ -350,7 +350,6 @@ func DialContext(ctx context.Context, target string, opts ...DialOption) (conn *
 	}
 
 	if cc.dopts.pm != nil {
-		// target, cc.proxyHeader, err = cc.dopts.pm.MapName(ctx, target)
 		t, h, err := cc.dopts.pm.MapName(ctx, target)
 		if err != nil && err != proxy.ErrIneffective {
 			return nil, err
@@ -777,20 +776,20 @@ func (ac *addrConn) resetTransport(closeTransport bool) error {
 	}
 	if ac.cc.dopts.pm != nil {
 		sinfo.UsingProxy = ac.cc.usingProxy
-		sinfo.ConnectTarget = ac.cc.target
+		sinfo.RealTarget = ac.cc.target
 		sinfo.Header = ac.cc.proxyHeader
 
-		tempAddr, tempHeader, err := ac.cc.dopts.pm.MapAddress(ac.ctx, ac.cc.target, ac.addr.Addr)
+		ta, th, err := ac.cc.dopts.pm.MapAddress(ac.ctx, ac.cc.target, ac.addr.Addr)
 		if err != nil && err != proxy.ErrIneffective {
 			return err
 		} else if err == nil {
 			sinfo.UsingProxy = true
-			sinfo.Addr = tempAddr
-			sinfo.ConnectTarget = ac.addr.Addr
+			sinfo.Addr = ta
+			sinfo.RealTarget = ac.addr.Addr
 			if sinfo.Header == nil {
-				sinfo.Header = tempHeader
+				sinfo.Header = th
 			} else {
-				for k, v := range tempHeader {
+				for k, v := range th {
 					sinfo.Header[k] = append(sinfo.Header[k], v...)
 				}
 			}

--- a/proxy/mapper.go
+++ b/proxy/mapper.go
@@ -1,0 +1,57 @@
+/*
+ *
+ * Copyright 2017, Google Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+// Package proxy ...
+package proxy // import "google.golang.org/grpc/proxy"
+import (
+	"errors"
+
+	"golang.org/x/net/context"
+)
+
+// ErrIneffective indicates the mapper function is not effective.
+var ErrIneffective = errors.New("Mapper function is not effective")
+
+// Mapper defines the interface gRPC uses to map the proxy address.
+type Mapper interface {
+	// MapName is called before the server name is resolved.
+	// It can be used to programmatically override the name that will be resolved.
+	// It returns the URI of the proxy, and the header to be sent in the request.
+	// ErrIneffective should be returned if the function is not effective.
+	MapName(ctx context.Context, uri string) (string, map[string][]string, error)
+	// MapAddress is called before we connect to the target address.
+	// It can be used to programmatically override the address that we will connect to.
+	// It returns the address of the proxy, and the header to be sent in the request.
+	// ErrIneffective should be returned if the function is not effective.
+	MapAddress(ctx context.Context, uri string, address string) (string, map[string][]string, error)
+}

--- a/proxy/mapper.go
+++ b/proxy/mapper.go
@@ -31,7 +31,7 @@
  *
  */
 
-// Package proxy ...
+// Package proxy defines interfaces to support proxyies in gRPC.
 package proxy // import "google.golang.org/grpc/proxy"
 import (
 	"errors"

--- a/rpc_util.go
+++ b/rpc_util.go
@@ -136,16 +136,6 @@ func (d *gzipDecompressor) Type() string {
 	return "gzip"
 }
 
-// ProxyMapper defines the interface gRPC uses to map the proxy address.
-type ProxyMapper interface {
-	// MapName is called before the server name is resolved.
-	// It can be used to programmatically override the name that will be resolved.
-	MapName(ctx context.Context, uri string) (string, error)
-	// MapAddress is called before we connect to the target address.
-	// It can be used to programmatically override the address that we will connect to.
-	MapAddress(ctx context.Context, uri string, address Address) (Address, error)
-}
-
 // callInfo contains all related configuration and information about an RPC.
 type callInfo struct {
 	failFast  bool

--- a/rpc_util.go
+++ b/rpc_util.go
@@ -136,6 +136,16 @@ func (d *gzipDecompressor) Type() string {
 	return "gzip"
 }
 
+// ProxyMapper defines the interface gRPC uses to map the proxy address.
+type ProxyMapper interface {
+	// MapName is called before the server name is resolved.
+	// It can be used to programmatically override the name that will be resolved.
+	MapName(ctx context.Context, uri string) (string, error)
+	// MapAddress is called before we connect to the target address.
+	// It can be used to programmatically override the address that we will connect to.
+	MapAddress(ctx context.Context, uri string, address Address) (Address, error)
+}
+
 // callInfo contains all related configuration and information about an RPC.
 type callInfo struct {
 	failFast  bool

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -3438,7 +3438,10 @@ func (p *proxyServer) run() {
 	}
 	p.in = in
 
+	p.t.Logf("received conn")
+
 	req, err := http.ReadRequest(bufio.NewReader(in))
+	p.t.Logf("received request: %+v", req)
 	if err != nil {
 		p.t.Errorf("failed to read CONNECT req: %v", err)
 		return
@@ -3450,13 +3453,14 @@ func (p *proxyServer) run() {
 		p.t.Errorf("get wrong CONNECT req: %+v", req)
 		return
 	}
+	p.t.Logf("req.URL.Host: %+v", req.URL.Host)
 
 	out, err := net.Dial("tcp", req.URL.Host)
 	if err != nil {
 		p.t.Errorf("failed to dial to server: %v", err)
 		return
 	}
-	resp := http.Response{StatusCode: 200}
+	resp := http.Response{StatusCode: 200, Proto: "HTTP/1.0"}
 	resp.Write(p.in)
 	p.out = out
 	go io.Copy(p.in, p.out)
@@ -3524,6 +3528,7 @@ func testProxyMapName(t *testing.T, e env) {
 		oldAddr: te.srvAddr,
 		newAddr: lis.Addr().String(),
 	}
+	t.Logf("oldAddr: %s, newAddr: %s", te.srvAddr, lis.Addr())
 	tc := testpb.NewTestServiceClient(te.clientConn())
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -34,6 +34,7 @@
 package grpc_test
 
 import (
+	"bufio"
 	"bytes"
 	"crypto/tls"
 	"errors"
@@ -43,6 +44,7 @@ import (
 	"log"
 	"math"
 	"net"
+	"net/http"
 	"os"
 	"reflect"
 	"runtime"
@@ -65,6 +67,7 @@ import (
 	"google.golang.org/grpc/internal"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/peer"
+	"google.golang.org/grpc/proxy"
 	"google.golang.org/grpc/tap"
 	testpb "google.golang.org/grpc/test/grpc_testing"
 )
@@ -429,6 +432,7 @@ type test struct {
 	unaryServerInt    grpc.UnaryServerInterceptor
 	streamServerInt   grpc.StreamServerInterceptor
 	sc                <-chan grpc.ServiceConfig
+	pm                proxy.Mapper
 
 	// srv and srvAddr are set once startServer is called.
 	srv     *grpc.Server
@@ -565,6 +569,9 @@ func (te *test) clientConn() *grpc.ClientConn {
 	}
 	if te.streamClientInt != nil {
 		opts = append(opts, grpc.WithStreamInterceptor(te.streamClientInt))
+	}
+	if te.pm != nil {
+		opts = append(opts, grpc.WithProxyMapper(te.pm))
 	}
 	switch te.e.security {
 	case "tls":
@@ -3414,6 +3421,161 @@ func (s *flowControlLogicalRaceServer) StreamingOutputCall(req *testpb.Streaming
 		}
 	}
 	return nil
+}
+
+type proxyServer struct {
+	t   *testing.T
+	lis net.Listener
+	in  net.Conn
+	out net.Conn
+}
+
+func (p *proxyServer) run() {
+	in, err := p.lis.Accept()
+	if err != nil {
+		p.t.Errorf("failed to accept: %v", err)
+		return
+	}
+	p.in = in
+
+	req, err := http.ReadRequest(bufio.NewReader(in))
+	if err != nil {
+		p.t.Errorf("failed to read CONNECT req: %v", err)
+		return
+	}
+	if req.Method != "CONNECT" || req.UserAgent() != "test-agent" {
+		resp := http.Response{StatusCode: 405}
+		resp.Write(p.in)
+		p.in.Close()
+		p.t.Errorf("get wrong CONNECT req: %+v", req)
+		return
+	}
+
+	out, err := net.Dial("tcp", req.URL.Host)
+	if err != nil {
+		p.t.Errorf("failed to dial to server: %v", err)
+		return
+	}
+	resp := http.Response{StatusCode: 200}
+	resp.Write(p.in)
+	p.out = out
+	go io.Copy(p.in, p.out)
+	go io.Copy(p.out, p.in)
+}
+
+func (p *proxyServer) stop() {
+	p.lis.Close()
+	if p.in != nil {
+		p.in.Close()
+	}
+	if p.out != nil {
+		p.out.Close()
+	}
+}
+
+type proxyMapper struct {
+	mapName, mapAddress bool
+	oldAddr             string
+	newAddr             string
+}
+
+func (p *proxyMapper) MapName(ctx context.Context, uri string) (string, map[string][]string, error) {
+	if !p.mapName {
+		return "", nil, proxy.ErrIneffective
+	}
+	if uri != p.oldAddr {
+		return "", nil, fmt.Errorf("in proxy MapName, got uri: %s, want uri: %s", uri, p.oldAddr)
+	}
+	return p.newAddr, map[string][]string{"User-Agent": {"test-agent"}}, nil
+}
+func (p *proxyMapper) MapAddress(ctx context.Context, uri string, address string) (string, map[string][]string, error) {
+	if !p.mapAddress {
+		return "", nil, proxy.ErrIneffective
+	}
+	if address != p.oldAddr {
+		return "", nil, fmt.Errorf("in proxy MapAddress, got address: %s, want address: %s", address, p.oldAddr)
+	}
+	return p.newAddr, map[string][]string{"User-Agent": {"test-agent"}}, nil
+}
+
+func TestProxyMapName(t *testing.T) {
+	defer leakCheck(t)()
+	for _, e := range []env{tcpClearEnv, tcpTLSEnv} {
+		testProxyMapName(t, e)
+	}
+}
+
+func testProxyMapName(t *testing.T, e env) {
+	te := newTest(t, e)
+	te.startServer(&testServer{security: e.security})
+	defer te.tearDown()
+
+	lis, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+	p := &proxyServer{t: t, lis: lis}
+	go p.run()
+	defer p.stop()
+
+	te.pm = &proxyMapper{
+		mapName: true,
+		oldAddr: te.srvAddr,
+		newAddr: lis.Addr().String(),
+	}
+	tc := testpb.NewTestServiceClient(te.clientConn())
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	stream, err := tc.FullDuplexCall(ctx, grpc.FailFast(false))
+	if err != nil {
+		t.Fatalf("%v.FullDuplexCall(_) = _, %v, want <nil>", tc, err)
+	}
+	if err := stream.CloseSend(); err != nil {
+		t.Fatalf("%v.CloseSend() got %v, want %v", stream, err, nil)
+	}
+	if _, err := stream.Recv(); err != io.EOF {
+		t.Fatalf("%v failed to complele the FullDuplexCall: %v", stream, err)
+	}
+}
+
+func TestProxyMapAddress(t *testing.T) {
+	defer leakCheck(t)()
+	for _, e := range []env{tcpClearEnv, tcpTLSEnv} {
+		testProxyMapAddress(t, e)
+	}
+}
+
+func testProxyMapAddress(t *testing.T, e env) {
+	te := newTest(t, e)
+	te.startServer(&testServer{security: e.security})
+	defer te.tearDown()
+
+	lis, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+	p := &proxyServer{t: t, lis: lis}
+	go p.run()
+	defer p.stop()
+
+	te.pm = &proxyMapper{
+		mapAddress: true,
+		oldAddr:    te.srvAddr,
+		newAddr:    lis.Addr().String(),
+	}
+	tc := testpb.NewTestServiceClient(te.clientConn())
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	stream, err := tc.FullDuplexCall(ctx, grpc.FailFast(false))
+	if err != nil {
+		t.Fatalf("%v.FullDuplexCall(_) = _, %v, want <nil>", tc, err)
+	}
+	if err := stream.CloseSend(); err != nil {
+		t.Fatalf("%v.CloseSend() got %v, want %v", stream, err, nil)
+	}
+	if _, err := stream.Recv(); err != io.EOF {
+		t.Fatalf("%v failed to complele the FullDuplexCall: %v", stream, err)
+	}
 }
 
 // interestingGoroutines returns all goroutines we care about for the purpose

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -3462,9 +3462,11 @@ func (p *proxyServer) run() {
 	}
 	resp := http.Response{StatusCode: 200, Proto: "HTTP/1.0"}
 	resp.Write(p.in)
+	p.t.Logf("resp sent")
 	p.out = out
 	go io.Copy(p.in, p.out)
 	go io.Copy(p.out, p.in)
+	p.t.Logf("run return")
 }
 
 func (p *proxyServer) stop() {
@@ -3530,7 +3532,7 @@ func testProxyMapName(t *testing.T, e env) {
 	}
 	t.Logf("oldAddr: %s, newAddr: %s", te.srvAddr, lis.Addr())
 	tc := testpb.NewTestServiceClient(te.clientConn())
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()
 	stream, err := tc.FullDuplexCall(ctx, grpc.FailFast(false))
 	if err != nil {
@@ -3570,7 +3572,7 @@ func testProxyMapAddress(t *testing.T, e env) {
 		newAddr:    lis.Addr().String(),
 	}
 	tc := testpb.NewTestServiceClient(te.clientConn())
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()
 	stream, err := tc.FullDuplexCall(ctx, grpc.FailFast(false))
 	if err != nil {

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -3488,6 +3488,7 @@ func (p *proxyMapper) MapName(ctx context.Context, uri string) (string, map[stri
 	}
 	return p.newAddr, map[string][]string{"User-Agent": {"test-agent"}}, nil
 }
+
 func (p *proxyMapper) MapAddress(ctx context.Context, uri string, address string) (string, map[string][]string, error) {
 	if !p.mapAddress {
 		return "", nil, proxy.ErrIneffective

--- a/transport/http2_client.go
+++ b/transport/http2_client.go
@@ -203,7 +203,8 @@ func newHTTP2Client(ctx context.Context, addr TargetInfo, opts ConnectOptions) (
 		}
 	}(conn)
 	if addr.UsingProxy {
-		if err := doHTTPConnectHandshake(ctx, conn, addr.ConnectTarget, addr.Header); err != nil {
+		// TODO support user provided proxy handshaker.
+		if err := doHTTPConnectHandshake(ctx, conn, addr.RealTarget, addr.Header); err != nil {
 			return nil, connectionErrorf(true, err, "failed to connect: %v", err)
 		}
 	}

--- a/transport/http2_client.go
+++ b/transport/http2_client.go
@@ -169,7 +169,8 @@ func newHTTP2Client(ctx context.Context, addr TargetInfo, opts ConnectOptions) (
 	}(conn)
 	if addr.UsingProxy {
 		// TODO support user provided proxy handshaker.
-		if err := doHTTPConnectHandshake(ctx, conn, addr.RealTarget, addr.Header); err != nil {
+		conn, err = doHTTPConnectHandshake(ctx, conn, addr.RealTarget, addr.Header)
+		if err != nil {
 			return nil, connectionErrorf(true, err, "failed to connect: %v", err)
 		}
 	}

--- a/transport/http2_client.go
+++ b/transport/http2_client.go
@@ -159,6 +159,10 @@ func doHTTPConnectHandshake(conn net.Conn, addr string, header http.Header) erro
 	if ua := header.Get("User-Agent"); ua == "" {
 		header.Set("User-Agent", primaryUA)
 	}
+	if host := header.Get("Host"); host != "" {
+		// Use the user specified Host header if it's set.
+		addr = host
+	}
 	req := http.Request{
 		Method: "CONNECT",
 		URL:    &url.URL{Host: addr},

--- a/transport/http2_client.go
+++ b/transport/http2_client.go
@@ -203,7 +203,7 @@ func newHTTP2Client(ctx context.Context, addr TargetInfo, opts ConnectOptions) (
 		}
 	}(conn)
 	if addr.UsingProxy {
-		if err := doHTTPConnectHandshake(ctx, conn, addr.ConnectTarget, nil); err != nil {
+		if err := doHTTPConnectHandshake(ctx, conn, addr.ConnectTarget, addr.Header); err != nil {
 			return nil, connectionErrorf(true, err, "failed to connect: %v", err)
 		}
 	}

--- a/transport/http2_client.go
+++ b/transport/http2_client.go
@@ -152,7 +152,7 @@ func isTemporary(err error) bool {
 	return false
 }
 
-func doHTTPConnectHandshake(conn net.Conn, addr string, header http.Header) error {
+func doHTTPConnectHandshake(ctx context.Context, conn net.Conn, addr string, header http.Header) error {
 	if header == nil {
 		header = make(map[string][]string)
 	}
@@ -163,11 +163,11 @@ func doHTTPConnectHandshake(conn net.Conn, addr string, header http.Header) erro
 		// Use the user specified Host header if it's set.
 		addr = host
 	}
-	req := http.Request{
+	req := (&http.Request{
 		Method: "CONNECT",
 		URL:    &url.URL{Host: addr},
 		Header: header,
-	}
+	}).WithContext(ctx)
 	if err := req.Write(conn); err != nil {
 		return fmt.Errorf("failed to write the HTTP request: %v", err)
 	}
@@ -203,7 +203,7 @@ func newHTTP2Client(ctx context.Context, addr TargetInfo, opts ConnectOptions) (
 		}
 	}(conn)
 	if addr.UsingProxy {
-		if err := doHTTPConnectHandshake(conn, addr.ConnectTarget, nil); err != nil {
+		if err := doHTTPConnectHandshake(ctx, conn, addr.ConnectTarget, nil); err != nil {
 			return nil, connectionErrorf(true, err, "failed to connect: %v", err)
 		}
 	}

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -394,11 +394,11 @@ type TargetInfo struct {
 	Addr     string
 	Metadata interface{}
 
-	// UsingProxy indicates if the transport is connecting to a proxy (if http CONNECT is requred).
+	// UsingProxy indicates if the transport is connecting to a proxy.
 	UsingProxy bool
-	// When UsingProxy is true, ConnectTarget contains the host for http CONNECT.
-	ConnectTarget string
-	// When UsingProxy is true, Header contains headers to be sent with http CONNECT.
+	// When UsingProxy is true, RealTarget contains the host of the real server.
+	RealTarget string
+	// When UsingProxy is true, Header contains headers to be sent to proxy.
 	Header map[string][]string
 }
 

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -42,7 +42,6 @@ import (
 	"fmt"
 	"io"
 	"net"
-	"net/http"
 	"sync"
 
 	"golang.org/x/net/context"
@@ -400,7 +399,7 @@ type TargetInfo struct {
 	// When UsingProxy is true, ConnectTarget contains the host for http CONNECT.
 	ConnectTarget string
 	// When UsingProxy is true, Header contains headers to be sent with http CONNECT.
-	Header http.Header
+	Header map[string][]string
 }
 
 // NewClientTransport establishes the transport with the required ConnectOptions

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -42,6 +42,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"net/http"
 	"sync"
 
 	"golang.org/x/net/context"
@@ -393,6 +394,13 @@ type ConnectOptions struct {
 type TargetInfo struct {
 	Addr     string
 	Metadata interface{}
+
+	// UsingProxy indicates if the transport is connecting to a proxy (if http CONNECT is requred).
+	UsingProxy bool
+	// When UsingProxy is true, ConnectTarget contains the host for http CONNECT.
+	ConnectTarget string
+	// When UsingProxy is true, Header contains headers to be sent with http CONNECT.
+	Header http.Header
 }
 
 // NewClientTransport establishes the transport with the required ConnectOptions


### PR DESCRIPTION
Support TCP-level proxies via the HTTP CONNECT request.

Implementes gRFC A1: https://github.com/grpc/proposal/pull/4.