### PR TITLE
opt in to frame reuse on the framer to reduce garbage

### DIFF
--- a/transport/http_util.go
+++ b/transport/http_util.go
@@ -379,6 +379,9 @@ func newFramer(conn net.Conn) *framer {
 		writer: bufio.NewWriterSize(conn, http2IOBufSize),
 	}
 	f.fr = http2.NewFramer(f.writer, f.reader)
+	// Opt-in to Frame reuse API on framer to reduce garbage.
+	// Frames aren't safe to read from after a subsequent call to ReadFrame.
+	f.fr.SetReuseFrames()
 	f.fr.ReadMetaHeaders = hpack.NewDecoder(http2InitHeaderTableSize, nil)
 	return f
 }


### PR DESCRIPTION
`DataFrame` structs account for slightly more than 1GB of allocs on the streaming QPS benchmark, but the framer can be configured to reuse them. Details in https://github.com/golang/go/issues/18502.