### PR TITLE
remove string comparing in test because text of an error string chang…

### DIFF
--- a/server_test.go
+++ b/server_test.go
@@ -60,7 +60,7 @@ func TestStopBeforeServe(t *testing.T) {
 	// server.Serve is responsible for closing the listener, even if the
 	// server was already stopped.
 	err = lis.Close()
-	if got, want := ErrorDesc(err), "use of closed network connection"; !strings.Contains(got, want) {
+	if got, want := ErrorDesc(err), "use of closed"; !strings.Contains(got, want) {
 		t.Errorf("Close() error = %q, want %q", got, want)
 	}
 }


### PR DESCRIPTION
…ed in Go 1.9
fixes #1102