### PR TITLE
Add comment explaining why cancel is not called in success path after client transport is created

### DIFF
--- a/clientconn.go
+++ b/clientconn.go
@@ -777,6 +777,8 @@ func (ac *addrConn) resetTransport(closeTransport bool) error {
 			Metadata: ac.addr.Metadata,
 		}
 		newTransport, err := transport.NewClientTransport(ctx, sinfo, ac.dopts.copts)
+		// Don't call cancel in success path due to a race in Go 1.6:
+		// https://github.com/golang/go/issues/15078.
 		if err != nil {
 			cancel()
 


### PR DESCRIPTION
Fixes #1099 