### PR TITLE
fix server panic sending to closed stream #1111

### DIFF
--- a/transport/handler_server.go
+++ b/transport/handler_server.go
@@ -174,11 +174,18 @@ func (a strAddr) String() string { return string(a) }
 
 // do runs fn in the ServeHTTP goroutine.
 func (ht *serverHandlerTransport) do(fn func()) error {
+	// Avoid a panic writing to closed channel. Imperfect but maybe good enough.
 	select {
-	case ht.writes <- fn:
-		return nil
 	case <-ht.closedCh:
 		return ErrConnClosing
+	default:
+		select {
+		case ht.writes <- fn:
+			return nil
+		case <-ht.closedCh:
+			return ErrConnClosing
+		}
+
 	}
 }
 


### PR DESCRIPTION
Proposed fix for #1111. I've already signed the CLA for another Google project (Camlistore).

I'm not aware of a golang construct which can completely guarantee the out chan won't be written to after the closed chan is closed but a nested select like this makes the window when that can happen way smaller. Specifically this change fixes the panic in #1111. Suggestions for improvements?