### PR TITLE
Max age

### DIFF
--- a/keepalive/keepalive.go
+++ b/keepalive/keepalive.go
@@ -16,3 +16,12 @@ type ClientParameters struct {
 	// If true, client runs keepalive checks even with no active RPCs.
 	PermitWithoutStream bool
 }
+
+// TODO(mmukhi) : documentation
+type ServerParameters struct {
+	MaxConnectionIdle     time.Duration
+	MaxConnectionAge      time.Duration
+	MaxConnectionAgeGrace time.Duration
+	Time                  time.Duration
+	Timeout               time.Duration
+}

--- a/keepalive/keepalive.go
+++ b/keepalive/keepalive.go
@@ -17,11 +17,18 @@ type ClientParameters struct {
 	PermitWithoutStream bool
 }
 
-// TODO(mmukhi) : documentation
+// ServerParameters is used to set keepalive and max-age parameters on the server-side.
 type ServerParameters struct {
-	MaxConnectionIdle     time.Duration
-	MaxConnectionAge      time.Duration
+	// MaxConnectionIdle is a duration for the amount of time after which an idle connection would be closed by sending a GoAway.
+	// Idleness duration is defined since the most recent time the number of outstanding RPCs became zero or the connection establishment.
+	MaxConnectionIdle time.Duration
+	// MaxConnectionAge is a duration for the maximum amount of time a connection may exist before it will be closed by sending a GoAway
+	MaxConnectionAge time.Duration
+	//MaxConnectinoAgeGrace is an additive period after MaxConnectionAge after which the connection will be forcibly closed.
 	MaxConnectionAgeGrace time.Duration
-	Time                  time.Duration
-	Timeout               time.Duration
+	// After a duration of this time if the server doesn't see any activity it pings the client to see if the transport is still alive.
+	Time time.Duration
+	// After having pinged for keepalive check, the server waits for a duration of Timeout and if no activity is seen even after that
+	// the connection is closed.
+	Timeout time.Duration
 }

--- a/keepalive/keepalive.go
+++ b/keepalive/keepalive.go
@@ -22,9 +22,10 @@ type ServerParameters struct {
 	// MaxConnectionIdle is a duration for the amount of time after which an idle connection would be closed by sending a GoAway.
 	// Idleness duration is defined since the most recent time the number of outstanding RPCs became zero or the connection establishment.
 	MaxConnectionIdle time.Duration
-	// MaxConnectionAge is a duration for the maximum amount of time a connection may exist before it will be closed by sending a GoAway
+	// MaxConnectionAge is a duration for the maximum amount of time a connection may exist before it will be closed by sending a GoAway.
+	// A random jitter of +/-10% will be added to MAX_CONNECTION_AGE to spread out connection storms.
 	MaxConnectionAge time.Duration
-	//MaxConnectinoAgeGrace is an additive period after MaxConnectionAge after which the connection will be forcibly closed.
+	// MaxConnectinoAgeGrace is an additive period after MaxConnectionAge after which the connection will be forcibly closed.
 	MaxConnectionAgeGrace time.Duration
 	// After a duration of this time if the server doesn't see any activity it pings the client to see if the transport is still alive.
 	Time time.Duration

--- a/keepalive/keepalive.go
+++ b/keepalive/keepalive.go
@@ -23,7 +23,7 @@ type ServerParameters struct {
 	// Idleness duration is defined since the most recent time the number of outstanding RPCs became zero or the connection establishment.
 	MaxConnectionIdle time.Duration
 	// MaxConnectionAge is a duration for the maximum amount of time a connection may exist before it will be closed by sending a GoAway.
-	// A random jitter of +/-10% will be added to MAX_CONNECTION_AGE to spread out connection storms.
+	// A random jitter of +/-10% will be added to MaxConnectionAge to spread out connection storms.
 	MaxConnectionAge time.Duration
 	// MaxConnectinoAgeGrace is an additive period after MaxConnectionAge after which the connection will be forcibly closed.
 	MaxConnectionAgeGrace time.Duration

--- a/server.go
+++ b/server.go
@@ -126,7 +126,7 @@ var defaultMaxMsgSize = 1024 * 1024 * 4 // use 4MB as the default message size l
 // A ServerOption sets options.
 type ServerOption func(*options)
 
-// TODO(mmukhi) : Documentation
+// KeepaliveParams returns a ServerOption that sets keepalive and max-age parameters for the server.
 func KeepaliveParams(kp keepalive.ServerParameters) ServerOption {
 	return func(o *options) {
 		o.keepaliveParams = kp
@@ -478,7 +478,7 @@ func (s *Server) serveHTTP2Transport(c net.Conn, authInfo credentials.AuthInfo) 
 		AuthInfo:        authInfo,
 		InTapHandle:     s.opts.inTapHandle,
 		StatsHandler:    s.opts.statsHandler,
-		keepaliveParams: s.opts.keepaliveParams,
+		KeepaliveParams: s.opts.keepaliveParams,
 	}
 	st, err := transport.NewServerTransport("http2", c, config)
 	if err != nil {

--- a/transport/control.go
+++ b/transport/control.go
@@ -46,12 +46,17 @@ const (
 	// The default value of flow control window size in HTTP2 spec.
 	defaultWindowSize = 65535
 	// The initial window size for flow control.
-	initialWindowSize       = defaultWindowSize      // for an RPC
-	initialConnWindowSize   = defaultWindowSize * 16 // for a connection
-	infinity                = time.Duration(math.MaxInt64)
-	defaultKeepaliveTime    = infinity
-	defaultKeepaliveTimeout = time.Duration(20 * time.Second)
-	defaultMaxStreamsClient = 100
+	initialWindowSize             = defaultWindowSize      // for an RPC
+	initialConnWindowSize         = defaultWindowSize * 16 // for a connection
+	infinity                      = time.Duration(math.MaxInt64)
+	defaultClientKeepaliveTime    = infinity
+	defaultClientKeepaliveTimeout = time.Duration(20 * time.Second)
+	defaultMaxStreamsClient       = 100
+	defaultMaxConnectionIdle      = infinity
+	defaultMaxConnectionAge       = infinity
+	defaultMaxConnectionAgeGrace  = infinity
+	defaultServerKeepaliveTime    = time.Duration(2 * time.Hour)
+	defaultServerKeepaliveTimeout = time.Duration(20 * time.Second)
 )
 
 // The following defines various control items which could flow through

--- a/transport/http2_client.go
+++ b/transport/http2_client.go
@@ -194,10 +194,10 @@ func newHTTP2Client(ctx context.Context, addr TargetInfo, opts ConnectOptions) (
 	kp := opts.KeepaliveParams
 	// Validate keepalive parameters.
 	if kp.Time == 0 {
-		kp.Time = defaultKeepaliveTime
+		kp.Time = defaultClientKeepaliveTime
 	}
 	if kp.Timeout == 0 {
-		kp.Timeout = defaultKeepaliveTimeout
+		kp.Timeout = defaultClientKeepaliveTimeout
 	}
 	var buf bytes.Buffer
 	t := &http2Client{

--- a/transport/http2_server.go
+++ b/transport/http2_server.go
@@ -975,13 +975,14 @@ func (t *http2Server) Drain() {
 	t.controlBuf.put(&goAway{})
 }
 
+var rgen = rand.New(rand.NewSource(time.Now().UnixNano()))
+
 func getJitter(v time.Duration) time.Duration {
 	if v == infinity {
 		return 0
 	}
-	rand.Seed(time.Now().UnixNano())
 	// Generate a jitter between +/- 10% of the value.
 	r := int64(v / 10)
-	j := rand.Int63n(2*r) - r
+	j := rgen.Int63n(2*r) - r
 	return time.Duration(j)
 }

--- a/transport/http2_server.go
+++ b/transport/http2_server.go
@@ -334,7 +334,7 @@ func (t *http2Server) HandleStreams(handle func(*Stream), traceCtx func(context.
 		t.Close()
 		return
 	}
-	atomic.CompareAndSwapUint32(&t.activity, 0, 1)
+	atomic.StoreUint32(&t.activity, 1)
 	sf, ok := frame.(*http2.SettingsFrame)
 	if !ok {
 		grpclog.Printf("transport: http2Server.HandleStreams saw invalid preface type %T from client", frame)
@@ -345,7 +345,7 @@ func (t *http2Server) HandleStreams(handle func(*Stream), traceCtx func(context.
 
 	for {
 		frame, err := t.framer.readFrame()
-		atomic.CompareAndSwapUint32(&t.activity, 0, 1)
+		atomic.StoreUint32(&t.activity, 1)
 		if err != nil {
 			if se, ok := err.(http2.StreamError); ok {
 				t.mu.Lock()

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -362,10 +362,11 @@ const (
 
 // ServerConfig consists of all the configurations to establish a server transport.
 type ServerConfig struct {
-	MaxStreams   uint32
-	AuthInfo     credentials.AuthInfo
-	InTapHandle  tap.ServerInHandle
-	StatsHandler stats.Handler
+	MaxStreams      uint32
+	AuthInfo        credentials.AuthInfo
+	InTapHandle     tap.ServerInHandle
+	StatsHandler    stats.Handler
+	keepaliveParams keepalive.ServerParameters
 }
 
 // NewServerTransport creates a ServerTransport with conn or non-nil error

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -366,7 +366,7 @@ type ServerConfig struct {
 	AuthInfo        credentials.AuthInfo
 	InTapHandle     tap.ServerInHandle
 	StatsHandler    stats.Handler
-	keepaliveParams keepalive.ServerParameters
+	KeepaliveParams keepalive.ServerParameters
 }
 
 // NewServerTransport creates a ServerTransport with conn or non-nil error

--- a/transport/transport_test.go
+++ b/transport/transport_test.go
@@ -350,7 +350,7 @@ func TestMaxConnectionIdleNegative(t *testing.T) {
 
 }
 
-// TestMaxConnectinoAge tests that a server will send GoAway after a duration of MaxConnectionAge.
+// TestMaxConnectionAge tests that a server will send GoAway after a duration of MaxConnectionAge.
 func TestMaxConnectionAge(t *testing.T) {
 	serverConfig := &ServerConfig{
 		KeepaliveParams: keepalive.ServerParameters{


### PR DESCRIPTION
The new logic added to the server does the following:
1. Gracefully closes an idle connection after a duration of keepalive.MaxConnectionIdle.
2. Gracefully closes any connection after a duration of keepalive.MaxConnectionAge.
3. Forcibly closes a connection after an additive period of keepalive.MaxConnectionAgeGrace over keepalive.MaxConnectionAge.
4. Makes sure a connection is alive by sending pings with a frequency of keepalive.Time and closes a non-resposive connection after an additional duration of keepalive.Timeout.
