### PR TITLE
Ensure that RoundRobin.Close() does not panic.

### DIFF
--- a/balancer.go
+++ b/balancer.go
@@ -385,6 +385,9 @@ func (rr *roundRobin) Notify() <-chan []Address {
 func (rr *roundRobin) Close() error {
 	rr.mu.Lock()
 	defer rr.mu.Unlock()
+	if rr.done {
+		return errBalancerClosed
+	}
 	rr.done = true
 	if rr.w != nil {
 		rr.w.Close()

--- a/clientconn.go
+++ b/clientconn.go
@@ -80,6 +80,8 @@ var (
 	errConnClosing = errors.New("grpc: the connection is closing")
 	// errConnUnavailable indicates that the connection is unavailable.
 	errConnUnavailable = errors.New("grpc: the connection is unavailable")
+	// errBalancerClosed indicates that the balancer is closed.
+	errBalancerClosed = errors.New("grpc: balancer is closed")
 	// minimum time to give a connection to complete
 	minConnectTimeout = 20 * time.Second
 )


### PR DESCRIPTION
This can only occur due to programmer error, but is quite confusing when it does.

Here's an example that triggers it:

```go
package main

import (
	"google.golang.org/grpc"
	"google.golang.org/grpc/naming"
)

type resolver struct {
}

// Resolve creates a Watcher for target.
func (resolver) Resolve(target string) (naming.Watcher, error) {
	return &watcher{addr: target}, nil
}

type watcher struct {
	addr string
}

func (w *watcher) Next() ([]*naming.Update, error) {
	if w.addr == "" {
		select {}
	}
	addr := w.addr
	w.addr = ""
	return []*naming.Update{{Addr: addr}}, nil
}
func (w *watcher) Close() {}

func main() {
	balancer := grpc.RoundRobin(&resolver{})
	_, err := grpc.Dial("127.0.0.1:1234", grpc.WithBalancer(balancer), grpc.WithInsecure())
	if err != nil {
		panic(err)
	}
	err = balancer.Close()
	if err != nil {
		panic(err)
	}
	err = balancer.Close()
	if err != nil {
		panic(err)
	}
	select {}
}
```