### PR TITLE
Bug fix(Issue#1141): Check if peer is nil before trying to derefer it.

### DIFF
--- a/rpc_util.go
+++ b/rpc_util.go
@@ -189,7 +189,9 @@ func Trailer(md *metadata.MD) CallOption {
 // unary RPC.
 func Peer(peer *peer.Peer) CallOption {
 	return afterCall(func(c *callInfo) {
-		*peer = *c.peer
+		if c.peer != nil {
+			*peer = *c.peer
+		}
 	})
 }
 

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -1538,6 +1538,29 @@ func testPeerClientSide(t *testing.T, e env) {
 	}
 }
 
+// TestPeerNegative tests that if call fails setting peer
+// doesn't cause a segmentation fault.
+// issue#1141 https://github.com/grpc/grpc-go/issues/1141
+func TestPeerNegative(t *testing.T) {
+	defer leakCheck(t)()
+	for _, e := range listTestEnv() {
+		testPeerNegative(t, e)
+	}
+}
+
+func testPeerNegative(t *testing.T, e env) {
+	te := newTest(t, e)
+	te.startServer(&testServer{security: e.security})
+	defer te.tearDown()
+
+	cc := te.clientConn()
+	tc := testpb.NewTestServiceClient(cc)
+	peer := new(peer.Peer)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	tc.EmptyCall(ctx, &testpb.Empty{}, grpc.Peer(peer))
+}
+
 func TestMetadataUnaryRPC(t *testing.T) {
 	defer leakCheck(t)()
 	for _, e := range listTestEnv() {


### PR DESCRIPTION
fixes #1141 