### PR TITLE
support protos as metadata

### DIFF
--- a/metadata/proto.go
+++ b/metadata/proto.go
@@ -1,0 +1,42 @@
+package metadata
+
+import (
+	"strings"
+
+	"github.com/golang/protobuf/proto"
+)
+
+// WithProto returns new metadata that is the given metadata *plus* the given
+// message. The canonical form of a proto message as metadata is a metadata
+// key of "<fqn>-bin" (where <fqn> is the fully-qualified name of the message)
+// and value that is the binary encoding of the message.
+func WithProto(md MD, msg proto.Message) (MD, error) {
+	b, err := proto.Marshal(msg)
+	if err != nil {
+		return nil, err
+	}
+	protoMD := Pairs(proto.MessageName(msg)+binHdrSuffix, string(b))
+	return Join(md, protoMD), nil
+}
+
+// GetProto populates the given message from its value in the given metadata. If
+// an error occurs, it is returned. If the message was found in the metadata (and
+// thus the given message is populated), this returns true; otherwise, if the
+// message was not found, it returns false.
+func GetProto(md MD, msg proto.Message) (bool, error) {
+	key := strings.ToLower(proto.MessageName(msg) + binHdrSuffix)
+	vals := md[key]
+	if len(vals) == 0 {
+		return false, nil
+	}
+	val := vals[len(vals)-1] // just use last one if there were more than one
+	key, val, err := DecodeKeyValue(key, val)
+	if err != nil {
+		return false, err
+	}
+	err = proto.Unmarshal([]byte(val), msg)
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}

--- a/metadata/proto_test.go
+++ b/metadata/proto_test.go
@@ -1,0 +1,68 @@
+package metadata_test
+
+import (
+	"testing"
+
+	"github.com/golang/protobuf/proto"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/test/grpc_testing"
+)
+
+func TestProtos(t *testing.T) {
+	msg := grpc_testing.Payload{
+		Body: []byte{1, 2, 3, 4, 5},
+		Type: grpc_testing.PayloadType_RANDOM.Enum(),
+	}
+	// adding to existing metadata
+	base := metadata.Pairs("key1", "value1", "key2", "value2")
+	md1, err := metadata.WithProto(base, &msg)
+	if err != nil {
+		t.Fatalf("Failed to add proto to metadata: %s", err.Error())
+	}
+	if len(md1) != 3 || len(md1) != len(base)+1 {
+		t.Error("metadata.WithProto did not produce metadata of expected size")
+	}
+	// adding to nil metadata
+	md2, err := metadata.WithProto(nil, &msg)
+	if err != nil {
+		t.Fatalf("Failed to add proto to metadata: %s", err.Error())
+	}
+	if len(md2) != 1 {
+		t.Error("metadata.WithProto did not produce metadata of expected size")
+	}
+
+	// now query back out of both metadatas produced above
+	var msg2 grpc_testing.Payload
+	ok, err := metadata.GetProto(md1, &msg2)
+	if err != nil {
+		t.Fatalf("Failed to get proto from metadata: %s", err.Error())
+	}
+	if !ok {
+		t.Fatal("GetProto should have found proto in metadata but did not")
+	}
+	if !proto.Equal(&msg, &msg2) {
+		t.Errorf("Message did not correctly survive round-trip through metadata: %v != %v", &msg, &msg2)
+	}
+
+	var msg3 grpc_testing.Payload
+	ok, err = metadata.GetProto(md2, &msg3)
+	if err != nil {
+		t.Fatalf("Failed to get proto from metadata: %s", err.Error())
+	}
+	if !ok {
+		t.Fatal("GetProto should have found proto in metadata but did not")
+	}
+	if !proto.Equal(&msg, &msg3) {
+		t.Errorf("Message did not correctly survive round-trip through metadata: %v != %v", &msg, &msg3)
+	}
+
+	// query non-existent proto
+	var missing grpc_testing.SimpleRequest
+	ok, err = metadata.GetProto(base, &missing)
+	if err != nil {
+		t.Fatalf("Failed to get proto from metadata: %s", err.Error())
+	}
+	if ok {
+		t.Error("GetProto could not have found proto in metadata but thinks it did")
+	}
+}


### PR DESCRIPTION
This adds utility methods to `metadata` that mirror functionality provided by [gRPC Java](https://github.com/grpc/grpc-java/blob/master/protobuf/src/main/java/io/grpc/protobuf/ProtoUtils.java#L124), for easily using protos as structured metadata.

This allows simple interop with non-Go services already using these facilities as well as provides a useful idiomatic way for Go services to use structured metadata.