### PR TITLE
Add status package for reporting gRPC status and errors

### DIFF
--- a/call.go
+++ b/call.go
@@ -43,6 +43,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/stats"
+	"google.golang.org/grpc/status"
 	"google.golang.org/grpc/transport"
 )
 
@@ -79,7 +80,7 @@ func recvResponse(ctx context.Context, dopts dialOptions, t transport.ClientTran
 			return
 		}
 	}
-	if inPayload != nil && err == io.EOF && stream.StatusCode() == codes.OK {
+	if inPayload != nil && err == io.EOF && stream.Status().Code() == codes.OK {
 		// TODO in the current implementation, inTrailer may be handled before inPayload in some cases.
 		// Fix the order if necessary.
 		dopts.copts.StatsHandler.HandleRPC(ctx, inPayload)
@@ -230,7 +231,7 @@ func invoke(ctx context.Context, method string, args, reply interface{}, cc *Cli
 		t, put, err = cc.getTransport(ctx, gopts)
 		if err != nil {
 			// TODO(zhaoq): Probably revisit the error handling.
-			if _, ok := err.(*rpcError); ok {
+			if _, ok := err.(status.Status); ok {
 				return err
 			}
 			if err == errConnClosing || err == errConnUnavailable {
@@ -284,6 +285,6 @@ func invoke(ctx context.Context, method string, args, reply interface{}, cc *Cli
 			put()
 			put = nil
 		}
-		return Errorf(stream.StatusCode(), "%s", stream.StatusDesc())
+		return stream.Status().Err()
 	}
 }

--- a/call_test.go
+++ b/call_test.go
@@ -46,6 +46,7 @@ import (
 
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/grpc/transport"
 )
 
@@ -99,21 +100,21 @@ func (h *testStreamHandler) handleStream(t *testing.T, s *transport.Stream) {
 			return
 		}
 		if v == "weird error" {
-			h.t.WriteStatus(s, codes.Internal, weirdError)
+			h.t.WriteStatus(s, status.New(codes.Internal, weirdError))
 			return
 		}
 		if v == "canceled" {
 			canceled++
-			h.t.WriteStatus(s, codes.Internal, "")
+			h.t.WriteStatus(s, status.New(codes.Internal, ""))
 			return
 		}
 		if v == "port" {
-			h.t.WriteStatus(s, codes.Internal, h.port)
+			h.t.WriteStatus(s, status.New(codes.Internal, h.port))
 			return
 		}
 
 		if v != expectedRequest {
-			h.t.WriteStatus(s, codes.Internal, strings.Repeat("A", sizeLargeErr))
+			h.t.WriteStatus(s, status.New(codes.Internal, strings.Repeat("A", sizeLargeErr)))
 			return
 		}
 	}
@@ -124,7 +125,7 @@ func (h *testStreamHandler) handleStream(t *testing.T, s *transport.Stream) {
 		return
 	}
 	h.t.Write(s, reply, &transport.Options{})
-	h.t.WriteStatus(s, codes.OK, "")
+	h.t.WriteStatus(s, status.New(codes.OK, ""))
 }
 
 type server struct {
@@ -239,7 +240,7 @@ func TestInvokeLargeErr(t *testing.T) {
 	var reply string
 	req := "hello"
 	err := Invoke(context.Background(), "/foo/bar", &req, &reply, cc)
-	if _, ok := err.(*rpcError); !ok {
+	if _, ok := err.(status.Status); !ok {
 		t.Fatalf("grpc.Invoke(_, _, _, _, _) receives non rpc error.")
 	}
 	if Code(err) != codes.Internal || len(ErrorDesc(err)) != sizeLargeErr {
@@ -255,7 +256,7 @@ func TestInvokeErrorSpecialChars(t *testing.T) {
 	var reply string
 	req := "weird error"
 	err := Invoke(context.Background(), "/foo/bar", &req, &reply, cc)
-	if _, ok := err.(*rpcError); !ok {
+	if _, ok := err.(status.Status); !ok {
 		t.Fatalf("grpc.Invoke(_, _, _, _, _) receives non rpc error.")
 	}
 	if got, want := ErrorDesc(err), weirdError; got != want {

--- a/rpc_util_test.go
+++ b/rpc_util_test.go
@@ -152,7 +152,7 @@ func TestToRPCErr(t *testing.T) {
 		// outputs
 		errOut error
 	}{
-		{transport.StreamError{codes.Unknown, ""}, status.Error(codes.Unknown, "")},
+		{transport.StreamError{Code: codes.Unknown, Desc: ""}, status.Error(codes.Unknown, "")},
 		{transport.ErrConnClosing, status.Error(codes.Internal, transport.ErrConnClosing.Desc)},
 	} {
 		err := toRPCErr(test.errIn)

--- a/rpc_util_test.go
+++ b/rpc_util_test.go
@@ -41,8 +41,8 @@ import (
 	"testing"
 
 	"github.com/golang/protobuf/proto"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	perfpb "google.golang.org/grpc/test/codec_perf"
 	"google.golang.org/grpc/transport"
 )
@@ -150,48 +150,18 @@ func TestToRPCErr(t *testing.T) {
 		// input
 		errIn error
 		// outputs
-		errOut *rpcError
+		errOut error
 	}{
-		{transport.StreamError{codes.Unknown, ""}, Errorf(codes.Unknown, "").(*rpcError)},
-		{transport.ErrConnClosing, Errorf(codes.Internal, transport.ErrConnClosing.Desc).(*rpcError)},
+		{transport.StreamError{codes.Unknown, ""}, status.Error(codes.Unknown, "")},
+		{transport.ErrConnClosing, status.Error(codes.Internal, transport.ErrConnClosing.Desc)},
 	} {
 		err := toRPCErr(test.errIn)
-		rpcErr, ok := err.(*rpcError)
-		if !ok {
-			t.Fatalf("toRPCErr{%v} returned type %T, want %T", test.errIn, err, rpcError{})
+		if _, ok := err.(status.Status); !ok {
+			t.Fatalf("toRPCErr{%v} returned type %T, want %T", test.errIn, err, status.Error(codes.Unknown, ""))
 		}
-		if *rpcErr != *test.errOut {
+		if !reflect.DeepEqual(err, test.errOut) {
 			t.Fatalf("toRPCErr{%v} = %v \nwant %v", test.errIn, err, test.errOut)
 		}
-	}
-}
-
-func TestContextErr(t *testing.T) {
-	for _, test := range []struct {
-		// input
-		errIn error
-		// outputs
-		errOut transport.StreamError
-	}{
-		{context.DeadlineExceeded, transport.StreamError{codes.DeadlineExceeded, context.DeadlineExceeded.Error()}},
-		{context.Canceled, transport.StreamError{codes.Canceled, context.Canceled.Error()}},
-	} {
-		err := transport.ContextErr(test.errIn)
-		if err != test.errOut {
-			t.Fatalf("ContextErr{%v} = %v \nwant %v", test.errIn, err, test.errOut)
-		}
-	}
-}
-
-func TestErrorsWithSameParameters(t *testing.T) {
-	const description = "some description"
-	e1 := Errorf(codes.AlreadyExists, description).(*rpcError)
-	e2 := Errorf(codes.AlreadyExists, description).(*rpcError)
-	if e1 == e2 {
-		t.Fatalf("Error interfaces should not be considered equal - e1: %p - %v  e2: %p - %v", e1, e1, e2, e2)
-	}
-	if Code(e1) != Code(e2) || ErrorDesc(e1) != ErrorDesc(e2) {
-		t.Fatalf("Expected errors to have same code and description - e1: %p - %v  e2: %p - %v", e1, e1, e2, e2)
 	}
 }
 

--- a/server.go
+++ b/server.go
@@ -56,6 +56,7 @@ import (
 	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/stats"
+	"google.golang.org/grpc/status"
 	"google.golang.org/grpc/tap"
 	"google.golang.org/grpc/transport"
 )
@@ -671,7 +672,7 @@ func (s *Server) processUnaryRPC(t transport.ServerTransport, stream *transport.
 		stream.SetSendCompress(s.opts.cp.Type())
 	}
 	p := &parser{r: stream}
-	for {
+	for { // TODO: delete
 		pf, req, err := p.recvMsg(s.opts.maxMsgSize)
 		if err == io.EOF {
 			// The entire stream is done (for unary RPC only).
@@ -681,36 +682,35 @@ func (s *Server) processUnaryRPC(t transport.ServerTransport, stream *transport.
 			err = Errorf(codes.Internal, io.ErrUnexpectedEOF.Error())
 		}
 		if err != nil {
-			switch err := err.(type) {
-			case *rpcError:
-				if e := t.WriteStatus(stream, err.code, err.desc); e != nil {
+			switch st := err.(type) {
+			case status.Status:
+				if e := t.WriteStatus(stream, st); e != nil {
 					grpclog.Printf("grpc: Server.processUnaryRPC failed to write status %v", e)
 				}
 			case transport.ConnectionError:
 				// Nothing to do here.
 			case transport.StreamError:
-				if e := t.WriteStatus(stream, err.Code, err.Desc); e != nil {
+				if e := t.WriteStatus(stream, status.New(st.Code, st.Desc)); e != nil {
 					grpclog.Printf("grpc: Server.processUnaryRPC failed to write status %v", e)
 				}
 			default:
-				panic(fmt.Sprintf("grpc: Unexpected error (%T) from recvMsg: %v", err, err))
+				panic(fmt.Sprintf("grpc: Unexpected error (%T) from recvMsg: %v", st, st))
 			}
 			return err
 		}
 
 		if err := checkRecvPayload(pf, stream.RecvCompress(), s.opts.dc); err != nil {
-			switch err := err.(type) {
-			case *rpcError:
-				if e := t.WriteStatus(stream, err.code, err.desc); e != nil {
+			if st, ok := err.(status.Status); ok {
+				if e := t.WriteStatus(stream, st); e != nil {
 					grpclog.Printf("grpc: Server.processUnaryRPC failed to write status %v", e)
 				}
 				return err
-			default:
-				if e := t.WriteStatus(stream, codes.Internal, err.Error()); e != nil {
-					grpclog.Printf("grpc: Server.processUnaryRPC failed to write status %v", e)
-				}
-				// TODO checkRecvPayload always return RPC error. Add a return here if necessary.
 			}
+			if e := t.WriteStatus(stream, status.New(codes.Internal, err.Error())); e != nil {
+				grpclog.Printf("grpc: Server.processUnaryRPC failed to write status %v", e)
+			}
+
+			// TODO checkRecvPayload always return RPC error. Add a return here if necessary.
 		}
 		var inPayload *stats.InPayload
 		if sh != nil {
@@ -718,8 +718,6 @@ func (s *Server) processUnaryRPC(t transport.ServerTransport, stream *transport.
 				RecvTime: time.Now(),
 			}
 		}
-		statusCode := codes.OK
-		statusDesc := ""
 		df := func(v interface{}) error {
 			if inPayload != nil {
 				inPayload.WireLength = len(req)
@@ -728,8 +726,8 @@ func (s *Server) processUnaryRPC(t transport.ServerTransport, stream *transport.
 				var err error
 				req, err = s.opts.dc.Do(bytes.NewReader(req))
 				if err != nil {
-					if err := t.WriteStatus(stream, codes.Internal, err.Error()); err != nil {
-						grpclog.Printf("grpc: Server.processUnaryRPC failed to write status %v", err)
+					if e := t.WriteStatus(stream, status.New(codes.Internal, err.Error())); e != nil {
+						grpclog.Printf("grpc: Server.processUnaryRPC failed to write status %v", e)
 					}
 					return Errorf(codes.Internal, err.Error())
 				}
@@ -737,8 +735,7 @@ func (s *Server) processUnaryRPC(t transport.ServerTransport, stream *transport.
 			if len(req) > s.opts.maxMsgSize {
 				// TODO: Revisit the error code. Currently keep it consistent with
 				// java implementation.
-				statusCode = codes.Internal
-				statusDesc = fmt.Sprintf("grpc: server received a message of %d bytes exceeding %d limit", len(req), s.opts.maxMsgSize)
+				return status.Errorf(codes.Internal, "grpc: server received a message of %d bytes exceeding %d limit", len(req), s.opts.maxMsgSize)
 			}
 			if err := s.opts.codec.Unmarshal(req, v); err != nil {
 				return err
@@ -756,21 +753,20 @@ func (s *Server) processUnaryRPC(t transport.ServerTransport, stream *transport.
 		}
 		reply, appErr := md.Handler(srv.server, stream.Context(), df, s.opts.unaryInt)
 		if appErr != nil {
-			if err, ok := appErr.(*rpcError); ok {
-				statusCode = err.code
-				statusDesc = err.desc
-			} else {
-				statusCode = convertCode(appErr)
-				statusDesc = appErr.Error()
+			appStatus, ok := status.FromError(appErr)
+			if !ok {
+				// Convert appErr if it is not a grpc status error.
+				appErr = status.Error(convertCode(appErr), appErr.Error())
+				appStatus, _ = status.FromError(appErr)
 			}
-			if trInfo != nil && statusCode != codes.OK {
-				trInfo.tr.LazyLog(stringer(statusDesc), true)
+			if trInfo != nil {
+				trInfo.tr.LazyLog(stringer(appStatus.Message()), true)
 				trInfo.tr.SetError()
 			}
-			if err := t.WriteStatus(stream, statusCode, statusDesc); err != nil {
-				grpclog.Printf("grpc: Server.processUnaryRPC failed to write status: %v", err)
+			if e := t.WriteStatus(stream, appStatus); e != nil {
+				grpclog.Printf("grpc: Server.processUnaryRPC failed to write status: %v", e)
 			}
-			return Errorf(statusCode, statusDesc)
+			return appErr
 		}
 		if trInfo != nil {
 			trInfo.tr.LazyLog(stringer("OK"), false)
@@ -780,26 +776,16 @@ func (s *Server) processUnaryRPC(t transport.ServerTransport, stream *transport.
 			Delay: false,
 		}
 		if err := s.sendResponse(t, stream, reply, s.opts.cp, opts); err != nil {
-			switch err := err.(type) {
-			case transport.ConnectionError:
-				// Nothing to do here.
-			case transport.StreamError:
-				statusCode = err.Code
-				statusDesc = err.Desc
-			default:
-				statusCode = codes.Unknown
-				statusDesc = err.Error()
-			}
+			// TODO: Translate error into a status.Status error if necessary?
 			return err
 		}
 		if trInfo != nil {
 			trInfo.tr.LazyLog(&payload{sent: true, msg: reply}, true)
 		}
-		errWrite := t.WriteStatus(stream, statusCode, statusDesc)
-		if statusCode != codes.OK {
-			return Errorf(statusCode, statusDesc)
-		}
-		return errWrite
+		// TODO: Should we be logging if writing status failed here, like above?
+		// Should the logging be in WriteStatus?  Should we ignore the WriteStatus
+		// error or allow the stats handler to see it?
+		return t.WriteStatus(stream, status.New(codes.OK, ""))
 	}
 }
 
@@ -868,32 +854,31 @@ func (s *Server) processStreamingRPC(t transport.ServerTransport, stream *transp
 		appErr = s.opts.streamInt(server, ss, info, sd.Handler)
 	}
 	if appErr != nil {
-		if err, ok := appErr.(*rpcError); ok {
-			ss.statusCode = err.code
-			ss.statusDesc = err.desc
-		} else if err, ok := appErr.(transport.StreamError); ok {
-			ss.statusCode = err.Code
-			ss.statusDesc = err.Desc
-		} else {
-			ss.statusCode = convertCode(appErr)
-			ss.statusDesc = appErr.Error()
+		switch err := appErr.(type) {
+		case status.Status:
+			// Do nothing
+		case transport.StreamError:
+			appErr = status.Error(err.Code, err.Desc)
+		default:
+			appErr = status.Error(convertCode(appErr), appErr.Error())
 		}
+		appStatus, _ := status.FromError(appErr)
+		if trInfo != nil {
+			ss.mu.Lock()
+			ss.trInfo.tr.LazyLog(stringer(appStatus.Message()), true)
+			ss.trInfo.tr.SetError()
+			ss.mu.Unlock()
+		}
+		t.WriteStatus(ss.s, appStatus)
+		// TODO: Should we log an error from WriteStatus here and below?
+		return appErr
 	}
 	if trInfo != nil {
 		ss.mu.Lock()
-		if ss.statusCode != codes.OK {
-			ss.trInfo.tr.LazyLog(stringer(ss.statusDesc), true)
-			ss.trInfo.tr.SetError()
-		} else {
-			ss.trInfo.tr.LazyLog(stringer("OK"), false)
-		}
+		ss.trInfo.tr.LazyLog(stringer("OK"), false)
 		ss.mu.Unlock()
 	}
-	errWrite := t.WriteStatus(ss.s, ss.statusCode, ss.statusDesc)
-	if ss.statusCode != codes.OK {
-		return Errorf(ss.statusCode, ss.statusDesc)
-	}
-	return errWrite
+	return t.WriteStatus(ss.s, status.New(codes.OK, ""))
 
 }
 
@@ -909,7 +894,7 @@ func (s *Server) handleStream(t transport.ServerTransport, stream *transport.Str
 			trInfo.tr.SetError()
 		}
 		errDesc := fmt.Sprintf("malformed method name: %q", stream.Method())
-		if err := t.WriteStatus(stream, codes.InvalidArgument, errDesc); err != nil {
+		if err := t.WriteStatus(stream, status.New(codes.InvalidArgument, errDesc)); err != nil {
 			if trInfo != nil {
 				trInfo.tr.LazyLog(&fmtStringer{"%v", []interface{}{err}}, true)
 				trInfo.tr.SetError()
@@ -934,7 +919,7 @@ func (s *Server) handleStream(t transport.ServerTransport, stream *transport.Str
 			trInfo.tr.SetError()
 		}
 		errDesc := fmt.Sprintf("unknown service %v", service)
-		if err := t.WriteStatus(stream, codes.Unimplemented, errDesc); err != nil {
+		if err := t.WriteStatus(stream, status.New(codes.Unimplemented, errDesc)); err != nil {
 			if trInfo != nil {
 				trInfo.tr.LazyLog(&fmtStringer{"%v", []interface{}{err}}, true)
 				trInfo.tr.SetError()
@@ -964,7 +949,7 @@ func (s *Server) handleStream(t transport.ServerTransport, stream *transport.Str
 		return
 	}
 	errDesc := fmt.Sprintf("unknown method %v", method)
-	if err := t.WriteStatus(stream, codes.Unimplemented, errDesc); err != nil {
+	if err := t.WriteStatus(stream, status.New(codes.Unimplemented, errDesc)); err != nil {
 		if trInfo != nil {
 			trInfo.tr.LazyLog(&fmtStringer{"%v", []interface{}{err}}, true)
 			trInfo.tr.SetError()

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -184,7 +184,7 @@ type End struct {
 	Client bool
 	// EndTime is the time when the RPC ends.
 	EndTime time.Time
-	// Error is the error just happened. Its type is gRPC error.
+	// Error is the error just happened.  It implements status.Status if non-nil.
 	Error error
 }
 

--- a/stats/stats_test.go
+++ b/stats/stats_test.go
@@ -732,7 +732,7 @@ func TestServerStatsUnaryRPC(t *testing.T) {
 	})
 }
 
-func TestServerStatsUnaryRPCError(t *testing.T) {
+func TestServerStatsUnaryError(t *testing.T) {
 	testServerStats(t, &testConfig{compress: ""}, &rpcConfig{success: false}, []func(t *testing.T, d *gotData, e *expectedData){
 		checkInHeader,
 		checkBegin,
@@ -764,7 +764,7 @@ func TestServerStatsStreamingRPC(t *testing.T) {
 	testServerStats(t, &testConfig{compress: "gzip"}, &rpcConfig{count: count, success: true, streaming: true}, checkFuncs)
 }
 
-func TestServerStatsStreamingRPCError(t *testing.T) {
+func TestServerStatsStreamingError(t *testing.T) {
 	count := 5
 	testServerStats(t, &testConfig{compress: "gzip"}, &rpcConfig{count: count, success: false, streaming: true}, []func(t *testing.T, d *gotData, e *expectedData){
 		checkInHeader,
@@ -944,7 +944,7 @@ func TestClientStatsUnaryRPC(t *testing.T) {
 	})
 }
 
-func TestClientStatsUnaryRPCError(t *testing.T) {
+func TestClientStatsUnaryError(t *testing.T) {
 	testClientStats(t, &testConfig{compress: ""}, &rpcConfig{success: false, failfast: false}, map[int]*checkFuncWithCount{
 		begin:      {checkBegin, 1},
 		outHeader:  {checkOutHeader, 1},
@@ -968,7 +968,7 @@ func TestClientStatsStreamingRPC(t *testing.T) {
 	})
 }
 
-func TestClientStatsStreamingRPCError(t *testing.T) {
+func TestClientStatsStreamingError(t *testing.T) {
 	count := 5
 	testClientStats(t, &testConfig{compress: "gzip"}, &rpcConfig{count: count, success: false, failfast: false, streaming: true}, map[int]*checkFuncWithCount{
 		begin:      {checkBegin, 1},

--- a/stats/stats_test.go
+++ b/stats/stats_test.go
@@ -732,7 +732,7 @@ func TestServerStatsUnaryRPC(t *testing.T) {
 	})
 }
 
-func TestServerStatsUnaryError(t *testing.T) {
+func TestServerStatsUnaryRPCError(t *testing.T) {
 	testServerStats(t, &testConfig{compress: ""}, &rpcConfig{success: false}, []func(t *testing.T, d *gotData, e *expectedData){
 		checkInHeader,
 		checkBegin,
@@ -764,7 +764,7 @@ func TestServerStatsStreamingRPC(t *testing.T) {
 	testServerStats(t, &testConfig{compress: "gzip"}, &rpcConfig{count: count, success: true, streaming: true}, checkFuncs)
 }
 
-func TestServerStatsStreamingError(t *testing.T) {
+func TestServerStatsStreamingRPCError(t *testing.T) {
 	count := 5
 	testServerStats(t, &testConfig{compress: "gzip"}, &rpcConfig{count: count, success: false, streaming: true}, []func(t *testing.T, d *gotData, e *expectedData){
 		checkInHeader,
@@ -944,7 +944,7 @@ func TestClientStatsUnaryRPC(t *testing.T) {
 	})
 }
 
-func TestClientStatsUnaryError(t *testing.T) {
+func TestClientStatsUnaryRPCError(t *testing.T) {
 	testClientStats(t, &testConfig{compress: ""}, &rpcConfig{success: false, failfast: false}, map[int]*checkFuncWithCount{
 		begin:      {checkBegin, 1},
 		outHeader:  {checkOutHeader, 1},
@@ -968,7 +968,7 @@ func TestClientStatsStreamingRPC(t *testing.T) {
 	})
 }
 
-func TestClientStatsStreamingError(t *testing.T) {
+func TestClientStatsStreamingRPCError(t *testing.T) {
 	count := 5
 	testClientStats(t, &testConfig{compress: "gzip"}, &rpcConfig{count: count, success: false, failfast: false, streaming: true}, map[int]*checkFuncWithCount{
 		begin:      {checkBegin, 1},

--- a/status/status.go
+++ b/status/status.go
@@ -52,6 +52,8 @@ import (
 
 // Status provides access to grpc status details and is implemented by all
 // errors returned from this package except nil errors, which are not typed.
+// Note: gRPC users should not implement their own Statuses.  Custom data may
+// be attached to the spb.Status proto's Details field.
 type Status interface {
 	// Code returns the status code.
 	Code() codes.Code

--- a/status/status.go
+++ b/status/status.go
@@ -119,7 +119,7 @@ func New(c codes.Code, msg string) Status {
 }
 
 // Newf returns New(c, fmt.Sprintf(format, a...)).
-func Newf(c codes.Code, format string, a ...interface{}) error {
+func Newf(c codes.Code, format string, a ...interface{}) Status {
 	return New(c, fmt.Sprintf(format, a...))
 }
 

--- a/status/status.go
+++ b/status/status.go
@@ -1,0 +1,159 @@
+/*
+ *
+ * Copyright 2017, Google Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+// Package status implements errors returned by gRPC.  These errors are
+// serialized and transmitted on the wire between server and client, and allow
+// for additional data to be transmitted via the Details field in the status
+// proto.  gRPC service handlers should return an error created by this
+// package, and gRPC clients should expect a corresponding error to be
+// returned from the RPC call.
+//
+// This package upholds the invariants that a non-nil error may not
+// contain an OK code, and an OK code must result in a nil error.
+package status
+
+import (
+	"fmt"
+
+	"github.com/golang/protobuf/proto"
+	spb "github.com/google/go-genproto/googleapis/rpc/status"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// Status provides access to grpc status details and is implemented by all
+// errors returned from this package except nil errors, which are not typed.
+type Status interface {
+	// Code returns the status code.
+	Code() codes.Code
+	// Message returns the status message.
+	Message() string
+	// Proto returns a copy of the status in proto form.
+	Proto() *spb.Status
+	// Err returns an error representing the status.
+	Err() error
+}
+
+// okStatus is a Status whose Code method returns codes.OK, but does not
+// implement error.  To represent an OK code as an error, use an untyped nil.
+type okStatus struct{}
+
+func (okStatus) Code() codes.Code {
+	return codes.OK
+}
+
+func (okStatus) Message() string {
+	return ""
+}
+
+func (okStatus) Proto() *spb.Status {
+	return nil
+}
+
+func (okStatus) Err() error {
+	return nil
+}
+
+// statusError contains a status proto.  It is embedded and not aliased to
+// allow for accessor functions of the same name.  It implements error and
+// Status, and a nil statusError should never be returned by this package.
+type statusError struct {
+	*spb.Status
+}
+
+func (se *statusError) Error() string {
+	return fmt.Sprintf("rpc error: code = %s desc = %s", se.Code(), se.Message())
+}
+
+func (se *statusError) Code() codes.Code {
+	return codes.Code(se.Status.Code)
+}
+
+func (se *statusError) Message() string {
+	return se.Status.Message
+}
+
+func (se *statusError) Proto() *spb.Status {
+	return proto.Clone(se.Status).(*spb.Status)
+}
+
+func (se *statusError) Err() error {
+	return se
+}
+
+// New returns a Status representing c and msg.
+func New(c codes.Code, msg string) status.Status {
+	if c == codes.OK {
+		return okStatus{}
+	}
+	return &statusError{Status: &spb.Status{Code: int32(c), Message: msg}}
+}
+
+// Newf returns New(c, fmt.Sprintf(format, a...)).
+func Newf(c codes.Code, format string, a ...interface{}) error {
+	return New(c, fmt.Sprintf(format, a...))
+}
+
+// Error returns an error representing c and msg.  If c is OK, returns nil.
+func Error(c codes.Code, msg string) error {
+	return New(c, msg).Err()
+}
+
+// Errorf returns Error(c, fmt.Sprintf(format, a...)).
+func Errorf(c codes.Code, format string, a ...interface{}) error {
+	return Error(c, fmt.Sprintf(format, a...))
+}
+
+// ErrorProto returns an error representing s.  If s.Code is OK, returns nil.
+func ErrorProto(s *spb.Status) error {
+	return FromProto(s).Err()
+}
+
+// FromProto returns a Status representing s.  If s.Code is OK, Message and
+// Details may be lost.
+func FromProto(s *spb.Status) status.Status {
+	if s.GetCode() == int32(codes.OK) {
+		return okStatus{}
+	}
+	return &statusError{Status: proto.Clone(s).(*spb.Status)}
+}
+
+// FromError returns a Status representing err if it was produced from this
+// package, otherwise it returns nil, false.
+func FromError(err error) (s Status, ok bool) {
+	if err == nil {
+		return okStatus{}, true
+	}
+	s, ok = err.(Status)
+	return s, ok
+}

--- a/status/status.go
+++ b/status/status.go
@@ -48,7 +48,6 @@ import (
 	"github.com/golang/protobuf/proto"
 	spb "github.com/google/go-genproto/googleapis/rpc/status"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 // Status provides access to grpc status details and is implemented by all
@@ -112,7 +111,7 @@ func (se *statusError) Err() error {
 }
 
 // New returns a Status representing c and msg.
-func New(c codes.Code, msg string) status.Status {
+func New(c codes.Code, msg string) Status {
 	if c == codes.OK {
 		return okStatus{}
 	}
@@ -141,7 +140,7 @@ func ErrorProto(s *spb.Status) error {
 
 // FromProto returns a Status representing s.  If s.Code is OK, Message and
 // Details may be lost.
-func FromProto(s *spb.Status) status.Status {
+func FromProto(s *spb.Status) Status {
 	if s.GetCode() == int32(codes.OK) {
 		return okStatus{}
 	}

--- a/status/status_test.go
+++ b/status/status_test.go
@@ -1,0 +1,110 @@
+/*
+ *
+ * Copyright 2017, Google Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+package status
+
+import (
+	"reflect"
+	"testing"
+
+	apb "github.com/golang/protobuf/ptypes/any"
+	spb "github.com/google/go-genproto/googleapis/rpc/status"
+	"google.golang.org/grpc/codes"
+)
+
+func TestErrorsWithSameParameters(t *testing.T) {
+	const description = "some description"
+	e1 := Errorf(codes.AlreadyExists, description)
+	e2 := Errorf(codes.AlreadyExists, description)
+	if e1 == e2 || !reflect.DeepEqual(e1, e2) {
+		t.Fatalf("Errors should be equivalent but unique - e1: %p - %v  e2: %p - %v", e1, e1, e2, e2)
+	}
+}
+
+func TestFromToProto(t *testing.T) {
+	s := &spb.Status{
+		Code:    int32(codes.Internal),
+		Message: "test test test",
+		Details: []*apb.Any{{TypeUrl: "foo", Value: []byte{3, 2, 1}}},
+	}
+
+	err := FromProto(s)
+	if got := err.Proto(); !reflect.DeepEqual(s, got) {
+		t.Fatalf("Expected errors to be identical - s: %v  got: %v", s, got)
+	}
+}
+
+func TestError(t *testing.T) {
+	err := Error(codes.Internal, "test description")
+	if got, want := err.Error(), "rpc error: code = Internal desc = test description"; got != want {
+		t.Fatalf("err.Error() = %q; want %q", got, want)
+	}
+	s := err.(Status)
+	if got, want := s.Code(), codes.Internal; got != want {
+		t.Fatalf("err.Code() = %s; want %s", got, want)
+	}
+	if got, want := s.Message(), "test description"; got != want {
+		t.Fatalf("err.Message() = %s; want %s", got, want)
+	}
+}
+
+func TestErrorOK(t *testing.T) {
+	err := Error(codes.OK, "foo")
+	if err != nil {
+		t.Fatalf("Error(codes.OK, _) = %p; want nil", err)
+	}
+}
+
+func TestErrorProtoOK(t *testing.T) {
+	s := &spb.Status{Code: int32(codes.OK)}
+	if got := ErrorProto(s); got != nil {
+		t.Fatalf("ErrorProto(%v) = %v; want nil", s, got)
+	}
+}
+
+func TestFromError(t *testing.T) {
+	code, message := codes.Internal, "test description"
+	err := Error(code, message)
+	s, ok := FromError(err)
+	if !ok || s.Code() != code || s.Message() != message || s.Err() == nil {
+		t.Fatalf("FromError(%v) = %v, %v; want <Code()=%s, Message()=%q, Err()!=nil>, true", err, s, ok, code, message)
+	}
+}
+
+func TestFromErrorOK(t *testing.T) {
+	code, message := codes.OK, ""
+	s, ok := FromError(nil)
+	if !ok || s.Code() != code || s.Message() != message || s.Err() != nil {
+		t.Fatalf("FromError(nil) = %v, %v; want <Code()=%s, Message()=%q, Err=nil>, true", s, ok, code, message)
+	}
+}

--- a/status/status_test.go
+++ b/status/status_test.go
@@ -47,7 +47,7 @@ func TestErrorsWithSameParameters(t *testing.T) {
 	e1 := Errorf(codes.AlreadyExists, description)
 	e2 := Errorf(codes.AlreadyExists, description)
 	if e1 == e2 || !reflect.DeepEqual(e1, e2) {
-		t.Fatalf("Errors should be equivalent but unique - e1: %p - %v  e2: %p - %v", e1, e1, e2, e2)
+		t.Fatalf("Errors should be equivalent but unique - e1: %v, %v  e2: %p, %v", e1.(*statusError), e1, e2.(*statusError), e2)
 	}
 }
 

--- a/status/status_test.go
+++ b/status/status_test.go
@@ -81,7 +81,7 @@ func TestError(t *testing.T) {
 func TestErrorOK(t *testing.T) {
 	err := Error(codes.OK, "foo")
 	if err != nil {
-		t.Fatalf("Error(codes.OK, _) = %p; want nil", err)
+		t.Fatalf("Error(codes.OK, _) = %p; want nil", err.(*statusError))
 	}
 }
 

--- a/stream.go
+++ b/stream.go
@@ -45,6 +45,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/stats"
+	"google.golang.org/grpc/status"
 	"google.golang.org/grpc/transport"
 )
 
@@ -177,7 +178,7 @@ func newClientStream(ctx context.Context, desc *StreamDesc, cc *ClientConn, meth
 		t, put, err = cc.getTransport(ctx, gopts)
 		if err != nil {
 			// TODO(zhaoq): Probably revisit the error handling.
-			if _, ok := err.(*rpcError); ok {
+			if _, ok := err.(status.Status); ok {
 				return nil, err
 			}
 			if err == errConnClosing || err == errConnUnavailable {
@@ -239,11 +240,7 @@ func newClientStream(ctx context.Context, desc *StreamDesc, cc *ClientConn, meth
 		case <-s.Done():
 			// TODO: The trace of the RPC is terminated here when there is no pending
 			// I/O, which is probably not the optimal solution.
-			if s.StatusCode() == codes.OK {
-				cs.finish(nil)
-			} else {
-				cs.finish(Errorf(s.StatusCode(), "%s", s.StatusDesc()))
-			}
+			cs.finish(s.Status().Err())
 			cs.closeTransportStream(nil)
 		case <-s.GoAway():
 			cs.finish(errConnDrain)
@@ -412,11 +409,11 @@ func (cs *clientStream) RecvMsg(m interface{}) (err error) {
 			return toRPCErr(errors.New("grpc: client streaming protocol violation: get <nil>, want <EOF>"))
 		}
 		if err == io.EOF {
-			if cs.s.StatusCode() == codes.OK {
-				cs.finish(err)
-				return nil
+			if se := cs.s.Status().Err(); se != nil {
+				return se
 			}
-			return Errorf(cs.s.StatusCode(), "%s", cs.s.StatusDesc())
+			cs.finish(err)
+			return nil
 		}
 		return toRPCErr(err)
 	}
@@ -424,11 +421,11 @@ func (cs *clientStream) RecvMsg(m interface{}) (err error) {
 		cs.closeTransportStream(err)
 	}
 	if err == io.EOF {
-		if cs.s.StatusCode() == codes.OK {
-			// Returns io.EOF to indicate the end of the stream.
-			return
+		if statusErr := cs.s.Status().Err(); statusErr != nil {
+			return statusErr
 		}
-		return Errorf(cs.s.StatusCode(), "%s", cs.s.StatusDesc())
+		// Returns io.EOF to indicate the end of the stream.
+		return
 	}
 	return toRPCErr(err)
 }
@@ -520,8 +517,6 @@ type serverStream struct {
 	dc         Decompressor
 	cbuf       *bytes.Buffer
 	maxMsgSize int
-	statusCode codes.Code
-	statusDesc string
 	trInfo     *traceInfo
 
 	statsHandler stats.Handler

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -54,6 +54,8 @@ import (
 	"time"
 
 	"github.com/golang/protobuf/proto"
+	anypb "github.com/golang/protobuf/ptypes/any"
+	spb "github.com/google/go-genproto/googleapis/rpc/status"
 	"golang.org/x/net/context"
 	"golang.org/x/net/http2"
 	"google.golang.org/grpc"
@@ -65,6 +67,7 @@ import (
 	"google.golang.org/grpc/internal"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/peer"
+	"google.golang.org/grpc/status"
 	"google.golang.org/grpc/tap"
 	testpb "google.golang.org/grpc/test/grpc_testing"
 )
@@ -106,12 +109,21 @@ type testServer struct {
 	multipleSetTrailer bool   // whether to call setTrailer multiple times.
 }
 
+var detailedError = status.FromProto(&spb.Status{
+	Code:    int32(codes.DataLoss),
+	Message: "missing expected user-agent",
+	Details: []*anypb.Any{{
+		TypeUrl: "url",
+		Value:   []byte{6, 0, 0, 6, 1, 3},
+	}},
+})
+
 func (s *testServer) EmptyCall(ctx context.Context, in *testpb.Empty) (*testpb.Empty, error) {
 	if md, ok := metadata.FromContext(ctx); ok {
 		// For testing purpose, returns an error if user-agent is failAppUA.
 		// To test that client gets the correct error.
 		if ua, ok := md["user-agent"]; !ok || strings.HasPrefix(ua[0], failAppUA) {
-			return nil, grpc.Errorf(codes.DataLoss, "error for testing: "+failAppUA)
+			return nil, detailedError
 		}
 		var str []string
 		for _, entry := range md["user-agent"] {
@@ -1216,7 +1228,7 @@ func testHealthCheckOnFailure(t *testing.T, e env) {
 
 	cc := te.clientConn()
 	wantErr := grpc.Errorf(codes.DeadlineExceeded, "context deadline exceeded")
-	if _, err := healthCheck(0*time.Second, cc, "grpc.health.v1.Health"); !equalErrors(err, wantErr) {
+	if _, err := healthCheck(0*time.Second, cc, "grpc.health.v1.Health"); !reflect.DeepEqual(err, wantErr) {
 		t.Fatalf("Health/Check(_, _) = _, %v, want _, error code %s", err, codes.DeadlineExceeded)
 	}
 	awaitNewConnLogOutput()
@@ -1238,7 +1250,7 @@ func testHealthCheckOff(t *testing.T, e env) {
 	te.startServer(&testServer{security: e.security})
 	defer te.tearDown()
 	want := grpc.Errorf(codes.Unimplemented, "unknown service grpc.health.v1.Health")
-	if _, err := healthCheck(1*time.Second, te.clientConn(), ""); !equalErrors(err, want) {
+	if _, err := healthCheck(1*time.Second, te.clientConn(), ""); !reflect.DeepEqual(err, want) {
 		t.Fatalf("Health/Check(_, _) = _, %v, want _, %v", err, want)
 	}
 }
@@ -1265,7 +1277,7 @@ func testUnknownHandler(t *testing.T, e env, unknownHandler grpc.StreamHandler) 
 	te.startServer(&testServer{security: e.security})
 	defer te.tearDown()
 	want := grpc.Errorf(codes.Unauthenticated, "user unauthenticated")
-	if _, err := healthCheck(1*time.Second, te.clientConn(), ""); !equalErrors(err, want) {
+	if _, err := healthCheck(1*time.Second, te.clientConn(), ""); !reflect.DeepEqual(err, want) {
 		t.Fatalf("Health/Check(_, _) = _, %v, want _, %v", err, want)
 	}
 }
@@ -1293,7 +1305,7 @@ func testHealthCheckServingStatus(t *testing.T, e env) {
 		t.Fatalf("Got the serving status %v, want SERVING", out.Status)
 	}
 	wantErr := grpc.Errorf(codes.NotFound, "unknown service")
-	if _, err := healthCheck(1*time.Second, cc, "grpc.health.v1.Health"); !equalErrors(err, wantErr) {
+	if _, err := healthCheck(1*time.Second, cc, "grpc.health.v1.Health"); !reflect.DeepEqual(err, wantErr) {
 		t.Fatalf("Health/Check(_, _) = _, %v, want _, error code %s", err, codes.NotFound)
 	}
 	hs.SetServingStatus("grpc.health.v1.Health", healthpb.HealthCheckResponse_SERVING)
@@ -1375,8 +1387,8 @@ func testFailedEmptyUnary(t *testing.T, e env) {
 	tc := testpb.NewTestServiceClient(te.clientConn())
 
 	ctx := metadata.NewContext(context.Background(), testMetadata)
-	wantErr := grpc.Errorf(codes.DataLoss, "error for testing: "+failAppUA)
-	if _, err := tc.EmptyCall(ctx, &testpb.Empty{}); !equalErrors(err, wantErr) {
+	wantErr := detailedError
+	if _, err := tc.EmptyCall(ctx, &testpb.Empty{}); !reflect.DeepEqual(err, wantErr) {
 		t.Fatalf("TestService/EmptyCall(_, _) = _, %v, want _, %v", err, wantErr)
 	}
 }
@@ -2478,7 +2490,7 @@ func testFailedServerStreaming(t *testing.T, e env) {
 		t.Fatalf("%v.StreamingOutputCall(_) = _, %v, want <nil>", tc, err)
 	}
 	wantErr := grpc.Errorf(codes.DataLoss, "error for testing: "+failAppUA)
-	if _, err := stream.Recv(); !equalErrors(err, wantErr) {
+	if _, err := stream.Recv(); !reflect.DeepEqual(err, wantErr) {
 		t.Fatalf("%v.Recv() = _, %v, want _, %v", stream, err, wantErr)
 	}
 }
@@ -3667,8 +3679,4 @@ func (fw *filterWriter) Write(p []byte) (n int, err error) {
 		}
 	}
 	return fw.dst.Write(p)
-}
-
-func equalErrors(l, r error) bool {
-	return grpc.Code(l) == grpc.Code(r) && grpc.ErrorDesc(l) == grpc.ErrorDesc(r)
 }

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -99,7 +99,7 @@ var (
 	failAppUA     = "fail-this-RPC"
 	detailedError = status.ErrorProto(&spb.Status{
 		Code:    int32(codes.DataLoss),
-		Message: "missing expected user-agent",
+		Message: "error for testing: " + failAppUA,
 		Details: []*anypb.Any{{
 			TypeUrl: "url",
 			Value:   []byte{6, 0, 0, 6, 1, 3},

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -109,7 +109,7 @@ type testServer struct {
 	multipleSetTrailer bool   // whether to call setTrailer multiple times.
 }
 
-var detailedError = status.FromProto(&spb.Status{
+var detailedError = status.ErrorProto(&spb.Status{
 	Code:    int32(codes.DataLoss),
 	Message: "missing expected user-agent",
 	Details: []*anypb.Any{{

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -95,8 +95,16 @@ var (
 	malformedHTTP2Metadata = metadata.MD{
 		"Key": []string{"foo"},
 	}
-	testAppUA = "myApp1/1.0 myApp2/0.9"
-	failAppUA = "fail-this-RPC"
+	testAppUA     = "myApp1/1.0 myApp2/0.9"
+	failAppUA     = "fail-this-RPC"
+	detailedError = status.ErrorProto(&spb.Status{
+		Code:    int32(codes.DataLoss),
+		Message: "missing expected user-agent",
+		Details: []*anypb.Any{{
+			TypeUrl: "url",
+			Value:   []byte{6, 0, 0, 6, 1, 3},
+		}},
+	})
 )
 
 var raceMode bool // set by race_test.go in race mode
@@ -108,15 +116,6 @@ type testServer struct {
 	setHeaderOnly      bool   // whether to only call setHeader, not sendHeader.
 	multipleSetTrailer bool   // whether to call setTrailer multiple times.
 }
-
-var detailedError = status.ErrorProto(&spb.Status{
-	Code:    int32(codes.DataLoss),
-	Message: "missing expected user-agent",
-	Details: []*anypb.Any{{
-		TypeUrl: "url",
-		Value:   []byte{6, 0, 0, 6, 1, 3},
-	}},
-})
 
 func (s *testServer) EmptyCall(ctx context.Context, in *testpb.Empty) (*testpb.Empty, error) {
 	if md, ok := metadata.FromContext(ctx); ok {

--- a/transport/handler_server.go
+++ b/transport/handler_server.go
@@ -53,6 +53,7 @@ import (
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/peer"
+	"google.golang.org/grpc/status"
 )
 
 // NewServerHandlerTransport returns a ServerTransport handling gRPC
@@ -182,7 +183,7 @@ func (ht *serverHandlerTransport) do(fn func()) error {
 	}
 }
 
-func (ht *serverHandlerTransport) WriteStatus(s *Stream, statusCode codes.Code, statusDesc string) error {
+func (ht *serverHandlerTransport) WriteStatus(s *Stream, st status.Status) error {
 	err := ht.do(func() {
 		ht.writeCommonHeaders(s)
 
@@ -192,10 +193,13 @@ func (ht *serverHandlerTransport) WriteStatus(s *Stream, statusCode codes.Code, 
 		ht.rw.(http.Flusher).Flush()
 
 		h := ht.rw.Header()
-		h.Set("Grpc-Status", fmt.Sprintf("%d", statusCode))
-		if statusDesc != "" {
-			h.Set("Grpc-Message", encodeGrpcMessage(statusDesc))
+		h.Set("Grpc-Status", fmt.Sprintf("%d", st.Code()))
+		if m := st.Message(); m != "" {
+			h.Set("Grpc-Message", encodeGrpcMessage(m))
 		}
+
+		// TODO: Support Grpc-Status-Details-Bin
+
 		if md := s.Trailer(); len(md) > 0 {
 			for k, vv := range md {
 				// Clients don't tolerate reading restricted headers after some non restricted ones were sent.
@@ -234,6 +238,7 @@ func (ht *serverHandlerTransport) writeCommonHeaders(s *Stream) {
 	// and https://golang.org/pkg/net/http/#example_ResponseWriter_trailers
 	h.Add("Trailer", "Grpc-Status")
 	h.Add("Trailer", "Grpc-Message")
+	// TODO: Support Grpc-Status-Details-Bin
 
 	if s.sendCompress != "" {
 		h.Set("Grpc-Encoding", s.sendCompress)

--- a/transport/handler_server_test.go
+++ b/transport/handler_server_test.go
@@ -46,6 +46,7 @@ import (
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 )
 
 func TestHandlerTransport_NewServerHandlerTransport(t *testing.T) {
@@ -298,7 +299,7 @@ func TestHandlerTransport_HandleStreams(t *testing.T) {
 			t.Errorf("stream method = %q; want %q", s.method, want)
 		}
 		st.bodyw.Close() // no body
-		st.ht.WriteStatus(s, codes.OK, "")
+		st.ht.WriteStatus(s, status.New(codes.OK, ""))
 	}
 	st.ht.HandleStreams(
 		func(s *Stream) { go handleStream(s) },
@@ -328,7 +329,7 @@ func TestHandlerTransport_HandleStreams_InvalidArgument(t *testing.T) {
 func handleStreamCloseBodyTest(t *testing.T, statusCode codes.Code, msg string) {
 	st := newHandleStreamTest(t)
 	handleStream := func(s *Stream) {
-		st.ht.WriteStatus(s, statusCode, msg)
+		st.ht.WriteStatus(s, status.New(statusCode, msg))
 	}
 	st.ht.HandleStreams(
 		func(s *Stream) { go handleStream(s) },
@@ -379,7 +380,7 @@ func TestHandlerTransport_HandleStreams_Timeout(t *testing.T) {
 			t.Errorf("ctx.Err = %v; want %v", err, context.DeadlineExceeded)
 			return
 		}
-		ht.WriteStatus(s, codes.DeadlineExceeded, "too slow")
+		ht.WriteStatus(s, status.New(codes.DeadlineExceeded, "too slow"))
 	}
 	ht.HandleStreams(
 		func(s *Stream) { go runStream(s) },

--- a/transport/http2_client.go
+++ b/transport/http2_client.go
@@ -35,7 +35,6 @@ package transport
 
 import (
 	"bytes"
-	"fmt"
 	"io"
 	"math"
 	"net"
@@ -858,7 +857,7 @@ func (t *http2Client) handleRSTStream(f *http2.RSTStreamFrame) {
 		grpclog.Println("transport: http2Client.handleRSTStream found no mapped gRPC status for the received http2 error ", f.ErrCode)
 		statusCode = codes.Unknown
 	}
-	s.finish(status.New(statusCode, fmt.Sprintf("stream terminated by RST_STREAM with error code: %d", f.ErrCode)))
+	s.finish(status.Newf(statusCode, "stream terminated by RST_STREAM with error code: %d", f.ErrCode))
 	s.mu.Unlock()
 	s.write(recvMsg{err: io.EOF})
 }

--- a/transport/http2_client.go
+++ b/transport/http2_client.go
@@ -54,6 +54,7 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/stats"
+	"google.golang.org/grpc/status"
 )
 
 // http2Client implements the ClientTransport interface with HTTP2.
@@ -311,7 +312,7 @@ func (t *http2Client) newStream(ctx context.Context, callHdr *CallHdr) *Stream {
 	return s
 }
 
-// NewStream creates a stream and register it into the transport as "active"
+// NewStream creates a stream and registers it into the transport as "active"
 // streams.
 func (t *http2Client) NewStream(ctx context.Context, callHdr *CallHdr) (_ *Stream, err error) {
 	pr := &peer.Peer{
@@ -802,12 +803,9 @@ func (t *http2Client) handleData(f *http2.DataFrame) {
 			return
 		}
 		if err := s.fc.onData(uint32(size)); err != nil {
-			s.state = streamDone
-			s.statusCode = codes.Internal
-			s.statusDesc = err.Error()
 			s.rstStream = true
 			s.rstError = http2.ErrCodeFlowControl
-			close(s.done)
+			s.finish(status.New(codes.Internal, err.Error()))
 			s.mu.Unlock()
 			s.write(recvMsg{err: io.EOF})
 			return
@@ -835,10 +833,7 @@ func (t *http2Client) handleData(f *http2.DataFrame) {
 			s.mu.Unlock()
 			return
 		}
-		s.state = streamDone
-		s.statusCode = codes.Internal
-		s.statusDesc = "server closed the stream without sending trailers"
-		close(s.done)
+		s.finish(status.New(codes.Internal, "server closed the stream without sending trailers"))
 		s.mu.Unlock()
 		s.write(recvMsg{err: io.EOF})
 	}
@@ -854,18 +849,16 @@ func (t *http2Client) handleRSTStream(f *http2.RSTStreamFrame) {
 		s.mu.Unlock()
 		return
 	}
-	s.state = streamDone
 	if !s.headerDone {
 		close(s.headerChan)
 		s.headerDone = true
 	}
-	s.statusCode, ok = http2ErrConvTab[http2.ErrCode(f.ErrCode)]
+	statusCode, ok := http2ErrConvTab[http2.ErrCode(f.ErrCode)]
 	if !ok {
 		grpclog.Println("transport: http2Client.handleRSTStream found no mapped gRPC status for the received http2 error ", f.ErrCode)
-		s.statusCode = codes.Unknown
+		statusCode = codes.Unknown
 	}
-	s.statusDesc = fmt.Sprintf("stream terminated by RST_STREAM with error code: %d", f.ErrCode)
-	close(s.done)
+	s.finish(status.New(statusCode, fmt.Sprintf("stream terminated by RST_STREAM with error code: %d", f.ErrCode)))
 	s.mu.Unlock()
 	s.write(recvMsg{err: io.EOF})
 }
@@ -944,18 +937,17 @@ func (t *http2Client) operateHeaders(frame *http2.MetaHeadersFrame) {
 	}
 	var state decodeState
 	for _, hf := range frame.Fields {
-		state.processHeaderField(hf)
-	}
-	if state.err != nil {
-		s.mu.Lock()
-		if !s.headerDone {
-			close(s.headerChan)
-			s.headerDone = true
+		if err := state.processHeaderField(hf); err != nil {
+			s.mu.Lock()
+			if !s.headerDone {
+				close(s.headerChan)
+				s.headerDone = true
+			}
+			s.mu.Unlock()
+			s.write(recvMsg{err: err})
+			// Something wrong. Stops reading even when there is remaining.
+			return
 		}
-		s.mu.Unlock()
-		s.write(recvMsg{err: state.err})
-		// Something wrong. Stops reading even when there is remaining.
-		return
 	}
 
 	endStream := frame.StreamEnded()
@@ -998,10 +990,7 @@ func (t *http2Client) operateHeaders(frame *http2.MetaHeadersFrame) {
 	if len(state.mdata) > 0 {
 		s.trailer = state.mdata
 	}
-	s.statusCode = state.statusCode
-	s.statusDesc = state.statusDesc
-	close(s.done)
-	s.state = streamDone
+	s.finish(state.status())
 	s.mu.Unlock()
 	s.write(recvMsg{err: io.EOF})
 }

--- a/transport/http_util.go
+++ b/transport/http_util.go
@@ -156,7 +156,7 @@ func validContentType(t string) bool {
 	return true
 }
 
-func (d *decodeState) status() error {
+func (d *decodeState) status() status.Status {
 	if d.statusGen == nil {
 		// No status-details were provided; generate status using code/msg.
 		d.statusGen = status.New(codes.Code(d.rawStatusCode), d.rawStatusMsg)

--- a/transport/http_util.go
+++ b/transport/http_util.go
@@ -44,11 +44,14 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/golang/protobuf/proto"
+	spb "github.com/google/go-genproto/googleapis/rpc/status"
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/hpack"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/grpclog"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 )
 
 const (
@@ -90,13 +93,15 @@ var (
 // Records the states during HPACK decoding. Must be reset once the
 // decoding of the entire headers are finished.
 type decodeState struct {
-	err error // first error encountered decoding
-
 	encoding string
-	// statusCode caches the stream status received from the trailer
-	// the server sent. Client side only.
-	statusCode codes.Code
-	statusDesc string
+	// statusGen caches the stream status received from the trailer the server
+	// sent.  Client side only.  Do not access directly.  After all trailers are
+	// parsed, use the status method to retrieve the status.
+	statusGen status.Status
+	// rawStatusCode and rawStatusMsg are set from the raw trailer fields and are not
+	// intended for direct access outside of parsing.
+	rawStatusCode int32
+	rawStatusMsg  string
 	// Server side only fields.
 	timeoutSet bool
 	timeout    time.Duration
@@ -119,6 +124,7 @@ func isReservedHeader(hdr string) bool {
 		"grpc-message",
 		"grpc-status",
 		"grpc-timeout",
+		"grpc-status-details-bin",
 		"te":
 		return true
 	default:
@@ -137,12 +143,6 @@ func isWhitelistedPseudoHeader(hdr string) bool {
 	}
 }
 
-func (d *decodeState) setErr(err error) {
-	if d.err == nil {
-		d.err = err
-	}
-}
-
 func validContentType(t string) bool {
 	e := "application/grpc"
 	if !strings.HasPrefix(t, e) {
@@ -156,31 +156,45 @@ func validContentType(t string) bool {
 	return true
 }
 
-func (d *decodeState) processHeaderField(f hpack.HeaderField) {
+func (d *decodeState) status() error {
+	if d.statusGen == nil {
+		// No status-details were provided; generate status using code/msg.
+		d.statusGen = status.New(codes.Code(d.rawStatusCode), d.rawStatusMsg)
+	}
+	return d.statusGen
+}
+
+func (d *decodeState) processHeaderField(f hpack.HeaderField) error {
 	switch f.Name {
 	case "content-type":
 		if !validContentType(f.Value) {
-			d.setErr(streamErrorf(codes.FailedPrecondition, "transport: received the unexpected content-type %q", f.Value))
-			return
+			return streamErrorf(codes.FailedPrecondition, "transport: received the unexpected content-type %q", f.Value)
 		}
 	case "grpc-encoding":
 		d.encoding = f.Value
 	case "grpc-status":
 		code, err := strconv.Atoi(f.Value)
 		if err != nil {
-			d.setErr(streamErrorf(codes.Internal, "transport: malformed grpc-status: %v", err))
-			return
+			return streamErrorf(codes.Internal, "transport: malformed grpc-status: %v", err)
 		}
-		d.statusCode = codes.Code(code)
+		d.rawStatusCode = int32(code)
 	case "grpc-message":
-		d.statusDesc = decodeGrpcMessage(f.Value)
+		d.rawStatusMsg = decodeGrpcMessage(f.Value)
+	case "grpc-status-details-bin":
+		_, v, err := metadata.DecodeKeyValue("grpc-status-details-bin", f.Value)
+		if err != nil {
+			return streamErrorf(codes.Internal, "transport: malformed grpc-status-details-bin: %v", err)
+		}
+		s := &spb.Status{}
+		if err := proto.Unmarshal([]byte(v), s); err != nil {
+			return streamErrorf(codes.Internal, "transport: malformed grpc-status-details-bin: %v", err)
+		}
+		d.statusGen = status.FromProto(s)
 	case "grpc-timeout":
 		d.timeoutSet = true
 		var err error
-		d.timeout, err = decodeTimeout(f.Value)
-		if err != nil {
-			d.setErr(streamErrorf(codes.Internal, "transport: malformed time-out: %v", err))
-			return
+		if d.timeout, err = decodeTimeout(f.Value); err != nil {
+			return streamErrorf(codes.Internal, "transport: malformed time-out: %v", err)
 		}
 	case ":path":
 		d.method = f.Value
@@ -192,11 +206,12 @@ func (d *decodeState) processHeaderField(f hpack.HeaderField) {
 			k, v, err := metadata.DecodeKeyValue(f.Name, f.Value)
 			if err != nil {
 				grpclog.Printf("Failed to decode (%q, %q): %v", f.Name, f.Value, err)
-				return
+				return nil
 			}
 			d.mdata[k] = append(d.mdata[k], v)
 		}
 	}
+	return nil
 }
 
 type timeoutUnit uint8

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -51,6 +51,7 @@ import (
 	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/stats"
+	"google.golang.org/grpc/status"
 	"google.golang.org/grpc/tap"
 )
 
@@ -212,9 +213,8 @@ type Stream struct {
 	// true iff headerChan is closed. Used to avoid closing headerChan
 	// multiple times.
 	headerDone bool
-	// the status received from the server.
-	statusCode codes.Code
-	statusDesc string
+	// the status error received from the server.
+	status status.Status
 	// rstStream indicates whether a RST_STREAM frame needs to be sent
 	// to the server to signify that this stream is closing.
 	rstStream bool
@@ -284,14 +284,9 @@ func (s *Stream) Method() string {
 	return s.method
 }
 
-// StatusCode returns statusCode received from the server.
-func (s *Stream) StatusCode() codes.Code {
-	return s.statusCode
-}
-
-// StatusDesc returns statusDesc received from the server.
-func (s *Stream) StatusDesc() string {
-	return s.statusDesc
+// Status returns the status received from the server.
+func (s *Stream) Status() status.Status {
+	return s.status
 }
 
 // SetHeader sets the header metadata. This can be called multiple times.
@@ -336,6 +331,14 @@ func (s *Stream) Read(p []byte) (n int, err error) {
 	}
 	s.windowHandler(n)
 	return
+}
+
+// finish sets the stream's state and status, and closes the done channel.
+// s.mu must be held by the caller.
+func (s *Stream) finish(st error) {
+	s.status = st
+	s.state = streamDone
+	close(s.done)
 }
 
 // The key to save transport.Stream in the context.
@@ -503,10 +506,9 @@ type ServerTransport interface {
 	// Write may not be called on all streams.
 	Write(s *Stream, data []byte, opts *Options) error
 
-	// WriteStatus sends the status of a stream to the client.
-	// WriteStatus is the final call made on a stream and always
-	// occurs.
-	WriteStatus(s *Stream, statusCode codes.Code, statusDesc string) error
+	// WriteStatus sends the status of a stream to the client.  WriteStatus is
+	// the final call made on a stream and always occurs.
+	WriteStatus(s *Stream, st status.Status) error
 
 	// Close tears down the transport. Once it is called, the transport
 	// should not be accessed any more. All the pending streams and their
@@ -571,6 +573,8 @@ var (
 	// the server stops accepting new RPCs.
 	ErrStreamDrain = streamErrorf(codes.Unavailable, "the server stops accepting new RPCs")
 )
+
+// TODO: See if we can replace StreamError with status package errors.
 
 // StreamError is an error that only affects one stream within a connection.
 type StreamError struct {

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -335,7 +335,7 @@ func (s *Stream) Read(p []byte) (n int, err error) {
 
 // finish sets the stream's state and status, and closes the done channel.
 // s.mu must be held by the caller.
-func (s *Stream) finish(st error) {
+func (s *Stream) finish(st status.Status) {
 	s.status = st
 	s.state = streamDone
 	close(s.done)

--- a/transport/transport_test.go
+++ b/transport/transport_test.go
@@ -1134,7 +1134,7 @@ func TestClientWithMisbehavedServer(t *testing.T) {
 	if err != io.EOF {
 		t.Fatalf("Got err %v, want <EOF>", err)
 	}
-	if st, ok := s.status.(status.Status); !ok || st.Code() != codes.Internal {
+	if s.status.Code() != codes.Internal {
 		t.Fatalf("Got s.status %v, want s.status.Code()=Internal", s.status)
 	}
 

--- a/transport/transport_test.go
+++ b/transport/transport_test.go
@@ -1075,8 +1075,8 @@ func TestServerWithMisbehavedClient(t *testing.T) {
 	if _, err := io.ReadFull(s, make([]byte, 1)); err != io.EOF {
 		t.Fatalf("%v got err %v want <EOF>", s, err)
 	}
-	if st := statusFromError(s.status); st.Code() != code {
-		t.Fatalf("%v got status %v; want Code=%v", s, st, code)
+	if s.status.Code() != code {
+		t.Fatalf("%v got status %v; want Code=%v", s.status, code)
 	}
 
 	if ss.fc.pendingData != 0 || ss.fc.pendingUpdate != 0 || sc.fc.pendingData != 0 || sc.fc.pendingUpdate <= initialWindowSize {

--- a/transport/transport_test.go
+++ b/transport/transport_test.go
@@ -1076,7 +1076,7 @@ func TestServerWithMisbehavedClient(t *testing.T) {
 		t.Fatalf("%v got err %v want <EOF>", s, err)
 	}
 	if s.status.Code() != code {
-		t.Fatalf("%v got status %v; want Code=%v", s.status, code)
+		t.Fatalf("%v got status %v; want Code=%v", s, s.status, code)
 	}
 
 	if ss.fc.pendingData != 0 || ss.fc.pendingUpdate != 0 || sc.fc.pendingData != 0 || sc.fc.pendingUpdate <= initialWindowSize {


### PR DESCRIPTION
Fixes #1122 

If an error implemented by the status package is returned from a service
handler, the server will transmit a rich status message in the
"grpc-status-details-bin" trailing metadata field if any detailed data is
attached to the error.  Client-side, we will decode them if present in the
server's response and return them to the user code performing the RPC.

This is backward compatible with the existing errors supported by the grpc
package.  However, the grpc.Errorf, grpc.Code and grpc.ErrorDesc functions for
managing errors are now deprecated; status.Errorf and status.FromError should
be used instead on the server and client respectively.