### PR TITLE
Support for per-RPC decompression

### DIFF
--- a/call.go
+++ b/call.go
@@ -71,8 +71,14 @@ func recvResponse(ctx context.Context, dopts dialOptions, t transport.ClientTran
 			Client: true,
 		}
 	}
+	var dc Decompressor
+	if c.decompressor != nil {
+		dc = c.decompressor
+	} else {
+		dc = dopts.dc
+	}
 	for {
-		if err = recv(p, dopts.codec, stream, dopts.dc, reply, dopts.maxMsgSize, inPayload); err != nil {
+		if err = recv(p, dopts.codec, stream, dc, reply, dopts.maxMsgSize, inPayload); err != nil {
 			if err == io.EOF {
 				break
 			}
@@ -222,6 +228,13 @@ func invoke(ctx context.Context, method string, args, reply interface{}, cc *Cli
 		}
 		if cc.dopts.cp != nil {
 			callHdr.SendCompress = cc.dopts.cp.Type()
+		}
+		// Add compression algorithms to grpc-accept-encoding header
+		// if a Decompressor is attached to the RPC or channel
+		if c.decompressor != nil {
+			callHdr.AcceptEncoding = c.decompressor.Type()
+		} else if cc.dopts.dc != nil {
+			callHdr.AcceptEncoding = cc.dopts.dc.Type()
 		}
 
 		gopts := BalancerGetOptions{

--- a/transport/http2_client.go
+++ b/transport/http2_client.go
@@ -410,6 +410,14 @@ func (t *http2Client) NewStream(ctx context.Context, callHdr *CallHdr) (_ *Strea
 	t.hEnc.WriteField(hpack.HeaderField{Name: ":scheme", Value: t.scheme})
 	t.hEnc.WriteField(hpack.HeaderField{Name: ":path", Value: callHdr.Method})
 	t.hEnc.WriteField(hpack.HeaderField{Name: ":authority", Value: callHdr.Host})
+
+	if callHdr.AcceptEncoding != "" {
+		encodings := "identity," + callHdr.AcceptEncoding
+		t.hEnc.WriteField(hpack.HeaderField{Name: "grpc-accept-encoding", Value: encodings})
+	} else {
+		t.hEnc.WriteField(hpack.HeaderField{Name: "grpc-accept-encoding", Value: "identity"})
+	}
+
 	t.hEnc.WriteField(hpack.HeaderField{Name: "content-type", Value: "application/grpc"})
 	t.hEnc.WriteField(hpack.HeaderField{Name: "user-agent", Value: t.userAgent})
 	t.hEnc.WriteField(hpack.HeaderField{Name: "te", Value: "trailers"})

--- a/transport/http_util.go
+++ b/transport/http_util.go
@@ -92,7 +92,8 @@ var (
 type decodeState struct {
 	err error // first error encountered decoding
 
-	encoding string
+	acceptEncoding []string
+	encoding       string
 	// statusCode caches the stream status received from the trailer
 	// the server sent. Client side only.
 	statusCode codes.Code
@@ -115,6 +116,7 @@ func isReservedHeader(hdr string) bool {
 	switch hdr {
 	case "content-type",
 		"grpc-message-type",
+		"grpc-accept-encoding",
 		"grpc-encoding",
 		"grpc-message",
 		"grpc-status",
@@ -163,6 +165,8 @@ func (d *decodeState) processHeaderField(f hpack.HeaderField) {
 			d.setErr(streamErrorf(codes.FailedPrecondition, "transport: received the unexpected content-type %q", f.Value))
 			return
 		}
+	case "grpc-accept-encoding":
+		d.acceptEncoding = strings.Split(f.Value, ",")
 	case "grpc-encoding":
 		d.encoding = f.Value
 	case "grpc-status":

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -440,6 +440,11 @@ type CallHdr struct {
 	// outbound message.
 	SendCompress string
 
+	// AcceptEncoding specifies the compression algorithm to
+	// populate the grpc-accept-encoding header on the outbound
+	// message.
+	AcceptEncoding string
+
 	// Flush indicates whether a new stream command should be sent
 	// to the peer without waiting for the first data. This is
 	// only a hint. The transport may modify the flush decision


### PR DESCRIPTION
- Addition of 'WithRPCDecompressor' CallOption to pass Decompressor per-RPC
- Client-side support to dynamically construct 'grpc-accept-encoding' header based off channel/RPC decompressors
- Fallback support to channel decompressor if per-RPC decompressor is not specified per https://github.com/grpc/grpc/blob/master/doc/compression.md
- Set 'grpc-accept-encoding' as reserved header and return slice of encodings for header processing