### PR TITLE
grpclog: remove Fatal functions

### DIFF
--- a/benchmark/benchmark_test.go
+++ b/benchmark/benchmark_test.go
@@ -10,7 +10,6 @@ import (
 	"google.golang.org/grpc"
 	testpb "google.golang.org/grpc/benchmark/grpc_testing"
 	"google.golang.org/grpc/benchmark/stats"
-	"google.golang.org/grpc/grpclog"
 )
 
 func runUnary(b *testing.B, maxConcurrentCalls int) {
@@ -23,7 +22,9 @@ func runUnary(b *testing.B, maxConcurrentCalls int) {
 
 	// Warm up connection.
 	for i := 0; i < 10; i++ {
-		unaryCaller(tc)
+		if err := DoUnaryCall(tc, 1, 1); err != nil {
+			b.Fatalf("DoUnaryCall failed: %v", err)
+		}
 	}
 	ch := make(chan int, maxConcurrentCalls*4)
 	var (
@@ -37,7 +38,9 @@ func runUnary(b *testing.B, maxConcurrentCalls int) {
 		go func() {
 			for range ch {
 				start := time.Now()
-				unaryCaller(tc)
+				if err := DoUnaryCall(tc, 1, 1); err != nil {
+					b.Fatalf("DoUnaryCall failed: %v", err)
+				}
 				elapse := time.Since(start)
 				mu.Lock()
 				s.Add(elapse)
@@ -70,7 +73,9 @@ func runStream(b *testing.B, maxConcurrentCalls int) {
 		b.Fatalf("%v.StreamingCall(_) = _, %v", tc, err)
 	}
 	for i := 0; i < 10; i++ {
-		streamCaller(stream)
+		if err := DoStreamingRoundTrip(stream, 1, 1); err != nil {
+			b.Fatalf("DoStreamingRoundTrip failed: %v", err)
+		}
 	}
 
 	ch := make(chan int, maxConcurrentCalls*4)
@@ -89,7 +94,9 @@ func runStream(b *testing.B, maxConcurrentCalls int) {
 			}
 			for range ch {
 				start := time.Now()
-				streamCaller(stream)
+				if err := DoStreamingRoundTrip(stream, 1, 1); err != nil {
+					b.Fatalf("DoStreamingRoundTrip failed: %v", err)
+				}
 				elapse := time.Since(start)
 				mu.Lock()
 				s.Add(elapse)
@@ -106,17 +113,6 @@ func runStream(b *testing.B, maxConcurrentCalls int) {
 	close(ch)
 	wg.Wait()
 	conn.Close()
-}
-func unaryCaller(client testpb.BenchmarkServiceClient) {
-	if err := DoUnaryCall(client, 1, 1); err != nil {
-		grpclog.Fatalf("DoUnaryCall failed: %v", err)
-	}
-}
-
-func streamCaller(stream testpb.BenchmarkService_StreamingCallClient) {
-	if err := DoStreamingRoundTrip(stream, 1, 1); err != nil {
-		grpclog.Fatalf("DoStreamingRoundTrip failed: %v", err)
-	}
 }
 
 func BenchmarkClientStreamc1(b *testing.B) {

--- a/benchmark/client/main.go
+++ b/benchmark/client/main.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"net/http"
 	_ "net/http/pprof"
+	"os"
 	"sync"
 	"time"
 
@@ -103,7 +104,7 @@ func closeLoopStream() {
 		go func() {
 			stream, err := tc.StreamingCall(context.Background())
 			if err != nil {
-				grpclog.Fatalf("%v.StreamingCall(_) = _, %v", tc, err)
+				fatalf("%v.StreamingCall(_) = _, %v", tc, err)
 			}
 			// Do some warm up.
 			for i := 0; i < 100; i++ {
@@ -146,11 +147,11 @@ func main() {
 	go func() {
 		lis, err := net.Listen("tcp", ":0")
 		if err != nil {
-			grpclog.Fatalf("Failed to listen: %v", err)
+			fatalf("Failed to listen: %v", err)
 		}
 		grpclog.Println("Client profiling address: ", lis.Addr().String())
 		if err := http.Serve(lis, nil); err != nil {
-			grpclog.Fatalf("Failed to serve: %v", err)
+			fatalf("Failed to serve: %v", err)
 		}
 	}()
 	switch *rpcType {
@@ -159,4 +160,9 @@ func main() {
 	case 1:
 		closeLoopStream()
 	}
+}
+
+func fatalf(format string, args ...interface{}) {
+	grpclog.Printf(format, args...)
+	os.Exit(1)
 }

--- a/benchmark/server/main.go
+++ b/benchmark/server/main.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"net/http"
 	_ "net/http/pprof"
+	"os"
 	"time"
 
 	"google.golang.org/grpc/benchmark"
@@ -21,15 +22,20 @@ func main() {
 	go func() {
 		lis, err := net.Listen("tcp", ":0")
 		if err != nil {
-			grpclog.Fatalf("Failed to listen: %v", err)
+			fatalf("Failed to listen: %v", err)
 		}
 		grpclog.Println("Server profiling address: ", lis.Addr().String())
 		if err := http.Serve(lis, nil); err != nil {
-			grpclog.Fatalf("Failed to serve: %v", err)
+			fatalf("Failed to serve: %v", err)
 		}
 	}()
 	addr, stopper := benchmark.StartServer(benchmark.ServerInfo{Addr: ":0", Type: "protobuf"}) // listen on all interfaces
 	grpclog.Println("Server Address: ", addr)
 	<-time.After(time.Duration(*duration) * time.Second)
 	stopper()
+}
+
+func fatalf(format string, args ...interface{}) {
+	grpclog.Printf(format, args...)
+	os.Exit(1)
 }

--- a/benchmark/worker/benchmark_client.go
+++ b/benchmark/worker/benchmark_client.go
@@ -312,7 +312,7 @@ func (bc *benchmarkClient) doCloseLoopStreaming(conns []*grpc.ClientConn, rpcCou
 			c := testpb.NewBenchmarkServiceClient(conn)
 			stream, err := c.StreamingCall(context.Background())
 			if err != nil {
-				grpclog.Fatalf("%v.StreamingCall(_) = _, %v", c, err)
+				fatalf("%v.StreamingCall(_) = _, %v", c, err)
 			}
 			// Create histogram for each goroutine.
 			idx := ic*rpcCountPerConn + j

--- a/benchmark/worker/benchmark_server.go
+++ b/benchmark/worker/benchmark_server.go
@@ -107,7 +107,7 @@ func startBenchmarkServer(config *testpb.ServerConfig, serverPort int) (*benchma
 	if config.SecurityParams != nil {
 		creds, err := credentials.NewServerTLSFromFile(abs(certFile), abs(keyFile))
 		if err != nil {
-			grpclog.Fatalf("failed to generate credentials %v", err)
+			fatalf("failed to generate credentials %v", err)
 		}
 		opts = append(opts, grpc.Creds(creds))
 	}
@@ -155,7 +155,7 @@ func startBenchmarkServer(config *testpb.ServerConfig, serverPort int) (*benchma
 	addrSplitted := strings.Split(addr, ":")
 	p, err := strconv.Atoi(addrSplitted[len(addrSplitted)-1])
 	if err != nil {
-		grpclog.Fatalf("failed to get port number from server address: %v", err)
+		fatalf("failed to get port number from server address: %v", err)
 	}
 
 	rusage := new(syscall.Rusage)

--- a/benchmark/worker/main.go
+++ b/benchmark/worker/main.go
@@ -40,6 +40,7 @@ import (
 	"net"
 	"net/http"
 	_ "net/http/pprof"
+	"os"
 	"runtime"
 	"strconv"
 	"time"
@@ -212,7 +213,7 @@ func main() {
 	flag.Parse()
 	lis, err := net.Listen("tcp", ":"+strconv.Itoa(*driverPort))
 	if err != nil {
-		grpclog.Fatalf("failed to listen: %v", err)
+		fatalf("failed to listen: %v", err)
 	}
 	grpclog.Printf("worker listening at port %v", *driverPort)
 
@@ -241,4 +242,9 @@ func main() {
 	}
 
 	s.Serve(lis)
+}
+
+func fatalf(format string, args ...interface{}) {
+	grpclog.Printf(format, args...)
+	os.Exit(1)
 }

--- a/examples/route_guide/server/server.go
+++ b/examples/route_guide/server/server.go
@@ -45,6 +45,7 @@ import (
 	"io/ioutil"
 	"math"
 	"net"
+	"os"
 	"time"
 
 	"golang.org/x/net/context"
@@ -159,10 +160,10 @@ func (s *routeGuideServer) RouteChat(stream pb.RouteGuide_RouteChatServer) error
 func (s *routeGuideServer) loadFeatures(filePath string) {
 	file, err := ioutil.ReadFile(filePath)
 	if err != nil {
-		grpclog.Fatalf("Failed to load default features: %v", err)
+		fatalf("Failed to load default features: %v", err)
 	}
 	if err := json.Unmarshal(file, &s.savedFeatures); err != nil {
-		grpclog.Fatalf("Failed to load default features: %v", err)
+		fatalf("Failed to load default features: %v", err)
 	}
 }
 
@@ -223,17 +224,22 @@ func main() {
 	flag.Parse()
 	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", *port))
 	if err != nil {
-		grpclog.Fatalf("failed to listen: %v", err)
+		fatalf("failed to listen: %v", err)
 	}
 	var opts []grpc.ServerOption
 	if *tls {
 		creds, err := credentials.NewServerTLSFromFile(*certFile, *keyFile)
 		if err != nil {
-			grpclog.Fatalf("Failed to generate credentials %v", err)
+			fatalf("Failed to generate credentials %v", err)
 		}
 		opts = []grpc.ServerOption{grpc.Creds(creds)}
 	}
 	grpcServer := grpc.NewServer(opts...)
 	pb.RegisterRouteGuideServer(grpcServer, newServer())
 	grpcServer.Serve(lis)
+}
+
+func fatalf(format string, args ...interface{}) {
+	grpclog.Printf(format, args...)
+	os.Exit(1)
 }

--- a/grpclog/glogger/glogger.go
+++ b/grpclog/glogger/glogger.go
@@ -49,22 +49,6 @@ func init() {
 
 type glogger struct{}
 
-func (g *glogger) Fatal(args ...interface{}) {
-	glog.FatalDepth(2, args...)
-}
-
-func (g *glogger) Fatalf(format string, args ...interface{}) {
-	glog.FatalDepth(2, fmt.Sprintf(format, args...))
-}
-
-func (g *glogger) Fatalln(args ...interface{}) {
-	glog.FatalDepth(2, fmt.Sprintln(args...))
-}
-
-func (g *glogger) Print(args ...interface{}) {
-	glog.InfoDepth(2, args...)
-}
-
 func (g *glogger) Printf(format string, args ...interface{}) {
 	glog.InfoDepth(2, fmt.Sprintf(format, args...))
 }

--- a/grpclog/logger.go
+++ b/grpclog/logger.go
@@ -48,10 +48,6 @@ var logger Logger = log.New(os.Stderr, "", log.LstdFlags)
 
 // Logger mimics golang's standard Logger as an interface.
 type Logger interface {
-	Fatal(args ...interface{})
-	Fatalf(format string, args ...interface{})
-	Fatalln(args ...interface{})
-	Print(args ...interface{})
 	Printf(format string, args ...interface{})
 	Println(args ...interface{})
 }
@@ -60,26 +56,6 @@ type Logger interface {
 // init() functions.
 func SetLogger(l Logger) {
 	logger = l
-}
-
-// Fatal is equivalent to Print() followed by a call to os.Exit() with a non-zero exit code.
-func Fatal(args ...interface{}) {
-	logger.Fatal(args...)
-}
-
-// Fatalf is equivalent to Printf() followed by a call to os.Exit() with a non-zero exit code.
-func Fatalf(format string, args ...interface{}) {
-	logger.Fatalf(format, args...)
-}
-
-// Fatalln is equivalent to Println() followed by a call to os.Exit()) with a non-zero exit code.
-func Fatalln(args ...interface{}) {
-	logger.Fatalln(args...)
-}
-
-// Print prints to the logger. Arguments are handled in the manner of fmt.Print.
-func Print(args ...interface{}) {
-	logger.Print(args...)
 }
 
 // Printf prints to the logger. Arguments are handled in the manner of fmt.Printf.

--- a/interop/http2/negative_http2_client.go
+++ b/interop/http2/negative_http2_client.go
@@ -41,6 +41,7 @@ package main
 import (
 	"flag"
 	"net"
+	"os"
 	"strconv"
 	"sync"
 	"time"
@@ -91,10 +92,10 @@ func rstAfterHeader(tc testpb.TestServiceClient) {
 	req := largeSimpleRequest()
 	reply, err := tc.UnaryCall(context.Background(), req)
 	if reply != nil {
-		grpclog.Fatalf("Client received reply despite server sending rst stream after header")
+		fatalf("Client received reply despite server sending rst stream after header")
 	}
 	if grpc.Code(err) != codes.Internal {
-		grpclog.Fatalf("%v.UnaryCall() = _, %v, want _, %v", tc, grpc.Code(err), codes.Internal)
+		fatalf("%v.UnaryCall() = _, %v, want _, %v", tc, grpc.Code(err), codes.Internal)
 	}
 }
 
@@ -102,10 +103,10 @@ func rstDuringData(tc testpb.TestServiceClient) {
 	req := largeSimpleRequest()
 	reply, err := tc.UnaryCall(context.Background(), req)
 	if reply != nil {
-		grpclog.Fatalf("Client received reply despite server sending rst stream during data")
+		fatalf("Client received reply despite server sending rst stream during data")
 	}
 	if grpc.Code(err) != codes.Unknown {
-		grpclog.Fatalf("%v.UnaryCall() = _, %v, want _, %v", tc, grpc.Code(err), codes.Unknown)
+		fatalf("%v.UnaryCall() = _, %v, want _, %v", tc, grpc.Code(err), codes.Unknown)
 	}
 }
 
@@ -113,10 +114,10 @@ func rstAfterData(tc testpb.TestServiceClient) {
 	req := largeSimpleRequest()
 	reply, err := tc.UnaryCall(context.Background(), req)
 	if reply != nil {
-		grpclog.Fatalf("Client received reply despite server sending rst stream after data")
+		fatalf("Client received reply despite server sending rst stream after data")
 	}
 	if grpc.Code(err) != codes.Internal {
-		grpclog.Fatalf("%v.UnaryCall() = _, %v, want _, %v", tc, grpc.Code(err), codes.Internal)
+		fatalf("%v.UnaryCall() = _, %v, want _, %v", tc, grpc.Code(err), codes.Internal)
 	}
 }
 
@@ -145,7 +146,7 @@ func main() {
 	opts = append(opts, grpc.WithInsecure())
 	conn, err := grpc.Dial(serverAddr, opts...)
 	if err != nil {
-		grpclog.Fatalf("Fail to dial: %v", err)
+		fatalf("Fail to dial: %v", err)
 	}
 	defer conn.Close()
 	tc := testpb.NewTestServiceClient(conn)
@@ -169,6 +170,11 @@ func main() {
 		maxStreams(tc)
 		grpclog.Println("max_streams done")
 	default:
-		grpclog.Fatal("Unsupported test case: ", *testCase)
+		fatalf("Unsupported test case: %v", *testCase)
 	}
+}
+
+func fatalf(format string, args ...interface{}) {
+	grpclog.Printf(format, args...)
+	os.Exit(1)
 }

--- a/interop/server/server.go
+++ b/interop/server/server.go
@@ -36,6 +36,7 @@ package main
 import (
 	"flag"
 	"net"
+	"os"
 	"strconv"
 
 	"google.golang.org/grpc"
@@ -57,17 +58,22 @@ func main() {
 	p := strconv.Itoa(*port)
 	lis, err := net.Listen("tcp", ":"+p)
 	if err != nil {
-		grpclog.Fatalf("failed to listen: %v", err)
+		fatalf("failed to listen: %v", err)
 	}
 	var opts []grpc.ServerOption
 	if *useTLS {
 		creds, err := credentials.NewServerTLSFromFile(*certFile, *keyFile)
 		if err != nil {
-			grpclog.Fatalf("Failed to generate credentials %v", err)
+			fatalf("Failed to generate credentials %v", err)
 		}
 		opts = []grpc.ServerOption{grpc.Creds(creds)}
 	}
 	server := grpc.NewServer(opts...)
 	testpb.RegisterTestServiceServer(server, interop.NewTestServer())
 	server.Serve(lis)
+}
+
+func fatalf(format string, args ...interface{}) {
+	grpclog.Printf(format, args...)
+	os.Exit(1)
 }

--- a/server.go
+++ b/server.go
@@ -294,7 +294,7 @@ func (s *Server) RegisterService(sd *ServiceDesc, ss interface{}) {
 	ht := reflect.TypeOf(sd.HandlerType).Elem()
 	st := reflect.TypeOf(ss)
 	if !st.Implements(ht) {
-		grpclog.Fatalf("grpc: Server.RegisterService found the handler of type %v that does not satisfy %v", st, ht)
+		panic(fmt.Errorf("grpc: Server.RegisterService found the handler of type %v that does not satisfy %v", st, ht))
 	}
 	s.register(sd, ss)
 }
@@ -304,7 +304,7 @@ func (s *Server) register(sd *ServiceDesc, ss interface{}) {
 	defer s.mu.Unlock()
 	s.printf("RegisterService(%q)", sd.ServiceName)
 	if _, ok := s.m[sd.ServiceName]; ok {
-		grpclog.Fatalf("grpc: Server.RegisterService found duplicate service registration for %q", sd.ServiceName)
+		panic(fmt.Errorf("grpc: Server.RegisterService found duplicate service registration for %q", sd.ServiceName))
 	}
 	srv := &service{
 		server: ss,
@@ -626,7 +626,7 @@ func (s *Server) sendResponse(t transport.ServerTransport, stream *transport.Str
 		// TODO(zhaoq): There exist other options also such as only closing the
 		// faulty stream locally and remotely (Other streams can keep going). Find
 		// the optimal option.
-		grpclog.Fatalf("grpc: Server failed to encode response %v", err)
+		panic(fmt.Errorf("grpc: Server failed to encode response %v", err))
 	}
 	err = t.Write(stream, p, opts)
 	if err == nil && outPayload != nil {
@@ -1082,7 +1082,7 @@ func SendHeader(ctx context.Context, md metadata.MD) error {
 	}
 	t := stream.ServerTransport()
 	if t == nil {
-		grpclog.Fatalf("grpc: SendHeader: %v has no ServerTransport to send header metadata.", stream)
+		panic(fmt.Errorf("grpc: SendHeader: %v has no ServerTransport to send header metadata", stream))
 	}
 	if err := t.WriteHeader(stream, md); err != nil {
 		return toRPCErr(err)

--- a/stress/client/main.go
+++ b/stress/client/main.go
@@ -39,6 +39,7 @@ import (
 	"fmt"
 	"math/rand"
 	"net"
+	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -210,7 +211,7 @@ func (s *server) createGauge(name string) *gauge {
 func startServer(server *server, port int) {
 	lis, err := net.Listen("tcp", ":"+strconv.Itoa(port))
 	if err != nil {
-		grpclog.Fatalf("failed to listen: %v", err)
+		fatalf("failed to listen: %v", err)
 	}
 
 	s := grpc.NewServer()
@@ -294,7 +295,7 @@ func newConn(address string, useTLS, testCA bool, tlsServerName string) (*grpc.C
 			var err error
 			creds, err = credentials.NewClientTLSFromFile(testCAFile, sn)
 			if err != nil {
-				grpclog.Fatalf("Failed to create TLS credentials %v", err)
+				fatalf("Failed to create TLS credentials %v", err)
 			}
 		} else {
 			creds = credentials.NewClientTLSFromCert(nil, sn)
@@ -322,7 +323,7 @@ func main() {
 		for connIndex := 0; connIndex < *numChannelsPerServer; connIndex++ {
 			conn, err := newConn(address, *useTLS, *testCA, *tlsServerName)
 			if err != nil {
-				grpclog.Fatalf("Fail to dial: %v", err)
+				fatalf("Fail to dial: %v", err)
 			}
 			defer conn.Close()
 			for clientIndex := 0; clientIndex < *numStubsPerChannel; clientIndex++ {
@@ -344,4 +345,9 @@ func main() {
 	wg.Wait()
 	grpclog.Printf(" ===== ALL DONE ===== ")
 
+}
+
+func fatalf(format string, args ...interface{}) {
+	grpclog.Printf(format, args...)
+	os.Exit(1)
 }


### PR DESCRIPTION
In all cases, there are better mechanisms (testing Fatalf, panic,
explicit os.Exit) to abort the relevant part of the code.  This makes
gRPC library behavior easier to reason about with alternate log
implementations.