### PR TITLE
transport: hide Stream string when stored in context

### DIFF
--- a/transport/transport.go
+++ b/transport/transport.go
@@ -341,6 +341,12 @@ func (s *Stream) finish(st *status.Status) {
 	close(s.done)
 }
 
+// GoString is implemented by Stream so context.String() won't
+// race when printing %#v.
+func (s *Stream) GoString() string {
+	return fmt.Sprintf("<stream: %p, %v>", s, s.method)
+}
+
 // The key to save transport.Stream in the context.
 type streamKey struct{}
 


### PR DESCRIPTION
It is not thread-safe to call context.String() on any context with a
stream value since valueCtx will use %#v to access all of the Stream
fields without holding a lock. Instead, use "<nil>" as the GoString.