### PR TITLE
grpc: make ServerOption panic messages more clear.

### DIFF
--- a/server.go
+++ b/server.go
@@ -192,7 +192,7 @@ func Creds(c credentials.TransportCredentials) ServerOption {
 func UnaryInterceptor(i UnaryServerInterceptor) ServerOption {
 	return func(o *options) {
 		if o.unaryInt != nil {
-			panic("The unary server interceptor has been set.")
+			panic("The unary server interceptor was already set and may not be reset.")
 		}
 		o.unaryInt = i
 	}
@@ -203,7 +203,7 @@ func UnaryInterceptor(i UnaryServerInterceptor) ServerOption {
 func StreamInterceptor(i StreamServerInterceptor) ServerOption {
 	return func(o *options) {
 		if o.streamInt != nil {
-			panic("The stream server interceptor has been set.")
+			panic("The stream server interceptor was already set and may not be reset.")
 		}
 		o.streamInt = i
 	}
@@ -214,7 +214,7 @@ func StreamInterceptor(i StreamServerInterceptor) ServerOption {
 func InTapHandle(h tap.ServerInHandle) ServerOption {
 	return func(o *options) {
 		if o.inTapHandle != nil {
-			panic("The tap handle has been set.")
+			panic("The tap handle was already set and may not be reset.")
 		}
 		o.inTapHandle = h
 	}


### PR DESCRIPTION
ServerOption panics when fields that have been manually set are
subsequently set again.  The message verbiage of `X has been set` is
unclear since `has been set` without an adverb like `already` does not
correctly convey that the fields are set-once and were previously set.
At the worst, the original verbiage `X has been set` could imply that
the new value would have been acceptable but another error occurred.

We discovered this while conducting a code survey for implementing
extensible stubs and uniform inbound interception API.