### PR TITLE
Use unpadded base64 encoding for binary metadata headers; handle padded or unpadded input

### DIFF
--- a/transport/http_util.go
+++ b/transport/http_util.go
@@ -174,9 +174,8 @@ func decodeBinHeader(v string) ([]byte, error) {
 	if len(v)%4 == 0 {
 		// Input was padded, or padding was not necessary.
 		return base64.StdEncoding.DecodeString(v)
-	} else {
-		return base64.RawStdEncoding.DecodeString(v)
 	}
+	return base64.RawStdEncoding.DecodeString(v)
 }
 
 func encodeMetadataHeader(k, v string) string {

--- a/transport/http_util.go
+++ b/transport/http_util.go
@@ -167,11 +167,16 @@ func (d *decodeState) status() *status.Status {
 const binHdrSuffix = "-bin"
 
 func encodeBinHeader(v []byte) string {
-	return base64.StdEncoding.EncodeToString(v)
+	return base64.RawStdEncoding.EncodeToString(v)
 }
 
 func decodeBinHeader(v string) ([]byte, error) {
-	return base64.StdEncoding.DecodeString(v)
+	if len(v)%4 == 0 {
+		// Input was padded, or padding was not necessary.
+		return base64.StdEncoding.DecodeString(v)
+	} else {
+		return base64.RawStdEncoding.DecodeString(v)
+	}
 }
 
 func encodeMetadataHeader(k, v string) string {

--- a/transport/http_util_test.go
+++ b/transport/http_util_test.go
@@ -158,7 +158,7 @@ func TestEncodeMetadataHeader(t *testing.T) {
 		{"key", "abc", "abc"},
 		{"KEY", "abc", "abc"},
 		{"key-bin", "abc", "YWJj"},
-		{"key-bin", binaryValue, "woA="},
+		{"key-bin", binaryValue, "woA"},
 	} {
 		v := encodeMetadataHeader(test.kin, test.vin)
 		if !reflect.DeepEqual(v, test.vout) {
@@ -178,6 +178,7 @@ func TestDecodeMetadataHeader(t *testing.T) {
 	}{
 		{"a", "abc", "abc", nil},
 		{"key-bin", "Zm9vAGJhcg==", "foo\x00bar", nil},
+		{"key-bin", "Zm9vAGJhcg", "foo\x00bar", nil},
 		{"key-bin", "woA=", binaryValue, nil},
 		{"a", "abc,efg", "abc,efg", nil},
 	} {


### PR DESCRIPTION
Fixes  #1207