### PR TITLE
Eagerly set a pointer to nil to help GC

### DIFF
--- a/transport/transport.go
+++ b/transport/transport.go
@@ -105,6 +105,7 @@ func (b *recvBuffer) load() {
 	if len(b.backlog) > 0 {
 		select {
 		case b.c <- b.backlog[0]:
+			b.backlog[0] = nil
 			b.backlog = b.backlog[1:]
 		default:
 		}


### PR DESCRIPTION
Addresses https://github.com/grpc/grpc-go/issues/1231

Perhaps encapsulating this behavior in a circular `queue` object and using that instead of direct slice manipulation would be the way to go in a future refactoring.