### PR TITLE
call listen with "localhost:port" instead of ":port" in tests

### DIFF
--- a/proxy_test.go
+++ b/proxy_test.go
@@ -133,7 +133,7 @@ func (p *proxyServer) stop() {
 }
 
 func TestHTTPConnect(t *testing.T) {
-	plis, err := net.Listen("tcp", ":0")
+	plis, err := net.Listen("tcp", "localhost:0")
 	if err != nil {
 		t.Fatalf("failed to listen: %v", err)
 	}
@@ -141,7 +141,7 @@ func TestHTTPConnect(t *testing.T) {
 	go p.run()
 	defer p.stop()
 
-	blis, err := net.Listen("tcp", ":0")
+	blis, err := net.Listen("tcp", "localhost:0")
 	if err != nil {
 		t.Fatalf("failed to listen: %v", err)
 	}

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -3412,7 +3412,7 @@ func (c *serverDispatchCred) getRawConn() net.Conn {
 }
 
 func TestServerCredsDispatch(t *testing.T) {
-	lis, err := net.Listen("tcp", ":0")
+	lis, err := net.Listen("tcp", "localhost:0")
 	if err != nil {
 		t.Fatalf("Failed to listen: %v", err)
 	}
@@ -3453,7 +3453,7 @@ func TestFlowControlLogicalRace(t *testing.T) {
 		requestCount = 1000
 	}
 
-	lis, err := net.Listen("tcp", ":0")
+	lis, err := net.Listen("tcp", "localhost:0")
 	if err != nil {
 		t.Fatalf("Failed to listen: %v", err)
 	}
@@ -3763,9 +3763,9 @@ func (ss *stubServer) FullDuplexCall(stream testpb.TestService_FullDuplexCallSer
 
 // Start starts the server and creates a client connected to it.
 func (ss *stubServer) Start() error {
-	lis, err := net.Listen("tcp", ":0")
+	lis, err := net.Listen("tcp", "localhost:0")
 	if err != nil {
-		return fmt.Errorf(`net.Listen("tcp", ":0") = %v`, err)
+		return fmt.Errorf(`net.Listen("tcp", "localhost:0") = %v`, err)
 	}
 	ss.cleanups = append(ss.cleanups, func() { lis.Close() })
 


### PR DESCRIPTION
fixes #1058 

The reason for using "localhost" is #1067.