### PR TITLE
grpclb balancer.Close() should not panic if called more than once

### DIFF
--- a/grpclb.go
+++ b/grpclb.go
@@ -745,6 +745,9 @@ func (b *balancer) Notify() <-chan []Address {
 func (b *balancer) Close() error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
+	if b.done {
+		return errBalancerClosed
+	}
 	b.done = true
 	if b.expTimer != nil {
 		b.expTimer.Stop()


### PR DESCRIPTION
fixes #1249 