### PR TITLE
Avoid uint32 overflow when applying initial window size setting

### DIFF
--- a/transport/http2_client.go
+++ b/transport/http2_client.go
@@ -1173,7 +1173,7 @@ func (t *http2Client) applySettings(ss []http2.Setting) {
 			t.mu.Lock()
 			for _, stream := range t.activeStreams {
 				// Adjust the sending quota for each stream.
-				stream.sendQuotaPool.add(int(s.Val - t.streamSendQuota))
+				stream.sendQuotaPool.add(int(s.Val) - int(t.streamSendQuota))
 			}
 			t.streamSendQuota = s.Val
 			t.mu.Unlock()

--- a/transport/http2_server.go
+++ b/transport/http2_server.go
@@ -877,7 +877,7 @@ func (t *http2Server) applySettings(ss []http2.Setting) {
 			t.mu.Lock()
 			defer t.mu.Unlock()
 			for _, stream := range t.activeStreams {
-				stream.sendQuotaPool.add(int(s.Val - t.streamSendQuota))
+				stream.sendQuotaPool.add(int(s.Val) - int(t.streamSendQuota))
 			}
 			t.streamSendQuota = s.Val
 		}


### PR DESCRIPTION
If `s.Val` is less than `t.streamSendQuota`, subtraction can result in a very big number due to overflow (both fields are `uint32`), effectively giving the stream a lot of quota to send data while its peer is expecting otherwise.