### PR TITLE
Update references to route_guide.proto to use new directory name

### DIFF
--- a/examples/route_guide/README.md
+++ b/examples/route_guide/README.md
@@ -4,7 +4,7 @@ perform unary, client streaming, server streaming and full duplex RPCs.
 
 Please refer to [gRPC Basics: Go] (http://www.grpc.io/docs/tutorials/basic/go.html) for more information.
 
-See the definition of the route guide service in proto/route_guide.proto.
+See the definition of the route guide service in routeguide/route_guide.proto.
 
 # Run the sample code
 To compile and run the server, assuming you are in the root of the route_guide

--- a/examples/route_guide/client/client.go
+++ b/examples/route_guide/client/client.go
@@ -34,7 +34,7 @@
 // Package main implements a simple gRPC client that demonstrates how to use gRPC-Go libraries
 // to perform unary, client streaming, server streaming and full duplex RPCs.
 //
-// It interacts with the route guide service whose definition can be found in proto/route_guide.proto.
+// It interacts with the route guide service whose definition can be found in routeguide/route_guide.proto.
 package main
 
 import (

--- a/examples/route_guide/server/server.go
+++ b/examples/route_guide/server/server.go
@@ -34,7 +34,7 @@
 // Package main implements a simple gRPC server that demonstrates how to use gRPC-Go libraries
 // to perform unary, client streaming, server streaming and full duplex RPCs.
 //
-// It implements the route guide service whose definition can be found in proto/route_guide.proto.
+// It implements the route guide service whose definition can be found in routeguide/route_guide.proto.
 package main
 
 import (


### PR DESCRIPTION
route_guide.proto used to be in a directory called proto. It was renamed
to routeguide but the code/README still referred to the previous
directory name.