### PR TITLE
add MaxConcurrentStreams to benchmark_test when start the server

### DIFF
--- a/benchmark/benchmark_test.go
+++ b/benchmark/benchmark_test.go
@@ -16,7 +16,7 @@ import (
 func runUnary(b *testing.B, maxConcurrentCalls int) {
 	s := stats.AddStats(b, 38)
 	b.StopTimer()
-	target, stopper := StartServer(ServerInfo{Addr: "localhost:0", Type: "protobuf"})
+	target, stopper := StartServer(ServerInfo{Addr: "localhost:0", Type: "protobuf"}, grpc.MaxConcurrentStreams(uint32(maxConcurrentCalls+1)))
 	defer stopper()
 	conn := NewClientConn(target, grpc.WithInsecure())
 	tc := testpb.NewBenchmarkServiceClient(conn)
@@ -59,7 +59,7 @@ func runUnary(b *testing.B, maxConcurrentCalls int) {
 func runStream(b *testing.B, maxConcurrentCalls int) {
 	s := stats.AddStats(b, 38)
 	b.StopTimer()
-	target, stopper := StartServer(ServerInfo{Addr: "localhost:0", Type: "protobuf"})
+	target, stopper := StartServer(ServerInfo{Addr: "localhost:0", Type: "protobuf"}, grpc.MaxConcurrentStreams(uint32(maxConcurrentCalls+1)))
 	defer stopper()
 	conn := NewClientConn(target, grpc.WithInsecure())
 	tc := testpb.NewBenchmarkServiceClient(conn)


### PR DESCRIPTION
the default setting of MaxConcurrentStreams is 100