### PR TITLE
Piggyback window updates for connection with those of a stream.

### DIFF
--- a/transport/control.go
+++ b/transport/control.go
@@ -68,6 +68,7 @@ const (
 type windowUpdate struct {
 	streamID  uint32
 	increment uint32
+	flush     bool
 }
 
 func (*windowUpdate) item() {}
@@ -239,4 +240,12 @@ func (f *inFlow) onRead(n uint32) uint32 {
 		return wu
 	}
 	return 0
+}
+
+func (f *inFlow) resetPendingUpdate() uint32 {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	n := f.pendingUpdate
+	f.pendingUpdate = 0
+	return n
 }


### PR DESCRIPTION
This is the last PR to further optimize for the benchmark simulating high latency networks and sending large messages. 

Note the original benchmark was flawed and has been revamped by @dfawley,

The final results are as follows:
```
Duration	Latency	Proto

6.970243ms	0s	GRPC
3.980085ms	0s	GRPC
4.13913ms	0s	GRPC
5.070389ms	0s	GRPC
3.96764ms	0s	GRPC
4.835682ms	0s	GRPC
5.500948ms	0s	GRPC
3.576878ms	0s	GRPC
4.252281ms	0s	GRPC
4.523893ms	0s	GRPC

17.831435ms	0s	HTTP/2.0
8.868534ms	0s	HTTP/2.0
8.8657ms	0s	HTTP/2.0
8.948182ms	0s	HTTP/2.0
7.335248ms	0s	HTTP/2.0
8.527652ms	0s	HTTP/2.0
8.085997ms	0s	HTTP/2.0
5.296444ms	0s	HTTP/2.0
7.930056ms	0s	HTTP/2.0
7.835599ms	0s	HTTP/2.0

16.513759ms	0s	HTTP/1.1
5.388497ms	0s	HTTP/1.1
6.687598ms	0s	HTTP/1.1
4.95173ms	0s	HTTP/1.1
4.838996ms	0s	HTTP/1.1
4.62064ms	0s	HTTP/1.1
6.379458ms	0s	HTTP/1.1
8.044864ms	0s	HTTP/1.1
5.949003ms	0s	HTTP/1.1
5.713183ms	0s	HTTP/1.1

11.169466ms	1ms	GRPC
10.854233ms	1ms	GRPC
7.905415ms	1ms	GRPC
8.654428ms	1ms	GRPC
8.608184ms	1ms	GRPC
7.830971ms	1ms	GRPC
8.009571ms	1ms	GRPC
8.935793ms	1ms	GRPC
7.821164ms	1ms	GRPC
10.615977ms	1ms	GRPC

58.29608ms	1ms	HTTP/2.0
44.29841ms	1ms	HTTP/2.0
44.264714ms	1ms	HTTP/2.0
44.379905ms	1ms	HTTP/2.0
44.110538ms	1ms	HTTP/2.0
42.722417ms	1ms	HTTP/2.0
40.261599ms	1ms	HTTP/2.0
42.0521ms	1ms	HTTP/2.0
42.686388ms	1ms	HTTP/2.0
44.531175ms	1ms	HTTP/2.0

20.788581ms	1ms	HTTP/1.1
6.963281ms	1ms	HTTP/1.1
8.530872ms	1ms	HTTP/1.1
7.912604ms	1ms	HTTP/1.1
9.299969ms	1ms	HTTP/1.1
7.583451ms	1ms	HTTP/1.1
7.197631ms	1ms	HTTP/1.1
7.965996ms	1ms	HTTP/1.1
8.146534ms	1ms	HTTP/1.1
8.150496ms	1ms	HTTP/1.1

14.370394ms	2ms	GRPC
11.812849ms	2ms	GRPC
12.297475ms	2ms	GRPC
13.34732ms	2ms	GRPC
12.316417ms	2ms	GRPC
11.495877ms	2ms	GRPC
12.897088ms	2ms	GRPC
12.59843ms	2ms	GRPC
13.181034ms	2ms	GRPC
12.84044ms	2ms	GRPC

94.399021ms	2ms	HTTP/2.0
79.117848ms	2ms	HTTP/2.0
78.307261ms	2ms	HTTP/2.0
79.361994ms	2ms	HTTP/2.0
78.943724ms	2ms	HTTP/2.0
78.506371ms	2ms	HTTP/2.0
78.842409ms	2ms	HTTP/2.0
79.170135ms	2ms	HTTP/2.0
78.543943ms	2ms	HTTP/2.0
78.373198ms	2ms	HTTP/2.0

22.807171ms	2ms	HTTP/1.1
7.900001ms	2ms	HTTP/1.1
8.413026ms	2ms	HTTP/1.1
9.711428ms	2ms	HTTP/1.1
9.775413ms	2ms	HTTP/1.1
8.003013ms	2ms	HTTP/1.1
7.878325ms	2ms	HTTP/1.1
9.988794ms	2ms	HTTP/1.1
7.086477ms	2ms	HTTP/1.1
7.927105ms	2ms	HTTP/1.1

21.001523ms	4ms	GRPC
20.397333ms	4ms	GRPC
21.37676ms	4ms	GRPC
20.22268ms	4ms	GRPC
20.288201ms	4ms	GRPC
20.985775ms	4ms	GRPC
21.277375ms	4ms	GRPC
19.990096ms	4ms	GRPC
20.155883ms	4ms	GRPC
19.751315ms	4ms	GRPC

164.786843ms	4ms	HTTP/2.0
146.280596ms	4ms	HTTP/2.0
148.42875ms	4ms	HTTP/2.0
144.679942ms	4ms	HTTP/2.0
145.789418ms	4ms	HTTP/2.0
147.949289ms	4ms	HTTP/2.0
146.51401ms	4ms	HTTP/2.0
147.386475ms	4ms	HTTP/2.0
147.219971ms	4ms	HTTP/2.0
146.376951ms	4ms	HTTP/2.0

38.606286ms	4ms	HTTP/1.1
13.095184ms	4ms	HTTP/1.1
13.065377ms	4ms	HTTP/1.1
13.635383ms	4ms	HTTP/1.1
12.996189ms	4ms	HTTP/1.1
13.708211ms	4ms	HTTP/1.1
12.303027ms	4ms	HTTP/1.1
14.386758ms	4ms	HTTP/1.1
13.261425ms	4ms	HTTP/1.1
11.995957ms	4ms	HTTP/1.1

36.78468ms	8ms	GRPC
36.282676ms	8ms	GRPC
35.492943ms	8ms	GRPC
37.131146ms	8ms	GRPC
36.521753ms	8ms	GRPC
37.038396ms	8ms	GRPC
35.74651ms	8ms	GRPC
35.519377ms	8ms	GRPC
37.104457ms	8ms	GRPC
35.734118ms	8ms	GRPC

325.973183ms	8ms	HTTP/2.0
283.653566ms	8ms	HTTP/2.0
283.151133ms	8ms	HTTP/2.0
282.973404ms	8ms	HTTP/2.0
282.867811ms	8ms	HTTP/2.0
283.669824ms	8ms	HTTP/2.0
282.674297ms	8ms	HTTP/2.0
283.425501ms	8ms	HTTP/2.0
283.95995ms	8ms	HTTP/2.0
283.729268ms	8ms	HTTP/2.0

62.040886ms	8ms	HTTP/1.1
22.174809ms	8ms	HTTP/1.1
20.659981ms	8ms	HTTP/1.1
21.347898ms	8ms	HTTP/1.1
22.354339ms	8ms	HTTP/1.1
19.902329ms	8ms	HTTP/1.1
21.200045ms	8ms	HTTP/1.1
21.734057ms	8ms	HTTP/1.1
19.676888ms	8ms	HTTP/1.1
21.022207ms	8ms	HTTP/1.1

69.328981ms	16ms	GRPC
69.562021ms	16ms	GRPC
68.584663ms	16ms	GRPC
69.252731ms	16ms	GRPC
68.450873ms	16ms	GRPC
69.165019ms	16ms	GRPC
68.346954ms	16ms	GRPC
67.871117ms	16ms	GRPC
70.145732ms	16ms	GRPC
70.872842ms	16ms	GRPC

621.522343ms	16ms	HTTP/2.0
556.583812ms	16ms	HTTP/2.0
555.544457ms	16ms	HTTP/2.0
557.404551ms	16ms	HTTP/2.0
555.906423ms	16ms	HTTP/2.0
555.929609ms	16ms	HTTP/2.0
556.343605ms	16ms	HTTP/2.0
555.649825ms	16ms	HTTP/2.0
556.789024ms	16ms	HTTP/2.0
557.110025ms	16ms	HTTP/2.0

112.217268ms	16ms	HTTP/1.1
37.909543ms	16ms	HTTP/1.1
37.346142ms	16ms	HTTP/1.1
37.62759ms	16ms	HTTP/1.1
38.593377ms	16ms	HTTP/1.1
38.959139ms	16ms	HTTP/1.1
36.252935ms	16ms	HTTP/1.1
36.80854ms	16ms	HTTP/1.1
37.615802ms	16ms	HTTP/1.1
37.359077ms	16ms	HTTP/1.1

133.679053ms	32ms	GRPC
134.2433ms	32ms	GRPC
133.258643ms	32ms	GRPC
133.00991ms	32ms	GRPC
132.720031ms	32ms	GRPC
134.578616ms	32ms	GRPC
132.307002ms	32ms	GRPC
132.514131ms	32ms	GRPC
132.667252ms	32ms	GRPC
132.533422ms	32ms	GRPC

1.237566409s	32ms	HTTP/2.0
1.100759888s	32ms	HTTP/2.0
1.100117609s	32ms	HTTP/2.0
1.09927653s	32ms	HTTP/2.0
1.100530355s	32ms	HTTP/2.0
1.100151009s	32ms	HTTP/2.0
1.100200907s	32ms	HTTP/2.0
1.100131684s	32ms	HTTP/2.0
1.099822057s	32ms	HTTP/2.0
1.100399981s	32ms	HTTP/2.0

210.658669ms	32ms	HTTP/1.1
70.058873ms	32ms	HTTP/1.1
69.518784ms	32ms	HTTP/1.1
70.297075ms	32ms	HTTP/1.1
68.170349ms	32ms	HTTP/1.1
69.634717ms	32ms	HTTP/1.1
69.710199ms	32ms	HTTP/1.1
71.644759ms	32ms	HTTP/1.1
69.905791ms	32ms	HTTP/1.1
70.209922ms	32ms	HTTP/1.1
```
A 76ms latency is chosen because it's comparable to a cross-continental connection.

```
313.083006ms	76ms	GRPC
310.458774ms	76ms	GRPC
309.142808ms	76ms	GRPC
308.943029ms	76ms	GRPC
308.673995ms	76ms	GRPC
309.993817ms	76ms	GRPC
309.354419ms	76ms	GRPC
309.380968ms	76ms	GRPC
307.946691ms	76ms	GRPC
309.661613ms	76ms	GRPC

2.906895722s	76ms	HTTP/2.0
2.597743122s	76ms	HTTP/2.0
2.597922795s	76ms	HTTP/2.0
2.597135865s	76ms	HTTP/2.0
2.597287595s	76ms	HTTP/2.0
2.597098329s	76ms	HTTP/2.0
2.597460937s	76ms	HTTP/2.0
2.597740973s	76ms	HTTP/2.0
2.597485081s	76ms	HTTP/2.0
2.597201971s	76ms	HTTP/2.0

473.870352ms	76ms	HTTP/1.1
158.867963ms	76ms	HTTP/1.1
159.00574ms	76ms	HTTP/1.1
158.582681ms	76ms	HTTP/1.1
157.048679ms	76ms	HTTP/1.1
158.84794ms	76ms	HTTP/1.1
158.140147ms	76ms	HTTP/1.1
158.17494ms	76ms	HTTP/1.1
158.168168ms	76ms	HTTP/1.1
158.604137ms	76ms	HTTP/1.1

```

fixes: #1043 