### PR TITLE
Deflake TestFlowContolLogicalRace

### DIFF
--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -4135,7 +4135,7 @@ func TestFlowControlLogicalRace(t *testing.T) {
 		recvCount   = 2
 		maxFailures = 3
 
-		requestTimeout = time.Second
+		requestTimeout = time.Second * 5
 	)
 
 	requestCount := 10000


### PR DESCRIPTION
Parital fix for #1255. However, we still need to figure out why the 1 second wasn't enough.