### PR TITLE
Return header in Stream.Header() if available

### DIFF
--- a/transport/transport.go
+++ b/transport/transport.go
@@ -252,20 +252,22 @@ func (s *Stream) GoAway() <-chan struct{} {
 // is available. It blocks until i) the metadata is ready or ii) there is no
 // header metadata or iii) the stream is canceled/expired.
 func (s *Stream) Header() (metadata.MD, error) {
+	var err error
 	select {
 	case <-s.ctx.Done():
-		// Even if the stream is closed, header is returned if available.
-		select {
-		case <-s.headerChan:
-			return s.header.Copy(), nil
-		default:
-			return nil, ContextErr(s.ctx.Err())
-		}
+		err = ContextErr(s.ctx.Err())
 	case <-s.goAway:
-		return nil, ErrStreamDrain
+		err = ErrStreamDrain
 	case <-s.headerChan:
 		return s.header.Copy(), nil
 	}
+	// Even if the stream is closed, header is returned if available.
+	select {
+	case <-s.headerChan:
+		return s.header.Copy(), nil
+	default:
+	}
+	return nil, err
 }
 
 // Trailer returns the cached trailer metedata. Note that if it is not called


### PR DESCRIPTION
Add additional nonblocking select clause that would
check if the header is available and return it if it is.

Current implementation of transport.go Stream Header often
doesn't return header, but a cancel error even though
the top level context is not canceled and the rpc
is successful and a header is actually available.
It's caused by the fact that select can choose any
"ready" channel.
Retrieving headers is flaky. With this fix, headers
are consistently retrieved for successful rpcs.