### PR TITLE
fixup #1258: differ 1.6 from others

### DIFF
--- a/transport/go16.go
+++ b/transport/go16.go
@@ -1,4 +1,4 @@
-// +build go1.6,!go1.7
+// +build go1.6
 
 /*
  * Copyright 2016, Google Inc.

--- a/transport/not_go16.go
+++ b/transport/not_go16.go
@@ -1,4 +1,4 @@
-// +build go1.7
+// +build !go1.6
 
 /*
  * Copyright 2016, Google Inc.


### PR DESCRIPTION
go1.7 introduces `context`, so I think `go1.8/go1.9/...` should follow `go1.7`.