### PR TITLE
Make Apache 2.0 LICENSE file a verbatim copy

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2015-2017 gRPC authors.
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
For consistency with our other repos (e.g. https://github.com/grpc/grpc/pull/11527) and automated check purposes, LICENSE (but not the headers in files) is preferably an exact match of Apache 2.0 (without specialization).