### PR TITLE
Don't check maxReceiveMessageSize twice

### DIFF
--- a/rpc_util.go
+++ b/rpc_util.go
@@ -374,11 +374,6 @@ func recv(p *parser, c Codec, s *transport.Stream, dc Decompressor, m interface{
 			return Errorf(codes.Internal, "grpc: failed to decompress the received message %v", err)
 		}
 	}
-	if len(d) > maxReceiveMessageSize {
-		// TODO: Revisit the error code. Currently keep it consistent with java
-		// implementation.
-		return Errorf(codes.ResourceExhausted, "grpc: received message larger than max (%d vs. %d)", len(d), maxReceiveMessageSize)
-	}
 	if err := c.Unmarshal(d, m); err != nil {
 		return Errorf(codes.Internal, "grpc: failed to unmarshal the received message %v", err)
 	}


### PR DESCRIPTION
The message length is checked twice, once before decompression in
recvMsg, then again after decompression in recv. Remove the check after
decompression to be consistent with the server behavior where then
length of a message is only checked after compression.