### PR TITLE
benchmark: Travis can compare the performance of benchmark between current commit and the base commit of this pull request.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,3 +18,4 @@ script:
   - 'if [[ $TRAVIS_GO_VERSION = 1.8* ]]; then ! go tool vet -all . 2>&1 | grep -vF .pb.go:; fi' # https://github.com/golang/protobuf/issues/214
   - make test testrace
   - 'if [[ $TRAVIS_GO_VERSION = 1.8* ]]; then staticcheck -ignore google.golang.org/grpc/transport/transport_test.go:SA2002 ./...; fi' # TODO(menghanl): fix these
+  - 'if [[ $TRAVIS_GO_VERSION = 1.8* ]]; then ./benchmark/compare/compare_travis.sh || true; fi'

--- a/benchmark/benchmark.go
+++ b/benchmark/benchmark.go
@@ -230,8 +230,12 @@ func NewClientConn(addr string, opts ...grpc.DialOption) *grpc.ClientConn {
 	return conn
 }
 
-func runUnary(b *testing.B, maxConcurrentCalls, reqSize, respSize, kbps, mtu int, ltc time.Duration) {
-	s := stats.AddStats(b, 38)
+func runUnary(b *testing.B, s *stats.Stats, maxConcurrentCalls, reqSize, respSize, kbps, mtu int, ltc time.Duration) {
+	if s == nil {
+		s = stats.AddStats(b, 38)
+	}
+	s.Clear()
+	b.ResetTimer()
 	nw := &latency.Network{Kbps: kbps, Latency: ltc, MTU: mtu}
 	b.StopTimer()
 	target, stopper := StartServer(ServerInfo{Addr: "localhost:0", Type: "protobuf", Network: nw}, grpc.MaxConcurrentStreams(uint32(maxConcurrentCalls+1)))
@@ -279,8 +283,11 @@ func runUnary(b *testing.B, maxConcurrentCalls, reqSize, respSize, kbps, mtu int
 	conn.Close()
 }
 
-func runStream(b *testing.B, maxConcurrentCalls, reqSize, respSize, kbps, mtu int, ltc time.Duration) {
-	s := stats.AddStats(b, 38)
+func runStream(b *testing.B, s *stats.Stats, maxConcurrentCalls, reqSize, respSize, kbps, mtu int, ltc time.Duration) {
+	//fmt.Println(s)
+	if s == nil {
+		s = stats.AddStats(b, 38)
+	}
 	nw := &latency.Network{Kbps: kbps, Latency: ltc, MTU: mtu}
 	b.StopTimer()
 	target, stopper := StartServer(ServerInfo{Addr: "localhost:0", Type: "protobuf", Network: nw}, grpc.MaxConcurrentStreams(uint32(maxConcurrentCalls+1)))

--- a/benchmark/benchmark16_test.go
+++ b/benchmark/benchmark16_test.go
@@ -30,80 +30,80 @@ import (
 
 func BenchmarkClientStreamc1(b *testing.B) {
 	grpc.EnableTracing = true
-	runStream(b, 1, 1, 1, 0, 0, 0)
+	runStream(b, nil, 1, 1, 1, 0, 0, 0)
 }
 
 func BenchmarkClientStreamc8(b *testing.B) {
 	grpc.EnableTracing = true
-	runStream(b, 8, 1, 1, 0, 0, 0)
+	runStream(b, nil, 8, 1, 1, 0, 0, 0)
 }
 
 func BenchmarkClientStreamc64(b *testing.B) {
 	grpc.EnableTracing = true
-	runStream(b, 64, 1, 1, 0, 0, 0)
+	runStream(b, nil, 64, 1, 1, 0, 0, 0)
 }
 
 func BenchmarkClientStreamc512(b *testing.B) {
 	grpc.EnableTracing = true
-	runStream(b, 512, 1, 1, 0, 0, 0)
+	runStream(b, nil, 512, 1, 1, 0, 0, 0)
 }
 func BenchmarkClientUnaryc1(b *testing.B) {
 	grpc.EnableTracing = true
-	runUnary(b, 1, 1, 1, 0, 0, 0)
+	runUnary(b, nil, 1, 1, 1, 0, 0, 0)
 }
 
 func BenchmarkClientUnaryc8(b *testing.B) {
 	grpc.EnableTracing = true
-	runUnary(b, 8, 1, 1, 0, 0, 0)
+	runUnary(b, nil, 8, 1, 1, 0, 0, 0)
 }
 
 func BenchmarkClientUnaryc64(b *testing.B) {
 	grpc.EnableTracing = true
-	runUnary(b, 64, 1, 1, 0, 0, 0)
+	runUnary(b, nil, 64, 1, 1, 0, 0, 0)
 }
 
 func BenchmarkClientUnaryc512(b *testing.B) {
 	grpc.EnableTracing = true
-	runUnary(b, 512, 1, 1, 0, 0, 0)
+	runUnary(b, nil, 512, 1, 1, 0, 0, 0)
 }
 
 func BenchmarkClientStreamNoTracec1(b *testing.B) {
 	grpc.EnableTracing = false
-	runStream(b, 1, 1, 1, 0, 0, 0)
+	runStream(b, nil, 1, 1, 1, 0, 0, 0)
 }
 
 func BenchmarkClientStreamNoTracec8(b *testing.B) {
 	grpc.EnableTracing = false
-	runStream(b, 8, 1, 1, 0, 0, 0)
+	runStream(b, nil, 8, 1, 1, 0, 0, 0)
 }
 
 func BenchmarkClientStreamNoTracec64(b *testing.B) {
 	grpc.EnableTracing = false
-	runStream(b, 64, 1, 1, 0, 0, 0)
+	runStream(b, nil, 64, 1, 1, 0, 0, 0)
 }
 
 func BenchmarkClientStreamNoTracec512(b *testing.B) {
 	grpc.EnableTracing = false
-	runStream(b, 512, 1, 1, 0, 0, 0)
+	runStream(b, nil, 512, 1, 1, 0, 0, 0)
 }
 func BenchmarkClientUnaryNoTracec1(b *testing.B) {
 	grpc.EnableTracing = false
-	runUnary(b, 1, 1, 1, 0, 0, 0)
+	runUnary(b, nil, 1, 1, 1, 0, 0, 0)
 }
 
 func BenchmarkClientUnaryNoTracec8(b *testing.B) {
 	grpc.EnableTracing = false
-	runUnary(b, 8, 1, 1, 0, 0, 0)
+	runUnary(b, nil, 8, 1, 1, 0, 0, 0)
 }
 
 func BenchmarkClientUnaryNoTracec64(b *testing.B) {
 	grpc.EnableTracing = false
-	runUnary(b, 64, 1, 1, 0, 0, 0)
+	runUnary(b, nil, 64, 1, 1, 0, 0, 0)
 }
 
 func BenchmarkClientUnaryNoTracec512(b *testing.B) {
 	grpc.EnableTracing = false
-	runUnary(b, 512, 1, 1, 0, 0, 0)
+	runUnary(b, nil, 512, 1, 1, 0, 0, 0)
 }
 
 func TestMain(m *testing.M) {

--- a/benchmark/compare/compare_travis.sh
+++ b/benchmark/compare/compare_travis.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+echo $TRAVIS_GO_VERSION
+echo $TRAVIS_COMMIT_RANGE
+IFS='...' read -r -a commits <<< "$TRAVIS_COMMIT_RANGE"
+echo "base commit number:"
+echo ${commits[0]}
+echo "current commit number:"
+echo ${commits[-1]}
+
+if [ -d "benchmark/compare" ]; then
+  echo "dir benchmark/compare exist"
+  go get -d -v -t google.golang.org/grpc/...
+
+  cp -r benchmark tmpbenchmark
+
+  go test google.golang.org/grpc/benchmark/... -benchmem -bench=BenchmarkClient/Tracing-kbps_0-MTU_0-maxConcurrentCalls_1 | tee result1
+  ls benchmark/compare/
+  git reset --hard ${commits[0]}
+  ls benchmark/compare/
+  if [ -e "benchmark/compare/main.go" ]; then
+    echo "after reset: dir benchmark/compare exist"
+  else
+    rm -r benchmark
+    mv tmpbenchmark benchmark
+  fi
+  go test google.golang.org/grpc/benchmark/... -benchmem -bench=BenchmarkClient/Tracing-kbps_0-MTU_0-maxConcurrentCalls_1 | tee result2
+  go run benchmark/compare/main.go result1 result2
+fi

--- a/benchmark/compare/main.go
+++ b/benchmark/compare/main.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+func parser(s string) []string {
+	start, end := 0, 0
+	leng := len(s)
+	var result []string
+	for end < leng {
+		for end < leng && (s[end] == ' ' || s[end] == '\t') {
+			end++
+		}
+		start = end
+		for end < leng && s[end] != ' ' && s[end] != '\t' {
+			end++
+		}
+		tmp := s[start:end]
+		start = end
+		result = append(result, tmp)
+	}
+	return result
+}
+
+func createMap(fileName string, m map[string][]string) {
+	f, err := os.Open(fileName)
+	if err != nil {
+		fmt.Println("read file err")
+	}
+	buf := bufio.NewReader(f)
+	var part1, part2 []string = nil, nil
+
+	for {
+		line, err := buf.ReadString('\n')
+		if err != nil {
+			break
+		}
+		line = strings.TrimSpace(line)
+		parserLine := parser(line)
+
+		if strings.HasPrefix(line, "Benchmark") {
+			if part2 != nil {
+				part1 = append(part1, part2...)
+				m[part1[0]] = part1[1:]
+				part1 = nil
+				part2 = nil
+			}
+			part1 = parserLine
+		} else if strings.HasPrefix(line, "Latency") {
+			part1 = append(part1, parserLine[3])
+		} else if strings.Contains(line, "|") {
+			part2 = append(part2, parserLine[1], parserLine[3])
+		}
+	}
+	if part2 != nil {
+		part1 = append(part1, part2...)
+		m[part1[0]] = part1[1:]
+	}
+}
+
+func combineString(title, val1, val2, percentChange string) string {
+	return fmt.Sprintf("%10s  %12s  %12s   %8s \n", title, val1, val2, percentChange)
+}
+
+func compareTwoMap(m1, m2 map[string][]string) {
+	unit2num := make(map[string]float64)
+	unit2num["s"] = 1000000000
+	unit2num["ms"] = 1000000
+	unit2num["µs"] = 1000
+	for k2, v2 := range m2 {
+		if v1, ok := m1[k2]; ok {
+			changes := combineString("\nTitle", "\tBefore", "After", "\tPercentage")
+			var factor float64 = 1
+			for i := 0; i < 18; i++ {
+				if i == 6 {
+					factor = unit2num[v1[7]] / unit2num[v2[7]]
+				}
+				num1, err := strconv.ParseFloat(v1[i], 64)
+				if err != nil {
+					continue
+				}
+				num2, err := strconv.ParseFloat(v2[i], 64)
+				percentChange := strconv.FormatFloat((num2-num1*factor)*100.0/(num1*factor), 'f', 2, 64) + "% "
+
+				switch {
+				case i == 0:
+					changes = changes + combineString("operations", v1[i], v2[i], "")
+				case i >= 1 && i <= 7:
+					changes = changes + combineString(v1[i+1], v1[i], v2[i], percentChange)
+				case i > 7:
+					changes = changes + combineString(v1[i-1], v1[i]+v1[7], v2[i]+v2[7], percentChange)
+				}
+			}
+			fmt.Printf("%s, %s\n", k2, changes)
+		}
+	}
+}
+
+func main() {
+	file1 := os.Args[1]
+	file2 := os.Args[2]
+
+	var BenchValueFile1 map[string][]string
+	var BenchValueFile2 map[string][]string
+	BenchValueFile1 = make(map[string][]string)
+	BenchValueFile2 = make(map[string][]string)
+
+	createMap(file1, BenchValueFile1)
+	createMap(file2, BenchValueFile2)
+
+	compareTwoMap(BenchValueFile1, BenchValueFile2)
+}

--- a/benchmark/stats/util.go
+++ b/benchmark/stats/util.go
@@ -68,7 +68,7 @@ func AddStatsWithName(b *testing.B, name string, numBuckets int) *Stats {
 		}
 		p := strings.Split(runtime.FuncForPC(pc).Name(), ".")
 		benchName = p[len(p)-1]
-		if strings.HasPrefix(benchName, "run") {
+		if strings.HasPrefix(benchName, "Benchmark") {
 			break
 		}
 	}
@@ -167,10 +167,9 @@ func injectStatsIfFinished(line string) {
 	injectCond.L.Lock()
 	defer injectCond.L.Unlock()
 	// We assume that the benchmark results start with "Benchmark".
-	if curB == nil || !strings.HasPrefix(line, "Benchmark") {
+	if curB == nil || !strings.HasPrefix(line, curBenchName) {
 		return
 	}
-
 	if !curB.Failed() {
 		// Output all stats in alphabetical order.
 		names := make([]string, 0, len(curStats))


### PR DESCRIPTION
1. Adding a file compare/main.go to compare the result of 2 benchmarks, thus the comparison can run locally.

2. Comparison in travis only runs in Go 1.8 version. You can open the travis of this pr. At the end of log, it prints result like
```
BenchmarkClient/Unary-Tracing-kbps_0-MTU_0-maxConcurrentCalls_1-reqSize_1048576B-respSize_1048576B-latency_40ms-2,     
Title       	Before         After   	Percentage 
operations           100           100            
     ns/op     239422160     239915920     0.21%  
      B/op      14594751      14299738    -2.02%  
 allocs/op          1936          1940     0.21%  
       50%    251.7915ms    251.9019ms     0.04%  
       90%    253.6508ms    255.2256ms     0.62%  
       99%    256.9438ms    259.5959ms     1.03%  
      100%    257.8455ms    261.3009ms     1.34%  
   Average    252.0007ms    252.4980ms     0.20%  
```