### PR TITLE
Fix mutex deadlock of roundrobin balancer

### DIFF
--- a/balancer.go
+++ b/balancer.go
@@ -201,6 +201,10 @@ func (rr *roundRobin) watchAddrUpdates() error {
 	if rr.done {
 		return ErrClientConnClosing
 	}
+	select {
+	case <-rr.addrCh:
+	default:
+	}
 	rr.addrCh <- open
 	return nil
 }
@@ -223,7 +227,7 @@ func (rr *roundRobin) Start(target string, config BalancerConfig) error {
 		return err
 	}
 	rr.w = w
-	rr.addrCh = make(chan []Address)
+	rr.addrCh = make(chan []Address, 1)
 	go func() {
 		for {
 			if err := rr.watchAddrUpdates(); err != nil {


### PR DESCRIPTION
### When it occurs?

1. roundrobin: watchAddrUpdates adds a new addrs list to addCh (some addrs have been deleted from the previous list)
2. clientconn: lbWatcher calls tearDown to close the addrConn
3. clientconn: tearDown calls ac.down to notify the balancer that the connection has been closed
4. deadlock (we are making a lock from the first step and all steps are synchronous)