### PR TITLE
Prevent resetAddrConn from re-adding addConn after being deleted by balancer

### DIFF
--- a/clientconn.go
+++ b/clientconn.go
@@ -594,7 +594,10 @@ func (cc *ClientConn) resetAddrConn(addr Address, block bool, tearDownErr error)
 		return ErrClientConnClosing
 	}
 	stale := cc.conns[ac.addr]
-	cc.conns[ac.addr] = ac
+	keep := tearDownErr == nil || stale != nil
+	if keep {
+		cc.conns[ac.addr] = ac
+	}
 	cc.mu.Unlock()
 	if stale != nil {
 		// There is an addrConn alive on ac.addr already. This could be due to
@@ -611,6 +614,10 @@ func (cc *ClientConn) resetAddrConn(addr Address, block bool, tearDownErr error)
 		} else {
 			stale.tearDown(tearDownErr)
 		}
+	}
+	if !keep {
+		ac.tearDown(tearDownErr)
+		return nil
 	}
 	if block {
 		if err := ac.resetTransport(false); err != nil {


### PR DESCRIPTION
Currently an addrConn is being added to the cc.conns without checking whether the address still exists in balancing targets list.
In some cases, for example, the client receives a goaway frame immediately after the addrConn has been deleted from the cc.conns list but before the tearDown of addrConn.
This causes a new addrConn will be added and an endless resetTransport loop begins.

This is easy to happen while shutting down multiple servers. The following loop will take enough time for some goaway frames to come.
https://github.com/grpc/grpc-go/blob/master/clientconn.go#L535