### PR TITLE
Populate callInfo.peer object for streaming RPCs

### DIFF
--- a/stream.go
+++ b/stream.go
@@ -29,6 +29,7 @@ import (
 	"golang.org/x/net/trace"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/stats"
 	"google.golang.org/grpc/status"
 	"google.golang.org/grpc/transport"
@@ -220,6 +221,10 @@ func newClientStream(ctx context.Context, desc *StreamDesc, cc *ClientConn, meth
 			return nil, toRPCErr(err)
 		}
 		break
+	}
+	// Set callInfo.peer object from stream's context.
+	if peer, ok := peer.FromContext(s.Context()); ok {
+		c.peer = peer
 	}
 	cs := &clientStream{
 		opts:   opts,


### PR DESCRIPTION
This PR populates the `callInfo.peer` object in case of streaming RPCs similarly to what is done for [non-streaming RPCs](https://github.com/grpc/grpc-go/blob/41d9b6ea2a6335f3a22074ed35c0542c9da1baf4/call.go#L77).

Testing:
- `make`: all tests pass.