### PR TITLE
Avoid unnecessary flushing during unary response processing

### DIFF
--- a/server.go
+++ b/server.go
@@ -800,7 +800,7 @@ func (s *Server) processUnaryRPC(t transport.ServerTransport, stream *transport.
 	}
 	opts := &transport.Options{
 		Last:  true,
-		Delay: false,
+		Delay: true,
 	}
 	if err := s.sendResponse(t, stream, reply, s.opts.cp, opts); err != nil {
 		if err == io.EOF {

--- a/transport/transport_test.go
+++ b/transport/transport_test.go
@@ -162,7 +162,7 @@ func (h *testStreamHandler) handleStreamInvalidHeaderField(t *testing.T, s *Stre
 	<-h.t.writableChan
 	h.t.hBuf.Reset()
 	h.t.hEnc.WriteField(hpack.HeaderField{Name: "content-type", Value: expectedInvalidHeaderField})
-	if err := h.t.writeHeaders(s, h.t.hBuf, false); err != nil {
+	if err := h.t.writeHeaders(s, h.t.hBuf, false, true); err != nil {
 		t.Fatalf("Failed to write headers: %v", err)
 	}
 	h.t.writableChan <- 0


### PR DESCRIPTION
This reduces the number of packets sent when responding to a unary RPC
from 3 to 1. This reduction in packets improves latency, presumably by
the lower syscall and packet overhead.

See #1256