### PR TITLE
Fix a typo in examples/gotutorial.md

### DIFF
--- a/examples/gotutorial.md
+++ b/examples/gotutorial.md
@@ -6,7 +6,7 @@ This tutorial provides a basic Go programmer's introduction to working with gRPC
 - Generate server and client code using the protocol buffer compiler.
 - Use the Go gRPC API to write a simple client and server for your service.
 
-It assumes that you have read the [Getting started](https://github.com/grpc/grpc/tree/master/examples) guide and are familiar with [protocol buffers] (https://developers.google.com/protocol-buffers/docs/overview). Note that the example in this tutorial uses the proto3 version of the protocol buffers language, which is currently in alpha release:you can find out more in the [proto3 language guide](https://developers.google.com/protocol-buffers/docs/proto3) and see the [release notes](https://github.com/google/protobuf/releases) for the new version in the protocol buffers Github repository.
+It assumes that you have read the [Getting started](https://github.com/grpc/grpc/tree/master/examples) guide and are familiar with [protocol buffers](https://developers.google.com/protocol-buffers/docs/overview). Note that the example in this tutorial uses the proto3 version of the protocol buffers language, which is currently in alpha release:you can find out more in the [proto3 language guide](https://developers.google.com/protocol-buffers/docs/proto3) and see the [release notes](https://github.com/google/protobuf/releases) for the new version in the protocol buffers Github repository.
 
 This isn't a comprehensive guide to using gRPC in Go: more reference documentation is coming soon.
 


### PR DESCRIPTION
Diff:
```diff
-[protocol buffers] (https://developers.google.com/protocol-buffers/docs/overview).
+[protocol buffers](https://developers.google.com/protocol-buffers/docs/overview).
``` 