### PR TITLE
stats: add methods to allow setting grpc-trace-bin and grpc-tags-bin headers

### DIFF
--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -44,6 +44,9 @@ type MD map[string][]string
 //  - lowercase letters: a-z
 //  - special characters: -_.
 // Uppercase letters are automatically converted to lowercase.
+//
+// Keys beginning with "grpc-" are reserved for grpc-internal use only and may
+// result in errors if set in metadata.
 func New(m map[string]string) MD {
 	md := MD{}
 	for k, val := range m {
@@ -62,6 +65,9 @@ func New(m map[string]string) MD {
 //  - lowercase letters: a-z
 //  - special characters: -_.
 // Uppercase letters are automatically converted to lowercase.
+//
+// Keys beginning with "grpc-" are reserved for grpc-internal use only and may
+// result in errors if set in metadata.
 func Pairs(kv ...string) MD {
 	if len(kv)%2 == 1 {
 		panic(fmt.Sprintf("metadata: Pairs got the odd number of input pairs for metadata: %d", len(kv)))

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -218,25 +218,31 @@ type outgoingTagsKey struct{}
 
 // SetTags attaches stats tagging data to the context, which will be sent in
 // the outgoing RPC with the header grpc-tags-bin.
+//
+// This is EXPERIMENTAL and will likely be removed in an upcoming release.
 func SetTags(ctx context.Context, b []byte) context.Context {
 	return context.WithValue(ctx, outgoingTagsKey{}, b)
 }
 
 // Tags returns the tags from the context for the inbound RPC.
+//
+// This is EXPERIMENTAL and will likely be removed in an upcoming release.
 func Tags(ctx context.Context) []byte {
 	b, _ := ctx.Value(incomingTagsKey{}).([]byte)
 	return b
 }
 
 // SetIncomingTags attaches stats tagging data to the context, to be read by
-// the application (not sent in outgoing RPCs).  It is intended for
-// gRPC-internal use.
+// the application (not sent in outgoing RPCs).
+//
+// This is intended for gRPC-internal use ONLY.
 func SetIncomingTags(ctx context.Context, b []byte) context.Context {
 	return context.WithValue(ctx, incomingTagsKey{}, b)
 }
 
-// OutgoingTags returns the tags from the context for the outbound RPC.  It is
-// intended for gRPC-internal use.
+// OutgoingTags returns the tags from the context for the outbound RPC.
+//
+// This is intended for gRPC-internal use ONLY.
 func OutgoingTags(ctx context.Context) []byte {
 	b, _ := ctx.Value(outgoingTagsKey{}).([]byte)
 	return b
@@ -247,11 +253,15 @@ type outgoingTraceKey struct{}
 
 // SetTrace attaches stats tagging data to the context, which will be sent in
 // the outgoing RPC with the header grpc-trace-bin.
+//
+// This is EXPERIMENTAL and will likely be removed in an upcoming release.
 func SetTrace(ctx context.Context, b []byte) context.Context {
 	return context.WithValue(ctx, outgoingTraceKey{}, b)
 }
 
 // Trace returns the trace from the context for the inbound RPC.
+//
+// This is EXPERIMENTAL and will likely be removed in an upcoming release.
 func Trace(ctx context.Context) []byte {
 	b, _ := ctx.Value(incomingTraceKey{}).([]byte)
 	return b

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -26,6 +26,8 @@ package stats // import "google.golang.org/grpc/stats"
 import (
 	"net"
 	"time"
+
+	"golang.org/x/net/context"
 )
 
 // RPCStats contains stats information about RPCs.
@@ -210,3 +212,61 @@ type ConnEnd struct {
 func (s *ConnEnd) IsClient() bool { return s.Client }
 
 func (s *ConnEnd) isConnStats() {}
+
+type incomingTagsKey struct{}
+type outgoingTagsKey struct{}
+
+// SetTags attaches stats tagging data to the context, which will be sent in
+// the outgoing RPC with the header grpc-tags-bin.
+func SetTags(ctx context.Context, b []byte) context.Context {
+	return context.WithValue(ctx, outgoingTagsKey{}, b)
+}
+
+// Tags returns the tags from the context for the inbound RPC.
+func Tags(ctx context.Context) []byte {
+	b, _ := ctx.Value(incomingTagsKey{}).([]byte)
+	return b
+}
+
+// SetIncomingTags attaches stats tagging data to the context, to be read by
+// the application (not sent in outgoing RPCs).  It is intended for
+// gRPC-internal use.
+func SetIncomingTags(ctx context.Context, b []byte) context.Context {
+	return context.WithValue(ctx, incomingTagsKey{}, b)
+}
+
+// OutgoingTags returns the tags from the context for the outbound RPC.  It is
+// intended for gRPC-internal use.
+func OutgoingTags(ctx context.Context) []byte {
+	b, _ := ctx.Value(outgoingTagsKey{}).([]byte)
+	return b
+}
+
+type incomingTraceKey struct{}
+type outgoingTraceKey struct{}
+
+// SetTrace attaches stats tagging data to the context, which will be sent in
+// the outgoing RPC with the header grpc-trace-bin.
+func SetTrace(ctx context.Context, b []byte) context.Context {
+	return context.WithValue(ctx, outgoingTraceKey{}, b)
+}
+
+// Trace returns the trace from the context for the inbound RPC.
+func Trace(ctx context.Context) []byte {
+	b, _ := ctx.Value(incomingTraceKey{}).([]byte)
+	return b
+}
+
+// SetIncomingTrace attaches stats tagging data to the context, to be read by
+// the application (not sent in outgoing RPCs).  It is intended for
+// gRPC-internal use.
+func SetIncomingTrace(ctx context.Context, b []byte) context.Context {
+	return context.WithValue(ctx, incomingTraceKey{}, b)
+}
+
+// OutgoingTrace returns the trace from the context for the outbound RPC.  It is
+// intended for gRPC-internal use.
+func OutgoingTrace(ctx context.Context) []byte {
+	b, _ := ctx.Value(outgoingTraceKey{}).([]byte)
+	return b
+}

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -217,11 +217,13 @@ type incomingTagsKey struct{}
 type outgoingTagsKey struct{}
 
 // SetTags attaches stats tagging data to the context, which will be sent in
-// the outgoing RPC with the header grpc-tags-bin.
+// the outgoing RPC with the header grpc-tags-bin.  Subsequent calls to
+// SetTags will overwrite the values from earlier calls.
 //
 // NOTE: this is provided only for backward compatibilty with existing clients
 // and will likely be removed in an upcoming release.  New uses should transmit
-// this type of data using metadata.
+// this type of data using metadata with a different, non-reserved (i.e. does
+// not begin with "grpc-") header name.
 func SetTags(ctx context.Context, b []byte) context.Context {
 	return context.WithValue(ctx, outgoingTagsKey{}, b)
 }
@@ -230,7 +232,8 @@ func SetTags(ctx context.Context, b []byte) context.Context {
 //
 // NOTE: this is provided only for backward compatibilty with existing clients
 // and will likely be removed in an upcoming release.  New uses should transmit
-// this type of data using metadata.
+// this type of data using metadata with a different, non-reserved (i.e. does
+// not begin with "grpc-") header name.
 func Tags(ctx context.Context) []byte {
 	b, _ := ctx.Value(incomingTagsKey{}).([]byte)
 	return b
@@ -256,11 +259,13 @@ type incomingTraceKey struct{}
 type outgoingTraceKey struct{}
 
 // SetTrace attaches stats tagging data to the context, which will be sent in
-// the outgoing RPC with the header grpc-trace-bin.
+// the outgoing RPC with the header grpc-trace-bin.  Subsequent calls to
+// SetTrace will overwrite the values from earlier calls.
 //
 // NOTE: this is provided only for backward compatibilty with existing clients
 // and will likely be removed in an upcoming release.  New uses should transmit
-// this type of data using metadata.
+// this type of data using metadata with a different, non-reserved (i.e. does
+// not begin with "grpc-") header name.
 func SetTrace(ctx context.Context, b []byte) context.Context {
 	return context.WithValue(ctx, outgoingTraceKey{}, b)
 }
@@ -269,7 +274,8 @@ func SetTrace(ctx context.Context, b []byte) context.Context {
 //
 // NOTE: this is provided only for backward compatibilty with existing clients
 // and will likely be removed in an upcoming release.  New uses should transmit
-// this type of data using metadata.
+// this type of data using metadata with a different, non-reserved (i.e. does
+// not begin with "grpc-") header name.
 func Trace(ctx context.Context) []byte {
 	b, _ := ctx.Value(incomingTraceKey{}).([]byte)
 	return b

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -219,14 +219,18 @@ type outgoingTagsKey struct{}
 // SetTags attaches stats tagging data to the context, which will be sent in
 // the outgoing RPC with the header grpc-tags-bin.
 //
-// This is EXPERIMENTAL and will likely be removed in an upcoming release.
+// NOTE: this is provided only for backward compatibilty with existing clients
+// and will likely be removed in an upcoming release.  New uses should transmit
+// this type of data using metadata.
 func SetTags(ctx context.Context, b []byte) context.Context {
 	return context.WithValue(ctx, outgoingTagsKey{}, b)
 }
 
 // Tags returns the tags from the context for the inbound RPC.
 //
-// This is EXPERIMENTAL and will likely be removed in an upcoming release.
+// NOTE: this is provided only for backward compatibilty with existing clients
+// and will likely be removed in an upcoming release.  New uses should transmit
+// this type of data using metadata.
 func Tags(ctx context.Context) []byte {
 	b, _ := ctx.Value(incomingTagsKey{}).([]byte)
 	return b
@@ -254,14 +258,18 @@ type outgoingTraceKey struct{}
 // SetTrace attaches stats tagging data to the context, which will be sent in
 // the outgoing RPC with the header grpc-trace-bin.
 //
-// This is EXPERIMENTAL and will likely be removed in an upcoming release.
+// NOTE: this is provided only for backward compatibilty with existing clients
+// and will likely be removed in an upcoming release.  New uses should transmit
+// this type of data using metadata.
 func SetTrace(ctx context.Context, b []byte) context.Context {
 	return context.WithValue(ctx, outgoingTraceKey{}, b)
 }
 
 // Trace returns the trace from the context for the inbound RPC.
 //
-// This is EXPERIMENTAL and will likely be removed in an upcoming release.
+// NOTE: this is provided only for backward compatibilty with existing clients
+// and will likely be removed in an upcoming release.  New uses should transmit
+// this type of data using metadata.
 func Trace(ctx context.Context) []byte {
 	b, _ := ctx.Value(incomingTraceKey{}).([]byte)
 	return b

--- a/stats/stats_test.go
+++ b/stats/stats_test.go
@@ -1238,3 +1238,41 @@ func TestClientStatsFullDuplexRPCNotCallingLastRecv(t *testing.T) {
 		end:        {checkEnd, 1},
 	})
 }
+
+func TestTags(t *testing.T) {
+	b := []byte{5, 2, 4, 3, 1}
+	ctx := stats.SetTags(context.Background(), b)
+	if tg := stats.OutgoingTags(ctx); !reflect.DeepEqual(tg, b) {
+		t.Errorf("OutgoingTags(%v) = %v; want %v", ctx, tg, b)
+	}
+	if tg := stats.Tags(ctx); tg != nil {
+		t.Errorf("Tags(%v) = %v; want nil", ctx, tg)
+	}
+
+	ctx = stats.SetIncomingTags(context.Background(), b)
+	if tg := stats.Tags(ctx); !reflect.DeepEqual(tg, b) {
+		t.Errorf("Tags(%v) = %v; want %v", ctx, tg, b)
+	}
+	if tg := stats.OutgoingTags(ctx); tg != nil {
+		t.Errorf("OutgoingTags(%v) = %v; want nil", ctx, tg)
+	}
+}
+
+func TestTrace(t *testing.T) {
+	b := []byte{5, 2, 4, 3, 1}
+	ctx := stats.SetTrace(context.Background(), b)
+	if tr := stats.OutgoingTrace(ctx); !reflect.DeepEqual(tr, b) {
+		t.Errorf("OutgoingTrace(%v) = %v; want %v", ctx, tr, b)
+	}
+	if tr := stats.Trace(ctx); tr != nil {
+		t.Errorf("Trace(%v) = %v; want nil", ctx, tr)
+	}
+
+	ctx = stats.SetIncomingTrace(context.Background(), b)
+	if tr := stats.Trace(ctx); !reflect.DeepEqual(tr, b) {
+		t.Errorf("Trace(%v) = %v; want %v", ctx, tr, b)
+	}
+	if tr := stats.OutgoingTrace(ctx); tr != nil {
+		t.Errorf("OutgoingTrace(%v) = %v; want nil", ctx, tr)
+	}
+}

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -4626,11 +4626,18 @@ func TestStatsTagsAndTrace(t *testing.T) {
 	// by the client and returns an error if not.
 	endpoint := &stubServer{
 		emptyCall: func(ctx context.Context, in *testpb.Empty) (*testpb.Empty, error) {
+			md, _ := metadata.FromIncomingContext(ctx)
 			if tg := stats.Tags(ctx); !reflect.DeepEqual(tg, tags) {
 				return nil, status.Errorf(codes.Internal, "stats.Tags(%v)=%v; want %v", ctx, tg, tags)
 			}
+			if !reflect.DeepEqual(md["grpc-tags-bin"], []string{string(tags)}) {
+				return nil, status.Errorf(codes.Internal, "md['grpc-tags-bin']=%v; want %v", md["grpc-tags-bin"], tags)
+			}
 			if tr := stats.Trace(ctx); !reflect.DeepEqual(tr, trace) {
 				return nil, status.Errorf(codes.Internal, "stats.Trace(%v)=%v; want %v", ctx, tr, trace)
+			}
+			if !reflect.DeepEqual(md["grpc-trace-bin"], []string{string(trace)}) {
+				return nil, status.Errorf(codes.Internal, "md['grpc-trace-bin']=%v; want %v", md["grpc-trace-bin"], trace)
 			}
 			return &testpb.Empty{}, nil
 		},

--- a/transport/http2_client.go
+++ b/transport/http2_client.go
@@ -471,6 +471,12 @@ func (t *http2Client) NewStream(ctx context.Context, callHdr *CallHdr) (_ *Strea
 	var (
 		endHeaders bool
 	)
+	if b := stats.OutgoingTags(ctx); b != nil {
+		t.hEnc.WriteField(hpack.HeaderField{Name: "grpc-tags-bin", Value: encodeBinHeader(b)})
+	}
+	if b := stats.OutgoingTrace(ctx); b != nil {
+		t.hEnc.WriteField(hpack.HeaderField{Name: "grpc-trace-bin", Value: encodeBinHeader(b)})
+	}
 	if md, ok := metadata.FromOutgoingContext(ctx); ok {
 		for k, vv := range md {
 			// HTTP doesn't allow you to set pseudoheaders after non pseudoheaders were set.

--- a/transport/http2_server.go
+++ b/transport/http2_server.go
@@ -274,6 +274,12 @@ func (t *http2Server) operateHeaders(frame *http2.MetaHeadersFrame, handle func(
 	if len(state.mdata) > 0 {
 		s.ctx = metadata.NewIncomingContext(s.ctx, state.mdata)
 	}
+	if state.statsTags != nil {
+		s.ctx = stats.SetIncomingTags(s.ctx, state.statsTags)
+	}
+	if state.statsTrace != nil {
+		s.ctx = stats.SetIncomingTrace(s.ctx, state.statsTrace)
+	}
 	s.trReader = &transportReader{
 		reader: &recvBufferReader{
 			ctx:  s.ctx,


### PR DESCRIPTION
Also, pick these up in grpc's transport when sending and fill them in when receiving.