### PR TITLE
benchmark: don't stop timer until after workers are done

### DIFF
--- a/benchmark/benchmark.go
+++ b/benchmark/benchmark.go
@@ -261,7 +261,6 @@ func NewClientConn(addr string, opts ...grpc.DialOption) *grpc.ClientConn {
 func runUnary(b *testing.B, benchFeatures Features) {
 	s := stats.AddStats(b, 38)
 	nw := &latency.Network{Kbps: benchFeatures.Kbps, Latency: benchFeatures.Latency, MTU: benchFeatures.Mtu}
-	b.StopTimer()
 	target, stopper := StartServer(ServerInfo{Addr: "localhost:0", Type: "protobuf", Network: nw}, grpc.MaxConcurrentStreams(uint32(benchFeatures.MaxConcurrentCalls+1)))
 	defer stopper()
 	conn := NewClientConn(
@@ -297,20 +296,19 @@ func runUnary(b *testing.B, benchFeatures Features) {
 			wg.Done()
 		}()
 	}
-	b.StartTimer()
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		ch <- i
 	}
-	b.StopTimer()
 	close(ch)
 	wg.Wait()
+	b.StopTimer()
 	conn.Close()
 }
 
 func runStream(b *testing.B, benchFeatures Features) {
 	s := stats.AddStats(b, 38)
 	nw := &latency.Network{Kbps: benchFeatures.Kbps, Latency: benchFeatures.Latency, MTU: benchFeatures.Mtu}
-	b.StopTimer()
 	target, stopper := StartServer(ServerInfo{Addr: "localhost:0", Type: "protobuf", Network: nw}, grpc.MaxConcurrentStreams(uint32(benchFeatures.MaxConcurrentCalls+1)))
 	defer stopper()
 	conn := NewClientConn(
@@ -355,13 +353,13 @@ func runStream(b *testing.B, benchFeatures Features) {
 			wg.Done()
 		}()
 	}
-	b.StartTimer()
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		ch <- struct{}{}
 	}
-	b.StopTimer()
 	close(ch)
 	wg.Wait()
+	b.StopTimer()
 	conn.Close()
 }
 func unaryCaller(client testpb.BenchmarkServiceClient, reqSize, respSize int) {


### PR DESCRIPTION
Also, a minor change to reset the timer when the test is ready to begin instead of stopping/starting around initialization.
