### PR TITLE
Automatic WriteStatus for RecvMsg/SendMsg error on server side

### DIFF
--- a/clientconn.go
+++ b/clientconn.go
@@ -20,6 +20,11 @@ package grpc
 
 import (
 	"errors"
+<<<<<<< HEAD
+=======
+	"fmt"
+	"math"
+>>>>>>> change defaultClientMaxSendMessageSize on client side
 	"net"
 	"strings"
 	"sync"
@@ -89,7 +94,7 @@ type dialOptions struct {
 
 const (
 	defaultClientMaxReceiveMessageSize = 1024 * 1024 * 4
-	defaultClientMaxSendMessageSize    = 1024 * 1024 * 4
+	defaultClientMaxSendMessageSize    = math.MaxInt32
 )
 
 // DialOption configures how we set up the connection.

--- a/clientconn.go
+++ b/clientconn.go
@@ -20,11 +20,7 @@ package grpc
 
 import (
 	"errors"
-<<<<<<< HEAD
-=======
-	"fmt"
 	"math"
->>>>>>> change defaultClientMaxSendMessageSize on client side
 	"net"
 	"strings"
 	"sync"

--- a/server.go
+++ b/server.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"net"
 	"net/http"
 	"reflect"
@@ -48,7 +49,7 @@ import (
 
 const (
 	defaultServerMaxReceiveMessageSize = 1024 * 1024 * 4
-	defaultServerMaxSendMessageSize    = 1024 * 1024 * 4
+	defaultServerMaxSendMessageSize    = math.MaxInt32
 )
 
 type methodHandler func(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor UnaryServerInterceptor) (interface{}, error)

--- a/server.go
+++ b/server.go
@@ -805,16 +805,10 @@ func (s *Server) processUnaryRPC(t transport.ServerTransport, stream *transport.
 	}
 	reply, appErr := md.Handler(srv.server, stream.Context(), df, s.opts.unaryInt)
 	if appErr != nil {
-		appStatus, ok := status.FromError(appErr)
-		if !ok {
-			switch err := appErr.(type) {
-			case transport.StreamError:
-				appStatus = status.New(err.Code, err.Desc)
-			default:
-				appStatus = status.New(convertCode(appErr), appErr.Error())
-			}
-			appErr = appStatus.Err()
-		}
+		// Convert appErr if it is not a grpc status error.
+		appErr = status.Error(convertCode(appErr), appErr.Error())
+		appStatus, _ = status.FromError(appErr)
+	}
 		if trInfo != nil {
 			trInfo.tr.LazyLog(stringer(appStatus.Message()), true)
 			trInfo.tr.SetError()
@@ -929,13 +923,9 @@ func (s *Server) processStreamingRPC(t transport.ServerTransport, stream *transp
 	if appErr != nil {
 		appStatus, ok := status.FromError(appErr)
 		if !ok {
-			switch err := appErr.(type) {
-			case transport.StreamError:
-				appStatus = status.New(err.Code, err.Desc)
-			default:
-				appStatus = status.New(convertCode(appErr), appErr.Error())
-			}
-			appErr = appStatus.Err()
+			// Convert appErr if it is not a grpc status error.
+			appErr = status.Error(convertCode(appErr), appErr.Error())
+			appStatus, _ = status.FromError(appErr)
 		}
 		if trInfo != nil {
 			ss.mu.Lock()

--- a/server.go
+++ b/server.go
@@ -931,6 +931,7 @@ func (s *Server) processStreamingRPC(t transport.ServerTransport, stream *transp
 			default:
 				appStatus = status.New(convertCode(appErr), appErr.Error())
 			}
+			appErr = appStatus.Err()
 		}
 		if trInfo != nil {
 			ss.mu.Lock()

--- a/stream.go
+++ b/stream.go
@@ -600,16 +600,7 @@ func (ss *serverStream) SendMsg(m interface{}) (err error) {
 			ss.mu.Unlock()
 		}
 		if err != nil && err != io.EOF {
-			st, ok := status.FromError(err)
-			if !ok {
-				switch err := err.(type) {
-				case transport.StreamError:
-					st = status.New(err.Code, err.Desc)
-				default:
-					st = status.New(convertCode(err), err.Error())
-				}
-				err = st.Err()
-			}
+			st, _ := status.FromError(toRPCErr(err))
 			ss.t.WriteStatus(ss.s, st)
 		}
 	}()
@@ -654,16 +645,7 @@ func (ss *serverStream) RecvMsg(m interface{}) (err error) {
 			ss.mu.Unlock()
 		}
 		if err != nil && err != io.EOF {
-			st, ok := status.FromError(err)
-			if !ok {
-				switch err := err.(type) {
-				case transport.StreamError:
-					st = status.New(err.Code, err.Desc)
-				default:
-					st = status.New(convertCode(err), err.Error())
-				}
-				err = st.Err()
-			}
+			st, _ := status.FromError(toRPCErr(err))
 			ss.t.WriteStatus(ss.s, st)
 		}
 	}()

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -295,6 +295,10 @@ func (s *testServer) FullDuplexCall(stream testpb.TestService_FullDuplexCallServ
 			return nil
 		}
 		if err != nil {
+			// to facilitate testSvrWriteStatusEarlyWrite
+			if grpc.Code(err) == codes.ResourceExhausted {
+				return grpc.Errorf(codes.Internal, "fake error for test testSvrWriteStatusEarlyWrite. true error: %s", err.Error())
+			}
 			return err
 		}
 		cs := in.GetResponseParameters()
@@ -311,6 +315,10 @@ func (s *testServer) FullDuplexCall(stream testpb.TestService_FullDuplexCallServ
 			if err := stream.Send(&testpb.StreamingOutputCallResponse{
 				Payload: payload,
 			}); err != nil {
+				// to facilitate testSvrWriteStatusEarlyWrite
+				if grpc.Code(err) == codes.ResourceExhausted {
+					return grpc.Errorf(codes.Internal, "fake error for test testSvrWriteStatusEarlyWrite. true error: %s", err.Error())
+				}
 				return err
 			}
 		}
@@ -4882,5 +4890,67 @@ func testEncodeDoesntPanic(t *testing.T, e env) {
 	// Passing case.
 	if _, err := tc.EmptyCall(context.Background(), &testpb.Empty{}); err != nil {
 		t.Fatalf("EmptyCall(_, _) = _, %v, want _, <nil>", err)
+	}
+}
+
+func TestSvrWriteStatusEarlyWrite(t *testing.T) {
+	defer leakCheck(t)()
+	for _, e := range listTestEnv() {
+		testSvrWriteStatusEarlyWrite(t, e)
+	}
+}
+
+func testSvrWriteStatusEarlyWrite(t *testing.T, e env) {
+	te := newTest(t, e)
+	const smallSize = 1024
+	const largeSize = 2048
+	const extraLargeSize = 4096
+	te.maxServerReceiveMsgSize = newInt(largeSize)
+	te.maxServerSendMsgSize = newInt(largeSize)
+	smallPayload, err := newPayload(testpb.PayloadType_COMPRESSABLE, smallSize)
+	if err != nil {
+		t.Fatal(err)
+	}
+	extraLargePayload, err := newPayload(testpb.PayloadType_COMPRESSABLE, extraLargeSize)
+	if err != nil {
+		t.Fatal(err)
+	}
+	te.startServer(&testServer{security: e.security})
+	defer te.tearDown()
+	tc := testpb.NewTestServiceClient(te.clientConn())
+	respParam := []*testpb.ResponseParameters{
+		{
+			Size: proto.Int32(int32(smallSize)),
+		},
+	}
+	sreq := &testpb.StreamingOutputCallRequest{
+		ResponseType:       testpb.PayloadType_COMPRESSABLE.Enum(),
+		ResponseParameters: respParam,
+		Payload:            extraLargePayload,
+	}
+	// Test recv case: server receives a message larger than maxServerReceiveMsgSize.
+	stream, err := tc.FullDuplexCall(te.ctx)
+	if err != nil {
+		t.Fatalf("%v.FullDuplexCall(_) = _, %v, want <nil>", tc, err)
+	}
+	if err = stream.Send(sreq); err != nil {
+		t.Fatalf("%v.Send() = _, %v, want <nil>", stream, err)
+	}
+	if _, err = stream.Recv(); err == nil || grpc.Code(err) != codes.ResourceExhausted {
+		t.Fatalf("%v.Recv() = _, %v, want _, error code: %s", stream, err, codes.ResourceExhausted)
+	}
+	// Test send case: server sends a message larger than maxServerSendMsgSize.
+	sreq.Payload = smallPayload
+	respParam[0].Size = proto.Int32(int32(extraLargeSize))
+
+	stream, err = tc.FullDuplexCall(te.ctx)
+	if err != nil {
+		t.Fatalf("%v.FullDuplexCall(_) = _, %v, want <nil>", tc, err)
+	}
+	if err = stream.Send(sreq); err != nil {
+		t.Fatalf("%v.Send(%v) = %v, want <nil>", stream, sreq, err)
+	}
+	if _, err = stream.Recv(); err == nil || grpc.Code(err) != codes.ResourceExhausted {
+		t.Fatalf("%v.Recv() = _, %v, want _, error code: %s", stream, err, codes.ResourceExhausted)
 	}
 }

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -1560,11 +1560,6 @@ func testMaxMsgSizeClientDefault(t *testing.T, e env) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	largePayload, err := newPayload(testpb.PayloadType_COMPRESSABLE, largeSize)
-	if err != nil {
-		t.Fatal(err)
-	}
 	req := &testpb.SimpleRequest{
 		ResponseType: testpb.PayloadType_COMPRESSABLE.Enum(),
 		ResponseSize: proto.Int32(int32(largeSize)),


### PR DESCRIPTION
- Automatically sending final status if error occurred in RecvMsg/SendMsg on server side.

- Increasing defaultClientMaxSendMessageSize/defaultServerMaxSendMessageSize to math.MaxInt32 to be consistent with C++/Java.

should resolve #1334. 