### PR TITLE
Set peer before sending request

### DIFF
--- a/call.go
+++ b/call.go
@@ -74,9 +74,6 @@ func recvResponse(ctx context.Context, dopts dialOptions, t transport.ClientTran
 		dopts.copts.StatsHandler.HandleRPC(ctx, inPayload)
 	}
 	c.trailerMD = stream.Trailer()
-	if peer, ok := peer.FromContext(stream.Context()); ok {
-		c.peer = peer
-	}
 	return nil
 }
 
@@ -261,6 +258,9 @@ func invoke(ctx context.Context, method string, args, reply interface{}, cc *Cli
 				continue
 			}
 			return toRPCErr(err)
+		}
+		if peer, ok := peer.FromContext(stream.Context()); ok {
+			c.peer = peer
 		}
 		err = sendRequest(ctx, cc.dopts, cc.dopts.cp, &c, callHdr, stream, t, args, topts)
 		if err != nil {

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -2308,7 +2308,6 @@ func testPeerFailedRPC(t *testing.T, e env) {
 			}
 			break
 		}
-		time.Sleep(10 * time.Millisecond)
 	}
 }
 

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -2308,6 +2308,7 @@ func testPeerFailedRPC(t *testing.T, e env) {
 			}
 			break
 		}
+		time.Sleep(10 * time.Millisecond)
 	}
 }
 


### PR DESCRIPTION
If a connection to the server exists but a request errors out due to context canceled or deadline exceeded, the peer information is not set. We can move setting the peer out of the recvResponse and before the sendRequest to get peer information for some failed RPCs. This addresses #1417

@MakMukhi @therc