### PR TITLE
Fix a goroutine leak in DialContext

### DIFF
--- a/clientconn.go
+++ b/clientconn.go
@@ -611,6 +611,15 @@ func (cc *ClientConn) GetState() ConnectivityState {
 // connections accordingly.  If doneChan is not nil, it is closed after the
 // first successfull connection is made.
 func (cc *ClientConn) lbWatcher(doneChan chan struct{}) {
+	defer func() {
+		// In case channel from cc.dopts.balancer.Notify() gets closed before a
+		// successful connection gets established, don't forget to notify the
+		// caller.
+		if doneChan != nil {
+			close(doneChan)
+		}
+	}()
+
 	for addrs := range cc.dopts.balancer.Notify() {
 		var (
 			add []Address   // Addresses need to setup connections.

--- a/clientconn_test.go
+++ b/clientconn_test.go
@@ -374,3 +374,19 @@ func TestClientUpdatesParamsAfterGoAway(t *testing.T) {
 		t.Fatalf("cc.dopts.copts.Keepalive.Time = %v , want 100ms", v)
 	}
 }
+
+func TestClientLBWatcherWithClosedBalancer(t *testing.T) {
+	b := newBlockingBalancer()
+	cc := &ClientConn{dopts: dialOptions{balancer: b}}
+
+	doneChan := make(chan struct{})
+	go cc.lbWatcher(doneChan)
+	// Balancer closes before any successful connections.
+	b.Close()
+
+	select {
+	case <-doneChan:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("lbWatcher with closed balancer didn't close doneChan after 100ms")
+	}
+}


### PR DESCRIPTION
A leak happens when DialContext times out before a balancer returns any
addresses or before a successful connection is established.

The loop in ClientConn.lbWatcher breaks and doneChan never gets closed.