### PR TITLE
Remove buf copy when the compressor exist

### DIFF
--- a/call.go
+++ b/call.go
@@ -106,22 +106,10 @@ func sendRequest(ctx context.Context, dopts dialOptions, compressor Compressor, 
 	if c.maxSendMessageSize == nil {
 		return Errorf(codes.Internal, "callInfo maxSendMessageSize field uninitialized(nil)")
 	}
-	if len(hdr)+len(data) > *c.maxSendMessageSize {
+	if len(data) > *c.maxSendMessageSize {
 		return Errorf(codes.ResourceExhausted, "grpc: trying to send message larger than max (%d vs. %d)", len(data), *c.maxSendMessageSize)
 	}
-	if len(data) != 0 {
-		prevOpts := opts.Last
-		opts.Last = false
-		err = t.Write(stream, hdr, opts)
-		if err != nil && err != io.EOF {
-			return err
-		}
-		opts.Last = prevOpts
-		err = t.Write(stream, data, opts)
-	} else {
-		err = t.Write(stream, hdr, opts)
-	}
-
+	err = t.Write(stream, hdr, data, opts)
 	if err == nil && outPayload != nil {
 		outPayload.SentTime = time.Now()
 		dopts.copts.StatsHandler.HandleRPC(ctx, outPayload)

--- a/call.go
+++ b/call.go
@@ -99,17 +99,18 @@ func sendRequest(ctx context.Context, dopts dialOptions, compressor Compressor, 
 			Client: true,
 		}
 	}
-	outBuf, err := encode(dopts.codec, args, compressor, cbuf, outPayload)
+	outBuf, outData, err := encode(dopts.codec, args, compressor, cbuf, outPayload)
 	if err != nil {
 		return err
 	}
 	if c.maxSendMessageSize == nil {
 		return Errorf(codes.Internal, "callInfo maxSendMessageSize field uninitialized(nil)")
 	}
-	if len(outBuf) > *c.maxSendMessageSize {
+	if len(outBuf)+len(outData) > *c.maxSendMessageSize {
 		return Errorf(codes.ResourceExhausted, "grpc: trying to send message larger than max (%d vs. %d)", len(outBuf), *c.maxSendMessageSize)
 	}
 	err = t.Write(stream, outBuf, opts)
+	err = t.Write(stream, outData, opts)
 	if err == nil && outPayload != nil {
 		outPayload.SentTime = time.Now()
 		dopts.copts.StatsHandler.HandleRPC(ctx, outPayload)

--- a/call_test.go
+++ b/call_test.go
@@ -104,13 +104,14 @@ func (h *testStreamHandler) handleStream(t *testing.T, s *transport.Stream) {
 		}
 	}
 	// send a response back to end the stream.
-	reply, replyData, err := encode(testCodec{}, &expectedResponse, nil, nil, nil)
+	hdr, data, err := encode(testCodec{}, &expectedResponse, nil, nil, nil)
 	if err != nil {
 		t.Errorf("Failed to encode the response: %v", err)
 		return
 	}
-	reply = append(reply, replyData...)
-	h.t.Write(s, reply, &transport.Options{})
+	o := &transport.Options{}
+	h.t.Write(s, hdr, o)
+	h.t.Write(s, data, o)
 	// h.t.Write(s, replyData, &transport.Options{})
 	h.t.WriteStatus(s, status.New(codes.OK, ""))
 }

--- a/call_test.go
+++ b/call_test.go
@@ -109,10 +109,7 @@ func (h *testStreamHandler) handleStream(t *testing.T, s *transport.Stream) {
 		t.Errorf("Failed to encode the response: %v", err)
 		return
 	}
-	o := &transport.Options{}
-	h.t.Write(s, hdr, o)
-	h.t.Write(s, data, o)
-	// h.t.Write(s, replyData, &transport.Options{})
+	h.t.Write(s, hdr, data, &transport.Options{})
 	h.t.WriteStatus(s, status.New(codes.OK, ""))
 }
 

--- a/call_test.go
+++ b/call_test.go
@@ -109,8 +109,9 @@ func (h *testStreamHandler) handleStream(t *testing.T, s *transport.Stream) {
 		t.Errorf("Failed to encode the response: %v", err)
 		return
 	}
+	reply = append(reply, replyData...)
 	h.t.Write(s, reply, &transport.Options{})
-	h.t.Write(s, replyData, &transport.Options{})
+	// h.t.Write(s, replyData, &transport.Options{})
 	h.t.WriteStatus(s, status.New(codes.OK, ""))
 }
 

--- a/call_test.go
+++ b/call_test.go
@@ -104,12 +104,13 @@ func (h *testStreamHandler) handleStream(t *testing.T, s *transport.Stream) {
 		}
 	}
 	// send a response back to end the stream.
-	reply, err := encode(testCodec{}, &expectedResponse, nil, nil, nil)
+	reply, replyData, err := encode(testCodec{}, &expectedResponse, nil, nil, nil)
 	if err != nil {
 		t.Errorf("Failed to encode the response: %v", err)
 		return
 	}
 	h.t.Write(s, reply, &transport.Options{})
+	h.t.Write(s, replyData, &transport.Options{})
 	h.t.WriteStatus(s, status.New(codes.OK, ""))
 }
 

--- a/rpc_util.go
+++ b/rpc_util.go
@@ -291,10 +291,8 @@ func (p *parser) recvMsg(maxReceiveMessageSize int) (pf payloadFormat, msg []byt
 // encode serializes msg and prepends the message header. If msg is nil, it
 // generates the message header of 0 message length.
 func encode(c Codec, msg interface{}, cp Compressor, cbuf *bytes.Buffer, outPayload *stats.OutPayload) ([]byte, []byte, error) {
-	var (
-		b      []byte
-		length int
-	)
+	var b []byte
+	var length uint
 	const payloadLen = 1
 	const sizeLen = 4
 
@@ -318,9 +316,9 @@ func encode(c Codec, msg interface{}, cp Compressor, cbuf *bytes.Buffer, outPayl
 			}
 			b = cbuf.Bytes()
 		}
+		length = uint(len(b))
 	}
 
-	length = len(b)
 	if length > math.MaxUint32 {
 		return nil, nil, Errorf(codes.ResourceExhausted, "grpc: message too large (%d bytes)", length)
 	}
@@ -334,7 +332,7 @@ func encode(c Codec, msg interface{}, cp Compressor, cbuf *bytes.Buffer, outPayl
 	// Write length of b into buf
 	binary.BigEndian.PutUint32(bufHeader[payloadLen:], uint32(length))
 	if outPayload != nil {
-		outPayload.WireLength = payloadLen + sizeLen + length
+		outPayload.WireLength = payloadLen + sizeLen + len(b)
 	}
 	return bufHeader, b, nil
 }

--- a/rpc_util.go
+++ b/rpc_util.go
@@ -332,13 +332,7 @@ func encode(c Codec, msg interface{}, cp Compressor, cbuf *bytes.Buffer, outPayl
 	if outPayload != nil {
 		outPayload.WireLength = payloadLen + sizeLen + len(b)
 	}
-
-	secondStart := 16384 - payloadLen - sizeLen
-	if len(b) < secondStart {
-		secondStart = len(b)
-	}
-	bufHeader = append(bufHeader, b[:secondStart]...)
-	return bufHeader, b[secondStart:], nil
+	return bufHeader, b, nil
 }
 
 func checkRecvPayload(pf payloadFormat, recvCompress string, dc Decompressor) error {

--- a/rpc_util_test.go
+++ b/rpc_util_test.go
@@ -110,7 +110,7 @@ func TestEncode(t *testing.T) {
 		{nil, nil, []byte{0, 0, 0, 0, 0}, nil},
 	} {
 		b, bData, err := encode(protoCodec{}, test.msg, nil, nil, nil)
-		b = append(b, bData)
+		b = append(b, bData...)
 		if err != test.err || !bytes.Equal(b, test.b) {
 			t.Fatalf("encode(_, _, %v, _) = %v, %v\nwant %v, %v", test.cp, b, err, test.b, test.err)
 		}
@@ -166,7 +166,7 @@ func TestToRPCErr(t *testing.T) {
 func bmEncode(b *testing.B, mSize int) {
 	msg := &perfpb.Buffer{Body: make([]byte, mSize)}
 	encoded, encodeData, _ := encode(protoCodec{}, msg, nil, nil, nil)
-	encoded = append(encode, encodeData)
+	encoded = append(encoded, encodeData...)
 	encodedSz := int64(len(encoded))
 	b.ReportAllocs()
 	b.ResetTimer()

--- a/rpc_util_test.go
+++ b/rpc_util_test.go
@@ -109,7 +109,8 @@ func TestEncode(t *testing.T) {
 	}{
 		{nil, nil, []byte{0, 0, 0, 0, 0}, nil},
 	} {
-		b, err := encode(protoCodec{}, test.msg, nil, nil, nil)
+		b, bData, err := encode(protoCodec{}, test.msg, nil, nil, nil)
+		b = append(b, bData)
 		if err != test.err || !bytes.Equal(b, test.b) {
 			t.Fatalf("encode(_, _, %v, _) = %v, %v\nwant %v, %v", test.cp, b, err, test.b, test.err)
 		}
@@ -164,7 +165,8 @@ func TestToRPCErr(t *testing.T) {
 // bytes.
 func bmEncode(b *testing.B, mSize int) {
 	msg := &perfpb.Buffer{Body: make([]byte, mSize)}
-	encoded, _ := encode(protoCodec{}, msg, nil, nil, nil)
+	encoded, encodeData, _ := encode(protoCodec{}, msg, nil, nil, nil)
+	encoded = append(encode, encodeData)
 	encodedSz := int64(len(encoded))
 	b.ReportAllocs()
 	b.ResetTimer()

--- a/rpc_util_test.go
+++ b/rpc_util_test.go
@@ -104,15 +104,15 @@ func TestEncode(t *testing.T) {
 		msg proto.Message
 		cp  Compressor
 		// outputs
-		b   []byte
-		err error
+		hdr  []byte
+		data []byte
+		err  error
 	}{
-		{nil, nil, []byte{0, 0, 0, 0, 0}, nil},
+		{nil, nil, []byte{0, 0, 0, 0, 0}, []byte{}, nil},
 	} {
-		b, bData, err := encode(protoCodec{}, test.msg, nil, nil, nil)
-		b = append(b, bData...)
-		if err != test.err || !bytes.Equal(b, test.b) {
-			t.Fatalf("encode(_, _, %v, _) = %v, %v\nwant %v, %v", test.cp, b, err, test.b, test.err)
+		hdr, data, err := encode(protoCodec{}, test.msg, nil, nil, nil)
+		if err != test.err || !bytes.Equal(hdr, test.hdr) || !bytes.Equal(data, test.data) {
+			t.Fatalf("encode(_, _, %v, _) = %v, %v, %v\nwant %v, %v, %v", test.cp, hdr, data, err, test.hdr, test.data, test.err)
 		}
 	}
 }
@@ -165,9 +165,8 @@ func TestToRPCErr(t *testing.T) {
 // bytes.
 func bmEncode(b *testing.B, mSize int) {
 	msg := &perfpb.Buffer{Body: make([]byte, mSize)}
-	encoded, encodeData, _ := encode(protoCodec{}, msg, nil, nil, nil)
-	encoded = append(encoded, encodeData...)
-	encodedSz := int64(len(encoded))
+	encodeHdr, encodeData, _ := encode(protoCodec{}, msg, nil, nil, nil)
+	encodedSz := int64(len(encodeHdr) + len(encodeData))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/server.go
+++ b/server.go
@@ -677,15 +677,16 @@ func (s *Server) sendResponse(t transport.ServerTransport, stream *transport.Str
 	if s.opts.statsHandler != nil {
 		outPayload = &stats.OutPayload{}
 	}
-	p, err := encode(s.opts.codec, msg, cp, cbuf, outPayload)
+	p, pData, err := encode(s.opts.codec, msg, cp, cbuf, outPayload)
 	if err != nil {
 		grpclog.Errorln("grpc: server failed to encode response: ", err)
 		return err
 	}
-	if len(p) > s.opts.maxSendMessageSize {
+	if len(p)+len(pData) > s.opts.maxSendMessageSize {
 		return status.Errorf(codes.ResourceExhausted, "grpc: trying to send message larger than max (%d vs. %d)", len(p), s.opts.maxSendMessageSize)
 	}
 	err = t.Write(stream, p, opts)
+	err = t.Write(stream, pData, opts)
 	if err == nil && outPayload != nil {
 		outPayload.SentTime = time.Now()
 		s.opts.statsHandler.HandleRPC(stream.Context(), outPayload)

--- a/server.go
+++ b/server.go
@@ -682,15 +682,22 @@ func (s *Server) sendResponse(t transport.ServerTransport, stream *transport.Str
 		grpclog.Errorln("grpc: server failed to encode response: ", err)
 		return err
 	}
-	if len(data)+len(hdr) > s.opts.maxSendMessageSize {
+	if len(hdr)+len(data) > s.opts.maxSendMessageSize {
 		return status.Errorf(codes.ResourceExhausted, "grpc: trying to send message larger than max (%d vs. %d)", len(data), s.opts.maxSendMessageSize)
 	}
-	prevOpts := opts.Last
-	opts.Last = false
-	errHeader := t.Write(stream, hdr, opts)
-	opts.Last = prevOpts
-	err = t.Write(stream, data, opts)
-	if err == nil && errHeader == nil && outPayload != nil {
+	if len(data) != 0 {
+		prevOpts := opts.Last
+		opts.Last = false
+		err = t.Write(stream, hdr, opts)
+		if err != nil {
+			return err
+		}
+		opts.Last = prevOpts
+		err = t.Write(stream, data, opts)
+	} else {
+		err = t.Write(stream, hdr, opts)
+	}
+	if err == nil && outPayload != nil {
 		outPayload.SentTime = time.Now()
 		s.opts.statsHandler.HandleRPC(stream.Context(), outPayload)
 	}

--- a/server.go
+++ b/server.go
@@ -685,15 +685,12 @@ func (s *Server) sendResponse(t transport.ServerTransport, stream *transport.Str
 	if len(data)+len(hdr) > s.opts.maxSendMessageSize {
 		return status.Errorf(codes.ResourceExhausted, "grpc: trying to send message larger than max (%d vs. %d)", len(data), s.opts.maxSendMessageSize)
 	}
-	/*
-		prevOpts := opts.Last
-		opts.Last = false
-		errHeader := t.Write(stream, hdr, opts)
-		opts.Last = prevOpts
-	*/
-	data = append(hdr, data...)
+	prevOpts := opts.Last
+	opts.Last = false
+	errHeader := t.Write(stream, hdr, opts)
+	opts.Last = prevOpts
 	err = t.Write(stream, data, opts)
-	if err == nil && outPayload != nil {
+	if err == nil && errHeader == nil && outPayload != nil {
 		outPayload.SentTime = time.Now()
 		s.opts.statsHandler.HandleRPC(stream.Context(), outPayload)
 	}

--- a/stream.go
+++ b/stream.go
@@ -623,13 +623,9 @@ func (ss *serverStream) SendMsg(m interface{}) (err error) {
 	if len(data)+len(hdr) > ss.maxSendMessageSize {
 		return Errorf(codes.ResourceExhausted, "trying to send message larger than max (%d vs. %d)", len(data), ss.maxSendMessageSize)
 	}
-	data = append(hdr, data...)
-
-	/*
-		if err := ss.t.Write(ss.s, hdr, &transport.Options{Last: false}); err != nil {
-			return toRPCErr(err)
-		}
-	*/
+	if err := ss.t.Write(ss.s, hdr, &transport.Options{Last: false}); err != nil {
+		return toRPCErr(err)
+	}
 	if err := ss.t.Write(ss.s, data, &transport.Options{Last: false}); err != nil {
 		return toRPCErr(err)
 	}

--- a/stream.go
+++ b/stream.go
@@ -362,7 +362,7 @@ func (cs *clientStream) SendMsg(m interface{}) (err error) {
 			Client: true,
 		}
 	}
-	out, err := encode(cs.codec, m, cs.cp, cs.cbuf, outPayload)
+	out, outData, err := encode(cs.codec, m, cs.cp, cs.cbuf, outPayload)
 	defer func() {
 		if cs.cbuf != nil {
 			cs.cbuf.Reset()
@@ -374,10 +374,11 @@ func (cs *clientStream) SendMsg(m interface{}) (err error) {
 	if cs.c.maxSendMessageSize == nil {
 		return Errorf(codes.Internal, "callInfo maxSendMessageSize field uninitialized(nil)")
 	}
-	if len(out) > *cs.c.maxSendMessageSize {
+	if len(out)+len(outData) > *cs.c.maxSendMessageSize {
 		return Errorf(codes.ResourceExhausted, "trying to send message larger than max (%d vs. %d)", len(out), *cs.c.maxSendMessageSize)
 	}
 	err = cs.t.Write(cs.s, out, &transport.Options{Last: false})
+	err = cs.t.Write(cs.s, outData, &transport.Options{Last: false})
 	if err == nil && outPayload != nil {
 		outPayload.SentTime = time.Now()
 		cs.statsHandler.HandleRPC(cs.statsCtx, outPayload)
@@ -449,6 +450,7 @@ func (cs *clientStream) RecvMsg(m interface{}) (err error) {
 }
 
 func (cs *clientStream) CloseSend() (err error) {
+	err = cs.t.Write(cs.s, nil, &transport.Options{Last: false})
 	err = cs.t.Write(cs.s, nil, &transport.Options{Last: true})
 	defer func() {
 		if err != nil {
@@ -608,7 +610,7 @@ func (ss *serverStream) SendMsg(m interface{}) (err error) {
 	if ss.statsHandler != nil {
 		outPayload = &stats.OutPayload{}
 	}
-	out, err := encode(ss.codec, m, ss.cp, ss.cbuf, outPayload)
+	out, outData, err := encode(ss.codec, m, ss.cp, ss.cbuf, outPayload)
 	defer func() {
 		if ss.cbuf != nil {
 			ss.cbuf.Reset()
@@ -617,10 +619,13 @@ func (ss *serverStream) SendMsg(m interface{}) (err error) {
 	if err != nil {
 		return err
 	}
-	if len(out) > ss.maxSendMessageSize {
+	if len(out)+len(outData) > ss.maxSendMessageSize {
 		return Errorf(codes.ResourceExhausted, "trying to send message larger than max (%d vs. %d)", len(out), ss.maxSendMessageSize)
 	}
 	if err := ss.t.Write(ss.s, out, &transport.Options{Last: false}); err != nil {
+		return toRPCErr(err)
+	}
+	if err := ss.t.Write(ss.s, outData, &transport.Options{Last: false}); err != nil {
 		return toRPCErr(err)
 	}
 	if outPayload != nil {

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -2410,7 +2410,6 @@ func testMultipleSetTrailerStreamingRPC(t *testing.T, e env) {
 	if _, err := stream.Recv(); err != io.EOF {
 		t.Fatalf("%v failed to complele the FullDuplexCall: %v", stream, err)
 	}
-
 	trailer := stream.Trailer()
 	expectedTrailer := metadata.Join(testTrailerMetadata, testTrailerMetadata2)
 	if !reflect.DeepEqual(trailer, expectedTrailer) {

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -1771,7 +1771,7 @@ func testMaxMsgSizeServerAPI(t *testing.T, e env) {
 	if err != nil {
 		t.Fatalf("%v.FullDuplexCall(_) = _, %v, want <nil>", tc, err)
 	}
-	if err := stream.Send(sreq); err != nil && err != io.EOF {
+	if err := stream.Send(sreq); err != nil {
 		t.Fatalf("%v.Send(%v) = %v, want <nil>", stream, sreq, err)
 	}
 	if _, err := stream.Recv(); err == nil || grpc.Code(err) != codes.ResourceExhausted {
@@ -2164,7 +2164,7 @@ func testExceedMsgLimit(t *testing.T, e env) {
 		ResponseParameters: respParam,
 		Payload:            spayload,
 	}
-	if err := stream.Send(sreq); err != nil && err != io.EOF {
+	if err := stream.Send(sreq); err != nil {
 		t.Fatalf("%v.Send(%v) = %v, want <nil>", stream, sreq, err)
 	}
 	if _, err := stream.Recv(); err == nil || grpc.Code(err) != codes.ResourceExhausted {
@@ -4933,7 +4933,7 @@ func testSvrWriteStatusEarlyWrite(t *testing.T, e env) {
 	if err != nil {
 		t.Fatalf("%v.FullDuplexCall(_) = _, %v, want <nil>", tc, err)
 	}
-	if err = stream.Send(sreq); err != nil && err != io.EOF {
+	if err = stream.Send(sreq); err != nil {
 		t.Fatalf("%v.Send() = _, %v, want <nil>", stream, err)
 	}
 	if _, err = stream.Recv(); err == nil || grpc.Code(err) != codes.ResourceExhausted {

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -1771,7 +1771,7 @@ func testMaxMsgSizeServerAPI(t *testing.T, e env) {
 	if err != nil {
 		t.Fatalf("%v.FullDuplexCall(_) = _, %v, want <nil>", tc, err)
 	}
-	if err := stream.Send(sreq); err != nil {
+	if err := stream.Send(sreq); err != nil && err != io.EOF {
 		t.Fatalf("%v.Send(%v) = %v, want <nil>", stream, sreq, err)
 	}
 	if _, err := stream.Recv(); err == nil || grpc.Code(err) != codes.ResourceExhausted {
@@ -2164,7 +2164,7 @@ func testExceedMsgLimit(t *testing.T, e env) {
 		ResponseParameters: respParam,
 		Payload:            spayload,
 	}
-	if err := stream.Send(sreq); err != nil {
+	if err := stream.Send(sreq); err != nil && err != io.EOF {
 		t.Fatalf("%v.Send(%v) = %v, want <nil>", stream, sreq, err)
 	}
 	if _, err := stream.Recv(); err == nil || grpc.Code(err) != codes.ResourceExhausted {
@@ -2410,6 +2410,7 @@ func testMultipleSetTrailerStreamingRPC(t *testing.T, e env) {
 	if _, err := stream.Recv(); err != io.EOF {
 		t.Fatalf("%v failed to complele the FullDuplexCall: %v", stream, err)
 	}
+
 	trailer := stream.Trailer()
 	expectedTrailer := metadata.Join(testTrailerMetadata, testTrailerMetadata2)
 	if !reflect.DeepEqual(trailer, expectedTrailer) {
@@ -4932,7 +4933,7 @@ func testSvrWriteStatusEarlyWrite(t *testing.T, e env) {
 	if err != nil {
 		t.Fatalf("%v.FullDuplexCall(_) = _, %v, want <nil>", tc, err)
 	}
-	if err = stream.Send(sreq); err != nil {
+	if err = stream.Send(sreq); err != nil && err != io.EOF {
 		t.Fatalf("%v.Send() = _, %v, want <nil>", stream, err)
 	}
 	if _, err = stream.Recv(); err == nil || grpc.Code(err) != codes.ResourceExhausted {

--- a/transport/handler_server.go
+++ b/transport/handler_server.go
@@ -246,9 +246,10 @@ func (ht *serverHandlerTransport) writeCommonHeaders(s *Stream) {
 	}
 }
 
-func (ht *serverHandlerTransport) Write(s *Stream, data []byte, opts *Options) error {
+func (ht *serverHandlerTransport) Write(s *Stream, hdr []byte, data []byte, opts *Options) error {
 	return ht.do(func() {
 		ht.writeCommonHeaders(s)
+		ht.rw.Write(hdr)
 		ht.rw.Write(data)
 		if !opts.Delay {
 			ht.rw.(http.Flusher).Flush()

--- a/transport/http2_client.go
+++ b/transport/http2_client.go
@@ -679,7 +679,7 @@ func (t *http2Client) GracefulClose() error {
 // TODO(zhaoq): opts.Delay is ignored in this implementation. Support it later
 // if it improves the performance.
 func (t *http2Client) Write(s *Stream, hdr []byte, data []byte, opts *Options) error {
-	secondStart := http2MaxFrameLen - len(hdr)
+	secondStart := http2MaxFrameLen - len(hdr)%http2MaxFrameLen
 	if len(data) < secondStart {
 		secondStart = len(data)
 	}

--- a/transport/http2_client.go
+++ b/transport/http2_client.go
@@ -721,7 +721,7 @@ func (t *http2Client) Write(s *Stream, data []byte, opts *Options) error {
 			endStream  bool
 			forceFlush bool
 		)
-		if opts.Last && r.Len() == 0 && s.headerOk {
+		if opts.Last && r.Len() == 0 {
 			endStream = true
 		}
 		// Indicate there is a writer who is about to write a data frame.
@@ -785,14 +785,12 @@ func (t *http2Client) Write(s *Stream, data []byte, opts *Options) error {
 		}
 	}
 	if !opts.Last {
-		s.headerOk = true
 		return nil
 	}
 	s.mu.Lock()
-	if s.state != streamDone && s.headerOk {
+	if s.state != streamDone {
 		s.state = streamWriteDone
 	}
-	s.headerOk = true
 	s.mu.Unlock()
 	return nil
 }

--- a/transport/http2_client.go
+++ b/transport/http2_client.go
@@ -721,7 +721,7 @@ func (t *http2Client) Write(s *Stream, data []byte, opts *Options) error {
 			endStream  bool
 			forceFlush bool
 		)
-		if opts.Last && r.Len() == 0 {
+		if opts.Last && r.Len() == 0 && s.headerOk {
 			endStream = true
 		}
 		// Indicate there is a writer who is about to write a data frame.
@@ -785,12 +785,14 @@ func (t *http2Client) Write(s *Stream, data []byte, opts *Options) error {
 		}
 	}
 	if !opts.Last {
+		s.headerOk = true
 		return nil
 	}
 	s.mu.Lock()
-	if s.state != streamDone {
+	if s.state != streamDone && s.headerOk {
 		s.state = streamWriteDone
 	}
+	s.headerOk = true
 	s.mu.Unlock()
 	return nil
 }

--- a/transport/http2_client.go
+++ b/transport/http2_client.go
@@ -678,8 +678,15 @@ func (t *http2Client) GracefulClose() error {
 // should proceed only if Write returns nil.
 // TODO(zhaoq): opts.Delay is ignored in this implementation. Support it later
 // if it improves the performance.
-func (t *http2Client) Write(s *Stream, data []byte, opts *Options) error {
-	r := bytes.NewBuffer(data)
+func (t *http2Client) Write(s *Stream, hdr []byte, data []byte, opts *Options) error {
+	secondStart := 16379 // 16384 - payloadLen - sizeLen
+	if len(data) < secondStart {
+		secondStart = len(data)
+	}
+	hdr = append(hdr, data[:secondStart]...)
+	data = data[secondStart:]
+	isLastSlice := (len(data) == 0)
+	r := bytes.NewBuffer(hdr)
 	var (
 		p   []byte
 		oqv uint32
@@ -721,9 +728,6 @@ func (t *http2Client) Write(s *Stream, data []byte, opts *Options) error {
 			endStream  bool
 			forceFlush bool
 		)
-		if opts.Last && r.Len() == 0 {
-			endStream = true
-		}
 		// Indicate there is a writer who is about to write a data frame.
 		t.framer.adjustNumWriters(1)
 		// Got some quota. Try to acquire writing privilege on the transport.
@@ -763,10 +767,18 @@ func (t *http2Client) Write(s *Stream, data []byte, opts *Options) error {
 			t.writableChan <- 0
 			continue
 		}
-		if r.Len() == 0 && t.framer.adjustNumWriters(0) == 1 {
+		if r.Len() == 0 && t.framer.adjustNumWriters(0) == 1 && isLastSlice {
 			// Do a force flush iff this is last frame for the entire gRPC message
 			// and the caller is the only writer at this moment.
 			forceFlush = true
+		}
+		if r.Len() == 0 {
+			if isLastSlice && opts.Last {
+				endStream = true
+			} else if !isLastSlice && len(data) != 0 {
+				r = bytes.NewBuffer(data)
+			}
+			isLastSlice = true
 		}
 		// If WriteData fails, all the pending streams will be handled
 		// by http2Client.Close(). No explicit CloseStream() needs to be

--- a/transport/http2_server.go
+++ b/transport/http2_server.go
@@ -821,8 +821,15 @@ func (t *http2Server) WriteStatus(s *Stream, st *status.Status) error {
 
 // Write converts the data into HTTP2 data frame and sends it out. Non-nil error
 // is returns if it fails (e.g., framing error, transport error).
-func (t *http2Server) Write(s *Stream, data []byte, opts *Options) (err error) {
+func (t *http2Server) Write(s *Stream, hdr []byte, data []byte, opts *Options) (err error) {
 	// TODO(zhaoq): Support multi-writers for a single stream.
+	secondStart := 16379 // 16384 - payloadLen - sizeLen
+	if len(data) < secondStart {
+		secondStart = len(data)
+	}
+	hdr = append(hdr, data[:secondStart]...)
+	data = data[secondStart:]
+	isLastSlice := (len(data) == 0)
 	var writeHeaderFrame bool
 	s.mu.Lock()
 	if s.state == streamDone {
@@ -836,7 +843,7 @@ func (t *http2Server) Write(s *Stream, data []byte, opts *Options) (err error) {
 	if writeHeaderFrame {
 		t.WriteHeader(s, nil)
 	}
-	r := bytes.NewBuffer(data)
+	r := bytes.NewBuffer(hdr)
 	var (
 		p   []byte
 		oqv uint32
@@ -915,8 +922,14 @@ func (t *http2Server) Write(s *Stream, data []byte, opts *Options) (err error) {
 			continue
 		}
 		var forceFlush bool
-		if r.Len() == 0 && t.framer.adjustNumWriters(0) == 1 && !opts.Last {
+		if r.Len() == 0 && t.framer.adjustNumWriters(0) == 1 && !opts.Last && isLastSlice {
 			forceFlush = true
+		}
+		if r.Len() == 0 {
+			if !isLastSlice {
+				r = bytes.NewBuffer(data)
+			}
+			isLastSlice = true
 		}
 		// Reset ping strikes when sending data since this might cause
 		// the peer to send ping.

--- a/transport/http2_server.go
+++ b/transport/http2_server.go
@@ -823,7 +823,7 @@ func (t *http2Server) WriteStatus(s *Stream, st *status.Status) error {
 // is returns if it fails (e.g., framing error, transport error).
 func (t *http2Server) Write(s *Stream, hdr []byte, data []byte, opts *Options) (err error) {
 	// TODO(zhaoq): Support multi-writers for a single stream.
-	secondStart := http2MaxFrameLen - len(hdr)
+	secondStart := http2MaxFrameLen - len(hdr)%http2MaxFrameLen
 	if len(data) < secondStart {
 		secondStart = len(data)
 	}

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -564,7 +564,7 @@ type ClientTransport interface {
 
 	// Write sends the data for the given stream. A nil stream indicates
 	// the write is to be performed on the transport as a whole.
-	Write(s *Stream, data []byte, opts *Options) error
+	Write(s *Stream, hdr []byte, data []byte, opts *Options) error
 
 	// NewStream creates a Stream for an RPC.
 	NewStream(ctx context.Context, callHdr *CallHdr) (*Stream, error)
@@ -606,7 +606,7 @@ type ServerTransport interface {
 
 	// Write sends the data for the given stream.
 	// Write may not be called on all streams.
-	Write(s *Stream, data []byte, opts *Options) error
+	Write(s *Stream, hdr []byte, data []byte, opts *Options) error
 
 	// WriteStatus sends the status of a stream to the client.  WriteStatus is
 	// the final call made on a stream and always occurs.


### PR DESCRIPTION
Re-use the buffer used by compressor. Doesn't need to create new "buf" and copy the old data.