### PR TITLE
Fix compileUpdate of dnsWatcher

### DIFF
--- a/naming/dns_resolver.go
+++ b/naming/dns_resolver.go
@@ -193,21 +193,24 @@ type AddrMetadataGRPCLB struct {
 // compileUpdate compares the old resolved addresses and newly resolved addresses,
 // and generates an update list
 func (w *dnsWatcher) compileUpdate(newAddrs []*Update) []*Update {
-	update := make(map[Update]bool)
+	update := make(map[*Update]bool)
+	newAddr := make(map[string]*Update)
 	for _, u := range newAddrs {
-		update[*u] = true
+		update[u] = true
+		newAddr[u.Addr] = u
 	}
+
 	for _, u := range w.curAddrs {
-		if _, ok := update[*u]; ok {
-			delete(update, *u)
+		if _, ok := newAddr[u.Addr]; ok {
+			delete(update, newAddr[u.Addr])
 			continue
 		}
-		update[Update{Addr: u.Addr, Op: Delete, Metadata: u.Metadata}] = true
+		update[&Update{Addr: u.Addr, Op: Delete, Metadata: u.Metadata}] = true
 	}
 	res := make([]*Update, 0, len(update))
 	for k := range update {
 		tmp := k
-		res = append(res, &tmp)
+		res = append(res, tmp)
 	}
 	return res
 }


### PR DESCRIPTION
I am using `go1.8.1 darwin/amd64`. 

sometime net.DefaultResolver.LookupHost return duplicate ips for eg - [ 10.0.1.1, `10.0.1.2` `10.0.1.2`] - (this happens when some ips are removed or added to the dns). So w.curAddrs array can have multiple `Update` items with same ips. 

Suppose the ip - `10.0.1.2` is present more than once in curAddrs. And the `update` map also contain the ip `10.0.1.2`. [Loop](https://github.com/grpc/grpc-go/pull/1449/files#diff-a17c141b2b5bec36655aea898dde10b5L200) over w.curAddrs will [delete](https://github.com/grpc/grpc-go/pull/1449/files#diff-a17c141b2b5bec36655aea898dde10b5L202) the ip `10.0.1.2` from `update` map and on the next iteration `update` map will not have ip -`10.0.1.2` so it will update the `update` list with `Op` `Delete` for this ip - which is not desirable.
 
Due to this - ip `10.0.1.2` will not be anymore available by grpc client. 
