### PR TITLE
Fix for 32-bit architectures

### DIFF
--- a/rpc_util.go
+++ b/rpc_util.go
@@ -317,7 +317,7 @@ func encode(c Codec, msg interface{}, cp Compressor, cbuf *bytes.Buffer, outPayl
 		}
 	}
 
-	if len(b) > math.MaxUint32 {
+	if uint(len(b)) > math.MaxUint32 {
 		return nil, nil, Errorf(codes.ResourceExhausted, "grpc: message too large (%d bytes)", len(b))
 	}
 


### PR DESCRIPTION
Tested with:

GOARCH=386 go test google.golang.org/grpc

Fixes #1469 
