### PR TITLE
Fix the output location of the generated .pb.go file. Currently it is…

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -51,7 +51,10 @@ OPTIONAL - Rebuilding the generated code
 
 ```
 $ go get -a github.com/golang/protobuf/protoc-gen-go
-$
-$ # from this dir; invoke protoc
-$  protoc -I ./helloworld/helloworld/ ./helloworld/helloworld/helloworld.proto --go_out=plugins=grpc:helloworld/helloworld
+```
+
+3 Rebuild the generated Go code.
+
+```
+$ go generate google.golang.org/grpc/examples/helloworld/...
 ```

--- a/examples/README.md
+++ b/examples/README.md
@@ -53,5 +53,5 @@ OPTIONAL - Rebuilding the generated code
 $ go get -a github.com/golang/protobuf/protoc-gen-go
 $
 $ # from this dir; invoke protoc
-$  protoc -I ./helloworld/helloworld/ ./helloworld/helloworld/helloworld.proto --go_out=plugins=grpc:helloworld
+$  protoc -I ./helloworld/helloworld/ ./helloworld/helloworld/helloworld.proto --go_out=plugins=grpc:helloworld/helloworld
 ```


### PR DESCRIPTION
… output to helloworld/helloworld.pb.go, where it should be helloworld/helloworld/helloworld.pb.go.