### PR TITLE
Serve() should not return error on Stop() or GracefulStop()

### DIFF
--- a/server.go
+++ b/server.go
@@ -96,7 +96,11 @@ type Server struct {
 	cv     *sync.Cond
 	m      map[string]*service // service name -> service info
 	events trace.EventLog
-	quit   chan struct{}
+
+	quit     chan struct{}
+	done     chan struct{}
+	quitOnce sync.Once
+	doneOnce sync.Once
 }
 
 type options struct {
@@ -308,7 +312,8 @@ func NewServer(opt ...ServerOption) *Server {
 		opts:  opts,
 		conns: make(map[io.Closer]bool),
 		m:     make(map[string]*service),
-		quit:  make(chan struct{}, 1),
+		quit:  make(chan struct{}),
+		done:  make(chan struct{}),
 	}
 	s.cv = sync.NewCond(&s.mu)
 	s.ctx, s.cancel = context.WithCancel(context.Background())
@@ -487,8 +492,11 @@ func (s *Server) Serve(lis net.Listener) error {
 			s.mu.Lock()
 			s.printf("done serving; Accept = %v", err)
 			s.mu.Unlock()
+
+			// If Stop or GracefulStop is called, block until they are done and return nil
 			select {
 			case <-s.quit:
+				<-s.done
 				return nil
 			default:
 			}
@@ -1059,10 +1067,15 @@ func (s *Server) handleStream(t transport.ServerTransport, stream *transport.Str
 // pending RPCs on the client side will get notified by connection
 // errors.
 func (s *Server) Stop() {
-	select {
-	case s.quit <- struct{}{}:
-	default:
-	}
+	s.quitOnce.Do(func() {
+		close(s.quit)
+	})
+
+	defer func() {
+		s.doneOnce.Do(func() {
+			close(s.done)
+		})
+	}()
 
 	s.mu.Lock()
 	listeners := s.lis
@@ -1093,10 +1106,16 @@ func (s *Server) Stop() {
 // accepting new connections and RPCs and blocks until all the pending RPCs are
 // finished.
 func (s *Server) GracefulStop() {
-	select {
-	case s.quit <- struct{}{}:
-	default:
-	}
+	s.quitOnce.Do(func() {
+		close(s.quit)
+	})
+
+	defer func() {
+		s.doneOnce.Do(func() {
+			close(s.done)
+		})
+	}()
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.conns == nil {


### PR DESCRIPTION
As https://github.com/grpc/grpc-go/issues/1372 reported, currently `Serve()` function returns non-nil error when `Stop()` or `GracefulStop()` is called. 

This is because both `Stop` and `GracefulStop` close the listener (`net.Listener`) directly, which is still being blocked on the `Accept()` call in `Serve()`. We can use a `quit` channel to indicate that the grpc server is being stopped on demand and return `nil` instead of an error.

