### PR TITLE
quotaPool version field 64-bit alignment on 32-bit ARM

### DIFF
--- a/transport/control.go
+++ b/transport/control.go
@@ -126,8 +126,8 @@ type quotaPool struct {
 	c chan int
 
 	mu      sync.Mutex
-	version uint64
 	quota   int
+	version uint64
 }
 
 // newQuotaPool creates a quotaPool which has quota q available to consume.


### PR DESCRIPTION
When trying to use grpc-go on armv7l a panic occurs when calling `atomic.loadUint64` with `quotaPool.version` from [transport/control.go](https://github.com/grpc/grpc-go/blob/894322f00c5475125c3d27aa8042a5b8d7e674a6/transport/control.go#L129).

Example panic when running `examples/helloworld/greeter_client/main.go`

```
$ go run greeter_client/main.go
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x4 pc=0x127bc]

goroutine 1 [running]:
sync/atomic.loadUint64(0x1170a70c, 0x2b8d7c, 0x331340)
        /usr/local/go/src/sync/atomic/64bit_arm.go:10 +0x3c
google.golang.org/grpc/transport.(*quotaPool).acquireWithVersion(0x1170a700, 0x1171a300, 0x7, 0x5)
        /home/pi/go/src/google.golang.org/grpc/transport/control.go:190 +0x24
google.golang.org/grpc/transport.(*http2Client).Write(0x11664380, 0x11740140, 0x1171a330, 0x5, 0x10, 0x1171a300, 0x0, 0x10, 0x1161468c, 0x5, ...)
        /home/pi/go/src/google.golang.org/grpc/transport/http2_client.go:682 +0x210
google.golang.org/grpc.sendRequest(0x544198, 0x11659140, 0x0, 0x0, 0x543c70, 0x58f3bc, 0x0, 0x0, 0x0, 0x0, ...)
        /home/pi/go/src/google.golang.org/grpc/call.go:113 +0x13c
google.golang.org/grpc.invoke(0x544198, 0x11659140, 0x39946c, 0x1c, 0x3632e8, 0x1160e810, 0x363260, 0x1160e818, 0x11672d80, 0x0, ...)
        /home/pi/go/src/google.golang.org/grpc/call.go:266 +0x910
google.golang.org/grpc.Invoke(0x544148, 0x116140b8, 0x39946c, 0x1c, 0x3632e8, 0x1160e810, 0x363260, 0x1160e818, 0x11672d80, 0x0, ...)
        /home/pi/go/src/google.golang.org/grpc/call.go:135 +0x100
google.golang.org/grpc/examples/helloworld/helloworld.(*greeterClient).SayHello(0x1160e808, 0x544148, 0x116140b8, 0x1160e810, 0x0, 0x0, 0x0, 0x0, 0x1, 0x1)
        /home/pi/go/src/google.golang.org/grpc/examples/helloworld/helloworld/helloworld.pb.go:100 +0x88
main.main()
        /home/pi/go/src/google.golang.org/grpc/examples/helloworld/greeter_client/main.go:49 +0x19c
exit status 2
```

As noted in the `sync/atomic` [docs](https://golang.org/pkg/sync/atomic/#pkg-note-BUG):

> On both ARM and x86-32, it is the caller's responsibility to arrange for 64-bit alignment of 64-bit words accessed atomically. The first word in a variable or in an allocated struct, array, or slice can be relied upon to be 64-bit aligned.

So by repositioning the `version` field within the struct, and arranging for the 64-bit alignment, I have been able to fix the panic.

However, it may be safer to move `version` to be the first field in the struct, ensuring that it is always 64-bit aligned.