### PR TITLE
transport: Fix 32-bit alignment issue.

### DIFF
--- a/transport/control.go
+++ b/transport/control.go
@@ -123,10 +123,9 @@ func (*ping) item() {}
 // quotaPool is a pool which accumulates the quota and sends it to acquire()
 // when it is available.
 type quotaPool struct {
-	c chan int
-
 	mu      sync.Mutex
 	version uint32
+	c       chan int
 	quota   int
 }
 


### PR DESCRIPTION
We perform atomic operations on the `version` attribute, so it needs
to be 64-bit aligned (at least when executing GOARCH=386 code on modern
64-bit Intel/AMD CPUs).  Unfortunately there is no way to tell the Go
compiler how to pack or align things, so the only way is to shuffle the
fields around so that the desired field is always on a 64-bit boundary,
no matter whether the code is compiled for 32-bit or 64-bit mode.