### PR TITLE
Use Type() method for OAuth tokens instead of accessing field directly.

### DIFF
--- a/credentials/oauth/oauth.go
+++ b/credentials/oauth/oauth.go
@@ -1,5 +1,5 @@
-/*
  *
+ /*
  * Copyright 2015 gRPC authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -80,7 +80,7 @@ func (j jwtAccess) GetRequestMetadata(ctx context.Context, uri ...string) (map[s
 		return nil, err
 	}
 	return map[string]string{
-		"authorization": token.TokenType + " " + token.AccessToken,
+		"authorization": token.Type() + " " + token.AccessToken,
 	}, nil
 }
 
@@ -100,7 +100,7 @@ func NewOauthAccess(token *oauth2.Token) credentials.PerRPCCredentials {
 
 func (oa oauthAccess) GetRequestMetadata(ctx context.Context, uri ...string) (map[string]string, error) {
 	return map[string]string{
-		"authorization": oa.token.TokenType + " " + oa.token.AccessToken,
+		"authorization": oa.token.Type() + " " + oa.token.AccessToken,
 	}, nil
 }
 
@@ -134,7 +134,7 @@ func (s *serviceAccount) GetRequestMetadata(ctx context.Context, uri ...string) 
 		}
 	}
 	return map[string]string{
-		"authorization": s.t.TokenType + " " + s.t.AccessToken,
+		"authorization": s.t.Type() + " " + s.t.AccessToken,
 	}, nil
 }
 

--- a/credentials/oauth/oauth.go
+++ b/credentials/oauth/oauth.go
@@ -1,5 +1,5 @@
- *
  /*
+ *
  * Copyright 2015 gRPC authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/interop/test_utils.go
+++ b/interop/test_utils.go
@@ -378,7 +378,7 @@ func DoPerRPCCreds(tc testpb.TestServiceClient, serviceAccountKeyFile, oauthScop
 		FillOauthScope: proto.Bool(true),
 	}
 	token := GetToken(serviceAccountKeyFile, oauthScope)
-	kv := map[string]string{"authorization": token.TokenType + " " + token.AccessToken}
+	kv := map[string]string{"authorization": token.Type() + " " + token.AccessToken}
 	ctx := metadata.NewOutgoingContext(context.Background(), metadata.MD{"authorization": []string{kv["authorization"]}})
 	reply, err := tc.UnaryCall(ctx, req)
 	if err != nil {


### PR DESCRIPTION
This causes a bug where getting the token type directly does not respect
the default behavior:

Type returns t.TokenType if non-empty, else "Bearer".