### PR TITLE
Fix format error

### DIFF
--- a/go17.go
+++ b/go17.go
@@ -41,7 +41,7 @@ func dialContext(ctx context.Context, network, address string) (net.Conn, error)
 func sendHTTPRequest(ctx context.Context, req *http.Request, conn net.Conn) error {
 	req = req.WithContext(ctx)
 	if err := req.Write(conn); err != nil {
-		return err
+		return fmt.Errorf("failed to write the HTTP request: %v", err)
 	}
 	return nil
 }

--- a/transport/transport_test.go
+++ b/transport/transport_test.go
@@ -1932,15 +1932,12 @@ func writeOneHeader(framer *http2.Framer, sid uint32, httpStatus int) error {
 	var buf bytes.Buffer
 	henc := hpack.NewEncoder(&buf)
 	henc.WriteField(hpack.HeaderField{Name: ":status", Value: fmt.Sprint(httpStatus)})
-	if err := framer.WriteHeaders(http2.HeadersFrameParam{
+	return framer.WriteHeaders(http2.HeadersFrameParam{
 		StreamID:      sid,
 		BlockFragment: buf.Bytes(),
 		EndStream:     true,
 		EndHeaders:    true,
-	}); err != nil {
-		return err
-	}
-	return nil
+	})
 }
 
 func writeTwoHeaders(framer *http2.Framer, sid uint32, httpStatus int) error {
@@ -1962,15 +1959,12 @@ func writeTwoHeaders(framer *http2.Framer, sid uint32, httpStatus int) error {
 		Name:  ":status",
 		Value: fmt.Sprint(httpStatus),
 	})
-	if err := framer.WriteHeaders(http2.HeadersFrameParam{
+	return framer.WriteHeaders(http2.HeadersFrameParam{
 		StreamID:      sid,
 		BlockFragment: buf.Bytes(),
 		EndStream:     true,
 		EndHeaders:    true,
-	}); err != nil {
-		return err
-	}
-	return nil
+	})
 }
 
 type httpServer struct {


### PR DESCRIPTION
```
go17.go:43:2: redundant if ...; err != nil check, just return error instead.
transport/transport_test.go:1935:2: redundant if ...; err != nil check, just return error instead.
transport/transport_test.go:1965:2: redundant if ...; err != nil check, just return error instead.
```

https://travis-ci.org/grpc/grpc-go/jobs/277505656#L537