### PR TITLE
benchmark: add primivites benchmark for Unlocking via defer vs. inline

### DIFF
--- a/benchmark/primitives/primitives_test.go
+++ b/benchmark/primitives/primitives_test.go
@@ -136,3 +136,37 @@ func BenchmarkRWMutexW(b *testing.B) {
 		b.Fatal("error")
 	}
 }
+
+func BenchmarkMutexWithDefer(b *testing.B) {
+	c := sync.Mutex{}
+	x := 0
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		func() {
+			c.Lock()
+			defer c.Unlock()
+			x++
+		}()
+	}
+	b.StopTimer()
+	if x != b.N {
+		b.Fatal("error")
+	}
+}
+
+func BenchmarkMutexWithoutDefer(b *testing.B) {
+	c := sync.Mutex{}
+	x := 0
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		func() {
+			c.Lock()
+			x++
+			c.Unlock()
+		}()
+	}
+	b.StopTimer()
+	if x != b.N {
+		b.Fatal("error")
+	}
+}

--- a/benchmark/primitives/primitives_test.go
+++ b/benchmark/primitives/primitives_test.go
@@ -154,6 +154,23 @@ func BenchmarkMutexWithDefer(b *testing.B) {
 	}
 }
 
+func BenchmarkMutexWithClosureDefer(b *testing.B) {
+	c := sync.Mutex{}
+	x := 0
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		func() {
+			c.Lock()
+			defer func() { c.Unlock() }()
+			x++
+		}()
+	}
+	b.StopTimer()
+	if x != b.N {
+		b.Fatal("error")
+	}
+}
+
 func BenchmarkMutexWithoutDefer(b *testing.B) {
 	c := sync.Mutex{}
 	x := 0


### PR DESCRIPTION
Results:

```
$ go test -benchtime=3s -benchmem -bench=Defer benchmark/primitives/*.go
goos: linux
goarch: amd64
BenchmarkMutexWithDefer-12       	100000000	        50.2 ns/op	       0 B/op	       0 allocs/op
BenchmarkMutexWithoutDefer-12    	300000000	        16.3 ns/op	       0 B/op	       0 allocs/op
```