### PR TITLE
Revert "Added localhost to net.Listen() calls to avoid macOS firewall dialog."

### DIFF
--- a/Documentation/grpc-auth-support.md
+++ b/Documentation/grpc-auth-support.md
@@ -15,7 +15,7 @@ creds, err := credentials.NewServerTLSFromFile(certFile, keyFile)
 if err != nil {
   log.Fatalf("Failed to generate credentials %v", err)
 }
-lis, err := net.Listen("tcp", "localhost:0")
+lis, err := net.Listen("tcp", ":0")
 server := grpc.NewServer(grpc.Creds(creds))
 ...
 server.Serve(lis)

--- a/benchmark/client/main.go
+++ b/benchmark/client/main.go
@@ -162,7 +162,7 @@ func main() {
 	flag.Parse()
 	grpc.EnableTracing = *trace
 	go func() {
-		lis, err := net.Listen("tcp", "localhost:0")
+		lis, err := net.Listen("tcp", ":0")
 		if err != nil {
 			grpclog.Fatalf("Failed to listen: %v", err)
 		}

--- a/benchmark/latency/latency_test.go
+++ b/benchmark/latency/latency_test.go
@@ -187,7 +187,7 @@ func TestListenerAndDialer(t *testing.T) {
 	}
 
 	// Create a real listener and wrap it.
-	l, err := net.Listen("tcp", "localhost:0")
+	l, err := net.Listen("tcp", ":0")
 	if err != nil {
 		t.Fatalf("Unexpected error creating listener: %v", err)
 	}

--- a/benchmark/server/main.go
+++ b/benchmark/server/main.go
@@ -37,7 +37,7 @@ var (
 func main() {
 	flag.Parse()
 	go func() {
-		lis, err := net.Listen("tcp", "localhost:0")
+		lis, err := net.Listen("tcp", ":0")
 		if err != nil {
 			grpclog.Fatalf("Failed to listen: %v", err)
 		}

--- a/benchmark/worker/main.go
+++ b/benchmark/worker/main.go
@@ -195,7 +195,7 @@ func main() {
 	grpc.EnableTracing = false
 
 	flag.Parse()
-	lis, err := net.Listen("tcp", "localhost:"+strconv.Itoa(*driverPort))
+	lis, err := net.Listen("tcp", ":"+strconv.Itoa(*driverPort))
 	if err != nil {
 		grpclog.Fatalf("failed to listen: %v", err)
 	}

--- a/examples/helloworld/greeter_server/main.go
+++ b/examples/helloworld/greeter_server/main.go
@@ -31,7 +31,7 @@ import (
 )
 
 const (
-	port = "50051"
+	port = ":50051"
 )
 
 // server is used to implement helloworld.GreeterServer.
@@ -43,7 +43,7 @@ func (s *server) SayHello(ctx context.Context, in *pb.HelloRequest) (*pb.HelloRe
 }
 
 func main() {
-	lis, err := net.Listen("tcp", "localhost:"+port)
+	lis, err := net.Listen("tcp", port)
 	if err != nil {
 		log.Fatalf("failed to listen: %v", err)
 	}

--- a/interop/server/server.go
+++ b/interop/server/server.go
@@ -41,7 +41,7 @@ var (
 func main() {
 	flag.Parse()
 	p := strconv.Itoa(*port)
-	lis, err := net.Listen("tcp", "localhost:"+p)
+	lis, err := net.Listen("tcp", ":"+p)
 	if err != nil {
 		grpclog.Fatalf("failed to listen: %v", err)
 	}

--- a/stress/client/main.go
+++ b/stress/client/main.go
@@ -194,7 +194,7 @@ func (s *server) createGauge(name string) *gauge {
 }
 
 func startServer(server *server, port int) {
-	lis, err := net.Listen("tcp", "localhost:"+strconv.Itoa(port))
+	lis, err := net.Listen("tcp", ":"+strconv.Itoa(port))
 	if err != nil {
 		grpclog.Fatalf("failed to listen: %v", err)
 	}


### PR DESCRIPTION
Reverts grpc/grpc-go#1539

This PR may have caused interop failures: https://github.com/grpc/grpc/issues/12723
All clients failed to create connection to go servers.

Could be `localhost` is not handled correctly.