### PR TITLE
Register and use default balancers and resolvers

### DIFF
--- a/balancer/balancer.go
+++ b/balancer/balancer.go
@@ -33,8 +33,6 @@ import (
 var (
 	// m is a map from name to balancer builder.
 	m = make(map[string]Builder)
-	// defaultBuilder is the default balancer to use.
-	defaultBuilder Builder // TODO(bar) install pickfirst as default.
 )
 
 // Register registers the balancer builder to the balancer map.
@@ -44,13 +42,12 @@ func Register(b Builder) {
 }
 
 // Get returns the resolver builder registered with the given name.
-// If no builder is register with the name, the default pickfirst will
-// be used.
+// If no builder is register with the name, nil will be returned.
 func Get(name string) Builder {
 	if b, ok := m[name]; ok {
 		return b
 	}
-	return defaultBuilder
+	return nil
 }
 
 // SubConn represents a gRPC sub connection.

--- a/balancer/roundrobin/roundrobin_test.go
+++ b/balancer/roundrobin/roundrobin_test.go
@@ -37,6 +37,8 @@ import (
 	"google.golang.org/grpc/test/leakcheck"
 )
 
+var rr = balancer.Get("roundrobin")
+
 type testServer struct {
 	testpb.TestServiceServer
 }
@@ -100,10 +102,6 @@ func TestOneBackend(t *testing.T) {
 	}
 	defer test.cleanup()
 
-	rr := balancer.Get("roundrobin")
-	if rr == nil {
-		t.Fatalf("got nil when trying to get roundrobin balancer builder")
-	}
 	cc, err := grpc.Dial(r.Scheme()+":///test.server", grpc.WithInsecure(), grpc.WithBalancerBuilder(rr))
 	if err != nil {
 		t.Fatalf("failed to dial: %v", err)
@@ -136,10 +134,6 @@ func TestBackendsRoundRobin(t *testing.T) {
 	}
 	defer test.cleanup()
 
-	rr := balancer.Get("roundrobin")
-	if rr == nil {
-		t.Fatalf("got nil when trying to get roundrobin balancer builder")
-	}
 	cc, err := grpc.Dial(r.Scheme()+":///test.server", grpc.WithInsecure(), grpc.WithBalancerBuilder(rr))
 	if err != nil {
 		t.Fatalf("failed to dial: %v", err)
@@ -199,10 +193,6 @@ func TestAddressesRemoved(t *testing.T) {
 	}
 	defer test.cleanup()
 
-	rr := balancer.Get("roundrobin")
-	if rr == nil {
-		t.Fatalf("got nil when trying to get roundrobin balancer builder")
-	}
 	cc, err := grpc.Dial(r.Scheme()+":///test.server", grpc.WithInsecure(), grpc.WithBalancerBuilder(rr))
 	if err != nil {
 		t.Fatalf("failed to dial: %v", err)
@@ -245,10 +235,6 @@ func TestCloseWithPendingRPC(t *testing.T) {
 	}
 	defer test.cleanup()
 
-	rr := balancer.Get("roundrobin")
-	if rr == nil {
-		t.Fatalf("got nil when trying to get roundrobin balancer builder")
-	}
 	cc, err := grpc.Dial(r.Scheme()+":///test.server", grpc.WithInsecure(), grpc.WithBalancerBuilder(rr))
 	if err != nil {
 		t.Fatalf("failed to dial: %v", err)
@@ -283,10 +269,6 @@ func TestNewAddressWhileBlocking(t *testing.T) {
 	}
 	defer test.cleanup()
 
-	rr := balancer.Get("roundrobin")
-	if rr == nil {
-		t.Fatalf("got nil when trying to get roundrobin balancer builder")
-	}
 	cc, err := grpc.Dial(r.Scheme()+":///test.server", grpc.WithInsecure(), grpc.WithBalancerBuilder(rr))
 	if err != nil {
 		t.Fatalf("failed to dial: %v", err)
@@ -336,10 +318,6 @@ func TestOneServerDown(t *testing.T) {
 	}
 	defer test.cleanup()
 
-	rr := balancer.Get("roundrobin")
-	if rr == nil {
-		t.Fatalf("got nil when trying to get roundrobin balancer builder")
-	}
 	cc, err := grpc.Dial(r.Scheme()+":///test.server", grpc.WithInsecure(), grpc.WithBalancerBuilder(rr))
 	if err != nil {
 		t.Fatalf("failed to dial: %v", err)
@@ -433,10 +411,6 @@ func TestAllServersDown(t *testing.T) {
 	}
 	defer test.cleanup()
 
-	rr := balancer.Get("roundrobin")
-	if rr == nil {
-		t.Fatalf("got nil when trying to get roundrobin balancer builder")
-	}
 	cc, err := grpc.Dial(r.Scheme()+":///test.server", grpc.WithInsecure(), grpc.WithBalancerBuilder(rr))
 	if err != nil {
 		t.Fatalf("failed to dial: %v", err)

--- a/balancer/roundrobin/roundrobin_test.go
+++ b/balancer/roundrobin/roundrobin_test.go
@@ -16,7 +16,7 @@
  *
  */
 
-package roundrobin
+package roundrobin_test
 
 import (
 	"fmt"
@@ -27,6 +27,7 @@ import (
 
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/balancer"
 	"google.golang.org/grpc/codes"
 	_ "google.golang.org/grpc/grpclog/glogger"
 	"google.golang.org/grpc/peer"
@@ -99,7 +100,11 @@ func TestOneBackend(t *testing.T) {
 	}
 	defer test.cleanup()
 
-	cc, err := grpc.Dial(r.Scheme()+":///test.server", grpc.WithInsecure(), grpc.WithBalancerBuilder(newBuilder()))
+	rr := balancer.Get("roundrobin")
+	if rr == nil {
+		t.Fatalf("got nil when trying to get roundrobin balancer builder")
+	}
+	cc, err := grpc.Dial(r.Scheme()+":///test.server", grpc.WithInsecure(), grpc.WithBalancerBuilder(rr))
 	if err != nil {
 		t.Fatalf("failed to dial: %v", err)
 	}
@@ -131,7 +136,11 @@ func TestBackendsRoundRobin(t *testing.T) {
 	}
 	defer test.cleanup()
 
-	cc, err := grpc.Dial(r.Scheme()+":///test.server", grpc.WithInsecure(), grpc.WithBalancerBuilder(newBuilder()))
+	rr := balancer.Get("roundrobin")
+	if rr == nil {
+		t.Fatalf("got nil when trying to get roundrobin balancer builder")
+	}
+	cc, err := grpc.Dial(r.Scheme()+":///test.server", grpc.WithInsecure(), grpc.WithBalancerBuilder(rr))
 	if err != nil {
 		t.Fatalf("failed to dial: %v", err)
 	}
@@ -190,7 +199,11 @@ func TestAddressesRemoved(t *testing.T) {
 	}
 	defer test.cleanup()
 
-	cc, err := grpc.Dial(r.Scheme()+":///test.server", grpc.WithInsecure(), grpc.WithBalancerBuilder(newBuilder()))
+	rr := balancer.Get("roundrobin")
+	if rr == nil {
+		t.Fatalf("got nil when trying to get roundrobin balancer builder")
+	}
+	cc, err := grpc.Dial(r.Scheme()+":///test.server", grpc.WithInsecure(), grpc.WithBalancerBuilder(rr))
 	if err != nil {
 		t.Fatalf("failed to dial: %v", err)
 	}
@@ -232,7 +245,11 @@ func TestCloseWithPendingRPC(t *testing.T) {
 	}
 	defer test.cleanup()
 
-	cc, err := grpc.Dial(r.Scheme()+":///test.server", grpc.WithInsecure(), grpc.WithBalancerBuilder(newBuilder()))
+	rr := balancer.Get("roundrobin")
+	if rr == nil {
+		t.Fatalf("got nil when trying to get roundrobin balancer builder")
+	}
+	cc, err := grpc.Dial(r.Scheme()+":///test.server", grpc.WithInsecure(), grpc.WithBalancerBuilder(rr))
 	if err != nil {
 		t.Fatalf("failed to dial: %v", err)
 	}
@@ -266,7 +283,11 @@ func TestNewAddressWhileBlocking(t *testing.T) {
 	}
 	defer test.cleanup()
 
-	cc, err := grpc.Dial(r.Scheme()+":///test.server", grpc.WithInsecure(), grpc.WithBalancerBuilder(newBuilder()))
+	rr := balancer.Get("roundrobin")
+	if rr == nil {
+		t.Fatalf("got nil when trying to get roundrobin balancer builder")
+	}
+	cc, err := grpc.Dial(r.Scheme()+":///test.server", grpc.WithInsecure(), grpc.WithBalancerBuilder(rr))
 	if err != nil {
 		t.Fatalf("failed to dial: %v", err)
 	}
@@ -315,7 +336,11 @@ func TestOneServerDown(t *testing.T) {
 	}
 	defer test.cleanup()
 
-	cc, err := grpc.Dial(r.Scheme()+":///test.server", grpc.WithInsecure(), grpc.WithBalancerBuilder(newBuilder()))
+	rr := balancer.Get("roundrobin")
+	if rr == nil {
+		t.Fatalf("got nil when trying to get roundrobin balancer builder")
+	}
+	cc, err := grpc.Dial(r.Scheme()+":///test.server", grpc.WithInsecure(), grpc.WithBalancerBuilder(rr))
 	if err != nil {
 		t.Fatalf("failed to dial: %v", err)
 	}
@@ -408,7 +433,11 @@ func TestAllServersDown(t *testing.T) {
 	}
 	defer test.cleanup()
 
-	cc, err := grpc.Dial(r.Scheme()+":///test.server", grpc.WithInsecure(), grpc.WithBalancerBuilder(newBuilder()))
+	rr := balancer.Get("roundrobin")
+	if rr == nil {
+		t.Fatalf("got nil when trying to get roundrobin balancer builder")
+	}
+	cc, err := grpc.Dial(r.Scheme()+":///test.server", grpc.WithInsecure(), grpc.WithBalancerBuilder(rr))
 	if err != nil {
 		t.Fatalf("failed to dial: %v", err)
 	}

--- a/balancer_conn_wrappers.go
+++ b/balancer_conn_wrappers.go
@@ -189,7 +189,9 @@ func (ccb *ccBalancerWrapper) NewSubConn(addrs []resolver.Address, opts balancer
 		return nil, err
 	}
 	acbw := &acBalancerWrapper{ac: ac}
+	acbw.ac.mu.Lock()
 	ac.acbw = acbw
+	acbw.ac.mu.Unlock()
 	ccb.subConns[acbw] = struct{}{}
 	return acbw, nil
 }

--- a/balancer_conn_wrappers.go
+++ b/balancer_conn_wrappers.go
@@ -73,7 +73,7 @@ func (b *scStateUpdateBuffer) load() {
 	}
 }
 
-// get returns the channel that receives a recvMsg in the buffer.
+// get returns the channel that the scStateUpdate will be sent to.
 //
 // Upon receiving, the caller should call load to send another
 // scStateChangeTuple onto the channel if there is any.

--- a/balancer_switching_test.go
+++ b/balancer_switching_test.go
@@ -1,0 +1,98 @@
+/*
+ *
+ * Copyright 2017 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package grpc
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"golang.org/x/net/context"
+	_ "google.golang.org/grpc/balancer/roundrobin" // To register roundrobin.
+	"google.golang.org/grpc/resolver"
+	"google.golang.org/grpc/resolver/manual"
+	"google.golang.org/grpc/test/leakcheck"
+)
+
+func checkPickFirst(cc *ClientConn, servers []*server, t *testing.T) {
+	var (
+		req   = "port"
+		reply string
+		err   error
+	)
+	// The second RPC should succeed with the first server.
+	for i := 0; i < 1000; i++ {
+		if err = Invoke(context.Background(), "/foo/bar", &req, &reply, cc); err != nil && ErrorDesc(err) == servers[0].port {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("EmptyCall() = _, %v, want _, %v", err, servers[0].port)
+}
+
+func checkRoundRobin(cc *ClientConn, servers []*server, t *testing.T) {
+	var (
+		req   = "port"
+		reply string
+		err   error
+	)
+
+	// Make sure connections to all servers are up.
+	for _, s := range servers {
+		for {
+			if err = Invoke(context.Background(), "/foo/bar", &req, &reply, cc); err != nil && ErrorDesc(err) == s.port {
+				break
+			}
+			time.Sleep(time.Millisecond)
+		}
+	}
+
+	serverCount := len(servers)
+	for i := 0; i < 3*serverCount; i++ {
+		err = Invoke(context.Background(), "/foo/bar", &req, &reply, cc)
+		if ErrorDesc(err) != servers[i%serverCount].port {
+			t.Fatalf("Index %d: want peer %v, got peer %v", i, servers[i%serverCount].port, err)
+		}
+	}
+}
+
+func TestSwitchBalancer(t *testing.T) {
+	defer leakcheck.Check(t)
+	r, rcleanup := manual.GenerateAndRegisterManualResolver()
+	defer rcleanup()
+
+	numServers := 2
+	servers, _, scleanup := startServers(t, numServers, math.MaxInt32)
+	defer scleanup()
+
+	cc, err := Dial(r.Scheme()+":///test.server", WithInsecure(), WithCodec(testCodec{}))
+	if err != nil {
+		t.Fatalf("failed to dial: %v", err)
+	}
+	defer cc.Close()
+	r.NewAddress([]resolver.Address{{Addr: servers[0].addr}, {Addr: servers[1].addr}})
+	// The default balancer is pickfirst.
+	checkPickFirst(cc, servers, t)
+	// Switch to roundrobin.
+	cc.switchBalancer("roundrobin")
+	checkRoundRobin(cc, servers, t)
+	// Switch to pickfirst.
+	cc.switchBalancer("pickfirst")
+	checkPickFirst(cc, servers, t)
+}

--- a/balancer_switching_test.go
+++ b/balancer_switching_test.go
@@ -24,7 +24,6 @@ import (
 	"time"
 
 	"golang.org/x/net/context"
-	_ "google.golang.org/grpc/balancer/roundrobin" // To register roundrobin.
 	"google.golang.org/grpc/resolver"
 	"google.golang.org/grpc/resolver/manual"
 	"google.golang.org/grpc/test/leakcheck"

--- a/balancer_test.go
+++ b/balancer_test.go
@@ -31,6 +31,10 @@ import (
 	_ "google.golang.org/grpc/grpclog/glogger"
 	"google.golang.org/grpc/naming"
 	"google.golang.org/grpc/test/leakcheck"
+
+	// V1 balancer tests use passthrough resolver instead of dns.
+	// TODO(bar) remove this when removing v1 balaner entirely.
+	_ "google.golang.org/grpc/resolver/passthrough"
 )
 
 type testWatcher struct {
@@ -117,7 +121,7 @@ func TestNameDiscovery(t *testing.T) {
 	numServers := 2
 	servers, r, cleanup := startServers(t, numServers, math.MaxUint32)
 	defer cleanup()
-	cc, err := Dial("foo.bar.com", WithBalancer(RoundRobin(r)), WithBlock(), WithInsecure(), WithCodec(testCodec{}))
+	cc, err := Dial("passthrough:///foo.bar.com", WithBalancer(RoundRobin(r)), WithBlock(), WithInsecure(), WithCodec(testCodec{}))
 	if err != nil {
 		t.Fatalf("Failed to create ClientConn: %v", err)
 	}
@@ -151,7 +155,7 @@ func TestEmptyAddrs(t *testing.T) {
 	defer leakcheck.Check(t)
 	servers, r, cleanup := startServers(t, 1, math.MaxUint32)
 	defer cleanup()
-	cc, err := Dial("foo.bar.com", WithBalancer(RoundRobin(r)), WithBlock(), WithInsecure(), WithCodec(testCodec{}))
+	cc, err := Dial("passthrough:///foo.bar.com", WithBalancer(RoundRobin(r)), WithBlock(), WithInsecure(), WithCodec(testCodec{}))
 	if err != nil {
 		t.Fatalf("Failed to create ClientConn: %v", err)
 	}
@@ -185,7 +189,7 @@ func TestRoundRobin(t *testing.T) {
 	numServers := 3
 	servers, r, cleanup := startServers(t, numServers, math.MaxUint32)
 	defer cleanup()
-	cc, err := Dial("foo.bar.com", WithBalancer(RoundRobin(r)), WithBlock(), WithInsecure(), WithCodec(testCodec{}))
+	cc, err := Dial("passthrough:///foo.bar.com", WithBalancer(RoundRobin(r)), WithBlock(), WithInsecure(), WithCodec(testCodec{}))
 	if err != nil {
 		t.Fatalf("Failed to create ClientConn: %v", err)
 	}
@@ -230,7 +234,7 @@ func TestCloseWithPendingRPC(t *testing.T) {
 	defer leakcheck.Check(t)
 	servers, r, cleanup := startServers(t, 1, math.MaxUint32)
 	defer cleanup()
-	cc, err := Dial("foo.bar.com", WithBalancer(RoundRobin(r)), WithBlock(), WithInsecure(), WithCodec(testCodec{}))
+	cc, err := Dial("passthrough:///foo.bar.com", WithBalancer(RoundRobin(r)), WithBlock(), WithInsecure(), WithCodec(testCodec{}))
 	if err != nil {
 		t.Fatalf("Failed to create ClientConn: %v", err)
 	}
@@ -282,7 +286,7 @@ func TestGetOnWaitChannel(t *testing.T) {
 	defer leakcheck.Check(t)
 	servers, r, cleanup := startServers(t, 1, math.MaxUint32)
 	defer cleanup()
-	cc, err := Dial("foo.bar.com", WithBalancer(RoundRobin(r)), WithBlock(), WithInsecure(), WithCodec(testCodec{}))
+	cc, err := Dial("passthrough:///foo.bar.com", WithBalancer(RoundRobin(r)), WithBlock(), WithInsecure(), WithCodec(testCodec{}))
 	if err != nil {
 		t.Fatalf("Failed to create ClientConn: %v", err)
 	}
@@ -328,7 +332,7 @@ func TestOneServerDown(t *testing.T) {
 	numServers := 2
 	servers, r, cleanup := startServers(t, numServers, math.MaxUint32)
 	defer cleanup()
-	cc, err := Dial("foo.bar.com", WithBalancer(RoundRobin(r)), WithBlock(), WithInsecure(), WithCodec(testCodec{}))
+	cc, err := Dial("passthrough:///foo.bar.com", WithBalancer(RoundRobin(r)), WithBlock(), WithInsecure(), WithCodec(testCodec{}))
 	if err != nil {
 		t.Fatalf("Failed to create ClientConn: %v", err)
 	}
@@ -381,7 +385,7 @@ func TestOneAddressRemoval(t *testing.T) {
 	numServers := 2
 	servers, r, cleanup := startServers(t, numServers, math.MaxUint32)
 	defer cleanup()
-	cc, err := Dial("foo.bar.com", WithBalancer(RoundRobin(r)), WithBlock(), WithInsecure(), WithCodec(testCodec{}))
+	cc, err := Dial("passthrough:///foo.bar.com", WithBalancer(RoundRobin(r)), WithBlock(), WithInsecure(), WithCodec(testCodec{}))
 	if err != nil {
 		t.Fatalf("Failed to create ClientConn: %v", err)
 	}
@@ -439,7 +443,7 @@ func TestOneAddressRemoval(t *testing.T) {
 func checkServerUp(t *testing.T, currentServer *server) {
 	req := "port"
 	port := currentServer.port
-	cc, err := Dial("localhost:"+port, WithBlock(), WithInsecure(), WithCodec(testCodec{}))
+	cc, err := Dial("passthrough:///localhost:"+port, WithBlock(), WithInsecure(), WithCodec(testCodec{}))
 	if err != nil {
 		t.Fatalf("Failed to create ClientConn: %v", err)
 	}
@@ -457,7 +461,7 @@ func TestPickFirstEmptyAddrs(t *testing.T) {
 	defer leakcheck.Check(t)
 	servers, r, cleanup := startServers(t, 1, math.MaxUint32)
 	defer cleanup()
-	cc, err := Dial("foo.bar.com", WithBalancer(pickFirstBalancerV1(r)), WithBlock(), WithInsecure(), WithCodec(testCodec{}))
+	cc, err := Dial("passthrough:///foo.bar.com", WithBalancer(pickFirstBalancerV1(r)), WithBlock(), WithInsecure(), WithCodec(testCodec{}))
 	if err != nil {
 		t.Fatalf("Failed to create ClientConn: %v", err)
 	}
@@ -489,7 +493,7 @@ func TestPickFirstCloseWithPendingRPC(t *testing.T) {
 	defer leakcheck.Check(t)
 	servers, r, cleanup := startServers(t, 1, math.MaxUint32)
 	defer cleanup()
-	cc, err := Dial("foo.bar.com", WithBalancer(pickFirstBalancerV1(r)), WithBlock(), WithInsecure(), WithCodec(testCodec{}))
+	cc, err := Dial("passthrough:///foo.bar.com", WithBalancer(pickFirstBalancerV1(r)), WithBlock(), WithInsecure(), WithCodec(testCodec{}))
 	if err != nil {
 		t.Fatalf("Failed to create ClientConn: %v", err)
 	}
@@ -543,7 +547,7 @@ func TestPickFirstOrderAllServerUp(t *testing.T) {
 	numServers := 3
 	servers, r, cleanup := startServers(t, numServers, math.MaxUint32)
 	defer cleanup()
-	cc, err := Dial("foo.bar.com", WithBalancer(pickFirstBalancerV1(r)), WithBlock(), WithInsecure(), WithCodec(testCodec{}))
+	cc, err := Dial("passthrough:///foo.bar.com", WithBalancer(pickFirstBalancerV1(r)), WithBlock(), WithInsecure(), WithCodec(testCodec{}))
 	if err != nil {
 		t.Fatalf("Failed to create ClientConn: %v", err)
 	}
@@ -656,7 +660,7 @@ func TestPickFirstOrderOneServerDown(t *testing.T) {
 	numServers := 3
 	servers, r, cleanup := startServers(t, numServers, math.MaxUint32)
 	defer cleanup()
-	cc, err := Dial("foo.bar.com", WithBalancer(pickFirstBalancerV1(r)), WithBlock(), WithInsecure(), WithCodec(testCodec{}))
+	cc, err := Dial("passthrough:///foo.bar.com", WithBalancer(pickFirstBalancerV1(r)), WithBlock(), WithInsecure(), WithCodec(testCodec{}))
 	if err != nil {
 		t.Fatalf("Failed to create ClientConn: %v", err)
 	}
@@ -747,7 +751,7 @@ func TestPickFirstOneAddressRemoval(t *testing.T) {
 	numServers := 2
 	servers, r, cleanup := startServers(t, numServers, math.MaxUint32)
 	defer cleanup()
-	cc, err := Dial("localhost:"+servers[0].port, WithBalancer(pickFirstBalancerV1(r)), WithBlock(), WithInsecure(), WithCodec(testCodec{}))
+	cc, err := Dial("passthrough:///localhost:"+servers[0].port, WithBalancer(pickFirstBalancerV1(r)), WithBlock(), WithInsecure(), WithCodec(testCodec{}))
 	if err != nil {
 		t.Fatalf("Failed to create ClientConn: %v", err)
 	}

--- a/balancer_v1_wrapper.go
+++ b/balancer_v1_wrapper.go
@@ -19,6 +19,7 @@
 package grpc
 
 import (
+	"strings"
 	"sync"
 
 	"golang.org/x/net/context"
@@ -34,20 +35,27 @@ type balancerWrapperBuilder struct {
 }
 
 func (bwb *balancerWrapperBuilder) Build(cc balancer.ClientConn, opts balancer.BuildOptions) balancer.Balancer {
-	bwb.b.Start(cc.Target(), BalancerConfig{
+	targetAddr := cc.Target()
+	targetSplitted := strings.Split(targetAddr, ":///")
+	if len(targetSplitted) >= 2 {
+		targetAddr = targetSplitted[1]
+	}
+
+	bwb.b.Start(targetAddr, BalancerConfig{
 		DialCreds: opts.DialCreds,
 		Dialer:    opts.Dialer,
 	})
 	_, pickfirst := bwb.b.(*pickFirst)
 	bw := &balancerWrapper{
-		balancer:  bwb.b,
-		pickfirst: pickfirst,
-		cc:        cc,
-		startCh:   make(chan struct{}),
-		conns:     make(map[resolver.Address]balancer.SubConn),
-		connSt:    make(map[balancer.SubConn]*scState),
-		csEvltr:   &connectivityStateEvaluator{},
-		state:     connectivity.Idle,
+		balancer:   bwb.b,
+		pickfirst:  pickfirst,
+		cc:         cc,
+		targetAddr: targetAddr,
+		startCh:    make(chan struct{}),
+		conns:      make(map[resolver.Address]balancer.SubConn),
+		connSt:     make(map[balancer.SubConn]*scState),
+		csEvltr:    &connectivityStateEvaluator{},
+		state:      connectivity.Idle,
 	}
 	cc.UpdateBalancerState(connectivity.Idle, bw)
 	go bw.lbWatcher()
@@ -68,7 +76,8 @@ type balancerWrapper struct {
 	balancer  Balancer // The v1 balancer.
 	pickfirst bool
 
-	cc balancer.ClientConn
+	cc         balancer.ClientConn
+	targetAddr string // Target without the scheme.
 
 	// To aggregate the connectivity state.
 	csEvltr *connectivityStateEvaluator
@@ -93,7 +102,7 @@ func (bw *balancerWrapper) lbWatcher() {
 	if notifyCh == nil {
 		// There's no resolver in the balancer. Connect directly.
 		a := resolver.Address{
-			Addr: bw.cc.Target(),
+			Addr: bw.targetAddr,
 			Type: resolver.Backend,
 		}
 		sc, err := bw.cc.NewSubConn([]resolver.Address{a}, balancer.NewSubConnOptions{})
@@ -103,7 +112,7 @@ func (bw *balancerWrapper) lbWatcher() {
 			bw.mu.Lock()
 			bw.conns[a] = sc
 			bw.connSt[sc] = &scState{
-				addr: Address{Addr: bw.cc.Target()},
+				addr: Address{Addr: bw.targetAddr},
 				s:    connectivity.Idle,
 			}
 			bw.mu.Unlock()

--- a/clientconn.go
+++ b/clientconn.go
@@ -600,11 +600,10 @@ func (cc *ClientConn) scWatcher() {
 
 func (cc *ClientConn) handleResolvedAddrs(addrs []resolver.Address, err error) {
 	cc.mu.Lock()
+	defer cc.mu.Unlock()
 	if cc.conns == nil {
-		cc.mu.Unlock()
 		return
 	}
-	defer cc.mu.Unlock()
 
 	// TODO(bar switching) when grpclb is submitted, check address type and start grpclb.
 	if !cc.customBalancer && cc.balancerWrapper == nil {

--- a/clientconn.go
+++ b/clientconn.go
@@ -31,17 +31,15 @@ import (
 	"golang.org/x/net/context"
 	"golang.org/x/net/trace"
 	"google.golang.org/grpc/balancer"
+	_ "google.golang.org/grpc/balancer/roundrobin" // To register roundrobin.
 	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/grpclog"
 	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/resolver"
+	_ "google.golang.org/grpc/resolver/dns" // To register dns resolver.
 	"google.golang.org/grpc/stats"
 	"google.golang.org/grpc/transport"
-
-	// TODO(bar switching) remove this when dns is imported by grpc.
-	// and remove the init() in passthrough package.
-	_ "google.golang.org/grpc/resolver/passthrough"
 )
 
 var (
@@ -608,7 +606,7 @@ func (cc *ClientConn) handleResolvedAddrs(addrs []resolver.Address, err error) {
 	}
 	defer cc.mu.Unlock()
 
-	// TODO(bar switching) check address type and start grpclb.
+	// TODO(bar switching) when grpclb is submitted, check address type and start grpclb.
 	if !cc.customBalancer && cc.balancerWrapper == nil {
 		// No customBalancer was specified by DialOption, and this is the first
 		// time handling resolved addresses, create a pickfirst balancer.
@@ -617,7 +615,7 @@ func (cc *ClientConn) handleResolvedAddrs(addrs []resolver.Address, err error) {
 		cc.balancerWrapper = newCCBalancerWrapper(cc, builder, cc.balancerBuildOpts)
 	}
 
-	// TODO(bar) compare addresses, if there's no update, don't notify balancer.
+	// TODO(bar switching) compare addresses, if there's no update, don't notify balancer.
 	cc.curAddresses = addrs
 	cc.balancerWrapper.handleResolvedAddrs(addrs, nil)
 }
@@ -662,6 +660,8 @@ func (cc *ClientConn) handleSubConnStateChange(sc balancer.SubConn, s connectivi
 		return
 	}
 	defer cc.mu.Unlock()
+	// TODO(bar switching) send updates to all balancer wrappers when balancer
+	// gracefully switching is supported.
 	cc.balancerWrapper.handleSubConnStateChange(sc, s)
 }
 

--- a/clientconn_test.go
+++ b/clientconn_test.go
@@ -30,6 +30,7 @@ import (
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/naming"
+	_ "google.golang.org/grpc/resolver/passthrough"
 	"google.golang.org/grpc/test/leakcheck"
 	"google.golang.org/grpc/testdata"
 )
@@ -47,7 +48,7 @@ func TestConnectivityStates(t *testing.T) {
 	defer leakcheck.Check(t)
 	servers, resolver, cleanup := startServers(t, 2, math.MaxUint32)
 	defer cleanup()
-	cc, err := Dial("foo.bar.com", WithBalancer(RoundRobin(resolver)), WithInsecure())
+	cc, err := Dial("passthrough:///foo.bar.com", WithBalancer(RoundRobin(resolver)), WithInsecure())
 	if err != nil {
 		t.Fatalf("Dial(\"foo.bar.com\", WithBalancer(_)) = _, %v, want _ <nil>", err)
 	}
@@ -82,7 +83,7 @@ func TestConnectivityStates(t *testing.T) {
 
 func TestDialTimeout(t *testing.T) {
 	defer leakcheck.Check(t)
-	conn, err := Dial("Non-Existent.Server:80", WithTimeout(time.Millisecond), WithBlock(), WithInsecure())
+	conn, err := Dial("passthrough:///Non-Existent.Server:80", WithTimeout(time.Millisecond), WithBlock(), WithInsecure())
 	if err == nil {
 		conn.Close()
 	}
@@ -97,7 +98,7 @@ func TestTLSDialTimeout(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create credentials %v", err)
 	}
-	conn, err := Dial("Non-Existent.Server:80", WithTransportCredentials(creds), WithTimeout(time.Millisecond), WithBlock())
+	conn, err := Dial("passthrough:///Non-Existent.Server:80", WithTransportCredentials(creds), WithTimeout(time.Millisecond), WithBlock())
 	if err == nil {
 		conn.Close()
 	}
@@ -126,7 +127,7 @@ func TestTLSServerNameOverwrite(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create credentials %v", err)
 	}
-	conn, err := Dial("Non-Existent.Server:80", WithTransportCredentials(creds))
+	conn, err := Dial("passthrough:///Non-Existent.Server:80", WithTransportCredentials(creds))
 	if err != nil {
 		t.Fatalf("Dial(_, _) = _, %v, want _, <nil>", err)
 	}
@@ -139,7 +140,7 @@ func TestTLSServerNameOverwrite(t *testing.T) {
 func TestWithAuthority(t *testing.T) {
 	defer leakcheck.Check(t)
 	overwriteServerName := "over.write.server.name"
-	conn, err := Dial("Non-Existent.Server:80", WithInsecure(), WithAuthority(overwriteServerName))
+	conn, err := Dial("passthrough:///Non-Existent.Server:80", WithInsecure(), WithAuthority(overwriteServerName))
 	if err != nil {
 		t.Fatalf("Dial(_, _) = _, %v, want _, <nil>", err)
 	}
@@ -156,7 +157,7 @@ func TestWithAuthorityAndTLS(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create credentials %v", err)
 	}
-	conn, err := Dial("Non-Existent.Server:80", WithTransportCredentials(creds), WithAuthority("no.effect.authority"))
+	conn, err := Dial("passthrough:///Non-Existent.Server:80", WithTransportCredentials(creds), WithAuthority("no.effect.authority"))
 	if err != nil {
 		t.Fatalf("Dial(_, _) = _, %v, want _, <nil>", err)
 	}
@@ -231,11 +232,11 @@ func TestCredentialsMisuse(t *testing.T) {
 		t.Fatalf("Failed to create authenticator %v", err)
 	}
 	// Two conflicting credential configurations
-	if _, err := Dial("Non-Existent.Server:80", WithTransportCredentials(tlsCreds), WithBlock(), WithInsecure()); err != errCredentialsConflict {
+	if _, err := Dial("passthrough:///Non-Existent.Server:80", WithTransportCredentials(tlsCreds), WithBlock(), WithInsecure()); err != errCredentialsConflict {
 		t.Fatalf("Dial(_, _) = _, %v, want _, %v", err, errCredentialsConflict)
 	}
 	// security info on insecure connection
-	if _, err := Dial("Non-Existent.Server:80", WithPerRPCCredentials(securePerRPCCredentials{}), WithBlock(), WithInsecure()); err != errTransportCredentialsMissing {
+	if _, err := Dial("passthrough:///Non-Existent.Server:80", WithPerRPCCredentials(securePerRPCCredentials{}), WithBlock(), WithInsecure()); err != errTransportCredentialsMissing {
 		t.Fatalf("Dial(_, _) = _, %v, want _, %v", err, errTransportCredentialsMissing)
 	}
 }
@@ -263,7 +264,7 @@ func TestWithBackoffMaxDelay(t *testing.T) {
 
 func testBackoffConfigSet(t *testing.T, expected *BackoffConfig, opts ...DialOption) {
 	opts = append(opts, WithInsecure())
-	conn, err := Dial("foo:80", opts...)
+	conn, err := Dial("passthrough:///foo:80", opts...)
 	if err != nil {
 		t.Fatalf("unexpected error dialing connection: %v", err)
 	}

--- a/pickfirst.go
+++ b/pickfirst.go
@@ -57,14 +57,20 @@ func (b *pickfirstBalancer) HandleResolvedAddrs(addrs []resolver.Address, err er
 			return
 		}
 		b.cc.UpdateBalancerState(connectivity.Idle, &picker{sc: b.sc})
+		b.sc.Connect()
 	} else {
 		b.sc.UpdateAddresses(addrs)
+		b.sc.Connect()
 	}
 }
 
 func (b *pickfirstBalancer) HandleSubConnStateChange(sc balancer.SubConn, s connectivity.State) {
 	grpclog.Infof("pickfirstBalancer: HandleSubConnStateChange: %p, %v", sc, s)
-	if b.sc != sc || s == connectivity.Shutdown {
+	if b.sc != sc {
+		grpclog.Infof("pickfirstBalancer: ignored state change because sc is not recognized")
+		return
+	}
+	if s == connectivity.Shutdown {
 		b.sc = nil
 		return
 	}
@@ -92,4 +98,8 @@ func (p *picker) Pick(ctx context.Context, opts balancer.PickOptions) (balancer.
 		return nil, nil, p.err
 	}
 	return p.sc, nil, nil
+}
+
+func init() {
+	balancer.Register(newPickfirstBuilder())
 }

--- a/resolver/passthrough/passthrough.go
+++ b/resolver/passthrough/passthrough.go
@@ -56,3 +56,16 @@ func (*passthroughResolver) Close() {}
 func init() {
 	resolver.Register(&passthroughBuilder{})
 }
+
+// TODO(bar switching) remove this when dns resolver is installed!!!
+type fakeDNSBuilder struct {
+	passthroughBuilder
+}
+
+func (*fakeDNSBuilder) Scheme() string {
+	return "dns"
+}
+
+func init() {
+	resolver.Register(&fakeDNSBuilder{})
+}

--- a/resolver/passthrough/passthrough.go
+++ b/resolver/passthrough/passthrough.go
@@ -56,16 +56,3 @@ func (*passthroughResolver) Close() {}
 func init() {
 	resolver.Register(&passthroughBuilder{})
 }
-
-// TODO(bar switching) remove this when dns resolver is installed!!!
-type fakeDNSBuilder struct {
-	passthroughBuilder
-}
-
-func (*fakeDNSBuilder) Scheme() string {
-	return "dns"
-}
-
-func init() {
-	resolver.Register(&fakeDNSBuilder{})
-}

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -24,7 +24,7 @@ var (
 	// m is a map from scheme to resolver builder.
 	m = make(map[string]Builder)
 	// defaultScheme is the default scheme to use.
-	defaultScheme string
+	defaultScheme = "dns"
 )
 
 // TODO(bar) install dns resolver in init(){}.

--- a/resolver_conn_wrapper.go
+++ b/resolver_conn_wrapper.go
@@ -63,7 +63,7 @@ func newCCResolverWrapper(cc *ClientConn) (*ccResolverWrapper, error) {
 
 	rb := resolver.Get(target.Scheme)
 	if rb == nil {
-		return nil, fmt.Errorf("could not get resolver for scheme: %q", scheme)
+		return nil, fmt.Errorf("could not get resolver for scheme: %q", target.Scheme)
 	}
 
 	ccr := &ccResolverWrapper{

--- a/resolver_conn_wrapper.go
+++ b/resolver_conn_wrapper.go
@@ -19,6 +19,7 @@
 package grpc
 
 import (
+	"fmt"
 	"strings"
 
 	"google.golang.org/grpc/grpclog"
@@ -56,19 +57,13 @@ func parseTarget(target string) (ret resolver.Target) {
 // newCCResolverWrapper parses cc.target for scheme and gets the resolver
 // builder for this scheme. It then builds the resolver and starts the
 // monitoring goroutine for it.
-//
-// This function could return nil, nil, in tests for old behaviors.
-// TODO(bar) never return nil, nil when DNS becomes the default resolver.
 func newCCResolverWrapper(cc *ClientConn) (*ccResolverWrapper, error) {
 	target := parseTarget(cc.target)
 	grpclog.Infof("dialing to target with scheme: %q", target.Scheme)
 
 	rb := resolver.Get(target.Scheme)
 	if rb == nil {
-		// TODO(bar) return error when DNS becomes the default (implemented and
-		// registered by DNS package).
-		grpclog.Infof("could not get resolver for scheme: %q", target.Scheme)
-		return nil, nil
+		return nil, fmt.Errorf("could not get resolver for scheme: %q", scheme)
 	}
 
 	ccr := &ccResolverWrapper{
@@ -100,13 +95,19 @@ func (ccr *ccResolverWrapper) watcher() {
 
 		select {
 		case addrs := <-ccr.addrCh:
-			grpclog.Infof("ccResolverWrapper: sending new addresses to balancer wrapper: %v", addrs)
-			// TODO(bar switching) this should never be nil. Pickfirst should be default.
-			if ccr.cc.balancerWrapper != nil {
-				// TODO(bar switching) create balancer if it's nil?
-				ccr.cc.balancerWrapper.handleResolvedAddrs(addrs, nil)
+			select {
+			case <-ccr.done:
+				return
+			default:
 			}
+			grpclog.Infof("ccResolverWrapper: sending new addresses to cc: %v", addrs)
+			ccr.cc.handleResolvedAddrs(addrs, nil)
 		case sc := <-ccr.scCh:
+			select {
+			case <-ccr.done:
+				return
+			default:
+			}
 			grpclog.Infof("ccResolverWrapper: got new service config: %v", sc)
 		case <-ccr.done:
 			return

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -559,8 +559,6 @@ func (te *test) startServer(ts testpb.TestServiceServer) {
 			te.t.Fatalf("Failed to generate credentials %v", err)
 		}
 		sopts = append(sopts, grpc.Creds(creds))
-	case "clientAlwaysFailCred":
-		sopts = append(sopts, grpc.Creds(clientAlwaysFailCred{}))
 	case "clientTimeoutCreds":
 		sopts = append(sopts, grpc.Creds(&clientTimeoutCreds{}))
 	}
@@ -634,8 +632,6 @@ func (te *test) clientConn() *grpc.ClientConn {
 			te.t.Fatalf("Failed to load credentials: %v", err)
 		}
 		opts = append(opts, grpc.WithTransportCredentials(creds))
-	case "clientAlwaysFailCred":
-		opts = append(opts, grpc.WithTransportCredentials(clientAlwaysFailCred{}))
 	case "clientTimeoutCreds":
 		opts = append(opts, grpc.WithTransportCredentials(&clientTimeoutCreds{}))
 	default:
@@ -4066,44 +4062,6 @@ func testClientRequestBodyErrorCancelStreamingInput(t *testing.T, e env) {
 			t.Errorf("error = %#v; want error code %s", got, codes.Canceled)
 		}
 	})
-}
-
-const clientAlwaysFailCredErrorMsg = "clientAlwaysFailCred always fails"
-
-var errClientAlwaysFailCred = errors.New(clientAlwaysFailCredErrorMsg)
-
-type clientAlwaysFailCred struct{}
-
-func (c clientAlwaysFailCred) ClientHandshake(ctx context.Context, addr string, rawConn net.Conn) (net.Conn, credentials.AuthInfo, error) {
-	return nil, nil, errClientAlwaysFailCred
-}
-func (c clientAlwaysFailCred) ServerHandshake(rawConn net.Conn) (net.Conn, credentials.AuthInfo, error) {
-	return rawConn, nil, nil
-}
-func (c clientAlwaysFailCred) Info() credentials.ProtocolInfo {
-	return credentials.ProtocolInfo{}
-}
-func (c clientAlwaysFailCred) Clone() credentials.TransportCredentials {
-	return nil
-}
-func (c clientAlwaysFailCred) OverrideServerName(s string) error {
-	return nil
-}
-
-func TestDialWithBlockErrorOnBadCertificates(t *testing.T) {
-	te := newTest(t, env{name: "bad-cred", network: "tcp", security: "clientAlwaysFailCred", balancer: "v1"})
-	te.startServer(&testServer{security: te.e.security})
-	defer te.tearDown()
-
-	var (
-		err  error
-		opts []grpc.DialOption
-	)
-	opts = append(opts, grpc.WithTransportCredentials(clientAlwaysFailCred{}), grpc.WithBlock())
-	te.cc, err = grpc.Dial(te.srvAddr, opts...)
-	if err != errClientAlwaysFailCred {
-		te.t.Fatalf("Dial(%q) = %v, want %v", te.srvAddr, err, errClientAlwaysFailCred)
-	}
 }
 
 type clientTimeoutCreds struct {

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -638,7 +638,7 @@ func (te *test) clientConn() *grpc.ClientConn {
 		opts = append(opts, grpc.WithInsecure())
 	}
 	// TODO(bar) switch balancer case "pickfirst".
-	var scheme string
+	scheme := "passthrough:///"
 	switch te.e.balancer {
 	case "v1":
 		opts = append(opts, grpc.WithBalancer(grpc.RoundRobin(nil)))
@@ -648,7 +648,6 @@ func (te *test) clientConn() *grpc.ClientConn {
 			te.t.Fatalf("got nil when trying to get roundrobin balancer builder")
 		}
 		opts = append(opts, grpc.WithBalancerBuilder(rr))
-		scheme = "passthrough:///"
 	}
 	if te.clientInitialWindowSize > 0 {
 		opts = append(opts, grpc.WithInitialWindowSize(te.clientInitialWindowSize))
@@ -665,6 +664,9 @@ func (te *test) clientConn() *grpc.ClientConn {
 	if !te.nonBlockingDial && te.srvAddr != "" {
 		// Only do a blocking dial if server is up.
 		opts = append(opts, grpc.WithBlock())
+	}
+	if te.srvAddr == "" {
+		te.srvAddr = "client.side.only.test"
 	}
 	var err error
 	te.cc, err = grpc.Dial(scheme+te.srvAddr, opts...)


### PR DESCRIPTION
The default balancer will be pickfirst if no balancer is specified.
And roundrobin is registered by default.

When switching balancer, the old balancer will be closed first, and a new balancer will start.
There's a gap between, where we will do optimization later.

Also removed two tests:
 - TestDialWithBlockErrorOnBadCertificates
 - TestDialWithBlockErrorOnNonTemporaryErrorDialer