### PR TITLE
Make interop client dial blocking

### DIFF
--- a/interop/client/client.go
+++ b/interop/client/client.go
@@ -107,6 +107,7 @@ func main() {
 	} else {
 		opts = append(opts, grpc.WithInsecure())
 	}
+	opts = append(opts, grpc.WithBlock())
 	conn, err := grpc.Dial(serverAddr, opts...)
 	if err != nil {
 		grpclog.Fatalf("Fail to dial: %v", err)


### PR DESCRIPTION
This should not be necessary once #1551 get merged.

Currently interop clients don't use balancer. With a non-blocking dial, the first failfast RPC will fail because there's no connection available.
This is a known bug, and will be fixed by the new balancer APIs.

This is a temp fix to make interop tests pass.