### PR TITLE
Temporary disable staticcheck

### DIFF
--- a/vet.sh
+++ b/vet.sh
@@ -27,7 +27,6 @@ if [ "$1" = "-install" ]; then
   go get -u \
     github.com/golang/lint/golint \
     golang.org/x/tools/cmd/goimports \
-    honnef.co/go/tools/cmd/staticcheck \
     github.com/golang/protobuf/protoc-gen-go \
     golang.org/x/tools/cmd/stringer
   if [[ "$check_proto" = "true" ]]; then
@@ -76,4 +75,4 @@ if [[ "$check_proto" = "true" ]]; then
 fi
 
 # TODO(menghanl): fix errors in transport_test.
-staticcheck -ignore google.golang.org/grpc/transport/transport_test.go:SA2002 ./...
+# staticcheck -ignore google.golang.org/grpc/transport/transport_test.go:SA2002 ./...


### PR DESCRIPTION
Because honnef.co is down.

This PR will be reverted when honnef.co is back up, or when we can get tool `staticcheck` somewhere else.