### PR TITLE
Update go_package declarations

### DIFF
--- a/grpclb/grpc_lb_v1/messages/messages.proto
+++ b/grpclb/grpc_lb_v1/messages/messages.proto
@@ -15,7 +15,7 @@
 syntax = "proto3";
 
 package grpc.lb.v1;
-option go_package = "messages";
+option go_package = "google.golang.org/grpc/grpclb/grpc_lb_v1/messages";
 
 message Duration {
   // Signed seconds of the span of time. Must be from -315,576,000,000

--- a/grpclb/grpc_lb_v1/service/service.proto
+++ b/grpclb/grpc_lb_v1/service/service.proto
@@ -15,7 +15,7 @@
 syntax = "proto3";
 
 package grpc.lb.v1;
-option go_package = "service";
+option go_package = "google.golang.org/grpc/grpclb/grpc_lb_v1/service";
 
 import "grpc_lb_v1/messages/messages.proto";
 

--- a/grpclb/grpclb_test.go
+++ b/grpclb/grpclb_test.go
@@ -16,8 +16,8 @@
  *
  */
 
-//go:generate protoc --go_out=plugins=:. grpc_lb_v1/messages/messages.proto
-//go:generate protoc --go_out=Mgrpc_lb_v1/messages/messages.proto=google.golang.org/grpc/grpclb/grpc_lb_v1/messages,plugins=grpc:. grpc_lb_v1/service/service.proto
+//go:generate protoc --go_out=plugins=:$GOPATH grpc_lb_v1/messages/messages.proto
+//go:generate protoc --go_out=plugins=grpc:$GOPATH grpc_lb_v1/service/service.proto
 
 // Package grpclb_test is currently used only for grpclb testing.
 package grpclb_test


### PR DESCRIPTION
The expected contents of `go_package` has changed, see golang/protobuf#139

This is needed to build stuff with bazel - see bazelbuild/rules_go#836