### PR TITLE
Make passthrough resolver the default instead of dns

### DIFF
--- a/clientconn.go
+++ b/clientconn.go
@@ -37,7 +37,8 @@ import (
 	"google.golang.org/grpc/grpclog"
 	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/resolver"
-	_ "google.golang.org/grpc/resolver/dns" // To register dns resolver.
+	_ "google.golang.org/grpc/resolver/dns"         // To register dns resolver.
+	_ "google.golang.org/grpc/resolver/passthrough" // To register passthrough resolver.
 	"google.golang.org/grpc/stats"
 	"google.golang.org/grpc/transport"
 )

--- a/resolver/passthrough/passthrough.go
+++ b/resolver/passthrough/passthrough.go
@@ -17,8 +17,7 @@
  */
 
 // Package passthrough implements a pass-through resolver. It sends the target
-// name without scheme back to gRPC as resolved address. It's for gRPC internal
-// test only.
+// name without scheme back to gRPC as resolved address.
 package passthrough
 
 import "google.golang.org/grpc/resolver"

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -24,7 +24,7 @@ var (
 	// m is a map from scheme to resolver builder.
 	m = make(map[string]Builder)
 	// defaultScheme is the default scheme to use.
-	defaultScheme = "dns"
+	defaultScheme = "passthrough"
 )
 
 // TODO(bar) install dns resolver in init(){}.


### PR DESCRIPTION
There are tests that depend on the behavior that target is not resolved, and is passed to the dialer directly. The recent change to make "dns" the default broke these tests.