### PR TITLE
Fix parseTarget for unix socket address without scheme

### DIFF
--- a/resolver_conn_wrapper.go
+++ b/resolver_conn_wrapper.go
@@ -41,7 +41,7 @@ type ccResolverWrapper struct {
 func split2(s, sep string) (string, string, bool) {
 	spl := strings.SplitN(s, sep, 2)
 	if len(spl) < 2 {
-		return "", s, false
+		return "", "", false
 	}
 	return spl[0], spl[1], true
 }

--- a/resolver_conn_wrapper.go
+++ b/resolver_conn_wrapper.go
@@ -37,20 +37,24 @@ type ccResolverWrapper struct {
 }
 
 // split2 returns the values from strings.SplitN(s, sep, 2).
-// If sep is not found, it returns "", s instead.
-func split2(s, sep string) (string, string) {
+// If sep is not found, it returns ("", s, false) instead.
+func split2(s, sep string) (string, string, bool) {
 	spl := strings.SplitN(s, sep, 2)
 	if len(spl) < 2 {
-		return "", s
+		return "", s, false
 	}
-	return spl[0], spl[1]
+	return spl[0], spl[1], true
 }
 
 // parseTarget splits target into a struct containing scheme, authority and
 // endpoint.
 func parseTarget(target string) (ret resolver.Target) {
-	ret.Scheme, ret.Endpoint = split2(target, "://")
-	ret.Authority, ret.Endpoint = split2(ret.Endpoint, "/")
+	var ok bool
+	ret.Scheme, ret.Endpoint, ok = split2(target, "://")
+	if !ok {
+		return resolver.Target{Endpoint: target}
+	}
+	ret.Authority, ret.Endpoint, _ = split2(ret.Endpoint, "/")
 	return ret
 }
 

--- a/resolver_conn_wrapper_test.go
+++ b/resolver_conn_wrapper_test.go
@@ -34,14 +34,43 @@ func TestParseTarget(t *testing.T) {
 		{"a", "", "b"},
 		{"", "a", "b"},
 		{"a", "b", "c"},
-		{"dns", "a.server.com", "google.com"},
+		{"dns", "", "google.com"},
 		{"dns", "a.server.com", "google.com"},
 		{"dns", "a.server.com", "google.com/?a=b"},
+		{"", "", "/unix/socket/address"},
 	} {
 		str := test.Scheme + "://" + test.Authority + "/" + test.Endpoint
 		got := parseTarget(str)
 		if got != test {
-			t.Errorf("parseTarget(%q) = %v, want %v", str, got, test)
+			t.Errorf("parseTarget(%q) = %+v, want %+v", str, got, test)
+		}
+	}
+}
+
+func TestParseTargetString(t *testing.T) {
+	for _, test := range []struct {
+		targetStr string
+		want      resolver.Target
+	}{
+		{"", resolver.Target{"", "", ""}},
+		{"a:///", resolver.Target{"a", "", ""}},
+		{"://a/", resolver.Target{"", "a", ""}},
+		{":///a", resolver.Target{"", "", "a"}},
+		{"a://b/", resolver.Target{"a", "b", ""}},
+		{"a:///b", resolver.Target{"a", "", "b"}},
+		{"://a/b", resolver.Target{"", "a", "b"}},
+		{"a://b/c", resolver.Target{"a", "b", "c"}},
+		{"dns:///google.com", resolver.Target{"dns", "", "google.com"}},
+		{"dns://a.server.com/google.com", resolver.Target{"dns", "a.server.com", "google.com"}},
+		{"dns://a.server.com/google.com/?a=b", resolver.Target{"dns", "a.server.com", "google.com/?a=b"}},
+
+		{"google.com", resolver.Target{"", "", "google.com"}},
+		{"google.com/?a=b", resolver.Target{"", "", "google.com/?a=b"}},
+		{"/unix/socket/address", resolver.Target{"", "", "/unix/socket/address"}},
+	} {
+		got := parseTarget(test.targetStr)
+		if got != test.want {
+			t.Errorf("parseTarget(%q) = %+v, want %+v", test.targetStr, got, test.want)
 		}
 	}
 }

--- a/resolver_conn_wrapper_test.go
+++ b/resolver_conn_wrapper_test.go
@@ -53,6 +53,8 @@ func TestParseTargetString(t *testing.T) {
 		want      resolver.Target
 	}{
 		{"", resolver.Target{"", "", ""}},
+		{"://", resolver.Target{"", "", ""}},
+		{":///", resolver.Target{"", "", ""}},
 		{"a:///", resolver.Target{"a", "", ""}},
 		{"://a/", resolver.Target{"", "a", ""}},
 		{":///a", resolver.Target{"", "", "a"}},
@@ -64,6 +66,7 @@ func TestParseTargetString(t *testing.T) {
 		{"dns://a.server.com/google.com", resolver.Target{"dns", "a.server.com", "google.com"}},
 		{"dns://a.server.com/google.com/?a=b", resolver.Target{"dns", "a.server.com", "google.com/?a=b"}},
 
+		{"/", resolver.Target{"", "", "/"}},
 		{"google.com", resolver.Target{"", "", "google.com"}},
 		{"google.com/?a=b", resolver.Target{"", "", "google.com/?a=b"}},
 		{"/unix/socket/address", resolver.Target{"", "", "/unix/socket/address"}},


### PR DESCRIPTION
The leading `"/"` was mistakenly stripped by `parseTarget`.