### PR TITLE
Acquire all stream related quota and cache it locally since no more than one write can happen in parallel on stream

### DIFF
--- a/transport/http2_server.go
+++ b/transport/http2_server.go
@@ -813,7 +813,7 @@ func (t *http2Server) WriteStatus(s *Stream, st *status.Status) error {
 
 // Write converts the data into HTTP2 data frame and sends it out. Non-nil error
 // is returns if it fails (e.g., framing error, transport error).
-func (t *http2Server) Write(s *Stream, hdr []byte, data []byte, opts *Options) (err error) {
+func (t *http2Server) Write(s *Stream, hdr []byte, data []byte, opts *Options) error {
 	select {
 	case <-s.ctx.Done():
 		return ContextErr(s.ctx.Err())
@@ -842,65 +842,80 @@ func (t *http2Server) Write(s *Stream, hdr []byte, data []byte, opts *Options) (
 	}
 	hdr = append(hdr, data[:emptyLen]...)
 	data = data[emptyLen:]
+	var (
+		streamQuota    int
+		streamQuotaVer uint32
+		localSendQuota int
+		err            error
+		sqChan         <-chan int
+	)
 	for _, r := range [][]byte{hdr, data} {
 		for len(r) > 0 {
 			size := http2MaxFrameLen
-			// Wait until the stream has some quota to send the data.
-			quotaChan, quotaVer := s.sendQuotaPool.acquireWithVersion()
-			sq, err := wait(s.ctx, t.ctx, nil, nil, quotaChan)
-			if err != nil {
-				return err
+			if size > len(r) {
+				size = len(r)
 			}
+			if streamQuota == 0 { // Used up all the locally cached stream quota.
+				sqChan, streamQuotaVer = s.sendQuotaPool.acquireWithVersion()
+				// Wait until the stream has some quota to send the data.
+				streamQuota, err = wait(s.ctx, t.ctx, nil, nil, sqChan)
+				if err != nil {
+					return err
+				}
+			}
+			if localSendQuota <= 0 {
+				localSendQuota, err = wait(s.ctx, t.ctx, nil, nil, s.localSendQuota.acquire())
+				if err != nil {
+					return err
+				}
+			}
+			if size > streamQuota {
+				size = streamQuota
+			} // No need to do that for localSendQuota since that's only a soft limit.
+			streamQuota -= size
+			localSendQuota -= size
 			// Wait until the transport has some quota to send the data.
 			tq, err := wait(s.ctx, t.ctx, nil, nil, t.sendQuotaPool.acquire())
 			if err != nil {
 				return err
 			}
-			if sq < size {
-				size = sq
-			}
 			if tq < size {
+				streamQuota += size - tq
+				localSendQuota += size - tq
 				size = tq
 			}
-			if size > len(r) {
-				size = len(r)
+			if tq > size {
+				t.sendQuotaPool.add(tq - size)
 			}
 			p := r[:size]
-			ps := len(p)
-			if ps < tq {
-				// Overbooked transport quota. Return it back.
-				t.sendQuotaPool.add(tq - ps)
-			}
-			// Acquire local send quota to be able to write to the controlBuf.
-			ltq, err := wait(s.ctx, t.ctx, nil, nil, s.localSendQuota.acquire())
-			if err != nil {
-				if _, ok := err.(ConnectionError); !ok {
-					t.sendQuotaPool.add(ps)
-				}
-				return err
-			}
-			s.localSendQuota.add(ltq - ps) // It's ok we make this negative.
 			// Reset ping strikes when sending data since this might cause
 			// the peer to send ping.
 			atomic.StoreUint32(&t.resetPingStrikes, 1)
 			success := func() {
+				sz := size
 				t.controlBuf.put(&dataFrame{streamID: s.id, endStream: false, d: p, f: func() {
-					s.localSendQuota.add(ps)
+					s.localSendQuota.add(sz)
 				}})
-				if ps < sq {
-					// Overbooked stream quota. Return it back.
-					s.sendQuotaPool.lockedAdd(sq - ps)
-				}
-				r = r[ps:]
+				r = r[size:]
 			}
-			failure := func() {
-				s.sendQuotaPool.lockedAdd(sq)
+			failure := func() { // The stream quota version must have changed.
+				// Our streamQuota cache is invalidated now, so give it back.
+				s.sendQuotaPool.lockedAdd(streamQuota + size)
 			}
-			if !s.sendQuotaPool.compareAndExecute(quotaVer, success, failure) {
-				t.sendQuotaPool.add(ps)
-				s.localSendQuota.add(ps)
+			if !s.sendQuotaPool.compareAndExecute(streamQuotaVer, success, failure) {
+				// Couldn't send this chunk out.
+				t.sendQuotaPool.add(size)
+				localSendQuota += size
+				streamQuota = 0
 			}
 		}
+	}
+	if streamQuota > 0 {
+		// ADd the left over quota back to stream.
+		s.sendQuotaPool.add(streamQuota)
+	}
+	if localSendQuota > 0 {
+		s.localSendQuota.add(localSendQuota)
 	}
 	return nil
 }

--- a/transport/http2_server.go
+++ b/transport/http2_server.go
@@ -872,21 +872,19 @@ func (t *http2Server) Write(s *Stream, hdr []byte, data []byte, opts *Options) e
 			if size > streamQuota {
 				size = streamQuota
 			} // No need to do that for localSendQuota since that's only a soft limit.
-			streamQuota -= size
-			localSendQuota -= size
 			// Wait until the transport has some quota to send the data.
 			tq, err := wait(s.ctx, t.ctx, nil, nil, t.sendQuotaPool.acquire())
 			if err != nil {
 				return err
 			}
 			if tq < size {
-				streamQuota += size - tq
-				localSendQuota += size - tq
 				size = tq
 			}
 			if tq > size {
 				t.sendQuotaPool.add(tq - size)
 			}
+			streamQuota -= size
+			localSendQuota -= size
 			p := r[:size]
 			// Reset ping strikes when sending data since this might cause
 			// the peer to send ping.

--- a/transport/transport_test.go
+++ b/transport/transport_test.go
@@ -1790,16 +1790,18 @@ func TestAccountCheckExpandingWindow(t *testing.T) {
 			t.Fatalf("Length of message received by client: %v, want: %v", len(recvMsg), len(msg))
 		}
 	}
+	defer func() {
+		ct.Write(cstream, nil, nil, &Options{Last: true}) // Close the stream.
+		if _, err := cstream.Read(header); err != io.EOF {
+			t.Fatalf("Client expected an EOF from the server. Got: %v", err)
+		}
+	}()
 	var sstream *Stream
 	st.mu.Lock()
 	for _, v := range st.activeStreams {
 		sstream = v
 	}
 	st.mu.Unlock()
-	ct.Write(cstream, nil, nil, &Options{Last: true}) // Close the stream.
-	if _, err := cstream.Read(header); err != io.EOF {
-		t.Fatalf("Client expected an EOF from the server. Got: %v", err)
-	}
 
 	waitWhileTrue(t, func() (bool, error) {
 		// Check that pendingData and delta on flow control windows on both sides are 0.

--- a/transport/transport_test.go
+++ b/transport/transport_test.go
@@ -2183,6 +2183,10 @@ func TestPingPong1MB(t *testing.T) {
 	runPingPongTest(t, 1048576)
 }
 
+// The continous ping-pong of data on a stream is meant to excercise the
+// flow-control logic to catch potential deadlocks.
+// These tests were added after a deadlock was caught by benchmarking
+// code while the test suite didn't catch it over multiple runs.
 func runPingPongTest(t *testing.T, msgSize int) {
 	server, client := setUp(t, 0, 0, pingpong)
 	defer server.stop()

--- a/transport/transport_test.go
+++ b/transport/transport_test.go
@@ -2183,10 +2183,7 @@ func TestPingPong1MB(t *testing.T) {
 	runPingPongTest(t, 1048576)
 }
 
-// The continous ping-pong of data on a stream is meant to excercise the
-// flow-control logic to catch potential deadlocks.
-// These tests were added after a deadlock was caught by benchmarking
-// code while the test suite didn't catch it over multiple runs.
+//This is a stress-test of flow control logic.
 func runPingPongTest(t *testing.T, msgSize int) {
 	server, client := setUp(t, 0, 0, pingpong)
 	defer server.stop()


### PR DESCRIPTION
This is a small optimization upon which a follow optimization will be built to reduce lock contention.
Benchmarks: https://docs.google.com/a/google.com/spreadsheets/d/1G-p6-uTt8IHRLGXLuTR6TAxeL3I5krVf5r9C86cJPDc/edit?usp=sharing