### PR TITLE
Revert "cap max msg size to min(max_int, max_uint32) (#1598)"

### DIFF
--- a/rpc_util.go
+++ b/rpc_util.go
@@ -206,7 +206,6 @@ func FailFast(failFast bool) CallOption {
 }
 
 // MaxCallRecvMsgSize returns a CallOption which sets the maximum message size the client can receive.
-// Note that the maximum effective value is MaxUint32 due to protocol limitations.
 func MaxCallRecvMsgSize(s int) CallOption {
 	return beforeCall(func(o *callInfo) error {
 		o.maxReceiveMessageSize = &s
@@ -215,7 +214,6 @@ func MaxCallRecvMsgSize(s int) CallOption {
 }
 
 // MaxCallSendMsgSize returns a CallOption which sets the maximum message size the client can send.
-// Note that the maximum effective value is MaxUint32 due to protocol limitations.
 func MaxCallSendMsgSize(s int) CallOption {
 	return beforeCall(func(o *callInfo) error {
 		o.maxSendMessageSize = &s

--- a/server.go
+++ b/server.go
@@ -208,27 +208,17 @@ func MaxMsgSize(m int) ServerOption {
 
 // MaxRecvMsgSize returns a ServerOption to set the max message size in bytes the server can receive.
 // If this is not set, gRPC uses the default 4MB.
-// Note that the maximum effective value is MaxUint32 due to protocol limitations.
 func MaxRecvMsgSize(m int) ServerOption {
 	return func(o *options) {
-		if int64(m) > int64(math.MaxUint32) {
-			o.maxReceiveMessageSize = math.MaxUint32
-		} else {
-			o.maxReceiveMessageSize = m
-		}
+		o.maxReceiveMessageSize = m
 	}
 }
 
 // MaxSendMsgSize returns a ServerOption to set the max message size in bytes the server can send.
 // If this is not set, gRPC uses the default 4MB.
-// Note that the maximum effective value is MaxUint32 due to protocol limitations.
 func MaxSendMsgSize(m int) ServerOption {
 	return func(o *options) {
-		if int64(m) > int64(math.MaxUint32) {
-			o.maxSendMessageSize = math.MaxUint32
-		} else {
-			o.maxSendMessageSize = m
-		}
+		o.maxSendMessageSize = m
 	}
 }
 

--- a/service_config.go
+++ b/service_config.go
@@ -20,7 +20,6 @@ package grpc
 
 import (
 	"encoding/json"
-	"math"
 	"time"
 
 	"google.golang.org/grpc/grpclog"
@@ -149,39 +148,24 @@ func parseServiceConfig(js string) (ServiceConfig, error) {
 	return sc, nil
 }
 
-func min(a, b int) int {
-	if a < b {
+func min(a, b *int) *int {
+	if *a < *b {
 		return a
 	}
 	return b
 }
 
-const maxInt = int(^uint(0) >> 1)
-
 func getMaxSize(mcMax, doptMax *int, defaultVal int) *int {
-	res := getRawMaxSize(mcMax, doptMax, defaultVal)
-
-	// Cap the max size to maxInt of current machine due to slice length limit.
-	res = min(res, maxInt)
-	if int64(res) > int64(math.MaxUint32) {
-		// Only reach here on 64-bit machine, where we need to cap the max size
-		// to MaxUint32.
-		res = math.MaxUint32
-	}
-	return &res
-}
-
-func getRawMaxSize(mcMax, doptMax *int, defaultVal int) int {
 	if mcMax == nil && doptMax == nil {
-		return defaultVal
+		return &defaultVal
 	}
 	if mcMax != nil && doptMax != nil {
-		return min(*mcMax, *doptMax)
+		return min(mcMax, doptMax)
 	}
 	if mcMax != nil {
-		return *mcMax
+		return mcMax
 	}
-	return *doptMax
+	return doptMax
 }
 
 func newBool(b bool) *bool {


### PR DESCRIPTION
This reverts commit 5856538706dc3abc44dd5ba1a8bb19a0dfb1ab25.