### PR TITLE
fix max msg size type issues on different arch

### DIFF
--- a/rpc_util.go
+++ b/rpc_util.go
@@ -275,7 +275,7 @@ func (p *parser) recvMsg(maxReceiveMessageSize int) (pf payloadFormat, msg []byt
 		return pf, nil, nil
 	}
 	if int64(length) > int64(maxInt) {
-		return 0, nil, Errorf(codes.ResourceExhausted, "grpc: received message larger than max length allowed on current machine(%d vs. %d)", length, maxInt)
+		return 0, nil, Errorf(codes.ResourceExhausted, "grpc: received message larger than max length allowed on current machine (%d vs. %d)", length, maxInt)
 	}
 	if int(length) > maxReceiveMessageSize {
 		return 0, nil, Errorf(codes.ResourceExhausted, "grpc: received message larger than max (%d vs. %d)", length, maxReceiveMessageSize)

--- a/rpc_util.go
+++ b/rpc_util.go
@@ -274,7 +274,10 @@ func (p *parser) recvMsg(maxReceiveMessageSize int) (pf payloadFormat, msg []byt
 	if length == 0 {
 		return pf, nil, nil
 	}
-	if length > uint32(maxReceiveMessageSize) {
+	if int64(length) > int64(maxInt) {
+		return 0, nil, Errorf(codes.ResourceExhausted, "grpc: received message larger than max length allowed on current machine(%d vs. %d)", length, maxInt)
+	}
+	if int(length) > maxReceiveMessageSize {
 		return 0, nil, Errorf(codes.ResourceExhausted, "grpc: received message larger than max (%d vs. %d)", length, maxReceiveMessageSize)
 	}
 	// TODO(bradfitz,zhaoq): garbage. reuse buffer after proto decoding instead


### PR DESCRIPTION
* Allow service config msg size field to be in range int64.
 * On 32-bit machine, it will then be capped to int32

Value range:
32-bit system: User API: int32, Service Config: int32, Max allowed slice length: int32, Max by spec: uint32
64-bit system: User API: int64, Service Config: int64, Max allowed slice length: int64, Max by spec: uint32


