### PR TITLE
Speed-up quota pools.

### DIFF
--- a/benchmark/stats/stats.go
+++ b/benchmark/stats/stats.go
@@ -255,7 +255,7 @@ func (stats *Stats) maybeUpdate() {
 	stats.dirty = false
 
 	if stats.durations.Len() != 0 {
-		var percentToObserve = []int{50, 90}
+		var percentToObserve = []int{50, 90, 99}
 		// First data record min unit from the latency result.
 		stats.result.Latency = append(stats.result.Latency, percentLatency{Percent: -1, Value: stats.unit})
 		for _, position := range percentToObserve {

--- a/transport/control.go
+++ b/transport/control.go
@@ -169,9 +169,9 @@ func (qb *quotaPool) lockedAdd(v int) {
 
 func (qb *quotaPool) addAndUpdate(v int) {
 	qb.mu.Lock()
-	defer qb.mu.Unlock()
 	qb.lockedAdd(v)
 	qb.version++
+	qb.mu.Unlock()
 }
 
 func (qb *quotaPool) get(v int, wc waiters) (int, uint32, error) {
@@ -221,12 +221,13 @@ func (qb *quotaPool) get(v int, wc waiters) (int, uint32, error) {
 
 func (qb *quotaPool) compareAndExecute(version uint32, success, failure func()) bool {
 	qb.mu.Lock()
-	defer qb.mu.Unlock()
 	if version == qb.version {
 		success()
+		qb.mu.Unlock()
 		return true
 	}
 	failure()
+	qb.mu.Unlock()
 	return false
 }
 

--- a/transport/control.go
+++ b/transport/control.go
@@ -49,7 +49,7 @@ const (
 	// defaultLocalSendQuota sets is default value for number of data
 	// bytes that each stream can schedule before some of it being
 	// flushed out.
-	defaultLocalSendQuota = 256 * 1024
+	defaultLocalSendQuota = 128 * 1024
 )
 
 // The following defines various control items which could flow through

--- a/transport/control.go
+++ b/transport/control.go
@@ -49,7 +49,7 @@ const (
 	// defaultLocalSendQuota sets is default value for number of data
 	// bytes that each stream can schedule before some of it being
 	// flushed out.
-	defaultLocalSendQuota = 64 * 1024
+	defaultLocalSendQuota = 256 * 1024
 )
 
 // The following defines various control items which could flow through

--- a/transport/control.go
+++ b/transport/control.go
@@ -20,9 +20,9 @@ package transport
 
 import (
 	"fmt"
+	"io"
 	"math"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"golang.org/x/net/http2"
@@ -130,9 +130,8 @@ func (*ping) item() {}
 // quotaPool is a pool which accumulates the quota and sends it to acquire()
 // when it is available.
 type quotaPool struct {
-	c chan int
-
 	mu      sync.Mutex
+	c       chan struct{}
 	version uint32
 	quota   int
 }
@@ -140,12 +139,8 @@ type quotaPool struct {
 // newQuotaPool creates a quotaPool which has quota q available to consume.
 func newQuotaPool(q int) *quotaPool {
 	qb := &quotaPool{
-		c: make(chan int, 1),
-	}
-	if q > 0 {
-		qb.c <- q
-	} else {
-		qb.quota = q
+		quota: q,
+		c:     make(chan struct{}, 1),
 	}
 	return qb
 }
@@ -159,23 +154,16 @@ func (qb *quotaPool) add(v int) {
 }
 
 func (qb *quotaPool) lockedAdd(v int) {
-	select {
-	case n := <-qb.c:
-		qb.quota += n
-	default:
+	var wakeUp bool
+	if qb.quota <= 0 {
+		wakeUp = true // Wake up potential watiers.
 	}
 	qb.quota += v
-	if qb.quota <= 0 {
-		return
-	}
-	// After the pool has been created, this is the only place that sends on
-	// the channel. Since mu is held at this point and any quota that was sent
-	// on the channel has been retrieved, we know that this code will always
-	// place any positive quota value on the channel.
-	select {
-	case qb.c <- qb.quota:
-		qb.quota = 0
-	default:
+	if wakeUp && qb.quota > 0 {
+		select {
+		case qb.c <- struct{}{}:
+		default:
+		}
 	}
 }
 
@@ -183,34 +171,63 @@ func (qb *quotaPool) addAndUpdate(v int) {
 	qb.mu.Lock()
 	defer qb.mu.Unlock()
 	qb.lockedAdd(v)
-	// Update the version only after having added to the quota
-	// so that if acquireWithVesrion sees the new vesrion it is
-	// guaranteed to have seen the updated quota.
-	// Also, still keep this inside of the lock, so that when
-	// compareAndExecute is processing, this function doesn't
-	// get executed partially (quota gets updated but the version
-	// doesn't).
-	atomic.AddUint32(&(qb.version), 1)
+	qb.version++
 }
 
-func (qb *quotaPool) acquireWithVersion() (<-chan int, uint32) {
-	return qb.c, atomic.LoadUint32(&(qb.version))
+func (qb *quotaPool) get(v int, wc waiters) (int, uint32, error) {
+	qb.mu.Lock()
+	if qb.quota > 0 {
+		if v > qb.quota {
+			v = qb.quota
+		}
+		qb.quota -= v
+		ver := qb.version
+		qb.mu.Unlock()
+		return v, ver, nil
+	}
+	qb.mu.Unlock()
+	for {
+		select {
+		case <-wc.ctx.Done():
+			return 0, 0, ContextErr(wc.ctx.Err())
+		case <-wc.tctx.Done():
+			return 0, 0, ErrConnClosing
+		case <-wc.done:
+			return 0, 0, io.EOF
+		case <-wc.goAway:
+			return 0, 0, ErrStreamDrain
+		case <-qb.c:
+			qb.mu.Lock()
+			if qb.quota > 0 {
+				if v > qb.quota {
+					v = qb.quota
+				}
+				qb.quota -= v
+				ver := qb.version
+				if qb.quota > 0 {
+					select {
+					case qb.c <- struct{}{}:
+					default:
+					}
+				}
+				qb.mu.Unlock()
+				return v, ver, nil
+
+			}
+			qb.mu.Unlock()
+		}
+	}
 }
 
 func (qb *quotaPool) compareAndExecute(version uint32, success, failure func()) bool {
 	qb.mu.Lock()
 	defer qb.mu.Unlock()
-	if version == atomic.LoadUint32(&(qb.version)) {
+	if version == qb.version {
 		success()
 		return true
 	}
 	failure()
 	return false
-}
-
-// acquire returns the channel on which available quota amounts are sent.
-func (qb *quotaPool) acquire() <-chan int {
-	return qb.c
 }
 
 // inFlow deals with inbound flow control

--- a/transport/http2_server.go
+++ b/transport/http2_server.go
@@ -863,7 +863,6 @@ func (t *http2Server) Write(s *Stream, hdr []byte, data []byte, opts *Options) e
 		streamQuotaVer uint32
 		localSendQuota int
 		err            error
-		sqChan         <-chan int
 	)
 	for _, r := range [][]byte{hdr, data} {
 		for len(r) > 0 {
@@ -872,15 +871,24 @@ func (t *http2Server) Write(s *Stream, hdr []byte, data []byte, opts *Options) e
 				size = len(r)
 			}
 			if streamQuota == 0 { // Used up all the locally cached stream quota.
-				sqChan, streamQuotaVer = s.sendQuotaPool.acquireWithVersion()
-				// Wait until the stream has some quota to send the data.
-				streamQuota, err = wait(s.ctx, t.ctx, nil, nil, sqChan)
+				// Get all the stream quota there is.
+				streamQuota, streamQuotaVer, err = s.sendQuotaPool.get(math.MaxInt32, waiters{
+					ctx:    s.ctx,
+					tctx:   t.ctx,
+					done:   s.done,
+					goAway: s.goAway,
+				})
 				if err != nil {
 					return err
 				}
 			}
 			if localSendQuota <= 0 {
-				localSendQuota, err = wait(s.ctx, t.ctx, nil, nil, s.localSendQuota.acquire())
+				localSendQuota, _, err = s.localSendQuota.get(math.MaxInt32, waiters{
+					ctx:    s.ctx,
+					tctx:   t.ctx,
+					done:   s.done,
+					goAway: s.goAway,
+				})
 				if err != nil {
 					return err
 				}
@@ -888,16 +896,18 @@ func (t *http2Server) Write(s *Stream, hdr []byte, data []byte, opts *Options) e
 			if size > streamQuota {
 				size = streamQuota
 			} // No need to do that for localSendQuota since that's only a soft limit.
-			// Wait until the transport has some quota to send the data.
-			tq, err := wait(s.ctx, t.ctx, nil, nil, t.sendQuotaPool.acquire())
+			// Get size worth quota from transport.
+			tq, _, err := t.sendQuotaPool.get(size, waiters{
+				ctx:    s.ctx,
+				tctx:   t.ctx,
+				done:   s.done,
+				goAway: s.goAway,
+			})
 			if err != nil {
 				return err
 			}
 			if tq < size {
 				size = tq
-			}
-			if tq > size {
-				t.sendQuotaPool.add(tq - size)
 			}
 			streamQuota -= size
 			localSendQuota -= size

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -238,8 +238,7 @@ type Stream struct {
 	// is used to adjust flow control, if need be.
 	requestRead func(int)
 
-	sendQuotaPool  *quotaPool
-	localSendQuota *quotaPool
+	sendQuotaPool *quotaPool
 	// Close headerChan to indicate the end of reception of header metadata.
 	headerChan chan struct{}
 	// header caches the received header metadata.

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -229,6 +229,7 @@ type Stream struct {
 	trReader     io.Reader
 	fc           *inFlow
 	recvQuota    uint32
+	waiters      waiters
 
 	// TODO: Remote this unused variable.
 	// The accumulated inbound quota pending for window update.

--- a/transport/transport_test.go
+++ b/transport/transport_test.go
@@ -1093,44 +1093,29 @@ func TestMaxStreams(t *testing.T) {
 			}
 		}
 	}()
-	var failureReason string
 	// Test these conditions untill they pass or
 	// we reach the deadline (failure case).
 	for {
 		select {
 		case <-ch:
 		case <-done:
-			t.Fatalf(failureReason)
+			t.Fatalf("streamsQuota.quota shouldn't be non-zero.")
 		}
-		select {
-		case q := <-cc.streamsQuota.acquire():
-			failureReason = "streamsQuota.acquire() becomes readable mistakenly."
-			cc.streamsQuota.add(q)
-		default:
-			cc.streamsQuota.mu.Lock()
-			quota := cc.streamsQuota.quota
-			cc.streamsQuota.mu.Unlock()
-			if quota != 0 {
-				failureReason = "streamsQuota.quota got non-zero quota mistakenly."
-			} else {
-				failureReason = ""
-			}
-		}
-		if failureReason == "" {
+		cc.streamsQuota.mu.Lock()
+		sq := cc.streamsQuota.quota
+		cc.streamsQuota.mu.Unlock()
+		if sq == 0 {
 			break
 		}
 	}
 	close(ready)
 	// Close the pending stream so that the streams quota becomes available for the next new stream.
 	ct.CloseStream(s, nil)
-	select {
-	case i := <-cc.streamsQuota.acquire():
-		if i != 1 {
-			t.Fatalf("streamsQuota.acquire() got %d quota, want 1.", i)
-		}
-		cc.streamsQuota.add(i)
-	default:
-		t.Fatalf("streamsQuota.acquire() is not readable.")
+	cc.streamsQuota.mu.Lock()
+	i := cc.streamsQuota.quota
+	cc.streamsQuota.mu.Unlock()
+	if i != 1 {
+		t.Fatalf("streamsQuota is  %d, want 1.", i)
 	}
 	if _, err := ct.NewStream(context.Background(), callHdr); err != nil {
 		t.Fatalf("Failed to open stream: %v", err)
@@ -1685,7 +1670,12 @@ func testAccountCheckWindowSize(t *testing.T, wc windowSizeConfig) {
 	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	serverSendQuota, err := wait(ctx, context.Background(), nil, nil, st.sendQuotaPool.acquire())
+	serverSendQuota, _, err := st.sendQuotaPool.get(math.MaxInt32, waiters{
+		ctx:    ctx,
+		tctx:   st.ctx,
+		done:   nil,
+		goAway: nil,
+	})
 	if err != nil {
 		t.Fatalf("Error while acquiring sendQuota on server. Err: %v", err)
 	}
@@ -1707,7 +1697,12 @@ func testAccountCheckWindowSize(t *testing.T, wc windowSizeConfig) {
 		t.Fatalf("Client transport flow control window size is %v, want %v", limit, connectOptions.InitialConnWindowSize)
 	}
 	ctx, cancel = context.WithTimeout(context.Background(), time.Second)
-	clientSendQuota, err := wait(ctx, context.Background(), nil, nil, ct.sendQuotaPool.acquire())
+	clientSendQuota, _, err := ct.sendQuotaPool.get(math.MaxInt32, waiters{
+		ctx:    ctx,
+		tctx:   ct.ctx,
+		done:   nil,
+		goAway: nil,
+	})
 	if err != nil {
 		t.Fatalf("Error while acquiring sendQuota on client. Err: %v", err)
 	}
@@ -1849,7 +1844,12 @@ func TestAccountCheckExpandingWindow(t *testing.T) {
 
 		// Check flow conrtrol window on client stream is equal to out flow on server stream.
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-		serverStreamSendQuota, err := wait(ctx, context.Background(), nil, nil, sstream.sendQuotaPool.acquire())
+		serverStreamSendQuota, _, err := sstream.sendQuotaPool.get(math.MaxInt32, waiters{
+			ctx:    ctx,
+			tctx:   context.Background(),
+			done:   nil,
+			goAway: nil,
+		})
 		cancel()
 		if err != nil {
 			return true, fmt.Errorf("error while acquiring server stream send quota. Err: %v", err)
@@ -1864,7 +1864,12 @@ func TestAccountCheckExpandingWindow(t *testing.T) {
 
 		// Check flow control window on server stream is equal to out flow on client stream.
 		ctx, cancel = context.WithTimeout(context.Background(), time.Second)
-		clientStreamSendQuota, err := wait(ctx, context.Background(), nil, nil, cstream.sendQuotaPool.acquire())
+		clientStreamSendQuota, _, err := cstream.sendQuotaPool.get(math.MaxInt32, waiters{
+			ctx:    ctx,
+			tctx:   context.Background(),
+			done:   nil,
+			goAway: nil,
+		})
 		cancel()
 		if err != nil {
 			return true, fmt.Errorf("error while acquiring client stream send quota. Err: %v", err)
@@ -1879,7 +1884,12 @@ func TestAccountCheckExpandingWindow(t *testing.T) {
 
 		// Check flow control window on client transport is equal to out flow of server transport.
 		ctx, cancel = context.WithTimeout(context.Background(), time.Second)
-		serverTrSendQuota, err := wait(ctx, context.Background(), nil, nil, st.sendQuotaPool.acquire())
+		serverTrSendQuota, _, err := st.sendQuotaPool.get(math.MaxInt32, waiters{
+			ctx:    ctx,
+			tctx:   st.ctx,
+			done:   nil,
+			goAway: nil,
+		})
 		cancel()
 		if err != nil {
 			return true, fmt.Errorf("error while acquring server transport send quota. Err: %v", err)
@@ -1894,7 +1904,12 @@ func TestAccountCheckExpandingWindow(t *testing.T) {
 
 		// Check flow control window on server transport is equal to out flow of client transport.
 		ctx, cancel = context.WithTimeout(context.Background(), time.Second)
-		clientTrSendQuota, err := wait(ctx, context.Background(), nil, nil, ct.sendQuotaPool.acquire())
+		clientTrSendQuota, _, err := ct.sendQuotaPool.get(math.MaxInt32, waiters{
+			ctx:    ctx,
+			tctx:   ct.ctx,
+			done:   nil,
+			goAway: nil,
+		})
 		cancel()
 		if err != nil {
 			return true, fmt.Errorf("error while acquiring client transport send quota. Err: %v", err)


### PR DESCRIPTION
In the fast path instead of both acquiring a lock and writing on a channel, quota pool now only acquires the lock. In the slow path however, it needs to do both. 

Following are benchmark results:

### gRPC-Go benchmakrs:
Ran streaming ping pong benchmarks with 1000 concurrent streams and varied request-response sizes.

#### Stream-traceMode_false-latency_0s-kbps_0-MTU_0-maxConcurrentCalls_1000-reqSize_1B-respSize_1B-Compressor_false: 

Before
```
50_Latency: 5852.5600 µs | 90_Latency: 8644.2170 µs | 99_Latency: 12326.9280 µs | Avg latency: 6096.6670 µs | Count: 9825882 | 835 Bytes/op | 31 Allocs/op |  
```

After
```
50_Latency: 2065.5250 µs | 90_Latency: 2782.8890 µs | 99_Latency: 5785.2260 µs | Avg latency: 2212.1370 µs | Count: 27098481 | 825 Bytes/op | 30 Allocs/op |  
```


#### Stream-traceMode_false-latency_0s-kbps_0-MTU_0-maxConcurrentCalls_1000-reqSize_100B-respSize_100B-Compressor_false:

Before
```
50_Latency: 6383.2990 µs | 90_Latency: 9348.2500 µs | 99_Latency: 13037.6390 µs | Avg latency: 6483.3020 µs | Count: 9242647 | 2490 Bytes/op | 31 Allocs/op |  
```

After
```
50_Latency: 2520.5400 µs | 90_Latency: 3535.2930 µs | 99_Latency: 7008.4330 µs | Avg latency: 2749.8300 µs | Count: 21809014 | 2475 Bytes/op | 30 Allocs/op
```


####  Stream-traceMode_false-latency_0s-kbps_0-MTU_0-maxConcurrentCalls_1000-reqSize_1024B-respSize_1024B-Compressor_false:

Before
```
50_Latency: 8374.0940 µs | 90_Latency: 12119.2840 µs | 99_Latency: 17004.9960 µs | Avg latency: 8447.3220 µs | Count: 7091109 | 18516 Bytes/op | 31 Allocs/op
```

After
```
50_Latency: 5253.6050 µs | 90_Latency: 10363.1550 µs | 99_Latency: 18257.3020 µs | Avg latency: 6233.3960 µs | Count: 9613785 | 18231 Bytes/op | 30 Allocs/op
```

#### Stream-traceMode_false-latency_0s-kbps_0-MTU_0-maxConcurrentCalls_1000-reqSize_65536B-respSize_65536B-Compressor_false:

Before
```
50_Latency: 103.2264 ms | 90_Latency: 148.4969 ms | 99_Latency: 168.8514 ms | Avg latency: 107.0320 ms | Count: 560864 | 969070 Bytes/op | 67 Allocs/op
```

After
```
50_Latency: 104503.3340 µs | 90_Latency: 147591.8060 µs | 99_Latency: 194919.4060 µs | Avg latency: 100270.9460 µs | Count: 598807 | 938790 Bytes/op | 73 Allocs/op
```

#### Stream-traceMode_false-latency_0s-kbps_0-MTU_0-maxConcurrentCalls_1000-reqSize_1048576B-respSize_1048576B-Compressor_false: 

Before
```
50_Latency: 1748.3104 ms | 90_Latency: 2404.2216 ms | 99_Latency: 6274.2200 ms | Avg latency: 1863.8317 ms | Count: 32668 | 14114507 Bytes/op | 646 Allocs/op
```

After
```
50_Latency: 1455.0151 ms | 90_Latency: 1724.1157 ms | 99_Latency: 4061.2610 ms | Avg latency: 1498.5305 ms | Count: 40510 | 13723061 Bytes/op | 717 Allocs/op
```

This also shows significant improvement on [pinger benchmark](https://github.com/petermattis/pinger) by @petermattis 

Before
```
 ./pinger -c 200 -p 1000 -n 1 -d 10s -t grpc localhost:50051
_elapsed____ops/s_____MB/s__p50(ms)__p95(ms)__p99(ms)_pMax(ms)
     10s 102770.7     39.2     13.1     15.7     18.9     37.7

```

After
```
 ./pinger -c 200 -p 1000 -n 1 -d 10s -t grpc localhost:50051
_elapsed____ops/s_____MB/s__p50(ms)__p95(ms)__p99(ms)_pMax(ms)
     10s 177063.1     67.5      0.0     14.7     18.9     46.1
```


In relation to #1512 

