### PR TITLE
latency: Listen on localhost:0 instead of :0 in test

### DIFF
--- a/benchmark/latency/latency_test.go
+++ b/benchmark/latency/latency_test.go
@@ -187,7 +187,7 @@ func TestListenerAndDialer(t *testing.T) {
 	}
 
 	// Create a real listener and wrap it.
-	l, err := net.Listen("tcp", ":0")
+	l, err := net.Listen("tcp", "localhost:0")
 	if err != nil {
 		t.Fatalf("Unexpected error creating listener: %v", err)
 	}


### PR DESCRIPTION
Errors are appearing from this test recently, with an error that shows an IPv6 address.  Travis does not support IPv6.  Using "localhost:0" seems to work for all our other tests, so let's go with that.
