### PR TITLE
travis: fix GOARCH=386 and add misspell check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,5 @@ before_install:
 script:
   - if [[ -n "$RUN386" ]]; then export GOARCH=386; fi
   - if [[ "$TRAVIS_GO_VERSION" = 1.9* && "$GOARCH" != "386" ]]; then ./vet.sh || exit 1; fi
-  - make test testrace
+  - make test
+  - if [[ "$GOARCH" != "386" ]]; then make testrace || exit 1; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ go:
 matrix:
   include:
   - go: 1.9.x
-    env: GOARCH=386
+    env: RUN386=1
 
 go_import_path: google.golang.org/grpc
 
@@ -17,5 +17,6 @@ before_install:
   - if [[ "$TRAVIS_GO_VERSION" = 1.9* && "$GOARCH" != "386" ]]; then ./vet.sh -install || exit 1; fi
 
 script:
+  - if [[ -n "$RUN386" ]]; then export GOARCH=386; fi
   - if [[ "$TRAVIS_GO_VERSION" = 1.9* && "$GOARCH" != "386" ]]; then ./vet.sh || exit 1; fi
   - make test testrace

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,5 +19,5 @@ before_install:
 script:
   - if [[ -n "$RUN386" ]]; then export GOARCH=386; fi
   - if [[ "$TRAVIS_GO_VERSION" = 1.9* && "$GOARCH" != "386" ]]; then ./vet.sh || exit 1; fi
-  - make test
-  - if [[ "$GOARCH" != "386" ]]; then make testrace || exit 1; fi
+  - make test || exit 1
+  - if [[ "$GOARCH" != "386" ]]; then make testrace; fi

--- a/transport/control.go
+++ b/transport/control.go
@@ -156,7 +156,7 @@ func (qb *quotaPool) add(v int) {
 func (qb *quotaPool) lockedAdd(v int) {
 	var wakeUp bool
 	if qb.quota <= 0 {
-		wakeUp = true // Wake up potential watiers.
+		wakeUp = true // Wake up potential waiters.
 	}
 	qb.quota += v
 	if wakeUp && qb.quota > 0 {

--- a/transport/http2_client.go
+++ b/transport/http2_client.go
@@ -985,7 +985,7 @@ func (t *http2Client) handleGoAway(f *http2.GoAwayFrame) {
 		t.Close()
 		return
 	}
-	// A client can recieve multiple GoAways from the server (see
+	// A client can receive multiple GoAways from the server (see
 	// https://github.com/grpc/grpc-go/issues/1387).  The idea is that the first
 	// GoAway will be sent with an ID of MaxInt32 and the second GoAway will be
 	// sent after an RTT delay with the ID of the last stream the server will

--- a/transport/transport_test.go
+++ b/transport/transport_test.go
@@ -1103,7 +1103,7 @@ func TestMaxStreams(t *testing.T) {
 			}
 		}
 	}()
-	// Test these conditions untill they pass or
+	// Test these conditions until they pass or
 	// we reach the deadline (failure case).
 	for {
 		select {

--- a/vet.sh
+++ b/vet.sh
@@ -22,6 +22,7 @@ if [ "$1" = "-install" ]; then
     github.com/golang/lint/golint \
     golang.org/x/tools/cmd/goimports \
     honnef.co/go/tools/cmd/staticcheck \
+    github.com/client9/misspell/cmd/misspell \
     github.com/golang/protobuf/protoc-gen-go \
     golang.org/x/tools/cmd/stringer
   if [[ "$check_proto" = "true" ]]; then
@@ -76,3 +77,4 @@ fi
 
 # TODO(menghanl): fix errors in transport_test.
 staticcheck -ignore google.golang.org/grpc/transport/transport_test.go:SA2002 ./...
+misspell -error .


### PR DESCRIPTION
1. Define env variable `RUN386` and set `GOARCH` later, instead of assigning to `GOARCH` directly. Otherwise, `gimme` will override `GOARCH` back
2. Add `misspell` check
3. Disable `-race` on 386