### PR TITLE
Add proper support for 'identity' encoding type

### DIFF
--- a/Documentation/compression.md
+++ b/Documentation/compression.md
@@ -1,0 +1,76 @@
+# Compression
+
+The preferred method for configuring message compression on both clients and
+servers is to use
+[`encoding.RegisterCompressor`](https://godoc.org/google.golang.org/grpc/encoding#RegisterCompressor)
+to register an implementation of a compression algorithm.  See
+`grpc/encoding/gzip/gzip.go` for an example of how to implement one.
+
+Once a compressor has been registered on the client-side, RPCs may be sent using
+it via the
+[`UseCompressor`](https://godoc.org/google.golang.org/grpc#UseCompressor)
+`CallOption`.  Remember that `CallOption`s may be turned into defaults for all
+calls from a `ClientConn` by using the
+[`WithDefaultCallOptions`](https://godoc.org/google.golang.org/grpc#WithDefaultCallOptions)
+`DialOption`.
+
+Server-side, registered compressors will be used automatically to decode request
+messages and encode the responses.  Servers currently always respond using the
+same compression method specified by the client.
+
+## Deprecated API
+
+There is a deprecated API for setting compression as well.  It is not
+recommended for use.  However, if you were previously using it, the following
+section may be helpful in understanding how it works in combination with the new
+API.
+
+### Client-Side
+
+There are two legacy functions and one new function to configure compression:
+
+```go
+func WithCompressor(grpc.Compressor) DialOption {}
+func WithDecompressor(grpc.Decompressor) DialOption {}
+func UseCompressor(name) CallOption {}
+```
+
+For outgoing requests, the following rules are applied in order:
+1. If `UseCompressor` is used, messages will be compressed using the compressor
+   named.
+   * If the compressor named is not registered, an Internal error is returned
+     back to the client before sending the RPC.
+   * If UseCompressor("identity"), no compressor will be used, but "identity"
+     will be sent in the header to the server.
+1. If `WithCompressor` is used, messages will be compressed using that
+   compressor implementation.
+1. Otherwise, outbound messages will be uncompressed.
+
+For incoming responses, the following rules are applied in order:
+1. If `WithDecompressor` is used and it matches the message's encoding, it will
+   be used.
+1. If a registered compressor matches the response's encoding, it will be used.
+1. Otherwise, the stream will be closed and an `Unimplemented` status error will
+   be returned to the application.
+
+### Server-Side
+
+There are two legacy functions to configure compression:
+```go
+func RPCCompressor(grpc.Compressor) ServerOption {}
+func RPCDecompressor(grpc.Decompressor) ServerOption {}
+```
+
+For incoming requests, the following rules are applied in order:
+1. If `RPCDecompressor` is used and that decompressor matches the request's
+   encoding: it will be used.
+1. If a registered compressor matches the request's encoding, it will be used.
+1. Otherwise, an `Unimplemented` status will be returned to the client.
+
+For outgoing responses, the following rules are applied in order:
+1. If `RPCCompressor` is used, that compressor will be used to compress all
+   response messages.
+1. If compression was used for the incoming request and a registered compressor
+   supports it, that same compression method will be used for the outgoing
+   response.
+1. Otherwise, no compression will be used for the outgoing response.

--- a/Documentation/compression.md
+++ b/Documentation/compression.md
@@ -12,11 +12,15 @@ it via the
 `CallOption`.  Remember that `CallOption`s may be turned into defaults for all
 calls from a `ClientConn` by using the
 [`WithDefaultCallOptions`](https://godoc.org/google.golang.org/grpc#WithDefaultCallOptions)
-`DialOption`.
+`DialOption`.  If `UseCompressor` is used and the corresponding compressor has
+not been installed, an `Internal` error will be returned to the application
+before the RPC is sent.
 
 Server-side, registered compressors will be used automatically to decode request
 messages and encode the responses.  Servers currently always respond using the
-same compression method specified by the client.
+same compression method specified by the client.  If the corresponding
+compressor has not been registered, an `Unimplemented` status will be returned
+to the client.
 
 ## Deprecated API
 

--- a/call.go
+++ b/call.go
@@ -61,7 +61,19 @@ func recvResponse(ctx context.Context, dopts dialOptions, t transport.ClientTran
 		if c.maxReceiveMessageSize == nil {
 			return Errorf(codes.Internal, "callInfo maxReceiveMessageSize field uninitialized(nil)")
 		}
-		if err = recv(p, dopts.codec, stream, dopts.dc, reply, *c.maxReceiveMessageSize, inPayload, encoding.GetCompressor(c.compressorType)); err != nil {
+
+		// Set dc if it exists and matches the message compression type used,
+		// otherwise set comp if a registered compressor exists for it.
+		var comp encoding.Compressor
+		var dc Decompressor
+		if rc := stream.RecvCompress(); dopts.dc == nil || dopts.dc.Type() != rc {
+			if rc != "" && rc != encoding.Identity {
+				comp = encoding.GetCompressor(rc)
+			}
+		} else {
+			dc = dopts.dc
+		}
+		if err = recv(p, dopts.codec, stream, dc, reply, *c.maxReceiveMessageSize, inPayload, comp); err != nil {
 			if err == io.EOF {
 				break
 			}
@@ -95,10 +107,18 @@ func sendRequest(ctx context.Context, dopts dialOptions, compressor Compressor, 
 			Client: true,
 		}
 	}
-	if c.compressorType != "" && encoding.GetCompressor(c.compressorType) == nil {
-		return Errorf(codes.Internal, "grpc: Compressor is not installed for grpc-encoding %q", c.compressorType)
+	// Set comp and clear compressor if a registered compressor matches the type
+	// specified via UseCompressor.  (And error if a matching compressor is not
+	// registered.)
+	var comp encoding.Compressor
+	if ct := c.compressorType; ct != "" && ct != encoding.Identity {
+		compressor = nil // Disable the legacy compressor.
+		comp = encoding.GetCompressor(ct)
+		if comp == nil {
+			return Errorf(codes.Internal, "grpc: Compressor is not installed for grpc-encoding %q", ct)
+		}
 	}
-	hdr, data, err := encode(dopts.codec, args, compressor, outPayload, encoding.GetCompressor(c.compressorType))
+	hdr, data, err := encode(dopts.codec, args, compressor, outPayload, comp)
 	if err != nil {
 		return err
 	}
@@ -210,9 +230,6 @@ func invoke(ctx context.Context, method string, args, reply interface{}, cc *Cli
 	callHdr := &transport.CallHdr{
 		Host:   cc.authority,
 		Method: method,
-	}
-	if cc.dopts.cp != nil {
-		callHdr.SendCompress = cc.dopts.cp.Type()
 	}
 	if c.creds != nil {
 		callHdr.Creds = c.creds

--- a/call.go
+++ b/call.go
@@ -66,12 +66,10 @@ func recvResponse(ctx context.Context, dopts dialOptions, t transport.ClientTran
 		// otherwise set comp if a registered compressor exists for it.
 		var comp encoding.Compressor
 		var dc Decompressor
-		if rc := stream.RecvCompress(); dopts.dc == nil || dopts.dc.Type() != rc {
-			if rc != "" && rc != encoding.Identity {
-				comp = encoding.GetCompressor(rc)
-			}
-		} else {
+		if rc := stream.RecvCompress(); dopts.dc != nil && dopts.dc.Type() == rc {
 			dc = dopts.dc
+		} else if rc != "" && rc != encoding.Identity {
+			comp = encoding.GetCompressor(rc)
 		}
 		if err = recv(p, dopts.codec, stream, dc, reply, *c.maxReceiveMessageSize, inPayload, comp); err != nil {
 			if err == io.EOF {

--- a/clientconn.go
+++ b/clientconn.go
@@ -107,16 +107,6 @@ const (
 // DialOption configures how we set up the connection.
 type DialOption func(*dialOptions)
 
-// UseCompressor returns a CallOption which sets the compressor used when sending the request.
-// If WithCompressor is set, UseCompressor has higher priority.
-// This API is EXPERIMENTAL.
-func UseCompressor(name string) CallOption {
-	return beforeCall(func(c *callInfo) error {
-		c.compressorType = name
-		return nil
-	})
-}
-
 // WithWriteBufferSize lets you set the size of write buffer, this determines how much data can be batched
 // before doing a write on the wire.
 func WithWriteBufferSize(s int) DialOption {
@@ -168,18 +158,26 @@ func WithCodec(c Codec) DialOption {
 	}
 }
 
-// WithCompressor returns a DialOption which sets a CompressorGenerator for generating message
-// compressor. It has lower priority than the compressor set by RegisterCompressor.
-// This function is deprecated.
+// WithCompressor returns a DialOption which sets a Compressor to use for
+// message compression. It has lower priority than the compressor set by
+// the UseCompressor CallOption.
+//
+// Deprecated: use UseCompressor instead.
 func WithCompressor(cp Compressor) DialOption {
 	return func(o *dialOptions) {
 		o.cp = cp
 	}
 }
 
-// WithDecompressor returns a DialOption which sets a DecompressorGenerator for generating
-// message decompressor. It has higher priority than the decompressor set by RegisterCompressor.
-// This function is deprecated.
+// WithDecompressor returns a DialOption which sets a Decompressor to use for
+// incoming message decompression.  If incoming response messages are encoded
+// using the decompressor's Type(), it will be used.  Otherwise, the message
+// encoding will be used to look up the compressor registered via
+// encoding.RegisterCompressor, which will then be used to decompress the
+// message.  If no compressor is registered for the encoding, an Unimplemented
+// status error will be returned.
+//
+// Deprecated: use encoding.RegisterCompressor instead.
 func WithDecompressor(dc Decompressor) DialOption {
 	return func(o *dialOptions) {
 		o.dc = dc

--- a/encoding/encoding.go
+++ b/encoding/encoding.go
@@ -55,3 +55,7 @@ func RegisterCompressor(c Compressor) {
 func GetCompressor(name string) Compressor {
 	return registerCompressor[name]
 }
+
+// Identity specifies the optional encoding for uncompressed streams.
+// It is intended for grpc internal use only.
+const Identity = "identity"

--- a/service_config_test.go
+++ b/service_config_test.go
@@ -83,7 +83,7 @@ func TestParseLoadBalancer(t *testing.T) {
 	}
 }
 
-func TestPraseWaitForReady(t *testing.T) {
+func TestParseWaitForReady(t *testing.T) {
 	testcases := []struct {
 		scjs    string
 		wantSC  ServiceConfig

--- a/stream.go
+++ b/stream.go
@@ -666,7 +666,6 @@ func (ss *serverStream) SendMsg(m interface{}) (err error) {
 }
 
 func (ss *serverStream) RecvMsg(m interface{}) (err error) {
-
 	defer func() {
 		if ss.trInfo != nil {
 			ss.mu.Lock()

--- a/stream.go
+++ b/stream.go
@@ -588,11 +588,10 @@ type serverStream struct {
 	p     *parser
 	codec Codec
 
-	cp        Compressor
-	dc        Decompressor
-	comp      encoding.Compressor
-	decomp    encoding.Compressor
-	decompSet bool
+	cp     Compressor
+	dc     Decompressor
+	comp   encoding.Compressor
+	decomp encoding.Compressor
 
 	maxReceiveMessageSize int
 	maxSendMessageSize    int
@@ -667,18 +666,6 @@ func (ss *serverStream) SendMsg(m interface{}) (err error) {
 }
 
 func (ss *serverStream) RecvMsg(m interface{}) (err error) {
-	if !ss.decompSet {
-		if ct := ss.s.RecvCompress(); ct != "" && ct != encoding.Identity {
-			if ss.dc == nil || ss.dc.Type() != ct {
-				ss.dc = nil
-				ss.decomp = encoding.GetCompressor(ct)
-			}
-		} else {
-			// No compression is used; disable our decompressor.
-			ss.dc = nil
-		}
-		ss.decompSet = true
-	}
 
 	defer func() {
 		if ss.trInfo != nil {

--- a/stream.go
+++ b/stream.go
@@ -151,10 +151,24 @@ func newClientStream(ctx context.Context, desc *StreamDesc, cc *ClientConn, meth
 		// time soon, so we ask the transport to flush the header.
 		Flush: desc.ClientStreams,
 	}
-	if c.compressorType != "" {
-		callHdr.SendCompress = c.compressorType
+
+	// Set our outgoing compression according to the UseCompressor CallOption, if
+	// set.  In that case, also find the compressor from the encoding package.
+	// Otherwise, use the compressor configured by the WithCompressor DialOption,
+	// if set.
+	var cp Compressor
+	var comp encoding.Compressor
+	if ct := c.compressorType; ct != "" {
+		callHdr.SendCompress = ct
+		if ct != encoding.Identity {
+			comp = encoding.GetCompressor(ct)
+			if comp == nil {
+				return nil, Errorf(codes.Internal, "grpc: Compressor is not installed for requested grpc-encoding %q", ct)
+			}
+		}
 	} else if cc.dopts.cp != nil {
 		callHdr.SendCompress = cc.dopts.cp.Type()
+		cp = cc.dopts.cp
 	}
 	if c.creds != nil {
 		callHdr.Creds = c.creds
@@ -241,9 +255,9 @@ func newClientStream(ctx context.Context, desc *StreamDesc, cc *ClientConn, meth
 		c:      c,
 		desc:   desc,
 		codec:  cc.dopts.codec,
-		cpType: c.compressorType,
-		cp:     cc.dopts.cp,
+		cp:     cp,
 		dc:     cc.dopts.dc,
+		comp:   comp,
 		cancel: cancel,
 
 		done: done,
@@ -285,16 +299,20 @@ func newClientStream(ctx context.Context, desc *StreamDesc, cc *ClientConn, meth
 
 // clientStream implements a client side Stream.
 type clientStream struct {
-	opts   []CallOption
-	c      *callInfo
-	t      transport.ClientTransport
-	s      *transport.Stream
-	p      *parser
-	desc   *StreamDesc
-	codec  Codec
-	cpType string
-	cp     Compressor
-	dc     Decompressor
+	opts []CallOption
+	c    *callInfo
+	t    transport.ClientTransport
+	s    *transport.Stream
+	p    *parser
+	desc *StreamDesc
+
+	codec     Codec
+	cp        Compressor
+	dc        Decompressor
+	comp      encoding.Compressor
+	decomp    encoding.Compressor
+	decompSet bool
+
 	cancel context.CancelFunc
 
 	tracing bool // set to EnableTracing when the clientStream is created.
@@ -370,10 +388,7 @@ func (cs *clientStream) SendMsg(m interface{}) (err error) {
 			Client: true,
 		}
 	}
-	if cs.cpType != "" && encoding.GetCompressor(cs.cpType) == nil {
-		return Errorf(codes.Internal, "grpc: Compressor is not installed for grpc-encoding %q", cs.cpType)
-	}
-	hdr, data, err := encode(cs.codec, m, cs.cp, outPayload, encoding.GetCompressor(cs.cpType))
+	hdr, data, err := encode(cs.codec, m, cs.cp, outPayload, cs.comp)
 	if err != nil {
 		return err
 	}
@@ -401,7 +416,23 @@ func (cs *clientStream) RecvMsg(m interface{}) (err error) {
 	if cs.c.maxReceiveMessageSize == nil {
 		return Errorf(codes.Internal, "callInfo maxReceiveMessageSize field uninitialized(nil)")
 	}
-	err = recv(cs.p, cs.codec, cs.s, cs.dc, m, *cs.c.maxReceiveMessageSize, inPayload, encoding.GetCompressor(cs.cpType))
+	if !cs.decompSet {
+		// Block until we receive headers containing received message encoding.
+		if ct := cs.s.RecvCompress(); ct != "" && ct != encoding.Identity {
+			if cs.dc == nil || cs.dc.Type() != ct {
+				// No configured decompressor, or it does not match the incoming
+				// message encoding; attempt to find a registered compressor that does.
+				cs.dc = nil
+				cs.decomp = encoding.GetCompressor(ct)
+			}
+		} else {
+			// No compression is used; disable our decompressor.
+			cs.dc = nil
+		}
+		// Only initialize this state once per stream.
+		cs.decompSet = true
+	}
+	err = recv(cs.p, cs.codec, cs.s, cs.dc, m, *cs.c.maxReceiveMessageSize, inPayload, cs.decomp)
 	defer func() {
 		// err != nil indicates the termination of the stream.
 		if err != nil {
@@ -427,7 +458,7 @@ func (cs *clientStream) RecvMsg(m interface{}) (err error) {
 		if cs.c.maxReceiveMessageSize == nil {
 			return Errorf(codes.Internal, "callInfo maxReceiveMessageSize field uninitialized(nil)")
 		}
-		err = recv(cs.p, cs.codec, cs.s, cs.dc, m, *cs.c.maxReceiveMessageSize, nil, encoding.GetCompressor(cs.cpType))
+		err = recv(cs.p, cs.codec, cs.s, cs.dc, m, *cs.c.maxReceiveMessageSize, nil, cs.decomp)
 		cs.closeTransportStream(err)
 		if err == nil {
 			return toRPCErr(errors.New("grpc: client streaming protocol violation: get <nil>, want <EOF>"))
@@ -552,13 +583,17 @@ type ServerStream interface {
 
 // serverStream implements a server side Stream.
 type serverStream struct {
-	t                     transport.ServerTransport
-	s                     *transport.Stream
-	p                     *parser
-	codec                 Codec
-	cpType                string
-	cp                    Compressor
-	dc                    Decompressor
+	t     transport.ServerTransport
+	s     *transport.Stream
+	p     *parser
+	codec Codec
+
+	cp        Compressor
+	dc        Decompressor
+	comp      encoding.Compressor
+	decomp    encoding.Compressor
+	decompSet bool
+
 	maxReceiveMessageSize int
 	maxSendMessageSize    int
 	trInfo                *traceInfo
@@ -614,12 +649,7 @@ func (ss *serverStream) SendMsg(m interface{}) (err error) {
 	if ss.statsHandler != nil {
 		outPayload = &stats.OutPayload{}
 	}
-	if ss.cpType != "" {
-		if encoding.GetCompressor(ss.cpType) == nil && (ss.cp == nil || ss.cp != nil && ss.cp.Type() != ss.cpType) {
-			return Errorf(codes.Internal, "grpc: Compressor is not installed for grpc-encoding %q", ss.cpType)
-		}
-	}
-	hdr, data, err := encode(ss.codec, m, ss.cp, outPayload, encoding.GetCompressor(ss.cpType))
+	hdr, data, err := encode(ss.codec, m, ss.cp, outPayload, ss.comp)
 	if err != nil {
 		return err
 	}
@@ -637,6 +667,19 @@ func (ss *serverStream) SendMsg(m interface{}) (err error) {
 }
 
 func (ss *serverStream) RecvMsg(m interface{}) (err error) {
+	if !ss.decompSet {
+		if ct := ss.s.RecvCompress(); ct != "" && ct != encoding.Identity {
+			if ss.dc == nil || ss.dc.Type() != ct {
+				ss.dc = nil
+				ss.decomp = encoding.GetCompressor(ct)
+			}
+		} else {
+			// No compression is used; disable our decompressor.
+			ss.dc = nil
+		}
+		ss.decompSet = true
+	}
+
 	defer func() {
 		if ss.trInfo != nil {
 			ss.mu.Lock()
@@ -659,7 +702,7 @@ func (ss *serverStream) RecvMsg(m interface{}) (err error) {
 	if ss.statsHandler != nil {
 		inPayload = &stats.InPayload{}
 	}
-	if err := recv(ss.p, ss.codec, ss.s, ss.dc, m, ss.maxReceiveMessageSize, inPayload, encoding.GetCompressor(ss.cpType)); err != nil {
+	if err := recv(ss.p, ss.codec, ss.s, ss.dc, m, ss.maxReceiveMessageSize, inPayload, ss.decomp); err != nil {
 		if err == io.EOF {
 			return err
 		}

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -252,6 +252,9 @@ type Stream struct {
 // RecvCompress returns the compression algorithm applied to the inbound
 // message. It is empty string if there is no compression applied.
 func (s *Stream) RecvCompress() string {
+	if s.headerChan != nil {
+		<-s.headerChan
+	}
 	return s.recvCompress
 }
 
@@ -527,10 +530,6 @@ type CallHdr struct {
 
 	// Method specifies the operation to perform.
 	Method string
-
-	// RecvCompress specifies the compression algorithm applied on
-	// inbound messages.
-	RecvCompress string
 
 	// SendCompress specifies the compression algorithm applied on
 	// outbound message.

--- a/vet.sh
+++ b/vet.sh
@@ -76,5 +76,10 @@ if [[ "$check_proto" = "true" ]]; then
 fi
 
 # TODO(menghanl): fix errors in transport_test.
-staticcheck -ignore "google.golang.org/grpc/transport/transport_test.go:SA2002 google.golang.org/grpc/benchmark/benchmain/main.go:SA1019 google.golang.org/grpc/stats/stats_test.go:SA1019 google.golang.org/grpc/test/end2end_test.go:SA1019" ./...
+staticcheck -ignore '
+google.golang.org/grpc/transport/transport_test.go:SA2002
+google.golang.org/grpc/benchmark/benchmain/main.go:SA1019
+google.golang.org/grpc/stats/stats_test.go:SA1019
+google.golang.org/grpc/test/end2end_test.go:SA1019
+' ./...
 misspell -error .

--- a/vet.sh
+++ b/vet.sh
@@ -76,5 +76,5 @@ if [[ "$check_proto" = "true" ]]; then
 fi
 
 # TODO(menghanl): fix errors in transport_test.
-staticcheck -ignore google.golang.org/grpc/transport/transport_test.go:SA2002 ./...
+staticcheck -ignore "google.golang.org/grpc/transport/transport_test.go:SA2002 google.golang.org/grpc/benchmark/benchmain/main.go:SA1019 google.golang.org/grpc/stats/stats_test.go:SA1019 google.golang.org/grpc/test/end2end_test.go:SA1019" ./...
 misspell -error .


### PR DESCRIPTION
I also added a document to explain how this is supposed to work, and how it works if you use the legacy compressor/decompressor.

Fixes #1654 