### PR TITLE
switch balancer based on service config info

### DIFF
--- a/balancer/roundrobin/roundrobin.go
+++ b/balancer/roundrobin/roundrobin.go
@@ -56,7 +56,7 @@ func (*rrBuilder) Build(cc balancer.ClientConn, opt balancer.BuildOptions) balan
 }
 
 func (*rrBuilder) Name() string {
-	return "roundrobin"
+	return "round_robin"
 }
 
 type rrBalancer struct {

--- a/balancer/roundrobin/roundrobin_test.go
+++ b/balancer/roundrobin/roundrobin_test.go
@@ -37,7 +37,7 @@ import (
 	"google.golang.org/grpc/test/leakcheck"
 )
 
-var rr = balancer.Get("roundrobin")
+var rr = balancer.Get("round_robin")
 
 type testServer struct {
 	testpb.TestServiceServer

--- a/balancer_switching_test.go
+++ b/balancer_switching_test.go
@@ -121,12 +121,12 @@ func TestSwitchBalancer(t *testing.T) {
 		t.Fatalf("check pickfirst returned non-nil error: %v", err)
 	}
 	// Switch to roundrobin.
-	cc.handleServiceConfig(`{"loadBalancingPolicy": "round_robin"}`)
+	cc.handleServiceConfig(`{"loadBalancingPolicy": "roundrobin"}`)
 	if err := checkRoundRobin(cc, servers); err != nil {
 		t.Fatalf("check roundrobin returned non-nil error: %v", err)
 	}
 	// Switch to pickfirst.
-	cc.handleServiceConfig(`{"loadBalancingPolicy": ""pickfirst"}`)
+	cc.handleServiceConfig(`{"loadBalancingPolicy": "pickfirst"}`)
 	if err := checkPickFirst(cc, servers); err != nil {
 		t.Fatalf("check pickfirst returned non-nil error: %v", err)
 	}

--- a/balancer_switching_test.go
+++ b/balancer_switching_test.go
@@ -121,12 +121,12 @@ func TestSwitchBalancer(t *testing.T) {
 		t.Fatalf("check pickfirst returned non-nil error: %v", err)
 	}
 	// Switch to roundrobin.
-	cc.handleServiceConfig(`{"loadBalancingPolicy": "roundrobin"}`)
+	cc.handleServiceConfig(`{"loadBalancingPolicy": "round_robin"}`)
 	if err := checkRoundRobin(cc, servers); err != nil {
 		t.Fatalf("check roundrobin returned non-nil error: %v", err)
 	}
 	// Switch to pickfirst.
-	cc.handleServiceConfig(`{"loadBalancingPolicy": "pickfirst"}`)
+	cc.handleServiceConfig(`{"loadBalancingPolicy": "pick_first"}`)
 	if err := checkPickFirst(cc, servers); err != nil {
 		t.Fatalf("check pickfirst returned non-nil error: %v", err)
 	}

--- a/balancer_switching_test.go
+++ b/balancer_switching_test.go
@@ -121,12 +121,12 @@ func TestSwitchBalancer(t *testing.T) {
 		t.Fatalf("check pickfirst returned non-nil error: %v", err)
 	}
 	// Switch to roundrobin.
-	cc.switchBalancer("roundrobin")
+	cc.handleServiceConfig(`{"loadBalancingPolicy": "round_robin"}`)
 	if err := checkRoundRobin(cc, servers); err != nil {
 		t.Fatalf("check roundrobin returned non-nil error: %v", err)
 	}
 	// Switch to pickfirst.
-	cc.switchBalancer("pickfirst")
+	cc.handleServiceConfig(`{"loadBalancingPolicy": ""pickfirst"}`)
 	if err := checkPickFirst(cc, servers); err != nil {
 		t.Fatalf("check pickfirst returned non-nil error: %v", err)
 	}

--- a/clientconn.go
+++ b/clientconn.go
@@ -645,7 +645,6 @@ func (cc *ClientConn) handleResolvedAddrs(addrs []resolver.Address, err error) {
 
 // switchBalancer starts the switching from current balancer to the balancer with name.
 func (cc *ClientConn) switchBalancer(name string) {
-
 	if cc.conns == nil {
 		return
 	}

--- a/clientconn.go
+++ b/clientconn.go
@@ -817,12 +817,12 @@ func (cc *ClientConn) handleServiceConfig(js string) error {
 		return err
 	}
 	cc.mu.Lock()
-	defer cc.mu.Unlock()
 	cc.scRaw = js
 	cc.sc = sc
 	if sc.LB != nil {
 		cc.switchBalancer(*sc.LB)
 	}
+	cc.mu.Unlock()
 	return nil
 }
 

--- a/clientconn.go
+++ b/clientconn.go
@@ -645,6 +645,7 @@ func (cc *ClientConn) handleResolvedAddrs(addrs []resolver.Address, err error) {
 
 // switchBalancer starts the switching from current balancer to the balancer with name.
 func (cc *ClientConn) switchBalancer(name string) {
+
 	if cc.conns == nil {
 		return
 	}
@@ -816,12 +817,12 @@ func (cc *ClientConn) handleServiceConfig(js string) error {
 		return err
 	}
 	cc.mu.Lock()
+	defer cc.mu.Unlock()
 	cc.scRaw = js
 	cc.sc = sc
 	if sc.LB != nil {
 		cc.switchBalancer(*sc.LB)
 	}
-	cc.mu.Unlock()
 	return nil
 }
 

--- a/clientconn.go
+++ b/clientconn.go
@@ -645,8 +645,6 @@ func (cc *ClientConn) handleResolvedAddrs(addrs []resolver.Address, err error) {
 
 // switchBalancer starts the switching from current balancer to the balancer with name.
 func (cc *ClientConn) switchBalancer(name string) {
-	cc.mu.Lock()
-	defer cc.mu.Unlock()
 	if cc.conns == nil {
 		return
 	}
@@ -820,6 +818,9 @@ func (cc *ClientConn) handleServiceConfig(js string) error {
 	cc.mu.Lock()
 	cc.scRaw = js
 	cc.sc = sc
+	if sc.LB != nil {
+		cc.switchBalancer(*sc.LB)
+	}
 	cc.mu.Unlock()
 	return nil
 }

--- a/pickfirst.go
+++ b/pickfirst.go
@@ -37,7 +37,7 @@ func (*pickfirstBuilder) Build(cc balancer.ClientConn, opt balancer.BuildOptions
 }
 
 func (*pickfirstBuilder) Name() string {
-	return "pickfirst"
+	return "pick_first"
 }
 
 type pickfirstBalancer struct {

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -377,7 +377,7 @@ type env struct {
 	network      string // The type of network such as tcp, unix, etc.
 	security     string // The security protocol such as TLS, SSH, etc.
 	httpHandler  bool   // whether to use the http.Handler ServerTransport; requires TLS
-	balancer     string // One of "roundrobin", "pickfirst", "v1", or "".
+	balancer     string // One of "round_robin", "pick_first", "v1", or "".
 	customDialer func(string, string, time.Duration) (net.Conn, error)
 }
 
@@ -398,9 +398,9 @@ func (e env) dialer(addr string, timeout time.Duration) (net.Conn, error) {
 var (
 	tcpClearEnv   = env{name: "tcp-clear-v1-balancer", network: "tcp", balancer: "v1"}
 	tcpTLSEnv     = env{name: "tcp-tls-v1-balancer", network: "tcp", security: "tls", balancer: "v1"}
-	tcpClearRREnv = env{name: "tcp-clear", network: "tcp", balancer: "roundrobin"}
-	tcpTLSRREnv   = env{name: "tcp-tls", network: "tcp", security: "tls", balancer: "roundrobin"}
-	handlerEnv    = env{name: "handler-tls", network: "tcp", security: "tls", httpHandler: true, balancer: "roundrobin"}
+	tcpClearRREnv = env{name: "tcp-clear", network: "tcp", balancer: "round_robin"}
+	tcpTLSRREnv   = env{name: "tcp-tls", network: "tcp", security: "tls", balancer: "round_robin"}
+	handlerEnv    = env{name: "handler-tls", network: "tcp", security: "tls", httpHandler: true, balancer: "round_robin"}
 	noBalancerEnv = env{name: "no-balancer", network: "tcp", security: "tls"}
 	allEnv        = []env{tcpClearEnv, tcpTLSEnv, tcpClearRREnv, tcpTLSRREnv, handlerEnv, noBalancerEnv}
 )
@@ -682,7 +682,7 @@ func (te *test) clientConn() *grpc.ClientConn {
 	default:
 		opts = append(opts, grpc.WithInsecure())
 	}
-	// TODO(bar) switch balancer case "pickfirst".
+	// TODO(bar) switch balancer case "pick_first".
 	var scheme string
 	if te.resolverScheme == "" {
 		scheme = "passthrough:///"
@@ -692,8 +692,8 @@ func (te *test) clientConn() *grpc.ClientConn {
 	switch te.e.balancer {
 	case "v1":
 		opts = append(opts, grpc.WithBalancer(grpc.RoundRobin(nil)))
-	case "roundrobin":
-		rr := balancer.Get("roundrobin")
+	case "round_robin":
+		rr := balancer.Get("round_robin")
 		if rr == nil {
 			te.t.Fatalf("got nil when trying to get roundrobin balancer builder")
 		}


### PR DESCRIPTION
Update roundrobin balancer's name from `roundrobin` to `round_robin. To be consistent with service config [spec](https://github.com/grpc/grpc/blob/e7987f80c6139671b639cdbe0dd37000359869ab/doc/service_config.md#format).