### PR TITLE
set context timeout when Timeout value >= 0

### DIFF
--- a/stream.go
+++ b/stream.go
@@ -124,7 +124,7 @@ func newClientStream(ctx context.Context, desc *StreamDesc, cc *ClientConn, meth
 		c.failFast = !*mc.WaitForReady
 	}
 
-	if mc.Timeout != nil {
+	if mc.Timeout != nil && *mc.Timeout >= 0 {
 		ctx, cancel = context.WithTimeout(ctx, *mc.Timeout)
 		defer func() {
 			if err != nil {


### PR DESCRIPTION
Just to be consistent with call.go/invoke
