### PR TITLE
Re-resolve target when one connection becomes TransientFailure

### DIFF
--- a/clientconn.go
+++ b/clientconn.go
@@ -637,10 +637,8 @@ func (cc *ClientConn) handleResolvedAddrs(addrs []resolver.Address, err error) {
 	if cc.balancerWrapper == nil {
 		// First time handling resolved addresses. Build a balancer use either
 		// the builder specified by dial option, or pickfirst.
-		var builder balancer.Builder
-		if cc.dopts.balancerBuilder != nil {
-			builder = cc.dopts.balancerBuilder
-		} else {
+		builder := cc.dopts.balancerBuilder
+		if builder == nil {
 			// No customBalancer was specified by DialOption, and this is the first
 			// time handling resolved addresses, create a pickfirst balancer.
 			builder = newPickfirstBuilder()
@@ -838,11 +836,10 @@ func (cc *ClientConn) handleServiceConfig(js string) error {
 func (cc *ClientConn) resolveNow(o resolver.ResolveNowOption) {
 	cc.mu.Lock()
 	r := cc.resolverWrapper
+	cc.mu.Unlock()
 	if r == nil {
-		cc.mu.Unlock()
 		return
 	}
-	cc.mu.Unlock()
 	go r.resolveNow(o)
 }
 

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -128,8 +128,10 @@ type ResolveNowOption struct{}
 // Resolver watches for the updates on the specified target.
 // Updates include address updates and service config updates.
 type Resolver interface {
-	// ResolveNow will be called by gRPC to try to resolve the target name again.
-	// It's just a hint, resolver can ignore this if it's not necessary.
+	// ResolveNow will be called by gRPC to try to resolve the target name
+	// again. It's just a hint, resolver can ignore this if it's not necessary.
+	//
+	// It could be called multiple times concurrently.
 	ResolveNow(ResolveNowOption)
 	// Close closes the resolver.
 	Close()

--- a/resolver_conn_wrapper.go
+++ b/resolver_conn_wrapper.go
@@ -81,8 +81,11 @@ func newCCResolverWrapper(cc *ClientConn) (*ccResolverWrapper, error) {
 	if err != nil {
 		return nil, err
 	}
-	go ccr.watcher()
 	return ccr, nil
+}
+
+func (ccr *ccResolverWrapper) start() {
+	go ccr.watcher()
 }
 
 // watcher processes address updates and service config updates sequencially.
@@ -117,6 +120,10 @@ func (ccr *ccResolverWrapper) watcher() {
 			return
 		}
 	}
+}
+
+func (ccr *ccResolverWrapper) resolveNow(o resolver.ResolveNowOption) {
+	ccr.resolver.ResolveNow(o)
 }
 
 func (ccr *ccResolverWrapper) close() {


### PR DESCRIPTION
This allows ClientConn to get more up-to-date addresses from resolver.
ClientConn compares new addresses with the cached ones. So if resolver returns the same set of addresses, ClientConn will not notify balancer about it.

Also moved the initialization of resolver and balancer to avoid race. Balancer will only be started when ClientConn gets resolved addresses from balancer.