### PR TITLE
Fix panics on balancer and resolver updates

### DIFF
--- a/clientconn_test.go
+++ b/clientconn_test.go
@@ -30,6 +30,8 @@ import (
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/naming"
+	"google.golang.org/grpc/resolver"
+	"google.golang.org/grpc/resolver/manual"
 	_ "google.golang.org/grpc/resolver/passthrough"
 	"google.golang.org/grpc/test/leakcheck"
 	"google.golang.org/grpc/testdata"
@@ -327,6 +329,41 @@ func TestNonblockingDialWithEmptyBalancer(t *testing.T) {
 	if err := <-dialDone; err != nil {
 		t.Fatalf("unexpected error dialing connection: %s", err)
 	}
+}
+
+func TestResolverServiceConfigBeforeAddressNotPanic(t *testing.T) {
+	defer leakcheck.Check(t)
+	r, rcleanup := manual.GenerateAndRegisterManualResolver()
+	defer rcleanup()
+
+	cc, err := Dial(r.Scheme()+":///test.server", WithInsecure())
+	if err != nil {
+		t.Fatalf("failed to dial: %v", err)
+	}
+	defer cc.Close()
+
+	// SwitchBalancer before NewAddress. There was no balancer created, this
+	// makes sure we don't call close on nil balancerWrapper.
+	r.NewServiceConfig(`{"loadBalancingPolicy": "round_robin"}`) // This should not panic.
+
+	time.Sleep(time.Second) //Sleep to make sure the service config is handled by ClientConn.
+}
+
+func TestResolverEmptyUpdateNotPanic(t *testing.T) {
+	defer leakcheck.Check(t)
+	r, rcleanup := manual.GenerateAndRegisterManualResolver()
+	defer rcleanup()
+
+	cc, err := Dial(r.Scheme()+":///test.server", WithInsecure())
+	if err != nil {
+		t.Fatalf("failed to dial: %v", err)
+	}
+	defer cc.Close()
+
+	// This make sure we don't create addrConn with empty address list.
+	r.NewAddress([]resolver.Address{}) // This should not panic.
+
+	time.Sleep(time.Second) //Sleep to make sure the service config is handled by ClientConn.
 }
 
 func TestClientUpdatesParamsAfterGoAway(t *testing.T) {

--- a/clientconn_test.go
+++ b/clientconn_test.go
@@ -346,7 +346,7 @@ func TestResolverServiceConfigBeforeAddressNotPanic(t *testing.T) {
 	// makes sure we don't call close on nil balancerWrapper.
 	r.NewServiceConfig(`{"loadBalancingPolicy": "round_robin"}`) // This should not panic.
 
-	time.Sleep(time.Second) //Sleep to make sure the service config is handled by ClientConn.
+	time.Sleep(time.Second) // Sleep to make sure the service config is handled by ClientConn.
 }
 
 func TestResolverEmptyUpdateNotPanic(t *testing.T) {
@@ -363,7 +363,7 @@ func TestResolverEmptyUpdateNotPanic(t *testing.T) {
 	// This make sure we don't create addrConn with empty address list.
 	r.NewAddress([]resolver.Address{}) // This should not panic.
 
-	time.Sleep(time.Second) //Sleep to make sure the service config is handled by ClientConn.
+	time.Sleep(time.Second) // Sleep to make sure the service config is handled by ClientConn.
 }
 
 func TestClientUpdatesParamsAfterGoAway(t *testing.T) {


### PR DESCRIPTION
 - NewAddress with empty list (addrConn with an empty address list)
 - NewServiceConfig to switch balancer before the first balancer is built

updates #1683

This makes NewSubConn() with empty list return an error, and makes UpdateAddress() with empty list tear the addrConn down. The SubConn won't be usable after this.
Eventually we want to make the SubConn with empty address list stay in TransientFailure but still usable, and balancer still can update this SubConn's address. This will be done in a follow-up PR.