### PR TITLE
transport: fix race sending RPC status that could lead to a panic

### DIFF
--- a/transport/handler_server_test.go
+++ b/transport/handler_server_test.go
@@ -391,9 +391,10 @@ func TestHandlerTransport_HandleStreams_Timeout(t *testing.T) {
 	}
 }
 
+// TestHandlerTransport_HandleStreams_MultiWriteStatus ensures that
+// concurrent "WriteStatus"s do not panic writing to closed "writes" channel.
 func TestHandlerTransport_HandleStreams_MultiWriteStatus(t *testing.T) {
-	st := newHandleStreamTest(t)
-	handleStream := func(s *Stream) {
+	testHandlerTransportHandleStreams(t, func(st *handleStreamTest, s *Stream) {
 		if want := "/service/foo.bar"; s.method != want {
 			t.Errorf("stream method = %q; want %q", s.method, want)
 		}
@@ -408,9 +409,27 @@ func TestHandlerTransport_HandleStreams_MultiWriteStatus(t *testing.T) {
 			}()
 		}
 		wg.Wait()
-	}
+	})
+}
+
+// TestHandlerTransport_HandleStreams_WriteStatusWrite ensures that "Write"
+// following "WriteStatus" does not panic writing to closed "writes" channel.
+func TestHandlerTransport_HandleStreams_WriteStatusWrite(t *testing.T) {
+	testHandlerTransportHandleStreams(t, func(st *handleStreamTest, s *Stream) {
+		if want := "/service/foo.bar"; s.method != want {
+			t.Errorf("stream method = %q; want %q", s.method, want)
+		}
+		st.bodyw.Close() // no body
+
+		st.ht.WriteStatus(s, status.New(codes.OK, ""))
+		st.ht.Write(s, []byte("hdr"), []byte("data"), &Options{})
+	})
+}
+
+func testHandlerTransportHandleStreams(t *testing.T, handleStream func(st *handleStreamTest, s *Stream)) {
+	st := newHandleStreamTest(t)
 	st.ht.HandleStreams(
-		func(s *Stream) { go handleStream(s) },
+		func(s *Stream) { go handleStream(st, s) },
 		func(ctx context.Context, method string) context.Context { return ctx },
 	)
 }


### PR DESCRIPTION
Fix https://github.com/coreos/etcd/issues/8904.

To reproduce, run these tests without this patch to `transport/handler_server.go`:

```
go test -v -run TestHandlerTransport_HandleStreams_WriteStatusWrite

=== RUN   TestHandlerTransport_HandleStreams_WriteStatusWrite
--- PASS: TestHandlerTransport_HandleStreams_WriteStatusWrite (0.00s)
panic: send on closed channel

goroutine 8 [running]:
google.golang.org/grpc/transport.(*serverHandlerTransport).do(0xc420164230, 0xc42007e410, 0x1012a08, 0x10)
	/Users/gyuho/go/src/google.golang.org/grpc/transport/handler_server.go:170 +0x115
google.golang.org/grpc/transport.(*serverHandlerTransport).Write(0xc420164230, 0xc420098640, 0xc420016760, 0x3, 0x8, 0xc420016768, 0x4, 0x8, 0xc420016770, 0x0, ...)
	/Users/gyuho/go/src/google.golang.org/grpc/transport/handler_server.go:256 +0xe6
google.golang.org/grpc/transport.TestHandlerTransport_HandleStreams_WriteStatusWrite.func1(0xc4200115c0, 0xc420098640)
	/Users/gyuho/go/src/google.golang.org/grpc/transport/handler_server_test.go:431 +0x2d8
created by google.golang.org/grpc/transport.testHandlerTransportHandleStreams.func1
	/Users/gyuho/go/src/google.golang.org/grpc/transport/handler_server_test.go:399 +0x45
exit status 2
FAIL	google.golang.org/grpc/transport	0.019s
```

UPDATE(2017-11-30):

`WriteStatus` can be called concurrently: one by `SendMsg`,
the other by `RecvMsg`. Then, closing `writes` channel
becomes racey without proper locking.

Make transport closing synchronous in such case.