### PR TITLE
use the request context with net/http handler

### DIFF
--- a/transport/go16.go
+++ b/transport/go16.go
@@ -22,6 +22,7 @@ package transport
 
 import (
 	"net"
+	"net/http"
 
 	"google.golang.org/grpc/codes"
 
@@ -42,4 +43,9 @@ func ContextErr(err error) StreamError {
 		return streamErrorf(codes.Canceled, "%v", err)
 	}
 	return streamErrorf(codes.Internal, "Unexpected error from context packet: %v", err)
+}
+
+// contextFromRequest returns a background context.
+func contextFromRequest(r *http.Request) context.Context {
+	return context.Background()
 }

--- a/transport/go17.go
+++ b/transport/go17.go
@@ -23,6 +23,7 @@ package transport
 import (
 	"context"
 	"net"
+	"net/http"
 
 	"google.golang.org/grpc/codes"
 
@@ -43,4 +44,9 @@ func ContextErr(err error) StreamError {
 		return streamErrorf(codes.Canceled, "%v", err)
 	}
 	return streamErrorf(codes.Internal, "Unexpected error from context packet: %v", err)
+}
+
+// contextFromRequest returns a context from the HTTP Request.
+func contextFromRequest(r *http.Request) context.Context {
+	return r.Context()
 }

--- a/transport/handler_server.go
+++ b/transport/handler_server.go
@@ -285,7 +285,7 @@ func (ht *serverHandlerTransport) WriteHeader(s *Stream, md metadata.MD) error {
 func (ht *serverHandlerTransport) HandleStreams(startStream func(*Stream), traceCtx func(context.Context, string) context.Context) {
 	// With this transport type there will be exactly 1 stream: this HTTP request.
 
-	ctx := ht.req.Context()
+	ctx := contextFromRequest(ht.req)
 	var cancel context.CancelFunc
 	if ht.timeoutSet {
 		ctx, cancel = context.WithTimeout(ctx, ht.timeout)

--- a/transport/handler_server.go
+++ b/transport/handler_server.go
@@ -285,12 +285,12 @@ func (ht *serverHandlerTransport) WriteHeader(s *Stream, md metadata.MD) error {
 func (ht *serverHandlerTransport) HandleStreams(startStream func(*Stream), traceCtx func(context.Context, string) context.Context) {
 	// With this transport type there will be exactly 1 stream: this HTTP request.
 
-	var ctx context.Context
+	ctx := ht.req.Context()
 	var cancel context.CancelFunc
 	if ht.timeoutSet {
-		ctx, cancel = context.WithTimeout(context.Background(), ht.timeout)
+		ctx, cancel = context.WithTimeout(ctx, ht.timeout)
 	} else {
-		ctx, cancel = context.WithCancel(context.Background())
+		ctx, cancel = context.WithCancel(ctx)
 	}
 
 	// requestOver is closed when either the request's context is done


### PR DESCRIPTION
When the grpc server is used as a `net/http` handler the request context is being discarded. This breaks logging and other uses where grpc and http are served on the same port in a Go application. 

This PR adds the request context to the server transport. I see that grpc is maintaining compatibility down to 1.6 so I'm happy to make the context changes backwards compatible. Looking to get some initial feedback first. 