### PR TITLE
Notify parent ClientConn to re-resolve in grpclb

### DIFF
--- a/balancer/balancer.go
+++ b/balancer/balancer.go
@@ -109,7 +109,7 @@ type ClientConn interface {
 	// on the new picker to pick new SubConn.
 	UpdateBalancerState(s connectivity.State, p Picker)
 
-	// ResolveNow is called by balancer to notify gRPC to do a name resolveing.
+	// ResolveNow is called by balancer to notify gRPC to do a name resolving.
 	ResolveNow(resolver.ResolveNowOption)
 
 	// Target returns the dial target for this ClientConn.

--- a/balancer/balancer.go
+++ b/balancer/balancer.go
@@ -109,6 +109,9 @@ type ClientConn interface {
 	// on the new picker to pick new SubConn.
 	UpdateBalancerState(s connectivity.State, p Picker)
 
+	// ResolveNow is called by balancer to notify gRPC to do a name resolveing.
+	ResolveNow(resolver.ResolveNowOption)
+
 	// Target returns the dial target for this ClientConn.
 	Target() string
 }

--- a/balancer_conn_wrappers.go
+++ b/balancer_conn_wrappers.go
@@ -233,6 +233,10 @@ func (ccb *ccBalancerWrapper) UpdateBalancerState(s connectivity.State, p balanc
 	ccb.cc.blockingpicker.updatePicker(p)
 }
 
+func (ccb *ccBalancerWrapper) ResolveNow(o resolver.ResolveNowOption) {
+	ccb.cc.resolveNow(o)
+}
+
 func (ccb *ccBalancerWrapper) Target() string {
 	return ccb.cc.target
 }

--- a/grpclb.go
+++ b/grpclb.go
@@ -30,7 +30,6 @@ import (
 	lbpb "google.golang.org/grpc/grpclb/grpc_lb_v1/messages"
 	"google.golang.org/grpc/grpclog"
 	"google.golang.org/grpc/resolver"
-	"google.golang.org/grpc/resolver/manual"
 )
 
 const (
@@ -117,7 +116,7 @@ func (b *lbBuilder) Build(cc balancer.ClientConn, opt balancer.BuildOptions) bal
 	// scheme will be used to dial to remote LB, so we can send filtered address
 	// updates to remote LB ClientConn using this manual resolver.
 	scheme := "grpclb_internal_" + strconv.FormatInt(time.Now().UnixNano(), 36)
-	r := manual.NewBuilderWithScheme(scheme)
+	r := &lbManualResolver{scheme: scheme, ccb: cc}
 
 	var target string
 	targetSplitted := strings.Split(cc.Target(), ":///")
@@ -155,7 +154,7 @@ type lbBalancer struct {
 	// manualResolver is used in the remote LB ClientConn inside grpclb. When
 	// resolved address updates are received by grpclb, filtered updates will be
 	// send to remote LB ClientConn through this resolver.
-	manualResolver *manual.Resolver
+	manualResolver *lbManualResolver
 	// The ClientConn to talk to the remote balancer.
 	ccRemoteLB *ClientConn
 

--- a/grpclb/grpclb_test.go
+++ b/grpclb/grpclb_test.go
@@ -567,6 +567,7 @@ func TestBalancerDisconnects(t *testing.T) {
 			t.Fatalf("%v.EmptyCall(_, _) = _, %v, want _, <nil>", testC, err)
 		}
 		if p.Addr.(*net.TCPAddr).Port == tests[1].bePorts[0] {
+			time.Sleep(time.Second)
 			return
 		}
 		time.Sleep(time.Millisecond)

--- a/grpclb/grpclb_test.go
+++ b/grpclb/grpclb_test.go
@@ -567,7 +567,6 @@ func TestBalancerDisconnects(t *testing.T) {
 			t.Fatalf("%v.EmptyCall(_, _) = _, %v, want _, <nil>", testC, err)
 		}
 		if p.Addr.(*net.TCPAddr).Port == tests[1].bePorts[0] {
-			time.Sleep(time.Second)
 			return
 		}
 		time.Sleep(time.Millisecond)

--- a/grpclb_util.go
+++ b/grpclb_util.go
@@ -1,0 +1,100 @@
+/*
+ *
+ * Copyright 2016 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package grpc
+
+import (
+	"google.golang.org/grpc/balancer"
+	"google.golang.org/grpc/resolver"
+)
+
+// The parent ClientConn should re-resolve when grpclb lose connection to the
+// remote balancer. When the ClientConn inside grpclb gets a TransientFailure,
+// it calls lbManualResolver.ResolveNow(), which calls parent ClientConn's
+// ResolveNow, and eventually results in re-resolve happening in parent
+// ClientConn's resolver (DNS for example).
+//
+//                          parent
+//                          ClientConn
+//  +-------------------------------------------------------------------+
+//  |                                                                   |
+//  |             parent          +----------------------------------+  |
+//  | DNS         ClientConn      |                                  |  |
+//  | resolver    balancerWrapper |  grpclb                          |  |
+//  |                             |                                  |  |
+//  | +              +            |    grpclb           grpclb       |  |
+//  | |              |            |    ManualResolver   ClientConn   |  |
+//  | |              |            |                                  |  |
+//  | |              |            |     +               +            |  |
+//  | |              |            |     |               | Transient  |  |
+//  | |              |            |     |               | Failure    |  |
+//  | |              |            |     |  <----------  |            |  |
+//  | |              |            |     |               |            |  |
+//  | |              |  <-------------  | ResolveNow    |            |  |
+//  | |              |            |     |               |            |  |
+//  | |  <---------  | ResolveNow |     |               |            |  |
+//  | |              |            |     |               |            |  |
+//  | | ResolveNow   |            |     |               |            |  |
+//  | |              |            |     |               |            |  |
+//  | |              |            |     |               |            |  |
+//  | |              |            |     |               |            |  |
+//  | +              +            |     +               +            |  |
+//  |                             |                                  |  |
+//  |                             +----------------------------------+  |
+//  |                                                                   |
+//  +-------------------------------------------------------------------+
+
+// lbManualResolver is used by the ClientConn inside grpclb. It's a manual
+// resolver with a special ResolveNow() function.
+//
+// When ResolveNow() is called, it calls ResolveNow() on the parent ClientConn,
+// so when grpclb client lose contact with remote balancers, the parent
+// ClientConn's resolver will re-resolve.
+type lbManualResolver struct {
+	scheme string
+	ccr    resolver.ClientConn
+
+	ccb balancer.ClientConn
+}
+
+func (r *lbManualResolver) Build(target resolver.Target, cc resolver.ClientConn, opts resolver.BuildOption) (resolver.Resolver, error) {
+	r.ccr = cc
+	return r, nil
+}
+
+func (r *lbManualResolver) Scheme() string {
+	return r.scheme
+}
+
+// ResolveNow calls resolveNow on the parent ClientConn.
+func (r *lbManualResolver) ResolveNow(o resolver.ResolveNowOption) {
+	r.ccb.ResolveNow(o)
+}
+
+// Close is a noop for Resolver.
+func (*lbManualResolver) Close() {}
+
+// NewAddress calls cc.NewAddress.
+func (r *lbManualResolver) NewAddress(addrs []resolver.Address) {
+	r.ccr.NewAddress(addrs)
+}
+
+// NewServiceConfig calls cc.NewServiceConfig.
+func (r *lbManualResolver) NewServiceConfig(sc string) {
+	r.ccr.NewServiceConfig(sc)
+}

--- a/grpclb_util.go
+++ b/grpclb_util.go
@@ -62,7 +62,7 @@ type lbManualResolver struct {
 	ccb balancer.ClientConn
 }
 
-func (r *lbManualResolver) Build(target resolver.Target, cc resolver.ClientConn, opts resolver.BuildOption) (resolver.Resolver, error) {
+func (r *lbManualResolver) Build(_ resolver.Target, cc resolver.ClientConn, _ resolver.BuildOption) (resolver.Resolver, error) {
 	r.ccr = cc
 	return r, nil
 }

--- a/grpclb_util.go
+++ b/grpclb_util.go
@@ -23,7 +23,7 @@ import (
 	"google.golang.org/grpc/resolver"
 )
 
-// The parent ClientConn should re-resolve when grpclb lose connection to the
+// The parent ClientConn should re-resolve when grpclb loses connection to the
 // remote balancer. When the ClientConn inside grpclb gets a TransientFailure,
 // it calls lbManualResolver.ResolveNow(), which calls parent ClientConn's
 // ResolveNow, and eventually results in re-resolve happening in parent
@@ -31,33 +31,23 @@ import (
 //
 //                          parent
 //                          ClientConn
-//  +-------------------------------------------------------------------+
-//  |                                                                   |
-//  |             parent          +----------------------------------+  |
-//  | DNS         ClientConn      |                                  |  |
-//  | resolver    balancerWrapper |  grpclb                          |  |
-//  |                             |                                  |  |
-//  | +              +            |    grpclb           grpclb       |  |
-//  | |              |            |    ManualResolver   ClientConn   |  |
-//  | |              |            |                                  |  |
-//  | |              |            |     +               +            |  |
-//  | |              |            |     |               | Transient  |  |
-//  | |              |            |     |               | Failure    |  |
-//  | |              |            |     |  <----------  |            |  |
-//  | |              |            |     |               |            |  |
-//  | |              |  <-------------  | ResolveNow    |            |  |
-//  | |              |            |     |               |            |  |
-//  | |  <---------  | ResolveNow |     |               |            |  |
-//  | |              |            |     |               |            |  |
-//  | | ResolveNow   |            |     |               |            |  |
-//  | |              |            |     |               |            |  |
-//  | |              |            |     |               |            |  |
-//  | |              |            |     |               |            |  |
-//  | +              +            |     +               +            |  |
-//  |                             |                                  |  |
-//  |                             +----------------------------------+  |
-//  |                                                                   |
-//  +-------------------------------------------------------------------+
+//  +-----------------------------------------------------------------+
+//  |             parent          +---------------------------------+ |
+//  | DNS         ClientConn      |  grpclb                         | |
+//  | resolver    balancerWrapper |                                 | |
+//  | +              +            |    grpclb          grpclb       | |
+//  | |              |            |    ManualResolver  ClientConn   | |
+//  | |              |            |     +              +            | |
+//  | |              |            |     |              | Transient  | |
+//  | |              |            |     |              | Failure    | |
+//  | |              |            |     |  <---------  |            | |
+//  | |              | <--------------- |  ResolveNow  |            | |
+//  | |  <---------  | ResolveNow |     |              |            | |
+//  | |  ResolveNow  |            |     |              |            | |
+//  | |              |            |     |              |            | |
+//  | +              +            |     +              +            | |
+//  |                             +---------------------------------+ |
+//  +-----------------------------------------------------------------+
 
 // lbManualResolver is used by the ClientConn inside grpclb. It's a manual
 // resolver with a special ResolveNow() function.


### PR DESCRIPTION
The parent ClientConn should re-resolve when grpclb loses connection to the
remote balancer.

When the `ClientConn` inside grpclb gets a `TransientFailure`, it calls
`lbManualResolver.ResolveNow()`, which calls parent ClientConn's `ResolveNow`, and
eventually results in re-resolve happening in parent ClientConn's resolver (DNS
for example).

This PR adds a method to `balancer.ClientConn` interface, so balancer can tell
parent ClientConn to re-resolve.