### PR TITLE
Fix misleading default resolver scheme comments

### DIFF
--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -38,7 +38,7 @@ func Register(b Builder) {
 // Get returns the resolver builder registered with the given scheme.
 // If no builder is register with the scheme, the default scheme will
 // be used.
-// If the default scheme is not modified, "dns" will be the default
+// If the default scheme is not modified, "passthrough" will be the default
 // scheme, and the preinstalled dns resolver will be used.
 // If the default scheme is modified, and a resolver is registered with
 // the scheme, that resolver will be returned.
@@ -55,7 +55,7 @@ func Get(scheme string) Builder {
 }
 
 // SetDefaultScheme sets the default scheme that will be used.
-// The default default scheme is "dns".
+// The default default scheme is "passthrough".
 func SetDefaultScheme(scheme string) {
 	defaultScheme = scheme
 }


### PR DESCRIPTION
Since a recent change, the default is `passthrough`, not `dns`.