### PR TITLE
Fix grpc basics link in route_guide example

### DIFF
--- a/examples/route_guide/README.md
+++ b/examples/route_guide/README.md
@@ -2,7 +2,7 @@
 The route guide server and client demonstrate how to use grpc go libraries to
 perform unary, client streaming, server streaming and full duplex RPCs.
 
-Please refer to [gRPC Basics: Go] (https://grpc.io/docs/tutorials/basic/go.html) for more information.
+Please refer to [gRPC Basics: Go](https://grpc.io/docs/tutorials/basic/go.html) for more information.
 
 See the definition of the route guide service in routeguide/route_guide.proto.
 


### PR DESCRIPTION
Typo cleanup