### PR TITLE
remove stringer and go generate

### DIFF
--- a/codes/codes.go
+++ b/codes/codes.go
@@ -23,8 +23,6 @@ package codes // import "google.golang.org/grpc/codes"
 // A Code is an unsigned 32-bit error code as defined in the gRPC spec.
 type Code uint32
 
-//go:generate stringer -type=Code
-
 const (
 	// OK is returned on success.
 	OK Code = 0

--- a/vet.sh
+++ b/vet.sh
@@ -23,8 +23,7 @@ if [ "$1" = "-install" ]; then
     golang.org/x/tools/cmd/goimports \
     honnef.co/go/tools/cmd/staticcheck \
     github.com/client9/misspell/cmd/misspell \
-    github.com/golang/protobuf/protoc-gen-go \
-    golang.org/x/tools/cmd/stringer
+    github.com/golang/protobuf/protoc-gen-go
   if [[ "$check_proto" = "true" ]]; then
     if [[ "$TRAVIS" = "true" ]]; then
       PROTOBUF_VERSION=3.3.0

--- a/vet.sh
+++ b/vet.sh
@@ -15,6 +15,9 @@ if [[ "$TRAVIS" != "true" || "$TRAVIS_EVENT_TYPE" = "cron" ]]; then
   check_proto="true"
 fi
 
+# Remove this!!!
+check_proto="true"
+
 if [ "$1" = "-install" ]; then
   go get -d \
     google.golang.org/grpc/...

--- a/vet.sh
+++ b/vet.sh
@@ -15,9 +15,6 @@ if [[ "$TRAVIS" != "true" || "$TRAVIS_EVENT_TYPE" = "cron" ]]; then
   check_proto="true"
 fi
 
-# Remove this!!!
-check_proto="true"
-
 if [ "$1" = "-install" ]; then
   go get -d \
     google.golang.org/grpc/...


### PR DESCRIPTION
Travis cron tests are failing because the stringer generated file doesn't match the new code_string.go file.