### PR TITLE
naming: Fix build constraints for go1.6 and go1.7

### DIFF
--- a/naming/go17.go
+++ b/naming/go17.go
@@ -1,4 +1,4 @@
-// +build go1.6, !go1.8
+// +build go1.6,!go1.8
 
 /*
  *


### PR DESCRIPTION
"go1.6, !go1.8" constraints are interpreted as (version >= 1.6 AND ) OR version < 1.8, where (version >= 1.6 AND ) is always false,
so it matches all go versions before 1.8, not only 1.6 and 1.7.

Removed a space, so the constraints are now matches only go1.6 and go1.7 versions