### PR TITLE
fix flaky TestPickfirstOneAddressRemoval

### DIFF
--- a/balancer_v1_wrapper.go
+++ b/balancer_v1_wrapper.go
@@ -173,10 +173,10 @@ func (bw *balancerWrapper) lbWatcher() {
 					sc.Connect()
 				}
 			} else {
-				oldSC.UpdateAddresses(newAddrs)
 				bw.mu.Lock()
 				bw.connSt[oldSC].addr = addrs[0]
 				bw.mu.Unlock()
+				oldSC.UpdateAddresses(newAddrs)
 			}
 		} else {
 			var (


### PR DESCRIPTION
TestPickfirstOneAddressRemoval timeout was ~2/1000.

Timeout is caused by the deadlock caused by race condition between: `bw.connSt[oldSC].addr = addrs[0]` and `oldSC.UpdateAddresses(newAddrs)` -> when current address is removed `ac.tearDown()`->`ac=newAddrConn()`->`ac.Connect()`->`HandleSubConnStateChange(...)`->`Up($bw.connSt[oldSC].addr)`