### PR TITLE
transport: fix race to ensure stream status is written before transport is closed

### DIFF
--- a/transport/control.go
+++ b/transport/control.go
@@ -116,6 +116,7 @@ type goAway struct {
 func (*goAway) item() {}
 
 type flushIO struct {
+	closeTr bool
 }
 
 func (*flushIO) item() {}


### PR DESCRIPTION
In GracefulStop, close server transport only after flushing status of the last stream.

fixes: #1681