### PR TITLE
fix stats flaky test

### DIFF
--- a/stats/stats_test.go
+++ b/stats/stats_test.go
@@ -1,3 +1,5 @@
+// +build go1.7
+
 /*
  *
  * Copyright 2016 gRPC authors.

--- a/transport/http2_server.go
+++ b/transport/http2_server.go
@@ -231,18 +231,21 @@ func newHTTP2Server(conn net.Conn, config *ServerConfig) (_ ServerTransport, err
 	// Check the validity of client preface.
 	preface := make([]byte, len(clientPreface))
 	if _, err := io.ReadFull(t.conn, preface); err != nil {
+		t.Close()
 		return nil, connectionErrorf(false, err, "transport: http2Server.HandleStreams failed to receive the preface from client: %v", err)
 	}
 	if !bytes.Equal(preface, clientPreface) {
+		t.Close()
 		return nil, connectionErrorf(false, nil, "transport: http2Server.HandleStreams received bogus greeting from client: %q", preface)
 	}
 
 	frame, err := t.framer.fr.ReadFrame()
 	if err == io.EOF || err == io.ErrUnexpectedEOF {
 		t.Close()
-		return
+		return nil, err
 	}
 	if err != nil {
+		t.Close()
 		return nil, connectionErrorf(false, err, "transport: http2Server.HandleStreams failed to read initial settings frame: %v", err)
 	}
 	atomic.StoreUint32(&t.activity, 1)


### PR DESCRIPTION
1. Call transport Close if newHTTP2Server returns non-nil error.
Handle ConnBegin was called before this error, and handle ConnEnd is not called (because Close() is not called), which caused ConnStats check to fail.

2. Skip stats test in go1.6.
go1.6 doesn't have DialContext (we use Dialer(Cancel: ctx.Done()) instead). When the give context is canceled, this function sometimes returns canceled error, while the server side still gets the conn. This caused the server blocking on reading the preface (which will eventually timeout, but the tests are too short for that), and there will be a missing ConnEnd.

fixes #1615