### PR TITLE
Add doc.go to grpc_lb_v1

### DIFF
--- a/grpclb/grpc_lb_v1/doc.go
+++ b/grpclb/grpc_lb_v1/doc.go
@@ -1,0 +1,21 @@
+/*
+ *
+ * Copyright 2017 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// Package grpc_lb_v1 is the parent package of all gRPC loadbalancer
+// message and service protobuf definitions.
+package grpc_lb_v1


### PR DESCRIPTION
In grpc 1.6.0 and earlier `grpc/grpclb/grpc_lb_v1` was a package. But now that it contains no go files, it is no longer considered a package. While this should be fine (since it didn't contribute to the developer facing API as far as I can tel), it has caused problems for tools like godep (https://github.com/tools/godep/issues/554).

It would be a huge help to kubernetes if we could mitigate this problem, and it can potentially be done cleanly with this PR, which adds some documentation to the `grpc_lb_v1` package, and by introducing a go file in the directory, makes go consider it a package once again.