### PR TITLE
Test fix: data race between test clean-up and reconnect attempts.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,5 +19,6 @@ before_install:
 script:
   - if [[ -n "$RUN386" ]]; then export GOARCH=386; fi
   - if [[ "$TRAVIS_GO_VERSION" = 1.9* && "$GOARCH" != "386" ]]; then ./vet.sh || exit 1; fi
-  - make test || exit 1
+  - make deps
+  - for i in {1..100}; do go test -race -cpu 1,4 -timeout 7m google.golang.org/grpc -run TestCloseConnectionWhenServerPrefaceNotReceived || exit 1; done
   - if [[ "$GOARCH" != "386" ]]; then make testrace; fi

--- a/clientconn.go
+++ b/clientconn.go
@@ -920,8 +920,6 @@ func (cc *ClientConn) resolveNow(o resolver.ResolveNowOption) {
 
 // Close tears down the ClientConn and all underlying connections.
 func (cc *ClientConn) Close() error {
-	cc.cancel()
-
 	cc.mu.Lock()
 	if cc.conns == nil {
 		cc.mu.Unlock()
@@ -946,6 +944,7 @@ func (cc *ClientConn) Close() error {
 	for ac := range conns {
 		ac.tearDown(ErrClientConnClosing)
 	}
+	cc.cancel()
 	return nil
 }
 

--- a/clientconn.go
+++ b/clientconn.go
@@ -1332,6 +1332,10 @@ func (ac *addrConn) tearDown(err error) {
 	ac.cancel()
 	ac.mu.Lock()
 	defer ac.mu.Unlock()
+	if ac.state == connectivity.Shutdown {
+		return
+	}
+	ac.state = connectivity.Shutdown
 	ac.curAddr = resolver.Address{}
 	if err == errConnDrain && ac.transport != nil {
 		// GracefulClose(...) may be executed multiple times when
@@ -1340,10 +1344,6 @@ func (ac *addrConn) tearDown(err error) {
 		// address removal and GoAway.
 		ac.transport.GracefulClose()
 	}
-	if ac.state == connectivity.Shutdown {
-		return
-	}
-	ac.state = connectivity.Shutdown
 	ac.tearDownErr = err
 	ac.cc.handleSubConnStateChange(ac.acbw, ac.state)
 	if ac.events != nil {


### PR DESCRIPTION
ClientConn.Close() should cancel context after finishing book-keeping to prevent unncessary reconnections.