### PR TITLE
Add doc.go to grpc_lb_v1 for 1.7.x branch

### DIFF
--- a/grpclb/grpc_lb_v1/doc.go
+++ b/grpclb/grpc_lb_v1/doc.go
@@ -1,0 +1,21 @@
+/*
+ *
+ * Copyright 2017 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// Package grpc_lb_v1 is the parent package of all gRPC loadbalancer
+// message and service protobuf definitions.
+package grpc_lb_v1

--- a/vet.sh
+++ b/vet.sh
@@ -51,7 +51,7 @@ fi
 git ls-files "*.go" | xargs grep -L "\(Copyright [0-9]\{4,\} gRPC authors\)\|DO NOT EDIT" 2>&1 | tee /dev/stderr | (! read)
 gofmt -s -d -l . 2>&1 | tee /dev/stderr | (! read)
 goimports -l . 2>&1 | tee /dev/stderr | (! read)
-golint ./... 2>&1 | (grep -vE "(_mock|_string|\.pb)\.go:" || true) | tee /dev/stderr | (! read)
+golint ./... 2>&1 | (grep -vE "(_mock|_string|grpc_lb_v1/doc|\.pb)\.go:" || true) | tee /dev/stderr | (! read)
 
 # Undo any edits made by this script.
 cleanup() {


### PR DESCRIPTION
Replaces https://github.com/grpc/grpc-go/pull/1743