### PR TITLE
vet: run golint on _string files

### DIFF
--- a/vet.sh
+++ b/vet.sh
@@ -51,7 +51,7 @@ fi
 git ls-files "*.go" | xargs grep -L "\(Copyright [0-9]\{4,\} gRPC authors\)\|DO NOT EDIT" 2>&1 | tee /dev/stderr | (! read)
 gofmt -s -d -l . 2>&1 | tee /dev/stderr | (! read)
 goimports -l . 2>&1 | tee /dev/stderr | (! read)
-golint ./... 2>&1 | (grep -vE "(_mock|_string|\.pb)\.go:" || true) | tee /dev/stderr | (! read)
+golint ./... 2>&1 | (grep -vE "(_mock|\.pb)\.go:" || true) | tee /dev/stderr | (! read)
 
 # Undo any edits made by this script.
 cleanup() {


### PR DESCRIPTION
Because we no longer use stringer.