### PR TITLE
compare atomic and mutex performance for incrementing one variable

### DIFF
--- a/benchmark/primitives/primitives_test.go
+++ b/benchmark/primitives/primitives_test.go
@@ -77,7 +77,7 @@ func BenchmarkAtomicBool(b *testing.B) {
 	}
 }
 
-func BenchmarkAtomicValue(b *testing.B) {
+func BenchmarkAtomicValueLoad(b *testing.B) {
 	c := atomic.Value{}
 	c.Store(0)
 	x := 0
@@ -91,6 +91,16 @@ func BenchmarkAtomicValue(b *testing.B) {
 	if x != b.N {
 		b.Fatal("error")
 	}
+}
+
+func BenchmarkAtomicValueStore(b *testing.B) {
+	c := atomic.Value{}
+	v := 123
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		c.Store(v)
+	}
+	b.StopTimer()
 }
 
 func BenchmarkMutex(b *testing.B) {
@@ -189,7 +199,7 @@ func BenchmarkMutexWithoutDefer(b *testing.B) {
 	}
 }
 
-func BenchmarkIncrInt64Atomics(b *testing.B) {
+func BenchmarkAtomicAddInt64(b *testing.B) {
 	var c int64
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -201,22 +211,7 @@ func BenchmarkIncrInt64Atomics(b *testing.B) {
 	}
 }
 
-func BenchmarkIncrInt64Mutex(b *testing.B) {
-	var c int64
-	mu := sync.Mutex{}
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		mu.Lock()
-		c++
-		mu.Unlock()
-	}
-	b.StopTimer()
-	if c != int64(b.N) {
-		b.Fatal("error")
-	}
-}
-
-func BenchmarkSetTimeAtomics(b *testing.B) {
+func BenchmarkAtomicTimeValueStore(b *testing.B) {
 	var c atomic.Value
 	t := time.Now()
 	b.ResetTimer()
@@ -224,22 +219,6 @@ func BenchmarkSetTimeAtomics(b *testing.B) {
 		c.Store(t)
 	}
 	b.StopTimer()
-}
-
-func BenchmarkSetTimeMutex(b *testing.B) {
-	mu := sync.Mutex{}
-	t := time.Now()
-	var tt time.Time
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		mu.Lock()
-		tt = t
-		mu.Unlock()
-	}
-	b.StopTimer()
-	if tt != t {
-		b.Fatal("error")
-	}
 }
 
 type myFooer struct{}

--- a/benchmark/primitives/primitives_test.go
+++ b/benchmark/primitives/primitives_test.go
@@ -219,32 +219,25 @@ func BenchmarkIncrInt64Mutex(b *testing.B) {
 func BenchmarkSetTimeAtomics(b *testing.B) {
 	var c atomic.Value
 	t := time.Now()
-	x := 0
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		c.Store(t)
-		x++
 	}
 	b.StopTimer()
-	if x != b.N {
-		b.Fatal("error")
-	}
 }
 
 func BenchmarkSetTimeMutex(b *testing.B) {
 	mu := sync.Mutex{}
 	t := time.Now()
-	x := 0
 	var tt time.Time
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		mu.Lock()
 		tt = t
 		mu.Unlock()
-		x++
 	}
 	b.StopTimer()
-	if x != b.N || tt != t {
+	if tt != t {
 		b.Fatal("error")
 	}
 }

--- a/benchmark/primitives/primitives_test.go
+++ b/benchmark/primitives/primitives_test.go
@@ -1,3 +1,5 @@
+// +build go1.7
+
 /*
  *
  * Copyright 2017 gRPC authors.
@@ -96,7 +98,7 @@ func BenchmarkAtomicValueLoad(b *testing.B) {
 
 func BenchmarkAtomicValueStore(b *testing.B) {
 	c := atomic.Value{}
-	var v int = 123
+	v := 123
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		c.Store(v)
@@ -285,6 +287,7 @@ func BenchmarkValueStoreWithContention(b *testing.B) {
 					wg.Done()
 				}()
 			}
+			_ = c
 			wg.Wait()
 		})
 	}

--- a/benchmark/primitives/primitives_test.go
+++ b/benchmark/primitives/primitives_test.go
@@ -24,6 +24,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 )
 
 func BenchmarkSelectClosed(b *testing.B) {
@@ -184,6 +185,48 @@ func BenchmarkMutexWithoutDefer(b *testing.B) {
 	}
 	b.StopTimer()
 	if x != b.N {
+		b.Fatal("error")
+	}
+}
+
+func BenchmarkIncrAtomics(b *testing.B) {
+	var c int64
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		atomic.AddInt64(&c, 1)
+	}
+	b.StopTimer()
+	if c != int64(b.N) {
+		b.Fatal("error")
+	}
+}
+
+func BenchmarkIncrAtomicsValue(b *testing.B) {
+	var c atomic.Value
+	t := time.Now()
+	x := 0
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		c.Store(t)
+		x++
+	}
+	b.StopTimer()
+	if x != b.N {
+		b.Fatal("error")
+	}
+}
+
+func BenchmarkIncrMutex(b *testing.B) {
+	var c int64
+	mu := sync.Mutex{}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		mu.Lock()
+		c++
+		mu.Unlock()
+	}
+	b.StopTimer()
+	if c != int64(b.N) {
 		b.Fatal("error")
 	}
 }

--- a/benchmark/primitives/primitives_test.go
+++ b/benchmark/primitives/primitives_test.go
@@ -28,6 +28,7 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+	"unsafe"
 )
 
 func BenchmarkSelectClosed(b *testing.B) {
@@ -257,21 +258,21 @@ func BenchmarkAtomic32BValueStore(b *testing.B) {
 }
 
 func BenchmarkAtomicPointerStore(b *testing.B) {
-	var c atomic.Value
 	t := 123
+	var up unsafe.Pointer
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		c.Store(&t)
+		atomic.StorePointer(&up, unsafe.Pointer(&t))
 	}
 	b.StopTimer()
 }
 
 func BenchmarkAtomicTimePointerStore(b *testing.B) {
-	var c atomic.Value
 	t := time.Now()
+	var up unsafe.Pointer
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		c.Store(&t)
+		atomic.StorePointer(&up, unsafe.Pointer(&t))
 	}
 	b.StopTimer()
 }
@@ -293,14 +294,14 @@ func BenchmarkValueStoreWithContention(b *testing.B) {
 			}
 			wg.Wait()
 		})
-		b.Run(fmt.Sprintf("AtomicPointer/%v", n), func(b *testing.B) {
+		b.Run(fmt.Sprintf("AtomicStorePointer/%v", n), func(b *testing.B) {
 			var wg sync.WaitGroup
-			var c atomic.Value
+			var up unsafe.Pointer
 			for i := 0; i < n; i++ {
 				wg.Add(1)
 				go func() {
 					for j := 0; j < b.N; j++ {
-						c.Store(&t)
+						atomic.StorePointer(&up, unsafe.Pointer(&t))
 					}
 					wg.Done()
 				}()

--- a/benchmark/primitives/primitives_test.go
+++ b/benchmark/primitives/primitives_test.go
@@ -189,7 +189,7 @@ func BenchmarkMutexWithoutDefer(b *testing.B) {
 	}
 }
 
-func BenchmarkIncrAtomics(b *testing.B) {
+func BenchmarkIncrInt64Atomics(b *testing.B) {
 	var c int64
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -201,7 +201,22 @@ func BenchmarkIncrAtomics(b *testing.B) {
 	}
 }
 
-func BenchmarkIncrAtomicsValue(b *testing.B) {
+func BenchmarkIncrInt64Mutex(b *testing.B) {
+	var c int64
+	mu := sync.Mutex{}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		mu.Lock()
+		c++
+		mu.Unlock()
+	}
+	b.StopTimer()
+	if c != int64(b.N) {
+		b.Fatal("error")
+	}
+}
+
+func BenchmarkSetTimeAtomics(b *testing.B) {
 	var c atomic.Value
 	t := time.Now()
 	x := 0
@@ -216,17 +231,20 @@ func BenchmarkIncrAtomicsValue(b *testing.B) {
 	}
 }
 
-func BenchmarkIncrMutex(b *testing.B) {
-	var c int64
+func BenchmarkSetTimeMutex(b *testing.B) {
 	mu := sync.Mutex{}
+	t := time.Now()
+	x := 0
+	var tt time.Time
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		mu.Lock()
-		c++
+		tt = t
 		mu.Unlock()
+		x++
 	}
 	b.StopTimer()
-	if c != int64(b.N) {
+	if x != b.N || tt != t {
 		b.Fatal("error")
 	}
 }


### PR DESCRIPTION
```
BenchmarkIncrInt64Atomics-12    	300000000	         5.59 ns/op
BenchmarkIncrInt64Mutex-12      	100000000	        15.8 ns/op
BenchmarkSetTimeAtomics-12      	20000000	       104 ns/op
BenchmarkSetTimeMutex-12        	100000000	        14.3 ns/op

```
