### PR TITLE
Fix flakey test TestClientUpdatesParamsAfterGoAway

### DIFF
--- a/clientconn_test.go
+++ b/clientconn_test.go
@@ -612,7 +612,7 @@ func TestClientUpdatesParamsAfterGoAway(t *testing.T) {
 	defer s.Stop()
 	cc, err := Dial(addr, WithBlock(), WithInsecure(), WithKeepaliveParams(keepalive.ClientParameters{
 		Time:                50 * time.Millisecond,
-		Timeout:             1 * time.Millisecond,
+		Timeout:             100 * time.Millisecond,
 		PermitWithoutStream: true,
 	}))
 	if err != nil {


### PR DESCRIPTION
This flake was related to other keepalive flakes where the client would close the connection instead of the server as a result of a small timeout.
The failure rate was about 1 in 1000. This patch was tested to successfully pass 10000 runs with asan on.

fixes #1753