### PR TITLE
Avoid copying headers/trailers in unary RPCs unless requested by CallOptions

### DIFF
--- a/call.go
+++ b/call.go
@@ -47,9 +47,11 @@ func recvResponse(ctx context.Context, dopts dialOptions, t transport.ClientTran
 			}
 		}
 	}()
-	c.headerMD, err = stream.Header()
-	if err != nil {
-		return
+	if c.headerNeeded {
+		c.headerMD, err = stream.Header()
+		if err != nil {
+			return
+		}
 	}
 	p := &parser{r: stream}
 	var inPayload *stats.InPayload
@@ -84,7 +86,9 @@ func recvResponse(ctx context.Context, dopts dialOptions, t transport.ClientTran
 		// Fix the order if necessary.
 		dopts.copts.StatsHandler.HandleRPC(ctx, inPayload)
 	}
-	c.trailerMD = stream.Trailer()
+	if c.trailerNeeded {
+		c.trailerMD = stream.Trailer()
+	}
 	return nil
 }
 

--- a/stream.go
+++ b/stream.go
@@ -30,7 +30,6 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/encoding"
 	"google.golang.org/grpc/metadata"
-	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/stats"
 	"google.golang.org/grpc/status"
 	"google.golang.org/grpc/transport"
@@ -253,10 +252,7 @@ func newClientStream(ctx context.Context, desc *StreamDesc, cc *ClientConn, meth
 		break
 	}
 
-	// Set callInfo.peer object from stream's context.
-	if peer, ok := peer.FromContext(s.Context()); ok {
-		c.peer = peer
-	}
+	c.stream = s
 	cs := &clientStream{
 		opts:   opts,
 		c:      c,


### PR DESCRIPTION
CPU profile shows that header copy takes a large proportion of CPU usage in a gRPC Call.
If the header is not needed, we don't need to pay the cost.