### PR TITLE
credentials: return Unavailable instead of Internal for per-RPC creds errors

### DIFF
--- a/credentials/credentials.go
+++ b/credentials/credentials.go
@@ -43,8 +43,9 @@ type PerRPCCredentials interface {
 	// GetRequestMetadata gets the current request metadata, refreshing
 	// tokens if required. This should be called by the transport layer on
 	// each request, and the data should be populated in headers or other
-	// context. uri is the URI of the entry point for the request. When
-	// supported by the underlying implementation, ctx can be used for
+	// context. If a status code is returned, it will be used as the status
+	// for the RPC. uri is the URI of the entry point for the request.
+	// When supported by the underlying implementation, ctx can be used for
 	// timeout and cancellation.
 	// TODO(zhaoq): Define the set of the qualified keys instead of leaving
 	// it as an arbitrary string.

--- a/transport/http2_client.go
+++ b/transport/http2_client.go
@@ -380,7 +380,11 @@ func (t *http2Client) NewStream(ctx context.Context, callHdr *CallHdr) (_ *Strea
 	for _, c := range t.creds {
 		data, err := c.GetRequestMetadata(ctx, audience)
 		if err != nil {
-			return nil, streamErrorf(codes.Internal, "transport: %v", err)
+			if _, ok := status.FromError(err); ok {
+				return nil, err
+			}
+
+			return nil, streamErrorf(codes.Unauthenticated, "transport: %v", err)
 		}
 		for k, v := range data {
 			// Capital header names are illegal in HTTP/2.


### PR DESCRIPTION
Referencing https://github.com/grpc/grpc-go/issues/1704.

I'm a little confused on the part, "The oauth implementation should return UNAVAILABLE if the oauth server cannot be reached.". Does that mean, all implementers of `TokenSource :: Token() (*Token, error)` should return `UNAVAILABLE` if the server cannot be reached? If so I'm happy to try and go through and add them either in this PR or a separate PR.