### PR TITLE
Don't set reconnect parameters when the server has already responded with preface.

### DIFF
--- a/clientconn.go
+++ b/clientconn.go
@@ -1119,8 +1119,8 @@ func (ac *addrConn) createTransport(connectRetryNum, ridx int, backoffDeadline, 
 		}
 		done := make(chan struct{})
 		onPrefaceReceipt := func() {
-			close(done)
 			ac.mu.Lock()
+			close(done)
 			if !ac.backoffDeadline.IsZero() {
 				// If we haven't already started reconnecting to
 				// other backends.
@@ -1185,10 +1185,16 @@ func (ac *addrConn) createTransport(connectRetryNum, ridx int, backoffDeadline, 
 			close(ac.ready)
 			ac.ready = nil
 		}
-		ac.connectRetryNum = connectRetryNum
-		ac.backoffDeadline = backoffDeadline
-		ac.connectDeadline = connectDeadline
-		ac.reconnectIdx = i + 1 // Start reconnecting from the next backend in the list.
+		select {
+		case <-done:
+			// If the server has responded back with preface already,
+			// don't set the reconnect parameters.
+		default:
+			ac.connectRetryNum = connectRetryNum
+			ac.backoffDeadline = backoffDeadline
+			ac.connectDeadline = connectDeadline
+			ac.reconnectIdx = i + 1 // Start reconnecting from the next backend in the list.
+		}
 		ac.mu.Unlock()
 		return true, nil
 	}


### PR DESCRIPTION
fixes #1772

Unfortunately, it is [not enough](https://travis-ci.org/MakMukhi/grpc-go/builds/324439341) to get rid of this workaround: https://github.com/grpc/grpc-go/blob/7aea499f9110a479b3777df064372f44188146aa/clientconn_test.go#L251

