### PR TITLE
Updating broken wire.html link.

### DIFF
--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -17,7 +17,8 @@
  */
 
 // Package metadata define the structure of the metadata supported by gRPC library.
-// Please refer to https://grpc.io/docs/guides/wire.html for more information about custom-metadata.
+// Please refer to https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md
+// for more information about custom-metadata.
 package metadata // import "google.golang.org/grpc/metadata"
 
 import (


### PR DESCRIPTION
https://grpc.io/docs/guides/wire.html is no longer valid.

Looking at an archived version of that page
(https://web.archive.org/web/20171006045517/https://grpc.io/docs/guides/wire.html)
it looks equilavent to what is now posted at:
https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md.

The gRPC guide: https://grpc.io/docs/guides/ contains a link in the
sidebar navigation to the same page, so pretty sure it's correct.