### PR TITLE
addrConn: stop retrying on addresses that returned fatal connecting errors

### DIFF
--- a/balancer_conn_wrappers.go
+++ b/balancer_conn_wrappers.go
@@ -189,9 +189,6 @@ func (ccb *ccBalancerWrapper) handleResolvedAddrs(addrs []resolver.Address, err 
 }
 
 func (ccb *ccBalancerWrapper) NewSubConn(addrs []resolver.Address, opts balancer.NewSubConnOptions) (balancer.SubConn, error) {
-	if len(addrs) <= 0 {
-		return nil, fmt.Errorf("grpc: cannot create SubConn with empty address list")
-	}
 	ccb.mu.Lock()
 	defer ccb.mu.Unlock()
 	if ccb.subConns == nil {
@@ -251,10 +248,6 @@ type acBalancerWrapper struct {
 func (acbw *acBalancerWrapper) UpdateAddresses(addrs []resolver.Address) {
 	acbw.mu.Lock()
 	defer acbw.mu.Unlock()
-	if len(addrs) <= 0 {
-		acbw.ac.tearDown(errConnDrain)
-		return
-	}
 	if !acbw.ac.tryUpdateAddrs(addrs) {
 		cc := acbw.ac.cc
 		acbw.ac.mu.Lock()

--- a/clientconn.go
+++ b/clientconn.go
@@ -1223,7 +1223,7 @@ func (ac *addrConn) createTransport(connectRetryNum, ridx int, backoffDeadline, 
 	// no point retrying on this addrConn.
 	if addrsCount <= 0 {
 		if clientFatalError == nil {
-			grpclog.Errorf("addrsCount == 0 while clientFatalError == nil")
+			grpclog.Errorf("addrsCount is 0 while clientFatalError is nil, the ac was created with empty slice")
 			return false, fmt.Errorf("no address is available for retrying")
 		}
 		grpclog.Warningf("grpc: addrConn stops retrying because of non-temporary error: %v", clientFatalError)


### PR DESCRIPTION
If connecting to an address returns a non-temporary error, this address will be removed from the list of addresses that will be retried on.
When there's no more address to retry, that addrConn will go to TransientError and then will be torn down (Shutdown).

This was part of #1657 and got reverted to avoid conflict with other changes.

Also it should be OK to call `newAddrConn()` or to update ac.addrs to empty list now. The ac with no connect-able addresses will be torn down.

fixes #1683