### PR TITLE
Disallow assignment to s.recvCompress after header chan is closed.

### DIFF
--- a/transport/http2_client.go
+++ b/transport/http2_client.go
@@ -1114,12 +1114,13 @@ func (t *http2Client) operateHeaders(frame *http2.MetaHeadersFrame) {
 	}()
 
 	s.mu.Lock()
-	if !endStream && !s.headerDone {
-		s.recvCompress = state.encoding
-	}
 	if !s.headerDone {
-		if !endStream && len(state.mdata) > 0 {
-			s.header = state.mdata
+		// Headers frame is not actually a trailers-only frame.
+		if !endStream {
+			s.recvCompress = state.encoding
+			if len(state.mdata) > 0 {
+				s.header = state.mdata
+			}
 		}
 		close(s.headerChan)
 		s.headerDone = true

--- a/transport/http2_client.go
+++ b/transport/http2_client.go
@@ -1114,7 +1114,7 @@ func (t *http2Client) operateHeaders(frame *http2.MetaHeadersFrame) {
 	}()
 
 	s.mu.Lock()
-	if !endStream {
+	if !endStream && !s.headerDone {
 		s.recvCompress = state.encoding
 	}
 	if !s.headerDone {


### PR DESCRIPTION
fix #1803 

Disallow assignment to s.recvCompress after header chan is closed.