### PR TITLE
client: send RST_STREAM on client-side errors to prevent server from blocking

### DIFF
--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -4261,7 +4261,7 @@ func testClientResourceExhaustedCancelFullDuplex(t *testing.T, e env) {
 		defer close(recvErr)
 		_, err := stream.Recv()
 		if err != nil {
-			return err
+			return status.Errorf(codes.Internal, "stream.Recv() got error: %v, want <nil>", err)
 		}
 		// create a payload that's larger than the default flow control window.
 		payload, err := newPayload(testpb.PayloadType_COMPRESSABLE, 10)

--- a/transport/http2_client.go
+++ b/transport/http2_client.go
@@ -570,6 +570,7 @@ func (t *http2Client) CloseStream(s *Stream, err error) {
 	s.mu.Lock()
 	rstStream = s.rstStream
 	rstError = s.rstError
+	rstRecv := s.rstReceived
 	if s.state == streamDone {
 		s.mu.Unlock()
 		return
@@ -580,13 +581,9 @@ func (t *http2Client) CloseStream(s *Stream, err error) {
 	}
 	s.state = streamDone
 	s.mu.Unlock()
-	if _, ok := err.(StreamError); ok {
+	if err != nil && !rstStream && !rstRecv {
 		rstStream = true
 		rstError = http2.ErrCodeCancel
-	}
-	if err != nil && !rstStream {
-		rstStream = true
-		rstError = http2.ErrCodeProtocol
 	}
 }
 
@@ -920,6 +917,7 @@ func (t *http2Client) handleRSTStream(f *http2.RSTStreamFrame) {
 		statusCode = codes.Unknown
 	}
 	s.finish(status.Newf(statusCode, "stream terminated by RST_STREAM with error code: %v", f.ErrCode))
+	s.rstReceived = true
 	s.mu.Unlock()
 	s.write(recvMsg{err: io.EOF})
 }

--- a/transport/http2_client.go
+++ b/transport/http2_client.go
@@ -584,6 +584,10 @@ func (t *http2Client) CloseStream(s *Stream, err error) {
 		rstStream = true
 		rstError = http2.ErrCodeCancel
 	}
+	if err != nil && !rstStream {
+		rstStream = true
+		rstError = http2.ErrCodeProtocol
+	}
 }
 
 // Close kicks off the shutdown process of the transport. This should be called

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -235,9 +235,10 @@ type Stream struct {
 	header        metadata.MD   // the received header metadata.
 	trailer       metadata.MD   // the key-value map of trailer metadata.
 
-	mu       sync.RWMutex // guard the following
-	headerOk bool         // becomes true from the first header is about to send
-	state    streamState
+	mu          sync.RWMutex // guard the following
+	headerOk    bool         // becomes true from the first header is about to send
+	state       streamState
+	rstReceived bool
 
 	status *status.Status // the status error received from the server
 

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -235,15 +235,15 @@ type Stream struct {
 	header        metadata.MD   // the received header metadata.
 	trailer       metadata.MD   // the key-value map of trailer metadata.
 
-	mu          sync.RWMutex // guard the following
-	headerOk    bool         // becomes true from the first header is about to send
-	state       streamState
-	rstReceived bool
+	mu       sync.RWMutex // guard the following
+	headerOk bool         // becomes true from the first header is about to send
+	state    streamState
 
 	status *status.Status // the status error received from the server
 
-	rstStream bool          // indicates whether a RST_STREAM frame needs to be sent
-	rstError  http2.ErrCode // the error that needs to be sent along with the RST_STREAM frame
+	rstStream   bool          // indicates whether a RST_STREAM frame needs to be sent
+	rstError    http2.ErrCode // the error that needs to be sent along with the RST_STREAM frame
+	rstReceived bool          // indicates whether a RST_STREAM frame has been received from the other endpoint
 
 	bytesReceived bool // indicates whether any bytes have been received on this stream
 	unprocessed   bool // set if the server sends a refused stream or GOAWAY including this stream


### PR DESCRIPTION
fix #1809

Previously, we only send reset stream if the rpc error is originated on client side at transport layer, which leave the grpc layer case unhandled. 