### PR TITLE
transport: remove redundant check of stream state in Write

### DIFF
--- a/transport/http2_server.go
+++ b/transport/http2_server.go
@@ -843,15 +843,6 @@ func (t *http2Server) Write(s *Stream, hdr []byte, data []byte, opts *Options) e
 
 	var writeHeaderFrame bool
 	s.mu.Lock()
-	if s.state == streamDone {
-		s.mu.Unlock()
-		select {
-		case <-s.ctx.Done():
-			return ContextErr(s.ctx.Err())
-		default:
-			return streamErrorf(codes.Unknown, "the stream has been done")
-		}
-	}
 	if !s.headerOk {
 		writeHeaderFrame = true
 	}


### PR DESCRIPTION
fix #1832 