### PR TITLE
transport: remove unnecessary rstReceived

### DIFF
--- a/transport/http2_client.go
+++ b/transport/http2_client.go
@@ -571,7 +571,6 @@ func (t *http2Client) CloseStream(s *Stream, err error) {
 	s.mu.Lock()
 	rstStream = s.rstStream
 	rstError = s.rstError
-	rstRecv := s.rstReceived
 	if s.state == streamDone {
 		s.mu.Unlock()
 		return
@@ -582,7 +581,7 @@ func (t *http2Client) CloseStream(s *Stream, err error) {
 	}
 	s.state = streamDone
 	s.mu.Unlock()
-	if err != nil && !rstStream && !rstRecv {
+	if err != nil && !rstStream {
 		rstStream = true
 		rstError = http2.ErrCodeCancel
 	}
@@ -920,7 +919,6 @@ func (t *http2Client) handleRSTStream(f *http2.RSTStreamFrame) {
 		statusCode = codes.Unknown
 	}
 	s.finish(status.Newf(statusCode, "stream terminated by RST_STREAM with error code: %v", f.ErrCode))
-	s.rstReceived = true
 	s.mu.Unlock()
 	s.write(recvMsg{err: io.EOF})
 }

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -241,9 +241,8 @@ type Stream struct {
 
 	status *status.Status // the status error received from the server
 
-	rstStream   bool          // indicates whether a RST_STREAM frame needs to be sent
-	rstError    http2.ErrCode // the error that needs to be sent along with the RST_STREAM frame
-	rstReceived bool          // indicates whether a RST_STREAM frame has been received from the other endpoint
+	rstStream bool          // indicates whether a RST_STREAM frame needs to be sent
+	rstError  http2.ErrCode // the error that needs to be sent along with the RST_STREAM frame
 
 	bytesReceived bool // indicates whether any bytes have been received on this stream
 	unprocessed   bool // set if the server sends a refused stream or GOAWAY including this stream


### PR DESCRIPTION
When client receives RST_STREAM from server, `handleRSTStream` will call `s.finish` which will set `s.state = streamDone`. And when later `closeStream` gets called, it will return in the conditional checking for `s.state == streamDone` before reaching the code setting `rstStream = true`, and thus prevents sending a RST_STREAM back to server. 

> The RST_STREAM frame fully terminates the referenced stream and causes it to enter the "closed" state. After receiving a RST_STREAM on a stream, the receiver MUST NOT send additional frames for that stream, with the exception of PRIORITY. However, after sending the RST_STREAM, the sending endpoint MUST be prepared to receive and process additional frames sent on the stream that might have been sent by the peer prior to the arrival of the RST_STREAM.