### PR TITLE
Stream: do not cancel ctx created with service config timeout

### DIFF
--- a/stream.go
+++ b/stream.go
@@ -126,8 +126,8 @@ func newClientStream(ctx context.Context, desc *StreamDesc, cc *ClientConn, meth
 	}
 
 	if mc.Timeout != nil && *mc.Timeout >= 0 {
-		// The cancel function for this context will NEVER be called because of
-		// https://github.com/grpc/grpc-go/issues/1818.
+		// The cancel function for this context will NEVER be called once the
+		// stream is returned (https://github.com/grpc/grpc-go/issues/1818).
 		//
 		// Possible situations (context leaks):
 		//  - If no timeout was specified by service config, this won't happen.
@@ -271,14 +271,13 @@ func newClientStream(ctx context.Context, desc *StreamDesc, cc *ClientConn, meth
 
 	c.stream = s
 	cs := &clientStream{
-		opts:   opts,
-		c:      c,
-		desc:   desc,
-		codec:  c.codec,
-		cp:     cp,
-		dc:     cc.dopts.dc,
-		comp:   comp,
-		cancel: cancel,
+		opts:  opts,
+		c:     c,
+		desc:  desc,
+		codec: c.codec,
+		cp:    cp,
+		dc:    cc.dopts.dc,
+		comp:  comp,
 
 		done: done,
 		t:    t,
@@ -332,10 +331,6 @@ type clientStream struct {
 	comp      encoding.Compressor
 	decomp    encoding.Compressor
 	decompSet bool
-
-	// cancel is never called because of
-	// https://github.com/grpc/grpc-go/issues/1818.
-	cancel context.CancelFunc
 
 	tracing bool // set to EnableTracing when the clientStream is created.
 
@@ -536,8 +531,6 @@ func (cs *clientStream) closeTransportStream(err error) {
 }
 
 func (cs *clientStream) finish(err error) {
-	// Do not call cs.cancel because of
-	// https://github.com/grpc/grpc-go/issues/1818.
 	cs.mu.Lock()
 	defer cs.mu.Unlock()
 	if cs.finished {

--- a/stream.go
+++ b/stream.go
@@ -489,6 +489,7 @@ func (cs *clientStream) RecvMsg(m interface{}) (err error) {
 				return se
 			}
 			cs.finish(err)
+			cs.cancel()
 			return nil
 		}
 		return toRPCErr(err)

--- a/stream.go
+++ b/stream.go
@@ -90,8 +90,9 @@ type ClientStream interface {
 	// Stream.SendMsg() may return a non-nil error when something wrong happens sending
 	// the request. The returned error indicates the status of this sending, not the final
 	// status of the RPC.
-	// Always call Stream.RecvMsg() to get the final status if you care about the status of
-	// the RPC.
+	//
+	// Always call Stream.RecvMsg() to drain the stream and get the final
+	// status, otherwise there could be leaked context.
 	Stream
 }
 

--- a/stream.go
+++ b/stream.go
@@ -92,7 +92,7 @@ type ClientStream interface {
 	// status of the RPC.
 	//
 	// Always call Stream.RecvMsg() to drain the stream and get the final
-	// status, otherwise there could be leaked context.
+	// status, otherwise there could be leaked resources.
 	Stream
 }
 

--- a/stream.go
+++ b/stream.go
@@ -457,7 +457,9 @@ func (cs *clientStream) RecvMsg(m interface{}) (err error) {
 		// err != nil indicates the termination of the stream.
 		if err != nil {
 			cs.finish(err)
-			cs.cancel()
+			if cs.cancel != nil {
+				cs.cancel()
+			}
 		}
 	}()
 	if err == nil {
@@ -489,7 +491,9 @@ func (cs *clientStream) RecvMsg(m interface{}) (err error) {
 				return se
 			}
 			cs.finish(err)
-			cs.cancel()
+			if cs.cancel != nil {
+				cs.cancel()
+			}
 			return nil
 		}
 		return toRPCErr(err)

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -1874,6 +1874,12 @@ func TestStreamingRPCWithTimeoutInServiceConfigRecv(t *testing.T) {
 	if _, err := stream.Recv(); err != nil {
 		t.Fatalf("stream.Recv = _, %v, want _, <nil>", err)
 	}
+	// Keep reading to drain the stream.
+	for {
+		if _, err := stream.Recv(); err != nil {
+			break
+		}
+	}
 }
 
 func TestMaxMsgSizeClientDefault(t *testing.T) {


### PR DESCRIPTION
See #1818 for behavior before this fix.

Limitations of this solution: there's a possible context leak
 - If no timeout was specified by service config, the child context won't be created. There's no context leak.
 - If user provided context is not `Background` (is cancel-able), this ctx will be freed when the user ctx timeout/is canceled. There's no leak if user is  handling the ctx appropriately.
 - If user's context is `Background`, this ctx will be leaked after the stream is done, until timeout.

fixes #1818 