### PR TITLE
Fix lint error and typo

### DIFF
--- a/encoding/proto/proto.go
+++ b/encoding/proto/proto.go
@@ -16,6 +16,8 @@
  *
  */
 
+// Package proto defines the protobuf codec. Importing this package will
+// register the codec.
 package proto
 
 import (

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -4239,7 +4239,7 @@ func TestClientResourceExhaustedCancelFullDuplex(t *testing.T) {
 	defer leakcheck.Check(t)
 	for _, e := range listTestEnv() {
 		if e.httpHandler {
-			// httpHanlder write won't be blocked on flow control window.
+			// httpHandler write won't be blocked on flow control window.
 			continue
 		}
 		testClientResourceExhaustedCancelFullDuplex(t, e)


### PR DESCRIPTION
We should lint/vet/typo check stricter but make them optional.