### PR TITLE
Add status.Convert convenience function

### DIFF
--- a/status/status.go
+++ b/status/status.go
@@ -120,7 +120,8 @@ func FromProto(s *spb.Status) *Status {
 }
 
 // FromError returns a Status representing err if it was produced from this
-// package, otherwise it returns nil, false.
+// package. Otherwise, ok is false and a Status is returned with codes.Unknown
+// and the original error message.
 func FromError(err error) (s *Status, ok bool) {
 	if err == nil {
 		return &Status{s: &spb.Status{Code: int32(codes.OK)}}, true
@@ -128,7 +129,14 @@ func FromError(err error) (s *Status, ok bool) {
 	if se, ok := err.(*statusError); ok {
 		return se.status(), true
 	}
-	return nil, false
+	return New(codes.Unknown, err.Error()), false
+}
+
+// Convert is a convenience function which removes the need to handle the
+// boolean return value from FromError.
+func Convert(err error) *Status {
+	s, _ := FromError(err)
+	return s
 }
 
 // WithDetails returns a new status with the provided details messages appended to the status.

--- a/status/status_test.go
+++ b/status/status_test.go
@@ -119,6 +119,33 @@ func TestFromErrorOK(t *testing.T) {
 	}
 }
 
+func TestFromErrorUnknownError(t *testing.T) {
+	code, message := codes.Unknown, "unknown error"
+	err := errors.New("unknown error")
+	s, ok := FromError(err)
+	if ok || s.Code() != code || s.Message() != message {
+		t.Fatalf("FromError(%v) = %v, %v; want <Code()=%s, Message()=%q>, false", err, s, ok, code, message)
+	}
+}
+
+func TestConvertKnownError(t *testing.T) {
+	code, message := codes.Internal, "test description"
+	err := Error(code, message)
+	s := Convert(err)
+	if s.Code() != code || s.Message() != message {
+		t.Fatalf("Convert(%v) = %v; want <Code()=%s, Message()=%q>", err, s, code, message)
+	}
+}
+
+func TestConvertUnknownError(t *testing.T) {
+	code, message := codes.Unknown, "unknown error"
+	err := errors.New("unknown error")
+	s := Convert(err)
+	if s.Code() != code || s.Message() != message {
+		t.Fatalf("Convert(%v) = %v; want <Code()=%s, Message()=%q>", err, s, code, message)
+	}
+}
+
 func TestStatus_ErrorDetails(t *testing.T) {
 	tests := []struct {
 		code    codes.Code


### PR DESCRIPTION
This commit adds a function to convert between gRPC errors to
status.Status types without having to deal with an "ok" return value.

Fixes #1378.

@dfawley This work is almost an exact copy of what you proposed. I tried to closely follow the established style for the tests and will be happy to make changes.