### PR TITLE
Keep retrying in addrConn even on non-temporary errors

### DIFF
--- a/clientconn.go
+++ b/clientconn.go
@@ -1129,15 +1129,6 @@ func (ac *addrConn) createTransport(connectRetryNum, ridx int, backoffDeadline, 
 		newTr, err := transport.NewClientTransport(connectCtx, ac.cc.ctx, target, copts, onPrefaceReceipt)
 		if err != nil {
 			cancel()
-			if e, ok := err.(transport.ConnectionError); ok && !e.Temporary() {
-				ac.mu.Lock()
-				if ac.state != connectivity.Shutdown {
-					ac.state = connectivity.TransientFailure
-					ac.cc.handleSubConnStateChange(ac.acbw, ac.state)
-				}
-				ac.mu.Unlock()
-				return false, err
-			}
 			ac.mu.Lock()
 			if ac.state == connectivity.Shutdown {
 				// ac.tearDown(...) has been invoked.

--- a/transport/http2_client.go
+++ b/transport/http2_client.go
@@ -121,18 +121,6 @@ func dial(ctx context.Context, fn func(context.Context, string) (net.Conn, error
 }
 
 func isTemporary(err error) bool {
-	switch err {
-	case io.EOF:
-		// Connection closures may be resolved upon retry, and are thus
-		// treated as temporary.
-		return true
-	case context.DeadlineExceeded:
-		// In Go 1.7, context.DeadlineExceeded implements Timeout(), and this
-		// special case is not needed. Until then, we need to keep this
-		// clause.
-		return true
-	}
-
 	switch err := err.(type) {
 	case interface {
 		Temporary() bool
@@ -145,7 +133,7 @@ func isTemporary(err error) bool {
 		// temporary.
 		return err.Timeout()
 	}
-	return false
+	return true
 }
 
 // newHTTP2Client constructs a connected ClientTransport to addr based on HTTP2
@@ -181,10 +169,7 @@ func newHTTP2Client(connectCtx, ctx context.Context, addr TargetInfo, opts Conne
 		scheme = "https"
 		conn, authInfo, err = creds.ClientHandshake(connectCtx, addr.Authority, conn)
 		if err != nil {
-			// Credentials handshake errors are typically considered permanent
-			// to avoid retrying on e.g. bad certificates.
-			temp := isTemporary(err)
-			return nil, connectionErrorf(temp, err, "transport: authentication handshake failed: %v", err)
+			return nil, connectionErrorf(isTemporary(err), err, "transport: authentication handshake failed: %v", err)
 		}
 		isSecure = true
 	}


### PR DESCRIPTION
Retrying happens with exponential backoff, so the overhead should be tolerable.
We need this to trigger resolver re-resolve for new addresses.

Permanent errors are in general hard to deal with, and it's not support in other languages.
It's sometimes hard to tell the difference between temporary errors and non-temporary errors. Even for the typical "permanent" TLS handshake errors, it could be caused by a wrong setting on the server side, and a second retry could work.

We still need to way to let the user find out this kind of errors quickly.
With #1855, users should have enough information to decide what to do based on the returned RPC errors.
