### PR TITLE
interop test: Expect io.EOF from stream.Send()

### DIFF
--- a/interop/test_utils.go
+++ b/interop/test_utils.go
@@ -241,10 +241,8 @@ func DoTimeoutOnSleepingServer(tc testpb.TestServiceClient, args ...grpc.CallOpt
 		ResponseType: testpb.PayloadType_COMPRESSABLE,
 		Payload:      pl,
 	}
-	if err := stream.Send(req); err != nil {
-		if status.Code(err) != codes.DeadlineExceeded {
-			grpclog.Fatalf("%v.Send(_) = %v", stream, err)
-		}
+	if err := stream.Send(req); err != nil && err != io.EOF {
+		grpclog.Fatalf("%v.Send(_) = %v", stream, err)
 	}
 	if _, err := stream.Recv(); status.Code(err) != codes.DeadlineExceeded {
 		grpclog.Fatalf("%v.Recv() = _, %v, want error code %d", stream, err, codes.DeadlineExceeded)


### PR DESCRIPTION
With #1854, send will get `io.EOF` instead of `DeadlineExceeded`.
`Recv` should always get the expected `DeadlineExceeded` error.