### PR TITLE
clientconn: fix a typo in GetMethodConfig documentation

### DIFF
--- a/clientconn.go
+++ b/clientconn.go
@@ -865,7 +865,7 @@ func (ac *addrConn) tryUpdateAddrs(addrs []resolver.Address) bool {
 // the corresponding MethodConfig.
 // If there isn't an exact match for the input method, we look for the default config
 // under the service (i.e /service/). If there is a default MethodConfig for
-// the serivce, we return it.
+// the service, we return it.
 // Otherwise, we return an empty MethodConfig.
 func (cc *ClientConn) GetMethodConfig(method string) MethodConfig {
 	// TODO: Avoid the locking here.


### PR DESCRIPTION
Title says it all, there was a typo in ClientConn.GetMethodConfig
documentation