### PR TITLE
server: Convert all non-status errors to codes.Unknown

### DIFF
--- a/go16.go
+++ b/go16.go
@@ -25,7 +25,6 @@ import (
 	"io"
 	"net"
 	"net/http"
-	"os"
 
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
@@ -68,32 +67,4 @@ func toRPCErr(err error) error {
 		}
 	}
 	return status.Error(codes.Unknown, err.Error())
-}
-
-// convertCode converts a standard Go error into its canonical code. Note that
-// this is only used to translate the error returned by the server applications.
-func convertCode(err error) codes.Code {
-	switch err {
-	case nil:
-		return codes.OK
-	case io.EOF:
-		return codes.OutOfRange
-	case io.ErrClosedPipe, io.ErrNoProgress, io.ErrShortBuffer, io.ErrShortWrite, io.ErrUnexpectedEOF:
-		return codes.FailedPrecondition
-	case os.ErrInvalid:
-		return codes.InvalidArgument
-	case context.Canceled:
-		return codes.Canceled
-	case context.DeadlineExceeded:
-		return codes.DeadlineExceeded
-	}
-	switch {
-	case os.IsExist(err):
-		return codes.AlreadyExists
-	case os.IsNotExist(err):
-		return codes.NotFound
-	case os.IsPermission(err):
-		return codes.PermissionDenied
-	}
-	return codes.Unknown
 }

--- a/go17.go
+++ b/go17.go
@@ -26,7 +26,6 @@ import (
 	"io"
 	"net"
 	"net/http"
-	"os"
 
 	netctx "golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
@@ -69,32 +68,4 @@ func toRPCErr(err error) error {
 		}
 	}
 	return status.Error(codes.Unknown, err.Error())
-}
-
-// convertCode converts a standard Go error into its canonical code. Note that
-// this is only used to translate the error returned by the server applications.
-func convertCode(err error) codes.Code {
-	switch err {
-	case nil:
-		return codes.OK
-	case io.EOF:
-		return codes.OutOfRange
-	case io.ErrClosedPipe, io.ErrNoProgress, io.ErrShortBuffer, io.ErrShortWrite, io.ErrUnexpectedEOF:
-		return codes.FailedPrecondition
-	case os.ErrInvalid:
-		return codes.InvalidArgument
-	case context.Canceled, netctx.Canceled:
-		return codes.Canceled
-	case context.DeadlineExceeded, netctx.DeadlineExceeded:
-		return codes.DeadlineExceeded
-	}
-	switch {
-	case os.IsExist(err):
-		return codes.AlreadyExists
-	case os.IsNotExist(err):
-		return codes.NotFound
-	case os.IsPermission(err):
-		return codes.PermissionDenied
-	}
-	return codes.Unknown
 }

--- a/interceptor.go
+++ b/interceptor.go
@@ -48,7 +48,9 @@ type UnaryServerInfo struct {
 }
 
 // UnaryHandler defines the handler invoked by UnaryServerInterceptor to complete the normal
-// execution of a unary RPC.
+// execution of a unary RPC. If a UnaryHandler returns an error, it should be produced by the
+// status package, or else gRPC will use codes.Unknown as the status code and err.Error() as
+// the status message of the RPC.
 type UnaryHandler func(ctx context.Context, req interface{}) (interface{}, error)
 
 // UnaryServerInterceptor provides a hook to intercept the execution of a unary RPC on the server. info

--- a/server.go
+++ b/server.go
@@ -922,7 +922,7 @@ func (s *Server) processUnaryRPC(t transport.ServerTransport, stream *transport.
 		appStatus, ok := status.FromError(appErr)
 		if !ok {
 			// Convert appErr if it is not a grpc status error.
-			appErr = status.Error(convertCode(appErr), appErr.Error())
+			appErr = status.Error(codes.Unknown, appErr.Error())
 			appStatus, _ = status.FromError(appErr)
 		}
 		if trInfo != nil {
@@ -1065,7 +1065,7 @@ func (s *Server) processStreamingRPC(t transport.ServerTransport, stream *transp
 			case transport.StreamError:
 				appStatus = status.New(err.Code, err.Desc)
 			default:
-				appStatus = status.New(convertCode(appErr), appErr.Error())
+				appStatus = status.New(codes.Unknown, appErr.Error())
 			}
 			appErr = appStatus.Err()
 		}

--- a/stream.go
+++ b/stream.go
@@ -36,7 +36,10 @@ import (
 )
 
 // StreamHandler defines the handler called by gRPC server to complete the
-// execution of a streaming RPC.
+// execution of a streaming RPC. If a StreamHandler returns an error, it
+// should be produced by the status package, or else gRPC will use
+// codes.Unknown as the status code and err.Error() as the status message
+// of the RPC.
 type StreamHandler func(srv interface{}, stream ServerStream) error
 
 // StreamDesc represents a streaming RPC service's method specification.


### PR DESCRIPTION
Was waffling on whether the `os.IsExist(err)` and `os.IsNotExist(err)` errors should be `Unknown`, but went with internal. Let me know if y'all think any of these could be amended