### PR TITLE
resolver: always fall back to default resolver when target does not follow URI scheme

### DIFF
--- a/resolver_conn_wrapper.go
+++ b/resolver_conn_wrapper.go
@@ -54,7 +54,10 @@ func parseTarget(target string) (ret resolver.Target) {
 	if !ok {
 		return resolver.Target{Endpoint: target}
 	}
-	ret.Authority, ret.Endpoint, _ = split2(ret.Endpoint, "/")
+	ret.Authority, ret.Endpoint, ok = split2(ret.Endpoint, "/")
+	if !ok {
+		return resolver.Target{Endpoint: target}
+	}
 	return ret
 }
 

--- a/resolver_conn_wrapper_test.go
+++ b/resolver_conn_wrapper_test.go
@@ -53,7 +53,6 @@ func TestParseTargetString(t *testing.T) {
 		want      resolver.Target
 	}{
 		{"", resolver.Target{"", "", ""}},
-		{"://", resolver.Target{"", "", ""}},
 		{":///", resolver.Target{"", "", ""}},
 		{"a:///", resolver.Target{"a", "", ""}},
 		{"://a/", resolver.Target{"", "a", ""}},
@@ -70,6 +69,10 @@ func TestParseTargetString(t *testing.T) {
 		{"google.com", resolver.Target{"", "", "google.com"}},
 		{"google.com/?a=b", resolver.Target{"", "", "google.com/?a=b"}},
 		{"/unix/socket/address", resolver.Target{"", "", "/unix/socket/address"}},
+
+		// If we can only parse part of the target.
+		{"://", resolver.Target{"", "", "://"}},
+		{"unix://domain", resolver.Target{"", "", "unix://domain"}},
 	} {
 		got := parseTarget(test.targetStr)
 		if got != test.want {

--- a/resolver_conn_wrapper_test.go
+++ b/resolver_conn_wrapper_test.go
@@ -73,6 +73,11 @@ func TestParseTargetString(t *testing.T) {
 		// If we can only parse part of the target.
 		{"://", resolver.Target{"", "", "://"}},
 		{"unix://domain", resolver.Target{"", "", "unix://domain"}},
+		{"a:b", resolver.Target{"", "", "a:b"}},
+		{"a/b", resolver.Target{"", "", "a/b"}},
+		{"a:/b", resolver.Target{"", "", "a:/b"}},
+		{"a//b", resolver.Target{"", "", "a//b"}},
+		{"a://b", resolver.Target{"", "", "a://b"}},
 	} {
 		got := parseTarget(test.targetStr)
 		if got != test.want {


### PR DESCRIPTION
#1741 
#1883