### PR TITLE
gzip: Add ability to set compression level

### DIFF
--- a/encoding/gzip/gzip.go
+++ b/encoding/gzip/gzip.go
@@ -58,7 +58,10 @@ func SetLevel(level int) error {
 	}
 	c := encoding.GetCompressor(Name).(*compressor)
 	c.poolCompressor.New = func() interface{} {
-		w, _ := gzip.NewWriterLevel(ioutil.Discard, level)
+		w, err := gzip.NewWriterLevel(ioutil.Discard, level)
+		if err != nil {
+			panic(err)
+		}
 		return &writer{Writer: w, pool: &c.poolCompressor}
 	}
 	return nil

--- a/encoding/gzip/gzip.go
+++ b/encoding/gzip/gzip.go
@@ -23,10 +23,10 @@ package gzip
 
 import (
 	"compress/gzip"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"sync"
-	"fmt"
 
 	"google.golang.org/grpc/encoding"
 )
@@ -47,12 +47,13 @@ type writer struct {
 	pool *sync.Pool
 }
 
-// SetLevel updates the registered gzip compressor to use the compression level specified.
-// NOTE: this function must only be called during initialization time (i.e. in an init() function), and is not thread-safe.
+// SetLevel updates the registered gzip compressor to use the compression level specified (gzip.HuffmanOnly is not supported).
+// NOTE: this function must only be called during initialization time (i.e. in an init() function),
+// and is not thread-safe.
 //
 // The error returned will be nil if the specified level is valid.
 func SetLevel(level int) error {
-	if level < gzip.HuffmanOnly || level > gzip.BestCompression {
+	if level < gzip.DefaultCompression || level > gzip.BestCompression {
 		return  fmt.Errorf("grpc: invalid gzip compression level: %d", level)
 	}
 	c := encoding.GetCompressor(Name).(*compressor)

--- a/encoding/gzip/gzip.go
+++ b/encoding/gzip/gzip.go
@@ -54,11 +54,11 @@ type writer struct {
 // The error returned will be nil if the specified level is valid.
 func SetLevel(level int) error {
 	if level < gzip.DefaultCompression || level > gzip.BestCompression {
-		return  fmt.Errorf("grpc: invalid gzip compression level: %d", level)
+		return fmt.Errorf("grpc: invalid gzip compression level: %d", level)
 	}
 	c := encoding.GetCompressor(Name).(*compressor)
 	c.poolCompressor.New = func() interface{} {
-		w,_:=gzip.NewWriterLevel(ioutil.Discard, level)
+		w, _ := gzip.NewWriterLevel(ioutil.Discard, level)
 		return &writer{Writer: w, pool: &c.poolCompressor}
 	}
 	return nil

--- a/rpc_util.go
+++ b/rpc_util.go
@@ -40,17 +40,16 @@ import (
 	"google.golang.org/grpc/stats"
 	"google.golang.org/grpc/status"
 	"google.golang.org/grpc/transport"
-	"compress/flate"
 
 )
-// These constants are copied from the flate package, to generify it for all
-// compression algorithms that can be used
+// These constants values are copied from the flate package, Declared to generify compression for all
+// compression algorithms
 const (
-	NoCompression      = flate.NoCompression
-	BestSpeed          = flate.BestSpeed
-	BestCompression    = flate.BestCompression
-	DefaultCompression = flate.DefaultCompression
-	HuffmanOnly        = flate.HuffmanOnly
+	NoCompression      = 0
+	BestSpeed          = 1
+	BestCompression    = 9
+	DefaultCompression = -1
+	HuffmanOnly = -2
 )
 
 // Compressor defines the interface gRPC uses to compress a message.

--- a/rpc_util.go
+++ b/rpc_util.go
@@ -65,7 +65,7 @@ func NewGZIPCompressor() Compressor {
 //
 // The error returned will be nil if the level is valid.
 func NewGZIPCompressorWithLevel(level int) (Compressor, error) {
-	if level < gzip.HuffmanOnly || level > gzip.BestCompression {
+	if level < gzip.DefaultCompression || level > gzip.BestCompression {
 		return nil, fmt.Errorf("grpc: invalid compression level: %d", level)
 	}
 	return &gzipCompressor{

--- a/rpc_util.go
+++ b/rpc_util.go
@@ -42,16 +42,6 @@ import (
 	"google.golang.org/grpc/transport"
 )
 
-// These constants values are copied from the flate package, Declared to generify compression for all
-// compression algorithms
-const (
-	NoCompression      = 0
-	BestSpeed          = 1
-	BestCompression    = 9
-	DefaultCompression = -1
-	HuffmanOnly        = -2
-)
-
 // Compressor defines the interface gRPC uses to compress a message.
 type Compressor interface {
 	// Do compresses p into w.
@@ -66,18 +56,16 @@ type gzipCompressor struct {
 
 // NewGZIPCompressor creates a Compressor based on GZIP.
 func NewGZIPCompressor() Compressor {
-	c, _ := NewGZIPCompressorWithLevel(BestCompression)
+	c, _ := NewGZIPCompressorWithLevel(gzip.DefaultCompression)
 	return c
 }
 
-// NewGZIPCompressorWithLevel is like NewGZIPCompressor but specifies the compression level instead
-// of assuming BestCompression.
+// NewGZIPCompressorWithLevel is like NewGZIPCompressor but specifies the gzip compression level instead
+// of assuming DefaultCompression.
 //
-// The compression level can be DefaultCompression, NoCompression, HuffmanOnly
-// or any integer value between BestSpeed and BestCompression inclusive.
 // The error returned will be nil if the level is valid.
 func NewGZIPCompressorWithLevel(level int) (Compressor, error) {
-	if level < HuffmanOnly || level > BestCompression {
+	if level < gzip.HuffmanOnly || level > gzip.BestCompression {
 		return nil, fmt.Errorf("grpc: invalid compression level: %d", level)
 	}
 	return &gzipCompressor{

--- a/rpc_util.go
+++ b/rpc_util.go
@@ -71,7 +71,10 @@ func NewGZIPCompressorWithLevel(level int) (Compressor, error) {
 	return &gzipCompressor{
 		pool: sync.Pool{
 			New: func() interface{} {
-				w, _ := gzip.NewWriterLevel(ioutil.Discard, level)
+				w, err := gzip.NewWriterLevel(ioutil.Discard, level)
+				if err != nil {
+					panic(err)
+				}
 				return w
 			},
 		},

--- a/rpc_util.go
+++ b/rpc_util.go
@@ -70,6 +70,12 @@ func NewGZIPCompressor() Compressor {
 	return c
 }
 
+// NewGZIPCompressorWithLevel is like NewGZIPCompressor but specifies the compression level instead
+// of assuming BestCompression.
+//
+// The compression level can be DefaultCompression, NoCompression, HuffmanOnly
+// or any integer value between BestSpeed and BestCompression inclusive.
+// The error returned will be nil if the level is valid.
 func NewGZIPCompressorWithLevel(level int) (Compressor, error) {
 	if level < HuffmanOnly || level > BestCompression {
 		return nil, fmt.Errorf("grpc: invalid compression level: %d", level)

--- a/rpc_util.go
+++ b/rpc_util.go
@@ -22,13 +22,13 @@ import (
 	"bytes"
 	"compress/gzip"
 	"encoding/binary"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"math"
 	"strings"
 	"sync"
 	"time"
-	"fmt"
 
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
@@ -40,8 +40,8 @@ import (
 	"google.golang.org/grpc/stats"
 	"google.golang.org/grpc/status"
 	"google.golang.org/grpc/transport"
-
 )
+
 // These constants values are copied from the flate package, Declared to generify compression for all
 // compression algorithms
 const (
@@ -49,7 +49,7 @@ const (
 	BestSpeed          = 1
 	BestCompression    = 9
 	DefaultCompression = -1
-	HuffmanOnly = -2
+	HuffmanOnly        = -2
 )
 
 // Compressor defines the interface gRPC uses to compress a message.
@@ -66,22 +66,22 @@ type gzipCompressor struct {
 
 // NewGZIPCompressor creates a Compressor based on GZIP.
 func NewGZIPCompressor() Compressor {
-	c,_:=NewGZIPCompressorWithLevel(BestCompression)
+	c, _ := NewGZIPCompressorWithLevel(BestCompression)
 	return c
 }
 
-func NewGZIPCompressorWithLevel(level int) (Compressor,error){
+func NewGZIPCompressorWithLevel(level int) (Compressor, error) {
 	if level < HuffmanOnly || level > BestCompression {
 		return nil, fmt.Errorf("grpc: invalid compression level: %d", level)
 	}
 	return &gzipCompressor{
 		pool: sync.Pool{
 			New: func() interface{} {
-				w,_:=gzip.NewWriterLevel(ioutil.Discard, level)
+				w, _ := gzip.NewWriterLevel(ioutil.Discard, level)
 				return w
 			},
 		},
-	},nil
+	}, nil
 }
 
 func (c *gzipCompressor) Do(w io.Writer, p []byte) error {

--- a/rpc_util_test.go
+++ b/rpc_util_test.go
@@ -20,6 +20,7 @@ package grpc
 
 import (
 	"bytes"
+	"compress/gzip"
 	"io"
 	"math"
 	"reflect"
@@ -120,6 +121,26 @@ func TestEncode(t *testing.T) {
 }
 
 func TestCompress(t *testing.T) {
+
+	bestCompressor, err := NewGZIPCompressorWithLevel(gzip.BestCompression)
+	if err != nil {
+		t.Fatalf("Could not initialize gzip compressor with best compression.")
+	}
+	bestSpeedCompressor, err := NewGZIPCompressorWithLevel(gzip.BestSpeed)
+	if err != nil {
+		t.Fatalf("Could not initialize gzip compressor with best speed compression.")
+	}
+
+	defaultCompressor, err := NewGZIPCompressorWithLevel(gzip.BestSpeed)
+	if err != nil {
+		t.Fatalf("Could not initialize gzip compressor with default compression.")
+	}
+
+	level5, err := NewGZIPCompressorWithLevel(5)
+	if err != nil {
+		t.Fatalf("Could not initialize gzip compressor with level 5 compression.")
+	}
+
 	for _, test := range []struct {
 		// input
 		data []byte
@@ -129,6 +150,10 @@ func TestCompress(t *testing.T) {
 		err error
 	}{
 		{make([]byte, 1024), NewGZIPCompressor(), NewGZIPDecompressor(), nil},
+		{make([]byte, 1024), bestCompressor, NewGZIPDecompressor(), nil},
+		{make([]byte, 1024), bestSpeedCompressor, NewGZIPDecompressor(), nil},
+		{make([]byte, 1024), defaultCompressor, NewGZIPDecompressor(), nil},
+		{make([]byte, 1024), level5, NewGZIPDecompressor(), nil},
 	} {
 		b := new(bytes.Buffer)
 		if err := test.cp.Do(b, test.data); err != test.err {


### PR DESCRIPTION
- BestSpeed compression level give 36% request throughput improvement over BestCompression with a slight compromise on network bandwidth
After this we can choose gzip compression level during server and client setup to level which suites our usecase