### PR TITLE
encoding/proto: remove capToMaxInt32 due to impossible range check

### DIFF
--- a/encoding/proto/proto.go
+++ b/encoding/proto/proto.go
@@ -21,7 +21,6 @@
 package proto
 
 import (
-	"math"
 	"sync"
 
 	"github.com/golang/protobuf/proto"
@@ -43,13 +42,6 @@ type cachedProtoBuffer struct {
 	proto.Buffer
 }
 
-func capToMaxInt32(val int) uint32 {
-	if val > math.MaxInt32 {
-		return uint32(math.MaxInt32)
-	}
-	return uint32(val)
-}
-
 func marshal(v interface{}, cb *cachedProtoBuffer) ([]byte, error) {
 	protoMsg := v.(proto.Message)
 	newSlice := make([]byte, 0, cb.lastMarshaledSize)
@@ -60,7 +52,7 @@ func marshal(v interface{}, cb *cachedProtoBuffer) ([]byte, error) {
 		return nil, err
 	}
 	out := cb.Bytes()
-	cb.lastMarshaledSize = capToMaxInt32(len(out))
+	cb.lastMarshaledSize = uint32(len(out))
 	return out, nil
 }
 


### PR DESCRIPTION
Fixes #1892

The range of int is:
  -2147483648 to 2147483647
hence the check:
  v > math.MaxInt32
is impossible and the entire function can be replaced by
the always taken else case:
  return uint32(v)

which in our case is:
  uint32(len(out))

but also the len(item) can never be less than zero in Go
https://golang.org/ref/spec#Length_and_capacity
  0 <= len(s) <= cap(s)
so we should never worry about this check.