### PR TITLE
ALTS: Simplify "New" APIs

### DIFF
--- a/credentials/alts/alts.go
+++ b/credentials/alts/alts.go
@@ -100,13 +100,13 @@ type altsTC struct {
 	accounts []string
 }
 
-// NewClientALTS constructs a client-side ALTS TransportCredentials object.
-func NewClientALTS(targetServiceAccounts []string) credentials.TransportCredentials {
+// NewClient constructs a client-side ALTS TransportCredentials object.
+func NewClient(targetServiceAccounts []string) credentials.TransportCredentials {
 	return newALTS(core.ClientSide, targetServiceAccounts)
 }
 
-// NewServerALTS constructs a server-side ALTS TransportCredentials object.
-func NewServerALTS() credentials.TransportCredentials {
+// NewServer constructs a server-side ALTS TransportCredentials object.
+func NewServer() credentials.TransportCredentials {
 	return newALTS(core.ServerSide, nil)
 }
 

--- a/credentials/alts/alts_test.go
+++ b/credentials/alts/alts_test.go
@@ -27,8 +27,8 @@ import (
 
 func TestInfoServerName(t *testing.T) {
 	// This is not testing any handshaker functionality, so it's fine to only
-	// use NewServerALTS and not NewClientALTS.
-	alts := NewServerALTS()
+	// use NewServer and not NewClient.
+	alts := NewServer()
 	if got, want := alts.Info().ServerName, ""; got != want {
 		t.Fatalf("%v.Info().ServerName = %v, want %v", alts, got, want)
 	}
@@ -37,8 +37,8 @@ func TestInfoServerName(t *testing.T) {
 func TestOverrideServerName(t *testing.T) {
 	wantServerName := "server.name"
 	// This is not testing any handshaker functionality, so it's fine to only
-	// use NewServerALTS and not NewClientALTS.
-	c := NewServerALTS()
+	// use NewServer and not NewClient.
+	c := NewServer()
 	c.OverrideServerName(wantServerName)
 	if got, want := c.Info().ServerName, wantServerName; got != want {
 		t.Fatalf("c.Info().ServerName = %v, want %v", got, want)
@@ -48,8 +48,8 @@ func TestOverrideServerName(t *testing.T) {
 func TestClone(t *testing.T) {
 	wantServerName := "server.name"
 	// This is not testing any handshaker functionality, so it's fine to only
-	// use NewServerALTS and not NewClientALTS.
-	c := NewServerALTS()
+	// use NewServer and not NewClient.
+	c := NewServer()
 	c.OverrideServerName(wantServerName)
 	cc := c.Clone()
 	if got, want := cc.Info().ServerName, wantServerName; got != want {
@@ -66,8 +66,8 @@ func TestClone(t *testing.T) {
 
 func TestInfo(t *testing.T) {
 	// This is not testing any handshaker functionality, so it's fine to only
-	// use NewServerALTS and not NewClientALTS.
-	c := NewServerALTS()
+	// use NewServer and not NewClient.
+	c := NewServer()
 	info := c.Info()
 	if got, want := info.ProtocolVersion, ""; got != want {
 		t.Errorf("info.ProtocolVersion=%v, want %v", got, want)

--- a/interop/alts/client/client.go
+++ b/interop/alts/client/client.go
@@ -41,7 +41,7 @@ var (
 func main() {
 	flag.Parse()
 
-	altsTC := alts.NewClientALTS(nil)
+	altsTC := alts.NewClient(nil)
 	// Block until the server is ready.
 	conn, err := grpc.Dial(*serverAddr, grpc.WithTransportCredentials(altsTC), grpc.WithBlock())
 	if err != nil {

--- a/interop/alts/server/server.go
+++ b/interop/alts/server/server.go
@@ -41,7 +41,7 @@ func main() {
 	if err != nil {
 		grpclog.Fatalf("gRPC Server: failed to start the server at %v: %v", *serverAddr, err)
 	}
-	altsTC := alts.NewServerALTS()
+	altsTC := alts.NewServer()
 	grpcServer := grpc.NewServer(grpc.Creds(altsTC))
 	testpb.RegisterTestServiceServer(grpcServer, interop.NewTestServer())
 	grpcServer.Serve(lis)


### PR DESCRIPTION
ALTS `NewClientALTS` and `NewServerALTS` APIs are in the `grpc/credentials/alts` package. Having the term ALTS in the API names is redundant. This PR removes it.

Note that this is an API change but it should not break anything.