### PR TITLE
stream: split per-attempt data from clientStream

### DIFF
--- a/call.go
+++ b/call.go
@@ -54,7 +54,7 @@ func invoke(ctx context.Context, method string, req, reply interface{}, cc *Clie
 		}
 		cs := csInt.(*clientStream)
 		if err := cs.SendMsg(req); err != nil {
-			if !cs.c.failFast && cs.s.Unprocessed() && firstAttempt {
+			if !cs.c.failFast && cs.attempt.s.Unprocessed() && firstAttempt {
 				// TODO: Add a field to header for grpc-transparent-retry-attempts
 				firstAttempt = false
 				continue
@@ -62,7 +62,7 @@ func invoke(ctx context.Context, method string, req, reply interface{}, cc *Clie
 			return err
 		}
 		if err := cs.RecvMsg(reply); err != nil {
-			if !cs.c.failFast && cs.s.Unprocessed() && firstAttempt {
+			if !cs.c.failFast && cs.attempt.s.Unprocessed() && firstAttempt {
 				// TODO: Add a field to header for grpc-transparent-retry-attempts
 				firstAttempt = false
 				continue

--- a/rpc_util.go
+++ b/rpc_util.go
@@ -127,7 +127,7 @@ func (d *gzipDecompressor) Type() string {
 type callInfo struct {
 	compressorType        string
 	failFast              bool
-	stream                *transport.Stream
+	stream                *clientStream
 	traceInfo             traceInfo // in trace.go
 	maxReceiveMessageSize *int
 	maxSendMessageSize    *int


### PR DESCRIPTION
This is pre-work to implementing retry support.  Each retry attempt will have its own `csAttempt`.  The fields left in clientStream are the same across all attempts.