### PR TITLE
Call options provide methods so interceptors in other packages can recover settings

### DIFF
--- a/call.go
+++ b/call.go
@@ -27,6 +27,10 @@ import (
 //
 // All errors returned by Invoke are compatible with the status package.
 func (cc *ClientConn) Invoke(ctx context.Context, method string, args, reply interface{}, opts ...CallOption) error {
+	// allow interceptor to see all applicable call options, which means those
+	// configured as defaults from dial option as well as per-call options
+	opts = append(cc.dopts.callOptions, opts...)
+
 	if cc.dopts.unaryInt != nil {
 		return cc.dopts.unaryInt(ctx, method, args, reply, cc, invoke, opts...)
 	}

--- a/rpc_util.go
+++ b/rpc_util.go
@@ -162,72 +162,79 @@ func (EmptyCallOption) after(*callInfo)        {}
 
 // Header returns a CallOptions that retrieves the header metadata
 // for a unary RPC.
-//
-// The returned CallOption provides a HeaderAddr() method that can
-// be used by interceptors to recover the given metadata address.
 func Header(md *metadata.MD) CallOption {
-	return headerCallOption{md: md}
+	return HeaderCallOption{md: md}
 }
 
-type headerCallOption struct {
+// HeaderCallOption is a CallOption for collecting response header metadata.
+// This is an EXPERIMENTAL API.
+type HeaderCallOption struct {
 	md *metadata.MD
 }
 
-func (o headerCallOption) before(c *callInfo) error { return nil }
-func (o headerCallOption) after(c *callInfo) {
+func (o HeaderCallOption) before(c *callInfo) error { return nil }
+func (o HeaderCallOption) after(c *callInfo) {
 	if c.stream != nil {
 		*o.md, _ = c.stream.Header()
 	}
 }
-func (o headerCallOption) HeaderAddr() *metadata.MD {
+
+// HeaderAddr returns the address where header metadata will be stored after the
+// unary RPC completes.
+func (o HeaderCallOption) HeaderAddr() *metadata.MD {
 	return o.md
 }
 
 // Trailer returns a CallOptions that retrieves the trailer metadata
 // for a unary RPC.
-//
-// The returned CallOption provides a TrailerAddr() method that can
-// be used by interceptors to recover the given metadata address.
 func Trailer(md *metadata.MD) CallOption {
-	return trailerCallOption{md: md}
+	return TrailerCallOption{md: md}
 }
 
-type trailerCallOption struct {
+// TrailerCallOption is a CallOption for collecting response trailer metadata.
+// This is an EXPERIMENTAL API.
+type TrailerCallOption struct {
 	md *metadata.MD
 }
 
-func (o trailerCallOption) before(c *callInfo) error { return nil }
-func (o trailerCallOption) after(c *callInfo) {
+func (o TrailerCallOption) before(c *callInfo) error { return nil }
+func (o TrailerCallOption) after(c *callInfo) {
 	if c.stream != nil {
 		*o.md = c.stream.Trailer()
 	}
 }
-func (o trailerCallOption) TrailerAddr() *metadata.MD {
+
+// TrailerAddr returns the address where trailer metadata will be stored after
+// the unary RPC completes.
+func (o TrailerCallOption) TrailerAddr() *metadata.MD {
 	return o.md
 }
 
 // Peer returns a CallOption that retrieves peer information for a
 // unary RPC.
-//
-// The returned CallOption provides a PeerAddr() method that can
-// be used by interceptors to recover the given peer address.
 func Peer(p *peer.Peer) CallOption {
-	return peerCallOption{p: p}
+	return PeerCallOption{p: p}
 }
 
-type peerCallOption struct {
+// PeerCallOption is a CallOption for collecting the identity of the remote
+// peer.
+// This is an EXPERIMENTAL API.
+type PeerCallOption struct {
 	p *peer.Peer
 }
 
-func (o peerCallOption) before(c *callInfo) error { return nil }
-func (o peerCallOption) after(c *callInfo) {
+func (o PeerCallOption) before(c *callInfo) error { return nil }
+func (o PeerCallOption) after(c *callInfo) {
 	if c.stream != nil {
 		if x, ok := peer.FromContext(c.stream.Context()); ok {
 			*o.p = *x
 		}
 	}
 }
-func (o peerCallOption) PeerAddr() *peer.Peer {
+
+// PeerAddr returns the address where peer info will be stored after the unary
+// completes.
+func (o PeerCallOption) PeerAddr() *peer.Peer {
 	return o.p
 }
 
@@ -241,83 +248,92 @@ func (o peerCallOption) PeerAddr() *peer.Peer {
 // https://github.com/grpc/grpc/blob/master/doc/wait-for-ready.md.
 //
 // By default, RPCs are "Fail Fast".
-//
-// The returned CallOption provides a FailFast() method that can
-// be used by interceptors to recover the setting.
 func FailFast(failFast bool) CallOption {
-	return failFastCallOption(failFast)
+	return FailFastCallOption(failFast)
 }
 
-type failFastCallOption bool
+// FailFastCallOption is a CallOption for indicating whether an RPC should fail
+// fast or not.
+// This is an EXPERIMENTAL API.
+type FailFastCallOption bool
 
-func (o failFastCallOption) before(c *callInfo) error {
+func (o FailFastCallOption) before(c *callInfo) error {
 	c.failFast = bool(o)
 	return nil
 }
-func (o failFastCallOption) after(c *callInfo) { return }
-func (o failFastCallOption) FailFast() bool {
+func (o FailFastCallOption) after(c *callInfo) { return }
+
+// FailFast returns true if this call option directs the RPC to fail fast, false
+// otherwise.
+func (o FailFastCallOption) FailFast() bool {
 	return bool(o)
 }
 
 // MaxCallRecvMsgSize returns a CallOption which sets the maximum message size the client can receive.
-//
-// The returned CallOption provides a MaxRecvMsgSize() method that can be used by interceptors to
-// recover the setting.
 func MaxCallRecvMsgSize(s int) CallOption {
-	return maxRecvMsgSizeCallOption(s)
+	return MaxRecvMsgSizeCallOption(s)
 }
 
-type maxRecvMsgSizeCallOption int
+// MaxRecvMsgSizeCallOption is a CallOption that indicates the maximum message
+// size the client can receive.
+// This is an EXPERIMENTAL API.
+type MaxRecvMsgSizeCallOption int
 
-func (o maxRecvMsgSizeCallOption) before(c *callInfo) error {
+func (o MaxRecvMsgSizeCallOption) before(c *callInfo) error {
 	s := int(o)
 	c.maxReceiveMessageSize = &s
 	return nil
 }
-func (o maxRecvMsgSizeCallOption) after(c *callInfo) { return }
-func (o maxRecvMsgSizeCallOption) MaxRecvMsgSize() int {
+func (o MaxRecvMsgSizeCallOption) after(c *callInfo) { return }
+
+// MaxRecvMsgSize returns the maximum size allowed for a received message.
+func (o MaxRecvMsgSizeCallOption) MaxRecvMsgSize() int {
 	return int(o)
 }
 
 // MaxCallSendMsgSize returns a CallOption which sets the maximum message size the client can send.
-//
-// The returned CallOption provides a MaxSendMsgSize() method that can be used by interceptors to
-// recover the setting.
 func MaxCallSendMsgSize(s int) CallOption {
-	return maxSendMsgSizeCallOption(s)
+	return MaxSendMsgSizeCallOption(s)
 }
 
-type maxSendMsgSizeCallOption int
+// MaxSendMsgSizeCallOption is a CallOption that indicates the maximum message
+// size the client can send.
+// This is an EXPERIMENTAL API.
+type MaxSendMsgSizeCallOption int
 
-func (o maxSendMsgSizeCallOption) before(c *callInfo) error {
+func (o MaxSendMsgSizeCallOption) before(c *callInfo) error {
 	s := int(o)
 	c.maxSendMessageSize = &s
 	return nil
 }
-func (o maxSendMsgSizeCallOption) after(c *callInfo) { return }
-func (o maxSendMsgSizeCallOption) MaxSendMsgSize() int {
+func (o MaxSendMsgSizeCallOption) after(c *callInfo) { return }
+
+// MaxSendMsgSize returns the maximum size allowed for a sent message.
+func (o MaxSendMsgSizeCallOption) MaxSendMsgSize() int {
 	return int(o)
 }
 
 // PerRPCCredentials returns a CallOption that sets credentials.PerRPCCredentials
 // for a call.
-//
-// The returned CallOption provides a PerRPCCredentials() method that can be used
-// by interceptors to recover the credentials.
 func PerRPCCredentials(creds credentials.PerRPCCredentials) CallOption {
-	return perRPCCredsCallOption{creds: creds}
+	return PerRPCCredsCallOption{creds: creds}
 }
 
-type perRPCCredsCallOption struct {
+// PerRPCCredsCallOption is a CallOption that indicates the the per-RPC
+// credentials to use for the call.
+// This is an EXPERIMENTAL API.
+type PerRPCCredsCallOption struct {
 	creds credentials.PerRPCCredentials
 }
 
-func (o perRPCCredsCallOption) before(c *callInfo) error {
+func (o PerRPCCredsCallOption) before(c *callInfo) error {
 	c.creds = o.creds
 	return nil
 }
-func (o perRPCCredsCallOption) after(c *callInfo) { return }
-func (o perRPCCredsCallOption) PerRPCCredentials() credentials.PerRPCCredentials {
+func (o PerRPCCredsCallOption) after(c *callInfo) { return }
+
+// PerRPCCredentials returns the per-RPC credentials.
+func (o PerRPCCredsCallOption) PerRPCCredentials() credentials.PerRPCCredentials {
 	return o.creds
 }
 
@@ -326,21 +342,22 @@ func (o perRPCCredsCallOption) PerRPCCredentials() credentials.PerRPCCredentials
 // higher priority.
 //
 // This API is EXPERIMENTAL.
-//
-// The returned CallOption provides a Compressor() method that can be used
-// by interceptors to recover the given name.
 func UseCompressor(name string) CallOption {
-	return compressorCallOption(name)
+	return CompressorCallOption(name)
 }
 
-type compressorCallOption string
+// CompressorCallOption is a CallOption that indicates the compressor to use.
+// This is an EXPERIMENTAL API.
+type CompressorCallOption string
 
-func (o compressorCallOption) before(c *callInfo) error {
+func (o CompressorCallOption) before(c *callInfo) error {
 	c.compressorType = string(o)
 	return nil
 }
-func (o compressorCallOption) after(c *callInfo) { return }
-func (o compressorCallOption) Compressor() string {
+func (o CompressorCallOption) after(c *callInfo) { return }
+
+// Compressor returns the name of the compressor to use for the call.
+func (o CompressorCallOption) Compressor() string {
 	return string(o)
 }
 
@@ -360,21 +377,23 @@ func (o compressorCallOption) Compressor() string {
 // If CallCustomCodec is also used, that Codec will be used for all request and
 // response messages, with the content-subtype set to the given contentSubtype
 // here for requests.
-//
-// The returned CallOption provides a ContentSubtype() method that can be used
-// by interceptors to recover the given setting.
 func CallContentSubtype(contentSubtype string) CallOption {
-	return contentSubtypeCallOption(strings.ToLower(contentSubtype))
+	return ContentSubtypeCallOption(strings.ToLower(contentSubtype))
 }
 
-type contentSubtypeCallOption string
+// ContentSubtypeCallOption is a CallOption that indicates the content-subtype
+// used for marshaling messages.
+// This is an EXPERIMENTAL API.
+type ContentSubtypeCallOption string
 
-func (o contentSubtypeCallOption) before(c *callInfo) error {
+func (o ContentSubtypeCallOption) before(c *callInfo) error {
 	c.contentSubtype = string(o)
 	return nil
 }
-func (o contentSubtypeCallOption) after(c *callInfo) { return }
-func (o contentSubtypeCallOption) ContentSubtype() string {
+func (o ContentSubtypeCallOption) after(c *callInfo) { return }
+
+// ContentSubtype returns the content-subtype of the codec used for the call.
+func (o ContentSubtypeCallOption) ContentSubtype() string {
 	return string(o)
 }
 
@@ -390,23 +409,25 @@ func (o contentSubtypeCallOption) ContentSubtype() string {
 //
 // This function is provided for advanced users; prefer to use only
 // CallContentSubtype to select a registered codec instead.
-//
-// The returned CallOption provides a Codec() method that can be used by
-// interceptors to recover the configured codec.
 func CallCustomCodec(codec Codec) CallOption {
-	return customCodecCallOption{codec: codec}
+	return CustomCodecCallOption{codec: codec}
 }
 
-type customCodecCallOption struct {
+// CustomCodecCallOption is a CallOption that indicates the codec used for
+// marshaling messages.
+// This is an EXPERIMENTAL API.
+type CustomCodecCallOption struct {
 	codec Codec
 }
 
-func (o customCodecCallOption) before(c *callInfo) error {
+func (o CustomCodecCallOption) before(c *callInfo) error {
 	c.codec = o.codec
 	return nil
 }
-func (o customCodecCallOption) after(c *callInfo) { return }
-func (o customCodecCallOption) Codec() Codec {
+func (o CustomCodecCallOption) after(c *callInfo) { return }
+
+// Codec returns the codec used for the call.
+func (o CustomCodecCallOption) Codec() Codec {
 	return o.codec
 }
 

--- a/rpc_util.go
+++ b/rpc_util.go
@@ -163,79 +163,61 @@ func (EmptyCallOption) after(*callInfo)        {}
 // Header returns a CallOptions that retrieves the header metadata
 // for a unary RPC.
 func Header(md *metadata.MD) CallOption {
-	return HeaderCallOption{md: md}
+	return HeaderCallOption{HeaderAddr: md}
 }
 
 // HeaderCallOption is a CallOption for collecting response header metadata.
 // This is an EXPERIMENTAL API.
 type HeaderCallOption struct {
-	md *metadata.MD
+	HeaderAddr *metadata.MD
 }
 
 func (o HeaderCallOption) before(c *callInfo) error { return nil }
 func (o HeaderCallOption) after(c *callInfo) {
 	if c.stream != nil {
-		*o.md, _ = c.stream.Header()
+		*o.HeaderAddr, _ = c.stream.Header()
 	}
-}
-
-// HeaderAddr returns the address where header metadata will be stored after the
-// unary RPC completes.
-func (o HeaderCallOption) HeaderAddr() *metadata.MD {
-	return o.md
 }
 
 // Trailer returns a CallOptions that retrieves the trailer metadata
 // for a unary RPC.
 func Trailer(md *metadata.MD) CallOption {
-	return TrailerCallOption{md: md}
+	return TrailerCallOption{TrailerAddr: md}
 }
 
 // TrailerCallOption is a CallOption for collecting response trailer metadata.
 // This is an EXPERIMENTAL API.
 type TrailerCallOption struct {
-	md *metadata.MD
+	TrailerAddr *metadata.MD
 }
 
 func (o TrailerCallOption) before(c *callInfo) error { return nil }
 func (o TrailerCallOption) after(c *callInfo) {
 	if c.stream != nil {
-		*o.md = c.stream.Trailer()
+		*o.TrailerAddr = c.stream.Trailer()
 	}
-}
-
-// TrailerAddr returns the address where trailer metadata will be stored after
-// the unary RPC completes.
-func (o TrailerCallOption) TrailerAddr() *metadata.MD {
-	return o.md
 }
 
 // Peer returns a CallOption that retrieves peer information for a
 // unary RPC.
 func Peer(p *peer.Peer) CallOption {
-	return PeerCallOption{p: p}
+	return PeerCallOption{PeerAddr: p}
 }
 
 // PeerCallOption is a CallOption for collecting the identity of the remote
 // peer.
 // This is an EXPERIMENTAL API.
 type PeerCallOption struct {
-	p *peer.Peer
+	PeerAddr *peer.Peer
 }
 
 func (o PeerCallOption) before(c *callInfo) error { return nil }
 func (o PeerCallOption) after(c *callInfo) {
 	if c.stream != nil {
 		if x, ok := peer.FromContext(c.stream.Context()); ok {
-			*o.p = *x
+			*o.PeerAddr = *x
 		}
 	}
-}
-
-// PeerAddr returns the address where peer info will be stored after the unary
-// completes.
-func (o PeerCallOption) PeerAddr() *peer.Peer {
-	return o.p
 }
 
 // FailFast configures the action to take when an RPC is attempted on broken
@@ -249,93 +231,76 @@ func (o PeerCallOption) PeerAddr() *peer.Peer {
 //
 // By default, RPCs are "Fail Fast".
 func FailFast(failFast bool) CallOption {
-	return FailFastCallOption(failFast)
+	return FailFastCallOption{FailFast: failFast}
 }
 
 // FailFastCallOption is a CallOption for indicating whether an RPC should fail
 // fast or not.
 // This is an EXPERIMENTAL API.
-type FailFastCallOption bool
+type FailFastCallOption struct {
+	FailFast bool
+}
 
 func (o FailFastCallOption) before(c *callInfo) error {
-	c.failFast = bool(o)
+	c.failFast = o.FailFast
 	return nil
 }
 func (o FailFastCallOption) after(c *callInfo) { return }
 
-// FailFast returns true if this call option directs the RPC to fail fast, false
-// otherwise.
-func (o FailFastCallOption) FailFast() bool {
-	return bool(o)
-}
-
 // MaxCallRecvMsgSize returns a CallOption which sets the maximum message size the client can receive.
 func MaxCallRecvMsgSize(s int) CallOption {
-	return MaxRecvMsgSizeCallOption(s)
+	return MaxRecvMsgSizeCallOption{MaxRecvMsgSize: s}
 }
 
 // MaxRecvMsgSizeCallOption is a CallOption that indicates the maximum message
 // size the client can receive.
 // This is an EXPERIMENTAL API.
-type MaxRecvMsgSizeCallOption int
+type MaxRecvMsgSizeCallOption struct {
+	MaxRecvMsgSize int
+}
 
 func (o MaxRecvMsgSizeCallOption) before(c *callInfo) error {
-	s := int(o)
-	c.maxReceiveMessageSize = &s
+	c.maxReceiveMessageSize = &o.MaxRecvMsgSize
 	return nil
 }
 func (o MaxRecvMsgSizeCallOption) after(c *callInfo) { return }
 
-// MaxRecvMsgSize returns the maximum size allowed for a received message.
-func (o MaxRecvMsgSizeCallOption) MaxRecvMsgSize() int {
-	return int(o)
-}
-
 // MaxCallSendMsgSize returns a CallOption which sets the maximum message size the client can send.
 func MaxCallSendMsgSize(s int) CallOption {
-	return MaxSendMsgSizeCallOption(s)
+	return MaxSendMsgSizeCallOption{MaxSendMsgSize: s}
 }
 
 // MaxSendMsgSizeCallOption is a CallOption that indicates the maximum message
 // size the client can send.
 // This is an EXPERIMENTAL API.
-type MaxSendMsgSizeCallOption int
+type MaxSendMsgSizeCallOption struct {
+	MaxSendMsgSize int
+}
 
 func (o MaxSendMsgSizeCallOption) before(c *callInfo) error {
-	s := int(o)
-	c.maxSendMessageSize = &s
+	c.maxSendMessageSize = &o.MaxSendMsgSize
 	return nil
 }
 func (o MaxSendMsgSizeCallOption) after(c *callInfo) { return }
 
-// MaxSendMsgSize returns the maximum size allowed for a sent message.
-func (o MaxSendMsgSizeCallOption) MaxSendMsgSize() int {
-	return int(o)
-}
-
 // PerRPCCredentials returns a CallOption that sets credentials.PerRPCCredentials
 // for a call.
 func PerRPCCredentials(creds credentials.PerRPCCredentials) CallOption {
-	return PerRPCCredsCallOption{creds: creds}
+	return PerRPCCredsCallOption{Creds: creds}
 }
 
 // PerRPCCredsCallOption is a CallOption that indicates the the per-RPC
 // credentials to use for the call.
 // This is an EXPERIMENTAL API.
 type PerRPCCredsCallOption struct {
-	creds credentials.PerRPCCredentials
+	Creds credentials.PerRPCCredentials
 }
 
 func (o PerRPCCredsCallOption) before(c *callInfo) error {
-	c.creds = o.creds
+	c.creds = o.Creds
 	return nil
 }
 func (o PerRPCCredsCallOption) after(c *callInfo) { return }
-
-// PerRPCCredentials returns the per-RPC credentials.
-func (o PerRPCCredsCallOption) PerRPCCredentials() credentials.PerRPCCredentials {
-	return o.creds
-}
 
 // UseCompressor returns a CallOption which sets the compressor used when
 // sending the request.  If WithCompressor is also set, UseCompressor has
@@ -343,23 +308,20 @@ func (o PerRPCCredsCallOption) PerRPCCredentials() credentials.PerRPCCredentials
 //
 // This API is EXPERIMENTAL.
 func UseCompressor(name string) CallOption {
-	return CompressorCallOption(name)
+	return CompressorCallOption{CompressorType: name}
 }
 
 // CompressorCallOption is a CallOption that indicates the compressor to use.
 // This is an EXPERIMENTAL API.
-type CompressorCallOption string
+type CompressorCallOption struct {
+	CompressorType string
+}
 
 func (o CompressorCallOption) before(c *callInfo) error {
-	c.compressorType = string(o)
+	c.compressorType = o.CompressorType
 	return nil
 }
 func (o CompressorCallOption) after(c *callInfo) { return }
-
-// Compressor returns the name of the compressor to use for the call.
-func (o CompressorCallOption) Compressor() string {
-	return string(o)
-}
 
 // CallContentSubtype returns a CallOption that will set the content-subtype
 // for a call. For example, if content-subtype is "json", the Content-Type over
@@ -378,24 +340,21 @@ func (o CompressorCallOption) Compressor() string {
 // response messages, with the content-subtype set to the given contentSubtype
 // here for requests.
 func CallContentSubtype(contentSubtype string) CallOption {
-	return ContentSubtypeCallOption(strings.ToLower(contentSubtype))
+	return ContentSubtypeCallOption{ContentSubtype: strings.ToLower(contentSubtype)}
 }
 
 // ContentSubtypeCallOption is a CallOption that indicates the content-subtype
 // used for marshaling messages.
 // This is an EXPERIMENTAL API.
-type ContentSubtypeCallOption string
+type ContentSubtypeCallOption struct {
+	ContentSubtype string
+}
 
 func (o ContentSubtypeCallOption) before(c *callInfo) error {
-	c.contentSubtype = string(o)
+	c.contentSubtype = o.ContentSubtype
 	return nil
 }
 func (o ContentSubtypeCallOption) after(c *callInfo) { return }
-
-// ContentSubtype returns the content-subtype of the codec used for the call.
-func (o ContentSubtypeCallOption) ContentSubtype() string {
-	return string(o)
-}
 
 // CallCustomCodec returns a CallOption that will set the given Codec to be
 // used for all request and response messages for a call. The result of calling
@@ -410,26 +369,21 @@ func (o ContentSubtypeCallOption) ContentSubtype() string {
 // This function is provided for advanced users; prefer to use only
 // CallContentSubtype to select a registered codec instead.
 func CallCustomCodec(codec Codec) CallOption {
-	return CustomCodecCallOption{codec: codec}
+	return CustomCodecCallOption{Codec: codec}
 }
 
 // CustomCodecCallOption is a CallOption that indicates the codec used for
 // marshaling messages.
 // This is an EXPERIMENTAL API.
 type CustomCodecCallOption struct {
-	codec Codec
+	Codec Codec
 }
 
 func (o CustomCodecCallOption) before(c *callInfo) error {
-	c.codec = o.codec
+	c.codec = o.Codec
 	return nil
 }
 func (o CustomCodecCallOption) after(c *callInfo) { return }
-
-// Codec returns the codec used for the call.
-func (o CustomCodecCallOption) Codec() Codec {
-	return o.codec
-}
 
 // The format of the payload: compressed or not?
 type payloadFormat uint8

--- a/rpc_util.go
+++ b/rpc_util.go
@@ -167,6 +167,7 @@ func Header(md *metadata.MD) CallOption {
 }
 
 // HeaderCallOption is a CallOption for collecting response header metadata.
+// The metadata field will be populated *after* the RPC completes.
 // This is an EXPERIMENTAL API.
 type HeaderCallOption struct {
 	HeaderAddr *metadata.MD
@@ -186,6 +187,7 @@ func Trailer(md *metadata.MD) CallOption {
 }
 
 // TrailerCallOption is a CallOption for collecting response trailer metadata.
+// The metadata field will be populated *after* the RPC completes.
 // This is an EXPERIMENTAL API.
 type TrailerCallOption struct {
 	TrailerAddr *metadata.MD
@@ -205,7 +207,7 @@ func Peer(p *peer.Peer) CallOption {
 }
 
 // PeerCallOption is a CallOption for collecting the identity of the remote
-// peer.
+// peer. The peer field will be populated *after* the RPC completes.
 // This is an EXPERIMENTAL API.
 type PeerCallOption struct {
 	PeerAddr *peer.Peer

--- a/stream.go
+++ b/stream.go
@@ -99,6 +99,10 @@ type ClientStream interface {
 // NewStream creates a new Stream for the client side. This is typically
 // called by generated code.
 func (cc *ClientConn) NewStream(ctx context.Context, desc *StreamDesc, method string, opts ...CallOption) (ClientStream, error) {
+	// allow interceptor to see all applicable call options, which means those
+	// configured as defaults from dial option as well as per-call options
+	opts = append(cc.dopts.callOptions, opts...)
+
 	if cc.dopts.streamInt != nil {
 		return cc.dopts.streamInt(ctx, desc, cc, method, newClientStream, opts...)
 	}
@@ -137,7 +141,6 @@ func newClientStream(ctx context.Context, desc *StreamDesc, cc *ClientConn, meth
 		}
 	}()
 
-	opts = append(cc.dopts.callOptions, opts...)
 	for _, o := range opts {
 		if err := o.before(c); err != nil {
 			return nil, toRPCErr(err)

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -627,14 +627,11 @@ func (d *nopDecompressor) Type() string {
 	return "nop"
 }
 
-func (te *test) clientConn() *grpc.ClientConn {
+func (te *test) clientConn(opts ...grpc.DialOption) *grpc.ClientConn {
 	if te.cc != nil {
 		return te.cc
 	}
-	opts := []grpc.DialOption{
-		grpc.WithDialer(te.e.dialer),
-		grpc.WithUserAgent(te.userAgent),
-	}
+	opts = append(opts, grpc.WithDialer(te.e.dialer), grpc.WithUserAgent(te.userAgent))
 
 	if te.sc != nil {
 		opts = append(opts, grpc.WithServiceConfig(te.sc))
@@ -5884,6 +5881,115 @@ func TestMethodFromServerStream(t *testing.T) {
 	_ = te.clientConn().Invoke(context.Background(), testMethod, nil, nil)
 	if !ok || method != testMethod {
 		t.Fatalf("Invoke with method %q, got %q, %v, want %q, true", testMethod, method, ok, testMethod)
+	}
+}
+
+func TestInterceptorCanAccessCallOptions(t *testing.T) {
+	defer leakcheck.Check(t)
+	e := tcpClearRREnv
+	te := newTest(t, e)
+	te.startServer(&testServer{security: e.security})
+	defer te.tearDown()
+
+	type observedOptions struct {
+		headers     []*metadata.MD
+		trailers    []*metadata.MD
+		peer        []*peer.Peer
+		creds       []credentials.PerRPCCredentials
+		failFast    []bool
+		maxRecvSize []int
+		maxSendSize []int
+		compressor  []string
+		subtype     []string
+		codec       []grpc.Codec
+	}
+	var observedOpts observedOptions
+	populateOpts := func(opts []grpc.CallOption) {
+		for _, o := range opts {
+			switch o := o.(type) {
+			case grpc.HeaderCallOption:
+				observedOpts.headers = append(observedOpts.headers, o.HeaderAddr)
+			case grpc.TrailerCallOption:
+				observedOpts.trailers = append(observedOpts.trailers, o.TrailerAddr)
+			case grpc.PeerCallOption:
+				observedOpts.peer = append(observedOpts.peer, o.PeerAddr)
+			case grpc.PerRPCCredsCallOption:
+				observedOpts.creds = append(observedOpts.creds, o.Creds)
+			case grpc.FailFastCallOption:
+				observedOpts.failFast = append(observedOpts.failFast, o.FailFast)
+			case grpc.MaxRecvMsgSizeCallOption:
+				observedOpts.maxRecvSize = append(observedOpts.maxRecvSize, o.MaxRecvMsgSize)
+			case grpc.MaxSendMsgSizeCallOption:
+				observedOpts.maxSendSize = append(observedOpts.maxSendSize, o.MaxSendMsgSize)
+			case grpc.CompressorCallOption:
+				observedOpts.compressor = append(observedOpts.compressor, o.CompressorType)
+			case grpc.ContentSubtypeCallOption:
+				observedOpts.subtype = append(observedOpts.subtype, o.ContentSubtype)
+			case grpc.CustomCodecCallOption:
+				observedOpts.codec = append(observedOpts.codec, o.Codec)
+			}
+		}
+	}
+
+	te.unaryClientInt = func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+		populateOpts(opts)
+		return nil
+	}
+	te.streamClientInt = func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+		populateOpts(opts)
+		return nil, nil
+	}
+
+	defaults := []grpc.CallOption{
+		grpc.FailFast(false),
+		grpc.MaxCallRecvMsgSize(1010),
+	}
+	tc := testpb.NewTestServiceClient(te.clientConn(grpc.WithDefaultCallOptions(defaults...)))
+
+	var headers metadata.MD
+	var trailers metadata.MD
+	var pr peer.Peer
+	tc.UnaryCall(context.Background(), &testpb.SimpleRequest{},
+		grpc.MaxCallRecvMsgSize(100),
+		grpc.MaxCallSendMsgSize(200),
+		grpc.PerRPCCredentials(testPerRPCCredentials{}),
+		grpc.Header(&headers),
+		grpc.Trailer(&trailers),
+		grpc.Peer(&pr))
+	expected := observedOptions{
+		failFast:    []bool{false},
+		maxRecvSize: []int{1010, 100},
+		maxSendSize: []int{200},
+		creds:       []credentials.PerRPCCredentials{testPerRPCCredentials{}},
+		headers:     []*metadata.MD{&headers},
+		trailers:    []*metadata.MD{&trailers},
+		peer:        []*peer.Peer{&pr},
+	}
+
+	if !reflect.DeepEqual(expected, observedOpts) {
+		t.Errorf("unary call did not observe expected options: expected %#v, got %#v", expected, observedOpts)
+	}
+
+	observedOpts = observedOptions{} // reset
+
+	var codec errCodec
+	tc.StreamingInputCall(context.Background(),
+		grpc.FailFast(true),
+		grpc.MaxCallSendMsgSize(2020),
+		grpc.UseCompressor("comp-type"),
+		grpc.CallContentSubtype("json"),
+		grpc.CallCustomCodec(&codec))
+	expected = observedOptions{
+		failFast:    []bool{false, true},
+		maxRecvSize: []int{1010},
+		maxSendSize: []int{2020},
+		compressor:  []string{"comp-type"},
+		subtype:     []string{"json"},
+		codec:       []grpc.Codec{&codec},
+	}
+
+	if !reflect.DeepEqual(expected, observedOpts) {
+		t.Errorf("streaming call did not observe expected options: expected %#v, got %#v", expected, observedOpts)
 	}
 }
 


### PR DESCRIPTION
This fixes #1495.

If I understood correctly, @dfawley, this is the approach you were suggesting. Can you take a look and let me know?
