### PR TITLE
allow storing alternate transport.ServerStream implementations in context

### DIFF
--- a/server.go
+++ b/server.go
@@ -1287,8 +1287,8 @@ func SetHeader(ctx context.Context, md metadata.MD) error {
 	if md.Len() == 0 {
 		return nil
 	}
-	stream, ok := transport.StreamFromContext(ctx)
-	if !ok {
+	stream := transport.ServerStreamFromContext(ctx)
+	if stream == nil {
 		return status.Errorf(codes.Internal, "grpc: failed to fetch the stream from the context %v", ctx)
 	}
 	return stream.SetHeader(md)
@@ -1297,15 +1297,11 @@ func SetHeader(ctx context.Context, md metadata.MD) error {
 // SendHeader sends header metadata. It may be called at most once.
 // The provided md and headers set by SetHeader() will be sent.
 func SendHeader(ctx context.Context, md metadata.MD) error {
-	stream, ok := transport.StreamFromContext(ctx)
-	if !ok {
+	stream := transport.ServerStreamFromContext(ctx)
+	if stream == nil {
 		return status.Errorf(codes.Internal, "grpc: failed to fetch the stream from the context %v", ctx)
 	}
-	t := stream.ServerTransport()
-	if t == nil {
-		grpclog.Fatalf("grpc: SendHeader: %v has no ServerTransport to send header metadata.", stream)
-	}
-	if err := t.WriteHeader(stream, md); err != nil {
+	if err := stream.SendHeader(md); err != nil {
 		return toRPCErr(err)
 	}
 	return nil
@@ -1317,8 +1313,8 @@ func SetTrailer(ctx context.Context, md metadata.MD) error {
 	if md.Len() == 0 {
 		return nil
 	}
-	stream, ok := transport.StreamFromContext(ctx)
-	if !ok {
+	stream := transport.ServerStreamFromContext(ctx)
+	if stream == nil {
 		return status.Errorf(codes.Internal, "grpc: failed to fetch the stream from the context %v", ctx)
 	}
 	return stream.SetTrailer(md)

--- a/server_test.go
+++ b/server_test.go
@@ -25,7 +25,9 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/net/context"
 	"google.golang.org/grpc/test/leakcheck"
+	"google.golang.org/grpc/transport"
 )
 
 type emptyServiceServer interface{}
@@ -120,5 +122,15 @@ func TestGetServiceInfo(t *testing.T) {
 
 	if !reflect.DeepEqual(info, want) {
 		t.Errorf("GetServiceInfo() = %+v, want %+v", info, want)
+	}
+}
+
+func TestStreamContext(t *testing.T) {
+	expectedStream := &transport.Stream{}
+	ctx := NewContextWithServerTransportStream(context.Background(), expectedStream)
+	s := serverTransportStreamFromContext(ctx)
+	stream, ok := s.(*transport.Stream)
+	if !ok || expectedStream != stream {
+		t.Fatalf("GetStreamFromContext(%v) = %v, %t, want: %v, true", ctx, stream, ok, expectedStream)
 	}
 }

--- a/stream.go
+++ b/stream.go
@@ -552,6 +552,7 @@ type ServerStream interface {
 
 // serverStream implements a server side Stream.
 type serverStream struct {
+	ctx   context.Context
 	t     transport.ServerTransport
 	s     *transport.Stream
 	p     *parser
@@ -572,7 +573,7 @@ type serverStream struct {
 }
 
 func (ss *serverStream) Context() context.Context {
-	return ss.s.Context()
+	return ss.ctx
 }
 
 func (ss *serverStream) SetHeader(md metadata.MD) error {
@@ -675,7 +676,7 @@ func (ss *serverStream) RecvMsg(m interface{}) (err error) {
 // MethodFromServerStream returns the method string for the input stream.
 // The returned string is in the format of "/service/method".
 func MethodFromServerStream(stream ServerStream) (string, bool) {
-	s := transport.ServerStreamFromContext(stream.Context())
+	s := serverTransportStreamFromContext(stream.Context())
 	if s == nil {
 		return "", false
 	}

--- a/stream.go
+++ b/stream.go
@@ -675,9 +675,9 @@ func (ss *serverStream) RecvMsg(m interface{}) (err error) {
 // MethodFromServerStream returns the method string for the input stream.
 // The returned string is in the format of "/service/method".
 func MethodFromServerStream(stream ServerStream) (string, bool) {
-	s, ok := transport.StreamFromContext(stream.Context())
-	if !ok {
-		return "", ok
+	s := transport.ServerStreamFromContext(stream.Context())
+	if s == nil {
+		return "", false
 	}
-	return s.Method(), ok
+	return s.Method(), true
 }

--- a/transport/handler_server.go
+++ b/transport/handler_server.go
@@ -355,7 +355,7 @@ func (ht *serverHandlerTransport) HandleStreams(startStream func(*Stream), trace
 	}
 	ctx = metadata.NewIncomingContext(ctx, ht.headerMD)
 	ctx = peer.NewContext(ctx, pr)
-	s.ctx = newContextWithStream(ctx, s)
+	s.ctx = NewContextWithServerStream(ctx, s)
 	if ht.stats != nil {
 		s.ctx = ht.stats.TagRPC(s.ctx, &stats.RPCTagInfo{FullMethodName: s.method})
 		inHeader := &stats.InHeader{

--- a/transport/handler_server.go
+++ b/transport/handler_server.go
@@ -354,8 +354,7 @@ func (ht *serverHandlerTransport) HandleStreams(startStream func(*Stream), trace
 		pr.AuthInfo = credentials.TLSInfo{State: *req.TLS}
 	}
 	ctx = metadata.NewIncomingContext(ctx, ht.headerMD)
-	ctx = peer.NewContext(ctx, pr)
-	s.ctx = NewContextWithServerStream(ctx, s)
+	s.ctx = peer.NewContext(ctx, pr)
 	if ht.stats != nil {
 		s.ctx = ht.stats.TagRPC(s.ctx, &stats.RPCTagInfo{FullMethodName: s.method})
 		inHeader := &stats.InHeader{

--- a/transport/http2_server.go
+++ b/transport/http2_server.go
@@ -307,10 +307,6 @@ func (t *http2Server) operateHeaders(frame *http2.MetaHeadersFrame, handle func(
 		pr.AuthInfo = t.authInfo
 	}
 	s.ctx = peer.NewContext(s.ctx, pr)
-	// Cache the current stream to the context so that the server application
-	// can find out. Required when the server wants to send some metadata
-	// back to the client (unary call only).
-	s.ctx = NewContextWithServerStream(s.ctx, s)
 	// Attach the received metadata to the context.
 	if len(state.mdata) > 0 {
 		s.ctx = metadata.NewIncomingContext(s.ctx, state.mdata)

--- a/transport/http2_server.go
+++ b/transport/http2_server.go
@@ -310,7 +310,7 @@ func (t *http2Server) operateHeaders(frame *http2.MetaHeadersFrame, handle func(
 	// Cache the current stream to the context so that the server application
 	// can find out. Required when the server wants to send some metadata
 	// back to the client (unary call only).
-	s.ctx = newContextWithStream(s.ctx, s)
+	s.ctx = NewContextWithServerStream(s.ctx, s)
 	// Attach the received metadata to the context.
 	if len(state.mdata) > 0 {
 		s.ctx = metadata.NewIncomingContext(s.ctx, state.mdata)

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -453,47 +453,6 @@ func (s *Stream) GoString() string {
 	return fmt.Sprintf("<stream: %p, %v>", s, s.method)
 }
 
-// The key to save transport.Stream in the context.
-type streamKey struct{}
-
-// NewContextWithServerStream creates a new context from ctx and attaches
-// stream to it.
-func NewContextWithServerStream(ctx context.Context, stream ServerStream) context.Context {
-	return context.WithValue(ctx, streamKey{}, stream)
-}
-
-// StreamFromContext returns the stream saved in ctx.
-//
-// Deprecated: use ServerStreamFromContext
-func StreamFromContext(ctx context.Context) (s *Stream, ok bool) {
-	// If there is a ServerStream in context, but it's not a *Stream,
-	// this still returns nil, false.
-	s, ok = ctx.Value(streamKey{}).(*Stream)
-	return
-}
-
-// ServerStream is a minimal interface that a transport stream must
-// implement. This can be used to mock an actual transport stream for
-// tests of handler code that use, for example, grpc.SetHeader (which
-// requires some stream to be in context).
-//
-// See also ContextWithServerStream.
-type ServerStream interface {
-	Context() context.Context
-	Method() string
-	SetHeader(md metadata.MD) error
-	SendHeader(md metadata.MD) error
-	SetTrailer(md metadata.MD) error
-}
-
-// ServerStreamFromContext returns the server stream saved in ctx. Returns
-// nil if the given context has no stream associated with it (which implies
-// it is not an RPC invocation context).
-func ServerStreamFromContext(ctx context.Context) ServerStream {
-	s, _ := ctx.Value(streamKey{}).(ServerStream)
-	return s
-}
-
 // state of transport
 type transportState int
 

--- a/transport/transport_test.go
+++ b/transport/transport_test.go
@@ -1554,10 +1554,11 @@ func TestInvalidHeaderField(t *testing.T) {
 
 func TestStreamContext(t *testing.T) {
 	expectedStream := &Stream{}
-	ctx := newContextWithStream(context.Background(), expectedStream)
-	s, ok := StreamFromContext(ctx)
-	if !ok || expectedStream != s {
-		t.Fatalf("GetStreamFromContext(%v) = %v, %t, want: %v, true", ctx, s, ok, expectedStream)
+	ctx := NewContextWithServerStream(context.Background(), expectedStream)
+	s := ServerStreamFromContext(ctx)
+	stream, ok := s.(*Stream)
+	if !ok || expectedStream != stream {
+		t.Fatalf("GetStreamFromContext(%v) = %v, %t, want: %v, true", ctx, stream, ok, expectedStream)
 	}
 }
 

--- a/transport/transport_test.go
+++ b/transport/transport_test.go
@@ -1552,16 +1552,6 @@ func TestInvalidHeaderField(t *testing.T) {
 	server.stop()
 }
 
-func TestStreamContext(t *testing.T) {
-	expectedStream := &Stream{}
-	ctx := NewContextWithServerStream(context.Background(), expectedStream)
-	s := ServerStreamFromContext(ctx)
-	stream, ok := s.(*Stream)
-	if !ok || expectedStream != stream {
-		t.Fatalf("GetStreamFromContext(%v) = %v, %t, want: %v, true", ctx, stream, ok, expectedStream)
-	}
-}
-
 func TestIsReservedHeader(t *testing.T) {
 	tests := []struct {
 		h    string


### PR DESCRIPTION
Fixes #1802.

This allows handlers to be run from tests without requiring the entirety of the gRPC server machinery: a test can store a mock `transport.ServerStream` into the context and then call the handler.

It also enables alternate transport implementations.