### PR TITLE
transport: fix race that could lead to the server closing a connection due to too many pings

### DIFF
--- a/transport/http2_server.go
+++ b/transport/http2_server.go
@@ -896,9 +896,6 @@ func (t *http2Server) Write(s *Stream, hdr []byte, data []byte, opts *Options) e
 			// ltq is only a soft limit.
 			streamQuota -= size
 			p := r[:size]
-			// Reset ping strikes when sending data since this might cause
-			// the peer to send ping.
-			atomic.StoreUint32(&t.resetPingStrikes, 1)
 			success := func() {
 				ltq := ltq
 				t.controlBuf.put(&dataFrame{streamID: s.id, endStream: false, d: p, f: func() {
@@ -1013,6 +1010,9 @@ var goAwayPing = &ping{data: [8]byte{1, 6, 1, 8, 0, 3, 3, 9}}
 func (t *http2Server) itemHandler(i item) error {
 	switch i := i.(type) {
 	case *dataFrame:
+		// Reset ping strikes when sending data since this might cause
+		// the peer to send ping.
+		atomic.StoreUint32(&t.resetPingStrikes, 1)
 		if err := t.framer.fr.WriteData(i.streamID, i.endStream, i.d); err != nil {
 			return err
 		}


### PR DESCRIPTION
fixes #1882 

Eliminate race which causes a ping to be scheduled between pingStrike counter being reset and data being scheduled.
