### PR TITLE
credentials/alts: fix infinite recursion bug [in custom error type]

### DIFF
--- a/credentials/alts/utils.go
+++ b/credentials/alts/utils.go
@@ -44,7 +44,7 @@ const (
 type platformError string
 
 func (k platformError) Error() string {
-	return fmt.Sprintf("%v is not supported", k)
+	return fmt.Sprintf("%s is not supported", string(k))
 }
 
 var (


### PR DESCRIPTION
I was trying to run tests locally, to see if another change I was making was good. And I encountered a stack overflow error. I am guessing that the tests for the `google.golang.org/grpc/credentials/alts` package are skipped during CI.

In any event, there was an `Error()` method that in turn called `fmt.Sprintf` and passed the receiver. This in turn resulted in the `fmt` package invoking the `Error()` method which then invoked `fmt.Sprintf`, and so on, ad infinitum.