### PR TITLE
feature: Let ConnOpt maxStreams configurable

### DIFF
--- a/clientconn.go
+++ b/clientconn.go
@@ -165,6 +165,13 @@ func WithMaxMsgSize(s int) DialOption {
 	return WithDefaultCallOptions(MaxCallRecvMsgSize(s))
 }
 
+// WithMaxStreamsClientSize returns a DialOption which sets the maximum stream client size.
+func WithMaxStreamsClientSize(s int) DialOption {
+	return func(o *dialOptions) {
+		o.copts.MaxStreamsClientSize = s
+	}
+}
+
 // WithDefaultCallOptions returns a DialOption which sets the default CallOptions for calls over the connection.
 func WithDefaultCallOptions(cos ...CallOption) DialOption {
 	return func(o *dialOptions) {

--- a/transport/http2_client.go
+++ b/transport/http2_client.go
@@ -196,6 +196,10 @@ func newHTTP2Client(connectCtx, ctx context.Context, addr TargetInfo, opts Conne
 	if opts.ReadBufferSize > 0 {
 		readBufSize = opts.ReadBufferSize
 	}
+	maxStreamsClientSize := defaultMaxStreamsClient
+	if opts.MaxStreamsClientSize > 0 {
+		maxStreamsClientSize = opts.MaxStreamsClientSize
+	}
 	t := &http2Client{
 		ctx:        ctx,
 		cancel:     cancel,
@@ -221,8 +225,8 @@ func newHTTP2Client(connectCtx, ctx context.Context, addr TargetInfo, opts Conne
 		activeStreams:     make(map[uint32]*Stream),
 		isSecure:          isSecure,
 		creds:             opts.PerRPCCredentials,
-		maxStreams:        defaultMaxStreamsClient,
-		streamsQuota:      newQuotaPool(defaultMaxStreamsClient),
+		maxStreams:        maxStreamsClientSize,
+		streamsQuota:      newQuotaPool(maxStreamsClientSize),
 		streamSendQuota:   defaultWindowSize,
 		kp:                kp,
 		statsHandler:      opts.StatsHandler,

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -516,6 +516,8 @@ type ConnectOptions struct {
 	WriteBufferSize int
 	// ReadBufferSize sets the size of read buffer, which in turn determines how much data can be read at most for one read syscall.
 	ReadBufferSize int
+	// MaxStreamsClientSize sets the max number of concurrent streams, which in turn determines how many concurrent streams can be hold by one grpc client.
+	MaxStreamsClientSize int
 }
 
 // TargetInfo contains the information of the target such as network address and metadata.


### PR DESCRIPTION
Signed-off-by: Michael Wan <zirenwan@gmail.com>

Sometimes we need use grpc client stream to stay connection with the grpc server, but the MaxStreams is a const int 100.
in many case, like docker container watcher that needs to watch all containers's status, the numbers of concurrent streams must larger then 100, so we should make this param configurable.  