### PR TITLE
credentials/alts: Update ALTS "New" APIs

### DIFF
--- a/credentials/alts/alts.go
+++ b/credentials/alts/alts.go
@@ -91,6 +91,19 @@ type AuthInfo interface {
 	PeerRPCVersions() *altspb.RpcProtocolVersions
 }
 
+// ClientOptions contains the client-side options of an ALTS channel. These
+// options will be passed to the underlying ALTS handshaker.
+type ClientOptions struct {
+	// TargetServiceAccounts contains a list of expected target service
+	// accounts.
+	TargetServiceAccounts []string
+}
+
+// DefaultClientOptions creates a default (empty) ClientOptions.
+func DefaultClientOptions() *ClientOptions {
+	return &ClientOptions{}
+}
+
 // altsTC is the credentials required for authenticating a connection using ALTS.
 // It implements credentials.TransportCredentials interface.
 type altsTC struct {
@@ -101,8 +114,8 @@ type altsTC struct {
 }
 
 // NewClient constructs a client-side ALTS TransportCredentials object.
-func NewClient(targetServiceAccounts []string) credentials.TransportCredentials {
-	return newALTS(core.ClientSide, targetServiceAccounts)
+func NewClient(opts *ClientOptions) credentials.TransportCredentials {
+	return newALTS(core.ClientSide, opts.TargetServiceAccounts)
 }
 
 // NewServer constructs a server-side ALTS TransportCredentials object.

--- a/credentials/alts/alts.go
+++ b/credentials/alts/alts.go
@@ -99,11 +99,6 @@ type ClientOptions struct {
 	TargetServiceAccounts []string
 }
 
-// DefaultClientOptions creates a default (empty) ClientOptions.
-func DefaultClientOptions() *ClientOptions {
-	return &ClientOptions{}
-}
-
 // altsTC is the credentials required for authenticating a connection using ALTS.
 // It implements credentials.TransportCredentials interface.
 type altsTC struct {
@@ -113,13 +108,13 @@ type altsTC struct {
 	accounts []string
 }
 
-// NewClient constructs a client-side ALTS TransportCredentials object.
-func NewClient(opts *ClientOptions) credentials.TransportCredentials {
+// NewClientCreds constructs a client-side ALTS TransportCredentials object.
+func NewClientCreds(opts *ClientOptions) credentials.TransportCredentials {
 	return newALTS(core.ClientSide, opts.TargetServiceAccounts)
 }
 
-// NewServer constructs a server-side ALTS TransportCredentials object.
-func NewServer() credentials.TransportCredentials {
+// NewServerCreds constructs a server-side ALTS TransportCredentials object.
+func NewServerCreds() credentials.TransportCredentials {
 	return newALTS(core.ServerSide, nil)
 }
 

--- a/credentials/alts/alts_test.go
+++ b/credentials/alts/alts_test.go
@@ -27,8 +27,8 @@ import (
 
 func TestInfoServerName(t *testing.T) {
 	// This is not testing any handshaker functionality, so it's fine to only
-	// use NewServer and not NewClient.
-	alts := NewServer()
+	// use NewServerCreds and not NewClientCreds.
+	alts := NewServerCreds()
 	if got, want := alts.Info().ServerName, ""; got != want {
 		t.Fatalf("%v.Info().ServerName = %v, want %v", alts, got, want)
 	}
@@ -37,8 +37,8 @@ func TestInfoServerName(t *testing.T) {
 func TestOverrideServerName(t *testing.T) {
 	wantServerName := "server.name"
 	// This is not testing any handshaker functionality, so it's fine to only
-	// use NewServer and not NewClient.
-	c := NewServer()
+	// use NewServerCreds and not NewClientCreds.
+	c := NewServerCreds()
 	c.OverrideServerName(wantServerName)
 	if got, want := c.Info().ServerName, wantServerName; got != want {
 		t.Fatalf("c.Info().ServerName = %v, want %v", got, want)
@@ -48,8 +48,8 @@ func TestOverrideServerName(t *testing.T) {
 func TestClone(t *testing.T) {
 	wantServerName := "server.name"
 	// This is not testing any handshaker functionality, so it's fine to only
-	// use NewServer and not NewClient.
-	c := NewServer()
+	// use NewServerCreds and not NewClientCreds.
+	c := NewServerCreds()
 	c.OverrideServerName(wantServerName)
 	cc := c.Clone()
 	if got, want := cc.Info().ServerName, wantServerName; got != want {
@@ -66,8 +66,8 @@ func TestClone(t *testing.T) {
 
 func TestInfo(t *testing.T) {
 	// This is not testing any handshaker functionality, so it's fine to only
-	// use NewServer and not NewClient.
-	c := NewServer()
+	// use NewServerCreds and not NewClientCreds.
+	c := NewServerCreds()
 	info := c.Info()
 	if got, want := info.ProtocolVersion, ""; got != want {
 		t.Errorf("info.ProtocolVersion=%v, want %v", got, want)

--- a/interop/alts/client/client.go
+++ b/interop/alts/client/client.go
@@ -41,7 +41,7 @@ var (
 func main() {
 	flag.Parse()
 
-	altsTC := alts.NewClient(alts.DefaultClientOptions())
+	altsTC := alts.NewClientCreds(&alts.ClientOptions{})
 	// Block until the server is ready.
 	conn, err := grpc.Dial(*serverAddr, grpc.WithTransportCredentials(altsTC), grpc.WithBlock())
 	if err != nil {

--- a/interop/alts/client/client.go
+++ b/interop/alts/client/client.go
@@ -41,7 +41,7 @@ var (
 func main() {
 	flag.Parse()
 
-	altsTC := alts.NewClient(nil)
+	altsTC := alts.NewClient(alts.DefaultClientOptions())
 	// Block until the server is ready.
 	conn, err := grpc.Dial(*serverAddr, grpc.WithTransportCredentials(altsTC), grpc.WithBlock())
 	if err != nil {

--- a/interop/alts/server/server.go
+++ b/interop/alts/server/server.go
@@ -41,7 +41,7 @@ func main() {
 	if err != nil {
 		grpclog.Fatalf("gRPC Server: failed to start the server at %v: %v", *serverAddr, err)
 	}
-	altsTC := alts.NewServer()
+	altsTC := alts.NewServerCreds()
 	grpcServer := grpc.NewServer(grpc.Creds(altsTC))
 	testpb.RegisterTestServiceServer(grpcServer, interop.NewTestServer())
 	grpcServer.Serve(lis)

--- a/interop/client/client.go
+++ b/interop/client/client.go
@@ -110,7 +110,7 @@ func main() {
 			opts = append(opts, grpc.WithPerRPCCredentials(oauth.NewOauthAccess(interop.GetToken(*serviceAccountKeyFile, *oauthScope))))
 		}
 	} else if *useALTS {
-		altsTC := alts.NewClient(nil)
+		altsTC := alts.NewClientCreds(&alts.ClientOptions{})
 		opts = append(opts, grpc.WithTransportCredentials(altsTC))
 	} else {
 		opts = append(opts, grpc.WithInsecure())

--- a/interop/server/server.go
+++ b/interop/server/server.go
@@ -64,7 +64,7 @@ func main() {
 		}
 		opts = append(opts, grpc.Creds(creds))
 	} else if *useALTS {
-		altsTC := alts.NewServer()
+		altsTC := alts.NewServerCreds()
 		opts = append(opts, grpc.Creds(altsTC))
 	}
 	server := grpc.NewServer(opts...)


### PR DESCRIPTION
Change the `alts.NewClient` API to take a struct containing all client-side options instead of passing them using parameters. This allows adding more options in the future without breaking the existing API or having to create a new one.

This API also changes `alts.NewClient` and `alts.NewServer` to `alts.NewClientCreds` and `alts.NewServerCreds`, respectively.

This API is only used by the `interop/alts/client/client.go`.