### PR TITLE
metadata: Fix bug where AppendToOutgoingContext could modify another context's metadata

### DIFF
--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -131,7 +131,11 @@ func AppendToOutgoingContext(ctx context.Context, kv ...string) context.Context 
 		panic(fmt.Sprintf("metadata: AppendToOutgoingContext got an odd number of input pairs for metadata: %d", len(kv)))
 	}
 	md, _ := ctx.Value(mdOutgoingKey{}).(rawMD)
-	return context.WithValue(ctx, mdOutgoingKey{}, rawMD{md: md.md, added: append(md.added, kv)})
+	added := make([][]string, len(md.added)+1)
+	copy(added, md.added)
+	added[len(added)-1] = make([]string, len(kv))
+	copy(added[len(added)-1], kv)
+	return context.WithValue(ctx, mdOutgoingKey{}, rawMD{md: md.md, added: added})
 }
 
 // FromIncomingContext returns the incoming metadata in ctx if it exists.  The
@@ -159,7 +163,7 @@ func FromOutgoingContextRaw(ctx context.Context) (MD, [][]string, bool) {
 
 // FromOutgoingContext returns the outgoing metadata in ctx if it exists.  The
 // returned MD should not be modified. Writing to it may cause races.
-// Modification should be made to the copies of the returned MD.
+// Modification should be made to copies of the returned MD.
 func FromOutgoingContext(ctx context.Context) (MD, bool) {
 	raw, ok := ctx.Value(mdOutgoingKey{}).(rawMD)
 	if !ok {

--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -134,30 +134,25 @@ func TestAppendToOutgoingContext_FromKVSlice(t *testing.T) {
 
 // Old/slow approach to adding metadata to context
 func Benchmark_AddingMetadata_ContextManipulationApproach(b *testing.B) {
-	for _, num := range []int{1, 10, 100} {
-		b.Run(strconv.Itoa(num), func(b *testing.B) {
-			for n := 0; n < b.N; n++ {
-				ctx := context.Background()
-				for i := 0; i < num; i++ {
-					md, _ := FromOutgoingContext(ctx)
-					NewOutgoingContext(ctx, Join(Pairs("k1", "v1", "k2", "v2"), md))
-				}
-			}
-		})
+	// TODO: Add in N=1-100 tests once Go1.6 support is removed.
+	const num = 10
+	for n := 0; n < b.N; n++ {
+		ctx := context.Background()
+		for i := 0; i < num; i++ {
+			md, _ := FromOutgoingContext(ctx)
+			NewOutgoingContext(ctx, Join(Pairs("k1", "v1", "k2", "v2"), md))
+		}
 	}
 }
 
 // Newer/faster approach to adding metadata to context
 func BenchmarkAppendToOutgoingContext(b *testing.B) {
-	for _, num := range []int{1, 10, 100} {
-		b.Run(strconv.Itoa(num), func(b *testing.B) {
-			for n := 0; n < b.N; n++ {
-				ctx := context.Background()
-				for i := 0; i < num; i++ {
-					ctx = AppendToOutgoingContext(ctx, "k1", "v1", "k2", "v2")
-				}
-			}
-		})
+	const num = 10
+	for n := 0; n < b.N; n++ {
+		ctx := context.Background()
+		for i := 0; i < num; i++ {
+			ctx = AppendToOutgoingContext(ctx, "k1", "v1", "k2", "v2")
+		}
 	}
 }
 

--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -20,6 +20,7 @@ package metadata
 
 import (
 	"reflect"
+	"strconv"
 	"testing"
 
 	"golang.org/x/net/context"
@@ -98,19 +99,65 @@ func TestAppendToOutgoingContext(t *testing.T) {
 	}
 }
 
+func TestAppendToOutgoingContext_Repeated(t *testing.T) {
+	ctx := context.Background()
+
+	for i := 0; i < 100; i = i + 2 {
+		ctx1 := AppendToOutgoingContext(ctx, "k", strconv.Itoa(i))
+		ctx2 := AppendToOutgoingContext(ctx, "k", strconv.Itoa(i+1))
+
+		md1, _ := FromOutgoingContext(ctx1)
+		md2, _ := FromOutgoingContext(ctx2)
+
+		if reflect.DeepEqual(md1, md2) {
+			t.Fatalf("md1, md2 = %v, %v; should not be equal", md1, md2)
+		}
+
+		ctx = ctx1
+	}
+}
+
+func TestAppendToOutgoingContext_FromKVSlice(t *testing.T) {
+	const k, v = "a", "b"
+	kv := []string{k, v}
+	ctx := AppendToOutgoingContext(context.Background(), kv...)
+	md, _ := FromOutgoingContext(ctx)
+	if md[k][0] != v {
+		t.Fatalf("md[%q] = %q; want %q", k, md[k], v)
+	}
+	kv[1] = "xxx"
+	md, _ = FromOutgoingContext(ctx)
+	if md[k][0] != v {
+		t.Fatalf("md[%q] = %q; want %q", k, md[k], v)
+	}
+}
+
 // Old/slow approach to adding metadata to context
 func Benchmark_AddingMetadata_ContextManipulationApproach(b *testing.B) {
-	for n := 0; n < b.N; n++ {
-		ctx := context.Background()
-		md, _ := FromOutgoingContext(ctx)
-		NewOutgoingContext(ctx, Join(Pairs("k1", "v1", "k2", "v2"), md))
+	for _, num := range []int{1, 10, 100} {
+		b.Run(strconv.Itoa(num), func(b *testing.B) {
+			for n := 0; n < b.N; n++ {
+				ctx := context.Background()
+				for i := 0; i < num; i++ {
+					md, _ := FromOutgoingContext(ctx)
+					NewOutgoingContext(ctx, Join(Pairs("k1", "v1", "k2", "v2"), md))
+				}
+			}
+		})
 	}
 }
 
 // Newer/faster approach to adding metadata to context
 func BenchmarkAppendToOutgoingContext(b *testing.B) {
-	for n := 0; n < b.N; n++ {
-		AppendToOutgoingContext(context.Background(), "k1", "v1", "k2", "v2")
+	for _, num := range []int{1, 10, 100} {
+		b.Run(strconv.Itoa(num), func(b *testing.B) {
+			for n := 0; n < b.N; n++ {
+				ctx := context.Background()
+				for i := 0; i < num; i++ {
+					ctx = AppendToOutgoingContext(ctx, "k1", "v1", "k2", "v2")
+				}
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Fixes #1925 

For 1-10 append operations, performance is slightly worse using this method, but it is correct and ~3x faster than the old method of copying the whole map.

Before:
```
BenchmarkAppendToOutgoingContext/1-12                          	10000000	       197 ns/op
BenchmarkAppendToOutgoingContext/10-12                         	 1000000	      2033 ns/op
BenchmarkAppendToOutgoingContext/100-12                        	  100000	     15497 ns/op
```

After:
```
BenchmarkAppendToOutgoingContext/1-12                          	10000000	       193 ns/op
BenchmarkAppendToOutgoingContext/10-12                         	  500000	      2513 ns/op
BenchmarkAppendToOutgoingContext/100-12                        	   30000	     51658 ns/op
```

The old method for reference:
```
Benchmark_AddingMetadata_ContextManipulationApproach/1-12  	 2000000	       805 ns/op
Benchmark_AddingMetadata_ContextManipulationApproach/10-12 	  200000	      7925 ns/op
Benchmark_AddingMetadata_ContextManipulationApproach/100-12    20000	     80581 ns/op
```

(Note: I'm also copying `kv...`, because it could be passed as `mySlice...`, and I also added a test to demonstrate/catch that.)