### PR TITLE
Fix broken link in rpc-errors.md

### DIFF
--- a/Documentation/rpc-errors.md
+++ b/Documentation/rpc-errors.md
@@ -64,4 +64,5 @@ exit status 1
 [with-details]: https://godoc.org/google.golang.org/grpc/status#Status.WithDetails
 [details]:      https://godoc.org/google.golang.org/grpc/status#Status.Details
 [status-err]:   https://godoc.org/google.golang.org/grpc/status#Status.Err
+[status-error]: https://godoc.org/google.golang.org/grpc/status#Error
 [example]:      https://github.com/grpc/grpc-go/blob/master/examples/rpc_errors


### PR DESCRIPTION
There's a broken link in the `rpc-errors.md` documentation. This commit repairs it.