### PR TITLE
metadata: Add Get, Set, and Append methods to metadata.MD

### DIFF
--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -95,6 +95,30 @@ func (md MD) Copy() MD {
 	return Join(md)
 }
 
+// Get obtains the values for a given key.
+func (md MD) Get(k string) []string {
+	k = strings.ToLower(k)
+	return md[k]
+}
+
+// Set sets the value of a given key with a slice of values.
+func (md MD) Set(k string, vals ...string) {
+	if len(vals) == 0 {
+		return
+	}
+	k = strings.ToLower(k)
+	md[k] = vals
+}
+
+// Append adds the values to key k, not overwriting what was already stored at that key.
+func (md MD) Append(k string, vals ...string) {
+	if len(vals) == 0 {
+		return
+	}
+	k = strings.ToLower(k)
+	md[k] = append(md[k], vals...)
+}
+
 // Join joins any number of mds into a single MD.
 // The order of values for each key is determined by the order in which
 // the mds containing those values are presented to Join.


### PR DESCRIPTION
Addresses issue #1926 by adding a Get and Set method which performs the lowercase transformation.

I guess one question I had was on the semantics of the Set method. I made is to that Set replaces the old key-value pair. I suppose it could also have meant _append values to key_. Was this the way it should have been done?