### PR TITLE
resolver: keep full unparsed target string if scheme in parsed target is not registered

### DIFF
--- a/clientconn.go
+++ b/clientconn.go
@@ -488,9 +488,15 @@ func DialContext(ctx context.Context, target string, opts ...DialOption) (conn *
 		cc.dopts.bs = DefaultBackoffConfig
 	}
 	if cc.dopts.resolverBuilder == nil {
+		// Only try to parse target when resolver builder is not already set.
 		cc.parsedTarget = parseTarget(cc.target)
+		grpclog.Infof("parsed scheme: %q", cc.parsedTarget.Scheme)
 		cc.dopts.resolverBuilder = resolver.Get(cc.parsedTarget.Scheme)
 		if cc.dopts.resolverBuilder == nil {
+			// If resolver builder is still nil, the parse target's scheme is
+			// not registered. Fallback to default resolver and set Endpoint to
+			// the original unparsed target.
+			grpclog.Infof("scheme %q not registered, fallback to default scheme", cc.parsedTarget.Scheme)
 			cc.parsedTarget = resolver.Target{
 				Scheme:   resolver.GetDefaultScheme(),
 				Endpoint: target,

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -35,8 +35,9 @@ func Register(b Builder) {
 	m[b.Scheme()] = b
 }
 
-// Find returns whether a resolver builder was registered with the given scheme.
-func Find(scheme string) bool {
+// SchemeRegistered returns whether a resolver builder was registered with the
+// given scheme.
+func SchemeRegistered(scheme string) bool {
 	_, ok := m[scheme]
 	return ok
 }

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -35,27 +35,11 @@ func Register(b Builder) {
 	m[b.Scheme()] = b
 }
 
-// SchemeRegistered returns whether a resolver builder was registered with the
-// given scheme.
-func SchemeRegistered(scheme string) bool {
-	_, ok := m[scheme]
-	return ok
-}
-
 // Get returns the resolver builder registered with the given scheme.
-// If no builder is register with the scheme, the default scheme will
-// be used.
-// If the default scheme is not modified, "passthrough" will be the default
-// scheme, and the preinstalled dns resolver will be used.
-// If the default scheme is modified, and a resolver is registered with
-// the scheme, that resolver will be returned.
-// If the default scheme is modified, and no resolver is registered with
-// the scheme, nil will be returned.
+//
+// If no builder is register with the scheme, nil will be returned.
 func Get(scheme string) Builder {
 	if b, ok := m[scheme]; ok {
-		return b
-	}
-	if b, ok := m[defaultScheme]; ok {
 		return b
 	}
 	return nil
@@ -65,6 +49,11 @@ func Get(scheme string) Builder {
 // The default default scheme is "passthrough".
 func SetDefaultScheme(scheme string) {
 	defaultScheme = scheme
+}
+
+// GetDefaultScheme gets the default scheme that will be used.
+func GetDefaultScheme() string {
+	return defaultScheme
 }
 
 // AddressType indicates the address type returned by name resolution.

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -35,6 +35,12 @@ func Register(b Builder) {
 	m[b.Scheme()] = b
 }
 
+// Find returns whether a resolver builder was registered with the given scheme.
+func Find(scheme string) bool {
+	_, ok := m[scheme]
+	return ok
+}
+
 // Get returns the resolver builder registered with the given scheme.
 // If no builder is register with the scheme, the default scheme will
 // be used.

--- a/resolver_conn_wrapper.go
+++ b/resolver_conn_wrapper.go
@@ -70,7 +70,7 @@ func splitTarget(target string) (ret resolver.Target) {
 // If the parsed scheme is not registered, it returns {Endpoint: target}.
 func parseTarget(target string) resolver.Target {
 	ret := splitTarget(target)
-	if !resolver.Find(ret.Scheme) {
+	if !resolver.SchemeRegistered(ret.Scheme) {
 		grpclog.Infof("scheme %q is not registered, falling back to passthrough", ret.Scheme)
 		return resolver.Target{Endpoint: target}
 	}

--- a/resolver_conn_wrapper.go
+++ b/resolver_conn_wrapper.go
@@ -51,8 +51,6 @@ func split2(s, sep string) (string, string, bool) {
 //
 // If target is not a valid scheme://authority/endpoint, it returns {Endpoint:
 // target}.
-//
-// If the parsed scheme is not registered, it returns {Endpoint: target}.
 func parseTarget(target string) (ret resolver.Target) {
 	var ok bool
 	ret.Scheme, ret.Endpoint, ok = split2(target, "://")
@@ -73,8 +71,6 @@ func parseTarget(target string) (ret resolver.Target) {
 // If withResolverBuilder dial option is set, the specified resolver will be
 // used instead.
 func newCCResolverWrapper(cc *ClientConn) (*ccResolverWrapper, error) {
-	grpclog.Infof("dialing to target with scheme: %q", cc.parsedTarget.Scheme)
-
 	rb := cc.dopts.resolverBuilder
 	if rb == nil {
 		return nil, fmt.Errorf("could not get resolver for scheme: %q", cc.parsedTarget.Scheme)

--- a/resolver_conn_wrapper_test.go
+++ b/resolver_conn_wrapper_test.go
@@ -26,18 +26,10 @@ import (
 
 func TestParseTarget(t *testing.T) {
 	for _, test := range []resolver.Target{
-		{"", "", ""},
-		{"a", "", ""},
-		{"", "a", ""},
-		{"", "", "a"},
-		{"a", "b", ""},
-		{"a", "", "b"},
-		{"", "a", "b"},
-		{"a", "b", "c"},
 		{"dns", "", "google.com"},
 		{"dns", "a.server.com", "google.com"},
 		{"dns", "a.server.com", "google.com/?a=b"},
-		{"", "", "/unix/socket/address"},
+		{"passthrough", "", "/unix/socket/address"},
 	} {
 		str := test.Scheme + "://" + test.Authority + "/" + test.Endpoint
 		got := parseTarget(str)
@@ -82,6 +74,41 @@ func TestSplitTargetString(t *testing.T) {
 		got := splitTarget(test.targetStr)
 		if got != test.want {
 			t.Errorf("splitTarget(%q) = %+v, want %+v", test.targetStr, got, test.want)
+		}
+	}
+}
+
+func TestParseTargetUnknownScheme(t *testing.T) {
+	for _, test := range []struct {
+		targetStr string
+		want      resolver.Target
+	}{
+		{"", resolver.Target{"", "", ""}},
+		{":///", resolver.Target{"", "", ":///"}},
+		{"a:///", resolver.Target{"", "", "a:///"}},
+		{"://a/", resolver.Target{"", "", "://a/"}},
+		{":///a", resolver.Target{"", "", ":///a"}},
+		{"a://b/", resolver.Target{"", "", "a://b/"}},
+		{"a:///b", resolver.Target{"", "", "a:///b"}},
+		{"://a/b", resolver.Target{"", "", "://a/b"}},
+		{"a://b/c", resolver.Target{"", "", "a://b/c"}},
+
+		{"/", resolver.Target{"", "", "/"}},
+		{"google.com", resolver.Target{"", "", "google.com"}},
+		{"google.com/?a=b", resolver.Target{"", "", "google.com/?a=b"}},
+		{"/unix/socket/address", resolver.Target{"", "", "/unix/socket/address"}},
+
+		// Special test for "unix:///".
+		{"unix:///unix/socket/address", resolver.Target{"", "", "unix:///unix/socket/address"}},
+
+		// For known scheme.
+		{"dns:///google.com", resolver.Target{"dns", "", "google.com"}},
+		{"dns://a.server.com/google.com", resolver.Target{"dns", "a.server.com", "google.com"}},
+		{"dns://a.server.com/google.com/?a=b", resolver.Target{"dns", "a.server.com", "google.com/?a=b"}},
+	} {
+		got := parseTarget(test.targetStr)
+		if got != test.want {
+			t.Errorf("parseTarget(%q) = %+v, want %+v", test.targetStr, got, test.want)
 		}
 	}
 }

--- a/resolver_conn_wrapper_test.go
+++ b/resolver_conn_wrapper_test.go
@@ -47,7 +47,7 @@ func TestParseTarget(t *testing.T) {
 	}
 }
 
-func TestParseTargetString(t *testing.T) {
+func TestSplitTargetString(t *testing.T) {
 	for _, test := range []struct {
 		targetStr string
 		want      resolver.Target
@@ -79,9 +79,9 @@ func TestParseTargetString(t *testing.T) {
 		{"a//b", resolver.Target{"", "", "a//b"}},
 		{"a://b", resolver.Target{"", "", "a://b"}},
 	} {
-		got := parseTarget(test.targetStr)
+		got := splitTarget(test.targetStr)
 		if got != test.want {
-			t.Errorf("parseTarget(%q) = %+v, want %+v", test.targetStr, got, test.want)
+			t.Errorf("splitTarget(%q) = %+v, want %+v", test.targetStr, got, test.want)
 		}
 	}
 }


### PR DESCRIPTION
For target `unix:///foo`:

**Before**:  it is parsed as `{scheme: "unix", authority: "", endpoint: "foo"}`, and the fallback resolver (`passthrough`) will get `"foo"` as the endpoint.

After: `{scheme: "", authority: "", endpoint: "unix:///foo"}`, the `passthrough` resolver will get `"unix:///foo"` as the endpoint.

fixes #1899

related to #1889