### PR TITLE
status: rename Status to GRPCStatus to avoid name conflicts

### DIFF
--- a/status/status.go
+++ b/status/status.go
@@ -46,7 +46,7 @@ func (se *statusError) Error() string {
 	return fmt.Sprintf("rpc error: code = %s desc = %s", codes.Code(p.GetCode()), p.GetMessage())
 }
 
-func (se *statusError) Status() *Status {
+func (se *statusError) GRPCStatus() *Status {
 	return &Status{s: (*spb.Status)(se)}
 }
 
@@ -120,14 +120,14 @@ func FromProto(s *spb.Status) *Status {
 }
 
 // FromError returns a Status representing err if it was produced from this
-// package or has a method Status() *Status. Otherwise, ok is false and a
+// package or has a method `GRPCStatus() *Status`. Otherwise, ok is false and a
 // Status is returned with codes.Unknown and the original error message.
 func FromError(err error) (s *Status, ok bool) {
 	if err == nil {
 		return &Status{s: &spb.Status{Code: int32(codes.OK)}}, true
 	}
-	if se, ok := err.(interface{ Status() *Status }); ok {
-		return se.Status(), true
+	if se, ok := err.(interface{ GRPCStatus() *Status }); ok {
+		return se.GRPCStatus(), true
 	}
 	return New(codes.Unknown, err.Error()), false
 }
@@ -182,8 +182,8 @@ func Code(err error) codes.Code {
 	if err == nil {
 		return codes.OK
 	}
-	if se, ok := err.(interface{ Status() *Status }); ok {
-		return se.Status().Code()
+	if se, ok := err.(interface{ GRPCStatus() *Status }); ok {
+		return se.GRPCStatus().Code()
 	}
 	return codes.Unknown
 }

--- a/status/status_test.go
+++ b/status/status_test.go
@@ -131,7 +131,7 @@ func (c customError) Error() string {
 	return fmt.Sprintf("rpc error: code = %s desc = %s", c.Code, c.Message)
 }
 
-func (c customError) Status() *Status {
+func (c customError) GRPCStatus() *Status {
 	return &Status{
 		s: &spb.Status{
 			Code:    int32(c.Code),


### PR DESCRIPTION
@johanbrandhorst Sorry for the change here, but this should help avoid naming conflicts and make it possible for statuses to work with many types of status packages.
