### PR TITLE
grpclb: cache SubConns for 10 seconds after it is removed from the backendlist

### DIFF
--- a/grpclb.go
+++ b/grpclb.go
@@ -127,7 +127,7 @@ func (b *lbBuilder) Build(cc balancer.ClientConn, opt balancer.BuildOptions) bal
 	}
 
 	lb := &lbBalancer{
-		cc:              &lbCacheClientConn{ClientConn: cc},
+		cc:              newLBCacheClientConn(cc),
 		target:          target,
 		opt:             opt,
 		fallbackTimeout: b.fallbackTimeout,
@@ -145,7 +145,7 @@ func (b *lbBuilder) Build(cc balancer.ClientConn, opt balancer.BuildOptions) bal
 }
 
 type lbBalancer struct {
-	cc              balancer.ClientConn
+	cc              *lbCacheClientConn
 	target          string
 	opt             balancer.BuildOptions
 	fallbackTimeout time.Duration
@@ -339,4 +339,5 @@ func (lb *lbBalancer) Close() {
 	if lb.ccRemoteLB != nil {
 		lb.ccRemoteLB.Close()
 	}
+	lb.cc.close()
 }

--- a/grpclb.go
+++ b/grpclb.go
@@ -127,7 +127,7 @@ func (b *lbBuilder) Build(cc balancer.ClientConn, opt balancer.BuildOptions) bal
 	}
 
 	lb := &lbBalancer{
-		cc:              cc,
+		cc:              &lbCacheClientConn{ClientConn: cc},
 		target:          target,
 		opt:             opt,
 		fallbackTimeout: b.fallbackTimeout,

--- a/grpclb_util.go
+++ b/grpclb_util.go
@@ -130,14 +130,15 @@ func (ccc *lbCacheClientConn) NewSubConn(addrs []resolver.Address, opts balancer
 	if len(addrs) != 1 {
 		return nil, fmt.Errorf("grpclb calling NewSubConn with addrs of length %v", len(addrs))
 	}
+	addr := addrs[0]
 
 	ccc.mu.Lock()
 	defer ccc.mu.Unlock()
-	if entry, ok := ccc.subConnCache[addrs[0]]; ok {
+	if entry, ok := ccc.subConnCache[addr]; ok {
 		// If entry is in subConnCache, the SubConn was being deleted.
 		// cancel function will never be nil.
 		entry.cancel()
-		delete(ccc.subConnCache, addrs[0])
+		delete(ccc.subConnCache, addr)
 		return entry.sc, nil
 	}
 
@@ -146,7 +147,7 @@ func (ccc *lbCacheClientConn) NewSubConn(addrs []resolver.Address, opts balancer
 		return nil, err
 	}
 
-	ccc.subConnToAddr[scNew] = addrs[0]
+	ccc.subConnToAddr[scNew] = addr
 	return scNew, nil
 }
 

--- a/grpclb_util_test.go
+++ b/grpclb_util_test.go
@@ -1,3 +1,21 @@
+/*
+ *
+ * Copyright 2018 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package grpc
 
 import (

--- a/grpclb_util_test.go
+++ b/grpclb_util_test.go
@@ -1,0 +1,191 @@
+package grpc
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc/balancer"
+	"google.golang.org/grpc/resolver"
+)
+
+type mockSubConn struct {
+	balancer.SubConn
+}
+
+type mockClientConn struct {
+	balancer.ClientConn
+
+	subConns map[balancer.SubConn]resolver.Address
+}
+
+func newMockClientConn() *mockClientConn {
+	return &mockClientConn{
+		subConns: make(map[balancer.SubConn]resolver.Address),
+	}
+}
+
+func (mcc *mockClientConn) NewSubConn(addrs []resolver.Address, opts balancer.NewSubConnOptions) (balancer.SubConn, error) {
+	sc := &mockSubConn{}
+	mcc.subConns[sc] = addrs[0]
+	return sc, nil
+}
+
+func (mcc *mockClientConn) RemoveSubConn(sc balancer.SubConn) {
+	delete(mcc.subConns, sc)
+}
+
+const testCacheTimeout = 100 * time.Millisecond
+
+func checkMockCC(mcc *mockClientConn, scLen int) error {
+	if len(mcc.subConns) != scLen {
+		return fmt.Errorf("mcc = %+v, want len(mcc.subConns) = %v", mcc, scLen)
+	}
+	return nil
+}
+
+func checkCacheCC(ccc *lbCacheClientConn, sccLen, sctaLen int) error {
+	if len(ccc.subConnCache) != sccLen {
+		return fmt.Errorf("ccc = %+v, want len(ccc.subConnCache) = %v", ccc, sccLen)
+	}
+	if len(ccc.subConnToAddr) != sctaLen {
+		return fmt.Errorf("ccc = %+v, want len(ccc.subConnToAddr) = %v", ccc, sctaLen)
+	}
+	return nil
+}
+
+// Test that SubConn won't be immediately removed.
+func TestLBCacheClientConnExpire(t *testing.T) {
+	mcc := newMockClientConn()
+	if err := checkMockCC(mcc, 0); err != nil {
+		t.Fatal(err)
+	}
+
+	ccc := newLBCacheClientConn(mcc)
+	ccc.timeout = testCacheTimeout
+	if err := checkCacheCC(ccc, 0, 0); err != nil {
+		t.Fatal(err)
+	}
+
+	sc, _ := ccc.NewSubConn([]resolver.Address{{Addr: "address1"}}, balancer.NewSubConnOptions{})
+	// One subconn in MockCC.
+	if err := checkMockCC(mcc, 1); err != nil {
+		t.Fatal(err)
+	}
+	// No subconn being deleted, and one in CacheCC.
+	if err := checkCacheCC(ccc, 0, 1); err != nil {
+		t.Fatal(err)
+	}
+
+	ccc.RemoveSubConn(sc)
+	// One subconn in MockCC before timeout.
+	if err := checkMockCC(mcc, 1); err != nil {
+		t.Fatal(err)
+	}
+	// One subconn being deleted, and one in CacheCC.
+	if err := checkCacheCC(ccc, 1, 1); err != nil {
+		t.Fatal(err)
+	}
+
+	// Should all become empty after timeout.
+	var err error
+	for i := 0; i < 2; i++ {
+		time.Sleep(testCacheTimeout)
+		err = checkMockCC(mcc, 0)
+		if err != nil {
+			continue
+		}
+		err = checkCacheCC(ccc, 0, 0)
+		if err != nil {
+			continue
+		}
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Test that NewSubConn with the same address of a SubConn being removed will
+// reuse the SubConn and cancel the removing.
+func TestLBCacheClientConnReuse(t *testing.T) {
+	mcc := newMockClientConn()
+	if err := checkMockCC(mcc, 0); err != nil {
+		t.Fatal(err)
+	}
+
+	ccc := newLBCacheClientConn(mcc)
+	ccc.timeout = testCacheTimeout
+	if err := checkCacheCC(ccc, 0, 0); err != nil {
+		t.Fatal(err)
+	}
+
+	sc, _ := ccc.NewSubConn([]resolver.Address{{Addr: "address1"}}, balancer.NewSubConnOptions{})
+	// One subconn in MockCC.
+	if err := checkMockCC(mcc, 1); err != nil {
+		t.Fatal(err)
+	}
+	// No subconn being deleted, and one in CacheCC.
+	if err := checkCacheCC(ccc, 0, 1); err != nil {
+		t.Fatal(err)
+	}
+
+	ccc.RemoveSubConn(sc)
+	// One subconn in MockCC before timeout.
+	if err := checkMockCC(mcc, 1); err != nil {
+		t.Fatal(err)
+	}
+	// One subconn being deleted, and one in CacheCC.
+	if err := checkCacheCC(ccc, 1, 1); err != nil {
+		t.Fatal(err)
+	}
+
+	// Recreate the old subconn, this should cancel the deleting process.
+	sc, _ = ccc.NewSubConn([]resolver.Address{{Addr: "address1"}}, balancer.NewSubConnOptions{})
+	// One subconn in MockCC.
+	if err := checkMockCC(mcc, 1); err != nil {
+		t.Fatal(err)
+	}
+	// No subconn being deleted, and one in CacheCC.
+	if err := checkCacheCC(ccc, 0, 1); err != nil {
+		t.Fatal(err)
+	}
+
+	var err error
+	// Should not become empty after 2*timeout.
+	time.Sleep(2 * testCacheTimeout)
+	err = checkMockCC(mcc, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = checkCacheCC(ccc, 0, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Call remove again, will delete after timeout.
+	ccc.RemoveSubConn(sc)
+	// One subconn in MockCC before timeout.
+	if err := checkMockCC(mcc, 1); err != nil {
+		t.Fatal(err)
+	}
+	// One subconn being deleted, and one in CacheCC.
+	if err := checkCacheCC(ccc, 1, 1); err != nil {
+		t.Fatal(err)
+	}
+
+	// Should all become empty after timeout.
+	for i := 0; i < 2; i++ {
+		time.Sleep(testCacheTimeout)
+		err = checkMockCC(mcc, 0)
+		if err != nil {
+			continue
+		}
+		err = checkCacheCC(ccc, 0, 0)
+		if err != nil {
+			continue
+		}
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
10 seconds timeout is arbitrary. Could make it configurable in the future.