### PR TITLE
cleanup: extend dial context for test to 10 seconds

### DIFF
--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -6170,7 +6170,7 @@ func TestFailFastRPCErrorOnBadCertificates(t *testing.T) {
 	defer te.tearDown()
 
 	opts := []grpc.DialOption{grpc.WithTransportCredentials(clientAlwaysFailCred{})}
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	cc, err := grpc.DialContext(ctx, te.srvAddr, opts...)
 	if err != nil {


### PR DESCRIPTION
for `TestFailFastRPCErrorOnBadCertificates`

We were getting `context deadline exceeded` from this dial, but the dial is not blocking.

updates #1968