### PR TITLE
Fix Test: race between t.Write() and t.closeStream()

### DIFF
--- a/transport/transport.go
+++ b/transport/transport.go
@@ -650,7 +650,7 @@ var (
 	errStreamDrain = streamErrorf(codes.Unavailable, "the connection is draining")
 	// errStreamDone is returned from write at the client side to indiacte application
 	// layer of an error.
-	errStreamDone = errors.New("tne stream is done")
+	errStreamDone = errors.New("the stream is done")
 	// StatusGoAway indicates that the server sent a GOAWAY that included this
 	// stream's ID in unprocessed RPCs.
 	statusGoAway = status.New(codes.Unavailable, "the stream is rejected because server is draining the connection")

--- a/transport/transport_test.go
+++ b/transport/transport_test.go
@@ -1640,13 +1640,6 @@ func TestInvalidHeaderField(t *testing.T) {
 	if err != nil {
 		return
 	}
-	opts := Options{
-		Last:  true,
-		Delay: false,
-	}
-	if err := ct.Write(s, nil, expectedRequest, &opts); err != nil && err != io.EOF {
-		t.Fatalf("Failed to write the request: %v", err)
-	}
 	p := make([]byte, http2MaxFrameLen)
 	_, err = s.trReader.(*transportReader).Read(p)
 	if se, ok := err.(StreamError); !ok || se.Code != codes.Internal || !strings.Contains(err.Error(), expectedInvalidHeaderField) {


### PR DESCRIPTION
With the transport refactoring (#1962),  the transport will now close the stream right way if the header received is invalid. Before, the error will be sent to the recv buffer, and wait until user read to detect the error and close the stream. Therefore, now there exist a race between receiving the invalid header thus closing stream and the write of request, and we may get `errStreamDone` error from `Write`, which causes test to fail. 