### PR TITLE
reflection: regenerate pb.go file after typo fix

### DIFF
--- a/reflection/grpc_reflection_v1alpha/reflection.pb.go
+++ b/reflection/grpc_reflection_v1alpha/reflection.pb.go
@@ -281,8 +281,8 @@ func (m *ExtensionRequest) GetExtensionNumber() int32 {
 type ServerReflectionResponse struct {
 	ValidHost       string                   `protobuf:"bytes,1,opt,name=valid_host,json=validHost" json:"valid_host,omitempty"`
 	OriginalRequest *ServerReflectionRequest `protobuf:"bytes,2,opt,name=original_request,json=originalRequest" json:"original_request,omitempty"`
-	// The server set one of the following fields according to the message_request
-	// in the request.
+	// The server sets one of the following fields according to the
+	// message_request in the request.
 	//
 	// Types that are valid to be assigned to MessageResponse:
 	//	*ServerReflectionResponse_FileDescriptorResponse


### PR DESCRIPTION
The typo in proto file was fixed, but not pb.go file. This was causing failures
in travis cron tests.

Fix for proto file: https://github.com/grpc/grpc-go/pull/1994/files#diff-46d5b9196e4de6acd555d67dde31211eR75