### PR TITLE
internal: remove transportMonitor, replace with callbacks

### DIFF
--- a/balancer.go
+++ b/balancer.go
@@ -406,7 +406,7 @@ func (rr *roundRobin) Close() error {
 
 // pickFirst is used to test multi-addresses in one addrConn in which all addresses share the same addrConn.
 // It is a wrapper around roundRobin balancer. The logic of all methods works fine because balancer.Get()
-// returns the only address Up by resetTransport().
+// returns the only address Up by continuallyRejuvenateTransport().
 type pickFirst struct {
 	*roundRobin
 }

--- a/balancer.go
+++ b/balancer.go
@@ -406,7 +406,7 @@ func (rr *roundRobin) Close() error {
 
 // pickFirst is used to test multi-addresses in one addrConn in which all addresses share the same addrConn.
 // It is a wrapper around roundRobin balancer. The logic of all methods works fine because balancer.Get()
-// returns the only address Up by continuallyRejuvenateTransport().
+// returns the only address Up by resetTransport().
 type pickFirst struct {
 	*roundRobin
 }

--- a/clientconn.go
+++ b/clientconn.go
@@ -1295,11 +1295,10 @@ func (ac *addrConn) continuallyRejuvenateTransport() error {
 
 		onGoAway := func() {
 			shutdownLock.Lock()
-			defer shutdownLock.Unlock()
-
 			if timer != nil {
 				timer.Stop()
 			}
+			shutdownLock.Unlock()
 
 			ac.mu.Lock()
 			ac.adjustParams(ac.transport.GetGoAwayReason())
@@ -1309,11 +1308,10 @@ func (ac *addrConn) continuallyRejuvenateTransport() error {
 		// onClose causes another reconnect loop.
 		onClose := func() {
 			shutdownLock.Lock()
-			defer shutdownLock.Unlock()
-
 			if timer != nil {
 				timer.Stop()
 			}
+			shutdownLock.Unlock()
 
 			ac.mu.Lock()
 			delete(ac.transports, newTrID)

--- a/clientconn.go
+++ b/clientconn.go
@@ -1238,20 +1238,10 @@ func (ac *addrConn) resetTransport() error {
 		grpclog.Warningf("grpc: addrConn.transportMonitor didn't get server preface after waiting. Closing the new transport now.")
 		t := ac.transport
 		ac.mu.Unlock()
-		if t != nil {
-			t.Close()
-		}
-
-		err := ac.nextAddr()
-		if err != nil {
-			grpclog.Error(err)
+		if t == nil {
 			return
 		}
-
-		err = ac.resetTransport()
-		if err != nil {
-			grpclog.Error(err)
-		}
+		t.Close()
 	}
 
 	shutdownLock := &sync.Mutex{}

--- a/clientconn.go
+++ b/clientconn.go
@@ -1315,6 +1315,7 @@ func (ac *addrConn) continuallyRejuvenateTransport() error {
 
 			ac.mu.Lock()
 			delete(ac.transports, newTrID)
+			ac.transport = nil
 			ac.mu.Unlock()
 
 			select {

--- a/clientconn.go
+++ b/clientconn.go
@@ -1400,11 +1400,6 @@ func (ac *addrConn) createTransport(id int32, backoffNum int, addr resolver.Addr
 	if ac.dopts.waitForHandshake {
 		select {
 		case <-done:
-		case <-connectCtx.Done():
-			// Didn't receive server preface, must kill this new transport now.
-			grpclog.Warningf("grpc: addrConn.createTransport failed to receive server preface before deadline.")
-			newTr.Close()
-			break
 		case <-ac.ctx.Done():
 		}
 	}

--- a/clientconn.go
+++ b/clientconn.go
@@ -1285,11 +1285,8 @@ func (ac *addrConn) continuallyRejuvenateTransport() error {
 		}
 
 		shutdownLock := &sync.Mutex{}
-		var timer *time.Timer
 		ac.mu.Lock()
-		if !ac.connectDeadline.IsZero() {
-			timer = time.AfterFunc(ac.connectDeadline.Sub(time.Now()), onDeadline)
-		}
+		timer := time.AfterFunc(ac.connectDeadline.Sub(time.Now()), onDeadline)
 		ac.mu.Unlock()
 		newTrID := atomic.AddInt32(&ac.transportIdx, 1)
 

--- a/clientconn.go
+++ b/clientconn.go
@@ -28,6 +28,8 @@ import (
 	"sync"
 	"time"
 
+	"sync/atomic"
+
 	"golang.org/x/net/context"
 	"golang.org/x/net/trace"
 	"google.golang.org/grpc/balancer"
@@ -46,7 +48,6 @@ import (
 	"google.golang.org/grpc/stats"
 	"google.golang.org/grpc/status"
 	"google.golang.org/grpc/transport"
-	"sync/atomic"
 )
 
 const (
@@ -1397,7 +1398,7 @@ func (ac *addrConn) createTransport(id int32, backoffNum int, addr resolver.Addr
 	ac.transports[id] = newTr
 	ac.mu.Unlock()
 	return nil
-};
+}
 
 // nextAddr increments the addrIdx if there are more addresses to try. If
 // there are no more addrs to try it will re-resolve, set addrIdx to 0, and
@@ -1406,13 +1407,13 @@ func (ac *addrConn) nextAddr() error {
 	ac.mu.Lock()
 
 	if ac.addrIdx < len(ac.addrs)-1 {
-		ac.addrIdx += 1
+		ac.addrIdx++
 		ac.mu.Unlock()
 		return nil
 	}
 
 	ac.addrIdx = 0
-	ac.backoffIdx += 1
+	ac.backoffIdx++
 
 	if ac.state == connectivity.Shutdown {
 		ac.mu.Unlock()

--- a/status/status.go
+++ b/status/status.go
@@ -126,7 +126,9 @@ func FromError(err error) (s *Status, ok bool) {
 	if err == nil {
 		return &Status{s: &spb.Status{Code: int32(codes.OK)}}, true
 	}
-	if se, ok := err.(interface{ GRPCStatus() *Status }); ok {
+	if se, ok := err.(interface {
+		GRPCStatus() *Status
+	}); ok {
 		return se.GRPCStatus(), true
 	}
 	return New(codes.Unknown, err.Error()), false
@@ -182,7 +184,9 @@ func Code(err error) codes.Code {
 	if err == nil {
 		return codes.OK
 	}
-	if se, ok := err.(interface{ GRPCStatus() *Status }); ok {
+	if se, ok := err.(interface {
+		GRPCStatus() *Status
+	}); ok {
 		return se.GRPCStatus().Code()
 	}
 	return codes.Unknown

--- a/stream.go
+++ b/stream.go
@@ -274,6 +274,11 @@ func newClientStream(ctx context.Context, desc *StreamDesc, cc *ClientConn, meth
 			return nil, err
 		}
 
+		// TODO(deklerk) what??
+		if t == nil {
+			continue
+		}
+
 		s, err = t.NewStream(ctx, callHdr)
 		if err != nil {
 			if done != nil {

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -488,7 +488,7 @@ type TargetInfo struct {
 
 // NewClientTransport establishes the transport with the required ConnectOptions
 // and returns it to the caller.
-func NewClientTransport(connectCtx, ctx context.Context, target TargetInfo, opts ConnectOptions, deadline time.Time, onSuccess, onDeadline, onGoAway, onClose func()) (ClientTransport, error) {
+func NewClientTransport(connectCtx, ctx context.Context, target TargetInfo, opts ConnectOptions, deadline time.Time, onSuccess, onDeadline func(), onGoAway func(GoAwayReason), onClose func()) (ClientTransport, error) {
 	return newHTTP2Client(connectCtx, ctx, target, opts, deadline, onSuccess, onDeadline, onGoAway, onClose)
 }
 

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -487,8 +487,8 @@ type TargetInfo struct {
 
 // NewClientTransport establishes the transport with the required ConnectOptions
 // and returns it to the caller.
-func NewClientTransport(connectCtx, ctx context.Context, target TargetInfo, opts ConnectOptions, onSuccess func()) (ClientTransport, error) {
-	return newHTTP2Client(connectCtx, ctx, target, opts, onSuccess)
+func NewClientTransport(connectCtx, ctx context.Context, target TargetInfo, opts ConnectOptions, onSuccess, onGoAway, onClose func()) (ClientTransport, error) {
+	return newHTTP2Client(connectCtx, ctx, target, opts, onSuccess, onGoAway, onClose)
 }
 
 // Options provides additional hints and information for message

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -29,6 +29,8 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"time"
+
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
@@ -37,7 +39,6 @@ import (
 	"google.golang.org/grpc/stats"
 	"google.golang.org/grpc/status"
 	"google.golang.org/grpc/tap"
-	"time"
 )
 
 // recvMsg represents the received msg from the transport. All transport

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -37,6 +37,7 @@ import (
 	"google.golang.org/grpc/stats"
 	"google.golang.org/grpc/status"
 	"google.golang.org/grpc/tap"
+	"time"
 )
 
 // recvMsg represents the received msg from the transport. All transport
@@ -487,8 +488,8 @@ type TargetInfo struct {
 
 // NewClientTransport establishes the transport with the required ConnectOptions
 // and returns it to the caller.
-func NewClientTransport(connectCtx, ctx context.Context, target TargetInfo, opts ConnectOptions, onSuccess, onGoAway, onClose func()) (ClientTransport, error) {
-	return newHTTP2Client(connectCtx, ctx, target, opts, onSuccess, onGoAway, onClose)
+func NewClientTransport(connectCtx, ctx context.Context, target TargetInfo, opts ConnectOptions, deadline time.Time, onSuccess, onDeadline, onGoAway, onClose func()) (ClientTransport, error) {
+	return newHTTP2Client(connectCtx, ctx, target, opts, deadline, onSuccess, onDeadline, onGoAway, onClose)
 }
 
 // Options provides additional hints and information for message

--- a/transport/transport_test.go
+++ b/transport/transport_test.go
@@ -989,7 +989,7 @@ func TestLargeMessageWithDelayRead(t *testing.T) {
 		InitialWindowSize:     defaultWindowSize,
 		InitialConnWindowSize: defaultWindowSize,
 	}
-	server, ct := setUpWithOptions(t, 0, sc, delayRead, co, func() {})
+	server, ct := setUpWithOptions(t, 0, sc, delayRead, co)
 	defer server.stop()
 	defer ct.Close()
 	server.mu.Lock()

--- a/transport/transport_test.go
+++ b/transport/transport_test.go
@@ -410,7 +410,7 @@ func setUpWithOptions(t *testing.T, port int, serverConfig *ServerConfig, ht hTy
 		Addr: addr,
 	}
 	connectCtx, cancel := context.WithDeadline(context.Background(), time.Now().Add(2*time.Second))
-	ct, connErr = NewClientTransport(connectCtx, context.Background(), target, copts, time.Time{}, func() {}, func() {}, func() {}, func() {})
+	ct, connErr = NewClientTransport(connectCtx, context.Background(), target, copts, time.Time{}, func() {}, func() {}, func(GoAwayReason) {}, func() {})
 	if connErr != nil {
 		cancel() // Do not cancel in success path.
 		t.Fatalf("failed to create transport: %v", connErr)
@@ -435,7 +435,7 @@ func setUpWithNoPingServer(t *testing.T, copts ConnectOptions, done chan net.Con
 		done <- conn
 	}()
 	connectCtx, cancel := context.WithDeadline(context.Background(), time.Now().Add(2*time.Second))
-	tr, err := NewClientTransport(connectCtx, context.Background(), TargetInfo{Addr: lis.Addr().String()}, copts, time.Time{}, func() {}, func() {}, func() {}, func() {})
+	tr, err := NewClientTransport(connectCtx, context.Background(), TargetInfo{Addr: lis.Addr().String()}, copts, time.Time{}, func() {}, func() {}, func(GoAwayReason) {}, func() {})
 	if err != nil {
 		cancel() // Do not cancel in success path.
 		// Server clean-up.
@@ -1618,7 +1618,7 @@ func TestClientWithMisbehavedServer(t *testing.T) {
 	}()
 	connectCtx, cancel := context.WithDeadline(context.Background(), time.Now().Add(2*time.Second))
 	defer cancel()
-	ct, err := NewClientTransport(connectCtx, context.Background(), TargetInfo{Addr: lis.Addr().String()}, ConnectOptions{}, time.Time{}, func() {}, func() {}, func() {}, func() {})
+	ct, err := NewClientTransport(connectCtx, context.Background(), TargetInfo{Addr: lis.Addr().String()}, ConnectOptions{}, time.Time{}, func() {}, func() {}, func(GoAwayReason) {}, func() {})
 	if err != nil {
 		t.Fatalf("Error while creating client transport: %v", err)
 	}
@@ -2019,7 +2019,7 @@ func setUpHTTPStatusTest(t *testing.T, httpStatus int, wh writeHeaders) (stream 
 	}
 	server.start(t, lis)
 	connectCtx, cancel := context.WithDeadline(context.Background(), time.Now().Add(2*time.Second))
-	client, err = newHTTP2Client(connectCtx, context.Background(), TargetInfo{Addr: lis.Addr().String()}, ConnectOptions{}, time.Time{}, func() {}, func() {}, func() {}, func() {})
+	client, err = newHTTP2Client(connectCtx, context.Background(), TargetInfo{Addr: lis.Addr().String()}, ConnectOptions{}, time.Time{}, func() {}, func() {}, func(GoAwayReason) {}, func() {})
 	if err != nil {
 		cancel() // Do not cancel in success path.
 		t.Fatalf("Error creating client. Err: %v", err)

--- a/transport/transport_test.go
+++ b/transport/transport_test.go
@@ -410,7 +410,7 @@ func setUpWithOptions(t *testing.T, port int, serverConfig *ServerConfig, ht hTy
 		Addr: addr,
 	}
 	connectCtx, cancel := context.WithDeadline(context.Background(), time.Now().Add(2*time.Second))
-	ct, connErr = NewClientTransport(connectCtx, context.Background(), target, copts, func() {}, func() {}, func() {})
+	ct, connErr = NewClientTransport(connectCtx, context.Background(), target, copts, time.Time{}, func() {}, func() {}, func() {}, func() {})
 	if connErr != nil {
 		cancel() // Do not cancel in success path.
 		t.Fatalf("failed to create transport: %v", connErr)
@@ -435,7 +435,7 @@ func setUpWithNoPingServer(t *testing.T, copts ConnectOptions, done chan net.Con
 		done <- conn
 	}()
 	connectCtx, cancel := context.WithDeadline(context.Background(), time.Now().Add(2*time.Second))
-	tr, err := NewClientTransport(connectCtx, context.Background(), TargetInfo{Addr: lis.Addr().String()}, copts, func() {}, func() {}, func() {})
+	tr, err := NewClientTransport(connectCtx, context.Background(), TargetInfo{Addr: lis.Addr().String()}, copts, time.Time{}, func() {}, func() {}, func() {}, func() {})
 	if err != nil {
 		cancel() // Do not cancel in success path.
 		// Server clean-up.
@@ -1618,7 +1618,7 @@ func TestClientWithMisbehavedServer(t *testing.T) {
 	}()
 	connectCtx, cancel := context.WithDeadline(context.Background(), time.Now().Add(2*time.Second))
 	defer cancel()
-	ct, err := NewClientTransport(connectCtx, context.Background(), TargetInfo{Addr: lis.Addr().String()}, ConnectOptions{}, func() {}, func() {}, func() {})
+	ct, err := NewClientTransport(connectCtx, context.Background(), TargetInfo{Addr: lis.Addr().String()}, ConnectOptions{}, time.Time{}, func() {}, func() {}, func() {}, func() {})
 	if err != nil {
 		t.Fatalf("Error while creating client transport: %v", err)
 	}
@@ -2019,7 +2019,7 @@ func setUpHTTPStatusTest(t *testing.T, httpStatus int, wh writeHeaders) (stream 
 	}
 	server.start(t, lis)
 	connectCtx, cancel := context.WithDeadline(context.Background(), time.Now().Add(2*time.Second))
-	client, err = newHTTP2Client(connectCtx, context.Background(), TargetInfo{Addr: lis.Addr().String()}, ConnectOptions{}, func() {}, func() {}, func() {})
+	client, err = newHTTP2Client(connectCtx, context.Background(), TargetInfo{Addr: lis.Addr().String()}, ConnectOptions{}, time.Time{}, func() {}, func() {}, func() {}, func() {})
 	if err != nil {
 		cancel() // Do not cancel in success path.
 		t.Fatalf("Error creating client. Err: %v", err)


### PR DESCRIPTION
This removes a goroutine (in which transportMonitor was running) and the backoff and addrs loops. Instead we use callbacks to handle the deadline, goaway, and close logic that transport monitor handled before, and we descend into recursive createTransport calls instead of loops.

As a result, backoffIdx and addrIdx now live on addrConn. Also, transport.Close now blocks until the addrConn that initiated it is connected - this is because t.Close calls onClose, whose last step is to begin reconnecting. In the event of a shutdown, all reconnect logic ends and t.Close will return.