### PR TITLE
Documentation: create doc describing grpc-go's log levels and their usages

### DIFF
--- a/Documentation/log_levels.md
+++ b/Documentation/log_levels.md
@@ -18,17 +18,18 @@ more than once every 5 minutes under normal operation.
 
 ### Warning
 
-Warning messages indicate problems that are non-fatal for the operation being
-performed, but could lead to unexpected behavior or subsequent errors.
+Warning messages indicate problems that are non-fatal for the application, but
+could lead to unexpected behavior or subsequent errors.
 
 Examples:
 - Resolver could not resolve target name.
 - Error received while connecting to a server.
+- Lost or corrupt connection with remote endpoint.
 
 ### Error
 
-Error messages represent errors in the usage of gRPC or internal gRPC-Go errors
-that are recoverable.
+Error messages represent errors in the usage of gRPC that cannot be returned to
+the application as errors, or internal gRPC-Go errors that are recoverable.
 
 Internal errors are detected during gRPC tests and will result in test failures.
 

--- a/Documentation/log_levels.md
+++ b/Documentation/log_levels.md
@@ -1,0 +1,48 @@
+# Log Levels
+
+This document describes the different log levels supported by the grpc-go
+library, and under what conditions they should be used.
+
+### Info
+
+Info messages are for informational purposes and may aid in the debugging of
+applications or the gRPC library.
+
+Examples:
+- The name resolver received an update.
+- The balancer updated its picker.
+- Significant gRPC state is changing.
+
+At verbosity of 0 (the default), any single info message should not be output
+more than once every 5 minutes under normal operation.
+
+### Warning
+
+Warning messages indicate problems that are non-fatal for the operation being
+performed, but could lead to unexpected behavior or subsequent errors.
+
+Examples:
+- Resolver could not resolve target name.
+- Error received while connecting to a server.
+
+### Error
+
+Error messages represent errors in the usage of gRPC or internal gRPC-Go errors
+that are recoverable.
+
+Internal errors are detected during gRPC tests and will result in test failures.
+
+Examples:
+- Invalid arguments passed to a function that cannot return an error.
+- An internal error that cannot be returned or would be inappropriate to return
+  to the user.
+
+### Fatal
+
+Fatal errors are severe internal errors that are unrecoverable.  These lead
+directly to panics, and are avoided as much as possible.
+
+Example:
+- Internal invariant was violated.
+- User attempted an action that cannot return an error gracefully, but would
+  lead to an invalid state if performed.


### PR DESCRIPTION
Once this is agreed upon, we should take a sweep through all our logging and make sure it is compliant.

related to #2025