### PR TITLE
client: fix interceptors after recent cleanup

### DIFF
--- a/call.go
+++ b/call.go
@@ -67,7 +67,7 @@ func invoke(ctx context.Context, method string, req, reply interface{}, cc *Clie
 	// newClientStream, SendMsg, RecvMsg.
 	firstAttempt := true
 	for {
-		csInt, err := cc.NewStream(ctx, unaryStreamDesc, method, opts...)
+		csInt, err := newClientStream(ctx, unaryStreamDesc, cc, method, opts...)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This is a partial revert of #2027 which seems to have broken the ability
to inject payload inspecting client interceptors. Specifically it causes
this test to break:
https://github.com/GoogleCloudPlatform/google-cloud-go/blob/eb0079f598a6640ecbb7a4d2d9dcb0278a320b61/bigtable/bigtable_test.go#L949-L971

With:

> panic: interface conversion: grpc.ClientStream is *bigtable.requestCountingInterceptor, not *grpc.clientStream [recovered]
> 	panic: interface conversion: grpc.ClientStream is *bigtable.requestCountingInterceptor, not *grpc.clientStream
> 

Which seems to be caused by invoke() expecting a clientStream from a
ClientConn:

https://github.com/grpc/grpc-go/blob/7c204fd174eaec3ef7de010a6673121d6625013e/call.go#L74

I'm not entirely sure if this is the correct solution, but figured I start the conversation with this PR. Please advise