### PR TITLE
Throw an error for non-default DNS authority.

### DIFF
--- a/resolver/dns/dns_resolver.go
+++ b/resolver/dns/dns_resolver.go
@@ -67,6 +67,9 @@ type dnsBuilder struct {
 
 // Build creates and starts a DNS resolver that watches the name resolution of the target.
 func (b *dnsBuilder) Build(target resolver.Target, cc resolver.ClientConn, opts resolver.BuildOption) (resolver.Resolver, error) {
+	if target.Authority != "" {
+		return nil, fmt.Errorf("non-default DNS resolver %q not supported", target.Authority)
+	}
 	host, port, err := parseTarget(target.Endpoint)
 	if err != nil {
 		return nil, err

--- a/resolver/dns/dns_resolver.go
+++ b/resolver/dns/dns_resolver.go
@@ -68,7 +68,7 @@ type dnsBuilder struct {
 // Build creates and starts a DNS resolver that watches the name resolution of the target.
 func (b *dnsBuilder) Build(target resolver.Target, cc resolver.ClientConn, opts resolver.BuildOption) (resolver.Resolver, error) {
 	if target.Authority != "" {
-		return nil, fmt.Errorf("non-default DNS resolver %q not supported", target.Authority)
+		return nil, fmt.Errorf("Default DNS resolver does not support custom DNS server")
 	}
 	host, port, err := parseTarget(target.Endpoint)
 	if err != nil {


### PR DESCRIPTION
The gRPC naming document at
https://github.com/grpc/grpc/blob/master/doc/naming.md says:

> for DNS, the authority may include the IP[:port] of the DNS server to use

However, grpc-go does not support configuring DNS servers. It will always use
Go's default DNS resolver.