### PR TITLE
clarify CloseSend vs CloseAndRecv; better formatting

### DIFF
--- a/stream.go
+++ b/stream.go
@@ -106,10 +106,16 @@ type ClientStream interface {
 // To ensure resources are not leaked due to the stream returned, one of the following
 // actions must be performed:
 //
-// 1. call Close on the ClientConn,
-// 2. cancel the context provided,
-// 3. call RecvMsg until a non-nil error is returned, or
-// 4. receive a non-nil, non-io.EOF error from Header or SendMsg.
+//		1. Call Close on the ClientConn.
+//		2. Cancel the context provided.
+//		3. Call RecvMsg until a non-nil error is returned. For protobuf-generated clients:
+//			- Unidirectional clients should call CloseAndRecv (in the unidirectional case,
+//			  the server should only ever respond in the "closing" case). Note that
+//			  CloseSend will may not release all goroutines; CloseAndRecv guarantees
+//			  release of resources.
+//			- Bidirectional clients should call Close and then call Recv until a non-nil
+// 			  error is returned.
+//		4. Receive a non-nil, non-io.EOF error from Header or SendMsg.
 //
 // If none of the above happen, a goroutine and a context will be leaked, and grpc
 // will not call the optionally-configured stats handler with a stats.End message.


### PR DESCRIPTION
This may be overly verbose - I'd love to know if there's a better way to say this.

wrt the formatting, it renders like this:

<img width="1374" alt="screen shot 2018-05-11 at 9 27 45 pm" src="https://user-images.githubusercontent.com/3584893/39953521-5861db5a-5562-11e8-9b19-110d5ae5e9c1.png">

Inspired by https://github.com/thunderdb/ThunderDB/pull/18 via https://github.com/golang/go/issues/7873.