### PR TITLE
benchmark: listen on all addresses in benchmark servers

### DIFF
--- a/benchmark/server/main.go
+++ b/benchmark/server/main.go
@@ -44,7 +44,7 @@ func main() {
 			grpclog.Fatalf("Failed to serve: %v", err)
 		}
 	}()
-	lis, err := net.Listen("tcp", "localhost:0")
+	lis, err := net.Listen("tcp", ":0")
 	if err != nil {
 		grpclog.Fatalf("Failed to listen: %v", err)
 	}

--- a/benchmark/worker/benchmark_server.go
+++ b/benchmark/worker/benchmark_server.go
@@ -112,7 +112,7 @@ func startBenchmarkServer(config *testpb.ServerConfig, serverPort int) (*benchma
 	if port == 0 {
 		port = serverPort
 	}
-	lis, err := net.Listen("tcp", fmt.Sprintf("localhost:%d", port))
+	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
 	if err != nil {
 		grpclog.Fatalf("Failed to listen: %v", err)
 	}


### PR DESCRIPTION
Trying to fix: https://github.com/grpc/grpc/issues/15291.

The error message was:
`FATAL: 2018/05/06 22:51:16 &{0xc420206300}.StreamingCall(_) = _, rpc error: code = Unavailable desc = all SubConns are in TransientFailure, latest connection error: connection error: desc = `**`"transport: Error while dialing dial tcp 10.240.0.251:38561: getsockopt: connection refused"`**

The failure might be caused by `Listen` only listens on ipv6 address, but client is trying to dialing to ipv4 addresses.

Possibly related golang issue: https://github.com/golang/go/issues/9334