### PR TITLE
internal: move version to a separate file

### DIFF
--- a/rpc_util.go
+++ b/rpc_util.go
@@ -738,7 +738,4 @@ const (
 	SupportPackageIsVersion5 = true
 )
 
-// Version is the current grpc version.
-const Version = "1.13.0-dev"
-
 const grpcUA = "grpc-go/" + Version

--- a/version.go
+++ b/version.go
@@ -1,0 +1,22 @@
+/*
+ *
+ * Copyright 2018 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package grpc
+
+// Version is the current grpc version.
+const Version = "1.13.0-dev"


### PR DESCRIPTION
So it's easier to update version when doing releases.