### PR TITLE
Revert "Strip port from server name in grpclb (#2066)"

### DIFF
--- a/grpclb.go
+++ b/grpclb.go
@@ -19,7 +19,6 @@
 package grpc
 
 import (
-	"net"
 	"strconv"
 	"strings"
 	"sync"
@@ -125,16 +124,6 @@ func (b *lbBuilder) Build(cc balancer.ClientConn, opt balancer.BuildOptions) bal
 		target = cc.Target()
 	} else {
 		target = targetSplitted[1]
-	}
-
-	// Remove port number from target if it exists.
-	if host, _, err := net.SplitHostPort(target); err == nil {
-		// When err is not nil, target remains unchanged.
-		//
-		// Possible non-nil err values:
-		// - missing port in address: no port to strip
-		// - other errors: failed to parse
-		target = host
 	}
 
 	lb := &lbBalancer{

--- a/grpclb/grpclb_test.go
+++ b/grpclb/grpclb_test.go
@@ -313,7 +313,7 @@ func newLoadBalancer(numberOfBackends int) (tss *testServers, cleanup func(), er
 	return
 }
 
-func testGRPCLBSimple(t *testing.T, target string) {
+func TestGRPCLB(t *testing.T) {
 	defer leakcheck.Check(t)
 
 	r, cleanup := manual.GenerateAndRegisterManualResolver()
@@ -341,7 +341,7 @@ func testGRPCLBSimple(t *testing.T, target string) {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	cc, err := grpc.DialContext(ctx, r.Scheme()+":///"+target,
+	cc, err := grpc.DialContext(ctx, r.Scheme()+":///"+beServerName,
 		grpc.WithTransportCredentials(&creds), grpc.WithDialer(fakeNameDialer))
 	if err != nil {
 		t.Fatalf("Failed to dial to the backend %v", err)
@@ -358,17 +358,6 @@ func testGRPCLBSimple(t *testing.T, target string) {
 	if _, err := testC.EmptyCall(context.Background(), &testpb.Empty{}, grpc.FailFast(false)); err != nil {
 		t.Fatalf("%v.EmptyCall(_, _) = _, %v, want _, <nil>", testC, err)
 	}
-}
-
-func TestGRPCLB(t *testing.T) {
-	testGRPCLBSimple(t, beServerName)
-}
-
-// TestGRPCLBWithPort is same as TestGRPCLB, expect that the dialing target
-// contains fake port number ":8080". The purpose of this test is to make sure
-// that grpclb strips port number from the dialing target in init request.
-func TestGRPCLBWithPort(t *testing.T) {
-	testGRPCLBSimple(t, beServerName+":8080")
 }
 
 // The remote balancer sends response with duplicates to grpclb client.


### PR DESCRIPTION
This reverts commit d24d0a4b993587a34ac7d09ac956b0375ee7d1fa.