### PR TITLE
internal: remove redundant channelz service go generate

### DIFF
--- a/channelz/service/service.go
+++ b/channelz/service/service.go
@@ -16,8 +16,6 @@
  *
  */
 
-//go:generate protoc -I ../grpc_channelz_v1 --go_out=plugins=grpc,paths=source_relative:../grpc_channelz_v1 ../grpc_channelz_v1/channelz.proto
-
 // Package service provides an implementation for channelz service server.
 package service
 

--- a/vet.sh
+++ b/vet.sh
@@ -29,7 +29,7 @@ if [ "$1" = "-install" ]; then
     honnef.co/go/tools/cmd/staticcheck \
     github.com/client9/misspell/cmd/misspell \
     github.com/golang/protobuf/protoc-gen-go
-  if [[ "$check_proto" = "true" ]] || true; then
+  if [[ "$check_proto" = "true" ]]; then
     if [[ "$TRAVIS" = "true" ]]; then
       PROTOBUF_VERSION=3.3.0
       PROTOC_FILENAME=protoc-${PROTOBUF_VERSION}-linux-x86_64.zip
@@ -74,7 +74,7 @@ go tool vet -all . 2>&1 | grep -vE '(clientconn|transport\/transport_test).go:.*
 set -o pipefail
 git reset --hard HEAD
 
-if [[ "$check_proto" = "true" ]] || true; then
+if [[ "$check_proto" = "true" ]]; then
   PATH="/home/travis/bin:$PATH" make proto && \
     git status --porcelain 2>&1 | (! read) || \
     (git status; git --no-pager diff; exit 1)

--- a/vet.sh
+++ b/vet.sh
@@ -29,7 +29,7 @@ if [ "$1" = "-install" ]; then
     honnef.co/go/tools/cmd/staticcheck \
     github.com/client9/misspell/cmd/misspell \
     github.com/golang/protobuf/protoc-gen-go
-  if [[ "$check_proto" = "true" ]]; then
+  if [[ "$check_proto" = "true" ]] || true; then
     if [[ "$TRAVIS" = "true" ]]; then
       PROTOBUF_VERSION=3.3.0
       PROTOC_FILENAME=protoc-${PROTOBUF_VERSION}-linux-x86_64.zip
@@ -74,7 +74,7 @@ go tool vet -all . 2>&1 | grep -vE '(clientconn|transport\/transport_test).go:.*
 set -o pipefail
 git reset --hard HEAD
 
-if [[ "$check_proto" = "true" ]]; then
+if [[ "$check_proto" = "true" ]] || true; then
   PATH="/home/travis/bin:$PATH" make proto && \
     git status --porcelain 2>&1 | (! read) || \
     (git status; git --no-pager diff; exit 1)


### PR DESCRIPTION
The proto files were removed. This `go generate` would fail because of missing files.