### PR TITLE
Clarify newCCResolverWrapper documentation.

### DIFF
--- a/resolver_conn_wrapper.go
+++ b/resolver_conn_wrapper.go
@@ -65,8 +65,8 @@ func parseTarget(target string) (ret resolver.Target) {
 }
 
 // newCCResolverWrapper parses cc.target for scheme and gets the resolver
-// builder for this scheme. It then builds the resolver and starts the
-// monitoring goroutine for it.
+// builder for this scheme and builds the resolver. The monitoring goroutine
+// for it is not started yet and can be created by calling start().
 //
 // If withResolverBuilder dial option is set, the specified resolver will be
 // used instead.


### PR DESCRIPTION
I think the goroutine does not get started any more (this used to be the case in an earlier version).