### PR TITLE
resolver/dns: create resolver builder with custom freq

### DIFF
--- a/resolver/dns/dns_resolver.go
+++ b/resolver/dns/dns_resolver.go
@@ -54,7 +54,12 @@ var errMissingAddr = errors.New("missing address")
 
 // NewBuilder creates a dnsBuilder which is used to factory DNS resolvers.
 func NewBuilder() resolver.Builder {
-	return &dnsBuilder{freq: defaultFreq}
+	return NewBuilderWithFreq(defaultFreq)
+}
+
+// NewBuilderWithFreq creates a dnsBuilder with passed in freq
+func NewBuilderWithFreq(freq time.Duration) resolver.Builder {
+	return &dnsBuilder{freq: freq}
 }
 
 type dnsBuilder struct {


### PR DESCRIPTION
In our use case of the resolver, we'd like to be able to specify the frequency of pulling the DNS server. Currently there's only one value allowed, which is kind of limiting.