### PR TITLE
grpclb: minor fixes on comments and tests

### DIFF
--- a/balancer/grpclb/grpclb.go
+++ b/balancer/grpclb/grpclb.go
@@ -16,7 +16,11 @@
  *
  */
 
-package grpclb // import "google.golang.org/grpc/balancer/grpclb"
+// Package grpclb defines a grpclb balancer.
+//
+// To install grpclb balancer, import this package as:
+//    import _ "google.golang.org/grpc/balancer/grpclb"
+package grpclb
 
 import (
 	"strconv"

--- a/balancer/grpclb/grpclb_test.go
+++ b/balancer/grpclb/grpclb_test.go
@@ -340,10 +340,6 @@ func newLoadBalancer(numberOfBackends int) (tss *testServers, cleanup func(), er
 		sn: lbServerName,
 	}
 	lb = grpc.NewServer(grpc.Creds(lbCreds))
-	if err != nil {
-		err = fmt.Errorf("Failed to generate the port number %v", err)
-		return
-	}
 	ls = newRemoteBalancer(nil)
 	lbspb.RegisterLoadBalancerServer(lb, ls)
 	go func() {

--- a/grpclb/noimport.go
+++ b/grpclb/noimport.go
@@ -23,5 +23,5 @@
 package grpclb
 
 func init() {
-	panic("don't import me")
+	panic("Don't import this package. For grpclb, see package google.golang.org/grpc/balancer/grpclb")
 }


### PR DESCRIPTION
* modify noimport.go panic message
* package level comments
* remove useless error check at grpclb_test.go:343
