### PR TITLE
grpclb: remove redundent testing struct

### DIFF
--- a/balancer/grpclb/grpclb_picker.go
+++ b/balancer/grpclb/grpclb_picker.go
@@ -29,7 +29,10 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+// rpcStats is same as lbmpb.ClientStats, except that numCallsDropped is a map
+// instead of a slice.
 type rpcStats struct {
+	// Only access the following fields atomically.
 	numCallsStarted                        int64
 	numCallsFinished                       int64
 	numCallsFinishedWithClientFailedToSend int64


### PR DESCRIPTION
Remove `rpcStatsForTest` and reuse `rpcStats` in tests.

Also fix races: https://travis-ci.org/grpc/grpc-go/jobs/388477002