### PR TITLE
Import grpclb package in the interop client

### DIFF
--- a/interop/client/client.go
+++ b/interop/client/client.go
@@ -24,6 +24,7 @@ import (
 	"strconv"
 
 	"google.golang.org/grpc"
+	_ "google.golang.org/grpc/balancer/grpclb"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/alts"
 	"google.golang.org/grpc/credentials/oauth"


### PR DESCRIPTION
This can allow the interop client to start running in scenarios in which the target is grpclb balanced.

cc @adelez 