### PR TITLE
Don't log grpclb server ending connection as error

### DIFF
--- a/balancer/grpclb/grpclb.go
+++ b/balancer/grpclb/grpclb.go
@@ -25,6 +25,7 @@
 package grpclb
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 	"sync"
@@ -58,6 +59,7 @@ var (
 	defaultBackoffConfig = backoff.Exponential{
 		MaxDelay: 120 * time.Second,
 	}
+	errServerTerminatedConnection = fmt.Errorf("grpclb: failed to recv server list: server terminated connection")
 )
 
 func convertDuration(d *durationpb.Duration) time.Duration {


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc-go/issues/2161

I introduced `serverTerminatedConnectionErr `, because I wanted `callRemoteBalancer` to still returns error on a terminated connections. Its client, which is function `watchRemoteBalancer` can decide how to log this error.

When remote grpclb-server terminates the connection, don't log it as
error. Instead, log it as info.

It is natural for servers to terminate long lived grpc streaming
connections. Two sample reasons to do this are: load balancing and
deployment of a new version. Therefore client of grpclb-server shouldn't
recognise this situation as an error.

