### PR TITLE
grpclb: s/fmt.Errorf/errors.New/

### DIFF
--- a/balancer/grpclb/grpclb.go
+++ b/balancer/grpclb/grpclb.go
@@ -25,7 +25,7 @@
 package grpclb
 
 import (
-	"fmt"
+	"errors"
 	"strconv"
 	"strings"
 	"sync"
@@ -59,7 +59,7 @@ var (
 	defaultBackoffConfig = backoff.Exponential{
 		MaxDelay: 120 * time.Second,
 	}
-	errServerTerminatedConnection = fmt.Errorf("grpclb: failed to recv server list: server terminated connection")
+	errServerTerminatedConnection = errors.New("grpclb: failed to recv server list: server terminated connection")
 )
 
 func convertDuration(d *durationpb.Duration) time.Duration {


### PR DESCRIPTION
Given the discussion at https://github.com/golang/go/issues/17173, this is minor.  However, I do think `errors.New` is more preferable when there is nothing to format from go readability perspective.
