### PR TITLE
internal: changes to travis to make it do less work

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: go
 
 matrix:
   include:
+  - go: 1.10.x
+    env: VET=1 RACE=1
   - go: 1.6.x
   - go: 1.7.x
   - go: 1.8.x
@@ -12,22 +14,21 @@ matrix:
     env: RUN386=1
   - go: 1.10.x
     env: GRPC_GO_RETRY=on
-  - go: 1.10.x
-    env: VET=1 RACE=1
 
 go_import_path: google.golang.org/grpc
 
 before_install:
-  - [[ -n "$RUN386" ]] && export GOARCH=386
-  - [[ "$TRAVIS_EVENT_TYPE" = "cron" ]] && RACE=1
-  - [[ "$TRAVIS_EVENT_TYPE" != "cron" ]] && VET_SKIP_PROTO=1
+  - if [[ -n "$RUN386" ]]; then export GOARCH=386; fi
+  - if [[ "$TRAVIS_EVENT_TYPE" = "cron" ]]; then RACE=1; fi
+  - if [[ "$TRAVIS_EVENT_TYPE" != "cron" ]]; then VET_SKIP_PROTO=1; fi
 
 install:
-  - [[ "$GAE" = 1 ]] && source ./install_gae.sh
-  - [[ "$VET" = 1 ]] && ./vet.sh -install
+  - if [[ "$GAE" = 1 ]]; then source ./install_gae.sh; fi
+  - if [[ "$VET" = 1 ]]; then ./vet.sh -install; fi
 
 script:
-  - if [[ "$GAE" = 1 ]]; then make testappengine; exit; fi
-  - if [[ "$VET" = 1 ]]; then ./vet.sh || exit; fi
-  - make test || exit
-  - [[ "$RACE" = 1 ]] && make testrace
+  - set -e
+  - if [[ "$GAE" = 1 ]]; then make testappengine; exit 0; fi
+  - if [[ "$VET" = 1 ]]; then ./vet.sh; fi
+  - make test
+  - if [[ "$RACE" = 1 ]]; then make testrace; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,30 +1,33 @@
 language: go
 
-go:
-  - 1.6.x
-  - 1.7.x
-  - 1.8.x
-  - 1.9.x
-  - 1.10.x
-
 matrix:
   include:
-  - go: 1.10.x
-    env: RUN386=1
+  - go: 1.6.x
+  - go: 1.7.x
+  - go: 1.8.x
+  - go: 1.9.x
   - go: 1.9.x
     env: GAE=1
   - go: 1.10.x
+    env: RUN386=1
+  - go: 1.10.x
     env: GRPC_GO_RETRY=on
+  - go: 1.10.x
+    env: VET=1 RACE=1
 
 go_import_path: google.golang.org/grpc
 
 before_install:
-  - if [[ -n "$RUN386" ]]; then export GOARCH=386; fi
-  - if [[ "$TRAVIS_GO_VERSION" = 1.10* && "$GOARCH" != "386" ]]; then ./vet.sh -install || exit 1; fi
-  - if [[ "$GAE" = 1 ]]; then source ./install_gae.sh || exit 1; fi
+  - [[ -n "$RUN386" ]] && export GOARCH=386
+  - [[ "$TRAVIS_EVENT_TYPE" = "cron" ]] && RACE=1
+  - [[ "$TRAVIS_EVENT_TYPE" != "cron" ]] && VET_SKIP_PROTO=1
+
+install:
+  - [[ "$GAE" = 1 ]] && source ./install_gae.sh
+  - [[ "$VET" = 1 ]] && ./vet.sh -install
 
 script:
-  - if [[ "$TRAVIS_GO_VERSION" = 1.10* && "$GOARCH" != "386" ]]; then ./vet.sh || exit 1; fi
-  - if [[ "$GAE" = 1 ]]; then make testappengine || exit 1; exit 0; fi
-  - make test || exit 1
-  - if [[ "$GOARCH" != "386" ]]; then make testrace; fi
+  - if [[ "$GAE" = 1 ]]; then make testappengine; exit; fi
+  - if [[ "$VET" = 1 ]]; then ./vet.sh || exit; fi
+  - make test || exit
+  - [[ "$RACE" = 1 ]] && make testrace

--- a/vet.sh
+++ b/vet.sh
@@ -15,11 +15,6 @@ die() {
 
 PATH="$GOPATH/bin:$GOROOT/bin:$PATH"
 
-# Check proto in manual runs or cron runs.
-if [[ "$TRAVIS" != "true" || "$TRAVIS_EVENT_TYPE" = "cron" ]]; then
-  check_proto="true"
-fi
-
 if [ "$1" = "-install" ]; then
   go get -d \
     google.golang.org/grpc/...
@@ -29,7 +24,7 @@ if [ "$1" = "-install" ]; then
     honnef.co/go/tools/cmd/staticcheck \
     github.com/client9/misspell/cmd/misspell \
     github.com/golang/protobuf/protoc-gen-go
-  if [[ "$check_proto" = "true" ]]; then
+  if [[ -z "$VET_SKIP_PROTO" ]]; then
     if [[ "$TRAVIS" = "true" ]]; then
       PROTOBUF_VERSION=3.3.0
       PROTOC_FILENAME=protoc-${PROTOBUF_VERSION}-linux-x86_64.zip
@@ -75,7 +70,7 @@ go tool vet -all . 2>&1 | grep -vE '(clientconn|transport\/transport_test).go:.*
 set -o pipefail
 git reset --hard HEAD
 
-if [[ "$check_proto" = "true" ]]; then
+if [[ -z "$VET_SKIP_PROTO" ]]; then
   PATH="/home/travis/bin:$PATH" make proto && \
     git status --porcelain 2>&1 | (! read) || \
     (git status; git --no-pager diff; exit 1)


### PR DESCRIPTION
This PR removes race testing from all travis runs except go1.10 except during nightlies.

|                 | Before* | After** | % Change |
| --------------- | ------- | ------- | -------- |
| Total runtime   | 65m     | 45m     | -31%     |
| Wall-clock time | 21m     | 11.5m   | -45%     |

*: (one random sample I found in our PRs)
**: (latest run on this PR)

Also includes some organization changes (making proper use of `before_install` and `install`) / cleanups in `.travis.yml` to make it easier to understand.  As a result, we now stop unintentionally running `vet` on a second build by accident (go1.10 with retry enabled).