### PR TITLE
balancer: add rpc method to PickOptions

### DIFF
--- a/balancer/balancer.go
+++ b/balancer/balancer.go
@@ -143,7 +143,10 @@ type Builder interface {
 }
 
 // PickOptions contains addition information for the Pick operation.
-type PickOptions struct{}
+type PickOptions struct {
+	// FullMethodName is the full method name of the RPC.
+	FullMethodName string
+}
 
 // DoneInfo contains additional information for done.
 type DoneInfo struct {

--- a/balancer/balancer.go
+++ b/balancer/balancer.go
@@ -144,7 +144,8 @@ type Builder interface {
 
 // PickOptions contains addition information for the Pick operation.
 type PickOptions struct {
-	// FullMethodName is the full method name of the RPC.
+	// FullMethodName is the method name that NewClientStream() is called
+	// with. The canonical format is /service/Method.
 	FullMethodName string
 }
 

--- a/clientconn.go
+++ b/clientconn.go
@@ -1051,8 +1051,10 @@ func (cc *ClientConn) GetMethodConfig(method string) MethodConfig {
 	return m
 }
 
-func (cc *ClientConn) getTransport(ctx context.Context, failfast bool) (transport.ClientTransport, func(balancer.DoneInfo), error) {
-	t, done, err := cc.blockingpicker.pick(ctx, failfast, balancer.PickOptions{})
+func (cc *ClientConn) getTransport(ctx context.Context, failfast bool, method string) (transport.ClientTransport, func(balancer.DoneInfo), error) {
+	t, done, err := cc.blockingpicker.pick(ctx, failfast, balancer.PickOptions{
+		FullMethodName: method,
+	})
 	if err != nil {
 		return nil, nil, toRPCErr(err)
 	}

--- a/stream.go
+++ b/stream.go
@@ -311,7 +311,7 @@ func (cs *clientStream) newAttemptLocked(sh stats.Handler, trInfo traceInfo) err
 	if err := cs.ctx.Err(); err != nil {
 		return toRPCErr(err)
 	}
-	t, done, err := cs.cc.getTransport(cs.ctx, cs.callInfo.failFast)
+	t, done, err := cs.cc.getTransport(cs.ctx, cs.callInfo.failFast, cs.callHdr.Method)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Provide additional context to Pickers that wish to make decisions based on the RPC method.

Relevant issue: https://github.com/grpc/grpc-go/issues/2103