### PR TITLE
Convert io.ErrUnexpectedEOF to a codes.Internal-marked status in toRPCerr.

### DIFF
--- a/go16.go
+++ b/go16.go
@@ -50,6 +50,9 @@ func toRPCErr(err error) error {
 	if err == nil || err == io.EOF {
 		return err
 	}
+	if err == io.ErrUnexpectedEOF {
+		return status.Error(codes.Internal, err.Error())
+	}
 	if _, ok := status.FromError(err); ok {
 		return err
 	}

--- a/go17.go
+++ b/go17.go
@@ -51,6 +51,9 @@ func toRPCErr(err error) error {
 	if err == nil || err == io.EOF {
 		return err
 	}
+	if err == io.ErrUnexpectedEOF {
+		return status.Error(codes.Internal, err.Error())
+	}
 	if _, ok := status.FromError(err); ok {
 		return err
 	}

--- a/rpc_util_test.go
+++ b/rpc_util_test.go
@@ -179,6 +179,7 @@ func TestToRPCErr(t *testing.T) {
 	}{
 		{transport.StreamError{Code: codes.Unknown, Desc: ""}, status.Error(codes.Unknown, "")},
 		{transport.ErrConnClosing, status.Error(codes.Unavailable, transport.ErrConnClosing.Desc)},
+		{io.ErrUnexpectedEOF, status.Error(codes.Internal, io.ErrUnexpectedEOF.Error())},
 	} {
 		err := toRPCErr(test.errIn)
 		if _, ok := status.FromError(err); !ok {


### PR DESCRIPTION
This is consistent with how io.ErrUnexpectedEOF is handled in a bunch of
other places (e.g. stream.go, server.go), and signals to
application-level code that the error is retryable.