### PR TITLE
disable go1.6 travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ matrix:
   include:
   - go: 1.10.x
     env: VET=1 RACE=1
-  - go: 1.6.x
   - go: 1.7.x
   - go: 1.8.x
   - go: 1.9.x


### PR DESCRIPTION
This can be reverted when https://github.com/golang/go/issues/26576 is resolved.