### PR TITLE
internal: remove TestingUseHandlerImpl

### DIFF
--- a/internal/internal.go
+++ b/internal/internal.go
@@ -21,14 +21,6 @@
 package internal
 
 var (
-
-	// TestingUseHandlerImpl enables the http.Handler-based server implementation.
-	// It must be called before Serve and requires TLS credentials.
-	//
-	// The provided grpcServer must be of type *grpc.Server. It is untyped
-	// for circular dependency reasons.
-	TestingUseHandlerImpl func(grpcServer interface{})
-
 	// WithContextDialer is exported by clientconn.go
 	WithContextDialer interface{} // func(context.Context, string) (net.Conn, error) grpc.DialOption
 	// WithResolverBuilder is exported by clientconn.go

--- a/internal/transport/handler_server.go
+++ b/internal/transport/handler_server.go
@@ -442,5 +442,8 @@ func mapRecvMsgError(err error) error {
 			return status.Error(code, se.Error())
 		}
 	}
+	if strings.Contains(err.Error(), "body closed by handler") {
+		return status.Error(codes.Canceled, err.Error())
+	}
 	return connectionErrorf(true, err, err.Error())
 }

--- a/internal/transport/handler_server.go
+++ b/internal/transport/handler_server.go
@@ -237,9 +237,9 @@ func (ht *serverHandlerTransport) WriteStatus(s *Stream, st *status.Status) erro
 		if ht.stats != nil {
 			ht.stats.HandleRPC(s.Context(), &stats.OutTrailer{})
 		}
-		ht.Close()
 		close(ht.writes)
 	}
+	ht.Close()
 	return err
 }
 
@@ -326,11 +326,11 @@ func (ht *serverHandlerTransport) HandleStreams(startStream func(*Stream), trace
 	go func() {
 		select {
 		case <-requestOver:
-			return
 		case <-ht.closedCh:
 		case <-clientGone:
 		}
 		cancel()
+		ht.Close()
 	}()
 
 	req := ht.req

--- a/test/channelz_test.go
+++ b/test/channelz_test.go
@@ -42,7 +42,7 @@ import (
 func (te *test) startServers(ts testpb.TestServiceServer, num int) {
 	for i := 0; i < num; i++ {
 		te.startServer(ts)
-		te.srvs = append(te.srvs, te.srv)
+		te.srvs = append(te.srvs, te.srv.(*grpc.Server))
 		te.srvAddrs = append(te.srvAddrs, te.srvAddr)
 		te.srv = nil
 		te.srvAddr = ""

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -634,14 +634,20 @@ func (te *test) listenAndServe(ts testpb.TestServiceServer, listen func(network,
 		hs := &http.Server{
 			Handler: s,
 		}
-		err := http2.ConfigureServer(hs, &http2.Server{
+		err = http2.ConfigureServer(hs, &http2.Server{
 			MaxConcurrentStreams: te.maxStream,
 		})
 		if err != nil {
-			te.t.Fatalf("error starting http2 server")
+			te.t.Fatal("error starting http2 server: ", err)
 		}
 
-		go hs.ServeTLS(lis, testdata.Path("server1.pem"), testdata.Path("server1.key"))
+		cert, err := tls.LoadX509KeyPair(testdata.Path("server1.pem"), testdata.Path("server1.key"))
+		if err != nil {
+			te.t.Fatal("Error creating TLS certificate: ", err)
+		}
+		hs.TLSConfig.Certificates = []tls.Certificate{cert}
+		tlsListener := tls.NewListener(lis, hs.TLSConfig)
+		go hs.Serve(tlsListener)
 
 		te.srv = (*wrapHS)(hs)
 		return lis

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -673,6 +673,7 @@ func (w *wrapHS) Accept() (net.Conn, error) {
 	}
 	w.Lock()
 	if w.conns == nil {
+		w.Unlock()
 		c.Close()
 		return nil, errors.New("connection after listener closed")
 	}

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -646,7 +646,7 @@ func (te *test) listenAndServe(ts testpb.TestServiceServer, listen func(network,
 		}
 		hs.TLSConfig.Certificates = []tls.Certificate{cert}
 		tlsListener := tls.NewListener(lis, hs.TLSConfig)
-		whs := &wrapHS{sync.Mutex{}, tlsListener, hs, make(map[net.Conn]bool)}
+		whs := &wrapHS{Listener: tlsListener, s: hs, conns: make(map[net.Conn]bool)}
 		te.srv = whs
 		go hs.Serve(whs)
 
@@ -677,7 +677,7 @@ func (w *wrapHS) Accept() (net.Conn, error) {
 		c.Close()
 		return nil, errors.New("connection after listener closed")
 	}
-	w.conns[&wrapConn{c, w}] = true
+	w.conns[&wrapConn{Conn: c, hs: w}] = true
 	w.Unlock()
 	return c, nil
 }

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -631,6 +631,10 @@ func (te *test) listenAndServe(ts testpb.TestServiceServer, listen func(network,
 		if te.e.security != "tls" {
 			te.t.Fatalf("unsupported environment settings")
 		}
+		cert, err := tls.LoadX509KeyPair(testdata.Path("server1.pem"), testdata.Path("server1.key"))
+		if err != nil {
+			te.t.Fatal("Error creating TLS certificate: ", err)
+		}
 		hs := &http.Server{
 			Handler: s,
 		}
@@ -639,11 +643,6 @@ func (te *test) listenAndServe(ts testpb.TestServiceServer, listen func(network,
 		})
 		if err != nil {
 			te.t.Fatal("error starting http2 server: ", err)
-		}
-
-		cert, err := tls.LoadX509KeyPair(testdata.Path("server1.pem"), testdata.Path("server1.key"))
-		if err != nil {
-			te.t.Fatal("Error creating TLS certificate: ", err)
 		}
 		hs.TLSConfig.Certificates = []tls.Certificate{cert}
 		tlsListener := tls.NewListener(lis, hs.TLSConfig)


### PR DESCRIPTION
This facility isn't actually necessary if we start an `http.Server` the way a user would.  This exercise also led to a bug fix in the handler transport that results in a goroutine leak in some error + race conditions.