### PR TITLE
credentials/alts: add ALTS AuthInfoFromPeer API

### DIFF
--- a/credentials/alts/utils.go
+++ b/credentials/alts/utils.go
@@ -128,16 +128,16 @@ func AuthInfoFromContext(ctx context.Context) (AuthInfo, error) {
 	if !ok {
 		return nil, errors.New("no Peer found in Context")
 	}
-	return AuthInfoFromPeer(*p)
+	return AuthInfoFromPeer(p)
 }
 
 // AuthInfoFromPeer extracts the alts.AuthInfo object from the given peer, if it
 // exists. This API should be used by gRPC clients after obtaining a peer object
 // using the grpc.Peer() CallOption.
-func AuthInfoFromPeer(p peer.Peer) (AuthInfo, error) {
+func AuthInfoFromPeer(p *peer.Peer) (AuthInfo, error) {
 	altsAuthInfo, ok := p.AuthInfo.(AuthInfo)
 	if !ok {
-		return nil, errors.New("no alts.AuthInfo found in Context")
+		return nil, errors.New("no alts.AuthInfo found in Peer")
 	}
 	return altsAuthInfo, nil
 }

--- a/credentials/alts/utils.go
+++ b/credentials/alts/utils.go
@@ -124,11 +124,18 @@ func readManufacturer() ([]byte, error) {
 // information about the communicating peer. For client-side, use grpc.Peer()
 // CallOption.
 func AuthInfoFromContext(ctx context.Context) (AuthInfo, error) {
-	peer, ok := peer.FromContext(ctx)
+	p, ok := peer.FromContext(ctx)
 	if !ok {
 		return nil, errors.New("no Peer found in Context")
 	}
-	altsAuthInfo, ok := peer.AuthInfo.(AuthInfo)
+	return AuthInfoFromPeer(*p)
+}
+
+// AuthInfoFromPeer extracts the alts.AuthInfo object from the given peer, if it
+// exists. This API should be used by gRPC clients after obtaining a peer object
+// using the grpc.Peer() CallOption.
+func AuthInfoFromPeer(p peer.Peer) (AuthInfo, error) {
+	altsAuthInfo, ok := p.AuthInfo.(AuthInfo)
 	if !ok {
 		return nil, errors.New("no alts.AuthInfo found in Context")
 	}

--- a/credentials/alts/utils_test.go
+++ b/credentials/alts/utils_test.go
@@ -100,12 +100,12 @@ func TestAuthInfoFromContext(t *testing.T) {
 
 func TestAuthInfoFromPeer(t *testing.T) {
 	altsAuthInfo := &fakeALTSAuthInfo{}
-	p := peer.Peer{
+	p := &peer.Peer{
 		AuthInfo: altsAuthInfo,
 	}
 	for _, tc := range []struct {
 		desc    string
-		p       peer.Peer
+		p       *peer.Peer
 		success bool
 		out     AuthInfo
 	}{

--- a/credentials/alts/utils_test.go
+++ b/credentials/alts/utils_test.go
@@ -98,6 +98,34 @@ func TestAuthInfoFromContext(t *testing.T) {
 	}
 }
 
+func TestAuthInfoFromPeer(t *testing.T) {
+	altsAuthInfo := &fakeALTSAuthInfo{}
+	p := peer.Peer{
+		AuthInfo: altsAuthInfo,
+	}
+	for _, tc := range []struct {
+		desc    string
+		p       peer.Peer
+		success bool
+		out     AuthInfo
+	}{
+		{
+			"working case",
+			p,
+			true,
+			altsAuthInfo,
+		},
+	} {
+		authInfo, err := AuthInfoFromPeer(tc.p)
+		if got, want := (err == nil), tc.success; got != want {
+			t.Errorf("%v: AuthInfoFromPeer(_)=(err=nil)=%v, want %v", tc.desc, got, want)
+		}
+		if got, want := authInfo, tc.out; got != want {
+			t.Errorf("%v:, AuthInfoFromPeer(_)=(%v, _), want (%v, _)", tc.desc, got, want)
+		}
+	}
+}
+
 type fakeALTSAuthInfo struct{}
 
 func (*fakeALTSAuthInfo) AuthType() string            { return "" }


### PR DESCRIPTION
This API can be used by the client side after obtaining a peer object using `grpc.Peer` `CallOption`.