### PR TITLE
Check error when calling compressor.Compress

### DIFF
--- a/rpc_util.go
+++ b/rpc_util.go
@@ -533,7 +533,10 @@ func compress(in []byte, cp Compressor, compressor encoding.Compressor) ([]byte,
 	}
 	cbuf := &bytes.Buffer{}
 	if compressor != nil {
-		z, _ := compressor.Compress(cbuf)
+		z, err := compressor.Compress(cbuf)
+		if err != nil {
+			return nil, wrapErr(err)
+		}
 		if _, err := z.Write(in); err != nil {
 			return nil, wrapErr(err)
 		}


### PR DESCRIPTION
Compress can return an error, which was not checked.