### PR TITLE
Travis/Makefile/vet cleanups

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,9 @@ language: go
 matrix:
   include:
   - go: 1.11.x
-    env: VET=1 RACE=1 GO111MODULE=on
+    env: VET=1 GO111MODULE=on
+  - go: 1.11.x
+    env: RACE=1 GO111MODULE=on
   - go: 1.11.x
     env: RUN386=1
   - go: 1.11.x
@@ -18,18 +20,19 @@ matrix:
 go_import_path: google.golang.org/grpc
 
 before_install:
-  - if [[ "$GO111MODULE" = "on" ]]; then mkdir "$HOME/go"; export GOPATH="$HOME/go"; fi
-  - if [[ -n "$RUN386" ]]; then export GOARCH=386; fi
-  - if [[ "$TRAVIS_EVENT_TYPE" = "cron" && -z "$RUN386" ]]; then RACE=1; fi
-  - if [[ "$TRAVIS_EVENT_TYPE" != "cron" ]]; then VET_SKIP_PROTO=1; fi
+  - if [[ "${GO111MODULE}" = "on" ]]; then mkdir "${HOME}/go"; export GOPATH="${HOME}/go"; fi
+  - if [[ -n "${RUN386}" ]]; then export GOARCH=386; fi
+  - if [[ "${TRAVIS_EVENT_TYPE}" = "cron" && -z "${RUN386}" ]]; then RACE=1; fi
+  - if [[ "${TRAVIS_EVENT_TYPE}" != "cron" ]]; then VET_SKIP_PROTO=1; fi
 
 install:
-  - if [[ "$GAE" = 1 ]]; then source ./install_gae.sh; fi
-  - if [[ "$VET" = 1 ]]; then ./vet.sh -install; fi
+  - if [[ "${GO111MODULE}" = "on" ]]; then go mod download; else make testdeps; fi
+  - if [[ "${GAE}" = 1 ]]; then source ./install_gae.sh; fi
+  - if [[ "${VET}" = 1 ]]; then ./vet.sh -install; fi
 
 script:
   - set -e
-  - if [[ "$GAE" = 1 ]]; then make testappengine; exit 0; fi
-  - if [[ "$VET" = 1 ]]; then ./vet.sh; fi
+  - if [[ "${VET}" = 1 ]]; then ./vet.sh; fi
+  - if [[ "${GAE}" = 1 ]]; then make testappengine; exit 0; fi
+  - if [[ "${RACE}" = 1 ]]; then make testrace; exit 0; fi
   - make test
-  - if [[ "$RACE" = 1 ]]; then make testrace; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ before_install:
 
 install:
   - if [[ "${GO111MODULE}" = "on" ]]; then go mod download; else make testdeps; fi
-  - if [[ "${GAE}" = 1 ]]; then source ./install_gae.sh; fi
+  - if [[ "${GAE}" = 1 ]]; then source ./install_gae.sh; make testappenginedeps; fi
   - if [[ "${VET}" = 1 ]]; then ./vet.sh -install; fi
 
 script:

--- a/Makefile
+++ b/Makefile
@@ -19,14 +19,14 @@ proto:
 test: testdeps
 	go test -cpu 1,4 -timeout 5m google.golang.org/grpc/...
 
-testappengine: testgaedeps
+testappengine: testappenginedeps
 	goapp test -cpu 1,4 -timeout 5m google.golang.org/grpc/...
+
+testappenginedeps:
+	goapp get -d -v -t -tags 'appengine appenginevm' google.golang.org/grpc/...
 
 testdeps:
 	go get -d -v -t google.golang.org/grpc/...
-
-testgaedeps:
-	goapp get -d -v -t -tags 'appengine appenginevm' google.golang.org/grpc/...
 
 testrace: testdeps
 	go test -race -cpu 1,4 -timeout 7m google.golang.org/grpc/...
@@ -51,8 +51,8 @@ vetdeps:
 	proto \
 	test \
 	testappengine \
+	testappenginedeps \
 	testdeps \
-	testgaedeps \
 	testrace \
 	updatedeps \
 	updatetestdeps \

--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,13 @@
-all: vet test testrace
-
-deps:
-	go get -d -v google.golang.org/grpc/...
-
-updatedeps:
-	go get -d -v -u -f google.golang.org/grpc/...
-
-testdeps:
-	go get -d -v -t google.golang.org/grpc/...
-
-testgaedeps:
-	goapp get -d -v -t -tags 'appengine appenginevm' google.golang.org/grpc/...
-
-updatetestdeps:
-	go get -d -v -t -u -f google.golang.org/grpc/...
+all: vet test testrace testappengine
 
 build: deps
 	go build google.golang.org/grpc/...
+
+clean:
+	go clean -i google.golang.org/grpc/...
+
+deps:
+	go get -d -v google.golang.org/grpc/...
 
 proto:
 	@ if ! which protoc > /dev/null; then \
@@ -25,31 +16,45 @@ proto:
 	fi
 	go generate google.golang.org/grpc/...
 
-vet:
-	./vet.sh
-
 test: testdeps
 	go test -cpu 1,4 -timeout 5m google.golang.org/grpc/...
-
-testrace: testdeps
-	go test -race -cpu 1,4 -timeout 7m google.golang.org/grpc/...
 
 testappengine: testgaedeps
 	goapp test -cpu 1,4 -timeout 5m google.golang.org/grpc/...
 
-clean:
-	go clean -i google.golang.org/grpc/...
+testdeps:
+	go get -d -v -t google.golang.org/grpc/...
+
+testgaedeps:
+	goapp get -d -v -t -tags 'appengine appenginevm' google.golang.org/grpc/...
+
+testrace: testdeps
+	go test -race -cpu 1,4 -timeout 7m google.golang.org/grpc/...
+
+updatedeps:
+	go get -d -v -u -f google.golang.org/grpc/...
+
+updatetestdeps:
+	go get -d -v -t -u -f google.golang.org/grpc/...
+
+vet: vetdeps
+	./vet.sh
+
+vetdeps:
+	./vet.sh -install
 
 .PHONY: \
 	all \
+	build \
+	clean \
 	deps \
-	updatedeps \
+	proto \
+	test \
+	testappengine \
 	testdeps \
 	testgaedeps \
-	updatetestdeps \
-	build \
-	proto \
-	vet \
-	test \
 	testrace \
-	clean
+	updatedeps \
+	updatetestdeps \
+	vet \
+	vetdeps


### PR DESCRIPTION
- .travis.yml:
  - Download dependencies at install time
  - Run race and non-race in separate instances
  - Use braces around env var names
- vet.sh:
  - Run `go mod tidy` to keep it tidy
  - Stop filtering transport errors from go/vet output
  - Use braces around env var names
- Makefile:
  - Reorder alphabetically
  - Add "vetdeps" as a dependency of "vet"
  - Add "testappengine" to "all"
