### PR TITLE
encoding/proto: fix codec instead of compressor

### DIFF
--- a/encoding/proto/proto.go
+++ b/encoding/proto/proto.go
@@ -28,7 +28,7 @@ import (
 	"google.golang.org/grpc/encoding"
 )
 
-// Name is the name registered for the proto compressor.
+// Name is the name registered for the proto codec.
 const Name = "proto"
 
 func init() {


### PR DESCRIPTION
Fix `codec` instead of the `compressor` on `proto.Name` comment.
`Name` is uses for `encoding.Codec`, not `encoding.Compressor`.