### PR TITLE
stream: never return errors from CloseSend

### DIFF
--- a/stream.go
+++ b/stream.go
@@ -660,7 +660,14 @@ func (cs *clientStream) CloseSend() error {
 		return nil
 	}
 	cs.sentLast = true
-	op := func(a *csAttempt) error { return a.t.Write(a.s, nil, nil, &transport.Options{Last: true}) }
+	op := func(a *csAttempt) error {
+		a.t.Write(a.s, nil, nil, &transport.Options{Last: true})
+		// Always return nil; io.EOF is the only error that might make sense
+		// instead, but there is no need to signal the client to call RecvMsg
+		// as the only use left for the stream after CloseSend is to call
+		// RecvMsg.  This also matches historical behavior.
+		return nil
+	}
 	cs.withRetry(op, func() { cs.bufferForRetryLocked(0, op) })
 	// We never returned an error here for reasons.
 	return nil


### PR DESCRIPTION
The Write call returns a non-status-package error in the event of a race with the server ending the stream.  This is not allowed by our API or expected by our tests.  Returning a nil even in the event of an error is acceptable, and matches historical behavior.