### PR TITLE
Avoid logging a warning on empty serviceconfig.

### DIFF
--- a/service_config.go
+++ b/service_config.go
@@ -229,6 +229,9 @@ type jsonSC struct {
 }
 
 func parseServiceConfig(js string) (ServiceConfig, error) {
+	if len(js) == 0 {
+		return ServiceConfig{}, fmt.Errorf("no JSON service config provided")
+	}
 	var rsc jsonSC
 	err := json.Unmarshal([]byte(js), &rsc)
 	if err != nil {


### PR DESCRIPTION
When using plain "A" records for service discovery, there is no JSON
service config available in DNS. Right now this logs a message at
warning level on every startup. This change short-circuits that case so
no spurious warning message is logged.