### PR TITLE
tests: fix goroutine leak

### DIFF
--- a/clientconn_test.go
+++ b/clientconn_test.go
@@ -731,6 +731,12 @@ func (b backoffForever) Backoff(int) time.Duration { return time.Duration(math.M
 func TestResetConnectBackoff(t *testing.T) {
 	defer leakcheck.Check(t)
 	dials := make(chan struct{})
+	defer func() { // If we fail, let the http2client break out of dialing.
+		select {
+		case <- dials:
+		default:
+		}
+	}()
 	dialer := func(string, time.Duration) (net.Conn, error) {
 		dials <- struct{}{}
 		return nil, errors.New("failed to fake dial")


### PR DESCRIPTION
If TestResetConnectBackoff fails, the resetTransport goroutine will be
stuck dialing and subsequently the goroutine will be leaked. This is
all despite the test including `defer cc.Close()`:

- defer cc.Close() will cause ac.cancel to be called
- ac.context will be appropriately cancelled
- ac.context is correctly the context that gets passed to the dialer
- However, the WithDialer throws away the context and only passes its
deadline, which is for `backoffForever{}` is math.MaxInt64. So, even
though teardown occurs, the resetTransport goroutine will still be
stuck dialing.

This CL adds a small amendment: before performing leakcheck, attempt
to take an item off the synchronous `dials` channel. Either the tests
passed and there is no item, or the tests failed and there is one.