### PR TITLE
tests: fix leak in TestDialParseTargetUnknownScheme

### DIFF
--- a/resolver_conn_wrapper_test.go
+++ b/resolver_conn_wrapper_test.go
@@ -98,7 +98,10 @@ func TestDialParseTargetUnknownScheme(t *testing.T) {
 	} {
 		dialStrCh := make(chan string, 1)
 		cc, err := Dial(test.targetStr, WithInsecure(), WithDialer(func(t string, _ time.Duration) (net.Conn, error) {
-			dialStrCh <- t
+			select {
+			case dialStrCh <- t:
+			default:
+			}
 			return nil, fmt.Errorf("test dialer, always error")
 		}))
 		if err != nil {

--- a/resolver_conn_wrapper_test.go
+++ b/resolver_conn_wrapper_test.go
@@ -97,9 +97,9 @@ func TestDialParseTargetUnknownScheme(t *testing.T) {
 		{"passthrough://a.server.com/google.com", "google.com"},
 	} {
 		dialStrCh := make(chan string, 1)
-		cc, err := Dial(test.targetStr, WithInsecure(), WithDialer(func(t string, _ time.Duration) (net.Conn, error) {
+		cc, err := Dial(test.targetStr, WithInsecure(), WithDialer(func(addr string, _ time.Duration) (net.Conn, error) {
 			select {
-			case dialStrCh <- t:
+			case dialStrCh <- addr:
 			default:
 			}
 			return nil, fmt.Errorf("test dialer, always error")


### PR DESCRIPTION
Do a non-blocking send so if dial is called again in a retry, it won't block forever.