### PR TITLE
internal: fix uninitialized mutex

### DIFF
--- a/internal/transport/transport_test.go
+++ b/internal/transport/transport_test.go
@@ -2029,7 +2029,7 @@ func setUpHTTPStatusTest(t *testing.T, httpStatus int, wh writeHeaders) (stream 
 		err    error
 		lis    net.Listener
 		server *httpServer
-		client ClientTransport
+		client *http2Client
 	)
 	cleanUp = func() {
 		if lis != nil {


### PR DESCRIPTION
Found this while running `TestHTTPToGRPCStatusMapping` 10,000 times. The SIGSEV is pretty rare, but it seems like a no-brainer fix (init the mutex)?

```
=== RUN   TestHTTPToGRPCStatusMapping
--- FAIL: TestHTTPToGRPCStatusMapping (2.01s)
    transport_test.go:2070: Error creating client. Err: connection error: desc = "transport: Error while dialing dial tcp 127.0.0.1:58187: i/o timeout"
    transport_test.go:1989: Error accepting connection: accept tcp 127.0.0.1:58187: use of closed network connection
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x150a97b]

goroutine 52455 [running]:
testing.tRunner.func1(0xc000344200)
	/usr/local/go/src/testing/testing.go:792 +0x6a7
panic(0x15cd420, 0x19f75c0)
	/usr/local/go/src/runtime/panic.go:513 +0x1b9
google.golang.org/grpc/internal/transport.(*http2Client).Close(0x0, 0x0, 0x0)
	/Users/deklerk/workspace/go/src/google.golang.org/grpc/internal/transport/http2_client.go:739 +0x4b
google.golang.org/grpc/internal/transport.setUpHTTPStatusTest.func1()
	/Users/deklerk/workspace/go/src/google.golang.org/grpc/internal/transport/transport_test.go:2048 +0xc8
google.golang.org/grpc/internal/transport.setUpHTTPStatusTest.func2(0xc0004dbd10, 0xc0004dbe48)
	/Users/deklerk/workspace/go/src/google.golang.org/grpc/internal/transport/transport_test.go:2053 +0x6e
runtime.Goexit()
	/usr/local/go/src/runtime/panic.go:397 +0xef
testing.(*common).FailNow(0xc000344200)
	/usr/local/go/src/testing/testing.go:590 +0x5b
testing.(*common).Fatalf(0xc000344200, 0x164426c, 0x1e, 0xc0004dbd30, 0x1, 0x1)
	/usr/local/go/src/testing/testing.go:634 +0x95
google.golang.org/grpc/internal/transport.setUpHTTPStatusTest(0xc000344200, 0x191, 0x16555d8, 0x0, 0xc00046e2c0)
	/Users/deklerk/workspace/go/src/google.golang.org/grpc/internal/transport/transport_test.go:2070 +0xaab
google.golang.org/grpc/internal/transport.testHTTPToGRPCStatusMapping(0xc000344200, 0x191, 0x16555d8)
	/Users/deklerk/workspace/go/src/google.golang.org/grpc/internal/transport/transport_test.go:2087 +0x6b
google.golang.org/grpc/internal/transport.TestHTTPToGRPCStatusMapping(0xc000344200)
	/Users/deklerk/workspace/go/src/google.golang.org/grpc/internal/transport/transport_test.go:2082 +0xcf
testing.tRunner(0xc000344200, 0x1655340)
	/usr/local/go/src/testing/testing.go:827 +0x163
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:878 +0x651
FAIL	google.golang.org/grpc/internal/transport	46.340s
```