### PR TITLE
internal: fix go1.6 tests

### DIFF
--- a/internal/transport/transport_test.go
+++ b/internal/transport/transport_test.go
@@ -2056,13 +2056,15 @@ func setUpHTTPStatusTest(t *testing.T, httpStatus int, wh writeHeaders) (stream 
 		wh:         wh,
 	}
 	server.start(t, lis)
+	// TODO(deklerk): we can `defer cancel()` here after we drop Go 1.6 support. Until then,
+	// doing a `defer cancel()` could cause the dialer to become broken:
+	// https://github.com/golang/go/issues/15078, https://github.com/golang/go/issues/15035
 	connectCtx, cancel := context.WithDeadline(context.Background(), time.Now().Add(2*time.Second))
 	client, err = newHTTP2Client(connectCtx, context.Background(), TargetInfo{Addr: lis.Addr().String()}, ConnectOptions{}, func() {}, func(GoAwayReason) {}, func() {})
 	if err != nil {
 		cancel() // Do not cancel in success path.
 		t.Fatalf("Error creating client. Err: %v", err)
 	}
-	defer cancel()
 	stream, err = client.NewStream(context.Background(), &CallHdr{Method: "bogus/method"})
 	if err != nil {
 		t.Fatalf("Error creating stream at client-side. Err: %v", err)

--- a/vet.sh
+++ b/vet.sh
@@ -80,7 +80,11 @@ golint ./... 2>&1 | (grep -vE "(_mock|\.pb)\.go:" || true) | tee /dev/stderr | (
 # TODO: Remove this mangling once "context" is imported directly (grpc/grpc-go#711).
 git ls-files "*.go" | xargs sed -i 's:"golang.org/x/net/context":"context":'
 set +o pipefail # vet exits with non-zero error if issues are found
+
+# TODO(deklerk) remove when we drop Go 1.6 support
 go tool vet -all . 2>&1 | grep -vE 'clientconn.go:.*cancel (function|var)' | tee /dev/stderr | (! read)
+go tool vet -all . 2>&1 | grep -vE 'transport_test.go:.*cancel (function|var)' | tee /dev/stderr | (! read)
+
 set -o pipefail
 git reset --hard HEAD
 


### PR DESCRIPTION
Commit 35c3afad17f705e725ca04bff658932689920154 added a `defer cancel()` line
to transport_test. While this line is generally good, there happens to be a
Go 1.6 bug that when a context that gets passed into Dial is canceled, it
has a 50% chance to incorrectly causes all future Dial writes to fail.

This PR removes that defer and adds a comment explaining the situation.

https://github.com/golang/go/issues/15078
https://github.com/golang/go/issues/15035