### PR TITLE
internal: fix various problems in transport_test.go

### DIFF
--- a/vet.sh
+++ b/vet.sh
@@ -80,7 +80,14 @@ golint ./... 2>&1 | (grep -vE "(_mock|\.pb)\.go:" || true) | tee /dev/stderr | (
 # TODO: Remove this mangling once "context" is imported directly (grpc/grpc-go#711).
 git ls-files "*.go" | xargs sed -i 's:"golang.org/x/net/context":"context":'
 set +o pipefail # vet exits with non-zero error if issues are found
-go tool vet -all . 2>&1 | grep -vE 'clientconn.go:.*cancel (function|var)' | tee /dev/stderr | (! read)
+
+# TODO(deklerk) remove when we drop Go 1.6 support
+go tool vet -all . 2>&1 | \
+    grep -vE 'clientconn.go:.*cancel (function|var)' | \
+    grep -vE '.*transport_test.go:.*cancel' | \
+    tee /dev/stderr | \
+    (! read)
+
 set -o pipefail
 git reset --hard HEAD
 


### PR DESCRIPTION
Commit 35c3afad17f705e725ca04bff658932689920154 added a `defer cancel()` line
to transport_test. While this line is generally good, there happens to be a
Go 1.6 bug that when a context that gets passed into Dial is canceled, it
has a 50% chance to incorrectly causes all future Dial writes to fail.

This commit removes that defer and adds a comment explaining the situation.

https://github.com/golang/go/issues/15078
https://github.com/golang/go/issues/15035

This commit also fixes a perceived (by the race detector) racy use of
server.conn by making conn.Close happen inside the goroutine that
uses conn.

This commit also fixes a SIGSEV caused by an incorrect typed nil
check.