### PR TITLE
Retry `go get` when it fails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,8 @@ before_install:
   - if [[ "${TRAVIS_EVENT_TYPE}" != "cron" ]]; then VET_SKIP_PROTO=1; fi
 
 install:
-  - if [[ "${GO111MODULE}" = "on" ]]; then go mod download; else make testdeps; fi
+  - try3() { eval "$*" || eval "$*" || eval "$*"; }
+  - try3 'if [[ "${GO111MODULE}" = "on" ]]; then go mod download; else make testdeps; fi'
   - if [[ "${GAE}" = 1 ]]; then source ./install_gae.sh; make testappenginedeps; fi
   - if [[ "${VET}" = 1 ]]; then ./vet.sh -install; fi
 


### PR DESCRIPTION
Open for discussion.  We seem to be having a lot of transient travis failures when just downloading packages lately.