### PR TITLE
Fix onclose state transition

### DIFF
--- a/clientconn.go
+++ b/clientconn.go
@@ -967,10 +967,12 @@ func (ac *addrConn) resetTransport(resolveNow bool) {
 			return
 		}
 
-		// If we're at the beginning of the address list
-		// And we didn't just see a successful handshake
-		// And it's not the very first addr to try (covered by the above if)
-		if ac.addrIdx == len(ac.addrs)-1 && !ac.successfulHandshake {
+		// If the connection is READY, we must have failed to get here
+		// Otherwise, we'll consider this is a transient failure when:
+		//   We've exhausted all addresses
+		//   We're in CONNECTING
+		//   And it's not the very first addr to try TODO(deklerk) find a better way to do this than checking ac.successfulHandshake
+		if ac.state == connectivity.Ready || (ac.addrIdx == len(ac.addrs)-1 && ac.state == connectivity.Connecting && !ac.successfulHandshake) {
 			ac.updateConnectivityState(connectivity.TransientFailure)
 			ac.cc.handleSubConnStateChange(ac.acbw, ac.state)
 		}

--- a/clientconn.go
+++ b/clientconn.go
@@ -967,7 +967,7 @@ func (ac *addrConn) resetTransport(resolveNow bool) {
 			return
 		}
 
-		// If the connection is READY, we must have failed to get here
+		// If the connection is READY, a failure must have occurred.
 		// Otherwise, we'll consider this is a transient failure when:
 		//   We've exhausted all addresses
 		//   We're in CONNECTING

--- a/clientconn_test.go
+++ b/clientconn_test.go
@@ -917,10 +917,16 @@ func TestDialCloseStateTransition(t *testing.T) {
 	// when the client has progressed past the first failure (which does not get backoff, because handshake was
 	// successful).
 	close(killFirstConnection)
-	client.WaitForStateChange(ctx, connectivity.Ready)
-	client.WaitForStateChange(ctx, connectivity.Connecting)
+	if !client.WaitForStateChange(ctx, connectivity.Ready) {
+		t.Fatal("expected WaitForStateChange to change state, but it timed out")
+	}
+	if !client.WaitForStateChange(ctx, connectivity.Connecting) {
+		t.Fatal("expected WaitForStateChange to change state, but it timed out")
+	}
 	<-backoffCaseReady
-	client.WaitForStateChange(ctx, connectivity.Connecting)
+	if !client.WaitForStateChange(ctx, connectivity.Connecting) {
+		t.Fatal("expected WaitForStateChange to change state, but it timed out")
+	}
 	if got, want := client.GetState(), connectivity.TransientFailure; got != want {
 		t.Fatalf("expected addrconn state to be %v, was %v", want, got)
 	}
@@ -947,7 +953,9 @@ func TestDialCloseStateTransition(t *testing.T) {
 	// The connection should be killed shortly by the above goroutine, and here we watch for the first new connectivity
 	// state and make sure it's TRANSIENT FAILURE. This is racy, but fairly accurate - expect it to catch failures
 	// 90% of the time or so.
-	client.WaitForStateChange(ctx, connectivity.Connecting)
+	if !client.WaitForStateChange(ctx, connectivity.Connecting) {
+		t.Fatal("expected WaitForStateChange to change state, but it timed out")
+	}
 	if got, want := client.GetState(), connectivity.TransientFailure; got != want {
 		t.Fatalf("expected addrconn state to be %v, was %v", want, got)
 	}

--- a/clientconn_test.go
+++ b/clientconn_test.go
@@ -833,8 +833,7 @@ func TestDialCloseStateTransition(t *testing.T) {
 	}
 	defer lis.Close()
 	testFinished := make(chan struct{})
-	backoffCaseReady := make(chan struct{}, 1)
-	defer close(backoffCaseReady)
+	backoffCaseReady := make(chan struct{})
 	killFirstConnection := make(chan struct{})
 	killSecondConnection := make(chan struct{})
 
@@ -880,7 +879,7 @@ func TestDialCloseStateTransition(t *testing.T) {
 		}
 
 		// The client should now be headed towards backoff.
-		backoffCaseReady <- struct{}{}
+		close(backoffCaseReady)
 
 		// Re-connect (without server preface).
 		conn, err = lis.Accept()
@@ -923,9 +922,6 @@ func TestDialCloseStateTransition(t *testing.T) {
 		t.Fatal("expected WaitForStateChange to change state, but it timed out")
 	}
 	if !client.WaitForStateChange(ctx, connectivity.TransientFailure) {
-		t.Fatal("expected WaitForStateChange to change state, but it timed out")
-	}
-	if !client.WaitForStateChange(ctx, connectivity.Connecting) {
 		t.Fatal("expected WaitForStateChange to change state, but it timed out")
 	}
 	<-backoffCaseReady

--- a/test/channelz_test.go
+++ b/test/channelz_test.go
@@ -1342,8 +1342,8 @@ func TestCZSubChannelTraceCreationDeletion(t *testing.T) {
 		if len(scm.Trace.Events) == 0 {
 			return false, fmt.Errorf("there should be at least one trace event for subChannel not 0")
 		}
-		if scm.Trace.Events[len(scm.Trace.Events)-1].Desc != "Subchannel Deleted" {
-			return false, fmt.Errorf("the first trace event should be \"Subchannel Deleted\", not %q", scm.Trace.Events[0].Desc)
+		if got, want := scm.Trace.Events[len(scm.Trace.Events)-1].Desc, "Subchannel Deleted"; got != want {
+			return false, fmt.Errorf("the last trace event should be \"%s\", not %q", want, got)
 		}
 
 		return true, nil

--- a/test/channelz_test.go
+++ b/test/channelz_test.go
@@ -1343,7 +1343,7 @@ func TestCZSubChannelTraceCreationDeletion(t *testing.T) {
 			return false, fmt.Errorf("there should be at least one trace event for subChannel not 0")
 		}
 		if got, want := scm.Trace.Events[len(scm.Trace.Events)-1].Desc, "Subchannel Deleted"; got != want {
-			return false, fmt.Errorf("the last trace event should be \"%s\", not %q", want, got)
+			return false, fmt.Errorf("the last trace event should be %q, not %q", want, got)
 		}
 
 		return true, nil


### PR DESCRIPTION
When onClose occurs during WaitForHandshake, it should immediately
exit createTransport instead of leaving CONNECTING and entering READY.

Furthermore, when any onClose happens, the state should change to
TRANSIENT FAILURE.

Fixes #2340
Fixes #2341

Also fixes an unreported bug in which entering READY causes a
Dial call to end prematurely, instead of blocking until a READY
transport is found.