### PR TITLE
refactor variable name

### DIFF
--- a/health/health.go
+++ b/health/health.go
@@ -55,9 +55,9 @@ func (s *Server) Check(ctx context.Context, in *healthpb.HealthCheckRequest) (*h
 			Status: healthpb.HealthCheckResponse_SERVING,
 		}, nil
 	}
-	if status, ok := s.statusMap[in.Service]; ok {
+	if servingStatus, ok := s.statusMap[in.Service]; ok {
 		return &healthpb.HealthCheckResponse{
-			Status: status,
+			Status: servingStatus,
 		}, nil
 	}
 	return nil, status.Error(codes.NotFound, "unknown service")


### PR DESCRIPTION
Refactor `status` variable name to `servingStatus` to avoid the complaint from Goland IDE about name conflict from the `status` package.