### PR TITLE
replace scStateUpdateBuffer with a general purpose buffer that uses interface{} 

### DIFF
--- a/server.go
+++ b/server.go
@@ -1016,11 +1016,11 @@ func (s *Server) processStreamingRPC(t transport.ServerTransport, stream *transp
 	}
 	ctx := NewContextWithServerTransportStream(stream.Context(), stream)
 	ss := &serverStream{
-		ctx:                   ctx,
-		t:                     t,
-		s:                     stream,
-		p:                     &parser{r: stream},
-		codec:                 s.getCodec(stream.ContentSubtype()),
+		ctx:   ctx,
+		t:     t,
+		s:     stream,
+		p:     &parser{r: stream},
+		codec: s.getCodec(stream.ContentSubtype()),
 		maxReceiveMessageSize: s.opts.maxReceiveMessageSize,
 		maxSendMessageSize:    s.opts.maxSendMessageSize,
 		trInfo:                trInfo,
@@ -1170,7 +1170,7 @@ func (s *Server) handleStream(t transport.ServerTransport, stream *transport.Str
 		trInfo.tr.SetError()
 	}
 	if unknownDesc := s.opts.unknownStreamDesc; unknownDesc != nil {
-		s.processStreamingRPC(t, stream, nil, unknownDesc, trInfo)
+		s.processStreamingRPC(t, stream, srv, unknownDesc, trInfo)
 		return
 	}
 	errDesc := fmt.Sprintf("unknown method %v", method)


### PR DESCRIPTION
replace scStateUpdateBuffer with a general purpose buffer that uses interface{} 