### PR TITLE
clientconn: not panic when service config updated while closing

### DIFF
--- a/clientconn.go
+++ b/clientconn.go
@@ -747,6 +747,13 @@ func (cc *ClientConn) handleServiceConfig(js string) error {
 		return err
 	}
 	cc.mu.Lock()
+	// Check if the ClientConn is already closed. Some fields (e.g.
+	// balancerWrapper) are set to nil when closing the ClientConn, and could
+	// cause nil pointer panic if we don't have this check.
+	if cc.conns == nil {
+		cc.mu.Unlock()
+		return nil
+	}
 	cc.scRaw = js
 	cc.sc = sc
 


### PR DESCRIPTION
Closing `ClientConn` sets `balancerWrapper` to nil.
If service config switches balancer, the new balancer will be notified of the existing addresses.

When these two happens together, there's a chance that a method will be called on the nil `balancerWrapper`. This change adds a check to make sure that never happens. 

fixes #2367