### PR TITLE
internal: fix client send preface problems

### DIFF
--- a/clientconn.go
+++ b/clientconn.go
@@ -1059,6 +1059,10 @@ func (ac *addrConn) createTransport(backoffNum int, addr resolver.Address, copts
 	prefaceReceived := make(chan struct{})
 	onCloseCalled := make(chan struct{})
 
+	var prefaceMu sync.Mutex
+	var serverPrefaceReceived bool
+	var clientPrefaceWrote bool
+
 	onGoAway := func(r transport.GoAwayReason) {
 		ac.mu.Lock()
 		ac.adjustParams(r)
@@ -1100,11 +1104,18 @@ func (ac *addrConn) createTransport(backoffNum int, addr resolver.Address, copts
 
 		// TODO(deklerk): optimization; does anyone else actually use this lock? maybe we can just remove it for this scope
 		ac.mu.Lock()
-		ac.successfulHandshake = true
-		ac.backoffDeadline = time.Time{}
-		ac.connectDeadline = time.Time{}
-		ac.addrIdx = 0
-		ac.backoffIdx = 0
+
+		prefaceMu.Lock()
+		serverPrefaceReceived = true
+		if clientPrefaceWrote {
+			ac.successfulHandshake = true
+			ac.backoffDeadline = time.Time{}
+			ac.connectDeadline = time.Time{}
+			ac.addrIdx = 0
+			ac.backoffIdx = 0
+		}
+		prefaceMu.Unlock()
+
 		ac.mu.Unlock()
 	}
 
@@ -1117,6 +1128,13 @@ func (ac *addrConn) createTransport(backoffNum int, addr resolver.Address, copts
 	newTr, err := transport.NewClientTransport(connectCtx, ac.cc.ctx, target, copts, onPrefaceReceipt, onGoAway, onClose)
 
 	if err == nil {
+		prefaceMu.Lock()
+		clientPrefaceWrote = true
+		if serverPrefaceReceived {
+			ac.successfulHandshake = true
+		}
+		prefaceMu.Unlock()
+
 		if ac.dopts.waitForHandshake {
 			select {
 			case <-prefaceTimer.C:

--- a/clientconn.go
+++ b/clientconn.go
@@ -1160,8 +1160,6 @@ func (ac *addrConn) createTransport(backoffNum int, addr resolver.Address, copts
 
 			return errConnClosing
 		}
-		ac.updateConnectivityState(connectivity.TransientFailure)
-		ac.cc.handleSubConnStateChange(ac.acbw, ac.state)
 		ac.mu.Unlock()
 		grpclog.Warningf("grpc: addrConn.createTransport failed to connect to %v. Err :%v. Reconnecting...", addr, err)
 

--- a/clientconn_state_transition_test.go
+++ b/clientconn_state_transition_test.go
@@ -49,7 +49,6 @@ func TestStateTransitions_SingleAddress(t *testing.T) {
 	defer leakcheck.Check(t)
 
 	mctBkp := getMinConnectTimeout()
-	// Call this only after transportMonitor goroutine has ended.
 	defer func() {
 		atomic.StoreInt64((*int64)(&mutableMinConnectTimeout), int64(mctBkp))
 	}()

--- a/clientconn_state_transition_test.go
+++ b/clientconn_state_transition_test.go
@@ -402,11 +402,7 @@ func TestStateTransitions_MultipleAddrsEntersReady(t *testing.T) {
 // things like client prefaces are not accepted in a timely fashion.
 func keepReading(conn net.Conn) {
 	buf := make([]byte, 1024)
-	for {
-		_, err := conn.Read(buf)
-		if err != nil {
-			return
-		}
+	for _, err := conn.Read(buf); err == nil; _, err = conn.Read(buf) {
 	}
 }
 

--- a/clientconn_state_transition_test.go
+++ b/clientconn_state_transition_test.go
@@ -43,7 +43,7 @@ func init() {
 	balancer.Register(testBalancer)
 }
 
-// These tests use a PipeListener. This listener is similar to net.Listener except that it is unbuffered, so each read
+// These tests use a pipeListener. This listener is similar to net.Listener except that it is unbuffered, so each read
 // and write will wait for the other side's corresponding write or read.
 func TestStateTransitions_SingleAddress(t *testing.T) {
 	defer leakcheck.Check(t)
@@ -101,7 +101,7 @@ func TestStateTransitions_SingleAddress(t *testing.T) {
 			},
 		},
 		{
-			desc: `When the server sends its connection preface, but the connection dies before the client can write its 
+			desc: `When the server sends its connection preface, but the connection dies before the client can write its
 connection preface, the client enters TRANSIENT FAILURE.`,
 			want: []connectivity.State{
 				connectivity.Connecting,
@@ -170,7 +170,7 @@ func testStateTransitionSingleAddress(t *testing.T, want []connectivity.State, s
 		connMu.Unlock()
 	}()
 
-	client, err := DialContext(ctx, pl.Addr().String(), WithWaitForHandshake(), WithInsecure(),
+	client, err := DialContext(ctx, "", WithWaitForHandshake(), WithInsecure(),
 		WithBalancerName(stateRecordingBalancerName), WithDialer(pl.Dialer()), withBackoff(noBackoff{}))
 	if err != nil {
 		t.Fatal(err)

--- a/clientconn_test.go
+++ b/clientconn_test.go
@@ -228,7 +228,6 @@ func TestCloseConnectionWhenServerPrefaceNotReceived(t *testing.T) {
 	// Call this only after transportMonitor goroutine has ended.
 	defer func() {
 		atomic.StoreInt64((*int64)(&mutableMinConnectTimeout), int64(mctBkp))
-
 	}()
 	defer leakcheck.Check(t)
 	atomic.StoreInt64((*int64)(&mutableMinConnectTimeout), int64(time.Millisecond)*500)

--- a/clientconn_test.go
+++ b/clientconn_test.go
@@ -225,7 +225,6 @@ func TestCloseConnectionWhenServerPrefaceNotReceived(t *testing.T) {
 	// 3. The new server sends its preface.
 	// 4. Client doesn't kill the connection this time.
 	mctBkp := getMinConnectTimeout()
-	// Call this only after transportMonitor goroutine has ended.
 	defer func() {
 		atomic.StoreInt64((*int64)(&mutableMinConnectTimeout), int64(mctBkp))
 	}()

--- a/internal/testutils/pipe_listener.go
+++ b/internal/testutils/pipe_listener.go
@@ -1,0 +1,93 @@
+/*
+ *
+ * Copyright 2018 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package testutils
+
+import (
+	"errors"
+	"net"
+	"time"
+)
+
+type pipeAddr struct{}
+
+func (p pipeAddr) Network() string { return "pipe" }
+func (p pipeAddr) String() string  { return "pipe" }
+
+// PipeListener is a listener with an unbuffered pipe. Each write will complete only once the other side reads.
+type PipeListener struct {
+	C    chan chan<- net.Conn
+	done chan struct{}
+}
+
+// NewPipeListener creates a new pipe listener.
+func NewPipeListener() *PipeListener {
+	return &PipeListener{
+		C:    make(chan chan<- net.Conn),
+		done: make(chan struct{}),
+	}
+}
+
+// Accept accepts a connection.
+func (p *PipeListener) Accept() (net.Conn, error) {
+	var connChan chan<- net.Conn
+	select {
+	case <-p.done:
+		return nil, errors.New("done")
+	case connChan = <-p.C:
+	}
+	c1, c2 := net.Pipe()
+	select {
+	case <-p.done:
+		return nil, errors.New("done")
+	case connChan <- c1:
+	}
+	close(connChan)
+	return c2, nil
+}
+
+// Close closes the listener.
+func (p *PipeListener) Close() error {
+	close(p.done)
+	// We don't close p.C, because it races with p.done and may be redundant.
+	// TODO(deklerk) Should we figure out how to synchronize these so that we can close p.C?
+	return nil
+}
+
+// Addr returns a pipe addr.
+func (p *PipeListener) Addr() net.Addr {
+	return pipeAddr{}
+}
+
+// Dialer dials a connection.
+func (p *PipeListener) Dialer() func(string, time.Duration) (net.Conn, error) {
+	return func(string, time.Duration) (net.Conn, error) {
+		connChan := make(chan net.Conn)
+		select {
+		case <-p.done:
+			return nil, errors.New("done")
+		case p.C <- connChan:
+		}
+		select {
+		case <-p.done:
+			return nil, errors.New("done")
+		case conn := <-connChan:
+			return conn, nil
+		}
+	}
+}

--- a/internal/testutils/pipe_listener.go
+++ b/internal/testutils/pipe_listener.go
@@ -24,39 +24,39 @@ import (
 	"time"
 )
 
-var closedErr = errors.New("closed")
+var errClosed = errors.New("closed")
 
 type pipeAddr struct{}
 
 func (p pipeAddr) Network() string { return "pipe" }
 func (p pipeAddr) String() string  { return "pipe" }
 
-// pipeListener is a listener with an unbuffered pipe. Each write will complete only once the other side reads. It
+// PipeListener is a listener with an unbuffered pipe. Each write will complete only once the other side reads. It
 // should only be created using NewPipeListener.
-type pipeListener struct {
-	C chan chan<- net.Conn
+type PipeListener struct {
+	c    chan chan<- net.Conn
 	done chan struct{}
 }
 
 // NewPipeListener creates a new pipe listener.
-func NewPipeListener() *pipeListener {
-	return &pipeListener{
-		C: make(chan chan<- net.Conn),
+func NewPipeListener() *PipeListener {
+	return &PipeListener{
+		c:    make(chan chan<- net.Conn),
 		done: make(chan struct{}),
 	}
 }
 
 // Accept accepts a connection.
-func (p *pipeListener) Accept() (net.Conn, error) {
+func (p *PipeListener) Accept() (net.Conn, error) {
 	var connChan chan<- net.Conn
 	select {
 	case <-p.done:
-		return nil, closedErr
-	case connChan = <-p.C:
+		return nil, errClosed
+	case connChan = <-p.c:
 		select {
 		case <-p.done:
 			close(connChan)
-			return nil, closedErr
+			return nil, errClosed
 		default:
 		}
 	}
@@ -67,28 +67,28 @@ func (p *pipeListener) Accept() (net.Conn, error) {
 }
 
 // Close closes the listener.
-func (p *pipeListener) Close() error {
+func (p *PipeListener) Close() error {
 	close(p.done)
 	return nil
 }
 
 // Addr returns a pipe addr.
-func (p *pipeListener) Addr() net.Addr {
+func (p *PipeListener) Addr() net.Addr {
 	return pipeAddr{}
 }
 
 // Dialer dials a connection.
-func (p *pipeListener) Dialer() func(string, time.Duration) (net.Conn, error) {
+func (p *PipeListener) Dialer() func(string, time.Duration) (net.Conn, error) {
 	return func(string, time.Duration) (net.Conn, error) {
 		connChan := make(chan net.Conn)
 		select {
-		case p.C <- connChan:
+		case p.c <- connChan:
 		case <-p.done:
-			return nil, closedErr
+			return nil, errClosed
 		}
 		conn, ok := <-connChan
 		if !ok {
-			return nil, closedErr
+			return nil, errClosed
 		}
 		return conn, nil
 	}

--- a/internal/testutils/pipe_listener_test.go
+++ b/internal/testutils/pipe_listener_test.go
@@ -1,0 +1,182 @@
+/*
+ *
+ * Copyright 2018 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package testutils_test
+
+import (
+	"testing"
+	"time"
+
+	"google.golang.org/grpc/internal/testutils"
+)
+
+func TestPipeListener(t *testing.T) {
+	pl := testutils.NewPipeListener()
+	recvdBytes := make(chan []byte)
+	want := "hello world"
+
+	go func() {
+		c, err := pl.Accept()
+		if err != nil {
+			t.Error(err)
+		}
+
+		read := make([]byte, len(want))
+		_, err = c.Read(read)
+		if err != nil {
+			t.Error(err)
+		}
+		recvdBytes <- read
+	}()
+
+	dl := pl.Dialer()
+	conn, err := dl("", time.Duration(0))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = conn.Write([]byte(want))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case gotBytes := <-recvdBytes:
+		got := string(gotBytes)
+		if got != want {
+			t.Fatalf("expected to get %s, got %s", got, want)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for server to receive bytes")
+	}
+}
+
+func TestAcceptUnblocksDial(t *testing.T) {
+	pl := testutils.NewPipeListener()
+	dialFinished := make(chan struct{})
+
+	go func() {
+		dl := pl.Dialer()
+		if _, err := dl("", time.Duration(0)); err != nil {
+			t.Error(err)
+		}
+		close(dialFinished)
+	}()
+
+	select {
+	case <-dialFinished:
+		t.Fatal("expected Dial to block until pl.Close or pl.Accept")
+	default:
+	}
+
+	if _, err := pl.Accept(); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case <-dialFinished:
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected Accept to unblock after pl.Accept was called")
+	}
+}
+
+func TestCloseUnblocksDial(t *testing.T) {
+	pl := testutils.NewPipeListener()
+	acceptFinished := make(chan struct{})
+
+	go func() {
+		dl := pl.Dialer()
+		if _, err := dl("", time.Duration(0)); err == nil {
+			t.Error("expected to receive a 'conn closed' error from dial, got nil")
+		}
+		close(acceptFinished)
+	}()
+
+	select {
+	case <-acceptFinished:
+		t.Fatal("expected Accept to block until pl.Close or a dial occurred")
+	default:
+	}
+
+	if err := pl.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case <-acceptFinished:
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected Accept to unblock after pl.Close was called")
+	}
+}
+
+func TestDialUnblocksAccept(t *testing.T) {
+	pl := testutils.NewPipeListener()
+	acceptFinished := make(chan struct{})
+
+	go func() {
+		if _, err := pl.Accept(); err != nil {
+			t.Error(err)
+		}
+		close(acceptFinished)
+	}()
+
+	select {
+	case <-acceptFinished:
+		t.Fatal("expected Accept to block until pl.Close or a dial occurred")
+	default:
+	}
+
+	dl := pl.Dialer()
+	if _, err := dl("", time.Duration(0)); err != nil {
+		panic(err)
+	}
+
+	select {
+	case <-acceptFinished:
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected Accept to unblock after Dial was called")
+	}
+}
+
+func TestCloseUnblocksAccept(t *testing.T) {
+	pl := testutils.NewPipeListener()
+	acceptFinished := make(chan struct{})
+
+	go func() {
+		if _, err := pl.Accept(); err == nil {
+			t.Error("expected to received a 'conn closed' error from dial, got nil")
+		}
+		close(acceptFinished)
+	}()
+
+	select {
+	case <-acceptFinished:
+		t.Fatal("expected Accept to block until pl.Close or a dial occurred")
+	default:
+	}
+
+	if err := pl.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case <-acceptFinished:
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected Accept to unblock after pl.Close was called")
+	}
+}


### PR DESCRIPTION
This CL fixes three problems:

- In clientconn_state_transitions_test.go, each time we set up a server to send
SETTINGS, we should also set up the server to read. This allows the client
to successfully send its SETTINGS.

- In clientconn.go, we incorrectly transitioned into TRANSIENT FAILURE when
creating an http2client returned an error. This should be handled in the outer
resetTransport main reset loop. The reason this became a problem is that the
outer resetTransport has very specific conditions around when to transition
into TRANSIENT FAILURE that the egregious transition did not have. So, it
could transition into TRANSIENT FAILURE after failing to dial, even if it
was trying to connect to a non-final address in the list of addresses.

- In clientconn.go, we incorrectly stay in CONNECTING after createTransport when a server sends
its connection preface but the client is not able to send its connection preface. This
CL causes the addrconn to correctly enter TRANSIENT FAILURE when createTransport
fails, even if a server preface was received. It does so by making
ac.successfulHandshake to consider both server preface received as well as
client preface sent.