### PR TITLE
binarylog: call binary log in Client and Server

### DIFF
--- a/internal/binarylog/binarylog.go
+++ b/internal/binarylog/binarylog.go
@@ -27,16 +27,42 @@ import (
 	"google.golang.org/grpc/grpclog"
 )
 
-// Logger is the global binary logger for the binary. One of this should be
+// Logger is the global binary logger. It can be used to get binary logger for
+// each method.
+type Logger interface {
+	getMethodLogger(methodName string) *MethodLogger
+}
+
+// binLogger is the global binary logger for the binary. One of this should be
 // built at init time from the configuration (environment varialbe or flags).
 //
 // It is used to get a methodLogger for each individual method.
-var Logger *logger
+var binLogger Logger
+
+// SetLogger sets the binarg logger.
+//
+// Only call this at init time.
+func SetLogger(l Logger) {
+	binLogger = l
+}
+
+// GetMethodLogger returns the methodLogger for the given methodName.
+//
+// methodName should be in the format of "/service/method".
+//
+// Each methodLogger returned by this method is a new instance. This is to
+// generate sequence id within the call.
+func GetMethodLogger(methodName string) *MethodLogger {
+	if binLogger == nil {
+		return nil
+	}
+	return binLogger.getMethodLogger(methodName)
+}
 
 func init() {
 	const envStr = "GRPC_BINARY_LOG_FILTER"
 	configStr := os.Getenv(envStr)
-	Logger = newLoggerFromConfigString(configStr)
+	binLogger = NewLoggerFromConfigString(configStr)
 }
 
 type methodLoggerConfig struct {
@@ -113,13 +139,13 @@ func (l *logger) setBlacklist(method string) error {
 	return nil
 }
 
-// GetMethodLogger returns the methodLogger for the given methodName.
+// getMethodLogger returns the methodLogger for the given methodName.
 //
 // methodName should be in the format of "/service/method".
 //
 // Each methodLogger returned by this method is a new instance. This is to
 // generate sequence id within the call.
-func (l *logger) GetMethodLogger(methodName string) *MethodLogger {
+func (l *logger) getMethodLogger(methodName string) *MethodLogger {
 	s, m, err := parseMethodName(methodName)
 	if err != nil {
 		grpclog.Infof("binarylogging: failed to parse %q: %v", methodName, err)

--- a/internal/binarylog/binarylog_end2end_test.go
+++ b/internal/binarylog/binarylog_end2end_test.go
@@ -55,13 +55,14 @@ type testBinLogSink struct {
 	buf []*pb.GrpcLogEntry
 }
 
-func (s *testBinLogSink) Write(e *pb.GrpcLogEntry) {
+func (s *testBinLogSink) Write(e *pb.GrpcLogEntry) error {
 	s.mu.Lock()
 	s.buf = append(s.buf, e)
 	s.mu.Unlock()
+	return nil
 }
 
-func (s *testBinLogSink) Close() {}
+func (s *testBinLogSink) Close() error { return nil }
 
 func (s *testBinLogSink) clear() {
 	s.mu.Lock()

--- a/internal/binarylog/binarylog_end2end_test.go
+++ b/internal/binarylog/binarylog_end2end_test.go
@@ -647,7 +647,7 @@ func (ed *expectedData) toClientLogEntries() []*pb.GrpcLogEntry {
 				ret = append(ret, ed.newServerHeaderEntry(true, globalRPCID, idInRPC))
 				idInRPC += 1
 			}
-			if !ed.cc.success { // } i >= len(ed.responses) || ed.responses[i] == nil {
+			if !ed.cc.success {
 				// There is no response in the RPC error case.
 				continue
 			}
@@ -711,7 +711,7 @@ func (ed *expectedData) toServerLogEntries() []*pb.GrpcLogEntry {
 		for i := 0; i < len(ed.requests); i++ {
 			ret = append(ret, ed.newClientMessageEntry(false, globalRPCID, idInRPC, ed.requests[i]))
 			idInRPC += 1
-			if !ed.cc.success { // } i >= len(ed.responses) || ed.responses[i] == nil {
+			if !ed.cc.success {
 				// There is no response in the RPC error case.
 				continue
 			}
@@ -730,7 +730,7 @@ func (ed *expectedData) toServerLogEntries() []*pb.GrpcLogEntry {
 			ret = append(ret, ed.newClientMessageEntry(false, globalRPCID, idInRPC, ed.requests[i]))
 			idInRPC += 1
 		}
-		if ed.cc.success { // } ed.cc.callType == clientStreamRPC {
+		if ed.cc.success {
 			ret = append(ret, ed.newHalfCloseEntry(false, globalRPCID, idInRPC))
 			idInRPC += 1
 			ret = append(ret, ed.newServerMessageEntry(false, globalRPCID, idInRPC, ed.responses[0]))
@@ -795,8 +795,7 @@ func runRPCs(t *testing.T, tc *testConfig, cc *rpcConfig) *expectedData {
 	return expect
 }
 
-// equalLogEntry sorts the metadata entries by key (to compare metadata) and
-// remove content-type from server header before doing a proto compare.
+// equalLogEntry sorts the metadata entries by key (to compare metadata).
 //
 // This function is typically called with only two entries. It's written in this
 // way so the code can be put in a for loop instead of copied twice.
@@ -809,11 +808,7 @@ func equalLogEntry(entries ...*pb.GrpcLogEntry) (equal bool) {
 			h.Timeout = nil
 			tmp := h.Metadata.Entry[:0]
 			for _, e := range h.Metadata.Entry {
-				switch e.Key {
-				case "content-type", ":authority", "user-agent":
-				default:
-					tmp = append(tmp, e)
-				}
+				tmp = append(tmp, e)
 			}
 			h.Metadata.Entry = tmp
 			sort.Slice(h.Metadata.Entry, func(i, j int) bool { return h.Metadata.Entry[i].Key < h.Metadata.Entry[j].Key })
@@ -821,11 +816,7 @@ func equalLogEntry(entries ...*pb.GrpcLogEntry) (equal bool) {
 		if h := e.GetServerHeader(); h != nil {
 			tmp := h.Metadata.Entry[:0]
 			for _, e := range h.Metadata.Entry {
-				switch e.Key {
-				case "content-type", ":authority", "user-agent":
-				default:
-					tmp = append(tmp, e)
-				}
+				tmp = append(tmp, e)
 			}
 			h.Metadata.Entry = tmp
 			sort.Slice(h.Metadata.Entry, func(i, j int) bool { return h.Metadata.Entry[i].Key < h.Metadata.Entry[j].Key })

--- a/internal/binarylog/binarylog_end2end_test.go
+++ b/internal/binarylog/binarylog_end2end_test.go
@@ -42,7 +42,8 @@ import (
 )
 
 func init() {
-	// Environment variable doesn't because of the init orders.
+	// Setting environment variable in tests doesn't work because of the init
+	// orders. Set the loggers directly here.
 	binarylog.SetLogger(binarylog.AllLogger)
 	binarylog.SetDefaultSink(testSink)
 }

--- a/internal/binarylog/binarylog_end2end_test.go
+++ b/internal/binarylog/binarylog_end2end_test.go
@@ -953,11 +953,10 @@ func testServerBinaryLog(t *testing.T, c *rpcConfig) error {
 		for i, e := range got {
 			t.Errorf("in got: %d, %s", i, e.GetType())
 		}
-		// return fmt.Errorf("didn't get same amount of log entries, want: %d, got: %d", len(want), len(got))
+		return fmt.Errorf("didn't get same amount of log entries, want: %d, got: %d", len(want), len(got))
 	}
 	var errored bool
-	// for i := 0; i < len(got); i++ {
-	for i := 0; i < len(got) && i < len(want); i++ {
+	for i := 0; i < len(got); i++ {
 		if !equalLogEntry(want[i], got[i]) {
 			t.Errorf("entry: %d, want %+v, got %+v", i, want[i], got[i])
 			errored = true

--- a/internal/binarylog/binarylog_end2end_test.go
+++ b/internal/binarylog/binarylog_end2end_test.go
@@ -1,0 +1,1023 @@
+// +build go1.8
+
+/*
+ *
+ * Copyright 2018 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package binarylog_test
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"sort"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/golang/protobuf/proto"
+
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+	pb "google.golang.org/grpc/binarylog/grpc_binarylog_v1"
+	"google.golang.org/grpc/grpclog"
+	"google.golang.org/grpc/internal/binarylog"
+	"google.golang.org/grpc/metadata"
+	testpb "google.golang.org/grpc/stats/grpc_testing"
+	"google.golang.org/grpc/status"
+)
+
+func init() {
+	// Environment variable doesn't because of the init orders.
+	binarylog.SetLogger(binarylog.AllLogger)
+	binarylog.SetDefaultSink(testSink)
+}
+
+var testSink = &testBinLogSink{}
+
+type testBinLogSink struct {
+	mu  sync.Mutex
+	buf []*pb.GrpcLogEntry
+}
+
+func (s *testBinLogSink) Write(e *pb.GrpcLogEntry) {
+	s.mu.Lock()
+	s.buf = append(s.buf, e)
+	s.mu.Unlock()
+}
+
+func (s *testBinLogSink) Close() {}
+
+func (s *testBinLogSink) clear() {
+	s.mu.Lock()
+	s.buf = nil
+	s.mu.Unlock()
+}
+
+var (
+	// For headers:
+	testMetadata = metadata.MD{
+		"key1": []string{"value1"},
+		"key2": []string{"value2"},
+	}
+	// For trailers:
+	testTrailerMetadata = metadata.MD{
+		"tkey1": []string{"trailerValue1"},
+		"tkey2": []string{"trailerValue2"},
+	}
+	// The id for which the service handler should return error.
+	errorID int32 = 32202
+
+	globalRPCID uint64 // RPC id starts with 1, but we do ++ at the beginning of each test.
+)
+
+type testServer struct {
+	te *test
+}
+
+func (s *testServer) UnaryCall(ctx context.Context, in *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if ok {
+		if err := grpc.SendHeader(ctx, md); err != nil {
+			return nil, status.Errorf(status.Code(err), "grpc.SendHeader(_, %v) = %v, want <nil>", md, err)
+		}
+		if err := grpc.SetTrailer(ctx, testTrailerMetadata); err != nil {
+			return nil, status.Errorf(status.Code(err), "grpc.SetTrailer(_, %v) = %v, want <nil>", testTrailerMetadata, err)
+		}
+	}
+
+	if in.Id == errorID {
+		return nil, fmt.Errorf("got error id: %v", in.Id)
+	}
+
+	return &testpb.SimpleResponse{Id: in.Id}, nil
+}
+
+func (s *testServer) FullDuplexCall(stream testpb.TestService_FullDuplexCallServer) error {
+	md, ok := metadata.FromIncomingContext(stream.Context())
+	if ok {
+		if err := stream.SendHeader(md); err != nil {
+			return status.Errorf(status.Code(err), "stream.SendHeader(%v) = %v, want %v", md, err, nil)
+		}
+		stream.SetTrailer(testTrailerMetadata)
+	}
+	for {
+		in, err := stream.Recv()
+		if err == io.EOF {
+			// read done.
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+
+		if in.Id == errorID {
+			return fmt.Errorf("got error id: %v", in.Id)
+		}
+
+		if err := stream.Send(&testpb.SimpleResponse{Id: in.Id}); err != nil {
+			return err
+		}
+	}
+}
+
+func (s *testServer) ClientStreamCall(stream testpb.TestService_ClientStreamCallServer) error {
+	md, ok := metadata.FromIncomingContext(stream.Context())
+	if ok {
+		if err := stream.SendHeader(md); err != nil {
+			return status.Errorf(status.Code(err), "stream.SendHeader(%v) = %v, want %v", md, err, nil)
+		}
+		stream.SetTrailer(testTrailerMetadata)
+	}
+	for {
+		in, err := stream.Recv()
+		if err == io.EOF {
+			// read done.
+			return stream.SendAndClose(&testpb.SimpleResponse{Id: int32(0)})
+		}
+		if err != nil {
+			return err
+		}
+
+		if in.Id == errorID {
+			return fmt.Errorf("got error id: %v", in.Id)
+		}
+	}
+}
+
+func (s *testServer) ServerStreamCall(in *testpb.SimpleRequest, stream testpb.TestService_ServerStreamCallServer) error {
+	md, ok := metadata.FromIncomingContext(stream.Context())
+	if ok {
+		if err := stream.SendHeader(md); err != nil {
+			return status.Errorf(status.Code(err), "stream.SendHeader(%v) = %v, want %v", md, err, nil)
+		}
+		stream.SetTrailer(testTrailerMetadata)
+	}
+
+	if in.Id == errorID {
+		return fmt.Errorf("got error id: %v", in.Id)
+	}
+
+	for i := 0; i < 5; i++ {
+		if err := stream.Send(&testpb.SimpleResponse{Id: in.Id}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// test is an end-to-end test. It should be created with the newTest
+// func, modified as needed, and then started with its startServer method.
+// It should be cleaned up with the tearDown method.
+type test struct {
+	t *testing.T
+
+	testServer testpb.TestServiceServer // nil means none
+	// srv and srvAddr are set once startServer is called.
+	srv     *grpc.Server
+	srvAddr string // Server IP without port.
+	srvIP   net.IP
+	srvPort int
+
+	cc *grpc.ClientConn // nil until requested via clientConn
+
+	// Fields for client address. Set by the service handler.
+	clientAddrMu sync.Mutex
+	clientIP     net.IP
+	clientPort   int
+}
+
+func (te *test) tearDown() {
+	if te.cc != nil {
+		te.cc.Close()
+		te.cc = nil
+	}
+	te.srv.Stop()
+}
+
+type testConfig struct {
+}
+
+// newTest returns a new test using the provided testing.T and
+// environment.  It is returned with default values. Tests should
+// modify it before calling its startServer and clientConn methods.
+func newTest(t *testing.T, tc *testConfig) *test {
+	te := &test{
+		t: t,
+	}
+	return te
+}
+
+type listenerWrapper struct {
+	net.Listener
+	te *test
+}
+
+func (lw *listenerWrapper) Accept() (net.Conn, error) {
+	conn, err := lw.Listener.Accept()
+	if err != nil {
+		return nil, err
+	}
+	lw.te.clientAddrMu.Lock()
+	lw.te.clientIP = conn.RemoteAddr().(*net.TCPAddr).IP
+	lw.te.clientPort = conn.RemoteAddr().(*net.TCPAddr).Port
+	lw.te.clientAddrMu.Unlock()
+	return conn, nil
+}
+
+// startServer starts a gRPC server listening. Callers should defer a
+// call to te.tearDown to clean up.
+func (te *test) startServer(ts testpb.TestServiceServer) {
+	te.testServer = ts
+	lis, err := net.Listen("tcp", "localhost:0")
+
+	lis = &listenerWrapper{
+		Listener: lis,
+		te:       te,
+	}
+
+	if err != nil {
+		te.t.Fatalf("Failed to listen: %v", err)
+	}
+	var opts []grpc.ServerOption
+	s := grpc.NewServer(opts...)
+	te.srv = s
+	if te.testServer != nil {
+		testpb.RegisterTestServiceServer(s, te.testServer)
+	}
+
+	go s.Serve(lis)
+	te.srvAddr = lis.Addr().String()
+	te.srvIP = lis.Addr().(*net.TCPAddr).IP
+	te.srvPort = lis.Addr().(*net.TCPAddr).Port
+}
+
+func (te *test) clientConn() *grpc.ClientConn {
+	if te.cc != nil {
+		return te.cc
+	}
+	opts := []grpc.DialOption{grpc.WithInsecure(), grpc.WithBlock()}
+
+	var err error
+	te.cc, err = grpc.Dial(te.srvAddr, opts...)
+	if err != nil {
+		te.t.Fatalf("Dial(%q) = %v", te.srvAddr, err)
+	}
+	return te.cc
+}
+
+type rpcType int
+
+const (
+	unaryRPC rpcType = iota
+	clientStreamRPC
+	serverStreamRPC
+	fullDuplexStreamRPC
+	cancelRPC
+)
+
+type rpcConfig struct {
+	count    int     // Number of requests and responses for streaming RPCs.
+	success  bool    // Whether the RPC should succeed or return error.
+	callType rpcType // Type of RPC.
+}
+
+func (te *test) doUnaryCall(c *rpcConfig) (*testpb.SimpleRequest, *testpb.SimpleResponse, error) {
+	var (
+		resp *testpb.SimpleResponse
+		req  *testpb.SimpleRequest
+		err  error
+	)
+	tc := testpb.NewTestServiceClient(te.clientConn())
+	if c.success {
+		req = &testpb.SimpleRequest{Id: errorID + 1}
+	} else {
+		req = &testpb.SimpleRequest{Id: errorID}
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	ctx = metadata.NewOutgoingContext(ctx, testMetadata)
+
+	resp, err = tc.UnaryCall(ctx, req)
+	return req, resp, err
+}
+
+func (te *test) doFullDuplexCallRoundtrip(c *rpcConfig) ([]*testpb.SimpleRequest, []*testpb.SimpleResponse, error) {
+	var (
+		reqs  []*testpb.SimpleRequest
+		resps []*testpb.SimpleResponse
+		err   error
+	)
+	tc := testpb.NewTestServiceClient(te.clientConn())
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	ctx = metadata.NewOutgoingContext(ctx, testMetadata)
+
+	stream, err := tc.FullDuplexCall(ctx)
+	if err != nil {
+		return reqs, resps, err
+	}
+
+	if c.callType == cancelRPC {
+		cancel()
+		return reqs, resps, context.Canceled
+	}
+
+	var startID int32
+	if !c.success {
+		startID = errorID
+	}
+	for i := 0; i < c.count; i++ {
+		req := &testpb.SimpleRequest{
+			Id: int32(i) + startID,
+		}
+		reqs = append(reqs, req)
+		if err = stream.Send(req); err != nil {
+			return reqs, resps, err
+		}
+		var resp *testpb.SimpleResponse
+		if resp, err = stream.Recv(); err != nil {
+			return reqs, resps, err
+		}
+		resps = append(resps, resp)
+	}
+	if err = stream.CloseSend(); err != nil && err != io.EOF {
+		return reqs, resps, err
+	}
+	if _, err = stream.Recv(); err != io.EOF {
+		return reqs, resps, err
+	}
+
+	return reqs, resps, nil
+}
+
+func (te *test) doClientStreamCall(c *rpcConfig) ([]*testpb.SimpleRequest, *testpb.SimpleResponse, error) {
+	var (
+		reqs []*testpb.SimpleRequest
+		resp *testpb.SimpleResponse
+		err  error
+	)
+	tc := testpb.NewTestServiceClient(te.clientConn())
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	ctx = metadata.NewOutgoingContext(ctx, testMetadata)
+
+	stream, err := tc.ClientStreamCall(ctx)
+	if err != nil {
+		return reqs, resp, err
+	}
+	var startID int32
+	if !c.success {
+		startID = errorID
+	}
+	for i := 0; i < c.count; i++ {
+		req := &testpb.SimpleRequest{
+			Id: int32(i) + startID,
+		}
+		reqs = append(reqs, req)
+		if err = stream.Send(req); err != nil {
+			return reqs, resp, err
+		}
+	}
+	resp, err = stream.CloseAndRecv()
+	return reqs, resp, err
+}
+
+func (te *test) doServerStreamCall(c *rpcConfig) (*testpb.SimpleRequest, []*testpb.SimpleResponse, error) {
+	var (
+		req   *testpb.SimpleRequest
+		resps []*testpb.SimpleResponse
+		err   error
+	)
+
+	tc := testpb.NewTestServiceClient(te.clientConn())
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	ctx = metadata.NewOutgoingContext(ctx, testMetadata)
+
+	var startID int32
+	if !c.success {
+		startID = errorID
+	}
+	req = &testpb.SimpleRequest{Id: startID}
+	stream, err := tc.ServerStreamCall(ctx, req)
+	if err != nil {
+		return req, resps, err
+	}
+	for {
+		var resp *testpb.SimpleResponse
+		resp, err := stream.Recv()
+		if err == io.EOF {
+			return req, resps, nil
+		} else if err != nil {
+			return req, resps, err
+		}
+		resps = append(resps, resp)
+	}
+}
+
+type expectedData struct {
+	te *test
+	cc *rpcConfig
+
+	method    string
+	requests  []*testpb.SimpleRequest
+	responses []*testpb.SimpleResponse
+	err       error
+}
+
+func (ed *expectedData) newClientHeaderEntry(client bool, rpcID, inRPCID uint64) *pb.GrpcLogEntry {
+	logger := pb.GrpcLogEntry_LOGGER_CLIENT
+	var peer *pb.Address
+	if !client {
+		logger = pb.GrpcLogEntry_LOGGER_SERVER
+		ed.te.clientAddrMu.Lock()
+		peer = &pb.Address{
+			Address: ed.te.clientIP.String(),
+			IpPort:  uint32(ed.te.clientPort),
+		}
+		if ed.te.clientIP.To4() != nil {
+			peer.Type = pb.Address_TYPE_IPV4
+		} else {
+			peer.Type = pb.Address_TYPE_IPV6
+		}
+		ed.te.clientAddrMu.Unlock()
+	}
+	return &pb.GrpcLogEntry{
+		Timestamp:            nil,
+		CallId:               rpcID,
+		SequenceIdWithinCall: inRPCID,
+		Type:                 pb.GrpcLogEntry_EVENT_TYPE_CLIENT_HEADER,
+		Logger:               logger,
+		Payload: &pb.GrpcLogEntry_ClientHeader{
+			ClientHeader: &pb.ClientHeader{
+				Metadata:   binarylog.MdToMetadataProto(testMetadata),
+				MethodName: ed.method,
+				Authority:  ed.te.srvAddr,
+			},
+		},
+		Peer: peer,
+	}
+}
+
+func (ed *expectedData) newServerHeaderEntry(client bool, rpcID, inRPCID uint64) *pb.GrpcLogEntry {
+	logger := pb.GrpcLogEntry_LOGGER_SERVER
+	var peer *pb.Address
+	if client {
+		logger = pb.GrpcLogEntry_LOGGER_CLIENT
+		peer = &pb.Address{
+			Address: ed.te.srvIP.String(),
+			IpPort:  uint32(ed.te.srvPort),
+		}
+		if ed.te.srvIP.To4() != nil {
+			peer.Type = pb.Address_TYPE_IPV4
+		} else {
+			peer.Type = pb.Address_TYPE_IPV6
+		}
+	}
+	return &pb.GrpcLogEntry{
+		Timestamp:            nil,
+		CallId:               rpcID,
+		SequenceIdWithinCall: inRPCID,
+		Type:                 pb.GrpcLogEntry_EVENT_TYPE_SERVER_HEADER,
+		Logger:               logger,
+		Payload: &pb.GrpcLogEntry_ServerHeader{
+			ServerHeader: &pb.ServerHeader{
+				Metadata: binarylog.MdToMetadataProto(testMetadata),
+			},
+		},
+		Peer: peer,
+	}
+}
+
+func (ed *expectedData) newClientMessageEntry(client bool, rpcID, inRPCID uint64, msg *testpb.SimpleRequest) *pb.GrpcLogEntry {
+	logger := pb.GrpcLogEntry_LOGGER_CLIENT
+	if !client {
+		logger = pb.GrpcLogEntry_LOGGER_SERVER
+	}
+	data, err := proto.Marshal(msg)
+	if err != nil {
+		grpclog.Infof("binarylogging_testing: failed to marshal proto message: %v", err)
+	}
+	return &pb.GrpcLogEntry{
+		Timestamp:            nil,
+		CallId:               rpcID,
+		SequenceIdWithinCall: inRPCID,
+		Type:                 pb.GrpcLogEntry_EVENT_TYPE_CLIENT_MESSAGE,
+		Logger:               logger,
+		Payload: &pb.GrpcLogEntry_Message{
+			Message: &pb.Message{
+				Length: uint32(len(data)),
+				Data:   data,
+			},
+		},
+	}
+}
+
+func (ed *expectedData) newServerMessageEntry(client bool, rpcID, inRPCID uint64, msg *testpb.SimpleResponse) *pb.GrpcLogEntry {
+	logger := pb.GrpcLogEntry_LOGGER_CLIENT
+	if !client {
+		logger = pb.GrpcLogEntry_LOGGER_SERVER
+	}
+	data, err := proto.Marshal(msg)
+	if err != nil {
+		grpclog.Infof("binarylogging_testing: failed to marshal proto message: %v", err)
+	}
+	return &pb.GrpcLogEntry{
+		Timestamp:            nil,
+		CallId:               rpcID,
+		SequenceIdWithinCall: inRPCID,
+		Type:                 pb.GrpcLogEntry_EVENT_TYPE_SERVER_MESSAGE,
+		Logger:               logger,
+		Payload: &pb.GrpcLogEntry_Message{
+			Message: &pb.Message{
+				Length: uint32(len(data)),
+				Data:   data,
+			},
+		},
+	}
+}
+
+func (ed *expectedData) newHalfCloseEntry(client bool, rpcID, inRPCID uint64) *pb.GrpcLogEntry {
+	logger := pb.GrpcLogEntry_LOGGER_CLIENT
+	if !client {
+		logger = pb.GrpcLogEntry_LOGGER_SERVER
+	}
+	return &pb.GrpcLogEntry{
+		Timestamp:            nil,
+		CallId:               rpcID,
+		SequenceIdWithinCall: inRPCID,
+		Type:                 pb.GrpcLogEntry_EVENT_TYPE_CLIENT_HALF_CLOSE,
+		Payload:              nil, // No payload here.
+		Logger:               logger,
+	}
+}
+
+func (ed *expectedData) newServerTrailerEntry(client bool, rpcID, inRPCID uint64, stErr error) *pb.GrpcLogEntry {
+	logger := pb.GrpcLogEntry_LOGGER_SERVER
+	var peer *pb.Address
+	if client {
+		logger = pb.GrpcLogEntry_LOGGER_CLIENT
+		peer = &pb.Address{
+			Address: ed.te.srvIP.String(),
+			IpPort:  uint32(ed.te.srvPort),
+		}
+		if ed.te.srvIP.To4() != nil {
+			peer.Type = pb.Address_TYPE_IPV4
+		} else {
+			peer.Type = pb.Address_TYPE_IPV6
+		}
+	}
+	st, ok := status.FromError(stErr)
+	if !ok {
+		grpclog.Info("binarylogging: error in trailer is not a status error")
+	}
+	stProto := st.Proto()
+	var (
+		detailsBytes []byte
+		err          error
+	)
+	if stProto != nil && len(stProto.Details) != 0 {
+		detailsBytes, err = proto.Marshal(stProto)
+		if err != nil {
+			grpclog.Infof("binarylogging: failed to marshal status proto: %v", err)
+		}
+	}
+	return &pb.GrpcLogEntry{
+		Timestamp:            nil,
+		CallId:               rpcID,
+		SequenceIdWithinCall: inRPCID,
+		Type:                 pb.GrpcLogEntry_EVENT_TYPE_SERVER_TRAILER,
+		Logger:               logger,
+		Payload: &pb.GrpcLogEntry_Trailer{
+			Trailer: &pb.Trailer{
+				Metadata: binarylog.MdToMetadataProto(testTrailerMetadata),
+				// st will be nil if err was not a status error, but nil is ok.
+				StatusCode:    uint32(st.Code()),
+				StatusMessage: st.Message(),
+				StatusDetails: detailsBytes,
+			},
+		},
+		Peer: peer,
+	}
+}
+
+func (ed *expectedData) newCancelEntry(rpcID, inRPCID uint64) *pb.GrpcLogEntry {
+	return &pb.GrpcLogEntry{
+		Timestamp:            nil,
+		CallId:               rpcID,
+		SequenceIdWithinCall: inRPCID,
+		Type:                 pb.GrpcLogEntry_EVENT_TYPE_CANCEL,
+		Logger:               pb.GrpcLogEntry_LOGGER_CLIENT,
+		Payload:              nil,
+	}
+}
+
+func (ed *expectedData) toClientLogEntries() []*pb.GrpcLogEntry {
+	var (
+		ret     []*pb.GrpcLogEntry
+		idInRPC uint64 = 1
+	)
+	ret = append(ret, ed.newClientHeaderEntry(true, globalRPCID, idInRPC))
+	idInRPC += 1
+
+	switch ed.cc.callType {
+	case unaryRPC, fullDuplexStreamRPC:
+		for i := 0; i < len(ed.requests); i++ {
+			ret = append(ret, ed.newClientMessageEntry(true, globalRPCID, idInRPC, ed.requests[i]))
+			idInRPC += 1
+			if i == 0 {
+				// First message, append ServerHeader.
+				ret = append(ret, ed.newServerHeaderEntry(true, globalRPCID, idInRPC))
+				idInRPC += 1
+			}
+			if !ed.cc.success { // } i >= len(ed.responses) || ed.responses[i] == nil {
+				// There is no response in the RPC error case.
+				continue
+			}
+			ret = append(ret, ed.newServerMessageEntry(true, globalRPCID, idInRPC, ed.responses[i]))
+			idInRPC += 1
+		}
+		if ed.cc.success && ed.cc.callType == fullDuplexStreamRPC {
+			ret = append(ret, ed.newHalfCloseEntry(true, globalRPCID, idInRPC))
+			idInRPC += 1
+		}
+	case clientStreamRPC, serverStreamRPC:
+		for i := 0; i < len(ed.requests); i++ {
+			ret = append(ret, ed.newClientMessageEntry(true, globalRPCID, idInRPC, ed.requests[i]))
+			idInRPC += 1
+		}
+		if ed.cc.callType == clientStreamRPC {
+			ret = append(ret, ed.newHalfCloseEntry(true, globalRPCID, idInRPC))
+			idInRPC += 1
+		}
+		ret = append(ret, ed.newServerHeaderEntry(true, globalRPCID, idInRPC))
+		idInRPC += 1
+		if ed.cc.success {
+			for i := 0; i < len(ed.responses); i++ {
+				ret = append(ret, ed.newServerMessageEntry(true, globalRPCID, idInRPC, ed.responses[0]))
+				idInRPC += 1
+			}
+		}
+	}
+
+	if ed.cc.callType == cancelRPC {
+		ret = append(ret, ed.newCancelEntry(globalRPCID, idInRPC))
+		idInRPC += 1
+	} else {
+		ret = append(ret, ed.newServerTrailerEntry(true, globalRPCID, idInRPC, ed.err))
+		idInRPC += 1
+	}
+	return ret
+}
+
+func (ed *expectedData) toServerLogEntries() []*pb.GrpcLogEntry {
+	var (
+		ret     []*pb.GrpcLogEntry
+		idInRPC uint64 = 1
+	)
+	ret = append(ret, ed.newClientHeaderEntry(false, globalRPCID, idInRPC))
+	idInRPC += 1
+
+	switch ed.cc.callType {
+	case unaryRPC:
+		ret = append(ret, ed.newClientMessageEntry(false, globalRPCID, idInRPC, ed.requests[0]))
+		idInRPC += 1
+		ret = append(ret, ed.newServerHeaderEntry(false, globalRPCID, idInRPC))
+		idInRPC += 1
+		if ed.cc.success {
+			ret = append(ret, ed.newServerMessageEntry(false, globalRPCID, idInRPC, ed.responses[0]))
+			idInRPC += 1
+		}
+	case fullDuplexStreamRPC:
+		ret = append(ret, ed.newServerHeaderEntry(false, globalRPCID, idInRPC))
+		idInRPC += 1
+		for i := 0; i < len(ed.requests); i++ {
+			ret = append(ret, ed.newClientMessageEntry(false, globalRPCID, idInRPC, ed.requests[i]))
+			idInRPC += 1
+			if !ed.cc.success { // } i >= len(ed.responses) || ed.responses[i] == nil {
+				// There is no response in the RPC error case.
+				continue
+			}
+			ret = append(ret, ed.newServerMessageEntry(false, globalRPCID, idInRPC, ed.responses[i]))
+			idInRPC += 1
+		}
+
+		if ed.cc.success && ed.cc.callType == fullDuplexStreamRPC {
+			ret = append(ret, ed.newHalfCloseEntry(false, globalRPCID, idInRPC))
+			idInRPC += 1
+		}
+	case clientStreamRPC:
+		ret = append(ret, ed.newServerHeaderEntry(false, globalRPCID, idInRPC))
+		idInRPC += 1
+		for i := 0; i < len(ed.requests); i++ {
+			ret = append(ret, ed.newClientMessageEntry(false, globalRPCID, idInRPC, ed.requests[i]))
+			idInRPC += 1
+		}
+		if ed.cc.success { // } ed.cc.callType == clientStreamRPC {
+			ret = append(ret, ed.newHalfCloseEntry(false, globalRPCID, idInRPC))
+			idInRPC += 1
+			ret = append(ret, ed.newServerMessageEntry(false, globalRPCID, idInRPC, ed.responses[0]))
+			idInRPC += 1
+		}
+	case serverStreamRPC:
+		ret = append(ret, ed.newClientMessageEntry(false, globalRPCID, idInRPC, ed.requests[0]))
+		idInRPC += 1
+		ret = append(ret, ed.newServerHeaderEntry(false, globalRPCID, idInRPC))
+		idInRPC += 1
+		for i := 0; i < len(ed.responses); i++ {
+			ret = append(ret, ed.newServerMessageEntry(false, globalRPCID, idInRPC, ed.responses[0]))
+			idInRPC += 1
+		}
+	}
+
+	ret = append(ret, ed.newServerTrailerEntry(false, globalRPCID, idInRPC, ed.err))
+	idInRPC += 1
+
+	return ret
+}
+
+func runRPCs(t *testing.T, tc *testConfig, cc *rpcConfig) *expectedData {
+	te := newTest(t, tc)
+	te.startServer(&testServer{te: te})
+	defer te.tearDown()
+
+	expect := &expectedData{
+		te: te,
+		cc: cc,
+	}
+
+	switch cc.callType {
+	case unaryRPC:
+		expect.method = "/grpc.testing.TestService/UnaryCall"
+		req, resp, err := te.doUnaryCall(cc)
+		expect.requests = []*testpb.SimpleRequest{req}
+		expect.responses = []*testpb.SimpleResponse{resp}
+		expect.err = err
+	case clientStreamRPC:
+		expect.method = "/grpc.testing.TestService/ClientStreamCall"
+		reqs, resp, err := te.doClientStreamCall(cc)
+		expect.requests = reqs
+		expect.responses = []*testpb.SimpleResponse{resp}
+		expect.err = err
+	case serverStreamRPC:
+		expect.method = "/grpc.testing.TestService/ServerStreamCall"
+		req, resps, err := te.doServerStreamCall(cc)
+		expect.responses = resps
+		expect.requests = []*testpb.SimpleRequest{req}
+		expect.err = err
+	case fullDuplexStreamRPC, cancelRPC:
+		expect.method = "/grpc.testing.TestService/FullDuplexCall"
+		expect.requests, expect.responses, expect.err = te.doFullDuplexCallRoundtrip(cc)
+	}
+	if cc.success != (expect.err == nil) {
+		t.Fatalf("cc.success: %v, got error: %v", cc.success, expect.err)
+	}
+	te.cc.Close()
+	te.srv.GracefulStop() // Wait for the server to stop.
+
+	return expect
+}
+
+// equalLogEntry sorts the metadata entries by key (to compare metadata) and
+// remove content-type from server header before doing a proto compare.
+//
+// This function is typically called with only two entries. It's written in this
+// way so the code can be put in a for loop instead of copied twice.
+func equalLogEntry(entries ...*pb.GrpcLogEntry) (equal bool) {
+	for i, e := range entries {
+		// Clear out some fields we don't compare.
+		e.Timestamp = nil
+		e.CallId = 0 // CallID is global to the binary, hard to compare.
+		if h := e.GetClientHeader(); h != nil {
+			h.Timeout = nil
+			tmp := h.Metadata.Entry[:0]
+			for _, e := range h.Metadata.Entry {
+				switch e.Key {
+				case "content-type", ":authority", "user-agent":
+				default:
+					tmp = append(tmp, e)
+				}
+			}
+			h.Metadata.Entry = tmp
+			sort.Slice(h.Metadata.Entry, func(i, j int) bool { return h.Metadata.Entry[i].Key < h.Metadata.Entry[j].Key })
+		}
+		if h := e.GetServerHeader(); h != nil {
+			tmp := h.Metadata.Entry[:0]
+			for _, e := range h.Metadata.Entry {
+				switch e.Key {
+				case "content-type", ":authority", "user-agent":
+				default:
+					tmp = append(tmp, e)
+				}
+			}
+			h.Metadata.Entry = tmp
+			sort.Slice(h.Metadata.Entry, func(i, j int) bool { return h.Metadata.Entry[i].Key < h.Metadata.Entry[j].Key })
+		}
+		if h := e.GetTrailer(); h != nil {
+			sort.Slice(h.Metadata.Entry, func(i, j int) bool { return h.Metadata.Entry[i].Key < h.Metadata.Entry[j].Key })
+		}
+
+		if i > 0 && !proto.Equal(e, entries[i-1]) {
+			return false
+		}
+	}
+	return true
+}
+
+func testClientBinaryLog(t *testing.T, c *rpcConfig) error {
+	defer testSink.clear()
+	// globalRPCID += 1
+	expect := runRPCs(t, &testConfig{}, c)
+	var got []*pb.GrpcLogEntry
+	for _, e := range testSink.buf {
+		if e.Logger == pb.GrpcLogEntry_LOGGER_CLIENT {
+			got = append(got, e)
+		}
+	}
+	want := expect.toClientLogEntries()
+	if len(want) != len(got) {
+		for i, e := range want {
+			t.Errorf("in want: %d, %s", i, e.GetType())
+		}
+		for i, e := range got {
+			t.Errorf("in got: %d, %s", i, e.GetType())
+		}
+		return fmt.Errorf("didn't get same amount of log entries, want: %d, got: %d", len(want), len(got))
+	}
+	var errored bool
+	for i := 0; i < len(got); i++ {
+		if !equalLogEntry(want[i], got[i]) {
+			t.Errorf("entry: %d, want %+v, got %+v", i, want[i], got[i])
+			errored = true
+		}
+	}
+	if errored {
+		return fmt.Errorf("test failed")
+	}
+	return nil
+}
+
+func TestClientBinaryLogUnaryRPC(t *testing.T) {
+	if err := testClientBinaryLog(t, &rpcConfig{success: true, callType: unaryRPC}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestClientBinaryLogUnaryRPCError(t *testing.T) {
+	if err := testClientBinaryLog(t, &rpcConfig{success: false, callType: unaryRPC}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestClientBinaryLogClientStreamRPC(t *testing.T) {
+	count := 5
+	if err := testClientBinaryLog(t, &rpcConfig{count: count, success: true, callType: clientStreamRPC}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestClientBinaryLogClientStreamRPCError(t *testing.T) {
+	count := 1
+	if err := testClientBinaryLog(t, &rpcConfig{count: count, success: false, callType: clientStreamRPC}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestClientBinaryLogServerStreamRPC(t *testing.T) {
+	count := 5
+	if err := testClientBinaryLog(t, &rpcConfig{count: count, success: true, callType: serverStreamRPC}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestClientBinaryLogServerStreamRPCError(t *testing.T) {
+	count := 5
+	if err := testClientBinaryLog(t, &rpcConfig{count: count, success: false, callType: serverStreamRPC}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestClientBinaryLogFullDuplexRPC(t *testing.T) {
+	count := 5
+	if err := testClientBinaryLog(t, &rpcConfig{count: count, success: true, callType: fullDuplexStreamRPC}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestClientBinaryLogFullDuplexRPCError(t *testing.T) {
+	count := 5
+	if err := testClientBinaryLog(t, &rpcConfig{count: count, success: false, callType: fullDuplexStreamRPC}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestClientBinaryLogCancel(t *testing.T) {
+	count := 5
+	if err := testClientBinaryLog(t, &rpcConfig{count: count, success: false, callType: cancelRPC}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func testServerBinaryLog(t *testing.T, c *rpcConfig) error {
+	defer testSink.clear()
+	// globalRPCID += 1
+	expect := runRPCs(t, &testConfig{}, c)
+	var got []*pb.GrpcLogEntry
+	for _, e := range testSink.buf {
+		if e.Logger == pb.GrpcLogEntry_LOGGER_SERVER {
+			got = append(got, e)
+		}
+	}
+
+	want := expect.toServerLogEntries()
+	if len(want) != len(got) {
+		for i, e := range want {
+			t.Errorf("in want: %d, %s", i, e.GetType())
+		}
+		for i, e := range got {
+			t.Errorf("in got: %d, %s", i, e.GetType())
+		}
+		// return fmt.Errorf("didn't get same amount of log entries, want: %d, got: %d", len(want), len(got))
+	}
+	var errored bool
+	// for i := 0; i < len(got); i++ {
+	for i := 0; i < len(got) && i < len(want); i++ {
+		if !equalLogEntry(want[i], got[i]) {
+			t.Errorf("entry: %d, want %+v, got %+v", i, want[i], got[i])
+			errored = true
+		}
+	}
+	if errored {
+		return fmt.Errorf("test failed")
+	}
+	return nil
+}
+
+func TestServerBinaryLogUnaryRPC(t *testing.T) {
+	if err := testServerBinaryLog(t, &rpcConfig{success: true, callType: unaryRPC}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestServerBinaryLogUnaryRPCError(t *testing.T) {
+	if err := testServerBinaryLog(t, &rpcConfig{success: false, callType: unaryRPC}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestServerBinaryLogClientStreamRPC(t *testing.T) {
+	count := 5
+	if err := testServerBinaryLog(t, &rpcConfig{count: count, success: true, callType: clientStreamRPC}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestServerBinaryLogClientStreamRPCError(t *testing.T) {
+	count := 1
+	if err := testServerBinaryLog(t, &rpcConfig{count: count, success: false, callType: clientStreamRPC}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestServerBinaryLogServerStreamRPC(t *testing.T) {
+	count := 5
+	if err := testServerBinaryLog(t, &rpcConfig{count: count, success: true, callType: serverStreamRPC}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestServerBinaryLogServerStreamRPCError(t *testing.T) {
+	count := 5
+	if err := testServerBinaryLog(t, &rpcConfig{count: count, success: false, callType: serverStreamRPC}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestServerBinaryLogFullDuplex(t *testing.T) {
+	count := 5
+	if err := testServerBinaryLog(t, &rpcConfig{count: count, success: true, callType: fullDuplexStreamRPC}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestServerBinaryLogFullDuplexError(t *testing.T) {
+	count := 5
+	if err := testServerBinaryLog(t, &rpcConfig{count: count, success: false, callType: fullDuplexStreamRPC}); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/binarylog/binarylog_test.go
+++ b/internal/binarylog/binarylog_test.go
@@ -78,12 +78,12 @@ func TestGetMethodLogger(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		l := newLoggerFromConfigString(tc.in)
+		l := NewLoggerFromConfigString(tc.in)
 		if l == nil {
 			t.Errorf("in: %q, failed to create logger from config string", tc.in)
 			continue
 		}
-		ml := l.GetMethodLogger(tc.method)
+		ml := l.getMethodLogger(tc.method)
 		if ml == nil {
 			t.Errorf("in: %q, method logger is nil, want non-nil", tc.in)
 			continue
@@ -134,12 +134,12 @@ func TestGetMethodLoggerOff(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		l := newLoggerFromConfigString(tc.in)
+		l := NewLoggerFromConfigString(tc.in)
 		if l == nil {
 			t.Errorf("in: %q, failed to create logger from config string", tc.in)
 			continue
 		}
-		ml := l.GetMethodLogger(tc.method)
+		ml := l.getMethodLogger(tc.method)
 		if ml != nil {
 			t.Errorf("in: %q, method logger is non-nil, want nil", tc.in)
 		}

--- a/internal/binarylog/binarylog_testutil.go
+++ b/internal/binarylog/binarylog_testutil.go
@@ -1,0 +1,42 @@
+/*
+ *
+ * Copyright 2018 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// This file contains exported variables/functions that are exported for testing
+// only.
+//
+// An ideal way for this would be to put those in a *_test.go but in binarylog
+// package. But this doesn't work with staticcheck with go module. Error was:
+// "MdToMetadataProto not declared by package binarylog". This could be caused
+// by the way staticcheck looks for files for a certain package, which doesn't
+// support *_test.go files.
+//
+// Move those to binary_test.go when staticcheck is fixed.
+
+package binarylog
+
+var (
+	// AllLogger is a logger that logs all headers/messages for all RPCs. It's
+	// for testing only.
+	AllLogger = NewLoggerFromConfigString("*")
+	// MdToMetadataProto converts metadata to a binary logging proto message.
+	// It's for testing only.
+	MdToMetadataProto = mdToMetadataProto
+	// AddrToProto converts an address to a binary logging proto message. It's
+	// for testing only.
+	AddrToProto = addrToProto
+)

--- a/internal/binarylog/env_config.go
+++ b/internal/binarylog/env_config.go
@@ -28,7 +28,8 @@ import (
 	"google.golang.org/grpc/grpclog"
 )
 
-// newLoggerFromConfigString reads the string and build a logger.
+// NewLoggerFromConfigString reads the string and build a logger. It can be used
+// to build a new logger and assign it to binarylog.Logger.
 //
 // Example filter config strings:
 //  - "" Nothing will be logged
@@ -43,7 +44,7 @@ import (
 //
 // If two configs exist for one certain method or service, the one specified
 // later overrides the privous config.
-func newLoggerFromConfigString(s string) *logger {
+func NewLoggerFromConfigString(s string) Logger {
 	l := newEmptyLogger()
 	methods := strings.Split(s, ",")
 	for _, method := range methods {

--- a/internal/binarylog/env_config_test.go
+++ b/internal/binarylog/env_config_test.go
@@ -34,7 +34,7 @@ func TestNewLoggerFromConfigString(t *testing.T) {
 		fullM2 = s1 + "/" + m2
 	)
 	c := fmt.Sprintf("*{h:1;m:2},%s{h},%s{m},%s{h;m}", s1+"/*", fullM1, fullM2)
-	l := newLoggerFromConfigString(c)
+	l := NewLoggerFromConfigString(c).(*logger)
 
 	if l.all.hdr != 1 || l.all.msg != 2 {
 		t.Errorf("l.all = %#v, want headerLen: 1, messageLen: 2", l.all)
@@ -83,7 +83,7 @@ func TestNewLoggerFromConfigStringInvalid(t *testing.T) {
 		"*,*{h:1;m:1}",
 	}
 	for _, tc := range testCases {
-		l := newLoggerFromConfigString(tc)
+		l := NewLoggerFromConfigString(tc)
 		if l != nil {
 			t.Errorf("With config %q, want logger %v, got %v", tc, nil, l)
 		}

--- a/internal/binarylog/method_logger.go
+++ b/internal/binarylog/method_logger.go
@@ -372,7 +372,7 @@ func (c *Cancel) toProto() *pb.GrpcLogEntry {
 // omitted.
 func metadataKeyOmit(key string) bool {
 	switch key {
-	case "lb-token", ":path", ":authority", "content-encoding", "user-agent", "te":
+	case "lb-token", ":path", ":authority", "content-encoding", "content-type", "user-agent", "te":
 		return true
 	case "grpc-trace-bin": // grpc-trace-bin is special because it's visiable to users.
 		return false

--- a/internal/binarylog/method_logger.go
+++ b/internal/binarylog/method_logger.go
@@ -206,8 +206,8 @@ func (c *ServerHeader) toProto() *pb.GrpcLogEntry {
 // ClientMessage configs the binary log entry to be a ClientMessage entry.
 type ClientMessage struct {
 	OnClientSide bool
-	// Message should only be a proto.Message. Could add support for other
-	// message types in the future.
+	// Message can be a proto.Message or []byte. Other messages formats are not
+	// supported.
 	Message interface{}
 }
 
@@ -246,8 +246,8 @@ func (c *ClientMessage) toProto() *pb.GrpcLogEntry {
 // ServerMessage configs the binary log entry to be a ServerMessage entry.
 type ServerMessage struct {
 	OnClientSide bool
-	// Message should only be a proto.Message. Could add support for other
-	// message types in the future.
+	// Message can be a proto.Message or []byte. Other messages formats are not
+	// supported.
 	Message interface{}
 }
 

--- a/internal/binarylog/method_logger_test.go
+++ b/internal/binarylog/method_logger_test.go
@@ -37,7 +37,7 @@ func TestLog(t *testing.T) {
 	ml := newMethodLogger(10, 10)
 	// Set sink to testing buffer.
 	buf := bytes.NewBuffer(nil)
-	ml.sink = NewWriterSink(buf)
+	ml.sink = newWriterSink(buf)
 
 	addr := "1.2.3.4"
 	port := 790
@@ -337,7 +337,7 @@ func TestLog(t *testing.T) {
 		tc.want.SequenceIdWithinCall = uint64(i + 1)
 		ml.Log(tc.config)
 		inSink := new(pb.GrpcLogEntry)
-		if err := proto.Unmarshal(buf.Bytes(), inSink); err != nil {
+		if err := proto.Unmarshal(buf.Bytes()[4:], inSink); err != nil {
 			t.Errorf("failed to unmarshal bytes in sink to proto: %v", err)
 			continue
 		}

--- a/internal/binarylog/sink.go
+++ b/internal/binarylog/sink.go
@@ -61,7 +61,7 @@ func (ns *noopSink) Close()                 {}
 // newWriterSink creates a binary log sink with the given writer.
 //
 // Write() marshalls the proto message and writes it to the given writer. Each
-// message is prefixed with a 4 byte big endial unsigned integer as the length.
+// message is prefixed with a 4 byte big endian unsigned integer as the length.
 //
 // No buffer is done, Close() doesn't try to close the writer.
 func newWriterSink(w io.Writer) *writerSink {
@@ -87,7 +87,7 @@ func (ws *writerSink) Close() {}
 
 type bufWriteCloserSink struct {
 	closer io.Closer
-	out    *writerSink   // out is built upen buf.
+	out    *writerSink   // out is built on buf.
 	buf    *bufio.Writer // buf is kept for flush.
 
 	writeStartOnce sync.Once

--- a/internal/binarylog/sink.go
+++ b/internal/binarylog/sink.go
@@ -19,7 +19,13 @@
 package binarylog
 
 import (
+	"bufio"
+	"encoding/binary"
+	"fmt"
 	"io"
+	"io/ioutil"
+	"sync"
+	"time"
 
 	"github.com/golang/protobuf/proto"
 	pb "google.golang.org/grpc/binarylog/grpc_binarylog_v1"
@@ -34,20 +40,31 @@ var (
 //
 // Not thread safe. Only set during initialization.
 func SetDefaultSink(s Sink) {
+	if defaultSink != nil {
+		defaultSink.Close()
+	}
 	defaultSink = s
 }
 
 // Sink writes log entry into the binary log sink.
 type Sink interface {
 	Write(*pb.GrpcLogEntry)
+	// Close will be called when the Sink is replaced by a new Sink.
+	Close()
 }
 
 type noopSink struct{}
 
 func (ns *noopSink) Write(*pb.GrpcLogEntry) {}
+func (ns *noopSink) Close()                 {}
 
-// NewWriterSink creates a binary log sink with the given writer.
-func NewWriterSink(w io.Writer) Sink {
+// newWriterSink creates a binary log sink with the given writer.
+//
+// Write() marshalls the proto message and writes it to the given writer. Each
+// message is prefixed with a 4 byte big endial unsigned integer as the length.
+//
+// No buffer is done, Close() doesn't try to close the writer.
+func newWriterSink(w io.Writer) *writerSink {
 	return &writerSink{out: w}
 }
 
@@ -55,10 +72,71 @@ type writerSink struct {
 	out io.Writer
 }
 
-func (fs *writerSink) Write(e *pb.GrpcLogEntry) {
+func (ws *writerSink) Write(e *pb.GrpcLogEntry) {
 	b, err := proto.Marshal(e)
 	if err != nil {
 		grpclog.Infof("binary logging: failed to marshal proto message: %v", err)
 	}
-	fs.out.Write(b)
+	hdr := make([]byte, 4)
+	binary.BigEndian.PutUint32(hdr, uint32(len(b)))
+	ws.out.Write(hdr)
+	ws.out.Write(b)
+}
+
+func (ws *writerSink) Close() {}
+
+type bufWriteCloserSink struct {
+	closer io.Closer
+	out    *writerSink   // out is built upen buf.
+	buf    *bufio.Writer // buf is kept for flush.
+
+	writeStartOnce sync.Once
+	writeTicker    *time.Ticker
+}
+
+func (fs *bufWriteCloserSink) Write(e *pb.GrpcLogEntry) {
+	// Start the write loop when Write is called.
+	fs.writeStartOnce.Do(fs.startFlushGoroutine)
+	fs.out.Write(e)
+}
+
+const (
+	bufFlushDuration = 60 * time.Second
+)
+
+func (fs *bufWriteCloserSink) startFlushGoroutine() {
+	fs.writeTicker = time.NewTicker(bufFlushDuration)
+	go func() {
+		for range fs.writeTicker.C {
+			fs.buf.Flush()
+		}
+	}()
+}
+
+func (fs *bufWriteCloserSink) Close() {
+	if fs.writeTicker != nil {
+		fs.writeTicker.Stop()
+	}
+	fs.buf.Flush()
+	fs.closer.Close()
+	fs.out.Close()
+}
+
+func newBufWriteCloserSink(o io.WriteCloser) Sink {
+	bufW := bufio.NewWriter(o)
+	return &bufWriteCloserSink{
+		closer: o,
+		out:    newWriterSink(bufW),
+		buf:    bufW,
+	}
+}
+
+// NewTempFileSink creates a temp file and returns a Sink that writes to this
+// file.
+func NewTempFileSink() (Sink, error) {
+	tempFile, err := ioutil.TempFile("/tmp", "grpcgo_binarylog_*.txt")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create temp file: %v", err)
+	}
+	return newBufWriteCloserSink(tempFile), nil
 }

--- a/internal/transport/transport.go
+++ b/internal/transport/transport.go
@@ -270,6 +270,11 @@ func (s *Stream) Done() <-chan struct{} {
 // is available. It blocks until i) the metadata is ready or ii) there is no
 // header metadata or iii) the stream is canceled/expired.
 func (s *Stream) Header() (metadata.MD, error) {
+	if s.headerChan == nil && s.header != nil {
+		// On server side, return the header in stream. It will be the out
+		// header after t.WriteHeader is called.
+		return s.header.Copy(), nil
+	}
 	err := s.waitOnHeader()
 	// Even if the stream is closed, header is returned if available.
 	select {

--- a/internal/transport/transport.go
+++ b/internal/transport/transport.go
@@ -186,8 +186,12 @@ type Stream struct {
 	headerDone uint32        // set when headerChan is closed. Used to avoid closing headerChan multiple times.
 
 	// hdrMu protects header and trailer metadata on the server-side.
-	hdrMu   sync.Mutex
-	header  metadata.MD // the received header metadata.
+	hdrMu sync.Mutex
+	// On client side, header keeps the received header metadata.
+	//
+	// On server side, header keeps the header set by SetHeader(). The complete
+	// header will merged into this after t.WriteHeader() is called.
+	header  metadata.MD
 	trailer metadata.MD // the key-value map of trailer metadata.
 
 	noHeaders bool // set if the client never received headers (set only after the stream is done).
@@ -266,9 +270,13 @@ func (s *Stream) Done() <-chan struct{} {
 	return s.done
 }
 
-// Header acquires the key-value pairs of header metadata once it
-// is available. It blocks until i) the metadata is ready or ii) there is no
-// header metadata or iii) the stream is canceled/expired.
+// Header returns the header metadata of the stream.
+//
+// On client side, it acquires the key-value pairs of header metadata once it is
+// available. It blocks until i) the metadata is ready or ii) there is no header
+// metadata or iii) the stream is canceled/expired.
+//
+// On server side, it returns the out header after t.WriteHeader is called.
 func (s *Stream) Header() (metadata.MD, error) {
 	if s.headerChan == nil && s.header != nil {
 		// On server side, return the header in stream. It will be the out

--- a/server.go
+++ b/server.go
@@ -40,10 +40,12 @@ import (
 	"google.golang.org/grpc/encoding"
 	"google.golang.org/grpc/encoding/proto"
 	"google.golang.org/grpc/grpclog"
+	"google.golang.org/grpc/internal/binarylog"
 	"google.golang.org/grpc/internal/channelz"
 	"google.golang.org/grpc/internal/transport"
 	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/stats"
 	"google.golang.org/grpc/status"
 	"google.golang.org/grpc/tap"
@@ -862,6 +864,30 @@ func (s *Server) processUnaryRPC(t transport.ServerTransport, stream *transport.
 		}()
 	}
 
+	binlog := binarylog.GetMethodLogger(stream.Method())
+	if binlog != nil {
+		ctx := stream.Context()
+		md, _ := metadata.FromIncomingContext(ctx)
+		logEntry := &binarylog.ClientHeader{
+			Header:     md,
+			MethodName: stream.Method(),
+			PeerAddr:   nil,
+		}
+		if deadline, ok := ctx.Deadline(); ok {
+			logEntry.Timeout = deadline.Sub(time.Now())
+			if logEntry.Timeout < 0 {
+				logEntry.Timeout = 0
+			}
+		}
+		if a := md[":authority"]; len(a) > 0 {
+			logEntry.Authority = a[0]
+		}
+		if peer, ok := peer.FromContext(ctx); ok {
+			logEntry.PeerAddr = peer.Addr
+		}
+		binlog.Log(logEntry)
+	}
+
 	// comp and cp are used for compression.  decomp and dc are used for
 	// decompression.  If comp and decomp are both set, they are the same;
 	// however they are kept separate to ensure that at most one of the
@@ -898,13 +924,11 @@ func (s *Server) processUnaryRPC(t transport.ServerTransport, stream *transport.
 		}
 	}
 
-	var inPayload *stats.InPayload
-	if sh != nil {
-		inPayload = &stats.InPayload{
-			RecvTime: time.Now(),
-		}
+	var payInfo *payloadInfo
+	if sh != nil || binlog != nil {
+		payInfo = &payloadInfo{}
 	}
-	d, err := recvAndDecompress(&parser{r: stream}, stream, dc, s.opts.maxReceiveMessageSize, inPayload, decomp)
+	d, err := recvAndDecompress(&parser{r: stream}, stream, dc, s.opts.maxReceiveMessageSize, payInfo, decomp)
 	if err != nil {
 		if st, ok := status.FromError(err); ok {
 			if e := t.WriteStatus(stream, st); e != nil {
@@ -920,11 +944,18 @@ func (s *Server) processUnaryRPC(t transport.ServerTransport, stream *transport.
 		if err := s.getCodec(stream.ContentSubtype()).Unmarshal(d, v); err != nil {
 			return status.Errorf(codes.Internal, "grpc: error unmarshalling request: %v", err)
 		}
-		if inPayload != nil {
-			inPayload.Payload = v
-			inPayload.Data = d
-			inPayload.Length = len(d)
-			sh.HandleRPC(stream.Context(), inPayload)
+		if sh != nil {
+			sh.HandleRPC(stream.Context(), &stats.InPayload{
+				RecvTime: time.Now(),
+				Payload:  v,
+				Data:     d,
+				Length:   len(d),
+			})
+		}
+		if binlog != nil {
+			binlog.Log(&binarylog.ClientMessage{
+				Message: d,
+			})
 		}
 		if trInfo != nil {
 			trInfo.tr.LazyLog(&payload{sent: false, msg: v}, true)
@@ -946,6 +977,19 @@ func (s *Server) processUnaryRPC(t transport.ServerTransport, stream *transport.
 		}
 		if e := t.WriteStatus(stream, appStatus); e != nil {
 			grpclog.Warningf("grpc: Server.processUnaryRPC failed to write status: %v", e)
+		}
+		if binlog != nil {
+			if h, _ := stream.Header(); h.Len() > 0 {
+				// Only log serverHeader if there was header. Otherwise it can
+				// be trailer only.
+				binlog.Log(&binarylog.ServerHeader{
+					Header: h,
+				})
+			}
+			binlog.Log(&binarylog.ServerTrailer{
+				Trailer: stream.Trailer(),
+				Err:     appErr,
+			})
 		}
 		return appErr
 	}
@@ -971,7 +1015,26 @@ func (s *Server) processUnaryRPC(t transport.ServerTransport, stream *transport.
 				panic(fmt.Sprintf("grpc: Unexpected error (%T) from sendResponse: %v", st, st))
 			}
 		}
+		if binlog != nil {
+			h, _ := stream.Header()
+			binlog.Log(&binarylog.ServerHeader{
+				Header: h,
+			})
+			binlog.Log(&binarylog.ServerTrailer{
+				Trailer: stream.Trailer(),
+				Err:     appErr,
+			})
+		}
 		return err
+	}
+	if binlog != nil {
+		h, _ := stream.Header()
+		binlog.Log(&binarylog.ServerHeader{
+			Header: h,
+		})
+		binlog.Log(&binarylog.ServerMessage{
+			Message: reply,
+		})
 	}
 	if channelz.IsOn() {
 		t.IncrMsgSent()
@@ -982,7 +1045,14 @@ func (s *Server) processUnaryRPC(t transport.ServerTransport, stream *transport.
 	// TODO: Should we be logging if writing status failed here, like above?
 	// Should the logging be in WriteStatus?  Should we ignore the WriteStatus
 	// error or allow the stats handler to see it?
-	return t.WriteStatus(stream, status.New(codes.OK, ""))
+	err = t.WriteStatus(stream, status.New(codes.OK, ""))
+	if binlog != nil {
+		binlog.Log(&binarylog.ServerTrailer{
+			Trailer: stream.Trailer(),
+			Err:     appErr,
+		})
+	}
+	return err
 }
 
 func (s *Server) processStreamingRPC(t transport.ServerTransport, stream *transport.Stream, srv *service, sd *StreamDesc, trInfo *traceInfo) (err error) {
@@ -1025,6 +1095,29 @@ func (s *Server) processStreamingRPC(t transport.ServerTransport, stream *transp
 		maxSendMessageSize:    s.opts.maxSendMessageSize,
 		trInfo:                trInfo,
 		statsHandler:          sh,
+	}
+
+	ss.binlog = binarylog.GetMethodLogger(stream.Method())
+	if ss.binlog != nil {
+		md, _ := metadata.FromIncomingContext(ctx)
+		logEntry := &binarylog.ClientHeader{
+			Header:     md,
+			MethodName: stream.Method(),
+			PeerAddr:   nil,
+		}
+		if deadline, ok := ctx.Deadline(); ok {
+			logEntry.Timeout = deadline.Sub(time.Now())
+			if logEntry.Timeout < 0 {
+				logEntry.Timeout = 0
+			}
+		}
+		if a := md[":authority"]; len(a) > 0 {
+			logEntry.Authority = a[0]
+		}
+		if peer, ok := peer.FromContext(ss.Context()); ok {
+			logEntry.PeerAddr = peer.Addr
+		}
+		ss.binlog.Log(logEntry)
 	}
 
 	// If dc is set and matches the stream's compression, use it.  Otherwise, try
@@ -1096,6 +1189,12 @@ func (s *Server) processStreamingRPC(t transport.ServerTransport, stream *transp
 			ss.mu.Unlock()
 		}
 		t.WriteStatus(ss.s, appStatus)
+		if ss.binlog != nil {
+			ss.binlog.Log(&binarylog.ServerTrailer{
+				Trailer: ss.s.Trailer(),
+				Err:     appErr,
+			})
+		}
 		// TODO: Should we log an error from WriteStatus here and below?
 		return appErr
 	}
@@ -1104,7 +1203,14 @@ func (s *Server) processStreamingRPC(t transport.ServerTransport, stream *transp
 		ss.trInfo.tr.LazyLog(stringer("OK"), false)
 		ss.mu.Unlock()
 	}
-	return t.WriteStatus(ss.s, status.New(codes.OK, ""))
+	err = t.WriteStatus(ss.s, status.New(codes.OK, ""))
+	if ss.binlog != nil {
+		ss.binlog.Log(&binarylog.ServerTrailer{
+			Trailer: ss.s.Trailer(),
+			Err:     appErr,
+		})
+	}
+	return err
 }
 
 func (s *Server) handleStream(t transport.ServerTransport, stream *transport.Stream, trInfo *traceInfo) {

--- a/stream.go
+++ b/stream.go
@@ -32,10 +32,12 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/encoding"
 	"google.golang.org/grpc/grpclog"
+	"google.golang.org/grpc/internal/binarylog"
 	"google.golang.org/grpc/internal/channelz"
 	"google.golang.org/grpc/internal/grpcrand"
 	"google.golang.org/grpc/internal/transport"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/stats"
 	"google.golang.org/grpc/status"
 )
@@ -262,6 +264,7 @@ func newClientStream(ctx context.Context, desc *StreamDesc, cc *ClientConn, meth
 	if !cc.dopts.disableRetry {
 		cs.retryThrottler = cc.retryThrottler.Load().(*retryThrottler)
 	}
+	cs.binlog = binarylog.GetMethodLogger(method)
 
 	cs.callInfo.stream = cs
 	// Only this initial attempt has stats/tracing.
@@ -275,6 +278,23 @@ func newClientStream(ctx context.Context, desc *StreamDesc, cc *ClientConn, meth
 	if err := cs.withRetry(op, func() { cs.bufferForRetryLocked(0, op) }); err != nil {
 		cs.finish(err)
 		return nil, err
+	}
+
+	if cs.binlog != nil {
+		md, _ := metadata.FromOutgoingContext(ctx)
+		logEntry := &binarylog.ClientHeader{
+			OnClientSide: true,
+			Header:       md,
+			MethodName:   method,
+			Authority:    cs.cc.authority,
+		}
+		if deadline, ok := ctx.Deadline(); ok {
+			logEntry.Timeout = deadline.Sub(time.Now())
+			if logEntry.Timeout < 0 {
+				logEntry.Timeout = 0
+			}
+		}
+		cs.binlog.Log(logEntry)
 	}
 
 	if desc != unaryStreamDesc {
@@ -349,6 +369,15 @@ type clientStream struct {
 	ctx context.Context // the application's context, wrapped by stats/tracing
 
 	retryThrottler *retryThrottler // The throttler active when the RPC began.
+
+	binlog *binarylog.MethodLogger // Binary logger, can be nil.
+	// serverHeaderBinlogged is a boolean for whether server header has been
+	// logged. Server header will be logged when the first time one of those
+	// happens: stream.Header(), stream.Recv().
+	//
+	// It's only read and used by Recv() and Header(), so it doesn't need to be
+	// synchronized.
+	serverHeaderBinlogged bool
 
 	mu                      sync.Mutex
 	firstAttempt            bool       // if true, transparent retry is valid
@@ -561,6 +590,20 @@ func (cs *clientStream) Header() (metadata.MD, error) {
 	}, cs.commitAttemptLocked)
 	if err != nil {
 		cs.finish(err)
+		return nil, err
+	}
+	if cs.binlog != nil && !cs.serverHeaderBinlogged {
+		// Only log if binary log is on and header has not been logged.
+		logEntry := &binarylog.ServerHeader{
+			OnClientSide: true,
+			Header:       m,
+			PeerAddr:     nil,
+		}
+		if peer, ok := peer.FromContext(cs.Context()); ok {
+			logEntry.PeerAddr = peer.Addr
+		}
+		cs.binlog.Log(logEntry)
+		cs.serverHeaderBinlogged = true
 	}
 	return m, err
 }
@@ -633,6 +676,7 @@ func (cs *clientStream) SendMsg(m interface{}) (err error) {
 	if len(payload) > *cs.callInfo.maxSendMessageSize {
 		return status.Errorf(codes.ResourceExhausted, "trying to send message larger than max (%d vs. %d)", len(payload), *cs.callInfo.maxSendMessageSize)
 	}
+	msgBytes := data // Store the pointer before setting to nil. For binary logging.
 	op := func(a *csAttempt) error {
 		err := a.sendMsg(m, hdr, payload, data)
 		// nil out the message and uncomp when replaying; they are only needed for
@@ -640,16 +684,53 @@ func (cs *clientStream) SendMsg(m interface{}) (err error) {
 		m, data = nil, nil
 		return err
 	}
-	return cs.withRetry(op, func() { cs.bufferForRetryLocked(len(hdr)+len(payload), op) })
+	err = cs.withRetry(op, func() { cs.bufferForRetryLocked(len(hdr)+len(payload), op) })
+	if cs.binlog != nil && err == nil {
+		cs.binlog.Log(&binarylog.ClientMessage{
+			OnClientSide: true,
+			Message:      msgBytes,
+		})
+	}
+	return
 }
 
 func (cs *clientStream) RecvMsg(m interface{}) error {
+	if cs.binlog != nil && !cs.serverHeaderBinlogged {
+		// Call Header() to binary log header if it's not already logged.
+		cs.Header()
+	}
+	var recvInfo *payloadInfo
+	if cs.binlog != nil {
+		recvInfo = &payloadInfo{}
+	}
 	err := cs.withRetry(func(a *csAttempt) error {
-		return a.recvMsg(m)
+		return a.recvMsg(m, recvInfo)
 	}, cs.commitAttemptLocked)
+	if cs.binlog != nil && err == nil {
+		cs.binlog.Log(&binarylog.ServerMessage{
+			OnClientSide: true,
+			Message:      recvInfo.uncompressedBytes,
+		})
+	}
 	if err != nil || !cs.desc.ServerStreams {
 		// err != nil or non-server-streaming indicates end of stream.
 		cs.finish(err)
+
+		if cs.binlog != nil {
+			// finish will not log Trailer. Log Trailer here.
+			logEntry := &binarylog.ServerTrailer{
+				OnClientSide: true,
+				Trailer:      cs.Trailer(),
+				Err:          err,
+			}
+			if logEntry.Err == io.EOF {
+				logEntry.Err = nil
+			}
+			if peer, ok := peer.FromContext(cs.Context()); ok {
+				logEntry.PeerAddr = peer.Addr
+			}
+			cs.binlog.Log(logEntry)
+		}
 	}
 	return err
 }
@@ -669,6 +750,11 @@ func (cs *clientStream) CloseSend() error {
 		return nil
 	}
 	cs.withRetry(op, func() { cs.bufferForRetryLocked(0, op) })
+	if cs.binlog != nil {
+		cs.binlog.Log(&binarylog.ClientHalfClose{
+			OnClientSide: true,
+		})
+	}
 	// We never returned an error here for reasons.
 	return nil
 }
@@ -686,6 +772,16 @@ func (cs *clientStream) finish(err error) {
 	cs.finished = true
 	cs.commitAttemptLocked()
 	cs.mu.Unlock()
+	// For binaly logging. only log cancel in finish (could be caused by RPC ctx
+	// canceled or ClientConn closed). Trailer will be logged in RecvMsg.
+	//
+	// Only one of cancel or trailer needs to be logged. In the cases where
+	// users don't call RecvMsg, users must have already canceled the RPC.
+	if cs.binlog != nil && status.Code(err) == codes.Canceled {
+		cs.binlog.Log(&binarylog.Cancel{
+			OnClientSide: true,
+		})
+	}
 	if err == nil {
 		cs.retryThrottler.successfulRPC()
 	}
@@ -735,14 +831,12 @@ func (a *csAttempt) sendMsg(m interface{}, hdr, payld, data []byte) error {
 	return nil
 }
 
-func (a *csAttempt) recvMsg(m interface{}) (err error) {
+func (a *csAttempt) recvMsg(m interface{}, payInfo *payloadInfo) (err error) {
 	cs := a.cs
-	var inPayload *stats.InPayload
-	if a.statsHandler != nil {
-		inPayload = &stats.InPayload{
-			Client: true,
-		}
+	if a.statsHandler != nil && payInfo == nil {
+		payInfo = &payloadInfo{}
 	}
+
 	if !a.decompSet {
 		// Block until we receive headers containing received message encoding.
 		if ct := a.s.RecvCompress(); ct != "" && ct != encoding.Identity {
@@ -759,7 +853,7 @@ func (a *csAttempt) recvMsg(m interface{}) (err error) {
 		// Only initialize this state once per stream.
 		a.decompSet = true
 	}
-	err = recv(a.p, cs.codec, a.s, a.dc, m, *cs.callInfo.maxReceiveMessageSize, inPayload, a.decomp)
+	err = recv(a.p, cs.codec, a.s, a.dc, m, *cs.callInfo.maxReceiveMessageSize, payInfo, a.decomp)
 	if err != nil {
 		if err == io.EOF {
 			if statusErr := a.s.Status().Err(); statusErr != nil {
@@ -776,8 +870,15 @@ func (a *csAttempt) recvMsg(m interface{}) (err error) {
 		}
 		a.mu.Unlock()
 	}
-	if inPayload != nil {
-		a.statsHandler.HandleRPC(cs.ctx, inPayload)
+	if a.statsHandler != nil {
+		a.statsHandler.HandleRPC(cs.ctx, &stats.InPayload{
+			Client:   true,
+			RecvTime: time.Now(),
+			Payload:  m,
+			// TODO truncate large payload.
+			Data:   payInfo.uncompressedBytes,
+			Length: len(payInfo.uncompressedBytes),
+		})
 	}
 	if channelz.IsOn() {
 		a.t.IncrMsgRecv()
@@ -786,7 +887,6 @@ func (a *csAttempt) recvMsg(m interface{}) (err error) {
 		// Subsequent messages should be received by subsequent RecvMsg calls.
 		return nil
 	}
-
 	// Special handling for non-server-stream rpcs.
 	// This recv expects EOF or errors, so we don't collect inPayload.
 	err = recv(a.p, cs.codec, a.s, a.dc, m, *cs.callInfo.maxReceiveMessageSize, nil, a.decomp)
@@ -916,6 +1016,15 @@ type serverStream struct {
 
 	statsHandler stats.Handler
 
+	binlog *binarylog.MethodLogger
+	// serverHeaderBinlogged indicates whether server header has been logged. It
+	// will happen when one of the following two happens: stream.SendHeader(),
+	// stream.Send().
+	//
+	// It's only checked in send and sendHeader, doesn't need to be
+	// synchronized.
+	serverHeaderBinlogged bool
+
 	mu sync.Mutex // protects trInfo.tr after the service handler runs.
 }
 
@@ -931,7 +1040,15 @@ func (ss *serverStream) SetHeader(md metadata.MD) error {
 }
 
 func (ss *serverStream) SendHeader(md metadata.MD) error {
-	return ss.t.WriteHeader(ss.s, md)
+	err := ss.t.WriteHeader(ss.s, md)
+	if ss.binlog != nil && !ss.serverHeaderBinlogged {
+		h, _ := ss.s.Header()
+		ss.binlog.Log(&binarylog.ServerHeader{
+			Header: h,
+		})
+		ss.serverHeaderBinlogged = true
+	}
+	return err
 }
 
 func (ss *serverStream) SetTrailer(md metadata.MD) {
@@ -958,6 +1075,12 @@ func (ss *serverStream) SendMsg(m interface{}) (err error) {
 		if err != nil && err != io.EOF {
 			st, _ := status.FromError(toRPCErr(err))
 			ss.t.WriteStatus(ss.s, st)
+			// Non-user specified status was sent out. This should be an error
+			// case (as a server side Cancel maybe).
+			//
+			// This is not handled specifically now. User will return a final
+			// status from the service handler, we will log that error instead.
+			// This behavior is similiar to an interceptor.
 		}
 		if channelz.IsOn() && err == nil {
 			ss.t.IncrMsgSent()
@@ -978,6 +1101,18 @@ func (ss *serverStream) SendMsg(m interface{}) (err error) {
 	}
 	if err := ss.t.Write(ss.s, hdr, payload, &transport.Options{Last: false}); err != nil {
 		return toRPCErr(err)
+	}
+	if ss.binlog != nil {
+		if !ss.serverHeaderBinlogged {
+			h, _ := ss.s.Header()
+			ss.binlog.Log(&binarylog.ServerHeader{
+				Header: h,
+			})
+			ss.serverHeaderBinlogged = true
+		}
+		ss.binlog.Log(&binarylog.ServerMessage{
+			Message: data,
+		})
 	}
 	if ss.statsHandler != nil {
 		ss.statsHandler.HandleRPC(ss.s.Context(), outPayload(false, m, data, payload, time.Now()))
@@ -1002,17 +1137,26 @@ func (ss *serverStream) RecvMsg(m interface{}) (err error) {
 		if err != nil && err != io.EOF {
 			st, _ := status.FromError(toRPCErr(err))
 			ss.t.WriteStatus(ss.s, st)
+			// Non-user specified status was sent out. This should be an error
+			// case (as a server side Cancel maybe).
+			//
+			// This is not handled specifically now. User will return a final
+			// status from the service handler, we will log that error instead.
+			// This behavior is similiar to an interceptor.
 		}
 		if channelz.IsOn() && err == nil {
 			ss.t.IncrMsgRecv()
 		}
 	}()
-	var inPayload *stats.InPayload
-	if ss.statsHandler != nil {
-		inPayload = &stats.InPayload{}
+	var payInfo *payloadInfo
+	if ss.statsHandler != nil || ss.binlog != nil {
+		payInfo = &payloadInfo{}
 	}
-	if err := recv(ss.p, ss.codec, ss.s, ss.dc, m, ss.maxReceiveMessageSize, inPayload, ss.decomp); err != nil {
+	if err := recv(ss.p, ss.codec, ss.s, ss.dc, m, ss.maxReceiveMessageSize, payInfo, ss.decomp); err != nil {
 		if err == io.EOF {
+			if ss.binlog != nil {
+				ss.binlog.Log(&binarylog.ClientHalfClose{})
+			}
 			return err
 		}
 		if err == io.ErrUnexpectedEOF {
@@ -1020,8 +1164,19 @@ func (ss *serverStream) RecvMsg(m interface{}) (err error) {
 		}
 		return toRPCErr(err)
 	}
-	if inPayload != nil {
-		ss.statsHandler.HandleRPC(ss.s.Context(), inPayload)
+	if ss.statsHandler != nil {
+		ss.statsHandler.HandleRPC(ss.s.Context(), &stats.InPayload{
+			RecvTime: time.Now(),
+			Payload:  m,
+			// TODO truncate large payload.
+			Data:   payInfo.uncompressedBytes,
+			Length: len(payInfo.uncompressedBytes),
+		})
+	}
+	if ss.binlog != nil {
+		ss.binlog.Log(&binarylog.ClientMessage{
+			Message: payInfo.uncompressedBytes,
+		})
 	}
 	return nil
 }

--- a/stream.go
+++ b/stream.go
@@ -772,7 +772,7 @@ func (cs *clientStream) finish(err error) {
 	cs.finished = true
 	cs.commitAttemptLocked()
 	cs.mu.Unlock()
-	// For binaly logging. only log cancel in finish (could be caused by RPC ctx
+	// For binary logging. only log cancel in finish (could be caused by RPC ctx
 	// canceled or ClientConn closed). Trailer will be logged in RecvMsg.
 	//
 	// Only one of cancel or trailer needs to be logged. In the cases where

--- a/stream.go
+++ b/stream.go
@@ -1080,7 +1080,7 @@ func (ss *serverStream) SendMsg(m interface{}) (err error) {
 			//
 			// This is not handled specifically now. User will return a final
 			// status from the service handler, we will log that error instead.
-			// This behavior is similiar to an interceptor.
+			// This behavior is similar to an interceptor.
 		}
 		if channelz.IsOn() && err == nil {
 			ss.t.IncrMsgSent()
@@ -1142,7 +1142,7 @@ func (ss *serverStream) RecvMsg(m interface{}) (err error) {
 			//
 			// This is not handled specifically now. User will return a final
 			// status from the service handler, we will log that error instead.
-			// This behavior is similiar to an interceptor.
+			// This behavior is similar to an interceptor.
 		}
 		if channelz.IsOn() && err == nil {
 			ss.t.IncrMsgRecv()


### PR DESCRIPTION
Also includes:
 - Export `NewLoggerFromConfigString` so it can be also used when config string is specified in another way (e.g. command line flag)
 - Export `Logger` so user can install custom sink
 - Add temp file sink implementation

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grpc/grpc-go/2388)
<!-- Reviewable:end -->
