### PR TITLE
internal: transport nil should happen before backoff

### DIFF
--- a/clientconn.go
+++ b/clientconn.go
@@ -965,6 +965,7 @@ func (ac *addrConn) resetTransport(resolveNow bool) {
 			ac.updateConnectivityState(connectivity.TransientFailure)
 			ac.cc.handleSubConnStateChange(ac.acbw, ac.state)
 		}
+		ac.transport = nil
 		ac.mu.Unlock()
 
 		if err := ac.nextAddr(); err != nil {
@@ -976,7 +977,6 @@ func (ac *addrConn) resetTransport(resolveNow bool) {
 			ac.mu.Unlock()
 			return
 		}
-		ac.transport = nil
 
 		backoffIdx := ac.backoffIdx
 		backoffFor := ac.dopts.bs.Backoff(backoffIdx)


### PR DESCRIPTION
Seems to fix https://travis-ci.org/grpc/grpc-go/jobs/443409852, but regardless
it's a more correct place for it to happen.