### PR TITLE
client: block RPCs early until the resolver has returned addresses

### DIFF
--- a/internal/grpcsync/event.go
+++ b/internal/grpcsync/event.go
@@ -20,12 +20,16 @@
 // the sync package.
 package grpcsync
 
-import "sync"
+import (
+	"sync"
+	"sync/atomic"
+)
 
 // Event represents a one-time event that may occur in the future.
 type Event struct {
-	c chan struct{}
-	o sync.Once
+	fired int32
+	c     chan struct{}
+	o     sync.Once
 }
 
 // Fire causes e to complete.  It is safe to call multiple times, and
@@ -34,6 +38,7 @@ type Event struct {
 func (e *Event) Fire() bool {
 	ret := false
 	e.o.Do(func() {
+		atomic.StoreInt32(&e.fired, 1)
 		close(e.c)
 		ret = true
 	})
@@ -47,12 +52,7 @@ func (e *Event) Done() <-chan struct{} {
 
 // HasFired returns true if Fire has been called.
 func (e *Event) HasFired() bool {
-	select {
-	case <-e.c:
-		return true
-	default:
-		return false
-	}
+	return atomic.LoadInt32(&e.fired) == 1
 }
 
 // NewEvent returns a new, ready-to-use Event.

--- a/stream.go
+++ b/stream.go
@@ -166,6 +166,11 @@ func newClientStream(ctx context.Context, desc *StreamDesc, cc *ClientConn, meth
 		}()
 	}
 	c := defaultCallInfo()
+	// Provide an opportunity for the first RPC to see the first service config
+	// provided by the resolver.
+	if err := cc.waitForResolvedAddrs(ctx); err != nil {
+		return nil, err
+	}
 	mc := cc.GetMethodConfig(method)
 	if mc.WaitForReady != nil {
 		c.failFast = !*mc.WaitForReady


### PR DESCRIPTION
This allows the initial RPC(s) an opportunity to apply settings from the service config; without this change we would still block, but only after observing the current service config settings.
