### PR TITLE
client: add GRPC_GO_REQUIRE_HANDSHAKE options to control connection behavior

### DIFF
--- a/clientconn.go
+++ b/clientconn.go
@@ -1131,10 +1131,6 @@ func (ac *addrConn) createTransport(backoffNum int, addr resolver.Address, copts
 		serverPrefaceReceived = true
 		if clientPrefaceWrote {
 			ac.successfulHandshake = true
-			ac.backoffDeadline = time.Time{}
-			ac.connectDeadline = time.Time{}
-			ac.addrIdx = 0
-			ac.backoffIdx = 0
 		}
 		prefaceMu.Unlock()
 
@@ -1312,11 +1308,14 @@ func (ac *addrConn) startHealthCheck(ctx context.Context, newTr transport.Client
 func (ac *addrConn) nextAddr() error {
 	ac.mu.Lock()
 
-	// If a handshake has been observed, we expect the counters to have manually
-	// been reset so we'll just return, since we want the next usage to start
-	// at index 0.
+	// If a handshake has been observed, we want the next usage to start at
+	// index 0 immediately.
 	if ac.successfulHandshake {
 		ac.successfulHandshake = false
+		ac.backoffDeadline = time.Time{}
+		ac.connectDeadline = time.Time{}
+		ac.addrIdx = 0
+		ac.backoffIdx = 0
 		ac.mu.Unlock()
 		return nil
 	}

--- a/clientconn.go
+++ b/clientconn.go
@@ -1145,12 +1145,12 @@ func (ac *addrConn) createTransport(backoffNum int, addr resolver.Address, copts
 	if err == nil {
 		prefaceMu.Lock()
 		clientPrefaceWrote = true
-		if serverPrefaceReceived || *ac.dopts.reqHandshake == envconfig.RequireHandshakeOff {
+		if serverPrefaceReceived || ac.dopts.reqHandshake == envconfig.RequireHandshakeOff {
 			ac.successfulHandshake = true
 		}
 		prefaceMu.Unlock()
 
-		if *ac.dopts.reqHandshake == envconfig.RequireHandshakeOn {
+		if ac.dopts.reqHandshake == envconfig.RequireHandshakeOn {
 			select {
 			case <-prefaceTimer.C:
 				// We didn't get the preface in time.
@@ -1163,7 +1163,7 @@ func (ac *addrConn) createTransport(backoffNum int, addr resolver.Address, copts
 				close(allowedToReset)
 				return nil
 			}
-		} else if *ac.dopts.reqHandshake == envconfig.RequireHandshakeHybrid {
+		} else if ac.dopts.reqHandshake == envconfig.RequireHandshakeHybrid {
 			go func() {
 				select {
 				case <-prefaceTimer.C:

--- a/clientconn_test.go
+++ b/clientconn_test.go
@@ -285,8 +285,8 @@ func TestDialWaitsForServerSettingsAndFails(t *testing.T) {
 				defer conn.Close()
 			}
 		}()
-		getMinConnectTimeout = func() time.Duration { return time.Second / 2 }
-		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		getMinConnectTimeout = func() time.Duration { return time.Second / 4 }
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 		defer cancel()
 		client, err := DialContext(ctx, lis.Addr().String(), WithInsecure(), WithWaitForHandshake(), WithBlock())
 		lis.Close()
@@ -331,8 +331,8 @@ func TestDialWaitsForServerSettingsViaEnvAndFails(t *testing.T) {
 			defer conn.Close()
 		}
 	}()
-	getMinConnectTimeout = func() time.Duration { return time.Second / 2 }
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	getMinConnectTimeout = func() time.Duration { return time.Second / 4 }
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()
 	client, err := DialContext(ctx, lis.Addr().String(), WithInsecure(), WithBlock())
 	lis.Close()

--- a/clientconn_test.go
+++ b/clientconn_test.go
@@ -32,6 +32,7 @@ import (
 	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/internal/backoff"
+	"google.golang.org/grpc/internal/envconfig"
 	"google.golang.org/grpc/internal/leakcheck"
 	"google.golang.org/grpc/internal/transport"
 	"google.golang.org/grpc/keepalive"
@@ -132,8 +133,83 @@ func TestDialWithMultipleBackendsNotSendingServerPreface(t *testing.T) {
 	}
 }
 
+var allReqHSSettings = []envconfig.RequireHandshakeSetting{
+	envconfig.RequireHandshakeOff,
+	envconfig.RequireHandshakeOn,
+	envconfig.RequireHandshakeHybrid,
+}
+var reqNoHSSettings = []envconfig.RequireHandshakeSetting{
+	envconfig.RequireHandshakeOff,
+	envconfig.RequireHandshakeHybrid,
+}
+var reqHSBeforeSuccess = []envconfig.RequireHandshakeSetting{
+	envconfig.RequireHandshakeOn,
+	envconfig.RequireHandshakeHybrid,
+}
+
 func TestDialWaitsForServerSettings(t *testing.T) {
+	// Restore current setting after test.
+	old := envconfig.RequireHandshake
+	defer func() { envconfig.RequireHandshake = old }()
+
 	defer leakcheck.Check(t)
+
+	for _, setting := range allReqHSSettings {
+		envconfig.RequireHandshake = setting
+		lis, err := net.Listen("tcp", "localhost:0")
+		if err != nil {
+			t.Fatalf("Error while listening. Err: %v", err)
+		}
+		defer lis.Close()
+		done := make(chan struct{})
+		sent := make(chan struct{})
+		dialDone := make(chan struct{})
+		go func() { // Launch the server.
+			defer func() {
+				close(done)
+			}()
+			conn, err := lis.Accept()
+			if err != nil {
+				t.Errorf("Error while accepting. Err: %v", err)
+				return
+			}
+			defer conn.Close()
+			// Sleep for a little bit to make sure that Dial on client
+			// side blocks until settings are received.
+			time.Sleep(100 * time.Millisecond)
+			framer := http2.NewFramer(conn, conn)
+			close(sent)
+			if err := framer.WriteSettings(http2.Setting{}); err != nil {
+				t.Errorf("Error while writing settings. Err: %v", err)
+				return
+			}
+			<-dialDone // Close conn only after dial returns.
+		}()
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		client, err := DialContext(ctx, lis.Addr().String(), WithInsecure(), WithWaitForHandshake(), WithBlock())
+		close(dialDone)
+		if err != nil {
+			t.Fatalf("Error while dialing. Err: %v", err)
+		}
+		defer client.Close()
+		select {
+		case <-sent:
+		default:
+			t.Fatalf("Dial returned before server settings were sent")
+		}
+		<-done
+	}
+}
+
+func TestDialWaitsForServerSettingsViaEnv(t *testing.T) {
+	// Set default behavior and restore current setting after test.
+	old := envconfig.RequireHandshake
+	envconfig.RequireHandshake = envconfig.RequireHandshakeOn
+	defer func() { envconfig.RequireHandshake = old }()
+
+	defer leakcheck.Check(t)
+
 	lis, err := net.Listen("tcp", "localhost:0")
 	if err != nil {
 		t.Fatalf("Error while listening. Err: %v", err)
@@ -154,7 +230,7 @@ func TestDialWaitsForServerSettings(t *testing.T) {
 		defer conn.Close()
 		// Sleep for a little bit to make sure that Dial on client
 		// side blocks until settings are received.
-		time.Sleep(500 * time.Millisecond)
+		time.Sleep(100 * time.Millisecond)
 		framer := http2.NewFramer(conn, conn)
 		close(sent)
 		if err := framer.WriteSettings(http2.Setting{}); err != nil {
@@ -165,7 +241,7 @@ func TestDialWaitsForServerSettings(t *testing.T) {
 	}()
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	client, err := DialContext(ctx, lis.Addr().String(), WithInsecure(), WithWaitForHandshake(), WithBlock())
+	client, err := DialContext(ctx, lis.Addr().String(), WithInsecure(), WithBlock())
 	close(dialDone)
 	if err != nil {
 		t.Fatalf("Error while dialing. Err: %v", err)
@@ -177,11 +253,63 @@ func TestDialWaitsForServerSettings(t *testing.T) {
 		t.Fatalf("Dial returned before server settings were sent")
 	}
 	<-done
-
 }
 
 func TestDialWaitsForServerSettingsAndFails(t *testing.T) {
+	// Restore current setting after test.
+	old := envconfig.RequireHandshake
+	defer func() { envconfig.RequireHandshake = old }()
+
 	defer leakcheck.Check(t)
+
+	for _, setting := range allReqHSSettings {
+		envconfig.RequireHandshake = setting
+		lis, err := net.Listen("tcp", "localhost:0")
+		if err != nil {
+			t.Fatalf("Error while listening. Err: %v", err)
+		}
+		done := make(chan struct{})
+		numConns := 0
+		go func() { // Launch the server.
+			defer func() {
+				close(done)
+			}()
+			for {
+				conn, err := lis.Accept()
+				if err != nil {
+					break
+				}
+				numConns++
+				defer conn.Close()
+			}
+		}()
+		getMinConnectTimeout = func() time.Duration { return time.Second / 2 }
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		defer cancel()
+		client, err := DialContext(ctx, lis.Addr().String(), WithInsecure(), WithWaitForHandshake(), WithBlock())
+		lis.Close()
+		if err == nil {
+			client.Close()
+			t.Fatalf("Unexpected success (err=nil) while dialing")
+		}
+		if err != context.DeadlineExceeded {
+			t.Fatalf("DialContext(_) = %v; want context.DeadlineExceeded", err)
+		}
+		if numConns < 2 {
+			t.Fatalf("dial attempts: %v; want > 1", numConns)
+		}
+		<-done
+	}
+}
+
+func TestDialWaitsForServerSettingsViaEnvAndFails(t *testing.T) {
+	// Set default behavior and restore current setting after test.
+	old := envconfig.RequireHandshake
+	envconfig.RequireHandshake = envconfig.RequireHandshakeOn
+	defer func() { envconfig.RequireHandshake = old }()
+
+	defer leakcheck.Check(t)
+
 	lis, err := net.Listen("tcp", "localhost:0")
 	if err != nil {
 		t.Fatalf("Error while listening. Err: %v", err)
@@ -204,7 +332,7 @@ func TestDialWaitsForServerSettingsAndFails(t *testing.T) {
 	getMinConnectTimeout = func() time.Duration { return time.Second / 2 }
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
-	client, err := DialContext(ctx, lis.Addr().String(), WithInsecure(), WithWaitForHandshake(), WithBlock())
+	client, err := DialContext(ctx, lis.Addr().String(), WithInsecure(), WithBlock())
 	lis.Close()
 	if err == nil {
 		client.Close()
@@ -219,7 +347,57 @@ func TestDialWaitsForServerSettingsAndFails(t *testing.T) {
 	<-done
 }
 
+func TestDialDoesNotWaitForServerSettings(t *testing.T) {
+	// Restore current setting after test.
+	old := envconfig.RequireHandshake
+	defer func() { envconfig.RequireHandshake = old }()
+
+	defer leakcheck.Check(t)
+
+	// Test with "off" and "hybrid".
+	for _, setting := range reqNoHSSettings {
+		envconfig.RequireHandshake = setting
+		lis, err := net.Listen("tcp", "localhost:0")
+		if err != nil {
+			t.Fatalf("Error while listening. Err: %v", err)
+		}
+		defer lis.Close()
+		done := make(chan struct{})
+		dialDone := make(chan struct{})
+		go func() { // Launch the server.
+			defer func() {
+				close(done)
+			}()
+			conn, err := lis.Accept()
+			if err != nil {
+				t.Errorf("Error while accepting. Err: %v", err)
+				return
+			}
+			defer conn.Close()
+			<-dialDone // Close conn only after dial returns.
+		}()
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		client, err := DialContext(ctx, lis.Addr().String(), WithInsecure(), WithBlock())
+
+		if err != nil {
+			t.Fatalf("DialContext returned err =%v; want nil", err)
+		}
+		defer client.Close()
+
+		if state := client.GetState(); state != connectivity.Ready {
+			t.Fatalf("client.GetState() = %v; want connectivity.Ready", state)
+		}
+		close(dialDone)
+		<-done
+	}
+}
+
 func TestCloseConnectionWhenServerPrefaceNotReceived(t *testing.T) {
+	// Restore current setting after test.
+	old := envconfig.RequireHandshake
+	defer func() { envconfig.RequireHandshake = old }()
+
 	// 1. Client connects to a server that doesn't send preface.
 	// 2. After minConnectTimeout(500 ms here), client disconnects and retries.
 	// 3. The new server sends its preface.
@@ -230,75 +408,81 @@ func TestCloseConnectionWhenServerPrefaceNotReceived(t *testing.T) {
 	}()
 	defer leakcheck.Check(t)
 	atomic.StoreInt64((*int64)(&mutableMinConnectTimeout), int64(time.Millisecond)*500)
-	lis, err := net.Listen("tcp", "localhost:0")
-	if err != nil {
-		t.Fatalf("Error while listening. Err: %v", err)
-	}
-	var (
-		conn2 net.Conn
-		over  uint32
-	)
-	defer func() {
-		lis.Close()
-		// conn2 shouldn't be closed until the client has
-		// observed a successful test.
-		if conn2 != nil {
-			conn2.Close()
-		}
-	}()
-	done := make(chan struct{})
-	accepted := make(chan struct{})
-	go func() { // Launch the server.
-		defer close(done)
-		conn1, err := lis.Accept()
+
+	// Test with "on" and "hybrid".
+	for _, setting := range reqHSBeforeSuccess {
+		envconfig.RequireHandshake = setting
+
+		lis, err := net.Listen("tcp", "localhost:0")
 		if err != nil {
-			t.Errorf("Error while accepting. Err: %v", err)
-			return
+			t.Fatalf("Error while listening. Err: %v", err)
 		}
-		defer conn1.Close()
-		// Don't send server settings and the client should close the connection and try again.
-		conn2, err = lis.Accept() // Accept a reconnection request from client.
-		if err != nil {
-			t.Errorf("Error while accepting. Err: %v", err)
-			return
-		}
-		close(accepted)
-		framer := http2.NewFramer(conn2, conn2)
-		if err = framer.WriteSettings(http2.Setting{}); err != nil {
-			t.Errorf("Error while writing settings. Err: %v", err)
-			return
-		}
-		b := make([]byte, 8)
-		for {
-			_, err = conn2.Read(b)
-			if err == nil {
-				continue
+		var (
+			conn2 net.Conn
+			over  uint32
+		)
+		defer func() {
+			lis.Close()
+			// conn2 shouldn't be closed until the client has
+			// observed a successful test.
+			if conn2 != nil {
+				conn2.Close()
 			}
-			if atomic.LoadUint32(&over) == 1 {
-				// The connection stayed alive for the timer.
-				// Success.
+		}()
+		done := make(chan struct{})
+		accepted := make(chan struct{})
+		go func() { // Launch the server.
+			defer close(done)
+			conn1, err := lis.Accept()
+			if err != nil {
+				t.Errorf("Error while accepting. Err: %v", err)
 				return
 			}
-			t.Errorf("Unexpected error while reading. Err: %v, want timeout error", err)
-			break
+			defer conn1.Close()
+			// Don't send server settings and the client should close the connection and try again.
+			conn2, err = lis.Accept() // Accept a reconnection request from client.
+			if err != nil {
+				t.Errorf("Error while accepting. Err: %v", err)
+				return
+			}
+			close(accepted)
+			framer := http2.NewFramer(conn2, conn2)
+			if err = framer.WriteSettings(http2.Setting{}); err != nil {
+				t.Errorf("Error while writing settings. Err: %v", err)
+				return
+			}
+			b := make([]byte, 8)
+			for {
+				_, err = conn2.Read(b)
+				if err == nil {
+					continue
+				}
+				if atomic.LoadUint32(&over) == 1 {
+					// The connection stayed alive for the timer.
+					// Success.
+					return
+				}
+				t.Errorf("Unexpected error while reading. Err: %v, want timeout error", err)
+				break
+			}
+		}()
+		client, err := Dial(lis.Addr().String(), WithInsecure())
+		if err != nil {
+			t.Fatalf("Error while dialing. Err: %v", err)
 		}
-	}()
-	client, err := Dial(lis.Addr().String(), WithInsecure())
-	if err != nil {
-		t.Fatalf("Error while dialing. Err: %v", err)
+		// wait for connection to be accepted on the server.
+		timer := time.NewTimer(time.Second * 10)
+		select {
+		case <-accepted:
+		case <-timer.C:
+			t.Fatalf("Client didn't make another connection request in time.")
+		}
+		// Make sure the connection stays alive for sometime.
+		time.Sleep(time.Second)
+		atomic.StoreUint32(&over, 1)
+		client.Close()
+		<-done
 	}
-	// wait for connection to be accepted on the server.
-	timer := time.NewTimer(time.Second * 10)
-	select {
-	case <-accepted:
-	case <-timer.C:
-		t.Fatalf("Client didn't make another connection request in time.")
-	}
-	// Make sure the connection stays alive for sometime.
-	time.Sleep(time.Second * 2)
-	atomic.StoreUint32(&over, 1)
-	client.Close()
-	<-done
 }
 
 func TestBackoffWhenNoServerPrefaceReceived(t *testing.T) {
@@ -727,7 +911,7 @@ func TestClientUpdatesParamsAfterGoAway(t *testing.T) {
 		t.Fatalf("Dial(%s, _) = _, %v, want _, <nil>", addr, err)
 	}
 	defer cc.Close()
-	time.Sleep(1 * time.Second)
+	time.Sleep(time.Second)
 	cc.mu.RLock()
 	defer cc.mu.RUnlock()
 	v := cc.mkp.Time
@@ -758,7 +942,7 @@ func TestDisableServiceConfigOption(t *testing.T) {
         }
     ]
 }`)
-	time.Sleep(1 * time.Second)
+	time.Sleep(time.Second)
 	m := cc.GetMethodConfig("/foo/Bar")
 	if m.WaitForReady != nil {
 		t.Fatalf("want: method (\"/foo/bar/\") config to be empty, got: %v", m)

--- a/clientconn_test.go
+++ b/clientconn_test.go
@@ -288,7 +288,7 @@ func TestDialWaitsForServerSettingsAndFails(t *testing.T) {
 		getMinConnectTimeout = func() time.Duration { return time.Second / 4 }
 		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 		defer cancel()
-		client, err := DialContext(ctx, lis.Addr().String(), WithInsecure(), WithWaitForHandshake(), WithBlock())
+		client, err := DialContext(ctx, lis.Addr().String(), WithInsecure(), WithWaitForHandshake(), WithBlock(), withBackoff(noBackoff{}))
 		lis.Close()
 		if err == nil {
 			client.Close()
@@ -334,7 +334,7 @@ func TestDialWaitsForServerSettingsViaEnvAndFails(t *testing.T) {
 	getMinConnectTimeout = func() time.Duration { return time.Second / 4 }
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()
-	client, err := DialContext(ctx, lis.Addr().String(), WithInsecure(), WithBlock())
+	client, err := DialContext(ctx, lis.Addr().String(), WithInsecure(), WithBlock(), withBackoff(noBackoff{}))
 	lis.Close()
 	if err == nil {
 		client.Close()

--- a/clientconn_test.go
+++ b/clientconn_test.go
@@ -154,6 +154,8 @@ func TestDialWaitsForServerSettings(t *testing.T) {
 
 	defer leakcheck.Check(t)
 
+	// Test with all environment variable settings, which should not impact the
+	// test case since WithWaitForHandshake has higher priority.
 	for _, setting := range allReqHSSettings {
 		envconfig.RequireHandshake = setting
 		lis, err := net.Listen("tcp", "localhost:0")

--- a/dialoptions.go
+++ b/dialoptions.go
@@ -55,7 +55,7 @@ type dialOptions struct {
 	balancerBuilder balancer.Builder
 	// This is to support grpclb.
 	resolverBuilder      resolver.Builder
-	reqHandshake         *envconfig.RequireHandshakeSetting
+	reqHandshake         envconfig.RequireHandshakeSetting
 	channelzParentID     int64
 	disableServiceConfig bool
 	disableRetry         bool
@@ -100,8 +100,7 @@ func newFuncDialOption(f func(*dialOptions)) *funcDialOption {
 // variable GRPC_GO_READY_BEFORE_HANDSHAKE=on.
 func WithWaitForHandshake() DialOption {
 	return newFuncDialOption(func(o *dialOptions) {
-		t := envconfig.RequireHandshakeOn
-		o.reqHandshake = &t
+		o.reqHandshake = envconfig.RequireHandshakeOn
 	})
 }
 
@@ -472,7 +471,7 @@ func WithDisableHealthCheck() DialOption {
 func defaultDialOptions() dialOptions {
 	return dialOptions{
 		disableRetry: !envconfig.Retry,
-		reqHandshake: &envconfig.RequireHandshake,
+		reqHandshake: envconfig.RequireHandshake,
 		copts: transport.ConnectOptions{
 			WriteBufferSize: defaultWriteBufSize,
 			ReadBufferSize:  defaultReadBufSize,

--- a/dialoptions.go
+++ b/dialoptions.go
@@ -55,7 +55,7 @@ type dialOptions struct {
 	balancerBuilder balancer.Builder
 	// This is to support grpclb.
 	resolverBuilder      resolver.Builder
-	waitForHandshake     bool
+	reqHandshake         *envconfig.RequireHandshakeSetting
 	channelzParentID     int64
 	disableServiceConfig bool
 	disableRetry         bool
@@ -100,7 +100,8 @@ func newFuncDialOption(f func(*dialOptions)) *funcDialOption {
 // variable GRPC_GO_READY_BEFORE_HANDSHAKE=on.
 func WithWaitForHandshake() DialOption {
 	return newFuncDialOption(func(o *dialOptions) {
-		o.waitForHandshake = true
+		t := envconfig.RequireHandshakeOn
+		o.reqHandshake = &t
 	})
 }
 
@@ -471,6 +472,7 @@ func WithDisableHealthCheck() DialOption {
 func defaultDialOptions() dialOptions {
 	return dialOptions{
 		disableRetry: !envconfig.Retry,
+		reqHandshake: &envconfig.RequireHandshake,
 		copts: transport.ConnectOptions{
 			WriteBufferSize: defaultWriteBufSize,
 			ReadBufferSize:  defaultReadBufSize,

--- a/dialoptions.go
+++ b/dialoptions.go
@@ -92,7 +92,12 @@ func newFuncDialOption(f func(*dialOptions)) *funcDialOption {
 }
 
 // WithWaitForHandshake blocks until the initial settings frame is received from
-// the server before assigning RPCs to the connection. Experimental API.
+// the server before assigning RPCs to the connection.
+//
+// Deprecated: this will become the default behavior in the 1.17 release, and
+// will be removed after the 1.18 release.  To override the default behavior in
+// the 1.17 release, either use this dial option or set the environment
+// variable GRPC_GO_READY_BEFORE_HANDSHAKE=on.
 func WithWaitForHandshake() DialOption {
 	return newFuncDialOption(func(o *dialOptions) {
 		o.waitForHandshake = true

--- a/internal/envconfig/envconfig.go
+++ b/internal/envconfig/envconfig.go
@@ -25,11 +25,45 @@ import (
 )
 
 const (
-	prefix   = "GRPC_GO_"
-	retryStr = prefix + "RETRY"
+	prefix              = "GRPC_GO_"
+	retryStr            = prefix + "RETRY"
+	requireHandshakeStr = prefix + "REQUIRE_HANDSHAKE"
+)
+
+// RequireHandshakeSetting describes the settings for handshaking.
+type RequireHandshakeSetting int
+
+const (
+	// RequireHandshakeHybrid (default, deprecated) indicates to wait for
+	// handshake before considering a connection ready, but wait before
+	// considering successful.
+	RequireHandshakeHybrid RequireHandshakeSetting = iota
+	// RequireHandshakeOn (default after the 1.17 release) indicates to wait
+	// for handshake before considering a connection ready/successful.
+	RequireHandshakeOn
+	// RequireHandshakeOff indicates to not wait for handshake before
+	// considering a connection ready/successful.
+	RequireHandshakeOff
 )
 
 var (
 	// Retry is set if retry is explicitly enabled via "GRPC_GO_RETRY=on".
 	Retry = strings.EqualFold(os.Getenv(retryStr), "on")
+	// RequireHandshake is set based upon the GRPC_GO_REQUIRE_HANDSHAKE
+	// environment variable.
+	//
+	// Will be removed after the 1.18 release.
+	RequireHandshake RequireHandshakeSetting
 )
+
+func init() {
+	switch strings.ToLower(os.Getenv(requireHandshakeStr)) {
+	case "on":
+		RequireHandshake = RequireHandshakeOn
+	case "off":
+		RequireHandshake = RequireHandshakeOff
+	case "hybrid":
+		// Will be removed after the 1.17 release.
+		RequireHandshake = RequireHandshakeHybrid
+	}
+}

--- a/vet.sh
+++ b/vet.sh
@@ -121,14 +121,16 @@ done
 
 # TODO(menghanl): fix errors in transport_test.
 staticcheck -ignore '
-internal/transport/transport_test.go:SA2002
-benchmark/benchmain/main.go:SA1019
-stats/stats_test.go:SA1019
-test/end2end_test.go:SA1019
-balancer_test.go:SA1019
 balancer.go:SA1019
+balancer_test.go:SA1019
 clientconn_test.go:SA1019
-internal/transport/handler_server_test.go:SA1019
+balancer/roundrobin/roundrobin_test.go:SA1019
+benchmark/benchmain/main.go:SA1019
 internal/transport/handler_server.go:SA1019
+internal/transport/handler_server_test.go:SA1019
+internal/transport/transport_test.go:SA2002
+stats/stats_test.go:SA1019
+test/channelz_test.go:SA1019
+test/end2end_test.go:SA1019
 ' ./...
 misspell -error .


### PR DESCRIPTION
#2406

Possible settings of this environment variable:
    
- "hybrid" (default; removed after the 1.17 release): do not wait for handshake before considering a connection ready, but wait before considering successful.
    
- "on" (default after the 1.17 release): wait for handshake before considering a connection ready/successful.
    
- "off": do not wait for handshake before considering a connection ready/successful.
    
This setting will be completely removed after the 1.18 release, and "on" will be the only supported behavior.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grpc/grpc-go/2464)
<!-- Reviewable:end -->
