### PR TITLE
grpclb: filter out grpclb addresses if balancer in use is not grpclb

### DIFF
--- a/balancer/balancer.go
+++ b/balancer/balancer.go
@@ -47,6 +47,14 @@ func Register(b Builder) {
 	m[strings.ToLower(b.Name())] = b
 }
 
+// UnregisterForTesting deletes the balancer with the given name from the
+// balancer map.
+//
+// This function is not thread-safe. And should only be used for testing.
+func UnregisterForTesting(name string) {
+	delete(m, name)
+}
+
 // Get returns the resolver builder registered with the given name.
 // Note that the compare is done in a case-insenstive fashion.
 // If no builder is register with the name, nil will be returned.

--- a/balancer/balancer.go
+++ b/balancer/balancer.go
@@ -28,6 +28,7 @@ import (
 
 	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/internal"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/resolver"
 )
@@ -47,12 +48,16 @@ func Register(b Builder) {
 	m[strings.ToLower(b.Name())] = b
 }
 
-// UnregisterForTesting deletes the balancer with the given name from the
+// unregisterForTesting deletes the balancer with the given name from the
 // balancer map.
 //
-// This function is not thread-safe. And should only be used for testing.
-func UnregisterForTesting(name string) {
+// This function is not thread-safe.
+func unregisterForTesting(name string) {
 	delete(m, name)
+}
+
+func init() {
+	internal.BalancerUnregister = unregisterForTesting
 }
 
 // Get returns the resolver builder registered with the given name.

--- a/balancer/grpclb/grpclb.go
+++ b/balancer/grpclb/grpclb.go
@@ -342,6 +342,7 @@ func (lb *lbBalancer) HandleResolvedAddrs(addrs []resolver.Address, err error) {
 	var remoteBalancerAddrs, backendAddrs []resolver.Address
 	for _, a := range addrs {
 		if a.Type == resolver.GRPCLB {
+			a.Type = resolver.Backend
 			remoteBalancerAddrs = append(remoteBalancerAddrs, a)
 		} else {
 			backendAddrs = append(backendAddrs, a)

--- a/balancer_switching_test.go
+++ b/balancer_switching_test.go
@@ -29,6 +29,7 @@ import (
 	"google.golang.org/grpc/balancer/roundrobin"
 	"google.golang.org/grpc/connectivity"
 	_ "google.golang.org/grpc/grpclog/glogger"
+	"google.golang.org/grpc/internal"
 	"google.golang.org/grpc/internal/leakcheck"
 	"google.golang.org/grpc/resolver"
 	"google.golang.org/grpc/resolver/manual"
@@ -133,7 +134,7 @@ func TestSwitchBalancer(t *testing.T) {
 	r, rcleanup := manual.GenerateAndRegisterManualResolver()
 	defer rcleanup()
 
-	numServers := 2
+	const numServers = 2
 	servers, _, scleanup := startServers(t, numServers, math.MaxInt32)
 	defer scleanup()
 
@@ -165,7 +166,7 @@ func TestBalancerDialOption(t *testing.T) {
 	r, rcleanup := manual.GenerateAndRegisterManualResolver()
 	defer rcleanup()
 
-	numServers := 2
+	const numServers = 2
 	servers, _, scleanup := startServers(t, numServers, math.MaxInt32)
 	defer scleanup()
 
@@ -476,14 +477,14 @@ func TestSwitchBalancerGRPCLBServiceConfig(t *testing.T) {
 // claim the first one is grpclb server. The all RPCs should all be send to the
 // other addresses, not the first one.
 func TestSwitchBalancerGRPCLBWithGRPCLBNotRegistered(t *testing.T) {
-	balancer.UnregisterForTesting("grpclb")
+	internal.BalancerUnregister("grpclb")
 	defer balancer.Register(&magicalLB{})
 
 	defer leakcheck.Check(t)
 	r, rcleanup := manual.GenerateAndRegisterManualResolver()
 	defer rcleanup()
 
-	numServers := 3
+	const numServers = 3
 	servers, _, scleanup := startServers(t, numServers, math.MaxInt32)
 	defer scleanup()
 

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -29,6 +29,8 @@ var (
 	WithResolverBuilder interface{} // func (resolver.Builder) grpc.DialOption
 	// HealthCheckFunc is used to provide client-side LB channel health checking
 	HealthCheckFunc func(ctx context.Context, newStream func() (interface{}, error), reportHealth func(bool), serviceName string) error
+	// BalancerUnregister is exported by package balancer to unregister a balancer.
+	BalancerUnregister func(name string)
 )
 
 const (


### PR DESCRIPTION
This can happen when resolved addresses contain grpclb address, but grpclb is
not registered.