### PR TITLE
internal: add apidiff to check compatibility between commits

### DIFF
--- a/vet.sh
+++ b/vet.sh
@@ -53,7 +53,8 @@ if [[ "$1" = "-install" ]]; then
       golang.org/x/tools/cmd/goimports \
       honnef.co/go/tools/cmd/staticcheck \
       github.com/client9/misspell/cmd/misspell \
-      github.com/golang/protobuf/protoc-gen-go
+      github.com/golang/protobuf/protoc-gen-go \
+      golang.org/x/exp/cmd/apidiff
   fi
   if [[ -z "${VET_SKIP_PROTO}" ]]; then
     if [[ "${TRAVIS}" = "true" ]]; then
@@ -135,3 +136,45 @@ test/end2end_test.go:SA1019
 test/healthcheck_test.go:SA1019
 ' ./...
 misspell -error .
+
+# We compare against master@HEAD. This is unfortunate in some cases: if you're
+# working on an out-of-date branch, and master gets some new feature (that has
+# nothing to do with your work on your branch), you'll get an error message.
+# Thankfully the fix is quite simple: rebase your branch.
+git clone https://github.com/grpc/grpc-go /tmp/grpc | true
+
+go install golang.org/x/exp/cmd/apidiff
+
+STABLE_DIRS=`find . \
+    -not -path '*/\.*' \
+    -type d | \
+    grep -v internal | \
+    grep -v examples | \
+    grep -v test | \
+    grep -v alpha | \
+    grep -v Documentation | \
+    grep -v interop | \
+    grep -v dummy | \
+    grep -v benchmark`
+
+for dir in $STABLE_DIRS; do
+  if [ ! -n "$(ls -A $dir/*.go 2> /dev/null)" ]; then
+    continue # skip directories with no .go files
+  fi
+
+  # turns things like ./foo/bar into /foo/bar
+  dir_without_junk=`echo $dir | sed -n "s#\.\(.*\)#\1#p"`
+  pkg="google.golang.org/grpc$dir_without_junk"
+  echo "Testing $pkg"
+
+  cd /tmp/grpc
+  apidiff -w /tmp/pkg.master $pkg
+  cd - > /dev/null
+
+  # TODO(deklerk) there's probably a nicer way to do this that doesn't require
+  # two invocations
+  if ! apidiff -incompatible /tmp/pkg.master $pkg | (! read); then
+    apidiff -incompatible /tmp/pkg.master $pkg
+    exit 1
+  fi
+done


### PR DESCRIPTION
Adds apidiff to check whether backwards-compatible changes are made between
commits. https://godoc.org/golang.org/x/exp/cmd/apidiff

@dfawley not sure if you want this yet, but thought I'd send it out for you to get an idea of what it looks like.