### PR TITLE
Implement GetServer method for channelz

### DIFF
--- a/channelz/service/service.go
+++ b/channelz/service/service.go
@@ -337,5 +337,10 @@ func (s *serverImpl) GetSocket(ctx context.Context, req *channelzpb.GetSocketReq
 }
 
 func (s *serverImpl) GetServer(ctx context.Context, req *channelzpb.GetServerRequest) (*channelzpb.GetServerResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "GetServer not implemented")
+	var metric *channelz.ServerMetric
+	if metric = channelz.GetServer(req.GetServerId()); metric == nil {
+		return nil, status.Errorf(codes.NotFound, "requested server %d not found", req.GetServerId())
+	}
+	resp := &channelzpb.GetServerResponse{Server: serverMetricToProto(metric)}
+	return resp, nil
 }

--- a/channelz/service/service.go
+++ b/channelz/service/service.go
@@ -312,7 +312,7 @@ func (s *serverImpl) GetServerSockets(ctx context.Context, req *channelzpb.GetSe
 func (s *serverImpl) GetChannel(ctx context.Context, req *channelzpb.GetChannelRequest) (*channelzpb.GetChannelResponse, error) {
 	var metric *channelz.ChannelMetric
 	if metric = channelz.GetChannel(req.GetChannelId()); metric == nil {
-		return &channelzpb.GetChannelResponse{}, nil
+		return nil, status.Errorf(codes.NotFound, "requested channel %d not found", req.GetChannelId())
 	}
 	resp := &channelzpb.GetChannelResponse{Channel: channelMetricToProto(metric)}
 	return resp, nil
@@ -321,7 +321,7 @@ func (s *serverImpl) GetChannel(ctx context.Context, req *channelzpb.GetChannelR
 func (s *serverImpl) GetSubchannel(ctx context.Context, req *channelzpb.GetSubchannelRequest) (*channelzpb.GetSubchannelResponse, error) {
 	var metric *channelz.SubChannelMetric
 	if metric = channelz.GetSubChannel(req.GetSubchannelId()); metric == nil {
-		return &channelzpb.GetSubchannelResponse{}, nil
+		return nil, status.Errorf(codes.NotFound, "requested sub channel %d not found", req.GetSubchannelId())
 	}
 	resp := &channelzpb.GetSubchannelResponse{Subchannel: subChannelMetricToProto(metric)}
 	return resp, nil
@@ -330,7 +330,7 @@ func (s *serverImpl) GetSubchannel(ctx context.Context, req *channelzpb.GetSubch
 func (s *serverImpl) GetSocket(ctx context.Context, req *channelzpb.GetSocketRequest) (*channelzpb.GetSocketResponse, error) {
 	var metric *channelz.SocketMetric
 	if metric = channelz.GetSocket(req.GetSocketId()); metric == nil {
-		return &channelzpb.GetSocketResponse{}, nil
+		return nil, status.Errorf(codes.NotFound, "requested socket %d not found", req.GetSocketId())
 	}
 	resp := &channelzpb.GetSocketResponse{Socket: socketMetricToProto(metric)}
 	return resp, nil

--- a/internal/channelz/funcs.go
+++ b/internal/channelz/funcs.go
@@ -155,6 +155,11 @@ func GetSocket(id int64) *SocketMetric {
 	return db.get().GetSocket(id)
 }
 
+// GetServer returns the ServerMetric for the server (identified by id).
+func GetServer(id int64) *ServerMetric {
+	return db.get().GetServer(id)
+}
+
 // RegisterChannel registers the given channel c in channelz database with ref
 // as its reference name, and add it to the child list of its parent (identified
 // by pid). pid = 0 means no parent. It returns the unique channelz tracking id
@@ -662,6 +667,23 @@ func (c *channelMap) GetSocket(id int64) *SocketMetric {
 	}
 	c.mu.RUnlock()
 	return nil
+}
+
+func (c *channelMap) GetServer(id int64) *ServerMetric {
+	sm := &ServerMetric{}
+	var svr *server
+	var ok bool
+	c.mu.RLock()
+	if svr, ok = c.servers[id]; !ok {
+		c.mu.RUnlock()
+		return nil
+	}
+	sm.ListenSockets = copyMap(svr.listenSockets)
+	c.mu.RUnlock()
+	sm.ID = svr.id
+	sm.RefName = svr.refName
+	sm.ServerData = svr.s.ChannelzMetric()
+	return sm
 }
 
 type idGenerator struct {


### PR DESCRIPTION
GetServer is not implemented for now.

And also fixes GetChannel, GetSubchannel, GetSocket response when requested id not found.
By gRFC spec, it should return NotFound status code, not empty message with OK.