### PR TITLE
internal: fix race reading/writing ac.dopts.copts.KeepaliveParams

### DIFF
--- a/clientconn.go
+++ b/clientconn.go
@@ -954,8 +954,8 @@ func (ac *addrConn) updateConnectivityState(s connectivity.State) {
 func (ac *addrConn) adjustParams(r transport.GoAwayReason) {
 	switch r {
 	case transport.GoAwayTooManyPings:
-		v := 2 * ac.dopts.copts.KeepaliveParams.Time
 		ac.cc.mu.Lock()
+		v := 2 * ac.dopts.copts.KeepaliveParams.Time
 		if v > ac.cc.mkp.Time {
 			ac.cc.mkp.Time = v
 		}
@@ -996,9 +996,7 @@ func (ac *addrConn) resetTransport() {
 			connectDeadline := time.Now().Add(dialDuration)
 
 			ac.mu.Lock()
-			ac.cc.mu.RLock()
 			ac.dopts.copts.KeepaliveParams = ac.cc.mkp
-			ac.cc.mu.RUnlock()
 
 			if ac.state == connectivity.Shutdown {
 				ac.mu.Unlock()


### PR DESCRIPTION
I actually couldn't observe the problem myself, and the line numbers in https://github.com/grpc/grpc-go/issues/2542 don't correspond to meaningful things on HEAD. All that said, it seems pretty straightforward that this code is outside the lock and should be inside.

Fixes https://github.com/grpc/grpc-go/issues/2542