### PR TITLE
internal: use -go option to target 1.9

### DIFF
--- a/vet.sh
+++ b/vet.sh
@@ -120,7 +120,7 @@ done
 ### END HACK HACK HACK
 
 # TODO(menghanl): fix errors in transport_test.
-staticcheck -ignore '
+staticcheck -go 1.9 -ignore '
 balancer.go:SA1019
 balancer_test.go:SA1019
 clientconn_test.go:SA1019


### PR DESCRIPTION
Staticcheck has a -go option which I _believe_ was recently added. This allows
us to pin to 1.9, preventing staticcheck from recommending we optimize to an
overly-recent version of Go.