### PR TITLE
fix grpctest comments to be more readable

### DIFF
--- a/internal/grpctest/grpctest.go
+++ b/internal/grpctest/grpctest.go
@@ -42,10 +42,10 @@ func getTestFunc(t *testing.T, xv reflect.Value, name string) func(*testing.T) {
 // functions, respectively.
 //
 // For example usage, see example_test.go.  Run it using:
-// $ go test -v -run TestExample .
+//     $ go test -v -run TestExample .
 //
 // To run a specific test/subtest:
-// $ go test -v -run 'TestExample/^Something$' .
+//     $ go test -v -run 'TestExample/^Something$' .
 func RunSubTests(t *testing.T, x interface{}) {
 	xt := reflect.TypeOf(x)
 	xv := reflect.ValueOf(x)


### PR DESCRIPTION
Before:
> ![image](https://user-images.githubusercontent.com/26072277/50935544-39efbd80-1421-11e9-8e8f-9fd5948947a5.png)

After:
> ![image](https://user-images.githubusercontent.com/26072277/50935569-4bd16080-1421-11e9-8858-bc6510ca5d8c.png)
