### PR TITLE
Add google_default_credentials interop test case for go

### DIFF
--- a/interop/client/client.go
+++ b/interop/client/client.go
@@ -67,6 +67,7 @@ var (
         jwt_token_creds: large_unary with jwt token auth;
         per_rpc_creds: large_unary with per rpc token;
         oauth2_auth_token: large_unary with oauth2 token auth;
+        google_default_credentials: large_unary with google default credentials
         cancel_after_begin: cancellation after metadata has been sent but before payloads are sent;
         cancel_after_first_response: cancellation after receiving 1st message from the server;
         status_code_and_message: status code propagated back to client;
@@ -143,7 +144,7 @@ func main() {
 	default:
 		opts = append(opts, grpc.WithInsecure())
 	}
-	if credsChosen == credsTLS || credsChosen == credsALTS {
+	if credsChosen == credsTLS {
 		if *testCase == "compute_engine_creds" {
 			opts = append(opts, grpc.WithPerRPCCredentials(oauth.NewComputeEngine()))
 		} else if *testCase == "service_account_creds" {
@@ -192,35 +193,41 @@ func main() {
 		interop.DoTimeoutOnSleepingServer(tc)
 		grpclog.Infoln("TimeoutOnSleepingServer done")
 	case "compute_engine_creds":
-		if credsChosen == credsNone {
-			grpclog.Fatalf("Credentials (TLS, ALTS or google default creds) need to be set for compute_engine_creds test case.")
+		if credsChosen != credsTLS {
+			grpclog.Fatalf("TLS credentials need to be set for compute_engine_creds test case.")
 		}
 		interop.DoComputeEngineCreds(tc, *defaultServiceAccount, *oauthScope)
 		grpclog.Infoln("ComputeEngineCreds done")
 	case "service_account_creds":
-		if credsChosen == credsNone {
-			grpclog.Fatalf("Credentials (TLS, ALTS or google default creds) need to be set for service_account_creds test case.")
+		if credsChosen != credsTLS {
+			grpclog.Fatalf("TLS credentials need to be set for service_account_creds test case.")
 		}
 		interop.DoServiceAccountCreds(tc, *serviceAccountKeyFile, *oauthScope)
 		grpclog.Infoln("ServiceAccountCreds done")
 	case "jwt_token_creds":
-		if credsChosen == credsNone {
-			grpclog.Fatalf("Credentials (TLS, ALTS or google default creds) need to be set for jwt_token_creds test case.")
+		if credsChosen != credsTLS {
+			grpclog.Fatalf("TLS credentials need to be set for jwt_token_creds test case.")
 		}
 		interop.DoJWTTokenCreds(tc, *serviceAccountKeyFile)
 		grpclog.Infoln("JWTtokenCreds done")
 	case "per_rpc_creds":
-		if credsChosen == credsNone {
-			grpclog.Fatalf("Credentials (TLS, ALTS or google default creds) need to be set for per_rpc_creds test case.")
+		if credsChosen != credsTLS {
+			grpclog.Fatalf("TLS credentials need to be set for per_rpc_creds test case.")
 		}
 		interop.DoPerRPCCreds(tc, *serviceAccountKeyFile, *oauthScope)
 		grpclog.Infoln("PerRPCCreds done")
 	case "oauth2_auth_token":
-		if credsChosen == credsNone {
-			grpclog.Fatalf("Credentials (TLS, ALTS or google default creds) need to be set for oauth2_auth_token test case.")
+		if credsChosen != credsTLS {
+			grpclog.Fatalf("TLS credentials need to be set for oauth2_auth_token test case.")
 		}
 		interop.DoOauth2TokenCreds(tc, *serviceAccountKeyFile, *oauthScope)
 		grpclog.Infoln("Oauth2TokenCreds done")
+	case "google_default_credentials":
+		if credsChosen != credsGoogleDefaultCreds {
+			grpclog.Fatalf("GoogleDefaultCredentials need to be set for google_default_credentials test case.")
+		}
+		interop.DoGoogleDefaultCredentials(tc, *defaultServiceAccount)
+		grpclog.Infoln("GoogleDefaultCredentials done")
 	case "cancel_after_begin":
 		interop.DoCancelAfterBegin(tc)
 		grpclog.Infoln("CancelAfterBegin done")

--- a/interop/client/client.go
+++ b/interop/client/client.go
@@ -141,8 +141,10 @@ func main() {
 		opts = append(opts, grpc.WithTransportCredentials(altsTC))
 	case credsGoogleDefaultCreds:
 		opts = append(opts, grpc.WithCredentialsBundle(google.NewDefaultCredentials()))
-	default:
+	case credsNone:
 		opts = append(opts, grpc.WithInsecure())
+	default:
+		grpclog.Fatal("Invalid creds")
 	}
 	if credsChosen == credsTLS {
 		if *testCase == "compute_engine_creds" {

--- a/interop/test_utils.go
+++ b/interop/test_utils.go
@@ -393,6 +393,25 @@ func DoPerRPCCreds(tc testpb.TestServiceClient, serviceAccountKeyFile, oauthScop
 	}
 }
 
+// DoGoogleDefaultCredentials performs a unary RPC with google default credentials
+func DoGoogleDefaultCredentials(tc testpb.TestServiceClient, defaultServiceAccount string) {
+	pl := ClientNewPayload(testpb.PayloadType_COMPRESSABLE, largeReqSize)
+	req := &testpb.SimpleRequest{
+		ResponseType:   testpb.PayloadType_COMPRESSABLE,
+		ResponseSize:   int32(largeRespSize),
+		Payload:        pl,
+		FillUsername:   true,
+		FillOauthScope: true,
+	}
+	reply, err := tc.UnaryCall(context.Background(), req)
+	if err != nil {
+		grpclog.Fatal("/TestService/UnaryCall RPC failed: ", err)
+	}
+	if reply.GetUsername() != defaultServiceAccount {
+		grpclog.Fatalf("Got user name %q; wanted %q. ", reply.GetUsername(), defaultServiceAccount)
+	}
+}
+
 var testMetadata = metadata.MD{
 	"key1": []string{"value1"},
 	"key2": []string{"value2"},


### PR DESCRIPTION
Implementing the [google default creds](https://github.com/grpc/grpc/blob/master/doc/interop-test-descriptions.md#google_default_credentials) interop test for go.

This test case was added in https://github.com/grpc/grpc/pull/17213. The existing OAuth creds test cases turned out to not be great first for google default creds testing, so https://github.com/grpc/grpc/pull/17213 got rid of those tests and created a new dedicated test for google default creds. This PR does that and also gets rid of the now-unneeded (we thought they would be needed earlier) OAuth test scenarios with plain ALTS.