### PR TITLE
Fix too many ping err

### DIFF
--- a/internal/transport/http2_server.go
+++ b/internal/transport/http2_server.go
@@ -456,6 +456,8 @@ func (t *http2Server) HandleStreams(handle func(*Stream), traceCtx func(context.
 		}
 		switch frame := frame.(type) {
 		case *http2.MetaHeadersFrame:
+			// handler is Asynchronous processing
+			atomic.StoreUint32(&t.resetPingStrikes, 1)
 			if t.operateHeaders(frame, handle, traceCtx) {
 				t.Close()
 				break


### PR DESCRIPTION
When concurrently call grpc client with keepalive ,  saw http2: Framer 0xc0014622a0: read GOAWAY len=22 LastStreamID=0 ErrCode=ENHANCE_YOUR_CALM Debug="too_many_pings"!