### PR TITLE
client: fix handling of GRPC_GO_REQUIRE_HANDSHAKE=on to not interpret as "hybrid"

### DIFF
--- a/internal/envconfig/envconfig.go
+++ b/internal/envconfig/envconfig.go
@@ -59,6 +59,7 @@ var (
 func init() {
 	switch strings.ToLower(os.Getenv(requireHandshakeStr)) {
 	case "on":
+		fallthrough
 	default:
 		RequireHandshake = RequireHandshakeOn
 	case "off":


### PR DESCRIPTION
https://github.com/grpc/grpc-go/commit/6cc789b34b72d30116d6139ae4af87d5bfc91478 made `envconfig.RequireHandshakeOn` the default when unspecified by environment variable, but missed a fallthrough leading to `GRPC_GO_REQUIRE_HANDSHAKE=on` specifying `envconfig.RequireHandshakeHybrid`.  This change adds the missing fallthrough.