### PR TITLE
Fixes established streams leak in the loopy writer.

### DIFF
--- a/internal/transport/http2_server.go
+++ b/internal/transport/http2_server.go
@@ -1004,6 +1004,29 @@ func (t *http2Server) Close() error {
 	return err
 }
 
+// deleteStream deletes the stream s from transport's active streams.
+func (t *http2Server) deleteStream(s *Stream, eosReceived bool) {
+	t.mu.Lock()
+	if _, ok := t.activeStreams[s.id]; !ok {
+		t.mu.Unlock()
+		return
+	}
+
+	delete(t.activeStreams, s.id)
+	if len(t.activeStreams) == 0 {
+		t.idle = time.Now()
+	}
+	t.mu.Unlock()
+
+	if channelz.IsOn() {
+		if eosReceived {
+			atomic.AddInt64(&t.czData.streamsSucceeded, 1)
+		} else {
+			atomic.AddInt64(&t.czData.streamsFailed, 1)
+		}
+	}
+}
+
 // closeStream clears the footprint of a stream when the stream is not needed
 // any more.
 func (t *http2Server) closeStream(s *Stream, rst bool, rstCode http2.ErrCode, hdr *headerFrame, eosReceived bool) {
@@ -1012,28 +1035,8 @@ func (t *http2Server) closeStream(s *Stream, rst bool, rstCode http2.ErrCode, hd
 	// called to interrupt the potential blocking on other goroutines.
 	s.cancel()
 
-	// Deletes stream from the active streams
-	func() {
-		t.mu.Lock()
-		if _, ok := t.activeStreams[s.id]; !ok {
-			t.mu.Unlock()
-			return
-		}
-
-		delete(t.activeStreams, s.id)
-		if len(t.activeStreams) == 0 {
-			t.idle = time.Now()
-		}
-		t.mu.Unlock()
-
-		if channelz.IsOn() {
-			if eosReceived {
-				atomic.AddInt64(&t.czData.streamsSucceeded, 1)
-			} else {
-				atomic.AddInt64(&t.czData.streamsFailed, 1)
-			}
-		}
-	}()
+	// Deletes the stream from active streams
+	t.deleteStream(s, eosReceived)
 
 	cleanup := &cleanupStream{
 		streamID: s.id,

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -5156,6 +5156,7 @@ type stubServer struct {
 
 	// Customizable implementations of server handlers.
 	emptyCall      func(ctx context.Context, in *testpb.Empty) (*testpb.Empty, error)
+	unaryCall      func(ctx context.Context, in *testpb.SimpleRequest) (*testpb.SimpleResponse, error)
 	fullDuplexCall func(stream testpb.TestService_FullDuplexCallServer) error
 
 	// A client connected to this service the test may use.  Created in Start().
@@ -5169,6 +5170,10 @@ type stubServer struct {
 
 func (ss *stubServer) EmptyCall(ctx context.Context, in *testpb.Empty) (*testpb.Empty, error) {
 	return ss.emptyCall(ctx, in)
+}
+
+func (ss *stubServer) UnaryCall(ctx context.Context, in *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
+	return ss.unaryCall(ctx, in)
 }
 
 func (ss *stubServer) FullDuplexCall(stream testpb.TestService_FullDuplexCallServer) error {

--- a/test/stream_cleanup_test.go
+++ b/test/stream_cleanup_test.go
@@ -1,0 +1,63 @@
+/*
+ *
+ * Copyright 2019 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package test
+
+import (
+	"context"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"google.golang.org/grpc"
+	testpb "google.golang.org/grpc/test/grpc_testing"
+)
+
+// Must be higher than default 64K, ignored otherwise
+const initialWindowSize uint = 70 * 1024
+
+// Something that is not going to fit in a single window
+const bodySize uint = 2 * initialWindowSize
+
+// The maximum message size the client can receive
+const callRecvMsgSize uint = 1
+
+func (s) TestStreamCleanup(t *testing.T) {
+	ss := &stubServer{
+		unaryCall: func(ctx context.Context, in *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
+			return &testpb.SimpleResponse{Payload: &testpb.Payload{
+				Body: make([]byte, bodySize),
+			}}, nil
+		},
+		emptyCall: func(context.Context, *testpb.Empty) (*testpb.Empty, error) {
+			return &testpb.Empty{}, nil
+		},
+	}
+	if err := ss.Start([]grpc.ServerOption{grpc.MaxConcurrentStreams(1)}, grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(int(callRecvMsgSize))), grpc.WithInitialWindowSize(int32(initialWindowSize))); err != nil {
+		t.Fatalf("Error starting endpoint server: %v", err)
+	}
+	defer ss.Stop()
+
+	if _, err := ss.client.UnaryCall(context.Background(), &testpb.SimpleRequest{}); status.Code(err) != codes.ResourceExhausted {
+		t.Fatalf("should fail with ResourceExhausted, message's body size: %v, maximum message size the client can receive: %v", bodySize, callRecvMsgSize)
+	}
+	if _, err := ss.client.EmptyCall(context.Background(), &testpb.Empty{}); err != nil {
+		t.Fatalf("should succeed, err: %v", err)
+	}
+}

--- a/test/stream_cleanup_test.go
+++ b/test/stream_cleanup_test.go
@@ -22,23 +22,17 @@ import (
 	"context"
 	"testing"
 
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-
-	"google.golang.org/grpc"
 	testpb "google.golang.org/grpc/test/grpc_testing"
 )
 
-// Must be higher than default 64K, ignored otherwise
-const initialWindowSize uint = 70 * 1024
-
-// Something that is not going to fit in a single window
-const bodySize uint = 2 * initialWindowSize
-
-// The maximum message size the client can receive
-const callRecvMsgSize uint = 1
-
 func (s) TestStreamCleanup(t *testing.T) {
+	const initialWindowSize uint = 70 * 1024    // Must be higher than default 64K, ignored otherwise
+	const bodySize uint = 2 * initialWindowSize // Something that is not going to fit in a single window
+	const callRecvMsgSize uint = 1              // The maximum message size the client can receive
+
 	ss := &stubServer{
 		unaryCall: func(ctx context.Context, in *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
 			return &testpb.SimpleResponse{Payload: &testpb.Payload{


### PR DESCRIPTION
`RSTStreamFrame`s used to be ignored by the server transport, if a trailer had already been put into the transport's control buffer. If loopy writer couldn't write anything into a stream because of an error on the client side, then this trailer would never be sent. At that point, server would receive an `RSTStreamFrame` from client. But this `RSTStreamFrame` would be ignored because a trailer was already put into the control buffer. This would keep the stream open and in memory on the server side.

With this change, a `cleanupStream` item is put into the transport's control buffer, whenever an `RSTStreamFrame` is received by the server, even after a trailer has been put into the buffer. When loopy writer handles this `cleanupStream`, the stream will be closed and cleaned up.