### PR TITLE
makefile: remove testappengine from make all

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,7 @@ How to get your contributions merged smoothly and quickly.
   - `make vet` to catch vet errors
   - `make test` to run the tests
   - `make testrace` to run tests in race mode
+  - optional `make testappengine` to run tests with appengine
 
 - Exceptions to the rules can be made if there's a compelling reason for doing so.
  

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-all: vet test testrace testappengine
+all: vet test testrace
 
 build: deps
 	go build google.golang.org/grpc/...


### PR DESCRIPTION
Since it requires goapp.

fixes #2618