### PR TITLE
internal: add buffer for channelz flowcontrol getter channel

### DIFF
--- a/internal/transport/http2_server.go
+++ b/internal/transport/http2_server.go
@@ -1155,7 +1155,7 @@ func (t *http2Server) IncrMsgRecv() {
 }
 
 func (t *http2Server) getOutFlowWindow() int64 {
-	resp := make(chan uint32)
+	resp := make(chan uint32, 1)
 	timer := time.NewTimer(time.Second)
 	defer timer.Stop()
 	t.controlBuf.put(&outFlowControlSizeRequest{resp})


### PR DESCRIPTION
to avoid leak at https://github.com/grpc/grpc-go/blob/2259ee6f1a16ff0bb8776e5d2476a2b12e8fda04/internal/transport/controlbuf.go#L648

Client transport already has the buffer: https://github.com/grpc/grpc-go/blob/2259ee6f1a16ff0bb8776e5d2476a2b12e8fda04/internal/transport/http2_client.go#L1368