### PR TITLE
grpclb: keep drop index unless a new serverlist is received

### DIFF
--- a/balancer/grpclb/grpclb_picker.go
+++ b/balancer/grpclb/grpclb_picker.go
@@ -191,5 +191,5 @@ func (p *lbPicker) updateReadySCs(readySCs []balancer.SubConn) {
 	defer p.mu.Unlock()
 
 	p.subConns = readySCs
-	p.subConnsNext = grpcrand.Intn(len(readySCs))
+	p.subConnsNext = p.subConnsNext % len(readySCs)
 }

--- a/balancer/grpclb/grpclb_picker.go
+++ b/balancer/grpclb/grpclb_picker.go
@@ -26,6 +26,7 @@ import (
 	"google.golang.org/grpc/balancer"
 	lbpb "google.golang.org/grpc/balancer/grpclb/grpc_lb_v1"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/internal/grpcrand"
 	"google.golang.org/grpc/status"
 )
 
@@ -110,6 +111,13 @@ type rrPicker struct {
 	subConnsNext int
 }
 
+func newRRPicker(readySCs []balancer.SubConn) *rrPicker {
+	return &rrPicker{
+		subConns:     readySCs,
+		subConnsNext: grpcrand.Intn(len(readySCs)),
+	}
+}
+
 func (p *rrPicker) Pick(ctx context.Context, opts balancer.PickOptions) (balancer.SubConn, func(balancer.DoneInfo), error) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -135,6 +143,17 @@ type lbPicker struct {
 	subConnsNext   int
 
 	stats *rpcStats
+}
+
+func newLBPicker(serverList []*lbpb.Server, readySCs []balancer.SubConn, stats *rpcStats) *lbPicker {
+	return &lbPicker{
+		serverList: serverList,
+		subConns:   readySCs,
+		// TODO: add this after adding len check before calling this function.
+		//  It's being done in another PR.
+		//  subConnsNext: grpcrand.Intn(len(readySCs)),
+		stats: stats,
+	}
 }
 
 func (p *lbPicker) Pick(ctx context.Context, opts balancer.PickOptions) (balancer.SubConn, func(balancer.DoneInfo), error) {
@@ -167,4 +186,13 @@ func (p *lbPicker) Pick(ctx context.Context, opts balancer.PickOptions) (balance
 		}
 	}
 	return sc, done, nil
+}
+
+func (p *lbPicker) updateReadySCs(readySCs []balancer.SubConn) {
+	// panic("sssssss")
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	p.subConns = readySCs
+	p.subConnsNext = grpcrand.Intn(len(readySCs))
 }

--- a/balancer/grpclb/grpclb_picker.go
+++ b/balancer/grpclb/grpclb_picker.go
@@ -147,12 +147,10 @@ type lbPicker struct {
 
 func newLBPicker(serverList []*lbpb.Server, readySCs []balancer.SubConn, stats *rpcStats) *lbPicker {
 	return &lbPicker{
-		serverList: serverList,
-		subConns:   readySCs,
-		// TODO: add this after adding len check before calling this function.
-		//  It's being done in another PR.
-		//  subConnsNext: grpcrand.Intn(len(readySCs)),
-		stats: stats,
+		serverList:   serverList,
+		subConns:     readySCs,
+		subConnsNext: grpcrand.Intn(len(readySCs)),
+		stats:        stats,
 	}
 }
 
@@ -189,7 +187,6 @@ func (p *lbPicker) Pick(ctx context.Context, opts balancer.PickOptions) (balance
 }
 
 func (p *lbPicker) updateReadySCs(readySCs []balancer.SubConn) {
-	// panic("sssssss")
 	p.mu.Lock()
 	defer p.mu.Unlock()
 

--- a/balancer/grpclb/grpclb_remote_balancer.go
+++ b/balancer/grpclb/grpclb_remote_balancer.go
@@ -88,7 +88,7 @@ func (lb *lbBalancer) processServerList(l *lbpb.ServerList) {
 	//
 	// Now with cache, even if SubConn was newed/removed, there might be no
 	// state changes.
-	lb.regeneratePicker()
+	lb.regeneratePicker(true)
 	lb.cc.UpdateBalancerState(lb.state, lb.picker)
 }
 

--- a/balancer/grpclb/grpclb_test.go
+++ b/balancer/grpclb/grpclb_test.go
@@ -291,11 +291,12 @@ func stopBackends(servers []*grpc.Server) {
 }
 
 type testServers struct {
-	lbAddr  string
-	ls      *remoteBalancer
-	lb      *grpc.Server
-	beIPs   []net.IP
-	bePorts []int
+	lbAddr   string
+	ls       *remoteBalancer
+	lb       *grpc.Server
+	backends []*grpc.Server
+	beIPs    []net.IP
+	bePorts  []int
 }
 
 func newLoadBalancer(numberOfBackends int) (tss *testServers, cleanup func(), err error) {
@@ -337,11 +338,12 @@ func newLoadBalancer(numberOfBackends int) (tss *testServers, cleanup func(), er
 	}()
 
 	tss = &testServers{
-		lbAddr:  fakeName + ":" + strconv.Itoa(lbLis.Addr().(*net.TCPAddr).Port),
-		ls:      ls,
-		lb:      lb,
-		beIPs:   beIPs,
-		bePorts: bePorts,
+		lbAddr:   fakeName + ":" + strconv.Itoa(lbLis.Addr().(*net.TCPAddr).Port),
+		ls:       ls,
+		lb:       lb,
+		backends: backends,
+		beIPs:    beIPs,
+		bePorts:  bePorts,
 	}
 	cleanup = func() {
 		defer stopBackends(backends)
@@ -477,7 +479,7 @@ func TestDropRequest(t *testing.T) {
 	r, cleanup := manual.GenerateAndRegisterManualResolver()
 	defer cleanup()
 
-	tss, cleanup, err := newLoadBalancer(1)
+	tss, cleanup, err := newLoadBalancer(2)
 	if err != nil {
 		t.Fatalf("failed to create new load balancer: %v", err)
 	}
@@ -486,6 +488,11 @@ func TestDropRequest(t *testing.T) {
 		Servers: []*lbpb.Server{{
 			IpAddress:        tss.beIPs[0],
 			Port:             int32(tss.bePorts[0]),
+			LoadBalanceToken: lbToken,
+			Drop:             false,
+		}, {
+			IpAddress:        tss.beIPs[1],
+			Port:             int32(tss.bePorts[1]),
 			LoadBalanceToken: lbToken,
 			Drop:             false,
 		}, {
@@ -512,8 +519,7 @@ func TestDropRequest(t *testing.T) {
 	}})
 
 	// Wait for the 1st, non-fail-fast RPC to succeed. This ensures both server
-	// connections are made, because the first one has DropForLoadBalancing set
-	// to true.
+	// connections are made, because the first one has Drop set to true.
 	var i int
 	for i = 0; i < 1000; i++ {
 		if _, err := testC.EmptyCall(ctx, &testpb.Empty{}, grpc.WaitForReady(true)); err == nil {
@@ -531,16 +537,39 @@ func TestDropRequest(t *testing.T) {
 	}
 	for _, failfast := range []bool{true, false} {
 		for i := 0; i < 3; i++ {
-			// Even RPCs should fail, because the 2st backend has
-			// DropForLoadBalancing set to true.
-			if _, err := testC.EmptyCall(context.Background(), &testpb.Empty{}, grpc.WaitForReady(!failfast)); status.Code(err) != codes.Unavailable {
-				t.Errorf("%v.EmptyCall(_, _) = _, %v, want _, %s", testC, err, codes.Unavailable)
-			}
-			// Odd RPCs should succeed since they choose the non-drop-request
-			// backend according to the round robin policy.
+			// 1st RPCs pick the second item in server list. They should succeed
+			// since they choose the non-drop-request backend according to the
+			// round robin policy.
 			if _, err := testC.EmptyCall(context.Background(), &testpb.Empty{}, grpc.WaitForReady(!failfast)); err != nil {
 				t.Errorf("%v.EmptyCall(_, _) = _, %v, want _, <nil>", testC, err)
 			}
+			// 2st RPCs should fail, because they pick last item in server list,
+			// with Drop set to true.
+			if _, err := testC.EmptyCall(context.Background(), &testpb.Empty{}, grpc.WaitForReady(!failfast)); status.Code(err) != codes.Unavailable {
+				t.Errorf("%v.EmptyCall(_, _) = _, %v, want _, %s", testC, err, codes.Unavailable)
+			}
+			// 3rd RPCs pick the first item in server list. They should succeed
+			// since they choose the non-drop-request backend according to the
+			// round robin policy.
+			if _, err := testC.EmptyCall(context.Background(), &testpb.Empty{}, grpc.WaitForReady(!failfast)); err != nil {
+				t.Errorf("%v.EmptyCall(_, _) = _, %v, want _, <nil>", testC, err)
+			}
+		}
+	}
+	tss.backends[0].Stop()
+	// This last pick was backend 0. Closing backend 0 doesn't reset drop index
+	// (for level 1 picking), so the following picks will be (backend, drop,
+	// backend), instead of (backend, backend, drop) if drop index was reset.
+	time.Sleep(time.Second)
+	for i := 0; i < 3; i++ {
+		if _, err := testC.EmptyCall(context.Background(), &testpb.Empty{}, grpc.WaitForReady(true)); err != nil {
+			t.Errorf("%v.EmptyCall(_, _) = _, %v, want _, <nil>", testC, err)
+		}
+		if _, err := testC.EmptyCall(context.Background(), &testpb.Empty{}, grpc.WaitForReady(true)); status.Code(err) != codes.Unavailable {
+			t.Errorf("%v.EmptyCall(_, _) = _, %v, want _, %s", testC, err, codes.Unavailable)
+		}
+		if _, err := testC.EmptyCall(context.Background(), &testpb.Empty{}, grpc.WaitForReady(true)); err != nil {
+			t.Errorf("%v.EmptyCall(_, _) = _, %v, want _, <nil>", testC, err)
 		}
 	}
 }


### PR DESCRIPTION
Keep the drop index from the previous picker when regenerating picker due to
subchannel state change. Only reset the drop index when picker is regenerated
because of a serverlist update.

fixes #2623