### PR TITLE
Use options pattern to allow overriding of LookupSRV and LookupHost.

### DIFF
--- a/naming/dns_resolver_test.go
+++ b/naming/dns_resolver_test.go
@@ -220,7 +220,7 @@ func testResolver(t *testing.T, freq time.Duration, slp time.Duration) {
 	}
 
 	for _, a := range tests {
-		r, err := NewDNSResolverWithFreq(freq)
+		r, err := NewDNSResolverWithOptions(Freq(freq), LookupHost(lookupHost), LookupSRV(lookupSRV))
 		if err != nil {
 			t.Fatalf("%v\n", err)
 		}
@@ -254,23 +254,15 @@ func testResolver(t *testing.T, freq time.Duration, slp time.Duration) {
 	}
 }
 
-func replaceNetFunc() func() {
-	oldLookupHost := lookupHost
-	oldLookupSRV := lookupSRV
-	lookupHost = func(ctx context.Context, host string) ([]string, error) {
-		return hostLookup(host)
-	}
-	lookupSRV = func(ctx context.Context, service, proto, name string) (string, []*net.SRV, error) {
-		return srvLookup(service, proto, name)
-	}
-	return func() {
-		lookupHost = oldLookupHost
-		lookupSRV = oldLookupSRV
-	}
+func lookupHost(ctx context.Context, host string) ([]string, error) {
+	return hostLookup(host)
+}
+
+func lookupSRV(ctx context.Context, service, proto, name string) (string, []*net.SRV, error) {
+	return srvLookup(service, proto, name)
 }
 
 func TestResolve(t *testing.T) {
-	defer replaceNetFunc()()
 	testResolver(t, time.Millisecond*5, time.Millisecond*10)
 }
 

--- a/naming/options.go
+++ b/naming/options.go
@@ -1,0 +1,54 @@
+package naming
+
+import (
+	"context"
+	"net"
+	"time"
+)
+
+// LookupSRVFn type for functions used to lookup SRV records.
+type LookupSRVFn func(ctx context.Context, service, proto, name string) (cname string, addrs []*net.SRV, err error)
+
+// LookupHostFn type for functions used to lookup A records.
+type LookupHostFn func(ctx context.Context, host string) (addrs []string, err error)
+
+type options struct {
+	lookupSRV  LookupSRVFn
+	lookupHost LookupHostFn
+
+	// frequency of polling the DNS server that the watchers created by this resolver will use.
+	freq time.Duration
+}
+
+var defaultOptions = options{
+	freq:       defaultFreq,
+	lookupSRV:  net.DefaultResolver.LookupSRV,
+	lookupHost: net.DefaultResolver.LookupHost,
+}
+
+// A Option sets options such as frequency etc.
+type Option func(*options)
+
+// LookupSRV configures the resolver to create watchers that poll the DNS
+// server using the specified LookupSRVFn.
+func LookupSRV(f LookupSRVFn) Option {
+	return func(o *options) {
+		o.lookupSRV = f
+	}
+}
+
+// LookupHost configures the resolver to create watchers that poll the DNS
+// server using the specified LookupHostFn.
+func LookupHost(f LookupHostFn) Option {
+	return func(o *options) {
+		o.lookupHost = f
+	}
+}
+
+// Freq configures the resolver to create watchers that poll the DNS server
+// with the specified frequency.
+func Freq(freq time.Duration) Option {
+	return func(o *options) {
+		o.freq = freq
+	}
+}

--- a/naming/options.go
+++ b/naming/options.go
@@ -1,3 +1,21 @@
+/*
+ *
+ * Copyright 2019 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package naming
 
 import (


### PR DESCRIPTION
Need to override LookupSRV as go1.11 got strict about SRV lookups on old k8s cluster: https://github.com/golang/go/issues/27546.

Signed-off-by: Tom Wilkie <tom.wilkie@gmail.com>