### PR TITLE
internal: delete an info log

### DIFF
--- a/clientconn.go
+++ b/clientconn.go
@@ -937,7 +937,6 @@ func (ac *addrConn) updateConnectivityState(s connectivity.State) {
 	}
 
 	updateMsg := fmt.Sprintf("Subchannel Connectivity change to %v", s)
-	grpclog.Infof(updateMsg)
 	ac.state = s
 	if channelz.IsOn() {
 		channelz.AddTraceEvent(ac.channelzID, &channelz.TraceEventDesc{


### PR DESCRIPTION
This log doesn't print useful information, and causes flooding