### PR TITLE
keepalive: apply minimum ping time of 10s to client and 1s to server

### DIFF
--- a/clientconn_test.go
+++ b/clientconn_test.go
@@ -948,10 +948,11 @@ func (s) TestClientUpdatesParamsAfterGoAway(t *testing.T) {
 		}
 		defer conn.Close()
 		f := http2.NewFramer(conn, conn)
+		// Start a goroutine to read from the conn to prevent the client from
+		// blocking after it writes its preface.
 		go func() {
 			for {
-				fr, err := f.ReadFrame()
-				if err != nil {
+				if _, err := f.ReadFrame(); err != nil {
 					return
 				}
 			}

--- a/dialoptions.go
+++ b/dialoptions.go
@@ -26,6 +26,7 @@ import (
 
 	"google.golang.org/grpc/balancer"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/grpclog"
 	"google.golang.org/grpc/internal"
 	"google.golang.org/grpc/internal/backoff"
 	"google.golang.org/grpc/internal/envconfig"
@@ -388,6 +389,10 @@ func WithUserAgent(s string) DialOption {
 // WithKeepaliveParams returns a DialOption that specifies keepalive parameters
 // for the client transport.
 func WithKeepaliveParams(kp keepalive.ClientParameters) DialOption {
+	if kp.Time < internal.KeepaliveMinPingTime {
+		grpclog.Warningf("Adjusting keepalive ping interval to minimum period of %v", internal.KeepaliveMinPingTime)
+		kp.Time = internal.KeepaliveMinPingTime
+	}
 	return newFuncDialOption(func(o *dialOptions) {
 		o.copts.KeepaliveParams = kp
 	})

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -20,7 +20,10 @@
 // symbols to avoid circular dependencies.
 package internal
 
-import "context"
+import (
+	"context"
+	"time"
+)
 
 var (
 	// WithContextDialer is exported by dialoptions.go
@@ -33,6 +36,9 @@ var (
 	HealthCheckFunc HealthChecker
 	// BalancerUnregister is exported by package balancer to unregister a balancer.
 	BalancerUnregister func(name string)
+	// KeepaliveMinPingTime is the minimum ping interval.  This must be 10s by
+	// default, but tests may wish to set it lower for convenience.
+	KeepaliveMinPingTime = 10 * time.Second
 )
 
 // HealthChecker defines the signature of the client-side LB channel health checking function.

--- a/keepalive/keepalive.go
+++ b/keepalive/keepalive.go
@@ -33,6 +33,7 @@ import (
 type ClientParameters struct {
 	// After a duration of this time if the client doesn't see any activity it
 	// pings the server to see if the transport is still alive.
+	// If set below 10s, a minimum value of 10s will be used instead.
 	Time time.Duration // The current default value is infinity.
 	// After having pinged for keepalive check, the client waits for a duration
 	// of Timeout and if no activity is seen even after that the connection is
@@ -62,6 +63,7 @@ type ServerParameters struct {
 	MaxConnectionAgeGrace time.Duration // The current default value is infinity.
 	// After a duration of this time if the server doesn't see any activity it
 	// pings the client to see if the transport is still alive.
+	// If set below 1s, a minimum value of 1s will be used instead.
 	Time time.Duration // The current default value is 2 hours.
 	// After having pinged for keepalive check, the server waits for a duration
 	// of Timeout and if no activity is seen even after that the connection is

--- a/server.go
+++ b/server.go
@@ -183,7 +183,7 @@ func InitialConnWindowSize(s int32) ServerOption {
 // KeepaliveParams returns a ServerOption that sets keepalive and max-age parameters for the server.
 func KeepaliveParams(kp keepalive.ServerParameters) ServerOption {
 	if kp.Time > 0 && kp.Time < time.Second {
-		grpclog.Warningf("Adjusting keepalive ping interval to minimum period of 1s")
+		grpclog.Warning("Adjusting keepalive ping interval to minimum period of 1s")
 		kp.Time = time.Second
 	}
 

--- a/server.go
+++ b/server.go
@@ -182,6 +182,11 @@ func InitialConnWindowSize(s int32) ServerOption {
 
 // KeepaliveParams returns a ServerOption that sets keepalive and max-age parameters for the server.
 func KeepaliveParams(kp keepalive.ServerParameters) ServerOption {
+	if kp.Time > 0 && kp.Time < time.Second {
+		grpclog.Warningf("Adjusting keepalive ping interval to minimum period of 1s")
+		kp.Time = time.Second
+	}
+
 	return func(o *options) {
 		o.keepaliveParams = kp
 	}

--- a/test/channelz_test.go
+++ b/test/channelz_test.go
@@ -849,7 +849,7 @@ func doIdleCallToInvokeKeepAlive(tc testpb.TestServiceClient, t *testing.T) {
 		t.Fatalf("TestService/FullDuplexCall(_) = _, %v, want <nil>", err)
 	}
 	// Allow for at least 2 keepalives (1s per ping interval)
-	time.Sleep(4000 * time.Millisecond)
+	time.Sleep(4 * time.Second)
 	cancel()
 }
 

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -62,7 +62,6 @@ import (
 	"google.golang.org/grpc/internal/grpctest"
 	"google.golang.org/grpc/internal/leakcheck"
 	"google.golang.org/grpc/internal/testutils"
-	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/resolver"
@@ -510,8 +509,6 @@ type test struct {
 	customDialOptions           []grpc.DialOption
 	customServerOptions         []grpc.ServerOption
 	resolverScheme              string
-	cliKeepAlive                *keepalive.ClientParameters
-	svrKeepAlive                *keepalive.ServerParameters
 
 	// All test dialing is blocking by default. Set this to true if dial
 	// should be non-blocking.
@@ -632,9 +629,6 @@ func (te *test) listenAndServe(ts testpb.TestServiceServer, listen func(network,
 		sopts = append(sopts, grpc.Creds(creds))
 	case "clientTimeoutCreds":
 		sopts = append(sopts, grpc.Creds(&clientTimeoutCreds{}))
-	}
-	if te.svrKeepAlive != nil {
-		sopts = append(sopts, grpc.KeepaliveParams(*te.svrKeepAlive))
 	}
 	sopts = append(sopts, te.customServerOptions...)
 	s := grpc.NewServer(sopts...)
@@ -872,9 +866,6 @@ func (te *test) configDial(opts ...grpc.DialOption) ([]grpc.DialOption, string) 
 	}
 	if te.srvAddr == "" {
 		te.srvAddr = "client.side.only.test"
-	}
-	if te.cliKeepAlive != nil {
-		opts = append(opts, grpc.WithKeepaliveParams(*te.cliKeepAlive))
 	}
 	opts = append(opts, te.customDialOptions...)
 	return opts, scheme


### PR DESCRIPTION
Also fix tests that relied upon setting lower values.

This is in preparation for the fix to issue #2638 
