### PR TITLE
transport: return ErrConnClosing for proper handling

### DIFF
--- a/internal/transport/http2_server.go
+++ b/internal/transport/http2_server.go
@@ -849,7 +849,7 @@ func (t *http2Server) WriteStatus(s *Stream, st *status.Status) error {
 func (t *http2Server) Write(s *Stream, hdr []byte, data []byte, opts *Options) error {
 	if !s.isHeaderSent() { // Headers haven't been written yet.
 		if err := t.WriteHeader(s, nil); err != nil {
-			if err == ErrConnClosing {
+			if _, ok := err.(ConnectionError); ok {
 				return err
 			}
 			// TODO(mmukhi, dfawley): Make sure this is the right code to return.

--- a/internal/transport/http2_server.go
+++ b/internal/transport/http2_server.go
@@ -849,6 +849,9 @@ func (t *http2Server) WriteStatus(s *Stream, st *status.Status) error {
 func (t *http2Server) Write(s *Stream, hdr []byte, data []byte, opts *Options) error {
 	if !s.isHeaderSent() { // Headers haven't been written yet.
 		if err := t.WriteHeader(s, nil); err != nil {
+			if err == ErrConnClosing {
+				return err
+			}
 			// TODO(mmukhi, dfawley): Make sure this is the right code to return.
 			return status.Errorf(codes.Internal, "transport: %v", err)
 		}


### PR DESCRIPTION
Solving #2593 

An easy solution might be to add one condition in `internal/transport/http_server2.go` to just return the `ErrConnClosing` as it is, and `toRPCError` will convert it to the said format. 

Better might be a function to handle it right there, but question is where should the function be kept?