### PR TITLE
examples: correct typo in keepalive example

### DIFF
--- a/examples/features/keepalive/server/main.go
+++ b/examples/features/keepalive/server/main.go
@@ -42,7 +42,7 @@ var kaep = keepalive.EnforcementPolicy{
 }
 
 var kasp = keepalive.ServerParameters{
-	MaxConnectionIdle:     15 * time.Second, // If a client is idle for 10 seconds, send a GOAWAY
+	MaxConnectionIdle:     15 * time.Second, // If a client is idle for 15 seconds, send a GOAWAY
 	MaxConnectionAge:      30 * time.Second, // If any connection is alive for more than 30 seconds, send a GOAWAY
 	MaxConnectionAgeGrace: 5 * time.Second,  // Allow 5 seconds for pending RPCs to complete before forcibly closing connections
 	Time:                  5 * time.Second,  // Ping the client if it is idle for 5 seconds to ensure the connection is still active


### PR DESCRIPTION
Correct the max connection idle time comment from `10` to `15`