### PR TITLE
clientconn: set dial target "Authority" with target address

### DIFF
--- a/clientconn.go
+++ b/clientconn.go
@@ -1153,6 +1153,19 @@ func (ac *addrConn) createTransport(addr resolver.Address, copts transport.Conne
 		Metadata:  addr.Metadata,
 		Authority: ac.cc.authority,
 	}
+	if target.Addr != target.Authority {
+		target.Authority = target.Addr
+
+		// When user dials with "grpc.WithDialer", "grpc.DialContext" "cc.parsedTarget"
+		// update only happpens once. This is problematic, because when TLS is enabled,
+		// retries happen through "grpc.WithDialer" with static "cc.parsedTarget" from
+		// the initial dial call.
+		// If the server authenticates by IP addresses, we want to set a new endpoint as
+		// a new authority. Otherwise
+		// "transport: authentication handshake failed: x509: certificate is valid for 127.0.0.1, 192.168.154.254, not 192.168.208.149"
+		// when the new dial target is "192.168.154.254" whose certificate host name is also "192.168.154.254"
+		// but client tries to authenticate with previously set "cc.parsedTarget" field "192.168.208.149"
+	}
 
 	prefaceTimer := time.NewTimer(time.Until(connectDeadline))
 


### PR DESCRIPTION
I am creating this PR, in order to start a discussion :)

When user dials with "grpc.WithDialer", "grpc.DialContext" "cc.parsedTarget"
update only happpens once. This is problematic, because when TLS is enabled,
retries happen through "grpc.WithDialer" with static "cc.parsedTarget" from
the initial dial call.

If the server authenticates by IP addresses, we want to set a new endpoint as
a new authority. Otherwise

```
transport: authentication handshake failed: x509: certificate is valid for 127.0.0.1, 192.168.154.254, not 192.168.208.149
```

when the new dial target is "192.168.154.254" whose certificate host name is also "192.168.154.254"
but client tries to authenticate with previously set "cc.parsedTarget" field "192.168.208.149"

ref.
- https://github.com/etcd-io/etcd/pull/10489
- https://github.com/etcd-io/etcd/issues/9949
- https://github.com/kubernetes/kubernetes/issues/72102

/cc @xiang90 @jpbetz


To add more details, this is the etcd use case.

Server 1 certificate:

```
X509v3 extensions:
    X509v3 Key Usage: critical
        Digital Signature, Key Encipherment
    X509v3 Extended Key Usage:
        TLS Web Server Authentication, TLS Web Client Authentication
    X509v3 Basic Constraints: critical
        CA:FALSE
    X509v3 Subject Alternative Name:
        DNS:localhost, IP Address:127.0.0.1, IP Address:192.168.208.149
```

Server 2 certificate:

```
X509v3 extensions:
    X509v3 Key Usage: critical
        Digital Signature, Key Encipherment
    X509v3 Extended Key Usage:
        TLS Web Server Authentication, TLS Web Client Authentication
    X509v3 Basic Constraints: critical
        CA:FALSE
    X509v3 Subject Alternative Name:
        DNS:localhost, IP Address:127.0.0.1, IP Address:192.168.154.254
```

Server 3 certificate:

```
X509v3 extensions:
    X509v3 Key Usage: critical
        Digital Signature, Key Encipherment
    X509v3 Extended Key Usage:
        TLS Web Server Authentication, TLS Web Client Authentication
    X509v3 Basic Constraints: critical
        CA:FALSE
    X509v3 Subject Alternative Name:
        DNS:localhost, IP Address:127.0.0.1, IP Address:192.168.152.228
```

1. Set up the 3-node cluster with those IPs and SAN fields.
2. Now shut down the `Server 1`.
3. Send etcd client requests (that uses `grpc.WithDialer` while passing the first endpoint in the slice to the balancer, later to be used for parsed target)

```
# ssh into remote machine (public IP "54.190.195.210", private IP "192.168.84.19")
ETCD_CLIENT_DEBUG=1 ETCDCTL_API=3 /usr/local/bin/etcdctl \
  --endpoints 192.168.208.149:2379,192.168.154.254:2379,192.168.152.228:2379 \
  --cacert ${HOME}/certs/etcd-root-ca.pem \
  --cert ${HOME}/certs/s1.pem \
  --key ${HOME}/certs/s1-key.pem \
  put foo bar
```

`192.168.84.19` is the IP requesting the client calls.

```
connection error: desc = "transport: authentication handshake failed: x509: certificate is valid for 127.0.0.1, 192.168.152.228, not 192.168.208.149"
```


