### PR TITLE
examples: remove duplicated words

### DIFF
--- a/examples/features/name_resolving/README.md
+++ b/examples/features/name_resolving/README.md
@@ -25,7 +25,7 @@ go run client/main.go
 
 The echo server is serving on ":50051". Two clients are created, one is dialing
 to `passthrough:///localhost:50051`, while the other is dialing to
-`example:///resolver.example.grpc.io`. Both of them can connect the the server.
+`example:///resolver.example.grpc.io`. Both of them can connect the server.
 
 Name resolver is picked based on the `scheme` in the target string. See
 https://github.com/grpc/grpc/blob/master/doc/naming.md for the target syntax.

--- a/examples/gotutorial.md
+++ b/examples/gotutorial.md
@@ -227,7 +227,7 @@ func (s *routeGuideServer) RecordRoute(stream pb.RouteGuide_RecordRouteServer) e
 }
 ```
 
-In the method body we use the `RouteGuide_RecordRouteServer`s `Recv()` method to repeatedly read in our client's requests to a request object (in this case a `Point`) until there are no more messages: the server needs to check the the error returned from `Recv()` after each call. If this is `nil`, the stream is still good and it can continue reading; if it's `io.EOF` the message stream has ended and the server can return its `RouteSummary`. If it has any other value, we return the error "as is" so that it'll be translated to an RPC status by the gRPC layer.
+In the method body we use the `RouteGuide_RecordRouteServer`s `Recv()` method to repeatedly read in our client's requests to a request object (in this case a `Point`) until there are no more messages: the server needs to check the error returned from `Recv()` after each call. If this is `nil`, the stream is still good and it can continue reading; if it's `io.EOF` the message stream has ended and the server can return its `RouteSummary`. If it has any other value, we return the error "as is" so that it'll be translated to an RPC status by the gRPC layer.
 
 #### Bidirectional streaming RPC
 Finally, let's look at our bidirectional streaming RPC `RouteChat()`.


### PR DESCRIPTION
Correct spelling for documents.