### PR TITLE
doc: fix typos

### DIFF
--- a/Documentation/gomock-example.md
+++ b/Documentation/gomock-example.md
@@ -130,7 +130,7 @@ Like before we'll use [mockgen](https://github.com/golang/mock#running-mockgen).
 
 Notice that we are mocking both client(`RouteGuideClient`) and stream(`RouteGuide_RouteChatClient`) interfaces here.
 
-This will create a file `rg_mock.go` under directory `mock_route_guide`. This file contins all the mocking code we need to write our test.
+This will create a file `rg_mock.go` under directory `mock_route_guide`. This file contains all the mocking code we need to write our test.
 
 In our test code, like before, we import the this mocking code along with the generated code
 
@@ -141,7 +141,7 @@ import (
 )
 ```
 
-Now conside a test that takes the RouteGuide client object as a parameter, makes a RouteChat rpc call and sends a message on the resulting stream. Furthermore, this test expects to see the same message to be received on the stream. 
+Now considering a test that takes the RouteGuide client object as a parameter, makes a RouteChat rpc call and sends a message on the resulting stream. Furthermore, this test expects to see the same message to be received on the stream. 
 
 ```go
 var msg = ...

--- a/examples/features/name_resolving/README.md
+++ b/examples/features/name_resolving/README.md
@@ -5,7 +5,7 @@ This examples shows how `ClientConn` can pick different name resolvers.
 ## What is a name resolver
 
 A name resolver can be seen as a `map[service-name][]backend-ip`. It takes a
-service name, and returns a list of IPs of the backends. A commen used name
+service name, and returns a list of IPs of the backends. A common used name
 resolver is DNS.
 
 In this example, a resolver is created to resolve `resolver.example.grpc.io` to


### PR DESCRIPTION
Correct some words spelling for reading more easily.
File changed:
* Documentation/gomock-example.md
* examples/features/name_resolving/README.md