### PR TITLE
stats: add BeginTime to InPayload and OutPayload

### DIFF
--- a/rpc_util.go
+++ b/rpc_util.go
@@ -603,14 +603,15 @@ func msgHeader(data, compData []byte) (hdr []byte, payload []byte) {
 	return hdr, data
 }
 
-func outPayload(client bool, msg interface{}, data, payload []byte, t time.Time) *stats.OutPayload {
+func outPayload(client bool, msg interface{}, data, payload []byte, beginTime, sentTime time.Time) *stats.OutPayload {
 	return &stats.OutPayload{
 		Client:     client,
 		Payload:    msg,
 		Data:       data,
 		Length:     len(data),
 		WireLength: len(payload) + headerLen,
-		SentTime:   t,
+		BeginTime:  beginTime,
+		SentTime:   sentTime,
 	}
 }
 

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -64,6 +64,8 @@ type InPayload struct {
 	Length int
 	// WireLength is the length of data on wire (compressed, signed, encrypted).
 	WireLength int
+	// BeginTime is the time when the payload began to be received.
+	BeginTime time.Time
 	// RecvTime is the time when the payload is received.
 	RecvTime time.Time
 }
@@ -121,6 +123,8 @@ type OutPayload struct {
 	Length int
 	// WireLength is the length of data on wire (compressed, signed, encrypted).
 	WireLength int
+	// BeginTime is the time when the payload began to be sent.
+	BeginTime time.Time
 	// SentTime is the time when the payload is sent.
 	SentTime time.Time
 }

--- a/stats/stats_test.go
+++ b/stats/stats_test.go
@@ -512,6 +512,9 @@ func checkInPayload(t *testing.T, d *gotData, e *expectedData) {
 		}
 	}
 	// TODO check WireLength and ReceivedTime.
+	if st.BeginTime.IsZero() {
+		t.Fatalf("st.BeginTime = %v, want <non-zero>", st.BeginTime)
+	}
 	if st.RecvTime.IsZero() {
 		t.Fatalf("st.ReceivedTime = %v, want <non-zero>", st.RecvTime)
 	}
@@ -604,6 +607,9 @@ func checkOutPayload(t *testing.T, d *gotData, e *expectedData) {
 		}
 	}
 	// TODO check WireLength and ReceivedTime.
+	if st.BeginTime.IsZero() {
+		t.Fatalf("st.BeginTime = %v, want <non-zero>", st.BeginTime)
+	}
 	if st.SentTime.IsZero() {
 		t.Fatalf("st.SentTime = %v, want <non-zero>", st.SentTime)
 	}


### PR DESCRIPTION
Add the time when the payload began to be received/sent. It is useful for detailed request tracing.