### PR TITLE
balancer: make sure non-nil done returned by Pick is called

### DIFF
--- a/balancer/balancer.go
+++ b/balancer/balancer.go
@@ -215,8 +215,10 @@ type Picker interface {
 	//
 	// If a SubConn is returned:
 	// - If it is READY, gRPC will send the RPC on it;
-	// - If it is not ready, or becomes not ready after it's returned, gRPC will block
-	//   until UpdateBalancerState() is called and will call pick on the new picker.
+	// - If it is not ready, or becomes not ready after it's returned, gRPC will
+	//   block until UpdateBalancerState() is called and will call pick on the
+	//   new picker. The done function returned from Pick(), if not nil, will be
+	//   called with nil error, no bytes sent and no bytes received.
 	//
 	// If the returned error is not nil:
 	// - If the error is ErrNoSubConnAvailable, gRPC will block until UpdateBalancerState()

--- a/picker_wrapper.go
+++ b/picker_wrapper.go
@@ -166,12 +166,9 @@ func (bp *pickerWrapper) pick(ctx context.Context, failfast bool, opts balancer.
 			return t, done, nil
 		}
 		if done != nil {
-			done(balancer.DoneInfo{
-				Err:           nil,
-				Trailer:       nil,
-				BytesSent:     false,
-				BytesReceived: false,
-			})
+			// Calling done with nil error, no bytes sent and no bytes received.
+			// DoneInfo with default value works.
+			done(balancer.DoneInfo{})
 		}
 		grpclog.Infof("blockingPicker: the picked transport is not ready, loop back to repick")
 		// If ok == false, ac.state is not READY.

--- a/picker_wrapper.go
+++ b/picker_wrapper.go
@@ -165,6 +165,14 @@ func (bp *pickerWrapper) pick(ctx context.Context, failfast bool, opts balancer.
 			}
 			return t, done, nil
 		}
+		if done != nil {
+			done(balancer.DoneInfo{
+				Err:           nil,
+				Trailer:       nil,
+				BytesSent:     false,
+				BytesReceived: false,
+			})
+		}
 		grpclog.Infof("blockingPicker: the picked transport is not ready, loop back to repick")
 		// If ok == false, ac.state is not READY.
 		// A valid picker always returns READY subConn. This means the state of ac


### PR DESCRIPTION
Special case: when SubConn returned by Picker is not Ready, call done before
looping back to re-pick.