### PR TITLE
internal: fix pickoptions in balancer_test

### DIFF
--- a/test/balancer_test.go
+++ b/test/balancer_test.go
@@ -45,6 +45,7 @@ type testBalancer struct {
 	sc balancer.SubConn
 
 	newSubConnOptions balancer.NewSubConnOptions
+	pickOptions       []balancer.PickOptions
 	doneInfo          []balancer.DoneInfo
 }
 


### PR DESCRIPTION
The same test was changed by two PRs, merge didn't catch the conflict