### PR TITLE
encoding: check whether encoding.Name() is empty before calling strings.ToLower

### DIFF
--- a/encoding/encoding.go
+++ b/encoding/encoding.go
@@ -102,10 +102,10 @@ func RegisterCodec(codec Codec) {
 	if codec == nil {
 		panic("cannot register a nil Codec")
 	}
-	contentSubtype := strings.ToLower(codec.Name())
-	if contentSubtype == "" {
+	if codec.Name() == "" {
 		panic("cannot register Codec with empty string result for String()")
 	}
+	contentSubtype := strings.ToLower(codec.Name())
 	registeredCodecs[contentSubtype] = codec
 }
 

--- a/encoding/encoding.go
+++ b/encoding/encoding.go
@@ -103,7 +103,7 @@ func RegisterCodec(codec Codec) {
 		panic("cannot register a nil Codec")
 	}
 	if codec.Name() == "" {
-		panic("cannot register Codec with empty string result for String()")
+		panic("cannot register Codec with empty string result for Name()")
 	}
 	contentSubtype := strings.ToLower(codec.Name())
 	registeredCodecs[contentSubtype] = codec


### PR DESCRIPTION
Calling strings.ToLower with an empty value is a waste.