### PR TITLE
credentials: add compute engine channel creds

### DIFF
--- a/credentials/google/google.go
+++ b/credentials/google/google.go
@@ -69,7 +69,7 @@ func NewComputeEngineCredentials() credentials.Bundle {
 	}
 	bundle, err := c.NewWithMode(internal.CredsBundleModeFallback)
 	if err != nil {
-		grpclog.Warningf("google default creds: failed to create new creds: %v", err)
+		grpclog.Warningf("compute engine creds: failed to create new creds: %v", err)
 	}
 	return bundle
 }
@@ -114,7 +114,7 @@ func (c *creds) NewWithMode(mode string) (credentials.Bundle, error) {
 		// to create new ALTS client creds here.
 		newCreds.transportCreds = alts.NewClientCreds(alts.DefaultClientOptions())
 	default:
-		return nil, fmt.Errorf("google default creds: unsupported mode: %v", mode)
+		return nil, fmt.Errorf("unsupported mode: %v", mode)
 	}
 
 	if mode == internal.CredsBundleModeFallback || mode == internal.CredsBundleModeBackendFromBalancer {

--- a/credentials/google/google.go
+++ b/credentials/google/google.go
@@ -56,12 +56,12 @@ func NewDefaultCredentials() credentials.Bundle {
 	return bundle
 }
 
-// NewComputeEngineChannelCredentials returns a credentials bundle that is configured to work
+// NewComputeEngineCredentials returns a credentials bundle that is configured to work
 // with google services. This API must only be used when running on GCE. Authentication configured
 // by this API represents the GCE VM's default service account.
 //
 // This API is experimental.
-func NewComputeEngineChannelCredentials() credentials.Bundle {
+func NewComputeEngineCredentials() credentials.Bundle {
 	c := &creds{
 		newPerRPCCreds: func() credentials.PerRPCCredentials {
 			return oauth.NewComputeEngine()

--- a/credentials/google/google.go
+++ b/credentials/google/google.go
@@ -39,14 +39,14 @@ const tokenRequestTimeout = 30 * time.Second
 // This API is experimental.
 func NewDefaultCredentials() credentials.Bundle {
 	c := &creds{
-		newPerRpcCreds: func() credentials.PerRPCCredentials {
+		newPerRPCCreds: func() credentials.PerRPCCredentials {
 			ctx, cancel := context.WithTimeout(context.Background(), tokenRequestTimeout)
 			defer cancel()
-			perRpcCreds, err := oauth.NewApplicationDefault(ctx)
+			perRPCCreds, err := oauth.NewApplicationDefault(ctx)
 			if err != nil {
 				grpclog.Warningf("google default creds: failed to create application oauth: %v", err)
 			}
-			return perRpcCreds
+			return perRPCCreds
 		},
 	}
 	bundle, err := c.NewWithMode(internal.CredsBundleModeFallback)
@@ -63,7 +63,7 @@ func NewDefaultCredentials() credentials.Bundle {
 // This API is experimental.
 func NewComputeEngineChannelCredentials() credentials.Bundle {
 	c := &creds{
-		newPerRpcCreds: func() credentials.PerRPCCredentials {
+		newPerRPCCreds: func() credentials.PerRPCCredentials {
 			return oauth.NewComputeEngine()
 		},
 	}
@@ -83,7 +83,7 @@ type creds struct {
 	// The per RPC credentials associated with this bundle.
 	perRPCCreds credentials.PerRPCCredentials
 	// Creates new per RPC credentials
-	newPerRpcCreds func() credentials.PerRPCCredentials
+	newPerRPCCreds func() credentials.PerRPCCredentials
 }
 
 func (c *creds) TransportCredentials() credentials.TransportCredentials {
@@ -102,7 +102,7 @@ func (c *creds) PerRPCCredentials() credentials.PerRPCCredentials {
 func (c *creds) NewWithMode(mode string) (credentials.Bundle, error) {
 	newCreds := &creds{
 		mode:           mode,
-		newPerRpcCreds: c.newPerRpcCreds,
+		newPerRPCCreds: c.newPerRPCCreds,
 	}
 
 	// Create transport credentials.
@@ -118,7 +118,7 @@ func (c *creds) NewWithMode(mode string) (credentials.Bundle, error) {
 	}
 
 	if mode == internal.CredsBundleModeFallback || mode == internal.CredsBundleModeBackendFromBalancer {
-		newCreds.perRPCCreds = newCreds.newPerRpcCreds()
+		newCreds.perRPCCreds = newCreds.newPerRPCCreds()
 	}
 
 	return newCreds, nil

--- a/interop/client/client.go
+++ b/interop/client/client.go
@@ -91,20 +91,20 @@ const (
 
 func main() {
 	flag.Parse()
-	var useGDC bool                       // use google default creds
-	var useComputeEngineChannelCreds bool // use compute engine channel creds
+	var useGDC bool // use google default creds
+	var useCEC bool // use compute engine creds
 	if *customCredentialsType != "" {
 		switch *customCredentialsType {
 		case googleDefaultCredsName:
 			useGDC = true
 		case computeEngineChannelCredsName:
-			useComputeEngineChannelCreds = true
+			useCEC = true
 		default:
 			grpclog.Fatalf("If set, custom_credentials_type can only be set to one of %v or %v",
 				googleDefaultCredsName, computeEngineChannelCredsName)
 		}
 	}
-	if (*useTLS && *useALTS) || (*useTLS && useGDC) || (*useALTS && useGDC) || (*useTLS && useComputeEngineChannelCreds) || (*useALTS && useComputeEngineChannelCreds) {
+	if (*useTLS && *useALTS) || (*useTLS && useGDC) || (*useALTS && useGDC) || (*useTLS && useCEC) || (*useALTS && useCEC) {
 		grpclog.Fatalf("only one of TLS, ALTS, google default creds, or compute engine channel creds can be used")
 	}
 
@@ -116,7 +116,7 @@ func main() {
 		credsChosen = credsALTS
 	case useGDC:
 		credsChosen = credsGoogleDefaultCreds
-	case useComputeEngineChannelCreds:
+	case useCEC:
 		credsChosen = credsComputeEngineChannelCreds
 	}
 

--- a/interop/client/client.go
+++ b/interop/client/client.go
@@ -37,8 +37,8 @@ import (
 )
 
 const (
-	googleDefaultCredsName        = "google_default_credentials"
-	computeEngineChannelCredsName = "compute_engine_channel_creds"
+	googleDefaultCredsName = "google_default_credentials"
+	computeEngineCredsName = "compute_engine_channel_creds"
 )
 
 var (
@@ -69,7 +69,7 @@ var (
         per_rpc_creds: large_unary with per rpc token;
         oauth2_auth_token: large_unary with oauth2 token auth;
         google_default_credentials: large_unary with google default credentials
-        compute_engine_channel_credentials: large_unary with compute engine channel creds
+        compute_engine_channel_credentials: large_unary with compute engine creds
         cancel_after_begin: cancellation after metadata has been sent but before payloads are sent;
         cancel_after_first_response: cancellation after receiving 1st message from the server;
         status_code_and_message: status code propagated back to client;
@@ -86,7 +86,7 @@ const (
 	credsTLS
 	credsALTS
 	credsGoogleDefaultCreds
-	credsComputeEngineChannelCreds
+	credsComputeEngineCreds
 )
 
 func main() {
@@ -97,15 +97,15 @@ func main() {
 		switch *customCredentialsType {
 		case googleDefaultCredsName:
 			useGDC = true
-		case computeEngineChannelCredsName:
+		case computeEngineCredsName:
 			useCEC = true
 		default:
 			grpclog.Fatalf("If set, custom_credentials_type can only be set to one of %v or %v",
-				googleDefaultCredsName, computeEngineChannelCredsName)
+				googleDefaultCredsName, computeEngineCredsName)
 		}
 	}
 	if (*useTLS && *useALTS) || (*useTLS && useGDC) || (*useALTS && useGDC) || (*useTLS && useCEC) || (*useALTS && useCEC) {
-		grpclog.Fatalf("only one of TLS, ALTS, google default creds, or compute engine channel creds can be used")
+		grpclog.Fatalf("only one of TLS, ALTS, google default creds, or compute engine creds can be used")
 	}
 
 	var credsChosen credsMode
@@ -117,7 +117,7 @@ func main() {
 	case useGDC:
 		credsChosen = credsGoogleDefaultCreds
 	case useCEC:
-		credsChosen = credsComputeEngineChannelCreds
+		credsChosen = credsComputeEngineCreds
 	}
 
 	resolver.SetDefaultScheme("dns")
@@ -152,7 +152,7 @@ func main() {
 		opts = append(opts, grpc.WithTransportCredentials(altsTC))
 	case credsGoogleDefaultCreds:
 		opts = append(opts, grpc.WithCredentialsBundle(google.NewDefaultCredentials()))
-	case credsComputeEngineChannelCreds:
+	case credsComputeEngineCreds:
 		opts = append(opts, grpc.WithCredentialsBundle(google.NewComputeEngineCredentials()))
 	case credsNone:
 		opts = append(opts, grpc.WithInsecure())
@@ -244,8 +244,8 @@ func main() {
 		interop.DoGoogleDefaultCredentials(tc, *defaultServiceAccount)
 		grpclog.Infoln("GoogleDefaultCredentials done")
 	case "compute_engine_channel_credentials":
-		if credsChosen != credsComputeEngineChannelCreds {
-			grpclog.Fatalf("ComputeEngineChannelCreds need to be set for compute_engine_channel_credentials test case.")
+		if credsChosen != credsComputeEngineCreds {
+			grpclog.Fatalf("ComputeEngineCreds need to be set for compute_engine_channel_credentials test case.")
 		}
 		interop.DoComputeEngineChannelCredentials(tc, *defaultServiceAccount)
 		grpclog.Infoln("ComputeEngineChannelCredentials done")

--- a/interop/client/client.go
+++ b/interop/client/client.go
@@ -153,7 +153,7 @@ func main() {
 	case credsGoogleDefaultCreds:
 		opts = append(opts, grpc.WithCredentialsBundle(google.NewDefaultCredentials()))
 	case credsComputeEngineChannelCreds:
-		opts = append(opts, grpc.WithCredentialsBundle(google.NewComputeEngineChannelCredentials()))
+		opts = append(opts, grpc.WithCredentialsBundle(google.NewComputeEngineCredentials()))
 	case credsNone:
 		opts = append(opts, grpc.WithInsecure())
 	default:

--- a/interop/test_utils.go
+++ b/interop/test_utils.go
@@ -393,8 +393,27 @@ func DoPerRPCCreds(tc testpb.TestServiceClient, serviceAccountKeyFile, oauthScop
 	}
 }
 
-// DoGoogleDefaultCredentials performs a unary RPC with google default credentials
+// DoGoogleDefaultCredentials performs an unary RPC with google default credentials
 func DoGoogleDefaultCredentials(tc testpb.TestServiceClient, defaultServiceAccount string) {
+	pl := ClientNewPayload(testpb.PayloadType_COMPRESSABLE, largeReqSize)
+	req := &testpb.SimpleRequest{
+		ResponseType:   testpb.PayloadType_COMPRESSABLE,
+		ResponseSize:   int32(largeRespSize),
+		Payload:        pl,
+		FillUsername:   true,
+		FillOauthScope: true,
+	}
+	reply, err := tc.UnaryCall(context.Background(), req)
+	if err != nil {
+		grpclog.Fatal("/TestService/UnaryCall RPC failed: ", err)
+	}
+	if reply.GetUsername() != defaultServiceAccount {
+		grpclog.Fatalf("Got user name %q; wanted %q. ", reply.GetUsername(), defaultServiceAccount)
+	}
+}
+
+// DoComputeEngineChannelCredentials performs an unary RPC with compute engine channel credentials
+func DoComputeEngineChannelCredentials(tc testpb.TestServiceClient, defaultServiceAccount string) {
 	pl := ClientNewPayload(testpb.PayloadType_COMPRESSABLE, largeReqSize)
 	req := &testpb.SimpleRequest{
 		ResponseType:   testpb.PayloadType_COMPRESSABLE,


### PR DESCRIPTION
This is the Go analogue of https://github.com/grpc/grpc-java/pull/5475.

Manually tested that the interop test works in all environments.