### PR TITLE
server: Improve error message when an unknown method is invoked.

### DIFF
--- a/server.go
+++ b/server.go
@@ -1246,7 +1246,8 @@ func (s *Server) handleStream(t transport.ServerTransport, stream *transport.Str
 	service := sm[:pos]
 	method := sm[pos+1:]
 
-	if srv, ok := s.m[service]; ok {
+	srv, knownService := s.m[service]
+	if knownService {
 		if md, ok := srv.md[method]; ok {
 			s.processUnaryRPC(t, stream, srv, md, trInfo)
 			return
@@ -1261,11 +1262,16 @@ func (s *Server) handleStream(t transport.ServerTransport, stream *transport.Str
 		s.processStreamingRPC(t, stream, nil, unknownDesc, trInfo)
 		return
 	}
+	var errDesc string
+	if !knownService {
+		errDesc = fmt.Sprintf("unknown service %v", service)
+	} else {
+		errDesc = fmt.Sprintf("unknown method %v for service %v", method, service)
+	}
 	if trInfo != nil {
-		trInfo.tr.LazyLog(&fmtStringer{"Unknown service %v", []interface{}{service}}, true)
+		trInfo.tr.LazyPrintf("%s", errDesc)
 		trInfo.tr.SetError()
 	}
-	errDesc := fmt.Sprintf("unknown service %v", service)
 	if err := t.WriteStatus(stream, status.New(codes.Unimplemented, errDesc)); err != nil {
 		if trInfo != nil {
 			trInfo.tr.LazyLog(&fmtStringer{"%v", []interface{}{err}}, true)


### PR DESCRIPTION
Previously only `unknown service <x>` was returned, which is misleading
when the service is known but the method is unknown.