### PR TITLE
syscall: remove logging in init().

### DIFF
--- a/internal/syscall/syscall_nonlinux.go
+++ b/internal/syscall/syscall_nonlinux.go
@@ -22,18 +22,24 @@ package syscall
 
 import (
 	"net"
+	"sync"
 	"time"
 
 	"google.golang.org/grpc/grpclog"
 )
 
-func init() {
-	grpclog.Info("CPU time info is unavailable on non-linux or appengine environment.")
+var once sync.Once
+
+func log() {
+	once.Do(func() {
+		grpclog.Info("CPU time info is unavailable on non-linux or appengine environment.")
+	})
 }
 
 // GetCPUTime returns the how much CPU time has passed since the start of this process.
 // It always returns 0 under non-linux or appengine environment.
 func GetCPUTime() int64 {
+	log()
 	return 0
 }
 
@@ -42,22 +48,26 @@ type Rusage struct{}
 
 // GetRusage is a no-op function under non-linux or appengine environment.
 func GetRusage() (rusage *Rusage) {
+	log()
 	return nil
 }
 
 // CPUTimeDiff returns the differences of user CPU time and system CPU time used
 // between two Rusage structs. It a no-op function for non-linux or appengine environment.
 func CPUTimeDiff(first *Rusage, latest *Rusage) (float64, float64) {
+	log()
 	return 0, 0
 }
 
 // SetTCPUserTimeout is a no-op function under non-linux or appengine environments
 func SetTCPUserTimeout(conn net.Conn, timeout time.Duration) error {
+	log()
 	return nil
 }
 
 // GetTCPUserTimeout is a no-op function under non-linux or appengine environments
 // a negative return value indicates the operation is not supported
 func GetTCPUserTimeout(conn net.Conn) (int, error) {
+	log()
 	return -1, nil
 }


### PR DESCRIPTION
The same as https://github.com/grpc/grpc-go/pull/2373.

@dfawley Could you help review this? Thank you.

Signed-off-by: Yangmin Zhu <ymzhu@google.com>