### PR TITLE
internal: balancer/xds go1.12 only

### DIFF
--- a/balancer/balancer.go
+++ b/balancer/balancer.go
@@ -1,3 +1,5 @@
+// +build go1.11
+
 /*
  *
  * Copyright 2017 gRPC authors.

--- a/balancer/balancer.go
+++ b/balancer/balancer.go
@@ -1,5 +1,3 @@
-// +build go1.11
-
 /*
  *
  * Copyright 2017 gRPC authors.

--- a/balancer/xds/edsbalancer/balancergroup.go
+++ b/balancer/xds/edsbalancer/balancergroup.go
@@ -1,3 +1,5 @@
+// +build go1.12
+
 /*
  * Copyright 2019 gRPC authors.
  *

--- a/balancer/xds/edsbalancer/balancergroup_test.go
+++ b/balancer/xds/edsbalancer/balancergroup_test.go
@@ -1,3 +1,5 @@
+// +build go1.12
+
 /*
  * Copyright 2019 gRPC authors.
  *

--- a/balancer/xds/edsbalancer/edsbalancer.go
+++ b/balancer/xds/edsbalancer/edsbalancer.go
@@ -1,3 +1,5 @@
+// +build go1.12
+
 /*
  * Copyright 2019 gRPC authors.
  *

--- a/balancer/xds/edsbalancer/edsbalancer_test.go
+++ b/balancer/xds/edsbalancer/edsbalancer_test.go
@@ -1,3 +1,5 @@
+// +build go1.12
+
 /*
  * Copyright 2019 gRPC authors.
  *

--- a/balancer/xds/edsbalancer/test_util_test.go
+++ b/balancer/xds/edsbalancer/test_util_test.go
@@ -1,3 +1,5 @@
+// +build go1.12
+
 /*
  * Copyright 2019 gRPC authors.
  *

--- a/balancer/xds/edsbalancer/util.go
+++ b/balancer/xds/edsbalancer/util.go
@@ -1,3 +1,5 @@
+// +build go1.12
+
 /*
  * Copyright 2019 gRPC authors.
  *

--- a/balancer/xds/edsbalancer/util_test.go
+++ b/balancer/xds/edsbalancer/util_test.go
@@ -1,3 +1,5 @@
+// +build go1.12
+
 /*
  * Copyright 2019 gRPC authors.
  *

--- a/balancer/xds/xds.go
+++ b/balancer/xds/xds.go
@@ -1,3 +1,5 @@
+// +build go1.12
+
 /*
  *
  * Copyright 2019 gRPC authors.

--- a/balancer/xds/xds_client.go
+++ b/balancer/xds/xds_client.go
@@ -1,3 +1,5 @@
+// +build go1.12
+
 /*
  *
  * Copyright 2019 gRPC authors.

--- a/balancer/xds/xds_client_test.go
+++ b/balancer/xds/xds_client_test.go
@@ -1,3 +1,5 @@
+// +build go1.12
+
 /*
  *
  * Copyright 2019 gRPC authors.

--- a/balancer/xds/xds_test.go
+++ b/balancer/xds/xds_test.go
@@ -1,3 +1,5 @@
+// +build go1.12
+
 /*
  *
  * Copyright 2019 gRPC authors.


### PR DESCRIPTION
Until https://github.com/envoyproxy/go-control-plane/issues/168 is fixed