### PR TITLE
fixing broken link in rpc-error doc

### DIFF
--- a/Documentation/rpc-errors.md
+++ b/Documentation/rpc-errors.md
@@ -65,4 +65,4 @@ exit status 1
 [details]:      https://godoc.org/google.golang.org/grpc/status#Status.Details
 [status-err]:   https://godoc.org/google.golang.org/grpc/status#Status.Err
 [status-error]: https://godoc.org/google.golang.org/grpc/status#Error
-[example]:      https://github.com/grpc/grpc-go/blob/master/examples/rpc_errors
+[example]:      https://github.com/grpc/grpc-go/tree/master/examples/features/errors


### PR DESCRIPTION
The link for example in the documentation for RPC errors redirects to the wrong URL.
This PR fixes that
Fixes #2752 