### PR TITLE
Use 'go vet' and not 'go tool vet'.

### DIFF
--- a/vet.sh
+++ b/vet.sh
@@ -88,7 +88,7 @@ go list -f {{.Dir}} ./... | xargs go run test/go_vet/vet.go
 gofmt -s -d -l . 2>&1 | fail_on_output
 goimports -l . 2>&1 | fail_on_output
 golint ./... 2>&1 | (! grep -vE "(_mock|\.pb)\.go:")
-go tool vet -all .
+go vet -all .
 
 # - Check that generated proto files are up to date.
 if [[ -z "${VET_SKIP_PROTO}" ]]; then


### PR DESCRIPTION
From [release notes](https://golang.org/doc/go1.12#vet):

The go vet command has been rewritten to serve as the
base for a range of different source code analysis tools. See
the golang.org/x/tools/go/analysis
package for details. A side-effect is that go tool vet
is no longer supported. External tools that use go tool vet must be
changed to use go vet. Using go vet instead of go tool vet should work
with all supported versions of Go.