### PR TITLE
internal: tweak ClientTransport.GracefulClose documentation

### DIFF
--- a/internal/transport/transport.go
+++ b/internal/transport/transport.go
@@ -579,7 +579,10 @@ type ClientTransport interface {
 	Close() error
 
 	// GracefulClose starts to tear down the transport. It stops accepting
-	// new RPCs and wait the completion of the pending RPCs.
+	// new RPCs by causing NewStream to return error. Once all streams are
+	// finished, the transport will close.
+	//
+	// It does not block.
 	GracefulClose() error
 
 	// Write sends the data for the given stream. A nil stream indicates

--- a/internal/transport/transport.go
+++ b/internal/transport/transport.go
@@ -578,8 +578,8 @@ type ClientTransport interface {
 	// is called only once.
 	Close() error
 
-	// GracefulClose starts to tear down the transport. It stops accepting
-	// new RPCs by causing NewStream to return error. Once all streams are
+	// GracefulClose starts to tear down the transport: the transport will stop
+	// accepting new RPCs and NewStream will return error. Once all streams are
 	// finished, the transport will close.
 	//
 	// It does not block.


### PR DESCRIPTION
Clarifies that the method GracefulStop does not block, but instead will cause the transport to close after all RPCs are finished. (AFAICT)