### PR TITLE
Keepalive pings should be sent every [Time+Timeout] period and not every [Time] period

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -8,20 +8,20 @@ See [CONTRIBUTING.md](https://github.com/grpc/grpc-community/blob/master/CONTRIB
 for general contribution guidelines.
 
 ## Maintainers (in alphabetical order)
-- [canguler](https://github.com/canguler), Google Inc.
-- [cesarghali](https://github.com/cesarghali), Google Inc.
-- [dfawley](https://github.com/dfawley), Google Inc.
-- [easwars](https://github.com/easwars), Google Inc.
-- [jadekler](https://github.com/jadekler), Google Inc.
-- [menghanl](https://github.com/menghanl), Google Inc.
-- [srini100](https://github.com/srini100), Google Inc.
+- [canguler](https://github.com/canguler), Google LLC
+- [cesarghali](https://github.com/cesarghali), Google LLC
+- [dfawley](https://github.com/dfawley), Google LLC
+- [easwars](https://github.com/easwars), Google LLC
+- [jadekler](https://github.com/jadekler), Google LLC
+- [menghanl](https://github.com/menghanl), Google LLC
+- [srini100](https://github.com/srini100), Google LLC
 
 ## Emeritus Maintainers (in alphabetical order)
-- [adelez](https://github.com/adelez), Google Inc.
-- [iamqizhao](https://github.com/iamqizhao), Google Inc.
-- [jtattermusch](https://github.com/jtattermusch), Google Inc.
-- [lyuxuan](https://github.com/lyuxuan), Google Inc.
-- [makmukhi](https://github.com/makmukhi), Google Inc.
-- [matt-kwong](https://github.com/matt-kwong), Google Inc.
-- [nicolasnoble](https://github.com/nicolasnoble), Google Inc.
-- [yongni](https://github.com/yongni), Google Inc.
+- [adelez](https://github.com/adelez), Google LLC
+- [iamqizhao](https://github.com/iamqizhao), Google LLC
+- [jtattermusch](https://github.com/jtattermusch), Google LLC
+- [lyuxuan](https://github.com/lyuxuan), Google LLC
+- [makmukhi](https://github.com/makmukhi), Google LLC
+- [matt-kwong](https://github.com/matt-kwong), Google LLC
+- [nicolasnoble](https://github.com/nicolasnoble), Google LLC
+- [yongni](https://github.com/yongni), Google LLC

--- a/benchmark/benchresult/main.go
+++ b/benchmark/benchresult/main.go
@@ -76,8 +76,8 @@ func compareTwoMap(m1, m2 map[string]stats.BenchResults) {
 			changes += intChange("TotalOps", v1.Data.TotalOps, v2.Data.TotalOps)
 			changes += intChange("SendOps", v1.Data.SendOps, v2.Data.SendOps)
 			changes += intChange("RecvOps", v1.Data.RecvOps, v2.Data.RecvOps)
-			changes += intChange("Bytes/op", v1.Data.AllocedBytes, v2.Data.AllocedBytes)
-			changes += intChange("Allocs/op", v1.Data.Allocs, v2.Data.Allocs)
+			changes += floatChange("Bytes/op", v1.Data.AllocedBytes, v2.Data.AllocedBytes)
+			changes += floatChange("Allocs/op", v1.Data.Allocs, v2.Data.Allocs)
 			changes += floatChange("ReqT/op", v1.Data.ReqT, v2.Data.ReqT)
 			changes += floatChange("RespT/op", v1.Data.RespT, v2.Data.RespT)
 			changes += timeChange("50th-Lat", v1.Data.Fiftieth, v2.Data.Fiftieth)
@@ -93,9 +93,16 @@ func compareBenchmark(file1, file2 string) {
 	compareTwoMap(createMap(file1), createMap(file2))
 }
 
-func printline(benchName, total, send, recv, allocB, allocN, reqT, respT, ltc50, ltc90, l99, lAvg interface{}) {
-	fmt.Printf("%-80v%12v%12v%12v%12v%12v%18v%18v%12v%12v%12v%12v\n",
-		benchName, total, send, recv, allocB, allocN, reqT, respT, ltc50, ltc90, l99, lAvg)
+func printHeader() {
+	fmt.Printf("%-80s%12s%12s%12s%18s%18s%18s%18s%12s%12s%12s%12s\n",
+		"Name", "TotalOps", "SendOps", "RecvOps", "Bytes/op (B)", "Allocs/op (#)",
+		"RequestT", "ResponseT", "L-50", "L-90", "L-99", "L-Avg")
+}
+
+func printline(benchName string, d stats.RunData) {
+	fmt.Printf("%-80s%12d%12d%12d%18.2f%18.2f%18.2f%18.2f%12v%12v%12v%12v\n",
+		benchName, d.TotalOps, d.SendOps, d.RecvOps, d.AllocedBytes, d.Allocs,
+		d.ReqT, d.RespT, d.Fiftieth, d.Ninetieth, d.NinetyNinth, d.Average)
 }
 
 func formatBenchmark(fileName string) {
@@ -122,12 +129,9 @@ func formatBenchmark(fileName string) {
 		wantFeatures[i] = !wantFeatures[i]
 	}
 
-	printline("Name", "TotalOps", "SendOps", "RecvOps", "Alloc (B)", "Alloc (#)",
-		"RequestT", "ResponseT", "L-50", "L-90", "L-99", "L-Avg")
+	printHeader()
 	for _, r := range results {
-		d := r.Data
-		printline(r.RunMode+r.Features.PrintableName(wantFeatures), d.TotalOps, d.SendOps, d.RecvOps,
-			d.AllocedBytes, d.Allocs, d.ReqT, d.RespT, d.Fiftieth, d.Ninetieth, d.NinetyNinth, d.Average)
+		printline(r.RunMode+r.Features.PrintableName(wantFeatures), r.Data)
 	}
 }
 

--- a/benchmark/stats/stats.go
+++ b/benchmark/stats/stats.go
@@ -200,9 +200,9 @@ type RunData struct {
 	// run. Only makes sense for unconstrained workloads.
 	RecvOps uint64
 	// AllocedBytes is the average memory allocation in bytes per operation.
-	AllocedBytes uint64
+	AllocedBytes float64
 	// Allocs is the average number of memory allocations per operation.
-	Allocs uint64
+	Allocs float64
 	// ReqT is the average request throughput associated with this run.
 	ReqT float64
 	// RespT is the average response throughput associated with this run.
@@ -275,8 +275,8 @@ func (s *Stats) EndRun(count uint64) {
 	r := &s.results[len(s.results)-1]
 	r.Data = RunData{
 		TotalOps:     count,
-		AllocedBytes: s.stopMS.TotalAlloc - s.startMS.TotalAlloc,
-		Allocs:       s.stopMS.Mallocs - s.startMS.Mallocs,
+		AllocedBytes: float64(s.stopMS.TotalAlloc-s.startMS.TotalAlloc) / float64(count),
+		Allocs:       float64(s.stopMS.Mallocs-s.startMS.Mallocs) / float64(count),
 		ReqT:         float64(count) * float64(r.Features.ReqSizeBytes) * 8 / r.Features.BenchTime.Seconds(),
 		RespT:        float64(count) * float64(r.Features.RespSizeBytes) * 8 / r.Features.BenchTime.Seconds(),
 	}
@@ -296,8 +296,8 @@ func (s *Stats) EndUnconstrainedRun(req uint64, resp uint64) {
 	r.Data = RunData{
 		SendOps:      req,
 		RecvOps:      resp,
-		AllocedBytes: (s.stopMS.TotalAlloc - s.startMS.TotalAlloc) / ((req + resp) / 2),
-		Allocs:       (s.stopMS.Mallocs - s.startMS.Mallocs) / ((req + resp) / 2),
+		AllocedBytes: float64(s.stopMS.TotalAlloc-s.startMS.TotalAlloc) / float64((req+resp)/2),
+		Allocs:       float64(s.stopMS.Mallocs-s.startMS.Mallocs) / float64((req+resp)/2),
 		ReqT:         float64(req) * float64(r.Features.ReqSizeBytes) * 8 / r.Features.BenchTime.Seconds(),
 		RespT:        float64(resp) * float64(r.Features.RespSizeBytes) * 8 / r.Features.BenchTime.Seconds(),
 	}

--- a/credentials/alts/utils.go
+++ b/credentials/alts/utils.go
@@ -83,6 +83,9 @@ var (
 // running on GCP.
 func isRunningOnGCP() bool {
 	manufacturer, err := readManufacturer()
+	if os.IsNotExist(err) {
+		return false
+	}
 	if err != nil {
 		log.Fatalf("failure to read manufacturer information: %v", err)
 	}

--- a/credentials/alts/utils_test.go
+++ b/credentials/alts/utils_test.go
@@ -21,12 +21,41 @@ package alts
 import (
 	"context"
 	"io"
+	"os"
 	"strings"
 	"testing"
 
 	altspb "google.golang.org/grpc/credentials/alts/internal/proto/grpc_gcp"
 	"google.golang.org/grpc/peer"
 )
+
+func setupManufacturerReader(testOS string, reader func() (io.Reader, error)) func() {
+	tmpOS := runningOS
+	tmpReader := manufacturerReader
+
+	// Set test OS and reader function.
+	runningOS = testOS
+	manufacturerReader = reader
+	return func() {
+		runningOS = tmpOS
+		manufacturerReader = tmpReader
+	}
+
+}
+
+func setup(testOS string, testReader io.Reader) func() {
+	reader := func() (io.Reader, error) {
+		return testReader, nil
+	}
+	return setupManufacturerReader(testOS, reader)
+}
+
+func setupError(testOS string, err error) func() {
+	reader := func() (io.Reader, error) {
+		return nil, err
+	}
+	return setupManufacturerReader(testOS, reader)
+}
 
 func TestIsRunningOnGCP(t *testing.T) {
 	for _, tc := range []struct {
@@ -53,20 +82,12 @@ func TestIsRunningOnGCP(t *testing.T) {
 	}
 }
 
-func setup(testOS string, testReader io.Reader) func() {
-	tmpOS := runningOS
-	tmpReader := manufacturerReader
-
-	// Set test OS and reader function.
-	runningOS = testOS
-	manufacturerReader = func() (io.Reader, error) {
-		return testReader, nil
+func TestIsRunningOnGCPNoProductNameFile(t *testing.T) {
+	reverseFunc := setupError("linux", os.ErrNotExist)
+	if isRunningOnGCP() {
+		t.Errorf("ErrNotExist: isRunningOnGCP()=true, want false")
 	}
-
-	return func() {
-		runningOS = tmpOS
-		manufacturerReader = tmpReader
-	}
+	reverseFunc()
 }
 
 func TestAuthInfoFromContext(t *testing.T) {

--- a/examples/helloworld/greeter_client/main.go
+++ b/examples/helloworld/greeter_client/main.go
@@ -54,5 +54,5 @@ func main() {
 	if err != nil {
 		log.Fatalf("could not greet: %v", err)
 	}
-	log.Printf("Greeting: %s", r.Message)
+	log.Printf("Greeting: %s", r.GetMessage())
 }

--- a/examples/helloworld/greeter_server/main.go
+++ b/examples/helloworld/greeter_server/main.go
@@ -39,8 +39,8 @@ type server struct{}
 
 // SayHello implements helloworld.GreeterServer
 func (s *server) SayHello(ctx context.Context, in *pb.HelloRequest) (*pb.HelloReply, error) {
-	log.Printf("Received: %v", in.Name)
-	return &pb.HelloReply{Message: "Hello " + in.Name}, nil
+	log.Printf("Received: %v", in.GetName())
+	return &pb.HelloReply{Message: "Hello " + in.GetName()}, nil
 }
 
 func main() {

--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -267,7 +267,6 @@ func newHTTP2Client(connectCtx, ctx context.Context, addr TargetInfo, opts Conne
 		onClose:               onClose,
 		keepaliveEnabled:      keepaliveEnabled,
 		bufferPool:            newBufferPool(),
-		activityCh:            make(chan struct{}, 1),
 		lr:                    lastRead{ch: make(chan struct{}, 1)},
 	}
 	t.controlBuf = newControlBuffer(t.ctxDone)

--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -1392,10 +1392,10 @@ func (t *http2Client) keepalive() {
 			// timeoutLeft. This will ensure that we wait only for kp.Time
 			// before sending out the next ping (for cases where the ping is
 			// acked).
-			sleepDuration = minTime(kp.Time, timeoutLeft)
+			sleepDuration := minTime(t.kp.Time, timeoutLeft)
 			timeoutLeft -= sleepDuration
 			prevNano = time.Now().UTC().UnixNano()
-			timer.Reset(timeoutLeft)
+			timer.Reset(sleepDuration)
 		case <-t.ctx.Done():
 			if !timer.Stop() {
 				<-timer.C

--- a/internal/transport/transport_test.go
+++ b/internal/transport/transport_test.go
@@ -462,6 +462,8 @@ func setUpWithNoPingServer(t *testing.T, copts ConnectOptions, done chan net.Con
 // TestInflightStreamClosing ensures that closing in-flight stream
 // sends status error to concurrent stream reader.
 func TestInflightStreamClosing(t *testing.T) {
+	t.Parallel()
+
 	serverConfig := &ServerConfig{}
 	server, client, cancel := setUpWithOptions(t, 0, serverConfig, suspended, ConnectOptions{})
 	defer cancel()
@@ -501,6 +503,8 @@ func TestInflightStreamClosing(t *testing.T) {
 // An idle client is one who doesn't make any RPC calls for a duration of
 // MaxConnectionIdle time.
 func TestMaxConnectionIdle(t *testing.T) {
+	t.Parallel()
+
 	serverConfig := &ServerConfig{
 		KeepaliveParams: keepalive.ServerParameters{
 			MaxConnectionIdle: 2 * time.Second,
@@ -529,6 +533,8 @@ func TestMaxConnectionIdle(t *testing.T) {
 
 // TestMaxConenctionIdleNegative tests that a server will not send GoAway to a non-idle(busy) client.
 func TestMaxConnectionIdleNegative(t *testing.T) {
+	t.Parallel()
+
 	serverConfig := &ServerConfig{
 		KeepaliveParams: keepalive.ServerParameters{
 			MaxConnectionIdle: 2 * time.Second,
@@ -556,6 +562,8 @@ func TestMaxConnectionIdleNegative(t *testing.T) {
 
 // TestMaxConnectionAge tests that a server will send GoAway after a duration of MaxConnectionAge.
 func TestMaxConnectionAge(t *testing.T) {
+	t.Parallel()
+
 	serverConfig := &ServerConfig{
 		KeepaliveParams: keepalive.ServerParameters{
 			MaxConnectionAge: 2 * time.Second,
@@ -588,6 +596,8 @@ const (
 
 // TestKeepaliveServer tests that a server closes connection with a client that doesn't respond to keepalive pings.
 func TestKeepaliveServer(t *testing.T) {
+	t.Parallel()
+
 	serverConfig := &ServerConfig{
 		KeepaliveParams: keepalive.ServerParameters{
 			Time:    2 * time.Second,
@@ -632,6 +642,8 @@ func TestKeepaliveServer(t *testing.T) {
 
 // TestKeepaliveServerNegative tests that a server doesn't close connection with a client that responds to keepalive pings.
 func TestKeepaliveServerNegative(t *testing.T) {
+	t.Parallel()
+
 	serverConfig := &ServerConfig{
 		KeepaliveParams: keepalive.ServerParameters{
 			Time:    2 * time.Second,
@@ -653,6 +665,8 @@ func TestKeepaliveServerNegative(t *testing.T) {
 }
 
 func TestKeepaliveClientClosesIdleTransport(t *testing.T) {
+	t.Parallel()
+
 	done := make(chan net.Conn, 1)
 	tr, cancel := setUpWithNoPingServer(t, ConnectOptions{KeepaliveParams: keepalive.ClientParameters{
 		Time:                2 * time.Second, // Keepalive time = 2 sec.
@@ -677,6 +691,8 @@ func TestKeepaliveClientClosesIdleTransport(t *testing.T) {
 }
 
 func TestKeepaliveClientStaysHealthyOnIdleTransport(t *testing.T) {
+	t.Parallel()
+
 	done := make(chan net.Conn, 1)
 	tr, cancel := setUpWithNoPingServer(t, ConnectOptions{KeepaliveParams: keepalive.ClientParameters{
 		Time:    2 * time.Second, // Keepalive time = 2 sec.
@@ -700,6 +716,8 @@ func TestKeepaliveClientStaysHealthyOnIdleTransport(t *testing.T) {
 }
 
 func TestKeepaliveClientClosesWithActiveStreams(t *testing.T) {
+	t.Parallel()
+
 	done := make(chan net.Conn, 1)
 	tr, cancel := setUpWithNoPingServer(t, ConnectOptions{KeepaliveParams: keepalive.ClientParameters{
 		Time:    2 * time.Second, // Keepalive time = 2 sec.
@@ -728,6 +746,8 @@ func TestKeepaliveClientClosesWithActiveStreams(t *testing.T) {
 }
 
 func TestKeepaliveClientStaysHealthyWithResponsiveServer(t *testing.T) {
+	t.Parallel()
+
 	s, tr, cancel := setUpWithOptions(t, 0, &ServerConfig{MaxStreams: math.MaxUint32}, normal, ConnectOptions{KeepaliveParams: keepalive.ClientParameters{
 		Time:                2 * time.Second, // Keepalive time = 2 sec.
 		Timeout:             1 * time.Second, // Keepalive timeout = 1 sec.
@@ -747,16 +767,18 @@ func TestKeepaliveClientStaysHealthyWithResponsiveServer(t *testing.T) {
 }
 
 func TestKeepaliveServerEnforcementWithAbusiveClientNoRPC(t *testing.T) {
+	t.Parallel()
+
 	serverConfig := &ServerConfig{
 		KeepalivePolicy: keepalive.EnforcementPolicy{
-			MinTime: 2 * time.Second,
+			MinTime: 5 * time.Second,
 		},
 	}
 	clientOptions := ConnectOptions{
 		KeepaliveParams: keepalive.ClientParameters{
-			Time:                50 * time.Millisecond,
-			Timeout:             1 * time.Second,
-			PermitWithoutStream: true,
+			Time:                2 * time.Second, // Keepalive time = 2 sec.
+			Timeout:             1 * time.Second, // Keepalive timeout = 1 sec.
+			PermitWithoutStream: true,            // Run keepalive even with no RPCs.
 		},
 	}
 	server, client, cancel := setUpWithOptions(t, 0, serverConfig, normal, clientOptions)
@@ -782,15 +804,17 @@ func TestKeepaliveServerEnforcementWithAbusiveClientNoRPC(t *testing.T) {
 }
 
 func TestKeepaliveServerEnforcementWithAbusiveClientWithRPC(t *testing.T) {
+	t.Parallel()
+
 	serverConfig := &ServerConfig{
 		KeepalivePolicy: keepalive.EnforcementPolicy{
-			MinTime: 2 * time.Second,
+			MinTime: 5 * time.Second,
 		},
 	}
 	clientOptions := ConnectOptions{
 		KeepaliveParams: keepalive.ClientParameters{
-			Time:    50 * time.Millisecond,
-			Timeout: 1 * time.Second,
+			Time:    2 * time.Second, // Keepalive time = 2 sec.
+			Timeout: 1 * time.Second, // Keepalive timeout = 1 sec.
 		},
 	}
 	server, client, cancel := setUpWithOptions(t, 0, serverConfig, suspended, clientOptions)
@@ -819,16 +843,18 @@ func TestKeepaliveServerEnforcementWithAbusiveClientWithRPC(t *testing.T) {
 }
 
 func TestKeepaliveServerEnforcementWithObeyingClientNoRPC(t *testing.T) {
+	t.Parallel()
+
 	serverConfig := &ServerConfig{
 		KeepalivePolicy: keepalive.EnforcementPolicy{
-			MinTime:             100 * time.Millisecond,
+			MinTime:             1 * time.Second,
 			PermitWithoutStream: true,
 		},
 	}
 	clientOptions := ConnectOptions{
 		KeepaliveParams: keepalive.ClientParameters{
-			Time:                101 * time.Millisecond,
-			Timeout:             1 * time.Second,
+			Time:                2 * time.Second,
+			Timeout:             5 * time.Second,
 			PermitWithoutStream: true,
 		},
 	}
@@ -838,7 +864,7 @@ func TestKeepaliveServerEnforcementWithObeyingClientNoRPC(t *testing.T) {
 	defer client.Close()
 
 	// Give keepalive enough time.
-	time.Sleep(3 * time.Second)
+	time.Sleep(10 * time.Second)
 	// Assert that connection is healthy.
 	client.mu.Lock()
 	defer client.mu.Unlock()
@@ -848,15 +874,17 @@ func TestKeepaliveServerEnforcementWithObeyingClientNoRPC(t *testing.T) {
 }
 
 func TestKeepaliveServerEnforcementWithObeyingClientWithRPC(t *testing.T) {
+	t.Parallel()
+
 	serverConfig := &ServerConfig{
 		KeepalivePolicy: keepalive.EnforcementPolicy{
-			MinTime: 100 * time.Millisecond,
+			MinTime: 1 * time.Second,
 		},
 	}
 	clientOptions := ConnectOptions{
 		KeepaliveParams: keepalive.ClientParameters{
-			Time:    101 * time.Millisecond,
-			Timeout: 1 * time.Second,
+			Time:    2 * time.Second,
+			Timeout: 5 * time.Second,
 		},
 	}
 	server, client, cancel := setUpWithOptions(t, 0, serverConfig, suspended, clientOptions)
@@ -869,7 +897,7 @@ func TestKeepaliveServerEnforcementWithObeyingClientWithRPC(t *testing.T) {
 	}
 
 	// Give keepalive enough time.
-	time.Sleep(3 * time.Second)
+	time.Sleep(10 * time.Second)
 	// Assert that connection is healthy.
 	client.mu.Lock()
 	defer client.mu.Unlock()
@@ -951,18 +979,35 @@ func performOneRPC(ct ClientTransport) {
 func TestClientMix(t *testing.T) {
 	s, ct, cancel := setUp(t, 0, math.MaxUint32, normal)
 	defer cancel()
+	done := make(chan struct{})
+
 	go func(s *server) {
-		time.Sleep(5 * time.Second)
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+		}
 		s.stop()
 	}(s)
+
 	go func(ct ClientTransport) {
-		<-ct.Error()
+		select {
+		case <-done:
+		case <-ct.Error():
+		}
 		ct.Close()
 	}(ct)
+
+	var wg sync.WaitGroup
 	for i := 0; i < 1000; i++ {
 		time.Sleep(10 * time.Millisecond)
-		go performOneRPC(ct)
+		wg.Add(1)
+		go func() {
+			performOneRPC(ct)
+			wg.Done()
+		}()
 	}
+	wg.Wait()
+	close(done)
 }
 
 func TestLargeMessage(t *testing.T) {

--- a/vet.sh
+++ b/vet.sh
@@ -111,6 +111,7 @@ google.golang.org/grpc/balancer.go:SA1019
 google.golang.org/grpc/balancer/grpclb/grpclb_remote_balancer.go:SA1019
 google.golang.org/grpc/balancer/roundrobin/roundrobin_test.go:SA1019
 google.golang.org/grpc/xds/internal/balancer/edsbalancer/balancergroup.go:SA1019
+google.golang.org/grpc/xds/internal/resolver/xds_resolver.go:SA1019
 google.golang.org/grpc/xds/internal/balancer/xds.go:SA1019
 google.golang.org/grpc/xds/internal/balancer/xds_client.go:SA1019
 google.golang.org/grpc/balancer_conn_wrappers.go:SA1019

--- a/xds/experimental/xds_experimental.go
+++ b/xds/experimental/xds_experimental.go
@@ -24,9 +24,12 @@ package experimental
 
 import (
 	"google.golang.org/grpc/balancer"
+	"google.golang.org/grpc/resolver"
 	xdsbalancer "google.golang.org/grpc/xds/internal/balancer"
+	xdsresolver "google.golang.org/grpc/xds/internal/resolver"
 )
 
 func init() {
+	resolver.Register(xdsresolver.NewBuilder())
 	balancer.Register(xdsbalancer.NewBalancerBuilder())
 }

--- a/xds/internal/balancer/xds_lrs_test.go
+++ b/xds/internal/balancer/xds_lrs_test.go
@@ -33,6 +33,7 @@ import (
 	"google.golang.org/grpc/resolver"
 	"google.golang.org/grpc/status"
 	"google.golang.org/grpc/xds/internal"
+	xdsinternal "google.golang.org/grpc/xds/internal"
 	basepb "google.golang.org/grpc/xds/internal/proto/envoy/api/v2/core/base"
 	lrsgrpc "google.golang.org/grpc/xds/internal/proto/envoy/service/load_stats/v2/lrs"
 	lrspb "google.golang.org/grpc/xds/internal/proto/envoy/service/load_stats/v2/lrs"
@@ -112,9 +113,9 @@ func (s) TestXdsLoadReporting(t *testing.T) {
 		Nanos:   intervalNano,
 	}
 
-	cfg := &xdsConfig{
+	cfg := &xdsinternal.LBConfig{
 		BalancerName: addr,
-		ChildPolicy:  &loadBalancingConfig{Name: fakeBalancerA}, // Set this to skip cds.
+		ChildPolicy:  &xdsinternal.LoadBalancingConfig{Name: fakeBalancerA}, // Set this to skip cds.
 	}
 	lb.UpdateClientConnState(balancer.ClientConnState{BalancerConfig: cfg})
 	td.sendResp(&response{resp: testEDSRespWithoutEndpoints})

--- a/xds/internal/balancer/xds_test.go
+++ b/xds/internal/balancer/xds_test.go
@@ -31,6 +31,7 @@ import (
 	"google.golang.org/grpc/internal/grpctest"
 	"google.golang.org/grpc/internal/leakcheck"
 	"google.golang.org/grpc/resolver"
+	xdsinternal "google.golang.org/grpc/xds/internal"
 	"google.golang.org/grpc/xds/internal/balancer/lrs"
 	discoverypb "google.golang.org/grpc/xds/internal/proto/envoy/api/v2/discovery"
 	edspb "google.golang.org/grpc/xds/internal/proto/envoy/api/v2/eds"
@@ -62,10 +63,10 @@ const (
 
 var (
 	testBalancerNameFooBar = "foo.bar"
-	testLBConfigFooBar     = &xdsConfig{
+	testLBConfigFooBar     = &xdsinternal.LBConfig{
 		BalancerName:   testBalancerNameFooBar,
-		ChildPolicy:    &loadBalancingConfig{Name: fakeBalancerA},
-		FallBackPolicy: &loadBalancingConfig{Name: fakeBalancerA},
+		ChildPolicy:    &xdsinternal.LoadBalancingConfig{Name: fakeBalancerA},
+		FallBackPolicy: &xdsinternal.LoadBalancingConfig{Name: fakeBalancerA},
 	}
 
 	specialAddrForBalancerA = resolver.Address{Addr: "this.is.balancer.A"}
@@ -178,8 +179,8 @@ type scStateChange struct {
 type fakeEDSBalancer struct {
 	cc                 balancer.ClientConn
 	edsChan            chan *edspb.ClusterLoadAssignment
-	childPolicy        chan *loadBalancingConfig
-	fallbackPolicy     chan *loadBalancingConfig
+	childPolicy        chan *xdsinternal.LoadBalancingConfig
+	fallbackPolicy     chan *xdsinternal.LoadBalancingConfig
 	subconnStateChange chan *scStateChange
 	loadStore          lrs.Store
 }
@@ -199,7 +200,7 @@ func (f *fakeEDSBalancer) HandleEDSResponse(edsResp *edspb.ClusterLoadAssignment
 }
 
 func (f *fakeEDSBalancer) HandleChildPolicy(name string, config json.RawMessage) {
-	f.childPolicy <- &loadBalancingConfig{
+	f.childPolicy <- &xdsinternal.LoadBalancingConfig{
 		Name:   name,
 		Config: config,
 	}
@@ -209,8 +210,8 @@ func newFakeEDSBalancer(cc balancer.ClientConn, loadStore lrs.Store) edsBalancer
 	lb := &fakeEDSBalancer{
 		cc:                 cc,
 		edsChan:            make(chan *edspb.ClusterLoadAssignment, 10),
-		childPolicy:        make(chan *loadBalancingConfig, 10),
-		fallbackPolicy:     make(chan *loadBalancingConfig, 10),
+		childPolicy:        make(chan *xdsinternal.LoadBalancingConfig, 10),
+		fallbackPolicy:     make(chan *xdsinternal.LoadBalancingConfig, 10),
 		subconnStateChange: make(chan *scStateChange, 10),
 		loadStore:          loadStore,
 	}
@@ -308,10 +309,10 @@ func (s) TestXdsBalanceHandleBalancerConfigBalancerNameUpdate(t *testing.T) {
 	for i := 0; i < 2; i++ {
 		addr, td, _, cleanup := setupServer(t)
 		cleanups = append(cleanups, cleanup)
-		workingLBConfig := &xdsConfig{
+		workingLBConfig := &xdsinternal.LBConfig{
 			BalancerName:   addr,
-			ChildPolicy:    &loadBalancingConfig{Name: fakeBalancerA},
-			FallBackPolicy: &loadBalancingConfig{Name: fakeBalancerA},
+			ChildPolicy:    &xdsinternal.LoadBalancingConfig{Name: fakeBalancerA},
+			FallBackPolicy: &xdsinternal.LoadBalancingConfig{Name: fakeBalancerA},
 		}
 		lb.UpdateClientConnState(balancer.ClientConnState{
 			ResolverState:  resolver.State{Addresses: addrs},
@@ -364,39 +365,39 @@ func (s) TestXdsBalanceHandleBalancerConfigChildPolicyUpdate(t *testing.T) {
 		}
 	}()
 	for _, test := range []struct {
-		cfg                 *xdsConfig
+		cfg                 *xdsinternal.LBConfig
 		responseToSend      *discoverypb.DiscoveryResponse
-		expectedChildPolicy *loadBalancingConfig
+		expectedChildPolicy *xdsinternal.LoadBalancingConfig
 	}{
 		{
-			cfg: &xdsConfig{
-				ChildPolicy: &loadBalancingConfig{
+			cfg: &xdsinternal.LBConfig{
+				ChildPolicy: &xdsinternal.LoadBalancingConfig{
 					Name:   fakeBalancerA,
 					Config: json.RawMessage("{}"),
 				},
 			},
 			responseToSend: testEDSRespWithoutEndpoints,
-			expectedChildPolicy: &loadBalancingConfig{
+			expectedChildPolicy: &xdsinternal.LoadBalancingConfig{
 				Name:   string(fakeBalancerA),
 				Config: json.RawMessage(`{}`),
 			},
 		},
 		{
-			cfg: &xdsConfig{
-				ChildPolicy: &loadBalancingConfig{
+			cfg: &xdsinternal.LBConfig{
+				ChildPolicy: &xdsinternal.LoadBalancingConfig{
 					Name:   fakeBalancerB,
 					Config: json.RawMessage("{}"),
 				},
 			},
-			expectedChildPolicy: &loadBalancingConfig{
+			expectedChildPolicy: &xdsinternal.LoadBalancingConfig{
 				Name:   string(fakeBalancerB),
 				Config: json.RawMessage(`{}`),
 			},
 		},
 		{
-			cfg:            &xdsConfig{},
+			cfg:            &xdsinternal.LBConfig{},
 			responseToSend: testCDSResp,
-			expectedChildPolicy: &loadBalancingConfig{
+			expectedChildPolicy: &xdsinternal.LoadBalancingConfig{
 				Name: "ROUND_ROBIN",
 			},
 		},
@@ -449,16 +450,16 @@ func (s) TestXdsBalanceHandleBalancerConfigFallBackUpdate(t *testing.T) {
 
 	addr, td, _, cleanup := setupServer(t)
 
-	cfg := xdsConfig{
+	cfg := xdsinternal.LBConfig{
 		BalancerName:   addr,
-		ChildPolicy:    &loadBalancingConfig{Name: fakeBalancerA},
-		FallBackPolicy: &loadBalancingConfig{Name: fakeBalancerA},
+		ChildPolicy:    &xdsinternal.LoadBalancingConfig{Name: fakeBalancerA},
+		FallBackPolicy: &xdsinternal.LoadBalancingConfig{Name: fakeBalancerA},
 	}
 	lb.UpdateClientConnState(balancer.ClientConnState{BalancerConfig: &cfg})
 
 	addrs := []resolver.Address{{Addr: "1.1.1.1:10001"}, {Addr: "2.2.2.2:10002"}, {Addr: "3.3.3.3:10003"}}
 	cfg2 := cfg
-	cfg2.FallBackPolicy = &loadBalancingConfig{Name: fakeBalancerB}
+	cfg2.FallBackPolicy = &xdsinternal.LoadBalancingConfig{Name: fakeBalancerB}
 	lb.UpdateClientConnState(balancer.ClientConnState{
 		ResolverState:  resolver.State{Addresses: addrs},
 		BalancerConfig: &cfg2,
@@ -490,7 +491,7 @@ func (s) TestXdsBalanceHandleBalancerConfigFallBackUpdate(t *testing.T) {
 	}
 
 	cfg3 := cfg
-	cfg3.FallBackPolicy = &loadBalancingConfig{Name: fakeBalancerA}
+	cfg3.FallBackPolicy = &xdsinternal.LoadBalancingConfig{Name: fakeBalancerA}
 	lb.UpdateClientConnState(balancer.ClientConnState{
 		ResolverState:  resolver.State{Addresses: addrs},
 		BalancerConfig: &cfg3,
@@ -524,10 +525,10 @@ func (s) TestXdsBalancerHandlerSubConnStateChange(t *testing.T) {
 
 	addr, td, _, cleanup := setupServer(t)
 	defer cleanup()
-	cfg := &xdsConfig{
+	cfg := &xdsinternal.LBConfig{
 		BalancerName:   addr,
-		ChildPolicy:    &loadBalancingConfig{Name: fakeBalancerA},
-		FallBackPolicy: &loadBalancingConfig{Name: fakeBalancerA},
+		ChildPolicy:    &xdsinternal.LoadBalancingConfig{Name: fakeBalancerA},
+		FallBackPolicy: &xdsinternal.LoadBalancingConfig{Name: fakeBalancerA},
 	}
 	lb.UpdateClientConnState(balancer.ClientConnState{BalancerConfig: cfg})
 
@@ -602,10 +603,10 @@ func (s) TestXdsBalancerFallBackSignalFromEdsBalancer(t *testing.T) {
 
 	addr, td, _, cleanup := setupServer(t)
 	defer cleanup()
-	cfg := &xdsConfig{
+	cfg := &xdsinternal.LBConfig{
 		BalancerName:   addr,
-		ChildPolicy:    &loadBalancingConfig{Name: fakeBalancerA},
-		FallBackPolicy: &loadBalancingConfig{Name: fakeBalancerA},
+		ChildPolicy:    &xdsinternal.LoadBalancingConfig{Name: fakeBalancerA},
+		FallBackPolicy: &xdsinternal.LoadBalancingConfig{Name: fakeBalancerA},
 	}
 	lb.UpdateClientConnState(balancer.ClientConnState{BalancerConfig: cfg})
 
@@ -673,12 +674,12 @@ func (s) TestXdsBalancerConfigParsingSelectingLBPolicy(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unable to unmarshal balancer config into xds config: %v", err)
 	}
-	xdsCfg := cfg.(*xdsConfig)
-	wantChildPolicy := &loadBalancingConfig{Name: string(fakeBalancerA), Config: json.RawMessage(`{}`)}
+	xdsCfg := cfg.(*xdsinternal.LBConfig)
+	wantChildPolicy := &xdsinternal.LoadBalancingConfig{Name: string(fakeBalancerA), Config: json.RawMessage(`{}`)}
 	if !reflect.DeepEqual(xdsCfg.ChildPolicy, wantChildPolicy) {
 		t.Fatalf("got child policy %v, want %v", xdsCfg.ChildPolicy, wantChildPolicy)
 	}
-	wantFallbackPolicy := &loadBalancingConfig{Name: string(fakeBalancerB), Config: json.RawMessage(`{}`)}
+	wantFallbackPolicy := &xdsinternal.LoadBalancingConfig{Name: string(fakeBalancerB), Config: json.RawMessage(`{}`)}
 	if !reflect.DeepEqual(xdsCfg.FallBackPolicy, wantFallbackPolicy) {
 		t.Fatalf("got fallback policy %v, want %v", xdsCfg.FallBackPolicy, wantFallbackPolicy)
 	}
@@ -688,18 +689,18 @@ func (s) TestXdsLoadbalancingConfigParsing(t *testing.T) {
 	tests := []struct {
 		name string
 		s    string
-		want *xdsConfig
+		want *xdsinternal.LBConfig
 	}{
 		{
 			name: "empty",
 			s:    "{}",
-			want: &xdsConfig{},
+			want: &xdsinternal.LBConfig{},
 		},
 		{
 			name: "success1",
 			s:    `{"childPolicy":[{"pick_first":{}}]}`,
-			want: &xdsConfig{
-				ChildPolicy: &loadBalancingConfig{
+			want: &xdsinternal.LBConfig{
+				ChildPolicy: &xdsinternal.LoadBalancingConfig{
 					Name:   "pick_first",
 					Config: json.RawMessage(`{}`),
 				},
@@ -708,8 +709,8 @@ func (s) TestXdsLoadbalancingConfigParsing(t *testing.T) {
 		{
 			name: "success2",
 			s:    `{"childPolicy":[{"round_robin":{}},{"pick_first":{}}]}`,
-			want: &xdsConfig{
-				ChildPolicy: &loadBalancingConfig{
+			want: &xdsinternal.LBConfig{
+				ChildPolicy: &xdsinternal.LoadBalancingConfig{
 					Name:   "round_robin",
 					Config: json.RawMessage(`{}`),
 				},
@@ -718,7 +719,7 @@ func (s) TestXdsLoadbalancingConfigParsing(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var cfg xdsConfig
+			var cfg xdsinternal.LBConfig
 			if err := json.Unmarshal([]byte(tt.s), &cfg); err != nil || !reflect.DeepEqual(&cfg, tt.want) {
 				t.Errorf("test name: %s, parseFullServiceConfig() = %+v, err: %v, want %+v, <nil>", tt.name, cfg, err, tt.want)
 			}

--- a/xds/internal/internal.go
+++ b/xds/internal/internal.go
@@ -18,8 +18,11 @@
 package internal
 
 import (
+	"encoding/json"
 	"fmt"
 
+	"google.golang.org/grpc/balancer"
+	"google.golang.org/grpc/serviceconfig"
 	basepb "google.golang.org/grpc/xds/internal/proto/envoy/api/v2/core/base"
 )
 
@@ -47,4 +50,89 @@ func (lamk Locality) ToProto() *basepb.Locality {
 		Zone:    lamk.Zone,
 		SubZone: lamk.SubZone,
 	}
+}
+
+// LBConfig represents the loadBalancingConfig section of the service config
+// for xDS balancers.
+type LBConfig struct {
+	serviceconfig.LoadBalancingConfig
+	// BalancerName represents the load balancer to use.
+	BalancerName string
+	// ChildPolicy represents the load balancing config for the child policy.
+	ChildPolicy *LoadBalancingConfig
+	// FallBackPolicy represents the load balancing config for the fallback.
+	FallBackPolicy *LoadBalancingConfig
+}
+
+// UnmarshalJSON parses the JSON-encoded byte slice in data and stores it in l.
+// When unmarshalling, we iterate through the childPolicy/fallbackPolicy lists
+// and select the first LB policy which has been registered.
+func (l *LBConfig) UnmarshalJSON(data []byte) error {
+	var val map[string]json.RawMessage
+	if err := json.Unmarshal(data, &val); err != nil {
+		return err
+	}
+	for k, v := range val {
+		switch k {
+		case "balancerName":
+			if err := json.Unmarshal(v, &l.BalancerName); err != nil {
+				return err
+			}
+		case "childPolicy":
+			var lbcfgs []*LoadBalancingConfig
+			if err := json.Unmarshal(v, &lbcfgs); err != nil {
+				return err
+			}
+			for _, lbcfg := range lbcfgs {
+				if balancer.Get(lbcfg.Name) != nil {
+					l.ChildPolicy = lbcfg
+					break
+				}
+			}
+		case "fallbackPolicy":
+			var lbcfgs []*LoadBalancingConfig
+			if err := json.Unmarshal(v, &lbcfgs); err != nil {
+				return err
+			}
+			for _, lbcfg := range lbcfgs {
+				if balancer.Get(lbcfg.Name) != nil {
+					l.FallBackPolicy = lbcfg
+					break
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// MarshalJSON returns a JSON enconding of l.
+func (l *LBConfig) MarshalJSON() ([]byte, error) {
+	return nil, nil
+}
+
+// LoadBalancingConfig represents a single load balancing config,
+// stored in JSON format.
+type LoadBalancingConfig struct {
+	Name   string
+	Config json.RawMessage
+}
+
+// MarshalJSON returns a JSON enconding of l.
+func (l *LoadBalancingConfig) MarshalJSON() ([]byte, error) {
+	m := make(map[string]json.RawMessage)
+	m[l.Name] = l.Config
+	return json.Marshal(m)
+}
+
+// UnmarshalJSON parses the JSON-encoded byte slice in data and stores it in l.
+func (l *LoadBalancingConfig) UnmarshalJSON(data []byte) error {
+	var cfg map[string]json.RawMessage
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return err
+	}
+	for name, config := range cfg {
+		l.Name = name
+		l.Config = config
+	}
+	return nil
 }

--- a/xds/internal/resolver/xds_resolver.go
+++ b/xds/internal/resolver/xds_resolver.go
@@ -1,0 +1,103 @@
+/*
+ *
+ * Copyright 2019 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// Package resolver implements the xds resolver.
+//
+// At this point, the resolver is named xds-experimental, and doesn't do very
+// much at all, except for returning a hard-coded service config which selects
+// the xds_experimental balancer.
+package resolver
+
+import (
+	"fmt"
+	"sync"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/internal"
+	"google.golang.org/grpc/resolver"
+	"google.golang.org/grpc/serviceconfig"
+)
+
+const (
+	// The JSON form of the hard-coded service config which picks the
+	// xds_experimental balancer with round_robin as the child policy.
+	jsonSC = `{
+    "loadBalancingConfig":[
+      {
+        "xds_experimental":{
+          "childPolicy":[
+            {
+              "round_robin": {}
+            }
+          ]
+        }
+      }
+    ]
+  }`
+	// xDS balancer name is xds_experimental while resolver scheme is
+	// xds-experimental since "_" is not a valid character in the URL.
+	xdsScheme = "xds-experimental"
+)
+
+var (
+	parseOnce sync.Once
+	parsedSC  serviceconfig.Config
+)
+
+// NewBuilder creates a new implementation of the resolver.Builder interface
+// for the xDS resolver.
+func NewBuilder() resolver.Builder {
+	return &xdsBuilder{}
+}
+
+type xdsBuilder struct{}
+
+// Build helps implement the resolver.Builder interface.
+func (b *xdsBuilder) Build(t resolver.Target, cc resolver.ClientConn, o resolver.BuildOption) (resolver.Resolver, error) {
+	parseOnce.Do(func() {
+		// The xds balancer must have been registered at this point for the service
+		// config to be parsed properly.
+		psc, err := internal.ParseServiceConfig(jsonSC)
+		if err != nil {
+			panic(fmt.Sprintf("service config %s parsing failed: %v", jsonSC, err))
+		}
+
+		var ok bool
+		if parsedSC, ok = psc.(*grpc.ServiceConfig); !ok {
+			panic(fmt.Sprintf("service config type is [%T], want [grpc.ServiceConfig]", psc))
+		}
+	})
+
+	// We return a resolver which bacically does nothing. The hard-coded service
+	// config returned here picks the xds balancer.
+	cc.UpdateState(resolver.State{ServiceConfig: parsedSC})
+	return &xdsResolver{}, nil
+}
+
+// Name helps implement the resolver.Builder interface.
+func (*xdsBuilder) Scheme() string {
+	return xdsScheme
+}
+
+type xdsResolver struct{}
+
+// ResolveNow is a no-op at this point.
+func (*xdsResolver) ResolveNow(o resolver.ResolveNowOption) {}
+
+// Close is a no-op at this point.
+func (*xdsResolver) Close() {}

--- a/xds/internal/resolver/xds_resolver_test.go
+++ b/xds/internal/resolver/xds_resolver_test.go
@@ -1,0 +1,196 @@
+/*
+ *
+ * Copyright 2019 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package resolver
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/balancer"
+	"google.golang.org/grpc/connectivity"
+	"google.golang.org/grpc/resolver"
+	"google.golang.org/grpc/serviceconfig"
+	xdsinternal "google.golang.org/grpc/xds/internal"
+)
+
+// This is initialized at init time.
+var fbb *fakeBalancerBuilder
+
+// We register a fake balancer builder and the actual xds_resolver here. We use
+// the fake balancer builder to verify the service config pushed by the
+// resolver.
+func init() {
+	resolver.Register(NewBuilder())
+	fbb = &fakeBalancerBuilder{
+		wantLBConfig: &wrappedLBConfig{lbCfg: json.RawMessage(`{
+      "childPolicy":[
+        {
+          "round_robin": {}
+        }
+      ]
+    }`)},
+		errCh: make(chan error),
+	}
+	balancer.Register(fbb)
+}
+
+// testClientConn is a fake implemetation of resolver.ClientConn. All is does
+// is to store the state received from the resolver locally and close the
+// provided done channel.
+type testClientConn struct {
+	done     chan struct{}
+	gotState resolver.State
+}
+
+func (t *testClientConn) UpdateState(s resolver.State) {
+	t.gotState = s
+	close(t.done)
+}
+
+func (*testClientConn) NewAddress(addresses []resolver.Address) { panic("unimplemented") }
+func (*testClientConn) NewServiceConfig(serviceConfig string)   { panic("unimplemented") }
+
+// TestXDSRsolverSchemeAndAddresses creates a new xds resolver, verifies that
+// it returns an empty address list and the appropriate xds-experimental
+// scheme.
+func TestXDSRsolverSchemeAndAddresses(t *testing.T) {
+	b := NewBuilder()
+	wantScheme := "xds-experimental"
+	if b.Scheme() != wantScheme {
+		t.Fatalf("got scheme %s, want %s", b.Scheme(), wantScheme)
+	}
+
+	tcc := &testClientConn{done: make(chan struct{})}
+	r, err := b.Build(resolver.Target{}, tcc, resolver.BuildOption{})
+	if err != nil {
+		t.Fatalf("xdsBuilder.Build() failed with error: %v", err)
+	}
+	defer r.Close()
+
+	<-tcc.done
+	if len(tcc.gotState.Addresses) != 0 {
+		t.Fatalf("got address list from resolver %v, want empty list", tcc.gotState.Addresses)
+	}
+}
+
+// fakeBalancer is used to verify that the xds_resolver returns the expected
+// serice config.
+type fakeBalancer struct {
+	wantLBConfig *wrappedLBConfig
+	errCh        chan error
+}
+
+func (*fakeBalancer) HandleSubConnStateChange(_ balancer.SubConn, _ connectivity.State) {
+	panic("unimplemented")
+}
+func (*fakeBalancer) HandleResolvedAddrs(_ []resolver.Address, _ error) {
+	panic("unimplemented")
+}
+
+// UpdateClientConnState verifies that the received LBConfig matches the
+// provided one, and if not, sends an error on the provided channel.
+func (f *fakeBalancer) UpdateClientConnState(ccs balancer.ClientConnState) {
+	gotLBConfig, ok := ccs.BalancerConfig.(*wrappedLBConfig)
+	if !ok {
+		f.errCh <- fmt.Errorf("in fakeBalancer got lbConfig of type %T, want %T", ccs.BalancerConfig, &wrappedLBConfig{})
+		return
+	}
+
+	var gotCfg, wantCfg xdsinternal.LBConfig
+	if err := wantCfg.UnmarshalJSON(f.wantLBConfig.lbCfg); err != nil {
+		f.errCh <- fmt.Errorf("unable to unmarshal balancer config %s into xds config", string(f.wantLBConfig.lbCfg))
+		return
+	}
+	if err := gotCfg.UnmarshalJSON(gotLBConfig.lbCfg); err != nil {
+		f.errCh <- fmt.Errorf("unable to unmarshal balancer config %s into xds config", string(gotLBConfig.lbCfg))
+		return
+	}
+	if !reflect.DeepEqual(gotCfg, wantCfg) {
+		f.errCh <- fmt.Errorf("in fakeBalancer got lbConfig %v, want %v", gotCfg, wantCfg)
+		return
+	}
+
+	f.errCh <- nil
+}
+
+func (*fakeBalancer) UpdateSubConnState(_ balancer.SubConn, _ balancer.SubConnState) {
+	panic("unimplemented")
+}
+
+func (*fakeBalancer) Close() {}
+
+// fakeBalancerBuilder builds a fake balancer and also provides a ParseConfig
+// method (which doesn't really the parse config, but just stores it as is).
+type fakeBalancerBuilder struct {
+	wantLBConfig *wrappedLBConfig
+	errCh        chan error
+}
+
+func (f *fakeBalancerBuilder) Build(cc balancer.ClientConn, opts balancer.BuildOptions) balancer.Balancer {
+	return &fakeBalancer{f.wantLBConfig, f.errCh}
+}
+
+func (f *fakeBalancerBuilder) Name() string {
+	return "xds_experimental"
+}
+
+func (f *fakeBalancerBuilder) ParseConfig(c json.RawMessage) (serviceconfig.LoadBalancingConfig, error) {
+	return &wrappedLBConfig{lbCfg: c}, nil
+}
+
+// wrappedLBConfig simply wraps the provided LB config with a
+// serviceconfig.LoadBalancingConfig interface.
+type wrappedLBConfig struct {
+	serviceconfig.LoadBalancingConfig
+	lbCfg json.RawMessage
+}
+
+// TestXDSRsolverServiceConfig verifies that the xds_resolver returns the
+// expected service config.
+//
+// The following sequence of events happen in this test:
+// * The xds_experimental balancer (fake) and resolver builders are initialized
+//   at init time.
+// * We dial a dummy address here with the xds-experimental scheme. This should
+//   pick the xds_resolver, which should return the hard-coded service config,
+//   which should reach the fake balancer that we registered (because the
+//   service config asks for the xds balancer).
+// * In the fake balancer, we verify that we receive the expected LB config.
+func TestXDSRsolverServiceConfig(t *testing.T) {
+	xdsAddr := fmt.Sprintf("%s:///dummy", xdsScheme)
+	cc, err := grpc.Dial(xdsAddr, grpc.WithInsecure())
+	if err != nil {
+		t.Fatalf("grpc.Dial(%s) failed with error: %v", xdsAddr, err)
+	}
+	defer cc.Close()
+
+	timer := time.NewTimer(5 * time.Second)
+	select {
+	case <-timer.C:
+		t.Fatal("timed out waiting for service config to reach balancer")
+	case err := <-fbb.errCh:
+		if err != nil {
+			t.Error(err)
+		}
+	}
+}


### PR DESCRIPTION
This commit makes the following changes:
* Keep track of the time of the last read in the transport.
* Use this in the keepalive implementation to decide when to send out
  keepalives.
* Address the issue of keepalives being sent every [Time+Timeout] period
  instead of every [Time] period, as mandated by proposal A8.
* Makes many of the transport tests to run in parallel (as most of them
  spend a lot of time just sleeping, waiting for things to happen).

Proposal A8 is here:
https://github.com/grpc/proposal/blob/master/A8-client-side-keepalive.md

Fixes https://github.com/grpc/grpc-go/issues/2638