### PR TITLE
Is ServeHTTP still considered experimental

### DIFF
--- a/server.go
+++ b/server.go
@@ -750,8 +750,7 @@ var _ http.Handler = (*Server)(nil)
 // Note that ServeHTTP uses Go's HTTP/2 server implementation which is totally
 // separate from grpc-go's HTTP/2 server. Performance and features may vary
 // between the two paths. ServeHTTP does not support some gRPC features
-// available through grpc-go's HTTP/2 server, and it is currently EXPERIMENTAL
-// and subject to change.
+// available through grpc-go's HTTP/2 server
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	st, err := transport.NewServerHandlerTransport(w, r, s.opts.statsHandler)
 	if err != nil {


### PR DESCRIPTION
Hi there,
this is more a question than a PR, but I wanted to know whether or not this feature was still considered experimental after 2 years?
Also, could we detail the features mentioned by this comment `ServeHTTP does not support some gRPC feature`?

Let me know if there is a way I can help make this comment more detailed!