### PR TITLE
credentials/alts: Panic Bug Fix

### DIFF
--- a/credentials/alts/alts.go
+++ b/credentials/alts/alts.go
@@ -197,14 +197,14 @@ func (g *altsTC) ClientHandshake(ctx context.Context, addr string, rawConn net.C
 		MinRpcVersion: minRPCVersion,
 	}
 	chs, err := handshaker.NewClientHandshaker(ctx, hsConn, rawConn, opts)
+	if err != nil {
+		return nil, nil, err
+	}
 	defer func() {
 		if err != nil {
 			chs.Close()
 		}
 	}()
-	if err != nil {
-		return nil, nil, err
-	}
 	secConn, authInfo, err := chs.ClientHandshake(ctx)
 	if err != nil {
 		return nil, nil, err
@@ -240,14 +240,14 @@ func (g *altsTC) ServerHandshake(rawConn net.Conn) (_ net.Conn, _ credentials.Au
 		MinRpcVersion: minRPCVersion,
 	}
 	shs, err := handshaker.NewServerHandshaker(ctx, hsConn, rawConn, opts)
+	if err != nil {
+		return nil, nil, err
+	}
 	defer func() {
 		if err != nil {
 			shs.Close()
 		}
 	}()
-	if err != nil {
-		return nil, nil, err
-	}
 	secConn, authInfo, err := shs.ServerHandshake(ctx)
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
Using `defer` before checking `NewClientHandshake` and `NewServerHandshake` error can cause panic. If these two APIs failed, `chs` and `shs` will be `nil` when `Close` is called.