### PR TITLE
xds: rpc counts (start/end) per locality

### DIFF
--- a/balancer/xds/edsbalancer/balancergroup.go
+++ b/balancer/xds/edsbalancer/balancergroup.go
@@ -59,29 +59,29 @@ type balancerGroup struct {
 	cc balancer.ClientConn
 
 	mu           sync.Mutex
-	idToBalancer map[internal.LocalityAsMapKey]balancer.Balancer
-	scToID       map[balancer.SubConn]internal.LocalityAsMapKey
+	idToBalancer map[internal.Locality]balancer.Balancer
+	scToID       map[balancer.SubConn]internal.Locality
 	loadStore    lrs.Store
 
 	pickerMu sync.Mutex
 	// All balancer IDs exist as keys in this map. If an ID is not in map, it's
 	// either removed or never added.
-	idToPickerState map[internal.LocalityAsMapKey]*pickerState
+	idToPickerState map[internal.Locality]*pickerState
 }
 
 func newBalancerGroup(cc balancer.ClientConn, loadStore lrs.Store) *balancerGroup {
 	return &balancerGroup{
 		cc: cc,
 
-		scToID:          make(map[balancer.SubConn]internal.LocalityAsMapKey),
-		idToBalancer:    make(map[internal.LocalityAsMapKey]balancer.Balancer),
-		idToPickerState: make(map[internal.LocalityAsMapKey]*pickerState),
+		scToID:          make(map[balancer.SubConn]internal.Locality),
+		idToBalancer:    make(map[internal.Locality]balancer.Balancer),
+		idToPickerState: make(map[internal.Locality]*pickerState),
 		loadStore:       loadStore,
 	}
 }
 
 // add adds a balancer built by builder to the group, with given id and weight.
-func (bg *balancerGroup) add(id internal.LocalityAsMapKey, weight uint32, builder balancer.Builder) {
+func (bg *balancerGroup) add(id internal.Locality, weight uint32, builder balancer.Builder) {
 	bg.mu.Lock()
 	if _, ok := bg.idToBalancer[id]; ok {
 		bg.mu.Unlock()
@@ -113,7 +113,7 @@ func (bg *balancerGroup) add(id internal.LocalityAsMapKey, weight uint32, builde
 //
 // It also removes the picker generated from this balancer from the picker
 // group. It always results in a picker update.
-func (bg *balancerGroup) remove(id internal.LocalityAsMapKey) {
+func (bg *balancerGroup) remove(id internal.Locality) {
 	bg.mu.Lock()
 	// Close balancer.
 	if b, ok := bg.idToBalancer[id]; ok {
@@ -143,7 +143,7 @@ func (bg *balancerGroup) remove(id internal.LocalityAsMapKey) {
 // NOTE: It always results in a picker update now. This probably isn't
 // necessary. But it seems better to do the update because it's a change in the
 // picker (which is balancer's snapshot).
-func (bg *balancerGroup) changeWeight(id internal.LocalityAsMapKey, newWeight uint32) {
+func (bg *balancerGroup) changeWeight(id internal.Locality, newWeight uint32) {
 	bg.pickerMu.Lock()
 	defer bg.pickerMu.Unlock()
 	pState, ok := bg.idToPickerState[id]
@@ -185,7 +185,7 @@ func (bg *balancerGroup) handleSubConnStateChange(sc balancer.SubConn, state con
 }
 
 // Address change: forward to balancer.
-func (bg *balancerGroup) handleResolvedAddrs(id internal.LocalityAsMapKey, addrs []resolver.Address) {
+func (bg *balancerGroup) handleResolvedAddrs(id internal.Locality, addrs []resolver.Address) {
 	bg.mu.Lock()
 	b, ok := bg.idToBalancer[id]
 	bg.mu.Unlock()
@@ -214,7 +214,7 @@ func (bg *balancerGroup) handleResolvedAddrs(id internal.LocalityAsMapKey, addrs
 // from map. Delete sc from the map only when state changes to Shutdown. Since
 // it's just forwarding the action, there's no need for a removeSubConn()
 // wrapper function.
-func (bg *balancerGroup) newSubConn(id internal.LocalityAsMapKey, addrs []resolver.Address, opts balancer.NewSubConnOptions) (balancer.SubConn, error) {
+func (bg *balancerGroup) newSubConn(id internal.Locality, addrs []resolver.Address, opts balancer.NewSubConnOptions) (balancer.SubConn, error) {
 	sc, err := bg.cc.NewSubConn(addrs, opts)
 	if err != nil {
 		return nil, err
@@ -227,7 +227,7 @@ func (bg *balancerGroup) newSubConn(id internal.LocalityAsMapKey, addrs []resolv
 
 // updateBalancerState: create an aggregated picker and an aggregated
 // connectivity state, then forward to ClientConn.
-func (bg *balancerGroup) updateBalancerState(id internal.LocalityAsMapKey, state connectivity.State, picker balancer.Picker) {
+func (bg *balancerGroup) updateBalancerState(id internal.Locality, state connectivity.State, picker balancer.Picker) {
 	grpclog.Infof("balancer group: update balancer state: %v, %v, %p", id, state, picker)
 	bg.pickerMu.Lock()
 	defer bg.pickerMu.Unlock()
@@ -255,7 +255,7 @@ func (bg *balancerGroup) close() {
 	bg.mu.Unlock()
 }
 
-func buildPickerAndState(m map[internal.LocalityAsMapKey]*pickerState) (connectivity.State, balancer.Picker) {
+func buildPickerAndState(m map[internal.Locality]*pickerState) (connectivity.State, balancer.Picker) {
 	var readyN, connectingN int
 	readyPickerWithWeights := make([]pickerState, 0, len(m))
 	for _, ps := range m {
@@ -320,11 +320,11 @@ func (pg *pickerGroup) Pick(ctx context.Context, opts balancer.PickOptions) (con
 type loadReportPicker struct {
 	balancer.Picker
 
-	id        internal.LocalityAsMapKey
+	id        internal.Locality
 	loadStore lrs.Store
 }
 
-func newLoadReportPicker(p balancer.Picker, id internal.LocalityAsMapKey, loadStore lrs.Store) *loadReportPicker {
+func newLoadReportPicker(p balancer.Picker, id internal.Locality, loadStore lrs.Store) *loadReportPicker {
 	return &loadReportPicker{
 		Picker:    p,
 		id:        id,
@@ -354,7 +354,7 @@ func (lrp *loadReportPicker) Pick(ctx context.Context, opts balancer.PickOptions
 // Some of the actions are forwarded to the parent ClientConn with no change.
 // Some are forward to balancer group with the sub-balancer ID.
 type balancerGroupCC struct {
-	id    internal.LocalityAsMapKey
+	id    internal.Locality
 	group *balancerGroup
 }
 

--- a/balancer/xds/edsbalancer/balancergroup.go
+++ b/balancer/xds/edsbalancer/balancergroup.go
@@ -23,6 +23,8 @@ import (
 	"google.golang.org/grpc/balancer"
 	"google.golang.org/grpc/balancer/base"
 	"google.golang.org/grpc/balancer/internal/wrr"
+	"google.golang.org/grpc/balancer/xds/internal"
+	"google.golang.org/grpc/balancer/xds/lrs"
 	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/grpclog"
 	"google.golang.org/grpc/resolver"
@@ -57,27 +59,29 @@ type balancerGroup struct {
 	cc balancer.ClientConn
 
 	mu           sync.Mutex
-	idToBalancer map[string]balancer.Balancer
-	scToID       map[balancer.SubConn]string
+	idToBalancer map[internal.LocalityAsMapKey]balancer.Balancer
+	scToID       map[balancer.SubConn]internal.LocalityAsMapKey
+	loadStore    lrs.Store
 
 	pickerMu sync.Mutex
 	// All balancer IDs exist as keys in this map. If an ID is not in map, it's
 	// either removed or never added.
-	idToPickerState map[string]*pickerState
+	idToPickerState map[internal.LocalityAsMapKey]*pickerState
 }
 
-func newBalancerGroup(cc balancer.ClientConn) *balancerGroup {
+func newBalancerGroup(cc balancer.ClientConn, loadStore lrs.Store) *balancerGroup {
 	return &balancerGroup{
 		cc: cc,
 
-		scToID:          make(map[balancer.SubConn]string),
-		idToBalancer:    make(map[string]balancer.Balancer),
-		idToPickerState: make(map[string]*pickerState),
+		scToID:          make(map[balancer.SubConn]internal.LocalityAsMapKey),
+		idToBalancer:    make(map[internal.LocalityAsMapKey]balancer.Balancer),
+		idToPickerState: make(map[internal.LocalityAsMapKey]*pickerState),
+		loadStore:       loadStore,
 	}
 }
 
 // add adds a balancer built by builder to the group, with given id and weight.
-func (bg *balancerGroup) add(id string, weight uint32, builder balancer.Builder) {
+func (bg *balancerGroup) add(id internal.LocalityAsMapKey, weight uint32, builder balancer.Builder) {
 	bg.mu.Lock()
 	if _, ok := bg.idToBalancer[id]; ok {
 		bg.mu.Unlock()
@@ -109,7 +113,7 @@ func (bg *balancerGroup) add(id string, weight uint32, builder balancer.Builder)
 //
 // It also removes the picker generated from this balancer from the picker
 // group. It always results in a picker update.
-func (bg *balancerGroup) remove(id string) {
+func (bg *balancerGroup) remove(id internal.LocalityAsMapKey) {
 	bg.mu.Lock()
 	// Close balancer.
 	if b, ok := bg.idToBalancer[id]; ok {
@@ -139,7 +143,7 @@ func (bg *balancerGroup) remove(id string) {
 // NOTE: It always results in a picker update now. This probably isn't
 // necessary. But it seems better to do the update because it's a change in the
 // picker (which is balancer's snapshot).
-func (bg *balancerGroup) changeWeight(id string, newWeight uint32) {
+func (bg *balancerGroup) changeWeight(id internal.LocalityAsMapKey, newWeight uint32) {
 	bg.pickerMu.Lock()
 	defer bg.pickerMu.Unlock()
 	pState, ok := bg.idToPickerState[id]
@@ -181,7 +185,7 @@ func (bg *balancerGroup) handleSubConnStateChange(sc balancer.SubConn, state con
 }
 
 // Address change: forward to balancer.
-func (bg *balancerGroup) handleResolvedAddrs(id string, addrs []resolver.Address) {
+func (bg *balancerGroup) handleResolvedAddrs(id internal.LocalityAsMapKey, addrs []resolver.Address) {
 	bg.mu.Lock()
 	b, ok := bg.idToBalancer[id]
 	bg.mu.Unlock()
@@ -210,7 +214,7 @@ func (bg *balancerGroup) handleResolvedAddrs(id string, addrs []resolver.Address
 // from map. Delete sc from the map only when state changes to Shutdown. Since
 // it's just forwarding the action, there's no need for a removeSubConn()
 // wrapper function.
-func (bg *balancerGroup) newSubConn(id string, addrs []resolver.Address, opts balancer.NewSubConnOptions) (balancer.SubConn, error) {
+func (bg *balancerGroup) newSubConn(id internal.LocalityAsMapKey, addrs []resolver.Address, opts balancer.NewSubConnOptions) (balancer.SubConn, error) {
 	sc, err := bg.cc.NewSubConn(addrs, opts)
 	if err != nil {
 		return nil, err
@@ -223,7 +227,7 @@ func (bg *balancerGroup) newSubConn(id string, addrs []resolver.Address, opts ba
 
 // updateBalancerState: create an aggregated picker and an aggregated
 // connectivity state, then forward to ClientConn.
-func (bg *balancerGroup) updateBalancerState(id string, state connectivity.State, picker balancer.Picker) {
+func (bg *balancerGroup) updateBalancerState(id internal.LocalityAsMapKey, state connectivity.State, picker balancer.Picker) {
 	grpclog.Infof("balancer group: update balancer state: %v, %v, %p", id, state, picker)
 	bg.pickerMu.Lock()
 	defer bg.pickerMu.Unlock()
@@ -234,7 +238,7 @@ func (bg *balancerGroup) updateBalancerState(id string, state connectivity.State
 		grpclog.Infof("balancer group: pickerState not found when update picker/state")
 		return
 	}
-	pickerSt.picker = picker
+	pickerSt.picker = newLoadReportPicker(picker, id, bg.loadStore)
 	pickerSt.state = state
 	bg.cc.UpdateBalancerState(buildPickerAndState(bg.idToPickerState))
 }
@@ -251,7 +255,7 @@ func (bg *balancerGroup) close() {
 	bg.mu.Unlock()
 }
 
-func buildPickerAndState(m map[string]*pickerState) (connectivity.State, balancer.Picker) {
+func buildPickerAndState(m map[internal.LocalityAsMapKey]*pickerState) (connectivity.State, balancer.Picker) {
 	var readyN, connectingN int
 	readyPickerWithWeights := make([]pickerState, 0, len(m))
 	for _, ps := range m {
@@ -313,6 +317,36 @@ func (pg *pickerGroup) Pick(ctx context.Context, opts balancer.PickOptions) (con
 	return p.Pick(ctx, opts)
 }
 
+type loadReportPicker struct {
+	balancer.Picker
+
+	id        internal.LocalityAsMapKey
+	loadStore lrs.Store
+}
+
+func newLoadReportPicker(p balancer.Picker, id internal.LocalityAsMapKey, loadStore lrs.Store) *loadReportPicker {
+	return &loadReportPicker{
+		Picker:    p,
+		id:        id,
+		loadStore: loadStore,
+	}
+}
+
+func (lrp *loadReportPicker) Pick(ctx context.Context, opts balancer.PickOptions) (conn balancer.SubConn, done func(balancer.DoneInfo), err error) {
+	conn, done, err = lrp.Picker.Pick(ctx, opts)
+	if lrp.loadStore != nil && err == nil {
+		lrp.loadStore.CallStarted(lrp.id)
+		td := done
+		done = func(info balancer.DoneInfo) {
+			lrp.loadStore.CallFinished(lrp.id, info.Err)
+			if td != nil {
+				td(info)
+			}
+		}
+	}
+	return
+}
+
 // balancerGroupCC implements the balancer.ClientConn API and get passed to each
 // sub-balancer. It contains the sub-balancer ID, so the parent balancer can
 // keep track of SubConn/pickers and the sub-balancers they belong to.
@@ -320,7 +354,7 @@ func (pg *pickerGroup) Pick(ctx context.Context, opts balancer.PickOptions) (con
 // Some of the actions are forwarded to the parent ClientConn with no change.
 // Some are forward to balancer group with the sub-balancer ID.
 type balancerGroupCC struct {
-	id    string
+	id    internal.LocalityAsMapKey
 	group *balancerGroup
 }
 

--- a/balancer/xds/edsbalancer/balancergroup_test.go
+++ b/balancer/xds/edsbalancer/balancergroup_test.go
@@ -30,7 +30,7 @@ import (
 
 var (
 	rrBuilder        = balancer.Get(roundrobin.Name)
-	testBalancerIDs  = []internal.LocalityAsMapKey{{Region: "b1"}, {Region: "b2"}, {Region: "b3"}}
+	testBalancerIDs  = []internal.Locality{{Region: "b1"}, {Region: "b2"}, {Region: "b3"}}
 	testBackendAddrs = []resolver.Address{{Addr: "1.1.1.1:1"}, {Addr: "2.2.2.2:2"}, {Addr: "3.3.3.3:3"}, {Addr: "4.4.4.4:4"}}
 )
 
@@ -382,7 +382,7 @@ func TestBalancerGroup_LoadReport(t *testing.T) {
 	cc := newTestClientConn(t)
 	bg := newBalancerGroup(cc, testLoadStore)
 
-	backendToBalancerID := make(map[balancer.SubConn]internal.LocalityAsMapKey)
+	backendToBalancerID := make(map[balancer.SubConn]internal.Locality)
 
 	// Add two balancers to group and send two resolved addresses to both
 	// balancers.
@@ -413,8 +413,8 @@ func TestBalancerGroup_LoadReport(t *testing.T) {
 	// Test roundrobin on the last picker.
 	p1 := <-cc.newPickerCh
 	var (
-		wantStart []internal.LocalityAsMapKey
-		wantEnd   []internal.LocalityAsMapKey
+		wantStart []internal.Locality
+		wantEnd   []internal.Locality
 	)
 	for i := 0; i < 10; i++ {
 		sc, done, _ := p1.Pick(context.Background(), balancer.PickOptions{})

--- a/balancer/xds/edsbalancer/edsbalancer.go
+++ b/balancer/xds/edsbalancer/edsbalancer.go
@@ -54,7 +54,7 @@ type EDSBalancer struct {
 
 	bg                 *balancerGroup
 	subBalancerBuilder balancer.Builder
-	lidToConfig        map[internal.LocalityAsMapKey]*localityConfig
+	lidToConfig        map[internal.Locality]*localityConfig
 	loadStore          lrs.Store
 
 	pickerMu    sync.Mutex
@@ -69,7 +69,7 @@ func NewXDSBalancer(cc balancer.ClientConn, loadStore lrs.Store) *EDSBalancer {
 		ClientConn:         cc,
 		subBalancerBuilder: balancer.Get(roundrobin.Name),
 
-		lidToConfig: make(map[internal.LocalityAsMapKey]*localityConfig),
+		lidToConfig: make(map[internal.Locality]*localityConfig),
 		loadStore:   loadStore,
 	}
 	// Don't start balancer group here. Start it when handling the first EDS
@@ -189,7 +189,7 @@ func (xdsB *EDSBalancer) HandleEDSResponse(edsResp *edspb.ClusterLoadAssignment)
 
 	// newLocalitiesSet contains all names of localitis in the new EDS response.
 	// It's used to delete localities that are removed in the new EDS response.
-	newLocalitiesSet := make(map[internal.LocalityAsMapKey]struct{})
+	newLocalitiesSet := make(map[internal.Locality]struct{})
 	for _, locality := range edsResp.Endpoints {
 		// One balancer for each locality.
 
@@ -198,7 +198,7 @@ func (xdsB *EDSBalancer) HandleEDSResponse(edsResp *edspb.ClusterLoadAssignment)
 			grpclog.Warningf("xds: received LocalityLbEndpoints with <nil> Locality")
 			continue
 		}
-		lid := internal.LocalityAsMapKey{
+		lid := internal.Locality{
 			Region:  l.Region,
 			Zone:    l.Zone,
 			SubZone: l.SubZone,

--- a/balancer/xds/edsbalancer/edsbalancer.go
+++ b/balancer/xds/edsbalancer/edsbalancer.go
@@ -20,7 +20,6 @@ package edsbalancer
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"net"
 	"reflect"
 	"strconv"
@@ -28,6 +27,7 @@ import (
 
 	"google.golang.org/grpc/balancer"
 	"google.golang.org/grpc/balancer/roundrobin"
+	"google.golang.org/grpc/balancer/xds/internal"
 	edspb "google.golang.org/grpc/balancer/xds/internal/proto/envoy/api/v2/eds"
 	percentpb "google.golang.org/grpc/balancer/xds/internal/proto/envoy/type/percent"
 	"google.golang.org/grpc/balancer/xds/lrs"
@@ -54,7 +54,7 @@ type EDSBalancer struct {
 
 	bg                 *balancerGroup
 	subBalancerBuilder balancer.Builder
-	lidToConfig        map[string]*localityConfig
+	lidToConfig        map[internal.LocalityAsMapKey]*localityConfig
 	loadStore          lrs.Store
 
 	pickerMu    sync.Mutex
@@ -69,7 +69,7 @@ func NewXDSBalancer(cc balancer.ClientConn, loadStore lrs.Store) *EDSBalancer {
 		ClientConn:         cc,
 		subBalancerBuilder: balancer.Get(roundrobin.Name),
 
-		lidToConfig: make(map[string]*localityConfig),
+		lidToConfig: make(map[internal.LocalityAsMapKey]*localityConfig),
 		loadStore:   loadStore,
 	}
 	// Don't start balancer group here. Start it when handling the first EDS
@@ -173,7 +173,7 @@ func (xdsB *EDSBalancer) HandleEDSResponse(edsResp *edspb.ClusterLoadAssignment)
 	// Create balancer group if it's never created (this is the first EDS
 	// response).
 	if xdsB.bg == nil {
-		xdsB.bg = newBalancerGroup(xdsB)
+		xdsB.bg = newBalancerGroup(xdsB, xdsB.loadStore)
 	}
 
 	// TODO: Unhandled fields from EDS response:
@@ -189,7 +189,7 @@ func (xdsB *EDSBalancer) HandleEDSResponse(edsResp *edspb.ClusterLoadAssignment)
 
 	// newLocalitiesSet contains all names of localitis in the new EDS response.
 	// It's used to delete localities that are removed in the new EDS response.
-	newLocalitiesSet := make(map[string]struct{})
+	newLocalitiesSet := make(map[internal.LocalityAsMapKey]struct{})
 	for _, locality := range edsResp.Endpoints {
 		// One balancer for each locality.
 
@@ -198,7 +198,11 @@ func (xdsB *EDSBalancer) HandleEDSResponse(edsResp *edspb.ClusterLoadAssignment)
 			grpclog.Warningf("xds: received LocalityLbEndpoints with <nil> Locality")
 			continue
 		}
-		lid := fmt.Sprintf("%s-%s-%s", l.Region, l.Zone, l.SubZone)
+		lid := internal.LocalityAsMapKey{
+			Region:  l.Region,
+			Zone:    l.Zone,
+			SubZone: l.SubZone,
+		}
 		newLocalitiesSet[lid] = struct{}{}
 
 		newWeight := locality.GetLoadBalancingWeight().GetValue()

--- a/balancer/xds/edsbalancer/edsbalancer_test.go
+++ b/balancer/xds/edsbalancer/edsbalancer_test.go
@@ -540,7 +540,7 @@ func TestEDS_LoadReport(t *testing.T) {
 	cc := newTestClientConn(t)
 	edsb := NewXDSBalancer(cc, testLoadStore)
 
-	backendToBalancerID := make(map[balancer.SubConn]internal.LocalityAsMapKey)
+	backendToBalancerID := make(map[balancer.SubConn]internal.Locality)
 
 	// Two localities, each with one backend.
 	clab1 := newClusterLoadAssignmentBuilder(testClusterNames[0], nil)
@@ -551,21 +551,21 @@ func TestEDS_LoadReport(t *testing.T) {
 	sc1 := <-cc.newSubConnCh
 	edsb.HandleSubConnStateChange(sc1, connectivity.Connecting)
 	edsb.HandleSubConnStateChange(sc1, connectivity.Ready)
-	backendToBalancerID[sc1] = internal.LocalityAsMapKey{
+	backendToBalancerID[sc1] = internal.Locality{
 		SubZone: testSubZones[0],
 	}
 	sc2 := <-cc.newSubConnCh
 	edsb.HandleSubConnStateChange(sc2, connectivity.Connecting)
 	edsb.HandleSubConnStateChange(sc2, connectivity.Ready)
-	backendToBalancerID[sc2] = internal.LocalityAsMapKey{
+	backendToBalancerID[sc2] = internal.Locality{
 		SubZone: testSubZones[1],
 	}
 
 	// Test roundrobin with two subconns.
 	p1 := <-cc.newPickerCh
 	var (
-		wantStart []internal.LocalityAsMapKey
-		wantEnd   []internal.LocalityAsMapKey
+		wantStart []internal.Locality
+		wantEnd   []internal.Locality
 	)
 
 	for i := 0; i < 10; i++ {

--- a/balancer/xds/edsbalancer/test_util_test.go
+++ b/balancer/xds/edsbalancer/test_util_test.go
@@ -124,8 +124,8 @@ func (tcc *testClientConn) Target() string {
 }
 
 type testLoadStore struct {
-	callsStarted []internal.LocalityAsMapKey
-	callsEnded   []internal.LocalityAsMapKey
+	callsStarted []internal.Locality
+	callsEnded   []internal.Locality
 }
 
 func newTestLoadStore() *testLoadStore {
@@ -136,11 +136,11 @@ func (*testLoadStore) CallDropped(category string) {
 	panic("not implemented")
 }
 
-func (tls *testLoadStore) CallStarted(l internal.LocalityAsMapKey) {
+func (tls *testLoadStore) CallStarted(l internal.Locality) {
 	tls.callsStarted = append(tls.callsStarted, l)
 }
 
-func (tls *testLoadStore) CallFinished(l internal.LocalityAsMapKey, err error) {
+func (tls *testLoadStore) CallFinished(l internal.Locality, err error) {
 	tls.callsEnded = append(tls.callsEnded, l)
 }
 

--- a/balancer/xds/edsbalancer/test_util_test.go
+++ b/balancer/xds/edsbalancer/test_util_test.go
@@ -17,10 +17,13 @@
 package edsbalancer
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/balancer"
+	"google.golang.org/grpc/balancer/xds/internal"
 	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/resolver"
 )
@@ -75,7 +78,7 @@ func (tcc *testClientConn) NewSubConn(a []resolver.Address, o balancer.NewSubCon
 	sc := testSubConns[tcc.subConnIdx]
 	tcc.subConnIdx++
 
-	tcc.t.Logf("testClientConn: NewSubConn(%v, %+v) => %p", a, o, sc)
+	tcc.t.Logf("testClientConn: NewSubConn(%v, %+v) => %s", a, o, sc)
 	select {
 	case tcc.newSubConnAddrsCh <- a:
 	default:
@@ -117,6 +120,31 @@ func (tcc *testClientConn) ResolveNow(resolver.ResolveNowOption) {
 }
 
 func (tcc *testClientConn) Target() string {
+	panic("not implemented")
+}
+
+type testLoadStore struct {
+	callsStarted []internal.LocalityAsMapKey
+	callsEnded   []internal.LocalityAsMapKey
+}
+
+func newTestLoadStore() *testLoadStore {
+	return &testLoadStore{}
+}
+
+func (*testLoadStore) CallDropped(category string) {
+	panic("not implemented")
+}
+
+func (tls *testLoadStore) CallStarted(l internal.LocalityAsMapKey) {
+	tls.callsStarted = append(tls.callsStarted, l)
+}
+
+func (tls *testLoadStore) CallFinished(l internal.LocalityAsMapKey, err error) {
+	tls.callsEnded = append(tls.callsEnded, l)
+}
+
+func (*testLoadStore) ReportTo(ctx context.Context, cc *grpc.ClientConn) {
 	panic("not implemented")
 }
 

--- a/balancer/xds/internal/internal.go
+++ b/balancer/xds/internal/internal.go
@@ -17,7 +17,11 @@
 
 package internal
 
-import "fmt"
+import (
+	"fmt"
+
+	basepb "google.golang.org/grpc/balancer/xds/internal/proto/envoy/api/v2/core/base"
+)
 
 // LocalityAsMapKey is xds.Locality without XXX fields, so it can be used as map
 // keys.
@@ -31,4 +35,13 @@ type LocalityAsMapKey struct {
 
 func (lamk LocalityAsMapKey) String() string {
 	return fmt.Sprintf("%s-%s-%s", lamk.Region, lamk.Zone, lamk.SubZone)
+}
+
+// ToProto convert LocalityAsMapKey to the proto representation.
+func (lamk LocalityAsMapKey) ToProto() *basepb.Locality {
+	return &basepb.Locality{
+		Region:  lamk.Region,
+		Zone:    lamk.Zone,
+		SubZone: lamk.SubZone,
+	}
 }

--- a/balancer/xds/internal/internal.go
+++ b/balancer/xds/internal/internal.go
@@ -23,22 +23,25 @@ import (
 	basepb "google.golang.org/grpc/balancer/xds/internal/proto/envoy/api/v2/core/base"
 )
 
-// LocalityAsMapKey is xds.Locality without XXX fields, so it can be used as map
+// Locality is xds.Locality without XXX fields, so it can be used as map
 // keys.
 //
 // xds.Locality cannot be map keys because one of the XXX fields is a slice.
-type LocalityAsMapKey struct {
+//
+// This struct should only be used as map keys. Use the proto message directly
+// in all other places.
+type Locality struct {
 	Region  string
 	Zone    string
 	SubZone string
 }
 
-func (lamk LocalityAsMapKey) String() string {
+func (lamk Locality) String() string {
 	return fmt.Sprintf("%s-%s-%s", lamk.Region, lamk.Zone, lamk.SubZone)
 }
 
-// ToProto convert LocalityAsMapKey to the proto representation.
-func (lamk LocalityAsMapKey) ToProto() *basepb.Locality {
+// ToProto convert Locality to the proto representation.
+func (lamk Locality) ToProto() *basepb.Locality {
 	return &basepb.Locality{
 		Region:  lamk.Region,
 		Zone:    lamk.Zone,

--- a/balancer/xds/internal/internal.go
+++ b/balancer/xds/internal/internal.go
@@ -1,0 +1,34 @@
+/*
+ *
+ * Copyright 2019 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package internal
+
+import "fmt"
+
+// LocalityAsMapKey is xds.Locality without XXX fields, so it can be used as map
+// keys.
+//
+// xds.Locality cannot be map keys because one of the XXX fields is a slice.
+type LocalityAsMapKey struct {
+	Region  string
+	Zone    string
+	SubZone string
+}
+
+func (lamk LocalityAsMapKey) String() string {
+	return fmt.Sprintf("%s-%s-%s", lamk.Region, lamk.Zone, lamk.SubZone)
+}

--- a/balancer/xds/internal/internal_test.go
+++ b/balancer/xds/internal/internal_test.go
@@ -35,11 +35,11 @@ func TestLocalityMatchProtoMessage(t *testing.T) {
 		want1[f.Name] = f.Type.Name()
 	}
 
-	const ignorePrevix = "XXX_"
+	const ignorePrefix = "XXX_"
 	want2 := make(map[string]string)
 	for ty, i := reflect.TypeOf(basepb.Locality{}), 0; i < ty.NumField(); i++ {
 		f := ty.Field(i)
-		if strings.HasPrefix(f.Name, ignorePrevix) {
+		if strings.HasPrefix(f.Name, ignorePrefix) {
 			continue
 		}
 		want2[f.Name] = f.Type.Name()

--- a/balancer/xds/internal/internal_test.go
+++ b/balancer/xds/internal/internal_test.go
@@ -1,0 +1,51 @@
+/*
+ *
+ * Copyright 2019 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package internal
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	basepb "google.golang.org/grpc/balancer/xds/internal/proto/envoy/api/v2/core/base"
+)
+
+// A reflection based test to make sure internal.Locality contains all the
+// fields (expect for XXX_) from the proto message.
+func TestLocalityMatchProtoMessage(t *testing.T) {
+	want1 := make(map[string]string)
+	for ty, i := reflect.TypeOf(Locality{}), 0; i < ty.NumField(); i++ {
+		f := ty.Field(i)
+		want1[f.Name] = f.Type.Name()
+	}
+
+	const ignorePrevix = "XXX_"
+	want2 := make(map[string]string)
+	for ty, i := reflect.TypeOf(basepb.Locality{}), 0; i < ty.NumField(); i++ {
+		f := ty.Field(i)
+		if strings.HasPrefix(f.Name, ignorePrevix) {
+			continue
+		}
+		want2[f.Name] = f.Type.Name()
+	}
+
+	if !reflect.DeepEqual(want1, want2) {
+		t.Fatalf("internal type and proto message have different fields:\n%+v", cmp.Diff(want1, want2))
+	}
+}

--- a/balancer/xds/lrs/lrs.go
+++ b/balancer/xds/lrs/lrs.go
@@ -39,6 +39,8 @@ import (
 // them to a server when requested.
 type Store interface {
 	CallDropped(category string)
+	CallStarted(l internal.LocalityAsMapKey)
+	CallFinished(l internal.LocalityAsMapKey, err error)
 	ReportTo(ctx context.Context, cc *grpc.ClientConn)
 }
 
@@ -86,9 +88,13 @@ func (ls *lrsStore) CallDropped(category string) {
 	atomic.AddUint64(p.(*uint64), 1)
 }
 
-// TODO: add query counts
-//  callStarted(l locality)
-//  callFinished(l locality, err error)
+func (ls *lrsStore) CallStarted(l internal.LocalityAsMapKey) {
+	panic("todo: call started")
+}
+
+func (ls *lrsStore) CallFinished(l internal.LocalityAsMapKey, err error) {
+	panic("todo: call finished")
+}
 
 func (ls *lrsStore) buildStats() []*loadreportpb.ClusterStats {
 	var (

--- a/balancer/xds/lrs/lrs_test.go
+++ b/balancer/xds/lrs/lrs_test.go
@@ -19,11 +19,13 @@ package lrs
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net"
 	"reflect"
 	"sort"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -43,7 +45,23 @@ import (
 
 const testService = "grpc.service.test"
 
-var dropCategories = []string{"drop_for_real", "drop_for_fun"}
+var (
+	dropCategories = []string{"drop_for_real", "drop_for_fun"}
+	localities     = []internal.LocalityAsMapKey{{Region: "a"}, {Region: "b"}}
+	errTest        = fmt.Errorf("test error")
+)
+
+func newRPCCountDataWithInitData(succeeded, errored, inprogress uint64) *rpcCountData {
+	return &rpcCountData{
+		succeeded:  &succeeded,
+		errored:    &errored,
+		inProgress: &inprogress,
+	}
+}
+
+func (rcd *rpcCountData) Equal(b *rpcCountData) bool {
+	return *rcd.inProgress == *b.inProgress && *rcd.errored == *b.errored && *rcd.succeeded == *b.succeeded
+}
 
 // equalClusterStats sorts requests and clear report internal before comparing.
 func equalClusterStats(a, b []*loadreportpb.ClusterStats) bool {
@@ -51,31 +69,37 @@ func equalClusterStats(a, b []*loadreportpb.ClusterStats) bool {
 		sort.Slice(s.DroppedRequests, func(i, j int) bool {
 			return s.DroppedRequests[i].Category < s.DroppedRequests[j].Category
 		})
+		sort.Slice(s.UpstreamLocalityStats, func(i, j int) bool {
+			return s.UpstreamLocalityStats[i].Locality.String() < s.UpstreamLocalityStats[j].Locality.String()
+		})
 		s.LoadReportInterval = nil
 	}
 	for _, s := range b {
 		sort.Slice(s.DroppedRequests, func(i, j int) bool {
 			return s.DroppedRequests[i].Category < s.DroppedRequests[j].Category
 		})
+		sort.Slice(s.UpstreamLocalityStats, func(i, j int) bool {
+			return s.UpstreamLocalityStats[i].Locality.String() < s.UpstreamLocalityStats[j].Locality.String()
+		})
 		s.LoadReportInterval = nil
 	}
 	return reflect.DeepEqual(a, b)
 }
 
-func Test_lrsStore_buildStats(t *testing.T) {
+func Test_lrsStore_buildStats_drops(t *testing.T) {
 	tests := []struct {
 		name  string
 		drops []map[string]uint64
 	}{
 		{
-			name: "one report",
+			name: "one drop report",
 			drops: []map[string]uint64{{
 				dropCategories[0]: 31,
 				dropCategories[1]: 41,
 			}},
 		},
 		{
-			name: "two reports",
+			name: "two drop reports",
 			drops: []map[string]uint64{{
 				dropCategories[0]: 31,
 				dropCategories[1]: 41,
@@ -130,11 +154,118 @@ func Test_lrsStore_buildStats(t *testing.T) {
 	}
 }
 
+func Test_lrsStore_buildStats_rpcCounts(t *testing.T) {
+	tests := []struct {
+		name string
+		rpcs []map[internal.LocalityAsMapKey]*rpcCountData
+	}{
+		{
+			name: "one rpcCount report",
+			rpcs: []map[internal.LocalityAsMapKey]*rpcCountData{{
+				localities[0]: newRPCCountDataWithInitData(3, 1, 4),
+			}},
+		},
+		{
+			name: "two localities rpcCount reports",
+			rpcs: []map[internal.LocalityAsMapKey]*rpcCountData{{
+				localities[0]: newRPCCountDataWithInitData(3, 1, 4),
+				localities[1]: newRPCCountDataWithInitData(1, 5, 9),
+			}},
+		},
+		{
+			name: "two rpcCount reports",
+			rpcs: []map[internal.LocalityAsMapKey]*rpcCountData{{
+				localities[0]: newRPCCountDataWithInitData(3, 1, 4),
+				localities[1]: newRPCCountDataWithInitData(1, 5, 9),
+			}, {
+				localities[0]: newRPCCountDataWithInitData(3, 1, 4),
+			}, {
+				localities[1]: newRPCCountDataWithInitData(1, 5, 9),
+			}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ls := NewStore(testService).(*lrsStore)
+
+			// InProgress count doesn't get cleared at each buildStats, keep
+			// them to carry over.
+			inProgressCounts := make(map[internal.LocalityAsMapKey]uint64)
+
+			for _, counts := range tt.rpcs {
+				var upstreamLocalityStats []*loadreportpb.UpstreamLocalityStats
+
+				for l, count := range counts {
+					tempInProgress := *count.inProgress + inProgressCounts[l]
+					upstreamLocalityStats = append(upstreamLocalityStats, &loadreportpb.UpstreamLocalityStats{
+						Locality:                l.ToProto(),
+						TotalSuccessfulRequests: *count.succeeded,
+						TotalRequestsInProgress: tempInProgress,
+						TotalErrorRequests:      *count.errored,
+					})
+					inProgressCounts[l] = tempInProgress
+				}
+				// InProgress count doesn't get cleared at each buildStats, and
+				// needs to be carried over to the next result.
+				for l, c := range inProgressCounts {
+					if _, ok := counts[l]; !ok {
+						upstreamLocalityStats = append(upstreamLocalityStats, &loadreportpb.UpstreamLocalityStats{
+							Locality:                l.ToProto(),
+							TotalRequestsInProgress: c,
+						})
+					}
+				}
+				want := []*loadreportpb.ClusterStats{
+					{
+						ClusterName:           testService,
+						UpstreamLocalityStats: upstreamLocalityStats,
+					},
+				}
+
+				var wg sync.WaitGroup
+				for l, count := range counts {
+					for i := 0; i < int(*count.succeeded); i++ {
+						wg.Add(1)
+						go func(i int, l internal.LocalityAsMapKey) {
+							ls.CallStarted(l)
+							ls.CallFinished(l, nil)
+							wg.Done()
+						}(i, l)
+					}
+					for i := 0; i < int(*count.inProgress); i++ {
+						wg.Add(1)
+						go func(i int, l internal.LocalityAsMapKey) {
+							ls.CallStarted(l)
+							wg.Done()
+						}(i, l)
+					}
+					for i := 0; i < int(*count.errored); i++ {
+						wg.Add(1)
+						go func(i int, l internal.LocalityAsMapKey) {
+							ls.CallStarted(l)
+							ls.CallFinished(l, errTest)
+							wg.Done()
+						}(i, l)
+					}
+				}
+				wg.Wait()
+
+				if got := ls.buildStats(); !equalClusterStats(got, want) {
+					t.Errorf("lrsStore.buildStats() = %v, want %v", got, want)
+					t.Errorf("%s", cmp.Diff(got, want))
+				}
+			}
+		})
+	}
+}
+
 type lrsServer struct {
-	mu                sync.Mutex
-	dropTotal         uint64
-	drops             map[string]uint64
 	reportingInterval *durationpb.Duration
+
+	mu        sync.Mutex
+	dropTotal uint64
+	drops     map[string]uint64
+	rpcs      map[internal.LocalityAsMapKey]*rpcCountData
 }
 
 func (lrss *lrsServer) StreamLoadStats(stream lrsgrpc.LoadReportingService_StreamLoadStatsServer) error {
@@ -176,6 +307,21 @@ func (lrss *lrsServer) StreamLoadStats(stream lrsgrpc.LoadReportingService_Strea
 		for _, d := range stats.DroppedRequests {
 			lrss.drops[d.Category] += d.DroppedCount
 		}
+		for _, ss := range stats.UpstreamLocalityStats {
+			l := internal.LocalityAsMapKey{
+				Region:  ss.Locality.Region,
+				Zone:    ss.Locality.Zone,
+				SubZone: ss.Locality.SubZone,
+			}
+			counts, ok := lrss.rpcs[l]
+			if !ok {
+				counts = newRPCCountDataWithInitData(0, 0, 0)
+				lrss.rpcs[l] = counts
+			}
+			atomic.AddUint64(counts.succeeded, ss.TotalSuccessfulRequests)
+			atomic.StoreUint64(counts.inProgress, ss.TotalRequestsInProgress)
+			atomic.AddUint64(counts.errored, ss.TotalErrorRequests)
+		}
 		lrss.mu.Unlock()
 	}
 }
@@ -187,8 +333,9 @@ func setupServer(t *testing.T, reportingInterval *durationpb.Duration) (addr str
 	}
 	svr := grpc.NewServer()
 	lrss = &lrsServer{
-		drops:             make(map[string]uint64),
 		reportingInterval: reportingInterval,
+		drops:             make(map[string]uint64),
+		rpcs:              make(map[internal.LocalityAsMapKey]*rpcCountData),
 	}
 	lrsgrpc.RegisterLoadReportingServiceServer(svr, lrss)
 	go svr.Serve(lis)
@@ -220,16 +367,40 @@ func Test_lrsStore_ReportTo(t *testing.T) {
 	}()
 
 	drops := map[string]uint64{
-		dropCategories[0]: 31,
-		dropCategories[1]: 41,
+		dropCategories[0]: 13,
+		dropCategories[1]: 14,
 	}
-
 	for c, d := range drops {
 		for i := 0; i < int(d); i++ {
 			ls.CallDropped(c)
 			time.Sleep(time.Nanosecond * intervalNano / 10)
 		}
 	}
+
+	rpcs := map[internal.LocalityAsMapKey]*rpcCountData{
+		localities[0]: newRPCCountDataWithInitData(3, 1, 4),
+		localities[1]: newRPCCountDataWithInitData(1, 5, 9),
+	}
+	for l, count := range rpcs {
+		for i := 0; i < int(*count.succeeded); i++ {
+			go func(i int, l internal.LocalityAsMapKey) {
+				ls.CallStarted(l)
+				ls.CallFinished(l, nil)
+			}(i, l)
+		}
+		for i := 0; i < int(*count.inProgress); i++ {
+			go func(i int, l internal.LocalityAsMapKey) {
+				ls.CallStarted(l)
+			}(i, l)
+		}
+		for i := 0; i < int(*count.errored); i++ {
+			go func(i int, l internal.LocalityAsMapKey) {
+				ls.CallStarted(l)
+				ls.CallFinished(l, errTest)
+			}(i, l)
+		}
+	}
+
 	time.Sleep(time.Nanosecond * intervalNano * 2)
 	cancel()
 	<-done
@@ -238,5 +409,8 @@ func Test_lrsStore_ReportTo(t *testing.T) {
 	defer lrss.mu.Unlock()
 	if !cmp.Equal(lrss.drops, drops) {
 		t.Errorf("different: %v", cmp.Diff(lrss.drops, drops))
+	}
+	if !cmp.Equal(lrss.rpcs, rpcs) {
+		t.Errorf("different: %v", cmp.Diff(lrss.rpcs, rpcs))
 	}
 }


### PR DESCRIPTION
This PR also changed the balancer ID in balancer group from string to a struct, so we don't need to parse the string to build locality when reporting loads. But the struct is a new one instead of the locality proto type, because proto messages are not hashable, and cannot be used a map keys.