### PR TITLE
xds: use BuildOptions.Target.endpoint string instead of deprecated cc.Target

### DIFF
--- a/balancer/xds/internal/const.go
+++ b/balancer/xds/internal/const.go
@@ -1,0 +1,23 @@
+/*
+ *
+ * Copyright 2019 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package internal
+
+var (
+	GrpcHostname = "TRAFFICDIRECTOR_GRPC_HOSTNAME"
+)

--- a/balancer/xds/internal/const.go
+++ b/balancer/xds/internal/const.go
@@ -19,5 +19,7 @@
 package internal
 
 var (
+	// GrpcHostname is the metadata key for specifying the grpc service name when sending xDS requests
+	// from grpc to the traffic director.
 	GrpcHostname = "TRAFFICDIRECTOR_GRPC_HOSTNAME"
 )

--- a/balancer/xds/lrs/lrs.go
+++ b/balancer/xds/lrs/lrs.go
@@ -25,6 +25,7 @@ import (
 	"github.com/golang/protobuf/ptypes"
 	structpb "github.com/golang/protobuf/ptypes/struct"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/balancer/xds/internal"
 	basepb "google.golang.org/grpc/balancer/xds/internal/proto/envoy/api/v2/core/base"
 	loadreportpb "google.golang.org/grpc/balancer/xds/internal/proto/envoy/api/v2/endpoint/load_report"
 	lrspb "google.golang.org/grpc/balancer/xds/internal/proto/envoy/service/load_stats/v2/lrs"
@@ -50,8 +51,6 @@ type lrsStore struct {
 	drops sync.Map // map[string]*uint64
 }
 
-const grpcHostname = "com.googleapis.trafficdirector.grpc_hostname"
-
 // NewStore creates a store for load reports.
 func NewStore(serviceName string) Store {
 	return &lrsStore{
@@ -59,7 +58,7 @@ func NewStore(serviceName string) Store {
 		node: &basepb.Node{
 			Metadata: &structpb.Struct{
 				Fields: map[string]*structpb.Value{
-					grpcHostname: {
+					internal.GrpcHostname: {
 						Kind: &structpb.Value_StringValue{StringValue: serviceName},
 					},
 				},

--- a/balancer/xds/lrs/lrs_test.go
+++ b/balancer/xds/lrs/lrs_test.go
@@ -32,6 +32,7 @@ import (
 	structpb "github.com/golang/protobuf/ptypes/struct"
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/balancer/xds/internal"
 	basepb "google.golang.org/grpc/balancer/xds/internal/proto/envoy/api/v2/core/base"
 	loadreportpb "google.golang.org/grpc/balancer/xds/internal/proto/envoy/api/v2/endpoint/load_report"
 	lrspb "google.golang.org/grpc/balancer/xds/internal/proto/envoy/service/load_stats/v2/lrs"
@@ -144,7 +145,7 @@ func (lrss *lrsServer) StreamLoadStats(stream lrspb.LoadReportingService_StreamL
 		Node: &basepb.Node{
 			Metadata: &structpb.Struct{
 				Fields: map[string]*structpb.Value{
-					grpcHostname: {
+					internal.GrpcHostname: {
 						Kind: &structpb.Value_StringValue{StringValue: testService},
 					},
 				},

--- a/balancer/xds/xds_test.go
+++ b/balancer/xds/xds_test.go
@@ -276,7 +276,7 @@ func (s) TestXdsBalanceHandleResolvedAddrs(t *testing.T) {
 
 	builder := balancer.Get("xds")
 	cc := newTestClientConn()
-	lb, ok := builder.Build(cc, balancer.BuildOptions{}).(*xdsBalancer)
+	lb, ok := builder.Build(cc, balancer.BuildOptions{Target: resolver.Target{Endpoint: testServiceName}}).(*xdsBalancer)
 	if !ok {
 		t.Fatalf("unable to type assert to *xdsBalancer")
 	}
@@ -310,7 +310,7 @@ func (s) TestXdsBalanceHandleBalancerConfigBalancerNameUpdate(t *testing.T) {
 
 	builder := balancer.Get("xds")
 	cc := newTestClientConn()
-	lb, ok := builder.Build(cc, balancer.BuildOptions{}).(*xdsBalancer)
+	lb, ok := builder.Build(cc, balancer.BuildOptions{Target: resolver.Target{Endpoint: testServiceName}}).(*xdsBalancer)
 	if !ok {
 		t.Fatalf("unable to type assert to *xdsBalancer")
 	}
@@ -385,7 +385,7 @@ func (s) TestXdsBalanceHandleBalancerConfigChildPolicyUpdate(t *testing.T) {
 
 	builder := balancer.Get("xds")
 	cc := newTestClientConn()
-	lb, ok := builder.Build(cc, balancer.BuildOptions{}).(*xdsBalancer)
+	lb, ok := builder.Build(cc, balancer.BuildOptions{Target: resolver.Target{Endpoint: testServiceName}}).(*xdsBalancer)
 	if !ok {
 		t.Fatalf("unable to type assert to *xdsBalancer")
 	}
@@ -471,7 +471,7 @@ func (s) TestXdsBalanceHandleBalancerConfigFallbackUpdate(t *testing.T) {
 
 	builder := balancer.Get("xds")
 	cc := newTestClientConn()
-	lb, ok := builder.Build(cc, balancer.BuildOptions{}).(*xdsBalancer)
+	lb, ok := builder.Build(cc, balancer.BuildOptions{Target: resolver.Target{Endpoint: testServiceName}}).(*xdsBalancer)
 	if !ok {
 		t.Fatalf("unable to type assert to *xdsBalancer")
 	}
@@ -546,7 +546,7 @@ func (s) TestXdsBalancerHandlerSubConnStateChange(t *testing.T) {
 
 	builder := balancer.Get("xds")
 	cc := newTestClientConn()
-	lb, ok := builder.Build(cc, balancer.BuildOptions{}).(*xdsBalancer)
+	lb, ok := builder.Build(cc, balancer.BuildOptions{Target: resolver.Target{Endpoint: testServiceName}}).(*xdsBalancer)
 	if !ok {
 		t.Fatalf("unable to type assert to *xdsBalancer")
 	}
@@ -626,7 +626,7 @@ func (s) TestXdsBalancerFallbackSignalFromEdsBalancer(t *testing.T) {
 
 	builder := balancer.Get("xds")
 	cc := newTestClientConn()
-	lb, ok := builder.Build(cc, balancer.BuildOptions{}).(*xdsBalancer)
+	lb, ok := builder.Build(cc, balancer.BuildOptions{Target: resolver.Target{Endpoint: testServiceName}}).(*xdsBalancer)
 	if !ok {
 		t.Fatalf("unable to type assert to *xdsBalancer")
 	}


### PR DESCRIPTION
cc.Target() returns the full target string which includes scheme, authority and endpoint, while xds should send the endpoint part of it for xDS requests. 

Also, cc.Target() has been deprecated and BuildOptions.Target field is being provided for parsed target info.