### PR TITLE
grpclb: only force update picker when cache is used

### DIFF
--- a/balancer/grpclb/grpclb_remote_balancer.go
+++ b/balancer/grpclb/grpclb_remote_balancer.go
@@ -95,14 +95,6 @@ func (lb *lbBalancer) processServerList(l *lbpb.ServerList) {
 //
 // Caller must hold lb.mu.
 func (lb *lbBalancer) refreshSubConns(backendAddrs []resolver.Address, fallback bool, pickFirst bool) {
-	defer func() {
-		// Regenerate and update picker after refreshing subconns because with
-		// cache, even if SubConn was newed/removed, there might be no state
-		// changes (the subconn will be kept in cache, not actually
-		// newed/removed).
-		lb.updateStateAndPicker(true, true)
-	}()
-
 	lb.inFallback = fallback
 
 	opts := balancer.NewSubConnOptions{}
@@ -184,6 +176,12 @@ func (lb *lbBalancer) refreshSubConns(backendAddrs []resolver.Address, fallback 
 			// The entry will be deleted in HandleSubConnStateChange.
 		}
 	}
+
+	// Regenerate and update picker after refreshing subconns because with
+	// cache, even if SubConn was newed/removed, there might be no state
+	// changes (the subconn will be kept in cache, not actually
+	// newed/removed).
+	lb.updateStateAndPicker(true, true)
 }
 
 func (lb *lbBalancer) readServerList(s *balanceLoadClientStream) error {


### PR DESCRIPTION
Only when sub-balancer is round-robin (not pick-first), subconns are cached.

The actual problem solved by this:

If pick-first is set as the sub-balancer, when switching sub-balancer from round-robin to pick-first, the first subconn creation will fail because no address is available (`grpclb: failed to create new SubConn: grpc: cannot create SubConn with empty address list`).

What should happen is, no picker is updated, and all RPCs block and wait. But because we will always regenerate and update picker, a TransientFailure error picker will be set and all RPCs will fail.