### PR TITLE
xds: fix difference between user target name and resource name

### DIFF
--- a/balancer/xds/lrs/lrs.go
+++ b/balancer/xds/lrs/lrs.go
@@ -64,7 +64,6 @@ func newRPCCountData() *rpcCountData {
 // lrsStore collects loads from xds balancer, and periodically sends load to the
 // server.
 type lrsStore struct {
-	serviceName  string
 	node         *basepb.Node
 	backoff      backoff.Strategy
 	lastReported time.Time
@@ -76,7 +75,6 @@ type lrsStore struct {
 // NewStore creates a store for load reports.
 func NewStore(serviceName string) Store {
 	return &lrsStore{
-		serviceName: serviceName,
 		node: &basepb.Node{
 			Metadata: &structpb.Struct{
 				Fields: map[string]*structpb.Value{

--- a/balancer/xds/lrs/lrs_test.go
+++ b/balancer/xds/lrs/lrs_test.go
@@ -158,7 +158,7 @@ func Test_lrsStore_buildStats_drops(t *testing.T) {
 				}
 				wg.Wait()
 
-				if got := ls.buildStats(); !equalClusterStats(got, want) {
+				if got := ls.buildStats(testService); !equalClusterStats(got, want) {
 					t.Errorf("lrsStore.buildStats() = %v, want %v", got, want)
 					t.Errorf("%s", cmp.Diff(got, want))
 				}
@@ -286,7 +286,7 @@ func Test_lrsStore_buildStats_rpcCounts(t *testing.T) {
 				}
 				wg.Wait()
 
-				if got := ls.buildStats(); !equalClusterStats(got, want) {
+				if got := ls.buildStats(testService); !equalClusterStats(got, want) {
 					t.Errorf("lrsStore.buildStats() = %v, want %v", got, want)
 					t.Errorf("%s", cmp.Diff(got, want))
 				}

--- a/balancer/xds/xds.go
+++ b/balancer/xds/xds.go
@@ -423,9 +423,8 @@ func (x *xdsBalancer) newADSResponse(ctx context.Context, resp proto.Message) er
 	var update interface{}
 	switch u := resp.(type) {
 	case *cdspb.Cluster:
-		if u.GetName() != x.buildOpts.Target.Endpoint {
-			return fmt.Errorf("unmatched service name, got %s, want %s", u.GetName(), x.buildOpts.Target.Endpoint)
-		}
+		// TODO: EDS requests should use CDS response's Name. Store
+		// `u.GetName()` in `x.clusterName` and use it in xds_client.
 		if u.GetType() != cdspb.Cluster_EDS {
 			return fmt.Errorf("unexpected service discovery type, got %v, want %v", u.GetType(), cdspb.Cluster_EDS)
 		}

--- a/balancer/xds/xds_client.go
+++ b/balancer/xds/xds_client.go
@@ -149,14 +149,26 @@ func (c *client) newEDSRequest() *discoverypb.DiscoveryRequest {
 		Node: &basepb.Node{
 			Metadata: &structpb.Struct{
 				Fields: map[string]*structpb.Value{
+					internal.GrpcHostname: {
+						Kind: &structpb.Value_StringValue{StringValue: c.serviceName},
+					},
 					endpointRequired: {
 						Kind: &structpb.Value_BoolValue{BoolValue: c.enableCDS},
 					},
 				},
 			},
 		},
-		ResourceNames: []string{c.serviceName},
-		TypeUrl:       edsType,
+		// TODO: the expected ResourceName could be in a different format from
+		// dial target. (test_service.test_namespace.traffic_director.com vs
+		// test_namespace:test_service).
+		//
+		// The solution today is to always include GrpcHostname in metadata,
+		// with the value set to dial target.
+		//
+		// A future solution could be: always do CDS, get cluster name from CDS
+		// response, and use it here.
+		// `ResourceNames: []string{c.clusterName},`
+		TypeUrl: edsType,
 	}
 	return edsReq
 }

--- a/balancer/xds/xds_client_test.go
+++ b/balancer/xds/xds_client_test.go
@@ -65,27 +65,31 @@ var (
 		Node: &basepb.Node{
 			Metadata: &structpb.Struct{
 				Fields: map[string]*structpb.Value{
+					internal.GrpcHostname: {
+						Kind: &structpb.Value_StringValue{StringValue: testServiceName},
+					},
 					endpointRequired: {
 						Kind: &structpb.Value_BoolValue{BoolValue: true},
 					},
 				},
 			},
 		},
-		ResourceNames: []string{testServiceName},
-		TypeUrl:       edsType,
+		TypeUrl: edsType,
 	}
 	testEDSReqWithoutEndpoints = &discoverypb.DiscoveryRequest{
 		Node: &basepb.Node{
 			Metadata: &structpb.Struct{
 				Fields: map[string]*structpb.Value{
+					internal.GrpcHostname: {
+						Kind: &structpb.Value_StringValue{StringValue: testServiceName},
+					},
 					endpointRequired: {
 						Kind: &structpb.Value_BoolValue{BoolValue: false},
 					},
 				},
 			},
 		},
-		ResourceNames: []string{testServiceName},
-		TypeUrl:       edsType,
+		TypeUrl: edsType,
 	}
 	testCluster = &cdspb.Cluster{
 		Name:                 testServiceName,


### PR DESCRIPTION
1. Stop setting xds request.ResourceName, and always set metadata
   - ResourceName is not the same format as user's dial target. (`test_service.test_namespace.traffic_director.com` vs `test_namespace:test_service`).
   - The solution today is to always include `GrpcHostname` in metadata, with the value set to dial target.
1. Stop comparing xds response's Name with user's dial target
   - Name doesn't match user's dial target for the same reason as above
1. Set lrs request.ClusterName to be the cluster name returned from first lrs response
   - Root cause is also the same as above