### PR TITLE
client: addrConn NewStream and health check cleanup

### DIFF
--- a/clientconn.go
+++ b/clientconn.go
@@ -1243,7 +1243,7 @@ func (ac *addrConn) startHealthCheck(ctx context.Context) {
 		if ac.transport != currentTr {
 			return nil, status.Error(codes.Canceled, "the provided transport is no longer valid to use")
 		}
-		return ac.newClientStream(ctx, &StreamDesc{ServerStreams: true}, method, currentTr)
+		return newNonRetryClientStream(ctx, &StreamDesc{ServerStreams: true}, method, currentTr, ac)
 	}
 	reportHealth := func(s connectivity.State) {
 		ac.mu.Lock()

--- a/clientconn.go
+++ b/clientconn.go
@@ -1246,7 +1246,7 @@ func (ac *addrConn) startHealthCheck(ctx context.Context) {
 		ac.mu.Unlock()
 		return newNonRetryClientStream(ctx, &StreamDesc{ServerStreams: true}, method, currentTr, ac)
 	}
-	reportHealth := func(s connectivity.State) {
+	setConnectivityState := func(s connectivity.State) {
 		ac.mu.Lock()
 		defer ac.mu.Unlock()
 		if ac.transport != currentTr {
@@ -1256,7 +1256,7 @@ func (ac *addrConn) startHealthCheck(ctx context.Context) {
 	}
 	// Start the health checking stream.
 	go func() {
-		err := ac.cc.dopts.healthCheckFunc(ctx, newStream, reportHealth, healthCheckConfig.ServiceName)
+		err := ac.cc.dopts.healthCheckFunc(ctx, newStream, setConnectivityState, healthCheckConfig.ServiceName)
 		if err != nil {
 			if status.Code(err) == codes.Unimplemented {
 				if channelz.IsOn() {

--- a/clientconn.go
+++ b/clientconn.go
@@ -1239,10 +1239,11 @@ func (ac *addrConn) startHealthCheck(ctx context.Context) {
 	currentTr := ac.transport
 	newStream := func(method string) (interface{}, error) {
 		ac.mu.Lock()
-		defer ac.mu.Unlock()
 		if ac.transport != currentTr {
+			ac.mu.Unlock()
 			return nil, status.Error(codes.Canceled, "the provided transport is no longer valid to use")
 		}
+		ac.mu.Unlock()
 		return newNonRetryClientStream(ctx, &StreamDesc{ServerStreams: true}, method, currentTr, ac)
 	}
 	reportHealth := func(s connectivity.State) {

--- a/clientconn.go
+++ b/clientconn.go
@@ -1069,27 +1069,8 @@ func (ac *addrConn) resetTransport() {
 		ac.transport = newTr
 		ac.backoffIdx = 0
 
-		healthCheckConfig := ac.cc.healthCheckConfig()
-		// LB channel health checking is only enabled when all the four requirements below are met:
-		// 1. it is not disabled by the user with the WithDisableHealthCheck DialOption,
-		// 2. the internal.HealthCheckFunc is set by importing the grpc/healthcheck package,
-		// 3. a service config with non-empty healthCheckConfig field is provided,
-		// 4. the current load balancer allows it.
 		hctx, hcancel := context.WithCancel(ac.ctx)
-		healthcheckManagingState := false
-		if !ac.cc.dopts.disableHealthCheck && healthCheckConfig != nil && ac.scopts.HealthCheckEnabled {
-			if ac.cc.dopts.healthCheckFunc == nil {
-				// TODO: add a link to the health check doc in the error message.
-				grpclog.Error("the client side LB channel health check function has not been set.")
-			} else {
-				// TODO(deklerk) refactor to just return transport
-				go ac.startHealthCheck(hctx, newTr, addr, healthCheckConfig.ServiceName)
-				healthcheckManagingState = true
-			}
-		}
-		if !healthcheckManagingState {
-			ac.updateConnectivityState(connectivity.Ready)
-		}
+		ac.startHealthCheck(hctx)
 		ac.mu.Unlock()
 
 		// Block until the created transport is down. And when this happens,
@@ -1213,42 +1194,86 @@ func (ac *addrConn) createTransport(addr resolver.Address, copts transport.Conne
 	return newTr, reconnect, nil
 }
 
-func (ac *addrConn) startHealthCheck(ctx context.Context, newTr transport.ClientTransport, addr resolver.Address, serviceName string) {
-	// Set up the health check helper functions
-	newStream := func() (interface{}, error) {
-		return ac.newClientStream(ctx, &StreamDesc{ServerStreams: true}, "/grpc.health.v1.Health/Watch", newTr)
+// startHealthCheck starts the health checking stream (RPC) to watch the health
+// stats of this connection if health checking is requested and configured.
+//
+// LB channel health checking is enabled when all requirements below are met:
+// 1. it is not disabled by the user with the WithDisableHealthCheck DialOption
+// 2. internal.HealthCheckFunc is set by importing the grpc/healthcheck package
+// 3. a service config with non-empty healthCheckConfig field is provided
+// 4. the load balancer requests it
+//
+// It sets addrConn to READY if the health checking stream is not started.
+//
+// Caller must hold ac.mu.
+func (ac *addrConn) startHealthCheck(ctx context.Context) {
+	var healthcheckManagingState bool
+	defer func() {
+		if !healthcheckManagingState {
+			ac.updateConnectivityState(connectivity.Ready)
+		}
+	}()
+
+	if ac.cc.dopts.disableHealthCheck {
+		return
 	}
-	firstReady := true
+	healthCheckConfig := ac.cc.healthCheckConfig()
+	if healthCheckConfig == nil {
+		return
+	}
+	if !ac.scopts.HealthCheckEnabled {
+		return
+	}
+	healthCheckFunc := ac.cc.dopts.healthCheckFunc
+	if healthCheckFunc == nil {
+		// The health package is not imported to set health check function.
+		//
+		// TODO: add a link to the health check doc in the error message.
+		grpclog.Error("Health check is requested but health check function is not set.")
+		return
+	}
+
+	healthcheckManagingState = true
+
+	// Set up the health check helper functions.
+	currentTr := ac.transport
+	newStream := func() (interface{}, error) {
+		ac.mu.Lock()
+		defer ac.mu.Unlock()
+		if ac.transport != currentTr {
+			return nil, status.Error(codes.Canceled, "the provided transport is no longer valid to use")
+		}
+		return ac.newClientStream(ctx, &StreamDesc{ServerStreams: true}, "/grpc.health.v1.Health/Watch", currentTr)
+	}
 	reportHealth := func(ok bool) {
 		ac.mu.Lock()
 		defer ac.mu.Unlock()
-		if ac.transport != newTr {
+		if ac.transport != currentTr {
 			return
 		}
 		if ok {
-			if firstReady {
-				firstReady = false
-				ac.curAddr = addr
-			}
 			ac.updateConnectivityState(connectivity.Ready)
 		} else {
 			ac.updateConnectivityState(connectivity.TransientFailure)
 		}
 	}
-	err := ac.cc.dopts.healthCheckFunc(ctx, newStream, reportHealth, serviceName)
-	if err != nil {
-		if status.Code(err) == codes.Unimplemented {
-			if channelz.IsOn() {
-				channelz.AddTraceEvent(ac.channelzID, &channelz.TraceEventDesc{
-					Desc:     "Subchannel health check is unimplemented at server side, thus health check is disabled",
-					Severity: channelz.CtError,
-				})
+	// Start the health checking stream.
+	go func() {
+		err := ac.cc.dopts.healthCheckFunc(ctx, newStream, reportHealth, healthCheckConfig.ServiceName)
+		if err != nil {
+			if status.Code(err) == codes.Unimplemented {
+				if channelz.IsOn() {
+					channelz.AddTraceEvent(ac.channelzID, &channelz.TraceEventDesc{
+						Desc:     "Subchannel health check is unimplemented at server side, thus health check is disabled",
+						Severity: channelz.CtError,
+					})
+				}
+				grpclog.Error("Subchannel health check is unimplemented at server side, thus health check is disabled")
+			} else {
+				grpclog.Errorf("HealthCheckFunc exits with unexpected error %v", err)
 			}
-			grpclog.Error("Subchannel health check is unimplemented at server side, thus health check is disabled")
-		} else {
-			grpclog.Errorf("HealthCheckFunc exits with unexpected error %v", err)
 		}
-	}
+	}()
 }
 
 func (ac *addrConn) resetConnectBackoff() {

--- a/health/client.go
+++ b/health/client.go
@@ -26,6 +26,7 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/connectivity"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/internal"
 	"google.golang.org/grpc/internal/backoff"
@@ -51,7 +52,9 @@ func init() {
 	internal.HealthCheckFunc = clientHealthCheck
 }
 
-func clientHealthCheck(ctx context.Context, newStream func() (interface{}, error), reportHealth func(bool), service string) error {
+const healthCheckMethod = "/grpc.health.v1.Health/Watch"
+
+func clientHealthCheck(ctx context.Context, newStream func(string) (interface{}, error), reportHealth func(connectivity.State), service string) error {
 	tryCnt := 0
 
 retryConnection:
@@ -65,7 +68,7 @@ retryConnection:
 		if ctx.Err() != nil {
 			return nil
 		}
-		rawS, err := newStream()
+		rawS, err := newStream(healthCheckMethod)
 		if err != nil {
 			continue retryConnection
 		}
@@ -73,7 +76,7 @@ retryConnection:
 		s, ok := rawS.(grpc.ClientStream)
 		// Ideally, this should never happen. But if it happens, the server is marked as healthy for LBing purposes.
 		if !ok {
-			reportHealth(true)
+			reportHealth(connectivity.Ready)
 			return fmt.Errorf("newStream returned %v (type %T); want grpc.ClientStream", rawS, rawS)
 		}
 
@@ -89,19 +92,23 @@ retryConnection:
 
 			// Reports healthy for the LBing purposes if health check is not implemented in the server.
 			if status.Code(err) == codes.Unimplemented {
-				reportHealth(true)
+				reportHealth(connectivity.Ready)
 				return err
 			}
 
 			// Reports unhealthy if server's Watch method gives an error other than UNIMPLEMENTED.
 			if err != nil {
-				reportHealth(false)
+				reportHealth(connectivity.TransientFailure)
 				continue retryConnection
 			}
 
 			// As a message has been received, removes the need for backoff for the next retry by reseting the try count.
 			tryCnt = 0
-			reportHealth(resp.Status == healthpb.HealthCheckResponse_SERVING)
+			if resp.Status == healthpb.HealthCheckResponse_SERVING {
+				reportHealth(connectivity.Ready)
+			} else {
+				reportHealth(connectivity.TransientFailure)
+			}
 		}
 	}
 }

--- a/health/client.go
+++ b/health/client.go
@@ -54,6 +54,8 @@ func init() {
 
 const healthCheckMethod = "/grpc.health.v1.Health/Watch"
 
+// This function implements the protocol defined at:
+// https://github.com/grpc/grpc/blob/master/doc/health-checking.md
 func clientHealthCheck(ctx context.Context, newStream func(string) (interface{}, error), reportHealth func(connectivity.State), service string) error {
 	tryCnt := 0
 

--- a/health/client.go
+++ b/health/client.go
@@ -56,7 +56,7 @@ const healthCheckMethod = "/grpc.health.v1.Health/Watch"
 
 // This function implements the protocol defined at:
 // https://github.com/grpc/grpc/blob/master/doc/health-checking.md
-func clientHealthCheck(ctx context.Context, newStream func(string) (interface{}, error), reportHealth func(connectivity.State), service string) error {
+func clientHealthCheck(ctx context.Context, newStream func(string) (interface{}, error), setConnectivityState func(connectivity.State), service string) error {
 	tryCnt := 0
 
 retryConnection:
@@ -70,7 +70,7 @@ retryConnection:
 		if ctx.Err() != nil {
 			return nil
 		}
-		reportHealth(connectivity.Connecting)
+		setConnectivityState(connectivity.Connecting)
 		rawS, err := newStream(healthCheckMethod)
 		if err != nil {
 			continue retryConnection
@@ -79,7 +79,7 @@ retryConnection:
 		s, ok := rawS.(grpc.ClientStream)
 		// Ideally, this should never happen. But if it happens, the server is marked as healthy for LBing purposes.
 		if !ok {
-			reportHealth(connectivity.Ready)
+			setConnectivityState(connectivity.Ready)
 			return fmt.Errorf("newStream returned %v (type %T); want grpc.ClientStream", rawS, rawS)
 		}
 
@@ -95,22 +95,22 @@ retryConnection:
 
 			// Reports healthy for the LBing purposes if health check is not implemented in the server.
 			if status.Code(err) == codes.Unimplemented {
-				reportHealth(connectivity.Ready)
+				setConnectivityState(connectivity.Ready)
 				return err
 			}
 
 			// Reports unhealthy if server's Watch method gives an error other than UNIMPLEMENTED.
 			if err != nil {
-				reportHealth(connectivity.TransientFailure)
+				setConnectivityState(connectivity.TransientFailure)
 				continue retryConnection
 			}
 
 			// As a message has been received, removes the need for backoff for the next retry by reseting the try count.
 			tryCnt = 0
 			if resp.Status == healthpb.HealthCheckResponse_SERVING {
-				reportHealth(connectivity.Ready)
+				setConnectivityState(connectivity.Ready)
 			} else {
-				reportHealth(connectivity.TransientFailure)
+				setConnectivityState(connectivity.TransientFailure)
 			}
 		}
 	}

--- a/health/client.go
+++ b/health/client.go
@@ -68,6 +68,7 @@ retryConnection:
 		if ctx.Err() != nil {
 			return nil
 		}
+		reportHealth(connectivity.Connecting)
 		rawS, err := newStream(healthCheckMethod)
 		if err != nil {
 			continue retryConnection

--- a/health/client_test.go
+++ b/health/client_test.go
@@ -51,7 +51,7 @@ func TestClientHealthCheckBackoff(t *testing.T) {
 	}
 	defer func() { backoffFunc = oldBackoffFunc }()
 
-	clientHealthCheck(context.Background(), newStream, func(_ connectivity.State) {}, "test")
+	clientHealthCheck(context.Background(), newStream, func(connectivity.State) {}, "test")
 
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("Backoff durations for %v retries are %v. (expected: %v)", maxRetries, got, want)

--- a/health/client_test.go
+++ b/health/client_test.go
@@ -24,6 +24,8 @@ import (
 	"reflect"
 	"testing"
 	"time"
+
+	"google.golang.org/grpc/connectivity"
 )
 
 func TestClientHealthCheckBackoff(t *testing.T) {
@@ -35,7 +37,7 @@ func TestClientHealthCheckBackoff(t *testing.T) {
 	}
 
 	var got []time.Duration
-	newStream := func() (interface{}, error) {
+	newStream := func(string) (interface{}, error) {
 		if len(got) < maxRetries {
 			return nil, errors.New("backoff")
 		}
@@ -49,7 +51,7 @@ func TestClientHealthCheckBackoff(t *testing.T) {
 	}
 	defer func() { backoffFunc = oldBackoffFunc }()
 
-	clientHealthCheck(context.Background(), newStream, func(_ bool) {}, "test")
+	clientHealthCheck(context.Background(), newStream, func(_ connectivity.State) {}, "test")
 
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("Backoff durations for %v retries are %v. (expected: %v)", maxRetries, got, want)

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -53,11 +53,11 @@ var (
 //
 // The implementation is expected to create a health checking RPC stream by
 // calling newStream(), watch for the health status of serviceName, and report
-// it's health back by calling reportHealth().
+// it's health back by calling setConnectivityState().
 //
 // The health checking protocol is defined at:
 // https://github.com/grpc/grpc/blob/master/doc/health-checking.md
-type HealthChecker func(ctx context.Context, newStream func(string) (interface{}, error), reportHealth func(connectivity.State), serviceName string) error
+type HealthChecker func(ctx context.Context, newStream func(string) (interface{}, error), setConnectivityState func(connectivity.State), serviceName string) error
 
 const (
 	// CredsBundleModeFallback switches GoogleDefaultCreds to fallback mode.

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -23,6 +23,8 @@ package internal
 import (
 	"context"
 	"time"
+
+	"google.golang.org/grpc/connectivity"
 )
 
 var (
@@ -48,7 +50,7 @@ var (
 )
 
 // HealthChecker defines the signature of the client-side LB channel health checking function.
-type HealthChecker func(ctx context.Context, newStream func() (interface{}, error), reportHealth func(bool), serviceName string) error
+type HealthChecker func(ctx context.Context, newStream func(string) (interface{}, error), reportHealth func(connectivity.State), serviceName string) error
 
 const (
 	// CredsBundleModeFallback switches GoogleDefaultCreds to fallback mode.

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -50,6 +50,13 @@ var (
 )
 
 // HealthChecker defines the signature of the client-side LB channel health checking function.
+//
+// The implementation is expected to create a health checking RPC stream by
+// calling newStream(), watch for the health status of serviceName, and report
+// it's health back by calling reportHealth().
+//
+// The health checking protocol is defined at:
+// https://github.com/grpc/grpc/blob/master/doc/health-checking.md
 type HealthChecker func(ctx context.Context, newStream func(string) (interface{}, error), reportHealth func(connectivity.State), serviceName string) error
 
 const (

--- a/stream.go
+++ b/stream.go
@@ -975,7 +975,7 @@ func (a *csAttempt) finish(err error) {
 // - no retry
 // - no service config (or wait for service config)
 // - no tracing or stats
-func (ac *addrConn) newClientStream(ctx context.Context, desc *StreamDesc, method string, t transport.ClientTransport, opts ...CallOption) (_ ClientStream, err error) {
+func newNonRetryClientStream(ctx context.Context, desc *StreamDesc, method string, t transport.ClientTransport, ac *addrConn, opts ...CallOption) (_ ClientStream, err error) {
 	if t == nil {
 		// TODO: return RPC error here?
 		return nil, errors.New("transport provided is nil")

--- a/stream.go
+++ b/stream.go
@@ -964,7 +964,7 @@ func (a *csAttempt) finish(err error) {
 	a.mu.Unlock()
 }
 
-// newClientStream creates a ClientConn with the specified transport, on the
+// newClientStream creates a ClientStream with the specified transport, on the
 // given addrConn.
 //
 // It's expected that the given transport is either the same one in addrConn, or

--- a/test/healthcheck_test.go
+++ b/test/healthcheck_test.go
@@ -592,7 +592,7 @@ func (s) TestHealthCheckWithClientConnClose(t *testing.T) {
 // This test is to test the logic in the createTransport after the health check function returns which
 // closes the skipReset channel(since it has not been closed inside health check func) to unblock
 // onGoAway/onClose goroutine.
-func (s) TestHealthCheckWithoutReportHealthCalledAddrConnShutDown(t *testing.T) {
+func (s) TestHealthCheckWithoutSetConnectivityStateCalledAddrConnShutDown(t *testing.T) {
 	hcEnterChan, hcExitChan, testHealthCheckFuncWrapper := setupHealthCheckWrapper()
 
 	_, lis, ts, deferFunc, err := setupServer(&svrConfig{
@@ -602,7 +602,7 @@ func (s) TestHealthCheckWithoutReportHealthCalledAddrConnShutDown(t *testing.T) 
 					"this special Watch function only handles request with service name to be \"delay\"")
 			}
 			// Do nothing to mock a delay of health check response from server side.
-			// This case is to help with the test that covers the condition that reportHealth is not
+			// This case is to help with the test that covers the condition that setConnectivityState is not
 			// called inside HealthCheckFunc before the func returns.
 			select {
 			case <-stream.Context().Done():
@@ -654,7 +654,7 @@ func (s) TestHealthCheckWithoutReportHealthCalledAddrConnShutDown(t *testing.T) 
 	// trigger teardown of the ac, ac in SHUTDOWN state
 	r.UpdateState(resolver.State{Addresses: []resolver.Address{}, ServiceConfig: sc})
 
-	// The health check func should exit without calling the reportHealth func, as server hasn't sent
+	// The health check func should exit without calling the setConnectivityState func, as server hasn't sent
 	// any response.
 	select {
 	case <-hcExitChan:
@@ -668,7 +668,7 @@ func (s) TestHealthCheckWithoutReportHealthCalledAddrConnShutDown(t *testing.T) 
 // This test is to test the logic in the createTransport after the health check function returns which
 // closes the allowedToReset channel(since it has not been closed inside health check func) to unblock
 // onGoAway/onClose goroutine.
-func (s) TestHealthCheckWithoutReportHealthCalled(t *testing.T) {
+func (s) TestHealthCheckWithoutSetConnectivityStateCalled(t *testing.T) {
 	hcEnterChan, hcExitChan, testHealthCheckFuncWrapper := setupHealthCheckWrapper()
 
 	s, lis, ts, deferFunc, err := setupServer(&svrConfig{
@@ -678,7 +678,7 @@ func (s) TestHealthCheckWithoutReportHealthCalled(t *testing.T) {
 					"this special Watch function only handles request with service name to be \"delay\"")
 			}
 			// Do nothing to mock a delay of health check response from server side.
-			// This case is to help with the test that covers the condition that reportHealth is not
+			// This case is to help with the test that covers the condition that setConnectivityState is not
 			// called inside HealthCheckFunc before the func returns.
 			select {
 			case <-stream.Context().Done():
@@ -728,7 +728,7 @@ func (s) TestHealthCheckWithoutReportHealthCalled(t *testing.T) {
 	// trigger transport being closed
 	s.Stop()
 
-	// The health check func should exit without calling the reportHealth func, as server hasn't sent
+	// The health check func should exit without calling the setConnectivityState func, as server hasn't sent
 	// any response.
 	select {
 	case <-hcExitChan:


### PR DESCRIPTION
1. Make newStream() take string (for method) so it can be used for out-of-band load reporting (which will also be a stream on an addrConn)
1. move healthcheck (streaming) related functions into a function
1. make ac.newClientStream not a method of addrConn
   - so it's (should be) easier to merge with cc.newStream()