### PR TITLE
test: fix GoAwayThenClose by wait for cc state change

### DIFF
--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -7165,7 +7165,7 @@ func (s) TestGoAwayThenClose(t *testing.T) {
 
 	// Do a bunch of RPCs, make sure it stays stable. These should go to connection 2.
 	for i := 0; i < 10; i++ {
-		if _, err := client.UnaryCall(ctx, &testpb.SimpleRequest{}); err != nil {
+		if _, err := client.UnaryCall(ctx, &testpb.SimpleRequest{}, grpc.WaitForReady(true)); err != nil {
 			t.Fatalf("UnaryCall(_) = _, %v; want _, nil", err)
 		}
 	}

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -7163,9 +7163,14 @@ func (s) TestGoAwayThenClose(t *testing.T) {
 		t.Fatal("expected the stream to die, but got a successful Recv")
 	}
 
+	// Connection was dialed, so ac is either in connecting or ready. Because there's a race
+	// between ac state change and balancer state change, so cc could still be transient
+	// failure. This wait make sure cc is at least in connecting, and RPCs won't fail after
+	// this.
+	cc.WaitForStateChange(ctx, connectivity.TransientFailure)
 	// Do a bunch of RPCs, make sure it stays stable. These should go to connection 2.
 	for i := 0; i < 10; i++ {
-		if _, err := client.UnaryCall(ctx, &testpb.SimpleRequest{}, grpc.WaitForReady(true)); err != nil {
+		if _, err := client.UnaryCall(ctx, &testpb.SimpleRequest{}); err != nil {
 			t.Fatalf("UnaryCall(_) = _, %v; want _, nil", err)
 		}
 	}


### PR DESCRIPTION
In the end of the test, 10 RPCs are made to make sure data is sent to
the second server. The first RPC of these 10 is made right after the
second server's listener receives a connection. But at this time, the
connectivity state on the client side is not set to READY yet (though
ac's state should be either connecting or ready, the race between ac
and balancer could cause cc to still be in transient failure). So the
first RPC fails due to transient failure, but the following 9 will
succeed.

fixes #2822 