### PR TITLE
xds: update fallback behavior

### DIFF
--- a/balancer/xds/xds_client_test.go
+++ b/balancer/xds/xds_client_test.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/ptypes"
 	anypb "github.com/golang/protobuf/ptypes/any"
 	durationpb "github.com/golang/protobuf/ptypes/duration"
 	structpb "github.com/golang/protobuf/ptypes/struct"
@@ -150,6 +151,9 @@ var (
 				Priority: 0,
 			},
 		},
+		Policy: &edspb.ClusterLoadAssignment_Policy{
+			EndpointStaleAfter: ptypes.DurationProto(time.Millisecond * 100),
+		},
 	}
 	marshaledClusterLoadAssignment, _ = proto.Marshal(testClusterLoadAssignment)
 	testEDSResp                       = &discoverypb.DiscoveryResponse{
@@ -174,7 +178,9 @@ var (
 				Priority: 0,
 			},
 		},
-		Policy: nil,
+		Policy: &edspb.ClusterLoadAssignment_Policy{
+			EndpointStaleAfter: ptypes.DurationProto(time.Millisecond * 100),
+		},
 	}
 	marshaledClusterLoadAssignmentWithoutEndpoints, _ = proto.Marshal(testClusterLoadAssignmentWithoutEndpoints)
 	testEDSRespWithoutEndpoints                       = &discoverypb.DiscoveryResponse{

--- a/balancer/xds/xds_test.go
+++ b/balancer/xds/xds_test.go
@@ -584,7 +584,7 @@ func (s) TestXdsBalancerHandlerSubConnStateChange(t *testing.T) {
 	}
 }
 
-func (s) TestXdsBalancerFallBackSignalFromEdsBalancer(t *testing.T) {
+func (s) TestXdsBalancerFallBackWithStaleTimeout(t *testing.T) {
 	originalNewEDSBalancer := newEDSBalancer
 	newEDSBalancer = newFakeEDSBalancer
 	defer func() {


### PR DESCRIPTION
Implement the following changes to xds fallback behavior:

- Cancel fallback or fallback monitoring when eds response indicates 100% drop.

- Remove the fallback condition when losing contact with both remote traffic director and backends.

- Get the stale timeout from eds response and trigger fallback when no response has been received from remote traffic director after losing contact + stale timeout.

Since there are following updates for the fallback behavior, I leave some TODO notes in the code. A quick glance at some of the following up updates:

- Except for eds 100% drop case, at startup cancel fallback monitoring only after we connect to at least one backend (READY reported from edsbalancer); 

- Graceful transition between balancers: not closing old ones util new ones reports READY.


