### PR TITLE
status: Implement *statusError.Is

### DIFF
--- a/status/status.go
+++ b/status/status.go
@@ -58,6 +58,17 @@ func (se *statusError) GRPCStatus() *Status {
 	return &Status{s: (*spb.Status)(se)}
 }
 
+// Is implements future error.Is functionality.
+// A statusError is equivalent if the code and message are identical.
+func (se *statusError) Is(target error) bool {
+	tse, ok := target.(*statusError)
+	if !ok {
+		return false
+	}
+
+	return proto.Equal((*spb.Status)(se), (*spb.Status)(tse))
+}
+
 // Status represents an RPC status code, message, and details.  It is immutable
 // and should be created with New, Newf, or FromProto.
 type Status struct {

--- a/status/status_ext_test.go
+++ b/status/status_ext_test.go
@@ -1,0 +1,72 @@
+/*
+ *
+ * Copyright 2019 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package status_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/golang/protobuf/proto"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/test/grpc_testing"
+)
+
+func errWithDetails(t *testing.T, s *status.Status, details ...proto.Message) error {
+	t.Helper()
+	res, err := s.WithDetails(details...)
+	if err != nil {
+		t.Fatalf("(%v).WithDetails(%v) = %v, %v; want _, <nil>", s, details, res, err)
+	}
+	return res.Err()
+}
+
+func TestErrorIs(t *testing.T) {
+	// Test errors.
+	testErr := status.Error(codes.Internal, "internal server error")
+	testErrWithDetails := errWithDetails(t, status.New(codes.Internal, "internal server error"), &grpc_testing.Empty{})
+
+	// Test cases.
+	testCases := []struct {
+		err1, err2 error
+		want       bool
+	}{
+		{err1: testErr, err2: nil, want: false},
+		{err1: testErr, err2: status.Error(codes.Internal, "internal server error"), want: true},
+		{err1: testErr, err2: status.Error(codes.Internal, "internal error"), want: false},
+		{err1: testErr, err2: status.Error(codes.Unknown, "internal server error"), want: false},
+		{err1: testErr, err2: errors.New("non-grpc error"), want: false},
+		{err1: testErrWithDetails, err2: status.Error(codes.Internal, "internal server error"), want: false},
+		{err1: testErrWithDetails, err2: errWithDetails(t, status.New(codes.Internal, "internal server error"), &grpc_testing.Empty{}), want: true},
+		{err1: testErrWithDetails, err2: errWithDetails(t, status.New(codes.Internal, "internal server error"), &grpc_testing.Empty{}, &grpc_testing.Empty{}), want: false},
+	}
+
+	for _, tc := range testCases {
+		isError, ok := tc.err1.(interface{ Is(target error) bool })
+		if !ok {
+			t.Errorf("(%v) does not implement is", tc.err1)
+			continue
+		}
+
+		is := isError.Is(tc.err2)
+		if is != tc.want {
+			t.Errorf("(%v).Is(%v) = %t; want %t", tc.err1, tc.err2, is, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
In the [go2 error proposal](https://go.googlesource.com/proposal/+/master/design/29934-error-values.md) the `Is` function adds matching of error targets.
[On this line](https://github.com/golang/exp/blob/sumdb/v0.0.2/errors/wrap.go#L58) of the proposal implementation, there is an interface check for Is, to provide
custom implementation of this matching.

gRPC status errors that are defined as a var, currently don't successfully work
with this function when crossing the gRPC boundary, as the pointer values will
not be equivalent.

Ideally, the following should work across gRPC boundaries:
```
var ErrAuthInvalidToken = status.Error(codes.Unauthenticated, "Invalid token")
_, err := grpcClient.Call(...) // Returns the above
errors.Is(err, ErrAuthInvalidToken) == true
```