### PR TITLE
Some improvements to test code.

### DIFF
--- a/test/channelz_test.go
+++ b/test/channelz_test.go
@@ -41,7 +41,6 @@ import (
 	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/resolver"
 	"google.golang.org/grpc/resolver/manual"
-	"google.golang.org/grpc/serviceconfig"
 	"google.golang.org/grpc/status"
 	testpb "google.golang.org/grpc/test/grpc_testing"
 	"google.golang.org/grpc/testdata"
@@ -50,16 +49,6 @@ import (
 func czCleanupWrapper(cleanup func() error, t *testing.T) {
 	if err := cleanup(); err != nil {
 		t.Error(err)
-	}
-}
-
-func (te *test) startServers(ts testpb.TestServiceServer, num int) {
-	for i := 0; i < num; i++ {
-		te.startServer(ts)
-		te.srvs = append(te.srvs, te.srv.(*grpc.Server))
-		te.srvAddrs = append(te.srvAddrs, te.srvAddr)
-		te.srv = nil
-		te.srvAddr = ""
 	}
 }
 
@@ -2013,12 +2002,4 @@ func (s) TestCZTraceTopChannelDeletionTraceClear(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-}
-
-func parseCfg(s string) serviceconfig.Config {
-	c, err := serviceconfig.Parse(s)
-	if err != nil {
-		panic(fmt.Sprintf("Error parsing config %q: %v", s, err))
-	}
-	return c
 }

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -3535,7 +3535,7 @@ func testMultipleSetHeaderStreamingRPCError(t *testing.T, e env) {
 	}
 }
 
-// TestMalformedHTTP2Metedata verfies the returned error when the client
+// TestMalformedHTTP2Metadata verfies the returned error when the client
 // sends an illegal metadata.
 func (s) TestMalformedHTTP2Metadata(t *testing.T) {
 	for _, e := range listTestEnv() {


### PR DESCRIPTION
    - end2end_test.go improvements:
      - Added an option to use the default health service implementation, instead
        of each test creating a new health.Server and passing it in.
      - Seperated and documented the options for client and server sides.
      - Better support for multiple grpc.Servers. This will be used in other
        improvements that I have in the works.
      - Handled a TODO to remove some http related code once Go1.6 and Go1.7
        support are gone.
      - Refactored functionality testing health checking.
    - healthcheck_test.go improvements:
      - Made most tests use the default health service implementation
        instead of a fake one defined in the test file.
      - Refactored code and made the tests smaller and easier to read.
    - Moved some common functionality from channelz_test.go to end2end_test.go
