### PR TITLE
test: end2end test cleanup http handler server

### DIFF
--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -661,23 +661,18 @@ func (te *test) listenAndServe(ts testpb.TestServiceServer, listen func(network,
 		}
 		cert, err := tls.LoadX509KeyPair(testdata.Path("server1.pem"), testdata.Path("server1.key"))
 		if err != nil {
-			te.t.Fatal("Error creating TLS certificate: ", err)
+			te.t.Fatal("tls.LoadX509KeyPair(server1.pem, server1.key) failed: ", err)
 		}
 		hs := &http.Server{
-			Handler: s,
+			Handler:   s,
+			TLSConfig: &tls.Config{Certificates: []tls.Certificate{cert}},
 		}
-		err = http2.ConfigureServer(hs, &http2.Server{
-			MaxConcurrentStreams: te.maxStream,
-		})
-		if err != nil {
-			te.t.Fatal("error starting http2 server: ", err)
+		if err := http2.ConfigureServer(hs, &http2.Server{MaxConcurrentStreams: te.maxStream}); err != nil {
+			te.t.Fatal("http2.ConfigureServer(_, _) failed: ", err)
 		}
-		hs.TLSConfig.Certificates = []tls.Certificate{cert}
+		te.srv = wrapHS{hs}
 		tlsListener := tls.NewListener(lis, hs.TLSConfig)
-		whs := &wrapHS{Listener: tlsListener, s: hs, conns: make(map[net.Conn]bool)}
-		te.srv = whs
-		go hs.Serve(whs)
-
+		go hs.Serve(tlsListener)
 		return lis
 	}
 
@@ -685,66 +680,21 @@ func (te *test) listenAndServe(ts testpb.TestServiceServer, listen func(network,
 	return lis
 }
 
-// TODO: delete wrapHS and wrapConn when Go1.6 and Go1.7 support are gone and
-// call s.Close and s.Shutdown instead.
 type wrapHS struct {
-	sync.Mutex
-	net.Listener
-	s     *http.Server
-	conns map[net.Conn]bool
+	s *http.Server
 }
 
-func (w *wrapHS) Accept() (net.Conn, error) {
-	c, err := w.Listener.Accept()
-	if err != nil {
-		return nil, err
-	}
-	w.Lock()
-	if w.conns == nil {
-		w.Unlock()
-		c.Close()
-		return nil, errors.New("connection after listener closed")
-	}
-	w.conns[&wrapConn{Conn: c, hs: w}] = true
-	w.Unlock()
-	return c, nil
+func (w wrapHS) GracefulStop() {
+	w.s.Shutdown(context.Background())
 }
 
-func (w *wrapHS) Stop() {
-	w.Listener.Close()
-	w.Lock()
-	conns := w.conns
-	w.conns = nil
-	w.Unlock()
-	for c := range conns {
-		c.Close()
-	}
-}
-
-// Poll for now..
-func (w *wrapHS) GracefulStop() {
-	w.Listener.Close()
-	for {
-		w.Lock()
-		l := len(w.conns)
-		w.Unlock()
-		if l == 0 {
-			return
-		}
-		time.Sleep(50 * time.Millisecond)
-	}
+func (w wrapHS) Stop() {
+	w.s.Close()
 }
 
 type wrapConn struct {
 	net.Conn
 	hs *wrapHS
-}
-
-func (w *wrapConn) Close() error {
-	w.hs.Lock()
-	delete(w.hs.conns, w.Conn)
-	w.hs.Unlock()
-	return w.Conn.Close()
 }
 
 func (te *test) startServerWithConnControl(ts testpb.TestServiceServer) *listenerWrapper {

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -692,11 +692,6 @@ func (w wrapHS) Stop() {
 	w.s.Close()
 }
 
-type wrapConn struct {
-	net.Conn
-	hs *wrapHS
-}
-
 func (te *test) startServerWithConnControl(ts testpb.TestServiceServer) *listenerWrapper {
 	l := te.listenAndServe(ts, listenWithConnControl)
 	return l.(*listenerWrapper)


### PR DESCRIPTION
#2330 

- Removed some old code which has a TODO asking for it's removal once Go1.6 and Go1.7 support is gone.
- Cleaned up a couple of error messages along with it.