### PR TITLE
test: end2end test improvements separate server and client configs.

### DIFF
--- a/test/channelz_test.go
+++ b/test/channelz_test.go
@@ -41,7 +41,6 @@ import (
 	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/resolver"
 	"google.golang.org/grpc/resolver/manual"
-	"google.golang.org/grpc/serviceconfig"
 	"google.golang.org/grpc/status"
 	testpb "google.golang.org/grpc/test/grpc_testing"
 	"google.golang.org/grpc/testdata"
@@ -50,16 +49,6 @@ import (
 func czCleanupWrapper(cleanup func() error, t *testing.T) {
 	if err := cleanup(); err != nil {
 		t.Error(err)
-	}
-}
-
-func (te *test) startServers(ts testpb.TestServiceServer, num int) {
-	for i := 0; i < num; i++ {
-		te.startServer(ts)
-		te.srvs = append(te.srvs, te.srv.(*grpc.Server))
-		te.srvAddrs = append(te.srvAddrs, te.srvAddr)
-		te.srv = nil
-		te.srvAddr = ""
 	}
 }
 
@@ -2013,12 +2002,4 @@ func (s) TestCZTraceTopChannelDeletionTraceClear(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-}
-
-func parseCfg(s string) serviceconfig.Config {
-	c, err := serviceconfig.Parse(s)
-	if err != nil {
-		panic(fmt.Sprintf("Error parsing config %q: %v", s, err))
-	}
-	return c
 }

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -480,12 +480,13 @@ type test struct {
 	// The following knobs are for the server-side, and should be set after
 	// calling newTest() and before calling startServer().
 
-	// whether or not to expose the server's health via the default health service implementation.
+	// whether or not to expose the server's health via the default health
+	// service implementation.
 	enableHealthServer bool
-	// In almost all cases, one should set the 'enableHealthServer' flag on the
-	// testServer to expose the server's health using the default health service
-	// implementation.. This should only be used when a non-default health
-	// service implementation is required.
+	// In almost all cases, one should set the 'enableHealthServer' flag above to
+	// expose the server's health using the default health service
+	// implementation. This should only be used when a non-default health service
+	// implementation is required.
 	healthServer            healthpb.HealthServer
 	maxStream               uint32
 	tapHandle               tap.ServerInHandle

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -749,15 +749,6 @@ func (te *test) startServers(ts testpb.TestServiceServer, num int) {
 	}
 }
 
-// setHealthServingStatus is a helper function to set the health status.
-func (te *test) setHealthServingStatus(service string, status healthpb.HealthCheckResponse_ServingStatus) {
-	if te.hSrv != nil {
-		if hs, ok := te.hSrv.(*health.Server); ok {
-			hs.SetServingStatus(service, status)
-		}
-	}
-}
-
 type nopCompressor struct {
 	grpc.Compressor
 }

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -568,20 +568,8 @@ func (te *test) tearDown() {
 	if te.srv != nil {
 		te.srv.Stop()
 	}
-	if te.hSrv != nil {
-		if hs, ok := te.hSrv.(*health.Server); ok {
-			hs.Shutdown()
-		}
-	}
 	for _, s := range te.srvs {
 		s.Stop()
-	}
-	for _, hSrv := range te.hSrvs {
-		if hSrv != nil {
-			if hs, ok := hSrv.(*health.Server); ok {
-				hs.Shutdown()
-			}
-		}
 	}
 }
 


### PR DESCRIPTION
#2330
- Seperated and documented the options for client and server sides.
- Better support for multiple grpc.Servers. This will be used in other
  improvements that I have in the works.
- Moved some common functionality from channelz_test.go to
  end2end_test.go.
- Added an option to use the default health service implementation, instead
 of each test creating a new health.Server and passing it in. The
 individual tests have not been changed in this PR. I will do that in a
 follow up PR to keep the changes to a reasonable size.
- Fixed one of the tests which had to be fixed because of the separation
  of client and server configs.