### PR TITLE
Make healthcheck tests in end2end_test.go more readable.

### DIFF
--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -2587,7 +2587,7 @@ func testHealthWatchMultipleClients(t *testing.T, e env) {
 
 // TestHealthWatchSameStatusmakes a streaming Watch() RPC on the health server
 // and makes sure that the health status of the server is as expected after
-// mutliple calls to SetServingStatus with the same status.
+// multiple calls to SetServingStatus with the same status.
 func (s) TestHealthWatchSameStatus(t *testing.T) {
 	for _, e := range listTestEnv() {
 		testHealthWatchSameStatus(t, e)


### PR DESCRIPTION
- Made these tests use the default health service implementation
  wherever possible.
- Refactored some common code used in these tests into helper functions.
- Added function comments for all these tests to improve readability.

In a follow up PR, I will be moving all these tests into
healthcheck_test.go.

#2330