### PR TITLE
proxy: add support for digest auth

### DIFF
--- a/digest.go
+++ b/digest.go
@@ -1,0 +1,194 @@
+/*
+ *
+ * Copyright 2013 M-Lab
+ * Copyright 2019 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/*
+ * digest.go is based on bobziuchkovski/digest
+ * Apache License, Version 2.0
+ * Copyright 2013 M-Lab
+ * See:
+ * https://github.com/bobziuchkovski/digest/blob/master/digest.go
+ * https://code.google.com/p/mlab-ns2/gae/ns/digest
+ */
+
+package grpc
+
+import (
+	"crypto/md5"
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+var (
+	// ErrBadChallenge indicates the received challenged is bad.
+	ErrBadChallenge = errors.New("Challenge is bad")
+
+	// ErrAlgNotImplemented indicates the algorithm requested by the server is not implemented.
+	ErrAlgNotImplemented = errors.New("Alg not implemented")
+)
+
+type digestChallenge struct {
+	Realm     string
+	Domain    string
+	Nonce     string
+	Opaque    string
+	Stale     string
+	Algorithm string
+	Qop       string
+}
+
+type digestCredentials struct {
+	Username   string
+	Realm      string
+	Nonce      string
+	DigestURI  string
+	Algorithm  string
+	Cnonce     string
+	Opaque     string
+	MessageQop string
+	NonceCount int
+	method     string
+	password   string
+}
+
+func parseChallenge(input string) (*digestChallenge, error) {
+	const ws = " \n\r\t"
+	const qs = `"`
+	s := strings.Trim(input, ws)
+	if !strings.HasPrefix(s, "Digest ") {
+		return nil, ErrBadChallenge
+	}
+	s = strings.Trim(s[7:], ws)
+	sl := strings.Split(s, ", ")
+	c := &digestChallenge{
+		Algorithm: "MD5",
+	}
+	var r []string
+	for i := range sl {
+		r = strings.SplitN(sl[i], "=", 2)
+		switch r[0] {
+		case "realm":
+			c.Realm = strings.Trim(r[1], qs)
+		case "domain":
+			c.Domain = strings.Trim(r[1], qs)
+		case "nonce":
+			c.Nonce = strings.Trim(r[1], qs)
+		case "opaque":
+			c.Opaque = strings.Trim(r[1], qs)
+		case "stale":
+			c.Stale = strings.Trim(r[1], qs)
+		case "algorithm":
+			c.Algorithm = strings.Trim(r[1], qs)
+		case "qop":
+			//TODO(gavaletz) should be an array of strings?
+			c.Qop = strings.Trim(r[1], qs)
+		default:
+			return nil, ErrBadChallenge
+		}
+	}
+	return c, nil
+}
+
+func newDigestCredentials(req *http.Request, c *digestChallenge, username, password string) *digestCredentials {
+	return &digestCredentials{
+		Username:   username,
+		Realm:      c.Realm,
+		Nonce:      c.Nonce,
+		DigestURI:  fmt.Sprintf("%s", req.URL.Host),
+		Algorithm:  c.Algorithm,
+		Opaque:     c.Opaque,
+		MessageQop: c.Qop, // "auth" must be a single value
+		NonceCount: 0,
+		method:     req.Method,
+		password:   password,
+	}
+}
+
+func h(data string) string {
+	hf := md5.New()
+	io.WriteString(hf, data)
+	return fmt.Sprintf("%x", hf.Sum(nil))
+}
+
+func kd(secret, data string) string {
+	return h(fmt.Sprintf("%s:%s", secret, data))
+}
+
+func (c *digestCredentials) ha1() string {
+	return h(fmt.Sprintf("%s:%s:%s", c.Username, c.Realm, c.password))
+}
+
+func (c *digestCredentials) ha2() string {
+	return h(fmt.Sprintf("%s:%s", c.method, c.DigestURI))
+}
+
+func (c *digestCredentials) resp(cnonce string) (string, error) {
+	c.NonceCount++
+	if c.MessageQop == "auth" {
+		if cnonce != "" {
+			c.Cnonce = cnonce
+		} else {
+			b := make([]byte, 8)
+			io.ReadFull(rand.Reader, b)
+			c.Cnonce = fmt.Sprintf("%x", b)[:16]
+		}
+		return kd(c.ha1(), fmt.Sprintf("%s:%08x:%s:%s:%s",
+			c.Nonce, c.NonceCount, c.Cnonce, c.MessageQop, c.ha2())), nil
+	} else if c.MessageQop == "" {
+		return kd(c.ha1(), fmt.Sprintf("%s:%s", c.Nonce, c.ha2())), nil
+	}
+	return "", ErrAlgNotImplemented
+}
+
+func (c *digestCredentials) authorize() (string, error) {
+	// Note that this is only implemented for MD5 and NOT MD5-sess.
+	// MD5-sess is rarely supported and those that do are a big mess.
+	if c.Algorithm != "MD5" {
+		return "", ErrAlgNotImplemented
+	}
+	// Note that this is NOT implemented for "qop=auth-int".  Similarly the
+	// auth-int server side implementations that do exist are a mess.
+	if c.MessageQop != "auth" && c.MessageQop != "" {
+		return "", ErrAlgNotImplemented
+	}
+	resp, err := c.resp("")
+	if err != nil {
+		return "", ErrAlgNotImplemented
+	}
+	sl := []string{fmt.Sprintf(`username="%s"`, c.Username)}
+	sl = append(sl, fmt.Sprintf(`realm="%s"`, c.Realm))
+	sl = append(sl, fmt.Sprintf(`nonce="%s"`, c.Nonce))
+	sl = append(sl, fmt.Sprintf(`uri="%s"`, c.DigestURI))
+	sl = append(sl, fmt.Sprintf(`response="%s"`, resp))
+	if c.Algorithm != "" {
+		sl = append(sl, fmt.Sprintf(`algorithm="%s"`, c.Algorithm))
+	}
+	if c.Opaque != "" {
+		sl = append(sl, fmt.Sprintf(`opaque="%s"`, c.Opaque))
+	}
+	if c.MessageQop != "" {
+		sl = append(sl, fmt.Sprintf("qop=%s", c.MessageQop))
+		sl = append(sl, fmt.Sprintf("nc=%08x", c.NonceCount))
+		sl = append(sl, fmt.Sprintf(`cnonce="%s"`, c.Cnonce))
+	}
+	return fmt.Sprintf("Digest %s", strings.Join(sl, ", ")), nil
+}

--- a/digest.go
+++ b/digest.go
@@ -40,10 +40,10 @@ import (
 
 var (
 	// ErrBadChallenge indicates the received challenged is bad.
-	ErrBadChallenge = errors.New("Challenge is bad")
+	ErrBadChallenge = errors.New("challenge is bad")
 
 	// ErrAlgNotImplemented indicates the algorithm requested by the server is not implemented.
-	ErrAlgNotImplemented = errors.New("Alg not implemented")
+	ErrAlgNotImplemented = errors.New("algorithm not implemented")
 )
 
 type digestChallenge struct {
@@ -116,7 +116,7 @@ func newDigestCredentials(req *http.Request, c *digestChallenge, username, passw
 		Username:   username,
 		Realm:      c.Realm,
 		Nonce:      c.Nonce,
-		DigestURI:  fmt.Sprintf("%s", req.URL.Host),
+		DigestURI:  req.URL.Host,
 		Algorithm:  c.Algorithm,
 		Opaque:     c.Opaque,
 		MessageQop: c.Qop, // "auth" must be a single value

--- a/digest_test.go
+++ b/digest_test.go
@@ -49,17 +49,17 @@ var cred = &digestCredentials{
 var cnonce = "0a4f113b"
 
 func (s) TestH(t *testing.T) {
-	r1 := h("Mufasa:testrealm@host.com:Circle Of Life")
+	r1 := h("Mufasa:testrealm@host.com:Circle Of Life", "MD5")
 	if r1 != "939e7578ed9e3c518a452acee763bce9" {
 		t.Fail()
 	}
 
-	r2 := h("GET:/dir/index.html")
+	r2 := h("GET:/dir/index.html", "MD5")
 	if r2 != "39aff3a2bab6126f332b942af96d3366" {
 		t.Fail()
 	}
 
-	r3 := h(fmt.Sprintf("%s:dcd98b7102dd2f0e8b11d0f600bfb0c093:00000001:0a4f113b:auth:%s", r1, r2))
+	r3 := h(fmt.Sprintf("%s:dcd98b7102dd2f0e8b11d0f600bfb0c093:00000001:0a4f113b:auth:%s", r1, r2), "MD5")
 	if r3 != "6629fae49393a05397450978507c4ef1" {
 		t.Fail()
 	}
@@ -67,7 +67,8 @@ func (s) TestH(t *testing.T) {
 
 func (s) TestKd(t *testing.T) {
 	r1 := kd("939e7578ed9e3c518a452acee763bce9",
-		"dcd98b7102dd2f0e8b11d0f600bfb0c093:00000001:0a4f113b:auth:39aff3a2bab6126f332b942af96d3366")
+		"dcd98b7102dd2f0e8b11d0f600bfb0c093:00000001:0a4f113b:auth:39aff3a2bab6126f332b942af96d3366",
+		"MD5")
 	if r1 != "6629fae49393a05397450978507c4ef1" {
 		t.Fail()
 	}

--- a/digest_test.go
+++ b/digest_test.go
@@ -1,0 +1,98 @@
+// +build !race
+
+/*
+ *
+ * Copyright 2013 M-Lab
+ * Copyright 2019 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/*
+ * digest_test.go is based on bobziuchkovski/digest
+ * Apache License, Version 2.0
+ * Copyright 2013 M-Lab
+ * See:
+ * https://github.com/bobziuchkovski/digest/blob/master/digest_test.go
+ * https://code.google.com/p/mlab-ns2/gae/ns/digest
+ */
+package grpc
+
+import (
+	"fmt"
+	"testing"
+)
+
+var cred = &digestCredentials{
+	Username:   "Mufasa",
+	Realm:      "testrealm@host.com",
+	Nonce:      "dcd98b7102dd2f0e8b11d0f600bfb0c093",
+	DigestURI:  "/dir/index.html",
+	Algorithm:  "MD5",
+	Opaque:     "5ccc069c403ebaf9f0171e9517f40e41",
+	MessageQop: "auth",
+	method:     "GET",
+	password:   "Circle Of Life",
+}
+
+var cnonce = "0a4f113b"
+
+func (s) TestH(t *testing.T) {
+	r1 := h("Mufasa:testrealm@host.com:Circle Of Life")
+	if r1 != "939e7578ed9e3c518a452acee763bce9" {
+		t.Fail()
+	}
+
+	r2 := h("GET:/dir/index.html")
+	if r2 != "39aff3a2bab6126f332b942af96d3366" {
+		t.Fail()
+	}
+
+	r3 := h(fmt.Sprintf("%s:dcd98b7102dd2f0e8b11d0f600bfb0c093:00000001:0a4f113b:auth:%s", r1, r2))
+	if r3 != "6629fae49393a05397450978507c4ef1" {
+		t.Fail()
+	}
+}
+
+func (s) TestKd(t *testing.T) {
+	r1 := kd("939e7578ed9e3c518a452acee763bce9",
+		"dcd98b7102dd2f0e8b11d0f600bfb0c093:00000001:0a4f113b:auth:39aff3a2bab6126f332b942af96d3366")
+	if r1 != "6629fae49393a05397450978507c4ef1" {
+		t.Fail()
+	}
+}
+
+func (s) TestHa1(t *testing.T) {
+	r1 := cred.ha1()
+	if r1 != "939e7578ed9e3c518a452acee763bce9" {
+		t.Fail()
+	}
+}
+
+func (s) TestHa2(t *testing.T) {
+	r1 := cred.ha2()
+	if r1 != "39aff3a2bab6126f332b942af96d3366" {
+		t.Fail()
+	}
+}
+
+func (s) TestResp(t *testing.T) {
+	r1, err := cred.resp(cnonce)
+	if err != nil {
+		t.Fail()
+	}
+	if r1 != "6629fae49393a05397450978507c4ef1" {
+		t.Fail()
+	}
+}

--- a/digest_test.go
+++ b/digest_test.go
@@ -34,7 +34,7 @@ import (
 	"testing"
 )
 
-var cred = &digestCredentials{
+var credExample = digestCredentials{
 	Username:   "Mufasa",
 	Realm:      "testrealm@host.com",
 	Nonce:      "dcd98b7102dd2f0e8b11d0f600bfb0c093",
@@ -75,6 +75,7 @@ func (s) TestKd(t *testing.T) {
 }
 
 func (s) TestHa1(t *testing.T) {
+	cred := credExample
 	r1 := cred.ha1()
 	if r1 != "939e7578ed9e3c518a452acee763bce9" {
 		t.Fail()
@@ -82,6 +83,7 @@ func (s) TestHa1(t *testing.T) {
 }
 
 func (s) TestHa2(t *testing.T) {
+	cred := credExample
 	r1 := cred.ha2()
 	if r1 != "39aff3a2bab6126f332b942af96d3366" {
 		t.Fail()
@@ -89,6 +91,7 @@ func (s) TestHa2(t *testing.T) {
 }
 
 func (s) TestResp(t *testing.T) {
+	cred := credExample
 	r1, err := cred.resp(cnonce)
 	if err != nil {
 		t.Fail()

--- a/examples/helloworld/greeter_client/main.go
+++ b/examples/helloworld/greeter_client/main.go
@@ -21,22 +21,25 @@ package main
 
 import (
 	"context"
+	"flag"
 	"log"
-	"os"
 	"time"
 
 	"google.golang.org/grpc"
 	pb "google.golang.org/grpc/examples/helloworld/helloworld"
 )
 
+var address = flag.String("address", "localhost:50051", "address to connect to")
+
 const (
-	address     = "localhost:50051"
 	defaultName = "world"
 )
 
 func main() {
+	flag.Parse()
+
 	// Set up a connection to the server.
-	conn, err := grpc.Dial(address, grpc.WithInsecure())
+	conn, err := grpc.Dial(*address, grpc.WithInsecure())
 	if err != nil {
 		log.Fatalf("did not connect: %v", err)
 	}
@@ -45,8 +48,8 @@ func main() {
 
 	// Contact the server and print out its response.
 	name := defaultName
-	if len(os.Args) > 1 {
-		name = os.Args[1]
+	if len(flag.Args()) > 1 {
+		name = flag.Args()[1]
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()

--- a/examples/helloworld/greeter_server/main.go
+++ b/examples/helloworld/greeter_server/main.go
@@ -23,6 +23,7 @@ package main
 
 import (
 	"context"
+	"flag"
 	"log"
 	"net"
 
@@ -30,9 +31,7 @@ import (
 	pb "google.golang.org/grpc/examples/helloworld/helloworld"
 )
 
-const (
-	port = ":50051"
-)
+var address = flag.String("address", "localhost:50051", "address to connect to")
 
 // server is used to implement helloworld.GreeterServer.
 type server struct{}
@@ -44,7 +43,9 @@ func (s *server) SayHello(ctx context.Context, in *pb.HelloRequest) (*pb.HelloRe
 }
 
 func main() {
-	lis, err := net.Listen("tcp", port)
+	flag.Parse()
+
+	lis, err := net.Listen("tcp", *address)
 	if err != nil {
 		log.Fatalf("failed to listen: %v", err)
 	}

--- a/proxy.go
+++ b/proxy.go
@@ -79,7 +79,6 @@ func basicAuth(username, password string) string {
 
 func parseAuthenticationScheme(input string) (string, error) {
 	const ws = " \n\r\t"
-	const qs = `"`
 	s := strings.Trim(input, ws)
 	words := strings.Split(s, " ")
 	if words[0] == "Basic" || words[0] == "Digest" {

--- a/proxy.go
+++ b/proxy.go
@@ -122,7 +122,14 @@ func doHTTPConnectHandshake(ctx context.Context, conn net.Conn, backendAddr stri
 				basicSchemeFound = true
 			} else if scheme == "Digest" {
 				digestSchemeFound = true
-				challenge, _ = parseChallenge(input)
+				challenge, err = parseChallenge(input)
+				if err != nil {
+					// ignore bad challenge. Maybe unsupported algorithm?
+					continue
+				}
+				// rfc7616: When the client receives the first challenge, it SHOULD use
+				// the first challenge it supports
+				break
 			}
 		}
 		if digestSchemeFound {

--- a/test/http-proxy-digest-auth/Dockerfile
+++ b/test/http-proxy-digest-auth/Dockerfile
@@ -1,0 +1,6 @@
+FROM httpd:2.4
+COPY ./index.html /usr/local/apache2/htdocs/
+RUN mkdir /usr/local/apache2/htdocs/auth-digest/
+COPY ./auth-digest/ /usr/local/apache2/htdocs/auth-digest/
+COPY ./httpd.conf /usr/local/apache2/conf/httpd.conf
+RUN mkdir /var/log/apache2

--- a/test/http-proxy-digest-auth/README.md
+++ b/test/http-proxy-digest-auth/README.md
@@ -1,0 +1,26 @@
+# HTTP Proxy Digest Auth
+
+This directory contains scripts to help testing manually digest authentication
+against a http proxy.
+
+## Start the HTTP proxy
+
+```
+./build.sh
+./run.sh
+```
+
+## Run the test
+
+Server:
+```
+export IP=$(hostname --ip-address)
+go run examples/helloworld/greeter_server/main.go -address $IP:50052
+```
+
+Client:
+```
+export IP=$(hostname --ip-address)
+export http_proxy='http://admin:secret@127.0.0.1:12345'
+go run examples/helloworld/greeter_client/main.go -address $IP:50052
+```

--- a/test/http-proxy-digest-auth/auth-digest/.htdigest
+++ b/test/http-proxy-digest-auth/auth-digest/.htdigest
@@ -1,0 +1,1 @@
+admin:digest-test:1bb52036aa88a4da97665065d711b2ed

--- a/test/http-proxy-digest-auth/auth-digest/index.html
+++ b/test/http-proxy-digest-auth/auth-digest/index.html
@@ -1,0 +1,5 @@
+<html><body>
+
+Congrats - successfully authenticated w/ digest auth!
+
+</body></html>

--- a/test/http-proxy-digest-auth/build.sh
+++ b/test/http-proxy-digest-auth/build.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+docker build -t digest-test-apache .

--- a/test/http-proxy-digest-auth/httpd.conf
+++ b/test/http-proxy-digest-auth/httpd.conf
@@ -1,0 +1,114 @@
+ServerRoot "./"
+
+#Listen 12.34.56.78:12345
+Listen 12345
+
+LoadModule mpm_event_module modules/mod_mpm_event.so
+LoadModule access_compat_module modules/mod_access_compat.so
+LoadModule actions_module modules/mod_actions.so
+LoadModule alias_module modules/mod_alias.so
+LoadModule allowmethods_module modules/mod_allowmethods.so
+LoadModule auth_digest_module modules/mod_auth_digest.so
+LoadModule authn_core_module modules/mod_authn_core.so
+LoadModule authn_file_module modules/mod_authn_file.so
+LoadModule authn_socache_module modules/mod_authn_socache.so
+LoadModule authz_core_module modules/mod_authz_core.so
+LoadModule authz_groupfile_module modules/mod_authz_groupfile.so
+LoadModule authz_host_module modules/mod_authz_host.so
+LoadModule authz_owner_module modules/mod_authz_owner.so
+LoadModule authz_user_module modules/mod_authz_user.so
+LoadModule autoindex_module modules/mod_autoindex.so
+LoadModule data_module modules/mod_data.so
+LoadModule deflate_module modules/mod_deflate.so
+LoadModule dir_module modules/mod_dir.so
+LoadModule dumpio_module modules/mod_dumpio.so
+LoadModule echo_module modules/mod_echo.so
+LoadModule env_module modules/mod_env.so
+LoadModule expires_module modules/mod_expires.so
+LoadModule ext_filter_module modules/mod_ext_filter.so
+LoadModule filter_module modules/mod_filter.so
+LoadModule headers_module modules/mod_headers.so
+LoadModule include_module modules/mod_include.so
+LoadModule info_module modules/mod_info.so
+LoadModule log_config_module modules/mod_log_config.so
+LoadModule logio_module modules/mod_logio.so
+LoadModule macro_module modules/mod_macro.so
+LoadModule negotiation_module modules/mod_negotiation.so
+LoadModule remoteip_module modules/mod_remoteip.so
+LoadModule reqtimeout_module modules/mod_reqtimeout.so
+LoadModule request_module modules/mod_request.so
+LoadModule rewrite_module modules/mod_rewrite.so
+LoadModule setenvif_module modules/mod_setenvif.so
+LoadModule slotmem_plain_module modules/mod_slotmem_plain.so
+LoadModule slotmem_shm_module modules/mod_slotmem_shm.so
+LoadModule socache_shmcb_module modules/mod_socache_shmcb.so
+LoadModule status_module modules/mod_status.so
+LoadModule substitute_module modules/mod_substitute.so
+LoadModule suexec_module modules/mod_suexec.so
+LoadModule unique_id_module modules/mod_unique_id.so
+LoadModule unixd_module modules/mod_unixd.so
+LoadModule userdir_module modules/mod_userdir.so
+LoadModule version_module modules/mod_version.so
+LoadModule vhost_alias_module modules/mod_vhost_alias.so
+LoadModule watchdog_module modules/mod_watchdog.so
+
+LoadModule proxy_module modules/mod_proxy.so
+LoadModule proxy_http_module modules/mod_proxy_http.so
+LoadModule proxy_connect_module modules/mod_proxy_connect.so
+
+LoadModule log_forensic_module modules/mod_log_forensic.so
+ForensicLog "/var/log/apache2/forensic.log"
+
+ServerAdmin root@localhost
+ServerName localhost:12345
+ErrorLog "/var/log/apache2/error.log"
+LogLevel debug
+
+PidFile "/var/log/apache2/httpd.pid"
+User www-data
+Group www-data
+
+# HTTP server digest auth config
+
+<Directory />
+    AllowOverride none
+    Require all denied
+</Directory>
+
+DocumentRoot "/usr/local/apache2/htdocs/"
+<Directory "/usr/local/apache2/htdocs/">
+    AllowOverride none
+    Require all granted
+</Directory>
+
+
+<Directory "/usr/local/apache2/htdocs/auth-digest">
+    AuthType Digest
+    AuthName "digest-test"
+    AuthDigestDomain "/auth-digest/"
+    AuthDigestProvider file
+    AuthUserFile "/usr/local/apache2/htdocs/auth-digest/.htdigest"
+    AllowOverride None
+    Options Indexes FollowSymLinks
+
+    Require valid-user
+</Directory>
+
+<Files ".ht*">
+    Require all denied
+</Files>
+
+# HTTP Proxy digest auth config
+ProxyRequests On
+ProxyVia On
+AllowCONNECT 0-65535
+<Proxy "*">
+    AuthType Digest
+    AuthName "digest-test"
+    AuthDigestDomain "/auth-digest/"
+    AuthDigestProvider file
+    AuthUserFile "/usr/local/apache2/htdocs/auth-digest/.htdigest"
+
+    Require valid-user
+</Proxy>
+

--- a/test/http-proxy-digest-auth/index.html
+++ b/test/http-proxy-digest-auth/index.html
@@ -1,0 +1,6 @@
+<html><body>
+
+Hey there - try accessing with digest auth:
+<a href="auth-digest/index.html">auth-digest/index.html</a>
+
+</body></html>

--- a/test/http-proxy-digest-auth/run.sh
+++ b/test/http-proxy-digest-auth/run.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+
+cat <<EOF
+#######################################
+## digest auth test server starting ###
+#######################################
+
+You should be able to access http://localhost:12345/index.html w/o auth.
+
+Accessing http://localhost:12345/auth-digest/index.html will require digest
+authentication (user: "admin", pass: "secret").
+
+You may also use localhost:12345 as a proxy (try with your web browser!). For
+using the proxy you'lll need to authenticate via digest, using the above
+credentials.
+
+EOF
+
+function set_or_append() {
+    local ret="$1"
+    local add="$2"
+
+    if [ -z "$ret" ]; then
+        ret="/usr/bin/tail -f $2"
+    else
+        ret="$ret $2"
+    fi
+
+    echo "$ret"
+}
+
+cmd=""
+while [ $# -gt 0 ] ; do
+    case "$1" in
+        -t|--tail) cmd=$(set_or_append "$cmd" "/var/log/apache2/error.log");;
+        -f|--forensic) cmd=$(set_or_append \
+                                    "$cmd" "/var/log/apache2/forensic.log");;
+    esac
+    shift
+done
+
+docker ps | grep -q digest-test-apache || { 
+    echo "Starting container."
+    docker run -dit --net=host --name=digest-test-apache digest-test-apache; }
+
+[ -n "$cmd" ] && { 
+    docker exec -ti digest-test-apache \
+        $cmd
+        }

--- a/test/http-proxy-digest-auth/stop.sh
+++ b/test/http-proxy-digest-auth/stop.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+docker kill digest-test-apache
+docker rm digest-test-apache


### PR DESCRIPTION
This adds client-side support for digest authentication against an http proxy.

MD5, SHA-512-256 and SHA-256 are supported ([rfc7616](https://tools.ietf.org/html/rfc7616)).

It could be tested in different ways:
- Unit tests have been updated to check both basic auth and digest auth.
- If you already have a http proxy configured and a grpc server, you can try:
```
export http_proxy='http://user:password@1.2.3.4:3128'
go run examples/helloworld/greeter_client/main.go -address 5.6.7.8:50052
```
- You can also locally test with apache configured. See `test/http-proxy-digest-auth/README.md` for more instructions.

Part of the implementation is based on [bobziuchkovski/digest](https://github.com/bobziuchkovski/digest) (Apache-2.0 license), with adaptation for HTTP proxies. The copyright headers are updated in relevant files.

Fixes https://github.com/grpc/grpc-go/issues/2440
