### PR TITLE
Store peer value in context

### DIFF
--- a/credentials/alts/utils.go
+++ b/credentials/alts/utils.go
@@ -126,7 +126,7 @@ func AuthInfoFromContext(ctx context.Context) (AuthInfo, error) {
 	if !ok {
 		return nil, errors.New("no Peer found in Context")
 	}
-	return AuthInfoFromPeer(p)
+	return AuthInfoFromPeer(&p)
 }
 
 // AuthInfoFromPeer extracts the alts.AuthInfo object from the given peer, if it

--- a/credentials/alts/utils_test.go
+++ b/credentials/alts/utils_test.go
@@ -72,7 +72,7 @@ func setup(testOS string, testReader io.Reader) func() {
 func TestAuthInfoFromContext(t *testing.T) {
 	ctx := context.Background()
 	altsAuthInfo := &fakeALTSAuthInfo{}
-	p := &peer.Peer{
+	p := peer.Peer{
 		AuthInfo: altsAuthInfo,
 	}
 	for _, tc := range []struct {

--- a/internal/transport/handler_server.go
+++ b/internal/transport/handler_server.go
@@ -330,7 +330,7 @@ func (ht *serverHandlerTransport) HandleStreams(startStream func(*Stream), trace
 		recvCompress:   req.Header.Get("grpc-encoding"),
 		contentSubtype: ht.contentSubtype,
 	}
-	pr := &peer.Peer{
+	pr := peer.Peer{
 		Addr: ht.RemoteAddr(),
 	}
 	if req.TLS != nil {

--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -379,8 +379,8 @@ func (t *http2Client) newStream(ctx context.Context, callHdr *CallHdr) *Stream {
 	return s
 }
 
-func (t *http2Client) getPeer() *peer.Peer {
-	pr := &peer.Peer{
+func (t *http2Client) getPeer() peer.Peer {
+	pr := peer.Peer{
 		Addr: t.remoteAddr,
 	}
 	// Attach Auth info if there is any.

--- a/internal/transport/http2_server.go
+++ b/internal/transport/http2_server.go
@@ -327,7 +327,7 @@ func (t *http2Server) operateHeaders(frame *http2.MetaHeadersFrame, handle func(
 	} else {
 		s.ctx, s.cancel = context.WithCancel(t.ctx)
 	}
-	pr := &peer.Peer{
+	pr := peer.Peer{
 		Addr: t.remoteAddr,
 	}
 	// Attach Auth info if there is any.

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -40,12 +40,12 @@ type Peer struct {
 type peerKey struct{}
 
 // NewContext creates a new context with peer information attached.
-func NewContext(ctx context.Context, p *Peer) context.Context {
+func NewContext(ctx context.Context, p Peer) context.Context {
 	return context.WithValue(ctx, peerKey{}, p)
 }
 
 // FromContext returns the peer information in ctx if it exists.
-func FromContext(ctx context.Context) (p *Peer, ok bool) {
-	p, ok = ctx.Value(peerKey{}).(*Peer)
+func FromContext(ctx context.Context) (p Peer, ok bool) {
+	p, ok = ctx.Value(peerKey{}).(Peer)
 	return
 }

--- a/rpc_util.go
+++ b/rpc_util.go
@@ -248,7 +248,7 @@ func (o PeerCallOption) before(c *callInfo) error { return nil }
 func (o PeerCallOption) after(c *callInfo) {
 	if c.stream != nil {
 		if x, ok := peer.FromContext(c.stream.Context()); ok {
-			*o.PeerAddr = *x
+			o.PeerAddr = &x
 		}
 	}
 }


### PR DESCRIPTION
Avoids spilling the struct to the heap. it only has 2 fields which are both pointers so it should be ok.