### PR TITLE
server: avoid call to trace.FromContext and resulting allocations when tracing is disabled

### DIFF
--- a/server.go
+++ b/server.go
@@ -759,6 +759,9 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // traceInfo returns a traceInfo and associates it with stream, if tracing is enabled.
 // If tracing is not enabled, it returns nil.
 func (s *Server) traceInfo(st transport.ServerTransport, stream *transport.Stream) (trInfo *traceInfo) {
+	if !EnableTracing {
+		return nil
+	}
 	tr, ok := trace.FromContext(stream.Context())
 	if !ok {
 		return nil


### PR DESCRIPTION
Sadly trace.FromContext isn't cheap because it uses a string as the context key which leads to allocations. This patch makes the function a no-op when tracing is disabled, as it should be.