### PR TITLE
Introduce PickerBuilderV2 that can take address weight into account.

### DIFF
--- a/balancer/base/base.go
+++ b/balancer/base/base.go
@@ -42,6 +42,16 @@ type PickerBuilder interface {
 	Build(readySCs map[resolver.Address]balancer.SubConn) balancer.Picker
 }
 
+type AddrInfo struct {
+	SubConn balancer.SubConn
+	Weight uint32
+}
+
+type PickerBuilderV2 interface {
+	PickerBuilder
+	BuildV2(readySCs map[resolver.Address]AddrInfo) balancer.Picker
+}
+
 // NewBalancerBuilder returns a balancer builder. The balancers
 // built by this builder will use the picker builder to build pickers.
 func NewBalancerBuilder(name string, pb PickerBuilder) balancer.Builder {

--- a/balancer/grpclb/grpclb.go
+++ b/balancer/grpclb/grpclb.go
@@ -434,7 +434,7 @@ func (lb *lbBalancer) UpdateClientConnState(ccs balancer.ClientConnState) {
 		return
 	}
 
-	var remoteBalancerAddrs, backendAddrs []resolver.Address
+	var remoteBalancerAddrs, backendAddrs []resolver.WeightedAddress
 	for _, a := range addrs {
 		if a.Type == resolver.GRPCLB {
 			a.Type = resolver.Backend
@@ -461,7 +461,7 @@ func (lb *lbBalancer) UpdateClientConnState(ccs balancer.ClientConnState) {
 	lb.manualResolver.UpdateState(resolver.State{Addresses: remoteBalancerAddrs})
 
 	lb.mu.Lock()
-	lb.resolvedBackendAddrs = backendAddrs
+	lb.resolvedBackendAddrs = resolver.WeightedAddressesToAddresses(backendAddrs)
 	if lb.inFallback {
 		// This means we received a new list of resolved backends, and we are
 		// still in fallback mode. Need to update the list of backends we are

--- a/balancer/grpclb/grpclb_test.go
+++ b/balancer/grpclb/grpclb_test.go
@@ -402,11 +402,11 @@ func TestGRPCLB(t *testing.T) {
 	defer cc.Close()
 	testC := testpb.NewTestServiceClient(cc)
 
-	r.UpdateState(resolver.State{Addresses: []resolver.Address{{
+	r.UpdateState(resolver.State{Addresses: resolver.AddressesToWeightedAddresses([]resolver.Address{{
 		Addr:       tss.lbAddr,
 		Type:       resolver.GRPCLB,
 		ServerName: lbServerName,
-	}}})
+	}})})
 
 	if _, err := testC.EmptyCall(context.Background(), &testpb.Empty{}, grpc.WaitForReady(true)); err != nil {
 		t.Fatalf("%v.EmptyCall(_, _) = _, %v, want _, <nil>", testC, err)
@@ -453,11 +453,11 @@ func TestGRPCLBWeighted(t *testing.T) {
 	defer cc.Close()
 	testC := testpb.NewTestServiceClient(cc)
 
-	r.UpdateState(resolver.State{Addresses: []resolver.Address{{
+	r.UpdateState(resolver.State{Addresses: resolver.AddressesToWeightedAddresses([]resolver.Address{{
 		Addr:       tss.lbAddr,
 		Type:       resolver.GRPCLB,
 		ServerName: lbServerName,
-	}}})
+	}})})
 
 	sequences := []string{"00101", "00011"}
 	for _, seq := range sequences {
@@ -523,11 +523,11 @@ func TestDropRequest(t *testing.T) {
 	defer cc.Close()
 	testC := testpb.NewTestServiceClient(cc)
 
-	r.UpdateState(resolver.State{Addresses: []resolver.Address{{
+	r.UpdateState(resolver.State{Addresses: resolver.AddressesToWeightedAddresses([]resolver.Address{{
 		Addr:       tss.lbAddr,
 		Type:       resolver.GRPCLB,
 		ServerName: lbServerName,
-	}}})
+	}})})
 
 	var (
 		i int
@@ -685,7 +685,7 @@ func TestBalancerDisconnects(t *testing.T) {
 	defer cc.Close()
 	testC := testpb.NewTestServiceClient(cc)
 
-	r.UpdateState(resolver.State{Addresses: []resolver.Address{{
+	r.UpdateState(resolver.State{Addresses: resolver.AddressesToWeightedAddresses([]resolver.Address{{
 		Addr:       tests[0].lbAddr,
 		Type:       resolver.GRPCLB,
 		ServerName: lbServerName,
@@ -693,7 +693,7 @@ func TestBalancerDisconnects(t *testing.T) {
 		Addr:       tests[1].lbAddr,
 		Type:       resolver.GRPCLB,
 		ServerName: lbServerName,
-	}}})
+	}})})
 
 	var p peer.Peer
 	if _, err := testC.EmptyCall(context.Background(), &testpb.Empty{}, grpc.WaitForReady(true), grpc.Peer(&p)); err != nil {
@@ -766,7 +766,7 @@ func TestFallback(t *testing.T) {
 	defer cc.Close()
 	testC := testpb.NewTestServiceClient(cc)
 
-	r.UpdateState(resolver.State{Addresses: []resolver.Address{{
+	r.UpdateState(resolver.State{Addresses: resolver.AddressesToWeightedAddresses([]resolver.Address{{
 		Addr:       "invalid.address",
 		Type:       resolver.GRPCLB,
 		ServerName: lbServerName,
@@ -774,7 +774,7 @@ func TestFallback(t *testing.T) {
 		Addr:       beLis.Addr().String(),
 		Type:       resolver.Backend,
 		ServerName: beServerName,
-	}}})
+	}})})
 
 	var p peer.Peer
 	if _, err := testC.EmptyCall(context.Background(), &testpb.Empty{}, grpc.WaitForReady(true), grpc.Peer(&p)); err != nil {
@@ -784,7 +784,7 @@ func TestFallback(t *testing.T) {
 		t.Fatalf("got peer: %v, want peer: %v", p.Addr, beLis.Addr())
 	}
 
-	r.UpdateState(resolver.State{Addresses: []resolver.Address{{
+	r.UpdateState(resolver.State{Addresses: resolver.AddressesToWeightedAddresses([]resolver.Address{{
 		Addr:       tss.lbAddr,
 		Type:       resolver.GRPCLB,
 		ServerName: lbServerName,
@@ -792,7 +792,7 @@ func TestFallback(t *testing.T) {
 		Addr:       beLis.Addr().String(),
 		Type:       resolver.Backend,
 		ServerName: beServerName,
-	}}})
+	}})})
 
 	var backendUsed bool
 	for i := 0; i < 1000; i++ {
@@ -910,11 +910,11 @@ func TestGRPCLBPickFirst(t *testing.T) {
 	// Start with sub policy pick_first.
 
 	r.UpdateState(resolver.State{
-		Addresses: []resolver.Address{{
+		Addresses: resolver.AddressesToWeightedAddresses([]resolver.Address{{
 			Addr:       tss.lbAddr,
 			Type:       resolver.GRPCLB,
 			ServerName: lbServerName,
-		}},
+		}}),
 		ServiceConfig: svcCfg,
 	})
 
@@ -960,11 +960,11 @@ func TestGRPCLBPickFirst(t *testing.T) {
 	}
 
 	r.UpdateState(resolver.State{
-		Addresses: []resolver.Address{{
+		Addresses: resolver.AddressesToWeightedAddresses([]resolver.Address{{
 			Addr:       tss.lbAddr,
 			Type:       resolver.GRPCLB,
 			ServerName: lbServerName,
-		}},
+		}}),
 		ServiceConfig: grpclbServiceConfigEmpty,
 	})
 
@@ -1049,11 +1049,11 @@ func runAndGetStats(t *testing.T, drop bool, runRPCs func(*grpc.ClientConn)) *rp
 	}
 	defer cc.Close()
 
-	r.UpdateState(resolver.State{Addresses: []resolver.Address{{
+	r.UpdateState(resolver.State{Addresses: resolver.AddressesToWeightedAddresses([]resolver.Address{{
 		Addr:       tss.lbAddr,
 		Type:       resolver.GRPCLB,
 		ServerName: lbServerName,
-	}}})
+	}})})
 
 	runRPCs(cc)
 	time.Sleep(1 * time.Second)

--- a/balancer/xds/edsbalancer/balancergroup.go
+++ b/balancer/xds/edsbalancer/balancergroup.go
@@ -198,7 +198,7 @@ func (bg *balancerGroup) handleSubConnStateChange(sc balancer.SubConn, state con
 }
 
 // Address change: forward to balancer.
-func (bg *balancerGroup) handleResolvedAddrs(id internal.Locality, addrs []resolver.Address) {
+func (bg *balancerGroup) handleResolvedAddrs(id internal.Locality, addrs []resolver.WeightedAddress) {
 	bg.mu.Lock()
 	b, ok := bg.idToBalancer[id]
 	bg.mu.Unlock()
@@ -209,7 +209,7 @@ func (bg *balancerGroup) handleResolvedAddrs(id internal.Locality, addrs []resol
 	if ub, ok := b.(balancer.V2Balancer); ok {
 		ub.UpdateClientConnState(balancer.ClientConnState{ResolverState: resolver.State{Addresses: addrs}})
 	} else {
-		b.HandleResolvedAddrs(addrs, nil)
+		b.HandleResolvedAddrs(resolver.WeightedAddressesToAddresses(addrs), nil)
 	}
 }
 

--- a/balancer/xds/edsbalancer/balancergroup_test.go
+++ b/balancer/xds/edsbalancer/balancergroup_test.go
@@ -32,7 +32,7 @@ import (
 var (
 	rrBuilder        = balancer.Get(roundrobin.Name)
 	testBalancerIDs  = []internal.Locality{{Region: "b1"}, {Region: "b2"}, {Region: "b3"}}
-	testBackendAddrs = []resolver.Address{{Addr: "1.1.1.1:1"}, {Addr: "2.2.2.2:2"}, {Addr: "3.3.3.3:3"}, {Addr: "4.4.4.4:4"}}
+	testBackendAddrs = resolver.AddressesToWeightedAddresses([]resolver.Address{{Addr: "1.1.1.1:1"}, {Addr: "2.2.2.2:2"}, {Addr: "3.3.3.3:3"}, {Addr: "4.4.4.4:4"}})
 )
 
 // 1 balancer, 1 backend -> 2 backends -> 1 backend.

--- a/balancer/xds/edsbalancer/edsbalancer.go
+++ b/balancer/xds/edsbalancer/edsbalancer.go
@@ -41,7 +41,7 @@ import (
 
 type localityConfig struct {
 	weight uint32
-	addrs  []resolver.Address
+	addrs  []resolver.WeightedAddress
 }
 
 // EDSBalancer does load balancing based on the EDS responses. Note that it
@@ -224,11 +224,14 @@ func (xdsB *EDSBalancer) HandleEDSResponse(edsResp *edspb.ClusterLoadAssignment)
 		newLocalitiesSet[lid] = struct{}{}
 
 		newWeight := locality.GetLoadBalancingWeight().GetValue()
-		var newAddrs []resolver.Address
+		var newAddrs []resolver.WeightedAddress
 		for _, lbEndpoint := range locality.GetLbEndpoints() {
 			socketAddress := lbEndpoint.GetEndpoint().GetAddress().GetSocketAddress()
-			newAddrs = append(newAddrs, resolver.Address{
-				Addr: net.JoinHostPort(socketAddress.GetAddress(), strconv.Itoa(int(socketAddress.GetPortValue()))),
+			newAddrs = append(newAddrs, resolver.WeightedAddress{
+				Address : resolver.Address{
+					Addr: net.JoinHostPort(socketAddress.GetAddress(), strconv.Itoa(int(socketAddress.GetPortValue()))),
+				},
+				Weight: lbEndpoint.GetLoadBalancingWeight().GetValue(),
 			})
 		}
 		var weightChanged, addrsChanged bool

--- a/balancer/xds/xds.go
+++ b/balancer/xds/xds.go
@@ -475,7 +475,7 @@ func (x *xdsBalancer) updateFallbackWithResolverState(s *resolver.State) {
 			// we can pass along the config struct.
 		}})
 	} else {
-		x.fallbackLB.HandleResolvedAddrs(s.Addresses, nil)
+		x.fallbackLB.HandleResolvedAddrs(resolver.WeightedAddressesToAddresses(s.Addresses), nil)
 	}
 }
 

--- a/balancer/xds/xds_test.go
+++ b/balancer/xds/xds_test.go
@@ -249,7 +249,7 @@ func (s) TestXdsBalanceHandleResolvedAddrs(t *testing.T) {
 	addrs := []resolver.Address{{Addr: "1.1.1.1:10001"}, {Addr: "2.2.2.2:10002"}, {Addr: "3.3.3.3:10003"}}
 	for i := 0; i < 3; i++ {
 		lb.UpdateClientConnState(balancer.ClientConnState{
-			ResolverState:  resolver.State{Addresses: addrs},
+			ResolverState:  resolver.State{Addresses: resolver.AddressesToWeightedAddresses(addrs)},
 			BalancerConfig: testLBConfigFooBar,
 		})
 		select {
@@ -282,7 +282,7 @@ func (s) TestXdsBalanceHandleBalancerConfigBalancerNameUpdate(t *testing.T) {
 	defer lb.Close()
 	addrs := []resolver.Address{{Addr: "1.1.1.1:10001"}, {Addr: "2.2.2.2:10002"}, {Addr: "3.3.3.3:10003"}}
 	lb.UpdateClientConnState(balancer.ClientConnState{
-		ResolverState:  resolver.State{Addresses: addrs},
+		ResolverState:  resolver.State{Addresses: resolver.AddressesToWeightedAddresses(addrs)},
 		BalancerConfig: testLBConfigFooBar,
 	})
 
@@ -313,7 +313,7 @@ func (s) TestXdsBalanceHandleBalancerConfigBalancerNameUpdate(t *testing.T) {
 			FallBackPolicy: &loadBalancingConfig{Name: fakeBalancerA},
 		}
 		lb.UpdateClientConnState(balancer.ClientConnState{
-			ResolverState:  resolver.State{Addresses: addrs},
+			ResolverState:  resolver.State{Addresses: resolver.AddressesToWeightedAddresses(addrs)},
 			BalancerConfig: workingLBConfig,
 		})
 		td.sendResp(&response{resp: testEDSRespWithoutEndpoints})
@@ -459,7 +459,7 @@ func (s) TestXdsBalanceHandleBalancerConfigFallBackUpdate(t *testing.T) {
 	cfg2 := cfg
 	cfg2.FallBackPolicy = &loadBalancingConfig{Name: fakeBalancerB}
 	lb.UpdateClientConnState(balancer.ClientConnState{
-		ResolverState:  resolver.State{Addresses: addrs},
+		ResolverState:  resolver.State{Addresses: resolver.AddressesToWeightedAddresses(addrs)},
 		BalancerConfig: &cfg2,
 	})
 
@@ -491,7 +491,7 @@ func (s) TestXdsBalanceHandleBalancerConfigFallBackUpdate(t *testing.T) {
 	cfg3 := cfg
 	cfg3.FallBackPolicy = &loadBalancingConfig{Name: fakeBalancerA}
 	lb.UpdateClientConnState(balancer.ClientConnState{
-		ResolverState:  resolver.State{Addresses: addrs},
+		ResolverState:  resolver.State{Addresses: resolver.AddressesToWeightedAddresses(addrs)},
 		BalancerConfig: &cfg3,
 	})
 

--- a/balancer_conn_wrappers.go
+++ b/balancer_conn_wrappers.go
@@ -136,7 +136,7 @@ func (ccb *ccBalancerWrapper) watcher() {
 			if ub, ok := ccb.balancer.(balancer.V2Balancer); ok {
 				ub.UpdateClientConnState(*s)
 			} else {
-				ccb.balancer.HandleResolvedAddrs(s.ResolverState.Addresses, nil)
+				ccb.balancer.HandleResolvedAddrs(resolver.WeightedAddressesToAddresses(s.ResolverState.Addresses), nil)
 			}
 		case <-ccb.done:
 		}

--- a/balancer_switching_test.go
+++ b/balancer_switching_test.go
@@ -142,7 +142,7 @@ func (s) TestSwitchBalancer(t *testing.T) {
 		t.Fatalf("failed to dial: %v", err)
 	}
 	defer cc.Close()
-	addrs := []resolver.Address{{Addr: servers[0].addr}, {Addr: servers[1].addr}}
+	addrs := resolver.AddressesToWeightedAddresses([]resolver.Address{{Addr: servers[0].addr}, {Addr: servers[1].addr}})
 	r.UpdateState(resolver.State{Addresses: addrs})
 	// The default balancer is pickfirst.
 	if err := checkPickFirst(cc, servers); err != nil {
@@ -174,7 +174,7 @@ func (s) TestBalancerDialOption(t *testing.T) {
 		t.Fatalf("failed to dial: %v", err)
 	}
 	defer cc.Close()
-	addrs := []resolver.Address{{Addr: servers[0].addr}, {Addr: servers[1].addr}}
+	addrs := resolver.AddressesToWeightedAddresses([]resolver.Address{{Addr: servers[0].addr}, {Addr: servers[1].addr}})
 	r.UpdateState(resolver.State{Addresses: addrs})
 	// The init balancer is roundrobin.
 	if err := checkRoundRobin(cc, servers); err != nil {
@@ -201,7 +201,7 @@ func (s) TestSwitchBalancerGRPCLBFirst(t *testing.T) {
 
 	// ClientConn will switch balancer to grpclb when receives an address of
 	// type GRPCLB.
-	r.UpdateState(resolver.State{Addresses: []resolver.Address{{Addr: "backend"}, {Addr: "grpclb", Type: resolver.GRPCLB}}})
+	r.UpdateState(resolver.State{Addresses: resolver.AddressesToWeightedAddresses([]resolver.Address{{Addr: "backend"}, {Addr: "grpclb", Type: resolver.GRPCLB}})})
 	var isGRPCLB bool
 	for i := 0; i < 5000; i++ {
 		cc.mu.Lock()
@@ -218,7 +218,7 @@ func (s) TestSwitchBalancerGRPCLBFirst(t *testing.T) {
 
 	// New update containing new backend and new grpclb. Should not switch
 	// balancer.
-	r.UpdateState(resolver.State{Addresses: []resolver.Address{{Addr: "backend2"}, {Addr: "grpclb2", Type: resolver.GRPCLB}}})
+	r.UpdateState(resolver.State{Addresses: resolver.AddressesToWeightedAddresses([]resolver.Address{{Addr: "backend2"}, {Addr: "grpclb2", Type: resolver.GRPCLB}})})
 	for i := 0; i < 200; i++ {
 		cc.mu.Lock()
 		isGRPCLB = cc.curBalancerName == "grpclb"
@@ -234,7 +234,7 @@ func (s) TestSwitchBalancerGRPCLBFirst(t *testing.T) {
 
 	var isPickFirst bool
 	// Switch balancer to pickfirst.
-	r.UpdateState(resolver.State{Addresses: []resolver.Address{{Addr: "backend"}}})
+	r.UpdateState(resolver.State{Addresses: resolver.AddressesToWeightedAddresses([]resolver.Address{{Addr: "backend"}})})
 	for i := 0; i < 5000; i++ {
 		cc.mu.Lock()
 		isPickFirst = cc.curBalancerName == PickFirstBalancerName
@@ -260,7 +260,7 @@ func (s) TestSwitchBalancerGRPCLBSecond(t *testing.T) {
 	}
 	defer cc.Close()
 
-	r.UpdateState(resolver.State{Addresses: []resolver.Address{{Addr: "backend"}}})
+	r.UpdateState(resolver.State{Addresses: resolver.AddressesToWeightedAddresses([]resolver.Address{{Addr: "backend"}})})
 	var isPickFirst bool
 	for i := 0; i < 5000; i++ {
 		cc.mu.Lock()
@@ -277,7 +277,7 @@ func (s) TestSwitchBalancerGRPCLBSecond(t *testing.T) {
 
 	// ClientConn will switch balancer to grpclb when receives an address of
 	// type GRPCLB.
-	r.UpdateState(resolver.State{Addresses: []resolver.Address{{Addr: "backend"}, {Addr: "grpclb", Type: resolver.GRPCLB}}})
+	r.UpdateState(resolver.State{Addresses: resolver.AddressesToWeightedAddresses([]resolver.Address{{Addr: "backend"}, {Addr: "grpclb", Type: resolver.GRPCLB}})})
 	var isGRPCLB bool
 	for i := 0; i < 5000; i++ {
 		cc.mu.Lock()
@@ -294,7 +294,7 @@ func (s) TestSwitchBalancerGRPCLBSecond(t *testing.T) {
 
 	// New update containing new backend and new grpclb. Should not switch
 	// balancer.
-	r.UpdateState(resolver.State{Addresses: []resolver.Address{{Addr: "backend2"}, {Addr: "grpclb2", Type: resolver.GRPCLB}}})
+	r.UpdateState(resolver.State{Addresses: resolver.AddressesToWeightedAddresses([]resolver.Address{{Addr: "backend2"}, {Addr: "grpclb2", Type: resolver.GRPCLB}})})
 	for i := 0; i < 200; i++ {
 		cc.mu.Lock()
 		isGRPCLB = cc.curBalancerName == "grpclb"
@@ -309,7 +309,7 @@ func (s) TestSwitchBalancerGRPCLBSecond(t *testing.T) {
 	}
 
 	// Switch balancer back.
-	r.UpdateState(resolver.State{Addresses: []resolver.Address{{Addr: "backend"}}})
+	r.UpdateState(resolver.State{Addresses: resolver.AddressesToWeightedAddresses([]resolver.Address{{Addr: "backend"}})})
 	for i := 0; i < 5000; i++ {
 		cc.mu.Lock()
 		isPickFirst = cc.curBalancerName == PickFirstBalancerName
@@ -339,7 +339,7 @@ func (s) TestSwitchBalancerGRPCLBRoundRobin(t *testing.T) {
 
 	sc := parseCfg(`{"loadBalancingPolicy": "round_robin"}`)
 
-	r.UpdateState(resolver.State{Addresses: []resolver.Address{{Addr: "backend"}}, ServiceConfig: sc})
+	r.UpdateState(resolver.State{Addresses: resolver.AddressesToWeightedAddresses([]resolver.Address{{Addr: "backend"}}), ServiceConfig: sc})
 	var isRoundRobin bool
 	for i := 0; i < 5000; i++ {
 		cc.mu.Lock()
@@ -356,7 +356,7 @@ func (s) TestSwitchBalancerGRPCLBRoundRobin(t *testing.T) {
 
 	// ClientConn will switch balancer to grpclb when receives an address of
 	// type GRPCLB.
-	r.UpdateState(resolver.State{Addresses: []resolver.Address{{Addr: "grpclb", Type: resolver.GRPCLB}}, ServiceConfig: sc})
+	r.UpdateState(resolver.State{Addresses: resolver.AddressesToWeightedAddresses([]resolver.Address{{Addr: "grpclb", Type: resolver.GRPCLB}}), ServiceConfig: sc})
 	var isGRPCLB bool
 	for i := 0; i < 5000; i++ {
 		cc.mu.Lock()
@@ -372,7 +372,7 @@ func (s) TestSwitchBalancerGRPCLBRoundRobin(t *testing.T) {
 	}
 
 	// Switch balancer back.
-	r.UpdateState(resolver.State{Addresses: []resolver.Address{{Addr: "backend"}}, ServiceConfig: sc})
+	r.UpdateState(resolver.State{Addresses: resolver.AddressesToWeightedAddresses([]resolver.Address{{Addr: "backend"}}), ServiceConfig: sc})
 	for i := 0; i < 5000; i++ {
 		cc.mu.Lock()
 		isRoundRobin = cc.curBalancerName == "round_robin"
@@ -400,7 +400,7 @@ func (s) TestSwitchBalancerGRPCLBServiceConfig(t *testing.T) {
 	}
 	defer cc.Close()
 
-	r.UpdateState(resolver.State{Addresses: []resolver.Address{{Addr: "backend"}}})
+	r.UpdateState(resolver.State{Addresses: resolver.AddressesToWeightedAddresses([]resolver.Address{{Addr: "backend"}})})
 	var isPickFirst bool
 	for i := 0; i < 5000; i++ {
 		cc.mu.Lock()
@@ -417,7 +417,7 @@ func (s) TestSwitchBalancerGRPCLBServiceConfig(t *testing.T) {
 
 	// ClientConn will switch balancer to grpclb when receives an address of
 	// type GRPCLB.
-	addrs := []resolver.Address{{Addr: "grpclb", Type: resolver.GRPCLB}}
+	addrs := resolver.AddressesToWeightedAddresses([]resolver.Address{{Addr: "grpclb", Type: resolver.GRPCLB}})
 	r.UpdateState(resolver.State{Addresses: addrs})
 	var isGRPCLB bool
 	for i := 0; i < 5000; i++ {
@@ -452,7 +452,7 @@ func (s) TestSwitchBalancerGRPCLBServiceConfig(t *testing.T) {
 	}
 
 	// Switch balancer back.
-	r.UpdateState(resolver.State{Addresses: []resolver.Address{{Addr: "backend"}}, ServiceConfig: sc})
+	r.UpdateState(resolver.State{Addresses: resolver.AddressesToWeightedAddresses([]resolver.Address{{Addr: "backend"}}), ServiceConfig: sc})
 	for i := 0; i < 5000; i++ {
 		cc.mu.Lock()
 		isRoundRobin = cc.curBalancerName == "round_robin"
@@ -490,7 +490,7 @@ func (s) TestSwitchBalancerGRPCLBWithGRPCLBNotRegistered(t *testing.T) {
 		t.Fatalf("failed to dial: %v", err)
 	}
 	defer cc.Close()
-	r.UpdateState(resolver.State{Addresses: []resolver.Address{{Addr: servers[1].addr}, {Addr: servers[2].addr}}})
+	r.UpdateState(resolver.State{Addresses: resolver.AddressesToWeightedAddresses([]resolver.Address{{Addr: servers[1].addr}, {Addr: servers[2].addr}})})
 	// The default balancer is pickfirst.
 	if err := checkPickFirst(cc, servers[1:]); err != nil {
 		t.Fatalf("check pickfirst returned non-nil error: %v", err)
@@ -501,9 +501,9 @@ func (s) TestSwitchBalancerGRPCLBWithGRPCLBNotRegistered(t *testing.T) {
 	//
 	// If the filtering failed, servers[0] will be used for RPCs and the RPCs
 	// will succeed. The following checks will catch this and fail.
-	addrs := []resolver.Address{
+	addrs := resolver.AddressesToWeightedAddresses([]resolver.Address{
 		{Addr: servers[0].addr, Type: resolver.GRPCLB},
-		{Addr: servers[1].addr}, {Addr: servers[2].addr}}
+		{Addr: servers[1].addr}, {Addr: servers[2].addr}})
 	r.UpdateState(resolver.State{Addresses: addrs})
 	// Still check for pickfirst, but only with server[1] and server[2].
 	if err := checkPickFirst(cc, servers[1:]); err != nil {

--- a/clientconn_state_transition_test.go
+++ b/clientconn_state_transition_test.go
@@ -316,10 +316,10 @@ func (s) TestStateTransitions_TriesAllAddrsBeforeTransientFailure(t *testing.T) 
 	}()
 
 	rb := manual.NewBuilderWithScheme("whatever")
-	rb.InitialState(resolver.State{Addresses: []resolver.Address{
+	rb.InitialState(resolver.State{Addresses: resolver.AddressesToWeightedAddresses([]resolver.Address{
 		{Addr: lis1.Addr().String()},
 		{Addr: lis2.Addr().String()},
-	}})
+	})})
 	client, err := DialContext(ctx, "this-gets-overwritten", WithInsecure(), WithBalancerName(stateRecordingBalancerName), withResolverBuilder(rb))
 	if err != nil {
 		t.Fatal(err)
@@ -410,10 +410,10 @@ func (s) TestStateTransitions_MultipleAddrsEntersReady(t *testing.T) {
 	}()
 
 	rb := manual.NewBuilderWithScheme("whatever")
-	rb.InitialState(resolver.State{Addresses: []resolver.Address{
+	rb.InitialState(resolver.State{Addresses: resolver.AddressesToWeightedAddresses([]resolver.Address{
 		{Addr: lis1.Addr().String()},
 		{Addr: lis2.Addr().String()},
-	}})
+	})})
 	client, err := DialContext(ctx, "this-gets-overwritten", WithInsecure(), WithBalancerName(stateRecordingBalancerName), withResolverBuilder(rb))
 	if err != nil {
 		t.Fatal(err)

--- a/clientconn_test.go
+++ b/clientconn_test.go
@@ -78,7 +78,7 @@ func (s) TestDialWithTimeout(t *testing.T) {
 
 	r, cleanup := manual.GenerateAndRegisterManualResolver()
 	defer cleanup()
-	r.InitialState(resolver.State{Addresses: []resolver.Address{lisAddr}})
+	r.InitialState(resolver.State{Addresses: resolver.AddressesToWeightedAddresses([]resolver.Address{lisAddr})})
 	client, err := Dial(r.Scheme()+":///test.server", WithInsecure(), WithTimeout(5*time.Second))
 	close(dialDone)
 	if err != nil {
@@ -131,7 +131,7 @@ func (s) TestDialWithMultipleBackendsNotSendingServerPreface(t *testing.T) {
 
 	r, cleanup := manual.GenerateAndRegisterManualResolver()
 	defer cleanup()
-	r.InitialState(resolver.State{Addresses: []resolver.Address{lis1Addr, lis2Addr}})
+	r.InitialState(resolver.State{Addresses: resolver.AddressesToWeightedAddresses([]resolver.Address{lis1Addr, lis2Addr})})
 	client, err := Dial(r.Scheme()+":///test.server", WithInsecure())
 	if err != nil {
 		t.Fatalf("Dial failed. Err: %v", err)
@@ -535,10 +535,10 @@ func (s) TestDial_OneBackoffPerRetryGroup(t *testing.T) {
 	}()
 
 	rb := manual.NewBuilderWithScheme("whatever")
-	rb.InitialState(resolver.State{Addresses: []resolver.Address{
+	rb.InitialState(resolver.State{Addresses: resolver.AddressesToWeightedAddresses([]resolver.Address{
 		{Addr: lis1.Addr().String()},
 		{Addr: lis2.Addr().String()},
-	}})
+	})})
 	client, err := DialContext(ctx, "this-gets-overwritten",
 		WithInsecure(),
 		WithBalancerName(stateRecordingBalancerName),
@@ -1055,7 +1055,7 @@ func (s) TestUpdateAddresses_RetryFromFirstAddr(t *testing.T) {
 		{Addr: lis3.Addr().String()},
 	}
 	rb := manual.NewBuilderWithScheme("whatever")
-	rb.InitialState(resolver.State{Addresses: addrsList})
+	rb.InitialState(resolver.State{Addresses: resolver.AddressesToWeightedAddresses(addrsList)})
 
 	client, err := Dial("this-gets-overwritten",
 		WithInsecure(),
@@ -1160,7 +1160,7 @@ func testDefaultServiceConfigWhenResolverServiceConfigDisabled(t *testing.T, r r
 	defer cc.Close()
 	// Resolver service config gets ignored since resolver service config is disabled.
 	r.(*manual.Resolver).UpdateState(resolver.State{
-		Addresses:     []resolver.Address{{Addr: addr}},
+		Addresses:     resolver.AddressesToWeightedAddresses([]resolver.Address{{Addr: addr}}),
 		ServiceConfig: parseCfg("{}"),
 	})
 	if !verifyWaitForReadyEqualsTrue(cc) {
@@ -1175,7 +1175,7 @@ func testDefaultServiceConfigWhenResolverDoesNotReturnServiceConfig(t *testing.T
 	}
 	defer cc.Close()
 	r.(*manual.Resolver).UpdateState(resolver.State{
-		Addresses: []resolver.Address{{Addr: addr}},
+		Addresses: resolver.AddressesToWeightedAddresses([]resolver.Address{{Addr: addr}}),
 	})
 	if !verifyWaitForReadyEqualsTrue(cc) {
 		t.Fatal("default service config failed to be applied after 1s")
@@ -1189,7 +1189,7 @@ func testDefaultServiceConfigWhenResolverReturnInvalidServiceConfig(t *testing.T
 	}
 	defer cc.Close()
 	r.(*manual.Resolver).UpdateState(resolver.State{
-		Addresses:     []resolver.Address{{Addr: addr}},
+		Addresses:     resolver.AddressesToWeightedAddresses([]resolver.Address{{Addr: addr}}),
 		ServiceConfig: nil,
 	})
 	if !verifyWaitForReadyEqualsTrue(cc) {

--- a/examples/features/debugging/client/main.go
+++ b/examples/features/debugging/client/main.go
@@ -59,7 +59,7 @@ func main() {
 	}
 	defer conn.Close()
 	// Manually provide resolved addresses for the target.
-	r.UpdateState(resolver.State{Addresses: []resolver.Address{{Addr: ":10001"}, {Addr: ":10002"}, {Addr: ":10003"}}})
+	r.UpdateState(resolver.State{Addresses: resolver.AddressesToWeightedAddresses([]resolver.Address{{Addr: ":10001"}, {Addr: ":10002"}, {Addr: ":10003"}})})
 
 	c := pb.NewGreeterClient(conn)
 

--- a/examples/features/load_balancing/client/main.go
+++ b/examples/features/load_balancing/client/main.go
@@ -115,7 +115,7 @@ func (r *exampleResolver) start() {
 	for i, s := range addrStrs {
 		addrs[i] = resolver.Address{Addr: s}
 	}
-	r.cc.UpdateState(resolver.State{Addresses: addrs})
+	r.cc.UpdateState(resolver.State{Addresses: resolver.AddressesToWeightedAddresses(addrs)})
 }
 func (*exampleResolver) ResolveNow(o resolver.ResolveNowOption) {}
 func (*exampleResolver) Close()                                 {}

--- a/examples/features/name_resolving/client/main.go
+++ b/examples/features/name_resolving/client/main.go
@@ -123,7 +123,7 @@ func (r *exampleResolver) start() {
 	for i, s := range addrStrs {
 		addrs[i] = resolver.Address{Addr: s}
 	}
-	r.cc.UpdateState(resolver.State{Addresses: addrs})
+	r.cc.UpdateState(resolver.State{Addresses: resolver.AddressesToWeightedAddresses(addrs)})
 }
 func (*exampleResolver) ResolveNow(o resolver.ResolveNowOption) {}
 func (*exampleResolver) Close()                                 {}

--- a/pickfirst_test.go
+++ b/pickfirst_test.go
@@ -60,7 +60,7 @@ func (s) TestOneBackendPickfirst(t *testing.T) {
 		t.Fatalf("EmptyCall() = _, %v, want _, DeadlineExceeded", err)
 	}
 
-	r.UpdateState(resolver.State{Addresses: []resolver.Address{{Addr: servers[0].addr}}})
+	r.UpdateState(resolver.State{Addresses: resolver.AddressesToWeightedAddresses([]resolver.Address{{Addr: servers[0].addr}})})
 	// The second RPC should succeed.
 	for i := 0; i < 1000; i++ {
 		if err = cc.Invoke(context.Background(), "/foo/bar", &req, &reply); err != nil && errorDesc(err) == servers[0].port {
@@ -93,7 +93,7 @@ func (s) TestBackendsPickfirst(t *testing.T) {
 		t.Fatalf("EmptyCall() = _, %v, want _, DeadlineExceeded", err)
 	}
 
-	r.UpdateState(resolver.State{Addresses: []resolver.Address{{Addr: servers[0].addr}, {Addr: servers[1].addr}}})
+	r.UpdateState(resolver.State{Addresses: resolver.AddressesToWeightedAddresses([]resolver.Address{{Addr: servers[0].addr}, {Addr: servers[1].addr}})})
 	// The second RPC should succeed with the first server.
 	for i := 0; i < 1000; i++ {
 		if err = cc.Invoke(context.Background(), "/foo/bar", &req, &reply); err != nil && errorDesc(err) == servers[0].port {
@@ -136,7 +136,7 @@ func (s) TestNewAddressWhileBlockingPickfirst(t *testing.T) {
 		}()
 	}
 	time.Sleep(50 * time.Millisecond)
-	r.UpdateState(resolver.State{Addresses: []resolver.Address{{Addr: servers[0].addr}}})
+	r.UpdateState(resolver.State{Addresses: resolver.AddressesToWeightedAddresses([]resolver.Address{{Addr: servers[0].addr}})})
 	wg.Wait()
 }
 
@@ -198,7 +198,7 @@ func (s) TestOneServerDownPickfirst(t *testing.T) {
 		t.Fatalf("EmptyCall() = _, %v, want _, DeadlineExceeded", err)
 	}
 
-	r.UpdateState(resolver.State{Addresses: []resolver.Address{{Addr: servers[0].addr}, {Addr: servers[1].addr}}})
+	r.UpdateState(resolver.State{Addresses: resolver.AddressesToWeightedAddresses([]resolver.Address{{Addr: servers[0].addr}, {Addr: servers[1].addr}})})
 	// The second RPC should succeed with the first server.
 	for i := 0; i < 1000; i++ {
 		if err = cc.Invoke(context.Background(), "/foo/bar", &req, &reply); err != nil && errorDesc(err) == servers[0].port {
@@ -239,7 +239,7 @@ func (s) TestAllServersDownPickfirst(t *testing.T) {
 		t.Fatalf("EmptyCall() = _, %v, want _, DeadlineExceeded", err)
 	}
 
-	r.UpdateState(resolver.State{Addresses: []resolver.Address{{Addr: servers[0].addr}, {Addr: servers[1].addr}}})
+	r.UpdateState(resolver.State{Addresses: resolver.AddressesToWeightedAddresses([]resolver.Address{{Addr: servers[0].addr}, {Addr: servers[1].addr}})})
 	// The second RPC should succeed with the first server.
 	for i := 0; i < 1000; i++ {
 		if err = cc.Invoke(context.Background(), "/foo/bar", &req, &reply); err != nil && errorDesc(err) == servers[0].port {
@@ -282,7 +282,7 @@ func (s) TestAddressesRemovedPickfirst(t *testing.T) {
 		t.Fatalf("EmptyCall() = _, %v, want _, DeadlineExceeded", err)
 	}
 
-	r.UpdateState(resolver.State{Addresses: []resolver.Address{{Addr: servers[0].addr}, {Addr: servers[1].addr}, {Addr: servers[2].addr}}})
+	r.UpdateState(resolver.State{Addresses: resolver.AddressesToWeightedAddresses([]resolver.Address{{Addr: servers[0].addr}, {Addr: servers[1].addr}, {Addr: servers[2].addr}})})
 	for i := 0; i < 1000; i++ {
 		if err = cc.Invoke(context.Background(), "/foo/bar", &req, &reply); err != nil && errorDesc(err) == servers[0].port {
 			break
@@ -297,7 +297,7 @@ func (s) TestAddressesRemovedPickfirst(t *testing.T) {
 	}
 
 	// Remove server[0].
-	r.UpdateState(resolver.State{Addresses: []resolver.Address{{Addr: servers[1].addr}, {Addr: servers[2].addr}}})
+	r.UpdateState(resolver.State{Addresses: resolver.AddressesToWeightedAddresses([]resolver.Address{{Addr: servers[1].addr}, {Addr: servers[2].addr}})})
 	for i := 0; i < 1000; i++ {
 		if err = cc.Invoke(context.Background(), "/foo/bar", &req, &reply); err != nil && errorDesc(err) == servers[1].port {
 			break
@@ -312,7 +312,7 @@ func (s) TestAddressesRemovedPickfirst(t *testing.T) {
 	}
 
 	// Append server[0], nothing should change.
-	r.UpdateState(resolver.State{Addresses: []resolver.Address{{Addr: servers[1].addr}, {Addr: servers[2].addr}, {Addr: servers[0].addr}}})
+	r.UpdateState(resolver.State{Addresses: resolver.AddressesToWeightedAddresses([]resolver.Address{{Addr: servers[1].addr}, {Addr: servers[2].addr}, {Addr: servers[0].addr}})})
 	for i := 0; i < 20; i++ {
 		if err := cc.Invoke(context.Background(), "/foo/bar", &req, &reply); err == nil || errorDesc(err) != servers[1].port {
 			t.Fatalf("Index %d: Invoke(_, _, _, _, _) = %v, want %s", 1, err, servers[1].port)
@@ -321,7 +321,7 @@ func (s) TestAddressesRemovedPickfirst(t *testing.T) {
 	}
 
 	// Remove server[1].
-	r.UpdateState(resolver.State{Addresses: []resolver.Address{{Addr: servers[2].addr}, {Addr: servers[0].addr}}})
+	r.UpdateState(resolver.State{Addresses: resolver.AddressesToWeightedAddresses([]resolver.Address{{Addr: servers[2].addr}, {Addr: servers[0].addr}})})
 	for i := 0; i < 1000; i++ {
 		if err = cc.Invoke(context.Background(), "/foo/bar", &req, &reply); err != nil && errorDesc(err) == servers[2].port {
 			break
@@ -336,7 +336,7 @@ func (s) TestAddressesRemovedPickfirst(t *testing.T) {
 	}
 
 	// Remove server[2].
-	r.UpdateState(resolver.State{Addresses: []resolver.Address{{Addr: servers[0].addr}}})
+	r.UpdateState(resolver.State{Addresses: resolver.AddressesToWeightedAddresses([]resolver.Address{{Addr: servers[0].addr}})})
 	for i := 0; i < 1000; i++ {
 		if err = cc.Invoke(context.Background(), "/foo/bar", &req, &reply); err != nil && errorDesc(err) == servers[0].port {
 			break

--- a/resolver/passthrough/passthrough.go
+++ b/resolver/passthrough/passthrough.go
@@ -45,7 +45,7 @@ type passthroughResolver struct {
 }
 
 func (r *passthroughResolver) start() {
-	r.cc.UpdateState(resolver.State{Addresses: []resolver.Address{{Addr: r.target.Endpoint}}})
+	r.cc.UpdateState(resolver.State{Addresses: []resolver.WeightedAddress{{Address : resolver.Address{Addr: r.target.Endpoint}}}})
 }
 
 func (*passthroughResolver) ResolveNow(o resolver.ResolveNowOption) {}

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -95,6 +95,27 @@ type Address struct {
 	Metadata interface{}
 }
 
+type WeightedAddress struct {
+	Address
+	Weight uint32
+}
+
+func AddressesToWeightedAddresses(addrs []Address) []WeightedAddress {
+	waddrs := make ([]WeightedAddress, len(addrs))
+	for i, addr := range addrs {
+		waddrs[i] = WeightedAddress{Address:addr}
+    }
+	return waddrs
+}
+
+func WeightedAddressesToAddresses(waddrs []WeightedAddress) []Address {
+	addrs := make ([]Address, len(waddrs))
+	for i, waddr := range waddrs {
+		addrs[i] = waddr.Address
+	}
+	return addrs
+}
+
 // BuildOption includes additional information for the builder to create
 // the resolver.
 type BuildOption struct {
@@ -104,7 +125,7 @@ type BuildOption struct {
 
 // State contains the current Resolver state relevant to the ClientConn.
 type State struct {
-	Addresses []Address // Resolved addresses for the target
+	Addresses []WeightedAddress // Resolved addresses for the target
 	// ServiceConfig is the parsed service config; obtained from
 	// serviceconfig.Parse.
 	ServiceConfig serviceconfig.Config

--- a/resolver_conn_wrapper.go
+++ b/resolver_conn_wrapper.go
@@ -124,10 +124,11 @@ func (ccr *ccResolverWrapper) NewAddress(addrs []resolver.Address) {
 		return
 	}
 	grpclog.Infof("ccResolverWrapper: sending new addresses to cc: %v", addrs)
+	weightedAddresses := resolver.AddressesToWeightedAddresses(addrs)
 	if channelz.IsOn() {
-		ccr.addChannelzTraceEvent(resolver.State{Addresses: addrs, ServiceConfig: ccr.curState.ServiceConfig})
+		ccr.addChannelzTraceEvent(resolver.State{Addresses: weightedAddresses, ServiceConfig: ccr.curState.ServiceConfig})
 	}
-	ccr.curState.Addresses = addrs
+	ccr.curState.Addresses = weightedAddresses
 	ccr.cc.updateResolverState(ccr.curState)
 }
 

--- a/test/balancer_test.go
+++ b/test/balancer_test.go
@@ -325,21 +325,21 @@ func (s) TestNonGRPCLBBalancerGetsNoGRPCLBAddress(t *testing.T) {
 	}}
 
 	r.UpdateState(resolver.State{
-		Addresses: nonGRPCLBAddresses,
+		Addresses: resolver.AddressesToWeightedAddresses(nonGRPCLBAddresses),
 	})
 	if got := <-b.addrsChan; !reflect.DeepEqual(got, nonGRPCLBAddresses) {
 		t.Fatalf("With only backend addresses, balancer got addresses %v, want %v", got, nonGRPCLBAddresses)
 	}
 
 	r.UpdateState(resolver.State{
-		Addresses: grpclbAddresses,
+		Addresses: resolver.AddressesToWeightedAddresses(grpclbAddresses),
 	})
 	if got := <-b.addrsChan; len(got) != 0 {
 		t.Fatalf("With only grpclb addresses, balancer got addresses %v, want empty", got)
 	}
 
 	r.UpdateState(resolver.State{
-		Addresses: append(grpclbAddresses, nonGRPCLBAddresses...),
+		Addresses: resolver.AddressesToWeightedAddresses(append(grpclbAddresses, nonGRPCLBAddresses...)),
 	})
 	if got := <-b.addrsChan; !reflect.DeepEqual(got, nonGRPCLBAddresses) {
 		t.Fatalf("With both backend and grpclb addresses, balancer got addresses %v, want %v", got, nonGRPCLBAddresses)

--- a/test/healthcheck_test.go
+++ b/test/healthcheck_test.go
@@ -193,7 +193,7 @@ func (s) TestHealthCheckWatchStateChange(t *testing.T) {
 	defer deferFunc()
 
 	r.UpdateState(resolver.State{
-		Addresses: []resolver.Address{{Addr: lis.Addr().String()}},
+		Addresses: resolver.AddressesToWeightedAddresses([]resolver.Address{{Addr: lis.Addr().String()}}),
 		ServiceConfig: parseCfg(`{
 	"healthCheckConfig": {
 		"serviceName": "foo"
@@ -261,7 +261,7 @@ func (s) TestHealthCheckHealthServerNotRegistered(t *testing.T) {
 	defer deferFunc()
 
 	r.UpdateState(resolver.State{
-		Addresses: []resolver.Address{{Addr: lis.Addr().String()}},
+		Addresses: resolver.AddressesToWeightedAddresses([]resolver.Address{{Addr: lis.Addr().String()}}),
 		ServiceConfig: parseCfg(`{
 	"healthCheckConfig": {
 		"serviceName": "foo"
@@ -305,7 +305,7 @@ func (s) TestHealthCheckWithGoAway(t *testing.T) {
 
 	tc := testpb.NewTestServiceClient(cc)
 	r.UpdateState(resolver.State{
-		Addresses: []resolver.Address{{Addr: lis.Addr().String()}},
+		Addresses: resolver.AddressesToWeightedAddresses([]resolver.Address{{Addr: lis.Addr().String()}}),
 		ServiceConfig: parseCfg(`{
 	"healthCheckConfig": {
 		"serviceName": "foo"
@@ -397,7 +397,7 @@ func (s) TestHealthCheckWithConnClose(t *testing.T) {
 	tc := testpb.NewTestServiceClient(cc)
 
 	r.UpdateState(resolver.State{
-		Addresses: []resolver.Address{{Addr: lis.Addr().String()}},
+		Addresses: resolver.AddressesToWeightedAddresses([]resolver.Address{{Addr: lis.Addr().String()}}),
 		ServiceConfig: parseCfg(`{
 	"healthCheckConfig": {
 		"serviceName": "foo"
@@ -463,7 +463,7 @@ func (s) TestHealthCheckWithAddrConnDrain(t *testing.T) {
 	}
 }`)
 	r.UpdateState(resolver.State{
-		Addresses:     []resolver.Address{{Addr: lis.Addr().String()}},
+		Addresses:     resolver.AddressesToWeightedAddresses([]resolver.Address{{Addr: lis.Addr().String()}}),
 		ServiceConfig: sc,
 	})
 
@@ -506,7 +506,7 @@ func (s) TestHealthCheckWithAddrConnDrain(t *testing.T) {
 	default:
 	}
 	// trigger teardown of the ac
-	r.UpdateState(resolver.State{Addresses: []resolver.Address{}, ServiceConfig: sc})
+	r.UpdateState(resolver.State{Addresses: []resolver.WeightedAddress{}, ServiceConfig: sc})
 
 	select {
 	case <-hcExitChan:
@@ -551,7 +551,7 @@ func (s) TestHealthCheckWithClientConnClose(t *testing.T) {
 
 	tc := testpb.NewTestServiceClient(cc)
 	r.UpdateState(resolver.State{
-		Addresses: []resolver.Address{{Addr: lis.Addr().String()}},
+		Addresses: resolver.AddressesToWeightedAddresses([]resolver.Address{{Addr: lis.Addr().String()}}),
 		ServiceConfig: parseCfg(`{
 	"healthCheckConfig": {
 		"serviceName": "foo"
@@ -636,7 +636,7 @@ func (s) TestHealthCheckWithoutSetConnectivityStateCalledAddrConnShutDown(t *tes
 	}
 }`)
 	r.UpdateState(resolver.State{
-		Addresses:     []resolver.Address{{Addr: lis.Addr().String()}},
+		Addresses:     resolver.AddressesToWeightedAddresses([]resolver.Address{{Addr: lis.Addr().String()}}),
 		ServiceConfig: sc,
 	})
 
@@ -652,7 +652,7 @@ func (s) TestHealthCheckWithoutSetConnectivityStateCalledAddrConnShutDown(t *tes
 		t.Fatal("Health check function has not been invoked after 5s.")
 	}
 	// trigger teardown of the ac, ac in SHUTDOWN state
-	r.UpdateState(resolver.State{Addresses: []resolver.Address{}, ServiceConfig: sc})
+	r.UpdateState(resolver.State{Addresses: []resolver.WeightedAddress{}, ServiceConfig: sc})
 
 	// The health check func should exit without calling the setConnectivityState func, as server hasn't sent
 	// any response.
@@ -707,7 +707,7 @@ func (s) TestHealthCheckWithoutSetConnectivityStateCalled(t *testing.T) {
 	// back to client immediately upon receiving the request (client should receive no response until
 	// test ends).
 	r.UpdateState(resolver.State{
-		Addresses: []resolver.Address{{Addr: lis.Addr().String()}},
+		Addresses: resolver.AddressesToWeightedAddresses([]resolver.Address{{Addr: lis.Addr().String()}}),
 		ServiceConfig: parseCfg(`{
 	"healthCheckConfig": {
 		"serviceName": "delay"
@@ -755,7 +755,7 @@ func testHealthCheckDisableWithDialOption(t *testing.T, addr string) {
 	tc := testpb.NewTestServiceClient(cc)
 
 	r.UpdateState(resolver.State{
-		Addresses: []resolver.Address{{Addr: addr}},
+		Addresses: resolver.AddressesToWeightedAddresses([]resolver.Address{{Addr: addr}}),
 		ServiceConfig: parseCfg(`{
 	"healthCheckConfig": {
 		"serviceName": "foo"
@@ -794,7 +794,7 @@ func testHealthCheckDisableWithBalancer(t *testing.T, addr string) {
 	tc := testpb.NewTestServiceClient(cc)
 
 	r.UpdateState(resolver.State{
-		Addresses: []resolver.Address{{Addr: addr}},
+		Addresses: resolver.AddressesToWeightedAddresses([]resolver.Address{{Addr: addr}}),
 		ServiceConfig: parseCfg(`{
 	"healthCheckConfig": {
 		"serviceName": "foo"
@@ -832,7 +832,7 @@ func testHealthCheckDisableWithServiceConfig(t *testing.T, addr string) {
 
 	tc := testpb.NewTestServiceClient(cc)
 
-	r.UpdateState(resolver.State{Addresses: []resolver.Address{{Addr: addr}}})
+	r.UpdateState(resolver.State{Addresses: resolver.AddressesToWeightedAddresses([]resolver.Address{{Addr: addr}})})
 
 	// send some rpcs to make sure transport has been created and is ready for use.
 	if err := verifyResultWithDelay(func() (bool, error) {
@@ -887,7 +887,7 @@ func (s) TestHealthCheckChannelzCountingCallSuccess(t *testing.T) {
 	defer deferFunc()
 
 	r.UpdateState(resolver.State{
-		Addresses: []resolver.Address{{Addr: lis.Addr().String()}},
+		Addresses: resolver.AddressesToWeightedAddresses([]resolver.Address{{Addr: lis.Addr().String()}}),
 		ServiceConfig: parseCfg(`{
 	"healthCheckConfig": {
 		"serviceName": "channelzSuccess"
@@ -943,7 +943,7 @@ func (s) TestHealthCheckChannelzCountingCallFailure(t *testing.T) {
 	defer deferFunc()
 
 	r.UpdateState(resolver.State{
-		Addresses: []resolver.Address{{Addr: lis.Addr().String()}},
+		Addresses: resolver.AddressesToWeightedAddresses([]resolver.Address{{Addr: lis.Addr().String()}}),
 		ServiceConfig: parseCfg(`{
 	"healthCheckConfig": {
 		"serviceName": "channelzFailure"


### PR DESCRIPTION
To make code backward compatible Weight is added to new struct resolver.WeightedAddress having old Address untouched.
