### PR TITLE
server: populate WireLength on stats.InPayload for unary RPCs (#2932)

### DIFF
--- a/server.go
+++ b/server.go
@@ -978,10 +978,11 @@ func (s *Server) processUnaryRPC(t transport.ServerTransport, stream *transport.
 		}
 		if sh != nil {
 			sh.HandleRPC(stream.Context(), &stats.InPayload{
-				RecvTime: time.Now(),
-				Payload:  v,
-				Data:     d,
-				Length:   len(d),
+				RecvTime:   time.Now(),
+				Payload:    v,
+				WireLength: payInfo.wireLength,
+				Data:       d,
+				Length:     len(d),
 			})
 		}
 		if binlog != nil {

--- a/stats/stats_test.go
+++ b/stats/stats_test.go
@@ -511,7 +511,12 @@ func checkInPayload(t *testing.T, d *gotData, e *expectedData) {
 			t.Fatalf("st.Lenght = %v, want %v", st.Length, len(b))
 		}
 	}
-	// TODO check WireLength and ReceivedTime.
+	// Below are sanity checks that WireLength and RecvTime are populated.
+	// TODO: check values of WireLength and RecvTime.
+	if len(st.Data) > 0 && st.WireLength == 0 {
+		t.Fatalf("st.WireLength = %v with non-empty data, want <non-zero>",
+			st.WireLength)
+	}
 	if st.RecvTime.IsZero() {
 		t.Fatalf("st.ReceivedTime = %v, want <non-zero>", st.RecvTime)
 	}
@@ -603,7 +608,12 @@ func checkOutPayload(t *testing.T, d *gotData, e *expectedData) {
 			t.Fatalf("st.Lenght = %v, want %v", st.Length, len(b))
 		}
 	}
-	// TODO check WireLength and ReceivedTime.
+	// Below are sanity checks that WireLength and SentTime are populated.
+	// TODO: check values of WireLength and SentTime.
+	if len(st.Data) > 0 && st.WireLength == 0 {
+		t.Fatalf("st.WireLength = %v with non-empty data, want <non-zero>",
+			st.WireLength)
+	}
 	if st.SentTime.IsZero() {
 		t.Fatalf("st.SentTime = %v, want <non-zero>", st.SentTime)
 	}


### PR DESCRIPTION
Backport of #2932 to v1.21.x.