### PR TITLE
Reuse read buffers between messages in a stream

### DIFF
--- a/call_test.go
+++ b/call_test.go
@@ -67,7 +67,7 @@ type testStreamHandler struct {
 func (h *testStreamHandler) handleStream(t *testing.T, s *transport.Stream) {
 	p := &parser{r: s}
 	for {
-		pf, req, err := p.recvMsg(math.MaxInt32)
+		pf, err := p.recvMsg(math.MaxInt32)
 		if err == io.EOF {
 			break
 		}
@@ -80,7 +80,7 @@ func (h *testStreamHandler) handleStream(t *testing.T, s *transport.Stream) {
 		}
 		var v string
 		codec := testCodec{}
-		if err := codec.Unmarshal(req, &v); err != nil {
+		if err := codec.Unmarshal(p.msg, &v); err != nil {
 			t.Errorf("Failed to unmarshal the received message: %v", err)
 			return
 		}

--- a/rpc_util_test.go
+++ b/rpc_util_test.go
@@ -66,9 +66,9 @@ func (s) TestSimpleParsing(t *testing.T) {
 	} {
 		buf := fullReader{bytes.NewReader(test.p)}
 		parser := &parser{r: buf}
-		pt, b, err := parser.recvMsg(math.MaxInt32)
-		if err != test.err || !bytes.Equal(b, test.b) || pt != test.pt {
-			t.Fatalf("parser{%v}.recvMsg(_) = %v, %v, %v\nwant %v, %v, %v", test.p, pt, b, err, test.pt, test.b, test.err)
+		pt, err := parser.recvMsg(math.MaxInt32)
+		if err != test.err || !bytes.Equal(parser.msg, test.b) || pt != test.pt {
+			t.Fatalf("parser{%v}.recvMsg(_) = %v, %v, %v\nwant %v, %v, %v", test.p, pt, parser.msg, err, test.pt, test.b, test.err)
 		}
 	}
 }


### PR DESCRIPTION
In future we could also pre-initialize the buffer in `parser` with a slice that came out of a side pool (for example to reuse buffers across streams or for unary RPCs).

I took a look at how we use the `uncompressedBytes` we hand out and it seems things should be mostly-safe. The one thing I'm worried about is the `HandleRPC` of stats logger can technically do whatever it wants with the reference.

We could be super-safe by storing a copy of the buffer in that field (and adding an option to not put the uncompress payload in there for users not wishing to pay the price). WDYT?