### PR TITLE
Gate normal connection info messages behind vebose

### DIFF
--- a/balancer_v1_wrapper.go
+++ b/balancer_v1_wrapper.go
@@ -113,7 +113,9 @@ func (bw *balancerWrapper) lbWatcher() {
 	}
 
 	for addrs := range notifyCh {
-		grpclog.Infof("balancerWrapper: got update addr from Notify: %v", addrs)
+		if grpclog.V(2) {
+			grpclog.Infof("balancerWrapper: got update addr from Notify: %v", addrs)
+		}
 		if bw.pickfirst {
 			var (
 				oldA  resolver.Address

--- a/clientconn.go
+++ b/clientconn.go
@@ -242,13 +242,17 @@ func DialContext(ctx context.Context, target string, opts ...DialOption) (conn *
 	if cc.dopts.resolverBuilder == nil {
 		// Only try to parse target when resolver builder is not already set.
 		cc.parsedTarget = parseTarget(cc.target)
-		grpclog.Infof("parsed scheme: %q", cc.parsedTarget.Scheme)
+		if grpclog.V(2) {
+			grpclog.Infof("parsed scheme: %q", cc.parsedTarget.Scheme)
+		}
 		cc.dopts.resolverBuilder = resolver.Get(cc.parsedTarget.Scheme)
 		if cc.dopts.resolverBuilder == nil {
 			// If resolver builder is still nil, the parsed target's scheme is
 			// not registered. Fallback to default resolver and set Endpoint to
 			// the original target.
-			grpclog.Infof("scheme %q not registered, fallback to default scheme", cc.parsedTarget.Scheme)
+			if grpclog.V(2) {
+				grpclog.Infof("scheme %q not registered, fallback to default scheme", cc.parsedTarget.Scheme)
+			}
 			cc.parsedTarget = resolver.Target{
 				Scheme:   resolver.GetDefaultScheme(),
 				Endpoint: target,

--- a/resolver_conn_wrapper.go
+++ b/resolver_conn_wrapper.go
@@ -110,7 +110,9 @@ func (ccr *ccResolverWrapper) UpdateState(s resolver.State) {
 	if ccr.isDone() {
 		return
 	}
-	grpclog.Infof("ccResolverWrapper: sending update to cc: %v", s)
+	if grpclog.V(2) {
+		grpclog.Infof("ccResolverWrapper: sending update to cc: %v", s)
+	}
 	if channelz.IsOn() {
 		ccr.addChannelzTraceEvent(s)
 	}
@@ -123,7 +125,9 @@ func (ccr *ccResolverWrapper) NewAddress(addrs []resolver.Address) {
 	if ccr.isDone() {
 		return
 	}
-	grpclog.Infof("ccResolverWrapper: sending new addresses to cc: %v", addrs)
+	if grpclog.V(2) {
+		grpclog.Infof("ccResolverWrapper: sending new addresses to cc: %v", addrs)
+	}
 	if channelz.IsOn() {
 		ccr.addChannelzTraceEvent(resolver.State{Addresses: addrs, ServiceConfig: ccr.curState.ServiceConfig})
 	}
@@ -137,7 +141,9 @@ func (ccr *ccResolverWrapper) NewServiceConfig(sc string) {
 	if ccr.isDone() {
 		return
 	}
-	grpclog.Infof("ccResolverWrapper: got new service config: %v", sc)
+	if grpclog.V(2) {
+		grpclog.Infof("ccResolverWrapper: got new service config: %v", sc)
+	}
 	c, err := parseServiceConfig(sc)
 	if err != nil {
 		return


### PR DESCRIPTION
This makes common info messages from the balancer and schema systems only show up under verbose log level since they aren't really relevant for most applications unless you're specifically debugging GRPC.

Made to fix https://github.com/kubernetes/kubernetes/issues/80741