### PR TITLE
Introduce PickerBuilderV2 that can take address weight into account.

### DIFF
--- a/balancer/base/balancer.go
+++ b/balancer/base/balancer.go
@@ -38,7 +38,7 @@ func (bb *baseBuilder) Build(cc balancer.ClientConn, opt balancer.BuildOptions) 
 		cc:            cc,
 		pickerBuilder: bb.pickerBuilder,
 
-		subConns: make(map[resolver.Address]balancer.SubConn),
+		subConns: make(map[resolver.Address]AddrInfo),
 		scStates: make(map[balancer.SubConn]connectivity.State),
 		csEvltr:  &balancer.ConnectivityStateEvaluator{},
 		// Initialize picker to a picker that always return
@@ -60,7 +60,7 @@ type baseBalancer struct {
 	csEvltr *balancer.ConnectivityStateEvaluator
 	state   connectivity.State
 
-	subConns map[resolver.Address]balancer.SubConn
+	subConns map[resolver.Address]AddrInfo
 	scStates map[balancer.SubConn]connectivity.State
 	picker   balancer.Picker
 	config   Config
@@ -85,7 +85,11 @@ func (b *baseBalancer) UpdateClientConnState(s balancer.ClientConnState) {
 				grpclog.Warningf("base.baseBalancer: failed to create new SubConn: %v", err)
 				continue
 			}
-			b.subConns[a] = sc
+			addrInfo := AddrInfo{SubConn: sc}
+			if s.ResolverState.AddrWeights != nil && s.ResolverState.AddrWeights[a] > 0 {
+				addrInfo.Weight = s.ResolverState.AddrWeights[a]
+			}
+			b.subConns[a] = addrInfo
 			b.scStates[sc] = connectivity.Idle
 			sc.Connect()
 		}
@@ -93,7 +97,7 @@ func (b *baseBalancer) UpdateClientConnState(s balancer.ClientConnState) {
 	for a, sc := range b.subConns {
 		// a was removed by resolver.
 		if _, ok := addrsSet[a]; !ok {
-			b.cc.RemoveSubConn(sc)
+			b.cc.RemoveSubConn(sc.SubConn)
 			delete(b.subConns, a)
 			// Keep the state of this sc in b.scStates until sc's state becomes Shutdown.
 			// The entry will be deleted in HandleSubConnStateChange.
@@ -110,15 +114,28 @@ func (b *baseBalancer) regeneratePicker() {
 		b.picker = NewErrPicker(balancer.ErrTransientFailure)
 		return
 	}
-	readySCs := make(map[resolver.Address]balancer.SubConn)
+	pickerBuilderV2, ok := b.pickerBuilder.(PickerBuilderV2)
+	if ok {
+		readySCs := make(map[resolver.Address]AddrInfo)
 
-	// Filter out all ready SCs from full subConn map.
-	for addr, sc := range b.subConns {
-		if st, ok := b.scStates[sc]; ok && st == connectivity.Ready {
-			readySCs[addr] = sc
+		// Filter out all ready SCs from full subConn map.
+		for addr, sc := range b.subConns {
+			if st, ok := b.scStates[sc.SubConn]; ok && st == connectivity.Ready {
+				readySCs[addr] = sc
+			}
 		}
+		b.picker = pickerBuilderV2.BuildV2(readySCs)
+	} else {
+		readySCs := make(map[resolver.Address]balancer.SubConn)
+
+		// Filter out all ready SCs from full subConn map.
+		for addr, sc := range b.subConns {
+			if st, ok := b.scStates[sc.SubConn]; ok && st == connectivity.Ready {
+				readySCs[addr] = sc.SubConn
+			}
+		}
+		b.picker = b.pickerBuilder.Build(readySCs)
 	}
-	b.picker = b.pickerBuilder.Build(readySCs)
 }
 
 func (b *baseBalancer) HandleSubConnStateChange(sc balancer.SubConn, s connectivity.State) {

--- a/balancer/base/base.go
+++ b/balancer/base/base.go
@@ -42,6 +42,16 @@ type PickerBuilder interface {
 	Build(readySCs map[resolver.Address]balancer.SubConn) balancer.Picker
 }
 
+type AddrInfo struct {
+	SubConn balancer.SubConn
+	Weight uint32
+}
+
+type PickerBuilderV2 interface {
+	PickerBuilder
+	BuildV2(readySCs map[resolver.Address]AddrInfo) balancer.Picker
+}
+
 // NewBalancerBuilder returns a balancer builder. The balancers
 // built by this builder will use the picker builder to build pickers.
 func NewBalancerBuilder(name string, pb PickerBuilder) balancer.Builder {

--- a/balancer/xds/edsbalancer/balancergroup.go
+++ b/balancer/xds/edsbalancer/balancergroup.go
@@ -198,7 +198,7 @@ func (bg *balancerGroup) handleSubConnStateChange(sc balancer.SubConn, state con
 }
 
 // Address change: forward to balancer.
-func (bg *balancerGroup) handleResolvedAddrs(id internal.Locality, addrs []resolver.Address) {
+func (bg *balancerGroup) handleResolvedAddrs(id internal.Locality, addrs []resolver.Address, addrWeights map[resolver.Address]uint32) {
 	bg.mu.Lock()
 	b, ok := bg.idToBalancer[id]
 	bg.mu.Unlock()
@@ -207,7 +207,7 @@ func (bg *balancerGroup) handleResolvedAddrs(id internal.Locality, addrs []resol
 		return
 	}
 	if ub, ok := b.(balancer.V2Balancer); ok {
-		ub.UpdateClientConnState(balancer.ClientConnState{ResolverState: resolver.State{Addresses: addrs}})
+		ub.UpdateClientConnState(balancer.ClientConnState{ResolverState: resolver.State{Addresses: addrs, AddrWeights: addrWeights}})
 	} else {
 		b.HandleResolvedAddrs(addrs, nil)
 	}

--- a/balancer/xds/edsbalancer/balancergroup_test.go
+++ b/balancer/xds/edsbalancer/balancergroup_test.go
@@ -43,7 +43,7 @@ func TestBalancerGroup_OneRR_AddRemoveBackend(t *testing.T) {
 	// Add one balancer to group.
 	bg.add(testBalancerIDs[0], 1, rrBuilder)
 	// Send one resolved address.
-	bg.handleResolvedAddrs(testBalancerIDs[0], testBackendAddrs[0:1])
+	bg.handleResolvedAddrs(testBalancerIDs[0], testBackendAddrs[0:1], nil)
 
 	// Send subconn state change.
 	sc1 := <-cc.newSubConnCh
@@ -60,7 +60,7 @@ func TestBalancerGroup_OneRR_AddRemoveBackend(t *testing.T) {
 	}
 
 	// Send two addresses.
-	bg.handleResolvedAddrs(testBalancerIDs[0], testBackendAddrs[0:2])
+	bg.handleResolvedAddrs(testBalancerIDs[0], testBackendAddrs[0:2], nil)
 	// Expect one new subconn, send state update.
 	sc2 := <-cc.newSubConnCh
 	bg.handleSubConnStateChange(sc2, connectivity.Connecting)
@@ -77,7 +77,7 @@ func TestBalancerGroup_OneRR_AddRemoveBackend(t *testing.T) {
 	}
 
 	// Remove the first address.
-	bg.handleResolvedAddrs(testBalancerIDs[0], testBackendAddrs[1:2])
+	bg.handleResolvedAddrs(testBalancerIDs[0], testBackendAddrs[1:2], nil)
 	scToRemove := <-cc.removeSubConnCh
 	if !reflect.DeepEqual(scToRemove, sc1) {
 		t.Fatalf("RemoveSubConn, want %v, got %v", sc1, scToRemove)
@@ -102,11 +102,11 @@ func TestBalancerGroup_TwoRR_OneBackend(t *testing.T) {
 	// Add two balancers to group and send one resolved address to both
 	// balancers.
 	bg.add(testBalancerIDs[0], 1, rrBuilder)
-	bg.handleResolvedAddrs(testBalancerIDs[0], testBackendAddrs[0:1])
+	bg.handleResolvedAddrs(testBalancerIDs[0], testBackendAddrs[0:1], nil)
 	sc1 := <-cc.newSubConnCh
 
 	bg.add(testBalancerIDs[1], 1, rrBuilder)
-	bg.handleResolvedAddrs(testBalancerIDs[1], testBackendAddrs[0:1])
+	bg.handleResolvedAddrs(testBalancerIDs[1], testBackendAddrs[0:1], nil)
 	sc2 := <-cc.newSubConnCh
 
 	// Send state changes for both subconns.
@@ -134,12 +134,12 @@ func TestBalancerGroup_TwoRR_MoreBackends(t *testing.T) {
 	// Add two balancers to group and send one resolved address to both
 	// balancers.
 	bg.add(testBalancerIDs[0], 1, rrBuilder)
-	bg.handleResolvedAddrs(testBalancerIDs[0], testBackendAddrs[0:2])
+	bg.handleResolvedAddrs(testBalancerIDs[0], testBackendAddrs[0:2], nil)
 	sc1 := <-cc.newSubConnCh
 	sc2 := <-cc.newSubConnCh
 
 	bg.add(testBalancerIDs[1], 1, rrBuilder)
-	bg.handleResolvedAddrs(testBalancerIDs[1], testBackendAddrs[2:4])
+	bg.handleResolvedAddrs(testBalancerIDs[1], testBackendAddrs[2:4], nil)
 	sc3 := <-cc.newSubConnCh
 	sc4 := <-cc.newSubConnCh
 
@@ -177,7 +177,7 @@ func TestBalancerGroup_TwoRR_MoreBackends(t *testing.T) {
 	}
 
 	// Remove sc3's addresses.
-	bg.handleResolvedAddrs(testBalancerIDs[1], testBackendAddrs[3:4])
+	bg.handleResolvedAddrs(testBalancerIDs[1], testBackendAddrs[3:4], nil)
 	scToRemove := <-cc.removeSubConnCh
 	if !reflect.DeepEqual(scToRemove, sc3) {
 		t.Fatalf("RemoveSubConn, want %v, got %v", sc3, scToRemove)
@@ -230,12 +230,12 @@ func TestBalancerGroup_TwoRR_DifferentWeight_MoreBackends(t *testing.T) {
 	// Add two balancers to group and send two resolved addresses to both
 	// balancers.
 	bg.add(testBalancerIDs[0], 2, rrBuilder)
-	bg.handleResolvedAddrs(testBalancerIDs[0], testBackendAddrs[0:2])
+	bg.handleResolvedAddrs(testBalancerIDs[0], testBackendAddrs[0:2], nil)
 	sc1 := <-cc.newSubConnCh
 	sc2 := <-cc.newSubConnCh
 
 	bg.add(testBalancerIDs[1], 1, rrBuilder)
-	bg.handleResolvedAddrs(testBalancerIDs[1], testBackendAddrs[2:4])
+	bg.handleResolvedAddrs(testBalancerIDs[1], testBackendAddrs[2:4], nil)
 	sc3 := <-cc.newSubConnCh
 	sc4 := <-cc.newSubConnCh
 
@@ -268,15 +268,15 @@ func TestBalancerGroup_ThreeRR_RemoveBalancer(t *testing.T) {
 	// Add three balancers to group and send one resolved address to both
 	// balancers.
 	bg.add(testBalancerIDs[0], 1, rrBuilder)
-	bg.handleResolvedAddrs(testBalancerIDs[0], testBackendAddrs[0:1])
+	bg.handleResolvedAddrs(testBalancerIDs[0], testBackendAddrs[0:1], nil)
 	sc1 := <-cc.newSubConnCh
 
 	bg.add(testBalancerIDs[1], 1, rrBuilder)
-	bg.handleResolvedAddrs(testBalancerIDs[1], testBackendAddrs[1:2])
+	bg.handleResolvedAddrs(testBalancerIDs[1], testBackendAddrs[1:2], nil)
 	sc2 := <-cc.newSubConnCh
 
 	bg.add(testBalancerIDs[2], 1, rrBuilder)
-	bg.handleResolvedAddrs(testBalancerIDs[2], testBackendAddrs[1:2])
+	bg.handleResolvedAddrs(testBalancerIDs[2], testBackendAddrs[1:2], nil)
 	sc3 := <-cc.newSubConnCh
 
 	// Send state changes for both subconns.
@@ -335,12 +335,12 @@ func TestBalancerGroup_TwoRR_ChangeWeight_MoreBackends(t *testing.T) {
 	// Add two balancers to group and send two resolved addresses to both
 	// balancers.
 	bg.add(testBalancerIDs[0], 2, rrBuilder)
-	bg.handleResolvedAddrs(testBalancerIDs[0], testBackendAddrs[0:2])
+	bg.handleResolvedAddrs(testBalancerIDs[0], testBackendAddrs[0:2], nil)
 	sc1 := <-cc.newSubConnCh
 	sc2 := <-cc.newSubConnCh
 
 	bg.add(testBalancerIDs[1], 1, rrBuilder)
-	bg.handleResolvedAddrs(testBalancerIDs[1], testBackendAddrs[2:4])
+	bg.handleResolvedAddrs(testBalancerIDs[1], testBackendAddrs[2:4], nil)
 	sc3 := <-cc.newSubConnCh
 	sc4 := <-cc.newSubConnCh
 
@@ -388,14 +388,14 @@ func TestBalancerGroup_LoadReport(t *testing.T) {
 	// Add two balancers to group and send two resolved addresses to both
 	// balancers.
 	bg.add(testBalancerIDs[0], 2, rrBuilder)
-	bg.handleResolvedAddrs(testBalancerIDs[0], testBackendAddrs[0:2])
+	bg.handleResolvedAddrs(testBalancerIDs[0], testBackendAddrs[0:2], nil)
 	sc1 := <-cc.newSubConnCh
 	sc2 := <-cc.newSubConnCh
 	backendToBalancerID[sc1] = testBalancerIDs[0]
 	backendToBalancerID[sc2] = testBalancerIDs[0]
 
 	bg.add(testBalancerIDs[1], 1, rrBuilder)
-	bg.handleResolvedAddrs(testBalancerIDs[1], testBackendAddrs[2:4])
+	bg.handleResolvedAddrs(testBalancerIDs[1], testBackendAddrs[2:4], nil)
 	sc3 := <-cc.newSubConnCh
 	sc4 := <-cc.newSubConnCh
 	backendToBalancerID[sc3] = testBalancerIDs[1]

--- a/balancer/xds/xds.go
+++ b/balancer/xds/xds.go
@@ -255,6 +255,7 @@ func (x *xdsBalancer) handleGRPCUpdate(update interface{}) {
 				x.config = cfg
 				x.fallbackInitData = &resolver.State{
 					Addresses: u.ResolverState.Addresses,
+					AddrWeights: u.ResolverState.AddrWeights,
 					// TODO(yuxuanli): get the fallback balancer config once the validation change completes, where
 					// we can pass along the config struct.
 				}
@@ -280,15 +281,19 @@ func (x *xdsBalancer) handleGRPCUpdate(update interface{}) {
 			}
 		}
 
-		if x.fallbackLB != nil && (!reflect.DeepEqual(x.fallbackInitData.Addresses, u.ResolverState.Addresses) || fallbackChanged) {
+		if x.fallbackLB != nil && (
+			!reflect.DeepEqual(x.fallbackInitData.Addresses, u.ResolverState.Addresses) ||
+			!reflect.DeepEqual(x.fallbackInitData.AddrWeights, u.ResolverState.AddrWeights) || fallbackChanged) {
 			x.updateFallbackWithResolverState(&resolver.State{
 				Addresses: u.ResolverState.Addresses,
+				AddrWeights: u.ResolverState.AddrWeights,
 			})
 		}
 
 		x.config = cfg
 		x.fallbackInitData = &resolver.State{
 			Addresses: u.ResolverState.Addresses,
+			AddrWeights: u.ResolverState.AddrWeights,
 			// TODO(yuxuanli): get the fallback balancer config once the validation change completes, where
 			// we can pass along the config struct.
 		}

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -109,6 +109,8 @@ type State struct {
 	// serviceconfig.Parse.
 	ServiceConfig serviceconfig.Config
 
+	AddrWeights map[Address]uint32 // Weights of addresses to be use for load balancing
+
 	// TODO: add Err error
 }
 


### PR DESCRIPTION
Weights are stored in resolver.State struct as a new Address->weight map.