### PR TITLE
stream: do not retry on nil clientStream

### DIFF
--- a/stream.go
+++ b/stream.go
@@ -689,6 +689,9 @@ func (cs *clientStream) SendMsg(m interface{}) (err error) {
 	}
 	msgBytes := data // Store the pointer before setting to nil. For binary logging.
 	op := func(a *csAttempt) error {
+		if a.s == nil {
+			return nil
+		}
 		err := a.sendMsg(m, hdr, payload, data)
 		// nil out the message and uncomp when replaying; they are only needed for
 		// stats which is disabled for subsequent attempts.


### PR DESCRIPTION
Fix the panic in

```
=== RUN   TestLeasingNonOwnerPutError
{"level":"warn","ts":"2019-08-03T07:18:10.564Z","caller":"clientv3/retry_interceptor.go:61","msg":"retrying of unary invoker failed","target":"endpoint://client-99ab9134-5b05-46e0-965d-601c54493c53/localhost:1341936467916325720","attempt":0,"error":"rpc error: code = DeadlineExceeded desc = latest connection error: connection error: desc = \"transport: Error while dialing dial unix localhost:1341936467916325720: connect: no such file or directory\""}
{"level":"warn","ts":"2019-08-03T07:18:10.565Z","caller":"clientv3/retry_interceptor.go:61","msg":"retrying of unary invoker failed","target":"endpoint://client-99ab9134-5b05-46e0-965d-601c54493c53/localhost:1341936467916325720","attempt":0,"error":"rpc error: code = DeadlineExceeded desc = context deadline exceeded"}
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x68 pc=0xbc42f5]

goroutine 26716 [running]:
go.etcd.io/etcd/vendor/google.golang.org/grpc.(*csAttempt).sendMsg(0xc00017e700, 0x146c6c0, 0xc000038580, 0xc000038588, 0x5, 0x5, 0xc000038590, 0xa, 0xa, 0xc000038590, ...)
	/go/src/go.etcd.io/etcd/vendor/google.golang.org/grpc/stream.go:827 +0x155
go.etcd.io/etcd/vendor/google.golang.org/grpc.(*clientStream).SendMsg.func2(0xc00017e700, 0x0, 0xc001cdca50)
	/go/src/go.etcd.io/etcd/vendor/google.golang.org/grpc/stream.go:692 +0x186
go.etcd.io/etcd/vendor/google.golang.org/grpc.(*clientStream).withRetry(0xc000392120, 0xc001cdca50, 0xc0012b8d38, 0x20c62f8, 0x0)
	/go/src/go.etcd.io/etcd/vendor/google.golang.org/grpc/stream.go:572 +0x43d
go.etcd.io/etcd/vendor/google.golang.org/grpc.(*clientStream).SendMsg(0xc000392120, 0x146c6c0, 0xc000038580, 0x0, 0x0)
	/go/src/go.etcd.io/etcd/vendor/google.golang.org/grpc/stream.go:698 +0x644
go.etcd.io/etcd/etcdserver/etcdserverpb.(*leaseLeaseKeepAliveClient).Send(0xc001cb2560, 0xc000038580, 0x0, 0x0)
	/go/src/go.etcd.io/etcd/etcdserver/etcdserverpb/rpc.pb.go:3828 +0x6b
go.etcd.io/etcd/clientv3.(*lessor).sendKeepAliveLoop(0xc001c68a00, 0x1768ae0, 0xc001cb2560)
	/go/src/go.etcd.io/etcd/clientv3/lease.go:573 +0x2d5
created by go.etcd.io/etcd/clientv3.(*lessor).resetRecv
	/go/src/go.etcd.io/etcd/clientv3/lease.go:489 +0x345
FAIL	go.etcd.io/etcd/clientv3/integration	136.425s
```

Or

```
go test -v -run TestLeasingTxnOwnerIf
```