### PR TITLE
transport: Change Unlock to defer Unlock, to avoid data race

### DIFF
--- a/internal/transport/flowcontrol.go
+++ b/internal/transport/flowcontrol.go
@@ -149,6 +149,7 @@ func (f *inFlow) maybeAdjust(n uint32) uint32 {
 		n = uint32(math.MaxInt32)
 	}
 	f.mu.Lock()
+	defer f.mu.Unlock()
 	// estSenderQuota is the receiver's view of the maximum number of bytes the sender
 	// can send without a window update.
 	estSenderQuota := int32(f.limit - (f.pendingData + f.pendingUpdate))
@@ -169,10 +170,8 @@ func (f *inFlow) maybeAdjust(n uint32) uint32 {
 			// is padded; We will fallback on the current available window(at least a 1/4th of the limit).
 			f.delta = n
 		}
-		f.mu.Unlock()
 		return f.delta
 	}
-	f.mu.Unlock()
 	return 0
 }
 


### PR DESCRIPTION
***Description***
Among 8 read/write operations to f.delta, 7 of them are protected by `f.mu.Lock()`, but the one at line 173 of file grpc/internal/transport/flowcontrol.go is not protected. In order to avoid potential data race here, I use `defer f.mu.Unlock()` to make sure that all usages of f.delta is in critical section.

***Buggy code***
The last read operation of f.delta happens after `f.mu.Unlock()`:
https://github.com/grpc/grpc-go/blob/92635fa6bffd9db9b2cca8ce8f978bfebabd9c29/internal/transport/flowcontrol.go#L162-L174