### PR TITLE
stream: do not reference nil pointer context

### DIFF
--- a/stream.go
+++ b/stream.go
@@ -559,6 +559,9 @@ func (cs *clientStream) retryLocked(lastErr error) error {
 
 func (cs *clientStream) Context() context.Context {
 	cs.commitAttempt()
+	if cs.attempt.s == nil {
+		return nil
+	}
 	// No need to lock before using attempt, since we know it is committed and
 	// cannot change.
 	return cs.attempt.s.Context()


### PR DESCRIPTION
Fix

```
=== RUN   TestLeasingNonOwnerPutError
{"level":"warn","ts":"2019-08-04T02:13:05.300Z","caller":"clientv3/retry_interceptor.go:61","msg":"retrying of unary invoker failed","target":"endpoint://client-1e17e7fb-c8b4-43a1-9d89-79ca429efaef/localhost:51782595789236259660","attempt":0,"error":"rpc error: code = DeadlineExceeded desc = latest connection error: connection error: desc = \"transport: Error while dialing dial unix localhost:51782595789236259660: connect: no such file or directory\""}
{"level":"warn","ts":"2019-08-04T02:13:05.300Z","caller":"clientv3/retry_interceptor.go:61","msg":"retrying of unary invoker failed","target":"endpoint://client-1e17e7fb-c8b4-43a1-9d89-79ca429efaef/localhost:51782595789236259660","attempt":0,"error":"rpc error: code = DeadlineExceeded desc = context deadline exceeded"}


[DEBUG] about to panic! true
this prints out when a.s == nil before the line
err := a.sendMsg(m, hdr, payload, data)


panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xbc1cb2]
goroutine 27073 [running]:
go.etcd.io/etcd/vendor/google.golang.org/grpc/internal/transport.(*Stream).Context(...)
	/go/src/go.etcd.io/etcd/vendor/google.golang.org/grpc/internal/transport/transport.go:386
go.etcd.io/etcd/vendor/google.golang.org/grpc.(*clientStream).Context(0xc0017a4480, 0xc001a7d080, 0x7f8cbd54b6)
	/go/src/go.etcd.io/etcd/vendor/google.golang.org/grpc/stream.go:565 +0x82
go.etcd.io/etcd/clientv3.(*lessor).sendKeepAliveLoop(0xc0000efb80, 0x1769b40, 0xc001a09d70)
	/go/src/go.etcd.io/etcd/clientv3/lease.go:581 +0x349
created by go.etcd.io/etcd/clientv3.(*lessor).resetRecv
	/go/src/go.etcd.io/etcd/clientv3/lease.go:489 +0x345
FAIL	go.etcd.io/etcd/clientv3/integration	142.556s
```
