### PR TITLE
bufconn: Implement read/write deadlines

### DIFF
--- a/test/bufconn/bufconn_test.go
+++ b/test/bufconn/bufconn_test.go
@@ -197,3 +197,122 @@ func TestCloseWhileAccepting(t *testing.T) {
 		t.Fatalf("c, err = %v, %v; want nil, %v", c, err, errClosed)
 	}
 }
+
+func TestDeadline(t *testing.T) {
+	sig := make(chan error)
+	blockingWrite := func(conn net.Conn) {
+		_, err := conn.Write([]byte("0123456789"))
+		sig <- err
+	}
+
+	blockingRead := func(conn net.Conn) {
+		_, err := conn.Read(make([]byte, 10))
+		sig <- err
+	}
+
+	p1, p2 := newPipe(5), newPipe(5)
+	c1, c2 := &conn{p1, p1}, &conn{p2, p2}
+	defer c1.Close()
+	defer c2.Close()
+
+	// Test with deadline
+	c1.SetWriteDeadline(time.Now())
+
+	go blockingWrite(c1)
+	select {
+	case <-time.After(100 * time.Millisecond):
+		t.Fatalf("Write timeout timed out, c = %v", c1)
+	case err := <-sig:
+		if netErr, ok := err.(net.Error); ok {
+			if !netErr.Timeout() {
+				t.Fatalf("Write returned unexpected error, c = %v, err = %v", c1, netErr)
+			}
+		} else {
+			t.Fatalf("Write returned unexpected error, c = %v, err = %v", c1, err)
+		}
+	}
+
+	c2.SetReadDeadline(time.Now())
+
+	go blockingRead(c2)
+	select {
+	case <-time.After(100 * time.Millisecond):
+		t.Fatalf("Read timeout timed out, c = %v", c2)
+	case err := <-sig:
+		if netErr, ok := err.(net.Error); ok {
+			if !netErr.Timeout() {
+				t.Fatalf("Read returned unexpected error, c = %v, err = %v", c2, netErr)
+			}
+		} else {
+			t.Fatalf("Read returned unexpected error, c = %v, err = %v", c2, err)
+		}
+	}
+
+	// Test timing out pending reads/writes
+	c1.SetWriteDeadline(time.Time{})
+	c2.SetReadDeadline(time.Time{})
+
+	go blockingWrite(c1)
+	select {
+	case <-time.After(100 * time.Millisecond):
+	case err := <-sig:
+		t.Fatalf("Write returned before timeout, err = %v", err)
+	}
+
+	c1.SetWriteDeadline(time.Now())
+	select {
+	case <-time.After(100 * time.Millisecond):
+		t.Fatalf("Write timeout timed out, c = %v", c1)
+	case err := <-sig:
+		if netErr, ok := err.(net.Error); ok {
+			if !netErr.Timeout() {
+				t.Fatalf("Write returned unexpected error, c = %v, err = %v", c1, netErr)
+			}
+		} else {
+			t.Fatalf("Write returned unexpected error, c = %v, err = %v", c1, err)
+		}
+	}
+
+	go blockingRead(c2)
+	select {
+	case <-time.After(100 * time.Millisecond):
+	case err := <-sig:
+		t.Fatalf("Read returned before timeout, err = %v", err)
+	}
+
+	c2.SetReadDeadline(time.Now())
+	select {
+	case <-time.After(100 * time.Millisecond):
+		t.Fatalf("Read timeout timed out, c = %v", c2)
+	case err := <-sig:
+		if netErr, ok := err.(net.Error); ok {
+			if !netErr.Timeout() {
+				t.Fatalf("Read returned unexpected error, c = %v, err = %v", c2, netErr)
+			}
+		} else {
+			t.Fatalf("Read returned unexpected error, c = %v, err = %v", c2, err)
+		}
+	}
+
+	// Test non-blocking read/write
+	c1, c2 = &conn{p1, p2}, &conn{p2, p1}
+
+	c1.SetWriteDeadline(time.Now().Add(10 * time.Second))
+	c2.SetReadDeadline(time.Now().Add(10 * time.Second))
+
+	// Not blocking here
+	go blockingWrite(c1)
+	go blockingRead(c2)
+
+	// Read response from both routines
+	for i := 0; i < 2; i++ {
+		select {
+		case <-time.After(100 * time.Millisecond):
+			t.Fatalf("Read/Write timed out, c1 = %v, c2 = %v", c1, c2)
+		case err := <-sig:
+			if err != nil {
+				t.Fatalf("Read/Write failed to complete, c1 = %v, c2 = %v, err = %v", c1, c2, err)
+			}
+		}
+	}
+}


### PR DESCRIPTION
This PR adds implementations for the `Set(Read|Write)Deadline` functions of the [`net.Conn`](https://golang.org/pkg/net/#Conn) interface. This functionality can be useful when testing I/O edge-cases or unreliable network connections.