### PR TITLE
client: add WithConnectParams to configure connection backoff and timeout

### DIFF
--- a/backoff.go
+++ b/backoff.go
@@ -24,20 +24,20 @@ package grpc
 import (
 	"time"
 
-	grpcbackoff "google.golang.org/grpc/backoff"
+	"google.golang.org/grpc/backoff"
 )
 
 // DefaultBackoffConfig uses values specified for backoff in
 // https://github.com/grpc/grpc/blob/master/doc/connection-backoff.md.
 //
-// Deprecated: use ConnectParams instead.
+// Deprecated: use ConnectParams instead. Will be supported throughout 1.x.
 var DefaultBackoffConfig = BackoffConfig{
 	MaxDelay: 120 * time.Second,
 }
 
 // BackoffConfig defines the parameters for the default gRPC backoff strategy.
 //
-// Deprecated: use ConnectParams instead.
+// Deprecated: use ConnectParams instead. Will be supported throughout 1.x.
 type BackoffConfig struct {
 	// MaxDelay is the upper bound of backoff delay.
 	MaxDelay time.Duration
@@ -51,7 +51,7 @@ type BackoffConfig struct {
 // This API is EXPERIMENTAL.
 type ConnectParams struct {
 	// Backoff specifies the configuration options for connection backoff.
-	Backoff grpcbackoff.Config
+	Backoff backoff.Config
 	// MinConnectTimeout is the minimum amount of time we are willing to give a
 	// connection to complete.
 	MinConnectTimeout time.Duration

--- a/backoff.go
+++ b/backoff.go
@@ -27,12 +27,34 @@ import (
 
 // DefaultBackoffConfig uses values specified for backoff in
 // https://github.com/grpc/grpc/blob/master/doc/connection-backoff.md.
+//
+// Deprecated: use ConnectParams instead.
 var DefaultBackoffConfig = BackoffConfig{
 	MaxDelay: 120 * time.Second,
 }
 
 // BackoffConfig defines the parameters for the default gRPC backoff strategy.
+//
+// Deprecated: use ConnectParams instead.
 type BackoffConfig struct {
 	// MaxDelay is the upper bound of backoff delay.
 	MaxDelay time.Duration
+}
+
+// ConnectParams defines the parameters for connecting and retrying. Users
+// are encouraged to use this instead of BackoffConfig.
+// https://github.com/grpc/grpc/blob/master/doc/connection-backoff.md.
+//
+// This API is EXPERIMENTAL.
+type ConnectParams struct {
+	// BackoffBaseDelay is the amount of time to backoff after the first
+	// connection failure.
+	BackoffBaseDelay time.Duration
+	// BackoffMultiplier is the factor with which to multiply backoffs after a
+	// failed retry. Should ideally be greater than 1.
+	BackoffMultiplier float64
+	// BackoffJitter is the factor with which backoffs are randomized.
+	BackoffJitter float64
+	// BackoffMaxDelay is the upper bound of backoff delay.
+	BackoffMaxDelay time.Duration
 }

--- a/backoff.go
+++ b/backoff.go
@@ -23,6 +23,8 @@ package grpc
 
 import (
 	"time"
+
+	grpcbackoff "google.golang.org/grpc/backoff"
 )
 
 // DefaultBackoffConfig uses values specified for backoff in
@@ -41,20 +43,16 @@ type BackoffConfig struct {
 	MaxDelay time.Duration
 }
 
-// ConnectParams defines the parameters for connecting and retrying. Users
-// are encouraged to use this instead of BackoffConfig.
+// ConnectParams defines the parameters for connecting and retrying. Users are
+// encouraged to use this instead of BackoffConfig the type defined above. See
+// here for more details:
 // https://github.com/grpc/grpc/blob/master/doc/connection-backoff.md.
 //
 // This API is EXPERIMENTAL.
 type ConnectParams struct {
-	// BackoffBaseDelay is the amount of time to backoff after the first
-	// connection failure.
-	BackoffBaseDelay time.Duration
-	// BackoffMultiplier is the factor with which to multiply backoffs after a
-	// failed retry. Should ideally be greater than 1.
-	BackoffMultiplier float64
-	// BackoffJitter is the factor with which backoffs are randomized.
-	BackoffJitter float64
-	// BackoffMaxDelay is the upper bound of backoff delay.
-	BackoffMaxDelay time.Duration
+	// Backoff specifies the configuration options for connection backoff.
+	Backoff grpcbackoff.Config
+	// MinConnectTimeout is the minimum amount of time we are willing to give a
+	// connection to complete.
+	MinConnectTimeout time.Duration
 }

--- a/backoff.go
+++ b/backoff.go
@@ -44,7 +44,7 @@ type BackoffConfig struct {
 }
 
 // ConnectParams defines the parameters for connecting and retrying. Users are
-// encouraged to use this instead of BackoffConfig the type defined above. See
+// encouraged to use this instead of the BackoffConfig type defined above. See
 // here for more details:
 // https://github.com/grpc/grpc/blob/master/doc/connection-backoff.md.
 //

--- a/backoff/backoff.go
+++ b/backoff/backoff.go
@@ -20,13 +20,13 @@
 //
 // More details can be found at:
 // https://github.com/grpc/grpc/blob/master/doc/connection-backoff.md.
+//
+// All APIs in this package are experimental.
 package backoff
 
 import "time"
 
 // Config defines the configuration options for backoff.
-//
-// This API is EXPERIMENTAL.
 type Config struct {
 	// BaseDelay is the amount of time to backoff after the first failure.
 	BaseDelay time.Duration
@@ -44,8 +44,6 @@ type Config struct {
 //
 // This should be useful for callers who want to configure backoff with
 // non-default values only for a subset of the options.
-//
-// This API is EXPERIMENTAL.
 var DefaultConfig = Config{
 	BaseDelay:  1.0 * time.Second,
 	Multiplier: 1.6,

--- a/backoff/backoff.go
+++ b/backoff/backoff.go
@@ -1,0 +1,53 @@
+/*
+ *
+ * Copyright 2019 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// Package backoff provides configuration options for connection backoff.
+package backoff
+
+import "time"
+
+// Config defines the configuration options for connection backoff. More
+// details can be found at
+// https://github.com/grpc/grpc/blob/master/doc/connection-backoff.md.
+//
+// This API is EXPERIMENTAL.
+type Config struct {
+	// BaseDelay is the amount of time to backoff after the first failure.
+	BaseDelay time.Duration
+	// Multiplier is the factor with which to multiply backoffs after a
+	// failed retry. Should ideally be greater than 1.
+	Multiplier float64
+	// Jitter is the factor with which backoffs are randomized.
+	Jitter float64
+	// MaxDelay is the upper bound of backoff delay.
+	MaxDelay time.Duration
+}
+
+// DefaultConfig is a backoff configuration with the default values specfied
+// in https://github.com/grpc/grpc/blob/master/doc/connection-backoff.md.
+//
+// This should be useful for callers who want to configure backoff with
+// non-default values only for a subset of the options.
+//
+// This API is EXPERIMENTAL.
+var DefaultConfig = Config{
+	BaseDelay:  1.0 * time.Second,
+	Multiplier: 1.6,
+	Jitter:     0.2,
+	MaxDelay:   120 * time.Second,
+}

--- a/backoff/backoff.go
+++ b/backoff/backoff.go
@@ -16,14 +16,15 @@
  *
  */
 
-// Package backoff provides configuration options for connection backoff.
+// Package backoff provides configuration options for backoff.
+//
+// More details can be found at:
+// https://github.com/grpc/grpc/blob/master/doc/connection-backoff.md.
 package backoff
 
 import "time"
 
-// Config defines the configuration options for connection backoff. More
-// details can be found at
-// https://github.com/grpc/grpc/blob/master/doc/connection-backoff.md.
+// Config defines the configuration options for backoff.
 //
 // This API is EXPERIMENTAL.
 type Config struct {

--- a/backoff/backoff.go
+++ b/backoff/backoff.go
@@ -39,7 +39,7 @@ type Config struct {
 }
 
 // DefaultConfig is a backoff configuration with the default values specfied
-// in https://github.com/grpc/grpc/blob/master/doc/connection-backoff.md.
+// at https://github.com/grpc/grpc/blob/master/doc/connection-backoff.md.
 //
 // This should be useful for callers who want to configure backoff with
 // non-default values only for a subset of the options.

--- a/balancer/grpclb/grpclb.go
+++ b/balancer/grpclb/grpclb.go
@@ -49,19 +49,7 @@ const (
 	grpclbName             = "grpclb"
 )
 
-var (
-	// defaultBackoffConfig configures the backoff strategy that's used when the
-	// init handshake in the RPC is unsuccessful. It's not for the clientconn
-	// reconnect backoff.
-	//
-	// It has the same value as the default grpc.DefaultBackoffConfig.
-	//
-	// TODO: make backoff configurable.
-	defaultBackoffConfig = backoff.Exponential{
-		MaxDelay: 120 * time.Second,
-	}
-	errServerTerminatedConnection = errors.New("grpclb: failed to recv server list: server terminated connection")
-)
+var errServerTerminatedConnection = errors.New("grpclb: failed to recv server list: server terminated connection")
 
 func convertDuration(d *durationpb.Duration) time.Duration {
 	if d == nil {
@@ -155,7 +143,7 @@ func (b *lbBuilder) Build(cc balancer.ClientConn, opt balancer.BuildOptions) bal
 		scStates:       make(map[balancer.SubConn]connectivity.State),
 		picker:         &errPicker{err: balancer.ErrNoSubConnAvailable},
 		clientStats:    newRPCStats(),
-		backoff:        defaultBackoffConfig, // TODO: make backoff configurable.
+		backoff:        backoff.DefaultExponential, // TODO: make backoff configurable.
 	}
 
 	var err error

--- a/clientconn.go
+++ b/clientconn.go
@@ -235,9 +235,7 @@ func DialContext(ctx context.Context, target string, opts ...DialOption) (conn *
 		}
 	}
 	if cc.dopts.bs == nil {
-		cc.dopts.bs = backoff.Exponential{
-			MaxDelay: DefaultBackoffConfig.MaxDelay,
-		}
+		cc.dopts.bs = backoff.DefaultExponential
 	}
 	if cc.dopts.resolverBuilder == nil {
 		// Only try to parse target when resolver builder is not already set.

--- a/clientconn_test.go
+++ b/clientconn_test.go
@@ -30,10 +30,10 @@ import (
 	"time"
 
 	"golang.org/x/net/http2"
-	grpcbackoff "google.golang.org/grpc/backoff"
+	"google.golang.org/grpc/backoff"
 	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/credentials"
-	"google.golang.org/grpc/internal/backoff"
+	internalbackoff "google.golang.org/grpc/internal/backoff"
 	"google.golang.org/grpc/internal/transport"
 	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/naming"
@@ -656,22 +656,22 @@ func (s) TestCredentialsMisuse(t *testing.T) {
 }
 
 func (s) TestWithBackoffConfigDefault(t *testing.T) {
-	testBackoffConfigSet(t, backoff.DefaultExponential)
+	testBackoffConfigSet(t, internalbackoff.DefaultExponential)
 }
 
 func (s) TestWithBackoffConfig(t *testing.T) {
 	b := BackoffConfig{MaxDelay: DefaultBackoffConfig.MaxDelay / 2}
-	bc := grpcbackoff.DefaultConfig
+	bc := backoff.DefaultConfig
 	bc.MaxDelay = b.MaxDelay
-	wantBackoff := backoff.Exponential{Config: bc}
+	wantBackoff := internalbackoff.Exponential{Config: bc}
 	testBackoffConfigSet(t, wantBackoff, WithBackoffConfig(b))
 }
 
 func (s) TestWithBackoffMaxDelay(t *testing.T) {
 	md := DefaultBackoffConfig.MaxDelay / 2
-	bc := grpcbackoff.DefaultConfig
+	bc := backoff.DefaultConfig
 	bc.MaxDelay = md
-	wantBackoff := backoff.Exponential{Config: bc}
+	wantBackoff := internalbackoff.Exponential{Config: bc}
 	testBackoffConfigSet(t, wantBackoff, WithBackoffMaxDelay(md))
 }
 
@@ -679,16 +679,16 @@ func (s) TestWithConnectParams(t *testing.T) {
 	bd := 2 * time.Second
 	mltpr := 2.0
 	jitter := 0.0
-	bc := grpcbackoff.Config{BaseDelay: bd, Multiplier: mltpr, Jitter: jitter}
+	bc := backoff.Config{BaseDelay: bd, Multiplier: mltpr, Jitter: jitter}
 
 	crt := ConnectParams{Backoff: bc}
 	// MaxDelay is not set in the ConnectParams. So it should not be set on
-	// backoff.Exponential as well.
-	wantBackoff := backoff.Exponential{Config: bc}
+	// internalbackoff.Exponential as well.
+	wantBackoff := internalbackoff.Exponential{Config: bc}
 	testBackoffConfigSet(t, wantBackoff, WithConnectParams(crt))
 }
 
-func testBackoffConfigSet(t *testing.T, wantBackoff backoff.Exponential, opts ...DialOption) {
+func testBackoffConfigSet(t *testing.T, wantBackoff internalbackoff.Exponential, opts ...DialOption) {
 	opts = append(opts, WithInsecure())
 	conn, err := Dial("passthrough:///foo:80", opts...)
 	if err != nil {
@@ -700,7 +700,7 @@ func testBackoffConfigSet(t *testing.T, wantBackoff backoff.Exponential, opts ..
 		t.Fatalf("backoff config not set")
 	}
 
-	gotBackoff, ok := conn.dopts.bs.(backoff.Exponential)
+	gotBackoff, ok := conn.dopts.bs.(internalbackoff.Exponential)
 	if !ok {
 		t.Fatalf("unexpected type of backoff config: %#v", conn.dopts.bs)
 	}

--- a/clientconn_test.go
+++ b/clientconn_test.go
@@ -663,7 +663,7 @@ func (s) TestWithBackoffConfig(t *testing.T) {
 	b := BackoffConfig{MaxDelay: DefaultBackoffConfig.MaxDelay / 2}
 	bc := grpcbackoff.DefaultConfig
 	bc.MaxDelay = b.MaxDelay
-	wantBackoff := backoff.Exponential{bc}
+	wantBackoff := backoff.Exponential{Config: bc}
 	testBackoffConfigSet(t, wantBackoff, WithBackoffConfig(b))
 }
 
@@ -671,7 +671,7 @@ func (s) TestWithBackoffMaxDelay(t *testing.T) {
 	md := DefaultBackoffConfig.MaxDelay / 2
 	bc := grpcbackoff.DefaultConfig
 	bc.MaxDelay = md
-	wantBackoff := backoff.Exponential{bc}
+	wantBackoff := backoff.Exponential{Config: bc}
 	testBackoffConfigSet(t, wantBackoff, WithBackoffMaxDelay(md))
 }
 
@@ -684,7 +684,7 @@ func (s) TestWithConnectParams(t *testing.T) {
 	crt := ConnectParams{Backoff: bc}
 	// MaxDelay is not set in the ConnectParams. So it should not be set on
 	// backoff.Exponential as well.
-	wantBackoff := backoff.Exponential{bc}
+	wantBackoff := backoff.Exponential{Config: bc}
 	testBackoffConfigSet(t, wantBackoff, WithConnectParams(crt))
 }
 

--- a/dialoptions.go
+++ b/dialoptions.go
@@ -276,7 +276,7 @@ func WithBackoffMaxDelay(md time.Duration) DialOption {
 // WithBackoffConfig configures the dialer to use the provided backoff
 // parameters after connection failures.
 //
-//￼Deprecated: use WithConnectParams instead. Will be supported throughout 1.x.
+// Deprecated: use WithConnectParams instead. Will be supported throughout 1.x.
 func WithBackoffConfig(b BackoffConfig) DialOption {
 	bc := backoff.DefaultConfig
 	bc.MaxDelay = b.MaxDelay

--- a/dialoptions.go
+++ b/dialoptions.go
@@ -248,7 +248,7 @@ func WithServiceConfig(c <-chan ServiceConfig) DialOption {
 }
 
 // WithConnectParams configures the dialer to use the provided ConnectParams.
-
+//
 // The backoff configuration specified as part of the ConnectParams overrides
 // all defaults specified in
 // https://github.com/grpc/grpc/blob/master/doc/connection-backoff.md. Consider

--- a/dialoptions.go
+++ b/dialoptions.go
@@ -252,7 +252,7 @@ func WithServiceConfig(c <-chan ServiceConfig) DialOption {
 // This API is EXPERIMENTAL.
 func WithConnectParams(p ConnectParams) DialOption {
 	return newFuncDialOption(func(o *dialOptions) {
-		o.bs = backoff.Exponential{p.Backoff}
+		o.bs = backoff.Exponential{Config: p.Backoff}
 		o.minConnectTimeout = func() time.Duration {
 			return p.MinConnectTimeout
 		}
@@ -274,7 +274,7 @@ func WithBackoffMaxDelay(md time.Duration) DialOption {
 func WithBackoffConfig(b BackoffConfig) DialOption {
 	bc := grpcbackoff.DefaultConfig
 	bc.MaxDelay = b.MaxDelay
-	return withBackoff(backoff.Exponential{bc})
+	return withBackoff(backoff.Exponential{Config: bc})
 }
 
 // withBackoff sets the backoff strategy used for connectRetryNum after a failed

--- a/dialoptions.go
+++ b/dialoptions.go
@@ -246,8 +246,26 @@ func WithServiceConfig(c <-chan ServiceConfig) DialOption {
 	})
 }
 
+// WithConnectParams configures the dialer to use the provided backoff
+// parameters for the algorithm defined in
+// https://github.com/grpc/grpc/blob/master/doc/connection-backoff.md.
+// This will override all the default values with the ones provided here. So,
+// use with caution.
+//
+// This API is EXPERIMENTAL.
+func WithConnectParams(p ConnectParams) DialOption {
+	return withBackoff(backoff.Exponential{
+		BaseDelay:  p.BackoffBaseDelay,
+		Multiplier: p.BackoffMultiplier,
+		Jitter:     p.BackoffJitter,
+		MaxDelay:   p.BackoffMaxDelay,
+	})
+}
+
 // WithBackoffMaxDelay configures the dialer to use the provided maximum delay
 // when backing off after failed connection attempts.
+//
+//￼Deprecated: use WithConnectParams instead.
 func WithBackoffMaxDelay(md time.Duration) DialOption {
 	return WithBackoffConfig(BackoffConfig{MaxDelay: md})
 }
@@ -255,12 +273,11 @@ func WithBackoffMaxDelay(md time.Duration) DialOption {
 // WithBackoffConfig configures the dialer to use the provided backoff
 // parameters after connection failures.
 //
-// Use WithBackoffMaxDelay until more parameters on BackoffConfig are opened up
-// for use.
+//￼Deprecated: use WithConnectParams instead.
 func WithBackoffConfig(b BackoffConfig) DialOption {
-	return withBackoff(backoff.Exponential{
-		MaxDelay: b.MaxDelay,
-	})
+	bs := backoff.DefaultExponential
+	bs.MaxDelay = b.MaxDelay
+	return withBackoff(bs)
 }
 
 // withBackoff sets the backoff strategy used for connectRetryNum after a failed

--- a/health/client.go
+++ b/health/client.go
@@ -33,20 +33,20 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-const maxDelay = 120 * time.Second
-
-var backoffStrategy = backoff.Exponential{MaxDelay: maxDelay}
-var backoffFunc = func(ctx context.Context, retries int) bool {
-	d := backoffStrategy.Backoff(retries)
-	timer := time.NewTimer(d)
-	select {
-	case <-timer.C:
-		return true
-	case <-ctx.Done():
-		timer.Stop()
-		return false
+var (
+	backoffStrategy = backoff.DefaultExponential
+	backoffFunc     = func(ctx context.Context, retries int) bool {
+		d := backoffStrategy.Backoff(retries)
+		timer := time.NewTimer(d)
+		select {
+		case <-timer.C:
+			return true
+		case <-ctx.Done():
+			timer.Stop()
+			return false
+		}
 	}
-}
+)
 
 func init() {
 	internal.HealthCheckFunc = clientHealthCheck

--- a/internal/backoff/backoff.go
+++ b/internal/backoff/backoff.go
@@ -51,6 +51,9 @@ const (
 	maxDelay = 120 * time.Second
 )
 
+// DefaultExponential is an exponential backoff implementation using the
+// default values for all the configurable knobs defined in
+// https://github.com/grpc/grpc/blob/master/doc/connection-backoff.md.
 var DefaultExponential = Exponential{BaseDelay: baseDelay, Multiplier: factor, Jitter: jitter, MaxDelay: maxDelay}
 
 // Exponential implements exponential backoff algorithm as defined in

--- a/internal/backoff/backoff.go
+++ b/internal/backoff/backoff.go
@@ -25,61 +25,39 @@ package backoff
 import (
 	"time"
 
+	grpcbackoff "google.golang.org/grpc/backoff"
 	"google.golang.org/grpc/internal/grpcrand"
 )
 
 // Strategy defines the methodology for backing off after a grpc connection
 // failure.
-//
 type Strategy interface {
 	// Backoff returns the amount of time to wait before the next retry given
 	// the number of consecutive failures.
 	Backoff(retries int) time.Duration
 }
 
-// These constants correspond to the ones defined in
-// https://github.com/grpc/grpc/blob/master/doc/connection-backoff.md.
-const (
-	// baseDelay is the amount of time to wait before retrying after the first
-	// failure.
-	baseDelay = 1.0 * time.Second
-	// factor is applied to the backoff after each retry.
-	factor = 1.6
-	// jitter provides a range to randomize backoff delays.
-	jitter = 0.2
-	// maxDelay is the upper bound of backoff delay.
-	maxDelay = 120 * time.Second
-)
-
 // DefaultExponential is an exponential backoff implementation using the
 // default values for all the configurable knobs defined in
 // https://github.com/grpc/grpc/blob/master/doc/connection-backoff.md.
-var DefaultExponential = Exponential{BaseDelay: baseDelay, Multiplier: factor, Jitter: jitter, MaxDelay: maxDelay}
+var DefaultExponential = Exponential{Config: grpcbackoff.DefaultConfig}
 
 // Exponential implements exponential backoff algorithm as defined in
 // https://github.com/grpc/grpc/blob/master/doc/connection-backoff.md.
 type Exponential struct {
-	// BaseDelay is the amount of time to backoff after the first connection
-	// failure.
-	BaseDelay time.Duration
-	// Multiplier is the factor with which to multiply backoffs after a failed
-	// retry.
-	Multiplier float64
-	// Jitter is the factor with which backoffs are randomized.
-	Jitter float64
-	// MaxDelay is the upper bound of backoff delay.
-	MaxDelay time.Duration
+	// Config contains all options to configure the backoff algorithm.
+	Config grpcbackoff.Config
 }
 
 // Backoff returns the amount of time to wait before the next retry given the
 // number of retries.
 func (bc Exponential) Backoff(retries int) time.Duration {
 	if retries == 0 {
-		return bc.BaseDelay
+		return bc.Config.BaseDelay
 	}
-	backoff, max := float64(bc.BaseDelay), float64(bc.MaxDelay)
+	backoff, max := float64(bc.Config.BaseDelay), float64(bc.Config.MaxDelay)
 	for backoff < max && retries > 0 {
-		backoff *= bc.Multiplier
+		backoff *= bc.Config.Multiplier
 		retries--
 	}
 	if backoff > max {
@@ -87,7 +65,7 @@ func (bc Exponential) Backoff(retries int) time.Duration {
 	}
 	// Randomize backoff delays so that if a cluster of requests start at
 	// the same time, they won't operate in lockstep.
-	backoff *= 1 + bc.Jitter*(grpcrand.Float64()*2-1)
+	backoff *= 1 + bc.Config.Jitter*(grpcrand.Float64()*2-1)
 	if backoff < 0 {
 		return 0
 	}

--- a/resolver/dns/dns_resolver.go
+++ b/resolver/dns/dns_resolver.go
@@ -32,9 +32,9 @@ import (
 	"sync"
 	"time"
 
-	grpcbackoff "google.golang.org/grpc/backoff"
+	"google.golang.org/grpc/backoff"
 	"google.golang.org/grpc/grpclog"
-	"google.golang.org/grpc/internal/backoff"
+	internalbackoff "google.golang.org/grpc/internal/backoff"
 	"google.golang.org/grpc/internal/grpcrand"
 	"google.golang.org/grpc/resolver"
 )
@@ -127,11 +127,11 @@ func (b *dnsBuilder) Build(target resolver.Target, cc resolver.ClientConn, opts 
 
 	// DNS address (non-IP).
 	ctx, cancel := context.WithCancel(context.Background())
-	bc := grpcbackoff.DefaultConfig
+	bc := backoff.DefaultConfig
 	bc.MaxDelay = b.minFreq
 	d := &dnsResolver{
 		freq:                 b.minFreq,
-		backoff:              backoff.Exponential{Config: bc},
+		backoff:              internalbackoff.Exponential{Config: bc},
 		host:                 host,
 		port:                 port,
 		ctx:                  ctx,
@@ -203,7 +203,7 @@ func (i *ipResolver) watcher() {
 // dnsResolver watches for the name resolution update for a non-IP target.
 type dnsResolver struct {
 	freq       time.Duration
-	backoff    backoff.Exponential
+	backoff    internalbackoff.Exponential
 	retryCount int
 	host       string
 	port       string

--- a/resolver/dns/dns_resolver.go
+++ b/resolver/dns/dns_resolver.go
@@ -126,9 +126,11 @@ func (b *dnsBuilder) Build(target resolver.Target, cc resolver.ClientConn, opts 
 
 	// DNS address (non-IP).
 	ctx, cancel := context.WithCancel(context.Background())
+	bs := backoff.DefaultExponential
+	bs.MaxDelay = b.minFreq
 	d := &dnsResolver{
 		freq:                 b.minFreq,
-		backoff:              backoff.Exponential{MaxDelay: b.minFreq},
+		backoff:              bs,
 		host:                 host,
 		port:                 port,
 		ctx:                  ctx,

--- a/resolver/dns/dns_resolver.go
+++ b/resolver/dns/dns_resolver.go
@@ -131,7 +131,7 @@ func (b *dnsBuilder) Build(target resolver.Target, cc resolver.ClientConn, opts 
 	bc.MaxDelay = b.minFreq
 	d := &dnsResolver{
 		freq:                 b.minFreq,
-		backoff:              backoff.Exponential{bc},
+		backoff:              backoff.Exponential{Config: bc},
 		host:                 host,
 		port:                 port,
 		ctx:                  ctx,

--- a/resolver/dns/dns_resolver.go
+++ b/resolver/dns/dns_resolver.go
@@ -32,6 +32,7 @@ import (
 	"sync"
 	"time"
 
+	grpcbackoff "google.golang.org/grpc/backoff"
 	"google.golang.org/grpc/grpclog"
 	"google.golang.org/grpc/internal/backoff"
 	"google.golang.org/grpc/internal/grpcrand"
@@ -126,11 +127,11 @@ func (b *dnsBuilder) Build(target resolver.Target, cc resolver.ClientConn, opts 
 
 	// DNS address (non-IP).
 	ctx, cancel := context.WithCancel(context.Background())
-	bs := backoff.DefaultExponential
-	bs.MaxDelay = b.minFreq
+	bc := grpcbackoff.DefaultConfig
+	bc.MaxDelay = b.minFreq
 	d := &dnsResolver{
 		freq:                 b.minFreq,
-		backoff:              bs,
+		backoff:              backoff.Exponential{bc},
 		host:                 host,
 		port:                 port,
 		ctx:                  ctx,

--- a/xds/internal/balancer/lrs/lrs.go
+++ b/xds/internal/balancer/lrs/lrs.go
@@ -161,9 +161,7 @@ func NewStore(serviceName string) Store {
 				},
 			},
 		},
-		backoff: backoff.Exponential{
-			MaxDelay: 120 * time.Second,
-		},
+		backoff:      backoff.DefaultExponential,
 		lastReported: time.Now(),
 	}
 }

--- a/xds/internal/balancer/xds_client.go
+++ b/xds/internal/balancer/xds_client.go
@@ -260,7 +260,7 @@ func newXDSClient(balancerName string, enableCDS bool, opts balancer.BuildOption
 		newADS:           newADS,
 		loseContact:      loseContact,
 		cleanup:          exitCleanup,
-		backoff:          defaultBackoffConfig,
+		backoff:          backoff.DefaultExponential,
 		loadStore:        loadStore,
 	}
 

--- a/xds/internal/balancer/xds_client.go
+++ b/xds/internal/balancer/xds_client.go
@@ -48,12 +48,6 @@ const (
 	endpointRequired = "endpoints_required"
 )
 
-var (
-	defaultBackoffConfig = backoff.Exponential{
-		MaxDelay: 120 * time.Second,
-	}
-)
-
 // client is responsible for connecting to the specified traffic director, passing the received
 // ADS response from the traffic director, and sending notification when communication with the
 // traffic director is lost.


### PR DESCRIPTION
    Implement missing pieces for connection backoff.
    
    Spec can be found here:
    https://github.com/grpc/grpc/blob/master/doc/connection-backoff.md
    
    Summary of changes:
    * Added a new type (marked experimental), ConnectParams, which contains
      the knobs defined in the spec (except for minConnectTimeout).
    * Added a new API (marked experimental), WithConnectParams() to return a
      DialOption to dial with the provided parameters.
    * Added new fields to the implementation of the exponential backoff in
      internal/backoff which mirror the ones in ConnectParams.
    * Marked existing APIs WithBackoffMaxDelay() and WithBackoffConfig() as
      deprecated.
    * Added a default exponential backoff implementation, for easy use of
      internal callers.


Fixes #2724