### PR TITLE
Switch Balancer group balancing from Random to EDF

### DIFF
--- a/xds/internal/balancer/edsbalancer/balancergroup.go
+++ b/xds/internal/balancer/edsbalancer/balancergroup.go
@@ -295,8 +295,8 @@ func buildPickerAndState(m map[internal.Locality]*pickerState) (connectivity.Sta
 	return aggregatedState, newPickerGroup(readyPickerWithWeights)
 }
 
-// RandomWRR constructor, to be modified in tests.
-var newRandomWRR = wrr.NewRandom
+// WRR constructor, to be modified in tests.
+var newWRR = wrr.NewEDF
 
 type pickerGroup struct {
 	length int
@@ -311,7 +311,7 @@ type pickerGroup struct {
 // TODO: (bg) confirm this is the expected behavior: non-ready balancers should
 // be ignored when picking. Only ready balancers are picked.
 func newPickerGroup(readyPickerWithWeights []pickerState) *pickerGroup {
-	w := newRandomWRR()
+	w := newWRR()
 	for _, ps := range readyPickerWithWeights {
 		w.Add(ps.picker, int64(ps.weight))
 	}

--- a/xds/internal/balancer/edsbalancer/util.go
+++ b/xds/internal/balancer/edsbalancer/util.go
@@ -27,7 +27,7 @@ type dropper struct {
 }
 
 func newDropper(numerator, denominator uint32, category string) *dropper {
-	w := newRandomWRR()
+	w := newWRR()
 	w.Add(true, int64(numerator))
 	w.Add(false, int64(denominator-numerator))
 

--- a/xds/internal/balancer/edsbalancer/util_test.go
+++ b/xds/internal/balancer/edsbalancer/util_test.go
@@ -66,7 +66,7 @@ func (twrr *testWRR) Next() interface{} {
 }
 
 func init() {
-	newRandomWRR = newTestWRR
+	newWRR = newTestWRR
 }
 
 func TestDropper(t *testing.T) {


### PR DESCRIPTION
EDF is strictly better than random.

This is continuation of https://github.com/grpc/grpc-go/pull/2957.