### PR TITLE
add MAINTAINERS.md

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,27 @@
+This page lists all active maintainers of this repository. If you were a
+maintainer and would like to add your name to the Emeritus list, please send us a
+PR.
+
+See [GOVERNANCE.md](https://github.com/grpc/grpc-community/blob/master/governance.md)
+for governance guidelines and how to become a maintainer.
+See [CONTRIBUTING.md](https://github.com/grpc/grpc-community/blob/master/CONTRIBUTING.md)
+for general contribution guidelines.
+
+## Maintainers (in alphabetical order)
+- [canguler](https://github.com/canguler), Google Inc.
+- [cesarghali](https://github.com/cesarghali), Google Inc.
+- [dfawley](https://github.com/dfawley), Google Inc.
+- [easwars](https://github.com/easwars), Google Inc.
+- [jadekler](https://github.com/jadekler), Google Inc.
+- [menghanl](https://github.com/menghanl), Google Inc.
+- [srini100](https://github.com/srini100), Google Inc.
+
+## Emeritus Maintainers (in alphabetical order)
+- [adelez](https://github.com/adelez), Google Inc.
+- [iamqizhao](https://github.com/iamqizhao), Google Inc.
+- [jtattermusch](https://github.com/jtattermusch), Google Inc.
+- [lyuxuan](https://github.com/lyuxuan), Google Inc.
+- [makmukhi](https://github.com/makmukhi), Google Inc.
+- [matt-kwong](https://github.com/matt-kwong), Google Inc.
+- [nicolasnoble](https://github.com/nicolasnoble), Google Inc.
+- [yongni](https://github.com/yongni), Google Inc.


### PR DESCRIPTION
List of current maintainers should be publicly available. The governance and contributing files this links to will be updated soon. 