### PR TITLE
transport: remove defer in http2Client.getStream

### DIFF
--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -850,8 +850,8 @@ func (t *http2Client) Write(s *Stream, hdr []byte, data []byte, opts *Options) e
 
 func (t *http2Client) getStream(f http2.Frame) (*Stream, bool) {
 	t.mu.Lock()
-	defer t.mu.Unlock()
 	s, ok := t.activeStreams[f.Header().StreamID]
+	t.mu.Unlock()
 	return s, ok
 }
 


### PR DESCRIPTION
The code is simple enough, the defer is pure cost.