### PR TITLE
Add a micro benchmark for context.WithValue()

### DIFF
--- a/benchmark/primitives/context_test.go
+++ b/benchmark/primitives/context_test.go
@@ -117,3 +117,34 @@ func BenchmarkTimerContextChannelGotErr(b *testing.B) {
 		}
 	}
 }
+
+type ctxKey struct{}
+
+func newContextWithLocalKey(parent context.Context) context.Context {
+	return context.WithValue(parent, ctxKey{}, nil)
+}
+
+var ck = ctxKey{}
+
+func newContextWithGlobalKey(parent context.Context) context.Context {
+	return context.WithValue(parent, ck, nil)
+}
+
+func BenchmarkContextWithValue(b *testing.B) {
+	benches := []struct {
+		name string
+		f    func(context.Context) context.Context
+	}{
+		{"newContextWithLocalKey", newContextWithLocalKey},
+		{"newContextWithGlobalKey", newContextWithGlobalKey},
+	}
+
+	pCtx := context.Background()
+	for _, bench := range benches {
+		b.Run(bench.name, func(b *testing.B) {
+			for j := 0; j < b.N; j++ {
+				bench.f(pCtx)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add a micro benchmark for context.WithValue() to compare using local and global keys.