### PR TITLE
xds: make balancer group restartable

### DIFF
--- a/xds/internal/balancer/edsbalancer/balancergroup.go
+++ b/xds/internal/balancer/edsbalancer/balancergroup.go
@@ -82,6 +82,11 @@ func (sbc *subBalancerWithConfig) updateAddrs(addrs []resolver.Address) {
 		// sub-balancers are closed when the locality is removed from EDS, or
 		// the balancer group is closed. There should be no further address
 		// updates when either of this happened.
+		//
+		// TODO: Update comment and delete the warning below.
+		// This will be a common case with priority support, because a
+		// sub-balancer (and the whole balancer group) could be closed because
+		// it's the lower priority, but it can still get address updates.
 		grpclog.Warningf("subBalancerWithConfig: updateAddrs is called when balancer is nil. This means this sub-balancer is closed.")
 		return
 	}

--- a/xds/internal/balancer/edsbalancer/balancergroup_test.go
+++ b/xds/internal/balancer/edsbalancer/balancergroup_test.go
@@ -544,3 +544,17 @@ func TestBalancerGroup_start_close(t *testing.T) {
 		t.Fatalf("want %v, got %v", want, err)
 	}
 }
+
+func TestBalancerGroup_start_close_deadlock(t *testing.T) {
+	cc := newTestClientConn(t)
+	bg := newBalancerGroup(cc, nil)
+
+	// Add two balancers to group and send two resolved addresses to both
+	// balancers.
+	bg.add(testBalancerIDs[0], 2, &testConstBalancerBuilder{})
+	bg.handleResolvedAddrs(testBalancerIDs[0], testBackendAddrs[0:2])
+	bg.add(testBalancerIDs[1], 1, &testConstBalancerBuilder{})
+	bg.handleResolvedAddrs(testBalancerIDs[1], testBackendAddrs[2:4])
+
+	bg.start()
+}

--- a/xds/internal/balancer/edsbalancer/balancergroup_test.go
+++ b/xds/internal/balancer/edsbalancer/balancergroup_test.go
@@ -39,6 +39,7 @@ var (
 func TestBalancerGroup_OneRR_AddRemoveBackend(t *testing.T) {
 	cc := newTestClientConn(t)
 	bg := newBalancerGroup(cc, nil)
+	bg.start()
 
 	// Add one balancer to group.
 	bg.add(testBalancerIDs[0], 1, rrBuilder)
@@ -98,6 +99,7 @@ func TestBalancerGroup_OneRR_AddRemoveBackend(t *testing.T) {
 func TestBalancerGroup_TwoRR_OneBackend(t *testing.T) {
 	cc := newTestClientConn(t)
 	bg := newBalancerGroup(cc, nil)
+	bg.start()
 
 	// Add two balancers to group and send one resolved address to both
 	// balancers.
@@ -130,6 +132,7 @@ func TestBalancerGroup_TwoRR_OneBackend(t *testing.T) {
 func TestBalancerGroup_TwoRR_MoreBackends(t *testing.T) {
 	cc := newTestClientConn(t)
 	bg := newBalancerGroup(cc, nil)
+	bg.start()
 
 	// Add two balancers to group and send one resolved address to both
 	// balancers.
@@ -226,6 +229,7 @@ func TestBalancerGroup_TwoRR_MoreBackends(t *testing.T) {
 func TestBalancerGroup_TwoRR_DifferentWeight_MoreBackends(t *testing.T) {
 	cc := newTestClientConn(t)
 	bg := newBalancerGroup(cc, nil)
+	bg.start()
 
 	// Add two balancers to group and send two resolved addresses to both
 	// balancers.
@@ -264,6 +268,7 @@ func TestBalancerGroup_TwoRR_DifferentWeight_MoreBackends(t *testing.T) {
 func TestBalancerGroup_ThreeRR_RemoveBalancer(t *testing.T) {
 	cc := newTestClientConn(t)
 	bg := newBalancerGroup(cc, nil)
+	bg.start()
 
 	// Add three balancers to group and send one resolved address to both
 	// balancers.
@@ -331,6 +336,7 @@ func TestBalancerGroup_ThreeRR_RemoveBalancer(t *testing.T) {
 func TestBalancerGroup_TwoRR_ChangeWeight_MoreBackends(t *testing.T) {
 	cc := newTestClientConn(t)
 	bg := newBalancerGroup(cc, nil)
+	bg.start()
 
 	// Add two balancers to group and send two resolved addresses to both
 	// balancers.
@@ -382,6 +388,7 @@ func TestBalancerGroup_LoadReport(t *testing.T) {
 
 	cc := newTestClientConn(t)
 	bg := newBalancerGroup(cc, testLoadStore)
+	bg.start()
 
 	backendToBalancerID := make(map[balancer.SubConn]internal.Locality)
 
@@ -448,5 +455,92 @@ func TestBalancerGroup_LoadReport(t *testing.T) {
 	}
 	if !reflect.DeepEqual(testLoadStore.callsCost, wantCost) {
 		t.Fatalf("want cost: %v, got: %v", testLoadStore.callsCost, wantCost)
+	}
+}
+
+// Create a new balancer group, add balancer and backends, but not start.
+// - b1, weight 2, backends [0,1]
+// - b2, weight 1, backends [2,3]
+// Start the balancer group and check behavior.
+//
+// Close the balancer group, call add/remove/change weight/change address.
+// - b2, weight 3, backends [0,3]
+// - b3, weight 1, backends [1,2]
+// Start the balancer group again and check for behavior.
+func TestBalancerGroup_start_close(t *testing.T) {
+	cc := newTestClientConn(t)
+	bg := newBalancerGroup(cc, nil)
+
+	// Add two balancers to group and send two resolved addresses to both
+	// balancers.
+	bg.add(testBalancerIDs[0], 2, rrBuilder)
+	bg.handleResolvedAddrs(testBalancerIDs[0], testBackendAddrs[0:2])
+	bg.add(testBalancerIDs[1], 1, rrBuilder)
+	bg.handleResolvedAddrs(testBalancerIDs[1], testBackendAddrs[2:4])
+
+	bg.start()
+
+	m1 := make(map[resolver.Address]balancer.SubConn)
+	for i := 0; i < 4; i++ {
+		addrs := <-cc.newSubConnAddrsCh
+		sc := <-cc.newSubConnCh
+		m1[addrs[0]] = sc
+		bg.handleSubConnStateChange(sc, connectivity.Connecting)
+		bg.handleSubConnStateChange(sc, connectivity.Ready)
+	}
+
+	// Test roundrobin on the last picker.
+	p1 := <-cc.newPickerCh
+	want := []balancer.SubConn{
+		m1[testBackendAddrs[0]], m1[testBackendAddrs[0]],
+		m1[testBackendAddrs[1]], m1[testBackendAddrs[1]],
+		m1[testBackendAddrs[2]], m1[testBackendAddrs[3]],
+	}
+	if err := isRoundRobin(want, func() balancer.SubConn {
+		sc, _, _ := p1.Pick(context.Background(), balancer.PickOptions{})
+		return sc
+	}); err != nil {
+		t.Fatalf("want %v, got %v", want, err)
+	}
+
+	bg.close()
+	for i := 0; i < 4; i++ {
+		bg.handleSubConnStateChange(<-cc.removeSubConnCh, connectivity.Shutdown)
+	}
+
+	// Add b3, weight 1, backends [1,2].
+	bg.add(testBalancerIDs[2], 1, rrBuilder)
+	bg.handleResolvedAddrs(testBalancerIDs[2], testBackendAddrs[1:3])
+
+	// Remove b1.
+	bg.remove(testBalancerIDs[0])
+
+	// Update b2 to weight 3, backends [0,3].
+	bg.changeWeight(testBalancerIDs[1], 3)
+	bg.handleResolvedAddrs(testBalancerIDs[1], append([]resolver.Address(nil), testBackendAddrs[0], testBackendAddrs[3]))
+
+	bg.start()
+
+	m2 := make(map[resolver.Address]balancer.SubConn)
+	for i := 0; i < 4; i++ {
+		addrs := <-cc.newSubConnAddrsCh
+		sc := <-cc.newSubConnCh
+		m2[addrs[0]] = sc
+		bg.handleSubConnStateChange(sc, connectivity.Connecting)
+		bg.handleSubConnStateChange(sc, connectivity.Ready)
+	}
+
+	// Test roundrobin on the last picker.
+	p2 := <-cc.newPickerCh
+	want = []balancer.SubConn{
+		m2[testBackendAddrs[0]], m2[testBackendAddrs[0]], m2[testBackendAddrs[0]],
+		m2[testBackendAddrs[3]], m2[testBackendAddrs[3]], m2[testBackendAddrs[3]],
+		m2[testBackendAddrs[1]], m2[testBackendAddrs[2]],
+	}
+	if err := isRoundRobin(want, func() balancer.SubConn {
+		sc, _, _ := p2.Pick(context.Background(), balancer.PickOptions{})
+		return sc
+	}); err != nil {
+		t.Fatalf("want %v, got %v", want, err)
 	}
 }

--- a/xds/internal/balancer/edsbalancer/edsbalancer.go
+++ b/xds/internal/balancer/edsbalancer/edsbalancer.go
@@ -176,6 +176,7 @@ func (xdsB *EDSBalancer) HandleEDSResponse(edsResp *edspb.ClusterLoadAssignment)
 	// response).
 	if xdsB.bg == nil {
 		xdsB.bg = newBalancerGroup(xdsB, xdsB.loadStore)
+		xdsB.bg.start()
 	}
 
 	// TODO: Unhandled fields from EDS response:

--- a/xds/internal/balancer/edsbalancer/test_util_test.go
+++ b/xds/internal/balancer/edsbalancer/test_util_test.go
@@ -28,9 +28,17 @@ import (
 	"google.golang.org/grpc/xds/internal"
 )
 
-var (
-	testSubConns = []*testSubConn{{id: "sc1"}, {id: "sc2"}, {id: "sc3"}, {id: "sc4"}}
-)
+const testSubConnsCount = 8
+
+var testSubConns []*testSubConn
+
+func init() {
+	for i := 0; i < testSubConnsCount; i++ {
+		testSubConns = append(testSubConns, &testSubConn{
+			id: fmt.Sprintf("sc%d", i),
+		})
+	}
+}
 
 type testSubConn struct {
 	id string


### PR DESCRIPTION
This is a preparing change to support priority failover. It adds `start()` and `close()` to balancer group, so we can have a balancer group that's not in use, but has all the data and is ready to be started (think about a lower priority when the higher priority is in use).

A balancer group is split into two parts: static and dynamic:
 - static: the data from EDS, and gets updated even if balancer group is closed
   - balancer IDs and builders, addresses for each balancer
 - dynamic: the sub-balancers
   - These are only created when the balancer group is started. They are closed when the balancer group is closed.
   - And only when the balancer group is started, the sub-balancers will get address updates.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grpc/grpc-go/2999)
<!-- Reviewable:end -->
