### PR TITLE
github: add mergeable config

### DIFF
--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -10,7 +10,7 @@ mergeable:
         status: 'failure'
         payload:
           title: 'Mergeable failed: no "Type:" label'
-          summary: `All PRs must include an appropriate "Type:" label.`
+          summary: 'All PRs must include an appropriate "Type:" label.'
   - when: pull_request.*
     validate:
       - do: label
@@ -24,4 +24,4 @@ mergeable:
         status: 'failure'
         payload:
           title: 'Mergeable failed: no milestone or "no release notes" label'
-          summary: `All PRs must include either a Release milestone or the "no release notes" label.`
+          summary: 'All PRs must include either a Release milestone or the "no release notes" label.'

--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -9,8 +9,8 @@ mergeable:
       - do: checks
         status: 'failure'
         payload:
-          title: 'Mergeable failed: no "Type:" label'
-          summary: 'All PRs must include an appropriate "Type:" label.'
+          title: 'All PRs must include an appropriate "Type:" label.'
+          # summary: 'All PRs must include an appropriate "Type:" label.'
   - when: pull_request.*
     validate:
       - do: label
@@ -23,5 +23,5 @@ mergeable:
       - do: checks
         status: 'failure'
         payload:
-          title: 'Mergeable failed: no milestone or "no release notes" label'
-          summary: 'All PRs must include either a Release milestone or the "no release notes" label.'
+          title: 'All PRs must include a Release milestone or the "no release notes" label'
+          # summary: 'All PRs must include either a Release milestone or the "no release notes" label.'

--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -6,11 +6,11 @@ mergeable:
         must_include:
           regex: '^Type:'
     fail:
-       - do: checks
-         status: 'failure'
-         payload:
-           title: 'Mergeable failed: no "Type:" label'
-           summary: `All PRs must include an appropriate "Type:" label.`
+      - do: checks
+        status: 'failure'
+        payload:
+          title: 'Mergeable failed: no "Type:" label'
+          summary: `All PRs must include an appropriate "Type:" label.`
   - when: pull_request.*
     validate:
       - do: label

--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -9,8 +9,8 @@ mergeable:
       - do: checks
         status: 'failure'
         payload:
-          title: 'All PRs must include an appropriate "Type:" label'
-          summary: 'All PRs must include an appropriate "Type:" label'
+          title: 'Need an appropriate "Type:" label'
+          summary: 'Need an appropriate "Type:" label'
   - when: pull_request.*
     validate:
       - do: label
@@ -23,8 +23,8 @@ mergeable:
       - do: checks
         status: 'failure'
         payload:
-          title: 'All PRs must include a Release milestone or the "no release notes" label'
-          summary: 'All PRs must include a Release milestone or the "no release notes" label'
+          title: 'Need Release milestone or "no release notes" label'
+          summary: 'Need Release milestone or "no release notes" label'
     fail:
       - do: checks
         status: 'success'

--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -12,6 +12,12 @@ mergeable:
           title: 'Need an appropriate "Type:" label'
           summary: 'Need an appropriate "Type:" label'
   - when: pull_request.*
+    # This validator requires either the "no release notes" label OR a "Release" milestone
+    # to be considered successful.  However, validators "pass" in mergeable only if all
+    # checks pass.  So it is implemented in reverse.
+    # I.e.: !(!no_relnotes && !release_milestone) ==> no_relnotes || release_milestone
+    # If both validators pass, then it is considered a failure, and if either fails, it is
+    # considered a success.
     validate:
       - do: label
         must_exclude:
@@ -21,10 +27,10 @@ mergeable:
           regex: 'Release$'
     pass:
       - do: checks
-        status: 'failure'
+        status: 'failure'  # fail on pass
         payload:
           title: 'Need Release milestone or "no release notes" label'
           summary: 'Need Release milestone or "no release notes" label'
     fail:
       - do: checks
-        status: 'success'
+        status: 'success' # pass on fail

--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -4,7 +4,24 @@ mergeable:
     validate:
       - do: label
         must_include:
-          regex: '^Type:|no release notes'
-          message: >
-            All PRs must be labeled with an appropriate "Type:" label, or have the
-            "no release notes" label applied before merging.
+          regex: '^Type:'
+     fail:
+        - do: checks
+          status: 'failure'
+          payload:
+            title: 'Mergeable failed: no "Type:" label'
+            summary: `All PRs must include an appropriate "Type:" label.`
+  - when: pull_request.*
+    validate:
+      - do: label
+        must_include:
+          regex: '^no release notes$'
+      - do: milestone
+        must_include:
+          regex: 'Release$'
+    fail:
+      - do: checks
+        status: 'failure'
+        payload:
+          title: 'Mergeable failed: no milestone or "no release notes" label'
+          summary: `All PRs must include either a Release milestone or the "no release notes" label.`

--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -5,12 +5,12 @@ mergeable:
       - do: label
         must_include:
           regex: '^Type:'
-     fail:
-        - do: checks
-          status: 'failure'
-          payload:
-            title: 'Mergeable failed: no "Type:" label'
-            summary: `All PRs must include an appropriate "Type:" label.`
+    fail:
+       - do: checks
+         status: 'failure'
+         payload:
+           title: 'Mergeable failed: no "Type:" label'
+           summary: `All PRs must include an appropriate "Type:" label.`
   - when: pull_request.*
     validate:
       - do: label

--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -9,8 +9,8 @@ mergeable:
       - do: checks
         status: 'failure'
         payload:
-          title: 'All PRs must include an appropriate "Type:" label.'
-          # summary: 'All PRs must include an appropriate "Type:" label.'
+          title: 'All PRs must include an appropriate "Type:" label'
+          summary: 'All PRs must include an appropriate "Type:" label'
   - when: pull_request.*
     validate:
       - do: label
@@ -24,4 +24,4 @@ mergeable:
         status: 'failure'
         payload:
           title: 'All PRs must include a Release milestone or the "no release notes" label'
-          # summary: 'All PRs must include either a Release milestone or the "no release notes" label.'
+          summary: 'All PRs must include a Release milestone or the "no release notes" label'

--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -1,0 +1,10 @@
+version: 2
+mergeable:
+  - when: pull_request.*
+    validate:
+      - do: label
+        must_include:
+          regex: '^Type:|no release notes'
+        message: >
+          All PRs must be labeled with an appropriate "Type:" label, or have the
+          "no release notes" label applied before merging.

--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -14,14 +14,17 @@ mergeable:
   - when: pull_request.*
     validate:
       - do: label
-        must_include:
+        must_exclude:
           regex: '^no release notes$'
       - do: milestone
-        must_include:
+        must_exclude:
           regex: 'Release$'
-    fail:
+    pass:
       - do: checks
         status: 'failure'
         payload:
           title: 'All PRs must include a Release milestone or the "no release notes" label'
           summary: 'All PRs must include a Release milestone or the "no release notes" label'
+    fail:
+      - do: checks
+        status: 'success'

--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -5,6 +5,6 @@ mergeable:
       - do: label
         must_include:
           regex: '^Type:|no release notes'
-        message: >
-          All PRs must be labeled with an appropriate "Type:" label, or have the
-          "no release notes" label applied before merging.
+          message: >
+            All PRs must be labeled with an appropriate "Type:" label, or have the
+            "no release notes" label applied before merging.


### PR DESCRIPTION
This PR causes mergeable to enforce the following rules on PRs:
- must include a "Type:" label
- must include either the "no release notes" label or a Release milestone