### PR TITLE
modules: add go 1.11 to go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module google.golang.org/grpc
 
+go 1.11
+
 require (
 	cloud.google.com/go v0.26.0 // indirect
 	github.com/BurntSushi/toml v0.3.1 // indirect


### PR DESCRIPTION
https://golang.org/doc/go1.12#modules

With go 1.13, a go command will add `go 1.13` to `go.mod` if `go` directive doesn't already exist, potentially because of the language changes https://golang.org/doc/go1.13#language.