### PR TITLE
Adding a RequestInfo struct for propagating request data to GetRequestMetadata calls.

### DIFF
--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -1,0 +1,3 @@
+## Community Code of Conduct
+
+gRPC follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,8 @@
 # How to contribute
 
-We definitely welcome your patches and contributions to gRPC!
+We definitely welcome your patches and contributions to gRPC! Please read the gRPC
+organization's [governance rules](https://github.com/grpc/grpc-community/blob/master/governance.md)
+and [contribution guidelines](https://github.com/grpc/grpc-community/blob/master/CONTRIBUTING.md) before proceeding.
 
 If you are new to github, please start by reading [Pull Request howto](https://help.github.com/articles/about-pull-requests/)
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,1 @@
+This repository is governed by the gRPC organization's [governance rules](https://github.com/grpc/grpc-community/blob/master/governance.md).

--- a/credentials/credentials.go
+++ b/credentials/credentials.go
@@ -334,3 +334,12 @@ func cloneTLSConfig(cfg *tls.Config) *tls.Config {
 
 	return cfg.Clone()
 }
+
+// RequestInfo contains request data to be attached to the context passed along to GetRequestMetadata calls.
+type RequestInfo struct {
+	// This is assumed to be of the format some.Service/Method
+	Method string
+}
+
+// RequestInfoKey is a struct to be used as the key when attacking a RequestInfo to a context object.
+type RequestInfoKey struct{}

--- a/credentials/credentials.go
+++ b/credentials/credentials.go
@@ -336,10 +336,30 @@ func cloneTLSConfig(cfg *tls.Config) *tls.Config {
 }
 
 // RequestInfo contains request data to be attached to the context passed along to GetRequestMetadata calls.
+//
+// This API is experimental.
 type RequestInfo struct {
 	// This is assumed to be of the format some.Service/Method
 	Method string
 }
 
-// RequestInfoKey is a struct to be used as the key when attacking a RequestInfo to a context object.
-type RequestInfoKey struct{}
+// requestInfoKey is a struct to be used as the key when attaching a RequestInfo to a context object.
+type requestInfoKey struct{}
+
+// RequestInfoFromContext extracts the RequestInfo object from the context object.
+//
+// This API is experimental.
+func RequestInfoFromContext(ctx context.Context) RequestInfo {
+	ri, ok := ctx.Value(requestInfoKey{}).(RequestInfo)
+	if !ok {
+		return RequestInfo{}
+	}
+	return ri
+}
+
+// WithRequestInfo adds the supplied RequestInfo object to the context object.
+//
+// This API is experimental.
+func WithRequestInfo(ctx context.Context, ri RequestInfo) context.Context {
+	return context.WithValue(ctx, requestInfoKey{}, ri)
+}

--- a/examples/features/debugging/README.md
+++ b/examples/features/debugging/README.md
@@ -11,7 +11,7 @@ To turn on the logs for debugging, run the code with the following environment v
 `GRPC_GO_LOG_VERBOSITY_LEVEL=99 GRPC_GO_LOG_SEVERITY_LEVEL=info`. 
 
 ## Channelz
-We also provides a runtime debugging tool, Channelz, to help users with live debugging.
+We also provide a runtime debugging tool, Channelz, to help users with live debugging.
 
 See the channelz blog post here ([link](https://grpc.io/blog/a_short_introduction_to_channelz)) for
 details about how to use channelz service to debug live program.

--- a/go.mod
+++ b/go.mod
@@ -16,8 +16,6 @@ require (
 	golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a
 	golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135
 	google.golang.org/appengine v1.1.0 // indirect
-	google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8
-	honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc
 )
 
 go 1.13

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,6 @@ require (
 	golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a
 	golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135
 	google.golang.org/appengine v1.1.0 // indirect
+  google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8
+  honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc
 )
-
-go 1.13

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,6 @@ require (
 	golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a
 	golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135
 	google.golang.org/appengine v1.1.0 // indirect
-  google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8
-  honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc
+	google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8
+	honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc
 )

--- a/go.mod
+++ b/go.mod
@@ -19,3 +19,5 @@ require (
 	google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8
 	honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc
 )
+
+go 1.13

--- a/go.mod
+++ b/go.mod
@@ -19,5 +19,3 @@ require (
 	google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8
 	honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc
 )
-
-go 1.13

--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -547,6 +547,10 @@ func (t *http2Client) getCallAuthData(ctx context.Context, audience string, call
 // streams.
 func (t *http2Client) NewStream(ctx context.Context, callHdr *CallHdr) (_ *Stream, err error) {
 	ctx = peer.NewContext(ctx, t.getPeer())
+	ri := credentials.RequestInfo{
+		Method: callHdr.Method,
+	}
+	ctx = context.WithValue(ctx, credentials.RequestInfoKey{}, ri)
 	headerFields, err := t.createHeaderFields(ctx, callHdr)
 	if err != nil {
 		return nil, err

--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -550,7 +550,7 @@ func (t *http2Client) NewStream(ctx context.Context, callHdr *CallHdr) (_ *Strea
 	ri := credentials.RequestInfo{
 		Method: callHdr.Method,
 	}
-	ctx = context.WithValue(ctx, credentials.RequestInfoKey{}, ri)
+	ctx = credentials.WithRequestInfo(ctx, ri)
 	headerFields, err := t.createHeaderFields(ctx, callHdr)
 	if err != nil {
 		return nil, err

--- a/internal/transport/transport_test.go
+++ b/internal/transport/transport_test.go
@@ -2384,7 +2384,9 @@ func TestTCPUserTimeout(t *testing.T) {
 // propagated into the context object as a credentials.RequestInfo object.
 func TestRequestInfoFoundInStreamContext(t *testing.T) {
 	serverConfig := &ServerConfig{}
-	_, client, _ := setUpWithOptions(t, 0, serverConfig, suspended, ConnectOptions{})
+	server, client, cancel := setUpWithOptions(t, 0, serverConfig, suspended, ConnectOptions{})
+	defer cancel()
+	defer server.stop()
 	defer client.Close()
 	ch := &CallHdr{
 		Method: "someService/Method",

--- a/internal/transport/transport_test.go
+++ b/internal/transport/transport_test.go
@@ -2388,17 +2388,18 @@ func TestRequestInfoFoundInStreamContext(t *testing.T) {
 	defer cancel()
 	defer server.stop()
 	defer client.Close()
+
 	ch := &CallHdr{
 		Method: "someService/Method",
 	}
-	s, err := client.NewStream(context.Background(), ch)
+	ctx, ctxCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer ctxCancel()
+
+	s, err := client.NewStream(ctx, ch)
 	if err != nil {
 		t.Fatalf("client.NewStream() failed: %v", err)
 	}
-	ri, ok := s.ctx.Value(credentials.RequestInfoKey{}).(credentials.RequestInfo)
-	if !ok {
-		t.Fatalf("s.ctx does not have an attached credentials.RequestInfo object: %v", s.ctx)
-	}
+	ri := credentials.RequestInfoFromContext(s.ctx)
 	if ch.Method != ri.Method {
 		t.Fatalf("RequestInfo.Method == %s; want %s", ri.Method, ch.Method)
 	}

--- a/internal/transport/transport_test.go
+++ b/internal/transport/transport_test.go
@@ -37,6 +37,7 @@ import (
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/hpack"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/internal/leakcheck"
 	"google.golang.org/grpc/internal/syscall"
 	"google.golang.org/grpc/internal/testutils"
@@ -2376,5 +2377,27 @@ func TestTCPUserTimeout(t *testing.T) {
 			t.Fatalf("wrong TCP_USER_TIMEOUT set on conn. expected %d. got %d",
 				timeoutMS, opt)
 		}
+	}
+}
+
+// TestRequestInfoFoundInStreamContext tests whether data passed in as callheader data gets
+// propagated into the context object as a credentials.RequestInfo object.
+func TestRequestInfoFoundInStreamContext(t *testing.T) {
+	serverConfig := &ServerConfig{}
+	_, client, _ := setUpWithOptions(t, 0, serverConfig, suspended, ConnectOptions{})
+	defer client.Close()
+	ch := &CallHdr{
+		Method: "someService/Method",
+	}
+	s, err := client.NewStream(context.Background(), ch)
+	if err != nil {
+		t.Fatalf("client.NewStream() failed: %v", err)
+	}
+	ri, ok := s.ctx.Value(credentials.RequestInfoKey{}).(credentials.RequestInfo)
+	if !ok {
+		t.Fatalf("s.ctx does not have an attached credentials.RequestInfo object: %v", s.ctx)
+	}
+	if ch.Method != ri.Method {
+		t.Fatalf("RequestInfo.Method == %s; want %s", ri.Method, ch.Method)
 	}
 }

--- a/service_config.go
+++ b/service_config.go
@@ -310,6 +310,14 @@ func parseServiceConfig(js string) (*ServiceConfig, error) {
 			}
 			break
 		}
+		if sc.lbConfig == nil {
+			// We had a loadBalancingConfig field but did not encounter a
+			// supported policy.  The config is considered invalid in this
+			// case.
+			err := fmt.Errorf("invalid loadBalancingConfig: no supported policies found")
+			grpclog.Warningf(err.Error())
+			return nil, err
+		}
 	}
 
 	if rsc.MethodConfig == nil {

--- a/service_config_test.go
+++ b/service_config_test.go
@@ -92,6 +92,23 @@ func (s) TestParseLBConfig(t *testing.T) {
 	runParseTests(t, testcases)
 }
 
+func (s) TestParseNoLBConfigSupported(t *testing.T) {
+	// We have a loadBalancingConfig field but will not encounter a supported
+	// policy.  The config will be considered invalid in this case.
+	testcases := []parseTestCase{
+		{
+			scjs: `{
+    "loadBalancingConfig": [{"not_a_balancer1": {} }, {"not_a_balancer2": {}}]
+}`,
+			wantErr: true,
+		}, {
+			scjs:    `{"loadBalancingConfig": []}`,
+			wantErr: true,
+		},
+	}
+	runParseTests(t, testcases)
+}
+
 func (s) TestParseLoadBalancer(t *testing.T) {
 	testcases := []parseTestCase{
 		{


### PR DESCRIPTION
Add a RequestInfo struct which initially is used for passing the full request method (though could later be expanded to pass more info) so that things like GetRequestMetadata can be used to apply logic based on that data.

This is a fix for https://github.com/grpc/grpc-go/issues/3019