### PR TITLE
client: consider service config invalid if loadBalancingConfig contains no supported policy

### DIFF
--- a/service_config.go
+++ b/service_config.go
@@ -310,6 +310,14 @@ func parseServiceConfig(js string) (*ServiceConfig, error) {
 			}
 			break
 		}
+		if sc.lbConfig == nil {
+			// We had a loadBalancingConfig field but did not encounter a
+			// supported policy.  The config is considered invalid in this
+			// case.
+			err := fmt.Errorf("invalid loadBalancingConfig: no supported policies found")
+			grpclog.Warningf(err.Error())
+			return nil, err
+		}
 	}
 
 	if rsc.MethodConfig == nil {

--- a/service_config_test.go
+++ b/service_config_test.go
@@ -93,6 +93,8 @@ func (s) TestParseLBConfig(t *testing.T) {
 }
 
 func (s) TestParseNoLBConfigSupported(t *testing.T) {
+	// We have a loadBalancingConfig field but will not encounter a supported
+	// policy.  The config will be considered invalid in this case.
 	testcases := []parseTestCase{
 		{
 			scjs: `{

--- a/service_config_test.go
+++ b/service_config_test.go
@@ -101,6 +101,9 @@ func (s) TestParseNoLBConfigSupported(t *testing.T) {
     "loadBalancingConfig": [{"not_a_balancer1": {} }, {"not_a_balancer2": {}}]
 }`,
 			wantErr: true,
+		}, {
+			scjs:    `{"loadBalancingConfig": []}`,
+			wantErr: true,
 		},
 	}
 	runParseTests(t, testcases)

--- a/service_config_test.go
+++ b/service_config_test.go
@@ -92,6 +92,18 @@ func (s) TestParseLBConfig(t *testing.T) {
 	runParseTests(t, testcases)
 }
 
+func (s) TestParseNoLBConfigSupported(t *testing.T) {
+	testcases := []parseTestCase{
+		{
+			scjs: `{
+    "loadBalancingConfig": [{"not_a_balancer1": {} }, {"not_a_balancer2": {}}]
+}`,
+			wantErr: true,
+		},
+	}
+	runParseTests(t, testcases)
+}
+
 func (s) TestParseLoadBalancer(t *testing.T) {
 	testcases := []parseTestCase{
 		{


### PR DESCRIPTION
If `loadBalancingConfig` is not specified in the service config, this has no effect.

Relevant [part](https://github.com/grpc/proposal/blob/master/A24-lb-policy-config.md#proposal) of gRFC:
```proto
message ServiceConfig {
...
  // Multiple LB policies can be specified; clients will iterate through
  // the list in order and stop at the first policy that they support. If none
  // are supported, the service config is considered invalid.
  repeated LoadBalancingConfig load_balancing_config = 4;
}
```