### PR TITLE
Pre-create larger buffers when uncompressing, to reduce garbage.

### DIFF
--- a/clientconn.go
+++ b/clientconn.go
@@ -94,6 +94,7 @@ var (
 const (
 	defaultClientMaxReceiveMessageSize = 1024 * 1024 * 4
 	defaultClientMaxSendMessageSize    = math.MaxInt32
+	defaultClientCompressionFactor     = 2
 	// http2IOBufSize specifies the buffer size for sending frames.
 	defaultWriteBufSize = 32 * 1024
 	defaultReadBufSize  = 32 * 1024

--- a/server.go
+++ b/server.go
@@ -130,6 +130,7 @@ type serverOptions struct {
 	readBufferSize        int
 	connectionTimeout     time.Duration
 	maxHeaderListSize     *uint32
+	compressionFactor     int
 }
 
 var defaultServerOptions = serverOptions{
@@ -138,6 +139,7 @@ var defaultServerOptions = serverOptions{
 	connectionTimeout:     120 * time.Second,
 	writeBufferSize:       defaultWriteBufSize,
 	readBufferSize:        defaultReadBufSize,
+	compressionFactor:     2,
 }
 
 // A ServerOption sets options such as credentials, codec and keepalive parameters, etc.
@@ -256,6 +258,14 @@ func RPCCompressor(cp Compressor) ServerOption {
 func RPCDecompressor(dc Decompressor) ServerOption {
 	return newFuncServerOption(func(o *serverOptions) {
 		o.dc = dc
+	})
+}
+
+// CompressionFactor returns a ServerOption to set the expected compression factor, used to size buffers.
+// If this is not set, gRPC uses the default factor 2.
+func CompressionFactor(f int) ServerOption {
+	return newFuncServerOption(func(o *serverOptions) {
+		o.compressionFactor = f
 	})
 }
 
@@ -956,7 +966,7 @@ func (s *Server) processUnaryRPC(t transport.ServerTransport, stream *transport.
 	if sh != nil || binlog != nil {
 		payInfo = &payloadInfo{}
 	}
-	d, err := recvAndDecompress(&parser{r: stream}, stream, dc, s.opts.maxReceiveMessageSize, payInfo, decomp)
+	d, err := recvAndDecompress(&parser{r: stream}, stream, dc, s.opts.maxReceiveMessageSize, payInfo, decomp, s.opts.compressionFactor)
 	if err != nil {
 		if st, ok := status.FromError(err); ok {
 			if e := t.WriteStatus(stream, st); e != nil {
@@ -1122,6 +1132,7 @@ func (s *Server) processStreamingRPC(t transport.ServerTransport, stream *transp
 		codec:                 s.getCodec(stream.ContentSubtype()),
 		maxReceiveMessageSize: s.opts.maxReceiveMessageSize,
 		maxSendMessageSize:    s.opts.maxSendMessageSize,
+		compressionFactor:     s.opts.compressionFactor,
 		trInfo:                trInfo,
 		statsHandler:          sh,
 	}


### PR DESCRIPTION
Fixes #2635 

The basic idea is that, instead of starting at a fixed size of 512 bytes, the buffer is created as a multiple of the size of the compressed data.

Add `CompressionFactor` options on call and server for the user to control this multiple.
