### PR TITLE
Use exact size, if known, to allocate decompression buffer

### DIFF
--- a/encoding/encoding.go
+++ b/encoding/encoding.go
@@ -52,8 +52,8 @@ type Compressor interface {
 // This API is EXPERIMENTAL.
 type CompressorSizer interface {
 	// DecompressedSize returns the exact size the message will
-	// uncompress into, if known.
-	DecompressedSize(buf []byte, maxSize int) (int, error)
+	// uncompress into, or -1 if unknown.
+	DecompressedSize(buf []byte) int
 }
 
 var registeredCompressor = make(map[string]Compressor)

--- a/encoding/encoding.go
+++ b/encoding/encoding.go
@@ -46,14 +46,10 @@ type Compressor interface {
 	// coding header.  The result must be static; the result cannot change
 	// between calls.
 	Name() string
-}
-
-// CompressorSizer is optional, can be implemented to improve efficiency.
-// This API is EXPERIMENTAL.
-type CompressorSizer interface {
-	// DecompressedSize returns the exact size the message will
-	// uncompress into, or -1 if unknown.
-	DecompressedSize(buf []byte) int
+	// EXPERIMENTAL: if a Compressor implements
+	// DecompressedSize(compressedBytes []byte) int, gRPC will call it
+	// to determine the size of the buffer allocated for the result of decompression.
+	// Return -1 to indicate unknown size.
 }
 
 var registeredCompressor = make(map[string]Compressor)

--- a/encoding/encoding.go
+++ b/encoding/encoding.go
@@ -48,6 +48,14 @@ type Compressor interface {
 	Name() string
 }
 
+// CompressorSizer is optional, can be implemented to improve efficiency.
+// This API is EXPERIMENTAL.
+type CompressorSizer interface {
+	// DecompressedSize returns the exact size the message will
+	// uncompress into, if known.
+	DecompressedSize(buf []byte, maxSize int) (int, error)
+}
+
 var registeredCompressor = make(map[string]Compressor)
 
 // RegisterCompressor registers the compressor with gRPC by its name.  It can

--- a/encoding/gzip/gzip.go
+++ b/encoding/gzip/gzip.go
@@ -108,8 +108,6 @@ func (z *reader) Read(p []byte) (n int, err error) {
 	return n, err
 }
 
-var _ encoding.CompressorSizer = &compressor{} // assert we conform to this optional interface
-
 // RFC1952 specifies that the last four bytes "contains the size of
 // the original (uncompressed) input data modulo 2^32."
 // gRPC has a max message size of 2GB so we don't need to worry about wraparound.

--- a/rpc_util.go
+++ b/rpc_util.go
@@ -686,18 +686,12 @@ func decompress(compressor encoding.Compressor, d []byte, maxReceiveMessageSize 
 			if size > maxReceiveMessageSize {
 				return nil, size, nil
 			}
+			// size is used as an estimate to size the buffer, but we
+			// will read more data if available.
 			var buf bytes.Buffer
 			buf.Grow(size + bytes.MinRead) // extra space guarantees no reallocation
-			// Limit to size+1 so we can detect if the compressed data
-			// is actually bigger than the reported size
-			bytesRead, err := buf.ReadFrom(io.LimitReader(dcReader, int64(size)+1))
-			if err != nil {
-				return nil, size, err
-			}
-			if bytesRead != int64(size) {
-				return nil, size, fmt.Errorf("read different size than expected (%d vs. %d)", bytesRead, size)
-			}
-			return buf.Bytes(), size, nil
+			bytesRead, err := buf.ReadFrom(io.LimitReader(dcReader, int64(maxReceiveMessageSize)+1))
+			return buf.Bytes(), int(bytesRead), err
 		}
 	}
 	// Read from LimitReader with limit max+1. So if the underlying

--- a/rpc_util.go
+++ b/rpc_util.go
@@ -688,8 +688,8 @@ func decompress(compressor encoding.Compressor, d []byte, maxReceiveMessageSize 
 			}
 			// size is used as an estimate to size the buffer, but we
 			// will read more data if available.
-			var buf bytes.Buffer
-			buf.Grow(size + bytes.MinRead) // extra space guarantees no reallocation
+			// +MinRead so ReadFrom will not reallocate if size is correct.
+			buf := bytes.NewBuffer(make([]byte, 0, size+bytes.MinRead))
 			bytesRead, err := buf.ReadFrom(io.LimitReader(dcReader, int64(maxReceiveMessageSize)+1))
 			return buf.Bytes(), int(bytesRead), err
 		}

--- a/rpc_util.go
+++ b/rpc_util.go
@@ -679,7 +679,9 @@ func decompress(compressor encoding.Compressor, d []byte, maxReceiveMessageSize 
 	if err != nil {
 		return nil, 0, err
 	}
-	if sizer, ok := compressor.(encoding.CompressorSizer); ok {
+	if sizer, ok := compressor.(interface {
+		DecompressedSize(compressedBytes []byte) int
+	}); ok {
 		if size := sizer.DecompressedSize(d); size >= 0 {
 			if size > maxReceiveMessageSize {
 				return nil, size, nil


### PR DESCRIPTION
Fixes #2635 

For large messages this generates far less garbage than `ioutil.ReadAll()`.

Implement for gzip - RFC1952 requires it, and the Go implementation checks it already (modulo 2^32).
