### PR TITLE
health: Use sync.RWMutex instead of sync.Mutex

### DIFF
--- a/health/server.go
+++ b/health/server.go
@@ -35,7 +35,7 @@ import (
 
 // Server implements `service Health`.
 type Server struct {
-	mu sync.Mutex
+	mu sync.RWMutex
 	// If shutdown is true, it's expected all serving status is NOT_SERVING, and
 	// will stay in NOT_SERVING.
 	shutdown bool
@@ -54,8 +54,8 @@ func NewServer() *Server {
 
 // Check implements `service Health`.
 func (s *Server) Check(ctx context.Context, in *healthpb.HealthCheckRequest) (*healthpb.HealthCheckResponse, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	if servingStatus, ok := s.statusMap[in.Service]; ok {
 		return &healthpb.HealthCheckResponse{
 			Status: servingStatus,


### PR DESCRIPTION
The `Check` method of the `Server` struct only reads some information from itself. And the other methods do both read and write operations.

In this case, many people usually use `sync.RWMutex` instead of `sync.Mutex`. It not only improves performance, but also clarifies what the method does.

This is not a necessary change, but I think it will help in many ways.