### PR TITLE
transport: fix race between operateHeaders and closeStream and reading headers

### DIFF
--- a/internal/transport/transport.go
+++ b/internal/transport/transport.go
@@ -320,6 +320,9 @@ func (s *Stream) waitOnHeader() {
 		// this function returns.
 		err := ContextErr(s.ctx.Err())
 		s.ct.closeStream(s, err, false, 0, status.Convert(err), nil, false)
+		// headerChan could possibly not be closed yet if closeStream raced
+		// with operateHeaders; wait until it is closed explicitly here.
+		<-s.headerChan
 	case <-s.headerChan:
 	}
 }


### PR DESCRIPTION
`headerChan` isn't necessarily closed when `closeStream` returns; block on it in `waitOnHeader`.