### PR TITLE
transport: don't check s.header on the server side in Stream.Header

### DIFF
--- a/internal/transport/http2_server.go
+++ b/internal/transport/http2_server.go
@@ -751,7 +751,7 @@ func (t *http2Server) checkForHeaderListSize(it interface{}) bool {
 	return true
 }
 
-// WriteHeader sends the header metedata md back to the client.
+// WriteHeader sends the header metadata md back to the client.
 func (t *http2Server) WriteHeader(s *Stream, md metadata.MD) error {
 	if s.updateHeaderSent() || s.getState() == streamDone {
 		return ErrIllegalHeaderWrite


### PR DESCRIPTION
Previously this would fall into returning the same `s.header.Copy(), nil`
condition at the end of the function, returning an empty `MD`.  After a recent
change it would instead check `headerValid`, which is always false on servers,
and return `nil` and an error.  Callers were ignoring this error so no behavior
change was seen, but there is no need to check `s.headers` here.