### PR TITLE
xds: support priority

### DIFF
--- a/xds/internal/balancer/edsbalancer/balancergroup.go
+++ b/xds/internal/balancer/edsbalancer/balancergroup.go
@@ -125,11 +125,9 @@ func (sbc *subBalancerWithConfig) updateAddrs(addrs []resolver.Address) {
 		// the balancer group is closed. There should be no further address
 		// updates when either of this happened.
 		//
-		// TODO: Update comment and delete the warning below.
 		// This will be a common case with priority support, because a
 		// sub-balancer (and the whole balancer group) could be closed because
 		// it's the lower priority, but it can still get address updates.
-		grpclog.Warningf("subBalancerWithConfig: updateAddrs is called when balancer is nil. This means this sub-balancer is closed.")
 		return
 	}
 	if ub, ok := b.(balancer.V2Balancer); ok {

--- a/xds/internal/balancer/edsbalancer/edsbalancer.go
+++ b/xds/internal/balancer/edsbalancer/edsbalancer.go
@@ -24,6 +24,7 @@ import (
 	"reflect"
 	"strconv"
 	"sync"
+	"time"
 
 	xdspb "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	corepb "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
@@ -41,9 +42,27 @@ import (
 	"google.golang.org/grpc/xds/internal/balancer/lrs"
 )
 
+// TODO: make this a environment variable?
+var defaultPriorityInitTimeout = 10 * time.Second
+
 type localityConfig struct {
 	weight uint32
 	addrs  []resolver.Address
+}
+
+// balancerGroupWithConfig contains the localities with the same priority. It
+// manages all localities using a balancerGroup.
+type balancerGroupWithConfig struct {
+	bg      *balancerGroup
+	configs map[internal.Locality]*localityConfig
+}
+
+// balancerState keeps the previous state updated by a priority. It's kept so if
+// a lower priority is removed, the higher priority's state will be sent to
+// parent ClientConn (even if it's not Ready).
+type balancerState struct {
+	state  connectivity.State
+	picker balancer.Picker
 }
 
 // EDSBalancer does load balancing based on the EDS responses. Note that it
@@ -53,12 +72,31 @@ type localityConfig struct {
 // The localities are picked as weighted round robin. A configurable child
 // policy is used to manage endpoints in each locality.
 type EDSBalancer struct {
-	balancer.ClientConn
+	cc balancer.ClientConn
 
-	bg                 *balancerGroup
-	subBalancerBuilder balancer.Builder
-	lidToConfig        map[internal.Locality]*localityConfig
-	loadStore          lrs.Store
+	subBalancerBuilder   balancer.Builder
+	loadStore            lrs.Store
+	priorityToLocalities map[priorityType]*balancerGroupWithConfig
+
+	// There's no need to hold any mutexes at the same time. The order to take
+	// mutex should be: priorityMu > subConnMu, but this is implicit via
+	// balancers (starting balancer with next priority while holding priorityMu,
+	// and the balancer may create new SubConn).
+
+	priorityMu sync.Mutex
+	// priorities are pointers, and will be nil when EDS returns empty result.
+	priorityInUse   priorityType
+	priorityLowest  priorityType
+	priorityToState map[priorityType]*balancerState
+	// The timer to give a priority 10 seconds to connect. And if the priority
+	// doesn't go into Ready/Failure, start the next priority.
+	//
+	// One timer is enough because there can be at most one priority in init
+	// state.
+	priorityInitTimer *time.Timer
+
+	subConnMu         sync.Mutex
+	subConnToPriority map[balancer.SubConn]priorityType
 
 	pickerMu    sync.Mutex
 	drops       []*dropper
@@ -69,11 +107,13 @@ type EDSBalancer struct {
 // NewXDSBalancer create a new EDSBalancer.
 func NewXDSBalancer(cc balancer.ClientConn, loadStore lrs.Store) *EDSBalancer {
 	xdsB := &EDSBalancer{
-		ClientConn:         cc,
+		cc:                 cc,
 		subBalancerBuilder: balancer.Get(roundrobin.Name),
 
-		lidToConfig: make(map[internal.Locality]*localityConfig),
-		loadStore:   loadStore,
+		priorityToLocalities: make(map[priorityType]*balancerGroupWithConfig),
+		priorityToState:      make(map[priorityType]*balancerState),
+		subConnToPriority:    make(map[balancer.SubConn]priorityType),
+		loadStore:            loadStore,
 	}
 	// Don't start balancer group here. Start it when handling the first EDS
 	// response. Otherwise the balancer group will be started with round-robin,
@@ -88,30 +128,26 @@ func NewXDSBalancer(cc balancer.ClientConn, loadStore lrs.Store) *EDSBalancer {
 //
 // HandleChildPolicy and HandleEDSResponse must be called by the same goroutine.
 func (xdsB *EDSBalancer) HandleChildPolicy(name string, config json.RawMessage) {
-	xdsB.updateSubBalancerName(name)
-	// TODO: (eds) send balancer config to the new child balancers.
-}
-
-func (xdsB *EDSBalancer) updateSubBalancerName(subBalancerName string) {
-	if xdsB.subBalancerBuilder.Name() == subBalancerName {
+	if xdsB.subBalancerBuilder.Name() == name {
 		return
 	}
-	newSubBalancerBuilder := balancer.Get(subBalancerName)
+	newSubBalancerBuilder := balancer.Get(name)
 	if newSubBalancerBuilder == nil {
-		grpclog.Infof("EDSBalancer: failed to find balancer with name %q, keep using %q", subBalancerName, xdsB.subBalancerBuilder.Name())
+		grpclog.Infof("EDSBalancer: failed to find balancer with name %q, keep using %q", name, xdsB.subBalancerBuilder.Name())
 		return
 	}
 	xdsB.subBalancerBuilder = newSubBalancerBuilder
-	if xdsB.bg != nil {
-		// xdsB.bg == nil until the first EDS response is handled. There's no
-		// need to update balancer group before that.
-		for id, config := range xdsB.lidToConfig {
+	for _, bgwc := range xdsB.priorityToLocalities {
+		if bgwc == nil {
+			continue
+		}
+		for id, config := range bgwc.configs {
 			// TODO: (eds) add support to balancer group to support smoothly
 			//  switching sub-balancers (keep old balancer around until new
 			//  balancer becomes ready).
-			xdsB.bg.remove(id)
-			xdsB.bg.add(id, config.weight, xdsB.subBalancerBuilder)
-			xdsB.bg.handleResolvedAddrs(id, config.addrs)
+			bgwc.bg.remove(id)
+			bgwc.bg.add(id, config.weight, xdsB.subBalancerBuilder)
+			bgwc.bg.handleResolvedAddrs(id, config.addrs)
 		}
 	}
 }
@@ -157,7 +193,7 @@ func (xdsB *EDSBalancer) updateDrops(dropPolicies []*xdspb.ClusterLoadAssignment
 		xdsB.drops = newDrops
 		if xdsB.innerPicker != nil {
 			// Update picker with old inner picker, new drops.
-			xdsB.ClientConn.UpdateBalancerState(xdsB.innerState, newDropPicker(xdsB.innerPicker, newDrops, xdsB.loadStore))
+			xdsB.cc.UpdateBalancerState(xdsB.innerState, newDropPicker(xdsB.innerPicker, newDrops, xdsB.loadStore))
 		}
 		xdsB.pickerMu.Unlock()
 	}
@@ -168,13 +204,6 @@ func (xdsB *EDSBalancer) updateDrops(dropPolicies []*xdspb.ClusterLoadAssignment
 //
 // HandleChildPolicy and HandleEDSResponse must be called by the same goroutine.
 func (xdsB *EDSBalancer) HandleEDSResponse(edsResp *xdspb.ClusterLoadAssignment) {
-	// Create balancer group if it's never created (this is the first EDS
-	// response).
-	if xdsB.bg == nil {
-		xdsB.bg = newBalancerGroup(xdsB, xdsB.loadStore)
-		xdsB.bg.start()
-	}
-
 	// TODO: Unhandled fields from EDS response:
 	//  - edsResp.GetPolicy().GetOverprovisioningFactor()
 	//  - locality.GetPriority()
@@ -195,18 +224,69 @@ func (xdsB *EDSBalancer) HandleEDSResponse(edsResp *xdspb.ClusterLoadAssignment)
 	//
 	// In the future, we should look at the config in CDS response and decide
 	// whether locality weight matters.
-	newEndpoints := make([]*endpointpb.LocalityLbEndpoints, 0, len(edsResp.Endpoints))
+	newLocalitiesWithPriority := make(map[priorityType][]*endpointpb.LocalityLbEndpoints)
 	for _, locality := range edsResp.Endpoints {
 		if locality.GetLoadBalancingWeight().GetValue() == 0 {
 			continue
 		}
-		newEndpoints = append(newEndpoints, locality)
+		priority := newPriorityType(locality.GetPriority())
+		newLocalitiesWithPriority[priority] = append(newLocalitiesWithPriority[priority], locality)
 	}
 
-	// newLocalitiesSet contains all names of localitis in the new EDS response.
-	// It's used to delete localities that are removed in the new EDS response.
+	var (
+		priorityLowest  priorityType
+		priorityChanged bool
+	)
+
+	for priority, newLocalities := range newLocalitiesWithPriority {
+		if !priorityLowest.isSet() || priorityLowest.higherThan(priority) {
+			priorityLowest = priority
+		}
+
+		bgwc, ok := xdsB.priorityToLocalities[priority]
+		if !ok {
+			// Create balancer group if it's never created (this is the first
+			// time this priority is received). We don't start it here. It may
+			// be started when necessary (e.g. when higher is down, or if it's a
+			// new lowest priority).
+			bgwc = &balancerGroupWithConfig{
+				bg: newBalancerGroup(
+					xdsB.ccWrapperWithPriority(priority), xdsB.loadStore,
+				),
+				configs: make(map[internal.Locality]*localityConfig),
+			}
+			xdsB.priorityToLocalities[priority] = bgwc
+			priorityChanged = true
+		}
+		xdsB.handleEDSResponsePerPriority(bgwc, newLocalities)
+	}
+	xdsB.priorityLowest = priorityLowest
+
+	// Delete priorities that are removed in the latest response, and also close
+	// the balancer group.
+	for p, bgwc := range xdsB.priorityToLocalities {
+		if _, ok := newLocalitiesWithPriority[p]; !ok {
+			delete(xdsB.priorityToLocalities, p)
+			bgwc.bg.close()
+			delete(xdsB.priorityToState, p)
+			priorityChanged = true
+		}
+	}
+
+	// If priority was added/removed, it may affect the balancer group to use.
+	// E.g. priorityInUse was removed, or all priorities are down, and a new
+	// lower priority was added.
+	if priorityChanged {
+		xdsB.handlePriorityChange()
+	}
+}
+
+func (xdsB *EDSBalancer) handleEDSResponsePerPriority(bgwc *balancerGroupWithConfig, newLocalities []*endpointpb.LocalityLbEndpoints) {
+	// newLocalitiesSet contains all names of localities in the new EDS response
+	// for the same priority. It's used to delete localities that are removed in
+	// the new EDS response.
 	newLocalitiesSet := make(map[internal.Locality]struct{})
-	for _, locality := range newEndpoints {
+	for _, locality := range newLocalities {
 		// One balancer for each locality.
 
 		l := locality.GetLocality()
@@ -245,17 +325,17 @@ func (xdsB *EDSBalancer) HandleEDSResponse(edsResp *xdspb.ClusterLoadAssignment)
 			newAddrs = append(newAddrs, address)
 		}
 		var weightChanged, addrsChanged bool
-		config, ok := xdsB.lidToConfig[lid]
+		config, ok := bgwc.configs[lid]
 		if !ok {
 			// A new balancer, add it to balancer group and balancer map.
-			xdsB.bg.add(lid, newWeight, xdsB.subBalancerBuilder)
+			bgwc.bg.add(lid, newWeight, xdsB.subBalancerBuilder)
 			config = &localityConfig{
 				weight: newWeight,
 			}
-			xdsB.lidToConfig[lid] = config
+			bgwc.configs[lid] = config
 
-			// weightChanged is false for new locality, because there's no need to
-			// update weight in bg.
+			// weightChanged is false for new locality, because there's no need
+			// to update weight in bg.
 			addrsChanged = true
 		} else {
 			// Compare weight and addrs.
@@ -269,44 +349,104 @@ func (xdsB *EDSBalancer) HandleEDSResponse(edsResp *xdspb.ClusterLoadAssignment)
 
 		if weightChanged {
 			config.weight = newWeight
-			xdsB.bg.changeWeight(lid, newWeight)
+			bgwc.bg.changeWeight(lid, newWeight)
 		}
 
 		if addrsChanged {
 			config.addrs = newAddrs
-			xdsB.bg.handleResolvedAddrs(lid, newAddrs)
+			bgwc.bg.handleResolvedAddrs(lid, newAddrs)
 		}
 	}
 
 	// Delete localities that are removed in the latest response.
-	for lid := range xdsB.lidToConfig {
+	for lid := range bgwc.configs {
 		if _, ok := newLocalitiesSet[lid]; !ok {
-			xdsB.bg.remove(lid)
-			delete(xdsB.lidToConfig, lid)
+			bgwc.bg.remove(lid)
+			delete(bgwc.configs, lid)
 		}
 	}
 }
 
 // HandleSubConnStateChange handles the state change and update pickers accordingly.
 func (xdsB *EDSBalancer) HandleSubConnStateChange(sc balancer.SubConn, s connectivity.State) {
-	xdsB.bg.handleSubConnStateChange(sc, s)
+	xdsB.subConnMu.Lock()
+	var bgwc *balancerGroupWithConfig
+	if p, ok := xdsB.subConnToPriority[sc]; ok {
+		if s == connectivity.Shutdown {
+			// Only delete sc from the map when state changed to Shutdown.
+			delete(xdsB.subConnToPriority, sc)
+		}
+		bgwc = xdsB.priorityToLocalities[p]
+	}
+	xdsB.subConnMu.Unlock()
+	if bgwc == nil {
+		grpclog.Infof("EDSBalancer: priority not found for sc state change")
+		return
+	}
+	if bg := bgwc.bg; bg != nil {
+		bg.handleSubConnStateChange(sc, s)
+	}
 }
 
-// UpdateBalancerState overrides balancer.ClientConn to wrap the picker in a
-// dropPicker.
-func (xdsB *EDSBalancer) UpdateBalancerState(s connectivity.State, p balancer.Picker) {
-	xdsB.pickerMu.Lock()
-	defer xdsB.pickerMu.Unlock()
-	xdsB.innerPicker = p
-	xdsB.innerState = s
-	// Don't reset drops when it's a state change.
-	xdsB.ClientConn.UpdateBalancerState(s, newDropPicker(p, xdsB.drops, xdsB.loadStore))
+// updateBalancerState first handles priority, and then wraps picker in a drop
+// picker before forwarding the update.
+func (xdsB *EDSBalancer) updateBalancerState(priority priorityType, s connectivity.State, p balancer.Picker) {
+	_, ok := xdsB.priorityToLocalities[priority]
+	if !ok {
+		grpclog.Infof("eds: received picker update from unknown priority")
+		return
+	}
+
+	if xdsB.handlePriorityWithNewState(priority, s, p) {
+		xdsB.pickerMu.Lock()
+		defer xdsB.pickerMu.Unlock()
+		xdsB.innerPicker = p
+		xdsB.innerState = s
+		// Don't reset drops when it's a state change.
+		xdsB.cc.UpdateBalancerState(s, newDropPicker(p, xdsB.drops, xdsB.loadStore))
+	}
+}
+
+func (xdsB *EDSBalancer) ccWrapperWithPriority(priority priorityType) *edsBalancerWrapperCC {
+	return &edsBalancerWrapperCC{
+		ClientConn: xdsB.cc,
+		priority:   priority,
+		parent:     xdsB,
+	}
+}
+
+// edsBalancerWrapperCC implements the balancer.ClientConn API and get passed to
+// each balancer group. It contains the locality priority.
+type edsBalancerWrapperCC struct {
+	balancer.ClientConn
+	priority priorityType
+	parent   *EDSBalancer
+}
+
+func (ebwcc *edsBalancerWrapperCC) NewSubConn(addrs []resolver.Address, opts balancer.NewSubConnOptions) (balancer.SubConn, error) {
+	return ebwcc.parent.newSubConn(ebwcc.priority, addrs, opts)
+}
+func (ebwcc *edsBalancerWrapperCC) UpdateBalancerState(state connectivity.State, picker balancer.Picker) {
+	ebwcc.parent.updateBalancerState(ebwcc.priority, state, picker)
+}
+
+func (xdsB *EDSBalancer) newSubConn(priority priorityType, addrs []resolver.Address, opts balancer.NewSubConnOptions) (balancer.SubConn, error) {
+	sc, err := xdsB.cc.NewSubConn(addrs, opts)
+	if err != nil {
+		return nil, err
+	}
+	xdsB.subConnMu.Lock()
+	xdsB.subConnToPriority[sc] = priority
+	xdsB.subConnMu.Unlock()
+	return sc, nil
 }
 
 // Close closes the balancer.
 func (xdsB *EDSBalancer) Close() {
-	if xdsB.bg != nil {
-		xdsB.bg.close()
+	for _, bgwc := range xdsB.priorityToLocalities {
+		if bg := bgwc.bg; bg != nil {
+			bg.close()
+		}
 	}
 }
 

--- a/xds/internal/balancer/edsbalancer/priority.go
+++ b/xds/internal/balancer/edsbalancer/priority.go
@@ -1,0 +1,326 @@
+/*
+ *
+ * Copyright 2019 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package edsbalancer
+
+import (
+	"time"
+
+	"google.golang.org/grpc/balancer"
+	"google.golang.org/grpc/balancer/base"
+	"google.golang.org/grpc/connectivity"
+	"google.golang.org/grpc/grpclog"
+)
+
+// handlePriorityChange handles priority after EDS adds/removes a
+// priority.
+//
+// - If all priorities were deleted, unset priorityInUse, and set parent
+// ClientConn to TransientFailure
+// - If priorityInUse wasn't set, this is either the first EDS resp, or the
+// previous EDS resp deleted everything. Set priorityInUse to 0, and start 0.
+// - If priorityInUse was deleted, send the picker from the new lowest priority
+// to parent ClientConn, and set priorityInUse to the new lowest.
+// - If priorityInUse has a non-Ready state, and also there's a priority lower
+// than priorityInUse (which means a lower priority was added), set the next
+// priority as new priorityInUse, and start the bg.
+func (xdsB *EDSBalancer) handlePriorityChange() {
+	xdsB.priorityMu.Lock()
+	defer xdsB.priorityMu.Unlock()
+
+	// Everything was removed by EDS.
+	if !xdsB.priorityLowest.isSet() {
+		xdsB.priorityInUse = newPriorityTypeUnset()
+		xdsB.cc.UpdateBalancerState(connectivity.TransientFailure, base.NewErrPicker(balancer.ErrTransientFailure))
+		return
+	}
+
+	// priorityInUse wasn't set, use 0.
+	if !xdsB.priorityInUse.isSet() {
+		xdsB.startPriority(newPriorityType(0))
+		return
+	}
+
+	// priorityInUse was deleted, use the new lowest.
+	if _, ok := xdsB.priorityToLocalities[xdsB.priorityInUse]; !ok {
+		xdsB.priorityInUse = xdsB.priorityLowest
+		if s, ok := xdsB.priorityToState[xdsB.priorityLowest]; ok {
+			xdsB.cc.UpdateBalancerState(s.state, s.picker)
+		} else {
+			// If state for priorityLowest is not found, this means priorityLowest was
+			// started, but never sent any update. The init timer fired and
+			// triggered the next priority. The old_priorityInUse (that was just
+			// deleted EDS) was picked later.
+			//
+			// We don't have an old state to send to parent, but we also don't
+			// want parent to keep using picker from old_priorityInUse. Send an
+			// update to trigger block picks until a new picker is ready.
+			xdsB.cc.UpdateBalancerState(connectivity.Connecting, base.NewErrPicker(balancer.ErrNoSubConnAvailable))
+		}
+		return
+	}
+
+	// priorityInUse is not ready, look for next priority, and use if found.
+	if s, ok := xdsB.priorityToState[xdsB.priorityInUse]; ok && s.state != connectivity.Ready {
+		pNext := xdsB.priorityInUse.nextLower()
+		if _, ok := xdsB.priorityToLocalities[pNext]; ok {
+			xdsB.startPriority(pNext)
+		}
+	}
+}
+
+// startPriority sets priorityInUse to p, and starts the balancer group for p.
+// It also starts a timer to fall to next priority after timeout.
+//
+// Caller must hold priorityMu, priority must exist, and xdsB.priorityInUse must
+// be non-nil.
+func (xdsB *EDSBalancer) startPriority(priority priorityType) {
+	xdsB.priorityInUse = priority
+	p := xdsB.priorityToLocalities[priority]
+	// NOTE: this will eventually send addresses to sub-balancers. If the
+	// sub-balancer tries to update picker, it will result in a deadlock on
+	// priorityMu. But it's not an expected behavior for the balancer to
+	// update picker when handling addresses.
+	p.bg.start()
+	// startPriority can be called when
+	// 1. first EDS resp, start p0
+	// 2. a high priority goes Failure, start next
+	// 3. a high priority init timeout, start next
+	//
+	// In all the cases, the existing init timer is either closed, also already
+	// expired. There's no need to close the old timer.
+	xdsB.priorityInitTimer = time.AfterFunc(defaultPriorityInitTimeout, func() {
+		xdsB.priorityMu.Lock()
+		defer xdsB.priorityMu.Unlock()
+		if !xdsB.priorityInUse.equal(priority) {
+			return
+		}
+		xdsB.priorityInitTimer = nil
+		pNext := priority.nextLower()
+		if _, ok := xdsB.priorityToLocalities[pNext]; ok {
+			xdsB.startPriority(pNext)
+		}
+	})
+}
+
+// handlePriorityWithNewState start/close priorities based on the connectivity
+// state. It returns whether the state should be forwarded to parent ClientConn.
+func (xdsB *EDSBalancer) handlePriorityWithNewState(priority priorityType, s connectivity.State, p balancer.Picker) bool {
+	xdsB.priorityMu.Lock()
+	defer xdsB.priorityMu.Unlock()
+
+	if !xdsB.priorityInUse.isSet() {
+		grpclog.Infof("eds: received picker update when no priority is in use (EDS returned an empty list)")
+		return false
+	}
+
+	if xdsB.priorityInUse.higherThan(priority) {
+		// Lower priorities should all be closed, this is an unexpected update.
+		grpclog.Infof("eds: received picker update from priority lower then priorityInUse")
+		return false
+	}
+
+	bState, ok := xdsB.priorityToState[priority]
+	if !ok {
+		bState = &balancerState{}
+		xdsB.priorityToState[priority] = bState
+	}
+	oldState := bState.state
+	bState.state = s
+	bState.picker = p
+
+	switch s {
+	case connectivity.Ready:
+		return xdsB.handlePriorityWithNewStateReady(priority)
+	case connectivity.TransientFailure:
+		return xdsB.handlePriorityWithNewStateTransientFailure(priority)
+	case connectivity.Connecting:
+		return xdsB.handlePriorityWithNewStateConnecting(priority, oldState)
+	default:
+		// New state is Idle, should never happen. Don't forward.
+		return false
+	}
+}
+
+// handlePriorityWithNewStateReady handles state Ready and decides whether to
+// forward update or not.
+//
+// An update with state Ready:
+// - If it's from higher priority:
+//   - Forward the update
+//   - Set the priority as priorityInUse
+//   - Close all priorities lower than this one
+// - If it's from priorityInUse:
+//   - Forward and do nothing else
+//
+// Caller must make sure priorityInUse is not higher than priority.
+//
+// Caller must hold priorityMu.
+func (xdsB *EDSBalancer) handlePriorityWithNewStateReady(priority priorityType) bool {
+	// If one priority higher or equal to priorityInUse goes Ready, stop the
+	// init timer. If update is from higher than priorityInUse,
+	// priorityInUse will be closed, and the init timer will become useless.
+	if timer := xdsB.priorityInitTimer; timer != nil {
+		timer.Stop()
+		xdsB.priorityInitTimer = nil
+	}
+
+	if xdsB.priorityInUse.lowerThan(priority) {
+		xdsB.priorityInUse = priority
+		for i := priority.nextLower(); !i.lowerThan(xdsB.priorityLowest); i = i.nextLower() {
+			xdsB.priorityToLocalities[i].bg.close()
+		}
+		return true
+	}
+	return true
+}
+
+// handlePriorityWithNewStateTransientFailure handles state TransientFailure and
+// decides whether to forward update or not.
+//
+// An update with state Failure:
+// - If it's from a higher priority:
+//   - Do not forward, and do nothing
+// - If it's from priorityInUse:
+//   - If there's no lower:
+//     - Forward and do nothing else
+//   - If there's a lower priority:
+//     - Forward
+//     - Set lower as priorityInUse
+//     - Start lower
+//
+// Caller must make sure priorityInUse is not higher than priority.
+//
+// Caller must hold priorityMu.
+func (xdsB *EDSBalancer) handlePriorityWithNewStateTransientFailure(priority priorityType) bool {
+	if xdsB.priorityInUse.lowerThan(priority) {
+		return false
+	}
+	// priorityInUse sends a failure. Stop its init timer.
+	if timer := xdsB.priorityInitTimer; timer != nil {
+		timer.Stop()
+		xdsB.priorityInitTimer = nil
+	}
+	pNext := priority.nextLower()
+	if _, okNext := xdsB.priorityToLocalities[pNext]; !okNext {
+		return true
+	}
+	xdsB.startPriority(pNext)
+	return true
+}
+
+// handlePriorityWithNewStateConnecting handles state Connecting and decides
+// whether to forward update or not.
+//
+// An update with state Connecting:
+// - If it's from a higher priority
+//   - Do nothing
+// - If it's from priorityInUse, the behavior depends on previous state.
+//
+// When new state is Connecting, the behavior depends on previous state. If the
+// previous state was Ready, this is a transition out from Ready to Connecting.
+// Assuming there are multiple backends in the same priority, this mean we are
+// in a bad situation and we should failover to the next priority (Side note:
+// the current connectivity state aggregating algorhtim (e.g. round-robin) is
+// not handling this right, because if many backends all go from Ready to
+// Connecting, the overall situation is more like TransientFailure, not
+// Connecting).
+//
+// If the previous state was Idle, we don't do anything special with failure,
+// and simply forward the update. The init timer should be in process, will
+// handle failover if it timeouts. If the previous state was TransientFailure,
+// we do not forward, because the lower priority is in use.
+//
+// Caller must make sure priorityInUse is not higher than priority.
+//
+// Caller must hold priorityMu.
+func (xdsB *EDSBalancer) handlePriorityWithNewStateConnecting(priority priorityType, oldState connectivity.State) bool {
+	if xdsB.priorityInUse.lowerThan(priority) {
+		return false
+	}
+
+	switch oldState {
+	case connectivity.Ready:
+		pNext := priority.nextLower()
+		if _, okNext := xdsB.priorityToLocalities[pNext]; !okNext {
+			return true
+		}
+		xdsB.startPriority(pNext)
+		return true
+	case connectivity.Idle:
+		return true
+	case connectivity.TransientFailure:
+		return false
+	default:
+		// Old state is Connecting or Shutdown. Don't forward.
+		return false
+	}
+}
+
+// priorityType represents the priority from EDS response.
+//
+// 0 is the highest priority. The bigger the number, the lower the priority.
+type priorityType struct {
+	set bool
+	p   uint32
+}
+
+func newPriorityType(p uint32) priorityType {
+	return priorityType{
+		set: true,
+		p:   p,
+	}
+}
+
+func newPriorityTypeUnset() priorityType {
+	return priorityType{}
+}
+
+func (p priorityType) isSet() bool {
+	return p.set
+}
+
+func (p priorityType) equal(p2 priorityType) bool {
+	if !p.isSet() || !p2.isSet() {
+		panic("priority unset")
+	}
+	return p == p2
+}
+
+func (p priorityType) higherThan(p2 priorityType) bool {
+	if !p.isSet() || !p2.isSet() {
+		panic("priority unset")
+	}
+	return p.p < p2.p
+}
+
+func (p priorityType) lowerThan(p2 priorityType) bool {
+	if !p.isSet() || !p2.isSet() {
+		panic("priority unset")
+	}
+	return p.p > p2.p
+}
+
+func (p priorityType) nextLower() priorityType {
+	if !p.isSet() {
+		panic("priority unset")
+	}
+	return priorityType{
+		set: true,
+		p:   p.p + 1,
+	}
+}

--- a/xds/internal/balancer/edsbalancer/priority_test.go
+++ b/xds/internal/balancer/edsbalancer/priority_test.go
@@ -1,0 +1,681 @@
+/*
+ *
+ * Copyright 2019 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package edsbalancer
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc/balancer"
+	"google.golang.org/grpc/connectivity"
+)
+
+// When a high priority is ready, adding/removing lower locality doesn't cause
+// changes.
+//
+// Init 0 and 1; 0 is up, use 0; add 2, use 0; remove 2, use 0.
+func TestEDSPriority_HighPriorityReady(t *testing.T) {
+	cc := newTestClientConn(t)
+	edsb := NewXDSBalancer(cc, nil)
+
+	// Two localities, with priorities [0, 1], each with one backend.
+	clab1 := newClusterLoadAssignmentBuilder(testClusterNames[0], nil)
+	clab1.addLocality(testSubZones[0], 1, 0, testEndpointAddrs[:1], nil)
+	clab1.addLocality(testSubZones[1], 1, 1, testEndpointAddrs[1:2], nil)
+	edsb.HandleEDSResponse(clab1.build())
+
+	addrs1 := <-cc.newSubConnAddrsCh
+	if got, want := addrs1[0].Addr, testEndpointAddrs[0]; got != want {
+		t.Fatalf("sc is created with addr %v, want %v", got, want)
+	}
+	sc1 := <-cc.newSubConnCh
+
+	// p0 is ready.
+	edsb.HandleSubConnStateChange(sc1, connectivity.Connecting)
+	edsb.HandleSubConnStateChange(sc1, connectivity.Ready)
+
+	// Test roundrobin with only p0 subconns.
+	p1 := <-cc.newPickerCh
+	want := []balancer.SubConn{sc1}
+	if err := isRoundRobin(want, func() balancer.SubConn {
+		sc, _, _ := p1.Pick(context.Background(), balancer.PickOptions{})
+		return sc
+	}); err != nil {
+		// t.Fatalf("want %v, got %v", want, err)
+		t.Fatalf("want %v, got %v", want, err)
+	}
+
+	// Add p2, it shouldn't cause any udpates.
+	clab2 := newClusterLoadAssignmentBuilder(testClusterNames[0], nil)
+	clab2.addLocality(testSubZones[0], 1, 0, testEndpointAddrs[:1], nil)
+	clab2.addLocality(testSubZones[1], 1, 1, testEndpointAddrs[1:2], nil)
+	clab2.addLocality(testSubZones[2], 1, 2, testEndpointAddrs[2:3], nil)
+	edsb.HandleEDSResponse(clab2.build())
+
+	select {
+	case <-cc.newPickerCh:
+		t.Fatalf("got unexpected new picker")
+	case <-cc.newSubConnCh:
+		t.Fatalf("got unexpected new SubConn")
+	case <-cc.removeSubConnCh:
+		t.Fatalf("got unexpected remove SubConn")
+	case <-time.After(time.Millisecond * 100):
+	}
+
+	// Remove p2, no updates.
+	clab3 := newClusterLoadAssignmentBuilder(testClusterNames[0], nil)
+	clab3.addLocality(testSubZones[0], 1, 0, testEndpointAddrs[:1], nil)
+	clab3.addLocality(testSubZones[1], 1, 1, testEndpointAddrs[1:2], nil)
+	edsb.HandleEDSResponse(clab3.build())
+
+	select {
+	case <-cc.newPickerCh:
+		t.Fatalf("got unexpected new picker")
+	case <-cc.newSubConnCh:
+		t.Fatalf("got unexpected new SubConn")
+	case <-cc.removeSubConnCh:
+		t.Fatalf("got unexpected remove SubConn")
+	case <-time.After(time.Millisecond * 100):
+	}
+}
+
+// Lower priority is used when higher priority is not ready.
+//
+// Init 0 and 1; 0 is up, use 0; 0 is down, 1 is up, use 1; add 2, use 1; 1 is
+// down, use 2; remove 2, use 1.
+func TestEDSPriority_SwitchPriority(t *testing.T) {
+	cc := newTestClientConn(t)
+	edsb := NewXDSBalancer(cc, nil)
+
+	// Two localities, with priorities [0, 1], each with one backend.
+	clab1 := newClusterLoadAssignmentBuilder(testClusterNames[0], nil)
+	clab1.addLocality(testSubZones[0], 1, 0, testEndpointAddrs[:1], nil)
+	clab1.addLocality(testSubZones[1], 1, 1, testEndpointAddrs[1:2], nil)
+	edsb.HandleEDSResponse(clab1.build())
+
+	addrs0 := <-cc.newSubConnAddrsCh
+	if got, want := addrs0[0].Addr, testEndpointAddrs[0]; got != want {
+		t.Fatalf("sc is created with addr %v, want %v", got, want)
+	}
+	sc0 := <-cc.newSubConnCh
+
+	// p0 is ready.
+	edsb.HandleSubConnStateChange(sc0, connectivity.Connecting)
+	edsb.HandleSubConnStateChange(sc0, connectivity.Ready)
+
+	// Test roundrobin with only p0 subconns.
+	p0 := <-cc.newPickerCh
+	want := []balancer.SubConn{sc0}
+	if err := isRoundRobin(want, func() balancer.SubConn {
+		sc, _, _ := p0.Pick(context.Background(), balancer.PickOptions{})
+		return sc
+	}); err != nil {
+		// t.Fatalf("want %v, got %v", want, err)
+		t.Fatalf("want %v, got %v", want, err)
+	}
+
+	// Turn down 0, 1 is used.
+	edsb.HandleSubConnStateChange(sc0, connectivity.TransientFailure)
+	addrs1 := <-cc.newSubConnAddrsCh
+	if got, want := addrs1[0].Addr, testEndpointAddrs[1]; got != want {
+		t.Fatalf("sc is created with addr %v, want %v", got, want)
+	}
+	sc1 := <-cc.newSubConnCh
+	edsb.HandleSubConnStateChange(sc1, connectivity.Connecting)
+	edsb.HandleSubConnStateChange(sc1, connectivity.Ready)
+
+	// Test pick with 1.
+	p1 := <-cc.newPickerCh
+	for i := 0; i < 5; i++ {
+		gotSC, _, _ := p1.Pick(context.Background(), balancer.PickOptions{})
+		if !reflect.DeepEqual(gotSC, sc1) {
+			t.Fatalf("picker.Pick, got %v, want %v", gotSC, sc1)
+		}
+	}
+
+	// Add p2, it shouldn't cause any udpates.
+	clab2 := newClusterLoadAssignmentBuilder(testClusterNames[0], nil)
+	clab2.addLocality(testSubZones[0], 1, 0, testEndpointAddrs[:1], nil)
+	clab2.addLocality(testSubZones[1], 1, 1, testEndpointAddrs[1:2], nil)
+	clab2.addLocality(testSubZones[2], 1, 2, testEndpointAddrs[2:3], nil)
+	edsb.HandleEDSResponse(clab2.build())
+
+	select {
+	case <-cc.newPickerCh:
+		t.Fatalf("got unexpected new picker")
+	case <-cc.newSubConnCh:
+		t.Fatalf("got unexpected new SubConn")
+	case <-cc.removeSubConnCh:
+		t.Fatalf("got unexpected remove SubConn")
+	case <-time.After(time.Millisecond * 100):
+	}
+
+	// Turn down 1, use 2
+	edsb.HandleSubConnStateChange(sc1, connectivity.TransientFailure)
+	addrs2 := <-cc.newSubConnAddrsCh
+	if got, want := addrs2[0].Addr, testEndpointAddrs[2]; got != want {
+		t.Fatalf("sc is created with addr %v, want %v", got, want)
+	}
+	sc2 := <-cc.newSubConnCh
+	edsb.HandleSubConnStateChange(sc2, connectivity.Connecting)
+	edsb.HandleSubConnStateChange(sc2, connectivity.Ready)
+
+	// Test pick with 2.
+	p2 := <-cc.newPickerCh
+	for i := 0; i < 5; i++ {
+		gotSC, _, _ := p2.Pick(context.Background(), balancer.PickOptions{})
+		if !reflect.DeepEqual(gotSC, sc2) {
+			t.Fatalf("picker.Pick, got %v, want %v", gotSC, sc2)
+		}
+	}
+
+	// Remove 2, use 1.
+	clab3 := newClusterLoadAssignmentBuilder(testClusterNames[0], nil)
+	clab3.addLocality(testSubZones[0], 1, 0, testEndpointAddrs[:1], nil)
+	clab3.addLocality(testSubZones[1], 1, 1, testEndpointAddrs[1:2], nil)
+	edsb.HandleEDSResponse(clab3.build())
+
+	// p2 SubConns are removed.
+	scToRemove := <-cc.removeSubConnCh
+	if !reflect.DeepEqual(scToRemove, sc2) {
+		t.Fatalf("RemoveSubConn, want %v, got %v", sc2, scToRemove)
+	}
+
+	// Should get an update with 1's old picker, to override 2's old picker.
+	p3 := <-cc.newPickerCh
+	for i := 0; i < 5; i++ {
+		if _, _, err := p3.Pick(context.Background(), balancer.PickOptions{}); err != balancer.ErrTransientFailure {
+			t.Fatalf("want pick error %v, got %v", balancer.ErrTransientFailure, err)
+		}
+	}
+}
+
+// Add a lower priority while the higher priority is down.
+//
+// Init 0 and 1; 0 and 1 both down; add 2, use 2.
+func TestEDSPriority_HigherDownWhileAddingLower(t *testing.T) {
+	cc := newTestClientConn(t)
+	edsb := NewXDSBalancer(cc, nil)
+
+	// Two localities, with different priorities, each with one backend.
+	clab1 := newClusterLoadAssignmentBuilder(testClusterNames[0], nil)
+	clab1.addLocality(testSubZones[0], 1, 0, testEndpointAddrs[:1], nil)
+	clab1.addLocality(testSubZones[1], 1, 1, testEndpointAddrs[1:2], nil)
+	edsb.HandleEDSResponse(clab1.build())
+
+	addrs0 := <-cc.newSubConnAddrsCh
+	if got, want := addrs0[0].Addr, testEndpointAddrs[0]; got != want {
+		t.Fatalf("sc is created with addr %v, want %v", got, want)
+	}
+	sc0 := <-cc.newSubConnCh
+
+	// Turn down 0, 1 is used.
+	edsb.HandleSubConnStateChange(sc0, connectivity.TransientFailure)
+	addrs1 := <-cc.newSubConnAddrsCh
+	if got, want := addrs1[0].Addr, testEndpointAddrs[1]; got != want {
+		t.Fatalf("sc is created with addr %v, want %v", got, want)
+	}
+	sc1 := <-cc.newSubConnCh
+	// Turn down 1, pick should error.
+	edsb.HandleSubConnStateChange(sc1, connectivity.TransientFailure)
+
+	// Test pick failure.
+	pFail := <-cc.newPickerCh
+	for i := 0; i < 5; i++ {
+		if _, _, err := pFail.Pick(context.Background(), balancer.PickOptions{}); err != balancer.ErrTransientFailure {
+			t.Fatalf("want pick error %v, got %v", balancer.ErrTransientFailure, err)
+		}
+	}
+
+	// Add p2, it should create a new SubConn.
+	clab2 := newClusterLoadAssignmentBuilder(testClusterNames[0], nil)
+	clab2.addLocality(testSubZones[0], 1, 0, testEndpointAddrs[:1], nil)
+	clab2.addLocality(testSubZones[1], 1, 1, testEndpointAddrs[1:2], nil)
+	clab2.addLocality(testSubZones[2], 1, 2, testEndpointAddrs[2:3], nil)
+	edsb.HandleEDSResponse(clab2.build())
+
+	addrs2 := <-cc.newSubConnAddrsCh
+	if got, want := addrs2[0].Addr, testEndpointAddrs[2]; got != want {
+		t.Fatalf("sc is created with addr %v, want %v", got, want)
+	}
+	sc2 := <-cc.newSubConnCh
+	edsb.HandleSubConnStateChange(sc2, connectivity.Connecting)
+	edsb.HandleSubConnStateChange(sc2, connectivity.Ready)
+
+	// Test pick with 2.
+	p2 := <-cc.newPickerCh
+	for i := 0; i < 5; i++ {
+		gotSC, _, _ := p2.Pick(context.Background(), balancer.PickOptions{})
+		if !reflect.DeepEqual(gotSC, sc2) {
+			t.Fatalf("picker.Pick, got %v, want %v", gotSC, sc2)
+		}
+	}
+}
+
+// When a higher priority becomes available, all lower priorities are closed.
+//
+// Init 0,1,2; 0 and 1 down, use 2; 0 up, close 1 and 2.
+func TestEDSPriority_HigherReadyCloseAllLower(t *testing.T) {
+	defer time.Sleep(10 * time.Millisecond)
+
+	cc := newTestClientConn(t)
+	edsb := NewXDSBalancer(cc, nil)
+
+	// Two localities, with priorities [0,1,2], each with one backend.
+	clab1 := newClusterLoadAssignmentBuilder(testClusterNames[0], nil)
+	clab1.addLocality(testSubZones[0], 1, 0, testEndpointAddrs[:1], nil)
+	clab1.addLocality(testSubZones[1], 1, 1, testEndpointAddrs[1:2], nil)
+	clab1.addLocality(testSubZones[2], 1, 2, testEndpointAddrs[2:3], nil)
+	edsb.HandleEDSResponse(clab1.build())
+
+	addrs0 := <-cc.newSubConnAddrsCh
+	if got, want := addrs0[0].Addr, testEndpointAddrs[0]; got != want {
+		t.Fatalf("sc is created with addr %v, want %v", got, want)
+	}
+	sc0 := <-cc.newSubConnCh
+
+	// Turn down 0, 1 is used.
+	edsb.HandleSubConnStateChange(sc0, connectivity.TransientFailure)
+	addrs1 := <-cc.newSubConnAddrsCh
+	if got, want := addrs1[0].Addr, testEndpointAddrs[1]; got != want {
+		t.Fatalf("sc is created with addr %v, want %v", got, want)
+	}
+	sc1 := <-cc.newSubConnCh
+	// Turn down 1, 2 is used.
+	edsb.HandleSubConnStateChange(sc1, connectivity.TransientFailure)
+	addrs2 := <-cc.newSubConnAddrsCh
+	if got, want := addrs2[0].Addr, testEndpointAddrs[2]; got != want {
+		t.Fatalf("sc is created with addr %v, want %v", got, want)
+	}
+	sc2 := <-cc.newSubConnCh
+	edsb.HandleSubConnStateChange(sc2, connectivity.Connecting)
+	edsb.HandleSubConnStateChange(sc2, connectivity.Ready)
+
+	// Test pick with 2.
+	p2 := <-cc.newPickerCh
+	for i := 0; i < 5; i++ {
+		gotSC, _, _ := p2.Pick(context.Background(), balancer.PickOptions{})
+		if !reflect.DeepEqual(gotSC, sc2) {
+			t.Fatalf("picker.Pick, got %v, want %v", gotSC, sc2)
+		}
+	}
+
+	// When 0 becomes ready, 0 should be used, 1 and 2 should all be closed.
+	edsb.HandleSubConnStateChange(sc0, connectivity.Ready)
+
+	// sc1 and sc2 should be removed.
+	//
+	// With localities caching, the lower priorities are closed after a timeout,
+	// in goroutines. The order is no longer guaranteed.
+	scToRemove := []balancer.SubConn{<-cc.removeSubConnCh, <-cc.removeSubConnCh}
+	if !(reflect.DeepEqual(scToRemove[0], sc1) && reflect.DeepEqual(scToRemove[1], sc2)) &&
+		!(reflect.DeepEqual(scToRemove[0], sc2) && reflect.DeepEqual(scToRemove[1], sc1)) {
+		t.Errorf("RemoveSubConn, want [%v, %v], got %v", sc1, sc2, scToRemove)
+	}
+
+	// Test pick with 0.
+	p0 := <-cc.newPickerCh
+	for i := 0; i < 5; i++ {
+		gotSC, _, _ := p0.Pick(context.Background(), balancer.PickOptions{})
+		if !reflect.DeepEqual(gotSC, sc0) {
+			t.Fatalf("picker.Pick, got %v, want %v", gotSC, sc0)
+		}
+	}
+}
+
+// At init, start the next lower priority after timeout if the higher priority
+// doesn't get ready.
+//
+// Init 0,1; 0 is not ready (in connecting), after timeout, use 1.
+func TestEDSPriority_InitTimeout(t *testing.T) {
+	const testPriorityInitTimeout = time.Second
+	defer func() func() {
+		old := defaultPriorityInitTimeout
+		defaultPriorityInitTimeout = testPriorityInitTimeout
+		return func() {
+			defaultPriorityInitTimeout = old
+		}
+	}()()
+
+	cc := newTestClientConn(t)
+	edsb := NewXDSBalancer(cc, nil)
+
+	// Two localities, with different priorities, each with one backend.
+	clab1 := newClusterLoadAssignmentBuilder(testClusterNames[0], nil)
+	clab1.addLocality(testSubZones[0], 1, 0, testEndpointAddrs[:1], nil)
+	clab1.addLocality(testSubZones[1], 1, 1, testEndpointAddrs[1:2], nil)
+	edsb.HandleEDSResponse(clab1.build())
+
+	addrs0 := <-cc.newSubConnAddrsCh
+	if got, want := addrs0[0].Addr, testEndpointAddrs[0]; got != want {
+		t.Fatalf("sc is created with addr %v, want %v", got, want)
+	}
+	sc0 := <-cc.newSubConnCh
+
+	// Keep 0 in connecting, 1 will be used after init timeout.
+	edsb.HandleSubConnStateChange(sc0, connectivity.Connecting)
+
+	// Make sure new SubConn is created before timeout.
+	select {
+	case <-time.After(testPriorityInitTimeout * 3 / 4):
+	case <-cc.newSubConnAddrsCh:
+		t.Fatalf("Got a new SubConn too early (Within timeout). Expect a new SubConn only after timeout")
+	}
+
+	addrs1 := <-cc.newSubConnAddrsCh
+	if got, want := addrs1[0].Addr, testEndpointAddrs[1]; got != want {
+		t.Fatalf("sc is created with addr %v, want %v", got, want)
+	}
+	sc1 := <-cc.newSubConnCh
+
+	edsb.HandleSubConnStateChange(sc1, connectivity.Connecting)
+	edsb.HandleSubConnStateChange(sc1, connectivity.Ready)
+
+	// Test pick with 1.
+	p1 := <-cc.newPickerCh
+	for i := 0; i < 5; i++ {
+		gotSC, _, _ := p1.Pick(context.Background(), balancer.PickOptions{})
+		if !reflect.DeepEqual(gotSC, sc1) {
+			t.Fatalf("picker.Pick, got %v, want %v", gotSC, sc1)
+		}
+	}
+}
+
+// Add localities to existing priorities.
+//
+//  - start with 2 locality with p0 and p1
+//  - add localities to existing p0 and p1
+func TestEDSPriority_MultipleLocalities(t *testing.T) {
+	cc := newTestClientConn(t)
+	edsb := NewXDSBalancer(cc, nil)
+
+	// Two localities, with different priorities, each with one backend.
+	clab0 := newClusterLoadAssignmentBuilder(testClusterNames[0], nil)
+	clab0.addLocality(testSubZones[0], 1, 0, testEndpointAddrs[:1], nil)
+	clab0.addLocality(testSubZones[1], 1, 1, testEndpointAddrs[1:2], nil)
+	edsb.HandleEDSResponse(clab0.build())
+
+	addrs0 := <-cc.newSubConnAddrsCh
+	if got, want := addrs0[0].Addr, testEndpointAddrs[0]; got != want {
+		t.Fatalf("sc is created with addr %v, want %v", got, want)
+	}
+	sc0 := <-cc.newSubConnCh
+	edsb.HandleSubConnStateChange(sc0, connectivity.Connecting)
+	edsb.HandleSubConnStateChange(sc0, connectivity.Ready)
+
+	// Test roundrobin with only p0 subconns.
+	p0 := <-cc.newPickerCh
+	want := []balancer.SubConn{sc0}
+	if err := isRoundRobin(want, func() balancer.SubConn {
+		sc, _, _ := p0.Pick(context.Background(), balancer.PickOptions{})
+		return sc
+	}); err != nil {
+		// t.Fatalf("want %v, got %v", want, err)
+		t.Fatalf("want %v, got %v", want, err)
+	}
+
+	// Turn down p0 subconns, p1 subconns will be created.
+	edsb.HandleSubConnStateChange(sc0, connectivity.TransientFailure)
+
+	addrs1 := <-cc.newSubConnAddrsCh
+	if got, want := addrs1[0].Addr, testEndpointAddrs[1]; got != want {
+		t.Fatalf("sc is created with addr %v, want %v", got, want)
+	}
+	sc1 := <-cc.newSubConnCh
+	edsb.HandleSubConnStateChange(sc1, connectivity.Connecting)
+	edsb.HandleSubConnStateChange(sc1, connectivity.Ready)
+
+	// Test roundrobin with only p1 subconns.
+	p1 := <-cc.newPickerCh
+	want = []balancer.SubConn{sc1}
+	if err := isRoundRobin(want, func() balancer.SubConn {
+		sc, _, _ := p1.Pick(context.Background(), balancer.PickOptions{})
+		return sc
+	}); err != nil {
+		// t.Fatalf("want %v, got %v", want, err)
+		t.Fatalf("want %v, got %v", want, err)
+	}
+
+	// Reconnect p0 subconns, p1 subconn will be closed.
+	edsb.HandleSubConnStateChange(sc0, connectivity.Ready)
+
+	scToRemove := <-cc.removeSubConnCh
+	if !reflect.DeepEqual(scToRemove, sc1) {
+		t.Fatalf("RemoveSubConn, want %v, got %v", sc1, scToRemove)
+	}
+
+	// Test roundrobin with only p0 subconns.
+	p2 := <-cc.newPickerCh
+	want = []balancer.SubConn{sc0}
+	if err := isRoundRobin(want, func() balancer.SubConn {
+		sc, _, _ := p2.Pick(context.Background(), balancer.PickOptions{})
+		return sc
+	}); err != nil {
+		t.Fatalf("want %v, got %v", want, err)
+	}
+
+	// Add two localities, with two priorities, with one backend.
+	clab1 := newClusterLoadAssignmentBuilder(testClusterNames[0], nil)
+	clab1.addLocality(testSubZones[0], 1, 0, testEndpointAddrs[:1], nil)
+	clab1.addLocality(testSubZones[1], 1, 1, testEndpointAddrs[1:2], nil)
+	clab1.addLocality(testSubZones[2], 1, 0, testEndpointAddrs[2:3], nil)
+	clab1.addLocality(testSubZones[3], 1, 1, testEndpointAddrs[3:4], nil)
+	edsb.HandleEDSResponse(clab1.build())
+
+	addrs2 := <-cc.newSubConnAddrsCh
+	if got, want := addrs2[0].Addr, testEndpointAddrs[2]; got != want {
+		t.Fatalf("sc is created with addr %v, want %v", got, want)
+	}
+	sc2 := <-cc.newSubConnCh
+	edsb.HandleSubConnStateChange(sc2, connectivity.Connecting)
+	edsb.HandleSubConnStateChange(sc2, connectivity.Ready)
+
+	// Test roundrobin with only two p0 subconns.
+	p3 := <-cc.newPickerCh
+	want = []balancer.SubConn{sc0, sc2}
+	if err := isRoundRobin(want, func() balancer.SubConn {
+		sc, _, _ := p3.Pick(context.Background(), balancer.PickOptions{})
+		return sc
+	}); err != nil {
+		t.Fatalf("want %v, got %v", want, err)
+	}
+
+	// Turn down p0 subconns, p1 subconns will be created.
+	edsb.HandleSubConnStateChange(sc0, connectivity.TransientFailure)
+	edsb.HandleSubConnStateChange(sc2, connectivity.TransientFailure)
+
+	sc3 := <-cc.newSubConnCh
+	edsb.HandleSubConnStateChange(sc3, connectivity.Connecting)
+	edsb.HandleSubConnStateChange(sc3, connectivity.Ready)
+	sc4 := <-cc.newSubConnCh
+	edsb.HandleSubConnStateChange(sc4, connectivity.Connecting)
+	edsb.HandleSubConnStateChange(sc4, connectivity.Ready)
+
+	// Test roundrobin with only p1 subconns.
+	p4 := <-cc.newPickerCh
+	want = []balancer.SubConn{sc3, sc4}
+	if err := isRoundRobin(want, func() balancer.SubConn {
+		sc, _, _ := p4.Pick(context.Background(), balancer.PickOptions{})
+		return sc
+	}); err != nil {
+		t.Fatalf("want %v, got %v", want, err)
+	}
+}
+
+// EDS removes all localities, and re-adds them.
+func TestEDSPriority_RemovesAllLocalities(t *testing.T) {
+	const testPriorityInitTimeout = time.Second
+	defer func() func() {
+		old := defaultPriorityInitTimeout
+		defaultPriorityInitTimeout = testPriorityInitTimeout
+		return func() {
+			defaultPriorityInitTimeout = old
+		}
+	}()()
+
+	cc := newTestClientConn(t)
+	edsb := NewXDSBalancer(cc, nil)
+
+	// Two localities, with different priorities, each with one backend.
+	clab0 := newClusterLoadAssignmentBuilder(testClusterNames[0], nil)
+	clab0.addLocality(testSubZones[0], 1, 0, testEndpointAddrs[:1], nil)
+	clab0.addLocality(testSubZones[1], 1, 1, testEndpointAddrs[1:2], nil)
+	edsb.HandleEDSResponse(clab0.build())
+
+	addrs0 := <-cc.newSubConnAddrsCh
+	if got, want := addrs0[0].Addr, testEndpointAddrs[0]; got != want {
+		t.Fatalf("sc is created with addr %v, want %v", got, want)
+	}
+	sc0 := <-cc.newSubConnCh
+	edsb.HandleSubConnStateChange(sc0, connectivity.Connecting)
+	edsb.HandleSubConnStateChange(sc0, connectivity.Ready)
+
+	// Test roundrobin with only p0 subconns.
+	p0 := <-cc.newPickerCh
+	want := []balancer.SubConn{sc0}
+	if err := isRoundRobin(want, func() balancer.SubConn {
+		sc, _, _ := p0.Pick(context.Background(), balancer.PickOptions{})
+		return sc
+	}); err != nil {
+		// t.Fatalf("want %v, got %v", want, err)
+		t.Fatalf("want %v, got %v", want, err)
+	}
+
+	// Remove all priorities.
+	clab1 := newClusterLoadAssignmentBuilder(testClusterNames[0], nil)
+	edsb.HandleEDSResponse(clab1.build())
+
+	// p0 subconn should be removed.
+	scToRemove := <-cc.removeSubConnCh
+	if !reflect.DeepEqual(scToRemove, sc0) {
+		t.Fatalf("RemoveSubConn, want %v, got %v", sc0, scToRemove)
+	}
+
+	// Test pick return TransientFailure.
+	pFail := <-cc.newPickerCh
+	for i := 0; i < 5; i++ {
+		if _, _, err := pFail.Pick(context.Background(), balancer.PickOptions{}); err != balancer.ErrTransientFailure {
+			t.Fatalf("want pick error %v, got %v", balancer.ErrTransientFailure, err)
+		}
+	}
+
+	// Re-add two localities, with previous priorities, but different backends.
+	clab2 := newClusterLoadAssignmentBuilder(testClusterNames[0], nil)
+	clab2.addLocality(testSubZones[0], 1, 0, testEndpointAddrs[2:3], nil)
+	clab2.addLocality(testSubZones[1], 1, 1, testEndpointAddrs[3:4], nil)
+	edsb.HandleEDSResponse(clab2.build())
+
+	addrs01 := <-cc.newSubConnAddrsCh
+	if got, want := addrs01[0].Addr, testEndpointAddrs[2]; got != want {
+		t.Fatalf("sc is created with addr %v, want %v", got, want)
+	}
+	sc01 := <-cc.newSubConnCh
+
+	// Don't send any update to p0, so to not override the old state of p0.
+	// Later, connect to p1 and then remove p1. This will fallback to p0, and
+	// will send p0's old picker if they are not correctly removed.
+
+	// p1 will be used after priority init timeout.
+	addrs11 := <-cc.newSubConnAddrsCh
+	if got, want := addrs11[0].Addr, testEndpointAddrs[3]; got != want {
+		t.Fatalf("sc is created with addr %v, want %v", got, want)
+	}
+	sc11 := <-cc.newSubConnCh
+	edsb.HandleSubConnStateChange(sc11, connectivity.Connecting)
+	edsb.HandleSubConnStateChange(sc11, connectivity.Ready)
+
+	// Test roundrobin with only p1 subconns.
+	p1 := <-cc.newPickerCh
+	want = []balancer.SubConn{sc11}
+	if err := isRoundRobin(want, func() balancer.SubConn {
+		sc, _, _ := p1.Pick(context.Background(), balancer.PickOptions{})
+		return sc
+	}); err != nil {
+		t.Fatalf("want %v, got %v", want, err)
+	}
+
+	// Remove p1 from EDS, to fallback to p0.
+	clab3 := newClusterLoadAssignmentBuilder(testClusterNames[0], nil)
+	clab3.addLocality(testSubZones[0], 1, 0, testEndpointAddrs[2:3], nil)
+	edsb.HandleEDSResponse(clab3.build())
+
+	// p1 subconn should be removed.
+	scToRemove1 := <-cc.removeSubConnCh
+	if !reflect.DeepEqual(scToRemove1, sc11) {
+		t.Fatalf("RemoveSubConn, want %v, got %v", sc11, scToRemove1)
+	}
+
+	// Test pick return TransientFailure.
+	pFail1 := <-cc.newPickerCh
+	for i := 0; i < 5; i++ {
+		if sc, _, err := pFail1.Pick(context.Background(), balancer.PickOptions{}); err != balancer.ErrNoSubConnAvailable {
+			t.Fatalf("want pick error _, _, %v, got %v, _ ,%v", balancer.ErrTransientFailure, sc, err)
+		}
+	}
+
+	// Send an ready update for the p0 sc that was received when re-adding
+	// localities to EDS.
+	edsb.HandleSubConnStateChange(sc01, connectivity.Connecting)
+	edsb.HandleSubConnStateChange(sc01, connectivity.Ready)
+
+	// Test roundrobin with only p0 subconns.
+	p2 := <-cc.newPickerCh
+	want = []balancer.SubConn{sc01}
+	if err := isRoundRobin(want, func() balancer.SubConn {
+		sc, _, _ := p2.Pick(context.Background(), balancer.PickOptions{})
+		return sc
+	}); err != nil {
+		t.Fatalf("want %v, got %v", want, err)
+	}
+
+	select {
+	case <-cc.newPickerCh:
+		t.Fatalf("got unexpected new picker")
+	case <-cc.newSubConnCh:
+		t.Fatalf("got unexpected new SubConn")
+	case <-cc.removeSubConnCh:
+		t.Fatalf("got unexpected remove SubConn")
+	case <-time.After(time.Millisecond * 100):
+	}
+}
+
+func TestPriorityType(t *testing.T) {
+	p0 := newPriorityType(0)
+	p1 := newPriorityType(1)
+	p2 := newPriorityType(2)
+
+	if !p0.higherThan(p1) || !p0.higherThan(p2) {
+		t.Errorf("want p0 to be higher than p1 and p2, got p0>p1: %v, p0>p2: %v", !p0.higherThan(p1), !p0.higherThan(p2))
+	}
+	if !p1.lowerThan(p0) || !p1.higherThan(p2) {
+		t.Errorf("want p1 to be between p0 and p2, got p1<p0: %v, p1>p2: %v", !p1.lowerThan(p0), !p1.higherThan(p2))
+	}
+	if !p2.lowerThan(p0) || !p2.lowerThan(p1) {
+		t.Errorf("want p2 to be lower than p0 and p1, got p2<p0: %v, p2<p1: %v", !p2.lowerThan(p0), !p2.lowerThan(p1))
+	}
+
+	if got := p1.equal(p0.nextLower()); !got {
+		t.Errorf("want p1 to be equal to p0's next lower, got p1==p0.nextLower: %v", got)
+	}
+
+	if got := p1.equal(newPriorityType(1)); !got {
+		t.Errorf("want p1 to be equal to priority with value 1, got p1==1: %v", got)
+	}
+}

--- a/xds/internal/balancer/edsbalancer/test_util_test.go
+++ b/xds/internal/balancer/edsbalancer/test_util_test.go
@@ -28,7 +28,7 @@ import (
 	"google.golang.org/grpc/xds/internal"
 )
 
-const testSubConnsCount = 8
+const testSubConnsCount = 16
 
 var testSubConns []*testSubConn
 


### PR DESCRIPTION
Each priority maps to a balancer group.

When a priority is in use, its balancer group is started, and it will close the balancer groups with lower priorities. When a priority is down (no connection ready), it will start the next priority balancer group.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grpc/grpc-go/3066)
<!-- Reviewable:end -->
