### PR TITLE
xds: cache locality (sub-balancer)

### DIFF
--- a/internal/cache/timeoutCache.go
+++ b/internal/cache/timeoutCache.go
@@ -27,8 +27,8 @@ type cacheEntry struct {
 	callback func()
 	timer    *time.Timer
 	// deleted is set to true when timer.Stop() fails. This can happen when
-	// stop() races with the timer (timer fires at the same time stop() is
-	// called).
+	// Remove() races with the timer (timer fires at the same time
+	// timer.stop() is called).
 	//
 	// This variable needs to be checked before deleting the entry and calling
 	// callback, to make sure the deleting is canceled.
@@ -72,8 +72,7 @@ func (c *TimeoutCache) Add(key, item interface{}, callback func()) (interface{},
 	entry.timer = time.AfterFunc(c.timeout, func() {
 		c.mu.Lock()
 		defer c.mu.Unlock()
-		if entry != c.cache[key] {
-			// if entry.deleted {
+		if entry.deleted {
 			// Abort deleting even if timer fires. This mean there was a race
 			// between stopping timer and the timer itself.
 			return

--- a/internal/cache/timeoutCache.go
+++ b/internal/cache/timeoutCache.go
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2019 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cache
+
+import (
+	"sync"
+	"time"
+)
+
+type cacheEntry struct {
+	item          interface{}
+	callback      func()
+	timer         *time.Timer
+	abortDeleting bool
+}
+
+// TimeoutCache is a cache with items to be deleted after a timeout.
+type TimeoutCache struct {
+	mu      sync.Mutex
+	timeout time.Duration
+	cache   map[interface{}]*cacheEntry
+}
+
+// NewTimeoutCache creates a TimeoutCache with the given timeout.
+func NewTimeoutCache(timeout time.Duration) *TimeoutCache {
+	return &TimeoutCache{
+		timeout: timeout,
+		cache:   make(map[interface{}]*cacheEntry),
+	}
+}
+
+// Store an item to the cache, with the callback to be called when item is
+// removed after timeout.
+//
+// The return item is the one stored in cache. If the same key is used for a
+// second time to store an item, before the item is removed, the item won't be
+// stored, the return values will be (false, the previous item)..
+func (c *TimeoutCache) Store(key, item interface{}, callback func()) (stored bool, storedItem interface{}) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	entry, ok := c.cache[key]
+	if !ok {
+		entry = &cacheEntry{
+			item:     item,
+			callback: callback,
+		}
+		entry.timer = time.AfterFunc(c.timeout, func() {
+			c.mu.Lock()
+			defer c.mu.Unlock()
+			if entry.abortDeleting {
+				return
+			}
+			entry.callback()
+			delete(c.cache, key)
+		})
+		c.cache[key] = entry
+		return true, item
+	}
+	return false, entry.item
+}
+
+// Retrive the item with the key from the cache.
+//
+// The item will be removed from the cache, and the timer for this item will be
+// stopped. The callback to be called after timeout will never be called.
+func (c *TimeoutCache) Retrive(key interface{}) (item interface{}, ok bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	entry, ok := c.retrieveAndRemoveItemUnlocked(key)
+	if !ok {
+		return nil, false
+	}
+	return entry.item, true
+}
+
+// retrieveAndRemoveItemUnlocked removes and returns the item with key. It
+// doesn't call the callback.
+//
+// caller must hold c.mu.
+func (c *TimeoutCache) retrieveAndRemoveItemUnlocked(key interface{}) (*cacheEntry, bool) {
+	entry, ok := c.cache[key]
+	if !ok {
+		return nil, false
+	}
+	delete(c.cache, key)
+	if !entry.timer.Stop() {
+		entry.abortDeleting = true
+	}
+	return entry, true
+}
+
+// Clear removes all entries, but doesn't run the callbacks.
+func (c *TimeoutCache) Clear() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for key := range c.cache {
+		c.retrieveAndRemoveItemUnlocked(key)
+	}
+}

--- a/internal/cache/timeoutCache_test.go
+++ b/internal/cache/timeoutCache_test.go
@@ -35,8 +35,9 @@ func (c *TimeoutCache) getForTesting(key interface{}) (*cacheEntry, bool) {
 	return r, ok
 }
 
-// Test that items will be kept in cache, and be removed after timeout. Callback
-// will also be called after timeout.
+// TestCacheExpire attempts to add an entry to the cache and verifies that it
+// was added successfully. It then makes sure that on timeout, it's removed and
+// the associated callback is called.
 func TestCacheExpire(t *testing.T) {
 	const k, v = 1, "1"
 	c := NewTimeoutCache(testCacheTimeout)
@@ -59,7 +60,9 @@ func TestCacheExpire(t *testing.T) {
 	}
 }
 
-// Test that remove returns the cached item, and also cancels the timer.
+// TestCacheRemove attempts to remove an existing entry from the cache and
+// verifies that the entry is removed and the associated callback is not
+// invoked.
 func TestCacheRemove(t *testing.T) {
 	const k, v = 1, "1"
 	c := NewTimeoutCache(testCacheTimeout)
@@ -89,7 +92,8 @@ func TestCacheRemove(t *testing.T) {
 	}
 }
 
-// Test that Clear(false) cancels all the timers, and doesn't run callback.
+// TestCacheClearWithoutCallback attempts to clear all entries from the cache
+// and verifies that the associated callbacks are not invoked.
 func TestCacheClearWithoutCallback(t *testing.T) {
 	var values []string
 	const itemCount = 3
@@ -136,7 +140,8 @@ func TestCacheClearWithoutCallback(t *testing.T) {
 	}
 }
 
-// Test that Clear(true) removes the items, and runs callbacks.
+// TestCacheClearWithCallback attempts to clear all entries from the cache and
+// verifies that the associated callbacks are invoked.
 func TestCacheClearWithCallback(t *testing.T) {
 	var values []string
 	const itemCount = 3
@@ -190,8 +195,9 @@ func TestCacheClearWithCallback(t *testing.T) {
 	}
 }
 
-// Test that if the timer to an item from cache fires at the same time that
-// Remove() cancels the timer, it doesn't cause deadlock.
+// TestCacheRetrieveTimeoutRace simulates the case where an entry's timer fires
+// around the same time that Remove() is called for it. It verifies that there
+// is no deadlock.
 func TestCacheRetrieveTimeoutRace(t *testing.T) {
 	c := NewTimeoutCache(time.Nanosecond)
 

--- a/internal/cache/timeoutCache_test.go
+++ b/internal/cache/timeoutCache_test.go
@@ -1,0 +1,112 @@
+/*
+ *
+ * Copyright 2019 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cache
+
+import (
+	"strconv"
+	"testing"
+	"time"
+)
+
+const (
+	testCacheTimeout = 100 * time.Millisecond
+)
+
+func (c *TimeoutCache) getForTesting(key interface{}) (*cacheEntry, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	r, ok := c.cache[key]
+	return r, ok
+}
+
+// Test that items will be kept in cache, and be removed after timeout. Callback
+// will also be called after timeout.
+func TestCacheExpire(t *testing.T) {
+	const k, v = 1, "1"
+	c := NewTimeoutCache(testCacheTimeout)
+
+	callbackChan := make(chan struct{})
+	c.Store(k, v, func() { close(callbackChan) })
+
+	if gotV, ok := c.getForTesting(k); !ok || gotV.item != v {
+		t.Fatalf("After store(), before timeout, from cache got: %v, %v, want %v, %v", gotV.item, ok, v, true)
+	}
+
+	select {
+	case <-callbackChan:
+	case <-time.After(testCacheTimeout * 2):
+		t.Fatalf("timeout waiting for callback")
+	}
+
+	if _, ok := c.getForTesting(k); ok {
+		t.Fatalf("After store(), after timeout, from cache got: _, %v, want _, %v", ok, false)
+	}
+}
+
+// Test that retrieve returns the cached item, and also cancels the timer.
+func TestCacheRetrieve(t *testing.T) {
+	const k, v = 1, "1"
+	c := NewTimeoutCache(testCacheTimeout)
+
+	callbackChan := make(chan struct{})
+	c.Store(k, v, func() { close(callbackChan) })
+
+	if got, ok := c.getForTesting(k); !ok || got.item != v {
+		t.Fatalf("After store(), before timeout, from cache got: %v, %v, want %v, %v", got.item, ok, v, true)
+	}
+
+	time.Sleep(testCacheTimeout / 2)
+
+	gotV, gotOK := c.Retrive(k)
+	if !gotOK || gotV != v {
+		t.Fatalf("After store(), before timeout, Retrieve() got: %v, %v, want %v, %v", gotV, gotOK, v, true)
+	}
+
+	if _, ok := c.getForTesting(k); ok {
+		t.Fatalf("After store(), before timeout, after Retrieve(), from cache got: _, %v, want _, %v", ok, false)
+	}
+
+	select {
+	case <-callbackChan:
+		t.Fatalf("unexpected callback after retrieve")
+	case <-time.After(testCacheTimeout * 2):
+	}
+}
+
+// Test that if the timer to an item from cache fires at the same time that
+// Retrieve() cancels the timer, it doesn't cause deadlock.
+func TestCache_Retrieve_Timeout_New_Race(t *testing.T) {
+	c := NewTimeoutCache(time.Nanosecond)
+
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < 1000; i++ {
+			// Store starts a timer with 1 ns timeout, then Retrieve will race
+			// with the timer.
+			c.Store(i, strconv.Itoa(i), func() {})
+			c.Retrive(i)
+		}
+		close(done)
+	}()
+
+	select {
+	case <-time.After(time.Second):
+		t.Fatalf("Test didn't finish within 1 second. Deadlock")
+	case <-done:
+	}
+}

--- a/internal/cache/timeoutCache_test.go
+++ b/internal/cache/timeoutCache_test.go
@@ -44,7 +44,7 @@ func TestCacheExpire(t *testing.T) {
 	c.Add(k, v, func() { close(callbackChan) })
 
 	if gotV, ok := c.getForTesting(k); !ok || gotV.item != v {
-		t.Fatalf("After add(), before timeout, from cache got: %v, %v, want %v, %v", gotV.item, ok, v, true)
+		t.Fatalf("After Add(), before timeout, from cache got: %v, %v, want %v, %v", gotV.item, ok, v, true)
 	}
 
 	select {
@@ -54,7 +54,7 @@ func TestCacheExpire(t *testing.T) {
 	}
 
 	if _, ok := c.getForTesting(k); ok {
-		t.Fatalf("After add(), after timeout, from cache got: _, %v, want _, %v", ok, false)
+		t.Fatalf("After Add(), after timeout, from cache got: _, %v, want _, %v", ok, false)
 	}
 }
 
@@ -67,18 +67,18 @@ func TestCacheRemove(t *testing.T) {
 	c.Add(k, v, func() { close(callbackChan) })
 
 	if got, ok := c.getForTesting(k); !ok || got.item != v {
-		t.Fatalf("After add(), before timeout, from cache got: %v, %v, want %v, %v", got.item, ok, v, true)
+		t.Fatalf("After Add(), before timeout, from cache got: %v, %v, want %v, %v", got.item, ok, v, true)
 	}
 
 	time.Sleep(testCacheTimeout / 2)
 
 	gotV, gotOK := c.Remove(k)
 	if !gotOK || gotV != v {
-		t.Fatalf("After add(), before timeout, remove() got: %v, %v, want %v, %v", gotV, gotOK, v, true)
+		t.Fatalf("After Add(), before timeout, Remove() got: %v, %v, want %v, %v", gotV, gotOK, v, true)
 	}
 
 	if _, ok := c.getForTesting(k); ok {
-		t.Fatalf("After add(), before timeout, after remove(), from cache got: _, %v, want _, %v", ok, false)
+		t.Fatalf("After Add(), before timeout, after Remove(), from cache got: _, %v, want _, %v", ok, false)
 	}
 
 	select {
@@ -115,7 +115,7 @@ func TestCacheClear(t *testing.T) {
 
 	for i, v := range values {
 		if got, ok := c.getForTesting(i); !ok || got.item != v {
-			t.Fatalf("After add(), before timeout, from cache got: %v, %v, want %v, %v", got.item, ok, v, true)
+			t.Fatalf("After Add(), before timeout, from cache got: %v, %v, want %v, %v", got.item, ok, v, true)
 		}
 	}
 
@@ -124,7 +124,7 @@ func TestCacheClear(t *testing.T) {
 
 	for i := range values {
 		if _, ok := c.getForTesting(i); ok {
-			t.Fatalf("After add(), before timeout, after remove(), from cache got: _, %v, want _, %v", ok, false)
+			t.Fatalf("After Add(), before timeout, after Remove(), from cache got: _, %v, want _, %v", ok, false)
 		}
 	}
 
@@ -136,7 +136,7 @@ func TestCacheClear(t *testing.T) {
 }
 
 // Test that if the timer to an item from cache fires at the same time that
-// remove() cancels the timer, it doesn't cause deadlock.
+// Remove() cancels the timer, it doesn't cause deadlock.
 func TestCacheRetrieveTimeoutRace(t *testing.T) {
 	c := NewTimeoutCache(time.Nanosecond)
 

--- a/xds/internal/balancer/edsbalancer/balancergroup.go
+++ b/xds/internal/balancer/edsbalancer/balancergroup.go
@@ -530,7 +530,7 @@ func (bg *balancerGroup) close() {
 			config.stopBalancer()
 		}
 	}
-	bg.balancerCache.Clear()
+	bg.balancerCache.Clear(true)
 	bg.outgoingMu.Unlock()
 }
 

--- a/xds/internal/balancer/edsbalancer/balancergroup_test.go
+++ b/xds/internal/balancer/edsbalancer/balancergroup_test.go
@@ -18,8 +18,10 @@ package edsbalancer
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"testing"
+	"time"
 
 	"google.golang.org/grpc/balancer"
 	"google.golang.org/grpc/balancer/roundrobin"
@@ -32,8 +34,20 @@ import (
 var (
 	rrBuilder        = balancer.Get(roundrobin.Name)
 	testBalancerIDs  = []internal.Locality{{Region: "b1"}, {Region: "b2"}, {Region: "b3"}}
-	testBackendAddrs = []resolver.Address{{Addr: "1.1.1.1:1"}, {Addr: "2.2.2.2:2"}, {Addr: "3.3.3.3:3"}, {Addr: "4.4.4.4:4"}}
+	testBackendAddrs []resolver.Address
 )
+
+const testBackendAddrsCount = 8
+
+func init() {
+	for i := 0; i < testBackendAddrsCount; i++ {
+		testBackendAddrs = append(testBackendAddrs, resolver.Address{Addr: fmt.Sprintf("%d.%d.%d.%d:%d", i, i, i, i, i)})
+	}
+
+	// Disable caching for all tests. It will be re-enabled in caching specific
+	// tests.
+	defaultSubBalancerCloseTimeout = time.Millisecond
+}
 
 // 1 balancer, 1 backend -> 2 backends -> 1 backend.
 func TestBalancerGroup_OneRR_AddRemoveBackend(t *testing.T) {
@@ -567,4 +581,417 @@ func TestBalancerGroup_start_close_deadlock(t *testing.T) {
 	bg.handleResolvedAddrs(testBalancerIDs[1], testBackendAddrs[2:4])
 
 	bg.start()
+}
+
+func replaceDefaultSubBalancerCloseTimeout(n time.Duration) func() {
+	old := defaultSubBalancerCloseTimeout
+	defaultSubBalancerCloseTimeout = n
+	return func() { defaultSubBalancerCloseTimeout = old }
+}
+
+// Test that if a sub-balancer is removed, and re-added within close timeout,
+// the subConns won't be re-created.
+func TestBalancerGroup_locality_caching(t *testing.T) {
+	defer replaceDefaultSubBalancerCloseTimeout(10 * time.Second)()
+	cc := newTestClientConn(t)
+	bg := newBalancerGroup(cc, nil)
+
+	// Add two balancers to group and send two resolved addresses to both
+	// balancers.
+	bg.add(testBalancerIDs[0], 2, rrBuilder)
+	bg.handleResolvedAddrs(testBalancerIDs[0], testBackendAddrs[0:2])
+	bg.add(testBalancerIDs[1], 1, rrBuilder)
+	bg.handleResolvedAddrs(testBalancerIDs[1], testBackendAddrs[2:4])
+
+	bg.start()
+
+	m1 := make(map[resolver.Address]balancer.SubConn)
+	for i := 0; i < 4; i++ {
+		addrs := <-cc.newSubConnAddrsCh
+		sc := <-cc.newSubConnCh
+		m1[addrs[0]] = sc
+		bg.handleSubConnStateChange(sc, connectivity.Connecting)
+		bg.handleSubConnStateChange(sc, connectivity.Ready)
+	}
+
+	// Test roundrobin on the last picker.
+	p1 := <-cc.newPickerCh
+	want := []balancer.SubConn{
+		m1[testBackendAddrs[0]], m1[testBackendAddrs[0]],
+		m1[testBackendAddrs[1]], m1[testBackendAddrs[1]],
+		m1[testBackendAddrs[2]], m1[testBackendAddrs[3]],
+	}
+	if err := isRoundRobin(want, func() balancer.SubConn {
+		sc, _, _ := p1.Pick(context.Background(), balancer.PickOptions{})
+		return sc
+	}); err != nil {
+		t.Fatalf("want %v, got %v", want, err)
+	}
+
+	bg.remove(testBalancerIDs[1])
+	// Don't wait for SubConns to be removed after close, because they are only
+	// removed after close timeout.
+	for i := 0; i < 10; i++ {
+		select {
+		case <-cc.removeSubConnCh:
+			t.Fatalf("Got request to remove subconn, want no remove subconn (because subconns were still in cache)")
+		default:
+		}
+		time.Sleep(time.Millisecond)
+	}
+	// Test roundrobin on the with only sub-balancer0.
+	p2 := <-cc.newPickerCh
+	want = []balancer.SubConn{
+		m1[testBackendAddrs[0]], m1[testBackendAddrs[1]],
+	}
+	if err := isRoundRobin(want, func() balancer.SubConn {
+		sc, _, _ := p2.Pick(context.Background(), balancer.PickOptions{})
+		return sc
+	}); err != nil {
+		t.Fatalf("want %v, got %v", want, err)
+	}
+
+	// Turn down subconn for addr2, shouldn't get picker update because
+	// sub-balancer1 was removed.
+	bg.handleSubConnStateChange(m1[testBackendAddrs[2]], connectivity.TransientFailure)
+	for i := 0; i < 10; i++ {
+		select {
+		case <-cc.newPickerCh:
+			t.Fatalf("Got new picker, want no new picker (because the sub-balancer was removed)")
+		default:
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	// Sleep, but sleep less then close timeout.
+	time.Sleep(time.Millisecond * 100)
+
+	// Re-add sub-balancer-1, because subconns were in cache, no new subconns
+	// should be created. But a new picker will still be generated, with subconn
+	// states update to date.
+	bg.add(testBalancerIDs[1], 1, rrBuilder)
+
+	p3 := <-cc.newPickerCh
+	want = []balancer.SubConn{
+		m1[testBackendAddrs[0]], m1[testBackendAddrs[0]],
+		m1[testBackendAddrs[1]], m1[testBackendAddrs[1]],
+		// addr2 is down, b2 only has addr3 in READY state.
+		m1[testBackendAddrs[3]], m1[testBackendAddrs[3]],
+	}
+	if err := isRoundRobin(want, func() balancer.SubConn {
+		sc, _, _ := p3.Pick(context.Background(), balancer.PickOptions{})
+		return sc
+	}); err != nil {
+		t.Fatalf("want %v, got %v", want, err)
+	}
+
+	for i := 0; i < 10; i++ {
+		select {
+		case <-cc.newSubConnAddrsCh:
+			t.Fatalf("Got new subconn, want no new subconn (because subconns were still in cache)")
+		default:
+		}
+		time.Sleep(time.Millisecond * 10)
+	}
+}
+
+// Sub-balancers are put in cache when they are removed. If balancer group is
+// closed within close timeout, all subconns should still be rmeoved
+// immediately.
+func TestBalancerGroup_locality_caching_close_group(t *testing.T) {
+	defer replaceDefaultSubBalancerCloseTimeout(10 * time.Second)()
+	cc := newTestClientConn(t)
+	bg := newBalancerGroup(cc, nil)
+
+	// Add two balancers to group and send two resolved addresses to both
+	// balancers.
+	bg.add(testBalancerIDs[0], 2, rrBuilder)
+	bg.handleResolvedAddrs(testBalancerIDs[0], testBackendAddrs[0:2])
+	bg.add(testBalancerIDs[1], 1, rrBuilder)
+	bg.handleResolvedAddrs(testBalancerIDs[1], testBackendAddrs[2:4])
+
+	bg.start()
+
+	m1 := make(map[resolver.Address]balancer.SubConn)
+	for i := 0; i < 4; i++ {
+		addrs := <-cc.newSubConnAddrsCh
+		sc := <-cc.newSubConnCh
+		m1[addrs[0]] = sc
+		bg.handleSubConnStateChange(sc, connectivity.Connecting)
+		bg.handleSubConnStateChange(sc, connectivity.Ready)
+	}
+
+	// Test roundrobin on the last picker.
+	p1 := <-cc.newPickerCh
+	want := []balancer.SubConn{
+		m1[testBackendAddrs[0]], m1[testBackendAddrs[0]],
+		m1[testBackendAddrs[1]], m1[testBackendAddrs[1]],
+		m1[testBackendAddrs[2]], m1[testBackendAddrs[3]],
+	}
+	if err := isRoundRobin(want, func() balancer.SubConn {
+		sc, _, _ := p1.Pick(context.Background(), balancer.PickOptions{})
+		return sc
+	}); err != nil {
+		t.Fatalf("want %v, got %v", want, err)
+	}
+
+	bg.remove(testBalancerIDs[1])
+	// Don't wait for SubConns to be removed after close, because they are only
+	// removed after close timeout.
+	for i := 0; i < 10; i++ {
+		select {
+		case <-cc.removeSubConnCh:
+			t.Fatalf("Got request to remove subconn, want no remove subconn (because subconns were still in cache)")
+		default:
+		}
+		time.Sleep(time.Millisecond)
+	}
+	// Test roundrobin on the with only sub-balancer0.
+	p2 := <-cc.newPickerCh
+	want = []balancer.SubConn{
+		m1[testBackendAddrs[0]], m1[testBackendAddrs[1]],
+	}
+	if err := isRoundRobin(want, func() balancer.SubConn {
+		sc, _, _ := p2.Pick(context.Background(), balancer.PickOptions{})
+		return sc
+	}); err != nil {
+		t.Fatalf("want %v, got %v", want, err)
+	}
+
+	bg.close()
+	// The balancer group is closed. The subconns should be removed immediately.
+	removeTimeout := time.After(time.Millisecond * 500)
+	scToRemove := map[balancer.SubConn]int{
+		m1[testBackendAddrs[0]]: 1,
+		m1[testBackendAddrs[1]]: 1,
+		m1[testBackendAddrs[2]]: 1,
+		m1[testBackendAddrs[3]]: 1,
+	}
+	for i := 0; i < len(scToRemove); i++ {
+		select {
+		case sc := <-cc.removeSubConnCh:
+			c := scToRemove[sc]
+			if c == 0 {
+				t.Fatalf("Got removeSubConn for %v when there's %d remove expected", sc, c)
+			}
+			scToRemove[sc] = c - 1
+		case <-removeTimeout:
+			t.Fatalf("timeout waiting for subConns (from balancer in cache) to be removed")
+		}
+	}
+}
+
+// Sub-balancers in cache will be closed if not re-added within timeout, and
+// subConns will be removed.
+func TestBalancerGroup_locality_caching_not_readd_within_timeout(t *testing.T) {
+	defer replaceDefaultSubBalancerCloseTimeout(time.Second)()
+	cc := newTestClientConn(t)
+	bg := newBalancerGroup(cc, nil)
+
+	// Add two balancers to group and send two resolved addresses to both
+	// balancers.
+	bg.add(testBalancerIDs[0], 2, rrBuilder)
+	bg.handleResolvedAddrs(testBalancerIDs[0], testBackendAddrs[0:2])
+	bg.add(testBalancerIDs[1], 1, rrBuilder)
+	bg.handleResolvedAddrs(testBalancerIDs[1], testBackendAddrs[2:4])
+
+	bg.start()
+
+	m1 := make(map[resolver.Address]balancer.SubConn)
+	for i := 0; i < 4; i++ {
+		addrs := <-cc.newSubConnAddrsCh
+		sc := <-cc.newSubConnCh
+		m1[addrs[0]] = sc
+		bg.handleSubConnStateChange(sc, connectivity.Connecting)
+		bg.handleSubConnStateChange(sc, connectivity.Ready)
+	}
+
+	// Test roundrobin on the last picker.
+	p1 := <-cc.newPickerCh
+	want := []balancer.SubConn{
+		m1[testBackendAddrs[0]], m1[testBackendAddrs[0]],
+		m1[testBackendAddrs[1]], m1[testBackendAddrs[1]],
+		m1[testBackendAddrs[2]], m1[testBackendAddrs[3]],
+	}
+	if err := isRoundRobin(want, func() balancer.SubConn {
+		sc, _, _ := p1.Pick(context.Background(), balancer.PickOptions{})
+		return sc
+	}); err != nil {
+		t.Fatalf("want %v, got %v", want, err)
+	}
+
+	bg.remove(testBalancerIDs[1])
+	// Don't wait for SubConns to be removed after close, because they are only
+	// removed after close timeout.
+	for i := 0; i < 10; i++ {
+		select {
+		case <-cc.removeSubConnCh:
+			t.Fatalf("Got request to remove subconn, want no remove subconn (because subconns were still in cache)")
+		default:
+		}
+		time.Sleep(time.Millisecond)
+	}
+	// Test roundrobin on the with only sub-balancer0.
+	p2 := <-cc.newPickerCh
+	want = []balancer.SubConn{
+		m1[testBackendAddrs[0]], m1[testBackendAddrs[1]],
+	}
+	if err := isRoundRobin(want, func() balancer.SubConn {
+		sc, _, _ := p2.Pick(context.Background(), balancer.PickOptions{})
+		return sc
+	}); err != nil {
+		t.Fatalf("want %v, got %v", want, err)
+	}
+
+	// The sub-balancer is not re-added withtin timeout. The subconns should be
+	// removed.
+	removeTimeout := time.After(defaultSubBalancerCloseTimeout)
+	scToRemove := map[balancer.SubConn]int{
+		m1[testBackendAddrs[2]]: 1,
+		m1[testBackendAddrs[3]]: 1,
+	}
+	for i := 0; i < len(scToRemove); i++ {
+		select {
+		case sc := <-cc.removeSubConnCh:
+			c := scToRemove[sc]
+			if c == 0 {
+				t.Fatalf("Got removeSubConn for %v when there's %d remove expected", sc, c)
+			}
+			scToRemove[sc] = c - 1
+		case <-removeTimeout:
+			t.Fatalf("timeout waiting for subConns (from balancer in cache) to be removed")
+		}
+	}
+}
+
+// Wrap the rr builder, so it behaves the same, but has a different pointer.
+type noopBalancerBuilderWrapper struct {
+	balancer.Builder
+}
+
+// After removing a sub-balancer, re-add with same ID, but different balancer
+// builder. Old subconns should be removed, and new subconns should be created.
+func TestBalancerGroup_locality_caching_readd_with_different_builder(t *testing.T) {
+	defer replaceDefaultSubBalancerCloseTimeout(10 * time.Second)()
+	cc := newTestClientConn(t)
+	bg := newBalancerGroup(cc, nil)
+
+	// Add two balancers to group and send two resolved addresses to both
+	// balancers.
+	bg.add(testBalancerIDs[0], 2, rrBuilder)
+	bg.handleResolvedAddrs(testBalancerIDs[0], testBackendAddrs[0:2])
+	bg.add(testBalancerIDs[1], 1, rrBuilder)
+	bg.handleResolvedAddrs(testBalancerIDs[1], testBackendAddrs[2:4])
+
+	bg.start()
+
+	m1 := make(map[resolver.Address]balancer.SubConn)
+	for i := 0; i < 4; i++ {
+		addrs := <-cc.newSubConnAddrsCh
+		sc := <-cc.newSubConnCh
+		m1[addrs[0]] = sc
+		bg.handleSubConnStateChange(sc, connectivity.Connecting)
+		bg.handleSubConnStateChange(sc, connectivity.Ready)
+	}
+
+	// Test roundrobin on the last picker.
+	p1 := <-cc.newPickerCh
+	want := []balancer.SubConn{
+		m1[testBackendAddrs[0]], m1[testBackendAddrs[0]],
+		m1[testBackendAddrs[1]], m1[testBackendAddrs[1]],
+		m1[testBackendAddrs[2]], m1[testBackendAddrs[3]],
+	}
+	if err := isRoundRobin(want, func() balancer.SubConn {
+		sc, _, _ := p1.Pick(context.Background(), balancer.PickOptions{})
+		return sc
+	}); err != nil {
+		t.Fatalf("want %v, got %v", want, err)
+	}
+
+	bg.remove(testBalancerIDs[1])
+	// Don't wait for SubConns to be removed after close, because they are only
+	// removed after close timeout.
+	for i := 0; i < 10; i++ {
+		select {
+		case <-cc.removeSubConnCh:
+			t.Fatalf("Got request to remove subconn, want no remove subconn (because subconns were still in cache)")
+		default:
+		}
+		time.Sleep(time.Millisecond)
+	}
+	// Test roundrobin on the with only sub-balancer0.
+	p2 := <-cc.newPickerCh
+	want = []balancer.SubConn{
+		m1[testBackendAddrs[0]], m1[testBackendAddrs[1]],
+	}
+	if err := isRoundRobin(want, func() balancer.SubConn {
+		sc, _, _ := p2.Pick(context.Background(), balancer.PickOptions{})
+		return sc
+	}); err != nil {
+		t.Fatalf("want %v, got %v", want, err)
+	}
+
+	// Re-add sub-balancer-1, but with a different balancer builder. The
+	// sub-balancer was still in cache, but cann't be reused. This should cause
+	// old sub-balancer's subconns to be removed immediately, and new subconns
+	// to be created.
+	bg.add(testBalancerIDs[1], 1, &noopBalancerBuilderWrapper{rrBuilder})
+
+	// The cached sub-balancer should be closed, and the subconns should be
+	// removed immediately.
+	removeTimeout := time.After(time.Millisecond * 500)
+	scToRemove := map[balancer.SubConn]int{
+		m1[testBackendAddrs[2]]: 1,
+		m1[testBackendAddrs[3]]: 1,
+	}
+	for i := 0; i < len(scToRemove); i++ {
+		select {
+		case sc := <-cc.removeSubConnCh:
+			c := scToRemove[sc]
+			if c == 0 {
+				t.Fatalf("Got removeSubConn for %v when there's %d remove expected", sc, c)
+			}
+			scToRemove[sc] = c - 1
+		case <-removeTimeout:
+			t.Fatalf("timeout waiting for subConns (from balancer in cache) to be removed")
+		}
+	}
+
+	bg.handleResolvedAddrs(testBalancerIDs[1], testBackendAddrs[4:6])
+
+	newSCTimeout := time.After(time.Millisecond * 500)
+	scToAdd := map[resolver.Address]int{
+		testBackendAddrs[4]: 1,
+		testBackendAddrs[5]: 1,
+	}
+	for i := 0; i < len(scToAdd); i++ {
+		select {
+		case addr := <-cc.newSubConnAddrsCh:
+			c := scToAdd[addr[0]]
+			if c == 0 {
+				t.Fatalf("Got newSubConn for %v when there's %d new expected", addr, c)
+			}
+			scToAdd[addr[0]] = c - 1
+			sc := <-cc.newSubConnCh
+			m1[addr[0]] = sc
+			bg.handleSubConnStateChange(sc, connectivity.Connecting)
+			bg.handleSubConnStateChange(sc, connectivity.Ready)
+		case <-newSCTimeout:
+			t.Fatalf("timeout waiting for subConns (from new sub-balancer) to be newed")
+		}
+	}
+
+	// Test roundrobin on the new picker.
+	p3 := <-cc.newPickerCh
+	want = []balancer.SubConn{
+		m1[testBackendAddrs[0]], m1[testBackendAddrs[0]],
+		m1[testBackendAddrs[1]], m1[testBackendAddrs[1]],
+		m1[testBackendAddrs[4]], m1[testBackendAddrs[5]],
+	}
+	if err := isRoundRobin(want, func() balancer.SubConn {
+		sc, _, _ := p3.Pick(context.Background(), balancer.PickOptions{})
+		return sc
+	}); err != nil {
+		t.Fatalf("want %v, got %v", want, err)
+	}
 }

--- a/xds/internal/balancer/edsbalancer/edsbalancer_test.go
+++ b/xds/internal/balancer/edsbalancer/edsbalancer_test.go
@@ -341,6 +341,17 @@ func TestEDS_TwoLocalities(t *testing.T) {
 	clab6.addLocality(testSubZones[2], 1, testEndpointAddrs[2:4])
 	edsb.HandleEDSResponse(clab6.build())
 
+	// Changing weight of locality[1] to 0 caused it to be removed. It's subconn
+	// should also be removed.
+	//
+	// NOTE: this is because we handle locality with weight 0 same as the
+	// locality doesn't exist. If this changes in the future, this removeSubConn
+	// behavior will also change.
+	scToRemove2 := <-cc.removeSubConnCh
+	if !reflect.DeepEqual(scToRemove2, sc2) {
+		t.Fatalf("RemoveSubConn, want %v, got %v", sc2, scToRemove2)
+	}
+
 	// Test pick with two subconns different locality weight.
 	p6 := <-cc.newPickerCh
 	// Locality-1 will be not be picked, and locality-2 will be picked.


### PR DESCRIPTION
When a locality is removed from EDS response, it's corresponding
sub-balancer will be removed from balancer group.

With this change, the sub-balancer won't be removed immediately. It will
be kept in a cache (for 15 minutes by default). If the locality is
re-added within the timeout, the sub-balancer in cache will be picked
and re-used.