### PR TITLE
clientconn: override authority with address's ServerName, if set

### DIFF
--- a/clientconn.go
+++ b/clientconn.go
@@ -1135,10 +1135,16 @@ func (ac *addrConn) createTransport(addr resolver.Address, copts transport.Conne
 	onCloseCalled := make(chan struct{})
 	reconnect := grpcsync.NewEvent()
 
+	authority := ac.cc.authority
+	// addr.ServerName takes precedent over ClientConn authority, if present.
+	if addr.ServerName != "" {
+		authority = addr.ServerName
+	}
+
 	target := transport.TargetInfo{
 		Addr:      addr.Addr,
 		Metadata:  addr.Metadata,
-		Authority: ac.cc.authority,
+		Authority: authority,
 	}
 
 	once := sync.Once{}

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -86,9 +86,16 @@ type Address struct {
 	// Type is the type of this address.
 	Type AddressType
 	// ServerName is the name of this address.
+	// If non-empty, the ServerName is used as the transport certification authority for
+	// the address, instead of the hostname from the Dial target string. In most cases,
+	// this should not be set.
 	//
-	// e.g. if Type is GRPCLB, ServerName should be the name of the remote load
+	// If Type is GRPCLB, ServerName should be the name of the remote load
 	// balancer, not the name of the backend.
+	//
+	// WARNING: ServerName must only be populated with trusted values. It
+	// is insecure to populate it with data from untrusted inputs since untrusted
+	// values could be used to bypass the authority checks performed by TLS.
 	ServerName string
 	// Metadata is the information associated with Addr, which may be used
 	// to make load balancing decision.


### PR DESCRIPTION
Fixes #3038

By default it is not set and the dialed target is used as the authority for all load balanced endpoints. This enables load balanced clients to use per-endpoint authorities when the address's ServerName is set.