### PR TITLE
test: embed Unimplemented___Server in every service

### DIFF
--- a/balancer/grpclb/grpclb_test.go
+++ b/balancer/grpclb/grpclb_test.go
@@ -249,7 +249,7 @@ func (b *remoteBalancer) BalanceLoad(stream lbgrpc.LoadBalancer_BalanceLoadServe
 }
 
 type testServer struct {
-	testpb.TestServiceServer
+	testpb.UnimplementedTestServiceServer
 
 	addr     string
 	fallback bool

--- a/balancer/roundrobin/roundrobin_test.go
+++ b/balancer/roundrobin/roundrobin_test.go
@@ -39,7 +39,7 @@ import (
 )
 
 type testServer struct {
-	testpb.TestServiceServer
+	testpb.UnimplementedTestServiceServer
 }
 
 func (s *testServer) EmptyCall(ctx context.Context, in *testpb.Empty) (*testpb.Empty, error) {

--- a/internal/binarylog/binarylog_end2end_test.go
+++ b/internal/binarylog/binarylog_end2end_test.go
@@ -104,6 +104,7 @@ var (
 )
 
 type testServer struct {
+	testpb.UnimplementedTestServiceServer
 	te *test
 }
 

--- a/reflection/serverreflection_test.go
+++ b/reflection/serverreflection_test.go
@@ -162,7 +162,9 @@ func TestAllExtensionNumbersForType(t *testing.T) {
 
 // Do end2end tests.
 
-type server struct{}
+type server struct {
+	pb.UnimplementedSearchServiceServer
+}
 
 func (s *server) Search(ctx context.Context, in *pb.SearchRequest) (*pb.SearchResponse, error) {
 	return &pb.SearchResponse{}, nil

--- a/stats/stats_test.go
+++ b/stats/stats_test.go
@@ -58,7 +58,9 @@ var (
 	errorID int32 = 32202
 )
 
-type testServer struct{}
+type testServer struct {
+	testpb.UnimplementedTestServiceServer
+}
 
 func (s *testServer) UnaryCall(ctx context.Context, in *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
 	md, ok := metadata.FromIncomingContext(ctx)

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -149,6 +149,8 @@ var (
 var raceMode bool // set by race.go in race mode
 
 type testServer struct {
+	testpb.UnimplementedTestServiceServer
+
 	security           string // indicate the authentication protocol used by this server.
 	earlyFail          bool   // whether to error out the execution of a service handler prematurely.
 	setAndSendHeader   bool   // whether to call setHeader and sendHeader.

--- a/test/healthcheck_test.go
+++ b/test/healthcheck_test.go
@@ -82,6 +82,7 @@ func defaultWatchFunc(s *testHealthServer, in *healthpb.HealthCheckRequest, stre
 }
 
 type testHealthServer struct {
+	healthpb.UnimplementedHealthServer
 	watchFunc func(s *testHealthServer, in *healthpb.HealthCheckRequest, stream healthgrpc.Health_WatchServer) error
 	mu        sync.Mutex
 	status    map[string]healthpb.HealthCheckResponse_ServingStatus


### PR DESCRIPTION
This omits xds for now, since those protos were not generated with the latest protoc-gen-go version in the repo.

#3069