### PR TITLE
examples: add UnimplementedGreeterServer in debugging example

### DIFF
--- a/examples/features/debugging/server/main.go
+++ b/examples/features/debugging/server/main.go
@@ -47,7 +47,9 @@ func (s *server) SayHello(ctx context.Context, in *pb.HelloRequest) (*pb.HelloRe
 }
 
 // slow server is used to simulate a server that has a variable delay in its response.
-type slowServer struct{}
+type slowServer struct {
+	pb.UnimplementedGreeterServer
+}
 
 // SayHello implements helloworld.GreeterServer
 func (s *slowServer) SayHello(ctx context.Context, in *pb.HelloRequest) (*pb.HelloReply, error) {


### PR DESCRIPTION
This pr add missing UnimplementedGreeterServer in order to address this issue: https://github.com/grpc/grpc-go/issues/3069