### PR TITLE
proxy_test: Fix a goroutine-leak bug in testHTTPConnect

### DIFF
--- a/proxy_test.go
+++ b/proxy_test.go
@@ -119,16 +119,16 @@ func testHTTPConnect(t *testing.T, proxyURLModify func(*url.URL) *url.URL, proxy
 
 	msg := []byte{4, 3, 5, 2}
 	recvBuf := make([]byte, len(msg))
-	done := make(chan struct{})
+	done := make(chan error)
 	go func() {
 		in, err := blis.Accept()
 		if err != nil {
-			t.Errorf("failed to accept: %v", err)
+			done <- err
 			return
 		}
 		defer in.Close()
 		in.Read(recvBuf)
-		close(done)
+		done <- nil
 	}()
 
 	// Overwrite the function in the test and restore them in defer.
@@ -154,7 +154,9 @@ func testHTTPConnect(t *testing.T, proxyURLModify func(*url.URL) *url.URL, proxy
 
 	// Send msg on the connection.
 	c.Write(msg)
-	<-done
+	if err := <-done; err != nil {
+		t.Fatalf("failed to accept: %v", err)
+	}
 
 	// Check received msg.
 	if string(recvBuf) != string(msg) {


### PR DESCRIPTION
**_Description_**
In google.golang.org/grpc/proxy_test.go, func testHTTPConnect, line 122, a local unbuffered channel `done` is created. `done` is only used two places: receive in main goroutine and close in a new goroutine. However, because `err != nil` may cause the new goroutine to return, the close instruction may never be reached,  making the receive in main goroutine be blocked forever.

**_How I fix this bug_**
I put `defer close(done)` at the beginning of the new goroutine, so `close(done)` will always be executed, no matter what branch is taken next. 