### PR TITLE
xds: add client interface

### DIFF
--- a/xds/internal/client/client.go
+++ b/xds/internal/client/client.go
@@ -1,0 +1,47 @@
+/*
+ *
+ * Copyright 2019 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// Package client contains the implementation of the xds client used by xds.
+package client
+
+import "context"
+
+// ServiceUpdate contains update about the service.
+type ServiceUpdate struct{}
+
+// ClusterUpdate contains update about the cluster.
+type ClusterUpdate struct{}
+
+// EndpointUpdate contains update about the endpoint.
+type EndpointUpdate struct{}
+
+// Client is the xds client resolver and balancer use to watch xds updates.
+//
+// All the watch methods don't block.
+type Client interface {
+	// WatchService watches LRS/RDS/VHDS.
+	WatchService(ctx context.Context, name string, callback func(*ServiceUpdate, error))
+
+	// WatchCluster watches CDS.
+	WatchCluster(ctx context.Context, name string, callback func(*ClusterUpdate, error))
+
+	// WatchEndpoint watches EDS.
+	WatchEndpoint(ctx context.Context, name string, callback func(*EndpointUpdate, error))
+
+	// TODO: add LRS
+}

--- a/xds/internal/client/client.go
+++ b/xds/internal/client/client.go
@@ -19,8 +19,6 @@
 // Package client contains the implementation of the xds client used by xds.
 package client
 
-import "context"
-
 // ServiceUpdate contains update about the service.
 type ServiceUpdate struct{}
 
@@ -37,15 +35,18 @@ type Client struct {
 }
 
 // WatchService watches LRS/RDS/VHDS.
-func (*Client) WatchService(ctx context.Context, target string, callback func(*ServiceUpdate, error)) {
+func (*Client) WatchService(target string, callback func(*ServiceUpdate, error)) (cancel func()) {
+	return nil
 }
 
 // WatchClusters watches CDS.
-func (*Client) WatchClusters(ctx context.Context, serviceName string, callback func(*ClusterUpdate, error)) {
+func (*Client) WatchClusters(serviceName string, callback func(*ClusterUpdate, error)) (cancel func()) {
+	return nil
 }
 
 // WatchEndpoints watches EDS.
-func (*Client) WatchEndpoints(ctx context.Context, clusterName string, callback func(*EndpointUpdate, error)) {
+func (*Client) WatchEndpoints(clusterName string, callback func(*EndpointUpdate, error)) (cancel func()) {
+	return nil
 }
 
 // TODO: add LRS

--- a/xds/internal/client/client.go
+++ b/xds/internal/client/client.go
@@ -33,15 +33,22 @@ type EndpointUpdate struct{}
 // Client is the xds client resolver and balancer use to watch xds updates.
 //
 // All the watch methods don't block.
-type Client interface {
-	// WatchService watches LRS/RDS/VHDS.
-	WatchService(ctx context.Context, name string, callback func(*ServiceUpdate, error))
+type Client struct {
+}
 
-	// WatchCluster watches CDS.
-	WatchCluster(ctx context.Context, name string, callback func(*ClusterUpdate, error))
+// WatchService watches LRS/RDS/VHDS.
+func (*Client) WatchService(ctx context.Context, name string, callback func(*ServiceUpdate, error)) {}
 
-	// WatchEndpoint watches EDS.
-	WatchEndpoint(ctx context.Context, name string, callback func(*EndpointUpdate, error))
+// WatchCluster watches CDS.
+func (*Client) WatchCluster(ctx context.Context, name string, callback func(*ClusterUpdate, error)) {}
 
-	// TODO: add LRS
+// WatchEndpoint watches EDS.
+func (*Client) WatchEndpoint(ctx context.Context, name string, callback func(*EndpointUpdate, error)) {
+}
+
+// TODO: add LRS
+
+// New creates a new XDS client.
+func New() *Client {
+	return &Client{}
 }

--- a/xds/internal/client/client.go
+++ b/xds/internal/client/client.go
@@ -37,13 +37,15 @@ type Client struct {
 }
 
 // WatchService watches LRS/RDS/VHDS.
-func (*Client) WatchService(ctx context.Context, name string, callback func(*ServiceUpdate, error)) {}
+func (*Client) WatchService(ctx context.Context, target string, callback func(*ServiceUpdate, error)) {
+}
 
-// WatchCluster watches CDS.
-func (*Client) WatchCluster(ctx context.Context, name string, callback func(*ClusterUpdate, error)) {}
+// WatchClusters watches CDS.
+func (*Client) WatchClusters(ctx context.Context, serviceName string, callback func(*ClusterUpdate, error)) {
+}
 
-// WatchEndpoint watches EDS.
-func (*Client) WatchEndpoint(ctx context.Context, name string, callback func(*EndpointUpdate, error)) {
+// WatchEndpoints watches EDS.
+func (*Client) WatchEndpoints(ctx context.Context, clusterName string, callback func(*EndpointUpdate, error)) {
 }
 
 // TODO: add LRS

--- a/xds/internal/client/client.go
+++ b/xds/internal/client/client.go
@@ -35,17 +35,17 @@ type Client struct {
 }
 
 // WatchService watches LRS/RDS/VHDS.
-func (*Client) WatchService(target string, callback func(*ServiceUpdate, error)) (cancel func()) {
+func (*Client) WatchService(target []string, callback func(*ServiceUpdate, error)) (cancel func()) {
 	return nil
 }
 
 // WatchClusters watches CDS.
-func (*Client) WatchClusters(serviceName string, callback func(*ClusterUpdate, error)) (cancel func()) {
+func (*Client) WatchClusters(serviceName []string, callback func(*ClusterUpdate, error)) (cancel func()) {
 	return nil
 }
 
 // WatchEndpoints watches EDS.
-func (*Client) WatchEndpoints(clusterName string, callback func(*EndpointUpdate, error)) (cancel func()) {
+func (*Client) WatchEndpoints(clusterName []string, callback func(*EndpointUpdate, error)) (cancel func()) {
 	return nil
 }
 

--- a/xds/internal/client/config.go
+++ b/xds/internal/client/config.go
@@ -16,8 +16,6 @@
  *
  */
 
-// Package client contains the implementation of the xds client used by
-// grpc-lb-v2.
 package client
 
 import (


### PR DESCRIPTION
The interface works as a placeholder, to unblock the implementations.
It's not the final API.