### PR TITLE
Fix a data race in resolver_conn_wrapper.go

### DIFF
--- a/resolver_conn_wrapper_test.go
+++ b/resolver_conn_wrapper_test.go
@@ -27,9 +27,12 @@ import (
 	"testing"
 	"time"
 
+	"google.golang.org/grpc/backoff"
 	"google.golang.org/grpc/codes"
+	internalbackoff "google.golang.org/grpc/internal/backoff"
 	"google.golang.org/grpc/resolver"
 	"google.golang.org/grpc/resolver/manual"
+	"google.golang.org/grpc/serviceconfig"
 	"google.golang.org/grpc/status"
 )
 
@@ -122,21 +125,18 @@ func (s) TestDialParseTargetUnknownScheme(t *testing.T) {
 }
 
 func testResolverErrorPolling(t *testing.T, badUpdate func(*manual.Resolver), goodUpdate func(*manual.Resolver), dopts ...DialOption) {
-	defer func(o func(int) time.Duration) { resolverBackoff = o }(resolverBackoff)
-
-	boIter := make(chan int)
-	resolverBackoff = func(v int) time.Duration {
-		boIter <- v
-		return 0
-	}
-
 	r, rcleanup := manual.GenerateAndRegisterManualResolver()
 	defer rcleanup()
 	rn := make(chan struct{})
 	defer func() { close(rn) }()
 	r.ResolveNowCallback = func(resolver.ResolveNowOption) { rn <- struct{}{} }
 
-	cc, err := Dial(r.Scheme()+":///test.server", append([]DialOption{WithInsecure()}, dopts...)...)
+	defaultDialOptions := []DialOption{
+		WithInsecure(),
+		// Use an empty backoff config which results in no backoff.
+		withResolveNowBackoff(internalbackoff.Exponential{Config: backoff.Config{}}.Backoff),
+	}
+	cc, err := Dial(r.Scheme()+":///test.server", append(defaultDialOptions, dopts...)...)
 	if err != nil {
 		t.Fatalf("Dial(_, _) = _, %v; want _, nil", err)
 	}
@@ -149,9 +149,6 @@ func testResolverErrorPolling(t *testing.T, badUpdate func(*manual.Resolver), go
 	// Ensure ResolveNow is called, then Backoff with the right parameter, several times
 	for i := 0; i < 7; i++ {
 		<-rn
-		if v := <-boIter; v != i {
-			t.Errorf("Backoff call %v uses value %v", i, v)
-		}
 	}
 
 	// UpdateState will block if ResolveNow is being called (which blocks on
@@ -165,8 +162,6 @@ func testResolverErrorPolling(t *testing.T, badUpdate func(*manual.Resolver), go
 		select {
 		case <-rn:
 			// ClientConn is still calling ResolveNow
-			<-boIter
-			time.Sleep(5 * time.Millisecond)
 			continue
 		case <-t.C:
 			// ClientConn stopped calling ResolveNow; success
@@ -200,6 +195,31 @@ func (s) TestServiceConfigErrorPolling(t *testing.T) {
 		// rn), so call it in a goroutine.
 		go r.CC.UpdateState(resolver.State{})
 	})
+}
+
+// TestResolverErrorInBuild makes the resolver.Builder call into the ClientConn
+// during the Build call. We use two separate mutexes in the code which make
+// sure there is no data race in this code path, and also that there is no
+// deadlock.
+func (s) TestResolverErrorInBuild(t *testing.T) {
+	r, rcleanup := manual.GenerateAndRegisterManualResolver()
+	defer rcleanup()
+	r.InitialState(resolver.State{ServiceConfig: &serviceconfig.ParseResult{Err: errors.New("resolver build err")}})
+
+	cc, err := Dial(r.Scheme()+":///test.server", WithInsecure())
+	if err != nil {
+		t.Fatalf("Dial(_, _) = _, %v; want _, nil", err)
+	}
+	defer cc.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	var dummy int
+	const wantMsg = "error parsing service config"
+	const wantCode = codes.Unavailable
+	if err := cc.Invoke(ctx, "/foo/bar", &dummy, &dummy); status.Code(err) != wantCode || !strings.Contains(status.Convert(err).Message(), wantMsg) {
+		t.Fatalf("cc.Invoke(_, _, _, _) = %v; want status.Code()==%v, status.Message() contains %q", err, wantCode, wantMsg)
+	}
 }
 
 func (s) TestServiceConfigErrorRPC(t *testing.T) {


### PR DESCRIPTION
Use separate mutexes to guard the underlying `resolver` and the `polling` channel in the `resolverWrapper`. 

The data race was happening between the write to `ccr.resolver` in `newCCResolverWrapper` using the result from the call to `rb.Build`, and the read of `ccr.resolver` in `ResolveNow` (which can be triggered through the following code path: `rb.Build-->ccr.ReportError-->ccr.poll-->ccr.resolveNow`.

After fixing the race in the code, I also figured that there was a race in the test code because the `resolverBackoff` package variable was modified in some tests, but not in some others, causing a weird data race. I added a `TestMain` to override that variable with an empty `backoff.Config`, so all calls to `Backoff` will return 0.