### PR TITLE
resolver: Add new fields to resolver.BuildOption struct to support dialing a remote name resolver

### DIFF
--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -112,18 +112,23 @@ type BuildOption struct {
 	// DisableServiceConfig indicates whether a resolver implementation should
 	// fetch service config data.
 	DisableServiceConfig bool
-	// DialCreds is the transport credentials that a resolver implementation
-	// can use to dial a remote name resolution server. Resolver
-	// implementations which do not need to talk to another party securely can
-	// safely ignore this field.
+	// DialCreds is the transport credentials used by the ClientConn for
+	// communicating with the target gRPC service (set via
+	// WithTransportCredentials). In cases where a name resolution service
+	// requires the same credentials, the resolver may use this field. In most
+	// cases though, it is not appropriate, and this field may be ignored.
 	DialCreds credentials.TransportCredentials
-	// CredsBundle is the credentials bundle that a resolver implementation can
-	// use while dialing a remote name resolution server. If both DialCreds and
-	// CredsBundle are set, the former takes precedence.
+	// CredsBundle is the credentials bundle used by the ClientConn for
+	// communicating with the target gRPC service (set via
+	// WithCredentialsBundle). In cases where a name resolution service
+	// requires the same credentials, the resolver may use this field. In most
+	// cases though, it is not appropriate, and this field may be ignored.
 	CredsBundle credentials.Bundle
-	// Dialer is the custom dialer that a resolver implementation can use to
-	// dial a remote name resolution server. Resolver implementations which do
-	// not need to talk to another party securely can safely ignore this field.
+	// Dialer is the custom dialer used by the ClientConn for dialling the
+	// target gRPC service (set via WithDialer). In cases where a name
+	// resolution service requires the same dialer, the resolver may use this
+	// field. In most cases though, it is not appropriate, and this field may
+	// be ignored.
 	Dialer func(context.Context, string) (net.Conn, error)
 }
 

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -21,6 +21,10 @@
 package resolver
 
 import (
+	"context"
+	"net"
+
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/serviceconfig"
 )
 
@@ -105,8 +109,22 @@ type Address struct {
 // BuildOption includes additional information for the builder to create
 // the resolver.
 type BuildOption struct {
-	// DisableServiceConfig indicates whether resolver should fetch service config data.
+	// DisableServiceConfig indicates whether a resolver implementation should
+	// fetch service config data.
 	DisableServiceConfig bool
+	// DialCreds is the transport credentials that a resolver implementation
+	// can use to dial a remote name resolution server. Resolver
+	// implementations which do not need to talk to another party securely can
+	// safely ignore this field.
+	DialCreds credentials.TransportCredentials
+	// CredsBundle is the credentials bundle that a resolver implementation can
+	// use while dialing a remote name resolution server. If both DialCreds and
+	// CredsBundle are set, the former takes precedence.
+	CredsBundle credentials.Bundle
+	// Dialer is the custom dialer that a resolver implementation can use to
+	// dial a remote name resolution server. Resolver implementations which do
+	// not need to talk to another party securely can safely ignore this field.
+	Dialer func(context.Context, string) (net.Conn, error)
 }
 
 // State contains the current Resolver state relevant to the ClientConn.

--- a/resolver_conn_wrapper.go
+++ b/resolver_conn_wrapper.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"google.golang.org/grpc/balancer"
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/grpclog"
 	"google.golang.org/grpc/internal/channelz"
 	"google.golang.org/grpc/internal/grpcsync"
@@ -90,13 +91,24 @@ func newCCResolverWrapper(cc *ClientConn) (*ccResolverWrapper, error) {
 		done: grpcsync.NewEvent(),
 	}
 
+	var credsClone credentials.TransportCredentials
+	if creds := cc.dopts.copts.TransportCredentials; creds != nil {
+		credsClone = creds.Clone()
+	}
+	rbo := resolver.BuildOption{
+		DisableServiceConfig: cc.dopts.disableServiceConfig,
+		DialCreds:            credsClone,
+		CredsBundle:          cc.dopts.copts.CredsBundle,
+		Dialer:               cc.dopts.copts.Dialer,
+	}
+
 	var err error
 	// We need to hold the lock here while we assign to the ccr.resolver field
 	// to guard against a data race caused by the following code path,
 	// rb.Build-->ccr.ReportError-->ccr.poll-->ccr.resolveNow, would end up
 	// accessing ccr.resolver which is being assigned here.
 	ccr.resolverMu.Lock()
-	ccr.resolver, err = rb.Build(cc.parsedTarget, ccr, resolver.BuildOption{DisableServiceConfig: cc.dopts.disableServiceConfig})
+	ccr.resolver, err = rb.Build(cc.parsedTarget, ccr, rbo)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
These fields will be used by resolver implementations which need to talk
to a remote name resolver.