### PR TITLE
dev_Emma Fix route_guide example. Client flag of server addr need to match ser…

### DIFF
--- a/examples/route_guide/client/client.go
+++ b/examples/route_guide/client/client.go
@@ -39,7 +39,7 @@ import (
 var (
 	tls                = flag.Bool("tls", false, "Connection uses TLS if true, else plain TCP")
 	caFile             = flag.String("ca_file", "", "The file containing the CA root cert file")
-	serverAddr         = flag.String("server_addr", "127.0.0.1:10000", "The server address in the format of host:port")
+	serverAddr         = flag.String("server_addr", "localhost:10000", "The server address in the format of host:port")
 	serverHostOverride = flag.String("server_host_override", "x.test.youtube.com", "The server name use to verify the hostname returned by TLS handshake")
 )
 


### PR DESCRIPTION
When I clone grpc-go, the example of route_guide don't work. Server ignored msg from client. I think the reason is that server was listening "localhost:10000", but client connected to "127.0.0.1:10000".