### PR TITLE
adds a 'v2' of the balancer/base interfaces

### DIFF
--- a/balancer/base/default_conn_mgr.go
+++ b/balancer/base/default_conn_mgr.go
@@ -1,0 +1,81 @@
+/*
+ *
+ * Copyright 2019 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package base
+
+import (
+	"google.golang.org/grpc/balancer"
+	"google.golang.org/grpc/grpclog"
+	"google.golang.org/grpc/resolver"
+)
+
+// DefaultConnectionManager returns a default connection manager
+// that will try to create one sub-connection for every resolved
+// address it receives from a resolver.
+func DefaultConnectionManager(scMgr SubConnManager, config Config) ConnectionManager {
+	return &defaultConnMgr{
+		scMgr:    scMgr,
+		config:   config,
+		subConns: make(map[resolver.Address]*SubConn),
+	}
+}
+
+type defaultConnMgr struct {
+	scMgr  SubConnManager
+	config Config
+
+	subConns map[resolver.Address]*SubConn
+}
+
+func (cm *defaultConnMgr) UpdateResolverState(state resolver.State) error {
+	// TODO: handle s.ResolverState.Err (log if not nil) once implemented
+	// TODO: handle s.ResolverState.ServiceConfig?
+	if grpclog.V(2) {
+		grpclog.Infoln("base.defaultConnMgr: got new resolver state: ", state)
+	}
+	// addrsSet is the set converted from addrs, it's used for quick lookup of an address.
+	addrsSet := make(map[resolver.Address]struct{})
+	for _, a := range state.Addresses {
+		addrsSet[a] = struct{}{}
+		if _, ok := cm.subConns[a]; !ok {
+			// a is a new address (not existing in b.subConns).
+			sc, err := cm.scMgr.NewSubConn(a, balancer.NewSubConnOptions{HealthCheckEnabled: cm.config.HealthCheck})
+			if err != nil {
+				grpclog.Warningf("base.baseBalancer: failed to create new SubConn: %v", err)
+				continue
+			}
+			cm.subConns[a] = sc
+			sc.Connect()
+		}
+	}
+	for a, sc := range cm.subConns {
+		// a was removed by resolver.
+		if _, ok := addrsSet[a]; !ok {
+			cm.scMgr.RemoveSubConn(sc)
+			delete(cm.subConns, a)
+			// Keep the state of this sc in b.scStates until sc's state becomes Shutdown.
+			// The entry will be deleted in HandleSubConnStateChange.
+		}
+	}
+	return nil
+}
+
+// Close is a nop because default manager doesn't have internal state to clean up,
+// and it doesn't need to call RemoveSubConn for the SubConns.
+func (cm *defaultConnMgr) Close() {
+}

--- a/balancer/base/v2.go
+++ b/balancer/base/v2.go
@@ -1,0 +1,111 @@
+/*
+ *
+ * Copyright 2019 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package base
+
+// This file contains the types and interfaces that support "v2" of the
+// base balancer. V2 provides an alternate PickerBuilder interface and
+// also exposes a separate ConnectionManager interface, allowing the
+// concerns of deciding what connections to establish be separated from
+// the concerns of actually picking a connection for an RPC.
+
+import (
+	"context"
+
+	"google.golang.org/grpc/balancer"
+	"google.golang.org/grpc/resolver"
+)
+
+// PickerBuilder creates a balancer.Picker. If a PickerBuilder implements this
+// interface, its method will be used instead.
+type PickerBuilderV2 interface {
+	// Build takes a slice of ready SubConns and returns a picker that will be
+	// used by gRPC to pick a SubConn.
+	Build(readySCs []*SubConn) Picker
+}
+
+// Picker is an alternative to balancer.Picker that is used by PickerBuilderV2.
+// It returns a *base.SubConn instead of a balancer.SubConn.
+type Picker interface {
+	Pick(ctx context.Context, opts balancer.PickOptions) (conn *SubConn, done func(balancer.DoneInfo), err error)
+}
+
+// SubConnManager is an interface that allows a ConnectionManager to interact
+// with a balancer.ClientConn.
+type SubConnManager interface {
+	NewSubConn(resolver.Address, balancer.NewSubConnOptions) (*SubConn, error)
+	RemoveSubConn(*SubConn)
+}
+
+// ConnectionManager decides what connections to establish, maintain, or
+// tear down, based on updates from a resolver.
+type ConnectionManager interface {
+	// UpdateResolverState provides new information about the state of a service.
+	// The ConnectionManager may then choose to use its SubConnManager to create
+	// or destroy sub-connections to resolved addresses.
+	UpdateResolverState(resolver.State) error
+
+	// Close closes the connection manager. The manager is not required to call
+	// SubConnManager.RemoveSubConn for its existing SubConns.
+	Close()
+}
+
+// SubConn represents a sub-conn to a single address. It exposes only the
+// operations needed by a PickerBuilderV2 and ConnectionManager.
+type SubConn struct {
+	subConn balancer.SubConn
+	addr    resolver.Address
+}
+
+func (sc *SubConn) Connect() {
+	sc.subConn.Connect()
+}
+
+func (sc *SubConn) Address() resolver.Address {
+	return sc.addr
+}
+
+type subConnManager struct {
+	bb *baseBalancer
+}
+
+func (scm subConnManager) NewSubConn(addr resolver.Address, opts balancer.NewSubConnOptions) (*SubConn, error) {
+	sc, err := scm.bb.cc.NewSubConn([]resolver.Address{addr}, opts)
+	if sc != nil {
+		s := &SubConn{subConn: sc, addr: addr}
+		scm.bb.addSubConn(s)
+		return s, err
+	}
+	return nil, err
+}
+
+func (scm subConnManager) RemoveSubConn(sc *SubConn) {
+	scm.bb.cc.RemoveSubConn(sc.subConn)
+}
+
+type pickerV2Adapter struct {
+	p Picker
+}
+
+func (a pickerV2Adapter) Pick(ctx context.Context, opts balancer.PickOptions) (conn balancer.SubConn, done func(balancer.DoneInfo), err error) {
+	c, done, err := a.p.Pick(ctx, opts)
+	if conn != nil {
+		return c.subConn, done, err
+	}
+	return nil, done, err
+}

--- a/balancer/roundrobin/roundrobin.go
+++ b/balancer/roundrobin/roundrobin.go
@@ -37,16 +37,18 @@ const Name = "round_robin"
 
 // newBuilder creates a new roundrobin balancer builder.
 func newBuilder() balancer.Builder {
-	return base.NewBalancerBuilderWithConfig(Name, &rrPickerBuilder{}, base.Config{HealthCheck: true})
+	return base.NewBalancerBuilderWithConfig(Name, PickerBuilder{}, base.Config{HealthCheck: true})
 }
 
 func init() {
 	balancer.Register(newBuilder())
 }
 
-type rrPickerBuilder struct{}
+// PickerBuilder is a base.PickerBuilder that implements the round-robin
+// selection strategy.
+type PickerBuilder struct{}
 
-func (*rrPickerBuilder) Build(readySCs map[resolver.Address]balancer.SubConn) balancer.Picker {
+func (PickerBuilder) Build(readySCs map[resolver.Address]balancer.SubConn) balancer.Picker {
 	grpclog.Infof("roundrobinPicker: newPicker called with readySCs: %v", readySCs)
 	if len(readySCs) == 0 {
 		return base.NewErrPicker(balancer.ErrNoSubConnAvailable)


### PR DESCRIPTION
The v2 set of interfaces allows separation of concerns between _managing_ connections (deciding which connections to create or tear-down, based on resolver results) and _picking_ them for RPCs.

It should be fully backwards compatible: the old built-in connection management behavior is now provided by a `DefaultConnectionManager`. And there are adapters in place to support the v1 version of the `PickerBuilder` interface.

The v2 interfaces define subtly different interfaces for things like `SubConnManager` (thin wrapper around `balancer.ClientConn`), `SubConn`, and `Picker` so that only the necessary things are exposed. If a v2 impl were to use other methods of these interfaces (particularly `balancer.SubConn` and `balancer.ClientConn`), it would break several assumptions. So these new limited interfaces make this API safer and more coherent.

This is the kind of API I was hoping for when I filed #2909. This PR also exposes `roundrobin.PickerBuilder`, intentionally towards the goal of composability. So now a custom balancer can compose a custom connection manager and re-use the round-robin selection strategy. And a custom selection strategy could be implemented that wraps/decorates the round-robin strategy, by wrapping just the picker builder.