### PR TITLE
cleanup: no x/net/context

### DIFF
--- a/examples/features/debugging/client/main.go
+++ b/examples/features/debugging/client/main.go
@@ -20,17 +20,18 @@
 package main
 
 import (
+	"context"
 	"log"
 	"net"
 	"os"
 	"time"
 
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/channelz/service"
-	pb "google.golang.org/grpc/examples/helloworld/helloworld"
 	"google.golang.org/grpc/resolver"
 	"google.golang.org/grpc/resolver/manual"
+
+	pb "google.golang.org/grpc/examples/helloworld/helloworld"
 )
 
 const (

--- a/examples/features/debugging/server/main.go
+++ b/examples/features/debugging/server/main.go
@@ -20,11 +20,11 @@
 package main
 
 import (
+	"context"
 	"log"
 	"net"
 	"time"
 
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/channelz/service"
 	"google.golang.org/grpc/internal/grpcrand"

--- a/examples/helloworld/mock_helloworld/hw_mock.go
+++ b/examples/helloworld/mock_helloworld/hw_mock.go
@@ -4,8 +4,8 @@
 package mock_helloworld
 
 import (
+	context "context"
 	gomock "github.com/golang/mock/gomock"
-	context "golang.org/x/net/context"
 	grpc "google.golang.org/grpc"
 	helloworld "google.golang.org/grpc/examples/helloworld/helloworld"
 )

--- a/examples/route_guide/mock_routeguide/rg_mock.go
+++ b/examples/route_guide/mock_routeguide/rg_mock.go
@@ -4,8 +4,8 @@
 package mock_routeguide
 
 import (
+	context "context"
 	gomock "github.com/golang/mock/gomock"
-	context "golang.org/x/net/context"
 	grpc "google.golang.org/grpc"
 	routeguide "google.golang.org/grpc/examples/route_guide/routeguide"
 	metadata "google.golang.org/grpc/metadata"

--- a/reflection/grpc_testingv3/README.md
+++ b/reflection/grpc_testingv3/README.md
@@ -1,0 +1,3 @@
+The pb.go is genenated with an older version of codegen, to test reflection behavior with `grpc.SupportPackageIsVersion3`. DO NOT REGENERATE!
+
+pb.go is manually edited to replace `"golang.org/x/net/context"` with `"context"`.

--- a/reflection/grpc_testingv3/testv3.pb.go
+++ b/reflection/grpc_testingv3/testv3.pb.go
@@ -19,7 +19,8 @@ import fmt "fmt"
 import math "math"
 
 import (
-	context "golang.org/x/net/context"
+	context "context"
+
 	grpc "google.golang.org/grpc"
 )
 

--- a/vet.sh
+++ b/vet.sh
@@ -76,6 +76,9 @@ fi
 (! grep 'func Test[^(]' *_test.go)
 (! grep 'func Test[^(]' test/*.go)
 
+# - Do not import x/net/context.
+git grep -l 'x/net/context' -- "*.go" 2>&1 | (! grep -v 'orca.pb.go')
+
 # - Do not import math/rand for real library code.  Use internal/grpcrand for
 #   thread safety.
 git grep -l '"math/rand"' -- "*.go" 2>&1 | (! grep -v '^examples\|^stress\|grpcrand\|wrr_test')


### PR DESCRIPTION
Manual change + mockgen

Remaining `x/net/context` will be updated separate (to update xds protos)
```
xds/internal/proto/envoy/api/v2/eds/eds.pb.go
18:     context "golang.org/x/net/context"

xds/internal/proto/envoy/api/v2/cds/cds.pb.go
28:     context "golang.org/x/net/context"

xds/internal/proto/envoy/service/load_stats/v2/lrs/lrs.pb.go
15:     context "golang.org/x/net/context"

xds/internal/proto/envoy/service/discovery/v2/ads/ads.pb.go
12:     context "golang.org/x/net/context"

xds/internal/proto/udpa/service/orca/v1/orca/orca.pb.go
14:     context "golang.org/x/net/context"
```