### PR TITLE
interop, examples: use localhost instead of 127.0.0.1

### DIFF
--- a/examples/route_guide/client/client.go
+++ b/examples/route_guide/client/client.go
@@ -39,7 +39,7 @@ import (
 var (
 	tls                = flag.Bool("tls", false, "Connection uses TLS if true, else plain TCP")
 	caFile             = flag.String("ca_file", "", "The file containing the CA root cert file")
-	serverAddr         = flag.String("server_addr", "127.0.0.1:10000", "The server address in the format of host:port")
+	serverAddr         = flag.String("server_addr", "localhost:10000", "The server address in the format of host:port")
 	serverHostOverride = flag.String("server_host_override", "x.test.youtube.com", "The server name use to verify the hostname returned by TLS handshake")
 )
 

--- a/interop/http2/negative_http2_client.go
+++ b/interop/http2/negative_http2_client.go
@@ -40,7 +40,7 @@ import (
 )
 
 var (
-	serverHost = flag.String("server_host", "127.0.0.1", "The server host name")
+	serverHost = flag.String("server_host", "localhost", "The server host name")
 	serverPort = flag.Int("server_port", 8080, "The server port number")
 	testCase   = flag.String("test_case", "goaway",
 		`Configure different test cases. Valid options are:


### PR DESCRIPTION
Made via:
```sh
grep -rl 127.0.0.1 | grep -v _test.go | xargs sed -i 's/127.0.0.1/localhost/g'
```