### PR TITLE
docs: fix reflection doc

### DIFF
--- a/Documentation/server-reflection-tutorial.md
+++ b/Documentation/server-reflection-tutorial.md
@@ -51,6 +51,7 @@ To build gRPC CLI:
 ```sh
 git clone https://github.com/grpc/grpc
 cd grpc
+git submodule update --init
 make grpc_cli
 cd bins/opt # grpc_cli is in directory bins/opt/
 ```


### PR DESCRIPTION
added `git submodule update --init` to readme instructions to pull in missing dependencies.