### PR TITLE
client: set grpc-accept-encoding header based on outgoing compressor

### DIFF
--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -424,6 +424,7 @@ func (t *http2Client) createHeaderFields(ctx context.Context, callHdr *CallHdr) 
 
 	if callHdr.SendCompress != "" {
 		headerFields = append(headerFields, hpack.HeaderField{Name: "grpc-encoding", Value: callHdr.SendCompress})
+		headerFields = append(headerFields, hpack.HeaderField{Name: "grpc-accept-encoding", Value: callHdr.SendCompress})
 	}
 	if dl, ok := ctx.Deadline(); ok {
 		// Send out timeout regardless its value. The server can detect timeout context by itself.


### PR DESCRIPTION
Apply this PR, the server will response with grpc-encoding whatever the client set. test via wireshark.

update #2786