### PR TITLE
dns: disable SRV record lookups unless grpclb is imported

### DIFF
--- a/balancer/grpclb/grpclb.go
+++ b/balancer/grpclb/grpclb.go
@@ -40,6 +40,7 @@ import (
 	"google.golang.org/grpc/grpclog"
 	"google.golang.org/grpc/internal"
 	"google.golang.org/grpc/internal/backoff"
+	"google.golang.org/grpc/internal/resolver/dns"
 	"google.golang.org/grpc/resolver"
 )
 
@@ -97,6 +98,7 @@ func (x *balanceLoadClientStream) Recv() (*lbpb.LoadBalanceResponse, error) {
 
 func init() {
 	balancer.Register(newLBBuilder())
+	dns.EnableSRVLookups = true
 }
 
 // newLBBuilder creates a builder for grpclb.

--- a/internal/resolver/dns/dns_resolver.go
+++ b/internal/resolver/dns/dns_resolver.go
@@ -39,6 +39,10 @@ import (
 	"google.golang.org/grpc/resolver"
 )
 
+// EnableSRVLookups controls whether the DNS resolver attempts to fetch gRPCLB
+// addresses from SRV records.  Must not be changed after init time.
+var EnableSRVLookups = false
+
 func init() {
 	resolver.Register(NewBuilder())
 }
@@ -280,6 +284,9 @@ func (d *dnsResolver) watcher() {
 }
 
 func (d *dnsResolver) lookupSRV() []resolver.Address {
+	if !EnableSRVLookups {
+		return nil
+	}
 	var newAddrs []resolver.Address
 	_, srvs, err := d.resolver.LookupSRV(d.ctx, "grpclb", "tcp", d.host)
 	if err != nil {


### PR DESCRIPTION
This implements part of https://github.com/grpc/proposal/pull/164, and should not be merged until November 8th, pending its approval.