### PR TITLE
cleanup: fix generic comparisons on protobuf messages

### DIFF
--- a/status/status_test.go
+++ b/status/status_test.go
@@ -22,13 +22,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"reflect"
 	"testing"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
 	apb "github.com/golang/protobuf/ptypes/any"
 	dpb "github.com/golang/protobuf/ptypes/duration"
+	"github.com/google/go-cmp/cmp"
 	cpb "google.golang.org/genproto/googleapis/rpc/code"
 	epb "google.golang.org/genproto/googleapis/rpc/errdetails"
 	spb "google.golang.org/genproto/googleapis/rpc/status"
@@ -318,10 +318,14 @@ func TestStatus_ErrorDetails_Fail(t *testing.T) {
 	}
 	for _, tc := range tests {
 		got := tc.s.Details()
-		if !reflect.DeepEqual(got, tc.i) {
+		if !cmp.Equal(got, tc.i, cmp.Comparer(proto.Equal), cmp.Comparer(equalError)) {
 			t.Errorf("(%v).Details() = %+v, want %+v", str(tc.s), got, tc.i)
 		}
 	}
+}
+
+func equalError(x, y error) bool {
+	return x == y || (x != nil && y != nil && x.Error() == y.Error())
 }
 
 func str(s *Status) string {

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -3919,9 +3919,13 @@ func testFailedServerStreaming(t *testing.T, e env) {
 		t.Fatalf("%v.StreamingOutputCall(_) = _, %v, want <nil>", tc, err)
 	}
 	wantErr := status.Error(codes.DataLoss, "error for testing: "+failAppUA)
-	if _, err := stream.Recv(); !reflect.DeepEqual(err, wantErr) {
+	if _, err := stream.Recv(); !equalError(err, wantErr) {
 		t.Fatalf("%v.Recv() = _, %v, want _, %v", stream, err, wantErr)
 	}
+}
+
+func equalError(x, y error) bool {
+	return x == y || (x != nil && y != nil && x.Error() == y.Error())
 }
 
 // concurrentSendServer is a TestServiceServer whose

--- a/test/retry_test.go
+++ b/test/retry_test.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"reflect"
 	"strconv"
 	"strings"
 	"testing"
@@ -362,7 +361,7 @@ func (s) TestRetryStreaming(t *testing.T) {
 			res, err := stream.Recv()
 			if res != nil ||
 				((err == nil) != (want == nil)) ||
-				(want != nil && !reflect.DeepEqual(err, want)) {
+				(want != nil && err.Error() != want.Error()) {
 				return fmt.Errorf("client: Recv() = %v, %v; want <nil>, %v", res, err, want)
 			}
 			return nil

--- a/xds/internal/balancer/lrs/lrs_test.go
+++ b/xds/internal/balancer/lrs/lrs_test.go
@@ -90,7 +90,7 @@ func equalClusterStats(a, b []*endpointpb.ClusterStats) bool {
 			s.LoadReportInterval = nil
 		}
 	}
-	return reflect.DeepEqual(a, b)
+	return cmp.Equal(a, b, cmp.Comparer(proto.Equal))
 }
 
 func Test_lrsStore_buildStats_drops(t *testing.T) {


### PR DESCRIPTION
Generated protobuf messages contain internal data structures
that general purpose comparison functions (e.g., reflect.DeepEqual,
pretty.Compare, etc) do not properly compare. It is already the case
today that these functions may report a difference when two messages
are actually semantically equivalent.

Fix all usages by either calling proto.Equal directly if
the top-level types are themselves proto.Message, or by calling
cmp.Equal with the cmp.Comparer(proto.Equal) option specified.
This option teaches cmp to use proto.Equal anytime it encounters
proto.Message types.