### PR TITLE
resolver: re-add dns and passthrough packages as references to internal versions

### DIFF
--- a/resolver/dns/dns_resolver.go
+++ b/resolver/dns/dns_resolver.go
@@ -24,9 +24,8 @@
 package dns
 
 import (
+	"google.golang.org/grpc/internal/resolver/dns"
 	"google.golang.org/grpc/resolver"
-
-	_ "google.golang.org/grpc/internal/resolver/dns" // import for side effects after package was moved
 )
 
 // NewBuilder creates a dnsBuilder which is used to factory DNS resolvers.

--- a/resolver/dns/dns_resolver.go
+++ b/resolver/dns/dns_resolver.go
@@ -1,0 +1,37 @@
+/*
+ *
+ * Copyright 2018 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// Package dns implements a dns resolver to be installed as the default resolver
+// in grpc.
+//
+// Deprecated: this package is imported by grpc and should not need to be
+// imported directly by users.
+package dns
+
+import (
+	"google.golang.org/grpc/resolver"
+
+	_ "google.golang.org/grpc/internal/resolver/dns"
+)
+
+// NewBuilder creates a dnsBuilder which is used to factory DNS resolvers.
+//
+// Deprecated: import grpc and use resolver.Get("dns") instead.
+func NewBuilder() resolver.Builder {
+	return dns.NewBuilder()
+}

--- a/resolver/dns/dns_resolver.go
+++ b/resolver/dns/dns_resolver.go
@@ -26,7 +26,7 @@ package dns
 import (
 	"google.golang.org/grpc/resolver"
 
-	_ "google.golang.org/grpc/internal/resolver/dns"
+	_ "google.golang.org/grpc/internal/resolver/dns" // import for side effects after package was moved
 )
 
 // NewBuilder creates a dnsBuilder which is used to factory DNS resolvers.

--- a/resolver/passthrough/passthrough.go
+++ b/resolver/passthrough/passthrough.go
@@ -23,4 +23,4 @@
 // imported directly by users.
 package passthrough
 
-import _ "google.golang.org/grpc/internal/resolver/passthrough"
+import _ "google.golang.org/grpc/internal/resolver/passthrough" // import for side effects after package was moved

--- a/resolver/passthrough/passthrough.go
+++ b/resolver/passthrough/passthrough.go
@@ -1,0 +1,26 @@
+/*
+ *
+ * Copyright 2017 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// Package passthrough implements a pass-through resolver. It sends the target
+// name without scheme back to gRPC as resolved address.
+//
+// Deprecated: this package is imported by grpc and should not need to be
+// imported directly by users.
+package passthrough
+
+import _ "google.golang.org/grpc/internal/resolver/passthrough"


### PR DESCRIPTION
Fixes #3157 
