### PR TITLE
dns: stop polling for updates; use UpdateState API

### DIFF
--- a/internal/resolver/dns/dns_resolver.go
+++ b/internal/resolver/dns/dns_resolver.go
@@ -138,7 +138,7 @@ func (b *dnsBuilder) Build(target resolver.Target, cc resolver.ClientConn, opts 
 
 	d.wg.Add(1)
 	go d.watcher()
-	d.ResolveNow(resolver.ResolveNowOption{})
+	d.ResolveNow(resolver.ResolveNowOptions{})
 	return d, nil
 }
 
@@ -156,7 +156,7 @@ type netResolver interface {
 // deadResolver is a resolver that does nothing.
 type deadResolver struct{}
 
-func (deadResolver) ResolveNow(_ resolver.ResolveNowOption) {}
+func (deadResolver) ResolveNow(resolver.ResolveNowOptions) {}
 
 func (deadResolver) Close() {}
 

--- a/internal/resolver/dns/dns_resolver.go
+++ b/internal/resolver/dns/dns_resolver.go
@@ -294,7 +294,6 @@ func (d *dnsResolver) lookup() *resolver.State {
 	state := &resolver.State{
 		Addresses: append(d.lookupHost(), srv...),
 	}
-	// Support fallback to non-balancer address.
 	if !d.disableServiceConfig {
 		state.ServiceConfig = d.lookupTXT()
 	}

--- a/internal/resolver/dns/dns_resolver_test.go
+++ b/internal/resolver/dns/dns_resolver_test.go
@@ -707,7 +707,7 @@ func testDNSResolver(t *testing.T) {
 			t.Errorf("Resolved addresses of target: %q = %+v, want %+v\n", a.target, state.Addresses, a.addrWant)
 		}
 		sc := scFromState(state)
-		if !reflect.DeepEqual(a.scWant, sc) {
+		if a.scWant != sc {
 			t.Errorf("Resolved service config of target: %q = %+v, want %+v\n", a.target, sc, a.scWant)
 		}
 		r.Close()
@@ -789,7 +789,7 @@ func testDNSResolverWithSRV(t *testing.T) {
 			t.Errorf("Resolved addresses of target: %q = %+v, want %+v\n", a.target, state.Addresses, a.addrWant)
 		}
 		sc := scFromState(state)
-		if !reflect.DeepEqual(a.scWant, sc) {
+		if a.scWant != sc {
 			t.Errorf("Resolved service config of target: %q = %+v, want %+v\n", a.target, sc, a.scWant)
 		}
 	}
@@ -857,7 +857,7 @@ func testDNSResolveNow(t *testing.T) {
 			t.Errorf("Resolved addresses of target: %q = %+v, want %+v\n", a.target, state.Addresses, a.addrWant)
 		}
 		sc := scFromState(state)
-		if !reflect.DeepEqual(a.scWant, sc) {
+		if a.scWant != sc {
 			t.Errorf("Resolved service config of target: %q = %+v, want %+v\n", a.target, sc, a.scWant)
 		}
 
@@ -877,7 +877,7 @@ func testDNSResolveNow(t *testing.T) {
 		if !reflect.DeepEqual(a.addrNext, state.Addresses) {
 			t.Errorf("Resolved addresses of target: %q = %+v, want %+v\n", a.target, state.Addresses, a.addrNext)
 		}
-		if !reflect.DeepEqual(a.scNext, sc) {
+		if a.scNext != sc {
 			t.Errorf("Resolved service config of target: %q = %+v, want %+v\n", a.target, sc, a.scNext)
 		}
 		revertTbl()
@@ -968,7 +968,7 @@ func TestResolveFunc(t *testing.T) {
 			r.Close()
 		}
 		if !reflect.DeepEqual(err, v.want) {
-			t.Errorf("Build(%q, cc, resolver.BuildOptions{}) = %v, want %v", v.addr, err, v.want)
+			t.Errorf("Build(%q, cc, _) = %v, want %v", v.addr, err, v.want)
 		}
 	}
 }
@@ -1013,7 +1013,7 @@ func TestDisableServiceConfig(t *testing.T) {
 			t.Fatalf("UpdateState not called after 2s; aborting")
 		}
 		sc := scFromState(state)
-		if !reflect.DeepEqual(a.scWant, sc) {
+		if a.scWant != sc {
 			t.Errorf("Resolved service config of target: %q = %+v, want %+v\n", a.target, sc, a.scWant)
 		}
 	}

--- a/internal/resolver/dns/dns_resolver_test.go
+++ b/internal/resolver/dns/dns_resolver_test.go
@@ -77,6 +77,9 @@ func (t *testClientConn) NewServiceConfig(serviceConfig string) {
 
 func scFromState(s resolver.State) string {
 	if s.ServiceConfig != nil {
+		if s.ServiceConfig.Err != nil {
+			return ""
+		}
 		return s.ServiceConfig.Config.(unparsedServiceConfig).config
 	}
 	return ""

--- a/internal/resolver/dns/dns_resolver_test.go
+++ b/internal/resolver/dns/dns_resolver_test.go
@@ -35,14 +35,11 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	// Set a valid duration for the re-resolution rate only for tests which are
-	// actually testing that feature.
-	dc := replaceDNSResRate(time.Duration(0))
-	defer dc()
-
-	cleanup := replaceNetFunc(nil)
+	// Set a non-zero duration only for tests which are actually testing that
+	// feature.
+	replaceDNSResRate(time.Duration(0)) // No nead to clean up since we os.Exit
+	replaceNetFunc(nil)                 // No nead to clean up since we os.Exit
 	code := m.Run()
-	cleanup()
 	os.Exit(code)
 }
 
@@ -51,47 +48,52 @@ const (
 )
 
 type testClientConn struct {
-	target string
-	m1     sync.Mutex
-	addrs  []resolver.Address
-	a      int // how many times NewAddress() has been called
-	m2     sync.Mutex
-	sc     string
-	s      int
+	target           string
+	m1               sync.Mutex
+	m2               sync.Mutex
+	sc               string
+	state            resolver.State
+	updateStateCalls int
 }
 
 func (t *testClientConn) UpdateState(s resolver.State) {
-	panic("unused")
+	t.m1.Lock()
+	defer t.m1.Unlock()
+	t.state = s
+	t.updateStateCalls++
 }
 
 func (t *testClientConn) NewAddress(addresses []resolver.Address) {
-	t.m1.Lock()
-	defer t.m1.Unlock()
-	t.addrs = addresses
-	t.a++
+	panic("unused")
 }
 
-func (t *testClientConn) getAddress() ([]resolver.Address, int) {
+func (t *testClientConn) getState() (resolver.State, int) {
 	t.m1.Lock()
 	defer t.m1.Unlock()
-	return t.addrs, t.a
+	return t.state, t.updateStateCalls
+}
+
+func (t *testClientConn) getSC() (string, int) {
+	t.m1.Lock()
+	defer t.m1.Unlock()
+	sc := ""
+	if t.state.ServiceConfig != nil {
+		sc = t.state.ServiceConfig.Config.(unparsedServiceConfig).config
+	}
+	return sc, t.updateStateCalls
 }
 
 func (t *testClientConn) NewServiceConfig(serviceConfig string) {
-	t.m2.Lock()
-	defer t.m2.Unlock()
-	t.sc = serviceConfig
-	t.s++
+	panic("unused")
 }
 
-func (t *testClientConn) getSc() (string, int) {
-	t.m2.Lock()
-	defer t.m2.Unlock()
-	return t.sc, t.s
+type unparsedServiceConfig struct {
+	serviceconfig.Config
+	config string
 }
 
-func (t *testClientConn) ParseServiceConfig(string) *serviceconfig.ParseResult {
-	panic("not implemented")
+func (t *testClientConn) ParseServiceConfig(s string) *serviceconfig.ParseResult {
+	return &serviceconfig.ParseResult{Config: unparsedServiceConfig{config: s}}
 }
 
 func (t *testClientConn) ReportError(error) {
@@ -671,7 +673,7 @@ func testDNSResolver(t *testing.T) {
 		},
 		{
 			"srv.ipv4.single.fake",
-			[]resolver.Address{{Addr: "2.4.6.8" + colonDefaultPort}},
+			[]resolver.Address{{Addr: "2.4.6.8" + colonDefaultPort}, {Addr: "1.2.3.4:1234", Type: resolver.GRPCLB, ServerName: "ipv4.single.fake"}},
 			generateSC("srv.ipv4.single.fake"),
 		},
 		{
@@ -789,36 +791,26 @@ func testDNSResolverWithSRV(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%v\n", err)
 		}
-		var addrs []resolver.Address
+		defer r.Close()
+		var state resolver.State
 		var cnt int
-		for {
-			addrs, cnt = cc.getAddress()
+		for i := 0; i < 2000; i++ {
+			state, cnt = cc.getState()
 			if cnt > 0 {
 				break
 			}
 			time.Sleep(time.Millisecond)
 		}
-		var sc string
-		if a.scWant != "" {
-			for {
-				sc, cnt = cc.getSc()
-				if cnt > 0 {
-					break
-				}
-				time.Sleep(time.Millisecond)
-			}
-		} else {
-			// A new service config should never be produced; call getSc once
-			// just in case.
-			sc, _ = cc.getSc()
+		if cnt == 0 {
+			t.Fatalf("UpdateState not called after 2s; aborting")
 		}
-		if !reflect.DeepEqual(a.addrWant, addrs) {
-			t.Errorf("Resolved addresses of target: %q = %+v, want %+v\n", a.target, addrs, a.addrWant)
+		if !reflect.DeepEqual(a.addrWant, state.Addresses) {
+			t.Errorf("Resolved addresses of target: %q = %+v, want %+v\n", a.target, state.Addresses, a.addrWant)
 		}
+		sc, _ := cc.getSC()
 		if !reflect.DeepEqual(a.scWant, sc) {
 			t.Errorf("Resolved service config of target: %q = %+v, want %+v\n", a.target, sc, a.scWant)
 		}
-		r.Close()
 	}
 }
 
@@ -867,55 +859,47 @@ func testDNSResolveNow(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%v\n", err)
 		}
-		var addrs []resolver.Address
+		defer r.Close()
+		var state resolver.State
 		var cnt int
-		for {
-			addrs, cnt = cc.getAddress()
+		for i := 0; i < 2000; i++ {
+			state, cnt = cc.getState()
 			if cnt > 0 {
 				break
 			}
 			time.Sleep(time.Millisecond)
 		}
-		var sc string
-		for {
-			sc, cnt = cc.getSc()
-			if cnt > 0 {
-				break
-			}
-			time.Sleep(time.Millisecond)
+		if cnt == 0 {
+			t.Fatalf("UpdateState not called after 2s; aborting.  state=%v", state)
 		}
-		if !reflect.DeepEqual(a.addrWant, addrs) {
-			t.Errorf("Resolved addresses of target: %q = %+v, want %+v\n", a.target, addrs, a.addrWant)
+		if !reflect.DeepEqual(a.addrWant, state.Addresses) {
+			t.Errorf("Resolved addresses of target: %q = %+v, want %+v\n", a.target, state.Addresses, a.addrWant)
 		}
+		sc, _ := cc.getSC()
 		if !reflect.DeepEqual(a.scWant, sc) {
 			t.Errorf("Resolved service config of target: %q = %+v, want %+v\n", a.target, sc, a.scWant)
 		}
+
 		revertTbl := mutateTbl(a.target)
 		r.ResolveNow(resolver.ResolveNowOptions{})
-		for i := 0; i < 1000; i++ {
-			addrs, cnt = cc.getAddress()
-			// Break if the address list changes or enough redundant updates happen.
-			if !reflect.DeepEqual(addrs, a.addrWant) || cnt > 10 {
+		for i := 0; i < 2000; i++ {
+			state, cnt = cc.getState()
+			if cnt == 2 {
 				break
 			}
 			time.Sleep(time.Millisecond)
 		}
-		for i := 0; i < 1000; i++ {
-			sc, cnt = cc.getSc()
-			// Break if the service config changes or enough redundant updates happen.
-			if !reflect.DeepEqual(sc, a.scWant) || cnt > 10 {
-				break
-			}
-			time.Sleep(time.Millisecond)
+		if cnt != 2 {
+			t.Fatalf("UpdateState not called after 2s; aborting.  state=%v", state)
 		}
-		if !reflect.DeepEqual(a.addrNext, addrs) {
-			t.Errorf("Resolved addresses of target: %q = %+v, want %+v\n", a.target, addrs, a.addrNext)
+		sc, _ = cc.getSC()
+		if !reflect.DeepEqual(a.addrNext, state.Addresses) {
+			t.Errorf("Resolved addresses of target: %q = %+v, want %+v\n", a.target, state.Addresses, a.addrNext)
 		}
 		if !reflect.DeepEqual(a.scNext, sc) {
 			t.Errorf("Resolved service config of target: %q = %+v, want %+v\n", a.target, sc, a.scNext)
 		}
 		revertTbl()
-		r.Close()
 	}
 }
 
@@ -946,28 +930,25 @@ func testIPResolver(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%v\n", err)
 		}
-		var addrs []resolver.Address
+		var state resolver.State
 		var cnt int
 		for {
-			addrs, cnt = cc.getAddress()
+			state, cnt = cc.getState()
 			if cnt > 0 {
 				break
 			}
 			time.Sleep(time.Millisecond)
 		}
-		if !reflect.DeepEqual(v.want, addrs) {
-			t.Errorf("Resolved addresses of target: %q = %+v, want %+v\n", v.target, addrs, v.want)
+		if !reflect.DeepEqual(v.want, state.Addresses) {
+			t.Errorf("Resolved addresses of target: %q = %+v, want %+v\n", v.target, state.Addresses, v.want)
 		}
 		r.ResolveNow(resolver.ResolveNowOptions{})
-		for {
-			addrs, cnt = cc.getAddress()
-			if cnt == 2 {
-				break
+		for i := 0; i < 50; i++ {
+			state, cnt = cc.getState()
+			if cnt > 1 {
+				t.Fatalf("Unexpected second call by resolver to UpdateState.  state: %v", state)
 			}
 			time.Sleep(time.Millisecond)
-		}
-		if !reflect.DeepEqual(v.want, addrs) {
-			t.Errorf("Resolved addresses of target: %q = %+v, want %+v\n", v.target, addrs, v.want)
 		}
 		r.Close()
 	}
@@ -1034,29 +1015,25 @@ func TestDisableServiceConfig(t *testing.T) {
 		b := NewBuilder()
 		cc := &testClientConn{target: a.target}
 		r, err := b.Build(resolver.Target{Endpoint: a.target}, cc, resolver.BuildOptions{DisableServiceConfig: a.disableServiceConfig})
+		defer r.Close()
 		if err != nil {
 			t.Fatalf("%v\n", err)
 		}
 		var cnt int
 		var sc string
-		// First wait for addresses.  We know service configs are reported
-		// first, so once addresses have been reported, we can then check to
-		// see whether any configs have been reported..
 		for i := 0; i < 1000; i++ {
-			_, cnt = cc.getAddress()
+			sc, cnt = cc.getSC()
 			if cnt > 0 {
 				break
 			}
 			time.Sleep(time.Millisecond)
 		}
-		sc, cnt = cc.getSc()
-		if a.disableServiceConfig && cnt > 0 {
-			t.Errorf("Resolver reported a service config even though lookups are disabled: sc=%v, cnt=%v", sc, cnt)
+		if cnt == 0 {
+			t.Fatalf("UpdateState not called after 2s; aborting.  sc=%v", sc)
 		}
 		if !reflect.DeepEqual(a.scWant, sc) {
 			t.Errorf("Resolved service config of target: %q = %+v, want %+v\n", a.target, sc, a.scWant)
 		}
-		r.Close()
 	}
 }
 
@@ -1068,49 +1045,49 @@ func TestDNSResolverRetry(t *testing.T) {
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}
-	var addrs []resolver.Address
-	for {
-		addrs, _ = cc.getAddress()
-		if len(addrs) == 1 {
+	defer r.Close()
+	var state resolver.State
+	for i := 0; i < 2000; i++ {
+		state, _ = cc.getState()
+		if len(state.Addresses) == 1 {
 			break
 		}
 		time.Sleep(time.Millisecond)
 	}
+	if len(state.Addresses) != 1 {
+		t.Fatalf("UpdateState not called with 1 address after 2s; aborting.  state=%v", state)
+	}
 	want := []resolver.Address{{Addr: "1.2.3.4" + colonDefaultPort}}
-	if !reflect.DeepEqual(want, addrs) {
-		t.Errorf("Resolved addresses of target: %q = %+v, want %+v\n", target, addrs, want)
+	if !reflect.DeepEqual(want, state.Addresses) {
+		t.Errorf("Resolved addresses of target: %q = %+v, want %+v\n", target, state.Addresses, want)
 	}
 	// mutate the host lookup table so the target has 0 address returned.
 	revertTbl := mutateTbl(target)
 	// trigger a resolve that will get empty address list
 	r.ResolveNow(resolver.ResolveNowOptions{})
-	for {
-		addrs, _ = cc.getAddress()
-		if len(addrs) == 0 {
+	for i := 0; i < 2000; i++ {
+		state, _ = cc.getState()
+		if len(state.Addresses) == 0 {
 			break
 		}
 		time.Sleep(time.Millisecond)
 	}
+	if len(state.Addresses) != 0 {
+		t.Fatalf("UpdateState not called with 0 address after 2s; aborting.  state=%v", state)
+	}
 	revertTbl()
 	// wait for the retry to happen in two seconds.
-	timer := time.NewTimer(2 * time.Second)
-loop:
-	for {
-		select {
-		case <-timer.C:
-			break loop
-		default:
-			addrs, _ = cc.getAddress()
-			if len(addrs) != 0 {
-				break loop
-			}
-			time.Sleep(time.Millisecond)
+	r.ResolveNow(resolver.ResolveNowOption{})
+	for i := 0; i < 2000; i++ {
+		state, _ = cc.getState()
+		if len(state.Addresses) == 1 {
+			break
 		}
+		time.Sleep(time.Millisecond)
 	}
-	if !reflect.DeepEqual(want, addrs) {
-		t.Errorf("Resolved addresses of target: %q = %+v, want %+v\n", target, addrs, want)
+	if !reflect.DeepEqual(want, state.Addresses) {
+		t.Errorf("Resolved addresses of target: %q = %+v, want %+v\n", target, state.Addresses, want)
 	}
-	r.Close()
 }
 
 func TestCustomAuthority(t *testing.T) {
@@ -1297,16 +1274,16 @@ func TestRateLimitedResolve(t *testing.T) {
 	}
 
 	wantAddrs := []resolver.Address{{Addr: "1.2.3.4" + colonDefaultPort}, {Addr: "5.6.7.8" + colonDefaultPort}}
-	var gotAddrs []resolver.Address
+	var state resolver.State
 	for {
 		var cnt int
-		gotAddrs, cnt = cc.getAddress()
+		state, cnt = cc.getState()
 		if cnt > 0 {
 			break
 		}
 		time.Sleep(time.Millisecond)
 	}
-	if !reflect.DeepEqual(gotAddrs, wantAddrs) {
-		t.Errorf("Resolved addresses of target: %q = %+v, want %+v\n", target, gotAddrs, wantAddrs)
+	if !reflect.DeepEqual(state.Addresses, wantAddrs) {
+		t.Errorf("Resolved addresses of target: %q = %+v, want %+v\n", target, state.Addresses, wantAddrs)
 	}
 }

--- a/internal/resolver/dns/dns_resolver_test.go
+++ b/internal/resolver/dns/dns_resolver_test.go
@@ -50,8 +50,6 @@ const (
 type testClientConn struct {
 	target           string
 	m1               sync.Mutex
-	m2               sync.Mutex
-	sc               string
 	state            resolver.State
 	updateStateCalls int
 }
@@ -1019,6 +1017,7 @@ func TestDisableServiceConfig(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%v\n", err)
 		}
+		defer r.Close()
 		var cnt int
 		var sc string
 		for i := 0; i < 1000; i++ {

--- a/internal/resolver/dns/dns_resolver_test.go
+++ b/internal/resolver/dns/dns_resolver_test.go
@@ -48,10 +48,11 @@ const (
 )
 
 type testClientConn struct {
-	target           string
-	m1               sync.Mutex
-	state            resolver.State
-	updateStateCalls int
+	resolver.ClientConn // For unimplemented functions
+	target              string
+	m1                  sync.Mutex
+	state               resolver.State
+	updateStateCalls    int
 }
 
 func (t *testClientConn) UpdateState(s resolver.State) {
@@ -61,18 +62,10 @@ func (t *testClientConn) UpdateState(s resolver.State) {
 	t.updateStateCalls++
 }
 
-func (t *testClientConn) NewAddress(addresses []resolver.Address) {
-	panic("unused")
-}
-
 func (t *testClientConn) getState() (resolver.State, int) {
 	t.m1.Lock()
 	defer t.m1.Unlock()
 	return t.state, t.updateStateCalls
-}
-
-func (t *testClientConn) NewServiceConfig(serviceConfig string) {
-	panic("unused")
 }
 
 func scFromState(s resolver.State) string {


### PR DESCRIPTION
This cannot be merged until the pickfirst and round_robin balancers are updated to return an error from `UpdateState` when zero addresses are provided, as we currently rely upon the polling behavior of DNS to refresh on error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grpc/grpc-go/3165)
<!-- Reviewable:end -->
