### PR TITLE
codec/proto: reuse of marshal byte buffers

### DIFF
--- a/Documentation/encoding.md
+++ b/Documentation/encoding.md
@@ -8,8 +8,13 @@ into bytes and vice-versa for the purposes of network transmission.
 ## Codecs (Serialization and Deserialization)
 
 A `Codec` contains code to serialize a message into a byte slice (`Marshal`) and
-deserialize a byte slice back into a message (`Unmarshal`).  `Codec`s are
-registered by name into a global registry maintained in the `encoding` package.
+deserialize a byte slice back into a message (`Unmarshal`).  Optionally, a
+`ReturnBuffer` method to potentially reuse the byte slice returned by the
+`Marshal` method may also be implemented; note that this is an experimental
+feature with an API that is still in flux.
+
+`Codec`s are registered by name into a global registry maintained in the
+`encoding` package.
 
 ### Implementing a `Codec`
 

--- a/codec.go
+++ b/codec.go
@@ -31,6 +31,24 @@ type baseCodec interface {
 	Unmarshal(data []byte, v interface{}) error
 }
 
+// A bufferedBaseCodec is exactly like a baseCodec, but also requires a
+// ReturnBuffer method to be implemented. Once a Marshal caller is done with
+// the returned byte buffer, they can choose to return it back to the encoding
+// library for re-use using this method.
+//
+// This API is EXPERIMENTAL.
+type bufferedBaseCodec interface {
+	baseCodec
+	// If implemented in a codec, this function may be called with the byte
+	// buffer returned by Marshal after gRPC is done with the buffer.
+	//
+	// gRPC will not call ReturnBuffer after it's done with the buffer if any of
+	// the following is true:
+	//   1. Stats handlers are used.
+	//   2. Binlogs are enabled.
+	ReturnBuffer(buf []byte)
+}
+
 var _ baseCodec = Codec(nil)
 var _ baseCodec = encoding.Codec(nil)
 

--- a/codec.go
+++ b/codec.go
@@ -31,12 +31,10 @@ type baseCodec interface {
 	Unmarshal(data []byte, v interface{}) error
 }
 
-// A reusableBaseCodec is exactly like a baseCodec, but also requires a
-// ReturnBuffer method to be implemented. Once a Marshal caller is done with
-// the returned byte buffer, they can choose to return it back to the encoding
-// library for re-use using this method.
-type reusableBaseCodec interface {
-	baseCodec
+// A bufferReturner requires a ReturnBuffer method to be implemented. Once a
+// Marshal caller is done with the returned byte buffer, they can choose to
+// return it back to the encoding library for re-use using this method.
+type bufferReturner interface {
 	// If implemented in a codec, this function may be called with the byte
 	// buffer returned by Marshal after gRPC is done with the buffer.
 	//

--- a/codec.go
+++ b/codec.go
@@ -31,13 +31,11 @@ type baseCodec interface {
 	Unmarshal(data []byte, v interface{}) error
 }
 
-// A bufferedBaseCodec is exactly like a baseCodec, but also requires a
+// A reusableBaseCodec is exactly like a baseCodec, but also requires a
 // ReturnBuffer method to be implemented. Once a Marshal caller is done with
 // the returned byte buffer, they can choose to return it back to the encoding
 // library for re-use using this method.
-//
-// This API is EXPERIMENTAL.
-type bufferedBaseCodec interface {
+type reusableBaseCodec interface {
 	baseCodec
 	// If implemented in a codec, this function may be called with the byte
 	// buffer returned by Marshal after gRPC is done with the buffer.

--- a/encoding/encoding.go
+++ b/encoding/encoding.go
@@ -86,6 +86,24 @@ type Codec interface {
 	Name() string
 }
 
+// A BufferedCodec is exactly like a Codec, but also requires a ReturnBuffer
+// method to be implemented. Once a Marshal caller is done with the returned
+// byte buffer, they can choose to return it back to the encoding library for
+// re-use using this method.
+//
+// This API is EXPERIMENTAL.
+type BufferedCodec interface {
+	Codec
+	// If implemented in a codec, this function may be called with the byte
+	// buffer returned by Marshal after gRPC is done with the buffer.
+	//
+	// gRPC will not call ReturnBuffer after it's done with the buffer if any of
+	// the following is true:
+	//   1. Stats handlers are used.
+	//   2. Binlogs are enabled.
+	ReturnBuffer(buf []byte)
+}
+
 var registeredCodecs = make(map[string]Codec)
 
 // RegisterCodec registers the provided Codec for use with all gRPC clients and

--- a/encoding/proto/proto_test.go
+++ b/encoding/proto/proto_test.go
@@ -20,7 +20,6 @@ package proto
 
 import (
 	"bytes"
-	"fmt"
 	"sync"
 	"testing"
 
@@ -132,19 +131,14 @@ func TestStaggeredMarshalAndUnmarshalUsingSamePool(t *testing.T) {
 func TestBufferReuse(t *testing.T) {
 	c := codec{}
 
-	var bptr string
 	marshal := func(toMarshal []byte) []byte {
 		protoIn := &codec_perf.Buffer{Body: toMarshal}
 		b, err := c.Marshal(protoIn)
 		if err != nil {
 			t.Errorf("codec.Marshal(%v) failed: %v", protoIn, err)
 		}
-		lbptr := fmt.Sprintf("%p", b)
-		if bptr == "" {
-			bptr = lbptr
-		} else if bptr != lbptr {
-			t.Errorf("expected the same buffer to be reused: lptr = %s, ptr = %s", lbptr, bptr)
-		}
+		// We cannot expect the actual pointer to be the same because sync.Pool
+		// during GC pauses.
 		bc := append([]byte(nil), b...)
 		c.ReturnBuffer(b)
 		return bc

--- a/internal/leakcheck/leakcheck.go
+++ b/internal/leakcheck/leakcheck.go
@@ -43,6 +43,8 @@ var goroutinesToIgnore = []string{
 	"runtime_mcall",
 	"(*loggingT).flushDaemon",
 	"goroutine in C code",
+	"grpc.callReturnBuffers",
+	"grpc.waitCallReturnBuffer",
 }
 
 // RegisterIgnoreGoroutine appends s into the ignore goroutine list. The

--- a/internal/leakcheck/leakcheck.go
+++ b/internal/leakcheck/leakcheck.go
@@ -43,8 +43,6 @@ var goroutinesToIgnore = []string{
 	"runtime_mcall",
 	"(*loggingT).flushDaemon",
 	"goroutine in C code",
-	"grpc.callReturnBuffers",
-	"grpc.waitCallReturnBuffer",
 }
 
 // RegisterIgnoreGoroutine appends s into the ignore goroutine list. The

--- a/internal/transport/controlbuf.go
+++ b/internal/transport/controlbuf.go
@@ -737,7 +737,7 @@ func (l *loopyWriter) cleanupStreamHandler(c *cleanupStream) error {
 	if str, ok := l.estdStreams[c.streamID]; ok {
 		// Dequeue all items from the stream's item list. This would call any pending onDequeue functions.
 		if str.state == active {
-			for str.itl.isEmpty() {
+			for !str.itl.isEmpty() {
 				str.itl.dequeue()
 			}
 		}

--- a/internal/transport/controlbuf.go
+++ b/internal/transport/controlbuf.go
@@ -34,8 +34,9 @@ var updateHeaderTblSize = func(e *hpack.Encoder, v uint32) {
 }
 
 type itemNode struct {
-	it   interface{}
-	next *itemNode
+	it        interface{}
+	onDequeue func()
+	next      *itemNode
 }
 
 type itemList struct {
@@ -43,8 +44,8 @@ type itemList struct {
 	tail *itemNode
 }
 
-func (il *itemList) enqueue(i interface{}) {
-	n := &itemNode{it: i}
+func (il *itemList) enqueue(i interface{}, onDequeue func()) {
+	n := &itemNode{it: i, onDequeue: onDequeue}
 	if il.tail == nil {
 		il.head, il.tail = n, n
 		return
@@ -63,10 +64,13 @@ func (il *itemList) dequeue() interface{} {
 	if il.head == nil {
 		return nil
 	}
-	i := il.head.it
+	i, onDequeue := il.head.it, il.head.onDequeue
 	il.head = il.head.next
 	if il.head == nil {
 		il.tail = nil
+	}
+	if onDequeue != nil {
+		onDequeue()
 	}
 	return i
 }
@@ -330,7 +334,7 @@ func (c *controlBuffer) executeAndPut(f func(it interface{}) bool, it cbItem) (b
 		wakeUp = true
 		c.consumerWaiting = false
 	}
-	c.list.enqueue(it)
+	c.list.enqueue(it, nil)
 	if it.isTransportResponseFrame() {
 		c.transportResponseFrames++
 		if c.transportResponseFrames == maxQueuedTransportResponseFrames {
@@ -617,7 +621,7 @@ func (l *loopyWriter) headerHandler(h *headerFrame) error {
 
 		if str.state != empty { // either active or waiting on stream quota.
 			// add it str's list of items.
-			str.itl.enqueue(h)
+			str.itl.enqueue(h, nil)
 			return nil
 		}
 		if err := l.writeHeader(h.streamID, h.endStream, h.hf, h.onWrite); err != nil {
@@ -632,7 +636,7 @@ func (l *loopyWriter) headerHandler(h *headerFrame) error {
 		itl:   &itemList{},
 		wq:    h.wq,
 	}
-	str.itl.enqueue(h)
+	str.itl.enqueue(h, nil)
 	return l.originateStream(str)
 }
 
@@ -703,7 +707,11 @@ func (l *loopyWriter) preprocessData(df *dataFrame) error {
 	}
 	// If we got data for a stream it means that
 	// stream was originated and the headers were sent out.
-	str.itl.enqueue(df)
+	var onDequeue func()
+	if df.rb != nil {
+		onDequeue = df.rb.Done
+	}
+	str.itl.enqueue(df, onDequeue)
 	if str.state == empty {
 		str.state = active
 		l.activeStreams.enqueue(str)
@@ -727,13 +735,10 @@ func (l *loopyWriter) outFlowControlSizeRequestHandler(o *outFlowControlSizeRequ
 func (l *loopyWriter) cleanupStreamHandler(c *cleanupStream) error {
 	c.onWrite()
 	if str, ok := l.estdStreams[c.streamID]; ok {
-		// If the stream is active and has unwritten data frames, the underlying
-		// payload buffers may need to be returned to the encoder.
+		// Dequeue all items from the stream's item list. This would call any pending onDequeue functions.
 		if str.state == active {
-			for !str.itl.isEmpty() {
-				if dataItem, ok := str.itl.dequeue().(*dataFrame); ok && dataItem.rb != nil {
-					dataItem.rb.Done()
-				}
+			for str.itl.isEmpty() {
+				str.itl.dequeue()
 			}
 		}
 		// On the server side it could be a trailers-only response or
@@ -852,9 +857,6 @@ func (l *loopyWriter) processData() (bool, error) {
 			return false, err
 		}
 		str.itl.dequeue() // remove the empty data item from stream
-		if dataItem.rb != nil {
-			dataItem.rb.Done()
-		}
 		if str.itl.isEmpty() {
 			str.state = empty
 		} else if trailer, ok := str.itl.peek().(*headerFrame); ok { // the next item is trailers.
@@ -920,9 +922,6 @@ func (l *loopyWriter) processData() (bool, error) {
 
 	if len(dataItem.h) == 0 && len(dataItem.d) == 0 { // All the data from that message was written out.
 		str.itl.dequeue()
-		if dataItem.rb != nil {
-			dataItem.rb.Done()
-		}
 	}
 	if str.itl.isEmpty() {
 		str.state = empty

--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -834,6 +834,7 @@ func (t *http2Client) Write(s *Stream, hdr []byte, data []byte, opts *Options) e
 	df := &dataFrame{
 		streamID:  s.id,
 		endStream: opts.Last,
+		wg:        opts.ReturnBufferWaitGroup,
 	}
 	if hdr != nil || data != nil { // If it's not an empty data frame.
 		// Add some data to grpc message header so that we can equally
@@ -849,6 +850,9 @@ func (t *http2Client) Write(s *Stream, hdr []byte, data []byte, opts *Options) e
 		if err := s.wq.get(int32(len(hdr) + len(data))); err != nil {
 			return err
 		}
+	}
+	if df.wg != nil {
+		df.wg.Add(1)
 	}
 	return t.controlBuf.put(df)
 }

--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -834,7 +834,7 @@ func (t *http2Client) Write(s *Stream, hdr []byte, data []byte, opts *Options) e
 	df := &dataFrame{
 		streamID:  s.id,
 		endStream: opts.Last,
-		wg:        opts.ReturnBufferWaitGroup,
+		rb:        opts.ReturnBuffer,
 	}
 	if hdr != nil || data != nil { // If it's not an empty data frame.
 		// Add some data to grpc message header so that we can equally
@@ -851,8 +851,8 @@ func (t *http2Client) Write(s *Stream, hdr []byte, data []byte, opts *Options) e
 			return err
 		}
 	}
-	if df.wg != nil {
-		df.wg.Add(1)
+	if df.rb != nil {
+		df.rb.Add(1)
 	}
 	return t.controlBuf.put(df)
 }

--- a/internal/transport/http2_server.go
+++ b/internal/transport/http2_server.go
@@ -912,6 +912,7 @@ func (t *http2Server) Write(s *Stream, hdr []byte, data []byte, opts *Options) e
 		h:           hdr,
 		d:           data,
 		onEachWrite: t.setResetPingStrikes,
+		wg:          opts.ReturnBufferWaitGroup,
 	}
 	if err := s.wq.get(int32(len(hdr) + len(data))); err != nil {
 		select {
@@ -920,6 +921,9 @@ func (t *http2Server) Write(s *Stream, hdr []byte, data []byte, opts *Options) e
 		default:
 		}
 		return ContextErr(s.ctx.Err())
+	}
+	if df.wg != nil {
+		df.wg.Add(1)
 	}
 	return t.controlBuf.put(df)
 }

--- a/internal/transport/http2_server.go
+++ b/internal/transport/http2_server.go
@@ -912,7 +912,7 @@ func (t *http2Server) Write(s *Stream, hdr []byte, data []byte, opts *Options) e
 		h:           hdr,
 		d:           data,
 		onEachWrite: t.setResetPingStrikes,
-		wg:          opts.ReturnBufferWaitGroup,
+		rb:          opts.ReturnBuffer,
 	}
 	if err := s.wq.get(int32(len(hdr) + len(data))); err != nil {
 		select {
@@ -922,8 +922,8 @@ func (t *http2Server) Write(s *Stream, hdr []byte, data []byte, opts *Options) e
 		}
 		return ContextErr(s.ctx.Err())
 	}
-	if df.wg != nil {
-		df.wg.Add(1)
+	if df.rb != nil {
+		df.rb.Add(1)
 	}
 	return t.controlBuf.put(df)
 }

--- a/internal/transport/transport.go
+++ b/internal/transport/transport.go
@@ -586,6 +586,9 @@ type Options struct {
 	// Last indicates whether this write is the last piece for
 	// this stream.
 	Last bool
+	// If non-nil, ReturnBufferWaitGroup.Done() should be called in order to
+	// return some allocated buffer back to a sync pool.
+	ReturnBufferWaitGroup *sync.WaitGroup
 }
 
 // CallHdr carries the information of a particular RPC.

--- a/preloader.go
+++ b/preloader.go
@@ -57,7 +57,7 @@ func (p *PreparedMsg) Encode(s Stream, msg interface{}) error {
 	}
 	p.encodedData = data
 	if cap(data) >= bufferReuseThreshold {
-		if bcodec, ok := rpcInfo.preloaderInfo.codec.(reusableBaseCodec); ok {
+		if bcodec, ok := rpcInfo.preloaderInfo.codec.(bufferReturner); ok {
 			p.returnBuffer = func() {
 				bcodec.ReturnBuffer(data)
 			}

--- a/preloader.go
+++ b/preloader.go
@@ -28,9 +28,10 @@ import (
 // This API is EXPERIMENTAL.
 type PreparedMsg struct {
 	// Struct for preparing msg before sending them
-	encodedData []byte
-	hdr         []byte
-	payload     []byte
+	encodedData  []byte
+	hdr          []byte
+	payload      []byte
+	returnBuffer func()
 }
 
 // Encode marshalls and compresses the message using the codec and compressor for the stream.
@@ -55,6 +56,14 @@ func (p *PreparedMsg) Encode(s Stream, msg interface{}) error {
 		return err
 	}
 	p.encodedData = data
+	if len(data) >= bufferReuseThreshold {
+		if bcodec, ok := rpcInfo.preloaderInfo.codec.(bufferedBaseCodec); ok {
+			p.returnBuffer = func() {
+				bcodec.ReturnBuffer(data)
+			}
+		}
+	}
+
 	compData, err := compress(data, rpcInfo.preloaderInfo.cp, rpcInfo.preloaderInfo.comp)
 	if err != nil {
 		return err

--- a/preloader.go
+++ b/preloader.go
@@ -56,8 +56,8 @@ func (p *PreparedMsg) Encode(s Stream, msg interface{}) error {
 		return err
 	}
 	p.encodedData = data
-	if len(data) >= bufferReuseThreshold {
-		if bcodec, ok := rpcInfo.preloaderInfo.codec.(bufferedBaseCodec); ok {
+	if cap(data) >= bufferReuseThreshold {
+		if bcodec, ok := rpcInfo.preloaderInfo.codec.(reusableBaseCodec); ok {
 			p.returnBuffer = func() {
 				bcodec.ReturnBuffer(data)
 			}

--- a/server.go
+++ b/server.go
@@ -850,7 +850,7 @@ func (s *Server) sendResponse(t transport.ServerTransport, stream *transport.Str
 	}
 
 	if attemptBufferReuse && len(data) >= bufferReuseThreshold {
-		if bcodec, ok := codec.(reusableBaseCodec); ok {
+		if bcodec, ok := codec.(bufferReturner); ok {
 			opts.ReturnBuffer = transport.NewReturnBuffer(1, func() {
 				bcodec.ReturnBuffer(data)
 			})

--- a/server.go
+++ b/server.go
@@ -851,7 +851,7 @@ func (s *Server) sendResponse(t transport.ServerTransport, stream *transport.Str
 
 	var f func()
 	if attemptBufferReuse && len(data) >= bufferReuseThreshold {
-		if bcodec, ok := codec.(bufferedBaseCodec); ok {
+		if bcodec, ok := codec.(reusableBaseCodec); ok {
 			f = func() {
 				bcodec.ReturnBuffer(data)
 			}

--- a/stream.go
+++ b/stream.go
@@ -459,13 +459,11 @@ type csAttempt struct {
 
 func (cs *clientStream) commitAttemptLocked() {
 	cs.buffer = nil
-	if !cs.committed {
-		cs.committed = true
-		for _, rb := range cs.returnBuffers {
-			rb.Done()
-		}
-		cs.returnBuffers = nil
+	cs.committed = true
+	for _, rb := range cs.returnBuffers {
+		rb.Done()
 	}
+	cs.returnBuffers = nil
 }
 
 func (cs *clientStream) commitAttempt() {

--- a/stream.go
+++ b/stream.go
@@ -1623,8 +1623,8 @@ func prepareMsg(m interface{}, codec baseCodec, cp Compressor, comp encoding.Com
 		return nil, nil, nil, nil, err
 	}
 
-	if attemptBufferReuse && len(data) >= bufferReuseThreshold {
-		if bcodec, ok := codec.(bufferedBaseCodec); ok {
+	if attemptBufferReuse && cap(data) >= bufferReuseThreshold {
+		if bcodec, ok := codec.(reusableBaseCodec); ok {
 			returnBuffer = func() {
 				bcodec.ReturnBuffer(data)
 			}

--- a/stream.go
+++ b/stream.go
@@ -461,7 +461,7 @@ func (cs *clientStream) commitAttemptLocked() {
 	cs.buffer = nil
 	if !cs.committed {
 		cs.committed = true
-		for _, rb := range(cs.returnBuffers) {
+		for _, rb := range cs.returnBuffers {
 			rb.Done()
 		}
 		cs.returnBuffers = nil

--- a/stream.go
+++ b/stream.go
@@ -278,6 +278,10 @@ func newClientStream(ctx context.Context, desc *StreamDesc, cc *ClientConn, meth
 	}
 	cs.binlog = binarylog.GetMethodLogger(method)
 
+	// Stats handlers and binlog handlers are allowed to retain references to
+	// this slice internally. We may not, therefore, return this to the pool.
+	cs.attemptBufferReuse = sh == nil && cs.binlog == nil
+
 	cs.callInfo.stream = cs
 	// Only this initial attempt has stats/tracing.
 	// TODO(dfawley): move to newAttempt when per-attempt stats are implemented.
@@ -422,6 +426,21 @@ type clientStream struct {
 	committed  bool                       // active attempt committed for retry?
 	buffer     []func(a *csAttempt) error // operations to replay on retry
 	bufferSize int                        // current size of buffer
+
+	// This is per-stream array instead of a per-attempt one because there may be
+	// multiple attempts working on the same data, but we may not free the same
+	// buffer twice.
+	returnBuffers      []*returnBuffer
+	attemptBufferReuse bool
+}
+
+// returnBuffer contains a function holding a closure that can return a byte
+// buffer back to the encoder for reuse. Before this function is called, all
+// data frames referencing the closured data must be written to the wire,
+// including all re-attempts.
+type returnBuffer struct {
+	f  func()
+	wg *sync.WaitGroup
 }
 
 // csAttempt implements a single transport stream attempt within a
@@ -696,9 +715,17 @@ func (cs *clientStream) SendMsg(m interface{}) (err error) {
 	}
 
 	// load hdr, payload, data
-	hdr, payload, data, err := prepareMsg(m, cs.codec, cs.cp, cs.comp)
+	hdr, payload, data, f, err := prepareMsg(m, cs.codec, cs.cp, cs.comp, cs.attemptBufferReuse)
 	if err != nil {
 		return err
+	}
+
+	var rb *returnBuffer
+	if f != nil {
+		// We can assume mutual exclusion on this slice as only one SendMsg is
+		// supported concurrently.
+		rb = &returnBuffer{f: f, wg: &sync.WaitGroup{}}
+		cs.returnBuffers = append(cs.returnBuffers, rb)
 	}
 
 	// TODO(dfawley): should we be checking len(data) instead?
@@ -707,7 +734,7 @@ func (cs *clientStream) SendMsg(m interface{}) (err error) {
 	}
 	msgBytes := data // Store the pointer before setting to nil. For binary logging.
 	op := func(a *csAttempt) error {
-		err := a.sendMsg(m, hdr, payload, data)
+		err := a.sendMsg(m, hdr, payload, data, rb)
 		// nil out the message and uncomp when replaying; they are only needed for
 		// stats which is disabled for subsequent attempts.
 		m, data = nil, nil
@@ -788,6 +815,23 @@ func (cs *clientStream) CloseSend() error {
 	return nil
 }
 
+func waitCallReturnBuffer(f func(), wg *sync.WaitGroup) {
+	if f == nil || wg == nil {
+		return
+	}
+	wg.Wait()
+	f()
+}
+
+func callReturnBuffers(returnBuffers []*returnBuffer) {
+	if returnBuffers == nil {
+		return
+	}
+	for _, rb := range returnBuffers {
+		waitCallReturnBuffer(rb.f, rb.wg)
+	}
+}
+
 func (cs *clientStream) finish(err error) {
 	if err == io.EOF {
 		// Ending a stream with EOF indicates a success.
@@ -798,6 +842,16 @@ func (cs *clientStream) finish(err error) {
 		cs.mu.Unlock()
 		return
 	}
+
+	// Regardless of what err is, we must return all byte slices to the codec
+	// layer once each attempt's transport work is done. This may take as long as
+	// the last data frame's write-to-wire, so we spawn a goroutine to wait on
+	// all such buffers without blocking. This must be called exactly once so as
+	// to not free the same buffer twice.
+	if cs.returnBuffers != nil {
+		go callReturnBuffers(cs.returnBuffers)
+	}
+
 	cs.finished = true
 	cs.commitAttemptLocked()
 	cs.mu.Unlock()
@@ -833,7 +887,7 @@ func (cs *clientStream) finish(err error) {
 	cs.cancel()
 }
 
-func (a *csAttempt) sendMsg(m interface{}, hdr, payld, data []byte) error {
+func (a *csAttempt) sendMsg(m interface{}, hdr, payld, data []byte, rb *returnBuffer) error {
 	cs := a.cs
 	if a.trInfo != nil {
 		a.mu.Lock()
@@ -842,7 +896,13 @@ func (a *csAttempt) sendMsg(m interface{}, hdr, payld, data []byte) error {
 		}
 		a.mu.Unlock()
 	}
-	if err := a.t.Write(a.s, hdr, payld, &transport.Options{Last: !cs.desc.ClientStreams}); err != nil {
+
+	var wg *sync.WaitGroup
+	if rb != nil {
+		wg = rb.wg
+	}
+
+	if err := a.t.Write(a.s, hdr, payld, &transport.Options{Last: !cs.desc.ClientStreams, ReturnBufferWaitGroup: wg}); err != nil {
 		if !cs.desc.ClientStreams {
 			// For non-client-streaming RPCs, we return nil instead of EOF on error
 			// because the generated code requires it.  finish is not called; RecvMsg()
@@ -1095,25 +1155,26 @@ func newNonRetryClientStream(ctx context.Context, desc *StreamDesc, method strin
 }
 
 type addrConnStream struct {
-	s         *transport.Stream
-	ac        *addrConn
-	callHdr   *transport.CallHdr
-	cancel    context.CancelFunc
-	opts      []CallOption
-	callInfo  *callInfo
-	t         transport.ClientTransport
-	ctx       context.Context
-	sentLast  bool
-	desc      *StreamDesc
-	codec     baseCodec
-	cp        Compressor
-	comp      encoding.Compressor
-	decompSet bool
-	dc        Decompressor
-	decomp    encoding.Compressor
-	p         *parser
-	mu        sync.Mutex
-	finished  bool
+	s             *transport.Stream
+	ac            *addrConn
+	callHdr       *transport.CallHdr
+	cancel        context.CancelFunc
+	opts          []CallOption
+	callInfo      *callInfo
+	t             transport.ClientTransport
+	ctx           context.Context
+	sentLast      bool
+	desc          *StreamDesc
+	codec         baseCodec
+	cp            Compressor
+	comp          encoding.Compressor
+	decompSet     bool
+	dc            Decompressor
+	decomp        encoding.Compressor
+	p             *parser
+	mu            sync.Mutex
+	finished      bool
+	returnBuffers []*returnBuffer
 }
 
 func (as *addrConnStream) Header() (metadata.MD, error) {
@@ -1165,10 +1226,20 @@ func (as *addrConnStream) SendMsg(m interface{}) (err error) {
 		as.sentLast = true
 	}
 
-	// load hdr, payload, data
-	hdr, payld, _, err := prepareMsg(m, as.codec, as.cp, as.comp)
+	// load hdr, payload, data, returnBuffer
+	hdr, payld, _, f, err := prepareMsg(m, as.codec, as.cp, as.comp, true)
 	if err != nil {
 		return err
+	}
+
+	var rb *returnBuffer
+	var wg *sync.WaitGroup
+	if f != nil {
+		// We can assume mutual exclusion on this slice as only one SendMsg is
+		// supported concurrently.
+		wg = &sync.WaitGroup{}
+		rb = &returnBuffer{f: f, wg: wg}
+		as.returnBuffers = append(as.returnBuffers, rb)
 	}
 
 	// TODO(dfawley): should we be checking len(data) instead?
@@ -1176,7 +1247,7 @@ func (as *addrConnStream) SendMsg(m interface{}) (err error) {
 		return status.Errorf(codes.ResourceExhausted, "trying to send message larger than max (%d vs. %d)", len(payld), *as.callInfo.maxSendMessageSize)
 	}
 
-	if err := as.t.Write(as.s, hdr, payld, &transport.Options{Last: !as.desc.ClientStreams}); err != nil {
+	if err := as.t.Write(as.s, hdr, payld, &transport.Options{Last: !as.desc.ClientStreams, ReturnBufferWaitGroup: wg}); err != nil {
 		if !as.desc.ClientStreams {
 			// For non-client-streaming RPCs, we return nil instead of EOF on error
 			// because the generated code requires it.  finish is not called; RecvMsg()
@@ -1248,6 +1319,13 @@ func (as *addrConnStream) RecvMsg(m interface{}) (err error) {
 }
 
 func (as *addrConnStream) finish(err error) {
+	// Regardless of what err is, we must return all byte slices to the codec
+	// layer. This may take as long as the last data frame's write-to-wire, so we
+	// spawn a goroutine to wait on all such buffers without blocking.
+	if as.returnBuffers != nil {
+		go callReturnBuffers(as.returnBuffers)
+	}
+
 	as.mu.Lock()
 	if as.finished {
 		as.mu.Unlock()
@@ -1347,6 +1425,9 @@ type serverStream struct {
 	serverHeaderBinlogged bool
 
 	mu sync.Mutex // protects trInfo.tr after the service handler runs.
+
+	returnBuffers      []*returnBuffer
+	attemptBufferReuse bool
 }
 
 func (ss *serverStream) Context() context.Context {
@@ -1408,17 +1489,27 @@ func (ss *serverStream) SendMsg(m interface{}) (err error) {
 		}
 	}()
 
-	// load hdr, payload, data
-	hdr, payload, data, err := prepareMsg(m, ss.codec, ss.cp, ss.comp)
+	// load hdr, payload, returnBuffer, data
+	hdr, payload, data, f, err := prepareMsg(m, ss.codec, ss.cp, ss.comp, ss.attemptBufferReuse)
 	if err != nil {
 		return err
+	}
+
+	var rb *returnBuffer
+	var wg *sync.WaitGroup
+	if f != nil {
+		// We can assume mutual exclusion on this slice as only one SendMsg is
+		// supported concurrently.
+		wg = &sync.WaitGroup{}
+		rb = &returnBuffer{f: f, wg: wg}
+		ss.returnBuffers = append(ss.returnBuffers, rb)
 	}
 
 	// TODO(dfawley): should we be checking len(data) instead?
 	if len(payload) > ss.maxSendMessageSize {
 		return status.Errorf(codes.ResourceExhausted, "trying to send message larger than max (%d vs. %d)", len(payload), ss.maxSendMessageSize)
 	}
-	if err := ss.t.Write(ss.s, hdr, payload, &transport.Options{Last: false}); err != nil {
+	if err := ss.t.Write(ss.s, hdr, payload, &transport.Options{Last: false, ReturnBufferWaitGroup: wg}); err != nil {
 		return toRPCErr(err)
 	}
 	if ss.binlog != nil {
@@ -1507,23 +1598,44 @@ func MethodFromServerStream(stream ServerStream) (string, bool) {
 	return Method(stream.Context())
 }
 
+// Threshold beyond which buffer reuse should apply.
+//
+// TODO(adtac): make this an option in the future so that the user can
+// configure it per-RPC or even per-message?
+const bufferReuseThreshold = 1024
+
 // prepareMsg returns the hdr, payload and data
 // using the compressors passed or using the
 // passed preparedmsg
-func prepareMsg(m interface{}, codec baseCodec, cp Compressor, comp encoding.Compressor) (hdr, payload, data []byte, err error) {
+func prepareMsg(m interface{}, codec baseCodec, cp Compressor, comp encoding.Compressor, attemptBufferReuse bool) (hdr, payload, data []byte, returnBuffer func(), err error) {
 	if preparedMsg, ok := m.(*PreparedMsg); ok {
-		return preparedMsg.hdr, preparedMsg.payload, preparedMsg.encodedData, nil
+		f := preparedMsg.returnBuffer
+		if !attemptBufferReuse {
+			f = nil
+		}
+		return preparedMsg.hdr, preparedMsg.payload, preparedMsg.encodedData, f, nil
 	}
+
 	// The input interface is not a prepared msg.
 	// Marshal and Compress the data at this point
 	data, err = encode(codec, m)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
+
+	if attemptBufferReuse && len(data) >= bufferReuseThreshold {
+		if bcodec, ok := codec.(bufferedBaseCodec); ok {
+			returnBuffer = func() {
+				bcodec.ReturnBuffer(data)
+			}
+		}
+	}
+
 	compData, err := compress(data, cp, comp)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
+
 	hdr, payload = msgHeader(data, compData)
-	return hdr, payload, data, nil
+	return hdr, payload, data, returnBuffer, nil
 }

--- a/stream.go
+++ b/stream.go
@@ -1580,7 +1580,7 @@ func prepareMsg(m interface{}, codec baseCodec, cp Compressor, comp encoding.Com
 	}
 
 	if attemptBufferReuse && cap(data) >= bufferReuseThreshold {
-		if bcodec, ok := codec.(reusableBaseCodec); ok {
+		if bcodec, ok := codec.(bufferReturner); ok {
 			returnBuffer = func() {
 				bcodec.ReturnBuffer(data)
 			}

--- a/vet.sh
+++ b/vet.sh
@@ -119,7 +119,7 @@ fi
 SC_OUT="$(mktemp)"
 staticcheck -go 1.9 -checks 'inherit,-ST1015' ./... > "${SC_OUT}" || true
 # Error if anything other than deprecation warnings are printed.
-(! grep -v "is deprecated:.*SA1019" "${SC_OUT}")
+(! grep -Pv "\((SA1019)|(SA6002)\)$" "${SC_OUT}")
 # Only ignore the following deprecated types/fields/functions.
 (! grep -Fv '.HandleResolvedAddrs
 .HandleSubConnStateChange
@@ -152,5 +152,6 @@ naming.Resolver
 naming.Update
 naming.Watcher
 resolver.Backend
-resolver.GRPCLB' "${SC_OUT}"
+resolver.GRPCLB
+SA6002' "${SC_OUT}"
 )

--- a/vet.sh
+++ b/vet.sh
@@ -117,9 +117,9 @@ fi
 # TODO(dfawley): don't use deprecated functions in examples or first-party
 # plugins.
 SC_OUT="$(mktemp)"
-staticcheck -go 1.9 -checks 'inherit,-ST1015' ./... > "${SC_OUT}" || true
+staticcheck -go 1.9 -checks 'inherit,-ST1015,-SA6002' ./... > "${SC_OUT}" || true
 # Error if anything other than deprecation warnings are printed.
-(! grep -Pv "\((SA1019)|(SA6002)\)$" "${SC_OUT}")
+(! grep -v "is deprecated:.*SA1019" "${SC_OUT}")
 # Only ignore the following deprecated types/fields/functions.
 (! grep -Fv '.HandleResolvedAddrs
 .HandleSubConnStateChange
@@ -152,6 +152,5 @@ naming.Resolver
 naming.Update
 naming.Watcher
 resolver.Backend
-resolver.GRPCLB
-SA6002' "${SC_OUT}"
+resolver.GRPCLB' "${SC_OUT}"
 )


### PR DESCRIPTION
Performance benchmarks can be found below. Obviously, a 8 KiB
request/response is tailored to showcase this improvement as this is
where codec buffer reuse shines, but I've run other benchmarks too (like
1-byte requests and responses) and there's no discernable impact on
performance.

We do not allow reuse of buffers when stat handlers or binlogs are
turned on. This is because those two may need access to the data and
payload even after the data has been written to the wire. In such cases,
we never return the data back to the pool.

A buffer reuse threshold of 1 KiB was determined after several
experiments. There's diminished returns when buffer reuse is enabled for
smaller messages (actually, a negative impact).

```
unary-networkMode_none-bufConn_false-keepalive_false-benchTime_40s-trace_false-latency_0s-kbps_0-MTU_0-maxConcurrentCalls_6-reqSize_8192B-respSize_8192B-compressor_off-channelz_false-preloader_false
               Title       Before        After Percentage
            TotalOps       839638       906223     7.93%
             SendOps            0            0      NaN%
             RecvOps            0            0      NaN%
            Bytes/op    103788.29     80592.47   -22.35%
           Allocs/op       183.33       189.30     3.27%
             ReqT/op 1375662899.20 1484755763.20     7.93%
            RespT/op 1375662899.20 1484755763.20     7.93%
            50th-Lat    238.746µs    225.019µs    -5.75%
            90th-Lat    514.253µs    456.439µs   -11.24%
            99th-Lat    711.083µs    702.466µs    -1.21%
             Avg-Lat     285.45µs    264.456µs    -7.35%
```

Closes https://github.com/grpc/grpc-go/issues/2816