### PR TITLE
stats: attach metadata to In/Out Headers/Trailers

### DIFF
--- a/internal/transport/handler_server.go
+++ b/internal/transport/handler_server.go
@@ -227,7 +227,9 @@ func (ht *serverHandlerTransport) WriteStatus(s *Stream, st *status.Status) erro
 
 	if err == nil { // transport has not been closed
 		if ht.stats != nil {
-			ht.stats.HandleRPC(s.Context(), &stats.OutTrailer{})
+			ht.stats.HandleRPC(s.Context(), &stats.OutTrailer{
+				Trailer: s.trailer.Copy(),
+			})
 		}
 	}
 	ht.Close()
@@ -289,7 +291,9 @@ func (ht *serverHandlerTransport) WriteHeader(s *Stream, md metadata.MD) error {
 
 	if err == nil {
 		if ht.stats != nil {
-			ht.stats.HandleRPC(s.Context(), &stats.OutHeader{})
+			ht.stats.HandleRPC(s.Context(), &stats.OutHeader{
+				Header: md.Copy(),
+			})
 		}
 	}
 	return err

--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -669,12 +669,14 @@ func (t *http2Client) NewStream(ctx context.Context, callHdr *CallHdr) (_ *Strea
 		}
 	}
 	if t.statsHandler != nil {
+		header, _, _ := metadata.FromOutgoingContextRaw(ctx)
 		outHeader := &stats.OutHeader{
 			Client:      true,
 			FullMethod:  callHdr.Method,
 			RemoteAddr:  t.remoteAddr,
 			LocalAddr:   t.localAddr,
 			Compression: callHdr.SendCompress,
+			Header:      header.Copy(),
 		}
 		t.statsHandler.HandleRPC(s.ctx, outHeader)
 	}
@@ -1177,12 +1179,14 @@ func (t *http2Client) operateHeaders(frame *http2.MetaHeadersFrame) {
 				inHeader := &stats.InHeader{
 					Client:     true,
 					WireLength: int(frame.Header().Length),
+					Header:     s.header.Copy(),
 				}
 				t.statsHandler.HandleRPC(s.ctx, inHeader)
 			} else {
 				inTrailer := &stats.InTrailer{
 					Client:     true,
 					WireLength: int(frame.Header().Length),
+					Trailer:    s.trailer.Copy(),
 				}
 				t.statsHandler.HandleRPC(s.ctx, inTrailer)
 			}

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -167,7 +167,7 @@ type OutTrailer struct {
 	// WireLength is the wire length of trailer.
 	WireLength int
 	// Trailer contains the trailer metadata sent to the client. This
-	// field is only valid if this InTrailer is from the server side.
+	// field is only valid if this OutTrailer is from the server side.
 	Trailer metadata.MD
 }
 

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -91,6 +91,8 @@ type InHeader struct {
 	LocalAddr net.Addr
 	// Compression is the compression algorithm used for the RPC.
 	Compression string
+	// Header contains the header metadata received.
+	Header metadata.MD
 }
 
 // IsClient indicates if the stats information is from client side.
@@ -104,6 +106,9 @@ type InTrailer struct {
 	Client bool
 	// WireLength is the wire length of trailer.
 	WireLength int
+	// Trailer contains the trailer metadata received from the server. This
+	// field is only valid if this InTrailer is from the client side.
+	Trailer metadata.MD
 }
 
 // IsClient indicates if the stats information is from client side.
@@ -146,6 +151,8 @@ type OutHeader struct {
 	LocalAddr net.Addr
 	// Compression is the compression algorithm used for the RPC.
 	Compression string
+	// Header contains the header metadata sent.
+	Header metadata.MD
 }
 
 // IsClient indicates if this stats information is from client side.
@@ -159,6 +166,9 @@ type OutTrailer struct {
 	Client bool
 	// WireLength is the wire length of trailer.
 	WireLength int
+	// Trailer contains the trailer metadata sent to the client. This
+	// field is only valid if this InTrailer is from the server side.
+	Trailer metadata.MD
 }
 
 // IsClient indicates if this stats information is from client side.

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -186,6 +186,7 @@ type End struct {
 	EndTime time.Time
 	// Trailer contains the trailer metadata received from the server. This
 	// field is only valid if this End is from the client side.
+	// Deprecated: use Trailer in InTrailer instead.
 	Trailer metadata.MD
 	// Error is the error the RPC ended with. It is an error generated from
 	// status.Status and can be converted back to status.Status using


### PR DESCRIPTION
This pull request originated with the discussion on https://github.com/grpc/grpc-go/issues/3132.

Per that conversation, currently, there isn't a good way to get at the header and trailer information in the stats handler. That information is valuable because it allows tagging telemetry (metrics, logs, and spans) by information container in the header. For example you might want to encode the peer service into a header field and then tag all metrics by peer service to allow slicing metrics by caller.

This pr attaches the header and trailer information to the `InHeader`, `InTrailer`, `OutHeader`, and `OutTrailer`, stats messages per @dfawley 's suggestion. That means that the trailer information is now attached to `InTrailer` and `End`, which is duplicate information, but I didn't want to remove it from `End` and create a backward incompatible change.

The issue only discusses attaching header metadata on the server side, but while I was in the code, I went through and attached header and trailer information on both in and out on both the client and server side. I am happy to revisit this decision and slim this change down to just the original stated issue if the scope of this change is now too big.

I noticed that is most of the places where header and trailer information is returned, a defensive copy is taken to prevent the receiver from mutating the information. That pattern is repeated in this pr, but that decision can also be reversed if that feels too expensive to make an additional copy for stats.

I don't think it's possible to send trailer information from the client to the server (only from the server to the client is possible) so that code path isn't tested or implemented.

There are a few updates to the tests that had to be made because before in and out header information was conflated (the test server returned the headers sent on the response) which made it difficult to test. Additionally, grpc appears to add additional headers so instead of testing equality, the test makes sure that all headers sent are received even if more are added.