### PR TITLE
server: Keepalive pings should be sent every [Time] period

### DIFF
--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -1369,7 +1369,6 @@ func (t *http2Client) keepalive() {
 			// acked).
 			sleepDuration := minTime(t.kp.Time, timeoutLeft)
 			timeoutLeft -= sleepDuration
-			prevNano = lastRead
 			timer.Reset(sleepDuration)
 		case <-t.ctx.Done():
 			if !timer.Stop() {

--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -47,7 +47,7 @@ import (
 
 // http2Client implements the ClientTransport interface with HTTP2.
 type http2Client struct {
-	lastRead   int64 // keep this field 64-bit aligned
+	lastRead   int64 // Keep this field 64-bit aligned. Accessed atomically.
 	ctx        context.Context
 	cancel     context.CancelFunc
 	ctxDone    <-chan struct{} // Cache the ctx.Done() chan.

--- a/internal/transport/http2_server.go
+++ b/internal/transport/http2_server.go
@@ -1010,7 +1010,6 @@ func (t *http2Server) keepalive() {
 			// acked).
 			sleepDuration := minTime(t.kp.Time, kpTimeoutLeft)
 			kpTimeoutLeft -= sleepDuration
-			prevNano = lastRead
 			kpTimer.Reset(sleepDuration)
 		case <-t.done:
 			return


### PR DESCRIPTION
This PR contains the server side changes corresponding to the client
side changes made in https://github.com/grpc/grpc-go/pull/3102.

Apart from the fix for the issue mentioned in
https://github.com/grpc/grpc-go/issues/2638, this PR also makes some
minor code cleanup and fixes the channelz test for keepalives count.