### PR TITLE
xds: Move bootstrap functionality to a new package.

### DIFF
--- a/xds/internal/balancer/xds_client.go
+++ b/xds/internal/balancer/xds_client.go
@@ -34,7 +34,7 @@ import (
 	"google.golang.org/grpc/internal/backoff"
 	"google.golang.org/grpc/internal/channelz"
 	"google.golang.org/grpc/xds/internal/balancer/lrs"
-	xdsclient "google.golang.org/grpc/xds/internal/client"
+	"google.golang.org/grpc/xds/internal/client/bootstrap"
 )
 
 const (
@@ -59,7 +59,7 @@ type client struct {
 
 	loadStore      lrs.Store
 	loadReportOnce sync.Once
-	config         *xdsclient.Config
+	config         *bootstrap.Config
 
 	mu sync.Mutex
 	cc *grpc.ClientConn
@@ -233,7 +233,7 @@ func newXDSClient(balancerName string, edsServiceName string, opts balancer.Buil
 
 	// It is possible that NewConfig returns a Config object with certain
 	// fields left unspecified. If so, we need to use some sane defaults here.
-	c.config = xdsclient.NewConfig()
+	c.config = bootstrap.NewConfig()
 	if c.config.BalancerName == "" {
 		c.config.BalancerName = balancerName
 	}

--- a/xds/internal/client/bootstrap/bootstrap.go
+++ b/xds/internal/client/bootstrap/bootstrap.go
@@ -16,9 +16,9 @@
  *
  */
 
-// Package client contains the implementation of the xds client used by
-// grpc-lb-v2.
-package client
+// Package bootstrap provides the functionality to initialize certain aspects
+// of an xDS client by reading a bootstrap file.
+package bootstrap
 
 import (
 	"bytes"
@@ -36,28 +36,26 @@ import (
 
 const (
 	// Environment variable which holds the name of the xDS bootstrap file.
-	bootstrapFileEnv = "GRPC_XDS_BOOTSTRAP"
+	fileEnv = "GRPC_XDS_BOOTSTRAP"
 	// Type name for Google default credentials.
 	googleDefaultCreds = "google_default"
 )
 
 var gRPCVersion = fmt.Sprintf("gRPC-Go %s", grpc.Version)
 
-// For overriding from unit tests.
+// For overriding in unit tests.
 var fileReadFunc = ioutil.ReadFile
 
 // Config provides the xDS client with several key bits of information that it
 // requires in its interaction with an xDS server. The Config is initialized
-// from the bootstrap file. If that process fails for any reason, it uses the
-// defaults passed in.
+// from the bootstrap file.
 type Config struct {
 	// BalancerName is the name of the xDS server to connect to.
 	BalancerName string
 	// Creds contains the credentials to be used while talking to the xDS
 	// server, as a grpc.DialOption.
 	Creds grpc.DialOption
-	// NodeProto contains the corepb.Node proto to be used in xDS calls made to the
-	// server.
+	// NodeProto contains the node proto to be used in xDS requests.
 	NodeProto *corepb.Node
 }
 
@@ -99,9 +97,9 @@ type xdsServer struct {
 func NewConfig() *Config {
 	config := &Config{}
 
-	fName, ok := os.LookupEnv(bootstrapFileEnv)
+	fName, ok := os.LookupEnv(fileEnv)
 	if !ok {
-		grpclog.Errorf("xds: %s environment variable not set", bootstrapFileEnv)
+		grpclog.Errorf("xds: %s environment variable not set", fileEnv)
 		return config
 	}
 
@@ -149,5 +147,6 @@ func NewConfig() *Config {
 		}
 	}
 
+	grpclog.Infof("xds: bootstrap.NewConfig returning: %+v", config)
 	return config
 }

--- a/xds/internal/client/bootstrap/bootstrap_test.go
+++ b/xds/internal/client/bootstrap/bootstrap_test.go
@@ -16,7 +16,7 @@
  *
  */
 
-package client
+package bootstrap
 
 import (
 	"os"
@@ -187,7 +187,7 @@ func TestNewConfig(t *testing.T) {
 	}
 	defer func() {
 		fileReadFunc = oldFileReadFunc
-		os.Unsetenv(bootstrapFileEnv)
+		os.Unsetenv(fileEnv)
 	}()
 
 	tests := []struct {
@@ -209,8 +209,8 @@ func TestNewConfig(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		if err := os.Setenv(bootstrapFileEnv, test.name); err != nil {
-			t.Fatalf("os.Setenv(%s, %s) failed with error: %v", bootstrapFileEnv, test.name, err)
+		if err := os.Setenv(fileEnv, test.name); err != nil {
+			t.Fatalf("os.Setenv(%s, %s) failed with error: %v", fileEnv, test.name, err)
 		}
 		config := NewConfig()
 		if config.BalancerName != test.wantConfig.BalancerName {
@@ -226,7 +226,7 @@ func TestNewConfig(t *testing.T) {
 }
 
 func TestNewConfigEnvNotSet(t *testing.T) {
-	os.Unsetenv(bootstrapFileEnv)
+	os.Unsetenv(fileEnv)
 	wantConfig := Config{}
 	if config := NewConfig(); *config != wantConfig {
 		t.Errorf("NewConfig() returned : %#v, wanted an empty Config object", config)


### PR DESCRIPTION
This will be useful for a few reasons:
- This package will expose a test-only function to build a good `Config` object which will be used by the `xdsResolver` while creating the `xdsClient`. We will have to change the `xdsClient` to have the `Config` dependency injected into it, instead of it being instantiated in the `NewClient` function.
- Other tests can also use this function and will not have to much around with setting the bootstrap file environment variable
