### PR TITLE
balancer: add V2Picker, ClientConn.UpdateState, SubConnState.ConnectionError

### DIFF
--- a/balancer/balancer.go
+++ b/balancer/balancer.go
@@ -120,7 +120,7 @@ type NewSubConnOptions struct {
 // State contains the balancer's state relevant to the gRPC ClientConn.
 type State struct {
 	// State controls the connectivity state of the ClientConn
-	State connectivity.State
+	ConnectivityState connectivity.State
 	// Picker is used to choose connections (SubConns) for RPCs.
 	Picker V2Picker
 }
@@ -377,8 +377,11 @@ type Balancer interface {
 
 // SubConnState describes the state of a SubConn.
 type SubConnState struct {
+	// ConnectivityState is the connectivity state of the SubConn.
 	ConnectivityState connectivity.State
-	ConnectionError   error
+	// ConnectionError is set if the ConnectivityState is TransientFailure,
+	// describing the reason the SubConn failed.  Otherwise, it is nil.
+	ConnectionError error
 }
 
 // ClientConnState describes the state of a ClientConn relevant to the

--- a/balancer/balancer.go
+++ b/balancer/balancer.go
@@ -119,7 +119,8 @@ type NewSubConnOptions struct {
 
 // State contains the balancer's state relevant to the gRPC ClientConn.
 type State struct {
-	// State controls the connectivity state of the ClientConn
+	// State contains the connectivity state of the balancer, which is used to
+	// determine the state of the ClientConn.
 	ConnectivityState connectivity.State
 	// Picker is used to choose connections (SubConns) for RPCs.
 	Picker V2Picker

--- a/balancer/balancer.go
+++ b/balancer/balancer.go
@@ -117,6 +117,14 @@ type NewSubConnOptions struct {
 	HealthCheckEnabled bool
 }
 
+// State contains the balancer's state relevant to the gRPC ClientConn.
+type State struct {
+	// State controls the connectivity state of the ClientConn
+	State connectivity.State
+	// Picker is used to choose connections (SubConns) for RPCs.
+	Picker Picker
+}
+
 // ClientConn represents a gRPC ClientConn.
 //
 // This interface is to be implemented by gRPC. Users should not need a
@@ -137,7 +145,16 @@ type ClientConn interface {
 	//
 	// gRPC will update the connectivity state of the ClientConn, and will call pick
 	// on the new picker to pick new SubConn.
+	//
+	// Deprecated: use UpdateState instead
 	UpdateBalancerState(s connectivity.State, p Picker)
+
+	// UpdateState notifies gRPC that the balancer's internal state has
+	// changed.
+	//
+	// gRPC will update the connectivity state of the ClientConn, and will call pick
+	// on the new picker to pick new SubConns.
+	UpdateState(State)
 
 	// ResolveNow is called by balancer to notify gRPC to do a name resolving.
 	ResolveNow(resolver.ResolveNowOptions)

--- a/balancer/balancer.go
+++ b/balancer/balancer.go
@@ -423,9 +423,8 @@ type V2Balancer interface {
 //
 // It's not thread safe.
 type ConnectivityStateEvaluator struct {
-	numReady            uint64 // Number of addrConns in ready state.
-	numConnecting       uint64 // Number of addrConns in connecting state.
-	numTransientFailure uint64 // Number of addrConns in transientFailure.
+	numReady      uint64 // Number of addrConns in ready state.
+	numConnecting uint64 // Number of addrConns in connecting state.
 }
 
 // RecordTransition records state change happening in subConn and based on that
@@ -445,8 +444,6 @@ func (cse *ConnectivityStateEvaluator) RecordTransition(oldState, newState conne
 			cse.numReady += updateVal
 		case connectivity.Connecting:
 			cse.numConnecting += updateVal
-		case connectivity.TransientFailure:
-			cse.numTransientFailure += updateVal
 		}
 	}
 

--- a/balancer/base/balancer.go
+++ b/balancer/base/balancer.go
@@ -82,7 +82,8 @@ func (b *baseBalancer) HandleResolvedAddrs(addrs []resolver.Address, err error) 
 }
 
 func (b *baseBalancer) ResolverError(err error) {
-	if b.state == connectivity.TransientFailure {
+	switch b.state {
+	case connectivity.TransientFailure, connectivity.Idle, connectivity.Connecting:
 		if b.picker != nil {
 			b.picker = NewErrPicker(err)
 		} else {
@@ -195,7 +196,7 @@ func (b *baseBalancer) UpdateSubConnState(sc balancer.SubConn, state balancer.Su
 	if b.picker != nil {
 		b.cc.UpdateBalancerState(b.state, b.picker)
 	} else {
-		b.cc.UpdateState(balancer.State{State: b.state, Picker: b.v2Picker})
+		b.cc.UpdateState(balancer.State{ConnectivityState: b.state, Picker: b.v2Picker})
 	}
 }
 

--- a/balancer/base/balancer.go
+++ b/balancer/base/balancer.go
@@ -169,7 +169,7 @@ func (b *baseBalancer) UpdateSubConnState(sc balancer.SubConn, state balancer.Su
 		b.regeneratePicker()
 	}
 
-	b.cc.UpdateBalancerState(b.state, b.picker)
+	b.cc.UpdateState(balancer.State{State: b.state, Picker: b.picker})
 }
 
 // Close is a nop because base balancer doesn't have internal state to clean up,

--- a/balancer/base/base.go
+++ b/balancer/base/base.go
@@ -42,10 +42,27 @@ type PickerBuilder interface {
 	Build(readySCs map[resolver.Address]balancer.SubConn) balancer.Picker
 }
 
+// V2PickerBuilder creates balancer.V2Picker.
+type V2PickerBuilder interface {
+	// Build takes a slice of ready SubConns, and returns a picker that will be
+	// used by gRPC to pick a SubConn.
+	Build(readySCs map[resolver.Address]balancer.SubConn, opts PickerBuildOptions) balancer.V2Picker
+}
+
+// PickerBuildOptions contains optional information needed by the picker
+// builder to construct a picker.
+type PickerBuildOptions struct{}
+
 // NewBalancerBuilder returns a balancer builder. The balancers
 // built by this builder will use the picker builder to build pickers.
 func NewBalancerBuilder(name string, pb PickerBuilder) balancer.Builder {
 	return NewBalancerBuilderWithConfig(name, pb, Config{})
+}
+
+// NewBalancerBuilderV2 returns a balancer builder. The balancers
+// built by this builder will use the picker builder to build pickers.
+func NewBalancerBuilderV2(name string, pb V2PickerBuilder) balancer.Builder {
+	return NewBalancerBuilderWithConfigV2(name, pb, Config{})
 }
 
 // Config contains the config info about the base balancer builder.
@@ -60,5 +77,14 @@ func NewBalancerBuilderWithConfig(name string, pb PickerBuilder, config Config) 
 		name:          name,
 		pickerBuilder: pb,
 		config:        config,
+	}
+}
+
+// NewBalancerBuilderWithConfigV2 returns a base balancer builder configured by the provided config.
+func NewBalancerBuilderWithConfigV2(name string, pb V2PickerBuilder, config Config) balancer.Builder {
+	return &baseBuilder{
+		name:            name,
+		v2PickerBuilder: pb,
+		config:          config,
 	}
 }

--- a/balancer/base/base.go
+++ b/balancer/base/base.go
@@ -46,12 +46,12 @@ type PickerBuilder interface {
 type V2PickerBuilder interface {
 	// Build takes a slice of ready SubConns, and returns a picker that will be
 	// used by gRPC to pick a SubConn.
-	Build(readySCs map[resolver.Address]balancer.SubConn, opts PickerBuildOptions) balancer.V2Picker
+	Build(readySCs map[resolver.Address]balancer.SubConn, info PickerBuildInfo) balancer.V2Picker
 }
 
-// PickerBuildOptions contains optional information needed by the picker
-// builder to construct a picker.
-type PickerBuildOptions struct{}
+// PickerBuildInfo contains information needed by the picker builder to
+// construct a picker.
+type PickerBuildInfo struct{}
 
 // NewBalancerBuilder returns a balancer builder. The balancers
 // built by this builder will use the picker builder to build pickers.

--- a/balancer/base/base.go
+++ b/balancer/base/base.go
@@ -44,25 +44,28 @@ type PickerBuilder interface {
 
 // V2PickerBuilder creates balancer.V2Picker.
 type V2PickerBuilder interface {
-	// Build takes a slice of ready SubConns, and returns a picker that will be
-	// used by gRPC to pick a SubConn.
-	Build(readySCs map[resolver.Address]balancer.SubConn, info PickerBuildInfo) balancer.V2Picker
+	// Build returns a picker that will be used by gRPC to pick a SubConn.
+	Build(info PickerBuildInfo) balancer.V2Picker
 }
 
 // PickerBuildInfo contains information needed by the picker builder to
 // construct a picker.
-type PickerBuildInfo struct{}
+type PickerBuildInfo struct {
+	// ReadySCs is a map from all ready SubConns to the Addresses used to
+	// create them.
+	ReadySCs map[balancer.SubConn]SubConnInfo
+}
+
+// SubConnInfo contains information about a SubConn created by the base
+// balancer.
+type SubConnInfo struct {
+	Address resolver.Address // the address used to create this SubConn
+}
 
 // NewBalancerBuilder returns a balancer builder. The balancers
 // built by this builder will use the picker builder to build pickers.
 func NewBalancerBuilder(name string, pb PickerBuilder) balancer.Builder {
 	return NewBalancerBuilderWithConfig(name, pb, Config{})
-}
-
-// NewBalancerBuilderV2 returns a balancer builder. The balancers
-// built by this builder will use the picker builder to build pickers.
-func NewBalancerBuilderV2(name string, pb V2PickerBuilder) balancer.Builder {
-	return NewBalancerBuilderWithConfigV2(name, pb, Config{})
 }
 
 // Config contains the config info about the base balancer builder.
@@ -80,8 +83,8 @@ func NewBalancerBuilderWithConfig(name string, pb PickerBuilder, config Config) 
 	}
 }
 
-// NewBalancerBuilderWithConfigV2 returns a base balancer builder configured by the provided config.
-func NewBalancerBuilderWithConfigV2(name string, pb V2PickerBuilder, config Config) balancer.Builder {
+// NewBalancerBuilderV2 returns a base balancer builder configured by the provided config.
+func NewBalancerBuilderV2(name string, pb V2PickerBuilder, config Config) balancer.Builder {
 	return &baseBuilder{
 		name:            name,
 		v2PickerBuilder: pb,

--- a/balancer/grpclb/grpclb.go
+++ b/balancer/grpclb/grpclb.go
@@ -369,7 +369,7 @@ func (lb *lbBalancer) updateStateAndPicker(forceRegeneratePicker bool, resetDrop
 		lb.regeneratePicker(resetDrop)
 	}
 
-	lb.cc.UpdateState(balancer.State{State: lb.state, Picker: lb.picker})
+	lb.cc.UpdateState(balancer.State{ConnectivityState: lb.state, Picker: lb.picker})
 }
 
 // fallbackToBackendsAfter blocks for fallbackTimeout and falls back to use

--- a/balancer/grpclb/grpclb.go
+++ b/balancer/grpclb/grpclb.go
@@ -369,7 +369,7 @@ func (lb *lbBalancer) updateStateAndPicker(forceRegeneratePicker bool, resetDrop
 		lb.regeneratePicker(resetDrop)
 	}
 
-	lb.cc.UpdateBalancerState(lb.state, lb.picker)
+	lb.cc.UpdateState(balancer.State{State: lb.state, Picker: lb.picker})
 }
 
 // fallbackToBackendsAfter blocks for fallbackTimeout and falls back to use

--- a/balancer/grpclb/grpclb.go
+++ b/balancer/grpclb/grpclb.go
@@ -214,7 +214,7 @@ type lbBalancer struct {
 	state    connectivity.State
 	subConns map[resolver.Address]balancer.SubConn   // Used to new/remove SubConn.
 	scStates map[balancer.SubConn]connectivity.State // Used to filter READY SubConns.
-	picker   balancer.Picker
+	picker   balancer.V2Picker
 	// Support fallback to resolved backend addresses if there's no response
 	// from remote balancer within fallbackTimeout.
 	remoteBalancerConnected bool

--- a/balancer/grpclb/grpclb_util.go
+++ b/balancer/grpclb/grpclb_util.go
@@ -24,7 +24,6 @@ import (
 	"time"
 
 	"google.golang.org/grpc/balancer"
-	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/resolver"
 )
 
@@ -195,8 +194,8 @@ func (ccc *lbCacheClientConn) RemoveSubConn(sc balancer.SubConn) {
 	}
 }
 
-func (ccc *lbCacheClientConn) UpdateBalancerState(s connectivity.State, p balancer.Picker) {
-	ccc.cc.UpdateBalancerState(s, p)
+func (ccc *lbCacheClientConn) UpdateState(s balancer.State) {
+	ccc.cc.UpdateState(s)
 }
 
 func (ccc *lbCacheClientConn) close() {

--- a/balancer/roundrobin/roundrobin.go
+++ b/balancer/roundrobin/roundrobin.go
@@ -45,7 +45,7 @@ func init() {
 
 type rrPickerBuilder struct{}
 
-func (*rrPickerBuilder) Build(readySCs map[resolver.Address]balancer.SubConn, _ base.PickerBuildOptions) balancer.V2Picker {
+func (*rrPickerBuilder) Build(readySCs map[resolver.Address]balancer.SubConn, _ base.PickerBuildInfo) balancer.V2Picker {
 	grpclog.Infof("roundrobinPicker: newPicker called with readySCs: %v", readySCs)
 	if len(readySCs) == 0 {
 		return base.NewErrPickerV2(balancer.ErrNoSubConnAvailable)

--- a/balancer/roundrobin/roundrobin.go
+++ b/balancer/roundrobin/roundrobin.go
@@ -28,7 +28,6 @@ import (
 	"google.golang.org/grpc/balancer/base"
 	"google.golang.org/grpc/grpclog"
 	"google.golang.org/grpc/internal/grpcrand"
-	"google.golang.org/grpc/resolver"
 )
 
 // Name is the name of round_robin balancer.
@@ -36,7 +35,7 @@ const Name = "round_robin"
 
 // newBuilder creates a new roundrobin balancer builder.
 func newBuilder() balancer.Builder {
-	return base.NewBalancerBuilderWithConfigV2(Name, &rrPickerBuilder{}, base.Config{HealthCheck: true})
+	return base.NewBalancerBuilderV2(Name, &rrPickerBuilder{}, base.Config{HealthCheck: true})
 }
 
 func init() {
@@ -45,13 +44,13 @@ func init() {
 
 type rrPickerBuilder struct{}
 
-func (*rrPickerBuilder) Build(readySCs map[resolver.Address]balancer.SubConn, _ base.PickerBuildInfo) balancer.V2Picker {
-	grpclog.Infof("roundrobinPicker: newPicker called with readySCs: %v", readySCs)
-	if len(readySCs) == 0 {
+func (*rrPickerBuilder) Build(info base.PickerBuildInfo) balancer.V2Picker {
+	grpclog.Infof("roundrobinPicker: newPicker called with info: %v", info)
+	if len(info.ReadySCs) == 0 {
 		return base.NewErrPickerV2(balancer.ErrNoSubConnAvailable)
 	}
 	var scs []balancer.SubConn
-	for _, sc := range readySCs {
+	for sc := range info.ReadySCs {
 		scs = append(scs, sc)
 	}
 	return &rrPicker{

--- a/balancer_conn_wrappers.go
+++ b/balancer_conn_wrappers.go
@@ -174,18 +174,7 @@ func (ccb *ccBalancerWrapper) RemoveSubConn(sc balancer.SubConn) {
 }
 
 func (ccb *ccBalancerWrapper) UpdateBalancerState(s connectivity.State, p balancer.Picker) {
-	ccb.mu.Lock()
-	defer ccb.mu.Unlock()
-	if ccb.subConns == nil {
-		return
-	}
-	// Update picker before updating state.  Even though the ordering here does
-	// not matter, it can lead to multiple calls of Pick in the common start-up
-	// case where we wait for ready and then perform an RPC.  If the picker is
-	// updated later, we could call the "connecting" picker when the state is
-	// updated, and then call the "ready" picker after the picker gets updated.
-	ccb.cc.blockingpicker.updatePicker(p)
-	ccb.cc.csMgr.updateState(s)
+	ccb.UpdateState(balancer.State{ConnectivityState: s, Picker: p})
 }
 
 func (ccb *ccBalancerWrapper) UpdateState(s balancer.State) {

--- a/balancer_conn_wrappers.go
+++ b/balancer_conn_wrappers.go
@@ -174,7 +174,18 @@ func (ccb *ccBalancerWrapper) RemoveSubConn(sc balancer.SubConn) {
 }
 
 func (ccb *ccBalancerWrapper) UpdateBalancerState(s connectivity.State, p balancer.Picker) {
-	ccb.UpdateState(balancer.State{ConnectivityState: s, Picker: p})
+	ccb.mu.Lock()
+	defer ccb.mu.Unlock()
+	if ccb.subConns == nil {
+		return
+	}
+	// Update picker before updating state.  Even though the ordering here does
+	// not matter, it can lead to multiple calls of Pick in the common start-up
+	// case where we wait for ready and then perform an RPC.  If the picker is
+	// updated later, we could call the "connecting" picker when the state is
+	// updated, and then call the "ready" picker after the picker gets updated.
+	ccb.cc.blockingpicker.updatePicker(p)
+	ccb.cc.csMgr.updateState(s)
 }
 
 func (ccb *ccBalancerWrapper) UpdateState(s balancer.State) {

--- a/balancer_conn_wrappers.go
+++ b/balancer_conn_wrappers.go
@@ -92,7 +92,7 @@ func (ccb *ccBalancerWrapper) watcher() {
 			for acbw := range scs {
 				ccb.cc.removeAddrConn(acbw.getAddrConn(), errConnDrain)
 			}
-			ccb.UpdateState(balancer.State{State: connectivity.Connecting, Picker: nil})
+			ccb.UpdateState(balancer.State{ConnectivityState: connectivity.Connecting, Picker: nil})
 			return
 		}
 	}
@@ -200,7 +200,7 @@ func (ccb *ccBalancerWrapper) UpdateState(s balancer.State) {
 	// updated later, we could call the "connecting" picker when the state is
 	// updated, and then call the "ready" picker after the picker gets updated.
 	ccb.cc.blockingpicker.updatePickerV2(s.Picker)
-	ccb.cc.csMgr.updateState(s.State)
+	ccb.cc.csMgr.updateState(s.ConnectivityState)
 }
 
 func (ccb *ccBalancerWrapper) ResolveNow(o resolver.ResolveNowOptions) {

--- a/balancer_conn_wrappers.go
+++ b/balancer_conn_wrappers.go
@@ -172,6 +172,10 @@ func (ccb *ccBalancerWrapper) RemoveSubConn(sc balancer.SubConn) {
 }
 
 func (ccb *ccBalancerWrapper) UpdateBalancerState(s connectivity.State, p balancer.Picker) {
+	ccb.UpdateState(balancer.State{State: s, Picker: p})
+}
+
+func (ccb *ccBalancerWrapper) UpdateState(s balancer.State) {
 	ccb.mu.Lock()
 	defer ccb.mu.Unlock()
 	if ccb.subConns == nil {
@@ -182,8 +186,8 @@ func (ccb *ccBalancerWrapper) UpdateBalancerState(s connectivity.State, p balanc
 	// case where we wait for ready and then perform an RPC.  If the picker is
 	// updated later, we could call the "connecting" picker when the state is
 	// updated, and then call the "ready" picker after the picker gets updated.
-	ccb.cc.blockingpicker.updatePicker(p)
-	ccb.cc.csMgr.updateState(s)
+	ccb.cc.blockingpicker.updatePicker(s.Picker)
+	ccb.cc.csMgr.updateState(s.State)
 }
 
 func (ccb *ccBalancerWrapper) ResolveNow(o resolver.ResolveNowOptions) {

--- a/balancer_conn_wrappers.go
+++ b/balancer_conn_wrappers.go
@@ -91,7 +91,7 @@ func (ccb *ccBalancerWrapper) watcher() {
 			for acbw := range scs {
 				ccb.cc.removeAddrConn(acbw.getAddrConn(), errConnDrain)
 			}
-			ccb.UpdateBalancerState(connectivity.Connecting, nil)
+			ccb.UpdateState(balancer.State{State: connectivity.Connecting, Picker: nil})
 			return
 		}
 	}

--- a/balancer_conn_wrappers_test.go
+++ b/balancer_conn_wrappers_test.go
@@ -43,9 +43,7 @@ func (*funcBalancer) HandleResolvedAddrs([]resolver.Address, error) {
 func (b *funcBalancer) UpdateClientConnState(s balancer.ClientConnState) error {
 	return b.updateClientConnState(s)
 }
-func (*funcBalancer) ResolverError(error) {
-	panic("unimplemented") // resolver never reports error
-}
+func (*funcBalancer) ResolverError(error) {}
 func (*funcBalancer) UpdateSubConnState(balancer.SubConn, balancer.SubConnState) {
 	panic("unimplemented") // we never have sub-conns
 }

--- a/balancer_switching_test.go
+++ b/balancer_switching_test.go
@@ -28,7 +28,6 @@ import (
 	"google.golang.org/grpc/balancer"
 	"google.golang.org/grpc/balancer/roundrobin"
 	"google.golang.org/grpc/connectivity"
-	_ "google.golang.org/grpc/grpclog/glogger"
 	"google.golang.org/grpc/internal"
 	"google.golang.org/grpc/resolver"
 	"google.golang.org/grpc/resolver/manual"

--- a/balancer_test.go
+++ b/balancer_test.go
@@ -28,7 +28,6 @@ import (
 	"time"
 
 	"google.golang.org/grpc/codes"
-	_ "google.golang.org/grpc/grpclog/glogger"
 	"google.golang.org/grpc/naming"
 	"google.golang.org/grpc/status"
 )

--- a/balancer_v1_wrapper.go
+++ b/balancer_v1_wrapper.go
@@ -48,7 +48,7 @@ func (bwb *balancerWrapperBuilder) Build(cc balancer.ClientConn, opts balancer.B
 		csEvltr:    &balancer.ConnectivityStateEvaluator{},
 		state:      connectivity.Idle,
 	}
-	cc.UpdateState(balancer.State{State: connectivity.Idle, Picker: bw})
+	cc.UpdateState(balancer.State{ConnectivityState: connectivity.Idle, Picker: bw})
 	go bw.lbWatcher()
 	return bw
 }
@@ -242,7 +242,7 @@ func (bw *balancerWrapper) HandleSubConnStateChange(sc balancer.SubConn, s conne
 	if bw.state != sa {
 		bw.state = sa
 	}
-	bw.cc.UpdateState(balancer.State{State: bw.state, Picker: bw})
+	bw.cc.UpdateState(balancer.State{ConnectivityState: bw.state, Picker: bw})
 	if s == connectivity.Shutdown {
 		// Remove state for this sc.
 		delete(bw.connSt, sc)

--- a/balancer_v1_wrapper.go
+++ b/balancer_v1_wrapper.go
@@ -19,7 +19,6 @@
 package grpc
 
 import (
-	"context"
 	"sync"
 
 	"google.golang.org/grpc/balancer"
@@ -275,17 +274,17 @@ func (bw *balancerWrapper) Close() {
 
 // The picker is the balancerWrapper itself.
 // It either blocks or returns error, consistent with v1 balancer Get().
-func (bw *balancerWrapper) Pick(ctx context.Context, opts balancer.PickOptions) (sc balancer.SubConn, done func(balancer.DoneInfo), err error) {
+func (bw *balancerWrapper) Pick(info balancer.PickInfo) (result balancer.PickResult, err error) {
 	failfast := true // Default failfast is true.
-	if ss, ok := rpcInfoFromContext(ctx); ok {
+	if ss, ok := rpcInfoFromContext(info.Ctx); ok {
 		failfast = ss.failfast
 	}
-	a, p, err := bw.balancer.Get(ctx, BalancerGetOptions{BlockingWait: !failfast})
+	a, p, err := bw.balancer.Get(info.Ctx, BalancerGetOptions{BlockingWait: !failfast})
 	if err != nil {
-		return nil, nil, err
+		return balancer.PickResult{}, toRPCErr(err)
 	}
 	if p != nil {
-		done = func(balancer.DoneInfo) { p() }
+		result.Done = func(balancer.DoneInfo) { p() }
 		defer func() {
 			if err != nil {
 				p()
@@ -297,38 +296,39 @@ func (bw *balancerWrapper) Pick(ctx context.Context, opts balancer.PickOptions) 
 	defer bw.mu.Unlock()
 	if bw.pickfirst {
 		// Get the first sc in conns.
-		for _, sc := range bw.conns {
-			return sc, done, nil
+		for _, result.SubConn = range bw.conns {
+			return result, nil
 		}
-		return nil, nil, balancer.ErrNoSubConnAvailable
+		return balancer.PickResult{}, balancer.ErrNoSubConnAvailable
 	}
-	sc, ok1 := bw.conns[resolver.Address{
+	var ok1 bool
+	result.SubConn, ok1 = bw.conns[resolver.Address{
 		Addr:       a.Addr,
 		Type:       resolver.Backend,
 		ServerName: "",
 		Metadata:   a.Metadata,
 	}]
-	s, ok2 := bw.connSt[sc]
+	s, ok2 := bw.connSt[result.SubConn]
 	if !ok1 || !ok2 {
 		// This can only happen due to a race where Get() returned an address
 		// that was subsequently removed by Notify.  In this case we should
 		// retry always.
-		return nil, nil, balancer.ErrNoSubConnAvailable
+		return balancer.PickResult{}, balancer.ErrNoSubConnAvailable
 	}
 	switch s.s {
 	case connectivity.Ready, connectivity.Idle:
-		return sc, done, nil
+		return result, nil
 	case connectivity.Shutdown, connectivity.TransientFailure:
 		// If the returned sc has been shut down or is in transient failure,
 		// return error, and this RPC will fail or wait for another picker (if
 		// non-failfast).
-		return nil, nil, balancer.ErrTransientFailure
+		return balancer.PickResult{}, balancer.ErrTransientFailure
 	default:
 		// For other states (connecting or unknown), the v1 balancer would
 		// traditionally wait until ready and then issue the RPC.  Returning
 		// ErrNoSubConnAvailable will be a slight improvement in that it will
 		// allow the balancer to choose another address in case others are
 		// connected.
-		return nil, nil, balancer.ErrNoSubConnAvailable
+		return balancer.PickResult{}, balancer.ErrNoSubConnAvailable
 	}
 }

--- a/balancer_v1_wrapper.go
+++ b/balancer_v1_wrapper.go
@@ -49,7 +49,7 @@ func (bwb *balancerWrapperBuilder) Build(cc balancer.ClientConn, opts balancer.B
 		csEvltr:    &balancer.ConnectivityStateEvaluator{},
 		state:      connectivity.Idle,
 	}
-	cc.UpdateBalancerState(connectivity.Idle, bw)
+	cc.UpdateState(balancer.State{State: connectivity.Idle, Picker: bw})
 	go bw.lbWatcher()
 	return bw
 }
@@ -243,7 +243,7 @@ func (bw *balancerWrapper) HandleSubConnStateChange(sc balancer.SubConn, s conne
 	if bw.state != sa {
 		bw.state = sa
 	}
-	bw.cc.UpdateBalancerState(bw.state, bw)
+	bw.cc.UpdateState(balancer.State{State: bw.state, Picker: bw})
 	if s == connectivity.Shutdown {
 		// Remove state for this sc.
 		delete(bw.connSt, sc)

--- a/clientconn.go
+++ b/clientconn.go
@@ -688,7 +688,7 @@ func (cc *ClientConn) switchBalancer(name string) {
 	cc.balancerWrapper = newCCBalancerWrapper(cc, builder, cc.balancerBuildOpts)
 }
 
-func (cc *ClientConn) handleSubConnStateChange(sc balancer.SubConn, s connectivity.State) {
+func (cc *ClientConn) handleSubConnStateChange(sc balancer.SubConn, s connectivity.State, err error) {
 	cc.mu.Lock()
 	if cc.conns == nil {
 		cc.mu.Unlock()
@@ -696,7 +696,7 @@ func (cc *ClientConn) handleSubConnStateChange(sc balancer.SubConn, s connectivi
 	}
 	// TODO(bar switching) send updates to all balancer wrappers when balancer
 	// gracefully switching is supported.
-	cc.balancerWrapper.handleSubConnStateChange(sc, s)
+	cc.balancerWrapper.handleSubConnStateChange(sc, s, err)
 	cc.mu.Unlock()
 }
 
@@ -793,7 +793,7 @@ func (ac *addrConn) connect() error {
 	}
 	// Update connectivity state within the lock to prevent subsequent or
 	// concurrent calls from resetting the transport more than once.
-	ac.updateConnectivityState(connectivity.Connecting)
+	ac.updateConnectivityState(connectivity.Connecting, nil)
 	ac.mu.Unlock()
 
 	// Start a goroutine connecting to the server asynchronously.
@@ -879,7 +879,8 @@ func (cc *ClientConn) healthCheckConfig() *healthCheckConfig {
 }
 
 func (cc *ClientConn) getTransport(ctx context.Context, failfast bool, method string) (transport.ClientTransport, func(balancer.DoneInfo), error) {
-	t, done, err := cc.blockingpicker.pick(ctx, failfast, balancer.PickOptions{
+	t, done, err := cc.blockingpicker.pick(ctx, failfast, balancer.PickInfo{
+		Ctx:            ctx,
 		FullMethodName: method,
 	})
 	if err != nil {
@@ -1048,7 +1049,7 @@ type addrConn struct {
 }
 
 // Note: this requires a lock on ac.mu.
-func (ac *addrConn) updateConnectivityState(s connectivity.State) {
+func (ac *addrConn) updateConnectivityState(s connectivity.State, lastErr error) {
 	if ac.state == s {
 		return
 	}
@@ -1061,7 +1062,7 @@ func (ac *addrConn) updateConnectivityState(s connectivity.State) {
 			Severity: channelz.CtINFO,
 		})
 	}
-	ac.cc.handleSubConnStateChange(ac.acbw, s)
+	ac.cc.handleSubConnStateChange(ac.acbw, s, lastErr)
 }
 
 // adjustParams updates parameters used to create transports upon
@@ -1110,7 +1111,7 @@ func (ac *addrConn) resetTransport() {
 		// https://github.com/grpc/grpc/blob/master/doc/connection-backoff.md#proposed-backoff-algorithm
 		connectDeadline := time.Now().Add(dialDuration)
 
-		ac.updateConnectivityState(connectivity.Connecting)
+		ac.updateConnectivityState(connectivity.Connecting, nil)
 		ac.transport = nil
 		ac.mu.Unlock()
 
@@ -1123,7 +1124,7 @@ func (ac *addrConn) resetTransport() {
 				ac.mu.Unlock()
 				return
 			}
-			ac.updateConnectivityState(connectivity.TransientFailure)
+			ac.updateConnectivityState(connectivity.TransientFailure, err)
 
 			// Backoff.
 			b := ac.resetBackoff
@@ -1179,6 +1180,7 @@ func (ac *addrConn) resetTransport() {
 // first successful one. It returns the transport, the address and a Event in
 // the successful case. The Event fires when the returned transport disconnects.
 func (ac *addrConn) tryAllAddrs(addrs []resolver.Address, connectDeadline time.Time) (transport.ClientTransport, resolver.Address, *grpcsync.Event, error) {
+	var firstConnErr error
 	for _, addr := range addrs {
 		ac.mu.Lock()
 		if ac.state == connectivity.Shutdown {
@@ -1207,11 +1209,14 @@ func (ac *addrConn) tryAllAddrs(addrs []resolver.Address, connectDeadline time.T
 		if err == nil {
 			return newTr, addr, reconnect, nil
 		}
+		if firstConnErr == nil {
+			firstConnErr = err
+		}
 		ac.cc.blockingpicker.updateConnectionError(err)
 	}
 
 	// Couldn't connect to any address.
-	return nil, resolver.Address{}, nil, fmt.Errorf("couldn't connect to any address")
+	return nil, resolver.Address{}, nil, firstConnErr
 }
 
 // createTransport creates a connection to addr. It returns the transport and a
@@ -1244,7 +1249,7 @@ func (ac *addrConn) createTransport(addr resolver.Address, copts transport.Conne
 				// state to Connecting.
 				//
 				// TODO: this should be Idle when grpc-go properly supports it.
-				ac.updateConnectivityState(connectivity.Connecting)
+				ac.updateConnectivityState(connectivity.Connecting, nil)
 			}
 		})
 		ac.mu.Unlock()
@@ -1259,7 +1264,7 @@ func (ac *addrConn) createTransport(addr resolver.Address, copts transport.Conne
 				// state to Connecting.
 				//
 				// TODO: this should be Idle when grpc-go properly supports it.
-				ac.updateConnectivityState(connectivity.Connecting)
+				ac.updateConnectivityState(connectivity.Connecting, nil)
 			}
 		})
 		ac.mu.Unlock()
@@ -1316,7 +1321,7 @@ func (ac *addrConn) startHealthCheck(ctx context.Context) {
 	var healthcheckManagingState bool
 	defer func() {
 		if !healthcheckManagingState {
-			ac.updateConnectivityState(connectivity.Ready)
+			ac.updateConnectivityState(connectivity.Ready, nil)
 		}
 	}()
 
@@ -1352,13 +1357,13 @@ func (ac *addrConn) startHealthCheck(ctx context.Context) {
 		ac.mu.Unlock()
 		return newNonRetryClientStream(ctx, &StreamDesc{ServerStreams: true}, method, currentTr, ac)
 	}
-	setConnectivityState := func(s connectivity.State) {
+	setConnectivityState := func(s connectivity.State, lastErr error) {
 		ac.mu.Lock()
 		defer ac.mu.Unlock()
 		if ac.transport != currentTr {
 			return
 		}
-		ac.updateConnectivityState(s)
+		ac.updateConnectivityState(s, lastErr)
 	}
 	// Start the health checking stream.
 	go func() {
@@ -1424,7 +1429,7 @@ func (ac *addrConn) tearDown(err error) {
 	ac.transport = nil
 	// We have to set the state to Shutdown before anything else to prevent races
 	// between setting the state and logic that waits on context cancellation / etc.
-	ac.updateConnectivityState(connectivity.Shutdown)
+	ac.updateConnectivityState(connectivity.Shutdown, nil)
 	ac.cancel()
 	ac.curAddr = resolver.Address{}
 	if err == errConnDrain && curTr != nil {

--- a/grpc_test.go
+++ b/grpc_test.go
@@ -24,6 +24,8 @@ import (
 
 	"google.golang.org/grpc/internal/grpctest"
 	"google.golang.org/grpc/internal/leakcheck"
+
+	_ "google.golang.org/grpc/grpclog/glogger"
 )
 
 type s struct{}

--- a/health/client.go
+++ b/health/client.go
@@ -20,7 +20,6 @@ package health
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"time"
@@ -102,7 +101,7 @@ retryConnection:
 
 			// Reports unhealthy if server's Watch method gives an error other than UNIMPLEMENTED.
 			if err != nil {
-				setConnectivityState(connectivity.TransientFailure, errors.New("health check RPC error"))
+				setConnectivityState(connectivity.TransientFailure, fmt.Errorf("connection active but received health check RPC error: %v", err))
 				continue retryConnection
 			}
 
@@ -111,7 +110,7 @@ retryConnection:
 			if resp.Status == healthpb.HealthCheckResponse_SERVING {
 				setConnectivityState(connectivity.Ready, nil)
 			} else {
-				setConnectivityState(connectivity.TransientFailure, errors.New("health check failed"))
+				setConnectivityState(connectivity.TransientFailure, fmt.Errorf("connection active but health check failed. status=%s", resp.Status))
 			}
 		}
 	}

--- a/health/client_test.go
+++ b/health/client_test.go
@@ -51,7 +51,7 @@ func TestClientHealthCheckBackoff(t *testing.T) {
 	}
 	defer func() { backoffFunc = oldBackoffFunc }()
 
-	clientHealthCheck(context.Background(), newStream, func(connectivity.State) {}, "test")
+	clientHealthCheck(context.Background(), newStream, func(connectivity.State, error) {}, "test")
 
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("Backoff durations for %v retries are %v. (expected: %v)", maxRetries, got, want)

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -60,7 +60,7 @@ var (
 //
 // The health checking protocol is defined at:
 // https://github.com/grpc/grpc/blob/master/doc/health-checking.md
-type HealthChecker func(ctx context.Context, newStream func(string) (interface{}, error), setConnectivityState func(connectivity.State), serviceName string) error
+type HealthChecker func(ctx context.Context, newStream func(string) (interface{}, error), setConnectivityState func(connectivity.State, error), serviceName string) error
 
 const (
 	// CredsBundleModeFallback switches GoogleDefaultCreds to fallback mode.

--- a/picker_wrapper.go
+++ b/picker_wrapper.go
@@ -20,6 +20,7 @@ package grpc
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"sync"
 
@@ -31,49 +32,79 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+type v2PickerWrapper struct {
+	picker balancer.Picker
+	pw     *pickerWrapper // for accessing the latest connection error
+}
+
+func (v *v2PickerWrapper) Pick(info balancer.PickInfo) (balancer.PickResult, error) {
+	sc, done, err := v.picker.Pick(info.Ctx, info)
+	if err != nil {
+		if err == balancer.ErrTransientFailure {
+			return balancer.PickResult{}, balancer.TransientFailureError(fmt.Errorf("%v, latest connection error: %v", err, v.pw.connectionError()))
+		}
+		return balancer.PickResult{}, err
+	}
+	return balancer.PickResult{SubConn: sc, Done: done}, nil
+}
+
 // pickerWrapper is a wrapper of balancer.Picker. It blocks on certain pick
 // actions and unblock when there's a picker update.
 type pickerWrapper struct {
 	mu         sync.Mutex
 	done       bool
 	blockingCh chan struct{}
-	picker     balancer.Picker
+	picker     balancer.V2Picker
 
-	// The latest connection happened.
+	// The latest connection error.  TODO: remove when V1 picker is deprecated;
+	// balancer should be responsible for providing the error.
 	connErrMu sync.Mutex
 	connErr   error
 }
 
 func newPickerWrapper() *pickerWrapper {
-	bp := &pickerWrapper{blockingCh: make(chan struct{})}
-	return bp
+	return &pickerWrapper{blockingCh: make(chan struct{})}
 }
 
-func (bp *pickerWrapper) updateConnectionError(err error) {
-	bp.connErrMu.Lock()
-	bp.connErr = err
-	bp.connErrMu.Unlock()
+func (pw *pickerWrapper) updateConnectionError(err error) {
+	pw.connErrMu.Lock()
+	pw.connErr = err
+	pw.connErrMu.Unlock()
 }
 
-func (bp *pickerWrapper) connectionError() error {
-	bp.connErrMu.Lock()
-	err := bp.connErr
-	bp.connErrMu.Unlock()
+func (pw *pickerWrapper) connectionError() error {
+	pw.connErrMu.Lock()
+	err := pw.connErr
+	pw.connErrMu.Unlock()
 	return err
 }
 
 // updatePicker is called by UpdateBalancerState. It unblocks all blocked pick.
-func (bp *pickerWrapper) updatePicker(p balancer.Picker) {
-	bp.mu.Lock()
-	if bp.done {
-		bp.mu.Unlock()
+func (pw *pickerWrapper) updatePicker(p balancer.Picker) {
+	pw.mu.Lock()
+	if pw.done {
+		pw.mu.Unlock()
 		return
 	}
-	bp.picker = p
-	// bp.blockingCh should never be nil.
-	close(bp.blockingCh)
-	bp.blockingCh = make(chan struct{})
-	bp.mu.Unlock()
+	pw.picker = &v2PickerWrapper{picker: p, pw: pw}
+	// pw.blockingCh should never be nil.
+	close(pw.blockingCh)
+	pw.blockingCh = make(chan struct{})
+	pw.mu.Unlock()
+}
+
+// updatePicker is called by UpdateBalancerState. It unblocks all blocked pick.
+func (pw *pickerWrapper) updatePickerV2(p balancer.V2Picker) {
+	pw.mu.Lock()
+	if pw.done {
+		pw.mu.Unlock()
+		return
+	}
+	pw.picker = p
+	// pw.blockingCh should never be nil.
+	close(pw.blockingCh)
+	pw.blockingCh = make(chan struct{})
+	pw.mu.Unlock()
 }
 
 func doneChannelzWrapper(acw *acBalancerWrapper, done func(balancer.DoneInfo)) func(balancer.DoneInfo) {
@@ -100,83 +131,85 @@ func doneChannelzWrapper(acw *acBalancerWrapper, done func(balancer.DoneInfo)) f
 // - the current picker returns other errors and failfast is false.
 // - the subConn returned by the current picker is not READY
 // When one of these situations happens, pick blocks until the picker gets updated.
-func (bp *pickerWrapper) pick(ctx context.Context, failfast bool, opts balancer.PickOptions) (transport.ClientTransport, func(balancer.DoneInfo), error) {
+func (pw *pickerWrapper) pick(ctx context.Context, failfast bool, info balancer.PickInfo) (transport.ClientTransport, func(balancer.DoneInfo), error) {
 	var ch chan struct{}
 
+	var lastPickErr error
 	for {
-		bp.mu.Lock()
-		if bp.done {
-			bp.mu.Unlock()
+		pw.mu.Lock()
+		if pw.done {
+			pw.mu.Unlock()
 			return nil, nil, ErrClientConnClosing
 		}
 
-		if bp.picker == nil {
-			ch = bp.blockingCh
+		if pw.picker == nil {
+			ch = pw.blockingCh
 		}
-		if ch == bp.blockingCh {
+		if ch == pw.blockingCh {
 			// This could happen when either:
-			// - bp.picker is nil (the previous if condition), or
+			// - pw.picker is nil (the previous if condition), or
 			// - has called pick on the current picker.
-			bp.mu.Unlock()
+			pw.mu.Unlock()
 			select {
 			case <-ctx.Done():
-				if connectionErr := bp.connectionError(); connectionErr != nil {
-					switch ctx.Err() {
-					case context.DeadlineExceeded:
-						return nil, nil, status.Errorf(codes.DeadlineExceeded, "latest connection error: %v", connectionErr)
-					case context.Canceled:
-						return nil, nil, status.Errorf(codes.Canceled, "latest connection error: %v", connectionErr)
-					}
+				var errStr string
+				if lastPickErr != nil {
+					errStr = "latest balancer error: " + lastPickErr.Error()
+				} else if connectionErr := pw.connectionError(); connectionErr != nil {
+					errStr = "latest connection error: " + connectionErr.Error()
+				} else {
+					errStr = ctx.Err().Error()
 				}
-				return nil, nil, ctx.Err()
+				switch ctx.Err() {
+				case context.DeadlineExceeded:
+					return nil, nil, status.Error(codes.DeadlineExceeded, errStr)
+				case context.Canceled:
+					return nil, nil, status.Error(codes.Canceled, errStr)
+				}
 			case <-ch:
 			}
 			continue
 		}
 
-		ch = bp.blockingCh
-		p := bp.picker
-		bp.mu.Unlock()
+		ch = pw.blockingCh
+		p := pw.picker
+		pw.mu.Unlock()
 
-		subConn, done, err := p.Pick(ctx, opts)
+		pickResult, err := p.Pick(info)
 
 		if err != nil {
-			switch err {
-			case balancer.ErrNoSubConnAvailable:
+			if err == balancer.ErrNoSubConnAvailable {
 				continue
-			case balancer.ErrTransientFailure:
+			}
+			if tfe, ok := err.(interface{ IsTransientFailure() bool }); ok && tfe.IsTransientFailure() {
 				if !failfast {
+					lastPickErr = err
 					continue
 				}
-				return nil, nil, status.Errorf(codes.Unavailable, "%v, latest connection error: %v", err, bp.connectionError())
-			case context.DeadlineExceeded:
-				return nil, nil, status.Error(codes.DeadlineExceeded, err.Error())
-			case context.Canceled:
-				return nil, nil, status.Error(codes.Canceled, err.Error())
-			default:
-				if _, ok := status.FromError(err); ok {
-					return nil, nil, err
-				}
-				// err is some other error.
-				return nil, nil, status.Error(codes.Unknown, err.Error())
+				return nil, nil, status.Error(codes.Unavailable, err.Error())
 			}
+			if _, ok := status.FromError(err); ok {
+				return nil, nil, err
+			}
+			// err is some other error.
+			return nil, nil, status.Error(codes.Unknown, err.Error())
 		}
 
-		acw, ok := subConn.(*acBalancerWrapper)
+		acw, ok := pickResult.SubConn.(*acBalancerWrapper)
 		if !ok {
 			grpclog.Error("subconn returned from pick is not *acBalancerWrapper")
 			continue
 		}
 		if t, ok := acw.getAddrConn().getReadyTransport(); ok {
 			if channelz.IsOn() {
-				return t, doneChannelzWrapper(acw, done), nil
+				return t, doneChannelzWrapper(acw, pickResult.Done), nil
 			}
-			return t, done, nil
+			return t, pickResult.Done, nil
 		}
-		if done != nil {
+		if pickResult.Done != nil {
 			// Calling done with nil error, no bytes sent and no bytes received.
 			// DoneInfo with default value works.
-			done(balancer.DoneInfo{})
+			pickResult.Done(balancer.DoneInfo{})
 		}
 		grpclog.Infof("blockingPicker: the picked transport is not ready, loop back to repick")
 		// If ok == false, ac.state is not READY.
@@ -186,12 +219,12 @@ func (bp *pickerWrapper) pick(ctx context.Context, failfast bool, opts balancer.
 	}
 }
 
-func (bp *pickerWrapper) close() {
-	bp.mu.Lock()
-	defer bp.mu.Unlock()
-	if bp.done {
+func (pw *pickerWrapper) close() {
+	pw.mu.Lock()
+	defer pw.mu.Unlock()
+	if pw.done {
 		return
 	}
-	bp.done = true
-	close(bp.blockingCh)
+	pw.done = true
+	close(pw.blockingCh)
 }

--- a/pickfirst.go
+++ b/pickfirst.go
@@ -65,7 +65,7 @@ func (b *pickfirstBalancer) HandleResolvedAddrs(addrs []resolver.Address, err er
 			}
 			return
 		}
-		b.cc.UpdateBalancerState(connectivity.Idle, &picker{sc: b.sc})
+		b.cc.UpdateState(balancer.State{State: connectivity.Idle, Picker: &picker{sc: b.sc}})
 		b.sc.Connect()
 	} else {
 		b.sc.UpdateAddresses(addrs)
@@ -90,11 +90,11 @@ func (b *pickfirstBalancer) HandleSubConnStateChange(sc balancer.SubConn, s conn
 
 	switch s {
 	case connectivity.Ready, connectivity.Idle:
-		b.cc.UpdateBalancerState(s, &picker{sc: sc})
+		b.cc.UpdateState(balancer.State{State: s, Picker: &picker{sc: sc}})
 	case connectivity.Connecting:
-		b.cc.UpdateBalancerState(s, &picker{err: balancer.ErrNoSubConnAvailable})
+		b.cc.UpdateState(balancer.State{State: s, Picker: &picker{err: balancer.ErrNoSubConnAvailable}})
 	case connectivity.TransientFailure:
-		b.cc.UpdateBalancerState(s, &picker{err: balancer.ErrTransientFailure})
+		b.cc.UpdateState(balancer.State{State: s, Picker: &picker{err: balancer.ErrTransientFailure}})
 	}
 }
 

--- a/test/balancer_test.go
+++ b/test/balancer_test.go
@@ -49,7 +49,7 @@ type testBalancer struct {
 	sc balancer.SubConn
 
 	newSubConnOptions balancer.NewSubConnOptions
-	pickOptions       []balancer.PickOptions
+	pickInfos         []balancer.PickInfo
 	doneInfo          []balancer.DoneInfo
 }
 
@@ -105,12 +105,13 @@ type picker struct {
 	bal *testBalancer
 }
 
-func (p *picker) Pick(ctx context.Context, opts balancer.PickOptions) (balancer.SubConn, func(balancer.DoneInfo), error) {
+func (p *picker) Pick(info balancer.PickInfo) (balancer.PickResult, error) {
 	if p.err != nil {
-		return nil, nil, p.err
+		return balancer.PickResult{}, p.err
 	}
-	p.bal.pickOptions = append(p.bal.pickOptions, opts)
-	return p.sc, func(d balancer.DoneInfo) { p.bal.doneInfo = append(p.bal.doneInfo, d) }, nil
+	info.Ctx = nil // Do not validate context.
+	p.bal.pickInfos = append(p.bal.pickInfos, info)
+	return balancer.PickResult{SubConn: p.sc, Done: func(d balancer.DoneInfo) { p.bal.doneInfo = append(p.bal.doneInfo, d) }}, nil
 }
 
 func (s) TestCredsBundleFromBalancer(t *testing.T) {
@@ -177,8 +178,8 @@ func testDoneInfo(t *testing.T, e env) {
 	if len(b.doneInfo) < 2 || !reflect.DeepEqual(b.doneInfo[1].Trailer, testTrailerMetadata) {
 		t.Fatalf("b.doneInfo = %v; want b.doneInfo[1].Trailer = %v", b.doneInfo, testTrailerMetadata)
 	}
-	if len(b.pickOptions) != len(b.doneInfo) {
-		t.Fatalf("Got %d picks, but %d doneInfo, want equal amount", len(b.pickOptions), len(b.doneInfo))
+	if len(b.pickInfos) != len(b.doneInfo) {
+		t.Fatalf("Got %d picks, but %d doneInfo, want equal amount", len(b.pickInfos), len(b.doneInfo))
 	}
 	// To test done() is always called, even if it's returned with a non-Ready
 	// SubConn.
@@ -194,8 +195,8 @@ func testDoneInfo(t *testing.T, e env) {
 	}()
 	te.srv.Stop()
 	<-finished
-	if len(b.pickOptions) != len(b.doneInfo) {
-		t.Fatalf("Got %d picks, %d doneInfo, want equal amount", len(b.pickOptions), len(b.doneInfo))
+	if len(b.pickInfos) != len(b.doneInfo) {
+		t.Fatalf("Got %d picks, %d doneInfo, want equal amount", len(b.pickInfos), len(b.doneInfo))
 	}
 }
 
@@ -246,11 +247,11 @@ func testDoneLoads(t *testing.T, e env) {
 		t.Fatalf("TestService/EmptyCall(_, _) = _, %v, want _, %v", err, nil)
 	}
 
-	poWant := []balancer.PickOptions{
+	piWant := []balancer.PickInfo{
 		{FullMethodName: "/grpc.testing.TestService/EmptyCall"},
 	}
-	if !reflect.DeepEqual(b.pickOptions, poWant) {
-		t.Fatalf("b.pickOptions = %v; want %v", b.pickOptions, poWant)
+	if !reflect.DeepEqual(b.pickInfos, piWant) {
+		t.Fatalf("b.pickInfos = %v; want %v", b.pickInfos, piWant)
 	}
 
 	if len(b.doneInfo) < 1 {

--- a/test/balancer_test.go
+++ b/test/balancer_test.go
@@ -70,7 +70,7 @@ func (b *testBalancer) HandleResolvedAddrs(addrs []resolver.Address, err error) 
 			grpclog.Errorf("testBalancer: failed to NewSubConn: %v", err)
 			return
 		}
-		b.cc.UpdateState(balancer.State{State: connectivity.Connecting, Picker: &picker{sc: b.sc, bal: b}})
+		b.cc.UpdateState(balancer.State{ConnectivityState: connectivity.Connecting, Picker: &picker{sc: b.sc, bal: b}})
 		b.sc.Connect()
 	}
 }
@@ -88,11 +88,11 @@ func (b *testBalancer) HandleSubConnStateChange(sc balancer.SubConn, s connectiv
 
 	switch s {
 	case connectivity.Ready, connectivity.Idle:
-		b.cc.UpdateState(balancer.State{State: s, Picker: &picker{sc: sc, bal: b}})
+		b.cc.UpdateState(balancer.State{ConnectivityState: s, Picker: &picker{sc: sc, bal: b}})
 	case connectivity.Connecting:
-		b.cc.UpdateState(balancer.State{State: s, Picker: &picker{err: balancer.ErrNoSubConnAvailable, bal: b}})
+		b.cc.UpdateState(balancer.State{ConnectivityState: s, Picker: &picker{err: balancer.ErrNoSubConnAvailable, bal: b}})
 	case connectivity.TransientFailure:
-		b.cc.UpdateState(balancer.State{State: s, Picker: &picker{err: balancer.ErrTransientFailure, bal: b}})
+		b.cc.UpdateState(balancer.State{ConnectivityState: s, Picker: &picker{err: balancer.ErrTransientFailure, bal: b}})
 	}
 }
 

--- a/test/balancer_test.go
+++ b/test/balancer_test.go
@@ -70,7 +70,7 @@ func (b *testBalancer) HandleResolvedAddrs(addrs []resolver.Address, err error) 
 			grpclog.Errorf("testBalancer: failed to NewSubConn: %v", err)
 			return
 		}
-		b.cc.UpdateBalancerState(connectivity.Connecting, &picker{sc: b.sc, bal: b})
+		b.cc.UpdateState(balancer.State{State: connectivity.Connecting, Picker: &picker{sc: b.sc, bal: b}})
 		b.sc.Connect()
 	}
 }
@@ -88,11 +88,11 @@ func (b *testBalancer) HandleSubConnStateChange(sc balancer.SubConn, s connectiv
 
 	switch s {
 	case connectivity.Ready, connectivity.Idle:
-		b.cc.UpdateBalancerState(s, &picker{sc: sc, bal: b})
+		b.cc.UpdateState(balancer.State{State: s, Picker: &picker{sc: sc, bal: b}})
 	case connectivity.Connecting:
-		b.cc.UpdateBalancerState(s, &picker{err: balancer.ErrNoSubConnAvailable, bal: b})
+		b.cc.UpdateState(balancer.State{State: s, Picker: &picker{err: balancer.ErrNoSubConnAvailable, bal: b}})
 	case connectivity.TransientFailure:
-		b.cc.UpdateBalancerState(s, &picker{err: balancer.ErrTransientFailure, bal: b})
+		b.cc.UpdateState(balancer.State{State: s, Picker: &picker{err: balancer.ErrTransientFailure, bal: b}})
 	}
 }
 

--- a/test/healthcheck_test.go
+++ b/test/healthcheck_test.go
@@ -115,7 +115,7 @@ func (s *testHealthServer) SetServingStatus(service string, status healthpb.Heal
 func setupHealthCheckWrapper() (hcEnterChan chan struct{}, hcExitChan chan struct{}, wrapper internal.HealthChecker) {
 	hcEnterChan = make(chan struct{})
 	hcExitChan = make(chan struct{})
-	wrapper = func(ctx context.Context, newStream func(string) (interface{}, error), update func(state connectivity.State), service string) error {
+	wrapper = func(ctx context.Context, newStream func(string) (interface{}, error), update func(connectivity.State, error), service string) error {
 		close(hcEnterChan)
 		defer close(hcExitChan)
 		return testHealthCheckFunc(ctx, newStream, update, service)

--- a/vet.sh
+++ b/vet.sh
@@ -128,6 +128,8 @@ staticcheck -go 1.9 -checks 'inherit,-ST1015' ./... > "${SC_OUT}" || true
 .NewServiceConfig
 .Metadata is deprecated: use Attributes
 .Type is deprecated: use Attributes
+.UpdateBalancerState
+balancer.Picker
 grpc.CallCustomCodec
 grpc.Code
 grpc.Compressor

--- a/xds/internal/balancer/edsbalancer/balancergroup.go
+++ b/xds/internal/balancer/edsbalancer/balancergroup.go
@@ -18,7 +18,6 @@ package edsbalancer
 
 import (
 	"fmt"
-	"runtime/debug"
 	"sync"
 	"time"
 
@@ -68,7 +67,6 @@ type subBalancerWithConfig struct {
 }
 
 func (sbc *subBalancerWithConfig) UpdateBalancerState(state connectivity.State, picker balancer.Picker) {
-	debug.PrintStack()
 	grpclog.Fatalln("not implemented")
 }
 
@@ -498,7 +496,7 @@ func (bg *balancerGroup) updateBalancerState(id internal.Locality, state balance
 		return
 	}
 	pickerSt.picker = newLoadReportPicker(state.Picker, id, bg.loadStore)
-	pickerSt.state = state.State
+	pickerSt.state = state.ConnectivityState
 	if bg.incomingStarted {
 		bg.cc.UpdateState(buildPickerAndState(bg.idToPickerState))
 	}

--- a/xds/internal/balancer/edsbalancer/balancergroup.go
+++ b/xds/internal/balancer/edsbalancer/balancergroup.go
@@ -17,8 +17,8 @@
 package edsbalancer
 
 import (
-	"context"
 	"fmt"
+	"runtime/debug"
 	"sync"
 	"time"
 
@@ -55,9 +55,8 @@ type subBalancerWithConfig struct {
 	id    internal.Locality
 	group *balancerGroup
 
-	mu     sync.Mutex
-	state  connectivity.State
-	picker balancer.Picker
+	mu    sync.Mutex
+	state balancer.State
 
 	// The static part of sub-balancer. Keeps balancerBuilders and addresses.
 	// To be used when restarting sub-balancer.
@@ -68,11 +67,16 @@ type subBalancerWithConfig struct {
 	balancer balancer.Balancer
 }
 
-// UpdateBalancerState overrides balancer.ClientConn, to keep state and picker.
 func (sbc *subBalancerWithConfig) UpdateBalancerState(state connectivity.State, picker balancer.Picker) {
+	debug.PrintStack()
+	grpclog.Fatalln("not implemented")
+}
+
+// UpdateState overrides balancer.ClientConn, to keep state and picker.
+func (sbc *subBalancerWithConfig) UpdateState(state balancer.State) {
 	sbc.mu.Lock()
-	sbc.state, sbc.picker = state, picker
-	sbc.group.updateBalancerState(sbc.id, state, picker)
+	sbc.state = state
+	sbc.group.updateBalancerState(sbc.id, state)
 	sbc.mu.Unlock()
 }
 
@@ -84,8 +88,8 @@ func (sbc *subBalancerWithConfig) NewSubConn(addrs []resolver.Address, opts bala
 
 func (sbc *subBalancerWithConfig) updateBalancerStateWithCachedPicker() {
 	sbc.mu.Lock()
-	if sbc.picker != nil {
-		sbc.group.updateBalancerState(sbc.id, sbc.state, sbc.picker)
+	if sbc.state.Picker != nil {
+		sbc.group.updateBalancerState(sbc.id, sbc.state)
 	}
 	sbc.mu.Unlock()
 }
@@ -144,7 +148,7 @@ func (sbc *subBalancerWithConfig) stopBalancer() {
 
 type pickerState struct {
 	weight uint32
-	picker balancer.Picker
+	picker balancer.V2Picker
 	state  connectivity.State
 }
 
@@ -359,7 +363,7 @@ func (bg *balancerGroup) remove(id internal.Locality) {
 		// Normally picker update is triggered by SubConn state change. But we
 		// want to update state and picker to reflect the changes, too. Because
 		// we don't want `ClientConn` to pick this sub-balancer anymore.
-		bg.cc.UpdateBalancerState(buildPickerAndState(bg.idToPickerState))
+		bg.cc.UpdateState(buildPickerAndState(bg.idToPickerState))
 	}
 	bg.incomingMu.Unlock()
 }
@@ -411,7 +415,7 @@ func (bg *balancerGroup) changeWeight(id internal.Locality, newWeight uint32) {
 		// Normally picker update is triggered by SubConn state change. But we
 		// want to update state and picker to reflect the changes, too. Because
 		// `ClientConn` should do pick with the new weights now.
-		bg.cc.UpdateBalancerState(buildPickerAndState(bg.idToPickerState))
+		bg.cc.UpdateState(buildPickerAndState(bg.idToPickerState))
 	}
 }
 
@@ -481,8 +485,8 @@ func (bg *balancerGroup) newSubConn(config *subBalancerWithConfig, addrs []resol
 
 // updateBalancerState: create an aggregated picker and an aggregated
 // connectivity state, then forward to ClientConn.
-func (bg *balancerGroup) updateBalancerState(id internal.Locality, state connectivity.State, picker balancer.Picker) {
-	grpclog.Infof("balancer group: update balancer state: %v, %v, %p", id, state, picker)
+func (bg *balancerGroup) updateBalancerState(id internal.Locality, state balancer.State) {
+	grpclog.Infof("balancer group: update balancer state: %v, %v", id, state)
 
 	bg.incomingMu.Lock()
 	defer bg.incomingMu.Unlock()
@@ -493,10 +497,10 @@ func (bg *balancerGroup) updateBalancerState(id internal.Locality, state connect
 		grpclog.Warningf("balancer group: pickerState for %v not found when update picker/state", id)
 		return
 	}
-	pickerSt.picker = newLoadReportPicker(picker, id, bg.loadStore)
-	pickerSt.state = state
+	pickerSt.picker = newLoadReportPicker(state.Picker, id, bg.loadStore)
+	pickerSt.state = state.State
 	if bg.incomingStarted {
-		bg.cc.UpdateBalancerState(buildPickerAndState(bg.idToPickerState))
+		bg.cc.UpdateState(buildPickerAndState(bg.idToPickerState))
 	}
 }
 
@@ -533,7 +537,7 @@ func (bg *balancerGroup) close() {
 	bg.balancerCache.Clear(true)
 }
 
-func buildPickerAndState(m map[internal.Locality]*pickerState) (connectivity.State, balancer.Picker) {
+func buildPickerAndState(m map[internal.Locality]*pickerState) balancer.State {
 	var readyN, connectingN int
 	readyPickerWithWeights := make([]pickerState, 0, len(m))
 	for _, ps := range m {
@@ -555,9 +559,9 @@ func buildPickerAndState(m map[internal.Locality]*pickerState) (connectivity.Sta
 		aggregatedState = connectivity.TransientFailure
 	}
 	if aggregatedState == connectivity.TransientFailure {
-		return aggregatedState, base.NewErrPicker(balancer.ErrTransientFailure)
+		return balancer.State{aggregatedState, base.NewErrPickerV2(balancer.ErrTransientFailure)}
 	}
-	return aggregatedState, newPickerGroup(readyPickerWithWeights)
+	return balancer.State{aggregatedState, newPickerGroup(readyPickerWithWeights)}
 }
 
 // RandomWRR constructor, to be modified in tests.
@@ -587,12 +591,12 @@ func newPickerGroup(readyPickerWithWeights []pickerState) *pickerGroup {
 	}
 }
 
-func (pg *pickerGroup) Pick(ctx context.Context, opts balancer.PickOptions) (conn balancer.SubConn, done func(balancer.DoneInfo), err error) {
+func (pg *pickerGroup) Pick(info balancer.PickInfo) (balancer.PickResult, error) {
 	if pg.length <= 0 {
-		return nil, nil, balancer.ErrNoSubConnAvailable
+		return balancer.PickResult{}, balancer.ErrNoSubConnAvailable
 	}
-	p := pg.w.Next().(balancer.Picker)
-	return p.Pick(ctx, opts)
+	p := pg.w.Next().(balancer.V2Picker)
+	return p.Pick(info)
 }
 
 const (
@@ -601,26 +605,26 @@ const (
 )
 
 type loadReportPicker struct {
-	balancer.Picker
+	p balancer.V2Picker
 
 	id        internal.Locality
 	loadStore lrs.Store
 }
 
-func newLoadReportPicker(p balancer.Picker, id internal.Locality, loadStore lrs.Store) *loadReportPicker {
+func newLoadReportPicker(p balancer.V2Picker, id internal.Locality, loadStore lrs.Store) *loadReportPicker {
 	return &loadReportPicker{
-		Picker:    p,
+		p:         p,
 		id:        id,
 		loadStore: loadStore,
 	}
 }
 
-func (lrp *loadReportPicker) Pick(ctx context.Context, opts balancer.PickOptions) (conn balancer.SubConn, done func(balancer.DoneInfo), err error) {
-	conn, done, err = lrp.Picker.Pick(ctx, opts)
+func (lrp *loadReportPicker) Pick(info balancer.PickInfo) (balancer.PickResult, error) {
+	res, err := lrp.p.Pick(info)
 	if lrp.loadStore != nil && err == nil {
 		lrp.loadStore.CallStarted(lrp.id)
-		td := done
-		done = func(info balancer.DoneInfo) {
+		td := res.Done
+		res.Done = func(info balancer.DoneInfo) {
 			lrp.loadStore.CallFinished(lrp.id, info.Err)
 			if load, ok := info.ServerLoad.(*orcapb.OrcaLoadReport); ok {
 				lrp.loadStore.CallServerLoad(lrp.id, serverLoadCPUName, load.CpuUtilization)
@@ -637,5 +641,5 @@ func (lrp *loadReportPicker) Pick(ctx context.Context, opts balancer.PickOptions
 			}
 		}
 	}
-	return
+	return res, err
 }

--- a/xds/internal/balancer/edsbalancer/edsbalancer.go
+++ b/xds/internal/balancer/edsbalancer/edsbalancer.go
@@ -18,7 +18,6 @@
 package edsbalancer
 
 import (
-	"context"
 	"encoding/json"
 	"reflect"
 	"sync"
@@ -52,14 +51,6 @@ type balancerGroupWithConfig struct {
 	configs map[internal.Locality]*localityConfig
 }
 
-// balancerState keeps the previous state updated by a priority. It's kept so if
-// a lower priority is removed, the higher priority's state will be sent to
-// parent ClientConn (even if it's not Ready).
-type balancerState struct {
-	state  connectivity.State
-	picker balancer.Picker
-}
-
 // EDSBalancer does load balancing based on the EDS responses. Note that it
 // doesn't implement the balancer interface. It's intended to be used by a high
 // level balancer implementation.
@@ -82,7 +73,7 @@ type EDSBalancer struct {
 	// priorities are pointers, and will be nil when EDS returns empty result.
 	priorityInUse   priorityType
 	priorityLowest  priorityType
-	priorityToState map[priorityType]*balancerState
+	priorityToState map[priorityType]*balancer.State
 	// The timer to give a priority 10 seconds to connect. And if the priority
 	// doesn't go into Ready/Failure, start the next priority.
 	//
@@ -93,10 +84,9 @@ type EDSBalancer struct {
 	subConnMu         sync.Mutex
 	subConnToPriority map[balancer.SubConn]priorityType
 
-	pickerMu    sync.Mutex
-	drops       []*dropper
-	innerPicker balancer.Picker    // The picker without drop support.
-	innerState  connectivity.State // The state of the picker.
+	pickerMu   sync.Mutex
+	drops      []*dropper
+	innerState balancer.State // The state of the picker without drop support.
 }
 
 // NewXDSBalancer create a new EDSBalancer.
@@ -106,7 +96,7 @@ func NewXDSBalancer(cc balancer.ClientConn, loadStore lrs.Store) *EDSBalancer {
 		subBalancerBuilder: balancer.Get(roundrobin.Name),
 
 		priorityToLocalities: make(map[priorityType]*balancerGroupWithConfig),
-		priorityToState:      make(map[priorityType]*balancerState),
+		priorityToState:      make(map[priorityType]*balancer.State),
 		subConnToPriority:    make(map[balancer.SubConn]priorityType),
 		loadStore:            loadStore,
 	}
@@ -177,9 +167,9 @@ func (xdsB *EDSBalancer) updateDrops(dropPolicies []xdsclient.OverloadDropConfig
 	if dropsChanged {
 		xdsB.pickerMu.Lock()
 		xdsB.drops = newDrops
-		if xdsB.innerPicker != nil {
+		if xdsB.innerState.Picker != nil {
 			// Update picker with old inner picker, new drops.
-			xdsB.cc.UpdateState(balancer.State{State: xdsB.innerState, Picker: newDropPicker(xdsB.innerPicker, newDrops, xdsB.loadStore)})
+			xdsB.cc.UpdateState(balancer.State{State: xdsB.innerState.State, Picker: newDropPicker(xdsB.innerState.Picker, newDrops, xdsB.loadStore)})
 		}
 		xdsB.pickerMu.Unlock()
 	}
@@ -363,22 +353,21 @@ func (xdsB *EDSBalancer) HandleSubConnStateChange(sc balancer.SubConn, s connect
 	}
 }
 
-// updateBalancerState first handles priority, and then wraps picker in a drop
-// picker before forwarding the update.
-func (xdsB *EDSBalancer) updateBalancerState(priority priorityType, s connectivity.State, p balancer.Picker) {
+// updateState first handles priority, and then wraps picker in a drop picker
+// before forwarding the update.
+func (xdsB *EDSBalancer) updateState(priority priorityType, s balancer.State) {
 	_, ok := xdsB.priorityToLocalities[priority]
 	if !ok {
 		grpclog.Infof("eds: received picker update from unknown priority")
 		return
 	}
 
-	if xdsB.handlePriorityWithNewState(priority, s, p) {
+	if xdsB.handlePriorityWithNewState(priority, s) {
 		xdsB.pickerMu.Lock()
 		defer xdsB.pickerMu.Unlock()
-		xdsB.innerPicker = p
 		xdsB.innerState = s
 		// Don't reset drops when it's a state change.
-		xdsB.cc.UpdateState(balancer.State{State: s, Picker: newDropPicker(p, xdsB.drops, xdsB.loadStore)})
+		xdsB.cc.UpdateState(balancer.State{State: s.State, Picker: newDropPicker(s.Picker, xdsB.drops, xdsB.loadStore)})
 	}
 }
 
@@ -402,7 +391,10 @@ func (ebwcc *edsBalancerWrapperCC) NewSubConn(addrs []resolver.Address, opts bal
 	return ebwcc.parent.newSubConn(ebwcc.priority, addrs, opts)
 }
 func (ebwcc *edsBalancerWrapperCC) UpdateBalancerState(state connectivity.State, picker balancer.Picker) {
-	ebwcc.parent.updateBalancerState(ebwcc.priority, state, picker)
+	grpclog.Fatalln("not implemented")
+}
+func (ebwcc *edsBalancerWrapperCC) UpdateState(state balancer.State) {
+	ebwcc.parent.updateState(ebwcc.priority, state)
 }
 
 func (xdsB *EDSBalancer) newSubConn(priority priorityType, addrs []resolver.Address, opts balancer.NewSubConnOptions) (balancer.SubConn, error) {
@@ -427,11 +419,11 @@ func (xdsB *EDSBalancer) Close() {
 
 type dropPicker struct {
 	drops     []*dropper
-	p         balancer.Picker
+	p         balancer.V2Picker
 	loadStore lrs.Store
 }
 
-func newDropPicker(p balancer.Picker, drops []*dropper, loadStore lrs.Store) *dropPicker {
+func newDropPicker(p balancer.V2Picker, drops []*dropper, loadStore lrs.Store) *dropPicker {
 	return &dropPicker{
 		drops:     drops,
 		p:         p,
@@ -439,7 +431,7 @@ func newDropPicker(p balancer.Picker, drops []*dropper, loadStore lrs.Store) *dr
 	}
 }
 
-func (d *dropPicker) Pick(ctx context.Context, opts balancer.PickOptions) (conn balancer.SubConn, done func(balancer.DoneInfo), err error) {
+func (d *dropPicker) Pick(info balancer.PickInfo) (balancer.PickResult, error) {
 	var (
 		drop     bool
 		category string
@@ -455,9 +447,9 @@ func (d *dropPicker) Pick(ctx context.Context, opts balancer.PickOptions) (conn 
 		if d.loadStore != nil {
 			d.loadStore.CallDropped(category)
 		}
-		return nil, nil, status.Errorf(codes.Unavailable, "RPC is dropped")
+		return balancer.PickResult{}, status.Errorf(codes.Unavailable, "RPC is dropped")
 	}
 	// TODO: (eds) don't drop unless the inner picker is READY. Similar to
 	// https://github.com/grpc/grpc-go/issues/2622.
-	return d.p.Pick(ctx, opts)
+	return d.p.Pick(info)
 }

--- a/xds/internal/balancer/edsbalancer/edsbalancer.go
+++ b/xds/internal/balancer/edsbalancer/edsbalancer.go
@@ -179,7 +179,7 @@ func (xdsB *EDSBalancer) updateDrops(dropPolicies []xdsclient.OverloadDropConfig
 		xdsB.drops = newDrops
 		if xdsB.innerPicker != nil {
 			// Update picker with old inner picker, new drops.
-			xdsB.cc.UpdateBalancerState(xdsB.innerState, newDropPicker(xdsB.innerPicker, newDrops, xdsB.loadStore))
+			xdsB.cc.UpdateState(balancer.State{State: xdsB.innerState, Picker: newDropPicker(xdsB.innerPicker, newDrops, xdsB.loadStore)})
 		}
 		xdsB.pickerMu.Unlock()
 	}
@@ -378,7 +378,7 @@ func (xdsB *EDSBalancer) updateBalancerState(priority priorityType, s connectivi
 		xdsB.innerPicker = p
 		xdsB.innerState = s
 		// Don't reset drops when it's a state change.
-		xdsB.cc.UpdateBalancerState(s, newDropPicker(p, xdsB.drops, xdsB.loadStore))
+		xdsB.cc.UpdateState(balancer.State{State: s, Picker: newDropPicker(p, xdsB.drops, xdsB.loadStore)})
 	}
 }
 

--- a/xds/internal/balancer/edsbalancer/edsbalancer.go
+++ b/xds/internal/balancer/edsbalancer/edsbalancer.go
@@ -169,7 +169,10 @@ func (xdsB *EDSBalancer) updateDrops(dropPolicies []xdsclient.OverloadDropConfig
 		xdsB.drops = newDrops
 		if xdsB.innerState.Picker != nil {
 			// Update picker with old inner picker, new drops.
-			xdsB.cc.UpdateState(balancer.State{State: xdsB.innerState.State, Picker: newDropPicker(xdsB.innerState.Picker, newDrops, xdsB.loadStore)})
+			xdsB.cc.UpdateState(balancer.State{
+				ConnectivityState: xdsB.innerState.ConnectivityState,
+				Picker:            newDropPicker(xdsB.innerState.Picker, newDrops, xdsB.loadStore)},
+			)
 		}
 		xdsB.pickerMu.Unlock()
 	}
@@ -367,7 +370,7 @@ func (xdsB *EDSBalancer) updateState(priority priorityType, s balancer.State) {
 		defer xdsB.pickerMu.Unlock()
 		xdsB.innerState = s
 		// Don't reset drops when it's a state change.
-		xdsB.cc.UpdateState(balancer.State{State: s.State, Picker: newDropPicker(s.Picker, xdsB.drops, xdsB.loadStore)})
+		xdsB.cc.UpdateState(balancer.State{ConnectivityState: s.ConnectivityState, Picker: newDropPicker(s.Picker, xdsB.drops, xdsB.loadStore)})
 	}
 }
 

--- a/xds/internal/balancer/edsbalancer/edsbalancer_test.go
+++ b/xds/internal/balancer/edsbalancer/edsbalancer_test.go
@@ -411,7 +411,7 @@ type testConstBalancer struct {
 }
 
 func (tb *testConstBalancer) HandleSubConnStateChange(sc balancer.SubConn, state connectivity.State) {
-	tb.cc.UpdateBalancerState(connectivity.Ready, &testConstPicker{err: errTestConstPicker})
+	tb.cc.UpdateState(balancer.State{State: connectivity.Ready, Picker: &testConstPicker{err: errTestConstPicker}})
 }
 
 func (tb *testConstBalancer) HandleResolvedAddrs(a []resolver.Address, err error) {

--- a/xds/internal/balancer/edsbalancer/edsbalancer_test.go
+++ b/xds/internal/balancer/edsbalancer/edsbalancer_test.go
@@ -386,7 +386,7 @@ type testConstBalancer struct {
 }
 
 func (tb *testConstBalancer) HandleSubConnStateChange(sc balancer.SubConn, state connectivity.State) {
-	tb.cc.UpdateState(balancer.State{State: connectivity.Ready, Picker: &testConstPicker{err: errTestConstPicker}})
+	tb.cc.UpdateState(balancer.State{ConnectivityState: connectivity.Ready, Picker: &testConstPicker{err: errTestConstPicker}})
 }
 
 func (tb *testConstBalancer) HandleResolvedAddrs(a []resolver.Address, err error) {

--- a/xds/internal/balancer/edsbalancer/priority.go
+++ b/xds/internal/balancer/edsbalancer/priority.go
@@ -45,7 +45,7 @@ func (xdsB *EDSBalancer) handlePriorityChange() {
 	// Everything was removed by EDS.
 	if !xdsB.priorityLowest.isSet() {
 		xdsB.priorityInUse = newPriorityTypeUnset()
-		xdsB.cc.UpdateBalancerState(connectivity.TransientFailure, base.NewErrPicker(balancer.ErrTransientFailure))
+		xdsB.cc.UpdateState(balancer.State{State: connectivity.TransientFailure, Picker: base.NewErrPicker(balancer.ErrTransientFailure)})
 		return
 	}
 
@@ -59,7 +59,7 @@ func (xdsB *EDSBalancer) handlePriorityChange() {
 	if _, ok := xdsB.priorityToLocalities[xdsB.priorityInUse]; !ok {
 		xdsB.priorityInUse = xdsB.priorityLowest
 		if s, ok := xdsB.priorityToState[xdsB.priorityLowest]; ok {
-			xdsB.cc.UpdateBalancerState(s.state, s.picker)
+			xdsB.cc.UpdateState(balancer.State{State: s.state, Picker: s.picker})
 		} else {
 			// If state for priorityLowest is not found, this means priorityLowest was
 			// started, but never sent any update. The init timer fired and
@@ -69,7 +69,7 @@ func (xdsB *EDSBalancer) handlePriorityChange() {
 			// We don't have an old state to send to parent, but we also don't
 			// want parent to keep using picker from old_priorityInUse. Send an
 			// update to trigger block picks until a new picker is ready.
-			xdsB.cc.UpdateBalancerState(connectivity.Connecting, base.NewErrPicker(balancer.ErrNoSubConnAvailable))
+			xdsB.cc.UpdateState(balancer.State{State: connectivity.Connecting, Picker: base.NewErrPicker(balancer.ErrNoSubConnAvailable)})
 		}
 		return
 	}

--- a/xds/internal/balancer/edsbalancer/priority.go
+++ b/xds/internal/balancer/edsbalancer/priority.go
@@ -45,7 +45,7 @@ func (xdsB *EDSBalancer) handlePriorityChange() {
 	// Everything was removed by EDS.
 	if !xdsB.priorityLowest.isSet() {
 		xdsB.priorityInUse = newPriorityTypeUnset()
-		xdsB.cc.UpdateState(balancer.State{State: connectivity.TransientFailure, Picker: base.NewErrPicker(balancer.ErrTransientFailure)})
+		xdsB.cc.UpdateState(balancer.State{State: connectivity.TransientFailure, Picker: base.NewErrPickerV2(balancer.ErrTransientFailure)})
 		return
 	}
 
@@ -59,7 +59,7 @@ func (xdsB *EDSBalancer) handlePriorityChange() {
 	if _, ok := xdsB.priorityToLocalities[xdsB.priorityInUse]; !ok {
 		xdsB.priorityInUse = xdsB.priorityLowest
 		if s, ok := xdsB.priorityToState[xdsB.priorityLowest]; ok {
-			xdsB.cc.UpdateState(balancer.State{State: s.state, Picker: s.picker})
+			xdsB.cc.UpdateState(*s)
 		} else {
 			// If state for priorityLowest is not found, this means priorityLowest was
 			// started, but never sent any update. The init timer fired and
@@ -69,13 +69,13 @@ func (xdsB *EDSBalancer) handlePriorityChange() {
 			// We don't have an old state to send to parent, but we also don't
 			// want parent to keep using picker from old_priorityInUse. Send an
 			// update to trigger block picks until a new picker is ready.
-			xdsB.cc.UpdateState(balancer.State{State: connectivity.Connecting, Picker: base.NewErrPicker(balancer.ErrNoSubConnAvailable)})
+			xdsB.cc.UpdateState(balancer.State{State: connectivity.Connecting, Picker: base.NewErrPickerV2(balancer.ErrNoSubConnAvailable)})
 		}
 		return
 	}
 
 	// priorityInUse is not ready, look for next priority, and use if found.
-	if s, ok := xdsB.priorityToState[xdsB.priorityInUse]; ok && s.state != connectivity.Ready {
+	if s, ok := xdsB.priorityToState[xdsB.priorityInUse]; ok && s.State != connectivity.Ready {
 		pNext := xdsB.priorityInUse.nextLower()
 		if _, ok := xdsB.priorityToLocalities[pNext]; ok {
 			xdsB.startPriority(pNext)
@@ -119,7 +119,7 @@ func (xdsB *EDSBalancer) startPriority(priority priorityType) {
 
 // handlePriorityWithNewState start/close priorities based on the connectivity
 // state. It returns whether the state should be forwarded to parent ClientConn.
-func (xdsB *EDSBalancer) handlePriorityWithNewState(priority priorityType, s connectivity.State, p balancer.Picker) bool {
+func (xdsB *EDSBalancer) handlePriorityWithNewState(priority priorityType, s balancer.State) bool {
 	xdsB.priorityMu.Lock()
 	defer xdsB.priorityMu.Unlock()
 
@@ -136,14 +136,13 @@ func (xdsB *EDSBalancer) handlePriorityWithNewState(priority priorityType, s con
 
 	bState, ok := xdsB.priorityToState[priority]
 	if !ok {
-		bState = &balancerState{}
+		bState = &balancer.State{}
 		xdsB.priorityToState[priority] = bState
 	}
-	oldState := bState.state
-	bState.state = s
-	bState.picker = p
+	oldState := bState.State
+	*bState = s
 
-	switch s {
+	switch s.State {
 	case connectivity.Ready:
 		return xdsB.handlePriorityWithNewStateReady(priority)
 	case connectivity.TransientFailure:

--- a/xds/internal/balancer/edsbalancer/test_util_test.go
+++ b/xds/internal/balancer/edsbalancer/test_util_test.go
@@ -63,7 +63,7 @@ type testClientConn struct {
 	newSubConnCh      chan balancer.SubConn   // The last 10 subconn created.
 	removeSubConnCh   chan balancer.SubConn   // The last 10 subconn removed.
 
-	newPickerCh chan balancer.Picker    // The last picker updated.
+	newPickerCh chan balancer.V2Picker  // The last picker updated.
 	newStateCh  chan connectivity.State // The last state.
 
 	subConnIdx int
@@ -77,7 +77,7 @@ func newTestClientConn(t *testing.T) *testClientConn {
 		newSubConnCh:      make(chan balancer.SubConn, 10),
 		removeSubConnCh:   make(chan balancer.SubConn, 10),
 
-		newPickerCh: make(chan balancer.Picker, 1),
+		newPickerCh: make(chan balancer.V2Picker, 1),
 		newStateCh:  make(chan connectivity.State, 1),
 	}
 }
@@ -109,18 +109,22 @@ func (tcc *testClientConn) RemoveSubConn(sc balancer.SubConn) {
 }
 
 func (tcc *testClientConn) UpdateBalancerState(s connectivity.State, p balancer.Picker) {
-	tcc.t.Logf("testClientConn: UpdateBalancerState(%v, %p)", s, p)
+	tcc.t.Fatal("not implemented")
+}
+
+func (tcc *testClientConn) UpdateState(bs balancer.State) {
+	tcc.t.Logf("testClientConn: UpdateState(%v)", bs)
 	select {
 	case <-tcc.newStateCh:
 	default:
 	}
-	tcc.newStateCh <- s
+	tcc.newStateCh <- bs.State
 
 	select {
 	case <-tcc.newPickerCh:
 	default:
 	}
-	tcc.newPickerCh <- p
+	tcc.newPickerCh <- bs.Picker
 }
 
 func (tcc *testClientConn) ResolveNow(resolver.ResolveNowOptions) {

--- a/xds/internal/balancer/edsbalancer/test_util_test.go
+++ b/xds/internal/balancer/edsbalancer/test_util_test.go
@@ -118,7 +118,7 @@ func (tcc *testClientConn) UpdateState(bs balancer.State) {
 	case <-tcc.newStateCh:
 	default:
 	}
-	tcc.newStateCh <- bs.State
+	tcc.newStateCh <- bs.ConnectivityState
 
 	select {
 	case <-tcc.newPickerCh:

--- a/xds/internal/balancer/xds.go
+++ b/xds/internal/balancer/xds.go
@@ -366,9 +366,12 @@ type xdsClientConn struct {
 	balancer.ClientConn
 }
 
+func (w *xdsClientConn) UpdateState(s balancer.State) {
+	w.updateState(s.State)
+	w.ClientConn.UpdateState(s)
+}
 func (w *xdsClientConn) UpdateBalancerState(s connectivity.State, p balancer.Picker) {
-	w.updateState(s)
-	w.ClientConn.UpdateState(balancer.State{State: s, Picker: p})
+	grpclog.Fatalln("not implemented")
 }
 
 type subConnStateUpdate struct {

--- a/xds/internal/balancer/xds.go
+++ b/xds/internal/balancer/xds.go
@@ -367,7 +367,7 @@ type xdsClientConn struct {
 }
 
 func (w *xdsClientConn) UpdateState(s balancer.State) {
-	w.updateState(s.State)
+	w.updateState(s.ConnectivityState)
 	w.ClientConn.UpdateState(s)
 }
 func (w *xdsClientConn) UpdateBalancerState(s connectivity.State, p balancer.Picker) {

--- a/xds/internal/balancer/xds.go
+++ b/xds/internal/balancer/xds.go
@@ -368,7 +368,7 @@ type xdsClientConn struct {
 
 func (w *xdsClientConn) UpdateBalancerState(s connectivity.State, p balancer.Picker) {
 	w.updateState(s)
-	w.ClientConn.UpdateBalancerState(s, p)
+	w.ClientConn.UpdateState(balancer.State{State: s, Picker: p})
 }
 
 type subConnStateUpdate struct {

--- a/xds/internal/balancer/xds_test.go
+++ b/xds/internal/balancer/xds_test.go
@@ -166,10 +166,11 @@ func (t *testClientConn) NewSubConn(addrs []resolver.Address, opts balancer.NewS
 	return nil, nil
 }
 
-func (testClientConn) RemoveSubConn(balancer.SubConn)                              {}
-func (testClientConn) UpdateBalancerState(s connectivity.State, p balancer.Picker) {}
-func (testClientConn) ResolveNow(resolver.ResolveNowOptions)                       {}
-func (testClientConn) Target() string                                              { return testServiceName }
+func (testClientConn) RemoveSubConn(balancer.SubConn)                          {}
+func (testClientConn) UpdateBalancerState(connectivity.State, balancer.Picker) {}
+func (testClientConn) UpdateState(balancer.State)                              {}
+func (testClientConn) ResolveNow(resolver.ResolveNowOptions)                   {}
+func (testClientConn) Target() string                                          { return testServiceName }
 
 type scStateChange struct {
 	sc    balancer.SubConn


### PR DESCRIPTION
Also implement V2 versions of `base.*`, xds, pickfirst, grpclb, and round robin balancers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grpc/grpc-go/3186)
<!-- Reviewable:end -->
