### PR TITLE
xds: Don't override dialFunc in xdsClient in tests.

### DIFF
--- a/vet.sh
+++ b/vet.sh
@@ -147,6 +147,7 @@ grpc.WithDecompressor
 grpc.WithDialer
 grpc.WithMaxMsgSize
 grpc.WithServiceConfig
+grpc.WithTimeout
 http.CloseNotifier
 naming.Resolver
 naming.Update

--- a/xds/internal/client/client.go
+++ b/xds/internal/client/client.go
@@ -32,9 +32,6 @@ import (
 	"google.golang.org/grpc/xds/internal/client/bootstrap"
 )
 
-// For overriding in unittests.
-var dialFunc = grpc.DialContext
-
 // Options provides all parameters required for the creation of an xDS client.
 type Options struct {
 	// Config contains a fully populated bootstrap config. It is the
@@ -73,7 +70,7 @@ func New(opts Options) (*Client, error) {
 	dopts := append([]grpc.DialOption{opts.Config.Creds}, opts.DialOpts...)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	cc, err := dialFunc(ctx, opts.Config.BalancerName, dopts...)
+	cc, err := grpc.DialContext(ctx, opts.Config.BalancerName, dopts...)
 	if err != nil {
 		// An error from a non-blocking dial indicates something serious.
 		return nil, fmt.Errorf("xds: failed to dial balancer {%s}: %v", opts.Config.BalancerName, err)

--- a/xds/internal/client/client.go
+++ b/xds/internal/client/client.go
@@ -21,7 +21,6 @@
 package client
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"sync"
@@ -68,9 +67,7 @@ func New(opts Options) (*Client, error) {
 	}
 
 	dopts := append([]grpc.DialOption{opts.Config.Creds}, opts.DialOpts...)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	cc, err := grpc.DialContext(ctx, opts.Config.BalancerName, dopts...)
+	cc, err := grpc.Dial(opts.Config.BalancerName, dopts...)
 	if err != nil {
 		// An error from a non-blocking dial indicates something serious.
 		return nil, fmt.Errorf("xds: failed to dial balancer {%s}: %v", opts.Config.BalancerName, err)

--- a/xds/internal/client/client_test.go
+++ b/xds/internal/client/client_test.go
@@ -40,7 +40,7 @@ func clientOpts(balancerName string) Options {
 		},
 		// WithTimeout is deprecated. But we are OK to call it here from the
 		// test, so we clearly know that the dial failed.
-		DialOpts: []grpc.DialOption{grpc.WithTimeout(5 * time.Second)},
+		DialOpts: []grpc.DialOption{grpc.WithTimeout(5 * time.Second), grpc.WithBlock()},
 	}
 }
 

--- a/xds/internal/client/client_test.go
+++ b/xds/internal/client/client_test.go
@@ -38,7 +38,9 @@ func clientOpts(balancerName string) Options {
 			Creds:        grpc.WithInsecure(),
 			NodeProto:    &corepb.Node{},
 		},
-		DialOpts: []grpc.DialOption{grpc.WithBlock()},
+		// WithTimeout is deprecated. But we are OK to call it here from the
+		// test, so we clearly know that the dial failed.
+		DialOpts: []grpc.DialOption{grpc.WithTimeout(5 * time.Second)},
 	}
 }
 

--- a/xds/internal/client/eds_test.go
+++ b/xds/internal/client/eds_test.go
@@ -302,6 +302,7 @@ func TestEDSWatchExpiryTimer(t *testing.T) {
 		sCleanup()
 	}()
 	v2c := newV2Client(client, goodNodeProto, func(int) time.Duration { return 0 })
+	defer v2c.close()
 	t.Log("Started xds v2Client...")
 
 	edsCallbackCh := make(chan error, 1)

--- a/xds/internal/client/eds_test.go
+++ b/xds/internal/client/eds_test.go
@@ -162,8 +162,12 @@ var (
 )
 
 func TestHandleEDSResponse(t *testing.T) {
-	fakeServer, client, cleanup := fakexds.StartClientAndServer(t)
-	defer cleanup()
+	fakeServer, sCleanup := fakexds.StartServer(t)
+	client, cCleanup := fakeServer.GetClientConn(t)
+	defer func() {
+		cCleanup()
+		sCleanup()
+	}()
 	v2c := newV2Client(client, goodNodeProto, func(int) time.Duration { return 0 })
 
 	tests := []struct {
@@ -271,8 +275,12 @@ func TestHandleEDSResponse(t *testing.T) {
 // TestHandleEDSResponseWithoutEDSWatch tests the case where the v2Client
 // receives an EDS response without a registered EDS watcher.
 func TestHandleEDSResponseWithoutEDSWatch(t *testing.T) {
-	_, client, cleanup := fakexds.StartClientAndServer(t)
-	defer cleanup()
+	fakeServer, sCleanup := fakexds.StartServer(t)
+	client, cCleanup := fakeServer.GetClientConn(t)
+	defer func() {
+		cCleanup()
+		sCleanup()
+	}()
 	v2c := newV2Client(client, goodNodeProto, func(int) time.Duration { return 0 })
 
 	if v2c.handleEDSResponse(goodEDSResponse1) == nil {
@@ -287,11 +295,13 @@ func TestEDSWatchExpiryTimer(t *testing.T) {
 		defaultWatchExpiryTimeout = oldWatchExpiryTimeout
 	}()
 
-	fakeServer, client, cleanup := fakexds.StartClientAndServer(t)
-	defer cleanup()
-
+	fakeServer, sCleanup := fakexds.StartServer(t)
+	client, cCleanup := fakeServer.GetClientConn(t)
+	defer func() {
+		cCleanup()
+		sCleanup()
+	}()
 	v2c := newV2Client(client, goodNodeProto, func(int) time.Duration { return 0 })
-	defer v2c.close()
 	t.Log("Started xds v2Client...")
 
 	edsCallbackCh := make(chan error, 1)

--- a/xds/internal/client/fakexds/fakexds.go
+++ b/xds/internal/client/fakexds/fakexds.go
@@ -85,8 +85,8 @@ func StartServer(t *testing.T) (*Server, func()) {
 	t.Logf("Starting fake xDS server at %v...", fs.Address)
 
 	return fs, func() {
-		server.Stop()
 		lis.Close()
+		server.Stop()
 	}
 }
 

--- a/xds/internal/client/fakexds/fakexds.go
+++ b/xds/internal/client/fakexds/fakexds.go
@@ -84,10 +84,7 @@ func StartServer(t *testing.T) (*Server, func()) {
 	go server.Serve(lis)
 	t.Logf("Starting fake xDS server at %v...", fs.Address)
 
-	return fs, func() {
-		lis.Close()
-		server.Stop()
-	}
+	return fs, func() { server.Stop() }
 }
 
 // GetClientConn returns a grpc.ClientConn talking to the fake server. The
@@ -105,7 +102,6 @@ func (fs *Server) GetClientConn(t *testing.T) (*grpc.ClientConn, func()) {
 	t.Log("Started xDS gRPC client...")
 
 	return cc, func() {
-		cancel()
 		cc.Close()
 	}
 }

--- a/xds/internal/client/fakexds/fakexds.go
+++ b/xds/internal/client/fakexds/fakexds.go
@@ -60,19 +60,16 @@ type Server struct {
 	// ResponseChan is a buffered channel from which the fake server reads the
 	// responses that it must send out to the client.
 	ResponseChan chan *Response
+	// Address is the host:port on which the fake xdsServer is listening on.
+	Address string
 }
 
-// StartClientAndServer starts a fakexds.Server and creates a ClientConn
-// talking to it. The returned cleanup function should be invoked by the caller
-// once the test is done.
-// TODO: Split this into two funcs, one to return a server and one to return a
-// ClientConn connected to this server, and change tests accordingly.
-func StartClientAndServer(t *testing.T) (*Server, *grpc.ClientConn, func()) {
+// StartServer starts a fakexds.Server. The returned function should be invoked
+// by the caller once the test is done.
+func StartServer(t *testing.T) (*Server, func()) {
 	t.Helper()
 
-	var lis net.Listener
-	var err error
-	lis, err = net.Listen("tcp", "localhost:0")
+	lis, err := net.Listen("tcp", "localhost:0")
 	if err != nil {
 		t.Fatalf("net.Listen() failed: %v", err)
 	}
@@ -81,30 +78,35 @@ func StartClientAndServer(t *testing.T) (*Server, *grpc.ClientConn, func()) {
 	fs := &Server{
 		RequestChan:  make(chan *Request, defaultChannelBufferSize),
 		ResponseChan: make(chan *Response, defaultChannelBufferSize),
+		Address:      lis.Addr().String(),
 	}
 	adsgrpc.RegisterAggregatedDiscoveryServiceServer(server, fs)
 	go server.Serve(lis)
-	t.Logf("Starting fake xDS server at %v...", lis.Addr().String())
-	defer func() {
-		if err != nil {
-			server.Stop()
-			lis.Close()
-		}
-	}()
+	t.Logf("Starting fake xDS server at %v...", fs.Address)
+
+	return fs, func() {
+		server.Stop()
+		lis.Close()
+	}
+}
+
+// GetClientConn returns a grpc.ClientConn talking to the fake server. The
+// returned function should be invoked by the caller once the test is done.
+func (fs *Server) GetClientConn(t *testing.T) (*grpc.ClientConn, func()) {
+	t.Helper()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	var cc *grpc.ClientConn
-	cc, err = grpc.DialContext(ctx, lis.Addr().String(), grpc.WithInsecure(), grpc.WithBlock())
+	cc, err := grpc.DialContext(ctx, fs.Address, grpc.WithInsecure(), grpc.WithBlock())
 	if err != nil {
-		t.Fatalf("grpc.DialContext(%s) failed: %v", lis.Addr().String(), err)
+		t.Fatalf("grpc.DialContext(%s) failed: %v", fs.Address, err)
 	}
 	t.Log("Started xDS gRPC client...")
 
-	return fs, cc, func() {
-		server.Stop()
-		lis.Close()
+	return cc, func() {
+		cancel()
+		cc.Close()
 	}
 }
 

--- a/xds/internal/client/lds_test.go
+++ b/xds/internal/client/lds_test.go
@@ -91,8 +91,12 @@ func TestGetRouteConfigNameFromListener(t *testing.T) {
 // and creates a v2Client using it. Then, it registers a watchLDS and tests
 // different LDS responses.
 func TestHandleLDSResponse(t *testing.T) {
-	fakeServer, client, cleanup := fakexds.StartClientAndServer(t)
-	defer cleanup()
+	fakeServer, sCleanup := fakexds.StartServer(t)
+	client, cCleanup := fakeServer.GetClientConn(t)
+	defer func() {
+		cCleanup()
+		sCleanup()
+	}()
 	v2c := newV2Client(client, goodNodeProto, func(int) time.Duration { return 0 })
 
 	tests := []struct {
@@ -223,8 +227,12 @@ func TestHandleLDSResponse(t *testing.T) {
 // TestHandleLDSResponseWithoutWatch tests the case where the v2Client receives
 // an LDS response without a registered watcher.
 func TestHandleLDSResponseWithoutWatch(t *testing.T) {
-	_, client, cleanup := fakexds.StartClientAndServer(t)
-	defer cleanup()
+	fakeServer, sCleanup := fakexds.StartServer(t)
+	client, cCleanup := fakeServer.GetClientConn(t)
+	defer func() {
+		cCleanup()
+		sCleanup()
+	}()
 	v2c := newV2Client(client, goodNodeProto, func(int) time.Duration { return 0 })
 
 	if v2c.handleLDSResponse(goodLDSResponse1) == nil {
@@ -242,8 +250,12 @@ func TestLDSWatchExpiryTimer(t *testing.T) {
 		defaultWatchExpiryTimeout = oldWatchExpiryTimeout
 	}()
 
-	fakeServer, client, cleanup := fakexds.StartClientAndServer(t)
-	defer cleanup()
+	fakeServer, sCleanup := fakexds.StartServer(t)
+	client, cCleanup := fakeServer.GetClientConn(t)
+	defer func() {
+		cCleanup()
+		sCleanup()
+	}()
 	v2c := newV2Client(client, goodNodeProto, func(int) time.Duration { return 0 })
 
 	// Wait till the request makes it to the fakeServer. This ensures that

--- a/xds/internal/client/rds_test.go
+++ b/xds/internal/client/rds_test.go
@@ -144,8 +144,12 @@ func TestGetClusterFromRouteConfiguration(t *testing.T) {
 // and creates a v2Client using it. Then, it registers an LDS and RDS watcher
 // and tests different RDS responses.
 func TestHandleRDSResponse(t *testing.T) {
-	fakeServer, client, cleanup := fakexds.StartClientAndServer(t)
-	defer cleanup()
+	fakeServer, sCleanup := fakexds.StartServer(t)
+	client, cCleanup := fakeServer.GetClientConn(t)
+	defer func() {
+		cCleanup()
+		sCleanup()
+	}()
 	v2c := newV2Client(client, goodNodeProto, func(int) time.Duration { return 0 })
 
 	// Register an LDS watcher, and wait till the request is sent out, the
@@ -262,8 +266,12 @@ func TestHandleRDSResponse(t *testing.T) {
 // TestHandleRDSResponseWithoutLDSWatch tests the case where the v2Client
 // receives an RDS response without a registered LDS watcher.
 func TestHandleRDSResponseWithoutLDSWatch(t *testing.T) {
-	_, client, cleanup := fakexds.StartClientAndServer(t)
-	defer cleanup()
+	fakeServer, sCleanup := fakexds.StartServer(t)
+	client, cCleanup := fakeServer.GetClientConn(t)
+	defer func() {
+		cCleanup()
+		sCleanup()
+	}()
 	v2c := newV2Client(client, goodNodeProto, func(int) time.Duration { return 0 })
 
 	if v2c.handleRDSResponse(goodRDSResponse1) == nil {
@@ -274,8 +282,12 @@ func TestHandleRDSResponseWithoutLDSWatch(t *testing.T) {
 // TestHandleRDSResponseWithoutRDSWatch tests the case where the v2Client
 // receives an RDS response without a registered RDS watcher.
 func TestHandleRDSResponseWithoutRDSWatch(t *testing.T) {
-	fakeServer, client, cleanup := fakexds.StartClientAndServer(t)
-	defer cleanup()
+	fakeServer, sCleanup := fakexds.StartServer(t)
+	client, cCleanup := fakeServer.GetClientConn(t)
+	defer func() {
+		cCleanup()
+		sCleanup()
+	}()
 	v2c := newV2Client(client, goodNodeProto, func(int) time.Duration { return 0 })
 
 	// Register an LDS watcher, and wait till the request is sent out, the
@@ -319,9 +331,12 @@ type testOp struct {
 func testRDSCaching(t *testing.T, testOps []testOp, errCh chan error) {
 	t.Helper()
 
-	fakeServer, client, cleanup := fakexds.StartClientAndServer(t)
-	defer cleanup()
-
+	fakeServer, sCleanup := fakexds.StartServer(t)
+	client, cCleanup := fakeServer.GetClientConn(t)
+	defer func() {
+		cCleanup()
+		sCleanup()
+	}()
 	v2c := newV2Client(client, goodNodeProto, func(int) time.Duration { return 0 })
 	defer v2c.close()
 	t.Log("Started xds v2Client...")
@@ -450,9 +465,12 @@ func TestRDSWatchExpiryTimer(t *testing.T) {
 		defaultWatchExpiryTimeout = oldWatchExpiryTimeout
 	}()
 
-	fakeServer, client, cleanup := fakexds.StartClientAndServer(t)
-	defer cleanup()
-
+	fakeServer, sCleanup := fakexds.StartServer(t)
+	client, cCleanup := fakeServer.GetClientConn(t)
+	defer func() {
+		cCleanup()
+		sCleanup()
+	}()
 	v2c := newV2Client(client, goodNodeProto, func(int) time.Duration { return 0 })
 	defer v2c.close()
 	t.Log("Started xds v2Client...")

--- a/xds/internal/client/v2client_test.go
+++ b/xds/internal/client/v2client_test.go
@@ -371,8 +371,12 @@ var (
 // TestV2ClientBackoffAfterRecvError verifies if the v2Client backoffs when it
 // encounters a Recv error while receiving an LDS response.
 func TestV2ClientBackoffAfterRecvError(t *testing.T) {
-	fakeServer, client, cleanup := fakexds.StartClientAndServer(t)
-	defer cleanup()
+	fakeServer, sCleanup := fakexds.StartServer(t)
+	client, cCleanup := fakeServer.GetClientConn(t)
+	defer func() {
+		cCleanup()
+		sCleanup()
+	}()
 
 	// Override the v2Client backoff function with this, so that we can verify
 	// that a backoff actually was triggerred.
@@ -412,9 +416,12 @@ func TestV2ClientBackoffAfterRecvError(t *testing.T) {
 // encountered a Recv() error, and is expected to send out xDS requests for
 // registered watchers once it comes back up again.
 func TestV2ClientRetriesAfterBrokenStream(t *testing.T) {
-	fakeServer, client, cleanup := fakexds.StartClientAndServer(t)
-	defer cleanup()
-
+	fakeServer, sCleanup := fakexds.StartServer(t)
+	client, cCleanup := fakeServer.GetClientConn(t)
+	defer func() {
+		cCleanup()
+		sCleanup()
+	}()
 	v2c := newV2Client(client, goodNodeProto, func(int) time.Duration { return 0 })
 	defer v2c.close()
 	t.Log("Started xds v2Client...")
@@ -457,9 +464,12 @@ func TestV2ClientRetriesAfterBrokenStream(t *testing.T) {
 // TestV2ClientCancelWatch verifies that the registered watch callback is not
 // invoked if a response is received after the watcher is cancelled.
 func TestV2ClientCancelWatch(t *testing.T) {
-	fakeServer, client, cleanup := fakexds.StartClientAndServer(t)
-	defer cleanup()
-
+	fakeServer, sCleanup := fakexds.StartServer(t)
+	client, cCleanup := fakeServer.GetClientConn(t)
+	defer func() {
+		cCleanup()
+		sCleanup()
+	}()
 	v2c := newV2Client(client, goodNodeProto, func(int) time.Duration { return 0 })
 	defer v2c.close()
 	t.Log("Started xds v2Client...")


### PR DESCRIPTION
* Add a helper to the fakexds package to return a ClientConn talking to
  the fake server.
* Tests will make use of this ClientConn wherever required, or they will
  directly pass the fake server's address as the balancerName to the
  xdsclient.New() function, thus exercising that code path as well.