### PR TITLE
benchmark: Enable server keepalive in benchmarks

### DIFF
--- a/benchmark/benchmain/main.go
+++ b/benchmark/benchmain/main.go
@@ -143,9 +143,11 @@ var (
 		networkModeWAN:   latency.WAN,
 		networkLongHaul:  latency.Longhaul,
 	}
-	keepaliveTime    = 10 * time.Second       // This is the minimum allowed
-	keepaliveMinTime = 800 * time.Millisecond // This is 0.8*keepaliveTime
+	keepaliveTime    = 10 * time.Second
 	keepaliveTimeout = 1 * time.Second
+	// This is 0.8*keepaliveTime to prevent connection issues because of server
+	// keepalive enforcement.
+	keepaliveMinTime = 8 * time.Second
 )
 
 // runModes indicates the workloads to run. This is initialized with a call to

--- a/benchmark/benchmain/main.go
+++ b/benchmark/benchmain/main.go
@@ -143,7 +143,8 @@ var (
 		networkModeWAN:   latency.WAN,
 		networkLongHaul:  latency.Longhaul,
 	}
-	keepaliveTime    = 10 * time.Second // this is the minimum allowed
+	keepaliveTime    = 10 * time.Second       // This is the minimum allowed
+	keepaliveMinTime = 800 * time.Millisecond // This is 0.8*keepaliveTime
 	keepaliveTimeout = 1 * time.Second
 )
 
@@ -281,7 +282,7 @@ func makeClient(bf stats.Features) (testpb.BenchmarkServiceClient, func()) {
 				Timeout: keepaliveTimeout,
 			}),
 			grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
-				MinTime:             keepaliveTime,
+				MinTime:             keepaliveMinTime,
 				PermitWithoutStream: true,
 			}),
 		)

--- a/benchmark/benchmain/main.go
+++ b/benchmark/benchmain/main.go
@@ -275,6 +275,16 @@ func makeClient(bf stats.Features) (testpb.BenchmarkServiceClient, func()) {
 		)
 	}
 	if bf.EnableKeepalive {
+		sopts = append(sopts,
+			grpc.KeepaliveParams(keepalive.ServerParameters{
+				Time:    keepaliveTime,
+				Timeout: keepaliveTimeout,
+			}),
+			grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
+				MinTime:             keepaliveTime,
+				PermitWithoutStream: true,
+			}),
+		)
 		opts = append(opts,
 			grpc.WithKeepaliveParams(keepalive.ClientParameters{
 				Time:                keepaliveTime,


### PR DESCRIPTION
I decided to reuse the same flag used to enable client-side keepalives for this one. Thought there wouldn't be a case where one would want to enable just the server side keepalives in benchmarks.