### PR TITLE
dns: do not call NewServiceConfig when lookups are disabled

### DIFF
--- a/internal/resolver/dns/dns_resolver.go
+++ b/internal/resolver/dns/dns_resolver.go
@@ -268,7 +268,9 @@ func (d *dnsResolver) watcher() {
 			d.retryCount = 0
 			d.t.Reset(d.freq)
 		}
-		d.cc.NewServiceConfig(sc)
+		if sc != "" { // We get empty string when disabled or the TXT lookup failed.
+			d.cc.NewServiceConfig(sc)
+		}
 		d.cc.NewAddress(result)
 
 		// Sleep to prevent excessive re-resolutions. Incoming resolution requests

--- a/internal/resolver/dns/dns_resolver_test.go
+++ b/internal/resolver/dns/dns_resolver_test.go
@@ -610,7 +610,8 @@ func generateSC(name string) string {
 func generateSCF(cfg string) []string {
 	b := append([]byte(txtAttribute), []byte(cfg)...)
 
-	// Split b into multiple strings, each with a max of 255 bytes.
+	// Split b into multiple strings, each with a max of 255 bytes, which is
+	// the DNS TXT record limit.
 	var r []string
 	for i := 0; i < len(b); i += txtBytesLimit {
 		if i+txtBytesLimit > len(b) {

--- a/internal/resolver/dns/dns_resolver_test.go
+++ b/internal/resolver/dns/dns_resolver_test.go
@@ -610,6 +610,7 @@ func generateSC(name string) string {
 func generateSCF(cfg string) []string {
 	b := append([]byte(txtAttribute), []byte(cfg)...)
 
+	// Split b into multiple strings, each with a max of 255 bytes.
 	var r []string
 	for i := 0; i < len(b); i += txtBytesLimit {
 		if i+txtBytesLimit > len(b) {

--- a/resolver_conn_wrapper.go
+++ b/resolver_conn_wrapper.go
@@ -217,6 +217,10 @@ func (ccr *ccResolverWrapper) NewServiceConfig(sc string) {
 		return
 	}
 	grpclog.Infof("ccResolverWrapper: got new service config: %v", sc)
+	if ccr.cc.dopts.disableServiceConfig {
+		grpclog.Infof("Service config lookups disabled; ignoring config")
+		return
+	}
 	scpr := parseServiceConfig(sc)
 	if scpr.Err != nil {
 		grpclog.Warningf("ccResolverWrapper: error parsing service config: %v", scpr.Err)


### PR DESCRIPTION
Also:
- Fully ignore `NewServiceConfig` calls in `resolver_conn_wrapper`
- Fix `dns_resolver_test` to actually test service configs, and a handful of cleanups

Fixes #3199

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grpc/grpc-go/3201)
<!-- Reviewable:end -->
