### PR TITLE
xds: change lrs server name field in xds balancer config to a string pointer

### DIFF
--- a/internal/proto/grpc_service_config/example_test.go
+++ b/internal/proto/grpc_service_config/example_test.go
@@ -30,22 +30,22 @@ import (
 // TestXdsConfigMarshalToJSON is an example to print json format of xds_config.
 func TestXdsConfigMarshalToJSON(t *testing.T) {
 	c := &scpb.XdsConfig{
-		ChildPolicy: []*scpb.LoadBalancingConfig{
-			{Policy: &scpb.LoadBalancingConfig_Grpclb{
-				Grpclb: &scpb.GrpcLbConfig{},
-			}},
-			{Policy: &scpb.LoadBalancingConfig_RoundRobin{
-				RoundRobin: &scpb.RoundRobinConfig{},
-			}},
-		},
-		FallbackPolicy: []*scpb.LoadBalancingConfig{
-			{Policy: &scpb.LoadBalancingConfig_Grpclb{
-				Grpclb: &scpb.GrpcLbConfig{},
-			}},
-			{Policy: &scpb.LoadBalancingConfig_PickFirst{
-				PickFirst: &scpb.PickFirstConfig{},
-			}},
-		},
+		// ChildPolicy: []*scpb.LoadBalancingConfig{
+		// 	{Policy: &scpb.LoadBalancingConfig_Grpclb{
+		// 		Grpclb: &scpb.GrpcLbConfig{},
+		// 	}},
+		// 	{Policy: &scpb.LoadBalancingConfig_RoundRobin{
+		// 		RoundRobin: &scpb.RoundRobinConfig{},
+		// 	}},
+		// },
+		// FallbackPolicy: []*scpb.LoadBalancingConfig{
+		// 	{Policy: &scpb.LoadBalancingConfig_Grpclb{
+		// 		Grpclb: &scpb.GrpcLbConfig{},
+		// 	}},
+		// 	{Policy: &scpb.LoadBalancingConfig_PickFirst{
+		// 		PickFirst: &scpb.PickFirstConfig{},
+		// 	}},
+		// },
 		EdsServiceName: "eds.service.name",
 		LrsLoadReportingServerName: &wrapperspb.StringValue{
 			Value: "lrs.server.name",

--- a/internal/proto/grpc_service_config/example_test.go
+++ b/internal/proto/grpc_service_config/example_test.go
@@ -30,22 +30,22 @@ import (
 // TestXdsConfigMarshalToJSON is an example to print json format of xds_config.
 func TestXdsConfigMarshalToJSON(t *testing.T) {
 	c := &scpb.XdsConfig{
-		// ChildPolicy: []*scpb.LoadBalancingConfig{
-		// 	{Policy: &scpb.LoadBalancingConfig_Grpclb{
-		// 		Grpclb: &scpb.GrpcLbConfig{},
-		// 	}},
-		// 	{Policy: &scpb.LoadBalancingConfig_RoundRobin{
-		// 		RoundRobin: &scpb.RoundRobinConfig{},
-		// 	}},
-		// },
-		// FallbackPolicy: []*scpb.LoadBalancingConfig{
-		// 	{Policy: &scpb.LoadBalancingConfig_Grpclb{
-		// 		Grpclb: &scpb.GrpcLbConfig{},
-		// 	}},
-		// 	{Policy: &scpb.LoadBalancingConfig_PickFirst{
-		// 		PickFirst: &scpb.PickFirstConfig{},
-		// 	}},
-		// },
+		ChildPolicy: []*scpb.LoadBalancingConfig{
+			{Policy: &scpb.LoadBalancingConfig_Grpclb{
+				Grpclb: &scpb.GrpcLbConfig{},
+			}},
+			{Policy: &scpb.LoadBalancingConfig_RoundRobin{
+				RoundRobin: &scpb.RoundRobinConfig{},
+			}},
+		},
+		FallbackPolicy: []*scpb.LoadBalancingConfig{
+			{Policy: &scpb.LoadBalancingConfig_Grpclb{
+				Grpclb: &scpb.GrpcLbConfig{},
+			}},
+			{Policy: &scpb.LoadBalancingConfig_PickFirst{
+				PickFirst: &scpb.PickFirstConfig{},
+			}},
+		},
 		EdsServiceName: "eds.service.name",
 		LrsLoadReportingServerName: &wrapperspb.StringValue{
 			Value: "lrs.server.name",

--- a/xds/internal/balancer/config.go
+++ b/xds/internal/balancer/config.go
@@ -43,9 +43,6 @@ type XDSConfig struct {
 	// LRS server to send load reports to.  If not present, load reporting
 	// will be disabled.  If set to the empty string, load reporting will
 	// be sent to the same server that we obtained CDS data from.
-	//
-	// TODO: this should be a pointer to a string, so nil means load reporting
-	// is disabled.
 	LrsLoadReportingServerName *string
 }
 

--- a/xds/internal/balancer/config.go
+++ b/xds/internal/balancer/config.go
@@ -46,7 +46,7 @@ type XDSConfig struct {
 	//
 	// TODO: this should be a pointer to a string, so nil means load reporting
 	// is disabled.
-	LrsLoadReportingServerName string
+	LrsLoadReportingServerName *string
 }
 
 // xdsConfigJSON is the intermediate unmarshal result of XDSConfig. ChildPolicy
@@ -57,7 +57,7 @@ type xdsConfigJSON struct {
 	ChildPolicy                []*loadBalancingConfig
 	FallbackPolicy             []*loadBalancingConfig
 	EDSServiceName             string
-	LRSLoadReportingServerName string
+	LRSLoadReportingServerName *string
 }
 
 // UnmarshalJSON parses the JSON-encoded byte slice in data and stores it in l.

--- a/xds/internal/balancer/xds.go
+++ b/xds/internal/balancer/xds.go
@@ -90,7 +90,7 @@ func (b *edsBalancerBuilder) Name() string {
 func (b *edsBalancerBuilder) ParseConfig(c json.RawMessage) (serviceconfig.LoadBalancingConfig, error) {
 	var cfg XDSConfig
 	if err := json.Unmarshal(c, &cfg); err != nil {
-		return nil, fmt.Errorf("unable to unmarshal balancer config %s into xds config", string(c))
+		return nil, fmt.Errorf("unable to unmarshal balancer config %s into xds config, error: %v", string(c), err)
 	}
 	return &cfg, nil
 }

--- a/xds/internal/balancer/xds_client_test.go
+++ b/xds/internal/balancer/xds_client_test.go
@@ -136,7 +136,7 @@ func (s) TestEDSClientResponseHandling(t *testing.T) {
 		client.handleUpdate(&XDSConfig{
 			BalancerName:               td.Address,
 			EDSServiceName:             test.edsServiceName,
-			LrsLoadReportingServerName: "",
+			LrsLoadReportingServerName: nil,
 		}, nil)
 		req := <-td.RequestChan
 		if req.Err != nil {
@@ -201,7 +201,7 @@ func (s) TestEDSClientInAttributes(t *testing.T) {
 	defer client.close()
 
 	client.handleUpdate(
-		&XDSConfig{EDSServiceName: testEDSClusterName, LrsLoadReportingServerName: ""},
+		&XDSConfig{EDSServiceName: testEDSClusterName, LrsLoadReportingServerName: nil},
 		attributes.New(xdsinternal.XDSClientID, c),
 	)
 
@@ -236,7 +236,7 @@ func (s) TestEDSClientInAttributes(t *testing.T) {
 
 	// Update with a new xds_client in attributes.
 	client.handleUpdate(
-		&XDSConfig{EDSServiceName: "", LrsLoadReportingServerName: ""},
+		&XDSConfig{EDSServiceName: "", LrsLoadReportingServerName: nil},
 		attributes.New(xdsinternal.XDSClientID, c2),
 	)
 
@@ -292,7 +292,7 @@ func (s) TestEDSServiceNameUpdate(t *testing.T) {
 	defer client.close()
 
 	client.handleUpdate(
-		&XDSConfig{EDSServiceName: testEDSClusterName, LrsLoadReportingServerName: ""},
+		&XDSConfig{EDSServiceName: testEDSClusterName, LrsLoadReportingServerName: nil},
 		attributes.New(xdsinternal.XDSClientID, c),
 	)
 
@@ -313,7 +313,7 @@ func (s) TestEDSServiceNameUpdate(t *testing.T) {
 
 	// Update with a new edsServiceName.
 	client.handleUpdate(
-		&XDSConfig{EDSServiceName: "", LrsLoadReportingServerName: ""},
+		&XDSConfig{EDSServiceName: "", LrsLoadReportingServerName: nil},
 		attributes.New(xdsinternal.XDSClientID, c),
 	)
 

--- a/xds/internal/balancer/xds_lrs_test.go
+++ b/xds/internal/balancer/xds_lrs_test.go
@@ -56,6 +56,9 @@ func (s) TestXdsLoadReporting(t *testing.T) {
 
 	cfg := &XDSConfig{
 		BalancerName: td.Address,
+		// Set lrs server name to an empty string, instead of nil, so the xds
+		// server will be used for LRS.
+		LrsLoadReportingServerName: new(string),
 	}
 	lb.UpdateClientConnState(balancer.ClientConnState{BalancerConfig: cfg})
 	td.ResponseChan <- &fakexds.Response{Resp: testEDSResp}

--- a/xds/internal/balancer/xds_test.go
+++ b/xds/internal/balancer/xds_test.go
@@ -773,10 +773,8 @@ func (s) TestXdsBalancerFallBackSignalFromEdsBalancer(t *testing.T) {
 }
 
 func TestXdsBalancerConfigParsing(t *testing.T) {
-	const (
-		testEDSName = "eds.service"
-		testLRSName = "lrs.server"
-	)
+	const testEDSName = "eds.service"
+	var testLRSName = "lrs.server"
 	b := bytes.NewBuffer(nil)
 	if err := (&jsonpb.Marshaler{}).Marshal(b, &scpb.XdsConfig{
 		ChildPolicy: []*scpb.LoadBalancingConfig{
@@ -816,7 +814,7 @@ func TestXdsBalancerConfigParsing(t *testing.T) {
 					Config: json.RawMessage("{}"),
 				},
 				EDSServiceName:             testEDSName,
-				LrsLoadReportingServerName: testLRSName,
+				LrsLoadReportingServerName: &testLRSName,
 			},
 			wantErr: false,
 		},
@@ -850,7 +848,23 @@ func TestXdsBalancerConfigParsing(t *testing.T) {
 					Config: json.RawMessage("{}"),
 				},
 				EDSServiceName:             testEDSName,
-				LrsLoadReportingServerName: testLRSName,
+				LrsLoadReportingServerName: &testLRSName,
+			},
+			wantErr: false,
+		},
+		{
+			// json with no lrs server name, LrsLoadReportingServerName should
+			// be nil (not an empty string).
+			name: "no-lrs-server-name",
+			js: json.RawMessage(`
+{
+  "balancerName": "fake.foo.bar",
+  "edsServiceName": "eds.service"
+}`),
+			want: &XDSConfig{
+				BalancerName:               "fake.foo.bar",
+				EDSServiceName:             testEDSName,
+				LrsLoadReportingServerName: nil,
 			},
 			wantErr: false,
 		},
@@ -906,6 +920,33 @@ func TestLoadbalancingConfigParsing(t *testing.T) {
 			var cfg XDSConfig
 			if err := json.Unmarshal([]byte(tt.s), &cfg); err != nil || !reflect.DeepEqual(&cfg, tt.want) {
 				t.Errorf("test name: %s, parseFullServiceConfig() = %+v, err: %v, want %+v, <nil>", tt.name, cfg, err, tt.want)
+			}
+		})
+	}
+}
+
+func TestEqualStringPointers(t *testing.T) {
+	var (
+		ta1 = "test-a"
+		ta2 = "test-a"
+		tb  = "test-b"
+	)
+	tests := []struct {
+		name string
+		a    *string
+		b    *string
+		want bool
+	}{
+		{"both-nil", nil, nil, true},
+		{"a-non-nil", &ta1, nil, false},
+		{"b-non-nil", nil, &tb, false},
+		{"equal", &ta1, &ta2, true},
+		{"different", &ta1, &tb, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := equalStringPointers(tt.a, tt.b); got != tt.want {
+				t.Errorf("equalStringPointers() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
LRS is disabled if this field is nil (is unset in json). The xds server
will be used if it's a pointer to an empty string.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grpc/grpc-go/3210)
<!-- Reviewable:end -->
