### PR TITLE
xds: Minor refactoring, prep for CDS LB policy

### DIFF
--- a/xds/internal/client/cds.go
+++ b/xds/internal/client/cds.go
@@ -95,7 +95,7 @@ func (v2c *v2Client) handleCDSResponse(resp *xdspb.DiscoveryResponse) error {
 }
 
 func validateCluster(cluster *xdspb.Cluster) (CDSUpdate, error) {
-	emptyUpdate := CDSUpdate{ServiceName: "", DoLRS: false}
+	emptyUpdate := CDSUpdate{ServiceName: "", EnableLRS: false}
 	switch {
 	case cluster.GetType() != xdspb.Cluster_EDS:
 		return emptyUpdate, fmt.Errorf("xds: unexpected cluster type %v in response: %+v", cluster.GetType(), cluster)
@@ -107,6 +107,6 @@ func validateCluster(cluster *xdspb.Cluster) (CDSUpdate, error) {
 
 	return CDSUpdate{
 		ServiceName: cluster.GetEdsClusterConfig().GetServiceName(),
-		DoLRS:       cluster.GetLrsServer().GetSelf() != nil,
+		EnableLRS:   cluster.GetLrsServer().GetSelf() != nil,
 	}, nil
 }

--- a/xds/internal/client/cds_test.go
+++ b/xds/internal/client/cds_test.go
@@ -51,7 +51,7 @@ func (v2c *v2Client) cloneCDSCacheForTesting() map[string]CDSUpdate {
 }
 
 func TestValidateCluster(t *testing.T) {
-	emptyUpdate := CDSUpdate{ServiceName: "", DoLRS: false}
+	emptyUpdate := CDSUpdate{ServiceName: "", EnableLRS: false}
 	tests := []struct {
 		name       string
 		cluster    *xdspb.Cluster
@@ -138,12 +138,12 @@ func TestValidateCluster(t *testing.T) {
 				},
 				LbPolicy: xdspb.Cluster_ROUND_ROBIN,
 			},
-			wantUpdate: CDSUpdate{ServiceName: serviceName1, DoLRS: false},
+			wantUpdate: CDSUpdate{ServiceName: serviceName1, EnableLRS: false},
 		},
 		{
 			name:       "happiest-case",
 			cluster:    goodCluster1,
-			wantUpdate: CDSUpdate{ServiceName: serviceName1, DoLRS: true},
+			wantUpdate: CDSUpdate{ServiceName: serviceName1, EnableLRS: true},
 		},
 	}
 
@@ -217,7 +217,7 @@ func TestCDSHandleResponse(t *testing.T) {
 			name:          "one-good-cluster",
 			cdsResponse:   goodCDSResponse1,
 			wantErr:       false,
-			wantUpdate:    &CDSUpdate{ServiceName: serviceName1, DoLRS: true},
+			wantUpdate:    &CDSUpdate{ServiceName: serviceName1, EnableLRS: true},
 			wantUpdateErr: false,
 		},
 	}

--- a/xds/internal/client/client.go
+++ b/xds/internal/client/client.go
@@ -154,6 +154,12 @@ func (c *Client) WatchService(serviceName string, callback func(ServiceUpdate, e
 	}
 }
 
+// WatchCluster uses CDS to discover information about the provided
+// clusterName.
+func (c *Client) WatchCluster(clusterName string, cdsCb func(CDSUpdate, error)) (cancel func()) {
+	return c.v2c.watchCDS(clusterName, cdsCb)
+}
+
 // WatchEDS watches the ghost.
 func (c *Client) WatchEDS(clusterName string, edsCb func(*EDSUpdate, error)) (cancel func()) {
 	return c.v2c.watchEDS(clusterName, edsCb)

--- a/xds/internal/client/types.go
+++ b/xds/internal/client/types.go
@@ -92,8 +92,8 @@ type CDSUpdate struct {
 	// ServiceName is the service name corresponding to the clusterName which
 	// is being watched for through CDS.
 	ServiceName string
-	// DoLRS indicates whether or not load should be reported through LRS.
-	DoLRS bool
+	// EnableLRS indicates whether or not load should be reported through LRS.
+	EnableLRS bool
 }
 type cdsCallback func(CDSUpdate, error)
 

--- a/xds/internal/client/types.go
+++ b/xds/internal/client/types.go
@@ -86,10 +86,15 @@ type rdsUpdate struct {
 }
 type rdsCallback func(rdsUpdate, error)
 
-type cdsUpdate struct {
-	serviceName string
-	doLRS       bool
+// CDSUpdate contains information from a received CDS response, which is of
+// interest to the registered CDS watcher.
+type CDSUpdate struct {
+	// ServiceName is the service name corresponding to the clusterName which
+	// is being watched for through CDS.
+	ServiceName string
+	// DoLRS indicates whether or not load should be reported through LRS.
+	DoLRS bool
 }
-type cdsCallback func(cdsUpdate, error)
+type cdsCallback func(CDSUpdate, error)
 
 type edsCallback func(*EDSUpdate, error)

--- a/xds/internal/client/v2client.go
+++ b/xds/internal/client/v2client.go
@@ -74,7 +74,7 @@ type v2Client struct {
 	// unrequested resources.
 	// https://github.com/envoyproxy/envoy/blob/master/api/xds_protocol.rst#resource-hints
 	rdsCache map[string]string
-	// rdsCache maintains a mapping of {clusterName --> cdsUpdate} from
+	// rdsCache maintains a mapping of {clusterName --> CDSUpdate} from
 	// validated cluster configurations received in CDS responses. We cache all
 	// valid cluster configurations, whether or not we are interested in them
 	// when we received them (because we could become interested in them in the
@@ -83,7 +83,7 @@ type v2Client struct {
 	// resource_names field. As per the latest spec, the server should resend
 	// the response when the request changes, even if it had sent the same
 	// resource earlier (when not asked for). Protected by the above mutex.
-	cdsCache map[string]cdsUpdate
+	cdsCache map[string]CDSUpdate
 }
 
 // newV2Client creates a new v2Client initialized with the passed arguments.
@@ -95,7 +95,7 @@ func newV2Client(cc *grpc.ClientConn, nodeProto *corepb.Node, backoff func(int) 
 		watchCh:   buffer.NewUnbounded(),
 		watchMap:  make(map[resourceType]*watchInfo),
 		rdsCache:  make(map[string]string),
-		cdsCache:  make(map[string]cdsUpdate),
+		cdsCache:  make(map[string]CDSUpdate),
 	}
 	v2c.ctx, v2c.cancelCtx = context.WithCancel(context.Background())
 
@@ -416,7 +416,7 @@ func (v2c *v2Client) checkCacheAndUpdateWatchMap(wi *watchInfo) {
 		}
 		wi.expiryTimer = time.AfterFunc(defaultWatchExpiryTimeout, func() {
 			v2c.mu.Lock()
-			wi.callback.(cdsCallback)(cdsUpdate{}, fmt.Errorf("xds: CDS target %s not found", wi.target))
+			wi.callback.(cdsCallback)(CDSUpdate{}, fmt.Errorf("xds: CDS target %s not found", wi.target))
 			v2c.mu.Unlock()
 		})
 	case edsResource:


### PR DESCRIPTION
Export the `cdsUpdate` struct and its fields so that the watch call in xdsClient can simply be a passthrough to the v2Client (the way EDS watch is implemented).