### PR TITLE
reuse receive buffer

### DIFF
--- a/server.go
+++ b/server.go
@@ -968,7 +968,9 @@ func (s *Server) processUnaryRPC(t transport.ServerTransport, stream *transport.
 	if sh != nil || binlog != nil {
 		payInfo = &payloadInfo{}
 	}
-	d, err := recvAndDecompress(&parser{r: stream}, stream, dc, s.opts.maxReceiveMessageSize, payInfo, decomp)
+	b := getRecvBuffer()
+	defer freeRecvBuffer(b)
+	d, err := recvAndDecompress(&parser{r: stream}, stream, dc, s.opts.maxReceiveMessageSize, payInfo, decomp, b)
 	if err != nil {
 		if st, ok := status.FromError(err); ok {
 			if e := t.WriteStatus(stream, st); e != nil {


### PR DESCRIPTION
A way to reuse memory on read path. Partial resolve of #1455.
sync.Pool used to reuse []byte which used by recvMsg method of parser to read data from i/o layer. I've tried to make minimal changes in code to provide this.