### PR TITLE
Reuse buffer to reads gRPC messages  from the underlying reader

### DIFF
--- a/call_test.go
+++ b/call_test.go
@@ -65,9 +65,12 @@ type testStreamHandler struct {
 }
 
 func (h *testStreamHandler) handleStream(t *testing.T, s *transport.Stream) {
+	b := getRecvBuffer()
+	defer freeRecvBuffer(b)
+
 	p := &parser{r: s}
 	for {
-		pf, req, err := p.recvMsg(math.MaxInt32)
+		pf, req, err := p.recvMsg(math.MaxInt32, b)
 		if err == io.EOF {
 			break
 		}

--- a/internal/binarylog/binarylog_end2end_test.go
+++ b/internal/binarylog/binarylog_end2end_test.go
@@ -55,7 +55,13 @@ type testBinLogSink struct {
 
 func (s *testBinLogSink) Write(e *pb.GrpcLogEntry) error {
 	s.mu.Lock()
-	s.buf = append(s.buf, e)
+
+	// Write should serialize entry to newest allocated memory and send somewhere, entry can be reused after Write
+	b, _ := proto.Marshal(e)
+	se := &pb.GrpcLogEntry{}
+	proto.Unmarshal(b, se)
+
+	s.buf = append(s.buf, se)
 	s.mu.Unlock()
 	return nil
 }

--- a/internal/binarylog/binarylog_end2end_test.go
+++ b/internal/binarylog/binarylog_end2end_test.go
@@ -54,13 +54,12 @@ type testBinLogSink struct {
 }
 
 func (s *testBinLogSink) Write(e *pb.GrpcLogEntry) error {
-	s.mu.Lock()
-
 	// Write should serialize entry to newest allocated memory and send somewhere, entry can be reused after Write
 	b, _ := proto.Marshal(e)
 	se := &pb.GrpcLogEntry{}
 	proto.Unmarshal(b, se)
 
+	s.mu.Lock()
 	s.buf = append(s.buf, se)
 	s.mu.Unlock()
 	return nil

--- a/rpc_util.go
+++ b/rpc_util.go
@@ -907,7 +907,7 @@ func getRecvBuffer() *recvBuffer {
 	return recvBufferPool.Get().(*recvBuffer)
 }
 
-func freeRecvBuffer(b *recvBuffer) () {
+func freeRecvBuffer(b *recvBuffer) {
 	if b != nil && b.cap() < maxPooledRecvBufferSize {
 		recvBufferPool.Put(b)
 	}

--- a/server.go
+++ b/server.go
@@ -968,7 +968,9 @@ func (s *Server) processUnaryRPC(t transport.ServerTransport, stream *transport.
 	if sh != nil || binlog != nil {
 		payInfo = &payloadInfo{}
 	}
-	d, err := recvAndDecompress(&parser{r: stream}, stream, dc, s.opts.maxReceiveMessageSize, payInfo, decomp)
+	b := getRecvBuffer()
+	defer freeRecvBuffer(b)
+	d, err := recvAndDecompress(&parser{r: stream}, stream, dc, s.opts.maxReceiveMessageSize, payInfo, decomp, b)
 	if err != nil {
 		if st, ok := status.FromError(err); ok {
 			if e := t.WriteStatus(stream, st); e != nil {


### PR DESCRIPTION
A way to reuse memory on read path. Partial resolve of #1455.
sync.Pool used to reuse []byte which used by recvMsg method of parser to read data from i/o layer. I've tried to make minimal changes in code to provide this.
