### PR TITLE
godoc: clarify WithTimeout deprecation note

### DIFF
--- a/dialoptions.go
+++ b/dialoptions.go
@@ -346,8 +346,8 @@ func WithCredentialsBundle(b credentials.Bundle) DialOption {
 // WithTimeout returns a DialOption that configures a timeout for dialing a
 // ClientConn initially. This is valid if and only if WithBlock() is present.
 //
-// Deprecated: use DialContext and context.WithTimeout instead.  Will be
-// supported throughout 1.x.
+// Deprecated: use DialContext instead of Dial and context.WithTimeout
+// instead.  Will be supported throughout 1.x.
 func WithTimeout(d time.Duration) DialOption {
 	return newFuncDialOption(func(o *dialOptions) {
 		o.timeout = d


### PR DESCRIPTION
Tell people to replace Dial + WithTimeout by DialContext + context.WithTimeout.