### PR TITLE
xds: small fixes

### DIFF
--- a/xds/experimental/xds_experimental.go
+++ b/xds/experimental/xds_experimental.go
@@ -23,8 +23,8 @@
 package experimental
 
 import (
-	_ "google.golang.org/grpc/xds/internal/balancer"     // Register the xds_balancer
-	_ "google.golang.org/grpc/xds/internal/balancer/cdsbalancer"     // Register the cds balancer
-	_ "google.golang.org/grpc/xds/internal/resolver"     // Register the xds_resolver
-	_ "google.golang.org/grpc/xds/internal/resolver/old" // Register the old xds_resolver
+	_ "google.golang.org/grpc/xds/internal/balancer"             // Register the xds_balancer
+	_ "google.golang.org/grpc/xds/internal/balancer/cdsbalancer" // Register the cds balancer
+	_ "google.golang.org/grpc/xds/internal/resolver"             // Register the xds_resolver
+	_ "google.golang.org/grpc/xds/internal/resolver/old"         // Register the old xds_resolver
 )

--- a/xds/experimental/xds_experimental.go
+++ b/xds/experimental/xds_experimental.go
@@ -24,6 +24,7 @@ package experimental
 
 import (
 	_ "google.golang.org/grpc/xds/internal/balancer"     // Register the xds_balancer
+	_ "google.golang.org/grpc/xds/internal/balancer/cdsbalancer"     // Register the cds balancer
 	_ "google.golang.org/grpc/xds/internal/resolver"     // Register the xds_resolver
 	_ "google.golang.org/grpc/xds/internal/resolver/old" // Register the old xds_resolver
 )

--- a/xds/internal/client/rds.go
+++ b/xds/internal/client/rds.go
@@ -21,6 +21,7 @@ package client
 import (
 	"fmt"
 	"net"
+	"strings"
 
 	"github.com/golang/protobuf/ptypes"
 	"google.golang.org/grpc/grpclog"
@@ -126,7 +127,8 @@ func (v2c *v2Client) handleRDSResponse(resp *xdspb.DiscoveryResponse) error {
 // field must be set.  Inside that route message, the cluster field will
 // contain the clusterName we are looking for.
 func getClusterFromRouteConfiguration(rc *xdspb.RouteConfiguration, target string) string {
-	host, _, err := net.SplitHostPort(target)
+	// TODO: return error for better error logging and nack.
+	host, err := hostFromTarget(target)
 	if err != nil {
 		return ""
 	}
@@ -143,4 +145,19 @@ func getClusterFromRouteConfiguration(rc *xdspb.RouteConfiguration, target strin
 		}
 	}
 	return ""
+}
+
+// hostFromTarget calls net.SplitHostPort and returns the host.
+//
+// It returns the original string instead of error if port is missing.
+func hostFromTarget(target string) (string, error) {
+	const portMissingErrDesc = "missing port in address"
+	h, _, err := net.SplitHostPort(target)
+	if err != nil {
+		if strings.Contains(err.Error(), portMissingErrDesc) {
+			return target, nil
+		}
+		return "", err
+	}
+	return h, nil
 }

--- a/xds/internal/client/rds_test.go
+++ b/xds/internal/client/rds_test.go
@@ -519,7 +519,7 @@ func TestRDSWatchExpiryTimer(t *testing.T) {
 	}
 }
 
-func TestHost(t *testing.T) {
+func TestHostFromTarget(t *testing.T) {
 	tests := []struct {
 		name    string
 		target  string

--- a/xds/internal/client/rds_test.go
+++ b/xds/internal/client/rds_test.go
@@ -518,3 +518,43 @@ func TestRDSWatchExpiryTimer(t *testing.T) {
 		}
 	}
 }
+
+func TestHost(t *testing.T) {
+	tests := []struct {
+		name    string
+		target  string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "correct",
+			target:  "foo.bar.com:1234",
+			want:    "foo.bar.com",
+			wantErr: false,
+		},
+		{
+			name:    "error",
+			target:  "invalid:1234:3421",
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name:    "correct but missing port",
+			target:  "foo.bar.com",
+			want:    "foo.bar.com",
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := hostFromTarget(tt.target)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("hostFromTarget() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("hostFromTarget() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
 - install cds balancer by importing package cdsbalancer
 - `net.SplitHostPort` fails when target doesn't have port, but we want to use the original string instead