### PR TITLE
xds: Update the check for match field when handling an RDS response.

### DIFF
--- a/xds/internal/client/rds.go
+++ b/xds/internal/client/rds.go
@@ -137,9 +137,13 @@ func getClusterFromRouteConfiguration(rc *xdspb.RouteConfiguration, target strin
 				continue
 			}
 			dr := vh.Routes[len(vh.Routes)-1]
-			if dr.GetMatch() == nil && dr.GetRoute() != nil {
-				return dr.GetRoute().GetCluster()
+			if dr.GetMatch() == nil || dr.GetRoute() == nil {
+				continue
 			}
+			if dr.GetMatch().GetPrefix() != "" {
+				continue
+			}
+			return dr.GetRoute().GetCluster()
 		}
 	}
 	return ""

--- a/xds/internal/client/rds.go
+++ b/xds/internal/client/rds.go
@@ -137,13 +137,14 @@ func getClusterFromRouteConfiguration(rc *xdspb.RouteConfiguration, target strin
 				continue
 			}
 			dr := vh.Routes[len(vh.Routes)-1]
-			if dr.GetMatch() == nil || dr.GetRoute() == nil {
+			if match := dr.GetMatch(); match == nil || match.GetPrefix() != "" {
 				continue
 			}
-			if dr.GetMatch().GetPrefix() != "" {
+			route := dr.GetRoute()
+			if route == nil {
 				continue
 			}
-			return dr.GetRoute().GetCluster()
+			return route.GetCluster()
 		}
 	}
 	return ""

--- a/xds/internal/client/rds_test.go
+++ b/xds/internal/client/rds_test.go
@@ -76,6 +76,26 @@ func TestRDSGetClusterFromRouteConfiguration(t *testing.T) {
 			wantCluster: "",
 		},
 		{
+			name: "default-route-match-field-is-nil",
+			rc: &xdspb.RouteConfiguration{
+				VirtualHosts: []*routepb.VirtualHost{
+					{
+						Domains: []string{goodMatchingDomain},
+						Routes: []*routepb.Route{
+							{
+								Action: &routepb.Route_Route{
+									Route: &routepb.RouteAction{
+										ClusterSpecifier: &routepb.RouteAction_Cluster{Cluster: goodClusterName1},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantCluster: "",
+		},
+		{
 			name: "default-route-match-field-is-non-nil",
 			rc: &xdspb.RouteConfiguration{
 				VirtualHosts: []*routepb.VirtualHost{

--- a/xds/internal/client/v2client_test.go
+++ b/xds/internal/client/v2client_test.go
@@ -268,6 +268,7 @@ var (
 				Domains: []string{uninterestingDomain},
 				Routes: []*routepb.Route{
 					{
+						Match: &routepb.RouteMatch{PathSpecifier: &routepb.RouteMatch_Prefix{Prefix: ""}},
 						Action: &routepb.Route_Route{
 							Route: &routepb.RouteAction{
 								ClusterSpecifier: &routepb.RouteAction_Cluster{Cluster: uninterestingClusterName},
@@ -280,6 +281,7 @@ var (
 				Domains: []string{goodMatchingDomain},
 				Routes: []*routepb.Route{
 					{
+						Match: &routepb.RouteMatch{PathSpecifier: &routepb.RouteMatch_Prefix{Prefix: ""}},
 						Action: &routepb.Route_Route{
 							Route: &routepb.RouteAction{
 								ClusterSpecifier: &routepb.RouteAction_Cluster{Cluster: goodClusterName1},
@@ -298,6 +300,7 @@ var (
 				Domains: []string{uninterestingDomain},
 				Routes: []*routepb.Route{
 					{
+						Match: &routepb.RouteMatch{PathSpecifier: &routepb.RouteMatch_Prefix{Prefix: ""}},
 						Action: &routepb.Route_Route{
 							Route: &routepb.RouteAction{
 								ClusterSpecifier: &routepb.RouteAction_Cluster{Cluster: uninterestingClusterName},
@@ -310,6 +313,7 @@ var (
 				Domains: []string{goodMatchingDomain},
 				Routes: []*routepb.Route{
 					{
+						Match: &routepb.RouteMatch{PathSpecifier: &routepb.RouteMatch_Prefix{Prefix: ""}},
 						Action: &routepb.Route_Route{
 							Route: &routepb.RouteAction{
 								ClusterSpecifier: &routepb.RouteAction_Cluster{Cluster: goodClusterName2},


### PR DESCRIPTION
The client will look only at the last route in the list (the default
route), whose match field must contain a prefix field whose value is the
empty string and whose route field must be set.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grpc/grpc-go/3239)
<!-- Reviewable:end -->
