### PR TITLE
xds: skip callback if xds client reports error

### DIFF
--- a/xds/internal/balancer/xds_client_wrapper.go
+++ b/xds/internal/balancer/xds_client_wrapper.go
@@ -182,8 +182,11 @@ func (c *xdsclientWrapper) startEDSWatch(nameToWatch string) {
 
 	c.edsServiceName = nameToWatch
 	c.cancelEDSWatch = c.xdsclient.WatchEDS(c.edsServiceName, func(update *xdsclient.EDSUpdate, err error) {
-		// TODO: this should trigger a call to `c.loseContact`, when the error
-		// indicates "lose contact".
+		if err != nil {
+			// TODO: this should trigger a call to `c.loseContact`, when the
+			// error indicates "lose contact".
+			return
+		}
 		if err := c.newEDSUpdate(update); err != nil {
 			grpclog.Warningf("xds: processing new EDS update failed due to %v.", err)
 		}


### PR DESCRIPTION
Errors will be handled specifically, depending on whether it's a
connection error or other types of errors.

Without this fix, balancer's callback will be called with <nil> update,
causing nil panic later.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grpc/grpc-go/3240)
<!-- Reviewable:end -->
