### PR TITLE
xds: support multiple xds servers in bootstrap file

### DIFF
--- a/xds/internal/client/bootstrap/bootstrap_test.go
+++ b/xds/internal/client/bootstrap/bootstrap_test.go
@@ -64,9 +64,9 @@ func TestNewConfig(t *testing.T) {
 		"badJSON": `["test": 123]`,
 		"emptyNodeProto": `
 		{
-			"xds_server" : {
+			"xds_servers" : [{
 				"server_uri": "trafficdirector.googleapis.com:443"
-			}
+			}]
 		}`,
 		"emptyXdsServer": `
 		{
@@ -85,12 +85,12 @@ func TestNewConfig(t *testing.T) {
 				    "TRAFFICDIRECTOR_GRPC_HOSTNAME": "trafficdirector"
 			    }
 			},
-			"xds_server" : {
+			"xds_servers" : [{
 				"server_uri": "trafficdirector.googleapis.com:443",
 				"channel_creds": [
 					{ "type": "not-google-default" }
 				]
-			},
+			}],
 			"unknownField": "foobar"
 		}`,
 		"unknownFieldInNodeProto": `
@@ -111,13 +111,13 @@ func TestNewConfig(t *testing.T) {
 				    "TRAFFICDIRECTOR_GRPC_HOSTNAME": "trafficdirector"
 			    }
 			},
-			"xds_server" : {
+			"xds_servers" : [{
 				"server_uri": "trafficdirector.googleapis.com:443",
 				"channel_creds": [
 					{ "type": "not-google-default" }
 				],
 				"unknownField": "foobar"
-			}
+			}]
 		}`,
 		"emptyChannelCreds": `
 		{
@@ -127,9 +127,9 @@ func TestNewConfig(t *testing.T) {
 				    "TRAFFICDIRECTOR_GRPC_HOSTNAME": "trafficdirector"
 			    }
 			},
-			"xds_server" : {
+			"xds_servers" : [{
 				"server_uri": "trafficdirector.googleapis.com:443"
-			}
+			}]
 		}`,
 		"nonGoogleDefaultCreds": `
 		{
@@ -139,12 +139,12 @@ func TestNewConfig(t *testing.T) {
 				    "TRAFFICDIRECTOR_GRPC_HOSTNAME": "trafficdirector"
 			    }
 			},
-			"xds_server" : {
+			"xds_servers" : [{
 				"server_uri": "trafficdirector.googleapis.com:443",
 				"channel_creds": [
 					{ "type": "not-google-default" }
 				]
-			}
+			}]
 		}`,
 		"multipleChannelCreds": `
 		{
@@ -154,13 +154,13 @@ func TestNewConfig(t *testing.T) {
 				    "TRAFFICDIRECTOR_GRPC_HOSTNAME": "trafficdirector"
 			    }
 			},
-			"xds_server" : {
+			"xds_servers" : [{
 				"server_uri": "trafficdirector.googleapis.com:443",
 				"channel_creds": [
 					{ "type": "not-google-default" },
 					{ "type": "google_default" }
 				]
-			}
+			}]
 		}`,
 		"goodBootstrap": `
 		{
@@ -170,12 +170,12 @@ func TestNewConfig(t *testing.T) {
 				    "TRAFFICDIRECTOR_GRPC_HOSTNAME": "trafficdirector"
 			    }
 			},
-			"xds_server" : {
+			"xds_servers" : [{
 				"server_uri": "trafficdirector.googleapis.com:443",
 				"channel_creds": [
 					{ "type": "google_default" }
 				]
-			}
+			}]
 		}`,
 	}
 

--- a/xds/internal/client/bootstrap/bootstrap_test.go
+++ b/xds/internal/client/bootstrap/bootstrap_test.go
@@ -177,6 +177,25 @@ func TestNewConfig(t *testing.T) {
 				]
 			}]
 		}`,
+		"multipleXDSServers": `
+		{
+			"node": {
+				"id": "ENVOY_NODE_ID",
+				"metadata": {
+				    "TRAFFICDIRECTOR_GRPC_HOSTNAME": "trafficdirector"
+			    }
+			},
+			"xds_servers" : [
+				{
+					"server_uri": "trafficdirector.googleapis.com:443",
+					"channel_creds": [{ "type": "google_default" }]
+				},
+				{
+					"server_uri": "backup.never.use.com:1234",
+					"channel_creds": [{ "type": "not-google-default" }]
+				}
+			]
+		}`,
 	}
 
 	oldFileReadFunc := fileReadFunc
@@ -198,13 +217,10 @@ func TestNewConfig(t *testing.T) {
 		{"nonExistentBootstrapFile", &Config{}},
 		{"empty", &Config{}},
 		{"badJSON", &Config{}},
-		{
-			"emptyNodeProto",
-			&Config{
-				BalancerName: "trafficdirector.googleapis.com:443",
-				NodeProto:    &corepb.Node{BuildVersion: gRPCVersion},
-			},
-		},
+		{"emptyNodeProto", &Config{
+			BalancerName: "trafficdirector.googleapis.com:443",
+			NodeProto:    &corepb.Node{BuildVersion: gRPCVersion},
+		}},
 		{"emptyXdsServer", &Config{NodeProto: nodeProto}},
 		{"unknownTopLevelFieldInFile", nilCredsConfig},
 		{"unknownFieldInNodeProto", &Config{NodeProto: nodeProto}},
@@ -213,6 +229,7 @@ func TestNewConfig(t *testing.T) {
 		{"nonGoogleDefaultCreds", nilCredsConfig},
 		{"multipleChannelCreds", nonNilCredsConfig},
 		{"goodBootstrap", nonNilCredsConfig},
+		{"multipleXDSServers", nonNilCredsConfig},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Changes to "xds_server" field in bootstrap file:

1. Field name is changed "xds_servers" (plural).
2. Field value should be a list of objects instead of a single object.

For now, we can ignore all entries except the first one.  In the future, we will add support for falling back to a secondary server when the primary is not reachable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grpc/grpc-go/3247)
<!-- Reviewable:end -->
