### PR TITLE
grpclb: do not send redundant empty load reports to remote LB

### DIFF
--- a/balancer/grpclb/grpclb_picker.go
+++ b/balancer/grpclb/grpclb_picker.go
@@ -49,6 +49,14 @@ func newRPCStats() *rpcStats {
 	}
 }
 
+func isZeroStats(stats *lbpb.ClientStats) bool {
+	return len(stats.CallsFinishedWithDrop) == 0 &&
+		stats.NumCallsStarted == 0 &&
+		stats.NumCallsFinished == 0 &&
+		stats.NumCallsFinishedWithClientFailedToSend == 0 &&
+		stats.NumCallsFinishedKnownReceived == 0
+}
+
 // toClientStats converts rpcStats to lbpb.ClientStats, and clears rpcStats.
 func (s *rpcStats) toClientStats() *lbpb.ClientStats {
 	stats := &lbpb.ClientStats{

--- a/balancer/grpclb/grpclb_test.go
+++ b/balancer/grpclb/grpclb_test.go
@@ -1108,6 +1108,10 @@ func (failPreRPCCred) RequireTransportSecurity() bool {
 
 func checkStats(stats, expected *rpcStats) error {
 	if !stats.equal(expected) {
+		stats.mu.Lock()
+		defer stats.mu.Unlock()
+		expected.mu.Lock()
+		defer expected.mu.Unlock()
 		return fmt.Errorf("stats not equal: got %+v, want %+v", stats, expected)
 	}
 	return nil

--- a/balancer/grpclb/grpclb_test.go
+++ b/balancer/grpclb/grpclb_test.go
@@ -116,11 +116,11 @@ func fakeNameDialer(ctx context.Context, addr string) (net.Conn, error) {
 //
 // It's a test-only method. rpcStats is defined in grpclb_picker.
 func (s *rpcStats) merge(cs *lbpb.ClientStats) {
-	s.mu.Lock()
 	atomic.AddInt64(&s.numCallsStarted, cs.NumCallsStarted)
 	atomic.AddInt64(&s.numCallsFinished, cs.NumCallsFinished)
 	atomic.AddInt64(&s.numCallsFinishedWithClientFailedToSend, cs.NumCallsFinishedWithClientFailedToSend)
 	atomic.AddInt64(&s.numCallsFinishedKnownReceived, cs.NumCallsFinishedKnownReceived)
+	s.mu.Lock()
 	for _, perToken := range cs.CallsFinishedWithDrop {
 		s.numCallsDropped[perToken.LoadBalanceToken] += perToken.NumCalls
 	}


### PR DESCRIPTION
Small refactor of tests:

- Add a channel to remoteBalancer on which to send received stats messages
- Change runAndGetStats to runAndCheckStats to allow for faster successful test
  runs (no longer need to sleep for one whole second per test).
- Remove redundant leak check from runAndCheckStats, otherwise excess load
  report messages not read from the channel will result in an infinite loop.