### PR TITLE
grpc: Defer the unlock in newCCResolverWrapper

### DIFF
--- a/resolver_conn_wrapper.go
+++ b/resolver_conn_wrapper.go
@@ -105,11 +105,11 @@ func newCCResolverWrapper(cc *ClientConn) (*ccResolverWrapper, error) {
 	// rb.Build-->ccr.ReportError-->ccr.poll-->ccr.resolveNow, would end up
 	// accessing ccr.resolver which is being assigned here.
 	ccr.resolverMu.Lock()
+	defer ccr.resolverMu.Unlock()
 	ccr.resolver, err = rb.Build(cc.parsedTarget, ccr, rbo)
 	if err != nil {
 		return nil, err
 	}
-	ccr.resolverMu.Unlock()
 	return ccr, nil
 }
 


### PR DESCRIPTION
Although the existing code wasn't causing a deadlock or causing
goroutines to hang forever, this is cleaner and prevents any such thing
from happening in the future.

Fixes https://github.com/grpc/grpc-go/issues/3244.