### PR TITLE
 xds: Improve balancer/xds_test.go.

### DIFF
--- a/xds/internal/testutils/channel.go
+++ b/xds/internal/testutils/channel.go
@@ -66,5 +66,10 @@ func (cwt *Channel) Receive() (interface{}, error) {
 
 // NewChannel returns a new Channel.
 func NewChannel() *Channel {
-	return &Channel{ch: make(chan interface{}, DefaultChanBufferSize)}
+	return NewChannelWithSize(DefaultChanBufferSize)
+}
+
+// NewChannelWithSize returns a new Channel with a buffer of bufSize.
+func NewChannelWithSize(bufSize int) *Channel {
+	return &Channel{ch: make(chan interface{}, bufSize)}
 }


### PR DESCRIPTION
Summary of changes:
* In xds_test.go:
  * Get rid of the flaky logic to get the `latest fake edsLB` and use channels instead and make it explicit.
  * Get rid of the `fakeXDSClient` implementation here and use the one from testutils instead.
  * Use `testutils.Channel` wherever there is a need to wait with a timeout on a channel.
* Make necessary changes in the testutils package
* Also add a mutex to protect certain fields in `fakexds.Client` to prevent a data race.