### PR TITLE
dns: report errors from A record lookups instead of zero addresses

### DIFF
--- a/internal/resolver/dns/dns_resolver.go
+++ b/internal/resolver/dns/dns_resolver.go
@@ -204,8 +204,12 @@ func (d *dnsResolver) watcher() {
 		case <-d.rn:
 		}
 
-		state := d.lookup()
-		d.cc.UpdateState(*state)
+		state, err := d.lookup()
+		if err != nil {
+			d.cc.ReportError(err)
+		} else {
+			d.cc.UpdateState(*state)
+		}
 
 		// Sleep to prevent excessive re-resolutions. Incoming resolution requests
 		// will be queued in d.rn.
@@ -219,33 +223,32 @@ func (d *dnsResolver) watcher() {
 	}
 }
 
-func (d *dnsResolver) lookupSRV() []resolver.Address {
+func (d *dnsResolver) lookupSRV() ([]resolver.Address, error) {
 	if !EnableSRVLookups {
-		return nil
+		return nil, nil
 	}
 	var newAddrs []resolver.Address
 	_, srvs, err := d.resolver.LookupSRV(d.ctx, "grpclb", "tcp", d.host)
 	if err != nil {
-		grpclog.Infof("grpc: failed dns SRV record lookup due to %v.\n", err)
-		return nil
+		err = handleDNSError(err, "SRV") // may become nil
+		return nil, err
 	}
 	for _, s := range srvs {
 		lbAddrs, err := d.resolver.LookupHost(d.ctx, s.Target)
 		if err != nil {
-			grpclog.Infof("grpc: failed load balancer address dns lookup due to %v.\n", err)
-			continue
+			err = handleDNSError(err, "A") // may become nil
+			return nil, err
 		}
 		for _, a := range lbAddrs {
-			a, ok := formatIP(a)
+			ip, ok := formatIP(a)
 			if !ok {
-				grpclog.Errorf("grpc: failed IP parsing due to %v.\n", err)
-				continue
+				return nil, fmt.Errorf("dns: error parsing A record IP address %v", a)
 			}
-			addr := a + ":" + strconv.Itoa(int(s.Port))
+			addr := ip + ":" + strconv.Itoa(int(s.Port))
 			newAddrs = append(newAddrs, resolver.Address{Addr: addr, Type: resolver.GRPCLB, ServerName: s.Target})
 		}
 	}
-	return newAddrs
+	return newAddrs, nil
 }
 
 var filterError = func(err error) error {
@@ -258,13 +261,19 @@ var filterError = func(err error) error {
 	return err
 }
 
+func handleDNSError(err error, lookupType string) error {
+	err = filterError(err)
+	if err != nil {
+		err = fmt.Errorf("dns: %v record lookup error: %v", lookupType, err)
+		grpclog.Infoln(err)
+	}
+	return err
+}
+
 func (d *dnsResolver) lookupTXT() *serviceconfig.ParseResult {
 	ss, err := d.resolver.LookupTXT(d.ctx, txtPrefix+d.host)
 	if err != nil {
-		err = filterError(err)
-		if err != nil {
-			err = fmt.Errorf("error from DNS TXT record lookup: %v", err)
-			grpclog.Infoln("grpc:", err)
+		if err = handleDNSError(err, "TXT"); err != nil {
 			return &serviceconfig.ParseResult{Err: err}
 		}
 		return nil
@@ -276,7 +285,7 @@ func (d *dnsResolver) lookupTXT() *serviceconfig.ParseResult {
 
 	// TXT record must have "grpc_config=" attribute in order to be used as service config.
 	if !strings.HasPrefix(res, txtAttribute) {
-		grpclog.Warningf("grpc: DNS TXT record %v missing %v attribute", res, txtAttribute)
+		grpclog.Warningf("dns: TXT record %v missing %v attribute", res, txtAttribute)
 		// This is not an error; it is the equivalent of not having a service config.
 		return nil
 	}
@@ -284,34 +293,37 @@ func (d *dnsResolver) lookupTXT() *serviceconfig.ParseResult {
 	return d.cc.ParseServiceConfig(sc)
 }
 
-func (d *dnsResolver) lookupHost() []resolver.Address {
+func (d *dnsResolver) lookupHost() ([]resolver.Address, error) {
 	var newAddrs []resolver.Address
 	addrs, err := d.resolver.LookupHost(d.ctx, d.host)
 	if err != nil {
-		grpclog.Warningf("grpc: failed dns A record lookup due to %v.\n", err)
-		return nil
+		err = handleDNSError(err, "A")
+		return nil, err
 	}
 	for _, a := range addrs {
-		a, ok := formatIP(a)
+		ip, ok := formatIP(a)
 		if !ok {
-			grpclog.Errorf("grpc: failed IP parsing due to %v.\n", err)
-			continue
+			return nil, fmt.Errorf("dns: error parsing A record IP address %v", a)
 		}
-		addr := a + ":" + d.port
+		addr := ip + ":" + d.port
 		newAddrs = append(newAddrs, resolver.Address{Addr: addr})
 	}
-	return newAddrs
+	return newAddrs, nil
 }
 
-func (d *dnsResolver) lookup() *resolver.State {
-	srv := d.lookupSRV()
+func (d *dnsResolver) lookup() (*resolver.State, error) {
+	srv, srvErr := d.lookupSRV()
+	addrs, hostErr := d.lookupHost()
+	if hostErr != nil && (srvErr != nil || len(srv) == 0) {
+		return nil, hostErr
+	}
 	state := &resolver.State{
-		Addresses: append(d.lookupHost(), srv...),
+		Addresses: append(addrs, srv...),
 	}
 	if !d.disableServiceConfig {
 		state.ServiceConfig = d.lookupTXT()
 	}
-	return state
+	return state, nil
 }
 
 // formatIP returns ok = false if addr is not a valid textual representation of an IP address.
@@ -397,12 +409,12 @@ func canaryingSC(js string) string {
 	var rcs []rawChoice
 	err := json.Unmarshal([]byte(js), &rcs)
 	if err != nil {
-		grpclog.Warningf("grpc: failed to parse service config json string due to %v.\n", err)
+		grpclog.Warningf("dns: error parsing service config json: %v", err)
 		return ""
 	}
 	cliHostname, err := os.Hostname()
 	if err != nil {
-		grpclog.Warningf("grpc: failed to get client hostname due to %v.\n", err)
+		grpclog.Warningf("dns: error getting client hostname: %v", err)
 		return ""
 	}
 	var sc string

--- a/internal/resolver/dns/dns_resolver.go
+++ b/internal/resolver/dns/dns_resolver.go
@@ -237,6 +237,11 @@ func (d *dnsResolver) lookupSRV() ([]resolver.Address, error) {
 		lbAddrs, err := d.resolver.LookupHost(d.ctx, s.Target)
 		if err != nil {
 			err = handleDNSError(err, "A") // may become nil
+			if err == nil {
+				// If there are other SRV records, look them up and ignore this
+				// one that does not exist.
+				continue
+			}
 			return nil, err
 		}
 		for _, a := range lbAddrs {

--- a/internal/resolver/dns/dns_resolver_test.go
+++ b/internal/resolver/dns/dns_resolver_test.go
@@ -157,9 +157,10 @@ func hostLookup(host string) ([]string, error) {
 		return addrs, nil
 	}
 	return nil, &net.DNSError{
-		Err:    "hostLookup error",
-		Name:   host,
-		Server: "fake",
+		Err:         "hostLookup error",
+		Name:        host,
+		Server:      "fake",
+		IsTemporary: true,
 	}
 }
 
@@ -183,9 +184,10 @@ func srvLookup(service, proto, name string) (string, []*net.SRV, error) {
 		return cname, srvs, nil
 	}
 	return "", nil, &net.DNSError{
-		Err:    "srvLookup error",
-		Name:   cname,
-		Server: "fake",
+		Err:         "srvLookup error",
+		Name:        cname,
+		Server:      "fake",
+		IsTemporary: true,
 	}
 }
 
@@ -649,9 +651,10 @@ func txtLookup(host string) ([]string, error) {
 		return scs, nil
 	}
 	return nil, &net.DNSError{
-		Err:    "txtLookup error",
-		Name:   host,
-		Server: "fake",
+		Err:         "txtLookup error",
+		Name:        host,
+		Server:      "fake",
+		IsTemporary: true,
 	}
 }
 


### PR DESCRIPTION
Fixes #3252 

This is not a regression caused by #3228 as best I can tell, so this will not be going into the 1.26 release today.