### PR TITLE
grpctest: implement grpclogger using testing.T and inject in tests

### DIFF
--- a/grpc_test.go
+++ b/grpc_test.go
@@ -23,9 +23,8 @@ import (
 	"testing"
 
 	"google.golang.org/grpc/internal/grpctest"
+	"google.golang.org/grpc/internal/grpctest/tlogger"
 	"google.golang.org/grpc/internal/leakcheck"
-
-	_ "google.golang.org/grpc/grpclog/glogger"
 )
 
 type s struct{}
@@ -39,6 +38,10 @@ type errorer struct {
 func (e errorer) Errorf(format string, args ...interface{}) {
 	atomic.StoreUint32(&lcFailed, 1)
 	e.t.Errorf(format, args...)
+}
+
+func (s) Setup(t *testing.T) {
+	tlogger.Update(t)
 }
 
 func (s) Teardown(t *testing.T) {

--- a/internal/grpctest/tlogger/tlogger.go
+++ b/internal/grpctest/tlogger/tlogger.go
@@ -1,0 +1,140 @@
+/*
+ *
+ * Copyright 2020 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// Package tlogger initializes the testing logger on import which logs to the
+// testing package's T struct.
+package tlogger
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"runtime/debug"
+	"strconv"
+	"strings"
+	"testing"
+
+	"google.golang.org/grpc/grpclog"
+)
+
+var logger = tLogger{v: 0}
+
+const callingFrame = 4
+
+type tLogger struct {
+	v int
+	t *testing.T
+}
+
+func init() {
+	vLevel := os.Getenv("GRPC_GO_LOG_VERBOSITY_LEVEL")
+	if vl, err := strconv.Atoi(vLevel); err == nil {
+		logger.v = vl
+	}
+	grpclog.SetLoggerV2(&logger)
+}
+
+func getStackFrame(stack []byte, frame int) (string, error) {
+	s := strings.Split(string(stack), "\n")
+	if frame >= (len(s)-1)/2 {
+		return "", errors.New("frame request out-of-bounds")
+	}
+	split := strings.Split(strings.Fields(s[(frame*2)+2][1:])[0], "/")
+	return fmt.Sprintf("%v:", split[len(split)-1]), nil
+}
+
+func log(t *testing.T, format string, fatal bool, args ...interface{}) {
+	s := debug.Stack()
+	prefix, err := getStackFrame(s, callingFrame)
+	args = append([]interface{}{prefix}, args...)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	if format == "" {
+		if fatal {
+			panic(fmt.Sprint(args...))
+		} else {
+			t.Log(args...)
+		}
+	} else {
+		if fatal {
+			panic(fmt.Sprintf("%v "+format, args...))
+		} else {
+			t.Logf("%v "+format, args...)
+		}
+	}
+}
+
+// Update updates the testing.T that the testing logger logs to. Should be done
+// before every test.
+func Update(t *testing.T) {
+	logger.t = t
+}
+
+func (g *tLogger) Info(args ...interface{}) {
+	log(g.t, "", false, args...)
+}
+
+func (g *tLogger) Infoln(args ...interface{}) {
+	log(g.t, "", false, args...)
+}
+
+func (g *tLogger) Infof(format string, args ...interface{}) {
+	log(g.t, format, false, args...)
+}
+
+func (g *tLogger) Warning(args ...interface{}) {
+	log(g.t, "", false, args...)
+}
+
+func (g *tLogger) Warningln(args ...interface{}) {
+	log(g.t, "", false, args...)
+}
+
+func (g *tLogger) Warningf(format string, args ...interface{}) {
+	log(g.t, format, false, args...)
+}
+
+func (g *tLogger) Error(args ...interface{}) {
+	log(g.t, "", false, args...)
+}
+
+func (g *tLogger) Errorln(args ...interface{}) {
+	log(g.t, "", false, args...)
+}
+
+func (g *tLogger) Errorf(format string, args ...interface{}) {
+	log(g.t, format, false, args...)
+}
+
+func (g *tLogger) Fatal(args ...interface{}) {
+	log(g.t, "", true, args...)
+}
+
+func (g *tLogger) Fatalln(args ...interface{}) {
+	log(g.t, "", true, args...)
+}
+
+func (g *tLogger) Fatalf(format string, args ...interface{}) {
+	log(g.t, format, true, args...)
+}
+
+func (g *tLogger) V(l int) bool {
+	return l <= g.v
+}

--- a/internal/grpctest/tlogger/tlogger_test.go
+++ b/internal/grpctest/tlogger/tlogger_test.go
@@ -1,0 +1,66 @@
+/*
+ *
+ * Copyright 2020 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package tlogger
+
+import (
+	"reflect"
+	"runtime"
+	"strings"
+	"testing"
+
+	"google.golang.org/grpc/grpclog"
+)
+
+func TestInfo(t *testing.T) {
+	Update(t)
+	grpclog.Info("Info", "message.")
+}
+
+func TestInfoln(t *testing.T) {
+	Update(t)
+	grpclog.Infoln("Info", "message.")
+}
+
+func TestInfof(t *testing.T) {
+	Update(t)
+	grpclog.Infof("%v %v.", "Info", "message")
+}
+
+func TestWarning(t *testing.T) {
+	Update(t)
+	grpclog.Warning("Warning", "message.")
+}
+
+func TestWarningln(t *testing.T) {
+	Update(t)
+	grpclog.Warningln("Warning", "message.")
+}
+
+func TestWarningf(t *testing.T) {
+	Update(t)
+	grpclog.Warningf("%v %v.", "Warning", "message")
+}
+
+func TestSubTests(t *testing.T) {
+	testFuncs := [6]func(*testing.T){TestInfo, TestInfoln, TestInfof, TestWarning, TestWarningln, TestWarningf}
+	for _, testFunc := range testFuncs {
+		splitFuncName := strings.Split(runtime.FuncForPC(reflect.ValueOf(testFunc).Pointer()).Name(), ".")
+		t.Run(splitFuncName[len(splitFuncName)-1], testFunc)
+	}
+}

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -56,13 +56,13 @@ import (
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/encoding"
 	_ "google.golang.org/grpc/encoding/gzip"
-	_ "google.golang.org/grpc/grpclog/glogger"
 	"google.golang.org/grpc/health"
 	healthgrpc "google.golang.org/grpc/health/grpc_health_v1"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/internal/channelz"
 	"google.golang.org/grpc/internal/grpcsync"
 	"google.golang.org/grpc/internal/grpctest"
+	"google.golang.org/grpc/internal/grpctest/tlogger"
 	"google.golang.org/grpc/internal/leakcheck"
 	"google.golang.org/grpc/internal/testutils"
 	"google.golang.org/grpc/internal/transport"
@@ -95,6 +95,10 @@ type errorer struct {
 func (e errorer) Errorf(format string, args ...interface{}) {
 	atomic.StoreUint32(&lcFailed, 1)
 	e.t.Errorf(format, args...)
+}
+
+func (s) Setup(t *testing.T) {
+	tlogger.Update(t)
 }
 
 func (s) Teardown(t *testing.T) {


### PR DESCRIPTION
Implemented a logger that logs to testing's T struct. Removed glogger import from two tests because this logger replaces the glogger in those tests. Only tests using grpctest's RunSubTests use this logger, as the T object logged to is updated in that function's loop.

updates https://github.com/grpc/grpc-go/issues/3006