### PR TITLE
xds test: read ACK to clear req chan

### DIFF
--- a/xds/internal/client/rds_test.go
+++ b/xds/internal/client/rds_test.go
@@ -185,6 +185,8 @@ func TestRDSHandleResponse(t *testing.T) {
 	if err := <-cbCh; err != nil {
 		t.Fatalf("v2c.watchLDS returned error in callback: %v", err)
 	}
+	// Read the LDS ack, to clear RequestChan for following tests.
+	<-fakeServer.RequestChan
 
 	tests := []struct {
 		name          string


### PR DESCRIPTION
The real test relies on req chan to know when the fake xds server
receives the request. Without this, req chan may unblock for the ack,
before the real watch handler is ready.

fixes #3264