### PR TITLE
xds: client test cleanup

### DIFF
--- a/xds/internal/client/cds_test.go
+++ b/xds/internal/client/cds_test.go
@@ -229,7 +229,7 @@ func TestCDSHandleResponse(t *testing.T) {
 				wantUpdate:       test.wantUpdate,
 				wantUpdateErr:    test.wantUpdateErr,
 			}, &watchHandleConfig{
-				typeURL:  clusterURL,
+				typeURL:  cdsURL,
 				cdsWatch: v2c.watchCDS,
 				handle:   v2c.handleCDSResponse,
 			}, fakeServer)

--- a/xds/internal/client/cds_test.go
+++ b/xds/internal/client/cds_test.go
@@ -223,47 +223,16 @@ func TestCDSHandleResponse(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			gotUpdateCh := make(chan CDSUpdate, 1)
-			gotUpdateErrCh := make(chan error, 1)
-
-			// Register a watcher, to trigger the v2Client to send an CDS request.
-			cancelWatch := v2c.watchCDS(clusterName1, func(u CDSUpdate, err error) {
-				t.Logf("in v2c.watchCDS callback, CDSUpdate: %+v, err: %v", u, err)
-				gotUpdateCh <- u
-				gotUpdateErrCh <- err
-			})
-
-			// Wait till the request makes it to the fakeServer. This ensures that
-			// the watch request has been processed by the v2Client.
-			<-fakeServer.RequestChan
-
-			// Directly push the response through a call to handleLDSResponse,
-			// thereby bypassing the fakeServer.
-			if err := v2c.handleCDSResponse(test.cdsResponse); (err != nil) != test.wantErr {
-				t.Fatalf("v2c.handleCDSResponse() returned err: %v, wantErr: %v", err, test.wantErr)
-			}
-
-			// If the test needs the callback to be invoked, verify the update and
-			// error pushed to the callback.
-			if test.wantUpdate != nil {
-				timer := time.NewTimer(defaultTestTimeout)
-				select {
-				case <-timer.C:
-					t.Fatal("Timeout when expecting CDS update")
-				case gotUpdate := <-gotUpdateCh:
-					timer.Stop()
-					if !reflect.DeepEqual(gotUpdate, *test.wantUpdate) {
-						t.Fatalf("got CDS update : %+v, want %+v", gotUpdate, test.wantUpdate)
-					}
-				}
-				// Since the callback that we registered pushes to both channels at
-				// the same time, this channel read should return immediately.
-				gotUpdateErr := <-gotUpdateErrCh
-				if (gotUpdateErr != nil) != test.wantUpdateErr {
-					t.Fatalf("got CDS update error {%v}, wantErr: %v", gotUpdateErr, test.wantUpdateErr)
-				}
-			}
-			cancelWatch()
+			testWatchHandle(t, &watchHandleTestcase{
+				responseToHandle: test.cdsResponse,
+				wantErr:          test.wantErr,
+				wantUpdate:       test.wantUpdate,
+				wantUpdateErr:    test.wantUpdateErr,
+			}, &watchHandleConfig{
+				typeURL:  clusterURL,
+				cdsWatch: v2c.watchCDS,
+				handle:   v2c.handleCDSResponse,
+			}, fakeServer)
 		})
 	}
 }

--- a/xds/internal/client/cds_test.go
+++ b/xds/internal/client/cds_test.go
@@ -225,14 +225,14 @@ func TestCDSHandleResponse(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			testWatchHandle(t, &watchHandleTestcase{
 				responseToHandle: test.cdsResponse,
-				wantErr:          test.wantErr,
+				wantHandleErr:    test.wantErr,
 				wantUpdate:       test.wantUpdate,
 				wantUpdateErr:    test.wantUpdateErr,
-			}, &watchHandleConfig{
-				typeURL:  cdsURL,
-				cdsWatch: v2c.watchCDS,
-				handle:   v2c.handleCDSResponse,
-			}, fakeServer)
+
+				cdsWatch:      v2c.watchCDS,
+				watchReqChan:  fakeServer.RequestChan,
+				handleXDSResp: v2c.handleCDSResponse,
+			})
 		})
 	}
 }

--- a/xds/internal/client/eds_test.go
+++ b/xds/internal/client/eds_test.go
@@ -230,14 +230,14 @@ func TestEDSHandleResponse(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			testWatchHandle(t, &watchHandleTestcase{
 				responseToHandle: test.edsResponse,
-				wantErr:          test.wantErr,
+				wantHandleErr:    test.wantErr,
 				wantUpdate:       test.wantUpdate,
 				wantUpdateErr:    test.wantUpdateErr,
-			}, &watchHandleConfig{
-				typeURL:  edsURL,
-				edsWatch: v2c.watchEDS,
-				handle:   v2c.handleEDSResponse,
-			}, fakeServer)
+
+				edsWatch:      v2c.watchEDS,
+				watchReqChan:  fakeServer.RequestChan,
+				handleXDSResp: v2c.handleEDSResponse,
+			})
 		})
 	}
 }

--- a/xds/internal/client/eds_test.go
+++ b/xds/internal/client/eds_test.go
@@ -234,7 +234,7 @@ func TestEDSHandleResponse(t *testing.T) {
 				wantUpdate:       test.wantUpdate,
 				wantUpdateErr:    test.wantUpdateErr,
 			}, &watchHandleConfig{
-				typeURL:  endpointURL,
+				typeURL:  edsURL,
 				edsWatch: v2c.watchEDS,
 				handle:   v2c.handleEDSResponse,
 			}, fakeServer)

--- a/xds/internal/client/eds_test.go
+++ b/xds/internal/client/eds_test.go
@@ -228,47 +228,16 @@ func TestEDSHandleResponse(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			gotUpdateCh := make(chan *EDSUpdate, 1)
-			gotUpdateErrCh := make(chan error, 1)
-
-			// Register a watcher, to trigger the v2Client to send an EDS request.
-			cancelWatch := v2c.watchEDS(goodEDSName, func(u *EDSUpdate, err error) {
-				t.Logf("in v2c.watchEDS callback, edsUpdate: %+v, err: %v", u, err)
-				gotUpdateCh <- u
-				gotUpdateErrCh <- err
-			})
-
-			// Wait till the request makes it to the fakeServer. This ensures that
-			// the watch request has been processed by the v2Client.
-			<-fakeServer.RequestChan
-
-			// Directly push the response through a call to handleEDSResponse,
-			// thereby bypassing the fakeServer.
-			if err := v2c.handleEDSResponse(test.edsResponse); (err != nil) != test.wantErr {
-				t.Fatalf("v2c.handleEDSResponse() returned err: %v, wantErr: %v", err, test.wantErr)
-			}
-
-			// If the test needs the callback to be invoked, verify the update and
-			// error pushed to the callback.
-			if test.wantUpdate != nil {
-				timer := time.NewTimer(defaultTestTimeout)
-				select {
-				case <-timer.C:
-					t.Fatal("Timeout when expecting EDS update")
-				case gotUpdate := <-gotUpdateCh:
-					timer.Stop()
-					if d := cmp.Diff(gotUpdate, test.wantUpdate); d != "" {
-						t.Fatalf("got EDS update : %+v, want %+v, diff: %v", gotUpdate, *test.wantUpdate, d)
-					}
-				}
-				// Since the callback that we registered pushes to both channels at
-				// the same time, this channel read should return immediately.
-				gotUpdateErr := <-gotUpdateErrCh
-				if (gotUpdateErr != nil) != test.wantUpdateErr {
-					t.Fatalf("got EDS update error {%v}, wantErr: %v", gotUpdateErr, test.wantUpdateErr)
-				}
-			}
-			cancelWatch()
+			testWatchHandle(t, &watchHandleTestcase{
+				responseToHandle: test.edsResponse,
+				wantErr:          test.wantErr,
+				wantUpdate:       test.wantUpdate,
+				wantUpdateErr:    test.wantUpdateErr,
+			}, &watchHandleConfig{
+				typeURL:  endpointURL,
+				edsWatch: v2c.watchEDS,
+				handle:   v2c.handleEDSResponse,
+			}, fakeServer)
 		})
 	}
 }

--- a/xds/internal/client/lds_test.go
+++ b/xds/internal/client/lds_test.go
@@ -21,7 +21,6 @@ package client
 import (
 	"errors"
 	"fmt"
-	"reflect"
 	"testing"
 	"time"
 
@@ -180,47 +179,16 @@ func TestLDSHandleResponse(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			gotUpdateCh := make(chan ldsUpdate, 1)
-			gotUpdateErrCh := make(chan error, 1)
-
-			// Register a watcher, to trigger the v2Client to send an LDS request.
-			cancelWatch := v2c.watchLDS(goodLDSTarget1, func(u ldsUpdate, err error) {
-				t.Logf("in v2c.watchLDS callback, ldsUpdate: %+v, err: %v", u, err)
-				gotUpdateCh <- u
-				gotUpdateErrCh <- err
-			})
-
-			// Wait till the request makes it to the fakeServer. This ensures that
-			// the watch request has been processed by the v2Client.
-			<-fakeServer.RequestChan
-
-			// Directly push the response through a call to handleLDSResponse,
-			// thereby bypassing the fakeServer.
-			if err := v2c.handleLDSResponse(test.ldsResponse); (err != nil) != test.wantErr {
-				t.Fatalf("v2c.handleLDSResponse() returned err: %v, wantErr: %v", err, test.wantErr)
-			}
-
-			// If the test needs the callback to be invoked, verify the update and
-			// error pushed to the callback.
-			if test.wantUpdate != nil {
-				timer := time.NewTimer(defaultTestTimeout)
-				select {
-				case <-timer.C:
-					t.Fatal("Timeout when expecting LDS update")
-				case gotUpdate := <-gotUpdateCh:
-					timer.Stop()
-					if !reflect.DeepEqual(gotUpdate, *test.wantUpdate) {
-						t.Fatalf("got LDS update : %+v, want %+v", gotUpdate, *test.wantUpdate)
-					}
-				}
-				// Since the callback that we registered pushes to both channels at
-				// the same time, this channel read should return immediately.
-				gotUpdateErr := <-gotUpdateErrCh
-				if (gotUpdateErr != nil) != test.wantUpdateErr {
-					t.Fatalf("got LDS update error {%v}, wantErr: %v", gotUpdateErr, test.wantUpdateErr)
-				}
-			}
-			cancelWatch()
+			testWatchHandle(t, &watchHandleTestcase{
+				responseToHandle: test.ldsResponse,
+				wantErr:          test.wantErr,
+				wantUpdate:       test.wantUpdate,
+				wantUpdateErr:    test.wantUpdateErr,
+			}, &watchHandleConfig{
+				typeURL:  listenerURL,
+				ldsWatch: v2c.watchLDS,
+				handle:   v2c.handleLDSResponse,
+			}, fakeServer)
 		})
 	}
 }

--- a/xds/internal/client/lds_test.go
+++ b/xds/internal/client/lds_test.go
@@ -181,14 +181,14 @@ func TestLDSHandleResponse(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			testWatchHandle(t, &watchHandleTestcase{
 				responseToHandle: test.ldsResponse,
-				wantErr:          test.wantErr,
+				wantHandleErr:    test.wantErr,
 				wantUpdate:       test.wantUpdate,
 				wantUpdateErr:    test.wantUpdateErr,
-			}, &watchHandleConfig{
-				typeURL:  ldsURL,
-				ldsWatch: v2c.watchLDS,
-				handle:   v2c.handleLDSResponse,
-			}, fakeServer)
+
+				ldsWatch:      v2c.watchLDS,
+				watchReqChan:  fakeServer.RequestChan,
+				handleXDSResp: v2c.handleLDSResponse,
+			})
 		})
 	}
 }

--- a/xds/internal/client/lds_test.go
+++ b/xds/internal/client/lds_test.go
@@ -185,7 +185,7 @@ func TestLDSHandleResponse(t *testing.T) {
 				wantUpdate:       test.wantUpdate,
 				wantUpdateErr:    test.wantUpdateErr,
 			}, &watchHandleConfig{
-				typeURL:  listenerURL,
+				typeURL:  ldsURL,
 				ldsWatch: v2c.watchLDS,
 				handle:   v2c.handleLDSResponse,
 			}, fakeServer)

--- a/xds/internal/client/rds_test.go
+++ b/xds/internal/client/rds_test.go
@@ -243,14 +243,14 @@ func TestRDSHandleResponse(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			testWatchHandle(t, &watchHandleTestcase{
 				responseToHandle: test.rdsResponse,
-				wantErr:          test.wantErr,
+				wantHandleErr:    test.wantErr,
 				wantUpdate:       test.wantUpdate,
 				wantUpdateErr:    test.wantUpdateErr,
-			}, &watchHandleConfig{
-				typeURL:  rdsURL,
-				rdsWatch: v2c.watchRDS,
-				handle:   v2c.handleRDSResponse,
-			}, fakeServer)
+
+				rdsWatch:      v2c.watchRDS,
+				watchReqChan:  fakeServer.RequestChan,
+				handleXDSResp: v2c.handleRDSResponse,
+			})
 		})
 	}
 }

--- a/xds/internal/client/rds_test.go
+++ b/xds/internal/client/rds_test.go
@@ -247,7 +247,7 @@ func TestRDSHandleResponse(t *testing.T) {
 				wantUpdate:       test.wantUpdate,
 				wantUpdateErr:    test.wantUpdateErr,
 			}, &watchHandleConfig{
-				typeURL:  routeURL,
+				typeURL:  rdsURL,
 				rdsWatch: v2c.watchRDS,
 				handle:   v2c.handleRDSResponse,
 			}, fakeServer)

--- a/xds/internal/client/testutil_test.go
+++ b/xds/internal/client/testutil_test.go
@@ -54,28 +54,28 @@ func testWatchHandle(t *testing.T, test *watchHandleTestcase, testConfig *watchH
 
 	var cancelWatch func()
 	switch testConfig.typeURL {
-	case listenerURL:
+	case ldsURL:
 		// Register a watcher, to trigger the v2Client to send an LDS request.
 		cancelWatch = testConfig.ldsWatch(goodLDSTarget1, func(u ldsUpdate, err error) {
 			t.Logf("in v2c.watchLDS callback, ldsUpdate: %+v, err: %v", u, err)
 			gotUpdateCh <- u
 			gotUpdateErrCh <- err
 		})
-	case routeURL:
+	case rdsURL:
 		// Register a watcher, to trigger the v2Client to send an RDS request.
 		cancelWatch = testConfig.rdsWatch(goodRouteName1, func(u rdsUpdate, err error) {
 			t.Logf("in v2c.watchRDS callback, rdsUpdate: %+v, err: %v", u, err)
 			gotUpdateCh <- u
 			gotUpdateErrCh <- err
 		})
-	case clusterURL:
+	case cdsURL:
 		// Register a watcher, to trigger the v2Client to send an CDS request.
 		cancelWatch = testConfig.cdsWatch(clusterName1, func(u CDSUpdate, err error) {
 			t.Logf("in v2c.watchCDS callback, cdsUpdate: %+v, err: %v", u, err)
 			gotUpdateCh <- u
 			gotUpdateErrCh <- err
 		})
-	case endpointURL:
+	case edsURL:
 		// Register a watcher, to trigger the v2Client to send an EDS request.
 		cancelWatch = testConfig.edsWatch(goodEDSName, func(u *EDSUpdate, err error) {
 			t.Logf("in v2c.watchEDS callback, edsUpdate: %+v, err: %v", u, err)

--- a/xds/internal/client/testutil_test.go
+++ b/xds/internal/client/testutil_test.go
@@ -1,0 +1,111 @@
+/*
+ *
+ * Copyright 2019 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package client
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	xdspb "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/grpc/xds/internal/client/fakexds"
+)
+
+type watchHandleConfig struct {
+	typeURL string
+
+	// Only one of the following should be non-nil. The one corresponding with
+	// typeURL will be called.
+	ldsWatch func(target string, ldsCb ldsCallback) (cancel func())
+	rdsWatch func(routeName string, rdsCb rdsCallback) (cancel func())
+	cdsWatch func(clusterName string, cdsCb cdsCallback) (cancel func())
+	edsWatch func(clusterName string, edsCb edsCallback) (cancel func())
+
+	handle func(response *xdspb.DiscoveryResponse) error
+}
+
+type watchHandleTestcase struct {
+	responseToHandle *xdspb.DiscoveryResponse
+	wantErr          bool
+	wantUpdate       interface{}
+	wantUpdateErr    bool
+}
+
+func testWatchHandle(t *testing.T, test *watchHandleTestcase, testConfig *watchHandleConfig, fakeServer *fakexds.Server) {
+	// t.Helper()
+	gotUpdateCh := make(chan rdsUpdate, 1)
+	gotUpdateErrCh := make(chan error, 1)
+
+	var cancelWatch func()
+	switch testConfig.typeURL {
+	case listenerURL:
+	case routeURL:
+		// Register a watcher, to trigger the v2Client to send an RDS request.
+		cancelWatch = testConfig.rdsWatch(goodRouteName1, func(u rdsUpdate, err error) {
+			t.Logf("in v2c.watchRDS callback, rdsUpdate: %+v, err: %v", u, err)
+			gotUpdateCh <- u
+			gotUpdateErrCh <- err
+		})
+	case clusterURL:
+	case endpointURL:
+	default:
+		t.Fatalf("unknown typeURL: %s", testConfig.typeURL)
+	}
+	defer cancelWatch()
+
+	// Wait till the request makes it to the fakeServer. This ensures that
+	// the watch request has been processed by the v2Client.
+	<-fakeServer.RequestChan
+
+	// Directly push the response through a call to handleRDSResponse,
+	// thereby bypassing the fakeServer.
+	if err := testConfig.handle(test.responseToHandle); (err != nil) != test.wantErr {
+		t.Fatalf("v2c.handleRDSResponse() returned err: %v, wantErr: %v", err, test.wantErr)
+	}
+
+	// If the test needs the callback to be invoked, verify the update and
+	// error pushed to the callback.
+	//
+	// if test.wantUpdate != nil {
+	// Cannot directly compare wantUpdate with nil (typed vs non-types nil).
+	// if c := test.wantUpdate; !(c == nil || (reflect.ValueOf(c).Kind() == reflect.Ptr && reflect.ValueOf(c).IsNil())) {
+	switch wantUpdate := test.wantUpdate.(type) {
+	case *rdsUpdate:
+		if wantUpdate == nil {
+			break
+		}
+		fmt.Printf("wantUpdate is not nil: %v\n", wantUpdate)
+		timer := time.NewTimer(defaultTestTimeout)
+		select {
+		case <-timer.C:
+			t.Fatal("Timeout expecting RDS update")
+		case gotUpdate := <-gotUpdateCh:
+			timer.Stop()
+			if !cmp.Equal(gotUpdate, *wantUpdate, cmp.AllowUnexported(rdsUpdate{})) {
+				t.Fatalf("got RDS update : %+v, want %+v", gotUpdate, wantUpdate)
+			}
+		}
+		// Since the callback that we registered pushes to both channels at
+		// the same time, this channel read should return immediately.
+		gotUpdateErr := <-gotUpdateErrCh
+		if (gotUpdateErr != nil) != test.wantUpdateErr {
+			t.Fatalf("got RDS update error {%v}, wantErr: %v", gotUpdateErr, test.wantUpdateErr)
+		}
+	}
+}

--- a/xds/internal/client/testutil_test.go
+++ b/xds/internal/client/testutil_test.go
@@ -69,6 +69,12 @@ func testWatchHandle(t *testing.T, test *watchHandleTestcase, testConfig *watchH
 			gotUpdateErrCh <- err
 		})
 	case clusterURL:
+		// Register a watcher, to trigger the v2Client to send an CDS request.
+		cancelWatch = testConfig.cdsWatch(clusterName1, func(u CDSUpdate, err error) {
+			t.Logf("in v2c.watchCDS callback, cdsUpdate: %+v, err: %v", u, err)
+			gotUpdateCh <- u
+			gotUpdateErrCh <- err
+		})
 	case endpointURL:
 		// Register a watcher, to trigger the v2Client to send an EDS request.
 		cancelWatch = testConfig.edsWatch(goodEDSName, func(u *EDSUpdate, err error) {


### PR DESCRIPTION
Share code for `TestHandlexDSrequest()`. The tests do very similar things: start a watch and compare the response.

The tricky part is the different `watch` function parameters. To avoid using `interface{}` everywhere (that will bypass all type checks), each xDS has a separate `watch` function, and the test function `switch` on the typeURL to know which to call.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grpc/grpc-go/3267)
<!-- Reviewable:end -->
