### PR TITLE
Add clearer logging to pickfirst balancer

### DIFF
--- a/pickfirst.go
+++ b/pickfirst.go
@@ -75,7 +75,7 @@ func (b *pickfirstBalancer) HandleResolvedAddrs(addrs []resolver.Address, err er
 
 func (b *pickfirstBalancer) HandleSubConnStateChange(sc balancer.SubConn, s connectivity.State) {
 	if grpclog.V(2) {
-		grpclog.Infof("pickfirstBalancer: HandleSubConnStateChange: %p, %v", sc, s)
+		grpclog.Infof("pickfirstBalancer: HandleSubConnStateChange: %+v, %v", sc, s)
 	}
 	if b.sc != sc {
 		if grpclog.V(2) {

--- a/test/balancer_test.go
+++ b/test/balancer_test.go
@@ -76,7 +76,7 @@ func (b *testBalancer) HandleResolvedAddrs(addrs []resolver.Address, err error) 
 }
 
 func (b *testBalancer) HandleSubConnStateChange(sc balancer.SubConn, s connectivity.State) {
-	grpclog.Infof("testBalancer: HandleSubConnStateChange: %p, %v", sc, s)
+	grpclog.Infof("testBalancer: HandleSubConnStateChange: %+v, %v", sc, s)
 	if b.sc != sc {
 		grpclog.Infof("testBalancer: ignored state change because sc is not recognized")
 		return

--- a/test/balancer_test.go
+++ b/test/balancer_test.go
@@ -76,7 +76,7 @@ func (b *testBalancer) HandleResolvedAddrs(addrs []resolver.Address, err error) 
 }
 
 func (b *testBalancer) HandleSubConnStateChange(sc balancer.SubConn, s connectivity.State) {
-	grpclog.Infof("testBalancer: HandleSubConnStateChange: %+v, %v", sc, s)
+	grpclog.Infof("testBalancer: HandleSubConnStateChange: %p, %v", sc, s)
 	if b.sc != sc {
 		grpclog.Infof("testBalancer: ignored state change because sc is not recognized")
 		return


### PR DESCRIPTION
Some pickfirst logs just print the address. This PR adds more clear logging of the struct variables and values.