### PR TITLE
eds: delete fallback related code from the EDS balancer

### DIFF
--- a/xds/internal/balancer/xds.go
+++ b/xds/internal/balancer/xds.go
@@ -43,10 +43,6 @@ const (
 )
 
 var (
-	// This field is for testing purpose.
-	// TODO: if later we make startupTimeout configurable through BuildOptions(maybe?), then we can remove
-	// this field and configure through BuildOptions instead.
-	startupTimeout = defaultTimeout
 	newEDSBalancer = func(cc balancer.ClientConn, loadStore lrs.Store) edsBalancerInterface {
 		return edsbalancer.NewXDSBalancer(cc, loadStore)
 	}
@@ -66,8 +62,6 @@ func (b *edsBalancerBuilder) Build(cc balancer.ClientConn, opts balancer.BuildOp
 		cancel:          cancel,
 		cc:              cc,
 		buildOpts:       opts,
-		startupTimeout:  startupTimeout,
-		startup:         true,
 		grpcUpdate:      make(chan interface{}),
 		xdsClientUpdate: make(chan interface{}),
 		loadStore:       lrs.NewStore(),
@@ -112,10 +106,8 @@ var _ balancer.V2Balancer = (*edsBalancer)(nil) // Assert that we implement V2Ba
 type edsBalancer struct {
 	cc             balancer.ClientConn // *xdsClientConn
 	buildOpts      balancer.BuildOptions
-	startupTimeout time.Duration
 	ctx            context.Context
 	cancel         context.CancelFunc
-	startup        bool // startup indicates whether this edsBalancer is in startup stage.
 
 	// edsBalancer continuously monitor the channels below, and will handle events from them in sync.
 	grpcUpdate      chan interface{}

--- a/xds/internal/balancer/xds.go
+++ b/xds/internal/balancer/xds.go
@@ -64,10 +64,10 @@ func (b *edsBalancerBuilder) Build(cc balancer.ClientConn, opts balancer.BuildOp
 		buildOpts:       opts,
 		grpcUpdate:      make(chan interface{}),
 		xdsClientUpdate: make(chan interface{}),
-		loadStore:       lrs.NewStore(),
 	}
-	x.xdsLB = newEDSBalancer(x.cc, x.loadStore)
-	x.client = newXDSClientWrapper(x.handleEDSUpdate, x.loseContact, x.buildOpts, x.loadStore)
+	loadStore := lrs.NewStore()
+	x.xdsLB = newEDSBalancer(x.cc, loadStore)
+	x.client = newXDSClientWrapper(x.handleEDSUpdate, x.loseContact, x.buildOpts, loadStore)
 	go x.run()
 	return x
 }
@@ -118,7 +118,6 @@ type edsBalancer struct {
 	client    *xdsclientWrapper // may change when passed a different service config
 	config    *XDSConfig        // may change when passed a different service config
 	xdsLB     edsBalancerInterface
-	loadStore lrs.Store
 }
 
 // run gets executed in a goroutine once edsBalancer is created. It monitors updates from grpc,

--- a/xds/internal/balancer/xds.go
+++ b/xds/internal/balancer/xds.go
@@ -101,8 +101,10 @@ type edsBalancerInterface interface {
 
 var _ balancer.V2Balancer = (*edsBalancer)(nil) // Assert that we implement V2Balancer
 
-// edsBalancer manages xdsClient and the actual balancer that does load balancing (either edsBalancer,
-// or fallback LB).
+// edsBalancer manages xdsClient and the actual balancer that does load
+// balancing.
+//
+// It currently has only an edsBalancer. Later, we may add fallback.
 type edsBalancer struct {
 	cc             balancer.ClientConn // *xdsClientConn
 	buildOpts      balancer.BuildOptions

--- a/xds/internal/balancer/xds.go
+++ b/xds/internal/balancer/xds.go
@@ -72,7 +72,7 @@ func (b *edsBalancerBuilder) Build(cc balancer.ClientConn, opts balancer.BuildOp
 		loadStore:       lrs.NewStore(),
 	}
 	x.cc = &xdsClientConn{
-		ClientConn:  cc,
+		ClientConn: cc,
 	}
 	x.xdsLB = newEDSBalancer(x.cc, x.loadStore)
 	x.client = newXDSClientWrapper(x.handleEDSUpdate, x.loseContact, x.buildOpts, x.loadStore)
@@ -112,13 +112,13 @@ var _ balancer.V2Balancer = (*edsBalancer)(nil) // Assert that we implement V2Ba
 // edsBalancer manages xdsClient and the actual balancer that does load balancing (either edsBalancer,
 // or fallback LB).
 type edsBalancer struct {
-	cc                balancer.ClientConn // *xdsClientConn
-	buildOpts         balancer.BuildOptions
-	startupTimeout    time.Duration
-	xdsStaleTimeout   *time.Duration
-	ctx               context.Context
-	cancel            context.CancelFunc
-	startup           bool // startup indicates whether this edsBalancer is in startup stage.
+	cc              balancer.ClientConn // *xdsClientConn
+	buildOpts       balancer.BuildOptions
+	startupTimeout  time.Duration
+	xdsStaleTimeout *time.Duration
+	ctx             context.Context
+	cancel          context.CancelFunc
+	startup         bool // startup indicates whether this edsBalancer is in startup stage.
 
 	// edsBalancer continuously monitor the channels below, and will handle events from them in sync.
 	grpcUpdate      chan interface{}
@@ -126,10 +126,10 @@ type edsBalancer struct {
 	timer           *time.Timer
 	noSubConnAlert  <-chan struct{}
 
-	client           *xdsclientWrapper // may change when passed a different service config
-	config           *XDSConfig        // may change when passed a different service config
-	xdsLB            edsBalancerInterface
-	loadStore        lrs.Store
+	client    *xdsclientWrapper // may change when passed a different service config
+	config    *XDSConfig        // may change when passed a different service config
+	xdsLB     edsBalancerInterface
+	loadStore lrs.Store
 }
 
 // run gets executed in a goroutine once edsBalancer is created. It monitors updates from grpc,
@@ -183,7 +183,6 @@ func (x *edsBalancer) handleGRPCUpdate(update interface{}) {
 				x.xdsLB.HandleChildPolicy(roundrobin.Name, nil)
 			}
 		}
-
 
 		x.config = cfg
 	default:
@@ -282,7 +281,6 @@ func (x *edsBalancer) loseContact() {
 	case <-x.ctx.Done():
 	}
 }
-
 
 func (x *edsBalancer) Close() {
 	x.cancel()

--- a/xds/internal/balancer/xds.go
+++ b/xds/internal/balancer/xds.go
@@ -24,7 +24,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
-	"sync"
 	"time"
 
 	"google.golang.org/grpc/balancer"
@@ -67,17 +66,15 @@ func (b *edsBalancerBuilder) Build(cc balancer.ClientConn, opts balancer.BuildOp
 		cancel:          cancel,
 		buildOpts:       opts,
 		startupTimeout:  startupTimeout,
-		connStateMgr:    &connStateMgr{},
 		startup:         true,
 		grpcUpdate:      make(chan interface{}),
 		xdsClientUpdate: make(chan interface{}),
-		timer:           createDrainedTimer(), // initialized a timer that won't fire without reset
 		loadStore:       lrs.NewStore(),
 	}
 	x.cc = &xdsClientConn{
-		updateState: x.connStateMgr.updateState,
 		ClientConn:  cc,
 	}
+	x.xdsLB = newEDSBalancer(x.cc, x.loadStore)
 	x.client = newXDSClientWrapper(x.handleEDSUpdate, x.loseContact, x.buildOpts, x.loadStore)
 	go x.run()
 	return x
@@ -119,11 +116,9 @@ type edsBalancer struct {
 	buildOpts         balancer.BuildOptions
 	startupTimeout    time.Duration
 	xdsStaleTimeout   *time.Duration
-	connStateMgr      *connStateMgr
 	ctx               context.Context
 	cancel            context.CancelFunc
 	startup           bool // startup indicates whether this edsBalancer is in startup stage.
-	inFallbackMonitor bool
 
 	// edsBalancer continuously monitor the channels below, and will handle events from them in sync.
 	grpcUpdate      chan interface{}
@@ -134,8 +129,6 @@ type edsBalancer struct {
 	client           *xdsclientWrapper // may change when passed a different service config
 	config           *XDSConfig        // may change when passed a different service config
 	xdsLB            edsBalancerInterface
-	fallbackLB       balancer.Balancer
-	fallbackInitData *resolver.State // may change when HandleResolved address is called
 	loadStore        lrs.Store
 }
 
@@ -149,19 +142,12 @@ func (x *edsBalancer) run() {
 			x.handleGRPCUpdate(update)
 		case update := <-x.xdsClientUpdate:
 			x.handleXDSClientUpdate(update)
-		case <-x.timer.C: // x.timer.C will block if we are not in fallback monitoring stage.
-			x.switchFallback()
-		case <-x.noSubConnAlert: // x.noSubConnAlert will block if we are not in fallback monitoring stage.
-			x.switchFallback()
 		case <-x.ctx.Done():
 			if x.client != nil {
 				x.client.close()
 			}
 			if x.xdsLB != nil {
 				x.xdsLB.Close()
-			}
-			if x.fallbackLB != nil {
-				x.fallbackLB.Close()
 			}
 			return
 		}
@@ -174,13 +160,6 @@ func (x *edsBalancer) handleGRPCUpdate(update interface{}) {
 		if x.xdsLB != nil {
 			x.xdsLB.HandleSubConnStateChange(u.sc, u.state.ConnectivityState)
 		}
-		if x.fallbackLB != nil {
-			if lb, ok := x.fallbackLB.(balancer.V2Balancer); ok {
-				lb.UpdateSubConnState(u.sc, u.state)
-			} else {
-				x.fallbackLB.HandleSubConnStateChange(u.sc, u.state.ConnectivityState)
-			}
-		}
 	case *balancer.ClientConnState:
 		cfg, _ := u.BalancerConfig.(*XDSConfig)
 		if cfg == nil {
@@ -191,18 +170,7 @@ func (x *edsBalancer) handleGRPCUpdate(update interface{}) {
 		x.client.handleUpdate(cfg, u.ResolverState.Attributes)
 
 		if x.config == nil {
-			// If this is the first config, the edsBalancer is in startup stage.
-			// We need to apply the startup timeout for the first xdsClient, in
-			// case it doesn't get a response from the traffic director in time.
-			if x.startup {
-				x.startFallbackMonitoring()
-			}
 			x.config = cfg
-			x.fallbackInitData = &resolver.State{
-				Addresses: u.ResolverState.Addresses,
-				// TODO(yuxuanli): get the fallback balancer config once the validation change completes, where
-				// we can pass along the config struct.
-			}
 			return
 		}
 
@@ -216,25 +184,8 @@ func (x *edsBalancer) handleGRPCUpdate(update interface{}) {
 			}
 		}
 
-		var fallbackChanged bool
-		if x.fallbackLB != nil && !reflect.DeepEqual(cfg.FallBackPolicy, x.config.FallBackPolicy) {
-			x.fallbackLB.Close()
-			x.buildFallBackBalancer(cfg)
-			fallbackChanged = true
-		}
-
-		if x.fallbackLB != nil && (!reflect.DeepEqual(x.fallbackInitData.Addresses, u.ResolverState.Addresses) || fallbackChanged) {
-			x.updateFallbackWithResolverState(&resolver.State{
-				Addresses: u.ResolverState.Addresses,
-			})
-		}
 
 		x.config = cfg
-		x.fallbackInitData = &resolver.State{
-			Addresses: u.ResolverState.Addresses,
-			// TODO(yuxuanli): get the fallback balancer config once the validation change completes, where
-			// we can pass along the config struct.
-		}
 	default:
 		// unreachable path
 		panic("wrong update type")
@@ -246,46 +197,12 @@ func (x *edsBalancer) handleXDSClientUpdate(update interface{}) {
 	// TODO: this func should accept (*xdsclient.EDSUpdate, error), and process
 	// the error, instead of having a separate loseContact signal.
 	case *xdsclient.EDSUpdate:
-		x.cancelFallbackAndSwitchEDSBalancerIfNecessary()
 		x.xdsLB.HandleEDSResponse(u)
 	case *loseContact:
-		// if we are already doing fallback monitoring, then we ignore new loseContact signal.
-		if x.inFallbackMonitor {
-			return
-		}
-		x.inFallbackMonitor = true
-		x.startFallbackMonitoring()
+		// TODO: start a monitor goroutine to switch to fallback
 	default:
 		panic("unexpected xds client update type")
 	}
-}
-
-type connStateMgr struct {
-	mu       sync.Mutex
-	curState connectivity.State
-	notify   chan struct{}
-}
-
-func (c *connStateMgr) updateState(s connectivity.State) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.curState = s
-	if s != connectivity.Ready && c.notify != nil {
-		close(c.notify)
-		c.notify = nil
-	}
-}
-
-func (c *connStateMgr) notifyWhenNotReady() <-chan struct{} {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	if c.curState != connectivity.Ready {
-		ch := make(chan struct{})
-		close(ch)
-		return ch
-	}
-	c.notify = make(chan struct{})
-	return c.notify
 }
 
 // xdsClientConn wraps around the balancer.ClientConn passed in from grpc. The wrapping is to add
@@ -366,113 +283,7 @@ func (x *edsBalancer) loseContact() {
 	}
 }
 
-func (x *edsBalancer) switchFallback() {
-	if x.xdsLB != nil {
-		x.xdsLB.Close()
-		x.xdsLB = nil
-	}
-	x.buildFallBackBalancer(x.config)
-	x.updateFallbackWithResolverState(x.fallbackInitData)
-	x.cancelFallbackMonitoring()
-}
-
-func (x *edsBalancer) updateFallbackWithResolverState(s *resolver.State) {
-	if lb, ok := x.fallbackLB.(balancer.V2Balancer); ok {
-		lb.UpdateClientConnState(balancer.ClientConnState{ResolverState: resolver.State{
-			Addresses: s.Addresses,
-			// TODO(yuxuanli): get the fallback balancer config once the validation change completes, where
-			// we can pass along the config struct.
-		}})
-	} else {
-		x.fallbackLB.HandleResolvedAddrs(s.Addresses, nil)
-	}
-}
-
-// x.cancelFallbackAndSwitchEDSBalancerIfNecessary() will be no-op if we have a working xds client.
-// It will cancel fallback monitoring if we are in fallback monitoring stage.
-// If there's no running edsBalancer currently, it will create one and initialize it. Also, it will
-// shutdown the fallback balancer if there's one running.
-func (x *edsBalancer) cancelFallbackAndSwitchEDSBalancerIfNecessary() {
-	// xDS update will cancel fallback monitoring if we are in fallback monitoring stage.
-	x.cancelFallbackMonitoring()
-
-	// xDS update will switch balancer back to edsBalancer if we are in fallback.
-	if x.xdsLB == nil {
-		if x.fallbackLB != nil {
-			x.fallbackLB.Close()
-			x.fallbackLB = nil
-		}
-		x.xdsLB = newEDSBalancer(x.cc, x.loadStore)
-		if x.config.ChildPolicy != nil {
-			x.xdsLB.HandleChildPolicy(x.config.ChildPolicy.Name, x.config.ChildPolicy.Config)
-		}
-	}
-}
-
-func (x *edsBalancer) buildFallBackBalancer(c *XDSConfig) {
-	if c.FallBackPolicy == nil {
-		x.buildFallBackBalancer(&XDSConfig{
-			FallBackPolicy: &loadBalancingConfig{
-				Name: "round_robin",
-			},
-		})
-		return
-	}
-	// builder will always be non-nil, since when parse JSON into xdsinternal.XDSConfig, we check whether the specified
-	// balancer is registered or not.
-	builder := balancer.Get(c.FallBackPolicy.Name)
-
-	x.fallbackLB = builder.Build(x.cc, x.buildOpts)
-}
-
-// There are three ways that could lead to fallback:
-// 1. During startup (i.e. the first xds client is just created and attempts to contact the traffic
-//    director), fallback if it has not received any response from the director within the configured
-//    timeout.
-// 2. After xds client loses contact with the remote, fallback if all connections to the backends are
-//    lost (i.e. not in state READY).
-func (x *edsBalancer) startFallbackMonitoring() {
-	if x.startup {
-		x.startup = false
-		x.timer.Reset(x.startupTimeout)
-		return
-	}
-
-	x.noSubConnAlert = x.connStateMgr.notifyWhenNotReady()
-	if x.xdsStaleTimeout != nil {
-		if !x.timer.Stop() {
-			<-x.timer.C
-		}
-		x.timer.Reset(*x.xdsStaleTimeout)
-	}
-}
-
-// There are two cases where fallback monitoring should be canceled:
-// 1. xDS client returns a new ADS message.
-// 2. fallback has been triggered.
-func (x *edsBalancer) cancelFallbackMonitoring() {
-	if !x.timer.Stop() {
-		select {
-		case <-x.timer.C:
-			// For cases where some fallback condition happens along with the timeout, but timeout loses
-			// the race, so we need to drain the x.timer.C. thus we don't trigger fallback again.
-		default:
-			// if the timer timeout leads us here, then there's no thing to drain from x.timer.C.
-		}
-	}
-	x.noSubConnAlert = nil
-	x.inFallbackMonitor = false
-}
 
 func (x *edsBalancer) Close() {
 	x.cancel()
-}
-
-func createDrainedTimer() *time.Timer {
-	timer := time.NewTimer(0 * time.Millisecond)
-	// make sure initially the timer channel is blocking until reset.
-	if !timer.Stop() {
-		<-timer.C
-	}
-	return timer
 }

--- a/xds/internal/balancer/xds.go
+++ b/xds/internal/balancer/xds.go
@@ -115,9 +115,9 @@ type edsBalancer struct {
 	grpcUpdate      chan interface{}
 	xdsClientUpdate chan interface{}
 
-	client    *xdsclientWrapper // may change when passed a different service config
-	config    *XDSConfig        // may change when passed a different service config
-	xdsLB     edsBalancerInterface
+	client *xdsclientWrapper // may change when passed a different service config
+	config *XDSConfig        // may change when passed a different service config
+	xdsLB  edsBalancerInterface
 }
 
 // run gets executed in a goroutine once edsBalancer is created. It monitors updates from grpc,

--- a/xds/internal/balancer/xds.go
+++ b/xds/internal/balancer/xds.go
@@ -195,7 +195,7 @@ func (x *edsBalancer) handleXDSClientUpdate(update interface{}) {
 	case *xdsclient.EDSUpdate:
 		x.xdsLB.HandleEDSResponse(u)
 	case *loseContact:
-		// TODO: start a monitor goroutine to switch to fallback
+		// loseContact can be useful for going into fallback.
 	default:
 		panic("unexpected xds client update type")
 	}

--- a/xds/internal/balancer/xds.go
+++ b/xds/internal/balancer/xds.go
@@ -106,10 +106,10 @@ var _ balancer.V2Balancer = (*edsBalancer)(nil) // Assert that we implement V2Ba
 //
 // It currently has only an edsBalancer. Later, we may add fallback.
 type edsBalancer struct {
-	cc             balancer.ClientConn // *xdsClientConn
-	buildOpts      balancer.BuildOptions
-	ctx            context.Context
-	cancel         context.CancelFunc
+	cc        balancer.ClientConn // *xdsClientConn
+	buildOpts balancer.BuildOptions
+	ctx       context.Context
+	cancel    context.CancelFunc
 
 	// edsBalancer continuously monitor the channels below, and will handle events from them in sync.
 	grpcUpdate      chan interface{}

--- a/xds/internal/balancer/xds.go
+++ b/xds/internal/balancer/xds.go
@@ -112,19 +112,16 @@ var _ balancer.V2Balancer = (*edsBalancer)(nil) // Assert that we implement V2Ba
 // edsBalancer manages xdsClient and the actual balancer that does load balancing (either edsBalancer,
 // or fallback LB).
 type edsBalancer struct {
-	cc              balancer.ClientConn // *xdsClientConn
-	buildOpts       balancer.BuildOptions
-	startupTimeout  time.Duration
-	xdsStaleTimeout *time.Duration
-	ctx             context.Context
-	cancel          context.CancelFunc
-	startup         bool // startup indicates whether this edsBalancer is in startup stage.
+	cc             balancer.ClientConn // *xdsClientConn
+	buildOpts      balancer.BuildOptions
+	startupTimeout time.Duration
+	ctx            context.Context
+	cancel         context.CancelFunc
+	startup        bool // startup indicates whether this edsBalancer is in startup stage.
 
 	// edsBalancer continuously monitor the channels below, and will handle events from them in sync.
 	grpcUpdate      chan interface{}
 	xdsClientUpdate chan interface{}
-	timer           *time.Timer
-	noSubConnAlert  <-chan struct{}
 
 	client    *xdsclientWrapper // may change when passed a different service config
 	config    *XDSConfig        // may change when passed a different service config

--- a/xds/internal/balancer/xds_test.go
+++ b/xds/internal/balancer/xds_test.go
@@ -215,16 +215,6 @@ func setup(edsLBCh *testutils.Channel, xdsClientCh *testutils.Channel) func() {
 	}
 }
 
-// setupForFallback performs everything that setup does and in addition
-// overrides the fallback startupTimeout to a small value to trigger fallback
-// in tests.
-func setupForFallback(edsLBCh *testutils.Channel, xdsClientCh *testutils.Channel) func() {
-	cancel := setup(edsLBCh, xdsClientCh)
-	return func() {
-		cancel()
-	}
-}
-
 // TestXDSConfigBalancerNameUpdate verifies different scenarios where the
 // balancer name in the lbConfig is updated.
 //
@@ -236,8 +226,7 @@ func setupForFallback(edsLBCh *testutils.Channel, xdsClientCh *testutils.Channel
 func (s) TestXDSConfigBalancerNameUpdate(t *testing.T) {
 	edsLBCh := testutils.NewChannel()
 	xdsClientCh := testutils.NewChannel()
-	// TODO: setup doesn't need to take edsLBCh.
-	cancel := setupForFallback(edsLBCh, xdsClientCh)
+	cancel := setup(edsLBCh, xdsClientCh)
 	defer cancel()
 
 	builder := balancer.Get(edsName)
@@ -365,8 +354,7 @@ func (s) TestXDSConnfigChildPolicyUpdate(t *testing.T) {
 }
 
 // TestXDSSubConnStateChange verifies if the top-level edsBalancer passes on
-// the subConnStateChange to appropriate child balancers (it tests for edsLB
-// and a fallbackLB).
+// the subConnStateChange to appropriate child balancers.
 func (s) TestXDSSubConnStateChange(t *testing.T) {
 	edsLBCh := testutils.NewChannel()
 	xdsClientCh := testutils.NewChannel()

--- a/xds/internal/balancer/xds_test.go
+++ b/xds/internal/balancer/xds_test.go
@@ -82,7 +82,7 @@ func (t *testClientConn) NewSubConn(addrs []resolver.Address, opts balancer.NewS
 	return nil, nil
 }
 
-func (testClientConn) Target() string                                          { return testServiceName }
+func (testClientConn) Target() string { return testServiceName }
 
 type scStateChange struct {
 	sc    balancer.SubConn

--- a/xds/internal/balancer/xds_test.go
+++ b/xds/internal/balancer/xds_test.go
@@ -263,57 +263,6 @@ type fakeSubConn struct{}
 func (*fakeSubConn) UpdateAddresses([]resolver.Address) { panic("implement me") }
 func (*fakeSubConn) Connect()                           { panic("implement me") }
 
-// TestXDSFallbackResolvedAddrs verifies that the fallback balancer specified
-// in the provided lbconfig is initialized, and that it receives the addresses
-// pushed by the resolver.
-//
-// The test does the following:
-// * Builds a new xds balancer.
-// * Since there is no xDS server to respond to requests from the xds client
-//   (created as part of the xds balancer), we expect the fallback policy to
-//   kick in.
-// * Repeatedly pushes new ClientConnState which specifies the same fallback
-//   policy, but a different set of resolved addresses.
-// * The fallback policy is implemented by a fake balancer, which appends a
-//   unique address to the list of addresses it uses to create the SubConn.
-// * We also have a fake ClientConn which verifies that it receives the
-//   expected address list.
-func (s) TestXDSFallbackResolvedAddrs(t *testing.T) {
-	startupTimeout = 500 * time.Millisecond
-	defer func() { startupTimeout = defaultTimeout }()
-
-	builder := balancer.Get(edsName)
-	cc := newTestClientConn()
-	edsB, ok := builder.Build(cc, balancer.BuildOptions{Target: resolver.Target{Endpoint: testServiceName}}).(*edsBalancer)
-	if !ok {
-		t.Fatalf("builder.Build(%s) returned type {%T}, want {*edsBalancer}", edsName, edsB)
-	}
-	defer edsB.Close()
-
-	tests := []struct {
-		resolvedAddrs []resolver.Address
-		wantAddrs     []resolver.Address
-	}{
-		{
-			resolvedAddrs: []resolver.Address{{Addr: "1.1.1.1:10001"}, {Addr: "2.2.2.2:10002"}},
-			wantAddrs:     []resolver.Address{{Addr: "1.1.1.1:10001"}, {Addr: "2.2.2.2:10002"}, specialAddrForBalancerA},
-		},
-		{
-			resolvedAddrs: []resolver.Address{{Addr: "1.1.1.1:10001"}},
-			wantAddrs:     []resolver.Address{{Addr: "1.1.1.1:10001"}, specialAddrForBalancerA},
-		},
-	}
-	for _, test := range tests {
-		edsB.UpdateClientConnState(balancer.ClientConnState{
-			ResolverState:  resolver.State{Addresses: test.resolvedAddrs},
-			BalancerConfig: testLBConfigFooBar,
-		})
-		if err := cc.waitForNewSubConns(test.wantAddrs); err != nil {
-			t.Fatal(err)
-		}
-	}
-}
-
 // waitForNewXDSClientWithEDSWatch makes sure that a new xdsClient is created
 // with the provided name. It also make sure that the newly created client
 // registers an eds watcher.
@@ -488,86 +437,6 @@ func (s) TestXDSConnfigChildPolicyUpdate(t *testing.T) {
 	})
 }
 
-// TestXDSConfigFallBackUpdate verifies different scenarios where the fallback
-// config part of the lbConfig is updated.
-//
-// The test does the following:
-// * Builds a top-level edsBalancer
-// * Fakes the xdsClient and the underlying edsLB implementations.
-// * Sends a ClientConn update to the edsBalancer with a bogus balancerName.
-//   This will get the balancer into fallback monitoring, but since the
-//   startupTimeout package variable is not overridden to a small value, fallback
-//   will not kick-in as yet.
-// * Sends another ClientConn update with fallback addresses. Still fallback
-//   would not have kicked in because the startupTimeout hasn't expired.
-// * Sends an EDSUpdate through the fakeclient.Client object. This will trigger
-//   the creation of an edsLB object. This is verified.
-// * Trigger fallback by directly calling the loseContact method on the
-//   top-level edsBalancer. This should instantiate the fallbackLB and should
-//   send the appropriate subConns.
-// * Update the fallback policy to specify and different fallback LB and make
-//   sure the new LB receives appropriate subConns.
-func (s) TestXDSConfigFallBackUpdate(t *testing.T) {
-	edsLBCh := testutils.NewChannel()
-	xdsClientCh := testutils.NewChannel()
-	cancel := setup(edsLBCh, xdsClientCh)
-	defer cancel()
-
-	builder := balancer.Get(edsName)
-	cc := newTestClientConn()
-	edsB, ok := builder.Build(cc, balancer.BuildOptions{Target: resolver.Target{Endpoint: testEDSClusterName}}).(*edsBalancer)
-	if !ok {
-		t.Fatalf("builder.Build(%s) returned type {%T}, want {*edsBalancer}", edsName, edsB)
-	}
-	defer edsB.Close()
-
-	bogusBalancerName := "wrong-balancer-name"
-	edsB.UpdateClientConnState(balancer.ClientConnState{
-		BalancerConfig: &XDSConfig{
-			BalancerName:   bogusBalancerName,
-			FallBackPolicy: &loadBalancingConfig{Name: fakeBalancerA},
-		},
-	})
-	xdsC := waitForNewXDSClientWithEDSWatch(t, xdsClientCh, bogusBalancerName)
-
-	addrs := []resolver.Address{{Addr: "1.1.1.1:10001"}, {Addr: "2.2.2.2:10002"}, {Addr: "3.3.3.3:10003"}}
-	edsB.UpdateClientConnState(balancer.ClientConnState{
-		ResolverState: resolver.State{Addresses: addrs},
-		BalancerConfig: &XDSConfig{
-			BalancerName:   bogusBalancerName,
-			FallBackPolicy: &loadBalancingConfig{Name: fakeBalancerB},
-		},
-	})
-
-	xdsC.InvokeWatchEDSCallback(&xdsclient.EDSUpdate{}, nil)
-	if _, err := edsLBCh.Receive(); err != nil {
-		t.Fatalf("edsBalancer did not create edsLB after receiveing EDS update: %v", err)
-	}
-
-	// Call loseContact explicitly, error in EDS callback is not handled.
-	// Eventually, this should call EDS ballback with an error that indicates
-	// "lost contact".
-	edsB.loseContact()
-
-	// Verify that fallback (fakeBalancerB) takes over.
-	if err := cc.waitForNewSubConns(append(addrs, specialAddrForBalancerB)); err != nil {
-		t.Fatal(err)
-	}
-
-	edsB.UpdateClientConnState(balancer.ClientConnState{
-		ResolverState: resolver.State{Addresses: addrs},
-		BalancerConfig: &XDSConfig{
-			BalancerName:   bogusBalancerName,
-			FallBackPolicy: &loadBalancingConfig{Name: fakeBalancerA},
-		},
-	})
-
-	// Verify that fallbackLB (fakeBalancerA) takes over.
-	if err := cc.waitForNewSubConns(append(addrs, specialAddrForBalancerA)); err != nil {
-		t.Fatal(err)
-	}
-}
-
 // TestXDSSubConnStateChange verifies if the top-level edsBalancer passes on
 // the subConnStateChange to appropriate child balancers (it tests for edsLB
 // and a fallbackLB).
@@ -604,25 +473,6 @@ func (s) TestXDSSubConnStateChange(t *testing.T) {
 	state := connectivity.Ready
 	edsB.UpdateSubConnState(fsc, balancer.SubConnState{ConnectivityState: state})
 	edsLB.waitForSubConnStateChange(&scStateChange{sc: fsc, state: state})
-
-	// lbABuilder maintains a pointer to the last balancerA that it created. We
-	// need to clear that to make sure a new one is created when we attempt to
-	// fallback in the next line.
-	lbABuilder.clearLastBalancer()
-	// Call loseContact explicitly, error in EDS callback is not handled.
-	// Eventually, this should call EDS ballback with an error that indicates
-	// "lost contact".
-	edsB.loseContact()
-	// Verify that fallback (fakeBalancerA) takes over.
-	if err := cc.waitForNewSubConns(append(addrs, specialAddrForBalancerA)); err != nil {
-		t.Fatal(err)
-	}
-	fblb := lbABuilder.getLastBalancer()
-	if fblb == nil {
-		t.Fatal("expected fallback balancerA to be built on fallback")
-	}
-	edsB.UpdateSubConnState(fsc, balancer.SubConnState{ConnectivityState: state})
-	fblb.waitForSubConnStateChange(&scStateChange{sc: fsc, state: state})
 }
 
 func TestXDSBalancerConfigParsing(t *testing.T) {

--- a/xds/internal/balancer/xds_test.go
+++ b/xds/internal/balancer/xds_test.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
-	"time"
 
 	corepb "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	"github.com/golang/protobuf/jsonpb"
@@ -221,10 +220,8 @@ func setup(edsLBCh *testutils.Channel, xdsClientCh *testutils.Channel) func() {
 // in tests.
 func setupForFallback(edsLBCh *testutils.Channel, xdsClientCh *testutils.Channel) func() {
 	cancel := setup(edsLBCh, xdsClientCh)
-	startupTimeout = 500 * time.Millisecond
 	return func() {
 		cancel()
-		startupTimeout = defaultTimeout
 	}
 }
 

--- a/xds/internal/balancer/xds_test.go
+++ b/xds/internal/balancer/xds_test.go
@@ -23,7 +23,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
-	"sync"
 	"testing"
 	"time"
 
@@ -46,12 +45,8 @@ import (
 	"google.golang.org/grpc/xds/internal/testutils/fakeclient"
 )
 
-var lbABuilder = &balancerABuilder{}
-
 func init() {
 	balancer.Register(&edsBalancerBuilder{})
-	balancer.Register(lbABuilder)
-	balancer.Register(&balancerBBuilder{})
 
 	bootstrapConfigNew = func() *bootstrap.Config {
 		return &bootstrap.Config{
@@ -72,77 +67,9 @@ func Test(t *testing.T) {
 	grpctest.RunSubTests(t, s{})
 }
 
-const (
-	fakeBalancerA = "fake_balancer_A"
-	fakeBalancerB = "fake_balancer_B"
-)
-
 var (
-	testBalancerNameFooBar  = "foo.bar"
-	specialAddrForBalancerA = resolver.Address{Addr: "this.is.balancer.A"}
-	specialAddrForBalancerB = resolver.Address{Addr: "this.is.balancer.B"}
+	testBalancerNameFooBar = "foo.bar"
 )
-
-type balancerABuilder struct {
-	mu           sync.Mutex
-	lastBalancer *balancerA
-}
-
-func (b *balancerABuilder) Build(cc balancer.ClientConn, opts balancer.BuildOptions) balancer.Balancer {
-	b.mu.Lock()
-	b.lastBalancer = &balancerA{cc: cc, subconnStateChange: testutils.NewChannelWithSize(10)}
-	b.mu.Unlock()
-	return b.lastBalancer
-}
-
-func (b *balancerABuilder) Name() string {
-	return string(fakeBalancerA)
-}
-
-type balancerBBuilder struct{}
-
-func (b *balancerBBuilder) Build(cc balancer.ClientConn, opts balancer.BuildOptions) balancer.Balancer {
-	return &balancerB{cc: cc}
-}
-
-func (*balancerBBuilder) Name() string {
-	return string(fakeBalancerB)
-}
-
-// A fake balancer implementation which does two things:
-// * Appends a unique address to the list of resolved addresses received before
-//   attempting to create a SubConn.
-// * Makes the received subConn state changes available through a channel, for
-//   the test to inspect.
-type balancerA struct {
-	cc                 balancer.ClientConn
-	subconnStateChange *testutils.Channel
-}
-
-func (b *balancerA) HandleSubConnStateChange(sc balancer.SubConn, state connectivity.State) {
-	b.subconnStateChange.Send(&scStateChange{sc: sc, state: state})
-}
-
-func (b *balancerA) HandleResolvedAddrs(addrs []resolver.Address, err error) {
-	_, _ = b.cc.NewSubConn(append(addrs, specialAddrForBalancerA), balancer.NewSubConnOptions{})
-}
-
-func (b *balancerA) Close() {}
-
-// A fake balancer implementation which appends a unique address to the list of
-// resolved addresses received before attempting to create a SubConn.
-type balancerB struct {
-	cc balancer.ClientConn
-}
-
-func (b *balancerB) HandleResolvedAddrs(addrs []resolver.Address, err error) {
-	_, _ = b.cc.NewSubConn(append(addrs, specialAddrForBalancerB), balancer.NewSubConnOptions{})
-}
-
-func (balancerB) HandleSubConnStateChange(sc balancer.SubConn, state connectivity.State) {
-	panic("implement me")
-}
-func (balancerB) Close() {}
 
 func newTestClientConn() *testClientConn {
 	return &testClientConn{newSubConns: testutils.NewChannelWithSize(10)}
@@ -331,8 +258,6 @@ func (s) TestXDSConfigBalancerNameUpdate(t *testing.T) {
 			ResolverState: resolver.State{Addresses: addrs},
 			BalancerConfig: &XDSConfig{
 				BalancerName:   balancerName,
-				ChildPolicy:    &loadBalancingConfig{Name: fakeBalancerA},
-				FallBackPolicy: &loadBalancingConfig{Name: fakeBalancerA},
 				EDSServiceName: testEDSClusterName,
 			},
 		})
@@ -341,6 +266,46 @@ func (s) TestXDSConfigBalancerNameUpdate(t *testing.T) {
 		xdsC.InvokeWatchEDSCallback(&xdsclient.EDSUpdate{}, nil)
 	}
 }
+
+const (
+	fakeBalancerA = "fake_balancer_A"
+	fakeBalancerB = "fake_balancer_B"
+)
+
+// Install two fake balancers for service config update tests.
+//
+// ParseConfig only accepts the json if the balancer specified is registered.
+
+func init() {
+	balancer.Register(&fakeBalancerBuilder{name: fakeBalancerA})
+	balancer.Register(&fakeBalancerBuilder{name: fakeBalancerB})
+}
+
+type fakeBalancerBuilder struct {
+	name string
+}
+
+func (b *fakeBalancerBuilder) Build(cc balancer.ClientConn, opts balancer.BuildOptions) balancer.Balancer {
+	return &fakeBalancer{cc: cc}
+}
+
+func (b *fakeBalancerBuilder) Name() string {
+	return b.name
+}
+
+type fakeBalancer struct {
+	cc balancer.ClientConn
+}
+
+func (b *fakeBalancer) HandleResolvedAddrs(addrs []resolver.Address, err error) {
+	panic("implement me")
+}
+
+func (b *fakeBalancer) HandleSubConnStateChange(sc balancer.SubConn, state connectivity.State) {
+	panic("implement me")
+}
+
+func (b *fakeBalancer) Close() {}
 
 // TestXDSConnfigChildPolicyUpdate verifies scenarios where the childPolicy
 // section of the lbConfig is updated.
@@ -424,8 +389,6 @@ func (s) TestXDSSubConnStateChange(t *testing.T) {
 		ResolverState: resolver.State{Addresses: addrs},
 		BalancerConfig: &XDSConfig{
 			BalancerName:   testBalancerNameFooBar,
-			ChildPolicy:    &loadBalancingConfig{Name: fakeBalancerA},
-			FallBackPolicy: &loadBalancingConfig{Name: fakeBalancerA},
 			EDSServiceName: testEDSClusterName,
 		},
 	})


### PR DESCRIPTION
We will add fallback support back when the design is finalized. Before that, fallback makes the code quite hard to follow.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grpc/grpc-go/3287)
<!-- Reviewable:end -->
