### PR TITLE
internal: fix initialBackoff typo

### DIFF
--- a/service_config.go
+++ b/service_config.go
@@ -136,9 +136,9 @@ type retryPolicy struct {
 	maxAttempts int
 
 	// Exponential backoff parameters. The initial retry attempt will occur at
-	// random(0, initialBackoffMS). In general, the nth attempt will occur at
+	// random(0, initialBackoff). In general, the nth attempt will occur at
 	// random(0,
-	//   min(initialBackoffMS*backoffMultiplier**(n-1), maxBackoffMS)).
+	//   min(initialBackoff*backoffMultiplier**(n-1), maxBackoff)).
 	//
 	// These fields are required and must be greater than zero.
 	initialBackoff    time.Duration


### PR DESCRIPTION
This PR renames `initialBackoffMS` to `initialBackoff`.