### PR TITLE
fix lbpb package name typo

### DIFF
--- a/balancer/grpclb/grpclb_picker.go
+++ b/balancer/grpclb/grpclb_picker.go
@@ -29,7 +29,7 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-// rpcStats is same as lbmpb.ClientStats, except that numCallsDropped is a map
+// rpcStats is same as lbpb.ClientStats, except that numCallsDropped is a map
 // instead of a slice.
 type rpcStats struct {
 	// Only access the following fields atomically.


### PR DESCRIPTION
This PR fixes `lbpb` package name typo from `lbmpb` to `lbpb`.