### PR TITLE
eds: remove balancer name from eds service config

### DIFF
--- a/xds/internal/balancer/edsbalancer/config.go
+++ b/xds/internal/balancer/edsbalancer/config.go
@@ -29,8 +29,6 @@ import (
 // for EDS balancers.
 type EDSConfig struct {
 	serviceconfig.LoadBalancingConfig
-	// BalancerName represents the load balancer to use.
-	BalancerName string
 	// ChildPolicy represents the load balancing config for the child
 	// policy.
 	ChildPolicy *loadBalancingConfig
@@ -50,7 +48,6 @@ type EDSConfig struct {
 // and Fallbackspolicy are post-processed, and for each, the first installed
 // policy is kept.
 type edsConfigJSON struct {
-	BalancerName               string
 	ChildPolicy                []*loadBalancingConfig
 	FallbackPolicy             []*loadBalancingConfig
 	EDSServiceName             string
@@ -66,7 +63,6 @@ func (l *EDSConfig) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	l.BalancerName = configJSON.BalancerName
 	l.EDSServiceName = configJSON.EDSServiceName
 	l.LrsLoadReportingServerName = configJSON.LRSLoadReportingServerName
 

--- a/xds/internal/balancer/edsbalancer/eds.go
+++ b/xds/internal/balancer/edsbalancer/eds.go
@@ -154,7 +154,10 @@ func (x *edsBalancer) handleGRPCUpdate(update interface{}) {
 			return
 		}
 
-		x.client.handleUpdate(cfg, u.ResolverState.Attributes)
+		if err := x.client.handleUpdate(cfg, u.ResolverState.Attributes); err != nil {
+			// TODO: propagate this error back to ClientConn, and fail the RPCs.
+			grpclog.Errorf("xds: eds failed to handle resolver update: %v", err)
+		}
 
 		if x.config == nil {
 			x.config = cfg

--- a/xds/internal/balancer/edsbalancer/eds_test.go
+++ b/xds/internal/balancer/edsbalancer/eds_test.go
@@ -47,12 +47,12 @@ import (
 func init() {
 	balancer.Register(&edsBalancerBuilder{})
 
-	bootstrapConfigNew = func() *bootstrap.Config {
+	bootstrapConfigNew = func() (*bootstrap.Config, error) {
 		return &bootstrap.Config{
 			BalancerName: "",
 			Creds:        grpc.WithInsecure(),
 			NodeProto:    &corepb.Node{},
-		}
+		}, nil
 	}
 }
 

--- a/xds/internal/balancer/edsbalancer/eds_test.go
+++ b/xds/internal/balancer/edsbalancer/eds_test.go
@@ -49,7 +49,7 @@ func init() {
 
 	bootstrapConfigNew = func() (*bootstrap.Config, error) {
 		return &bootstrap.Config{
-			BalancerName: "",
+			BalancerName: "no.balancer.name",
 			Creds:        grpc.WithInsecure(),
 			NodeProto:    &corepb.Node{},
 		}, nil

--- a/xds/internal/balancer/edsbalancer/eds_test.go
+++ b/xds/internal/balancer/edsbalancer/eds_test.go
@@ -206,44 +206,6 @@ func setup(edsLBCh *testutils.Channel, xdsClientCh *testutils.Channel) func() {
 	}
 }
 
-// TestXDSConfigBalancerNameUpdate verifies different scenarios where the
-// balancer name in the lbConfig is updated.
-//
-// The test does the following:
-// * Builds a new xds balancer.
-// * Repeatedly pushes new ClientConnState which specifies different
-//   balancerName in the lbConfig. We expect xdsClient objects to created
-//   whenever the balancerName changes.
-func (s) TestXDSConfigBalancerNameUpdate(t *testing.T) {
-	edsLBCh := testutils.NewChannel()
-	xdsClientCh := testutils.NewChannel()
-	cancel := setup(edsLBCh, xdsClientCh)
-	defer cancel()
-
-	builder := balancer.Get(edsName)
-	cc := newNoopTestClientConn()
-	edsB, ok := builder.Build(cc, balancer.BuildOptions{Target: resolver.Target{Endpoint: testEDSClusterName}}).(*edsBalancer)
-	if !ok {
-		t.Fatalf("builder.Build(%s) returned type {%T}, want {*edsBalancer}", edsName, edsB)
-	}
-	defer edsB.Close()
-
-	addrs := []resolver.Address{{Addr: "1.1.1.1:10001"}, {Addr: "2.2.2.2:10002"}, {Addr: "3.3.3.3:10003"}}
-	for i := 0; i < 2; i++ {
-		balancerName := fmt.Sprintf("balancer-%d", i)
-		edsB.UpdateClientConnState(balancer.ClientConnState{
-			ResolverState: resolver.State{Addresses: addrs},
-			BalancerConfig: &EDSConfig{
-				BalancerName:   balancerName,
-				EDSServiceName: testEDSClusterName,
-			},
-		})
-
-		xdsC := waitForNewXDSClientWithEDSWatch(t, xdsClientCh, balancerName)
-		xdsC.InvokeWatchEDSCallback(&xdsclient.EDSUpdate{}, nil)
-	}
-}
-
 const (
 	fakeBalancerA = "fake_balancer_A"
 	fakeBalancerB = "fake_balancer_B"
@@ -302,6 +264,16 @@ func (s) TestXDSConnfigChildPolicyUpdate(t *testing.T) {
 	cancel := setup(edsLBCh, xdsClientCh)
 	defer cancel()
 
+	oldBootstrapConfigNew := bootstrapConfigNew
+	bootstrapConfigNew = func() (*bootstrap.Config, error) {
+		return &bootstrap.Config{
+			BalancerName: testBalancerNameFooBar,
+			Creds:        grpc.WithInsecure(),
+			NodeProto:    &corepb.Node{},
+		}, nil
+	}
+	defer func() { bootstrapConfigNew = oldBootstrapConfigNew }()
+
 	builder := balancer.Get(edsName)
 	cc := newNoopTestClientConn()
 	edsB, ok := builder.Build(cc, balancer.BuildOptions{Target: resolver.Target{Endpoint: testServiceName}}).(*edsBalancer)
@@ -312,7 +284,6 @@ func (s) TestXDSConnfigChildPolicyUpdate(t *testing.T) {
 
 	edsB.UpdateClientConnState(balancer.ClientConnState{
 		BalancerConfig: &EDSConfig{
-			BalancerName: testBalancerNameFooBar,
 			ChildPolicy: &loadBalancingConfig{
 				Name:   fakeBalancerA,
 				Config: json.RawMessage("{}"),
@@ -330,7 +301,6 @@ func (s) TestXDSConnfigChildPolicyUpdate(t *testing.T) {
 
 	edsB.UpdateClientConnState(balancer.ClientConnState{
 		BalancerConfig: &EDSConfig{
-			BalancerName: testBalancerNameFooBar,
 			ChildPolicy: &loadBalancingConfig{
 				Name:   fakeBalancerB,
 				Config: json.RawMessage("{}"),
@@ -352,6 +322,16 @@ func (s) TestXDSSubConnStateChange(t *testing.T) {
 	cancel := setup(edsLBCh, xdsClientCh)
 	defer cancel()
 
+	oldBootstrapConfigNew := bootstrapConfigNew
+	bootstrapConfigNew = func() (*bootstrap.Config, error) {
+		return &bootstrap.Config{
+			BalancerName: testBalancerNameFooBar,
+			Creds:        grpc.WithInsecure(),
+			NodeProto:    &corepb.Node{},
+		}, nil
+	}
+	defer func() { bootstrapConfigNew = oldBootstrapConfigNew }()
+
 	builder := balancer.Get(edsName)
 	cc := newNoopTestClientConn()
 	edsB, ok := builder.Build(cc, balancer.BuildOptions{Target: resolver.Target{Endpoint: testEDSClusterName}}).(*edsBalancer)
@@ -364,7 +344,6 @@ func (s) TestXDSSubConnStateChange(t *testing.T) {
 	edsB.UpdateClientConnState(balancer.ClientConnState{
 		ResolverState: resolver.State{Addresses: addrs},
 		BalancerConfig: &EDSConfig{
-			BalancerName:   testBalancerNameFooBar,
 			EDSServiceName: testEDSClusterName,
 		},
 	})
@@ -430,7 +409,6 @@ func TestXDSBalancerConfigParsing(t *testing.T) {
 			name: "manually-generated",
 			js: json.RawMessage(`
 {
-  "balancerName": "fake.foo.bar",
   "childPolicy": [
     {"fake_balancer_C": {}},
     {"fake_balancer_A": {}},
@@ -445,7 +423,6 @@ func TestXDSBalancerConfigParsing(t *testing.T) {
   "lrsLoadReportingServerName": "lrs.server"
 }`),
 			want: &EDSConfig{
-				BalancerName: "fake.foo.bar",
 				ChildPolicy: &loadBalancingConfig{
 					Name:   "fake_balancer_A",
 					Config: json.RawMessage("{}"),
@@ -465,11 +442,9 @@ func TestXDSBalancerConfigParsing(t *testing.T) {
 			name: "no-lrs-server-name",
 			js: json.RawMessage(`
 {
-  "balancerName": "fake.foo.bar",
   "edsServiceName": "eds.service"
 }`),
 			want: &EDSConfig{
-				BalancerName:               "fake.foo.bar",
 				EDSServiceName:             testEDSName,
 				LrsLoadReportingServerName: nil,
 			},

--- a/xds/internal/balancer/edsbalancer/xds_client_wrapper.go
+++ b/xds/internal/balancer/edsbalancer/xds_client_wrapper.go
@@ -131,8 +131,13 @@ func (c *xdsclientWrapper) updateXDSClient(config *EDSConfig, attr *attributes.A
 		}
 	}
 
-	clientConfig := bootstrapConfigNew()
-	if clientConfig.BalancerName == "" {
+	clientConfig, err := bootstrapConfigNew()
+	if err != nil {
+		// TODO: propogate this error to ClientConn, and fail RPCs if necessary.
+		clientConfig = &bootstrap.Config{
+			BalancerName: config.BalancerName,
+		}
+	} else if clientConfig.BalancerName == "" {
 		clientConfig.BalancerName = config.BalancerName
 	}
 

--- a/xds/internal/balancer/edsbalancer/xds_client_wrapper.go
+++ b/xds/internal/balancer/edsbalancer/xds_client_wrapper.go
@@ -134,11 +134,7 @@ func (c *xdsclientWrapper) updateXDSClient(config *EDSConfig, attr *attributes.A
 	clientConfig, err := bootstrapConfigNew()
 	if err != nil {
 		// TODO: propogate this error to ClientConn, and fail RPCs if necessary.
-		clientConfig = &bootstrap.Config{
-			BalancerName: config.BalancerName,
-		}
-	} else if clientConfig.BalancerName == "" {
-		clientConfig.BalancerName = config.BalancerName
+		return false
 	}
 
 	if c.balancerName == clientConfig.BalancerName {

--- a/xds/internal/balancer/edsbalancer/xds_client_wrapper_test.go
+++ b/xds/internal/balancer/edsbalancer/xds_client_wrapper_test.go
@@ -26,11 +26,13 @@ import (
 	corepb "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	"github.com/golang/protobuf/proto"
 	"github.com/google/go-cmp/cmp"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/attributes"
 	"google.golang.org/grpc/balancer"
 	"google.golang.org/grpc/resolver"
 	xdsinternal "google.golang.org/grpc/xds/internal"
 	xdsclient "google.golang.org/grpc/xds/internal/client"
+	"google.golang.org/grpc/xds/internal/client/bootstrap"
 	"google.golang.org/grpc/xds/internal/testutils"
 	"google.golang.org/grpc/xds/internal/testutils/fakeclient"
 	"google.golang.org/grpc/xds/internal/testutils/fakeserver"
@@ -93,8 +95,16 @@ func (s) TestClientWrapperWatchEDS(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
+			oldBootstrapConfigNew := bootstrapConfigNew
+			bootstrapConfigNew = func() (*bootstrap.Config, error) {
+				return &bootstrap.Config{
+					BalancerName: fakeServer.Address,
+					Creds:        grpc.WithInsecure(),
+					NodeProto:    &corepb.Node{},
+				}, nil
+			}
+			defer func() { bootstrapConfigNew = oldBootstrapConfigNew }()
 			cw.handleUpdate(&EDSConfig{
-				BalancerName:   fakeServer.Address,
 				EDSServiceName: test.edsServiceName,
 			}, nil)
 

--- a/xds/internal/client/bootstrap/bootstrap_test.go
+++ b/xds/internal/client/bootstrap/bootstrap_test.go
@@ -60,8 +60,9 @@ var (
 // file.
 func TestNewConfig(t *testing.T) {
 	bootstrapFileMap := map[string]string{
-		"empty":   "",
-		"badJSON": `["test": 123]`,
+		"empty":          "",
+		"badJSON":        `["test": 123]`,
+		"noBalancerName": `{"node": {"id": "ENVOY_NODE_ID"}}`,
 		"emptyNodeProto": `
 		{
 			"xds_servers" : [{
@@ -101,7 +102,10 @@ func TestNewConfig(t *testing.T) {
 				"metadata": {
 				    "TRAFFICDIRECTOR_GRPC_HOSTNAME": "trafficdirector"
 			    }
-			}
+			},
+			"xds_servers" : [{
+				"server_uri": "trafficdirector.googleapis.com:443"
+			}]
 		}`,
 		"unknownFieldInXdsServer": `
 		{
@@ -213,23 +217,25 @@ func TestNewConfig(t *testing.T) {
 	tests := []struct {
 		name       string
 		wantConfig *Config
+		wantError  bool
 	}{
-		{"nonExistentBootstrapFile", &Config{}},
-		{"empty", &Config{}},
-		{"badJSON", &Config{}},
+		{"nonExistentBootstrapFile", nil, true},
+		{"empty", nil, true},
+		{"badJSON", nil, true},
 		{"emptyNodeProto", &Config{
 			BalancerName: "trafficdirector.googleapis.com:443",
 			NodeProto:    &corepb.Node{BuildVersion: gRPCVersion},
-		}},
-		{"emptyXdsServer", &Config{NodeProto: nodeProto}},
-		{"unknownTopLevelFieldInFile", nilCredsConfig},
-		{"unknownFieldInNodeProto", &Config{NodeProto: nodeProto}},
-		{"unknownFieldInXdsServer", nilCredsConfig},
-		{"emptyChannelCreds", nilCredsConfig},
-		{"nonGoogleDefaultCreds", nilCredsConfig},
-		{"multipleChannelCreds", nonNilCredsConfig},
-		{"goodBootstrap", nonNilCredsConfig},
-		{"multipleXDSServers", nonNilCredsConfig},
+		}, false},
+		{"noBalancerName", nil, true},
+		{"emptyXdsServer", nil, true},
+		{"unknownTopLevelFieldInFile", nilCredsConfig, false},
+		{"unknownFieldInNodeProto", nilCredsConfig, false},
+		{"unknownFieldInXdsServer", nilCredsConfig, false},
+		{"emptyChannelCreds", nilCredsConfig, false},
+		{"nonGoogleDefaultCreds", nilCredsConfig, false},
+		{"multipleChannelCreds", nonNilCredsConfig, false},
+		{"goodBootstrap", nonNilCredsConfig, false},
+		{"multipleXDSServers", nonNilCredsConfig, false},
 	}
 
 	for _, test := range tests {
@@ -237,7 +243,16 @@ func TestNewConfig(t *testing.T) {
 			if err := os.Setenv(fileEnv, test.name); err != nil {
 				t.Fatalf("os.Setenv(%s, %s) failed with error: %v", fileEnv, test.name, err)
 			}
-			config := NewConfig()
+			config, err := NewConfig()
+			if test.wantError {
+				if err == nil {
+					t.Fatalf("wantError: %v, got error %v", test.wantError, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error %v", err)
+			}
 			if config.BalancerName != test.wantConfig.BalancerName {
 				t.Errorf("config.BalancerName is %s, want %s", config.BalancerName, test.wantConfig.BalancerName)
 			}
@@ -253,8 +268,8 @@ func TestNewConfig(t *testing.T) {
 
 func TestNewConfigEnvNotSet(t *testing.T) {
 	os.Unsetenv(fileEnv)
-	wantConfig := Config{}
-	if config := NewConfig(); *config != wantConfig {
-		t.Errorf("NewConfig() returned : %#v, wanted an empty Config object", config)
+	config, err := NewConfig()
+	if err == nil {
+		t.Errorf("NewConfig() returned: %#v, <nil>, wanted non-nil error", config)
 	}
 }

--- a/xds/internal/resolver/xds_resolver.go
+++ b/xds/internal/resolver/xds_resolver.go
@@ -21,7 +21,6 @@ package resolver
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"google.golang.org/grpc"
@@ -57,9 +56,9 @@ type xdsResolverBuilder struct{}
 // The xds bootstrap process is performed (and a new xds client is built) every
 // time an xds resolver is built.
 func (b *xdsResolverBuilder) Build(t resolver.Target, cc resolver.ClientConn, rbo resolver.BuildOptions) (resolver.Resolver, error) {
-	config := newXDSConfig()
-	if config.BalancerName == "" {
-		return nil, errors.New("xds: balancerName not found in bootstrap file")
+	config, err := newXDSConfig()
+	if err != nil {
+		return nil, fmt.Errorf("xds: failed to read bootstrap file: %v", err)
 	}
 	if config.Creds == nil {
 		// TODO: Once we start supporting a mechanism to register credential

--- a/xds/internal/resolver/xds_resolver_test.go
+++ b/xds/internal/resolver/xds_resolver_test.go
@@ -172,7 +172,12 @@ func TestResolverBuilder(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			// Fake out the bootstrap process by providing our own config.
 			oldConfigMaker := newXDSConfig
-			newXDSConfig = func() *bootstrap.Config { return &test.config }
+			newXDSConfig = func() (*bootstrap.Config, error) {
+				if test.config.BalancerName == "" {
+					return nil, fmt.Errorf("no balancer name found in config")
+				}
+				return &test.config, nil
+			}
 			// Fake out the xdsClient creation process by providing a fake.
 			oldClientMaker := newXDSClient
 			newXDSClient = test.xdsClientFunc
@@ -208,7 +213,7 @@ func testSetup(t *testing.T, opts setupOpts) (*xdsResolver, *testClientConn, fun
 	t.Helper()
 
 	oldConfigMaker := newXDSConfig
-	newXDSConfig = func() *bootstrap.Config { return opts.config }
+	newXDSConfig = func() (*bootstrap.Config, error) { return opts.config, nil }
 	oldClientMaker := newXDSClient
 	newXDSClient = opts.xdsClientFunc
 	cancel := func() {


### PR DESCRIPTION
The `BalancerName` field, and all the references to it are removed. In tests where it was used to pass the xds server address to the xds client, `bootstrapConfigNew()` is overridden.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grpc/grpc-go/3316)
<!-- Reviewable:end -->
