### PR TITLE
client: add interface for ClientConn to be accepted by generated code

### DIFF
--- a/clientconn.go
+++ b/clientconn.go
@@ -455,7 +455,7 @@ type ClientConnInterface interface {
 	NewStream(ctx context.Context, desc *StreamDesc, method string, opts ...CallOption) (ClientStream, error)
 }
 
-// Assert ClientConn implements ClientConnInterface.
+// Assert *ClientConn implements ClientConnInterface.
 var _ ClientConnInterface = (*ClientConn)(nil)
 
 // ClientConn represents a virtual connection to a conceptual endpoint, to

--- a/clientconn.go
+++ b/clientconn.go
@@ -454,8 +454,8 @@ type ClientConnInterface interface {
 	NewStream(ctx context.Context, desc *StreamDesc, method string, opts ...CallOption) (ClientStream, error)
 }
 
-// Assert ClientConn implements InvokerStreamer.
-var _ InvokerStreamer = (*ClientConn)(nil)
+// Assert ClientConn implements ClientConnInterface.
+var _ ClientConnInterface = (*ClientConn)(nil)
 
 // ClientConn represents a virtual connection to a conceptual endpoint, to
 // perform RPCs.

--- a/clientconn.go
+++ b/clientconn.go
@@ -444,6 +444,19 @@ func (csm *connectivityStateManager) getNotifyChan() <-chan struct{} {
 	return csm.notifyChan
 }
 
+// ClientConnInterface defines the functions clients need to perform unary and
+// streaming RPCs.  It is implemented by ClientConn.
+type ClientConnInterface interface {
+	// Invoke performs a unary RPC and returns after the response is received
+	// into reply.
+	Invoke(ctx context.Context, method string, args interface{}, reply interface{}, opts ...CallOption) error
+	// NewStream begins a streaming RPC.
+	NewStream(ctx context.Context, desc *StreamDesc, method string, opts ...CallOption) (ClientStream, error)
+}
+
+// Assert ClientConn implements InvokerStreamer.
+var _ InvokerStreamer = (*ClientConn)(nil)
+
 // ClientConn represents a virtual connection to a conceptual endpoint, to
 // perform RPCs.
 //

--- a/clientconn.go
+++ b/clientconn.go
@@ -445,7 +445,8 @@ func (csm *connectivityStateManager) getNotifyChan() <-chan struct{} {
 }
 
 // ClientConnInterface defines the functions clients need to perform unary and
-// streaming RPCs.  It is implemented by ClientConn.
+// streaming RPCs.  It is implemented by *ClientConn, and is only intended to
+// be referenced by generated code.
 type ClientConnInterface interface {
 	// Invoke performs a unary RPC and returns after the response is received
 	// into reply.

--- a/rpc_util.go
+++ b/rpc_util.go
@@ -871,7 +871,7 @@ type channelzData struct {
 
 // The SupportPackageIsVersion variables are referenced from generated protocol
 // buffer files to ensure compatibility with the gRPC version used.  The latest
-// support package version is 5.
+// support package version is 6.
 //
 // Older versions are kept for compatibility. They may be removed if
 // compatibility cannot be maintained.
@@ -881,6 +881,7 @@ const (
 	SupportPackageIsVersion3 = true
 	SupportPackageIsVersion4 = true
 	SupportPackageIsVersion5 = true
+	SupportPackageIsVersion6 = true
 )
 
 const grpcUA = "grpc-go/" + Version


### PR DESCRIPTION
Fixes #1287

Reviving #2535, which github would not allow me to reopen.  Regarding the comment about `ClientConn() *ClientConn` from that PR, I don't think we will need such a method unless we need to extend the functionality of the generated code.  In this unlikely case, we could add it when it is needed, but use a new interface name to reflect the new functionality.

cc @broady 
