### PR TITLE
advancedtls: use grpc 1.27.0 and small fixes

### DIFF
--- a/security/advancedtls/advancedtls.go
+++ b/security/advancedtls/advancedtls.go
@@ -207,7 +207,13 @@ func (c *advancedTLSCreds) ClientHandshake(ctx context.Context, authority string
 		conn.Close()
 		return nil, nil, ctx.Err()
 	}
-	return WrapSyscallConn(rawConn, conn), credentials.TLSInfo{State: conn.ConnectionState()}, nil
+	info := credentials.TLSInfo{
+		State: conn.ConnectionState(),
+		CommonAuthInfo: credentials.CommonAuthInfo{
+			SecurityLevel: credentials.PrivacyAndIntegrity,
+		},
+	}
+	return WrapSyscallConn(rawConn, conn), info, nil
 }
 
 func (c *advancedTLSCreds) ServerHandshake(rawConn net.Conn) (net.Conn, credentials.AuthInfo, error) {
@@ -221,7 +227,13 @@ func (c *advancedTLSCreds) ServerHandshake(rawConn net.Conn) (net.Conn, credenti
 		conn.Close()
 		return nil, nil, err
 	}
-	return WrapSyscallConn(rawConn, conn), credentials.TLSInfo{State: conn.ConnectionState()}, nil
+	info := credentials.TLSInfo{
+		State: conn.ConnectionState(),
+		CommonAuthInfo: credentials.CommonAuthInfo{
+			SecurityLevel: credentials.PrivacyAndIntegrity,
+		},
+	}
+	return WrapSyscallConn(rawConn, conn), info, nil
 }
 
 func (c *advancedTLSCreds) Clone() credentials.TransportCredentials {

--- a/security/advancedtls/advancedtls_integration_test.go
+++ b/security/advancedtls/advancedtls_integration_test.go
@@ -172,7 +172,10 @@ func callAndVerifyWithClientConn(connCtx context.Context, msg string, creds cred
 // (could be change the client's trust certificate, or change server authorization function, etc)
 func TestEnd2End(t *testing.T) {
 	cs := &certStore{}
-	cs.loadCerts()
+	err := cs.loadCerts()
+	if err != nil {
+		t.Fatalf("failed to load certs: %v", err)
+	}
 	stage := &stageInfo{}
 	for _, test := range []struct {
 		desc             string
@@ -330,7 +333,7 @@ func TestEnd2End(t *testing.T) {
 			}
 			serverTLSCreds, err := NewServerCreds(serverOptions)
 			if err != nil {
-				t.Fatalf("Failed to create server creds: %v", err)
+				t.Fatalf("failed to create server creds: %v", err)
 			}
 			s := grpc.NewServer(grpc.Creds(serverTLSCreds))
 			defer s.Stop()
@@ -338,7 +341,7 @@ func TestEnd2End(t *testing.T) {
 				lis, err := net.Listen("tcp", port)
 				// defer lis.Close()
 				if err != nil {
-					t.Fatalf("Failed to listen: %v", err)
+					t.Fatalf("failed to listen: %v", err)
 				}
 				pb.RegisterGreeterServer(s, &serverImpl{})
 				if err := s.Serve(lis); err != nil {

--- a/security/advancedtls/go.mod
+++ b/security/advancedtls/go.mod
@@ -2,4 +2,4 @@ module google.golang.org/grpc/security/advancedtls
 
 go 1.13
 
-require google.golang.org/grpc v1.26.0
+require google.golang.org/grpc v1.27.0

--- a/security/advancedtls/go.sum
+++ b/security/advancedtls/go.sum
@@ -47,5 +47,7 @@ google.golang.org/grpc v1.25.1 h1:wdKvqQk7IttEw92GoRyKG2IDrUIpgpj6H6m81yfeMW0=
 google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=
 google.golang.org/grpc v1.26.0 h1:2dTRdpdFEEhJYQD8EMLB61nnrzSCTbG38PhqdhvOltg=
 google.golang.org/grpc v1.26.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
+google.golang.org/grpc v1.27.0 h1:rRYRFMVgRv6E0D70Skyfsr28tDXIuuPZyWGMPdMcnXg=
+google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=


### PR DESCRIPTION
This PR involves the following changes in advancedtls library:
1. bump the gRPC dependency version to 1.27.0
2. make changes on advancedtls.go to align with the new changes of tls.go in gRPC library
3. some small fixes in advancedtls_integration_test.go