### PR TITLE
rls: Implementation of the RLS client.

### DIFF
--- a/balancer/rls/internal/client/client.go
+++ b/balancer/rls/internal/client/client.go
@@ -1,0 +1,108 @@
+/*
+ *
+ * Copyright 2020 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// Package client provides an implementation of the RouteLookupService client
+// with adaptive throttling built in.
+package client
+
+import (
+	"context"
+	"errors"
+
+	"google.golang.org/grpc"
+
+	rlspb "google.golang.org/grpc/balancer/rls/internal/proto/grpc_lookup_v1"
+)
+
+// For gRPC services using RLS, the value of target_type in the
+// RouteLookupServiceRequest will be set to this.
+const grpcTargetType = "grpc"
+
+// An interface which captures the methods exported by the adaptive throttler
+// implementation. Allows overriding from unittests.
+type adaptiveThrottlerInterface interface {
+	ShouldThrottle() bool
+	RegisterBackendResponse(bool)
+}
+
+// Client is a simple wrapper around a RouteLookupService client with adaptive
+// throttling.
+type Client struct {
+	cc        *grpc.ClientConn
+	stub      rlspb.RouteLookupServiceClient
+	throttler adaptiveThrottlerInterface
+}
+
+// New returns an RLS client with the provided arguments. The RLS LB policy
+// creates a grpc.ClientConn to the RLS server using appropriate credentials
+// from the parent channel, and creates an adaptive throttler implementation
+// using default values and passes them here.
+func New(cc *grpc.ClientConn, throttler adaptiveThrottlerInterface) *Client {
+	return &Client{
+		cc:        cc,
+		stub:      rlspb.NewRouteLookupServiceClient(cc),
+		throttler: throttler,
+	}
+}
+
+// LookupArgs wraps the values to be sent in an RLS request.
+type LookupArgs struct {
+	// Target is the user's dial target, e.g. "firestore.googleapis.com".
+	Target string
+	// Path is full RPC path, e.g. "/service/method".
+	Path string
+	// KeyMap is the request's keys built by the RLS LB using the
+	// grpcKeyBuilders received in the service config.
+	KeyMap map[string]string
+}
+
+// LookupResult wraps the values received in an RLS response.
+type LookupResult struct {
+	// Target is the actual addressable entity to use for routing decision,
+	// e.g. "us_east_1.firestore.googleapis.com".
+	Target string
+	// HeaderData contains optional header values to pass along to the backend
+	// in the X-Google-RLS-Data header (cached by the RLS LB policy).
+	HeaderData string
+}
+
+// ErrRequestThrottled is the error returned by Lookup when the adaptive
+// throttler decides that the request should be throttled.
+var ErrRequestThrottled = errors.New("RLS request throttled")
+
+// Lookup makes a RouteLookup RPC using data provided in args. It is assumed
+// that a reasonable deadline is set on the provided context so that RPCs
+// taking too long to complete fail automatically.
+func (c *Client) Lookup(ctx context.Context, args *LookupArgs) (*LookupResult, error) {
+	if c.throttler.ShouldThrottle() {
+		return nil, ErrRequestThrottled
+	}
+
+	resp, err := c.stub.RouteLookup(ctx, &rlspb.RouteLookupRequest{
+		Server:     args.Target,
+		Path:       args.Path,
+		TargetType: grpcTargetType,
+		KeyMap:     args.KeyMap,
+	})
+	c.throttler.RegisterBackendResponse(err != nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return &LookupResult{Target: resp.GetTarget(), HeaderData: resp.GetHeaderData()}, nil
+}

--- a/balancer/rls/internal/client/client_test.go
+++ b/balancer/rls/internal/client/client_test.go
@@ -1,0 +1,214 @@
+/*
+ *
+ * Copyright 2020 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package client
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/balancer/rls/internal/testutils/fakeserver"
+	"google.golang.org/grpc/codes"
+
+	rlspb "google.golang.org/grpc/balancer/rls/internal/proto/grpc_lookup_v1"
+)
+
+type fakeThrottler struct {
+	shouldThrottle              bool
+	gotBackendResponseThrottled bool
+}
+
+func (f *fakeThrottler) ShouldThrottle() bool {
+	return f.shouldThrottle
+}
+
+func (f *fakeThrottler) RegisterBackendResponse(throttled bool) {
+	f.gotBackendResponseThrottled = throttled
+}
+
+func setup(t *testing.T) (*fakeserver.Server, *grpc.ClientConn, func()) {
+	t.Helper()
+
+	server, sCleanup, err := fakeserver.Start()
+	if err != nil {
+		t.Fatalf("Failed to start fake RLS server: %v", err)
+	}
+
+	cc, cCleanup, err := server.ClientConn()
+	if err != nil {
+		t.Fatalf("Failed to get a ClientConn to the RLS server: %v", err)
+	}
+
+	return server, cc, func() {
+		sCleanup()
+		cCleanup()
+	}
+}
+
+// TestLookupThrottled verifies that the Lookup API fails when the throttler
+// asks the request to be throttled.
+func TestLookupThrottled(t *testing.T) {
+	_, cc, cleanup := setup(t)
+	defer cleanup()
+
+	rlsClient := New(cc, &fakeThrottler{shouldThrottle: true})
+	_, err := rlsClient.Lookup(context.Background(), nil)
+	if err != ErrRequestThrottled {
+		t.Errorf("rlsClient.Lookup() = %v, want %v", err, ErrRequestThrottled)
+	}
+}
+
+// TestLookupFailure verifies the case where the RLS server returns an error.
+func TestLookupFailure(t *testing.T) {
+	server, cc, cleanup := setup(t)
+	defer cleanup()
+
+	throttler := &fakeThrottler{shouldThrottle: false}
+	rlsClient := New(cc, throttler)
+
+	// We setup the fake server to return an error.
+	server.ResponseChan <- fakeserver.Response{Err: errors.New("rls failure")}
+	gotResult, err := rlsClient.Lookup(context.Background(), &LookupArgs{})
+	if err == nil || gotResult != nil {
+		t.Fatalf("rlsClient.Lookup() = (%v, %v) succeeded, should have failed", gotResult, err)
+	}
+	if !throttler.gotBackendResponseThrottled {
+		t.Fatal("Lookup reported successful backend response to throttler, after request failed")
+	}
+}
+
+// TestLookupCanceled tests the case where the Lookup API is cancelled, and
+// verifies that the appropriate error is returned.
+func TestLookupCanceled(t *testing.T) {
+	_, cc, cleanup := setup(t)
+	defer cleanup()
+
+	rlsClient := New(cc, &fakeThrottler{shouldThrottle: false})
+	// Give the Lookup RPC a big deadline, but don't setup the fake server to
+	// return anything. So the Lookup call will block and we will cancel the
+	// context in parallel, causing the Lookup call to return with a status
+	// code of Canceled.
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+
+	enterCh := make(chan struct{})
+	errCh := make(chan error)
+	go func() {
+		close(enterCh)
+		_, err := rlsClient.Lookup(ctx, &LookupArgs{})
+		errCh <- err
+	}()
+
+	<-enterCh
+	// Canceling the context here will unblock the Lookup call.
+	cancel()
+
+	if err := <-errCh; grpc.Code(err) != codes.Canceled {
+		t.Fatalf("rlsClient.Lookup() returned error: %v, want %v", err, codes.Canceled)
+	}
+}
+
+// TestLookupDeadlineExceeded tests the case where the RPC deadline associated
+// with the Lookup API expires.
+func TestLookupDeadlineExceeded(t *testing.T) {
+	_, cc, cleanup := setup(t)
+	defer cleanup()
+
+	rlsClient := New(cc, &fakeThrottler{shouldThrottle: false})
+	// Give the Lookup RPC a small deadline, but don't setup the fake server to
+	// return anything. So the Lookup call will block and eventuall expire.
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	if _, err := rlsClient.Lookup(ctx, &LookupArgs{}); grpc.Code(err) != codes.DeadlineExceeded {
+		t.Fatalf("rlsClient.Lookup() returned error: %v, want %v", err, codes.DeadlineExceeded)
+	}
+}
+
+// TestLookupSuccess verifies the successful Lookup API case.
+func TestLookupSuccess(t *testing.T) {
+	server, cc, cleanup := setup(t)
+	defer cleanup()
+
+	throttler := &fakeThrottler{shouldThrottle: false}
+	rlsClient := New(cc, throttler)
+
+	const (
+		defaultTestTimeout = 1 * time.Second
+		rlsReqTarget       = "firestore.googleapis.com"
+		rlsReqPath         = "/service/method"
+		rlsRespTarget      = "us_east_1.firestore.googleapis.com"
+		rlsHeaderData      = "headerData"
+	)
+
+	// We setup the fake server to return this response when it receives a
+	// request.
+	server.ResponseChan <- fakeserver.Response{
+		Resp: &rlspb.RouteLookupResponse{
+			Target:     rlsRespTarget,
+			HeaderData: rlsHeaderData,
+		},
+	}
+	rlsReqKeyMap := map[string]string{
+		"k1": "v1",
+		"k2": "v2",
+	}
+	wantLookupRequest := &rlspb.RouteLookupRequest{
+		Server:     rlsReqTarget,
+		Path:       rlsReqPath,
+		TargetType: "grpc",
+		KeyMap:     rlsReqKeyMap,
+	}
+	wantResp := &LookupResult{
+		Target:     rlsRespTarget,
+		HeaderData: rlsHeaderData,
+	}
+
+	// Make the actual Lookup API call, and make sure that the fake server
+	// received the expected RouteLookupRequest proto.
+	gotResult, err := rlsClient.Lookup(context.Background(), &LookupArgs{
+		Target: rlsReqTarget,
+		Path:   rlsReqPath,
+		KeyMap: rlsReqKeyMap,
+	})
+	if err != nil {
+		t.Fatalf("rlsClient.Lookup() failed: %v", err)
+	}
+
+	timer := time.NewTimer(defaultTestTimeout)
+	select {
+	case gotLookupRequest := <-server.RequestChan:
+		timer.Stop()
+		if diff := cmp.Diff(wantLookupRequest, gotLookupRequest, cmp.Comparer(proto.Equal)); diff != "" {
+			t.Fatalf("RouteLookupRequest diff (-want, +got):\n%s", diff)
+		}
+	case <-timer.C:
+		t.Fatalf("Timed out wile waiting for a RouteLookupRequest")
+	}
+
+	if !cmp.Equal(gotResult, wantResp) {
+		t.Fatalf("rlsClient.Lookup() = %v, want %v", gotResult, wantResp)
+	}
+	if throttler.gotBackendResponseThrottled {
+		t.Fatal("Lookup reported failed backend response to throttler, after request succeeded")
+	}
+}

--- a/balancer/rls/internal/testutils/fakeserver/server.go
+++ b/balancer/rls/internal/testutils/fakeserver/server.go
@@ -1,0 +1,93 @@
+/*
+ *
+ * Copyright 2020 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// Package fakeserver provides a fake implementation of the RouteLookupService,
+// to be used in unit tests.
+package fakeserver
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"time"
+
+	"google.golang.org/grpc"
+
+	rlsgrpc "google.golang.org/grpc/balancer/rls/internal/proto/grpc_lookup_v1"
+	rlspb "google.golang.org/grpc/balancer/rls/internal/proto/grpc_lookup_v1"
+)
+
+const defaultDialTimeout = 5 * time.Second
+
+// Response wraps the response protobuf (xds/LRS) and error that the Server
+// should send out to the client through a call to stream.Send()
+type Response struct {
+	Resp *rlspb.RouteLookupResponse
+	Err  error
+}
+
+// Server is a fake implementation of RLS. It exposes channels to send/receive
+// RLS requests and responses.
+type Server struct {
+	RequestChan  chan *rlspb.RouteLookupRequest
+	ResponseChan chan Response
+	Address      string
+}
+
+// Start makes a new Server and gets it to start listening on a local port for
+// gRPC requests. The returned cancel function should be invoked by the caller
+// upon completion of the test.
+func Start() (*Server, func(), error) {
+	lis, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		return nil, func() {}, fmt.Errorf("net.Listen() failed: %v", err)
+	}
+
+	s := &Server{
+		// Give the channels a buffer size of 1 so that we can setup
+		// expectations for one lookup call, without blocking.
+		RequestChan:  make(chan *rlspb.RouteLookupRequest, 1),
+		ResponseChan: make(chan Response, 1),
+		Address:      lis.Addr().String(),
+	}
+
+	server := grpc.NewServer()
+	rlsgrpc.RegisterRouteLookupServiceServer(server, s)
+	go server.Serve(lis)
+
+	return s, func() { server.Stop() }, nil
+}
+
+// RouteLookup implements the RouteLookupService.
+func (s *Server) RouteLookup(ctx context.Context, req *rlspb.RouteLookupRequest) (*rlspb.RouteLookupResponse, error) {
+	s.RequestChan <- req
+	resp := <-s.ResponseChan
+	return resp.Resp, resp.Err
+}
+
+// ClientConn returns a grpc.ClientConn connected to the fakeServer.
+func (s *Server) ClientConn() (*grpc.ClientConn, func(), error) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultDialTimeout)
+	defer cancel()
+
+	cc, err := grpc.DialContext(ctx, s.Address, grpc.WithInsecure(), grpc.WithBlock())
+	if err != nil {
+		return nil, nil, fmt.Errorf("grpc.DialContext(%s) failed: %v", s.Address, err)
+	}
+	return cc, func() { cc.Close() }, nil
+}


### PR DESCRIPTION
* This client is a very thin wrapper around the `RouteLookupService` client from the generated code. 
* It incorporates adaptive throttling. 
* Cancelation of a Lookup request can be accomplished by simply canceling the associated context object.