### PR TITLE
stats: set response compression codec on stats.InHeader and stats.OutHeader

### DIFF
--- a/internal/transport/handler_server.go
+++ b/internal/transport/handler_server.go
@@ -296,7 +296,8 @@ func (ht *serverHandlerTransport) WriteHeader(s *Stream, md metadata.MD) error {
 			// Note: The header fields are compressed with hpack after this call returns.
 			// No WireLength field is set here.
 			ht.stats.HandleRPC(s.Context(), &stats.OutHeader{
-				Header: md.Copy(),
+				Header:      md.Copy(),
+				Compression: s.sendCompress,
 			})
 		}
 	}

--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -1195,9 +1195,10 @@ func (t *http2Client) operateHeaders(frame *http2.MetaHeadersFrame) {
 		if t.statsHandler != nil {
 			if isHeader {
 				inHeader := &stats.InHeader{
-					Client:     true,
-					WireLength: int(frame.Header().Length),
-					Header:     s.header.Copy(),
+					Client:      true,
+					WireLength:  int(frame.Header().Length),
+					Header:      s.header.Copy(),
+					Compression: s.recvCompress,
 				}
 				t.statsHandler.HandleRPC(s.ctx, inHeader)
 			} else {

--- a/internal/transport/http2_server.go
+++ b/internal/transport/http2_server.go
@@ -816,7 +816,8 @@ func (t *http2Server) writeHeaderLocked(s *Stream) error {
 		// Note: Headers are compressed with hpack after this call returns.
 		// No WireLength field is set here.
 		outHeader := &stats.OutHeader{
-			Header: s.header.Copy(),
+			Header:      s.header.Copy(),
+			Compression: s.sendCompress,
 		}
 		t.stats.HandleRPC(s.Context(), outHeader)
 	}

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -81,6 +81,10 @@ type InHeader struct {
 	Client bool
 	// WireLength is the wire length of header.
 	WireLength int
+	// Compression is the compression algorithm used for the RPC.
+	Compression string
+	// Header contains the header metadata received.
+	Header metadata.MD
 
 	// The following fields are valid only if Client is false.
 	// FullMethod is the full RPC method string, i.e., /package.service/method.
@@ -89,10 +93,6 @@ type InHeader struct {
 	RemoteAddr net.Addr
 	// LocalAddr is the local address of the corresponding connection.
 	LocalAddr net.Addr
-	// Compression is the compression algorithm used for the RPC.
-	Compression string
-	// Header contains the header metadata received.
-	Header metadata.MD
 }
 
 // IsClient indicates if the stats information is from client side.
@@ -141,6 +141,10 @@ func (s *OutPayload) isRPCStats() {}
 type OutHeader struct {
 	// Client is true if this OutHeader is from client side.
 	Client bool
+	// Compression is the compression algorithm used for the RPC.
+	Compression string
+	// Header contains the header metadata sent.
+	Header metadata.MD
 
 	// The following fields are valid only if Client is true.
 	// FullMethod is the full RPC method string, i.e., /package.service/method.
@@ -149,10 +153,6 @@ type OutHeader struct {
 	RemoteAddr net.Addr
 	// LocalAddr is the local address of the corresponding connection.
 	LocalAddr net.Addr
-	// Compression is the compression algorithm used for the RPC.
-	Compression string
-	// Header contains the header metadata sent.
-	Header metadata.MD
 }
 
 // IsClient indicates if this stats information is from client side.

--- a/stats/stats_test.go
+++ b/stats/stats_test.go
@@ -446,6 +446,9 @@ func checkInHeader(t *testing.T, d *gotData, e *expectedData) {
 	if d.ctx == nil {
 		t.Fatalf("d.ctx = nil, want <non-nil>")
 	}
+	if st.Compression != e.compression {
+		t.Fatalf("st.Compression = %v, want %v", st.Compression, e.compression)
+	}
 	if d.client {
 		// additional headers might be injected so instead of testing equality, test that all the
 		// expected headers keys have the expected header values.
@@ -460,9 +463,6 @@ func checkInHeader(t *testing.T, d *gotData, e *expectedData) {
 		}
 		if st.LocalAddr.String() != e.serverAddr {
 			t.Fatalf("st.LocalAddr = %v, want %v", st.LocalAddr, e.serverAddr)
-		}
-		if st.Compression != e.compression {
-			t.Fatalf("st.Compression = %v, want %v", st.Compression, e.compression)
 		}
 		// additional headers might be injected so instead of testing equality, test that all the
 		// expected headers keys have the expected header values.
@@ -575,15 +575,15 @@ func checkOutHeader(t *testing.T, d *gotData, e *expectedData) {
 	if d.ctx == nil {
 		t.Fatalf("d.ctx = nil, want <non-nil>")
 	}
+	if st.Compression != e.compression {
+		t.Fatalf("st.Compression = %v, want %v", st.Compression, e.compression)
+	}
 	if d.client {
 		if st.FullMethod != e.method {
 			t.Fatalf("st.FullMethod = %s, want %v", st.FullMethod, e.method)
 		}
 		if st.RemoteAddr.String() != e.serverAddr {
 			t.Fatalf("st.RemoteAddr = %v, want %v", st.RemoteAddr, e.serverAddr)
-		}
-		if st.Compression != e.compression {
-			t.Fatalf("st.Compression = %v, want %v", st.Compression, e.compression)
 		}
 		// additional headers might be injected so instead of testing equality, test that all the
 		// expected headers keys have the expected header values.


### PR DESCRIPTION
Currently, the request compression is recorded (on `stats.OutHeader` client-side and `stats.InHeader` server-side), but the response compression is never recorded. Although these compression codecs are often the same, the gRPC compression specification (https://github.com/grpc/grpc/blob/master/doc/compression.md) states that it's valid for them to be different.

- The pull request captures the response compression (on `stats.InHeader` client-side and `stats.OutHeader` server-side).
- This pull request moves the two fields (`Compression` and `Header`) above the comment `The following fields are valid only if Client is true.` because they are now both valid on the server-side and client-side.

