### PR TITLE
xds: LRS send hostname and handle response clusters

### DIFF
--- a/xds/internal/balancer/edsbalancer/test_util_test.go
+++ b/xds/internal/balancer/edsbalancer/test_util_test.go
@@ -168,7 +168,7 @@ func (tls *testLoadStore) CallServerLoad(l internal.Locality, name string, d flo
 	tls.callsCost = append(tls.callsCost, testServerLoad{name: name, d: d})
 }
 
-func (*testLoadStore) ReportTo(ctx context.Context, cc *grpc.ClientConn, clusterName string, node *corepb.Node) {
+func (*testLoadStore) ReportTo(ctx context.Context, cc *grpc.ClientConn, clusterName string, hostname string, node *corepb.Node) {
 	panic("not implemented")
 }
 

--- a/xds/internal/balancer/lrs/lrs.go
+++ b/xds/internal/balancer/lrs/lrs.go
@@ -346,6 +346,11 @@ func (ls *lrsStore) ReportTo(ctx context.Context, cc *grpc.ClientConn, clusterNa
 			grpclog.Warningf("lrs: failed to convert report interval: %v", err)
 			continue
 		}
+		// The LRS client should join the clusters it knows with the cluster
+		// list from response, and send loads for them.
+		//
+		// But the LRS client now only supports one cluster. TODO: extent it to
+		// support multiple clusters.
 		var clusterFoundInResponse bool
 		for _, c := range first.Clusters {
 			if c == clusterName {

--- a/xds/internal/balancer/lrs/lrs_test.go
+++ b/xds/internal/balancer/lrs/lrs_test.go
@@ -367,7 +367,7 @@ func (lrss *lrsServer) StreamLoadStats(stream lrsgrpc.LoadReportingService_Strea
 		return status.Errorf(codes.FailedPrecondition, "unexpected req: %+v", req)
 	}
 	if err := stream.Send(&lrspb.LoadStatsResponse{
-		Clusters:              []string{testService},
+		Clusters:              []string{testService, "another-cluster"},
 		LoadReportingInterval: lrss.reportingInterval,
 	}); err != nil {
 		return err

--- a/xds/internal/client/client.go
+++ b/xds/internal/client/client.go
@@ -41,12 +41,17 @@ type Options struct {
 	Config bootstrap.Config
 	// DialOpts contains dial options to be used when dialing the xDS server.
 	DialOpts []grpc.DialOption
+	// TargetName is the target of the parent ClientConn.
+	TargetName string
 }
 
 // Client is a full fledged gRPC client which queries a set of discovery APIs
 // (collectively termed as xDS) on a remote management server, to discover
-// various dynamic resources. A single client object will be shared by the xds
-// resolver and balancer implementations.
+// various dynamic resources.
+//
+// A single client object will be shared by the xds resolver and balancer
+// implementations. But the same client can only be shared by the same parent
+// ClientConn.
 type Client struct {
 	opts Options
 	cc   *grpc.ClientConn // Connection to the xDS server

--- a/xds/internal/client/client_loadreport.go
+++ b/xds/internal/client/client_loadreport.go
@@ -53,7 +53,7 @@ func (c *Client) ReportLoad(server string, clusterName string, loadStore lrs.Sto
 		closeCC = true
 	}
 	ctx, cancel := context.WithCancel(context.Background())
-	go loadStore.ReportTo(ctx, c.cc, clusterName, c.opts.Config.NodeProto)
+	go loadStore.ReportTo(ctx, c.cc, clusterName, c.opts.TargetName, c.opts.Config.NodeProto)
 	return func() {
 		cancel()
 		if closeCC {

--- a/xds/internal/resolver/xds_resolver.go
+++ b/xds/internal/resolver/xds_resolver.go
@@ -74,7 +74,7 @@ func (b *xdsResolverBuilder) Build(t resolver.Target, cc resolver.ClientConn, rb
 		dopts = []grpc.DialOption{grpc.WithContextDialer(rbo.Dialer)}
 	}
 
-	client, err := newXDSClient(xdsclient.Options{Config: *config, DialOpts: dopts})
+	client, err := newXDSClient(xdsclient.Options{Config: *config, DialOpts: dopts, TargetName: t.Endpoint})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
 - The first LRS req will send hostname in metadata
   - With key "PROXYLESS_CLIENT_HOSTNAME"
 - The LRS client will find known clusters from the response, and send the loads
   - The LRS client support only one cluster now, will be extended to support multiple