### PR TITLE
vet.sh: ensure vet runs on all packages

### DIFF
--- a/vet.sh
+++ b/vet.sh
@@ -94,7 +94,7 @@ go list -f {{.Dir}} ./... | xargs go run test/go_vet/vet.go
 gofmt -s -d -l . 2>&1 | fail_on_output
 goimports -l . 2>&1 | (! grep -vE "(_mock|\.pb)\.go")
 golint ./... 2>&1 | (! grep -vE "(_mock|\.pb)\.go:")
-go vet -all .
+go vet -all ./...
 
 misspell -error .
 


### PR DESCRIPTION
It seems go vet was not being run on the packages.

https://github.com/grpc/grpc-go/pull/3396 contains fixes.