### PR TITLE
test: include xDS package in test client dependencies

### DIFF
--- a/interop/xds/client/client.go
+++ b/interop/xds/client/client.go
@@ -31,6 +31,7 @@ import (
 	"google.golang.org/grpc/grpclog"
 	testpb "google.golang.org/grpc/interop/grpc_testing"
 	"google.golang.org/grpc/peer"
+	_ "google.golang.org/grpc/xds/experimental"
 )
 
 type statsWatcherKey struct {


### PR DESCRIPTION
Corrects a mistake from https://github.com/grpc/grpc-go/pull/3326

@menghanl 