### PR TITLE
stats: add comments about why out headers and out trailers have no wire length

### DIFF
--- a/internal/transport/handler_server.go
+++ b/internal/transport/handler_server.go
@@ -227,6 +227,8 @@ func (ht *serverHandlerTransport) WriteStatus(s *Stream, st *status.Status) erro
 
 	if err == nil { // transport has not been closed
 		if ht.stats != nil {
+			// Note: The trailer fields are compressed with hpack after this call returns.
+			// No WireLength field is set here.
 			ht.stats.HandleRPC(s.Context(), &stats.OutTrailer{
 				Trailer: s.trailer.Copy(),
 			})
@@ -291,6 +293,8 @@ func (ht *serverHandlerTransport) WriteHeader(s *Stream, md metadata.MD) error {
 
 	if err == nil {
 		if ht.stats != nil {
+			// Note: The header fields are compressed with hpack after this call returns.
+			// No WireLength field is set here.
 			ht.stats.HandleRPC(s.Context(), &stats.OutHeader{
 				Header: md.Copy(),
 			})

--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -686,6 +686,8 @@ func (t *http2Client) NewStream(ctx context.Context, callHdr *CallHdr) (_ *Strea
 		} else {
 			header = metadata.Pairs("user-agent", t.userAgent)
 		}
+		// Note: The header fields are compressed with hpack after this call returns.
+		// No WireLength field is set here.
 		outHeader := &stats.OutHeader{
 			Client:      true,
 			FullMethod:  callHdr.Method,

--- a/internal/transport/http2_server.go
+++ b/internal/transport/http2_server.go
@@ -813,8 +813,8 @@ func (t *http2Server) writeHeaderLocked(s *Stream) error {
 		return ErrHeaderListSizeLimitViolation
 	}
 	if t.stats != nil {
-		// Note: WireLength is not set in outHeader.
-		// TODO(mmukhi): Revisit this later, if needed.
+		// Note: Headers are compressed with hpack after this call returns.
+		// No WireLength field is set here.
 		outHeader := &stats.OutHeader{
 			Header: s.header.Copy(),
 		}
@@ -880,6 +880,8 @@ func (t *http2Server) WriteStatus(s *Stream, st *status.Status) error {
 	rst := s.getState() == streamActive
 	t.finishStream(s, rst, http2.ErrCodeNo, trailingHeader, true)
 	if t.stats != nil {
+		// Note: The trailer fields are compressed with hpack after this call returns.
+		// No WireLength field is set here.
 		t.stats.HandleRPC(s.Context(), &stats.OutTrailer{
 			Trailer: s.trailer.Copy(),
 		})

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -165,6 +165,8 @@ type OutTrailer struct {
 	// Client is true if this OutTrailer is from client side.
 	Client bool
 	// WireLength is the wire length of trailer.
+	// Deprecated: This field is never set. The length is not known when this message is
+	//             emitted because the trailer fields are compressed with hpack after that.
 	WireLength int
 	// Trailer contains the trailer metadata sent to the client. This
 	// field is only valid if this OutTrailer is from the server side.

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -165,8 +165,9 @@ type OutTrailer struct {
 	// Client is true if this OutTrailer is from client side.
 	Client bool
 	// WireLength is the wire length of trailer.
+	//
 	// Deprecated: This field is never set. The length is not known when this message is
-	//             emitted because the trailer fields are compressed with hpack after that.
+	// emitted because the trailer fields are compressed with hpack after that.
 	WireLength int
 	// Trailer contains the trailer metadata sent to the client. This
 	// field is only valid if this OutTrailer is from the server side.


### PR DESCRIPTION
I was trying to debug why the `OutTrailer.WireLength` field was always zero and I discovered that it was never set. This is because Header and Trailer WireLengths are difficult to calculate. They are compressed with hpack after the stats handler is called.

I looked into attaching them but couldn't find a good way to defer these calls until after the headers are encoded and the lengths are known so instead, I opted for comments and deprecation.

This pr should make it easier for the next reader to understand what's going on.

- I added comments to the struct initializations to make it more clear to the next reader wire we don't have WireLength fields.
- I marked the `OutTrailer.WireLength` field as deprecated because it is never set. Happy to remove the field if that's preferred. Wanted to err on the side of not making a breaking change but given that the field is never set, it might be nicer to just remove it. The header one was just removed with no deprecation warning: https://github.com/grpc/grpc-go/pull/1536/files#diff-6aa7b5bbbe0875c6ad9d048ced4e456fL138-L139