### PR TITLE
test: record peers by hostname in xds client

### DIFF
--- a/interop/xds/client/client.go
+++ b/interop/xds/client/client.go
@@ -94,7 +94,7 @@ func (s *statsService) GetClientStats(ctx context.Context, in *testpb.LoadBalanc
 		select {
 		case r := <-watcher.c:
 			if r != nil {
-				watcher.rpcsByPeer[(*r).GetServerId()]++
+				watcher.rpcsByPeer[(*r).GetHostname()]++
 			} else {
 				watcher.numFailures++
 			}


### PR DESCRIPTION
One more fix for this. `server_id` is actually unused in OSS, the client's rpc service should report the distribution by server hostname instead.

@menghanl 