### PR TITLE
client: add a WithNoProxy dialoption

### DIFF
--- a/clientconn.go
+++ b/clientconn.go
@@ -198,7 +198,7 @@ func DialContext(ctx context.Context, target string, opts ...DialOption) (conn *
 			network, addr := parseDialTarget(addr)
 			return (&net.Dialer{}).DialContext(ctx, network, addr)
 		}
-		if !cc.dopts.withoutProxy {
+		if cc.dopts.withProxy {
 			cc.dopts.copts.Dialer = newProxyDialer(cc.dopts.copts.Dialer)
 		}
 	}

--- a/clientconn.go
+++ b/clientconn.go
@@ -194,12 +194,13 @@ func DialContext(ctx context.Context, target string, opts ...DialOption) (conn *
 	cc.mkp = cc.dopts.copts.KeepaliveParams
 
 	if cc.dopts.copts.Dialer == nil {
-		cc.dopts.copts.Dialer = newProxyDialer(
-			func(ctx context.Context, addr string) (net.Conn, error) {
-				network, addr := parseDialTarget(addr)
-				return (&net.Dialer{}).DialContext(ctx, network, addr)
-			},
-		)
+		cc.dopts.copts.Dialer = func(ctx context.Context, addr string) (net.Conn, error) {
+			network, addr := parseDialTarget(addr)
+			return (&net.Dialer{}).DialContext(ctx, network, addr)
+		}
+		if !cc.dopts.withoutProxy {
+			cc.dopts.copts.Dialer = newProxyDialer(cc.dopts.copts.Dialer)
+		}
 	}
 
 	if cc.dopts.copts.UserAgent != "" {

--- a/dialoptions.go
+++ b/dialoptions.go
@@ -72,6 +72,7 @@ type dialOptions struct {
 	// we need to be able to configure this in tests.
 	resolveNowBackoff func(int) time.Duration
 	resolvers         []resolver.Builder
+	withoutProxy      bool
 }
 
 // DialOption configures how we set up the connection.
@@ -304,6 +305,14 @@ func WithBlock() DialOption {
 func WithInsecure() DialOption {
 	return newFuncDialOption(func(o *dialOptions) {
 		o.insecure = true
+	})
+}
+
+// WithoutProxy returns a DialOption which disables the use of proxies for this
+// ClientConn. This is ignored if WithDialer or WithContextDialer are used.
+func WithoutProxy() DialOption {
+	return newFuncDialOption(func(o *dialOptions) {
+		o.withoutProxy = true
 	})
 }
 

--- a/dialoptions.go
+++ b/dialoptions.go
@@ -72,7 +72,7 @@ type dialOptions struct {
 	// we need to be able to configure this in tests.
 	resolveNowBackoff func(int) time.Duration
 	resolvers         []resolver.Builder
-	withoutProxy      bool
+	withProxy         bool
 }
 
 // DialOption configures how we set up the connection.
@@ -314,7 +314,7 @@ func WithInsecure() DialOption {
 // This API is EXPERIMENTAL.
 func WithNoProxy() DialOption {
 	return newFuncDialOption(func(o *dialOptions) {
-		o.withoutProxy = true
+		o.withProxy = false
 	})
 }
 
@@ -568,6 +568,7 @@ func defaultDialOptions() dialOptions {
 			ReadBufferSize:  defaultReadBufSize,
 		},
 		resolveNowBackoff: internalbackoff.DefaultExponential.Backoff,
+		withProxy:         true,
 	}
 }
 

--- a/dialoptions.go
+++ b/dialoptions.go
@@ -308,9 +308,11 @@ func WithInsecure() DialOption {
 	})
 }
 
-// WithoutProxy returns a DialOption which disables the use of proxies for this
+// WithNoProxy returns a DialOption which disables the use of proxies for this
 // ClientConn. This is ignored if WithDialer or WithContextDialer are used.
-func WithoutProxy() DialOption {
+//
+// This API is EXPERIMENTAL.
+func WithNoProxy() DialOption {
 	return newFuncDialOption(func(o *dialOptions) {
 		o.withoutProxy = true
 	})


### PR DESCRIPTION
Hullo! I'm working with a system that talks to some things via grpc and some things not via grpc. (actually, talking over a UNIX domain socket via grpc :grimacing:).

The non-grpc things are mostly HTTP requests that we do need to proxy. The grpc things, as noted, as via local sockets, which _can't_ and shouldn't be proxied.

Providing our own dialer is an option, but this seems a little cleaner and like other folks might also find it useful.