### PR TITLE
client: option to surface connection errors to callers

### DIFF
--- a/clientconn.go
+++ b/clientconn.go
@@ -219,7 +219,7 @@ func DialContext(ctx context.Context, target string, opts ...DialOption) (conn *
 			switch {
 			case ctx.Err() == err:
 				conn = nil
-			case err == nil:
+			case err == nil || !cc.dopts.returnLastError:
 				conn, err = nil, ctx.Err()
 			default:
 				conn, err = nil, fmt.Errorf("%v: %v", ctx.Err(), err)
@@ -328,7 +328,7 @@ func DialContext(ctx context.Context, target string, opts ...DialOption) (conn *
 			}
 			if !cc.WaitForStateChange(ctx, s) {
 				// ctx got timeout or canceled.
-				if err = cc.blockingpicker.connectionError(); err != nil {
+				if err = cc.blockingpicker.connectionError(); err != nil && cc.dopts.returnLastError {
 					return nil, err
 				}
 				return nil, ctx.Err()

--- a/clientconn_test.go
+++ b/clientconn_test.go
@@ -229,8 +229,9 @@ func (s) TestDialWaitsForServerSettingsAndFails(t *testing.T) {
 		client.Close()
 		t.Fatalf("Unexpected success (err=nil) while dialing")
 	}
-	if err != context.DeadlineExceeded {
-		t.Fatalf("DialContext(_) = %v; want context.DeadlineExceeded", err)
+	expectedMsg := "server handshake"
+	if !strings.Contains(err.Error(), context.DeadlineExceeded.Error()) || !strings.Contains(err.Error(), expectedMsg) {
+		t.Fatalf("DialContext(_) = %v; want a message that includes both %q and %q", err, context.DeadlineExceeded.Error(), expectedMsg)
 	}
 	<-done
 	if numConns < 2 {

--- a/clientconn_test.go
+++ b/clientconn_test.go
@@ -221,7 +221,7 @@ func (s) TestDialWaitsForServerSettingsAndFails(t *testing.T) {
 	client, err := DialContext(ctx,
 		lis.Addr().String(),
 		WithInsecure(),
-		WithReturnLastError(),
+		WithReturnConnectionError(),
 		withBackoff(noBackoff{}),
 		withMinConnectDeadline(func() time.Duration { return time.Second / 4 }))
 	lis.Close()

--- a/clientconn_test.go
+++ b/clientconn_test.go
@@ -221,7 +221,7 @@ func (s) TestDialWaitsForServerSettingsAndFails(t *testing.T) {
 	client, err := DialContext(ctx,
 		lis.Addr().String(),
 		WithInsecure(),
-		WithBlock(),
+		WithReturnLastError(),
 		withBackoff(noBackoff{}),
 		withMinConnectDeadline(func() time.Duration { return time.Second / 4 }))
 	lis.Close()

--- a/dialoptions.go
+++ b/dialoptions.go
@@ -299,10 +299,13 @@ func WithBlock() DialOption {
 	})
 }
 
-// WithReturnLastError returns a DialOption which makes the client connection
-// return the last connection error that occurred instead of a context.DeadlineExceeded error.
+// WithReturnConnectionError returns a DialOption which makes the client connection
+// return a string containing both the last connection error that occurred and
+// the context.DeadlineExceeded error.
 // Implies WithBlock()
-func WithReturnLastError() DialOption {
+//
+// This API is EXPERIMENTAL.
+func WithReturnConnectionError() DialOption {
 	return newFuncDialOption(func(o *dialOptions) {
 		o.block = true
 		o.returnLastError = true

--- a/dialoptions.go
+++ b/dialoptions.go
@@ -46,16 +46,17 @@ type dialOptions struct {
 	chainUnaryInts  []UnaryClientInterceptor
 	chainStreamInts []StreamClientInterceptor
 
-	cp          Compressor
-	dc          Decompressor
-	bs          internalbackoff.Strategy
-	block       bool
-	insecure    bool
-	timeout     time.Duration
-	scChan      <-chan ServiceConfig
-	authority   string
-	copts       transport.ConnectOptions
-	callOptions []CallOption
+	cp              Compressor
+	dc              Decompressor
+	bs              internalbackoff.Strategy
+	block           bool
+	returnLastError bool
+	insecure        bool
+	timeout         time.Duration
+	scChan          <-chan ServiceConfig
+	authority       string
+	copts           transport.ConnectOptions
+	callOptions     []CallOption
 	// This is used by v1 balancer dial option WithBalancer to support v1
 	// balancer, and also by WithBalancerName dial option.
 	balancerBuilder             balancer.Builder
@@ -295,6 +296,16 @@ func withBackoff(bs internalbackoff.Strategy) DialOption {
 func WithBlock() DialOption {
 	return newFuncDialOption(func(o *dialOptions) {
 		o.block = true
+	})
+}
+
+// WithReturnLastError returns a DialOption which makes the client connection
+// return the last connection error that occurred instead of a context.DeadlineExceeded error.
+// Implies WithBlock()
+func WithReturnLastError() DialOption {
+	return newFuncDialOption(func(o *dialOptions) {
+		o.block = true
+		o.returnLastError = true
 	})
 }
 


### PR DESCRIPTION
This commit allows blocking clients to receive a more informative error
message than "context deadline exceeded", which is especially helpful in
tracking down persistent client misconfiguration (such as an invalid TLS
certificate, an invalid server that's refusing connections, etc.)
