### PR TITLE
client: fix getResolver to use scheme param

### DIFF
--- a/clientconn.go
+++ b/clientconn.go
@@ -1525,9 +1525,9 @@ var ErrClientConnTimeout = errors.New("grpc: timed out when dialing")
 
 func (cc *ClientConn) getResolver(scheme string) resolver.Builder {
 	for _, rb := range cc.dopts.resolvers {
-		if cc.parsedTarget.Scheme == rb.Scheme() {
+		if scheme == rb.Scheme() {
 			return rb
 		}
 	}
-	return resolver.Get(cc.parsedTarget.Scheme)
+	return resolver.Get(scheme)
 }


### PR DESCRIPTION
clientconn getResolver scheme param unused
fix #3445 