### PR TITLE
rls: Add an Equal method to the KeyBuilderMap type.

### DIFF
--- a/balancer/rls/internal/keys/builder.go
+++ b/balancer/rls/internal/keys/builder.go
@@ -124,6 +124,7 @@ func (bm BuilderMap) RLSKey(md metadata.MD, path string) KeyMap {
 	return b.keys(md)
 }
 
+// BuilderMapEqual returns true if the provided BuilderMap objects are equal.
 func BuilderMapEqual(a, b BuilderMap) bool {
 	return cmp.Equal(a, b, cmp.AllowUnexported(builder{}, matcher{}))
 }

--- a/balancer/rls/internal/keys/builder.go
+++ b/balancer/rls/internal/keys/builder.go
@@ -24,6 +24,7 @@ package keys
 import (
 	"errors"
 	"fmt"
+	"github.com/google/go-cmp/cmp"
 	"sort"
 	"strings"
 
@@ -120,6 +121,10 @@ func (bm BuilderMap) RLSKey(md metadata.MD, path string) KeyMap {
 		}
 	}
 	return b.keys(md)
+}
+
+func BuilderMapEqual(a, b BuilderMap) bool {
+	return cmp.Equal(a, b, cmp.AllowUnexported(builder{}, matcher{}))
 }
 
 // builder provides the actual functionality of building RLS keys. These are

--- a/balancer/rls/internal/keys/builder.go
+++ b/balancer/rls/internal/keys/builder.go
@@ -24,9 +24,10 @@ package keys
 import (
 	"errors"
 	"fmt"
-	"github.com/google/go-cmp/cmp"
 	"sort"
 	"strings"
+
+	"github.com/google/go-cmp/cmp"
 
 	rlspb "google.golang.org/grpc/balancer/rls/internal/proto/grpc_lookup_v1"
 	"google.golang.org/grpc/metadata"

--- a/balancer/rls/internal/keys/builder.go
+++ b/balancer/rls/internal/keys/builder.go
@@ -28,7 +28,6 @@ import (
 	"strings"
 
 	"github.com/google/go-cmp/cmp"
-
 	rlspb "google.golang.org/grpc/balancer/rls/internal/proto/grpc_lookup_v1"
 	"google.golang.org/grpc/metadata"
 )

--- a/balancer/rls/internal/keys/builder_test.go
+++ b/balancer/rls/internal/keys/builder_test.go
@@ -85,7 +85,7 @@ func TestMakeBuilderMap(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
 			builderMap, err := MakeBuilderMap(test.cfg)
-			if err != nil || !cmp.Equal(builderMap, test.wantBuilderMap, cmp.AllowUnexported(builder{}, matcher{})) {
+			if err != nil || !BuilderMapEqual(builderMap, test.wantBuilderMap) {
 				t.Errorf("MakeBuilderMap(%+v) returned {%v, %v}, want: {%v, nil}", test.cfg, builderMap, err, test.wantBuilderMap)
 			}
 		})


### PR DESCRIPTION
This will be used by the RLS LB policy when it is processing config
updates and needs to make a decision as to whether or not the new config
specifies a new KeyBuilderMap.