### PR TITLE
advancedtls: add fine-grained verification levels in XXXOptions

### DIFF
--- a/security/advancedtls/advancedtls.go
+++ b/security/advancedtls/advancedtls.go
@@ -33,7 +33,7 @@ import (
 	"google.golang.org/grpc/credentials"
 )
 
-// VerificationFuncParams contains the parameters available to users when implementing |CustomVerificationFunc|.
+// VerificationFuncParams contains the parameters available to users when implementing CustomVerificationFunc.
 // The fields contain in this struct are used when making custom verification decisions, and are hence read-only.
 // Setting these fields wouldn't have any effect.
 type VerificationFuncParams struct {
@@ -43,7 +43,7 @@ type VerificationFuncParams struct {
 	VerifiedChains [][]*x509.Certificate
 }
 
-// VerificationResults contains the information about results of |CustomVerificationFunc|.
+// VerificationResults contains the information about results of CustomVerificationFunc.
 // VerificationResults is an empty struct for now. It may be extended in the future to include more information.
 type VerificationResults struct{}
 
@@ -106,19 +106,19 @@ type ClientOptions struct {
 	GetClientCertificate func(*tls.CertificateRequestInfo) (*tls.Certificate, error)
 	// VerifyPeer is a custom verification check after certificate signature check.
 	// If this is set, we will perform this customized check after doing the normal check(s)
-	// indicated by setting |VType|.
+	// indicated by setting VType.
 	VerifyPeer CustomVerificationFunc
 	// ServerNameOverride is for testing only. If set to a non-empty string,
 	// it will override the virtual host name of authority (e.g. :authority header field) in requests.
 	ServerNameOverride string
 	// RootCertificateOptions is REQUIRED to be correctly set on client side.
 	RootCertificateOptions
-	// If setting this field to |CertAndHostVerification|, we would perform both the certificate
+	// If setting this field to CertAndHostVerification, we would perform both the certificate
 	// verification and hostname verification.
-	// If setting to |CertVerification|, we would only perform verification for the certificate sent from
+	// If setting to CertVerification, we would only perform verification for the certificate sent from
 	// the server. Setting this field without proper custom verification check would leave the
 	// application susceptible to the MITM attack.
-	// If setting to |SkipVerification|, we would skip all the verification. Setting this field without
+	// If setting to SkipVerification, we would skip all the verification. Setting this field without
 	// proper custom verification check would leave the peer completely unauthenticated, and is
 	// highly discouraged unless you really have reasons to do so.
 	VType VerificationType
@@ -139,21 +139,21 @@ type ServerOptions struct {
 	GetCertificate func(*tls.ClientHelloInfo) (*tls.Certificate, error)
 	// VerifyPeer is a custom verification check after certificate signature check.
 	// If this is set, we will perform this customized check after doing the normal check(s)
-	// indicated by setting |VType|.
+	// indicated by setting VType.
 	VerifyPeer CustomVerificationFunc
-	// RootCertificateOptions is only required when mutual TLS is enabled(|RequireClientCert| is true).
+	// RootCertificateOptions is only required when mutual TLS is enabled(RequireClientCert is true).
 	RootCertificateOptions
 	// If the server want the client to send certificates.
 	RequireClientCert bool
-	// Note that this field will only take into effect when we set |RequireClientCert| to true,
+	// Note that this field will only take into effect when we set RequireClientCert to true,
 	// meaning we are using mTLS and want to verify the client certificates.
-	// If setting this field to |CertAndHostVerification|, we would only perform the certificate
-	// verification, which has the same effect as setting to |CertVerification|, because we don't have
+	// If setting this field to CertAndHostVerification, we would only perform the certificate
+	// verification, which has the same effect as setting to CertVerification, because we don't have
 	// hostname check on server side.
-	// If setting to |CertVerification|, we would perform verification for certificates sent from the
+	// If setting to CertVerification, we would perform verification for certificates sent from the
 	// client. Setting this field without proper custom authorization would leave the application
 	// susceptible to the MITM attack.
-	// If setting to |SkipVerification|, we would skip all the verification. Setting this field without
+	// If setting to SkipVerification, we would skip all the verification. Setting this field without
 	// proper custom authorization would leave the peer completely unauthenticated, and is
 	// highly discouraged unless you really have reasons to do so.
 	VType VerificationType
@@ -186,7 +186,7 @@ func (o *ServerOptions) config() (*tls.Config, error) {
 	}
 	clientAuth := tls.NoClientCert
 	if o.RequireClientCert {
-		// We have to set |clientAuth| to RequireAnyClientCert to force underlying TLS package to use the
+		// We have to set clientAuth to RequireAnyClientCert to force underlying TLS package to use the
 		// verification function we built from buildVerifyFunc.
 		clientAuth = tls.RequireAnyClientCert
 	}

--- a/security/advancedtls/advancedtls.go
+++ b/security/advancedtls/advancedtls.go
@@ -37,8 +37,8 @@ import (
 // implementing CustomVerificationFunc.
 // The fields in this struct are read-only.
 type VerificationFuncParams struct {
-	// The target server name that the client connects to when establish the
-	// connection.This field is only meaningful for client side. On server side,
+	// The target server name that the client connects to when establishing the
+	// connection. This field is only meaningful for client side. On server side,
 	// this field would be an empty string.
 	ServerName string
 	// The raw certificates sent from peer.
@@ -339,14 +339,15 @@ func buildVerifyFunc(c *advancedTLSCreds,
 				}
 				certs[i] = cert
 			}
+			keyUsages := []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}
+			if !c.isClient {
+				keyUsages = []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}
+			}
 			opts := x509.VerifyOptions{
 				Roots:         rootCAs,
 				CurrentTime:   time.Now(),
 				Intermediates: x509.NewCertPool(),
-				KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
-			}
-			if !c.isClient {
-				opts.KeyUsages = []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}
+				KeyUsages:     keyUsages,
 			}
 			for _, cert := range certs[1:] {
 				opts.Intermediates.AddCert(cert)

--- a/security/advancedtls/advancedtls.go
+++ b/security/advancedtls/advancedtls.go
@@ -17,8 +17,8 @@
  */
 
 // Package advancedtls is a utility library containing functions to construct
-// credentials. TransportCredentials that can perform credential reloading and custom
-// verification check.
+// credentials.TransportCredentials that can perform credential reloading and
+// custom verification check.
 package advancedtls
 
 import (
@@ -33,129 +33,145 @@ import (
 	"google.golang.org/grpc/credentials"
 )
 
-// VerificationFuncParams contains the parameters available to users when implementing CustomVerificationFunc.
-// The fields contain in this struct are used when making custom verification decisions, and are hence read-only.
-// Setting these fields wouldn't have any effect.
+// VerificationFuncParams contains parameters available to users when
+// implementing CustomVerificationFunc.
+// The fields in this struct are read-only.
 type VerificationFuncParams struct {
-	// This field is only meaningful for client side. On server side, this field would be an empty string.
-	ServerName     string
-	RawCerts       [][]byte
+	// The target server name that the client connects to when establish the
+	// connection.This field is only meaningful for client side. On server side,
+	// this field would be an empty string.
+	ServerName string
+	// The raw certificates sent from peer.
+	RawCerts [][]byte
+	// The verification chain obtained by checking peer RawCerts against the
+	// trust certificate bundle(s), if applicable.
 	VerifiedChains [][]*x509.Certificate
 }
 
-// VerificationResults contains the information about results of CustomVerificationFunc.
-// VerificationResults is an empty struct for now. It may be extended in the future to include more information.
+// VerificationResults contains the information about results of
+// CustomVerificationFunc.
+// VerificationResults is an empty struct for now. It may be extended in the
+// future to include more information.
 type VerificationResults struct{}
 
-// CustomVerificationFunc is the function defined by users to perform custom verification check.
-// CustomVerificationFunc returns nil if the authorization fails; otherwise returns an empty struct.
+// CustomVerificationFunc is the function defined by users to perform custom
+// verification check.
+// CustomVerificationFunc returns nil if the authorization fails; otherwise
+// returns an empty struct.
 type CustomVerificationFunc func(params *VerificationFuncParams) (*VerificationResults, error)
 
-// GetRootCAsParams contains the parameters available to users when implementing GetRootCAs.
+// GetRootCAsParams contains the parameters available to users when
+// implementing GetRootCAs.
 type GetRootCAsParams struct {
 	RawConn  net.Conn
 	RawCerts [][]byte
 }
 
 // GetRootCAsResults contains the results of GetRootCAs.
-// If users want to reload the root trust certificate, it is required to return the proper TrustCerts in GetRootCAs.
+// If users want to reload the root trust certificate, it is required to return
+// the proper TrustCerts in GetRootCAs.
 type GetRootCAsResults struct {
 	TrustCerts *x509.CertPool
 }
 
-// RootCertificateOptions contains a field and a function for obtaining root trust certificates.
+// RootCertificateOptions contains a field and a function for obtaining root
+// trust certificates.
 // It is used by both ClientOptions and ServerOptions.
 type RootCertificateOptions struct {
-	// If field RootCACerts is set, field GetRootCAs will be ignored. RootCACerts will be used
-	// every time when verifying the peer certificates, without performing root certificate reloading.
+	// If field RootCACerts is set, field GetRootCAs will be ignored. RootCACerts
+	// will be used every time when verifying the peer certificates, without
+	// performing root certificate reloading.
 	RootCACerts *x509.CertPool
-	// If GetRootCAs is set and RootCACerts is nil, GetRootCAs will be invoked every time
-	// asked to check certificates sent from the server when a new connection is established.
+	// If GetRootCAs is set and RootCACerts is nil, GetRootCAs will be invoked
+	// every time asked to check certificates sent from the server when a new
+	// connection is established.
 	// This is known as root CA certificate reloading.
 	GetRootCAs func(params *GetRootCAsParams) (*GetRootCAsResults, error)
 }
 
-// VerificationType is the enum type that represents different levels of verification users
-// could set, both on client side and on server side.
+// VerificationType is the enum type that represents different levels of
+// verification users could set, both on client side and on server side.
 type VerificationType int
 
 const (
-	// CertAndHostVerification indicates doing both certificate signature check and hostname check.
+	// CertAndHostVerification indicates doing both certificate signature check
+	// and hostname check.
 	CertAndHostVerification VerificationType = iota
-	// CertVerification indicates doing certificate signature check only.
+	// CertVerification indicates doing certificate signature check only. Setting
+	// this field without proper custom verification check would leave the
+	// application susceptible to the MITM attack.
 	CertVerification
-	// SkipVerification indicates skipping both certificate signature check and hostname check.
+	// SkipVerification indicates skipping both certificate signature check and
+	// hostname check. If setting this field, proper custom verification needs to
+	// be implemented in order to complete the authentication. Setting this field
+	// with a nil custom verification would raise an error.
 	SkipVerification
 )
 
-// ClientOptions contains all the fields and functions needed to be filled by the client.
+// ClientOptions contains all the fields and functions needed to be filled by
+// the client.
 // General rules for certificate setting on client side:
-// Certificates or GetClientCertificate indicates the certificates sent from the client to the
-// server to prove client's identities. The rules for setting these two fields are:
+// Certificates or GetClientCertificate indicates the certificates sent from
+// the client to the server to prove client's identities. The rules for setting
+// these two fields are:
 // If requiring mutual authentication on server side:
-//     Either Certificates or GetClientCertificate must be set; the other will be ignored.
+//     Either Certificates or GetClientCertificate must be set; the other will
+//     be ignored.
 // Otherwise:
 //     Nothing needed(the two fields will be ignored).
 type ClientOptions struct {
-	// If field Certificates is set, field GetClientCertificate will be ignored. The client will use
-	// Certificates every time when asked for a certificate, without performing certificate reloading.
+	// If field Certificates is set, field GetClientCertificate will be ignored.
+	// The client will use Certificates every time when asked for a certificate,
+	// without performing certificate reloading.
 	Certificates []tls.Certificate
-	// If GetClientCertificate is set and Certificates is nil, the client will invoke this
-	// function every time asked to present certificates to the server when a new connection is
-	// established. This is known as peer certificate reloading.
+	// If GetClientCertificate is set and Certificates is nil, the client will
+	// invoke this function every time asked to present certificates to the
+	// server when a new connection is established. This is known as peer
+	// certificate reloading.
 	GetClientCertificate func(*tls.CertificateRequestInfo) (*tls.Certificate, error)
-	// VerifyPeer is a custom verification check after certificate signature check.
-	// If this is set, we will perform this customized check after doing the normal check(s)
-	// indicated by setting VType.
+	// VerifyPeer is a custom verification check after certificate signature
+	// check.
+	// If this is set, we will perform this customized check after doing the
+	// normal check(s) indicated by setting VType.
 	VerifyPeer CustomVerificationFunc
 	// ServerNameOverride is for testing only. If set to a non-empty string,
-	// it will override the virtual host name of authority (e.g. :authority header field) in requests.
+	// it will override the virtual host name of authority (e.g. :authority
+	// header field) in requests.
 	ServerNameOverride string
 	// RootCertificateOptions is REQUIRED to be correctly set on client side.
 	RootCertificateOptions
-	// If setting this field to CertAndHostVerification, we would perform both the certificate
-	// verification and hostname verification.
-	// If setting to CertVerification, we would only perform verification for the certificate sent from
-	// the server. Setting this field without proper custom verification check would leave the
-	// application susceptible to the MITM attack.
-	// If setting to SkipVerification, we would skip all the verification. Setting this field without
-	// proper custom verification check would leave the peer completely unauthenticated, and is
-	// highly discouraged unless you really have reasons to do so.
+	// VType is the verification type on the client side.
 	VType VerificationType
 }
 
-// ServerOptions contains all the fields and functions needed to be filled by the client.
+// ServerOptions contains all the fields and functions needed to be filled by
+// the client.
 // General rules for certificate setting on server side:
-// Certificates or GetClientCertificate indicates the certificates sent from the server to
-// the client to prove server's identities. The rules for setting these two fields are:
+// Certificates or GetClientCertificate indicates the certificates sent from
+// the server to the client to prove server's identities. The rules for setting
+// these two fields are:
 // Either Certificates or GetCertificate must be set; the other will be ignored.
 type ServerOptions struct {
-	// If field Certificates is set, field GetClientCertificate will be ignored. The server will use
-	// Certificates every time when asked for a certificate, without performing certificate reloading.
+	// If field Certificates is set, field GetClientCertificate will be ignored.
+	// The server will use Certificates every time when asked for a certificate,
+	// without performing certificate reloading.
 	Certificates []tls.Certificate
-	// If GetClientCertificate is set and Certificates is nil, the server will invoke this
-	// function every time asked to present certificates to the client when a new connection is
-	// established. This is known as peer certificate reloading.
+	// If GetClientCertificate is set and Certificates is nil, the server will
+	// invoke this function every time asked to present certificates to the
+	// client when a new connection is established. This is known as peer
+	// certificate reloading.
 	GetCertificate func(*tls.ClientHelloInfo) (*tls.Certificate, error)
-	// VerifyPeer is a custom verification check after certificate signature check.
-	// If this is set, we will perform this customized check after doing the normal check(s)
-	// indicated by setting VType.
+	// VerifyPeer is a custom verification check after certificate signature
+	// check.
+	// If this is set, we will perform this customized check after doing the
+	// normal check(s) indicated by setting VType.
 	VerifyPeer CustomVerificationFunc
-	// RootCertificateOptions is only required when mutual TLS is enabled(RequireClientCert is true).
+	// RootCertificateOptions is only required when mutual TLS is
+	// enabled(RequireClientCert is true).
 	RootCertificateOptions
 	// If the server want the client to send certificates.
 	RequireClientCert bool
-	// Note that this field will only take into effect when we set RequireClientCert to true,
-	// meaning we are using mTLS and want to verify the client certificates.
-	// If setting this field to CertAndHostVerification, we would only perform the certificate
-	// verification, which has the same effect as setting to CertVerification, because we don't have
-	// hostname check on server side.
-	// If setting to CertVerification, we would perform verification for certificates sent from the
-	// client. Setting this field without proper custom authorization would leave the application
-	// susceptible to the MITM attack.
-	// If setting to SkipVerification, we would skip all the verification. Setting this field without
-	// proper custom authorization would leave the peer completely unauthenticated, and is
-	// highly discouraged unless you really have reasons to do so.
+	// VType is the verification type on the server side.
 	VType VerificationType
 }
 
@@ -164,8 +180,8 @@ func (o *ClientOptions) config() (*tls.Config, error) {
 		return nil, fmt.Errorf(
 			"client needs to provide custom verification mechanism if choose to skip default verification")
 	}
-	// We have to set InsecureSkipVerify to true to skip the default checks and use the
-	// verification function we built from buildVerifyFunc.
+	// We have to set InsecureSkipVerify to true to skip the default checks and
+	// use the verification function we built from buildVerifyFunc.
 	config := &tls.Config{
 		ServerName:           o.ServerNameOverride,
 		Certificates:         o.Certificates,
@@ -186,8 +202,9 @@ func (o *ServerOptions) config() (*tls.Config, error) {
 	}
 	clientAuth := tls.NoClientCert
 	if o.RequireClientCert {
-		// We have to set clientAuth to RequireAnyClientCert to force underlying TLS package to use the
-		// verification function we built from buildVerifyFunc.
+		// We have to set clientAuth to RequireAnyClientCert to force underlying
+		// TLS package to use the verification function we built from
+		// buildVerifyFunc.
 		clientAuth = tls.RequireAnyClientCert
 	}
 	config := &tls.Config{
@@ -201,7 +218,8 @@ func (o *ServerOptions) config() (*tls.Config, error) {
 	return config, nil
 }
 
-// advancedTLSCreds is the credentials required for authenticating a connection using TLS.
+// advancedTLSCreds is the credentials required for authenticating a connection
+// using TLS.
 type advancedTLSCreds struct {
 	config     *tls.Config
 	verifyFunc CustomVerificationFunc
@@ -283,11 +301,13 @@ func (c *advancedTLSCreds) OverrideServerName(serverNameOverride string) error {
 	return nil
 }
 
-// The function buildVerifyFunc is used when users want root cert reloading, and possibly custom
-// verification check.
-// We have to build our own verification function here because current tls module:
-// 1. does not have a good support on root cert reloading.
-// 2. will ignore basic certificate check when setting InsecureSkipVerify to true.
+// The function buildVerifyFunc is used when users want root cert reloading,
+// and possibly custom verification check.
+// We have to build our own verification function here because current
+// tls module:
+//   1. does not have a good support on root cert reloading.
+//   2. will ignore basic certificate check when setting InsecureSkipVerify
+//   to true.
 func buildVerifyFunc(c *advancedTLSCreds,
 	serverName string,
 	rawConn net.Conn) func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
@@ -295,10 +315,8 @@ func buildVerifyFunc(c *advancedTLSCreds,
 		chains := verifiedChains
 		if c.vType == CertAndHostVerification || c.vType == CertVerification {
 			// perform possible trust credential reloading and certificate check
-			var rootCAs *x509.CertPool
-			if c.isClient {
-				rootCAs = c.config.RootCAs
-			} else {
+			rootCAs := c.config.RootCAs
+			if !c.isClient {
 				rootCAs = c.config.ClientCAs
 			}
 			// Reload root CA certs.
@@ -325,20 +343,19 @@ func buildVerifyFunc(c *advancedTLSCreds,
 				Roots:         rootCAs,
 				CurrentTime:   time.Now(),
 				Intermediates: x509.NewCertPool(),
+				KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 			}
 			if !c.isClient {
 				opts.KeyUsages = []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}
-			} else {
-				opts.KeyUsages = []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}
 			}
 			for _, cert := range certs[1:] {
 				opts.Intermediates.AddCert(cert)
 			}
 			// Perform default hostname check if specified.
-			var err error
 			if c.isClient && c.vType == CertAndHostVerification && serverName != "" {
 				opts.DNSName = serverName
 			}
+			var err error
 			chains, err = certs[0].Verify(opts)
 			if err != nil {
 				return err
@@ -357,7 +374,8 @@ func buildVerifyFunc(c *advancedTLSCreds,
 	}
 }
 
-// NewClientCreds uses ClientOptions to construct a TransportCredentials based on TLS.
+// NewClientCreds uses ClientOptions to construct a TransportCredentials based
+// on TLS.
 func NewClientCreds(o *ClientOptions) (credentials.TransportCredentials, error) {
 	conf, err := o.config()
 	if err != nil {
@@ -374,7 +392,8 @@ func NewClientCreds(o *ClientOptions) (credentials.TransportCredentials, error) 
 	return tc, nil
 }
 
-// NewServerCreds uses ServerOptions to construct a TransportCredentials based on TLS.
+// NewServerCreds uses ServerOptions to construct a TransportCredentials based
+// on TLS.
 func NewServerCreds(o *ServerOptions) (credentials.TransportCredentials, error) {
 	conf, err := o.config()
 	if err != nil {

--- a/security/advancedtls/advancedtls.go
+++ b/security/advancedtls/advancedtls.go
@@ -35,7 +35,7 @@ import (
 
 // VerificationFuncParams contains the parameters available to users when implementing CustomVerificationFunc.
 type VerificationFuncParams struct {
-	// This field is only meaningful in client side. This will be an empty string on server side.
+	// This field is only meaningful for client side. On server side, this field would be an empty string.
 	ServerName     string
 	RawCerts       [][]byte
 	VerifiedChains [][]*x509.Certificate

--- a/security/advancedtls/advancedtls_integration_test.go
+++ b/security/advancedtls/advancedtls_integration_test.go
@@ -184,13 +184,13 @@ func TestEnd2End(t *testing.T) {
 		clientRoot       *x509.CertPool
 		clientGetRoot    func(params *GetRootCAsParams) (*GetRootCAsResults, error)
 		clientVerifyFunc CustomVerificationFunc
-		clientVType      VerificationAuthType
+		clientVType      VerificationType
 		serverCert       []tls.Certificate
 		serverGetCert    func(*tls.ClientHelloInfo) (*tls.Certificate, error)
 		serverRoot       *x509.CertPool
 		serverGetRoot    func(params *GetRootCAsParams) (*GetRootCAsResults, error)
 		serverVerifyFunc CustomVerificationFunc
-		serverVType      VerificationAuthType
+		serverVType      VerificationType
 	}{
 		// Test Scenarios:
 		// At initialization(stage = 0), client will be initialized with cert clientPeer1 and clientTrust1, server with serverPeer1 and serverTrust1.

--- a/security/advancedtls/advancedtls_integration_test.go
+++ b/security/advancedtls/advancedtls_integration_test.go
@@ -39,9 +39,11 @@ var (
 	port    = ":50051"
 )
 
-// stageInfo contains a stage number indicating the current phase of each integration test, and a mutex.
-// Based on the stage number of current test, we will use different certificates and custom verification
-// functions to check if our tests behave as expected.
+// stageInfo contains a stage number indicating the current phase of each
+// integration test, and a mutex.
+// Based on the stage number of current test, we will use different
+// certificates and custom verification functions to check if our tests behave
+// as expected.
 type stageInfo struct {
 	mutex sync.Mutex
 	stage int
@@ -67,13 +69,17 @@ func (s *stageInfo) reset() {
 
 // certStore contains all the certificates used in the integration tests.
 type certStore struct {
-	// clientPeer1 is the certificate sent by client to prove its identity. It is trusted by serverTrust1.
+	// clientPeer1 is the certificate sent by client to prove its identity.
+	// It is trusted by serverTrust1.
 	clientPeer1 tls.Certificate
-	// clientPeer2 is the certificate sent by client to prove its identity. It is trusted by serverTrust2.
+	// clientPeer2 is the certificate sent by client to prove its identity.
+	// It is trusted by serverTrust2.
 	clientPeer2 tls.Certificate
-	// serverPeer1 is the certificate sent by server to prove its identity. It is trusted by clientTrust1.
+	// serverPeer1 is the certificate sent by server to prove its identity.
+	// It is trusted by clientTrust1.
 	serverPeer1 tls.Certificate
-	// serverPeer2 is the certificate sent by server to prove its identity. It is trusted by clientTrust2.
+	// serverPeer2 is the certificate sent by server to prove its identity.
+	// It is trusted by clientTrust2.
 	serverPeer2  tls.Certificate
 	clientTrust1 *x509.CertPool
 	clientTrust2 *x509.CertPool
@@ -81,7 +87,8 @@ type certStore struct {
 	serverTrust2 *x509.CertPool
 }
 
-// loadCerts function is used to load test certificates at the beginning of each integration test.
+// loadCerts function is used to load test certificates at the beginning of
+// each integration test.
 func (cs *certStore) loadCerts() error {
 	var err error
 	cs.clientPeer1, err = tls.LoadX509KeyPair(testdata.Path("client_cert_1.pem"),
@@ -144,7 +151,8 @@ func callAndVerify(msg string, client pb.GreeterClient, shouldFail bool) error {
 func callAndVerifyWithClientConn(connCtx context.Context, msg string, creds credentials.TransportCredentials, shouldFail bool) (*grpc.ClientConn, pb.GreeterClient, error) {
 	var conn *grpc.ClientConn
 	var err error
-	// If we want the test to fail, we establish a non-blocking connection to avoid it hangs and killed by the context.
+	// If we want the test to fail, we establish a non-blocking connection to
+	// avoid it hangs and killed by the context.
 	if shouldFail {
 		conn, err = grpc.DialContext(connCtx, address, grpc.WithTransportCredentials(creds))
 		if err != nil {
@@ -166,10 +174,13 @@ func callAndVerifyWithClientConn(connCtx context.Context, msg string, creds cred
 
 // The advanced TLS features are tested in different stages.
 // At stage 0, we establish a good connection between client and server.
-// At stage 1, we change one factor(it could be we change the server's certificate, or custom verification function, etc),
-// and test if the following connections would be dropped.
-// At stage 2, we re-establish the connection by changing the counterpart of the factor we modified in stage 1.
-// (could be change the client's trust certificate, or change custom verification function, etc)
+// At stage 1, we change one factor(it could be we change the server's
+// certificate, or custom verification function, etc), and test if the
+// following connections would be dropped.
+// At stage 2, we re-establish the connection by changing the counterpart of
+// the factor we modified in stage 1.
+// (could be change the client's trust certificate, or change custom
+// verification function, etc)
 func TestEnd2End(t *testing.T) {
 	cs := &certStore{}
 	err := cs.loadCerts()
@@ -193,11 +204,16 @@ func TestEnd2End(t *testing.T) {
 		serverVType      VerificationType
 	}{
 		// Test Scenarios:
-		// At initialization(stage = 0), client will be initialized with cert clientPeer1 and clientTrust1, server with serverPeer1 and serverTrust1.
-		// The mutual authentication works at the beginning, since clientPeer1 is trusted by serverTrust1, and serverPeer1 by clientTrust1.
-		// At stage 1, client changes clientPeer1 to clientPeer2. Since clientPeer2 is not trusted by serverTrust1, following rpc calls are expected
-		// to fail, while the previous rpc calls are still good because those are already authenticated.
-		// At stage 2, the server changes serverTrust1 to serverTrust2, and we should see it again accepts the connection, since clientPeer2 is trusted
+		// At initialization(stage = 0), client will be initialized with cert
+		// clientPeer1 and clientTrust1, server with serverPeer1 and serverTrust1.
+		// The mutual authentication works at the beginning, since clientPeer1 is
+		// trusted by serverTrust1, and serverPeer1 by clientTrust1.
+		// At stage 1, client changes clientPeer1 to clientPeer2. Since clientPeer2
+		// is not trusted by serverTrust1, following rpc calls are expected to
+		// fail, while the previous rpc calls are still good because those are
+		// already authenticated.
+		// At stage 2, the server changes serverTrust1 to serverTrust2, and we
+		// should see it again accepts the connection, since clientPeer2 is trusted
 		// by serverTrust2.
 		{
 			desc:       "TestClientPeerCertReloadServerTrustCertReload",
@@ -233,11 +249,16 @@ func TestEnd2End(t *testing.T) {
 			serverVType: CertVerification,
 		},
 		// Test Scenarios:
-		// At initialization(stage = 0), client will be initialized with cert clientPeer1 and clientTrust1, server with serverPeer1 and serverTrust1.
-		// The mutual authentication works at the beginning, since clientPeer1 is trusted by serverTrust1, and serverPeer1 by clientTrust1.
-		// At stage 1, server changes serverPeer1 to serverPeer2. Since serverPeer2 is not trusted by clientTrust1, following rpc calls are expected
-		// to fail, while the previous rpc calls are still good because those are already authenticated.
-		// At stage 2, the client changes clientTrust1 to clientTrust2, and we should see it again accepts the connection, since serverPeer2 is trusted
+		// At initialization(stage = 0), client will be initialized with cert
+		// clientPeer1 and clientTrust1, server with serverPeer1 and serverTrust1.
+		// The mutual authentication works at the beginning, since clientPeer1 is
+		// trusted by serverTrust1, and serverPeer1 by clientTrust1.
+		// At stage 1, server changes serverPeer1 to serverPeer2. Since serverPeer2
+		// is not trusted by clientTrust1, following rpc calls are expected to
+		// fail, while the previous rpc calls are still good because those are
+		// already authenticated.
+		// At stage 2, the client changes clientTrust1 to clientTrust2, and we
+		// should see it again accepts the connection, since serverPeer2 is trusted
 		// by clientTrust2.
 		{
 			desc:          "TestServerPeerCertReloadClientTrustCertReload",
@@ -273,13 +294,18 @@ func TestEnd2End(t *testing.T) {
 			serverVType: CertVerification,
 		},
 		// Test Scenarios:
-		// At initialization(stage = 0), client will be initialized with cert clientPeer1 and clientTrust1, server with serverPeer1 and serverTrust1.
-		// The mutual authentication works at the beginning, since clientPeer1 trusted by serverTrust1, serverPeer1 by clientTrust1, and also the
+		// At initialization(stage = 0), client will be initialized with cert
+		// clientPeer1 and clientTrust1, server with serverPeer1 and serverTrust1.
+		// The mutual authentication works at the beginning, since clientPeer1
+		// trusted by serverTrust1, serverPeer1 by clientTrust1, and also the
 		// custom verification check allows the CommonName on serverPeer1.
-		// At stage 1, server changes serverPeer1 to serverPeer2, and client changes clientTrust1 to clientTrust2. Although serverPeer2 is trusted by
-		// clientTrust2, our authorization check only accepts serverPeer1, and hence the following calls should fail. Previous connections should
+		// At stage 1, server changes serverPeer1 to serverPeer2, and client
+		// changes clientTrust1 to clientTrust2. Although serverPeer2 is trusted by
+		// clientTrust2, our authorization check only accepts serverPeer1, and
+		// hence the following calls should fail. Previous connections should
 		// not be affected.
-		// At stage 2, the client changes authorization check to only accept serverPeer2. Now we should see the connection becomes normal again.
+		// At stage 2, the client changes authorization check to only accept
+		// serverPeer2. Now we should see the connection becomes normal again.
 		{
 			desc:          "TestClientCustomVerification",
 			clientCert:    []tls.Certificate{cs.clientPeer1},
@@ -337,12 +363,16 @@ func TestEnd2End(t *testing.T) {
 			serverVType: CertVerification,
 		},
 		// Test Scenarios:
-		// At initialization(stage = 0), client will be initialized with cert clientPeer1 and clientTrust1, server with serverPeer1 and serverTrust1.
-		// The mutual authentication works at the beginning, since clientPeer1 trusted by serverTrust1, serverPeer1 by clientTrust1, and also the
+		// At initialization(stage = 0), client will be initialized with cert
+		// clientPeer1 and clientTrust1, server with serverPeer1 and serverTrust1.
+		// The mutual authentication works at the beginning, since clientPeer1
+		// trusted by serverTrust1, serverPeer1 by clientTrust1, and also the
 		// custom verification check on server side allows all connections.
-		// At stage 1, server disallows the the connections by setting custom verification check. The following calls should fail. Previous
+		// At stage 1, server disallows the the connections by setting custom
+		// verification check. The following calls should fail. Previous
 		// connections should not be affected.
-		// At stage 2, server allows all the connections again and the authentications should go back to normal.
+		// At stage 2, server allows all the connections again and the
+		// authentications should go back to normal.
 		{
 			desc:          "TestServerCustomVerification",
 			clientCert:    []tls.Certificate{cs.clientPeer1},
@@ -415,7 +445,7 @@ func TestEnd2End(t *testing.T) {
 			if err != nil {
 				t.Fatalf("clientTLSCreds failed to create")
 			}
-			// ------------------------Scenario 1-----------------------------------------
+			// ------------------------Scenario 1------------------------------------
 			// stage = 0, initial connection should succeed
 			ctx1, cancel1 := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel1()
@@ -424,15 +454,15 @@ func TestEnd2End(t *testing.T) {
 				t.Fatal(err)
 			}
 			defer conn.Close()
-			// ---------------------------------------------------------------------------
+			// ----------------------------------------------------------------------
 			stage.increase()
-			// ------------------------Scenario 2-----------------------------------------
+			// ------------------------Scenario 2------------------------------------
 			// stage = 1, previous connection should still succeed
 			err = callAndVerify("rpc call 2", greetClient, false)
 			if err != nil {
 				t.Fatal(err)
 			}
-			// ------------------------Scenario 3-----------------------------------------
+			// ------------------------Scenario 3------------------------------------
 			// stage = 1, new connection should fail
 			ctx2, cancel2 := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel2()
@@ -441,9 +471,9 @@ func TestEnd2End(t *testing.T) {
 				t.Fatal(err)
 			}
 			defer conn2.Close()
-			//// ---------------------------------------------------------------------------
+			//// --------------------------------------------------------------------
 			stage.increase()
-			// ------------------------Scenario 4-----------------------------------------
+			// ------------------------Scenario 4------------------------------------
 			// stage = 2,  new connection should succeed
 			ctx3, cancel3 := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel3()
@@ -452,7 +482,7 @@ func TestEnd2End(t *testing.T) {
 				t.Fatal(err)
 			}
 			defer conn3.Close()
-			// ---------------------------------------------------------------------------
+			// ----------------------------------------------------------------------
 			stage.reset()
 		})
 	}

--- a/security/advancedtls/advancedtls_test.go
+++ b/security/advancedtls/advancedtls_test.go
@@ -92,10 +92,10 @@ func TestClientServerHandshake(t *testing.T) {
 		// Client: nil setting
 		// Server: only set serverCert with mutual TLS off
 		// Expected Behavior: server side failure
-		// Reason: if clientRoot, clientGetRoot and verifyFunc is not set, client side
-		// doesn't provide any verification mechanism. We don't allow this even setting
-		// vType to SkipVerification. Clients should at least provide their own
-		// verification logic.
+		// Reason: if clientRoot, clientGetRoot and verifyFunc is not set, client
+		// side doesn't provide any verification mechanism. We don't allow this
+		// even setting vType to SkipVerification. Clients should at least provide
+		// their own verification logic.
 		{
 			"Client_no_trust_cert_Server_peer_cert",
 			nil,
@@ -142,8 +142,9 @@ func TestClientServerHandshake(t *testing.T) {
 		// Client: only set clientRoot
 		// Server: only set serverCert with mutual TLS off
 		// Expected Behavior: server side failure and client handshake failure
-		// Reason: client side sets vType to CertAndHostVerification, and will do default
-		// hostname check. All the default hostname checks will fail in this test suites.
+		// Reason: client side sets vType to CertAndHostVerification, and will do
+		// default hostname check. All the default hostname checks will fail in
+		// this test suites.
 		{
 			"Client_root_cert_Server_peer_cert",
 			nil,
@@ -166,8 +167,9 @@ func TestClientServerHandshake(t *testing.T) {
 		// Client: only set clientGetRoot
 		// Server: only set serverCert with mutual TLS off
 		// Expected Behavior: server side failure and client handshake failure
-		// Reason: client side sets vType to CertAndHostVerification, and will do default
-		// hostname check. All the default hostname checks will fail in this test suites.
+		// Reason: client side sets vType to CertAndHostVerification, and will do
+		// default hostname check. All the default hostname checks will fail in
+		// this test suites.
 		{
 			"Client_reload_root_Server_peer_cert",
 			nil,
@@ -278,12 +280,12 @@ func TestClientServerHandshake(t *testing.T) {
 			false,
 		},
 		// Client: set clientGetRoot, clientVerifyFunc and clientCert
-		// Server: set serverCert, but not setting any of serverRoot, serverGetRoot or
-		// serverVerifyFunc, with mutual TLS on
+		// Server: set serverCert, but not setting any of serverRoot, serverGetRoot
+		// or serverVerifyFunc, with mutual TLS on
 		// Expected Behavior: server side failure
-		// Reason: server side needs to provide any verification mechanism when mTLS in on, even setting
-		// vType to SkipVerification. Servers should at least provide their own
-		// verification logic.
+		// Reason: server side needs to provide any verification mechanism when
+		// mTLS in on, even setting vType to SkipVerification. Servers should at
+		// least provide their own verification logic.
 		{
 			"Client_peer_cert_reload_root_verifyFuncGood_Server_no_verification_mutualTLS",
 			[]tls.Certificate{clientPeerCert},
@@ -326,7 +328,8 @@ func TestClientServerHandshake(t *testing.T) {
 			false,
 		},
 		// Client: set clientGetRoot, clientVerifyFunc and clientCert
-		// Server: set serverGetRoot returning error and serverCert with mutual TLS on
+		// Server: set serverGetRoot returning error and serverCert with mutual
+		// TLS on
 		// Expected Behavior: server side failure
 		// Reason: server side reloading returns failure
 		{
@@ -374,7 +377,8 @@ func TestClientServerHandshake(t *testing.T) {
 			CertVerification,
 			false,
 		},
-		// Client: set everything but with the wrong peer cert not trusted by server
+		// Client: set everything but with the wrong peer cert not trusted by
+		// server
 		// Server: set serverGetRoot and serverGetCert with mutual TLS on
 		// Expected Behavior: server side returns failure because of
 		// certificate mismatch
@@ -429,7 +433,8 @@ func TestClientServerHandshake(t *testing.T) {
 			true,
 		},
 		// Client: set clientGetRoot, clientVerifyFunc and clientCert
-		// Server: set everything but with the wrong peer cert not trusted by client
+		// Server: set everything but with the wrong peer cert not trusted by
+		// client
 		// Expected Behavior: server side and client side return failure due to
 		// certificate mismatch and handshake failure
 		{

--- a/security/advancedtls/advancedtls_test.go
+++ b/security/advancedtls/advancedtls_test.go
@@ -278,6 +278,32 @@ func TestClientServerHandshake(t *testing.T) {
 			false,
 		},
 		// Client: set clientGetRoot, clientVerifyFunc and clientCert
+		// Server: set serverCert, but not setting any of |serverRoot|, |serverGetRoot| or
+		// |serverVerifyFunc|, with mutual TLS on
+		// Expected Behavior: server side failure
+		// Reason: server side needs to provide any verification mechanism when mTLS in on, even setting
+		// |vType| to SkipVerification. Servers should at least provide their own
+		// verification logic.
+		{
+			"Client_peer_cert_reload_root_verifyFuncGood_Server_peer_cert_root_cert_mutualTLS",
+			[]tls.Certificate{clientPeerCert},
+			nil,
+			nil,
+			getRootCAsForClient,
+			verifyFuncGood,
+			CertVerification,
+			false,
+			true,
+			true,
+			[]tls.Certificate{serverPeerCert},
+			nil,
+			nil,
+			nil,
+			nil,
+			SkipVerification,
+			true,
+		},
+		// Client: set clientGetRoot, clientVerifyFunc and clientCert
 		// Server: set serverGetRoot and serverCert with mutual TLS on
 		// Expected Behavior: success
 		{
@@ -496,8 +522,8 @@ func TestClientServerHandshake(t *testing.T) {
 					GetRootCAs:  test.serverGetRoot,
 				},
 				RequireClientCert: test.serverMutualTLS,
-				VerifyPeer: test.serverVerifyFunc,
-				VType: test.serverVType,
+				VerifyPeer:        test.serverVerifyFunc,
+				VType:             test.serverVType,
 			}
 			go func(done chan credentials.AuthInfo, lis net.Listener, serverOptions *ServerOptions) {
 				serverRawConn, err := lis.Accept()

--- a/security/advancedtls/advancedtls_test.go
+++ b/security/advancedtls/advancedtls_test.go
@@ -77,7 +77,7 @@ func TestClientServerHandshake(t *testing.T) {
 		clientRoot                 *x509.CertPool
 		clientGetRoot              func(params *GetRootCAsParams) (*GetRootCAsResults, error)
 		clientVerifyFunc           CustomVerificationFunc
-		clientVType                VerificationAuthType
+		clientVType                VerificationType
 		clientExpectCreateError    bool
 		clientExpectHandshakeError bool
 		serverMutualTLS            bool
@@ -86,7 +86,7 @@ func TestClientServerHandshake(t *testing.T) {
 		serverRoot                 *x509.CertPool
 		serverGetRoot              func(params *GetRootCAsParams) (*GetRootCAsResults, error)
 		serverVerifyFunc           CustomVerificationFunc
-		serverVType                VerificationAuthType
+		serverVType                VerificationType
 		serverExpectError          bool
 	}{
 		// Client: nil setting

--- a/security/advancedtls/advancedtls_test.go
+++ b/security/advancedtls/advancedtls_test.go
@@ -92,9 +92,9 @@ func TestClientServerHandshake(t *testing.T) {
 		// Client: nil setting
 		// Server: only set serverCert with mutual TLS off
 		// Expected Behavior: server side failure
-		// Reason: if |clientRoot|, |clientGetRoot| and |verifyFunc| is not set, client side
+		// Reason: if clientRoot, clientGetRoot and verifyFunc is not set, client side
 		// doesn't provide any verification mechanism. We don't allow this even setting
-		// |vType| to SkipVerification. Clients should at least provide their own
+		// vType to SkipVerification. Clients should at least provide their own
 		// verification logic.
 		{
 			"Client_no_trust_cert_Server_peer_cert",
@@ -142,7 +142,7 @@ func TestClientServerHandshake(t *testing.T) {
 		// Client: only set clientRoot
 		// Server: only set serverCert with mutual TLS off
 		// Expected Behavior: server side failure and client handshake failure
-		// Reason: client side sets |vType| to CertAndHostVerification, and will do default
+		// Reason: client side sets vType to CertAndHostVerification, and will do default
 		// hostname check. All the default hostname checks will fail in this test suites.
 		{
 			"Client_root_cert_Server_peer_cert",
@@ -166,7 +166,7 @@ func TestClientServerHandshake(t *testing.T) {
 		// Client: only set clientGetRoot
 		// Server: only set serverCert with mutual TLS off
 		// Expected Behavior: server side failure and client handshake failure
-		// Reason: client side sets |vType| to CertAndHostVerification, and will do default
+		// Reason: client side sets vType to CertAndHostVerification, and will do default
 		// hostname check. All the default hostname checks will fail in this test suites.
 		{
 			"Client_reload_root_Server_peer_cert",
@@ -278,11 +278,11 @@ func TestClientServerHandshake(t *testing.T) {
 			false,
 		},
 		// Client: set clientGetRoot, clientVerifyFunc and clientCert
-		// Server: set serverCert, but not setting any of |serverRoot|, |serverGetRoot| or
-		// |serverVerifyFunc|, with mutual TLS on
+		// Server: set serverCert, but not setting any of serverRoot, serverGetRoot or
+		// serverVerifyFunc, with mutual TLS on
 		// Expected Behavior: server side failure
 		// Reason: server side needs to provide any verification mechanism when mTLS in on, even setting
-		// |vType| to SkipVerification. Servers should at least provide their own
+		// vType to SkipVerification. Servers should at least provide their own
 		// verification logic.
 		{
 			"Client_peer_cert_reload_root_verifyFuncGood_Server_no_verification_mutualTLS",

--- a/security/advancedtls/advancedtls_test.go
+++ b/security/advancedtls/advancedtls_test.go
@@ -285,7 +285,7 @@ func TestClientServerHandshake(t *testing.T) {
 		// |vType| to SkipVerification. Servers should at least provide their own
 		// verification logic.
 		{
-			"Client_peer_cert_reload_root_verifyFuncGood_Server_peer_cert_root_cert_mutualTLS",
+			"Client_peer_cert_reload_root_verifyFuncGood_Server_no_verification_mutualTLS",
 			[]tls.Certificate{clientPeerCert},
 			nil,
 			nil,
@@ -487,7 +487,7 @@ func TestClientServerHandshake(t *testing.T) {
 		// Expected Behavior: server side and client side return failure due to
 		// server custom check fails
 		{
-			"Client_peer_cert_reload_root_verifyFuncGood_Server_peer_cert_reload_root_mutualTLS",
+			"Client_peer_cert_reload_root_verifyFuncGood_Server_bad_custom_verification_mutualTLS",
 			[]tls.Certificate{clientPeerCert},
 			nil,
 			nil,


### PR DESCRIPTION
The main purpose of this PR is to set a new enum field `VerificationAuthType` for users to choose their own verification levels. Users could have three levels of verification: certificate and hostname check, certificate check only, and no check. The reasons for this change is:

  1. We used to determine which level users are intended to set by checking some particular fields, such as if user set the root credential reloading field, etc. This not only needs users to read comments carefully, but also add a lot of if-else statements in our code that is hard to debug. By asking users to explicitly choosing one level, in accompany with the custom verification check, we offer more flexible APIs for users.
  2. This is also to keep implementation align with other languages, like the constants [in C core](https://github.com/grpc/grpc/blob/2b200d2313e739fa1841edf3ea86ab8532862505/include/grpc/grpc_security_constants.h#L121-L133).

Note that with this change, we are able to provide better custom verification checks, both on client side and server side. Before, this feature is called "custom server authorization check", and only available on client side. Now since we also give server side the ability to choose "skip all verifications", server side also needs some "custom verification mechanism", so I changed the verification mechanism to apply to both sides, and updated the comments accordingly.
In sum, there should be no "custom server authorization check" any more, but instead "custom verification check".

I also added some unit tests and a new integration test for the newly added/changed behaviors.