### PR TITLE
kokora: checkout matching grpc/grpc branch for xds test

### DIFF
--- a/test/kokoro/xds.sh
+++ b/test/kokoro/xds.sh
@@ -7,12 +7,16 @@ cd github
 
 export GOPATH="${HOME}/gopath"
 pushd grpc-go/interop/xds/client
-BRANCH=$(git name-rev --name-only "${KOKORO_GITHUB_COMMIT}")
-BRANCH="${BRANCH#remotes/origin/}"
+branch=$(git branch --all --no-color --contains "${KOKORO_GITHUB_COMMIT}" \
+    | grep -v HEAD | head -1)
+shopt -s extglob
+branch="${branch//[[:space:]]}"
+branch="${branch##remotes/origin/}"
+shopt -u extglob
 go build
 popd
 
-git clone -b "${BRANCH}" https://github.com/grpc/grpc.git
+git clone -b "${branch}" https://github.com/grpc/grpc.git
 
 grpc/tools/run_tests/helper_scripts/prep_xds.sh
 GRPC_GO_LOG_VERBOSITY_LEVEL=99 GRPC_GO_LOG_SEVERITY_LEVEL=info \

--- a/test/kokoro/xds.sh
+++ b/test/kokoro/xds.sh
@@ -7,10 +7,11 @@ cd github
 
 export GOPATH="${HOME}/gopath"
 pushd grpc-go/interop/xds/client
+BRANCH="$(git rev-parse --abbrev-ref HEAD)"
 go build
 popd
 
-git clone https://github.com/grpc/grpc.git
+git clone -b "${BRANCH}" https://github.com/grpc/grpc.git
 
 grpc/tools/run_tests/helper_scripts/prep_xds.sh
 GRPC_GO_LOG_VERBOSITY_LEVEL=99 GRPC_GO_LOG_SEVERITY_LEVEL=info \

--- a/test/kokoro/xds.sh
+++ b/test/kokoro/xds.sh
@@ -7,7 +7,8 @@ cd github
 
 export GOPATH="${HOME}/gopath"
 pushd grpc-go/interop/xds/client
-BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+BRANCH=$(git name-rev --name-only "${KOKORO_GITHUB_COMMIT}")
+BRANCH="${BRANCH#remotes/origin/}"
 go build
 popd
 


### PR DESCRIPTION
This will enable the script to checkout the corresponding version of `run_xds_tests.py` from the `grpc/grpc` repo when running on release branches.

Another option would be hardcoding in the corresponding internal config file for the job on each branch, which would be passed to the script as an environment variable (Kokoro does not currently set the branch as one of the environment variables it automatically provides). This would work fine but require modifying the version number manually upon every release when creating the new config file, which could be slightly error prone. 

This will need to be backported to the v1.28.x branch to work :)

cc @menghanl 