### PR TITLE
alts: add trailing dot to metadata.google.internal

### DIFF
--- a/credentials/alts/alts.go
+++ b/credentials/alts/alts.go
@@ -42,7 +42,7 @@ import (
 const (
 	// hypervisorHandshakerServiceAddress represents the default ALTS gRPC
 	// handshaker service address in the hypervisor.
-	hypervisorHandshakerServiceAddress = "metadata.google.internal:8080"
+	hypervisorHandshakerServiceAddress = "metadata.google.internal.:8080"
 	// defaultTimeout specifies the server handshake timeout.
 	defaultTimeout = 30.0 * time.Second
 	// The following constants specify the minimum and maximum acceptable


### PR DESCRIPTION
See https://github.com/grpc/grpc/pull/17598 for discussion
This change will make it consistent with C++ and Java ALTS implementation.