### PR TITLE
channelz: Make staticchecker happy on darwin.

### DIFF
--- a/channelz/service/func_linux.go
+++ b/channelz/service/func_linux.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/golang/protobuf/ptypes"
+	durpb "github.com/golang/protobuf/ptypes/duration"
 	channelzpb "google.golang.org/grpc/channelz/grpc_channelz_v1"
 	"google.golang.org/grpc/internal/channelz"
 )

--- a/channelz/service/func_linux.go
+++ b/channelz/service/func_linux.go
@@ -21,10 +21,16 @@
 package service
 
 import (
+	"time"
+
 	"github.com/golang/protobuf/ptypes"
 	channelzpb "google.golang.org/grpc/channelz/grpc_channelz_v1"
 	"google.golang.org/grpc/internal/channelz"
 )
+
+func convertToPtypesDuration(sec int64, usec int64) *durpb.Duration {
+	return ptypes.DurationProto(time.Duration(sec*1e9 + usec*1e3))
+}
 
 func sockoptToProto(skopts *channelz.SocketOptionData) []*channelzpb.SocketOption {
 	var opts []*channelzpb.SocketOption

--- a/channelz/service/service.go
+++ b/channelz/service/service.go
@@ -24,10 +24,8 @@ package service
 import (
 	"context"
 	"net"
-	"time"
 
 	"github.com/golang/protobuf/ptypes"
-	durpb "github.com/golang/protobuf/ptypes/duration"
 	wrpb "github.com/golang/protobuf/ptypes/wrappers"
 	"google.golang.org/grpc"
 	channelzgrpc "google.golang.org/grpc/channelz/grpc_channelz_v1"
@@ -41,10 +39,6 @@ import (
 
 func init() {
 	channelz.TurnOn()
-}
-
-func convertToPtypesDuration(sec int64, usec int64) *durpb.Duration {
-	return ptypes.DurationProto(time.Duration(sec*1e9 + usec*1e3))
 }
 
 // RegisterChannelzServiceToServer registers the channelz service to the given server.


### PR DESCRIPTION
convertToPtypesDuration is used only in linux. So, moving to the linux
specific file so that the staticchecker does not complain on dawrin.

Fixes #2047

