### PR TITLE
rls: Rename type `picker` to `rlsPicker`.

### DIFF
--- a/balancer/rls/internal/picker.go
+++ b/balancer/rls/internal/picker.go
@@ -34,16 +34,16 @@ import (
 var errRLSThrottled = balancer.TransientFailureError(errors.New("RLS call throttled at client side"))
 
 // Compile time assert to ensure we implement V2Picker.
-var _ balancer.V2Picker = (*picker)(nil)
+var _ balancer.V2Picker = (*rlsPicker)(nil)
 
-// RLS picker selects the subConn to be used for a particular RPC. It does not
-// manage subConns directly and usually deletegates to pickers provided by
+// RLS rlsPicker selects the subConn to be used for a particular RPC. It does
+// not manage subConns directly and usually deletegates to pickers provided by
 // child policies.
 //
-// The RLS LB policy creates a new picker object whenever its ServiceConfig is
-// updated and provides a bunch of hooks for the picker to get the latest state
-// that it can used to make its decision.
-type picker struct {
+// The RLS LB policy creates a new rlsPicker object whenever its ServiceConfig
+// is updated and provides a bunch of hooks for the rlsPicker to get the latest
+// state that it can used to make its decision.
+type rlsPicker struct {
 	// The keyBuilder map used to generate RLS keys for the RPC. This is built
 	// by the LB policy based on the received ServiceConfig.
 	kbm keys.BuilderMap
@@ -52,17 +52,17 @@ type picker struct {
 	// to make the pick decision is not in the cache.
 	strategy rlspb.RouteLookupConfig_RequestProcessingStrategy
 
-	// The following hooks are setup by the LB policy to enable the picker to
+	// The following hooks are setup by the LB policy to enable the rlsPicker to
 	// access state stored in the policy. This approach has the following
 	// advantages:
-	// 1. The picker is loosely coupled with the LB policy in the sense that
+	// 1. The rlsPicker is loosely coupled with the LB policy in the sense that
 	//    updates happening on the LB policy like the receipt of an RLS
-	//    response, or an update to the default picker etc are not explicitly
-	//    pushed to the picker, but are readily available to the picker when it
-	//    invokes these hooks. And the LB policy takes care of synchronizing
-	//    access to these shared state.
-	// 2. It makes unit testing the picker easy since any number of these hooks
-	//    could be overridden.
+	//    response, or an update to the default rlsPicker etc are not explicitly
+	//    pushed to the rlsPicker, but are readily available to the rlsPicker
+	//    when it invokes these hooks. And the LB policy takes care of
+	//    synchronizing access to these shared state.
+	// 2. It makes unit testing the rlsPicker easy since any number of these
+	//    hooks could be overridden.
 
 	// readCache is used to read from the data cache and the pending request
 	// map in an atomic fashion. The first return parameter is the entry in the
@@ -78,23 +78,23 @@ type picker struct {
 	// updated upon receipt of a response. See implementation in the LB policy
 	// for details.
 	startRLS func(string, keys.KeyMap)
-	// defaultPick enables the picker to delegate the pick decision to the
-	// picker returned by the child LB policy pointing to the default target
+	// defaultPick enables the rlsPicker to delegate the pick decision to the
+	// rlsPicker returned by the child LB policy pointing to the default target
 	// specified in the service config.
 	defaultPick func(balancer.PickInfo) (balancer.PickResult, error)
 }
 
 // This helper function decides if the pick should delegate to the default
-// picker based on the request processing strategy. This is used when the data
-// cache does not have a valid entry for the current RPC and the RLS request is
-// throttled, or if the current data cache entry is in backoff.
-func (p *picker) shouldDelegateToDefault() bool {
+// rlsPicker based on the request processing strategy. This is used when the
+// data cache does not have a valid entry for the current RPC and the RLS
+// request is throttled, or if the current data cache entry is in backoff.
+func (p *rlsPicker) shouldDelegateToDefault() bool {
 	return p.strategy == rlspb.RouteLookupConfig_SYNC_LOOKUP_DEFAULT_TARGET_ON_ERROR ||
 		p.strategy == rlspb.RouteLookupConfig_ASYNC_LOOKUP_DEFAULT_TARGET_ON_MISS
 }
 
 // Pick makes the routing decision for every outbound RPC.
-func (p *picker) Pick(info balancer.PickInfo) (balancer.PickResult, error) {
+func (p *rlsPicker) Pick(info balancer.PickInfo) (balancer.PickResult, error) {
 	// For every incoming request, we first build the RLS keys using the
 	// keyBuilder we received from the LB policy. If no metadata is present in
 	// the context, we end up using an empty key.
@@ -150,8 +150,8 @@ func (p *picker) Pick(info balancer.PickInfo) (balancer.PickResult, error) {
 			return entry.ChildPicker.Pick(info)
 		} else if entry.BackoffTime.After(now) {
 			// The entry has expired, but is in backoff. We either delegate to
-			// the default picker or return the error from the last failed RLS
-			// request for this entry.
+			// the default rlsPicker or return the error from the last failed
+			// RLS request for this entry.
 			if p.shouldDelegateToDefault() {
 				return p.defaultPick(info)
 			}
@@ -163,8 +163,8 @@ func (p *picker) Pick(info balancer.PickInfo) (balancer.PickResult, error) {
 	// was not in backoff (which is also essentially equivalent to not finding
 	// an entry), and we started an RLS request in the background. We either
 	// queue the pick or delegate to the default pick. In the former case, upon
-	// receipt of an RLS response, the LB policy will send a new picker to the
-	// channel, and the pick will be retried.
+	// receipt of an RLS response, the LB policy will send a new rlsPicker to
+	// the channel, and the pick will be retried.
 	if p.strategy == rlspb.RouteLookupConfig_SYNC_LOOKUP_DEFAULT_TARGET_ON_ERROR ||
 		p.strategy == rlspb.RouteLookupConfig_SYNC_LOOKUP_CLIENT_SEES_ERROR {
 		return balancer.PickResult{}, balancer.ErrNoSubConnAvailable

--- a/balancer/rls/internal/picker_test.go
+++ b/balancer/rls/internal/picker_test.go
@@ -59,7 +59,7 @@ func initKeyBuilderMap() (keys.BuilderMap, error) {
 }
 
 // fakeSubConn embeds the balancer.SubConn interface and contains an id which
-// helps verify that the expected subConn was returned by the picker.
+// helps verify that the expected subConn was returned by the rlsPicker.
 type fakeSubConn struct {
 	balancer.SubConn
 	id int
@@ -74,8 +74,8 @@ func (p *fakeChildPicker) Pick(_ balancer.PickInfo) (balancer.PickResult, error)
 	return balancer.PickResult{SubConn: &fakeSubConn{id: p.id}}, nil
 }
 
-// TestPickKeyBuilder verifies the different possible scenarios for
-// forming an RLS key for an incoming RPC.
+// TestPickKeyBuilder verifies the different possible scenarios for forming an
+// RLS key for an incoming RPC.
 func TestPickKeyBuilder(t *testing.T) {
 	kbm, err := initKeyBuilderMap()
 	if err != nil {
@@ -111,12 +111,12 @@ func TestPickKeyBuilder(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
 			randID := grpcrand.Intn(math.MaxInt32)
-			p := picker{
+			p := rlsPicker{
 				kbm:      kbm,
 				strategy: rlspb.RouteLookupConfig_SYNC_LOOKUP_DEFAULT_TARGET_ON_ERROR,
 				readCache: func(key cache.Key) (*cache.Entry, bool) {
 					if !cmp.Equal(key, test.wantKey) {
-						t.Fatalf("picker using cacheKey %v, want %v", key, test.wantKey)
+						t.Fatalf("rlsPicker using cacheKey %v, want %v", key, test.wantKey)
 					}
 
 					now := time.Now()
@@ -124,7 +124,7 @@ func TestPickKeyBuilder(t *testing.T) {
 						ExpiryTime: now.Add(defaultTestMaxAge),
 						StaleTime:  now.Add(defaultTestMaxAge),
 						// Cache entry is configured with a child policy whose
-						// picker always returns an empty PickResult and nil
+						// rlsPicker always returns an empty PickResult and nil
 						// error.
 						ChildPicker: &fakeChildPicker{id: randID},
 					}, false
@@ -180,9 +180,9 @@ func TestPick(t *testing.T) {
 		// Whether or not the test ends up delegating to the child policy in
 		// the cache entry.
 		useChildPick bool
-		// Request processing strategy as used by the picker.
+		// Request processing strategy as used by the rlsPicker.
 		strategy rlspb.RouteLookupConfig_RequestProcessingStrategy
-		// Expected error returned by the picker under test.
+		// Expected error returned by the rlsPicker under test.
 		wantErr error
 	}{
 		{
@@ -510,7 +510,7 @@ func TestPick(t *testing.T) {
 			// useChidlPick or useDefaultPick is set in the test.
 			childPicker := &fakeChildPicker{id: randID}
 
-			p := picker{
+			p := rlsPicker{
 				kbm:      kbm,
 				strategy: test.strategy,
 				readCache: func(key cache.Key) (*cache.Entry, bool) {
@@ -555,8 +555,8 @@ func TestPick(t *testing.T) {
 			}
 			if test.useChildPick || test.useDefaultPick {
 				// For cases where the pick is not queued, but is delegated to
-				// either the child picker or the default picker, we verify that
-				// the expected fakeSubConn is returned.
+				// either the child rlsPicker or the default rlsPicker, we
+				// verify that the expected fakeSubConn is returned.
 				sc, ok := gotResult.SubConn.(*fakeSubConn)
 				if !ok {
 					t.Fatalf("Pick() returned a SubConn of type %T, want %T", gotResult.SubConn, &fakeSubConn{})


### PR DESCRIPTION
This change only renames the type and reformats comment lines. No change
in functionality. The rename was deemed necessary once I started
implementing the balancer and wanted to be consistent. The builder is
named `rlsBB`, the balancer is named `rlsBalancer`, so the picker should
be `rlsPicker`. Also, this rename allows the field in the balancer which
caches the last picker to be named `picker`.