### PR TITLE
kokoro: allow individual test case logs for xds

### DIFF
--- a/test/kokoro/xds.cfg
+++ b/test/kokoro/xds.cfg
@@ -3,3 +3,9 @@
 # Location of the continuous shell script in repository.
 build_file: "grpc-go/test/kokoro/xds.sh"
 timeout_mins: 90
+action {
+  define_artifacts {
+    regex: "**/*sponge_log.*"
+    regex: "github/grpc/reports/**"
+  }
+}

--- a/test/kokoro/xds.sh
+++ b/test/kokoro/xds.sh
@@ -16,7 +16,7 @@ shopt -u extglob
 go build
 popd
 
-git clone -b "${branch}" https://github.com/grpc/grpc.git
+git clone -b "${branch}" --single-branch --depth=1 https://github.com/grpc/grpc.git
 
 grpc/tools/run_tests/helper_scripts/prep_xds.sh
 GRPC_GO_LOG_VERBOSITY_LEVEL=99 GRPC_GO_LOG_SEVERITY_LEVEL=info \


### PR DESCRIPTION
Also reduce the size of the grpc/grpc download

Analog of https://github.com/grpc/grpc-java/pull/6857. This allows Kokoro to upload individual test logs for easier viewing on sponge/dashboards.

cc @menghanl 