### PR TITLE
server: allow PreparedMsgs to work for server streams

### DIFF
--- a/server.go
+++ b/server.go
@@ -1521,6 +1521,8 @@ func (s *Server) processStreamingRPC(t transport.ServerTransport, stream *transp
 		}
 	}
 
+	ss.ctx = newContextWithRPCInfo(ss.ctx, false, ss.codec, ss.cp, ss.comp)
+
 	if trInfo != nil {
 		trInfo.tr.LazyLog(&trInfo.firstLine, false)
 	}


### PR DESCRIPTION
Using `PreparedMsg` in `ServerStream` to fix #3489.