### PR TITLE
Honor NO_PROXY when using dns scheme

### DIFF
--- a/clientconn.go
+++ b/clientconn.go
@@ -193,16 +193,6 @@ func DialContext(ctx context.Context, target string, opts ...DialOption) (conn *
 	}
 	cc.mkp = cc.dopts.copts.KeepaliveParams
 
-	if cc.dopts.copts.Dialer == nil {
-		cc.dopts.copts.Dialer = func(ctx context.Context, addr string) (net.Conn, error) {
-			network, addr := parseDialTarget(addr)
-			return (&net.Dialer{}).DialContext(ctx, network, addr)
-		}
-		if cc.dopts.withProxy {
-			cc.dopts.copts.Dialer = newProxyDialer(cc.dopts.copts.Dialer)
-		}
-	}
-
 	if cc.dopts.copts.UserAgent != "" {
 		cc.dopts.copts.UserAgent += " " + grpcUA
 	} else {
@@ -254,6 +244,16 @@ func DialContext(ctx context.Context, target string, opts ...DialOption) (conn *
 		resolverBuilder = cc.getResolver(cc.parsedTarget.Scheme)
 		if resolverBuilder == nil {
 			return nil, fmt.Errorf("could not get resolver for default scheme: %q", cc.parsedTarget.Scheme)
+		}
+	}
+
+	if cc.dopts.copts.Dialer == nil {
+		cc.dopts.copts.Dialer = func(ctx context.Context, addr string) (net.Conn, error) {
+			network, addr := parseDialTarget(addr)
+			return (&net.Dialer{}).DialContext(ctx, network, addr)
+		}
+		if cc.dopts.withProxy {
+			cc.dopts.copts.Dialer = newProxyDialer(cc.dopts.copts.Dialer, cc.parsedTarget.Endpoint)
 		}
 	}
 

--- a/proxy.go
+++ b/proxy.go
@@ -118,10 +118,10 @@ func doHTTPConnectHandshake(ctx context.Context, conn net.Conn, backendAddr stri
 // newProxyDialer returns a dialer that connects to proxy first if necessary.
 // The returned dialer checks if a proxy is necessary, dial to the proxy with the
 // provided dialer, does HTTP CONNECT handshake and returns the connection.
-func newProxyDialer(dialer func(context.Context, string) (net.Conn, error)) func(context.Context, string) (net.Conn, error) {
+func newProxyDialer(dialer func(context.Context, string) (net.Conn, error), endpoint string) func(context.Context, string) (net.Conn, error) {
 	return func(ctx context.Context, addr string) (conn net.Conn, err error) {
 		var newAddr string
-		proxyURL, err := mapAddress(ctx, addr)
+		proxyURL, err := mapAddress(ctx, endpoint)
 		if err != nil {
 			if err != errDisabled {
 				return nil, err

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -143,7 +143,7 @@ func testHTTPConnect(t *testing.T, proxyURLModify func(*url.URL) *url.URL, proxy
 			return net.DialTimeout("tcp", addr, time.Until(deadline))
 		}
 		return net.Dial("tcp", addr)
-	})
+	}, blis.Addr().String())
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 	c, err := dialer(ctx, blis.Addr().String())


### PR DESCRIPTION
https://github.com/grpc/grpc-go/issues/3401

WIP for comment, if it is an acceptable approach then I'll attempt some tests to
confirm.
 
Use the endpoint name rather than any resolved IPs when
calculating whether we should use any proxy as defined
in the environment, specifically so the domain name can
be compared against the NO_PROXY list.

Moves the dialer construction after assigning the parsedTarget so we can use the Endpoint