### PR TITLE
balancer: change roundrobin to accept empty address list

### DIFF
--- a/balancer/base/balancer.go
+++ b/balancer/base/balancer.go
@@ -20,7 +20,6 @@ package base
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"google.golang.org/grpc/balancer"
@@ -113,10 +112,6 @@ func (b *baseBalancer) UpdateClientConnState(s balancer.ClientConnState) error {
 	if grpclog.V(2) {
 		grpclog.Infoln("base.baseBalancer: got new ClientConn state: ", s)
 	}
-	if len(s.ResolverState.Addresses) == 0 {
-		b.ResolverError(errors.New("produced zero addresses"))
-		return balancer.ErrBadResolverState
-	}
 	// Successful resolution; clear resolver error and ensure we return nil.
 	b.resolverErr = nil
 	// addrsSet is the set converted from addrs, it's used for quick lookup of an address.
@@ -143,6 +138,11 @@ func (b *baseBalancer) UpdateClientConnState(s balancer.ClientConnState) error {
 			// Keep the state of this sc in b.scStates until sc's state becomes Shutdown.
 			// The entry will be deleted in HandleSubConnStateChange.
 		}
+	}
+	// If resolver state contains no addresses, return an error so ClientConn
+	// will trigger re-resolve.
+	if len(s.ResolverState.Addresses) == 0 {
+		return balancer.ErrBadResolverState
 	}
 	return nil
 }

--- a/balancer/base/balancer.go
+++ b/balancer/base/balancer.go
@@ -20,6 +20,7 @@ package base
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"google.golang.org/grpc/balancer"
@@ -140,8 +141,11 @@ func (b *baseBalancer) UpdateClientConnState(s balancer.ClientConnState) error {
 		}
 	}
 	// If resolver state contains no addresses, return an error so ClientConn
-	// will trigger re-resolve.
+	// will trigger re-resolve. Also records this as an resolver error, so when
+	// the overall state turns transient failure, the error message will have
+	// the zero address information.
 	if len(s.ResolverState.Addresses) == 0 {
+		b.ResolverError(errors.New("produced zero addresses"))
 		return balancer.ErrBadResolverState
 	}
 	return nil

--- a/balancer/roundrobin/roundrobin_test.go
+++ b/balancer/roundrobin/roundrobin_test.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -216,31 +215,19 @@ func (s) TestAddressesRemoved(t *testing.T) {
 	}
 
 	r.UpdateState(resolver.State{Addresses: []resolver.Address{}})
-	// Removing addresses results in an error reported to the clientconn, but
-	// the existing connections remain.  RPCs should still succeed.
-	ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	if _, err := testc.EmptyCall(ctx, &testpb.Empty{}, grpc.WaitForReady(true)); err != nil {
-		t.Fatalf("EmptyCall() = _, %v, want _, <nil>", err)
-	}
 
-	// Stop the server to bring the channel state into transient failure.
-	test.cleanup()
-	// Wait for not-ready.
-	for src := cc.GetState(); src == connectivity.Ready; src = cc.GetState() {
-		if !cc.WaitForStateChange(ctx, src) {
-			t.Fatalf("timed out waiting for state change.  got %v; want !%v", src, connectivity.Ready)
+	ctx2, cancel2 := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel2()
+	// Wait for state to change to transient failure.
+	for src := cc.GetState(); src != connectivity.TransientFailure; src = cc.GetState() {
+		if !cc.WaitForStateChange(ctx2, src) {
+			t.Fatalf("timed out waiting for state change.  got %v; want %v", src, connectivity.TransientFailure)
 		}
 	}
-	// Report an empty server list again; because the state is not ready, the
-	// empty address list error should surface to the user.
-	r.UpdateState(resolver.State{Addresses: []resolver.Address{}})
 
-	const msgWant = "produced zero addresses"
-	if _, err := testc.EmptyCall(ctx, &testpb.Empty{}); err == nil || !strings.Contains(status.Convert(err).Message(), msgWant) {
-		t.Fatalf("EmptyCall() = _, %v, want _, Contains(Message(), %q)", err, msgWant)
+	if _, err := testc.EmptyCall(ctx2, &testpb.Empty{}, grpc.WaitForReady(true)); status.Code(err) != codes.DeadlineExceeded {
+		t.Fatalf("Want RPC to fail with DeadlineExceeded after removing all addresses")
 	}
-
 }
 
 func (s) TestCloseWithPendingRPC(t *testing.T) {

--- a/balancer/roundrobin/roundrobin_test.go
+++ b/balancer/roundrobin/roundrobin_test.go
@@ -216,7 +216,7 @@ func (s) TestAddressesRemoved(t *testing.T) {
 
 	r.UpdateState(resolver.State{Addresses: []resolver.Address{}})
 
-	ctx2, cancel2 := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	ctx2, cancel2 := context.WithTimeout(context.Background(), 500*time.Millisecond)
 	defer cancel2()
 	// Wait for state to change to transient failure.
 	for src := cc.GetState(); src != connectivity.TransientFailure; src = cc.GetState() {

--- a/balancer/roundrobin/roundrobin_test.go
+++ b/balancer/roundrobin/roundrobin_test.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -225,8 +226,9 @@ func (s) TestAddressesRemoved(t *testing.T) {
 		}
 	}
 
-	if _, err := testc.EmptyCall(ctx2, &testpb.Empty{}, grpc.WaitForReady(true)); status.Code(err) != codes.DeadlineExceeded {
-		t.Fatalf("Want RPC to fail with DeadlineExceeded after removing all addresses")
+	const msgWant = "produced zero addresses"
+	if _, err := testc.EmptyCall(ctx2, &testpb.Empty{}); err == nil || !strings.Contains(status.Convert(err).Message(), msgWant) {
+		t.Fatalf("EmptyCall() = _, %v, want _, Contains(Message(), %q)", err, msgWant)
 	}
 }
 

--- a/xds/internal/balancer/edsbalancer/eds_impl_priority_test.go
+++ b/xds/internal/balancer/edsbalancer/eds_impl_priority_test.go
@@ -699,8 +699,13 @@ func (s) TestEDSPriority_HighPriorityAllUnhealthy(t *testing.T) {
 
 	// p0 will remove the subconn, and ClientConn will send a sc update to
 	// transient failure.
-	scToRemove := <-cc.removeSubConnCh
-	edsb.HandleSubConnStateChange(scToRemove, connectivity.TransientFailure)
+	var scToRemove balancer.SubConn
+	select {
+	case <-time.After(time.Second):
+		t.Fatalf("lalala")
+	case scToRemove = <-cc.removeSubConnCh:
+	}
+	edsb.HandleSubConnStateChange(scToRemove, connectivity.Shutdown)
 
 	var addrs2 []resolver.Address
 	select {

--- a/xds/internal/balancer/edsbalancer/eds_impl_priority_test.go
+++ b/xds/internal/balancer/edsbalancer/eds_impl_priority_test.go
@@ -57,7 +57,6 @@ func (s) TestEDSPriority_HighPriorityReady(t *testing.T) {
 	p1 := <-cc.newPickerCh
 	want := []balancer.SubConn{sc1}
 	if err := isRoundRobin(want, subConnFromPicker(p1)); err != nil {
-		// t.Fatalf("want %v, got %v", want, err)
 		t.Fatalf("want %v, got %v", want, err)
 	}
 
@@ -124,7 +123,6 @@ func (s) TestEDSPriority_SwitchPriority(t *testing.T) {
 	p0 := <-cc.newPickerCh
 	want := []balancer.SubConn{sc0}
 	if err := isRoundRobin(want, subConnFromPicker(p0)); err != nil {
-		// t.Fatalf("want %v, got %v", want, err)
 		t.Fatalf("want %v, got %v", want, err)
 	}
 
@@ -427,7 +425,6 @@ func (s) TestEDSPriority_MultipleLocalities(t *testing.T) {
 	p0 := <-cc.newPickerCh
 	want := []balancer.SubConn{sc0}
 	if err := isRoundRobin(want, subConnFromPicker(p0)); err != nil {
-		// t.Fatalf("want %v, got %v", want, err)
 		t.Fatalf("want %v, got %v", want, err)
 	}
 
@@ -446,7 +443,6 @@ func (s) TestEDSPriority_MultipleLocalities(t *testing.T) {
 	p1 := <-cc.newPickerCh
 	want = []balancer.SubConn{sc1}
 	if err := isRoundRobin(want, subConnFromPicker(p1)); err != nil {
-		// t.Fatalf("want %v, got %v", want, err)
 		t.Fatalf("want %v, got %v", want, err)
 	}
 
@@ -686,7 +682,6 @@ func (s) TestEDSPriority_HighPriorityNoEndpoints(t *testing.T) {
 	p1 := <-cc.newPickerCh
 	want := []balancer.SubConn{sc1}
 	if err := isRoundRobin(want, subConnFromPicker(p1)); err != nil {
-		// t.Fatalf("want %v, got %v", want, err)
 		t.Fatalf("want %v, got %v", want, err)
 	}
 
@@ -746,7 +741,6 @@ func (s) TestEDSPriority_HighPriorityAllUnhealthy(t *testing.T) {
 	p1 := <-cc.newPickerCh
 	want := []balancer.SubConn{sc1}
 	if err := isRoundRobin(want, subConnFromPicker(p1)); err != nil {
-		// t.Fatalf("want %v, got %v", want, err)
 		t.Fatalf("want %v, got %v", want, err)
 	}
 

--- a/xds/internal/balancer/edsbalancer/eds_impl_priority_test.go
+++ b/xds/internal/balancer/edsbalancer/eds_impl_priority_test.go
@@ -715,7 +715,6 @@ func (s) TestEDSPriority_HighPriorityNoEndpoints(t *testing.T) {
 	p2 := <-cc.newPickerCh
 	want = []balancer.SubConn{sc2}
 	if err := isRoundRobin(want, subConnFromPicker(p2)); err != nil {
-		// t.Fatalf("want %v, got %v", want, err)
 		t.Fatalf("want %v, got %v", want, err)
 	}
 }
@@ -778,7 +777,6 @@ func (s) TestEDSPriority_HighPriorityAllUnhealthy(t *testing.T) {
 	p2 := <-cc.newPickerCh
 	want = []balancer.SubConn{sc2}
 	if err := isRoundRobin(want, subConnFromPicker(p2)); err != nil {
-		// t.Fatalf("want %v, got %v", want, err)
 		t.Fatalf("want %v, got %v", want, err)
 	}
 }


### PR DESCRIPTION
Roundrobin will remove all SubConns. The ClientConn will set SubConn state change to shutdown, and the overall state will turn transient failure.