### PR TITLE
xds: update nonce even if the ACK/NACK is not sent on wire

### DIFF
--- a/xds/internal/client/types.go
+++ b/xds/internal/client/types.go
@@ -72,8 +72,12 @@ func (wi *watchInfo) stopTimer() {
 
 type ackInfo struct {
 	typeURL string
-	version string // Nack if version is an empty string.
+	version string // NACK if version is an empty string.
 	nonce   string
+	// ACK/NACK are tagged with the stream it's for. When the stream is down,
+	// all the ACK/NACK for this stream will be dropped, and the version/nonce
+	// won't be updated.
+	stream adsStream
 }
 
 type ldsUpdate struct {

--- a/xds/internal/client/v2client_ack_test.go
+++ b/xds/internal/client/v2client_ack_test.go
@@ -263,3 +263,114 @@ func (s) TestV2ClientAckNackAfterNewWatch(t *testing.T) {
 	sendGoodResp(t, "LDS", fakeServer, versionLDS, goodLDSResponse1, goodLDSRequest, cbLDS)
 	versionLDS++
 }
+
+// TestV2ClientAckNewWatchAfterCancel verifies the new request for a new watch
+// after the previous watch is canceled, has the right version.
+//
+// This test also verifies the version for different types are independent.
+func (s) TestV2ClientAckNewWatchAfterCancel(t *testing.T) {
+	var versionCDS = 3000
+
+	fakeServer, cc, cleanup := startServerAndGetCC(t)
+	defer cleanup()
+	v2c := newV2Client(cc, goodNodeProto, func(int) time.Duration { return 0 }, nil)
+	defer v2c.close()
+	t.Log("Started xds v2Client...")
+
+	// Start a CDS watch.
+	callbackCh := testutils.NewChannel()
+	cancel := v2c.watchCDS(goodClusterName1, func(u CDSUpdate, err error) {
+		t.Logf("Received %s callback with ldsUpdate {%+v} and error {%v}", "CDS", u, err)
+		callbackCh.Send(struct{}{})
+	})
+	if err := compareXDSRequest(fakeServer.XDSRequestChan, goodCDSRequest, "", ""); err != nil {
+		t.Fatalf("Failed to receive %s request: %v", "CDS", err)
+	}
+	t.Logf("FakeServer received %s request...", "CDS")
+
+	// Send a good CDS response, this function waits for the ACK with the right
+	// version.
+	nonce := sendGoodResp(t, "CDS", fakeServer, versionCDS, goodCDSResponse1, goodCDSRequest, callbackCh)
+
+	// Cancel the CDS watch, and start a new one. The new watch should have the
+	// version from the response above.
+	cancel()
+	v2c.watchCDS(goodClusterName1, func(u CDSUpdate, err error) {
+		t.Logf("Received %s callback with ldsUpdate {%+v} and error {%v}", "CDS", u, err)
+		callbackCh.Send(struct{}{})
+	})
+	if err := compareXDSRequest(fakeServer.XDSRequestChan, goodCDSRequest, strconv.Itoa(versionCDS), nonce); err != nil {
+		t.Fatalf("Failed to receive %s request: %v", "CDS", err)
+	}
+	versionCDS++
+
+	// Send a bad response with the next version.
+	sendBadResp(t, "CDS", fakeServer, versionCDS, goodCDSRequest)
+	versionCDS++
+
+	// send another good response, and check for ack, with the new version.
+	sendGoodResp(t, "CDS", fakeServer, versionCDS, goodCDSResponse1, goodCDSRequest, callbackCh)
+	versionCDS++
+}
+
+// TestV2ClientAckCancelResponseRace verifies if the response and ACK request
+// race with cancel (which means the ACK request will not be sent on wire,
+// because there's no active watch), the version will still be updates, and the
+// new request with the new watch will have the correct version number.
+//
+// This test also verifies the version for different types are independent.
+func (s) TestV2ClientAckCancelResponseRace(t *testing.T) {
+	var versionCDS = 3000
+
+	fakeServer, cc, cleanup := startServerAndGetCC(t)
+	defer cleanup()
+	v2c := newV2Client(cc, goodNodeProto, func(int) time.Duration { return 0 }, nil)
+	defer v2c.close()
+	t.Log("Started xds v2Client...")
+
+	// Start a CDS watch.
+	callbackCh := testutils.NewChannel()
+	cancel := v2c.watchCDS(goodClusterName1, func(u CDSUpdate, err error) {
+		t.Logf("Received %s callback with ldsUpdate {%+v} and error {%v}", "CDS", u, err)
+		callbackCh.Send(struct{}{})
+	})
+	if err := compareXDSRequest(fakeServer.XDSRequestChan, goodCDSRequest, "", ""); err != nil {
+		t.Fatalf("Failed to receive %s request: %v", "CDS", err)
+	}
+	t.Logf("FakeServer received %s request...", "CDS")
+
+	// send another good response, and check for ack, with the new version.
+	sendGoodResp(t, "CDS", fakeServer, versionCDS, goodCDSResponse1, goodCDSRequest, callbackCh)
+	versionCDS++
+
+	// Cancel the watch before the next response is sent. This mimics the case
+	// watch is canceled while response is on wire.
+	cancel()
+
+	// Send a good response.
+	nonce := sendXDSRespWithVersion(fakeServer.XDSResponseChan, goodCDSResponse1, versionCDS)
+	t.Logf("Good %s response pushed to fakeServer...", "CDS")
+
+	// Expect no ACK because watch was canceled.
+	if req, err := fakeServer.XDSRequestChan.Receive(); err != testutils.ErrRecvTimeout {
+		t.Fatalf("Got unexpected xds request after watch is canceled: %v", req)
+	}
+
+	// Start a new watch. The new watch should have the nonce from the response
+	// above, and version from the first good response.
+	v2c.watchCDS(goodClusterName1, func(u CDSUpdate, err error) {
+		t.Logf("Received %s callback with ldsUpdate {%+v} and error {%v}", "CDS", u, err)
+		callbackCh.Send(struct{}{})
+	})
+	if err := compareXDSRequest(fakeServer.XDSRequestChan, goodCDSRequest, strconv.Itoa(versionCDS-1), nonce); err != nil {
+		t.Fatalf("Failed to receive %s request: %v", "CDS", err)
+	}
+
+	// Send a bad response with the next version.
+	sendBadResp(t, "CDS", fakeServer, versionCDS, goodCDSRequest)
+	versionCDS++
+
+	// send another good response, and check for ack, with the new version.
+	sendGoodResp(t, "CDS", fakeServer, versionCDS, goodCDSResponse1, goodCDSRequest, callbackCh)
+	versionCDS++
+}


### PR DESCRIPTION
This can happen when the watch is canceled while the response is on wire.

Also, tag ACK/NACK with the stream so nonce for a new stream doesn't get updated by a ACK from the previous stream.