### PR TITLE
Add type aliases to honour go compatibility promise

### DIFF
--- a/balancer/v1api_aliases.go
+++ b/balancer/v1api_aliases.go
@@ -1,0 +1,7 @@
+package balancer
+
+// These type aliases should be removed when this project reaches
+// major version 2. They exist so we can stabilize the API on the
+// correct names, whilst preserving the Go compatibility promise.
+
+type PickOptions = PickInfo

--- a/resolver/v1api_aliases.go
+++ b/resolver/v1api_aliases.go
@@ -1,0 +1,8 @@
+package resolver
+
+// These type aliases should be removed when this project reaches
+// major version 2. They exist so we can stabilize the API on the
+// correct names, whilst preserving the Go compatibility promise.
+
+type BuildOption = BuildOptions
+type ResolveNowOption = ResolveNowOptions


### PR DESCRIPTION
As noted in https://github.com/grpc/grpc-go/issues/3180#issuecomment-609804749 there are different libraries which depend on different versions of this library, within major version 1, that contain API differences. An example pair of these is [go.etcd.io/etcd v3.4.7](https://github.com/etcd-io/etcd/blob/v3.4.7/go.mod#L46) and [cloud.google.com/go v0.56.0](https://github.com/googleapis/google-cloud-go/blob/v0.56.0/go.mod#L27) which require v1.23.1 and v1.28.0 of this library, respectively. Between these two versions, [non-backwards compatible changes were made to the names of 3 types in 2 packages](https://github.com/grpc/grpc-go/issues/3180#issue-523118753) in this module. This breaks Go's [required compatibility](https://blog.golang.org/publishing-go-modules) for modules sharing an import path (i.e. with the same major version) Other Go modules are hence unable to import these libraries because the Go tool assumes that all code within a major version API-compatible.

This change adds type aliases so that as of the next minor or patch release this module will again be API-compatible with all downstream modules that depend on major version 1 (once they get around to updating their version requirements accordingly).

The type aliases are in their own files so that when releasing major version 2 eventually, they can simply be deleted.