### PR TITLE
Properly release the buffer created by make([]byte, frameLimit) after…

### DIFF
--- a/credentials/alts/internal/handshaker/handshaker.go
+++ b/credentials/alts/internal/handshaker/handshaker.go
@@ -246,6 +246,8 @@ func (h *altsHandshaker) ServerHandshake(ctx context.Context) (net.Conn, credent
 	if err != nil {
 		return nil, nil, err
 	}
+	inBytes := make([]byte, n)
+	copy(inBytes, p)
 
 	// Prepare server parameters.
 	// TODO: currently only ALTS parameters are provided. Might need to use
@@ -259,7 +261,7 @@ func (h *altsHandshaker) ServerHandshake(ctx context.Context) (net.Conn, credent
 			ServerStart: &altspb.StartServerHandshakeReq{
 				ApplicationProtocols: appProtocols,
 				HandshakeParameters:  params,
-				InBytes:              p[:n],
+				InBytes:              inBytes,
 				RpcVersions:          h.serverOpts.RPCVersions,
 			},
 		},


### PR DESCRIPTION
… it finishes reading in ALTS ServerHandShanke. Otherwise the handshaker will keep referencing the 64kb buffer and the memory won't be released.