### PR TITLE
credentials/alts: Properly release server InBytes buffer after the handshake is complete.

### DIFF
--- a/credentials/alts/internal/conn/record.go
+++ b/credentials/alts/internal/conn/record.go
@@ -111,19 +111,22 @@ func NewConn(c net.Conn, side core.Side, recordProtocol string, key []byte, prot
 	}
 	overhead := MsgLenFieldSize + msgTypeFieldSize + crypto.EncryptionOverhead()
 	payloadLengthLimit := altsRecordDefaultLength - overhead
-	var protectedBuf []byte
+	// We pre-allocate protectedBuf to be at least of size
+	// 2*altsRecordDefaultLength-1 during initialization. We only read from
+	// the network into protectedBuf when protectedBuf does not contain a
+	// complete frame, which is at most altsRecordDefaultLength-1 (bytes).
+	// And we read at most altsRecordDefaultLength (bytes) data into
+	// protectedBuf at one time. Therefore, 2*altsRecordDefaultLength-1 is
+	// large enough to buffer data read from the network. If protected is
+	// not nil, and its size is larger than 2*altsRecordDefaultLength-1, we
+	// allocate protectedBuf to be size of len(protected), then we copy the
+	// protected content to protectedBuf.
+	protectedBufLen := 2*altsRecordDefaultLength - 1
+	if len(protected) > protectedBufLen {
+		protectedBufLen = len(protected)
+	}
+	protectedBuf := make([]byte, 0, protectedBufLen)
 	if protected == nil {
-		// We pre-allocate protected to be of size
-		// 2*altsRecordDefaultLength-1 during initialization. We only
-		// read from the network into protected when protected does not
-		// contain a complete frame, which is at most
-		// altsRecordDefaultLength-1 (bytes). And we read at most
-		// altsRecordDefaultLength (bytes) data into protected at one
-		// time. Therefore, 2*altsRecordDefaultLength-1 is large enough
-		// to buffer data read from the network.
-		protectedBuf = make([]byte, 0, 2*altsRecordDefaultLength-1)
-	} else {
-		protectedBuf = make([]byte, len(protected))
 		copy(protectedBuf, protected)
 	}
 


### PR DESCRIPTION
Part of the the server-side `InBytes` buffer is eventually passed to `conn.NewConn()`. Since the connection resulting from calling that API stays open as long as the gRPC channel is open, the original 64KB `InBytes` buffer will stay references for the entire channel lifetime and will never be released. This PR fixes that issue.