### PR TITLE
examples/helloworld: refresh .pb.go

### DIFF
--- a/examples/helloworld/helloworld/helloworld.pb.go
+++ b/examples/helloworld/helloworld/helloworld.pb.go
@@ -109,7 +109,9 @@ func init() {
 	proto.RegisterType((*HelloReply)(nil), "helloworld.HelloReply")
 }
 
-func init() { proto.RegisterFile("helloworld.proto", fileDescriptor_17b8c58d586b62f2) }
+func init() {
+	proto.RegisterFile("helloworld.proto", fileDescriptor_17b8c58d586b62f2)
+}
 
 var fileDescriptor_17b8c58d586b62f2 = []byte{
 	// 175 bytes of a gzipped FileDescriptorProto


### PR DESCRIPTION
As mentioned in #3516, "update `.pb.go` file due to changes in Go 1.14's `gofmt` and `go-cmp`.

cc @dfawley 