### PR TITLE
Revert "credentials/alts: Properly release server InBytes buffer after the handshake is complete."

### DIFF
--- a/credentials/alts/internal/conn/record.go
+++ b/credentials/alts/internal/conn/record.go
@@ -111,32 +111,25 @@ func NewConn(c net.Conn, side core.Side, recordProtocol string, key []byte, prot
 	}
 	overhead := MsgLenFieldSize + msgTypeFieldSize + crypto.EncryptionOverhead()
 	payloadLengthLimit := altsRecordDefaultLength - overhead
-	// We pre-allocate protectedBuf to be at least of size
-	// 2*altsRecordDefaultLength-1 during initialization. We only read from
-	// the network into protectedBuf when protectedBuf does not contain a
-	// complete frame, which is at most altsRecordDefaultLength-1 (bytes).
-	// And we read at most altsRecordDefaultLength (bytes) data into
-	// protectedBuf at one time. Therefore, 2*altsRecordDefaultLength-1 is
-	// large enough to buffer data read from the network. If protected is
-	// not nil, and its size is larger than 2*altsRecordDefaultLength-1, we
-	// allocate protectedBuf to be size of len(protected), then we copy the
-	// protected content to protectedBuf.
-	protectedBufLen := 2*altsRecordDefaultLength - 1
-	if len(protected) > protectedBufLen {
-		protectedBufLen = len(protected)
-	}
-	protectedBuf := make([]byte, 0, protectedBufLen)
 	if protected == nil {
-		copy(protectedBuf, protected)
+		// We pre-allocate protected to be of size
+		// 2*altsRecordDefaultLength-1 during initialization. We only
+		// read from the network into protected when protected does not
+		// contain a complete frame, which is at most
+		// altsRecordDefaultLength-1 (bytes). And we read at most
+		// altsRecordDefaultLength (bytes) data into protected at one
+		// time. Therefore, 2*altsRecordDefaultLength-1 is large enough
+		// to buffer data read from the network.
+		protected = make([]byte, 0, 2*altsRecordDefaultLength-1)
 	}
 
 	altsConn := &conn{
 		Conn:               c,
 		crypto:             crypto,
 		payloadLengthLimit: payloadLengthLimit,
-		protected:          protectedBuf,
+		protected:          protected,
 		writeBuf:           make([]byte, altsWriteBufferInitialSize),
-		nextFrame:          protectedBuf,
+		nextFrame:          protected,
 		overhead:           overhead,
 	}
 	return altsConn, nil


### PR DESCRIPTION
Reverts grpc/grpc-go#3513

The change breaks interop tests: https://github.com/grpc/grpc/issues/22650