### PR TITLE
credentials/alts: Properly release server InBytes buffer after the handshake is complete.

### DIFF
--- a/credentials/alts/internal/conn/record.go
+++ b/credentials/alts/internal/conn/record.go
@@ -124,6 +124,7 @@ func NewConn(c net.Conn, side core.Side, recordProtocol string, key []byte, prot
 		protectedBuf = make([]byte, 0, 2*altsRecordDefaultLength-1)
 	} else {
 		protectedBuf = make([]byte, len(protected))
+		copy(protectedBuf, protected)
 	}
 
 	altsConn := &conn{

--- a/credentials/alts/internal/conn/record.go
+++ b/credentials/alts/internal/conn/record.go
@@ -111,6 +111,7 @@ func NewConn(c net.Conn, side core.Side, recordProtocol string, key []byte, prot
 	}
 	overhead := MsgLenFieldSize + msgTypeFieldSize + crypto.EncryptionOverhead()
 	payloadLengthLimit := altsRecordDefaultLength - overhead
+	var protectedBuf []byte
 	if protected == nil {
 		// We pre-allocate protected to be of size
 		// 2*altsRecordDefaultLength-1 during initialization. We only
@@ -120,16 +121,18 @@ func NewConn(c net.Conn, side core.Side, recordProtocol string, key []byte, prot
 		// altsRecordDefaultLength (bytes) data into protected at one
 		// time. Therefore, 2*altsRecordDefaultLength-1 is large enough
 		// to buffer data read from the network.
-		protected = make([]byte, 0, 2*altsRecordDefaultLength-1)
+		protectedBuf = make([]byte, 0, 2*altsRecordDefaultLength-1)
+	} else {
+		protectedBuf = make([]byte, len(protected))
 	}
 
 	altsConn := &conn{
 		Conn:               c,
 		crypto:             crypto,
 		payloadLengthLimit: payloadLengthLimit,
-		protected:          protected,
+		protected:          protectedBuf,
 		writeBuf:           make([]byte, altsWriteBufferInitialSize),
-		nextFrame:          protected,
+		nextFrame:          protectedBuf,
 		overhead:           overhead,
 	}
 	return altsConn, nil


### PR DESCRIPTION
Part of the the server-side `InBytes` buffer is eventually passed to `conn.NewConn()`. Since the connection resulting from calling that API stays open as long as the gRPC channel is open, the original 64KB `InBytes` buffer will stay references for the entire channel lifetime and will never be released. This PR fixes that issue.

Another attempt to fix the buffer ownership issue was done in #3513 but that got reverted in #3528.