### PR TITLE
Pass weights to wrr balancer through attributes.

### DIFF
--- a/attributes/attributes.go
+++ b/attributes/attributes.go
@@ -74,3 +74,14 @@ func (a *Attributes) Value(key interface{}) interface{} {
 	}
 	return a.m[key]
 }
+
+// Clone returns a new Attributes containing all key/value pairs found in a.
+// Since Attributes stores its key/value paris as type `interface{}`, it is not
+// possible to perform deep copies here.
+func (a *Attributes) Clone() *Attributes {
+	b := &Attributes{m: make(map[interface{}]interface{}, len(a.m))}
+	for k, v := range a.m {
+		b.m[k] = v
+	}
+	return b
+}

--- a/attributes/attributes.go
+++ b/attributes/attributes.go
@@ -79,6 +79,9 @@ func (a *Attributes) Value(key interface{}) interface{} {
 // Since Attributes stores its key/value paris as type `interface{}`, it is not
 // possible to perform deep copies here.
 func (a *Attributes) Clone() *Attributes {
+	if a == nil {
+		return nil
+	}
 	b := &Attributes{m: make(map[interface{}]interface{}, len(a.m))}
 	for k, v := range a.m {
 		b.m[k] = v

--- a/attributes/attributes.go
+++ b/attributes/attributes.go
@@ -50,6 +50,9 @@ func New(kvs ...interface{}) *Attributes {
 // times, the last value overwrites all previous values for that key.  To
 // remove an existing key, use a nil value.
 func (a *Attributes) WithValues(kvs ...interface{}) *Attributes {
+	if a == nil {
+		a = New()
+	}
 	if len(kvs)%2 != 0 {
 		panic(fmt.Sprintf("attributes.New called with unexpected input: len(kvs) = %v", len(kvs)))
 	}

--- a/attributes/attributes.go
+++ b/attributes/attributes.go
@@ -51,7 +51,7 @@ func New(kvs ...interface{}) *Attributes {
 // remove an existing key, use a nil value.
 func (a *Attributes) WithValues(kvs ...interface{}) *Attributes {
 	if a == nil {
-		a = New()
+		return New(kvs...)
 	}
 	if len(kvs)%2 != 0 {
 		panic(fmt.Sprintf("attributes.New called with unexpected input: len(kvs) = %v", len(kvs)))
@@ -69,5 +69,8 @@ func (a *Attributes) WithValues(kvs ...interface{}) *Attributes {
 // Value returns the value associated with these attributes for key, or nil if
 // no value is associated with key.
 func (a *Attributes) Value(key interface{}) interface{} {
+	if a == nil {
+		return nil
+	}
 	return a.m[key]
 }

--- a/attributes/attributes.go
+++ b/attributes/attributes.go
@@ -74,17 +74,3 @@ func (a *Attributes) Value(key interface{}) interface{} {
 	}
 	return a.m[key]
 }
-
-// Clone returns a new Attributes containing all key/value pairs found in a.
-// Since Attributes stores its key/value paris as type `interface{}`, it is not
-// possible to perform deep copies here.
-func (a *Attributes) Clone() *Attributes {
-	if a == nil {
-		return nil
-	}
-	b := &Attributes{m: make(map[interface{}]interface{}, len(a.m))}
-	for k, v := range a.m {
-		b.m[k] = v
-	}
-	return b
-}

--- a/attributes/attributes_test.go
+++ b/attributes/attributes_test.go
@@ -20,9 +20,7 @@ package attributes_test
 
 import (
 	"fmt"
-	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"google.golang.org/grpc/attributes"
 )
 
@@ -47,14 +45,4 @@ func ExampleAttributes_WithValues() {
 	// Output:
 	// Key one: 1
 	// Key two: two
-}
-
-func TestAttributesClone(t *testing.T) {
-	type keyOne struct{}
-	type keyTwo struct{}
-	a := attributes.New(keyOne{}, 1, keyTwo{}, "two")
-	b := a.Clone()
-	if !cmp.Equal(b, a, cmp.AllowUnexported(attributes.Attributes{})) {
-		t.Errorf("attributes.Clone() returned %v, want %v", b, a)
-	}
 }

--- a/attributes/attributes_test.go
+++ b/attributes/attributes_test.go
@@ -20,7 +20,9 @@ package attributes_test
 
 import (
 	"fmt"
+	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"google.golang.org/grpc/attributes"
 )
 
@@ -45,4 +47,14 @@ func ExampleAttributes_WithValues() {
 	// Output:
 	// Key one: 1
 	// Key two: two
+}
+
+func TestAttributesClone(t *testing.T) {
+	type keyOne struct{}
+	type keyTwo struct{}
+	a := attributes.New(keyOne{}, 1, keyTwo{}, "two")
+	b := a.Clone()
+	if !cmp.Equal(b, a, cmp.AllowUnexported(attributes.Attributes{})) {
+		t.Errorf("attributes.Clone() returned %v, want %v", b, a)
+	}
 }

--- a/balancer/weightedroundrobin/weightedroundrobin.go
+++ b/balancer/weightedroundrobin/weightedroundrobin.go
@@ -42,7 +42,7 @@ type AddrInfo struct {
 // This is an EXPERIMENTAL API.
 func SetAddrInfo(addrInfo AddrInfo, addr resolver.Address) resolver.Address {
 	newAddr := addr
-	newAddr.Attributes = addr.Attributes.Clone().WithValues(attributeKey{}, addrInfo)
+	newAddr.Attributes = addr.Attributes.WithValues(attributeKey{}, addrInfo)
 	return newAddr
 }
 

--- a/balancer/weightedroundrobin/weightedroundrobin.go
+++ b/balancer/weightedroundrobin/weightedroundrobin.go
@@ -20,6 +20,7 @@
 package weightedroundrobin
 
 import (
+	"google.golang.org/grpc/attributes"
 	"google.golang.org/grpc/resolver"
 )
 
@@ -36,17 +37,26 @@ type AddrInfo struct {
 	Weight uint32
 }
 
-// SetAddrInfo sets addInfo in the Attributes field of addr.
+// SetAddrInfo returns a copy of addr in which the Attributes field is updated
+// with addrInfo.
+//
 // This is an EXPERIMENTAL API.
-func SetAddrInfo(addrInfo AddrInfo, addr *resolver.Address) {
-	addr.Attributes = addr.Attributes.WithValues(attributeKey{}, addrInfo)
+func SetAddrInfo(addrInfo AddrInfo, addr resolver.Address) resolver.Address {
+	newAddr := addr
+	if newAddr.Attributes == nil {
+		newAddr.Attributes = attributes.New(attributeKey{}, addrInfo)
+		return newAddr
+	}
+	newAddr.Attributes = addr.Attributes.Clone().WithValues(attributeKey{}, addrInfo)
+	return newAddr
 }
 
 // GetAddrInfo returns the AddrInfo stored in the Attributes fields of addr.
 // Returns nil if no AddrInfo is present.
+//
 // This is an EXPERIMENTAL API.
-func GetAddrInfo(addr *resolver.Address) AddrInfo {
-	if addr == nil || addr.Attributes == nil {
+func GetAddrInfo(addr resolver.Address) AddrInfo {
+	if addr.Attributes == nil {
 		return AddrInfo{}
 	}
 	ai := addr.Attributes.Value(attributeKey{})

--- a/balancer/weightedroundrobin/weightedroundrobin.go
+++ b/balancer/weightedroundrobin/weightedroundrobin.go
@@ -37,22 +37,24 @@ type AddrInfo struct {
 }
 
 // SetAddrInfo sets addInfo in the Attributes field of addr.
-func SetAddrInfo(addrInfo *AddrInfo, addr *resolver.Address) {
+// This is an EXPERIMENTAL API.
+func SetAddrInfo(addrInfo AddrInfo, addr *resolver.Address) {
 	addr.Attributes = addr.Attributes.WithValues(attributeKey{}, addrInfo)
 }
 
 // GetAddrInfo returns the AddrInfo stored in the Attributes fields of addr.
 // Returns nil if no AddrInfo is present.
-func GetAddrInfo(addr *resolver.Address) *AddrInfo {
+// This is an EXPERIMENTAL API.
+func GetAddrInfo(addr *resolver.Address) AddrInfo {
 	if addr == nil || addr.Attributes == nil {
-		return nil
+		return AddrInfo{}
 	}
 	ai := addr.Attributes.Value(attributeKey{})
 	if ai == nil {
-		return nil
+		return AddrInfo{}
 	}
-	if _, ok := ai.(*AddrInfo); !ok {
-		return nil
+	if _, ok := ai.(AddrInfo); !ok {
+		return AddrInfo{}
 	}
-	return ai.(*AddrInfo)
+	return ai.(AddrInfo)
 }

--- a/balancer/weightedroundrobin/weightedroundrobin.go
+++ b/balancer/weightedroundrobin/weightedroundrobin.go
@@ -40,17 +40,20 @@ type AddrInfo struct {
 // with addrInfo.
 //
 // This is an EXPERIMENTAL API.
-func SetAddrInfo(addrInfo AddrInfo, addr resolver.Address) resolver.Address {
+func SetAddrInfo(addr resolver.Address, addrInfo AddrInfo) resolver.Address {
 	addr.Attributes = addr.Attributes.WithValues(attributeKey{}, addrInfo)
 	return addr
 }
 
 // GetAddrInfo returns the AddrInfo stored in the Attributes fields of addr.
-// Returns nil if no AddrInfo is present.
 //
 // This is an EXPERIMENTAL API.
 func GetAddrInfo(addr resolver.Address) AddrInfo {
 	v := addr.Attributes.Value(attributeKey{})
+	if v == nil {
+		return AddrInfo{}
+	}
+
 	ai, _ := v.(AddrInfo)
 	return ai
 }

--- a/balancer/weightedroundrobin/weightedroundrobin.go
+++ b/balancer/weightedroundrobin/weightedroundrobin.go
@@ -50,10 +50,6 @@ func SetAddrInfo(addr resolver.Address, addrInfo AddrInfo) resolver.Address {
 // This is an EXPERIMENTAL API.
 func GetAddrInfo(addr resolver.Address) AddrInfo {
 	v := addr.Attributes.Value(attributeKey{})
-	if v == nil {
-		return AddrInfo{}
-	}
-
 	ai, _ := v.(AddrInfo)
 	return ai
 }

--- a/balancer/weightedroundrobin/weightedroundrobin.go
+++ b/balancer/weightedroundrobin/weightedroundrobin.go
@@ -19,36 +19,35 @@
 // Package weightedroundrobin defines a weighted roundrobin balancer.
 package weightedroundrobin
 
-import "google.golang.org/grpc/attributes"
-
-const (
-	// Name is the name of weighted_round_robin balancer.
-	Name = "weighted_round_robin"
-
-	// Attribute key used to store AddrInfo in the Attributes field of
-	// resolver.Address.
-	attributeKey = "/balancer/weightedroundrobin/addrInfo"
+import (
+	"google.golang.org/grpc/resolver"
 )
 
-// AddrInfo will be stored inside Address metadata in order to use weighted roundrobin
-// balancer.
+// Name is the name of weighted_round_robin balancer.
+const Name = "weighted_round_robin"
+
+// attributeKey is the type used as the key to store AddrInfo in the Attributes
+// field of resolver.Address.
+type attributeKey struct{}
+
+// AddrInfo will be stored inside Address metadata in order to use weighted
+// roundrobin balancer.
 type AddrInfo struct {
 	Weight uint32
 }
 
-// AddAddrInfoToAttributes returns a new Attributes containing all key/value
-// pairs in a with ai being added to it.
-func AddAddrInfoToAttributes(ai *AddrInfo, a *attributes.Attributes) *attributes.Attributes {
-	return a.WithValues(attributeKey, ai)
+// SetAddrInfo sets addInfo in the Attributes field of addr.
+func SetAddrInfo(addrInfo *AddrInfo, addr *resolver.Address) {
+	addr.Attributes = addr.Attributes.WithValues(attributeKey{}, addrInfo)
 }
 
-// GetAddrInfoFromAttributes returns the AddrInfo stored in a. Returns nil if no
-// AddrInfo is present in a.
-func GetAddrInfoFromAttributes(a *attributes.Attributes) *AddrInfo {
-	if a == nil {
+// GetAddrInfo returns the AddrInfo stored in the Attributes fields of addr.
+// Returns nil if no AddrInfo is present.
+func GetAddrInfo(addr *resolver.Address) *AddrInfo {
+	if addr == nil || addr.Attributes == nil {
 		return nil
 	}
-	ai := a.Value(attributeKey)
+	ai := addr.Attributes.Value(attributeKey{})
 	if ai == nil {
 		return nil
 	}

--- a/balancer/weightedroundrobin/weightedroundrobin.go
+++ b/balancer/weightedroundrobin/weightedroundrobin.go
@@ -19,11 +19,41 @@
 // Package weightedroundrobin defines a weighted roundrobin balancer.
 package weightedroundrobin
 
-// Name is the name of weighted_round_robin balancer.
-const Name = "weighted_round_robin"
+import "google.golang.org/grpc/attributes"
+
+const (
+	// Name is the name of weighted_round_robin balancer.
+	Name = "weighted_round_robin"
+
+	// Attribute key used to store AddrInfo in the Attributes field of
+	// resolver.Address.
+	attributeKey = "/balancer/weightedroundrobin/addrInfo"
+)
 
 // AddrInfo will be stored inside Address metadata in order to use weighted roundrobin
 // balancer.
 type AddrInfo struct {
 	Weight uint32
+}
+
+// AddAddrInfoToAttributes returns a new Attributes containing all key/value
+// pairs in a with ai being added to it.
+func AddAddrInfoToAttributes(ai *AddrInfo, a *attributes.Attributes) *attributes.Attributes {
+	return a.WithValues(attributeKey, ai)
+}
+
+// GetAddrInfoFromAttributes returns the AddrInfo stored in a. Returns nil if no
+// AddrInfo is present in a.
+func GetAddrInfoFromAttributes(a *attributes.Attributes) *AddrInfo {
+	if a == nil {
+		return nil
+	}
+	ai := a.Value(attributeKey)
+	if ai == nil {
+		return nil
+	}
+	if _, ok := ai.(*AddrInfo); !ok {
+		return nil
+	}
+	return ai.(*AddrInfo)
 }

--- a/balancer/weightedroundrobin/weightedroundrobin.go
+++ b/balancer/weightedroundrobin/weightedroundrobin.go
@@ -41,9 +41,8 @@ type AddrInfo struct {
 //
 // This is an EXPERIMENTAL API.
 func SetAddrInfo(addrInfo AddrInfo, addr resolver.Address) resolver.Address {
-	newAddr := addr
-	newAddr.Attributes = addr.Attributes.WithValues(attributeKey{}, addrInfo)
-	return newAddr
+	addr.Attributes = addr.Attributes.WithValues(attributeKey{}, addrInfo)
+	return addr
 }
 
 // GetAddrInfo returns the AddrInfo stored in the Attributes fields of addr.
@@ -51,15 +50,7 @@ func SetAddrInfo(addrInfo AddrInfo, addr resolver.Address) resolver.Address {
 //
 // This is an EXPERIMENTAL API.
 func GetAddrInfo(addr resolver.Address) AddrInfo {
-	if addr.Attributes == nil {
-		return AddrInfo{}
-	}
-	ai := addr.Attributes.Value(attributeKey{})
-	if ai == nil {
-		return AddrInfo{}
-	}
-	if _, ok := ai.(AddrInfo); !ok {
-		return AddrInfo{}
-	}
-	return ai.(AddrInfo)
+	v := addr.Attributes.Value(attributeKey{})
+	ai, _ := v.(AddrInfo)
+	return ai
 }

--- a/balancer/weightedroundrobin/weightedroundrobin.go
+++ b/balancer/weightedroundrobin/weightedroundrobin.go
@@ -20,7 +20,6 @@
 package weightedroundrobin
 
 import (
-	"google.golang.org/grpc/attributes"
 	"google.golang.org/grpc/resolver"
 )
 
@@ -43,10 +42,6 @@ type AddrInfo struct {
 // This is an EXPERIMENTAL API.
 func SetAddrInfo(addrInfo AddrInfo, addr resolver.Address) resolver.Address {
 	newAddr := addr
-	if newAddr.Attributes == nil {
-		newAddr.Attributes = attributes.New(attributeKey{}, addrInfo)
-		return newAddr
-	}
 	newAddr.Attributes = addr.Attributes.Clone().WithValues(attributeKey{}, addrInfo)
 	return newAddr
 }

--- a/balancer/weightedroundrobin/weightedwoundrobin_test.go
+++ b/balancer/weightedroundrobin/weightedwoundrobin_test.go
@@ -26,7 +26,7 @@ import (
 	"google.golang.org/grpc/resolver"
 )
 
-func TestAddAddrInfoToAndFromAttributes(t *testing.T) {
+func TestAddrInfoToAndFromAttributes(t *testing.T) {
 	tests := []struct {
 		desc            string
 		inputAddrInfo   AddrInfo
@@ -69,5 +69,14 @@ func TestAddAddrInfoToAndFromAttributes(t *testing.T) {
 			}
 
 		})
+	}
+}
+
+func TestGetAddInfoEmpty(t *testing.T) {
+	addr := resolver.Address{Attributes: attributes.New()}
+	gotAddrInfo := GetAddrInfo(addr)
+	wantAddrInfo := AddrInfo{}
+	if !cmp.Equal(gotAddrInfo, wantAddrInfo) {
+		t.Errorf("gotAddrInfo: %v, wantAddrInfo: %v", gotAddrInfo, wantAddrInfo)
 	}
 }

--- a/balancer/weightedroundrobin/weightedwoundrobin_test.go
+++ b/balancer/weightedroundrobin/weightedwoundrobin_test.go
@@ -22,8 +22,8 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-
 	"google.golang.org/grpc/attributes"
+	"google.golang.org/grpc/resolver"
 )
 
 func TestAddAddrInfoToAndFromAttributes(t *testing.T) {
@@ -61,8 +61,9 @@ func TestAddAddrInfoToAndFromAttributes(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			outputAttributes := AddAddrInfoToAttributes(test.inputAddrInfo, test.inputAttributes)
-			gotAddrInfo := GetAddrInfoFromAttributes(outputAttributes)
+			addr := &resolver.Address{Attributes: test.inputAttributes}
+			SetAddrInfo(test.inputAddrInfo, addr)
+			gotAddrInfo := GetAddrInfo(addr)
 			if !cmp.Equal(gotAddrInfo, test.wantAddrInfo) {
 				t.Errorf("gotAddrInfo: %v, wantAddrInfo: %v", gotAddrInfo, test.wantAddrInfo)
 			}

--- a/balancer/weightedroundrobin/weightedwoundrobin_test.go
+++ b/balancer/weightedroundrobin/weightedwoundrobin_test.go
@@ -29,33 +29,33 @@ import (
 func TestAddAddrInfoToAndFromAttributes(t *testing.T) {
 	tests := []struct {
 		desc            string
-		inputAddrInfo   *AddrInfo
+		inputAddrInfo   AddrInfo
 		inputAttributes *attributes.Attributes
-		wantAddrInfo    *AddrInfo
+		wantAddrInfo    AddrInfo
 	}{
 		{
 			desc:            "empty attributes",
-			inputAddrInfo:   &AddrInfo{Weight: 100},
+			inputAddrInfo:   AddrInfo{Weight: 100},
 			inputAttributes: nil,
-			wantAddrInfo:    &AddrInfo{Weight: 100},
+			wantAddrInfo:    AddrInfo{Weight: 100},
 		},
 		{
 			desc:            "non-empty attributes",
-			inputAddrInfo:   &AddrInfo{Weight: 100},
+			inputAddrInfo:   AddrInfo{Weight: 100},
 			inputAttributes: attributes.New("foo", "bar"),
-			wantAddrInfo:    &AddrInfo{Weight: 100},
+			wantAddrInfo:    AddrInfo{Weight: 100},
 		},
 		{
 			desc:            "addrInfo not present in empty attributes",
-			inputAddrInfo:   nil,
+			inputAddrInfo:   AddrInfo{},
 			inputAttributes: nil,
-			wantAddrInfo:    nil,
+			wantAddrInfo:    AddrInfo{},
 		},
 		{
 			desc:            "addrInfo not present in non-empty attributes",
-			inputAddrInfo:   nil,
+			inputAddrInfo:   AddrInfo{},
 			inputAttributes: attributes.New("foo", "bar"),
-			wantAddrInfo:    nil,
+			wantAddrInfo:    AddrInfo{},
 		},
 	}
 

--- a/balancer/weightedroundrobin/weightedwoundrobin_test.go
+++ b/balancer/weightedroundrobin/weightedwoundrobin_test.go
@@ -62,7 +62,7 @@ func TestAddAddrInfoToAndFromAttributes(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
 			addr := resolver.Address{Attributes: test.inputAttributes}
-			addr = SetAddrInfo(test.inputAddrInfo, addr)
+			addr = SetAddrInfo(addr, test.inputAddrInfo)
 			gotAddrInfo := GetAddrInfo(addr)
 			if !cmp.Equal(gotAddrInfo, test.wantAddrInfo) {
 				t.Errorf("gotAddrInfo: %v, wantAddrInfo: %v", gotAddrInfo, test.wantAddrInfo)

--- a/balancer/weightedroundrobin/weightedwoundrobin_test.go
+++ b/balancer/weightedroundrobin/weightedwoundrobin_test.go
@@ -61,8 +61,8 @@ func TestAddAddrInfoToAndFromAttributes(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			addr := &resolver.Address{Attributes: test.inputAttributes}
-			SetAddrInfo(test.inputAddrInfo, addr)
+			addr := resolver.Address{Attributes: test.inputAttributes}
+			addr = SetAddrInfo(test.inputAddrInfo, addr)
 			gotAddrInfo := GetAddrInfo(addr)
 			if !cmp.Equal(gotAddrInfo, test.wantAddrInfo) {
 				t.Errorf("gotAddrInfo: %v, wantAddrInfo: %v", gotAddrInfo, test.wantAddrInfo)

--- a/balancer/weightedroundrobin/weightedwoundrobin_test.go
+++ b/balancer/weightedroundrobin/weightedwoundrobin_test.go
@@ -1,0 +1,72 @@
+/*
+ *
+ * Copyright 2020 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package weightedroundrobin
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"google.golang.org/grpc/attributes"
+)
+
+func TestAddAddrInfoToAndFromAttributes(t *testing.T) {
+	tests := []struct {
+		desc            string
+		inputAddrInfo   *AddrInfo
+		inputAttributes *attributes.Attributes
+		wantAddrInfo    *AddrInfo
+	}{
+		{
+			desc:            "empty attributes",
+			inputAddrInfo:   &AddrInfo{Weight: 100},
+			inputAttributes: nil,
+			wantAddrInfo:    &AddrInfo{Weight: 100},
+		},
+		{
+			desc:            "non-empty attributes",
+			inputAddrInfo:   &AddrInfo{Weight: 100},
+			inputAttributes: attributes.New("foo", "bar"),
+			wantAddrInfo:    &AddrInfo{Weight: 100},
+		},
+		{
+			desc:            "addrInfo not present in empty attributes",
+			inputAddrInfo:   nil,
+			inputAttributes: nil,
+			wantAddrInfo:    nil,
+		},
+		{
+			desc:            "addrInfo not present in non-empty attributes",
+			inputAddrInfo:   nil,
+			inputAttributes: attributes.New("foo", "bar"),
+			wantAddrInfo:    nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			outputAttributes := AddAddrInfoToAttributes(test.inputAddrInfo, test.inputAttributes)
+			gotAddrInfo := GetAddrInfoFromAttributes(outputAttributes)
+			if !cmp.Equal(gotAddrInfo, test.wantAddrInfo) {
+				t.Errorf("gotAddrInfo: %v, wantAddrInfo: %v", gotAddrInfo, test.wantAddrInfo)
+			}
+
+		})
+	}
+}

--- a/xds/internal/balancer/edsbalancer/eds_impl.go
+++ b/xds/internal/balancer/edsbalancer/eds_impl.go
@@ -285,6 +285,7 @@ func (edsImpl *edsBalancerImpl) handleEDSResponsePerPriority(bgwc *balancerGroup
 				// Metadata field here to allow users of this field to migrate
 				// to the new one.
 				// TODO(easwars): Remove this once all users have migrated.
+				// See https://github.com/grpc/grpc-go/issues/3563.
 				address.Metadata = &ai
 			}
 			newAddrs = append(newAddrs, address)

--- a/xds/internal/balancer/edsbalancer/eds_impl.go
+++ b/xds/internal/balancer/edsbalancer/eds_impl.go
@@ -277,7 +277,7 @@ func (edsImpl *edsBalancerImpl) handleEDSResponsePerPriority(bgwc *balancerGroup
 				Addr: lbEndpoint.Address,
 			}
 			if edsImpl.subBalancerBuilder.Name() == weightedroundrobin.Name && lbEndpoint.Weight != 0 {
-				ai := &weightedroundrobin.AddrInfo{Weight: lbEndpoint.Weight}
+				ai := weightedroundrobin.AddrInfo{Weight: lbEndpoint.Weight}
 				weightedroundrobin.SetAddrInfo(ai, &address)
 				// Metadata field in resolver.Address is deprecated. The
 				// attributes field should be used to specify arbitrary
@@ -285,7 +285,7 @@ func (edsImpl *edsBalancerImpl) handleEDSResponsePerPriority(bgwc *balancerGroup
 				// Metadata field here to allow users of this field to migrate
 				// to the new one.
 				// TODO(easwars): Remove this once all users have migrated.
-				address.Metadata = ai
+				address.Metadata = &ai
 			}
 			newAddrs = append(newAddrs, address)
 		}

--- a/xds/internal/balancer/edsbalancer/eds_impl.go
+++ b/xds/internal/balancer/edsbalancer/eds_impl.go
@@ -278,7 +278,7 @@ func (edsImpl *edsBalancerImpl) handleEDSResponsePerPriority(bgwc *balancerGroup
 			}
 			if edsImpl.subBalancerBuilder.Name() == weightedroundrobin.Name && lbEndpoint.Weight != 0 {
 				ai := weightedroundrobin.AddrInfo{Weight: lbEndpoint.Weight}
-				address = weightedroundrobin.SetAddrInfo(ai, address)
+				address = weightedroundrobin.SetAddrInfo(address, ai)
 				// Metadata field in resolver.Address is deprecated. The
 				// attributes field should be used to specify arbitrary
 				// attributes about the address. We still need to populate the

--- a/xds/internal/balancer/edsbalancer/eds_impl.go
+++ b/xds/internal/balancer/edsbalancer/eds_impl.go
@@ -278,7 +278,7 @@ func (edsImpl *edsBalancerImpl) handleEDSResponsePerPriority(bgwc *balancerGroup
 			}
 			if edsImpl.subBalancerBuilder.Name() == weightedroundrobin.Name && lbEndpoint.Weight != 0 {
 				ai := &weightedroundrobin.AddrInfo{Weight: lbEndpoint.Weight}
-				address.Attributes = weightedroundrobin.AddAddrInfoToAttributes(ai, address.Attributes)
+				weightedroundrobin.SetAddrInfo(ai, &address)
 				// Metadata field in resolver.Address is deprecated. The
 				// attributes field should be used to specify arbitrary
 				// attributes about the address. We still need to populate the

--- a/xds/internal/balancer/edsbalancer/eds_impl.go
+++ b/xds/internal/balancer/edsbalancer/eds_impl.go
@@ -277,9 +277,15 @@ func (edsImpl *edsBalancerImpl) handleEDSResponsePerPriority(bgwc *balancerGroup
 				Addr: lbEndpoint.Address,
 			}
 			if edsImpl.subBalancerBuilder.Name() == weightedroundrobin.Name && lbEndpoint.Weight != 0 {
-				address.Metadata = &weightedroundrobin.AddrInfo{
-					Weight: lbEndpoint.Weight,
-				}
+				ai := &weightedroundrobin.AddrInfo{Weight: lbEndpoint.Weight}
+				address.Attributes = weightedroundrobin.AddAddrInfoToAttributes(ai, address.Attributes)
+				// Metadata field in resolver.Address is deprecated. The
+				// attributes field should be used to specify arbitrary
+				// attributes about the address. We still need to populate the
+				// Metadata field here to allow users of this field to migrate
+				// to the new one.
+				// TODO(easwars): Remove this once all users have migrated.
+				address.Metadata = ai
 			}
 			newAddrs = append(newAddrs, address)
 		}

--- a/xds/internal/balancer/edsbalancer/eds_impl.go
+++ b/xds/internal/balancer/edsbalancer/eds_impl.go
@@ -278,7 +278,7 @@ func (edsImpl *edsBalancerImpl) handleEDSResponsePerPriority(bgwc *balancerGroup
 			}
 			if edsImpl.subBalancerBuilder.Name() == weightedroundrobin.Name && lbEndpoint.Weight != 0 {
 				ai := weightedroundrobin.AddrInfo{Weight: lbEndpoint.Weight}
-				weightedroundrobin.SetAddrInfo(ai, &address)
+				address = weightedroundrobin.SetAddrInfo(ai, address)
 				// Metadata field in resolver.Address is deprecated. The
 				// attributes field should be used to specify arbitrary
 				// attributes about the address. We still need to populate the


### PR DESCRIPTION
* Add methods to the `weightedroundrobin` package to add/get `AddrInfo` to/from `attributes.Attributes`.
* Update the edsBalancer implementation to send the weights as attributes using these methods.
* Update `attributes.WithValues` to work with a nil receiver to avoid call sites from having to perform nil checks and creating empty `Attributes` before being able to use this method.