### PR TITLE
env: check GRPC_GO_IGNORE_TXT_ERRORS env var

### DIFF
--- a/internal/envconfig/envconfig.go
+++ b/internal/envconfig/envconfig.go
@@ -34,5 +34,5 @@ var (
 	// Retry is set if retry is explicitly enabled via "GRPC_GO_RETRY=on".
 	Retry = strings.EqualFold(os.Getenv(retryStr), "on")
 	// TXTErrIgnore is set if TXT errors should be ignored ("GRPC_GO_IGNORE_TXT_ERRORS" is not "false").
-	TXTErrIgnore = !strings.EqualFold(os.Getenv(retryStr), "false")
+	TXTErrIgnore = !strings.EqualFold(os.Getenv(txtErrIgnoreStr), "false")
 )


### PR DESCRIPTION
I think we need check GRPC_GO_IGNORE_TXT_ERRORS instead of GRPC_GO_RETRY for value of TXTErrIgnore variable.