### PR TITLE
xds: accept either "" or "/" as the prefix for the default route

### DIFF
--- a/xds/internal/client/v2client_rds.go
+++ b/xds/internal/client/v2client_rds.go
@@ -95,8 +95,8 @@ func getClusterFromRouteConfiguration(rc *xdspb.RouteConfiguration, host string)
 		return ""
 	}
 	dr := vh.Routes[len(vh.Routes)-1]
-	if match := dr.GetMatch(); match == nil || match.GetPrefix() != "" {
-		// The matched virtual host is invalid.
+	if match := dr.GetMatch(); match == nil || (match.GetPrefix() != "" && match.GetPrefix() != "/") {
+		// The matched virtual host is invalid. Match is not "" or "/".
 		return ""
 	}
 	if route := dr.GetRoute(); route != nil {

--- a/xds/internal/client/v2client_rds_test.go
+++ b/xds/internal/client/v2client_rds_test.go
@@ -133,8 +133,23 @@ func (s) TestRDSGetClusterFromRouteConfiguration(t *testing.T) {
 			wantCluster: "",
 		},
 		{
-			name:        "good-route-config",
+			name:        "good-route-config-with-empty-string-route",
 			rc:          goodRouteConfig1,
+			wantCluster: goodClusterName1,
+		},
+		{
+			// default route's match is not empty string, but "/".
+			name: "good-route-config-with-slash-string-route",
+			rc: &xdspb.RouteConfiguration{
+				Name: goodRouteName1,
+				VirtualHosts: []*routepb.VirtualHost{{
+					Domains: []string{goodLDSTarget1},
+					Routes: []*routepb.Route{{
+						Match: &routepb.RouteMatch{PathSpecifier: &routepb.RouteMatch_Prefix{Prefix: "/"}},
+						Action: &routepb.Route_Route{
+							Route: &routepb.RouteAction{
+								ClusterSpecifier: &routepb.RouteAction_Cluster{Cluster: goodClusterName1},
+							}}}}}}},
 			wantCluster: goodClusterName1,
 		},
 	}


### PR DESCRIPTION
see also https://github.com/grpc/grpc/pull/22675