### PR TITLE
internal: add missing package comment

### DIFF
--- a/internal/syscall/syscall_nonlinux.go
+++ b/internal/syscall/syscall_nonlinux.go
@@ -18,6 +18,8 @@
  *
  */
 
+// Package syscall provides functionalities that grpc uses to get low-level
+// operating system stats/info.
 package syscall
 
 import (


### PR DESCRIPTION
vet started failing on darwin after the recent package related lint changes.