### PR TITLE
status: remove Error method accidentally added to *Status

### DIFF
--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -100,11 +100,6 @@ func (s *Status) Err() error {
 	return (*Error)(s.Proto())
 }
 
-func (s *Status) Error() string {
-	p := s.Proto()
-	return fmt.Sprintf("rpc error: code = %s desc = %s", codes.Code(p.GetCode()), p.GetMessage())
-}
-
 // WithDetails returns a new status with the provided details messages appended to the status.
 // If any errors are encountered, it returns nil and the first error encountered.
 func (s *Status) WithDetails(details ...proto.Message) (*Status, error) {


### PR DESCRIPTION
This is a serious problem for it to exist, as it allows an OK status to have a non-nil error representation.