### PR TITLE
kokoro: use xds-test-server image (v1.28.x backport)

### DIFF
--- a/test/kokoro/xds.sh
+++ b/test/kokoro/xds.sh
@@ -23,6 +23,8 @@ GRPC_GO_LOG_VERBOSITY_LEVEL=99 GRPC_GO_LOG_SEVERITY_LEVEL=info \
   python3 grpc/tools/run_tests/run_xds_tests.py \
     --test_case=all \
     --project_id=grpc-testing \
+    --source_image=projects/grpc-testing/global/images/xds-test-server \
+    --path_to_server_binary=/java_server/grpc-java/interop-testing/build/install/grpc-interop-testing/bin/xds-test-server \
     --gcp_suffix=$(date '+%s') \
     --verbose \
     --client_cmd="grpc-go/interop/xds/client/client \


### PR DESCRIPTION
Cherry-pick of https://github.com/grpc/grpc-go/pull/3564

cc @menghanl 