### PR TITLE
advancedtls: add field names for unit tests

### DIFF
--- a/security/advancedtls/advancedtls_integration_test.go
+++ b/security/advancedtls/advancedtls_integration_test.go
@@ -216,8 +216,7 @@ func TestEnd2End(t *testing.T) {
 		// should see it again accepts the connection, since clientPeer2 is trusted
 		// by serverTrust2.
 		{
-			desc:       "TestClientPeerCertReloadServerTrustCertReload",
-			clientCert: nil,
+			desc: "TestClientPeerCertReloadServerTrustCertReload",
 			clientGetCert: func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
 				switch stage.read() {
 				case 0:
@@ -226,15 +225,12 @@ func TestEnd2End(t *testing.T) {
 					return &cs.clientPeer2, nil
 				}
 			},
-			clientGetRoot: nil,
-			clientRoot:    cs.clientTrust1,
+			clientRoot: cs.clientTrust1,
 			clientVerifyFunc: func(params *VerificationFuncParams) (*VerificationResults, error) {
 				return &VerificationResults{}, nil
 			},
-			clientVType:   CertVerification,
-			serverCert:    []tls.Certificate{cs.serverPeer1},
-			serverGetCert: nil,
-			serverRoot:    nil,
+			clientVType: CertVerification,
+			serverCert:  []tls.Certificate{cs.serverPeer1},
 			serverGetRoot: func(params *GetRootCAsParams) (*GetRootCAsResults, error) {
 				switch stage.read() {
 				case 0, 1:
@@ -261,9 +257,8 @@ func TestEnd2End(t *testing.T) {
 		// should see it again accepts the connection, since serverPeer2 is trusted
 		// by clientTrust2.
 		{
-			desc:          "TestServerPeerCertReloadClientTrustCertReload",
-			clientCert:    []tls.Certificate{cs.clientPeer1},
-			clientGetCert: nil,
+			desc:       "TestServerPeerCertReloadClientTrustCertReload",
+			clientCert: []tls.Certificate{cs.clientPeer1},
 			clientGetRoot: func(params *GetRootCAsParams) (*GetRootCAsResults, error) {
 				switch stage.read() {
 				case 0, 1:
@@ -272,12 +267,10 @@ func TestEnd2End(t *testing.T) {
 					return &GetRootCAsResults{TrustCerts: cs.clientTrust2}, nil
 				}
 			},
-			clientRoot: nil,
 			clientVerifyFunc: func(params *VerificationFuncParams) (*VerificationResults, error) {
 				return &VerificationResults{}, nil
 			},
 			clientVType: CertVerification,
-			serverCert:  nil,
 			serverGetCert: func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
 				switch stage.read() {
 				case 0:
@@ -286,8 +279,7 @@ func TestEnd2End(t *testing.T) {
 					return &cs.serverPeer2, nil
 				}
 			},
-			serverRoot:    cs.serverTrust1,
-			serverGetRoot: nil,
+			serverRoot: cs.serverTrust1,
 			serverVerifyFunc: func(params *VerificationFuncParams) (*VerificationResults, error) {
 				return &VerificationResults{}, nil
 			},
@@ -307,9 +299,8 @@ func TestEnd2End(t *testing.T) {
 		// At stage 2, the client changes authorization check to only accept
 		// serverPeer2. Now we should see the connection becomes normal again.
 		{
-			desc:          "TestClientCustomVerification",
-			clientCert:    []tls.Certificate{cs.clientPeer1},
-			clientGetCert: nil,
+			desc:       "TestClientCustomVerification",
+			clientCert: []tls.Certificate{cs.clientPeer1},
 			clientGetRoot: func(params *GetRootCAsParams) (*GetRootCAsResults, error) {
 				switch stage.read() {
 				case 0:
@@ -318,7 +309,6 @@ func TestEnd2End(t *testing.T) {
 					return &GetRootCAsResults{TrustCerts: cs.clientTrust2}, nil
 				}
 			},
-			clientRoot: nil,
 			clientVerifyFunc: func(params *VerificationFuncParams) (*VerificationResults, error) {
 				if len(params.RawCerts) == 0 {
 					return nil, fmt.Errorf("no peer certs")
@@ -346,7 +336,6 @@ func TestEnd2End(t *testing.T) {
 				return nil, fmt.Errorf("custom authz check fails")
 			},
 			clientVType: CertVerification,
-			serverCert:  nil,
 			serverGetCert: func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
 				switch stage.read() {
 				case 0:
@@ -355,8 +344,7 @@ func TestEnd2End(t *testing.T) {
 					return &cs.serverPeer2, nil
 				}
 			},
-			serverRoot:    cs.serverTrust1,
-			serverGetRoot: nil,
+			serverRoot: cs.serverTrust1,
 			serverVerifyFunc: func(params *VerificationFuncParams) (*VerificationResults, error) {
 				return &VerificationResults{}, nil
 			},
@@ -374,19 +362,15 @@ func TestEnd2End(t *testing.T) {
 		// At stage 2, server allows all the connections again and the
 		// authentications should go back to normal.
 		{
-			desc:          "TestServerCustomVerification",
-			clientCert:    []tls.Certificate{cs.clientPeer1},
-			clientGetCert: nil,
-			clientGetRoot: nil,
-			clientRoot:    cs.clientTrust1,
+			desc:       "TestServerCustomVerification",
+			clientCert: []tls.Certificate{cs.clientPeer1},
+			clientRoot: cs.clientTrust1,
 			clientVerifyFunc: func(params *VerificationFuncParams) (*VerificationResults, error) {
 				return &VerificationResults{}, nil
 			},
-			clientVType:   CertVerification,
-			serverCert:    []tls.Certificate{cs.serverPeer1},
-			serverGetCert: nil,
-			serverRoot:    cs.serverTrust1,
-			serverGetRoot: nil,
+			clientVType: CertVerification,
+			serverCert:  []tls.Certificate{cs.serverPeer1},
+			serverRoot:  cs.serverTrust1,
 			serverVerifyFunc: func(params *VerificationFuncParams) (*VerificationResults, error) {
 				switch stage.read() {
 				case 0, 2:

--- a/security/advancedtls/advancedtls_test.go
+++ b/security/advancedtls/advancedtls_test.go
@@ -73,7 +73,7 @@ func TestClientServerHandshake(t *testing.T) {
 	for _, test := range []struct {
 		desc                       string
 		clientCert                 []tls.Certificate
-		clientGetClientCert        func(*tls.CertificateRequestInfo) (*tls.Certificate, error)
+		clientGetCert              func(*tls.CertificateRequestInfo) (*tls.Certificate, error)
 		clientRoot                 *x509.CertPool
 		clientGetRoot              func(params *GetRootCAsParams) (*GetRootCAsResults, error)
 		clientVerifyFunc           CustomVerificationFunc
@@ -97,47 +97,30 @@ func TestClientServerHandshake(t *testing.T) {
 		// even setting vType to SkipVerification. Clients should at least provide
 		// their own verification logic.
 		{
-			"Client_no_trust_cert_Server_peer_cert",
-			nil,
-			nil,
-			nil,
-			nil,
-			nil,
-			SkipVerification,
-			true,
-			false,
-			false,
-			[]tls.Certificate{serverPeerCert},
-			nil,
-			nil,
-			nil,
-			nil,
-			CertAndHostVerification,
-			true,
+			desc:                       "Client_no_trust_cert_Server_peer_cert",
+			clientVType:                SkipVerification,
+			clientExpectCreateError:    true,
+			clientExpectHandshakeError: false,
+			serverMutualTLS:            false,
+			serverCert:                 []tls.Certificate{serverPeerCert},
+			serverVType:                CertAndHostVerification,
+			serverExpectError:          true,
 		},
 		// Client: nil setting except verifyFuncGood
 		// Server: only set serverCert with mutual TLS off
 		// Expected Behavior: success
 		// Reason: we will use verifyFuncGood to verify the server,
-		// if either clientCert or clientGetClientCert is not set
+		// if either clientCert or clientGetCert is not set
 		{
-			"Client_no_trust_cert_verifyFuncGood_Server_peer_cert",
-			nil,
-			nil,
-			nil,
-			nil,
-			verifyFuncGood,
-			SkipVerification,
-			false,
-			false,
-			false,
-			[]tls.Certificate{serverPeerCert},
-			nil,
-			nil,
-			nil,
-			nil,
-			CertAndHostVerification,
-			false,
+			desc:                       "Client_no_trust_cert_verifyFuncGood_Server_peer_cert",
+			clientVerifyFunc:           verifyFuncGood,
+			clientVType:                SkipVerification,
+			clientExpectCreateError:    false,
+			clientExpectHandshakeError: false,
+			serverMutualTLS:            false,
+			serverCert:                 []tls.Certificate{serverPeerCert},
+			serverVType:                CertAndHostVerification,
+			serverExpectError:          false,
 		},
 		// Client: only set clientRoot
 		// Server: only set serverCert with mutual TLS off
@@ -146,23 +129,15 @@ func TestClientServerHandshake(t *testing.T) {
 		// default hostname check. All the default hostname checks will fail in
 		// this test suites.
 		{
-			"Client_root_cert_Server_peer_cert",
-			nil,
-			nil,
-			clientTrustPool,
-			nil,
-			nil,
-			CertAndHostVerification,
-			false,
-			true,
-			false,
-			[]tls.Certificate{serverPeerCert},
-			nil,
-			nil,
-			nil,
-			nil,
-			CertAndHostVerification,
-			true,
+			desc:                       "Client_root_cert_Server_peer_cert",
+			clientRoot:                 clientTrustPool,
+			clientVType:                CertAndHostVerification,
+			clientExpectCreateError:    false,
+			clientExpectHandshakeError: true,
+			serverMutualTLS:            false,
+			serverCert:                 []tls.Certificate{serverPeerCert},
+			serverVType:                CertAndHostVerification,
+			serverExpectError:          true,
 		},
 		// Client: only set clientGetRoot
 		// Server: only set serverCert with mutual TLS off
@@ -171,113 +146,78 @@ func TestClientServerHandshake(t *testing.T) {
 		// default hostname check. All the default hostname checks will fail in
 		// this test suites.
 		{
-			"Client_reload_root_Server_peer_cert",
-			nil,
-			nil,
-			nil,
-			getRootCAsForClient,
-			nil,
-			CertAndHostVerification,
-			false,
-			true,
-			false,
-			[]tls.Certificate{serverPeerCert},
-			nil,
-			nil,
-			nil,
-			nil,
-			CertAndHostVerification,
-			true,
+			desc:                       "Client_reload_root_Server_peer_cert",
+			clientGetRoot:              getRootCAsForClient,
+			clientVType:                CertAndHostVerification,
+			clientExpectCreateError:    false,
+			clientExpectHandshakeError: true,
+			serverMutualTLS:            false,
+			serverCert:                 []tls.Certificate{serverPeerCert},
+			serverVType:                CertAndHostVerification,
+			serverExpectError:          true,
 		},
 		// Client: set clientGetRoot and clientVerifyFunc
 		// Server: only set serverCert with mutual TLS off
 		// Expected Behavior: success
 		{
-			"Client_reload_root_verifyFuncGood_Server_peer_cert",
-			nil,
-			nil,
-			nil,
-			getRootCAsForClient,
-			verifyFuncGood,
-			CertVerification,
-			false,
-			false,
-			false,
-			[]tls.Certificate{serverPeerCert},
-			nil,
-			nil,
-			nil,
-			nil,
-			CertAndHostVerification,
-			false,
+			desc:                       "Client_reload_root_verifyFuncGood_Server_peer_cert",
+			clientGetRoot:              getRootCAsForClient,
+			clientVerifyFunc:           verifyFuncGood,
+			clientVType:                CertVerification,
+			clientExpectCreateError:    false,
+			clientExpectHandshakeError: false,
+			serverMutualTLS:            false,
+			serverCert:                 []tls.Certificate{serverPeerCert},
+			serverVType:                CertAndHostVerification,
+			serverExpectError:          false,
 		},
 		// Client: set clientGetRoot and bad clientVerifyFunc function
 		// Server: only set serverCert with mutual TLS off
 		// Expected Behavior: server side failure and client handshake failure
 		// Reason: custom verification function is bad
 		{
-			"Client_reload_root_verifyFuncBad_Server_peer_cert",
-			nil,
-			nil,
-			nil,
-			getRootCAsForClient,
-			verifyFuncBad,
-			CertVerification,
-			false,
-			true,
-			false,
-			[]tls.Certificate{serverPeerCert},
-			nil,
-			nil,
-			nil,
-			nil,
-			CertVerification,
-			true,
+			desc:                       "Client_reload_root_verifyFuncBad_Server_peer_cert",
+			clientGetRoot:              getRootCAsForClient,
+			clientVerifyFunc:           verifyFuncBad,
+			clientVType:                CertVerification,
+			clientExpectCreateError:    false,
+			clientExpectHandshakeError: true,
+			serverMutualTLS:            false,
+			serverCert:                 []tls.Certificate{serverPeerCert},
+			serverVType:                CertVerification,
+			serverExpectError:          true,
 		},
 		// Client: set clientGetRoot and clientVerifyFunc
 		// Server: nil setting
 		// Expected Behavior: server side failure
 		// Reason: server side must either set serverCert or serverGetCert
 		{
-			"Client_reload_root_verifyFuncGood_Server_nil",
-			nil,
-			nil,
-			nil,
-			getRootCAsForClient,
-			verifyFuncGood,
-			CertVerification,
-			false,
-			false,
-			false,
-			nil,
-			nil,
-			nil,
-			nil,
-			nil,
-			CertVerification,
-			true,
+			desc:                       "Client_reload_root_verifyFuncGood_Server_nil",
+			clientGetRoot:              getRootCAsForClient,
+			clientVerifyFunc:           verifyFuncGood,
+			clientVType:                CertVerification,
+			clientExpectCreateError:    false,
+			clientExpectHandshakeError: false,
+			serverMutualTLS:            false,
+			serverVType:                CertVerification,
+			serverExpectError:          true,
 		},
 		// Client: set clientGetRoot, clientVerifyFunc and clientCert
 		// Server: set serverRoot and serverCert with mutual TLS on
 		// Expected Behavior: success
 		{
-			"Client_peer_cert_reload_root_verifyFuncGood_Server_peer_cert_root_cert_mutualTLS",
-			[]tls.Certificate{clientPeerCert},
-			nil,
-			nil,
-			getRootCAsForClient,
-			verifyFuncGood,
-			CertVerification,
-			false,
-			false,
-			true,
-			[]tls.Certificate{serverPeerCert},
-			nil,
-			serverTrustPool,
-			nil,
-			nil,
-			CertVerification,
-			false,
+			desc:                       "Client_peer_cert_reload_root_verifyFuncGood_Server_peer_cert_root_cert_mutualTLS",
+			clientCert:                 []tls.Certificate{clientPeerCert},
+			clientGetRoot:              getRootCAsForClient,
+			clientVerifyFunc:           verifyFuncGood,
+			clientVType:                CertVerification,
+			clientExpectCreateError:    false,
+			clientExpectHandshakeError: false,
+			serverMutualTLS:            true,
+			serverCert:                 []tls.Certificate{serverPeerCert},
+			serverRoot:                 serverTrustPool,
+			serverVType:                CertVerification,
+			serverExpectError:          false,
 		},
 		// Client: set clientGetRoot, clientVerifyFunc and clientCert
 		// Server: set serverCert, but not setting any of serverRoot, serverGetRoot
@@ -287,45 +227,34 @@ func TestClientServerHandshake(t *testing.T) {
 		// mTLS in on, even setting vType to SkipVerification. Servers should at
 		// least provide their own verification logic.
 		{
-			"Client_peer_cert_reload_root_verifyFuncGood_Server_no_verification_mutualTLS",
-			[]tls.Certificate{clientPeerCert},
-			nil,
-			nil,
-			getRootCAsForClient,
-			verifyFuncGood,
-			CertVerification,
-			false,
-			true,
-			true,
-			[]tls.Certificate{serverPeerCert},
-			nil,
-			nil,
-			nil,
-			nil,
-			SkipVerification,
-			true,
+			desc:                       "Client_peer_cert_reload_root_verifyFuncGood_Server_no_verification_mutualTLS",
+			clientCert:                 []tls.Certificate{clientPeerCert},
+			clientGetRoot:              getRootCAsForClient,
+			clientVerifyFunc:           verifyFuncGood,
+			clientVType:                CertVerification,
+			clientExpectCreateError:    false,
+			clientExpectHandshakeError: true,
+			serverMutualTLS:            true,
+			serverCert:                 []tls.Certificate{serverPeerCert},
+			serverVType:                SkipVerification,
+			serverExpectError:          true,
 		},
 		// Client: set clientGetRoot, clientVerifyFunc and clientCert
 		// Server: set serverGetRoot and serverCert with mutual TLS on
 		// Expected Behavior: success
 		{
-			"Client_peer_cert_reload_root_verifyFuncGood_Server_peer_cert_reload_root_mutualTLS",
-			[]tls.Certificate{clientPeerCert},
-			nil,
-			nil,
-			getRootCAsForClient,
-			verifyFuncGood,
-			CertVerification,
-			false,
-			false,
-			true,
-			[]tls.Certificate{serverPeerCert},
-			nil,
-			nil,
-			getRootCAsForServer,
-			nil,
-			CertVerification,
-			false,
+			desc:                       "Client_peer_cert_reload_root_verifyFuncGood_Server_peer_cert_reload_root_mutualTLS",
+			clientCert:                 []tls.Certificate{clientPeerCert},
+			clientGetRoot:              getRootCAsForClient,
+			clientVerifyFunc:           verifyFuncGood,
+			clientVType:                CertVerification,
+			clientExpectCreateError:    false,
+			clientExpectHandshakeError: false,
+			serverMutualTLS:            true,
+			serverCert:                 []tls.Certificate{serverPeerCert},
+			serverGetRoot:              getRootCAsForServer,
+			serverVType:                CertVerification,
+			serverExpectError:          false,
 		},
 		// Client: set clientGetRoot, clientVerifyFunc and clientCert
 		// Server: set serverGetRoot returning error and serverCert with mutual
@@ -333,49 +262,40 @@ func TestClientServerHandshake(t *testing.T) {
 		// Expected Behavior: server side failure
 		// Reason: server side reloading returns failure
 		{
-			"Client_peer_cert_reload_root_verifyFuncGood_Server_peer_cert_bad_reload_root_mutualTLS",
-			[]tls.Certificate{clientPeerCert},
-			nil,
-			nil,
-			getRootCAsForClient,
-			verifyFuncGood,
-			CertVerification,
-			false,
-			false,
-			true,
-			[]tls.Certificate{serverPeerCert},
-			nil,
-			nil,
-			getRootCAsForServerBad,
-			nil,
-			CertVerification,
-			true,
+			desc:                       "Client_peer_cert_reload_root_verifyFuncGood_Server_peer_cert_bad_reload_root_mutualTLS",
+			clientCert:                 []tls.Certificate{clientPeerCert},
+			clientGetRoot:              getRootCAsForClient,
+			clientVerifyFunc:           verifyFuncGood,
+			clientVType:                CertVerification,
+			clientExpectCreateError:    false,
+			clientExpectHandshakeError: false,
+			serverMutualTLS:            true,
+			serverCert:                 []tls.Certificate{serverPeerCert},
+			serverGetRoot:              getRootCAsForServerBad,
+			serverVType:                CertVerification,
+			serverExpectError:          true,
 		},
-		// Client: set clientGetRoot, clientVerifyFunc and clientGetClientCert
+		// Client: set clientGetRoot, clientVerifyFunc and clientGetCert
 		// Server: set serverGetRoot and serverGetCert with mutual TLS on
 		// Expected Behavior: success
 		{
-			"Client_reload_both_certs_verifyFuncGood_Server_reload_both_certs_mutualTLS",
-			nil,
-			func(info *tls.CertificateRequestInfo) (*tls.Certificate, error) {
+			desc: "Client_reload_both_certs_verifyFuncGood_Server_reload_both_certs_mutualTLS",
+			clientGetCert: func(info *tls.CertificateRequestInfo) (*tls.Certificate, error) {
 				return &clientPeerCert, nil
 			},
-			nil,
-			getRootCAsForClient,
-			verifyFuncGood,
-			CertVerification,
-			false,
-			false,
-			true,
-			nil,
-			func(info *tls.ClientHelloInfo) (*tls.Certificate, error) {
+			clientGetRoot:              getRootCAsForClient,
+			clientVerifyFunc:           verifyFuncGood,
+			clientVType:                CertVerification,
+			clientExpectCreateError:    false,
+			clientExpectHandshakeError: false,
+			serverMutualTLS:            true,
+			serverGetCert: func(info *tls.ClientHelloInfo) (*tls.Certificate, error) {
 				return &serverPeerCert, nil
 			},
-			nil,
-			getRootCAsForServer,
-			verifyFuncGood,
-			CertVerification,
-			false,
+			serverGetRoot:     getRootCAsForServer,
+			serverVerifyFunc:  verifyFuncGood,
+			serverVType:       CertVerification,
+			serverExpectError: false,
 		},
 		// Client: set everything but with the wrong peer cert not trusted by
 		// server
@@ -383,54 +303,46 @@ func TestClientServerHandshake(t *testing.T) {
 		// Expected Behavior: server side returns failure because of
 		// certificate mismatch
 		{
-			"Client_wrong_peer_cert_Server_reload_both_certs_mutualTLS",
-			nil,
-			func(info *tls.CertificateRequestInfo) (*tls.Certificate, error) {
+			desc: "Client_wrong_peer_cert_Server_reload_both_certs_mutualTLS",
+			clientGetCert: func(info *tls.CertificateRequestInfo) (*tls.Certificate, error) {
 				return &serverPeerCert, nil
 			},
-			nil,
-			getRootCAsForClient,
-			verifyFuncGood,
-			CertVerification,
-			false,
-			false,
-			true,
-			nil,
-			func(info *tls.ClientHelloInfo) (*tls.Certificate, error) {
+			clientGetRoot:              getRootCAsForClient,
+			clientVerifyFunc:           verifyFuncGood,
+			clientVType:                CertVerification,
+			clientExpectCreateError:    false,
+			clientExpectHandshakeError: false,
+			serverMutualTLS:            true,
+			serverGetCert: func(info *tls.ClientHelloInfo) (*tls.Certificate, error) {
 				return &serverPeerCert, nil
 			},
-			nil,
-			getRootCAsForServer,
-			verifyFuncGood,
-			CertVerification,
-			true,
+			serverGetRoot:     getRootCAsForServer,
+			serverVerifyFunc:  verifyFuncGood,
+			serverVType:       CertVerification,
+			serverExpectError: true,
 		},
 		// Client: set everything but with the wrong trust cert not trusting server
 		// Server: set serverGetRoot and serverGetCert with mutual TLS on
 		// Expected Behavior: server side and client side return failure due to
 		// certificate mismatch and handshake failure
 		{
-			"Client_wrong_trust_cert_Server_reload_both_certs_mutualTLS",
-			nil,
-			func(info *tls.CertificateRequestInfo) (*tls.Certificate, error) {
+			desc: "Client_wrong_trust_cert_Server_reload_both_certs_mutualTLS",
+			clientGetCert: func(info *tls.CertificateRequestInfo) (*tls.Certificate, error) {
 				return &clientPeerCert, nil
 			},
-			nil,
-			getRootCAsForServer,
-			verifyFuncGood,
-			CertVerification,
-			false,
-			true,
-			true,
-			nil,
-			func(info *tls.ClientHelloInfo) (*tls.Certificate, error) {
+			clientGetRoot:              getRootCAsForServer,
+			clientVerifyFunc:           verifyFuncGood,
+			clientVType:                CertVerification,
+			clientExpectCreateError:    false,
+			clientExpectHandshakeError: true,
+			serverMutualTLS:            true,
+			serverGetCert: func(info *tls.ClientHelloInfo) (*tls.Certificate, error) {
 				return &serverPeerCert, nil
 			},
-			nil,
-			getRootCAsForServer,
-			verifyFuncGood,
-			CertVerification,
-			true,
+			serverGetRoot:     getRootCAsForServer,
+			serverVerifyFunc:  verifyFuncGood,
+			serverVType:       CertVerification,
+			serverExpectError: true,
 		},
 		// Client: set clientGetRoot, clientVerifyFunc and clientCert
 		// Server: set everything but with the wrong peer cert not trusted by
@@ -438,77 +350,65 @@ func TestClientServerHandshake(t *testing.T) {
 		// Expected Behavior: server side and client side return failure due to
 		// certificate mismatch and handshake failure
 		{
-			"Client_reload_both_certs_verifyFuncGood_Server_wrong_peer_cert",
-			nil,
-			func(info *tls.CertificateRequestInfo) (*tls.Certificate, error) {
+			desc: "Client_reload_both_certs_verifyFuncGood_Server_wrong_peer_cert",
+			clientGetCert: func(info *tls.CertificateRequestInfo) (*tls.Certificate, error) {
 				return &clientPeerCert, nil
 			},
-			nil,
-			getRootCAsForClient,
-			verifyFuncGood,
-			CertVerification,
-			false,
-			false,
-			true,
-			nil,
-			func(info *tls.ClientHelloInfo) (*tls.Certificate, error) {
+			clientGetRoot:              getRootCAsForClient,
+			clientVerifyFunc:           verifyFuncGood,
+			clientVType:                CertVerification,
+			clientExpectCreateError:    false,
+			clientExpectHandshakeError: false,
+			serverMutualTLS:            true,
+			serverGetCert: func(info *tls.ClientHelloInfo) (*tls.Certificate, error) {
 				return &clientPeerCert, nil
 			},
-			nil,
-			getRootCAsForServer,
-			verifyFuncGood,
-			CertVerification,
-			true,
+			serverGetRoot:     getRootCAsForServer,
+			serverVerifyFunc:  verifyFuncGood,
+			serverVType:       CertVerification,
+			serverExpectError: true,
 		},
 		// Client: set clientGetRoot, clientVerifyFunc and clientCert
 		// Server: set everything but with the wrong trust cert not trusting client
 		// Expected Behavior: server side and client side return failure due to
 		// certificate mismatch and handshake failure
 		{
-			"Client_reload_both_certs_verifyFuncGood_Server_wrong_trust_cert",
-			nil,
-			func(info *tls.CertificateRequestInfo) (*tls.Certificate, error) {
+			desc: "Client_reload_both_certs_verifyFuncGood_Server_wrong_trust_cert",
+			clientGetCert: func(info *tls.CertificateRequestInfo) (*tls.Certificate, error) {
 				return &clientPeerCert, nil
 			},
-			nil,
-			getRootCAsForClient,
-			verifyFuncGood,
-			CertVerification,
-			false,
-			true,
-			true,
-			nil,
-			func(info *tls.ClientHelloInfo) (*tls.Certificate, error) {
+			clientGetRoot:              getRootCAsForClient,
+			clientVerifyFunc:           verifyFuncGood,
+			clientVType:                CertVerification,
+			clientExpectCreateError:    false,
+			clientExpectHandshakeError: true,
+			serverMutualTLS:            true,
+			serverGetCert: func(info *tls.ClientHelloInfo) (*tls.Certificate, error) {
 				return &serverPeerCert, nil
 			},
-			nil,
-			getRootCAsForClient,
-			verifyFuncGood,
-			CertVerification,
-			true,
+			serverGetRoot:     getRootCAsForClient,
+			serverVerifyFunc:  verifyFuncGood,
+			serverVType:       CertVerification,
+			serverExpectError: true,
 		},
 		// Client: set clientGetRoot, clientVerifyFunc and clientCert
 		// Server: set serverGetRoot and serverCert, but with bad verifyFunc
 		// Expected Behavior: server side and client side return failure due to
 		// server custom check fails
 		{
-			"Client_peer_cert_reload_root_verifyFuncGood_Server_bad_custom_verification_mutualTLS",
-			[]tls.Certificate{clientPeerCert},
-			nil,
-			nil,
-			getRootCAsForClient,
-			verifyFuncGood,
-			CertVerification,
-			false,
-			true,
-			true,
-			[]tls.Certificate{serverPeerCert},
-			nil,
-			nil,
-			getRootCAsForServer,
-			verifyFuncBad,
-			CertVerification,
-			true,
+			desc:                       "Client_peer_cert_reload_root_verifyFuncGood_Server_bad_custom_verification_mutualTLS",
+			clientCert:                 []tls.Certificate{clientPeerCert},
+			clientGetRoot:              getRootCAsForClient,
+			clientVerifyFunc:           verifyFuncGood,
+			clientVType:                CertVerification,
+			clientExpectCreateError:    false,
+			clientExpectHandshakeError: true,
+			serverMutualTLS:            true,
+			serverCert:                 []tls.Certificate{serverPeerCert},
+			serverGetRoot:              getRootCAsForServer,
+			serverVerifyFunc:           verifyFuncBad,
+			serverVType:                CertVerification,
+			serverExpectError:          true,
 		},
 	} {
 		test := test
@@ -560,7 +460,7 @@ func TestClientServerHandshake(t *testing.T) {
 			defer conn.Close()
 			clientOptions := &ClientOptions{
 				Certificates:         test.clientCert,
-				GetClientCertificate: test.clientGetClientCert,
+				GetClientCertificate: test.clientGetCert,
 				VerifyPeer:           test.clientVerifyFunc,
 				RootCertificateOptions: RootCertificateOptions{
 					RootCACerts: test.clientRoot,

--- a/security/advancedtls/advancedtls_test.go
+++ b/security/advancedtls/advancedtls_test.go
@@ -97,14 +97,12 @@ func TestClientServerHandshake(t *testing.T) {
 		// even setting vType to SkipVerification. Clients should at least provide
 		// their own verification logic.
 		{
-			desc:                       "Client_no_trust_cert_Server_peer_cert",
-			clientVType:                SkipVerification,
-			clientExpectCreateError:    true,
-			clientExpectHandshakeError: false,
-			serverMutualTLS:            false,
-			serverCert:                 []tls.Certificate{serverPeerCert},
-			serverVType:                CertAndHostVerification,
-			serverExpectError:          true,
+			desc:                    "Client has no trust cert; server sends peer cert",
+			clientVType:             SkipVerification,
+			clientExpectCreateError: true,
+			serverCert:              []tls.Certificate{serverPeerCert},
+			serverVType:             CertAndHostVerification,
+			serverExpectError:       true,
 		},
 		// Client: nil setting except verifyFuncGood
 		// Server: only set serverCert with mutual TLS off
@@ -112,15 +110,11 @@ func TestClientServerHandshake(t *testing.T) {
 		// Reason: we will use verifyFuncGood to verify the server,
 		// if either clientCert or clientGetCert is not set
 		{
-			desc:                       "Client_no_trust_cert_verifyFuncGood_Server_peer_cert",
-			clientVerifyFunc:           verifyFuncGood,
-			clientVType:                SkipVerification,
-			clientExpectCreateError:    false,
-			clientExpectHandshakeError: false,
-			serverMutualTLS:            false,
-			serverCert:                 []tls.Certificate{serverPeerCert},
-			serverVType:                CertAndHostVerification,
-			serverExpectError:          false,
+			desc:             "Client has no trust cert with verifyFuncGood; server sends peer cert",
+			clientVerifyFunc: verifyFuncGood,
+			clientVType:      SkipVerification,
+			serverCert:       []tls.Certificate{serverPeerCert},
+			serverVType:      CertAndHostVerification,
 		},
 		// Client: only set clientRoot
 		// Server: only set serverCert with mutual TLS off
@@ -129,12 +123,10 @@ func TestClientServerHandshake(t *testing.T) {
 		// default hostname check. All the default hostname checks will fail in
 		// this test suites.
 		{
-			desc:                       "Client_root_cert_Server_peer_cert",
+			desc:                       "Client has root cert; server sends peer cert",
 			clientRoot:                 clientTrustPool,
 			clientVType:                CertAndHostVerification,
-			clientExpectCreateError:    false,
 			clientExpectHandshakeError: true,
-			serverMutualTLS:            false,
 			serverCert:                 []tls.Certificate{serverPeerCert},
 			serverVType:                CertAndHostVerification,
 			serverExpectError:          true,
@@ -146,12 +138,10 @@ func TestClientServerHandshake(t *testing.T) {
 		// default hostname check. All the default hostname checks will fail in
 		// this test suites.
 		{
-			desc:                       "Client_reload_root_Server_peer_cert",
+			desc:                       "Client sets reload root function; server sends peer cert",
 			clientGetRoot:              getRootCAsForClient,
 			clientVType:                CertAndHostVerification,
-			clientExpectCreateError:    false,
 			clientExpectHandshakeError: true,
-			serverMutualTLS:            false,
 			serverCert:                 []tls.Certificate{serverPeerCert},
 			serverVType:                CertAndHostVerification,
 			serverExpectError:          true,
@@ -160,29 +150,23 @@ func TestClientServerHandshake(t *testing.T) {
 		// Server: only set serverCert with mutual TLS off
 		// Expected Behavior: success
 		{
-			desc:                       "Client_reload_root_verifyFuncGood_Server_peer_cert",
-			clientGetRoot:              getRootCAsForClient,
-			clientVerifyFunc:           verifyFuncGood,
-			clientVType:                CertVerification,
-			clientExpectCreateError:    false,
-			clientExpectHandshakeError: false,
-			serverMutualTLS:            false,
-			serverCert:                 []tls.Certificate{serverPeerCert},
-			serverVType:                CertAndHostVerification,
-			serverExpectError:          false,
+			desc:             "Client sets reload root function with verifyFuncGood; server sends peer cert",
+			clientGetRoot:    getRootCAsForClient,
+			clientVerifyFunc: verifyFuncGood,
+			clientVType:      CertVerification,
+			serverCert:       []tls.Certificate{serverPeerCert},
+			serverVType:      CertAndHostVerification,
 		},
 		// Client: set clientGetRoot and bad clientVerifyFunc function
 		// Server: only set serverCert with mutual TLS off
 		// Expected Behavior: server side failure and client handshake failure
 		// Reason: custom verification function is bad
 		{
-			desc:                       "Client_reload_root_verifyFuncBad_Server_peer_cert",
+			desc:                       "Client sets reload root function with verifyFuncBad; server sends peer cert",
 			clientGetRoot:              getRootCAsForClient,
 			clientVerifyFunc:           verifyFuncBad,
 			clientVType:                CertVerification,
-			clientExpectCreateError:    false,
 			clientExpectHandshakeError: true,
-			serverMutualTLS:            false,
 			serverCert:                 []tls.Certificate{serverPeerCert},
 			serverVType:                CertVerification,
 			serverExpectError:          true,
@@ -192,32 +176,26 @@ func TestClientServerHandshake(t *testing.T) {
 		// Expected Behavior: server side failure
 		// Reason: server side must either set serverCert or serverGetCert
 		{
-			desc:                       "Client_reload_root_verifyFuncGood_Server_nil",
-			clientGetRoot:              getRootCAsForClient,
-			clientVerifyFunc:           verifyFuncGood,
-			clientVType:                CertVerification,
-			clientExpectCreateError:    false,
-			clientExpectHandshakeError: false,
-			serverMutualTLS:            false,
-			serverVType:                CertVerification,
-			serverExpectError:          true,
+			desc:              "Client sets reload root function with verifyFuncGood; server sets nil",
+			clientGetRoot:     getRootCAsForClient,
+			clientVerifyFunc:  verifyFuncGood,
+			clientVType:       CertVerification,
+			serverVType:       CertVerification,
+			serverExpectError: true,
 		},
 		// Client: set clientGetRoot, clientVerifyFunc and clientCert
 		// Server: set serverRoot and serverCert with mutual TLS on
 		// Expected Behavior: success
 		{
-			desc:                       "Client_peer_cert_reload_root_verifyFuncGood_Server_peer_cert_root_cert_mutualTLS",
-			clientCert:                 []tls.Certificate{clientPeerCert},
-			clientGetRoot:              getRootCAsForClient,
-			clientVerifyFunc:           verifyFuncGood,
-			clientVType:                CertVerification,
-			clientExpectCreateError:    false,
-			clientExpectHandshakeError: false,
-			serverMutualTLS:            true,
-			serverCert:                 []tls.Certificate{serverPeerCert},
-			serverRoot:                 serverTrustPool,
-			serverVType:                CertVerification,
-			serverExpectError:          false,
+			desc:             "Client sets peer cert, reload root function with verifyFuncGood; server sets peer cert and root cert; mutualTLS",
+			clientCert:       []tls.Certificate{clientPeerCert},
+			clientGetRoot:    getRootCAsForClient,
+			clientVerifyFunc: verifyFuncGood,
+			clientVType:      CertVerification,
+			serverMutualTLS:  true,
+			serverCert:       []tls.Certificate{serverPeerCert},
+			serverRoot:       serverTrustPool,
+			serverVType:      CertVerification,
 		},
 		// Client: set clientGetRoot, clientVerifyFunc and clientCert
 		// Server: set serverCert, but not setting any of serverRoot, serverGetRoot
@@ -227,12 +205,11 @@ func TestClientServerHandshake(t *testing.T) {
 		// mTLS in on, even setting vType to SkipVerification. Servers should at
 		// least provide their own verification logic.
 		{
-			desc:                       "Client_peer_cert_reload_root_verifyFuncGood_Server_no_verification_mutualTLS",
+			desc:                       "Client sets peer cert, reload root function with verifyFuncGood; server sets no verification; mutualTLS",
 			clientCert:                 []tls.Certificate{clientPeerCert},
 			clientGetRoot:              getRootCAsForClient,
 			clientVerifyFunc:           verifyFuncGood,
 			clientVType:                CertVerification,
-			clientExpectCreateError:    false,
 			clientExpectHandshakeError: true,
 			serverMutualTLS:            true,
 			serverCert:                 []tls.Certificate{serverPeerCert},
@@ -243,18 +220,15 @@ func TestClientServerHandshake(t *testing.T) {
 		// Server: set serverGetRoot and serverCert with mutual TLS on
 		// Expected Behavior: success
 		{
-			desc:                       "Client_peer_cert_reload_root_verifyFuncGood_Server_peer_cert_reload_root_mutualTLS",
-			clientCert:                 []tls.Certificate{clientPeerCert},
-			clientGetRoot:              getRootCAsForClient,
-			clientVerifyFunc:           verifyFuncGood,
-			clientVType:                CertVerification,
-			clientExpectCreateError:    false,
-			clientExpectHandshakeError: false,
-			serverMutualTLS:            true,
-			serverCert:                 []tls.Certificate{serverPeerCert},
-			serverGetRoot:              getRootCAsForServer,
-			serverVType:                CertVerification,
-			serverExpectError:          false,
+			desc:             "Client sets peer cert, reload root function with verifyFuncGood; Server sets peer cert, reload root function; mutualTLS",
+			clientCert:       []tls.Certificate{clientPeerCert},
+			clientGetRoot:    getRootCAsForClient,
+			clientVerifyFunc: verifyFuncGood,
+			clientVType:      CertVerification,
+			serverMutualTLS:  true,
+			serverCert:       []tls.Certificate{serverPeerCert},
+			serverGetRoot:    getRootCAsForServer,
+			serverVType:      CertVerification,
 		},
 		// Client: set clientGetRoot, clientVerifyFunc and clientCert
 		// Server: set serverGetRoot returning error and serverCert with mutual
@@ -262,40 +236,35 @@ func TestClientServerHandshake(t *testing.T) {
 		// Expected Behavior: server side failure
 		// Reason: server side reloading returns failure
 		{
-			desc:                       "Client_peer_cert_reload_root_verifyFuncGood_Server_peer_cert_bad_reload_root_mutualTLS",
-			clientCert:                 []tls.Certificate{clientPeerCert},
-			clientGetRoot:              getRootCAsForClient,
-			clientVerifyFunc:           verifyFuncGood,
-			clientVType:                CertVerification,
-			clientExpectCreateError:    false,
-			clientExpectHandshakeError: false,
-			serverMutualTLS:            true,
-			serverCert:                 []tls.Certificate{serverPeerCert},
-			serverGetRoot:              getRootCAsForServerBad,
-			serverVType:                CertVerification,
-			serverExpectError:          true,
+			desc:              "Client sets peer cert, reload root function with verifyFuncGood; Server sets peer cert, bad reload root function; mutualTLS",
+			clientCert:        []tls.Certificate{clientPeerCert},
+			clientGetRoot:     getRootCAsForClient,
+			clientVerifyFunc:  verifyFuncGood,
+			clientVType:       CertVerification,
+			serverMutualTLS:   true,
+			serverCert:        []tls.Certificate{serverPeerCert},
+			serverGetRoot:     getRootCAsForServerBad,
+			serverVType:       CertVerification,
+			serverExpectError: true,
 		},
 		// Client: set clientGetRoot, clientVerifyFunc and clientGetCert
 		// Server: set serverGetRoot and serverGetCert with mutual TLS on
 		// Expected Behavior: success
 		{
-			desc: "Client_reload_both_certs_verifyFuncGood_Server_reload_both_certs_mutualTLS",
+			desc: "Client sets reload peer/root function with verifyFuncGood; Server sets reload peer/root function with verifyFuncGood; mutualTLS",
 			clientGetCert: func(info *tls.CertificateRequestInfo) (*tls.Certificate, error) {
 				return &clientPeerCert, nil
 			},
-			clientGetRoot:              getRootCAsForClient,
-			clientVerifyFunc:           verifyFuncGood,
-			clientVType:                CertVerification,
-			clientExpectCreateError:    false,
-			clientExpectHandshakeError: false,
-			serverMutualTLS:            true,
+			clientGetRoot:    getRootCAsForClient,
+			clientVerifyFunc: verifyFuncGood,
+			clientVType:      CertVerification,
+			serverMutualTLS:  true,
 			serverGetCert: func(info *tls.ClientHelloInfo) (*tls.Certificate, error) {
 				return &serverPeerCert, nil
 			},
-			serverGetRoot:     getRootCAsForServer,
-			serverVerifyFunc:  verifyFuncGood,
-			serverVType:       CertVerification,
-			serverExpectError: false,
+			serverGetRoot:    getRootCAsForServer,
+			serverVerifyFunc: verifyFuncGood,
+			serverVType:      CertVerification,
 		},
 		// Client: set everything but with the wrong peer cert not trusted by
 		// server
@@ -303,16 +272,14 @@ func TestClientServerHandshake(t *testing.T) {
 		// Expected Behavior: server side returns failure because of
 		// certificate mismatch
 		{
-			desc: "Client_wrong_peer_cert_Server_reload_both_certs_mutualTLS",
+			desc: "Client sends wrong peer cert; Server sets reload peer/root function with verifyFuncGood; mutualTLS",
 			clientGetCert: func(info *tls.CertificateRequestInfo) (*tls.Certificate, error) {
 				return &serverPeerCert, nil
 			},
-			clientGetRoot:              getRootCAsForClient,
-			clientVerifyFunc:           verifyFuncGood,
-			clientVType:                CertVerification,
-			clientExpectCreateError:    false,
-			clientExpectHandshakeError: false,
-			serverMutualTLS:            true,
+			clientGetRoot:    getRootCAsForClient,
+			clientVerifyFunc: verifyFuncGood,
+			clientVType:      CertVerification,
+			serverMutualTLS:  true,
 			serverGetCert: func(info *tls.ClientHelloInfo) (*tls.Certificate, error) {
 				return &serverPeerCert, nil
 			},
@@ -326,14 +293,13 @@ func TestClientServerHandshake(t *testing.T) {
 		// Expected Behavior: server side and client side return failure due to
 		// certificate mismatch and handshake failure
 		{
-			desc: "Client_wrong_trust_cert_Server_reload_both_certs_mutualTLS",
+			desc: "Client has wrong trust cert; Server sets reload peer/root function with verifyFuncGood; mutualTLS",
 			clientGetCert: func(info *tls.CertificateRequestInfo) (*tls.Certificate, error) {
 				return &clientPeerCert, nil
 			},
 			clientGetRoot:              getRootCAsForServer,
 			clientVerifyFunc:           verifyFuncGood,
 			clientVType:                CertVerification,
-			clientExpectCreateError:    false,
 			clientExpectHandshakeError: true,
 			serverMutualTLS:            true,
 			serverGetCert: func(info *tls.ClientHelloInfo) (*tls.Certificate, error) {
@@ -350,16 +316,14 @@ func TestClientServerHandshake(t *testing.T) {
 		// Expected Behavior: server side and client side return failure due to
 		// certificate mismatch and handshake failure
 		{
-			desc: "Client_reload_both_certs_verifyFuncGood_Server_wrong_peer_cert",
+			desc: "Client sets reload peer/root function with verifyFuncGood; Server sends wrong peer cert; mutualTLS",
 			clientGetCert: func(info *tls.CertificateRequestInfo) (*tls.Certificate, error) {
 				return &clientPeerCert, nil
 			},
-			clientGetRoot:              getRootCAsForClient,
-			clientVerifyFunc:           verifyFuncGood,
-			clientVType:                CertVerification,
-			clientExpectCreateError:    false,
-			clientExpectHandshakeError: false,
-			serverMutualTLS:            true,
+			clientGetRoot:    getRootCAsForClient,
+			clientVerifyFunc: verifyFuncGood,
+			clientVType:      CertVerification,
+			serverMutualTLS:  true,
 			serverGetCert: func(info *tls.ClientHelloInfo) (*tls.Certificate, error) {
 				return &clientPeerCert, nil
 			},
@@ -373,14 +337,13 @@ func TestClientServerHandshake(t *testing.T) {
 		// Expected Behavior: server side and client side return failure due to
 		// certificate mismatch and handshake failure
 		{
-			desc: "Client_reload_both_certs_verifyFuncGood_Server_wrong_trust_cert",
+			desc: "Client sets reload peer/root function with verifyFuncGood; Server has wrong trust cert; mutualTLS",
 			clientGetCert: func(info *tls.CertificateRequestInfo) (*tls.Certificate, error) {
 				return &clientPeerCert, nil
 			},
 			clientGetRoot:              getRootCAsForClient,
 			clientVerifyFunc:           verifyFuncGood,
 			clientVType:                CertVerification,
-			clientExpectCreateError:    false,
 			clientExpectHandshakeError: true,
 			serverMutualTLS:            true,
 			serverGetCert: func(info *tls.ClientHelloInfo) (*tls.Certificate, error) {
@@ -396,12 +359,11 @@ func TestClientServerHandshake(t *testing.T) {
 		// Expected Behavior: server side and client side return failure due to
 		// server custom check fails
 		{
-			desc:                       "Client_peer_cert_reload_root_verifyFuncGood_Server_bad_custom_verification_mutualTLS",
+			desc:                       "Client sets peer cert, reload root function with verifyFuncGood; Server sets bad custom check; mutualTLS",
 			clientCert:                 []tls.Certificate{clientPeerCert},
 			clientGetRoot:              getRootCAsForClient,
 			clientVerifyFunc:           verifyFuncGood,
 			clientVType:                CertVerification,
-			clientExpectCreateError:    false,
 			clientExpectHandshakeError: true,
 			serverMutualTLS:            true,
 			serverCert:                 []tls.Certificate{serverPeerCert},


### PR DESCRIPTION
This PR does two things:
1. add field names for the unit tests for better readability
2. change field name `clientGetClientCert` to `clientGetCert`, to keep it align with other names in the same struct
