### PR TITLE
balancergroup: fix connectivity state

### DIFF
--- a/xds/internal/balancer/balancergroup/balancergroup.go
+++ b/xds/internal/balancer/balancergroup/balancergroup.go
@@ -19,7 +19,6 @@
 package balancergroup
 
 import (
-	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -571,8 +570,6 @@ func (bg *BalancerGroup) Close() {
 	bg.balancerCache.Clear(true)
 }
 
-var errTransientFailure = errors.New("no sub-balancer has READY connection to pick")
-
 func buildPickerAndState(m map[internal.LocalityID]*pickerState) balancer.State {
 	var readyN, connectingN int
 	readyPickerWithWeights := make([]pickerState, 0, len(m))
@@ -604,7 +601,7 @@ func buildPickerAndState(m map[internal.LocalityID]*pickerState) balancer.State 
 	var picker balancer.Picker
 	switch aggregatedState {
 	case connectivity.TransientFailure:
-		picker = base.NewErrPicker(errTransientFailure)
+		picker = base.NewErrPicker(balancer.ErrTransientFailure)
 	case connectivity.Connecting:
 		picker = base.NewErrPicker(balancer.ErrNoSubConnAvailable)
 	default:

--- a/xds/internal/balancer/balancergroup/balancergroup_test.go
+++ b/xds/internal/balancer/balancergroup/balancergroup_test.go
@@ -224,8 +224,8 @@ func (s) TestBalancerGroup_TwoRR_MoreBackends(t *testing.T) {
 	bg.UpdateSubConnState(sc4, balancer.SubConnState{ConnectivityState: connectivity.TransientFailure})
 	p6 := <-cc.NewPickerCh
 	for i := 0; i < 5; i++ {
-		if _, err := p6.Pick(balancer.PickInfo{}); err != balancer.ErrTransientFailure {
-			t.Fatalf("want pick error %v, got %v", balancer.ErrTransientFailure, err)
+		if _, err := p6.Pick(balancer.PickInfo{}); err != errTransientFailure {
+			t.Fatalf("want pick error %v, got %v", errTransientFailure, err)
 		}
 	}
 }
@@ -322,8 +322,8 @@ func (s) TestBalancerGroup_ThreeRR_RemoveBalancer(t *testing.T) {
 	}
 	p3 := <-cc.NewPickerCh
 	for i := 0; i < 5; i++ {
-		if _, err := p3.Pick(balancer.PickInfo{}); err != balancer.ErrTransientFailure {
-			t.Fatalf("want pick error %v, got %v", balancer.ErrTransientFailure, err)
+		if _, err := p3.Pick(balancer.PickInfo{}); err != errTransientFailure {
+			t.Fatalf("want pick error %v, got %v", errTransientFailure, err)
 		}
 	}
 }
@@ -610,8 +610,8 @@ func (s) TestBalancerGroup_SubBalancerTurnsConnectingFromTransientFailure(t *tes
 	p1 := <-cc.NewPickerCh
 	for i := 0; i < 5; i++ {
 		r, err := p1.Pick(balancer.PickInfo{})
-		if err != balancer.ErrTransientFailure {
-			t.Fatalf("want pick to fail with %v, got result %v, err %v", balancer.ErrTransientFailure, r, err)
+		if err != errTransientFailure {
+			t.Fatalf("want pick to fail with %v, got result %v, err %v", errTransientFailure, r, err)
 		}
 	}
 
@@ -621,8 +621,8 @@ func (s) TestBalancerGroup_SubBalancerTurnsConnectingFromTransientFailure(t *tes
 	p2 := <-cc.NewPickerCh
 	for i := 0; i < 5; i++ {
 		r, err := p2.Pick(balancer.PickInfo{})
-		if err != balancer.ErrTransientFailure {
-			t.Fatalf("want pick to fail with %v, got result %v, err %v", balancer.ErrTransientFailure, r, err)
+		if err != errTransientFailure {
+			t.Fatalf("want pick to fail with %v, got result %v, err %v", errTransientFailure, r, err)
 		}
 	}
 }

--- a/xds/internal/balancer/balancergroup/balancergroup_test.go
+++ b/xds/internal/balancer/balancergroup/balancergroup_test.go
@@ -224,8 +224,8 @@ func (s) TestBalancerGroup_TwoRR_MoreBackends(t *testing.T) {
 	bg.UpdateSubConnState(sc4, balancer.SubConnState{ConnectivityState: connectivity.TransientFailure})
 	p6 := <-cc.NewPickerCh
 	for i := 0; i < 5; i++ {
-		if _, err := p6.Pick(balancer.PickInfo{}); err != errTransientFailure {
-			t.Fatalf("want pick error %v, got %v", errTransientFailure, err)
+		if _, err := p6.Pick(balancer.PickInfo{}); err != balancer.ErrTransientFailure {
+			t.Fatalf("want pick error %v, got %v", balancer.ErrTransientFailure, err)
 		}
 	}
 }
@@ -322,8 +322,8 @@ func (s) TestBalancerGroup_ThreeRR_RemoveBalancer(t *testing.T) {
 	}
 	p3 := <-cc.NewPickerCh
 	for i := 0; i < 5; i++ {
-		if _, err := p3.Pick(balancer.PickInfo{}); err != errTransientFailure {
-			t.Fatalf("want pick error %v, got %v", errTransientFailure, err)
+		if _, err := p3.Pick(balancer.PickInfo{}); err != balancer.ErrTransientFailure {
+			t.Fatalf("want pick error %v, got %v", balancer.ErrTransientFailure, err)
 		}
 	}
 }
@@ -610,8 +610,8 @@ func (s) TestBalancerGroup_SubBalancerTurnsConnectingFromTransientFailure(t *tes
 	p1 := <-cc.NewPickerCh
 	for i := 0; i < 5; i++ {
 		r, err := p1.Pick(balancer.PickInfo{})
-		if err != errTransientFailure {
-			t.Fatalf("want pick to fail with %v, got result %v, err %v", errTransientFailure, r, err)
+		if err != balancer.ErrTransientFailure {
+			t.Fatalf("want pick to fail with %v, got result %v, err %v", balancer.ErrTransientFailure, r, err)
 		}
 	}
 
@@ -621,8 +621,8 @@ func (s) TestBalancerGroup_SubBalancerTurnsConnectingFromTransientFailure(t *tes
 	p2 := <-cc.NewPickerCh
 	for i := 0; i < 5; i++ {
 		r, err := p2.Pick(balancer.PickInfo{})
-		if err != errTransientFailure {
-			t.Fatalf("want pick to fail with %v, got result %v, err %v", errTransientFailure, r, err)
+		if err != balancer.ErrTransientFailure {
+			t.Fatalf("want pick to fail with %v, got result %v, err %v", balancer.ErrTransientFailure, r, err)
 		}
 	}
 }


### PR DESCRIPTION
 - Stop sending empty update to sub-balancers at init time
 - At init, when only one sub-balancer reports transient failure, wait for other sub-balancers
 - When aggregating states, consider a sub-balancer turns Connecting from TransientFailure still in TransientFailure, so aggregated state doesn't stay connecting for a long time