### PR TITLE
xds_client: make sure LDS sets ConfigSource to ADS

### DIFF
--- a/xds/internal/client/v2client_lds.go
+++ b/xds/internal/client/v2client_lds.go
@@ -68,11 +68,10 @@ func (v2c *v2Client) getRouteConfigNameFromListener(lis *xdspb.Listener) (string
 	v2c.logger.Infof("Resource with type %T, contains %v", apiLis, apiLis)
 	switch apiLis.RouteSpecifier.(type) {
 	case *httppb.HttpConnectionManager_Rds:
-		tempRDS := apiLis.GetRds()
-		if tempRDS.GetConfigSource().GetAds() == nil {
+		if apiLis.GetRds().GetConfigSource().GetAds() == nil {
 			return "", fmt.Errorf("xds: ConfigSource is not ADS in LDS response: %+v", lis)
 		}
-		name := tempRDS.GetRouteConfigName()
+		name := apiLis.GetRds().GetRouteConfigName()
 		if name == "" {
 			return "", fmt.Errorf("xds: empty route_config_name in LDS response: %+v", lis)
 		}

--- a/xds/internal/client/v2client_lds.go
+++ b/xds/internal/client/v2client_lds.go
@@ -68,7 +68,11 @@ func (v2c *v2Client) getRouteConfigNameFromListener(lis *xdspb.Listener) (string
 	v2c.logger.Infof("Resource with type %T, contains %v", apiLis, apiLis)
 	switch apiLis.RouteSpecifier.(type) {
 	case *httppb.HttpConnectionManager_Rds:
-		name := apiLis.GetRds().GetRouteConfigName()
+		tempRDS := apiLis.GetRds()
+		if tempRDS.GetConfigSource().GetAds() == nil {
+			return "", fmt.Errorf("xds: ConfigSource is not ADS in LDS response: %+v", lis)
+		}
+		name := tempRDS.GetRouteConfigName()
 		if name == "" {
 			return "", fmt.Errorf("xds: empty route_config_name in LDS response: %+v", lis)
 		}

--- a/xds/internal/client/v2client_lds_test.go
+++ b/xds/internal/client/v2client_lds_test.go
@@ -22,7 +22,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/golang/protobuf/proto"
+
 	xdspb "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	basepb "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	httppb "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
+	listenerpb "github.com/envoyproxy/go-control-plane/envoy/config/listener/v2"
+	anypb "github.com/golang/protobuf/ptypes/any"
 )
 
 func (s) TestLDSGetRouteConfig(t *testing.T) {
@@ -59,6 +65,29 @@ func (s) TestLDSGetRouteConfig(t *testing.T) {
 		{
 			name:      "scopedRoutes-routeConfig-in-apiListener",
 			lis:       listenerWithScopedRoutesRouteConfig,
+			wantRoute: "",
+			wantErr:   true,
+		},
+		{
+			name: "rds.ConfigSource-in-apiListener-is-not-ADS",
+			lis: &xdspb.Listener{
+				Name: goodLDSTarget1,
+				ApiListener: &listenerpb.ApiListener{
+					ApiListener: &anypb.Any{
+						TypeUrl: httpConnManagerURL,
+						Value: func() []byte {
+							goodHTTPConnManager1 = &httppb.HttpConnectionManager{
+								RouteSpecifier: &httppb.HttpConnectionManager_Rds{
+									Rds: &httppb.Rds{
+										ConfigSource: &basepb.ConfigSource{
+											ConfigSourceSpecifier: &basepb.ConfigSource_Path{
+												Path: "/some/path",
+											},
+										},
+										RouteConfigName: goodRouteName1}}}
+							marshaledConnMgr1, _ = proto.Marshal(goodHTTPConnManager1)
+							return marshaledConnMgr1
+						}()}}},
 			wantRoute: "",
 			wantErr:   true,
 		},

--- a/xds/internal/client/v2client_lds_test.go
+++ b/xds/internal/client/v2client_lds_test.go
@@ -76,7 +76,7 @@ func (s) TestLDSGetRouteConfig(t *testing.T) {
 					ApiListener: &anypb.Any{
 						TypeUrl: httpConnManagerURL,
 						Value: func() []byte {
-							goodHTTPConnManager1 = &httppb.HttpConnectionManager{
+							cm := &httppb.HttpConnectionManager{
 								RouteSpecifier: &httppb.HttpConnectionManager_Rds{
 									Rds: &httppb.Rds{
 										ConfigSource: &basepb.ConfigSource{
@@ -85,8 +85,8 @@ func (s) TestLDSGetRouteConfig(t *testing.T) {
 											},
 										},
 										RouteConfigName: goodRouteName1}}}
-							marshaledConnMgr1, _ = proto.Marshal(goodHTTPConnManager1)
-							return marshaledConnMgr1
+							mcm, _ := proto.Marshal(cm)
+							return mcm
 						}()}}},
 			wantRoute: "",
 			wantErr:   true,

--- a/xds/internal/client/v2client_test.go
+++ b/xds/internal/client/v2client_test.go
@@ -88,6 +88,9 @@ var (
 	goodHTTPConnManager1 = &httppb.HttpConnectionManager{
 		RouteSpecifier: &httppb.HttpConnectionManager_Rds{
 			Rds: &httppb.Rds{
+				ConfigSource: &basepb.ConfigSource{
+					ConfigSourceSpecifier: &basepb.ConfigSource_Ads{Ads: &basepb.AggregatedConfigSource{}},
+				},
 				RouteConfigName: goodRouteName1,
 			},
 		},


### PR DESCRIPTION
When LDS tells client to make an RDS request, ConfigSource should be set to ADS.