### PR TITLE
advancedtls: remove test.Fatal() from child goroutine

### DIFF
--- a/security/advancedtls/advancedtls_integration_test.go
+++ b/security/advancedtls/advancedtls_integration_test.go
@@ -404,17 +404,13 @@ func TestEnd2End(t *testing.T) {
 			}
 			s := grpc.NewServer(grpc.Creds(serverTLSCreds))
 			defer s.Stop()
-			go func(s *grpc.Server) {
-				lis, err := net.Listen("tcp", port)
-				// defer lis.Close()
-				if err != nil {
-					t.Fatalf("failed to listen: %v", err)
-				}
-				pb.RegisterGreeterServer(s, &serverImpl{})
-				if err := s.Serve(lis); err != nil {
-					t.Fatalf("failed to serve: %v", err)
-				}
-			}(s)
+			lis, err := net.Listen("tcp", port)
+			defer lis.Close()
+			if err != nil {
+				t.Fatalf("failed to listen: %v", err)
+			}
+			pb.RegisterGreeterServer(s, &serverImpl{})
+			go s.Serve(lis)
 			clientOptions := &ClientOptions{
 				Certificates:         test.clientCert,
 				GetClientCertificate: test.clientGetCert,


### PR DESCRIPTION
This is to fix https://github.com/grpc/grpc-go/issues/3587 and be a better replacement of https://github.com/grpc/grpc-go/pull/3590.

@menghanl Could you please also take a look and see if we have any alternatives here? Thank you so much in advance!