### PR TITLE
xds: handle weighted cluster as route action

### DIFF
--- a/internal/internal.go
+++ b/internal/internal.go
@@ -49,8 +49,8 @@ var (
 	ParseServiceConfigForTesting interface{} // func(string) *serviceconfig.ParseResult
 	// EqualServiceConfigForTesting is for testing service config generation and
 	// parsing. Both a and b should be returned by ParseServiceConfigForTesting.
-	// This function removes rawJSON before compareing, and adds back
-	// afterwards.
+	// This function compares the config without rawJSON stripped, in case the
+	// there's difference in white space.
 	EqualServiceConfigForTesting func(a, b serviceconfig.Config) bool
 )
 

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"google.golang.org/grpc/connectivity"
+	"google.golang.org/grpc/serviceconfig"
 )
 
 var (
@@ -46,6 +47,11 @@ var (
 	// ParseServiceConfigForTesting is for creating a fake
 	// ClientConn for resolver testing only
 	ParseServiceConfigForTesting interface{} // func(string) *serviceconfig.ParseResult
+	// EqualServiceConfigForTesting is for testing service config generation and
+	// parsing. Both a and b should be returned by ParseServiceConfigForTesting.
+	// This function removes rawJSON before compareing, and adds back
+	// afterwards.
+	EqualServiceConfigForTesting func(a, b serviceconfig.Config) bool
 )
 
 // HealthChecker defines the signature of the client-side LB channel health checking function.

--- a/service_config.go
+++ b/service_config.go
@@ -406,8 +406,8 @@ func init() {
 	internal.EqualServiceConfigForTesting = equalServiceConfig
 }
 
-// equalServiceConfig compares two configs. If modifies the configs to remove
-// rawJSONString before comparing, and adds it backwards.
+// equalServiceConfig compares two configs. The rawJSONString field is ignored,
+// because they may diff in white spaces.
 //
 // If any of them is NOT *ServiceConfig, return false.
 func equalServiceConfig(a, b serviceconfig.Config) bool {
@@ -427,5 +427,8 @@ func equalServiceConfig(a, b serviceconfig.Config) bool {
 		aa.rawJSONString = aaRaw
 		bb.rawJSONString = bbRaw
 	}()
+	// Using reflect.DeepEqual instead of cmp.Equal because many balancer
+	// configs are unexported, and cmp.Equal cannot compare unexported fields
+	// from unexported structs.
 	return reflect.DeepEqual(aa, bb)
 }

--- a/xds/internal/balancer/balancer.go
+++ b/xds/internal/balancer/balancer.go
@@ -20,6 +20,7 @@
 package balancer
 
 import (
-	_ "google.golang.org/grpc/xds/internal/balancer/cdsbalancer" // Register the CDS balancer
-	_ "google.golang.org/grpc/xds/internal/balancer/edsbalancer" // Register the EDS balancer
+	_ "google.golang.org/grpc/xds/internal/balancer/cdsbalancer"    // Register the CDS balancer
+	_ "google.golang.org/grpc/xds/internal/balancer/edsbalancer"    // Register the EDS balancer
+	_ "google.golang.org/grpc/xds/internal/balancer/weightedtarget" // Register the weighted_target balancer
 )

--- a/xds/internal/client/client_watchers_rds.go
+++ b/xds/internal/client/client_watchers_rds.go
@@ -23,7 +23,6 @@ import (
 )
 
 type rdsUpdate struct {
-	clusterName     string
 	weightedCluster map[string]uint32
 }
 type rdsCallbackFunc func(rdsUpdate, error)

--- a/xds/internal/client/client_watchers_rds.go
+++ b/xds/internal/client/client_watchers_rds.go
@@ -23,7 +23,8 @@ import (
 )
 
 type rdsUpdate struct {
-	clusterName string
+	clusterName     string
+	weightedCluster map[string]uint32
 }
 type rdsCallbackFunc func(rdsUpdate, error)
 

--- a/xds/internal/client/client_watchers_rds_test.go
+++ b/xds/internal/client/client_watchers_rds_test.go
@@ -51,7 +51,7 @@ func (s) TestRDSWatch(t *testing.T) {
 		rdsUpdateCh.Send(rdsUpdateErr{u: update, err: err})
 	})
 
-	wantUpdate := rdsUpdate{clusterName: testCDSName}
+	wantUpdate := rdsUpdate{weightedCluster: map[string]uint32{testCDSName: 1}}
 	v2Client.r.newRDSUpdate(map[string]rdsUpdate{
 		testRDSName: wantUpdate,
 	})
@@ -107,7 +107,7 @@ func (s) TestRDSTwoWatchSameResourceName(t *testing.T) {
 		})
 	}
 
-	wantUpdate := rdsUpdate{clusterName: testCDSName}
+	wantUpdate := rdsUpdate{weightedCluster: map[string]uint32{testCDSName: 1}}
 	v2Client.r.newRDSUpdate(map[string]rdsUpdate{
 		testRDSName: wantUpdate,
 	})
@@ -167,8 +167,8 @@ func (s) TestRDSThreeWatchDifferentResourceName(t *testing.T) {
 		rdsUpdateCh2.Send(rdsUpdateErr{u: update, err: err})
 	})
 
-	wantUpdate1 := rdsUpdate{clusterName: testCDSName + "1"}
-	wantUpdate2 := rdsUpdate{clusterName: testCDSName + "2"}
+	wantUpdate1 := rdsUpdate{weightedCluster: map[string]uint32{testCDSName + "1": 1}}
+	wantUpdate2 := rdsUpdate{weightedCluster: map[string]uint32{testCDSName + "2": 1}}
 	v2Client.r.newRDSUpdate(map[string]rdsUpdate{
 		testRDSName + "1": wantUpdate1,
 		testRDSName + "2": wantUpdate2,
@@ -204,7 +204,7 @@ func (s) TestRDSWatchAfterCache(t *testing.T) {
 		rdsUpdateCh.Send(rdsUpdateErr{u: update, err: err})
 	})
 
-	wantUpdate := rdsUpdate{clusterName: testCDSName}
+	wantUpdate := rdsUpdate{weightedCluster: map[string]uint32{testCDSName: 1}}
 	v2Client.r.newRDSUpdate(map[string]rdsUpdate{
 		testRDSName: wantUpdate,
 	})

--- a/xds/internal/client/client_watchers_rds_test.go
+++ b/xds/internal/client/client_watchers_rds_test.go
@@ -21,6 +21,7 @@ package client
 import (
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"google.golang.org/grpc/xds/internal/testutils"
 )
 
@@ -55,7 +56,7 @@ func (s) TestRDSWatch(t *testing.T) {
 		testRDSName: wantUpdate,
 	})
 
-	if u, err := rdsUpdateCh.Receive(); err != nil || u != (rdsUpdateErr{wantUpdate, nil}) {
+	if u, err := rdsUpdateCh.Receive(); err != nil || !cmp.Equal(u, rdsUpdateErr{wantUpdate, nil}, cmp.AllowUnexported(rdsUpdate{}, rdsUpdateErr{})) {
 		t.Errorf("unexpected rdsUpdate: %v, error receiving from channel: %v", u, err)
 	}
 
@@ -112,7 +113,7 @@ func (s) TestRDSTwoWatchSameResourceName(t *testing.T) {
 	})
 
 	for i := 0; i < count; i++ {
-		if u, err := rdsUpdateChs[i].Receive(); err != nil || u != (rdsUpdateErr{wantUpdate, nil}) {
+		if u, err := rdsUpdateChs[i].Receive(); err != nil || !cmp.Equal(u, rdsUpdateErr{wantUpdate, nil}, cmp.AllowUnexported(rdsUpdate{}, rdsUpdateErr{})) {
 			t.Errorf("i=%v, unexpected rdsUpdate: %v, error receiving from channel: %v", i, u, err)
 		}
 	}
@@ -124,7 +125,7 @@ func (s) TestRDSTwoWatchSameResourceName(t *testing.T) {
 	})
 
 	for i := 0; i < count-1; i++ {
-		if u, err := rdsUpdateChs[i].Receive(); err != nil || u != (rdsUpdateErr{wantUpdate, nil}) {
+		if u, err := rdsUpdateChs[i].Receive(); err != nil || !cmp.Equal(u, rdsUpdateErr{wantUpdate, nil}, cmp.AllowUnexported(rdsUpdate{}, rdsUpdateErr{})) {
 			t.Errorf("i=%v, unexpected rdsUpdate: %v, error receiving from channel: %v", i, u, err)
 		}
 	}
@@ -174,12 +175,12 @@ func (s) TestRDSThreeWatchDifferentResourceName(t *testing.T) {
 	})
 
 	for i := 0; i < count; i++ {
-		if u, err := rdsUpdateChs[i].Receive(); err != nil || u != (rdsUpdateErr{wantUpdate1, nil}) {
+		if u, err := rdsUpdateChs[i].Receive(); err != nil || !cmp.Equal(u, rdsUpdateErr{wantUpdate1, nil}, cmp.AllowUnexported(rdsUpdate{}, rdsUpdateErr{})) {
 			t.Errorf("i=%v, unexpected rdsUpdate: %v, error receiving from channel: %v", i, u, err)
 		}
 	}
 
-	if u, err := rdsUpdateCh2.Receive(); err != nil || u != (rdsUpdateErr{wantUpdate2, nil}) {
+	if u, err := rdsUpdateCh2.Receive(); err != nil || !cmp.Equal(u, rdsUpdateErr{wantUpdate2, nil}, cmp.AllowUnexported(rdsUpdate{}, rdsUpdateErr{})) {
 		t.Errorf("unexpected rdsUpdate: %v, error receiving from channel: %v", u, err)
 	}
 }
@@ -208,7 +209,7 @@ func (s) TestRDSWatchAfterCache(t *testing.T) {
 		testRDSName: wantUpdate,
 	})
 
-	if u, err := rdsUpdateCh.Receive(); err != nil || u != (rdsUpdateErr{wantUpdate, nil}) {
+	if u, err := rdsUpdateCh.Receive(); err != nil || !cmp.Equal(u, rdsUpdateErr{wantUpdate, nil}, cmp.AllowUnexported(rdsUpdate{}, rdsUpdateErr{})) {
 		t.Errorf("unexpected rdsUpdate: %v, error receiving from channel: %v", u, err)
 	}
 
@@ -219,7 +220,7 @@ func (s) TestRDSWatchAfterCache(t *testing.T) {
 	})
 
 	// New watch should receives the update.
-	if u, err := rdsUpdateCh2.Receive(); err != nil || u != (rdsUpdateErr{wantUpdate, nil}) {
+	if u, err := rdsUpdateCh2.Receive(); err != nil || !cmp.Equal(u, rdsUpdateErr{wantUpdate, nil}, cmp.AllowUnexported(rdsUpdate{}, rdsUpdateErr{})) {
 		t.Errorf("unexpected rdsUpdate: %v, error receiving from channel: %v", u, err)
 	}
 

--- a/xds/internal/client/client_watchers_service.go
+++ b/xds/internal/client/client_watchers_service.go
@@ -25,7 +25,6 @@ import (
 
 // ServiceUpdate contains update about the service.
 type ServiceUpdate struct {
-	Cluster         string
 	WeightedCluster map[string]uint32
 }
 
@@ -101,7 +100,6 @@ func (w *serviceUpdateWatcher) handleRDSResp(update rdsUpdate, err error) {
 		return
 	}
 	w.serviceCb(ServiceUpdate{
-		Cluster:         update.clusterName,
 		WeightedCluster: update.weightedCluster,
 	}, nil)
 }

--- a/xds/internal/client/client_watchers_service.go
+++ b/xds/internal/client/client_watchers_service.go
@@ -25,6 +25,8 @@ import (
 
 // ServiceUpdate contains update about the service.
 type ServiceUpdate struct {
+	// WeightedCluster is a map from cluster names (CDS resource to watch) to
+	// their weights.
 	WeightedCluster map[string]uint32
 }
 

--- a/xds/internal/client/client_watchers_service.go
+++ b/xds/internal/client/client_watchers_service.go
@@ -25,7 +25,8 @@ import (
 
 // ServiceUpdate contains update about the service.
 type ServiceUpdate struct {
-	Cluster string
+	Cluster         string
+	WeightedCluster map[string]uint32
 }
 
 // WatchService uses LDS and RDS to discover information about the provided
@@ -99,7 +100,10 @@ func (w *serviceUpdateWatcher) handleRDSResp(update rdsUpdate, err error) {
 		w.serviceCb(ServiceUpdate{}, err)
 		return
 	}
-	w.serviceCb(ServiceUpdate{Cluster: update.clusterName}, nil)
+	w.serviceCb(ServiceUpdate{
+		Cluster:         update.clusterName,
+		WeightedCluster: update.weightedCluster,
+	}, nil)
 }
 
 func (w *serviceUpdateWatcher) close() {

--- a/xds/internal/client/client_watchers_service_test.go
+++ b/xds/internal/client/client_watchers_service_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"google.golang.org/grpc/xds/internal/testutils"
 	"google.golang.org/grpc/xds/internal/testutils/fakeserver"
 )
@@ -65,7 +66,7 @@ func (s) TestServiceWatch(t *testing.T) {
 		testRDSName: {clusterName: testCDSName},
 	})
 
-	if u, err := serviceUpdateCh.Receive(); err != nil || u != (serviceUpdateErr{wantUpdate, nil}) {
+	if u, err := serviceUpdateCh.Receive(); err != nil || !cmp.Equal(u, serviceUpdateErr{wantUpdate, nil}, cmp.AllowUnexported(serviceUpdateErr{})) {
 		t.Errorf("unexpected serviceUpdate: %v, error receiving from channel: %v", u, err)
 	}
 }
@@ -101,7 +102,7 @@ func (s) TestServiceWatchLDSUpdate(t *testing.T) {
 		testRDSName: {clusterName: testCDSName},
 	})
 
-	if u, err := serviceUpdateCh.Receive(); err != nil || u != (serviceUpdateErr{wantUpdate, nil}) {
+	if u, err := serviceUpdateCh.Receive(); err != nil || !cmp.Equal(u, serviceUpdateErr{wantUpdate, nil}, cmp.AllowUnexported(serviceUpdateErr{})) {
 		t.Errorf("unexpected serviceUpdate: %v, error receiving from channel: %v", u, err)
 	}
 
@@ -126,7 +127,7 @@ func (s) TestServiceWatchLDSUpdate(t *testing.T) {
 		testRDSName + "2": {clusterName: testCDSName + "2"},
 	})
 
-	if u, err := serviceUpdateCh.Receive(); err != nil || u != (serviceUpdateErr{wantUpdate2, nil}) {
+	if u, err := serviceUpdateCh.Receive(); err != nil || !cmp.Equal(u, serviceUpdateErr{wantUpdate2, nil}, cmp.AllowUnexported(serviceUpdateErr{})) {
 		t.Errorf("unexpected serviceUpdate: %v, error receiving from channel: %v", u, err)
 	}
 }
@@ -162,7 +163,7 @@ func (s) TestServiceWatchSecond(t *testing.T) {
 		testRDSName: {clusterName: testCDSName},
 	})
 
-	if u, err := serviceUpdateCh.Receive(); err != nil || u != (serviceUpdateErr{wantUpdate, nil}) {
+	if u, err := serviceUpdateCh.Receive(); err != nil || !cmp.Equal(u, serviceUpdateErr{wantUpdate, nil}, cmp.AllowUnexported(serviceUpdateErr{})) {
 		t.Errorf("unexpected serviceUpdate: %v, error receiving from channel: %v", u, err)
 	}
 
@@ -177,7 +178,7 @@ func (s) TestServiceWatchSecond(t *testing.T) {
 		t.Fatalf("failed to get serviceUpdate: %v", err)
 	}
 	uu := u.(serviceUpdateErr)
-	if uu.u != (ServiceUpdate{}) {
+	if !cmp.Equal(uu.u, ServiceUpdate{}) {
 		t.Errorf("unexpected serviceUpdate: %v, want %v", uu.u, ServiceUpdate{})
 	}
 	if uu.err == nil {
@@ -193,7 +194,7 @@ func (s) TestServiceWatchSecond(t *testing.T) {
 		testRDSName: {clusterName: testCDSName},
 	})
 
-	if u, err := serviceUpdateCh.Receive(); err != nil || u != (serviceUpdateErr{wantUpdate, nil}) {
+	if u, err := serviceUpdateCh.Receive(); err != nil || !cmp.Equal(u, serviceUpdateErr{wantUpdate, nil}, cmp.AllowUnexported(serviceUpdateErr{})) {
 		t.Errorf("unexpected serviceUpdate: %v, error receiving from channel: %v", u, err)
 	}
 

--- a/xds/internal/client/v2client_rds.go
+++ b/xds/internal/client/v2client_rds.go
@@ -48,26 +48,25 @@ func (v2c *v2Client) handleRDSResponse(resp *xdspb.DiscoveryResponse) error {
 		v2c.logger.Infof("Resource with name: %v, type: %T, contains: %v. Picking routes for current watching hostname %v", rc.GetName(), rc, rc, v2c.hostname)
 
 		// Use the hostname (resourceName for LDS) to find the routes.
-		cluster, err := getClusterFromRouteConfiguration(rc, hostname)
-		if cluster == "" {
+		u, err := generateRDSUpdateFromRouteConfiguration(rc, hostname)
+		if err != nil {
 			return fmt.Errorf("xds: received invalid RouteConfiguration in RDS response: %+v with err: %v", rc, err)
 		}
-
 		// If we get here, it means that this resource was a good one.
-		returnUpdate[rc.GetName()] = rdsUpdate{clusterName: cluster}
+		returnUpdate[rc.GetName()] = u
 	}
 
 	v2c.parent.newRDSUpdate(returnUpdate)
 	return nil
 }
 
-// getClusterFromRouteConfiguration checks if the provided RouteConfiguration
-// meets the expected criteria. If so, it returns a non-empty clusterName with
-// nil error.
+// generateRDSUpdateFromRouteConfiguration checks if the provided
+// RouteConfiguration meets the expected criteria. If so, it returns a rdsUpdate
+// with nil error.
 //
 // A RouteConfiguration resource is considered valid when only if it contains a
 // VirtualHost whose domain field matches the server name from the URI passed
-// to the gRPC channel, and it contains a clusterName.
+// to the gRPC channel, and it contains a clusterName or a weighted cluster.
 //
 // The RouteConfiguration includes a list of VirtualHosts, which may have zero
 // or more elements. We are interested in the element whose domains field
@@ -75,8 +74,9 @@ func (v2c *v2Client) handleRDSResponse(resp *xdspb.DiscoveryResponse) error {
 // VirtualHost proto that the we are interested in is the list of routes. We
 // only look at the last route in the list (the default route), whose match
 // field must be empty and whose route field must be set.  Inside that route
-// message, the cluster field will contain the clusterName we are looking for.
-func getClusterFromRouteConfiguration(rc *xdspb.RouteConfiguration, host string) (string, error) {
+// message, the cluster field will contain the clusterName or weighted clusters
+// we are looking for.
+func generateRDSUpdateFromRouteConfiguration(rc *xdspb.RouteConfiguration, host string) (rdsUpdate, error) {
 	//
 	// Currently this returns "" on error, and the caller will return an error.
 	// But the error doesn't contain details of why the response is invalid
@@ -87,31 +87,58 @@ func getClusterFromRouteConfiguration(rc *xdspb.RouteConfiguration, host string)
 	vh := findBestMatchingVirtualHost(host, rc.GetVirtualHosts())
 	if vh == nil {
 		// No matching virtual host found.
-		return "", fmt.Errorf("no matching virtual host found")
+		return rdsUpdate{}, fmt.Errorf("no matching virtual host found")
 	}
 	if len(vh.Routes) == 0 {
 		// The matched virtual host has no routes, this is invalid because there
 		// should be at least one default route.
-		return "", fmt.Errorf("matched virtual host has no routes")
+		return rdsUpdate{}, fmt.Errorf("matched virtual host has no routes")
 	}
 	dr := vh.Routes[len(vh.Routes)-1]
 	match := dr.GetMatch()
 	if match == nil {
-		return "", fmt.Errorf("matched virtual host's default route doesn't have a match")
+		return rdsUpdate{}, fmt.Errorf("matched virtual host's default route doesn't have a match")
 	}
 	if prefix := match.GetPrefix(); prefix != "" && prefix != "/" {
 		// The matched virtual host is invalid. Match is not "" or "/".
-		return "", fmt.Errorf("matched virtual host's default route is %v, want Prefix empty string or /", match)
+		return rdsUpdate{}, fmt.Errorf("matched virtual host's default route is %v, want Prefix empty string or /", match)
 	}
 	if caseSensitive := match.GetCaseSensitive(); caseSensitive != nil && !caseSensitive.Value {
 		// The case sensitive is set to false. Not set or set to true are both
 		// valid.
-		return "", fmt.Errorf("matches virtual host's default route set case-sensitive to false")
+		return rdsUpdate{}, fmt.Errorf("matches virtual host's default route set case-sensitive to false")
 	}
-	if route := dr.GetRoute(); route != nil {
-		return route.GetCluster(), nil
+	route := dr.GetRoute()
+	if route == nil {
+		return rdsUpdate{}, fmt.Errorf("matched route is nil")
 	}
-	return "", fmt.Errorf("matched route is nil")
+
+	if wc := route.GetWeightedClusters(); wc != nil {
+		m, err := weightedClustersProtoToMap(wc)
+		if err != nil {
+			return rdsUpdate{}, fmt.Errorf("match weighted cluster is invalid: %v", err)
+		}
+		return rdsUpdate{weightedCluster: m}, nil
+	}
+
+	return rdsUpdate{clusterName: route.GetCluster()}, nil
+}
+
+func weightedClustersProtoToMap(wc *routepb.WeightedCluster) (map[string]uint32, error) {
+	ret := make(map[string]uint32)
+	var totalWeight uint32 = 100
+	if t := wc.TotalWeight; t != nil {
+		totalWeight = t.Value
+	}
+	for _, cw := range wc.Clusters {
+		w := cw.Weight.Value
+		ret[cw.Name] = w
+		totalWeight -= w
+	}
+	if totalWeight != 0 {
+		return nil, fmt.Errorf("weights of clusters do not add up to total total weight, difference: %v", totalWeight)
+	}
+	return ret, nil
 }
 
 type domainMatchType int

--- a/xds/internal/client/v2client_rds.go
+++ b/xds/internal/client/v2client_rds.go
@@ -135,8 +135,8 @@ func generateRDSUpdateFromRouteConfiguration(rc *xdspb.RouteConfiguration, host 
 func weightedClustersProtoToMap(wc *routepb.WeightedCluster) (map[string]uint32, error) {
 	ret := make(map[string]uint32)
 	var totalWeight uint32 = 100
-	if t := wc.TotalWeight; t != nil {
-		totalWeight = t.Value
+	if t := wc.GetTotalWeight().GetValue(); t != 0 {
+		totalWeight = t
 	}
 	for _, cw := range wc.Clusters {
 		w := cw.Weight.GetValue()

--- a/xds/internal/client/v2client_rds.go
+++ b/xds/internal/client/v2client_rds.go
@@ -121,7 +121,7 @@ func generateRDSUpdateFromRouteConfiguration(rc *xdspb.RouteConfiguration, host 
 		return rdsUpdate{weightedCluster: m}, nil
 	}
 
-	return rdsUpdate{clusterName: route.GetCluster()}, nil
+	return rdsUpdate{weightedCluster: map[string]uint32{route.GetCluster(): 1}}, nil
 }
 
 func weightedClustersProtoToMap(wc *routepb.WeightedCluster) (map[string]uint32, error) {

--- a/xds/internal/client/v2client_rds_test.go
+++ b/xds/internal/client/v2client_rds_test.go
@@ -156,7 +156,7 @@ func (s) TestRDSGenerateRDSUpdateFromRouteConfiguration(t *testing.T) {
 		{
 			name:       "good-route-config-with-empty-string-route",
 			rc:         goodRouteConfig1,
-			wantUpdate: rdsUpdate{clusterName: goodClusterName1},
+			wantUpdate: rdsUpdate{weightedCluster: map[string]uint32{goodClusterName1: 1}},
 			wantError:  false,
 		},
 		{
@@ -172,7 +172,7 @@ func (s) TestRDSGenerateRDSUpdateFromRouteConfiguration(t *testing.T) {
 							Route: &routepb.RouteAction{
 								ClusterSpecifier: &routepb.RouteAction_Cluster{Cluster: goodClusterName1},
 							}}}}}}},
-			wantUpdate: rdsUpdate{clusterName: goodClusterName1},
+			wantUpdate: rdsUpdate{weightedCluster: map[string]uint32{goodClusterName1: 1}},
 		},
 		{
 			name: "good-route-config-with-weighted_clusters",
@@ -269,7 +269,7 @@ func (s) TestRDSHandleResponse(t *testing.T) {
 			name:          "one-good-route-config",
 			rdsResponse:   goodRDSResponse1,
 			wantErr:       false,
-			wantUpdate:    &rdsUpdate{clusterName: goodClusterName1},
+			wantUpdate:    &rdsUpdate{weightedCluster: map[string]uint32{goodClusterName1: 1}},
 			wantUpdateErr: false,
 		},
 	}

--- a/xds/internal/resolver/serviceconfig.go
+++ b/xds/internal/resolver/serviceconfig.go
@@ -20,6 +20,7 @@ package resolver
 
 import (
 	"encoding/json"
+	"fmt"
 
 	xdsclient "google.golang.org/grpc/xds/internal/client"
 )
@@ -52,7 +53,7 @@ type cdsBalancerConfig struct {
 	Cluster string `json:"cluster"`
 }
 
-func serviceUpdateToJSON(su xdsclient.ServiceUpdate) string {
+func serviceUpdateToJSON(su xdsclient.ServiceUpdate) (string, error) {
 	// Even if WeightedCluster has only one entry, we still use weighted_target
 	// as top level balancer, to avoid switching top policy between CDS and
 	// weighted_target, causing TCP connection to be recreated.
@@ -73,7 +74,7 @@ func serviceUpdateToJSON(su xdsclient.ServiceUpdate) string {
 	}
 	bs, err := json.Marshal(sc)
 	if err != nil {
-		panic(err.Error())
+		return "", fmt.Errorf("failed to marshal json: %v", err)
 	}
-	return string(bs)
+	return string(bs), nil
 }

--- a/xds/internal/resolver/serviceconfig.go
+++ b/xds/internal/resolver/serviceconfig.go
@@ -27,8 +27,6 @@ import (
 const (
 	cdsName            = "cds_experimental"
 	weightedTargetName = "weighted_target_experimental"
-
-	jsonFormatClusterOnly = `{"loadBalancingConfig":[{"cds_experimental":{"Cluster": "%s"}}]}`
 )
 
 type serviceConfig struct {

--- a/xds/internal/resolver/serviceconfig.go
+++ b/xds/internal/resolver/serviceconfig.go
@@ -1,0 +1,19 @@
+/*
+ *
+ * Copyright 2020 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package resolver

--- a/xds/internal/resolver/serviceconfig.go
+++ b/xds/internal/resolver/serviceconfig.go
@@ -17,3 +17,68 @@
  */
 
 package resolver
+
+import (
+	"encoding/json"
+	"fmt"
+
+	xdsclient "google.golang.org/grpc/xds/internal/client"
+)
+
+const (
+	cdsName            = "cds_experimental"
+	weightedTargetName = "weighted_target_experimental"
+
+	jsonFormatClusterOnly = `{"loadBalancingConfig":[{"cds_experimental":{"Cluster": "%s"}}]}`
+)
+
+type serviceConfig struct {
+	LoadBalancingConfig balancerConfig `json:"loadBalancingConfig"`
+}
+
+type balancerConfig []map[string]interface{}
+
+func newBalancerConfig(name string, config interface{}) balancerConfig {
+	return []map[string]interface{}{{name: config}}
+}
+
+type weightedCDSBalancerConfig struct {
+	Targets map[string]cdsWithWeight `json:"targets"`
+}
+
+type cdsWithWeight struct {
+	Weight      uint32         `json:"weight"`
+	ChildPolicy balancerConfig `json:"childPolicy"`
+}
+
+type cdsBalancerConfig struct {
+	Cluster string `json:"cluster"`
+}
+
+func serviceUpdateToJSON(su xdsclient.ServiceUpdate) string {
+	if su.WeightedCluster == nil {
+		// We can get rid of this, and also build the struct, marshal to json.
+		// But this seems more efficient.
+		return fmt.Sprintf(jsonFormatClusterOnly, su.Cluster)
+	}
+	targets := make(map[string]cdsWithWeight)
+	for name, weight := range su.WeightedCluster {
+		targets[name] = cdsWithWeight{
+			Weight:      weight,
+			ChildPolicy: newBalancerConfig(cdsName, cdsBalancerConfig{Cluster: name}),
+		}
+	}
+
+	sc := serviceConfig{
+		LoadBalancingConfig: newBalancerConfig(
+			weightedTargetName, weightedCDSBalancerConfig{
+				Targets: targets,
+			},
+		),
+	}
+	bs, err := json.Marshal(sc)
+	if err != nil {
+		panic(err.Error())
+	}
+	return string(bs)
+}

--- a/xds/internal/resolver/serviceconfig_test.go
+++ b/xds/internal/resolver/serviceconfig_test.go
@@ -30,7 +30,11 @@ import (
 
 const (
 	testCluster1        = "test-cluster-1"
-	testClusterOnlyJSON = `{"loadBalancingConfig":[{"cds_experimental":{"Cluster": "test-cluster-1"}}]}`
+	testClusterOnlyJSON = `{"loadBalancingConfig":[{
+    "weighted_target_experimental": {
+	  "targets": { "test-cluster-1" : { "weight":1, "childPolicy":[{"cds_experimental":{"cluster":"test-cluster-1"}}] } }
+	}
+}]}`
 	testWeightedCDSJSON = `{"loadBalancingConfig":[{
     "weighted_target_experimental": {
 	  "targets": {
@@ -54,8 +58,8 @@ func TestServiceUpdateToJSON(t *testing.T) {
 		wantJSON string // wantJSON is not to be compared verbatim.
 	}{
 		{
-			name:     "cluster only",
-			su:       client.ServiceUpdate{Cluster: testCluster1},
+			name:     "one cluster only",
+			su:       client.ServiceUpdate{WeightedCluster: map[string]uint32{testCluster1: 1}},
 			wantJSON: testClusterOnlyJSON,
 		},
 		{

--- a/xds/internal/resolver/serviceconfig_test.go
+++ b/xds/internal/resolver/serviceconfig_test.go
@@ -1,0 +1,84 @@
+/*
+ *
+ * Copyright 2020 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package resolver
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/grpc/internal"
+	"google.golang.org/grpc/serviceconfig"
+	_ "google.golang.org/grpc/xds/internal/balancer/weightedtarget"
+	"google.golang.org/grpc/xds/internal/client"
+)
+
+const (
+	testCluster1        = "test-cluster-1"
+	testClusterOnlyJSON = `{"loadBalancingConfig":[{"cds_experimental":{"Cluster": "test-cluster-1"}}]}`
+	testWeightedCDSJSON = `{"loadBalancingConfig":[{
+    "weighted_target_experimental": {
+	  "targets": {
+		"cluster_1" : {
+		  "weight":75,
+		  "childPolicy":[{"cds_experimental":{"cluster":"cluster_1"}}]
+		},
+		"cluster_2" : {
+		  "weight":25,
+		  "childPolicy":[{"cds_experimental":{"cluster":"cluster_2"}}]
+		}
+	  }
+	}
+}]}`
+)
+
+func TestServiceUpdateToJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		su       client.ServiceUpdate
+		wantJSON string // wantJSON is not to be compared verbatim.
+	}{
+		{
+			name:     "cluster only",
+			su:       client.ServiceUpdate{Cluster: testCluster1},
+			wantJSON: testClusterOnlyJSON,
+		},
+		{
+			name: "weighted clusters",
+			su: client.ServiceUpdate{WeightedCluster: map[string]uint32{
+				"cluster_1": 75,
+				"cluster_2": 25,
+			}},
+			wantJSON: testWeightedCDSJSON,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotJSON := serviceUpdateToJSON(tt.su)
+
+			gotParsed := internal.ParseServiceConfigForTesting.(func(string) *serviceconfig.ParseResult)(gotJSON)
+			wantParsed := internal.ParseServiceConfigForTesting.(func(string) *serviceconfig.ParseResult)(tt.wantJSON)
+
+			if !internal.EqualServiceConfigForTesting(gotParsed.Config, wantParsed.Config) {
+				t.Errorf("serviceUpdateToJSON() = %v, want %v", gotJSON, tt.wantJSON)
+				t.Error("gotParsed: ", cmp.Diff(nil, gotParsed))
+				t.Error("wantParsed: ", cmp.Diff(nil, wantParsed))
+			}
+		})
+	}
+}

--- a/xds/internal/resolver/serviceconfig_test.go
+++ b/xds/internal/resolver/serviceconfig_test.go
@@ -73,7 +73,11 @@ func TestServiceUpdateToJSON(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotJSON := serviceUpdateToJSON(tt.su)
+			gotJSON, err := serviceUpdateToJSON(tt.su)
+			if err != nil {
+				t.Errorf("serviceUpdateToJSON returned error: %v", err)
+				return
+			}
 
 			gotParsed := internal.ParseServiceConfigForTesting.(func(string) *serviceconfig.ParseResult)(gotJSON)
 			wantParsed := internal.ParseServiceConfigForTesting.(func(string) *serviceconfig.ParseResult)(tt.wantJSON)

--- a/xds/internal/resolver/xds_resolver.go
+++ b/xds/internal/resolver/xds_resolver.go
@@ -163,16 +163,6 @@ type xdsResolver struct {
 	cancelWatch func()
 }
 
-const jsonFormatSC = `{
-    "loadBalancingConfig":[
-      {
-        "cds_experimental":{
-          "Cluster": "%s"
-        }
-      }
-    ]
-  }`
-
 // run is a long running goroutine which blocks on receiving service updates
 // and passes it on the ClientConn.
 func (r *xdsResolver) run() {
@@ -185,7 +175,7 @@ func (r *xdsResolver) run() {
 				r.cc.ReportError(update.err)
 				continue
 			}
-			sc := fmt.Sprintf(jsonFormatSC, update.su.Cluster)
+			sc := serviceUpdateToJSON(update.su)
 			r.logger.Infof("Received update on resource %v from xds-client %p, generated service config: %v", r.target.Endpoint, r.client, sc)
 			r.cc.UpdateState(resolver.State{
 				ServiceConfig: r.cc.ParseServiceConfig(sc),

--- a/xds/internal/resolver/xds_resolver.go
+++ b/xds/internal/resolver/xds_resolver.go
@@ -175,7 +175,12 @@ func (r *xdsResolver) run() {
 				r.cc.ReportError(update.err)
 				continue
 			}
-			sc := serviceUpdateToJSON(update.su)
+			sc, err := serviceUpdateToJSON(update.su)
+			if err != nil {
+				r.logger.Warningf("failed to convert update to service config: %v", err)
+				r.cc.ReportError(err)
+				continue
+			}
 			r.logger.Infof("Received update on resource %v from xds-client %p, generated service config: %v", r.target.Endpoint, r.client, sc)
 			r.cc.UpdateState(resolver.State{
 				ServiceConfig: r.cc.ParseServiceConfig(sc),

--- a/xds/internal/resolver/xds_resolver_test.go
+++ b/xds/internal/resolver/xds_resolver_test.go
@@ -266,7 +266,7 @@ func TestXDSResolverWatchCallbackAfterClose(t *testing.T) {
 	// Call the watchAPI callback after closing the resolver, and make sure no
 	// update is triggerred on the ClientConn.
 	xdsR.Close()
-	xdsC.InvokeWatchServiceCallback(xdsclient.ServiceUpdate{Cluster: cluster}, nil)
+	xdsC.InvokeWatchServiceCallback(xdsclient.ServiceUpdate{WeightedCluster: map[string]uint32{cluster: 1}}, nil)
 	if gotVal, gotErr := tcc.stateCh.Receive(); gotErr != testutils.ErrRecvTimeout {
 		t.Fatalf("ClientConn.UpdateState called after xdsResolver is closed: %v", gotVal)
 	}
@@ -316,7 +316,7 @@ func TestXDSResolverGoodServiceUpdate(t *testing.T) {
 		wantJSON string
 	}{
 		{
-			su:       client.ServiceUpdate{Cluster: testCluster1},
+			su:       client.ServiceUpdate{WeightedCluster: map[string]uint32{testCluster1: 1}},
 			wantJSON: testClusterOnlyJSON,
 		},
 		{
@@ -376,7 +376,7 @@ func TestXDSResolverGoodUpdateAfterError(t *testing.T) {
 
 	// Invoke the watchAPI callback with a good service update and wait for the
 	// UpdateState method to be called on the ClientConn.
-	xdsC.InvokeWatchServiceCallback(xdsclient.ServiceUpdate{Cluster: cluster}, nil)
+	xdsC.InvokeWatchServiceCallback(xdsclient.ServiceUpdate{WeightedCluster: map[string]uint32{cluster: 1}}, nil)
 	gotState, err := tcc.stateCh.Receive()
 	if err != nil {
 		t.Fatalf("ClientConn.UpdateState returned error: %v", err)

--- a/xds/internal/resolver/xds_resolver_test.go
+++ b/xds/internal/resolver/xds_resolver_test.go
@@ -25,12 +25,14 @@ import (
 	"net"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/internal"
 	"google.golang.org/grpc/resolver"
 	"google.golang.org/grpc/serviceconfig"
 	xdsinternal "google.golang.org/grpc/xds/internal"
 	_ "google.golang.org/grpc/xds/internal/balancer/cdsbalancer" // To parse LB config
+	"google.golang.org/grpc/xds/internal/client"
 	xdsclient "google.golang.org/grpc/xds/internal/client"
 	"google.golang.org/grpc/xds/internal/client/bootstrap"
 	"google.golang.org/grpc/xds/internal/testutils"
@@ -264,7 +266,7 @@ func TestXDSResolverWatchCallbackAfterClose(t *testing.T) {
 	// Call the watchAPI callback after closing the resolver, and make sure no
 	// update is triggerred on the ClientConn.
 	xdsR.Close()
-	xdsC.InvokeWatchServiceCallback(cluster, nil)
+	xdsC.InvokeWatchServiceCallback(xdsclient.ServiceUpdate{Cluster: cluster}, nil)
 	if gotVal, gotErr := tcc.stateCh.Receive(); gotErr != testutils.ErrRecvTimeout {
 		t.Fatalf("ClientConn.UpdateState called after xdsResolver is closed: %v", gotVal)
 	}
@@ -288,7 +290,7 @@ func TestXDSResolverBadServiceUpdate(t *testing.T) {
 	// Invoke the watchAPI callback with a bad service update and wait for the
 	// ReportError method to be called on the ClientConn.
 	suErr := errors.New("bad serviceupdate")
-	xdsC.InvokeWatchServiceCallback("", suErr)
+	xdsC.InvokeWatchServiceCallback(xdsclient.ServiceUpdate{}, suErr)
 	if gotErrVal, gotErr := tcc.errorCh.Receive(); gotErr != nil || gotErrVal != suErr {
 		t.Fatalf("ClientConn.ReportError() received %v, want %v", gotErrVal, suErr)
 	}
@@ -309,19 +311,43 @@ func TestXDSResolverGoodServiceUpdate(t *testing.T) {
 
 	waitForWatchService(t, xdsC, targetStr)
 
-	// Invoke the watchAPI callback with a good service update and wait for the
-	// UpdateState method to be called on the ClientConn.
-	xdsC.InvokeWatchServiceCallback(cluster, nil)
-	gotState, err := tcc.stateCh.Receive()
-	if err != nil {
-		t.Fatalf("ClientConn.UpdateState returned error: %v", err)
-	}
-	rState := gotState.(resolver.State)
-	if gotClient := rState.Attributes.Value(xdsinternal.XDSClientID); gotClient != xdsC {
-		t.Fatalf("ClientConn.UpdateState got xdsClient: %v, want %v", gotClient, xdsC)
-	}
-	if err := rState.ServiceConfig.Err; err != nil {
-		t.Fatalf("ClientConn.UpdateState received error in service config: %v", rState.ServiceConfig.Err)
+	for _, tt := range []struct {
+		su       client.ServiceUpdate
+		wantJSON string
+	}{
+		{
+			su:       client.ServiceUpdate{Cluster: testCluster1},
+			wantJSON: testClusterOnlyJSON,
+		},
+		{
+			su: client.ServiceUpdate{WeightedCluster: map[string]uint32{
+				"cluster_1": 75,
+				"cluster_2": 25,
+			}},
+			wantJSON: testWeightedCDSJSON,
+		},
+	} {
+		// Invoke the watchAPI callback with a good service update and wait for the
+		// UpdateState method to be called on the ClientConn.
+		xdsC.InvokeWatchServiceCallback(tt.su, nil)
+		gotState, err := tcc.stateCh.Receive()
+		if err != nil {
+			t.Fatalf("ClientConn.UpdateState returned error: %v", err)
+		}
+		rState := gotState.(resolver.State)
+		if gotClient := rState.Attributes.Value(xdsinternal.XDSClientID); gotClient != xdsC {
+			t.Fatalf("ClientConn.UpdateState got xdsClient: %v, want %v", gotClient, xdsC)
+		}
+		if err := rState.ServiceConfig.Err; err != nil {
+			t.Fatalf("ClientConn.UpdateState received error in service config: %v", rState.ServiceConfig.Err)
+		}
+
+		wantSCParsed := internal.ParseServiceConfigForTesting.(func(string) *serviceconfig.ParseResult)(tt.wantJSON)
+		if !internal.EqualServiceConfigForTesting(rState.ServiceConfig.Config, wantSCParsed.Config) {
+			t.Errorf("ClientConn.UpdateState received different service config")
+			t.Error("got: ", cmp.Diff(nil, rState.ServiceConfig.Config))
+			t.Error("want: ", cmp.Diff(nil, wantSCParsed.Config))
+		}
 	}
 }
 
@@ -343,14 +369,14 @@ func TestXDSResolverGoodUpdateAfterError(t *testing.T) {
 	// Invoke the watchAPI callback with a bad service update and wait for the
 	// ReportError method to be called on the ClientConn.
 	suErr := errors.New("bad serviceupdate")
-	xdsC.InvokeWatchServiceCallback("", suErr)
+	xdsC.InvokeWatchServiceCallback(xdsclient.ServiceUpdate{}, suErr)
 	if gotErrVal, gotErr := tcc.errorCh.Receive(); gotErr != nil || gotErrVal != suErr {
 		t.Fatalf("ClientConn.ReportError() received %v, want %v", gotErrVal, suErr)
 	}
 
 	// Invoke the watchAPI callback with a good service update and wait for the
 	// UpdateState method to be called on the ClientConn.
-	xdsC.InvokeWatchServiceCallback(cluster, nil)
+	xdsC.InvokeWatchServiceCallback(xdsclient.ServiceUpdate{Cluster: cluster}, nil)
 	gotState, err := tcc.stateCh.Receive()
 	if err != nil {
 		t.Fatalf("ClientConn.UpdateState returned error: %v", err)
@@ -366,7 +392,7 @@ func TestXDSResolverGoodUpdateAfterError(t *testing.T) {
 	// Invoke the watchAPI callback with a bad service update and wait for the
 	// ReportError method to be called on the ClientConn.
 	suErr2 := errors.New("bad serviceupdate 2")
-	xdsC.InvokeWatchServiceCallback("", suErr2)
+	xdsC.InvokeWatchServiceCallback(xdsclient.ServiceUpdate{}, suErr2)
 	if gotErrVal, gotErr := tcc.errorCh.Receive(); gotErr != nil || gotErrVal != suErr2 {
 		t.Fatalf("ClientConn.ReportError() received %v, want %v", gotErrVal, suErr2)
 	}

--- a/xds/internal/testutils/fakeclient/client.go
+++ b/xds/internal/testutils/fakeclient/client.go
@@ -69,11 +69,11 @@ func (xdsC *Client) WaitForWatchService() (string, error) {
 }
 
 // InvokeWatchServiceCallback invokes the registered service watch callback.
-func (xdsC *Client) InvokeWatchServiceCallback(cluster string, err error) {
+func (xdsC *Client) InvokeWatchServiceCallback(u xdsclient.ServiceUpdate, err error) {
 	xdsC.mu.Lock()
 	defer xdsC.mu.Unlock()
 
-	xdsC.serviceCb(xdsclient.ServiceUpdate{Cluster: cluster}, err)
+	xdsC.serviceCb(u, err)
 }
 
 // WatchCluster registers a CDS watch.


### PR DESCRIPTION
This change adds support for route action being weighted cluster (instead of just one cluster). We still only support the default route (the last in the list).

Changes:
 - xds_client: handle RDS response's weighted cluster fields, and propagate the update to xds resolver (by adding a fields to `ServiceUpdate`.
   - This makes `ServiceUpdate` not comparable by `==`, thus the updates to use `cmp.Equal`
 - xds_resolver: marshal weighted cluster into balancer config, which picks weighted_target as the top level balancer

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grpc/grpc-go/3613)
<!-- Reviewable:end -->
