### PR TITLE
xds: handle errors in eds balancer

### DIFF
--- a/xds/internal/balancer/edsbalancer/eds.go
+++ b/xds/internal/balancer/edsbalancer/eds.go
@@ -168,18 +168,8 @@ func (x *edsBalancer) handleErrorFromUpdate(err error) {
 	// In both cases, the sub-balancers should be closed, and the picks should
 	// all fail.
 	if xdsclient.TypeOfError(err) == xdsclient.ErrorTypeResourceNotFound {
-		// FIXME: does an empty update closes all sub-balancers?
-		// -- Yes
-		//
-		// FIXME: what picker do we get after closing all sub-balancers? It
-		// should update picker with an error picker. Needs tests to verify.
-		// -- Transient failure
 		x.edsImpl.handleEDSResponse(xdsclient.EndpointsUpdate{})
 	}
-
-	// FIXME: do we need to manually update the picker to an error picker with
-	// the err passed in? If we do, we need to make sure the picker won't be
-	// replaced by a later picker update.
 }
 
 func (x *edsBalancer) handleGRPCUpdate(update interface{}) {

--- a/xds/internal/balancer/edsbalancer/eds_impl.go
+++ b/xds/internal/balancer/edsbalancer/eds_impl.go
@@ -18,11 +18,13 @@ package edsbalancer
 
 import (
 	"encoding/json"
+	"reflect"
 	"sync"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/grpc/balancer"
+	"google.golang.org/grpc/balancer/base"
 	"google.golang.org/grpc/balancer/roundrobin"
 	"google.golang.org/grpc/balancer/weightedroundrobin"
 	"google.golang.org/grpc/codes"
@@ -66,6 +68,7 @@ type edsBalancerImpl struct {
 	subBalancerBuilder   balancer.Builder
 	loadStore            lrs.Store
 	priorityToLocalities map[priorityType]*balancerGroupWithConfig
+	respReceived         bool
 
 	// There's no need to hold any mutexes at the same time. The order to take
 	// mutex should be: priorityMu > subConnMu, but this is implicit via
@@ -182,6 +185,14 @@ func (edsImpl *edsBalancerImpl) handleEDSResponse(edsResp xdsclient.EndpointsUpd
 	//  - if socketAddress is not ip:port
 	//     - socketAddress.GetNamedPort(), socketAddress.GetResolverName()
 	//     - resolve endpoint's name with another resolver
+
+	// If the first EDS update is an empty update, nothing is changing from the
+	// previous update (which is the default empty value). We need to explicitly
+	// handle first update being empty, and send a transient failure picker.
+	if !edsImpl.respReceived && reflect.DeepEqual(edsResp, xdsclient.EndpointsUpdate{}) {
+		edsImpl.cc.UpdateState(balancer.State{ConnectivityState: connectivity.TransientFailure, Picker: base.NewErrPicker(errAllPrioritiesRemoved)})
+	}
+	edsImpl.respReceived = true
 
 	edsImpl.updateDrops(edsResp.Drops)
 

--- a/xds/internal/balancer/edsbalancer/eds_impl_priority.go
+++ b/xds/internal/balancer/edsbalancer/eds_impl_priority.go
@@ -18,6 +18,7 @@
 package edsbalancer
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -26,6 +27,8 @@ import (
 	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/grpclog"
 )
+
+var errAllPrioritiesRemoved = errors.New("no locality is provided, all priorities are removed")
 
 // handlePriorityChange handles priority after EDS adds/removes a
 // priority.
@@ -46,7 +49,7 @@ func (edsImpl *edsBalancerImpl) handlePriorityChange() {
 	// Everything was removed by EDS.
 	if !edsImpl.priorityLowest.isSet() {
 		edsImpl.priorityInUse = newPriorityTypeUnset()
-		edsImpl.cc.UpdateState(balancer.State{ConnectivityState: connectivity.TransientFailure, Picker: base.NewErrPicker(balancer.ErrTransientFailure)})
+		edsImpl.cc.UpdateState(balancer.State{ConnectivityState: connectivity.TransientFailure, Picker: base.NewErrPicker(errAllPrioritiesRemoved)})
 		return
 	}
 

--- a/xds/internal/balancer/edsbalancer/eds_impl_priority_test.go
+++ b/xds/internal/balancer/edsbalancer/eds_impl_priority_test.go
@@ -553,8 +553,8 @@ func (s) TestEDSPriority_RemovesAllLocalities(t *testing.T) {
 	// Test pick return TransientFailure.
 	pFail := <-cc.NewPickerCh
 	for i := 0; i < 5; i++ {
-		if _, err := pFail.Pick(balancer.PickInfo{}); err != balancer.ErrTransientFailure {
-			t.Fatalf("want pick error %v, got %v", balancer.ErrTransientFailure, err)
+		if _, err := pFail.Pick(balancer.PickInfo{}); err != errAllPrioritiesRemoved {
+			t.Fatalf("want pick error %v, got %v", errAllPrioritiesRemoved, err)
 		}
 	}
 

--- a/xds/internal/balancer/edsbalancer/eds_impl_test.go
+++ b/xds/internal/balancer/edsbalancer/eds_impl_test.go
@@ -18,6 +18,7 @@ package edsbalancer
 
 import (
 	"fmt"
+	"reflect"
 	"sort"
 	"testing"
 	"time"
@@ -386,6 +387,70 @@ func (s) TestClose(t *testing.T) {
 	edsb.close()
 }
 
+// TestEDS_EmptyUpdate covers the cases when eds impl receives an empty update.
+//
+// It should send an error picker with transient failure to the parent.
+func (s) TestEDS_EmptyUpdate(t *testing.T) {
+	cc := testutils.NewTestClientConn(t)
+	edsb := newEDSBalancerImpl(cc, nil, nil, nil)
+	edsb.enqueueChildBalancerStateUpdate = edsb.updateState
+
+	// The first update is an empty update.
+	edsb.handleEDSResponse(xdsclient.EndpointsUpdate{})
+	// Pick should fail with transient failure, and all priority removed error.
+	perr0 := <-cc.NewPickerCh
+	for i := 0; i < 5; i++ {
+		_, err := perr0.Pick(balancer.PickInfo{})
+		if !reflect.DeepEqual(err, errAllPrioritiesRemoved) {
+			t.Fatalf("picker.Pick, got error %v, want error %v", err, errAllPrioritiesRemoved)
+		}
+	}
+
+	// One locality with one backend.
+	clab1 := xdsclient.NewClusterLoadAssignmentBuilder(testClusterNames[0], nil)
+	clab1.AddLocality(testSubZones[0], 1, 0, testEndpointAddrs[:1], nil)
+	edsb.handleEDSResponse(xdsclient.ParseEDSRespProtoForTesting(clab1.Build()))
+
+	sc1 := <-cc.NewSubConnCh
+	edsb.handleSubConnStateChange(sc1, connectivity.Connecting)
+	edsb.handleSubConnStateChange(sc1, connectivity.Ready)
+
+	// Pick with only the first backend.
+	p1 := <-cc.NewPickerCh
+	for i := 0; i < 5; i++ {
+		gotSCSt, _ := p1.Pick(balancer.PickInfo{})
+		if !reflect.DeepEqual(gotSCSt.SubConn, sc1) {
+			t.Fatalf("picker.Pick, got %v, want SubConn=%v", gotSCSt, sc1)
+		}
+	}
+
+	edsb.handleEDSResponse(xdsclient.EndpointsUpdate{})
+	// Pick should fail with transient failure, and all priority removed error.
+	perr1 := <-cc.NewPickerCh
+	for i := 0; i < 5; i++ {
+		_, err := perr1.Pick(balancer.PickInfo{})
+		if !reflect.DeepEqual(err, errAllPrioritiesRemoved) {
+			t.Fatalf("picker.Pick, got error %v, want error %v", err, errAllPrioritiesRemoved)
+		}
+	}
+
+	// Handle another update with priorities and localities.
+	edsb.handleEDSResponse(xdsclient.ParseEDSRespProtoForTesting(clab1.Build()))
+
+	sc2 := <-cc.NewSubConnCh
+	edsb.handleSubConnStateChange(sc2, connectivity.Connecting)
+	edsb.handleSubConnStateChange(sc2, connectivity.Ready)
+
+	// Pick with only the first backend.
+	p2 := <-cc.NewPickerCh
+	for i := 0; i < 5; i++ {
+		gotSCSt, _ := p2.Pick(balancer.PickInfo{})
+		if !reflect.DeepEqual(gotSCSt.SubConn, sc2) {
+			t.Fatalf("picker.Pick, got %v, want SubConn=%v", gotSCSt, sc2)
+		}
+	}
+}
+
 // Create XDS balancer, and update sub-balancer before handling eds responses.
 // Then switch between round-robin and test-const-balancer after handling first
 // eds response.
@@ -412,7 +477,7 @@ func (s) TestEDS_UpdateSubBalancerName(t *testing.T) {
 	for i := 0; i < 5; i++ {
 		_, err := p0.Pick(balancer.PickInfo{})
 		if err != testutils.ErrTestConstPicker {
-			t.Fatalf("picker.Pick, got err %q, want err %q", err, testutils.ErrTestConstPicker)
+			t.Fatalf("picker.Pick, got err %+v, want err %+v", err, testutils.ErrTestConstPicker)
 		}
 	}
 

--- a/xds/internal/balancer/edsbalancer/eds_test.go
+++ b/xds/internal/balancer/edsbalancer/eds_test.go
@@ -22,6 +22,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"testing"
 
 	corepb "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
@@ -97,6 +98,7 @@ type fakeEDSBalancer struct {
 	cc                 balancer.ClientConn
 	childPolicy        *testutils.Channel
 	subconnStateChange *testutils.Channel
+	edsUpdate          *testutils.Channel
 	loadStore          lrs.Store
 }
 
@@ -108,9 +110,13 @@ func (f *fakeEDSBalancer) handleChildPolicy(name string, config json.RawMessage)
 	f.childPolicy.Send(&loadBalancingConfig{Name: name, Config: config})
 }
 
-func (f *fakeEDSBalancer) close()                                              {}
-func (f *fakeEDSBalancer) handleEDSResponse(edsResp xdsclient.EndpointsUpdate) {}
+func (f *fakeEDSBalancer) handleEDSResponse(edsResp xdsclient.EndpointsUpdate) {
+	f.edsUpdate.Send(edsResp)
+}
+
 func (f *fakeEDSBalancer) updateState(priority priorityType, s balancer.State) {}
+
+func (f *fakeEDSBalancer) close() {}
 
 func (f *fakeEDSBalancer) waitForChildPolicy(wantPolicy *loadBalancingConfig) error {
 	val, err := f.childPolicy.Receive()
@@ -136,11 +142,24 @@ func (f *fakeEDSBalancer) waitForSubConnStateChange(wantState *scStateChange) er
 	return nil
 }
 
+func (f *fakeEDSBalancer) waitForEDSResponse(wantUpdate xdsclient.EndpointsUpdate) error {
+	val, err := f.edsUpdate.Receive()
+	if err != nil {
+		return fmt.Errorf("error waiting for edsUpdate: %v", err)
+	}
+	gotUpdate := val.(xdsclient.EndpointsUpdate)
+	if !reflect.DeepEqual(gotUpdate, wantUpdate) {
+		return fmt.Errorf("got edsUpdate %+v, want %+v", gotUpdate, wantUpdate)
+	}
+	return nil
+}
+
 func newFakeEDSBalancer(cc balancer.ClientConn, loadStore lrs.Store) edsBalancerImplInterface {
 	return &fakeEDSBalancer{
 		cc:                 cc,
 		childPolicy:        testutils.NewChannelWithSize(10),
 		subconnStateChange: testutils.NewChannelWithSize(10),
+		edsUpdate:          testutils.NewChannelWithSize(10),
 		loadStore:          loadStore,
 	}
 }
@@ -395,6 +414,118 @@ func (s) TestXDSSubConnStateChange(t *testing.T) {
 	state := connectivity.Ready
 	edsB.UpdateSubConnState(fsc, balancer.SubConnState{ConnectivityState: state})
 	edsLB.waitForSubConnStateChange(&scStateChange{sc: fsc, state: state})
+}
+
+// TestErrorFromXDSClientUpdate verifies that errros from xdsclient update are
+// handled correctly.
+//
+// If it's resource-not-found, watch will NOT be canceled, the EDS impl will
+// receive an empty EDS update, and new RPCs will fail.
+//
+// If it's connection error, nothing will happen. This will need to change to
+// handle fallback.
+func (s) TestErrorFromXDSClientUpdate(t *testing.T) {
+	edsLBCh := testutils.NewChannel()
+	xdsClientCh := testutils.NewChannel()
+	cancel := setup(edsLBCh, xdsClientCh)
+	defer cancel()
+
+	builder := balancer.Get(edsName)
+	cc := newNoopTestClientConn()
+	edsB, ok := builder.Build(cc, balancer.BuildOptions{Target: resolver.Target{Endpoint: testEDSClusterName}}).(*edsBalancer)
+	if !ok {
+		t.Fatalf("builder.Build(%s) returned type {%T}, want {*edsBalancer}", edsName, edsB)
+	}
+	defer edsB.Close()
+
+	edsB.UpdateClientConnState(balancer.ClientConnState{
+		BalancerConfig: &EDSConfig{
+			BalancerName:   testBalancerNameFooBar,
+			EDSServiceName: testEDSClusterName,
+		},
+	})
+
+	xdsC := waitForNewXDSClientWithEDSWatch(t, xdsClientCh, testBalancerNameFooBar)
+	xdsC.InvokeWatchEDSCallback(xdsclient.EndpointsUpdate{}, nil)
+	edsLB := waitForNewEDSLB(t, edsLBCh)
+	if err := edsLB.waitForEDSResponse(xdsclient.EndpointsUpdate{}); err != nil {
+		t.Fatalf("EDS impl got unexpected EDS response: %v", err)
+	}
+
+	connectionErr := xdsclient.NewErrorf(xdsclient.ErrorTypeConnection, "connection error")
+	xdsC.InvokeWatchEDSCallback(xdsclient.EndpointsUpdate{}, connectionErr)
+	if err := xdsC.WaitForCancelEDSWatch(); err == nil {
+		t.Fatalf("watch was canceled, want not canceled (timeout error)")
+	}
+	if err := edsLB.waitForEDSResponse(xdsclient.EndpointsUpdate{}); err == nil {
+		t.Fatalf("eds impl got EDS resp, want timeout error")
+	}
+
+	resourceErr := xdsclient.NewErrorf(xdsclient.ErrorTypeResourceNotFound, "edsBalancer resource not found error")
+	xdsC.InvokeWatchEDSCallback(xdsclient.EndpointsUpdate{}, resourceErr)
+	// Even if error is resource not found, watch shouldn't be canceled, because
+	// this is an EDS resource removed (and xds client actually never sends this
+	// error, but we still handles it).
+	if err := xdsC.WaitForCancelEDSWatch(); err == nil {
+		t.Fatalf("watch was canceled, want not canceled (timeout error)")
+	}
+	if err := edsLB.waitForEDSResponse(xdsclient.EndpointsUpdate{}); err != nil {
+		t.Fatalf("eds impl expecting empty update, got %v", err)
+	}
+}
+
+// TestErrorFromResolver verifies that resolver errors are handled correctly.
+//
+// If it's resource-not-found, watch will be canceled, the EDS impl will receive
+// an empty EDS update, and new RPCs will fail.
+//
+// If it's connection error, nothing will happen. This will need to change to
+// handle fallback.
+func (s) TestErrorFromResolver(t *testing.T) {
+	edsLBCh := testutils.NewChannel()
+	xdsClientCh := testutils.NewChannel()
+	cancel := setup(edsLBCh, xdsClientCh)
+	defer cancel()
+
+	builder := balancer.Get(edsName)
+	cc := newNoopTestClientConn()
+	edsB, ok := builder.Build(cc, balancer.BuildOptions{Target: resolver.Target{Endpoint: testEDSClusterName}}).(*edsBalancer)
+	if !ok {
+		t.Fatalf("builder.Build(%s) returned type {%T}, want {*edsBalancer}", edsName, edsB)
+	}
+	defer edsB.Close()
+
+	edsB.UpdateClientConnState(balancer.ClientConnState{
+		BalancerConfig: &EDSConfig{
+			BalancerName:   testBalancerNameFooBar,
+			EDSServiceName: testEDSClusterName,
+		},
+	})
+
+	xdsC := waitForNewXDSClientWithEDSWatch(t, xdsClientCh, testBalancerNameFooBar)
+	xdsC.InvokeWatchEDSCallback(xdsclient.EndpointsUpdate{}, nil)
+	edsLB := waitForNewEDSLB(t, edsLBCh)
+	if err := edsLB.waitForEDSResponse(xdsclient.EndpointsUpdate{}); err != nil {
+		t.Fatalf("EDS impl got unexpected EDS response: %v", err)
+	}
+
+	connectionErr := xdsclient.NewErrorf(xdsclient.ErrorTypeConnection, "connection error")
+	edsB.ResolverError(connectionErr)
+	if err := xdsC.WaitForCancelEDSWatch(); err == nil {
+		t.Fatalf("watch was canceled, want not canceled (timeout error)")
+	}
+	if err := edsLB.waitForEDSResponse(xdsclient.EndpointsUpdate{}); err == nil {
+		t.Fatalf("eds impl got EDS resp, want timeout error")
+	}
+
+	resourceErr := xdsclient.NewErrorf(xdsclient.ErrorTypeResourceNotFound, "edsBalancer resource not found error")
+	edsB.ResolverError(resourceErr)
+	if err := xdsC.WaitForCancelEDSWatch(); err != nil {
+		t.Fatalf("want watch to be canceled, waitForCancel failed: %v", err)
+	}
+	if err := edsLB.waitForEDSResponse(xdsclient.EndpointsUpdate{}); err != nil {
+		t.Fatalf("EDS impl got unexpected EDS response: %v", err)
+	}
 }
 
 func (s) TestXDSBalancerConfigParsing(t *testing.T) {

--- a/xds/internal/client/errors.go
+++ b/xds/internal/client/errors.go
@@ -1,0 +1,60 @@
+/*
+ *
+ * Copyright 2020 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package client
+
+import "fmt"
+
+// ErrorType is the type of the error that the watcher will receive from the xds
+// client.
+type ErrorType int
+
+const (
+	// ErrorTypeUnknown indicates the error doesn't have a specific type. It is
+	// the default value, and is returned if the error is not an xds error.
+	ErrorTypeUnknown ErrorType = iota
+	// ErrorTypeConnection indicates a connection error from the gRPC client.
+	ErrorTypeConnection
+	// ErrorTypeResourceNotFound indicates a resource is not found from the xds
+	// response. It's typically returned if the resource is removed in the xds
+	// server.
+	ErrorTypeResourceNotFound
+)
+
+type xdsClientError struct {
+	t    ErrorType
+	desc string
+}
+
+func (e *xdsClientError) Error() string {
+	return e.desc
+}
+
+// NewErrorf creates an xds client error. The callbacks are called with this
+// error, to pass additional information about the error.
+func NewErrorf(t ErrorType, format string, args ...interface{}) error {
+	return &xdsClientError{t: t, desc: fmt.Sprintf(format, args...)}
+}
+
+// TypeOfError returns the error's type.
+func TypeOfError(e error) ErrorType {
+	if xe, ok := e.(*xdsClientError); ok {
+		return xe.t
+	}
+	return ErrorTypeUnknown
+}

--- a/xds/internal/testutils/fakeclient/client.go
+++ b/xds/internal/testutils/fakeclient/client.go
@@ -143,6 +143,13 @@ func (xdsC *Client) InvokeWatchEDSCallback(update xdsclient.EndpointsUpdate, err
 	xdsC.edsCb(update, err)
 }
 
+// WaitForCancelEDSWatch waits for a EDS watch to be cancelled within a
+// reasonable timeout, and returns testutils.ErrRecvTimeout otherwise.
+func (xdsC *Client) WaitForCancelEDSWatch() error {
+	_, err := xdsC.edsCancelCh.Receive()
+	return err
+}
+
 // ReportLoadArgs wraps the arguments passed to ReportLoad.
 type ReportLoadArgs struct {
 	// Server is the name of the server to which the load is reported.


### PR DESCRIPTION
EDS balancer ignores all errors before this change.

Changes in this PR:
- in xds_client
  - add error types to all errors returned by the xds_client
- in EDS balancer
  - handle errors from the callback
    - also merges EDS update handling function (there was a separate function for `lostContact()`)
  - handle errors from resolver update

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grpc/grpc-go/3636)
<!-- Reviewable:end -->
