### PR TITLE
Fix ALTS record crypto interface comments

### DIFF
--- a/credentials/alts/internal/conn/record.go
+++ b/credentials/alts/internal/conn/record.go
@@ -32,7 +32,7 @@ import (
 // ALTSRecordCrypto is the interface for gRPC ALTS record protocol.
 type ALTSRecordCrypto interface {
 	// Encrypt encrypts the plaintext and computes the tag (if any) of dst
-	// and plaintext, dst and plaintext do not overlap.
+	// and plaintext. dst and plaintext may fully overlap or not at all.
 	Encrypt(dst, plaintext []byte) ([]byte, error)
 	// EncryptionOverhead returns the tag size (if any) in bytes.
 	EncryptionOverhead() int


### PR DESCRIPTION
Fixed the documentation of ALTSRecordCrypto to match https://golang.org/pkg/crypto/cipher/#AEAD. `dst` and `plaintext` may overlap fully, as well as not overlap at all.

@cesarghali 