### PR TITLE
xds: handle errors in xds_client and resolver

### DIFF
--- a/xds/internal/client/client_test.go
+++ b/xds/internal/client/client_test.go
@@ -126,8 +126,8 @@ func (s) TestNew(t *testing.T) {
 type testXDSV2Client struct {
 	r updateHandler
 
-	addWatches    map[string]chan string
-	removeWatches map[string]chan string
+	addWatches    map[string]*testutils.Channel
+	removeWatches map[string]*testutils.Channel
 }
 
 func overrideNewXDSV2Client() (<-chan *testXDSV2Client, func()) {
@@ -142,16 +142,16 @@ func overrideNewXDSV2Client() (<-chan *testXDSV2Client, func()) {
 }
 
 func newTestXDSV2Client(r updateHandler) *testXDSV2Client {
-	addWatches := make(map[string]chan string)
-	addWatches[ldsURL] = make(chan string, 10)
-	addWatches[rdsURL] = make(chan string, 10)
-	addWatches[cdsURL] = make(chan string, 10)
-	addWatches[edsURL] = make(chan string, 10)
-	removeWatches := make(map[string]chan string)
-	removeWatches[ldsURL] = make(chan string, 10)
-	removeWatches[rdsURL] = make(chan string, 10)
-	removeWatches[cdsURL] = make(chan string, 10)
-	removeWatches[edsURL] = make(chan string, 10)
+	addWatches := make(map[string]*testutils.Channel)
+	addWatches[ldsURL] = testutils.NewChannel()
+	addWatches[rdsURL] = testutils.NewChannel()
+	addWatches[cdsURL] = testutils.NewChannel()
+	addWatches[edsURL] = testutils.NewChannel()
+	removeWatches := make(map[string]*testutils.Channel)
+	removeWatches[ldsURL] = testutils.NewChannel()
+	removeWatches[rdsURL] = testutils.NewChannel()
+	removeWatches[cdsURL] = testutils.NewChannel()
+	removeWatches[edsURL] = testutils.NewChannel()
 	return &testXDSV2Client{
 		r:             r,
 		addWatches:    addWatches,
@@ -160,11 +160,11 @@ func newTestXDSV2Client(r updateHandler) *testXDSV2Client {
 }
 
 func (c *testXDSV2Client) addWatch(resourceType, resourceName string) {
-	c.addWatches[resourceType] <- resourceName
+	c.addWatches[resourceType].Send(resourceName)
 }
 
 func (c *testXDSV2Client) removeWatch(resourceType, resourceName string) {
-	c.removeWatches[resourceType] <- resourceName
+	c.removeWatches[resourceType].Send(resourceName)
 }
 
 func (c *testXDSV2Client) close() {}

--- a/xds/internal/client/client_watchers_lds_test.go
+++ b/xds/internal/client/client_watchers_lds_test.go
@@ -31,7 +31,7 @@ type ldsUpdateErr struct {
 
 // TestLDSWatch covers the cases:
 // - an update is received after a watch()
-// - an update for another resource name (which doesn't trigger callback)
+// - an update for another resource name
 // - an upate is received after cancel()
 func (s) TestLDSWatch(t *testing.T) {
 	v2ClientCh, cleanup := overrideNewXDSV2Client()
@@ -59,12 +59,13 @@ func (s) TestLDSWatch(t *testing.T) {
 		t.Errorf("unexpected ldsUpdate: %v, error receiving from channel: %v", u, err)
 	}
 
-	// Another update for a different resource name.
+	// Another update, with an extra resource for a different resource name.
 	v2Client.r.newLDSUpdate(map[string]ldsUpdate{
+		testLDSName:  wantUpdate,
 		"randomName": {},
 	})
 
-	if u, err := ldsUpdateCh.TimedReceive(chanRecvTimeout); err != testutils.ErrRecvTimeout {
+	if u, err := ldsUpdateCh.Receive(); err != nil || u != (ldsUpdateErr{wantUpdate, nil}) {
 		t.Errorf("unexpected ldsUpdate: %v, %v, want channel recv timeout", u, err)
 	}
 
@@ -226,5 +227,79 @@ func (s) TestLDSWatchAfterCache(t *testing.T) {
 	// Old watch should see nothing.
 	if u, err := ldsUpdateCh.TimedReceive(chanRecvTimeout); err != testutils.ErrRecvTimeout {
 		t.Errorf("unexpected ldsUpdate: %v, %v, want channel recv timeout", u, err)
+	}
+}
+
+// TestLDSResourceRemoved covers the cases:
+// - an update is received after a watch()
+// - another update is received, with one resource removed
+//   - this should trigger callback with resource removed error
+// - one more update without the removed resource
+//   - the callback (above) shouldn't receive any update
+func (s) TestLDSResourceRemoved(t *testing.T) {
+	v2ClientCh, cleanup := overrideNewXDSV2Client()
+	defer cleanup()
+
+	c, err := New(clientOpts(testXDSServer))
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+	defer c.Close()
+
+	v2Client := <-v2ClientCh
+
+	ldsUpdateCh1 := testutils.NewChannel()
+	c.watchLDS(testLDSName+"1", func(update ldsUpdate, err error) {
+		ldsUpdateCh1.Send(ldsUpdateErr{u: update, err: err})
+	})
+	// Another watch for a different name.
+	ldsUpdateCh2 := testutils.NewChannel()
+	c.watchLDS(testLDSName+"2", func(update ldsUpdate, err error) {
+		ldsUpdateCh2.Send(ldsUpdateErr{u: update, err: err})
+	})
+
+	wantUpdate1 := ldsUpdate{routeName: testEDSName + "1"}
+	wantUpdate2 := ldsUpdate{routeName: testEDSName + "2"}
+	v2Client.r.newLDSUpdate(map[string]ldsUpdate{
+		testLDSName + "1": wantUpdate1,
+		testLDSName + "2": wantUpdate2,
+	})
+
+	if u, err := ldsUpdateCh1.Receive(); err != nil || u != (ldsUpdateErr{wantUpdate1, nil}) {
+		t.Errorf("unexpected ldsUpdate: %v, error receiving from channel: %v", u, err)
+	}
+
+	if u, err := ldsUpdateCh2.Receive(); err != nil || u != (ldsUpdateErr{wantUpdate2, nil}) {
+		t.Errorf("unexpected ldsUpdate: %v, error receiving from channel: %v", u, err)
+	}
+
+	// Send another update to remove resource 1.
+	v2Client.r.newLDSUpdate(map[string]ldsUpdate{
+		testLDSName + "2": wantUpdate2,
+	})
+
+	// watcher 1 should get an error.
+	if u, err := ldsUpdateCh1.Receive(); err != nil || ErrType(u.(ldsUpdateErr).err) != ErrorTypeResourceNotFound {
+		t.Errorf("unexpected ldsUpdate: %v, error receiving from channel: %v, want update with error resource not found", u, err)
+	}
+
+	// watcher 2 should get the same update again.
+	if u, err := ldsUpdateCh2.Receive(); err != nil || u != (ldsUpdateErr{wantUpdate2, nil}) {
+		t.Errorf("unexpected ldsUpdate: %v, error receiving from channel: %v", u, err)
+	}
+
+	// Send one more update without resource 1.
+	v2Client.r.newLDSUpdate(map[string]ldsUpdate{
+		testLDSName + "2": wantUpdate2,
+	})
+
+	// watcher 1 should get an error.
+	if u, err := ldsUpdateCh1.Receive(); err != testutils.ErrRecvTimeout {
+		t.Errorf("unexpected ldsUpdate: %v, want receiving from channel timeout", u)
+	}
+
+	// watcher 2 should get the same update again.
+	if u, err := ldsUpdateCh2.Receive(); err != nil || u != (ldsUpdateErr{wantUpdate2, nil}) {
+		t.Errorf("unexpected ldsUpdate: %v, error receiving from channel: %v", u, err)
 	}
 }

--- a/xds/internal/client/client_watchers_service_test.go
+++ b/xds/internal/client/client_watchers_service_test.go
@@ -57,11 +57,15 @@ func (s) TestServiceWatch(t *testing.T) {
 
 	wantUpdate := ServiceUpdate{WeightedCluster: map[string]uint32{testCDSName: 1}}
 
-	<-v2Client.addWatches[ldsURL]
+	if _, err := v2Client.addWatches[ldsURL].Receive(); err != nil {
+		t.Fatalf("want new watch to start, got error %v", err)
+	}
 	v2Client.r.newLDSUpdate(map[string]ldsUpdate{
 		testLDSName: {routeName: testRDSName},
 	})
-	<-v2Client.addWatches[rdsURL]
+	if _, err := v2Client.addWatches[rdsURL].Receive(); err != nil {
+		t.Fatalf("want new watch to start, got error %v", err)
+	}
 	v2Client.r.newRDSUpdate(map[string]rdsUpdate{
 		testRDSName: {weightedCluster: map[string]uint32{testCDSName: 1}},
 	})
@@ -93,11 +97,15 @@ func (s) TestServiceWatchLDSUpdate(t *testing.T) {
 
 	wantUpdate := ServiceUpdate{WeightedCluster: map[string]uint32{testCDSName: 1}}
 
-	<-v2Client.addWatches[ldsURL]
+	if _, err := v2Client.addWatches[ldsURL].Receive(); err != nil {
+		t.Fatalf("want new watch to start, got error %v", err)
+	}
 	v2Client.r.newLDSUpdate(map[string]ldsUpdate{
 		testLDSName: {routeName: testRDSName},
 	})
-	<-v2Client.addWatches[rdsURL]
+	if _, err := v2Client.addWatches[rdsURL].Receive(); err != nil {
+		t.Fatalf("want new watch to start, got error %v", err)
+	}
 	v2Client.r.newRDSUpdate(map[string]rdsUpdate{
 		testRDSName: {weightedCluster: map[string]uint32{testCDSName: 1}},
 	})
@@ -110,7 +118,9 @@ func (s) TestServiceWatchLDSUpdate(t *testing.T) {
 	v2Client.r.newLDSUpdate(map[string]ldsUpdate{
 		testLDSName: {routeName: testRDSName + "2"},
 	})
-	<-v2Client.addWatches[rdsURL]
+	if _, err := v2Client.addWatches[rdsURL].Receive(); err != nil {
+		t.Fatalf("want new watch to start, got error %v", err)
+	}
 
 	// Another update for the old name.
 	v2Client.r.newRDSUpdate(map[string]rdsUpdate{
@@ -154,11 +164,15 @@ func (s) TestServiceWatchSecond(t *testing.T) {
 
 	wantUpdate := ServiceUpdate{WeightedCluster: map[string]uint32{testCDSName: 1}}
 
-	<-v2Client.addWatches[ldsURL]
+	if _, err := v2Client.addWatches[ldsURL].Receive(); err != nil {
+		t.Fatalf("want new watch to start, got error %v", err)
+	}
 	v2Client.r.newLDSUpdate(map[string]ldsUpdate{
 		testLDSName: {routeName: testRDSName},
 	})
-	<-v2Client.addWatches[rdsURL]
+	if _, err := v2Client.addWatches[rdsURL].Receive(); err != nil {
+		t.Fatalf("want new watch to start, got error %v", err)
+	}
 	v2Client.r.newRDSUpdate(map[string]rdsUpdate{
 		testRDSName: {weightedCluster: map[string]uint32{testCDSName: 1}},
 	})
@@ -361,11 +375,15 @@ func (s) TestServiceNotCancelRDSOnSameLDSUpdate(t *testing.T) {
 
 	wantUpdate := ServiceUpdate{WeightedCluster: map[string]uint32{testCDSName: 1}}
 
-	<-v2Client.addWatches[ldsURL]
+	if _, err := v2Client.addWatches[ldsURL].Receive(); err != nil {
+		t.Fatalf("want new watch to start, got error %v", err)
+	}
 	v2Client.r.newLDSUpdate(map[string]ldsUpdate{
 		testLDSName: {routeName: testRDSName},
 	})
-	<-v2Client.addWatches[rdsURL]
+	if _, err := v2Client.addWatches[rdsURL].Receive(); err != nil {
+		t.Fatalf("want new watch to start, got error %v", err)
+	}
 	v2Client.r.newRDSUpdate(map[string]rdsUpdate{
 		testRDSName: {weightedCluster: map[string]uint32{testCDSName: 1}},
 	})
@@ -378,9 +396,89 @@ func (s) TestServiceNotCancelRDSOnSameLDSUpdate(t *testing.T) {
 	v2Client.r.newLDSUpdate(map[string]ldsUpdate{
 		testLDSName: {routeName: testRDSName},
 	})
-	select {
-	case <-v2Client.removeWatches[rdsURL]:
-		t.Fatalf("unexpected rds watch cancel")
-	case <-time.After(time.Second):
+	if v, err := v2Client.removeWatches[rdsURL].Receive(); err == nil {
+		t.Fatalf("unexpected rds watch cancel: %v", v)
+	}
+}
+
+// TestServiceResourceRemoved covers the cases:
+// - an update is received after a watch()
+// - another update is received, with one resource removed
+//   - this should trigger callback with resource removed error
+// - one more update without the removed resource
+//   - the callback (above) shouldn't receive any update
+func (s) TestServiceResourceRemoved(t *testing.T) {
+	v2ClientCh, cleanup := overrideNewXDSV2Client()
+	defer cleanup()
+
+	c, err := New(clientOpts(testXDSServer))
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+	defer c.Close()
+
+	v2Client := <-v2ClientCh
+
+	serviceUpdateCh := testutils.NewChannel()
+	c.WatchService(testLDSName, func(update ServiceUpdate, err error) {
+		serviceUpdateCh.Send(serviceUpdateErr{u: update, err: err})
+	})
+
+	wantUpdate := ServiceUpdate{WeightedCluster: map[string]uint32{testCDSName: 1}}
+
+	if _, err := v2Client.addWatches[ldsURL].Receive(); err != nil {
+		t.Fatalf("want new watch to start, got error %v", err)
+	}
+	v2Client.r.newLDSUpdate(map[string]ldsUpdate{
+		testLDSName: {routeName: testRDSName},
+	})
+	if _, err := v2Client.addWatches[rdsURL].Receive(); err != nil {
+		t.Fatalf("want new watch to start, got error %v", err)
+	}
+	v2Client.r.newRDSUpdate(map[string]rdsUpdate{
+		testRDSName: {weightedCluster: map[string]uint32{testCDSName: 1}},
+	})
+
+	if u, err := serviceUpdateCh.Receive(); err != nil || !cmp.Equal(u, serviceUpdateErr{wantUpdate, nil}, cmp.AllowUnexported(serviceUpdateErr{})) {
+		t.Errorf("unexpected serviceUpdate: %v, error receiving from channel: %v", u, err)
+	}
+
+	// Remove LDS resource, should cancel the RDS watch, and trigger resource
+	// removed error.
+	v2Client.r.newLDSUpdate(map[string]ldsUpdate{})
+	if _, err := v2Client.removeWatches[rdsURL].Receive(); err != nil {
+		t.Fatalf("want watch to be canceled, got error %v", err)
+	}
+	if u, err := serviceUpdateCh.Receive(); err != nil || ErrType(u.(serviceUpdateErr).err) != ErrorTypeResourceNotFound {
+		t.Errorf("unexpected serviceUpdate: %v, error receiving from channel: %v, want update with error resource not found", u, err)
+	}
+
+	// Send RDS update for the removed LDS resource, expect no updates to
+	// callback, because RDS should be canceled.
+	v2Client.r.newRDSUpdate(map[string]rdsUpdate{
+		testRDSName: {weightedCluster: map[string]uint32{testCDSName + "new": 1}},
+	})
+	if u, err := serviceUpdateCh.Receive(); err != testutils.ErrRecvTimeout {
+		t.Errorf("unexpected serviceUpdate: %v, want receiving from channel timeout", u)
+	}
+
+	// Add LDS resource, but not RDS resource, should
+	//  - start a new RDS watch
+	//  - timeout on service channel, because RDS cache was cleared
+	v2Client.r.newLDSUpdate(map[string]ldsUpdate{
+		testLDSName: {routeName: testRDSName},
+	})
+	if _, err := v2Client.addWatches[rdsURL].Receive(); err != nil {
+		t.Fatalf("want new watch to start, got error %v", err)
+	}
+	if u, err := serviceUpdateCh.Receive(); err != testutils.ErrRecvTimeout {
+		t.Errorf("unexpected serviceUpdate: %v, want receiving from channel timeout", u)
+	}
+
+	v2Client.r.newRDSUpdate(map[string]rdsUpdate{
+		testRDSName: {weightedCluster: map[string]uint32{testCDSName + "new2": 1}},
+	})
+	if u, err := serviceUpdateCh.Receive(); err != nil || !cmp.Equal(u, serviceUpdateErr{ServiceUpdate{WeightedCluster: map[string]uint32{testCDSName + "new2": 1}}, nil}, cmp.AllowUnexported(serviceUpdateErr{})) {
+		t.Errorf("unexpected serviceUpdate: %v, error receiving from channel: %v", u, err)
 	}
 }

--- a/xds/internal/resolver/serviceconfig_test.go
+++ b/xds/internal/resolver/serviceconfig_test.go
@@ -49,6 +49,11 @@ const (
 	  }
 	}
 }]}`
+	testWeightedCDSNoChildJSON = `{"loadBalancingConfig":[{
+    "weighted_target_experimental": {
+	  "targets": {}
+	}
+}]}`
 )
 
 func TestServiceUpdateToJSON(t *testing.T) {
@@ -61,6 +66,11 @@ func TestServiceUpdateToJSON(t *testing.T) {
 			name:     "one cluster only",
 			su:       client.ServiceUpdate{WeightedCluster: map[string]uint32{testCluster1: 1}},
 			wantJSON: testClusterOnlyJSON,
+		},
+		{
+			name:     "empty weighted clusters",
+			su:       client.ServiceUpdate{WeightedCluster: nil},
+			wantJSON: testWeightedCDSNoChildJSON,
 		},
 		{
 			name: "weighted clusters",

--- a/xds/internal/resolver/xds_resolver_test.go
+++ b/xds/internal/resolver/xds_resolver_test.go
@@ -406,3 +406,45 @@ func TestXDSResolverGoodUpdateAfterError(t *testing.T) {
 		t.Fatalf("ClientConn.ReportError() received %v, want %v", gotErrVal, suErr2)
 	}
 }
+
+// TestXDSResolverResourceNotFoundError tests the cases where the resolver gets
+// a ResourceNotFoundError. It should generate a service config picking
+// weighted_target, but no child balancers.
+func TestXDSResolverResourceNotFoundError(t *testing.T) {
+	xdsC := fakeclient.NewClient()
+	xdsR, tcc, cancel := testSetup(t, setupOpts{
+		config:        &validConfig,
+		xdsClientFunc: func(_ xdsclient.Options) (xdsClientInterface, error) { return xdsC, nil },
+	})
+	defer func() {
+		cancel()
+		xdsR.Close()
+	}()
+
+	waitForWatchService(t, xdsC, targetStr)
+
+	// Invoke the watchAPI callback with a bad service update and wait for the
+	// ReportError method to be called on the ClientConn.
+	suErr := xdsclient.NewErrorf(xdsclient.ErrorTypeResourceNotFound, "resource removed error")
+	xdsC.InvokeWatchServiceCallback(xdsclient.ServiceUpdate{}, suErr)
+	if gotErrVal, gotErr := tcc.errorCh.Receive(); gotErr != testutils.ErrRecvTimeout {
+		t.Fatalf("ClientConn.ReportError() received %v, %v, want channel recv timeout", gotErrVal, gotErr)
+	}
+	gotState, err := tcc.stateCh.Receive()
+	if err != nil {
+		t.Fatalf("ClientConn.UpdateState returned error: %v", err)
+	}
+	rState := gotState.(resolver.State)
+	if gotClient := rState.Attributes.Value(xdsinternal.XDSClientID); gotClient != xdsC {
+		t.Fatalf("ClientConn.UpdateState got xdsClient: %v, want %v", gotClient, xdsC)
+	}
+	wantParsedConfig := internal.ParseServiceConfigForTesting.(func(string) *serviceconfig.ParseResult)(testWeightedCDSNoChildJSON)
+	if !internal.EqualServiceConfigForTesting(rState.ServiceConfig.Config, wantParsedConfig.Config) {
+		t.Errorf("ClientConn.UpdateState got wrong service config")
+		t.Error("gotParsed: ", cmp.Diff(nil, rState.ServiceConfig.Config))
+		t.Error("wantParsed: ", cmp.Diff(nil, wantParsedConfig.Config))
+	}
+	if err := rState.ServiceConfig.Err; err != nil {
+		t.Fatalf("ClientConn.UpdateState received error in service config: %v", rState.ServiceConfig.Err)
+	}
+}


### PR DESCRIPTION
- xds_client
  - send resource-not-found error when a resource is removed for LDS or CDS
  - handle LDS resource-not-found to cancel RDS watch
- xds_resolver
  - generate service config to remove all sub-balancers if resource-not-found error
  - forward other errors

- test update because it was expecting no update when resource is removed
- test cleanup to apply timeout to channels