### PR TITLE
xds: handle errors in xds resolver

### DIFF
--- a/xds/internal/resolver/serviceconfig_test.go
+++ b/xds/internal/resolver/serviceconfig_test.go
@@ -49,6 +49,11 @@ const (
 	  }
 	}
 }]}`
+	testWeightedCDSNoChildJSON = `{"loadBalancingConfig":[{
+    "weighted_target_experimental": {
+	  "targets": {}
+	}
+}]}`
 )
 
 func TestServiceUpdateToJSON(t *testing.T) {
@@ -61,6 +66,11 @@ func TestServiceUpdateToJSON(t *testing.T) {
 			name:     "one cluster only",
 			su:       client.ServiceUpdate{WeightedCluster: map[string]uint32{testCluster1: 1}},
 			wantJSON: testClusterOnlyJSON,
+		},
+		{
+			name:     "empty weighted clusters",
+			su:       client.ServiceUpdate{WeightedCluster: nil},
+			wantJSON: testWeightedCDSNoChildJSON,
 		},
 		{
 			name: "weighted clusters",

--- a/xds/internal/resolver/xds_resolver_test.go
+++ b/xds/internal/resolver/xds_resolver_test.go
@@ -435,10 +435,12 @@ func TestXDSResolverResourceNotFoundError(t *testing.T) {
 		t.Fatalf("ClientConn.UpdateState returned error: %v", err)
 	}
 	rState := gotState.(resolver.State)
-	if gotClient := rState.Attributes.Value(xdsinternal.XDSClientID); gotClient != xdsC {
-		t.Fatalf("ClientConn.UpdateState got xdsClient: %v, want %v", gotClient, xdsC)
+	// This update shouldn't have xds-client in it, because it doesn't pick an
+	// xds balancer.
+	if gotClient := rState.Attributes.Value(xdsinternal.XDSClientID); gotClient != nil {
+		t.Fatalf("ClientConn.UpdateState got xdsClient: %v, want <nil>", gotClient)
 	}
-	wantParsedConfig := internal.ParseServiceConfigForTesting.(func(string) *serviceconfig.ParseResult)(testWeightedCDSNoChildJSON)
+	wantParsedConfig := internal.ParseServiceConfigForTesting.(func(string) *serviceconfig.ParseResult)("{}")
 	if !internal.EqualServiceConfigForTesting(rState.ServiceConfig.Config, wantParsedConfig.Config) {
 		t.Errorf("ClientConn.UpdateState got wrong service config")
 		t.Error("gotParsed: ", cmp.Diff(nil, rState.ServiceConfig.Config))

--- a/xds/internal/resolver/xds_resolver_test.go
+++ b/xds/internal/resolver/xds_resolver_test.go
@@ -442,9 +442,9 @@ func TestXDSResolverResourceNotFoundError(t *testing.T) {
 	}
 	wantParsedConfig := internal.ParseServiceConfigForTesting.(func(string) *serviceconfig.ParseResult)("{}")
 	if !internal.EqualServiceConfigForTesting(rState.ServiceConfig.Config, wantParsedConfig.Config) {
-		t.Errorf("ClientConn.UpdateState got wrong service config")
-		t.Error("gotParsed: ", cmp.Diff(nil, rState.ServiceConfig.Config))
-		t.Error("wantParsed: ", cmp.Diff(nil, wantParsedConfig.Config))
+		t.Error("ClientConn.UpdateState got wrong service config")
+		t.Errorf("gotParsed: %s", cmp.Diff(nil, rState.ServiceConfig.Config))
+		t.Errorf("wantParsed: %s", cmp.Diff(nil, wantParsedConfig.Config))
 	}
 	if err := rState.ServiceConfig.Err; err != nil {
 		t.Fatalf("ClientConn.UpdateState received error in service config: %v", rState.ServiceConfig.Err)

--- a/xds/internal/resolver/xds_resolver_test.go
+++ b/xds/internal/resolver/xds_resolver_test.go
@@ -406,3 +406,45 @@ func TestXDSResolverGoodUpdateAfterError(t *testing.T) {
 		t.Fatalf("ClientConn.ReportError() received %v, want %v", gotErrVal, suErr2)
 	}
 }
+
+// TestXDSResolverResourceNotFoundError tests the cases where the resolver gets
+// a ResourceNotFoundError. It should generate a service config picking
+// weighted_target, but no child balancers.
+func TestXDSResolverResourceNotFoundError(t *testing.T) {
+	xdsC := fakeclient.NewClient()
+	xdsR, tcc, cancel := testSetup(t, setupOpts{
+		config:        &validConfig,
+		xdsClientFunc: func(_ xdsclient.Options) (xdsClientInterface, error) { return xdsC, nil },
+	})
+	defer func() {
+		cancel()
+		xdsR.Close()
+	}()
+
+	waitForWatchService(t, xdsC, targetStr)
+
+	// Invoke the watchAPI callback with a bad service update and wait for the
+	// ReportError method to be called on the ClientConn.
+	suErr := xdsclient.NewErrorf(xdsclient.ErrorTypeResourceNotFound, "resource removed error")
+	xdsC.InvokeWatchServiceCallback(xdsclient.ServiceUpdate{}, suErr)
+	if gotErrVal, gotErr := tcc.errorCh.Receive(); gotErr != testutils.ErrRecvTimeout {
+		t.Fatalf("ClientConn.ReportError() received %v, %v, want channel recv timeout", gotErrVal, gotErr)
+	}
+	gotState, err := tcc.stateCh.Receive()
+	if err != nil {
+		t.Fatalf("ClientConn.UpdateState returned error: %v", err)
+	}
+	rState := gotState.(resolver.State)
+	if gotClient := rState.Attributes.Value(xdsinternal.XDSClientID); gotClient != xdsC {
+		t.Fatalf("ClientConn.UpdateState got xdsClient: %v, want %v", gotClient, xdsC)
+	}
+	wantParsedConfig := internal.ParseServiceConfigForTesting.(func(string) *serviceconfig.ParseResult)(testWeightedCDSNoChildJSON)
+	if !internal.EqualServiceConfigForTesting(rState.ServiceConfig.Config, wantParsedConfig.Config) {
+		t.Errorf("ClientConn.UpdateState got wrong service config")
+		t.Error("gotParsed: ", cmp.Diff(nil, rState.ServiceConfig.Config))
+		t.Error("wantParsed: ", cmp.Diff(nil, wantParsedConfig.Config))
+	}
+	if err := rState.ServiceConfig.Err; err != nil {
+		t.Fatalf("ClientConn.UpdateState received error in service config: %v", rState.ServiceConfig.Err)
+	}
+}


### PR DESCRIPTION
  - generate service config to use pickfirst with no address, to put clientconn  into transient failure
  - forward other errors