### PR TITLE
credentials/local: fix incorrect binding of listener port

### DIFF
--- a/credentials/local/local_test.go
+++ b/credentials/local/local_test.go
@@ -163,17 +163,17 @@ func (s) TestServerAndClientHandshake(t *testing.T) {
 	}{
 		{
 			testNetwork: "tcp",
-			testAddr:    "127.0.0.1:10000",
+			testAddr:    "127.0.0.1:0",
 			want:        credentials.NoSecurity,
 		},
 		{
 			testNetwork: "tcp",
-			testAddr:    "[::1]:10000",
+			testAddr:    "[::1]:0",
 			want:        credentials.NoSecurity,
 		},
 		{
 			testNetwork: "tcp",
-			testAddr:    "localhost:10000",
+			testAddr:    "localhost:0",
 			want:        credentials.NoSecurity,
 		},
 		{


### PR DESCRIPTION
When doing an internal import of #3517, there was an error - `Failed to listen: listen tcp [::1]:10000: bind: permission denied` in `local_test.go`. This PR fixes the issue.