### PR TITLE
xds: handle errors in xds_client

### DIFF
--- a/xds/internal/client/client_callback.go
+++ b/xds/internal/client/client_callback.go
@@ -74,11 +74,11 @@ func (c *Client) callCallback(wiu *watcherInfoWithUpdate) {
 //
 // A response can contain multiple resources. They will be parsed and put in a
 // map from resource name to the resource content.
-func (c *Client) newLDSUpdate(d map[string]ldsUpdate) {
+func (c *Client) newLDSUpdate(updates map[string]ldsUpdate) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	for name, update := range d {
+	for name, update := range updates {
 		if s, ok := c.ldsWatchers[name]; ok {
 			for wi := range s {
 				wi.newUpdate(update)
@@ -89,7 +89,7 @@ func (c *Client) newLDSUpdate(d map[string]ldsUpdate) {
 		}
 	}
 	for name := range c.ldsCache {
-		if _, ok := d[name]; !ok {
+		if _, ok := updates[name]; !ok {
 			// If resource exists in cache, but not in the new update, delete it
 			// from cache, and also send an resource not found error to indicate
 			// resource removed.
@@ -100,8 +100,8 @@ func (c *Client) newLDSUpdate(d map[string]ldsUpdate) {
 		}
 	}
 	// When LDS resource is removed, we don't delete corresponding RDS cached
-	// data. The RDS watch will be canceled, and cache is removed when the last
-	// watch is canceled.
+	// data. The RDS watch will be canceled, and cache entry is removed when the
+	// last watch is canceled.
 }
 
 // newRDSUpdate is called by the underlying xdsv2Client when it receives an xDS
@@ -109,11 +109,11 @@ func (c *Client) newLDSUpdate(d map[string]ldsUpdate) {
 //
 // A response can contain multiple resources. They will be parsed and put in a
 // map from resource name to the resource content.
-func (c *Client) newRDSUpdate(d map[string]rdsUpdate) {
+func (c *Client) newRDSUpdate(updates map[string]rdsUpdate) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	for name, update := range d {
+	for name, update := range updates {
 		if s, ok := c.rdsWatchers[name]; ok {
 			for wi := range s {
 				wi.newUpdate(update)
@@ -130,11 +130,11 @@ func (c *Client) newRDSUpdate(d map[string]rdsUpdate) {
 //
 // A response can contain multiple resources. They will be parsed and put in a
 // map from resource name to the resource content.
-func (c *Client) newCDSUpdate(d map[string]ClusterUpdate) {
+func (c *Client) newCDSUpdate(updates map[string]ClusterUpdate) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	for name, update := range d {
+	for name, update := range updates {
 		if s, ok := c.cdsWatchers[name]; ok {
 			for wi := range s {
 				wi.newUpdate(update)
@@ -145,7 +145,7 @@ func (c *Client) newCDSUpdate(d map[string]ClusterUpdate) {
 		}
 	}
 	for name := range c.cdsCache {
-		if _, ok := d[name]; !ok {
+		if _, ok := updates[name]; !ok {
 			// If resource exists in cache, but not in the new update, delete it
 			// from cache, and also send an resource not found error to indicate
 			// resource removed.
@@ -156,8 +156,8 @@ func (c *Client) newCDSUpdate(d map[string]ClusterUpdate) {
 		}
 	}
 	// When CDS resource is removed, we don't delete corresponding EDS cached
-	// data. The EDS watch will be canceled, and cache is removed when the last
-	// watch is canceled.
+	// data. The EDS watch will be canceled, and cache entry is removed when the
+	// last watch is canceled.
 }
 
 // newEDSUpdate is called by the underlying xdsv2Client when it receives an xDS
@@ -165,11 +165,11 @@ func (c *Client) newCDSUpdate(d map[string]ClusterUpdate) {
 //
 // A response can contain multiple resources. They will be parsed and put in a
 // map from resource name to the resource content.
-func (c *Client) newEDSUpdate(d map[string]EndpointsUpdate) {
+func (c *Client) newEDSUpdate(updates map[string]EndpointsUpdate) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	for name, update := range d {
+	for name, update := range updates {
 		if s, ok := c.edsWatchers[name]; ok {
 			for wi := range s {
 				wi.newUpdate(update)

--- a/xds/internal/client/client_test.go
+++ b/xds/internal/client/client_test.go
@@ -126,8 +126,8 @@ func (s) TestNew(t *testing.T) {
 type testXDSV2Client struct {
 	r updateHandler
 
-	addWatches    map[string]chan string
-	removeWatches map[string]chan string
+	addWatches    map[string]*testutils.Channel
+	removeWatches map[string]*testutils.Channel
 }
 
 func overrideNewXDSV2Client() (<-chan *testXDSV2Client, func()) {
@@ -142,16 +142,16 @@ func overrideNewXDSV2Client() (<-chan *testXDSV2Client, func()) {
 }
 
 func newTestXDSV2Client(r updateHandler) *testXDSV2Client {
-	addWatches := make(map[string]chan string)
-	addWatches[ldsURL] = make(chan string, 10)
-	addWatches[rdsURL] = make(chan string, 10)
-	addWatches[cdsURL] = make(chan string, 10)
-	addWatches[edsURL] = make(chan string, 10)
-	removeWatches := make(map[string]chan string)
-	removeWatches[ldsURL] = make(chan string, 10)
-	removeWatches[rdsURL] = make(chan string, 10)
-	removeWatches[cdsURL] = make(chan string, 10)
-	removeWatches[edsURL] = make(chan string, 10)
+	addWatches := make(map[string]*testutils.Channel)
+	addWatches[ldsURL] = testutils.NewChannel()
+	addWatches[rdsURL] = testutils.NewChannel()
+	addWatches[cdsURL] = testutils.NewChannel()
+	addWatches[edsURL] = testutils.NewChannel()
+	removeWatches := make(map[string]*testutils.Channel)
+	removeWatches[ldsURL] = testutils.NewChannel()
+	removeWatches[rdsURL] = testutils.NewChannel()
+	removeWatches[cdsURL] = testutils.NewChannel()
+	removeWatches[edsURL] = testutils.NewChannel()
 	return &testXDSV2Client{
 		r:             r,
 		addWatches:    addWatches,
@@ -160,11 +160,11 @@ func newTestXDSV2Client(r updateHandler) *testXDSV2Client {
 }
 
 func (c *testXDSV2Client) addWatch(resourceType, resourceName string) {
-	c.addWatches[resourceType] <- resourceName
+	c.addWatches[resourceType].Send(resourceName)
 }
 
 func (c *testXDSV2Client) removeWatch(resourceType, resourceName string) {
-	c.removeWatches[resourceType] <- resourceName
+	c.removeWatches[resourceType].Send(resourceName)
 }
 
 func (c *testXDSV2Client) close() {}

--- a/xds/internal/client/client_watchers_endpoints_test.go
+++ b/xds/internal/client/client_watchers_endpoints_test.go
@@ -69,6 +69,9 @@ func (s) TestEndpointsWatch(t *testing.T) {
 	cancelWatch := c.WatchEndpoints(testCDSName, func(update EndpointsUpdate, err error) {
 		endpointsUpdateCh.Send(endpointsUpdateErr{u: update, err: err})
 	})
+	if _, err := v2Client.addWatches[edsURL].Receive(); err != nil {
+		t.Fatalf("want new watch to start, got error %v", err)
+	}
 
 	wantUpdate := EndpointsUpdate{Localities: []Locality{testLocalities[0]}}
 	v2Client.r.newEDSUpdate(map[string]EndpointsUpdate{
@@ -124,6 +127,9 @@ func (s) TestEndpointsTwoWatchSameResourceName(t *testing.T) {
 		cancelLastWatch = c.WatchEndpoints(testCDSName, func(update EndpointsUpdate, err error) {
 			endpointsUpdateCh.Send(endpointsUpdateErr{u: update, err: err})
 		})
+		if _, err := v2Client.addWatches[edsURL].Receive(); i == 0 && err != nil {
+			t.Fatalf("want new watch to start, got error %v", err)
+		}
 	}
 
 	wantUpdate := EndpointsUpdate{Localities: []Locality{testLocalities[0]}}
@@ -178,6 +184,9 @@ func (s) TestEndpointsThreeWatchDifferentResourceName(t *testing.T) {
 		c.WatchEndpoints(testCDSName+"1", func(update EndpointsUpdate, err error) {
 			endpointsUpdateCh.Send(endpointsUpdateErr{u: update, err: err})
 		})
+		if _, err := v2Client.addWatches[edsURL].Receive(); i == 0 && err != nil {
+			t.Fatalf("want new watch to start, got error %v", err)
+		}
 	}
 
 	// Third watch for a different name.
@@ -185,6 +194,9 @@ func (s) TestEndpointsThreeWatchDifferentResourceName(t *testing.T) {
 	c.WatchEndpoints(testCDSName+"2", func(update EndpointsUpdate, err error) {
 		endpointsUpdateCh2.Send(endpointsUpdateErr{u: update, err: err})
 	})
+	if _, err := v2Client.addWatches[edsURL].Receive(); err != nil {
+		t.Fatalf("want new watch to start, got error %v", err)
+	}
 
 	wantUpdate1 := EndpointsUpdate{Localities: []Locality{testLocalities[0]}}
 	wantUpdate2 := EndpointsUpdate{Localities: []Locality{testLocalities[1]}}
@@ -222,6 +234,9 @@ func (s) TestEndpointsWatchAfterCache(t *testing.T) {
 	c.WatchEndpoints(testCDSName, func(update EndpointsUpdate, err error) {
 		endpointsUpdateCh.Send(endpointsUpdateErr{u: update, err: err})
 	})
+	if _, err := v2Client.addWatches[edsURL].Receive(); err != nil {
+		t.Fatalf("want new watch to start, got error %v", err)
+	}
 
 	wantUpdate := EndpointsUpdate{Localities: []Locality{testLocalities[0]}}
 	v2Client.r.newEDSUpdate(map[string]EndpointsUpdate{
@@ -237,6 +252,9 @@ func (s) TestEndpointsWatchAfterCache(t *testing.T) {
 	c.WatchEndpoints(testCDSName, func(update EndpointsUpdate, err error) {
 		endpointsUpdateCh2.Send(endpointsUpdateErr{u: update, err: err})
 	})
+	if n, err := v2Client.addWatches[edsURL].Receive(); err == nil {
+		t.Fatalf("want no new watch to start (recv timeout), got resource name: %v error %v", n, err)
+	}
 
 	// New watch should receives the update.
 	if u, err := endpointsUpdateCh2.Receive(); err != nil || !cmp.Equal(u, endpointsUpdateErr{wantUpdate, nil}, cmp.AllowUnexported(endpointsUpdateErr{})) {
@@ -268,12 +286,15 @@ func (s) TestEndpointsWatchExpiryTimer(t *testing.T) {
 	}
 	defer c.Close()
 
-	<-v2ClientCh
+	v2Client := <-v2ClientCh
 
 	endpointsUpdateCh := testutils.NewChannel()
 	c.WatchEndpoints(testCDSName, func(update EndpointsUpdate, err error) {
 		endpointsUpdateCh.Send(endpointsUpdateErr{u: update, err: err})
 	})
+	if _, err := v2Client.addWatches[edsURL].Receive(); err != nil {
+		t.Fatalf("want new watch to start, got error %v", err)
+	}
 
 	u, err := endpointsUpdateCh.TimedReceive(defaultWatchExpiryTimeout * 2)
 	if err != nil {

--- a/xds/internal/client/client_watchers_lds_test.go
+++ b/xds/internal/client/client_watchers_lds_test.go
@@ -49,6 +49,9 @@ func (s) TestLDSWatch(t *testing.T) {
 	cancelWatch := c.watchLDS(testLDSName, func(update ldsUpdate, err error) {
 		ldsUpdateCh.Send(ldsUpdateErr{u: update, err: err})
 	})
+	if _, err := v2Client.addWatches[ldsURL].Receive(); err != nil {
+		t.Fatalf("want new watch to start, got error %v", err)
+	}
 
 	wantUpdate := ldsUpdate{routeName: testRDSName}
 	v2Client.r.newLDSUpdate(map[string]ldsUpdate{
@@ -105,6 +108,9 @@ func (s) TestLDSTwoWatchSameResourceName(t *testing.T) {
 		cancelLastWatch = c.watchLDS(testLDSName, func(update ldsUpdate, err error) {
 			ldsUpdateCh.Send(ldsUpdateErr{u: update, err: err})
 		})
+		if _, err := v2Client.addWatches[ldsURL].Receive(); i == 0 && err != nil {
+			t.Fatalf("want new watch to start, got error %v", err)
+		}
 	}
 
 	wantUpdate := ldsUpdate{routeName: testRDSName}
@@ -159,6 +165,9 @@ func (s) TestLDSThreeWatchDifferentResourceName(t *testing.T) {
 		c.watchLDS(testLDSName+"1", func(update ldsUpdate, err error) {
 			ldsUpdateCh.Send(ldsUpdateErr{u: update, err: err})
 		})
+		if _, err := v2Client.addWatches[ldsURL].Receive(); i == 0 && err != nil {
+			t.Fatalf("want new watch to start, got error %v", err)
+		}
 	}
 
 	// Third watch for a different name.
@@ -166,6 +175,9 @@ func (s) TestLDSThreeWatchDifferentResourceName(t *testing.T) {
 	c.watchLDS(testLDSName+"2", func(update ldsUpdate, err error) {
 		ldsUpdateCh2.Send(ldsUpdateErr{u: update, err: err})
 	})
+	if _, err := v2Client.addWatches[ldsURL].Receive(); err != nil {
+		t.Fatalf("want new watch to start, got error %v", err)
+	}
 
 	wantUpdate1 := ldsUpdate{routeName: testRDSName + "1"}
 	wantUpdate2 := ldsUpdate{routeName: testRDSName + "2"}
@@ -203,6 +215,9 @@ func (s) TestLDSWatchAfterCache(t *testing.T) {
 	c.watchLDS(testLDSName, func(update ldsUpdate, err error) {
 		ldsUpdateCh.Send(ldsUpdateErr{u: update, err: err})
 	})
+	if _, err := v2Client.addWatches[ldsURL].Receive(); err != nil {
+		t.Fatalf("want new watch to start, got error %v", err)
+	}
 
 	wantUpdate := ldsUpdate{routeName: testRDSName}
 	v2Client.r.newLDSUpdate(map[string]ldsUpdate{
@@ -218,6 +233,9 @@ func (s) TestLDSWatchAfterCache(t *testing.T) {
 	c.watchLDS(testLDSName, func(update ldsUpdate, err error) {
 		ldsUpdateCh2.Send(ldsUpdateErr{u: update, err: err})
 	})
+	if n, err := v2Client.addWatches[ldsURL].Receive(); err == nil {
+		t.Fatalf("want no new watch to start (recv timeout), got resource name: %v error %v", n, err)
+	}
 
 	// New watch should receives the update.
 	if u, err := ldsUpdateCh2.Receive(); err != nil || u != (ldsUpdateErr{wantUpdate, nil}) {
@@ -252,11 +270,17 @@ func (s) TestLDSResourceRemoved(t *testing.T) {
 	c.watchLDS(testLDSName+"1", func(update ldsUpdate, err error) {
 		ldsUpdateCh1.Send(ldsUpdateErr{u: update, err: err})
 	})
+	if _, err := v2Client.addWatches[ldsURL].Receive(); err != nil {
+		t.Fatalf("want new watch to start, got error %v", err)
+	}
 	// Another watch for a different name.
 	ldsUpdateCh2 := testutils.NewChannel()
 	c.watchLDS(testLDSName+"2", func(update ldsUpdate, err error) {
 		ldsUpdateCh2.Send(ldsUpdateErr{u: update, err: err})
 	})
+	if _, err := v2Client.addWatches[ldsURL].Receive(); err != nil {
+		t.Fatalf("want new watch to start, got error %v", err)
+	}
 
 	wantUpdate1 := ldsUpdate{routeName: testEDSName + "1"}
 	wantUpdate2 := ldsUpdate{routeName: testEDSName + "2"}

--- a/xds/internal/client/client_watchers_lds_test.go
+++ b/xds/internal/client/client_watchers_lds_test.go
@@ -31,7 +31,7 @@ type ldsUpdateErr struct {
 
 // TestLDSWatch covers the cases:
 // - an update is received after a watch()
-// - an update for another resource name (which doesn't trigger callback)
+// - an update for another resource name
 // - an upate is received after cancel()
 func (s) TestLDSWatch(t *testing.T) {
 	v2ClientCh, cleanup := overrideNewXDSV2Client()
@@ -59,12 +59,13 @@ func (s) TestLDSWatch(t *testing.T) {
 		t.Errorf("unexpected ldsUpdate: %v, error receiving from channel: %v", u, err)
 	}
 
-	// Another update for a different resource name.
+	// Another update, with an extra resource for a different resource name.
 	v2Client.r.newLDSUpdate(map[string]ldsUpdate{
+		testLDSName:  wantUpdate,
 		"randomName": {},
 	})
 
-	if u, err := ldsUpdateCh.TimedReceive(chanRecvTimeout); err != testutils.ErrRecvTimeout {
+	if u, err := ldsUpdateCh.Receive(); err != nil || u != (ldsUpdateErr{wantUpdate, nil}) {
 		t.Errorf("unexpected ldsUpdate: %v, %v, want channel recv timeout", u, err)
 	}
 
@@ -226,5 +227,79 @@ func (s) TestLDSWatchAfterCache(t *testing.T) {
 	// Old watch should see nothing.
 	if u, err := ldsUpdateCh.TimedReceive(chanRecvTimeout); err != testutils.ErrRecvTimeout {
 		t.Errorf("unexpected ldsUpdate: %v, %v, want channel recv timeout", u, err)
+	}
+}
+
+// TestLDSResourceRemoved covers the cases:
+// - an update is received after a watch()
+// - another update is received, with one resource removed
+//   - this should trigger callback with resource removed error
+// - one more update without the removed resource
+//   - the callback (above) shouldn't receive any update
+func (s) TestLDSResourceRemoved(t *testing.T) {
+	v2ClientCh, cleanup := overrideNewXDSV2Client()
+	defer cleanup()
+
+	c, err := New(clientOpts(testXDSServer))
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+	defer c.Close()
+
+	v2Client := <-v2ClientCh
+
+	ldsUpdateCh1 := testutils.NewChannel()
+	c.watchLDS(testLDSName+"1", func(update ldsUpdate, err error) {
+		ldsUpdateCh1.Send(ldsUpdateErr{u: update, err: err})
+	})
+	// Another watch for a different name.
+	ldsUpdateCh2 := testutils.NewChannel()
+	c.watchLDS(testLDSName+"2", func(update ldsUpdate, err error) {
+		ldsUpdateCh2.Send(ldsUpdateErr{u: update, err: err})
+	})
+
+	wantUpdate1 := ldsUpdate{routeName: testEDSName + "1"}
+	wantUpdate2 := ldsUpdate{routeName: testEDSName + "2"}
+	v2Client.r.newLDSUpdate(map[string]ldsUpdate{
+		testLDSName + "1": wantUpdate1,
+		testLDSName + "2": wantUpdate2,
+	})
+
+	if u, err := ldsUpdateCh1.Receive(); err != nil || u != (ldsUpdateErr{wantUpdate1, nil}) {
+		t.Errorf("unexpected ldsUpdate: %v, error receiving from channel: %v", u, err)
+	}
+
+	if u, err := ldsUpdateCh2.Receive(); err != nil || u != (ldsUpdateErr{wantUpdate2, nil}) {
+		t.Errorf("unexpected ldsUpdate: %v, error receiving from channel: %v", u, err)
+	}
+
+	// Send another update to remove resource 1.
+	v2Client.r.newLDSUpdate(map[string]ldsUpdate{
+		testLDSName + "2": wantUpdate2,
+	})
+
+	// watcher 1 should get an error.
+	if u, err := ldsUpdateCh1.Receive(); err != nil || ErrType(u.(ldsUpdateErr).err) != ErrorTypeResourceNotFound {
+		t.Errorf("unexpected ldsUpdate: %v, error receiving from channel: %v, want update with error resource not found", u, err)
+	}
+
+	// watcher 2 should get the same update again.
+	if u, err := ldsUpdateCh2.Receive(); err != nil || u != (ldsUpdateErr{wantUpdate2, nil}) {
+		t.Errorf("unexpected ldsUpdate: %v, error receiving from channel: %v", u, err)
+	}
+
+	// Send one more update without resource 1.
+	v2Client.r.newLDSUpdate(map[string]ldsUpdate{
+		testLDSName + "2": wantUpdate2,
+	})
+
+	// watcher 1 should get an error.
+	if u, err := ldsUpdateCh1.Receive(); err != testutils.ErrRecvTimeout {
+		t.Errorf("unexpected ldsUpdate: %v, want receiving from channel timeout", u)
+	}
+
+	// watcher 2 should get the same update again.
+	if u, err := ldsUpdateCh2.Receive(); err != nil || u != (ldsUpdateErr{wantUpdate2, nil}) {
+		t.Errorf("unexpected ldsUpdate: %v, error receiving from channel: %v", u, err)
 	}
 }

--- a/xds/internal/client/client_watchers_rds_test.go
+++ b/xds/internal/client/client_watchers_rds_test.go
@@ -50,6 +50,9 @@ func (s) TestRDSWatch(t *testing.T) {
 	cancelWatch := c.watchRDS(testRDSName, func(update rdsUpdate, err error) {
 		rdsUpdateCh.Send(rdsUpdateErr{u: update, err: err})
 	})
+	if _, err := v2Client.addWatches[rdsURL].Receive(); err != nil {
+		t.Fatalf("want new watch to start, got error %v", err)
+	}
 
 	wantUpdate := rdsUpdate{weightedCluster: map[string]uint32{testCDSName: 1}}
 	v2Client.r.newRDSUpdate(map[string]rdsUpdate{
@@ -105,6 +108,9 @@ func (s) TestRDSTwoWatchSameResourceName(t *testing.T) {
 		cancelLastWatch = c.watchRDS(testRDSName, func(update rdsUpdate, err error) {
 			rdsUpdateCh.Send(rdsUpdateErr{u: update, err: err})
 		})
+		if _, err := v2Client.addWatches[rdsURL].Receive(); i == 0 && err != nil {
+			t.Fatalf("want new watch to start, got error %v", err)
+		}
 	}
 
 	wantUpdate := rdsUpdate{weightedCluster: map[string]uint32{testCDSName: 1}}
@@ -159,6 +165,9 @@ func (s) TestRDSThreeWatchDifferentResourceName(t *testing.T) {
 		c.watchRDS(testRDSName+"1", func(update rdsUpdate, err error) {
 			rdsUpdateCh.Send(rdsUpdateErr{u: update, err: err})
 		})
+		if _, err := v2Client.addWatches[rdsURL].Receive(); i == 0 && err != nil {
+			t.Fatalf("want new watch to start, got error %v", err)
+		}
 	}
 
 	// Third watch for a different name.
@@ -166,6 +175,9 @@ func (s) TestRDSThreeWatchDifferentResourceName(t *testing.T) {
 	c.watchRDS(testRDSName+"2", func(update rdsUpdate, err error) {
 		rdsUpdateCh2.Send(rdsUpdateErr{u: update, err: err})
 	})
+	if _, err := v2Client.addWatches[rdsURL].Receive(); err != nil {
+		t.Fatalf("want new watch to start, got error %v", err)
+	}
 
 	wantUpdate1 := rdsUpdate{weightedCluster: map[string]uint32{testCDSName + "1": 1}}
 	wantUpdate2 := rdsUpdate{weightedCluster: map[string]uint32{testCDSName + "2": 1}}
@@ -203,6 +215,9 @@ func (s) TestRDSWatchAfterCache(t *testing.T) {
 	c.watchRDS(testRDSName, func(update rdsUpdate, err error) {
 		rdsUpdateCh.Send(rdsUpdateErr{u: update, err: err})
 	})
+	if _, err := v2Client.addWatches[rdsURL].Receive(); err != nil {
+		t.Fatalf("want new watch to start, got error %v", err)
+	}
 
 	wantUpdate := rdsUpdate{weightedCluster: map[string]uint32{testCDSName: 1}}
 	v2Client.r.newRDSUpdate(map[string]rdsUpdate{
@@ -218,6 +233,9 @@ func (s) TestRDSWatchAfterCache(t *testing.T) {
 	c.watchRDS(testRDSName, func(update rdsUpdate, err error) {
 		rdsUpdateCh2.Send(rdsUpdateErr{u: update, err: err})
 	})
+	if n, err := v2Client.addWatches[rdsURL].Receive(); err == nil {
+		t.Fatalf("want no new watch to start (recv timeout), got resource name: %v error %v", n, err)
+	}
 
 	// New watch should receives the update.
 	if u, err := rdsUpdateCh2.Receive(); err != nil || !cmp.Equal(u, rdsUpdateErr{wantUpdate, nil}, cmp.AllowUnexported(rdsUpdate{}, rdsUpdateErr{})) {

--- a/xds/internal/client/client_watchers_service_test.go
+++ b/xds/internal/client/client_watchers_service_test.go
@@ -57,11 +57,15 @@ func (s) TestServiceWatch(t *testing.T) {
 
 	wantUpdate := ServiceUpdate{WeightedCluster: map[string]uint32{testCDSName: 1}}
 
-	<-v2Client.addWatches[ldsURL]
+	if _, err := v2Client.addWatches[ldsURL].Receive(); err != nil {
+		t.Fatalf("want new watch to start, got error %v", err)
+	}
 	v2Client.r.newLDSUpdate(map[string]ldsUpdate{
 		testLDSName: {routeName: testRDSName},
 	})
-	<-v2Client.addWatches[rdsURL]
+	if _, err := v2Client.addWatches[rdsURL].Receive(); err != nil {
+		t.Fatalf("want new watch to start, got error %v", err)
+	}
 	v2Client.r.newRDSUpdate(map[string]rdsUpdate{
 		testRDSName: {weightedCluster: map[string]uint32{testCDSName: 1}},
 	})
@@ -93,11 +97,15 @@ func (s) TestServiceWatchLDSUpdate(t *testing.T) {
 
 	wantUpdate := ServiceUpdate{WeightedCluster: map[string]uint32{testCDSName: 1}}
 
-	<-v2Client.addWatches[ldsURL]
+	if _, err := v2Client.addWatches[ldsURL].Receive(); err != nil {
+		t.Fatalf("want new watch to start, got error %v", err)
+	}
 	v2Client.r.newLDSUpdate(map[string]ldsUpdate{
 		testLDSName: {routeName: testRDSName},
 	})
-	<-v2Client.addWatches[rdsURL]
+	if _, err := v2Client.addWatches[rdsURL].Receive(); err != nil {
+		t.Fatalf("want new watch to start, got error %v", err)
+	}
 	v2Client.r.newRDSUpdate(map[string]rdsUpdate{
 		testRDSName: {weightedCluster: map[string]uint32{testCDSName: 1}},
 	})
@@ -110,7 +118,9 @@ func (s) TestServiceWatchLDSUpdate(t *testing.T) {
 	v2Client.r.newLDSUpdate(map[string]ldsUpdate{
 		testLDSName: {routeName: testRDSName + "2"},
 	})
-	<-v2Client.addWatches[rdsURL]
+	if _, err := v2Client.addWatches[rdsURL].Receive(); err != nil {
+		t.Fatalf("want new watch to start, got error %v", err)
+	}
 
 	// Another update for the old name.
 	v2Client.r.newRDSUpdate(map[string]rdsUpdate{
@@ -154,11 +164,15 @@ func (s) TestServiceWatchSecond(t *testing.T) {
 
 	wantUpdate := ServiceUpdate{WeightedCluster: map[string]uint32{testCDSName: 1}}
 
-	<-v2Client.addWatches[ldsURL]
+	if _, err := v2Client.addWatches[ldsURL].Receive(); err != nil {
+		t.Fatalf("want new watch to start, got error %v", err)
+	}
 	v2Client.r.newLDSUpdate(map[string]ldsUpdate{
 		testLDSName: {routeName: testRDSName},
 	})
-	<-v2Client.addWatches[rdsURL]
+	if _, err := v2Client.addWatches[rdsURL].Receive(); err != nil {
+		t.Fatalf("want new watch to start, got error %v", err)
+	}
 	v2Client.r.newRDSUpdate(map[string]rdsUpdate{
 		testRDSName: {weightedCluster: map[string]uint32{testCDSName: 1}},
 	})
@@ -361,11 +375,15 @@ func (s) TestServiceNotCancelRDSOnSameLDSUpdate(t *testing.T) {
 
 	wantUpdate := ServiceUpdate{WeightedCluster: map[string]uint32{testCDSName: 1}}
 
-	<-v2Client.addWatches[ldsURL]
+	if _, err := v2Client.addWatches[ldsURL].Receive(); err != nil {
+		t.Fatalf("want new watch to start, got error %v", err)
+	}
 	v2Client.r.newLDSUpdate(map[string]ldsUpdate{
 		testLDSName: {routeName: testRDSName},
 	})
-	<-v2Client.addWatches[rdsURL]
+	if _, err := v2Client.addWatches[rdsURL].Receive(); err != nil {
+		t.Fatalf("want new watch to start, got error %v", err)
+	}
 	v2Client.r.newRDSUpdate(map[string]rdsUpdate{
 		testRDSName: {weightedCluster: map[string]uint32{testCDSName: 1}},
 	})
@@ -378,9 +396,89 @@ func (s) TestServiceNotCancelRDSOnSameLDSUpdate(t *testing.T) {
 	v2Client.r.newLDSUpdate(map[string]ldsUpdate{
 		testLDSName: {routeName: testRDSName},
 	})
-	select {
-	case <-v2Client.removeWatches[rdsURL]:
-		t.Fatalf("unexpected rds watch cancel")
-	case <-time.After(time.Second):
+	if v, err := v2Client.removeWatches[rdsURL].Receive(); err == nil {
+		t.Fatalf("unexpected rds watch cancel: %v", v)
+	}
+}
+
+// TestServiceResourceRemoved covers the cases:
+// - an update is received after a watch()
+// - another update is received, with one resource removed
+//   - this should trigger callback with resource removed error
+// - one more update without the removed resource
+//   - the callback (above) shouldn't receive any update
+func (s) TestServiceResourceRemoved(t *testing.T) {
+	v2ClientCh, cleanup := overrideNewXDSV2Client()
+	defer cleanup()
+
+	c, err := New(clientOpts(testXDSServer))
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+	defer c.Close()
+
+	v2Client := <-v2ClientCh
+
+	serviceUpdateCh := testutils.NewChannel()
+	c.WatchService(testLDSName, func(update ServiceUpdate, err error) {
+		serviceUpdateCh.Send(serviceUpdateErr{u: update, err: err})
+	})
+
+	wantUpdate := ServiceUpdate{WeightedCluster: map[string]uint32{testCDSName: 1}}
+
+	if _, err := v2Client.addWatches[ldsURL].Receive(); err != nil {
+		t.Fatalf("want new watch to start, got error %v", err)
+	}
+	v2Client.r.newLDSUpdate(map[string]ldsUpdate{
+		testLDSName: {routeName: testRDSName},
+	})
+	if _, err := v2Client.addWatches[rdsURL].Receive(); err != nil {
+		t.Fatalf("want new watch to start, got error %v", err)
+	}
+	v2Client.r.newRDSUpdate(map[string]rdsUpdate{
+		testRDSName: {weightedCluster: map[string]uint32{testCDSName: 1}},
+	})
+
+	if u, err := serviceUpdateCh.Receive(); err != nil || !cmp.Equal(u, serviceUpdateErr{wantUpdate, nil}, cmp.AllowUnexported(serviceUpdateErr{})) {
+		t.Errorf("unexpected serviceUpdate: %v, error receiving from channel: %v", u, err)
+	}
+
+	// Remove LDS resource, should cancel the RDS watch, and trigger resource
+	// removed error.
+	v2Client.r.newLDSUpdate(map[string]ldsUpdate{})
+	if _, err := v2Client.removeWatches[rdsURL].Receive(); err != nil {
+		t.Fatalf("want watch to be canceled, got error %v", err)
+	}
+	if u, err := serviceUpdateCh.Receive(); err != nil || ErrType(u.(serviceUpdateErr).err) != ErrorTypeResourceNotFound {
+		t.Errorf("unexpected serviceUpdate: %v, error receiving from channel: %v, want update with error resource not found", u, err)
+	}
+
+	// Send RDS update for the removed LDS resource, expect no updates to
+	// callback, because RDS should be canceled.
+	v2Client.r.newRDSUpdate(map[string]rdsUpdate{
+		testRDSName: {weightedCluster: map[string]uint32{testCDSName + "new": 1}},
+	})
+	if u, err := serviceUpdateCh.Receive(); err != testutils.ErrRecvTimeout {
+		t.Errorf("unexpected serviceUpdate: %v, want receiving from channel timeout", u)
+	}
+
+	// Add LDS resource, but not RDS resource, should
+	//  - start a new RDS watch
+	//  - timeout on service channel, because RDS cache was cleared
+	v2Client.r.newLDSUpdate(map[string]ldsUpdate{
+		testLDSName: {routeName: testRDSName},
+	})
+	if _, err := v2Client.addWatches[rdsURL].Receive(); err != nil {
+		t.Fatalf("want new watch to start, got error %v", err)
+	}
+	if u, err := serviceUpdateCh.Receive(); err != testutils.ErrRecvTimeout {
+		t.Errorf("unexpected serviceUpdate: %v, want receiving from channel timeout", u)
+	}
+
+	v2Client.r.newRDSUpdate(map[string]rdsUpdate{
+		testRDSName: {weightedCluster: map[string]uint32{testCDSName + "new2": 1}},
+	})
+	if u, err := serviceUpdateCh.Receive(); err != nil || !cmp.Equal(u, serviceUpdateErr{ServiceUpdate{WeightedCluster: map[string]uint32{testCDSName + "new2": 1}}, nil}, cmp.AllowUnexported(serviceUpdateErr{})) {
+		t.Errorf("unexpected serviceUpdate: %v, error receiving from channel: %v", u, err)
 	}
 }


### PR DESCRIPTION
- xds_client
  - send resource-not-found error when a resource is removed for LDS or CDS
  - handle LDS resource-not-found to cancel RDS watch

- test update because it was expecting no update when resource is removed
- test cleanup to apply timeout to channels