### PR TITLE
advancedtls: Add system default CAs to config function

### DIFF
--- a/security/advancedtls/advancedtls.go
+++ b/security/advancedtls/advancedtls.go
@@ -187,7 +187,7 @@ func (o *ClientOptions) config() (*tls.Config, error) {
 			"client needs to provide custom verification mechanism if choose to skip default verification")
 	}
 	rootCAs := o.RootCACerts
-	if o.VType < SkipVerification && o.RootCACerts == nil && o.GetRootCAs == nil {
+	if o.VType != SkipVerification && o.RootCACerts == nil && o.GetRootCAs == nil {
 		// Set rootCAs to system default.
 		systemRootCAs, err := x509.SystemCertPool()
 		if err != nil {
@@ -218,7 +218,7 @@ func (o *ServerOptions) config() (*tls.Config, error) {
 			"server needs to provide custom verification mechanism if choose to skip default verification, but require client certificate(s)")
 	}
 	clientCAs := o.RootCACerts
-	if o.VType < SkipVerification && o.RootCACerts == nil && o.GetRootCAs == nil && o.RequireClientCert {
+	if o.VType != SkipVerification && o.RootCACerts == nil && o.GetRootCAs == nil && o.RequireClientCert {
 		// Set clientCAs to system default.
 		systemRootCAs, err := x509.SystemCertPool()
 		if err != nil {

--- a/security/advancedtls/advancedtls.go
+++ b/security/advancedtls/advancedtls.go
@@ -82,10 +82,7 @@ type GetRootCAsResults struct {
 // trust certificates.
 // It is used by both ClientOptions and ServerOptions.
 // If users want to use default verification, but did not provide a valid
-// RootCertificateOptions:
-//     Assign the system default certificate to RootCAs on the client side;
-//     assign the system default certificate to ClientCAs on the server side
-//	   if the server needs trust certificate.
+// RootCertificateOptions, we use the system default trust certificates.
 type RootCertificateOptions struct {
 	// If field RootCACerts is set, field GetRootCAs will be ignored. RootCACerts
 	// will be used every time when verifying the peer certificates, without
@@ -191,7 +188,7 @@ func (o *ClientOptions) config() (*tls.Config, error) {
 	}
 	rootCAs := o.RootCACerts
 	if o.VType < SkipVerification && o.RootCACerts == nil && o.GetRootCAs == nil {
-		// Set rootCAs to system default
+		// Set rootCAs to system default.
 		systemRootCAs, err := x509.SystemCertPool()
 		if err != nil {
 			return nil, err
@@ -222,7 +219,7 @@ func (o *ServerOptions) config() (*tls.Config, error) {
 	}
 	clientCAs := o.RootCACerts
 	if o.VType < SkipVerification && o.RootCACerts == nil && o.GetRootCAs == nil && o.RequireClientCert {
-		// Set clientCAs to system default
+		// Set clientCAs to system default.
 		systemRootCAs, err := x509.SystemCertPool()
 		if err != nil {
 			return nil, err

--- a/security/advancedtls/advancedtls.go
+++ b/security/advancedtls/advancedtls.go
@@ -190,7 +190,7 @@ func (o *ClientOptions) config() (*tls.Config, error) {
 			"client needs to provide custom verification mechanism if choose to skip default verification")
 	}
 	rootCAs := o.RootCACerts
-	if o.VType > SkipVerification && o.RootCACerts == nil && o.GetRootCAs == nil {
+	if o.VType < SkipVerification && o.RootCACerts == nil && o.GetRootCAs == nil {
 		// Set rootCAs to system default
 		systemRootCAs, err := x509.SystemCertPool()
 		if err != nil {
@@ -221,7 +221,7 @@ func (o *ServerOptions) config() (*tls.Config, error) {
 			"server needs to provide custom verification mechanism if choose to skip default verification, but require client certificate(s)")
 	}
 	clientCAs := o.RootCACerts
-	if o.VType > SkipVerification && o.RootCACerts == nil && o.GetRootCAs == nil && o.RequireClientCert {
+	if o.VType < SkipVerification && o.RootCACerts == nil && o.GetRootCAs == nil && o.RequireClientCert {
 		// Set clientCAs to system default
 		systemRootCAs, err := x509.SystemCertPool()
 		if err != nil {

--- a/security/advancedtls/advancedtls_test.go
+++ b/security/advancedtls/advancedtls_test.go
@@ -136,6 +136,19 @@ func TestClientServerHandshake(t *testing.T) {
 			serverCert:       []tls.Certificate{serverPeerCert},
 			serverVType:      CertAndHostVerification,
 		},
+		// Client: nil setting
+		// Server: only set serverCert with mutual TLS on
+		// Expected Behavior: server side failure and client handshake failure
+		// Reason: 
+		{
+			desc:                       "Client uses default RootCAs; server uses default ClientCAs",
+			clientVType:                CertVerification,
+			clientExpectHandshakeError: true,
+			serverMutualTLS:            true,
+			serverCert:                 []tls.Certificate{serverPeerCert},
+			serverVType:                CertAndHostVerification,
+			serverExpectError:          true,
+		},
 		// Client: only set clientRoot
 		// Server: only set serverCert with mutual TLS off
 		// Expected Behavior: server side failure and client handshake failure
@@ -412,9 +425,9 @@ func TestClientServerHandshake(t *testing.T) {
 				VerifyPeer:        test.serverVerifyFunc,
 				VType:             test.serverVType,
 			}
-			servertConf, _ := serverOptions.config()
+			servertConfig, _ := serverOptions.config()
 			if serverOptions.VType < SkipVerification && serverOptions.RootCACerts == nil &&
-				serverOptions.GetRootCAs == nil && serverOptions.RequireClientCert && servertConf.ClientCAs == nil {
+				serverOptions.GetRootCAs == nil && serverOptions.RequireClientCert && servertConfig.ClientCAs == nil {
 				t.Fatalf("Failed to assign default certificate on the server side.")
 			}
 			go func(done chan credentials.AuthInfo, lis net.Listener, serverOptions *ServerOptions) {
@@ -455,9 +468,9 @@ func TestClientServerHandshake(t *testing.T) {
 				},
 				VType: test.clientVType,
 			}
-			clientConf, _ := clientOptions.config()
+			clientConfig, _ := clientOptions.config()
 			if clientOptions.VType < SkipVerification && clientOptions.RootCACerts == nil &&
-				clientOptions.GetRootCAs == nil && clientConf.RootCAs == nil {
+				clientOptions.GetRootCAs == nil && clientConfig.RootCAs == nil {
 				t.Fatalf("Failed to assign default certificate on the client side.")
 			}
 			clientTLS, newClientErr := NewClientCreds(clientOptions)

--- a/security/advancedtls/advancedtls_test.go
+++ b/security/advancedtls/advancedtls_test.go
@@ -412,6 +412,11 @@ func TestClientServerHandshake(t *testing.T) {
 				VerifyPeer:        test.serverVerifyFunc,
 				VType:             test.serverVType,
 			}
+			servertConf, _ := serverOptions.config()
+			if serverOptions.VType < SkipVerification && serverOptions.RootCACerts == nil &&
+				serverOptions.GetRootCAs == nil && serverOptions.RequireClientCert && servertConf.ClientCAs == nil {
+				t.Fatalf("Failed to assign default certificate on the server side.")
+			}
 			go func(done chan credentials.AuthInfo, lis net.Listener, serverOptions *ServerOptions) {
 				serverRawConn, err := lis.Accept()
 				if err != nil {
@@ -449,6 +454,11 @@ func TestClientServerHandshake(t *testing.T) {
 					GetRootCAs:  test.clientGetRoot,
 				},
 				VType: test.clientVType,
+			}
+			clientConf, _ := clientOptions.config()
+			if clientOptions.VType < SkipVerification && clientOptions.RootCACerts == nil &&
+				clientOptions.GetRootCAs == nil && clientConf.RootCAs == nil {
+				t.Fatalf("Failed to assign default certificate on the client side.")
 			}
 			clientTLS, newClientErr := NewClientCreds(clientOptions)
 			if newClientErr != nil && test.clientExpectCreateError {

--- a/security/advancedtls/advancedtls_test.go
+++ b/security/advancedtls/advancedtls_test.go
@@ -659,8 +659,8 @@ func TestOptionsConfig(t *testing.T) {
 			}
 			// Verify that the system-provided certificates would be used
 			// when no verification method was set in serverOptions.
-			if serverOptions.VType < SkipVerification && serverOptions.RootCACerts == nil &&
-				serverOptions.GetRootCAs == nil && serverOptions.RequireClientCert && serverConfig.ClientCAs == nil {
+			if serverOptions.RootCACerts == nil && serverOptions.GetRootCAs == nil &&
+				serverOptions.RequireClientCert && serverConfig.ClientCAs == nil {
 				t.Fatalf("Failed to assign system-provided certificates on the server side.")
 			}
 			clientOptions := &ClientOptions{
@@ -672,8 +672,8 @@ func TestOptionsConfig(t *testing.T) {
 			}
 			// Verify that the system-provided certificates would be used
 			// when no verification method was set in clientOptions.
-			if clientOptions.VType < SkipVerification && clientOptions.RootCACerts == nil &&
-				clientOptions.GetRootCAs == nil && clientConfig.RootCAs == nil {
+			if clientOptions.RootCACerts == nil && clientOptions.GetRootCAs == nil &&
+				clientConfig.RootCAs == nil {
 				t.Fatalf("Failed to assign system-provided certificates on the client side.")
 			}
 		})

--- a/security/advancedtls/advancedtls_test.go
+++ b/security/advancedtls/advancedtls_test.go
@@ -139,7 +139,8 @@ func TestClientServerHandshake(t *testing.T) {
 		// Client: nil setting
 		// Server: only set serverCert with mutual TLS on
 		// Expected Behavior: server side failure and client handshake failure
-		// Reason: 
+		// Reason: We will use the system default certs, which doesn't trust server's identity,
+		// and hence causing the handshake failure
 		{
 			desc:                       "Client uses default RootCAs; server uses default ClientCAs",
 			clientVType:                CertVerification,

--- a/security/advancedtls/advancedtls_test.go
+++ b/security/advancedtls/advancedtls_test.go
@@ -628,7 +628,7 @@ func TestOptionsConfig(t *testing.T) {
 	serverPeerCert, err := tls.LoadX509KeyPair(testdata.Path("server_cert_1.pem"),
 		testdata.Path("server_key_1.pem"))
 	if err != nil {
-		t.Fatalf("server is unable to parse peer certificates, error: %v", err)
+		t.Fatalf("Server is unable to parse peer certificates. Error: %v", err)
 	}
 	tests := []struct {
 		desc            string
@@ -655,26 +655,26 @@ func TestOptionsConfig(t *testing.T) {
 			}
 			serverConfig, err := serverOptions.config()
 			if err != nil {
-				t.Fatalf("unable to generate serverConfig, error: %v", err)
+				t.Fatalf("Unable to generate serverConfig. Error: %v", err)
 			}
 			// Verify that the system-provided certificates would be used
 			// when no verification method was set in serverOptions.
 			if serverOptions.VType < SkipVerification && serverOptions.RootCACerts == nil &&
 				serverOptions.GetRootCAs == nil && serverOptions.RequireClientCert && serverConfig.ClientCAs == nil {
-				t.Fatalf("failed to assign system-provided certificates on the server side.")
+				t.Fatalf("Failed to assign system-provided certificates on the server side.")
 			}
 			clientOptions := &ClientOptions{
 				VType: test.clientVType,
 			}
 			clientConfig, err := clientOptions.config()
 			if err != nil {
-				t.Fatalf("unable to generate clientConfig, error: %v", err)
+				t.Fatalf("Unable to generate clientConfig. Error: %v", err)
 			}
 			// Verify that the system-provided certificates would be used
 			// when no verification method was set in clientOptions.
 			if clientOptions.VType < SkipVerification && clientOptions.RootCACerts == nil &&
 				clientOptions.GetRootCAs == nil && clientConfig.RootCAs == nil {
-				t.Fatalf("failed to assign system-provided certificates on the client side.")
+				t.Fatalf("Failed to assign system-provided certificates on the client side.")
 			}
 		})
 	}

--- a/security/advancedtls/advancedtls_test.go
+++ b/security/advancedtls/advancedtls_test.go
@@ -628,7 +628,7 @@ func TestOptionsConfig(t *testing.T) {
 	serverPeerCert, err := tls.LoadX509KeyPair(testdata.Path("server_cert_1.pem"),
 		testdata.Path("server_key_1.pem"))
 	if err != nil {
-		t.Fatalf("Server is unable to parse peer certificates, error: %v", err)
+		t.Fatalf("server is unable to parse peer certificates, error: %v", err)
 	}
 	tests := []struct {
 		desc            string
@@ -655,26 +655,26 @@ func TestOptionsConfig(t *testing.T) {
 			}
 			serverConfig, err := serverOptions.config()
 			if err != nil {
-				t.Fatalf("Unable to generate serverConfig, error: %v", err)
+				t.Fatalf("unable to generate serverConfig, error: %v", err)
 			}
 			// Verify that the system-provided certificates would be used
 			// when no verification method was set in serverOptions.
 			if serverOptions.VType < SkipVerification && serverOptions.RootCACerts == nil &&
 				serverOptions.GetRootCAs == nil && serverOptions.RequireClientCert && serverConfig.ClientCAs == nil {
-				t.Fatalf("Failed to assign system-provided certificates on the server side.")
+				t.Fatalf("failed to assign system-provided certificates on the server side.")
 			}
 			clientOptions := &ClientOptions{
 				VType: test.clientVType,
 			}
 			clientConfig, err := clientOptions.config()
 			if err != nil {
-				t.Fatalf("Unable to generate clientConfig, error: %v", err)
+				t.Fatalf("unable to generate clientConfig, error: %v", err)
 			}
 			// Verify that the system-provided certificates would be used
 			// when no verification method was set in clientOptions.
 			if clientOptions.VType < SkipVerification && clientOptions.RootCACerts == nil &&
 				clientOptions.GetRootCAs == nil && clientConfig.RootCAs == nil {
-				t.Fatalf("Failed to assign system-provided certificates on the client side.")
+				t.Fatalf("failed to assign system-provided certificates on the client side.")
 			}
 		})
 	}


### PR DESCRIPTION
This PR does the following thing:

If users set `SkipVerification` to `False` yet did not provide with a valid `RootCertificateOptions`, a system default certificate `x509.SystemCertPool()` will be assigned in the `config()` function.

After this change:

If users choose to use default verification, clients are guaranteed to have a valid `RootCAs` certificate and servers are guaranteed to have a valid `ClientCAs` certificate.

@ZhenLian 