### PR TITLE
doc: fix references to status methods

### DIFF
--- a/Documentation/rpc-errors.md
+++ b/Documentation/rpc-errors.md
@@ -61,8 +61,8 @@ exit status 1
 [status]:       https://godoc.org/google.golang.org/grpc/status#Status
 [new-status]:   https://godoc.org/google.golang.org/grpc/status#New
 [code]:         https://godoc.org/google.golang.org/grpc/codes#Code
-[with-details]: https://godoc.org/google.golang.org/grpc/status#Status.WithDetails
-[details]:      https://godoc.org/google.golang.org/grpc/status#Status.Details
-[status-err]:   https://godoc.org/google.golang.org/grpc/status#Status.Err
+[with-details]: https://godoc.org/google.golang.org/grpc/internal/status#Status.WithDetails
+[details]:      https://godoc.org/google.golang.org/grpc/internal/status#Status.Details
+[status-err]:   https://godoc.org/google.golang.org/grpc/internal/status#Status.Err
 [status-error]: https://godoc.org/google.golang.org/grpc/status#Error
 [example]:      https://github.com/grpc/grpc-go/tree/master/examples/features/errors


### PR DESCRIPTION
These methods were moved into `internal/status` in https://github.com/grpc/grpc-go/pull/3432/files, so the doc links are outdated.