### PR TITLE
xds: use logging components

### DIFF
--- a/internal/grpclog/prefixLogger.go
+++ b/internal/grpclog/prefixLogger.go
@@ -22,6 +22,7 @@ package grpclog
 //
 // Logging method on a nil logs without any prefix.
 type PrefixLogger struct {
+	logger LoggerV2
 	prefix string
 }
 
@@ -30,6 +31,8 @@ func (pl *PrefixLogger) Infof(format string, args ...interface{}) {
 	if pl != nil {
 		// Handle nil, so the tests can pass in a nil logger.
 		format = pl.prefix + format
+		pl.logger.Infof(format, args...)
+		return
 	}
 	Logger.Infof(format, args...)
 }
@@ -38,6 +41,8 @@ func (pl *PrefixLogger) Infof(format string, args ...interface{}) {
 func (pl *PrefixLogger) Warningf(format string, args ...interface{}) {
 	if pl != nil {
 		format = pl.prefix + format
+		pl.logger.Warningf(format, args...)
+		return
 	}
 	Logger.Warningf(format, args...)
 }
@@ -46,6 +51,8 @@ func (pl *PrefixLogger) Warningf(format string, args ...interface{}) {
 func (pl *PrefixLogger) Errorf(format string, args ...interface{}) {
 	if pl != nil {
 		format = pl.prefix + format
+		pl.logger.Errorf(format, args...)
+		return
 	}
 	Logger.Errorf(format, args...)
 }
@@ -58,6 +65,6 @@ func (pl *PrefixLogger) Debugf(format string, args ...interface{}) {
 }
 
 // NewPrefixLogger creates a prefix logger with the given prefix.
-func NewPrefixLogger(prefix string) *PrefixLogger {
-	return &PrefixLogger{prefix: prefix}
+func NewPrefixLogger(logger LoggerV2, prefix string) *PrefixLogger {
+	return &PrefixLogger{logger: logger, prefix: prefix}
 }

--- a/internal/grpclog/prefixLogger.go
+++ b/internal/grpclog/prefixLogger.go
@@ -18,11 +18,15 @@
 
 package grpclog
 
+import (
+	"fmt"
+)
+
 // PrefixLogger does logging with a prefix.
 //
 // Logging method on a nil logs without any prefix.
 type PrefixLogger struct {
-	logger LoggerV2
+	logger DepthLoggerV2
 	prefix string
 }
 
@@ -31,40 +35,47 @@ func (pl *PrefixLogger) Infof(format string, args ...interface{}) {
 	if pl != nil {
 		// Handle nil, so the tests can pass in a nil logger.
 		format = pl.prefix + format
-		pl.logger.Infof(format, args...)
+		pl.logger.InfoDepth(1, fmt.Sprintf(format, args...))
 		return
 	}
-	Logger.Infof(format, args...)
+	InfoDepth(1, fmt.Sprintf(format, args...))
 }
 
 // Warningf does warning logging.
 func (pl *PrefixLogger) Warningf(format string, args ...interface{}) {
 	if pl != nil {
 		format = pl.prefix + format
-		pl.logger.Warningf(format, args...)
+		pl.logger.WarningDepth(1, fmt.Sprintf(format, args...))
 		return
 	}
-	Logger.Warningf(format, args...)
+	WarningDepth(1, fmt.Sprintf(format, args...))
 }
 
 // Errorf does error logging.
 func (pl *PrefixLogger) Errorf(format string, args ...interface{}) {
 	if pl != nil {
 		format = pl.prefix + format
-		pl.logger.Errorf(format, args...)
+		pl.logger.ErrorDepth(1, fmt.Sprintf(format, args...))
 		return
 	}
-	Logger.Errorf(format, args...)
+	ErrorDepth(1, fmt.Sprintf(format, args...))
 }
 
 // Debugf does info logging at verbose level 2.
 func (pl *PrefixLogger) Debugf(format string, args ...interface{}) {
-	if Logger.V(2) {
-		pl.Infof(format, args...)
+	if !Logger.V(2) {
+		return
 	}
+	if pl != nil {
+		// Handle nil, so the tests can pass in a nil logger.
+		format = pl.prefix + format
+		pl.logger.InfoDepth(1, fmt.Sprintf(format, args...))
+		return
+	}
+	InfoDepth(1, fmt.Sprintf(format, args...))
 }
 
 // NewPrefixLogger creates a prefix logger with the given prefix.
-func NewPrefixLogger(logger LoggerV2, prefix string) *PrefixLogger {
+func NewPrefixLogger(logger DepthLoggerV2, prefix string) *PrefixLogger {
 	return &PrefixLogger{logger: logger, prefix: prefix}
 }

--- a/xds/internal/balancer/cdsbalancer/cdsbalancer.go
+++ b/xds/internal/balancer/cdsbalancer/cdsbalancer.go
@@ -76,7 +76,7 @@ func (cdsBB) Build(cc balancer.ClientConn, opts balancer.BuildOptions) balancer.
 		bOpts:    opts,
 		updateCh: buffer.NewUnbounded(),
 	}
-	b.logger = grpclog.NewPrefixLogger(logger, loggingPrefix(b))
+	b.logger = prefixLogger((b))
 	b.logger.Infof("Created")
 	go b.run()
 	return b

--- a/xds/internal/balancer/cdsbalancer/cdsbalancer.go
+++ b/xds/internal/balancer/cdsbalancer/cdsbalancer.go
@@ -76,7 +76,7 @@ func (cdsBB) Build(cc balancer.ClientConn, opts balancer.BuildOptions) balancer.
 		bOpts:    opts,
 		updateCh: buffer.NewUnbounded(),
 	}
-	b.logger = grpclog.NewPrefixLogger(loggingPrefix(b))
+	b.logger = grpclog.NewPrefixLogger(logger, loggingPrefix(b))
 	b.logger.Infof("Created")
 	go b.run()
 	return b

--- a/xds/internal/balancer/cdsbalancer/logging.go
+++ b/xds/internal/balancer/cdsbalancer/logging.go
@@ -22,12 +22,13 @@ import (
 	"fmt"
 
 	"google.golang.org/grpc/grpclog"
+	internalgrpclog "google.golang.org/grpc/internal/grpclog"
 )
 
 const prefix = "[cds-lb %p] "
 
 var logger = grpclog.Component("xds")
 
-func loggingPrefix(p *cdsBalancer) string {
-	return fmt.Sprintf(prefix, p)
+func prefixLogger(p *cdsBalancer) *internalgrpclog.PrefixLogger {
+	return internalgrpclog.NewPrefixLogger(logger, fmt.Sprintf(prefix, p))
 }

--- a/xds/internal/balancer/cdsbalancer/logging.go
+++ b/xds/internal/balancer/cdsbalancer/logging.go
@@ -20,9 +20,13 @@ package cdsbalancer
 
 import (
 	"fmt"
+
+	"google.golang.org/grpc/grpclog"
 )
 
 const prefix = "[cds-lb %p] "
+
+var logger = grpclog.Component("xds")
 
 func loggingPrefix(p *cdsBalancer) string {
 	return fmt.Sprintf(prefix, p)

--- a/xds/internal/balancer/edsbalancer/eds.go
+++ b/xds/internal/balancer/edsbalancer/eds.go
@@ -64,7 +64,7 @@ func (b *edsBalancerBuilder) Build(cc balancer.ClientConn, opts balancer.BuildOp
 		childPolicyUpdate: buffer.NewUnbounded(),
 	}
 	loadStore := lrs.NewStore()
-	x.logger = grpclog.NewPrefixLogger(logger, loggingPrefix(x))
+	x.logger = prefixLogger((x))
 	x.edsImpl = newEDSBalancer(x.cc, x.enqueueChildBalancerState, loadStore, x.logger)
 	x.client = newXDSClientWrapper(x.handleEDSUpdate, x.buildOpts, loadStore, x.logger)
 	x.logger.Infof("Created")

--- a/xds/internal/balancer/edsbalancer/eds.go
+++ b/xds/internal/balancer/edsbalancer/eds.go
@@ -64,7 +64,7 @@ func (b *edsBalancerBuilder) Build(cc balancer.ClientConn, opts balancer.BuildOp
 		childPolicyUpdate: buffer.NewUnbounded(),
 	}
 	loadStore := lrs.NewStore()
-	x.logger = grpclog.NewPrefixLogger(loggingPrefix(x))
+	x.logger = grpclog.NewPrefixLogger(logger, loggingPrefix(x))
 	x.edsImpl = newEDSBalancer(x.cc, x.enqueueChildBalancerState, loadStore, x.logger)
 	x.client = newXDSClientWrapper(x.handleEDSUpdate, x.buildOpts, loadStore, x.logger)
 	x.logger.Infof("Created")

--- a/xds/internal/balancer/edsbalancer/eds_impl_priority.go
+++ b/xds/internal/balancer/edsbalancer/eds_impl_priority.go
@@ -25,10 +25,8 @@ import (
 	"google.golang.org/grpc/balancer"
 	"google.golang.org/grpc/balancer/base"
 	"google.golang.org/grpc/connectivity"
-	"google.golang.org/grpc/grpclog"
 )
 
-var logger = grpclog.Component("xds")
 var errAllPrioritiesRemoved = errors.New("eds: no locality is provided, all priorities are removed")
 
 // handlePriorityChange handles priority after EDS adds/removes a
@@ -135,13 +133,13 @@ func (edsImpl *edsBalancerImpl) handlePriorityWithNewState(priority priorityType
 	defer edsImpl.priorityMu.Unlock()
 
 	if !edsImpl.priorityInUse.isSet() {
-		logger.Infof("eds: received picker update when no priority is in use (EDS returned an empty list)")
+		edsImpl.logger.Infof("eds: received picker update when no priority is in use (EDS returned an empty list)")
 		return false
 	}
 
 	if edsImpl.priorityInUse.higherThan(priority) {
 		// Lower priorities should all be closed, this is an unexpected update.
-		logger.Infof("eds: received picker update from priority lower then priorityInUse")
+		edsImpl.logger.Infof("eds: received picker update from priority lower then priorityInUse")
 		return false
 	}
 

--- a/xds/internal/balancer/edsbalancer/logging.go
+++ b/xds/internal/balancer/edsbalancer/logging.go
@@ -20,9 +20,13 @@ package edsbalancer
 
 import (
 	"fmt"
+
+	"google.golang.org/grpc/grpclog"
 )
 
 const prefix = "[eds-lb %p] "
+
+var logger = grpclog.Component("xds")
 
 func loggingPrefix(p *edsBalancer) string {
 	return fmt.Sprintf(prefix, p)

--- a/xds/internal/balancer/edsbalancer/logging.go
+++ b/xds/internal/balancer/edsbalancer/logging.go
@@ -22,12 +22,13 @@ import (
 	"fmt"
 
 	"google.golang.org/grpc/grpclog"
+	internalgrpclog "google.golang.org/grpc/internal/grpclog"
 )
 
 const prefix = "[eds-lb %p] "
 
 var logger = grpclog.Component("xds")
 
-func loggingPrefix(p *edsBalancer) string {
-	return fmt.Sprintf(prefix, p)
+func prefixLogger(p *edsBalancer) *internalgrpclog.PrefixLogger {
+	return internalgrpclog.NewPrefixLogger(logger, fmt.Sprintf(prefix, p))
 }

--- a/xds/internal/balancer/weightedtarget/logging.go
+++ b/xds/internal/balancer/weightedtarget/logging.go
@@ -22,12 +22,13 @@ import (
 	"fmt"
 
 	"google.golang.org/grpc/grpclog"
+	internalgrpclog "google.golang.org/grpc/internal/grpclog"
 )
 
 const prefix = "[weighted-target-lb %p] "
 
 var logger = grpclog.Component("xds")
 
-func loggingPrefix(p *weightedTargetBalancer) string {
-	return fmt.Sprintf(prefix, p)
+func prefixLogger(p *weightedTargetBalancer) *internalgrpclog.PrefixLogger {
+	return internalgrpclog.NewPrefixLogger(logger, fmt.Sprintf(prefix, p))
 }

--- a/xds/internal/balancer/weightedtarget/logging.go
+++ b/xds/internal/balancer/weightedtarget/logging.go
@@ -20,9 +20,13 @@ package weightedtarget
 
 import (
 	"fmt"
+
+	"google.golang.org/grpc/grpclog"
 )
 
 const prefix = "[weighted-target-lb %p] "
+
+var logger = grpclog.Component("xds")
 
 func loggingPrefix(p *weightedTargetBalancer) string {
 	return fmt.Sprintf(prefix, p)

--- a/xds/internal/balancer/weightedtarget/weightedtarget.go
+++ b/xds/internal/balancer/weightedtarget/weightedtarget.go
@@ -43,7 +43,7 @@ type weightedTargetBB struct{}
 
 func (wt *weightedTargetBB) Build(cc balancer.ClientConn, _ balancer.BuildOptions) balancer.Balancer {
 	b := &weightedTargetBalancer{}
-	b.logger = grpclog.NewPrefixLogger(loggingPrefix(b))
+	b.logger = grpclog.NewPrefixLogger(logger, loggingPrefix(b))
 	b.bg = balancergroup.New(cc, nil, b.logger)
 	b.bg.Start()
 	b.logger.Infof("Created")

--- a/xds/internal/balancer/weightedtarget/weightedtarget.go
+++ b/xds/internal/balancer/weightedtarget/weightedtarget.go
@@ -43,7 +43,7 @@ type weightedTargetBB struct{}
 
 func (wt *weightedTargetBB) Build(cc balancer.ClientConn, _ balancer.BuildOptions) balancer.Balancer {
 	b := &weightedTargetBalancer{}
-	b.logger = grpclog.NewPrefixLogger(logger, loggingPrefix(b))
+	b.logger = prefixLogger((b))
 	b.bg = balancergroup.New(cc, nil, b.logger)
 	b.bg.Start()
 	b.logger.Infof("Created")

--- a/xds/internal/client/bootstrap/logging.go
+++ b/xds/internal/client/bootstrap/logging.go
@@ -18,8 +18,11 @@
 
 package bootstrap
 
-import "google.golang.org/grpc/internal/grpclog"
+import (
+	"google.golang.org/grpc/grpclog"
+	internalgrpclog "google.golang.org/grpc/internal/grpclog"
+)
 
 const prefix = "[xds-bootstrap] "
 
-var logger = grpclog.NewPrefixLogger(prefix)
+var logger = internalgrpclog.NewPrefixLogger(grpclog.Component("xds"), prefix)

--- a/xds/internal/client/client.go
+++ b/xds/internal/client/client.go
@@ -128,7 +128,7 @@ func New(opts Options) (*Client, error) {
 		return nil, fmt.Errorf("xds: failed to dial balancer {%s}: %v", opts.Config.BalancerName, err)
 	}
 	c.cc = cc
-	c.logger = grpclog.NewPrefixLogger(logger, loggingPrefix(c))
+	c.logger = prefixLogger((c))
 	c.logger.Infof("Created ClientConn to xDS server: %s", opts.Config.BalancerName)
 
 	c.v2c = newXDSV2Client(c, cc, opts.Config.NodeProto, backoff.DefaultExponential.Backoff, c.logger)

--- a/xds/internal/client/client.go
+++ b/xds/internal/client/client.go
@@ -128,7 +128,7 @@ func New(opts Options) (*Client, error) {
 		return nil, fmt.Errorf("xds: failed to dial balancer {%s}: %v", opts.Config.BalancerName, err)
 	}
 	c.cc = cc
-	c.logger = grpclog.NewPrefixLogger(loggingPrefix(c))
+	c.logger = grpclog.NewPrefixLogger(logger, loggingPrefix(c))
 	c.logger.Infof("Created ClientConn to xDS server: %s", opts.Config.BalancerName)
 
 	c.v2c = newXDSV2Client(c, cc, opts.Config.NodeProto, backoff.DefaultExponential.Backoff, c.logger)

--- a/xds/internal/client/client_loadreport.go
+++ b/xds/internal/client/client_loadreport.go
@@ -24,13 +24,10 @@ import (
 	"github.com/golang/protobuf/proto"
 	structpb "github.com/golang/protobuf/ptypes/struct"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/grpclog"
 	"google.golang.org/grpc/xds/internal/balancer/lrs"
 )
 
 const nodeMetadataHostnameKey = "PROXYLESS_CLIENT_HOSTNAME"
-
-var logger = grpclog.Component("xds")
 
 // ReportLoad sends the load of the given clusterName from loadStore to the
 // given server. If the server is not an empty string, and is different from the
@@ -55,7 +52,7 @@ func (c *Client) ReportLoad(server string, clusterName string, loadStore lrs.Sto
 		ccNew, err := grpc.Dial(server, dopts...)
 		if err != nil {
 			// An error from a non-blocking dial indicates something serious.
-			logger.Infof("xds: failed to dial load report server {%s}: %v", server, err)
+			c.logger.Infof("xds: failed to dial load report server {%s}: %v", server, err)
 			return func() {}
 		}
 		cc = ccNew

--- a/xds/internal/client/client_logging.go
+++ b/xds/internal/client/client_logging.go
@@ -20,9 +20,13 @@ package client
 
 import (
 	"fmt"
+
+	"google.golang.org/grpc/grpclog"
 )
 
 const prefix = "[xds-client %p] "
+
+var logger = grpclog.Component("xds")
 
 func loggingPrefix(p *Client) string {
 	return fmt.Sprintf(prefix, p)

--- a/xds/internal/client/client_logging.go
+++ b/xds/internal/client/client_logging.go
@@ -22,12 +22,13 @@ import (
 	"fmt"
 
 	"google.golang.org/grpc/grpclog"
+	internalgrpclog "google.golang.org/grpc/internal/grpclog"
 )
 
 const prefix = "[xds-client %p] "
 
 var logger = grpclog.Component("xds")
 
-func loggingPrefix(p *Client) string {
-	return fmt.Sprintf(prefix, p)
+func prefixLogger(p *Client) *internalgrpclog.PrefixLogger {
+	return internalgrpclog.NewPrefixLogger(logger, fmt.Sprintf(prefix, p))
 }

--- a/xds/internal/resolver/logging.go
+++ b/xds/internal/resolver/logging.go
@@ -20,9 +20,13 @@ package resolver
 
 import (
 	"fmt"
+
+	"google.golang.org/grpc/grpclog"
 )
 
 const prefix = "[xds-resolver %p] "
+
+var logger = grpclog.Component("xds")
 
 func loggingPrefix(p *xdsResolver) string {
 	return fmt.Sprintf(prefix, p)

--- a/xds/internal/resolver/logging.go
+++ b/xds/internal/resolver/logging.go
@@ -22,12 +22,13 @@ import (
 	"fmt"
 
 	"google.golang.org/grpc/grpclog"
+	internalgrpclog "google.golang.org/grpc/internal/grpclog"
 )
 
 const prefix = "[xds-resolver %p] "
 
 var logger = grpclog.Component("xds")
 
-func loggingPrefix(p *xdsResolver) string {
-	return fmt.Sprintf(prefix, p)
+func prefixLogger(p *xdsResolver) *internalgrpclog.PrefixLogger {
+	return internalgrpclog.NewPrefixLogger(logger, fmt.Sprintf(prefix, p))
 }

--- a/xds/internal/resolver/xds_resolver.go
+++ b/xds/internal/resolver/xds_resolver.go
@@ -64,7 +64,7 @@ func (b *xdsResolverBuilder) Build(t resolver.Target, cc resolver.ClientConn, rb
 		cc:       cc,
 		updateCh: make(chan suWithError, 1),
 	}
-	r.logger = grpclog.NewPrefixLogger(loggingPrefix(r))
+	r.logger = grpclog.NewPrefixLogger(logger, loggingPrefix(r))
 	r.logger.Infof("Creating resolver for target: %+v", t)
 
 	if config.Creds == nil {

--- a/xds/internal/resolver/xds_resolver.go
+++ b/xds/internal/resolver/xds_resolver.go
@@ -64,7 +64,7 @@ func (b *xdsResolverBuilder) Build(t resolver.Target, cc resolver.ClientConn, rb
 		cc:       cc,
 		updateCh: make(chan suWithError, 1),
 	}
-	r.logger = grpclog.NewPrefixLogger(logger, loggingPrefix(r))
+	r.logger = prefixLogger((r))
 	r.logger.Infof("Creating resolver for target: %+v", t)
 
 	if config.Creds == nil {


### PR DESCRIPTION
All xds logs are in component `xds`.
This includes balancer `weighted_target` for now, which may need to change in the future.

Also fix logging depth.