### PR TITLE
README: adjust links, and slight rework of page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,65 +1,48 @@
 # gRPC-Go
 
 [![Build Status](https://travis-ci.org/grpc/grpc-go.svg)](https://travis-ci.org/grpc/grpc-go)
-[![GoDoc](https://godoc.org/google.golang.org/grpc?status.svg)](https://godoc.org/google.golang.org/grpc)
+[![GoDoc](https://godoc.org/google.golang.org/grpc?status.svg)][API]
 [![GoReportCard](https://goreportcard.com/badge/grpc/grpc-go)](https://goreportcard.com/report/github.com/grpc/grpc-go)
 
-The Go implementation of [gRPC](https://grpc.io/): A high performance, open
-source, general RPC framework that puts mobile and HTTP/2 first. For more
-information see the [gRPC Quick Start:
-Go](https://grpc.io/docs/languages/go/quickstart/) guide.
+The Go implementation of [gRPC][]: A high performance, open source, general RPC
+framework that puts mobile and HTTP/2 first. For more information see the [Go
+gRPC docs][], or jump directly into the [quick start][].
 
-Installation
-------------
+## Prerequisites
 
-To install this package, you need to install Go and setup your Go workspace on
-your computer. The simplest way to install the library is to run:
+- **[Go][]**, any one of the **three latest major** [releases of Go][].
 
-```
+## Installation
+
+The simplest way to install the grpc-go package is to run the following command:
+
+```console
 $ go get -u google.golang.org/grpc
 ```
 
-With Go module support (Go 1.11+), simply `import "google.golang.org/grpc"` in
-your source code and `go [build|run|test]` will automatically download the
-necessary dependencies ([Go modules
-ref](https://github.com/golang/go/wiki/Modules)).
+With [Go module][] support (Go 1.11+), simply `import "google.golang.org/grpc"`
+in your source code and `go [build|run|test]` will automatically download the
+necessary dependencies.
 
-If you are trying to access grpc-go from within China, please see the
+> **Note:** If you are trying to access grpc-go from within **China**, see the
 [FAQ](#FAQ) below.
 
-Prerequisites
--------------
-gRPC-Go officially supports the
-[three latest major releases of Go](https://golang.org/doc/devel/release.html).
+## Learn more
 
-Documentation
--------------
-- See [godoc](https://godoc.org/google.golang.org/grpc) for package and API
-  descriptions.
-- Documentation on specific topics can be found in the [Documentation
-  directory](Documentation/).
-- Examples can be found in the [examples directory](examples/).
+- [Go gRPC docs][], which include a [quick start][] and [API
+  reference][API] among other resources
+- [Low-level technical docs](Documentation) from this repository
+- [Performance benchmark][]
+- [Examples](examples)
 
-Performance
------------
-Performance benchmark data for grpc-go and other languages is maintained in
-[this
-dashboard](https://performance-dot-grpc-testing.appspot.com/explore?dashboard=5652536396611584&widget=490377658&container=1286539696).
+## FAQ
 
-Status
-------
-General Availability [Google Cloud Platform Launch
-Stages](https://cloud.google.com/terms/launch-stages).
-
-FAQ
----
-
-#### I/O Timeout Errors
+### I/O Timeout Errors
 
 The `golang.org` domain may be blocked from some countries.  `go get` usually
 produces an error like the following when this happens:
 
-```
+```console
 $ go get -u google.golang.org/grpc
 package google.golang.org/grpc: unrecognized import path "google.golang.org/grpc" (https fetch: Get https://google.golang.org/grpc?go-get=1: dial tcp 216.239.37.1:443: i/o timeout)
 ```
@@ -70,8 +53,8 @@ To build Go code, there are several options:
 
 - Without Go module support: `git clone` the repo manually:
 
-  ```
-  git clone https://github.com/grpc/grpc-go.git $GOPATH/src/google.golang.org/grpc
+  ```console
+  $ git clone https://github.com/grpc/grpc-go.git $GOPATH/src/google.golang.org/grpc
   ```
 
   You will need to do the same for all of grpc's dependencies in `golang.org`,
@@ -80,11 +63,11 @@ To build Go code, there are several options:
 - With Go module support: it is possible to use the `replace` feature of `go
   mod` to create aliases for golang.org packages.  In your project's directory:
 
-  ```
-  go mod edit -replace=google.golang.org/grpc=github.com/grpc/grpc-go@latest
-  go mod tidy
-  go mod vendor
-  go build -mod=vendor
+  ```console
+  $ go mod edit -replace=google.golang.org/grpc=github.com/grpc/grpc-go@latest
+  $ go mod tidy
+  $ go mod vendor
+  $ go build -mod=vendor
   ```
 
   Again, this will need to be done for all transitive dependencies hosted on
@@ -92,15 +75,15 @@ To build Go code, there are several options:
   issue](https://github.com/golang/go/issues/28652) in the golang repo regarding
   this concern.
 
-#### Compiling error, undefined: grpc.SupportPackageIsVersion
+### Compiling error, undefined: grpc.SupportPackageIsVersion
 
-##### If you are using Go modules:
+#### If you are using Go modules:
 
 Please ensure your gRPC-Go version is `require`d at the appropriate version in
 the same module containing the generated `.pb.go` files.  For example,
 `SupportPackageIsVersion6` needs `v1.27.0`, so in your `go.mod` file:
 
-```
+```go
 module <your module name>
 
 require (
@@ -108,23 +91,24 @@ require (
 )
 ```
 
-##### If you are *not* using Go modules:
+#### If you are *not* using Go modules:
 
 Please update proto package, gRPC package and rebuild the proto files:
  - `go get -u github.com/golang/protobuf/{proto,protoc-gen-go}`
  - `go get -u google.golang.org/grpc`
  - `protoc --go_out=plugins=grpc:. *.proto`
 
-#### How to turn on logging
+### How to turn on logging
 
-The default logger is controlled by the environment variables. Turn everything
-on by setting:
+The default logger is controlled by environment variables. Turn everything on
+like this:
 
+```console
+$ export GRPC_GO_LOG_VERBOSITY_LEVEL=99
+$ export GRPC_GO_LOG_SEVERITY_LEVEL=info
 ```
-GRPC_GO_LOG_VERBOSITY_LEVEL=99 GRPC_GO_LOG_SEVERITY_LEVEL=info
-```
 
-#### The RPC failed with error `"code = Unavailable desc = transport is closing"`
+### The RPC failed with error `"code = Unavailable desc = transport is closing"`
 
 This error means the connection the RPC is using was closed, and there are many
 possible reasons, including:
@@ -140,3 +124,12 @@ It can be tricky to debug this because the error happens on the client side but
 the root cause of the connection being closed is on the server side. Turn on
 logging on __both client and server__, and see if there are any transport
 errors.
+
+[API]: https://grpc.io/docs/languages/go/api
+[Go]: https://golang.org
+[Go module]: https://github.com/golang/go/wiki/Modules
+[gRPC]: https://grpc.io
+[Go gRPC docs]: https://grpc.io/docs/languages/go
+[Performance benchmark]: https://performance-dot-grpc-testing.appspot.com/explore?dashboard=5652536396611584&widget=490377658&container=1286539696
+[quick start]: https://grpc.io/docs/languages/go/quickstart
+[releases of Go]: https://golang.org/doc/devel/release.html

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ $ go get -u google.golang.org/grpc
 
 ### I/O Timeout Errors
 
-The `golang.org` domain may be blocked from some countries.  `go get` usually
+The `golang.org` domain may be blocked from some countries. `go get` usually
 produces an error like the following when this happens:
 
 ```console
@@ -58,8 +58,8 @@ To build Go code, there are several options:
 
 - Without Go module support: `git clone` the repo manually:
 
-  ```console
-  $ git clone https://github.com/grpc/grpc-go.git $GOPATH/src/google.golang.org/grpc
+  ```sh
+  git clone https://github.com/grpc/grpc-go.git $GOPATH/src/google.golang.org/grpc
   ```
 
   You will need to do the same for all of grpc's dependencies in `golang.org`,
@@ -68,23 +68,21 @@ To build Go code, there are several options:
 - With Go module support: it is possible to use the `replace` feature of `go
   mod` to create aliases for golang.org packages.  In your project's directory:
 
-  ```console
-  $ go mod edit -replace=google.golang.org/grpc=github.com/grpc/grpc-go@latest
-  $ go mod tidy
-  $ go mod vendor
-  $ go build -mod=vendor
+  ```sh
+  go mod edit -replace=google.golang.org/grpc=github.com/grpc/grpc-go@latest
+  go mod tidy
+  go mod vendor
+  go build -mod=vendor
   ```
 
   Again, this will need to be done for all transitive dependencies hosted on
-  golang.org as well.  Please refer to [this
-  issue](https://github.com/golang/go/issues/28652) in the golang repo regarding
-  this concern.
+  golang.org as well. For details, refer to [golang/go issue #28652](https://github.com/golang/go/issues/28652).
 
 ### Compiling error, undefined: grpc.SupportPackageIsVersion
 
 #### If you are using Go modules:
 
-Please ensure your gRPC-Go version is `require`d at the appropriate version in
+Ensure your gRPC-Go version is `require`d at the appropriate version in
 the same module containing the generated `.pb.go` files.  For example,
 `SupportPackageIsVersion6` needs `v1.27.0`, so in your `go.mod` file:
 
@@ -98,10 +96,13 @@ require (
 
 #### If you are *not* using Go modules:
 
-Please update proto package, gRPC package and rebuild the proto files:
- - `go get -u github.com/golang/protobuf/{proto,protoc-gen-go}`
- - `go get -u google.golang.org/grpc`
- - `protoc --go_out=plugins=grpc:. *.proto`
+Update the `proto` package, gRPC package, and rebuild the `.proto` files:
+
+```sh
+go get -u github.com/golang/protobuf/{proto,protoc-gen-go}
+go get -u google.golang.org/grpc
+protoc --go_out=plugins=grpc:. *.proto
+```
 
 ### How to turn on logging
 

--- a/README.md
+++ b/README.md
@@ -4,28 +4,33 @@
 [![GoDoc](https://godoc.org/google.golang.org/grpc?status.svg)][API]
 [![GoReportCard](https://goreportcard.com/badge/grpc/grpc-go)](https://goreportcard.com/report/github.com/grpc/grpc-go)
 
-The Go implementation of [gRPC][]: A high performance, open source, general RPC
-framework that puts mobile and HTTP/2 first. For more information see the [Go
-gRPC docs][], or jump directly into the [quick start][].
+The [Go][] implementation of [gRPC][]: A high performance, open source, general
+RPC framework that puts mobile and HTTP/2 first. For more information see the
+[Go gRPC docs][], or jump directly into the [quick start][].
 
 ## Prerequisites
 
-- **[Go][]**, any one of the **three latest major** [releases of Go][].
+- **[Go][]**: any one of the **three latest major** [releases][go-releases].
 
 ## Installation
 
-The simplest way to install the grpc-go package is to run the following command:
+With [Go module][] support (Go 1.11+), simply add the following import
+
+```go
+import "google.golang.org/grpc"
+```
+
+to your code, and then `go [build|run|test]` will automatically fetch the
+necessary dependencies.
+
+Otherwise, to install the `grpc-go` package, run the following command:
 
 ```console
 $ go get -u google.golang.org/grpc
 ```
 
-With [Go module][] support (Go 1.11+), simply `import "google.golang.org/grpc"`
-in your source code and `go [build|run|test]` will automatically download the
-necessary dependencies.
-
-> **Note:** If you are trying to access grpc-go from within **China**, see the
-[FAQ](#FAQ) below.
+> **Note:** If you are trying to access `grpc-go` from **China**, see the
+> [FAQ](#FAQ) below.
 
 ## Learn more
 
@@ -132,4 +137,4 @@ errors.
 [Go gRPC docs]: https://grpc.io/docs/languages/go
 [Performance benchmark]: https://performance-dot-grpc-testing.appspot.com/explore?dashboard=5652536396611584&widget=490377658&container=1286539696
 [quick start]: https://grpc.io/docs/languages/go/quickstart
-[releases of Go]: https://golang.org/doc/devel/release.html
+[go-releases]: https://golang.org/doc/devel/release.html


### PR DESCRIPTION
- API reference link: use the same (canonical) link as the one used on grpc.io
- Put "Prerequisites" before "Installation" so that we don't have to repeat the prerequisite
- Set code-block styles where appropriate
- Copy edits
- Contributes to https://github.com/grpc/grpc.io/issues/180

@dfawley 