### PR TITLE
balancer: remove deprecated type aliases as planned

### DIFF
--- a/balancer/balancer.go
+++ b/balancer/balancer.go
@@ -312,16 +312,6 @@ type Balancer interface {
 	Close()
 }
 
-// V2Balancer is temporarily defined for backward compatibility reasons.
-//
-// Deprecated: use Balancer directly instead.
-type V2Balancer = Balancer
-
-// V2Picker is temporarily defined for backward compatibility reasons.
-//
-// Deprecated: use Picker directly instead.
-type V2Picker = Picker
-
 // SubConnState describes the state of a SubConn.
 type SubConnState struct {
 	// ConnectivityState is the connectivity state of the SubConn.

--- a/balancer/base/base.go
+++ b/balancer/base/base.go
@@ -69,14 +69,3 @@ func NewBalancerBuilder(name string, pb PickerBuilder, config Config) balancer.B
 		config:        config,
 	}
 }
-
-// NewBalancerBuilderV2 is temporarily defined for backward compatibility
-// reasons.
-//
-// Deprecated: use NewBalancerBuilder instead.
-var NewBalancerBuilderV2 = NewBalancerBuilder
-
-// V2PickerBuilder is temporarily defined for backward compatibility reasons.
-//
-// Deprecated: use PickerBuilder instead.
-type V2PickerBuilder = PickerBuilder

--- a/balancer/rls/internal/balancer.go
+++ b/balancer/rls/internal/balancer.go
@@ -96,7 +96,7 @@ func (lb *rlsBalancer) handleClientConnUpdate(ccs *balancer.ClientConnState) {
 
 // UpdateClientConnState pushes the received ClientConnState update on the
 // update channel which will be processed asynchronously by the run goroutine.
-// Implements balancer.V2Balancer interface.
+// Implements balancer.Balancer interface.
 func (lb *rlsBalancer) UpdateClientConnState(ccs balancer.ClientConnState) error {
 	select {
 	case lb.ccUpdateCh <- &ccs:
@@ -105,14 +105,14 @@ func (lb *rlsBalancer) UpdateClientConnState(ccs balancer.ClientConnState) error
 	return nil
 }
 
-// ResolverErr implements balancer.V2Balancer interface.
+// ResolverErr implements balancer.Balancer interface.
 func (lb *rlsBalancer) ResolverError(error) {
 	// ResolverError is called by gRPC when the name resolver reports an error.
 	// TODO(easwars): How do we handle this?
 	grpclog.Fatal("rls: ResolverError is not yet unimplemented")
 }
 
-// UpdateSubConnState implements balancer.V2Balancer interface.
+// UpdateSubConnState implements balancer.Balancer interface.
 func (lb *rlsBalancer) UpdateSubConnState(_ balancer.SubConn, _ balancer.SubConnState) {
 	grpclog.Fatal("rls: UpdateSubConnState is not yet implemented")
 }

--- a/xds/internal/balancer/cdsbalancer/cdsbalancer_test.go
+++ b/xds/internal/balancer/cdsbalancer/cdsbalancer_test.go
@@ -231,7 +231,6 @@ func edsCCS(service string, enableLRS bool, xdsClient interface{}) balancer.Clie
 func setup() (*cdsBalancer, *testEDSBalancer, *testClientConn, func()) {
 	builder := cdsBB{}
 	tcc := newTestClientConn()
-	// cdsB := builder.Build(tcc, balancer.BuildOptions{}).(balancer.V2Balancer)
 	cdsB := builder.Build(tcc, balancer.BuildOptions{})
 
 	edsB := newTestEDSBalancer()


### PR DESCRIPTION
Closes #3180

This implements the final step of #3180, removing the backward-compatibility type aliases intended to provide a migration window for users of the removed, experimental API.
