### PR TITLE
advancedtls: Add PeerCredFileReader and TrustCredFileReader implementation

### DIFF
--- a/security/advancedtls/advancedtls_test.go
+++ b/security/advancedtls/advancedtls_test.go
@@ -717,7 +717,7 @@ func testPeerCredFileReader(t *testing.T) {
 				CertFilePath: test.certFilePath,
 				KeyFilePath:  test.keyFilePath,
 			}
-			pemPeerCredFileReader, err := newPemPeerCredFileReader(*pemPeerCredFileReaderOption)
+			pemPeerCredFileReader, err := NewPemPeerCredFileReader(*pemPeerCredFileReaderOption)
 			if err != nil {
 				t.Fatalf("Unable to generate NewPemPeerCredFileReader. Error: %v", err)
 			}
@@ -763,7 +763,7 @@ func testTrustCredFileReader(t *testing.T) {
 			pemTrustCredFileReaderOption := &PemTrustCredFileReaderOption{
 				TrustCertPath: test.trustCertPath,
 			}
-			pemTrustCredFileReader, err := newPemTrustCredFileReader(*pemTrustCredFileReaderOption)
+			pemTrustCredFileReader, err := NewPemTrustCredFileReader(*pemTrustCredFileReaderOption)
 			if err != nil {
 				t.Fatalf("Unable to generate NewPemTrustCredFileReader. Error: %v", err)
 			}

--- a/security/advancedtls/advancedtls_test.go
+++ b/security/advancedtls/advancedtls_test.go
@@ -698,13 +698,13 @@ func testPeerCredFileReader(t *testing.T) {
 		expectedPeerCert tls.Certificate
 	}{
 		{
-			desc:             "Selected certificate by SNI should be serverPeerCert1",
+			desc:             "Read peer credential files on the client side",
 			certFilePath:     testdata.Path("client_cert_1.pem"),
 			keyFilePath:      testdata.Path("client_key_1.pem"),
 			expectedPeerCert: clientPeerCert,
 		},
 		{
-			desc:             "Selected certificate by SNI should be serverPeerCert2",
+			desc:             "Read peer credential files on the server side",
 			certFilePath:     testdata.Path("server_cert_1.pem"),
 			keyFilePath:      testdata.Path("server_key_1.pem"),
 			expectedPeerCert: serverPeerCert,
@@ -717,13 +717,13 @@ func testPeerCredFileReader(t *testing.T) {
 				CertFilePath: test.certFilePath,
 				KeyFilePath:  test.keyFilePath,
 			}
-			pemPeerCredFileReader, err := NewPemPeerCredFileReader(*pemPeerCredFileReaderOption)
+			pemPeerCredFileReader, err := newPemPeerCredFileReader(*pemPeerCredFileReaderOption)
 			if err != nil {
-				t.Fatalf("Unable to generate pemPeerCredFileReader. Error: %v", err)
+				t.Fatalf("Unable to generate NewPemPeerCredFileReader. Error: %v", err)
 			}
 			gotPeerCert, err := pemPeerCredFileReader.ReadKeyAndCerts()
 			if err != nil {
-				t.Fatalf("Unable to read key and certificates. Error: %v", err)
+				t.Fatalf("NewPemPeerCredFileReader is unable to parse peer certificates. Error: %v", err)
 			}
 			if !reflect.DeepEqual(*gotPeerCert, test.expectedPeerCert) {
 				t.Errorf("ReadKeyAndCerts() = %v, want %v", gotPeerCert, test.expectedPeerCert)
@@ -747,12 +747,12 @@ func testTrustCredFileReader(t *testing.T) {
 		expectedTrustPool *x509.CertPool
 	}{
 		{
-			desc:              "Selected certificate by SNI should be serverPeerCert1",
+			desc:              "Read trust credential files on the client side",
 			trustCertPath:     testdata.Path("client_trust_cert_1.pem"),
 			expectedTrustPool: clientTrustPool,
 		},
 		{
-			desc:              "Selected certificate by SNI should be serverPeerCert2",
+			desc:              "Read trust credential files on the server side",
 			trustCertPath:     testdata.Path("server_trust_cert_1.pem"),
 			expectedTrustPool: serverTrustPool,
 		},
@@ -763,13 +763,13 @@ func testTrustCredFileReader(t *testing.T) {
 			pemTrustCredFileReaderOption := &PemTrustCredFileReaderOption{
 				TrustCertPath: test.trustCertPath,
 			}
-			pemTrustCredFileReader, err := NewPemTrustCredFileReader(*pemTrustCredFileReaderOption)
+			pemTrustCredFileReader, err := newPemTrustCredFileReader(*pemTrustCredFileReaderOption)
 			if err != nil {
-				t.Fatalf("Unable to generate pemTrustCredFileReader. Error: %v", err)
+				t.Fatalf("Unable to generate NewPemTrustCredFileReader. Error: %v", err)
 			}
 			gotTrustPool, err := pemTrustCredFileReader.ReadTrustCerts()
 			if err != nil {
-				t.Fatalf("Unable to read key and certificates. Error: %v", err)
+				t.Fatalf("NewPemTrustCredFileReader is unable to load trust certs. Error: %v", err)
 			}
 			if !reflect.DeepEqual(*gotTrustPool, test.expectedTrustPool) {
 				t.Errorf("ReadTrustCerts() = %v, want %v", gotTrustPool, test.expectedTrustPool)

--- a/security/advancedtls/file_reader.go
+++ b/security/advancedtls/file_reader.go
@@ -1,0 +1,126 @@
+/*
+ *
+ * Copyright 2020 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package advancedtls
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"io/ioutil"
+	"time"
+)
+
+// PeerCredFileReader contains
+type PeerCredFileReader interface {
+	ReadKeyAndCerts() (*tls.Certificate, error)
+}
+
+// TrustCredFileReader contains
+type TrustCredFileReader interface {
+	ReadTrustCerts() (*x509.CertPool, error)
+}
+
+type pemPeerCredFileReader struct {
+	certFilePath string
+	keyFilePath  string
+	interval     time.Duration
+}
+
+// PemPeerCredFileReaderOption contains
+type PemPeerCredFileReaderOption struct {
+	CertFilePath string
+	KeyFilePath  string
+	Interval     time.Duration
+}
+
+// NewPemPeerCredFileReader is
+func NewPemPeerCredFileReader(o PemPeerCredFileReaderOption) (*pemPeerCredFileReader, error) {
+	if o.CertFilePath == "" {
+		return nil, fmt.Errorf("PemPeerCredFileReaderOption needs to specify certificate file path")
+	}
+	if o.KeyFilePath == "" {
+		return nil, fmt.Errorf("PemPeerCredFileReaderOption needs to specify key file path")
+	}
+	// If interval is invalid, set it to 1 hour by default.
+	interval := o.Interval
+	if interval == 0*time.Hour {
+		interval = 1 * time.Hour
+	}
+	r := &pemPeerCredFileReader{
+		certFilePath: o.CertFilePath,
+		keyFilePath:  o.KeyFilePath,
+		interval:     interval,
+	}
+	return r, nil
+}
+
+func (r pemPeerCredFileReader) ReadKeyAndCerts() (*tls.Certificate, error) {
+	cert, err := tls.LoadX509KeyPair(r.certFilePath, r.keyFilePath)
+	if err != nil {
+		return nil, err
+	}
+	return &cert, nil
+}
+
+type pemTrustCredFileReader struct {
+	trustCertPath string
+	interval      time.Duration
+}
+
+// PemTrustCredFileReaderOption contains
+type PemTrustCredFileReaderOption struct {
+	TrustCertPath string
+	Interval      time.Duration
+}
+
+// NewPemTrustCredFileReader is
+func NewPemTrustCredFileReader(o PemTrustCredFileReaderOption) (*pemTrustCredFileReader, error) {
+	if o.TrustCertPath == "" {
+		return nil, fmt.Errorf("PemTrustCredFileReaderOption needs to specify certificate file path")
+	}
+	// If interval is invalid, set it to 1 hour by default.
+	interval := o.Interval
+	if interval == 0*time.Hour {
+		interval = 1 * time.Hour
+	}
+	r := &pemTrustCredFileReader{
+		trustCertPath: o.TrustCertPath,
+		interval:      interval,
+	}
+	return r, nil
+}
+
+func (r pemTrustCredFileReader) ReadTrustCerts() (*x509.CertPool, error) {
+	trustData, err := ioutil.ReadFile(r.trustCertPath)
+	if err != nil {
+		return nil, err
+	}
+	trustBlock, _ := pem.Decode(trustData)
+	if trustBlock == nil {
+		return nil, err
+	}
+	trustCert, err := x509.ParseCertificate(trustBlock.Bytes)
+	if err != nil {
+		return nil, err
+	}
+	trustPool := x509.NewCertPool()
+	trustPool.AddCert(trustCert)
+	return trustPool, nil
+}

--- a/security/advancedtls/file_reader.go
+++ b/security/advancedtls/file_reader.go
@@ -39,9 +39,9 @@ type TrustCredFileReader interface {
 	ReadTrustCerts() (*x509.CertPool, error)
 }
 
-// pemPeerCredFileReader is the default implementation of PeerCredFileReader.
-// pemPeerCredFileReader supports reading peer credential files of PEM format.
-type pemPeerCredFileReader struct {
+// PemPeerCredFileReader is the default implementation of PeerCredFileReader.
+// PemPeerCredFileReader supports reading peer credential files of PEM format.
+type PemPeerCredFileReader struct {
 	certFilePath string
 	keyFilePath  string
 	interval     time.Duration
@@ -55,9 +55,9 @@ type PemPeerCredFileReaderOption struct {
 	Interval     time.Duration
 }
 
-// newPemPeerCredFileReader uses PemPeerCredFileReaderOption
-// to contruct a pemPeerCredFileReader.
-func newPemPeerCredFileReader(o PemPeerCredFileReaderOption) (*pemPeerCredFileReader, error) {
+// NewPemPeerCredFileReader uses PemPeerCredFileReaderOption
+// to contruct a PemPeerCredFileReader.
+func NewPemPeerCredFileReader(o PemPeerCredFileReaderOption) (*PemPeerCredFileReader, error) {
 	if o.CertFilePath == "" {
 		return nil, fmt.Errorf(
 			"users need to specify certificate file path in PemPeerCredFileReaderOption")
@@ -71,7 +71,7 @@ func newPemPeerCredFileReader(o PemPeerCredFileReaderOption) (*pemPeerCredFileRe
 	if interval == 0*time.Nanosecond {
 		interval = 1 * time.Hour
 	}
-	r := &pemPeerCredFileReader{
+	r := &PemPeerCredFileReader{
 		certFilePath: o.CertFilePath,
 		keyFilePath:  o.KeyFilePath,
 		interval:     interval,
@@ -80,8 +80,8 @@ func newPemPeerCredFileReader(o PemPeerCredFileReaderOption) (*pemPeerCredFileRe
 }
 
 // ReadKeyAndCerts reads and parses peer certificates from the certificate file path
-// and the key file path specified in pemPeerCredFileReader.
-func (r pemPeerCredFileReader) ReadKeyAndCerts() (*tls.Certificate, error) {
+// and the key file path specified in PemPeerCredFileReader.
+func (r PemPeerCredFileReader) ReadKeyAndCerts() (*tls.Certificate, error) {
 	cert, err := tls.LoadX509KeyPair(r.certFilePath, r.keyFilePath)
 	if err != nil {
 		return nil, err
@@ -89,9 +89,9 @@ func (r pemPeerCredFileReader) ReadKeyAndCerts() (*tls.Certificate, error) {
 	return &cert, nil
 }
 
-// pemTrustCredFileReader is the default implementation of TrustCredFileReader.
-// pemTrustCredFileReader supports reading trust credential files of PEM format.
-type pemTrustCredFileReader struct {
+// PemTrustCredFileReader is the default implementation of TrustCredFileReader.
+// PemTrustCredFileReader supports reading trust credential files of PEM format.
+type PemTrustCredFileReader struct {
 	trustCertPath string
 	interval      time.Duration
 }
@@ -103,9 +103,9 @@ type PemTrustCredFileReaderOption struct {
 	Interval      time.Duration
 }
 
-// newPemTrustCredFileReader uses PemTrustCredFileReaderOption
-// to contruct a pemTrustCredFileReader.
-func newPemTrustCredFileReader(o PemTrustCredFileReaderOption) (*pemTrustCredFileReader, error) {
+// NewPemTrustCredFileReader uses PemTrustCredFileReaderOption
+// to contruct a PemTrustCredFileReader.
+func NewPemTrustCredFileReader(o PemTrustCredFileReaderOption) (*PemTrustCredFileReader, error) {
 	if o.TrustCertPath == "" {
 		return nil, fmt.Errorf(
 			"users need to specify key file path in PemTrustCredFileReaderOption")
@@ -115,7 +115,7 @@ func newPemTrustCredFileReader(o PemTrustCredFileReaderOption) (*pemTrustCredFil
 	if interval == 0*time.Nanosecond {
 		interval = 1 * time.Hour
 	}
-	r := &pemTrustCredFileReader{
+	r := &PemTrustCredFileReader{
 		trustCertPath: o.TrustCertPath,
 		interval:      interval,
 	}
@@ -123,8 +123,8 @@ func newPemTrustCredFileReader(o PemTrustCredFileReaderOption) (*pemTrustCredFil
 }
 
 // ReadTrustCerts reads and parses trust certificates from trust certificate path
-// specified in pemTrustCredFileReader.
-func (r pemTrustCredFileReader) ReadTrustCerts() (*x509.CertPool, error) {
+// specified in PemTrustCredFileReader.
+func (r PemTrustCredFileReader) ReadTrustCerts() (*x509.CertPool, error) {
 	trustData, err := ioutil.ReadFile(r.trustCertPath)
 	if err != nil {
 		return nil, err

--- a/security/advancedtls/file_reader.go
+++ b/security/advancedtls/file_reader.go
@@ -21,7 +21,6 @@ package advancedtls
 import (
 	"crypto/tls"
 	"crypto/x509"
-	"encoding/pem"
 	"fmt"
 	"io/ioutil"
 	"time"
@@ -129,15 +128,7 @@ func (r PemTrustCredFileReader) ReadTrustCerts() (*x509.CertPool, error) {
 	if err != nil {
 		return nil, err
 	}
-	trustBlock, _ := pem.Decode(trustData)
-	if trustBlock == nil {
-		return nil, err
-	}
-	trustCert, err := x509.ParseCertificate(trustBlock.Bytes)
-	if err != nil {
-		return nil, err
-	}
 	trustPool := x509.NewCertPool()
-	trustPool.AddCert(trustCert)
+	trustPool.AppendCertsFromPEM(trustData)
 	return trustPool, nil
 }

--- a/security/advancedtls/file_reader.go
+++ b/security/advancedtls/file_reader.go
@@ -23,7 +23,6 @@ import (
 	"crypto/x509"
 	"fmt"
 	"io/ioutil"
-	"time"
 )
 
 // PeerCredFileReader is an interface that supports reading
@@ -43,7 +42,6 @@ type TrustCredFileReader interface {
 type PemPeerCredFileReader struct {
 	certFilePath string
 	keyFilePath  string
-	interval     time.Duration
 }
 
 // PemPeerCredFileReaderOption contains all information needed to be filled out
@@ -51,29 +49,20 @@ type PemPeerCredFileReader struct {
 type PemPeerCredFileReaderOption struct {
 	CertFilePath string
 	KeyFilePath  string
-	Interval     time.Duration
 }
 
 // NewPemPeerCredFileReader uses PemPeerCredFileReaderOption
 // to contruct a PemPeerCredFileReader.
 func NewPemPeerCredFileReader(o PemPeerCredFileReaderOption) (*PemPeerCredFileReader, error) {
 	if o.CertFilePath == "" {
-		return nil, fmt.Errorf(
-			"users need to specify certificate file path in PemPeerCredFileReaderOption")
+		return nil, fmt.Errorf("users need to specify certificate file path in PemPeerCredFileReaderOption")
 	}
 	if o.KeyFilePath == "" {
-		return nil, fmt.Errorf(
-			"users need to specify key file path in PemPeerCredFileReaderOption")
-	}
-	// If interval is not set by users explicitly, set it to 1 hour by default.
-	interval := o.Interval
-	if interval == 0*time.Nanosecond {
-		interval = 1 * time.Hour
+		return nil, fmt.Errorf("users need to specify key file path in PemPeerCredFileReaderOption")
 	}
 	r := &PemPeerCredFileReader{
 		certFilePath: o.CertFilePath,
 		keyFilePath:  o.KeyFilePath,
-		interval:     interval,
 	}
 	return r, nil
 }
@@ -92,31 +81,22 @@ func (r PemPeerCredFileReader) ReadKeyAndCerts() (*tls.Certificate, error) {
 // PemTrustCredFileReader supports reading trust credential files of PEM format.
 type PemTrustCredFileReader struct {
 	trustCertPath string
-	interval      time.Duration
 }
 
 // PemTrustCredFileReaderOption contains all information needed to be filled out
 // by users in order to use NewPemTrustCredFileReader.
 type PemTrustCredFileReaderOption struct {
 	TrustCertPath string
-	Interval      time.Duration
 }
 
 // NewPemTrustCredFileReader uses PemTrustCredFileReaderOption
 // to contruct a PemTrustCredFileReader.
 func NewPemTrustCredFileReader(o PemTrustCredFileReaderOption) (*PemTrustCredFileReader, error) {
 	if o.TrustCertPath == "" {
-		return nil, fmt.Errorf(
-			"users need to specify key file path in PemTrustCredFileReaderOption")
-	}
-	// If interval is not set by users explicitly, set it to 1 hour by default.
-	interval := o.Interval
-	if interval == 0*time.Nanosecond {
-		interval = 1 * time.Hour
+		return nil, fmt.Errorf("users need to specify key file path in PemTrustCredFileReaderOption")
 	}
 	r := &PemTrustCredFileReader{
 		trustCertPath: o.TrustCertPath,
-		interval:      interval,
 	}
 	return r, nil
 }

--- a/security/advancedtls/go.mod
+++ b/security/advancedtls/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/golang/protobuf v1.3.5 // indirect
-	github.com/google/go-cmp v0.4.0 // indirect
+	github.com/google/go-cmp v0.4.0
 	golang.org/x/net v0.0.0-20200602114024-627f9648deb9 // indirect
 	golang.org/x/sys v0.0.0-20200602225109-6fdc65e7d980 // indirect
 	golang.org/x/text v0.3.3 // indirect


### PR DESCRIPTION
This PR added implementation and unit test for `PeerCredFileReader`, `TrustCredFileReader` and related structs and methods used in on-file-change credential reloading.

`PeerCredFileReader`, `TrustCredFileReader` are two interfaces that could support reading credential files of different formats. We provided implementation for reading PEM files as an default option, which are referred as `PemPeerCredFileReader` and `PemTrustCredFileReader`.

@ZhenLian 