### PR TITLE
xdsrouting: handle route fields in xds_client

### DIFF
--- a/xds/internal/client/client_watchers_rds.go
+++ b/xds/internal/client/client_watchers_rds.go
@@ -49,8 +49,8 @@ type Route struct {
 }
 
 type rdsUpdate struct {
-	// weightedCluster is only set when routing is disabled (not enabled) by env
-	// variable.
+	// weightedCluster is only set when routing is disabled (env variable
+	// GRPC_XDS_EXPERIMENTAL_ROUTING is not true).
 	weightedCluster map[string]uint32
 
 	routes []*Route

--- a/xds/internal/client/client_watchers_rds.go
+++ b/xds/internal/client/client_watchers_rds.go
@@ -40,8 +40,20 @@ type HeaderMatcher struct {
 	PresentMatch *bool       `json:"presentMatch,omitempty"`
 }
 
+// Route represents route with matchers and action.
+type Route struct {
+	Path, Prefix, Regex *string
+	Headers             []*HeaderMatcher
+	Fraction            *uint32
+	Action              map[string]uint32 // action is weighted clusters.
+}
+
 type rdsUpdate struct {
+	// weightedCluster is only set when routing is disabled (not enabled) by env
+	// variable.
 	weightedCluster map[string]uint32
+
+	routes []*Route
 }
 type rdsCallbackFunc func(rdsUpdate, error)
 

--- a/xds/internal/client/client_watchers_service.go
+++ b/xds/internal/client/client_watchers_service.go
@@ -27,7 +27,13 @@ import (
 type ServiceUpdate struct {
 	// WeightedCluster is a map from cluster names (CDS resource to watch) to
 	// their weights.
+	//
+	// This field is only set when routing is disabled (not enabled) by env
+	// variable.
 	WeightedCluster map[string]uint32
+
+	// Routes
+	Routes []*Route
 }
 
 // WatchService uses LDS and RDS to discover information about the provided
@@ -121,6 +127,7 @@ func (w *serviceUpdateWatcher) handleRDSResp(update rdsUpdate, err error) {
 	}
 	w.serviceCb(ServiceUpdate{
 		WeightedCluster: update.weightedCluster,
+		Routes:          update.routes,
 	}, nil)
 }
 

--- a/xds/internal/client/client_watchers_service.go
+++ b/xds/internal/client/client_watchers_service.go
@@ -28,8 +28,8 @@ type ServiceUpdate struct {
 	// WeightedCluster is a map from cluster names (CDS resource to watch) to
 	// their weights.
 	//
-	// This field is only set when routing is disabled (not enabled) by env
-	// variable.
+	// This field is only set when routing is disabled (env variable
+	// GRPC_XDS_EXPERIMENTAL_ROUTING is not true).
 	WeightedCluster map[string]uint32
 
 	// Routes

--- a/xds/internal/client/envconfig.go
+++ b/xds/internal/client/envconfig.go
@@ -23,6 +23,9 @@ import (
 	"strings"
 )
 
+// TODO: there are multiple env variables, GRPC_XDS_BOOTSTRAP and
+// GRPC_XDS_EXPERIMENTAL_V3_SUPPORT, and this. Move all env variables into a
+// separate package.
 const routingEnabledConfigStr = "GRPC_XDS_EXPERIMENTAL_ROUTING"
 
 // routing is enabled only if env variable is set to true. The default is false.

--- a/xds/internal/client/envconfig.go
+++ b/xds/internal/client/envconfig.go
@@ -1,0 +1,30 @@
+/*
+ *
+ * Copyright 2020 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package client
+
+import (
+	"os"
+	"strings"
+)
+
+const routingEnabledConfigStr = "GRPC_XDS_EXPERIMENTAL_ROUTING"
+
+// routing is enabled only if env variable is set to true. The default is false.
+// We may flip the default later.
+var routingEnabled = strings.EqualFold(os.Getenv(routingEnabledConfigStr), "true")

--- a/xds/internal/client/v2client_rds.go
+++ b/xds/internal/client/v2client_rds.go
@@ -24,6 +24,7 @@ import (
 
 	xdspb "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	routepb "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
+	typepb "github.com/envoyproxy/go-control-plane/envoy/type"
 	"github.com/golang/protobuf/ptypes"
 )
 
@@ -94,42 +95,154 @@ func generateRDSUpdateFromRouteConfiguration(rc *xdspb.RouteConfiguration, host 
 		// should be at least one default route.
 		return rdsUpdate{}, fmt.Errorf("matched virtual host has no routes")
 	}
-	dr := vh.Routes[len(vh.Routes)-1]
-	match := dr.GetMatch()
-	if match == nil {
-		return rdsUpdate{}, fmt.Errorf("matched virtual host's default route doesn't have a match")
-	}
-	if prefix := match.GetPrefix(); prefix != "" && prefix != "/" {
-		// The matched virtual host is invalid. Match is not "" or "/".
-		return rdsUpdate{}, fmt.Errorf("matched virtual host's default route is %v, want Prefix empty string or /", match)
-	}
-	if caseSensitive := match.GetCaseSensitive(); caseSensitive != nil && !caseSensitive.Value {
-		// The case sensitive is set to false. Not set or set to true are both
-		// valid.
-		return rdsUpdate{}, fmt.Errorf("matched virtual host's default route set case-sensitive to false")
-	}
-	route := dr.GetRoute()
-	if route == nil {
-		return rdsUpdate{}, fmt.Errorf("matched route is nil")
-	}
 
-	if wc := route.GetWeightedClusters(); wc != nil {
-		m, err := weightedClustersProtoToMap(wc)
-		if err != nil {
-			return rdsUpdate{}, fmt.Errorf("matched weighted cluster is invalid: %v", err)
+	// Keep the old code path for routing disabled.
+	if !routingEnabled {
+		dr := vh.Routes[len(vh.Routes)-1]
+		match := dr.GetMatch()
+		if match == nil {
+			return rdsUpdate{}, fmt.Errorf("matched virtual host's default route doesn't have a match")
 		}
-		return rdsUpdate{weightedCluster: m}, nil
+		if prefix := match.GetPrefix(); prefix != "" && prefix != "/" {
+			// The matched virtual host is invalid. Match is not "" or "/".
+			return rdsUpdate{}, fmt.Errorf("matched virtual host's default route is %v, want Prefix empty string or /", match)
+		}
+		if caseSensitive := match.GetCaseSensitive(); caseSensitive != nil && !caseSensitive.Value {
+			// The case sensitive is set to false. Not set or set to true are both
+			// valid.
+			return rdsUpdate{}, fmt.Errorf("matched virtual host's default route set case-sensitive to false")
+		}
+		route := dr.GetRoute()
+		if route == nil {
+			return rdsUpdate{}, fmt.Errorf("matched route is nil")
+		}
+
+		if wc := route.GetWeightedClusters(); wc != nil {
+			m, err := weightedClustersProtoToMap(wc)
+			if err != nil {
+				return rdsUpdate{}, fmt.Errorf("matched weighted cluster is invalid: %v", err)
+			}
+			return rdsUpdate{weightedCluster: m}, nil
+		}
+
+		// When there's just one cluster, we set weightedCluster to map with one
+		// entry. This mean we will build a weighted_target balancer even if there's
+		// just one cluster.
+		//
+		// Otherwise, we will need to switch the top policy between weighted_target
+		// and CDS. In case when the action changes between one cluster and multiple
+		// clusters, changing top level policy means recreating TCP connection every
+		// time.
+		return rdsUpdate{weightedCluster: map[string]uint32{route.GetCluster(): 1}}, nil
 	}
 
-	// When there's just one cluster, we set weightedCluster to map with one
-	// entry. This mean we will build a weighted_target balancer even if there's
-	// just one cluster.
-	//
-	// Otherwise, we will need to switch the top policy between weighted_target
-	// and CDS. In case when the action changes between one cluster and multiple
-	// clusters, changing top level policy means recreating TCP connection every
-	// time.
-	return rdsUpdate{weightedCluster: map[string]uint32{route.GetCluster(): 1}}, nil
+	routes, err := routesProtoToSlice(vh.Routes)
+	if err != nil {
+		return rdsUpdate{}, fmt.Errorf("received route is invalid: %v", err)
+	}
+	return rdsUpdate{routes: routes}, nil
+}
+
+func routesProtoToSlice(routes []*routepb.Route) ([]*Route, error) {
+	var routesRet []*Route
+
+	for _, route := range routes {
+		match := route.GetMatch()
+		if match == nil {
+			return nil, fmt.Errorf("route %v doesn't have a match", route)
+		}
+
+		if len(match.GetQueryParameters()) != 0 {
+			// Ignore route with query parameters.
+			continue
+		}
+
+		if caseSensitive := match.GetCaseSensitive(); caseSensitive != nil && !caseSensitive.Value {
+			return nil, fmt.Errorf("route %v has case-sensitive false", route)
+		}
+
+		var routeTemp Route
+
+		pathSp := match.GetPathSpecifier()
+		if pathSp == nil {
+			return nil, fmt.Errorf("route %v doesn't have a path specifier", route)
+		}
+		switch pt := pathSp.(type) {
+		case *routepb.RouteMatch_Prefix:
+			routeTemp.Prefix = &pt.Prefix
+		case *routepb.RouteMatch_Path:
+			routeTemp.Path = &pt.Path
+		case *routepb.RouteMatch_SafeRegex:
+			routeTemp.Regex = &pt.SafeRegex.Regex
+		case *routepb.RouteMatch_Regex:
+			return nil, fmt.Errorf("route %v has Regex, expected SafeRegex instead", route)
+		}
+
+		for _, header := range match.GetHeaders() {
+			var headerTemp HeaderMatcher
+			switch ht := header.GetHeaderMatchSpecifier().(type) {
+			case *routepb.HeaderMatcher_ExactMatch:
+				headerTemp.ExactMatch = &ht.ExactMatch
+			case *routepb.HeaderMatcher_SafeRegexMatch:
+				headerTemp.RegexMatch = &ht.SafeRegexMatch.Regex
+			case *routepb.HeaderMatcher_RangeMatch:
+				headerTemp.RangeMatch = &Int64Range{
+					Start: ht.RangeMatch.Start,
+					End:   ht.RangeMatch.End,
+				}
+			case *routepb.HeaderMatcher_PresentMatch:
+				headerTemp.PresentMatch = &ht.PresentMatch
+			case *routepb.HeaderMatcher_PrefixMatch:
+				headerTemp.PrefixMatch = &ht.PrefixMatch
+			case *routepb.HeaderMatcher_SuffixMatch:
+				headerTemp.SuffixMatch = &ht.SuffixMatch
+			case *routepb.HeaderMatcher_RegexMatch:
+				return nil, fmt.Errorf("route %v has a header matcher with Regex, expected SafeRegex instead", route)
+			default:
+				continue
+			}
+			headerTemp.Name = header.GetName()
+			invert := header.GetInvertMatch()
+			headerTemp.InvertMatch = &invert
+			routeTemp.Headers = append(routeTemp.Headers, &headerTemp)
+		}
+
+		if fr := match.GetRuntimeFraction(); fr != nil {
+			d := fr.GetDefaultValue()
+			n := d.GetNumerator()
+			switch d.GetDenominator() {
+			case typepb.FractionalPercent_HUNDRED:
+				n *= 10000
+			case typepb.FractionalPercent_TEN_THOUSAND:
+				n *= 100
+			case typepb.FractionalPercent_MILLION:
+			}
+			routeTemp.Fraction = &n
+		}
+
+		clusters := make(map[string]uint32)
+		switch a := route.GetRoute().GetClusterSpecifier().(type) {
+		case *routepb.RouteAction_Cluster:
+			clusters[a.Cluster] = 1
+		case *routepb.RouteAction_WeightedClusters:
+			wcs := a.WeightedClusters
+			var totalWeight uint32
+			for _, c := range wcs.Clusters {
+				w := c.GetWeight().GetValue()
+				clusters[c.GetName()] = w
+				totalWeight += w
+			}
+			if totalWeight != wcs.GetTotalWeight().GetValue() {
+				return nil, fmt.Errorf("route %v, action %v, weights of clusters do not add up to total total weight, got: %v, want %v", route, a, wcs.GetTotalWeight().GetValue(), totalWeight)
+			}
+		case *routepb.RouteAction_ClusterHeader:
+			continue
+		}
+
+		routeTemp.Action = clusters
+		routesRet = append(routesRet, &routeTemp)
+	}
+	return routesRet, nil
 }
 
 func weightedClustersProtoToMap(wc *routepb.WeightedCluster) (map[string]uint32, error) {

--- a/xds/internal/client/v2client_rds_test.go
+++ b/xds/internal/client/v2client_rds_test.go
@@ -579,7 +579,6 @@ func TestRoutesProtoToSlice(t *testing.T) {
 		{
 			name: "no path",
 			routes: []*routepb.Route{{
-				Name:  "",
 				Match: &routepb.RouteMatch{},
 			}},
 			wantErr: true,
@@ -587,7 +586,6 @@ func TestRoutesProtoToSlice(t *testing.T) {
 		{
 			name: "path is regex instead of saferegex",
 			routes: []*routepb.Route{{
-				Name: "",
 				Match: &routepb.RouteMatch{
 					PathSpecifier: &routepb.RouteMatch_Regex{Regex: "*"},
 				},
@@ -597,7 +595,6 @@ func TestRoutesProtoToSlice(t *testing.T) {
 		{
 			name: "header contains regex",
 			routes: []*routepb.Route{{
-				Name: "",
 				Match: &routepb.RouteMatch{
 					PathSpecifier: &routepb.RouteMatch_Prefix{Prefix: "/"},
 					Headers: []*routepb.HeaderMatcher{{
@@ -613,7 +610,6 @@ func TestRoutesProtoToSlice(t *testing.T) {
 		{
 			name: "case_sensitive is false",
 			routes: []*routepb.Route{{
-				Name: "",
 				Match: &routepb.RouteMatch{
 					PathSpecifier: &routepb.RouteMatch_Prefix{Prefix: "/"},
 					CaseSensitive: &wrapperspb.BoolValue{Value: false},
@@ -625,7 +621,6 @@ func TestRoutesProtoToSlice(t *testing.T) {
 			name: "good",
 			routes: []*routepb.Route{
 				{
-					Name: "",
 					Match: &routepb.RouteMatch{
 						PathSpecifier: &routepb.RouteMatch_Prefix{Prefix: "/a/"},
 						Headers: []*routepb.HeaderMatcher{
@@ -674,7 +669,6 @@ func TestRoutesProtoToSlice(t *testing.T) {
 			name: "query is ignored",
 			routes: []*routepb.Route{
 				{
-					Name: "",
 					Match: &routepb.RouteMatch{
 						PathSpecifier: &routepb.RouteMatch_Prefix{Prefix: "/a/"},
 					},

--- a/xds/internal/client/v2client_rds_test.go
+++ b/xds/internal/client/v2client_rds_test.go
@@ -223,7 +223,7 @@ func (s) TestRDSGenerateRDSUpdateFromRouteConfiguration(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			gotUpdate, gotError := generateRDSUpdateFromRouteConfiguration(test.rc, goodLDSTarget1)
+			gotUpdate, gotError := generateRDSUpdateFromRouteConfiguration(test.rc, goodLDSTarget1, nil)
 			if !cmp.Equal(gotUpdate, test.wantUpdate, cmp.AllowUnexported(rdsUpdate{})) || (gotError != nil) != test.wantError {
 				t.Errorf("generateRDSUpdateFromRouteConfiguration(%+v, %v) = %v, want %v", test.rc, goodLDSTarget1, gotUpdate, test.wantUpdate)
 			}
@@ -714,7 +714,7 @@ func TestRoutesProtoToSlice(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := routesProtoToSlice(tt.routes)
+			got, err := routesProtoToSlice(tt.routes, nil)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("routesProtoToSlice() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
All new fields are guarded by env variable `GRPC_XDS_EXPERIMENTAL_ROUTING`.

The client copies the content from RDS response to xds resolver. It doesn't do
too much processing on the content (e.g. split routes into routes+actions, and
reuse action names).  The xds resolver will do these when generating service
config.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grpc/grpc-go/3747)
<!-- Reviewable:end -->
