### PR TITLE
credentials/alts: Added error logging for isRunningOnGCP

### DIFF
--- a/credentials/alts/alts.go
+++ b/credentials/alts/alts.go
@@ -137,19 +137,24 @@ type altsTC struct {
 }
 
 // NewClientCreds constructs a client-side ALTS TransportCredentials object.
-func NewClientCreds(opts *ClientOptions) credentials.TransportCredentials {
+func NewClientCreds(opts *ClientOptions) (credentials.TransportCredentials, error) {
 	return newALTS(core.ClientSide, opts.TargetServiceAccounts, opts.HandshakerServiceAddress)
 }
 
 // NewServerCreds constructs a server-side ALTS TransportCredentials object.
-func NewServerCreds(opts *ServerOptions) credentials.TransportCredentials {
+func NewServerCreds(opts *ServerOptions) (credentials.TransportCredentials, error) {
 	return newALTS(core.ServerSide, nil, opts.HandshakerServiceAddress)
 }
 
-func newALTS(side core.Side, accounts []string, hsAddress string) credentials.TransportCredentials {
+func newALTS(side core.Side, accounts []string, hsAddress string) (credentials.TransportCredentials, error) {
+	var err error
+	err = nil
 	once.Do(func() {
-		vmOnGCP = isRunningOnGCP()
+		vmOnGCP, err = isRunningOnGCP()
 	})
+	if err != nil {
+		return nil, err
+	}
 
 	if hsAddress == "" {
 		hsAddress = hypervisorHandshakerServiceAddress
@@ -162,7 +167,7 @@ func newALTS(side core.Side, accounts []string, hsAddress string) credentials.Tr
 		side:      side,
 		accounts:  accounts,
 		hsAddress: hsAddress,
-	}
+	}, nil
 }
 
 // ClientHandshake implements the client side handshake protocol.

--- a/credentials/alts/alts_test.go
+++ b/credentials/alts/alts_test.go
@@ -38,7 +38,10 @@ func Test(t *testing.T) {
 func (s) TestInfoServerName(t *testing.T) {
 	// This is not testing any handshaker functionality, so it's fine to only
 	// use NewServerCreds and not NewClientCreds.
-	alts := NewServerCreds(DefaultServerOptions())
+	alts, err := NewServerCreds(DefaultServerOptions())
+	if err != nil {
+		t.Fatalf("failed to create new server creds: %v", err)
+	}
 	if got, want := alts.Info().ServerName, ""; got != want {
 		t.Fatalf("%v.Info().ServerName = %v, want %v", alts, got, want)
 	}
@@ -48,7 +51,10 @@ func (s) TestOverrideServerName(t *testing.T) {
 	wantServerName := "server.name"
 	// This is not testing any handshaker functionality, so it's fine to only
 	// use NewServerCreds and not NewClientCreds.
-	c := NewServerCreds(DefaultServerOptions())
+	c, err := NewServerCreds(DefaultServerOptions())
+	if err != nil {
+		t.Fatalf("failed to create new server creds: %v", err)
+	}
 	c.OverrideServerName(wantServerName)
 	if got, want := c.Info().ServerName, wantServerName; got != want {
 		t.Fatalf("c.Info().ServerName = %v, want %v", got, want)
@@ -59,7 +65,10 @@ func (s) TestCloneClient(t *testing.T) {
 	wantServerName := "server.name"
 	opt := DefaultClientOptions()
 	opt.TargetServiceAccounts = []string{"not", "empty"}
-	c := NewClientCreds(opt)
+	c, err := NewClientCreds(opt)
+	if err != nil {
+		t.Fatalf("failed to create new client creds: %v", err)
+	}
 	c.OverrideServerName(wantServerName)
 	cc := c.Clone()
 	if got, want := cc.Info().ServerName, wantServerName; got != want {
@@ -89,7 +98,10 @@ func (s) TestCloneClient(t *testing.T) {
 
 func (s) TestCloneServer(t *testing.T) {
 	wantServerName := "server.name"
-	c := NewServerCreds(DefaultServerOptions())
+	c, err := NewServerCreds(DefaultServerOptions())
+	if err != nil {
+		t.Fatalf("failed to create new server creds: %v", err)
+	}
 	c.OverrideServerName(wantServerName)
 	cc := c.Clone()
 	if got, want := cc.Info().ServerName, wantServerName; got != want {
@@ -120,7 +132,10 @@ func (s) TestCloneServer(t *testing.T) {
 func (s) TestInfo(t *testing.T) {
 	// This is not testing any handshaker functionality, so it's fine to only
 	// use NewServerCreds and not NewClientCreds.
-	c := NewServerCreds(DefaultServerOptions())
+	c, err := NewServerCreds(DefaultServerOptions())
+	if err != nil {
+		t.Fatalf("failed to create new server creds: %v", err)
+	}
 	info := c.Info()
 	if got, want := info.ProtocolVersion, ""; got != want {
 		t.Errorf("info.ProtocolVersion=%v, want %v", got, want)

--- a/credentials/alts/utils.go
+++ b/credentials/alts/utils.go
@@ -86,7 +86,7 @@ func isRunningOnGCP() (bool, error) {
 	manufacturer, err := readManufacturer()
 	if os.IsNotExist(err) {
 		return false, nil
-	},
+	}
 	if err != nil {
 		return false, status.Errorf(codes.Internal, "failed to read manufacturer information: %v", err)
 	}

--- a/credentials/alts/utils.go
+++ b/credentials/alts/utils.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
 	"os"
 	"os/exec"
 	"regexp"
@@ -83,28 +82,28 @@ var (
 
 // isRunningOnGCP checks whether the local system, without doing a network request is
 // running on GCP.
-func isRunningOnGCP() bool {
+func isRunningOnGCP() (bool, error) {
 	manufacturer, err := readManufacturer()
 	if os.IsNotExist(err) {
-		return false
+		return false, nil
 	}
 	if err != nil {
-		log.Fatalf("failure to read manufacturer information: %v", err)
+		return false, status.Errorf(codes.Internal, "failure to read manufacturer information: %v", err)
 	}
 	name := string(manufacturer)
 	switch runningOS {
 	case "linux":
 		name = strings.TrimSpace(name)
-		return name == "Google" || name == "Google Compute Engine"
+		return name == "Google" || name == "Google Compute Engine", nil
 	case "windows":
 		name = strings.Replace(name, " ", "", -1)
 		name = strings.Replace(name, "\n", "", -1)
 		name = strings.Replace(name, "\r", "", -1)
-		return name == "Google"
+		return name == "Google", nil
 	default:
-		log.Fatal(platformError(runningOS))
+		return false, platformError(runningOS)
 	}
-	return false
+	return false, nil
 }
 
 func readManufacturer() ([]byte, error) {

--- a/credentials/alts/utils.go
+++ b/credentials/alts/utils.go
@@ -103,7 +103,6 @@ func isRunningOnGCP() (bool, error) {
 	default:
 		return false, platformError(runningOS)
 	}
-	return false, nil
 }
 
 func readManufacturer() ([]byte, error) {

--- a/credentials/alts/utils.go
+++ b/credentials/alts/utils.go
@@ -86,9 +86,9 @@ func isRunningOnGCP() (bool, error) {
 	manufacturer, err := readManufacturer()
 	if os.IsNotExist(err) {
 		return false, nil
-	}
+	},
 	if err != nil {
-		return false, status.Errorf(codes.Internal, "failure to read manufacturer information: %v", err)
+		return false, status.Errorf(codes.Internal, "failed to read manufacturer information: %v", err)
 	}
 	name := string(manufacturer)
 	switch runningOS {
@@ -101,7 +101,7 @@ func isRunningOnGCP() (bool, error) {
 		name = strings.Replace(name, "\r", "", -1)
 		return name == "Google", nil
 	default:
-		return false, platformError(runningOS)
+		return false, nil
 	}
 }
 

--- a/credentials/alts/utils_test.go
+++ b/credentials/alts/utils_test.go
@@ -83,7 +83,8 @@ func (s) TestIsRunningOnGCP(t *testing.T) {
 		{"windows: GCP platform (Google) with extra spaces", "windows", strings.NewReader("  Google     "), true},
 	} {
 		reverseFunc := setup(tc.testOS, tc.testReader)
-		if got, want := isRunningOnGCP(), tc.out; got != want {
+		got, _ := isRunningOnGCP()
+		if want := tc.out; got != want {
 			t.Errorf("%v: isRunningOnGCP()=%v, want %v", tc.description, got, want)
 		}
 		reverseFunc()
@@ -92,7 +93,7 @@ func (s) TestIsRunningOnGCP(t *testing.T) {
 
 func (s) TestIsRunningOnGCPNoProductNameFile(t *testing.T) {
 	reverseFunc := setupError("linux", os.ErrNotExist)
-	if isRunningOnGCP() {
+	if result, _ := isRunningOnGCP(); result {
 		t.Errorf("ErrNotExist: isRunningOnGCP()=true, want false")
 	}
 	reverseFunc()

--- a/credentials/alts/utils_test.go
+++ b/credentials/alts/utils_test.go
@@ -97,8 +97,8 @@ func (s) TestIsRunningOnGCP(t *testing.T) {
 
 func (s) TestIsRunningOnGCPNoProductNameFile(t *testing.T) {
 	reverseFunc := setupError("linux", os.ErrNotExist)
-	if result, _ := isRunningOnGCP(); result {
-		t.Errorf("ErrNotExist: isRunningOnGCP()=true, want false")
+	if result, err := isRunningOnGCP(); err != nil || result {
+		t.Errorf("ErrNotExist: isRunningOnGCP()=true or returned error, want false")
 	}
 	reverseFunc()
 }

--- a/credentials/alts/utils_test.go
+++ b/credentials/alts/utils_test.go
@@ -81,10 +81,14 @@ func (s) TestIsRunningOnGCP(t *testing.T) {
 		{"windows: not a GCP platform", "windows", strings.NewReader("not GCP"), false},
 		{"windows: GCP platform (Google)", "windows", strings.NewReader("Google"), true},
 		{"windows: GCP platform (Google) with extra spaces", "windows", strings.NewReader("  Google     "), true},
+		// MacOS tests.
+		{"MacOS: not a GCP platform", "macos", strings.NewReader("not GCP"), false},
+		{"MacOS: GCP platform (Google)", "macos", strings.NewReader("Google"), false},
+		{"MacOS: GCP platform (Google) with extra spaces", "macos", strings.NewReader("  Google     "), false},
 	} {
 		reverseFunc := setup(tc.testOS, tc.testReader)
-		got, _ := isRunningOnGCP()
-		if want := tc.out; got != want {
+		got, err := isRunningOnGCP()
+		if want := tc.out; err != nil || got != want {
 			t.Errorf("%v: isRunningOnGCP()=%v, want %v", tc.description, got, want)
 		}
 		reverseFunc()

--- a/credentials/google/google.go
+++ b/credentials/google/google.go
@@ -112,7 +112,11 @@ func (c *creds) NewWithMode(mode string) (credentials.Bundle, error) {
 	case internal.CredsBundleModeBackendFromBalancer, internal.CredsBundleModeBalancer:
 		// Only the clients can use google default credentials, so we only need
 		// to create new ALTS client creds here.
-		newCreds.transportCreds = alts.NewClientCreds(alts.DefaultClientOptions())
+		creds, err := alts.NewClientCreds(alts.DefaultClientOptions())
+		newCreds.transportCreds = creds
+		if err != nil {
+			return nil, fmt.Errorf("failed to create new client credentials: %v", err)
+		}
 	default:
 		return nil, fmt.Errorf("unsupported mode: %v", mode)
 	}

--- a/credentials/google/google.go
+++ b/credentials/google/google.go
@@ -113,10 +113,10 @@ func (c *creds) NewWithMode(mode string) (credentials.Bundle, error) {
 		// Only the clients can use google default credentials, so we only need
 		// to create new ALTS client creds here.
 		creds, err := alts.NewClientCreds(alts.DefaultClientOptions())
-		newCreds.transportCreds = creds
 		if err != nil {
 			return nil, fmt.Errorf("failed to create new client credentials: %v", err)
 		}
+		newCreds.transportCreds = creds
 	default:
 		return nil, fmt.Errorf("unsupported mode: %v", mode)
 	}

--- a/examples/features/encryption/ALTS/client/main.go
+++ b/examples/features/encryption/ALTS/client/main.go
@@ -47,7 +47,10 @@ func main() {
 	flag.Parse()
 
 	// Create alts based credential.
-	altsTC := alts.NewClientCreds(alts.DefaultClientOptions())
+	altsTC, err := alts.NewClientCreds(alts.DefaultClientOptions())
+	if err != nil {
+		log.Fatalf("failed to create new client credentials: %v", err)
+	}
 
 	// Set up a connection to the server.
 	conn, err := grpc.Dial(*addr, grpc.WithTransportCredentials(altsTC), grpc.WithBlock())

--- a/examples/features/encryption/ALTS/server/main.go
+++ b/examples/features/encryption/ALTS/server/main.go
@@ -50,14 +50,17 @@ func main() {
 		log.Fatalf("failed to listen: %v", err)
 	}
 	// Create alts based credential.
-	altsTC := alts.NewServerCreds(alts.DefaultServerOptions())
+	altsTC, err := alts.NewServerCreds(alts.DefaultServerOptions())
+	if err != nil {
+		log.Fatalf("failed to create new server credentials: %v", err)
+	}
 
 	s := grpc.NewServer(grpc.Creds(altsTC))
 
 	// Register EchoServer on the server.
 	pb.RegisterEchoServer(s, &ecServer{})
 
-	if err := s.Serve(lis); err != nil {
+	if err = s.Serve(lis); err != nil {
 		log.Fatalf("failed to serve: %v", err)
 	}
 }

--- a/examples/features/encryption/ALTS/server/main.go
+++ b/examples/features/encryption/ALTS/server/main.go
@@ -60,7 +60,7 @@ func main() {
 	// Register EchoServer on the server.
 	pb.RegisterEchoServer(s, &ecServer{})
 
-	if err = s.Serve(lis); err != nil {
+	if err := s.Serve(lis); err != nil {
 		log.Fatalf("failed to serve: %v", err)
 	}
 }

--- a/interop/alts/client/client.go
+++ b/interop/alts/client/client.go
@@ -44,7 +44,7 @@ func main() {
 	}
 	altsTC, err := alts.NewClientCreds(opts)
 	if err != nil {
-		grpclog.Fatalf("Failed to create new client credentials: %v", err)
+		grpclog.Fatalf("failed to create new client credentials: %v", err)
 	}
 	// Block until the server is ready.
 	conn, err := grpc.Dial(*serverAddr, grpc.WithTransportCredentials(altsTC), grpc.WithBlock())

--- a/interop/alts/client/client.go
+++ b/interop/alts/client/client.go
@@ -42,7 +42,10 @@ func main() {
 	if *hsAddr != "" {
 		opts.HandshakerServiceAddress = *hsAddr
 	}
-	altsTC := alts.NewClientCreds(opts)
+	altsTC, err := alts.NewClientCreds(opts)
+	if err != nil {
+		grpclog.Fatalf("Failed to create new client credentials: %v", err)
+	}
 	// Block until the server is ready.
 	conn, err := grpc.Dial(*serverAddr, grpc.WithTransportCredentials(altsTC), grpc.WithBlock())
 	if err != nil {

--- a/interop/alts/server/server.go
+++ b/interop/alts/server/server.go
@@ -60,7 +60,10 @@ func main() {
 	if *hsAddr != "" {
 		opts.HandshakerServiceAddress = *hsAddr
 	}
-	altsTC := alts.NewServerCreds(opts)
+	altsTC, err := alts.NewServerCreds(opts)
+	if err != nil {
+		grpclog.Fatalf("Failed to create new server credentials: %v", err)
+	}
 	grpcServer := grpc.NewServer(grpc.Creds(altsTC), grpc.InTapHandle(authz))
 	testpb.RegisterTestServiceServer(grpcServer, interop.NewTestServer())
 	grpcServer.Serve(lis)

--- a/interop/alts/server/server.go
+++ b/interop/alts/server/server.go
@@ -62,7 +62,7 @@ func main() {
 	}
 	altsTC, err := alts.NewServerCreds(opts)
 	if err != nil {
-		grpclog.Fatalf("Failed to create new server credentials: %v", err)
+		grpclog.Fatalf("failed to create new server credentials: %v", err)
 	}
 	grpcServer := grpc.NewServer(grpc.Creds(altsTC), grpc.InTapHandle(authz))
 	testpb.RegisterTestServiceServer(grpcServer, interop.NewTestServer())

--- a/interop/client/client.go
+++ b/interop/client/client.go
@@ -150,7 +150,10 @@ func main() {
 		if *altsHSAddr != "" {
 			altsOpts.HandshakerServiceAddress = *altsHSAddr
 		}
-		altsTC := alts.NewClientCreds(altsOpts)
+		altsTC, err := alts.NewClientCreds(altsOpts)
+		if err != nil {
+			grpclog.Fatalf("Failed to create new client credentials: %v", err)
+		}
 		opts = append(opts, grpc.WithTransportCredentials(altsTC))
 	case credsGoogleDefaultCreds:
 		opts = append(opts, grpc.WithCredentialsBundle(google.NewDefaultCredentials()))

--- a/interop/fake_grpclb/fake_grpclb.go
+++ b/interop/fake_grpclb/fake_grpclb.go
@@ -121,7 +121,10 @@ func main() {
 		opts = append(opts, grpc.Creds(creds))
 	} else if *useALTS {
 		altsOpts := alts.DefaultServerOptions()
-		altsTC := alts.NewServerCreds(altsOpts)
+		altsTC, err := alts.NewServerCreds(altsOpts)
+		if err != nil {
+			grpclog.Fatalf("Failed to create new server credentials: %v", err)
+		}
 		opts = append(opts, grpc.Creds(altsTC))
 	}
 	var serverList []*lbpb.Server

--- a/interop/grpclb_fallback/client.go
+++ b/interop/grpclb_fallback/client.go
@@ -107,7 +107,10 @@ func createTestConn() *grpc.ClientConn {
 		creds := credentials.NewClientTLSFromCert(nil, "")
 		opts = append(opts, grpc.WithTransportCredentials(creds))
 	case "alts":
-		creds := alts.NewClientCreds(alts.DefaultClientOptions())
+		creds, err := alts.NewClientCreds(alts.DefaultClientOptions())
+		if err != nil {
+			errorLog.Fatalf("Failed to create new client credentials: %v", err)
+		}
 		opts = append(opts, grpc.WithTransportCredentials(creds))
 	case "google_default_credentials":
 		opts = append(opts, grpc.WithCredentialsBundle(google.NewDefaultCredentials()))

--- a/interop/server/server.go
+++ b/interop/server/server.go
@@ -70,7 +70,10 @@ func main() {
 		if *altsHSAddr != "" {
 			altsOpts.HandshakerServiceAddress = *altsHSAddr
 		}
-		altsTC := alts.NewServerCreds(altsOpts)
+		altsTC, err := alts.NewServerCreds(altsOpts)
+		if err != nil {
+			grpclog.Fatalf("Failed to create new server credentials: %v", err)
+		}
 		opts = append(opts, grpc.Creds(altsTC))
 	}
 	server := grpc.NewServer(opts...)


### PR DESCRIPTION
@ZhenLian 
Currently, `isRunningOnGCP` doesn’t return any errors. However, there are reasons that it will fail, which causes `log.Fatal`. This PR enables the function to return error, avoiding any `log.Fatal` calls and changes everything along the call path of this function.