### PR TITLE
examples: break from 'PerRPCCredsCallOption' status checking loop

### DIFF
--- a/examples/features/interceptor/client/main.go
+++ b/examples/features/interceptor/client/main.go
@@ -93,6 +93,7 @@ func streamInterceptor(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.Clie
 		_, ok := o.(*grpc.PerRPCCredsCallOption)
 		if ok {
 			credsConfigured = true
+			break
 		}
 	}
 	if !credsConfigured {


### PR DESCRIPTION
If *grpc.PerRPCCredsCallOption is not found in the option array then change credentialConfigStatus to true and break from the loop. No need to iterate further.