### PR TITLE
xds: Pass WatchExpiryTimeout to Client via Options.

### DIFF
--- a/xds/internal/client/client_test.go
+++ b/xds/internal/client/client_test.go
@@ -116,7 +116,7 @@ func (s) TestWatchCallAnotherWatch(t *testing.T) {
 	v2ClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	c, err := New(clientOpts(testXDSServer, false /* overrideWatchExpiryTimeout */))
+	c, err := New(clientOpts(testXDSServer, false))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}

--- a/xds/internal/client/client_test.go
+++ b/xds/internal/client/client_test.go
@@ -45,15 +45,22 @@ const (
 	testRDSName = "test-rds"
 	testCDSName = "test-cds"
 	testEDSName = "test-eds"
+
+	defaultTestWatchExpiryTimeout = 500 * time.Millisecond
 )
 
-func clientOpts(balancerName string) Options {
+func clientOpts(balancerName string, overrideWatchExpiryTImeout bool) Options {
+	watchExpiryTimeout := time.Duration(0)
+	if overrideWatchExpiryTImeout {
+		watchExpiryTimeout = defaultTestWatchExpiryTimeout
+	}
 	return Options{
 		Config: bootstrap.Config{
 			BalancerName: balancerName,
 			Creds:        grpc.WithInsecure(),
 			NodeProto:    testutils.EmptyNodeProtoV2,
 		},
+		WatchExpiryTimeout: watchExpiryTimeout,
 	}
 }
 
@@ -109,7 +116,7 @@ func (s) TestWatchCallAnotherWatch(t *testing.T) {
 	v2ClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	c, err := New(clientOpts(testXDSServer))
+	c, err := New(clientOpts(testXDSServer, false /* overrideWatchExpiryTimeout */))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}

--- a/xds/internal/client/client_watchers.go
+++ b/xds/internal/client/client_watchers.go
@@ -26,10 +26,6 @@ import (
 	"google.golang.org/grpc/xds/internal/version"
 )
 
-// The value chosen here is based on the default value of the
-// initial_fetch_timeout field in corepb.ConfigSource proto.
-var defaultWatchExpiryTimeout = 15 * time.Second
-
 type watchInfoState int
 
 const (
@@ -222,7 +218,7 @@ func (c *Client) watchLDS(serviceName string, cb func(ListenerUpdate, error)) (c
 		ldsCallback: cb,
 	}
 
-	wi.expiryTimer = time.AfterFunc(defaultWatchExpiryTimeout, func() {
+	wi.expiryTimer = time.AfterFunc(c.opts.WatchExpiryTimeout, func() {
 		wi.timeout()
 	})
 	return c.watch(wi)
@@ -241,7 +237,7 @@ func (c *Client) watchRDS(routeName string, cb func(RouteConfigUpdate, error)) (
 		rdsCallback: cb,
 	}
 
-	wi.expiryTimer = time.AfterFunc(defaultWatchExpiryTimeout, func() {
+	wi.expiryTimer = time.AfterFunc(c.opts.WatchExpiryTimeout, func() {
 		wi.timeout()
 	})
 	return c.watch(wi)
@@ -367,7 +363,7 @@ func (c *Client) WatchCluster(clusterName string, cb func(ClusterUpdate, error))
 		cdsCallback: cb,
 	}
 
-	wi.expiryTimer = time.AfterFunc(defaultWatchExpiryTimeout, func() {
+	wi.expiryTimer = time.AfterFunc(c.opts.WatchExpiryTimeout, func() {
 		wi.timeout()
 	})
 	return c.watch(wi)
@@ -389,7 +385,7 @@ func (c *Client) WatchEndpoints(clusterName string, cb func(EndpointsUpdate, err
 		edsCallback: cb,
 	}
 
-	wi.expiryTimer = time.AfterFunc(defaultWatchExpiryTimeout, func() {
+	wi.expiryTimer = time.AfterFunc(c.opts.WatchExpiryTimeout, func() {
 		wi.timeout()
 	})
 	return c.watch(wi)

--- a/xds/internal/client/client_watchers_cluster_test.go
+++ b/xds/internal/client/client_watchers_cluster_test.go
@@ -20,7 +20,6 @@ package client
 
 import (
 	"testing"
-	"time"
 
 	"google.golang.org/grpc/xds/internal/testutils"
 	"google.golang.org/grpc/xds/internal/version"
@@ -39,7 +38,7 @@ func (s) TestClusterWatch(t *testing.T) {
 	v2ClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	c, err := New(clientOpts(testXDSServer))
+	c, err := New(clientOpts(testXDSServer, false /* overrideWatchExpiryTimeout */))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
@@ -100,7 +99,7 @@ func (s) TestClusterTwoWatchSameResourceName(t *testing.T) {
 	v2ClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	c, err := New(clientOpts(testXDSServer))
+	c, err := New(clientOpts(testXDSServer, false /* overrideWatchExpiryTimeout */))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
@@ -109,10 +108,9 @@ func (s) TestClusterTwoWatchSameResourceName(t *testing.T) {
 	v2Client := <-v2ClientCh
 
 	var clusterUpdateChs []*testutils.Channel
-	const count = 2
-
 	var cancelLastWatch func()
 
+	const count = 2
 	for i := 0; i < count; i++ {
 		clusterUpdateCh := testutils.NewChannel()
 		clusterUpdateChs = append(clusterUpdateChs, clusterUpdateCh)
@@ -158,7 +156,7 @@ func (s) TestClusterThreeWatchDifferentResourceName(t *testing.T) {
 	v2ClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	c, err := New(clientOpts(testXDSServer))
+	c, err := New(clientOpts(testXDSServer, false /* overrideWatchExpiryTimeout */))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
@@ -214,7 +212,7 @@ func (s) TestClusterWatchAfterCache(t *testing.T) {
 	v2ClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	c, err := New(clientOpts(testXDSServer))
+	c, err := New(clientOpts(testXDSServer, false /* overrideWatchExpiryTimeout */))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
@@ -263,16 +261,10 @@ func (s) TestClusterWatchAfterCache(t *testing.T) {
 // an CDS response for the request that it sends out. We want the watch callback
 // to be invoked with an error once the watchExpiryTimer fires.
 func (s) TestClusterWatchExpiryTimer(t *testing.T) {
-	oldWatchExpiryTimeout := defaultWatchExpiryTimeout
-	defaultWatchExpiryTimeout = 500 * time.Millisecond
-	defer func() {
-		defaultWatchExpiryTimeout = oldWatchExpiryTimeout
-	}()
-
 	v2ClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	c, err := New(clientOpts(testXDSServer))
+	c, err := New(clientOpts(testXDSServer, true /* overrideWatchExpiryTimeout */))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
@@ -288,7 +280,7 @@ func (s) TestClusterWatchExpiryTimer(t *testing.T) {
 		t.Fatalf("want new watch to start, got error %v", err)
 	}
 
-	u, err := clusterUpdateCh.TimedReceive(defaultWatchExpiryTimeout * 2)
+	u, err := clusterUpdateCh.TimedReceive(defaultTestWatchExpiryTimeout * 2)
 	if err != nil {
 		t.Fatalf("failed to get clusterUpdate: %v", err)
 	}
@@ -305,16 +297,10 @@ func (s) TestClusterWatchExpiryTimer(t *testing.T) {
 // an CDS response for the request that it sends out. We want no error even
 // after expiry timeout.
 func (s) TestClusterWatchExpiryTimerStop(t *testing.T) {
-	oldWatchExpiryTimeout := defaultWatchExpiryTimeout
-	defaultWatchExpiryTimeout = 500 * time.Millisecond
-	defer func() {
-		defaultWatchExpiryTimeout = oldWatchExpiryTimeout
-	}()
-
 	v2ClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	c, err := New(clientOpts(testXDSServer))
+	c, err := New(clientOpts(testXDSServer, true /* overrideWatchExpiryTimeout */))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
@@ -340,7 +326,7 @@ func (s) TestClusterWatchExpiryTimerStop(t *testing.T) {
 	}
 
 	// Wait for an error, the error should never happen.
-	u, err := clusterUpdateCh.TimedReceive(defaultWatchExpiryTimeout * 2)
+	u, err := clusterUpdateCh.TimedReceive(defaultTestWatchExpiryTimeout * 2)
 	if err != testutils.ErrRecvTimeout {
 		t.Fatalf("got unexpected: %v, %v, want recv timeout", u.(clusterUpdateErr).u, u.(clusterUpdateErr).err)
 	}
@@ -356,7 +342,7 @@ func (s) TestClusterResourceRemoved(t *testing.T) {
 	v2ClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	c, err := New(clientOpts(testXDSServer))
+	c, err := New(clientOpts(testXDSServer, false /* overrideWatchExpiryTimeout */))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}

--- a/xds/internal/client/client_watchers_cluster_test.go
+++ b/xds/internal/client/client_watchers_cluster_test.go
@@ -38,7 +38,7 @@ func (s) TestClusterWatch(t *testing.T) {
 	v2ClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	c, err := New(clientOpts(testXDSServer, false /* overrideWatchExpiryTimeout */))
+	c, err := New(clientOpts(testXDSServer, false))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
@@ -99,7 +99,7 @@ func (s) TestClusterTwoWatchSameResourceName(t *testing.T) {
 	v2ClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	c, err := New(clientOpts(testXDSServer, false /* overrideWatchExpiryTimeout */))
+	c, err := New(clientOpts(testXDSServer, false))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
@@ -156,7 +156,7 @@ func (s) TestClusterThreeWatchDifferentResourceName(t *testing.T) {
 	v2ClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	c, err := New(clientOpts(testXDSServer, false /* overrideWatchExpiryTimeout */))
+	c, err := New(clientOpts(testXDSServer, false))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
@@ -212,7 +212,7 @@ func (s) TestClusterWatchAfterCache(t *testing.T) {
 	v2ClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	c, err := New(clientOpts(testXDSServer, false /* overrideWatchExpiryTimeout */))
+	c, err := New(clientOpts(testXDSServer, false))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
@@ -264,7 +264,7 @@ func (s) TestClusterWatchExpiryTimer(t *testing.T) {
 	v2ClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	c, err := New(clientOpts(testXDSServer, true /* overrideWatchExpiryTimeout */))
+	c, err := New(clientOpts(testXDSServer, true))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
@@ -300,7 +300,7 @@ func (s) TestClusterWatchExpiryTimerStop(t *testing.T) {
 	v2ClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	c, err := New(clientOpts(testXDSServer, true /* overrideWatchExpiryTimeout */))
+	c, err := New(clientOpts(testXDSServer, true))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
@@ -342,7 +342,7 @@ func (s) TestClusterResourceRemoved(t *testing.T) {
 	v2ClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	c, err := New(clientOpts(testXDSServer, false /* overrideWatchExpiryTimeout */))
+	c, err := New(clientOpts(testXDSServer, false))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}

--- a/xds/internal/client/client_watchers_endpoints_test.go
+++ b/xds/internal/client/client_watchers_endpoints_test.go
@@ -59,7 +59,7 @@ func (s) TestEndpointsWatch(t *testing.T) {
 	v2ClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	c, err := New(clientOpts(testXDSServer, false /* overrideWatchExpiryTimeout */))
+	c, err := New(clientOpts(testXDSServer, false))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
@@ -110,7 +110,7 @@ func (s) TestEndpointsTwoWatchSameResourceName(t *testing.T) {
 	v2ClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	c, err := New(clientOpts(testXDSServer, false /* overrideWatchExpiryTimeout */))
+	c, err := New(clientOpts(testXDSServer, false))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
@@ -168,7 +168,7 @@ func (s) TestEndpointsThreeWatchDifferentResourceName(t *testing.T) {
 	v2ClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	c, err := New(clientOpts(testXDSServer, false /* overrideWatchExpiryTimeout */))
+	c, err := New(clientOpts(testXDSServer, false))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
@@ -224,7 +224,7 @@ func (s) TestEndpointsWatchAfterCache(t *testing.T) {
 	v2ClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	c, err := New(clientOpts(testXDSServer, false /* overrideWatchExpiryTimeout */))
+	c, err := New(clientOpts(testXDSServer, false))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
@@ -276,7 +276,7 @@ func (s) TestEndpointsWatchExpiryTimer(t *testing.T) {
 	v2ClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	c, err := New(clientOpts(testXDSServer, true /* overrideWatchExpiryTimeout */))
+	c, err := New(clientOpts(testXDSServer, true))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}

--- a/xds/internal/client/client_watchers_endpoints_test.go
+++ b/xds/internal/client/client_watchers_endpoints_test.go
@@ -20,7 +20,6 @@ package client
 
 import (
 	"testing"
-	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -60,7 +59,7 @@ func (s) TestEndpointsWatch(t *testing.T) {
 	v2ClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	c, err := New(clientOpts(testXDSServer))
+	c, err := New(clientOpts(testXDSServer, false /* overrideWatchExpiryTimeout */))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
@@ -111,7 +110,7 @@ func (s) TestEndpointsTwoWatchSameResourceName(t *testing.T) {
 	v2ClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	c, err := New(clientOpts(testXDSServer))
+	c, err := New(clientOpts(testXDSServer, false /* overrideWatchExpiryTimeout */))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
@@ -169,7 +168,7 @@ func (s) TestEndpointsThreeWatchDifferentResourceName(t *testing.T) {
 	v2ClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	c, err := New(clientOpts(testXDSServer))
+	c, err := New(clientOpts(testXDSServer, false /* overrideWatchExpiryTimeout */))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
@@ -225,7 +224,7 @@ func (s) TestEndpointsWatchAfterCache(t *testing.T) {
 	v2ClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	c, err := New(clientOpts(testXDSServer))
+	c, err := New(clientOpts(testXDSServer, false /* overrideWatchExpiryTimeout */))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
@@ -274,16 +273,10 @@ func (s) TestEndpointsWatchAfterCache(t *testing.T) {
 // an CDS response for the request that it sends out. We want the watch callback
 // to be invoked with an error once the watchExpiryTimer fires.
 func (s) TestEndpointsWatchExpiryTimer(t *testing.T) {
-	oldWatchExpiryTimeout := defaultWatchExpiryTimeout
-	defaultWatchExpiryTimeout = 500 * time.Millisecond
-	defer func() {
-		defaultWatchExpiryTimeout = oldWatchExpiryTimeout
-	}()
-
 	v2ClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	c, err := New(clientOpts(testXDSServer))
+	c, err := New(clientOpts(testXDSServer, true /* overrideWatchExpiryTimeout */))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
@@ -299,7 +292,7 @@ func (s) TestEndpointsWatchExpiryTimer(t *testing.T) {
 		t.Fatalf("want new watch to start, got error %v", err)
 	}
 
-	u, err := endpointsUpdateCh.TimedReceive(defaultWatchExpiryTimeout * 2)
+	u, err := endpointsUpdateCh.TimedReceive(defaultTestWatchExpiryTimeout * 2)
 	if err != nil {
 		t.Fatalf("failed to get endpointsUpdate: %v", err)
 	}

--- a/xds/internal/client/client_watchers_lds_test.go
+++ b/xds/internal/client/client_watchers_lds_test.go
@@ -38,7 +38,7 @@ func (s) TestLDSWatch(t *testing.T) {
 	v2ClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	c, err := New(clientOpts(testXDSServer, false /* overrideWatchExpiryTimeout */))
+	c, err := New(clientOpts(testXDSServer, false))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
@@ -90,7 +90,7 @@ func (s) TestLDSTwoWatchSameResourceName(t *testing.T) {
 	v2ClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	c, err := New(clientOpts(testXDSServer, false /* overrideWatchExpiryTimeout */))
+	c, err := New(clientOpts(testXDSServer, false))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
@@ -148,7 +148,7 @@ func (s) TestLDSThreeWatchDifferentResourceName(t *testing.T) {
 	v2ClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	c, err := New(clientOpts(testXDSServer, false /* overrideWatchExpiryTimeout */))
+	c, err := New(clientOpts(testXDSServer, false))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
@@ -204,7 +204,7 @@ func (s) TestLDSWatchAfterCache(t *testing.T) {
 	v2ClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	c, err := New(clientOpts(testXDSServer, false /* overrideWatchExpiryTimeout */))
+	c, err := New(clientOpts(testXDSServer, false))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
@@ -259,7 +259,7 @@ func (s) TestLDSResourceRemoved(t *testing.T) {
 	v2ClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	c, err := New(clientOpts(testXDSServer, false /* overrideWatchExpiryTimeout */))
+	c, err := New(clientOpts(testXDSServer, false))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}

--- a/xds/internal/client/client_watchers_lds_test.go
+++ b/xds/internal/client/client_watchers_lds_test.go
@@ -38,7 +38,7 @@ func (s) TestLDSWatch(t *testing.T) {
 	v2ClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	c, err := New(clientOpts(testXDSServer))
+	c, err := New(clientOpts(testXDSServer, false /* overrideWatchExpiryTimeout */))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
@@ -90,7 +90,7 @@ func (s) TestLDSTwoWatchSameResourceName(t *testing.T) {
 	v2ClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	c, err := New(clientOpts(testXDSServer))
+	c, err := New(clientOpts(testXDSServer, false /* overrideWatchExpiryTimeout */))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
@@ -148,7 +148,7 @@ func (s) TestLDSThreeWatchDifferentResourceName(t *testing.T) {
 	v2ClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	c, err := New(clientOpts(testXDSServer))
+	c, err := New(clientOpts(testXDSServer, false /* overrideWatchExpiryTimeout */))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
@@ -204,7 +204,7 @@ func (s) TestLDSWatchAfterCache(t *testing.T) {
 	v2ClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	c, err := New(clientOpts(testXDSServer))
+	c, err := New(clientOpts(testXDSServer, false /* overrideWatchExpiryTimeout */))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
@@ -259,7 +259,7 @@ func (s) TestLDSResourceRemoved(t *testing.T) {
 	v2ClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	c, err := New(clientOpts(testXDSServer))
+	c, err := New(clientOpts(testXDSServer, false /* overrideWatchExpiryTimeout */))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}

--- a/xds/internal/client/client_watchers_rds_test.go
+++ b/xds/internal/client/client_watchers_rds_test.go
@@ -39,7 +39,7 @@ func (s) TestRDSWatch(t *testing.T) {
 	v2ClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	c, err := New(clientOpts(testXDSServer, false /* overrideWatchExpiryTimeout */))
+	c, err := New(clientOpts(testXDSServer, false))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
@@ -90,7 +90,7 @@ func (s) TestRDSTwoWatchSameResourceName(t *testing.T) {
 	v2ClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	c, err := New(clientOpts(testXDSServer, false /* overrideWatchExpiryTimeout */))
+	c, err := New(clientOpts(testXDSServer, false))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
@@ -148,7 +148,7 @@ func (s) TestRDSThreeWatchDifferentResourceName(t *testing.T) {
 	v2ClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	c, err := New(clientOpts(testXDSServer, false /* overrideWatchExpiryTimeout */))
+	c, err := New(clientOpts(testXDSServer, false))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
@@ -204,7 +204,7 @@ func (s) TestRDSWatchAfterCache(t *testing.T) {
 	v2ClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	c, err := New(clientOpts(testXDSServer, false /* overrideWatchExpiryTimeout */))
+	c, err := New(clientOpts(testXDSServer, false))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}

--- a/xds/internal/client/client_watchers_rds_test.go
+++ b/xds/internal/client/client_watchers_rds_test.go
@@ -39,7 +39,7 @@ func (s) TestRDSWatch(t *testing.T) {
 	v2ClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	c, err := New(clientOpts(testXDSServer))
+	c, err := New(clientOpts(testXDSServer, false /* overrideWatchExpiryTimeout */))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
@@ -90,7 +90,7 @@ func (s) TestRDSTwoWatchSameResourceName(t *testing.T) {
 	v2ClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	c, err := New(clientOpts(testXDSServer))
+	c, err := New(clientOpts(testXDSServer, false /* overrideWatchExpiryTimeout */))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
@@ -148,7 +148,7 @@ func (s) TestRDSThreeWatchDifferentResourceName(t *testing.T) {
 	v2ClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	c, err := New(clientOpts(testXDSServer))
+	c, err := New(clientOpts(testXDSServer, false /* overrideWatchExpiryTimeout */))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
@@ -204,7 +204,7 @@ func (s) TestRDSWatchAfterCache(t *testing.T) {
 	v2ClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	c, err := New(clientOpts(testXDSServer))
+	c, err := New(clientOpts(testXDSServer, false /* overrideWatchExpiryTimeout */))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}

--- a/xds/internal/client/client_watchers_service_test.go
+++ b/xds/internal/client/client_watchers_service_test.go
@@ -41,7 +41,7 @@ func (s) TestServiceWatch(t *testing.T) {
 	v2ClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	c, err := New(clientOpts(testXDSServer, false /* overrideWatchExpiryTimeout */))
+	c, err := New(clientOpts(testXDSServer, false))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
@@ -99,7 +99,7 @@ func (s) TestServiceWatchLDSUpdate(t *testing.T) {
 	v2ClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	c, err := New(clientOpts(testXDSServer, false /* overrideWatchExpiryTimeout */))
+	c, err := New(clientOpts(testXDSServer, false))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
@@ -166,7 +166,7 @@ func (s) TestServiceWatchSecond(t *testing.T) {
 	v2ClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	c, err := New(clientOpts(testXDSServer, false /* overrideWatchExpiryTimeout */))
+	c, err := New(clientOpts(testXDSServer, false))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
@@ -241,7 +241,7 @@ func (s) TestServiceWatchWithNoResponseFromServer(t *testing.T) {
 	v2ClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	c, err := New(clientOpts(testXDSServer, true /* overrideWatchExpiryTimeout */))
+	c, err := New(clientOpts(testXDSServer, true))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
@@ -275,7 +275,7 @@ func (s) TestServiceWatchEmptyRDS(t *testing.T) {
 	v2ClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	c, err := New(clientOpts(testXDSServer, true /* overrideWatchExpiryTimeout */))
+	c, err := New(clientOpts(testXDSServer, true))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
@@ -318,7 +318,7 @@ func (s) TestServiceWatchWithClientClose(t *testing.T) {
 	v2ClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	c, err := New(clientOpts(testXDSServer, true /* overrideWatchExpiryTimeout */))
+	c, err := New(clientOpts(testXDSServer, true))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
@@ -354,7 +354,7 @@ func (s) TestServiceNotCancelRDSOnSameLDSUpdate(t *testing.T) {
 	v2ClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	c, err := New(clientOpts(testXDSServer, false /* overrideWatchExpiryTimeout */))
+	c, err := New(clientOpts(testXDSServer, false))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
@@ -405,7 +405,7 @@ func (s) TestServiceResourceRemoved(t *testing.T) {
 	v2ClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	c, err := New(clientOpts(testXDSServer, false /* overrideWatchExpiryTimeout */))
+	c, err := New(clientOpts(testXDSServer, false))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}


### PR DESCRIPTION
Tests can pass a different value when necessary. This avoids overriding
a global variable from tests, leading to unnecessary races.