### PR TITLE
Add some appengine build constraints.

### DIFF
--- a/channelz/service/func_nonlinux.go
+++ b/channelz/service/func_nonlinux.go
@@ -1,4 +1,4 @@
-// +build !linux
+// +build !linux appengine
 
 /*
  *

--- a/internal/channelz/types_nonlinux.go
+++ b/internal/channelz/types_nonlinux.go
@@ -1,4 +1,4 @@
-// +build !linux
+// +build !linux appengine
 
 /*
  *

--- a/internal/credentials/spiffe_appengine.go
+++ b/internal/credentials/spiffe_appengine.go
@@ -1,8 +1,8 @@
-// +build !linux appengine
+// +build appengine
 
 /*
  *
- * Copyright 2018 gRPC authors.
+ * Copyright 2020 gRPC authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,9 +18,14 @@
  *
  */
 
-package channelz
+package credentials
 
-// GetSocketOption gets the socket option info of the conn.
-func GetSocketOption(c interface{}) *SocketOptionData {
+import (
+	"crypto/tls"
+	"net/url"
+)
+
+// SPIFFEIDFromState is a no-op for appengine builds.
+func SPIFFEIDFromState(state tls.ConnectionState) *url.URL {
 	return nil
 }

--- a/internal/syscall/syscall_linux.go
+++ b/internal/syscall/syscall_linux.go
@@ -1,5 +1,3 @@
-// +build linux
-
 /*
  *
  * Copyright 2018 gRPC authors.

--- a/internal/syscall/syscall_linux.go
+++ b/internal/syscall/syscall_linux.go
@@ -1,3 +1,5 @@
+// +build linux
+
 /*
  *
  * Copyright 2018 gRPC authors.

--- a/internal/syscall/syscall_nonlinux.go
+++ b/internal/syscall/syscall_nonlinux.go
@@ -1,4 +1,4 @@
-// +build !linux
+// +build !linux appengine
 
 /*
  *

--- a/security/advancedtls/sni_appengine.go
+++ b/security/advancedtls/sni_appengine.go
@@ -1,8 +1,8 @@
-// +build !linux appengine
+// +build appengine
 
 /*
  *
- * Copyright 2018 gRPC authors.
+ * Copyright 2020 gRPC authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,9 +18,13 @@
  *
  */
 
-package channelz
+package advancedtls
 
-// GetSocketOption gets the socket option info of the conn.
-func GetSocketOption(c interface{}) *SocketOptionData {
-	return nil
+import (
+	"crypto/tls"
+)
+
+// buildGetCertificates is a no-op for appengine builds.
+func buildGetCertificates(clientHello *tls.ClientHelloInfo, o *ServerOptions) (*tls.Certificate, error) {
+	return nil, nil
 }

--- a/xds/internal/client/v2/client.go
+++ b/xds/internal/client/v2/client.go
@@ -53,7 +53,7 @@ func (clientBuilder) Version() version.TransportAPI {
 func newClient(cc *grpc.ClientConn, opts xdsclient.BuildOptions) (xdsclient.APIClient, error) {
 	nodeProto, ok := opts.NodeProto.(*v2corepb.Node)
 	if !ok {
-		return nil, fmt.Errorf("xds: unsupported Node proto type: %T, want %T", opts.NodeProto, v2corepb.Node{})
+		return nil, fmt.Errorf("xds: unsupported Node proto type: %T, want %T", opts.NodeProto, (*v2corepb.Node)(nil))
 	}
 	v2c := &client{
 		cc:        cc,

--- a/xds/internal/client/v2/client.go
+++ b/xds/internal/client/v2/client.go
@@ -53,7 +53,7 @@ func (clientBuilder) Version() version.TransportAPI {
 func newClient(cc *grpc.ClientConn, opts xdsclient.BuildOptions) (xdsclient.APIClient, error) {
 	nodeProto, ok := opts.NodeProto.(*v2corepb.Node)
 	if !ok {
-		return nil, fmt.Errorf("xds: unsupported Node proto type: %T, want %T", opts.NodeProto, (*v2corepb.Node)(nil))
+		return nil, fmt.Errorf("xds: unsupported Node proto type: %T, want %T", opts.NodeProto, v2corepb.Node{})
 	}
 	v2c := &client{
 		cc:        cc,


### PR DESCRIPTION
Support for Go1.9 and appengine was removed in https://github.com/grpc/grpc-go/pull/3767. But it looks like we still need some way to do things differently for certain appengine builds.