### PR TITLE
credentials/alts: ClientAuthorizationCheck to case-fold compare of peer SA

### DIFF
--- a/credentials/alts/utils.go
+++ b/credentials/alts/utils.go
@@ -152,12 +152,13 @@ func AuthInfoFromPeer(p *peer.Peer) (AuthInfo, error) {
 func ClientAuthorizationCheck(ctx context.Context, expectedServiceAccounts []string) error {
 	authInfo, err := AuthInfoFromContext(ctx)
 	if err != nil {
-		return status.Newf(codes.PermissionDenied, "The context is not an ALTS-compatible context: %v", err).Err()
+		return status.Errorf(codes.PermissionDenied, "The context is not an ALTS-compatible context: %v", err)
 	}
+	peer := authInfo.PeerServiceAccount()
 	for _, sa := range expectedServiceAccounts {
-		if authInfo.PeerServiceAccount() == sa {
+		if strings.EqualFold(peer, sa) {
 			return nil
 		}
 	}
-	return status.Newf(codes.PermissionDenied, "Client %v is not authorized", authInfo.PeerServiceAccount()).Err()
+	return status.Errorf(codes.PermissionDenied, "Client %v is not authorized", peer)
 }

--- a/credentials/alts/utils_test.go
+++ b/credentials/alts/utils_test.go
@@ -176,6 +176,13 @@ func (s) TestClientAuthorizationCheck(t *testing.T) {
 			codes.OK, // err is nil, code is OK.
 		},
 		{
+			"working case (case ignored)",
+			peer.NewContext(ctx, p),
+			[]string{strings.ToUpper(testServiceAccount1), testServiceAccount2},
+			true,
+			codes.OK, // err is nil, code is OK.
+		},
+		{
 			"context does not have AuthInfo",
 			ctx,
 			[]string{testServiceAccount1, testServiceAccount2},


### PR DESCRIPTION
`expectedServiceAccounts` are commonly mixed-case, while the `PeerServiceAccount` is lowel-case.
The discrepancy can be error-prone, recommendation is to use Unicode case-folding comparison.
Nit: change `status.Newf(...).Err()` to the semantically equal `status.Errorf(...)`.