### PR TITLE
examples: update grpc version

### DIFF
--- a/examples/features/debugging/client/main.go
+++ b/examples/features/debugging/client/main.go
@@ -53,7 +53,7 @@ func main() {
 	/***** Initialize manual resolver and Dial *****/
 	r := manual.NewBuilderWithScheme("whatever")
 	// Set up a connection to the server.
-	conn, err := grpc.Dial(r.Scheme()+":///test.server", grpc.WithInsecure(), grpc.WithResolvers(r), grpc.WithBalancerName("round_robin"))
+	conn, err := grpc.Dial(r.Scheme()+":///test.server", grpc.WithInsecure(), grpc.WithResolvers(r), grpc.WithDefaultServiceConfig(`{"loadBalancingPolicy":"round_robin"}`))
 	if err != nil {
 		log.Fatalf("did not connect: %v", err)
 	}

--- a/examples/features/load_balancing/README.md
+++ b/examples/features/load_balancing/README.md
@@ -25,9 +25,10 @@ with `this is examples/load_balancing (from :50051)`.
 Two clients are created, to connect to both of these servers (they get both
 server addresses from the name resolver).
 
-Each client picks a different load balancer (using `grpc.WithBalancerName`):
-`pick_first` or `round_robin`. (These two policies are supported in gRPC by
-default. To add a custom balancing policy, implement the interfaces defined in
+Each client picks a different load balancer (using
+`grpc.WithDefaultServiceConfig`): `pick_first` or `round_robin`. (These two
+policies are supported in gRPC by default. To add a custom balancing policy,
+implement the interfaces defined in
 https://godoc.org/google.golang.org/grpc/balancer).
 
 Note that balancers can also be switched using service config, which allows

--- a/examples/features/load_balancing/client/main.go
+++ b/examples/features/load_balancing/client/main.go
@@ -55,9 +55,9 @@ func makeRPCs(cc *grpc.ClientConn, n int) {
 }
 
 func main() {
+	// "pick_first" is the default, so there's no need to set the load balancer.
 	pickfirstConn, err := grpc.Dial(
 		fmt.Sprintf("%s:///%s", exampleScheme, exampleServiceName),
-		// grpc.WithBalancerName("pick_first"), // "pick_first" is the default, so this DialOption is not necessary.
 		grpc.WithInsecure(),
 		grpc.WithBlock(),
 	)
@@ -74,7 +74,7 @@ func main() {
 	// Make another ClientConn with round_robin policy.
 	roundrobinConn, err := grpc.Dial(
 		fmt.Sprintf("%s:///%s", exampleScheme, exampleServiceName),
-		grpc.WithBalancerName("round_robin"), // This sets the initial balancing policy.
+		grpc.WithDefaultServiceConfig(`{"loadBalancingPolicy":"round_robin"}`), // This sets the initial balancing policy.
 		grpc.WithInsecure(),
 		grpc.WithBlock(),
 	)

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -6,5 +6,5 @@ require (
 	github.com/golang/protobuf v1.4.2
 	golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be
 	google.golang.org/genproto v0.0.0-20200624020401-64a14ca9d1ad
-	google.golang.org/grpc v1.30.0
+	google.golang.org/grpc v1.31.0
 )

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -71,8 +71,8 @@ google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZi
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=
 google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
-google.golang.org/grpc v1.30.0 h1:M5a8xTlYTxwMn5ZFkwhRabsygDY5G8TYLyQDBxJNAxE=
-google.golang.org/grpc v1.30.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
+google.golang.org/grpc v1.31.0 h1:T7P4R73V3SSDPhH7WW7ATbfViLtmamH0DKrP3f9AuDI=
+google.golang.org/grpc v1.31.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=


### PR DESCRIPTION
And remove example usages of `WithBalancerName`

fixes #3811