### PR TITLE
advancedtls: add PEMFileProvider implementation for on-file-change credential reloading

### DIFF
--- a/security/advancedtls/pemfile_provider.go
+++ b/security/advancedtls/pemfile_provider.go
@@ -65,14 +65,13 @@ type PEMFileProviderOptions struct {
 	// IdentityInterval is the time duration between two credential update checks for identity certs.
 	// Optional. If not set, we will use the default interval.
 	IdentityInterval *time.Duration
-	// RootInterval is the time duration between two credential update checks for root certs. The default is set to 1 hour.
+	// RootInterval is the time duration between two credential update checks for root certs.
 	// Optional. If not set, we will use the default interval.
 	RootInterval *time.Duration
 }
 
 // PEMFileProvider implements certprovider.Provider.
-// It provides the most up-to-date identity private key/cert pair
-// and root certificates based on the input PEM files.
+// It provides the most up-to-date identity private key-cert pairs and/or root certificates.
 type PEMFileProvider struct {
 	identityDistributor *certprovider.Distributor
 	rootDistributor     *certprovider.Distributor

--- a/security/advancedtls/pemfile_provider.go
+++ b/security/advancedtls/pemfile_provider.go
@@ -1,0 +1,160 @@
+/*
+ *
+ * Copyright 2020 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package advancedtls
+
+import (
+"context"
+"crypto/tls"
+"crypto/x509"
+"io/ioutil"
+"time"
+
+"google.golang.org/grpc/credentials/tls/certprovider"
+"google.golang.org/grpc/grpclog"
+)
+
+const defaultInterval = 1 * time.Hour
+
+var logger = grpclog.Component("advancedtls")
+
+// PEMFileProviderOptions contains options to configure a PEMFileProvider.
+type PEMFileProviderOptions struct {
+	// CertFile is the file path that holds certificate file specified by users
+	// whose updates will be captured by a watching goroutine.
+	CertFile string
+	// KeyFile is the file path that holds private key specified by users
+	// whose updates will be captured by a watching goroutine.
+	KeyFile string
+	// TrustFile is the file path that holds trust file specified by users
+	// whose updates will be captured by a watching goroutine.
+	TrustFile string
+	// The identity files will be periodically reloaded for the duration of IdentityInterval.
+	// The default Interval is set to 1 hour if users did not specify this field.
+	IdentityInterval time.Duration
+	// The trust files will be periodically reloaded for the duration of RootInterval.
+	// The default Interval is set to 1 hour if users did not specify this field.
+	RootInterval time.Duration
+}
+
+// PEMFileProvider implements certprovider.Provider.
+// It provides the most up-to-date identity private key/cert pair
+// and root certificates based on the input PEM files.
+type PEMFileProvider struct {
+	identityDistributor *certprovider.Distributor
+	rootDistributor     *certprovider.Distributor
+	cancel              context.CancelFunc
+}
+
+// NewPEMFileProvider uses PEMFileProviderOptions to construct a PEMFileProvider.
+func NewPEMFileProvider(o *PEMFileProviderOptions) (*PEMFileProvider, error) {
+	var identityUpdate, rootUpdate bool
+	if o.CertFile != "" && o.KeyFile != "" {
+		identityUpdate = true
+	} else if o.CertFile != "" || o.KeyFile != "" {
+		logger.Warning("users must specify both KeyFile and CertFile to update identity credentials")
+	}
+	if o.TrustFile != "" {
+		rootUpdate = true
+	}
+	if o.IdentityInterval == 0 {
+		o.IdentityInterval = defaultInterval
+	}
+	if o.RootInterval == 0 {
+		o.RootInterval = defaultInterval
+	}
+	identityTicker := time.NewTicker(o.IdentityInterval)
+	rootTicker := time.NewTicker(o.RootInterval)
+	ctx, cancel := context.WithCancel(context.Background())
+	provider := &PEMFileProvider{
+		identityDistributor: certprovider.NewDistributor(),
+		rootDistributor:     certprovider.NewDistributor(),
+	}
+	// A goroutine to pull file changes.
+	go func(ctx context.Context) {
+		for {
+			select {
+			case <-ctx.Done():
+				identityTicker.Stop()
+				rootTicker.Stop()
+				return
+			case <-identityTicker.C:
+				if !identityUpdate {
+					continue
+				}
+				// Read identity certs from PEM files.
+				identityCert, err := tls.LoadX509KeyPair(o.CertFile, o.KeyFile)
+				if err != nil {
+					// If the reading produces an error, we will skip the update for this round and log the error.
+					// Note that LoadX509KeyPair will return error if file is empty,
+					// so there is no separate check for empty file contents.
+					logger.Warning("tls.LoadX509KeyPair(%v, %v) failed: %v", o.CertFile, o.KeyFile, err)
+					continue
+				}
+				provider.identityDistributor.Set(&certprovider.KeyMaterial{Certs: []tls.Certificate{identityCert}}, nil)
+			case <-rootTicker.C:
+				if !rootUpdate {
+					continue
+				}
+				// Read root certs from PEM files.
+				trustData, err := ioutil.ReadFile(o.TrustFile)
+				if err != nil {
+					// If the reading produces an error, we will skip the update for this round and log the error.
+					logger.Warning("ioutil.ReadFile(%v) failed: %v", o.TrustFile, err)
+					continue
+				}
+				if len(trustData) == 0 {
+					// If the current file is empty, skip the update for this round.
+					logger.Warning("ioutil.ReadFile(%v) reads an empty file: %v", o.TrustFile, err)
+					continue
+				}
+				trustPool := x509.NewCertPool()
+				ok := trustPool.AppendCertsFromPEM(trustData)
+				if !ok {
+					logger.Warning("trustPool.AppendCertsFromPEM(trustData) failed")
+					continue
+				}
+				provider.rootDistributor.Set(&certprovider.KeyMaterial{Roots: trustPool}, nil)
+			default:
+			}
+		}
+	}(ctx)
+	provider.cancel = cancel
+	return provider, nil
+}
+
+// KeyMaterial returns the key material sourced by the PEMFileProvider.
+// Callers are expected to use the returned value as read-only.
+func (p *PEMFileProvider) KeyMaterial(ctx context.Context) (*certprovider.KeyMaterial, error) {
+	identityKM, err := p.identityDistributor.KeyMaterial(ctx)
+	if err != nil {
+		return nil, err
+	}
+	rootKM, err := p.rootDistributor.KeyMaterial(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &certprovider.KeyMaterial{Certs: identityKM.Certs, Roots: rootKM.Roots}, nil
+}
+
+// Close cleans up resources allocated by the PEMFileProvider.
+func (p *PEMFileProvider) Close() {
+	p.cancel()
+	p.identityDistributor.Stop()
+	p.rootDistributor.Stop()
+}

--- a/security/advancedtls/pemfile_provider_test.go
+++ b/security/advancedtls/pemfile_provider_test.go
@@ -1,0 +1,251 @@
+/*
+ *
+ * Copyright 2020 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package advancedtls
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"io/ioutil"
+	"math/big"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/grpc/credentials/tls/certprovider"
+	"google.golang.org/grpc/security/advancedtls/testdata"
+)
+
+// The PEMFileProvider for identity credentials updates is tested in different stages.
+// At stage 0, we create an PEMFileProvider with empty initial files.
+// At stage 1, we copy the first set of certFile and keyFile to the temp files
+// that are watched by the goroutine.
+// The KeyMaterial is expected to be updated if there is a matching key-cert pair.
+// At stage 2, we copy the second set of certFile and keyFile to the temp files
+// and verify the credential files are updated.
+// The KeyMaterial is expected to be updated if there is a matching key-cert pair.
+// At stage 3, we clear the file contents of temp files.
+// The KeyMaterial is expected to skip the update because the file contents are empty.
+func (s) TestIdentityPEMFileProvider(t *testing.T) {
+	// Load certificates.
+	cs := &certStore{}
+	err := cs.loadCerts()
+	if err != nil {
+		t.Errorf("cs.loadCerts() failed: %v", err)
+	}
+	// Create temp files that are used to hold credentials.
+	certTmp, err := ioutil.TempFile(os.TempDir(), "pre-")
+	if err != nil {
+		t.Errorf("ioutil.TempFile(os.TempDir(), pre-) failed: %v", err)
+	}
+	defer os.Remove(certTmp.Name())
+	keyTmp, err := ioutil.TempFile(os.TempDir(), "pre-")
+	if err != nil {
+		t.Errorf("ioutil.TempFile(os.TempDir(), pre-) failed: %v", err)
+	}
+	defer os.Remove(keyTmp.Name())
+	tests := []struct {
+		desc           string
+		certFileBefore string
+		keyFileBefore  string
+		wantKmBefore   certprovider.KeyMaterial
+		certFileAfter  string
+		keyFileAfter   string
+		wantKmAfter    certprovider.KeyMaterial
+	}{
+		{
+			desc:           "Test identity provider on the client side",
+			certFileBefore: testdata.Path("client_cert_1.pem"),
+			keyFileBefore:  testdata.Path("client_key_1.pem"),
+			wantKmBefore:   certprovider.KeyMaterial{Certs: []tls.Certificate{cs.clientPeer1}},
+			certFileAfter:  testdata.Path("client_cert_2.pem"),
+			keyFileAfter:   testdata.Path("client_key_2.pem"),
+			wantKmAfter:    certprovider.KeyMaterial{Certs: []tls.Certificate{cs.clientPeer2}},
+		},
+		{
+			desc:           "Test identity provider on the server side",
+			certFileBefore: testdata.Path("server_cert_1.pem"),
+			keyFileBefore:  testdata.Path("server_key_1.pem"),
+			wantKmBefore:   certprovider.KeyMaterial{Certs: []tls.Certificate{cs.serverPeer1}},
+			certFileAfter:  testdata.Path("server_cert_2.pem"),
+			keyFileAfter:   testdata.Path("server_key_2.pem"),
+			wantKmAfter:    certprovider.KeyMaterial{Certs: []tls.Certificate{cs.serverPeer2}},
+		},
+		{
+			desc:           "Update failed due to key-cert mismatch",
+			certFileBefore: testdata.Path("server_cert_1.pem"),
+			keyFileBefore:  testdata.Path("server_key_1.pem"),
+			wantKmBefore:   certprovider.KeyMaterial{Certs: []tls.Certificate{cs.serverPeer1}},
+			certFileAfter:  testdata.Path("server_cert_1.pem"),
+			keyFileAfter:   testdata.Path("server_key_2.pem"),
+			wantKmAfter:    certprovider.KeyMaterial{Certs: []tls.Certificate{cs.serverPeer1}},
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			PEMFileProviderOptions := &PEMFileProviderOptions{
+				CertFile:         certTmp.Name(),
+				KeyFile:          keyTmp.Name(),
+				IdentityInterval: 1 * time.Second,
+			}
+			// ------------------------Stage 0------------------------------------
+			PEMFileProvider, err := NewPEMFileProvider(PEMFileProviderOptions)
+			if err != nil {
+				t.Errorf("NewPEMFileProvider(PEMFileProviderOptions) failed: %v", err)
+			}
+			// ------------------------Stage 1------------------------------------
+			err = copyFileContents(test.certFileBefore, certTmp.Name())
+			if err != nil {
+				t.Errorf("copyFileContents(test.certFileBefore, certTmp): %v", err)
+			}
+			err = copyFileContents(test.keyFileBefore, keyTmp.Name())
+			if err != nil {
+				t.Errorf("copyFileContents(test.keyFileBefore, keyTmp): %v", err)
+			}
+			time.Sleep(2 * time.Second)
+			gotKM, err := PEMFileProvider.identityDistributor.KeyMaterial(context.Background())
+			if !cmp.Equal(*gotKM, test.wantKmBefore, cmp.AllowUnexported(big.Int{})) {
+				t.Errorf("provider.KeyMaterial() = %+v, want %+v", *gotKM, test.wantKmBefore)
+			}
+			// ------------------------Stage 2------------------------------------
+			err = copyFileContents(test.certFileAfter, certTmp.Name())
+			if err != nil {
+				t.Errorf("copyFileContents(test.certFileAfter, certTmp): %v", err)
+			}
+			err = copyFileContents(test.keyFileAfter, keyTmp.Name())
+			if err != nil {
+				t.Errorf("copyFileContents(test.keyFileAfter, keyTmp): %v", err)
+			}
+			time.Sleep(2 * time.Second)
+			gotKM, err = PEMFileProvider.identityDistributor.KeyMaterial(context.Background())
+			if !cmp.Equal(*gotKM, test.wantKmAfter, cmp.AllowUnexported(big.Int{})) {
+				t.Errorf("provider.KeyMaterial() = %+v, want %+v", *gotKM, test.wantKmAfter)
+			}
+			// ------------------------Stage 3------------------------------------
+			certTmp.Truncate(0)
+			keyTmp.Truncate(0)
+			time.Sleep(2 * time.Second)
+			gotKM, err = PEMFileProvider.identityDistributor.KeyMaterial(context.Background())
+			if !cmp.Equal(*gotKM, test.wantKmAfter, cmp.AllowUnexported(big.Int{})) {
+				t.Errorf("provider.KeyMaterial() = %+v, want %+v", *gotKM, test.wantKmAfter)
+			}
+			PEMFileProvider.Close()
+		})
+	}
+}
+
+// The PEMFileProvider for root credentials updates is tested in different stages.
+// At stage 0, we create an RootPEMFileProvider with empty initial file.
+// At stage 1, we copy the first set of certFile and keyFile to the temp files
+// that are watched by the goroutine. The KeyMaterial is expected to be updated.
+// At stage 2, we copy the second set of certFile and keyFile to the temp files
+// and verify the credential files are updated. The KeyMaterial is expected to be updated.
+// At stage 3, we clear the file contents of temp files.
+// The KeyMaterial is expected to skip the update because the file contents are empty.
+func (s) TestRootPEMFileProvider(t *testing.T) {
+	cs := &certStore{}
+	err := cs.loadCerts()
+	if err != nil {
+		t.Errorf("cs.loadCerts() failed: %v", err)
+	}
+	// Create temp files that are used to hold root credentials.
+	trustTmp, err := ioutil.TempFile(os.TempDir(), "pre-")
+	if err != nil {
+		t.Errorf("ioutil.TempFile(os.TempDir(), pre-) failed: %v", err)
+	}
+	defer os.Remove(trustTmp.Name())
+	tests := []struct {
+		desc            string
+		trustFileBefore string
+		wantKmBefore    certprovider.KeyMaterial
+		trustFileAfter  string
+		wantKmAfter     certprovider.KeyMaterial
+	}{
+		{
+			desc:            "Test root provider on the client side",
+			trustFileBefore: testdata.Path("client_trust_cert_1.pem"),
+			wantKmBefore:    certprovider.KeyMaterial{Roots: cs.clientTrust1},
+			trustFileAfter:  testdata.Path("client_trust_cert_2.pem"),
+			wantKmAfter:     certprovider.KeyMaterial{Roots: cs.clientTrust2},
+		},
+		{
+			desc:            "Test root provider on the server side",
+			trustFileBefore: testdata.Path("server_trust_cert_1.pem"),
+			wantKmBefore:    certprovider.KeyMaterial{Roots: cs.serverTrust1},
+			trustFileAfter:  testdata.Path("server_trust_cert_2.pem"),
+			wantKmAfter:     certprovider.KeyMaterial{Roots: cs.serverTrust2},
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			PEMFileProviderOptions := &PEMFileProviderOptions{
+				TrustFile:    trustTmp.Name(),
+				RootInterval: 1 * time.Second,
+			}
+			// ------------------------Stage 0------------------------------------
+			PEMFileProvider, err := NewPEMFileProvider(PEMFileProviderOptions)
+			if err != nil {
+				t.Errorf("NewPEMFileProvider(PEMFileProviderOptions) failed: %v", err)
+			}
+			// ------------------------Stage 1------------------------------------
+			err = copyFileContents(test.trustFileBefore, trustTmp.Name())
+			if err != nil {
+				t.Errorf("copyFileContents(test.trustFileBefore, trustTmp): %v", err)
+			}
+			time.Sleep(2 * time.Second)
+			gotKM, err := PEMFileProvider.rootDistributor.KeyMaterial(context.Background())
+			if !cmp.Equal(*gotKM, test.wantKmBefore, cmp.AllowUnexported(x509.CertPool{})) {
+				t.Errorf("provider.KeyMaterial() = %+v, want %+v", *gotKM, test.wantKmBefore)
+			}
+			// ------------------------Stage 2------------------------------------
+			err = copyFileContents(test.trustFileAfter, trustTmp.Name())
+			if err != nil {
+				t.Errorf("copyFileContents(test.trustFileAfter, trustTmp): %v", err)
+			}
+			time.Sleep(2 * time.Second)
+			gotKM, err = PEMFileProvider.rootDistributor.KeyMaterial(context.Background())
+			if !cmp.Equal(*gotKM, test.wantKmAfter, cmp.AllowUnexported(x509.CertPool{})) {
+				t.Errorf("provider.KeyMaterial() = %+v, want %+v", *gotKM, test.wantKmAfter)
+			}
+			// ------------------------Stage 3------------------------------------
+			trustTmp.Truncate(0)
+			time.Sleep(2 * time.Second)
+			gotKM, err = PEMFileProvider.rootDistributor.KeyMaterial(context.Background())
+			if !cmp.Equal(*gotKM, test.wantKmAfter, cmp.AllowUnexported(x509.CertPool{})) {
+				t.Errorf("provider.KeyMaterial() = %+v, want %+v", *gotKM, test.wantKmAfter)
+			}
+			PEMFileProvider.Close()
+		})
+	}
+}
+
+func copyFileContents(sourceFile, destinationFile string) error {
+	input, err := ioutil.ReadFile(sourceFile)
+	if err != nil {
+		return err
+	}
+	err = ioutil.WriteFile(destinationFile, input, 0644)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/security/advancedtls/pemfile_provider_test.go
+++ b/security/advancedtls/pemfile_provider_test.go
@@ -191,7 +191,7 @@ func (s) TestWatchingRoutineUpdates(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 			//// ------------------------Stage 0------------------------------------
-			// wait for the refreshing go-routine to pick up the changes.
+			// Wait for the refreshing go-routine to pick up the changes.
 			time.Sleep(1 * time.Second)
 			gotKM, err := provider.KeyMaterial(ctx)
 			if !cmp.Equal(*gotKM, test.wantKmStage0, cmp.AllowUnexported(big.Int{}, x509.CertPool{})) {
@@ -199,14 +199,14 @@ func (s) TestWatchingRoutineUpdates(t *testing.T) {
 			}
 			// ------------------------Stage 1------------------------------------
 			stage.increase()
-			// wait for the refreshing go-routine to pick up the changes.
+			// Wait for the refreshing go-routine to pick up the changes.
 			time.Sleep(1 * time.Second)
 			gotKM, err = provider.KeyMaterial(ctx)
 			if !cmp.Equal(*gotKM, test.wantKmStage1, cmp.AllowUnexported(big.Int{}, x509.CertPool{})) {
 				t.Fatalf("provider.KeyMaterial() = %+v, want %+v", *gotKM, test.wantKmStage1)
 			}
 			//// ------------------------Stage 2------------------------------------
-			// wait for the refreshing go-routine to pick up the changes.
+			// Wait for the refreshing go-routine to pick up the changes.
 			stage.increase()
 			time.Sleep(1 * time.Second)
 			gotKM, err = provider.KeyMaterial(ctx)


### PR DESCRIPTION
This is fork of work https://github.com/grpc/grpc-go/pull/3785.
This PR added implementation and unit tests of PemFileProvider. It will fetch identity certificate updates and root certificate updates from the identity PEM file and the root PEM file specified by users via PemFileProviderOptions periodically.