### PR TITLE
internal/wrr add two functions UpdateOrAdd, Remove to WRR interface

### DIFF
--- a/internal/wrr/edf_test.go
+++ b/internal/wrr/edf_test.go
@@ -22,9 +22,9 @@ import (
 
 func (s) TestEDFOnEndpointsWithSameWeight(t *testing.T) {
 	wrr := NewEDF()
-	wrr.Add("1", 1)
-	wrr.Add("2", 1)
-	wrr.Add("3", 1)
+	wrr.UpdateOrAdd("1", 1)
+	wrr.UpdateOrAdd("2", 1)
+	wrr.UpdateOrAdd("3", 1)
 	expected := []string{"1", "2", "3", "1", "2", "3", "1", "2", "3", "1", "2", "3"}
 	for i := 0; i < len(expected); i++ {
 		item := wrr.Next().(string)

--- a/internal/wrr/wrr.go
+++ b/internal/wrr/wrr.go
@@ -21,12 +21,16 @@ package wrr
 
 // WRR defines an interface that implements weighted round robin.
 type WRR interface {
-	// Add adds an item with weight to the WRR set.
+	// UpdateOrAdd update the item with new `weight` or add the
+	// item to the WRR set if item is not existed.
 	//
-	// Add and Next need to be thread safe.
-	Add(item interface{}, weight int64)
+	// UpdateOrAdd, Remove and Next need to be thread safe.
+	UpdateOrAdd(item interface{}, weight int64)
 	// Next returns the next picked item.
 	//
-	// Add and Next need to be thread safe.
+	// UpdateOrAdd, Remove and Next need to be thread safe.
 	Next() interface{}
+
+	// UpdateOrAdd, Remove and Next need to be thread safe.
+	Remove(item interface{})
 }

--- a/internal/wrr/wrr_test.go
+++ b/internal/wrr/wrr_test.go
@@ -22,6 +22,7 @@ import (
 	"math"
 	"math/rand"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/grpc/internal/grpctest"
@@ -41,7 +42,7 @@ func equalApproximate(a, b float64) error {
 	opt := cmp.Comparer(func(x, y float64) bool {
 		delta := math.Abs(x - y)
 		mean := math.Abs(x+y) / 2.0
-		return delta/mean < 0.05
+		return x == 0 && y == 0 || delta/mean < 0.05
 	})
 	if !cmp.Equal(a, b, opt) {
 		return errors.New(cmp.Diff(a, b))
@@ -77,7 +78,7 @@ func testWRRNext(t *testing.T, newWRR func() WRR) {
 
 			w := newWRR()
 			for i, weight := range tt.weights {
-				w.Add(i, weight)
+				w.UpdateOrAdd(i, weight)
 				sumOfWeights += weight
 			}
 
@@ -104,15 +105,151 @@ func testWRRNext(t *testing.T, newWRR func() WRR) {
 	}
 }
 
+func testWRRUpdate(t *testing.T, newWRR func() WRR) {
+	tests := []struct {
+		name    string
+		weights []int64
+	}{
+		{
+			name:    "1-1-1",
+			weights: []int64{1, 1, 1},
+		},
+		{
+			name:    "1-2-3",
+			weights: []int64{1, 2, 3},
+		},
+		{
+			name:    "23-17-37",
+			weights: []int64{23, 17, 37},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var sumOfWeights int64
+
+			w := newWRR()
+			for i, weight := range tt.weights {
+				w.UpdateOrAdd(i, weight)
+				sumOfWeights += weight
+			}
+
+			for i := 0; i < iterCount; i++ {
+				w.Next()
+			}
+
+			w.UpdateOrAdd(1, 2*tt.weights[1])
+			sumOfWeights += tt.weights[1]
+			tt.weights[1] = 2 * tt.weights[1]
+
+			results := make(map[int]int)
+			for i := 0; i < iterCount; i++ {
+				results[w.Next().(int)]++
+			}
+
+			wantRatio := make([]float64, len(tt.weights))
+			for i, weight := range tt.weights {
+				wantRatio[i] = float64(weight) / float64(sumOfWeights)
+			}
+
+			gotRatio := make([]float64, len(tt.weights))
+			for i, count := range results {
+				gotRatio[i] = float64(count) / iterCount
+			}
+
+			for i := range wantRatio {
+				if err := equalApproximate(gotRatio[i], wantRatio[i]); err != nil {
+					t.Errorf("%v not equal %v, (%v, %v), %v", i, err, gotRatio[i], wantRatio[i], tt.weights)
+				}
+			}
+
+		})
+	}
+}
+
+func testWRRRemove(t *testing.T, newWRR func() WRR) {
+	tests := []struct {
+		name    string
+		weights []int64
+	}{
+		{
+			name:    "1-1-1",
+			weights: []int64{1, 1, 1},
+		},
+		{
+			name:    "1-2-3",
+			weights: []int64{1, 2, 3},
+		},
+		{
+			name:    "23-17-37",
+			weights: []int64{23, 17, 37},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var sumOfWeights int64
+
+			w := newWRR()
+			for i, weight := range tt.weights {
+				w.UpdateOrAdd(i, weight)
+				sumOfWeights += weight
+			}
+
+			for i := 0; i < iterCount; i++ {
+				w.Next()
+			}
+			w.Remove(0)
+			sumOfWeights -= tt.weights[0]
+			tt.weights[0] = 0
+
+			results := make(map[int]int)
+			for i := 0; i < iterCount; i++ {
+				results[w.Next().(int)]++
+			}
+
+			wantRatio := make([]float64, len(tt.weights))
+			for i, weight := range tt.weights {
+				wantRatio[i] = float64(weight) / float64(sumOfWeights)
+			}
+
+			gotRatio := make([]float64, len(tt.weights))
+			for i, count := range results {
+				gotRatio[i] = float64(count) / iterCount
+			}
+
+			for i := range wantRatio {
+				if err := equalApproximate(gotRatio[i], wantRatio[i]); err != nil {
+					t.Errorf("%v not equal %v, (%v, %v)", i, err, gotRatio[i], wantRatio[i])
+				}
+			}
+		})
+	}
+}
+
 func (s) TestRandomWRRNext(t *testing.T) {
 	testWRRNext(t, NewRandom)
 }
 
-func (s) TestEdfWrrNext(t *testing.T) {
+func (s) TestEdfWRRNext(t *testing.T) {
 	testWRRNext(t, NewEDF)
 }
 
+func (s) TestEdfWRRRemove(t *testing.T) {
+	testWRRRemove(t, NewEDF)
+}
+
+func (s) TestRandomWRRRemove(t *testing.T) {
+	testWRRRemove(t, NewRandom)
+}
+
+func (s) TestEdfWRRUpdate(t *testing.T) {
+	testWRRUpdate(t, NewEDF)
+}
+
+func (s) TestRandomWRRUpdate(t *testing.T) {
+	testWRRUpdate(t, NewRandom)
+}
+
 func init() {
-	r := rand.New(rand.NewSource(0))
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 	grpcrandInt63n = r.Int63n
 }


### PR DESCRIPTION
#3810  

`UpdateOrAdd` is more useful instead of simply `Add`, so I remove `Add` and replaced with `UpdateOrAdd`.  My thought was we want to call `Add` when there is a new `SubConn` *and* it's `Ready`, and call `UpdateWeight` when there is a `SubConn` has weight change *and* it's Ready. In both cases, we need to check the connectivity state before calling `UpdateWeight` or `Add`. the difference is for `Add` there is another extra step to check the `SubConn` is already in `WRR`.  I would prefer to put checking existence logic in WRR implementation and combine `UpdateWeight` and `Add` to a simple `UpdateOrAdd`.

Let me know if you think standalone `Add` is useful. I will add it back.

Since there is only `UpdateAndAdd`, `UpdateAndAdd` a `SubConn` with weight 0 is equal to `Remove`