### PR TITLE
cmd/protoc-gen-go-grpc: call interceptor even if handler is unset

### DIFF
--- a/balancer/grpclb/grpc_lb_v1/load_balancer_grpc.pb.go
+++ b/balancer/grpclb/grpc_lb_v1/load_balancer_grpc.pb.go
@@ -26,10 +26,10 @@ func (s *LoadBalancerService) balanceLoad(_ interface{}, stream grpc.ServerStrea
 }
 
 // RegisterLoadBalancerService registers a service implementation with a gRPC server.
-// srv must not be modified after this function is called, and it may be modified by this function.
 func RegisterLoadBalancerService(s grpc.ServiceRegistrar, srv *LoadBalancerService) {
-	if srv.BalanceLoad == nil {
-		srv.BalanceLoad = func(LoadBalancer_BalanceLoadServer) error {
+	srvCopy := *srv
+	if srvCopy.BalanceLoad == nil {
+		srvCopy.BalanceLoad = func(LoadBalancer_BalanceLoadServer) error {
 			return status.Errorf(codes.Unimplemented, "method BalanceLoad not implemented")
 		}
 	}
@@ -39,7 +39,7 @@ func RegisterLoadBalancerService(s grpc.ServiceRegistrar, srv *LoadBalancerServi
 		Streams: []grpc.StreamDesc{
 			{
 				StreamName:    "BalanceLoad",
-				Handler:       srv.balanceLoad,
+				Handler:       srvCopy.balanceLoad,
 				ServerStreams: true,
 				ClientStreams: true,
 			},

--- a/balancer/grpclb/grpc_lb_v1/load_balancer_grpc.pb.go
+++ b/balancer/grpclb/grpc_lb_v1/load_balancer_grpc.pb.go
@@ -22,14 +22,17 @@ type LoadBalancerService struct {
 }
 
 func (s *LoadBalancerService) balanceLoad(_ interface{}, stream grpc.ServerStream) error {
-	if s.BalanceLoad == nil {
-		return status.Errorf(codes.Unimplemented, "method BalanceLoad not implemented")
-	}
 	return s.BalanceLoad(&loadBalancerBalanceLoadServer{stream})
 }
 
 // RegisterLoadBalancerService registers a service implementation with a gRPC server.
+// srv must not be modified after this function is called, and it may be modified by this function.
 func RegisterLoadBalancerService(s grpc.ServiceRegistrar, srv *LoadBalancerService) {
+	if srv.BalanceLoad == nil {
+		srv.BalanceLoad = func(LoadBalancer_BalanceLoadServer) error {
+			return status.Errorf(codes.Unimplemented, "method BalanceLoad not implemented")
+		}
+	}
 	sd := grpc.ServiceDesc{
 		ServiceName: "grpc.lb.v1.LoadBalancer",
 		Methods:     []grpc.MethodDesc{},

--- a/balancer/rls/internal/proto/grpc_lookup_v1/rls_grpc.pb.go
+++ b/balancer/rls/internal/proto/grpc_lookup_v1/rls_grpc.pb.go
@@ -23,9 +23,6 @@ type RouteLookupServiceService struct {
 }
 
 func (s *RouteLookupServiceService) routeLookup(_ interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	if s.RouteLookup == nil {
-		return nil, status.Errorf(codes.Unimplemented, "method RouteLookup not implemented")
-	}
 	in := new(RouteLookupRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -44,7 +41,13 @@ func (s *RouteLookupServiceService) routeLookup(_ interface{}, ctx context.Conte
 }
 
 // RegisterRouteLookupServiceService registers a service implementation with a gRPC server.
+// srv must not be modified after this function is called, and it may be modified by this function.
 func RegisterRouteLookupServiceService(s grpc.ServiceRegistrar, srv *RouteLookupServiceService) {
+	if srv.RouteLookup == nil {
+		srv.RouteLookup = func(context.Context, *RouteLookupRequest) (*RouteLookupResponse, error) {
+			return nil, status.Errorf(codes.Unimplemented, "method RouteLookup not implemented")
+		}
+	}
 	sd := grpc.ServiceDesc{
 		ServiceName: "grpc.lookup.v1.RouteLookupService",
 		Methods: []grpc.MethodDesc{

--- a/balancer/rls/internal/proto/grpc_lookup_v1/rls_grpc.pb.go
+++ b/balancer/rls/internal/proto/grpc_lookup_v1/rls_grpc.pb.go
@@ -41,10 +41,10 @@ func (s *RouteLookupServiceService) routeLookup(_ interface{}, ctx context.Conte
 }
 
 // RegisterRouteLookupServiceService registers a service implementation with a gRPC server.
-// srv must not be modified after this function is called, and it may be modified by this function.
 func RegisterRouteLookupServiceService(s grpc.ServiceRegistrar, srv *RouteLookupServiceService) {
-	if srv.RouteLookup == nil {
-		srv.RouteLookup = func(context.Context, *RouteLookupRequest) (*RouteLookupResponse, error) {
+	srvCopy := *srv
+	if srvCopy.RouteLookup == nil {
+		srvCopy.RouteLookup = func(context.Context, *RouteLookupRequest) (*RouteLookupResponse, error) {
 			return nil, status.Errorf(codes.Unimplemented, "method RouteLookup not implemented")
 		}
 	}
@@ -53,7 +53,7 @@ func RegisterRouteLookupServiceService(s grpc.ServiceRegistrar, srv *RouteLookup
 		Methods: []grpc.MethodDesc{
 			{
 				MethodName: "RouteLookup",
-				Handler:    srv.routeLookup,
+				Handler:    srvCopy.routeLookup,
 			},
 		},
 		Streams:  []grpc.StreamDesc{},

--- a/benchmark/grpc_testing/services_grpc.pb.go
+++ b/benchmark/grpc_testing/services_grpc.pb.go
@@ -208,20 +208,20 @@ func (x *benchmarkServiceUnconstrainedStreamingCallServer) Recv() (*SimpleReques
 }
 
 // RegisterBenchmarkServiceService registers a service implementation with a gRPC server.
-// srv must not be modified after this function is called, and it may be modified by this function.
 func RegisterBenchmarkServiceService(s grpc.ServiceRegistrar, srv *BenchmarkServiceService) {
-	if srv.UnaryCall == nil {
-		srv.UnaryCall = func(context.Context, *SimpleRequest) (*SimpleResponse, error) {
+	srvCopy := *srv
+	if srvCopy.UnaryCall == nil {
+		srvCopy.UnaryCall = func(context.Context, *SimpleRequest) (*SimpleResponse, error) {
 			return nil, status.Errorf(codes.Unimplemented, "method UnaryCall not implemented")
 		}
 	}
-	if srv.StreamingCall == nil {
-		srv.StreamingCall = func(BenchmarkService_StreamingCallServer) error {
+	if srvCopy.StreamingCall == nil {
+		srvCopy.StreamingCall = func(BenchmarkService_StreamingCallServer) error {
 			return status.Errorf(codes.Unimplemented, "method StreamingCall not implemented")
 		}
 	}
-	if srv.UnconstrainedStreamingCall == nil {
-		srv.UnconstrainedStreamingCall = func(BenchmarkService_UnconstrainedStreamingCallServer) error {
+	if srvCopy.UnconstrainedStreamingCall == nil {
+		srvCopy.UnconstrainedStreamingCall = func(BenchmarkService_UnconstrainedStreamingCallServer) error {
 			return status.Errorf(codes.Unimplemented, "method UnconstrainedStreamingCall not implemented")
 		}
 	}
@@ -230,19 +230,19 @@ func RegisterBenchmarkServiceService(s grpc.ServiceRegistrar, srv *BenchmarkServ
 		Methods: []grpc.MethodDesc{
 			{
 				MethodName: "UnaryCall",
-				Handler:    srv.unaryCall,
+				Handler:    srvCopy.unaryCall,
 			},
 		},
 		Streams: []grpc.StreamDesc{
 			{
 				StreamName:    "StreamingCall",
-				Handler:       srv.streamingCall,
+				Handler:       srvCopy.streamingCall,
 				ServerStreams: true,
 				ClientStreams: true,
 			},
 			{
 				StreamName:    "UnconstrainedStreamingCall",
-				Handler:       srv.unconstrainedStreamingCall,
+				Handler:       srvCopy.unconstrainedStreamingCall,
 				ServerStreams: true,
 				ClientStreams: true,
 			},
@@ -538,25 +538,25 @@ func (x *workerServiceRunClientServer) Recv() (*ClientArgs, error) {
 }
 
 // RegisterWorkerServiceService registers a service implementation with a gRPC server.
-// srv must not be modified after this function is called, and it may be modified by this function.
 func RegisterWorkerServiceService(s grpc.ServiceRegistrar, srv *WorkerServiceService) {
-	if srv.RunServer == nil {
-		srv.RunServer = func(WorkerService_RunServerServer) error {
+	srvCopy := *srv
+	if srvCopy.RunServer == nil {
+		srvCopy.RunServer = func(WorkerService_RunServerServer) error {
 			return status.Errorf(codes.Unimplemented, "method RunServer not implemented")
 		}
 	}
-	if srv.RunClient == nil {
-		srv.RunClient = func(WorkerService_RunClientServer) error {
+	if srvCopy.RunClient == nil {
+		srvCopy.RunClient = func(WorkerService_RunClientServer) error {
 			return status.Errorf(codes.Unimplemented, "method RunClient not implemented")
 		}
 	}
-	if srv.CoreCount == nil {
-		srv.CoreCount = func(context.Context, *CoreRequest) (*CoreResponse, error) {
+	if srvCopy.CoreCount == nil {
+		srvCopy.CoreCount = func(context.Context, *CoreRequest) (*CoreResponse, error) {
 			return nil, status.Errorf(codes.Unimplemented, "method CoreCount not implemented")
 		}
 	}
-	if srv.QuitWorker == nil {
-		srv.QuitWorker = func(context.Context, *Void) (*Void, error) {
+	if srvCopy.QuitWorker == nil {
+		srvCopy.QuitWorker = func(context.Context, *Void) (*Void, error) {
 			return nil, status.Errorf(codes.Unimplemented, "method QuitWorker not implemented")
 		}
 	}
@@ -565,23 +565,23 @@ func RegisterWorkerServiceService(s grpc.ServiceRegistrar, srv *WorkerServiceSer
 		Methods: []grpc.MethodDesc{
 			{
 				MethodName: "CoreCount",
-				Handler:    srv.coreCount,
+				Handler:    srvCopy.coreCount,
 			},
 			{
 				MethodName: "QuitWorker",
-				Handler:    srv.quitWorker,
+				Handler:    srvCopy.quitWorker,
 			},
 		},
 		Streams: []grpc.StreamDesc{
 			{
 				StreamName:    "RunServer",
-				Handler:       srv.runServer,
+				Handler:       srvCopy.runServer,
 				ServerStreams: true,
 				ClientStreams: true,
 			},
 			{
 				StreamName:    "RunClient",
-				Handler:       srv.runClient,
+				Handler:       srvCopy.runClient,
 				ServerStreams: true,
 				ClientStreams: true,
 			},

--- a/benchmark/grpc_testing/services_grpc.pb.go
+++ b/benchmark/grpc_testing/services_grpc.pb.go
@@ -140,9 +140,6 @@ type BenchmarkServiceService struct {
 }
 
 func (s *BenchmarkServiceService) unaryCall(_ interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	if s.UnaryCall == nil {
-		return nil, status.Errorf(codes.Unimplemented, "method UnaryCall not implemented")
-	}
 	in := new(SimpleRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -160,15 +157,9 @@ func (s *BenchmarkServiceService) unaryCall(_ interface{}, ctx context.Context, 
 	return interceptor(ctx, in, info, handler)
 }
 func (s *BenchmarkServiceService) streamingCall(_ interface{}, stream grpc.ServerStream) error {
-	if s.StreamingCall == nil {
-		return status.Errorf(codes.Unimplemented, "method StreamingCall not implemented")
-	}
 	return s.StreamingCall(&benchmarkServiceStreamingCallServer{stream})
 }
 func (s *BenchmarkServiceService) unconstrainedStreamingCall(_ interface{}, stream grpc.ServerStream) error {
-	if s.UnconstrainedStreamingCall == nil {
-		return status.Errorf(codes.Unimplemented, "method UnconstrainedStreamingCall not implemented")
-	}
 	return s.UnconstrainedStreamingCall(&benchmarkServiceUnconstrainedStreamingCallServer{stream})
 }
 
@@ -217,7 +208,23 @@ func (x *benchmarkServiceUnconstrainedStreamingCallServer) Recv() (*SimpleReques
 }
 
 // RegisterBenchmarkServiceService registers a service implementation with a gRPC server.
+// srv must not be modified after this function is called, and it may be modified by this function.
 func RegisterBenchmarkServiceService(s grpc.ServiceRegistrar, srv *BenchmarkServiceService) {
+	if srv.UnaryCall == nil {
+		srv.UnaryCall = func(context.Context, *SimpleRequest) (*SimpleResponse, error) {
+			return nil, status.Errorf(codes.Unimplemented, "method UnaryCall not implemented")
+		}
+	}
+	if srv.StreamingCall == nil {
+		srv.StreamingCall = func(BenchmarkService_StreamingCallServer) error {
+			return status.Errorf(codes.Unimplemented, "method StreamingCall not implemented")
+		}
+	}
+	if srv.UnconstrainedStreamingCall == nil {
+		srv.UnconstrainedStreamingCall = func(BenchmarkService_UnconstrainedStreamingCallServer) error {
+			return status.Errorf(codes.Unimplemented, "method UnconstrainedStreamingCall not implemented")
+		}
+	}
 	sd := grpc.ServiceDesc{
 		ServiceName: "grpc.testing.BenchmarkService",
 		Methods: []grpc.MethodDesc{
@@ -446,21 +453,12 @@ type WorkerServiceService struct {
 }
 
 func (s *WorkerServiceService) runServer(_ interface{}, stream grpc.ServerStream) error {
-	if s.RunServer == nil {
-		return status.Errorf(codes.Unimplemented, "method RunServer not implemented")
-	}
 	return s.RunServer(&workerServiceRunServerServer{stream})
 }
 func (s *WorkerServiceService) runClient(_ interface{}, stream grpc.ServerStream) error {
-	if s.RunClient == nil {
-		return status.Errorf(codes.Unimplemented, "method RunClient not implemented")
-	}
 	return s.RunClient(&workerServiceRunClientServer{stream})
 }
 func (s *WorkerServiceService) coreCount(_ interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	if s.CoreCount == nil {
-		return nil, status.Errorf(codes.Unimplemented, "method CoreCount not implemented")
-	}
 	in := new(CoreRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -478,9 +476,6 @@ func (s *WorkerServiceService) coreCount(_ interface{}, ctx context.Context, dec
 	return interceptor(ctx, in, info, handler)
 }
 func (s *WorkerServiceService) quitWorker(_ interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	if s.QuitWorker == nil {
-		return nil, status.Errorf(codes.Unimplemented, "method QuitWorker not implemented")
-	}
 	in := new(Void)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -543,7 +538,28 @@ func (x *workerServiceRunClientServer) Recv() (*ClientArgs, error) {
 }
 
 // RegisterWorkerServiceService registers a service implementation with a gRPC server.
+// srv must not be modified after this function is called, and it may be modified by this function.
 func RegisterWorkerServiceService(s grpc.ServiceRegistrar, srv *WorkerServiceService) {
+	if srv.RunServer == nil {
+		srv.RunServer = func(WorkerService_RunServerServer) error {
+			return status.Errorf(codes.Unimplemented, "method RunServer not implemented")
+		}
+	}
+	if srv.RunClient == nil {
+		srv.RunClient = func(WorkerService_RunClientServer) error {
+			return status.Errorf(codes.Unimplemented, "method RunClient not implemented")
+		}
+	}
+	if srv.CoreCount == nil {
+		srv.CoreCount = func(context.Context, *CoreRequest) (*CoreResponse, error) {
+			return nil, status.Errorf(codes.Unimplemented, "method CoreCount not implemented")
+		}
+	}
+	if srv.QuitWorker == nil {
+		srv.QuitWorker = func(context.Context, *Void) (*Void, error) {
+			return nil, status.Errorf(codes.Unimplemented, "method QuitWorker not implemented")
+		}
+	}
 	sd := grpc.ServiceDesc{
 		ServiceName: "grpc.testing.WorkerService",
 		Methods: []grpc.MethodDesc{

--- a/channelz/grpc_channelz_v1/channelz_grpc.pb.go
+++ b/channelz/grpc_channelz_v1/channelz_grpc.pb.go
@@ -156,40 +156,40 @@ func (s *ChannelzService) getSocket(_ interface{}, ctx context.Context, dec func
 }
 
 // RegisterChannelzService registers a service implementation with a gRPC server.
-// srv must not be modified after this function is called, and it may be modified by this function.
 func RegisterChannelzService(s grpc.ServiceRegistrar, srv *ChannelzService) {
-	if srv.GetTopChannels == nil {
-		srv.GetTopChannels = func(context.Context, *GetTopChannelsRequest) (*GetTopChannelsResponse, error) {
+	srvCopy := *srv
+	if srvCopy.GetTopChannels == nil {
+		srvCopy.GetTopChannels = func(context.Context, *GetTopChannelsRequest) (*GetTopChannelsResponse, error) {
 			return nil, status.Errorf(codes.Unimplemented, "method GetTopChannels not implemented")
 		}
 	}
-	if srv.GetServers == nil {
-		srv.GetServers = func(context.Context, *GetServersRequest) (*GetServersResponse, error) {
+	if srvCopy.GetServers == nil {
+		srvCopy.GetServers = func(context.Context, *GetServersRequest) (*GetServersResponse, error) {
 			return nil, status.Errorf(codes.Unimplemented, "method GetServers not implemented")
 		}
 	}
-	if srv.GetServer == nil {
-		srv.GetServer = func(context.Context, *GetServerRequest) (*GetServerResponse, error) {
+	if srvCopy.GetServer == nil {
+		srvCopy.GetServer = func(context.Context, *GetServerRequest) (*GetServerResponse, error) {
 			return nil, status.Errorf(codes.Unimplemented, "method GetServer not implemented")
 		}
 	}
-	if srv.GetServerSockets == nil {
-		srv.GetServerSockets = func(context.Context, *GetServerSocketsRequest) (*GetServerSocketsResponse, error) {
+	if srvCopy.GetServerSockets == nil {
+		srvCopy.GetServerSockets = func(context.Context, *GetServerSocketsRequest) (*GetServerSocketsResponse, error) {
 			return nil, status.Errorf(codes.Unimplemented, "method GetServerSockets not implemented")
 		}
 	}
-	if srv.GetChannel == nil {
-		srv.GetChannel = func(context.Context, *GetChannelRequest) (*GetChannelResponse, error) {
+	if srvCopy.GetChannel == nil {
+		srvCopy.GetChannel = func(context.Context, *GetChannelRequest) (*GetChannelResponse, error) {
 			return nil, status.Errorf(codes.Unimplemented, "method GetChannel not implemented")
 		}
 	}
-	if srv.GetSubchannel == nil {
-		srv.GetSubchannel = func(context.Context, *GetSubchannelRequest) (*GetSubchannelResponse, error) {
+	if srvCopy.GetSubchannel == nil {
+		srvCopy.GetSubchannel = func(context.Context, *GetSubchannelRequest) (*GetSubchannelResponse, error) {
 			return nil, status.Errorf(codes.Unimplemented, "method GetSubchannel not implemented")
 		}
 	}
-	if srv.GetSocket == nil {
-		srv.GetSocket = func(context.Context, *GetSocketRequest) (*GetSocketResponse, error) {
+	if srvCopy.GetSocket == nil {
+		srvCopy.GetSocket = func(context.Context, *GetSocketRequest) (*GetSocketResponse, error) {
 			return nil, status.Errorf(codes.Unimplemented, "method GetSocket not implemented")
 		}
 	}
@@ -198,31 +198,31 @@ func RegisterChannelzService(s grpc.ServiceRegistrar, srv *ChannelzService) {
 		Methods: []grpc.MethodDesc{
 			{
 				MethodName: "GetTopChannels",
-				Handler:    srv.getTopChannels,
+				Handler:    srvCopy.getTopChannels,
 			},
 			{
 				MethodName: "GetServers",
-				Handler:    srv.getServers,
+				Handler:    srvCopy.getServers,
 			},
 			{
 				MethodName: "GetServer",
-				Handler:    srv.getServer,
+				Handler:    srvCopy.getServer,
 			},
 			{
 				MethodName: "GetServerSockets",
-				Handler:    srv.getServerSockets,
+				Handler:    srvCopy.getServerSockets,
 			},
 			{
 				MethodName: "GetChannel",
-				Handler:    srv.getChannel,
+				Handler:    srvCopy.getChannel,
 			},
 			{
 				MethodName: "GetSubchannel",
-				Handler:    srv.getSubchannel,
+				Handler:    srvCopy.getSubchannel,
 			},
 			{
 				MethodName: "GetSocket",
-				Handler:    srv.getSocket,
+				Handler:    srvCopy.getSocket,
 			},
 		},
 		Streams:  []grpc.StreamDesc{},

--- a/channelz/grpc_channelz_v1/channelz_grpc.pb.go
+++ b/channelz/grpc_channelz_v1/channelz_grpc.pb.go
@@ -36,9 +36,6 @@ type ChannelzService struct {
 }
 
 func (s *ChannelzService) getTopChannels(_ interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	if s.GetTopChannels == nil {
-		return nil, status.Errorf(codes.Unimplemented, "method GetTopChannels not implemented")
-	}
 	in := new(GetTopChannelsRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -56,9 +53,6 @@ func (s *ChannelzService) getTopChannels(_ interface{}, ctx context.Context, dec
 	return interceptor(ctx, in, info, handler)
 }
 func (s *ChannelzService) getServers(_ interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	if s.GetServers == nil {
-		return nil, status.Errorf(codes.Unimplemented, "method GetServers not implemented")
-	}
 	in := new(GetServersRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -76,9 +70,6 @@ func (s *ChannelzService) getServers(_ interface{}, ctx context.Context, dec fun
 	return interceptor(ctx, in, info, handler)
 }
 func (s *ChannelzService) getServer(_ interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	if s.GetServer == nil {
-		return nil, status.Errorf(codes.Unimplemented, "method GetServer not implemented")
-	}
 	in := new(GetServerRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -96,9 +87,6 @@ func (s *ChannelzService) getServer(_ interface{}, ctx context.Context, dec func
 	return interceptor(ctx, in, info, handler)
 }
 func (s *ChannelzService) getServerSockets(_ interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	if s.GetServerSockets == nil {
-		return nil, status.Errorf(codes.Unimplemented, "method GetServerSockets not implemented")
-	}
 	in := new(GetServerSocketsRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -116,9 +104,6 @@ func (s *ChannelzService) getServerSockets(_ interface{}, ctx context.Context, d
 	return interceptor(ctx, in, info, handler)
 }
 func (s *ChannelzService) getChannel(_ interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	if s.GetChannel == nil {
-		return nil, status.Errorf(codes.Unimplemented, "method GetChannel not implemented")
-	}
 	in := new(GetChannelRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -136,9 +121,6 @@ func (s *ChannelzService) getChannel(_ interface{}, ctx context.Context, dec fun
 	return interceptor(ctx, in, info, handler)
 }
 func (s *ChannelzService) getSubchannel(_ interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	if s.GetSubchannel == nil {
-		return nil, status.Errorf(codes.Unimplemented, "method GetSubchannel not implemented")
-	}
 	in := new(GetSubchannelRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -156,9 +138,6 @@ func (s *ChannelzService) getSubchannel(_ interface{}, ctx context.Context, dec 
 	return interceptor(ctx, in, info, handler)
 }
 func (s *ChannelzService) getSocket(_ interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	if s.GetSocket == nil {
-		return nil, status.Errorf(codes.Unimplemented, "method GetSocket not implemented")
-	}
 	in := new(GetSocketRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -177,7 +156,43 @@ func (s *ChannelzService) getSocket(_ interface{}, ctx context.Context, dec func
 }
 
 // RegisterChannelzService registers a service implementation with a gRPC server.
+// srv must not be modified after this function is called, and it may be modified by this function.
 func RegisterChannelzService(s grpc.ServiceRegistrar, srv *ChannelzService) {
+	if srv.GetTopChannels == nil {
+		srv.GetTopChannels = func(context.Context, *GetTopChannelsRequest) (*GetTopChannelsResponse, error) {
+			return nil, status.Errorf(codes.Unimplemented, "method GetTopChannels not implemented")
+		}
+	}
+	if srv.GetServers == nil {
+		srv.GetServers = func(context.Context, *GetServersRequest) (*GetServersResponse, error) {
+			return nil, status.Errorf(codes.Unimplemented, "method GetServers not implemented")
+		}
+	}
+	if srv.GetServer == nil {
+		srv.GetServer = func(context.Context, *GetServerRequest) (*GetServerResponse, error) {
+			return nil, status.Errorf(codes.Unimplemented, "method GetServer not implemented")
+		}
+	}
+	if srv.GetServerSockets == nil {
+		srv.GetServerSockets = func(context.Context, *GetServerSocketsRequest) (*GetServerSocketsResponse, error) {
+			return nil, status.Errorf(codes.Unimplemented, "method GetServerSockets not implemented")
+		}
+	}
+	if srv.GetChannel == nil {
+		srv.GetChannel = func(context.Context, *GetChannelRequest) (*GetChannelResponse, error) {
+			return nil, status.Errorf(codes.Unimplemented, "method GetChannel not implemented")
+		}
+	}
+	if srv.GetSubchannel == nil {
+		srv.GetSubchannel = func(context.Context, *GetSubchannelRequest) (*GetSubchannelResponse, error) {
+			return nil, status.Errorf(codes.Unimplemented, "method GetSubchannel not implemented")
+		}
+	}
+	if srv.GetSocket == nil {
+		srv.GetSocket = func(context.Context, *GetSocketRequest) (*GetSocketResponse, error) {
+			return nil, status.Errorf(codes.Unimplemented, "method GetSocket not implemented")
+		}
+	}
 	sd := grpc.ServiceDesc{
 		ServiceName: "grpc.channelz.v1.Channelz",
 		Methods: []grpc.MethodDesc{

--- a/credentials/alts/internal/proto/grpc_gcp/handshaker_grpc.pb.go
+++ b/credentials/alts/internal/proto/grpc_gcp/handshaker_grpc.pb.go
@@ -27,14 +27,17 @@ type HandshakerServiceService struct {
 }
 
 func (s *HandshakerServiceService) doHandshake(_ interface{}, stream grpc.ServerStream) error {
-	if s.DoHandshake == nil {
-		return status.Errorf(codes.Unimplemented, "method DoHandshake not implemented")
-	}
 	return s.DoHandshake(&handshakerServiceDoHandshakeServer{stream})
 }
 
 // RegisterHandshakerServiceService registers a service implementation with a gRPC server.
+// srv must not be modified after this function is called, and it may be modified by this function.
 func RegisterHandshakerServiceService(s grpc.ServiceRegistrar, srv *HandshakerServiceService) {
+	if srv.DoHandshake == nil {
+		srv.DoHandshake = func(HandshakerService_DoHandshakeServer) error {
+			return status.Errorf(codes.Unimplemented, "method DoHandshake not implemented")
+		}
+	}
 	sd := grpc.ServiceDesc{
 		ServiceName: "grpc.gcp.HandshakerService",
 		Methods:     []grpc.MethodDesc{},

--- a/credentials/alts/internal/proto/grpc_gcp/handshaker_grpc.pb.go
+++ b/credentials/alts/internal/proto/grpc_gcp/handshaker_grpc.pb.go
@@ -31,10 +31,10 @@ func (s *HandshakerServiceService) doHandshake(_ interface{}, stream grpc.Server
 }
 
 // RegisterHandshakerServiceService registers a service implementation with a gRPC server.
-// srv must not be modified after this function is called, and it may be modified by this function.
 func RegisterHandshakerServiceService(s grpc.ServiceRegistrar, srv *HandshakerServiceService) {
-	if srv.DoHandshake == nil {
-		srv.DoHandshake = func(HandshakerService_DoHandshakeServer) error {
+	srvCopy := *srv
+	if srvCopy.DoHandshake == nil {
+		srvCopy.DoHandshake = func(HandshakerService_DoHandshakeServer) error {
 			return status.Errorf(codes.Unimplemented, "method DoHandshake not implemented")
 		}
 	}
@@ -44,7 +44,7 @@ func RegisterHandshakerServiceService(s grpc.ServiceRegistrar, srv *HandshakerSe
 		Streams: []grpc.StreamDesc{
 			{
 				StreamName:    "DoHandshake",
-				Handler:       srv.doHandshake,
+				Handler:       srvCopy.doHandshake,
 				ServerStreams: true,
 				ClientStreams: true,
 			},

--- a/credentials/tls/certprovider/meshca/internal/v1/meshca_grpc.pb.go
+++ b/credentials/tls/certprovider/meshca/internal/v1/meshca_grpc.pb.go
@@ -42,10 +42,10 @@ func (s *MeshCertificateServiceService) createCertificate(_ interface{}, ctx con
 }
 
 // RegisterMeshCertificateServiceService registers a service implementation with a gRPC server.
-// srv must not be modified after this function is called, and it may be modified by this function.
 func RegisterMeshCertificateServiceService(s grpc.ServiceRegistrar, srv *MeshCertificateServiceService) {
-	if srv.CreateCertificate == nil {
-		srv.CreateCertificate = func(context.Context, *MeshCertificateRequest) (*MeshCertificateResponse, error) {
+	srvCopy := *srv
+	if srvCopy.CreateCertificate == nil {
+		srvCopy.CreateCertificate = func(context.Context, *MeshCertificateRequest) (*MeshCertificateResponse, error) {
 			return nil, status.Errorf(codes.Unimplemented, "method CreateCertificate not implemented")
 		}
 	}
@@ -54,7 +54,7 @@ func RegisterMeshCertificateServiceService(s grpc.ServiceRegistrar, srv *MeshCer
 		Methods: []grpc.MethodDesc{
 			{
 				MethodName: "CreateCertificate",
-				Handler:    srv.createCertificate,
+				Handler:    srvCopy.createCertificate,
 			},
 		},
 		Streams:  []grpc.StreamDesc{},

--- a/credentials/tls/certprovider/meshca/internal/v1/meshca_grpc.pb.go
+++ b/credentials/tls/certprovider/meshca/internal/v1/meshca_grpc.pb.go
@@ -24,9 +24,6 @@ type MeshCertificateServiceService struct {
 }
 
 func (s *MeshCertificateServiceService) createCertificate(_ interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	if s.CreateCertificate == nil {
-		return nil, status.Errorf(codes.Unimplemented, "method CreateCertificate not implemented")
-	}
 	in := new(MeshCertificateRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -45,7 +42,13 @@ func (s *MeshCertificateServiceService) createCertificate(_ interface{}, ctx con
 }
 
 // RegisterMeshCertificateServiceService registers a service implementation with a gRPC server.
+// srv must not be modified after this function is called, and it may be modified by this function.
 func RegisterMeshCertificateServiceService(s grpc.ServiceRegistrar, srv *MeshCertificateServiceService) {
+	if srv.CreateCertificate == nil {
+		srv.CreateCertificate = func(context.Context, *MeshCertificateRequest) (*MeshCertificateResponse, error) {
+			return nil, status.Errorf(codes.Unimplemented, "method CreateCertificate not implemented")
+		}
+	}
 	sd := grpc.ServiceDesc{
 		ServiceName: "google.security.meshca.v1.MeshCertificateService",
 		Methods: []grpc.MethodDesc{

--- a/examples/features/proto/echo/echo_grpc.pb.go
+++ b/examples/features/proto/echo/echo_grpc.pb.go
@@ -265,25 +265,25 @@ func (x *echoBidirectionalStreamingEchoServer) Recv() (*EchoRequest, error) {
 }
 
 // RegisterEchoService registers a service implementation with a gRPC server.
-// srv must not be modified after this function is called, and it may be modified by this function.
 func RegisterEchoService(s grpc.ServiceRegistrar, srv *EchoService) {
-	if srv.UnaryEcho == nil {
-		srv.UnaryEcho = func(context.Context, *EchoRequest) (*EchoResponse, error) {
+	srvCopy := *srv
+	if srvCopy.UnaryEcho == nil {
+		srvCopy.UnaryEcho = func(context.Context, *EchoRequest) (*EchoResponse, error) {
 			return nil, status.Errorf(codes.Unimplemented, "method UnaryEcho not implemented")
 		}
 	}
-	if srv.ServerStreamingEcho == nil {
-		srv.ServerStreamingEcho = func(*EchoRequest, Echo_ServerStreamingEchoServer) error {
+	if srvCopy.ServerStreamingEcho == nil {
+		srvCopy.ServerStreamingEcho = func(*EchoRequest, Echo_ServerStreamingEchoServer) error {
 			return status.Errorf(codes.Unimplemented, "method ServerStreamingEcho not implemented")
 		}
 	}
-	if srv.ClientStreamingEcho == nil {
-		srv.ClientStreamingEcho = func(Echo_ClientStreamingEchoServer) error {
+	if srvCopy.ClientStreamingEcho == nil {
+		srvCopy.ClientStreamingEcho = func(Echo_ClientStreamingEchoServer) error {
 			return status.Errorf(codes.Unimplemented, "method ClientStreamingEcho not implemented")
 		}
 	}
-	if srv.BidirectionalStreamingEcho == nil {
-		srv.BidirectionalStreamingEcho = func(Echo_BidirectionalStreamingEchoServer) error {
+	if srvCopy.BidirectionalStreamingEcho == nil {
+		srvCopy.BidirectionalStreamingEcho = func(Echo_BidirectionalStreamingEchoServer) error {
 			return status.Errorf(codes.Unimplemented, "method BidirectionalStreamingEcho not implemented")
 		}
 	}
@@ -292,23 +292,23 @@ func RegisterEchoService(s grpc.ServiceRegistrar, srv *EchoService) {
 		Methods: []grpc.MethodDesc{
 			{
 				MethodName: "UnaryEcho",
-				Handler:    srv.unaryEcho,
+				Handler:    srvCopy.unaryEcho,
 			},
 		},
 		Streams: []grpc.StreamDesc{
 			{
 				StreamName:    "ServerStreamingEcho",
-				Handler:       srv.serverStreamingEcho,
+				Handler:       srvCopy.serverStreamingEcho,
 				ServerStreams: true,
 			},
 			{
 				StreamName:    "ClientStreamingEcho",
-				Handler:       srv.clientStreamingEcho,
+				Handler:       srvCopy.clientStreamingEcho,
 				ClientStreams: true,
 			},
 			{
 				StreamName:    "BidirectionalStreamingEcho",
-				Handler:       srv.bidirectionalStreamingEcho,
+				Handler:       srvCopy.bidirectionalStreamingEcho,
 				ServerStreams: true,
 				ClientStreams: true,
 			},

--- a/examples/features/proto/echo/echo_grpc.pb.go
+++ b/examples/features/proto/echo/echo_grpc.pb.go
@@ -177,9 +177,6 @@ type EchoService struct {
 }
 
 func (s *EchoService) unaryEcho(_ interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	if s.UnaryEcho == nil {
-		return nil, status.Errorf(codes.Unimplemented, "method UnaryEcho not implemented")
-	}
 	in := new(EchoRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -197,9 +194,6 @@ func (s *EchoService) unaryEcho(_ interface{}, ctx context.Context, dec func(int
 	return interceptor(ctx, in, info, handler)
 }
 func (s *EchoService) serverStreamingEcho(_ interface{}, stream grpc.ServerStream) error {
-	if s.ServerStreamingEcho == nil {
-		return status.Errorf(codes.Unimplemented, "method ServerStreamingEcho not implemented")
-	}
 	m := new(EchoRequest)
 	if err := stream.RecvMsg(m); err != nil {
 		return err
@@ -207,15 +201,9 @@ func (s *EchoService) serverStreamingEcho(_ interface{}, stream grpc.ServerStrea
 	return s.ServerStreamingEcho(m, &echoServerStreamingEchoServer{stream})
 }
 func (s *EchoService) clientStreamingEcho(_ interface{}, stream grpc.ServerStream) error {
-	if s.ClientStreamingEcho == nil {
-		return status.Errorf(codes.Unimplemented, "method ClientStreamingEcho not implemented")
-	}
 	return s.ClientStreamingEcho(&echoClientStreamingEchoServer{stream})
 }
 func (s *EchoService) bidirectionalStreamingEcho(_ interface{}, stream grpc.ServerStream) error {
-	if s.BidirectionalStreamingEcho == nil {
-		return status.Errorf(codes.Unimplemented, "method BidirectionalStreamingEcho not implemented")
-	}
 	return s.BidirectionalStreamingEcho(&echoBidirectionalStreamingEchoServer{stream})
 }
 
@@ -277,7 +265,28 @@ func (x *echoBidirectionalStreamingEchoServer) Recv() (*EchoRequest, error) {
 }
 
 // RegisterEchoService registers a service implementation with a gRPC server.
+// srv must not be modified after this function is called, and it may be modified by this function.
 func RegisterEchoService(s grpc.ServiceRegistrar, srv *EchoService) {
+	if srv.UnaryEcho == nil {
+		srv.UnaryEcho = func(context.Context, *EchoRequest) (*EchoResponse, error) {
+			return nil, status.Errorf(codes.Unimplemented, "method UnaryEcho not implemented")
+		}
+	}
+	if srv.ServerStreamingEcho == nil {
+		srv.ServerStreamingEcho = func(*EchoRequest, Echo_ServerStreamingEchoServer) error {
+			return status.Errorf(codes.Unimplemented, "method ServerStreamingEcho not implemented")
+		}
+	}
+	if srv.ClientStreamingEcho == nil {
+		srv.ClientStreamingEcho = func(Echo_ClientStreamingEchoServer) error {
+			return status.Errorf(codes.Unimplemented, "method ClientStreamingEcho not implemented")
+		}
+	}
+	if srv.BidirectionalStreamingEcho == nil {
+		srv.BidirectionalStreamingEcho = func(Echo_BidirectionalStreamingEchoServer) error {
+			return status.Errorf(codes.Unimplemented, "method BidirectionalStreamingEcho not implemented")
+		}
+	}
 	sd := grpc.ServiceDesc{
 		ServiceName: "grpc.examples.echo.Echo",
 		Methods: []grpc.MethodDesc{

--- a/examples/helloworld/helloworld/helloworld_grpc.pb.go
+++ b/examples/helloworld/helloworld/helloworld_grpc.pb.go
@@ -52,9 +52,6 @@ type GreeterService struct {
 }
 
 func (s *GreeterService) sayHello(_ interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	if s.SayHello == nil {
-		return nil, status.Errorf(codes.Unimplemented, "method SayHello not implemented")
-	}
 	in := new(HelloRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -73,7 +70,13 @@ func (s *GreeterService) sayHello(_ interface{}, ctx context.Context, dec func(i
 }
 
 // RegisterGreeterService registers a service implementation with a gRPC server.
+// srv must not be modified after this function is called, and it may be modified by this function.
 func RegisterGreeterService(s grpc.ServiceRegistrar, srv *GreeterService) {
+	if srv.SayHello == nil {
+		srv.SayHello = func(context.Context, *HelloRequest) (*HelloReply, error) {
+			return nil, status.Errorf(codes.Unimplemented, "method SayHello not implemented")
+		}
+	}
 	sd := grpc.ServiceDesc{
 		ServiceName: "helloworld.Greeter",
 		Methods: []grpc.MethodDesc{

--- a/examples/helloworld/helloworld/helloworld_grpc.pb.go
+++ b/examples/helloworld/helloworld/helloworld_grpc.pb.go
@@ -70,10 +70,10 @@ func (s *GreeterService) sayHello(_ interface{}, ctx context.Context, dec func(i
 }
 
 // RegisterGreeterService registers a service implementation with a gRPC server.
-// srv must not be modified after this function is called, and it may be modified by this function.
 func RegisterGreeterService(s grpc.ServiceRegistrar, srv *GreeterService) {
-	if srv.SayHello == nil {
-		srv.SayHello = func(context.Context, *HelloRequest) (*HelloReply, error) {
+	srvCopy := *srv
+	if srvCopy.SayHello == nil {
+		srvCopy.SayHello = func(context.Context, *HelloRequest) (*HelloReply, error) {
 			return nil, status.Errorf(codes.Unimplemented, "method SayHello not implemented")
 		}
 	}
@@ -82,7 +82,7 @@ func RegisterGreeterService(s grpc.ServiceRegistrar, srv *GreeterService) {
 		Methods: []grpc.MethodDesc{
 			{
 				MethodName: "SayHello",
-				Handler:    srv.sayHello,
+				Handler:    srvCopy.sayHello,
 			},
 		},
 		Streams:  []grpc.StreamDesc{},

--- a/examples/route_guide/routeguide/route_guide_grpc.pb.go
+++ b/examples/route_guide/routeguide/route_guide_grpc.pb.go
@@ -209,9 +209,6 @@ type RouteGuideService struct {
 }
 
 func (s *RouteGuideService) getFeature(_ interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	if s.GetFeature == nil {
-		return nil, status.Errorf(codes.Unimplemented, "method GetFeature not implemented")
-	}
 	in := new(Point)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -229,9 +226,6 @@ func (s *RouteGuideService) getFeature(_ interface{}, ctx context.Context, dec f
 	return interceptor(ctx, in, info, handler)
 }
 func (s *RouteGuideService) listFeatures(_ interface{}, stream grpc.ServerStream) error {
-	if s.ListFeatures == nil {
-		return status.Errorf(codes.Unimplemented, "method ListFeatures not implemented")
-	}
 	m := new(Rectangle)
 	if err := stream.RecvMsg(m); err != nil {
 		return err
@@ -239,15 +233,9 @@ func (s *RouteGuideService) listFeatures(_ interface{}, stream grpc.ServerStream
 	return s.ListFeatures(m, &routeGuideListFeaturesServer{stream})
 }
 func (s *RouteGuideService) recordRoute(_ interface{}, stream grpc.ServerStream) error {
-	if s.RecordRoute == nil {
-		return status.Errorf(codes.Unimplemented, "method RecordRoute not implemented")
-	}
 	return s.RecordRoute(&routeGuideRecordRouteServer{stream})
 }
 func (s *RouteGuideService) routeChat(_ interface{}, stream grpc.ServerStream) error {
-	if s.RouteChat == nil {
-		return status.Errorf(codes.Unimplemented, "method RouteChat not implemented")
-	}
 	return s.RouteChat(&routeGuideRouteChatServer{stream})
 }
 
@@ -309,7 +297,28 @@ func (x *routeGuideRouteChatServer) Recv() (*RouteNote, error) {
 }
 
 // RegisterRouteGuideService registers a service implementation with a gRPC server.
+// srv must not be modified after this function is called, and it may be modified by this function.
 func RegisterRouteGuideService(s grpc.ServiceRegistrar, srv *RouteGuideService) {
+	if srv.GetFeature == nil {
+		srv.GetFeature = func(context.Context, *Point) (*Feature, error) {
+			return nil, status.Errorf(codes.Unimplemented, "method GetFeature not implemented")
+		}
+	}
+	if srv.ListFeatures == nil {
+		srv.ListFeatures = func(*Rectangle, RouteGuide_ListFeaturesServer) error {
+			return status.Errorf(codes.Unimplemented, "method ListFeatures not implemented")
+		}
+	}
+	if srv.RecordRoute == nil {
+		srv.RecordRoute = func(RouteGuide_RecordRouteServer) error {
+			return status.Errorf(codes.Unimplemented, "method RecordRoute not implemented")
+		}
+	}
+	if srv.RouteChat == nil {
+		srv.RouteChat = func(RouteGuide_RouteChatServer) error {
+			return status.Errorf(codes.Unimplemented, "method RouteChat not implemented")
+		}
+	}
 	sd := grpc.ServiceDesc{
 		ServiceName: "routeguide.RouteGuide",
 		Methods: []grpc.MethodDesc{

--- a/examples/route_guide/routeguide/route_guide_grpc.pb.go
+++ b/examples/route_guide/routeguide/route_guide_grpc.pb.go
@@ -297,25 +297,25 @@ func (x *routeGuideRouteChatServer) Recv() (*RouteNote, error) {
 }
 
 // RegisterRouteGuideService registers a service implementation with a gRPC server.
-// srv must not be modified after this function is called, and it may be modified by this function.
 func RegisterRouteGuideService(s grpc.ServiceRegistrar, srv *RouteGuideService) {
-	if srv.GetFeature == nil {
-		srv.GetFeature = func(context.Context, *Point) (*Feature, error) {
+	srvCopy := *srv
+	if srvCopy.GetFeature == nil {
+		srvCopy.GetFeature = func(context.Context, *Point) (*Feature, error) {
 			return nil, status.Errorf(codes.Unimplemented, "method GetFeature not implemented")
 		}
 	}
-	if srv.ListFeatures == nil {
-		srv.ListFeatures = func(*Rectangle, RouteGuide_ListFeaturesServer) error {
+	if srvCopy.ListFeatures == nil {
+		srvCopy.ListFeatures = func(*Rectangle, RouteGuide_ListFeaturesServer) error {
 			return status.Errorf(codes.Unimplemented, "method ListFeatures not implemented")
 		}
 	}
-	if srv.RecordRoute == nil {
-		srv.RecordRoute = func(RouteGuide_RecordRouteServer) error {
+	if srvCopy.RecordRoute == nil {
+		srvCopy.RecordRoute = func(RouteGuide_RecordRouteServer) error {
 			return status.Errorf(codes.Unimplemented, "method RecordRoute not implemented")
 		}
 	}
-	if srv.RouteChat == nil {
-		srv.RouteChat = func(RouteGuide_RouteChatServer) error {
+	if srvCopy.RouteChat == nil {
+		srvCopy.RouteChat = func(RouteGuide_RouteChatServer) error {
 			return status.Errorf(codes.Unimplemented, "method RouteChat not implemented")
 		}
 	}
@@ -324,23 +324,23 @@ func RegisterRouteGuideService(s grpc.ServiceRegistrar, srv *RouteGuideService) 
 		Methods: []grpc.MethodDesc{
 			{
 				MethodName: "GetFeature",
-				Handler:    srv.getFeature,
+				Handler:    srvCopy.getFeature,
 			},
 		},
 		Streams: []grpc.StreamDesc{
 			{
 				StreamName:    "ListFeatures",
-				Handler:       srv.listFeatures,
+				Handler:       srvCopy.listFeatures,
 				ServerStreams: true,
 			},
 			{
 				StreamName:    "RecordRoute",
-				Handler:       srv.recordRoute,
+				Handler:       srvCopy.recordRoute,
 				ClientStreams: true,
 			},
 			{
 				StreamName:    "RouteChat",
-				Handler:       srv.routeChat,
+				Handler:       srvCopy.routeChat,
 				ServerStreams: true,
 				ClientStreams: true,
 			},

--- a/health/grpc_health_v1/health_grpc.pb.go
+++ b/health/grpc_health_v1/health_grpc.pb.go
@@ -65,15 +65,15 @@ func (s *HealthService) watch(_ interface{}, stream grpc.ServerStream) error {
 }
 
 // RegisterHealthService registers a service implementation with a gRPC server.
-// srv must not be modified after this function is called, and it may be modified by this function.
 func RegisterHealthService(s grpc.ServiceRegistrar, srv *HealthService) {
-	if srv.Check == nil {
-		srv.Check = func(context.Context, *HealthCheckRequest) (*HealthCheckResponse, error) {
+	srvCopy := *srv
+	if srvCopy.Check == nil {
+		srvCopy.Check = func(context.Context, *HealthCheckRequest) (*HealthCheckResponse, error) {
 			return nil, status.Errorf(codes.Unimplemented, "method Check not implemented")
 		}
 	}
-	if srv.Watch == nil {
-		srv.Watch = func(*HealthCheckRequest, Health_WatchServer) error {
+	if srvCopy.Watch == nil {
+		srvCopy.Watch = func(*HealthCheckRequest, Health_WatchServer) error {
 			return status.Errorf(codes.Unimplemented, "method Watch not implemented")
 		}
 	}
@@ -82,13 +82,13 @@ func RegisterHealthService(s grpc.ServiceRegistrar, srv *HealthService) {
 		Methods: []grpc.MethodDesc{
 			{
 				MethodName: "Check",
-				Handler:    srv.check,
+				Handler:    srvCopy.check,
 			},
 		},
 		Streams: []grpc.StreamDesc{
 			{
 				StreamName:    "Watch",
-				Handler:       srv.watch,
+				Handler:       srvCopy.watch,
 				ServerStreams: true,
 			},
 		},

--- a/interop/grpc_testing/test_grpc.pb.go
+++ b/interop/grpc_testing/test_grpc.pb.go
@@ -251,9 +251,6 @@ type TestServiceService struct {
 }
 
 func (s *TestServiceService) emptyCall(_ interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	if s.EmptyCall == nil {
-		return nil, status.Errorf(codes.Unimplemented, "method EmptyCall not implemented")
-	}
 	in := new(Empty)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -271,9 +268,6 @@ func (s *TestServiceService) emptyCall(_ interface{}, ctx context.Context, dec f
 	return interceptor(ctx, in, info, handler)
 }
 func (s *TestServiceService) unaryCall(_ interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	if s.UnaryCall == nil {
-		return nil, status.Errorf(codes.Unimplemented, "method UnaryCall not implemented")
-	}
 	in := new(SimpleRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -291,9 +285,6 @@ func (s *TestServiceService) unaryCall(_ interface{}, ctx context.Context, dec f
 	return interceptor(ctx, in, info, handler)
 }
 func (s *TestServiceService) streamingOutputCall(_ interface{}, stream grpc.ServerStream) error {
-	if s.StreamingOutputCall == nil {
-		return status.Errorf(codes.Unimplemented, "method StreamingOutputCall not implemented")
-	}
 	m := new(StreamingOutputCallRequest)
 	if err := stream.RecvMsg(m); err != nil {
 		return err
@@ -301,21 +292,12 @@ func (s *TestServiceService) streamingOutputCall(_ interface{}, stream grpc.Serv
 	return s.StreamingOutputCall(m, &testServiceStreamingOutputCallServer{stream})
 }
 func (s *TestServiceService) streamingInputCall(_ interface{}, stream grpc.ServerStream) error {
-	if s.StreamingInputCall == nil {
-		return status.Errorf(codes.Unimplemented, "method StreamingInputCall not implemented")
-	}
 	return s.StreamingInputCall(&testServiceStreamingInputCallServer{stream})
 }
 func (s *TestServiceService) fullDuplexCall(_ interface{}, stream grpc.ServerStream) error {
-	if s.FullDuplexCall == nil {
-		return status.Errorf(codes.Unimplemented, "method FullDuplexCall not implemented")
-	}
 	return s.FullDuplexCall(&testServiceFullDuplexCallServer{stream})
 }
 func (s *TestServiceService) halfDuplexCall(_ interface{}, stream grpc.ServerStream) error {
-	if s.HalfDuplexCall == nil {
-		return status.Errorf(codes.Unimplemented, "method HalfDuplexCall not implemented")
-	}
 	return s.HalfDuplexCall(&testServiceHalfDuplexCallServer{stream})
 }
 
@@ -399,7 +381,38 @@ func (x *testServiceHalfDuplexCallServer) Recv() (*StreamingOutputCallRequest, e
 }
 
 // RegisterTestServiceService registers a service implementation with a gRPC server.
+// srv must not be modified after this function is called, and it may be modified by this function.
 func RegisterTestServiceService(s grpc.ServiceRegistrar, srv *TestServiceService) {
+	if srv.EmptyCall == nil {
+		srv.EmptyCall = func(context.Context, *Empty) (*Empty, error) {
+			return nil, status.Errorf(codes.Unimplemented, "method EmptyCall not implemented")
+		}
+	}
+	if srv.UnaryCall == nil {
+		srv.UnaryCall = func(context.Context, *SimpleRequest) (*SimpleResponse, error) {
+			return nil, status.Errorf(codes.Unimplemented, "method UnaryCall not implemented")
+		}
+	}
+	if srv.StreamingOutputCall == nil {
+		srv.StreamingOutputCall = func(*StreamingOutputCallRequest, TestService_StreamingOutputCallServer) error {
+			return status.Errorf(codes.Unimplemented, "method StreamingOutputCall not implemented")
+		}
+	}
+	if srv.StreamingInputCall == nil {
+		srv.StreamingInputCall = func(TestService_StreamingInputCallServer) error {
+			return status.Errorf(codes.Unimplemented, "method StreamingInputCall not implemented")
+		}
+	}
+	if srv.FullDuplexCall == nil {
+		srv.FullDuplexCall = func(TestService_FullDuplexCallServer) error {
+			return status.Errorf(codes.Unimplemented, "method FullDuplexCall not implemented")
+		}
+	}
+	if srv.HalfDuplexCall == nil {
+		srv.HalfDuplexCall = func(TestService_HalfDuplexCallServer) error {
+			return status.Errorf(codes.Unimplemented, "method HalfDuplexCall not implemented")
+		}
+	}
 	sd := grpc.ServiceDesc{
 		ServiceName: "grpc.testing.TestService",
 		Methods: []grpc.MethodDesc{
@@ -549,9 +562,6 @@ type UnimplementedServiceService struct {
 }
 
 func (s *UnimplementedServiceService) unimplementedCall(_ interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	if s.UnimplementedCall == nil {
-		return nil, status.Errorf(codes.Unimplemented, "method UnimplementedCall not implemented")
-	}
 	in := new(Empty)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -570,7 +580,13 @@ func (s *UnimplementedServiceService) unimplementedCall(_ interface{}, ctx conte
 }
 
 // RegisterUnimplementedServiceService registers a service implementation with a gRPC server.
+// srv must not be modified after this function is called, and it may be modified by this function.
 func RegisterUnimplementedServiceService(s grpc.ServiceRegistrar, srv *UnimplementedServiceService) {
+	if srv.UnimplementedCall == nil {
+		srv.UnimplementedCall = func(context.Context, *Empty) (*Empty, error) {
+			return nil, status.Errorf(codes.Unimplemented, "method UnimplementedCall not implemented")
+		}
+	}
 	sd := grpc.ServiceDesc{
 		ServiceName: "grpc.testing.UnimplementedService",
 		Methods: []grpc.MethodDesc{
@@ -650,9 +666,6 @@ type LoadBalancerStatsServiceService struct {
 }
 
 func (s *LoadBalancerStatsServiceService) getClientStats(_ interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	if s.GetClientStats == nil {
-		return nil, status.Errorf(codes.Unimplemented, "method GetClientStats not implemented")
-	}
 	in := new(LoadBalancerStatsRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -671,7 +684,13 @@ func (s *LoadBalancerStatsServiceService) getClientStats(_ interface{}, ctx cont
 }
 
 // RegisterLoadBalancerStatsServiceService registers a service implementation with a gRPC server.
+// srv must not be modified after this function is called, and it may be modified by this function.
 func RegisterLoadBalancerStatsServiceService(s grpc.ServiceRegistrar, srv *LoadBalancerStatsServiceService) {
+	if srv.GetClientStats == nil {
+		srv.GetClientStats = func(context.Context, *LoadBalancerStatsRequest) (*LoadBalancerStatsResponse, error) {
+			return nil, status.Errorf(codes.Unimplemented, "method GetClientStats not implemented")
+		}
+	}
 	sd := grpc.ServiceDesc{
 		ServiceName: "grpc.testing.LoadBalancerStatsService",
 		Methods: []grpc.MethodDesc{

--- a/interop/grpc_testing/test_grpc.pb.go
+++ b/interop/grpc_testing/test_grpc.pb.go
@@ -381,35 +381,35 @@ func (x *testServiceHalfDuplexCallServer) Recv() (*StreamingOutputCallRequest, e
 }
 
 // RegisterTestServiceService registers a service implementation with a gRPC server.
-// srv must not be modified after this function is called, and it may be modified by this function.
 func RegisterTestServiceService(s grpc.ServiceRegistrar, srv *TestServiceService) {
-	if srv.EmptyCall == nil {
-		srv.EmptyCall = func(context.Context, *Empty) (*Empty, error) {
+	srvCopy := *srv
+	if srvCopy.EmptyCall == nil {
+		srvCopy.EmptyCall = func(context.Context, *Empty) (*Empty, error) {
 			return nil, status.Errorf(codes.Unimplemented, "method EmptyCall not implemented")
 		}
 	}
-	if srv.UnaryCall == nil {
-		srv.UnaryCall = func(context.Context, *SimpleRequest) (*SimpleResponse, error) {
+	if srvCopy.UnaryCall == nil {
+		srvCopy.UnaryCall = func(context.Context, *SimpleRequest) (*SimpleResponse, error) {
 			return nil, status.Errorf(codes.Unimplemented, "method UnaryCall not implemented")
 		}
 	}
-	if srv.StreamingOutputCall == nil {
-		srv.StreamingOutputCall = func(*StreamingOutputCallRequest, TestService_StreamingOutputCallServer) error {
+	if srvCopy.StreamingOutputCall == nil {
+		srvCopy.StreamingOutputCall = func(*StreamingOutputCallRequest, TestService_StreamingOutputCallServer) error {
 			return status.Errorf(codes.Unimplemented, "method StreamingOutputCall not implemented")
 		}
 	}
-	if srv.StreamingInputCall == nil {
-		srv.StreamingInputCall = func(TestService_StreamingInputCallServer) error {
+	if srvCopy.StreamingInputCall == nil {
+		srvCopy.StreamingInputCall = func(TestService_StreamingInputCallServer) error {
 			return status.Errorf(codes.Unimplemented, "method StreamingInputCall not implemented")
 		}
 	}
-	if srv.FullDuplexCall == nil {
-		srv.FullDuplexCall = func(TestService_FullDuplexCallServer) error {
+	if srvCopy.FullDuplexCall == nil {
+		srvCopy.FullDuplexCall = func(TestService_FullDuplexCallServer) error {
 			return status.Errorf(codes.Unimplemented, "method FullDuplexCall not implemented")
 		}
 	}
-	if srv.HalfDuplexCall == nil {
-		srv.HalfDuplexCall = func(TestService_HalfDuplexCallServer) error {
+	if srvCopy.HalfDuplexCall == nil {
+		srvCopy.HalfDuplexCall = func(TestService_HalfDuplexCallServer) error {
 			return status.Errorf(codes.Unimplemented, "method HalfDuplexCall not implemented")
 		}
 	}
@@ -418,33 +418,33 @@ func RegisterTestServiceService(s grpc.ServiceRegistrar, srv *TestServiceService
 		Methods: []grpc.MethodDesc{
 			{
 				MethodName: "EmptyCall",
-				Handler:    srv.emptyCall,
+				Handler:    srvCopy.emptyCall,
 			},
 			{
 				MethodName: "UnaryCall",
-				Handler:    srv.unaryCall,
+				Handler:    srvCopy.unaryCall,
 			},
 		},
 		Streams: []grpc.StreamDesc{
 			{
 				StreamName:    "StreamingOutputCall",
-				Handler:       srv.streamingOutputCall,
+				Handler:       srvCopy.streamingOutputCall,
 				ServerStreams: true,
 			},
 			{
 				StreamName:    "StreamingInputCall",
-				Handler:       srv.streamingInputCall,
+				Handler:       srvCopy.streamingInputCall,
 				ClientStreams: true,
 			},
 			{
 				StreamName:    "FullDuplexCall",
-				Handler:       srv.fullDuplexCall,
+				Handler:       srvCopy.fullDuplexCall,
 				ServerStreams: true,
 				ClientStreams: true,
 			},
 			{
 				StreamName:    "HalfDuplexCall",
-				Handler:       srv.halfDuplexCall,
+				Handler:       srvCopy.halfDuplexCall,
 				ServerStreams: true,
 				ClientStreams: true,
 			},
@@ -580,10 +580,10 @@ func (s *UnimplementedServiceService) unimplementedCall(_ interface{}, ctx conte
 }
 
 // RegisterUnimplementedServiceService registers a service implementation with a gRPC server.
-// srv must not be modified after this function is called, and it may be modified by this function.
 func RegisterUnimplementedServiceService(s grpc.ServiceRegistrar, srv *UnimplementedServiceService) {
-	if srv.UnimplementedCall == nil {
-		srv.UnimplementedCall = func(context.Context, *Empty) (*Empty, error) {
+	srvCopy := *srv
+	if srvCopy.UnimplementedCall == nil {
+		srvCopy.UnimplementedCall = func(context.Context, *Empty) (*Empty, error) {
 			return nil, status.Errorf(codes.Unimplemented, "method UnimplementedCall not implemented")
 		}
 	}
@@ -592,7 +592,7 @@ func RegisterUnimplementedServiceService(s grpc.ServiceRegistrar, srv *Unimpleme
 		Methods: []grpc.MethodDesc{
 			{
 				MethodName: "UnimplementedCall",
-				Handler:    srv.unimplementedCall,
+				Handler:    srvCopy.unimplementedCall,
 			},
 		},
 		Streams:  []grpc.StreamDesc{},
@@ -684,10 +684,10 @@ func (s *LoadBalancerStatsServiceService) getClientStats(_ interface{}, ctx cont
 }
 
 // RegisterLoadBalancerStatsServiceService registers a service implementation with a gRPC server.
-// srv must not be modified after this function is called, and it may be modified by this function.
 func RegisterLoadBalancerStatsServiceService(s grpc.ServiceRegistrar, srv *LoadBalancerStatsServiceService) {
-	if srv.GetClientStats == nil {
-		srv.GetClientStats = func(context.Context, *LoadBalancerStatsRequest) (*LoadBalancerStatsResponse, error) {
+	srvCopy := *srv
+	if srvCopy.GetClientStats == nil {
+		srvCopy.GetClientStats = func(context.Context, *LoadBalancerStatsRequest) (*LoadBalancerStatsResponse, error) {
 			return nil, status.Errorf(codes.Unimplemented, "method GetClientStats not implemented")
 		}
 	}
@@ -696,7 +696,7 @@ func RegisterLoadBalancerStatsServiceService(s grpc.ServiceRegistrar, srv *LoadB
 		Methods: []grpc.MethodDesc{
 			{
 				MethodName: "GetClientStats",
-				Handler:    srv.getClientStats,
+				Handler:    srvCopy.getClientStats,
 			},
 		},
 		Streams:  []grpc.StreamDesc{},

--- a/profiling/proto/service_grpc.pb.go
+++ b/profiling/proto/service_grpc.pb.go
@@ -26,9 +26,6 @@ type ProfilingService struct {
 }
 
 func (s *ProfilingService) enable(_ interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	if s.Enable == nil {
-		return nil, status.Errorf(codes.Unimplemented, "method Enable not implemented")
-	}
 	in := new(EnableRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -46,9 +43,6 @@ func (s *ProfilingService) enable(_ interface{}, ctx context.Context, dec func(i
 	return interceptor(ctx, in, info, handler)
 }
 func (s *ProfilingService) getStreamStats(_ interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	if s.GetStreamStats == nil {
-		return nil, status.Errorf(codes.Unimplemented, "method GetStreamStats not implemented")
-	}
 	in := new(GetStreamStatsRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -67,7 +61,18 @@ func (s *ProfilingService) getStreamStats(_ interface{}, ctx context.Context, de
 }
 
 // RegisterProfilingService registers a service implementation with a gRPC server.
+// srv must not be modified after this function is called, and it may be modified by this function.
 func RegisterProfilingService(s grpc.ServiceRegistrar, srv *ProfilingService) {
+	if srv.Enable == nil {
+		srv.Enable = func(context.Context, *EnableRequest) (*EnableResponse, error) {
+			return nil, status.Errorf(codes.Unimplemented, "method Enable not implemented")
+		}
+	}
+	if srv.GetStreamStats == nil {
+		srv.GetStreamStats = func(context.Context, *GetStreamStatsRequest) (*GetStreamStatsResponse, error) {
+			return nil, status.Errorf(codes.Unimplemented, "method GetStreamStats not implemented")
+		}
+	}
 	sd := grpc.ServiceDesc{
 		ServiceName: "grpc.go.profiling.v1alpha.Profiling",
 		Methods: []grpc.MethodDesc{

--- a/profiling/proto/service_grpc.pb.go
+++ b/profiling/proto/service_grpc.pb.go
@@ -61,15 +61,15 @@ func (s *ProfilingService) getStreamStats(_ interface{}, ctx context.Context, de
 }
 
 // RegisterProfilingService registers a service implementation with a gRPC server.
-// srv must not be modified after this function is called, and it may be modified by this function.
 func RegisterProfilingService(s grpc.ServiceRegistrar, srv *ProfilingService) {
-	if srv.Enable == nil {
-		srv.Enable = func(context.Context, *EnableRequest) (*EnableResponse, error) {
+	srvCopy := *srv
+	if srvCopy.Enable == nil {
+		srvCopy.Enable = func(context.Context, *EnableRequest) (*EnableResponse, error) {
 			return nil, status.Errorf(codes.Unimplemented, "method Enable not implemented")
 		}
 	}
-	if srv.GetStreamStats == nil {
-		srv.GetStreamStats = func(context.Context, *GetStreamStatsRequest) (*GetStreamStatsResponse, error) {
+	if srvCopy.GetStreamStats == nil {
+		srvCopy.GetStreamStats = func(context.Context, *GetStreamStatsRequest) (*GetStreamStatsResponse, error) {
 			return nil, status.Errorf(codes.Unimplemented, "method GetStreamStats not implemented")
 		}
 	}
@@ -78,11 +78,11 @@ func RegisterProfilingService(s grpc.ServiceRegistrar, srv *ProfilingService) {
 		Methods: []grpc.MethodDesc{
 			{
 				MethodName: "Enable",
-				Handler:    srv.enable,
+				Handler:    srvCopy.enable,
 			},
 			{
 				MethodName: "GetStreamStats",
-				Handler:    srv.getStreamStats,
+				Handler:    srvCopy.getStreamStats,
 			},
 		},
 		Streams:  []grpc.StreamDesc{},

--- a/reflection/grpc_reflection_v1alpha/reflection_grpc.pb.go
+++ b/reflection/grpc_reflection_v1alpha/reflection_grpc.pb.go
@@ -27,10 +27,10 @@ func (s *ServerReflectionService) serverReflectionInfo(_ interface{}, stream grp
 }
 
 // RegisterServerReflectionService registers a service implementation with a gRPC server.
-// srv must not be modified after this function is called, and it may be modified by this function.
 func RegisterServerReflectionService(s grpc.ServiceRegistrar, srv *ServerReflectionService) {
-	if srv.ServerReflectionInfo == nil {
-		srv.ServerReflectionInfo = func(ServerReflection_ServerReflectionInfoServer) error {
+	srvCopy := *srv
+	if srvCopy.ServerReflectionInfo == nil {
+		srvCopy.ServerReflectionInfo = func(ServerReflection_ServerReflectionInfoServer) error {
 			return status.Errorf(codes.Unimplemented, "method ServerReflectionInfo not implemented")
 		}
 	}
@@ -40,7 +40,7 @@ func RegisterServerReflectionService(s grpc.ServiceRegistrar, srv *ServerReflect
 		Streams: []grpc.StreamDesc{
 			{
 				StreamName:    "ServerReflectionInfo",
-				Handler:       srv.serverReflectionInfo,
+				Handler:       srvCopy.serverReflectionInfo,
 				ServerStreams: true,
 				ClientStreams: true,
 			},

--- a/reflection/grpc_reflection_v1alpha/reflection_grpc.pb.go
+++ b/reflection/grpc_reflection_v1alpha/reflection_grpc.pb.go
@@ -23,14 +23,17 @@ type ServerReflectionService struct {
 }
 
 func (s *ServerReflectionService) serverReflectionInfo(_ interface{}, stream grpc.ServerStream) error {
-	if s.ServerReflectionInfo == nil {
-		return status.Errorf(codes.Unimplemented, "method ServerReflectionInfo not implemented")
-	}
 	return s.ServerReflectionInfo(&serverReflectionServerReflectionInfoServer{stream})
 }
 
 // RegisterServerReflectionService registers a service implementation with a gRPC server.
+// srv must not be modified after this function is called, and it may be modified by this function.
 func RegisterServerReflectionService(s grpc.ServiceRegistrar, srv *ServerReflectionService) {
+	if srv.ServerReflectionInfo == nil {
+		srv.ServerReflectionInfo = func(ServerReflection_ServerReflectionInfoServer) error {
+			return status.Errorf(codes.Unimplemented, "method ServerReflectionInfo not implemented")
+		}
+	}
 	sd := grpc.ServiceDesc{
 		ServiceName: "grpc.reflection.v1alpha.ServerReflection",
 		Methods:     []grpc.MethodDesc{},

--- a/reflection/grpc_testing/test_grpc.pb.go
+++ b/reflection/grpc_testing/test_grpc.pb.go
@@ -89,9 +89,6 @@ type SearchServiceService struct {
 }
 
 func (s *SearchServiceService) search(_ interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	if s.Search == nil {
-		return nil, status.Errorf(codes.Unimplemented, "method Search not implemented")
-	}
 	in := new(SearchRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -109,9 +106,6 @@ func (s *SearchServiceService) search(_ interface{}, ctx context.Context, dec fu
 	return interceptor(ctx, in, info, handler)
 }
 func (s *SearchServiceService) streamingSearch(_ interface{}, stream grpc.ServerStream) error {
-	if s.StreamingSearch == nil {
-		return status.Errorf(codes.Unimplemented, "method StreamingSearch not implemented")
-	}
 	return s.StreamingSearch(&searchServiceStreamingSearchServer{stream})
 }
 
@@ -138,7 +132,18 @@ func (x *searchServiceStreamingSearchServer) Recv() (*SearchRequest, error) {
 }
 
 // RegisterSearchServiceService registers a service implementation with a gRPC server.
+// srv must not be modified after this function is called, and it may be modified by this function.
 func RegisterSearchServiceService(s grpc.ServiceRegistrar, srv *SearchServiceService) {
+	if srv.Search == nil {
+		srv.Search = func(context.Context, *SearchRequest) (*SearchResponse, error) {
+			return nil, status.Errorf(codes.Unimplemented, "method Search not implemented")
+		}
+	}
+	if srv.StreamingSearch == nil {
+		srv.StreamingSearch = func(SearchService_StreamingSearchServer) error {
+			return status.Errorf(codes.Unimplemented, "method StreamingSearch not implemented")
+		}
+	}
 	sd := grpc.ServiceDesc{
 		ServiceName: "grpc.testing.SearchService",
 		Methods: []grpc.MethodDesc{

--- a/reflection/grpc_testing/test_grpc.pb.go
+++ b/reflection/grpc_testing/test_grpc.pb.go
@@ -132,15 +132,15 @@ func (x *searchServiceStreamingSearchServer) Recv() (*SearchRequest, error) {
 }
 
 // RegisterSearchServiceService registers a service implementation with a gRPC server.
-// srv must not be modified after this function is called, and it may be modified by this function.
 func RegisterSearchServiceService(s grpc.ServiceRegistrar, srv *SearchServiceService) {
-	if srv.Search == nil {
-		srv.Search = func(context.Context, *SearchRequest) (*SearchResponse, error) {
+	srvCopy := *srv
+	if srvCopy.Search == nil {
+		srvCopy.Search = func(context.Context, *SearchRequest) (*SearchResponse, error) {
 			return nil, status.Errorf(codes.Unimplemented, "method Search not implemented")
 		}
 	}
-	if srv.StreamingSearch == nil {
-		srv.StreamingSearch = func(SearchService_StreamingSearchServer) error {
+	if srvCopy.StreamingSearch == nil {
+		srvCopy.StreamingSearch = func(SearchService_StreamingSearchServer) error {
 			return status.Errorf(codes.Unimplemented, "method StreamingSearch not implemented")
 		}
 	}
@@ -149,13 +149,13 @@ func RegisterSearchServiceService(s grpc.ServiceRegistrar, srv *SearchServiceSer
 		Methods: []grpc.MethodDesc{
 			{
 				MethodName: "Search",
-				Handler:    srv.search,
+				Handler:    srvCopy.search,
 			},
 		},
 		Streams: []grpc.StreamDesc{
 			{
 				StreamName:    "StreamingSearch",
-				Handler:       srv.streamingSearch,
+				Handler:       srvCopy.streamingSearch,
 				ServerStreams: true,
 				ClientStreams: true,
 			},

--- a/stats/grpc_testing/test_grpc.pb.go
+++ b/stats/grpc_testing/test_grpc.pb.go
@@ -183,9 +183,6 @@ type TestServiceService struct {
 }
 
 func (s *TestServiceService) unaryCall(_ interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	if s.UnaryCall == nil {
-		return nil, status.Errorf(codes.Unimplemented, "method UnaryCall not implemented")
-	}
 	in := new(SimpleRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -203,21 +200,12 @@ func (s *TestServiceService) unaryCall(_ interface{}, ctx context.Context, dec f
 	return interceptor(ctx, in, info, handler)
 }
 func (s *TestServiceService) fullDuplexCall(_ interface{}, stream grpc.ServerStream) error {
-	if s.FullDuplexCall == nil {
-		return status.Errorf(codes.Unimplemented, "method FullDuplexCall not implemented")
-	}
 	return s.FullDuplexCall(&testServiceFullDuplexCallServer{stream})
 }
 func (s *TestServiceService) clientStreamCall(_ interface{}, stream grpc.ServerStream) error {
-	if s.ClientStreamCall == nil {
-		return status.Errorf(codes.Unimplemented, "method ClientStreamCall not implemented")
-	}
 	return s.ClientStreamCall(&testServiceClientStreamCallServer{stream})
 }
 func (s *TestServiceService) serverStreamCall(_ interface{}, stream grpc.ServerStream) error {
-	if s.ServerStreamCall == nil {
-		return status.Errorf(codes.Unimplemented, "method ServerStreamCall not implemented")
-	}
 	m := new(SimpleRequest)
 	if err := stream.RecvMsg(m); err != nil {
 		return err
@@ -283,7 +271,28 @@ func (x *testServiceServerStreamCallServer) Send(m *SimpleResponse) error {
 }
 
 // RegisterTestServiceService registers a service implementation with a gRPC server.
+// srv must not be modified after this function is called, and it may be modified by this function.
 func RegisterTestServiceService(s grpc.ServiceRegistrar, srv *TestServiceService) {
+	if srv.UnaryCall == nil {
+		srv.UnaryCall = func(context.Context, *SimpleRequest) (*SimpleResponse, error) {
+			return nil, status.Errorf(codes.Unimplemented, "method UnaryCall not implemented")
+		}
+	}
+	if srv.FullDuplexCall == nil {
+		srv.FullDuplexCall = func(TestService_FullDuplexCallServer) error {
+			return status.Errorf(codes.Unimplemented, "method FullDuplexCall not implemented")
+		}
+	}
+	if srv.ClientStreamCall == nil {
+		srv.ClientStreamCall = func(TestService_ClientStreamCallServer) error {
+			return status.Errorf(codes.Unimplemented, "method ClientStreamCall not implemented")
+		}
+	}
+	if srv.ServerStreamCall == nil {
+		srv.ServerStreamCall = func(*SimpleRequest, TestService_ServerStreamCallServer) error {
+			return status.Errorf(codes.Unimplemented, "method ServerStreamCall not implemented")
+		}
+	}
 	sd := grpc.ServiceDesc{
 		ServiceName: "grpc.testing.TestService",
 		Methods: []grpc.MethodDesc{

--- a/stats/grpc_testing/test_grpc.pb.go
+++ b/stats/grpc_testing/test_grpc.pb.go
@@ -271,25 +271,25 @@ func (x *testServiceServerStreamCallServer) Send(m *SimpleResponse) error {
 }
 
 // RegisterTestServiceService registers a service implementation with a gRPC server.
-// srv must not be modified after this function is called, and it may be modified by this function.
 func RegisterTestServiceService(s grpc.ServiceRegistrar, srv *TestServiceService) {
-	if srv.UnaryCall == nil {
-		srv.UnaryCall = func(context.Context, *SimpleRequest) (*SimpleResponse, error) {
+	srvCopy := *srv
+	if srvCopy.UnaryCall == nil {
+		srvCopy.UnaryCall = func(context.Context, *SimpleRequest) (*SimpleResponse, error) {
 			return nil, status.Errorf(codes.Unimplemented, "method UnaryCall not implemented")
 		}
 	}
-	if srv.FullDuplexCall == nil {
-		srv.FullDuplexCall = func(TestService_FullDuplexCallServer) error {
+	if srvCopy.FullDuplexCall == nil {
+		srvCopy.FullDuplexCall = func(TestService_FullDuplexCallServer) error {
 			return status.Errorf(codes.Unimplemented, "method FullDuplexCall not implemented")
 		}
 	}
-	if srv.ClientStreamCall == nil {
-		srv.ClientStreamCall = func(TestService_ClientStreamCallServer) error {
+	if srvCopy.ClientStreamCall == nil {
+		srvCopy.ClientStreamCall = func(TestService_ClientStreamCallServer) error {
 			return status.Errorf(codes.Unimplemented, "method ClientStreamCall not implemented")
 		}
 	}
-	if srv.ServerStreamCall == nil {
-		srv.ServerStreamCall = func(*SimpleRequest, TestService_ServerStreamCallServer) error {
+	if srvCopy.ServerStreamCall == nil {
+		srvCopy.ServerStreamCall = func(*SimpleRequest, TestService_ServerStreamCallServer) error {
 			return status.Errorf(codes.Unimplemented, "method ServerStreamCall not implemented")
 		}
 	}
@@ -298,24 +298,24 @@ func RegisterTestServiceService(s grpc.ServiceRegistrar, srv *TestServiceService
 		Methods: []grpc.MethodDesc{
 			{
 				MethodName: "UnaryCall",
-				Handler:    srv.unaryCall,
+				Handler:    srvCopy.unaryCall,
 			},
 		},
 		Streams: []grpc.StreamDesc{
 			{
 				StreamName:    "FullDuplexCall",
-				Handler:       srv.fullDuplexCall,
+				Handler:       srvCopy.fullDuplexCall,
 				ServerStreams: true,
 				ClientStreams: true,
 			},
 			{
 				StreamName:    "ClientStreamCall",
-				Handler:       srv.clientStreamCall,
+				Handler:       srvCopy.clientStreamCall,
 				ClientStreams: true,
 			},
 			{
 				StreamName:    "ServerStreamCall",
-				Handler:       srv.serverStreamCall,
+				Handler:       srvCopy.serverStreamCall,
 				ServerStreams: true,
 			},
 		},

--- a/stress/grpc_testing/metrics_grpc.pb.go
+++ b/stress/grpc_testing/metrics_grpc.pb.go
@@ -95,9 +95,6 @@ type MetricsServiceService struct {
 }
 
 func (s *MetricsServiceService) getAllGauges(_ interface{}, stream grpc.ServerStream) error {
-	if s.GetAllGauges == nil {
-		return status.Errorf(codes.Unimplemented, "method GetAllGauges not implemented")
-	}
 	m := new(EmptyMessage)
 	if err := stream.RecvMsg(m); err != nil {
 		return err
@@ -105,9 +102,6 @@ func (s *MetricsServiceService) getAllGauges(_ interface{}, stream grpc.ServerSt
 	return s.GetAllGauges(m, &metricsServiceGetAllGaugesServer{stream})
 }
 func (s *MetricsServiceService) getGauge(_ interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	if s.GetGauge == nil {
-		return nil, status.Errorf(codes.Unimplemented, "method GetGauge not implemented")
-	}
 	in := new(GaugeRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -139,7 +133,18 @@ func (x *metricsServiceGetAllGaugesServer) Send(m *GaugeResponse) error {
 }
 
 // RegisterMetricsServiceService registers a service implementation with a gRPC server.
+// srv must not be modified after this function is called, and it may be modified by this function.
 func RegisterMetricsServiceService(s grpc.ServiceRegistrar, srv *MetricsServiceService) {
+	if srv.GetAllGauges == nil {
+		srv.GetAllGauges = func(*EmptyMessage, MetricsService_GetAllGaugesServer) error {
+			return status.Errorf(codes.Unimplemented, "method GetAllGauges not implemented")
+		}
+	}
+	if srv.GetGauge == nil {
+		srv.GetGauge = func(context.Context, *GaugeRequest) (*GaugeResponse, error) {
+			return nil, status.Errorf(codes.Unimplemented, "method GetGauge not implemented")
+		}
+	}
 	sd := grpc.ServiceDesc{
 		ServiceName: "grpc.testing.MetricsService",
 		Methods: []grpc.MethodDesc{

--- a/stress/grpc_testing/metrics_grpc.pb.go
+++ b/stress/grpc_testing/metrics_grpc.pb.go
@@ -133,15 +133,15 @@ func (x *metricsServiceGetAllGaugesServer) Send(m *GaugeResponse) error {
 }
 
 // RegisterMetricsServiceService registers a service implementation with a gRPC server.
-// srv must not be modified after this function is called, and it may be modified by this function.
 func RegisterMetricsServiceService(s grpc.ServiceRegistrar, srv *MetricsServiceService) {
-	if srv.GetAllGauges == nil {
-		srv.GetAllGauges = func(*EmptyMessage, MetricsService_GetAllGaugesServer) error {
+	srvCopy := *srv
+	if srvCopy.GetAllGauges == nil {
+		srvCopy.GetAllGauges = func(*EmptyMessage, MetricsService_GetAllGaugesServer) error {
 			return status.Errorf(codes.Unimplemented, "method GetAllGauges not implemented")
 		}
 	}
-	if srv.GetGauge == nil {
-		srv.GetGauge = func(context.Context, *GaugeRequest) (*GaugeResponse, error) {
+	if srvCopy.GetGauge == nil {
+		srvCopy.GetGauge = func(context.Context, *GaugeRequest) (*GaugeResponse, error) {
 			return nil, status.Errorf(codes.Unimplemented, "method GetGauge not implemented")
 		}
 	}
@@ -150,13 +150,13 @@ func RegisterMetricsServiceService(s grpc.ServiceRegistrar, srv *MetricsServiceS
 		Methods: []grpc.MethodDesc{
 			{
 				MethodName: "GetGauge",
-				Handler:    srv.getGauge,
+				Handler:    srvCopy.getGauge,
 			},
 		},
 		Streams: []grpc.StreamDesc{
 			{
 				StreamName:    "GetAllGauges",
-				Handler:       srv.getAllGauges,
+				Handler:       srvCopy.getAllGauges,
 				ServerStreams: true,
 			},
 		},

--- a/test/grpc_testing/test_grpc.pb.go
+++ b/test/grpc_testing/test_grpc.pb.go
@@ -251,9 +251,6 @@ type TestServiceService struct {
 }
 
 func (s *TestServiceService) emptyCall(_ interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	if s.EmptyCall == nil {
-		return nil, status.Errorf(codes.Unimplemented, "method EmptyCall not implemented")
-	}
 	in := new(Empty)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -271,9 +268,6 @@ func (s *TestServiceService) emptyCall(_ interface{}, ctx context.Context, dec f
 	return interceptor(ctx, in, info, handler)
 }
 func (s *TestServiceService) unaryCall(_ interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	if s.UnaryCall == nil {
-		return nil, status.Errorf(codes.Unimplemented, "method UnaryCall not implemented")
-	}
 	in := new(SimpleRequest)
 	if err := dec(in); err != nil {
 		return nil, err
@@ -291,9 +285,6 @@ func (s *TestServiceService) unaryCall(_ interface{}, ctx context.Context, dec f
 	return interceptor(ctx, in, info, handler)
 }
 func (s *TestServiceService) streamingOutputCall(_ interface{}, stream grpc.ServerStream) error {
-	if s.StreamingOutputCall == nil {
-		return status.Errorf(codes.Unimplemented, "method StreamingOutputCall not implemented")
-	}
 	m := new(StreamingOutputCallRequest)
 	if err := stream.RecvMsg(m); err != nil {
 		return err
@@ -301,21 +292,12 @@ func (s *TestServiceService) streamingOutputCall(_ interface{}, stream grpc.Serv
 	return s.StreamingOutputCall(m, &testServiceStreamingOutputCallServer{stream})
 }
 func (s *TestServiceService) streamingInputCall(_ interface{}, stream grpc.ServerStream) error {
-	if s.StreamingInputCall == nil {
-		return status.Errorf(codes.Unimplemented, "method StreamingInputCall not implemented")
-	}
 	return s.StreamingInputCall(&testServiceStreamingInputCallServer{stream})
 }
 func (s *TestServiceService) fullDuplexCall(_ interface{}, stream grpc.ServerStream) error {
-	if s.FullDuplexCall == nil {
-		return status.Errorf(codes.Unimplemented, "method FullDuplexCall not implemented")
-	}
 	return s.FullDuplexCall(&testServiceFullDuplexCallServer{stream})
 }
 func (s *TestServiceService) halfDuplexCall(_ interface{}, stream grpc.ServerStream) error {
-	if s.HalfDuplexCall == nil {
-		return status.Errorf(codes.Unimplemented, "method HalfDuplexCall not implemented")
-	}
 	return s.HalfDuplexCall(&testServiceHalfDuplexCallServer{stream})
 }
 
@@ -399,7 +381,38 @@ func (x *testServiceHalfDuplexCallServer) Recv() (*StreamingOutputCallRequest, e
 }
 
 // RegisterTestServiceService registers a service implementation with a gRPC server.
+// srv must not be modified after this function is called, and it may be modified by this function.
 func RegisterTestServiceService(s grpc.ServiceRegistrar, srv *TestServiceService) {
+	if srv.EmptyCall == nil {
+		srv.EmptyCall = func(context.Context, *Empty) (*Empty, error) {
+			return nil, status.Errorf(codes.Unimplemented, "method EmptyCall not implemented")
+		}
+	}
+	if srv.UnaryCall == nil {
+		srv.UnaryCall = func(context.Context, *SimpleRequest) (*SimpleResponse, error) {
+			return nil, status.Errorf(codes.Unimplemented, "method UnaryCall not implemented")
+		}
+	}
+	if srv.StreamingOutputCall == nil {
+		srv.StreamingOutputCall = func(*StreamingOutputCallRequest, TestService_StreamingOutputCallServer) error {
+			return status.Errorf(codes.Unimplemented, "method StreamingOutputCall not implemented")
+		}
+	}
+	if srv.StreamingInputCall == nil {
+		srv.StreamingInputCall = func(TestService_StreamingInputCallServer) error {
+			return status.Errorf(codes.Unimplemented, "method StreamingInputCall not implemented")
+		}
+	}
+	if srv.FullDuplexCall == nil {
+		srv.FullDuplexCall = func(TestService_FullDuplexCallServer) error {
+			return status.Errorf(codes.Unimplemented, "method FullDuplexCall not implemented")
+		}
+	}
+	if srv.HalfDuplexCall == nil {
+		srv.HalfDuplexCall = func(TestService_HalfDuplexCallServer) error {
+			return status.Errorf(codes.Unimplemented, "method HalfDuplexCall not implemented")
+		}
+	}
 	sd := grpc.ServiceDesc{
 		ServiceName: "grpc.testing.TestService",
 		Methods: []grpc.MethodDesc{

--- a/test/grpc_testing/test_grpc.pb.go
+++ b/test/grpc_testing/test_grpc.pb.go
@@ -381,35 +381,35 @@ func (x *testServiceHalfDuplexCallServer) Recv() (*StreamingOutputCallRequest, e
 }
 
 // RegisterTestServiceService registers a service implementation with a gRPC server.
-// srv must not be modified after this function is called, and it may be modified by this function.
 func RegisterTestServiceService(s grpc.ServiceRegistrar, srv *TestServiceService) {
-	if srv.EmptyCall == nil {
-		srv.EmptyCall = func(context.Context, *Empty) (*Empty, error) {
+	srvCopy := *srv
+	if srvCopy.EmptyCall == nil {
+		srvCopy.EmptyCall = func(context.Context, *Empty) (*Empty, error) {
 			return nil, status.Errorf(codes.Unimplemented, "method EmptyCall not implemented")
 		}
 	}
-	if srv.UnaryCall == nil {
-		srv.UnaryCall = func(context.Context, *SimpleRequest) (*SimpleResponse, error) {
+	if srvCopy.UnaryCall == nil {
+		srvCopy.UnaryCall = func(context.Context, *SimpleRequest) (*SimpleResponse, error) {
 			return nil, status.Errorf(codes.Unimplemented, "method UnaryCall not implemented")
 		}
 	}
-	if srv.StreamingOutputCall == nil {
-		srv.StreamingOutputCall = func(*StreamingOutputCallRequest, TestService_StreamingOutputCallServer) error {
+	if srvCopy.StreamingOutputCall == nil {
+		srvCopy.StreamingOutputCall = func(*StreamingOutputCallRequest, TestService_StreamingOutputCallServer) error {
 			return status.Errorf(codes.Unimplemented, "method StreamingOutputCall not implemented")
 		}
 	}
-	if srv.StreamingInputCall == nil {
-		srv.StreamingInputCall = func(TestService_StreamingInputCallServer) error {
+	if srvCopy.StreamingInputCall == nil {
+		srvCopy.StreamingInputCall = func(TestService_StreamingInputCallServer) error {
 			return status.Errorf(codes.Unimplemented, "method StreamingInputCall not implemented")
 		}
 	}
-	if srv.FullDuplexCall == nil {
-		srv.FullDuplexCall = func(TestService_FullDuplexCallServer) error {
+	if srvCopy.FullDuplexCall == nil {
+		srvCopy.FullDuplexCall = func(TestService_FullDuplexCallServer) error {
 			return status.Errorf(codes.Unimplemented, "method FullDuplexCall not implemented")
 		}
 	}
-	if srv.HalfDuplexCall == nil {
-		srv.HalfDuplexCall = func(TestService_HalfDuplexCallServer) error {
+	if srvCopy.HalfDuplexCall == nil {
+		srvCopy.HalfDuplexCall = func(TestService_HalfDuplexCallServer) error {
 			return status.Errorf(codes.Unimplemented, "method HalfDuplexCall not implemented")
 		}
 	}
@@ -418,33 +418,33 @@ func RegisterTestServiceService(s grpc.ServiceRegistrar, srv *TestServiceService
 		Methods: []grpc.MethodDesc{
 			{
 				MethodName: "EmptyCall",
-				Handler:    srv.emptyCall,
+				Handler:    srvCopy.emptyCall,
 			},
 			{
 				MethodName: "UnaryCall",
-				Handler:    srv.unaryCall,
+				Handler:    srvCopy.unaryCall,
 			},
 		},
 		Streams: []grpc.StreamDesc{
 			{
 				StreamName:    "StreamingOutputCall",
-				Handler:       srv.streamingOutputCall,
+				Handler:       srvCopy.streamingOutputCall,
 				ServerStreams: true,
 			},
 			{
 				StreamName:    "StreamingInputCall",
-				Handler:       srv.streamingInputCall,
+				Handler:       srvCopy.streamingInputCall,
 				ClientStreams: true,
 			},
 			{
 				StreamName:    "FullDuplexCall",
-				Handler:       srv.fullDuplexCall,
+				Handler:       srvCopy.fullDuplexCall,
 				ServerStreams: true,
 				ClientStreams: true,
 			},
 			{
 				StreamName:    "HalfDuplexCall",
-				Handler:       srv.halfDuplexCall,
+				Handler:       srvCopy.halfDuplexCall,
 				ServerStreams: true,
 				ClientStreams: true,
 			},


### PR DESCRIPTION
This ensures all service handlers are non-nil when the service is registered, such that they can be called safely (after an interceptor in the case of unary RPCs).

Fixes #3847 
