### PR TITLE
benchmark: Revert to use old certs.

### DIFF
--- a/benchmark/worker/benchmark_client.go
+++ b/benchmark/worker/benchmark_client.go
@@ -123,7 +123,7 @@ func createConns(config *testpb.ClientConfig) ([]*grpc.ClientConn, func(), error
 	// Check and set security options.
 	if config.SecurityParams != nil {
 		if *caFile == "" {
-			*caFile = testdata.Path("x509/server_ca.pem")
+			*caFile = testdata.Path("ca.pem")
 		}
 		creds, err := credentials.NewClientTLSFromFile(*caFile, config.SecurityParams.ServerHostOverride)
 		if err != nil {

--- a/benchmark/worker/benchmark_server.go
+++ b/benchmark/worker/benchmark_server.go
@@ -94,10 +94,10 @@ func startBenchmarkServer(config *testpb.ServerConfig, serverPort int) (*benchma
 	// Set security options.
 	if config.SecurityParams != nil {
 		if *certFile == "" {
-			*certFile = testdata.Path("x509/server1_cert.pem")
+			*certFile = testdata.Path("server1.pem")
 		}
 		if *keyFile == "" {
-			*keyFile = testdata.Path("x509/server1_key.pem")
+			*keyFile = testdata.Path("server1.key")
 		}
 		creds, err := credentials.NewServerTLSFromFile(*certFile, *keyFile)
 		if err != nil {


### PR DESCRIPTION
Other language client and servers still use the old certs.