### PR TITLE
Remove grpc_cli build instructions

### DIFF
--- a/Documentation/server-reflection-tutorial.md
+++ b/Documentation/server-reflection-tutorial.md
@@ -43,18 +43,8 @@ An example server with reflection registered can be found at
 
 After enabling Server Reflection in a server application, you can use gRPC CLI
 to check its services. gRPC CLI is only available in c++. Instructions on how to
-use gRPC CLI can be found at
+build and use gRPC CLI can be found at
 [command_line_tool.md](https://github.com/grpc/grpc/blob/master/doc/command_line_tool.md).
-
-To build gRPC CLI:
-
-```sh
-git clone https://github.com/grpc/grpc
-cd grpc
-git submodule update --init
-make grpc_cli
-cd bins/opt # grpc_cli is in directory bins/opt/
-```
 
 ## Use gRPC CLI to check services
 


### PR DESCRIPTION
The instructions didn't work, as the build process has changed a bit. It's probably best to just link to the official build instructions to avoid future skew.