### PR TITLE
lrs: add a layer for clusters in load store

### DIFF
--- a/xds/internal/balancer/balancergroup/balancergroup_test.go
+++ b/xds/internal/balancer/balancergroup/balancergroup_test.go
@@ -70,7 +70,7 @@ func subConnFromPicker(p balancer.Picker) func() balancer.SubConn {
 	}
 }
 
-func newTestBalancerGroup(t *testing.T, loadStore *load.Store) (*testutils.TestClientConn, *weightedaggregator.Aggregator, *BalancerGroup) {
+func newTestBalancerGroup(t *testing.T, loadStore *load.PerClusterStore) (*testutils.TestClientConn, *weightedaggregator.Aggregator, *BalancerGroup) {
 	cc := testutils.NewTestClientConn(t)
 	gator := weightedaggregator.New(cc, nil, testutils.NewTestWRR)
 	gator.Start()
@@ -400,7 +400,7 @@ func (s) TestBalancerGroup_TwoRR_ChangeWeight_MoreBackends(t *testing.T) {
 }
 
 func (s) TestBalancerGroup_LoadReport(t *testing.T) {
-	loadStore := &load.Store{}
+	loadStore := &load.PerClusterStore{}
 	cc, gator, bg := newTestBalancerGroup(t, loadStore)
 
 	backendToBalancerID := make(map[balancer.SubConn]string)

--- a/xds/internal/balancer/edsbalancer/eds_impl.go
+++ b/xds/internal/balancer/edsbalancer/eds_impl.go
@@ -36,6 +36,7 @@ import (
 	"google.golang.org/grpc/xds/internal/balancer/balancergroup"
 	"google.golang.org/grpc/xds/internal/balancer/weightedtarget/weightedaggregator"
 	xdsclient "google.golang.org/grpc/xds/internal/client"
+	"google.golang.org/grpc/xds/internal/client/load"
 )
 
 // TODO: make this a environment variable?
@@ -450,20 +451,13 @@ func (edsImpl *edsBalancerImpl) close() {
 	}
 }
 
-// dropReporter wraps the single method used by the dropPicker to report dropped
-// calls to the load store.
-type dropReporter interface {
-	// CallDropped reports the drop of one RPC with the given category.
-	CallDropped(category string)
-}
-
 type dropPicker struct {
 	drops     []*dropper
 	p         balancer.Picker
-	loadStore dropReporter
+	loadStore load.PerClusterReporter
 }
 
-func newDropPicker(p balancer.Picker, drops []*dropper, loadStore dropReporter) *dropPicker {
+func newDropPicker(p balancer.Picker, drops []*dropper, loadStore load.PerClusterReporter) *dropPicker {
 	return &dropPicker{
 		drops:     drops,
 		p:         p,

--- a/xds/internal/balancer/edsbalancer/eds_impl_test.go
+++ b/xds/internal/balancer/edsbalancer/eds_impl_test.go
@@ -682,12 +682,12 @@ func (s) TestDropPicker(t *testing.T) {
 	}
 }
 
-type loadStoreWrapper struct {
+type testLoadStoreWrapper struct {
 	xdsClientInterface
 	ls *load.Store
 }
 
-func (l *loadStoreWrapper) LoadStore() *load.Store {
+func (l *testLoadStoreWrapper) LoadStore() *load.Store {
 	return l.ls
 }
 
@@ -697,7 +697,7 @@ func (s) TestEDS_LoadReport(t *testing.T) {
 	// be used.
 	loadStore := &load.Store{}
 	cw := &xdsClientWrapper{
-		xdsClient: &loadStoreWrapper{ls: loadStore},
+		load: &loadStoreWrapper{store: loadStore, service: testClusterNames[0]},
 	}
 
 	cc := testutils.NewTestClientConn(t)
@@ -745,7 +745,7 @@ func (s) TestEDS_LoadReport(t *testing.T) {
 		}
 	}
 
-	gotStoreData := loadStore.Stats()
+	gotStoreData := loadStore.PerCluster(testClusterNames[0], "").Stats()
 	if diff := cmp.Diff(wantStoreData, gotStoreData, cmpopts.EquateEmpty()); diff != "" {
 		t.Errorf("store.Stats() returned unexpected diff (-want +got):\n%s", diff)
 	}

--- a/xds/internal/balancer/edsbalancer/eds_impl_test.go
+++ b/xds/internal/balancer/edsbalancer/eds_impl_test.go
@@ -682,20 +682,11 @@ func (s) TestDropPicker(t *testing.T) {
 	}
 }
 
-type testLoadStoreWrapper struct {
-	xdsClientInterface
-	ls *load.Store
-}
-
-func (l *testLoadStoreWrapper) LoadStore() *load.Store {
-	return l.ls
-}
-
 func (s) TestEDS_LoadReport(t *testing.T) {
 	// We create an xdsClientWrapper with a dummy xdsClientInterface which only
 	// implements the LoadStore() method to return the underlying load.Store to
 	// be used.
-	loadStore := &load.Store{}
+	loadStore := load.NewStore()
 	cw := &xdsClientWrapper{
 		load: &loadStoreWrapper{store: loadStore, service: testClusterNames[0]},
 	}

--- a/xds/internal/balancer/edsbalancer/xds_client_wrapper.go
+++ b/xds/internal/balancer/edsbalancer/xds_client_wrapper.go
@@ -208,12 +208,11 @@ func (c *xdsClientWrapper) updateXDSClient(config *EDSConfig, attr *attributes.A
 //
 // This usually means load report needs to be restarted, but this function does
 // NOT do that. Caller needs to call startLoadReport separately.
-func (c *xdsClientWrapper) startEndpointsWatch(nameToWatch string) {
+func (c *xdsClientWrapper) startEndpointsWatch() {
 	if c.xdsClient == nil {
 		return
 	}
 
-	c.edsServiceName = nameToWatch
 	if c.cancelEndpointsWatch != nil {
 		c.cancelEndpointsWatch()
 	}
@@ -252,7 +251,6 @@ func (c *xdsClientWrapper) loadStore() load.PerClusterReporter {
 	if c == nil || c.load.store == nil {
 		return nil
 	}
-	// return c.xdsClient.LoadStore().PerCluster(c.edsServiceName, "")
 	return c.load
 }
 
@@ -265,7 +263,8 @@ func (c *xdsClientWrapper) handleUpdate(config *EDSConfig, attr *attributes.Attr
 	// - the xds_client is updated
 	// - the xds_client didn't change, but the edsServiceName changed
 	if clientChanged || c.edsServiceName != config.EDSServiceName {
-		c.startEndpointsWatch(config.EDSServiceName)
+		c.edsServiceName = config.EDSServiceName
+		c.startEndpointsWatch()
 		// TODO: this update for the LRS service name is too early. It should
 		// only apply to the new EDS response. But this is applied to the RPCs
 		// before the new EDS response. To fully fix this, the EDS balancer

--- a/xds/internal/balancer/edsbalancer/xds_client_wrapper.go
+++ b/xds/internal/balancer/edsbalancer/xds_client_wrapper.go
@@ -19,6 +19,8 @@
 package edsbalancer
 
 import (
+	"sync"
+
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/attributes"
 	"google.golang.org/grpc/balancer"
@@ -45,7 +47,44 @@ var (
 	bootstrapConfigNew = bootstrap.NewConfig
 )
 
-// xdsClientWrapper is responsible for getting the xds client from attributes or
+type loadStoreWrapper struct {
+	mu      sync.RWMutex
+	store   *load.Store
+	service string
+}
+
+func (lsw *loadStoreWrapper) update(store *load.Store, service string) {
+	lsw.mu.Lock()
+	defer lsw.mu.Unlock()
+	lsw.store = store
+	lsw.service = service
+}
+
+func (lsw *loadStoreWrapper) CallStarted(locality string) {
+	lsw.mu.RLock()
+	defer lsw.mu.RUnlock()
+	lsw.store.PerCluster(lsw.service, "").CallStarted(locality)
+}
+
+func (lsw *loadStoreWrapper) CallFinished(locality string, err error) {
+	lsw.mu.RLock()
+	defer lsw.mu.RUnlock()
+	lsw.store.PerCluster(lsw.service, "").CallFinished(locality, err)
+}
+
+func (lsw *loadStoreWrapper) CallServerLoad(locality, name string, val float64) {
+	lsw.mu.RLock()
+	defer lsw.mu.RUnlock()
+	lsw.store.PerCluster(lsw.service, "").CallServerLoad(locality, name, val)
+}
+
+func (lsw *loadStoreWrapper) CallDropped(category string) {
+	lsw.mu.RLock()
+	defer lsw.mu.RUnlock()
+	lsw.store.PerCluster(lsw.service, "").CallDropped(category)
+}
+
+// xdsclientWrapper is responsible for getting the xds client from attributes or
 // creating a new xds client, and start watching EDS. The given callbacks will
 // be called with EDS updates or errors.
 type xdsClientWrapper struct {
@@ -58,6 +97,7 @@ type xdsClientWrapper struct {
 	// xdsClient could come from attributes, or created with balancerName.
 	xdsClient xdsClientInterface
 
+	load *loadStoreWrapper
 	// edsServiceName is the edsServiceName currently being watched, not
 	// necessary the edsServiceName from service config.
 	//
@@ -82,6 +122,7 @@ func newXDSClientWrapper(newEDSUpdate func(xdsclient.EndpointsUpdate, error), bb
 		logger:       logger,
 		newEDSUpdate: newEDSUpdate,
 		bbo:          bbo,
+		load:         &loadStoreWrapper{},
 	}
 }
 
@@ -193,7 +234,7 @@ func (c *xdsClientWrapper) startEndpointsWatch(nameToWatch string) {
 // Caller can cal this when the loadReportServer name changes, but
 // edsServiceName doesn't (so we only need to restart load reporting, not EDS
 // watch).
-func (c *xdsClientWrapper) startLoadReport(edsServiceNameBeingWatched string, loadReportServer *string) {
+func (c *xdsClientWrapper) startLoadReport(loadReportServer *string) {
 	if c.xdsClient == nil {
 		c.logger.Warningf("xds: xdsClient is nil when trying to start load reporting. This means xdsClient wasn't passed in from the resolver, and xdsClient.New failed")
 		return
@@ -203,15 +244,16 @@ func (c *xdsClientWrapper) startLoadReport(edsServiceNameBeingWatched string, lo
 	}
 	c.loadReportServer = loadReportServer
 	if c.loadReportServer != nil {
-		c.cancelLoadReport = c.xdsClient.ReportLoad(*c.loadReportServer, edsServiceNameBeingWatched)
+		c.cancelLoadReport = c.xdsClient.ReportLoad(*c.loadReportServer, c.edsServiceName)
 	}
 }
 
-func (c *xdsClientWrapper) loadStore() *load.Store {
-	if c == nil || c.xdsClient == nil {
+func (c *xdsClientWrapper) loadStore() load.PerClusterReporter {
+	if c == nil || c.load.store == nil {
 		return nil
 	}
-	return c.xdsClient.LoadStore()
+	// return c.xdsClient.LoadStore().PerCluster(c.edsServiceName, "")
+	return c.load
 }
 
 // handleUpdate applies the service config and attributes updates to the client,
@@ -219,38 +261,25 @@ func (c *xdsClientWrapper) loadStore() *load.Store {
 func (c *xdsClientWrapper) handleUpdate(config *EDSConfig, attr *attributes.Attributes) {
 	clientChanged := c.updateXDSClient(config, attr)
 
-	var (
-		restartEndpointsWatch bool
-		restartLoadReport     bool
-	)
-
-	// The clusterName to watch should come from CDS response, via service
-	// config. If it's an empty string, fallback user's dial target.
-	nameToWatch := config.EDSServiceName
-	if nameToWatch == "" {
-		c.logger.Warningf("eds: cluster name to watch is an empty string. Fallback to user's dial target")
-		nameToWatch = c.bbo.Target.Endpoint
-	}
-
 	// Need to restart EDS watch when one of the following happens:
 	// - the xds_client is updated
 	// - the xds_client didn't change, but the edsServiceName changed
-	//
+	if clientChanged || c.edsServiceName != config.EDSServiceName {
+		c.startEndpointsWatch(config.EDSServiceName)
+		// TODO: this update for the LRS service name is too early. It should
+		// only apply to the new EDS response. But this is applied to the RPCs
+		// before the new EDS response. To fully fix this, the EDS balancer
+		// needs to do a graceful switch to another EDS implementation.
+		//
+		// This is OK for now, because we don't actually expect edsServiceName
+		// to change. Fix this (a bigger change) will happen later.
+		c.load.update(c.xdsClient.LoadStore(), c.edsServiceName)
+	}
+
 	// Only need to restart load reporting when:
-	// - no need to restart EDS, but loadReportServer name changed
-	if clientChanged || c.edsServiceName != nameToWatch {
-		restartEndpointsWatch = true
-		restartLoadReport = true
-	} else if !equalStringPointers(c.loadReportServer, config.LrsLoadReportingServerName) {
-		restartLoadReport = true
-	}
-
-	if restartEndpointsWatch {
-		c.startEndpointsWatch(nameToWatch)
-	}
-
-	if restartLoadReport {
-		c.startLoadReport(nameToWatch, config.LrsLoadReportingServerName)
+	// - the loadReportServer name changed
+	if !equalStringPointers(c.loadReportServer, config.LrsLoadReportingServerName) {
+		c.startLoadReport(config.LrsLoadReportingServerName)
 	}
 }
 

--- a/xds/internal/balancer/edsbalancer/xds_client_wrapper_test.go
+++ b/xds/internal/balancer/edsbalancer/xds_client_wrapper_test.go
@@ -107,36 +107,20 @@ func (s) TestClientWrapperWatchEDS(t *testing.T) {
 	}
 	defer func() { bootstrapConfigNew = oldBootstrapConfigNew }()
 
-	// Update with an empty edsServiceName should trigger an EDS watch
-	// for the user's dial target.
-	cw.handleUpdate(&EDSConfig{
-		BalancerName:   fakeServer.Address,
-		EDSServiceName: "",
-	}, nil)
-	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
-	defer cancel()
-	if _, err := fakeServer.NewConnChan.Receive(ctx); err != nil {
-		t.Fatal("Failed to connect to fake server")
-	}
-	t.Log("Client connection established to fake server...")
-	if err := verifyExpectedRequests(fakeServer, testServiceName); err != nil {
-		t.Fatal(err)
-	}
-
 	// Update with an non-empty edsServiceName should trigger an EDS watch for
-	// the same. The previously registered watch will be cancelled, which will
-	// result in an EDS request with no resource names being sent to the server.
+	// the same.
 	cw.handleUpdate(&EDSConfig{
 		BalancerName:   fakeServer.Address,
 		EDSServiceName: "foobar-1",
 	}, nil)
-	if err := verifyExpectedRequests(fakeServer, "", "foobar-1"); err != nil {
+	if err := verifyExpectedRequests(fakeServer, "foobar-1"); err != nil {
 		t.Fatal(err)
 	}
 
-	// Also test the case where the edsServerName changes from one
-	// non-empty name to another, and make sure a new watch is
-	// registered.
+	// Also test the case where the edsServerName changes from one non-empty
+	// name to another, and make sure a new watch is registered. The previously
+	// registered watch will be cancelled, which will result in an EDS request
+	// with no resource names being sent to the server.
 	cw.handleUpdate(&EDSConfig{
 		BalancerName:   fakeServer.Address,
 		EDSServiceName: "foobar-2",

--- a/xds/internal/balancer/edsbalancer/xds_lrs_test.go
+++ b/xds/internal/balancer/edsbalancer/xds_lrs_test.go
@@ -35,7 +35,7 @@ import (
 func (s) TestXDSLoadReporting(t *testing.T) {
 	builder := balancer.Get(edsName)
 	cc := newNoopTestClientConn()
-	edsB, ok := builder.Build(cc, balancer.BuildOptions{Target: resolver.Target{Endpoint: testEDSClusterName}}).(*edsBalancer)
+	edsB, ok := builder.Build(cc, balancer.BuildOptions{}).(*edsBalancer)
 	if !ok {
 		t.Fatalf("builder.Build(%s) returned type {%T}, want {*edsBalancer}", edsName, edsB)
 	}
@@ -43,8 +43,11 @@ func (s) TestXDSLoadReporting(t *testing.T) {
 
 	xdsC := fakeclient.NewClient()
 	if err := edsB.UpdateClientConnState(balancer.ClientConnState{
-		ResolverState:  resolver.State{Attributes: attributes.New(xdsinternal.XDSClientID, xdsC)},
-		BalancerConfig: &EDSConfig{LrsLoadReportingServerName: new(string)},
+		ResolverState: resolver.State{Attributes: attributes.New(xdsinternal.XDSClientID, xdsC)},
+		BalancerConfig: &EDSConfig{
+			EDSServiceName:             testEDSClusterName,
+			LrsLoadReportingServerName: new(string),
+		},
 	}); err != nil {
 		t.Fatal(err)
 	}

--- a/xds/internal/balancer/lrs/balancer_test.go
+++ b/xds/internal/balancer/lrs/balancer_test.go
@@ -65,7 +65,8 @@ func TestLoadReporting(t *testing.T) {
 			Attributes: attributes.New(xdsinternal.XDSClientID, xdsC),
 		},
 		BalancerConfig: &lbConfig{
-			EdsServiceName:             testClusterName,
+			ClusterName:                testClusterName,
+			EdsServiceName:             testServiceName,
 			LrsLoadReportingServerName: testLRSServerName,
 			Locality:                   testLocality,
 			ChildPolicy: &internalserviceconfig.BalancerConfig{
@@ -115,7 +116,7 @@ func TestLoadReporting(t *testing.T) {
 	if loadStore == nil {
 		t.Fatal("loadStore is nil in xdsClient")
 	}
-	sd := loadStore.Stats()
+	sd := loadStore.PerCluster(testClusterName, testServiceName).Stats()
 	localityData, ok := sd.LocalityStats[testLocality.String()]
 	if !ok {
 		t.Fatalf("loads for %v not found in store", testLocality)

--- a/xds/internal/client/client.go
+++ b/xds/internal/client/client.go
@@ -348,7 +348,7 @@ func New(opts Options) (*Client, error) {
 	c := &Client{
 		done:      grpcsync.NewEvent(),
 		opts:      opts,
-		loadStore: &load.Store{},
+		loadStore: load.NewStore(),
 
 		updateCh:    buffer.NewUnbounded(),
 		ldsWatchers: make(map[string]map[*watchInfo]bool),

--- a/xds/internal/client/load/reporter.go
+++ b/xds/internal/client/load/reporter.go
@@ -1,0 +1,27 @@
+/*
+ *
+ * Copyright 2020 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package load
+
+// PerClusterReporter wraps the methods from the loadStore that are used here.
+type PerClusterReporter interface {
+	CallStarted(locality string)
+	CallFinished(locality string, err error)
+	CallServerLoad(locality, name string, val float64)
+	CallDropped(category string)
+}

--- a/xds/internal/client/load/store.go
+++ b/xds/internal/client/load/store.go
@@ -24,8 +24,58 @@ import (
 
 const negativeOneUInt64 = ^uint64(0)
 
-// Store is a repository for LB policy implementations to report store load
-// data. It is safe for concurrent use.
+// A pair of cluster and service name. The same cluster can be used by multiple
+// services, and one service can use multiple clusters. So we need a pair with
+// both name to accurately indicate where the load belongs.
+type clusterAndServiceNames struct {
+	cluster string
+	service string
+}
+
+type Store struct {
+	clusters sync.Map // map[clusterAndServiceNames]*rpcCountData
+}
+
+// PerCluster returns the PerClusterStore for the given clusterName +
+// serviceName.
+func (ls *Store) PerCluster(clusterName, serviceName string) *PerClusterStore {
+	if ls == nil {
+		return nil
+	}
+
+	k := clusterAndServiceNames{
+		cluster: clusterName,
+		service: serviceName,
+	}
+	p, ok := ls.clusters.Load(k)
+	if !ok {
+		s := &PerClusterStore{}
+		p, _ = ls.clusters.LoadOrStore(k, s)
+	}
+	return p.(*PerClusterStore)
+}
+
+// CallServerLoad adds one server load record for the given locality. The
+// load type is specified by desc, and its value by val.
+func (ls *Store) CallServerLoad(clusterName, serviceName, locality, name string, d float64) {
+	if ls == nil {
+		return
+	}
+
+	k := clusterAndServiceNames{
+		cluster: clusterName,
+		service: serviceName,
+	}
+	p, ok := ls.clusters.Load(k)
+	if !ok {
+		s := &PerClusterStore{}
+		p, _ = ls.clusters.LoadOrStore(k, s)
+	}
+	p.(*PerClusterStore).CallServerLoad(locality, name, d)
+}
+
+// PerClusterStore is a repository for LB policy implementations to report store
+// load data. It is safe for concurrent use.
 //
 // A zero Store is empty and ready for use.
 //
@@ -38,7 +88,7 @@ const negativeOneUInt64 = ^uint64(0)
 // RWMutex.
 // Neither of these conditions are met here, and we should transition to a
 // regular map with a mutex for better type safety.
-type Store struct {
+type PerClusterStore struct {
 	drops            sync.Map // map[string]*uint64
 	localityRPCCount sync.Map // map[string]*rpcCountData
 }
@@ -47,7 +97,7 @@ type Store struct {
 // updates are done atomically.
 
 // CallDropped adds one drop record with the given category to store.
-func (ls *Store) CallDropped(category string) {
+func (ls *PerClusterStore) CallDropped(category string) {
 	if ls == nil {
 		return
 	}
@@ -61,7 +111,7 @@ func (ls *Store) CallDropped(category string) {
 }
 
 // CallStarted adds one call started record for the given locality.
-func (ls *Store) CallStarted(locality string) {
+func (ls *PerClusterStore) CallStarted(locality string) {
 	if ls == nil {
 		return
 	}
@@ -76,7 +126,7 @@ func (ls *Store) CallStarted(locality string) {
 
 // CallFinished adds one call finished record for the given locality.
 // For successful calls, err needs to be nil.
-func (ls *Store) CallFinished(locality string, err error) {
+func (ls *PerClusterStore) CallFinished(locality string, err error) {
 	if ls == nil {
 		return
 	}
@@ -97,7 +147,7 @@ func (ls *Store) CallFinished(locality string, err error) {
 
 // CallServerLoad adds one server load record for the given locality. The
 // load type is specified by desc, and its value by val.
-func (ls *Store) CallServerLoad(locality, name string, d float64) {
+func (ls *PerClusterStore) CallServerLoad(locality, name string, d float64) {
 	if ls == nil {
 		return
 	}
@@ -158,7 +208,7 @@ func newStoreData() *Data {
 
 // Stats returns and resets all loads reported to the store, except inProgress
 // rpc counts.
-func (ls *Store) Stats() *Data {
+func (ls *PerClusterStore) Stats() *Data {
 	if ls == nil {
 		return nil
 	}

--- a/xds/internal/client/load/store.go
+++ b/xds/internal/client/load/store.go
@@ -27,7 +27,7 @@ const negativeOneUInt64 = ^uint64(0)
 // A pair of cluster and service name. The same cluster can be used by multiple
 // services, and one service can use multiple clusters. So we need a pair with
 // both name to accurately indicate where the load belongs.
-type clusterAndServiceNames struct {
+type storeKey struct {
 	cluster string
 	service string
 }
@@ -36,13 +36,13 @@ type clusterAndServiceNames struct {
 // LRS. It is safe for concurrent use.
 type Store struct {
 	mu       sync.RWMutex
-	clusters map[clusterAndServiceNames]*PerClusterStore
+	clusters map[storeKey]*PerClusterStore
 }
 
 // NewStore creates a Store.
 func NewStore() *Store {
 	return &Store{
-		clusters: make(map[clusterAndServiceNames]*PerClusterStore),
+		clusters: make(map[storeKey]*PerClusterStore),
 	}
 }
 
@@ -53,7 +53,7 @@ func (ls *Store) PerCluster(clusterName, serviceName string) *PerClusterStore {
 		return nil
 	}
 
-	k := clusterAndServiceNames{
+	k := storeKey{
 		cluster: clusterName,
 		service: serviceName,
 	}

--- a/xds/internal/client/load/store_test.go
+++ b/xds/internal/client/load/store_test.go
@@ -56,7 +56,7 @@ func TestDrops(t *testing.T) {
 		}
 	)
 
-	ls := Store{}
+	ls := PerClusterStore{}
 	var wg sync.WaitGroup
 	for category, count := range drops {
 		for i := 0; i < count; i++ {
@@ -118,7 +118,7 @@ func TestLocalityStats(t *testing.T) {
 		}
 	)
 
-	ls := Store{}
+	ls := PerClusterStore{}
 	var wg sync.WaitGroup
 	for locality, data := range localityData {
 		wg.Add(data.start)
@@ -211,7 +211,7 @@ func TestResetAfterStats(t *testing.T) {
 		}
 	)
 
-	reportLoad := func(ls *Store) {
+	reportLoad := func(ls *PerClusterStore) {
 		for category, count := range drops {
 			for i := 0; i < count; i++ {
 				ls.CallDropped(category)
@@ -233,7 +233,7 @@ func TestResetAfterStats(t *testing.T) {
 		}
 	}
 
-	ls := Store{}
+	ls := PerClusterStore{}
 	reportLoad(&ls)
 	gotStoreData := ls.Stats()
 	if diff := cmp.Diff(wantStoreData, gotStoreData, cmpopts.EquateEmpty()); diff != "" {

--- a/xds/internal/client/v2/loadreport.go
+++ b/xds/internal/client/v2/loadreport.go
@@ -121,7 +121,7 @@ func (v2c *client) SendLoadStatsRequest(s grpc.ClientStream, clusterName string)
 		localityStats []*v2endpointpb.UpstreamLocalityStats
 	)
 
-	sd := v2c.loadStore.Stats()
+	sd := v2c.loadStore.PerCluster(clusterName, "").Stats()
 	for category, count := range sd.Drops {
 		droppedReqs = append(droppedReqs, &v2endpointpb.ClusterStats_DroppedRequests{
 			Category:     category,

--- a/xds/internal/client/v3/loadreport.go
+++ b/xds/internal/client/v3/loadreport.go
@@ -121,7 +121,7 @@ func (v3c *client) SendLoadStatsRequest(s grpc.ClientStream, clusterName string)
 		localityStats []*v3endpointpb.UpstreamLocalityStats
 	)
 
-	sd := v3c.loadStore.Stats()
+	sd := v3c.loadStore.PerCluster(clusterName, "").Stats()
 	for category, count := range sd.Drops {
 		droppedReqs = append(droppedReqs, &v3endpointpb.ClusterStats_DroppedRequests{
 			Category:     category,

--- a/xds/internal/testutils/fakeclient/client.go
+++ b/xds/internal/testutils/fakeclient/client.go
@@ -214,6 +214,6 @@ func NewClientWithName(name string) *Client {
 		edsCancelCh:  testutils.NewChannel(),
 		loadReportCh: testutils.NewChannel(),
 		closeCh:      testutils.NewChannel(),
-		loadStore:    &load.Store{},
+		loadStore:    load.NewStore(),
 	}
 }


### PR DESCRIPTION
- The original Store is renamed to PerClusterStore. The new Store has a method
  to get PerClusterStore.
  - All usages of old Store are updated to PerClusterStore
- In EDS and LRS, where the load reporting is happening (by wrapping the
  picker), a closure is created with the store and clusterName, serviceName, so
  loads will be associated with the right cluster.
  - This also means when cluster/service is changed, the closure needs to
    update as well.
  - TODO: there's no correct timing for this update. The update in this change
    is happening too early. The fix would be to do a graceful switch of EDS
    when the cluster/service name is changed. That will happen in a later fix.
- When reporting loads (to LRS stream), the lrs client gets the PerClusterStore,
  and reports its data.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grpc/grpc-go/3880)
<!-- Reviewable:end -->
