### PR TITLE
stats: include message header in stats.InPayload.WireLength

### DIFF
--- a/rpc_util.go
+++ b/rpc_util.go
@@ -636,7 +636,7 @@ func recvAndDecompress(p *parser, s *transport.Stream, dc Decompressor, maxRecei
 		return nil, err
 	}
 	if payInfo != nil {
-		payInfo.wireLength = len(d)
+		payInfo.wireLength = len(d) + headerLen
 	}
 
 	if st := checkRecvPayload(pf, s.RecvCompress(), compressor != nil || dc != nil); st != nil {

--- a/rpc_util.go
+++ b/rpc_util.go
@@ -636,7 +636,7 @@ func recvAndDecompress(p *parser, s *transport.Stream, dc Decompressor, maxRecei
 		return nil, err
 	}
 	if payInfo != nil {
-		payInfo.wireLength = len(d) + headerLen
+		payInfo.wireLength = len(d)
 	}
 
 	if st := checkRecvPayload(pf, s.RecvCompress(), compressor != nil || dc != nil); st != nil {

--- a/server.go
+++ b/server.go
@@ -1175,7 +1175,7 @@ func (s *Server) processUnaryRPC(t transport.ServerTransport, stream *transport.
 			sh.HandleRPC(stream.Context(), &stats.InPayload{
 				RecvTime:   time.Now(),
 				Payload:    v,
-				WireLength: payInfo.wireLength,
+				WireLength: payInfo.wireLength + headerLen,
 				Data:       d,
 				Length:     len(d),
 			})

--- a/stream.go
+++ b/stream.go
@@ -929,7 +929,7 @@ func (a *csAttempt) recvMsg(m interface{}, payInfo *payloadInfo) (err error) {
 			Payload:  m,
 			// TODO truncate large payload.
 			Data:       payInfo.uncompressedBytes,
-			WireLength: payInfo.wireLength,
+			WireLength: payInfo.wireLength + headerLen,
 			Length:     len(payInfo.uncompressedBytes),
 		})
 	}
@@ -1511,7 +1511,7 @@ func (ss *serverStream) RecvMsg(m interface{}) (err error) {
 			Payload:  m,
 			// TODO truncate large payload.
 			Data:       payInfo.uncompressedBytes,
-			WireLength: payInfo.wireLength,
+			WireLength: payInfo.wireLength + headerLen,
 			Length:     len(payInfo.uncompressedBytes),
 		})
 	}


### PR DESCRIPTION
### Summary
Currently, the `stats.InPayload.WireLength` actually under-reports the true WireSize of each received message by 5 bytes (`headerLen`), as it does not include the size of the header going over the wire.
However, `stats.OutPayload.WireLength` *does* include the size of the 5 byte header in `WireLength`. 

This leads to the `InPayload.WireLength` not being equal to the `OutPayload.WireLength` for the same underlying payload, which further leads to many weird accounting errors.