### PR TITLE
advancedtls: clean up test files and shared code

### DIFF
--- a/security/advancedtls/advancedtls_integration_test.go
+++ b/security/advancedtls/advancedtls_integration_test.go
@@ -31,7 +31,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	pb "google.golang.org/grpc/examples/helloworld/helloworld"
-	"google.golang.org/grpc/security/advancedtls/internal"
+	"google.golang.org/grpc/security/advancedtls/internal/testutils"
 )
 
 var (
@@ -120,9 +120,9 @@ func callAndVerifyWithClientConn(connCtx context.Context, msg string, creds cred
 // (could be change the client's trust certificate, or change custom
 // verification function, etc)
 func (s) TestEnd2End(t *testing.T) {
-	cs := &internal.CertStore{}
+	cs := &testutils.CertStore{}
 	if err := cs.LoadCerts(); err != nil {
-		t.Fatalf("Function cs.LoadCerts() failed, err: %v", err)
+		t.Fatalf("cs.LoadCerts() failed, err: %v", err)
 	}
 	stage := &stageInfo{}
 	for _, test := range []struct {

--- a/security/advancedtls/advancedtls_integration_test.go
+++ b/security/advancedtls/advancedtls_integration_test.go
@@ -31,7 +31,6 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	pb "google.golang.org/grpc/examples/helloworld/helloworld"
-	"google.golang.org/grpc/security/advancedtls/testdata"
 )
 
 var (
@@ -65,69 +64,6 @@ func (s *stageInfo) reset() {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 	s.stage = 0
-}
-
-// certStore contains all the certificates used in the integration tests.
-type certStore struct {
-	// clientPeer1 is the certificate sent by client to prove its identity.
-	// It is trusted by serverTrust1.
-	clientPeer1 tls.Certificate
-	// clientPeer2 is the certificate sent by client to prove its identity.
-	// It is trusted by serverTrust2.
-	clientPeer2 tls.Certificate
-	// serverPeer1 is the certificate sent by server to prove its identity.
-	// It is trusted by clientTrust1.
-	serverPeer1 tls.Certificate
-	// serverPeer2 is the certificate sent by server to prove its identity.
-	// It is trusted by clientTrust2.
-	serverPeer2  tls.Certificate
-	clientTrust1 *x509.CertPool
-	clientTrust2 *x509.CertPool
-	serverTrust1 *x509.CertPool
-	serverTrust2 *x509.CertPool
-}
-
-// loadCerts function is used to load test certificates at the beginning of
-// each integration test.
-func (cs *certStore) loadCerts() error {
-	var err error
-	cs.clientPeer1, err = tls.LoadX509KeyPair(testdata.Path("client_cert_1.pem"),
-		testdata.Path("client_key_1.pem"))
-	if err != nil {
-		return err
-	}
-	cs.clientPeer2, err = tls.LoadX509KeyPair(testdata.Path("client_cert_2.pem"),
-		testdata.Path("client_key_2.pem"))
-	if err != nil {
-		return err
-	}
-	cs.serverPeer1, err = tls.LoadX509KeyPair(testdata.Path("server_cert_1.pem"),
-		testdata.Path("server_key_1.pem"))
-	if err != nil {
-		return err
-	}
-	cs.serverPeer2, err = tls.LoadX509KeyPair(testdata.Path("server_cert_2.pem"),
-		testdata.Path("server_key_2.pem"))
-	if err != nil {
-		return err
-	}
-	cs.clientTrust1, err = readTrustCert(testdata.Path("client_trust_cert_1.pem"))
-	if err != nil {
-		return err
-	}
-	cs.clientTrust2, err = readTrustCert(testdata.Path("client_trust_cert_2.pem"))
-	if err != nil {
-		return err
-	}
-	cs.serverTrust1, err = readTrustCert(testdata.Path("server_trust_cert_1.pem"))
-	if err != nil {
-		return err
-	}
-	cs.serverTrust2, err = readTrustCert(testdata.Path("server_trust_cert_2.pem"))
-	if err != nil {
-		return err
-	}
-	return nil
 }
 
 type greeterServer struct {

--- a/security/advancedtls/advancedtls_integration_test.go
+++ b/security/advancedtls/advancedtls_integration_test.go
@@ -142,16 +142,16 @@ func (s) TestEnd2End(t *testing.T) {
 	}{
 		// Test Scenarios:
 		// At initialization(stage = 0), client will be initialized with cert
-		// clientCert1 and clientTrust1, server with serverCert1 and serverTrust1.
-		// The mutual authentication works at the beginning, since clientCert1 is
-		// trusted by serverTrust1, and serverCert1 by clientTrust1.
-		// At stage 1, client changes clientCert1 to clientCert2. Since clientCert2
-		// is not trusted by serverTrust1, following rpc calls are expected to
+		// ClientCert1 and ClientTrust1, server with ServerCert1 and ServerTrust1.
+		// The mutual authentication works at the beginning, since ClientCert1 is
+		// trusted by ServerTrust1, and ServerCert1 by ClientTrust1.
+		// At stage 1, client changes ClientCert1 to ClientCert2. Since ClientCert2
+		// is not trusted by ServerTrust1, following rpc calls are expected to
 		// fail, while the previous rpc calls are still good because those are
 		// already authenticated.
-		// At stage 2, the server changes serverTrust1 to serverTrust2, and we
-		// should see it again accepts the connection, since clientCert2 is trusted
-		// by serverTrust2.
+		// At stage 2, the server changes ServerTrust1 to ServerTrust2, and we
+		// should see it again accepts the connection, since ClientCert2 is trusted
+		// by ServerTrust2.
 		{
 			desc: "TestClientPeerCertReloadServerTrustCertReload",
 			clientGetCert: func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
@@ -183,16 +183,16 @@ func (s) TestEnd2End(t *testing.T) {
 		},
 		// Test Scenarios:
 		// At initialization(stage = 0), client will be initialized with cert
-		// clientCert1 and clientTrust1, server with serverCert1 and serverTrust1.
-		// The mutual authentication works at the beginning, since clientCert1 is
-		// trusted by serverTrust1, and serverCert1 by clientTrust1.
-		// At stage 1, server changes serverCert1 to serverCert2. Since serverCert2
-		// is not trusted by clientTrust1, following rpc calls are expected to
+		// ClientCert1 and ClientTrust1, server with ServerCert1 and ServerTrust1.
+		// The mutual authentication works at the beginning, since ClientCert1 is
+		// trusted by ServerTrust1, and ServerCert1 by ClientTrust1.
+		// At stage 1, server changes ServerCert1 to ServerCert2. Since ServerCert2
+		// is not trusted by ClientTrust1, following rpc calls are expected to
 		// fail, while the previous rpc calls are still good because those are
 		// already authenticated.
-		// At stage 2, the client changes clientTrust1 to clientTrust2, and we
-		// should see it again accepts the connection, since serverCert2 is trusted
-		// by clientTrust2.
+		// At stage 2, the client changes ClientTrust1 to ClientTrust2, and we
+		// should see it again accepts the connection, since ServerCert2 is trusted
+		// by ClientTrust2.
 		{
 			desc:       "TestServerPeerCertReloadClientTrustCertReload",
 			clientCert: []tls.Certificate{cs.ClientCert1},
@@ -224,17 +224,17 @@ func (s) TestEnd2End(t *testing.T) {
 		},
 		// Test Scenarios:
 		// At initialization(stage = 0), client will be initialized with cert
-		// clientCert1 and clientTrust1, server with serverCert1 and serverTrust1.
-		// The mutual authentication works at the beginning, since clientCert1
-		// trusted by serverTrust1, serverCert1 by clientTrust1, and also the
-		// custom verification check allows the CommonName on serverCert1.
-		// At stage 1, server changes serverCert1 to serverCert2, and client
-		// changes clientTrust1 to clientTrust2. Although serverCert2 is trusted by
-		// clientTrust2, our authorization check only accepts serverCert1, and
+		// ClientCert1 and ClientTrust1, server with ServerCert1 and ServerTrust1.
+		// The mutual authentication works at the beginning, since ClientCert1
+		// trusted by ServerTrust1, ServerCert1 by ClientTrust1, and also the
+		// custom verification check allows the CommonName on ServerCert1.
+		// At stage 1, server changes ServerCert1 to ServerCert2, and client
+		// changes ClientTrust1 to ClientTrust2. Although ServerCert2 is trusted by
+		// ClientTrust2, our authorization check only accepts ServerCert1, and
 		// hence the following calls should fail. Previous connections should
 		// not be affected.
 		// At stage 2, the client changes authorization check to only accept
-		// serverCert2. Now we should see the connection becomes normal again.
+		// ServerCert2. Now we should see the connection becomes normal again.
 		{
 			desc:       "TestClientCustomVerification",
 			clientCert: []tls.Certificate{cs.ClientCert1},
@@ -257,12 +257,12 @@ func (s) TestEnd2End(t *testing.T) {
 				authzCheck := false
 				switch stage.read() {
 				case 0, 1:
-					// foo.bar.com is the common name on serverCert1
+					// foo.bar.com is the common name on ServerCert1
 					if cert.Subject.CommonName == "foo.bar.com" {
 						authzCheck = true
 					}
 				default:
-					// foo.bar.server2.com is the common name on serverCert2
+					// foo.bar.server2.com is the common name on ServerCert2
 					if cert.Subject.CommonName == "foo.bar.server2.com" {
 						authzCheck = true
 					}
@@ -289,9 +289,9 @@ func (s) TestEnd2End(t *testing.T) {
 		},
 		// Test Scenarios:
 		// At initialization(stage = 0), client will be initialized with cert
-		// clientCert1 and clientTrust1, server with serverCert1 and serverTrust1.
-		// The mutual authentication works at the beginning, since clientCert1
-		// trusted by serverTrust1, serverCert1 by clientTrust1, and also the
+		// ClientCert1 and ClientTrust1, server with ServerCert1 and ServerTrust1.
+		// The mutual authentication works at the beginning, since ClientCert1
+		// trusted by ServerTrust1, ServerCert1 by ClientTrust1, and also the
 		// custom verification check on server side allows all connections.
 		// At stage 1, server disallows the the connections by setting custom
 		// verification check. The following calls should fail. Previous

--- a/security/advancedtls/advancedtls_test.go
+++ b/security/advancedtls/advancedtls_test.go
@@ -55,7 +55,6 @@ type fakeProvider struct {
 	isClient      bool
 	wantMultiCert bool
 	wantError     bool
-	t             *testing.T
 }
 
 func (f fakeProvider) KeyMaterial(ctx context.Context) (*certprovider.KeyMaterial, error) {
@@ -102,7 +101,7 @@ func (s) TestClientOptionsConfigErrorCases(t *testing.T) {
 			clientVType: CertVerification,
 			RootOptions: RootCertificateOptions{
 				RootCACerts:  x509.NewCertPool(),
-				RootProvider: fakeProvider{t: t},
+				RootProvider: fakeProvider{},
 			},
 		},
 		{
@@ -112,7 +111,7 @@ func (s) TestClientOptionsConfigErrorCases(t *testing.T) {
 				GetIdentityCertificatesForClient: func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
 					return nil, nil
 				},
-				IdentityProvider: fakeProvider{pt: provTypeIdentity, t: t},
+				IdentityProvider: fakeProvider{pt: provTypeIdentity},
 			},
 		},
 		{
@@ -155,10 +154,10 @@ func (s) TestClientOptionsConfigSuccessCases(t *testing.T) {
 			desc:        "Good case with mutual TLS",
 			clientVType: CertVerification,
 			RootOptions: RootCertificateOptions{
-				RootProvider: fakeProvider{t: t},
+				RootProvider: fakeProvider{},
 			},
 			IdentityOptions: IdentityCertificateOptions{
-				IdentityProvider: fakeProvider{pt: provTypeIdentity, t: t},
+				IdentityProvider: fakeProvider{pt: provTypeIdentity},
 			},
 		},
 	}
@@ -215,7 +214,7 @@ func (s) TestServerOptionsConfigErrorCases(t *testing.T) {
 			serverVType: CertVerification,
 			IdentityOptions: IdentityCertificateOptions{
 				Certificates:     []tls.Certificate{},
-				IdentityProvider: fakeProvider{pt: provTypeIdentity, t: t},
+				IdentityProvider: fakeProvider{pt: provTypeIdentity},
 			},
 		},
 		{
@@ -269,7 +268,7 @@ func (s) TestServerOptionsConfigSuccessCases(t *testing.T) {
 			requireClientCert: true,
 			serverVType:       CertVerification,
 			RootOptions: RootCertificateOptions{
-				RootProvider: fakeProvider{t: t},
+				RootProvider: fakeProvider{},
 			},
 			IdentityOptions: IdentityCertificateOptions{
 				GetIdentityCertificatesForServer: func(*tls.ClientHelloInfo) ([]*tls.Certificate, error) {
@@ -607,13 +606,13 @@ func (s) TestClientServerHandshake(t *testing.T) {
 		// clientIdentityProvider
 		{
 			desc:                   "Client sets multiple certs in clientIdentityProvider; Server sets root and identity provider; mutualTLS",
-			clientIdentityProvider: fakeProvider{pt: provTypeIdentity, isClient: true, wantMultiCert: true, t: t},
-			clientRootProvider:     fakeProvider{isClient: true, t: t},
+			clientIdentityProvider: fakeProvider{pt: provTypeIdentity, isClient: true, wantMultiCert: true},
+			clientRootProvider:     fakeProvider{isClient: true},
 			clientVerifyFunc:       clientVerifyFuncGood,
 			clientVType:            CertVerification,
 			serverMutualTLS:        true,
-			serverIdentityProvider: fakeProvider{pt: provTypeIdentity, isClient: false, t: t},
-			serverRootProvider:     fakeProvider{isClient: false, t: t},
+			serverIdentityProvider: fakeProvider{pt: provTypeIdentity, isClient: false},
+			serverRootProvider:     fakeProvider{isClient: false},
 			serverVType:            CertVerification,
 			serverExpectError:      true,
 		},
@@ -622,13 +621,13 @@ func (s) TestClientServerHandshake(t *testing.T) {
 		// Expected Behavior: server side failure due to bad clientIdentityProvider
 		{
 			desc:                   "Client sets bad clientIdentityProvider; Server sets root and identity provider; mutualTLS",
-			clientIdentityProvider: fakeProvider{pt: provTypeIdentity, isClient: true, wantError: true, t: t},
-			clientRootProvider:     fakeProvider{isClient: true, t: t},
+			clientIdentityProvider: fakeProvider{pt: provTypeIdentity, isClient: true, wantError: true},
+			clientRootProvider:     fakeProvider{isClient: true},
 			clientVerifyFunc:       clientVerifyFuncGood,
 			clientVType:            CertVerification,
 			serverMutualTLS:        true,
-			serverIdentityProvider: fakeProvider{pt: provTypeIdentity, isClient: false, t: t},
-			serverRootProvider:     fakeProvider{isClient: false, t: t},
+			serverIdentityProvider: fakeProvider{pt: provTypeIdentity, isClient: false},
+			serverRootProvider:     fakeProvider{isClient: false},
 			serverVType:            CertVerification,
 			serverExpectError:      true,
 		},
@@ -637,13 +636,13 @@ func (s) TestClientServerHandshake(t *testing.T) {
 		// Expected Behavior: server side failure due to bad serverRootProvider
 		{
 			desc:                   "Client sets root and identity provider; Server sets bad root provider; mutualTLS",
-			clientIdentityProvider: fakeProvider{pt: provTypeIdentity, isClient: true, t: t},
-			clientRootProvider:     fakeProvider{isClient: true, t: t},
+			clientIdentityProvider: fakeProvider{pt: provTypeIdentity, isClient: true},
+			clientRootProvider:     fakeProvider{isClient: true},
 			clientVerifyFunc:       clientVerifyFuncGood,
 			clientVType:            CertVerification,
 			serverMutualTLS:        true,
-			serverIdentityProvider: fakeProvider{pt: provTypeIdentity, isClient: false, t: t},
-			serverRootProvider:     fakeProvider{isClient: false, wantError: true, t: t},
+			serverIdentityProvider: fakeProvider{pt: provTypeIdentity, isClient: false},
+			serverRootProvider:     fakeProvider{isClient: false, wantError: true},
 			serverVType:            CertVerification,
 			serverExpectError:      true,
 		},
@@ -652,13 +651,13 @@ func (s) TestClientServerHandshake(t *testing.T) {
 		// Expected Behavior: success
 		{
 			desc:                   "Client sets root and identity provider; Server sets root and identity provider; mutualTLS",
-			clientIdentityProvider: fakeProvider{pt: provTypeIdentity, isClient: true, t: t},
-			clientRootProvider:     fakeProvider{isClient: true, t: t},
+			clientIdentityProvider: fakeProvider{pt: provTypeIdentity, isClient: true},
+			clientRootProvider:     fakeProvider{isClient: true},
 			clientVerifyFunc:       clientVerifyFuncGood,
 			clientVType:            CertVerification,
 			serverMutualTLS:        true,
-			serverIdentityProvider: fakeProvider{pt: provTypeIdentity, isClient: false, t: t},
-			serverRootProvider:     fakeProvider{isClient: false, t: t},
+			serverIdentityProvider: fakeProvider{pt: provTypeIdentity, isClient: false},
+			serverRootProvider:     fakeProvider{isClient: false},
 			serverVType:            CertVerification,
 		},
 		// Client: set clientIdentityProvider and clientRootProvider
@@ -666,13 +665,13 @@ func (s) TestClientServerHandshake(t *testing.T) {
 		// Expected Behavior: success, because server side has SNI
 		{
 			desc:                   "Client sets root and identity provider; Server sets multiple certs in serverIdentityProvider; mutualTLS",
-			clientIdentityProvider: fakeProvider{pt: provTypeIdentity, isClient: true, t: t},
-			clientRootProvider:     fakeProvider{isClient: true, t: t},
+			clientIdentityProvider: fakeProvider{pt: provTypeIdentity, isClient: true},
+			clientRootProvider:     fakeProvider{isClient: true},
 			clientVerifyFunc:       clientVerifyFuncGood,
 			clientVType:            CertVerification,
 			serverMutualTLS:        true,
-			serverIdentityProvider: fakeProvider{pt: provTypeIdentity, isClient: false, wantMultiCert: true, t: t},
-			serverRootProvider:     fakeProvider{isClient: false, t: t},
+			serverIdentityProvider: fakeProvider{pt: provTypeIdentity, isClient: false, wantMultiCert: true},
+			serverRootProvider:     fakeProvider{isClient: false},
 			serverVType:            CertVerification,
 		},
 	} {
@@ -824,13 +823,13 @@ func (s) TestGetCertificatesSNI(t *testing.T) {
 		wantCert   tls.Certificate
 	}{
 		{
-			desc: "Select serverCert1",
+			desc: "Select ServerCert1",
 			// "foo.bar.com" is the common name on server certificate server_cert_1.pem.
 			serverName: "foo.bar.com",
 			wantCert:   cs.ServerCert1,
 		},
 		{
-			desc: "Select serverCert2",
+			desc: "Select ServerCert2",
 			// "foo.bar.server2.com" is the common name on server certificate server_cert_2.pem.
 			serverName: "foo.bar.server2.com",
 			wantCert:   cs.ServerCert2,

--- a/security/advancedtls/advancedtls_test.go
+++ b/security/advancedtls/advancedtls_test.go
@@ -32,7 +32,7 @@ import (
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/tls/certprovider"
 	"google.golang.org/grpc/internal/grpctest"
-	"google.golang.org/grpc/security/advancedtls/internal"
+	"google.golang.org/grpc/security/advancedtls/internal/testutils"
 )
 
 type s struct {
@@ -61,7 +61,7 @@ func (f fakeProvider) KeyMaterial(ctx context.Context) (*certprovider.KeyMateria
 	if f.wantError {
 		return nil, fmt.Errorf("bad fakeProvider")
 	}
-	cs := &internal.CertStore{}
+	cs := &testutils.CertStore{}
 	if err := cs.LoadCerts(); err != nil {
 		return nil, fmt.Errorf("cs.LoadCerts() failed, err: %v", err)
 	}
@@ -303,9 +303,9 @@ func (s) TestServerOptionsConfigSuccessCases(t *testing.T) {
 }
 
 func (s) TestClientServerHandshake(t *testing.T) {
-	cs := &internal.CertStore{}
+	cs := &testutils.CertStore{}
 	if err := cs.LoadCerts(); err != nil {
-		t.Fatalf("Function cs.LoadCerts() failed, err: %v", err)
+		t.Fatalf("cs.LoadCerts() failed, err: %v", err)
 	}
 	getRootCAsForClient := func(params *GetRootCAsParams) (*GetRootCAsResults, error) {
 		return &GetRootCAsResults{TrustCerts: cs.ClientTrust1}, nil
@@ -792,9 +792,9 @@ func compare(a1, a2 credentials.AuthInfo) bool {
 
 func (s) TestAdvancedTLSOverrideServerName(t *testing.T) {
 	expectedServerName := "server.name"
-	cs := &internal.CertStore{}
+	cs := &testutils.CertStore{}
 	if err := cs.LoadCerts(); err != nil {
-		t.Fatalf("Function cs.LoadCerts() failed, err: %v", err)
+		t.Fatalf("cs.LoadCerts() failed, err: %v", err)
 	}
 	clientOptions := &ClientOptions{
 		RootOptions: RootCertificateOptions{
@@ -813,9 +813,9 @@ func (s) TestAdvancedTLSOverrideServerName(t *testing.T) {
 }
 
 func (s) TestGetCertificatesSNI(t *testing.T) {
-	cs := &internal.CertStore{}
+	cs := &testutils.CertStore{}
 	if err := cs.LoadCerts(); err != nil {
-		t.Fatalf("Function cs.LoadCerts() failed, err: %v", err)
+		t.Fatalf("cs.LoadCerts() failed, err: %v", err)
 	}
 	tests := []struct {
 		desc       string

--- a/security/advancedtls/internal/testutils.go
+++ b/security/advancedtls/internal/testutils.go
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2020 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package internal
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"google.golang.org/grpc/security/advancedtls/testdata"
+	"io/ioutil"
+)
+
+// CertStore contains all the certificates used in the integration tests.
+type CertStore struct {
+	// ClientCert1 is the certificate sent by client to prove its identity.
+	// It is trusted by ServerTrust1.
+	ClientCert1 tls.Certificate
+	// ClientCert2 is the certificate sent by client to prove its identity.
+	// It is trusted by ServerTrust2.
+	ClientCert2 tls.Certificate
+	// ServerCert1 is the certificate sent by server to prove its identity.
+	// It is trusted by ClientTrust1.
+	ServerCert1 tls.Certificate
+	// ServerCert2 is the certificate sent by server to prove its identity.
+	// It is trusted by ClientTrust2.
+	ServerCert2 tls.Certificate
+	// ServerPeer3 is the certificate sent by server to prove its identity.
+	ServerPeer3  tls.Certificate
+	ClientTrust1 *x509.CertPool
+	ClientTrust2 *x509.CertPool
+	ServerTrust1 *x509.CertPool
+	ServerTrust2 *x509.CertPool
+}
+
+func readTrustCert(fileName string) (*x509.CertPool, error) {
+	trustData, err := ioutil.ReadFile(fileName)
+	if err != nil {
+		return nil, err
+	}
+	trustPool := x509.NewCertPool()
+	if !trustPool.AppendCertsFromPEM(trustData) {
+		return nil, fmt.Errorf("error loading trust certificates")
+	}
+	return trustPool, nil
+}
+
+// LoadCerts function is used to load test certificates at the beginning of
+// each integration test.
+func (cs *CertStore) LoadCerts() error {
+	var err error
+	if cs.ClientCert1, err = tls.LoadX509KeyPair(testdata.Path("client_cert_1.pem"), testdata.Path("client_key_1.pem")); err != nil {
+		return err
+	}
+	if cs.ClientCert2, err = tls.LoadX509KeyPair(testdata.Path("client_cert_2.pem"), testdata.Path("client_key_2.pem")); err != nil {
+		return err
+	}
+	if cs.ServerCert1, err = tls.LoadX509KeyPair(testdata.Path("server_cert_1.pem"), testdata.Path("server_key_1.pem")); err != nil {
+		return err
+	}
+	if cs.ServerCert2, err = tls.LoadX509KeyPair(testdata.Path("server_cert_2.pem"), testdata.Path("server_key_2.pem")); err != nil {
+		return err
+	}
+	if cs.ServerPeer3, err = tls.LoadX509KeyPair(testdata.Path("server_cert_3.pem"), testdata.Path("server_key_3.pem")); err != nil {
+		return err
+	}
+	if cs.ClientTrust1, err = readTrustCert(testdata.Path("client_trust_cert_1.pem")); err != nil {
+		return err
+	}
+	if cs.ClientTrust2, err = readTrustCert(testdata.Path("client_trust_cert_2.pem")); err != nil {
+		return err
+	}
+	if cs.ServerTrust1, err = readTrustCert(testdata.Path("server_trust_cert_1.pem")); err != nil {
+		return err
+	}
+	if cs.ServerTrust2, err = readTrustCert(testdata.Path("server_trust_cert_2.pem")); err != nil {
+		return err
+	}
+	return nil
+}

--- a/security/advancedtls/internal/testutils.go
+++ b/security/advancedtls/internal/testutils.go
@@ -15,14 +15,16 @@
  *
  */
 
+// Package internal contains helper functions for advancedtls.
 package internal
 
 import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"google.golang.org/grpc/security/advancedtls/testdata"
 	"io/ioutil"
+
+	"google.golang.org/grpc/security/advancedtls/testdata"
 )
 
 // CertStore contains all the certificates used in the integration tests.

--- a/security/advancedtls/internal/testutils/testutils.go
+++ b/security/advancedtls/internal/testutils/testutils.go
@@ -15,8 +15,8 @@
  *
  */
 
-// Package internal contains helper functions for advancedtls.
-package internal
+// Package testutils contains helper functions for advancedtls.
+package testutils
 
 import (
 	"crypto/tls"

--- a/security/advancedtls/internal/testutils/testutils.go
+++ b/security/advancedtls/internal/testutils/testutils.go
@@ -42,10 +42,14 @@ type CertStore struct {
 	// It is trusted by ClientTrust2.
 	ServerCert2 tls.Certificate
 	// ServerPeer3 is the certificate sent by server to prove its identity.
-	ServerPeer3  tls.Certificate
+	ServerPeer3 tls.Certificate
+	// ClientTrust1 is the root certificate used on the client side.
 	ClientTrust1 *x509.CertPool
+	// ClientTrust2 is the root certificate used on the client side.
 	ClientTrust2 *x509.CertPool
+	// ServerTrust1 is the root certificate used on the server side.
 	ServerTrust1 *x509.CertPool
+	// ServerTrust2 is the root certificate used on the server side.
 	ServerTrust2 *x509.CertPool
 }
 

--- a/security/advancedtls/pemfile_provider_test.go
+++ b/security/advancedtls/pemfile_provider_test.go
@@ -29,7 +29,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/grpc/credentials/tls/certprovider"
-	"google.golang.org/grpc/security/advancedtls/internal"
+	"google.golang.org/grpc/security/advancedtls/internal/testutils"
 	"google.golang.org/grpc/security/advancedtls/testdata"
 )
 
@@ -104,9 +104,9 @@ func (s) TestNewPEMFileProvider(t *testing.T) {
 // and see if the new credentials are picked up.
 func (s) TestWatchingRoutineUpdates(t *testing.T) {
 	// Load certificates.
-	cs := &internal.CertStore{}
+	cs := &testutils.CertStore{}
 	if err := cs.LoadCerts(); err != nil {
-		t.Fatalf("Function cs.LoadCerts() failed, err: %v", err)
+		t.Fatalf("cs.LoadCerts() failed, err: %v", err)
 	}
 	tests := []struct {
 		desc         string

--- a/security/advancedtls/pemfile_provider_test.go
+++ b/security/advancedtls/pemfile_provider_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/grpc/credentials/tls/certprovider"
+	"google.golang.org/grpc/security/advancedtls/internal"
 	"google.golang.org/grpc/security/advancedtls/testdata"
 )
 
@@ -103,8 +104,10 @@ func (s) TestNewPEMFileProvider(t *testing.T) {
 // and see if the new credentials are picked up.
 func (s) TestWatchingRoutineUpdates(t *testing.T) {
 	// Load certificates.
-	cs := &certStore{}
-	cs.loadCerts(t)
+	cs := &internal.CertStore{}
+	if err := cs.LoadCerts(); err != nil {
+		t.Fatalf("Function cs.LoadCerts() failed, err: %v", err)
+	}
 	tests := []struct {
 		desc         string
 		options      PEMFileProviderOptions
@@ -119,9 +122,9 @@ func (s) TestWatchingRoutineUpdates(t *testing.T) {
 				KeyFile:   "not_empty_key_file",
 				TrustFile: "not_empty_trust_file",
 			},
-			wantKmStage0: certprovider.KeyMaterial{Certs: []tls.Certificate{cs.clientCert1}, Roots: cs.serverTrust1},
-			wantKmStage1: certprovider.KeyMaterial{Certs: []tls.Certificate{cs.clientCert1}, Roots: cs.serverTrust1},
-			wantKmStage2: certprovider.KeyMaterial{Certs: []tls.Certificate{cs.clientCert2}, Roots: cs.serverTrust2},
+			wantKmStage0: certprovider.KeyMaterial{Certs: []tls.Certificate{cs.ClientCert1}, Roots: cs.ServerTrust1},
+			wantKmStage1: certprovider.KeyMaterial{Certs: []tls.Certificate{cs.ClientCert1}, Roots: cs.ServerTrust1},
+			wantKmStage2: certprovider.KeyMaterial{Certs: []tls.Certificate{cs.ClientCert2}, Roots: cs.ServerTrust2},
 		},
 		{
 			desc: "use identity certs only",
@@ -129,18 +132,18 @@ func (s) TestWatchingRoutineUpdates(t *testing.T) {
 				CertFile: "not_empty_cert_file",
 				KeyFile:  "not_empty_key_file",
 			},
-			wantKmStage0: certprovider.KeyMaterial{Certs: []tls.Certificate{cs.clientCert1}},
-			wantKmStage1: certprovider.KeyMaterial{Certs: []tls.Certificate{cs.clientCert1}},
-			wantKmStage2: certprovider.KeyMaterial{Certs: []tls.Certificate{cs.clientCert2}},
+			wantKmStage0: certprovider.KeyMaterial{Certs: []tls.Certificate{cs.ClientCert1}},
+			wantKmStage1: certprovider.KeyMaterial{Certs: []tls.Certificate{cs.ClientCert1}},
+			wantKmStage2: certprovider.KeyMaterial{Certs: []tls.Certificate{cs.ClientCert2}},
 		},
 		{
 			desc: "use trust certs only",
 			options: PEMFileProviderOptions{
 				TrustFile: "not_empty_trust_file",
 			},
-			wantKmStage0: certprovider.KeyMaterial{Roots: cs.serverTrust1},
-			wantKmStage1: certprovider.KeyMaterial{Roots: cs.serverTrust1},
-			wantKmStage2: certprovider.KeyMaterial{Roots: cs.serverTrust2},
+			wantKmStage0: certprovider.KeyMaterial{Roots: cs.ServerTrust1},
+			wantKmStage1: certprovider.KeyMaterial{Roots: cs.ServerTrust1},
+			wantKmStage2: certprovider.KeyMaterial{Roots: cs.ServerTrust2},
 		},
 	}
 	for _, test := range tests {
@@ -153,11 +156,11 @@ func (s) TestWatchingRoutineUpdates(t *testing.T) {
 			readKeyCertPairFunc = func(certFile, keyFile string) (tls.Certificate, error) {
 				switch stage.read() {
 				case 0:
-					return cs.clientCert1, nil
+					return cs.ClientCert1, nil
 				case 1:
 					return tls.Certificate{}, fmt.Errorf("error occurred while reloading")
 				case 2:
-					return cs.clientCert2, nil
+					return cs.ClientCert2, nil
 				default:
 					return tls.Certificate{}, fmt.Errorf("test stage not supported")
 				}
@@ -169,11 +172,11 @@ func (s) TestWatchingRoutineUpdates(t *testing.T) {
 			readTrustCertFunc = func(trustFile string) (*x509.CertPool, error) {
 				switch stage.read() {
 				case 0:
-					return cs.serverTrust1, nil
+					return cs.ServerTrust1, nil
 				case 1:
 					return nil, fmt.Errorf("error occurred while reloading")
 				case 2:
-					return cs.serverTrust2, nil
+					return cs.ServerTrust2, nil
 				default:
 					return nil, fmt.Errorf("test stage not supported")
 				}

--- a/security/advancedtls/pemfile_provider_test.go
+++ b/security/advancedtls/pemfile_provider_test.go
@@ -96,11 +96,11 @@ func (s) TestNewPEMFileProvider(t *testing.T) {
 
 // This test overwrites the credential reading function used by the watching
 // goroutine. It is tested under different stages:
-// At stage 0, we force reading function to load clientCert1 and serverTrust1,
+// At stage 0, we force reading function to load ClientCert1 and ServerTrust1,
 // and see if the credentials are picked up by the watching go routine.
 // At stage 1, we force reading function to cause an error. The watching go
 // routine should log the error while leaving the credentials unchanged.
-// At stage 2, we force reading function to load clientCert2 and serverTrust2,
+// At stage 2, we force reading function to load ClientCert2 and ServerTrust2,
 // and see if the new credentials are picked up.
 func (s) TestWatchingRoutineUpdates(t *testing.T) {
 	// Load certificates.


### PR DESCRIPTION
This PR does two following things:
1. clean up the test files, and make the way to load file credentials consistent across all the tests
2. remove the duplicate dependency of advancedtls. There were some shared code in `credentials/` which can't be used by advancedtls before, so in advancedtls we just duplicated the code. Now the shared part was moved to `internal/credentials/` which can be used by advancedtls, so we removed the previous duplicate code. 