### PR TITLE
xds/testutils: Minor cleanup.

### DIFF
--- a/xds/internal/testutils/balancer.go
+++ b/xds/internal/testutils/balancer.go
@@ -28,9 +28,9 @@ import (
 	"google.golang.org/grpc/resolver"
 )
 
-// DefaultTestSubConnsCount is the number of TestSubConns initialized as part of
+// TestSubConnsCount is the number of TestSubConns initialized as part of
 // package init.
-const DefaultTestSubConnsCount = 16
+const TestSubConnsCount = 16
 
 // testingLogger wraps the logging methods from testing.T.
 type testingLogger interface {
@@ -42,7 +42,7 @@ type testingLogger interface {
 var TestSubConns []*TestSubConn
 
 func init() {
-	for i := 0; i < DefaultTestSubConnsCount; i++ {
+	for i := 0; i < TestSubConnsCount; i++ {
 		TestSubConns = append(TestSubConns, &TestSubConn{
 			id: fmt.Sprintf("sc%d", i),
 		})

--- a/xds/internal/testutils/balancer.go
+++ b/xds/internal/testutils/balancer.go
@@ -20,27 +20,29 @@
 package testutils
 
 import (
-	"context"
 	"fmt"
-	"sync"
 	"testing"
 
-	corepb "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/balancer"
 	"google.golang.org/grpc/connectivity"
-	"google.golang.org/grpc/internal/wrr"
 	"google.golang.org/grpc/resolver"
-	"google.golang.org/grpc/xds/internal"
 )
 
-const testSubConnsCount = 16
+// DefaultTestSubConnsCount is the number of TestSubConns initialized as part of
+// package init.
+const DefaultTestSubConnsCount = 16
+
+// testingLogger wraps the logging methods from testing.T.
+type testingLogger interface {
+	Log(args ...interface{})
+	Logf(format string, args ...interface{})
+}
 
 // TestSubConns contains a list of SubConns to be used in tests.
 var TestSubConns []*TestSubConn
 
 func init() {
-	for i := 0; i < testSubConnsCount; i++ {
+	for i := 0; i < DefaultTestSubConnsCount; i++ {
 		TestSubConns = append(TestSubConns, &TestSubConn{
 			id: fmt.Sprintf("sc%d", i),
 		})
@@ -65,7 +67,7 @@ func (tsc *TestSubConn) String() string {
 
 // TestClientConn is a mock balancer.ClientConn used in tests.
 type TestClientConn struct {
-	t *testing.T // For logging only.
+	logger testingLogger
 
 	NewSubConnAddrsCh chan []resolver.Address // the last 10 []Address to create subconn.
 	NewSubConnCh      chan balancer.SubConn   // the last 10 subconn created.
@@ -80,7 +82,7 @@ type TestClientConn struct {
 // NewTestClientConn creates a TestClientConn.
 func NewTestClientConn(t *testing.T) *TestClientConn {
 	return &TestClientConn{
-		t: t,
+		logger: t,
 
 		NewSubConnAddrsCh: make(chan []resolver.Address, 10),
 		NewSubConnCh:      make(chan balancer.SubConn, 10),
@@ -96,7 +98,7 @@ func (tcc *TestClientConn) NewSubConn(a []resolver.Address, o balancer.NewSubCon
 	sc := TestSubConns[tcc.subConnIdx]
 	tcc.subConnIdx++
 
-	tcc.t.Logf("testClientConn: NewSubConn(%v, %+v) => %s", a, o, sc)
+	tcc.logger.Logf("testClientConn: NewSubConn(%v, %+v) => %s", a, o, sc)
 	select {
 	case tcc.NewSubConnAddrsCh <- a:
 	default:
@@ -112,7 +114,7 @@ func (tcc *TestClientConn) NewSubConn(a []resolver.Address, o balancer.NewSubCon
 
 // RemoveSubConn removes the SubConn.
 func (tcc *TestClientConn) RemoveSubConn(sc balancer.SubConn) {
-	tcc.t.Logf("testClientCOnn: RemoveSubConn(%p)", sc)
+	tcc.logger.Logf("testClientCOnn: RemoveSubConn(%p)", sc)
 	select {
 	case tcc.RemoveSubConnCh <- sc:
 	default:
@@ -122,12 +124,12 @@ func (tcc *TestClientConn) RemoveSubConn(sc balancer.SubConn) {
 // UpdateBalancerState implements balancer.Balancer API. It will be removed when
 // switching to the new balancer interface.
 func (tcc *TestClientConn) UpdateBalancerState(s connectivity.State, p balancer.Picker) {
-	tcc.t.Fatal("not implemented")
+	panic("not implemented")
 }
 
 // UpdateState updates connectivity state and picker.
 func (tcc *TestClientConn) UpdateState(bs balancer.State) {
-	tcc.t.Logf("testClientConn: UpdateState(%v)", bs)
+	tcc.logger.Logf("testClientConn: UpdateState(%v)", bs)
 	select {
 	case <-tcc.NewStateCh:
 	default:
@@ -148,49 +150,6 @@ func (tcc *TestClientConn) ResolveNow(resolver.ResolveNowOptions) {
 
 // Target panics.
 func (tcc *TestClientConn) Target() string {
-	panic("not implemented")
-}
-
-// TestServerLoad is testing Load for testing LRS.
-type TestServerLoad struct {
-	Name string
-	D    float64
-}
-
-// TestLoadStore is a load store to be used in tests.
-type TestLoadStore struct {
-	CallsStarted []internal.LocalityID
-	CallsEnded   []internal.LocalityID
-	CallsCost    []TestServerLoad
-}
-
-// NewTestLoadStore creates a new TestLoadStore.
-func NewTestLoadStore() *TestLoadStore {
-	return &TestLoadStore{}
-}
-
-// CallDropped records a call dropped.
-func (*TestLoadStore) CallDropped(category string) {
-	panic("not implemented")
-}
-
-// CallStarted records a call started.
-func (tls *TestLoadStore) CallStarted(l internal.LocalityID) {
-	tls.CallsStarted = append(tls.CallsStarted, l)
-}
-
-// CallFinished records a call finished.
-func (tls *TestLoadStore) CallFinished(l internal.LocalityID, err error) {
-	tls.CallsEnded = append(tls.CallsEnded, l)
-}
-
-// CallServerLoad records a call server load.
-func (tls *TestLoadStore) CallServerLoad(l internal.LocalityID, name string, d float64) {
-	tls.CallsCost = append(tls.CallsCost, TestServerLoad{Name: name, D: d})
-}
-
-// ReportTo panics.
-func (*TestLoadStore) ReportTo(ctx context.Context, cc *grpc.ClientConn, clusterName string, node *corepb.Node) {
 	panic("not implemented")
 }
 
@@ -317,47 +276,4 @@ func (tcp *TestConstPicker) Pick(info balancer.PickInfo) (balancer.PickResult, e
 		return balancer.PickResult{}, tcp.Err
 	}
 	return balancer.PickResult{SubConn: tcp.SC}, nil
-}
-
-// testWRR is a deterministic WRR implementation.
-//
-// The real implementation does random WRR. testWRR makes the balancer behavior
-// deterministic and easier to test.
-//
-// With {a: 2, b: 3}, the Next() results will be {a, a, b, b, b}.
-type testWRR struct {
-	itemsWithWeight []struct {
-		item   interface{}
-		weight int64
-	}
-	length int
-
-	mu    sync.Mutex
-	idx   int   // The index of the item that will be picked
-	count int64 // The number of times the current item has been picked.
-}
-
-// NewTestWRR return a WRR for testing. It's deterministic instead random.
-func NewTestWRR() wrr.WRR {
-	return &testWRR{}
-}
-
-func (twrr *testWRR) Add(item interface{}, weight int64) {
-	twrr.itemsWithWeight = append(twrr.itemsWithWeight, struct {
-		item   interface{}
-		weight int64
-	}{item: item, weight: weight})
-	twrr.length++
-}
-
-func (twrr *testWRR) Next() interface{} {
-	twrr.mu.Lock()
-	iww := twrr.itemsWithWeight[twrr.idx]
-	twrr.count++
-	if twrr.count >= iww.weight {
-		twrr.idx = (twrr.idx + 1) % twrr.length
-		twrr.count = 0
-	}
-	twrr.mu.Unlock()
-	return iww.item
 }

--- a/xds/internal/testutils/wrr.go
+++ b/xds/internal/testutils/wrr.go
@@ -1,0 +1,68 @@
+/*
+ *
+ * Copyright 2020 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package testutils
+
+import (
+	"sync"
+
+	"google.golang.org/grpc/internal/wrr"
+)
+
+// testWRR is a deterministic WRR implementation.
+//
+// The real implementation does random WRR. testWRR makes the balancer behavior
+// deterministic and easier to test.
+//
+// With {a: 2, b: 3}, the Next() results will be {a, a, b, b, b}.
+type testWRR struct {
+	itemsWithWeight []struct {
+		item   interface{}
+		weight int64
+	}
+	length int
+
+	mu    sync.Mutex
+	idx   int   // The index of the item that will be picked
+	count int64 // The number of times the current item has been picked.
+}
+
+// NewTestWRR return a WRR for testing. It's deterministic instead of random.
+func NewTestWRR() wrr.WRR {
+	return &testWRR{}
+}
+
+func (twrr *testWRR) Add(item interface{}, weight int64) {
+	twrr.itemsWithWeight = append(twrr.itemsWithWeight, struct {
+		item   interface{}
+		weight int64
+	}{item: item, weight: weight})
+	twrr.length++
+}
+
+func (twrr *testWRR) Next() interface{} {
+	twrr.mu.Lock()
+	iww := twrr.itemsWithWeight[twrr.idx]
+	twrr.count++
+	if twrr.count >= iww.weight {
+		twrr.idx = (twrr.idx + 1) % twrr.length
+		twrr.count = 0
+	}
+	twrr.mu.Unlock()
+	return iww.item
+}


### PR DESCRIPTION
Changes include the following:
- Define a `testingLogger` interface instead of directly using `testing.T` here. This make sure that we don't call `t.Error` or `t.Fatal` from here because there could be no guarantee that such a call would actually fail the running test (since we could be on a different goroutine here).
- Get rid of the `TestLoadStore` type. It is not used anymore.
- Move `testWRR` to its own file.