### PR TITLE
xds: Add bootstrap support for certificate providers.

### DIFF
--- a/credentials/tls/certprovider/provider.go
+++ b/credentials/tls/certprovider/provider.go
@@ -29,7 +29,13 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
+
+	"google.golang.org/grpc/internal"
 )
+
+func init() {
+	internal.GetCertificateProviderBuilder = getBuilder
+}
 
 var (
 	// errProviderClosed is returned by Distributor.KeyMaterial when it is
@@ -47,9 +53,9 @@ func Register(b Builder) {
 	m[b.Name()] = b
 }
 
-// GetBuilder returns the Provider builder registered with the given name.
+// getBuilder returns the Provider builder registered with the given name.
 // If no builder is registered with the provided name, nil will be returned.
-func GetBuilder(name string) Builder {
+func getBuilder(name string) Builder {
 	if b, ok := m[name]; ok {
 		return b
 	}

--- a/credentials/tls/certprovider/provider.go
+++ b/credentials/tls/certprovider/provider.go
@@ -47,9 +47,9 @@ func Register(b Builder) {
 	m[b.Name()] = b
 }
 
-// getBuilder returns the Provider builder registered with the given name.
+// GetBuilder returns the Provider builder registered with the given name.
 // If no builder is registered with the provided name, nil will be returned.
-func getBuilder(name string) Builder {
+func GetBuilder(name string) Builder {
 	if b, ok := m[name]; ok {
 		return b
 	}

--- a/credentials/tls/certprovider/store.go
+++ b/credentials/tls/certprovider/store.go
@@ -76,7 +76,7 @@ func GetProvider(name string, config interface{}, opts Options) (Provider, error
 	provStore.mu.Lock()
 	defer provStore.mu.Unlock()
 
-	builder := GetBuilder(name)
+	builder := getBuilder(name)
 	if builder == nil {
 		return nil, fmt.Errorf("no registered builder for provider name: %s", name)
 	}

--- a/credentials/tls/certprovider/store.go
+++ b/credentials/tls/certprovider/store.go
@@ -76,7 +76,7 @@ func GetProvider(name string, config interface{}, opts Options) (Provider, error
 	provStore.mu.Lock()
 	defer provStore.mu.Unlock()
 
-	builder := getBuilder(name)
+	builder := GetBuilder(name)
 	if builder == nil {
 		return nil, fmt.Errorf("no registered builder for provider name: %s", name)
 	}

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -52,6 +52,11 @@ var (
 	// This function compares the config without rawJSON stripped, in case the
 	// there's difference in white space.
 	EqualServiceConfigForTesting func(a, b serviceconfig.Config) bool
+	// GetCertificateProviderBuilder returns the registered builder for the
+	// given name. This is set by package certprovider for use from xDS
+	// bootstrap code while parsing certificate provider configs in the
+	// bootstrap file.
+	GetCertificateProviderBuilder interface{} // func(string) certprovider.Builder
 )
 
 // HealthChecker defines the signature of the client-side LB channel health checking function.

--- a/xds/internal/client/bootstrap/bootstrap_test.go
+++ b/xds/internal/client/bootstrap/bootstrap_test.go
@@ -19,6 +19,8 @@
 package bootstrap
 
 import (
+	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"testing"
@@ -28,8 +30,10 @@ import (
 	"github.com/golang/protobuf/proto"
 	structpb "github.com/golang/protobuf/ptypes/struct"
 	"github.com/google/go-cmp/cmp"
+
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/google"
+	"google.golang.org/grpc/credentials/tls/certprovider"
 	"google.golang.org/grpc/xds/internal/version"
 )
 
@@ -232,6 +236,24 @@ func (c *Config) compare(want *Config) error {
 	}
 	if diff := cmp.Diff(want.NodeProto, c.NodeProto, cmp.Comparer(proto.Equal)); diff != "" {
 		return fmt.Errorf("config.NodeProto diff (-want, +got):\n%s", diff)
+	}
+
+	// A vanilla cmp.Equal or cmp.Diff will not produce useful error message
+	// here. So, we iterate through the list of configs and compare them one at
+	// a time.
+	gotCfgs := c.CertProviderConfigs
+	wantCfgs := want.CertProviderConfigs
+	if len(gotCfgs) != len(wantCfgs) {
+		return fmt.Errorf("config.CertProviderConfigs is %d entries, want %d", len(gotCfgs), len(wantCfgs))
+	}
+	for name, gotCfg := range gotCfgs {
+		wantCfg := wantCfgs[name]
+		if wantCfg == nil {
+			return fmt.Errorf("config.CertProviderConfigs has unexpected plugin %q with config %q", name, string(gotCfg.Canonical()))
+		}
+		if !cmp.Equal(gotCfg.Canonical(), wantCfg.Canonical()) {
+			return fmt.Errorf("config.CertProviderConfigs for plugin %q has config %q, want %q", name, string(gotCfg.Canonical()), string(wantCfg.Canonical()))
+		}
 	}
 	return nil
 }
@@ -450,5 +472,230 @@ func TestNewConfigBootstrapFileEnvNotSet(t *testing.T) {
 	os.Unsetenv(bootstrapFileEnv)
 	if _, err := NewConfig(); err == nil {
 		t.Errorf("NewConfig() returned nil error, expected to fail")
+	}
+}
+
+func init() {
+	certprovider.Register(&fakeCertProviderBuilder{})
+}
+
+const fakeCertProviderName = "fake-certificate-provider"
+
+// fakeCertProviderBuilder builds new instances of fakeCertProvider and
+// interprets the config provided to it as JSON with a single key and value.
+type fakeCertProviderBuilder struct{}
+
+func (b *fakeCertProviderBuilder) Build(certprovider.StableConfig, certprovider.Options) certprovider.Provider {
+	return &fakeCertProvider{}
+}
+
+// ParseConfig expects input in JSON format containing a map from string to
+// string, with a single entry and mapKey being "configKey".
+func (b *fakeCertProviderBuilder) ParseConfig(cfg interface{}) (certprovider.StableConfig, error) {
+	config, ok := cfg.(json.RawMessage)
+	if !ok {
+		return nil, fmt.Errorf("fakeCertProviderBuilder received config of type %T, want []byte", config)
+	}
+	var cfgData map[string]string
+	if err := json.Unmarshal(config, &cfgData); err != nil {
+		return nil, fmt.Errorf("fakeCertProviderBuilder config parsing failed: %v", err)
+	}
+	if len(cfgData) != 1 || cfgData["configKey"] == "" {
+		return nil, errors.New("fakeCertProviderBuilder received invalid config")
+	}
+	return &fakeStableConfig{config: cfgData}, nil
+}
+
+func (b *fakeCertProviderBuilder) Name() string {
+	return fakeCertProviderName
+}
+
+type fakeStableConfig struct {
+	config map[string]string
+}
+
+func (c *fakeStableConfig) Canonical() []byte {
+	var cfg string
+	for k, v := range c.config {
+		cfg = fmt.Sprintf("%s:%s", k, v)
+	}
+	return []byte(cfg)
+}
+
+// fakeCertProvider is an empty implementation of the Provider interface.
+type fakeCertProvider struct {
+	certprovider.Provider
+}
+
+func TestNewConfigWithCertificateProviders(t *testing.T) {
+	bootstrapFileMap := map[string]string{
+		"badJSONCertProviderConfig": `
+		{
+			"node": {
+				"id": "ENVOY_NODE_ID",
+				"metadata": {
+				    "TRAFFICDIRECTOR_GRPC_HOSTNAME": "trafficdirector"
+			    }
+			},
+			"xds_servers" : [{
+				"server_uri": "trafficdirector.googleapis.com:443",
+				"channel_creds": [
+					{ "type": "google_default" }
+				]
+			}],
+			"server_features" : ["foo", "bar", "xds_v3"],
+			"certificate_providers": "bad JSON"
+		}`,
+		"allUnknownCertProviders": `
+		{
+			"node": {
+				"id": "ENVOY_NODE_ID",
+				"metadata": {
+				    "TRAFFICDIRECTOR_GRPC_HOSTNAME": "trafficdirector"
+			    }
+			},
+			"xds_servers" : [{
+				"server_uri": "trafficdirector.googleapis.com:443",
+				"channel_creds": [
+					{ "type": "google_default" }
+				]
+			}],
+			"server_features" : ["foo", "bar", "xds_v3"],
+			"certificate_providers": {
+				"unknownProviderInstance1": {
+					"foo1": "bar1"
+				},
+				"unknownProviderInstance2": {
+					"foo2": "bar2"
+				}
+			}
+		}`,
+		"badCertProviderConfig": `
+		{
+			"node": {
+				"id": "ENVOY_NODE_ID",
+				"metadata": {
+				    "TRAFFICDIRECTOR_GRPC_HOSTNAME": "trafficdirector"
+			    }
+			},
+			"xds_servers" : [{
+				"server_uri": "trafficdirector.googleapis.com:443",
+				"channel_creds": [
+					{ "type": "google_default" }
+				]
+			}],
+			"server_features" : ["foo", "bar", "xds_v3"],
+			"certificate_providers": {
+				"unknownProviderInstance": {
+					"foo": "bar"
+				},
+				"fakeProviderInstance": {
+					"fake-certificate-provider": {
+						"configKey": "configValue"
+					}
+				},
+				"fakeProviderInstanceBad": {
+					"fake-certificate-provider": {
+						"configKey": 666
+					}
+				}
+			}
+		}`,
+		"goodCertProviderConfig": `
+		{
+			"node": {
+				"id": "ENVOY_NODE_ID",
+				"metadata": {
+				    "TRAFFICDIRECTOR_GRPC_HOSTNAME": "trafficdirector"
+			    }
+			},
+			"xds_servers" : [{
+				"server_uri": "trafficdirector.googleapis.com:443",
+				"channel_creds": [
+					{ "type": "google_default" }
+				]
+			}],
+			"server_features" : ["foo", "bar", "xds_v3"],
+			"certificate_providers": {
+				"unknownProviderInstance": {
+					"foo": "bar"
+				},
+				"fakeProviderInstance": {
+					"fake-certificate-provider": {
+						"configKey": "configValue"
+					}
+				}
+			}
+		}`,
+	}
+	parser := certprovider.GetBuilder(fakeCertProviderName)
+	if parser == nil {
+		t.Fatalf("missing certprovider plugin %q", fakeCertProviderName)
+	}
+	wantCfg, err := parser.ParseConfig(json.RawMessage(`{
+						"configKey": "configValue"
+	}`))
+	if err != nil {
+		t.Fatalf("config parsing for plugin %q failed: %v", fakeCertProviderName, err)
+	}
+
+	if err := os.Setenv(v3SupportEnv, "true"); err != nil {
+		t.Fatalf("os.Setenv(%s, %s) failed with error: %v", v3SupportEnv, "true", err)
+	}
+	defer os.Unsetenv(v3SupportEnv)
+
+	cancel := setupBootstrapOverride(bootstrapFileMap)
+	defer cancel()
+
+	goodConfig := &Config{
+		BalancerName: "trafficdirector.googleapis.com:443",
+		Creds:        grpc.WithCredentialsBundle(google.NewComputeEngineCredentials()),
+		TransportAPI: version.TransportV3,
+		NodeProto:    v3NodeProto,
+		CertProviderConfigs: map[string]certprovider.StableConfig{
+			"fakeProviderInstance": wantCfg,
+		},
+	}
+	tests := []struct {
+		name       string
+		wantConfig *Config
+		wantErr    bool
+	}{
+		{
+			name:    "badJSONCertProviderConfig",
+			wantErr: true,
+		},
+		{
+
+			name:    "badCertProviderConfig",
+			wantErr: true,
+		},
+		{
+
+			name:       "allUnknownCertProviders",
+			wantConfig: nonNilCredsConfigV3,
+		},
+		{
+			name:       "goodCertProviderConfig",
+			wantConfig: goodConfig,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if err := os.Setenv(bootstrapFileEnv, test.name); err != nil {
+				t.Fatalf("os.Setenv(%s, %s) failed with error: %v", bootstrapFileEnv, test.name, err)
+			}
+			c, err := NewConfig()
+			if (err != nil) != test.wantErr {
+				t.Fatalf("NewConfig() returned: %v, wantErr: %v", err, test.wantErr)
+			}
+			if test.wantErr {
+				return
+			}
+			if err := c.compare(test.wantConfig); err != nil {
+				t.Fatal(err)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Changes include:
- Exporting the `GetBuilder` function from `certprovider` package.
- Add a `CertProviderConfigs` field in the `Config` type exported by the `bootstrap` package. This will contain the parsed certprovider configs.