### PR TITLE
xds: Refactor/cleanup xds client tests.

### DIFF
--- a/xds/internal/client/client_watchers_cluster_test.go
+++ b/xds/internal/client/client_watchers_cluster_test.go
@@ -22,6 +22,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+
 	"google.golang.org/grpc/internal/testutils"
 )
 
@@ -35,62 +37,54 @@ type clusterUpdateErr struct {
 // - an update for another resource name
 // - an update is received after cancel()
 func (s) TestClusterWatch(t *testing.T) {
-	v2ClientCh, cleanup := overrideNewAPIClient()
+	apiClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	c, err := New(clientOpts(testXDSServer, false))
+	client, err := New(clientOpts(testXDSServer, false))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
-	defer c.Close()
-
-	// TODO: add a timeout to this recv.
-	// Note that this won't be necessary if we finish the TODO below to call
-	// Client directly instead of v2Client.r.
-	v2Client := <-v2ClientCh
-
-	clusterUpdateCh := testutils.NewChannel()
-	cancelWatch := c.WatchCluster(testCDSName, func(update ClusterUpdate, err error) {
-		clusterUpdateCh.Send(clusterUpdateErr{u: update, err: err})
-	})
+	defer client.Close()
 
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
-	if _, err := v2Client.addWatches[ClusterResource].Receive(ctx); err != nil {
+	c, err := apiClientCh.Receive(ctx)
+	if err != nil {
+		t.Fatalf("timeout when waiting for API client to be created: %v", err)
+	}
+	apiClient := c.(*testAPIClient)
+
+	clusterUpdateCh := testutils.NewChannel()
+	cancelWatch := client.WatchCluster(testCDSName, func(update ClusterUpdate, err error) {
+		clusterUpdateCh.Send(clusterUpdateErr{u: update, err: err})
+	})
+
+	ctx, cancel = context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	if _, err := apiClient.addWatches[ClusterResource].Receive(ctx); err != nil {
 		t.Fatalf("want new watch to start, got error %v", err)
 	}
 
 	wantUpdate := ClusterUpdate{ServiceName: testEDSName}
-	// This is calling v2Client.r to send the update, but r is set to Client, so
-	// this is same as calling Client to update. The one thing this covers is
-	// that `NewXDSV2Client` is called with the right parent.
-	//
-	// TODO: in a future cleanup, this (and the same thing in other tests) can
-	// be changed call Client directly.
-	v2Client.r.NewClusters(map[string]ClusterUpdate{
-		testCDSName: wantUpdate,
-	})
-
-	if u, err := clusterUpdateCh.Receive(ctx); err != nil || u != (clusterUpdateErr{wantUpdate, nil}) {
-		t.Errorf("unexpected clusterUpdate: %v, error receiving from channel: %v", u, err)
+	client.NewClusters(map[string]ClusterUpdate{testCDSName: wantUpdate})
+	if err := verifyClusterUpdate(clusterUpdateCh, wantUpdate); err != nil {
+		t.Fatal(err)
 	}
 
 	// Another update, with an extra resource for a different resource name.
-	v2Client.r.NewClusters(map[string]ClusterUpdate{
+	client.NewClusters(map[string]ClusterUpdate{
 		testCDSName:  wantUpdate,
 		"randomName": {},
 	})
-
-	if u, err := clusterUpdateCh.Receive(ctx); err != nil || u != (clusterUpdateErr{wantUpdate, nil}) {
-		t.Errorf("unexpected clusterUpdate: %+v, %v, want channel recv timeout", u, err)
+	if err := verifyClusterUpdate(clusterUpdateCh, wantUpdate); err != nil {
+		t.Fatal(err)
 	}
 
 	// Cancel watch, and send update again.
 	cancelWatch()
-	v2Client.r.NewClusters(map[string]ClusterUpdate{
-		testCDSName: wantUpdate,
-	})
-
+	client.NewClusters(map[string]ClusterUpdate{testCDSName: wantUpdate})
+	ctx, cancel = context.WithTimeout(context.Background(), defaultTestShortTimeout)
+	defer cancel()
 	if u, err := clusterUpdateCh.Receive(ctx); err != context.DeadlineExceeded {
 		t.Errorf("unexpected clusterUpdate: %v, %v, want channel recv timeout", u, err)
 	}
@@ -99,63 +93,64 @@ func (s) TestClusterWatch(t *testing.T) {
 // TestClusterTwoWatchSameResourceName covers the case where an update is received
 // after two watch() for the same resource name.
 func (s) TestClusterTwoWatchSameResourceName(t *testing.T) {
-	v2ClientCh, cleanup := overrideNewAPIClient()
+	apiClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	c, err := New(clientOpts(testXDSServer, false))
+	client, err := New(clientOpts(testXDSServer, false))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
-	defer c.Close()
+	defer client.Close()
 
-	v2Client := <-v2ClientCh
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	c, err := apiClientCh.Receive(ctx)
+	if err != nil {
+		t.Fatalf("timeout when waiting for API client to be created: %v", err)
+	}
+	apiClient := c.(*testAPIClient)
 
 	var clusterUpdateChs []*testutils.Channel
 	var cancelLastWatch func()
-
-	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	ctx, cancel = context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
 
 	const count = 2
 	for i := 0; i < count; i++ {
 		clusterUpdateCh := testutils.NewChannel()
 		clusterUpdateChs = append(clusterUpdateChs, clusterUpdateCh)
-		cancelLastWatch = c.WatchCluster(testCDSName, func(update ClusterUpdate, err error) {
+		cancelLastWatch = client.WatchCluster(testCDSName, func(update ClusterUpdate, err error) {
 			clusterUpdateCh.Send(clusterUpdateErr{u: update, err: err})
 		})
 
 		if i == 0 {
 			// A new watch is registered on the underlying API client only for
 			// the first iteration because we are using the same resource name.
-			if _, err := v2Client.addWatches[ClusterResource].Receive(ctx); err != nil {
+			if _, err := apiClient.addWatches[ClusterResource].Receive(ctx); err != nil {
 				t.Fatalf("want new watch to start, got error %v", err)
 			}
 		}
 	}
 
 	wantUpdate := ClusterUpdate{ServiceName: testEDSName}
-	v2Client.r.NewClusters(map[string]ClusterUpdate{
-		testCDSName: wantUpdate,
-	})
-
+	client.NewClusters(map[string]ClusterUpdate{testCDSName: wantUpdate})
 	for i := 0; i < count; i++ {
-		if u, err := clusterUpdateChs[i].Receive(ctx); err != nil || u != (clusterUpdateErr{wantUpdate, nil}) {
-			t.Errorf("i=%v, unexpected clusterUpdate: %v, error receiving from channel: %v", i, u, err)
+		if err := verifyClusterUpdate(clusterUpdateChs[i], wantUpdate); err != nil {
+			t.Fatal(err)
 		}
 	}
 
 	// Cancel the last watch, and send update again.
 	cancelLastWatch()
-	v2Client.r.NewClusters(map[string]ClusterUpdate{
-		testCDSName: wantUpdate,
-	})
-
+	client.NewClusters(map[string]ClusterUpdate{testCDSName: wantUpdate})
 	for i := 0; i < count-1; i++ {
-		if u, err := clusterUpdateChs[i].Receive(ctx); err != nil || u != (clusterUpdateErr{wantUpdate, nil}) {
-			t.Errorf("i=%v, unexpected clusterUpdate: %v, error receiving from channel: %v", i, u, err)
+		if err := verifyClusterUpdate(clusterUpdateChs[i], wantUpdate); err != nil {
+			t.Fatal(err)
 		}
 	}
 
+	ctx, cancel = context.WithTimeout(context.Background(), defaultTestShortTimeout)
+	defer cancel()
 	if u, err := clusterUpdateChs[count-1].Receive(ctx); err != context.DeadlineExceeded {
 		t.Errorf("unexpected clusterUpdate: %v, %v, want channel recv timeout", u, err)
 	}
@@ -164,34 +159,40 @@ func (s) TestClusterTwoWatchSameResourceName(t *testing.T) {
 // TestClusterThreeWatchDifferentResourceName covers the case where an update is
 // received after three watch() for different resource names.
 func (s) TestClusterThreeWatchDifferentResourceName(t *testing.T) {
-	v2ClientCh, cleanup := overrideNewAPIClient()
+	apiClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	c, err := New(clientOpts(testXDSServer, false))
+	client, err := New(clientOpts(testXDSServer, false))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
-	defer c.Close()
+	defer client.Close()
 
-	v2Client := <-v2ClientCh
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	c, err := apiClientCh.Receive(ctx)
+	if err != nil {
+		t.Fatalf("timeout when waiting for API client to be created: %v", err)
+	}
+	apiClient := c.(*testAPIClient)
 
 	var clusterUpdateChs []*testutils.Channel
 	const count = 2
 
 	// Two watches for the same name.
-	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	ctx, cancel = context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
 	for i := 0; i < count; i++ {
 		clusterUpdateCh := testutils.NewChannel()
 		clusterUpdateChs = append(clusterUpdateChs, clusterUpdateCh)
-		c.WatchCluster(testCDSName+"1", func(update ClusterUpdate, err error) {
+		client.WatchCluster(testCDSName+"1", func(update ClusterUpdate, err error) {
 			clusterUpdateCh.Send(clusterUpdateErr{u: update, err: err})
 		})
 
 		if i == 0 {
 			// A new watch is registered on the underlying API client only for
 			// the first iteration because we are using the same resource name.
-			if _, err := v2Client.addWatches[ClusterResource].Receive(ctx); err != nil {
+			if _, err := apiClient.addWatches[ClusterResource].Receive(ctx); err != nil {
 				t.Fatalf("want new watch to start, got error %v", err)
 			}
 		}
@@ -199,82 +200,88 @@ func (s) TestClusterThreeWatchDifferentResourceName(t *testing.T) {
 
 	// Third watch for a different name.
 	clusterUpdateCh2 := testutils.NewChannel()
-	c.WatchCluster(testCDSName+"2", func(update ClusterUpdate, err error) {
+	client.WatchCluster(testCDSName+"2", func(update ClusterUpdate, err error) {
 		clusterUpdateCh2.Send(clusterUpdateErr{u: update, err: err})
 	})
-	if _, err := v2Client.addWatches[ClusterResource].Receive(ctx); err != nil {
+	if _, err := apiClient.addWatches[ClusterResource].Receive(ctx); err != nil {
 		t.Fatalf("want new watch to start, got error %v", err)
 	}
 
 	wantUpdate1 := ClusterUpdate{ServiceName: testEDSName + "1"}
 	wantUpdate2 := ClusterUpdate{ServiceName: testEDSName + "2"}
-	v2Client.r.NewClusters(map[string]ClusterUpdate{
+	client.NewClusters(map[string]ClusterUpdate{
 		testCDSName + "1": wantUpdate1,
 		testCDSName + "2": wantUpdate2,
 	})
 
 	for i := 0; i < count; i++ {
-		if u, err := clusterUpdateChs[i].Receive(ctx); err != nil || u != (clusterUpdateErr{wantUpdate1, nil}) {
-			t.Errorf("i=%v, unexpected clusterUpdate: %v, error receiving from channel: %v", i, u, err)
+		if err := verifyClusterUpdate(clusterUpdateChs[i], wantUpdate1); err != nil {
+			t.Fatal(err)
 		}
 	}
-
-	if u, err := clusterUpdateCh2.Receive(ctx); err != nil || u != (clusterUpdateErr{wantUpdate2, nil}) {
-		t.Errorf("unexpected clusterUpdate: %v, error receiving from channel: %v", u, err)
+	if err := verifyClusterUpdate(clusterUpdateCh2, wantUpdate2); err != nil {
+		t.Fatal(err)
 	}
 }
 
 // TestClusterWatchAfterCache covers the case where watch is called after the update
 // is in cache.
 func (s) TestClusterWatchAfterCache(t *testing.T) {
-	v2ClientCh, cleanup := overrideNewAPIClient()
+	apiClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	c, err := New(clientOpts(testXDSServer, false))
+	client, err := New(clientOpts(testXDSServer, false))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
-	defer c.Close()
-
-	v2Client := <-v2ClientCh
-
-	clusterUpdateCh := testutils.NewChannel()
-	c.WatchCluster(testCDSName, func(update ClusterUpdate, err error) {
-		clusterUpdateCh.Send(clusterUpdateErr{u: update, err: err})
-	})
+	defer client.Close()
 
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
-	if _, err := v2Client.addWatches[ClusterResource].Receive(ctx); err != nil {
+	c, err := apiClientCh.Receive(ctx)
+	if err != nil {
+		t.Fatalf("timeout when waiting for API client to be created: %v", err)
+	}
+	apiClient := c.(*testAPIClient)
+
+	clusterUpdateCh := testutils.NewChannel()
+	client.WatchCluster(testCDSName, func(update ClusterUpdate, err error) {
+		clusterUpdateCh.Send(clusterUpdateErr{u: update, err: err})
+	})
+
+	ctx, cancel = context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	if _, err := apiClient.addWatches[ClusterResource].Receive(ctx); err != nil {
 		t.Fatalf("want new watch to start, got error %v", err)
 	}
 
 	wantUpdate := ClusterUpdate{ServiceName: testEDSName}
-	v2Client.r.NewClusters(map[string]ClusterUpdate{
+	client.NewClusters(map[string]ClusterUpdate{
 		testCDSName: wantUpdate,
 	})
-
-	if u, err := clusterUpdateCh.Receive(ctx); err != nil || u != (clusterUpdateErr{wantUpdate, nil}) {
-		t.Errorf("unexpected clusterUpdate: %v, error receiving from channel: %v", u, err)
+	if err := verifyClusterUpdate(clusterUpdateCh, wantUpdate); err != nil {
+		t.Fatal(err)
 	}
 
 	// Another watch for the resource in cache.
 	clusterUpdateCh2 := testutils.NewChannel()
-	c.WatchCluster(testCDSName, func(update ClusterUpdate, err error) {
+	client.WatchCluster(testCDSName, func(update ClusterUpdate, err error) {
 		clusterUpdateCh2.Send(clusterUpdateErr{u: update, err: err})
 	})
-	if n, err := v2Client.addWatches[ClusterResource].Receive(ctx); err != context.DeadlineExceeded {
+	ctx, cancel = context.WithTimeout(context.Background(), defaultTestShortTimeout)
+	defer cancel()
+	if n, err := apiClient.addWatches[ClusterResource].Receive(ctx); err != context.DeadlineExceeded {
 		t.Fatalf("want no new watch to start (recv timeout), got resource name: %v error %v", n, err)
 	}
 
 	// New watch should receives the update.
-	ctx, cancel = context.WithTimeout(context.Background(), defaultTestTimeout)
-	defer cancel()
-	if u, err := clusterUpdateCh2.Receive(ctx); err != nil || u != (clusterUpdateErr{wantUpdate, nil}) {
-		t.Errorf("unexpected clusterUpdate: %v, error receiving from channel: %v", u, err)
+	if err := verifyClusterUpdate(clusterUpdateCh2, wantUpdate); err != nil {
+		t.Fatal(err)
 	}
 
 	// Old watch should see nothing.
+	ctx, cancel = context.WithTimeout(context.Background(), defaultTestShortTimeout)
+	defer cancel()
 	if u, err := clusterUpdateCh.Receive(ctx); err != context.DeadlineExceeded {
 		t.Errorf("unexpected clusterUpdate: %v, %v, want channel recv timeout", u, err)
 	}
@@ -284,38 +291,43 @@ func (s) TestClusterWatchAfterCache(t *testing.T) {
 // an CDS response for the request that it sends out. We want the watch callback
 // to be invoked with an error once the watchExpiryTimer fires.
 func (s) TestClusterWatchExpiryTimer(t *testing.T) {
-	v2ClientCh, cleanup := overrideNewAPIClient()
+	apiClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	c, err := New(clientOpts(testXDSServer, true))
+	client, err := New(clientOpts(testXDSServer, true))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
-	defer c.Close()
-
-	v2Client := <-v2ClientCh
-
-	clusterUpdateCh := testutils.NewChannel()
-	c.WatchCluster(testCDSName, func(u ClusterUpdate, err error) {
-		clusterUpdateCh.Send(clusterUpdateErr{u: u, err: err})
-	})
+	defer client.Close()
 
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
-	if _, err := v2Client.addWatches[ClusterResource].Receive(ctx); err != nil {
+	c, err := apiClientCh.Receive(ctx)
+	if err != nil {
+		t.Fatalf("timeout when waiting for API client to be created: %v", err)
+	}
+	apiClient := c.(*testAPIClient)
+
+	clusterUpdateCh := testutils.NewChannel()
+	client.WatchCluster(testCDSName, func(u ClusterUpdate, err error) {
+		clusterUpdateCh.Send(clusterUpdateErr{u: u, err: err})
+	})
+
+	ctx, cancel = context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	if _, err := apiClient.addWatches[ClusterResource].Receive(ctx); err != nil {
 		t.Fatalf("want new watch to start, got error %v", err)
 	}
 
+	ctx, cancel = context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
 	u, err := clusterUpdateCh.Receive(ctx)
 	if err != nil {
-		t.Fatalf("failed to get clusterUpdate: %v", err)
+		t.Fatalf("timeout when waiting for cluster update: %v", err)
 	}
-	uu := u.(clusterUpdateErr)
-	if uu.u != (ClusterUpdate{}) {
-		t.Errorf("unexpected clusterUpdate: %v, want %v", uu.u, ClusterUpdate{})
-	}
-	if uu.err == nil {
-		t.Errorf("unexpected clusterError: <nil>, want error watcher timeout")
+	gotUpdate := u.(clusterUpdateErr)
+	if gotUpdate.err == nil || !cmp.Equal(gotUpdate.u, ClusterUpdate{}) {
+		t.Fatalf("unexpected clusterUpdate: (%v, %v), want: (ClusterUpdate{}, nil)", gotUpdate.u, gotUpdate.err)
 	}
 }
 
@@ -323,41 +335,47 @@ func (s) TestClusterWatchExpiryTimer(t *testing.T) {
 // an CDS response for the request that it sends out. We want no error even
 // after expiry timeout.
 func (s) TestClusterWatchExpiryTimerStop(t *testing.T) {
-	v2ClientCh, cleanup := overrideNewAPIClient()
+	apiClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	c, err := New(clientOpts(testXDSServer, true))
+	client, err := New(clientOpts(testXDSServer, true))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
-	defer c.Close()
-
-	v2Client := <-v2ClientCh
-
-	clusterUpdateCh := testutils.NewChannel()
-	c.WatchCluster(testCDSName, func(u ClusterUpdate, err error) {
-		clusterUpdateCh.Send(clusterUpdateErr{u: u, err: err})
-	})
+	defer client.Close()
 
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
-	if _, err := v2Client.addWatches[ClusterResource].Receive(ctx); err != nil {
+	c, err := apiClientCh.Receive(ctx)
+	if err != nil {
+		t.Fatalf("timeout when waiting for API client to be created: %v", err)
+	}
+	apiClient := c.(*testAPIClient)
+
+	clusterUpdateCh := testutils.NewChannel()
+	client.WatchCluster(testCDSName, func(u ClusterUpdate, err error) {
+		clusterUpdateCh.Send(clusterUpdateErr{u: u, err: err})
+	})
+
+	ctx, cancel = context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	if _, err := apiClient.addWatches[ClusterResource].Receive(ctx); err != nil {
 		t.Fatalf("want new watch to start, got error %v", err)
 	}
 
 	wantUpdate := ClusterUpdate{ServiceName: testEDSName}
-	v2Client.r.NewClusters(map[string]ClusterUpdate{
+	client.NewClusters(map[string]ClusterUpdate{
 		testCDSName: wantUpdate,
 	})
-
-	if u, err := clusterUpdateCh.Receive(ctx); err != nil || u != (clusterUpdateErr{wantUpdate, nil}) {
-		t.Errorf("unexpected clusterUpdate: %v, error receiving from channel: %v", u, err)
+	if err := verifyClusterUpdate(clusterUpdateCh, wantUpdate); err != nil {
+		t.Fatal(err)
 	}
 
 	// Wait for an error, the error should never happen.
-	u, err := clusterUpdateCh.Receive(ctx)
-	if err != context.DeadlineExceeded {
-		t.Fatalf("got unexpected: %v, %v, want recv timeout", u.(clusterUpdateErr).u, u.(clusterUpdateErr).err)
+	ctx, cancel = context.WithTimeout(context.Background(), defaultTestWatchExpiryTimeout)
+	defer cancel()
+	if u, err := clusterUpdateCh.Receive(ctx); err != context.DeadlineExceeded {
+		t.Errorf("unexpected clusterUpdate: %v, %v, want channel recv timeout", u, err)
 	}
 }
 
@@ -368,80 +386,84 @@ func (s) TestClusterWatchExpiryTimerStop(t *testing.T) {
 // - one more update without the removed resource
 //   - the callback (above) shouldn't receive any update
 func (s) TestClusterResourceRemoved(t *testing.T) {
-	v2ClientCh, cleanup := overrideNewAPIClient()
+	apiClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	c, err := New(clientOpts(testXDSServer, false))
+	client, err := New(clientOpts(testXDSServer, false))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
-	defer c.Close()
-
-	v2Client := <-v2ClientCh
-
-	clusterUpdateCh1 := testutils.NewChannel()
-	c.WatchCluster(testCDSName+"1", func(update ClusterUpdate, err error) {
-		clusterUpdateCh1.Send(clusterUpdateErr{u: update, err: err})
-	})
+	defer client.Close()
 
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
-	if _, err := v2Client.addWatches[ClusterResource].Receive(ctx); err != nil {
+	c, err := apiClientCh.Receive(ctx)
+	if err != nil {
+		t.Fatalf("timeout when waiting for API client to be created: %v", err)
+	}
+	apiClient := c.(*testAPIClient)
+
+	clusterUpdateCh1 := testutils.NewChannel()
+	client.WatchCluster(testCDSName+"1", func(update ClusterUpdate, err error) {
+		clusterUpdateCh1.Send(clusterUpdateErr{u: update, err: err})
+	})
+	ctx, cancel = context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	if _, err := apiClient.addWatches[ClusterResource].Receive(ctx); err != nil {
 		t.Fatalf("want new watch to start, got error %v", err)
 	}
+
 	// Another watch for a different name.
 	clusterUpdateCh2 := testutils.NewChannel()
-	c.WatchCluster(testCDSName+"2", func(update ClusterUpdate, err error) {
+	client.WatchCluster(testCDSName+"2", func(update ClusterUpdate, err error) {
 		clusterUpdateCh2.Send(clusterUpdateErr{u: update, err: err})
 	})
-	if _, err := v2Client.addWatches[ClusterResource].Receive(ctx); err != nil {
+	ctx, cancel = context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	if _, err := apiClient.addWatches[ClusterResource].Receive(ctx); err != nil {
 		t.Fatalf("want new watch to start, got error %v", err)
 	}
 
 	wantUpdate1 := ClusterUpdate{ServiceName: testEDSName + "1"}
 	wantUpdate2 := ClusterUpdate{ServiceName: testEDSName + "2"}
-	v2Client.r.NewClusters(map[string]ClusterUpdate{
+	client.NewClusters(map[string]ClusterUpdate{
 		testCDSName + "1": wantUpdate1,
 		testCDSName + "2": wantUpdate2,
 	})
-
-	if u, err := clusterUpdateCh1.Receive(ctx); err != nil || u != (clusterUpdateErr{wantUpdate1, nil}) {
-		t.Errorf("unexpected clusterUpdate: %v, error receiving from channel: %v", u, err)
+	if err := verifyClusterUpdate(clusterUpdateCh1, wantUpdate1); err != nil {
+		t.Fatal(err)
 	}
-
-	if u, err := clusterUpdateCh2.Receive(ctx); err != nil || u != (clusterUpdateErr{wantUpdate2, nil}) {
-		t.Errorf("unexpected clusterUpdate: %v, error receiving from channel: %v", u, err)
+	if err := verifyClusterUpdate(clusterUpdateCh2, wantUpdate2); err != nil {
+		t.Fatal(err)
 	}
 
 	// Send another update to remove resource 1.
-	v2Client.r.NewClusters(map[string]ClusterUpdate{
-		testCDSName + "2": wantUpdate2,
-	})
+	client.NewClusters(map[string]ClusterUpdate{testCDSName + "2": wantUpdate2})
 
-	// watcher 1 should get an error.
+	// Watcher 1 should get an error.
+	ctx, cancel = context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
 	if u, err := clusterUpdateCh1.Receive(ctx); err != nil || ErrType(u.(clusterUpdateErr).err) != ErrorTypeResourceNotFound {
 		t.Errorf("unexpected clusterUpdate: %v, error receiving from channel: %v, want update with error resource not found", u, err)
 	}
 
-	// watcher 2 should get the same update again.
-	if u, err := clusterUpdateCh2.Receive(ctx); err != nil || u != (clusterUpdateErr{wantUpdate2, nil}) {
-		t.Errorf("unexpected clusterUpdate: %v, error receiving from channel: %v", u, err)
+	// Watcher 2 should get the same update again.
+	if err := verifyClusterUpdate(clusterUpdateCh2, wantUpdate2); err != nil {
+		t.Fatal(err)
 	}
 
 	// Send one more update without resource 1.
-	v2Client.r.NewClusters(map[string]ClusterUpdate{
-		testCDSName + "2": wantUpdate2,
-	})
+	client.NewClusters(map[string]ClusterUpdate{testCDSName + "2": wantUpdate2})
 
-	// watcher 1 should get an error.
+	// Watcher 1 should not see an update.
+	ctx, cancel = context.WithTimeout(context.Background(), defaultTestShortTimeout)
+	defer cancel()
 	if u, err := clusterUpdateCh1.Receive(ctx); err != context.DeadlineExceeded {
-		t.Errorf("unexpected clusterUpdate: %v, want receiving from channel timeout", u)
+		t.Errorf("unexpected clusterUpdate: %v, %v, want channel recv timeout", u, err)
 	}
 
-	// watcher 2 should get the same update again.
-	ctx, cancel = context.WithTimeout(context.Background(), defaultTestTimeout)
-	defer cancel()
-	if u, err := clusterUpdateCh2.Receive(ctx); err != nil || u != (clusterUpdateErr{wantUpdate2, nil}) {
-		t.Errorf("unexpected clusterUpdate: %v, error receiving from channel: %v", u, err)
+	// Watcher 2 should get the same update again.
+	if err := verifyClusterUpdate(clusterUpdateCh2, wantUpdate2); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/xds/internal/client/client_watchers_cluster_test.go
+++ b/xds/internal/client/client_watchers_cluster_test.go
@@ -80,7 +80,7 @@ func (s) TestClusterWatch(t *testing.T) {
 	// Cancel watch, and send update again.
 	cancelWatch()
 	client.NewClusters(map[string]ClusterUpdate{testCDSName: wantUpdate})
-	sCtx, sCancel := context.WithTimeout(context.Background(), defaultTestShortTimeout)
+	sCtx, sCancel := context.WithTimeout(ctx, defaultTestShortTimeout)
 	defer sCancel()
 	if u, err := clusterUpdateCh.Receive(sCtx); err != context.DeadlineExceeded {
 		t.Errorf("unexpected clusterUpdate: %v, %v, want channel recv timeout", u, err)
@@ -143,7 +143,7 @@ func (s) TestClusterTwoWatchSameResourceName(t *testing.T) {
 		}
 	}
 
-	sCtx, sCancel := context.WithTimeout(context.Background(), defaultTestShortTimeout)
+	sCtx, sCancel := context.WithTimeout(ctx, defaultTestShortTimeout)
 	defer sCancel()
 	if u, err := clusterUpdateChs[count-1].Receive(sCtx); err != context.DeadlineExceeded {
 		t.Errorf("unexpected clusterUpdate: %v, %v, want channel recv timeout", u, err)
@@ -256,7 +256,7 @@ func (s) TestClusterWatchAfterCache(t *testing.T) {
 	client.WatchCluster(testCDSName, func(update ClusterUpdate, err error) {
 		clusterUpdateCh2.Send(clusterUpdateErr{u: update, err: err})
 	})
-	sCtx, sCancel := context.WithTimeout(context.Background(), defaultTestShortTimeout)
+	sCtx, sCancel := context.WithTimeout(ctx, defaultTestShortTimeout)
 	defer sCancel()
 	if n, err := apiClient.addWatches[ClusterResource].Receive(sCtx); err != context.DeadlineExceeded {
 		t.Fatalf("want no new watch to start (recv timeout), got resource name: %v error %v", n, err)
@@ -268,7 +268,7 @@ func (s) TestClusterWatchAfterCache(t *testing.T) {
 	}
 
 	// Old watch should see nothing.
-	sCtx, sCancel = context.WithTimeout(context.Background(), defaultTestShortTimeout)
+	sCtx, sCancel = context.WithTimeout(ctx, defaultTestShortTimeout)
 	defer sCancel()
 	if u, err := clusterUpdateCh.Receive(sCtx); err != context.DeadlineExceeded {
 		t.Errorf("unexpected clusterUpdate: %v, %v, want channel recv timeout", u, err)
@@ -352,7 +352,7 @@ func (s) TestClusterWatchExpiryTimerStop(t *testing.T) {
 	}
 
 	// Wait for an error, the error should never happen.
-	sCtx, sCancel := context.WithTimeout(context.Background(), defaultTestWatchExpiryTimeout)
+	sCtx, sCancel := context.WithTimeout(ctx, defaultTestWatchExpiryTimeout)
 	defer sCancel()
 	if u, err := clusterUpdateCh.Receive(sCtx); err != context.DeadlineExceeded {
 		t.Errorf("unexpected clusterUpdate: %v, %v, want channel recv timeout", u, err)
@@ -430,7 +430,7 @@ func (s) TestClusterResourceRemoved(t *testing.T) {
 	client.NewClusters(map[string]ClusterUpdate{testCDSName + "2": wantUpdate2})
 
 	// Watcher 1 should not see an update.
-	sCtx, sCancel := context.WithTimeout(context.Background(), defaultTestShortTimeout)
+	sCtx, sCancel := context.WithTimeout(ctx, defaultTestShortTimeout)
 	defer sCancel()
 	if u, err := clusterUpdateCh1.Receive(sCtx); err != context.DeadlineExceeded {
 		t.Errorf("unexpected clusterUpdate: %v, %v, want channel recv timeout", u, err)

--- a/xds/internal/client/client_watchers_endpoints_test.go
+++ b/xds/internal/client/client_watchers_endpoints_test.go
@@ -88,7 +88,7 @@ func (s) TestEndpointsWatch(t *testing.T) {
 
 	// Another update for a different resource name.
 	client.NewEndpoints(map[string]EndpointsUpdate{"randomName": {}})
-	sCtx, sCancel := context.WithTimeout(context.Background(), defaultTestShortTimeout)
+	sCtx, sCancel := context.WithTimeout(ctx, defaultTestShortTimeout)
 	defer sCancel()
 	if u, err := endpointsUpdateCh.Receive(sCtx); err != context.DeadlineExceeded {
 		t.Errorf("unexpected endpointsUpdate: %v, %v, want channel recv timeout", u, err)
@@ -97,7 +97,7 @@ func (s) TestEndpointsWatch(t *testing.T) {
 	// Cancel watch, and send update again.
 	cancelWatch()
 	client.NewEndpoints(map[string]EndpointsUpdate{testCDSName: wantUpdate})
-	sCtx, sCancel = context.WithTimeout(context.Background(), defaultTestShortTimeout)
+	sCtx, sCancel = context.WithTimeout(ctx, defaultTestShortTimeout)
 	defer sCancel()
 	if u, err := endpointsUpdateCh.Receive(sCtx); err != context.DeadlineExceeded {
 		t.Errorf("unexpected endpointsUpdate: %v, %v, want channel recv timeout", u, err)
@@ -162,7 +162,7 @@ func (s) TestEndpointsTwoWatchSameResourceName(t *testing.T) {
 		}
 	}
 
-	sCtx, sCancel := context.WithTimeout(context.Background(), defaultTestShortTimeout)
+	sCtx, sCancel := context.WithTimeout(ctx, defaultTestShortTimeout)
 	defer sCancel()
 	if u, err := endpointsUpdateChs[count-1].Receive(sCtx); err != context.DeadlineExceeded {
 		t.Errorf("unexpected endpointsUpdate: %v, %v, want channel recv timeout", u, err)
@@ -273,7 +273,7 @@ func (s) TestEndpointsWatchAfterCache(t *testing.T) {
 	client.WatchEndpoints(testCDSName, func(update EndpointsUpdate, err error) {
 		endpointsUpdateCh2.Send(endpointsUpdateErr{u: update, err: err})
 	})
-	sCtx, sCancel := context.WithTimeout(context.Background(), defaultTestShortTimeout)
+	sCtx, sCancel := context.WithTimeout(ctx, defaultTestShortTimeout)
 	defer sCancel()
 	if n, err := apiClient.addWatches[EndpointsResource].Receive(sCtx); err != context.DeadlineExceeded {
 		t.Fatalf("want no new watch to start (recv timeout), got resource name: %v error %v", n, err)
@@ -285,7 +285,7 @@ func (s) TestEndpointsWatchAfterCache(t *testing.T) {
 	}
 
 	// Old watch should see nothing.
-	sCtx, sCancel = context.WithTimeout(context.Background(), defaultTestShortTimeout)
+	sCtx, sCancel = context.WithTimeout(ctx, defaultTestShortTimeout)
 	defer sCancel()
 	if u, err := endpointsUpdateCh.Receive(sCtx); err != context.DeadlineExceeded {
 		t.Errorf("unexpected endpointsUpdate: %v, %v, want channel recv timeout", u, err)

--- a/xds/internal/client/client_watchers_lds_test.go
+++ b/xds/internal/client/client_watchers_lds_test.go
@@ -78,7 +78,7 @@ func (s) TestLDSWatch(t *testing.T) {
 	// Cancel watch, and send update again.
 	cancelWatch()
 	client.NewListeners(map[string]ListenerUpdate{testLDSName: wantUpdate})
-	sCtx, sCancel := context.WithTimeout(context.Background(), defaultTestShortTimeout)
+	sCtx, sCancel := context.WithTimeout(ctx, defaultTestShortTimeout)
 	defer sCancel()
 	if u, err := ldsUpdateCh.Receive(sCtx); err != context.DeadlineExceeded {
 		t.Errorf("unexpected ListenerUpdate: %v, %v, want channel recv timeout", u, err)
@@ -144,7 +144,7 @@ func (s) TestLDSTwoWatchSameResourceName(t *testing.T) {
 		}
 	}
 
-	sCtx, sCancel := context.WithTimeout(context.Background(), defaultTestShortTimeout)
+	sCtx, sCancel := context.WithTimeout(ctx, defaultTestShortTimeout)
 	defer sCancel()
 	if u, err := ldsUpdateChs[count-1].Receive(sCtx); err != context.DeadlineExceeded {
 		t.Errorf("unexpected ListenerUpdate: %v, %v, want channel recv timeout", u, err)
@@ -256,7 +256,7 @@ func (s) TestLDSWatchAfterCache(t *testing.T) {
 	client.watchLDS(testLDSName, func(update ListenerUpdate, err error) {
 		ldsUpdateCh2.Send(ldsUpdateErr{u: update, err: err})
 	})
-	sCtx, sCancel := context.WithTimeout(context.Background(), defaultTestShortTimeout)
+	sCtx, sCancel := context.WithTimeout(ctx, defaultTestShortTimeout)
 	defer sCancel()
 	if n, err := apiClient.addWatches[ListenerResource].Receive(sCtx); err != context.DeadlineExceeded {
 		t.Fatalf("want no new watch to start (recv timeout), got resource name: %v error %v", n, err)
@@ -268,7 +268,7 @@ func (s) TestLDSWatchAfterCache(t *testing.T) {
 	}
 
 	// Old watch should see nothing.
-	sCtx, sCancel = context.WithTimeout(context.Background(), defaultTestShortTimeout)
+	sCtx, sCancel = context.WithTimeout(ctx, defaultTestShortTimeout)
 	defer sCancel()
 	if u, err := ldsUpdateCh.Receive(sCtx); err != context.DeadlineExceeded {
 		t.Errorf("unexpected ListenerUpdate: %v, %v, want channel recv timeout", u, err)
@@ -345,7 +345,7 @@ func (s) TestLDSResourceRemoved(t *testing.T) {
 	client.NewListeners(map[string]ListenerUpdate{testLDSName + "2": wantUpdate2})
 
 	// Watcher 1 should not see an update.
-	sCtx, sCancel := context.WithTimeout(context.Background(), defaultTestShortTimeout)
+	sCtx, sCancel := context.WithTimeout(ctx, defaultTestShortTimeout)
 	defer sCancel()
 	if u, err := ldsUpdateCh1.Receive(sCtx); err != context.DeadlineExceeded {
 		t.Errorf("unexpected ListenerUpdate: %v, want receiving from channel timeout", u)

--- a/xds/internal/client/client_watchers_rds_test.go
+++ b/xds/internal/client/client_watchers_rds_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
 	"google.golang.org/grpc/internal/testutils"
 )
 
@@ -36,52 +37,51 @@ type rdsUpdateErr struct {
 // - an update for another resource name (which doesn't trigger callback)
 // - an update is received after cancel()
 func (s) TestRDSWatch(t *testing.T) {
-	v2ClientCh, cleanup := overrideNewAPIClient()
+	apiClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	c, err := New(clientOpts(testXDSServer, false))
+	client, err := New(clientOpts(testXDSServer, false))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
-	defer c.Close()
+	defer client.Close()
 
-	v2Client := <-v2ClientCh
-
-	rdsUpdateCh := testutils.NewChannel()
-	cancelWatch := c.watchRDS(testRDSName, func(update RouteConfigUpdate, err error) {
-		rdsUpdateCh.Send(rdsUpdateErr{u: update, err: err})
-	})
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
-	if _, err := v2Client.addWatches[RouteConfigResource].Receive(ctx); err != nil {
+	c, err := apiClientCh.Receive(ctx)
+	if err != nil {
+		t.Fatalf("timeout when waiting for API client to be created: %v", err)
+	}
+	apiClient := c.(*testAPIClient)
+
+	rdsUpdateCh := testutils.NewChannel()
+	cancelWatch := client.watchRDS(testRDSName, func(update RouteConfigUpdate, err error) {
+		rdsUpdateCh.Send(rdsUpdateErr{u: update, err: err})
+	})
+	ctx, cancel = context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	if _, err := apiClient.addWatches[RouteConfigResource].Receive(ctx); err != nil {
 		t.Fatalf("want new watch to start, got error %v", err)
 	}
 
 	wantUpdate := RouteConfigUpdate{Routes: []*Route{{Prefix: newStringP(""), Action: map[string]uint32{testCDSName: 1}}}}
-	v2Client.r.NewRouteConfigs(map[string]RouteConfigUpdate{
-		testRDSName: wantUpdate,
-	})
-
-	if u, err := rdsUpdateCh.Receive(ctx); err != nil || !cmp.Equal(u, rdsUpdateErr{wantUpdate, nil}, cmp.AllowUnexported(rdsUpdateErr{})) {
-		t.Errorf("unexpected RouteConfigUpdate: %v, error receiving from channel: %v", u, err)
+	client.NewRouteConfigs(map[string]RouteConfigUpdate{testRDSName: wantUpdate})
+	if err := verifyRouteConfigUpdate(rdsUpdateCh, wantUpdate); err != nil {
+		t.Fatal(err)
 	}
 
 	// Another update for a different resource name.
-	v2Client.r.NewRouteConfigs(map[string]RouteConfigUpdate{
-		"randomName": {},
-	})
-
+	client.NewRouteConfigs(map[string]RouteConfigUpdate{"randomName": {}})
+	ctx, cancel = context.WithTimeout(context.Background(), defaultTestShortTimeout)
+	defer cancel()
 	if u, err := rdsUpdateCh.Receive(ctx); err != context.DeadlineExceeded {
 		t.Errorf("unexpected RouteConfigUpdate: %v, %v, want channel recv timeout", u, err)
 	}
 
 	// Cancel watch, and send update again.
 	cancelWatch()
-	v2Client.r.NewRouteConfigs(map[string]RouteConfigUpdate{
-		testRDSName: wantUpdate,
-	})
-
-	ctx, cancel = context.WithTimeout(context.Background(), defaultTestTimeout)
+	client.NewRouteConfigs(map[string]RouteConfigUpdate{testRDSName: wantUpdate})
+	ctx, cancel = context.WithTimeout(context.Background(), defaultTestShortTimeout)
 	defer cancel()
 	if u, err := rdsUpdateCh.Receive(ctx); err != context.DeadlineExceeded {
 		t.Errorf("unexpected RouteConfigUpdate: %v, %v, want channel recv timeout", u, err)
@@ -91,63 +91,66 @@ func (s) TestRDSWatch(t *testing.T) {
 // TestRDSTwoWatchSameResourceName covers the case where an update is received
 // after two watch() for the same resource name.
 func (s) TestRDSTwoWatchSameResourceName(t *testing.T) {
-	v2ClientCh, cleanup := overrideNewAPIClient()
+	apiClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	c, err := New(clientOpts(testXDSServer, false))
+	client, err := New(clientOpts(testXDSServer, false))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
-	defer c.Close()
-
-	v2Client := <-v2ClientCh
-
-	var rdsUpdateChs []*testutils.Channel
-	const count = 2
-
-	var cancelLastWatch func()
+	defer client.Close()
 
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	c, err := apiClientCh.Receive(ctx)
+	if err != nil {
+		t.Fatalf("timeout when waiting for API client to be created: %v", err)
+	}
+	apiClient := c.(*testAPIClient)
+
+	const count = 2
+	var (
+		rdsUpdateChs    []*testutils.Channel
+		cancelLastWatch func()
+	)
+
+	ctx, cancel = context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
 	for i := 0; i < count; i++ {
 		rdsUpdateCh := testutils.NewChannel()
 		rdsUpdateChs = append(rdsUpdateChs, rdsUpdateCh)
-		cancelLastWatch = c.watchRDS(testRDSName, func(update RouteConfigUpdate, err error) {
+		cancelLastWatch = client.watchRDS(testRDSName, func(update RouteConfigUpdate, err error) {
 			rdsUpdateCh.Send(rdsUpdateErr{u: update, err: err})
 		})
 
 		if i == 0 {
 			// A new watch is registered on the underlying API client only for
 			// the first iteration because we are using the same resource name.
-			if _, err := v2Client.addWatches[RouteConfigResource].Receive(ctx); err != nil {
+			if _, err := apiClient.addWatches[RouteConfigResource].Receive(ctx); err != nil {
 				t.Fatalf("want new watch to start, got error %v", err)
 			}
 		}
 	}
 
 	wantUpdate := RouteConfigUpdate{Routes: []*Route{{Prefix: newStringP(""), Action: map[string]uint32{testCDSName: 1}}}}
-	v2Client.r.NewRouteConfigs(map[string]RouteConfigUpdate{
-		testRDSName: wantUpdate,
-	})
-
+	client.NewRouteConfigs(map[string]RouteConfigUpdate{testRDSName: wantUpdate})
 	for i := 0; i < count; i++ {
-		if u, err := rdsUpdateChs[i].Receive(ctx); err != nil || !cmp.Equal(u, rdsUpdateErr{wantUpdate, nil}, cmp.AllowUnexported(rdsUpdateErr{})) {
-			t.Errorf("i=%v, unexpected RouteConfigUpdate: %v, error receiving from channel: %v", i, u, err)
+		if err := verifyRouteConfigUpdate(rdsUpdateChs[i], wantUpdate); err != nil {
+			t.Fatal(err)
 		}
 	}
 
 	// Cancel the last watch, and send update again.
 	cancelLastWatch()
-	v2Client.r.NewRouteConfigs(map[string]RouteConfigUpdate{
-		testRDSName: wantUpdate,
-	})
-
+	client.NewRouteConfigs(map[string]RouteConfigUpdate{testRDSName: wantUpdate})
 	for i := 0; i < count-1; i++ {
-		if u, err := rdsUpdateChs[i].Receive(ctx); err != nil || !cmp.Equal(u, rdsUpdateErr{wantUpdate, nil}, cmp.AllowUnexported(rdsUpdateErr{})) {
-			t.Errorf("i=%v, unexpected RouteConfigUpdate: %v, error receiving from channel: %v", i, u, err)
+		if err := verifyRouteConfigUpdate(rdsUpdateChs[i], wantUpdate); err != nil {
+			t.Fatal(err)
 		}
 	}
 
+	ctx, cancel = context.WithTimeout(context.Background(), defaultTestShortTimeout)
+	defer cancel()
 	if u, err := rdsUpdateChs[count-1].Receive(ctx); err != context.DeadlineExceeded {
 		t.Errorf("unexpected RouteConfigUpdate: %v, %v, want channel recv timeout", u, err)
 	}
@@ -156,34 +159,40 @@ func (s) TestRDSTwoWatchSameResourceName(t *testing.T) {
 // TestRDSThreeWatchDifferentResourceName covers the case where an update is
 // received after three watch() for different resource names.
 func (s) TestRDSThreeWatchDifferentResourceName(t *testing.T) {
-	v2ClientCh, cleanup := overrideNewAPIClient()
+	apiClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	c, err := New(clientOpts(testXDSServer, false))
+	client, err := New(clientOpts(testXDSServer, false))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
-	defer c.Close()
+	defer client.Close()
 
-	v2Client := <-v2ClientCh
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	c, err := apiClientCh.Receive(ctx)
+	if err != nil {
+		t.Fatalf("timeout when waiting for API client to be created: %v", err)
+	}
+	apiClient := c.(*testAPIClient)
 
 	var rdsUpdateChs []*testutils.Channel
 	const count = 2
 
 	// Two watches for the same name.
-	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	ctx, cancel = context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
 	for i := 0; i < count; i++ {
 		rdsUpdateCh := testutils.NewChannel()
 		rdsUpdateChs = append(rdsUpdateChs, rdsUpdateCh)
-		c.watchRDS(testRDSName+"1", func(update RouteConfigUpdate, err error) {
+		client.watchRDS(testRDSName+"1", func(update RouteConfigUpdate, err error) {
 			rdsUpdateCh.Send(rdsUpdateErr{u: update, err: err})
 		})
 
 		if i == 0 {
 			// A new watch is registered on the underlying API client only for
 			// the first iteration because we are using the same resource name.
-			if _, err := v2Client.addWatches[RouteConfigResource].Receive(ctx); err != nil {
+			if _, err := apiClient.addWatches[RouteConfigResource].Receive(ctx); err != nil {
 				t.Fatalf("want new watch to start, got error %v", err)
 			}
 		}
@@ -191,70 +200,74 @@ func (s) TestRDSThreeWatchDifferentResourceName(t *testing.T) {
 
 	// Third watch for a different name.
 	rdsUpdateCh2 := testutils.NewChannel()
-	c.watchRDS(testRDSName+"2", func(update RouteConfigUpdate, err error) {
+	client.watchRDS(testRDSName+"2", func(update RouteConfigUpdate, err error) {
 		rdsUpdateCh2.Send(rdsUpdateErr{u: update, err: err})
 	})
-	if _, err := v2Client.addWatches[RouteConfigResource].Receive(ctx); err != nil {
+	if _, err := apiClient.addWatches[RouteConfigResource].Receive(ctx); err != nil {
 		t.Fatalf("want new watch to start, got error %v", err)
 	}
 
 	wantUpdate1 := RouteConfigUpdate{Routes: []*Route{{Prefix: newStringP(""), Action: map[string]uint32{testCDSName + "1": 1}}}}
 	wantUpdate2 := RouteConfigUpdate{Routes: []*Route{{Prefix: newStringP(""), Action: map[string]uint32{testCDSName + "2": 1}}}}
-	v2Client.r.NewRouteConfigs(map[string]RouteConfigUpdate{
+	client.NewRouteConfigs(map[string]RouteConfigUpdate{
 		testRDSName + "1": wantUpdate1,
 		testRDSName + "2": wantUpdate2,
 	})
 
 	for i := 0; i < count; i++ {
-		if u, err := rdsUpdateChs[i].Receive(ctx); err != nil || !cmp.Equal(u, rdsUpdateErr{wantUpdate1, nil}, cmp.AllowUnexported(rdsUpdateErr{})) {
-			t.Errorf("i=%v, unexpected RouteConfigUpdate: %v, error receiving from channel: %v", i, u, err)
+		if err := verifyRouteConfigUpdate(rdsUpdateChs[i], wantUpdate1); err != nil {
+			t.Fatal(err)
 		}
 	}
-
-	if u, err := rdsUpdateCh2.Receive(ctx); err != nil || !cmp.Equal(u, rdsUpdateErr{wantUpdate2, nil}, cmp.AllowUnexported(rdsUpdateErr{})) {
-		t.Errorf("unexpected RouteConfigUpdate: %v, error receiving from channel: %v", u, err)
+	if err := verifyRouteConfigUpdate(rdsUpdateCh2, wantUpdate2); err != nil {
+		t.Fatal(err)
 	}
 }
 
 // TestRDSWatchAfterCache covers the case where watch is called after the update
 // is in cache.
 func (s) TestRDSWatchAfterCache(t *testing.T) {
-	v2ClientCh, cleanup := overrideNewAPIClient()
+	apiClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	c, err := New(clientOpts(testXDSServer, false))
+	client, err := New(clientOpts(testXDSServer, false))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
-	defer c.Close()
+	defer client.Close()
 
-	v2Client := <-v2ClientCh
-
-	rdsUpdateCh := testutils.NewChannel()
-	c.watchRDS(testRDSName, func(update RouteConfigUpdate, err error) {
-		rdsUpdateCh.Send(rdsUpdateErr{u: update, err: err})
-	})
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
-	if _, err := v2Client.addWatches[RouteConfigResource].Receive(ctx); err != nil {
+	c, err := apiClientCh.Receive(ctx)
+	if err != nil {
+		t.Fatalf("timeout when waiting for API client to be created: %v", err)
+	}
+	apiClient := c.(*testAPIClient)
+
+	rdsUpdateCh := testutils.NewChannel()
+	client.watchRDS(testRDSName, func(update RouteConfigUpdate, err error) {
+		rdsUpdateCh.Send(rdsUpdateErr{u: update, err: err})
+	})
+	ctx, cancel = context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	if _, err := apiClient.addWatches[RouteConfigResource].Receive(ctx); err != nil {
 		t.Fatalf("want new watch to start, got error %v", err)
 	}
 
 	wantUpdate := RouteConfigUpdate{Routes: []*Route{{Prefix: newStringP(""), Action: map[string]uint32{testCDSName: 1}}}}
-	v2Client.r.NewRouteConfigs(map[string]RouteConfigUpdate{
-		testRDSName: wantUpdate,
-	})
-
-	if u, err := rdsUpdateCh.Receive(ctx); err != nil || !cmp.Equal(u, rdsUpdateErr{wantUpdate, nil}, cmp.AllowUnexported(rdsUpdateErr{})) {
-		t.Errorf("unexpected RouteConfigUpdate: %v, error receiving from channel: %v", u, err)
+	client.NewRouteConfigs(map[string]RouteConfigUpdate{testRDSName: wantUpdate})
+	if err := verifyRouteConfigUpdate(rdsUpdateCh, wantUpdate); err != nil {
+		t.Fatal(err)
 	}
 
 	// Another watch for the resource in cache.
 	rdsUpdateCh2 := testutils.NewChannel()
-	c.watchRDS(testRDSName, func(update RouteConfigUpdate, err error) {
+	client.watchRDS(testRDSName, func(update RouteConfigUpdate, err error) {
 		rdsUpdateCh2.Send(rdsUpdateErr{u: update, err: err})
 	})
-	if n, err := v2Client.addWatches[RouteConfigResource].Receive(ctx); err != context.DeadlineExceeded {
+	ctx, cancel = context.WithTimeout(context.Background(), defaultTestShortTimeout)
+	defer cancel()
+	if n, err := apiClient.addWatches[RouteConfigResource].Receive(ctx); err != context.DeadlineExceeded {
 		t.Fatalf("want no new watch to start (recv timeout), got resource name: %v error %v", n, err)
 	}
 
@@ -266,6 +279,8 @@ func (s) TestRDSWatchAfterCache(t *testing.T) {
 	}
 
 	// Old watch should see nothing.
+	ctx, cancel = context.WithTimeout(context.Background(), defaultTestShortTimeout)
+	defer cancel()
 	if u, err := rdsUpdateCh.Receive(ctx); err != context.DeadlineExceeded {
 		t.Errorf("unexpected RouteConfigUpdate: %v, %v, want channel recv timeout", u, err)
 	}

--- a/xds/internal/client/client_watchers_rds_test.go
+++ b/xds/internal/client/client_watchers_rds_test.go
@@ -70,7 +70,7 @@ func (s) TestRDSWatch(t *testing.T) {
 
 	// Another update for a different resource name.
 	client.NewRouteConfigs(map[string]RouteConfigUpdate{"randomName": {}})
-	sCtx, sCancel := context.WithTimeout(context.Background(), defaultTestShortTimeout)
+	sCtx, sCancel := context.WithTimeout(ctx, defaultTestShortTimeout)
 	defer sCancel()
 	if u, err := rdsUpdateCh.Receive(sCtx); err != context.DeadlineExceeded {
 		t.Errorf("unexpected RouteConfigUpdate: %v, %v, want channel recv timeout", u, err)
@@ -79,7 +79,7 @@ func (s) TestRDSWatch(t *testing.T) {
 	// Cancel watch, and send update again.
 	cancelWatch()
 	client.NewRouteConfigs(map[string]RouteConfigUpdate{testRDSName: wantUpdate})
-	sCtx, sCancel = context.WithTimeout(context.Background(), defaultTestShortTimeout)
+	sCtx, sCancel = context.WithTimeout(ctx, defaultTestShortTimeout)
 	defer sCancel()
 	if u, err := rdsUpdateCh.Receive(sCtx); err != context.DeadlineExceeded {
 		t.Errorf("unexpected RouteConfigUpdate: %v, %v, want channel recv timeout", u, err)
@@ -144,7 +144,7 @@ func (s) TestRDSTwoWatchSameResourceName(t *testing.T) {
 		}
 	}
 
-	sCtx, sCancel := context.WithTimeout(context.Background(), defaultTestShortTimeout)
+	sCtx, sCancel := context.WithTimeout(ctx, defaultTestShortTimeout)
 	defer sCancel()
 	if u, err := rdsUpdateChs[count-1].Receive(sCtx); err != context.DeadlineExceeded {
 		t.Errorf("unexpected RouteConfigUpdate: %v, %v, want channel recv timeout", u, err)
@@ -255,7 +255,7 @@ func (s) TestRDSWatchAfterCache(t *testing.T) {
 	client.watchRDS(testRDSName, func(update RouteConfigUpdate, err error) {
 		rdsUpdateCh2.Send(rdsUpdateErr{u: update, err: err})
 	})
-	sCtx, sCancel := context.WithTimeout(context.Background(), defaultTestShortTimeout)
+	sCtx, sCancel := context.WithTimeout(ctx, defaultTestShortTimeout)
 	defer sCancel()
 	if n, err := apiClient.addWatches[RouteConfigResource].Receive(sCtx); err != context.DeadlineExceeded {
 		t.Fatalf("want no new watch to start (recv timeout), got resource name: %v error %v", n, err)
@@ -267,7 +267,7 @@ func (s) TestRDSWatchAfterCache(t *testing.T) {
 	}
 
 	// Old watch should see nothing.
-	sCtx, sCancel = context.WithTimeout(context.Background(), defaultTestShortTimeout)
+	sCtx, sCancel = context.WithTimeout(ctx, defaultTestShortTimeout)
 	defer sCancel()
 	if u, err := rdsUpdateCh.Receive(sCtx); err != context.DeadlineExceeded {
 		t.Errorf("unexpected RouteConfigUpdate: %v, %v, want channel recv timeout", u, err)

--- a/xds/internal/client/client_watchers_service_test.go
+++ b/xds/internal/client/client_watchers_service_test.go
@@ -143,7 +143,7 @@ func (s) TestServiceWatchLDSUpdate(t *testing.T) {
 	client.NewRouteConfigs(map[string]RouteConfigUpdate{
 		testRDSName: {Routes: []*Route{{Prefix: newStringP(""), Action: map[string]uint32{testCDSName: 1}}}},
 	})
-	sCtx, sCancel := context.WithTimeout(context.Background(), defaultTestShortTimeout)
+	sCtx, sCancel := context.WithTimeout(ctx, defaultTestShortTimeout)
 	defer sCancel()
 	if u, err := serviceUpdateCh.Receive(sCtx); err != context.DeadlineExceeded {
 		t.Errorf("unexpected serviceUpdate: %v, %v, want channel recv timeout", u, err)
@@ -227,7 +227,7 @@ func (s) TestServiceWatchSecond(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sCtx, sCancel := context.WithTimeout(context.Background(), defaultTestShortTimeout)
+	sCtx, sCancel := context.WithTimeout(ctx, defaultTestShortTimeout)
 	defer sCancel()
 	if u, err := serviceUpdateCh2.Receive(sCtx); err != context.DeadlineExceeded {
 		t.Errorf("unexpected serviceUpdate: %v, %v, want channel recv timeout", u, err)
@@ -356,7 +356,7 @@ func (s) TestServiceWatchWithClientClose(t *testing.T) {
 
 	// Client is closed before it receives the RDS response.
 	client.Close()
-	sCtx, sCancel := context.WithTimeout(context.Background(), defaultTestShortTimeout)
+	sCtx, sCancel := context.WithTimeout(ctx, defaultTestShortTimeout)
 	defer sCancel()
 	if u, err := serviceUpdateCh.Receive(sCtx); err != context.DeadlineExceeded {
 		t.Errorf("unexpected serviceUpdate: %v, %v, want channel recv timeout", u, err)
@@ -406,7 +406,7 @@ func (s) TestServiceNotCancelRDSOnSameLDSUpdate(t *testing.T) {
 
 	// Another LDS update with a the same RDS_name.
 	client.NewListeners(map[string]ListenerUpdate{testLDSName: {RouteConfigName: testRDSName}})
-	sCtx, sCancel := context.WithTimeout(context.Background(), defaultTestShortTimeout)
+	sCtx, sCancel := context.WithTimeout(ctx, defaultTestShortTimeout)
 	defer sCancel()
 	if _, err := apiClient.removeWatches[RouteConfigResource].Receive(sCtx); err != context.DeadlineExceeded {
 		t.Fatalf("unexpected rds watch cancel")
@@ -471,7 +471,7 @@ func (s) TestServiceResourceRemoved(t *testing.T) {
 	client.NewRouteConfigs(map[string]RouteConfigUpdate{
 		testRDSName: {Routes: []*Route{{Prefix: newStringP(""), Action: map[string]uint32{testCDSName + "new": 1}}}},
 	})
-	sCtx, sCancel := context.WithTimeout(context.Background(), defaultTestShortTimeout)
+	sCtx, sCancel := context.WithTimeout(ctx, defaultTestShortTimeout)
 	defer sCancel()
 	if u, err := serviceUpdateCh.Receive(sCtx); err != context.DeadlineExceeded {
 		t.Errorf("unexpected serviceUpdate: %v, want receiving from channel timeout", u)
@@ -484,7 +484,7 @@ func (s) TestServiceResourceRemoved(t *testing.T) {
 	if _, err := apiClient.addWatches[RouteConfigResource].Receive(ctx); err != nil {
 		t.Fatalf("want new watch to start, got error %v", err)
 	}
-	sCtx, sCancel = context.WithTimeout(context.Background(), defaultTestShortTimeout)
+	sCtx, sCancel = context.WithTimeout(ctx, defaultTestShortTimeout)
 	defer sCancel()
 	if u, err := serviceUpdateCh.Receive(sCtx); err != context.DeadlineExceeded {
 		t.Errorf("unexpected serviceUpdate: %v, want receiving from channel timeout", u)

--- a/xds/internal/client/client_watchers_service_test.go
+++ b/xds/internal/client/client_watchers_service_test.go
@@ -23,7 +23,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 
 	"google.golang.org/grpc/internal/testutils"
 )
@@ -33,47 +32,49 @@ type serviceUpdateErr struct {
 	err error
 }
 
-var serviceCmpOpts = []cmp.Option{cmp.AllowUnexported(serviceUpdateErr{}), cmpopts.EquateEmpty()}
-
 // TestServiceWatch covers the cases:
 // - an update is received after a watch()
 // - an update with routes received
 func (s) TestServiceWatch(t *testing.T) {
-	v2ClientCh, cleanup := overrideNewAPIClient()
+	apiClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	c, err := New(clientOpts(testXDSServer, false))
+	client, err := New(clientOpts(testXDSServer, false))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
-	defer c.Close()
-
-	v2Client := <-v2ClientCh
-
-	serviceUpdateCh := testutils.NewChannel()
-	c.WatchService(testLDSName, func(update ServiceUpdate, err error) {
-		serviceUpdateCh.Send(serviceUpdateErr{u: update, err: err})
-	})
-
-	wantUpdate := ServiceUpdate{Routes: []*Route{{Prefix: newStringP(""), Action: map[string]uint32{testCDSName: 1}}}}
+	defer client.Close()
 
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
-	if _, err := v2Client.addWatches[ListenerResource].Receive(ctx); err != nil {
-		t.Fatalf("want new watch to start, got error %v", err)
+	c, err := apiClientCh.Receive(ctx)
+	if err != nil {
+		t.Fatalf("timeout when waiting for API client to be created: %v", err)
 	}
-	v2Client.r.NewListeners(map[string]ListenerUpdate{
-		testLDSName: {RouteConfigName: testRDSName},
+	apiClient := c.(*testAPIClient)
+
+	serviceUpdateCh := testutils.NewChannel()
+	client.WatchService(testLDSName, func(update ServiceUpdate, err error) {
+		serviceUpdateCh.Send(serviceUpdateErr{u: update, err: err})
 	})
-	if _, err := v2Client.addWatches[RouteConfigResource].Receive(ctx); err != nil {
+	ctx, cancel = context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	if _, err := apiClient.addWatches[ListenerResource].Receive(ctx); err != nil {
 		t.Fatalf("want new watch to start, got error %v", err)
 	}
-	v2Client.r.NewRouteConfigs(map[string]RouteConfigUpdate{
+
+	wantUpdate := ServiceUpdate{Routes: []*Route{{Prefix: newStringP(""), Action: map[string]uint32{testCDSName: 1}}}}
+	client.NewListeners(map[string]ListenerUpdate{testLDSName: {RouteConfigName: testRDSName}})
+	ctx, cancel = context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	if _, err := apiClient.addWatches[RouteConfigResource].Receive(ctx); err != nil {
+		t.Fatalf("want new watch to start, got error %v", err)
+	}
+	client.NewRouteConfigs(map[string]RouteConfigUpdate{
 		testRDSName: {Routes: []*Route{{Prefix: newStringP(""), Action: map[string]uint32{testCDSName: 1}}}},
 	})
-
-	if u, err := serviceUpdateCh.Receive(ctx); err != nil || !cmp.Equal(u, serviceUpdateErr{wantUpdate, nil}, serviceCmpOpts...) {
-		t.Errorf("unexpected serviceUpdate: %v, error receiving from channel: %v", u, err)
+	if err := verifyServiceUpdate(serviceUpdateCh, wantUpdate); err != nil {
+		t.Fatal(err)
 	}
 
 	wantUpdate2 := ServiceUpdate{
@@ -82,7 +83,7 @@ func (s) TestServiceWatch(t *testing.T) {
 			Action: map[string]uint32{testCDSName: 1},
 		}},
 	}
-	v2Client.r.NewRouteConfigs(map[string]RouteConfigUpdate{
+	client.NewRouteConfigs(map[string]RouteConfigUpdate{
 		testRDSName: {
 			Routes: []*Route{{
 				Prefix: newStringP(""),
@@ -90,8 +91,8 @@ func (s) TestServiceWatch(t *testing.T) {
 			}},
 		},
 	})
-	if u, err := serviceUpdateCh.Receive(ctx); err != nil || !cmp.Equal(u, serviceUpdateErr{wantUpdate2, nil}, serviceCmpOpts...) {
-		t.Errorf("unexpected serviceUpdate: %v, error receiving from channel: %v", u, err)
+	if err := verifyServiceUpdate(serviceUpdateCh, wantUpdate2); err != nil {
+		t.Fatal(err)
 	}
 }
 
@@ -99,70 +100,72 @@ func (s) TestServiceWatch(t *testing.T) {
 // response, the second LDS response trigger an new RDS watch, and an update of
 // the old RDS watch doesn't trigger update to service callback.
 func (s) TestServiceWatchLDSUpdate(t *testing.T) {
-	v2ClientCh, cleanup := overrideNewAPIClient()
+	apiClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	c, err := New(clientOpts(testXDSServer, false))
+	client, err := New(clientOpts(testXDSServer, false))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
-	defer c.Close()
-
-	v2Client := <-v2ClientCh
-
-	serviceUpdateCh := testutils.NewChannel()
-	c.WatchService(testLDSName, func(update ServiceUpdate, err error) {
-		serviceUpdateCh.Send(serviceUpdateErr{u: update, err: err})
-	})
-
-	wantUpdate := ServiceUpdate{Routes: []*Route{{Prefix: newStringP(""), Action: map[string]uint32{testCDSName: 1}}}}
+	defer client.Close()
 
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
-	if _, err := v2Client.addWatches[ListenerResource].Receive(ctx); err != nil {
-		t.Fatalf("want new watch to start, got error %v", err)
+	c, err := apiClientCh.Receive(ctx)
+	if err != nil {
+		t.Fatalf("timeout when waiting for API client to be created: %v", err)
 	}
-	v2Client.r.NewListeners(map[string]ListenerUpdate{
-		testLDSName: {RouteConfigName: testRDSName},
+	apiClient := c.(*testAPIClient)
+
+	serviceUpdateCh := testutils.NewChannel()
+	client.WatchService(testLDSName, func(update ServiceUpdate, err error) {
+		serviceUpdateCh.Send(serviceUpdateErr{u: update, err: err})
 	})
-	if _, err := v2Client.addWatches[RouteConfigResource].Receive(ctx); err != nil {
+	ctx, cancel = context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	if _, err := apiClient.addWatches[ListenerResource].Receive(ctx); err != nil {
 		t.Fatalf("want new watch to start, got error %v", err)
 	}
-	v2Client.r.NewRouteConfigs(map[string]RouteConfigUpdate{
+
+	wantUpdate := ServiceUpdate{Routes: []*Route{{Prefix: newStringP(""), Action: map[string]uint32{testCDSName: 1}}}}
+	client.NewListeners(map[string]ListenerUpdate{testLDSName: {RouteConfigName: testRDSName}})
+	ctx, cancel = context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	if _, err := apiClient.addWatches[RouteConfigResource].Receive(ctx); err != nil {
+		t.Fatalf("want new watch to start, got error %v", err)
+	}
+	client.NewRouteConfigs(map[string]RouteConfigUpdate{
 		testRDSName: {Routes: []*Route{{Prefix: newStringP(""), Action: map[string]uint32{testCDSName: 1}}}},
 	})
-
-	if u, err := serviceUpdateCh.Receive(ctx); err != nil || !cmp.Equal(u, serviceUpdateErr{wantUpdate, nil}, serviceCmpOpts...) {
-		t.Errorf("unexpected serviceUpdate: %v, error receiving from channel: %v", u, err)
+	if err := verifyServiceUpdate(serviceUpdateCh, wantUpdate); err != nil {
+		t.Fatal(err)
 	}
 
 	// Another LDS update with a different RDS_name.
-	v2Client.r.NewListeners(map[string]ListenerUpdate{
-		testLDSName: {RouteConfigName: testRDSName + "2"},
-	})
-	if _, err := v2Client.addWatches[RouteConfigResource].Receive(ctx); err != nil {
+	client.NewListeners(map[string]ListenerUpdate{testLDSName: {RouteConfigName: testRDSName + "2"}})
+	ctx, cancel = context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	if _, err := apiClient.addWatches[RouteConfigResource].Receive(ctx); err != nil {
 		t.Fatalf("want new watch to start, got error %v", err)
 	}
 
 	// Another update for the old name.
-	v2Client.r.NewRouteConfigs(map[string]RouteConfigUpdate{
+	client.NewRouteConfigs(map[string]RouteConfigUpdate{
 		testRDSName: {Routes: []*Route{{Prefix: newStringP(""), Action: map[string]uint32{testCDSName: 1}}}},
 	})
-
+	ctx, cancel = context.WithTimeout(context.Background(), defaultTestShortTimeout)
+	defer cancel()
 	if u, err := serviceUpdateCh.Receive(ctx); err != context.DeadlineExceeded {
 		t.Errorf("unexpected serviceUpdate: %v, %v, want channel recv timeout", u, err)
 	}
 
-	wantUpdate2 := ServiceUpdate{Routes: []*Route{{Prefix: newStringP(""), Action: map[string]uint32{testCDSName + "2": 1}}}}
 	// RDS update for the new name.
-	v2Client.r.NewRouteConfigs(map[string]RouteConfigUpdate{
+	wantUpdate2 := ServiceUpdate{Routes: []*Route{{Prefix: newStringP(""), Action: map[string]uint32{testCDSName + "2": 1}}}}
+	client.NewRouteConfigs(map[string]RouteConfigUpdate{
 		testRDSName + "2": {Routes: []*Route{{Prefix: newStringP(""), Action: map[string]uint32{testCDSName + "2": 1}}}},
 	})
-
-	ctx, cancel = context.WithTimeout(context.Background(), defaultTestTimeout)
-	defer cancel()
-	if u, err := serviceUpdateCh.Receive(ctx); err != nil || !cmp.Equal(u, serviceUpdateErr{wantUpdate2, nil}, serviceCmpOpts...) {
-		t.Errorf("unexpected serviceUpdate: %v, error receiving from channel: %v", u, err)
+	if err := verifyServiceUpdate(serviceUpdateCh, wantUpdate2); err != nil {
+		t.Fatal(err)
 	}
 }
 
@@ -170,49 +173,54 @@ func (s) TestServiceWatchLDSUpdate(t *testing.T) {
 // error (because only one is allowed). But the first watch still receives
 // updates.
 func (s) TestServiceWatchSecond(t *testing.T) {
-	v2ClientCh, cleanup := overrideNewAPIClient()
+	apiClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	c, err := New(clientOpts(testXDSServer, false))
+	client, err := New(clientOpts(testXDSServer, false))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
-	defer c.Close()
-
-	v2Client := <-v2ClientCh
-
-	serviceUpdateCh := testutils.NewChannel()
-	c.WatchService(testLDSName, func(update ServiceUpdate, err error) {
-		serviceUpdateCh.Send(serviceUpdateErr{u: update, err: err})
-	})
-
-	wantUpdate := ServiceUpdate{Routes: []*Route{{Prefix: newStringP(""), Action: map[string]uint32{testCDSName: 1}}}}
+	defer client.Close()
 
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
-	if _, err := v2Client.addWatches[ListenerResource].Receive(ctx); err != nil {
-		t.Fatalf("want new watch to start, got error %v", err)
+	c, err := apiClientCh.Receive(ctx)
+	if err != nil {
+		t.Fatalf("timeout when waiting for API client to be created: %v", err)
 	}
-	v2Client.r.NewListeners(map[string]ListenerUpdate{
-		testLDSName: {RouteConfigName: testRDSName},
+	apiClient := c.(*testAPIClient)
+
+	serviceUpdateCh := testutils.NewChannel()
+	client.WatchService(testLDSName, func(update ServiceUpdate, err error) {
+		serviceUpdateCh.Send(serviceUpdateErr{u: update, err: err})
 	})
-	if _, err := v2Client.addWatches[RouteConfigResource].Receive(ctx); err != nil {
+	ctx, cancel = context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	if _, err := apiClient.addWatches[ListenerResource].Receive(ctx); err != nil {
 		t.Fatalf("want new watch to start, got error %v", err)
 	}
-	v2Client.r.NewRouteConfigs(map[string]RouteConfigUpdate{
+
+	wantUpdate := ServiceUpdate{Routes: []*Route{{Prefix: newStringP(""), Action: map[string]uint32{testCDSName: 1}}}}
+	client.NewListeners(map[string]ListenerUpdate{testLDSName: {RouteConfigName: testRDSName}})
+	ctx, cancel = context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	if _, err := apiClient.addWatches[RouteConfigResource].Receive(ctx); err != nil {
+		t.Fatalf("want new watch to start, got error %v", err)
+	}
+	client.NewRouteConfigs(map[string]RouteConfigUpdate{
 		testRDSName: {Routes: []*Route{{Prefix: newStringP(""), Action: map[string]uint32{testCDSName: 1}}}},
 	})
-
-	if u, err := serviceUpdateCh.Receive(ctx); err != nil || !cmp.Equal(u, serviceUpdateErr{wantUpdate, nil}, serviceCmpOpts...) {
-		t.Errorf("unexpected serviceUpdate: %v, error receiving from channel: %v", u, err)
+	if err := verifyServiceUpdate(serviceUpdateCh, wantUpdate); err != nil {
+		t.Fatal(err)
 	}
 
-	serviceUpdateCh2 := testutils.NewChannel()
 	// Call WatchService() again, with the same or different name.
-	c.WatchService(testLDSName, func(update ServiceUpdate, err error) {
+	serviceUpdateCh2 := testutils.NewChannel()
+	client.WatchService(testLDSName, func(update ServiceUpdate, err error) {
 		serviceUpdateCh2.Send(serviceUpdateErr{u: update, err: err})
 	})
-
+	ctx, cancel = context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
 	u, err := serviceUpdateCh2.Receive(ctx)
 	if err != nil {
 		t.Fatalf("failed to get serviceUpdate: %v", err)
@@ -227,17 +235,15 @@ func (s) TestServiceWatchSecond(t *testing.T) {
 
 	// Send update again, first callback should be called, second should
 	// timeout.
-	v2Client.r.NewListeners(map[string]ListenerUpdate{
-		testLDSName: {RouteConfigName: testRDSName},
-	})
-	v2Client.r.NewRouteConfigs(map[string]RouteConfigUpdate{
+	client.NewListeners(map[string]ListenerUpdate{testLDSName: {RouteConfigName: testRDSName}})
+	client.NewRouteConfigs(map[string]RouteConfigUpdate{
 		testRDSName: {Routes: []*Route{{Prefix: newStringP(""), Action: map[string]uint32{testCDSName: 1}}}},
 	})
-
-	if u, err := serviceUpdateCh.Receive(ctx); err != nil || !cmp.Equal(u, serviceUpdateErr{wantUpdate, nil}, serviceCmpOpts...) {
-		t.Errorf("unexpected serviceUpdate: %v, error receiving from channel: %v", u, err)
+	if err := verifyServiceUpdate(serviceUpdateCh, wantUpdate); err != nil {
+		t.Fatal(err)
 	}
-
+	ctx, cancel = context.WithTimeout(context.Background(), defaultTestShortTimeout)
+	defer cancel()
 	if u, err := serviceUpdateCh2.Receive(ctx); err != context.DeadlineExceeded {
 		t.Errorf("unexpected serviceUpdate: %v, %v, want channel recv timeout", u, err)
 	}
@@ -247,25 +253,31 @@ func (s) TestServiceWatchSecond(t *testing.T) {
 // does not respond to the requests being sent out as part of registering a
 // service update watcher. The callback will get an error.
 func (s) TestServiceWatchWithNoResponseFromServer(t *testing.T) {
-	v2ClientCh, cleanup := overrideNewAPIClient()
+	apiClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	c, err := New(clientOpts(testXDSServer, true))
+	client, err := New(clientOpts(testXDSServer, true))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
-	defer c.Close()
-
-	v2Client := <-v2ClientCh
-
-	serviceUpdateCh := testutils.NewChannel()
-	c.WatchService(testLDSName, func(update ServiceUpdate, err error) {
-		serviceUpdateCh.Send(serviceUpdateErr{u: update, err: err})
-	})
+	defer client.Close()
 
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
-	if _, err := v2Client.addWatches[ListenerResource].Receive(ctx); err != nil {
+	c, err := apiClientCh.Receive(ctx)
+	if err != nil {
+		t.Fatalf("timeout when waiting for API client to be created: %v", err)
+	}
+	apiClient := c.(*testAPIClient)
+
+	serviceUpdateCh := testutils.NewChannel()
+	client.WatchService(testLDSName, func(update ServiceUpdate, err error) {
+		serviceUpdateCh.Send(serviceUpdateErr{u: update, err: err})
+	})
+
+	ctx, cancel = context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	if _, err := apiClient.addWatches[ListenerResource].Receive(ctx); err != nil {
 		t.Fatalf("want new watch to start, got error %v", err)
 	}
 	u, err := serviceUpdateCh.Receive(ctx)
@@ -281,37 +293,46 @@ func (s) TestServiceWatchWithNoResponseFromServer(t *testing.T) {
 	}
 }
 
-// TestServiceWatchEmptyRDS tests the case where the underlying v2Client
+// TestServiceWatchEmptyRDS tests the case where the underlying apiClient
 // receives an empty RDS response. The callback will get an error.
 func (s) TestServiceWatchEmptyRDS(t *testing.T) {
-	v2ClientCh, cleanup := overrideNewAPIClient()
+	apiClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	c, err := New(clientOpts(testXDSServer, true))
+	client, err := New(clientOpts(testXDSServer, true))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
-	defer c.Close()
-
-	v2Client := <-v2ClientCh
-
-	serviceUpdateCh := testutils.NewChannel()
-	c.WatchService(testLDSName, func(update ServiceUpdate, err error) {
-		serviceUpdateCh.Send(serviceUpdateErr{u: update, err: err})
-	})
+	defer client.Close()
 
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
-	if _, err := v2Client.addWatches[ListenerResource].Receive(ctx); err != nil {
-		t.Fatalf("want new watch to start, got error %v", err)
+	c, err := apiClientCh.Receive(ctx)
+	if err != nil {
+		t.Fatalf("timeout when waiting for API client to be created: %v", err)
 	}
-	v2Client.r.NewListeners(map[string]ListenerUpdate{
-		testLDSName: {RouteConfigName: testRDSName},
+	apiClient := c.(*testAPIClient)
+
+	serviceUpdateCh := testutils.NewChannel()
+	client.WatchService(testLDSName, func(update ServiceUpdate, err error) {
+		serviceUpdateCh.Send(serviceUpdateErr{u: update, err: err})
 	})
-	if _, err := v2Client.addWatches[RouteConfigResource].Receive(ctx); err != nil {
+
+	ctx, cancel = context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	if _, err := apiClient.addWatches[ListenerResource].Receive(ctx); err != nil {
 		t.Fatalf("want new watch to start, got error %v", err)
 	}
-	v2Client.r.NewRouteConfigs(map[string]RouteConfigUpdate{})
+	client.NewListeners(map[string]ListenerUpdate{testLDSName: {RouteConfigName: testRDSName}})
+	ctx, cancel = context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	if _, err := apiClient.addWatches[RouteConfigResource].Receive(ctx); err != nil {
+		t.Fatalf("want new watch to start, got error %v", err)
+	}
+
+	client.NewRouteConfigs(map[string]RouteConfigUpdate{})
+	ctx, cancel = context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
 	u, err := serviceUpdateCh.Receive(ctx)
 	if err != nil {
 		t.Fatalf("failed to get serviceUpdate: %v", err)
@@ -329,35 +350,43 @@ func (s) TestServiceWatchEmptyRDS(t *testing.T) {
 // received after the client is closed, and we make sure that the registered
 // watcher callback is not invoked.
 func (s) TestServiceWatchWithClientClose(t *testing.T) {
-	v2ClientCh, cleanup := overrideNewAPIClient()
+	apiClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	c, err := New(clientOpts(testXDSServer, true))
+	client, err := New(clientOpts(testXDSServer, true))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
-	defer c.Close()
-
-	v2Client := <-v2ClientCh
-
-	serviceUpdateCh := testutils.NewChannel()
-	c.WatchService(testLDSName, func(update ServiceUpdate, err error) {
-		serviceUpdateCh.Send(serviceUpdateErr{u: update, err: err})
-	})
+	defer client.Close()
 
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
-	if _, err := v2Client.addWatches[ListenerResource].Receive(ctx); err != nil {
-		t.Fatalf("want new watch to start, got error %v", err)
+	c, err := apiClientCh.Receive(ctx)
+	if err != nil {
+		t.Fatalf("timeout when waiting for API client to be created: %v", err)
 	}
-	v2Client.r.NewListeners(map[string]ListenerUpdate{
-		testLDSName: {RouteConfigName: testRDSName},
+	apiClient := c.(*testAPIClient)
+
+	serviceUpdateCh := testutils.NewChannel()
+	client.WatchService(testLDSName, func(update ServiceUpdate, err error) {
+		serviceUpdateCh.Send(serviceUpdateErr{u: update, err: err})
 	})
-	if _, err := v2Client.addWatches[RouteConfigResource].Receive(ctx); err != nil {
+	ctx, cancel = context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	if _, err := apiClient.addWatches[ListenerResource].Receive(ctx); err != nil {
 		t.Fatalf("want new watch to start, got error %v", err)
 	}
+	client.NewListeners(map[string]ListenerUpdate{testLDSName: {RouteConfigName: testRDSName}})
+	ctx, cancel = context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	if _, err := apiClient.addWatches[RouteConfigResource].Receive(ctx); err != nil {
+		t.Fatalf("want new watch to start, got error %v", err)
+	}
+
 	// Client is closed before it receives the RDS response.
-	c.Close()
+	client.Close()
+	ctx, cancel = context.WithTimeout(context.Background(), defaultTestShortTimeout)
+	defer cancel()
 	if u, err := serviceUpdateCh.Receive(ctx); err != context.DeadlineExceeded {
 		t.Errorf("unexpected serviceUpdate: %v, %v, want channel recv timeout", u, err)
 	}
@@ -367,49 +396,53 @@ func (s) TestServiceWatchWithClientClose(t *testing.T) {
 // update contains the same RDS name as the previous, the RDS watch isn't
 // canceled and restarted.
 func (s) TestServiceNotCancelRDSOnSameLDSUpdate(t *testing.T) {
-	v2ClientCh, cleanup := overrideNewAPIClient()
+	apiClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	c, err := New(clientOpts(testXDSServer, false))
+	client, err := New(clientOpts(testXDSServer, false))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
-	defer c.Close()
-
-	v2Client := <-v2ClientCh
-
-	serviceUpdateCh := testutils.NewChannel()
-	c.WatchService(testLDSName, func(update ServiceUpdate, err error) {
-		serviceUpdateCh.Send(serviceUpdateErr{u: update, err: err})
-	})
-
-	wantUpdate := ServiceUpdate{Routes: []*Route{{Prefix: newStringP(""), Action: map[string]uint32{testCDSName: 1}}}}
+	defer client.Close()
 
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
-	if _, err := v2Client.addWatches[ListenerResource].Receive(ctx); err != nil {
-		t.Fatalf("want new watch to start, got error %v", err)
+	c, err := apiClientCh.Receive(ctx)
+	if err != nil {
+		t.Fatalf("timeout when waiting for API client to be created: %v", err)
 	}
-	v2Client.r.NewListeners(map[string]ListenerUpdate{
-		testLDSName: {RouteConfigName: testRDSName},
+	apiClient := c.(*testAPIClient)
+
+	serviceUpdateCh := testutils.NewChannel()
+	client.WatchService(testLDSName, func(update ServiceUpdate, err error) {
+		serviceUpdateCh.Send(serviceUpdateErr{u: update, err: err})
 	})
-	if _, err := v2Client.addWatches[RouteConfigResource].Receive(ctx); err != nil {
+	ctx, cancel = context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	if _, err := apiClient.addWatches[ListenerResource].Receive(ctx); err != nil {
 		t.Fatalf("want new watch to start, got error %v", err)
 	}
-	v2Client.r.NewRouteConfigs(map[string]RouteConfigUpdate{
+	client.NewListeners(map[string]ListenerUpdate{testLDSName: {RouteConfigName: testRDSName}})
+	ctx, cancel = context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	if _, err := apiClient.addWatches[RouteConfigResource].Receive(ctx); err != nil {
+		t.Fatalf("want new watch to start, got error %v", err)
+	}
+	client.NewRouteConfigs(map[string]RouteConfigUpdate{
 		testRDSName: {Routes: []*Route{{Prefix: newStringP(""), Action: map[string]uint32{testCDSName: 1}}}},
 	})
 
-	if u, err := serviceUpdateCh.Receive(ctx); err != nil || !cmp.Equal(u, serviceUpdateErr{wantUpdate, nil}, serviceCmpOpts...) {
-		t.Errorf("unexpected serviceUpdate: %v, error receiving from channel: %v", u, err)
+	wantUpdate := ServiceUpdate{Routes: []*Route{{Prefix: newStringP(""), Action: map[string]uint32{testCDSName: 1}}}}
+	if err := verifyServiceUpdate(serviceUpdateCh, wantUpdate); err != nil {
+		t.Fatal(err)
 	}
 
 	// Another LDS update with a the same RDS_name.
-	v2Client.r.NewListeners(map[string]ListenerUpdate{
-		testLDSName: {RouteConfigName: testRDSName},
-	})
-	if v, err := v2Client.removeWatches[RouteConfigResource].Receive(ctx); err == nil {
-		t.Fatalf("unexpected rds watch cancel: %v", v)
+	client.NewListeners(map[string]ListenerUpdate{testLDSName: {RouteConfigName: testRDSName}})
+	ctx, cancel = context.WithTimeout(context.Background(), defaultTestShortTimeout)
+	defer cancel()
+	if _, err := apiClient.removeWatches[RouteConfigResource].Receive(ctx); err != context.DeadlineExceeded {
+		t.Fatalf("unexpected rds watch cancel")
 	}
 }
 
@@ -420,56 +453,66 @@ func (s) TestServiceNotCancelRDSOnSameLDSUpdate(t *testing.T) {
 // - one more update without the removed resource
 //   - the callback (above) shouldn't receive any update
 func (s) TestServiceResourceRemoved(t *testing.T) {
-	v2ClientCh, cleanup := overrideNewAPIClient()
+	apiClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	c, err := New(clientOpts(testXDSServer, false))
+	client, err := New(clientOpts(testXDSServer, false))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
-	defer c.Close()
-
-	v2Client := <-v2ClientCh
-
-	serviceUpdateCh := testutils.NewChannel()
-	c.WatchService(testLDSName, func(update ServiceUpdate, err error) {
-		serviceUpdateCh.Send(serviceUpdateErr{u: update, err: err})
-	})
-
-	wantUpdate := ServiceUpdate{Routes: []*Route{{Prefix: newStringP(""), Action: map[string]uint32{testCDSName: 1}}}}
+	defer client.Close()
 
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
-	if _, err := v2Client.addWatches[ListenerResource].Receive(ctx); err != nil {
-		t.Fatalf("want new watch to start, got error %v", err)
+	c, err := apiClientCh.Receive(ctx)
+	if err != nil {
+		t.Fatalf("timeout when waiting for API client to be created: %v", err)
 	}
-	v2Client.r.NewListeners(map[string]ListenerUpdate{
-		testLDSName: {RouteConfigName: testRDSName},
-	})
-	if _, err := v2Client.addWatches[RouteConfigResource].Receive(ctx); err != nil {
-		t.Fatalf("want new watch to start, got error %v", err)
-	}
-	v2Client.r.NewRouteConfigs(map[string]RouteConfigUpdate{
-		testRDSName: {Routes: []*Route{{Prefix: newStringP(""), Action: map[string]uint32{testCDSName: 1}}}},
+	apiClient := c.(*testAPIClient)
+
+	serviceUpdateCh := testutils.NewChannel()
+	client.WatchService(testLDSName, func(update ServiceUpdate, err error) {
+		serviceUpdateCh.Send(serviceUpdateErr{u: update, err: err})
 	})
 
-	if u, err := serviceUpdateCh.Receive(ctx); err != nil || !cmp.Equal(u, serviceUpdateErr{wantUpdate, nil}, serviceCmpOpts...) {
-		t.Errorf("unexpected serviceUpdate: %v, error receiving from channel: %v", u, err)
+	ctx, cancel = context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	if _, err := apiClient.addWatches[ListenerResource].Receive(ctx); err != nil {
+		t.Fatalf("want new watch to start, got error %v", err)
+	}
+	client.NewListeners(map[string]ListenerUpdate{testLDSName: {RouteConfigName: testRDSName}})
+	ctx, cancel = context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	if _, err := apiClient.addWatches[RouteConfigResource].Receive(ctx); err != nil {
+		t.Fatalf("want new watch to start, got error %v", err)
+	}
+	client.NewRouteConfigs(map[string]RouteConfigUpdate{
+		testRDSName: {Routes: []*Route{{Prefix: newStringP(""), Action: map[string]uint32{testCDSName: 1}}}},
+	})
+	wantUpdate := ServiceUpdate{Routes: []*Route{{Prefix: newStringP(""), Action: map[string]uint32{testCDSName: 1}}}}
+	if err := verifyServiceUpdate(serviceUpdateCh, wantUpdate); err != nil {
+		t.Fatal(err)
 	}
 
 	// Remove LDS resource, should cancel the RDS watch, and trigger resource
 	// removed error.
-	v2Client.r.NewListeners(map[string]ListenerUpdate{})
-	if _, err := v2Client.removeWatches[RouteConfigResource].Receive(ctx); err != nil {
+	client.NewListeners(map[string]ListenerUpdate{})
+	ctx, cancel = context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	if _, err := apiClient.removeWatches[RouteConfigResource].Receive(ctx); err != nil {
 		t.Fatalf("want watch to be canceled, got error %v", err)
 	}
+	ctx, cancel = context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
 	if u, err := serviceUpdateCh.Receive(ctx); err != nil || ErrType(u.(serviceUpdateErr).err) != ErrorTypeResourceNotFound {
 		t.Errorf("unexpected serviceUpdate: %v, error receiving from channel: %v, want update with error resource not found", u, err)
 	}
 
 	// Send RDS update for the removed LDS resource, expect no updates to
 	// callback, because RDS should be canceled.
-	v2Client.r.NewRouteConfigs(map[string]RouteConfigUpdate{
+	ctx, cancel = context.WithTimeout(context.Background(), defaultTestShortTimeout)
+	defer cancel()
+	client.NewRouteConfigs(map[string]RouteConfigUpdate{
 		testRDSName: {Routes: []*Route{{Prefix: newStringP(""), Action: map[string]uint32{testCDSName + "new": 1}}}},
 	})
 	if u, err := serviceUpdateCh.Receive(ctx); err != context.DeadlineExceeded {
@@ -479,24 +522,23 @@ func (s) TestServiceResourceRemoved(t *testing.T) {
 	// Add LDS resource, but not RDS resource, should
 	//  - start a new RDS watch
 	//  - timeout on service channel, because RDS cache was cleared
-	v2Client.r.NewListeners(map[string]ListenerUpdate{
-		testLDSName: {RouteConfigName: testRDSName},
-	})
+	client.NewListeners(map[string]ListenerUpdate{testLDSName: {RouteConfigName: testRDSName}})
 	ctx, cancel = context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
-	if _, err := v2Client.addWatches[RouteConfigResource].Receive(ctx); err != nil {
+	if _, err := apiClient.addWatches[RouteConfigResource].Receive(ctx); err != nil {
 		t.Fatalf("want new watch to start, got error %v", err)
 	}
+	ctx, cancel = context.WithTimeout(context.Background(), defaultTestWatchExpiryTimeout)
+	defer cancel()
 	if u, err := serviceUpdateCh.Receive(ctx); err != context.DeadlineExceeded {
 		t.Errorf("unexpected serviceUpdate: %v, want receiving from channel timeout", u)
 	}
 
-	v2Client.r.NewRouteConfigs(map[string]RouteConfigUpdate{
+	client.NewRouteConfigs(map[string]RouteConfigUpdate{
 		testRDSName: {Routes: []*Route{{Prefix: newStringP(""), Action: map[string]uint32{testCDSName + "new2": 1}}}},
 	})
-	ctx, cancel = context.WithTimeout(context.Background(), defaultTestTimeout)
-	defer cancel()
-	if u, err := serviceUpdateCh.Receive(ctx); err != nil || !cmp.Equal(u, serviceUpdateErr{ServiceUpdate{Routes: []*Route{{Prefix: newStringP(""), Action: map[string]uint32{testCDSName + "new2": 1}}}}, nil}, serviceCmpOpts...) {
-		t.Errorf("unexpected serviceUpdate: %v, error receiving from channel: %v", u, err)
+	wantUpdate = ServiceUpdate{Routes: []*Route{{Prefix: newStringP(""), Action: map[string]uint32{testCDSName + "new2": 1}}}}
+	if err := verifyServiceUpdate(serviceUpdateCh, wantUpdate); err != nil {
+		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
- Cleanup includes the following:
  - Split `TestValidateCluster` into failure and success cases. I will adding more cases here as part of other PR which adds support to process security configuration at the `xdsClient`.
  - Use a `testutils.Channel` to push the fake API client. This allows tests to block on this with a deadline. This addresses a TODO in the code.
  - Add `verify*Update` functions to test successfully received updates. 
  - Push the different updates directly on the `xds.Client` object instead of going through the `fakeAPIClient`. This addresses a TODO in the code.
    - Rename variables: `c` -> `client`, `v2Client` -> `apiClient`, `v2ClientCh` -> `apiClientCh`
  - Use short timeouts when blocking for events which are expected to *not* happen

`go test google.golang.org/grpc/xds/internal/client/` now takes `~5s`. Used to take `~30s`.