### PR TITLE
cmd/protoc-gen-go-grpc: add --version flag support

### DIFF
--- a/cmd/protoc-gen-go-grpc/main.go
+++ b/cmd/protoc-gen-go-grpc/main.go
@@ -32,14 +32,24 @@ package main
 
 import (
 	"flag"
+	"fmt"
 
 	"google.golang.org/protobuf/compiler/protogen"
 	"google.golang.org/protobuf/types/pluginpb"
 )
 
+const version = "1.0"
+
 var requireUnimplemented *bool
 
 func main() {
+	showVersion := flag.Bool("version", false, "print the version and exit")
+	flag.Parse()
+	if *showVersion {
+		fmt.Printf("protoc-gen-go-grpc %v\n", version)
+		return
+	}
+
 	var flags flag.FlagSet
 	requireUnimplemented = flags.Bool("require_unimplemented_servers", true, "set to false to match legacy behavior")
 


### PR DESCRIPTION
This replaces #3720.  There are two differences:

- Prints to stdout instead of stderr, which is more standard.
- Prints the version of protoc-gen-go-grpc instead of grpc's version, which would be coincidental.

v1.0 will be tagged and released after this PR is merged.
