### PR TITLE
xds/bootstrap: Use correct format for "certificate_providers" field.

### DIFF
--- a/xds/internal/client/bootstrap/bootstrap.go
+++ b/xds/internal/client/bootstrap/bootstrap.go
@@ -120,7 +120,7 @@ type xdsServer struct {
 //		"certificate_providers" : {
 //			"default": {
 //				"plugin_name": "default-plugin-name",
-//				"config": {	default plugin config in JSON }
+//				"config": { default plugin config in JSON }
 //			},
 //			"foo": {
 //				"plugin_name": "foo",

--- a/xds/internal/client/bootstrap/bootstrap_test.go
+++ b/xds/internal/client/bootstrap/bootstrap_test.go
@@ -564,10 +564,12 @@ func TestNewConfigWithCertificateProviders(t *testing.T) {
 			"server_features" : ["foo", "bar", "xds_v3"],
 			"certificate_providers": {
 				"unknownProviderInstance1": {
-					"foo1": "bar1"
+					"plugin_name": "foo",
+					"config": {"foo": "bar"}
 				},
 				"unknownProviderInstance2": {
-					"foo2": "bar2"
+					"plugin_name": "bar",
+					"config": {"foo": "bar"}
 				}
 			}
 		}`,
@@ -588,17 +590,12 @@ func TestNewConfigWithCertificateProviders(t *testing.T) {
 			"server_features" : ["foo", "bar", "xds_v3"],
 			"certificate_providers": {
 				"unknownProviderInstance": {
-					"foo": "bar"
-				},
-				"fakeProviderInstance": {
-					"fake-certificate-provider": {
-						"configKey": "configValue"
-					}
+					"plugin_name": "foo",
+					"config": {"foo": "bar"}
 				},
 				"fakeProviderInstanceBad": {
-					"fake-certificate-provider": {
-						"configKey": 666
-					}
+					"plugin_name": "fake-certificate-provider",
+					"config": {"configKey": 666}
 				}
 			}
 		}`,
@@ -619,12 +616,12 @@ func TestNewConfigWithCertificateProviders(t *testing.T) {
 			"server_features" : ["foo", "bar", "xds_v3"],
 			"certificate_providers": {
 				"unknownProviderInstance": {
-					"foo": "bar"
+					"plugin_name": "foo",
+					"config": {"foo": "bar"}
 				},
 				"fakeProviderInstance": {
-					"fake-certificate-provider": {
-						"configKey": "configValue"
-					}
+					"plugin_name": "fake-certificate-provider",
+					"config": {"configKey": "configValue"}
 				}
 			}
 		}`,
@@ -692,7 +689,7 @@ func TestNewConfigWithCertificateProviders(t *testing.T) {
 			}
 			c, err := NewConfig()
 			if (err != nil) != test.wantErr {
-				t.Fatalf("NewConfig() returned: %v, wantErr: %v", err, test.wantErr)
+				t.Fatalf("NewConfig() returned: (%+v, %v), wantErr: %v", c.CertProviderConfigs, err, test.wantErr)
 			}
 			if test.wantErr {
 				return


### PR DESCRIPTION
The expected format for the `certificate_providers` field was wrong:
```
	"certificate_providers" : {
		"default": { 
			"plugin_bar" : {bar plugin config in JSON }
		},
		"foo": {
			"plugin_foo" : { foo plugin config in JSON }
		}
	}
```

The correct format is:
```
	"certificate_providers" : {
		"default": {
			"plugin_name": "plugin_bar",
			"config": { default plugin config in JSON }
		},
		"foo": {
			"plugin_name": "plugin_foo",
			"config": { foo plugin config in JSON }
		}
	}
```