### PR TITLE
channelz: remove redundant case from AddTraceEvent and remove caps from severities

### DIFF
--- a/channelz/service/service_test.go
+++ b/channelz/service/service_test.go
@@ -470,39 +470,39 @@ func (s) TestGetChannel(t *testing.T) {
 	ids[0] = channelz.RegisterChannel(&dummyChannel{}, 0, refNames[0])
 	channelz.AddTraceEvent(logger, ids[0], 0, &channelz.TraceEventDesc{
 		Desc:     "Channel Created",
-		Severity: channelz.CtINFO,
+		Severity: channelz.CtInfo,
 	})
 	ids[1] = channelz.RegisterChannel(&dummyChannel{}, ids[0], refNames[1])
 	channelz.AddTraceEvent(logger, ids[1], 0, &channelz.TraceEventDesc{
 		Desc:     "Channel Created",
-		Severity: channelz.CtINFO,
+		Severity: channelz.CtInfo,
 		Parent: &channelz.TraceEventDesc{
 			Desc:     fmt.Sprintf("Nested Channel(id:%d) created", ids[1]),
-			Severity: channelz.CtINFO,
+			Severity: channelz.CtInfo,
 		},
 	})
 
 	ids[2] = channelz.RegisterSubChannel(&dummyChannel{}, ids[0], refNames[2])
 	channelz.AddTraceEvent(logger, ids[2], 0, &channelz.TraceEventDesc{
 		Desc:     "SubChannel Created",
-		Severity: channelz.CtINFO,
+		Severity: channelz.CtInfo,
 		Parent: &channelz.TraceEventDesc{
 			Desc:     fmt.Sprintf("SubChannel(id:%d) created", ids[2]),
-			Severity: channelz.CtINFO,
+			Severity: channelz.CtInfo,
 		},
 	})
 	ids[3] = channelz.RegisterChannel(&dummyChannel{}, ids[1], refNames[3])
 	channelz.AddTraceEvent(logger, ids[3], 0, &channelz.TraceEventDesc{
 		Desc:     "Channel Created",
-		Severity: channelz.CtINFO,
+		Severity: channelz.CtInfo,
 		Parent: &channelz.TraceEventDesc{
 			Desc:     fmt.Sprintf("Nested Channel(id:%d) created", ids[3]),
-			Severity: channelz.CtINFO,
+			Severity: channelz.CtInfo,
 		},
 	})
 	channelz.AddTraceEvent(logger, ids[0], 0, &channelz.TraceEventDesc{
 		Desc:     fmt.Sprintf("Channel Connectivity change to %v", connectivity.Ready),
-		Severity: channelz.CtINFO,
+		Severity: channelz.CtInfo,
 	})
 	channelz.AddTraceEvent(logger, ids[0], 0, &channelz.TraceEventDesc{
 		Desc:     "Resolver returns an empty address list",
@@ -573,26 +573,26 @@ func (s) TestGetSubChannel(t *testing.T) {
 	ids[0] = channelz.RegisterChannel(&dummyChannel{}, 0, refNames[0])
 	channelz.AddTraceEvent(logger, ids[0], 0, &channelz.TraceEventDesc{
 		Desc:     "Channel Created",
-		Severity: channelz.CtINFO,
+		Severity: channelz.CtInfo,
 	})
 	ids[1] = channelz.RegisterSubChannel(&dummyChannel{}, ids[0], refNames[1])
 	channelz.AddTraceEvent(logger, ids[1], 0, &channelz.TraceEventDesc{
 		Desc:     subchanCreated,
-		Severity: channelz.CtINFO,
+		Severity: channelz.CtInfo,
 		Parent: &channelz.TraceEventDesc{
 			Desc:     fmt.Sprintf("Nested Channel(id:%d) created", ids[0]),
-			Severity: channelz.CtINFO,
+			Severity: channelz.CtInfo,
 		},
 	})
 	ids[2] = channelz.RegisterNormalSocket(&dummySocket{}, ids[1], refNames[2])
 	ids[3] = channelz.RegisterNormalSocket(&dummySocket{}, ids[1], refNames[3])
 	channelz.AddTraceEvent(logger, ids[1], 0, &channelz.TraceEventDesc{
 		Desc:     subchanConnectivityChange,
-		Severity: channelz.CtINFO,
+		Severity: channelz.CtInfo,
 	})
 	channelz.AddTraceEvent(logger, ids[1], 0, &channelz.TraceEventDesc{
 		Desc:     subChanPickNewAddress,
-		Severity: channelz.CtINFO,
+		Severity: channelz.CtInfo,
 	})
 	for _, id := range ids {
 		defer channelz.RemoveEntry(id)

--- a/clientconn.go
+++ b/clientconn.go
@@ -151,10 +151,10 @@ func DialContext(ctx context.Context, target string, opts ...DialOption) (conn *
 			cc.channelzID = channelz.RegisterChannel(&channelzChannel{cc}, cc.dopts.channelzParentID, target)
 			channelz.AddTraceEvent(logger, cc.channelzID, 0, &channelz.TraceEventDesc{
 				Desc:     "Channel Created",
-				Severity: channelz.CtINFO,
+				Severity: channelz.CtInfo,
 				Parent: &channelz.TraceEventDesc{
 					Desc:     fmt.Sprintf("Nested Channel(id:%d) created", cc.channelzID),
-					Severity: channelz.CtINFO,
+					Severity: channelz.CtInfo,
 				},
 			})
 		} else {
@@ -744,10 +744,10 @@ func (cc *ClientConn) newAddrConn(addrs []resolver.Address, opts balancer.NewSub
 		ac.channelzID = channelz.RegisterSubChannel(ac, cc.channelzID, "")
 		channelz.AddTraceEvent(logger, ac.channelzID, 0, &channelz.TraceEventDesc{
 			Desc:     "Subchannel Created",
-			Severity: channelz.CtINFO,
+			Severity: channelz.CtInfo,
 			Parent: &channelz.TraceEventDesc{
 				Desc:     fmt.Sprintf("Subchannel(id:%d) created", ac.channelzID),
-				Severity: channelz.CtINFO,
+				Severity: channelz.CtInfo,
 			},
 		})
 	}
@@ -1033,12 +1033,12 @@ func (cc *ClientConn) Close() error {
 	if channelz.IsOn() {
 		ted := &channelz.TraceEventDesc{
 			Desc:     "Channel Deleted",
-			Severity: channelz.CtINFO,
+			Severity: channelz.CtInfo,
 		}
 		if cc.dopts.channelzParentID != 0 {
 			ted.Parent = &channelz.TraceEventDesc{
 				Desc:     fmt.Sprintf("Nested channel(id:%d) deleted", cc.channelzID),
-				Severity: channelz.CtINFO,
+				Severity: channelz.CtInfo,
 			}
 		}
 		channelz.AddTraceEvent(logger, cc.channelzID, 0, ted)
@@ -1451,10 +1451,10 @@ func (ac *addrConn) tearDown(err error) {
 	if channelz.IsOn() {
 		channelz.AddTraceEvent(logger, ac.channelzID, 0, &channelz.TraceEventDesc{
 			Desc:     "Subchannel Deleted",
-			Severity: channelz.CtINFO,
+			Severity: channelz.CtInfo,
 			Parent: &channelz.TraceEventDesc{
 				Desc:     fmt.Sprintf("Subchanel(id:%d) deleted", ac.channelzID),
-				Severity: channelz.CtINFO,
+				Severity: channelz.CtInfo,
 			},
 		})
 		// TraceEvent needs to be called before RemoveEntry, as TraceEvent may add trace reference to

--- a/internal/channelz/funcs.go
+++ b/internal/channelz/funcs.go
@@ -297,9 +297,7 @@ type TraceEventDesc struct {
 func AddTraceEvent(l grpclog.DepthLoggerV2, id int64, depth int, desc *TraceEventDesc) {
 	for d := desc; d != nil; d = d.Parent {
 		switch d.Severity {
-		case CtUNKNOWN:
-			l.InfoDepth(depth+1, d.Desc)
-		case CtINFO:
+		case CtUnknown, CtInfo:
 			l.InfoDepth(depth+1, d.Desc)
 		case CtWarning:
 			l.WarningDepth(depth+1, d.Desc)

--- a/internal/channelz/logging.go
+++ b/internal/channelz/logging.go
@@ -31,7 +31,7 @@ func Info(l grpclog.DepthLoggerV2, id int64, args ...interface{}) {
 	if IsOn() {
 		AddTraceEvent(l, id, 1, &TraceEventDesc{
 			Desc:     fmt.Sprint(args...),
-			Severity: CtINFO,
+			Severity: CtInfo,
 		})
 	} else {
 		l.InfoDepth(1, args...)
@@ -44,7 +44,7 @@ func Infof(l grpclog.DepthLoggerV2, id int64, format string, args ...interface{}
 	if IsOn() {
 		AddTraceEvent(l, id, 1, &TraceEventDesc{
 			Desc:     msg,
-			Severity: CtINFO,
+			Severity: CtInfo,
 		})
 	} else {
 		l.InfoDepth(1, msg)

--- a/internal/channelz/types.go
+++ b/internal/channelz/types.go
@@ -672,10 +672,10 @@ func (c *channelTrace) clear() {
 type Severity int
 
 const (
-	// CtUNKNOWN indicates unknown severity of a trace event.
-	CtUNKNOWN Severity = iota
-	// CtINFO indicates info level severity of a trace event.
-	CtINFO
+	// CtUnknown indicates unknown severity of a trace event.
+	CtUnknown Severity = iota
+	// CtInfo indicates info level severity of a trace event.
+	CtInfo
 	// CtWarning indicates warning level severity of a trace event.
 	CtWarning
 	// CtError indicates error level severity of a trace event.

--- a/resolver_conn_wrapper.go
+++ b/resolver_conn_wrapper.go
@@ -217,6 +217,6 @@ func (ccr *ccResolverWrapper) addChannelzTraceEvent(s resolver.State) {
 	}
 	channelz.AddTraceEvent(logger, ccr.cc.channelzID, 0, &channelz.TraceEventDesc{
 		Desc:     fmt.Sprintf("Resolver state updated: %+v (%v)", s, strings.Join(updates, "; ")),
-		Severity: channelz.CtINFO,
+		Severity: channelz.CtInfo,
 	})
 }


### PR DESCRIPTION
This PR is introducing the following minor changes:
- Remove a redundant case from the switch-case that exists in `channelz.AddTraceEvent` - Unknown and Info severities have the same behaviour.
- Rename severities Unknown and Info - change caps to lowercase letters.