### PR TITLE
lrs: handle multiple clusters in LRS stream

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -71,7 +71,6 @@ google.golang.org/appengine v1.4.0 h1:/wp5JvzpHIxhs/dumFmF7BXTf3Z+dd4uXta4kVyO50
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
-google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 h1:+kGHl1aib/qcwaRi1CbqBZ1rk19r85MNUf8HaBghugY=
 google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEYHJ7i3ixzK3sjbqSGDJWnxyFXZblF3eUsNvo=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
@@ -85,7 +84,6 @@ google.golang.org/protobuf v1.21.0/go.mod h1:47Nbq4nVaFHyn7ilMalzfO3qCViNmqZ2kzi
 google.golang.org/protobuf v1.22.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
-google.golang.org/protobuf v1.25.0 h1:Ejskq+SyPohKW+1uil0JJMtmHCgJPJ/qWTxr8qp+R4c=
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/go.sum
+++ b/go.sum
@@ -71,6 +71,7 @@ google.golang.org/appengine v1.4.0 h1:/wp5JvzpHIxhs/dumFmF7BXTf3Z+dd4uXta4kVyO50
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
+google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 h1:+kGHl1aib/qcwaRi1CbqBZ1rk19r85MNUf8HaBghugY=
 google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEYHJ7i3ixzK3sjbqSGDJWnxyFXZblF3eUsNvo=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
@@ -84,6 +85,7 @@ google.golang.org/protobuf v1.21.0/go.mod h1:47Nbq4nVaFHyn7ilMalzfO3qCViNmqZ2kzi
 google.golang.org/protobuf v1.22.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
+google.golang.org/protobuf v1.25.0 h1:Ejskq+SyPohKW+1uil0JJMtmHCgJPJ/qWTxr8qp+R4c=
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/xds/internal/balancer/edsbalancer/eds.go
+++ b/xds/internal/balancer/edsbalancer/eds.go
@@ -178,7 +178,7 @@ func (x *edsBalancer) handleGRPCUpdate(update interface{}) {
 		}
 
 		if err := x.client.handleUpdate(cfg, u.ResolverState.Attributes); err != nil {
-			x.logger.Infof("failed to update xds clients: %v", err)
+			x.logger.Warningf("failed to update xds clients: %v", err)
 		}
 
 		if x.config == nil {

--- a/xds/internal/balancer/edsbalancer/eds.go
+++ b/xds/internal/balancer/edsbalancer/eds.go
@@ -177,7 +177,9 @@ func (x *edsBalancer) handleGRPCUpdate(update interface{}) {
 			return
 		}
 
-		x.client.handleUpdate(cfg, u.ResolverState.Attributes)
+		if err := x.client.handleUpdate(cfg, u.ResolverState.Attributes); err != nil {
+			x.logger.Infof("failed to update xds clients: %v", err)
+		}
 
 		if x.config == nil {
 			x.config = cfg

--- a/xds/internal/balancer/edsbalancer/eds_impl_test.go
+++ b/xds/internal/balancer/edsbalancer/eds_impl_test.go
@@ -690,7 +690,7 @@ func (s) TestEDS_LoadReport(t *testing.T) {
 	lsWrapper := &loadStoreWrapper{}
 	lsWrapper.update(loadStore, testClusterNames[0])
 	cw := &xdsClientWrapper{
-		load: lsWrapper,
+		loadWrapper: lsWrapper,
 	}
 
 	cc := testutils.NewTestClientConn(t)

--- a/xds/internal/balancer/edsbalancer/eds_impl_test.go
+++ b/xds/internal/balancer/edsbalancer/eds_impl_test.go
@@ -688,7 +688,8 @@ func (s) TestEDS_LoadReport(t *testing.T) {
 	// be used.
 	loadStore := load.NewStore()
 	lsWrapper := &loadStoreWrapper{}
-	lsWrapper.update(loadStore, testClusterNames[0])
+	lsWrapper.updateServiceName(testClusterNames[0])
+	lsWrapper.updateLoadStore(loadStore)
 	cw := &xdsClientWrapper{
 		loadWrapper: lsWrapper,
 	}

--- a/xds/internal/balancer/edsbalancer/xds_lrs_test.go
+++ b/xds/internal/balancer/edsbalancer/xds_lrs_test.go
@@ -66,7 +66,7 @@ func (s) TestXDSLoadReporting(t *testing.T) {
 	if err != nil {
 		t.Fatalf("xdsClient.ReportLoad failed with error: %v", err)
 	}
-	if got.Server != "" || got.Cluster != testEDSClusterName {
-		t.Fatalf("xdsClient.ReportLoad called with {%v, %v}: want {\"\", %v}", got.Server, got.Cluster, testEDSClusterName)
+	if got.Server != "" {
+		t.Fatalf("xdsClient.ReportLoad called with {%v}: want {\"\"}", got.Server)
 	}
 }

--- a/xds/internal/balancer/lrs/balancer_test.go
+++ b/xds/internal/balancer/lrs/balancer_test.go
@@ -84,8 +84,8 @@ func TestLoadReporting(t *testing.T) {
 	if err != nil {
 		t.Fatalf("xdsClient.ReportLoad failed with error: %v", err)
 	}
-	if got.Server != testLRSServerName || got.Cluster != testClusterName {
-		t.Fatalf("xdsClient.ReportLoad called with {%q, %q}: want {%q, %q}", got.Server, got.Cluster, testLRSServerName, testClusterName)
+	if got.Server != testLRSServerName {
+		t.Fatalf("xdsClient.ReportLoad called with {%q}: want {%q}", got.Server, testLRSServerName)
 	}
 
 	sc1 := <-cc.NewSubConnCh

--- a/xds/internal/client/client_loadreport_test.go
+++ b/xds/internal/client/client_loadreport_test.go
@@ -1,0 +1,148 @@
+/*
+ *
+ * Copyright 2020 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package client_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	v2corepb "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	endpointpb "github.com/envoyproxy/go-control-plane/envoy/api/v2/endpoint"
+	lrspb "github.com/envoyproxy/go-control-plane/envoy/service/load_stats/v2"
+	"github.com/golang/protobuf/proto"
+	durationpb "github.com/golang/protobuf/ptypes/duration"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/internal/grpctest"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/xds/internal/client"
+	"google.golang.org/grpc/xds/internal/client/bootstrap"
+	"google.golang.org/grpc/xds/internal/testutils/fakeserver"
+	"google.golang.org/grpc/xds/internal/version"
+
+	_ "google.golang.org/grpc/xds/internal/client/v2" // Register the v2 xDS API client.
+)
+
+const (
+	defaultTestTimeout      = 5 * time.Second
+	defaultTestShortTimeout = 10 * time.Millisecond // For events expected to *not* happen.
+)
+
+type s struct {
+	grpctest.Tester
+}
+
+func Test(t *testing.T) {
+	grpctest.RunSubTests(t, s{})
+}
+
+func (s) TestLRSClient(t *testing.T) {
+	fs, sCleanup, err := fakeserver.StartServer()
+	if err != nil {
+		t.Fatalf("failed to start fake xDS server: %v", err)
+	}
+	defer sCleanup()
+
+	xdsC, err := client.New(client.Options{
+		Config: bootstrap.Config{
+			BalancerName: fs.Address,
+			Creds:        grpc.WithInsecure(),
+			NodeProto:    &v2corepb.Node{},
+			TransportAPI: version.TransportV2,
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to create xds client: %v", err)
+	}
+	defer xdsC.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	if u, err := fs.NewConnChan.Receive(ctx); err != nil {
+		t.Errorf("unexpected timeout: %v, %v, want NewConn", u, err)
+	}
+
+	// Report to the same address should not create new ClientConn.
+	store1, lrsCancel1 := xdsC.ReportLoad(fs.Address)
+	defer lrsCancel1()
+	ctx, cancel = context.WithTimeout(context.Background(), defaultTestShortTimeout)
+	defer cancel()
+	if u, err := fs.NewConnChan.Receive(ctx); err != context.DeadlineExceeded {
+		t.Errorf("unexpected NewConn: %v, %v, want channel recv timeout", u, err)
+	}
+
+	fs2, sCleanup2, err := fakeserver.StartServer()
+	if err != nil {
+		t.Fatalf("failed to start fake xDS server: %v", err)
+	}
+	defer sCleanup2()
+
+	// Report to a different address should create new ClientConn.
+	store2, lrsCancel2 := xdsC.ReportLoad(fs2.Address)
+	defer lrsCancel2()
+	ctx, cancel = context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	if u, err := fs2.NewConnChan.Receive(ctx); err != nil {
+		t.Errorf("unexpected timeout: %v, %v, want NewConn", u, err)
+	}
+
+	if store1 == store2 {
+		t.Fatalf("got same store for different servers, want different")
+	}
+
+	if u, err := fs2.LRSRequestChan.Receive(ctx); err != nil {
+		t.Errorf("unexpected timeout: %v, %v, want NewConn", u, err)
+	}
+	store2.PerCluster("cluster", "eds").CallDropped("test")
+
+	// Send one resp to the client.
+	fs2.LRSResponseChan <- &fakeserver.Response{
+		Resp: &lrspb.LoadStatsResponse{
+			SendAllClusters:       true,
+			LoadReportingInterval: &durationpb.Duration{Nanos: 50000000},
+		},
+	}
+
+	// Server should receive a req with the loads.
+	u, err := fs2.LRSRequestChan.Receive(ctx)
+	if err != nil {
+		t.Fatalf("unexpected LRS request: %v, %v, want error canceled", u, err)
+	}
+	receivedLoad := u.(*fakeserver.Request).Req.(*lrspb.LoadStatsRequest).ClusterStats
+	if len(receivedLoad) <= 0 {
+		t.Fatalf("unexpected load received, want load for cluster, eds, dropped for test")
+	}
+	receivedLoad[0].LoadReportInterval = nil
+	if want := (&endpointpb.ClusterStats{
+		ClusterName:          "cluster",
+		ClusterServiceName:   "eds",
+		TotalDroppedRequests: 1,
+		DroppedRequests:      []*endpointpb.ClusterStats_DroppedRequests{{Category: "test", DroppedCount: 1}},
+	}); !proto.Equal(want, receivedLoad[0]) {
+		t.Fatalf("unexpected load received, want load for cluster, eds, dropped for test")
+	}
+
+	// Cancel this load reporting stream, server should see error canceled.
+	lrsCancel2()
+
+	// Server should receive a stream canceled error.
+	if u, err := fs2.LRSRequestChan.Receive(ctx); err != nil || status.Code(u.(*fakeserver.Request).Err) != codes.Canceled {
+		t.Errorf("unexpected LRS request: %v, %v, want error canceled", u, err)
+	}
+}

--- a/xds/internal/client/client_test.go
+++ b/xds/internal/client/client_test.go
@@ -115,7 +115,7 @@ func (c *testAPIClient) RemoveWatch(resourceType ResourceType, resourceName stri
 	c.removeWatches[resourceType].Send(resourceName)
 }
 
-func (c *testAPIClient) ReportLoad(ctx context.Context, cc *grpc.ClientConn, opts LoadReportingOptions) {
+func (c *testAPIClient) reportLoad(_ context.Context, _ *grpc.ClientConn, _ loadReportingOptions) {
 }
 
 func (c *testAPIClient) Close() {}

--- a/xds/internal/client/client_test.go
+++ b/xds/internal/client/client_test.go
@@ -115,7 +115,7 @@ func (c *testAPIClient) RemoveWatch(resourceType ResourceType, resourceName stri
 	c.removeWatches[resourceType].Send(resourceName)
 }
 
-func (c *testAPIClient) reportLoad(_ context.Context, _ *grpc.ClientConn, _ loadReportingOptions) {
+func (c *testAPIClient) reportLoad(context.Context, *grpc.ClientConn, loadReportingOptions) {
 }
 
 func (c *testAPIClient) Close() {}

--- a/xds/internal/client/transport_helper.go
+++ b/xds/internal/client/transport_helper.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/golang/protobuf/proto"
+	"google.golang.org/grpc/xds/internal/client/load"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/internal/buffer"
@@ -71,19 +72,21 @@ type VersionedClient interface {
 	NewLoadStatsStream(ctx context.Context, cc *grpc.ClientConn) (grpc.ClientStream, error)
 
 	// SendFirstLoadStatsRequest constructs and sends the first request on the
-	// LRS stream. This contains the node proto with appropriate metadata
-	// fields.
-	SendFirstLoadStatsRequest(s grpc.ClientStream, targetName string) error
+	// LRS stream.
+	SendFirstLoadStatsRequest(s grpc.ClientStream) error
 
 	// HandleLoadStatsResponse receives the first response from the server which
 	// contains the load reporting interval and the clusters for which the
 	// server asks the client to report load for.
-	HandleLoadStatsResponse(s grpc.ClientStream, clusterName string) (time.Duration, error)
+	//
+	// If the response sets SendAllClusters to true, the returned clusters is
+	// nil.
+	HandleLoadStatsResponse(s grpc.ClientStream) (clusters []string, _ time.Duration, _ error)
 
 	// SendLoadStatsRequest will be invoked at regular intervals to send load
 	// report with load data reported since the last time this method was
 	// invoked.
-	SendLoadStatsRequest(s grpc.ClientStream, clusterName string) error
+	SendLoadStatsRequest(s grpc.ClientStream, loads []*load.Data) error
 }
 
 // TransportHelper contains all xDS transport protocol related functionality
@@ -440,9 +443,9 @@ func (t *TransportHelper) processAckInfo(ack *ackAction, stream grpc.ClientStrea
 	return target, rType, version, nonce, send
 }
 
-// ReportLoad starts an LRS stream to report load data to the management server.
+// reportLoad starts an LRS stream to report load data to the management server.
 // It blocks until the context is cancelled.
-func (t *TransportHelper) ReportLoad(ctx context.Context, cc *grpc.ClientConn, opts LoadReportingOptions) {
+func (t *TransportHelper) reportLoad(ctx context.Context, cc *grpc.ClientConn, opts loadReportingOptions) {
 	retries := 0
 	for {
 		if ctx.Err() != nil {
@@ -469,23 +472,23 @@ func (t *TransportHelper) ReportLoad(ctx context.Context, cc *grpc.ClientConn, o
 		}
 		logger.Infof("lrs: created LRS stream")
 
-		if err := t.vClient.SendFirstLoadStatsRequest(stream, opts.TargetName); err != nil {
+		if err := t.vClient.SendFirstLoadStatsRequest(stream); err != nil {
 			logger.Warningf("lrs: failed to send first request: %v", err)
 			continue
 		}
 
-		interval, err := t.vClient.HandleLoadStatsResponse(stream, opts.ClusterName)
+		clusters, interval, err := t.vClient.HandleLoadStatsResponse(stream)
 		if err != nil {
 			logger.Warning(err)
 			continue
 		}
 
 		retries = 0
-		t.sendLoads(ctx, stream, opts.ClusterName, interval)
+		t.sendLoads(ctx, stream, opts.loadStore, clusters, interval)
 	}
 }
 
-func (t *TransportHelper) sendLoads(ctx context.Context, stream grpc.ClientStream, clusterName string, interval time.Duration) {
+func (t *TransportHelper) sendLoads(ctx context.Context, stream grpc.ClientStream, store *load.Store, clusterNames []string, interval time.Duration) {
 	tick := time.NewTicker(interval)
 	defer tick.Stop()
 	for {
@@ -494,7 +497,7 @@ func (t *TransportHelper) sendLoads(ctx context.Context, stream grpc.ClientStrea
 		case <-ctx.Done():
 			return
 		}
-		if err := t.vClient.SendLoadStatsRequest(stream, clusterName); err != nil {
+		if err := t.vClient.SendLoadStatsRequest(stream, store.Stats(clusterNames)); err != nil {
 			logger.Warning(err)
 			return
 		}

--- a/xds/internal/client/v2/client.go
+++ b/xds/internal/client/v2/client.go
@@ -27,7 +27,6 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/internal/grpclog"
 	xdsclient "google.golang.org/grpc/xds/internal/client"
-	"google.golang.org/grpc/xds/internal/client/load"
 	"google.golang.org/grpc/xds/internal/version"
 
 	v2xdspb "github.com/envoyproxy/go-control-plane/envoy/api/v2"
@@ -67,7 +66,6 @@ func newClient(cc *grpc.ClientConn, opts xdsclient.BuildOptions) (xdsclient.APIC
 		cc:        cc,
 		parent:    opts.Parent,
 		nodeProto: nodeProto,
-		loadStore: opts.LoadStore,
 		logger:    opts.Logger,
 	}
 	v2c.ctx, v2c.cancelCtx = context.WithCancel(context.Background())
@@ -86,7 +84,6 @@ type client struct {
 	ctx       context.Context
 	cancelCtx context.CancelFunc
 	parent    xdsclient.UpdateHandler
-	loadStore *load.Store
 	logger    *grpclog.PrefixLogger
 
 	// ClientConn to the xDS gRPC server. Owned by the parent xdsClient.

--- a/xds/internal/client/v2/loadreport.go
+++ b/xds/internal/client/v2/loadreport.go
@@ -26,16 +26,17 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
+	"google.golang.org/grpc/xds/internal/client/load"
 
 	v2corepb "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	v2endpointpb "github.com/envoyproxy/go-control-plane/envoy/api/v2/endpoint"
 	lrsgrpc "github.com/envoyproxy/go-control-plane/envoy/service/load_stats/v2"
 	lrspb "github.com/envoyproxy/go-control-plane/envoy/service/load_stats/v2"
-	structpb "github.com/golang/protobuf/ptypes/struct"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/xds/internal"
-	xdsclient "google.golang.org/grpc/xds/internal/client"
 )
+
+const clientFeatureLRSSendAllClusters = "envoy.lrs.supports_send_all_clusters"
 
 type lrsStream lrsgrpc.LoadReportingService_StreamLoadStatsClient
 
@@ -44,7 +45,7 @@ func (v2c *client) NewLoadStatsStream(ctx context.Context, cc *grpc.ClientConn) 
 	return c.StreamLoadStats(ctx)
 }
 
-func (v2c *client) SendFirstLoadStatsRequest(s grpc.ClientStream, targetName string) error {
+func (v2c *client) SendFirstLoadStatsRequest(s grpc.ClientStream) error {
 	stream, ok := s.(lrsStream)
 	if !ok {
 		return fmt.Errorf("lrs: Attempt to send request on unsupported stream type: %T", s)
@@ -53,72 +54,52 @@ func (v2c *client) SendFirstLoadStatsRequest(s grpc.ClientStream, targetName str
 	if node == nil {
 		node = &v2corepb.Node{}
 	}
-	if node.Metadata == nil {
-		node.Metadata = &structpb.Struct{}
-	}
-	if node.Metadata.Fields == nil {
-		node.Metadata.Fields = make(map[string]*structpb.Value)
-	}
-	node.Metadata.Fields[xdsclient.NodeMetadataHostnameKey] = &structpb.Value{
-		Kind: &structpb.Value_StringValue{StringValue: targetName},
-	}
+	node.ClientFeatures = append(node.ClientFeatures, clientFeatureLRSSendAllClusters)
 
 	req := &lrspb.LoadStatsRequest{Node: node}
 	v2c.logger.Infof("lrs: sending init LoadStatsRequest: %v", req)
 	return stream.Send(req)
 }
 
-func (v2c *client) HandleLoadStatsResponse(s grpc.ClientStream, clusterName string) (time.Duration, error) {
+func (v2c *client) HandleLoadStatsResponse(s grpc.ClientStream) ([]string, time.Duration, error) {
 	stream, ok := s.(lrsStream)
 	if !ok {
-		return 0, fmt.Errorf("lrs: Attempt to receive response on unsupported stream type: %T", s)
+		return nil, 0, fmt.Errorf("lrs: Attempt to receive response on unsupported stream type: %T", s)
 	}
 
 	resp, err := stream.Recv()
 	if err != nil {
-		return 0, fmt.Errorf("lrs: failed to receive first response: %v", err)
+		return nil, 0, fmt.Errorf("lrs: failed to receive first response: %v", err)
 	}
 	v2c.logger.Infof("lrs: received first LoadStatsResponse: %+v", resp)
 
 	interval, err := ptypes.Duration(resp.GetLoadReportingInterval())
 	if err != nil {
-		return 0, fmt.Errorf("lrs: failed to convert report interval: %v", err)
+		return nil, 0, fmt.Errorf("lrs: failed to convert report interval: %v", err)
 	}
 
-	// The LRS client should join the clusters it knows with the cluster
-	// list from response, and send loads for them.
-	//
-	// But the LRS client now only supports one cluster. TODO: extend it to
-	// support multiple clusters.
-	var clusterFoundInResponse bool
-	for _, c := range resp.Clusters {
-		if c == clusterName {
-			clusterFoundInResponse = true
-		}
-	}
-	if !clusterFoundInResponse {
-		return 0, fmt.Errorf("lrs: received clusters %v does not contain expected {%v}", resp.Clusters, clusterName)
-	}
 	if resp.ReportEndpointGranularity {
 		// TODO: fixme to support per endpoint loads.
-		return 0, errors.New("lrs: endpoint loads requested, but not supported by current implementation")
+		return nil, 0, errors.New("lrs: endpoint loads requested, but not supported by current implementation")
 	}
 
-	return interval, nil
+	clusters := resp.Clusters
+	if resp.SendAllClusters {
+		// Return nil to send stats for all clusters.
+		clusters = nil
+	}
+
+	return clusters, interval, nil
 }
 
-func (v2c *client) SendLoadStatsRequest(s grpc.ClientStream, clusterName string) error {
+func (v2c *client) SendLoadStatsRequest(s grpc.ClientStream, loads []*load.Data) error {
 	stream, ok := s.(lrsStream)
 	if !ok {
 		return fmt.Errorf("lrs: Attempt to send request on unsupported stream type: %T", s)
 	}
-	if v2c.loadStore == nil {
-		return errors.New("lrs: LoadStore is not initialized")
-	}
 
 	var clusterStats []*v2endpointpb.ClusterStats
-	sds := v2c.loadStore.Stats([]string{clusterName})
-	for _, sd := range sds {
+	for _, sd := range loads {
 		var (
 			droppedReqs   []*v2endpointpb.ClusterStats_DroppedRequests
 			localityStats []*v2endpointpb.UpstreamLocalityStats

--- a/xds/internal/client/v3/client.go
+++ b/xds/internal/client/v3/client.go
@@ -27,7 +27,6 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/internal/grpclog"
 	xdsclient "google.golang.org/grpc/xds/internal/client"
-	"google.golang.org/grpc/xds/internal/client/load"
 	"google.golang.org/grpc/xds/internal/version"
 
 	v3corepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -67,7 +66,6 @@ func newClient(cc *grpc.ClientConn, opts xdsclient.BuildOptions) (xdsclient.APIC
 		cc:        cc,
 		parent:    opts.Parent,
 		nodeProto: nodeProto,
-		loadStore: opts.LoadStore,
 		logger:    opts.Logger,
 	}
 	v3c.ctx, v3c.cancelCtx = context.WithCancel(context.Background())
@@ -86,7 +84,6 @@ type client struct {
 	ctx       context.Context
 	cancelCtx context.CancelFunc
 	parent    xdsclient.UpdateHandler
-	loadStore *load.Store
 	logger    *grpclog.PrefixLogger
 
 	// ClientConn to the xDS gRPC server. Owned by the parent xdsClient.

--- a/xds/internal/testutils/fakeclient/client.go
+++ b/xds/internal/testutils/fakeclient/client.go
@@ -156,14 +156,12 @@ func (xdsC *Client) WaitForCancelEDSWatch(ctx context.Context) error {
 type ReportLoadArgs struct {
 	// Server is the name of the server to which the load is reported.
 	Server string
-	// Cluster is the name of the cluster for which load is reported.
-	Cluster string
 }
 
 // ReportLoad starts reporting load about clusterName to server.
-func (xdsC *Client) ReportLoad(server string, clusterName string) (cancel func()) {
-	xdsC.loadReportCh.Send(ReportLoadArgs{Server: server, Cluster: clusterName})
-	return func() {}
+func (xdsC *Client) ReportLoad(server string) (loadStore *load.Store, cancel func()) {
+	xdsC.loadReportCh.Send(ReportLoadArgs{Server: server})
+	return xdsC.loadStore, func() {}
 }
 
 // LoadStore returns the underlying load data store.

--- a/xds/internal/testutils/fakeserver/server.go
+++ b/xds/internal/testutils/fakeserver/server.go
@@ -203,10 +203,10 @@ type lrsServer struct {
 
 func (lrsS *lrsServer) StreamLoadStats(s lrsgrpc.LoadReportingService_StreamLoadStatsServer) error {
 	req, err := s.Recv()
+	lrsS.reqChan.Send(&Request{req, err})
 	if err != nil {
 		return err
 	}
-	lrsS.reqChan.Send(&Request{req, err})
 
 	select {
 	case r := <-lrsS.respChan:
@@ -222,12 +222,12 @@ func (lrsS *lrsServer) StreamLoadStats(s lrsgrpc.LoadReportingService_StreamLoad
 
 	for {
 		req, err := s.Recv()
+		lrsS.reqChan.Send(&Request{req, err})
 		if err != nil {
 			if err == io.EOF {
 				return nil
 			}
 			return err
 		}
-		lrsS.reqChan.Send(&Request{req, err})
 	}
 }


### PR DESCRIPTION
- xdsclient.ReportLoad
  - create one LRS stream and one load.Store for each server address
  - to take just the server address, and return the load.Store
  - update EDS and LRS balancing policy to recreate LRS stream only when server address changes
- LRS stream (v2 and v3)
  - set feature `send_all_clusters` in `node`
  - handle `resp.Clusters` and only send load for those clusters
  - handle `resp.SendAllClusters` and send load for all clusters