### PR TITLE
xdsClient: change WatchRDS to return all virtual hosts

### DIFF
--- a/xds/internal/client/client.go
+++ b/xds/internal/client/client.go
@@ -149,6 +149,15 @@ type ListenerUpdate struct {
 // RouteConfigUpdate contains information received in an RDS response, which is
 // of interest to the registered RDS watcher.
 type RouteConfigUpdate struct {
+	VirtualHosts []*VirtualHost
+}
+
+// VirtualHost contains the routes for a list of Domains.
+//
+// Note that the domains in this slice can be a wildcard, not an exact string.
+// The consumer of this struct needs to find the best match for its hostname.
+type VirtualHost struct {
+	Domains []string
 	// Routes contains a list of routes, each containing matchers and
 	// corresponding action.
 	Routes []*Route

--- a/xds/internal/client/client_watchers_rds_test.go
+++ b/xds/internal/client/client_watchers_rds_test.go
@@ -62,7 +62,14 @@ func (s) TestRDSWatch(t *testing.T) {
 		t.Fatalf("want new watch to start, got error %v", err)
 	}
 
-	wantUpdate := RouteConfigUpdate{Routes: []*Route{{Prefix: newStringP(""), Action: map[string]uint32{testCDSName: 1}}}}
+	wantUpdate := RouteConfigUpdate{
+		VirtualHosts: []*VirtualHost{
+			{
+				Domains: []string{testLDSName},
+				Routes:  []*Route{{Prefix: newStringP(""), Action: map[string]uint32{testCDSName: 1}}},
+			},
+		},
+	}
 	client.NewRouteConfigs(map[string]RouteConfigUpdate{testRDSName: wantUpdate})
 	if err := verifyRouteConfigUpdate(ctx, rdsUpdateCh, wantUpdate); err != nil {
 		t.Fatal(err)
@@ -127,7 +134,14 @@ func (s) TestRDSTwoWatchSameResourceName(t *testing.T) {
 		}
 	}
 
-	wantUpdate := RouteConfigUpdate{Routes: []*Route{{Prefix: newStringP(""), Action: map[string]uint32{testCDSName: 1}}}}
+	wantUpdate := RouteConfigUpdate{
+		VirtualHosts: []*VirtualHost{
+			{
+				Domains: []string{testLDSName},
+				Routes:  []*Route{{Prefix: newStringP(""), Action: map[string]uint32{testCDSName: 1}}},
+			},
+		},
+	}
 	client.NewRouteConfigs(map[string]RouteConfigUpdate{testRDSName: wantUpdate})
 	for i := 0; i < count; i++ {
 		if err := verifyRouteConfigUpdate(ctx, rdsUpdateChs[i], wantUpdate); err != nil {
@@ -199,8 +213,22 @@ func (s) TestRDSThreeWatchDifferentResourceName(t *testing.T) {
 		t.Fatalf("want new watch to start, got error %v", err)
 	}
 
-	wantUpdate1 := RouteConfigUpdate{Routes: []*Route{{Prefix: newStringP(""), Action: map[string]uint32{testCDSName + "1": 1}}}}
-	wantUpdate2 := RouteConfigUpdate{Routes: []*Route{{Prefix: newStringP(""), Action: map[string]uint32{testCDSName + "2": 1}}}}
+	wantUpdate1 := RouteConfigUpdate{
+		VirtualHosts: []*VirtualHost{
+			{
+				Domains: []string{testLDSName},
+				Routes:  []*Route{{Prefix: newStringP(""), Action: map[string]uint32{testCDSName + "1": 1}}},
+			},
+		},
+	}
+	wantUpdate2 := RouteConfigUpdate{
+		VirtualHosts: []*VirtualHost{
+			{
+				Domains: []string{testLDSName},
+				Routes:  []*Route{{Prefix: newStringP(""), Action: map[string]uint32{testCDSName + "2": 1}}},
+			},
+		},
+	}
 	client.NewRouteConfigs(map[string]RouteConfigUpdate{
 		testRDSName + "1": wantUpdate1,
 		testRDSName + "2": wantUpdate2,
@@ -244,7 +272,14 @@ func (s) TestRDSWatchAfterCache(t *testing.T) {
 		t.Fatalf("want new watch to start, got error %v", err)
 	}
 
-	wantUpdate := RouteConfigUpdate{Routes: []*Route{{Prefix: newStringP(""), Action: map[string]uint32{testCDSName: 1}}}}
+	wantUpdate := RouteConfigUpdate{
+		VirtualHosts: []*VirtualHost{
+			{
+				Domains: []string{testLDSName},
+				Routes:  []*Route{{Prefix: newStringP(""), Action: map[string]uint32{testCDSName: 1}}},
+			},
+		},
+	}
 	client.NewRouteConfigs(map[string]RouteConfigUpdate{testRDSName: wantUpdate})
 	if err := verifyRouteConfigUpdate(ctx, rdsUpdateCh, wantUpdate); err != nil {
 		t.Fatal(err)

--- a/xds/internal/client/client_watchers_service_test.go
+++ b/xds/internal/client/client_watchers_service_test.go
@@ -67,7 +67,14 @@ func (s) TestServiceWatch(t *testing.T) {
 		t.Fatalf("want new watch to start, got error %v", err)
 	}
 	client.NewRouteConfigs(map[string]RouteConfigUpdate{
-		testRDSName: {Routes: []*Route{{Prefix: newStringP(""), Action: map[string]uint32{testCDSName: 1}}}},
+		testRDSName: {
+			VirtualHosts: []*VirtualHost{
+				{
+					Domains: []string{testLDSName},
+					Routes:  []*Route{{Prefix: newStringP(""), Action: map[string]uint32{testCDSName: 1}}},
+				},
+			},
+		},
 	})
 	if err := verifyServiceUpdate(ctx, serviceUpdateCh, wantUpdate); err != nil {
 		t.Fatal(err)
@@ -81,10 +88,12 @@ func (s) TestServiceWatch(t *testing.T) {
 	}
 	client.NewRouteConfigs(map[string]RouteConfigUpdate{
 		testRDSName: {
-			Routes: []*Route{{
-				Prefix: newStringP(""),
-				Action: map[string]uint32{testCDSName: 1},
-			}},
+			VirtualHosts: []*VirtualHost{
+				{
+					Domains: []string{testLDSName},
+					Routes:  []*Route{{Prefix: newStringP(""), Action: map[string]uint32{testCDSName: 1}}},
+				},
+			},
 		},
 	})
 	if err := verifyServiceUpdate(ctx, serviceUpdateCh, wantUpdate2); err != nil {
@@ -127,7 +136,14 @@ func (s) TestServiceWatchLDSUpdate(t *testing.T) {
 		t.Fatalf("want new watch to start, got error %v", err)
 	}
 	client.NewRouteConfigs(map[string]RouteConfigUpdate{
-		testRDSName: {Routes: []*Route{{Prefix: newStringP(""), Action: map[string]uint32{testCDSName: 1}}}},
+		testRDSName: {
+			VirtualHosts: []*VirtualHost{
+				{
+					Domains: []string{testLDSName},
+					Routes:  []*Route{{Prefix: newStringP(""), Action: map[string]uint32{testCDSName: 1}}},
+				},
+			},
+		},
 	})
 	if err := verifyServiceUpdate(ctx, serviceUpdateCh, wantUpdate); err != nil {
 		t.Fatal(err)
@@ -141,7 +157,14 @@ func (s) TestServiceWatchLDSUpdate(t *testing.T) {
 
 	// Another update for the old name.
 	client.NewRouteConfigs(map[string]RouteConfigUpdate{
-		testRDSName: {Routes: []*Route{{Prefix: newStringP(""), Action: map[string]uint32{testCDSName: 1}}}},
+		testRDSName: {
+			VirtualHosts: []*VirtualHost{
+				{
+					Domains: []string{testLDSName},
+					Routes:  []*Route{{Prefix: newStringP(""), Action: map[string]uint32{testCDSName: 1}}},
+				},
+			},
+		},
 	})
 	sCtx, sCancel := context.WithTimeout(ctx, defaultTestShortTimeout)
 	defer sCancel()
@@ -152,7 +175,14 @@ func (s) TestServiceWatchLDSUpdate(t *testing.T) {
 	// RDS update for the new name.
 	wantUpdate2 := ServiceUpdate{Routes: []*Route{{Prefix: newStringP(""), Action: map[string]uint32{testCDSName + "2": 1}}}}
 	client.NewRouteConfigs(map[string]RouteConfigUpdate{
-		testRDSName + "2": {Routes: []*Route{{Prefix: newStringP(""), Action: map[string]uint32{testCDSName + "2": 1}}}},
+		testRDSName + "2": {
+			VirtualHosts: []*VirtualHost{
+				{
+					Domains: []string{testLDSName},
+					Routes:  []*Route{{Prefix: newStringP(""), Action: map[string]uint32{testCDSName + "2": 1}}},
+				},
+			},
+		},
 	})
 	if err := verifyServiceUpdate(ctx, serviceUpdateCh, wantUpdate2); err != nil {
 		t.Fatal(err)
@@ -194,7 +224,14 @@ func (s) TestServiceWatchSecond(t *testing.T) {
 		t.Fatalf("want new watch to start, got error %v", err)
 	}
 	client.NewRouteConfigs(map[string]RouteConfigUpdate{
-		testRDSName: {Routes: []*Route{{Prefix: newStringP(""), Action: map[string]uint32{testCDSName: 1}}}},
+		testRDSName: {
+			VirtualHosts: []*VirtualHost{
+				{
+					Domains: []string{testLDSName},
+					Routes:  []*Route{{Prefix: newStringP(""), Action: map[string]uint32{testCDSName: 1}}},
+				},
+			},
+		},
 	})
 	if err := verifyServiceUpdate(ctx, serviceUpdateCh, wantUpdate); err != nil {
 		t.Fatal(err)
@@ -221,7 +258,14 @@ func (s) TestServiceWatchSecond(t *testing.T) {
 	// timeout.
 	client.NewListeners(map[string]ListenerUpdate{testLDSName: {RouteConfigName: testRDSName}})
 	client.NewRouteConfigs(map[string]RouteConfigUpdate{
-		testRDSName: {Routes: []*Route{{Prefix: newStringP(""), Action: map[string]uint32{testCDSName: 1}}}},
+		testRDSName: {
+			VirtualHosts: []*VirtualHost{
+				{
+					Domains: []string{testLDSName},
+					Routes:  []*Route{{Prefix: newStringP(""), Action: map[string]uint32{testCDSName: 1}}},
+				},
+			},
+		},
 	})
 	if err := verifyServiceUpdate(ctx, serviceUpdateCh, wantUpdate); err != nil {
 		t.Fatal(err)
@@ -396,7 +440,14 @@ func (s) TestServiceNotCancelRDSOnSameLDSUpdate(t *testing.T) {
 		t.Fatalf("want new watch to start, got error %v", err)
 	}
 	client.NewRouteConfigs(map[string]RouteConfigUpdate{
-		testRDSName: {Routes: []*Route{{Prefix: newStringP(""), Action: map[string]uint32{testCDSName: 1}}}},
+		testRDSName: {
+			VirtualHosts: []*VirtualHost{
+				{
+					Domains: []string{testLDSName},
+					Routes:  []*Route{{Prefix: newStringP(""), Action: map[string]uint32{testCDSName: 1}}},
+				},
+			},
+		},
 	})
 
 	wantUpdate := ServiceUpdate{Routes: []*Route{{Prefix: newStringP(""), Action: map[string]uint32{testCDSName: 1}}}}
@@ -449,7 +500,14 @@ func (s) TestServiceResourceRemoved(t *testing.T) {
 		t.Fatalf("want new watch to start, got error %v", err)
 	}
 	client.NewRouteConfigs(map[string]RouteConfigUpdate{
-		testRDSName: {Routes: []*Route{{Prefix: newStringP(""), Action: map[string]uint32{testCDSName: 1}}}},
+		testRDSName: {
+			VirtualHosts: []*VirtualHost{
+				{
+					Domains: []string{testLDSName},
+					Routes:  []*Route{{Prefix: newStringP(""), Action: map[string]uint32{testCDSName: 1}}},
+				},
+			},
+		},
 	})
 	wantUpdate := ServiceUpdate{Routes: []*Route{{Prefix: newStringP(""), Action: map[string]uint32{testCDSName: 1}}}}
 	if err := verifyServiceUpdate(ctx, serviceUpdateCh, wantUpdate); err != nil {
@@ -469,7 +527,14 @@ func (s) TestServiceResourceRemoved(t *testing.T) {
 	// Send RDS update for the removed LDS resource, expect no updates to
 	// callback, because RDS should be canceled.
 	client.NewRouteConfigs(map[string]RouteConfigUpdate{
-		testRDSName: {Routes: []*Route{{Prefix: newStringP(""), Action: map[string]uint32{testCDSName + "new": 1}}}},
+		testRDSName: {
+			VirtualHosts: []*VirtualHost{
+				{
+					Domains: []string{testLDSName},
+					Routes:  []*Route{{Prefix: newStringP(""), Action: map[string]uint32{testCDSName + "new": 1}}},
+				},
+			},
+		},
 	})
 	sCtx, sCancel := context.WithTimeout(ctx, defaultTestShortTimeout)
 	defer sCancel()
@@ -491,7 +556,14 @@ func (s) TestServiceResourceRemoved(t *testing.T) {
 	}
 
 	client.NewRouteConfigs(map[string]RouteConfigUpdate{
-		testRDSName: {Routes: []*Route{{Prefix: newStringP(""), Action: map[string]uint32{testCDSName + "new2": 1}}}},
+		testRDSName: {
+			VirtualHosts: []*VirtualHost{
+				{
+					Domains: []string{testLDSName},
+					Routes:  []*Route{{Prefix: newStringP(""), Action: map[string]uint32{testCDSName + "new2": 1}}},
+				},
+			},
+		},
 	})
 	wantUpdate = ServiceUpdate{Routes: []*Route{{Prefix: newStringP(""), Action: map[string]uint32{testCDSName + "new2": 1}}}}
 	if err := verifyServiceUpdate(ctx, serviceUpdateCh, wantUpdate); err != nil {

--- a/xds/internal/client/v2/client.go
+++ b/xds/internal/client/v2/client.go
@@ -22,7 +22,6 @@ package v2
 import (
 	"context"
 	"fmt"
-	"sync"
 
 	"github.com/golang/protobuf/proto"
 	"google.golang.org/grpc"
@@ -93,54 +92,6 @@ type client struct {
 	// ClientConn to the xDS gRPC server. Owned by the parent xdsClient.
 	cc        *grpc.ClientConn
 	nodeProto *v2corepb.Node
-
-	mu sync.Mutex
-	// ldsResourceName is the LDS resource_name to watch. It is set to the first
-	// LDS resource_name to watch, and removed when the LDS watch is canceled.
-	//
-	// It's from the dial target of the parent ClientConn. RDS resource
-	// processing needs this to do the host matching.
-	ldsResourceName string
-	ldsWatchCount   int
-}
-
-// AddWatch overrides the transport helper's AddWatch to save the LDS
-// resource_name. This is required when handling an RDS response to perform host
-// matching.
-func (v2c *client) AddWatch(rType xdsclient.ResourceType, rName string) {
-	v2c.mu.Lock()
-	// Special handling for LDS, because RDS needs the LDS resource_name for
-	// response host matching.
-	if rType == xdsclient.ListenerResource {
-		// Set hostname to the first LDS resource_name, and reset it when the
-		// last LDS watch is removed. The upper level Client isn't expected to
-		// watchLDS more than once.
-		v2c.ldsWatchCount++
-		if v2c.ldsWatchCount == 1 {
-			v2c.ldsResourceName = rName
-		}
-	}
-	v2c.mu.Unlock()
-	v2c.TransportHelper.AddWatch(rType, rName)
-}
-
-// RemoveWatch overrides the transport helper's RemoveWatch to clear the LDS
-// resource_name when the last watch is removed.
-func (v2c *client) RemoveWatch(rType xdsclient.ResourceType, rName string) {
-	v2c.mu.Lock()
-	// Special handling for LDS, because RDS needs the LDS resource_name for
-	// response host matching.
-	if rType == xdsclient.ListenerResource {
-		// Set hostname to the first LDS resource_name, and reset it when the
-		// last LDS watch is removed. The upper level Client isn't expected to
-		// watchLDS more than once.
-		v2c.ldsWatchCount--
-		if v2c.ldsWatchCount == 0 {
-			v2c.ldsResourceName = ""
-		}
-	}
-	v2c.mu.Unlock()
-	v2c.TransportHelper.RemoveWatch(rType, rName)
 }
 
 func (v2c *client) NewStream(ctx context.Context) (grpc.ClientStream, error) {
@@ -242,11 +193,7 @@ func (v2c *client) handleLDSResponse(resp *v2xdspb.DiscoveryResponse) error {
 // receipt of a good response, it caches validated resources and also invokes
 // the registered watcher callback.
 func (v2c *client) handleRDSResponse(resp *v2xdspb.DiscoveryResponse) error {
-	v2c.mu.Lock()
-	hostname := v2c.ldsResourceName
-	v2c.mu.Unlock()
-
-	update, err := xdsclient.UnmarshalRouteConfig(resp.GetResources(), hostname, v2c.logger)
+	update, err := xdsclient.UnmarshalRouteConfig(resp.GetResources(), v2c.logger)
 	if err != nil {
 		return err
 	}

--- a/xds/internal/client/v2/client_test.go
+++ b/xds/internal/client/v2/client_test.go
@@ -236,15 +236,15 @@ var (
 		},
 		TypeUrl: version.V2RouteConfigURL,
 	}
-	emptyRouteConfig = &xdspb.RouteConfiguration{
+	noVirtualHostsRouteConfig = &xdspb.RouteConfiguration{
 		Name: goodRouteName1,
 	}
-	marshaledEmptyRouteConfig, _ = proto.Marshal(emptyRouteConfig)
-	noVirtualHostsInRDSResponse  = &xdspb.DiscoveryResponse{
+	marshaledNoVirtualHostsRouteConfig, _ = proto.Marshal(noVirtualHostsRouteConfig)
+	noVirtualHostsInRDSResponse           = &xdspb.DiscoveryResponse{
 		Resources: []*anypb.Any{
 			{
 				TypeUrl: version.V2RouteConfigURL,
-				Value:   marshaledEmptyRouteConfig,
+				Value:   marshaledNoVirtualHostsRouteConfig,
 			},
 		},
 		TypeUrl: version.V2RouteConfigURL,

--- a/xds/internal/client/v2/client_test.go
+++ b/xds/internal/client/v2/client_test.go
@@ -236,7 +236,9 @@ var (
 		},
 		TypeUrl: version.V2RouteConfigURL,
 	}
-	emptyRouteConfig             = &xdspb.RouteConfiguration{}
+	emptyRouteConfig = &xdspb.RouteConfiguration{
+		Name: goodRouteName1,
+	}
 	marshaledEmptyRouteConfig, _ = proto.Marshal(emptyRouteConfig)
 	noVirtualHostsInRDSResponse  = &xdspb.DiscoveryResponse{
 		Resources: []*anypb.Any{
@@ -410,11 +412,6 @@ func testWatchHandle(t *testing.T, test *watchHandleTestcase) {
 		t.Fatal(err)
 	}
 	defer v2c.Close()
-
-	// RDS needs an existing LDS watch for the hostname.
-	if test.rType == xdsclient.RouteConfigResource {
-		doLDS(t, v2c, fakeServer)
-	}
 
 	// Register the watcher, this will also trigger the v2Client to send the xDS
 	// request.


### PR DESCRIPTION
Instead of finding the best matching domain for the service, and return only
that one virtual host's routes.

This removes the lds request name from the xds client, and makes it xds client
handle multiple RDS watches, so one xds client can be shared by multiple
ClientConns.

This also removes some response validation from the client (e.g. if no virtual
host matches what the client is asking for, the response won't be nack'ed).