### PR TITLE
xds: CDS balancer security integration.

### DIFF
--- a/credentials/tls/certprovider/store.go
+++ b/credentials/tls/certprovider/store.go
@@ -80,9 +80,19 @@ func GetProvider(name string, config interface{}, opts Options) (Provider, error
 	if builder == nil {
 		return nil, fmt.Errorf("no registered builder for provider name: %s", name)
 	}
-	stableConfig, err := builder.ParseConfig(config)
-	if err != nil {
-		return nil, err
+
+	var (
+		stableConfig StableConfig
+		err          error
+	)
+	if c, ok := config.(StableConfig); ok {
+		// The config passed to the store has already been parsed.
+		stableConfig = c
+	} else {
+		stableConfig, err = builder.ParseConfig(config)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	sk := storeKey{

--- a/credentials/xds/xds.go
+++ b/credentials/xds/xds.go
@@ -43,7 +43,7 @@ import (
 )
 
 func init() {
-	internal.GetXDSHandshakeInfo = getHandshakeInfo
+	internal.GetXDSHandshakeInfoForTesting = getHandshakeInfo
 }
 
 // ClientOptions contains parameters to configure a new client-side xDS

--- a/credentials/xds/xds.go
+++ b/credentials/xds/xds.go
@@ -142,10 +142,6 @@ func (hi *HandshakeInfo) UseFallbackCreds() bool {
 }
 
 func (hi *HandshakeInfo) validate(isClient bool) error {
-	if hi == nil {
-		return nil
-	}
-
 	hi.mu.Lock()
 	defer hi.mu.Unlock()
 
@@ -266,11 +262,11 @@ func (c *credsImpl) ClientHandshake(ctx context.Context, authority string, rawCo
 		return c.fallback.ClientHandshake(ctx, authority, rawConn)
 	}
 	hi := getHandshakeInfo(chi.Attributes)
-	if err := hi.validate(c.isClient); err != nil {
-		return nil, nil, err
-	}
 	if hi.UseFallbackCreds() {
 		return c.fallback.ClientHandshake(ctx, authority, rawConn)
+	}
+	if err := hi.validate(c.isClient); err != nil {
+		return nil, nil, err
 	}
 
 	// We build the tls.Config with the following values

--- a/credentials/xds/xds.go
+++ b/credentials/xds/xds.go
@@ -361,12 +361,8 @@ func (c *credsImpl) OverrideServerName(_ string) error {
 	return errors.New("serverName for peer validation must be configured as a list of acceptable SANs")
 }
 
-// CredentialsUsesXDS returns true if c uses xDS to fetch security configuration
+// UsesXDS returns true if c uses xDS to fetch security configuration
 // used at handshake time, and false otherwise.
-func CredentialsUsesXDS(c credentials.TransportCredentials) bool {
-	if c == nil {
-		return false
-	}
-	_, ok := c.(*credsImpl)
-	return ok
+func (c *credsImpl) UsesXDS() bool {
+	return true
 }

--- a/credentials/xds/xds.go
+++ b/credentials/xds/xds.go
@@ -37,9 +37,14 @@ import (
 	"google.golang.org/grpc/attributes"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/tls/certprovider"
+	"google.golang.org/grpc/internal"
 	credinternal "google.golang.org/grpc/internal/credentials"
 	"google.golang.org/grpc/resolver"
 )
+
+func init() {
+	internal.GetXDSHandshakeInfo = getHandshakeInfo
+}
 
 // ClientOptions contains parameters to configure a new client-side xDS
 // credentials implementation.
@@ -81,10 +86,8 @@ func SetHandshakeInfo(addr resolver.Address, hInfo *HandshakeInfo) resolver.Addr
 	return addr
 }
 
-// GetHandshakeInfo returns a pointer to the HandshakeInfo stored in attr.
-//
-// Outside of this package, this function is meant only to be used for testing.
-func GetHandshakeInfo(attr *attributes.Attributes) *HandshakeInfo {
+// getHandshakeInfo returns a pointer to the HandshakeInfo stored in attr.
+func getHandshakeInfo(attr *attributes.Attributes) *HandshakeInfo {
 	v := attr.Value(handshakeAttrKey{})
 	hi, _ := v.(*HandshakeInfo)
 	return hi
@@ -246,7 +249,7 @@ func (c *credsImpl) ClientHandshake(ctx context.Context, authority string, rawCo
 	if chi.Attributes == nil {
 		return c.fallback.ClientHandshake(ctx, authority, rawConn)
 	}
-	hi := GetHandshakeInfo(chi.Attributes)
+	hi := getHandshakeInfo(chi.Attributes)
 	if hi == nil {
 		return c.fallback.ClientHandshake(ctx, authority, rawConn)
 	}

--- a/credentials/xds/xds.go
+++ b/credentials/xds/xds.go
@@ -81,8 +81,10 @@ func SetHandshakeInfo(addr resolver.Address, hInfo *HandshakeInfo) resolver.Addr
 	return addr
 }
 
-// getHandshakeInfo returns a pointer to the HandshakeInfo stored in attr.
-func getHandshakeInfo(attr *attributes.Attributes) *HandshakeInfo {
+// GetHandshakeInfo returns a pointer to the HandshakeInfo stored in attr.
+//
+// Outside of this package, this function is meant only to be used for testing.
+func GetHandshakeInfo(attr *attributes.Attributes) *HandshakeInfo {
 	v := attr.Value(handshakeAttrKey{})
 	hi, _ := v.(*HandshakeInfo)
 	return hi
@@ -244,7 +246,7 @@ func (c *credsImpl) ClientHandshake(ctx context.Context, authority string, rawCo
 	if chi.Attributes == nil {
 		return c.fallback.ClientHandshake(ctx, authority, rawConn)
 	}
-	hi := getHandshakeInfo(chi.Attributes)
+	hi := GetHandshakeInfo(chi.Attributes)
 	if hi == nil {
 		return c.fallback.ClientHandshake(ctx, authority, rawConn)
 	}
@@ -354,4 +356,14 @@ func (c *credsImpl) Clone() credentials.TransportCredentials {
 
 func (c *credsImpl) OverrideServerName(_ string) error {
 	return errors.New("serverName for peer validation must be configured as a list of acceptable SANs")
+}
+
+// CredentialsUsesXDS returns true if c uses xDS to fetch security configuration
+// used at handshake time, and false otherwise.
+func CredentialsUsesXDS(c credentials.TransportCredentials) bool {
+	if c == nil {
+		return false
+	}
+	_, ok := c.(*credsImpl)
+	return ok
 }

--- a/credentials/xds/xds.go
+++ b/credentials/xds/xds.go
@@ -129,6 +129,8 @@ func (hi *HandshakeInfo) SetAcceptedSANs(sans []string) {
 	hi.mu.Unlock()
 }
 
+// UseFallbackCreds returns true when fallback credentials are to be used based
+// on the contents of the HandshakeInfo.
 func (hi *HandshakeInfo) UseFallbackCreds() bool {
 	if hi == nil {
 		return true

--- a/credentials/xds/xds_test.go
+++ b/credentials/xds/xds_test.go
@@ -303,12 +303,7 @@ func (s) TestClientCredsInvalidHandshakeInfo(t *testing.T) {
 
 	pCtx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
-	ctx := newTestContextWithHandshakeInfo(pCtx, nil, nil)
-	if _, _, err := creds.ClientHandshake(ctx, authority, nil); err == nil {
-		t.Fatal("ClientHandshake succeeded without certificate providers in HandshakeInfo")
-	}
-
-	ctx = newTestContextWithHandshakeInfo(pCtx, nil, &fakeProvider{})
+	ctx := newTestContextWithHandshakeInfo(pCtx, nil, &fakeProvider{})
 	if _, _, err := creds.ClientHandshake(ctx, authority, nil); err == nil {
 		t.Fatal("ClientHandshake succeeded without root certificate provider in HandshakeInfo")
 	}

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -57,6 +57,9 @@ var (
 	// bootstrap code while parsing certificate provider configs in the
 	// bootstrap file.
 	GetCertificateProviderBuilder interface{} // func(string) certprovider.Builder
+	// GetXDSHandshakeInfo returns a pointer to the xds.HandshakeInfo stored in
+	// the passed in attributes. This is set by credentials/xds/xds.go.
+	GetXDSHandshakeInfo interface{} // func (attr *attributes.Attributes) *xds.HandshakeInfo
 )
 
 // HealthChecker defines the signature of the client-side LB channel health checking function.

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -57,9 +57,10 @@ var (
 	// bootstrap code while parsing certificate provider configs in the
 	// bootstrap file.
 	GetCertificateProviderBuilder interface{} // func(string) certprovider.Builder
-	// GetXDSHandshakeInfo returns a pointer to the xds.HandshakeInfo stored in
-	// the passed in attributes. This is set by credentials/xds/xds.go.
-	GetXDSHandshakeInfo interface{} // func (attr *attributes.Attributes) *xds.HandshakeInfo
+	// GetXDSHandshakeInfoForTesting returns a pointer to the xds.HandshakeInfo
+	// stored in the passed in attributes. This is set by
+	// credentials/xds/xds.go.
+	GetXDSHandshakeInfoForTesting interface{} // func (attr *attributes.Attributes) *xds.HandshakeInfo
 )
 
 // HealthChecker defines the signature of the client-side LB channel health checking function.

--- a/xds/internal/balancer/cdsbalancer/cdsbalancer.go
+++ b/xds/internal/balancer/cdsbalancer/cdsbalancer.go
@@ -63,9 +63,7 @@ var (
 		return builder.Build(cc, opts), nil
 	}
 
-	getProviderFunc = func(name string, cfg interface{}, opts certprovider.Options) (certprovider.Provider, error) {
-		return certprovider.GetProvider(name, cfg, opts)
-	}
+	getProvider = certprovider.GetProvider
 )
 
 func init() {
@@ -251,7 +249,7 @@ func (b *cdsBalancer) handleSecurityConfig(config *xdsclient.SecurityConfig) err
 	if !ok {
 		return fmt.Errorf("certificate provider instance %q not found in bootstrap file", config.RootInstanceName)
 	}
-	rootProvider, err := getProviderFunc(rootCfg.Name, rootCfg.Config, certprovider.Options{
+	rootProvider, err := getProvider(rootCfg.Name, rootCfg.Config, certprovider.Options{
 		CertName: config.RootCertName,
 		WantRoot: true,
 	})
@@ -260,7 +258,7 @@ func (b *cdsBalancer) handleSecurityConfig(config *xdsclient.SecurityConfig) err
 		// config and makes sure that it is acceptable to the plugin. Still, it
 		// is possible that the plugin parses the config successfully, but its
 		// Build() method errors out.
-		return fmt.Errorf("xds: failed to get plugin instance (%+v): %v", rootCfg, err)
+		return fmt.Errorf("xds: failed to get security plugin instance (%+v): %v", rootCfg, err)
 	}
 	if b.cachedRoot != nil {
 		b.cachedRoot.Close()
@@ -274,7 +272,7 @@ func (b *cdsBalancer) handleSecurityConfig(config *xdsclient.SecurityConfig) err
 		if !ok {
 			return fmt.Errorf("certificate provider instance %q not found in bootstrap file", config.IdentityInstanceName)
 		}
-		identityProvider, err = getProviderFunc(identityCfg.Name, identityCfg.Config, certprovider.Options{
+		identityProvider, err = getProvider(identityCfg.Name, identityCfg.Config, certprovider.Options{
 			CertName:     config.IdentityCertName,
 			WantIdentity: true,
 		})
@@ -283,7 +281,7 @@ func (b *cdsBalancer) handleSecurityConfig(config *xdsclient.SecurityConfig) err
 			// config and makes sure that it is acceptable to the plugin. Still,
 			// it is possible that the plugin parses the config successfully,
 			// but its Build() method errors out.
-			return fmt.Errorf("xds: failed to get plugin instance (%+v): %v", identityCfg, err)
+			return fmt.Errorf("xds: failed to get security plugin instance (%+v): %v", identityCfg, err)
 		}
 	}
 	if b.cachedIdentity != nil {

--- a/xds/internal/balancer/cdsbalancer/cdsbalancer.go
+++ b/xds/internal/balancer/cdsbalancer/cdsbalancer.go
@@ -538,3 +538,6 @@ func (ccw *ccWrapper) setHandshakeInfo(hi *xds.HandshakeInfo) {
 	ccw.xdsHI = hi
 	ccw.mu.Unlock()
 }
+
+// TODO(easwars): Look into whether the cdsBalancer also needs to wrap the
+// SubConn interface and add attributes to addresses in UpdateAddresses() call.

--- a/xds/internal/balancer/cdsbalancer/cdsbalancer.go
+++ b/xds/internal/balancer/cdsbalancer/cdsbalancer.go
@@ -189,8 +189,8 @@ type cdsBalancer struct {
 // cancellation of existing watch and propagation of the same error to the
 // edsBalancer.
 func (b *cdsBalancer) handleClientConnUpdate(update *ccUpdate) {
-	// We first handle errors, if any, and then proceed with handling
-	// the update, only if the status quo has changed.
+	// We first handle errors, if any, and then proceed with handling the
+	// update, only if the status quo has changed.
 	if err := update.err; err != nil {
 		b.handleErrorFromUpdate(err, true)
 	}
@@ -198,9 +198,9 @@ func (b *cdsBalancer) handleClientConnUpdate(update *ccUpdate) {
 		return
 	}
 	if update.client != nil {
-		// Since the cdsBalancer doesn't own the xdsClient object, we
-		// don't have to bother about closing the old client here, but
-		// we still need to cancel the watch on the old client.
+		// Since the cdsBalancer doesn't own the xdsClient object, we don't have
+		// to bother about closing the old client here, but we still need to
+		// cancel the watch on the old client.
 		b.cancelWatch()
 		b.xdsClient = update.client
 	}
@@ -227,26 +227,23 @@ func (b *cdsBalancer) handleWatchUpdate(update *watchUpdate) {
 
 	b.logger.Infof("Watch update from xds-client %p, content: %+v", b.xdsClient, update.cds)
 
-	// We process the security config from the received update
-	// before building the child policy or forwarding the update to
-	// it. The reason for doing this is because there is no
-	// guarantee that the child policy will try to create a new
-	// subConn inline. Processing the security configuration here
-	// and setting up the handshakeInfo will make sure that we
-	// handle such attempts to create new subConns properly.
+	// Process the security config from the received update before building the
+	// child policy or forwarding the update to it. We do this because the child
+	// policy may try to create a new subConn inline. Processing the security
+	// configuration here and setting up the handshakeInfo will make sure that
+	// such attempts are handled properly.
 	if err := b.ccw.handleSecurityConfig(update.cds.SecurityCfg); err != nil {
-		// If the security config is invalid, for example, if the
-		// provider instance is not found in the bootstrap config,
-		// we need to put the channel in transient failure. Calling
-		// handleErrorFromUpdate() takes care of that.
+		// If the security config is invalid, for example, if the provider
+		// instance is not found in the bootstrap config, we need to put the
+		// channel in transient failure.
 		b.logger.Warningf("Invalid security config update from xds-client %p: %v", b.xdsClient, err)
 		b.handleErrorFromUpdate(err, false)
 		return
 	}
 
-	// The first good update from the watch API leads to the
-	// instantiation of an edsBalancer. Further updates/errors are
-	// propagated to the existing edsBalancer.
+	// The first good update from the watch API leads to the instantiation of an
+	// edsBalancer. Further updates/errors are propagated to the existing
+	// edsBalancer.
 	if b.edsLB == nil {
 		edsLB, err := newEDSBalancer(b.ccw, b.bOpts)
 		if err != nil {
@@ -258,9 +255,9 @@ func (b *cdsBalancer) handleWatchUpdate(update *watchUpdate) {
 	}
 	lbCfg := &edsbalancer.EDSConfig{EDSServiceName: update.cds.ServiceName}
 	if update.cds.EnableLRS {
-		// An empty string here indicates that the edsBalancer
-		// should use the same xDS server for load reporting as
-		// it does for EDS requests/responses.
+		// An empty string here indicates that the edsBalancer should use the
+		// same xDS server for load reporting as it does for EDS
+		// requests/responses.
 		lbCfg.LrsLoadReportingServerName = new(string)
 
 	}
@@ -438,9 +435,9 @@ type ccWrapper struct {
 	cachedIdentity certprovider.Provider
 }
 
-// NewSubConn handles intercepts attempts create a new SubConn from the child
-// policy and adds an address attribute which provides all information required
-// by the xdsCreds handshaker to perform the TLS handshake.
+// NewSubConn intercepts NewSubConn() calls from the child policy and adds an
+// address attribute which provides all information required by the xdsCreds
+// handshaker to perform the TLS handshake.
 func (ccw *ccWrapper) NewSubConn(addrs []resolver.Address, opts balancer.NewSubConnOptions) (balancer.SubConn, error) {
 	ccw.mu.Lock()
 	defer ccw.mu.Unlock()

--- a/xds/internal/balancer/cdsbalancer/cdsbalancer.go
+++ b/xds/internal/balancer/cdsbalancer/cdsbalancer.go
@@ -528,6 +528,3 @@ func (ccw *ccWrapper) NewSubConn(addrs []resolver.Address, opts balancer.NewSubC
 	}
 	return ccw.ClientConn.NewSubConn(newAddrs, opts)
 }
-
-// TODO(easwars): Look into whether the cdsBalancer also needs to wrap the
-// SubConn interface and add attributes to addresses in UpdateAddresses() call.

--- a/xds/internal/balancer/cdsbalancer/cdsbalancer_security_test.go
+++ b/xds/internal/balancer/cdsbalancer/cdsbalancer_security_test.go
@@ -22,10 +22,12 @@ import (
 	"fmt"
 	"testing"
 
+	"google.golang.org/grpc/attributes"
 	"google.golang.org/grpc/balancer"
 	"google.golang.org/grpc/credentials/local"
 	"google.golang.org/grpc/credentials/tls/certprovider"
 	"google.golang.org/grpc/credentials/xds"
+	"google.golang.org/grpc/internal"
 	"google.golang.org/grpc/internal/testutils"
 	"google.golang.org/grpc/resolver"
 	xdsclient "google.golang.org/grpc/xds/internal/client"
@@ -203,7 +205,8 @@ func makeNewSubConn(ctx context.Context, edsCC balancer.ClientConn, parentCC *xd
 		if got, want := gotAddrs[0].Addr, addrs[0].Addr; got != want {
 			return fmt.Errorf("resolver.Address passed to parent ClientConn has address %q, want %q", got, want)
 		}
-		if hi := xds.GetHandshakeInfo(gotAddrs[0].Attributes); (hi != nil) != wantAttributes {
+		getHI := internal.GetXDSHandshakeInfo.(func(attr *attributes.Attributes) *xds.HandshakeInfo)
+		if hi := getHI(gotAddrs[0].Attributes); (hi != nil) != wantAttributes {
 			return fmt.Errorf("resolver.Address passed to parent ClientConn contains attributes: %v, wantAttributes: %v", (hi != nil), wantAttributes)
 		}
 	}

--- a/xds/internal/balancer/cdsbalancer/cdsbalancer_security_test.go
+++ b/xds/internal/balancer/cdsbalancer/cdsbalancer_security_test.go
@@ -1,0 +1,632 @@
+/*
+ * Copyright 2020 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cdsbalancer
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"google.golang.org/grpc/balancer"
+	"google.golang.org/grpc/credentials/local"
+	"google.golang.org/grpc/credentials/tls/certprovider"
+	"google.golang.org/grpc/credentials/xds"
+	"google.golang.org/grpc/internal/testutils"
+	"google.golang.org/grpc/resolver"
+	xdsclient "google.golang.org/grpc/xds/internal/client"
+	"google.golang.org/grpc/xds/internal/client/bootstrap"
+	xdstestutils "google.golang.org/grpc/xds/internal/testutils"
+	"google.golang.org/grpc/xds/internal/testutils/fakeclient"
+)
+
+const (
+	fakeProvider1Name = "fake-certificate-provider-1"
+	fakeProvider2Name = "fake-certificate-provider-2"
+	fakeConfig        = "my fake config"
+)
+
+var (
+	fpb1, fpb2                   *fakeProviderBuilder
+	bootstrapCertProviderConfigs = map[string]bootstrap.CertProviderConfig{
+		"default1": {
+			Name:   fakeProvider1Name,
+			Config: &fakeStableConfig{config: fakeConfig + "1111"},
+		},
+		"default2": {
+			Name:   fakeProvider2Name,
+			Config: &fakeStableConfig{config: fakeConfig + "2222"},
+		},
+	}
+	cdsUpdateWithGoodSecurityCfg = xdsclient.ClusterUpdate{
+		ServiceName: serviceName,
+		SecurityCfg: &xdsclient.SecurityConfig{
+			RootInstanceName:     "default1",
+			IdentityInstanceName: "default2",
+		},
+	}
+	cdsUpdateWithMissingSecurityCfg = xdsclient.ClusterUpdate{
+		ServiceName: serviceName,
+		SecurityCfg: &xdsclient.SecurityConfig{
+			RootInstanceName: "not-default",
+		},
+	}
+)
+
+func init() {
+	fpb1 = &fakeProviderBuilder{name: fakeProvider1Name}
+	fpb2 = &fakeProviderBuilder{name: fakeProvider2Name}
+	certprovider.Register(fpb1)
+	certprovider.Register(fpb2)
+}
+
+// fakeProviderBuilder builds new instances of fakeProvider and interprets the
+// config provided to it as a string.
+type fakeProviderBuilder struct {
+	name string
+}
+
+func (b *fakeProviderBuilder) Build(certprovider.StableConfig, certprovider.Options) certprovider.Provider {
+	p := &fakeProvider{}
+	return p
+}
+
+func (b *fakeProviderBuilder) ParseConfig(config interface{}) (certprovider.StableConfig, error) {
+	s, ok := config.(string)
+	if !ok {
+		return nil, fmt.Errorf("providerBuilder %s received config of type %T, want string", b.name, config)
+	}
+	return &fakeStableConfig{config: s}, nil
+}
+
+func (b *fakeProviderBuilder) Name() string {
+	return b.name
+}
+
+type fakeStableConfig struct {
+	config string
+}
+
+func (c *fakeStableConfig) Canonical() []byte {
+	return []byte(c.config)
+}
+
+// fakeProvider is an implementation of the Provider interface which provides a
+// method for tests to invoke to push new key materials.
+type fakeProvider struct {
+	certprovider.Provider
+}
+
+// setupWithXDSCreds performs all the setup steps required for tests which use
+// xDSCredentials.
+func setupWithXDSCreds(t *testing.T, storeErr bool) (*fakeclient.Client, *cdsBalancer, *testEDSBalancer, *xdstestutils.TestClientConn, *testutils.Channel, func()) {
+	t.Helper()
+
+	builder := balancer.Get(cdsName)
+	if builder == nil {
+		t.Fatalf("balancer.Get(%q) returned nil", cdsName)
+	}
+	// Create and pass xdsCredentials while building the CDS balancer.
+	creds, err := xds.NewClientCredentials(xds.ClientOptions{
+		FallbackCreds: local.NewCredentials(), // Placeholder fallback credentials.
+	})
+	if err != nil {
+		t.Fatalf("Failed to create xDS client creds: %v", err)
+	}
+	// Create a new CDS balancer and pass it a fake balancer.ClientConn which we
+	// can use to inspect the different calls made by the balancer.
+	tcc := xdstestutils.NewTestClientConn(t)
+	cdsB := builder.Build(tcc, balancer.BuildOptions{DialCreds: creds})
+
+	// Override the creation of the EDS balancer to return a fake EDS balancer
+	// implementation.
+	edsB := newTestEDSBalancer()
+	oldEDSBalancerBuilder := newEDSBalancer
+	newEDSBalancer = func(cc balancer.ClientConn, opts balancer.BuildOptions) (balancer.Balancer, error) {
+		edsB.parentCC = cc
+		return edsB, nil
+	}
+
+	// Create a fake xDS client and push a ClientConnState update to the CDS
+	// balancer with a cluster name and the fake xDS client in the attributes.
+	xdsC := fakeclient.NewClient()
+	if err := cdsB.UpdateClientConnState(cdsCCS(clusterName, xdsC)); err != nil {
+		t.Fatalf("cdsBalancer.UpdateClientConnState failed with error: %v", err)
+	}
+
+	// Make sure the CDS balancer registers a Cluster watch with the xDS client
+	// passed via attributes in the above update.
+	ctx, ctxCancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer ctxCancel()
+	gotCluster, err := xdsC.WaitForWatchCluster(ctx)
+	if err != nil {
+		t.Fatalf("xdsClient.WatchCDS failed with error: %v", err)
+	}
+	if gotCluster != clusterName {
+		t.Fatalf("xdsClient.WatchCDS called for cluster: %v, want: %v", gotCluster, clusterName)
+	}
+
+	// Override the certificate provider creation function to get notified about
+	// provider creation. Create a channel with size 2, so we have buffer to
+	// push notifications for both providers.
+	providerCh := testutils.NewChannelWithSize(2)
+	origGetProviderFunc := getProviderFunc
+	if storeErr {
+		getProviderFunc = func(string, interface{}, certprovider.Options) (certprovider.Provider, error) {
+			return nil, errors.New("certprovider.Store failed to created provider")
+		}
+	} else {
+		getProviderFunc = func(name string, cfg interface{}, opts certprovider.Options) (certprovider.Provider, error) {
+			providerCh.Send(nil)
+			return origGetProviderFunc(name, cfg, opts)
+		}
+	}
+
+	return xdsC, cdsB.(*cdsBalancer), edsB, tcc, providerCh, func() {
+		newEDSBalancer = oldEDSBalancerBuilder
+		getProviderFunc = origGetProviderFunc
+	}
+}
+
+// makeNewSubConn invokes the NewSubConn() call on the balancer.ClientConn
+// passed to the EDS balancer, and verifies that the CDS balancer forwards the
+// call appropriately to its parent balancer.ClientConn with or without
+// attributes bases on the value of wantAttributes.
+func makeNewSubConn(ctx context.Context, edsCC balancer.ClientConn, parentCC *xdstestutils.TestClientConn, wantAttributes bool) error {
+	dummyAddr := "foo-address"
+	addrs := []resolver.Address{{Addr: dummyAddr}}
+	if _, err := edsCC.NewSubConn(addrs, balancer.NewSubConnOptions{}); err != nil {
+		return fmt.Errorf("NewSubConn(%+v) on parent ClientConn failed: %v", addrs, err)
+	}
+
+	select {
+	case <-ctx.Done():
+		return errors.New("timeout when waiting for new SubConn")
+	case gotAddrs := <-parentCC.NewSubConnAddrsCh:
+		if len(gotAddrs) != 1 {
+			return fmt.Errorf("NewSubConn expected 1 address, got %d", len(gotAddrs))
+		}
+		if got, want := gotAddrs[0].Addr, addrs[0].Addr; got != want {
+			return fmt.Errorf("resolver.Address passed to parent ClientConn has address %q, want %q", got, want)
+		}
+		if hi := xds.GetHandshakeInfo(gotAddrs[0].Attributes); (hi != nil) != wantAttributes {
+			return fmt.Errorf("resolver.Address passed to parent ClientConn contains attributes: %v, wantAttributes: %v", (hi != nil), wantAttributes)
+		}
+	}
+	return nil
+}
+
+// TestSecurityConfigWithoutXDSCreds tests the case where xdsCredentials are not
+// in use, but the CDS balancer receives a Cluster update with security
+// configuration. Verifies that no certificate providers are created, and that
+// no address attributes are added as part of the intercepted NewSubConn()
+// method.
+func (s) TestSecurityConfigWithoutXDSCreds(t *testing.T) {
+	// Override the certificate provider creation function to get notified about
+	// provider creation.
+	providerCh := testutils.NewChannel()
+	origGetProviderFunc := getProviderFunc
+	getProviderFunc = func(name string, cfg interface{}, opts certprovider.Options) (certprovider.Provider, error) {
+		providerCh.Send(nil)
+		return origGetProviderFunc(name, cfg, opts)
+	}
+	defer func() { getProviderFunc = origGetProviderFunc }()
+
+	// This creates a CDS balancer, pushes a ClientConnState update with a fake
+	// xdsClient, and makes sure that the CDS balancer registers a watch on the
+	// provided xdsClient.
+	xdsC, cdsB, edsB, tcc, cancel := setupWithWatch(t)
+	defer func() {
+		cancel()
+		cdsB.Close()
+	}()
+
+	// Here we invoke the watch callback registered on the fake xdsClient. This
+	// will trigger the watch handler on the CDS balancer, which will attempt to
+	// create a new EDS balancer. The fake EDS balancer created above will be
+	// returned to the CDS balancer, because we have overridden the
+	// newEDSBalancer function as part of test setup.
+	cdsUpdate := xdsclient.ClusterUpdate{ServiceName: serviceName}
+	wantCCS := edsCCS(serviceName, false, xdsC)
+	ctx, ctxCancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer ctxCancel()
+	if err := invokeWatchCbAndWait(ctx, xdsC, cdsWatchInfo{cdsUpdate, nil}, wantCCS, edsB); err != nil {
+		t.Fatal(err)
+	}
+
+	// Make a NewSubConn and verify that attributes are not added.
+	if err := makeNewSubConn(ctx, edsB.parentCC, tcc, false); err != nil {
+		t.Fatal(err)
+	}
+
+	// Again, since xdsCredentials are not in use, no certificate providers
+	// should have been initialized by the CDS balancer.
+	sCtx, sCancel := context.WithTimeout(context.Background(), defaultTestShortTimeout)
+	defer sCancel()
+	if _, err := providerCh.Receive(sCtx); err != context.DeadlineExceeded {
+		t.Fatal("cds balancer created certificate providers when not using xds credentials")
+	}
+}
+
+// TestNoSecurityConfigWithXDSCreds tests the case where xdsCredentials are in
+// use, but the CDS balancer receives a Cluster update without security
+// configuration. Verifies that no certificate providers are created, and that
+// no address attributes are added as part of the intercepted NewSubConn()
+// method.
+func (s) TestNoSecurityConfigWithXDSCreds(t *testing.T) {
+	// This creates a CDS balancer which uses xdsCredentials, pushes a
+	// ClientConnState update with a fake xdsClient, and makes sure that the CDS
+	// balancer registers a watch on the provided xdsClient.
+	xdsC, cdsB, edsB, tcc, providerCh, cancel := setupWithXDSCreds(t, false)
+	defer func() {
+		cancel()
+		cdsB.Close()
+	}()
+
+	// Here we invoke the watch callback registered on the fake xdsClient. This
+	// will trigger the watch handler on the CDS balancer, which will attempt to
+	// create a new EDS balancer. The fake EDS balancer created above will be
+	// returned to the CDS balancer, because we have overridden the
+	// newEDSBalancer function as part of test setup. No security config is
+	// passed to the CDS balancer as part of this update.
+	cdsUpdate := xdsclient.ClusterUpdate{ServiceName: serviceName}
+	wantCCS := edsCCS(serviceName, false, xdsC)
+	ctx, ctxCancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer ctxCancel()
+	if err := invokeWatchCbAndWait(ctx, xdsC, cdsWatchInfo{cdsUpdate, nil}, wantCCS, edsB); err != nil {
+		t.Fatal(err)
+	}
+
+	// Make a NewSubConn and verify that attributes are not added.
+	if err := makeNewSubConn(ctx, edsB.parentCC, tcc, false); err != nil {
+		t.Fatal(err)
+	}
+
+	// Again, since no security configuration was received, no certificate
+	// providers should have been initialized by the CDS balancer.
+	sCtx, sCancel := context.WithTimeout(context.Background(), defaultTestShortTimeout)
+	defer sCancel()
+	if _, err := providerCh.Receive(sCtx); err != context.DeadlineExceeded {
+		t.Fatal("cds balancer created certificate providers when not using xds credentials")
+	}
+}
+
+// TestSecurityConfigNotFoundInBootstrap tests the case where the security
+// config returned by the xDS server cannot be resolved based on the contents of
+// the bootstrap config. Verifies that the balancer puts the channel in a failed
+// state, and returns an error picker.
+func (s) TestSecurityConfigNotFoundInBootstrap(t *testing.T) {
+	// We test two cases here:
+	// 0: Bootstrap contains security config. But received plugin instance name
+	//    is not found in the bootstrap config.
+	// 1: Bootstrap contains no security config.
+	for i := 0; i < 2; i++ {
+		// This creates a CDS balancer which uses xdsCredentials, pushes a
+		// ClientConnState update with a fake xdsClient, and makes sure that the CDS
+		// balancer registers a watch on the provided xdsClient.
+		xdsC, cdsB, edsB, tcc, _, cancel := setupWithXDSCreds(t, false)
+		defer func() {
+			cancel()
+			cdsB.Close()
+		}()
+
+		if i == 0 {
+			// Set the bootstrap config used by the fake client.
+			xdsC.SetCertProviderConfigs(bootstrapCertProviderConfigs)
+		}
+
+		// Here we invoke the watch callback registered on the fake xdsClient. A bad
+		// security config is passed here. So, we expect the CDS balancer to not
+		// create an EDS balancer and instead reject this update and put the channel
+		// in a bad state.
+		xdsC.InvokeWatchClusterCallback(cdsUpdateWithMissingSecurityCfg, nil)
+
+		// The CDS balancer has not yet created an EDS balancer. So, this bad
+		// watcher update should not be forwarded forwarded to our fake EDS balancer
+		// as an error.
+		sCtx, sCancel := context.WithTimeout(context.Background(), defaultTestShortTimeout)
+		defer sCancel()
+		if err := edsB.waitForResolverError(sCtx, nil); err != context.DeadlineExceeded {
+			t.Fatal("eds balancer shouldn't get error (shouldn't be built yet)")
+		}
+
+		// Make sure the CDS balancer reports an error picker.
+		ctx, ctxCancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+		defer ctxCancel()
+		if err := tcc.WaitForErrPicker(ctx); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+// TestCertproviderStoreError tests the case where the certprovider.Store
+// returns an error when the CDS balancer attempts to create a provider.
+func (s) TestCertproviderStoreError(t *testing.T) {
+	// This creates a CDS balancer which uses xdsCredentials, pushes a
+	// ClientConnState update with a fake xdsClient, and makes sure that the CDS
+	// balancer registers a watch on the provided xdsClient.
+	xdsC, cdsB, edsB, tcc, _, cancel := setupWithXDSCreds(t, true)
+	defer func() {
+		cancel()
+		cdsB.Close()
+	}()
+
+	// Set the bootstrap config used by the fake client.
+	xdsC.SetCertProviderConfigs(bootstrapCertProviderConfigs)
+
+	// Here we invoke the watch callback registered on the fake xdsClient. Even
+	// though the received update is good, the certprovider.Store is configured
+	// to return an error. So, CDS balancer should reject this config and report
+	// an error.
+	xdsC.InvokeWatchClusterCallback(cdsUpdateWithGoodSecurityCfg, nil)
+
+	// The CDS balancer has not yet created an EDS balancer. So, this bad
+	// watcher update should not be forwarded forwarded to our fake EDS balancer
+	// as an error.
+	sCtx, sCancel := context.WithTimeout(context.Background(), defaultTestShortTimeout)
+	defer sCancel()
+	if err := edsB.waitForResolverError(sCtx, nil); err != context.DeadlineExceeded {
+		t.Fatal("eds balancer shouldn't get error (shouldn't be built yet)")
+	}
+
+	// Make sure the CDS balancer reports an error picker.
+	ctx, ctxCancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer ctxCancel()
+	if err := tcc.WaitForErrPicker(ctx); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func (s) TestSecurityConfigUpdate_BadToGood(t *testing.T) {
+	// This creates a CDS balancer which uses xdsCredentials, pushes a
+	// ClientConnState update with a fake xdsClient, and makes sure that the CDS
+	// balancer registers a watch on the provided xdsClient.
+	xdsC, cdsB, edsB, tcc, providerCh, cancel := setupWithXDSCreds(t, false)
+	defer func() {
+		cancel()
+		cdsB.Close()
+	}()
+
+	// Set the bootstrap config used by the fake client.
+	xdsC.SetCertProviderConfigs(bootstrapCertProviderConfigs)
+
+	// Here we invoke the watch callback registered on the fake xdsClient. A bad
+	// security config is passed here. So, we expect the CDS balancer to not
+	// create an EDS balancer and instead reject this update and put the channel
+	// in a bad state.
+	xdsC.InvokeWatchClusterCallback(cdsUpdateWithMissingSecurityCfg, nil)
+
+	// The CDS balancer has not yet created an EDS balancer. So, this bad
+	// watcher update should not be forwarded forwarded to our fake EDS balancer
+	// as an error.
+	sCtx, sCancel := context.WithTimeout(context.Background(), defaultTestShortTimeout)
+	defer sCancel()
+	if err := edsB.waitForResolverError(sCtx, nil); err != context.DeadlineExceeded {
+		t.Fatal("eds balancer shouldn't get error (shouldn't be built yet)")
+	}
+
+	// Make sure the CDS balancer reports an error picker.
+	ctx, ctxCancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer ctxCancel()
+	if err := tcc.WaitForErrPicker(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	// Here we invoke the watch callback registered on the fake xdsClient. This
+	// will trigger the watch handler on the CDS balancer, which will attempt to
+	// create a new EDS balancer. The fake EDS balancer created above will be
+	// returned to the CDS balancer, because we have overridden the
+	// newEDSBalancer function as part of test setup.
+	wantCCS := edsCCS(serviceName, false, xdsC)
+	if err := invokeWatchCbAndWait(ctx, xdsC, cdsWatchInfo{cdsUpdateWithGoodSecurityCfg, nil}, wantCCS, edsB); err != nil {
+		t.Fatal(err)
+	}
+	// Make sure two certificate providers are created.
+	for i := 0; i < 2; i++ {
+		if _, err := providerCh.Receive(ctx); err != nil {
+			t.Fatalf("Failed to create certificate provider upon receipt of security config")
+		}
+	}
+
+	// Make a NewSubConn and verify that attributes are added.
+	if err := makeNewSubConn(ctx, edsB.parentCC, tcc, true); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestGoodSecurityConfig tests the case where the CDS balancer receives
+// security configuration as part of the Cluster resource which can be
+// successfully resolved using the bootstrap file contents. Verifies that
+// certificate providers are created, and that the NewSubConn() call adds
+// appropriate address attributes.
+func (s) TestGoodSecurityConfig(t *testing.T) {
+	// This creates a CDS balancer which uses xdsCredentials, pushes a
+	// ClientConnState update with a fake xdsClient, and makes sure that the CDS
+	// balancer registers a watch on the provided xdsClient.
+	xdsC, cdsB, edsB, tcc, providerCh, cancel := setupWithXDSCreds(t, false)
+	defer func() {
+		cancel()
+		cdsB.Close()
+	}()
+
+	// Set the bootstrap config used by the fake client.
+	xdsC.SetCertProviderConfigs(bootstrapCertProviderConfigs)
+
+	// Here we invoke the watch callback registered on the fake xdsClient. This
+	// will trigger the watch handler on the CDS balancer, which will attempt to
+	// create a new EDS balancer. The fake EDS balancer created above will be
+	// returned to the CDS balancer, because we have overridden the
+	// newEDSBalancer function as part of test setup.
+	wantCCS := edsCCS(serviceName, false, xdsC)
+	ctx, ctxCancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer ctxCancel()
+	if err := invokeWatchCbAndWait(ctx, xdsC, cdsWatchInfo{cdsUpdateWithGoodSecurityCfg, nil}, wantCCS, edsB); err != nil {
+		t.Fatal(err)
+	}
+	// Make sure two certificate providers are created.
+	for i := 0; i < 2; i++ {
+		if _, err := providerCh.Receive(ctx); err != nil {
+			t.Fatalf("Failed to create certificate provider upon receipt of security config")
+		}
+	}
+
+	// Make a NewSubConn and verify that attributes are added.
+	if err := makeNewSubConn(ctx, edsB.parentCC, tcc, true); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestSecurityConfigUpdate_GoodToBad tests the case where the first security
+// config returned by the xDS server is successful, but the second update cannot
+// be resolved based on the contents of the bootstrap config. Verifies that the
+// error is forwarded to the EDS balancer (which was created as part of the
+// first successful update).
+func (s) TestSecurityConfigUpdate_GoodToBad(t *testing.T) {
+	// This creates a CDS balancer which uses xdsCredentials, pushes a
+	// ClientConnState update with a fake xdsClient, and makes sure that the CDS
+	// balancer registers a watch on the provided xdsClient.
+	xdsC, cdsB, edsB, tcc, providerCh, cancel := setupWithXDSCreds(t, false)
+	defer func() {
+		cancel()
+		cdsB.Close()
+	}()
+
+	// Set the bootstrap config used by the fake client.
+	xdsC.SetCertProviderConfigs(bootstrapCertProviderConfigs)
+
+	// Here we invoke the watch callback registered on the fake xdsClient. This
+	// will trigger the watch handler on the CDS balancer, which will attempt to
+	// create a new EDS balancer. The fake EDS balancer created above will be
+	// returned to the CDS balancer, because we have overridden the
+	// newEDSBalancer function as part of test setup.
+	wantCCS := edsCCS(serviceName, false, xdsC)
+	ctx, ctxCancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer ctxCancel()
+	if err := invokeWatchCbAndWait(ctx, xdsC, cdsWatchInfo{cdsUpdateWithGoodSecurityCfg, nil}, wantCCS, edsB); err != nil {
+		t.Fatal(err)
+	}
+	// Make sure two certificate providers are created.
+	for i := 0; i < 2; i++ {
+		if _, err := providerCh.Receive(ctx); err != nil {
+			t.Fatalf("Failed to create certificate provider upon receipt of security config")
+		}
+	}
+
+	// Make a NewSubConn and verify that attributes are added.
+	if err := makeNewSubConn(ctx, edsB.parentCC, tcc, true); err != nil {
+		t.Fatal(err)
+	}
+
+	// Here we invoke the watch callback registered on the fake xdsClient with
+	// an update which contains bad security config. So, we expect the CDS
+	// balancer to forward this error to the EDS balancer and eventually the
+	// channel needs to be put in a bad state.
+	xdsC.InvokeWatchClusterCallback(cdsUpdateWithMissingSecurityCfg, nil)
+
+	// We manually check that an error is forwarded to the EDS balancer instead
+	// of using one of the helper methods on the testEDSBalancer, because all we
+	// care here is whether an error is sent to it or not. We don't care about
+	// the exact error.
+	gotErr, err := edsB.resolverErrCh.Receive(ctx)
+	if err != nil {
+		t.Fatal("timeout waiting for CDS balancer to forward error to EDS balancer upon receipt of bad security config")
+	}
+	if gotErr == nil {
+		t.Fatal("CDS balancer did not forward error to EDS balancer upon receipt of bad security config")
+	}
+
+	// Since the error being pushed here is not a resource-not-found-error, the
+	// registered watch should not be cancelled.
+	sCtx, sCancel := context.WithTimeout(context.Background(), defaultTestShortTimeout)
+	defer sCancel()
+	if err := xdsC.WaitForCancelClusterWatch(sCtx); err != context.DeadlineExceeded {
+		t.Fatal("cluster watch cancelled for a non-resource-not-found-error")
+	}
+}
+
+// TestSecurityConfigUpdate_GoodToGood tests the case where the CDS balancer
+// receives two different but successful updates with security configuration.
+// Verifies that appropriate providers are created, and that address attributes
+// are added.
+func (s) TestSecurityConfigUpdate_GoodToGood(t *testing.T) {
+	// This creates a CDS balancer which uses xdsCredentials, pushes a
+	// ClientConnState update with a fake xdsClient, and makes sure that the CDS
+	// balancer registers a watch on the provided xdsClient.
+	xdsC, cdsB, edsB, tcc, providerCh, cancel := setupWithXDSCreds(t, false)
+	defer func() {
+		cancel()
+		cdsB.Close()
+	}()
+
+	// Set the bootstrap config used by the fake client.
+	xdsC.SetCertProviderConfigs(bootstrapCertProviderConfigs)
+
+	// Here we invoke the watch callback registered on the fake xdsClient. This
+	// will trigger the watch handler on the CDS balancer, which will attempt to
+	// create a new EDS balancer. The fake EDS balancer created above will be
+	// returned to the CDS balancer, because we have overridden the
+	// newEDSBalancer function as part of test setup.
+	cdsUpdate := xdsclient.ClusterUpdate{
+		ServiceName: serviceName,
+		SecurityCfg: &xdsclient.SecurityConfig{
+			RootInstanceName: "default1",
+		},
+	}
+	wantCCS := edsCCS(serviceName, false, xdsC)
+	ctx, ctxCancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer ctxCancel()
+	if err := invokeWatchCbAndWait(ctx, xdsC, cdsWatchInfo{cdsUpdate, nil}, wantCCS, edsB); err != nil {
+		t.Fatal(err)
+	}
+
+	// We specified only the root provider. So, expect only one provider here.
+	if _, err := providerCh.Receive(ctx); err != nil {
+		t.Fatalf("Failed to create certificate provider upon receipt of security config")
+	}
+
+	// Make a NewSubConn and verify that attributes are added.
+	if err := makeNewSubConn(ctx, edsB.parentCC, tcc, true); err != nil {
+		t.Fatal(err)
+	}
+
+	// Push another update with a new security configuration.
+	cdsUpdate = xdsclient.ClusterUpdate{
+		ServiceName: serviceName,
+		SecurityCfg: &xdsclient.SecurityConfig{
+			RootInstanceName: "default2",
+		},
+	}
+	if err := invokeWatchCbAndWait(ctx, xdsC, cdsWatchInfo{cdsUpdate, nil}, wantCCS, edsB); err != nil {
+		t.Fatal(err)
+	}
+
+	// We specified only the root provider. So, expect only one provider here.
+	if _, err := providerCh.Receive(ctx); err != nil {
+		t.Fatalf("Failed to create certificate provider upon receipt of security config")
+	}
+
+	// Make a NewSubConn and verify that attributes are added.
+	if err := makeNewSubConn(ctx, edsB.parentCC, tcc, true); err != nil {
+		t.Fatal(err)
+	}
+
+	// The HandshakeInfo type does not expose its internals. So, we cannot
+	// verify that the HandshakeInfo carried by the attributes have actually
+	// been changed. This will be covered in e2e/interop tests.
+	// TODO(easwars): Remove this TODO once appropriate e2e/intertop tests have
+	// been added.
+}

--- a/xds/internal/balancer/edsbalancer/eds.go
+++ b/xds/internal/balancer/edsbalancer/eds.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 
 	"github.com/google/go-cmp/cmp"
+
 	"google.golang.org/grpc/balancer"
 	"google.golang.org/grpc/balancer/roundrobin"
 	"google.golang.org/grpc/connectivity"
@@ -153,6 +154,7 @@ func (x *edsBalancer) run() {
 // In both cases, the sub-balancers will be closed, and the future picks will
 // fail.
 func (x *edsBalancer) handleErrorFromUpdate(err error, fromParent bool) {
+	x.logger.Warningf("Received error: %v", err)
 	if xdsclient.ErrType(err) == xdsclient.ErrorTypeResourceNotFound {
 		if fromParent {
 			// This is an error from the parent ClientConn (can be the parent
@@ -198,11 +200,10 @@ func (x *edsBalancer) handleGRPCUpdate(update interface{}) {
 
 		x.config = cfg
 	case error:
-		x.logger.Warningf("Received error from resolver: %v", u)
 		x.handleErrorFromUpdate(u, true)
 	default:
 		// unreachable path
-		panic("wrong update type")
+		x.logger.Errorf("wrong update type: %T", update)
 	}
 }
 

--- a/xds/internal/balancer/edsbalancer/eds.go
+++ b/xds/internal/balancer/edsbalancer/eds.go
@@ -198,6 +198,7 @@ func (x *edsBalancer) handleGRPCUpdate(update interface{}) {
 
 		x.config = cfg
 	case error:
+		x.logger.Warningf("Received error from resolver: %v", u)
 		x.handleErrorFromUpdate(u, true)
 	default:
 		// unreachable path

--- a/xds/internal/client/client.go
+++ b/xds/internal/client/client.go
@@ -418,6 +418,14 @@ func New(opts Options) (*Client, error) {
 	return c, nil
 }
 
+// CertProviderConfigs returns the certificate provider configuration from the
+// "certificate_providers" field of the bootstrap file. The returned value is a
+// map from plugin_instance_name to {plugin_name, plugin_config}. Callers must
+// not modify the returned map.
+func (c *Client) CertProviderConfigs() map[string]bootstrap.CertProviderConfig {
+	return c.opts.Config.CertProviderConfigs
+}
+
 // run is a goroutine for all the callbacks.
 //
 // Callback can be called in watch(), if an item is found in cache. Without this

--- a/xds/internal/testutils/fakeclient/client.go
+++ b/xds/internal/testutils/fakeclient/client.go
@@ -24,6 +24,7 @@ import (
 
 	"google.golang.org/grpc/internal/testutils"
 	xdsclient "google.golang.org/grpc/xds/internal/client"
+	"google.golang.org/grpc/xds/internal/client/bootstrap"
 	"google.golang.org/grpc/xds/internal/client/load"
 )
 
@@ -42,6 +43,7 @@ type Client struct {
 	loadReportCh *testutils.Channel
 	closeCh      *testutils.Channel
 	loadStore    *load.Store
+	certConfigs  map[string]bootstrap.CertProviderConfig
 
 	ldsCb func(xdsclient.ListenerUpdate, error)
 	rdsCb func(xdsclient.RouteConfigUpdate, error)
@@ -219,6 +221,16 @@ func (xdsC *Client) Close() {
 func (xdsC *Client) WaitForClose(ctx context.Context) error {
 	_, err := xdsC.closeCh.Receive(ctx)
 	return err
+}
+
+// CertProviderConfigs returns the configured certificate provider configs.
+func (xdsC *Client) CertProviderConfigs() map[string]bootstrap.CertProviderConfig {
+	return xdsC.certConfigs
+}
+
+// SetCertProviderConfigs updates the certificate provider configs.
+func (xdsC *Client) SetCertProviderConfigs(configs map[string]bootstrap.CertProviderConfig) {
+	xdsC.certConfigs = configs
 }
 
 // Name returns the name of the xds client.


### PR DESCRIPTION
- Summary of changes:
  - CDS LB changes to act on the security configuration received as part of the `Cluster` resource.
  - Export a `CertProviderConfigs` method on the `xds.Client` to return the parsed certificate provider configs.
  - Fix the `certprovider.store` to accept configs which have already been parsed. With the change to sourcing the configs from the bootstrap file, the bootstrap processing will parse the config and make it available from the `xds.Client`. So, the CDS balancer will use the parsed configs instead of raw JSON configs.
  - Export `getHandshakeInfo` from `credentials/xds` to make it possible to test whether the `HandshakeInfo` type was added as an `Attribute` to the `resolver.Address`. Also export a `CredentialsUsesXDS` function from this package to return if a given `credentials.TransportCredentials` is an xDS credentials.
  - Some test cleanup related to using a single context with a `defaultTestTimeout` instead of sprinkling new context creations all over the place. This seems to have been missed out as part of the other PR in which I cleaned up other tests.