### PR TITLE
encoding/proto: simplify & optimize proto codec

### DIFF
--- a/encoding/proto/proto.go
+++ b/encoding/proto/proto.go
@@ -21,9 +21,6 @@
 package proto
 
 import (
-	"math"
-	"sync"
-
 	"github.com/golang/protobuf/proto"
 	"google.golang.org/grpc/encoding"
 )
@@ -38,73 +35,14 @@ func init() {
 // codec is a Codec implementation with protobuf. It is the default codec for gRPC.
 type codec struct{}
 
-type cachedProtoBuffer struct {
-	lastMarshaledSize uint32
-	proto.Buffer
-}
-
-func capToMaxInt32(val int) uint32 {
-	if val > math.MaxInt32 {
-		return uint32(math.MaxInt32)
-	}
-	return uint32(val)
-}
-
-func marshal(v interface{}, cb *cachedProtoBuffer) ([]byte, error) {
-	protoMsg := v.(proto.Message)
-	newSlice := make([]byte, 0, cb.lastMarshaledSize)
-
-	cb.SetBuf(newSlice)
-	cb.Reset()
-	if err := cb.Marshal(protoMsg); err != nil {
-		return nil, err
-	}
-	out := cb.Bytes()
-	cb.lastMarshaledSize = capToMaxInt32(len(out))
-	return out, nil
-}
-
 func (codec) Marshal(v interface{}) ([]byte, error) {
-	if pm, ok := v.(proto.Marshaler); ok {
-		// object can marshal itself, no need for buffer
-		return pm.Marshal()
-	}
-
-	cb := protoBufferPool.Get().(*cachedProtoBuffer)
-	out, err := marshal(v, cb)
-
-	// put back buffer and lose the ref to the slice
-	cb.SetBuf(nil)
-	protoBufferPool.Put(cb)
-	return out, err
+	return proto.Marshal(v.(proto.Message))
 }
 
 func (codec) Unmarshal(data []byte, v interface{}) error {
-	protoMsg := v.(proto.Message)
-	protoMsg.Reset()
-
-	if pu, ok := protoMsg.(proto.Unmarshaler); ok {
-		// object can unmarshal itself, no need for buffer
-		return pu.Unmarshal(data)
-	}
-
-	cb := protoBufferPool.Get().(*cachedProtoBuffer)
-	cb.SetBuf(data)
-	err := cb.Unmarshal(protoMsg)
-	cb.SetBuf(nil)
-	protoBufferPool.Put(cb)
-	return err
+	return proto.Unmarshal(data, v.(proto.Message))
 }
 
 func (codec) Name() string {
 	return Name
-}
-
-var protoBufferPool = &sync.Pool{
-	New: func() interface{} {
-		return &cachedProtoBuffer{
-			Buffer:            proto.Buffer{},
-			lastMarshaledSize: 16,
-		}
-	},
 }


### PR DESCRIPTION
Adopt recommendation in #3400 to simplify the proto codec; it seems the buffer pool is no longer buying us any performance wins.

Performance #s:

First run:

```
unary-networkMode_Local-bufConn_false-keepalive_false-benchTime_1m0s-trace_false-latency_0s-kbps_0-MTU_0-maxConcurrentCalls_4-reqSize_1B-respSize_1B-compressor_off-channelz_false-preloader_false
               Title       Before        After Percentage
            TotalOps      1258048      1246113    -0.95%
            Bytes/op      9041.12      9030.22    -0.12%

unary-networkMode_Local-bufConn_false-keepalive_false-benchTime_1m0s-trace_false-latency_0s-kbps_0-MTU_0-maxConcurrentCalls_4-reqSize_1B-respSize_1048576B-compressor_off-channelz_false-preloader_false
               Title       Before        After Percentage
            TotalOps        79675        78736    -1.18%
            Bytes/op   4544492.46   4272822.58    -5.98%

unary-networkMode_Local-bufConn_false-keepalive_false-benchTime_1m0s-trace_false-latency_0s-kbps_0-MTU_0-maxConcurrentCalls_4-reqSize_1048576B-respSize_1B-compressor_off-channelz_false-preloader_false
               Title       Before        After Percentage
            TotalOps        75874        78201     3.07%
            Bytes/op   4547662.25   4271000.57    -6.08%

unary-networkMode_Local-bufConn_false-keepalive_false-benchTime_1m0s-trace_false-latency_0s-kbps_0-MTU_0-maxConcurrentCalls_4-reqSize_1048576B-respSize_1048576B-compressor_off-channelz_false-preloader_false
               Title       Before        After Percentage
            TotalOps        47519        47441    -0.16%
            Bytes/op   8773989.78   8576394.34    -2.25%
```

Second run:

```
unary-networkMode_Local-bufConn_false-keepalive_false-benchTime_1m0s-trace_false-latency_0s-kbps_0-MTU_0-maxConcurrentCalls_2-reqSize_1B-respSize_1B-compressor_off-channelz_false-preloader_false
               Title       Before        After Percentage
            TotalOps       743806       748614     0.65%
            Bytes/op      9233.55      9221.13    -0.13%

unary-networkMode_Local-bufConn_false-keepalive_false-benchTime_1m0s-trace_false-latency_0s-kbps_0-MTU_0-maxConcurrentCalls_2-reqSize_1B-respSize_1048576B-compressor_off-channelz_false-preloader_false
               Title       Before        After Percentage
            TotalOps        62939        66276     5.30%
            Bytes/op   4523063.20   4278421.65    -5.41%

unary-networkMode_Local-bufConn_false-keepalive_false-benchTime_1m0s-trace_false-latency_0s-kbps_0-MTU_0-maxConcurrentCalls_2-reqSize_1048576B-respSize_1B-compressor_off-channelz_false-preloader_false
               Title       Before        After Percentage
            TotalOps        60894        62828     3.18%
            Bytes/op   4553250.74   4277739.19    -6.05%

unary-networkMode_Local-bufConn_false-keepalive_false-benchTime_1m0s-trace_false-latency_0s-kbps_0-MTU_0-maxConcurrentCalls_2-reqSize_1048576B-respSize_1048576B-compressor_off-channelz_false-preloader_false
               Title       Before        After Percentage
            TotalOps        33206        33723     1.56%
            Bytes/op   8903907.39   8693996.61    -2.36%
```

This appears to provide slightly better performance on average, and is considerably simpler, and would provide a lower memory footprint due to the lack of a buffer pool.

Related to #3932

