### PR TITLE
Add GitHub release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,79 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - cmd/protoc-gen-go-grpc/v[0-9]+.[0-9]+.[0-9]+
+
+jobs:
+  create_release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    outputs: 
+      upload_url: ${{ steps.create_release.outputs.upload_url }} 
+    
+    steps:
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          draft: true
+          prerelease: false
+
+  build_release:
+    name: Build Release assets
+    runs-on: ubuntu-latest
+    needs: create_release
+    strategy:
+      matrix:
+        goos: [linux, darwin, windows]
+        goarch: [386, amd64]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.15
+
+      - name: Download dependencies
+        run: |
+          cd cmd/protoc-gen-go-grpc
+          go mod download
+
+      - name: Prepare build directory
+        run: |
+          mkdir -p build/
+          cp README.md build/
+          cp LICENSE build/
+
+      - name: Build protoc-gen-go-grpc
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+        run: |
+          cd cmd/protoc-gen-go-grpc
+          go build -trimpath -o $GITHUB_WORKSPACE/build
+
+      - name: Create package
+        id: package
+        run: |
+          PACKAGE_NAME=protoc-gen-go-grpc.${GITHUB_REF#refs/tags/cmd/protoc-gen-go-grpc/}.${{ matrix.goos }}.${{ matrix.goarch }}.tar.gz
+          tar -czvf PACKAGE_NAME -C build .
+          echo ::set-output name=name::${PACKAGE_NAME}
+
+      - name: Upload asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.create_release.outputs.upload_url }}
+          asset_path: ./build/${{ steps.package.outputs.name }}
+          asset_name: ${{ steps.package.outputs.name }}
+          asset_content_type: application/gzip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,9 @@ jobs:
       matrix:
         goos: [linux, darwin, windows]
         goarch: [386, amd64]
+        exclude:
+          - goos: darwin
+            goarch: 386
 
     steps:
       - name: Checkout code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
         id: package
         run: |
           PACKAGE_NAME=protoc-gen-go-grpc.${GITHUB_REF#refs/tags/cmd/protoc-gen-go-grpc/}.${{ matrix.goos }}.${{ matrix.goarch }}.tar.gz
-          tar -czvf PACKAGE_NAME -C build .
+          tar -czvf $PACKAGE_NAME -C build .
           echo ::set-output name=name::${PACKAGE_NAME}
 
       - name: Upload asset

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,8 +42,6 @@ jobs:
 
       - name: Set up Go
         uses: actions/setup-go@v2
-        with:
-          go-version: 1.15
 
       - name: Download dependencies
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
           cp README.md build/
           cp LICENSE build/
 
-      - name: Build protoc-gen-go-grpc
+      - name: Build
         env:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   create_release:
-    name: Create Release
+    name: Create cmd/protoc-gen-go-grpc Release
     runs-on: ubuntu-latest
     outputs: 
       upload_url: ${{ steps.create_release.outputs.upload_url }} 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,33 +1,14 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - cmd/protoc-gen-go-grpc/v[0-9]+.[0-9]+.[0-9]+
+  release:
+    types: [published]
 
 jobs:
-  create_release:
-    name: Create cmd/protoc-gen-go-grpc Release
+  release:
+    name: Release cmd/protoc-gen-go-grpc
     runs-on: ubuntu-latest
-    outputs: 
-      upload_url: ${{ steps.create_release.outputs.upload_url }} 
-    
-    steps:
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
-          draft: true
-          prerelease: false
-
-  build_release:
-    name: Build Release assets
-    runs-on: ubuntu-latest
-    needs: create_release
+    if: startsWith(github.event.release.tag_name, 'cmd/protoc-gen-go-grpc/')
     strategy:
       matrix:
         goos: [linux, darwin, windows]
@@ -74,7 +55,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ needs.create_release.outputs.upload_url }}
+          upload_url: ${{ github.event.release.upload_url }}
           asset_path: ./${{ steps.package.outputs.name }}
           asset_name: ${{ steps.package.outputs.name }}
           asset_content_type: application/gzip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,6 +77,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ needs.create_release.outputs.upload_url }}
-          asset_path: ./build/${{ steps.package.outputs.name }}
+          asset_path: ./${{ steps.package.outputs.name }}
           asset_name: ${{ steps.package.outputs.name }}
           asset_content_type: application/gzip


### PR DESCRIPTION
This PR adds a GitHub action workflow that is triggered when a tag matching `cmd/protoc-gen-go-grpc/v[0-9]+.[0-9]+.[0-9]+` is pushed.

The workflow creates a draft release for the tag and uploads build artifacts to it as discussed in #3924. The release follows [protobuf-go](https://github.com/protocolbuffers/protobuf-go) conventions for release name assets.

An example for the created draft can be found here: https://github.com/sagikazarmark/grpc-go/releases/tag/cmd%2Fprotoc-gen-go-grpc%2Fv1.2.0
(Published, so others can see it)

Fixes #3924 

