### PR TITLE
credentials/xds: Handle unspecified acceptedSANs correctly.

### DIFF
--- a/credentials/xds/xds.go
+++ b/credentials/xds/xds.go
@@ -174,6 +174,11 @@ func (hi *HandshakeInfo) makeTLSConfig(ctx context.Context) (*tls.Config, error)
 }
 
 func (hi *HandshakeInfo) matchingSANExists(cert *x509.Certificate) bool {
+	if len(hi.acceptedSANs) == 0 {
+		// An empty list of acceptedSANs means "accept everything".
+		return true
+	}
+
 	var sans []string
 	// SANs can be specified in any of these four fields on the parsed cert.
 	sans = append(sans, cert.DNSNames...)


### PR DESCRIPTION
Earlier the behavior was that if no accepted SANs were specified, no connection would go through. But clearly the Envoy docs indicate the behavior should be the other way around.