### PR TITLE
cmd/protoc-gen-go-grpc: use grpc.ServiceRegistrar instead of *grpc.Server

### DIFF
--- a/balancer/grpclb/grpc_lb_v1/load_balancer_grpc.pb.go
+++ b/balancer/grpclb/grpc_lb_v1/load_balancer_grpc.pb.go
@@ -83,7 +83,7 @@ type UnsafeLoadBalancerServer interface {
 	mustEmbedUnimplementedLoadBalancerServer()
 }
 
-func RegisterLoadBalancerServer(s *grpc.Server, srv LoadBalancerServer) {
+func RegisterLoadBalancerServer(s grpc.ServiceRegistrar, srv LoadBalancerServer) {
 	s.RegisterService(&_LoadBalancer_serviceDesc, srv)
 }
 

--- a/balancer/rls/internal/proto/grpc_lookup_v1/rls_grpc.pb.go
+++ b/balancer/rls/internal/proto/grpc_lookup_v1/rls_grpc.pb.go
@@ -63,7 +63,7 @@ type UnsafeRouteLookupServiceServer interface {
 	mustEmbedUnimplementedRouteLookupServiceServer()
 }
 
-func RegisterRouteLookupServiceServer(s *grpc.Server, srv RouteLookupServiceServer) {
+func RegisterRouteLookupServiceServer(s grpc.ServiceRegistrar, srv RouteLookupServiceServer) {
 	s.RegisterService(&_RouteLookupService_serviceDesc, srv)
 }
 

--- a/benchmark/grpc_testing/services_grpc.pb.go
+++ b/benchmark/grpc_testing/services_grpc.pb.go
@@ -145,7 +145,7 @@ type UnsafeBenchmarkServiceServer interface {
 	mustEmbedUnimplementedBenchmarkServiceServer()
 }
 
-func RegisterBenchmarkServiceServer(s *grpc.Server, srv BenchmarkServiceServer) {
+func RegisterBenchmarkServiceServer(s grpc.ServiceRegistrar, srv BenchmarkServiceServer) {
 	s.RegisterService(&_BenchmarkService_serviceDesc, srv)
 }
 
@@ -407,7 +407,7 @@ type UnsafeWorkerServiceServer interface {
 	mustEmbedUnimplementedWorkerServiceServer()
 }
 
-func RegisterWorkerServiceServer(s *grpc.Server, srv WorkerServiceServer) {
+func RegisterWorkerServiceServer(s grpc.ServiceRegistrar, srv WorkerServiceServer) {
 	s.RegisterService(&_WorkerService_serviceDesc, srv)
 }
 

--- a/channelz/grpc_channelz_v1/channelz_grpc.pb.go
+++ b/channelz/grpc_channelz_v1/channelz_grpc.pb.go
@@ -159,7 +159,7 @@ type UnsafeChannelzServer interface {
 	mustEmbedUnimplementedChannelzServer()
 }
 
-func RegisterChannelzServer(s *grpc.Server, srv ChannelzServer) {
+func RegisterChannelzServer(s grpc.ServiceRegistrar, srv ChannelzServer) {
 	s.RegisterService(&_Channelz_serviceDesc, srv)
 }
 

--- a/cmd/protoc-gen-go-grpc/grpc.go
+++ b/cmd/protoc-gen-go-grpc/grpc.go
@@ -181,7 +181,7 @@ func genService(gen *protogen.Plugin, file *protogen.File, g *protogen.Generated
 		g.P(deprecationComment)
 	}
 	serviceDescVar := "_" + service.GoName + "_serviceDesc"
-	g.P("func Register", service.GoName, "Server(s *", grpcPackage.Ident("Server"), ", srv ", serverType, ") {")
+	g.P("func Register", service.GoName, "Server(s ", grpcPackage.Ident("ServiceRegistrar"), ", srv ", serverType, ") {")
 	g.P("s.RegisterService(&", serviceDescVar, `, srv)`)
 	g.P("}")
 	g.P()

--- a/credentials/alts/internal/proto/grpc_gcp/handshaker_grpc.pb.go
+++ b/credentials/alts/internal/proto/grpc_gcp/handshaker_grpc.pb.go
@@ -95,7 +95,7 @@ type UnsafeHandshakerServiceServer interface {
 	mustEmbedUnimplementedHandshakerServiceServer()
 }
 
-func RegisterHandshakerServiceServer(s *grpc.Server, srv HandshakerServiceServer) {
+func RegisterHandshakerServiceServer(s grpc.ServiceRegistrar, srv HandshakerServiceServer) {
 	s.RegisterService(&_HandshakerService_serviceDesc, srv)
 }
 

--- a/credentials/tls/certprovider/meshca/internal/v1/meshca_grpc.pb.go
+++ b/credentials/tls/certprovider/meshca/internal/v1/meshca_grpc.pb.go
@@ -66,7 +66,7 @@ type UnsafeMeshCertificateServiceServer interface {
 	mustEmbedUnimplementedMeshCertificateServiceServer()
 }
 
-func RegisterMeshCertificateServiceServer(s *grpc.Server, srv MeshCertificateServiceServer) {
+func RegisterMeshCertificateServiceServer(s grpc.ServiceRegistrar, srv MeshCertificateServiceServer) {
 	s.RegisterService(&_MeshCertificateService_serviceDesc, srv)
 }
 

--- a/examples/features/proto/echo/echo_grpc.pb.go
+++ b/examples/features/proto/echo/echo_grpc.pb.go
@@ -181,7 +181,7 @@ type UnsafeEchoServer interface {
 	mustEmbedUnimplementedEchoServer()
 }
 
-func RegisterEchoServer(s *grpc.Server, srv EchoServer) {
+func RegisterEchoServer(s grpc.ServiceRegistrar, srv EchoServer) {
 	s.RegisterService(&_Echo_serviceDesc, srv)
 }
 

--- a/examples/helloworld/helloworld/helloworld_grpc.pb.go
+++ b/examples/helloworld/helloworld/helloworld_grpc.pb.go
@@ -63,7 +63,7 @@ type UnsafeGreeterServer interface {
 	mustEmbedUnimplementedGreeterServer()
 }
 
-func RegisterGreeterServer(s *grpc.Server, srv GreeterServer) {
+func RegisterGreeterServer(s grpc.ServiceRegistrar, srv GreeterServer) {
 	s.RegisterService(&_Greeter_serviceDesc, srv)
 }
 

--- a/examples/route_guide/routeguide/route_guide_grpc.pb.go
+++ b/examples/route_guide/routeguide/route_guide_grpc.pb.go
@@ -213,7 +213,7 @@ type UnsafeRouteGuideServer interface {
 	mustEmbedUnimplementedRouteGuideServer()
 }
 
-func RegisterRouteGuideServer(s *grpc.Server, srv RouteGuideServer) {
+func RegisterRouteGuideServer(s grpc.ServiceRegistrar, srv RouteGuideServer) {
 	s.RegisterService(&_RouteGuide_serviceDesc, srv)
 }
 

--- a/health/grpc_health_v1/health_grpc.pb.go
+++ b/health/grpc_health_v1/health_grpc.pb.go
@@ -130,7 +130,7 @@ type UnsafeHealthServer interface {
 	mustEmbedUnimplementedHealthServer()
 }
 
-func RegisterHealthServer(s *grpc.Server, srv HealthServer) {
+func RegisterHealthServer(s grpc.ServiceRegistrar, srv HealthServer) {
 	s.RegisterService(&_Health_serviceDesc, srv)
 }
 

--- a/interop/grpc_testing/test_grpc.pb.go
+++ b/interop/grpc_testing/test_grpc.pb.go
@@ -251,7 +251,7 @@ type UnsafeTestServiceServer interface {
 	mustEmbedUnimplementedTestServiceServer()
 }
 
-func RegisterTestServiceServer(s *grpc.Server, srv TestServiceServer) {
+func RegisterTestServiceServer(s grpc.ServiceRegistrar, srv TestServiceServer) {
 	s.RegisterService(&_TestService_serviceDesc, srv)
 }
 
@@ -480,7 +480,7 @@ type UnsafeUnimplementedServiceServer interface {
 	mustEmbedUnimplementedUnimplementedServiceServer()
 }
 
-func RegisterUnimplementedServiceServer(s *grpc.Server, srv UnimplementedServiceServer) {
+func RegisterUnimplementedServiceServer(s grpc.ServiceRegistrar, srv UnimplementedServiceServer) {
 	s.RegisterService(&_UnimplementedService_serviceDesc, srv)
 }
 
@@ -566,7 +566,7 @@ type UnsafeLoadBalancerStatsServiceServer interface {
 	mustEmbedUnimplementedLoadBalancerStatsServiceServer()
 }
 
-func RegisterLoadBalancerStatsServiceServer(s *grpc.Server, srv LoadBalancerStatsServiceServer) {
+func RegisterLoadBalancerStatsServiceServer(s grpc.ServiceRegistrar, srv LoadBalancerStatsServiceServer) {
 	s.RegisterService(&_LoadBalancerStatsService_serviceDesc, srv)
 }
 

--- a/profiling/proto/service_grpc.pb.go
+++ b/profiling/proto/service_grpc.pb.go
@@ -79,7 +79,7 @@ type UnsafeProfilingServer interface {
 	mustEmbedUnimplementedProfilingServer()
 }
 
-func RegisterProfilingServer(s *grpc.Server, srv ProfilingServer) {
+func RegisterProfilingServer(s grpc.ServiceRegistrar, srv ProfilingServer) {
 	s.RegisterService(&_Profiling_serviceDesc, srv)
 }
 

--- a/reflection/grpc_reflection_v1alpha/reflection_grpc.pb.go
+++ b/reflection/grpc_reflection_v1alpha/reflection_grpc.pb.go
@@ -85,7 +85,7 @@ type UnsafeServerReflectionServer interface {
 	mustEmbedUnimplementedServerReflectionServer()
 }
 
-func RegisterServerReflectionServer(s *grpc.Server, srv ServerReflectionServer) {
+func RegisterServerReflectionServer(s grpc.ServiceRegistrar, srv ServerReflectionServer) {
 	s.RegisterService(&_ServerReflection_serviceDesc, srv)
 }
 

--- a/reflection/grpc_testing/test_grpc.pb.go
+++ b/reflection/grpc_testing/test_grpc.pb.go
@@ -97,7 +97,7 @@ type UnsafeSearchServiceServer interface {
 	mustEmbedUnimplementedSearchServiceServer()
 }
 
-func RegisterSearchServiceServer(s *grpc.Server, srv SearchServiceServer) {
+func RegisterSearchServiceServer(s grpc.ServiceRegistrar, srv SearchServiceServer) {
 	s.RegisterService(&_SearchService_serviceDesc, srv)
 }
 

--- a/stats/grpc_testing/test_grpc.pb.go
+++ b/stats/grpc_testing/test_grpc.pb.go
@@ -187,7 +187,7 @@ type UnsafeTestServiceServer interface {
 	mustEmbedUnimplementedTestServiceServer()
 }
 
-func RegisterTestServiceServer(s *grpc.Server, srv TestServiceServer) {
+func RegisterTestServiceServer(s grpc.ServiceRegistrar, srv TestServiceServer) {
 	s.RegisterService(&_TestService_serviceDesc, srv)
 }
 

--- a/stress/grpc_testing/metrics_grpc.pb.go
+++ b/stress/grpc_testing/metrics_grpc.pb.go
@@ -104,7 +104,7 @@ type UnsafeMetricsServiceServer interface {
 	mustEmbedUnimplementedMetricsServiceServer()
 }
 
-func RegisterMetricsServiceServer(s *grpc.Server, srv MetricsServiceServer) {
+func RegisterMetricsServiceServer(s grpc.ServiceRegistrar, srv MetricsServiceServer) {
 	s.RegisterService(&_MetricsService_serviceDesc, srv)
 }
 

--- a/test/grpc_testing/test_grpc.pb.go
+++ b/test/grpc_testing/test_grpc.pb.go
@@ -251,7 +251,7 @@ type UnsafeTestServiceServer interface {
 	mustEmbedUnimplementedTestServiceServer()
 }
 
-func RegisterTestServiceServer(s *grpc.Server, srv TestServiceServer) {
+func RegisterTestServiceServer(s grpc.ServiceRegistrar, srv TestServiceServer) {
 	s.RegisterService(&_TestService_serviceDesc, srv)
 }
 


### PR DESCRIPTION
Fixes #3966