### PR TITLE
internal/transport: fix a bug causing -bin metadata to be incorrectly encoded

### DIFF
--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -489,14 +489,14 @@ func (t *http2Client) createHeaderFields(ctx context.Context, callHdr *CallHdr) 
 		for _, vv := range added {
 			for i, v := range vv {
 				if i%2 == 0 {
-					k = v
+					k = strings.ToLower(v)
 					continue
 				}
 				// HTTP doesn't allow you to set pseudoheaders after non pseudoheaders were set.
 				if isReservedHeader(k) {
 					continue
 				}
-				headerFields = append(headerFields, hpack.HeaderField{Name: strings.ToLower(k), Value: encodeMetadataHeader(k, v)})
+				headerFields = append(headerFields, hpack.HeaderField{Name: k, Value: encodeMetadataHeader(k, v)})
 			}
 		}
 	}


### PR DESCRIPTION
Most interfaces for adding metadata to a context downcase keys, except metadata.AppendToOutgoingContext (presumably for performance reasons).  Documentation for metadata.AppendToOutgoingContext, referring to that of metadata.Pairs, states that metadata keys are downcased.

The bug is manifest if you use metadata.AppendToOutgoingContext to add metadata with a non-downcased `-Bin` suffix.  http2Client will not encode such metadata, as encodeMetadataHeader just performs a lower suffix check.