### PR TITLE
xds: remove xdsclient.New from EDS balancer

### DIFF
--- a/xds/internal/balancer/edsbalancer/config.go
+++ b/xds/internal/balancer/edsbalancer/config.go
@@ -29,8 +29,6 @@ import (
 // for EDS balancers.
 type EDSConfig struct {
 	serviceconfig.LoadBalancingConfig
-	// BalancerName represents the load balancer to use.
-	BalancerName string
 	// ChildPolicy represents the load balancing config for the child
 	// policy.
 	ChildPolicy *loadBalancingConfig
@@ -50,7 +48,6 @@ type EDSConfig struct {
 // and Fallbackspolicy are post-processed, and for each, the first installed
 // policy is kept.
 type edsConfigJSON struct {
-	BalancerName               string
 	ChildPolicy                []*loadBalancingConfig
 	FallbackPolicy             []*loadBalancingConfig
 	EDSServiceName             string
@@ -66,7 +63,6 @@ func (l *EDSConfig) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	l.BalancerName = configJSON.BalancerName
 	l.EDSServiceName = configJSON.EDSServiceName
 	l.LrsLoadReportingServerName = configJSON.LRSLoadReportingServerName
 

--- a/xds/internal/balancer/edsbalancer/eds.go
+++ b/xds/internal/balancer/edsbalancer/eds.go
@@ -51,17 +51,16 @@ func init() {
 type edsBalancerBuilder struct{}
 
 // Build helps implement the balancer.Builder interface.
-func (b *edsBalancerBuilder) Build(cc balancer.ClientConn, opts balancer.BuildOptions) balancer.Balancer {
+func (b *edsBalancerBuilder) Build(cc balancer.ClientConn, _ balancer.BuildOptions) balancer.Balancer {
 	x := &edsBalancer{
 		cc:                cc,
-		buildOpts:         opts,
 		closed:            grpcsync.NewEvent(),
 		grpcUpdate:        make(chan interface{}),
 		xdsClientUpdate:   make(chan *edsUpdate),
 		childPolicyUpdate: buffer.NewUnbounded(),
 	}
 	x.logger = prefixLogger((x))
-	x.client = newXDSClientWrapper(x.handleEDSUpdate, x.buildOpts, x.logger)
+	x.client = newXDSClientWrapper(x.handleEDSUpdate, x.logger)
 	x.edsImpl = newEDSBalancer(x.cc, x.enqueueChildBalancerState, x.client, x.logger)
 	x.logger.Infof("Created")
 	go x.run()
@@ -102,10 +101,9 @@ type edsBalancerImplInterface interface {
 //
 // It currently has only an edsBalancer. Later, we may add fallback.
 type edsBalancer struct {
-	cc        balancer.ClientConn // *xdsClientConn
-	buildOpts balancer.BuildOptions
-	closed    *grpcsync.Event
-	logger    *grpclog.PrefixLogger
+	cc     balancer.ClientConn // *xdsClientConn
+	closed *grpcsync.Event
+	logger *grpclog.PrefixLogger
 
 	// edsBalancer continuously monitor the channels below, and will handle events from them in sync.
 	grpcUpdate        chan interface{}


### PR DESCRIPTION
EDS balancer should only get the xdsClient from attributes.

This is part of making xds_client shared by multiple clients.