### PR TITLE
internal: increase timeout non timeout test in xds/client/v2

### DIFF
--- a/xds/internal/client/v2/client_test.go
+++ b/xds/internal/client/v2/client_test.go
@@ -610,7 +610,7 @@ func (s) TestV2ClientRetriesAfterBrokenStream(t *testing.T) {
 	t.Log("Bad LDS response pushed to fakeServer...")
 
 	val, err := fakeServer.XDSRequestChan.Receive(ctx)
-	if err == context.DeadlineExceeded {
+	if err != nil {
 		t.Fatalf("Timeout expired when expecting LDS update")
 	}
 	gotRequest := val.(*fakeserver.Request)

--- a/xds/internal/client/v2/client_test.go
+++ b/xds/internal/client/v2/client_test.go
@@ -609,9 +609,7 @@ func (s) TestV2ClientRetriesAfterBrokenStream(t *testing.T) {
 	fakeServer.XDSResponseChan <- &fakeserver.Response{Err: errors.New("RPC error")}
 	t.Log("Bad LDS response pushed to fakeServer...")
 
-	sCtx, sCancel := context.WithTimeout(context.Background(), defaultTestShortTimeout)
-	defer sCancel()
-	val, err := fakeServer.XDSRequestChan.Receive(sCtx)
+	val, err := fakeServer.XDSRequestChan.Receive(ctx)
 	if err == context.DeadlineExceeded {
 		t.Fatalf("Timeout expired when expecting LDS update")
 	}


### PR DESCRIPTION
This check is not expecting a deadline exceeded error, but it's using a short timeout. It should use the long timeout.