### PR TITLE
Fix a typo in interceptor example's README.md

### DIFF
--- a/examples/features/interceptor/README.md
+++ b/examples/features/interceptor/README.md
@@ -76,7 +76,7 @@ user to operate on.
 
 In the example, we define a new struct `wrappedStream`, which is embedded with a
 `ClientStream`. Then, we implement (overload) the `SendMsg` and `RecvMsg`
-methods on `wrappedStream` to intercepts these two operations on the embedded
+methods on `wrappedStream` to intercept these two operations on the embedded
 `ClientStream`. In the example, we log the message type info and time info for
 interception purpose.
 


### PR DESCRIPTION
This is a trivial change fixing a typo in the interceptor example's documentation.