### PR TITLE
xds: make xds client a singleton

### DIFF
--- a/xds/internal/client/bootstrap/bootstrap.go
+++ b/xds/internal/client/bootstrap/bootstrap.go
@@ -57,7 +57,7 @@ var gRPCVersion = fmt.Sprintf("%s %s", gRPCUserAgentName, grpc.Version)
 var bootstrapFileReadFunc = ioutil.ReadFile
 
 // Config provides the xDS client with several key bits of information that it
-// requires in its interaction with an management server. The Config is
+// requires in its interaction with the management server. The Config is
 // initialized from the bootstrap file.
 type Config struct {
 	// BalancerName is the name of the management server to connect to.

--- a/xds/internal/client/bootstrap/bootstrap.go
+++ b/xds/internal/client/bootstrap/bootstrap.go
@@ -57,10 +57,10 @@ var gRPCVersion = fmt.Sprintf("%s %s", gRPCUserAgentName, grpc.Version)
 var bootstrapFileReadFunc = ioutil.ReadFile
 
 // Config provides the xDS client with several key bits of information that it
-// requires in its interaction with an xDS server. The Config is initialized
-// from the bootstrap file.
+// requires in its interaction with an management server. The Config is
+// initialized from the bootstrap file.
 type Config struct {
-	// BalancerName is the name of the xDS server to connect to.
+	// BalancerName is the name of the management server to connect to.
 	//
 	// The bootstrap file contains a list of servers (with name+creds), but we
 	// pick the first one.
@@ -96,7 +96,7 @@ type xdsServer struct {
 // The format of the bootstrap file will be as follows:
 // {
 //    "xds_server": {
-//      "server_uri": <string containing URI of xds server>,
+//      "server_uri": <string containing URI of management server>,
 //      "channel_creds": [
 //        {
 //          "type": <string containing channel cred type>,
@@ -168,7 +168,7 @@ func NewConfig() (*Config, error) {
 				return nil, fmt.Errorf("xds: json.Unmarshal(%v) for field %q failed during bootstrap: %v", string(v), k, err)
 			}
 			if len(servers) < 1 {
-				return nil, fmt.Errorf("xds: bootstrap file parsing failed during bootstrap: file doesn't contain any xds server to connect to")
+				return nil, fmt.Errorf("xds: bootstrap file parsing failed during bootstrap: file doesn't contain any management server to connect to")
 			}
 			xs := servers[0]
 			config.BalancerName = xs.ServerURI

--- a/xds/internal/client/client.go
+++ b/xds/internal/client/client.go
@@ -296,7 +296,7 @@ var newAPIClient = func(apiVersion version.TransportAPI, cc *grpc.ClientConn, op
 type clientImpl struct {
 	done               *grpcsync.Event
 	config             *bootstrap.Config
-	cc                 *grpc.ClientConn // Connection to the xDS server
+	cc                 *grpc.ClientConn // Connection to the management server.
 	apiClient          APIClient
 	watchExpiryTimeout time.Duration
 
@@ -373,7 +373,7 @@ func newWithConfig(config *bootstrap.Config, watchExpiryTimeout time.Duration) (
 	}
 	c.cc = cc
 	c.logger = prefixLogger((c))
-	c.logger.Infof("Created ClientConn to xDS server: %s", config.BalancerName)
+	c.logger.Infof("Created ClientConn to xDS management server: %s", config.BalancerName)
 
 	apiClient, err := newAPIClient(config.TransportAPI, cc, BuildOptions{
 		Parent:    c,
@@ -418,7 +418,7 @@ func (c *clientImpl) run() {
 	}
 }
 
-// Close closes the gRPC connection to the xDS server.
+// Close closes the gRPC connection to the management server.
 func (c *clientImpl) Close() {
 	if c.done.HasFired() {
 		return

--- a/xds/internal/client/client_callback.go
+++ b/xds/internal/client/client_callback.go
@@ -26,7 +26,7 @@ type watcherInfoWithUpdate struct {
 
 // scheduleCallback should only be called by methods of watchInfo, which checks
 // for watcher states and maintain consistency.
-func (c *Client) scheduleCallback(wi *watchInfo, update interface{}, err error) {
+func (c *clientImpl) scheduleCallback(wi *watchInfo, update interface{}, err error) {
 	c.updateCh.Put(&watcherInfoWithUpdate{
 		wi:     wi,
 		update: update,
@@ -34,7 +34,7 @@ func (c *Client) scheduleCallback(wi *watchInfo, update interface{}, err error) 
 	})
 }
 
-func (c *Client) callCallback(wiu *watcherInfoWithUpdate) {
+func (c *clientImpl) callCallback(wiu *watcherInfoWithUpdate) {
 	c.mu.Lock()
 	// Use a closure to capture the callback and type assertion, to save one
 	// more switch case.
@@ -74,7 +74,7 @@ func (c *Client) callCallback(wiu *watcherInfoWithUpdate) {
 //
 // A response can contain multiple resources. They will be parsed and put in a
 // map from resource name to the resource content.
-func (c *Client) NewListeners(updates map[string]ListenerUpdate) {
+func (c *clientImpl) NewListeners(updates map[string]ListenerUpdate) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -109,7 +109,7 @@ func (c *Client) NewListeners(updates map[string]ListenerUpdate) {
 //
 // A response can contain multiple resources. They will be parsed and put in a
 // map from resource name to the resource content.
-func (c *Client) NewRouteConfigs(updates map[string]RouteConfigUpdate) {
+func (c *clientImpl) NewRouteConfigs(updates map[string]RouteConfigUpdate) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -130,7 +130,7 @@ func (c *Client) NewRouteConfigs(updates map[string]RouteConfigUpdate) {
 //
 // A response can contain multiple resources. They will be parsed and put in a
 // map from resource name to the resource content.
-func (c *Client) NewClusters(updates map[string]ClusterUpdate) {
+func (c *clientImpl) NewClusters(updates map[string]ClusterUpdate) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -165,7 +165,7 @@ func (c *Client) NewClusters(updates map[string]ClusterUpdate) {
 //
 // A response can contain multiple resources. They will be parsed and put in a
 // map from resource name to the resource content.
-func (c *Client) NewEndpoints(updates map[string]EndpointsUpdate) {
+func (c *clientImpl) NewEndpoints(updates map[string]EndpointsUpdate) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 

--- a/xds/internal/client/client_loadreport.go
+++ b/xds/internal/client/client_loadreport.go
@@ -33,7 +33,7 @@ import (
 //
 // It returns a Store for the user to report loads, a function to cancel the
 // load reporting stream.
-func (c *Client) ReportLoad(server string) (*load.Store, func()) {
+func (c *clientImpl) ReportLoad(server string) (*load.Store, func()) {
 	c.lrsMu.Lock()
 	defer c.lrsMu.Unlock()
 
@@ -61,7 +61,7 @@ func (c *Client) ReportLoad(server string) (*load.Store, func()) {
 // - a ClientConn to this server (only if it's different from the xds server)
 // - a load.Store that contains loads only for this server
 type lrsClient struct {
-	parent *Client
+	parent *clientImpl
 	server string
 
 	cc           *grpc.ClientConn // nil if the server is same as the xds server
@@ -71,7 +71,7 @@ type lrsClient struct {
 }
 
 // newLRSClient creates a new LRS stream to the server.
-func newLRSClient(parent *Client, server string) *lrsClient {
+func newLRSClient(parent *clientImpl, server string) *lrsClient {
 	return &lrsClient{
 		parent:   parent,
 		server:   server,
@@ -114,13 +114,12 @@ func (lrsC *lrsClient) startStream() {
 	var cc *grpc.ClientConn
 
 	lrsC.parent.logger.Infof("Starting load report to server: %s", lrsC.server)
-	if lrsC.server == "" || lrsC.server == lrsC.parent.opts.Config.BalancerName {
+	if lrsC.server == "" || lrsC.server == lrsC.parent.config.BalancerName {
 		// Reuse the xDS client if server is the same.
 		cc = lrsC.parent.cc
 	} else {
 		lrsC.parent.logger.Infof("LRS server is different from xDS server, starting a new ClientConn")
-		dopts := append([]grpc.DialOption{lrsC.parent.opts.Config.Creds}, lrsC.parent.opts.DialOpts...)
-		ccNew, err := grpc.Dial(lrsC.server, dopts...)
+		ccNew, err := grpc.Dial(lrsC.server, lrsC.parent.config.Creds)
 		if err != nil {
 			// An error from a non-blocking dial indicates something serious.
 			lrsC.parent.logger.Infof("xds: failed to dial load report server {%s}: %v", lrsC.server, err)

--- a/xds/internal/client/client_loadreport_test.go
+++ b/xds/internal/client/client_loadreport_test.go
@@ -44,6 +44,8 @@ import (
 const (
 	defaultTestTimeout      = 5 * time.Second
 	defaultTestShortTimeout = 10 * time.Millisecond // For events expected to *not* happen.
+
+	defaultClientWatchExpiryTimeout = 15 * time.Second
 )
 
 type s struct {
@@ -66,7 +68,7 @@ func (s) TestLRSClient(t *testing.T) {
 		Creds:        grpc.WithInsecure(),
 		NodeProto:    &v2corepb.Node{},
 		TransportAPI: version.TransportV2,
-	}, 15*time.Second)
+	}, defaultClientWatchExpiryTimeout)
 	if err != nil {
 		t.Fatalf("failed to create xds client: %v", err)
 	}

--- a/xds/internal/client/client_loadreport_test.go
+++ b/xds/internal/client/client_loadreport_test.go
@@ -61,14 +61,12 @@ func (s) TestLRSClient(t *testing.T) {
 	}
 	defer sCleanup()
 
-	xdsC, err := client.New(client.Options{
-		Config: bootstrap.Config{
-			BalancerName: fs.Address,
-			Creds:        grpc.WithInsecure(),
-			NodeProto:    &v2corepb.Node{},
-			TransportAPI: version.TransportV2,
-		},
-	})
+	xdsC, err := client.NewWithConfigForTesting(&bootstrap.Config{
+		BalancerName: fs.Address,
+		Creds:        grpc.WithInsecure(),
+		NodeProto:    &v2corepb.Node{},
+		TransportAPI: version.TransportV2,
+	}, 15*time.Second)
 	if err != nil {
 		t.Fatalf("failed to create xds client: %v", err)
 	}

--- a/xds/internal/client/client_logging.go
+++ b/xds/internal/client/client_logging.go
@@ -29,6 +29,6 @@ const prefix = "[xds-client %p] "
 
 var logger = grpclog.Component("xds")
 
-func prefixLogger(p *Client) *internalgrpclog.PrefixLogger {
+func prefixLogger(p *clientImpl) *internalgrpclog.PrefixLogger {
 	return internalgrpclog.NewPrefixLogger(logger, fmt.Sprintf(prefix, p))
 }

--- a/xds/internal/client/client_singleton.go
+++ b/xds/internal/client/client_singleton.go
@@ -1,0 +1,101 @@
+/*
+ *
+ * Copyright 2020 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package client
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"google.golang.org/grpc/xds/internal/client/bootstrap"
+)
+
+const defaultWatchExpiryTimeout = 15 * time.Second
+
+// This is the Client returned by New(). It contains one client implementation,
+// and maintains the refcount.
+var singletonClient = &Client{}
+
+// To override in tests.
+var bootstrapNewConfig = bootstrap.NewConfig
+
+// Client is a full fledged gRPC client which queries a set of discovery APIs
+// (collectively termed as xDS) on a remote management server, to discover
+// various dynamic resources.
+//
+// The xds client is a singleton. It will be shared by the xds resolver and
+// balancer implementations, cross multiple ClientConns and Servers.
+type Client struct {
+	*clientImpl
+
+	// This mu protects all the fields, including the embedded clientImpl above.
+	mu       sync.Mutex
+	refCount int
+}
+
+// New returns a new xdsClient configured by the bootstrap file specified in env
+// variable GRPC_XDS_BOOTSTRAP.
+func New() (*Client, error) {
+	singletonClient.mu.Lock()
+	defer singletonClient.mu.Unlock()
+	// If the client implementation was created, increment ref count and return
+	// the client.
+	if singletonClient.clientImpl != nil {
+		singletonClient.refCount++
+		return singletonClient, nil
+	}
+
+	// Create the new client implementation.
+	config, err := bootstrapNewConfig()
+	if err != nil {
+		return nil, fmt.Errorf("xds: failed to read bootstrap file: %v", err)
+	}
+	c, err := newWithConfig(config, defaultWatchExpiryTimeout)
+	if err != nil {
+		return nil, err
+	}
+
+	singletonClient.clientImpl = c
+	singletonClient.refCount++
+	return singletonClient, nil
+}
+
+// Close closes the client. It does ref count of the xds client implementation,
+// and closes the gRPC connection to the xDS server when ref count reaches 0.
+func (c *Client) Close() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.refCount--
+	if c.refCount == 0 {
+		c.clientImpl.Close()
+		// Set clientImpl back to nil. So if New() is called after this, a new
+		// implementation will be created.
+		c.clientImpl = nil
+	}
+}
+
+// NewWithConfigForTesting is exported for testing only. For prod uses, call
+// New().
+func NewWithConfigForTesting(config *bootstrap.Config, watchExpiryTimeout time.Duration) (*Client, error) {
+	cl, err := newWithConfig(config, watchExpiryTimeout)
+	if err != nil {
+		return nil, err
+	}
+	return &Client{clientImpl: cl, refCount: 1}, nil
+}

--- a/xds/internal/client/client_singleton.go
+++ b/xds/internal/client/client_singleton.go
@@ -40,7 +40,7 @@ var bootstrapNewConfig = bootstrap.NewConfig
 // various dynamic resources.
 //
 // The xds client is a singleton. It will be shared by the xds resolver and
-// balancer implementations, cross multiple ClientConns and Servers.
+// balancer implementations, across multiple ClientConns and Servers.
 type Client struct {
 	*clientImpl
 
@@ -77,7 +77,8 @@ func New() (*Client, error) {
 }
 
 // Close closes the client. It does ref count of the xds client implementation,
-// and closes the gRPC connection to the xDS server when ref count reaches 0.
+// and closes the gRPC connection to the management server when ref count
+// reaches 0.
 func (c *Client) Close() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -90,8 +91,7 @@ func (c *Client) Close() {
 	}
 }
 
-// NewWithConfigForTesting is exported for testing only. For prod uses, call
-// New().
+// NewWithConfigForTesting is exported for testing only.
 func NewWithConfigForTesting(config *bootstrap.Config, watchExpiryTimeout time.Duration) (*Client, error) {
 	cl, err := newWithConfig(config, watchExpiryTimeout)
 	if err != nil {

--- a/xds/internal/client/client_test.go
+++ b/xds/internal/client/client_test.go
@@ -45,8 +45,7 @@ func Test(t *testing.T) {
 }
 
 const (
-	testXDSServer   = "xds-server"
-	chanRecvTimeout = 100 * time.Millisecond
+	testXDSServer = "xds-server"
 
 	testLDSName = "test-lds"
 	testRDSName = "test-rds"
@@ -59,7 +58,7 @@ const (
 )
 
 func clientOpts(balancerName string, overrideWatchExpiryTimeout bool) (*bootstrap.Config, time.Duration) {
-	watchExpiryTimeout := time.Second * 15
+	watchExpiryTimeout := defaultWatchExpiryTimeout
 	if overrideWatchExpiryTimeout {
 		watchExpiryTimeout = defaultTestWatchExpiryTimeout
 	}

--- a/xds/internal/client/client_test.go
+++ b/xds/internal/client/client_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"google.golang.org/grpc/internal/grpcsync"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/internal/grpctest"
@@ -57,22 +58,20 @@ const (
 	defaultTestShortTimeout       = 10 * time.Millisecond // For events expected to *not* happen.
 )
 
-func clientOpts(balancerName string, overrideWatchExpiryTImeout bool) Options {
+func clientOpts(balancerName string, overrideWatchExpiryTimeout bool) (*bootstrap.Config, time.Duration) {
 	watchExpiryTimeout := time.Duration(0)
-	if overrideWatchExpiryTImeout {
+	if overrideWatchExpiryTimeout {
 		watchExpiryTimeout = defaultTestWatchExpiryTimeout
 	}
-	return Options{
-		Config: bootstrap.Config{
-			BalancerName: balancerName,
-			Creds:        grpc.WithInsecure(),
-			NodeProto:    xdstestutils.EmptyNodeProtoV2,
-		},
-		WatchExpiryTimeout: watchExpiryTimeout,
-	}
+	return &bootstrap.Config{
+		BalancerName: balancerName,
+		Creds:        grpc.WithInsecure(),
+		NodeProto:    xdstestutils.EmptyNodeProtoV2,
+	}, watchExpiryTimeout
 }
 
 type testAPIClient struct {
+	done          *grpcsync.Event
 	addWatches    map[ResourceType]*testutils.Channel
 	removeWatches map[ResourceType]*testutils.Channel
 }
@@ -102,6 +101,7 @@ func newTestAPIClient() *testAPIClient {
 		EndpointsResource:   testutils.NewChannel(),
 	}
 	return &testAPIClient{
+		done:          grpcsync.NewEvent(),
 		addWatches:    addWatches,
 		removeWatches: removeWatches,
 	}
@@ -118,7 +118,9 @@ func (c *testAPIClient) RemoveWatch(resourceType ResourceType, resourceName stri
 func (c *testAPIClient) reportLoad(context.Context, *grpc.ClientConn, loadReportingOptions) {
 }
 
-func (c *testAPIClient) Close() {}
+func (c *testAPIClient) Close() {
+	c.done.Fire()
+}
 
 // TestWatchCallAnotherWatch covers the case where watch() is called inline by a
 // callback. It makes sure it doesn't cause a deadlock.
@@ -126,7 +128,7 @@ func (s) TestWatchCallAnotherWatch(t *testing.T) {
 	apiClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	client, err := New(clientOpts(testXDSServer, false))
+	client, err := newWithConfig(clientOpts(testXDSServer, false))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
@@ -215,4 +217,105 @@ func verifyEndpointsUpdate(ctx context.Context, updateCh *testutils.Channel, wan
 		return fmt.Errorf("unexpected endpointsUpdate: (%v, %v), want: (%v, nil)", gotUpdate.u, gotUpdate.err, wantUpdate)
 	}
 	return nil
+}
+
+// Test that multiple New() returns the same Client. And only when the last
+// client is closed, the underlying client is closed.
+func (s) TestClientNewSingleton(t *testing.T) {
+	oldBootstrapNewConfig := bootstrapNewConfig
+	bootstrapNewConfig = func() (*bootstrap.Config, error) {
+		return &bootstrap.Config{
+			BalancerName: testXDSServer,
+			Creds:        grpc.WithInsecure(),
+			NodeProto:    xdstestutils.EmptyNodeProtoV2,
+		}, nil
+	}
+	defer func() { bootstrapNewConfig = oldBootstrapNewConfig }()
+
+	apiClientCh, cleanup := overrideNewAPIClient()
+	defer cleanup()
+
+	// The first New(). Should create a Client and a new APIClient.
+	client, err := New()
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+	clientImpl := client.clientImpl
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	c, err := apiClientCh.Receive(ctx)
+	if err != nil {
+		t.Fatalf("timeout when waiting for API client to be created: %v", err)
+	}
+	apiClient := c.(*testAPIClient)
+
+	// Call New() again. They should all return the same client implementation,
+	// and should not create new API client.
+	const count = 9
+	for i := 0; i < count; i++ {
+		tc, terr := New()
+		if terr != nil {
+			client.Close()
+			t.Fatalf("%d-th call to New() failed with error: %v", i, terr)
+		}
+		if tc.clientImpl != clientImpl {
+			client.Close()
+			tc.Close()
+			t.Fatalf("%d-th call to New() got a different client %p, want %p", i, tc.clientImpl, clientImpl)
+		}
+
+		sctx, scancel := context.WithTimeout(context.Background(), defaultTestShortTimeout)
+		defer scancel()
+		_, err := apiClientCh.Receive(sctx)
+		if err == nil {
+			client.Close()
+			t.Fatalf("%d-th call to New() created a new API client", i)
+		}
+	}
+
+	// Call Close(). Nothing should be actually closed until the last ref calls
+	// Close().
+	for i := 0; i < count; i++ {
+		client.Close()
+		if clientImpl.done.HasFired() {
+			t.Fatalf("%d-th call to Close(), unexpected done in the client implemenation", i)
+		}
+		if apiClient.done.HasFired() {
+			t.Fatalf("%d-th call to Close(), unexpected done in the API client", i)
+		}
+	}
+
+	// Call the last Close(). The underlying implementation and API Client
+	// should all be closed.
+	client.Close()
+	if !clientImpl.done.HasFired() {
+		t.Fatalf("want client implementation to be closed, got not done")
+	}
+	if !apiClient.done.HasFired() {
+		t.Fatalf("want API client to be closed, got not done")
+	}
+
+	// Call New() again after the previous Client is actually closed. Should
+	// create a Client and a new APIClient.
+	client2, err2 := New()
+	if err2 != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+	defer client2.Close()
+	c2, err := apiClientCh.Receive(ctx)
+	if err != nil {
+		t.Fatalf("timeout when waiting for API client to be created: %v", err)
+	}
+	apiClient2 := c2.(*testAPIClient)
+
+	// The client wrapper with ref count should be the same.
+	if client2 != client {
+		t.Fatalf("New() after Close() should return the same client wrapper, got different %p, %p", client2, client)
+	}
+	if client2.clientImpl == clientImpl {
+		t.Fatalf("New() after Close() should return different client implementation, got the same %p", client2.clientImpl)
+	}
+	if apiClient2 == apiClient {
+		t.Fatalf("New() after Close() should return different API client, got the same %p", apiClient2)
+	}
 }

--- a/xds/internal/client/client_test.go
+++ b/xds/internal/client/client_test.go
@@ -59,7 +59,7 @@ const (
 )
 
 func clientOpts(balancerName string, overrideWatchExpiryTimeout bool) (*bootstrap.Config, time.Duration) {
-	watchExpiryTimeout := time.Duration(0)
+	watchExpiryTimeout := time.Second * 15
 	if overrideWatchExpiryTimeout {
 		watchExpiryTimeout = defaultTestWatchExpiryTimeout
 	}

--- a/xds/internal/client/client_watchers.go
+++ b/xds/internal/client/client_watchers.go
@@ -35,7 +35,7 @@ const (
 
 // watchInfo holds all the information from a watch() call.
 type watchInfo struct {
-	c      *Client
+	c      *clientImpl
 	rType  ResourceType
 	target string
 
@@ -113,7 +113,7 @@ func (wi *watchInfo) cancel() {
 	wi.state = watchInfoStateCanceled
 }
 
-func (c *Client) watch(wi *watchInfo) (cancel func()) {
+func (c *clientImpl) watch(wi *watchInfo) (cancel func()) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.logger.Debugf("new watch for type %v, resource name %v", wi.rType, wi.target)
@@ -208,7 +208,7 @@ func (c *Client) watch(wi *watchInfo) (cancel func()) {
 // Note that during race (e.g. an xDS response is received while the user is
 // calling cancel()), there's a small window where the callback can be called
 // after the watcher is canceled. The caller needs to handle this case.
-func (c *Client) WatchListener(serviceName string, cb func(ListenerUpdate, error)) (cancel func()) {
+func (c *clientImpl) WatchListener(serviceName string, cb func(ListenerUpdate, error)) (cancel func()) {
 	wi := &watchInfo{
 		c:           c,
 		rType:       ListenerResource,
@@ -216,7 +216,7 @@ func (c *Client) WatchListener(serviceName string, cb func(ListenerUpdate, error
 		ldsCallback: cb,
 	}
 
-	wi.expiryTimer = time.AfterFunc(c.opts.WatchExpiryTimeout, func() {
+	wi.expiryTimer = time.AfterFunc(c.watchExpiryTimeout, func() {
 		wi.timeout()
 	})
 	return c.watch(wi)
@@ -227,7 +227,7 @@ func (c *Client) WatchListener(serviceName string, cb func(ListenerUpdate, error
 // Note that during race (e.g. an xDS response is received while the user is
 // calling cancel()), there's a small window where the callback can be called
 // after the watcher is canceled. The caller needs to handle this case.
-func (c *Client) WatchRouteConfig(routeName string, cb func(RouteConfigUpdate, error)) (cancel func()) {
+func (c *clientImpl) WatchRouteConfig(routeName string, cb func(RouteConfigUpdate, error)) (cancel func()) {
 	wi := &watchInfo{
 		c:           c,
 		rType:       RouteConfigResource,
@@ -235,7 +235,7 @@ func (c *Client) WatchRouteConfig(routeName string, cb func(RouteConfigUpdate, e
 		rdsCallback: cb,
 	}
 
-	wi.expiryTimer = time.AfterFunc(c.opts.WatchExpiryTimeout, func() {
+	wi.expiryTimer = time.AfterFunc(c.watchExpiryTimeout, func() {
 		wi.timeout()
 	})
 	return c.watch(wi)
@@ -250,7 +250,7 @@ func (c *Client) WatchRouteConfig(routeName string, cb func(RouteConfigUpdate, e
 // Note that during race (e.g. an xDS response is received while the user is
 // calling cancel()), there's a small window where the callback can be called
 // after the watcher is canceled. The caller needs to handle this case.
-func (c *Client) WatchCluster(clusterName string, cb func(ClusterUpdate, error)) (cancel func()) {
+func (c *clientImpl) WatchCluster(clusterName string, cb func(ClusterUpdate, error)) (cancel func()) {
 	wi := &watchInfo{
 		c:           c,
 		rType:       ClusterResource,
@@ -258,7 +258,7 @@ func (c *Client) WatchCluster(clusterName string, cb func(ClusterUpdate, error))
 		cdsCallback: cb,
 	}
 
-	wi.expiryTimer = time.AfterFunc(c.opts.WatchExpiryTimeout, func() {
+	wi.expiryTimer = time.AfterFunc(c.watchExpiryTimeout, func() {
 		wi.timeout()
 	})
 	return c.watch(wi)
@@ -272,7 +272,7 @@ func (c *Client) WatchCluster(clusterName string, cb func(ClusterUpdate, error))
 // Note that during race (e.g. an xDS response is received while the user is
 // calling cancel()), there's a small window where the callback can be called
 // after the watcher is canceled. The caller needs to handle this case.
-func (c *Client) WatchEndpoints(clusterName string, cb func(EndpointsUpdate, error)) (cancel func()) {
+func (c *clientImpl) WatchEndpoints(clusterName string, cb func(EndpointsUpdate, error)) (cancel func()) {
 	wi := &watchInfo{
 		c:           c,
 		rType:       EndpointsResource,
@@ -280,7 +280,7 @@ func (c *Client) WatchEndpoints(clusterName string, cb func(EndpointsUpdate, err
 		edsCallback: cb,
 	}
 
-	wi.expiryTimer = time.AfterFunc(c.opts.WatchExpiryTimeout, func() {
+	wi.expiryTimer = time.AfterFunc(c.watchExpiryTimeout, func() {
 		wi.timeout()
 	})
 	return c.watch(wi)

--- a/xds/internal/client/client_watchers_cluster_test.go
+++ b/xds/internal/client/client_watchers_cluster_test.go
@@ -40,7 +40,7 @@ func (s) TestClusterWatch(t *testing.T) {
 	apiClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	client, err := New(clientOpts(testXDSServer, false))
+	client, err := newWithConfig(clientOpts(testXDSServer, false))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
@@ -93,7 +93,7 @@ func (s) TestClusterTwoWatchSameResourceName(t *testing.T) {
 	apiClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	client, err := New(clientOpts(testXDSServer, false))
+	client, err := newWithConfig(clientOpts(testXDSServer, false))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
@@ -156,7 +156,7 @@ func (s) TestClusterThreeWatchDifferentResourceName(t *testing.T) {
 	apiClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	client, err := New(clientOpts(testXDSServer, false))
+	client, err := newWithConfig(clientOpts(testXDSServer, false))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
@@ -221,7 +221,7 @@ func (s) TestClusterWatchAfterCache(t *testing.T) {
 	apiClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	client, err := New(clientOpts(testXDSServer, false))
+	client, err := newWithConfig(clientOpts(testXDSServer, false))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
@@ -282,7 +282,7 @@ func (s) TestClusterWatchExpiryTimer(t *testing.T) {
 	apiClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	client, err := New(clientOpts(testXDSServer, true))
+	client, err := newWithConfig(clientOpts(testXDSServer, true))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
@@ -321,7 +321,7 @@ func (s) TestClusterWatchExpiryTimerStop(t *testing.T) {
 	apiClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	client, err := New(clientOpts(testXDSServer, true))
+	client, err := newWithConfig(clientOpts(testXDSServer, true))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
@@ -369,7 +369,7 @@ func (s) TestClusterResourceRemoved(t *testing.T) {
 	apiClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	client, err := New(clientOpts(testXDSServer, false))
+	client, err := newWithConfig(clientOpts(testXDSServer, false))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}

--- a/xds/internal/client/client_watchers_endpoints_test.go
+++ b/xds/internal/client/client_watchers_endpoints_test.go
@@ -58,7 +58,7 @@ func (s) TestEndpointsWatch(t *testing.T) {
 	apiClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	client, err := New(clientOpts(testXDSServer, false))
+	client, err := newWithConfig(clientOpts(testXDSServer, false))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
@@ -110,7 +110,7 @@ func (s) TestEndpointsTwoWatchSameResourceName(t *testing.T) {
 	apiClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	client, err := New(clientOpts(testXDSServer, false))
+	client, err := newWithConfig(clientOpts(testXDSServer, false))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
@@ -175,7 +175,7 @@ func (s) TestEndpointsThreeWatchDifferentResourceName(t *testing.T) {
 	apiClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	client, err := New(clientOpts(testXDSServer, false))
+	client, err := newWithConfig(clientOpts(testXDSServer, false))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
@@ -240,7 +240,7 @@ func (s) TestEndpointsWatchAfterCache(t *testing.T) {
 	apiClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	client, err := New(clientOpts(testXDSServer, false))
+	client, err := newWithConfig(clientOpts(testXDSServer, false))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
@@ -299,7 +299,7 @@ func (s) TestEndpointsWatchExpiryTimer(t *testing.T) {
 	apiClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	client, err := New(clientOpts(testXDSServer, true))
+	client, err := newWithConfig(clientOpts(testXDSServer, true))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}

--- a/xds/internal/client/client_watchers_listener_test.go
+++ b/xds/internal/client/client_watchers_listener_test.go
@@ -38,7 +38,7 @@ func (s) TestLDSWatch(t *testing.T) {
 	apiClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	client, err := New(clientOpts(testXDSServer, false))
+	client, err := newWithConfig(clientOpts(testXDSServer, false))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
@@ -91,7 +91,7 @@ func (s) TestLDSTwoWatchSameResourceName(t *testing.T) {
 	apiClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	client, err := New(clientOpts(testXDSServer, false))
+	client, err := newWithConfig(clientOpts(testXDSServer, false))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
@@ -157,7 +157,7 @@ func (s) TestLDSThreeWatchDifferentResourceName(t *testing.T) {
 	apiClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	client, err := New(clientOpts(testXDSServer, false))
+	client, err := newWithConfig(clientOpts(testXDSServer, false))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
@@ -223,7 +223,7 @@ func (s) TestLDSWatchAfterCache(t *testing.T) {
 	apiClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	client, err := New(clientOpts(testXDSServer, false))
+	client, err := newWithConfig(clientOpts(testXDSServer, false))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
@@ -285,7 +285,7 @@ func (s) TestLDSResourceRemoved(t *testing.T) {
 	apiClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	client, err := New(clientOpts(testXDSServer, false))
+	client, err := newWithConfig(clientOpts(testXDSServer, false))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}

--- a/xds/internal/client/client_watchers_route_test.go
+++ b/xds/internal/client/client_watchers_route_test.go
@@ -40,7 +40,7 @@ func (s) TestRDSWatch(t *testing.T) {
 	apiClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	client, err := New(clientOpts(testXDSServer, false))
+	client, err := newWithConfig(clientOpts(testXDSServer, false))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
@@ -99,7 +99,7 @@ func (s) TestRDSTwoWatchSameResourceName(t *testing.T) {
 	apiClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	client, err := New(clientOpts(testXDSServer, false))
+	client, err := newWithConfig(clientOpts(testXDSServer, false))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
@@ -171,7 +171,7 @@ func (s) TestRDSThreeWatchDifferentResourceName(t *testing.T) {
 	apiClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	client, err := New(clientOpts(testXDSServer, false))
+	client, err := newWithConfig(clientOpts(testXDSServer, false))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
@@ -250,7 +250,7 @@ func (s) TestRDSWatchAfterCache(t *testing.T) {
 	apiClientCh, cleanup := overrideNewAPIClient()
 	defer cleanup()
 
-	client, err := New(clientOpts(testXDSServer, false))
+	client, err := newWithConfig(clientOpts(testXDSServer, false))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}

--- a/xds/internal/client/tests/client_test.go
+++ b/xds/internal/client/tests/client_test.go
@@ -20,6 +20,7 @@ package tests_test
 
 import (
 	"testing"
+	"time"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/internal/grpctest"
@@ -42,77 +43,67 @@ const (
 	testXDSServer = "xds-server"
 )
 
-func clientOpts(balancerName string) xdsclient.Options {
-	return xdsclient.Options{
-		Config: bootstrap.Config{
-			BalancerName: balancerName,
-			Creds:        grpc.WithInsecure(),
-			NodeProto:    testutils.EmptyNodeProtoV2,
-		},
-	}
-}
-
 func (s) TestNew(t *testing.T) {
 	tests := []struct {
 		name    string
-		opts    xdsclient.Options
+		config  *bootstrap.Config
 		wantErr bool
 	}{
-		{name: "empty-opts", opts: xdsclient.Options{}, wantErr: true},
+		{
+			name:    "empty-opts",
+			config:  &bootstrap.Config{},
+			wantErr: true,
+		},
 		{
 			name: "empty-balancer-name",
-			opts: xdsclient.Options{
-				Config: bootstrap.Config{
-					Creds:     grpc.WithInsecure(),
-					NodeProto: testutils.EmptyNodeProtoV2,
-				},
+			config: &bootstrap.Config{
+				Creds:     grpc.WithInsecure(),
+				NodeProto: testutils.EmptyNodeProtoV2,
 			},
 			wantErr: true,
 		},
 		{
 			name: "empty-dial-creds",
-			opts: xdsclient.Options{
-				Config: bootstrap.Config{
-					BalancerName: testXDSServer,
-					NodeProto:    testutils.EmptyNodeProtoV2,
-				},
+			config: &bootstrap.Config{
+				BalancerName: testXDSServer,
+				NodeProto:    testutils.EmptyNodeProtoV2,
 			},
 			wantErr: true,
 		},
 		{
 			name: "empty-node-proto",
-			opts: xdsclient.Options{
-				Config: bootstrap.Config{
-					BalancerName: testXDSServer,
-					Creds:        grpc.WithInsecure(),
-				},
+			config: &bootstrap.Config{
+				BalancerName: testXDSServer,
+				Creds:        grpc.WithInsecure(),
 			},
 			wantErr: true,
 		},
 		{
 			name: "node-proto-version-mismatch",
-			opts: xdsclient.Options{
-				Config: bootstrap.Config{
-					BalancerName: testXDSServer,
-					Creds:        grpc.WithInsecure(),
-					NodeProto:    testutils.EmptyNodeProtoV3,
-					TransportAPI: version.TransportV2,
-				},
+			config: &bootstrap.Config{
+				BalancerName: testXDSServer,
+				Creds:        grpc.WithInsecure(),
+				NodeProto:    testutils.EmptyNodeProtoV3,
+				TransportAPI: version.TransportV2,
 			},
 			wantErr: true,
 		},
 		// TODO(easwars): Add cases for v3 API client.
 		{
 			name: "happy-case",
-			opts: clientOpts(testXDSServer),
+			config: &bootstrap.Config{
+				BalancerName: testXDSServer,
+				Creds:        grpc.WithInsecure(),
+				NodeProto:    testutils.EmptyNodeProtoV2,
+			},
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			c, err := xdsclient.New(test.opts)
+			c, err := xdsclient.NewWithConfigForTesting(test.config, 15*time.Second)
 			if (err != nil) != test.wantErr {
-				t.Fatalf("New(%+v) = %v, wantErr: %v", test.opts, err, test.wantErr)
+				t.Fatalf("New(%+v) = %v, wantErr: %v", test.config, err, test.wantErr)
 			}
 			if c != nil {
 				c.Close()

--- a/xds/internal/client/v2/client.go
+++ b/xds/internal/client/v2/client.go
@@ -181,8 +181,9 @@ func (v2c *client) HandleResponse(r proto.Message) (xdsclient.ResourceType, stri
 	return rType, resp.GetVersionInfo(), resp.GetNonce(), err
 }
 
-// handleLDSResponse processes an LDS response received from the xDS server. On
-// receipt of a good response, it also invokes the registered watcher callback.
+// handleLDSResponse processes an LDS response received from the management
+// server. On receipt of a good response, it also invokes the registered watcher
+// callback.
 func (v2c *client) handleLDSResponse(resp *v2xdspb.DiscoveryResponse) error {
 	update, err := xdsclient.UnmarshalListener(resp.GetResources(), v2c.logger)
 	if err != nil {
@@ -192,9 +193,9 @@ func (v2c *client) handleLDSResponse(resp *v2xdspb.DiscoveryResponse) error {
 	return nil
 }
 
-// handleRDSResponse processes an RDS response received from the xDS server. On
-// receipt of a good response, it caches validated resources and also invokes
-// the registered watcher callback.
+// handleRDSResponse processes an RDS response received from the management
+// server. On receipt of a good response, it caches validated resources and also
+// invokes the registered watcher callback.
 func (v2c *client) handleRDSResponse(resp *v2xdspb.DiscoveryResponse) error {
 	update, err := xdsclient.UnmarshalRouteConfig(resp.GetResources(), v2c.logger)
 	if err != nil {
@@ -204,8 +205,9 @@ func (v2c *client) handleRDSResponse(resp *v2xdspb.DiscoveryResponse) error {
 	return nil
 }
 
-// handleCDSResponse processes an CDS response received from the xDS server. On
-// receipt of a good response, it also invokes the registered watcher callback.
+// handleCDSResponse processes an CDS response received from the management
+// server. On receipt of a good response, it also invokes the registered watcher
+// callback.
 func (v2c *client) handleCDSResponse(resp *v2xdspb.DiscoveryResponse) error {
 	update, err := xdsclient.UnmarshalCluster(resp.GetResources(), v2c.logger)
 	if err != nil {

--- a/xds/internal/client/v3/client.go
+++ b/xds/internal/client/v3/client.go
@@ -181,8 +181,9 @@ func (v3c *client) HandleResponse(r proto.Message) (xdsclient.ResourceType, stri
 	return rType, resp.GetVersionInfo(), resp.GetNonce(), err
 }
 
-// handleLDSResponse processes an LDS response received from the xDS server. On
-// receipt of a good response, it also invokes the registered watcher callback.
+// handleLDSResponse processes an LDS response received from the management
+// server. On receipt of a good response, it also invokes the registered watcher
+// callback.
 func (v3c *client) handleLDSResponse(resp *v3discoverypb.DiscoveryResponse) error {
 	update, err := xdsclient.UnmarshalListener(resp.GetResources(), v3c.logger)
 	if err != nil {
@@ -192,9 +193,9 @@ func (v3c *client) handleLDSResponse(resp *v3discoverypb.DiscoveryResponse) erro
 	return nil
 }
 
-// handleRDSResponse processes an RDS response received from the xDS server. On
-// receipt of a good response, it caches validated resources and also invokes
-// the registered watcher callback.
+// handleRDSResponse processes an RDS response received from the management
+// server. On receipt of a good response, it caches validated resources and also
+// invokes the registered watcher callback.
 func (v3c *client) handleRDSResponse(resp *v3discoverypb.DiscoveryResponse) error {
 	update, err := xdsclient.UnmarshalRouteConfig(resp.GetResources(), v3c.logger)
 	if err != nil {
@@ -204,8 +205,9 @@ func (v3c *client) handleRDSResponse(resp *v3discoverypb.DiscoveryResponse) erro
 	return nil
 }
 
-// handleCDSResponse processes an CDS response received from the xDS server. On
-// receipt of a good response, it also invokes the registered watcher callback.
+// handleCDSResponse processes an CDS response received from the management
+// server. On receipt of a good response, it also invokes the registered watcher
+// callback.
 func (v3c *client) handleCDSResponse(resp *v3discoverypb.DiscoveryResponse) error {
 	update, err := xdsclient.UnmarshalCluster(resp.GetResources(), v3c.logger)
 	if err != nil {

--- a/xds/internal/testutils/fakeserver/server.go
+++ b/xds/internal/testutils/fakeserver/server.go
@@ -16,7 +16,7 @@
  *
  */
 
-// Package fakeserver provides a fake implementation of an management server.
+// Package fakeserver provides a fake implementation of the management server.
 package fakeserver
 
 import (

--- a/xds/internal/testutils/fakeserver/server.go
+++ b/xds/internal/testutils/fakeserver/server.go
@@ -16,7 +16,7 @@
  *
  */
 
-// Package fakeserver provides a fake implementation of an xDS server.
+// Package fakeserver provides a fake implementation of an management server.
 package fakeserver
 
 import (

--- a/xds/server.go
+++ b/xds/server.go
@@ -43,8 +43,8 @@ const (
 
 var (
 	// These new functions will be overridden in unit tests.
-	newXDSClient = func(opts xdsclient.Options) (xdsClientInterface, error) {
-		return xdsclient.New(opts)
+	newXDSClient = func() (xdsClientInterface, error) {
+		return xdsclient.New()
 	}
 	newXDSConfig  = bootstrap.NewConfig
 	newGRPCServer = func(opts ...grpc.ServerOption) grpcServerInterface {
@@ -162,12 +162,7 @@ func (s *GRPCServer) initXDSClient() error {
 		return nil
 	}
 
-	// Read the bootstrap file as part of initializing the xdsClient.
-	config, err := newXDSConfig()
-	if err != nil {
-		return fmt.Errorf("xds: failed to read bootstrap file: %v", err)
-	}
-	client, err := newXDSClient(xdsclient.Options{Config: *config})
+	client, err := newXDSClient()
 	if err != nil {
 		return fmt.Errorf("xds: failed to create xds-client: %v", err)
 	}

--- a/xds/server_test.go
+++ b/xds/server_test.go
@@ -196,7 +196,7 @@ func setupOverrides(t *testing.T) (*fakeGRPCServer, *testutils.Channel, func()) 
 
 	clientCh := testutils.NewChannel()
 	origNewXDSClient := newXDSClient
-	newXDSClient = func(xdsclient.Options) (xdsClientInterface, error) {
+	newXDSClient = func() (xdsClientInterface, error) {
 		c := fakeclient.NewClient()
 		clientCh.Send(c)
 		return c, nil
@@ -365,7 +365,7 @@ func (s) TestServeNewClientFailure(t *testing.T) {
 	defer func() { newXDSConfig = origNewXDSConfig }()
 
 	origNewXDSClient := newXDSClient
-	newXDSClient = func(xdsclient.Options) (xdsClientInterface, error) {
+	newXDSClient = func() (xdsClientInterface, error) {
 		return nil, errors.New("xdsClient creation failed")
 	}
 	defer func() { newXDSClient = origNewXDSClient }()


### PR DESCRIPTION
- xdsclient.New() no longer takes any input, all configs are from bootstrap file
  - added a NewForTesting()
- The returned *Client is a wrapper of the underlying client implementation, for ref-couting
- xds-resolver and xds-server no longer calls bootstrap.NewConfig. It only calls xdsclient.New()