### PR TITLE
xds: Minor improvements to xDS server API and test.

### DIFF
--- a/xds/internal/test/xds_server_integration_test.go
+++ b/xds/internal/test/xds_server_integration_test.go
@@ -150,9 +150,9 @@ func (s) TestServerSideXDS(t *testing.T) {
 	testpb.RegisterTestServiceServer(server, &testService{})
 	defer server.Stop()
 
-	localAddr, err := testutils.ListenerHostPort()
+	localAddr, err := testutils.AvailableHostPort()
 	if err != nil {
-		t.Fatalf("testutils.ListenerHostPort() failed: %v", err)
+		t.Fatalf("testutils.AvailableHostPort() failed: %v", err)
 	}
 
 	go func() {

--- a/xds/internal/testutils/local_address.go
+++ b/xds/internal/testutils/local_address.go
@@ -20,7 +20,7 @@ package testutils
 
 import "net"
 
-// ListenerHostPort returns a local address to listen on. This will be of the
+// AvailableHostPort returns a local address to listen on. This will be of the
 // form "host:port", where the host will be a literal IP address, and port
 // must be a literal port number. If the host is a literal IPv6 address it
 // will be enclosed in square brackets, as in "[2001:db8::1]:80.
@@ -29,7 +29,7 @@ import "net"
 // xds.GRPCServer which needs to be passed an IP:Port to listen on, where the IP
 // must be a literal IP and not localhost. This approach will work on support
 // one or both of IPv4 or IPv6.
-func ListenerHostPort() (string, error) {
+func AvailableHostPort() (string, error) {
 	l, err := net.Listen("tcp", "localhost:0")
 	if err != nil {
 		return "", err

--- a/xds/internal/testutils/local_address.go
+++ b/xds/internal/testutils/local_address.go
@@ -1,0 +1,40 @@
+/*
+ *
+ * Copyright 2020 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package testutils
+
+import "net"
+
+// ListenerHostPort returns a local address to listen on. This will be of the
+// form "host:port", where the host will be a literal IP address, and port
+// must be a literal port number. If the host is a literal IPv6 address it
+// will be enclosed in square brackets, as in "[2001:db8::1]:80.
+//
+// This is useful for tests which need to call the Serve() method on
+// xds.GRPCServer which needs to be passed an IP:Port to listen on, where the IP
+// must be a literal IP and not localhost. This approach will work on support
+// one or both of IPv4 or IPv6.
+func ListenerHostPort() (string, error) {
+	l, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		return "", err
+	}
+	addr := l.Addr().String()
+	l.Close()
+	return addr, nil
+}

--- a/xds/server.go
+++ b/xds/server.go
@@ -85,8 +85,7 @@ type ServeOptions struct {
 	// Address contains the local address to listen on. This should be of the
 	// form "host:port", where the host must be a literal IP address, and port
 	// must be a literal port number. If the host is a literal IPv6 address it
-	// must be enclosed in square brackets, as in "[2001:db8::1]:80. The host
-	// portion can be left unspecified.
+	// must be enclosed in square brackets, as in "[2001:db8::1]:80.
 	Address string
 }
 

--- a/xds/server_test.go
+++ b/xds/server_test.go
@@ -230,9 +230,9 @@ func (s) TestServeSuccess(t *testing.T) {
 	server := NewGRPCServer()
 	defer server.Stop()
 
-	localAddr, err := xdstestutils.ListenerHostPort()
+	localAddr, err := xdstestutils.AvailableHostPort()
 	if err != nil {
-		t.Fatalf("testutils.ListenerHostPort() failed: %v", err)
+		t.Fatalf("testutils.AvailableHostPort() failed: %v", err)
 	}
 
 	// Call Serve() in a goroutine, and push on a channel when Serve returns.
@@ -291,9 +291,9 @@ func (s) TestServeWithStop(t *testing.T) {
 	// it after the LDS watch has been registered.
 	server := NewGRPCServer()
 
-	localAddr, err := xdstestutils.ListenerHostPort()
+	localAddr, err := xdstestutils.AvailableHostPort()
 	if err != nil {
-		t.Fatalf("testutils.ListenerHostPort() failed: %v", err)
+		t.Fatalf("testutils.AvailableHostPort() failed: %v", err)
 	}
 
 	// Call Serve() in a goroutine, and push on a channel when Serve returns.
@@ -350,9 +350,9 @@ func (s) TestServeBootstrapFailure(t *testing.T) {
 	server := NewGRPCServer()
 	defer server.Stop()
 
-	localAddr, err := xdstestutils.ListenerHostPort()
+	localAddr, err := xdstestutils.AvailableHostPort()
 	if err != nil {
-		t.Fatalf("testutils.ListenerHostPort() failed: %v", err)
+		t.Fatalf("testutils.AvailableHostPort() failed: %v", err)
 	}
 
 	serveDone := testutils.NewChannel()
@@ -394,9 +394,9 @@ func (s) TestServeNewClientFailure(t *testing.T) {
 	server := NewGRPCServer()
 	defer server.Stop()
 
-	localAddr, err := xdstestutils.ListenerHostPort()
+	localAddr, err := xdstestutils.AvailableHostPort()
 	if err != nil {
-		t.Fatalf("testutils.ListenerHostPort() failed: %v", err)
+		t.Fatalf("testutils.AvailableHostPort() failed: %v", err)
 	}
 
 	serveDone := testutils.NewChannel()

--- a/xds/server_test.go
+++ b/xds/server_test.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 	"net"
 	"reflect"
-	"strings"
 	"testing"
 	"time"
 
@@ -259,7 +258,7 @@ func (s) TestServeSuccess(t *testing.T) {
 		t.Fatalf("error when waiting for a ListenerWatch: %v", err)
 	}
 	wantName := fmt.Sprintf("grpc/server?udpa.resource.listening_address=%s", localAddr)
-	if !strings.HasPrefix(name, wantName) {
+	if name != wantName {
 		t.Fatalf("LDS watch registered for name %q, want %q", name, wantName)
 	}
 
@@ -321,7 +320,7 @@ func (s) TestServeWithStop(t *testing.T) {
 		t.Fatalf("error when waiting for a ListenerWatch: %v", err)
 	}
 	wantName := fmt.Sprintf("grpc/server?udpa.resource.listening_address=%s", localAddr)
-	if !strings.HasPrefix(name, wantName) {
+	if name != wantName {
 		server.Stop()
 		t.Fatalf("LDS watch registered for name %q, wantPrefix %q", name, wantName)
 	}


### PR DESCRIPTION
Changes include the following:
- Remove the `Network` field from `ServeOptions` and hardcode it to `tcp` for now. This was decided in a previous PR.
- Enhance `ServeOptions.validate()` method to do the following:
  - accept only literal IPs, not even localhost
  - accept only valid port numbers
- Add a function in `xds/testutils` package named `ListenerHostPort` which will return the `IP:Port` as required by the `Serve()` method. This can be swapped out in google3 to work with restrictions there.
- Update the tests to comply with the above changes.