### PR TITLE
xds: call xdsclient.New instead of getting xds_client from attributes

### DIFF
--- a/xds/internal/internal.go
+++ b/xds/internal/internal.go
@@ -24,13 +24,6 @@ import (
 	"strings"
 )
 
-type clientID string
-
-// XDSClientID is the attributes key used to pass the address of the xdsClient
-// object shared between the resolver and the balancer. The xdsClient object is
-// created by the resolver and passed to the balancer.
-const XDSClientID = clientID("xdsClientID")
-
 // LocalityID is xds.Locality without XXX fields, so it can be used as map
 // keys.
 //

--- a/xds/internal/resolver/xds_resolver.go
+++ b/xds/internal/resolver/xds_resolver.go
@@ -22,23 +22,17 @@ package resolver
 import (
 	"fmt"
 
-	"google.golang.org/grpc/attributes"
 	"google.golang.org/grpc/internal/grpclog"
 	"google.golang.org/grpc/internal/grpcsync"
 	"google.golang.org/grpc/resolver"
 
-	xdsinternal "google.golang.org/grpc/xds/internal"
 	xdsclient "google.golang.org/grpc/xds/internal/client"
 )
 
 const xdsScheme = "xds"
 
 // For overriding in unittests.
-var (
-	newXDSClient = func() (xdsClientInterface, error) {
-		return xdsclient.New()
-	}
-)
+var newXDSClient = func() (xdsClientInterface, error) { return xdsclient.New() }
 
 func init() {
 	resolver.Register(&xdsResolverBuilder{})
@@ -163,7 +157,6 @@ func (r *xdsResolver) run() {
 			r.logger.Infof("Received update on resource %v from xds-client %p, generated service config: %v", r.target.Endpoint, r.client, sc)
 			r.cc.UpdateState(resolver.State{
 				ServiceConfig: r.cc.ParseServiceConfig(sc),
-				Attributes:    attributes.New(xdsinternal.XDSClientID, r.client),
 			})
 		}
 	}

--- a/xds/internal/resolver/xds_resolver_test.go
+++ b/xds/internal/resolver/xds_resolver_test.go
@@ -31,7 +31,6 @@ import (
 	"google.golang.org/grpc/internal/testutils"
 	"google.golang.org/grpc/resolver"
 	"google.golang.org/grpc/serviceconfig"
-	xdsinternal "google.golang.org/grpc/xds/internal"
 	_ "google.golang.org/grpc/xds/internal/balancer/cdsbalancer" // To parse LB config
 	"google.golang.org/grpc/xds/internal/client"
 	xdsclient "google.golang.org/grpc/xds/internal/client"
@@ -313,9 +312,6 @@ func (s) TestXDSResolverGoodServiceUpdate(t *testing.T) {
 			t.Fatalf("ClientConn.UpdateState returned error: %v", err)
 		}
 		rState := gotState.(resolver.State)
-		if gotClient := rState.Attributes.Value(xdsinternal.XDSClientID); gotClient != xdsC {
-			t.Fatalf("ClientConn.UpdateState got xdsClient: %v, want %v", gotClient, xdsC)
-		}
 		if err := rState.ServiceConfig.Err; err != nil {
 			t.Fatalf("ClientConn.UpdateState received error in service config: %v", rState.ServiceConfig.Err)
 		}
@@ -371,9 +367,6 @@ func (s) TestXDSResolverGoodUpdateAfterError(t *testing.T) {
 		t.Fatalf("ClientConn.UpdateState returned error: %v", err)
 	}
 	rState := gotState.(resolver.State)
-	if gotClient := rState.Attributes.Value(xdsinternal.XDSClientID); gotClient != xdsC {
-		t.Fatalf("ClientConn.UpdateState got xdsClient: %v, want %v", gotClient, xdsC)
-	}
 	if err := rState.ServiceConfig.Err; err != nil {
 		t.Fatalf("ClientConn.UpdateState received error in service config: %v", rState.ServiceConfig.Err)
 	}
@@ -422,11 +415,6 @@ func (s) TestXDSResolverResourceNotFoundError(t *testing.T) {
 		t.Fatalf("ClientConn.UpdateState returned error: %v", err)
 	}
 	rState := gotState.(resolver.State)
-	// This update shouldn't have xds-client in it, because it doesn't pick an
-	// xds balancer.
-	if gotClient := rState.Attributes.Value(xdsinternal.XDSClientID); gotClient != nil {
-		t.Fatalf("ClientConn.UpdateState got xdsClient: %v, want <nil>", gotClient)
-	}
 	wantParsedConfig := internal.ParseServiceConfigForTesting.(func(string) *serviceconfig.ParseResult)("{}")
 	if !internal.EqualServiceConfigForTesting(rState.ServiceConfig.Config, wantParsedConfig.Config) {
 		t.Error("ClientConn.UpdateState got wrong service config")


### PR DESCRIPTION
This is done in all xds resolver/balancers.

And each balancer needs to call client.Close on Close(), to refcount--.