### PR TITLE
trim the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,10 @@
 all: vet test testrace
 
-build: deps
+build:
 	go build google.golang.org/grpc/...
 
 clean:
 	go clean -i google.golang.org/grpc/...
-
-deps:
-	go get -d -v google.golang.org/grpc/...
 
 proto:
 	@ if ! which protoc > /dev/null; then \
@@ -16,30 +13,15 @@ proto:
 	fi
 	go generate google.golang.org/grpc/...
 
-test: testdeps
+test:
 	go test -cpu 1,4 -timeout 7m google.golang.org/grpc/...
 
-testsubmodule: testdeps
+testsubmodule:
 	cd security/advancedtls && go test -cpu 1,4 -timeout 7m google.golang.org/grpc/security/advancedtls/...
 	cd security/authorization && go test -cpu 1,4 -timeout 7m google.golang.org/grpc/security/authorization/...
 
-testappengine: testappenginedeps
-	goapp test -cpu 1,4 -timeout 7m google.golang.org/grpc/...
-
-testappenginedeps:
-	goapp get -d -v -t -tags 'appengine appenginevm' google.golang.org/grpc/...
-
-testdeps:
-	go get -d -v -t google.golang.org/grpc/...
-
-testrace: testdeps
+testrace:
 	go test -race -cpu 1,4 -timeout 7m google.golang.org/grpc/...
-
-updatedeps:
-	go get -d -v -u -f google.golang.org/grpc/...
-
-updatetestdeps:
-	go get -d -v -t -u -f google.golang.org/grpc/...
 
 vet: vetdeps
 	./vet.sh
@@ -51,14 +33,10 @@ vetdeps:
 	all \
 	build \
 	clean \
-	deps \
 	proto \
 	test \
 	testappengine \
 	testappenginedeps \
-	testdeps \
 	testrace \
-	updatedeps \
-	updatetestdeps \
 	vet \
 	vetdeps


### PR DESCRIPTION
Remove sections which deal with `deps`. These are not required with the
move to Go modules, and create unnecessary diffs in go.mod and go.sum
files.

Left the rest as is, as some are used from `testing.yaml` and others
serve as a handy reference when one wants to build/test something
specific.