### PR TITLE
eds/lrs: handle nil when LRS is disabled

### DIFF
--- a/xds/internal/balancer/edsbalancer/eds_impl_test.go
+++ b/xds/internal/balancer/edsbalancer/eds_impl_test.go
@@ -750,7 +750,6 @@ func (s) TestEDS_LoadReportDisabled(t *testing.T) {
 	// We create an xdsClientWrapper with a dummy xdsClientInterface which only
 	// implements the LoadStore() method to return the underlying load.Store to
 	// be used.
-	loadStore := load.NewStore()
 	lsWrapper := &loadStoreWrapper{}
 	lsWrapper.updateServiceName(testClusterNames[0])
 	// Not calling lsWrapper.updateLoadStore(loadStore) because LRS is disabled.
@@ -759,8 +758,6 @@ func (s) TestEDS_LoadReportDisabled(t *testing.T) {
 	edsb := newEDSBalancerImpl(cc, nil, lsWrapper, nil)
 	edsb.enqueueChildBalancerStateUpdate = edsb.updateState
 
-	backendToBalancerID := make(map[balancer.SubConn]internal.LocalityID)
-
 	// Two localities, each with one backend.
 	clab1 := testutils.NewClusterLoadAssignmentBuilder(testClusterNames[0], nil)
 	clab1.AddLocality(testSubZones[0], 1, 0, testEndpointAddrs[:1], nil)
@@ -768,35 +765,11 @@ func (s) TestEDS_LoadReportDisabled(t *testing.T) {
 	sc1 := <-cc.NewSubConnCh
 	edsb.handleSubConnStateChange(sc1, connectivity.Connecting)
 	edsb.handleSubConnStateChange(sc1, connectivity.Ready)
-	locality1 := internal.LocalityID{SubZone: testSubZones[0]}
-	backendToBalancerID[sc1] = locality1
-
-	// Add the second locality later to make sure sc2 belongs to the second
-	// locality. Otherwise the test is flaky because of a map is used in EDS to
-	// keep localities.
-	clab1.AddLocality(testSubZones[1], 1, 0, testEndpointAddrs[1:2], nil)
-	edsb.handleEDSResponse(parseEDSRespProtoForTesting(clab1.Build()))
-	sc2 := <-cc.NewSubConnCh
-	edsb.handleSubConnStateChange(sc2, connectivity.Connecting)
-	edsb.handleSubConnStateChange(sc2, connectivity.Ready)
-	locality2 := internal.LocalityID{SubZone: testSubZones[1]}
-	backendToBalancerID[sc2] = locality2
 
 	// Test roundrobin with two subconns.
 	p1 := <-cc.NewPickerCh
-	// We expect the 10 picks to be split between the localities since they are
-	// of equal weight. And since we only mark the picks routed to sc2 as done,
-	// the picks on sc1 should show up as inProgress.
+	// We call picks to make sure they don't panic.
 	for i := 0; i < 10; i++ {
-		scst, _ := p1.Pick(balancer.PickInfo{})
-		if scst.Done != nil && scst.SubConn != sc1 {
-			scst.Done(balancer.DoneInfo{})
-		}
-	}
-
-	var wantStoreData []*load.Data
-	gotStoreData := loadStore.Stats(testClusterNames[0:1])
-	if diff := cmp.Diff(wantStoreData, gotStoreData, cmpopts.EquateEmpty(), cmpopts.IgnoreFields(load.Data{}, "ReportInterval")); diff != "" {
-		t.Errorf("store.stats() returned unexpected diff (-want +got):\n%s", diff)
+		p1.Pick(balancer.PickInfo{})
 	}
 }

--- a/xds/internal/balancer/edsbalancer/eds_impl_test.go
+++ b/xds/internal/balancer/edsbalancer/eds_impl_test.go
@@ -747,9 +747,6 @@ func (s) TestEDS_LoadReport(t *testing.T) {
 // TestEDS_LoadReportDisabled covers the case that LRS is disabled. It makes
 // sure the EDS implementation isn't broken (doesn't panic).
 func (s) TestEDS_LoadReportDisabled(t *testing.T) {
-	// We create an xdsClientWrapper with a dummy xdsClientInterface which only
-	// implements the LoadStore() method to return the underlying load.Store to
-	// be used.
 	lsWrapper := &loadStoreWrapper{}
 	lsWrapper.updateServiceName(testClusterNames[0])
 	// Not calling lsWrapper.updateLoadStore(loadStore) because LRS is disabled.
@@ -758,7 +755,7 @@ func (s) TestEDS_LoadReportDisabled(t *testing.T) {
 	edsb := newEDSBalancerImpl(cc, nil, lsWrapper, nil)
 	edsb.enqueueChildBalancerStateUpdate = edsb.updateState
 
-	// Two localities, each with one backend.
+	// One localities, with one backend.
 	clab1 := testutils.NewClusterLoadAssignmentBuilder(testClusterNames[0], nil)
 	clab1.AddLocality(testSubZones[0], 1, 0, testEndpointAddrs[:1], nil)
 	edsb.handleEDSResponse(parseEDSRespProtoForTesting(clab1.Build()))

--- a/xds/internal/balancer/edsbalancer/load_store_wrapper.go
+++ b/xds/internal/balancer/edsbalancer/load_store_wrapper.go
@@ -58,23 +58,31 @@ func (lsw *loadStoreWrapper) updateLoadStore(store *load.Store) {
 func (lsw *loadStoreWrapper) CallStarted(locality string) {
 	lsw.mu.RLock()
 	defer lsw.mu.RUnlock()
-	lsw.perCluster.CallStarted(locality)
+	if lsw.perCluster != nil {
+		lsw.perCluster.CallStarted(locality)
+	}
 }
 
 func (lsw *loadStoreWrapper) CallFinished(locality string, err error) {
 	lsw.mu.RLock()
 	defer lsw.mu.RUnlock()
-	lsw.perCluster.CallFinished(locality, err)
+	if lsw.perCluster != nil {
+		lsw.perCluster.CallFinished(locality, err)
+	}
 }
 
 func (lsw *loadStoreWrapper) CallServerLoad(locality, name string, val float64) {
 	lsw.mu.RLock()
 	defer lsw.mu.RUnlock()
-	lsw.perCluster.CallServerLoad(locality, name, val)
+	if lsw.perCluster != nil {
+		lsw.perCluster.CallServerLoad(locality, name, val)
+	}
 }
 
 func (lsw *loadStoreWrapper) CallDropped(category string) {
 	lsw.mu.RLock()
 	defer lsw.mu.RUnlock()
-	lsw.perCluster.CallDropped(category)
+	if lsw.perCluster != nil {
+		lsw.perCluster.CallDropped(category)
+	}
 }

--- a/xds/internal/balancer/lrs/balancer.go
+++ b/xds/internal/balancer/lrs/balancer.go
@@ -195,25 +195,33 @@ func (lsw *loadStoreWrapper) updateLoadStore(store *load.Store) {
 func (lsw *loadStoreWrapper) CallStarted(locality string) {
 	lsw.mu.RLock()
 	defer lsw.mu.RUnlock()
-	lsw.perCluster.CallStarted(locality)
+	if lsw.perCluster != nil {
+		lsw.perCluster.CallStarted(locality)
+	}
 }
 
 func (lsw *loadStoreWrapper) CallFinished(locality string, err error) {
 	lsw.mu.RLock()
 	defer lsw.mu.RUnlock()
-	lsw.perCluster.CallFinished(locality, err)
+	if lsw.perCluster != nil {
+		lsw.perCluster.CallFinished(locality, err)
+	}
 }
 
 func (lsw *loadStoreWrapper) CallServerLoad(locality, name string, val float64) {
 	lsw.mu.RLock()
 	defer lsw.mu.RUnlock()
-	lsw.perCluster.CallServerLoad(locality, name, val)
+	if lsw.perCluster != nil {
+		lsw.perCluster.CallServerLoad(locality, name, val)
+	}
 }
 
 func (lsw *loadStoreWrapper) CallDropped(category string) {
 	lsw.mu.RLock()
 	defer lsw.mu.RUnlock()
-	lsw.perCluster.CallDropped(category)
+	if lsw.perCluster != nil {
+		lsw.perCluster.CallDropped(category)
+	}
 }
 
 type xdsClientWrapper struct {


### PR DESCRIPTION
Checking `nil` before calling the methods. Even though the implementation's receiver checks for nil, the interface `nil` doesn't have the implementation type, and won't call the implementation's receiver.

https://play.golang.org/p/LilYpHAr84j