### PR TITLE
internal/syscall: make Rusage a type alias

### DIFF
--- a/internal/syscall/syscall_linux.go
+++ b/internal/syscall/syscall_linux.go
@@ -44,25 +44,23 @@ func GetCPUTime() int64 {
 }
 
 // Rusage is an alias for syscall.Rusage under linux environment.
-type Rusage syscall.Rusage
+type Rusage = syscall.Rusage
 
 // GetRusage returns the resource usage of current process.
-func GetRusage() (rusage *Rusage) {
-	rusage = new(Rusage)
-	syscall.Getrusage(syscall.RUSAGE_SELF, (*syscall.Rusage)(rusage))
-	return
+func GetRusage() *Rusage {
+	rusage := new(Rusage)
+	syscall.Getrusage(syscall.RUSAGE_SELF, rusage)
+	return rusage
 }
 
 // CPUTimeDiff returns the differences of user CPU time and system CPU time used
 // between two Rusage structs.
 func CPUTimeDiff(first *Rusage, latest *Rusage) (float64, float64) {
-	f := (*syscall.Rusage)(first)
-	l := (*syscall.Rusage)(latest)
 	var (
-		utimeDiffs  = l.Utime.Sec - f.Utime.Sec
-		utimeDiffus = l.Utime.Usec - f.Utime.Usec
-		stimeDiffs  = l.Stime.Sec - f.Stime.Sec
-		stimeDiffus = l.Stime.Usec - f.Stime.Usec
+		utimeDiffs  = latest.Utime.Sec - first.Utime.Sec
+		utimeDiffus = latest.Utime.Usec - first.Utime.Usec
+		stimeDiffs  = latest.Stime.Sec - first.Stime.Sec
+		stimeDiffus = latest.Stime.Usec - first.Stime.Usec
 	)
 
 	uTimeElapsed := float64(utimeDiffs) + float64(utimeDiffus)*1.0e-6

--- a/internal/syscall/syscall_nonlinux.go
+++ b/internal/syscall/syscall_nonlinux.go
@@ -50,7 +50,7 @@ func GetCPUTime() int64 {
 type Rusage struct{}
 
 // GetRusage is a no-op function under non-linux or appengine environment.
-func GetRusage() (rusage *Rusage) {
+func GetRusage() *Rusage {
 	log()
 	return nil
 }


### PR DESCRIPTION
Making Rusage a type alias rather than a type definition allows to avoid
type conversions in several places.

Type aliases are supported since Go 1.9, go.mod states Go 1.11 to be the
minimum supported version.