### PR TITLE
credentials/xds: ServerHandshake() implementation

### DIFF
--- a/credentials/xds/xds_client_test.go
+++ b/credentials/xds/xds_client_test.go
@@ -432,7 +432,7 @@ func (s) TestClientCredsHandshakeTimeout(t *testing.T) {
 	sCtx, sCancel := context.WithTimeout(context.Background(), defaultTestShortTimeout)
 	defer sCancel()
 	ctx := newTestContextWithHandshakeInfo(sCtx, makeRootProvider(t, "x509/server_ca_cert.pem"), nil, defaultTestCertSAN)
-	if _, _, err := creds.ClientHandshake(sCtx, authority, conn); err == nil {
+	if _, _, err := creds.ClientHandshake(ctx, authority, conn); err == nil {
 		t.Fatal("ClientHandshake() succeeded when expected to timeout")
 	}
 	close(clientDone)

--- a/credentials/xds/xds_server_test.go
+++ b/credentials/xds/xds_server_test.go
@@ -255,9 +255,13 @@ func (s) TestServerCredsHandshakeFailure(t *testing.T) {
 	defer rawConn.Close()
 	tlsConn := tls.Client(rawConn, makeClientTLSConfig(t, true))
 	tlsConn.SetDeadline(time.Now().Add(defaultTestTimeout))
-	if err := tlsConn.Handshake(); err != nil {
-		t.Fatal(err)
-	}
+	// There seems to be a discrepancy in the return value of this function
+	// between Go versions before and after 1.13. It returns an error in earlier
+	// versions while it returns nil in more recent versions. This could be
+	// because of the switch to TLS1.3 in recent version.
+	// TODO(easwars): Check the return value and call t.Fatalf() for non-nil
+	// errors once we drop support for versions older than Go1.13.
+	tlsConn.Handshake()
 
 	// Read handshake result from the testServer which will return an error if
 	// the handshake succeeded.
@@ -444,9 +448,13 @@ func (s) TestServerCredsProviderSwitch(t *testing.T) {
 		defer rawConn.Close()
 		tlsConn := tls.Client(rawConn, makeClientTLSConfig(t, true))
 		tlsConn.SetDeadline(time.Now().Add(defaultTestTimeout))
-		if err := tlsConn.Handshake(); err != nil {
-			t.Fatal(err)
-		}
+		// There seems to be a discrepancy in the return value of this function
+		// between Go versions before and after 1.13. It returns an error in earlier
+		// versions while it returns nil in more recent versions. This could be
+		// because of the switch to TLS1.3 in recent version.
+		// TODO(easwars): Check the return value and call t.Fatalf() for non-nil
+		// errors once we drop support for versions older than Go1.13.
+		tlsConn.Handshake()
 
 		// Read the handshake result from the testServer which contains the
 		// TLS connection state on the server-side and compare it with the

--- a/credentials/xds/xds_server_test.go
+++ b/credentials/xds/xds_server_test.go
@@ -255,13 +255,9 @@ func (s) TestServerCredsHandshakeFailure(t *testing.T) {
 	defer rawConn.Close()
 	tlsConn := tls.Client(rawConn, makeClientTLSConfig(t, true))
 	tlsConn.SetDeadline(time.Now().Add(defaultTestTimeout))
-	// There seems to be a discrepancy in the return value of this function
-	// between Go versions before and after 1.13. It returns an error in earlier
-	// versions while it returns nil in more recent versions. This could be
-	// because of the switch to TLS1.3 in recent version.
-	// TODO(easwars): Check the return value and call t.Fatalf() for non-nil
-	// errors once we drop support for versions older than Go1.13.
-	tlsConn.Handshake()
+	if err := tlsConn.Handshake(); err != nil {
+		t.Fatal(err)
+	}
 
 	// Read handshake result from the testServer which will return an error if
 	// the handshake succeeded.
@@ -448,13 +444,9 @@ func (s) TestServerCredsProviderSwitch(t *testing.T) {
 		defer rawConn.Close()
 		tlsConn := tls.Client(rawConn, makeClientTLSConfig(t, true))
 		tlsConn.SetDeadline(time.Now().Add(defaultTestTimeout))
-		// There seems to be a discrepancy in the return value of this function
-		// between Go versions before and after 1.13. It returns an error in earlier
-		// versions while it returns nil in more recent versions. This could be
-		// because of the switch to TLS1.3 in recent version.
-		// TODO(easwars): Check the return value and call t.Fatalf() for non-nil
-		// errors once we drop support for versions older than Go1.13.
-		tlsConn.Handshake()
+		if err := tlsConn.Handshake(); err != nil {
+			t.Fatal(err)
+		}
 
 		// Read the handshake result from the testServer which contains the
 		// TLS connection state on the server-side and compare it with the

--- a/credentials/xds/xds_server_test.go
+++ b/credentials/xds/xds_server_test.go
@@ -255,8 +255,9 @@ func (s) TestServerCredsHandshakeFailure(t *testing.T) {
 	defer rawConn.Close()
 	tlsConn := tls.Client(rawConn, makeClientTLSConfig(t, true))
 	tlsConn.SetDeadline(time.Now().Add(defaultTestTimeout))
-	// See comment in makeClientTLSConfig() on why we ignore this error.
-	tlsConn.Handshake()
+	if err := tlsConn.Handshake(); err != nil {
+		t.Fatal(err)
+	}
 
 	// Read handshake result from the testServer which will return an error if
 	// the handshake succeeded.
@@ -346,8 +347,9 @@ func (s) TestServerCredsHandshakeSuccess(t *testing.T) {
 			defer rawConn.Close()
 			tlsConn := tls.Client(rawConn, makeClientTLSConfig(t, test.requireClientCert))
 			tlsConn.SetDeadline(time.Now().Add(defaultTestTimeout))
-			// See comment in makeClientTLSConfig() on why we ignore this error.
-			tlsConn.Handshake()
+			if err := tlsConn.Handshake(); err != nil {
+				t.Fatal(err)
+			}
 
 			// Read the handshake result from the testServer which contains the
 			// TLS connection state on the server-side and compare it with the
@@ -442,8 +444,9 @@ func (s) TestServerCredsProviderSwitch(t *testing.T) {
 		defer rawConn.Close()
 		tlsConn := tls.Client(rawConn, makeClientTLSConfig(t, true))
 		tlsConn.SetDeadline(time.Now().Add(defaultTestTimeout))
-		// See comment in makeClientTLSConfig() on why we ignore this error.
-		tlsConn.Handshake()
+		if err := tlsConn.Handshake(); err != nil {
+			t.Fatal(err)
+		}
 
 		// Read the handshake result from the testServer which contains the
 		// TLS connection state on the server-side and compare it with the

--- a/credentials/xds/xds_server_test.go
+++ b/credentials/xds/xds_server_test.go
@@ -1,0 +1,489 @@
+/*
+ *
+ * Copyright 2020 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package xds
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/tls/certprovider"
+	"google.golang.org/grpc/testdata"
+)
+
+func makeClientTLSConfig(t *testing.T, mTLS bool) *tls.Config {
+	t.Helper()
+
+	pemData, err := ioutil.ReadFile(testdata.Path("x509/server_ca_cert.pem"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	roots := x509.NewCertPool()
+	roots.AppendCertsFromPEM(pemData)
+
+	var certs []tls.Certificate
+	if mTLS {
+		cert, err := tls.LoadX509KeyPair(testdata.Path("x509/client1_cert.pem"), testdata.Path("x509/client1_key.pem"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		certs = append(certs, cert)
+	}
+
+	return &tls.Config{
+		Certificates: certs,
+		RootCAs:      roots,
+		ServerName:   "*.test.example.com",
+		// Setting this to true completely turns off the certificate validation
+		// on the client side. So, the client side handshake always seems to
+		// succeed. But if we want to turn this ON, we will need to generate
+		// certificates which work with localhost, or supply a custom
+		// verification function. So, the server credentials tests will rely
+		// solely on the success/failure of the server-side handshake.
+		InsecureSkipVerify: true,
+	}
+}
+
+// Helper function to create a real TLS server credentials which is used as
+// fallback credentials from multiple tests.
+func makeFallbackServerCreds(t *testing.T) credentials.TransportCredentials {
+	t.Helper()
+
+	creds, err := credentials.NewServerTLSFromFile(testdata.Path("x509/server1_cert.pem"), testdata.Path("x509/server1_key.pem"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return creds
+}
+
+type errorCreds struct {
+	credentials.TransportCredentials
+}
+
+// TestServerCredsWithoutFallback verifies that the call to
+// NewServerCredentials() fails when no fallback is specified.
+func (s) TestServerCredsWithoutFallback(t *testing.T) {
+	if _, err := NewServerCredentials(ServerOptions{}); err == nil {
+		t.Fatal("NewServerCredentials() succeeded without specifying fallback")
+	}
+}
+
+type wrapperConn struct {
+	net.Conn
+	xdsHI    *HandshakeInfo
+	deadline time.Time
+}
+
+func (wc *wrapperConn) XDSHandshakeInfo() *HandshakeInfo {
+	return wc.xdsHI
+}
+
+func (wc *wrapperConn) GetDeadline() time.Time {
+	return wc.deadline
+}
+
+func newWrappedConn(conn net.Conn, xdsHI *HandshakeInfo, deadline time.Time) *wrapperConn {
+	return &wrapperConn{Conn: conn, xdsHI: xdsHI, deadline: deadline}
+}
+
+// TestServerCredsInvalidHandshakeInfo verifies scenarios where the passed in
+// HandshakeInfo is invalid because it does not contain the expected certificate
+// providers.
+func (s) TestServerCredsInvalidHandshakeInfo(t *testing.T) {
+	opts := ServerOptions{FallbackCreds: &errorCreds{}}
+	creds, err := NewServerCredentials(opts)
+	if err != nil {
+		t.Fatalf("NewServerCredentials(%v) failed: %v", opts, err)
+	}
+
+	info := NewHandshakeInfo(&fakeProvider{}, nil)
+	conn := newWrappedConn(nil, info, time.Time{})
+	if _, _, err := creds.ServerHandshake(conn); err == nil {
+		t.Fatal("ServerHandshake succeeded without identity certificate provider in HandshakeInfo")
+	}
+}
+
+// TestServerCredsProviderFailure verifies the cases where an expected
+// certificate provider is missing in the HandshakeInfo value in the context.
+func (s) TestServerCredsProviderFailure(t *testing.T) {
+	opts := ServerOptions{FallbackCreds: &errorCreds{}}
+	creds, err := NewServerCredentials(opts)
+	if err != nil {
+		t.Fatalf("NewServerCredentials(%v) failed: %v", opts, err)
+	}
+
+	tests := []struct {
+		desc             string
+		rootProvider     certprovider.Provider
+		identityProvider certprovider.Provider
+		wantErr          string
+	}{
+		{
+			desc:             "erroring identity provider",
+			identityProvider: &fakeProvider{err: errors.New("identity provider error")},
+			wantErr:          "identity provider error",
+		},
+		{
+			desc:             "erroring root provider",
+			identityProvider: &fakeProvider{km: &certprovider.KeyMaterial{}},
+			rootProvider:     &fakeProvider{err: errors.New("root provider error")},
+			wantErr:          "root provider error",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			info := NewHandshakeInfo(test.rootProvider, test.identityProvider)
+			conn := newWrappedConn(nil, info, time.Time{})
+			if _, _, err := creds.ServerHandshake(conn); err == nil || !strings.Contains(err.Error(), test.wantErr) {
+				t.Fatalf("ServerHandshake() returned error: %q, wantErr: %q", err, test.wantErr)
+			}
+		})
+	}
+}
+
+// TestServerCredsHandshakeTimeout verifies the case where the client does not
+// send required handshake data before the deadline set on the net.Conn passed
+// to ServerHandshake().
+func (s) TestServerCredsHandshakeTimeout(t *testing.T) {
+	opts := ServerOptions{FallbackCreds: &errorCreds{}}
+	creds, err := NewServerCredentials(opts)
+	if err != nil {
+		t.Fatalf("NewServerCredentials(%v) failed: %v", opts, err)
+	}
+
+	// Create a test server which uses the xDS server credentials created above
+	// to perform TLS handshake on incoming connections.
+	ts := newTestServerWithHandshakeFunc(func(rawConn net.Conn) handshakeResult {
+		hi := NewHandshakeInfo(makeRootProvider(t, "x509/client_ca_cert.pem"), makeIdentityProvider(t, "x509/server2_cert.pem", "x509/server2_key.pem"))
+		hi.SetRequireClientCert(true)
+
+		// Create a wrapped conn which can return the HandshakeInfo created
+		// above with a very small deadline.
+		d := time.Now().Add(defaultTestShortTimeout)
+		rawConn.SetDeadline(d)
+		conn := newWrappedConn(rawConn, hi, d)
+
+		// ServerHandshake() on the xDS credentials is expected to fail.
+		if _, _, err := creds.ServerHandshake(conn); err == nil {
+			return handshakeResult{err: errors.New("ServerHandshake() succeeded when expected to timeout")}
+		}
+		return handshakeResult{}
+	})
+	defer ts.stop()
+
+	// Dial the test server, but don't trigger the TLS handshake. This will
+	// cause ServerHandshake() to fail.
+	rawConn, err := net.Dial("tcp", ts.address)
+	if err != nil {
+		t.Fatalf("net.Dial(%s) failed: %v", ts.address, err)
+	}
+	defer rawConn.Close()
+
+	// Read handshake result from the testServer and expect a failure result.
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	val, err := ts.hsResult.Receive(ctx)
+	if err != nil {
+		t.Fatalf("testServer failed to return handshake result: %v", err)
+	}
+	hsr := val.(handshakeResult)
+	if hsr.err != nil {
+		t.Fatalf("testServer handshake failure: %v", hsr.err)
+	}
+}
+
+// TestServerCredsHandshakeFailure verifies the case where the server-side
+// credentials uses a root certificate which does not match the certificate
+// presented by the client, and hence the handshake must fail.
+func (s) TestServerCredsHandshakeFailure(t *testing.T) {
+	opts := ServerOptions{FallbackCreds: &errorCreds{}}
+	creds, err := NewServerCredentials(opts)
+	if err != nil {
+		t.Fatalf("NewServerCredentials(%v) failed: %v", opts, err)
+	}
+
+	// Create a test server which uses the xDS server credentials created above
+	// to perform TLS handshake on incoming connections.
+	ts := newTestServerWithHandshakeFunc(func(rawConn net.Conn) handshakeResult {
+		// Create a HandshakeInfo which has a root provider which does not match
+		// the certificate sent by the client.
+		hi := NewHandshakeInfo(makeRootProvider(t, "x509/server_ca_cert.pem"), makeIdentityProvider(t, "x509/client2_cert.pem", "x509/client2_key.pem"))
+		hi.SetRequireClientCert(true)
+
+		// Create a wrapped conn which can return the HandshakeInfo and
+		// configured deadline to the xDS credentials' ServerHandshake()
+		// method.
+		conn := newWrappedConn(rawConn, hi, time.Now().Add(defaultTestTimeout))
+
+		// ServerHandshake() on the xDS credentials is expected to fail.
+		if _, _, err := creds.ServerHandshake(conn); err == nil {
+			return handshakeResult{err: errors.New("ServerHandshake() succeeded when expected to fail")}
+		}
+		return handshakeResult{}
+	})
+	defer ts.stop()
+
+	// Dial the test server, and trigger the TLS handshake.
+	rawConn, err := net.Dial("tcp", ts.address)
+	if err != nil {
+		t.Fatalf("net.Dial(%s) failed: %v", ts.address, err)
+	}
+	defer rawConn.Close()
+	tlsConn := tls.Client(rawConn, makeClientTLSConfig(t, true))
+	tlsConn.SetDeadline(time.Now().Add(defaultTestTimeout))
+	// See comment in makeClientTLSConfig() on why we ignore this error.
+	tlsConn.Handshake()
+
+	// Read handshake result from the testServer which will return an error if
+	// the handshake succeeded.
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	val, err := ts.hsResult.Receive(ctx)
+	if err != nil {
+		t.Fatalf("testServer failed to return handshake result: %v", err)
+	}
+	hsr := val.(handshakeResult)
+	if hsr.err != nil {
+		t.Fatalf("testServer handshake failure: %v", hsr.err)
+	}
+}
+
+// TestServerCredsHandshakeSuccess verifies success handshake cases.
+func (s) TestServerCredsHandshakeSuccess(t *testing.T) {
+	tests := []struct {
+		desc              string
+		fallbackCreds     credentials.TransportCredentials
+		rootProvider      certprovider.Provider
+		identityProvider  certprovider.Provider
+		requireClientCert bool
+	}{
+		{
+			desc:          "fallback",
+			fallbackCreds: makeFallbackServerCreds(t),
+		},
+		{
+			desc:             "TLS",
+			fallbackCreds:    &errorCreds{},
+			identityProvider: makeIdentityProvider(t, "x509/server2_cert.pem", "x509/server2_key.pem"),
+		},
+		{
+			desc:              "mTLS",
+			fallbackCreds:     &errorCreds{},
+			identityProvider:  makeIdentityProvider(t, "x509/server2_cert.pem", "x509/server2_key.pem"),
+			rootProvider:      makeRootProvider(t, "x509/client_ca_cert.pem"),
+			requireClientCert: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			// Create an xDS server credentials.
+			opts := ServerOptions{FallbackCreds: test.fallbackCreds}
+			creds, err := NewServerCredentials(opts)
+			if err != nil {
+				t.Fatalf("NewServerCredentials(%v) failed: %v", opts, err)
+			}
+
+			// Create a test server which uses the xDS server credentials
+			// created above to perform TLS handshake on incoming connections.
+			ts := newTestServerWithHandshakeFunc(func(rawConn net.Conn) handshakeResult {
+				// Create a HandshakeInfo with information from the test table.
+				hi := NewHandshakeInfo(test.rootProvider, test.identityProvider)
+				hi.SetRequireClientCert(test.requireClientCert)
+
+				// Create a wrapped conn which can return the HandshakeInfo and
+				// configured deadline to the xDS credentials' ServerHandshake()
+				// method.
+				conn := newWrappedConn(rawConn, hi, time.Now().Add(defaultTestTimeout))
+
+				// Invoke the ServerHandshake() method on the xDS credentials
+				// and make some sanity checks before pushing the result for
+				// inspection by the main test body.
+				_, ai, err := creds.ServerHandshake(conn)
+				if err != nil {
+					return handshakeResult{err: fmt.Errorf("ServerHandshake() failed: %v", err)}
+				}
+				if ai.AuthType() != "tls" {
+					return handshakeResult{err: fmt.Errorf("ServerHandshake returned authType %q, want %q", ai.AuthType(), "tls")}
+				}
+				info, ok := ai.(credentials.TLSInfo)
+				if !ok {
+					return handshakeResult{err: fmt.Errorf("ServerHandshake returned authInfo of type %T, want %T", ai, credentials.TLSInfo{})}
+				}
+				return handshakeResult{connState: info.State}
+			})
+			defer ts.stop()
+
+			// Dial the test server, and trigger the TLS handshake.
+			rawConn, err := net.Dial("tcp", ts.address)
+			if err != nil {
+				t.Fatalf("net.Dial(%s) failed: %v", ts.address, err)
+			}
+			defer rawConn.Close()
+			tlsConn := tls.Client(rawConn, makeClientTLSConfig(t, test.requireClientCert))
+			tlsConn.SetDeadline(time.Now().Add(defaultTestTimeout))
+			// See comment in makeClientTLSConfig() on why we ignore this error.
+			tlsConn.Handshake()
+
+			// Read the handshake result from the testServer which contains the
+			// TLS connection state on the server-side and compare it with the
+			// one received on the client-side.
+			ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+			defer cancel()
+			val, err := ts.hsResult.Receive(ctx)
+			if err != nil {
+				t.Fatalf("testServer failed to return handshake result: %v", err)
+			}
+			hsr := val.(handshakeResult)
+			if hsr.err != nil {
+				t.Fatalf("testServer handshake failure: %v", hsr.err)
+			}
+
+			// AuthInfo contains a variety of information. We only verify a
+			// subset here. This is the same subset which is verified in TLS
+			// credentials tests.
+			if err := compareConnState(tlsConn.ConnectionState(), hsr.connState); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func (s) TestServerCredsProviderSwitch(t *testing.T) {
+	opts := ServerOptions{FallbackCreds: &errorCreds{}}
+	creds, err := NewServerCredentials(opts)
+	if err != nil {
+		t.Fatalf("NewServerCredentials(%v) failed: %v", opts, err)
+	}
+
+	// The first time the handshake function is invoked, it returns a
+	// HandshakeInfo which is expected to fail. Further invocations return a
+	// HandshakeInfo which is expected to succeed.
+	cnt := 0
+	// Create a test server which uses the xDS server credentials created above
+	// to perform TLS handshake on incoming connections.
+	ts := newTestServerWithHandshakeFunc(func(rawConn net.Conn) handshakeResult {
+		cnt++
+		var hi *HandshakeInfo
+		if cnt == 1 {
+			// Create a HandshakeInfo which has a root provider which does not match
+			// the certificate sent by the client.
+			hi = NewHandshakeInfo(makeRootProvider(t, "x509/server_ca_cert.pem"), makeIdentityProvider(t, "x509/client2_cert.pem", "x509/client2_key.pem"))
+			hi.SetRequireClientCert(true)
+
+			// Create a wrapped conn which can return the HandshakeInfo and
+			// configured deadline to the xDS credentials' ServerHandshake()
+			// method.
+			conn := newWrappedConn(rawConn, hi, time.Now().Add(defaultTestTimeout))
+
+			// ServerHandshake() on the xDS credentials is expected to fail.
+			if _, _, err := creds.ServerHandshake(conn); err == nil {
+				return handshakeResult{err: errors.New("ServerHandshake() succeeded when expected to fail")}
+			}
+			return handshakeResult{}
+		} else {
+			hi = NewHandshakeInfo(makeRootProvider(t, "x509/client_ca_cert.pem"), makeIdentityProvider(t, "x509/server1_cert.pem", "x509/server1_key.pem"))
+			hi.SetRequireClientCert(true)
+
+			// Create a wrapped conn which can return the HandshakeInfo and
+			// configured deadline to the xDS credentials' ServerHandshake()
+			// method.
+			conn := newWrappedConn(rawConn, hi, time.Now().Add(defaultTestTimeout))
+
+			// Invoke the ServerHandshake() method on the xDS credentials
+			// and make some sanity checks before pushing the result for
+			// inspection by the main test body.
+			_, ai, err := creds.ServerHandshake(conn)
+			if err != nil {
+				return handshakeResult{err: fmt.Errorf("ServerHandshake() failed: %v", err)}
+			}
+			if ai.AuthType() != "tls" {
+				return handshakeResult{err: fmt.Errorf("ServerHandshake returned authType %q, want %q", ai.AuthType(), "tls")}
+			}
+			info, ok := ai.(credentials.TLSInfo)
+			if !ok {
+				return handshakeResult{err: fmt.Errorf("ServerHandshake returned authInfo of type %T, want %T", ai, credentials.TLSInfo{})}
+			}
+			return handshakeResult{connState: info.State}
+		}
+	})
+	defer ts.stop()
+
+	for i := 0; i < 5; i++ {
+		// Dial the test server, and trigger the TLS handshake.
+		rawConn, err := net.Dial("tcp", ts.address)
+		if err != nil {
+			t.Fatalf("net.Dial(%s) failed: %v", ts.address, err)
+		}
+		defer rawConn.Close()
+		tlsConn := tls.Client(rawConn, makeClientTLSConfig(t, true))
+		tlsConn.SetDeadline(time.Now().Add(defaultTestTimeout))
+		// See comment in makeClientTLSConfig() on why we ignore this error.
+		tlsConn.Handshake()
+
+		// Read the handshake result from the testServer which contains the
+		// TLS connection state on the server-side and compare it with the
+		// one received on the client-side.
+		ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+		defer cancel()
+		val, err := ts.hsResult.Receive(ctx)
+		if err != nil {
+			t.Fatalf("testServer failed to return handshake result: %v", err)
+		}
+		hsr := val.(handshakeResult)
+		if hsr.err != nil {
+			t.Fatalf("testServer handshake failure: %v", hsr.err)
+		}
+		if i == 0 {
+			// We expect the first handshake to fail. So, we skip checks which
+			// compare connection state.
+			continue
+		}
+		// AuthInfo contains a variety of information. We only verify a
+		// subset here. This is the same subset which is verified in TLS
+		// credentials tests.
+		if err := compareConnState(tlsConn.ConnectionState(), hsr.connState); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+// TestServerClone verifies the Clone() method on client credentials.
+func (s) TestServerClone(t *testing.T) {
+	opts := ServerOptions{FallbackCreds: makeFallbackServerCreds(t)}
+	orig, err := NewServerCredentials(opts)
+	if err != nil {
+		t.Fatalf("NewServerCredentials(%v) failed: %v", opts, err)
+	}
+
+	// The credsImpl does not have any exported fields, and it does not make
+	// sense to use any cmp options to look deep into. So, all we make sure here
+	// is that the cloned object points to a different location in memory.
+	if clone := orig.Clone(); clone == orig {
+		t.Fatal("return value from Clone() doesn't point to new credentials instance")
+	}
+}

--- a/credentials/xds/xds_server_test.go
+++ b/credentials/xds/xds_server_test.go
@@ -405,31 +405,31 @@ func (s) TestServerCredsProviderSwitch(t *testing.T) {
 				return handshakeResult{err: errors.New("ServerHandshake() succeeded when expected to fail")}
 			}
 			return handshakeResult{}
-		} else {
-			hi = NewHandshakeInfo(makeRootProvider(t, "x509/client_ca_cert.pem"), makeIdentityProvider(t, "x509/server1_cert.pem", "x509/server1_key.pem"))
-			hi.SetRequireClientCert(true)
-
-			// Create a wrapped conn which can return the HandshakeInfo and
-			// configured deadline to the xDS credentials' ServerHandshake()
-			// method.
-			conn := newWrappedConn(rawConn, hi, time.Now().Add(defaultTestTimeout))
-
-			// Invoke the ServerHandshake() method on the xDS credentials
-			// and make some sanity checks before pushing the result for
-			// inspection by the main test body.
-			_, ai, err := creds.ServerHandshake(conn)
-			if err != nil {
-				return handshakeResult{err: fmt.Errorf("ServerHandshake() failed: %v", err)}
-			}
-			if ai.AuthType() != "tls" {
-				return handshakeResult{err: fmt.Errorf("ServerHandshake returned authType %q, want %q", ai.AuthType(), "tls")}
-			}
-			info, ok := ai.(credentials.TLSInfo)
-			if !ok {
-				return handshakeResult{err: fmt.Errorf("ServerHandshake returned authInfo of type %T, want %T", ai, credentials.TLSInfo{})}
-			}
-			return handshakeResult{connState: info.State}
 		}
+
+		hi = NewHandshakeInfo(makeRootProvider(t, "x509/client_ca_cert.pem"), makeIdentityProvider(t, "x509/server1_cert.pem", "x509/server1_key.pem"))
+		hi.SetRequireClientCert(true)
+
+		// Create a wrapped conn which can return the HandshakeInfo and
+		// configured deadline to the xDS credentials' ServerHandshake()
+		// method.
+		conn := newWrappedConn(rawConn, hi, time.Now().Add(defaultTestTimeout))
+
+		// Invoke the ServerHandshake() method on the xDS credentials
+		// and make some sanity checks before pushing the result for
+		// inspection by the main test body.
+		_, ai, err := creds.ServerHandshake(conn)
+		if err != nil {
+			return handshakeResult{err: fmt.Errorf("ServerHandshake() failed: %v", err)}
+		}
+		if ai.AuthType() != "tls" {
+			return handshakeResult{err: fmt.Errorf("ServerHandshake returned authType %q, want %q", ai.AuthType(), "tls")}
+		}
+		info, ok := ai.(credentials.TLSInfo)
+		if !ok {
+			return handshakeResult{err: fmt.Errorf("ServerHandshake returned authInfo of type %T, want %T", ai, credentials.TLSInfo{})}
+		}
+		return handshakeResult{connState: info.State}
 	})
 	defer ts.stop()
 

--- a/go.sum
+++ b/go.sum
@@ -43,6 +43,7 @@ github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 h1:VklqNMn3ovrHsnt90PveolxSbWFaJdECFbxSq0Mqo2M=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=


### PR DESCRIPTION
Summary of changes:
- `NewServerCredentials()` which returns a `TransportCredentials` implementation for use on the server-side.
- `ServerHandshake()` implementation which does the following:
  - Expects the passed in `net.Conn` to implement `XDSHandshakeInfo()`, and if so, gets the certificate providers from the returned `HandshakeInfo`. If not, uses `fallback` credentials.
  - Expects the passed in `net.Conn` to implement a `GetDeadline()`, which is used to create the `context` passed to `certprovider.KeyMaterial()`.

The corresponding server-side changes will be sent out in a separate PR since this is big enough and separate enough to be considered on its own.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grpc/grpc-go/4089)
<!-- Reviewable:end -->
