### PR TITLE
xds: Process `require_client_cert` field in security config

### DIFF
--- a/xds/internal/client/client.go
+++ b/xds/internal/client/client.go
@@ -221,6 +221,10 @@ type SecurityConfig struct {
 	// this list, and the handshake succeeds only if a match is found. Used only
 	// on the client-side.
 	AcceptedSANs []string
+	// RequireClientCert indicates if the server handshake process expects the
+	// client to present a certificate. Set to true when performing mTLS. Used
+	// only on the server-side.
+	RequireClientCert bool
 }
 
 // ClusterUpdate contains information from a received CDS response, which is of

--- a/xds/internal/client/client_lds_test.go
+++ b/xds/internal/client/client_lds_test.go
@@ -32,6 +32,7 @@ import (
 	v3tlspb "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	"github.com/golang/protobuf/proto"
 	anypb "github.com/golang/protobuf/ptypes/any"
+	wrapperspb "github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"google.golang.org/grpc/xds/internal/version"
@@ -777,6 +778,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 												TypeUrl: version.V3DownstreamTLSContextURL,
 												Value: func() []byte {
 													tls := &v3tlspb.DownstreamTlsContext{
+														RequireClientCertificate: &wrapperspb.BoolValue{Value: true},
 														CommonTlsContext: &v3tlspb.CommonTlsContext{
 															ValidationContextType: &v3tlspb.CommonTlsContext_ValidationContextCertificateProviderInstance{
 																ValidationContextCertificateProviderInstance: &v3tlspb.CommonTlsContext_CertificateProviderInstance{
@@ -803,8 +805,9 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 			wantUpdate: map[string]ListenerUpdate{
 				v3LDSTarget: {
 					SecurityCfg: &SecurityConfig{
-						RootInstanceName: "rootPluginInstance",
-						RootCertName:     "rootCertName",
+						RootInstanceName:  "rootPluginInstance",
+						RootCertName:      "rootCertName",
+						RequireClientCert: true,
 					},
 				},
 			},
@@ -840,6 +843,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 												TypeUrl: version.V3DownstreamTLSContextURL,
 												Value: func() []byte {
 													tls := &v3tlspb.DownstreamTlsContext{
+														RequireClientCertificate: &wrapperspb.BoolValue{Value: true},
 														CommonTlsContext: &v3tlspb.CommonTlsContext{
 															TlsCertificateCertificateProviderInstance: &v3tlspb.CommonTlsContext_CertificateProviderInstance{
 																InstanceName:    "identityPluginInstance",
@@ -874,6 +878,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 						RootCertName:         "rootCertName",
 						IdentityInstanceName: "identityPluginInstance",
 						IdentityCertName:     "identityCertName",
+						RequireClientCert:    true,
 					},
 				},
 			},

--- a/xds/internal/client/client_xds.go
+++ b/xds/internal/client/client_xds.go
@@ -173,6 +173,7 @@ func processServerSideListener(lis *v3listenerpb.Listener) (*ListenerUpdate, err
 	if err != nil {
 		return nil, err
 	}
+	sc.RequireClientCert = downstreamCtx.GetRequireClientCertificate().GetValue()
 	return &ListenerUpdate{SecurityCfg: sc}, nil
 }
 


### PR DESCRIPTION
The processing of this field was missed out earlier.