### PR TITLE
server: unwrap status errors from RPC handler methods.

### DIFF
--- a/status/status_test.go
+++ b/status/status_test.go
@@ -136,6 +136,15 @@ func (s) TestFromError(t *testing.T) {
 	}
 }
 
+func (s) TestFromErrorWrappedError(t *testing.T) {
+	code, message := codes.Internal, "test description"
+	err := fmt.Errorf("wrapped: %w", Error(code, message))
+	s, ok := FromError(err)
+	if !ok || s.Code() != code || s.Message() != message || s.Err() == nil {
+		t.Fatalf("FromError(%v) = %v, %v; want <Code()=%s, Message()=%q, Err()!=nil>, true", err, s, ok, code, message)
+	}
+}
+
 func (s) TestFromErrorOK(t *testing.T) {
 	code, message := codes.OK, ""
 	s, ok := FromError(nil)
@@ -189,6 +198,33 @@ func (s) TestFromErrorUnknownError(t *testing.T) {
 	s, ok := FromError(err)
 	if ok || s.Code() != code || s.Message() != message {
 		t.Fatalf("FromError(%v) = %v, %v; want <Code()=%s, Message()=%q>, false", err, s, ok, code, message)
+	}
+}
+
+func (s) TestCode(t *testing.T) {
+	code, message := codes.Internal, "test description"
+	err := Error(code, message)
+	if c := Code(err); c != code {
+		t.Fatalf("Code(%v) = %v; want %v", err, c, code)
+	}
+}
+
+func (s) TestCodeImplementsInterface(t *testing.T) {
+	code := codes.Internal
+	err := customError{
+		Code:    code,
+		Message: "test message",
+	}
+	if c := Code(err); c != code {
+		t.Fatalf("Code(%v) = %v; want %v", err, c, code)
+	}
+}
+
+func (s) TestCodeWrappedError(t *testing.T) {
+	code, message := codes.Internal, "test description"
+	err := fmt.Errorf("wrapped: %w", Error(code, message))
+	if c := Code(err); c != code {
+		t.Fatalf("Code(%v) = %v; want %v", err, c, code)
 	}
 }
 


### PR DESCRIPTION
Currently, if an RPC handler method returns an error with a GRPCStatus
method, the GRPC server calls that method and uses the result's code
and message in the RPC response. However, if the error in question
wraps an error with a GRPCStatus method, the RPC response has code
UNKNOWN. This commit changes status.FromError and status.Code to
also extract statuses from wrapped errors.

The use case is something like this: I have RPC server X; it has a
method that makes calls to RPC servers Y and Z, computes something
from the responses, and returns it. If there's an error talking to Y
or Z, then X's error response should have the same code as Y's or Z's
response did. Currently, I can accomplish this by returning the error
from Y or Z directly.

However, if there's some helpful code in the middle that wraps the
error from Y or Z (e.g. to say which of Y or Z goofed), then I have to
unwrap the error myself. This might not seem too onerous, but it means
that either (a) I need some boilerplate helper unwrapping for every
RPC handler method, or (b) any code between my RPC handler method and
the RPC stubs for Y or Z can break things at any time by wrapping an
error.

With this commit, the GRPC server handles the error unwrapping for me.

Error wrapping and unwrwapping were introduced in Go 1.13[1], so the
last three major releases of Go all have them.

[1] https://golang.org/doc/go1.13#error_wrapping