### PR TITLE
xds: Implement server-side security

### DIFF
--- a/internal/internal.go
+++ b/internal/internal.go
@@ -60,11 +60,11 @@ var (
 	// GetXDSHandshakeInfoForTesting returns a pointer to the xds.HandshakeInfo
 	// stored in the passed in attributes. This is set by
 	// credentials/xds/xds.go.
-	GetXDSHandshakeInfoForTesting interface{} // func (attr *attributes.Attributes) *xds.HandshakeInfo
+	GetXDSHandshakeInfoForTesting interface{} // func (*attributes.Attributes) *xds.HandshakeInfo
 	// GetServerCredentials returns the transport credentials configured on a
 	// gRPC server. An xDS-enabled server needs to know what type of credentials
 	// is configured on the underlying gRPC server. This is set by server.go.
-	GetServerCredentials interface{} // func (s interface{}) *credentials.TransportCredentials
+	GetServerCredentials interface{} // func (interface{}) credentials.TransportCredentials
 )
 
 // HealthChecker defines the signature of the client-side LB channel health checking function.

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -64,7 +64,7 @@ var (
 	// GetServerCredentials returns the transport credentials configured on a
 	// gRPC server. An xDS-enabled server needs to know what type of credentials
 	// is configured on the underlying gRPC server. This is set by server.go.
-	GetServerCredentials interface{} // func (interface{}) credentials.TransportCredentials
+	GetServerCredentials interface{} // func (*grpc.Server) credentials.TransportCredentials
 )
 
 // HealthChecker defines the signature of the client-side LB channel health checking function.

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -64,7 +64,7 @@ var (
 	// GetServerCredentials returns the transport credentials configured on a
 	// gRPC server. An xDS-enabled server needs to know what type of credentials
 	// is configured on the underlying gRPC server. This is set by server.go.
-	GetServerCredentials interface{} // func (*grpc.Server) credentials.TransportCredentials
+	GetServerCredentials interface{} // func (interface{}) credentials.TransportCredentials
 )
 
 // HealthChecker defines the signature of the client-side LB channel health checking function.

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -61,6 +61,10 @@ var (
 	// stored in the passed in attributes. This is set by
 	// credentials/xds/xds.go.
 	GetXDSHandshakeInfoForTesting interface{} // func (attr *attributes.Attributes) *xds.HandshakeInfo
+	// GetServerCredentials returns the transport credentials configured on a
+	// gRPC server. An xDS-enabled server needs to know what type of credentials
+	// is configured on the underlying gRPC server. This is set by server.go.
+	GetServerCredentials interface{} // func (s interface{}) *credentials.TransportCredentials
 )
 
 // HealthChecker defines the signature of the client-side LB channel health checking function.

--- a/server.go
+++ b/server.go
@@ -40,6 +40,7 @@ import (
 	"google.golang.org/grpc/encoding"
 	"google.golang.org/grpc/encoding/proto"
 	"google.golang.org/grpc/grpclog"
+	"google.golang.org/grpc/internal"
 	"google.golang.org/grpc/internal/binarylog"
 	"google.golang.org/grpc/internal/channelz"
 	"google.golang.org/grpc/internal/grpcrand"
@@ -57,6 +58,16 @@ const (
 	defaultServerMaxReceiveMessageSize = 1024 * 1024 * 4
 	defaultServerMaxSendMessageSize    = math.MaxInt32
 )
+
+func init() {
+	internal.GetServerCredentials = func(srv interface{}) credentials.TransportCredentials {
+		s, ok := srv.(*Server)
+		if !ok {
+			return nil
+		}
+		return s.opts.creds
+	}
+}
 
 var statusOK = status.New(codes.OK, "")
 var logger = grpclog.Component("core")

--- a/server.go
+++ b/server.go
@@ -60,12 +60,8 @@ const (
 )
 
 func init() {
-	internal.GetServerCredentials = func(srv interface{}) credentials.TransportCredentials {
-		s, ok := srv.(*Server)
-		if !ok {
-			return nil
-		}
-		return s.opts.creds
+	internal.GetServerCredentials = func(srv *Server) credentials.TransportCredentials {
+		return srv.opts.creds
 	}
 }
 

--- a/xds/internal/client/client.go
+++ b/xds/internal/client/client.go
@@ -149,6 +149,10 @@ type ListenerUpdate struct {
 	SecurityCfg *SecurityConfig
 }
 
+func (lu *ListenerUpdate) String() string {
+	return fmt.Sprintf("{RouteConfigName: %q, SecurityConfig: %+v", lu.RouteConfigName, lu.SecurityCfg)
+}
+
 // RouteConfigUpdate contains information received in an RDS response, which is
 // of interest to the registered RDS watcher.
 type RouteConfigUpdate struct {

--- a/xds/internal/test/xds_server_integration_test.go
+++ b/xds/internal/test/xds_server_integration_test.go
@@ -38,16 +38,15 @@ import (
 	v3tlspb "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	wrapperspb "github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/google/uuid"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
+
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 	xdscreds "google.golang.org/grpc/credentials/xds"
-<<<<<<< HEAD
-=======
-	"google.golang.org/grpc/internal/grpctest"
 	"google.golang.org/grpc/status"
->>>>>>> beced0ad (review comments)
 	testpb "google.golang.org/grpc/test/grpc_testing"
 	"google.golang.org/grpc/testdata"
 	"google.golang.org/grpc/xds"
@@ -55,8 +54,6 @@ import (
 	"google.golang.org/grpc/xds/internal/testutils"
 	"google.golang.org/grpc/xds/internal/testutils/e2e"
 	"google.golang.org/grpc/xds/internal/version"
-	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/types/known/anypb"
 )
 
 const (

--- a/xds/internal/test/xds_server_integration_test.go
+++ b/xds/internal/test/xds_server_integration_test.go
@@ -23,36 +23,119 @@ package xds_test
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"fmt"
+	"io/ioutil"
+	"net"
+	"os"
+	"path"
+	"strconv"
 	"testing"
-
-	"github.com/google/uuid"
-	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/types/known/anypb"
 
 	v3corepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	v3listenerpb "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
-	v3httppb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
-
+	v3tlspb "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
+	wrapperspb "github.com/golang/protobuf/ptypes/wrappers"
+	"github.com/google/uuid"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
+	xdscreds "google.golang.org/grpc/credentials/xds"
 	testpb "google.golang.org/grpc/test/grpc_testing"
+	"google.golang.org/grpc/testdata"
 	"google.golang.org/grpc/xds"
 	"google.golang.org/grpc/xds/internal/env"
 	"google.golang.org/grpc/xds/internal/testutils"
 	"google.golang.org/grpc/xds/internal/testutils/e2e"
 	"google.golang.org/grpc/xds/internal/version"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
 )
 
-// TestServerSideXDS is an e2e tests for xDS use on the server. This does not
-// use any xDS features because we have not implemented any on the server side.
-func (s) TestServerSideXDS(t *testing.T) {
+const (
+	// Names of files inside tempdir, for certprovider plugin to watch.
+	certFile = "cert.pem"
+	keyFile  = "key.pem"
+	rootFile = "ca.pem"
+)
+
+func createTmpFile(t *testing.T, src, dst string) {
+	t.Helper()
+
+	data, err := ioutil.ReadFile(src)
+	if err != nil {
+		t.Fatalf("ioutil.ReadFile(%q) failed: %v", src, err)
+	}
+	if err := ioutil.WriteFile(dst, data, os.ModePerm); err != nil {
+		t.Fatalf("ioutil.WriteFile(%q) failed: %v", dst, err)
+	}
+	t.Logf("Wrote file at: %s", dst)
+	t.Logf("%s", string(data))
+}
+
+// createTempDirWithFiles creates a temporary directory under the system default
+// tempDir with the given dirSuffix. It also reads from certSrc, keySrc and
+// rootSrc files are creates appropriate files under the newly create tempDir.
+// Returns the name of the created tempDir.
+func createTmpDirWithFiles(t *testing.T, dirSuffix, certSrc, keySrc, rootSrc string) string {
+	t.Helper()
+
+	// Create a temp directory. Passing an empty string for the first argument
+	// uses the system temp directory.
+	dir, err := ioutil.TempDir("", dirSuffix)
+	if err != nil {
+		t.Fatalf("ioutil.TempDir() failed: %v", err)
+	}
+	t.Logf("Using tmpdir: %s", dir)
+
+	createTmpFile(t, testdata.Path(certSrc), path.Join(dir, certFile))
+	createTmpFile(t, testdata.Path(keySrc), path.Join(dir, keyFile))
+	createTmpFile(t, testdata.Path(rootSrc), path.Join(dir, rootFile))
+	return dir
+}
+
+// createClientTLSCredentials creates client-side TLS transport credentials.
+func createClientTLSCredentials(t *testing.T) credentials.TransportCredentials {
+	cert, err := tls.LoadX509KeyPair(testdata.Path("x509/client1_cert.pem"), testdata.Path("x509/client1_key.pem"))
+	if err != nil {
+		t.Fatalf("tls.LoadX509KeyPair(x509/client1_cert.pem, x509/client1_key.pem) failed: %v", err)
+	}
+	b, err := ioutil.ReadFile(testdata.Path("x509/server_ca_cert.pem"))
+	if err != nil {
+		t.Fatalf("ioutil.ReadFile(x509/server_ca_cert.pem) failed: %v", err)
+	}
+	roots := x509.NewCertPool()
+	if !roots.AppendCertsFromPEM(b) {
+		t.Fatal("failed to append certificates")
+	}
+	return credentials.NewTLS(&tls.Config{
+		Certificates: []tls.Certificate{cert},
+		RootCAs:      roots,
+		ServerName:   "x.test.example.com",
+	})
+}
+
+// commonSetup performs a bunch of steps common to all xDS server tests here:
+// - turn on V3 support by setting the environment variable
+// - spin up an xDS management server on a local port
+// - set up certificates for consumption by the file_watcher plugin
+// - spin up an xDS-enabled gRPC server, configure it with xdsCredentials and
+//   register the test service on it
+// - create a local TCP listener and start serving on it
+//
+// Returns the following:
+// - the management server: tests use this to configure resources
+// - nodeID expected by the management server: this is set in the Node proto
+//   sent by the xdsClient used on the xDS-enabled gRPC server
+// - local listener on which the xDS-enabled gRPC server is serving on
+// - cleanup function to be invoked by the tests when done
+func commonSetup(t *testing.T) (*e2e.ManagementServer, string, net.Listener, func()) {
+	t.Helper()
+
+	// Turn on xDS V3 support.
 	origV3Support := env.V3Support
 	env.V3Support = true
-	defer func() { env.V3Support = origV3Support }()
-
-	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
-	defer cancel()
 
 	// Spin up a xDS management server on a local port.
 	nodeID := uuid.New().String()
@@ -60,24 +143,37 @@ func (s) TestServerSideXDS(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer fs.Stop()
+
+	// Create certificate and key files in a temporary directory and generate
+	// certificate provider configuration for a file_watcher plugin.
+	tmpdir := createTmpDirWithFiles(t, "testServerSideXDS*", "x509/server1_cert.pem", "x509/server1_key.pem", "x509/client_ca_cert.pem")
+	cpc := e2e.DefaultFileWatcherConfig(path.Join(tmpdir, certFile), path.Join(tmpdir, keyFile), path.Join(tmpdir, rootFile))
 
 	// Create a bootstrap file in a temporary directory.
-	cleanup, err := e2e.SetupBootstrapFile(e2e.BootstrapOptions{
-		Version:   e2e.TransportV3,
-		NodeID:    nodeID,
-		ServerURI: fs.Address,
+	bootstrapCleanup, err := e2e.SetupBootstrapFile(e2e.BootstrapOptions{
+		Version:              e2e.TransportV3,
+		NodeID:               nodeID,
+		ServerURI:            fs.Address,
+		CertificateProviders: cpc,
+		ServerResourceNameID: "grpc/server",
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer cleanup()
+
+	// Configure xDS credentials to be used on the server-side.
+	creds, err := xdscreds.NewServerCredentials(xdscreds.ServerOptions{
+		FallbackCreds: insecure.NewCredentials(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// Initialize an xDS-enabled gRPC server and register the stubServer on it.
-	server := xds.NewGRPCServer()
+	server := xds.NewGRPCServer(grpc.Creds(creds))
 	testpb.RegisterTestServiceServer(server, &testService{})
-	defer server.Stop()
 
+	// Create a local listener and pass it to Serve().
 	lis, err := testutils.LocalTCPListener()
 	if err != nil {
 		t.Fatalf("testutils.LocalTCPListener() failed: %v", err)
@@ -89,40 +185,124 @@ func (s) TestServerSideXDS(t *testing.T) {
 		}
 	}()
 
-	// Setup the fake management server to respond with a Listener resource.
-	go func() {
-		listener := &v3listenerpb.Listener{
-			// This needs to match the name we are querying for.
-			Name: fmt.Sprintf("grpc/server?udpa.resource.listening_address=%s", lis.Addr().String()),
-			ApiListener: &v3listenerpb.ApiListener{
-				ApiListener: &anypb.Any{
-					TypeUrl: version.V2HTTPConnManagerURL,
-					Value: func() []byte {
-						cm := &v3httppb.HttpConnectionManager{
-							RouteSpecifier: &v3httppb.HttpConnectionManager_Rds{
-								Rds: &v3httppb.Rds{
-									ConfigSource: &v3corepb.ConfigSource{
-										ConfigSourceSpecifier: &v3corepb.ConfigSource_Ads{Ads: &v3corepb.AggregatedConfigSource{}},
-									},
-									RouteConfigName: "route-config",
-								},
-							},
-						}
-						mcm, _ := proto.Marshal(cm)
-						return mcm
-					}(),
+	return fs, nodeID, lis, func() {
+		env.V3Support = origV3Support
+		fs.Stop()
+		bootstrapCleanup()
+		server.Stop()
+	}
+}
+
+func hostPortFromListener(t *testing.T, lis net.Listener) (string, uint32) {
+	t.Helper()
+
+	host, p, err := net.SplitHostPort(lis.Addr().String())
+	if err != nil {
+		t.Fatalf("net.SplitHostPort(%s) failed: %v", lis.Addr().String(), err)
+	}
+	port, err := strconv.ParseInt(p, 10, 32)
+	if err != nil {
+		t.Fatalf("strconv.ParseInt(%s, 10, 32) failed: %v", p, err)
+	}
+	return host, uint32(port)
+
+}
+
+// listenerResourceWithoutSecurityConfig returns a listener resource with no
+// security configuration, and name and address fields matching the passed in
+// net.Listener.
+func listenerResourceWithoutSecurityConfig(t *testing.T, lis net.Listener) *v3listenerpb.Listener {
+	host, port := hostPortFromListener(t, lis)
+	return &v3listenerpb.Listener{
+		// This needs to match the name we are querying for.
+		Name: fmt.Sprintf("grpc/server?udpa.resource.listening_address=%s", lis.Addr().String()),
+		Address: &v3corepb.Address{
+			Address: &v3corepb.Address_SocketAddress{
+				SocketAddress: &v3corepb.SocketAddress{
+					Address: host,
+					PortSpecifier: &v3corepb.SocketAddress_PortValue{
+						PortValue: port,
+					},
 				},
 			},
-		}
-		if err := fs.Update(e2e.UpdateOptions{
-			NodeID:    nodeID,
-			Listeners: []*v3listenerpb.Listener{listener},
-		}); err != nil {
-			t.Error(err)
-		}
-	}()
+		},
+		FilterChains: []*v3listenerpb.FilterChain{
+			{
+				Name: "filter-chain-1",
+				FilterChainMatch: &v3listenerpb.FilterChainMatch{
+					ApplicationProtocols: []string{"managed-mtls"},
+				},
+			},
+		},
+	}
+}
+
+// listenerResourceWithSecurityConfig returns a listener resource with security
+// configuration pointing to the use of the file_watcher certificate provider
+// plugin, and name and address fields matching the passed in net.Listener.
+func listenerResourceWithSecurityConfig(t *testing.T, lis net.Listener) *v3listenerpb.Listener {
+	host, port := hostPortFromListener(t, lis)
+	return &v3listenerpb.Listener{
+		// This needs to match the name we are querying for.
+		Name: fmt.Sprintf("grpc/server?udpa.resource.listening_address=%s", lis.Addr().String()),
+		Address: &v3corepb.Address{
+			Address: &v3corepb.Address_SocketAddress{
+				SocketAddress: &v3corepb.SocketAddress{
+					Address: host,
+					PortSpecifier: &v3corepb.SocketAddress_PortValue{
+						PortValue: port,
+					}}}},
+		FilterChains: []*v3listenerpb.FilterChain{
+			{
+				Name: "filter-chain-1",
+				FilterChainMatch: &v3listenerpb.FilterChainMatch{
+					ApplicationProtocols: []string{"managed-mtls"},
+				},
+				TransportSocket: &v3corepb.TransportSocket{
+					Name: "envoy.transport_sockets.tls",
+					ConfigType: &v3corepb.TransportSocket_TypedConfig{
+						TypedConfig: &anypb.Any{
+							TypeUrl: version.V3DownstreamTLSContextURL,
+							Value: func() []byte {
+								tls := &v3tlspb.DownstreamTlsContext{
+									RequireClientCertificate: &wrapperspb.BoolValue{Value: true},
+									CommonTlsContext: &v3tlspb.CommonTlsContext{
+										TlsCertificateCertificateProviderInstance: &v3tlspb.CommonTlsContext_CertificateProviderInstance{
+											InstanceName: "google_cloud_private_spiffe",
+										},
+										ValidationContextType: &v3tlspb.CommonTlsContext_ValidationContextCertificateProviderInstance{
+											ValidationContextCertificateProviderInstance: &v3tlspb.CommonTlsContext_CertificateProviderInstance{
+												InstanceName: "google_cloud_private_spiffe",
+											}}}}
+								mtls, _ := proto.Marshal(tls)
+								return mtls
+							}(),
+						}}}}},
+	}
+}
+
+// TestServerSideXDS_Fallback is an e2e test where xDS is enabled on the
+// server-side and xdsCredentials are configured for security. The control plane
+// does not provide any security configuration and therefore the xdsCredentials
+// uses fallback credentials, which in this case is insecure creds.
+func (s) TestServerSideXDS_Fallback(t *testing.T) {
+	fs, nodeID, lis, cleanup := commonSetup(t)
+	defer cleanup()
+
+	// Setup the fake management server to respond with a Listener resource that
+	// does not contain any security configuration. This should force the
+	// server-side xdsCredentials to use fallback.
+	listener := listenerResourceWithoutSecurityConfig(t, lis)
+	if err := fs.Update(e2e.UpdateOptions{
+		NodeID:    nodeID,
+		Listeners: []*v3listenerpb.Listener{listener},
+	}); err != nil {
+		t.Error(err)
+	}
 
 	// Create a ClientConn and make a successful RPC.
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
 	cc, err := grpc.DialContext(ctx, lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		t.Fatalf("failed to dial local test server: %v", err)
@@ -130,6 +310,99 @@ func (s) TestServerSideXDS(t *testing.T) {
 	defer cc.Close()
 
 	client := testpb.NewTestServiceClient(cc)
+	if _, err := client.EmptyCall(ctx, &testpb.Empty{}, grpc.WaitForReady(true)); err != nil {
+		t.Fatalf("rpc EmptyCall() failed: %v", err)
+	}
+}
+
+// TestServerSideXDS_FileWatcherCerts is an e2e test where xDS is enabled on the
+// server-side and xdsCredentials are configured for security. The control plane
+// sends security configuration pointing to the use of the file_watcher plugin,
+// and we verify that a client connecting with TLS creds is able to successfully
+// make an RPC.
+func (s) TestServerSideXDS_FileWatcherCerts(t *testing.T) {
+	fs, nodeID, lis, cleanup := commonSetup(t)
+	defer cleanup()
+
+	// Setup the fake management server to respond with a Listener resource with
+	// security configuration pointing to the file watcher plugin and requiring
+	// mTLS.
+	listener := listenerResourceWithSecurityConfig(t, lis)
+	if err := fs.Update(e2e.UpdateOptions{
+		NodeID:    nodeID,
+		Listeners: []*v3listenerpb.Listener{listener},
+	}); err != nil {
+		t.Error(err)
+	}
+
+	// Create a ClientConn with TLS creds and make a successful RPC.
+	clientCreds := createClientTLSCredentials(t)
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	cc, err := grpc.DialContext(ctx, lis.Addr().String(), grpc.WithTransportCredentials(clientCreds))
+	if err != nil {
+		t.Fatalf("failed to dial local test server: %v", err)
+	}
+	defer cc.Close()
+
+	client := testpb.NewTestServiceClient(cc)
+	if _, err := client.EmptyCall(ctx, &testpb.Empty{}, grpc.WaitForReady(true)); err != nil {
+		t.Fatalf("rpc EmptyCall() failed: %v", err)
+	}
+}
+
+// TestServerSideXDS_SecurityConfigChange is an e2e test where xDS is enabled on
+// the server-side and xdsCredentials are configured for security. The control
+// plane initially does not any security configuration. This forces the
+// xdsCredentials to use fallback creds, which is this case is insecure creds.
+// We verify that a client connecting with TLS creds is not able to successfully
+// make an RPC. The control plan then sends a listener resource with security
+// configuration pointing to the use of the file_watcher plugin and we verify
+// that the same client is now able to successfully make an RPC.
+func (s) TestServerSideXDS_SecurityConfigChange(t *testing.T) {
+	fs, nodeID, lis, cleanup := commonSetup(t)
+	defer cleanup()
+
+	// Setup the fake management server to respond with a Listener resource that
+	// does not contain any security configuration. This should force the
+	// server-side xdsCredentials to use fallback.
+	listener := listenerResourceWithoutSecurityConfig(t, lis)
+	if err := fs.Update(e2e.UpdateOptions{
+		NodeID:    nodeID,
+		Listeners: []*v3listenerpb.Listener{listener},
+	}); err != nil {
+		t.Error(err)
+	}
+
+	// Create a ClientConn with TLS creds. This should fail since the server is
+	// using fallback credentials which in this case in insecure creds.
+	clientCreds := createClientTLSCredentials(t)
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	cc, err := grpc.DialContext(ctx, lis.Addr().String(), grpc.WithTransportCredentials(clientCreds))
+	if err != nil {
+		t.Fatalf("failed to dial local test server: %v", err)
+	}
+	defer cc.Close()
+
+	// We don't set 'waitForReady` here since we want this call to failfast.
+	client := testpb.NewTestServiceClient(cc)
+	if _, err := client.EmptyCall(ctx, &testpb.Empty{}); err == nil {
+		t.Fatal("rpc EmptyCall() succeeded when expected to fail")
+	}
+
+	// Setup the fake management server to respond with a Listener resource with
+	// security configuration pointing to the file watcher plugin and requiring
+	// mTLS.
+	listener = listenerResourceWithSecurityConfig(t, lis)
+	if err := fs.Update(e2e.UpdateOptions{
+		NodeID:    nodeID,
+		Listeners: []*v3listenerpb.Listener{listener},
+	}); err != nil {
+		t.Error(err)
+	}
+
+	// Make another RPC with `waitForReady` set and expect this to succeed.
 	if _, err := client.EmptyCall(ctx, &testpb.Empty{}, grpc.WaitForReady(true)); err != nil {
 		t.Fatalf("rpc EmptyCall() failed: %v", err)
 	}

--- a/xds/internal/test/xds_server_integration_test.go
+++ b/xds/internal/test/xds_server_integration_test.go
@@ -39,9 +39,15 @@ import (
 	wrapperspb "github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/google/uuid"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 	xdscreds "google.golang.org/grpc/credentials/xds"
+<<<<<<< HEAD
+=======
+	"google.golang.org/grpc/internal/grpctest"
+	"google.golang.org/grpc/status"
+>>>>>>> beced0ad (review comments)
 	testpb "google.golang.org/grpc/test/grpc_testing"
 	"google.golang.org/grpc/testdata"
 	"google.golang.org/grpc/xds"
@@ -387,7 +393,7 @@ func (s) TestServerSideXDS_SecurityConfigChange(t *testing.T) {
 
 	// We don't set 'waitForReady` here since we want this call to failfast.
 	client := testpb.NewTestServiceClient(cc)
-	if _, err := client.EmptyCall(ctx, &testpb.Empty{}); err == nil {
+	if _, err := client.EmptyCall(ctx, &testpb.Empty{}); status.Convert(err).Code() != codes.Unavailable {
 		t.Fatal("rpc EmptyCall() succeeded when expected to fail")
 	}
 

--- a/xds/internal/testutils/e2e/bootstrap.go
+++ b/xds/internal/testutils/e2e/bootstrap.go
@@ -46,6 +46,10 @@ type BootstrapOptions struct {
 	NodeID string
 	// ServerURI is the address of the management server.
 	ServerURI string
+	// ServerResourceNameID is the Listener resource name to fetch.
+	ServerResourceNameID string
+	// CertificateProviders is the certificate providers configuration.
+	CertificateProviders map[string]json.RawMessage
 }
 
 // SetupBootstrapFile creates a temporary file with bootstrap contents, based on
@@ -75,6 +79,8 @@ func SetupBootstrapFile(opts BootstrapOptions) (func(), error) {
 		Node: node{
 			ID: opts.NodeID,
 		},
+		CertificateProviders:     opts.CertificateProviders,
+		GRPCServerResourceNameID: opts.ServerResourceNameID,
 	}
 	switch opts.Version {
 	case TransportV2:
@@ -102,9 +108,29 @@ func SetupBootstrapFile(opts BootstrapOptions) (func(), error) {
 	}, nil
 }
 
+// DefaultFileWatcherConfig is a helper function to create a default certificate
+// provider plugin configuration. The test is expected to have setup the files
+// appropriately before this configuration is used to instantiate providers.
+func DefaultFileWatcherConfig(certPath, keyPath, caPath string) map[string]json.RawMessage {
+	cfg := fmt.Sprintf(`{
+			"plugin_name": "file_watcher",
+			"config": {
+				"certificate_file": %q,
+				"private_key_file": %q,
+				"ca_certificate_file": %q,
+				"refresh_interval": "600s"
+			}
+		}`, certPath, keyPath, caPath)
+	return map[string]json.RawMessage{
+		"google_cloud_private_spiffe": json.RawMessage(cfg),
+	}
+}
+
 type bootstrapConfig struct {
-	XdsServers []server `json:"xds_servers,omitempty"`
-	Node       node     `json:"node,omitempty"`
+	XdsServers               []server                   `json:"xds_servers,omitempty"`
+	Node                     node                       `json:"node,omitempty"`
+	CertificateProviders     map[string]json.RawMessage `json:"certificate_providers,omitempty"`
+	GRPCServerResourceNameID string                     `json:"grpc_server_resource_name_id,omitempty"`
 }
 
 type server struct {

--- a/xds/server.go
+++ b/xds/server.go
@@ -177,7 +177,7 @@ func (s *GRPCServer) Serve(lis net.Listener) error {
 	// providers after receiving an LDS response with security configuration.
 	if s.xdsCredsInUse {
 		bc := s.xdsC.BootstrapConfig()
-		if len(bc.CertProviderConfigs) == 0 {
+		if bc == nil || len(bc.CertProviderConfigs) == 0 {
 			return errors.New("xds: certificate_providers config missing in bootstrap file")
 		}
 	}

--- a/xds/server.go
+++ b/xds/server.go
@@ -20,12 +20,18 @@ package xds
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"sync"
+	"time"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/tls/certprovider"
+	"google.golang.org/grpc/credentials/xds"
 	"google.golang.org/grpc/grpclog"
+	"google.golang.org/grpc/internal"
 	internalgrpclog "google.golang.org/grpc/internal/grpclog"
 	"google.golang.org/grpc/internal/grpcsync"
 	xdsclient "google.golang.org/grpc/xds/internal/client"
@@ -42,8 +48,8 @@ var (
 	newGRPCServer = func(opts ...grpc.ServerOption) grpcServerInterface {
 		return grpc.NewServer(opts...)
 	}
-
-	logger = grpclog.Component("xds")
+	buildProvider = buildProviderFunc
+	logger        = grpclog.Component("xds")
 )
 
 func prefixLogger(p *GRPCServer) *internalgrpclog.PrefixLogger {
@@ -77,9 +83,10 @@ type grpcServerInterface interface {
 // Notice: This type is EXPERIMENTAL and may be changed or removed in a
 // later release.
 type GRPCServer struct {
-	gs     grpcServerInterface
-	quit   *grpcsync.Event
-	logger *internalgrpclog.PrefixLogger
+	gs            grpcServerInterface
+	quit          *grpcsync.Event
+	logger        *internalgrpclog.PrefixLogger
+	xdsCredsInUse bool
 
 	// clientMu is used only in initXDSClient(), which is called at the
 	// beginning of Serve(), where we have to decide if we have to create a
@@ -108,6 +115,12 @@ func NewGRPCServer(opts ...grpc.ServerOption) *GRPCServer {
 	}
 	s.logger = prefixLogger(s)
 	s.logger.Infof("Created xds.GRPCServer")
+
+	creds := internal.GetServerCredentials.(func(interface{}) credentials.TransportCredentials)(s.gs)
+	if xc, ok := creds.(interface{ UsesXDS() bool }); ok && xc.UsesXDS() {
+		s.xdsCredsInUse = true
+	}
+	s.logger.Infof("xDS credentials in use: %v", s.xdsCredsInUse)
 	return s
 }
 
@@ -154,6 +167,18 @@ func (s *GRPCServer) Serve(lis net.Listener) error {
 	if err := s.initXDSClient(); err != nil {
 		return err
 	}
+
+	// If xds credentials were specified by the user, but bootstrap configs do
+	// not contain any certificate provider configuration, it is better to fail
+	// right now rather than failing when attempting to create certificate
+	// providers after receiving an LDS response with security configuration.
+	if s.xdsCredsInUse {
+		bc := s.xdsC.BootstrapConfig()
+		if bc == nil || bc.CertProviderConfigs == nil {
+			return errors.New("xds: certificate_providers config missing in bootstrap file")
+		}
+	}
+
 	lw, err := s.newListenerWrapper(lis)
 	if lw == nil {
 		// Error returned can be nil (when Stop/GracefulStop() is called). So,
@@ -171,7 +196,11 @@ func (s *GRPCServer) Serve(lis net.Listener) error {
 // response is received or the server is stopped by a call to
 // Stop/GracefulStop().
 func (s *GRPCServer) newListenerWrapper(lis net.Listener) (*listenerWrapper, error) {
-	lw := &listenerWrapper{Listener: lis}
+	lw := &listenerWrapper{
+		Listener: lis,
+		closed:   grpcsync.NewEvent(),
+		xdsHI:    xds.NewHandshakeInfo(nil, nil),
+	}
 
 	// This is used to notify that a good update has been received and that
 	// Serve() can be invoked on the underlying gRPC server. Using a
@@ -195,25 +224,14 @@ func (s *GRPCServer) newListenerWrapper(lis net.Listener) (*listenerWrapper, err
 	// Register an LDS watch using our xdsClient, and specify the listening
 	// address as the resource name.
 	cancelWatch := s.xdsC.WatchListener(name, func(update xdsclient.ListenerUpdate, err error) {
-		if err != nil {
-			// We simply log an error here and hope we get a successful update
-			// in the future. The error could be because of a timeout or an
-			// actual error, like the requested resource not found. In any case,
-			// it is fine for the server to hang indefinitely until Stop() is
-			// called.
-			s.logger.Warningf("Received error for resource %q: %+v", name, err)
-			return
-		}
-
-		s.logger.Infof("Received update for resource %q: %+v", name, update)
-
-		// TODO(easwars): Handle security configuration, create appropriate
-		// certificate providers and update the listenerWrapper before firing
-		// the event. Errors encountered during any of these steps should result
-		// in an early exit, and the update event should not fire.
-		goodUpdate.Fire()
+		s.handleListenerUpdate(watchUpdate{
+			lw:         lw,
+			name:       name,
+			lds:        update,
+			err:        err,
+			goodUpdate: goodUpdate,
+		})
 	})
-
 	s.logger.Infof("Watch started on resource name %v", name)
 	lw.cancelWatch = func() {
 		cancelWatch()
@@ -231,6 +249,116 @@ func (s *GRPCServer) newListenerWrapper(lis net.Listener) (*listenerWrapper, err
 	case <-goodUpdate.Done():
 	}
 	return lw, nil
+}
+
+// watchUpdate wraps the information received from a registered LDS watcher.
+type watchUpdate struct {
+	lw         *listenerWrapper         // listener associated with this watch
+	name       string                   // resource name being watched
+	lds        xdsclient.ListenerUpdate // received update
+	err        error                    // received error
+	goodUpdate *grpcsync.Event          // event to fire upon a good update
+}
+
+func (s *GRPCServer) handleListenerUpdate(update watchUpdate) {
+	if update.lw.closed.HasFired() {
+		s.logger.Warningf("Resource %q received update: %v with error: %v, after for listener was closed", update.name, update.lds, update.err)
+		return
+	}
+
+	if update.err != nil {
+		// We simply log an error here and hope we get a successful update
+		// in the future. The error could be because of a timeout or an
+		// actual error, like the requested resource not found. In any case,
+		// it is fine for the server to hang indefinitely until Stop() is
+		// called.
+		s.logger.Warningf("Received error for resource %q: %+v", update.name, update.err)
+		return
+	}
+	s.logger.Infof("Received update for resource %q: %+v", update.name, update.lds.String())
+
+	if err := s.handleSecurityConfig(update.lds.SecurityCfg, update.lw); err != nil {
+		s.logger.Warningf("Invalid security config update: %v", err)
+		return
+	}
+
+	// If we got all the way here, it means the received update was a good one.
+	update.goodUpdate.Fire()
+}
+
+func (s *GRPCServer) handleSecurityConfig(config *xdsclient.SecurityConfig, lw *listenerWrapper) error {
+	// If xdsCredentials are not in use, i.e, the user did not want to get
+	// security configuration from the control plane, we should not be acting on
+	// the received security config here. Doing so poses a security threat.
+	if !s.xdsCredsInUse {
+		return nil
+	}
+
+	// Security config being nil is a valid case where the control plane has
+	// not sent any security configuration. The xdsCredentials implementation
+	// handles this by delegating to its fallback credentials.
+	if config == nil {
+		// We need to explicitly set the fields to nil here since this might be
+		// a case of switching from a good security configuration to an empty
+		// one where fallback credentials are to be used.
+		lw.xdsHI.SetRootCertProvider(nil)
+		lw.xdsHI.SetIdentityCertProvider(nil)
+		lw.xdsHI.SetRequireClientCert(false)
+		return nil
+	}
+
+	cpc := s.xdsC.BootstrapConfig().CertProviderConfigs
+	// Identity provider is mandatory on the server side.
+	identityProvider, err := buildProvider(cpc, config.IdentityInstanceName, config.IdentityCertName, true, false)
+	if err != nil {
+		return err
+	}
+
+	// A root provider is required only when doing mTLS.
+	var rootProvider certprovider.Provider
+	if config.RootInstanceName != "" {
+		rootProvider, err = buildProvider(cpc, config.RootInstanceName, config.RootCertName, false, true)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Close the old providers and cache the new ones.
+	if lw.cachedIdentity != nil {
+		lw.cachedIdentity.Close()
+	}
+	if lw.cachedRoot != nil {
+		lw.cachedRoot.Close()
+	}
+	lw.cachedRoot = rootProvider
+	lw.cachedIdentity = identityProvider
+
+	// We set all fields here, even if some of them are nil, since they
+	// could have been non-nil earlier.
+	lw.xdsHI.SetRootCertProvider(rootProvider)
+	lw.xdsHI.SetIdentityCertProvider(identityProvider)
+	lw.xdsHI.SetRequireClientCert(config.RequireClientCert)
+	return nil
+}
+
+func buildProviderFunc(configs map[string]*certprovider.BuildableConfig, instanceName, certName string, wantIdentity, wantRoot bool) (certprovider.Provider, error) {
+	cfg, ok := configs[instanceName]
+	if !ok {
+		return nil, fmt.Errorf("certificate provider instance %q not found in bootstrap file", instanceName)
+	}
+	provider, err := cfg.Build(certprovider.BuildOptions{
+		CertName:     certName,
+		WantIdentity: wantIdentity,
+		WantRoot:     wantRoot,
+	})
+	if err != nil {
+		// This error is not expected since the bootstrap process parses the
+		// config and makes sure that it is acceptable to the plugin. Still, it
+		// is possible that the plugin parses the config successfully, but its
+		// Build() method errors out.
+		return nil, fmt.Errorf("xds: failed to get security plugin instance (%+v): %v", cfg, err)
+	}
+	return provider, nil
 }
 
 // Stop stops the underlying gRPC server. It immediately closes all open
@@ -279,7 +407,16 @@ type listenerWrapper struct {
 	net.Listener
 	cancelWatch func()
 
-	// TODO(easwars): Add fields for certificate providers.
+	// A small race exists in the xdsClient code where an xDS response is
+	// received while the user is calling cancel(). In this small window the
+	// registered callback can be called after the watcher is canceled.
+	closed *grpcsync.Event
+
+	// The certificate providers are cached here to that they can be closed when
+	// a new provider is to be created.
+	cachedRoot     certprovider.Provider
+	cachedIdentity certprovider.Provider
+	xdsHI          *xds.HandshakeInfo
 }
 
 // Accept blocks on an Accept() on the underlying listener, and wraps the
@@ -289,17 +426,26 @@ func (l *listenerWrapper) Accept() (net.Conn, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &conn{Conn: c}, nil
+	return &conn{Conn: c, xdsHI: l.xdsHI}, nil
 }
 
 // Close closes the underlying listener. It also cancels the xDS watch
 // registered in Serve() and closes any certificate provider instances created
 // based on security configuration received in the LDS response.
 func (l *listenerWrapper) Close() error {
+	l.closed.Fire()
 	l.Listener.Close()
 	if l.cancelWatch != nil {
 		l.cancelWatch()
 	}
+	if l.cachedIdentity != nil {
+		l.cachedIdentity.Close()
+	}
+	if l.cachedRoot != nil {
+		l.cachedRoot.Close()
+	}
+	l.cachedRoot = nil
+	l.cachedIdentity = nil
 	return nil
 }
 
@@ -307,5 +453,41 @@ func (l *listenerWrapper) Close() error {
 type conn struct {
 	net.Conn
 
-	// TODO(easwars): Add fields for certificate providers.
+	// This is the same HandshakeInfo as stored in the listenerWrapper that
+	// created this conn. The former updates the HandshakeInfo whenever it
+	// receives new security configuration.
+	xdsHI *xds.HandshakeInfo
+
+	// The connection deadline as configured by the grpc.Server on the rawConn
+	// that is returned by a call to Accept(). This is set to the connection
+	// timeout value configured by the user (or to a default value) before
+	// initiating the transport credential handshake, and set to zero after
+	// completing the HTTP2 handshake.
+	deadlineMu sync.Mutex
+	deadline   time.Time
+}
+
+// SetDeadline makes a copy of the passed in deadline and forwards the call to
+// the underlying rawConn.
+func (c *conn) SetDeadline(t time.Time) error {
+	c.deadlineMu.Lock()
+	c.deadline = t
+	c.deadlineMu.Unlock()
+	return c.Conn.SetDeadline(t)
+}
+
+// GetDeadline returns the configured deadline. This will be invoked by the
+// ServerHandshake() method of the XdsCredentials, which needs a deadline to
+// pass to the certificate provider.
+func (c *conn) GetDeadline() time.Time {
+	c.deadlineMu.Lock()
+	t := c.deadline
+	c.deadlineMu.Unlock()
+	return t
+}
+
+// XDSHandshakeInfo returns a pointer to the HandshakeInfo stored in conn. This
+// will be invoked by the ServerHandshake() method of the XdsCredentials.
+func (c *conn) XDSHandshakeInfo() *xds.HandshakeInfo {
+	return c.xdsHI
 }

--- a/xds/server.go
+++ b/xds/server.go
@@ -350,7 +350,7 @@ func (s *GRPCServer) handleSecurityConfig(config *xdsclient.SecurityConfig, lw *
 func buildProviderFunc(configs map[string]*certprovider.BuildableConfig, instanceName, certName string, wantIdentity, wantRoot bool) (certprovider.Provider, error) {
 	cfg, ok := configs[instanceName]
 	if !ok {
-		return nil, fmt.Errorf("xds: certificate provider instance %q not found in bootstrap file", instanceName)
+		return nil, fmt.Errorf("certificate provider instance %q not found in bootstrap file", instanceName)
 	}
 	provider, err := cfg.Build(certprovider.BuildOptions{
 		CertName:     certName,
@@ -362,7 +362,7 @@ func buildProviderFunc(configs map[string]*certprovider.BuildableConfig, instanc
 		// config and makes sure that it is acceptable to the plugin. Still, it
 		// is possible that the plugin parses the config successfully, but its
 		// Build() method errors out.
-		return nil, fmt.Errorf("xds: failed to get security plugin instance (%+v): %v", cfg, err)
+		return nil, fmt.Errorf("failed to get security plugin instance (%+v): %v", cfg, err)
 	}
 	return provider, nil
 }

--- a/xds/server_test.go
+++ b/xds/server_test.go
@@ -29,6 +29,8 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/credentials/tls/certprovider"
+	"google.golang.org/grpc/credentials/xds"
 	"google.golang.org/grpc/internal/grpctest"
 	"google.golang.org/grpc/internal/testutils"
 	xdsclient "google.golang.org/grpc/xds/internal/client"
@@ -89,28 +91,56 @@ func newFakeGRPCServer() *fakeGRPCServer {
 }
 
 func (s) TestNewServer(t *testing.T) {
-	// The xds package adds a couple of server options (unary and stream
-	// interceptors) to the server options passed in by the user.
-	serverOpts := []grpc.ServerOption{grpc.Creds(insecure.NewCredentials())}
-	wantServerOpts := len(serverOpts) + 2
-
-	origNewGRPCServer := newGRPCServer
-	newGRPCServer = func(opts ...grpc.ServerOption) grpcServerInterface {
-		if got := len(opts); got != wantServerOpts {
-			t.Fatalf("%d ServerOptions passed to grpc.Server, want %d", got, wantServerOpts)
-		}
-		// Verify that the user passed ServerOptions are forwarded as is.
-		if !reflect.DeepEqual(opts[2:], serverOpts) {
-			t.Fatalf("got ServerOptions %v, want %v", opts[2:], serverOpts)
-		}
-		return newFakeGRPCServer()
+	xdsCreds, err := xds.NewServerCredentials(xds.ServerOptions{FallbackCreds: insecure.NewCredentials()})
+	if err != nil {
+		t.Fatalf("failed to create xds server credentials: %v", err)
 	}
-	defer func() {
-		newGRPCServer = origNewGRPCServer
-	}()
 
-	s := NewGRPCServer(serverOpts...)
-	defer s.Stop()
+	tests := []struct {
+		desc              string
+		serverOpts        []grpc.ServerOption
+		wantXDSCredsInUse bool
+	}{
+		{
+			desc:       "without_xds_creds",
+			serverOpts: []grpc.ServerOption{grpc.Creds(insecure.NewCredentials())},
+		},
+		{
+			desc:              "with_xds_creds",
+			serverOpts:        []grpc.ServerOption{grpc.Creds(xdsCreds)},
+			wantXDSCredsInUse: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			// The xds package adds a couple of server options (unary and stream
+			// interceptors) to the server options passed in by the user.
+			wantServerOpts := len(test.serverOpts) + 2
+
+			origNewGRPCServer := newGRPCServer
+			newGRPCServer = func(opts ...grpc.ServerOption) grpcServerInterface {
+				if got := len(opts); got != wantServerOpts {
+					t.Fatalf("%d ServerOptions passed to grpc.Server, want %d", got, wantServerOpts)
+				}
+				// Verify that the user passed ServerOptions are forwarded as is.
+				if !reflect.DeepEqual(opts[2:], test.serverOpts) {
+					t.Fatalf("got ServerOptions %v, want %v", opts[2:], test.serverOpts)
+				}
+				return grpc.NewServer(opts...)
+			}
+			defer func() {
+				newGRPCServer = origNewGRPCServer
+			}()
+
+			s := NewGRPCServer(test.serverOpts...)
+			defer s.Stop()
+
+			if s.xdsCredsInUse != test.wantXDSCredsInUse {
+				t.Fatalf("xdsCredsInUse is %v, want %v", s.xdsCredsInUse, test.wantXDSCredsInUse)
+			}
+		})
+	}
 }
 
 func (s) TestRegisterService(t *testing.T) {
@@ -131,11 +161,68 @@ func (s) TestRegisterService(t *testing.T) {
 	}
 }
 
-// setupOverrides sets up overrides for bootstrap config, new xdsClient creation
-// and new gRPC.Server creation.
-func setupOverrides(t *testing.T) (*fakeGRPCServer, *testutils.Channel, func()) {
-	t.Helper()
+const (
+	fakeProvider1Name = "fake-certificate-provider-1"
+	fakeProvider2Name = "fake-certificate-provider-2"
+	fakeConfig        = "my fake config"
+)
 
+var (
+	fpb1, fpb2          *fakeProviderBuilder
+	certProviderConfigs map[string]*certprovider.BuildableConfig
+)
+
+func init() {
+	fpb1 = &fakeProviderBuilder{name: fakeProvider1Name}
+	fpb2 = &fakeProviderBuilder{name: fakeProvider2Name}
+	cfg1, _ := fpb1.ParseConfig(fakeConfig + "1111")
+	cfg2, _ := fpb2.ParseConfig(fakeConfig + "2222")
+	certProviderConfigs = map[string]*certprovider.BuildableConfig{
+		"default1": cfg1,
+		"default2": cfg2,
+	}
+	certprovider.Register(fpb1)
+	certprovider.Register(fpb2)
+}
+
+// fakeProviderBuilder builds new instances of fakeProvider and interprets the
+// config provided to it as a string.
+type fakeProviderBuilder struct {
+	name string
+}
+
+func (b *fakeProviderBuilder) ParseConfig(config interface{}) (*certprovider.BuildableConfig, error) {
+	s, ok := config.(string)
+	if !ok {
+		return nil, fmt.Errorf("providerBuilder %s received config of type %T, want string", b.name, config)
+	}
+	return certprovider.NewBuildableConfig(b.name, []byte(s), func(certprovider.BuildOptions) certprovider.Provider {
+		return &fakeProvider{
+			Distributor: certprovider.NewDistributor(),
+			config:      s,
+		}
+	}), nil
+}
+
+func (b *fakeProviderBuilder) Name() string {
+	return b.name
+}
+
+// fakeProvider is an implementation of the Provider interface which provides a
+// method for tests to invoke to push new key materials.
+type fakeProvider struct {
+	*certprovider.Distributor
+	config string
+}
+
+// Close helps implement the Provider interface.
+func (p *fakeProvider) Close() {
+	p.Distributor.Stop()
+}
+
+// setupOverrides sets up overrides for bootstrap config, new xdsClient creation,
+// new gRPC.Server creation, and certificate provider creation.
+func setupOverrides() (*fakeGRPCServer, *testutils.Channel, *testutils.Channel, func()) {
 	clientCh := testutils.NewChannel()
 	origNewXDSClient := newXDSClient
 	newXDSClient = func() (xdsClientInterface, error) {
@@ -145,6 +232,7 @@ func setupOverrides(t *testing.T) (*fakeGRPCServer, *testutils.Channel, func()) 
 			Creds:                grpc.WithTransportCredentials(insecure.NewCredentials()),
 			NodeProto:            xdstestutils.EmptyNodeProtoV3,
 			ServerResourceNameID: testServerResourceNameID,
+			CertProviderConfigs:  certProviderConfigs,
 		})
 		clientCh.Send(c)
 		return c, nil
@@ -154,9 +242,55 @@ func setupOverrides(t *testing.T) (*fakeGRPCServer, *testutils.Channel, func()) 
 	origNewGRPCServer := newGRPCServer
 	newGRPCServer = func(opts ...grpc.ServerOption) grpcServerInterface { return fs }
 
-	return fs, clientCh, func() {
+	providerCh := testutils.NewChannel()
+	origBuildProvider := buildProvider
+	buildProvider = func(c map[string]*certprovider.BuildableConfig, id, cert string, wi, wr bool) (certprovider.Provider, error) {
+		p, err := origBuildProvider(c, id, cert, wi, wr)
+		providerCh.Send(nil)
+		return p, err
+	}
+
+	return fs, clientCh, providerCh, func() {
 		newXDSClient = origNewXDSClient
 		newGRPCServer = origNewGRPCServer
+		buildProvider = origBuildProvider
+	}
+}
+
+// setupOverridesForXDSCreds overrides only the xdsClient creation with a fake
+// one. Tests that use xdsCredentials need a real grpc.Server instead of a fake
+// one, because the xDS-enabled server needs to read configured creds from the
+// underlying grpc.Server to confirm whether xdsCreds were configured.
+func setupOverridesForXDSCreds(includeCertProviderCfg bool) (*testutils.Channel, *testutils.Channel, func()) {
+	clientCh := testutils.NewChannel()
+	origNewXDSClient := newXDSClient
+	newXDSClient = func() (xdsClientInterface, error) {
+		c := fakeclient.NewClient()
+		bc := &bootstrap.Config{
+			BalancerName:         "dummyBalancer",
+			Creds:                grpc.WithTransportCredentials(insecure.NewCredentials()),
+			NodeProto:            xdstestutils.EmptyNodeProtoV3,
+			ServerResourceNameID: testServerResourceNameID,
+		}
+		if includeCertProviderCfg {
+			bc.CertProviderConfigs = certProviderConfigs
+		}
+		c.SetBootstrapConfig(bc)
+		clientCh.Send(c)
+		return c, nil
+	}
+
+	providerCh := testutils.NewChannel()
+	origBuildProvider := buildProvider
+	buildProvider = func(c map[string]*certprovider.BuildableConfig, id, cert string, wi, wr bool) (certprovider.Provider, error) {
+		p, err := origBuildProvider(c, id, cert, wi, wr)
+		providerCh.Send(nil)
+		return p, err
+	}
+
+	return clientCh, providerCh, func() {
+		newXDSClient = origNewXDSClient
+		buildProvider = origBuildProvider
 	}
 }
 
@@ -169,7 +303,7 @@ func setupOverrides(t *testing.T) (*fakeGRPCServer, *testutils.Channel, func()) 
 // 4. Push a good response from the xdsClient, and make sure that Serve() on the
 // 	  underlying grpc.Server is called.
 func (s) TestServeSuccess(t *testing.T) {
-	fs, clientCh, cleanup := setupOverrides(t)
+	fs, clientCh, _, cleanup := setupOverrides()
 	defer cleanup()
 
 	server := NewGRPCServer()
@@ -229,7 +363,7 @@ func (s) TestServeSuccess(t *testing.T) {
 // is received. This should cause Serve() to exit before calling Serve() on the
 // underlying grpc.Server.
 func (s) TestServeWithStop(t *testing.T) {
-	fs, clientCh, cleanup := setupOverrides(t)
+	fs, clientCh, _, cleanup := setupOverrides()
 	defer cleanup()
 
 	// Note that we are not deferring the Stop() here since we explicitly call
@@ -301,6 +435,39 @@ func (s) TestServeBootstrapFailure(t *testing.T) {
 	}
 
 	serveDone := testutils.NewChannel()
+	go func() { serveDone.Send(server.Serve(lis)) }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	v, err := serveDone.Receive(ctx)
+	if err != nil {
+		t.Fatalf("error when waiting for Serve() to exit: %v", err)
+	}
+	if err, ok := v.(error); !ok || err == nil {
+		t.Fatal("Serve() did not exit with error")
+	}
+}
+
+// TestServeBootstrapWithMissingCertProviders tests the case where the bootstrap
+// config does not contain certificate provider configuration, but xdsCreds are
+// passed to the server. Verifies that the call to Serve() fails.
+func (s) TestServeBootstrapWithMissingCertProviders(t *testing.T) {
+	_, _, cleanup := setupOverridesForXDSCreds(false)
+	defer cleanup()
+
+	xdsCreds, err := xds.NewServerCredentials(xds.ServerOptions{FallbackCreds: insecure.NewCredentials()})
+	if err != nil {
+		t.Fatalf("failed to create xds server credentials: %v", err)
+	}
+	server := NewGRPCServer(grpc.Creds(xdsCreds))
+	defer server.Stop()
+
+	lis, err := xdstestutils.LocalTCPListener()
+	if err != nil {
+		t.Fatalf("xdstestutils.LocalTCPListener() failed: %v", err)
+	}
+
+	serveDone := testutils.NewChannel()
 	go func() {
 		err := server.Serve(lis)
 		serveDone.Send(err)
@@ -348,5 +515,218 @@ func (s) TestServeNewClientFailure(t *testing.T) {
 	}
 	if err, ok := v.(error); !ok || err == nil {
 		t.Fatal("Serve() did not exit with error")
+	}
+}
+
+// TestHandleListenerUpdate_NoXDSCreds tests the case where an xds-enabled gRPC
+// server is not configured with xDS credentials. Verifies that the security
+// config received as part of a Listener update is not acted upon.
+func (s) TestHandleListenerUpdate_NoXDSCreds(t *testing.T) {
+	fs, clientCh, providerCh, cleanup := setupOverrides()
+	defer cleanup()
+
+	server := NewGRPCServer()
+	defer server.Stop()
+
+	lis, err := xdstestutils.LocalTCPListener()
+	if err != nil {
+		t.Fatalf("xdstestutils.LocalTCPListener() failed: %v", err)
+	}
+
+	// Call Serve() in a goroutine, and push on a channel when Serve returns.
+	serveDone := testutils.NewChannel()
+	go func() {
+		if err := server.Serve(lis); err != nil {
+			t.Error(err)
+		}
+		serveDone.Send(nil)
+	}()
+
+	// Wait for an xdsClient to be created.
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	c, err := clientCh.Receive(ctx)
+	if err != nil {
+		t.Fatalf("error when waiting for new xdsClient to be created: %v", err)
+	}
+	client := c.(*fakeclient.Client)
+
+	// Wait for a listener watch to be registered on the xdsClient.
+	name, err := client.WaitForWatchListener(ctx)
+	if err != nil {
+		t.Fatalf("error when waiting for a ListenerWatch: %v", err)
+	}
+	wantName := fmt.Sprintf("%s?udpa.resource.listening_address=%s", client.BootstrapConfig().ServerResourceNameID, lis.Addr().String())
+	if name != wantName {
+		t.Fatalf("LDS watch registered for name %q, want %q", name, wantName)
+	}
+
+	// Push a good LDS response with security config, and wait for Serve() to be
+	// invoked on the underlying grpc.Server. Also make sure that certificate
+	// providers are not created.
+	client.InvokeWatchListenerCallback(xdsclient.ListenerUpdate{
+		RouteConfigName: "routeconfig",
+		SecurityCfg: &xdsclient.SecurityConfig{
+			RootInstanceName:     "default1",
+			IdentityInstanceName: "default2",
+			RequireClientCert:    true,
+		},
+	}, nil)
+	if _, err := fs.serveCh.Receive(ctx); err != nil {
+		t.Fatalf("error when waiting for Serve() to be invoked on the grpc.Server")
+	}
+
+	// Make sure the security configuration is not acted upon.
+	sCtx, sCancel := context.WithTimeout(context.Background(), defaultTestShortTimeout)
+	defer sCancel()
+	if _, err := providerCh.Receive(sCtx); err != context.DeadlineExceeded {
+		t.Fatalf("certificate provider created when no xDS creds were specified")
+	}
+}
+
+// TestHandleListenerUpdate_ErrorUpdate tests the case where an xds-enabled gRPC
+// server is configured with xDS credentials, but receives a Listener update
+// with an error. Verifies that no certificate providers are created.
+func (s) TestHandleListenerUpdate_ErrorUpdate(t *testing.T) {
+	clientCh, providerCh, cleanup := setupOverridesForXDSCreds(true)
+	defer cleanup()
+
+	xdsCreds, err := xds.NewServerCredentials(xds.ServerOptions{FallbackCreds: insecure.NewCredentials()})
+	if err != nil {
+		t.Fatalf("failed to create xds server credentials: %v", err)
+	}
+
+	server := NewGRPCServer(grpc.Creds(xdsCreds))
+	defer server.Stop()
+
+	lis, err := xdstestutils.LocalTCPListener()
+	if err != nil {
+		t.Fatalf("xdstestutils.LocalTCPListener() failed: %v", err)
+	}
+
+	// Call Serve() in a goroutine, and push on a channel when Serve returns.
+	serveDone := testutils.NewChannel()
+	go func() {
+		if err := server.Serve(lis); err != nil {
+			t.Error(err)
+		}
+		serveDone.Send(nil)
+	}()
+
+	// Wait for an xdsClient to be created.
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	c, err := clientCh.Receive(ctx)
+	if err != nil {
+		t.Fatalf("error when waiting for new xdsClient to be created: %v", err)
+	}
+	client := c.(*fakeclient.Client)
+
+	// Wait for a listener watch to be registered on the xdsClient.
+	name, err := client.WaitForWatchListener(ctx)
+	if err != nil {
+		t.Fatalf("error when waiting for a ListenerWatch: %v", err)
+	}
+	wantName := fmt.Sprintf("%s?udpa.resource.listening_address=%s", client.BootstrapConfig().ServerResourceNameID, lis.Addr().String())
+	if name != wantName {
+		t.Fatalf("LDS watch registered for name %q, want %q", name, wantName)
+	}
+
+	// Push an error to the registered listener watch callback and make sure
+	// that Serve does not return.
+	client.InvokeWatchListenerCallback(xdsclient.ListenerUpdate{
+		RouteConfigName: "routeconfig",
+		SecurityCfg: &xdsclient.SecurityConfig{
+			RootInstanceName:     "default1",
+			IdentityInstanceName: "default2",
+			RequireClientCert:    true,
+		},
+	}, errors.New("LDS error"))
+	sCtx, sCancel := context.WithTimeout(context.Background(), defaultTestShortTimeout)
+	defer sCancel()
+	if _, err := serveDone.Receive(sCtx); err != context.DeadlineExceeded {
+		t.Fatal("Serve() returned after a bad LDS response")
+	}
+
+	// Also make sure that no certificate providers are created.
+	sCtx, sCancel = context.WithTimeout(context.Background(), defaultTestShortTimeout)
+	defer sCancel()
+	if _, err := providerCh.Receive(sCtx); err != context.DeadlineExceeded {
+		t.Fatalf("certificate provider created when no xDS creds were specified")
+	}
+}
+
+func (s) TestHandleListenerUpdate_ClosedListener(t *testing.T) {
+	clientCh, providerCh, cleanup := setupOverridesForXDSCreds(true)
+	defer cleanup()
+
+	xdsCreds, err := xds.NewServerCredentials(xds.ServerOptions{FallbackCreds: insecure.NewCredentials()})
+	if err != nil {
+		t.Fatalf("failed to create xds server credentials: %v", err)
+	}
+
+	server := NewGRPCServer(grpc.Creds(xdsCreds))
+	defer server.Stop()
+
+	lis, err := xdstestutils.LocalTCPListener()
+	if err != nil {
+		t.Fatalf("xdstestutils.LocalTCPListener() failed: %v", err)
+	}
+
+	// Call Serve() in a goroutine, and push on a channel when Serve returns.
+	serveDone := testutils.NewChannel()
+	go func() { serveDone.Send(server.Serve(lis)) }()
+
+	// Wait for an xdsClient to be created.
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	c, err := clientCh.Receive(ctx)
+	if err != nil {
+		t.Fatalf("error when waiting for new xdsClient to be created: %v", err)
+	}
+	client := c.(*fakeclient.Client)
+
+	// Wait for a listener watch to be registered on the xdsClient.
+	name, err := client.WaitForWatchListener(ctx)
+	if err != nil {
+		t.Fatalf("error when waiting for a ListenerWatch: %v", err)
+	}
+	wantName := fmt.Sprintf("%s?udpa.resource.listening_address=%s", client.BootstrapConfig().ServerResourceNameID, lis.Addr().String())
+	if name != wantName {
+		t.Fatalf("LDS watch registered for name %q, want %q", name, wantName)
+	}
+
+	// Push a good update to the registered listener watch callback. This will
+	// unblock the xds-enabled server which is waiting for a good listener
+	// update before calling Serve() on the underlying grpc.Server.
+	client.InvokeWatchListenerCallback(xdsclient.ListenerUpdate{
+		RouteConfigName: "routeconfig",
+		SecurityCfg:     &xdsclient.SecurityConfig{IdentityInstanceName: "default2"},
+	}, nil)
+	if _, err := providerCh.Receive(ctx); err != nil {
+		t.Fatal("error when waiting for certificate provider to be created")
+	}
+
+	// Close the listener passed to Serve(), and wait for the latter to return a
+	// non-nil error.
+	lis.Close()
+	v, err := serveDone.Receive(ctx)
+	if err != nil {
+		t.Fatalf("error when waiting for Serve() to exit: %v", err)
+	}
+	if err, ok := v.(error); !ok || err == nil {
+		t.Fatal("Serve() did not exit with error")
+	}
+
+	// Push another listener update and make sure that no certificate providers
+	// are created.
+	client.InvokeWatchListenerCallback(xdsclient.ListenerUpdate{
+		RouteConfigName: "routeconfig",
+		SecurityCfg:     &xdsclient.SecurityConfig{IdentityInstanceName: "default1"},
+	}, nil)
+	sCtx, sCancel := context.WithTimeout(context.Background(), defaultTestShortTimeout)
+	defer sCancel()
+	if _, err := providerCh.Receive(sCtx); err != context.DeadlineExceeded {
+		t.Fatalf("certificate provider created when no xDS creds were specified")
 	}
 }


### PR DESCRIPTION
Summary of changes:
- Add security integration to `xds.GRPCServer`:
  - Retrieve configured transport credentials from the underlying `grpc.Server`
  - Handle security configuration in received `Listener` resource
    - create appropriate certificate providers
    - setup `HandshakeInfo` to be passed to `xds.Credentials`
    - wrap the underlying `net.Conn`
      - support for setting and getting deadline
      - support for retrieving the `HandshakeInfo`
- e2e test which exercises xDS security with a file watcher plugin.
- A way to retrieve the transport credentials configured on a `grpc.Server` through the `internal` package.