### PR TITLE
github: Get tests111 to actually run subset of tests

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -77,7 +77,7 @@ jobs:
       # Main tests run for everything except when testing "extras", the race
       # detector and Go1.11 (where we run a reduced set of tests).
       - name: Run tests
-        if: ${{ matrix.type != 'extras' && matrix.type != 'race' && matrix.type != 'test111' }}
+        if: ${{ matrix.type != 'extras' && matrix.type != 'race' && matrix.type != 'tests111' }}
         run: go test -cpu 1,4 -timeout 7m google.golang.org/grpc/...
 
       # Race detector tests
@@ -99,5 +99,6 @@ jobs:
       - name: Run Go1.11 tests
         if: ${{ matrix.type == 'tests111' }}
         run: |
-          tests=$(find ${GITHUB_WORKSPACE} -name '*_test.go' | xargs -n1 dirname | sort -u | sed "s:^${GITHUB_WORKSPACE}:.:" | sed "s:\/$::" | grep -v ^./security | grep -v ^./credentials/sts | grep -v ^./credentials/tls/certprovider | grep -v ^./credentials/xds | grep -v ^./xds | grep -v ^./security)
+          tests=$(find ${GITHUB_WORKSPACE} -name '*_test.go' | xargs -n1 dirname | sort -u | sed "s:^${GITHUB_WORKSPACE}:.:" | sed "s:\/$::" | grep -v ^./security | grep -v ^./credentials/sts | grep -v ^./credentials/tls/certprovider | grep -v ^./credentials/xds | grep -v ^./xds )
+          echo "Running tests for " ${tests}
           go test -cpu 1,4 -timeout 7m ${tests}


### PR DESCRIPTION
- Looks like https://github.com/grpc/grpc-go/pull/4102 did not achieve what it set out to because of a typo. Fixed that `s/test111/tests111`.
- There were two `grep -v ^./security`. Deleted one of them.
- Added an print of the actual tests being run to aid with any debugging in the future.

