### PR TITLE
xds: Expect certprovider bootstrap configs when xdsCreds are in use

### DIFF
--- a/xds/internal/resolver/xds_resolver.go
+++ b/xds/internal/resolver/xds_resolver.go
@@ -79,7 +79,7 @@ func (b *xdsResolverBuilder) Build(t resolver.Target, cc resolver.ClientConn, op
 	if xc, ok := creds.(interface{ UsesXDS() bool }); ok && xc.UsesXDS() {
 		bc := client.BootstrapConfig()
 		if len(bc.CertProviderConfigs) == 0 {
-			return nil, errors.New("xds: certificate_providers config missing in bootstrap file")
+			return nil, errors.New("xds: xdsCreds specified but certificate_providers config missing in bootstrap file")
 		}
 	}
 


### PR DESCRIPTION
If xds credentials were specified by the user, but bootstrap configs do 
not contain any certificate provider configuration, it is better to fail
the `resolver.Build()` and hence `grpc.Dial() instead of failing when attempting to create certificate
providers after receiving a CDS response with security configuration.
