### PR TITLE
pemfile: Update distributor only inside of the for loop

### DIFF
--- a/credentials/tls/certprovider/pemfile/watcher.go
+++ b/credentials/tls/certprovider/pemfile/watcher.go
@@ -214,11 +214,6 @@ func (w *watcher) updateRootDistributor() {
 // changes, and pushes new key material into the appropriate distributors which
 // is returned from calls to KeyMaterial().
 func (w *watcher) run(ctx context.Context) {
-	// Update both root and identity certs at the beginning. Subsequently,
-	// update only the appropriate file whose ticker has fired.
-	w.updateIdentityDistributor()
-	w.updateRootDistributor()
-
 	ticker := time.NewTicker(w.opts.RefreshDuration)
 	for {
 		w.updateIdentityDistributor()


### PR DESCRIPTION
The `run()` method had changed a little over time and it looks like we are calling
`update*Distributor()` once from outside the `for` and then immediately at the top
of the `for` loop.

Even though the `update*Distributor()` methods check if the file contents have changed
before updating the distributor with new key material, the current state is suboptimal.

This seems to be fix: https://github.com/grpc/grpc-go/issues/4048
I don't understand why it fixes it though. I have run the test a few hundred times on GA with this fix
and it never failed. Without this fix though, it would fail around once every hundred times. I have never been
able to repro this locally though.