### PR TITLE
xds: implement RouteAction timeout support

### DIFF
--- a/internal/wrr/random.go
+++ b/internal/wrr/random.go
@@ -18,6 +18,7 @@
 package wrr
 
 import (
+	"fmt"
 	"sync"
 
 	"google.golang.org/grpc/internal/grpcrand"
@@ -27,6 +28,10 @@ import (
 type weightedItem struct {
 	Item   interface{}
 	Weight int64
+}
+
+func (w *weightedItem) String() string {
+	return fmt.Sprint(*w)
 }
 
 // randomWRR is a struct that contains weighted items implement weighted random algorithm.
@@ -67,4 +72,8 @@ func (rw *randomWRR) Add(item interface{}, weight int64) {
 	rItem := &weightedItem{Item: item, Weight: weight}
 	rw.items = append(rw.items, rItem)
 	rw.sumOfWeights += weight
+}
+
+func (rw *randomWRR) String() string {
+	return fmt.Sprint(rw.items)
 }

--- a/xds/internal/client/client.go
+++ b/xds/internal/client/client.go
@@ -176,9 +176,11 @@ type Route struct {
 	Path, Prefix, Regex *string
 	// Indicates if prefix/path matching should be case insensitive. The default
 	// is false (case sensitive).
-	CaseInsensitive   bool
-	Headers           []*HeaderMatcher
-	Fraction          *uint32
+	CaseInsensitive bool
+	Headers         []*HeaderMatcher
+	Fraction        *uint32
+
+	// If the matchers above indicate a match, the below configuration is used.
 	Action            map[string]uint32 // action is weighted clusters.
 	MaxStreamDuration time.Duration
 }

--- a/xds/internal/client/client.go
+++ b/xds/internal/client/client.go
@@ -176,10 +176,11 @@ type Route struct {
 	Path, Prefix, Regex *string
 	// Indicates if prefix/path matching should be case insensitive. The default
 	// is false (case sensitive).
-	CaseInsensitive bool
-	Headers         []*HeaderMatcher
-	Fraction        *uint32
-	Action          map[string]uint32 // action is weighted clusters.
+	CaseInsensitive   bool
+	Headers           []*HeaderMatcher
+	Fraction          *uint32
+	Action            map[string]uint32 // action is weighted clusters.
+	MaxStreamDuration time.Duration
 }
 
 // HeaderMatcher represents header matchers.

--- a/xds/internal/env/env.go
+++ b/xds/internal/env/env.go
@@ -29,7 +29,7 @@ const (
 	bootstrapFileNameEnv      = "GRPC_XDS_BOOTSTRAP"
 	xdsV3SupportEnv           = "GRPC_XDS_EXPERIMENTAL_V3_SUPPORT"
 	circuitBreakingSupportEnv = "GRPC_XDS_EXPERIMENTAL_CIRCUIT_BREAKING"
-	timeoutSupportEnv         = "GRPC_XDS_EXPERIMENTAL_TIMEOUT"
+	timeoutSupportEnv         = "GRPC_XDS_EXPERIMENTAL_ENABLE_TIMEOUT"
 )
 
 var (
@@ -47,6 +47,6 @@ var (
 	CircuitBreakingSupport = strings.EqualFold(os.Getenv(circuitBreakingSupportEnv), "true")
 	// TimeoutSupport indicates whether support for max_stream_duration in
 	// route actions is enabled.  This can be enabled by setting the
-	// environment variable "GRPC_XDS_EXPERIMENTAL_TIMEOUT" to "true".
+	// environment variable "GRPC_XDS_EXPERIMENTAL_ENABLE_TIMEOUT" to "true".
 	TimeoutSupport = strings.EqualFold(os.Getenv(timeoutSupportEnv), "true")
 )

--- a/xds/internal/env/env.go
+++ b/xds/internal/env/env.go
@@ -29,6 +29,7 @@ const (
 	bootstrapFileNameEnv      = "GRPC_XDS_BOOTSTRAP"
 	xdsV3SupportEnv           = "GRPC_XDS_EXPERIMENTAL_V3_SUPPORT"
 	circuitBreakingSupportEnv = "GRPC_XDS_EXPERIMENTAL_CIRCUIT_BREAKING"
+	timeoutSupportEnv         = "GRPC_XDS_EXPERIMENTAL_TIMEOUT"
 )
 
 var (
@@ -44,4 +45,8 @@ var (
 	// enabled, which can be done by setting the environment variable
 	// "GRPC_XDS_EXPERIMENTAL_CIRCUIT_BREAKING" to "true".
 	CircuitBreakingSupport = strings.EqualFold(os.Getenv(circuitBreakingSupportEnv), "true")
+	// TimeoutSupport indicates whether support for max_stream_duration in
+	// route actions is enabled.  This can be enabled by setting the
+	// environment variable "GRPC_XDS_EXPERIMENTAL_TIMEOUT" to "true".
+	TimeoutSupport = strings.EqualFold(os.Getenv(timeoutSupportEnv), "true")
 )

--- a/xds/internal/resolver/serviceconfig.go
+++ b/xds/internal/resolver/serviceconfig.go
@@ -101,7 +101,7 @@ type route struct {
 }
 
 func (r route) String() string {
-	return r.m.String() + "->" + fmt.Sprint(r.clusters)
+	return fmt.Sprintf("%s -> { clusters: %v, maxStreamDuration: %v }", r.m.String(), r.clusters, r.maxStreamDuration)
 }
 
 type configSelector struct {

--- a/xds/internal/resolver/serviceconfig.go
+++ b/xds/internal/resolver/serviceconfig.go
@@ -22,12 +22,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"sync/atomic"
+	"time"
 
 	"google.golang.org/grpc/codes"
 	iresolver "google.golang.org/grpc/internal/resolver"
 	"google.golang.org/grpc/internal/wrr"
 	"google.golang.org/grpc/status"
 	"google.golang.org/grpc/xds/internal/balancer/clustermanager"
+	"google.golang.org/grpc/xds/internal/env"
 )
 
 const (
@@ -93,12 +95,13 @@ func serviceConfigJSON(activeClusters map[string]*clusterInfo) (string, error) {
 }
 
 type route struct {
-	action wrr.WRR
-	m      *compositeMatcher // converted from route matchers
+	m                 *compositeMatcher // converted from route matchers
+	clusters          wrr.WRR
+	maxStreamDuration time.Duration
 }
 
 func (r route) String() string {
-	return r.m.String() + "->" + fmt.Sprint(r.action)
+	return r.m.String() + "->" + fmt.Sprint(r.clusters)
 }
 
 type configSelector struct {
@@ -110,18 +113,18 @@ type configSelector struct {
 var errNoMatchedRouteFound = status.Errorf(codes.Unavailable, "no matched route was found")
 
 func (cs *configSelector) SelectConfig(rpcInfo iresolver.RPCInfo) (*iresolver.RPCConfig, error) {
-	var action wrr.WRR
+	var rt *route
 	// Loop through routes in order and select first match.
-	for _, rt := range cs.routes {
-		if rt.m.match(rpcInfo) {
-			action = rt.action
+	for _, r := range cs.routes {
+		if r.m.match(rpcInfo) {
+			rt = &r
 			break
 		}
 	}
-	if action == nil {
+	if rt == nil || rt.clusters == nil {
 		return nil, errNoMatchedRouteFound
 	}
-	cluster, ok := action.Next().(string)
+	cluster, ok := rt.clusters.Next().(string)
 	if !ok {
 		return nil, status.Errorf(codes.Internal, "error retrieving cluster for match: %v (%T)", cluster, cluster)
 	}
@@ -129,7 +132,8 @@ func (cs *configSelector) SelectConfig(rpcInfo iresolver.RPCInfo) (*iresolver.RP
 	// it is committed.
 	ref := &cs.clusters[cluster].refCount
 	atomic.AddInt32(ref, 1)
-	return &iresolver.RPCConfig{
+
+	config := &iresolver.RPCConfig{
 		// Communicate to the LB policy the chosen cluster.
 		Context: clustermanager.SetPickedCluster(rpcInfo.Context, cluster),
 		OnCommitted: func() {
@@ -144,7 +148,13 @@ func (cs *configSelector) SelectConfig(rpcInfo iresolver.RPCInfo) (*iresolver.RP
 				}
 			}
 		},
-	}, nil
+	}
+
+	if env.TimeoutSupport && rt.maxStreamDuration != 0 {
+		config.MethodConfig.Timeout = &rt.maxStreamDuration
+	}
+
+	return config, nil
 }
 
 // incRefs increments refs of all clusters referenced by this config selector.
@@ -196,9 +206,9 @@ func (r *xdsResolver) newConfigSelector(su serviceUpdate) (*configSelector, erro
 	}
 
 	for i, rt := range su.Routes {
-		action := newWRR()
+		clusters := newWRR()
 		for cluster, weight := range rt.Action {
-			action.Add(cluster, int64(weight))
+			clusters.Add(cluster, int64(weight))
 
 			// Initialize entries in cs.clusters map, creating entries in
 			// r.activeClusters as necessary.  Set to zero as they will be
@@ -210,14 +220,16 @@ func (r *xdsResolver) newConfigSelector(su serviceUpdate) (*configSelector, erro
 			}
 			cs.clusters[cluster] = ci
 		}
-		cs.routes[i].action = action
+		cs.routes[i].clusters = clusters
 
 		var err error
 		cs.routes[i].m, err = routeToMatcher(rt)
 		if err != nil {
 			return nil, err
 		}
+		cs.routes[i].maxStreamDuration = rt.MaxStreamDuration
 	}
+
 	return cs, nil
 }
 

--- a/xds/internal/testutils/wrr.go
+++ b/xds/internal/testutils/wrr.go
@@ -19,6 +19,7 @@
 package testutils
 
 import (
+	"fmt"
 	"sync"
 
 	"google.golang.org/grpc/internal/wrr"
@@ -65,4 +66,8 @@ func (twrr *testWRR) Next() interface{} {
 	}
 	twrr.mu.Unlock()
 	return iww.item
+}
+
+func (twrr *testWRR) String() string {
+	return fmt.Sprint(twrr.itemsWithWeight)
 }


### PR DESCRIPTION
This is missing one last piece from A31: reading the HTTP connection manager default max_stream_duration.  I'll add that in a follow-on PR.
