### PR TITLE
xds client: Updated v3 type for http connection manager

### DIFF
--- a/xds/internal/client/client_lds_test.go
+++ b/xds/internal/client/client_lds_test.go
@@ -31,6 +31,7 @@ import (
 	v3httppb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	v3tlspb "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/ptypes"
 	anypb "github.com/golang/protobuf/ptypes/any"
 	wrapperspb "github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/google/go-cmp/cmp"
@@ -87,14 +88,11 @@ func (s) TestUnmarshalListener_ClientSide(t *testing.T) {
 						},
 					},
 				}
-				mcm, _ := proto.Marshal(cm)
+				mcm, _ := ptypes.MarshalAny(cm)
 				lis := &v3listenerpb.Listener{
 					Name: v3LDSTarget,
 					ApiListener: &v3listenerpb.ApiListener{
-						ApiListener: &anypb.Any{
-							TypeUrl: version.V3HTTPConnManagerURL,
-							Value:   mcm,
-						},
+						ApiListener: mcm,
 					},
 				}
 				mLis, _ := proto.Marshal(lis)

--- a/xds/internal/version/version.go
+++ b/xds/internal/version/version.go
@@ -45,7 +45,7 @@ const (
 	V3RouteConfigURL          = "type.googleapis.com/envoy.config.route.v3.RouteConfiguration"
 	V3ClusterURL              = "type.googleapis.com/envoy.config.cluster.v3.Cluster"
 	V3EndpointsURL            = "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment"
-	V3HTTPConnManagerURL      = "type.googleapis.com/envoy.config.filter.network.http_connection_manager.v3.HttpConnectionManager"
+	V3HTTPConnManagerURL      = "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager"
 	V3UpstreamTLSContextURL   = "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext"
 	V3DownstreamTLSContextURL = "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext"
 )


### PR DESCRIPTION
Fix for Issue #4136 
I am unable to validate the failure running unit tests for `client_lds_tests.go`