### PR TITLE
xds bootstrap: support config content in env variable

### DIFF
--- a/xds/internal/client/bootstrap/bootstrap.go
+++ b/xds/internal/client/bootstrap/bootstrap.go
@@ -96,6 +96,28 @@ type xdsServer struct {
 	ServerFeatures []string       `json:"server_features"`
 }
 
+func bootstrapConfigFromEnvVariable() ([]byte, error) {
+	fName := env.BootstrapFileName
+	fContent := env.BootstrapFileContent
+
+	// Bootstrap file name has higher priority than bootstrap content.
+	if fName != "" {
+		// If file name is set
+		// - If file not found (or other errors), fail
+		// - Otherwise, use the content.
+		//
+		// Note that even if the content is invalid, we don't failover to the
+		// file content env variable.
+		return bootstrapFileReadFunc(fName)
+	}
+
+	if fContent != "" {
+		return []byte(fContent), nil
+	}
+
+	return nil, fmt.Errorf("xds: bootstrap environment variable (%q, or %q) not defined", "GRPC_XDS_BOOTSTRAP", "GRPC_XDS_BOOTSTRAP_CONFIG")
+}
+
 // NewConfig returns a new instance of Config initialized by reading the
 // bootstrap file found at ${GRPC_XDS_BOOTSTRAP}.
 //
@@ -136,21 +158,15 @@ type xdsServer struct {
 func NewConfig() (*Config, error) {
 	config := &Config{}
 
-	fName := env.BootstrapFileName
-	if fName == "" {
-		return nil, fmt.Errorf("xds: Environment variable %q not defined", "GRPC_XDS_BOOTSTRAP")
-	}
-	logger.Infof("Got bootstrap file location %q", fName)
-
-	data, err := bootstrapFileReadFunc(fName)
+	data, err := bootstrapConfigFromEnvVariable()
 	if err != nil {
-		return nil, fmt.Errorf("xds: Failed to read bootstrap file %s with error %v", fName, err)
+		return nil, fmt.Errorf("xds: Failed to get bootstrap config, error %v", err)
 	}
 	logger.Debugf("Bootstrap content: %s", data)
 
 	var jsonData map[string]json.RawMessage
 	if err := json.Unmarshal(data, &jsonData); err != nil {
-		return nil, fmt.Errorf("xds: Failed to parse file %s (content %v) with error: %v", fName, string(data), err)
+		return nil, fmt.Errorf("xds: Failed to parse bootstrap config (content %v) with error: %v", string(data), err)
 	}
 
 	serverSupportsV3 := false

--- a/xds/internal/client/bootstrap/bootstrap.go
+++ b/xds/internal/client/bootstrap/bootstrap.go
@@ -108,6 +108,7 @@ func bootstrapConfigFromEnvVariable() ([]byte, error) {
 		//
 		// Note that even if the content is invalid, we don't failover to the
 		// file content env variable.
+		logger.Debugf("xds: using bootstrap file with name %q", fName)
 		return bootstrapFileReadFunc(fName)
 	}
 
@@ -115,7 +116,7 @@ func bootstrapConfigFromEnvVariable() ([]byte, error) {
 		return []byte(fContent), nil
 	}
 
-	return nil, fmt.Errorf("xds: bootstrap environment variable (%q, or %q) not defined", "GRPC_XDS_BOOTSTRAP", "GRPC_XDS_BOOTSTRAP_CONFIG")
+	return nil, fmt.Errorf("none of the bootstrap environment variables (%q or %q) defined", "GRPC_XDS_BOOTSTRAP", "GRPC_XDS_BOOTSTRAP_CONFIG")
 }
 
 // NewConfig returns a new instance of Config initialized by reading the
@@ -160,13 +161,13 @@ func NewConfig() (*Config, error) {
 
 	data, err := bootstrapConfigFromEnvVariable()
 	if err != nil {
-		return nil, fmt.Errorf("xds: Failed to get bootstrap config, error %v", err)
+		return nil, fmt.Errorf("xds: Failed to read bootstrap config: %v", err)
 	}
 	logger.Debugf("Bootstrap content: %s", data)
 
 	var jsonData map[string]json.RawMessage
 	if err := json.Unmarshal(data, &jsonData); err != nil {
-		return nil, fmt.Errorf("xds: Failed to parse bootstrap config (content %v) with error: %v", string(data), err)
+		return nil, fmt.Errorf("xds: Failed to parse bootstrap config: %v", err)
 	}
 
 	serverSupportsV3 := false

--- a/xds/internal/client/bootstrap/bootstrap.go
+++ b/xds/internal/client/bootstrap/bootstrap.go
@@ -116,7 +116,7 @@ func bootstrapConfigFromEnvVariable() ([]byte, error) {
 		return []byte(fContent), nil
 	}
 
-	return nil, fmt.Errorf("none of the bootstrap environment variables (%q or %q) defined", "GRPC_XDS_BOOTSTRAP", "GRPC_XDS_BOOTSTRAP_CONFIG")
+	return nil, fmt.Errorf("none of the bootstrap environment variables (%q or %q) defined", env.BootstrapFileNameEnv, env.BootstrapFileContentEnv)
 }
 
 // NewConfig returns a new instance of Config initialized by reading the

--- a/xds/internal/client/bootstrap/bootstrap_test.go
+++ b/xds/internal/client/bootstrap/bootstrap_test.go
@@ -282,10 +282,36 @@ func setupBootstrapOverride(bootstrapFileMap map[string]string) func() {
 // TODO: enable leak check for this package when
 // https://github.com/googleapis/google-cloud-go/issues/2417 is fixed.
 
+// This function overrides the bootstrap file NAME env variable, to test the
+// code that reads file with the given fileName.
 func testNewConfigWithFileNameEnv(t *testing.T, fileName string, wantError bool, wantConfig *Config) {
 	origBootstrapFileName := env.BootstrapFileName
 	env.BootstrapFileName = fileName
 	defer func() { env.BootstrapFileName = origBootstrapFileName }()
+
+	c, err := NewConfig()
+	if (err != nil) != wantError {
+		t.Fatalf("NewConfig() returned error %v, wantError: %v", err, wantError)
+	}
+	if wantError {
+		return
+	}
+	if err := c.compare(wantConfig); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// This function overrides the bootstrap file CONTENT env variable, to test the
+// code that uses the content from env directly.
+func testNewConfigWithFileContentEnv(t *testing.T, fileName string, wantError bool, wantConfig *Config) {
+	b, err := bootstrapFileReadFunc(fileName)
+	if err != nil {
+		// If file reading failed, skip this test.
+		return
+	}
+	origBootstrapContent := env.BootstrapFileContent
+	env.BootstrapFileContent = string(b)
+	defer func() { env.BootstrapFileContent = origBootstrapContent }()
 
 	c, err := NewConfig()
 	if (err != nil) != wantError {
@@ -360,6 +386,7 @@ func TestNewConfigV2ProtoFailure(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			testNewConfigWithFileNameEnv(t, test.name, true, nil)
+			testNewConfigWithFileContentEnv(t, test.name, true, nil)
 		})
 	}
 }
@@ -398,6 +425,7 @@ func TestNewConfigV2ProtoSuccess(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			testNewConfigWithFileNameEnv(t, test.name, false, test.wantConfig)
+			testNewConfigWithFileContentEnv(t, test.name, false, test.wantConfig)
 		})
 	}
 }
@@ -425,6 +453,7 @@ func TestNewConfigV3SupportNotEnabledOnClient(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			testNewConfigWithFileNameEnv(t, test.name, false, test.wantConfig)
+			testNewConfigWithFileContentEnv(t, test.name, false, test.wantConfig)
 		})
 	}
 }
@@ -452,6 +481,7 @@ func TestNewConfigV3SupportEnabledOnClient(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			testNewConfigWithFileNameEnv(t, test.name, false, test.wantConfig)
+			testNewConfigWithFileContentEnv(t, test.name, false, test.wantConfig)
 		})
 	}
 }
@@ -673,6 +703,7 @@ func TestNewConfigWithCertificateProviders(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			testNewConfigWithFileNameEnv(t, test.name, test.wantErr, test.wantConfig)
+			testNewConfigWithFileContentEnv(t, test.name, test.wantErr, test.wantConfig)
 		})
 	}
 }
@@ -738,6 +769,7 @@ func TestNewConfigWithServerResourceNameID(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			testNewConfigWithFileNameEnv(t, test.name, test.wantErr, test.wantConfig)
+			testNewConfigWithFileContentEnv(t, test.name, test.wantErr, test.wantConfig)
 		})
 	}
 }

--- a/xds/internal/env/env.go
+++ b/xds/internal/env/env.go
@@ -27,6 +27,7 @@ import (
 
 const (
 	bootstrapFileNameEnv      = "GRPC_XDS_BOOTSTRAP"
+	bootstrapFileContentEnv   = "GRPC_XDS_BOOTSTRAP_CONFIG"
 	xdsV3SupportEnv           = "GRPC_XDS_EXPERIMENTAL_V3_SUPPORT"
 	circuitBreakingSupportEnv = "GRPC_XDS_EXPERIMENTAL_CIRCUIT_BREAKING"
 	timeoutSupportEnv         = "GRPC_XDS_EXPERIMENTAL_ENABLE_TIMEOUT"
@@ -37,6 +38,10 @@ var (
 	// configuration. Users can specify the location of the bootstrap file by
 	// setting the environment variable "GRPC_XDS_BOOSTRAP".
 	BootstrapFileName = os.Getenv(bootstrapFileNameEnv)
+	// BootstrapFileContent holds the content of the xDS bootstrap
+	// configuration. Users can specify the bootstrap config by
+	// setting the environment variable "GRPC_XDS_BOOSTRAP_CONFIG".
+	BootstrapFileContent = os.Getenv(bootstrapFileContentEnv)
 	// V3Support indicates whether xDS v3 API support is enabled, which can be
 	// done by setting the environment variable
 	// "GRPC_XDS_EXPERIMENTAL_V3_SUPPORT" to "true".

--- a/xds/internal/env/env.go
+++ b/xds/internal/env/env.go
@@ -26,8 +26,18 @@ import (
 )
 
 const (
-	bootstrapFileNameEnv      = "GRPC_XDS_BOOTSTRAP"
-	bootstrapFileContentEnv   = "GRPC_XDS_BOOTSTRAP_CONFIG"
+	// BootstrapFileNameEnv is the env variable to set bootstrap file name.
+	// Do not use this and read from env directly. Its value is read and kept in
+	// variable BootstrapFileName.
+	//
+	// When both bootstrap FileName and FileContent are set, FileName is used.
+	BootstrapFileNameEnv = "GRPC_XDS_BOOTSTRAP"
+	// BootstrapFileContentEnv is the env variable to set bootstrapp file
+	// content. Do not use this and read from env directly. Its value is read
+	// and kept in variable BootstrapFileName.
+	//
+	// When both bootstrap FileName and FileContent are set, FileName is used.
+	BootstrapFileContentEnv   = "GRPC_XDS_BOOTSTRAP_CONFIG"
 	xdsV3SupportEnv           = "GRPC_XDS_EXPERIMENTAL_V3_SUPPORT"
 	circuitBreakingSupportEnv = "GRPC_XDS_EXPERIMENTAL_CIRCUIT_BREAKING"
 	timeoutSupportEnv         = "GRPC_XDS_EXPERIMENTAL_ENABLE_TIMEOUT"
@@ -37,11 +47,15 @@ var (
 	// BootstrapFileName holds the name of the file which contains xDS bootstrap
 	// configuration. Users can specify the location of the bootstrap file by
 	// setting the environment variable "GRPC_XDS_BOOSTRAP".
-	BootstrapFileName = os.Getenv(bootstrapFileNameEnv)
+	//
+	// When both bootstrap FileName and FileContent are set, FileName is used.
+	BootstrapFileName = os.Getenv(BootstrapFileNameEnv)
 	// BootstrapFileContent holds the content of the xDS bootstrap
 	// configuration. Users can specify the bootstrap config by
 	// setting the environment variable "GRPC_XDS_BOOSTRAP_CONFIG".
-	BootstrapFileContent = os.Getenv(bootstrapFileContentEnv)
+	//
+	// When both bootstrap FileName and FileContent are set, FileName is used.
+	BootstrapFileContent = os.Getenv(BootstrapFileContentEnv)
 	// V3Support indicates whether xDS v3 API support is enabled, which can be
 	// done by setting the environment variable
 	// "GRPC_XDS_EXPERIMENTAL_V3_SUPPORT" to "true".


### PR DESCRIPTION
1. If `GRPC_XDS_BOOTSTRAP` exists then use its value as the name of the bootstrap file. If the file is missing or the contents of the file are malformed, return an error.
1. Else, if `GRPC_XDS_BOOTSTRAP_CONFIG` exists then use its value as the bootstrap config. If the value is malformed, return an error.

fixes #4127