### PR TITLE
test: Run e2e authority tests only on linux.

### DIFF
--- a/test/authority_test.go
+++ b/test/authority_test.go
@@ -1,3 +1,5 @@
+// +build linux
+
 /*
  *
  * Copyright 2020 gRPC authors.


### PR DESCRIPTION
Although darwin supports UDS, these tests need some non-trivial amount
of work to get them to pass on darwin. This build constraint will make a
top-level `go test` happy on darwin.