### PR TITLE
pemfile: Make test happy with Go1.16

### DIFF
--- a/credentials/tls/certprovider/pemfile/watcher_test.go
+++ b/credentials/tls/certprovider/pemfile/watcher_test.go
@@ -20,15 +20,16 @@ package pemfile
 
 import (
 	"context"
-	"crypto/x509"
+	"fmt"
 	"io/ioutil"
-	"math/big"
 	"os"
 	"path"
+	"reflect"
 	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 
 	"google.golang.org/grpc/credentials/tls/certprovider"
 	"google.golang.org/grpc/internal/grpctest"
@@ -53,6 +54,29 @@ type s struct {
 
 func Test(t *testing.T) {
 	grpctest.RunSubTests(t, s{})
+}
+
+func compareKeyMaterial(got, want *certprovider.KeyMaterial) error {
+	// TODO(easwars): Remove all references to reflect.DeepEqual and use
+	// cmp.Equal instead. Currently, the later panics because x509.Certificate
+	// type defines an Equal method, but does not check for nil. This has been
+	// fixed in
+	// https://github.com/golang/go/commit/89865f8ba64ccb27f439cce6daaa37c9aa38f351,
+	// but this is only available starting go1.14. So, once we remove support
+	// for go1.13, we can make the switch.
+	if !reflect.DeepEqual(got.Certs, want.Certs) {
+		return fmt.Errorf("KeyMaterial certs = %+v, want %+v", got, want)
+	}
+	// x509.CertPool contains only unexported fields some of which contain other
+	// unexported fields. So usage of cmp.AllowUnexported() or
+	// cmpopts.IgnoreUnexported() does not help us much here. Also, the standard
+	// library does not provide a way to compare CertPool values. Comparing the
+	// subjects field of the certs in the CertPool seems like a reasonable
+	// approach.
+	if gotR, wantR := got.Roots.Subjects(), want.Roots.Subjects(); !cmp.Equal(gotR, wantR, cmpopts.EquateEmpty()) {
+		return fmt.Errorf("KeyMaterial roots = %v, want %v", string(gotR[0]), string(wantR[0]))
+	}
+	return nil
 }
 
 // TestNewProvider tests the NewProvider() function with different inputs.
@@ -263,7 +287,7 @@ func (s) TestProvider_UpdateSuccess(t *testing.T) {
 	if err != nil {
 		t.Fatalf("provider.KeyMaterial() failed: %v", err)
 	}
-	if cmp.Equal(km1, km2, cmp.AllowUnexported(big.Int{}, x509.CertPool{})) {
+	if err := compareKeyMaterial(km1, km2); err == nil {
 		t.Fatal("expected provider to return new key material after update to underlying file")
 	}
 
@@ -279,7 +303,7 @@ func (s) TestProvider_UpdateSuccess(t *testing.T) {
 	if err != nil {
 		t.Fatalf("provider.KeyMaterial() failed: %v", err)
 	}
-	if cmp.Equal(km2, km3, cmp.AllowUnexported(big.Int{}, x509.CertPool{})) {
+	if err := compareKeyMaterial(km2, km3); err == nil {
 		t.Fatal("expected provider to return new key material after update to underlying file")
 	}
 }
@@ -363,7 +387,7 @@ func (s) TestProvider_UpdateSuccessWithSymlink(t *testing.T) {
 		t.Fatalf("provider.KeyMaterial() failed: %v", err)
 	}
 
-	if cmp.Equal(km1, km2, cmp.AllowUnexported(big.Int{}, x509.CertPool{})) {
+	if err := compareKeyMaterial(km1, km2); err == nil {
 		t.Fatal("expected provider to return new key material after symlink update")
 	}
 }
@@ -403,8 +427,8 @@ func (s) TestProvider_UpdateFailure_ThenSuccess(t *testing.T) {
 	if err != nil {
 		t.Fatalf("provider.KeyMaterial() failed: %v", err)
 	}
-	if !cmp.Equal(km1, km2, cmp.AllowUnexported(big.Int{}, x509.CertPool{})) {
-		t.Fatal("expected provider to not update key material")
+	if err := compareKeyMaterial(km1, km2); err != nil {
+		t.Fatalf("expected provider to not update key material: %v", err)
 	}
 
 	// Update the key file to match the cert file.
@@ -418,7 +442,7 @@ func (s) TestProvider_UpdateFailure_ThenSuccess(t *testing.T) {
 	if err != nil {
 		t.Fatalf("provider.KeyMaterial() failed: %v", err)
 	}
-	if cmp.Equal(km2, km3, cmp.AllowUnexported(big.Int{}, x509.CertPool{})) {
+	if err := compareKeyMaterial(km2, km3); err == nil {
 		t.Fatal("expected provider to return new key material after update to underlying file")
 	}
 }

--- a/credentials/tls/certprovider/pemfile/watcher_test.go
+++ b/credentials/tls/certprovider/pemfile/watcher_test.go
@@ -74,7 +74,7 @@ func compareKeyMaterial(got, want *certprovider.KeyMaterial) error {
 	// subjects field of the certs in the CertPool seems like a reasonable
 	// approach.
 	if gotR, wantR := got.Roots.Subjects(), want.Roots.Subjects(); !cmp.Equal(gotR, wantR, cmpopts.EquateEmpty()) {
-		return fmt.Errorf("KeyMaterial roots = %v, want %v", string(gotR[0]), string(wantR[0]))
+		return fmt.Errorf("KeyMaterial roots = %v, want %v", gotR, wantR)
 	}
 	return nil
 }


### PR DESCRIPTION
Go1.16 adds a new unexported field to x509.CertPool which causes our
tests to fail because cmp.Equal() isn't happy. This change introduces a
helper function which compares certprovider.KeyMaterial in a way that
makes the test happy with the new Go version.

Fixes https://github.com/grpc/grpc-go/issues/4162