### PR TITLE
Proposal: Add support for base64 in experimental grpc.ServeHTTP(w, r) API (allowing no proxies for grpc-web-text)

### DIFF
--- a/server.go
+++ b/server.go
@@ -1801,7 +1801,7 @@ func (c *channelzServer) ChannelzMetric() *channelz.ServerInternalMetric {
 	return c.s.channelzMetric()
 }
 
-// base64Writer wraps a request body to abstract away base64 decoding on read
+// base64Reader wraps a request body to abstract away base64 decoding on read
 type base64Reader struct {
 	// ensure on close the entire object is closed by pointer reference
 	nested *io.ReadCloser
@@ -1856,6 +1856,8 @@ func (w *base64Writer) WriteHeader(code int) {
 }
 
 func (w *base64Writer) Flush() {
+	// In streams we need to make sure the Content-Type is right for.
+	w.convertHeader()
 	// encoder handles current frame flushing. Since http.Flusher doesn't return an error, we silently ignore them.
 	w.encoder.Close()
 	w.encoder = base64.NewEncoder(base64.StdEncoding, w.nested)
@@ -1892,7 +1894,6 @@ func (w *base64Writer) AppendTrailer() error {
 	if err != nil {
 		return err
 	}
-	_, err = w.Write(nil)
 	w.Flush()
 	return nil
 }


### PR DESCRIPTION
Like many folks who love GRPC out there, Envoy( a powerful and  versatile tool) or other alternatives often feel either overkill or unnecessary for the needs we desire. I took a look at the folks over at improbable and how they handle their wrapper, went through the various protocol definitions  and looked at the API documentation and threw something together that allows bypassing of this requirement. Simply, this PR adds abstractions that hijack the request body reader and response writer when content-type = application/grpc-web-text. This is desirable because said format currently offers most functionality in terms of streams. Requests still have to have arrived on HTTP/2 and subsequently TLS.

Notes:
* I couldn't find, albeit admittedly didn't look very hard for good E2E template tests in the code, but I'm willing to put some thought into testing if this is of interest. This, or rather a locally implemented version, however does work for both unary and streams.