### PR TITLE
Add service comments in protoc-gen-go-grpc generation

### DIFF
--- a/cmd/protoc-gen-go-grpc/grpc.go
+++ b/cmd/protoc-gen-go-grpc/grpc.go
@@ -135,7 +135,7 @@ func genService(gen *protogen.Plugin, file *protogen.File, g *protogen.Generated
 		g.P(deprecationComment)
 	}
 	g.Annotate(serverType, service.Location)
-	g.P("type ", serverType, " interface {")
+	g.P(service.Comments.Leading, "type ", serverType, " interface {")
 	for _, method := range service.Methods {
 		g.Annotate(serverType+"."+method.GoName, method.Location)
 		if method.Desc.Options().(*descriptorpb.MethodOptions).GetDeprecated() {


### PR DESCRIPTION
* Add service's comments generation in grpc-go

It's needed if you use comment tags (e.g. "+k8s:conversion-gen=false" in k8s) in code generation based on grpc.pb.go code