### PR TITLE
csds: change client to keep update metadata

### DIFF
--- a/xds/internal/client/callback.go
+++ b/xds/internal/client/callback.go
@@ -79,11 +79,12 @@ func (c *clientImpl) NewListeners(updates map[string]ListenerUpdate, metadata Up
 	defer c.mu.Unlock()
 
 	if metadata.ErrState != nil {
-		// On NACK, update overall version and status to the NACKed resp.
+		// On NACK, update overall version to the NACKed resp.
 		c.ldsVersion = metadata.ErrState.Version
 		for name := range updates {
 			if _, ok := c.ldsWatchers[name]; ok {
-				// On error, keep previous version and status. Only update error.
+				// On error, keep previous version for each resource. But update
+				// status and error.
 				mdCopy := c.ldsMD[name]
 				mdCopy.ErrState = metadata.ErrState
 				mdCopy.Status = metadata.Status
@@ -137,11 +138,12 @@ func (c *clientImpl) NewRouteConfigs(updates map[string]RouteConfigUpdate, metad
 	defer c.mu.Unlock()
 
 	if metadata.ErrState != nil {
-		// On NACK, update overall version and status to the NACKed resp.
+		// On NACK, update overall version to the NACKed resp.
 		c.rdsVersion = metadata.ErrState.Version
 		for name := range updates {
 			if _, ok := c.rdsWatchers[name]; ok {
-				// On error, keep previous version and status. Only update error.
+				// On error, keep previous version for each resource. But update
+				// status and error.
 				mdCopy := c.rdsMD[name]
 				mdCopy.ErrState = metadata.ErrState
 				mdCopy.Status = metadata.Status
@@ -178,11 +180,12 @@ func (c *clientImpl) NewClusters(updates map[string]ClusterUpdate, metadata Upda
 	defer c.mu.Unlock()
 
 	if metadata.ErrState != nil {
-		// On NACK, update overall version and status to the NACKed resp.
+		// On NACK, update overall version to the NACKed resp.
 		c.cdsVersion = metadata.ErrState.Version
 		for name := range updates {
 			if _, ok := c.cdsWatchers[name]; ok {
-				// On error, keep previous version and status. Only update error.
+				// On error, keep previous version for each resource. But update
+				// status and error.
 				mdCopy := c.cdsMD[name]
 				mdCopy.ErrState = metadata.ErrState
 				mdCopy.Status = metadata.Status
@@ -236,11 +239,12 @@ func (c *clientImpl) NewEndpoints(updates map[string]EndpointsUpdate, metadata U
 	defer c.mu.Unlock()
 
 	if metadata.ErrState != nil {
-		// On NACK, update overall version and status to the NACKed resp.
+		// On NACK, update overall version to the NACKed resp.
 		c.edsVersion = metadata.ErrState.Version
 		for name := range updates {
 			if _, ok := c.edsWatchers[name]; ok {
-				// On error, keep previous version and status. Only update error.
+				// On error, keep previous version for each resource. But update
+				// status and error.
 				mdCopy := c.edsMD[name]
 				mdCopy.ErrState = metadata.ErrState
 				mdCopy.Status = metadata.Status

--- a/xds/internal/client/callback.go
+++ b/xds/internal/client/callback.go
@@ -74,25 +74,51 @@ func (c *clientImpl) callCallback(wiu *watcherInfoWithUpdate) {
 //
 // A response can contain multiple resources. They will be parsed and put in a
 // map from resource name to the resource content.
-func (c *clientImpl) NewListeners(updates map[string]ListenerUpdate) {
+func (c *clientImpl) NewListeners(updates map[string]ListenerUpdate, metadata UpdateMetadata) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
+	if metadata.ErrState != nil {
+		// On NACK, update overall version and status to the NACKed resp.
+		c.ldsVersion = metadata.ErrState.Version
+		c.ldsStatus = ServiceStatusNACKed
+		for name := range updates {
+			if _, ok := c.ldsWatchers[name]; ok {
+				// On error, keep previous version and status. Only update error.
+				updateCopy := c.ldsCache[name]
+				updateCopy.MD.ErrState = metadata.ErrState
+				c.ldsCache[name] = updateCopy
+				// TODO: send the NACK error to the watcher.
+			}
+		}
+		return
+	}
+
+	// If no error received, the status is ACK.
+	c.ldsVersion = metadata.Version
+	c.ldsStatus = ServiceStatusACKed
 	for name, update := range updates {
 		if s, ok := c.ldsWatchers[name]; ok {
+			// Only send the update if this is not an error.
 			for wi := range s {
 				wi.newUpdate(update)
 			}
 			// Sync cache.
 			c.logger.Debugf("LDS resource with name %v, value %+v added to cache", name, update)
-			c.ldsCache[name] = update
+			c.ldsCache[name] = LDSUpdateWithMD{
+				Update: update,
+				MD:     metadata,
+			}
 		}
 	}
+	// Resources not in the new update were removed by the server, so delete
+	// them.
 	for name := range c.ldsCache {
 		if _, ok := updates[name]; !ok {
 			// If resource exists in cache, but not in the new update, delete it
 			// from cache, and also send an resource not found error to indicate
 			// resource removed.
+			// FIXME: keep metadata in cache, but update state to REMOVED.
 			delete(c.ldsCache, name)
 			for wi := range c.ldsWatchers[name] {
 				wi.resourceNotFound()
@@ -109,18 +135,41 @@ func (c *clientImpl) NewListeners(updates map[string]ListenerUpdate) {
 //
 // A response can contain multiple resources. They will be parsed and put in a
 // map from resource name to the resource content.
-func (c *clientImpl) NewRouteConfigs(updates map[string]RouteConfigUpdate) {
+func (c *clientImpl) NewRouteConfigs(updates map[string]RouteConfigUpdate, metadata UpdateMetadata) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
+	if metadata.ErrState != nil {
+		// On NACK, update overall version and status to the NACKed resp.
+		c.rdsVersion = metadata.ErrState.Version
+		c.rdsStatus = ServiceStatusNACKed
+		for name := range updates {
+			if _, ok := c.rdsWatchers[name]; ok {
+				// On error, keep previous version and status. Only update error.
+				updateCopy := c.rdsCache[name]
+				updateCopy.MD.ErrState = metadata.ErrState
+				c.rdsCache[name] = updateCopy
+				// TODO: send the NACK error to the watcher.
+			}
+		}
+		return
+	}
+
+	// If no error received, the status is ACK.
+	c.rdsVersion = metadata.Version
+	c.rdsStatus = ServiceStatusACKed
 	for name, update := range updates {
 		if s, ok := c.rdsWatchers[name]; ok {
+			// Only send the update if this is not an error.
 			for wi := range s {
 				wi.newUpdate(update)
 			}
 			// Sync cache.
 			c.logger.Debugf("RDS resource with name %v, value %+v added to cache", name, update)
-			c.rdsCache[name] = update
+			c.rdsCache[name] = RDSUpdateWithMD{
+				Update: update,
+				MD:     metadata,
+			}
 		}
 	}
 }
@@ -130,25 +179,52 @@ func (c *clientImpl) NewRouteConfigs(updates map[string]RouteConfigUpdate) {
 //
 // A response can contain multiple resources. They will be parsed and put in a
 // map from resource name to the resource content.
-func (c *clientImpl) NewClusters(updates map[string]ClusterUpdate) {
+func (c *clientImpl) NewClusters(updates map[string]ClusterUpdate, metadata UpdateMetadata) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
+	if metadata.ErrState != nil {
+		// On NACK, update overall version and status to the NACKed resp.
+		c.cdsVersion = metadata.ErrState.Version
+		c.cdsStatus = ServiceStatusNACKed
+		for name := range updates {
+			if _, ok := c.cdsWatchers[name]; ok {
+				// On error, keep previous version and status. Only update error.
+				updateCopy := c.cdsCache[name]
+				updateCopy.MD.ErrState = metadata.ErrState
+				c.cdsCache[name] = updateCopy
+				// TODO: send the NACK error to the watcher.
+			}
+		}
+		return
+	}
+
+	// If no error received, the status is ACK.
+	c.cdsVersion = metadata.Version
+	c.cdsStatus = ServiceStatusACKed
 	for name, update := range updates {
 		if s, ok := c.cdsWatchers[name]; ok {
+			// Only send the update if this is not an error.
 			for wi := range s {
 				wi.newUpdate(update)
 			}
 			// Sync cache.
 			c.logger.Debugf("CDS resource with name %v, value %+v added to cache", name, update)
-			c.cdsCache[name] = update
+			c.cdsCache[name] = CDSUpdateWithMD{
+				Update: update,
+				MD:     metadata,
+			}
 		}
 	}
+	// Resources not in the new update were removed by the server, so delete
+	// them.
+	c.cdsStatus = ServiceStatusACKed
 	for name := range c.cdsCache {
 		if _, ok := updates[name]; !ok {
 			// If resource exists in cache, but not in the new update, delete it
 			// from cache, and also send an resource not found error to indicate
 			// resource removed.
+			// FIXME: keep metadata in cache, but update state to REMOVED.
 			delete(c.cdsCache, name)
 			for wi := range c.cdsWatchers[name] {
 				wi.resourceNotFound()
@@ -165,18 +241,41 @@ func (c *clientImpl) NewClusters(updates map[string]ClusterUpdate) {
 //
 // A response can contain multiple resources. They will be parsed and put in a
 // map from resource name to the resource content.
-func (c *clientImpl) NewEndpoints(updates map[string]EndpointsUpdate) {
+func (c *clientImpl) NewEndpoints(updates map[string]EndpointsUpdate, metadata UpdateMetadata) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
+	if metadata.ErrState != nil {
+		// On NACK, update overall version and status to the NACKed resp.
+		c.edsVersion = metadata.ErrState.Version
+		c.edsStatus = ServiceStatusNACKed
+		for name := range updates {
+			if _, ok := c.edsWatchers[name]; ok {
+				// On error, keep previous version and status. Only update error.
+				updateCopy := c.edsCache[name]
+				updateCopy.MD.ErrState = metadata.ErrState
+				c.edsCache[name] = updateCopy
+				// TODO: send the NACK error to the watcher.
+			}
+		}
+		return
+	}
+
+	// If no error received, the status is ACK.
+	c.edsVersion = metadata.Version
+	c.edsStatus = ServiceStatusACKed
 	for name, update := range updates {
 		if s, ok := c.edsWatchers[name]; ok {
+			// Only send the update if this is not an error.
 			for wi := range s {
 				wi.newUpdate(update)
 			}
 			// Sync cache.
 			c.logger.Debugf("EDS resource with name %v, value %+v added to cache", name, update)
-			c.edsCache[name] = update
+			c.edsCache[name] = EDSUpdateWithMD{
+				Update: update,
+				MD:     metadata,
+			}
 		}
 	}
 }

--- a/xds/internal/client/cds_test.go
+++ b/xds/internal/client/cds_test.go
@@ -571,6 +571,13 @@ func (s) TestUnmarshalCluster(t *testing.T) {
 				},
 			},
 		}
+		v2ClusterAny = &anypb.Any{
+			TypeUrl: version.V2ClusterURL,
+			Value: func() []byte {
+				mcl, _ := proto.Marshal(v2Cluster)
+				return mcl
+			}(),
+		}
 
 		v3Cluster = &v3clusterpb.Cluster{
 			Name:                 v3ClusterName,
@@ -590,12 +597,21 @@ func (s) TestUnmarshalCluster(t *testing.T) {
 				},
 			},
 		}
+		v3ClusterAny = &anypb.Any{
+			TypeUrl: version.V3ClusterURL,
+			Value: func() []byte {
+				mcl, _ := proto.Marshal(v3Cluster)
+				return mcl
+			}(),
+		}
 	)
+	const testVersion = "test-version-cds"
 
 	tests := []struct {
 		name       string
 		resources  []*anypb.Any
 		wantUpdate map[string]ClusterUpdate
+		wantMD     UpdateMetadata
 		wantErr    bool
 	}{
 		{
@@ -630,64 +646,65 @@ func (s) TestUnmarshalCluster(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "v2 cluster",
-			resources: []*anypb.Any{
-				{
-					TypeUrl: version.V3ClusterURL,
-					Value: func() []byte {
-						mcl, _ := proto.Marshal(v2Cluster)
-						return mcl
-					}(),
+			name:      "v2 cluster",
+			resources: []*anypb.Any{v2ClusterAny},
+			wantUpdate: map[string]ClusterUpdate{
+				v2ClusterName: {
+					ServiceName: v2Service, EnableLRS: true,
+					Raw: v2ClusterAny,
 				},
 			},
-			wantUpdate: map[string]ClusterUpdate{
-				v2ClusterName: {ServiceName: v2Service, EnableLRS: true},
+			wantMD: UpdateMetadata{
+				Version: testVersion,
 			},
 		},
 		{
-			name: "v3 cluster",
-			resources: []*anypb.Any{
-				{
-					TypeUrl: version.V3ClusterURL,
-					Value: func() []byte {
-						mcl, _ := proto.Marshal(v3Cluster)
-						return mcl
-					}(),
+			name:      "v3 cluster",
+			resources: []*anypb.Any{v3ClusterAny},
+			wantUpdate: map[string]ClusterUpdate{
+				v3ClusterName: {
+					ServiceName: v3Service, EnableLRS: true,
+					Raw: v3ClusterAny,
 				},
 			},
-			wantUpdate: map[string]ClusterUpdate{
-				v3ClusterName: {ServiceName: v3Service, EnableLRS: true},
+			wantMD: UpdateMetadata{
+				Version: testVersion,
 			},
 		},
 		{
-			name: "multiple clusters",
-			resources: []*anypb.Any{
-				{
-					TypeUrl: version.V3ClusterURL,
-					Value: func() []byte {
-						mcl, _ := proto.Marshal(v2Cluster)
-						return mcl
-					}(),
+			name:      "multiple clusters",
+			resources: []*anypb.Any{v2ClusterAny, v3ClusterAny},
+			wantUpdate: map[string]ClusterUpdate{
+				v2ClusterName: {
+					ServiceName: v2Service, EnableLRS: true,
+					Raw: v2ClusterAny,
 				},
-				{
-					TypeUrl: version.V3ClusterURL,
-					Value: func() []byte {
-						mcl, _ := proto.Marshal(v3Cluster)
-						return mcl
-					}(),
+				v3ClusterName: {
+					ServiceName: v3Service, EnableLRS: true,
+					Raw: v3ClusterAny,
 				},
 			},
-			wantUpdate: map[string]ClusterUpdate{
-				v2ClusterName: {ServiceName: v2Service, EnableLRS: true},
-				v3ClusterName: {ServiceName: v3Service, EnableLRS: true},
+			wantMD: UpdateMetadata{
+				Version: testVersion,
 			},
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			update, err := UnmarshalCluster(test.resources, nil)
-			if ((err != nil) != test.wantErr) || !cmp.Equal(update, test.wantUpdate, cmpopts.EquateEmpty()) {
-				t.Errorf("UnmarshalCluster(%v) = (%+v, %v) want (%+v, %v)", test.resources, update, err, test.wantUpdate, test.wantErr)
+			update, md, err := UnmarshalCluster(testVersion, test.resources, nil)
+			if (err != nil) != test.wantErr {
+				t.Errorf("UnmarshalCluster(%v) = got err: %v, wantErr: %v", test.resources, err, test.wantErr)
+			}
+			if test.wantErr {
+				return
+			}
+			if !cmp.Equal(update, test.wantUpdate, cmpOpts) {
+				t.Errorf("UnmarshalCluster(%v) = %v want %v", test.resources, update, test.wantUpdate)
+				t.Errorf(cmp.Diff(update, test.wantUpdate, cmpOpts))
+			}
+			if !cmp.Equal(md, test.wantMD, cmpOpts) {
+				t.Errorf("UnmarshalCluster(%v) = %v want %v", test.resources, md, test.wantMD)
+				t.Errorf(cmp.Diff(md, test.wantMD, cmpOpts))
 			}
 		})
 	}

--- a/xds/internal/client/client.go
+++ b/xds/internal/client/client.go
@@ -363,46 +363,6 @@ var newAPIClient = func(apiVersion version.TransportAPI, cc *grpc.ClientConn, op
 	return cb.Build(cc, opts)
 }
 
-// LDSUpdateWithMD contains the LDSUpdate and metadata, including version, raw
-// message, timestamp.
-//
-// This is to be used for config dump and CSDS, not directly by users (like
-// resolvers/balancers).
-type LDSUpdateWithMD struct {
-	Update ListenerUpdate
-	MD     UpdateMetadata
-}
-
-// RDSUpdateWithMD contains the RDSUpdate and metadata, including version, raw
-// message, timestamp.
-//
-// This is to be used for config dump and CSDS, not directly by users (like
-// resolvers/balancers).
-type RDSUpdateWithMD struct {
-	Update RouteConfigUpdate
-	MD     UpdateMetadata
-}
-
-// CDSUpdateWithMD contains the CDSUpdate and metadata, including version, raw
-// message, timestamp.
-//
-// This is to be used for config dump and CSDS, not directly by users (like
-// resolvers/balancers).
-type CDSUpdateWithMD struct {
-	Update ClusterUpdate
-	MD     UpdateMetadata
-}
-
-// EDSUpdateWithMD contains the EDSUpdate and metadata, including version, raw
-// message, timestamp.
-//
-// This is to be used for config dump and CSDS, not directly by users (like
-// resolvers/balancers).
-type EDSUpdateWithMD struct {
-	Update EndpointsUpdate
-	MD     UpdateMetadata
-}
-
 // clientImpl is the real implementation of the xds client. The exported Client
 // is a wrapper of this struct with a ref count.
 //

--- a/xds/internal/client/client_test.go
+++ b/xds/internal/client/client_test.go
@@ -26,16 +26,15 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"google.golang.org/grpc/internal/grpcsync"
-	"google.golang.org/protobuf/testing/protocmp"
-
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/internal/grpcsync"
 	"google.golang.org/grpc/internal/grpctest"
 	"google.golang.org/grpc/internal/testutils"
 	"google.golang.org/grpc/xds/internal/client/bootstrap"
 	xdstestutils "google.golang.org/grpc/xds/internal/testutils"
 	"google.golang.org/grpc/xds/internal/version"
+	"google.golang.org/protobuf/testing/protocmp"
 )
 
 type s struct {
@@ -62,13 +61,6 @@ const (
 var (
 	cmpOpts = cmp.Options{
 		cmpopts.EquateEmpty(),
-		cmp.Comparer(func(a, b time.Time) bool { return true }),
-		cmp.Comparer(func(x, y error) bool {
-			if x == nil || y == nil {
-				return x == nil && y == nil
-			}
-			return x.Error() == y.Error()
-		}),
 		protocmp.Transform(),
 	}
 

--- a/xds/internal/client/client_test.go
+++ b/xds/internal/client/client_test.go
@@ -59,17 +59,29 @@ const (
 	defaultTestShortTimeout       = 10 * time.Millisecond // For events expected to *not* happen.
 )
 
-var cmpOpts = cmp.Options{
-	cmpopts.EquateEmpty(),
-	cmp.Comparer(func(a, b time.Time) bool { return true }),
-	cmp.Comparer(func(x, y error) bool {
-		if x == nil || y == nil {
-			return x == nil && y == nil
-		}
-		return x.Error() == y.Error()
-	}),
-	protocmp.Transform(),
-}
+var (
+	cmpOpts = cmp.Options{
+		cmpopts.EquateEmpty(),
+		cmp.Comparer(func(a, b time.Time) bool { return true }),
+		cmp.Comparer(func(x, y error) bool {
+			if x == nil || y == nil {
+				return x == nil && y == nil
+			}
+			return x.Error() == y.Error()
+		}),
+		protocmp.Transform(),
+	}
+
+	// When comparing NACK UpdateMetadata, we only care if error is nil, but not
+	// the details in error.
+	errPlaceHolder            = fmt.Errorf("error whose details don't matter")
+	cmpOptsIgnoreErrorDetails = cmp.Options{
+		cmp.Comparer(func(a, b time.Time) bool { return true }),
+		cmp.Comparer(func(x, y error) bool {
+			return (x == nil) == (y == nil)
+		}),
+	}
+)
 
 func clientOpts(balancerName string, overrideWatchExpiryTimeout bool) (*bootstrap.Config, time.Duration) {
 	watchExpiryTimeout := defaultWatchExpiryTimeout

--- a/xds/internal/client/lds_test.go
+++ b/xds/internal/client/lds_test.go
@@ -116,7 +116,15 @@ func (s) TestUnmarshalListener_ClientSide(t *testing.T) {
 		{
 			name:      "non-listener resource",
 			resources: []*anypb.Any{{TypeUrl: version.V3HTTPConnManagerURL}},
-			wantErr:   true,
+			wantMD: UpdateMetadata{
+				Status:  ServiceStatusNACKed,
+				Version: testVersion,
+				ErrState: &UpdateErrorMetadata{
+					Version: testVersion,
+					Err:     errPlaceHolder,
+				},
+			},
+			wantErr: true,
 		},
 		{
 			name: "badly marshaled listener resource",
@@ -136,6 +144,15 @@ func (s) TestUnmarshalListener_ClientSide(t *testing.T) {
 						mLis, _ := proto.Marshal(lis)
 						return mLis
 					}(),
+				},
+			},
+			wantUpdate: map[string]ListenerUpdate{v3LDSTarget: {}},
+			wantMD: UpdateMetadata{
+				Status:  ServiceStatusNACKed,
+				Version: testVersion,
+				ErrState: &UpdateErrorMetadata{
+					Version: testVersion,
+					Err:     errPlaceHolder,
 				},
 			},
 			wantErr: true,
@@ -173,6 +190,15 @@ func (s) TestUnmarshalListener_ClientSide(t *testing.T) {
 					}(),
 				},
 			},
+			wantUpdate: map[string]ListenerUpdate{v3LDSTarget: {}},
+			wantMD: UpdateMetadata{
+				Status:  ServiceStatusNACKed,
+				Version: testVersion,
+				ErrState: &UpdateErrorMetadata{
+					Version: testVersion,
+					Err:     errPlaceHolder,
+				},
+			},
 			wantErr: true,
 		},
 		{
@@ -203,6 +229,15 @@ func (s) TestUnmarshalListener_ClientSide(t *testing.T) {
 					}(),
 				},
 			},
+			wantUpdate: map[string]ListenerUpdate{v3LDSTarget: {}},
+			wantMD: UpdateMetadata{
+				Status:  ServiceStatusNACKed,
+				Version: testVersion,
+				ErrState: &UpdateErrorMetadata{
+					Version: testVersion,
+					Err:     errPlaceHolder,
+				},
+			},
 			wantErr: true,
 		},
 		{
@@ -229,6 +264,15 @@ func (s) TestUnmarshalListener_ClientSide(t *testing.T) {
 						mLis, _ := proto.Marshal(lis)
 						return mLis
 					}(),
+				},
+			},
+			wantUpdate: map[string]ListenerUpdate{v3LDSTarget: {}},
+			wantMD: UpdateMetadata{
+				Status:  ServiceStatusNACKed,
+				Version: testVersion,
+				ErrState: &UpdateErrorMetadata{
+					Version: testVersion,
+					Err:     errPlaceHolder,
 				},
 			},
 			wantErr: true,
@@ -268,11 +312,21 @@ func (s) TestUnmarshalListener_ClientSide(t *testing.T) {
 					}(),
 				},
 			},
+			wantUpdate: map[string]ListenerUpdate{v3LDSTarget: {}},
+			wantMD: UpdateMetadata{
+				Status:  ServiceStatusNACKed,
+				Version: testVersion,
+				ErrState: &UpdateErrorMetadata{
+					Version: testVersion,
+					Err:     errPlaceHolder,
+				},
+			},
 			wantErr: true,
 		},
 		{
 			name: "empty resource list",
 			wantMD: UpdateMetadata{
+				Status:  ServiceStatusACKed,
 				Version: testVersion,
 			},
 		},
@@ -283,6 +337,7 @@ func (s) TestUnmarshalListener_ClientSide(t *testing.T) {
 				v2LDSTarget: {RouteConfigName: v2RouteConfigName, Raw: v2Lis},
 			},
 			wantMD: UpdateMetadata{
+				Status:  ServiceStatusACKed,
 				Version: testVersion,
 			},
 		},
@@ -293,6 +348,7 @@ func (s) TestUnmarshalListener_ClientSide(t *testing.T) {
 				v3LDSTarget: {RouteConfigName: v3RouteConfigName, MaxStreamDuration: time.Second, Raw: v3Lis},
 			},
 			wantMD: UpdateMetadata{
+				Status:  ServiceStatusACKed,
 				Version: testVersion,
 			},
 		},
@@ -304,6 +360,7 @@ func (s) TestUnmarshalListener_ClientSide(t *testing.T) {
 				v3LDSTarget: {RouteConfigName: v3RouteConfigName, MaxStreamDuration: time.Second, Raw: v3Lis},
 			},
 			wantMD: UpdateMetadata{
+				Status:  ServiceStatusACKed,
 				Version: testVersion,
 			},
 		},
@@ -315,16 +372,13 @@ func (s) TestUnmarshalListener_ClientSide(t *testing.T) {
 			if (err != nil) != test.wantErr {
 				t.Errorf("UnmarshalListener(%v) = got err: %v, wantErr: %v", test.resources, err, test.wantErr)
 			}
-			if test.wantErr {
-				return
-			}
-			if !cmp.Equal(update, test.wantUpdate, cmpOpts) {
+			if diff := cmp.Diff(update, test.wantUpdate, cmpOpts); diff != "" {
 				t.Errorf("UnmarshalListener(%v) = %v want %v", test.resources, update, test.wantUpdate)
-				t.Errorf(cmp.Diff(update, test.wantUpdate, cmpOpts))
+				t.Errorf(diff)
 			}
-			if !cmp.Equal(md, test.wantMD, cmpOpts) {
+			if diff := cmp.Diff(md, test.wantMD, cmpOptsIgnoreErrorDetails); diff != "" {
 				t.Errorf("UnmarshalListener(%v) = %v want %v", test.resources, md, test.wantMD)
-				t.Errorf(cmp.Diff(md, test.wantMD, cmpOpts))
+				t.Errorf(diff)
 			}
 		})
 	}
@@ -480,6 +534,15 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 					}(),
 				},
 			},
+			wantUpdate: map[string]ListenerUpdate{v3LDSTarget: {}},
+			wantMD: UpdateMetadata{
+				Status:  ServiceStatusNACKed,
+				Version: testVersion,
+				ErrState: &UpdateErrorMetadata{
+					Version: testVersion,
+					Err:     errPlaceHolder,
+				},
+			},
 			wantErr: "no address field in LDS response",
 		},
 		{
@@ -495,6 +558,15 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 						mLis, _ := proto.Marshal(lis)
 						return mLis
 					}(),
+				},
+			},
+			wantUpdate: map[string]ListenerUpdate{v3LDSTarget: {}},
+			wantMD: UpdateMetadata{
+				Status:  ServiceStatusNACKed,
+				Version: testVersion,
+				ErrState: &UpdateErrorMetadata{
+					Version: testVersion,
+					Err:     errPlaceHolder,
 				},
 			},
 			wantErr: "no socket_address field in LDS response",
@@ -523,6 +595,15 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 					}(),
 				},
 			},
+			wantUpdate: map[string]ListenerUpdate{"foo": {}},
+			wantMD: UpdateMetadata{
+				Status:  ServiceStatusNACKed,
+				Version: testVersion,
+				ErrState: &UpdateErrorMetadata{
+					Version: testVersion,
+					Err:     errPlaceHolder,
+				},
+			},
 			wantErr: "no host:port in name field of LDS response",
 		},
 		{
@@ -549,6 +630,15 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 					}(),
 				},
 			},
+			wantUpdate: map[string]ListenerUpdate{v3LDSTarget: {}},
+			wantMD: UpdateMetadata{
+				Status:  ServiceStatusNACKed,
+				Version: testVersion,
+				ErrState: &UpdateErrorMetadata{
+					Version: testVersion,
+					Err:     errPlaceHolder,
+				},
+			},
 			wantErr: "socket_address host does not match the one in name",
 		},
 		{
@@ -573,6 +663,15 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 						mLis, _ := proto.Marshal(lis)
 						return mLis
 					}(),
+				},
+			},
+			wantUpdate: map[string]ListenerUpdate{v3LDSTarget: {}},
+			wantMD: UpdateMetadata{
+				Status:  ServiceStatusNACKed,
+				Version: testVersion,
+				ErrState: &UpdateErrorMetadata{
+					Version: testVersion,
+					Err:     errPlaceHolder,
 				},
 			},
 			wantErr: "socket_address port does not match the one in name",
@@ -603,6 +702,15 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 						mLis, _ := proto.Marshal(lis)
 						return mLis
 					}(),
+				},
+			},
+			wantUpdate: map[string]ListenerUpdate{v3LDSTarget: {}},
+			wantMD: UpdateMetadata{
+				Status:  ServiceStatusNACKed,
+				Version: testVersion,
+				ErrState: &UpdateErrorMetadata{
+					Version: testVersion,
+					Err:     errPlaceHolder,
 				},
 			},
 			wantErr: "filter chains count in LDS response does not match expected",
@@ -637,6 +745,15 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 						mLis, _ := proto.Marshal(lis)
 						return mLis
 					}(),
+				},
+			},
+			wantUpdate: map[string]ListenerUpdate{v3LDSTarget: {}},
+			wantMD: UpdateMetadata{
+				Status:  ServiceStatusNACKed,
+				Version: testVersion,
+				ErrState: &UpdateErrorMetadata{
+					Version: testVersion,
+					Err:     errPlaceHolder,
 				},
 			},
 			wantErr: "transport_socket field has unexpected name",
@@ -678,6 +795,15 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 					}(),
 				},
 			},
+			wantUpdate: map[string]ListenerUpdate{v3LDSTarget: {}},
+			wantMD: UpdateMetadata{
+				Status:  ServiceStatusNACKed,
+				Version: testVersion,
+				ErrState: &UpdateErrorMetadata{
+					Version: testVersion,
+					Err:     errPlaceHolder,
+				},
+			},
 			wantErr: "transport_socket field has unexpected typeURL",
 		},
 		{
@@ -716,6 +842,15 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 						mLis, _ := proto.Marshal(lis)
 						return mLis
 					}(),
+				},
+			},
+			wantUpdate: map[string]ListenerUpdate{v3LDSTarget: {}},
+			wantMD: UpdateMetadata{
+				Status:  ServiceStatusNACKed,
+				Version: testVersion,
+				ErrState: &UpdateErrorMetadata{
+					Version: testVersion,
+					Err:     errPlaceHolder,
 				},
 			},
 			wantErr: "failed to unmarshal DownstreamTlsContext in LDS response",
@@ -760,6 +895,15 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 						mLis, _ := proto.Marshal(lis)
 						return mLis
 					}(),
+				},
+			},
+			wantUpdate: map[string]ListenerUpdate{v3LDSTarget: {}},
+			wantMD: UpdateMetadata{
+				Status:  ServiceStatusNACKed,
+				Version: testVersion,
+				ErrState: &UpdateErrorMetadata{
+					Version: testVersion,
+					Err:     errPlaceHolder,
 				},
 			},
 			wantErr: "DownstreamTlsContext in LDS response does not contain a CommonTlsContext",
@@ -814,6 +958,15 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 					}(),
 				},
 			},
+			wantUpdate: map[string]ListenerUpdate{v3LDSTarget: {}},
+			wantMD: UpdateMetadata{
+				Status:  ServiceStatusNACKed,
+				Version: testVersion,
+				ErrState: &UpdateErrorMetadata{
+					Version: testVersion,
+					Err:     errPlaceHolder,
+				},
+			},
 			wantErr: "validation context contains unexpected type",
 		},
 		{
@@ -823,6 +976,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 				v3LDSTarget: {Raw: listenerEmptyTransportSocket},
 			},
 			wantMD: UpdateMetadata{
+				Status:  ServiceStatusACKed,
 				Version: testVersion,
 			},
 		},
@@ -876,6 +1030,15 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 					}(),
 				},
 			},
+			wantUpdate: map[string]ListenerUpdate{v3LDSTarget: {}},
+			wantMD: UpdateMetadata{
+				Status:  ServiceStatusNACKed,
+				Version: testVersion,
+				ErrState: &UpdateErrorMetadata{
+					Version: testVersion,
+					Err:     errPlaceHolder,
+				},
+			},
 			wantErr: "security configuration on the server-side does not contain root certificate provider instance name, but require_client_cert field is set",
 		},
 		{
@@ -922,6 +1085,15 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 					}(),
 				},
 			},
+			wantUpdate: map[string]ListenerUpdate{v3LDSTarget: {}},
+			wantMD: UpdateMetadata{
+				Status:  ServiceStatusNACKed,
+				Version: testVersion,
+				ErrState: &UpdateErrorMetadata{
+					Version: testVersion,
+					Err:     errPlaceHolder,
+				},
+			},
 			wantErr: "security configuration on the server-side does not contain identity certificate provider instance name",
 		},
 		{
@@ -937,6 +1109,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 				},
 			},
 			wantMD: UpdateMetadata{
+				Status:  ServiceStatusACKed,
 				Version: testVersion,
 			},
 		},
@@ -956,6 +1129,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 				},
 			},
 			wantMD: UpdateMetadata{
+				Status:  ServiceStatusACKed,
 				Version: testVersion,
 			},
 		},
@@ -970,16 +1144,13 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 			if err != nil && !strings.Contains(err.Error(), test.wantErr) {
 				t.Fatalf("UnmarshalListener(%v) = %v wantErr: %q", test.resources, err, test.wantErr)
 			}
-			if test.wantErr != "" {
-				return
-			}
-			if !cmp.Equal(gotUpdate, test.wantUpdate, cmpOpts) {
+			if diff := cmp.Diff(gotUpdate, test.wantUpdate, cmpOpts); diff != "" {
 				t.Errorf("UnmarshalListener(%v) = %v want %v", test.resources, gotUpdate, test.wantUpdate)
-				t.Errorf(cmp.Diff(gotUpdate, test.wantUpdate, cmpOpts))
+				t.Errorf(diff)
 			}
-			if !cmp.Equal(md, test.wantMD, cmpOpts) {
+			if diff := cmp.Diff(md, test.wantMD, cmpOptsIgnoreErrorDetails); diff != "" {
 				t.Errorf("UnmarshalListener(%v) = %v want %v", test.resources, md, test.wantMD)
-				t.Errorf(cmp.Diff(md, test.wantMD, cmpOpts))
+				t.Errorf(diff)
 			}
 		})
 	}

--- a/xds/internal/client/rds_test.go
+++ b/xds/internal/client/rds_test.go
@@ -497,7 +497,15 @@ func (s) TestUnmarshalRouteConfig(t *testing.T) {
 		{
 			name:      "non-routeConfig resource type",
 			resources: []*anypb.Any{{TypeUrl: version.V3HTTPConnManagerURL}},
-			wantErr:   true,
+			wantMD: UpdateMetadata{
+				Status:  ServiceStatusNACKed,
+				Version: testVersion,
+				ErrState: &UpdateErrorMetadata{
+					Version: testVersion,
+					Err:     errPlaceHolder,
+				},
+			},
+			wantErr: true,
 		},
 		{
 			name: "badly marshaled routeconfig resource",
@@ -507,11 +515,20 @@ func (s) TestUnmarshalRouteConfig(t *testing.T) {
 					Value:   []byte{1, 2, 3, 4},
 				},
 			},
+			wantMD: UpdateMetadata{
+				Status:  ServiceStatusNACKed,
+				Version: testVersion,
+				ErrState: &UpdateErrorMetadata{
+					Version: testVersion,
+					Err:     errPlaceHolder,
+				},
+			},
 			wantErr: true,
 		},
 		{
 			name: "empty resource list",
 			wantMD: UpdateMetadata{
+				Status:  ServiceStatusACKed,
 				Version: testVersion,
 			},
 		},
@@ -534,6 +551,7 @@ func (s) TestUnmarshalRouteConfig(t *testing.T) {
 				},
 			},
 			wantMD: UpdateMetadata{
+				Status:  ServiceStatusACKed,
 				Version: testVersion,
 			},
 		},
@@ -556,6 +574,7 @@ func (s) TestUnmarshalRouteConfig(t *testing.T) {
 				},
 			},
 			wantMD: UpdateMetadata{
+				Status:  ServiceStatusACKed,
 				Version: testVersion,
 			},
 		},
@@ -591,6 +610,7 @@ func (s) TestUnmarshalRouteConfig(t *testing.T) {
 				},
 			},
 			wantMD: UpdateMetadata{
+				Status:  ServiceStatusACKed,
 				Version: testVersion,
 			},
 		},
@@ -601,16 +621,13 @@ func (s) TestUnmarshalRouteConfig(t *testing.T) {
 			if (err != nil) != test.wantErr {
 				t.Errorf("UnmarshalRouteConfig(%v) = got err: %v, wantErr: %v", test.resources, err, test.wantErr)
 			}
-			if test.wantErr {
-				return
-			}
-			if !cmp.Equal(update, test.wantUpdate, cmpOpts) {
+			if diff := cmp.Diff(update, test.wantUpdate, cmpOpts); diff != "" {
 				t.Errorf("UnmarshalRouteConfig(%v) = %v want %v", test.resources, update, test.wantUpdate)
-				t.Errorf(cmp.Diff(update, test.wantUpdate, cmpOpts))
+				t.Errorf(diff)
 			}
-			if !cmp.Equal(md, test.wantMD, cmpOpts) {
+			if diff := cmp.Diff(md, test.wantMD, cmpOptsIgnoreErrorDetails); diff != "" {
 				t.Errorf("UnmarshalRouteConfig(%v) = %v want %v", test.resources, md, test.wantMD)
-				t.Errorf(cmp.Diff(md, test.wantMD, cmpOpts))
+				t.Errorf(diff)
 			}
 		})
 	}

--- a/xds/internal/client/v2/ack_test.go
+++ b/xds/internal/client/v2/ack_test.go
@@ -47,7 +47,7 @@ func startXDSV2Client(t *testing.T, cc *grpc.ClientConn) (v2c *client, cbLDS, cb
 	cbCDS = testutils.NewChannel()
 	cbEDS = testutils.NewChannel()
 	v2c, err := newV2Client(&testUpdateReceiver{
-		f: func(rType xdsclient.ResourceType, d map[string]interface{}) {
+		f: func(rType xdsclient.ResourceType, d map[string]interface{}, md xdsclient.UpdateMetadata) {
 			t.Logf("Received %v callback with {%+v}", rType, d)
 			switch rType {
 			case xdsclient.ListenerResource:

--- a/xds/internal/client/v2/cds_test.go
+++ b/xds/internal/client/v2/cds_test.go
@@ -111,6 +111,7 @@ func (s) TestCDSHandleResponse(t *testing.T) {
 			wantErr:     true,
 			wantUpdate:  nil,
 			wantUpdateMD: xdsclient.UpdateMetadata{
+				Status: xdsclient.ServiceStatusNACKed,
 				ErrState: &xdsclient.UpdateErrorMetadata{
 					Err: errPlaceHolder,
 				},
@@ -124,6 +125,7 @@ func (s) TestCDSHandleResponse(t *testing.T) {
 			wantErr:     true,
 			wantUpdate:  nil,
 			wantUpdateMD: xdsclient.UpdateMetadata{
+				Status: xdsclient.ServiceStatusNACKed,
 				ErrState: &xdsclient.UpdateErrorMetadata{
 					Err: errPlaceHolder,
 				},
@@ -137,6 +139,7 @@ func (s) TestCDSHandleResponse(t *testing.T) {
 			wantErr:     false,
 			wantUpdate:  nil,
 			wantUpdateMD: xdsclient.UpdateMetadata{
+				Status:   xdsclient.ServiceStatusACKed,
 				ErrState: nil,
 			},
 			wantUpdateErr: false,
@@ -150,6 +153,7 @@ func (s) TestCDSHandleResponse(t *testing.T) {
 				goodClusterName2: {ServiceName: serviceName2, Raw: marshaledCluster2},
 			},
 			wantUpdateMD: xdsclient.UpdateMetadata{
+				Status:   xdsclient.ServiceStatusACKed,
 				ErrState: nil,
 			},
 			wantUpdateErr: false,
@@ -163,6 +167,7 @@ func (s) TestCDSHandleResponse(t *testing.T) {
 				goodClusterName1: {ServiceName: serviceName1, EnableLRS: true, Raw: marshaledCluster1},
 			},
 			wantUpdateMD: xdsclient.UpdateMetadata{
+				Status:   xdsclient.ServiceStatusACKed,
 				ErrState: nil,
 			},
 			wantUpdateErr: false,

--- a/xds/internal/client/v2/cds_test.go
+++ b/xds/internal/client/v2/cds_test.go
@@ -24,7 +24,7 @@ import (
 
 	xdspb "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	corepb "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
-	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/ptypes"
 	anypb "github.com/golang/protobuf/ptypes/any"
 	xdsclient "google.golang.org/grpc/xds/internal/client"
 	"google.golang.org/grpc/xds/internal/version"
@@ -63,7 +63,7 @@ var (
 			},
 		},
 	}
-	marshaledCluster1, _ = proto.Marshal(goodCluster1)
+	marshaledCluster1, _ = ptypes.MarshalAny(goodCluster1)
 	goodCluster2         = &xdspb.Cluster{
 		Name:                 goodClusterName2,
 		ClusterDiscoveryType: &xdspb.Cluster_Type{Type: xdspb.Cluster_EDS},
@@ -77,22 +77,16 @@ var (
 		},
 		LbPolicy: xdspb.Cluster_ROUND_ROBIN,
 	}
-	marshaledCluster2, _ = proto.Marshal(goodCluster2)
+	marshaledCluster2, _ = ptypes.MarshalAny(goodCluster2)
 	goodCDSResponse1     = &xdspb.DiscoveryResponse{
 		Resources: []*anypb.Any{
-			{
-				TypeUrl: version.V2ClusterURL,
-				Value:   marshaledCluster1,
-			},
+			marshaledCluster1,
 		},
 		TypeUrl: version.V2ClusterURL,
 	}
 	goodCDSResponse2 = &xdspb.DiscoveryResponse{
 		Resources: []*anypb.Any{
-			{
-				TypeUrl: version.V2ClusterURL,
-				Value:   marshaledCluster2,
-			},
+			marshaledCluster2,
 		},
 		TypeUrl: version.V2ClusterURL,
 	}
@@ -106,47 +100,71 @@ func (s) TestCDSHandleResponse(t *testing.T) {
 		name          string
 		cdsResponse   *xdspb.DiscoveryResponse
 		wantErr       bool
-		wantUpdate    *xdsclient.ClusterUpdate
+		wantUpdate    map[string]xdsclient.ClusterUpdate
+		wantUpdateMD  xdsclient.UpdateMetadata
 		wantUpdateErr bool
 	}{
 		// Badly marshaled CDS response.
 		{
-			name:          "badly-marshaled-response",
-			cdsResponse:   badlyMarshaledCDSResponse,
-			wantErr:       true,
-			wantUpdate:    nil,
+			name:        "badly-marshaled-response",
+			cdsResponse: badlyMarshaledCDSResponse,
+			wantErr:     true,
+			wantUpdate:  nil,
+			wantUpdateMD: xdsclient.UpdateMetadata{
+				ErrState: &xdsclient.UpdateErrorMetadata{
+					Err: errPlaceHolder,
+				},
+			},
 			wantUpdateErr: false,
 		},
 		// Response does not contain Cluster proto.
 		{
-			name:          "no-cluster-proto-in-response",
-			cdsResponse:   badResourceTypeInLDSResponse,
-			wantErr:       true,
-			wantUpdate:    nil,
+			name:        "no-cluster-proto-in-response",
+			cdsResponse: badResourceTypeInLDSResponse,
+			wantErr:     true,
+			wantUpdate:  nil,
+			wantUpdateMD: xdsclient.UpdateMetadata{
+				ErrState: &xdsclient.UpdateErrorMetadata{
+					Err: errPlaceHolder,
+				},
+			},
 			wantUpdateErr: false,
 		},
 		// Response contains no clusters.
 		{
-			name:          "no-cluster",
-			cdsResponse:   &xdspb.DiscoveryResponse{},
-			wantErr:       false,
-			wantUpdate:    nil,
+			name:        "no-cluster",
+			cdsResponse: &xdspb.DiscoveryResponse{},
+			wantErr:     false,
+			wantUpdate:  nil,
+			wantUpdateMD: xdsclient.UpdateMetadata{
+				ErrState: nil,
+			},
 			wantUpdateErr: false,
 		},
 		// Response contains one good cluster we are not interested in.
 		{
-			name:          "one-uninteresting-cluster",
-			cdsResponse:   goodCDSResponse2,
-			wantErr:       false,
-			wantUpdate:    nil,
+			name:        "one-uninteresting-cluster",
+			cdsResponse: goodCDSResponse2,
+			wantErr:     false,
+			wantUpdate: map[string]xdsclient.ClusterUpdate{
+				goodClusterName2: {ServiceName: serviceName2, Raw: marshaledCluster2},
+			},
+			wantUpdateMD: xdsclient.UpdateMetadata{
+				ErrState: nil,
+			},
 			wantUpdateErr: false,
 		},
 		// Response contains one cluster and it is good.
 		{
-			name:          "one-good-cluster",
-			cdsResponse:   goodCDSResponse1,
-			wantErr:       false,
-			wantUpdate:    &xdsclient.ClusterUpdate{ServiceName: serviceName1, EnableLRS: true},
+			name:        "one-good-cluster",
+			cdsResponse: goodCDSResponse1,
+			wantErr:     false,
+			wantUpdate: map[string]xdsclient.ClusterUpdate{
+				goodClusterName1: {ServiceName: serviceName1, EnableLRS: true, Raw: marshaledCluster1},
+			},
+			wantUpdateMD: xdsclient.UpdateMetadata{
+				ErrState: nil,
+			},
 			wantUpdateErr: false,
 		},
 	}
@@ -159,6 +177,7 @@ func (s) TestCDSHandleResponse(t *testing.T) {
 				responseToHandle: test.cdsResponse,
 				wantHandleErr:    test.wantErr,
 				wantUpdate:       test.wantUpdate,
+				wantUpdateMD:     test.wantUpdateMD,
 				wantUpdateErr:    test.wantUpdateErr,
 			})
 		})
@@ -172,7 +191,7 @@ func (s) TestCDSHandleResponseWithoutWatch(t *testing.T) {
 	defer cleanup()
 
 	v2c, err := newV2Client(&testUpdateReceiver{
-		f: func(xdsclient.ResourceType, map[string]interface{}) {},
+		f: func(xdsclient.ResourceType, map[string]interface{}, xdsclient.UpdateMetadata) {},
 	}, cc, goodNodeProto, func(int) time.Duration { return 0 }, nil)
 	if err != nil {
 		t.Fatal(err)

--- a/xds/internal/client/v2/client.go
+++ b/xds/internal/client/v2/client.go
@@ -185,43 +185,31 @@ func (v2c *client) HandleResponse(r proto.Message) (xdsclient.ResourceType, stri
 // server. On receipt of a good response, it also invokes the registered watcher
 // callback.
 func (v2c *client) handleLDSResponse(resp *v2xdspb.DiscoveryResponse) error {
-	update, err := xdsclient.UnmarshalListener(resp.GetResources(), v2c.logger)
-	if err != nil {
-		return err
-	}
-	v2c.parent.NewListeners(update)
-	return nil
+	update, md, err := xdsclient.UnmarshalListener(resp.GetVersionInfo(), resp.GetResources(), v2c.logger)
+	v2c.parent.NewListeners(update, md)
+	return err
 }
 
 // handleRDSResponse processes an RDS response received from the management
 // server. On receipt of a good response, it caches validated resources and also
 // invokes the registered watcher callback.
 func (v2c *client) handleRDSResponse(resp *v2xdspb.DiscoveryResponse) error {
-	update, err := xdsclient.UnmarshalRouteConfig(resp.GetResources(), v2c.logger)
-	if err != nil {
-		return err
-	}
-	v2c.parent.NewRouteConfigs(update)
-	return nil
+	update, md, err := xdsclient.UnmarshalRouteConfig(resp.GetVersionInfo(), resp.GetResources(), v2c.logger)
+	v2c.parent.NewRouteConfigs(update, md)
+	return err
 }
 
 // handleCDSResponse processes an CDS response received from the management
 // server. On receipt of a good response, it also invokes the registered watcher
 // callback.
 func (v2c *client) handleCDSResponse(resp *v2xdspb.DiscoveryResponse) error {
-	update, err := xdsclient.UnmarshalCluster(resp.GetResources(), v2c.logger)
-	if err != nil {
-		return err
-	}
-	v2c.parent.NewClusters(update)
-	return nil
+	update, md, err := xdsclient.UnmarshalCluster(resp.GetVersionInfo(), resp.GetResources(), v2c.logger)
+	v2c.parent.NewClusters(update, md)
+	return err
 }
 
 func (v2c *client) handleEDSResponse(resp *v2xdspb.DiscoveryResponse) error {
-	update, err := xdsclient.UnmarshalEndpoints(resp.GetResources(), v2c.logger)
-	if err != nil {
-		return err
-	}
-	v2c.parent.NewEndpoints(update)
-	return nil
+	update, md, err := xdsclient.UnmarshalEndpoints(resp.GetVersionInfo(), resp.GetResources(), v2c.logger)
+	v2c.parent.NewEndpoints(update, md)
+	return err
 }

--- a/xds/internal/client/v2/client_test.go
+++ b/xds/internal/client/v2/client_test.go
@@ -455,7 +455,8 @@ func testWatchHandle(t *testing.T, test *watchHandleTestcase) {
 	wantUpdate := test.wantUpdate
 	cmpOpts := cmp.Options{
 		cmpopts.EquateEmpty(), protocmp.Transform(),
-		cmp.Comparer(func(a, b time.Time) bool { return true }),
+		cmpopts.IgnoreFields(xdsclient.UpdateMetadata{}, "Timestamp"),
+		cmpopts.IgnoreFields(xdsclient.UpdateErrorMetadata{}, "Timestamp"),
 		cmp.Comparer(func(x, y error) bool { return (x == nil) == (y == nil) }),
 	}
 	uErr, err := gotUpdateCh.Receive(ctx)

--- a/xds/internal/client/v2/eds_test.go
+++ b/xds/internal/client/v2/eds_test.go
@@ -93,6 +93,7 @@ func (s) TestEDSHandleResponse(t *testing.T) {
 			wantErr:     true,
 			wantUpdate:  nil,
 			wantUpdateMD: xdsclient.UpdateMetadata{
+				Status: xdsclient.ServiceStatusNACKed,
 				ErrState: &xdsclient.UpdateErrorMetadata{
 					Err: errPlaceHolder,
 				},
@@ -106,6 +107,7 @@ func (s) TestEDSHandleResponse(t *testing.T) {
 			wantErr:     true,
 			wantUpdate:  nil,
 			wantUpdateMD: xdsclient.UpdateMetadata{
+				Status: xdsclient.ServiceStatusNACKed,
 				ErrState: &xdsclient.UpdateErrorMetadata{
 					Err: errPlaceHolder,
 				},
@@ -131,6 +133,7 @@ func (s) TestEDSHandleResponse(t *testing.T) {
 				},
 			},
 			wantUpdateMD: xdsclient.UpdateMetadata{
+				Status:   xdsclient.ServiceStatusACKed,
 				ErrState: nil,
 			},
 			wantUpdateErr: false,
@@ -160,6 +163,7 @@ func (s) TestEDSHandleResponse(t *testing.T) {
 				},
 			},
 			wantUpdateMD: xdsclient.UpdateMetadata{
+				Status:   xdsclient.ServiceStatusACKed,
 				ErrState: nil,
 			},
 			wantUpdateErr: false,

--- a/xds/internal/client/v2/eds_test.go
+++ b/xds/internal/client/v2/eds_test.go
@@ -50,27 +50,28 @@ var (
 		},
 		TypeUrl: version.V2EndpointsURL,
 	}
+	marshaledGoodCLA1 = func() *anypb.Any {
+		clab0 := testutils.NewClusterLoadAssignmentBuilder(goodEDSName, nil)
+		clab0.AddLocality("locality-1", 1, 1, []string{"addr1:314"}, nil)
+		clab0.AddLocality("locality-2", 1, 0, []string{"addr2:159"}, nil)
+		a, _ := ptypes.MarshalAny(clab0.Build())
+		return a
+	}()
 	goodEDSResponse1 = &v2xdspb.DiscoveryResponse{
 		Resources: []*anypb.Any{
-			func() *anypb.Any {
-				clab0 := testutils.NewClusterLoadAssignmentBuilder(goodEDSName, nil)
-				clab0.AddLocality("locality-1", 1, 1, []string{"addr1:314"}, nil)
-				clab0.AddLocality("locality-2", 1, 0, []string{"addr2:159"}, nil)
-				a, _ := ptypes.MarshalAny(clab0.Build())
-				return a
-			}(),
+			marshaledGoodCLA1,
 		},
 		TypeUrl: version.V2EndpointsURL,
 	}
+	marshaledGoodCLA2 = func() *anypb.Any {
+		clab0 := testutils.NewClusterLoadAssignmentBuilder("not-goodEDSName", nil)
+		clab0.AddLocality("locality-1", 1, 0, []string{"addr1:314"}, nil)
+		a, _ := ptypes.MarshalAny(clab0.Build())
+		return a
+	}()
 	goodEDSResponse2 = &v2xdspb.DiscoveryResponse{
 		Resources: []*anypb.Any{
-			func() *anypb.Any {
-				clab0 := testutils.NewClusterLoadAssignmentBuilder("not-goodEDSName", nil)
-				clab0.AddLocality("locality-1", 1, 1, []string{"addr1:314"}, nil)
-				clab0.AddLocality("locality-2", 1, 0, []string{"addr2:159"}, nil)
-				a, _ := ptypes.MarshalAny(clab0.Build())
-				return a
-			}(),
+			marshaledGoodCLA2,
 		},
 		TypeUrl: version.V2EndpointsURL,
 	}
@@ -81,31 +82,57 @@ func (s) TestEDSHandleResponse(t *testing.T) {
 		name          string
 		edsResponse   *v2xdspb.DiscoveryResponse
 		wantErr       bool
-		wantUpdate    *xdsclient.EndpointsUpdate
+		wantUpdate    map[string]xdsclient.EndpointsUpdate
+		wantUpdateMD  xdsclient.UpdateMetadata
 		wantUpdateErr bool
 	}{
 		// Any in resource is badly marshaled.
 		{
-			name:          "badly-marshaled_response",
-			edsResponse:   badlyMarshaledEDSResponse,
-			wantErr:       true,
-			wantUpdate:    nil,
+			name:        "badly-marshaled_response",
+			edsResponse: badlyMarshaledEDSResponse,
+			wantErr:     true,
+			wantUpdate:  nil,
+			wantUpdateMD: xdsclient.UpdateMetadata{
+				ErrState: &xdsclient.UpdateErrorMetadata{
+					Err: errPlaceHolder,
+				},
+			},
 			wantUpdateErr: false,
 		},
 		// Response doesn't contain resource with the right type.
 		{
-			name:          "no-config-in-response",
-			edsResponse:   badResourceTypeInEDSResponse,
-			wantErr:       true,
-			wantUpdate:    nil,
+			name:        "no-config-in-response",
+			edsResponse: badResourceTypeInEDSResponse,
+			wantErr:     true,
+			wantUpdate:  nil,
+			wantUpdateMD: xdsclient.UpdateMetadata{
+				ErrState: &xdsclient.UpdateErrorMetadata{
+					Err: errPlaceHolder,
+				},
+			},
 			wantUpdateErr: false,
 		},
 		// Response contains one uninteresting ClusterLoadAssignment.
 		{
-			name:          "one-uninterestring-assignment",
-			edsResponse:   goodEDSResponse2,
-			wantErr:       false,
-			wantUpdate:    nil,
+			name:        "one-uninterestring-assignment",
+			edsResponse: goodEDSResponse2,
+			wantErr:     false,
+			wantUpdate: map[string]xdsclient.EndpointsUpdate{
+				"not-goodEDSName": {
+					Localities: []xdsclient.Locality{
+						{
+							Endpoints: []xdsclient.Endpoint{{Address: "addr1:314"}},
+							ID:        internal.LocalityID{SubZone: "locality-1"},
+							Priority:  0,
+							Weight:    1,
+						},
+					},
+					Raw: marshaledGoodCLA2,
+				},
+			},
+			wantUpdateMD: xdsclient.UpdateMetadata{
+				ErrState: nil,
+			},
 			wantUpdateErr: false,
 		},
 		// Response contains one good ClusterLoadAssignment.
@@ -113,21 +140,27 @@ func (s) TestEDSHandleResponse(t *testing.T) {
 			name:        "one-good-assignment",
 			edsResponse: goodEDSResponse1,
 			wantErr:     false,
-			wantUpdate: &xdsclient.EndpointsUpdate{
-				Localities: []xdsclient.Locality{
-					{
-						Endpoints: []xdsclient.Endpoint{{Address: "addr1:314"}},
-						ID:        internal.LocalityID{SubZone: "locality-1"},
-						Priority:  1,
-						Weight:    1,
+			wantUpdate: map[string]xdsclient.EndpointsUpdate{
+				goodEDSName: {
+					Localities: []xdsclient.Locality{
+						{
+							Endpoints: []xdsclient.Endpoint{{Address: "addr1:314"}},
+							ID:        internal.LocalityID{SubZone: "locality-1"},
+							Priority:  1,
+							Weight:    1,
+						},
+						{
+							Endpoints: []xdsclient.Endpoint{{Address: "addr2:159"}},
+							ID:        internal.LocalityID{SubZone: "locality-2"},
+							Priority:  0,
+							Weight:    1,
+						},
 					},
-					{
-						Endpoints: []xdsclient.Endpoint{{Address: "addr2:159"}},
-						ID:        internal.LocalityID{SubZone: "locality-2"},
-						Priority:  0,
-						Weight:    1,
-					},
+					Raw: marshaledGoodCLA1,
 				},
+			},
+			wantUpdateMD: xdsclient.UpdateMetadata{
+				ErrState: nil,
 			},
 			wantUpdateErr: false,
 		},
@@ -140,6 +173,7 @@ func (s) TestEDSHandleResponse(t *testing.T) {
 				responseToHandle: test.edsResponse,
 				wantHandleErr:    test.wantErr,
 				wantUpdate:       test.wantUpdate,
+				wantUpdateMD:     test.wantUpdateMD,
 				wantUpdateErr:    test.wantUpdateErr,
 			})
 		})
@@ -153,7 +187,7 @@ func (s) TestEDSHandleResponseWithoutWatch(t *testing.T) {
 	defer cleanup()
 
 	v2c, err := newV2Client(&testUpdateReceiver{
-		f: func(xdsclient.ResourceType, map[string]interface{}) {},
+		f: func(xdsclient.ResourceType, map[string]interface{}, xdsclient.UpdateMetadata) {},
 	}, cc, goodNodeProto, func(int) time.Duration { return 0 }, nil)
 	if err != nil {
 		t.Fatal(err)

--- a/xds/internal/client/v2/lds_test.go
+++ b/xds/internal/client/v2/lds_test.go
@@ -35,77 +35,122 @@ func (s) TestLDSHandleResponse(t *testing.T) {
 		name          string
 		ldsResponse   *v2xdspb.DiscoveryResponse
 		wantErr       bool
-		wantUpdate    *xdsclient.ListenerUpdate
+		wantUpdate    map[string]xdsclient.ListenerUpdate
+		wantUpdateMD  xdsclient.UpdateMetadata
 		wantUpdateErr bool
 	}{
 		// Badly marshaled LDS response.
 		{
-			name:          "badly-marshaled-response",
-			ldsResponse:   badlyMarshaledLDSResponse,
-			wantErr:       true,
-			wantUpdate:    nil,
+			name:        "badly-marshaled-response",
+			ldsResponse: badlyMarshaledLDSResponse,
+			wantErr:     true,
+			wantUpdate:  nil,
+			wantUpdateMD: xdsclient.UpdateMetadata{
+				ErrState: &xdsclient.UpdateErrorMetadata{
+					Err: errPlaceHolder,
+				},
+			},
 			wantUpdateErr: false,
 		},
 		// Response does not contain Listener proto.
 		{
-			name:          "no-listener-proto-in-response",
-			ldsResponse:   badResourceTypeInLDSResponse,
-			wantErr:       true,
-			wantUpdate:    nil,
+			name:        "no-listener-proto-in-response",
+			ldsResponse: badResourceTypeInLDSResponse,
+			wantErr:     true,
+			wantUpdate:  nil,
+			wantUpdateMD: xdsclient.UpdateMetadata{
+				ErrState: &xdsclient.UpdateErrorMetadata{
+					Err: errPlaceHolder,
+				},
+			},
 			wantUpdateErr: false,
 		},
 		// No APIListener in the response. Just one test case here for a bad
 		// ApiListener, since the others are covered in
 		// TestGetRouteConfigNameFromListener.
 		{
-			name:          "no-apiListener-in-response",
-			ldsResponse:   noAPIListenerLDSResponse,
-			wantErr:       true,
-			wantUpdate:    nil,
+			name:        "no-apiListener-in-response",
+			ldsResponse: noAPIListenerLDSResponse,
+			wantErr:     true,
+			wantUpdate: map[string]xdsclient.ListenerUpdate{
+				goodLDSTarget1: {},
+			},
+			wantUpdateMD: xdsclient.UpdateMetadata{
+				ErrState: &xdsclient.UpdateErrorMetadata{
+					Err: errPlaceHolder,
+				},
+			},
 			wantUpdateErr: false,
 		},
 		// Response contains one listener and it is good.
 		{
-			name:          "one-good-listener",
-			ldsResponse:   goodLDSResponse1,
-			wantErr:       false,
-			wantUpdate:    &xdsclient.ListenerUpdate{RouteConfigName: goodRouteName1},
+			name:        "one-good-listener",
+			ldsResponse: goodLDSResponse1,
+			wantErr:     false,
+			wantUpdate: map[string]xdsclient.ListenerUpdate{
+				goodLDSTarget1: {RouteConfigName: goodRouteName1, Raw: marshaledListener1},
+			},
+			wantUpdateMD: xdsclient.UpdateMetadata{
+				ErrState: nil,
+			},
 			wantUpdateErr: false,
 		},
 		// Response contains multiple good listeners, including the one we are
 		// interested in.
 		{
-			name:          "multiple-good-listener",
-			ldsResponse:   ldsResponseWithMultipleResources,
-			wantErr:       false,
-			wantUpdate:    &xdsclient.ListenerUpdate{RouteConfigName: goodRouteName1},
+			name:        "multiple-good-listener",
+			ldsResponse: ldsResponseWithMultipleResources,
+			wantErr:     false,
+			wantUpdate: map[string]xdsclient.ListenerUpdate{
+				goodLDSTarget1: {RouteConfigName: goodRouteName1, Raw: marshaledListener1},
+				goodLDSTarget2: {RouteConfigName: goodRouteName1, Raw: marshaledListener2},
+			},
+			wantUpdateMD: xdsclient.UpdateMetadata{
+				ErrState: nil,
+			},
 			wantUpdateErr: false,
 		},
 		// Response contains two good listeners (one interesting and one
 		// uninteresting), and one badly marshaled listener. This will cause a
 		// nack because the uninteresting listener will still be parsed.
 		{
-			name:          "good-bad-ugly-listeners",
-			ldsResponse:   goodBadUglyLDSResponse,
-			wantErr:       true,
-			wantUpdate:    nil,
+			name:        "good-bad-ugly-listeners",
+			ldsResponse: goodBadUglyLDSResponse,
+			wantErr:     true,
+			wantUpdate: map[string]xdsclient.ListenerUpdate{
+				goodLDSTarget1: {RouteConfigName: goodRouteName1, Raw: marshaledListener1},
+				goodLDSTarget2: {},
+			},
+			wantUpdateMD: xdsclient.UpdateMetadata{
+				ErrState: &xdsclient.UpdateErrorMetadata{
+					Err: errPlaceHolder,
+				},
+			},
 			wantUpdateErr: false,
 		},
 		// Response contains one listener, but we are not interested in it.
 		{
-			name:          "one-uninteresting-listener",
-			ldsResponse:   goodLDSResponse2,
-			wantErr:       false,
-			wantUpdate:    nil,
+			name:        "one-uninteresting-listener",
+			ldsResponse: goodLDSResponse2,
+			wantErr:     false,
+			wantUpdate: map[string]xdsclient.ListenerUpdate{
+				goodLDSTarget2: {RouteConfigName: goodRouteName1, Raw: marshaledListener2},
+			},
+			wantUpdateMD: xdsclient.UpdateMetadata{
+				ErrState: nil,
+			},
 			wantUpdateErr: false,
 		},
 		// Response constains no resources. This is the case where the server
 		// does not know about the target we are interested in.
 		{
-			name:          "empty-response",
-			ldsResponse:   emptyLDSResponse,
-			wantErr:       false,
-			wantUpdate:    nil,
+			name:        "empty-response",
+			ldsResponse: emptyLDSResponse,
+			wantErr:     false,
+			wantUpdate:  nil,
+			wantUpdateMD: xdsclient.UpdateMetadata{
+				ErrState: nil,
+			},
 			wantUpdateErr: false,
 		},
 	}
@@ -118,6 +163,7 @@ func (s) TestLDSHandleResponse(t *testing.T) {
 				responseToHandle: test.ldsResponse,
 				wantHandleErr:    test.wantErr,
 				wantUpdate:       test.wantUpdate,
+				wantUpdateMD:     test.wantUpdateMD,
 				wantUpdateErr:    test.wantUpdateErr,
 			})
 		})
@@ -131,7 +177,7 @@ func (s) TestLDSHandleResponseWithoutWatch(t *testing.T) {
 	defer cleanup()
 
 	v2c, err := newV2Client(&testUpdateReceiver{
-		f: func(xdsclient.ResourceType, map[string]interface{}) {},
+		f: func(xdsclient.ResourceType, map[string]interface{}, xdsclient.UpdateMetadata) {},
 	}, cc, goodNodeProto, func(int) time.Duration { return 0 }, nil)
 	if err != nil {
 		t.Fatal(err)

--- a/xds/internal/client/v2/lds_test.go
+++ b/xds/internal/client/v2/lds_test.go
@@ -46,6 +46,7 @@ func (s) TestLDSHandleResponse(t *testing.T) {
 			wantErr:     true,
 			wantUpdate:  nil,
 			wantUpdateMD: xdsclient.UpdateMetadata{
+				Status: xdsclient.ServiceStatusNACKed,
 				ErrState: &xdsclient.UpdateErrorMetadata{
 					Err: errPlaceHolder,
 				},
@@ -59,6 +60,7 @@ func (s) TestLDSHandleResponse(t *testing.T) {
 			wantErr:     true,
 			wantUpdate:  nil,
 			wantUpdateMD: xdsclient.UpdateMetadata{
+				Status: xdsclient.ServiceStatusNACKed,
 				ErrState: &xdsclient.UpdateErrorMetadata{
 					Err: errPlaceHolder,
 				},
@@ -76,6 +78,7 @@ func (s) TestLDSHandleResponse(t *testing.T) {
 				goodLDSTarget1: {},
 			},
 			wantUpdateMD: xdsclient.UpdateMetadata{
+				Status: xdsclient.ServiceStatusNACKed,
 				ErrState: &xdsclient.UpdateErrorMetadata{
 					Err: errPlaceHolder,
 				},
@@ -91,6 +94,7 @@ func (s) TestLDSHandleResponse(t *testing.T) {
 				goodLDSTarget1: {RouteConfigName: goodRouteName1, Raw: marshaledListener1},
 			},
 			wantUpdateMD: xdsclient.UpdateMetadata{
+				Status:   xdsclient.ServiceStatusACKed,
 				ErrState: nil,
 			},
 			wantUpdateErr: false,
@@ -106,6 +110,7 @@ func (s) TestLDSHandleResponse(t *testing.T) {
 				goodLDSTarget2: {RouteConfigName: goodRouteName1, Raw: marshaledListener2},
 			},
 			wantUpdateMD: xdsclient.UpdateMetadata{
+				Status:   xdsclient.ServiceStatusACKed,
 				ErrState: nil,
 			},
 			wantUpdateErr: false,
@@ -122,6 +127,7 @@ func (s) TestLDSHandleResponse(t *testing.T) {
 				goodLDSTarget2: {},
 			},
 			wantUpdateMD: xdsclient.UpdateMetadata{
+				Status: xdsclient.ServiceStatusNACKed,
 				ErrState: &xdsclient.UpdateErrorMetadata{
 					Err: errPlaceHolder,
 				},
@@ -137,6 +143,7 @@ func (s) TestLDSHandleResponse(t *testing.T) {
 				goodLDSTarget2: {RouteConfigName: goodRouteName1, Raw: marshaledListener2},
 			},
 			wantUpdateMD: xdsclient.UpdateMetadata{
+				Status:   xdsclient.ServiceStatusACKed,
 				ErrState: nil,
 			},
 			wantUpdateErr: false,
@@ -149,6 +156,7 @@ func (s) TestLDSHandleResponse(t *testing.T) {
 			wantErr:     false,
 			wantUpdate:  nil,
 			wantUpdateMD: xdsclient.UpdateMetadata{
+				Status:   xdsclient.ServiceStatusACKed,
 				ErrState: nil,
 			},
 			wantUpdateErr: false,

--- a/xds/internal/client/v2/rds_test.go
+++ b/xds/internal/client/v2/rds_test.go
@@ -60,6 +60,7 @@ func (s) TestRDSHandleResponseWithRouting(t *testing.T) {
 			wantErr:     true,
 			wantUpdate:  nil,
 			wantUpdateMD: xdsclient.UpdateMetadata{
+				Status: xdsclient.ServiceStatusNACKed,
 				ErrState: &xdsclient.UpdateErrorMetadata{
 					Err: errPlaceHolder,
 				},
@@ -73,6 +74,7 @@ func (s) TestRDSHandleResponseWithRouting(t *testing.T) {
 			wantErr:     true,
 			wantUpdate:  nil,
 			wantUpdateMD: xdsclient.UpdateMetadata{
+				Status: xdsclient.ServiceStatusNACKed,
 				ErrState: &xdsclient.UpdateErrorMetadata{
 					Err: errPlaceHolder,
 				},
@@ -93,6 +95,7 @@ func (s) TestRDSHandleResponseWithRouting(t *testing.T) {
 				},
 			},
 			wantUpdateMD: xdsclient.UpdateMetadata{
+				Status:   xdsclient.ServiceStatusACKed,
 				ErrState: nil,
 			},
 			wantUpdateErr: false,
@@ -118,6 +121,7 @@ func (s) TestRDSHandleResponseWithRouting(t *testing.T) {
 				},
 			},
 			wantUpdateMD: xdsclient.UpdateMetadata{
+				Status:   xdsclient.ServiceStatusACKed,
 				ErrState: nil,
 			},
 			wantUpdateErr: false,
@@ -143,6 +147,7 @@ func (s) TestRDSHandleResponseWithRouting(t *testing.T) {
 				},
 			},
 			wantUpdateMD: xdsclient.UpdateMetadata{
+				Status:   xdsclient.ServiceStatusACKed,
 				ErrState: nil,
 			},
 			wantUpdateErr: false,

--- a/xds/internal/client/v3/client.go
+++ b/xds/internal/client/v3/client.go
@@ -185,43 +185,31 @@ func (v3c *client) HandleResponse(r proto.Message) (xdsclient.ResourceType, stri
 // server. On receipt of a good response, it also invokes the registered watcher
 // callback.
 func (v3c *client) handleLDSResponse(resp *v3discoverypb.DiscoveryResponse) error {
-	update, err := xdsclient.UnmarshalListener(resp.GetResources(), v3c.logger)
-	if err != nil {
-		return err
-	}
-	v3c.parent.NewListeners(update)
-	return nil
+	update, md, err := xdsclient.UnmarshalListener(resp.GetVersionInfo(), resp.GetResources(), v3c.logger)
+	v3c.parent.NewListeners(update, md)
+	return err
 }
 
 // handleRDSResponse processes an RDS response received from the management
 // server. On receipt of a good response, it caches validated resources and also
 // invokes the registered watcher callback.
 func (v3c *client) handleRDSResponse(resp *v3discoverypb.DiscoveryResponse) error {
-	update, err := xdsclient.UnmarshalRouteConfig(resp.GetResources(), v3c.logger)
-	if err != nil {
-		return err
-	}
-	v3c.parent.NewRouteConfigs(update)
-	return nil
+	update, md, err := xdsclient.UnmarshalRouteConfig(resp.GetVersionInfo(), resp.GetResources(), v3c.logger)
+	v3c.parent.NewRouteConfigs(update, md)
+	return err
 }
 
 // handleCDSResponse processes an CDS response received from the management
 // server. On receipt of a good response, it also invokes the registered watcher
 // callback.
 func (v3c *client) handleCDSResponse(resp *v3discoverypb.DiscoveryResponse) error {
-	update, err := xdsclient.UnmarshalCluster(resp.GetResources(), v3c.logger)
-	if err != nil {
-		return err
-	}
-	v3c.parent.NewClusters(update)
-	return nil
+	update, md, err := xdsclient.UnmarshalCluster(resp.GetVersionInfo(), resp.GetResources(), v3c.logger)
+	v3c.parent.NewClusters(update, md)
+	return err
 }
 
 func (v3c *client) handleEDSResponse(resp *v3discoverypb.DiscoveryResponse) error {
-	update, err := xdsclient.UnmarshalEndpoints(resp.GetResources(), v3c.logger)
-	if err != nil {
-		return err
-	}
-	v3c.parent.NewEndpoints(update)
-	return nil
+	update, md, err := xdsclient.UnmarshalEndpoints(resp.GetVersionInfo(), resp.GetResources(), v3c.logger)
+	v3c.parent.NewEndpoints(update, md)
+	return err
 }

--- a/xds/internal/client/watchers_cluster_test.go
+++ b/xds/internal/client/watchers_cluster_test.go
@@ -63,7 +63,7 @@ func (s) TestClusterWatch(t *testing.T) {
 	}
 
 	wantUpdate := ClusterUpdate{ServiceName: testEDSName}
-	client.NewClusters(map[string]ClusterUpdate{testCDSName: wantUpdate})
+	client.NewClusters(map[string]ClusterUpdate{testCDSName: wantUpdate}, UpdateMetadata{})
 	if err := verifyClusterUpdate(ctx, clusterUpdateCh, wantUpdate); err != nil {
 		t.Fatal(err)
 	}
@@ -72,14 +72,14 @@ func (s) TestClusterWatch(t *testing.T) {
 	client.NewClusters(map[string]ClusterUpdate{
 		testCDSName:  wantUpdate,
 		"randomName": {},
-	})
+	}, UpdateMetadata{})
 	if err := verifyClusterUpdate(ctx, clusterUpdateCh, wantUpdate); err != nil {
 		t.Fatal(err)
 	}
 
 	// Cancel watch, and send update again.
 	cancelWatch()
-	client.NewClusters(map[string]ClusterUpdate{testCDSName: wantUpdate})
+	client.NewClusters(map[string]ClusterUpdate{testCDSName: wantUpdate}, UpdateMetadata{})
 	sCtx, sCancel := context.WithTimeout(ctx, defaultTestShortTimeout)
 	defer sCancel()
 	if u, err := clusterUpdateCh.Receive(sCtx); err != context.DeadlineExceeded {
@@ -127,7 +127,7 @@ func (s) TestClusterTwoWatchSameResourceName(t *testing.T) {
 	}
 
 	wantUpdate := ClusterUpdate{ServiceName: testEDSName}
-	client.NewClusters(map[string]ClusterUpdate{testCDSName: wantUpdate})
+	client.NewClusters(map[string]ClusterUpdate{testCDSName: wantUpdate}, UpdateMetadata{})
 	for i := 0; i < count; i++ {
 		if err := verifyClusterUpdate(ctx, clusterUpdateChs[i], wantUpdate); err != nil {
 			t.Fatal(err)
@@ -136,7 +136,7 @@ func (s) TestClusterTwoWatchSameResourceName(t *testing.T) {
 
 	// Cancel the last watch, and send update again.
 	cancelLastWatch()
-	client.NewClusters(map[string]ClusterUpdate{testCDSName: wantUpdate})
+	client.NewClusters(map[string]ClusterUpdate{testCDSName: wantUpdate}, UpdateMetadata{})
 	for i := 0; i < count-1; i++ {
 		if err := verifyClusterUpdate(ctx, clusterUpdateChs[i], wantUpdate); err != nil {
 			t.Fatal(err)
@@ -203,7 +203,7 @@ func (s) TestClusterThreeWatchDifferentResourceName(t *testing.T) {
 	client.NewClusters(map[string]ClusterUpdate{
 		testCDSName + "1": wantUpdate1,
 		testCDSName + "2": wantUpdate2,
-	})
+	}, UpdateMetadata{})
 
 	for i := 0; i < count; i++ {
 		if err := verifyClusterUpdate(ctx, clusterUpdateChs[i], wantUpdate1); err != nil {
@@ -246,7 +246,7 @@ func (s) TestClusterWatchAfterCache(t *testing.T) {
 	wantUpdate := ClusterUpdate{ServiceName: testEDSName}
 	client.NewClusters(map[string]ClusterUpdate{
 		testCDSName: wantUpdate,
-	})
+	}, UpdateMetadata{})
 	if err := verifyClusterUpdate(ctx, clusterUpdateCh, wantUpdate); err != nil {
 		t.Fatal(err)
 	}
@@ -346,7 +346,7 @@ func (s) TestClusterWatchExpiryTimerStop(t *testing.T) {
 	wantUpdate := ClusterUpdate{ServiceName: testEDSName}
 	client.NewClusters(map[string]ClusterUpdate{
 		testCDSName: wantUpdate,
-	})
+	}, UpdateMetadata{})
 	if err := verifyClusterUpdate(ctx, clusterUpdateCh, wantUpdate); err != nil {
 		t.Fatal(err)
 	}
@@ -405,7 +405,7 @@ func (s) TestClusterResourceRemoved(t *testing.T) {
 	client.NewClusters(map[string]ClusterUpdate{
 		testCDSName + "1": wantUpdate1,
 		testCDSName + "2": wantUpdate2,
-	})
+	}, UpdateMetadata{})
 	if err := verifyClusterUpdate(ctx, clusterUpdateCh1, wantUpdate1); err != nil {
 		t.Fatal(err)
 	}
@@ -414,7 +414,7 @@ func (s) TestClusterResourceRemoved(t *testing.T) {
 	}
 
 	// Send another update to remove resource 1.
-	client.NewClusters(map[string]ClusterUpdate{testCDSName + "2": wantUpdate2})
+	client.NewClusters(map[string]ClusterUpdate{testCDSName + "2": wantUpdate2}, UpdateMetadata{})
 
 	// Watcher 1 should get an error.
 	if u, err := clusterUpdateCh1.Receive(ctx); err != nil || ErrType(u.(clusterUpdateErr).err) != ErrorTypeResourceNotFound {
@@ -427,7 +427,7 @@ func (s) TestClusterResourceRemoved(t *testing.T) {
 	}
 
 	// Send one more update without resource 1.
-	client.NewClusters(map[string]ClusterUpdate{testCDSName + "2": wantUpdate2})
+	client.NewClusters(map[string]ClusterUpdate{testCDSName + "2": wantUpdate2}, UpdateMetadata{})
 
 	// Watcher 1 should not see an update.
 	sCtx, sCancel := context.WithTimeout(ctx, defaultTestShortTimeout)

--- a/xds/internal/client/watchers_endpoints_test.go
+++ b/xds/internal/client/watchers_endpoints_test.go
@@ -81,13 +81,13 @@ func (s) TestEndpointsWatch(t *testing.T) {
 	}
 
 	wantUpdate := EndpointsUpdate{Localities: []Locality{testLocalities[0]}}
-	client.NewEndpoints(map[string]EndpointsUpdate{testCDSName: wantUpdate})
+	client.NewEndpoints(map[string]EndpointsUpdate{testCDSName: wantUpdate}, UpdateMetadata{})
 	if err := verifyEndpointsUpdate(ctx, endpointsUpdateCh, wantUpdate); err != nil {
 		t.Fatal(err)
 	}
 
 	// Another update for a different resource name.
-	client.NewEndpoints(map[string]EndpointsUpdate{"randomName": {}})
+	client.NewEndpoints(map[string]EndpointsUpdate{"randomName": {}}, UpdateMetadata{})
 	sCtx, sCancel := context.WithTimeout(ctx, defaultTestShortTimeout)
 	defer sCancel()
 	if u, err := endpointsUpdateCh.Receive(sCtx); err != context.DeadlineExceeded {
@@ -96,7 +96,7 @@ func (s) TestEndpointsWatch(t *testing.T) {
 
 	// Cancel watch, and send update again.
 	cancelWatch()
-	client.NewEndpoints(map[string]EndpointsUpdate{testCDSName: wantUpdate})
+	client.NewEndpoints(map[string]EndpointsUpdate{testCDSName: wantUpdate}, UpdateMetadata{})
 	sCtx, sCancel = context.WithTimeout(ctx, defaultTestShortTimeout)
 	defer sCancel()
 	if u, err := endpointsUpdateCh.Receive(sCtx); err != context.DeadlineExceeded {
@@ -146,7 +146,7 @@ func (s) TestEndpointsTwoWatchSameResourceName(t *testing.T) {
 	}
 
 	wantUpdate := EndpointsUpdate{Localities: []Locality{testLocalities[0]}}
-	client.NewEndpoints(map[string]EndpointsUpdate{testCDSName: wantUpdate})
+	client.NewEndpoints(map[string]EndpointsUpdate{testCDSName: wantUpdate}, UpdateMetadata{})
 	for i := 0; i < count; i++ {
 		if err := verifyEndpointsUpdate(ctx, endpointsUpdateChs[i], wantUpdate); err != nil {
 			t.Fatal(err)
@@ -155,7 +155,7 @@ func (s) TestEndpointsTwoWatchSameResourceName(t *testing.T) {
 
 	// Cancel the last watch, and send update again.
 	cancelLastWatch()
-	client.NewEndpoints(map[string]EndpointsUpdate{testCDSName: wantUpdate})
+	client.NewEndpoints(map[string]EndpointsUpdate{testCDSName: wantUpdate}, UpdateMetadata{})
 	for i := 0; i < count-1; i++ {
 		if err := verifyEndpointsUpdate(ctx, endpointsUpdateChs[i], wantUpdate); err != nil {
 			t.Fatal(err)
@@ -222,7 +222,7 @@ func (s) TestEndpointsThreeWatchDifferentResourceName(t *testing.T) {
 	client.NewEndpoints(map[string]EndpointsUpdate{
 		testCDSName + "1": wantUpdate1,
 		testCDSName + "2": wantUpdate2,
-	})
+	}, UpdateMetadata{})
 
 	for i := 0; i < count; i++ {
 		if err := verifyEndpointsUpdate(ctx, endpointsUpdateChs[i], wantUpdate1); err != nil {
@@ -263,7 +263,7 @@ func (s) TestEndpointsWatchAfterCache(t *testing.T) {
 	}
 
 	wantUpdate := EndpointsUpdate{Localities: []Locality{testLocalities[0]}}
-	client.NewEndpoints(map[string]EndpointsUpdate{testCDSName: wantUpdate})
+	client.NewEndpoints(map[string]EndpointsUpdate{testCDSName: wantUpdate}, UpdateMetadata{})
 	if err := verifyEndpointsUpdate(ctx, endpointsUpdateCh, wantUpdate); err != nil {
 		t.Fatal(err)
 	}

--- a/xds/internal/client/watchers_listener_test.go
+++ b/xds/internal/client/watchers_listener_test.go
@@ -61,7 +61,7 @@ func (s) TestLDSWatch(t *testing.T) {
 	}
 
 	wantUpdate := ListenerUpdate{RouteConfigName: testRDSName}
-	client.NewListeners(map[string]ListenerUpdate{testLDSName: wantUpdate})
+	client.NewListeners(map[string]ListenerUpdate{testLDSName: wantUpdate}, UpdateMetadata{})
 	if err := verifyListenerUpdate(ctx, ldsUpdateCh, wantUpdate); err != nil {
 		t.Fatal(err)
 	}
@@ -70,14 +70,14 @@ func (s) TestLDSWatch(t *testing.T) {
 	client.NewListeners(map[string]ListenerUpdate{
 		testLDSName:  wantUpdate,
 		"randomName": {},
-	})
+	}, UpdateMetadata{})
 	if err := verifyListenerUpdate(ctx, ldsUpdateCh, wantUpdate); err != nil {
 		t.Fatal(err)
 	}
 
 	// Cancel watch, and send update again.
 	cancelWatch()
-	client.NewListeners(map[string]ListenerUpdate{testLDSName: wantUpdate})
+	client.NewListeners(map[string]ListenerUpdate{testLDSName: wantUpdate}, UpdateMetadata{})
 	sCtx, sCancel := context.WithTimeout(ctx, defaultTestShortTimeout)
 	defer sCancel()
 	if u, err := ldsUpdateCh.Receive(sCtx); err != context.DeadlineExceeded {
@@ -128,7 +128,7 @@ func (s) TestLDSTwoWatchSameResourceName(t *testing.T) {
 	}
 
 	wantUpdate := ListenerUpdate{RouteConfigName: testRDSName}
-	client.NewListeners(map[string]ListenerUpdate{testLDSName: wantUpdate})
+	client.NewListeners(map[string]ListenerUpdate{testLDSName: wantUpdate}, UpdateMetadata{})
 	for i := 0; i < count; i++ {
 		if err := verifyListenerUpdate(ctx, ldsUpdateChs[i], wantUpdate); err != nil {
 			t.Fatal(err)
@@ -137,7 +137,7 @@ func (s) TestLDSTwoWatchSameResourceName(t *testing.T) {
 
 	// Cancel the last watch, and send update again.
 	cancelLastWatch()
-	client.NewListeners(map[string]ListenerUpdate{testLDSName: wantUpdate})
+	client.NewListeners(map[string]ListenerUpdate{testLDSName: wantUpdate}, UpdateMetadata{})
 	for i := 0; i < count-1; i++ {
 		if err := verifyListenerUpdate(ctx, ldsUpdateChs[i], wantUpdate); err != nil {
 			t.Fatal(err)
@@ -205,7 +205,7 @@ func (s) TestLDSThreeWatchDifferentResourceName(t *testing.T) {
 	client.NewListeners(map[string]ListenerUpdate{
 		testLDSName + "1": wantUpdate1,
 		testLDSName + "2": wantUpdate2,
-	})
+	}, UpdateMetadata{})
 
 	for i := 0; i < count; i++ {
 		if err := verifyListenerUpdate(ctx, ldsUpdateChs[i], wantUpdate1); err != nil {
@@ -246,7 +246,7 @@ func (s) TestLDSWatchAfterCache(t *testing.T) {
 	}
 
 	wantUpdate := ListenerUpdate{RouteConfigName: testRDSName}
-	client.NewListeners(map[string]ListenerUpdate{testLDSName: wantUpdate})
+	client.NewListeners(map[string]ListenerUpdate{testLDSName: wantUpdate}, UpdateMetadata{})
 	if err := verifyListenerUpdate(ctx, ldsUpdateCh, wantUpdate); err != nil {
 		t.Fatal(err)
 	}
@@ -320,7 +320,7 @@ func (s) TestLDSResourceRemoved(t *testing.T) {
 	client.NewListeners(map[string]ListenerUpdate{
 		testLDSName + "1": wantUpdate1,
 		testLDSName + "2": wantUpdate2,
-	})
+	}, UpdateMetadata{})
 	if err := verifyListenerUpdate(ctx, ldsUpdateCh1, wantUpdate1); err != nil {
 		t.Fatal(err)
 	}
@@ -329,7 +329,7 @@ func (s) TestLDSResourceRemoved(t *testing.T) {
 	}
 
 	// Send another update to remove resource 1.
-	client.NewListeners(map[string]ListenerUpdate{testLDSName + "2": wantUpdate2})
+	client.NewListeners(map[string]ListenerUpdate{testLDSName + "2": wantUpdate2}, UpdateMetadata{})
 
 	// Watcher 1 should get an error.
 	if u, err := ldsUpdateCh1.Receive(ctx); err != nil || ErrType(u.(ldsUpdateErr).err) != ErrorTypeResourceNotFound {
@@ -342,7 +342,7 @@ func (s) TestLDSResourceRemoved(t *testing.T) {
 	}
 
 	// Send one more update without resource 1.
-	client.NewListeners(map[string]ListenerUpdate{testLDSName + "2": wantUpdate2})
+	client.NewListeners(map[string]ListenerUpdate{testLDSName + "2": wantUpdate2}, UpdateMetadata{})
 
 	// Watcher 1 should not see an update.
 	sCtx, sCancel := context.WithTimeout(ctx, defaultTestShortTimeout)

--- a/xds/internal/client/watchers_route_test.go
+++ b/xds/internal/client/watchers_route_test.go
@@ -70,13 +70,13 @@ func (s) TestRDSWatch(t *testing.T) {
 			},
 		},
 	}
-	client.NewRouteConfigs(map[string]RouteConfigUpdate{testRDSName: wantUpdate})
+	client.NewRouteConfigs(map[string]RouteConfigUpdate{testRDSName: wantUpdate}, UpdateMetadata{})
 	if err := verifyRouteConfigUpdate(ctx, rdsUpdateCh, wantUpdate); err != nil {
 		t.Fatal(err)
 	}
 
 	// Another update for a different resource name.
-	client.NewRouteConfigs(map[string]RouteConfigUpdate{"randomName": {}})
+	client.NewRouteConfigs(map[string]RouteConfigUpdate{"randomName": {}}, UpdateMetadata{})
 	sCtx, sCancel := context.WithTimeout(ctx, defaultTestShortTimeout)
 	defer sCancel()
 	if u, err := rdsUpdateCh.Receive(sCtx); err != context.DeadlineExceeded {
@@ -85,7 +85,7 @@ func (s) TestRDSWatch(t *testing.T) {
 
 	// Cancel watch, and send update again.
 	cancelWatch()
-	client.NewRouteConfigs(map[string]RouteConfigUpdate{testRDSName: wantUpdate})
+	client.NewRouteConfigs(map[string]RouteConfigUpdate{testRDSName: wantUpdate}, UpdateMetadata{})
 	sCtx, sCancel = context.WithTimeout(ctx, defaultTestShortTimeout)
 	defer sCancel()
 	if u, err := rdsUpdateCh.Receive(sCtx); err != context.DeadlineExceeded {
@@ -142,7 +142,7 @@ func (s) TestRDSTwoWatchSameResourceName(t *testing.T) {
 			},
 		},
 	}
-	client.NewRouteConfigs(map[string]RouteConfigUpdate{testRDSName: wantUpdate})
+	client.NewRouteConfigs(map[string]RouteConfigUpdate{testRDSName: wantUpdate}, UpdateMetadata{})
 	for i := 0; i < count; i++ {
 		if err := verifyRouteConfigUpdate(ctx, rdsUpdateChs[i], wantUpdate); err != nil {
 			t.Fatal(err)
@@ -151,7 +151,7 @@ func (s) TestRDSTwoWatchSameResourceName(t *testing.T) {
 
 	// Cancel the last watch, and send update again.
 	cancelLastWatch()
-	client.NewRouteConfigs(map[string]RouteConfigUpdate{testRDSName: wantUpdate})
+	client.NewRouteConfigs(map[string]RouteConfigUpdate{testRDSName: wantUpdate}, UpdateMetadata{})
 	for i := 0; i < count-1; i++ {
 		if err := verifyRouteConfigUpdate(ctx, rdsUpdateChs[i], wantUpdate); err != nil {
 			t.Fatal(err)
@@ -232,7 +232,7 @@ func (s) TestRDSThreeWatchDifferentResourceName(t *testing.T) {
 	client.NewRouteConfigs(map[string]RouteConfigUpdate{
 		testRDSName + "1": wantUpdate1,
 		testRDSName + "2": wantUpdate2,
-	})
+	}, UpdateMetadata{})
 
 	for i := 0; i < count; i++ {
 		if err := verifyRouteConfigUpdate(ctx, rdsUpdateChs[i], wantUpdate1); err != nil {
@@ -280,7 +280,7 @@ func (s) TestRDSWatchAfterCache(t *testing.T) {
 			},
 		},
 	}
-	client.NewRouteConfigs(map[string]RouteConfigUpdate{testRDSName: wantUpdate})
+	client.NewRouteConfigs(map[string]RouteConfigUpdate{testRDSName: wantUpdate}, UpdateMetadata{})
 	if err := verifyRouteConfigUpdate(ctx, rdsUpdateCh, wantUpdate); err != nil {
 		t.Fatal(err)
 	}

--- a/xds/internal/client/xds.go
+++ b/xds/internal/client/xds.go
@@ -84,9 +84,11 @@ func UnmarshalListener(version string, resources []*anypb.Any, logger *grpclog.P
 	}
 
 	if len(topLevelErrors) == 0 && len(perResourceErrors) == 0 {
+		md.Status = ServiceStatusACKed
 		return update, md, nil
 	}
 
+	md.Status = ServiceStatusNACKed
 	errRet := combineErrors("LDS", topLevelErrors, perResourceErrors)
 	md.ErrState = &UpdateErrorMetadata{
 		Version:   version,
@@ -256,9 +258,11 @@ func UnmarshalRouteConfig(version string, resources []*anypb.Any, logger *grpclo
 	}
 
 	if len(topLevelErrors) == 0 && len(perResourceErrors) == 0 {
+		md.Status = ServiceStatusACKed
 		return update, md, nil
 	}
 
+	md.Status = ServiceStatusNACKed
 	errRet := combineErrors("RDS", topLevelErrors, perResourceErrors)
 	md.ErrState = &UpdateErrorMetadata{
 		Version:   version,
@@ -462,9 +466,11 @@ func UnmarshalCluster(version string, resources []*anypb.Any, logger *grpclog.Pr
 	}
 
 	if len(topLevelErrors) == 0 && len(perResourceErrors) == 0 {
+		md.Status = ServiceStatusACKed
 		return update, md, nil
 	}
 
+	md.Status = ServiceStatusNACKed
 	errRet := combineErrors("CDS", topLevelErrors, perResourceErrors)
 	md.ErrState = &UpdateErrorMetadata{
 		Version:   version,
@@ -639,9 +645,11 @@ func UnmarshalEndpoints(version string, resources []*anypb.Any, logger *grpclog.
 	}
 
 	if len(topLevelErrors) == 0 && len(perResourceErrors) == 0 {
+		md.Status = ServiceStatusACKed
 		return update, md, nil
 	}
 
+	md.Status = ServiceStatusNACKed
 	errRet := combineErrors("EDS", topLevelErrors, perResourceErrors)
 	md.ErrState = &UpdateErrorMetadata{
 		Version:   version,


### PR DESCRIPTION
- A new metadata type for timestamp, version, and optional error message
- A new fields in xds updates, for raw proto.Any
- client_callback.go
  - Accept metadata when handling parsed xds updates
  - Update status (ACKed/NACKed) and version
- xds_client.go
  - When unmarshalling responses, DON'T stop at the first error. Keep
    processing all the resources, so we know which resources are NACKed.
- v2/v3 client.go
  - Send the updates to client_callback.go even when response is NACKed. This
    is necessary for CSDS's purpose, and also necessary when we later call
    user's callback with the NACK errors.
- Test changes

In the next PR, csds will read those data, and send to the csds client.