### PR TITLE
xds testing: increase timeout from 90 minutes to 120 minutes

### DIFF
--- a/test/kokoro/xds.cfg
+++ b/test/kokoro/xds.cfg
@@ -2,7 +2,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc-go/test/kokoro/xds.sh"
-timeout_mins: 90
+timeout_mins: 120
 action {
   define_artifacts {
     regex: "**/*sponge_log.*"


### PR DESCRIPTION
This is the timeout for all the tests, after which the VM will be termiated.
Since now we have more tests, we need more time.

The current average is around 85-90 minutes. The extra 30 minutes should be
enough for several new tests.