### PR TITLE
circuit breaking: keep max_count per picker, instead of globally, and add support in cluster_impl balancer

### DIFF
--- a/xds/internal/balancer/cdsbalancer/cdsbalancer.go
+++ b/xds/internal/balancer/cdsbalancer/cdsbalancer.go
@@ -34,7 +34,6 @@ import (
 	"google.golang.org/grpc/resolver"
 	"google.golang.org/grpc/serviceconfig"
 	"google.golang.org/grpc/xds/internal/balancer/edsbalancer"
-	"google.golang.org/grpc/xds/internal/client"
 	xdsclient "google.golang.org/grpc/xds/internal/client"
 	"google.golang.org/grpc/xds/internal/client/bootstrap"
 )
@@ -328,8 +327,6 @@ func (b *cdsBalancer) handleWatchUpdate(update *watchUpdate) {
 		return
 	}
 
-	client.SetMaxRequests(update.cds.ServiceName, update.cds.MaxRequests)
-
 	// The first good update from the watch API leads to the instantiation of an
 	// edsBalancer. Further updates/errors are propagated to the existing
 	// edsBalancer.
@@ -342,7 +339,10 @@ func (b *cdsBalancer) handleWatchUpdate(update *watchUpdate) {
 		b.edsLB = edsLB
 		b.logger.Infof("Created child policy %p of type %s", b.edsLB, edsName)
 	}
-	lbCfg := &edsbalancer.EDSConfig{EDSServiceName: update.cds.ServiceName}
+	lbCfg := &edsbalancer.EDSConfig{
+		EDSServiceName:        update.cds.ServiceName,
+		MaxConcurrentRequests: update.cds.MaxRequests,
+	}
 	if update.cds.EnableLRS {
 		// An empty string here indicates that the edsBalancer should use the
 		// same xDS server for load reporting as it does for EDS

--- a/xds/internal/balancer/cdsbalancer/cdsbalancer_security_test.go
+++ b/xds/internal/balancer/cdsbalancer/cdsbalancer_security_test.go
@@ -233,7 +233,7 @@ func (s) TestSecurityConfigWithoutXDSCreds(t *testing.T) {
 	// returned to the CDS balancer, because we have overridden the
 	// newEDSBalancer function as part of test setup.
 	cdsUpdate := xdsclient.ClusterUpdate{ServiceName: serviceName}
-	wantCCS := edsCCS(serviceName, false)
+	wantCCS := edsCCS(serviceName, nil, false)
 	ctx, ctxCancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer ctxCancel()
 	if err := invokeWatchCbAndWait(ctx, xdsC, cdsWatchInfo{cdsUpdate, nil}, wantCCS, edsB); err != nil {
@@ -289,7 +289,7 @@ func (s) TestNoSecurityConfigWithXDSCreds(t *testing.T) {
 	// newEDSBalancer function as part of test setup. No security config is
 	// passed to the CDS balancer as part of this update.
 	cdsUpdate := xdsclient.ClusterUpdate{ServiceName: serviceName}
-	wantCCS := edsCCS(serviceName, false)
+	wantCCS := edsCCS(serviceName, nil, false)
 	ctx, ctxCancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer ctxCancel()
 	if err := invokeWatchCbAndWait(ctx, xdsC, cdsWatchInfo{cdsUpdate, nil}, wantCCS, edsB); err != nil {
@@ -445,7 +445,7 @@ func (s) TestSecurityConfigUpdate_BadToGood(t *testing.T) {
 	// create a new EDS balancer. The fake EDS balancer created above will be
 	// returned to the CDS balancer, because we have overridden the
 	// newEDSBalancer function as part of test setup.
-	wantCCS := edsCCS(serviceName, false)
+	wantCCS := edsCCS(serviceName, nil, false)
 	if err := invokeWatchCbAndWait(ctx, xdsC, cdsWatchInfo{cdsUpdateWithGoodSecurityCfg, nil}, wantCCS, edsB); err != nil {
 		t.Fatal(err)
 	}
@@ -479,7 +479,7 @@ func (s) TestGoodSecurityConfig(t *testing.T) {
 	// create a new EDS balancer. The fake EDS balancer created above will be
 	// returned to the CDS balancer, because we have overridden the
 	// newEDSBalancer function as part of test setup.
-	wantCCS := edsCCS(serviceName, false)
+	wantCCS := edsCCS(serviceName, nil, false)
 	ctx, ctxCancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer ctxCancel()
 	if err := invokeWatchCbAndWait(ctx, xdsC, cdsWatchInfo{cdsUpdateWithGoodSecurityCfg, nil}, wantCCS, edsB); err != nil {
@@ -510,7 +510,7 @@ func (s) TestSecurityConfigUpdate_GoodToFallback(t *testing.T) {
 	// create a new EDS balancer. The fake EDS balancer created above will be
 	// returned to the CDS balancer, because we have overridden the
 	// newEDSBalancer function as part of test setup.
-	wantCCS := edsCCS(serviceName, false)
+	wantCCS := edsCCS(serviceName, nil, false)
 	ctx, ctxCancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer ctxCancel()
 	if err := invokeWatchCbAndWait(ctx, xdsC, cdsWatchInfo{cdsUpdateWithGoodSecurityCfg, nil}, wantCCS, edsB); err != nil {
@@ -560,7 +560,7 @@ func (s) TestSecurityConfigUpdate_GoodToBad(t *testing.T) {
 	// create a new EDS balancer. The fake EDS balancer created above will be
 	// returned to the CDS balancer, because we have overridden the
 	// newEDSBalancer function as part of test setup.
-	wantCCS := edsCCS(serviceName, false)
+	wantCCS := edsCCS(serviceName, nil, false)
 	ctx, ctxCancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer ctxCancel()
 	if err := invokeWatchCbAndWait(ctx, xdsC, cdsWatchInfo{cdsUpdateWithGoodSecurityCfg, nil}, wantCCS, edsB); err != nil {
@@ -637,7 +637,7 @@ func (s) TestSecurityConfigUpdate_GoodToGood(t *testing.T) {
 			RootInstanceName: "default1",
 		},
 	}
-	wantCCS := edsCCS(serviceName, false)
+	wantCCS := edsCCS(serviceName, nil, false)
 	ctx, ctxCancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer ctxCancel()
 	if err := invokeWatchCbAndWait(ctx, xdsC, cdsWatchInfo{cdsUpdate, nil}, wantCCS, edsB); err != nil {

--- a/xds/internal/balancer/clusterimpl/clusterimpl.go
+++ b/xds/internal/balancer/clusterimpl/clusterimpl.go
@@ -38,8 +38,8 @@ import (
 )
 
 const (
-	clusterImplName = "xds_cluster_impl_experimental"
-	// TODO: define defaultRequestCountMax = 1024
+	clusterImplName        = "xds_cluster_impl_experimental"
+	defaultRequestCountMax = 1024
 )
 
 func init() {
@@ -52,11 +52,12 @@ type clusterImplBB struct{}
 
 func (clusterImplBB) Build(cc balancer.ClientConn, bOpts balancer.BuildOptions) balancer.Balancer {
 	b := &clusterImplBalancer{
-		ClientConn:     cc,
-		bOpts:          bOpts,
-		closed:         grpcsync.NewEvent(),
-		loadWrapper:    loadstore.NewWrapper(),
-		pickerUpdateCh: buffer.NewUnbounded(),
+		ClientConn:      cc,
+		bOpts:           bOpts,
+		closed:          grpcsync.NewEvent(),
+		loadWrapper:     loadstore.NewWrapper(),
+		pickerUpdateCh:  buffer.NewUnbounded(),
+		requestCountMax: defaultRequestCountMax,
 	}
 	b.logger = prefixLogger(b)
 
@@ -105,10 +106,11 @@ type clusterImplBalancer struct {
 	// childState/drops/requestCounter can only be accessed in run(). And run()
 	// is the only goroutine that sends picker to the parent ClientConn. All
 	// requests to update picker need to be sent to pickerUpdateCh.
-	childState balancer.State
-	drops      []*dropper
-	// TODO: add serviceRequestCount and maxRequestCount for circuit breaking.
-	pickerUpdateCh *buffer.Unbounded
+	childState      balancer.State
+	drops           []*dropper
+	requestCounter  *xdsclient.ServiceRequestsCounter
+	requestCountMax uint32
+	pickerUpdateCh  *buffer.Unbounded
 }
 
 // updateLoadStore checks the config for load store, and decides whether it
@@ -198,19 +200,28 @@ func (cib *clusterImplBalancer) UpdateClientConnState(s balancer.ClientConnState
 		updatePicker = true
 	}
 
-	// TODO: compare cluster name. And update picker if it's changed, because
-	// circuit breaking's stream counter will be different.
-	//
-	// Set `updatePicker` to manually update the picker.
-
-	// TODO: compare upper bound of stream count. And update picker if it's
-	// changed. This is also for circuit breaking.
-	//
-	// Set `updatePicker` to manually update the picker.
+	// Compare cluster name. And update picker if it's changed, because circuit
+	// breaking's stream counter will be different.
+	if cib.config == nil || cib.config.Cluster != newConfig.Cluster {
+		cib.requestCounter = xdsclient.GetServiceRequestsCounter(newConfig.Cluster)
+		updatePicker = true
+	}
+	// Compare upper bound of stream count. And update picker if it's changed.
+	// This is also for circuit breaking.
+	var newRequestCountMax uint32 = 1024
+	if newConfig.MaxConcurrentRequests != nil {
+		newRequestCountMax = *newConfig.MaxConcurrentRequests
+	}
+	if cib.requestCountMax != newRequestCountMax {
+		cib.requestCountMax = newRequestCountMax
+		updatePicker = true
+	}
 
 	if updatePicker {
 		cib.pickerUpdateCh.Put(&dropConfigs{
-			drops: cib.drops,
+			drops:           cib.drops,
+			requestCounter:  cib.requestCounter,
+			requestCountMax: cib.requestCountMax,
 		})
 	}
 
@@ -280,7 +291,9 @@ func (cib *clusterImplBalancer) UpdateState(state balancer.State) {
 }
 
 type dropConfigs struct {
-	drops []*dropper
+	drops           []*dropper
+	requestCounter  *xdsclient.ServiceRequestsCounter
+	requestCountMax uint32
 }
 
 func (cib *clusterImplBalancer) run() {
@@ -293,15 +306,19 @@ func (cib *clusterImplBalancer) run() {
 				cib.childState = u
 				cib.ClientConn.UpdateState(balancer.State{
 					ConnectivityState: cib.childState.ConnectivityState,
-					Picker:            newDropPicker(cib.childState, cib.drops, cib.loadWrapper),
+					Picker: newDropPicker(cib.childState, &dropConfigs{
+						drops:           cib.drops,
+						requestCounter:  cib.requestCounter,
+						requestCountMax: cib.requestCountMax,
+					}, cib.loadWrapper),
 				})
 			case *dropConfigs:
 				cib.drops = u.drops
-				// cib.requestCounter = u.requestCounter
+				cib.requestCounter = u.requestCounter
 				if cib.childState.Picker != nil {
 					cib.ClientConn.UpdateState(balancer.State{
 						ConnectivityState: cib.childState.ConnectivityState,
-						Picker:            newDropPicker(cib.childState, cib.drops, cib.loadWrapper),
+						Picker:            newDropPicker(cib.childState, u, cib.loadWrapper),
 					})
 				}
 			}

--- a/xds/internal/balancer/edsbalancer/config.go
+++ b/xds/internal/balancer/edsbalancer/config.go
@@ -38,6 +38,15 @@ type EDSConfig struct {
 	// Name to use in EDS query.  If not present, defaults to the server
 	// name from the target URI.
 	EDSServiceName string
+	// MaxConcurrentRequests is the max number of concurrent request allowed for
+	// this service. If unset, default value 1024 is used.
+	//
+	// Note that this is not defined in the service config proto. And the reason
+	// is, we are dropping EDS and moving the features into cluster_impl. But in
+	// the mean time, to keep things working, we need to add this field. And it
+	// should be fine to add this extra field here, because EDS is only used in
+	// CDS today, so we have full control.
+	MaxConcurrentRequests *uint32
 	// LRS server to send load reports to.  If not present, load reporting
 	// will be disabled.  If set to the empty string, load reporting will
 	// be sent to the same server that we obtained CDS data from.
@@ -51,6 +60,7 @@ type edsConfigJSON struct {
 	ChildPolicy                []*loadBalancingConfig
 	FallbackPolicy             []*loadBalancingConfig
 	EDSServiceName             string
+	MaxConcurrentRequests      *uint32
 	LRSLoadReportingServerName *string
 }
 
@@ -64,6 +74,7 @@ func (l *EDSConfig) UnmarshalJSON(data []byte) error {
 	}
 
 	l.EDSServiceName = configJSON.EDSServiceName
+	l.MaxConcurrentRequests = configJSON.MaxConcurrentRequests
 	l.LrsLoadReportingServerName = configJSON.LRSLoadReportingServerName
 
 	for _, lbcfg := range configJSON.ChildPolicy {

--- a/xds/internal/balancer/edsbalancer/eds.go
+++ b/xds/internal/balancer/edsbalancer/eds.go
@@ -113,9 +113,9 @@ type edsBalancerImplInterface interface {
 	handleSubConnStateChange(sc balancer.SubConn, state connectivity.State)
 	// updateState handle a balancer state update from the priority.
 	updateState(priority priorityType, s balancer.State)
-	// updateServiceRequestsCounter updates the service requests counter to the
+	// updateServiceRequestsConfig updates the service requests counter to the
 	// one for the given service name.
-	updateServiceRequestsCounter(serviceName string)
+	updateServiceRequestsConfig(serviceName string, max *uint32)
 	// close closes the eds balancer.
 	close()
 }
@@ -215,7 +215,7 @@ func (x *edsBalancer) handleGRPCUpdate(update interface{}) {
 			x.logger.Warningf("failed to update xDS client: %v", err)
 		}
 
-		x.edsImpl.updateServiceRequestsCounter(cfg.EDSServiceName)
+		x.edsImpl.updateServiceRequestsConfig(cfg.EDSServiceName, cfg.MaxConcurrentRequests)
 
 		// We will update the edsImpl with the new child policy, if we got a
 		// different one.

--- a/xds/internal/balancer/edsbalancer/eds_impl_test.go
+++ b/xds/internal/balancer/edsbalancer/eds_impl_test.go
@@ -579,9 +579,8 @@ func (s) TestEDS_CircuitBreaking(t *testing.T) {
 	cc := testutils.NewTestClientConn(t)
 	edsb := newEDSBalancerImpl(cc, balancer.BuildOptions{}, nil, nil, nil)
 	edsb.enqueueChildBalancerStateUpdate = edsb.updateState
-	edsb.updateServiceRequestsCounter("test")
 	var maxRequests uint32 = 50
-	client.SetMaxRequests("test", &maxRequests)
+	edsb.updateServiceRequestsConfig("test", &maxRequests)
 
 	// One locality with one backend.
 	clab1 := testutils.NewClusterLoadAssignmentBuilder(testClusterNames[0], nil)
@@ -738,7 +737,7 @@ func (s) TestDropPicker(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 
-			p := newDropPicker(constPicker, tt.drops, nil, nil)
+			p := newDropPicker(constPicker, tt.drops, nil, nil, defaultServiceRequestCountMax)
 
 			// scCount is the number of sc's returned by pick. The opposite of
 			// drop-count.
@@ -786,9 +785,8 @@ func (s) TestEDS_LoadReport(t *testing.T) {
 		cbMaxRequests   = 20
 	)
 	var maxRequestsTemp uint32 = cbMaxRequests
-	client.SetMaxRequests(testServiceName, &maxRequestsTemp)
+	edsb.updateServiceRequestsConfig(testServiceName, &maxRequestsTemp)
 	defer client.ClearCounterForTesting(testServiceName)
-	edsb.updateServiceRequestsCounter(testServiceName)
 
 	backendToBalancerID := make(map[balancer.SubConn]internal.LocalityID)
 


### PR DESCRIPTION
Also changed circuit breaking counter implementation to move max_count into the
picker, because this is how cluster_impl is designed. Implementation in EDS is
also modified to keep max_count in picker.