### PR TITLE
circuit breaking: update picker inline when there's a counter update

### DIFF
--- a/xds/internal/balancer/edsbalancer/eds_impl.go
+++ b/xds/internal/balancer/edsbalancer/eds_impl.go
@@ -419,12 +419,24 @@ func (edsImpl *edsBalancerImpl) updateServiceRequestsConfig(serviceName string, 
 	if !env.CircuitBreakingSupport {
 		return
 	}
+	edsImpl.pickerMu.Lock()
+	var updatePicker bool
 	if edsImpl.serviceRequestsCounter == nil || edsImpl.serviceRequestsCounter.ServiceName != serviceName {
 		edsImpl.serviceRequestsCounter = client.GetServiceRequestsCounter(serviceName)
+		updatePicker = true
 	}
 	if max != nil {
 		edsImpl.serviceRequestCountMax = *max
+		updatePicker = true
 	}
+	if updatePicker && edsImpl.innerState.Picker != nil {
+		// Update picker with old inner picker, new counter and counterMax.
+		edsImpl.cc.UpdateState(balancer.State{
+			ConnectivityState: edsImpl.innerState.ConnectivityState,
+			Picker:            newDropPicker(edsImpl.innerState.Picker, edsImpl.drops, edsImpl.loadReporter, edsImpl.serviceRequestsCounter, edsImpl.serviceRequestCountMax)},
+		)
+	}
+	edsImpl.pickerMu.Unlock()
 }
 
 // updateState first handles priority, and then wraps picker in a drop picker

--- a/xds/internal/balancer/edsbalancer/eds_impl.go
+++ b/xds/internal/balancer/edsbalancer/eds_impl.go
@@ -425,8 +425,13 @@ func (edsImpl *edsBalancerImpl) updateServiceRequestsConfig(serviceName string, 
 		edsImpl.serviceRequestsCounter = client.GetServiceRequestsCounter(serviceName)
 		updatePicker = true
 	}
+
+	var newMax uint32 = defaultServiceRequestCountMax
 	if max != nil {
-		edsImpl.serviceRequestCountMax = *max
+		newMax = *max
+	}
+	if edsImpl.serviceRequestCountMax != newMax {
+		edsImpl.serviceRequestCountMax = newMax
 		updatePicker = true
 	}
 	if updatePicker && edsImpl.innerState.Picker != nil {

--- a/xds/internal/balancer/edsbalancer/eds_impl_test.go
+++ b/xds/internal/balancer/edsbalancer/eds_impl_test.go
@@ -629,6 +629,51 @@ func (s) TestEDS_CircuitBreaking(t *testing.T) {
 	for _, done := range dones {
 		done()
 	}
+
+	// Send another update, with only circuit breaking update (and no picker
+	// update afterwards). Make sure the new picker uses the new configs.
+	var maxRequests2 uint32 = 10
+	edsb.updateServiceRequestsConfig("test", &maxRequests2)
+
+	// Picks with drops.
+	dones2 := []func(){}
+	p2 := <-cc.NewPickerCh
+	for i := 0; i < 100; i++ {
+		pr, err := p2.Pick(balancer.PickInfo{})
+		if i < 10 && err != nil {
+			t.Errorf("The first 10%% picks should be non-drops, got error %v", err)
+		} else if i > 10 && err == nil {
+			t.Errorf("The next 90%% picks should be drops, got error <nil>")
+		}
+		dones2 = append(dones2, func() {
+			if pr.Done != nil {
+				pr.Done(balancer.DoneInfo{})
+			}
+		})
+	}
+
+	for _, done := range dones2 {
+		done()
+	}
+	dones2 = []func(){}
+
+	// Pick without drops.
+	for i := 0; i < 10; i++ {
+		pr, err := p2.Pick(balancer.PickInfo{})
+		if err != nil {
+			t.Errorf("The next 10%% picks should be non-drops, got error %v", err)
+		}
+		dones2 = append(dones2, func() {
+			if pr.Done != nil {
+				pr.Done(balancer.DoneInfo{})
+			}
+		})
+	}
+
+	// Without this, future tests with the same service name will fail.
+	for _, done := range dones2 {
+		done()
+	}
 }
 
 func init() {

--- a/xds/internal/balancer/edsbalancer/eds_impl_test.go
+++ b/xds/internal/balancer/edsbalancer/eds_impl_test.go
@@ -636,7 +636,7 @@ func (s) TestEDS_CircuitBreaking(t *testing.T) {
 	edsb.updateServiceRequestsConfig("test", &maxRequests2)
 
 	// Picks with drops.
-	dones2 := []func(){}
+	dones = []func(){}
 	p2 := <-cc.NewPickerCh
 	for i := 0; i < 100; i++ {
 		pr, err := p2.Pick(balancer.PickInfo{})
@@ -645,17 +645,17 @@ func (s) TestEDS_CircuitBreaking(t *testing.T) {
 		} else if i > 10 && err == nil {
 			t.Errorf("The next 90%% picks should be drops, got error <nil>")
 		}
-		dones2 = append(dones2, func() {
+		dones = append(dones, func() {
 			if pr.Done != nil {
 				pr.Done(balancer.DoneInfo{})
 			}
 		})
 	}
 
-	for _, done := range dones2 {
+	for _, done := range dones {
 		done()
 	}
-	dones2 = []func(){}
+	dones = []func(){}
 
 	// Pick without drops.
 	for i := 0; i < 10; i++ {
@@ -663,7 +663,7 @@ func (s) TestEDS_CircuitBreaking(t *testing.T) {
 		if err != nil {
 			t.Errorf("The next 10%% picks should be non-drops, got error %v", err)
 		}
-		dones2 = append(dones2, func() {
+		dones = append(dones, func() {
 			if pr.Done != nil {
 				pr.Done(balancer.DoneInfo{})
 			}
@@ -671,7 +671,7 @@ func (s) TestEDS_CircuitBreaking(t *testing.T) {
 	}
 
 	// Without this, future tests with the same service name will fail.
-	for _, done := range dones2 {
+	for _, done := range dones {
 		done()
 	}
 }


### PR DESCRIPTION
Otherwise, if there's no further picker update, the new counter will never be used.

Regression caused by #4203
This is handled in `cluster_impl`, but missed in `eds`.