### PR TITLE
balancer: Add UpdateAddresses() to balancer.ClientConn interface

### DIFF
--- a/balancer/balancer.go
+++ b/balancer/balancer.go
@@ -101,6 +101,9 @@ type SubConn interface {
 	// a new connection will be created.
 	//
 	// This will trigger a state transition for the SubConn.
+	//
+	// Deprecated: This method is now part of the ClientConn interface and will
+	// eventually be removed from here.
 	UpdateAddresses([]resolver.Address)
 	// Connect starts the connecting for this SubConn.
 	Connect()
@@ -143,6 +146,13 @@ type ClientConn interface {
 	// RemoveSubConn removes the SubConn from ClientConn.
 	// The SubConn will be shutdown.
 	RemoveSubConn(SubConn)
+	// UpdateAddresses updates the addresses used in the passed in SubConn.
+	// gRPC checks if the currently connected address is still in the new list.
+	// If so, the connection will be kept. Else, the connection will be
+	// gracefully closed, and a new connection will be created.
+	//
+	// This will trigger a state transition for the SubConn.
+	UpdateAddresses(SubConn, []resolver.Address)
 
 	// UpdateState notifies gRPC that the balancer's internal state has
 	// changed.

--- a/balancer/base/balancer.go
+++ b/balancer/base/balancer.go
@@ -135,7 +135,7 @@ func (b *baseBalancer) UpdateClientConnState(s balancer.ClientConnState) error {
 			// The SubConn does a reflect.DeepEqual of the new and old
 			// addresses. So this is a noop if the current address is the same
 			// as the old one (including attributes).
-			sc.UpdateAddresses([]resolver.Address{a})
+			b.cc.UpdateAddresses(sc, []resolver.Address{a})
 		}
 	}
 	for a, sc := range b.subConns {

--- a/balancer/grpclb/grpclb_remote_balancer.go
+++ b/balancer/grpclb/grpclb_remote_balancer.go
@@ -140,7 +140,7 @@ func (lb *lbBalancer) refreshSubConns(backendAddrs []resolver.Address, fallback 
 			break
 		}
 		if sc != nil {
-			sc.UpdateAddresses(backendAddrs)
+			lb.cc.cc.UpdateAddresses(sc, backendAddrs)
 			sc.Connect()
 			return
 		}

--- a/balancer_conn_wrappers.go
+++ b/balancer_conn_wrappers.go
@@ -168,14 +168,6 @@ func (ccb *ccBalancerWrapper) UpdateAddresses(sc balancer.SubConn, addrs []resol
 	if !ok {
 		return
 	}
-
-	ccb.mu.Lock()
-	if ccb.subConns == nil {
-		ccb.mu.Unlock()
-		return
-	}
-	ccb.mu.Unlock()
-
 	acbw.UpdateAddresses(addrs)
 }
 

--- a/balancer_conn_wrappers.go
+++ b/balancer_conn_wrappers.go
@@ -163,6 +163,22 @@ func (ccb *ccBalancerWrapper) RemoveSubConn(sc balancer.SubConn) {
 	ccb.cc.removeAddrConn(acbw.getAddrConn(), errConnDrain)
 }
 
+func (ccb *ccBalancerWrapper) UpdateAddresses(sc balancer.SubConn, addrs []resolver.Address) {
+	acbw, ok := sc.(*acBalancerWrapper)
+	if !ok {
+		return
+	}
+
+	ccb.mu.Lock()
+	if ccb.subConns == nil {
+		ccb.mu.Unlock()
+		return
+	}
+	ccb.mu.Unlock()
+
+	acbw.UpdateAddresses(addrs)
+}
+
 func (ccb *ccBalancerWrapper) UpdateState(s balancer.State) {
 	ccb.mu.Lock()
 	defer ccb.mu.Unlock()

--- a/pickfirst.go
+++ b/pickfirst.go
@@ -84,7 +84,7 @@ func (b *pickfirstBalancer) UpdateClientConnState(cs balancer.ClientConnState) e
 		b.cc.UpdateState(balancer.State{ConnectivityState: connectivity.Idle, Picker: &picker{result: balancer.PickResult{SubConn: b.sc}}})
 		b.sc.Connect()
 	} else {
-		b.sc.UpdateAddresses(cs.ResolverState.Addresses)
+		b.cc.UpdateAddresses(b.sc, cs.ResolverState.Addresses)
 		b.sc.Connect()
 	}
 	return nil

--- a/xds/internal/testutils/balancer.go
+++ b/xds/internal/testutils/balancer.go
@@ -123,6 +123,9 @@ func (tcc *TestClientConn) RemoveSubConn(sc balancer.SubConn) {
 	}
 }
 
+// UpdateAddresses updates the addresses on the SubConn.
+func (tcc *TestClientConn) UpdateAddresses(sc balancer.SubConn, addrs []resolver.Address) {}
+
 // UpdateState updates connectivity state and picker.
 func (tcc *TestClientConn) UpdateState(bs balancer.State) {
 	tcc.logger.Logf("testClientConn: UpdateState(%v)", bs)


### PR DESCRIPTION
This is the first PR for the set of API changes outlined in https://github.com/grpc/grpc-go/issues/4207.

This PR adds the `UpdateAddresses()` method to the `balancer.ClientConn` interface and changes gRPC code to use the new method instead of similarly named method on the `SubConn` interface.