### PR TITLE
csds: update client resource cache to keep and dump metadata

### DIFF
--- a/xds/internal/client/callback.go
+++ b/xds/internal/client/callback.go
@@ -74,26 +74,50 @@ func (c *clientImpl) callCallback(wiu *watcherInfoWithUpdate) {
 //
 // A response can contain multiple resources. They will be parsed and put in a
 // map from resource name to the resource content.
-func (c *clientImpl) NewListeners(updates map[string]ListenerUpdate) {
+func (c *clientImpl) NewListeners(updates map[string]ListenerUpdate, metadata UpdateMetadata) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
+	if metadata.ErrState != nil {
+		// On NACK, update overall version to the NACKed resp.
+		c.ldsVersion = metadata.ErrState.Version
+		for name := range updates {
+			if _, ok := c.ldsWatchers[name]; ok {
+				// On error, keep previous version for each resource. But update
+				// status and error.
+				mdCopy := c.ldsMD[name]
+				mdCopy.ErrState = metadata.ErrState
+				mdCopy.Status = metadata.Status
+				c.ldsMD[name] = mdCopy
+				// TODO: send the NACK error to the watcher.
+			}
+		}
+		return
+	}
+
+	// If no error received, the status is ACK.
+	c.ldsVersion = metadata.Version
 	for name, update := range updates {
 		if s, ok := c.ldsWatchers[name]; ok {
+			// Only send the update if this is not an error.
 			for wi := range s {
 				wi.newUpdate(update)
 			}
 			// Sync cache.
 			c.logger.Debugf("LDS resource with name %v, value %+v added to cache", name, update)
 			c.ldsCache[name] = update
+			c.ldsMD[name] = metadata
 		}
 	}
+	// Resources not in the new update were removed by the server, so delete
+	// them.
 	for name := range c.ldsCache {
 		if _, ok := updates[name]; !ok {
-			// If resource exists in cache, but not in the new update, delete it
-			// from cache, and also send an resource not found error to indicate
-			// resource removed.
+			// If resource exists in cache, but not in the new update, delete
+			// the resource from cache, and also send an resource not found
+			// error to indicate resource removed.
 			delete(c.ldsCache, name)
+			c.ldsMD[name] = UpdateMetadata{Status: ServiceStatusNotExist}
 			for wi := range c.ldsWatchers[name] {
 				wi.resourceNotFound()
 			}
@@ -109,18 +133,39 @@ func (c *clientImpl) NewListeners(updates map[string]ListenerUpdate) {
 //
 // A response can contain multiple resources. They will be parsed and put in a
 // map from resource name to the resource content.
-func (c *clientImpl) NewRouteConfigs(updates map[string]RouteConfigUpdate) {
+func (c *clientImpl) NewRouteConfigs(updates map[string]RouteConfigUpdate, metadata UpdateMetadata) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
+	if metadata.ErrState != nil {
+		// On NACK, update overall version to the NACKed resp.
+		c.rdsVersion = metadata.ErrState.Version
+		for name := range updates {
+			if _, ok := c.rdsWatchers[name]; ok {
+				// On error, keep previous version for each resource. But update
+				// status and error.
+				mdCopy := c.rdsMD[name]
+				mdCopy.ErrState = metadata.ErrState
+				mdCopy.Status = metadata.Status
+				c.rdsMD[name] = mdCopy
+				// TODO: send the NACK error to the watcher.
+			}
+		}
+		return
+	}
+
+	// If no error received, the status is ACK.
+	c.rdsVersion = metadata.Version
 	for name, update := range updates {
 		if s, ok := c.rdsWatchers[name]; ok {
+			// Only send the update if this is not an error.
 			for wi := range s {
 				wi.newUpdate(update)
 			}
 			// Sync cache.
 			c.logger.Debugf("RDS resource with name %v, value %+v added to cache", name, update)
 			c.rdsCache[name] = update
+			c.rdsMD[name] = metadata
 		}
 	}
 }
@@ -130,26 +175,50 @@ func (c *clientImpl) NewRouteConfigs(updates map[string]RouteConfigUpdate) {
 //
 // A response can contain multiple resources. They will be parsed and put in a
 // map from resource name to the resource content.
-func (c *clientImpl) NewClusters(updates map[string]ClusterUpdate) {
+func (c *clientImpl) NewClusters(updates map[string]ClusterUpdate, metadata UpdateMetadata) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
+	if metadata.ErrState != nil {
+		// On NACK, update overall version to the NACKed resp.
+		c.cdsVersion = metadata.ErrState.Version
+		for name := range updates {
+			if _, ok := c.cdsWatchers[name]; ok {
+				// On error, keep previous version for each resource. But update
+				// status and error.
+				mdCopy := c.cdsMD[name]
+				mdCopy.ErrState = metadata.ErrState
+				mdCopy.Status = metadata.Status
+				c.cdsMD[name] = mdCopy
+				// TODO: send the NACK error to the watcher.
+			}
+		}
+		return
+	}
+
+	// If no error received, the status is ACK.
+	c.cdsVersion = metadata.Version
 	for name, update := range updates {
 		if s, ok := c.cdsWatchers[name]; ok {
+			// Only send the update if this is not an error.
 			for wi := range s {
 				wi.newUpdate(update)
 			}
 			// Sync cache.
 			c.logger.Debugf("CDS resource with name %v, value %+v added to cache", name, update)
 			c.cdsCache[name] = update
+			c.cdsMD[name] = metadata
 		}
 	}
+	// Resources not in the new update were removed by the server, so delete
+	// them.
 	for name := range c.cdsCache {
 		if _, ok := updates[name]; !ok {
 			// If resource exists in cache, but not in the new update, delete it
 			// from cache, and also send an resource not found error to indicate
 			// resource removed.
 			delete(c.cdsCache, name)
+			c.ldsMD[name] = UpdateMetadata{Status: ServiceStatusNotExist}
 			for wi := range c.cdsWatchers[name] {
 				wi.resourceNotFound()
 			}
@@ -165,18 +234,39 @@ func (c *clientImpl) NewClusters(updates map[string]ClusterUpdate) {
 //
 // A response can contain multiple resources. They will be parsed and put in a
 // map from resource name to the resource content.
-func (c *clientImpl) NewEndpoints(updates map[string]EndpointsUpdate) {
+func (c *clientImpl) NewEndpoints(updates map[string]EndpointsUpdate, metadata UpdateMetadata) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
+	if metadata.ErrState != nil {
+		// On NACK, update overall version to the NACKed resp.
+		c.edsVersion = metadata.ErrState.Version
+		for name := range updates {
+			if _, ok := c.edsWatchers[name]; ok {
+				// On error, keep previous version for each resource. But update
+				// status and error.
+				mdCopy := c.edsMD[name]
+				mdCopy.ErrState = metadata.ErrState
+				mdCopy.Status = metadata.Status
+				c.edsMD[name] = mdCopy
+				// TODO: send the NACK error to the watcher.
+			}
+		}
+		return
+	}
+
+	// If no error received, the status is ACK.
+	c.edsVersion = metadata.Version
 	for name, update := range updates {
 		if s, ok := c.edsWatchers[name]; ok {
+			// Only send the update if this is not an error.
 			for wi := range s {
 				wi.newUpdate(update)
 			}
 			// Sync cache.
 			c.logger.Debugf("EDS resource with name %v, value %+v added to cache", name, update)
 			c.edsCache[name] = update
+			c.edsMD[name] = metadata
 		}
 	}
 }

--- a/xds/internal/client/cds_test.go
+++ b/xds/internal/client/cds_test.go
@@ -685,7 +685,7 @@ func (s) TestUnmarshalCluster(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			update, err := UnmarshalCluster(test.resources, nil)
+			update, _, err := UnmarshalCluster("", test.resources, nil)
 			if ((err != nil) != test.wantErr) || !cmp.Equal(update, test.wantUpdate, cmpopts.EquateEmpty()) {
 				t.Errorf("UnmarshalCluster(%v) = (%+v, %v) want (%+v, %v)", test.resources, update, err, test.wantUpdate, test.wantErr)
 			}

--- a/xds/internal/client/client.go
+++ b/xds/internal/client/client.go
@@ -372,46 +372,6 @@ var newAPIClient = func(apiVersion version.TransportAPI, cc *grpc.ClientConn, op
 	return cb.Build(cc, opts)
 }
 
-// LDSUpdateWithMD contains the LDSUpdate and metadata, including version, raw
-// message, timestamp.
-//
-// This is to be used for config dump and CSDS, not directly by users (like
-// resolvers/balancers).
-type LDSUpdateWithMD struct {
-	MD  UpdateMetadata
-	Raw *anypb.Any
-}
-
-// RDSUpdateWithMD contains the RDSUpdate and metadata, including version, raw
-// message, timestamp.
-//
-// This is to be used for config dump and CSDS, not directly by users (like
-// resolvers/balancers).
-type RDSUpdateWithMD struct {
-	MD  UpdateMetadata
-	Raw *anypb.Any
-}
-
-// CDSUpdateWithMD contains the CDSUpdate and metadata, including version, raw
-// message, timestamp.
-//
-// This is to be used for config dump and CSDS, not directly by users (like
-// resolvers/balancers).
-type CDSUpdateWithMD struct {
-	MD  UpdateMetadata
-	Raw *anypb.Any
-}
-
-// EDSUpdateWithMD contains the EDSUpdate and metadata, including version, raw
-// message, timestamp.
-//
-// This is to be used for config dump and CSDS, not directly by users (like
-// resolvers/balancers).
-type EDSUpdateWithMD struct {
-	MD  UpdateMetadata
-	Raw *anypb.Any
-}
-
 // clientImpl is the real implementation of the xds client. The exported Client
 // is a wrapper of this struct with a ref count.
 //

--- a/xds/internal/client/client.go
+++ b/xds/internal/client/client.go
@@ -30,7 +30,7 @@ import (
 	v2corepb "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	v3corepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	"github.com/golang/protobuf/proto"
-	anypb "github.com/golang/protobuf/ptypes/any"
+	"google.golang.org/protobuf/types/known/anypb"
 
 	"google.golang.org/grpc/xds/internal/client/load"
 
@@ -143,7 +143,6 @@ type UpdateHandler interface {
 // ServiceStatus is the status of the update.
 type ServiceStatus int
 
-// Version agnostic resource type constants.
 const (
 	ServiceStatusUnknown ServiceStatus = iota
 	ServiceStatusRequested
@@ -169,8 +168,9 @@ type UpdateMetadata struct {
 	// Status is the status of this resource, e.g. ACKed, NACKed, or
 	// Not_exist(removed).
 	Status ServiceStatus
-	// Version is the version of the xds response. In the future, we may add a
-	// field for different versions of each resource in the same xds response.
+	// Version is the version of the xds response. Note that this is the version
+	// of the resource in use (previous ACKed). If a response is NACKed, the
+	// NACKed version is in ErrState.
 	Version string
 	// Timestamp is when the response is received.
 	Timestamp time.Time

--- a/xds/internal/client/client.go
+++ b/xds/internal/client/client.go
@@ -164,7 +164,7 @@ type UpdateErrorMetadata struct {
 }
 
 // UpdateMetadata contains the metadata for each update, including timestamp,
-// version, and so on.
+// raw message, and so on.
 type UpdateMetadata struct {
 	// Status is the status of this resource, e.g. ACKed, NACKed, or
 	// Not_exist(removed).
@@ -361,6 +361,46 @@ var newAPIClient = func(apiVersion version.TransportAPI, cc *grpc.ClientConn, op
 		return nil, fmt.Errorf("no client builder for xDS API version: %v", apiVersion)
 	}
 	return cb.Build(cc, opts)
+}
+
+// LDSUpdateWithMD contains the LDSUpdate and metadata, including version, raw
+// message, timestamp.
+//
+// This is to be used for config dump and CSDS, not directly by users (like
+// resolvers/balancers).
+type LDSUpdateWithMD struct {
+	Update ListenerUpdate
+	MD     UpdateMetadata
+}
+
+// RDSUpdateWithMD contains the RDSUpdate and metadata, including version, raw
+// message, timestamp.
+//
+// This is to be used for config dump and CSDS, not directly by users (like
+// resolvers/balancers).
+type RDSUpdateWithMD struct {
+	Update RouteConfigUpdate
+	MD     UpdateMetadata
+}
+
+// CDSUpdateWithMD contains the CDSUpdate and metadata, including version, raw
+// message, timestamp.
+//
+// This is to be used for config dump and CSDS, not directly by users (like
+// resolvers/balancers).
+type CDSUpdateWithMD struct {
+	Update ClusterUpdate
+	MD     UpdateMetadata
+}
+
+// EDSUpdateWithMD contains the EDSUpdate and metadata, including version, raw
+// message, timestamp.
+//
+// This is to be used for config dump and CSDS, not directly by users (like
+// resolvers/balancers).
+type EDSUpdateWithMD struct {
+	Update EndpointsUpdate
+	MD     UpdateMetadata
 }
 
 // clientImpl is the real implementation of the xds client. The exported Client

--- a/xds/internal/client/client.go
+++ b/xds/internal/client/client.go
@@ -394,19 +394,19 @@ type clientImpl struct {
 	// And CSDS handler can be implemented directly by the cache.
 	mu          sync.Mutex
 	ldsWatchers map[string]map[*watchInfo]bool
-	ldsVersion  string
+	ldsVersion  string // Only used in CSDS.
 	ldsCache    map[string]ListenerUpdate
 	ldsMD       map[string]UpdateMetadata
 	rdsWatchers map[string]map[*watchInfo]bool
-	rdsVersion  string
+	rdsVersion  string // Only used in CSDS.
 	rdsCache    map[string]RouteConfigUpdate
 	rdsMD       map[string]UpdateMetadata
 	cdsWatchers map[string]map[*watchInfo]bool
-	cdsVersion  string
+	cdsVersion  string // Only used in CSDS.
 	cdsCache    map[string]ClusterUpdate
 	cdsMD       map[string]UpdateMetadata
 	edsWatchers map[string]map[*watchInfo]bool
-	edsVersion  string
+	edsVersion  string // Only used in CSDS.
 	edsCache    map[string]EndpointsUpdate
 	edsMD       map[string]UpdateMetadata
 

--- a/xds/internal/client/client_test.go
+++ b/xds/internal/client/client_test.go
@@ -159,13 +159,13 @@ func (s) TestWatchCallAnotherWatch(t *testing.T) {
 	}
 
 	wantUpdate := ClusterUpdate{ServiceName: testEDSName}
-	client.NewClusters(map[string]ClusterUpdate{testCDSName: wantUpdate})
+	client.NewClusters(map[string]ClusterUpdate{testCDSName: wantUpdate}, UpdateMetadata{})
 	if err := verifyClusterUpdate(ctx, clusterUpdateCh, wantUpdate); err != nil {
 		t.Fatal(err)
 	}
 
 	wantUpdate2 := ClusterUpdate{ServiceName: testEDSName + "2"}
-	client.NewClusters(map[string]ClusterUpdate{testCDSName: wantUpdate2})
+	client.NewClusters(map[string]ClusterUpdate{testCDSName: wantUpdate2}, UpdateMetadata{})
 	if err := verifyClusterUpdate(ctx, clusterUpdateCh, wantUpdate2); err != nil {
 		t.Fatal(err)
 	}

--- a/xds/internal/client/client_test.go
+++ b/xds/internal/client/client_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"google.golang.org/grpc/internal/grpcsync"
+	"google.golang.org/protobuf/testing/protocmp"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -56,6 +57,20 @@ const (
 	defaultTestWatchExpiryTimeout = 500 * time.Millisecond
 	defaultTestTimeout            = 5 * time.Second
 	defaultTestShortTimeout       = 10 * time.Millisecond // For events expected to *not* happen.
+)
+
+var (
+	cmpOpts = cmp.Options{
+		cmpopts.EquateEmpty(),
+		cmp.Comparer(func(a, b time.Time) bool { return true }),
+		cmp.Comparer(func(x, y error) bool {
+			if x == nil || y == nil {
+				return x == nil && y == nil
+			}
+			return x.Error() == y.Error()
+		}),
+		protocmp.Transform(),
+	}
 )
 
 func clientOpts(balancerName string, overrideWatchExpiryTimeout bool) (*bootstrap.Config, time.Duration) {

--- a/xds/internal/client/dump.go
+++ b/xds/internal/client/dump.go
@@ -25,8 +25,8 @@ func (c *clientImpl) DumpLDS() (version string, _ map[string]LDSUpdateWithMD) {
 	ret := make(map[string]LDSUpdateWithMD, len(c.ldsMD))
 	for s, md := range c.ldsMD {
 		ret[s] = LDSUpdateWithMD{
-			Update: c.ldsCache[s],
-			MD:     md,
+			MD:  md,
+			Raw: c.ldsCache[s].Raw,
 		}
 	}
 	return c.ldsVersion, ret
@@ -39,8 +39,8 @@ func (c *clientImpl) DumpRDS() (version string, _ map[string]RDSUpdateWithMD) {
 	ret := make(map[string]RDSUpdateWithMD, len(c.rdsMD))
 	for s, md := range c.rdsMD {
 		ret[s] = RDSUpdateWithMD{
-			Update: c.rdsCache[s],
-			MD:     md,
+			MD:  md,
+			Raw: c.rdsCache[s].Raw,
 		}
 	}
 	return c.rdsVersion, ret
@@ -53,8 +53,8 @@ func (c *clientImpl) DumpCDS() (version string, _ map[string]CDSUpdateWithMD) {
 	ret := make(map[string]CDSUpdateWithMD, len(c.cdsMD))
 	for s, md := range c.cdsMD {
 		ret[s] = CDSUpdateWithMD{
-			Update: c.cdsCache[s],
-			MD:     md,
+			MD:  md,
+			Raw: c.cdsCache[s].Raw,
 		}
 	}
 	return c.cdsVersion, ret
@@ -67,8 +67,8 @@ func (c *clientImpl) DumpEDS() (version string, _ map[string]EDSUpdateWithMD) {
 	ret := make(map[string]EDSUpdateWithMD, len(c.edsMD))
 	for s, md := range c.edsMD {
 		ret[s] = EDSUpdateWithMD{
-			Update: c.edsCache[s],
-			MD:     md,
+			MD:  md,
+			Raw: c.edsCache[s].Raw,
 		}
 	}
 	return c.edsVersion, ret

--- a/xds/internal/client/dump.go
+++ b/xds/internal/client/dump.go
@@ -18,58 +18,105 @@
 
 package client
 
-// DumpLDS returns the status and contents of LDS.
-func (c *clientImpl) DumpLDS() (version string, _ map[string]LDSUpdateWithMD) {
+import anypb "github.com/golang/protobuf/ptypes/any"
+
+// UpdateWithMD contains the raw message of the update and the metadata,
+// including version, raw message, timestamp.
+//
+// This is to be used for config dump and CSDS, not directly by users (like
+// resolvers/balancers).
+type UpdateWithMD struct {
+	MD  UpdateMetadata
+	Raw *anypb.Any
+}
+
+func rawFromCache(s string, cache interface{}) *anypb.Any {
+	switch c := cache.(type) {
+	case map[string]ListenerUpdate:
+		v, ok := c[s]
+		if !ok {
+			return nil
+		}
+		return v.Raw
+	case map[string]RouteConfigUpdate:
+		v, ok := c[s]
+		if !ok {
+			return nil
+		}
+		return v.Raw
+	case map[string]ClusterUpdate:
+		v, ok := c[s]
+		if !ok {
+			return nil
+		}
+		return v.Raw
+	case map[string]EndpointsUpdate:
+		v, ok := c[s]
+		if !ok {
+			return nil
+		}
+		return v.Raw
+	default:
+		return nil
+	}
+}
+
+func (c *clientImpl) dump(t ResourceType) (version string, _ map[string]UpdateWithMD) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	ret := make(map[string]LDSUpdateWithMD, len(c.ldsMD))
-	for s, md := range c.ldsMD {
-		ret[s] = LDSUpdateWithMD{
+
+	var (
+		md    map[string]UpdateMetadata
+		cache interface{}
+	)
+	switch t {
+	case ListenerResource:
+		version = c.ldsVersion
+		md = c.ldsMD
+		cache = c.ldsCache
+	case RouteConfigResource:
+		version = c.rdsVersion
+		md = c.rdsMD
+		cache = c.rdsCache
+	case ClusterResource:
+		version = c.cdsVersion
+		md = c.cdsMD
+		cache = c.cdsCache
+	case EndpointsResource:
+		version = c.edsVersion
+		md = c.edsMD
+		cache = c.edsCache
+	default:
+		c.logger.Errorf("dumping resource of unknown type: %v", t)
+		return "", nil
+	}
+
+	ret := make(map[string]UpdateWithMD, len(md))
+	for s, md := range md {
+		ret[s] = UpdateWithMD{
 			MD:  md,
-			Raw: c.ldsCache[s].Raw,
+			Raw: rawFromCache(s, cache),
 		}
 	}
-	return c.ldsVersion, ret
+	return version, ret
+}
+
+// DumpLDS returns the status and contents of LDS.
+func (c *clientImpl) DumpLDS() (version string, _ map[string]UpdateWithMD) {
+	return c.dump(ListenerResource)
 }
 
 // DumpRDS returns the status and contents of RDS.
-func (c *clientImpl) DumpRDS() (version string, _ map[string]RDSUpdateWithMD) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	ret := make(map[string]RDSUpdateWithMD, len(c.rdsMD))
-	for s, md := range c.rdsMD {
-		ret[s] = RDSUpdateWithMD{
-			MD:  md,
-			Raw: c.rdsCache[s].Raw,
-		}
-	}
-	return c.rdsVersion, ret
+func (c *clientImpl) DumpRDS() (version string, _ map[string]UpdateWithMD) {
+	return c.dump(RouteConfigResource)
 }
 
 // DumpCDS returns the status and contents of CDS.
-func (c *clientImpl) DumpCDS() (version string, _ map[string]CDSUpdateWithMD) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	ret := make(map[string]CDSUpdateWithMD, len(c.cdsMD))
-	for s, md := range c.cdsMD {
-		ret[s] = CDSUpdateWithMD{
-			MD:  md,
-			Raw: c.cdsCache[s].Raw,
-		}
-	}
-	return c.cdsVersion, ret
+func (c *clientImpl) DumpCDS() (version string, _ map[string]UpdateWithMD) {
+	return c.dump(ClusterResource)
 }
 
 // DumpEDS returns the status and contents of EDS.
-func (c *clientImpl) DumpEDS() (version string, _ map[string]EDSUpdateWithMD) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	ret := make(map[string]EDSUpdateWithMD, len(c.edsMD))
-	for s, md := range c.edsMD {
-		ret[s] = EDSUpdateWithMD{
-			MD:  md,
-			Raw: c.edsCache[s].Raw,
-		}
-	}
-	return c.edsVersion, ret
+func (c *clientImpl) DumpEDS() (version string, _ map[string]UpdateWithMD) {
+	return c.dump(EndpointsResource)
 }

--- a/xds/internal/client/dump.go
+++ b/xds/internal/client/dump.go
@@ -61,13 +61,14 @@ func rawFromCache(s string, cache interface{}) *anypb.Any {
 	}
 }
 
-func (c *clientImpl) dump(t ResourceType) (version string, _ map[string]UpdateWithMD) {
+func (c *clientImpl) dump(t ResourceType) (string, map[string]UpdateWithMD) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
 	var (
-		md    map[string]UpdateMetadata
-		cache interface{}
+		version string
+		md      map[string]UpdateMetadata
+		cache   interface{}
 	)
 	switch t {
 	case ListenerResource:
@@ -102,21 +103,21 @@ func (c *clientImpl) dump(t ResourceType) (version string, _ map[string]UpdateWi
 }
 
 // DumpLDS returns the status and contents of LDS.
-func (c *clientImpl) DumpLDS() (version string, _ map[string]UpdateWithMD) {
+func (c *clientImpl) DumpLDS() (string, map[string]UpdateWithMD) {
 	return c.dump(ListenerResource)
 }
 
 // DumpRDS returns the status and contents of RDS.
-func (c *clientImpl) DumpRDS() (version string, _ map[string]UpdateWithMD) {
+func (c *clientImpl) DumpRDS() (string, map[string]UpdateWithMD) {
 	return c.dump(RouteConfigResource)
 }
 
 // DumpCDS returns the status and contents of CDS.
-func (c *clientImpl) DumpCDS() (version string, _ map[string]UpdateWithMD) {
+func (c *clientImpl) DumpCDS() (string, map[string]UpdateWithMD) {
 	return c.dump(ClusterResource)
 }
 
 // DumpEDS returns the status and contents of EDS.
-func (c *clientImpl) DumpEDS() (version string, _ map[string]UpdateWithMD) {
+func (c *clientImpl) DumpEDS() (string, map[string]UpdateWithMD) {
 	return c.dump(EndpointsResource)
 }

--- a/xds/internal/client/dump.go
+++ b/xds/internal/client/dump.go
@@ -1,0 +1,75 @@
+/*
+ *
+ * Copyright 2021 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package client
+
+// DumpLDS returns the status and contents of LDS.
+func (c *clientImpl) DumpLDS() (version string, _ map[string]LDSUpdateWithMD) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	ret := make(map[string]LDSUpdateWithMD, len(c.ldsMD))
+	for s, md := range c.ldsMD {
+		ret[s] = LDSUpdateWithMD{
+			Update: c.ldsCache[s],
+			MD:     md,
+		}
+	}
+	return c.ldsVersion, ret
+}
+
+// DumpRDS returns the status and contents of RDS.
+func (c *clientImpl) DumpRDS() (version string, _ map[string]RDSUpdateWithMD) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	ret := make(map[string]RDSUpdateWithMD, len(c.rdsMD))
+	for s, md := range c.rdsMD {
+		ret[s] = RDSUpdateWithMD{
+			Update: c.rdsCache[s],
+			MD:     md,
+		}
+	}
+	return c.rdsVersion, ret
+}
+
+// DumpCDS returns the status and contents of CDS.
+func (c *clientImpl) DumpCDS() (version string, _ map[string]CDSUpdateWithMD) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	ret := make(map[string]CDSUpdateWithMD, len(c.cdsMD))
+	for s, md := range c.cdsMD {
+		ret[s] = CDSUpdateWithMD{
+			Update: c.cdsCache[s],
+			MD:     md,
+		}
+	}
+	return c.cdsVersion, ret
+}
+
+// DumpEDS returns the status and contents of EDS.
+func (c *clientImpl) DumpEDS() (version string, _ map[string]EDSUpdateWithMD) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	ret := make(map[string]EDSUpdateWithMD, len(c.edsMD))
+	for s, md := range c.edsMD {
+		ret[s] = EDSUpdateWithMD{
+			Update: c.edsCache[s],
+			MD:     md,
+		}
+	}
+	return c.edsVersion, ret
+}

--- a/xds/internal/client/dump_test.go
+++ b/xds/internal/client/dump_test.go
@@ -78,22 +78,22 @@ func (s) TestLDSConfigDump(t *testing.T) {
 	defer client.Close()
 
 	// Expected unknown.
-	compareDump(t, client.DumpLDS, "", map[string]LDSUpdateWithMD{})
+	compareDump(t, client.DumpLDS, "", map[string]UpdateWithMD{})
 
-	wantRequested := make(map[string]LDSUpdateWithMD)
+	wantRequested := make(map[string]UpdateWithMD)
 	for _, n := range ldsTargets {
 		cancel := client.WatchListener(n, func(update ListenerUpdate, err error) {})
 		defer cancel()
-		wantRequested[n] = LDSUpdateWithMD{MD: UpdateMetadata{Status: ServiceStatusRequested}}
+		wantRequested[n] = UpdateWithMD{MD: UpdateMetadata{Status: ServiceStatusRequested}}
 	}
 	// Expected requested.
 	compareDump(t, client.DumpLDS, "", wantRequested)
 
 	update0 := make(map[string]ListenerUpdate)
-	want0 := make(map[string]LDSUpdateWithMD)
+	want0 := make(map[string]UpdateWithMD)
 	for n, r := range listenerRaws {
 		update0[n] = ListenerUpdate{Raw: r}
-		want0[n] = LDSUpdateWithMD{
+		want0[n] = UpdateWithMD{
 			MD:  UpdateMetadata{Version: testVersion},
 			Raw: r,
 		}
@@ -118,10 +118,10 @@ func (s) TestLDSConfigDump(t *testing.T) {
 	)
 
 	// Expect NACK for [0], but old ACK for [1].
-	wantDump := make(map[string]LDSUpdateWithMD)
+	wantDump := make(map[string]UpdateWithMD)
 	// Though resource 0 was NACKed, the dump should show the previous ACKed raw
 	// message, as well as the NACK error.
-	wantDump[ldsTargets[0]] = LDSUpdateWithMD{
+	wantDump[ldsTargets[0]] = UpdateWithMD{
 		MD: UpdateMetadata{
 			Version: testVersion,
 			ErrState: &UpdateErrorMetadata{
@@ -132,7 +132,7 @@ func (s) TestLDSConfigDump(t *testing.T) {
 		Raw: listenerRaws[ldsTargets[0]],
 	}
 
-	wantDump[ldsTargets[1]] = LDSUpdateWithMD{
+	wantDump[ldsTargets[1]] = UpdateWithMD{
 		MD:  UpdateMetadata{Version: testVersion},
 		Raw: listenerRaws[ldsTargets[1]],
 	}
@@ -180,22 +180,22 @@ func (s) TestRDSConfigDump(t *testing.T) {
 	defer client.Close()
 
 	// Expected unknown.
-	compareDump(t, client.DumpRDS, "", map[string]RDSUpdateWithMD{})
+	compareDump(t, client.DumpRDS, "", map[string]UpdateWithMD{})
 
-	wantRequested := make(map[string]RDSUpdateWithMD)
+	wantRequested := make(map[string]UpdateWithMD)
 	for _, n := range rdsTargets {
 		cancel := client.WatchRouteConfig(n, func(update RouteConfigUpdate, err error) {})
 		defer cancel()
-		wantRequested[n] = RDSUpdateWithMD{MD: UpdateMetadata{Status: ServiceStatusRequested}}
+		wantRequested[n] = UpdateWithMD{MD: UpdateMetadata{Status: ServiceStatusRequested}}
 	}
 	// Expected requested.
 	compareDump(t, client.DumpRDS, "", wantRequested)
 
 	update0 := make(map[string]RouteConfigUpdate)
-	want0 := make(map[string]RDSUpdateWithMD)
+	want0 := make(map[string]UpdateWithMD)
 	for n, r := range routeRaws {
 		update0[n] = RouteConfigUpdate{Raw: r}
-		want0[n] = RDSUpdateWithMD{
+		want0[n] = UpdateWithMD{
 			MD:  UpdateMetadata{Version: testVersion},
 			Raw: r,
 		}
@@ -220,10 +220,10 @@ func (s) TestRDSConfigDump(t *testing.T) {
 	)
 
 	// Expect NACK for [0], but old ACK for [1].
-	wantDump := make(map[string]RDSUpdateWithMD)
+	wantDump := make(map[string]UpdateWithMD)
 	// Though resource 0 was NACKed, the dump should show the previous ACKed raw
 	// message, as well as the NACK error.
-	wantDump[rdsTargets[0]] = RDSUpdateWithMD{
+	wantDump[rdsTargets[0]] = UpdateWithMD{
 		MD: UpdateMetadata{
 			Version: testVersion,
 			ErrState: &UpdateErrorMetadata{
@@ -233,7 +233,7 @@ func (s) TestRDSConfigDump(t *testing.T) {
 		},
 		Raw: routeRaws[rdsTargets[0]],
 	}
-	wantDump[rdsTargets[1]] = RDSUpdateWithMD{
+	wantDump[rdsTargets[1]] = UpdateWithMD{
 		MD:  UpdateMetadata{Version: testVersion},
 		Raw: routeRaws[rdsTargets[1]],
 	}
@@ -282,22 +282,22 @@ func (s) TestCDSConfigDump(t *testing.T) {
 	defer client.Close()
 
 	// Expected unknown.
-	compareDump(t, client.DumpCDS, "", map[string]CDSUpdateWithMD{})
+	compareDump(t, client.DumpCDS, "", map[string]UpdateWithMD{})
 
-	wantRequested := make(map[string]CDSUpdateWithMD)
+	wantRequested := make(map[string]UpdateWithMD)
 	for _, n := range cdsTargets {
 		cancel := client.WatchCluster(n, func(update ClusterUpdate, err error) {})
 		defer cancel()
-		wantRequested[n] = CDSUpdateWithMD{MD: UpdateMetadata{Status: ServiceStatusRequested}}
+		wantRequested[n] = UpdateWithMD{MD: UpdateMetadata{Status: ServiceStatusRequested}}
 	}
 	// Expected requested.
 	compareDump(t, client.DumpCDS, "", wantRequested)
 
 	update0 := make(map[string]ClusterUpdate)
-	want0 := make(map[string]CDSUpdateWithMD)
+	want0 := make(map[string]UpdateWithMD)
 	for n, r := range clusterRaws {
 		update0[n] = ClusterUpdate{Raw: r}
-		want0[n] = CDSUpdateWithMD{
+		want0[n] = UpdateWithMD{
 			MD:  UpdateMetadata{Version: testVersion},
 			Raw: r,
 		}
@@ -322,10 +322,10 @@ func (s) TestCDSConfigDump(t *testing.T) {
 	)
 
 	// Expect NACK for [0], but old ACK for [1].
-	wantDump := make(map[string]CDSUpdateWithMD)
+	wantDump := make(map[string]UpdateWithMD)
 	// Though resource 0 was NACKed, the dump should show the previous ACKed raw
 	// message, as well as the NACK error.
-	wantDump[cdsTargets[0]] = CDSUpdateWithMD{
+	wantDump[cdsTargets[0]] = UpdateWithMD{
 		MD: UpdateMetadata{
 			Version: testVersion,
 			ErrState: &UpdateErrorMetadata{
@@ -335,7 +335,7 @@ func (s) TestCDSConfigDump(t *testing.T) {
 		},
 		Raw: clusterRaws[cdsTargets[0]],
 	}
-	wantDump[cdsTargets[1]] = CDSUpdateWithMD{
+	wantDump[cdsTargets[1]] = UpdateWithMD{
 		MD:  UpdateMetadata{Version: testVersion},
 		Raw: clusterRaws[cdsTargets[1]],
 	}
@@ -370,22 +370,22 @@ func (s) TestEDSConfigDump(t *testing.T) {
 	defer client.Close()
 
 	// Expected unknown.
-	compareDump(t, client.DumpEDS, "", map[string]EDSUpdateWithMD{})
+	compareDump(t, client.DumpEDS, "", map[string]UpdateWithMD{})
 
-	wantRequested := make(map[string]EDSUpdateWithMD)
+	wantRequested := make(map[string]UpdateWithMD)
 	for _, n := range edsTargets {
 		cancel := client.WatchEndpoints(n, func(update EndpointsUpdate, err error) {})
 		defer cancel()
-		wantRequested[n] = EDSUpdateWithMD{MD: UpdateMetadata{Status: ServiceStatusRequested}}
+		wantRequested[n] = UpdateWithMD{MD: UpdateMetadata{Status: ServiceStatusRequested}}
 	}
 	// Expected requested.
 	compareDump(t, client.DumpEDS, "", wantRequested)
 
 	update0 := make(map[string]EndpointsUpdate)
-	want0 := make(map[string]EDSUpdateWithMD)
+	want0 := make(map[string]UpdateWithMD)
 	for n, r := range endpointRaws {
 		update0[n] = EndpointsUpdate{Raw: r}
-		want0[n] = EDSUpdateWithMD{
+		want0[n] = UpdateWithMD{
 			MD:  UpdateMetadata{Version: testVersion},
 			Raw: r,
 		}
@@ -410,10 +410,10 @@ func (s) TestEDSConfigDump(t *testing.T) {
 	)
 
 	// Expect NACK for [0], but old ACK for [1].
-	wantDump := make(map[string]EDSUpdateWithMD)
+	wantDump := make(map[string]UpdateWithMD)
 	// Though resource 0 was NACKed, the dump should show the previous ACKed raw
 	// message, as well as the NACK error.
-	wantDump[edsTargets[0]] = EDSUpdateWithMD{
+	wantDump[edsTargets[0]] = UpdateWithMD{
 		MD: UpdateMetadata{
 			Version: testVersion,
 			ErrState: &UpdateErrorMetadata{
@@ -423,30 +423,17 @@ func (s) TestEDSConfigDump(t *testing.T) {
 		},
 		Raw: endpointRaws[edsTargets[0]],
 	}
-	wantDump[edsTargets[1]] = EDSUpdateWithMD{
+	wantDump[edsTargets[1]] = UpdateWithMD{
 		MD:  UpdateMetadata{Version: testVersion},
 		Raw: endpointRaws[edsTargets[1]],
 	}
 	compareDump(t, client.DumpEDS, nackVersion, wantDump)
 }
 
-func compareDump(t *testing.T, dumpFunc interface{}, wantVersion string, wantDump interface{}) {
+func compareDump(t *testing.T, dumpFunc func() (string, map[string]UpdateWithMD), wantVersion string, wantDump interface{}) {
 	t.Helper()
 
-	var (
-		v    string
-		dump interface{}
-	)
-	switch dumpFuncT := dumpFunc.(type) {
-	case func() (string, map[string]LDSUpdateWithMD):
-		v, dump = dumpFuncT()
-	case func() (string, map[string]RDSUpdateWithMD):
-		v, dump = dumpFuncT()
-	case func() (string, map[string]CDSUpdateWithMD):
-		v, dump = dumpFuncT()
-	case func() (string, map[string]EDSUpdateWithMD):
-		v, dump = dumpFuncT()
-	}
+	v, dump := dumpFunc()
 	if v != wantVersion {
 		t.Fatalf("Dump returned version %q, want %q", v, wantVersion)
 	}

--- a/xds/internal/client/dump_test.go
+++ b/xds/internal/client/dump_test.go
@@ -78,7 +78,9 @@ func (s) TestLDSConfigDump(t *testing.T) {
 	defer client.Close()
 
 	// Expected unknown.
-	compareDump(t, client.DumpLDS, "", map[string]UpdateWithMD{})
+	if err := compareDump(client.DumpLDS, "", map[string]UpdateWithMD{}); err != nil {
+		t.Fatalf(err.Error())
+	}
 
 	wantRequested := make(map[string]UpdateWithMD)
 	for _, n := range ldsTargets {
@@ -87,7 +89,9 @@ func (s) TestLDSConfigDump(t *testing.T) {
 		wantRequested[n] = UpdateWithMD{MD: UpdateMetadata{Status: ServiceStatusRequested}}
 	}
 	// Expected requested.
-	compareDump(t, client.DumpLDS, "", wantRequested)
+	if err := compareDump(client.DumpLDS, "", wantRequested); err != nil {
+		t.Fatalf(err.Error())
+	}
 
 	update0 := make(map[string]ListenerUpdate)
 	want0 := make(map[string]UpdateWithMD)
@@ -101,7 +105,9 @@ func (s) TestLDSConfigDump(t *testing.T) {
 	client.NewListeners(update0, UpdateMetadata{Version: testVersion})
 
 	// Expect ACK.
-	compareDump(t, client.DumpLDS, testVersion, want0)
+	if err := compareDump(client.DumpLDS, testVersion, want0); err != nil {
+		t.Fatalf(err.Error())
+	}
 
 	const nackVersion = "lds-version-nack"
 	var nackErr = fmt.Errorf("lds nack error")
@@ -136,7 +142,9 @@ func (s) TestLDSConfigDump(t *testing.T) {
 		MD:  UpdateMetadata{Version: testVersion},
 		Raw: listenerRaws[ldsTargets[1]],
 	}
-	compareDump(t, client.DumpLDS, nackVersion, wantDump)
+	if err := compareDump(client.DumpLDS, nackVersion, wantDump); err != nil {
+		t.Fatalf(err.Error())
+	}
 }
 
 func (s) TestRDSConfigDump(t *testing.T) {
@@ -180,7 +188,9 @@ func (s) TestRDSConfigDump(t *testing.T) {
 	defer client.Close()
 
 	// Expected unknown.
-	compareDump(t, client.DumpRDS, "", map[string]UpdateWithMD{})
+	if err := compareDump(client.DumpRDS, "", map[string]UpdateWithMD{}); err != nil {
+		t.Fatalf(err.Error())
+	}
 
 	wantRequested := make(map[string]UpdateWithMD)
 	for _, n := range rdsTargets {
@@ -189,7 +199,9 @@ func (s) TestRDSConfigDump(t *testing.T) {
 		wantRequested[n] = UpdateWithMD{MD: UpdateMetadata{Status: ServiceStatusRequested}}
 	}
 	// Expected requested.
-	compareDump(t, client.DumpRDS, "", wantRequested)
+	if err := compareDump(client.DumpRDS, "", wantRequested); err != nil {
+		t.Fatalf(err.Error())
+	}
 
 	update0 := make(map[string]RouteConfigUpdate)
 	want0 := make(map[string]UpdateWithMD)
@@ -203,7 +215,9 @@ func (s) TestRDSConfigDump(t *testing.T) {
 	client.NewRouteConfigs(update0, UpdateMetadata{Version: testVersion})
 
 	// Expect ACK.
-	compareDump(t, client.DumpRDS, testVersion, want0)
+	if err := compareDump(client.DumpRDS, testVersion, want0); err != nil {
+		t.Fatalf(err.Error())
+	}
 
 	const nackVersion = "rds-version-nack"
 	var nackErr = fmt.Errorf("rds nack error")
@@ -237,7 +251,9 @@ func (s) TestRDSConfigDump(t *testing.T) {
 		MD:  UpdateMetadata{Version: testVersion},
 		Raw: routeRaws[rdsTargets[1]],
 	}
-	compareDump(t, client.DumpRDS, nackVersion, wantDump)
+	if err := compareDump(client.DumpRDS, nackVersion, wantDump); err != nil {
+		t.Fatalf(err.Error())
+	}
 }
 
 func (s) TestCDSConfigDump(t *testing.T) {
@@ -282,7 +298,9 @@ func (s) TestCDSConfigDump(t *testing.T) {
 	defer client.Close()
 
 	// Expected unknown.
-	compareDump(t, client.DumpCDS, "", map[string]UpdateWithMD{})
+	if err := compareDump(client.DumpCDS, "", map[string]UpdateWithMD{}); err != nil {
+		t.Fatalf(err.Error())
+	}
 
 	wantRequested := make(map[string]UpdateWithMD)
 	for _, n := range cdsTargets {
@@ -291,7 +309,9 @@ func (s) TestCDSConfigDump(t *testing.T) {
 		wantRequested[n] = UpdateWithMD{MD: UpdateMetadata{Status: ServiceStatusRequested}}
 	}
 	// Expected requested.
-	compareDump(t, client.DumpCDS, "", wantRequested)
+	if err := compareDump(client.DumpCDS, "", wantRequested); err != nil {
+		t.Fatalf(err.Error())
+	}
 
 	update0 := make(map[string]ClusterUpdate)
 	want0 := make(map[string]UpdateWithMD)
@@ -305,7 +325,9 @@ func (s) TestCDSConfigDump(t *testing.T) {
 	client.NewClusters(update0, UpdateMetadata{Version: testVersion})
 
 	// Expect ACK.
-	compareDump(t, client.DumpCDS, testVersion, want0)
+	if err := compareDump(client.DumpCDS, testVersion, want0); err != nil {
+		t.Fatalf(err.Error())
+	}
 
 	const nackVersion = "cds-version-nack"
 	var nackErr = fmt.Errorf("cds nack error")
@@ -339,7 +361,9 @@ func (s) TestCDSConfigDump(t *testing.T) {
 		MD:  UpdateMetadata{Version: testVersion},
 		Raw: clusterRaws[cdsTargets[1]],
 	}
-	compareDump(t, client.DumpCDS, nackVersion, wantDump)
+	if err := compareDump(client.DumpCDS, nackVersion, wantDump); err != nil {
+		t.Fatalf(err.Error())
+	}
 }
 
 func (s) TestEDSConfigDump(t *testing.T) {
@@ -370,7 +394,9 @@ func (s) TestEDSConfigDump(t *testing.T) {
 	defer client.Close()
 
 	// Expected unknown.
-	compareDump(t, client.DumpEDS, "", map[string]UpdateWithMD{})
+	if err := compareDump(client.DumpEDS, "", map[string]UpdateWithMD{}); err != nil {
+		t.Fatalf(err.Error())
+	}
 
 	wantRequested := make(map[string]UpdateWithMD)
 	for _, n := range edsTargets {
@@ -379,7 +405,9 @@ func (s) TestEDSConfigDump(t *testing.T) {
 		wantRequested[n] = UpdateWithMD{MD: UpdateMetadata{Status: ServiceStatusRequested}}
 	}
 	// Expected requested.
-	compareDump(t, client.DumpEDS, "", wantRequested)
+	if err := compareDump(client.DumpEDS, "", wantRequested); err != nil {
+		t.Fatalf(err.Error())
+	}
 
 	update0 := make(map[string]EndpointsUpdate)
 	want0 := make(map[string]UpdateWithMD)
@@ -393,7 +421,9 @@ func (s) TestEDSConfigDump(t *testing.T) {
 	client.NewEndpoints(update0, UpdateMetadata{Version: testVersion})
 
 	// Expect ACK.
-	compareDump(t, client.DumpEDS, testVersion, want0)
+	if err := compareDump(client.DumpEDS, testVersion, want0); err != nil {
+		t.Fatalf(err.Error())
+	}
 
 	const nackVersion = "eds-version-nack"
 	var nackErr = fmt.Errorf("eds nack error")
@@ -427,17 +457,18 @@ func (s) TestEDSConfigDump(t *testing.T) {
 		MD:  UpdateMetadata{Version: testVersion},
 		Raw: endpointRaws[edsTargets[1]],
 	}
-	compareDump(t, client.DumpEDS, nackVersion, wantDump)
+	if err := compareDump(client.DumpEDS, nackVersion, wantDump); err != nil {
+		t.Fatalf(err.Error())
+	}
 }
 
-func compareDump(t *testing.T, dumpFunc func() (string, map[string]UpdateWithMD), wantVersion string, wantDump interface{}) {
-	t.Helper()
-
+func compareDump(dumpFunc func() (string, map[string]UpdateWithMD), wantVersion string, wantDump interface{}) error {
 	v, dump := dumpFunc()
 	if v != wantVersion {
-		t.Fatalf("Dump returned version %q, want %q", v, wantVersion)
+		return fmt.Errorf("Dump returned version %q, want %q", v, wantVersion)
 	}
 	if diff := cmp.Diff(dump, wantDump, cmpOpts); diff != "" {
-		t.Fatalf("Dump returned unexpected dump, diff (-got +want): %s", diff)
+		return fmt.Errorf("Dump returned unexpected dump, diff (-got +want): %s", diff)
 	}
+	return nil
 }

--- a/xds/internal/client/dump_test.go
+++ b/xds/internal/client/dump_test.go
@@ -1,0 +1,456 @@
+/*
+ *
+ * Copyright 2021 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package client
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	v3clusterpb "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	v3corepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	v3listenerpb "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	v3routepb "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	v3httppb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+	"github.com/golang/protobuf/ptypes"
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/durationpb"
+)
+
+func (s) TestLDSConfigDump(t *testing.T) {
+	const testVersion = "test-version-lds"
+	var (
+		ldsTargets       = []string{"lds.target.good:0000", "lds.target.good:1111"}
+		routeConfigNames = []string{"route-config-0", "route-config-1"}
+		listenerRaws     = make(map[string]*anypb.Any, len(ldsTargets))
+	)
+
+	for i := range ldsTargets {
+		listenersT := &v3listenerpb.Listener{
+			Name: ldsTargets[i],
+			ApiListener: &v3listenerpb.ApiListener{
+				ApiListener: func() *anypb.Any {
+					mcm, _ := ptypes.MarshalAny(&v3httppb.HttpConnectionManager{
+						RouteSpecifier: &v3httppb.HttpConnectionManager_Rds{
+							Rds: &v3httppb.Rds{
+								ConfigSource: &v3corepb.ConfigSource{
+									ConfigSourceSpecifier: &v3corepb.ConfigSource_Ads{Ads: &v3corepb.AggregatedConfigSource{}},
+								},
+								RouteConfigName: routeConfigNames[i],
+							},
+						},
+						CommonHttpProtocolOptions: &v3corepb.HttpProtocolOptions{
+							MaxStreamDuration: durationpb.New(time.Second),
+						},
+					})
+					return mcm
+				}(),
+			},
+		}
+		anyT, err := ptypes.MarshalAny(listenersT)
+		if err != nil {
+			t.Fatalf("failed to marshal proto to any: %v", err)
+		}
+		listenerRaws[ldsTargets[i]] = anyT
+	}
+
+	client, err := newWithConfig(clientOpts(testXDSServer, false))
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+	defer client.Close()
+
+	// Expected unknown.
+	compareDump(t, client.DumpLDS, "", map[string]LDSUpdateWithMD{})
+
+	wantRequested := make(map[string]LDSUpdateWithMD)
+	for _, n := range ldsTargets {
+		cancel := client.WatchListener(n, func(update ListenerUpdate, err error) {})
+		defer cancel()
+		wantRequested[n] = LDSUpdateWithMD{MD: UpdateMetadata{Status: ServiceStatusRequested}}
+	}
+	// Expected requested.
+	compareDump(t, client.DumpLDS, "", wantRequested)
+
+	update0 := make(map[string]ListenerUpdate)
+	want0 := make(map[string]LDSUpdateWithMD)
+	for n, r := range listenerRaws {
+		update0[n] = ListenerUpdate{Raw: r}
+		want0[n] = LDSUpdateWithMD{
+			Update: ListenerUpdate{Raw: r},
+			MD:     UpdateMetadata{Version: testVersion},
+		}
+	}
+	client.NewListeners(update0, UpdateMetadata{Version: testVersion})
+
+	// Expect ACK.
+	compareDump(t, client.DumpLDS, testVersion, want0)
+
+	const nackVersion = "lds-version-nack"
+	var nackErr = fmt.Errorf("lds nack error")
+	client.NewListeners(
+		map[string]ListenerUpdate{
+			ldsTargets[0]: {},
+		},
+		UpdateMetadata{
+			ErrState: &UpdateErrorMetadata{
+				Version: nackVersion,
+				Err:     nackErr,
+			},
+		},
+	)
+
+	// Expect NACK for [0], but old ACK for [1].
+	wantDump := make(map[string]LDSUpdateWithMD)
+	// Though resource 0 was NACKed, the dump should show the previous ACKed raw
+	// message, as well as the NACK error.
+	wantDump[ldsTargets[0]] = LDSUpdateWithMD{
+		Update: ListenerUpdate{Raw: listenerRaws[ldsTargets[0]]},
+		MD: UpdateMetadata{
+			Version: testVersion,
+			ErrState: &UpdateErrorMetadata{
+				Version: nackVersion,
+				Err:     nackErr,
+			},
+		},
+	}
+
+	wantDump[ldsTargets[1]] = LDSUpdateWithMD{
+		Update: ListenerUpdate{Raw: listenerRaws[ldsTargets[1]]},
+		MD:     UpdateMetadata{Version: testVersion},
+	}
+	compareDump(t, client.DumpLDS, nackVersion, wantDump)
+}
+
+func (s) TestRDSConfigDump(t *testing.T) {
+	const testVersion = "test-version-rds"
+	var (
+		listenerNames = []string{"lds.target.good:0000", "lds.target.good:1111"}
+		rdsTargets    = []string{"route-config-0", "route-config-1"}
+		clusterNames  = []string{"cluster-0", "cluster-1"}
+		routeRaws     = make(map[string]*anypb.Any, len(rdsTargets))
+	)
+
+	for i := range rdsTargets {
+		routeConfigT := &v3routepb.RouteConfiguration{
+			Name: rdsTargets[i],
+			VirtualHosts: []*v3routepb.VirtualHost{
+				{
+					Domains: []string{listenerNames[i]},
+					Routes: []*v3routepb.Route{{
+						Match: &v3routepb.RouteMatch{PathSpecifier: &v3routepb.RouteMatch_Prefix{Prefix: ""}},
+						Action: &v3routepb.Route_Route{
+							Route: &v3routepb.RouteAction{
+								ClusterSpecifier: &v3routepb.RouteAction_Cluster{Cluster: clusterNames[i]},
+							},
+						},
+					}},
+				},
+			},
+		}
+
+		anyT, err := ptypes.MarshalAny(routeConfigT)
+		if err != nil {
+			t.Fatalf("failed to marshal proto to any: %v", err)
+		}
+		routeRaws[rdsTargets[i]] = anyT
+	}
+
+	client, err := newWithConfig(clientOpts(testXDSServer, false))
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+	defer client.Close()
+
+	// Expected unknown.
+	compareDump(t, client.DumpRDS, "", map[string]RDSUpdateWithMD{})
+
+	wantRequested := make(map[string]RDSUpdateWithMD)
+	for _, n := range rdsTargets {
+		cancel := client.WatchRouteConfig(n, func(update RouteConfigUpdate, err error) {})
+		defer cancel()
+		wantRequested[n] = RDSUpdateWithMD{MD: UpdateMetadata{Status: ServiceStatusRequested}}
+	}
+	// Expected requested.
+	compareDump(t, client.DumpRDS, "", wantRequested)
+
+	update0 := make(map[string]RouteConfigUpdate)
+	want0 := make(map[string]RDSUpdateWithMD)
+	for n, r := range routeRaws {
+		update0[n] = RouteConfigUpdate{Raw: r}
+		want0[n] = RDSUpdateWithMD{
+			Update: RouteConfigUpdate{Raw: r},
+			MD:     UpdateMetadata{Version: testVersion},
+		}
+	}
+	client.NewRouteConfigs(update0, UpdateMetadata{Version: testVersion})
+
+	// Expect ACK.
+	compareDump(t, client.DumpRDS, testVersion, want0)
+
+	const nackVersion = "rds-version-nack"
+	var nackErr = fmt.Errorf("rds nack error")
+	client.NewRouteConfigs(
+		map[string]RouteConfigUpdate{
+			rdsTargets[0]: {},
+		},
+		UpdateMetadata{
+			ErrState: &UpdateErrorMetadata{
+				Version: nackVersion,
+				Err:     nackErr,
+			},
+		},
+	)
+
+	// Expect NACK for [0], but old ACK for [1].
+	wantDump := make(map[string]RDSUpdateWithMD)
+	// Though resource 0 was NACKed, the dump should show the previous ACKed raw
+	// message, as well as the NACK error.
+	wantDump[rdsTargets[0]] = RDSUpdateWithMD{
+		Update: RouteConfigUpdate{Raw: routeRaws[rdsTargets[0]]},
+		MD: UpdateMetadata{
+			Version: testVersion,
+			ErrState: &UpdateErrorMetadata{
+				Version: nackVersion,
+				Err:     nackErr,
+			},
+		},
+	}
+	wantDump[rdsTargets[1]] = RDSUpdateWithMD{
+		Update: RouteConfigUpdate{Raw: routeRaws[rdsTargets[1]]},
+		MD:     UpdateMetadata{Version: testVersion},
+	}
+	compareDump(t, client.DumpRDS, nackVersion, wantDump)
+}
+
+func (s) TestCDSConfigDump(t *testing.T) {
+	const testVersion = "test-version-cds"
+	var (
+		cdsTargets   = []string{"cluster-0", "cluster-1"}
+		serviceNames = []string{"service-0", "service-1"}
+		clusterRaws  = make(map[string]*anypb.Any, len(cdsTargets))
+	)
+
+	for i := range cdsTargets {
+		clusterT := &v3clusterpb.Cluster{
+			Name:                 cdsTargets[i],
+			ClusterDiscoveryType: &v3clusterpb.Cluster_Type{Type: v3clusterpb.Cluster_EDS},
+			EdsClusterConfig: &v3clusterpb.Cluster_EdsClusterConfig{
+				EdsConfig: &v3corepb.ConfigSource{
+					ConfigSourceSpecifier: &v3corepb.ConfigSource_Ads{
+						Ads: &v3corepb.AggregatedConfigSource{},
+					},
+				},
+				ServiceName: serviceNames[i],
+			},
+			LbPolicy: v3clusterpb.Cluster_ROUND_ROBIN,
+			LrsServer: &v3corepb.ConfigSource{
+				ConfigSourceSpecifier: &v3corepb.ConfigSource_Self{
+					Self: &v3corepb.SelfConfigSource{},
+				},
+			},
+		}
+
+		anyT, err := ptypes.MarshalAny(clusterT)
+		if err != nil {
+			t.Fatalf("failed to marshal proto to any: %v", err)
+		}
+		clusterRaws[cdsTargets[i]] = anyT
+	}
+
+	client, err := newWithConfig(clientOpts(testXDSServer, false))
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+	defer client.Close()
+
+	// Expected unknown.
+	compareDump(t, client.DumpCDS, "", map[string]CDSUpdateWithMD{})
+
+	wantRequested := make(map[string]CDSUpdateWithMD)
+	for _, n := range cdsTargets {
+		cancel := client.WatchCluster(n, func(update ClusterUpdate, err error) {})
+		defer cancel()
+		wantRequested[n] = CDSUpdateWithMD{MD: UpdateMetadata{Status: ServiceStatusRequested}}
+	}
+	// Expected requested.
+	compareDump(t, client.DumpCDS, "", wantRequested)
+
+	update0 := make(map[string]ClusterUpdate)
+	want0 := make(map[string]CDSUpdateWithMD)
+	for n, r := range clusterRaws {
+		update0[n] = ClusterUpdate{Raw: r}
+		want0[n] = CDSUpdateWithMD{
+			Update: ClusterUpdate{Raw: r},
+			MD:     UpdateMetadata{Version: testVersion},
+		}
+	}
+	client.NewClusters(update0, UpdateMetadata{Version: testVersion})
+
+	// Expect ACK.
+	compareDump(t, client.DumpCDS, testVersion, want0)
+
+	const nackVersion = "cds-version-nack"
+	var nackErr = fmt.Errorf("cds nack error")
+	client.NewClusters(
+		map[string]ClusterUpdate{
+			cdsTargets[0]: {},
+		},
+		UpdateMetadata{
+			ErrState: &UpdateErrorMetadata{
+				Version: nackVersion,
+				Err:     nackErr,
+			},
+		},
+	)
+
+	// Expect NACK for [0], but old ACK for [1].
+	wantDump := make(map[string]CDSUpdateWithMD)
+	// Though resource 0 was NACKed, the dump should show the previous ACKed raw
+	// message, as well as the NACK error.
+	wantDump[cdsTargets[0]] = CDSUpdateWithMD{
+		Update: ClusterUpdate{Raw: clusterRaws[cdsTargets[0]]},
+		MD: UpdateMetadata{
+			Version: testVersion,
+			ErrState: &UpdateErrorMetadata{
+				Version: nackVersion,
+				Err:     nackErr,
+			},
+		},
+	}
+	wantDump[cdsTargets[1]] = CDSUpdateWithMD{
+		Update: ClusterUpdate{Raw: clusterRaws[cdsTargets[1]]},
+		MD:     UpdateMetadata{Version: testVersion},
+	}
+	compareDump(t, client.DumpCDS, nackVersion, wantDump)
+}
+
+func (s) TestEDSConfigDump(t *testing.T) {
+	const testVersion = "test-version-cds"
+	var (
+		edsTargets    = []string{"cluster-0", "cluster-1"}
+		localityNames = []string{"locality-0", "locality-1"}
+		addrs         = []string{"addr0:123", "addr1:456"}
+		endpointRaws  = make(map[string]*anypb.Any, len(edsTargets))
+	)
+
+	for i := range edsTargets {
+		clab0 := newClaBuilder(edsTargets[i], nil)
+		clab0.addLocality(localityNames[i], 1, 1, []string{addrs[i]}, nil)
+		claT := clab0.Build()
+
+		anyT, err := ptypes.MarshalAny(claT)
+		if err != nil {
+			t.Fatalf("failed to marshal proto to any: %v", err)
+		}
+		endpointRaws[edsTargets[i]] = anyT
+	}
+
+	client, err := newWithConfig(clientOpts(testXDSServer, false))
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+	defer client.Close()
+
+	// Expected unknown.
+	compareDump(t, client.DumpEDS, "", map[string]EDSUpdateWithMD{})
+
+	wantRequested := make(map[string]EDSUpdateWithMD)
+	for _, n := range edsTargets {
+		cancel := client.WatchEndpoints(n, func(update EndpointsUpdate, err error) {})
+		defer cancel()
+		wantRequested[n] = EDSUpdateWithMD{MD: UpdateMetadata{Status: ServiceStatusRequested}}
+	}
+	// Expected requested.
+	compareDump(t, client.DumpEDS, "", wantRequested)
+
+	update0 := make(map[string]EndpointsUpdate)
+	want0 := make(map[string]EDSUpdateWithMD)
+	for n, r := range endpointRaws {
+		update0[n] = EndpointsUpdate{Raw: r}
+		want0[n] = EDSUpdateWithMD{
+			Update: EndpointsUpdate{Raw: r},
+			MD:     UpdateMetadata{Version: testVersion},
+		}
+	}
+	client.NewEndpoints(update0, UpdateMetadata{Version: testVersion})
+
+	// Expect ACK.
+	compareDump(t, client.DumpEDS, testVersion, want0)
+
+	const nackVersion = "eds-version-nack"
+	var nackErr = fmt.Errorf("eds nack error")
+	client.NewEndpoints(
+		map[string]EndpointsUpdate{
+			edsTargets[0]: {},
+		},
+		UpdateMetadata{
+			ErrState: &UpdateErrorMetadata{
+				Version: nackVersion,
+				Err:     nackErr,
+			},
+		},
+	)
+
+	// Expect NACK for [0], but old ACK for [1].
+	wantDump := make(map[string]EDSUpdateWithMD)
+	// Though resource 0 was NACKed, the dump should show the previous ACKed raw
+	// message, as well as the NACK error.
+	wantDump[edsTargets[0]] = EDSUpdateWithMD{
+		Update: EndpointsUpdate{Raw: endpointRaws[edsTargets[0]]},
+		MD: UpdateMetadata{
+			Version: testVersion,
+			ErrState: &UpdateErrorMetadata{
+				Version: nackVersion,
+				Err:     nackErr,
+			},
+		},
+	}
+	wantDump[edsTargets[1]] = EDSUpdateWithMD{
+		Update: EndpointsUpdate{Raw: endpointRaws[edsTargets[1]]},
+		MD:     UpdateMetadata{Version: testVersion},
+	}
+	compareDump(t, client.DumpEDS, nackVersion, wantDump)
+}
+
+func compareDump(t *testing.T, dumpFunc interface{}, wantVersion string, wantDump interface{}) {
+	t.Helper()
+
+	var (
+		v    string
+		dump interface{}
+	)
+	switch dumpFuncT := dumpFunc.(type) {
+	case func() (string, map[string]LDSUpdateWithMD):
+		v, dump = dumpFuncT()
+	case func() (string, map[string]RDSUpdateWithMD):
+		v, dump = dumpFuncT()
+	case func() (string, map[string]CDSUpdateWithMD):
+		v, dump = dumpFuncT()
+	case func() (string, map[string]EDSUpdateWithMD):
+		v, dump = dumpFuncT()
+	}
+	if v != wantVersion {
+		t.Fatalf("Dump returned version %q, want %q", v, wantVersion)
+	}
+	if diff := cmp.Diff(dump, wantDump, cmpOpts); diff != "" {
+		t.Fatalf("Dump returned unexpected dump, diff (-got +want): %s", diff)
+	}
+}

--- a/xds/internal/client/dump_test.go
+++ b/xds/internal/client/dump_test.go
@@ -94,8 +94,8 @@ func (s) TestLDSConfigDump(t *testing.T) {
 	for n, r := range listenerRaws {
 		update0[n] = ListenerUpdate{Raw: r}
 		want0[n] = LDSUpdateWithMD{
-			Update: ListenerUpdate{Raw: r},
-			MD:     UpdateMetadata{Version: testVersion},
+			MD:  UpdateMetadata{Version: testVersion},
+			Raw: r,
 		}
 	}
 	client.NewListeners(update0, UpdateMetadata{Version: testVersion})
@@ -122,7 +122,6 @@ func (s) TestLDSConfigDump(t *testing.T) {
 	// Though resource 0 was NACKed, the dump should show the previous ACKed raw
 	// message, as well as the NACK error.
 	wantDump[ldsTargets[0]] = LDSUpdateWithMD{
-		Update: ListenerUpdate{Raw: listenerRaws[ldsTargets[0]]},
 		MD: UpdateMetadata{
 			Version: testVersion,
 			ErrState: &UpdateErrorMetadata{
@@ -130,11 +129,12 @@ func (s) TestLDSConfigDump(t *testing.T) {
 				Err:     nackErr,
 			},
 		},
+		Raw: listenerRaws[ldsTargets[0]],
 	}
 
 	wantDump[ldsTargets[1]] = LDSUpdateWithMD{
-		Update: ListenerUpdate{Raw: listenerRaws[ldsTargets[1]]},
-		MD:     UpdateMetadata{Version: testVersion},
+		MD:  UpdateMetadata{Version: testVersion},
+		Raw: listenerRaws[ldsTargets[1]],
 	}
 	compareDump(t, client.DumpLDS, nackVersion, wantDump)
 }
@@ -196,8 +196,8 @@ func (s) TestRDSConfigDump(t *testing.T) {
 	for n, r := range routeRaws {
 		update0[n] = RouteConfigUpdate{Raw: r}
 		want0[n] = RDSUpdateWithMD{
-			Update: RouteConfigUpdate{Raw: r},
-			MD:     UpdateMetadata{Version: testVersion},
+			MD:  UpdateMetadata{Version: testVersion},
+			Raw: r,
 		}
 	}
 	client.NewRouteConfigs(update0, UpdateMetadata{Version: testVersion})
@@ -224,7 +224,6 @@ func (s) TestRDSConfigDump(t *testing.T) {
 	// Though resource 0 was NACKed, the dump should show the previous ACKed raw
 	// message, as well as the NACK error.
 	wantDump[rdsTargets[0]] = RDSUpdateWithMD{
-		Update: RouteConfigUpdate{Raw: routeRaws[rdsTargets[0]]},
 		MD: UpdateMetadata{
 			Version: testVersion,
 			ErrState: &UpdateErrorMetadata{
@@ -232,10 +231,11 @@ func (s) TestRDSConfigDump(t *testing.T) {
 				Err:     nackErr,
 			},
 		},
+		Raw: routeRaws[rdsTargets[0]],
 	}
 	wantDump[rdsTargets[1]] = RDSUpdateWithMD{
-		Update: RouteConfigUpdate{Raw: routeRaws[rdsTargets[1]]},
-		MD:     UpdateMetadata{Version: testVersion},
+		MD:  UpdateMetadata{Version: testVersion},
+		Raw: routeRaws[rdsTargets[1]],
 	}
 	compareDump(t, client.DumpRDS, nackVersion, wantDump)
 }
@@ -298,8 +298,8 @@ func (s) TestCDSConfigDump(t *testing.T) {
 	for n, r := range clusterRaws {
 		update0[n] = ClusterUpdate{Raw: r}
 		want0[n] = CDSUpdateWithMD{
-			Update: ClusterUpdate{Raw: r},
-			MD:     UpdateMetadata{Version: testVersion},
+			MD:  UpdateMetadata{Version: testVersion},
+			Raw: r,
 		}
 	}
 	client.NewClusters(update0, UpdateMetadata{Version: testVersion})
@@ -326,7 +326,6 @@ func (s) TestCDSConfigDump(t *testing.T) {
 	// Though resource 0 was NACKed, the dump should show the previous ACKed raw
 	// message, as well as the NACK error.
 	wantDump[cdsTargets[0]] = CDSUpdateWithMD{
-		Update: ClusterUpdate{Raw: clusterRaws[cdsTargets[0]]},
 		MD: UpdateMetadata{
 			Version: testVersion,
 			ErrState: &UpdateErrorMetadata{
@@ -334,10 +333,11 @@ func (s) TestCDSConfigDump(t *testing.T) {
 				Err:     nackErr,
 			},
 		},
+		Raw: clusterRaws[cdsTargets[0]],
 	}
 	wantDump[cdsTargets[1]] = CDSUpdateWithMD{
-		Update: ClusterUpdate{Raw: clusterRaws[cdsTargets[1]]},
-		MD:     UpdateMetadata{Version: testVersion},
+		MD:  UpdateMetadata{Version: testVersion},
+		Raw: clusterRaws[cdsTargets[1]],
 	}
 	compareDump(t, client.DumpCDS, nackVersion, wantDump)
 }
@@ -386,8 +386,8 @@ func (s) TestEDSConfigDump(t *testing.T) {
 	for n, r := range endpointRaws {
 		update0[n] = EndpointsUpdate{Raw: r}
 		want0[n] = EDSUpdateWithMD{
-			Update: EndpointsUpdate{Raw: r},
-			MD:     UpdateMetadata{Version: testVersion},
+			MD:  UpdateMetadata{Version: testVersion},
+			Raw: r,
 		}
 	}
 	client.NewEndpoints(update0, UpdateMetadata{Version: testVersion})
@@ -414,7 +414,6 @@ func (s) TestEDSConfigDump(t *testing.T) {
 	// Though resource 0 was NACKed, the dump should show the previous ACKed raw
 	// message, as well as the NACK error.
 	wantDump[edsTargets[0]] = EDSUpdateWithMD{
-		Update: EndpointsUpdate{Raw: endpointRaws[edsTargets[0]]},
 		MD: UpdateMetadata{
 			Version: testVersion,
 			ErrState: &UpdateErrorMetadata{
@@ -422,10 +421,11 @@ func (s) TestEDSConfigDump(t *testing.T) {
 				Err:     nackErr,
 			},
 		},
+		Raw: endpointRaws[edsTargets[0]],
 	}
 	wantDump[edsTargets[1]] = EDSUpdateWithMD{
-		Update: EndpointsUpdate{Raw: endpointRaws[edsTargets[1]]},
-		MD:     UpdateMetadata{Version: testVersion},
+		MD:  UpdateMetadata{Version: testVersion},
+		Raw: endpointRaws[edsTargets[1]],
 	}
 	compareDump(t, client.DumpEDS, nackVersion, wantDump)
 }

--- a/xds/internal/client/eds_test.go
+++ b/xds/internal/client/eds_test.go
@@ -211,7 +211,7 @@ func (s) TestUnmarshalEndpoints(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			update, err := UnmarshalEndpoints(test.resources, nil)
+			update, _, err := UnmarshalEndpoints("", test.resources, nil)
 			if ((err != nil) != test.wantErr) || !cmp.Equal(update, test.wantUpdate, cmpopts.EquateEmpty()) {
 				t.Errorf("UnmarshalEndpoints(%v) = (%+v, %v) want (%+v, %v)", test.resources, update, err, test.wantUpdate, test.wantErr)
 			}

--- a/xds/internal/client/lds_test.go
+++ b/xds/internal/client/lds_test.go
@@ -298,7 +298,7 @@ func (s) TestUnmarshalListener_ClientSide(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			update, err := UnmarshalListener(test.resources, nil)
+			update, _, err := UnmarshalListener("", test.resources, nil)
 			if ((err != nil) != test.wantErr) || !cmp.Equal(update, test.wantUpdate, cmpopts.EquateEmpty()) {
 				t.Errorf("UnmarshalListener(%v) = (%v, %v) want (%v, %v)", test.resources, update, err, test.wantUpdate, test.wantErr)
 			}
@@ -926,7 +926,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			gotUpdate, err := UnmarshalListener(test.resources, nil)
+			gotUpdate, _, err := UnmarshalListener("", test.resources, nil)
 			if (err != nil) != (test.wantErr != "") {
 				t.Fatalf("UnmarshalListener(%v) = %v wantErr: %q", test.resources, err, test.wantErr)
 			}

--- a/xds/internal/client/rds_test.go
+++ b/xds/internal/client/rds_test.go
@@ -579,7 +579,7 @@ func (s) TestUnmarshalRouteConfig(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			update, err := UnmarshalRouteConfig(test.resources, nil)
+			update, _, err := UnmarshalRouteConfig("", test.resources, nil)
 			if ((err != nil) != test.wantErr) || !cmp.Equal(update, test.wantUpdate, cmpopts.EquateEmpty()) {
 				t.Errorf("UnmarshalRouteConfig(%v, %v) = (%v, %v) want (%v, %v)", test.resources, ldsTarget, update, err, test.wantUpdate, test.wantErr)
 			}

--- a/xds/internal/client/v2/ack_test.go
+++ b/xds/internal/client/v2/ack_test.go
@@ -47,7 +47,7 @@ func startXDSV2Client(t *testing.T, cc *grpc.ClientConn) (v2c *client, cbLDS, cb
 	cbCDS = testutils.NewChannel()
 	cbEDS = testutils.NewChannel()
 	v2c, err := newV2Client(&testUpdateReceiver{
-		f: func(rType xdsclient.ResourceType, d map[string]interface{}) {
+		f: func(rType xdsclient.ResourceType, d map[string]interface{}, md xdsclient.UpdateMetadata) {
 			t.Logf("Received %v callback with {%+v}", rType, d)
 			switch rType {
 			case xdsclient.ListenerResource:

--- a/xds/internal/client/v2/cds_test.go
+++ b/xds/internal/client/v2/cds_test.go
@@ -172,7 +172,7 @@ func (s) TestCDSHandleResponseWithoutWatch(t *testing.T) {
 	defer cleanup()
 
 	v2c, err := newV2Client(&testUpdateReceiver{
-		f: func(xdsclient.ResourceType, map[string]interface{}) {},
+		f: func(xdsclient.ResourceType, map[string]interface{}, xdsclient.UpdateMetadata) {},
 	}, cc, goodNodeProto, func(int) time.Duration { return 0 }, nil)
 	if err != nil {
 		t.Fatal(err)

--- a/xds/internal/client/v2/client.go
+++ b/xds/internal/client/v2/client.go
@@ -185,11 +185,11 @@ func (v2c *client) HandleResponse(r proto.Message) (xdsclient.ResourceType, stri
 // server. On receipt of a good response, it also invokes the registered watcher
 // callback.
 func (v2c *client) handleLDSResponse(resp *v2xdspb.DiscoveryResponse) error {
-	update, err := xdsclient.UnmarshalListener(resp.GetResources(), v2c.logger)
+	update, md, err := xdsclient.UnmarshalListener(resp.GetVersionInfo(), resp.GetResources(), v2c.logger)
 	if err != nil {
 		return err
 	}
-	v2c.parent.NewListeners(update)
+	v2c.parent.NewListeners(update, md)
 	return nil
 }
 
@@ -197,11 +197,11 @@ func (v2c *client) handleLDSResponse(resp *v2xdspb.DiscoveryResponse) error {
 // server. On receipt of a good response, it caches validated resources and also
 // invokes the registered watcher callback.
 func (v2c *client) handleRDSResponse(resp *v2xdspb.DiscoveryResponse) error {
-	update, err := xdsclient.UnmarshalRouteConfig(resp.GetResources(), v2c.logger)
+	update, md, err := xdsclient.UnmarshalRouteConfig(resp.GetVersionInfo(), resp.GetResources(), v2c.logger)
 	if err != nil {
 		return err
 	}
-	v2c.parent.NewRouteConfigs(update)
+	v2c.parent.NewRouteConfigs(update, md)
 	return nil
 }
 
@@ -209,19 +209,19 @@ func (v2c *client) handleRDSResponse(resp *v2xdspb.DiscoveryResponse) error {
 // server. On receipt of a good response, it also invokes the registered watcher
 // callback.
 func (v2c *client) handleCDSResponse(resp *v2xdspb.DiscoveryResponse) error {
-	update, err := xdsclient.UnmarshalCluster(resp.GetResources(), v2c.logger)
+	update, md, err := xdsclient.UnmarshalCluster(resp.GetVersionInfo(), resp.GetResources(), v2c.logger)
 	if err != nil {
 		return err
 	}
-	v2c.parent.NewClusters(update)
+	v2c.parent.NewClusters(update, md)
 	return nil
 }
 
 func (v2c *client) handleEDSResponse(resp *v2xdspb.DiscoveryResponse) error {
-	update, err := xdsclient.UnmarshalEndpoints(resp.GetResources(), v2c.logger)
+	update, md, err := xdsclient.UnmarshalEndpoints(resp.GetVersionInfo(), resp.GetResources(), v2c.logger)
 	if err != nil {
 		return err
 	}
-	v2c.parent.NewEndpoints(update)
+	v2c.parent.NewEndpoints(update, md)
 	return nil
 }

--- a/xds/internal/client/v2/client_test.go
+++ b/xds/internal/client/v2/client_test.go
@@ -21,7 +21,6 @@ package v2
 import (
 	"context"
 	"errors"
-	"fmt"
 	"reflect"
 	"testing"
 	"time"
@@ -331,9 +330,6 @@ var (
 		},
 		TypeUrl: version.V2RouteConfigURL,
 	}
-	// An place holder error. When comparing UpdateErrorMetadata, we only check
-	// if error is nil, and don't compare error content.
-	errPlaceHolder = fmt.Errorf("err place holder")
 )
 
 type watchHandleTestcase struct {

--- a/xds/internal/client/v2/eds_test.go
+++ b/xds/internal/client/v2/eds_test.go
@@ -153,7 +153,7 @@ func (s) TestEDSHandleResponseWithoutWatch(t *testing.T) {
 	defer cleanup()
 
 	v2c, err := newV2Client(&testUpdateReceiver{
-		f: func(xdsclient.ResourceType, map[string]interface{}) {},
+		f: func(xdsclient.ResourceType, map[string]interface{}, xdsclient.UpdateMetadata) {},
 	}, cc, goodNodeProto, func(int) time.Duration { return 0 }, nil)
 	if err != nil {
 		t.Fatal(err)

--- a/xds/internal/client/v2/lds_test.go
+++ b/xds/internal/client/v2/lds_test.go
@@ -131,7 +131,7 @@ func (s) TestLDSHandleResponseWithoutWatch(t *testing.T) {
 	defer cleanup()
 
 	v2c, err := newV2Client(&testUpdateReceiver{
-		f: func(xdsclient.ResourceType, map[string]interface{}) {},
+		f: func(xdsclient.ResourceType, map[string]interface{}, xdsclient.UpdateMetadata) {},
 	}, cc, goodNodeProto, func(int) time.Duration { return 0 }, nil)
 	if err != nil {
 		t.Fatal(err)

--- a/xds/internal/client/v2/rds_test.go
+++ b/xds/internal/client/v2/rds_test.go
@@ -129,7 +129,7 @@ func (s) TestRDSHandleResponseWithoutRDSWatch(t *testing.T) {
 	defer cleanup()
 
 	v2c, err := newV2Client(&testUpdateReceiver{
-		f: func(xdsclient.ResourceType, map[string]interface{}) {},
+		f: func(xdsclient.ResourceType, map[string]interface{}, xdsclient.UpdateMetadata) {},
 	}, cc, goodNodeProto, func(int) time.Duration { return 0 }, nil)
 	if err != nil {
 		t.Fatal(err)

--- a/xds/internal/client/v3/client.go
+++ b/xds/internal/client/v3/client.go
@@ -185,11 +185,11 @@ func (v3c *client) HandleResponse(r proto.Message) (xdsclient.ResourceType, stri
 // server. On receipt of a good response, it also invokes the registered watcher
 // callback.
 func (v3c *client) handleLDSResponse(resp *v3discoverypb.DiscoveryResponse) error {
-	update, err := xdsclient.UnmarshalListener(resp.GetResources(), v3c.logger)
+	update, md, err := xdsclient.UnmarshalListener(resp.GetVersionInfo(), resp.GetResources(), v3c.logger)
 	if err != nil {
 		return err
 	}
-	v3c.parent.NewListeners(update)
+	v3c.parent.NewListeners(update, md)
 	return nil
 }
 
@@ -197,11 +197,11 @@ func (v3c *client) handleLDSResponse(resp *v3discoverypb.DiscoveryResponse) erro
 // server. On receipt of a good response, it caches validated resources and also
 // invokes the registered watcher callback.
 func (v3c *client) handleRDSResponse(resp *v3discoverypb.DiscoveryResponse) error {
-	update, err := xdsclient.UnmarshalRouteConfig(resp.GetResources(), v3c.logger)
+	update, md, err := xdsclient.UnmarshalRouteConfig(resp.GetVersionInfo(), resp.GetResources(), v3c.logger)
 	if err != nil {
 		return err
 	}
-	v3c.parent.NewRouteConfigs(update)
+	v3c.parent.NewRouteConfigs(update, md)
 	return nil
 }
 
@@ -209,19 +209,19 @@ func (v3c *client) handleRDSResponse(resp *v3discoverypb.DiscoveryResponse) erro
 // server. On receipt of a good response, it also invokes the registered watcher
 // callback.
 func (v3c *client) handleCDSResponse(resp *v3discoverypb.DiscoveryResponse) error {
-	update, err := xdsclient.UnmarshalCluster(resp.GetResources(), v3c.logger)
+	update, md, err := xdsclient.UnmarshalCluster(resp.GetVersionInfo(), resp.GetResources(), v3c.logger)
 	if err != nil {
 		return err
 	}
-	v3c.parent.NewClusters(update)
+	v3c.parent.NewClusters(update, md)
 	return nil
 }
 
 func (v3c *client) handleEDSResponse(resp *v3discoverypb.DiscoveryResponse) error {
-	update, err := xdsclient.UnmarshalEndpoints(resp.GetResources(), v3c.logger)
+	update, md, err := xdsclient.UnmarshalEndpoints(resp.GetVersionInfo(), resp.GetResources(), v3c.logger)
 	if err != nil {
 		return err
 	}
-	v3c.parent.NewEndpoints(update)
+	v3c.parent.NewEndpoints(update, md)
 	return nil
 }

--- a/xds/internal/client/watchers.go
+++ b/xds/internal/client/watchers.go
@@ -117,16 +117,26 @@ func (c *clientImpl) watch(wi *watchInfo) (cancel func()) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.logger.Debugf("new watch for type %v, resource name %v", wi.rType, wi.target)
-	var watchers map[string]map[*watchInfo]bool
+	var (
+		watchers map[string]map[*watchInfo]bool
+		mds      map[string]UpdateMetadata
+	)
 	switch wi.rType {
 	case ListenerResource:
 		watchers = c.ldsWatchers
+		mds = c.ldsMD
 	case RouteConfigResource:
 		watchers = c.rdsWatchers
+		mds = c.rdsMD
 	case ClusterResource:
 		watchers = c.cdsWatchers
+		mds = c.cdsMD
 	case EndpointsResource:
 		watchers = c.edsWatchers
+		mds = c.edsMD
+	default:
+		c.logger.Errorf("unknown watch type: %v", wi.rType)
+		return nil
 	}
 
 	resourceName := wi.target
@@ -140,6 +150,7 @@ func (c *clientImpl) watch(wi *watchInfo) (cancel func()) {
 		c.logger.Debugf("first watch for type %v, resource name %v, will send a new xDS request", wi.rType, wi.target)
 		s = make(map[*watchInfo]bool)
 		watchers[resourceName] = s
+		mds[resourceName] = UpdateMetadata{Status: ServiceStatusRequested}
 		c.apiClient.AddWatch(wi.rType, resourceName)
 	}
 	// No matter what, add the new watcher to the set, so it's callback will be
@@ -184,6 +195,7 @@ func (c *clientImpl) watch(wi *watchInfo) (cancel func()) {
 				// If this was the last watcher, also tell xdsv2Client to stop
 				// watching this resource.
 				delete(watchers, resourceName)
+				delete(mds, resourceName)
 				c.apiClient.RemoveWatch(wi.rType, resourceName)
 				// Remove the resource from cache. When a watch for this
 				// resource is added later, it will trigger a xDS request with

--- a/xds/internal/client/watchers_cluster_test.go
+++ b/xds/internal/client/watchers_cluster_test.go
@@ -63,7 +63,7 @@ func (s) TestClusterWatch(t *testing.T) {
 	}
 
 	wantUpdate := ClusterUpdate{ServiceName: testEDSName}
-	client.NewClusters(map[string]ClusterUpdate{testCDSName: wantUpdate})
+	client.NewClusters(map[string]ClusterUpdate{testCDSName: wantUpdate}, UpdateMetadata{})
 	if err := verifyClusterUpdate(ctx, clusterUpdateCh, wantUpdate); err != nil {
 		t.Fatal(err)
 	}
@@ -72,14 +72,14 @@ func (s) TestClusterWatch(t *testing.T) {
 	client.NewClusters(map[string]ClusterUpdate{
 		testCDSName:  wantUpdate,
 		"randomName": {},
-	})
+	}, UpdateMetadata{})
 	if err := verifyClusterUpdate(ctx, clusterUpdateCh, wantUpdate); err != nil {
 		t.Fatal(err)
 	}
 
 	// Cancel watch, and send update again.
 	cancelWatch()
-	client.NewClusters(map[string]ClusterUpdate{testCDSName: wantUpdate})
+	client.NewClusters(map[string]ClusterUpdate{testCDSName: wantUpdate}, UpdateMetadata{})
 	sCtx, sCancel := context.WithTimeout(ctx, defaultTestShortTimeout)
 	defer sCancel()
 	if u, err := clusterUpdateCh.Receive(sCtx); err != context.DeadlineExceeded {
@@ -127,7 +127,7 @@ func (s) TestClusterTwoWatchSameResourceName(t *testing.T) {
 	}
 
 	wantUpdate := ClusterUpdate{ServiceName: testEDSName}
-	client.NewClusters(map[string]ClusterUpdate{testCDSName: wantUpdate})
+	client.NewClusters(map[string]ClusterUpdate{testCDSName: wantUpdate}, UpdateMetadata{})
 	for i := 0; i < count; i++ {
 		if err := verifyClusterUpdate(ctx, clusterUpdateChs[i], wantUpdate); err != nil {
 			t.Fatal(err)
@@ -136,7 +136,7 @@ func (s) TestClusterTwoWatchSameResourceName(t *testing.T) {
 
 	// Cancel the last watch, and send update again.
 	cancelLastWatch()
-	client.NewClusters(map[string]ClusterUpdate{testCDSName: wantUpdate})
+	client.NewClusters(map[string]ClusterUpdate{testCDSName: wantUpdate}, UpdateMetadata{})
 	for i := 0; i < count-1; i++ {
 		if err := verifyClusterUpdate(ctx, clusterUpdateChs[i], wantUpdate); err != nil {
 			t.Fatal(err)
@@ -203,7 +203,7 @@ func (s) TestClusterThreeWatchDifferentResourceName(t *testing.T) {
 	client.NewClusters(map[string]ClusterUpdate{
 		testCDSName + "1": wantUpdate1,
 		testCDSName + "2": wantUpdate2,
-	})
+	}, UpdateMetadata{})
 
 	for i := 0; i < count; i++ {
 		if err := verifyClusterUpdate(ctx, clusterUpdateChs[i], wantUpdate1); err != nil {
@@ -246,7 +246,7 @@ func (s) TestClusterWatchAfterCache(t *testing.T) {
 	wantUpdate := ClusterUpdate{ServiceName: testEDSName}
 	client.NewClusters(map[string]ClusterUpdate{
 		testCDSName: wantUpdate,
-	})
+	}, UpdateMetadata{})
 	if err := verifyClusterUpdate(ctx, clusterUpdateCh, wantUpdate); err != nil {
 		t.Fatal(err)
 	}
@@ -346,7 +346,7 @@ func (s) TestClusterWatchExpiryTimerStop(t *testing.T) {
 	wantUpdate := ClusterUpdate{ServiceName: testEDSName}
 	client.NewClusters(map[string]ClusterUpdate{
 		testCDSName: wantUpdate,
-	})
+	}, UpdateMetadata{})
 	if err := verifyClusterUpdate(ctx, clusterUpdateCh, wantUpdate); err != nil {
 		t.Fatal(err)
 	}
@@ -405,7 +405,7 @@ func (s) TestClusterResourceRemoved(t *testing.T) {
 	client.NewClusters(map[string]ClusterUpdate{
 		testCDSName + "1": wantUpdate1,
 		testCDSName + "2": wantUpdate2,
-	})
+	}, UpdateMetadata{})
 	if err := verifyClusterUpdate(ctx, clusterUpdateCh1, wantUpdate1); err != nil {
 		t.Fatal(err)
 	}
@@ -414,7 +414,7 @@ func (s) TestClusterResourceRemoved(t *testing.T) {
 	}
 
 	// Send another update to remove resource 1.
-	client.NewClusters(map[string]ClusterUpdate{testCDSName + "2": wantUpdate2})
+	client.NewClusters(map[string]ClusterUpdate{testCDSName + "2": wantUpdate2}, UpdateMetadata{})
 
 	// Watcher 1 should get an error.
 	if u, err := clusterUpdateCh1.Receive(ctx); err != nil || ErrType(u.(clusterUpdateErr).err) != ErrorTypeResourceNotFound {
@@ -427,7 +427,7 @@ func (s) TestClusterResourceRemoved(t *testing.T) {
 	}
 
 	// Send one more update without resource 1.
-	client.NewClusters(map[string]ClusterUpdate{testCDSName + "2": wantUpdate2})
+	client.NewClusters(map[string]ClusterUpdate{testCDSName + "2": wantUpdate2}, UpdateMetadata{})
 
 	// Watcher 1 should not see an update.
 	sCtx, sCancel := context.WithTimeout(ctx, defaultTestShortTimeout)

--- a/xds/internal/client/watchers_endpoints_test.go
+++ b/xds/internal/client/watchers_endpoints_test.go
@@ -81,13 +81,13 @@ func (s) TestEndpointsWatch(t *testing.T) {
 	}
 
 	wantUpdate := EndpointsUpdate{Localities: []Locality{testLocalities[0]}}
-	client.NewEndpoints(map[string]EndpointsUpdate{testCDSName: wantUpdate})
+	client.NewEndpoints(map[string]EndpointsUpdate{testCDSName: wantUpdate}, UpdateMetadata{})
 	if err := verifyEndpointsUpdate(ctx, endpointsUpdateCh, wantUpdate); err != nil {
 		t.Fatal(err)
 	}
 
 	// Another update for a different resource name.
-	client.NewEndpoints(map[string]EndpointsUpdate{"randomName": {}})
+	client.NewEndpoints(map[string]EndpointsUpdate{"randomName": {}}, UpdateMetadata{})
 	sCtx, sCancel := context.WithTimeout(ctx, defaultTestShortTimeout)
 	defer sCancel()
 	if u, err := endpointsUpdateCh.Receive(sCtx); err != context.DeadlineExceeded {
@@ -96,7 +96,7 @@ func (s) TestEndpointsWatch(t *testing.T) {
 
 	// Cancel watch, and send update again.
 	cancelWatch()
-	client.NewEndpoints(map[string]EndpointsUpdate{testCDSName: wantUpdate})
+	client.NewEndpoints(map[string]EndpointsUpdate{testCDSName: wantUpdate}, UpdateMetadata{})
 	sCtx, sCancel = context.WithTimeout(ctx, defaultTestShortTimeout)
 	defer sCancel()
 	if u, err := endpointsUpdateCh.Receive(sCtx); err != context.DeadlineExceeded {
@@ -146,7 +146,7 @@ func (s) TestEndpointsTwoWatchSameResourceName(t *testing.T) {
 	}
 
 	wantUpdate := EndpointsUpdate{Localities: []Locality{testLocalities[0]}}
-	client.NewEndpoints(map[string]EndpointsUpdate{testCDSName: wantUpdate})
+	client.NewEndpoints(map[string]EndpointsUpdate{testCDSName: wantUpdate}, UpdateMetadata{})
 	for i := 0; i < count; i++ {
 		if err := verifyEndpointsUpdate(ctx, endpointsUpdateChs[i], wantUpdate); err != nil {
 			t.Fatal(err)
@@ -155,7 +155,7 @@ func (s) TestEndpointsTwoWatchSameResourceName(t *testing.T) {
 
 	// Cancel the last watch, and send update again.
 	cancelLastWatch()
-	client.NewEndpoints(map[string]EndpointsUpdate{testCDSName: wantUpdate})
+	client.NewEndpoints(map[string]EndpointsUpdate{testCDSName: wantUpdate}, UpdateMetadata{})
 	for i := 0; i < count-1; i++ {
 		if err := verifyEndpointsUpdate(ctx, endpointsUpdateChs[i], wantUpdate); err != nil {
 			t.Fatal(err)
@@ -222,7 +222,7 @@ func (s) TestEndpointsThreeWatchDifferentResourceName(t *testing.T) {
 	client.NewEndpoints(map[string]EndpointsUpdate{
 		testCDSName + "1": wantUpdate1,
 		testCDSName + "2": wantUpdate2,
-	})
+	}, UpdateMetadata{})
 
 	for i := 0; i < count; i++ {
 		if err := verifyEndpointsUpdate(ctx, endpointsUpdateChs[i], wantUpdate1); err != nil {
@@ -263,7 +263,7 @@ func (s) TestEndpointsWatchAfterCache(t *testing.T) {
 	}
 
 	wantUpdate := EndpointsUpdate{Localities: []Locality{testLocalities[0]}}
-	client.NewEndpoints(map[string]EndpointsUpdate{testCDSName: wantUpdate})
+	client.NewEndpoints(map[string]EndpointsUpdate{testCDSName: wantUpdate}, UpdateMetadata{})
 	if err := verifyEndpointsUpdate(ctx, endpointsUpdateCh, wantUpdate); err != nil {
 		t.Fatal(err)
 	}

--- a/xds/internal/client/watchers_listener_test.go
+++ b/xds/internal/client/watchers_listener_test.go
@@ -61,7 +61,7 @@ func (s) TestLDSWatch(t *testing.T) {
 	}
 
 	wantUpdate := ListenerUpdate{RouteConfigName: testRDSName}
-	client.NewListeners(map[string]ListenerUpdate{testLDSName: wantUpdate})
+	client.NewListeners(map[string]ListenerUpdate{testLDSName: wantUpdate}, UpdateMetadata{})
 	if err := verifyListenerUpdate(ctx, ldsUpdateCh, wantUpdate); err != nil {
 		t.Fatal(err)
 	}
@@ -70,14 +70,14 @@ func (s) TestLDSWatch(t *testing.T) {
 	client.NewListeners(map[string]ListenerUpdate{
 		testLDSName:  wantUpdate,
 		"randomName": {},
-	})
+	}, UpdateMetadata{})
 	if err := verifyListenerUpdate(ctx, ldsUpdateCh, wantUpdate); err != nil {
 		t.Fatal(err)
 	}
 
 	// Cancel watch, and send update again.
 	cancelWatch()
-	client.NewListeners(map[string]ListenerUpdate{testLDSName: wantUpdate})
+	client.NewListeners(map[string]ListenerUpdate{testLDSName: wantUpdate}, UpdateMetadata{})
 	sCtx, sCancel := context.WithTimeout(ctx, defaultTestShortTimeout)
 	defer sCancel()
 	if u, err := ldsUpdateCh.Receive(sCtx); err != context.DeadlineExceeded {
@@ -128,7 +128,7 @@ func (s) TestLDSTwoWatchSameResourceName(t *testing.T) {
 	}
 
 	wantUpdate := ListenerUpdate{RouteConfigName: testRDSName}
-	client.NewListeners(map[string]ListenerUpdate{testLDSName: wantUpdate})
+	client.NewListeners(map[string]ListenerUpdate{testLDSName: wantUpdate}, UpdateMetadata{})
 	for i := 0; i < count; i++ {
 		if err := verifyListenerUpdate(ctx, ldsUpdateChs[i], wantUpdate); err != nil {
 			t.Fatal(err)
@@ -137,7 +137,7 @@ func (s) TestLDSTwoWatchSameResourceName(t *testing.T) {
 
 	// Cancel the last watch, and send update again.
 	cancelLastWatch()
-	client.NewListeners(map[string]ListenerUpdate{testLDSName: wantUpdate})
+	client.NewListeners(map[string]ListenerUpdate{testLDSName: wantUpdate}, UpdateMetadata{})
 	for i := 0; i < count-1; i++ {
 		if err := verifyListenerUpdate(ctx, ldsUpdateChs[i], wantUpdate); err != nil {
 			t.Fatal(err)
@@ -205,7 +205,7 @@ func (s) TestLDSThreeWatchDifferentResourceName(t *testing.T) {
 	client.NewListeners(map[string]ListenerUpdate{
 		testLDSName + "1": wantUpdate1,
 		testLDSName + "2": wantUpdate2,
-	})
+	}, UpdateMetadata{})
 
 	for i := 0; i < count; i++ {
 		if err := verifyListenerUpdate(ctx, ldsUpdateChs[i], wantUpdate1); err != nil {
@@ -246,7 +246,7 @@ func (s) TestLDSWatchAfterCache(t *testing.T) {
 	}
 
 	wantUpdate := ListenerUpdate{RouteConfigName: testRDSName}
-	client.NewListeners(map[string]ListenerUpdate{testLDSName: wantUpdate})
+	client.NewListeners(map[string]ListenerUpdate{testLDSName: wantUpdate}, UpdateMetadata{})
 	if err := verifyListenerUpdate(ctx, ldsUpdateCh, wantUpdate); err != nil {
 		t.Fatal(err)
 	}
@@ -320,7 +320,7 @@ func (s) TestLDSResourceRemoved(t *testing.T) {
 	client.NewListeners(map[string]ListenerUpdate{
 		testLDSName + "1": wantUpdate1,
 		testLDSName + "2": wantUpdate2,
-	})
+	}, UpdateMetadata{})
 	if err := verifyListenerUpdate(ctx, ldsUpdateCh1, wantUpdate1); err != nil {
 		t.Fatal(err)
 	}
@@ -329,7 +329,7 @@ func (s) TestLDSResourceRemoved(t *testing.T) {
 	}
 
 	// Send another update to remove resource 1.
-	client.NewListeners(map[string]ListenerUpdate{testLDSName + "2": wantUpdate2})
+	client.NewListeners(map[string]ListenerUpdate{testLDSName + "2": wantUpdate2}, UpdateMetadata{})
 
 	// Watcher 1 should get an error.
 	if u, err := ldsUpdateCh1.Receive(ctx); err != nil || ErrType(u.(ldsUpdateErr).err) != ErrorTypeResourceNotFound {
@@ -342,7 +342,7 @@ func (s) TestLDSResourceRemoved(t *testing.T) {
 	}
 
 	// Send one more update without resource 1.
-	client.NewListeners(map[string]ListenerUpdate{testLDSName + "2": wantUpdate2})
+	client.NewListeners(map[string]ListenerUpdate{testLDSName + "2": wantUpdate2}, UpdateMetadata{})
 
 	// Watcher 1 should not see an update.
 	sCtx, sCancel := context.WithTimeout(ctx, defaultTestShortTimeout)

--- a/xds/internal/client/watchers_route_test.go
+++ b/xds/internal/client/watchers_route_test.go
@@ -70,13 +70,13 @@ func (s) TestRDSWatch(t *testing.T) {
 			},
 		},
 	}
-	client.NewRouteConfigs(map[string]RouteConfigUpdate{testRDSName: wantUpdate})
+	client.NewRouteConfigs(map[string]RouteConfigUpdate{testRDSName: wantUpdate}, UpdateMetadata{})
 	if err := verifyRouteConfigUpdate(ctx, rdsUpdateCh, wantUpdate); err != nil {
 		t.Fatal(err)
 	}
 
 	// Another update for a different resource name.
-	client.NewRouteConfigs(map[string]RouteConfigUpdate{"randomName": {}})
+	client.NewRouteConfigs(map[string]RouteConfigUpdate{"randomName": {}}, UpdateMetadata{})
 	sCtx, sCancel := context.WithTimeout(ctx, defaultTestShortTimeout)
 	defer sCancel()
 	if u, err := rdsUpdateCh.Receive(sCtx); err != context.DeadlineExceeded {
@@ -85,7 +85,7 @@ func (s) TestRDSWatch(t *testing.T) {
 
 	// Cancel watch, and send update again.
 	cancelWatch()
-	client.NewRouteConfigs(map[string]RouteConfigUpdate{testRDSName: wantUpdate})
+	client.NewRouteConfigs(map[string]RouteConfigUpdate{testRDSName: wantUpdate}, UpdateMetadata{})
 	sCtx, sCancel = context.WithTimeout(ctx, defaultTestShortTimeout)
 	defer sCancel()
 	if u, err := rdsUpdateCh.Receive(sCtx); err != context.DeadlineExceeded {
@@ -142,7 +142,7 @@ func (s) TestRDSTwoWatchSameResourceName(t *testing.T) {
 			},
 		},
 	}
-	client.NewRouteConfigs(map[string]RouteConfigUpdate{testRDSName: wantUpdate})
+	client.NewRouteConfigs(map[string]RouteConfigUpdate{testRDSName: wantUpdate}, UpdateMetadata{})
 	for i := 0; i < count; i++ {
 		if err := verifyRouteConfigUpdate(ctx, rdsUpdateChs[i], wantUpdate); err != nil {
 			t.Fatal(err)
@@ -151,7 +151,7 @@ func (s) TestRDSTwoWatchSameResourceName(t *testing.T) {
 
 	// Cancel the last watch, and send update again.
 	cancelLastWatch()
-	client.NewRouteConfigs(map[string]RouteConfigUpdate{testRDSName: wantUpdate})
+	client.NewRouteConfigs(map[string]RouteConfigUpdate{testRDSName: wantUpdate}, UpdateMetadata{})
 	for i := 0; i < count-1; i++ {
 		if err := verifyRouteConfigUpdate(ctx, rdsUpdateChs[i], wantUpdate); err != nil {
 			t.Fatal(err)
@@ -232,7 +232,7 @@ func (s) TestRDSThreeWatchDifferentResourceName(t *testing.T) {
 	client.NewRouteConfigs(map[string]RouteConfigUpdate{
 		testRDSName + "1": wantUpdate1,
 		testRDSName + "2": wantUpdate2,
-	})
+	}, UpdateMetadata{})
 
 	for i := 0; i < count; i++ {
 		if err := verifyRouteConfigUpdate(ctx, rdsUpdateChs[i], wantUpdate1); err != nil {
@@ -280,7 +280,7 @@ func (s) TestRDSWatchAfterCache(t *testing.T) {
 			},
 		},
 	}
-	client.NewRouteConfigs(map[string]RouteConfigUpdate{testRDSName: wantUpdate})
+	client.NewRouteConfigs(map[string]RouteConfigUpdate{testRDSName: wantUpdate}, UpdateMetadata{})
 	if err := verifyRouteConfigUpdate(ctx, rdsUpdateCh, wantUpdate); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Metadata includs timestamp, status, raw message, error details.
Before, it only keeps parsed resources.

- Change `UnmarshalXXX()` functions (e.g. `UnmarshalListener()` to return metadata)
  - Metadata is not populated yet. Will be done in the next PR.
- Change `NewXXX()` functions (e.g. `NewListener()` to handle the metadata)
- Add `Dump()` functions to dump message and metadata

Most of the test changes are boilerplate changes due to the function signature change.
The real tests are in `dump_test.go`