### PR TITLE
encoding/proto: do not panic when types do not match

### DIFF
--- a/encoding/proto/proto.go
+++ b/encoding/proto/proto.go
@@ -40,7 +40,7 @@ type codec struct{}
 func (codec) Marshal(v interface{}) ([]byte, error) {
 	vv, ok := v.(proto.Message)
 	if !ok {
-		return nil, fmt.Errorf("failed to marshal, message is %T, want proto", v)
+		return nil, fmt.Errorf("failed to marshal, message is %T, want proto.Message", v)
 	}
 	return proto.Marshal(vv)
 }
@@ -48,7 +48,7 @@ func (codec) Marshal(v interface{}) ([]byte, error) {
 func (codec) Unmarshal(data []byte, v interface{}) error {
 	vv, ok := v.(proto.Message)
 	if !ok {
-		return fmt.Errorf("failed to marshal, message is %T, want proto", v)
+		return fmt.Errorf("failed to unmarshal, message is %T, want proto.Message", v)
 	}
 	return proto.Unmarshal(data, vv)
 }

--- a/encoding/proto/proto.go
+++ b/encoding/proto/proto.go
@@ -21,6 +21,8 @@
 package proto
 
 import (
+	"fmt"
+
 	"github.com/golang/protobuf/proto"
 	"google.golang.org/grpc/encoding"
 )
@@ -36,11 +38,19 @@ func init() {
 type codec struct{}
 
 func (codec) Marshal(v interface{}) ([]byte, error) {
-	return proto.Marshal(v.(proto.Message))
+	vv, ok := v.(proto.Message)
+	if !ok {
+		return nil, fmt.Errorf("failed to marshal, message is %T, want proto", v)
+	}
+	return proto.Marshal(vv)
 }
 
 func (codec) Unmarshal(data []byte, v interface{}) error {
-	return proto.Unmarshal(data, v.(proto.Message))
+	vv, ok := v.(proto.Message)
+	if !ok {
+		return fmt.Errorf("failed to marshal, message is %T, want proto", v)
+	}
+	return proto.Unmarshal(data, vv)
 }
 
 func (codec) Name() string {


### PR DESCRIPTION
fixes #4213

The type mismatch can happen if
1. user is using a non-proto generated code, so the message is not `proto.Message`
2. the proto codec is picked (e.g. on receiving side, by content-type `application/grpc+subtype`)