### PR TITLE
xds/bootstrap: Support server_listener_resource_name_template

### DIFF
--- a/internal/internal.go
+++ b/internal/internal.go
@@ -65,6 +65,10 @@ var (
 	// gRPC server. An xDS-enabled server needs to know what type of credentials
 	// is configured on the underlying gRPC server. This is set by server.go.
 	GetServerCredentials interface{} // func (*grpc.Server) credentials.TransportCredentials
+	// AddressFromListenerResourceName extracts the listening address encoded in
+	// the Listener resource name on the server side. This is implemented by the
+	// xdsClient code.
+	AddressFromListenerResourceName func(string) (string, string, error)
 )
 
 // HealthChecker defines the signature of the client-side LB channel health checking function.

--- a/xds/internal/client/bootstrap/bootstrap.go
+++ b/xds/internal/client/bootstrap/bootstrap.go
@@ -79,10 +79,12 @@ type Config struct {
 	// CertProviderConfigs contains a mapping from certificate provider plugin
 	// instance names to parsed buildable configs.
 	CertProviderConfigs map[string]*certprovider.BuildableConfig
-	// ServerResourceNameID contains the value to be used as the id in the
-	// resource name used to fetch the Listener resource on the xDS-enabled gRPC
-	// server.
-	ServerResourceNameID string
+	// ServerListenerResourceNameTemplate is a template for the name of the
+	// Listener resource to subscribe to for a gRPC server. If the token `%s` is
+	// present in the string, it will be replaced with the server's listening
+	// "IP:port" (e.g., "0.0.0.0:8080", "[::]:8080"). For example, a value of
+	// "example/resource/%s" could become "example/resource/0.0.0.0:8080".
+	ServerListenerResourceNameTemplate string
 }
 
 type channelCreds struct {
@@ -145,7 +147,7 @@ func bootstrapConfigFromEnvVariable() ([]byte, error) {
 //        "config": { foo plugin config in JSON }
 //      }
 //    },
-//    "grpc_server_resource_name_id": "grpc/server"
+//    "server_listener_resource_name_template": "grpc/server?xds.resource.listening_address=%s"
 // }
 //
 // Currently, we support exactly one type of credential, which is
@@ -241,8 +243,8 @@ func NewConfig() (*Config, error) {
 				configs[instance] = bc
 			}
 			config.CertProviderConfigs = configs
-		case "grpc_server_resource_name_id":
-			if err := json.Unmarshal(v, &config.ServerResourceNameID); err != nil {
+		case "server_listener_resource_name_template":
+			if err := json.Unmarshal(v, &config.ServerListenerResourceNameTemplate); err != nil {
 				return nil, fmt.Errorf("xds: json.Unmarshal(%v) for field %q failed during bootstrap: %v", string(v), k, err)
 			}
 		}

--- a/xds/internal/client/bootstrap/bootstrap_test.go
+++ b/xds/internal/client/bootstrap/bootstrap_test.go
@@ -240,8 +240,8 @@ func (c *Config) compare(want *Config) error {
 	if diff := cmp.Diff(want.NodeProto, c.NodeProto, cmp.Comparer(proto.Equal)); diff != "" {
 		return fmt.Errorf("config.NodeProto diff (-want, +got):\n%s", diff)
 	}
-	if c.ServerResourceNameID != want.ServerResourceNameID {
-		return fmt.Errorf("config.ServerResourceNameID is %q, want %q", c.ServerResourceNameID, want.ServerResourceNameID)
+	if c.ServerListenerResourceNameTemplate != want.ServerListenerResourceNameTemplate {
+		return fmt.Errorf("config.ServerListenerResourceNameTemplate is %q, want %q", c.ServerListenerResourceNameTemplate, want.ServerListenerResourceNameTemplate)
 	}
 
 	// A vanilla cmp.Equal or cmp.Diff will not produce useful error message
@@ -711,9 +711,9 @@ func TestNewConfigWithCertificateProviders(t *testing.T) {
 	}
 }
 
-func TestNewConfigWithServerResourceNameID(t *testing.T) {
+func TestNewConfigWithServerListenerResourceNameTemplate(t *testing.T) {
 	cancel := setupBootstrapOverride(map[string]string{
-		"badServerResourceNameID": `
+		"badServerListenerResourceNameTemplate": `
 		{
 			"node": {
 				"id": "ENVOY_NODE_ID",
@@ -727,9 +727,9 @@ func TestNewConfigWithServerResourceNameID(t *testing.T) {
 					{ "type": "google_default" }
 				]
 			}],
-			"grpc_server_resource_name_id": 123456789
+			"server_listener_resource_name_template": 123456789
 		}`,
-		"goodServerResourceNameID": `
+		"goodServerListenerResourceNameTemplate": `
 		{
 			"node": {
 				"id": "ENVOY_NODE_ID",
@@ -743,7 +743,7 @@ func TestNewConfigWithServerResourceNameID(t *testing.T) {
 					{ "type": "google_default" }
 				]
 			}],
-			"grpc_server_resource_name_id": "grpc/server"
+			"server_listener_resource_name_template": "grpc/server?xds.resource.listening_address=%s"
 		}`,
 	})
 	defer cancel()
@@ -754,17 +754,17 @@ func TestNewConfigWithServerResourceNameID(t *testing.T) {
 		wantErr    bool
 	}{
 		{
-			name:    "badServerResourceNameID",
+			name:    "badServerListenerResourceNameTemplate",
 			wantErr: true,
 		},
 		{
-			name: "goodServerResourceNameID",
+			name: "goodServerListenerResourceNameTemplate",
 			wantConfig: &Config{
-				BalancerName:         "trafficdirector.googleapis.com:443",
-				Creds:                grpc.WithCredentialsBundle(google.NewComputeEngineCredentials()),
-				TransportAPI:         version.TransportV2,
-				NodeProto:            v2NodeProto,
-				ServerResourceNameID: "grpc/server",
+				BalancerName:                       "trafficdirector.googleapis.com:443",
+				Creds:                              grpc.WithCredentialsBundle(google.NewComputeEngineCredentials()),
+				TransportAPI:                       version.TransportV2,
+				NodeProto:                          v2NodeProto,
+				ServerListenerResourceNameTemplate: "grpc/server?xds.resource.listening_address=%s",
 			},
 		},
 	}

--- a/xds/internal/client/lds_test.go
+++ b/xds/internal/client/lds_test.go
@@ -19,22 +19,10 @@
 package client
 
 import (
-	"fmt"
 	"strings"
 	"testing"
 	"time"
 
-	"github.com/golang/protobuf/proto"
-	"github.com/golang/protobuf/ptypes"
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"google.golang.org/grpc/xds/internal/env"
-	"google.golang.org/grpc/xds/internal/httpfilter"
-	"google.golang.org/grpc/xds/internal/version"
-	"google.golang.org/protobuf/testing/protocmp"
-	"google.golang.org/protobuf/types/known/durationpb"
-
-	v1typepb "github.com/cncf/udpa/go/udpa/type/v1"
 	v2xdspb "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	v2corepb "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	v3corepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -43,9 +31,18 @@ import (
 	v3listenerpb "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	v3httppb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	v3tlspb "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
+	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/ptypes"
 	anypb "github.com/golang/protobuf/ptypes/any"
-	spb "github.com/golang/protobuf/ptypes/struct"
 	wrapperspb "github.com/golang/protobuf/ptypes/wrappers"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"google.golang.org/protobuf/types/known/durationpb"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/xds/internal/client/bootstrap"
+	xdstestutils "google.golang.org/grpc/xds/internal/testutils"
+	"google.golang.org/grpc/xds/internal/version"
 )
 
 func (s) TestUnmarshalListener_ClientSide(t *testing.T) {
@@ -84,59 +81,32 @@ func (s) TestUnmarshalListener_ClientSide(t *testing.T) {
 				return mLis
 			}(),
 		}
-		customFilter = &v3httppb.HttpFilter{
-			Name:       "customFilter",
-			ConfigType: &v3httppb.HttpFilter_TypedConfig{TypedConfig: customFilterConfig},
-		}
-		typedStructFilter = &v3httppb.HttpFilter{
-			Name:       "customFilter",
-			ConfigType: &v3httppb.HttpFilter_TypedConfig{TypedConfig: wrappedCustomFilterTypedStructConfig},
-		}
-		customFilter2 = &v3httppb.HttpFilter{
-			Name:       "customFilter2",
-			ConfigType: &v3httppb.HttpFilter_TypedConfig{TypedConfig: customFilterConfig},
-		}
-		errFilter = &v3httppb.HttpFilter{
-			Name:       "errFilter",
-			ConfigType: &v3httppb.HttpFilter_TypedConfig{TypedConfig: errFilterConfig},
-		}
-		clientOnlyCustomFilter = &v3httppb.HttpFilter{
-			Name:       "clientOnlyCustomFilter",
-			ConfigType: &v3httppb.HttpFilter_TypedConfig{TypedConfig: clientOnlyCustomFilterConfig},
-		}
-		serverOnlyCustomFilter = &v3httppb.HttpFilter{
-			Name:       "serverOnlyCustomFilter",
-			ConfigType: &v3httppb.HttpFilter_TypedConfig{TypedConfig: serverOnlyCustomFilterConfig},
-		}
-		v3LisWithFilters = func(fs ...*v3httppb.HttpFilter) *anypb.Any {
-			hcm := &v3httppb.HttpConnectionManager{
-				RouteSpecifier: &v3httppb.HttpConnectionManager_Rds{
-					Rds: &v3httppb.Rds{
-						ConfigSource: &v3corepb.ConfigSource{
-							ConfigSourceSpecifier: &v3corepb.ConfigSource_Ads{Ads: &v3corepb.AggregatedConfigSource{}},
+		v3Lis = &anypb.Any{
+			TypeUrl: version.V3ListenerURL,
+			Value: func() []byte {
+				cm := &v3httppb.HttpConnectionManager{
+					RouteSpecifier: &v3httppb.HttpConnectionManager_Rds{
+						Rds: &v3httppb.Rds{
+							ConfigSource: &v3corepb.ConfigSource{
+								ConfigSourceSpecifier: &v3corepb.ConfigSource_Ads{Ads: &v3corepb.AggregatedConfigSource{}},
+							},
+							RouteConfigName: v3RouteConfigName,
 						},
-						RouteConfigName: v3RouteConfigName,
 					},
-				},
-				CommonHttpProtocolOptions: &v3corepb.HttpProtocolOptions{
-					MaxStreamDuration: durationpb.New(time.Second),
-				},
-				HttpFilters: fs,
-			}
-			return &anypb.Any{
-				TypeUrl: version.V3ListenerURL,
-				Value: func() []byte {
-					mcm, _ := ptypes.MarshalAny(hcm)
-					lis := &v3listenerpb.Listener{
-						Name: v3LDSTarget,
-						ApiListener: &v3listenerpb.ApiListener{
-							ApiListener: mcm,
-						},
-					}
-					mLis, _ := proto.Marshal(lis)
-					return mLis
-				}(),
-			}
+					CommonHttpProtocolOptions: &v3corepb.HttpProtocolOptions{
+						MaxStreamDuration: durationpb.New(time.Second),
+					},
+				}
+				mcm, _ := ptypes.MarshalAny(cm)
+				lis := &v3listenerpb.Listener{
+					Name: v3LDSTarget,
+					ApiListener: &v3listenerpb.ApiListener{
+						ApiListener: mcm,
+					},
+				}
+				mLis, _ := proto.Marshal(lis)
+				return mLis
+			}(),
 		}
 	)
 
@@ -145,7 +115,6 @@ func (s) TestUnmarshalListener_ClientSide(t *testing.T) {
 		resources  []*anypb.Any
 		wantUpdate map[string]ListenerUpdate
 		wantErr    bool
-		disableFI  bool // disable fault injection
 	}{
 		{
 			name:      "non-listener resource",
@@ -308,104 +277,6 @@ func (s) TestUnmarshalListener_ClientSide(t *testing.T) {
 			name: "empty resource list",
 		},
 		{
-			name:      "v3 with no filters",
-			resources: []*anypb.Any{v3LisWithFilters()},
-			wantUpdate: map[string]ListenerUpdate{
-				v3LDSTarget: {RouteConfigName: v3RouteConfigName, MaxStreamDuration: time.Second},
-			},
-		},
-		{
-			name:      "v3 with custom filter",
-			resources: []*anypb.Any{v3LisWithFilters(customFilter)},
-			wantUpdate: map[string]ListenerUpdate{
-				v3LDSTarget: {
-					RouteConfigName: v3RouteConfigName, MaxStreamDuration: time.Second,
-					HTTPFilters: []HTTPFilter{{
-						Name:   "customFilter",
-						Filter: httpFilter{},
-						Config: filterConfig{Cfg: customFilterConfig},
-					}},
-				},
-			},
-		},
-		{
-			name:      "v3 with custom filter in typed struct",
-			resources: []*anypb.Any{v3LisWithFilters(typedStructFilter)},
-			wantUpdate: map[string]ListenerUpdate{
-				v3LDSTarget: {
-					RouteConfigName: v3RouteConfigName, MaxStreamDuration: time.Second,
-					HTTPFilters: []HTTPFilter{{
-						Name:   "customFilter",
-						Filter: httpFilter{},
-						Config: filterConfig{Cfg: customFilterTypedStructConfig},
-					}},
-				},
-			},
-		},
-		{
-			name:      "v3 with custom filter, fault injection disabled",
-			resources: []*anypb.Any{v3LisWithFilters(customFilter)},
-			wantUpdate: map[string]ListenerUpdate{
-				v3LDSTarget: {RouteConfigName: v3RouteConfigName, MaxStreamDuration: time.Second},
-			},
-			disableFI: true,
-		},
-		{
-			name:      "v3 with two filters with same name",
-			resources: []*anypb.Any{v3LisWithFilters(customFilter, customFilter)},
-			wantErr:   true,
-		},
-		{
-			name:      "v3 with two filters - same type different name",
-			resources: []*anypb.Any{v3LisWithFilters(customFilter, customFilter2)},
-			wantUpdate: map[string]ListenerUpdate{
-				v3LDSTarget: {
-					RouteConfigName: v3RouteConfigName, MaxStreamDuration: time.Second,
-					HTTPFilters: []HTTPFilter{{
-						Name:   "customFilter",
-						Filter: httpFilter{},
-						Config: filterConfig{Cfg: customFilterConfig},
-					}, {
-						Name:   "customFilter2",
-						Filter: httpFilter{},
-						Config: filterConfig{Cfg: customFilterConfig},
-					}},
-				},
-			},
-		},
-		{
-			name:      "v3 with server-only filter",
-			resources: []*anypb.Any{v3LisWithFilters(serverOnlyCustomFilter)},
-			wantErr:   true,
-		},
-		{
-			name:      "v3 with client-only filter",
-			resources: []*anypb.Any{v3LisWithFilters(clientOnlyCustomFilter)},
-			wantUpdate: map[string]ListenerUpdate{
-				v3LDSTarget: {
-					RouteConfigName: v3RouteConfigName, MaxStreamDuration: time.Second,
-					HTTPFilters: []HTTPFilter{{
-						Name:   "clientOnlyCustomFilter",
-						Filter: clientOnlyHTTPFilter{},
-						Config: filterConfig{Cfg: clientOnlyCustomFilterConfig},
-					}},
-				},
-			},
-		},
-		{
-			name:      "v3 with err filter",
-			resources: []*anypb.Any{v3LisWithFilters(errFilter)},
-			wantErr:   true,
-		},
-		{
-			name:      "v3 with error filter, fault injection disabled",
-			resources: []*anypb.Any{v3LisWithFilters(errFilter)},
-			wantUpdate: map[string]ListenerUpdate{
-				v3LDSTarget: {RouteConfigName: v3RouteConfigName, MaxStreamDuration: time.Second},
-			},
-			disableFI: true,
-		},
-		{
 			name:      "v2 listener resource",
 			resources: []*anypb.Any{v2Lis},
 			wantUpdate: map[string]ListenerUpdate{
@@ -414,14 +285,14 @@ func (s) TestUnmarshalListener_ClientSide(t *testing.T) {
 		},
 		{
 			name:      "v3 listener resource",
-			resources: []*anypb.Any{v3LisWithFilters()},
+			resources: []*anypb.Any{v3Lis},
 			wantUpdate: map[string]ListenerUpdate{
 				v3LDSTarget: {RouteConfigName: v3RouteConfigName, MaxStreamDuration: time.Second},
 			},
 		},
 		{
 			name:      "multiple listener resources",
-			resources: []*anypb.Any{v2Lis, v3LisWithFilters()},
+			resources: []*anypb.Any{v2Lis, v3Lis},
 			wantUpdate: map[string]ListenerUpdate{
 				v2LDSTarget: {RouteConfigName: v2RouteConfigName},
 				v3LDSTarget: {RouteConfigName: v3RouteConfigName, MaxStreamDuration: time.Second},
@@ -431,22 +302,39 @@ func (s) TestUnmarshalListener_ClientSide(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			oldFI := env.FaultInjectionSupport
-			env.FaultInjectionSupport = !test.disableFI
-
-			update, _, err := UnmarshalListener("", test.resources, nil)
-			if ((err != nil) != test.wantErr) ||
-				!cmp.Equal(update, test.wantUpdate, cmpopts.EquateEmpty(), protocmp.Transform()) {
+			update, err := UnmarshalListener(test.resources, nil)
+			if ((err != nil) != test.wantErr) || !cmp.Equal(update, test.wantUpdate, cmpopts.EquateEmpty()) {
 				t.Errorf("UnmarshalListener(%v) = (%v, %v) want (%v, %v)", test.resources, update, err, test.wantUpdate, test.wantErr)
 			}
-
-			env.FaultInjectionSupport = oldFI
 		})
 	}
 }
 
 func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
-	const v3LDSTarget = "grpc/server?udpa.resource.listening_address=0.0.0.0:9999"
+	const v3LDSTarget = "grpc/server?xds.resource.listening_address=0.0.0.0:9999"
+
+	// Unmarshaling a server-side listener actually ends up attempting to create
+	// an xdsClient because it needs to verify if the received Listener
+	// resource's name field encodes the IP:port in its address field. Hence we
+	// need to override the bootstrap and API client creation here.
+	origBootstrapNewConfig := bootstrapNewConfig
+	bootstrapNewConfig = func() (*bootstrap.Config, error) {
+		return &bootstrap.Config{
+			BalancerName:                       testXDSServer,
+			TransportAPI:                       version.TransportV3,
+			Creds:                              grpc.WithInsecure(),
+			NodeProto:                          xdstestutils.EmptyNodeProtoV3,
+			ServerListenerResourceNameTemplate: "grpc/server?xds.resource.listening_address=%s",
+		}, nil
+	}
+	origNewAPIClient := newAPIClient
+	newAPIClient = func(_ version.TransportAPI, _ *grpc.ClientConn, _ BuildOptions) (APIClient, error) {
+		return newTestAPIClient(), nil
+	}
+	defer func() {
+		bootstrapNewConfig = origBootstrapNewConfig
+		newAPIClient = origNewAPIClient
+	}()
 
 	tests := []struct {
 		name       string
@@ -486,84 +374,6 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 				},
 			},
 			wantErr: "no socket_address field in LDS response",
-		},
-		{
-			name: "listener name does not match expected format",
-			resources: []*anypb.Any{
-				{
-					TypeUrl: version.V3ListenerURL,
-					Value: func() []byte {
-						lis := &v3listenerpb.Listener{
-							Name: "foo",
-							Address: &v3corepb.Address{
-								Address: &v3corepb.Address_SocketAddress{
-									SocketAddress: &v3corepb.SocketAddress{
-										Address: "0.0.0.0",
-										PortSpecifier: &v3corepb.SocketAddress_PortValue{
-											PortValue: 9999,
-										},
-									},
-								},
-							},
-						}
-						mLis, _ := proto.Marshal(lis)
-						return mLis
-					}(),
-				},
-			},
-			wantErr: "no host:port in name field of LDS response",
-		},
-		{
-			name: "host mismatch",
-			resources: []*anypb.Any{
-				{
-					TypeUrl: version.V3ListenerURL,
-					Value: func() []byte {
-						lis := &v3listenerpb.Listener{
-							Name: v3LDSTarget,
-							Address: &v3corepb.Address{
-								Address: &v3corepb.Address_SocketAddress{
-									SocketAddress: &v3corepb.SocketAddress{
-										Address: "1.2.3.4",
-										PortSpecifier: &v3corepb.SocketAddress_PortValue{
-											PortValue: 9999,
-										},
-									},
-								},
-							},
-						}
-						mLis, _ := proto.Marshal(lis)
-						return mLis
-					}(),
-				},
-			},
-			wantErr: "socket_address host does not match the one in name",
-		},
-		{
-			name: "port mismatch",
-			resources: []*anypb.Any{
-				{
-					TypeUrl: version.V3ListenerURL,
-					Value: func() []byte {
-						lis := &v3listenerpb.Listener{
-							Name: v3LDSTarget,
-							Address: &v3corepb.Address{
-								Address: &v3corepb.Address_SocketAddress{
-									SocketAddress: &v3corepb.SocketAddress{
-										Address: "0.0.0.0",
-										PortSpecifier: &v3corepb.SocketAddress_PortValue{
-											PortValue: 1234,
-										},
-									},
-								},
-							},
-						}
-						mLis, _ := proto.Marshal(lis)
-						return mLis
-					}(),
-				},
-			},
-			wantErr: "socket_address port does not match the one in name",
 		},
 		{
 			name: "unexpected number of filter chains",
@@ -834,7 +644,12 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 				},
 			},
 			wantUpdate: map[string]ListenerUpdate{
-				v3LDSTarget: {},
+				v3LDSTarget: {
+					InboundListenerCfg: &InboundListenerConfig{
+						Address: "0.0.0.0",
+						Port:    "9999",
+					},
+				},
 			},
 		},
 		{
@@ -990,6 +805,10 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 						IdentityInstanceName: "identityPluginInstance",
 						IdentityCertName:     "identityCertName",
 					},
+					InboundListenerCfg: &InboundListenerConfig{
+						Address: "0.0.0.0",
+						Port:    "9999",
+					},
 				},
 			},
 		},
@@ -1058,6 +877,10 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 						IdentityCertName:     "identityCertName",
 						RequireClientCert:    true,
 					},
+					InboundListenerCfg: &InboundListenerConfig{
+						Address: "0.0.0.0",
+						Port:    "9999",
+					},
 				},
 			},
 		},
@@ -1065,7 +888,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			gotUpdate, _, err := UnmarshalListener("", test.resources, nil)
+			gotUpdate, err := UnmarshalListener(test.resources, nil)
 			if (err != nil) != (test.wantErr != "") {
 				t.Fatalf("UnmarshalListener(%v) = %v wantErr: %q", test.resources, err, test.wantErr)
 			}
@@ -1076,117 +899,5 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 				t.Errorf("UnmarshalListener(%v) = %v want %v", test.resources, gotUpdate, test.wantUpdate)
 			}
 		})
-	}
-}
-
-type filterConfig struct {
-	httpfilter.FilterConfig
-	Cfg      proto.Message
-	Override proto.Message
-}
-
-// httpFilter allows testing the http filter registry and parsing functionality.
-type httpFilter struct {
-	httpfilter.ClientInterceptorBuilder
-	httpfilter.ServerInterceptorBuilder
-}
-
-func (httpFilter) TypeURLs() []string { return []string{"custom.filter"} }
-
-func (httpFilter) ParseFilterConfig(cfg proto.Message) (httpfilter.FilterConfig, error) {
-	return filterConfig{Cfg: cfg}, nil
-}
-
-func (httpFilter) ParseFilterConfigOverride(override proto.Message) (httpfilter.FilterConfig, error) {
-	return filterConfig{Override: override}, nil
-}
-
-// errHTTPFilter returns errors no matter what is passed to ParseFilterConfig.
-type errHTTPFilter struct {
-	httpfilter.ClientInterceptorBuilder
-}
-
-func (errHTTPFilter) TypeURLs() []string { return []string{"err.custom.filter"} }
-
-func (errHTTPFilter) ParseFilterConfig(cfg proto.Message) (httpfilter.FilterConfig, error) {
-	return nil, fmt.Errorf("error from ParseFilterConfig")
-}
-
-func (errHTTPFilter) ParseFilterConfigOverride(override proto.Message) (httpfilter.FilterConfig, error) {
-	return nil, fmt.Errorf("error from ParseFilterConfigOverride")
-}
-
-func init() {
-	httpfilter.Register(httpFilter{})
-	httpfilter.Register(errHTTPFilter{})
-	httpfilter.Register(serverOnlyHTTPFilter{})
-	httpfilter.Register(clientOnlyHTTPFilter{})
-}
-
-// serverOnlyHTTPFilter does not implement ClientInterceptorBuilder
-type serverOnlyHTTPFilter struct {
-	httpfilter.ServerInterceptorBuilder
-}
-
-func (serverOnlyHTTPFilter) TypeURLs() []string { return []string{"serverOnly.custom.filter"} }
-
-func (serverOnlyHTTPFilter) ParseFilterConfig(cfg proto.Message) (httpfilter.FilterConfig, error) {
-	return filterConfig{Cfg: cfg}, nil
-}
-
-func (serverOnlyHTTPFilter) ParseFilterConfigOverride(override proto.Message) (httpfilter.FilterConfig, error) {
-	return filterConfig{Override: override}, nil
-}
-
-// clientOnlyHTTPFilter does not implement ServerInterceptorBuilder
-type clientOnlyHTTPFilter struct {
-	httpfilter.ClientInterceptorBuilder
-}
-
-func (clientOnlyHTTPFilter) TypeURLs() []string { return []string{"clientOnly.custom.filter"} }
-
-func (clientOnlyHTTPFilter) ParseFilterConfig(cfg proto.Message) (httpfilter.FilterConfig, error) {
-	return filterConfig{Cfg: cfg}, nil
-}
-
-func (clientOnlyHTTPFilter) ParseFilterConfigOverride(override proto.Message) (httpfilter.FilterConfig, error) {
-	return filterConfig{Override: override}, nil
-}
-
-var customFilterConfig = &anypb.Any{
-	TypeUrl: "custom.filter",
-	Value:   []byte{1, 2, 3},
-}
-
-var errFilterConfig = &anypb.Any{
-	TypeUrl: "err.custom.filter",
-	Value:   []byte{1, 2, 3},
-}
-
-var serverOnlyCustomFilterConfig = &anypb.Any{
-	TypeUrl: "serverOnly.custom.filter",
-	Value:   []byte{1, 2, 3},
-}
-
-var clientOnlyCustomFilterConfig = &anypb.Any{
-	TypeUrl: "clientOnly.custom.filter",
-	Value:   []byte{1, 2, 3},
-}
-
-var customFilterTypedStructConfig = &v1typepb.TypedStruct{
-	TypeUrl: "custom.filter",
-	Value: &spb.Struct{
-		Fields: map[string]*spb.Value{
-			"foo": {Kind: &spb.Value_StringValue{StringValue: "bar"}},
-		},
-	},
-}
-var wrappedCustomFilterTypedStructConfig *anypb.Any
-
-func init() {
-	var err error
-	wrappedCustomFilterTypedStructConfig, err = ptypes.MarshalAny(customFilterTypedStructConfig)
-	if err != nil {
-		panic(err.Error())
 	}
 }

--- a/xds/internal/client/xds.go
+++ b/xds/internal/client/xds.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"net"
 	"strconv"
-	"strings"
 
 	v1typepb "github.com/cncf/udpa/go/udpa/type/v1"
 	v3clusterpb "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
@@ -39,7 +38,7 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 
 	"google.golang.org/grpc/internal/grpclog"
-	"google.golang.org/grpc/xds/internal"
+	xdsinternal "google.golang.org/grpc/xds/internal"
 	"google.golang.org/grpc/xds/internal/env"
 	"google.golang.org/grpc/xds/internal/httpfilter"
 	"google.golang.org/grpc/xds/internal/version"
@@ -217,10 +216,6 @@ func processHTTPFilters(filters []*v3httppb.HttpFilter, server bool) ([]HTTPFilt
 }
 
 func processServerSideListener(lis *v3listenerpb.Listener) (*ListenerUpdate, error) {
-	// Make sure that an address encoded in the received listener resource, and
-	// that it matches the one specified in the name. Listener names on the
-	// server-side as in the following format:
-	// grpc/server?udpa.resource.listening_address=IP:Port.
 	addr := lis.GetAddress()
 	if addr == nil {
 		return nil, fmt.Errorf("xds: no address field in LDS response: %+v", lis)
@@ -229,15 +224,11 @@ func processServerSideListener(lis *v3listenerpb.Listener) (*ListenerUpdate, err
 	if sockAddr == nil {
 		return nil, fmt.Errorf("xds: no socket_address field in LDS response: %+v", lis)
 	}
-	host, port, err := getAddressFromName(lis.GetName())
-	if err != nil {
-		return nil, fmt.Errorf("xds: no host:port in name field of LDS response: %+v, error: %v", lis, err)
-	}
-	if h := sockAddr.GetAddress(); host != h {
-		return nil, fmt.Errorf("xds: socket_address host does not match the one in name. Got %q, want %q", h, host)
-	}
-	if p := strconv.Itoa(int(sockAddr.GetPortValue())); port != p {
-		return nil, fmt.Errorf("xds: socket_address port does not match the one in name. Got %q, want %q", p, port)
+	lu := &ListenerUpdate{
+		InboundListenerCfg: &InboundListenerConfig{
+			Address: sockAddr.GetAddress(),
+			Port:    strconv.Itoa(int(sockAddr.GetPortValue())),
+		},
 	}
 
 	// Make sure the listener resource contains a single filter chain. We do not
@@ -254,7 +245,7 @@ func processServerSideListener(lis *v3listenerpb.Listener) (*ListenerUpdate, err
 	// xdsCredentials.
 	ts := fc.GetTransportSocket()
 	if ts == nil {
-		return &ListenerUpdate{}, nil
+		return lu, nil
 	}
 	if name := ts.GetName(); name != transportSocketName {
 		return nil, fmt.Errorf("xds: transport_socket field has unexpected name: %s", name)
@@ -281,15 +272,8 @@ func processServerSideListener(lis *v3listenerpb.Listener) (*ListenerUpdate, err
 	if sc.RequireClientCert && sc.RootInstanceName == "" {
 		return nil, errors.New("security configuration on the server-side does not contain root certificate provider instance name, but require_client_cert field is set")
 	}
-	return &ListenerUpdate{SecurityCfg: sc}, nil
-}
-
-func getAddressFromName(name string) (host string, port string, err error) {
-	parts := strings.SplitN(name, "udpa.resource.listening_address=", 2)
-	if len(parts) != 2 {
-		return "", "", fmt.Errorf("udpa.resource_listening_address not found in name: %v", name)
-	}
-	return net.SplitHostPort(parts[1])
+	lu.SecurityCfg = sc
+	return lu, nil
 }
 
 // UnmarshalRouteConfig processes resources received in an RDS response,
@@ -723,7 +707,7 @@ func parseEDSRespProto(m *v3endpointpb.ClusterLoadAssignment) (EndpointsUpdate, 
 		if l == nil {
 			return EndpointsUpdate{}, fmt.Errorf("EDS response contains a locality without ID, locality: %+v", locality)
 		}
-		lid := internal.LocalityID{
+		lid := xdsinternal.LocalityID{
 			Region:  l.Region,
 			Zone:    l.Zone,
 			SubZone: l.SubZone,

--- a/xds/internal/test/xds_server_integration_test.go
+++ b/xds/internal/test/xds_server_integration_test.go
@@ -60,6 +60,9 @@ const (
 	certFile = "cert.pem"
 	keyFile  = "key.pem"
 	rootFile = "ca.pem"
+
+	// Template for server Listener resource name.
+	serverListenerResourceNameTemplate = "grpc/server?xds.resource.listening_address=%s"
 )
 
 func createTmpFile(t *testing.T, src, dst string) {
@@ -148,11 +151,11 @@ func commonSetup(t *testing.T) (*e2e.ManagementServer, string, net.Listener, fun
 
 	// Create a bootstrap file in a temporary directory.
 	bootstrapCleanup, err := e2e.SetupBootstrapFile(e2e.BootstrapOptions{
-		Version:              e2e.TransportV3,
-		NodeID:               nodeID,
-		ServerURI:            fs.Address,
-		CertificateProviders: cpc,
-		ServerResourceNameID: "grpc/server",
+		Version:                            e2e.TransportV3,
+		NodeID:                             nodeID,
+		ServerURI:                          fs.Address,
+		CertificateProviders:               cpc,
+		ServerListenerResourceNameTemplate: serverListenerResourceNameTemplate,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -211,7 +214,7 @@ func listenerResourceWithoutSecurityConfig(t *testing.T, lis net.Listener) *v3li
 	host, port := hostPortFromListener(t, lis)
 	return &v3listenerpb.Listener{
 		// This needs to match the name we are querying for.
-		Name: fmt.Sprintf("grpc/server?udpa.resource.listening_address=%s", lis.Addr().String()),
+		Name: fmt.Sprintf(serverListenerResourceNameTemplate, lis.Addr().String()),
 		Address: &v3corepb.Address{
 			Address: &v3corepb.Address_SocketAddress{
 				SocketAddress: &v3corepb.SocketAddress{
@@ -237,7 +240,7 @@ func listenerResourceWithSecurityConfig(t *testing.T, lis net.Listener) *v3liste
 	host, port := hostPortFromListener(t, lis)
 	return &v3listenerpb.Listener{
 		// This needs to match the name we are querying for.
-		Name: fmt.Sprintf("grpc/server?udpa.resource.listening_address=%s", lis.Addr().String()),
+		Name: fmt.Sprintf(serverListenerResourceNameTemplate, lis.Addr().String()),
 		Address: &v3corepb.Address{
 			Address: &v3corepb.Address_SocketAddress{
 				SocketAddress: &v3corepb.SocketAddress{

--- a/xds/internal/testutils/e2e/bootstrap.go
+++ b/xds/internal/testutils/e2e/bootstrap.go
@@ -46,8 +46,8 @@ type BootstrapOptions struct {
 	NodeID string
 	// ServerURI is the address of the management server.
 	ServerURI string
-	// ServerResourceNameID is the Listener resource name to fetch.
-	ServerResourceNameID string
+	// ServerListenerResourceNameTemplate is the Listener resource name to fetch.
+	ServerListenerResourceNameTemplate string
 	// CertificateProviders is the certificate providers configuration.
 	CertificateProviders map[string]json.RawMessage
 }
@@ -79,8 +79,8 @@ func SetupBootstrapFile(opts BootstrapOptions) (func(), error) {
 		Node: node{
 			ID: opts.NodeID,
 		},
-		CertificateProviders:     opts.CertificateProviders,
-		GRPCServerResourceNameID: opts.ServerResourceNameID,
+		CertificateProviders:               opts.CertificateProviders,
+		ServerListenerResourceNameTemplate: opts.ServerListenerResourceNameTemplate,
 	}
 	switch opts.Version {
 	case TransportV2:
@@ -127,10 +127,10 @@ func DefaultFileWatcherConfig(certPath, keyPath, caPath string) map[string]json.
 }
 
 type bootstrapConfig struct {
-	XdsServers               []server                   `json:"xds_servers,omitempty"`
-	Node                     node                       `json:"node,omitempty"`
-	CertificateProviders     map[string]json.RawMessage `json:"certificate_providers,omitempty"`
-	GRPCServerResourceNameID string                     `json:"grpc_server_resource_name_id,omitempty"`
+	XdsServers                         []server                   `json:"xds_servers,omitempty"`
+	Node                               node                       `json:"node,omitempty"`
+	CertificateProviders               map[string]json.RawMessage `json:"certificate_providers,omitempty"`
+	ServerListenerResourceNameTemplate string                     `json:"server_listener_resource_name_template,omitempty"`
 }
 
 type server struct {

--- a/xds/server.go
+++ b/xds/server.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"strings"
 	"sync"
 	"time"
 
@@ -220,33 +221,36 @@ func (s *GRPCServer) newListenerWrapper(lis net.Listener) (*listenerWrapper, err
 	// or not.
 	goodUpdate := grpcsync.NewEvent()
 
-	// The resource_name in the LDS request sent by the xDS-enabled gRPC server
-	// is of the following format:
-	// "/path/to/resource?udpa.resource.listening_address=IP:Port". The
-	// `/path/to/resource` part of the name is sourced from the bootstrap config
-	// field `grpc_server_resource_name_id`. If this field is not specified in
-	// the bootstrap file, we will use a default of `grpc/server`.
-	path := "grpc/server"
-	if cfg := s.xdsC.BootstrapConfig(); cfg != nil && cfg.ServerResourceNameID != "" {
-		path = cfg.ServerResourceNameID
+	// The server listener resource name template from the bootstrap
+	// configuration contains a template for the name of the Listener resource
+	// to subscribe to for a gRPC server. If the token `%s` is present in the
+	// string, it will be replaced with the server's listening "IP:port" (e.g.,
+	// "0.0.0.0:8080", "[::]:8080"). The absence of a template will be treated
+	// as an error since we do not have any default value for this.
+	cfg := s.xdsC.BootstrapConfig()
+	if cfg == nil || cfg.ServerListenerResourceNameTemplate == "" {
+		return nil, errors.New("missing server_listener_resource_name_template in the bootstrap configuration")
 	}
-	name := fmt.Sprintf("%s?udpa.resource.listening_address=%s", path, lis.Addr().String())
+	listenerName := cfg.ServerListenerResourceNameTemplate
+	if strings.Contains(cfg.ServerListenerResourceNameTemplate, "%s") {
+		listenerName = fmt.Sprintf(cfg.ServerListenerResourceNameTemplate, lis.Addr().String())
+	}
 
 	// Register an LDS watch using our xdsClient, and specify the listening
 	// address as the resource name.
-	cancelWatch := s.xdsC.WatchListener(name, func(update xdsclient.ListenerUpdate, err error) {
+	cancelWatch := s.xdsC.WatchListener(listenerName, func(update xdsclient.ListenerUpdate, err error) {
 		s.handleListenerUpdate(listenerUpdate{
 			lw:         lw,
-			name:       name,
+			name:       listenerName,
 			lds:        update,
 			err:        err,
 			goodUpdate: goodUpdate,
 		})
 	})
-	s.logger.Infof("Watch started on resource name %v", name)
+	s.logger.Infof("Watch started on resource name %v", listenerName)
 	lw.cancelWatch = func() {
 		cancelWatch()
-		s.logger.Infof("Watch cancelled on resource name %v", name)
+		s.logger.Infof("Watch cancelled on resource name %v", listenerName)
 	}
 
 	// Block until a good LDS response is received or the server is stopped.
@@ -287,6 +291,35 @@ func (s *GRPCServer) handleListenerUpdate(update listenerUpdate) {
 		return
 	}
 	s.logger.Infof("Received update for resource %q: %+v", update.name, update.lds.String())
+
+	// Make sure that the socket address on the received Listener resource
+	// matches the address of the net.Listener passed to us by the user. This
+	// check is done here instead of at the xdsClient layer because of the
+	// following couple of reasons:
+	// - xdsClient cannot know the listening address of every listener in the
+	//   system, and hence cannot perform this check.
+	// - this is a very context-dependent check and only the server has the
+	//   appropriate context to perform this check.
+	//
+	// What this means is that the xdsClient has ACKed a resource which is going
+	// to push the server into a "not serving" state. This is not ideal, but
+	// this is what we have decided to do. See gRPC A36 for more details.
+	// TODO(easwars): Switch to "not serving" if the host:port does not match.
+	lisAddr := update.lw.Listener.Addr().String()
+	addr, port, err := net.SplitHostPort(lisAddr)
+	if err != nil {
+		s.logger.Warningf("Local listener address %q failed to parse as IP:port: %v", lisAddr, err)
+		return
+	}
+	ilc := update.lds.InboundListenerCfg
+	if ilc == nil {
+		s.logger.Warningf("Missing host:port in Listener updates")
+		return
+	}
+	if ilc.Address != addr || ilc.Port != port {
+		s.logger.Warningf("Received host:port (%s:%d) in Listener update does not match local listening address: %s", ilc.Address, ilc.Port, lisAddr)
+		return
+	}
 
 	if err := s.handleSecurityConfig(update.lds.SecurityCfg, update.lw); err != nil {
 		s.logger.Warningf("Invalid security config update: %v", err)

--- a/xds/server_test.go
+++ b/xds/server_test.go
@@ -40,9 +40,9 @@ import (
 )
 
 const (
-	defaultTestTimeout       = 5 * time.Second
-	defaultTestShortTimeout  = 10 * time.Millisecond
-	testServerResourceNameID = "/path/to/resource"
+	defaultTestTimeout                     = 5 * time.Second
+	defaultTestShortTimeout                = 10 * time.Millisecond
+	testServerListenerResourceNameTemplate = "/path/to/resource/%s"
 )
 
 type s struct {
@@ -88,6 +88,14 @@ func newFakeGRPCServer() *fakeGRPCServer {
 		stopCh:            testutils.NewChannel(),
 		gracefulStopCh:    testutils.NewChannel(),
 	}
+}
+
+func splitHostPort(hostport string) (string, string) {
+	addr, port, err := net.SplitHostPort(hostport)
+	if err != nil {
+		panic(fmt.Sprintf("listener address %q does not parse: %v", hostport, err))
+	}
+	return addr, port
 }
 
 func (s) TestNewServer(t *testing.T) {
@@ -228,11 +236,11 @@ func setupOverrides() (*fakeGRPCServer, *testutils.Channel, *testutils.Channel, 
 	newXDSClient = func() (xdsClientInterface, error) {
 		c := fakeclient.NewClient()
 		c.SetBootstrapConfig(&bootstrap.Config{
-			BalancerName:         "dummyBalancer",
-			Creds:                grpc.WithTransportCredentials(insecure.NewCredentials()),
-			NodeProto:            xdstestutils.EmptyNodeProtoV3,
-			ServerResourceNameID: testServerResourceNameID,
-			CertProviderConfigs:  certProviderConfigs,
+			BalancerName:                       "dummyBalancer",
+			Creds:                              grpc.WithTransportCredentials(insecure.NewCredentials()),
+			NodeProto:                          xdstestutils.EmptyNodeProtoV3,
+			ServerListenerResourceNameTemplate: testServerListenerResourceNameTemplate,
+			CertProviderConfigs:                certProviderConfigs,
 		})
 		clientCh.Send(c)
 		return c, nil
@@ -267,10 +275,10 @@ func setupOverridesForXDSCreds(includeCertProviderCfg bool) (*testutils.Channel,
 	newXDSClient = func() (xdsClientInterface, error) {
 		c := fakeclient.NewClient()
 		bc := &bootstrap.Config{
-			BalancerName:         "dummyBalancer",
-			Creds:                grpc.WithTransportCredentials(insecure.NewCredentials()),
-			NodeProto:            xdstestutils.EmptyNodeProtoV3,
-			ServerResourceNameID: testServerResourceNameID,
+			BalancerName:                       "dummyBalancer",
+			Creds:                              grpc.WithTransportCredentials(insecure.NewCredentials()),
+			NodeProto:                          xdstestutils.EmptyNodeProtoV3,
+			ServerListenerResourceNameTemplate: testServerListenerResourceNameTemplate,
 		}
 		if includeCertProviderCfg {
 			bc.CertProviderConfigs = certProviderConfigs
@@ -337,7 +345,7 @@ func (s) TestServeSuccess(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error when waiting for a ListenerWatch: %v", err)
 	}
-	wantName := fmt.Sprintf("%s?udpa.resource.listening_address=%s", client.BootstrapConfig().ServerResourceNameID, lis.Addr().String())
+	wantName := fmt.Sprintf(testServerListenerResourceNameTemplate, lis.Addr().String())
 	if name != wantName {
 		t.Fatalf("LDS watch registered for name %q, want %q", name, wantName)
 	}
@@ -353,9 +361,37 @@ func (s) TestServeSuccess(t *testing.T) {
 
 	// Push a good LDS response, and wait for Serve() to be invoked on the
 	// underlying grpc.Server.
-	client.InvokeWatchListenerCallback(xdsclient.ListenerUpdate{RouteConfigName: "routeconfig"}, nil)
+	addr, port := splitHostPort(lis.Addr().String())
+	if err != nil {
+		t.Fatalf("listener address %q does not parse: %v", lis.Addr().String(), err)
+	}
+	client.InvokeWatchListenerCallback(xdsclient.ListenerUpdate{
+		RouteConfigName: "routeconfig",
+		InboundListenerCfg: &xdsclient.InboundListenerConfig{
+			Address: addr,
+			Port:    port,
+		},
+	}, nil)
 	if _, err := fs.serveCh.Receive(ctx); err != nil {
 		t.Fatalf("error when waiting for Serve() to be invoked on the grpc.Server")
+	}
+
+	// Push an update to the registered listener watch callback with a Listener
+	// resource whose host:port does not match the actual listening address and
+	// port. Serve() should not return and should continue to use the old state.
+	//
+	// This will change once we add start tracking serving state.
+	client.InvokeWatchListenerCallback(xdsclient.ListenerUpdate{
+		RouteConfigName: "routeconfig",
+		InboundListenerCfg: &xdsclient.InboundListenerConfig{
+			Address: "10.20.30.40",
+			Port:    "666",
+		},
+	}, nil)
+	sCtx, sCancel = context.WithTimeout(context.Background(), defaultTestShortTimeout)
+	defer sCancel()
+	if _, err := serveDone.Receive(sCtx); err != context.DeadlineExceeded {
+		t.Fatal("Serve() returned after a bad LDS response")
 	}
 }
 
@@ -399,7 +435,7 @@ func (s) TestServeWithStop(t *testing.T) {
 		server.Stop()
 		t.Fatalf("error when waiting for a ListenerWatch: %v", err)
 	}
-	wantName := fmt.Sprintf("%s?udpa.resource.listening_address=%s", client.BootstrapConfig().ServerResourceNameID, lis.Addr().String())
+	wantName := fmt.Sprintf(testServerListenerResourceNameTemplate, lis.Addr().String())
 	if name != wantName {
 		server.Stop()
 		t.Fatalf("LDS watch registered for name %q, wantPrefix %q", name, wantName)
@@ -448,39 +484,79 @@ func (s) TestServeBootstrapFailure(t *testing.T) {
 	}
 }
 
-// TestServeBootstrapWithMissingCertProviders tests the case where the bootstrap
-// config does not contain certificate provider configuration, but xdsCreds are
-// passed to the server. Verifies that the call to Serve() fails.
-func (s) TestServeBootstrapWithMissingCertProviders(t *testing.T) {
-	_, _, cleanup := setupOverridesForXDSCreds(false)
-	defer cleanup()
-
-	xdsCreds, err := xds.NewServerCredentials(xds.ServerOptions{FallbackCreds: insecure.NewCredentials()})
-	if err != nil {
-		t.Fatalf("failed to create xds server credentials: %v", err)
+// TestServeBootstrapConfigInvalid tests the cases where the bootstrap config
+// does not contain expected fields. Verifies that the call to Serve() fails.
+func (s) TestServeBootstrapConfigInvalid(t *testing.T) {
+	tests := []struct {
+		desc            string
+		bootstrapConfig *bootstrap.Config
+	}{
+		{
+			desc:            "bootstrap config is missing",
+			bootstrapConfig: nil,
+		},
+		{
+			desc: "certificate provider config is missing",
+			bootstrapConfig: &bootstrap.Config{
+				BalancerName:                       "dummyBalancer",
+				Creds:                              grpc.WithTransportCredentials(insecure.NewCredentials()),
+				NodeProto:                          xdstestutils.EmptyNodeProtoV3,
+				ServerListenerResourceNameTemplate: testServerListenerResourceNameTemplate,
+			},
+		},
+		{
+			desc: "server_listener_resource_name_template is missing",
+			bootstrapConfig: &bootstrap.Config{
+				BalancerName:        "dummyBalancer",
+				Creds:               grpc.WithTransportCredentials(insecure.NewCredentials()),
+				NodeProto:           xdstestutils.EmptyNodeProtoV3,
+				CertProviderConfigs: certProviderConfigs,
+			},
+		},
 	}
-	server := NewGRPCServer(grpc.Creds(xdsCreds))
-	defer server.Stop()
 
-	lis, err := xdstestutils.LocalTCPListener()
-	if err != nil {
-		t.Fatalf("xdstestutils.LocalTCPListener() failed: %v", err)
-	}
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			// Override the xdsClient creation with one that returns a fake
+			// xdsClient with the specified bootstrap configuration.
+			clientCh := testutils.NewChannel()
+			origNewXDSClient := newXDSClient
+			newXDSClient = func() (xdsClientInterface, error) {
+				c := fakeclient.NewClient()
+				c.SetBootstrapConfig(test.bootstrapConfig)
+				clientCh.Send(c)
+				return c, nil
+			}
+			defer func() { newXDSClient = origNewXDSClient }()
 
-	serveDone := testutils.NewChannel()
-	go func() {
-		err := server.Serve(lis)
-		serveDone.Send(err)
-	}()
+			xdsCreds, err := xds.NewServerCredentials(xds.ServerOptions{FallbackCreds: insecure.NewCredentials()})
+			if err != nil {
+				t.Fatalf("failed to create xds server credentials: %v", err)
+			}
+			server := NewGRPCServer(grpc.Creds(xdsCreds))
+			defer server.Stop()
 
-	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
-	defer cancel()
-	v, err := serveDone.Receive(ctx)
-	if err != nil {
-		t.Fatalf("error when waiting for Serve() to exit: %v", err)
-	}
-	if err, ok := v.(error); !ok || err == nil {
-		t.Fatal("Serve() did not exit with error")
+			lis, err := xdstestutils.LocalTCPListener()
+			if err != nil {
+				t.Fatalf("xdstestutils.LocalTCPListener() failed: %v", err)
+			}
+
+			serveDone := testutils.NewChannel()
+			go func() {
+				err := server.Serve(lis)
+				serveDone.Send(err)
+			}()
+
+			ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+			defer cancel()
+			v, err := serveDone.Receive(ctx)
+			if err != nil {
+				t.Fatalf("error when waiting for Serve() to exit: %v", err)
+			}
+			if err, ok := v.(error); !ok || err == nil {
+				t.Fatal("Serve() did not exit with error")
+			}
+		})
 	}
 }
 
@@ -556,7 +632,7 @@ func (s) TestHandleListenerUpdate_NoXDSCreds(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error when waiting for a ListenerWatch: %v", err)
 	}
-	wantName := fmt.Sprintf("%s?udpa.resource.listening_address=%s", client.BootstrapConfig().ServerResourceNameID, lis.Addr().String())
+	wantName := fmt.Sprintf(testServerListenerResourceNameTemplate, lis.Addr().String())
 	if name != wantName {
 		t.Fatalf("LDS watch registered for name %q, want %q", name, wantName)
 	}
@@ -564,12 +640,17 @@ func (s) TestHandleListenerUpdate_NoXDSCreds(t *testing.T) {
 	// Push a good LDS response with security config, and wait for Serve() to be
 	// invoked on the underlying grpc.Server. Also make sure that certificate
 	// providers are not created.
+	addr, port := splitHostPort(lis.Addr().String())
 	client.InvokeWatchListenerCallback(xdsclient.ListenerUpdate{
 		RouteConfigName: "routeconfig",
 		SecurityCfg: &xdsclient.SecurityConfig{
 			RootInstanceName:     "default1",
 			IdentityInstanceName: "default2",
 			RequireClientCert:    true,
+		},
+		InboundListenerCfg: &xdsclient.InboundListenerConfig{
+			Address: addr,
+			Port:    port,
 		},
 	}, nil)
 	if _, err := fs.serveCh.Receive(ctx); err != nil {
@@ -627,21 +708,14 @@ func (s) TestHandleListenerUpdate_ErrorUpdate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error when waiting for a ListenerWatch: %v", err)
 	}
-	wantName := fmt.Sprintf("%s?udpa.resource.listening_address=%s", client.BootstrapConfig().ServerResourceNameID, lis.Addr().String())
+	wantName := fmt.Sprintf(testServerListenerResourceNameTemplate, lis.Addr().String())
 	if name != wantName {
 		t.Fatalf("LDS watch registered for name %q, want %q", name, wantName)
 	}
 
 	// Push an error to the registered listener watch callback and make sure
 	// that Serve does not return.
-	client.InvokeWatchListenerCallback(xdsclient.ListenerUpdate{
-		RouteConfigName: "routeconfig",
-		SecurityCfg: &xdsclient.SecurityConfig{
-			RootInstanceName:     "default1",
-			IdentityInstanceName: "default2",
-			RequireClientCert:    true,
-		},
-	}, errors.New("LDS error"))
+	client.InvokeWatchListenerCallback(xdsclient.ListenerUpdate{}, errors.New("LDS error"))
 	sCtx, sCancel := context.WithTimeout(context.Background(), defaultTestShortTimeout)
 	defer sCancel()
 	if _, err := serveDone.Receive(sCtx); err != context.DeadlineExceeded {
@@ -691,7 +765,7 @@ func (s) TestHandleListenerUpdate_ClosedListener(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error when waiting for a ListenerWatch: %v", err)
 	}
-	wantName := fmt.Sprintf("%s?udpa.resource.listening_address=%s", client.BootstrapConfig().ServerResourceNameID, lis.Addr().String())
+	wantName := fmt.Sprintf(testServerListenerResourceNameTemplate, lis.Addr().String())
 	if name != wantName {
 		t.Fatalf("LDS watch registered for name %q, want %q", name, wantName)
 	}
@@ -699,9 +773,14 @@ func (s) TestHandleListenerUpdate_ClosedListener(t *testing.T) {
 	// Push a good update to the registered listener watch callback. This will
 	// unblock the xds-enabled server which is waiting for a good listener
 	// update before calling Serve() on the underlying grpc.Server.
+	addr, port := splitHostPort(lis.Addr().String())
 	client.InvokeWatchListenerCallback(xdsclient.ListenerUpdate{
 		RouteConfigName: "routeconfig",
 		SecurityCfg:     &xdsclient.SecurityConfig{IdentityInstanceName: "default2"},
+		InboundListenerCfg: &xdsclient.InboundListenerConfig{
+			Address: addr,
+			Port:    port,
+		},
 	}, nil)
 	if _, err := providerCh.Receive(ctx); err != nil {
 		t.Fatal("error when waiting for certificate provider to be created")
@@ -723,6 +802,10 @@ func (s) TestHandleListenerUpdate_ClosedListener(t *testing.T) {
 	client.InvokeWatchListenerCallback(xdsclient.ListenerUpdate{
 		RouteConfigName: "routeconfig",
 		SecurityCfg:     &xdsclient.SecurityConfig{IdentityInstanceName: "default1"},
+		InboundListenerCfg: &xdsclient.InboundListenerConfig{
+			Address: addr,
+			Port:    port,
+		},
 	}, nil)
 	sCtx, sCancel := context.WithTimeout(context.Background(), defaultTestShortTimeout)
 	defer sCancel()


### PR DESCRIPTION
As described in gRFC A36, we are moving to a templated `server_listener_resource_name` in the bootstrap file.

Summary of changes here:
- Support for the new `server_listener_resource_name_template` field in the bootstrap configuration.
- Server-side changes to the use the new field and encode the `IP:Port` in the listener name.
- A function in the `internal` package to extract the `IP:Port` encoded in the `name` field of a `Listener` resource based on the contents of the `server_listener_resource_name_template` of the bootstrap file. The implementation is provided by the `xdsClient`.
- Making tests happy.

fixes #4209