### PR TITLE
csds: update xds_client to populate update metadata

### DIFF
--- a/xds/internal/client/cds_test.go
+++ b/xds/internal/client/cds_test.go
@@ -762,7 +762,7 @@ func (s) TestUnmarshalCluster(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			update, md, err := UnmarshalCluster(testVersion, test.resources, nil)
 			if (err != nil) != test.wantErr {
-				t.Errorf("UnmarshalCluster(), got err: %v, wantErr: %v", err, test.wantErr)
+				t.Fatalf("UnmarshalCluster(), got err: %v, wantErr: %v", err, test.wantErr)
 			}
 			if diff := cmp.Diff(update, test.wantUpdate, cmpOpts); diff != "" {
 				t.Errorf("got unexpected update, diff (-got +want): %v", diff)

--- a/xds/internal/client/client_test.go
+++ b/xds/internal/client/client_test.go
@@ -74,8 +74,8 @@ var (
 
 	// When comparing NACK UpdateMetadata, we only care if error is nil, but not
 	// the details in error.
-	errPlaceHolder            = fmt.Errorf("error whose details don't matter")
-	cmpOptsIgnoreErrorDetails = cmp.Options{
+	errPlaceHolder       = fmt.Errorf("error whose details don't matter")
+	cmpOptsIgnoreDetails = cmp.Options{
 		cmp.Comparer(func(a, b time.Time) bool { return true }),
 		cmp.Comparer(func(x, y error) bool {
 			return (x == nil) == (y == nil)

--- a/xds/internal/client/eds_test.go
+++ b/xds/internal/client/eds_test.go
@@ -301,7 +301,7 @@ func (s) TestUnmarshalEndpoints(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			update, md, err := UnmarshalEndpoints(testVersion, test.resources, nil)
 			if (err != nil) != test.wantErr {
-				t.Errorf("UnmarshalEndpoints(), got err: %v, wantErr: %v", err, test.wantErr)
+				t.Fatalf("UnmarshalEndpoints(), got err: %v, wantErr: %v", err, test.wantErr)
 			}
 			if diff := cmp.Diff(update, test.wantUpdate, cmpOpts); diff != "" {
 				t.Errorf("got unexpected update, diff (-got +want): %v", diff)

--- a/xds/internal/client/lds_test.go
+++ b/xds/internal/client/lds_test.go
@@ -685,11 +685,11 @@ func (s) TestUnmarshalListener_ClientSide(t *testing.T) {
 						return mLis
 					}(),
 				},
-				v3Lis,
+				v3LisWithFilters(),
 			},
 			wantUpdate: map[string]ListenerUpdate{
 				v2LDSTarget: {RouteConfigName: v2RouteConfigName, Raw: v2Lis},
-				v3LDSTarget: {RouteConfigName: v3RouteConfigName, MaxStreamDuration: time.Second, Raw: v3Lis},
+				v3LDSTarget: {RouteConfigName: v3RouteConfigName, MaxStreamDuration: time.Second, Raw: v3LisWithFilters()},
 				"bad":       {},
 			},
 			wantMD: UpdateMetadata{

--- a/xds/internal/client/lds_test.go
+++ b/xds/internal/client/lds_test.go
@@ -711,7 +711,7 @@ func (s) TestUnmarshalListener_ClientSide(t *testing.T) {
 
 			update, md, err := UnmarshalListener(testVersion, test.resources, nil)
 			if (err != nil) != test.wantErr {
-				t.Errorf("UnmarshalListener(), got err: %v, wantErr: %v", err, test.wantErr)
+				t.Fatalf("UnmarshalListener(), got err: %v, wantErr: %v", err, test.wantErr)
 			}
 			if diff := cmp.Diff(update, test.wantUpdate, cmpOpts); diff != "" {
 				t.Errorf("got unexpected update, diff (-got +want): %v", diff)
@@ -1480,7 +1480,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			gotUpdate, md, err := UnmarshalListener(testVersion, test.resources, nil)
 			if (err != nil) != (test.wantErr != "") {
-				t.Errorf("UnmarshalListener(), got err: %v, wantErr: %v", err, test.wantErr)
+				t.Fatalf("UnmarshalListener(), got err: %v, wantErr: %v", err, test.wantErr)
 			}
 			if err != nil && !strings.Contains(err.Error(), test.wantErr) {
 				t.Fatalf("UnmarshalListener() = %v wantErr: %q", err, test.wantErr)

--- a/xds/internal/client/rds_test.go
+++ b/xds/internal/client/rds_test.go
@@ -743,11 +743,11 @@ func (s) TestUnmarshalRouteConfig(t *testing.T) {
 					VirtualHosts: []*VirtualHost{
 						{
 							Domains: []string{uninterestingDomain},
-							Routes:  []*Route{{Prefix: newStringP(""), Action: map[string]uint32{uninterestingClusterName: 1}}},
+							Routes:  []*Route{{Prefix: newStringP(""), WeightedClusters: map[string]WeightedCluster{uninterestingClusterName: {Weight: 1}}}},
 						},
 						{
 							Domains: []string{ldsTarget},
-							Routes:  []*Route{{Prefix: newStringP(""), Action: map[string]uint32{v3ClusterName: 1}}},
+							Routes:  []*Route{{Prefix: newStringP(""), WeightedClusters: map[string]WeightedCluster{v3ClusterName: {Weight: 1}}}},
 						},
 					},
 					Raw: v3RouteConfig,
@@ -756,11 +756,11 @@ func (s) TestUnmarshalRouteConfig(t *testing.T) {
 					VirtualHosts: []*VirtualHost{
 						{
 							Domains: []string{uninterestingDomain},
-							Routes:  []*Route{{Prefix: newStringP(""), Action: map[string]uint32{uninterestingClusterName: 1}}},
+							Routes:  []*Route{{Prefix: newStringP(""), WeightedClusters: map[string]WeightedCluster{uninterestingClusterName: {Weight: 1}}}},
 						},
 						{
 							Domains: []string{ldsTarget},
-							Routes:  []*Route{{Prefix: newStringP(""), Action: map[string]uint32{v2ClusterName: 1}}},
+							Routes:  []*Route{{Prefix: newStringP(""), WeightedClusters: map[string]WeightedCluster{v2ClusterName: {Weight: 1}}}},
 						},
 					},
 					Raw: v2RouteConfig,

--- a/xds/internal/client/rds_test.go
+++ b/xds/internal/client/rds_test.go
@@ -782,7 +782,7 @@ func (s) TestUnmarshalRouteConfig(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			update, md, err := UnmarshalRouteConfig(testVersion, test.resources, nil)
 			if (err != nil) != test.wantErr {
-				t.Errorf("UnmarshalRouteConfig(), got err: %v, wantErr: %v", err, test.wantErr)
+				t.Fatalf("UnmarshalRouteConfig(), got err: %v, wantErr: %v", err, test.wantErr)
 			}
 			if diff := cmp.Diff(update, test.wantUpdate, cmpOpts); diff != "" {
 				t.Errorf("got unexpected update, diff (-got +want): %v", diff)

--- a/xds/internal/client/v2/cds_test.go
+++ b/xds/internal/client/v2/cds_test.go
@@ -24,7 +24,7 @@ import (
 
 	xdspb "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	corepb "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
-	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/ptypes"
 	anypb "github.com/golang/protobuf/ptypes/any"
 	xdsclient "google.golang.org/grpc/xds/internal/client"
 	"google.golang.org/grpc/xds/internal/version"
@@ -63,7 +63,7 @@ var (
 			},
 		},
 	}
-	marshaledCluster1, _ = proto.Marshal(goodCluster1)
+	marshaledCluster1, _ = ptypes.MarshalAny(goodCluster1)
 	goodCluster2         = &xdspb.Cluster{
 		Name:                 goodClusterName2,
 		ClusterDiscoveryType: &xdspb.Cluster_Type{Type: xdspb.Cluster_EDS},
@@ -77,22 +77,16 @@ var (
 		},
 		LbPolicy: xdspb.Cluster_ROUND_ROBIN,
 	}
-	marshaledCluster2, _ = proto.Marshal(goodCluster2)
+	marshaledCluster2, _ = ptypes.MarshalAny(goodCluster2)
 	goodCDSResponse1     = &xdspb.DiscoveryResponse{
 		Resources: []*anypb.Any{
-			{
-				TypeUrl: version.V2ClusterURL,
-				Value:   marshaledCluster1,
-			},
+			marshaledCluster1,
 		},
 		TypeUrl: version.V2ClusterURL,
 	}
 	goodCDSResponse2 = &xdspb.DiscoveryResponse{
 		Resources: []*anypb.Any{
-			{
-				TypeUrl: version.V2ClusterURL,
-				Value:   marshaledCluster2,
-			},
+			marshaledCluster2,
 		},
 		TypeUrl: version.V2ClusterURL,
 	}
@@ -106,47 +100,76 @@ func (s) TestCDSHandleResponse(t *testing.T) {
 		name          string
 		cdsResponse   *xdspb.DiscoveryResponse
 		wantErr       bool
-		wantUpdate    *xdsclient.ClusterUpdate
+		wantUpdate    map[string]xdsclient.ClusterUpdate
+		wantUpdateMD  xdsclient.UpdateMetadata
 		wantUpdateErr bool
 	}{
 		// Badly marshaled CDS response.
 		{
-			name:          "badly-marshaled-response",
-			cdsResponse:   badlyMarshaledCDSResponse,
-			wantErr:       true,
-			wantUpdate:    nil,
+			name:        "badly-marshaled-response",
+			cdsResponse: badlyMarshaledCDSResponse,
+			wantErr:     true,
+			wantUpdate:  nil,
+			wantUpdateMD: xdsclient.UpdateMetadata{
+				Status: xdsclient.ServiceStatusNACKed,
+				ErrState: &xdsclient.UpdateErrorMetadata{
+					Err: errPlaceHolder,
+				},
+			},
 			wantUpdateErr: false,
 		},
 		// Response does not contain Cluster proto.
 		{
-			name:          "no-cluster-proto-in-response",
-			cdsResponse:   badResourceTypeInLDSResponse,
-			wantErr:       true,
-			wantUpdate:    nil,
+			name:        "no-cluster-proto-in-response",
+			cdsResponse: badResourceTypeInLDSResponse,
+			wantErr:     true,
+			wantUpdate:  nil,
+			wantUpdateMD: xdsclient.UpdateMetadata{
+				Status: xdsclient.ServiceStatusNACKed,
+				ErrState: &xdsclient.UpdateErrorMetadata{
+					Err: errPlaceHolder,
+				},
+			},
 			wantUpdateErr: false,
 		},
 		// Response contains no clusters.
 		{
-			name:          "no-cluster",
-			cdsResponse:   &xdspb.DiscoveryResponse{},
-			wantErr:       false,
-			wantUpdate:    nil,
+			name:        "no-cluster",
+			cdsResponse: &xdspb.DiscoveryResponse{},
+			wantErr:     false,
+			wantUpdate:  nil,
+			wantUpdateMD: xdsclient.UpdateMetadata{
+				Status:   xdsclient.ServiceStatusACKed,
+				ErrState: nil,
+			},
 			wantUpdateErr: false,
 		},
 		// Response contains one good cluster we are not interested in.
 		{
-			name:          "one-uninteresting-cluster",
-			cdsResponse:   goodCDSResponse2,
-			wantErr:       false,
-			wantUpdate:    nil,
+			name:        "one-uninteresting-cluster",
+			cdsResponse: goodCDSResponse2,
+			wantErr:     false,
+			wantUpdate: map[string]xdsclient.ClusterUpdate{
+				goodClusterName2: {ServiceName: serviceName2, Raw: marshaledCluster2},
+			},
+			wantUpdateMD: xdsclient.UpdateMetadata{
+				Status:   xdsclient.ServiceStatusACKed,
+				ErrState: nil,
+			},
 			wantUpdateErr: false,
 		},
 		// Response contains one cluster and it is good.
 		{
-			name:          "one-good-cluster",
-			cdsResponse:   goodCDSResponse1,
-			wantErr:       false,
-			wantUpdate:    &xdsclient.ClusterUpdate{ServiceName: serviceName1, EnableLRS: true},
+			name:        "one-good-cluster",
+			cdsResponse: goodCDSResponse1,
+			wantErr:     false,
+			wantUpdate: map[string]xdsclient.ClusterUpdate{
+				goodClusterName1: {ServiceName: serviceName1, EnableLRS: true, Raw: marshaledCluster1},
+			},
+			wantUpdateMD: xdsclient.UpdateMetadata{
+				Status:   xdsclient.ServiceStatusACKed,
+				ErrState: nil,
+			},
 			wantUpdateErr: false,
 		},
 	}
@@ -159,6 +182,7 @@ func (s) TestCDSHandleResponse(t *testing.T) {
 				responseToHandle: test.cdsResponse,
 				wantHandleErr:    test.wantErr,
 				wantUpdate:       test.wantUpdate,
+				wantUpdateMD:     test.wantUpdateMD,
 				wantUpdateErr:    test.wantUpdateErr,
 			})
 		})

--- a/xds/internal/client/v2/cds_test.go
+++ b/xds/internal/client/v2/cds_test.go
@@ -139,8 +139,7 @@ func (s) TestCDSHandleResponse(t *testing.T) {
 			wantErr:     false,
 			wantUpdate:  nil,
 			wantUpdateMD: xdsclient.UpdateMetadata{
-				Status:   xdsclient.ServiceStatusACKed,
-				ErrState: nil,
+				Status: xdsclient.ServiceStatusACKed,
 			},
 			wantUpdateErr: false,
 		},
@@ -153,8 +152,7 @@ func (s) TestCDSHandleResponse(t *testing.T) {
 				goodClusterName2: {ServiceName: serviceName2, Raw: marshaledCluster2},
 			},
 			wantUpdateMD: xdsclient.UpdateMetadata{
-				Status:   xdsclient.ServiceStatusACKed,
-				ErrState: nil,
+				Status: xdsclient.ServiceStatusACKed,
 			},
 			wantUpdateErr: false,
 		},
@@ -167,8 +165,7 @@ func (s) TestCDSHandleResponse(t *testing.T) {
 				goodClusterName1: {ServiceName: serviceName1, EnableLRS: true, Raw: marshaledCluster1},
 			},
 			wantUpdateMD: xdsclient.UpdateMetadata{
-				Status:   xdsclient.ServiceStatusACKed,
-				ErrState: nil,
+				Status: xdsclient.ServiceStatusACKed,
 			},
 			wantUpdateErr: false,
 		},

--- a/xds/internal/client/v2/client.go
+++ b/xds/internal/client/v2/client.go
@@ -186,11 +186,8 @@ func (v2c *client) HandleResponse(r proto.Message) (xdsclient.ResourceType, stri
 // callback.
 func (v2c *client) handleLDSResponse(resp *v2xdspb.DiscoveryResponse) error {
 	update, md, err := xdsclient.UnmarshalListener(resp.GetVersionInfo(), resp.GetResources(), v2c.logger)
-	if err != nil {
-		return err
-	}
 	v2c.parent.NewListeners(update, md)
-	return nil
+	return err
 }
 
 // handleRDSResponse processes an RDS response received from the management
@@ -198,11 +195,8 @@ func (v2c *client) handleLDSResponse(resp *v2xdspb.DiscoveryResponse) error {
 // invokes the registered watcher callback.
 func (v2c *client) handleRDSResponse(resp *v2xdspb.DiscoveryResponse) error {
 	update, md, err := xdsclient.UnmarshalRouteConfig(resp.GetVersionInfo(), resp.GetResources(), v2c.logger)
-	if err != nil {
-		return err
-	}
 	v2c.parent.NewRouteConfigs(update, md)
-	return nil
+	return err
 }
 
 // handleCDSResponse processes an CDS response received from the management
@@ -210,18 +204,12 @@ func (v2c *client) handleRDSResponse(resp *v2xdspb.DiscoveryResponse) error {
 // callback.
 func (v2c *client) handleCDSResponse(resp *v2xdspb.DiscoveryResponse) error {
 	update, md, err := xdsclient.UnmarshalCluster(resp.GetVersionInfo(), resp.GetResources(), v2c.logger)
-	if err != nil {
-		return err
-	}
 	v2c.parent.NewClusters(update, md)
-	return nil
+	return err
 }
 
 func (v2c *client) handleEDSResponse(resp *v2xdspb.DiscoveryResponse) error {
 	update, md, err := xdsclient.UnmarshalEndpoints(resp.GetVersionInfo(), resp.GetResources(), v2c.logger)
-	if err != nil {
-		return err
-	}
 	v2c.parent.NewEndpoints(update, md)
-	return nil
+	return err
 }

--- a/xds/internal/client/v2/eds_test.go
+++ b/xds/internal/client/v2/eds_test.go
@@ -50,27 +50,28 @@ var (
 		},
 		TypeUrl: version.V2EndpointsURL,
 	}
+	marshaledGoodCLA1 = func() *anypb.Any {
+		clab0 := testutils.NewClusterLoadAssignmentBuilder(goodEDSName, nil)
+		clab0.AddLocality("locality-1", 1, 1, []string{"addr1:314"}, nil)
+		clab0.AddLocality("locality-2", 1, 0, []string{"addr2:159"}, nil)
+		a, _ := ptypes.MarshalAny(clab0.Build())
+		return a
+	}()
 	goodEDSResponse1 = &v2xdspb.DiscoveryResponse{
 		Resources: []*anypb.Any{
-			func() *anypb.Any {
-				clab0 := testutils.NewClusterLoadAssignmentBuilder(goodEDSName, nil)
-				clab0.AddLocality("locality-1", 1, 1, []string{"addr1:314"}, nil)
-				clab0.AddLocality("locality-2", 1, 0, []string{"addr2:159"}, nil)
-				a, _ := ptypes.MarshalAny(clab0.Build())
-				return a
-			}(),
+			marshaledGoodCLA1,
 		},
 		TypeUrl: version.V2EndpointsURL,
 	}
+	marshaledGoodCLA2 = func() *anypb.Any {
+		clab0 := testutils.NewClusterLoadAssignmentBuilder("not-goodEDSName", nil)
+		clab0.AddLocality("locality-1", 1, 0, []string{"addr1:314"}, nil)
+		a, _ := ptypes.MarshalAny(clab0.Build())
+		return a
+	}()
 	goodEDSResponse2 = &v2xdspb.DiscoveryResponse{
 		Resources: []*anypb.Any{
-			func() *anypb.Any {
-				clab0 := testutils.NewClusterLoadAssignmentBuilder("not-goodEDSName", nil)
-				clab0.AddLocality("locality-1", 1, 1, []string{"addr1:314"}, nil)
-				clab0.AddLocality("locality-2", 1, 0, []string{"addr2:159"}, nil)
-				a, _ := ptypes.MarshalAny(clab0.Build())
-				return a
-			}(),
+			marshaledGoodCLA2,
 		},
 		TypeUrl: version.V2EndpointsURL,
 	}
@@ -81,31 +82,60 @@ func (s) TestEDSHandleResponse(t *testing.T) {
 		name          string
 		edsResponse   *v2xdspb.DiscoveryResponse
 		wantErr       bool
-		wantUpdate    *xdsclient.EndpointsUpdate
+		wantUpdate    map[string]xdsclient.EndpointsUpdate
+		wantUpdateMD  xdsclient.UpdateMetadata
 		wantUpdateErr bool
 	}{
 		// Any in resource is badly marshaled.
 		{
-			name:          "badly-marshaled_response",
-			edsResponse:   badlyMarshaledEDSResponse,
-			wantErr:       true,
-			wantUpdate:    nil,
+			name:        "badly-marshaled_response",
+			edsResponse: badlyMarshaledEDSResponse,
+			wantErr:     true,
+			wantUpdate:  nil,
+			wantUpdateMD: xdsclient.UpdateMetadata{
+				Status: xdsclient.ServiceStatusNACKed,
+				ErrState: &xdsclient.UpdateErrorMetadata{
+					Err: errPlaceHolder,
+				},
+			},
 			wantUpdateErr: false,
 		},
 		// Response doesn't contain resource with the right type.
 		{
-			name:          "no-config-in-response",
-			edsResponse:   badResourceTypeInEDSResponse,
-			wantErr:       true,
-			wantUpdate:    nil,
+			name:        "no-config-in-response",
+			edsResponse: badResourceTypeInEDSResponse,
+			wantErr:     true,
+			wantUpdate:  nil,
+			wantUpdateMD: xdsclient.UpdateMetadata{
+				Status: xdsclient.ServiceStatusNACKed,
+				ErrState: &xdsclient.UpdateErrorMetadata{
+					Err: errPlaceHolder,
+				},
+			},
 			wantUpdateErr: false,
 		},
 		// Response contains one uninteresting ClusterLoadAssignment.
 		{
-			name:          "one-uninterestring-assignment",
-			edsResponse:   goodEDSResponse2,
-			wantErr:       false,
-			wantUpdate:    nil,
+			name:        "one-uninterestring-assignment",
+			edsResponse: goodEDSResponse2,
+			wantErr:     false,
+			wantUpdate: map[string]xdsclient.EndpointsUpdate{
+				"not-goodEDSName": {
+					Localities: []xdsclient.Locality{
+						{
+							Endpoints: []xdsclient.Endpoint{{Address: "addr1:314"}},
+							ID:        internal.LocalityID{SubZone: "locality-1"},
+							Priority:  0,
+							Weight:    1,
+						},
+					},
+					Raw: marshaledGoodCLA2,
+				},
+			},
+			wantUpdateMD: xdsclient.UpdateMetadata{
+				Status:   xdsclient.ServiceStatusACKed,
+				ErrState: nil,
+			},
 			wantUpdateErr: false,
 		},
 		// Response contains one good ClusterLoadAssignment.
@@ -113,21 +143,28 @@ func (s) TestEDSHandleResponse(t *testing.T) {
 			name:        "one-good-assignment",
 			edsResponse: goodEDSResponse1,
 			wantErr:     false,
-			wantUpdate: &xdsclient.EndpointsUpdate{
-				Localities: []xdsclient.Locality{
-					{
-						Endpoints: []xdsclient.Endpoint{{Address: "addr1:314"}},
-						ID:        internal.LocalityID{SubZone: "locality-1"},
-						Priority:  1,
-						Weight:    1,
+			wantUpdate: map[string]xdsclient.EndpointsUpdate{
+				goodEDSName: {
+					Localities: []xdsclient.Locality{
+						{
+							Endpoints: []xdsclient.Endpoint{{Address: "addr1:314"}},
+							ID:        internal.LocalityID{SubZone: "locality-1"},
+							Priority:  1,
+							Weight:    1,
+						},
+						{
+							Endpoints: []xdsclient.Endpoint{{Address: "addr2:159"}},
+							ID:        internal.LocalityID{SubZone: "locality-2"},
+							Priority:  0,
+							Weight:    1,
+						},
 					},
-					{
-						Endpoints: []xdsclient.Endpoint{{Address: "addr2:159"}},
-						ID:        internal.LocalityID{SubZone: "locality-2"},
-						Priority:  0,
-						Weight:    1,
-					},
+					Raw: marshaledGoodCLA1,
 				},
+			},
+			wantUpdateMD: xdsclient.UpdateMetadata{
+				Status:   xdsclient.ServiceStatusACKed,
+				ErrState: nil,
 			},
 			wantUpdateErr: false,
 		},
@@ -140,6 +177,7 @@ func (s) TestEDSHandleResponse(t *testing.T) {
 				responseToHandle: test.edsResponse,
 				wantHandleErr:    test.wantErr,
 				wantUpdate:       test.wantUpdate,
+				wantUpdateMD:     test.wantUpdateMD,
 				wantUpdateErr:    test.wantUpdateErr,
 			})
 		})

--- a/xds/internal/client/v2/eds_test.go
+++ b/xds/internal/client/v2/eds_test.go
@@ -133,8 +133,7 @@ func (s) TestEDSHandleResponse(t *testing.T) {
 				},
 			},
 			wantUpdateMD: xdsclient.UpdateMetadata{
-				Status:   xdsclient.ServiceStatusACKed,
-				ErrState: nil,
+				Status: xdsclient.ServiceStatusACKed,
 			},
 			wantUpdateErr: false,
 		},
@@ -163,8 +162,7 @@ func (s) TestEDSHandleResponse(t *testing.T) {
 				},
 			},
 			wantUpdateMD: xdsclient.UpdateMetadata{
-				Status:   xdsclient.ServiceStatusACKed,
-				ErrState: nil,
+				Status: xdsclient.ServiceStatusACKed,
 			},
 			wantUpdateErr: false,
 		},

--- a/xds/internal/client/v2/lds_test.go
+++ b/xds/internal/client/v2/lds_test.go
@@ -94,8 +94,7 @@ func (s) TestLDSHandleResponse(t *testing.T) {
 				goodLDSTarget1: {RouteConfigName: goodRouteName1, Raw: marshaledListener1},
 			},
 			wantUpdateMD: xdsclient.UpdateMetadata{
-				Status:   xdsclient.ServiceStatusACKed,
-				ErrState: nil,
+				Status: xdsclient.ServiceStatusACKed,
 			},
 			wantUpdateErr: false,
 		},
@@ -110,8 +109,7 @@ func (s) TestLDSHandleResponse(t *testing.T) {
 				goodLDSTarget2: {RouteConfigName: goodRouteName1, Raw: marshaledListener2},
 			},
 			wantUpdateMD: xdsclient.UpdateMetadata{
-				Status:   xdsclient.ServiceStatusACKed,
-				ErrState: nil,
+				Status: xdsclient.ServiceStatusACKed,
 			},
 			wantUpdateErr: false,
 		},
@@ -143,8 +141,7 @@ func (s) TestLDSHandleResponse(t *testing.T) {
 				goodLDSTarget2: {RouteConfigName: goodRouteName1, Raw: marshaledListener2},
 			},
 			wantUpdateMD: xdsclient.UpdateMetadata{
-				Status:   xdsclient.ServiceStatusACKed,
-				ErrState: nil,
+				Status: xdsclient.ServiceStatusACKed,
 			},
 			wantUpdateErr: false,
 		},
@@ -156,8 +153,7 @@ func (s) TestLDSHandleResponse(t *testing.T) {
 			wantErr:     false,
 			wantUpdate:  nil,
 			wantUpdateMD: xdsclient.UpdateMetadata{
-				Status:   xdsclient.ServiceStatusACKed,
-				ErrState: nil,
+				Status: xdsclient.ServiceStatusACKed,
 			},
 			wantUpdateErr: false,
 		},

--- a/xds/internal/client/v2/lds_test.go
+++ b/xds/internal/client/v2/lds_test.go
@@ -35,77 +35,130 @@ func (s) TestLDSHandleResponse(t *testing.T) {
 		name          string
 		ldsResponse   *v2xdspb.DiscoveryResponse
 		wantErr       bool
-		wantUpdate    *xdsclient.ListenerUpdate
+		wantUpdate    map[string]xdsclient.ListenerUpdate
+		wantUpdateMD  xdsclient.UpdateMetadata
 		wantUpdateErr bool
 	}{
 		// Badly marshaled LDS response.
 		{
-			name:          "badly-marshaled-response",
-			ldsResponse:   badlyMarshaledLDSResponse,
-			wantErr:       true,
-			wantUpdate:    nil,
+			name:        "badly-marshaled-response",
+			ldsResponse: badlyMarshaledLDSResponse,
+			wantErr:     true,
+			wantUpdate:  nil,
+			wantUpdateMD: xdsclient.UpdateMetadata{
+				Status: xdsclient.ServiceStatusNACKed,
+				ErrState: &xdsclient.UpdateErrorMetadata{
+					Err: errPlaceHolder,
+				},
+			},
 			wantUpdateErr: false,
 		},
 		// Response does not contain Listener proto.
 		{
-			name:          "no-listener-proto-in-response",
-			ldsResponse:   badResourceTypeInLDSResponse,
-			wantErr:       true,
-			wantUpdate:    nil,
+			name:        "no-listener-proto-in-response",
+			ldsResponse: badResourceTypeInLDSResponse,
+			wantErr:     true,
+			wantUpdate:  nil,
+			wantUpdateMD: xdsclient.UpdateMetadata{
+				Status: xdsclient.ServiceStatusNACKed,
+				ErrState: &xdsclient.UpdateErrorMetadata{
+					Err: errPlaceHolder,
+				},
+			},
 			wantUpdateErr: false,
 		},
 		// No APIListener in the response. Just one test case here for a bad
 		// ApiListener, since the others are covered in
 		// TestGetRouteConfigNameFromListener.
 		{
-			name:          "no-apiListener-in-response",
-			ldsResponse:   noAPIListenerLDSResponse,
-			wantErr:       true,
-			wantUpdate:    nil,
+			name:        "no-apiListener-in-response",
+			ldsResponse: noAPIListenerLDSResponse,
+			wantErr:     true,
+			wantUpdate: map[string]xdsclient.ListenerUpdate{
+				goodLDSTarget1: {},
+			},
+			wantUpdateMD: xdsclient.UpdateMetadata{
+				Status: xdsclient.ServiceStatusNACKed,
+				ErrState: &xdsclient.UpdateErrorMetadata{
+					Err: errPlaceHolder,
+				},
+			},
 			wantUpdateErr: false,
 		},
 		// Response contains one listener and it is good.
 		{
-			name:          "one-good-listener",
-			ldsResponse:   goodLDSResponse1,
-			wantErr:       false,
-			wantUpdate:    &xdsclient.ListenerUpdate{RouteConfigName: goodRouteName1},
+			name:        "one-good-listener",
+			ldsResponse: goodLDSResponse1,
+			wantErr:     false,
+			wantUpdate: map[string]xdsclient.ListenerUpdate{
+				goodLDSTarget1: {RouteConfigName: goodRouteName1, Raw: marshaledListener1},
+			},
+			wantUpdateMD: xdsclient.UpdateMetadata{
+				Status:   xdsclient.ServiceStatusACKed,
+				ErrState: nil,
+			},
 			wantUpdateErr: false,
 		},
 		// Response contains multiple good listeners, including the one we are
 		// interested in.
 		{
-			name:          "multiple-good-listener",
-			ldsResponse:   ldsResponseWithMultipleResources,
-			wantErr:       false,
-			wantUpdate:    &xdsclient.ListenerUpdate{RouteConfigName: goodRouteName1},
+			name:        "multiple-good-listener",
+			ldsResponse: ldsResponseWithMultipleResources,
+			wantErr:     false,
+			wantUpdate: map[string]xdsclient.ListenerUpdate{
+				goodLDSTarget1: {RouteConfigName: goodRouteName1, Raw: marshaledListener1},
+				goodLDSTarget2: {RouteConfigName: goodRouteName1, Raw: marshaledListener2},
+			},
+			wantUpdateMD: xdsclient.UpdateMetadata{
+				Status:   xdsclient.ServiceStatusACKed,
+				ErrState: nil,
+			},
 			wantUpdateErr: false,
 		},
 		// Response contains two good listeners (one interesting and one
 		// uninteresting), and one badly marshaled listener. This will cause a
 		// nack because the uninteresting listener will still be parsed.
 		{
-			name:          "good-bad-ugly-listeners",
-			ldsResponse:   goodBadUglyLDSResponse,
-			wantErr:       true,
-			wantUpdate:    nil,
+			name:        "good-bad-ugly-listeners",
+			ldsResponse: goodBadUglyLDSResponse,
+			wantErr:     true,
+			wantUpdate: map[string]xdsclient.ListenerUpdate{
+				goodLDSTarget1: {RouteConfigName: goodRouteName1, Raw: marshaledListener1},
+				goodLDSTarget2: {},
+			},
+			wantUpdateMD: xdsclient.UpdateMetadata{
+				Status: xdsclient.ServiceStatusNACKed,
+				ErrState: &xdsclient.UpdateErrorMetadata{
+					Err: errPlaceHolder,
+				},
+			},
 			wantUpdateErr: false,
 		},
 		// Response contains one listener, but we are not interested in it.
 		{
-			name:          "one-uninteresting-listener",
-			ldsResponse:   goodLDSResponse2,
-			wantErr:       false,
-			wantUpdate:    nil,
+			name:        "one-uninteresting-listener",
+			ldsResponse: goodLDSResponse2,
+			wantErr:     false,
+			wantUpdate: map[string]xdsclient.ListenerUpdate{
+				goodLDSTarget2: {RouteConfigName: goodRouteName1, Raw: marshaledListener2},
+			},
+			wantUpdateMD: xdsclient.UpdateMetadata{
+				Status:   xdsclient.ServiceStatusACKed,
+				ErrState: nil,
+			},
 			wantUpdateErr: false,
 		},
 		// Response constains no resources. This is the case where the server
 		// does not know about the target we are interested in.
 		{
-			name:          "empty-response",
-			ldsResponse:   emptyLDSResponse,
-			wantErr:       false,
-			wantUpdate:    nil,
+			name:        "empty-response",
+			ldsResponse: emptyLDSResponse,
+			wantErr:     false,
+			wantUpdate:  nil,
+			wantUpdateMD: xdsclient.UpdateMetadata{
+				Status:   xdsclient.ServiceStatusACKed,
+				ErrState: nil,
+			},
 			wantUpdateErr: false,
 		},
 	}
@@ -118,6 +171,7 @@ func (s) TestLDSHandleResponse(t *testing.T) {
 				responseToHandle: test.ldsResponse,
 				wantHandleErr:    test.wantErr,
 				wantUpdate:       test.wantUpdate,
+				wantUpdateMD:     test.wantUpdateMD,
 				wantUpdateErr:    test.wantUpdateErr,
 			})
 		})

--- a/xds/internal/client/v2/rds_test.go
+++ b/xds/internal/client/v2/rds_test.go
@@ -95,8 +95,7 @@ func (s) TestRDSHandleResponseWithRouting(t *testing.T) {
 				},
 			},
 			wantUpdateMD: xdsclient.UpdateMetadata{
-				Status:   xdsclient.ServiceStatusACKed,
-				ErrState: nil,
+				Status: xdsclient.ServiceStatusACKed,
 			},
 			wantUpdateErr: false,
 		},
@@ -121,8 +120,7 @@ func (s) TestRDSHandleResponseWithRouting(t *testing.T) {
 				},
 			},
 			wantUpdateMD: xdsclient.UpdateMetadata{
-				Status:   xdsclient.ServiceStatusACKed,
-				ErrState: nil,
+				Status: xdsclient.ServiceStatusACKed,
 			},
 			wantUpdateErr: false,
 		},
@@ -147,8 +145,7 @@ func (s) TestRDSHandleResponseWithRouting(t *testing.T) {
 				},
 			},
 			wantUpdateMD: xdsclient.UpdateMetadata{
-				Status:   xdsclient.ServiceStatusACKed,
-				ErrState: nil,
+				Status: xdsclient.ServiceStatusACKed,
 			},
 			wantUpdateErr: false,
 		},

--- a/xds/internal/client/v2/rds_test.go
+++ b/xds/internal/client/v2/rds_test.go
@@ -49,23 +49,36 @@ func (s) TestRDSHandleResponseWithRouting(t *testing.T) {
 		name          string
 		rdsResponse   *xdspb.DiscoveryResponse
 		wantErr       bool
-		wantUpdate    *xdsclient.RouteConfigUpdate
+		wantUpdate    map[string]xdsclient.RouteConfigUpdate
+		wantUpdateMD  xdsclient.UpdateMetadata
 		wantUpdateErr bool
 	}{
 		// Badly marshaled RDS response.
 		{
-			name:          "badly-marshaled-response",
-			rdsResponse:   badlyMarshaledRDSResponse,
-			wantErr:       true,
-			wantUpdate:    nil,
+			name:        "badly-marshaled-response",
+			rdsResponse: badlyMarshaledRDSResponse,
+			wantErr:     true,
+			wantUpdate:  nil,
+			wantUpdateMD: xdsclient.UpdateMetadata{
+				Status: xdsclient.ServiceStatusNACKed,
+				ErrState: &xdsclient.UpdateErrorMetadata{
+					Err: errPlaceHolder,
+				},
+			},
 			wantUpdateErr: false,
 		},
 		// Response does not contain RouteConfiguration proto.
 		{
-			name:          "no-route-config-in-response",
-			rdsResponse:   badResourceTypeInRDSResponse,
-			wantErr:       true,
-			wantUpdate:    nil,
+			name:        "no-route-config-in-response",
+			rdsResponse: badResourceTypeInRDSResponse,
+			wantErr:     true,
+			wantUpdate:  nil,
+			wantUpdateMD: xdsclient.UpdateMetadata{
+				Status: xdsclient.ServiceStatusNACKed,
+				ErrState: &xdsclient.UpdateErrorMetadata{
+					Err: errPlaceHolder,
+				},
+			},
 			wantUpdateErr: false,
 		},
 		// No VirtualHosts in the response. Just one test case here for a bad
@@ -75,17 +88,42 @@ func (s) TestRDSHandleResponseWithRouting(t *testing.T) {
 			name:        "no-virtual-hosts-in-response",
 			rdsResponse: noVirtualHostsInRDSResponse,
 			wantErr:     false,
-			wantUpdate: &xdsclient.RouteConfigUpdate{
-				VirtualHosts: nil,
+			wantUpdate: map[string]xdsclient.RouteConfigUpdate{
+				goodRouteName1: {
+					VirtualHosts: nil,
+					Raw:          marshaledNoVirtualHostsRouteConfig,
+				},
+			},
+			wantUpdateMD: xdsclient.UpdateMetadata{
+				Status:   xdsclient.ServiceStatusACKed,
+				ErrState: nil,
 			},
 			wantUpdateErr: false,
 		},
 		// Response contains one good RouteConfiguration, uninteresting though.
 		{
-			name:          "one-uninteresting-route-config",
-			rdsResponse:   goodRDSResponse2,
-			wantErr:       false,
-			wantUpdate:    nil,
+			name:        "one-uninteresting-route-config",
+			rdsResponse: goodRDSResponse2,
+			wantErr:     false,
+			wantUpdate: map[string]xdsclient.RouteConfigUpdate{
+				goodRouteName2: {
+					VirtualHosts: []*xdsclient.VirtualHost{
+						{
+							Domains: []string{uninterestingDomain},
+							Routes:  []*xdsclient.Route{{Prefix: newStringP(""), WeightedClusters: map[string]xdsclient.WeightedCluster{uninterestingClusterName: {Weight: 1}}}},
+						},
+						{
+							Domains: []string{goodLDSTarget1},
+							Routes:  []*xdsclient.Route{{Prefix: newStringP(""), WeightedClusters: map[string]xdsclient.WeightedCluster{goodClusterName2: {Weight: 1}}}},
+						},
+					},
+					Raw: marshaledGoodRouteConfig2,
+				},
+			},
+			wantUpdateMD: xdsclient.UpdateMetadata{
+				Status:   xdsclient.ServiceStatusACKed,
+				ErrState: nil,
+			},
 			wantUpdateErr: false,
 		},
 		// Response contains one good interesting RouteConfiguration.
@@ -93,17 +131,24 @@ func (s) TestRDSHandleResponseWithRouting(t *testing.T) {
 			name:        "one-good-route-config",
 			rdsResponse: goodRDSResponse1,
 			wantErr:     false,
-			wantUpdate: &xdsclient.RouteConfigUpdate{
-				VirtualHosts: []*xdsclient.VirtualHost{
-					{
-						Domains: []string{uninterestingDomain},
-						Routes:  []*xdsclient.Route{{Prefix: newStringP(""), WeightedClusters: map[string]xdsclient.WeightedCluster{uninterestingClusterName: {Weight: 1}}}},
+			wantUpdate: map[string]xdsclient.RouteConfigUpdate{
+				goodRouteName1: {
+					VirtualHosts: []*xdsclient.VirtualHost{
+						{
+							Domains: []string{uninterestingDomain},
+							Routes:  []*xdsclient.Route{{Prefix: newStringP(""), WeightedClusters: map[string]xdsclient.WeightedCluster{uninterestingClusterName: {Weight: 1}}}},
+						},
+						{
+							Domains: []string{goodLDSTarget1},
+							Routes:  []*xdsclient.Route{{Prefix: newStringP(""), WeightedClusters: map[string]xdsclient.WeightedCluster{goodClusterName1: {Weight: 1}}}},
+						},
 					},
-					{
-						Domains: []string{goodLDSTarget1},
-						Routes:  []*xdsclient.Route{{Prefix: newStringP(""), WeightedClusters: map[string]xdsclient.WeightedCluster{goodClusterName1: {Weight: 1}}}},
-					},
+					Raw: marshaledGoodRouteConfig1,
 				},
+			},
+			wantUpdateMD: xdsclient.UpdateMetadata{
+				Status:   xdsclient.ServiceStatusACKed,
+				ErrState: nil,
 			},
 			wantUpdateErr: false,
 		},
@@ -116,6 +161,7 @@ func (s) TestRDSHandleResponseWithRouting(t *testing.T) {
 				responseToHandle: test.rdsResponse,
 				wantHandleErr:    test.wantErr,
 				wantUpdate:       test.wantUpdate,
+				wantUpdateMD:     test.wantUpdateMD,
 				wantUpdateErr:    test.wantUpdateErr,
 			})
 		})

--- a/xds/internal/client/v3/client.go
+++ b/xds/internal/client/v3/client.go
@@ -186,11 +186,8 @@ func (v3c *client) HandleResponse(r proto.Message) (xdsclient.ResourceType, stri
 // callback.
 func (v3c *client) handleLDSResponse(resp *v3discoverypb.DiscoveryResponse) error {
 	update, md, err := xdsclient.UnmarshalListener(resp.GetVersionInfo(), resp.GetResources(), v3c.logger)
-	if err != nil {
-		return err
-	}
 	v3c.parent.NewListeners(update, md)
-	return nil
+	return err
 }
 
 // handleRDSResponse processes an RDS response received from the management
@@ -198,11 +195,8 @@ func (v3c *client) handleLDSResponse(resp *v3discoverypb.DiscoveryResponse) erro
 // invokes the registered watcher callback.
 func (v3c *client) handleRDSResponse(resp *v3discoverypb.DiscoveryResponse) error {
 	update, md, err := xdsclient.UnmarshalRouteConfig(resp.GetVersionInfo(), resp.GetResources(), v3c.logger)
-	if err != nil {
-		return err
-	}
 	v3c.parent.NewRouteConfigs(update, md)
-	return nil
+	return err
 }
 
 // handleCDSResponse processes an CDS response received from the management
@@ -210,18 +204,12 @@ func (v3c *client) handleRDSResponse(resp *v3discoverypb.DiscoveryResponse) erro
 // callback.
 func (v3c *client) handleCDSResponse(resp *v3discoverypb.DiscoveryResponse) error {
 	update, md, err := xdsclient.UnmarshalCluster(resp.GetVersionInfo(), resp.GetResources(), v3c.logger)
-	if err != nil {
-		return err
-	}
 	v3c.parent.NewClusters(update, md)
-	return nil
+	return err
 }
 
 func (v3c *client) handleEDSResponse(resp *v3discoverypb.DiscoveryResponse) error {
 	update, md, err := xdsclient.UnmarshalEndpoints(resp.GetVersionInfo(), resp.GetResources(), v3c.logger)
-	if err != nil {
-		return err
-	}
 	v3c.parent.NewEndpoints(update, md)
-	return nil
+	return err
 }

--- a/xds/internal/client/xds.go
+++ b/xds/internal/client/xds.go
@@ -130,7 +130,7 @@ func processClientSideListener(lis *v3listenerpb.Listener, v2 bool) (*ListenerUp
 
 	var err error
 	if update.HTTPFilters, err = processHTTPFilters(apiLis.GetHttpFilters(), false); err != nil {
-		return nil, fmt.Errorf("xds: %v", err)
+		return nil, err
 	}
 
 	return update, nil

--- a/xds/internal/client/xds.go
+++ b/xds/internal/client/xds.go
@@ -276,28 +276,28 @@ func processServerSideListener(lis *v3listenerpb.Listener) (*ListenerUpdate, err
 	// grpc/server?udpa.resource.listening_address=IP:Port.
 	addr := lis.GetAddress()
 	if addr == nil {
-		return nil, fmt.Errorf("xds: no address field in LDS response: %+v", lis)
+		return nil, fmt.Errorf("no address field in LDS response: %+v", lis)
 	}
 	sockAddr := addr.GetSocketAddress()
 	if sockAddr == nil {
-		return nil, fmt.Errorf("xds: no socket_address field in LDS response: %+v", lis)
+		return nil, fmt.Errorf("no socket_address field in LDS response: %+v", lis)
 	}
 	host, port, err := getAddressFromName(lis.GetName())
 	if err != nil {
-		return nil, fmt.Errorf("xds: no host:port in name field of LDS response: %+v, error: %v", lis, err)
+		return nil, fmt.Errorf("no host:port in name field of LDS response: %+v, error: %v", lis, err)
 	}
 	if h := sockAddr.GetAddress(); host != h {
-		return nil, fmt.Errorf("xds: socket_address host does not match the one in name. Got %q, want %q", h, host)
+		return nil, fmt.Errorf("socket_address host does not match the one in name. Got %q, want %q", h, host)
 	}
 	if p := strconv.Itoa(int(sockAddr.GetPortValue())); port != p {
-		return nil, fmt.Errorf("xds: socket_address port does not match the one in name. Got %q, want %q", p, port)
+		return nil, fmt.Errorf("socket_address port does not match the one in name. Got %q, want %q", p, port)
 	}
 
 	// Make sure the listener resource contains a single filter chain. We do not
 	// support multiple filter chains and picking the best match from the list.
 	fcs := lis.GetFilterChains()
 	if n := len(fcs); n != 1 {
-		return nil, fmt.Errorf("xds: filter chains count in LDS response does not match expected. Got %d, want 1", n)
+		return nil, fmt.Errorf("filter chains count in LDS response does not match expected. Got %d, want 1", n)
 	}
 	fc := fcs[0]
 
@@ -310,18 +310,18 @@ func processServerSideListener(lis *v3listenerpb.Listener) (*ListenerUpdate, err
 		return &ListenerUpdate{}, nil
 	}
 	if name := ts.GetName(); name != transportSocketName {
-		return nil, fmt.Errorf("xds: transport_socket field has unexpected name: %s", name)
+		return nil, fmt.Errorf("transport_socket field has unexpected name: %s", name)
 	}
 	any := ts.GetTypedConfig()
 	if any == nil || any.TypeUrl != version.V3DownstreamTLSContextURL {
-		return nil, fmt.Errorf("xds: transport_socket field has unexpected typeURL: %s", any.TypeUrl)
+		return nil, fmt.Errorf("transport_socket field has unexpected typeURL: %s", any.TypeUrl)
 	}
 	downstreamCtx := &v3tlspb.DownstreamTlsContext{}
 	if err := proto.Unmarshal(any.GetValue(), downstreamCtx); err != nil {
-		return nil, fmt.Errorf("xds: failed to unmarshal DownstreamTlsContext in LDS response: %v", err)
+		return nil, fmt.Errorf("failed to unmarshal DownstreamTlsContext in LDS response: %v", err)
 	}
 	if downstreamCtx.GetCommonTlsContext() == nil {
-		return nil, errors.New("xds: DownstreamTlsContext in LDS response does not contain a CommonTlsContext")
+		return nil, errors.New("DownstreamTlsContext in LDS response does not contain a CommonTlsContext")
 	}
 	sc, err := securityConfigFromCommonTLSContext(downstreamCtx.GetCommonTlsContext())
 	if err != nil {
@@ -634,11 +634,11 @@ func validateCluster(cluster *v3clusterpb.Cluster) (ClusterUpdate, error) {
 	emptyUpdate := ClusterUpdate{ServiceName: "", EnableLRS: false}
 	switch {
 	case cluster.GetType() != v3clusterpb.Cluster_EDS:
-		return emptyUpdate, fmt.Errorf("xds: unexpected cluster type %v in response: %+v", cluster.GetType(), cluster)
+		return emptyUpdate, fmt.Errorf("unexpected cluster type %v in response: %+v", cluster.GetType(), cluster)
 	case cluster.GetEdsClusterConfig().GetEdsConfig().GetAds() == nil:
-		return emptyUpdate, fmt.Errorf("xds: unexpected edsConfig in response: %+v", cluster)
+		return emptyUpdate, fmt.Errorf("unexpected edsConfig in response: %+v", cluster)
 	case cluster.GetLbPolicy() != v3clusterpb.Cluster_ROUND_ROBIN:
-		return emptyUpdate, fmt.Errorf("xds: unexpected lbPolicy %v in response: %+v", cluster.GetLbPolicy(), cluster)
+		return emptyUpdate, fmt.Errorf("unexpected lbPolicy %v in response: %+v", cluster.GetLbPolicy(), cluster)
 	}
 
 	sc, err := securityConfigFromCluster(cluster)
@@ -664,18 +664,18 @@ func securityConfigFromCluster(cluster *v3clusterpb.Cluster) (*SecurityConfig, e
 		return nil, nil
 	}
 	if name := ts.GetName(); name != transportSocketName {
-		return nil, fmt.Errorf("xds: transport_socket field has unexpected name: %s", name)
+		return nil, fmt.Errorf("transport_socket field has unexpected name: %s", name)
 	}
 	any := ts.GetTypedConfig()
 	if any == nil || any.TypeUrl != version.V3UpstreamTLSContextURL {
-		return nil, fmt.Errorf("xds: transport_socket field has unexpected typeURL: %s", any.TypeUrl)
+		return nil, fmt.Errorf("transport_socket field has unexpected typeURL: %s", any.TypeUrl)
 	}
 	upstreamCtx := &v3tlspb.UpstreamTlsContext{}
 	if err := proto.Unmarshal(any.GetValue(), upstreamCtx); err != nil {
-		return nil, fmt.Errorf("xds: failed to unmarshal UpstreamTlsContext in CDS response: %v", err)
+		return nil, fmt.Errorf("failed to unmarshal UpstreamTlsContext in CDS response: %v", err)
 	}
 	if upstreamCtx.GetCommonTlsContext() == nil {
-		return nil, errors.New("xds: UpstreamTlsContext in CDS response does not contain a CommonTlsContext")
+		return nil, errors.New("UpstreamTlsContext in CDS response does not contain a CommonTlsContext")
 	}
 
 	sc, err := securityConfigFromCommonTLSContext(upstreamCtx.GetCommonTlsContext())
@@ -731,7 +731,7 @@ func securityConfigFromCommonTLSContext(common *v3tlspb.CommonTlsContext) (*Secu
 	case nil:
 		// It is valid for the validation context to be nil on the server side.
 	default:
-		return nil, fmt.Errorf("xds: validation context contains unexpected type: %T", t)
+		return nil, fmt.Errorf("validation context contains unexpected type: %T", t)
 	}
 	return sc, nil
 }
@@ -886,7 +886,7 @@ func combineErrors(rType string, topLevelErrors []error, perResourceErrors map[s
 		errStrB.WriteString("top level errors: ")
 		for i, err := range topLevelErrors {
 			if i != 0 {
-				errStrB.WriteString("; ")
+				errStrB.WriteString(";\n")
 			}
 			errStrB.WriteString(err.Error())
 		}
@@ -895,8 +895,9 @@ func combineErrors(rType string, topLevelErrors []error, perResourceErrors map[s
 		var i int
 		for name, err := range perResourceErrors {
 			if i != 0 {
-				errStrB.WriteString("; ")
+				errStrB.WriteString(";\n")
 			}
+			i++
 			errStrB.WriteString(fmt.Sprintf("resource %q: %v", name, err.Error()))
 		}
 	}

--- a/xds/internal/client/xds.go
+++ b/xds/internal/client/xds.go
@@ -24,6 +24,7 @@ import (
 	"net"
 	"strconv"
 	"strings"
+	"time"
 
 	v1typepb "github.com/cncf/udpa/go/udpa/type/v1"
 	v3clusterpb "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
@@ -52,27 +53,54 @@ const transportSocketName = "envoy.transport_sockets.tls"
 // UnmarshalListener processes resources received in an LDS response, validates
 // them, and transforms them into a native struct which contains only fields we
 // are interested in.
-func UnmarshalListener(_ string, resources []*anypb.Any, logger *grpclog.PrefixLogger) (map[string]ListenerUpdate, UpdateMetadata, error) {
+func UnmarshalListener(versionStr string, resources []*anypb.Any, logger *grpclog.PrefixLogger) (map[string]ListenerUpdate, UpdateMetadata, error) {
+	timestamp := time.Now()
 	update := make(map[string]ListenerUpdate)
+	md := UpdateMetadata{
+		Version:   versionStr,
+		Timestamp: timestamp,
+	}
+	var topLevelErrors []error
+	perResourceErrors := make(map[string]error)
 	for _, r := range resources {
 		if !IsListenerResource(r.GetTypeUrl()) {
-			return nil, UpdateMetadata{}, fmt.Errorf("xds: unexpected resource type: %q in LDS response", r.GetTypeUrl())
+			topLevelErrors = append(topLevelErrors, fmt.Errorf("unexpected resource type: %q ", r.GetTypeUrl()))
+			continue
 		}
 		// TODO: Pass version.TransportAPI instead of relying upon the type URL
 		v2 := r.GetTypeUrl() == version.V2ListenerURL
 		lis := &v3listenerpb.Listener{}
 		if err := proto.Unmarshal(r.GetValue(), lis); err != nil {
-			return nil, UpdateMetadata{}, fmt.Errorf("xds: failed to unmarshal resource in LDS response: %v", err)
+			topLevelErrors = append(topLevelErrors, fmt.Errorf("failed to unmarshal resource: %v", err))
+			continue
 		}
 		logger.Infof("Resource with name: %v, type: %T, contains: %v", lis.GetName(), lis, lis)
 
 		lu, err := processListener(lis, v2)
 		if err != nil {
-			return nil, UpdateMetadata{}, err
+			perResourceErrors[lis.GetName()] = err
+			// Add place holder in the map so we know this resource name was in
+			// the response.
+			update[lis.GetName()] = ListenerUpdate{}
+			continue
 		}
+		lu.Raw = r
 		update[lis.GetName()] = *lu
 	}
-	return update, UpdateMetadata{}, nil
+
+	if len(topLevelErrors) == 0 && len(perResourceErrors) == 0 {
+		md.Status = ServiceStatusACKed
+		return update, md, nil
+	}
+
+	md.Status = ServiceStatusNACKed
+	errRet := combineErrors("LDS", topLevelErrors, perResourceErrors)
+	md.ErrState = &UpdateErrorMetadata{
+		Version:   versionStr,
+		Err:       errRet,
+		Timestamp: timestamp,
+	}
+	return update, md, errRet
 }
 
 func processListener(lis *v3listenerpb.Listener, v2 bool) (*ListenerUpdate, error) {
@@ -89,31 +117,31 @@ func processClientSideListener(lis *v3listenerpb.Listener, v2 bool) (*ListenerUp
 
 	apiLisAny := lis.GetApiListener().GetApiListener()
 	if !IsHTTPConnManagerResource(apiLisAny.GetTypeUrl()) {
-		return nil, fmt.Errorf("xds: unexpected resource type: %q in LDS response", apiLisAny.GetTypeUrl())
+		return nil, fmt.Errorf("unexpected resource type: %q", apiLisAny.GetTypeUrl())
 	}
 	apiLis := &v3httppb.HttpConnectionManager{}
 	if err := proto.Unmarshal(apiLisAny.GetValue(), apiLis); err != nil {
-		return nil, fmt.Errorf("xds: failed to unmarshal api_listner in LDS response: %v", err)
+		return nil, fmt.Errorf("failed to unmarshal api_listner: %v", err)
 	}
 
 	switch apiLis.RouteSpecifier.(type) {
 	case *v3httppb.HttpConnectionManager_Rds:
 		if apiLis.GetRds().GetConfigSource().GetAds() == nil {
-			return nil, fmt.Errorf("xds: ConfigSource is not ADS in LDS response: %+v", lis)
+			return nil, fmt.Errorf("ConfigSource is not ADS: %+v", lis)
 		}
 		name := apiLis.GetRds().GetRouteConfigName()
 		if name == "" {
-			return nil, fmt.Errorf("xds: empty route_config_name in LDS response: %+v", lis)
+			return nil, fmt.Errorf("empty route_config_name: %+v", lis)
 		}
 		update.RouteConfigName = name
 	case *v3httppb.HttpConnectionManager_RouteConfig:
 		// TODO: Add support for specifying the RouteConfiguration inline
 		// in the LDS response.
-		return nil, fmt.Errorf("xds: LDS response contains RDS config inline. Not supported for now: %+v", apiLis)
+		return nil, fmt.Errorf("LDS response contains RDS config inline. Not supported for now: %+v", apiLis)
 	case nil:
-		return nil, fmt.Errorf("xds: no RouteSpecifier in received LDS response: %+v", apiLis)
+		return nil, fmt.Errorf("no RouteSpecifier: %+v", apiLis)
 	default:
-		return nil, fmt.Errorf("xds: unsupported type %T for RouteSpecifier in received LDS response", apiLis.RouteSpecifier)
+		return nil, fmt.Errorf("unsupported type %T for RouteSpecifier", apiLis.RouteSpecifier)
 	}
 
 	if v2 {
@@ -321,15 +349,24 @@ func getAddressFromName(name string) (host string, port string, err error) {
 // validates them, and transforms them into a native struct which contains only
 // fields we are interested in. The provided hostname determines the route
 // configuration resources of interest.
-func UnmarshalRouteConfig(_ string, resources []*anypb.Any, logger *grpclog.PrefixLogger) (map[string]RouteConfigUpdate, UpdateMetadata, error) {
+func UnmarshalRouteConfig(versionStr string, resources []*anypb.Any, logger *grpclog.PrefixLogger) (map[string]RouteConfigUpdate, UpdateMetadata, error) {
+	timestamp := time.Now()
 	update := make(map[string]RouteConfigUpdate)
+	md := UpdateMetadata{
+		Version:   versionStr,
+		Timestamp: timestamp,
+	}
+	var topLevelErrors []error
+	perResourceErrors := make(map[string]error)
 	for _, r := range resources {
 		if !IsRouteConfigResource(r.GetTypeUrl()) {
-			return nil, UpdateMetadata{}, fmt.Errorf("xds: unexpected resource type: %q in RDS response", r.GetTypeUrl())
+			topLevelErrors = append(topLevelErrors, fmt.Errorf("unexpected resource type: %q ", r.GetTypeUrl()))
+			continue
 		}
 		rc := &v3routepb.RouteConfiguration{}
 		if err := proto.Unmarshal(r.GetValue(), rc); err != nil {
-			return nil, UpdateMetadata{}, fmt.Errorf("xds: failed to unmarshal resource in RDS response: %v", err)
+			topLevelErrors = append(topLevelErrors, fmt.Errorf("failed to unmarshal resource: %v", err))
+			continue
 		}
 		logger.Infof("Resource with name: %v, type: %T, contains: %v.", rc.GetName(), rc, rc)
 
@@ -338,11 +375,29 @@ func UnmarshalRouteConfig(_ string, resources []*anypb.Any, logger *grpclog.Pref
 		// Use the hostname (resourceName for LDS) to find the routes.
 		u, err := generateRDSUpdateFromRouteConfiguration(rc, logger, v2)
 		if err != nil {
-			return nil, UpdateMetadata{}, fmt.Errorf("xds: received invalid RouteConfiguration in RDS response: %+v with err: %v", rc, err)
+			perResourceErrors[rc.GetName()] = err
+			// Add place holder in the map so we know this resource name was in
+			// the response.
+			update[rc.GetName()] = RouteConfigUpdate{}
+			continue
 		}
+		u.Raw = r
 		update[rc.GetName()] = u
 	}
-	return update, UpdateMetadata{}, nil
+
+	if len(topLevelErrors) == 0 && len(perResourceErrors) == 0 {
+		md.Status = ServiceStatusACKed
+		return update, md, nil
+	}
+
+	md.Status = ServiceStatusNACKed
+	errRet := combineErrors("RDS", topLevelErrors, perResourceErrors)
+	md.ErrState = &UpdateErrorMetadata{
+		Version:   versionStr,
+		Err:       errRet,
+		Timestamp: timestamp,
+	}
+	return update, md, errRet
 }
 
 // generateRDSUpdateFromRouteConfiguration checks if the provided
@@ -520,23 +575,37 @@ func routesProtoToSlice(routes []*v3routepb.Route, logger *grpclog.PrefixLogger,
 // UnmarshalCluster processes resources received in an CDS response, validates
 // them, and transforms them into a native struct which contains only fields we
 // are interested in.
-func UnmarshalCluster(version string, resources []*anypb.Any, logger *grpclog.PrefixLogger) (map[string]ClusterUpdate, UpdateMetadata, error) {
+func UnmarshalCluster(versionStr string, resources []*anypb.Any, logger *grpclog.PrefixLogger) (map[string]ClusterUpdate, UpdateMetadata, error) {
+	timestamp := time.Now()
 	update := make(map[string]ClusterUpdate)
+	md := UpdateMetadata{
+		Version:   versionStr,
+		Timestamp: timestamp,
+	}
+	var topLevelErrors []error
+	perResourceErrors := make(map[string]error)
 	for _, r := range resources {
 		if !IsClusterResource(r.GetTypeUrl()) {
-			return nil, UpdateMetadata{}, fmt.Errorf("xds: unexpected resource type: %q in CDS response", r.GetTypeUrl())
+			topLevelErrors = append(topLevelErrors, fmt.Errorf("unexpected resource type: %q ", r.GetTypeUrl()))
+			continue
 		}
 
 		cluster := &v3clusterpb.Cluster{}
 		if err := proto.Unmarshal(r.GetValue(), cluster); err != nil {
-			return nil, UpdateMetadata{}, fmt.Errorf("xds: failed to unmarshal resource in CDS response: %v", err)
+			topLevelErrors = append(topLevelErrors, fmt.Errorf("failed to unmarshal resource: %v", err))
+			continue
 		}
 		logger.Infof("Resource with name: %v, type: %T, contains: %v", cluster.GetName(), cluster, cluster)
+
 		cu, err := validateCluster(cluster)
 		if err != nil {
-			return nil, UpdateMetadata{}, err
+			perResourceErrors[cluster.GetName()] = err
+			// Add place holder in the map so we know this resource name was in
+			// the response.
+			update[cluster.GetName()] = ClusterUpdate{}
+			continue
 		}
-
+		cu.Raw = r
 		// If the Cluster message in the CDS response did not contain a
 		// serviceName, we will just use the clusterName for EDS.
 		if cu.ServiceName == "" {
@@ -545,7 +614,20 @@ func UnmarshalCluster(version string, resources []*anypb.Any, logger *grpclog.Pr
 		logger.Debugf("Resource with name %v, value %+v added to cache", cluster.GetName(), cu)
 		update[cluster.GetName()] = cu
 	}
-	return update, UpdateMetadata{}, nil
+
+	if len(topLevelErrors) == 0 && len(perResourceErrors) == 0 {
+		md.Status = ServiceStatusACKed
+		return update, md, nil
+	}
+
+	md.Status = ServiceStatusNACKed
+	errRet := combineErrors("CDS", topLevelErrors, perResourceErrors)
+	md.ErrState = &UpdateErrorMetadata{
+		Version:   versionStr,
+		Err:       errRet,
+		Timestamp: timestamp,
+	}
+	return update, md, errRet
 }
 
 func validateCluster(cluster *v3clusterpb.Cluster) (ClusterUpdate, error) {
@@ -678,26 +760,53 @@ func circuitBreakersFromCluster(cluster *v3clusterpb.Cluster) *uint32 {
 // UnmarshalEndpoints processes resources received in an EDS response,
 // validates them, and transforms them into a native struct which contains only
 // fields we are interested in.
-func UnmarshalEndpoints(version string, resources []*anypb.Any, logger *grpclog.PrefixLogger) (map[string]EndpointsUpdate, UpdateMetadata, error) {
+func UnmarshalEndpoints(versionStr string, resources []*anypb.Any, logger *grpclog.PrefixLogger) (map[string]EndpointsUpdate, UpdateMetadata, error) {
+	timestamp := time.Now()
 	update := make(map[string]EndpointsUpdate)
+	md := UpdateMetadata{
+		Version:   versionStr,
+		Timestamp: timestamp,
+	}
+	var topLevelErrors []error
+	perResourceErrors := make(map[string]error)
 	for _, r := range resources {
 		if !IsEndpointsResource(r.GetTypeUrl()) {
-			return nil, UpdateMetadata{}, fmt.Errorf("xds: unexpected resource type: %q in EDS response", r.GetTypeUrl())
+			topLevelErrors = append(topLevelErrors, fmt.Errorf("unexpected resource type: %q ", r.GetTypeUrl()))
+			continue
 		}
 
 		cla := &v3endpointpb.ClusterLoadAssignment{}
 		if err := proto.Unmarshal(r.GetValue(), cla); err != nil {
-			return nil, UpdateMetadata{}, fmt.Errorf("xds: failed to unmarshal resource in EDS response: %v", err)
+			topLevelErrors = append(topLevelErrors, fmt.Errorf("failed to unmarshal resource: %v", err))
+			continue
 		}
 		logger.Infof("Resource with name: %v, type: %T, contains: %v", cla.GetClusterName(), cla, cla)
 
 		u, err := parseEDSRespProto(cla)
 		if err != nil {
-			return nil, UpdateMetadata{}, err
+			perResourceErrors[cla.GetClusterName()] = err
+			// Add place holder in the map so we know this resource name was in
+			// the response.
+			update[cla.GetClusterName()] = EndpointsUpdate{}
+			continue
 		}
+		u.Raw = r
 		update[cla.GetClusterName()] = u
 	}
-	return update, UpdateMetadata{}, nil
+
+	if len(topLevelErrors) == 0 && len(perResourceErrors) == 0 {
+		md.Status = ServiceStatusACKed
+		return update, md, nil
+	}
+
+	md.Status = ServiceStatusNACKed
+	errRet := combineErrors("EDS", topLevelErrors, perResourceErrors)
+	md.ErrState = &UpdateErrorMetadata{
+		Version:   versionStr,
+		Err:       errRet,
+		Timestamp: timestamp,
+	}
+	return update, md, errRet
 }
 
 func parseAddress(socketAddress *v3corepb.SocketAddress) string {
@@ -768,4 +877,28 @@ func parseEDSRespProto(m *v3endpointpb.ClusterLoadAssignment) (EndpointsUpdate, 
 		}
 	}
 	return ret, nil
+}
+
+func combineErrors(rType string, topLevelErrors []error, perResourceErrors map[string]error) error {
+	var errStrB strings.Builder
+	errStrB.WriteString(fmt.Sprintf("error parsing %q response: ", rType))
+	if len(topLevelErrors) > 0 {
+		errStrB.WriteString("top level errors: ")
+		for i, err := range topLevelErrors {
+			if i != 0 {
+				errStrB.WriteString("; ")
+			}
+			errStrB.WriteString(err.Error())
+		}
+	}
+	if len(perResourceErrors) > 0 {
+		var i int
+		for name, err := range perResourceErrors {
+			if i != 0 {
+				errStrB.WriteString("; ")
+			}
+			errStrB.WriteString(fmt.Sprintf("resource %q: %v", name, err.Error()))
+		}
+	}
+	return errors.New(errStrB.String())
 }

--- a/xds/internal/client/xds.go
+++ b/xds/internal/client/xds.go
@@ -781,8 +781,8 @@ func parseEDSRespProto(m *v3endpointpb.ClusterLoadAssignment) (EndpointsUpdate, 
 	return ret, nil
 }
 
-// processAllResources unmarshal and validate the resources, populate the
-// provided ret (a map), and return metadata and error.
+// processAllResources unmarshals and validates the resources, populates the
+// provided ret (a map), and returns metadata and error.
 //
 // The type of the resource is determined by the type of ret. E.g.
 // map[string]ListenerUpdate means this is for LDS.


### PR DESCRIPTION
- xds_client.go
  - populate Metadata for the update
  - When unmarshalling responses, DON'T stop at the first error. Keep processing
    all the resources, so we know which resources are NACKed.
- v2/v3 client.go
  - Send the updates to client_callback.go even when response is NACKed. This is
    necessary for CSDS's purpose, and also necessary when we later call user's
    callback with the NACK errors.
- Test changes