### PR TITLE
xds: add support for more resources to e2e server

### DIFF
--- a/xds/internal/test/xds_client_integration_test.go
+++ b/xds/internal/test/xds_client_integration_test.go
@@ -1,0 +1,112 @@
+// +build !386
+
+/*
+ *
+ * Copyright 2021 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package xds_test
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/google/uuid"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/xds/internal/testutils"
+	"google.golang.org/grpc/xds/internal/testutils/e2e"
+
+	testpb "google.golang.org/grpc/test/grpc_testing"
+)
+
+// clientSetup performs a bunch of steps common to all xDS client tests here:
+// - spin up an xDS management server on a local port
+// - spin up a gRPC server and register the test service on it
+// - create a local TCP listener and start serving on it
+//
+// Returns the following:
+// - the management server: tests use this to configure resources
+// - nodeID expected by the management server: this is set in the Node proto
+//   sent by the xdsClient for queries.
+// - the port the server is listening on
+// - cleanup function to be invoked by the tests when done
+func clientSetup(t *testing.T) (*e2e.ManagementServer, string, uint32, func()) {
+	// Spin up a xDS management server on a local port.
+	nodeID := uuid.New().String()
+	fs, err := e2e.StartManagementServer()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a bootstrap file in a temporary directory.
+	bootstrapCleanup, err := e2e.SetupBootstrapFile(e2e.BootstrapOptions{
+		Version:              e2e.TransportV3,
+		NodeID:               nodeID,
+		ServerURI:            fs.Address,
+		ServerResourceNameID: "grpc/server",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Initialize a gRPC server and register the stubServer on it.
+	server := grpc.NewServer()
+	testpb.RegisterTestServiceServer(server, &testService{})
+
+	// Create a local listener and pass it to Serve().
+	lis, err := testutils.LocalTCPListener()
+	if err != nil {
+		t.Fatalf("testutils.LocalTCPListener() failed: %v", err)
+	}
+
+	go func() {
+		if err := server.Serve(lis); err != nil {
+			t.Errorf("Serve() failed: %v", err)
+		}
+	}()
+
+	return fs, nodeID, uint32(lis.Addr().(*net.TCPAddr).Port), func() {
+		fs.Stop()
+		bootstrapCleanup()
+		server.Stop()
+	}
+}
+
+func (s) TestClientSideXDS(t *testing.T) {
+	fs, nodeID, port, cleanup := clientSetup(t)
+	defer cleanup()
+
+	resources := e2e.DefaultClientResources("myservice", nodeID, "localhost", port)
+	if err := fs.Update(resources); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a ClientConn and make a successful RPC.
+	cc, err := grpc.Dial("xds:///myservice", grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("failed to dial local test server: %v", err)
+	}
+	defer cc.Close()
+
+	client := testpb.NewTestServiceClient(cc)
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	if _, err := client.EmptyCall(ctx, &testpb.Empty{}, grpc.WaitForReady(true)); err != nil {
+		t.Fatalf("rpc EmptyCall() failed: %v", err)
+	}
+}

--- a/xds/internal/test/xds_server_integration_test.go
+++ b/xds/internal/test/xds_server_integration_test.go
@@ -119,7 +119,6 @@ func createClientTLSCredentials(t *testing.T) credentials.TransportCredentials {
 }
 
 // commonSetup performs a bunch of steps common to all xDS server tests here:
-// - turn on V3 support by setting the environment variable
 // - spin up an xDS management server on a local port
 // - set up certificates for consumption by the file_watcher plugin
 // - spin up an xDS-enabled gRPC server, configure it with xdsCredentials and

--- a/xds/internal/testutils/e2e/clientresources.go
+++ b/xds/internal/testutils/e2e/clientresources.go
@@ -1,0 +1,148 @@
+/*
+ *
+ * Copyright 2021 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package e2e
+
+import (
+	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/ptypes"
+	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	v3clusterpb "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	v3corepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	v3endpointpb "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
+	v3listenerpb "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	v3routepb "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	v3routerpb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/router/v3"
+	v3httppb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
+)
+
+func any(m proto.Message) *anypb.Any {
+	a, err := ptypes.MarshalAny(m)
+	if err != nil {
+		panic("error marshalling any: " + err.Error())
+	}
+	return a
+}
+
+// DefaultClientResources returns a set of resources (LDS, RDS, CDS, EDS) for a
+// client to generically connect to one server.
+func DefaultClientResources(target, nodeID, host string, port uint32) UpdateOptions {
+	const routeConfigName = "route"
+	const clusterName = "cluster"
+	const endpointsName = "endpoints"
+
+	return UpdateOptions{
+		NodeID:    nodeID,
+		Listeners: []*v3listenerpb.Listener{DefaultListener(target, routeConfigName)},
+		Routes:    []*v3routepb.RouteConfiguration{DefaultRouteConfig(routeConfigName, target, clusterName)},
+		Clusters:  []*v3clusterpb.Cluster{DefaultCluster(clusterName, endpointsName)},
+		Endpoints: []*v3endpointpb.ClusterLoadAssignment{DefaultEndpoint(endpointsName, host, port)},
+	}
+}
+
+// DefaultListener returns a basic xds Listener resource.
+func DefaultListener(target, routeName string) *v3listenerpb.Listener {
+	hcm := any(&v3httppb.HttpConnectionManager{
+		RouteSpecifier: &v3httppb.HttpConnectionManager_Rds{Rds: &v3httppb.Rds{
+			ConfigSource: &v3corepb.ConfigSource{
+				ConfigSourceSpecifier: &v3corepb.ConfigSource_Ads{Ads: &v3corepb.AggregatedConfigSource{}},
+			},
+			RouteConfigName: routeName,
+		}},
+		HttpFilters: []*v3httppb.HttpFilter{HTTPFilter("router", &v3routerpb.Router{})}, // router fields are unused by grpc
+	})
+	return &v3listenerpb.Listener{
+		Name:        target,
+		ApiListener: &v3listenerpb.ApiListener{ApiListener: hcm},
+		FilterChains: []*v3listenerpb.FilterChain{{
+			Name: "filter-chain-name",
+			Filters: []*v3listenerpb.Filter{{
+				Name:       wellknown.HTTPConnectionManager,
+				ConfigType: &v3listenerpb.Filter_TypedConfig{TypedConfig: hcm},
+			}},
+		}},
+	}
+}
+
+// HTTPFilter constructs an xds HttpFilter with the provided name and config.
+func HTTPFilter(name string, config proto.Message) *v3httppb.HttpFilter {
+	return &v3httppb.HttpFilter{
+		Name: name,
+		ConfigType: &v3httppb.HttpFilter_TypedConfig{
+			TypedConfig: any(config),
+		},
+	}
+}
+
+// DefaultRouteConfig returns a basic xds RouteConfig resource.
+func DefaultRouteConfig(routeName, ldsTarget, clusterName string) *v3routepb.RouteConfiguration {
+	return &v3routepb.RouteConfiguration{
+		Name: routeName,
+		VirtualHosts: []*v3routepb.VirtualHost{{
+			Domains: []string{ldsTarget},
+			Routes: []*v3routepb.Route{{
+				Match: &v3routepb.RouteMatch{PathSpecifier: &v3routepb.RouteMatch_Prefix{Prefix: "/"}},
+				Action: &v3routepb.Route_Route{Route: &v3routepb.RouteAction{
+					ClusterSpecifier: &v3routepb.RouteAction_Cluster{Cluster: clusterName},
+				}},
+			}},
+		}},
+	}
+}
+
+// DefaultCluster returns a basic xds Cluster resource.
+func DefaultCluster(clusterName, edsServiceName string) *v3clusterpb.Cluster {
+	return &v3clusterpb.Cluster{
+		Name:                 clusterName,
+		ClusterDiscoveryType: &v3clusterpb.Cluster_Type{Type: v3clusterpb.Cluster_EDS},
+		EdsClusterConfig: &v3clusterpb.Cluster_EdsClusterConfig{
+			EdsConfig: &v3corepb.ConfigSource{
+				ConfigSourceSpecifier: &v3corepb.ConfigSource_Ads{
+					Ads: &v3corepb.AggregatedConfigSource{},
+				},
+			},
+			ServiceName: edsServiceName,
+		},
+		LbPolicy: v3clusterpb.Cluster_ROUND_ROBIN,
+	}
+}
+
+// DefaultEndpoint returns a basic xds Endpoint resource.
+func DefaultEndpoint(clusterName string, host string, port uint32) *v3endpointpb.ClusterLoadAssignment {
+	return &v3endpointpb.ClusterLoadAssignment{
+		ClusterName: clusterName,
+		Endpoints: []*v3endpointpb.LocalityLbEndpoints{{
+			Locality: &v3corepb.Locality{SubZone: "subzone"},
+			LbEndpoints: []*v3endpointpb.LbEndpoint{{
+				HostIdentifier: &v3endpointpb.LbEndpoint_Endpoint{Endpoint: &v3endpointpb.Endpoint{
+					Address: &v3corepb.Address{Address: &v3corepb.Address_SocketAddress{
+						SocketAddress: &v3corepb.SocketAddress{
+							Protocol:      v3corepb.SocketAddress_TCP,
+							Address:       host,
+							PortSpecifier: &v3corepb.SocketAddress_PortValue{PortValue: uint32(port)}},
+					}},
+				}},
+			}},
+			LoadBalancingWeight: &wrapperspb.UInt32Value{Value: 1},
+			Priority:            0,
+		}},
+	}
+}

--- a/xds/internal/testutils/e2e/clientresources.go
+++ b/xds/internal/testutils/e2e/clientresources.go
@@ -19,10 +19,9 @@
 package e2e
 
 import (
+	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
-	"google.golang.org/protobuf/types/known/anypb"
-	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	v3clusterpb "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	v3corepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -31,7 +30,8 @@ import (
 	v3routepb "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	v3routerpb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/router/v3"
 	v3httppb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
-	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
+	anypb "github.com/golang/protobuf/ptypes/any"
+	wrapperspb "github.com/golang/protobuf/ptypes/wrappers"
 )
 
 func any(m proto.Message) *anypb.Any {

--- a/xds/internal/testutils/e2e/server.go
+++ b/xds/internal/testutils/e2e/server.go
@@ -113,7 +113,6 @@ type UpdateOptions struct {
 	Clusters  []*v3clusterpb.Cluster
 	Routes    []*v3routepb.RouteConfiguration
 	Listeners []*v3listenerpb.Listener
-	// TODO(easwars): Add support for other resource types.
 }
 
 // Update changes the resource snapshot held by the management server, which

--- a/xds/internal/testutils/e2e/server.go
+++ b/xds/internal/testutils/e2e/server.go
@@ -23,9 +23,13 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"reflect"
 	"strconv"
 
+	v3clusterpb "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	v3endpointpb "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 	v3listenerpb "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	v3routepb "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	v3discoverygrpc "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
 	v3cache "github.com/envoyproxy/go-control-plane/pkg/cache/v3"
@@ -103,7 +107,11 @@ func StartManagementServer() (*ManagementServer, error) {
 type UpdateOptions struct {
 	// NodeID is the id of the client to which this update is to be pushed.
 	NodeID string
-	// Listeners is the updated list of listener resources.
+	// Endpoints, Clusters, Routes, and Listeners are the updated list of xds
+	// resources for the server.  All must be provided with each Update.
+	Endpoints []*v3endpointpb.ClusterLoadAssignment
+	Clusters  []*v3clusterpb.Cluster
+	Routes    []*v3routepb.RouteConfiguration
 	Listeners []*v3listenerpb.Listener
 	// TODO(easwars): Add support for other resource types.
 }
@@ -114,11 +122,7 @@ func (s *ManagementServer) Update(opts UpdateOptions) error {
 	s.version++
 
 	// Create a snapshot with the passed in resources.
-	var listeners []types.Resource
-	for _, l := range opts.Listeners {
-		listeners = append(listeners, l)
-	}
-	snapshot := v3cache.NewSnapshot(strconv.Itoa(s.version), nil, nil, nil, listeners, nil, nil)
+	snapshot := v3cache.NewSnapshot(strconv.Itoa(s.version), resourceSlice(opts.Endpoints), resourceSlice(opts.Clusters), resourceSlice(opts.Routes), resourceSlice(opts.Listeners), nil /*runtimes*/, nil /*secrets*/)
 	if err := snapshot.Consistent(); err != nil {
 		return fmt.Errorf("failed to create new resource snapshot: %v", err)
 	}
@@ -139,4 +143,15 @@ func (s *ManagementServer) Stop() {
 	}
 	s.gs.Stop()
 	logger.Infof("Stopped the xDS management server...")
+}
+
+// resourceSlice accepts a slice of any type of proto messages and returns a
+// slice of types.Resource.  Will panic if there is an input type mismatch.
+func resourceSlice(i interface{}) []types.Resource {
+	v := reflect.ValueOf(i)
+	rs := make([]types.Resource, v.Len())
+	for i := 0; i < v.Len(); i++ {
+		rs[i] = v.Index(i).Interface().(types.Resource)
+	}
+	return rs
 }


### PR DESCRIPTION
FWIW, I may refactor & move this `clientSetup` to `testUtils` instead, to allow for easier writing of e2e tests in other packages.  E.g. I want to test fault injection *inside* the fault injection package so I can stub out the randomness and time-based functionality, but I want it to be in an end-to-end style.
