### PR TITLE
xds: Support server_listener_resource_name_template 

### DIFF
--- a/xds/internal/client/bootstrap/bootstrap.go
+++ b/xds/internal/client/bootstrap/bootstrap.go
@@ -79,10 +79,12 @@ type Config struct {
 	// CertProviderConfigs contains a mapping from certificate provider plugin
 	// instance names to parsed buildable configs.
 	CertProviderConfigs map[string]*certprovider.BuildableConfig
-	// ServerResourceNameID contains the value to be used as the id in the
-	// resource name used to fetch the Listener resource on the xDS-enabled gRPC
-	// server.
-	ServerResourceNameID string
+	// ServerListenerResourceNameTemplate is a template for the name of the
+	// Listener resource to subscribe to for a gRPC server. If the token `%s` is
+	// present in the string, it will be replaced with the server's listening
+	// "IP:port" (e.g., "0.0.0.0:8080", "[::]:8080"). For example, a value of
+	// "example/resource/%s" could become "example/resource/0.0.0.0:8080".
+	ServerListenerResourceNameTemplate string
 }
 
 type channelCreds struct {
@@ -145,7 +147,7 @@ func bootstrapConfigFromEnvVariable() ([]byte, error) {
 //        "config": { foo plugin config in JSON }
 //      }
 //    },
-//    "grpc_server_resource_name_id": "grpc/server"
+//    "server_listener_resource_name_template": "grpc/server?xds.resource.listening_address=%s"
 // }
 //
 // Currently, we support exactly one type of credential, which is
@@ -241,8 +243,8 @@ func NewConfig() (*Config, error) {
 				configs[instance] = bc
 			}
 			config.CertProviderConfigs = configs
-		case "grpc_server_resource_name_id":
-			if err := json.Unmarshal(v, &config.ServerResourceNameID); err != nil {
+		case "server_listener_resource_name_template":
+			if err := json.Unmarshal(v, &config.ServerListenerResourceNameTemplate); err != nil {
 				return nil, fmt.Errorf("xds: json.Unmarshal(%v) for field %q failed during bootstrap: %v", string(v), k, err)
 			}
 		}

--- a/xds/internal/client/bootstrap/bootstrap_test.go
+++ b/xds/internal/client/bootstrap/bootstrap_test.go
@@ -240,8 +240,8 @@ func (c *Config) compare(want *Config) error {
 	if diff := cmp.Diff(want.NodeProto, c.NodeProto, cmp.Comparer(proto.Equal)); diff != "" {
 		return fmt.Errorf("config.NodeProto diff (-want, +got):\n%s", diff)
 	}
-	if c.ServerResourceNameID != want.ServerResourceNameID {
-		return fmt.Errorf("config.ServerResourceNameID is %q, want %q", c.ServerResourceNameID, want.ServerResourceNameID)
+	if c.ServerListenerResourceNameTemplate != want.ServerListenerResourceNameTemplate {
+		return fmt.Errorf("config.ServerListenerResourceNameTemplate is %q, want %q", c.ServerListenerResourceNameTemplate, want.ServerListenerResourceNameTemplate)
 	}
 
 	// A vanilla cmp.Equal or cmp.Diff will not produce useful error message
@@ -711,9 +711,9 @@ func TestNewConfigWithCertificateProviders(t *testing.T) {
 	}
 }
 
-func TestNewConfigWithServerResourceNameID(t *testing.T) {
+func TestNewConfigWithServerListenerResourceNameTemplate(t *testing.T) {
 	cancel := setupBootstrapOverride(map[string]string{
-		"badServerResourceNameID": `
+		"badServerListenerResourceNameTemplate:": `
 		{
 			"node": {
 				"id": "ENVOY_NODE_ID",
@@ -727,9 +727,9 @@ func TestNewConfigWithServerResourceNameID(t *testing.T) {
 					{ "type": "google_default" }
 				]
 			}],
-			"grpc_server_resource_name_id": 123456789
+			"server_listener_resource_name_template": 123456789
 		}`,
-		"goodServerResourceNameID": `
+		"goodServerListenerResourceNameTemplate": `
 		{
 			"node": {
 				"id": "ENVOY_NODE_ID",
@@ -743,7 +743,7 @@ func TestNewConfigWithServerResourceNameID(t *testing.T) {
 					{ "type": "google_default" }
 				]
 			}],
-			"grpc_server_resource_name_id": "grpc/server"
+			"server_listener_resource_name_template": "grpc/server?xds.resource.listening_address=%s"
 		}`,
 	})
 	defer cancel()
@@ -754,17 +754,17 @@ func TestNewConfigWithServerResourceNameID(t *testing.T) {
 		wantErr    bool
 	}{
 		{
-			name:    "badServerResourceNameID",
+			name:    "badServerListenerResourceNameTemplate",
 			wantErr: true,
 		},
 		{
-			name: "goodServerResourceNameID",
+			name: "goodServerListenerResourceNameTemplate",
 			wantConfig: &Config{
-				BalancerName:         "trafficdirector.googleapis.com:443",
-				Creds:                grpc.WithCredentialsBundle(google.NewComputeEngineCredentials()),
-				TransportAPI:         version.TransportV2,
-				NodeProto:            v2NodeProto,
-				ServerResourceNameID: "grpc/server",
+				BalancerName:                       "trafficdirector.googleapis.com:443",
+				Creds:                              grpc.WithCredentialsBundle(google.NewComputeEngineCredentials()),
+				TransportAPI:                       version.TransportV2,
+				NodeProto:                          v2NodeProto,
+				ServerListenerResourceNameTemplate: "grpc/server?xds.resource.listening_address=%s",
 			},
 		},
 	}

--- a/xds/internal/client/client.go
+++ b/xds/internal/client/client.go
@@ -203,6 +203,8 @@ type ListenerUpdate struct {
 	// HTTPFilters is a list of HTTP filters (name, config) from the LDS
 	// response.
 	HTTPFilters []HTTPFilter
+	// InboundListenerCfg contains inbound listener configuration.
+	InboundListenerCfg *InboundListenerConfig
 
 	// Raw is the resource from the xds response.
 	Raw *anypb.Any
@@ -219,6 +221,17 @@ type HTTPFilter struct {
 	Filter httpfilter.Filter
 	// Config contains the filter's configuration
 	Config httpfilter.FilterConfig
+}
+
+// InboundListenerConfig contains information about the inbound listener, i.e
+// the server-side listener.
+type InboundListenerConfig struct {
+	// Address is the local address on which the inbound listener is expected to
+	// accept incoming connections.
+	Address string
+	// Port is the local port on which the inbound listener is expected to
+	// accept incoming connections.
+	Port string
 }
 
 func (lu *ListenerUpdate) String() string {

--- a/xds/internal/test/xds_client_integration_test.go
+++ b/xds/internal/test/xds_client_integration_test.go
@@ -55,10 +55,9 @@ func clientSetup(t *testing.T) (*e2e.ManagementServer, string, uint32, func()) {
 
 	// Create a bootstrap file in a temporary directory.
 	bootstrapCleanup, err := e2e.SetupBootstrapFile(e2e.BootstrapOptions{
-		Version:              e2e.TransportV3,
-		NodeID:               nodeID,
-		ServerURI:            fs.Address,
-		ServerResourceNameID: "grpc/server",
+		Version:   e2e.TransportV3,
+		NodeID:    nodeID,
+		ServerURI: fs.Address,
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/xds/internal/test/xds_server_integration_test.go
+++ b/xds/internal/test/xds_server_integration_test.go
@@ -60,6 +60,9 @@ const (
 	certFile = "cert.pem"
 	keyFile  = "key.pem"
 	rootFile = "ca.pem"
+
+	// Template for server Listener resource name.
+	serverListenerResourceNameTemplate = "grpc/server?xds.resource.listening_address=%s"
 )
 
 func createTmpFile(t *testing.T, src, dst string) {
@@ -148,11 +151,11 @@ func commonSetup(t *testing.T) (*e2e.ManagementServer, string, net.Listener, fun
 
 	// Create a bootstrap file in a temporary directory.
 	bootstrapCleanup, err := e2e.SetupBootstrapFile(e2e.BootstrapOptions{
-		Version:              e2e.TransportV3,
-		NodeID:               nodeID,
-		ServerURI:            fs.Address,
-		CertificateProviders: cpc,
-		ServerResourceNameID: "grpc/server",
+		Version:                            e2e.TransportV3,
+		NodeID:                             nodeID,
+		ServerURI:                          fs.Address,
+		CertificateProviders:               cpc,
+		ServerListenerResourceNameTemplate: serverListenerResourceNameTemplate,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -211,7 +214,7 @@ func listenerResourceWithoutSecurityConfig(t *testing.T, lis net.Listener) *v3li
 	host, port := hostPortFromListener(t, lis)
 	return &v3listenerpb.Listener{
 		// This needs to match the name we are querying for.
-		Name: fmt.Sprintf("grpc/server?udpa.resource.listening_address=%s", lis.Addr().String()),
+		Name: fmt.Sprintf(serverListenerResourceNameTemplate, lis.Addr().String()),
 		Address: &v3corepb.Address{
 			Address: &v3corepb.Address_SocketAddress{
 				SocketAddress: &v3corepb.SocketAddress{
@@ -237,7 +240,7 @@ func listenerResourceWithSecurityConfig(t *testing.T, lis net.Listener) *v3liste
 	host, port := hostPortFromListener(t, lis)
 	return &v3listenerpb.Listener{
 		// This needs to match the name we are querying for.
-		Name: fmt.Sprintf("grpc/server?udpa.resource.listening_address=%s", lis.Addr().String()),
+		Name: fmt.Sprintf(serverListenerResourceNameTemplate, lis.Addr().String()),
 		Address: &v3corepb.Address{
 			Address: &v3corepb.Address_SocketAddress{
 				SocketAddress: &v3corepb.SocketAddress{

--- a/xds/internal/testutils/e2e/bootstrap.go
+++ b/xds/internal/testutils/e2e/bootstrap.go
@@ -46,7 +46,7 @@ type BootstrapOptions struct {
 	NodeID string
 	// ServerURI is the address of the management server.
 	ServerURI string
-	// ServerResourceNameID is the Listener resource name to fetch.
+	// ServerListenerResourceNameTemplate is the Listener resource name to fetch.
 	ServerResourceNameID string
 	// CertificateProviders is the certificate providers configuration.
 	CertificateProviders map[string]json.RawMessage

--- a/xds/internal/testutils/e2e/bootstrap.go
+++ b/xds/internal/testutils/e2e/bootstrap.go
@@ -47,7 +47,7 @@ type BootstrapOptions struct {
 	// ServerURI is the address of the management server.
 	ServerURI string
 	// ServerListenerResourceNameTemplate is the Listener resource name to fetch.
-	ServerResourceNameID string
+	ServerListenerResourceNameTemplate string
 	// CertificateProviders is the certificate providers configuration.
 	CertificateProviders map[string]json.RawMessage
 }
@@ -79,8 +79,8 @@ func SetupBootstrapFile(opts BootstrapOptions) (func(), error) {
 		Node: node{
 			ID: opts.NodeID,
 		},
-		CertificateProviders:     opts.CertificateProviders,
-		GRPCServerResourceNameID: opts.ServerResourceNameID,
+		CertificateProviders:               opts.CertificateProviders,
+		ServerListenerResourceNameTemplate: opts.ServerListenerResourceNameTemplate,
 	}
 	switch opts.Version {
 	case TransportV2:
@@ -127,10 +127,10 @@ func DefaultFileWatcherConfig(certPath, keyPath, caPath string) map[string]json.
 }
 
 type bootstrapConfig struct {
-	XdsServers               []server                   `json:"xds_servers,omitempty"`
-	Node                     node                       `json:"node,omitempty"`
-	CertificateProviders     map[string]json.RawMessage `json:"certificate_providers,omitempty"`
-	GRPCServerResourceNameID string                     `json:"grpc_server_resource_name_id,omitempty"`
+	XdsServers                         []server                   `json:"xds_servers,omitempty"`
+	Node                               node                       `json:"node,omitempty"`
+	CertificateProviders               map[string]json.RawMessage `json:"certificate_providers,omitempty"`
+	ServerListenerResourceNameTemplate string                     `json:"server_listener_resource_name_template,omitempty"`
 }
 
 type server struct {

--- a/xds/server.go
+++ b/xds/server.go
@@ -233,7 +233,7 @@ func (s *GRPCServer) newListenerWrapper(lis net.Listener) (*listenerWrapper, err
 	}
 	name := cfg.ServerListenerResourceNameTemplate
 	if strings.Contains(cfg.ServerListenerResourceNameTemplate, "%s") {
-		name = fmt.Sprintf(cfg.ServerListenerResourceNameTemplate, lis.Addr().String())
+		name = strings.Replace(cfg.ServerListenerResourceNameTemplate, "%s", lis.Addr().String(), 1)
 	}
 
 	// Register an LDS watch using our xdsClient, and specify the listening

--- a/xds/server.go
+++ b/xds/server.go
@@ -233,7 +233,7 @@ func (s *GRPCServer) newListenerWrapper(lis net.Listener) (*listenerWrapper, err
 	}
 	name := cfg.ServerListenerResourceNameTemplate
 	if strings.Contains(cfg.ServerListenerResourceNameTemplate, "%s") {
-		name = strings.Replace(cfg.ServerListenerResourceNameTemplate, "%s", lis.Addr().String(), 1)
+		name = strings.ReplaceAll(cfg.ServerListenerResourceNameTemplate, "%s", lis.Addr().String())
 	}
 
 	// Register an LDS watch using our xdsClient, and specify the listening
@@ -308,6 +308,9 @@ func (s *GRPCServer) handleListenerUpdate(update listenerUpdate) {
 	lisAddr := update.lw.Listener.Addr().String()
 	addr, port, err := net.SplitHostPort(lisAddr)
 	if err != nil {
+		// This is never expected to return a non-nil error since we have made
+		// sure that the listener is a TCP listener at the beginning of Serve().
+		// This is simply paranoia.
 		s.logger.Warningf("Local listener address %q failed to parse as IP:port: %v", lisAddr, err)
 		return
 	}

--- a/xds/server.go
+++ b/xds/server.go
@@ -227,8 +227,8 @@ func (s *GRPCServer) newListenerWrapper(lis net.Listener) (*listenerWrapper, err
 	// field `grpc_server_resource_name_id`. If this field is not specified in
 	// the bootstrap file, we will use a default of `grpc/server`.
 	path := "grpc/server"
-	if cfg := s.xdsC.BootstrapConfig(); cfg != nil && cfg.ServerResourceNameID != "" {
-		path = cfg.ServerResourceNameID
+	if cfg := s.xdsC.BootstrapConfig(); cfg != nil && cfg.ServerListenerResourceNameTemplate != "" {
+		path = cfg.ServerListenerResourceNameTemplate
 	}
 	name := fmt.Sprintf("%s?udpa.resource.listening_address=%s", path, lis.Addr().String())
 

--- a/xds/server.go
+++ b/xds/server.go
@@ -231,26 +231,26 @@ func (s *GRPCServer) newListenerWrapper(lis net.Listener) (*listenerWrapper, err
 	if cfg == nil || cfg.ServerListenerResourceNameTemplate == "" {
 		return nil, errors.New("missing server_listener_resource_name_template in the bootstrap configuration")
 	}
-	listenerName := cfg.ServerListenerResourceNameTemplate
+	name := cfg.ServerListenerResourceNameTemplate
 	if strings.Contains(cfg.ServerListenerResourceNameTemplate, "%s") {
-		listenerName = fmt.Sprintf(cfg.ServerListenerResourceNameTemplate, lis.Addr().String())
+		name = fmt.Sprintf(cfg.ServerListenerResourceNameTemplate, lis.Addr().String())
 	}
 
 	// Register an LDS watch using our xdsClient, and specify the listening
 	// address as the resource name.
-	cancelWatch := s.xdsC.WatchListener(listenerName, func(update xdsclient.ListenerUpdate, err error) {
+	cancelWatch := s.xdsC.WatchListener(name, func(update xdsclient.ListenerUpdate, err error) {
 		s.handleListenerUpdate(listenerUpdate{
 			lw:         lw,
-			name:       listenerName,
+			name:       name,
 			lds:        update,
 			err:        err,
 			goodUpdate: goodUpdate,
 		})
 	})
-	s.logger.Infof("Watch started on resource name %v", listenerName)
+	s.logger.Infof("Watch started on resource name %v", name)
 	lw.cancelWatch = func() {
 		cancelWatch()
-		s.logger.Infof("Watch cancelled on resource name %v", listenerName)
+		s.logger.Infof("Watch cancelled on resource name %v", name)
 	}
 
 	// Block until a good LDS response is received or the server is stopped.

--- a/xds/server.go
+++ b/xds/server.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"strings"
 	"sync"
 	"time"
 
@@ -220,33 +221,36 @@ func (s *GRPCServer) newListenerWrapper(lis net.Listener) (*listenerWrapper, err
 	// or not.
 	goodUpdate := grpcsync.NewEvent()
 
-	// The resource_name in the LDS request sent by the xDS-enabled gRPC server
-	// is of the following format:
-	// "/path/to/resource?udpa.resource.listening_address=IP:Port". The
-	// `/path/to/resource` part of the name is sourced from the bootstrap config
-	// field `grpc_server_resource_name_id`. If this field is not specified in
-	// the bootstrap file, we will use a default of `grpc/server`.
-	path := "grpc/server"
-	if cfg := s.xdsC.BootstrapConfig(); cfg != nil && cfg.ServerListenerResourceNameTemplate != "" {
-		path = cfg.ServerListenerResourceNameTemplate
+	// The server listener resource name template from the bootstrap
+	// configuration contains a template for the name of the Listener resource
+	// to subscribe to for a gRPC server. If the token `%s` is present in the
+	// string, it will be replaced with the server's listening "IP:port" (e.g.,
+	// "0.0.0.0:8080", "[::]:8080"). The absence of a template will be treated
+	// as an error since we do not have any default value for this.
+	cfg := s.xdsC.BootstrapConfig()
+	if cfg == nil || cfg.ServerListenerResourceNameTemplate == "" {
+		return nil, errors.New("missing server_listener_resource_name_template in the bootstrap configuration")
 	}
-	name := fmt.Sprintf("%s?udpa.resource.listening_address=%s", path, lis.Addr().String())
+	listenerName := cfg.ServerListenerResourceNameTemplate
+	if strings.Contains(cfg.ServerListenerResourceNameTemplate, "%s") {
+		listenerName = fmt.Sprintf(cfg.ServerListenerResourceNameTemplate, lis.Addr().String())
+	}
 
 	// Register an LDS watch using our xdsClient, and specify the listening
 	// address as the resource name.
-	cancelWatch := s.xdsC.WatchListener(name, func(update xdsclient.ListenerUpdate, err error) {
+	cancelWatch := s.xdsC.WatchListener(listenerName, func(update xdsclient.ListenerUpdate, err error) {
 		s.handleListenerUpdate(listenerUpdate{
 			lw:         lw,
-			name:       name,
+			name:       listenerName,
 			lds:        update,
 			err:        err,
 			goodUpdate: goodUpdate,
 		})
 	})
-	s.logger.Infof("Watch started on resource name %v", name)
+	s.logger.Infof("Watch started on resource name %v", listenerName)
 	lw.cancelWatch = func() {
 		cancelWatch()
-		s.logger.Infof("Watch cancelled on resource name %v", name)
+		s.logger.Infof("Watch cancelled on resource name %v", listenerName)
 	}
 
 	// Block until a good LDS response is received or the server is stopped.
@@ -287,6 +291,35 @@ func (s *GRPCServer) handleListenerUpdate(update listenerUpdate) {
 		return
 	}
 	s.logger.Infof("Received update for resource %q: %+v", update.name, update.lds.String())
+
+	// Make sure that the socket address on the received Listener resource
+	// matches the address of the net.Listener passed to us by the user. This
+	// check is done here instead of at the xdsClient layer because of the
+	// following couple of reasons:
+	// - xdsClient cannot know the listening address of every listener in the
+	//   system, and hence cannot perform this check.
+	// - this is a very context-dependent check and only the server has the
+	//   appropriate context to perform this check.
+	//
+	// What this means is that the xdsClient has ACKed a resource which is going
+	// to push the server into a "not serving" state. This is not ideal, but
+	// this is what we have decided to do. See gRPC A36 for more details.
+	// TODO(easwars): Switch to "not serving" if the host:port does not match.
+	lisAddr := update.lw.Listener.Addr().String()
+	addr, port, err := net.SplitHostPort(lisAddr)
+	if err != nil {
+		s.logger.Warningf("Local listener address %q failed to parse as IP:port: %v", lisAddr, err)
+		return
+	}
+	ilc := update.lds.InboundListenerCfg
+	if ilc == nil {
+		s.logger.Warningf("Missing host:port in Listener updates")
+		return
+	}
+	if ilc.Address != addr || ilc.Port != port {
+		s.logger.Warningf("Received host:port (%s:%d) in Listener update does not match local listening address: %s", ilc.Address, ilc.Port, lisAddr)
+		return
+	}
 
 	if err := s.handleSecurityConfig(update.lds.SecurityCfg, update.lw); err != nil {
 		s.logger.Warningf("Invalid security config update: %v", err)

--- a/xds/server_test.go
+++ b/xds/server_test.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"net"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -42,7 +43,7 @@ import (
 const (
 	defaultTestTimeout                     = 5 * time.Second
 	defaultTestShortTimeout                = 10 * time.Millisecond
-	testServerListenerResourceNameTemplate = "/path/to/resource/%s"
+	testServerListenerResourceNameTemplate = "/path/to/resource/%s/%s"
 )
 
 type s struct {
@@ -345,7 +346,7 @@ func (s) TestServeSuccess(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error when waiting for a ListenerWatch: %v", err)
 	}
-	wantName := fmt.Sprintf(testServerListenerResourceNameTemplate, lis.Addr().String())
+	wantName := strings.ReplaceAll(testServerListenerResourceNameTemplate, "%s", lis.Addr().String())
 	if name != wantName {
 		t.Fatalf("LDS watch registered for name %q, want %q", name, wantName)
 	}
@@ -432,7 +433,7 @@ func (s) TestServeWithStop(t *testing.T) {
 		server.Stop()
 		t.Fatalf("error when waiting for a ListenerWatch: %v", err)
 	}
-	wantName := fmt.Sprintf(testServerListenerResourceNameTemplate, lis.Addr().String())
+	wantName := strings.ReplaceAll(testServerListenerResourceNameTemplate, "%s", lis.Addr().String())
 	if name != wantName {
 		server.Stop()
 		t.Fatalf("LDS watch registered for name %q, wantPrefix %q", name, wantName)
@@ -629,7 +630,7 @@ func (s) TestHandleListenerUpdate_NoXDSCreds(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error when waiting for a ListenerWatch: %v", err)
 	}
-	wantName := fmt.Sprintf(testServerListenerResourceNameTemplate, lis.Addr().String())
+	wantName := strings.ReplaceAll(testServerListenerResourceNameTemplate, "%s", lis.Addr().String())
 	if name != wantName {
 		t.Fatalf("LDS watch registered for name %q, want %q", name, wantName)
 	}
@@ -705,7 +706,7 @@ func (s) TestHandleListenerUpdate_ErrorUpdate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error when waiting for a ListenerWatch: %v", err)
 	}
-	wantName := fmt.Sprintf(testServerListenerResourceNameTemplate, lis.Addr().String())
+	wantName := strings.ReplaceAll(testServerListenerResourceNameTemplate, "%s", lis.Addr().String())
 	if name != wantName {
 		t.Fatalf("LDS watch registered for name %q, want %q", name, wantName)
 	}
@@ -762,7 +763,7 @@ func (s) TestHandleListenerUpdate_ClosedListener(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error when waiting for a ListenerWatch: %v", err)
 	}
-	wantName := fmt.Sprintf(testServerListenerResourceNameTemplate, lis.Addr().String())
+	wantName := strings.ReplaceAll(testServerListenerResourceNameTemplate, "%s", lis.Addr().String())
 	if name != wantName {
 		t.Fatalf("LDS watch registered for name %q, want %q", name, wantName)
 	}

--- a/xds/server_test.go
+++ b/xds/server_test.go
@@ -228,11 +228,11 @@ func setupOverrides() (*fakeGRPCServer, *testutils.Channel, *testutils.Channel, 
 	newXDSClient = func() (xdsClientInterface, error) {
 		c := fakeclient.NewClient()
 		c.SetBootstrapConfig(&bootstrap.Config{
-			BalancerName:         "dummyBalancer",
-			Creds:                grpc.WithTransportCredentials(insecure.NewCredentials()),
-			NodeProto:            xdstestutils.EmptyNodeProtoV3,
-			ServerResourceNameID: testServerResourceNameID,
-			CertProviderConfigs:  certProviderConfigs,
+			BalancerName:                       "dummyBalancer",
+			Creds:                              grpc.WithTransportCredentials(insecure.NewCredentials()),
+			NodeProto:                          xdstestutils.EmptyNodeProtoV3,
+			ServerListenerResourceNameTemplate: testServerResourceNameID,
+			CertProviderConfigs:                certProviderConfigs,
 		})
 		clientCh.Send(c)
 		return c, nil
@@ -267,10 +267,10 @@ func setupOverridesForXDSCreds(includeCertProviderCfg bool) (*testutils.Channel,
 	newXDSClient = func() (xdsClientInterface, error) {
 		c := fakeclient.NewClient()
 		bc := &bootstrap.Config{
-			BalancerName:         "dummyBalancer",
-			Creds:                grpc.WithTransportCredentials(insecure.NewCredentials()),
-			NodeProto:            xdstestutils.EmptyNodeProtoV3,
-			ServerResourceNameID: testServerResourceNameID,
+			BalancerName:                       "dummyBalancer",
+			Creds:                              grpc.WithTransportCredentials(insecure.NewCredentials()),
+			NodeProto:                          xdstestutils.EmptyNodeProtoV3,
+			ServerListenerResourceNameTemplate: testServerResourceNameID,
 		}
 		if includeCertProviderCfg {
 			bc.CertProviderConfigs = certProviderConfigs
@@ -337,7 +337,7 @@ func (s) TestServeSuccess(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error when waiting for a ListenerWatch: %v", err)
 	}
-	wantName := fmt.Sprintf("%s?udpa.resource.listening_address=%s", client.BootstrapConfig().ServerResourceNameID, lis.Addr().String())
+	wantName := fmt.Sprintf("%s?udpa.resource.listening_address=%s", client.BootstrapConfig().ServerListenerResourceNameTemplate, lis.Addr().String())
 	if name != wantName {
 		t.Fatalf("LDS watch registered for name %q, want %q", name, wantName)
 	}
@@ -399,7 +399,7 @@ func (s) TestServeWithStop(t *testing.T) {
 		server.Stop()
 		t.Fatalf("error when waiting for a ListenerWatch: %v", err)
 	}
-	wantName := fmt.Sprintf("%s?udpa.resource.listening_address=%s", client.BootstrapConfig().ServerResourceNameID, lis.Addr().String())
+	wantName := fmt.Sprintf("%s?udpa.resource.listening_address=%s", client.BootstrapConfig().ServerListenerResourceNameTemplate, lis.Addr().String())
 	if name != wantName {
 		server.Stop()
 		t.Fatalf("LDS watch registered for name %q, wantPrefix %q", name, wantName)
@@ -556,7 +556,7 @@ func (s) TestHandleListenerUpdate_NoXDSCreds(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error when waiting for a ListenerWatch: %v", err)
 	}
-	wantName := fmt.Sprintf("%s?udpa.resource.listening_address=%s", client.BootstrapConfig().ServerResourceNameID, lis.Addr().String())
+	wantName := fmt.Sprintf("%s?udpa.resource.listening_address=%s", client.BootstrapConfig().ServerListenerResourceNameTemplate, lis.Addr().String())
 	if name != wantName {
 		t.Fatalf("LDS watch registered for name %q, want %q", name, wantName)
 	}
@@ -627,7 +627,7 @@ func (s) TestHandleListenerUpdate_ErrorUpdate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error when waiting for a ListenerWatch: %v", err)
 	}
-	wantName := fmt.Sprintf("%s?udpa.resource.listening_address=%s", client.BootstrapConfig().ServerResourceNameID, lis.Addr().String())
+	wantName := fmt.Sprintf("%s?udpa.resource.listening_address=%s", client.BootstrapConfig().ServerListenerResourceNameTemplate, lis.Addr().String())
 	if name != wantName {
 		t.Fatalf("LDS watch registered for name %q, want %q", name, wantName)
 	}
@@ -691,7 +691,7 @@ func (s) TestHandleListenerUpdate_ClosedListener(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error when waiting for a ListenerWatch: %v", err)
 	}
-	wantName := fmt.Sprintf("%s?udpa.resource.listening_address=%s", client.BootstrapConfig().ServerResourceNameID, lis.Addr().String())
+	wantName := fmt.Sprintf("%s?udpa.resource.listening_address=%s", client.BootstrapConfig().ServerListenerResourceNameTemplate, lis.Addr().String())
 	if name != wantName {
 		t.Fatalf("LDS watch registered for name %q, want %q", name, wantName)
 	}

--- a/xds/server_test.go
+++ b/xds/server_test.go
@@ -40,9 +40,9 @@ import (
 )
 
 const (
-	defaultTestTimeout       = 5 * time.Second
-	defaultTestShortTimeout  = 10 * time.Millisecond
-	testServerResourceNameID = "/path/to/resource"
+	defaultTestTimeout                     = 5 * time.Second
+	defaultTestShortTimeout                = 10 * time.Millisecond
+	testServerListenerResourceNameTemplate = "/path/to/resource/%s"
 )
 
 type s struct {
@@ -88,6 +88,14 @@ func newFakeGRPCServer() *fakeGRPCServer {
 		stopCh:            testutils.NewChannel(),
 		gracefulStopCh:    testutils.NewChannel(),
 	}
+}
+
+func splitHostPort(hostport string) (string, string) {
+	addr, port, err := net.SplitHostPort(hostport)
+	if err != nil {
+		panic(fmt.Sprintf("listener address %q does not parse: %v", hostport, err))
+	}
+	return addr, port
 }
 
 func (s) TestNewServer(t *testing.T) {
@@ -231,7 +239,7 @@ func setupOverrides() (*fakeGRPCServer, *testutils.Channel, *testutils.Channel, 
 			BalancerName:                       "dummyBalancer",
 			Creds:                              grpc.WithTransportCredentials(insecure.NewCredentials()),
 			NodeProto:                          xdstestutils.EmptyNodeProtoV3,
-			ServerListenerResourceNameTemplate: testServerResourceNameID,
+			ServerListenerResourceNameTemplate: testServerListenerResourceNameTemplate,
 			CertProviderConfigs:                certProviderConfigs,
 		})
 		clientCh.Send(c)
@@ -270,7 +278,7 @@ func setupOverridesForXDSCreds(includeCertProviderCfg bool) (*testutils.Channel,
 			BalancerName:                       "dummyBalancer",
 			Creds:                              grpc.WithTransportCredentials(insecure.NewCredentials()),
 			NodeProto:                          xdstestutils.EmptyNodeProtoV3,
-			ServerListenerResourceNameTemplate: testServerResourceNameID,
+			ServerListenerResourceNameTemplate: testServerListenerResourceNameTemplate,
 		}
 		if includeCertProviderCfg {
 			bc.CertProviderConfigs = certProviderConfigs
@@ -337,7 +345,7 @@ func (s) TestServeSuccess(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error when waiting for a ListenerWatch: %v", err)
 	}
-	wantName := fmt.Sprintf("%s?udpa.resource.listening_address=%s", client.BootstrapConfig().ServerListenerResourceNameTemplate, lis.Addr().String())
+	wantName := fmt.Sprintf(testServerListenerResourceNameTemplate, lis.Addr().String())
 	if name != wantName {
 		t.Fatalf("LDS watch registered for name %q, want %q", name, wantName)
 	}
@@ -353,9 +361,34 @@ func (s) TestServeSuccess(t *testing.T) {
 
 	// Push a good LDS response, and wait for Serve() to be invoked on the
 	// underlying grpc.Server.
-	client.InvokeWatchListenerCallback(xdsclient.ListenerUpdate{RouteConfigName: "routeconfig"}, nil)
+	addr, port := splitHostPort(lis.Addr().String())
+	client.InvokeWatchListenerCallback(xdsclient.ListenerUpdate{
+		RouteConfigName: "routeconfig",
+		InboundListenerCfg: &xdsclient.InboundListenerConfig{
+			Address: addr,
+			Port:    port,
+		},
+	}, nil)
 	if _, err := fs.serveCh.Receive(ctx); err != nil {
 		t.Fatalf("error when waiting for Serve() to be invoked on the grpc.Server")
+	}
+
+	// Push an update to the registered listener watch callback with a Listener
+	// resource whose host:port does not match the actual listening address and
+	// port. Serve() should not return and should continue to use the old state.
+	//
+	// This will change once we add start tracking serving state.
+	client.InvokeWatchListenerCallback(xdsclient.ListenerUpdate{
+		RouteConfigName: "routeconfig",
+		InboundListenerCfg: &xdsclient.InboundListenerConfig{
+			Address: "10.20.30.40",
+			Port:    "666",
+		},
+	}, nil)
+	sCtx, sCancel = context.WithTimeout(context.Background(), defaultTestShortTimeout)
+	defer sCancel()
+	if _, err := serveDone.Receive(sCtx); err != context.DeadlineExceeded {
+		t.Fatal("Serve() returned after a bad LDS response")
 	}
 }
 
@@ -399,7 +432,7 @@ func (s) TestServeWithStop(t *testing.T) {
 		server.Stop()
 		t.Fatalf("error when waiting for a ListenerWatch: %v", err)
 	}
-	wantName := fmt.Sprintf("%s?udpa.resource.listening_address=%s", client.BootstrapConfig().ServerListenerResourceNameTemplate, lis.Addr().String())
+	wantName := fmt.Sprintf(testServerListenerResourceNameTemplate, lis.Addr().String())
 	if name != wantName {
 		server.Stop()
 		t.Fatalf("LDS watch registered for name %q, wantPrefix %q", name, wantName)
@@ -448,39 +481,79 @@ func (s) TestServeBootstrapFailure(t *testing.T) {
 	}
 }
 
-// TestServeBootstrapWithMissingCertProviders tests the case where the bootstrap
-// config does not contain certificate provider configuration, but xdsCreds are
-// passed to the server. Verifies that the call to Serve() fails.
-func (s) TestServeBootstrapWithMissingCertProviders(t *testing.T) {
-	_, _, cleanup := setupOverridesForXDSCreds(false)
-	defer cleanup()
-
-	xdsCreds, err := xds.NewServerCredentials(xds.ServerOptions{FallbackCreds: insecure.NewCredentials()})
-	if err != nil {
-		t.Fatalf("failed to create xds server credentials: %v", err)
+// TestServeBootstrapConfigInvalid tests the cases where the bootstrap config
+// does not contain expected fields. Verifies that the call to Serve() fails.
+func (s) TestServeBootstrapConfigInvalid(t *testing.T) {
+	tests := []struct {
+		desc            string
+		bootstrapConfig *bootstrap.Config
+	}{
+		{
+			desc:            "bootstrap config is missing",
+			bootstrapConfig: nil,
+		},
+		{
+			desc: "certificate provider config is missing",
+			bootstrapConfig: &bootstrap.Config{
+				BalancerName:                       "dummyBalancer",
+				Creds:                              grpc.WithTransportCredentials(insecure.NewCredentials()),
+				NodeProto:                          xdstestutils.EmptyNodeProtoV3,
+				ServerListenerResourceNameTemplate: testServerListenerResourceNameTemplate,
+			},
+		},
+		{
+			desc: "server_listener_resource_name_template is missing",
+			bootstrapConfig: &bootstrap.Config{
+				BalancerName:        "dummyBalancer",
+				Creds:               grpc.WithTransportCredentials(insecure.NewCredentials()),
+				NodeProto:           xdstestutils.EmptyNodeProtoV3,
+				CertProviderConfigs: certProviderConfigs,
+			},
+		},
 	}
-	server := NewGRPCServer(grpc.Creds(xdsCreds))
-	defer server.Stop()
 
-	lis, err := xdstestutils.LocalTCPListener()
-	if err != nil {
-		t.Fatalf("xdstestutils.LocalTCPListener() failed: %v", err)
-	}
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			// Override the xdsClient creation with one that returns a fake
+			// xdsClient with the specified bootstrap configuration.
+			clientCh := testutils.NewChannel()
+			origNewXDSClient := newXDSClient
+			newXDSClient = func() (xdsClientInterface, error) {
+				c := fakeclient.NewClient()
+				c.SetBootstrapConfig(test.bootstrapConfig)
+				clientCh.Send(c)
+				return c, nil
+			}
+			defer func() { newXDSClient = origNewXDSClient }()
 
-	serveDone := testutils.NewChannel()
-	go func() {
-		err := server.Serve(lis)
-		serveDone.Send(err)
-	}()
+			xdsCreds, err := xds.NewServerCredentials(xds.ServerOptions{FallbackCreds: insecure.NewCredentials()})
+			if err != nil {
+				t.Fatalf("failed to create xds server credentials: %v", err)
+			}
+			server := NewGRPCServer(grpc.Creds(xdsCreds))
+			defer server.Stop()
 
-	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
-	defer cancel()
-	v, err := serveDone.Receive(ctx)
-	if err != nil {
-		t.Fatalf("error when waiting for Serve() to exit: %v", err)
-	}
-	if err, ok := v.(error); !ok || err == nil {
-		t.Fatal("Serve() did not exit with error")
+			lis, err := xdstestutils.LocalTCPListener()
+			if err != nil {
+				t.Fatalf("xdstestutils.LocalTCPListener() failed: %v", err)
+			}
+
+			serveDone := testutils.NewChannel()
+			go func() {
+				err := server.Serve(lis)
+				serveDone.Send(err)
+			}()
+
+			ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+			defer cancel()
+			v, err := serveDone.Receive(ctx)
+			if err != nil {
+				t.Fatalf("error when waiting for Serve() to exit: %v", err)
+			}
+			if err, ok := v.(error); !ok || err == nil {
+				t.Fatal("Serve() did not exit with error")
+			}
+		})
 	}
 }
 
@@ -556,7 +629,7 @@ func (s) TestHandleListenerUpdate_NoXDSCreds(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error when waiting for a ListenerWatch: %v", err)
 	}
-	wantName := fmt.Sprintf("%s?udpa.resource.listening_address=%s", client.BootstrapConfig().ServerListenerResourceNameTemplate, lis.Addr().String())
+	wantName := fmt.Sprintf(testServerListenerResourceNameTemplate, lis.Addr().String())
 	if name != wantName {
 		t.Fatalf("LDS watch registered for name %q, want %q", name, wantName)
 	}
@@ -564,12 +637,17 @@ func (s) TestHandleListenerUpdate_NoXDSCreds(t *testing.T) {
 	// Push a good LDS response with security config, and wait for Serve() to be
 	// invoked on the underlying grpc.Server. Also make sure that certificate
 	// providers are not created.
+	addr, port := splitHostPort(lis.Addr().String())
 	client.InvokeWatchListenerCallback(xdsclient.ListenerUpdate{
 		RouteConfigName: "routeconfig",
 		SecurityCfg: &xdsclient.SecurityConfig{
 			RootInstanceName:     "default1",
 			IdentityInstanceName: "default2",
 			RequireClientCert:    true,
+		},
+		InboundListenerCfg: &xdsclient.InboundListenerConfig{
+			Address: addr,
+			Port:    port,
 		},
 	}, nil)
 	if _, err := fs.serveCh.Receive(ctx); err != nil {
@@ -627,21 +705,14 @@ func (s) TestHandleListenerUpdate_ErrorUpdate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error when waiting for a ListenerWatch: %v", err)
 	}
-	wantName := fmt.Sprintf("%s?udpa.resource.listening_address=%s", client.BootstrapConfig().ServerListenerResourceNameTemplate, lis.Addr().String())
+	wantName := fmt.Sprintf(testServerListenerResourceNameTemplate, lis.Addr().String())
 	if name != wantName {
 		t.Fatalf("LDS watch registered for name %q, want %q", name, wantName)
 	}
 
 	// Push an error to the registered listener watch callback and make sure
 	// that Serve does not return.
-	client.InvokeWatchListenerCallback(xdsclient.ListenerUpdate{
-		RouteConfigName: "routeconfig",
-		SecurityCfg: &xdsclient.SecurityConfig{
-			RootInstanceName:     "default1",
-			IdentityInstanceName: "default2",
-			RequireClientCert:    true,
-		},
-	}, errors.New("LDS error"))
+	client.InvokeWatchListenerCallback(xdsclient.ListenerUpdate{}, errors.New("LDS error"))
 	sCtx, sCancel := context.WithTimeout(context.Background(), defaultTestShortTimeout)
 	defer sCancel()
 	if _, err := serveDone.Receive(sCtx); err != context.DeadlineExceeded {
@@ -691,7 +762,7 @@ func (s) TestHandleListenerUpdate_ClosedListener(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error when waiting for a ListenerWatch: %v", err)
 	}
-	wantName := fmt.Sprintf("%s?udpa.resource.listening_address=%s", client.BootstrapConfig().ServerListenerResourceNameTemplate, lis.Addr().String())
+	wantName := fmt.Sprintf(testServerListenerResourceNameTemplate, lis.Addr().String())
 	if name != wantName {
 		t.Fatalf("LDS watch registered for name %q, want %q", name, wantName)
 	}
@@ -699,9 +770,14 @@ func (s) TestHandleListenerUpdate_ClosedListener(t *testing.T) {
 	// Push a good update to the registered listener watch callback. This will
 	// unblock the xds-enabled server which is waiting for a good listener
 	// update before calling Serve() on the underlying grpc.Server.
+	addr, port := splitHostPort(lis.Addr().String())
 	client.InvokeWatchListenerCallback(xdsclient.ListenerUpdate{
 		RouteConfigName: "routeconfig",
 		SecurityCfg:     &xdsclient.SecurityConfig{IdentityInstanceName: "default2"},
+		InboundListenerCfg: &xdsclient.InboundListenerConfig{
+			Address: addr,
+			Port:    port,
+		},
 	}, nil)
 	if _, err := providerCh.Receive(ctx); err != nil {
 		t.Fatal("error when waiting for certificate provider to be created")
@@ -723,6 +799,10 @@ func (s) TestHandleListenerUpdate_ClosedListener(t *testing.T) {
 	client.InvokeWatchListenerCallback(xdsclient.ListenerUpdate{
 		RouteConfigName: "routeconfig",
 		SecurityCfg:     &xdsclient.SecurityConfig{IdentityInstanceName: "default1"},
+		InboundListenerCfg: &xdsclient.InboundListenerConfig{
+			Address: addr,
+			Port:    port,
+		},
 	}, nil)
 	sCtx, sCancel := context.WithTimeout(context.Background(), defaultTestShortTimeout)
 	defer sCancel()


### PR DESCRIPTION
Summary of changes
- Update `bootstrap` package to process `server_listener_resource_name_template`
- Update `client` package to do the following:
  - Do not match socket address in `Listener` resource with address from resource `name`
  - Populate the `host` and `port` from `sockaddr` in `ListenerUpdate` sent to upper layers
- Update `xdsServer` to do the following:
  - Use the `server_listener_resource_name_template` field and replace token (`%s`) if present when generating the `Listener` resource name
  - Make sure the `host:port` received in the `ListenerUpdate` matches the actual listening address
- Update e2e tests