### PR TITLE
Added server side check for POST method

### DIFF
--- a/internal/transport/http2_server.go
+++ b/internal/transport/http2_server.go
@@ -26,6 +26,7 @@ import (
 	"io"
 	"math"
 	"net"
+	"net/http"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -400,6 +401,20 @@ func (t *http2Server) operateHeaders(frame *http2.MetaHeadersFrame, handle func(
 		}
 		s.cancel()
 		return true
+	}
+	if state.data.httpMethod != http.MethodPost {
+		t.mu.Unlock()
+		if logger.V(logLevel) {
+			logger.Warningf("transport: http2Server.operateHeaders parsed a :method field: %v which should be POST", state.data.httpMethod)
+		}
+		t.controlBuf.put(&cleanupStream{
+			streamID: streamID,
+			rst:      true,
+			rstCode:  http2.ErrCodeProtocol,
+			onWrite:  func() {},
+		})
+		s.cancel()
+		return false
 	}
 	t.maxStreamID = streamID
 	t.activeStreams[streamID] = s

--- a/internal/transport/http_util.go
+++ b/internal/transport/http_util.go
@@ -130,6 +130,8 @@ type parsedHeaderData struct {
 	grpcErr        error
 	httpErr        error
 	contentTypeErr string
+
+	httpMethod string
 }
 
 // decodeState configures decoding criteria and records the decoded data.
@@ -363,6 +365,8 @@ func (d *decodeState) processHeaderField(f hpack.HeaderField) {
 		}
 		d.data.statsTrace = v
 		d.addMetadata(f.Name, string(v))
+	case ":method":
+		d.data.httpMethod = f.Value
 	default:
 		if isReservedHeader(f.Name) && !isWhitelistedHeader(f.Name) {
 			break


### PR DESCRIPTION
Fixes issue https://github.com/grpc/grpc-go/issues/2881.

Added check to after HTTP/2 stream logic checks in order for the precedence of error checking to account for HTTP/2 first, as gRPC rests on top of HTTP/2.