### PR TITLE
xds: Move tests requiring API client to `tests` directory

### DIFF
--- a/xds/internal/client/client_test.go
+++ b/xds/internal/client/client_test.go
@@ -26,11 +26,10 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"google.golang.org/grpc/internal/grpcsync"
-	"google.golang.org/protobuf/testing/protocmp"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/internal/grpcsync"
 	"google.golang.org/grpc/internal/grpctest"
 	"google.golang.org/grpc/internal/testutils"
 	"google.golang.org/grpc/xds/internal/client/bootstrap"
@@ -57,20 +56,6 @@ const (
 	defaultTestWatchExpiryTimeout = 500 * time.Millisecond
 	defaultTestTimeout            = 5 * time.Second
 	defaultTestShortTimeout       = 10 * time.Millisecond // For events expected to *not* happen.
-)
-
-var (
-	cmpOpts = cmp.Options{
-		cmpopts.EquateEmpty(),
-		cmp.Comparer(func(a, b time.Time) bool { return true }),
-		cmp.Comparer(func(x, y error) bool {
-			if x == nil || y == nil {
-				return x == nil && y == nil
-			}
-			return x.Error() == y.Error()
-		}),
-		protocmp.Transform(),
-	}
 )
 
 func clientOpts(balancerName string, overrideWatchExpiryTimeout bool) (*bootstrap.Config, time.Duration) {

--- a/xds/internal/client/tests/README.md
+++ b/xds/internal/client/tests/README.md
@@ -1,0 +1,1 @@
+This package contains tests which cannot live in the `client` package because they need to import one of the API client packages (which itself has a dependency on the `client` package).

--- a/xds/internal/client/tests/loadreport_test.go
+++ b/xds/internal/client/tests/loadreport_test.go
@@ -16,7 +16,7 @@
  *
  */
 
-package client_test
+package tests_test
 
 import (
 	"context"
@@ -31,7 +31,6 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
-	"google.golang.org/grpc/internal/grpctest"
 	"google.golang.org/grpc/status"
 	"google.golang.org/grpc/xds/internal/client"
 	"google.golang.org/grpc/xds/internal/client/bootstrap"
@@ -43,19 +42,10 @@ import (
 )
 
 const (
-	defaultTestTimeout      = 5 * time.Second
-	defaultTestShortTimeout = 10 * time.Millisecond // For events expected to *not* happen.
-
+	defaultTestTimeout              = 5 * time.Second
+	defaultTestShortTimeout         = 10 * time.Millisecond // For events expected to *not* happen.
 	defaultClientWatchExpiryTimeout = 15 * time.Second
 )
-
-type s struct {
-	grpctest.Tester
-}
-
-func Test(t *testing.T) {
-	grpctest.RunSubTests(t, s{})
-}
 
 func (s) TestLRSClient(t *testing.T) {
 	fs, sCleanup, err := fakeserver.StartServer()


### PR DESCRIPTION
This is required for this week's import.