### PR TITLE
Added server side check for POST method

### DIFF
--- a/internal/transport/http2_server.go
+++ b/internal/transport/http2_server.go
@@ -26,6 +26,7 @@ import (
 	"io"
 	"math"
 	"net"
+	"net/http"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -400,6 +401,20 @@ func (t *http2Server) operateHeaders(frame *http2.MetaHeadersFrame, handle func(
 		}
 		s.cancel()
 		return true
+	}
+	if state.data.httpMethod != http.MethodPost {
+		t.mu.Unlock()
+		if logger.V(logLevel) {
+			logger.Warningf("transport: http2Server.operateHeaders parsed a :method field: %v which should be POST", state.data.httpMethod)
+		}
+		t.controlBuf.put(&cleanupStream{
+			streamID: streamID,
+			rst:      true,
+			rstCode:  http2.ErrCodeProtocol,
+			onWrite:  func() {},
+		})
+		s.cancel()
+		return false
 	}
 	t.maxStreamID = streamID
 	t.activeStreams[streamID] = s

--- a/internal/transport/http2_server.go
+++ b/internal/transport/http2_server.go
@@ -402,6 +402,7 @@ func (t *http2Server) operateHeaders(frame *http2.MetaHeadersFrame, handle func(
 		s.cancel()
 		return true
 	}
+	t.maxStreamID = streamID
 	if state.data.httpMethod != http.MethodPost {
 		t.mu.Unlock()
 		if logger.V(logLevel) {
@@ -416,7 +417,6 @@ func (t *http2Server) operateHeaders(frame *http2.MetaHeadersFrame, handle func(
 		s.cancel()
 		return false
 	}
-	t.maxStreamID = streamID
 	t.activeStreams[streamID] = s
 	if len(t.activeStreams) == 1 {
 		t.idle = time.Time{}

--- a/internal/transport/http_util.go
+++ b/internal/transport/http_util.go
@@ -130,6 +130,8 @@ type parsedHeaderData struct {
 	grpcErr        error
 	httpErr        error
 	contentTypeErr string
+
+	httpMethod string
 }
 
 // decodeState configures decoding criteria and records the decoded data.
@@ -363,6 +365,8 @@ func (d *decodeState) processHeaderField(f hpack.HeaderField) {
 		}
 		d.data.statsTrace = v
 		d.addMetadata(f.Name, string(v))
+	case ":method":
+		d.data.httpMethod = f.Value
 	default:
 		if isReservedHeader(f.Name) && !isWhitelistedHeader(f.Name) {
 			break

--- a/internal/transport/transport_test.go
+++ b/internal/transport/transport_test.go
@@ -71,7 +71,7 @@ var (
 	expectedRequestLarge           = make([]byte, initialWindowSize*2)
 	expectedResponseLarge          = make([]byte, initialWindowSize*2)
 	expectedInvalidHeaderField     = "invalid/content-type"
-	expectedInvalidHttpMethodField = "PUT"
+	expectedInvalidHTTPMethodField = "PUT"
 )
 
 func init() {
@@ -98,7 +98,7 @@ const (
 	invalidHeaderField
 	delayRead
 	pingpong
-	invalidHttpMethod
+	invalidHTTPMethod
 )
 
 func (h *testStreamHandler) handleStreamAndNotify(s *Stream) {
@@ -211,9 +211,9 @@ func (h *testStreamHandler) handleStreamInvalidHeaderField(t *testing.T, s *Stre
 	})
 }
 
-func (h *testStreamHandler) handleStreamInvalidHttpMethod(t *testing.T, s *Stream) {
+func (h *testStreamHandler) handleStreamInvalidHTTPMethod(t *testing.T, s *Stream) {
 	headerFields := []hpack.HeaderField{}
-	headerFields = append(headerFields, hpack.HeaderField{Name: ":method", Value: expectedInvalidHttpMethodField})
+	headerFields = append(headerFields, hpack.HeaderField{Name: ":method", Value: expectedInvalidHTTPMethodField})
 	h.t.controlBuf.put(&headerFrame{
 		streamID:  s.id,
 		hf:        headerFields,
@@ -378,9 +378,9 @@ func (s *server) start(t *testing.T, port int, serverConfig *ServerConfig, ht hT
 			}, func(ctx context.Context, method string) context.Context {
 				return ctx
 			})
-		case invalidHttpMethod:
+		case invalidHTTPMethod:
 			go transport.HandleStreams(func(s *Stream) {
-				go h.handleStreamInvalidHttpMethod(t, s)
+				go h.handleStreamInvalidHTTPMethod(t, s)
 			}, func(ctx context.Context, method string) context.Context {
 				return ctx
 			})
@@ -1753,8 +1753,8 @@ func runPingPongTest(t *testing.T, msgSize int) {
 	}
 }
 
-func (s) TestInvalidHttpMethod(t *testing.T) {
-	server, ct, cancel := setUp(t, 0, math.MaxUint32, invalidHttpMethod)
+func (s) TestInvalidHTTPMethod(t *testing.T) {
+	server, ct, cancel := setUp(t, 0, math.MaxUint32, invalidHTTPMethod)
 	defer cancel()
 	callHdr := &CallHdr{
 		Host:   "localhost",

--- a/internal/transport/transport_test.go
+++ b/internal/transport/transport_test.go
@@ -66,11 +66,11 @@ type server struct {
 }
 
 var (
-	expectedRequest            = []byte("ping")
-	expectedResponse           = []byte("pong")
-	expectedRequestLarge       = make([]byte, initialWindowSize*2)
-	expectedResponseLarge      = make([]byte, initialWindowSize*2)
-	expectedInvalidHeaderField = "invalid/content-type"
+	expectedRequest                = []byte("ping")
+	expectedResponse               = []byte("pong")
+	expectedRequestLarge           = make([]byte, initialWindowSize*2)
+	expectedResponseLarge          = make([]byte, initialWindowSize*2)
+	expectedInvalidHeaderField     = "invalid/content-type"
 	expectedInvalidHttpMethodField = "PUT"
 )
 
@@ -215,8 +215,8 @@ func (h *testStreamHandler) handleStreamInvalidHttpMethod(t *testing.T, s *Strea
 	headerFields := []hpack.HeaderField{}
 	headerFields = append(headerFields, hpack.HeaderField{Name: ":method", Value: expectedInvalidHttpMethodField})
 	h.t.controlBuf.put(&headerFrame{
-		streamID: s.id,
-		hf: headerFields,
+		streamID:  s.id,
+		hf:        headerFields,
 		endStream: false,
 	})
 }
@@ -1757,7 +1757,7 @@ func (s) TestInvalidHttpMethod(t *testing.T) {
 	server, ct, cancel := setUp(t, 0, math.MaxUint32, invalidHttpMethod)
 	defer cancel()
 	callHdr := &CallHdr{
-		Host: "localhost",
+		Host:   "localhost",
 		Method: "foo",
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)


### PR DESCRIPTION
Fixes issue #2881.

Added check to after HTTP/2 stream logic checks in order for the precedence of error checking to account for HTTP/2 first, as gRPC rests on top of HTTP/2.