### PR TITLE
Added check for POST method in http2_server

### DIFF
--- a/internal/transport/http_util.go
+++ b/internal/transport/http_util.go
@@ -111,6 +111,7 @@ type parsedHeaderData struct {
 	timeoutSet bool
 	timeout    time.Duration
 	method     string
+	httpMethod string
 	// key-value metadata map from the peer.
 	mdata          map[string][]string
 	statsTags      []byte
@@ -130,8 +131,6 @@ type parsedHeaderData struct {
 	grpcErr        error
 	httpErr        error
 	contentTypeErr string
-
-	httpMethod string
 }
 
 // decodeState configures decoding criteria and records the decoded data.

--- a/internal/transport/http_util.go
+++ b/internal/transport/http_util.go
@@ -130,6 +130,8 @@ type parsedHeaderData struct {
 	grpcErr        error
 	httpErr        error
 	contentTypeErr string
+
+	httpMethod string
 }
 
 // decodeState configures decoding criteria and records the decoded data.
@@ -363,6 +365,8 @@ func (d *decodeState) processHeaderField(f hpack.HeaderField) {
 		}
 		d.data.statsTrace = v
 		d.addMetadata(f.Name, string(v))
+	case ":method":
+		d.data.httpMethod = f.Value
 	default:
 		if isReservedHeader(f.Name) && !isWhitelistedHeader(f.Name) {
 			break


### PR DESCRIPTION
Fixes issue #2881.

Added check to after HTTP/2 stream logic checks in order for the precedence of error checking to account for HTTP/2 first, as gRPC rests on top of HTTP/2.