### PR TITLE
xds: add env var protection for client-side security

### DIFF
--- a/xds/internal/client/xds.go
+++ b/xds/internal/client/xds.go
@@ -567,10 +567,17 @@ func validateCluster(cluster *v3clusterpb.Cluster) (ClusterUpdate, error) {
 		return emptyUpdate, fmt.Errorf("unexpected lbPolicy %v in response: %+v", cluster.GetLbPolicy(), cluster)
 	}
 
-	sc, err := securityConfigFromCluster(cluster)
-	if err != nil {
-		return emptyUpdate, err
+	// Process security configuration received from the control plane iff the
+	// corresponding environment variable is set.
+	var sc *SecurityConfig
+	if env.ClientSideSecuritySupport {
+		var err error
+		sc, err = securityConfigFromCluster(cluster)
+		if err != nil {
+			return emptyUpdate, err
+		}
 	}
+
 	return ClusterUpdate{
 		ServiceName: cluster.GetEdsClusterConfig().GetServiceName(),
 		EnableLRS:   cluster.GetLrsServer().GetSelf() != nil,

--- a/xds/internal/client/xds.go
+++ b/xds/internal/client/xds.go
@@ -572,8 +572,7 @@ func validateCluster(cluster *v3clusterpb.Cluster) (ClusterUpdate, error) {
 	var sc *SecurityConfig
 	if env.ClientSideSecuritySupport {
 		var err error
-		sc, err = securityConfigFromCluster(cluster)
-		if err != nil {
+		if sc, err = securityConfigFromCluster(cluster); err != nil {
 			return emptyUpdate, err
 		}
 	}

--- a/xds/internal/env/env.go
+++ b/xds/internal/env/env.go
@@ -37,10 +37,11 @@ const (
 	// and kept in variable BootstrapFileName.
 	//
 	// When both bootstrap FileName and FileContent are set, FileName is used.
-	BootstrapFileContentEnv   = "GRPC_XDS_BOOTSTRAP_CONFIG"
-	circuitBreakingSupportEnv = "GRPC_XDS_EXPERIMENTAL_CIRCUIT_BREAKING"
-	timeoutSupportEnv         = "GRPC_XDS_EXPERIMENTAL_ENABLE_TIMEOUT"
-	faultInjectionSupportEnv  = "GRPC_XDS_EXPERIMENTAL_FAULT_INJECTION"
+	BootstrapFileContentEnv      = "GRPC_XDS_BOOTSTRAP_CONFIG"
+	circuitBreakingSupportEnv    = "GRPC_XDS_EXPERIMENTAL_CIRCUIT_BREAKING"
+	timeoutSupportEnv            = "GRPC_XDS_EXPERIMENTAL_ENABLE_TIMEOUT"
+	faultInjectionSupportEnv     = "GRPC_XDS_EXPERIMENTAL_FAULT_INJECTION"
+	clientSideSecuritySupportEnv = "GRPC_XDS_EXPERIMENTAL_SECURITY_SUPPORT"
 )
 
 var (
@@ -67,4 +68,11 @@ var (
 	// FaultInjectionSupport is used to control both fault injection and HTTP
 	// filter support.
 	FaultInjectionSupport = strings.EqualFold(os.Getenv(faultInjectionSupportEnv), "true")
+	// ClientSideSecuritySupport is used to control processing of security
+	// configuration on the client-side.
+	//
+	// Note that there is no env var protection for the server-side because we
+	// have a brand new API on the server-side and users explicitly need to use
+	// the new API to get security integration on the server.
+	ClientSideSecuritySupport = strings.EqualFold(os.Getenv(clientSideSecuritySupportEnv), "true")
 )


### PR DESCRIPTION
We never got around to protecting client-side security configuration parsing with an env var in gRPC-Go. Better late than never.

Addresses https://github.com/grpc/grpc-go/issues/4245

#grpc-psm-security-client-side

