### PR TITLE
Added a GOAWAY frame send on client transport shutdown

### DIFF
--- a/internal/transport/controlbuf.go
+++ b/internal/transport/controlbuf.go
@@ -460,6 +460,7 @@ type loopyWriter struct {
 	draining      bool
 
 	// Side-specific handlers
+	csGoAwayHandler func(*goAway) error
 	ssGoAwayHandler func(*goAway) (bool, error)
 }
 
@@ -761,6 +762,9 @@ func (l *loopyWriter) incomingGoAwayHandler(*incomingGoAway) error {
 
 func (l *loopyWriter) goAwayHandler(g *goAway) error {
 	// Handling of outgoing GoAway is very specific to side.
+	if l.csGoAwayHandler != nil {
+		return l.csGoAwayHandler(g)
+	}
 	if l.ssGoAwayHandler != nil {
 		draining, err := l.ssGoAwayHandler(g)
 		if err != nil {

--- a/internal/transport/controlbuf.go
+++ b/internal/transport/controlbuf.go
@@ -460,7 +460,6 @@ type loopyWriter struct {
 	draining      bool
 
 	// Side-specific handlers
-	csGoAwayHandler func(*goAway) error
 	ssGoAwayHandler func(*goAway) (bool, error)
 }
 
@@ -761,10 +760,6 @@ func (l *loopyWriter) incomingGoAwayHandler(*incomingGoAway) error {
 }
 
 func (l *loopyWriter) goAwayHandler(g *goAway) error {
-	// Handling of outgoing GoAway is very specific to side.
-	if l.csGoAwayHandler != nil {
-		return l.csGoAwayHandler(g)
-	}
 	if l.ssGoAwayHandler != nil {
 		draining, err := l.ssGoAwayHandler(g)
 		if err != nil {

--- a/internal/transport/controlbuf.go
+++ b/internal/transport/controlbuf.go
@@ -760,6 +760,7 @@ func (l *loopyWriter) incomingGoAwayHandler(*incomingGoAway) error {
 }
 
 func (l *loopyWriter) goAwayHandler(g *goAway) error {
+	// Handling of outgoing GoAway is very specific to side.
 	if l.ssGoAwayHandler != nil {
 		draining, err := l.ssGoAwayHandler(g)
 		if err != nil {

--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -388,6 +388,7 @@ func newHTTP2Client(connectCtx, ctx context.Context, addr resolver.Address, opts
 	}
 	go func() {
 		t.loopy = newLoopyWriter(clientSide, t.framer, t.controlBuf, t.bdpEst)
+		t.loopy.csGoAwayHandler = t.outgoingGoAwayHandler
 		err := t.loopy.run()
 		if err != nil {
 			if logger.V(logLevel) {
@@ -838,6 +839,14 @@ func (t *http2Client) closeStream(s *Stream, err error, rst bool, rstCode http2.
 	}
 }
 
+func (t *http2Client) outgoingGoAwayHandler(g *goAway) error {
+	// Keep this as error code from goAway struct in case httpClient.Close() starts to take an HTTP/2 error.
+	if err := t.framer.fr.WriteGoAway(math.MaxUint32, g.code, g.debugData); err != nil {
+		return err
+	}
+	return nil
+}
+
 // Close kicks off the shutdown process of the transport. This should be called
 // only once on a transport. Once it is called, the transport should not be
 // accessed any more.
@@ -864,6 +873,10 @@ func (t *http2Client) Close() error {
 		t.kpDormancyCond.Signal()
 	}
 	t.mu.Unlock()
+	// The HTTP/2 spec mentions that a GOAWAY frame should be sent before a connection close. If this close() function
+	// ever starts to take in an HTTP/2 error code the peer will be able to get more information about the reason
+	// behind the connection close.
+	t.controlBuf.put(&goAway{code: http2.ErrCodeNo, debugData: []byte{}})
 	t.controlBuf.finish()
 	t.cancel()
 	err := t.conn.Close()

--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -863,13 +863,14 @@ func (t *http2Client) Close() error {
 		// should unblock it so that the goroutine eventually exits.
 		t.kpDormancyCond.Signal()
 	}
-	t.mu.Unlock()
 	// The HTTP/2 spec mentions that a GOAWAY frame should be sent before a connection close. If this close() function
 	// ever starts to take in an HTTP/2 error code the peer will be able to get more information about the reason
 	// behind the connection close.
 	if err := t.framer.fr.WriteGoAway(math.MaxUint32, http2.ErrCodeNo, []byte{}); err != nil {
+		t.mu.Unlock()
 		return err
 	}
+	t.mu.Unlock()
 	t.controlBuf.finish()
 	t.cancel()
 	err := t.conn.Close()


### PR DESCRIPTION
Fixes issue https://github.com/grpc/grpc-go/issues/460. The data of the GOAWAY frame is that of a peer attempting a graceful shutdown according to the HTTP/2 spec (ErrCodeNo, Stream ID of 2 ^ 32 - 1). Eventually, seen by Doug's comment in #4190, it is desirable to pass an error into http2_client.close(), which will end up in the GOAWAY frame, but for now any GOAWAY frame sent is better than none.