### PR TITLE
vet: set PATH to HOME/go/bin, and print go version

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -78,17 +78,22 @@ jobs:
       # detector and Go1.11 (where we run a reduced set of tests).
       - name: Run tests
         if: ${{ matrix.type != 'extras' && matrix.type != 'race' && matrix.type != 'tests111' }}
-        run: go test -cpu 1,4 -timeout 7m google.golang.org/grpc/...
+        run: |
+          go version
+          go test -cpu 1,4 -timeout 7m google.golang.org/grpc/...
 
       # Race detector tests
       - name: Run test race
         if: ${{ matrix.TYPE == 'race' }}
-        run: go test -race -cpu 1,4 -timeout 7m google.golang.org/grpc/...
+        run: |
+          go version
+          go test -race -cpu 1,4 -timeout 7m google.golang.org/grpc/...
 
       # Non-core gRPC tests (examples, interop, etc)
       - name: Run extras tests
         if: ${{ matrix.TYPE == 'extras' }}
         run: |
+          go version
           examples/examples_test.sh
           security/advancedtls/examples/examples_test.sh
           interop/interop_test.sh
@@ -99,6 +104,7 @@ jobs:
       - name: Run Go1.11 tests
         if: ${{ matrix.type == 'tests111' }}
         run: |
+          go version
           tests=$(find ${GITHUB_WORKSPACE} -name '*_test.go' | xargs -n1 dirname | sort -u | sed "s:^${GITHUB_WORKSPACE}:.:" | sed "s:\/$::" | grep -v ^./security | grep -v ^./credentials/sts | grep -v ^./credentials/tls/certprovider | grep -v ^./credentials/xds | grep -v ^./xds )
           echo "Running tests for " ${tests}
           go test -cpu 1,4 -timeout 7m ${tests}

--- a/vet.sh
+++ b/vet.sh
@@ -28,7 +28,8 @@ cleanup() {
 }
 trap cleanup EXIT
 
-PATH="${GOPATH}/bin:${GOROOT}/bin:${PATH}"
+PATH="${HOME}/go/bin:${GOROOT}/bin:${PATH}"
+go version
 
 if [[ "$1" = "-install" ]]; then
   # Check for module support


### PR DESCRIPTION
Setting PATH to GOPATH caused failures with older go: https://github.com/grpc/grpc-go/runs/2069166312