### PR TITLE
xds: filter chain matching logic for server-side

### DIFF
--- a/xds/internal/client/client.go
+++ b/xds/internal/client/client.go
@@ -24,7 +24,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net"
 	"sync"
 	"time"
 
@@ -241,60 +240,7 @@ type InboundListenerConfig struct {
 	// accept incoming connections.
 	Port string
 	// FilterChains is the list of filter chains associated with this listener.
-	FilterChains []*FilterChain
-	// DefaultFilterChain is the filter chain to be used when none of the above
-	// filter chains matches an incoming connection.
-	DefaultFilterChain *FilterChain
-}
-
-// FilterChain wraps a set of match criteria and associated security
-// configuration.
-//
-// The actual set filters associated with this filter chain are not captured
-// here, since we do not support these filters on the server yet.
-type FilterChain struct {
-	// Match contains the criteria to use when matching a connection to this
-	// filter chain.
-	Match *FilterChainMatch
-	// SecurityCfg contains transport socket security configuration.
-	SecurityCfg *SecurityConfig
-}
-
-// SourceType specifies the connection source IP match type.
-type SourceType int
-
-const (
-	// SourceTypeAny matches connection attempts from any source.
-	SourceTypeAny SourceType = iota
-	// SourceTypeSameOrLoopback matches connection attempts from the same host.
-	SourceTypeSameOrLoopback
-	// SourceTypeExternal matches connection attempts from a different host.
-	SourceTypeExternal
-)
-
-// FilterChainMatch specifies the match criteria for selecting a specific filter
-// chain of a listener, for an incoming connection.
-//
-// The xDS FilterChainMatch proto specifies 8 match criteria. But we only have a
-// subset of those fields here because we explicitly ignore filter chains whose
-// match criteria specifies values for fields like destination_port,
-// server_names, application_protocols, transport_protocol.
-type FilterChainMatch struct {
-	// DestPrefixRanges specifies a set of IP addresses and prefix lengths to
-	// match the destination address of the incoming connection when the
-	// listener is bound to 0.0.0.0/[::]. If this field is empty, the
-	// destination address is ignored.
-	DestPrefixRanges []net.IP
-	// SourceType specifies the connection source IP match type. Can be any,
-	// local or external network.
-	SourceType SourceType
-	// SourcePrefixRanges specifies a set of IP addresses and prefix lengths to
-	// match the source address of the incoming connection. If this field is
-	// empty, the source address is ignored.
-	SourcePrefixRanges []net.IP
-	// SourcePorts specifies a set of ports to match the source port of the
-	// incoming connection. If this field is empty, the source port is ignored.
-	SourcePorts []uint32
+	FilterChains *FilterChainManager
 }
 
 // RouteConfigUpdate contains information received in an RDS response, which is

--- a/xds/internal/client/filter_chain.go
+++ b/xds/internal/client/filter_chain.go
@@ -1,0 +1,570 @@
+/*
+ *
+ * Copyright 2021 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package client
+
+import (
+	"errors"
+	"fmt"
+	"net"
+
+	v3listenerpb "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	v3tlspb "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
+	"github.com/golang/protobuf/proto"
+
+	"google.golang.org/grpc/xds/internal/version"
+)
+
+// Represents a wildcard IP prefix. Go stdlib `Contains()` method works for both
+// v4 and v6 addresses when used on this wildcard address.
+const emptyAddrMapKey = "0.0.0.0/0"
+
+var (
+	// Parsed wildcard IP prefix.
+	_, zeroIP, _ = net.ParseCIDR("0.0.0.0/0")
+)
+
+// FilterChain captures information from within a FilterChain message in a
+// Listener resource.
+//
+// Currently, this simply contains the security configuration found in the
+// 'transport_socket' field of the filter chain. The actual set of filters
+// associated with this filter chain are not captured here, since we do not
+// support these filters on the server-side yet.
+type FilterChain struct {
+	// SecurityCfg contains transport socket security configuration.
+	SecurityCfg *SecurityConfig
+}
+
+// SourceType specifies the connection source IP match type.
+type SourceType int
+
+const (
+	// SourceTypeAny matches connection attempts from any source.
+	SourceTypeAny SourceType = iota
+	// SourceTypeSameOrLoopback matches connection attempts from the same host.
+	SourceTypeSameOrLoopback
+	// SourceTypeExternal matches connection attempts from a different host.
+	SourceTypeExternal
+)
+
+// FilterChainManager contains all the match criteria specified through all
+// filter chains in a single Listener resource. It also contains the default
+// filter chain specified in the Listener resource. It provides two important
+// pieces of functionality:
+// 1. Validate the filter chains in an incoming Listener resource to make sure
+//    that there aren't filter chains which contain the same match criteria.
+// 2. As part of performing the above validation, it builds an internal data
+//    structure which will if used to look up the matching filter chain at
+//    connection time.
+//
+// The logic specified in the documentation around the xDS FilterChainMatch
+// proto mentions 8 criteria to match on. gRPC does not support 4 of those, and
+// we get rid of filter chains which contain any of these unsupported fields at
+// parsing time. Here we use the remaining 4 criteria to find a matching filter
+// chain in the following order:
+// Destination IP address, Source type, Source IP address, Source port.
+type FilterChainManager struct {
+	// Destination prefix is the first match criteria that we support.
+	// Therefore, this multi-stage map is indexed on destination prefixes
+	// specified in the match criteria.
+	// Unspecified destination prefix matches end up as a wildcard entry here
+	// with a key of 0.0.0.0/0.
+	dstPrefixMap map[string]*destPrefixEntry
+
+	// At connection time, we do not have the actual destination prefix to match
+	// on. We only have the real destination address of the incoming connection.
+	// This means that we cannot use the above map at connection time. This list
+	// contains the map entries from the above map that we can use at connection
+	// time to find matching destination prefixes in O(n) time.
+	// TODO: Implement LC-trie to support logarithmic time lookups.
+	dstPrefixes []*destPrefixEntry
+
+	def   *FilterChain // Default filter chain, if specified.
+	fcCnt int          // Count of supported filter chains, for validation.
+}
+
+// destPrefixEntry is the value type of the map indexed on destination prefixes.
+type destPrefixEntry struct {
+	net *net.IPNet // The actual destination prefix.
+	// For each specified source type in the filter chain match criteria, this
+	// array points to the set of specified source prefixes.
+	// Unspecified source type matches end up as a wildcard entry here with an
+	// index of 0, which actually represents the source type `ANY`.
+	srcTypeArr [3]*sourcePrefixes
+}
+
+// sourcePrefixes contains source prefix related information specified in the
+// match criteria. These are pointed to by the array of source types.
+type sourcePrefixes struct {
+	// These are very similar to the 'dstPrefixMap' and 'dstPrefixes' field of
+	// FilterChainManager. Go there for more info.
+	srcPrefixMap map[string]*sourcePrefixEntry
+	srcPrefixes  []*sourcePrefixEntry
+}
+
+// sourcePrefixEntry contains match criteria per source prefix.
+type sourcePrefixEntry struct {
+	net *net.IPNet // The actual source prefix.
+	// Mapping from source ports specified in the match criteria to the actual
+	// filter chain. Unspecified source port matches en up as a wildcard entry
+	// here with a key of 0.
+	srcPortMap map[int]*FilterChain
+}
+
+// NewFilterChainManager parses the received Listener resource and builds a
+// FilterChainManager. Returns a non-nil error on validation failures.
+//
+// This function is only exported so that tests outside of this package can
+// create a FilterChainManager.
+func NewFilterChainManager(lis *v3listenerpb.Listener) (*FilterChainManager, error) {
+	// Parse all the filter chains and build the internal data structures.
+	fci := &FilterChainManager{dstPrefixMap: make(map[string]*destPrefixEntry)}
+	if err := fci.addFilterChains(lis.GetFilterChains()); err != nil {
+		return nil, err
+	}
+
+	// Retrieve the default filter chain. The match criteria specified on the
+	// default filter chain is never used. The default filter chain simply gets
+	// used when none of the other filter chains match.
+	var def *FilterChain
+	if dfc := lis.GetDefaultFilterChain(); dfc != nil {
+		var err error
+		if def, err = filterChainFromProto(lis.GetDefaultFilterChain()); err != nil {
+			return nil, err
+		}
+	}
+	fci.def = def
+
+	// If there are no supported filter chains and no default filter chain, we
+	// fail here. This will call the Listener resource to be NACK'ed.
+	if fci.fcCnt == 0 && fci.def == nil {
+		return nil, fmt.Errorf("no supported filter chains and no default filter chain")
+	}
+	return fci, nil
+}
+
+// addFilterChains parses the filter chains in fcs and adds the required
+// internal data structures corresponding to the match criteria.
+func (fci *FilterChainManager) addFilterChains(fcs []*v3listenerpb.FilterChain) error {
+	for _, fc := range fcs {
+		// Skip filter chains with unsupported match fields/criteria.
+		fcm := fc.GetFilterChainMatch()
+		if fcm.GetDestinationPort().GetValue() != 0 ||
+			fcm.GetServerNames() != nil ||
+			(fcm.GetTransportProtocol() != "" && fcm.TransportProtocol != "raw_buffer") ||
+			fcm.GetApplicationProtocols() != nil {
+			continue
+		}
+
+		// Extract the supported match criteria, which will be used by
+		// successive addFilterChainsForXxx() functions.
+		var dstPrefixes []*net.IPNet
+		for _, pr := range fcm.GetPrefixRanges() {
+			cidr := fmt.Sprintf("%s/%d", pr.GetAddressPrefix(), pr.GetPrefixLen().GetValue())
+			_, ipnet, err := net.ParseCIDR(cidr)
+			if err != nil {
+				return fmt.Errorf("failed to parse destination prefix range: %+v", pr)
+			}
+			dstPrefixes = append(dstPrefixes, ipnet)
+		}
+
+		var srcType SourceType
+		switch fcm.GetSourceType() {
+		case v3listenerpb.FilterChainMatch_ANY:
+			srcType = SourceTypeAny
+		case v3listenerpb.FilterChainMatch_SAME_IP_OR_LOOPBACK:
+			srcType = SourceTypeSameOrLoopback
+		case v3listenerpb.FilterChainMatch_EXTERNAL:
+			srcType = SourceTypeExternal
+		default:
+			return fmt.Errorf("unsupported source type: %v", fcm.GetSourceType())
+		}
+
+		var srcPrefixes []*net.IPNet
+		for _, pr := range fcm.GetSourcePrefixRanges() {
+			cidr := fmt.Sprintf("%s/%d", pr.GetAddressPrefix(), pr.GetPrefixLen().GetValue())
+			_, ipnet, err := net.ParseCIDR(cidr)
+			if err != nil {
+				return fmt.Errorf("failed to parse source prefix range: %+v", pr)
+			}
+			srcPrefixes = append(srcPrefixes, ipnet)
+		}
+
+		var srcPorts []int
+		for _, port := range fcm.GetSourcePorts() {
+			srcPorts = append(srcPorts, int(port))
+		}
+
+		// Build the internal representation of the filter chain match fields.
+		if err := fci.addFilterChainsForDestPrefixes(dstPrefixes, srcType, srcPrefixes, srcPorts, fc); err != nil {
+			return err
+		}
+		fci.fcCnt++
+	}
+
+	// Build the source and dest prefix slices used by Lookup().
+	for _, dstPrefix := range fci.dstPrefixMap {
+		fci.dstPrefixes = append(fci.dstPrefixes, dstPrefix)
+		for _, st := range dstPrefix.srcTypeArr {
+			if st == nil {
+				continue
+			}
+			for _, srcPrefix := range st.srcPrefixMap {
+				st.srcPrefixes = append(st.srcPrefixes, srcPrefix)
+			}
+		}
+	}
+	return nil
+}
+
+// addFilterChainsForDestPrefixes adds destination prefixes to the internal data
+// structures and delegates control to addFilterChainsForSourceType to continue
+// building the internal data structure.
+func (fci *FilterChainManager) addFilterChainsForDestPrefixes(dstPrefixes []*net.IPNet, srcType SourceType, srcPrefixes []*net.IPNet, srcPorts []int, fc *v3listenerpb.FilterChain) error {
+	if len(dstPrefixes) == 0 {
+		// Use the wildcard IP when destination prefix is unspecified.
+		if fci.dstPrefixMap[emptyAddrMapKey] == nil {
+			fci.dstPrefixMap[emptyAddrMapKey] = &destPrefixEntry{net: zeroIP}
+		}
+		return fci.addFilterChainsForSourceType(fci.dstPrefixMap[emptyAddrMapKey], srcType, srcPrefixes, srcPorts, fc)
+	}
+	for _, prefix := range dstPrefixes {
+		p := prefix.String()
+		if fci.dstPrefixMap[p] == nil {
+			fci.dstPrefixMap[p] = &destPrefixEntry{net: prefix}
+		}
+		if err := fci.addFilterChainsForSourceType(fci.dstPrefixMap[p], srcType, srcPrefixes, srcPorts, fc); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// addFilterChainsForSourceType adds source types to the internal data
+// structures and delegates control to addFilterChainsForSourcePrefixes to
+// continue building the internal data structure.
+func (fci *FilterChainManager) addFilterChainsForSourceType(dstEntry *destPrefixEntry, srcType SourceType, srcPrefixes []*net.IPNet, srcPorts []int, fc *v3listenerpb.FilterChain) error {
+	st := int(srcType)
+	if dstEntry.srcTypeArr[st] == nil {
+		dstEntry.srcTypeArr[st] = &sourcePrefixes{srcPrefixMap: make(map[string]*sourcePrefixEntry)}
+	}
+	return fci.addFilterChainsForSourcePrefixes(dstEntry.srcTypeArr[st].srcPrefixMap, srcPrefixes, srcPorts, fc)
+}
+
+// addFilterChainsForSourcePrefixes adds source prefixes to the internal data
+// structures and delegates control to addFilterChainsForSourcePorts to continue
+// building the internal data structure.
+func (fci *FilterChainManager) addFilterChainsForSourcePrefixes(srcPrefixMap map[string]*sourcePrefixEntry, srcPrefixes []*net.IPNet, srcPorts []int, fc *v3listenerpb.FilterChain) error {
+	if len(srcPrefixes) == 0 {
+		// Use the wildcard IP when source prefix is unspecified.
+		if srcPrefixMap[emptyAddrMapKey] == nil {
+			srcPrefixMap[emptyAddrMapKey] = &sourcePrefixEntry{
+				net:        zeroIP,
+				srcPortMap: make(map[int]*FilterChain),
+			}
+		}
+		return fci.addFilterChainsForSourcePorts(srcPrefixMap[emptyAddrMapKey], srcPorts, fc)
+	}
+	for _, prefix := range srcPrefixes {
+		p := prefix.String()
+		if srcPrefixMap[p] == nil {
+			srcPrefixMap[p] = &sourcePrefixEntry{
+				net:        prefix,
+				srcPortMap: make(map[int]*FilterChain),
+			}
+		}
+		if err := fci.addFilterChainsForSourcePorts(srcPrefixMap[p], srcPorts, fc); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// addFilterChainsForSourcePorts adds source ports to the internal data
+// structures and completes the process of building the internal data structure.
+// It is here that we determine if there are multiple filter chains with
+// overlapping matching rules.
+func (fci *FilterChainManager) addFilterChainsForSourcePorts(srcEntry *sourcePrefixEntry, srcPorts []int, fcProto *v3listenerpb.FilterChain) error {
+	fc, err := filterChainFromProto(fcProto)
+	if err != nil {
+		return err
+	}
+
+	if len(srcPorts) == 0 {
+		// Use the wildcard port '0', when source ports are unspecified.
+		if curFC := srcEntry.srcPortMap[0]; curFC != nil {
+			return errors.New("multiple filter chains with overlapping matching rules are defined")
+		}
+		srcEntry.srcPortMap[0] = fc
+		return nil
+	}
+	for _, port := range srcPorts {
+		if curFC := srcEntry.srcPortMap[port]; curFC != nil {
+			return errors.New("multiple filter chains with overlapping matching rules are defined")
+		}
+		srcEntry.srcPortMap[port] = fc
+	}
+	return nil
+}
+
+// filterChainFromProto extracts the relevant information from the FilterChain
+// proto and stores it in our internal representation. Currently, we only
+// process the security configuration stored in the transport_socket field.
+func filterChainFromProto(fc *v3listenerpb.FilterChain) (*FilterChain, error) {
+	// If the transport_socket field is not specified, it means that the control
+	// plane has not sent us any security config. This is fine and the server
+	// will use the fallback credentials configured as part of the
+	// xdsCredentials.
+	ts := fc.GetTransportSocket()
+	if ts == nil {
+		return &FilterChain{}, nil
+	}
+	if name := ts.GetName(); name != transportSocketName {
+		return nil, fmt.Errorf("transport_socket field has unexpected name: %s", name)
+	}
+	any := ts.GetTypedConfig()
+	if any == nil || any.TypeUrl != version.V3DownstreamTLSContextURL {
+		return nil, fmt.Errorf("transport_socket field has unexpected typeURL: %s", any.TypeUrl)
+	}
+	downstreamCtx := &v3tlspb.DownstreamTlsContext{}
+	if err := proto.Unmarshal(any.GetValue(), downstreamCtx); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal DownstreamTlsContext in LDS response: %v", err)
+	}
+	if downstreamCtx.GetCommonTlsContext() == nil {
+		return nil, errors.New("DownstreamTlsContext in LDS response does not contain a CommonTlsContext")
+	}
+	sc, err := securityConfigFromCommonTLSContext(downstreamCtx.GetCommonTlsContext())
+	if err != nil {
+		return nil, err
+	}
+	if sc.IdentityInstanceName == "" {
+		return nil, errors.New("security configuration on the server-side does not contain identity certificate provider instance name")
+	}
+	sc.RequireClientCert = downstreamCtx.GetRequireClientCertificate().GetValue()
+	if sc.RequireClientCert && sc.RootInstanceName == "" {
+		return nil, errors.New("security configuration on the server-side does not contain root certificate provider instance name, but require_client_cert field is set")
+	}
+	return &FilterChain{SecurityCfg: sc}, nil
+}
+
+// FilterChainLookupParams wraps parameters to be passed to Lookup.
+type FilterChainLookupParams struct {
+	// IsUnspecified indicates whether the server is listening on a wildcard
+	// address, "0.0.0.0" for IPv4 and "::" for IPv6. Only when this is set to
+	// true, do we consider the destination prefixes specified in the filter
+	// chain match criteria.
+	IsUnspecifiedListener bool
+	// DestAddr is the local address of an incoming connection.
+	DestAddr net.IP
+	// SourceAddr is the remote address of an incoming connection.
+	SourceAddr net.IP
+	// SourcePort is the remote port of an incoming connection.
+	SourcePort int
+}
+
+// Lookup returns the most specific matching filter chain to be used for an
+// incoming connection on the server side.
+//
+// Returns a non-nil error if no matching filter chain could be found or
+// multiple matching filter chains were found, and in both cases, the incoming
+// connection must be dropped.
+func (fci *FilterChainManager) Lookup(params FilterChainLookupParams) (*FilterChain, error) {
+	dstPrefixes := filterBasedOnDestinationPrefixes(fci.dstPrefixes, params.IsUnspecifiedListener, params.DestAddr)
+	if len(dstPrefixes) == 0 {
+		if fci.def != nil {
+			return fci.def, nil
+		}
+		return nil, fmt.Errorf("no matching filter chain based on destination prefix match for %+v", params)
+	}
+
+	srcType := SourceTypeExternal
+	if params.SourceAddr.Equal(params.DestAddr) || params.SourceAddr.IsLoopback() {
+		srcType = SourceTypeSameOrLoopback
+	}
+	srcPrefixes := filterBasedOnSourceType(dstPrefixes, srcType)
+	if len(srcPrefixes) == 0 {
+		if fci.def != nil {
+			return fci.def, nil
+		}
+		return nil, fmt.Errorf("no matching filter chain based on source type match for %+v", params)
+	}
+
+	srcPrefixEntries := filterBasedOnSourcePrefixes(srcPrefixes, params.SourceAddr)
+	if len(srcPrefixEntries) == 0 {
+		if fci.def != nil {
+			return fci.def, nil
+		}
+		return nil, fmt.Errorf("no matching filter chain based on source prefix match for %+v", params)
+	}
+
+	filterChain, err := filterBasedOnSourcePorts(srcPrefixEntries, params.SourcePort)
+	if err != nil {
+		return nil, fmt.Errorf("filter chain match failed for %+v: %v", params, err)
+	}
+	if filterChain != nil {
+		return filterChain, nil
+	}
+	if fci.def != nil {
+		return fci.def, nil
+	}
+	return nil, fmt.Errorf("no matching filter chain after all match criteria for %+v", params)
+}
+
+// filterBasedOnDestinationPrefixes is the first stage of the filter chain
+// matching algorithm. It takes the complete set of configured filter chain
+// matchers and returns the most specific matchers based on the destination
+// prefix match criteria (the prefixes which match the most number of bits).
+func filterBasedOnDestinationPrefixes(dstPrefixes []*destPrefixEntry, isUnspecified bool, dstAddr net.IP) []*destPrefixEntry {
+	if !isUnspecified {
+		// Destination prefix matchers are considered only when the listener is
+		// bound to the wildcard address.
+		return dstPrefixes
+	}
+	var (
+		matchingDstPrefixes []*destPrefixEntry
+		maxSubnetMatch      int
+	)
+	for _, prefix := range dstPrefixes {
+		if !prefix.net.Contains(dstAddr) {
+			continue
+		}
+		matchSize, _ := prefix.net.Mask.Size()
+		if matchSize < maxSubnetMatch {
+			continue
+		}
+		if matchSize > maxSubnetMatch {
+			maxSubnetMatch = matchSize
+			matchingDstPrefixes = make([]*destPrefixEntry, 0)
+		}
+		matchingDstPrefixes = append(matchingDstPrefixes, prefix)
+	}
+	return matchingDstPrefixes
+}
+
+// filterBasedOnSourceType is the second stage of the matching algorithm. It
+// trims the filter chains based on the most specific source type match.
+func filterBasedOnSourceType(dstPrefixes []*destPrefixEntry, srcType SourceType) []*sourcePrefixes {
+	var (
+		srcPrefixes      []*sourcePrefixes
+		bestSrcTypeMatch int
+	)
+	for _, prefix := range dstPrefixes {
+		var (
+			srcPrefix *sourcePrefixes
+			match     int
+		)
+		switch srcType {
+		case SourceTypeExternal:
+			match = int(SourceTypeExternal)
+			srcPrefix = prefix.srcTypeArr[match]
+		case SourceTypeSameOrLoopback:
+			match = int(SourceTypeSameOrLoopback)
+			srcPrefix = prefix.srcTypeArr[match]
+		}
+		if srcPrefix == nil {
+			match = int(SourceTypeAny)
+			srcPrefix = prefix.srcTypeArr[match]
+		}
+		if match < bestSrcTypeMatch {
+			continue
+		}
+		if match > bestSrcTypeMatch {
+			bestSrcTypeMatch = match
+			srcPrefixes = make([]*sourcePrefixes, 0)
+		}
+		if srcPrefix != nil {
+			// The source type array always has 3 entries, but these could be
+			// nil if the appropriate source type match was not specified.
+			srcPrefixes = append(srcPrefixes, srcPrefix)
+		}
+	}
+	return srcPrefixes
+}
+
+// filterBasedOnSourcePrefixes is the third stage of the filter chain matching
+// algorithm. It trims the filter chains based on the source prefix. Only filter
+// chains with the most specific match progress to the next stage.
+func filterBasedOnSourcePrefixes(srcPrefixes []*sourcePrefixes, srcAddr net.IP) []*sourcePrefixEntry {
+	var (
+		matchingSrcPrefixes []*sourcePrefixEntry
+		maxSubnetMatch      int
+	)
+	for _, sp := range srcPrefixes {
+		for _, prefix := range sp.srcPrefixes {
+			if !prefix.net.Contains(srcAddr) {
+				continue
+			}
+			matchSize, _ := prefix.net.Mask.Size()
+			if matchSize < maxSubnetMatch {
+				continue
+			}
+			if matchSize > maxSubnetMatch {
+				maxSubnetMatch = matchSize
+				matchingSrcPrefixes = make([]*sourcePrefixEntry, 0)
+			}
+			matchingSrcPrefixes = append(matchingSrcPrefixes, prefix)
+		}
+	}
+	return matchingSrcPrefixes
+}
+
+// filterBasedOnSourcePorts is the last state of the filter chain matching
+// algorithm. It trims the filter chains based on the source ports. It expects
+// to be left with a single matching filter chain and returns an error if there
+// are multiple matching filter chains at the end.
+func filterBasedOnSourcePorts(srcPrefixEntries []*sourcePrefixEntry, srcPort int) (*FilterChain, error) {
+	// We need to find the most specific match from each of these source prefix
+	// entries. Matching filter chains are associated with a weight of 0 or 1,
+	// indicating whether they were a wildcard or a specific port match
+	// respectively. Once all source prefix entries have been processed, if we
+	// are left with more than one matching filter chain at the highest weight,
+	// it means that we have a match conflict.
+	matchingFCs := make(map[int][]*FilterChain)
+	for _, spe := range srcPrefixEntries {
+		if fc := spe.srcPortMap[srcPort]; fc != nil {
+			// There can only be one specific match. So, the moment we find a
+			// second specific match, we can error out.
+			if len(matchingFCs[1]) != 0 {
+				return nil, errors.New("multiple matching filter chains")
+			}
+			matchingFCs[1] = append(matchingFCs[1], fc)
+		} else if fc := spe.srcPortMap[0]; fc != nil {
+			matchingFCs[0] = append(matchingFCs[0], fc)
+		}
+	}
+	if len(matchingFCs) == 0 {
+		// This happens when specific source ports are mentioned in the matching
+		// source prefix (and therefore there is no entry for a wildcard port),
+		// but none of them match the incoming source port.
+		return nil, errors.New("no matching filter chain after all match criteria")
+	}
+
+	// If we have a specific match, we can be sure that there was only one such
+	// match. So, we can safely return it.
+	if fcs := matchingFCs[1]; len(fcs) != 0 {
+		return fcs[0], nil
+	}
+
+	// If we did not find a specific match and have more than one wildcard
+	// match, we have a match conflict.
+	if fcs := matchingFCs[0]; len(fcs) != 1 {
+		return nil, errors.New("multiple matching filter chains")
+	}
+	return matchingFCs[0][0], nil
+}

--- a/xds/internal/client/filter_chain.go
+++ b/xds/internal/client/filter_chain.go
@@ -93,7 +93,9 @@ type FilterChainManager struct {
 	// This means that we cannot use the above map at connection time. This list
 	// contains the map entries from the above map that we can use at connection
 	// time to find matching destination prefixes in O(n) time.
-	// TODO: Implement LC-trie to support logarithmic time lookups.
+	//
+	// TODO: Implement LC-trie to support logarithmic time lookups. If that
+	// involves too much time/effort, sort this slice based on the netmask size.
 	dstPrefixes []*destPrefixEntry
 
 	def   *FilterChain // Default filter chain, if specified.
@@ -442,7 +444,7 @@ func filterByDestinationPrefixes(dstPrefixes []*destPrefixEntry, isUnspecified b
 		}
 		if matchSize > maxSubnetMatch {
 			maxSubnetMatch = matchSize
-			matchingDstPrefixes = make([]*destPrefixEntry, 0)
+			matchingDstPrefixes = make([]*destPrefixEntry, 0, 1)
 		}
 		matchingDstPrefixes = append(matchingDstPrefixes, prefix)
 	}
@@ -508,7 +510,7 @@ func filterBySourcePrefixes(srcPrefixes []*sourcePrefixes, srcAddr net.IP) (*sou
 			}
 			if matchSize > maxSubnetMatch {
 				maxSubnetMatch = matchSize
-				matchingSrcPrefixes = make([]*sourcePrefixEntry, 0)
+				matchingSrcPrefixes = make([]*sourcePrefixEntry, 0, 1)
 			}
 			matchingSrcPrefixes = append(matchingSrcPrefixes, prefix)
 		}

--- a/xds/internal/client/filter_chain_test.go
+++ b/xds/internal/client/filter_chain_test.go
@@ -1,0 +1,1316 @@
+/*
+ *
+ * Copyright 2021 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package client
+
+import (
+	"fmt"
+	"net"
+	"strings"
+	"testing"
+
+	v3corepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	v3listenerpb "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	v3tlspb "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	"google.golang.org/grpc/xds/internal/version"
+)
+
+func TestNewFilterChainImpl_Failure_BadMatchFields(t *testing.T) {
+	tests := []struct {
+		desc string
+		lis  *v3listenerpb.Listener
+	}{
+		{
+			desc: "unsupported destination port field",
+			lis: &v3listenerpb.Listener{
+				FilterChains: []*v3listenerpb.FilterChain{
+					{
+						FilterChainMatch: &v3listenerpb.FilterChainMatch{DestinationPort: &wrapperspb.UInt32Value{Value: 666}},
+					},
+				},
+			},
+		},
+		{
+			desc: "unsupported server names field",
+			lis: &v3listenerpb.Listener{
+				FilterChains: []*v3listenerpb.FilterChain{
+					{
+						FilterChainMatch: &v3listenerpb.FilterChainMatch{ServerNames: []string{"example-server"}},
+					},
+				},
+			},
+		},
+		{
+			desc: "unsupported transport protocol ",
+			lis: &v3listenerpb.Listener{
+				FilterChains: []*v3listenerpb.FilterChain{
+					{
+						FilterChainMatch: &v3listenerpb.FilterChainMatch{TransportProtocol: "tls"},
+					},
+				},
+			},
+		},
+		{
+			desc: "unsupported application protocol field",
+			lis: &v3listenerpb.Listener{
+				FilterChains: []*v3listenerpb.FilterChain{
+					{
+						FilterChainMatch: &v3listenerpb.FilterChainMatch{ApplicationProtocols: []string{"h2"}},
+					},
+				},
+			},
+		},
+		{
+			desc: "bad dest address prefix",
+			lis: &v3listenerpb.Listener{
+				FilterChains: []*v3listenerpb.FilterChain{
+					{
+						FilterChainMatch: &v3listenerpb.FilterChainMatch{PrefixRanges: []*v3corepb.CidrRange{{AddressPrefix: "a.b.c.d"}}},
+					},
+				},
+			},
+		},
+		{
+			desc: "bad dest prefix length",
+			lis: &v3listenerpb.Listener{
+				FilterChains: []*v3listenerpb.FilterChain{
+					{
+						FilterChainMatch: &v3listenerpb.FilterChainMatch{PrefixRanges: []*v3corepb.CidrRange{cidrRangeFromAddressAndPrefixLen("10.1.1.0", 50)}},
+					},
+				},
+			},
+		},
+		{
+			desc: "bad source address prefix",
+			lis: &v3listenerpb.Listener{
+				FilterChains: []*v3listenerpb.FilterChain{
+					{
+						FilterChainMatch: &v3listenerpb.FilterChainMatch{SourcePrefixRanges: []*v3corepb.CidrRange{{AddressPrefix: "a.b.c.d"}}},
+					},
+				},
+			},
+		},
+		{
+			desc: "bad source prefix length",
+			lis: &v3listenerpb.Listener{
+				FilterChains: []*v3listenerpb.FilterChain{
+					{
+						FilterChainMatch: &v3listenerpb.FilterChainMatch{SourcePrefixRanges: []*v3corepb.CidrRange{cidrRangeFromAddressAndPrefixLen("10.1.1.0", 50)}},
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			if fci, err := NewFilterChainManager(test.lis); err == nil {
+				t.Fatalf("NewFilterChainManager() returned %v when expected to fail", fci)
+			}
+		})
+	}
+}
+
+func TestNewFilterChainImpl_Failure_OverlappingMatchingRules(t *testing.T) {
+	tests := []struct {
+		desc string
+		lis  *v3listenerpb.Listener
+	}{
+		{
+			desc: "matching destination prefixes with no other matchers",
+			lis: &v3listenerpb.Listener{
+				FilterChains: []*v3listenerpb.FilterChain{
+					{
+						FilterChainMatch: &v3listenerpb.FilterChainMatch{
+							PrefixRanges: []*v3corepb.CidrRange{cidrRangeFromAddressAndPrefixLen("192.168.1.1", 16), cidrRangeFromAddressAndPrefixLen("10.0.0.0", 0)},
+						},
+					},
+					{
+						FilterChainMatch: &v3listenerpb.FilterChainMatch{
+							PrefixRanges: []*v3corepb.CidrRange{cidrRangeFromAddressAndPrefixLen("192.168.2.2", 16)},
+						},
+					},
+				},
+			},
+		},
+		{
+			desc: "matching source type",
+			lis: &v3listenerpb.Listener{
+				FilterChains: []*v3listenerpb.FilterChain{
+					{
+						FilterChainMatch: &v3listenerpb.FilterChainMatch{SourceType: v3listenerpb.FilterChainMatch_ANY},
+					},
+					{
+						FilterChainMatch: &v3listenerpb.FilterChainMatch{SourceType: v3listenerpb.FilterChainMatch_SAME_IP_OR_LOOPBACK},
+					},
+					{
+						FilterChainMatch: &v3listenerpb.FilterChainMatch{SourceType: v3listenerpb.FilterChainMatch_EXTERNAL},
+					},
+					{
+						FilterChainMatch: &v3listenerpb.FilterChainMatch{SourceType: v3listenerpb.FilterChainMatch_EXTERNAL},
+					},
+				},
+			},
+		},
+		{
+			desc: "matching source prefixes",
+			lis: &v3listenerpb.Listener{
+				FilterChains: []*v3listenerpb.FilterChain{
+					{
+						FilterChainMatch: &v3listenerpb.FilterChainMatch{
+							SourcePrefixRanges: []*v3corepb.CidrRange{cidrRangeFromAddressAndPrefixLen("192.168.1.1", 16), cidrRangeFromAddressAndPrefixLen("10.0.0.0", 0)},
+						},
+					},
+					{
+						FilterChainMatch: &v3listenerpb.FilterChainMatch{
+							SourcePrefixRanges: []*v3corepb.CidrRange{cidrRangeFromAddressAndPrefixLen("192.168.2.2", 16)},
+						},
+					},
+				},
+			},
+		},
+		{
+			desc: "matching source ports",
+			lis: &v3listenerpb.Listener{
+				FilterChains: []*v3listenerpb.FilterChain{
+					{
+						FilterChainMatch: &v3listenerpb.FilterChainMatch{SourcePorts: []uint32{1, 2, 3, 4, 5}},
+					},
+					{
+						FilterChainMatch: &v3listenerpb.FilterChainMatch{},
+					},
+					{
+						FilterChainMatch: &v3listenerpb.FilterChainMatch{SourcePorts: []uint32{5, 6, 7}},
+					},
+				},
+			},
+		},
+	}
+
+	const wantErr = "multiple filter chains with overlapping matching rules are defined"
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			_, err := NewFilterChainManager(test.lis)
+			if err == nil || !strings.Contains(err.Error(), wantErr) {
+				t.Fatalf("NewFilterChainManager() returned err: %v, wantErr: %s", err, wantErr)
+			}
+		})
+	}
+}
+
+func TestNewFilterChainImpl_Failure_BadSecurityConfig(t *testing.T) {
+	tests := []struct {
+		desc    string
+		lis     *v3listenerpb.Listener
+		wantErr string
+	}{
+		{
+			desc:    "no filter chains",
+			lis:     &v3listenerpb.Listener{},
+			wantErr: "no supported filter chains and no default filter chain",
+		},
+		{
+			desc: "unexpected transport socket name",
+			lis: &v3listenerpb.Listener{
+				FilterChains: []*v3listenerpb.FilterChain{
+					{
+						TransportSocket: &v3corepb.TransportSocket{Name: "unsupported-transport-socket-name"},
+					},
+				},
+			},
+			wantErr: "transport_socket field has unexpected name",
+		},
+		{
+			desc: "unexpected transport socket URL",
+			lis: &v3listenerpb.Listener{
+				FilterChains: []*v3listenerpb.FilterChain{
+					{
+						TransportSocket: &v3corepb.TransportSocket{
+							Name: "envoy.transport_sockets.tls",
+							ConfigType: &v3corepb.TransportSocket_TypedConfig{
+								TypedConfig: marshalAny(&v3tlspb.UpstreamTlsContext{}),
+							},
+						},
+					},
+				},
+			},
+			wantErr: "transport_socket field has unexpected typeURL",
+		},
+		{
+			desc: "badly marshaled transport socket",
+			lis: &v3listenerpb.Listener{
+				FilterChains: []*v3listenerpb.FilterChain{
+					{
+						TransportSocket: &v3corepb.TransportSocket{
+							Name: "envoy.transport_sockets.tls",
+							ConfigType: &v3corepb.TransportSocket_TypedConfig{
+								TypedConfig: &anypb.Any{
+									TypeUrl: version.V3DownstreamTLSContextURL,
+									Value:   []byte{1, 2, 3, 4},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: "failed to unmarshal DownstreamTlsContext in LDS response",
+		},
+		{
+			desc: "missing CommonTlsContext",
+			lis: &v3listenerpb.Listener{
+				FilterChains: []*v3listenerpb.FilterChain{
+					{
+						TransportSocket: &v3corepb.TransportSocket{
+							Name: "envoy.transport_sockets.tls",
+							ConfigType: &v3corepb.TransportSocket_TypedConfig{
+								TypedConfig: marshalAny(&v3tlspb.DownstreamTlsContext{}),
+							},
+						},
+					},
+				},
+			},
+			wantErr: "DownstreamTlsContext in LDS response does not contain a CommonTlsContext",
+		},
+		{
+			desc: "unsupported validation context in transport socket",
+			lis: &v3listenerpb.Listener{
+				FilterChains: []*v3listenerpb.FilterChain{
+					{
+						TransportSocket: &v3corepb.TransportSocket{
+							Name: "envoy.transport_sockets.tls",
+							ConfigType: &v3corepb.TransportSocket_TypedConfig{
+								TypedConfig: marshalAny(&v3tlspb.DownstreamTlsContext{
+									CommonTlsContext: &v3tlspb.CommonTlsContext{
+										ValidationContextType: &v3tlspb.CommonTlsContext_ValidationContextSdsSecretConfig{
+											ValidationContextSdsSecretConfig: &v3tlspb.SdsSecretConfig{
+												Name: "foo-sds-secret",
+											},
+										},
+									},
+								}),
+							},
+						},
+					},
+				},
+			},
+			wantErr: "validation context contains unexpected type",
+		},
+		{
+			desc: "no root certificate provider with require_client_cert",
+			lis: &v3listenerpb.Listener{
+				FilterChains: []*v3listenerpb.FilterChain{
+					{
+						TransportSocket: &v3corepb.TransportSocket{
+							Name: "envoy.transport_sockets.tls",
+							ConfigType: &v3corepb.TransportSocket_TypedConfig{
+								TypedConfig: marshalAny(&v3tlspb.DownstreamTlsContext{
+									RequireClientCertificate: &wrapperspb.BoolValue{Value: true},
+									CommonTlsContext: &v3tlspb.CommonTlsContext{
+										TlsCertificateCertificateProviderInstance: &v3tlspb.CommonTlsContext_CertificateProviderInstance{
+											InstanceName:    "identityPluginInstance",
+											CertificateName: "identityCertName",
+										},
+									},
+								}),
+							},
+						},
+					},
+				},
+			},
+			wantErr: "security configuration on the server-side does not contain root certificate provider instance name, but require_client_cert field is set",
+		},
+		{
+			desc: "no identity certificate provider",
+			lis: &v3listenerpb.Listener{
+				FilterChains: []*v3listenerpb.FilterChain{
+					{
+						TransportSocket: &v3corepb.TransportSocket{
+							Name: "envoy.transport_sockets.tls",
+							ConfigType: &v3corepb.TransportSocket_TypedConfig{
+								TypedConfig: marshalAny(&v3tlspb.DownstreamTlsContext{
+									CommonTlsContext: &v3tlspb.CommonTlsContext{},
+								}),
+							},
+						},
+					},
+				},
+			},
+			wantErr: "security configuration on the server-side does not contain identity certificate provider instance name",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			_, err := NewFilterChainManager(test.lis)
+			if err == nil || !strings.Contains(err.Error(), test.wantErr) {
+				t.Fatalf("NewFilterChainManager() returned err: %v, wantErr: %s", err, test.wantErr)
+			}
+		})
+	}
+}
+
+func TestNewFilterChainImpl_Success_SecurityConfig(t *testing.T) {
+	tests := []struct {
+		desc   string
+		lis    *v3listenerpb.Listener
+		wantFC *FilterChainManager
+	}{
+		{
+			desc: "empty transport socket",
+			lis: &v3listenerpb.Listener{
+				FilterChains: []*v3listenerpb.FilterChain{
+					{
+						Name: "filter-chain-1",
+					},
+				},
+				DefaultFilterChain: &v3listenerpb.FilterChain{},
+			},
+			wantFC: &FilterChainManager{
+				dstPrefixMap: map[string]*destPrefixEntry{
+					"0.0.0.0/0": {
+						net: zeroIP,
+						srcTypeArr: [3]*sourcePrefixes{
+							{
+								srcPrefixMap: map[string]*sourcePrefixEntry{
+									"0.0.0.0/0": {
+										net: zeroIP,
+										srcPortMap: map[int]*FilterChain{
+											0: {},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				def:   &FilterChain{},
+				fcCnt: 1,
+			},
+		},
+		{
+			desc: "no validation context",
+			lis: &v3listenerpb.Listener{
+				FilterChains: []*v3listenerpb.FilterChain{
+					{
+						TransportSocket: &v3corepb.TransportSocket{
+							Name: "envoy.transport_sockets.tls",
+							ConfigType: &v3corepb.TransportSocket_TypedConfig{
+								TypedConfig: marshalAny(&v3tlspb.DownstreamTlsContext{
+									CommonTlsContext: &v3tlspb.CommonTlsContext{
+										TlsCertificateCertificateProviderInstance: &v3tlspb.CommonTlsContext_CertificateProviderInstance{
+											InstanceName:    "identityPluginInstance",
+											CertificateName: "identityCertName",
+										},
+									},
+								}),
+							},
+						},
+					},
+				},
+				DefaultFilterChain: &v3listenerpb.FilterChain{
+					TransportSocket: &v3corepb.TransportSocket{
+						Name: "envoy.transport_sockets.tls",
+						ConfigType: &v3corepb.TransportSocket_TypedConfig{
+							TypedConfig: marshalAny(&v3tlspb.DownstreamTlsContext{
+								CommonTlsContext: &v3tlspb.CommonTlsContext{
+									TlsCertificateCertificateProviderInstance: &v3tlspb.CommonTlsContext_CertificateProviderInstance{
+										InstanceName:    "defaultIdentityPluginInstance",
+										CertificateName: "defaultIdentityCertName",
+									},
+								},
+							}),
+						},
+					},
+				},
+			},
+			wantFC: &FilterChainManager{
+				dstPrefixMap: map[string]*destPrefixEntry{
+					"0.0.0.0/0": {
+						net: zeroIP,
+						srcTypeArr: [3]*sourcePrefixes{
+							{
+								srcPrefixMap: map[string]*sourcePrefixEntry{
+									"0.0.0.0/0": {
+										net: zeroIP,
+										srcPortMap: map[int]*FilterChain{
+											0: {
+												SecurityCfg: &SecurityConfig{
+													IdentityInstanceName: "identityPluginInstance",
+													IdentityCertName:     "identityCertName",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				def: &FilterChain{
+					SecurityCfg: &SecurityConfig{
+						IdentityInstanceName: "defaultIdentityPluginInstance",
+						IdentityCertName:     "defaultIdentityCertName",
+					},
+				},
+				fcCnt: 1,
+			},
+		},
+		{
+			desc: "validation context with certificate provider",
+			lis: &v3listenerpb.Listener{
+				FilterChains: []*v3listenerpb.FilterChain{
+					{
+						TransportSocket: &v3corepb.TransportSocket{
+							Name: "envoy.transport_sockets.tls",
+							ConfigType: &v3corepb.TransportSocket_TypedConfig{
+								TypedConfig: marshalAny(&v3tlspb.DownstreamTlsContext{
+									RequireClientCertificate: &wrapperspb.BoolValue{Value: true},
+									CommonTlsContext: &v3tlspb.CommonTlsContext{
+										TlsCertificateCertificateProviderInstance: &v3tlspb.CommonTlsContext_CertificateProviderInstance{
+											InstanceName:    "identityPluginInstance",
+											CertificateName: "identityCertName",
+										},
+										ValidationContextType: &v3tlspb.CommonTlsContext_ValidationContextCertificateProviderInstance{
+											ValidationContextCertificateProviderInstance: &v3tlspb.CommonTlsContext_CertificateProviderInstance{
+												InstanceName:    "rootPluginInstance",
+												CertificateName: "rootCertName",
+											},
+										},
+									},
+								}),
+							},
+						},
+					},
+				},
+				DefaultFilterChain: &v3listenerpb.FilterChain{
+					Name: "default-filter-chain-1",
+					TransportSocket: &v3corepb.TransportSocket{
+						Name: "envoy.transport_sockets.tls",
+						ConfigType: &v3corepb.TransportSocket_TypedConfig{
+							TypedConfig: marshalAny(&v3tlspb.DownstreamTlsContext{
+								RequireClientCertificate: &wrapperspb.BoolValue{Value: true},
+								CommonTlsContext: &v3tlspb.CommonTlsContext{
+									TlsCertificateCertificateProviderInstance: &v3tlspb.CommonTlsContext_CertificateProviderInstance{
+										InstanceName:    "defaultIdentityPluginInstance",
+										CertificateName: "defaultIdentityCertName",
+									},
+									ValidationContextType: &v3tlspb.CommonTlsContext_ValidationContextCertificateProviderInstance{
+										ValidationContextCertificateProviderInstance: &v3tlspb.CommonTlsContext_CertificateProviderInstance{
+											InstanceName:    "defaultRootPluginInstance",
+											CertificateName: "defaultRootCertName",
+										},
+									},
+								},
+							}),
+						},
+					},
+				},
+			},
+			wantFC: &FilterChainManager{
+				dstPrefixMap: map[string]*destPrefixEntry{
+					"0.0.0.0/0": {
+						net: zeroIP,
+						srcTypeArr: [3]*sourcePrefixes{
+							{
+								srcPrefixMap: map[string]*sourcePrefixEntry{
+									"0.0.0.0/0": {
+										net: zeroIP,
+										srcPortMap: map[int]*FilterChain{
+											0: {
+												SecurityCfg: &SecurityConfig{
+													RootInstanceName:     "rootPluginInstance",
+													RootCertName:         "rootCertName",
+													IdentityInstanceName: "identityPluginInstance",
+													IdentityCertName:     "identityCertName",
+													RequireClientCert:    true,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				def: &FilterChain{
+					SecurityCfg: &SecurityConfig{
+						RootInstanceName:     "defaultRootPluginInstance",
+						RootCertName:         "defaultRootCertName",
+						IdentityInstanceName: "defaultIdentityPluginInstance",
+						IdentityCertName:     "defaultIdentityCertName",
+						RequireClientCert:    true,
+					},
+				},
+				fcCnt: 1,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			gotFC, err := NewFilterChainManager(test.lis)
+			if err != nil {
+				t.Fatalf("NewFilterChainManager() returned err: %v, wantErr: nil", err)
+			}
+			if !cmp.Equal(gotFC, test.wantFC, cmp.AllowUnexported(FilterChainManager{}, destPrefixEntry{}, sourcePrefixes{}, sourcePrefixEntry{})) {
+				t.Fatalf("NewFilterChainManager() returned %+v, want: %+v", gotFC, test.wantFC)
+			}
+		})
+	}
+}
+
+func TestNewFilterChainImpl_Success_AllCombinations(t *testing.T) {
+	tests := []struct {
+		desc   string
+		lis    *v3listenerpb.Listener
+		wantFC *FilterChainManager
+	}{
+		{
+			desc: "multiple destination prefixes",
+			lis: &v3listenerpb.Listener{
+				FilterChains: []*v3listenerpb.FilterChain{
+					{
+						FilterChainMatch: &v3listenerpb.FilterChainMatch{},
+					},
+					{
+						FilterChainMatch: &v3listenerpb.FilterChainMatch{PrefixRanges: []*v3corepb.CidrRange{cidrRangeFromAddressAndPrefixLen("192.168.1.1", 16)}},
+					},
+					{
+						FilterChainMatch: &v3listenerpb.FilterChainMatch{PrefixRanges: []*v3corepb.CidrRange{cidrRangeFromAddressAndPrefixLen("10.0.0.0", 8)}},
+					},
+				},
+				DefaultFilterChain: &v3listenerpb.FilterChain{},
+			},
+			wantFC: &FilterChainManager{
+				dstPrefixMap: map[string]*destPrefixEntry{
+					"0.0.0.0/0": {
+						net: zeroIP,
+						srcTypeArr: [3]*sourcePrefixes{
+							{
+								srcPrefixMap: map[string]*sourcePrefixEntry{
+									"0.0.0.0/0": {
+										net: zeroIP,
+										srcPortMap: map[int]*FilterChain{
+											0: {},
+										},
+									},
+								},
+							},
+						},
+					},
+					"192.168.0.0/16": {
+						net: ipNetFromCIDR("192.168.2.2/16"),
+						srcTypeArr: [3]*sourcePrefixes{
+							{
+								srcPrefixMap: map[string]*sourcePrefixEntry{
+									"0.0.0.0/0": {
+										net: zeroIP,
+										srcPortMap: map[int]*FilterChain{
+											0: {},
+										},
+									},
+								},
+							},
+						},
+					},
+					"10.0.0.0/8": {
+						net: ipNetFromCIDR("10.0.0.0/8"),
+						srcTypeArr: [3]*sourcePrefixes{
+							{
+								srcPrefixMap: map[string]*sourcePrefixEntry{
+									"0.0.0.0/0": {
+										net: zeroIP,
+										srcPortMap: map[int]*FilterChain{
+											0: {},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				def:   &FilterChain{},
+				fcCnt: 3,
+			},
+		},
+		{
+			desc: "multiple source types",
+			lis: &v3listenerpb.Listener{
+				FilterChains: []*v3listenerpb.FilterChain{
+					{
+						FilterChainMatch: &v3listenerpb.FilterChainMatch{SourceType: v3listenerpb.FilterChainMatch_SAME_IP_OR_LOOPBACK},
+					},
+					{
+						FilterChainMatch: &v3listenerpb.FilterChainMatch{
+							PrefixRanges: []*v3corepb.CidrRange{cidrRangeFromAddressAndPrefixLen("192.168.1.1", 16)},
+							SourceType:   v3listenerpb.FilterChainMatch_EXTERNAL,
+						},
+					},
+				},
+				DefaultFilterChain: &v3listenerpb.FilterChain{},
+			},
+			wantFC: &FilterChainManager{
+				dstPrefixMap: map[string]*destPrefixEntry{
+					"0.0.0.0/0": {
+						net: zeroIP,
+						srcTypeArr: [3]*sourcePrefixes{
+							nil,
+							{
+								srcPrefixMap: map[string]*sourcePrefixEntry{
+									"0.0.0.0/0": {
+										net: zeroIP,
+										srcPortMap: map[int]*FilterChain{
+											0: {},
+										},
+									},
+								},
+							},
+						},
+					},
+					"192.168.0.0/16": {
+						net: ipNetFromCIDR("192.168.2.2/16"),
+						srcTypeArr: [3]*sourcePrefixes{
+							nil,
+							nil,
+							{
+								srcPrefixMap: map[string]*sourcePrefixEntry{
+									"0.0.0.0/0": {
+										net: zeroIP,
+										srcPortMap: map[int]*FilterChain{
+											0: {},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				def:   &FilterChain{},
+				fcCnt: 2,
+			},
+		},
+		{
+			desc: "multiple source prefixes",
+			lis: &v3listenerpb.Listener{
+				FilterChains: []*v3listenerpb.FilterChain{
+					{
+						FilterChainMatch: &v3listenerpb.FilterChainMatch{SourcePrefixRanges: []*v3corepb.CidrRange{cidrRangeFromAddressAndPrefixLen("10.0.0.0", 8)}},
+					},
+					{
+						FilterChainMatch: &v3listenerpb.FilterChainMatch{
+							PrefixRanges:       []*v3corepb.CidrRange{cidrRangeFromAddressAndPrefixLen("192.168.1.1", 16)},
+							SourcePrefixRanges: []*v3corepb.CidrRange{cidrRangeFromAddressAndPrefixLen("192.168.1.1", 16)},
+						},
+					},
+				},
+				DefaultFilterChain: &v3listenerpb.FilterChain{},
+			},
+			wantFC: &FilterChainManager{
+				dstPrefixMap: map[string]*destPrefixEntry{
+					"0.0.0.0/0": {
+						net: zeroIP,
+						srcTypeArr: [3]*sourcePrefixes{
+							{
+								srcPrefixMap: map[string]*sourcePrefixEntry{
+									"10.0.0.0/8": {
+										net: ipNetFromCIDR("10.0.0.0/8"),
+										srcPortMap: map[int]*FilterChain{
+											0: {},
+										},
+									},
+								},
+							},
+						},
+					},
+					"192.168.0.0/16": {
+						net: ipNetFromCIDR("192.168.2.2/16"),
+						srcTypeArr: [3]*sourcePrefixes{
+							{
+								srcPrefixMap: map[string]*sourcePrefixEntry{
+									"192.168.0.0/16": {
+										net: ipNetFromCIDR("192.168.0.0/16"),
+										srcPortMap: map[int]*FilterChain{
+											0: {},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				def:   &FilterChain{},
+				fcCnt: 2,
+			},
+		},
+		{
+			desc: "multiple source ports",
+			lis: &v3listenerpb.Listener{
+				FilterChains: []*v3listenerpb.FilterChain{
+					{
+						FilterChainMatch: &v3listenerpb.FilterChainMatch{SourcePorts: []uint32{1, 2, 3}},
+					},
+					{
+						FilterChainMatch: &v3listenerpb.FilterChainMatch{
+							PrefixRanges:       []*v3corepb.CidrRange{cidrRangeFromAddressAndPrefixLen("192.168.1.1", 16)},
+							SourcePrefixRanges: []*v3corepb.CidrRange{cidrRangeFromAddressAndPrefixLen("192.168.1.1", 16)},
+							SourceType:         v3listenerpb.FilterChainMatch_EXTERNAL,
+							SourcePorts:        []uint32{1, 2, 3},
+						},
+					},
+				},
+				DefaultFilterChain: &v3listenerpb.FilterChain{},
+			},
+			wantFC: &FilterChainManager{
+				dstPrefixMap: map[string]*destPrefixEntry{
+					"0.0.0.0/0": {
+						net: zeroIP,
+						srcTypeArr: [3]*sourcePrefixes{
+							{
+								srcPrefixMap: map[string]*sourcePrefixEntry{
+									"0.0.0.0/0": {
+										net: zeroIP,
+										srcPortMap: map[int]*FilterChain{
+											1: {},
+											2: {},
+											3: {},
+										},
+									},
+								},
+							},
+						},
+					},
+					"192.168.0.0/16": {
+						net: ipNetFromCIDR("192.168.2.2/16"),
+						srcTypeArr: [3]*sourcePrefixes{
+							nil,
+							nil,
+							{
+								srcPrefixMap: map[string]*sourcePrefixEntry{
+									"192.168.0.0/16": {
+										net: ipNetFromCIDR("192.168.0.0/16"),
+										srcPortMap: map[int]*FilterChain{
+											1: {},
+											2: {},
+											3: {},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				def:   &FilterChain{},
+				fcCnt: 2,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			gotFC, err := NewFilterChainManager(test.lis)
+			if err != nil {
+				t.Fatalf("NewFilterChainManager() returned err: %v, wantErr: nil", err)
+			}
+			if !cmp.Equal(gotFC, test.wantFC, cmp.AllowUnexported(FilterChainManager{}, destPrefixEntry{}, sourcePrefixes{}, sourcePrefixEntry{})) {
+				t.Fatalf("NewFilterChainManager() returned %+v, want: %+v", gotFC, test.wantFC)
+			}
+		})
+	}
+}
+
+func TestLookup_Failures(t *testing.T) {
+	tests := []struct {
+		desc    string
+		lis     *v3listenerpb.Listener
+		params  FilterChainLookupParams
+		wantErr string
+	}{
+		{
+			desc: "no destination prefix match",
+			lis: &v3listenerpb.Listener{
+				FilterChains: []*v3listenerpb.FilterChain{
+					{
+						FilterChainMatch: &v3listenerpb.FilterChainMatch{PrefixRanges: []*v3corepb.CidrRange{cidrRangeFromAddressAndPrefixLen("192.168.1.1", 16)}},
+					},
+				},
+			},
+			params: FilterChainLookupParams{
+				IsUnspecifiedListener: true,
+				DestAddr:              net.IPv4(10, 1, 1, 1),
+			},
+			wantErr: "no matching filter chain based on destination prefix match",
+		},
+		{
+			desc: "no source type match",
+			lis: &v3listenerpb.Listener{
+				FilterChains: []*v3listenerpb.FilterChain{
+					{
+						FilterChainMatch: &v3listenerpb.FilterChainMatch{
+							PrefixRanges: []*v3corepb.CidrRange{cidrRangeFromAddressAndPrefixLen("192.168.1.1", 16)},
+							SourceType:   v3listenerpb.FilterChainMatch_SAME_IP_OR_LOOPBACK,
+						},
+					},
+				},
+			},
+			params: FilterChainLookupParams{
+				IsUnspecifiedListener: true,
+				DestAddr:              net.IPv4(192, 168, 100, 1),
+				SourceAddr:            net.IPv4(192, 168, 100, 2),
+			},
+			wantErr: "no matching filter chain based on source type match",
+		},
+		{
+			desc: "no source prefix match",
+			lis: &v3listenerpb.Listener{
+				FilterChains: []*v3listenerpb.FilterChain{
+					{
+						FilterChainMatch: &v3listenerpb.FilterChainMatch{
+							SourcePrefixRanges: []*v3corepb.CidrRange{cidrRangeFromAddressAndPrefixLen("192.168.1.1", 24)},
+							SourceType:         v3listenerpb.FilterChainMatch_SAME_IP_OR_LOOPBACK,
+						},
+					},
+				},
+			},
+			params: FilterChainLookupParams{
+				IsUnspecifiedListener: true,
+				DestAddr:              net.IPv4(192, 168, 100, 1),
+				SourceAddr:            net.IPv4(192, 168, 100, 1),
+			},
+			wantErr: "no matching filter chain based on source prefix match",
+		},
+		{
+			desc: "multiple matching filter chains",
+			lis: &v3listenerpb.Listener{
+				FilterChains: []*v3listenerpb.FilterChain{
+					{
+						FilterChainMatch: &v3listenerpb.FilterChainMatch{SourcePorts: []uint32{1, 2, 3}},
+					},
+					{
+						FilterChainMatch: &v3listenerpb.FilterChainMatch{
+							PrefixRanges: []*v3corepb.CidrRange{cidrRangeFromAddressAndPrefixLen("192.168.1.1", 16)},
+							SourcePorts:  []uint32{1},
+						},
+					},
+				},
+			},
+			params: FilterChainLookupParams{
+				// IsUnspecified is not set. This means that the destination
+				// prefix matchers will be ignored.
+				DestAddr:   net.IPv4(192, 168, 100, 1),
+				SourceAddr: net.IPv4(192, 168, 100, 1),
+				SourcePort: 1,
+			},
+			wantErr: "multiple matching filter chains",
+		},
+		{
+			desc: "no default filter chain",
+			lis: &v3listenerpb.Listener{
+				FilterChains: []*v3listenerpb.FilterChain{
+					{
+						FilterChainMatch: &v3listenerpb.FilterChainMatch{SourcePorts: []uint32{1, 2, 3}},
+					},
+				},
+			},
+			params: FilterChainLookupParams{
+				DestAddr:   net.IPv4(192, 168, 100, 1),
+				SourceAddr: net.IPv4(192, 168, 100, 1),
+				SourcePort: 80,
+			},
+			wantErr: "no matching filter chain after all match criteria",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			fci, err := NewFilterChainManager(test.lis)
+			if err != nil {
+				t.Fatalf("NewFilterChainManager() failed: %v", err)
+			}
+			fc, err := fci.Lookup(test.params)
+			if err == nil || !strings.Contains(err.Error(), test.wantErr) {
+				t.Fatalf("FilterChainManager.Lookup(%v) = (%v, %v) want (nil, %s)", test.params, fc, err, test.wantErr)
+			}
+		})
+	}
+}
+
+func TestLookup_Successes(t *testing.T) {
+	lisWithDefaultChain := &v3listenerpb.Listener{
+		FilterChains: []*v3listenerpb.FilterChain{
+			{
+				FilterChainMatch: &v3listenerpb.FilterChainMatch{PrefixRanges: []*v3corepb.CidrRange{cidrRangeFromAddressAndPrefixLen("192.168.1.1", 16)}},
+				TransportSocket: &v3corepb.TransportSocket{
+					Name: "envoy.transport_sockets.tls",
+					ConfigType: &v3corepb.TransportSocket_TypedConfig{
+						TypedConfig: marshalAny(&v3tlspb.DownstreamTlsContext{
+							CommonTlsContext: &v3tlspb.CommonTlsContext{
+								TlsCertificateCertificateProviderInstance: &v3tlspb.CommonTlsContext_CertificateProviderInstance{InstanceName: "instance1"},
+							},
+						}),
+					},
+				},
+			},
+		},
+		// A default filter chain with an empty transport socket.
+		DefaultFilterChain: &v3listenerpb.FilterChain{
+			TransportSocket: &v3corepb.TransportSocket{
+				Name: "envoy.transport_sockets.tls",
+				ConfigType: &v3corepb.TransportSocket_TypedConfig{
+					TypedConfig: marshalAny(&v3tlspb.DownstreamTlsContext{
+						CommonTlsContext: &v3tlspb.CommonTlsContext{
+							TlsCertificateCertificateProviderInstance: &v3tlspb.CommonTlsContext_CertificateProviderInstance{InstanceName: "default"},
+						},
+					}),
+				},
+			},
+		},
+	}
+	lisWithoutDefaultChain := &v3listenerpb.Listener{
+		FilterChains: []*v3listenerpb.FilterChain{
+			{
+				TransportSocket: transportSocketWithInstanceName("wildcard"),
+			},
+			{
+				FilterChainMatch: &v3listenerpb.FilterChainMatch{
+					PrefixRanges: []*v3corepb.CidrRange{cidrRangeFromAddressAndPrefixLen("0.0.0.0", 0)},
+					SourceType:   v3listenerpb.FilterChainMatch_EXTERNAL,
+				},
+				TransportSocket: transportSocketWithInstanceName("any-destination-prefix"),
+			},
+			{
+				FilterChainMatch: &v3listenerpb.FilterChainMatch{PrefixRanges: []*v3corepb.CidrRange{cidrRangeFromAddressAndPrefixLen("192.168.1.1", 16)}},
+				TransportSocket:  transportSocketWithInstanceName("specific-destination-prefix-wildcard-source-type"),
+			},
+			{
+				FilterChainMatch: &v3listenerpb.FilterChainMatch{
+					PrefixRanges: []*v3corepb.CidrRange{cidrRangeFromAddressAndPrefixLen("192.168.1.1", 24)},
+					SourceType:   v3listenerpb.FilterChainMatch_EXTERNAL,
+				},
+				TransportSocket: transportSocketWithInstanceName("specific-destination-prefix-specific-source-type"),
+			},
+			{
+				FilterChainMatch: &v3listenerpb.FilterChainMatch{
+					PrefixRanges:       []*v3corepb.CidrRange{cidrRangeFromAddressAndPrefixLen("192.168.1.1", 24)},
+					SourcePrefixRanges: []*v3corepb.CidrRange{cidrRangeFromAddressAndPrefixLen("192.168.92.1", 24)},
+					SourceType:         v3listenerpb.FilterChainMatch_EXTERNAL,
+				},
+				TransportSocket: transportSocketWithInstanceName("specific-destination-prefix-specific-source-type-specific-source-prefix"),
+			},
+			{
+				FilterChainMatch: &v3listenerpb.FilterChainMatch{
+					PrefixRanges:       []*v3corepb.CidrRange{cidrRangeFromAddressAndPrefixLen("192.168.1.1", 24)},
+					SourcePrefixRanges: []*v3corepb.CidrRange{cidrRangeFromAddressAndPrefixLen("192.168.92.1", 24)},
+					SourceType:         v3listenerpb.FilterChainMatch_EXTERNAL,
+					SourcePorts:        []uint32{80},
+				},
+				TransportSocket: transportSocketWithInstanceName("specific-destination-prefix-specific-source-type-specific-source-prefix-specific-source-port"),
+			},
+		},
+	}
+
+	tests := []struct {
+		desc   string
+		lis    *v3listenerpb.Listener
+		params FilterChainLookupParams
+		wantFC *FilterChain
+	}{
+		{
+			desc: "default filter chain",
+			lis:  lisWithDefaultChain,
+			params: FilterChainLookupParams{
+				IsUnspecifiedListener: true,
+				DestAddr:              net.IPv4(10, 1, 1, 1),
+			},
+			wantFC: &FilterChain{SecurityCfg: &SecurityConfig{IdentityInstanceName: "default"}},
+		},
+		{
+			desc: "wildcard destination match",
+			lis:  lisWithoutDefaultChain,
+			params: FilterChainLookupParams{
+				IsUnspecifiedListener: true,
+				DestAddr:              net.IPv4(10, 1, 1, 1),
+				SourceAddr:            net.IPv4(10, 1, 1, 1),
+				SourcePort:            1,
+			},
+			wantFC: &FilterChain{SecurityCfg: &SecurityConfig{IdentityInstanceName: "wildcard"}},
+		},
+		{
+			desc: "ANY destination match",
+			lis:  lisWithoutDefaultChain,
+			params: FilterChainLookupParams{
+				IsUnspecifiedListener: true,
+				DestAddr:              net.IPv4(10, 1, 1, 1),
+				SourceAddr:            net.IPv4(10, 1, 1, 2),
+				SourcePort:            1,
+			},
+			wantFC: &FilterChain{SecurityCfg: &SecurityConfig{IdentityInstanceName: "any-destination-prefix"}},
+		},
+		{
+			desc: "specific destination and wildcard source type match",
+			lis:  lisWithoutDefaultChain,
+			params: FilterChainLookupParams{
+				IsUnspecifiedListener: true,
+				DestAddr:              net.IPv4(192, 168, 100, 1),
+				SourceAddr:            net.IPv4(192, 168, 100, 1),
+				SourcePort:            80,
+			},
+			wantFC: &FilterChain{SecurityCfg: &SecurityConfig{IdentityInstanceName: "specific-destination-prefix-wildcard-source-type"}},
+		},
+		{
+			desc: "specific destination and source type match",
+			lis:  lisWithoutDefaultChain,
+			params: FilterChainLookupParams{
+				IsUnspecifiedListener: true,
+				DestAddr:              net.IPv4(192, 168, 1, 1),
+				SourceAddr:            net.IPv4(10, 1, 1, 1),
+				SourcePort:            80,
+			},
+			wantFC: &FilterChain{SecurityCfg: &SecurityConfig{IdentityInstanceName: "specific-destination-prefix-specific-source-type"}},
+		},
+		{
+			desc: "specific destination source type and source prefix",
+			lis:  lisWithoutDefaultChain,
+			params: FilterChainLookupParams{
+				IsUnspecifiedListener: true,
+				DestAddr:              net.IPv4(192, 168, 1, 1),
+				SourceAddr:            net.IPv4(192, 168, 92, 100),
+				SourcePort:            70,
+			},
+			wantFC: &FilterChain{SecurityCfg: &SecurityConfig{IdentityInstanceName: "specific-destination-prefix-specific-source-type-specific-source-prefix"}},
+		},
+		{
+			desc: "specific destination source type source prefix and source port",
+			lis:  lisWithoutDefaultChain,
+			params: FilterChainLookupParams{
+				IsUnspecifiedListener: true,
+				DestAddr:              net.IPv4(192, 168, 1, 1),
+				SourceAddr:            net.IPv4(192, 168, 92, 100),
+				SourcePort:            80,
+			},
+			wantFC: &FilterChain{SecurityCfg: &SecurityConfig{IdentityInstanceName: "specific-destination-prefix-specific-source-type-specific-source-prefix-specific-source-port"}},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			fci, err := NewFilterChainManager(test.lis)
+			if err != nil {
+				t.Fatalf("NewFilterChainManager() failed: %v", err)
+			}
+			gotFC, err := fci.Lookup(test.params)
+			if err != nil {
+				t.Fatalf("FilterChainManager.Lookup(%v) failed: %v", test.params, err)
+			}
+			if !cmp.Equal(gotFC, test.wantFC) {
+				t.Fatalf("FilterChainManager.Lookup(%v) = %v, want %v", test.params, gotFC, test.wantFC)
+			}
+		})
+	}
+}
+
+// The Equal() methods defined below help with using cmp.Equal() on these types
+// which contain all unexported fields.
+
+func (fci *FilterChainManager) Equal(other *FilterChainManager) bool {
+	if (fci == nil) != (other == nil) {
+		return false
+	}
+	if fci == nil {
+		return true
+	}
+	switch {
+	case !cmp.Equal(fci.dstPrefixMap, other.dstPrefixMap):
+		return false
+	case !cmp.Equal(fci.def, other.def):
+		return false
+	case fci.fcCnt != other.fcCnt:
+		return false
+	}
+	return true
+}
+
+func (dpe *destPrefixEntry) Equal(other *destPrefixEntry) bool {
+	if (dpe == nil) != (other == nil) {
+		return false
+	}
+	if dpe == nil {
+		return true
+	}
+	if !cmp.Equal(dpe.net, other.net) {
+		return false
+	}
+	for i, st := range dpe.srcTypeArr {
+		if !cmp.Equal(st, other.srcTypeArr[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func (sp *sourcePrefixes) Equal(other *sourcePrefixes) bool {
+	if (sp == nil) != (other == nil) {
+		return false
+	}
+	if sp == nil {
+		return true
+	}
+	return cmp.Equal(sp.srcPrefixMap, other.srcPrefixMap)
+}
+
+func (spe *sourcePrefixEntry) Equal(other *sourcePrefixEntry) bool {
+	if (spe == nil) != (other == nil) {
+		return false
+	}
+	if spe == nil {
+		return true
+	}
+	switch {
+	case !cmp.Equal(spe.net, other.net):
+		return false
+	case !cmp.Equal(spe.srcPortMap, other.srcPortMap):
+		return false
+	}
+	return true
+}
+
+// The String() methods defined below help with debugging test failures as the
+// regular %v or %+v formatting directives do not expands pointer fields inside
+// structs, and these types have a lot of pointers pointing to other structs.
+func (fci *FilterChainManager) String() string {
+	if fci == nil {
+		return ""
+	}
+
+	var sb strings.Builder
+	if fci.dstPrefixMap != nil {
+		sb.WriteString("destination_prefix_map: map {\n")
+		for k, v := range fci.dstPrefixMap {
+			sb.WriteString(fmt.Sprintf("%q: %v\n", k, v))
+		}
+		sb.WriteString("}\n")
+	}
+	if fci.dstPrefixes != nil {
+		sb.WriteString("destination_prefixes: [")
+		for _, p := range fci.dstPrefixes {
+			sb.WriteString(fmt.Sprintf("%v ", p))
+		}
+		sb.WriteString("]")
+	}
+	if fci.def != nil {
+		sb.WriteString(fmt.Sprintf("default_filter_chain: %+v ", fci.def))
+	}
+	sb.WriteString(fmt.Sprintf("filter_chain_count: %d ", fci.fcCnt))
+	return sb.String()
+}
+
+func (dpe *destPrefixEntry) String() string {
+	if dpe == nil {
+		return ""
+	}
+	var sb strings.Builder
+	if dpe.net != nil {
+		sb.WriteString(fmt.Sprintf("destination_prefix: %s ", dpe.net.String()))
+	}
+	sb.WriteString("source_types_array: [")
+	for _, st := range dpe.srcTypeArr {
+		sb.WriteString(fmt.Sprintf("%v ", st))
+	}
+	sb.WriteString("]")
+	return sb.String()
+}
+
+func (sp *sourcePrefixes) String() string {
+	if sp == nil {
+		return ""
+	}
+	var sb strings.Builder
+	if sp.srcPrefixMap != nil {
+		sb.WriteString("source_prefix_map: map {")
+		for k, v := range sp.srcPrefixMap {
+			sb.WriteString(fmt.Sprintf("%q: %v ", k, v))
+		}
+		sb.WriteString("}")
+	}
+	if sp.srcPrefixes != nil {
+		sb.WriteString("source_prefixes: [")
+		for _, p := range sp.srcPrefixes {
+			sb.WriteString(fmt.Sprintf("%v ", p))
+		}
+		sb.WriteString("]")
+	}
+	return sb.String()
+}
+
+func (spe *sourcePrefixEntry) String() string {
+	if spe == nil {
+		return ""
+	}
+	var sb strings.Builder
+	if spe.net != nil {
+		sb.WriteString(fmt.Sprintf("source_prefix: %s ", spe.net.String()))
+	}
+	if spe.srcPortMap != nil {
+		sb.WriteString("source_ports_map: map {")
+		for k, v := range spe.srcPortMap {
+			sb.WriteString(fmt.Sprintf("%d: %+v ", k, v))
+		}
+		sb.WriteString("}")
+	}
+	return sb.String()
+}
+
+func (f *FilterChain) String() string {
+	if f == nil || f.SecurityCfg == nil {
+		return ""
+	}
+	return fmt.Sprintf("security_config: %v", f.SecurityCfg)
+}
+
+func ipNetFromCIDR(cidr string) *net.IPNet {
+	_, ipnet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		panic(err)
+	}
+	return ipnet
+}
+
+func transportSocketWithInstanceName(name string) *v3corepb.TransportSocket {
+	return &v3corepb.TransportSocket{
+		Name: "envoy.transport_sockets.tls",
+		ConfigType: &v3corepb.TransportSocket_TypedConfig{
+			TypedConfig: marshalAny(&v3tlspb.DownstreamTlsContext{
+				CommonTlsContext: &v3tlspb.CommonTlsContext{
+					TlsCertificateCertificateProviderInstance: &v3tlspb.CommonTlsContext_CertificateProviderInstance{InstanceName: name},
+				},
+			}),
+		},
+	}
+}
+
+func cidrRangeFromAddressAndPrefixLen(address string, len int) *v3corepb.CidrRange {
+	return &v3corepb.CidrRange{
+		AddressPrefix: address,
+		PrefixLen: &wrapperspb.UInt32Value{
+			Value: uint32(len),
+		},
+	}
+}

--- a/xds/internal/client/filter_chain_test.go
+++ b/xds/internal/client/filter_chain_test.go
@@ -895,7 +895,7 @@ func TestLookup_Failures(t *testing.T) {
 				DestAddr:              net.IPv4(192, 168, 100, 1),
 				SourceAddr:            net.IPv4(192, 168, 100, 1),
 			},
-			wantErr: "no matching filter chain based on source prefix match",
+			wantErr: "no matching filter chain after all match criteria",
 		},
 		{
 			desc: "multiple matching filter chains",

--- a/xds/internal/server/listener_wrapper.go
+++ b/xds/internal/server/listener_wrapper.go
@@ -179,13 +179,15 @@ func (l *listenerWrapper) Accept() (net.Conn, error) {
 
 		// Since the net.Conn represents an incoming connection, the source and
 		// destination address can be retrieved from the local address and
-		// remote address of the net.Conn respectively. If the incoming
-		// connection is not a TCP connection, we close it and move on.
+		// remote address of the net.Conn respectively.
 		destAddr, ok1 := conn.LocalAddr().(*net.TCPAddr)
 		srcAddr, ok2 := conn.RemoteAddr().(*net.TCPAddr)
 		if !ok1 || !ok2 {
-			conn.Close()
-			continue
+			// If the incoming connection is not a TCP connection, which is
+			// really unexpected since we check whether the provided listener is
+			// a TCP listener in Serve(), we return an error which would cause
+			// us to stop serving.
+			return nil, fmt.Errorf("received connection with non-TCP address (local: %T, remote %T)", conn.LocalAddr(), conn.RemoteAddr())
 		}
 
 		l.mu.RLock()

--- a/xds/internal/server/listener_wrapper.go
+++ b/xds/internal/server/listener_wrapper.go
@@ -184,12 +184,15 @@ func (l *listenerWrapper) Accept() (net.Conn, error) {
 		// listeners in Serve(), we can safely type assert here.
 		destAddr := conn.LocalAddr().(*net.TCPAddr).IP
 		srcAddr := conn.RemoteAddr().(*net.TCPAddr)
+
+		l.mu.RLock()
 		fc, err := l.filterChains.Lookup(xdsclient.FilterChainLookupParams{
 			IsUnspecifiedListener: l.isUnspecifiedAddr,
 			DestAddr:              destAddr,
 			SourceAddr:            srcAddr.IP,
 			SourcePort:            srcAddr.Port,
 		})
+		l.mu.RUnlock()
 		if err != nil {
 			// When a matching filter chain is not found, we close the
 			// connection right away, but do not return an error back to

--- a/xds/internal/server/listener_wrapper_test.go
+++ b/xds/internal/server/listener_wrapper_test.go
@@ -1,0 +1,335 @@
+/*
+ *
+ * Copyright 2021 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package server
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"strconv"
+	"testing"
+	"time"
+
+	v3corepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	v3listenerpb "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	v3tlspb "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
+	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/ptypes"
+	anypb "github.com/golang/protobuf/ptypes/any"
+	wrapperspb "github.com/golang/protobuf/ptypes/wrappers"
+	"google.golang.org/grpc/internal/grpctest"
+	"google.golang.org/grpc/internal/testutils"
+	xdsclient "google.golang.org/grpc/xds/internal/client"
+	"google.golang.org/grpc/xds/internal/testutils/fakeclient"
+)
+
+const (
+	fakeListenerHost         = "0.0.0.0"
+	fakeListenerPort         = 50051
+	testListenerResourceName = "lds.target.1.2.3.4:1111"
+	defaultTestTimeout       = 1 * time.Second
+	defaultTestShortTimeout  = 10 * time.Millisecond
+)
+
+var listenerWithFilterChains = &v3listenerpb.Listener{
+	FilterChains: []*v3listenerpb.FilterChain{
+		{
+			FilterChainMatch: &v3listenerpb.FilterChainMatch{
+				PrefixRanges: []*v3corepb.CidrRange{
+					{
+						AddressPrefix: "192.168.0.0",
+						PrefixLen: &wrapperspb.UInt32Value{
+							Value: uint32(16),
+						},
+					},
+				},
+				SourceType: v3listenerpb.FilterChainMatch_SAME_IP_OR_LOOPBACK,
+				SourcePrefixRanges: []*v3corepb.CidrRange{
+					{
+						AddressPrefix: "192.168.0.0",
+						PrefixLen: &wrapperspb.UInt32Value{
+							Value: uint32(16),
+						},
+					},
+				},
+				SourcePorts: []uint32{80},
+			},
+			TransportSocket: &v3corepb.TransportSocket{
+				Name: "envoy.transport_sockets.tls",
+				ConfigType: &v3corepb.TransportSocket_TypedConfig{
+					TypedConfig: marshalAny(&v3tlspb.DownstreamTlsContext{
+						CommonTlsContext: &v3tlspb.CommonTlsContext{
+							TlsCertificateCertificateProviderInstance: &v3tlspb.CommonTlsContext_CertificateProviderInstance{
+								InstanceName:    "identityPluginInstance",
+								CertificateName: "identityCertName",
+							},
+						},
+					}),
+				},
+			},
+		},
+	},
+}
+
+type s struct {
+	grpctest.Tester
+}
+
+func Test(t *testing.T) {
+	grpctest.RunSubTests(t, s{})
+}
+
+type tempError struct{}
+
+func (tempError) Error() string {
+	return "listenerWrapper test temporary error"
+}
+
+func (tempError) Temporary() bool {
+	return true
+}
+
+// connAndErr wraps a net.Conn and an error.
+type connAndErr struct {
+	conn net.Conn
+	err  error
+}
+
+// fakeListener allows the user to inject conns returned by Accept().
+type fakeListener struct {
+	acceptCh chan connAndErr
+	closeCh  *testutils.Channel
+}
+
+func (fl *fakeListener) Accept() (net.Conn, error) {
+	cne := <-fl.acceptCh
+	return cne.conn, cne.err
+}
+
+func (fl *fakeListener) Close() error {
+	fl.closeCh.Send(nil)
+	return nil
+}
+
+func (fl *fakeListener) Addr() net.Addr {
+	return &net.TCPAddr{
+		IP:   net.IPv4(0, 0, 0, 0),
+		Port: fakeListenerPort,
+	}
+}
+
+// fakeConn overrides LocalAddr, RemoteAddr and Close methods.
+type fakeConn struct {
+	net.Conn
+	local, remote net.Addr
+	closeCh       *testutils.Channel
+}
+
+func (fc *fakeConn) LocalAddr() net.Addr {
+	return fc.local
+}
+
+func (fc *fakeConn) RemoteAddr() net.Addr {
+	return fc.remote
+}
+
+func (fc *fakeConn) Close() error {
+	fc.closeCh.Send(nil)
+	return nil
+}
+
+func newListenerWrapper(t *testing.T) (*listenerWrapper, <-chan struct{}, *fakeclient.Client, *fakeListener, func()) {
+	t.Helper()
+
+	// Create a listener wrapper with a fake listener and fake xdsClient and
+	// verify that it extracts the host and port from the passed in listener.
+	lis := &fakeListener{
+		acceptCh: make(chan connAndErr, 1),
+		closeCh:  testutils.NewChannel(),
+	}
+	xdsC := fakeclient.NewClient()
+	lParams := ListenerWrapperParams{
+		Listener:             lis,
+		ListenerResourceName: testListenerResourceName,
+		XDSClient:            xdsC,
+	}
+	l, readyCh := NewListenerWrapper(lParams)
+	if l == nil {
+		t.Fatalf("NewListenerWrapper(%+v) returned nil", lParams)
+	}
+	lw, ok := l.(*listenerWrapper)
+	if !ok {
+		t.Fatalf("NewListenerWrapper(%+v) returned listener of type %T want *listenerWrapper", lParams, l)
+	}
+	if lw.addr != fakeListenerHost || lw.port != strconv.Itoa(fakeListenerPort) {
+		t.Fatalf("listenerWrapper has host:port %s:%s, want %s:%d", lw.addr, lw.port, fakeListenerHost, fakeListenerPort)
+	}
+	return lw, readyCh, xdsC, lis, func() { l.Close() }
+}
+
+func (s) TestNewListenerWrapper(t *testing.T) {
+	_, readyCh, xdsC, _, cleanup := newListenerWrapper(t)
+	defer cleanup()
+
+	// Verify that the listener wrapper registers a listener watch for the
+	// expected Listener resource name.
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	name, err := xdsC.WaitForWatchListener(ctx)
+	if err != nil {
+		t.Fatalf("error when waiting for a watch on a Listener resource: %v", err)
+	}
+	if name != testListenerResourceName {
+		t.Fatalf("listenerWrapper registered a watch on %s, want %s", name, testListenerResourceName)
+	}
+
+	// Push an error to the listener update handler.
+	xdsC.InvokeWatchListenerCallback(xdsclient.ListenerUpdate{}, errors.New("bad listener update"))
+	timer := time.NewTimer(defaultTestShortTimeout)
+	select {
+	case <-timer.C:
+		timer.Stop()
+	case <-readyCh:
+		t.Fatalf("ready channel written to after receipt of a bad Listener update")
+	}
+
+	// Push an update whose address does not match the address to which our
+	// listener is bound, and verify that the ready channel is not written to.
+	xdsC.InvokeWatchListenerCallback(xdsclient.ListenerUpdate{
+		InboundListenerCfg: &xdsclient.InboundListenerConfig{
+			Address: "10.0.0.1",
+			Port:    "50051",
+		}}, nil)
+	timer = time.NewTimer(defaultTestShortTimeout)
+	select {
+	case <-timer.C:
+		timer.Stop()
+	case <-readyCh:
+		t.Fatalf("ready channel written to after receipt of a bad Listener update")
+	}
+
+	// Push a good update, and verify that the ready channel is written to.
+	xdsC.InvokeWatchListenerCallback(xdsclient.ListenerUpdate{
+		InboundListenerCfg: &xdsclient.InboundListenerConfig{
+			Address: fakeListenerHost,
+			Port:    strconv.Itoa(fakeListenerPort),
+		}}, nil)
+	select {
+	case <-ctx.Done():
+		t.Fatalf("timeout waiting for the ready channel to be written to after receipt of a good Listener update")
+	case <-readyCh:
+	}
+}
+
+func (s) TestListenerWrapper_Accept(t *testing.T) {
+	boCh := testutils.NewChannel()
+	origBackoffFunc := backoffFunc
+	backoffFunc = func(v int) time.Duration {
+		boCh.Send(v)
+		return 0
+	}
+	defer func() { backoffFunc = origBackoffFunc }()
+
+	lw, readyCh, xdsC, lis, cleanup := newListenerWrapper(t)
+	defer cleanup()
+
+	// Push a good update with a filter chain which accepts local connections on
+	// 192.168.0.0/16 subnet and port 80.
+	fcm, err := xdsclient.NewFilterChainManager(listenerWithFilterChains)
+	if err != nil {
+		t.Fatalf("xdsclient.NewFilterChainManager() failed with error: %v", err)
+	}
+	xdsC.InvokeWatchListenerCallback(xdsclient.ListenerUpdate{
+		InboundListenerCfg: &xdsclient.InboundListenerConfig{
+			Address:      fakeListenerHost,
+			Port:         strconv.Itoa(fakeListenerPort),
+			FilterChains: fcm,
+		}}, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	select {
+	case <-ctx.Done():
+		t.Fatalf("timeout waiting for the ready channel to be written to after receipt of a good Listener update")
+	case <-readyCh:
+	}
+
+	// Push a non-temporary error into Accept().
+	nonTempErr := errors.New("a non-temporary error")
+	lis.acceptCh <- connAndErr{err: nonTempErr}
+	if _, err := lw.Accept(); err != nonTempErr {
+		t.Fatalf("listenerWrapper.Accept() returned error: %v, want: %v", err, nonTempErr)
+	}
+
+	// Invoke Accept() in a goroutine since we expect it to swallow:
+	// 1. temporary errors returned from the underlying listener
+	// 2. errors related to finding a matching filter chain for the incoming
+	// 	  connection.
+	errCh := testutils.NewChannel()
+	go func() {
+		conn, err := lw.Accept()
+		if err != nil {
+			errCh.Send(err)
+			return
+		}
+		if _, ok := conn.(*connWrapper); !ok {
+			errCh.Send(errors.New("listenerWrapper.Accept() returned a Conn of type %T, want *connWrapper"))
+			return
+		}
+		errCh.Send(nil)
+	}()
+
+	// Push a temporary error into Accept() and verify that it backs off.
+	lis.acceptCh <- connAndErr{err: tempError{}}
+	if _, err := boCh.Receive(ctx); err != nil {
+		t.Fatalf("error when waiting for Accept() to backoff on temporary errors: %v", err)
+	}
+
+	// Push a fakeConn which does not match any filter chains configured on the
+	// received Listener resource. Verify that the conn is closed.
+	fc := &fakeConn{
+		local:   &net.TCPAddr{IP: net.IPv4(192, 168, 1, 2), Port: 79},
+		remote:  &net.TCPAddr{IP: net.IPv4(10, 1, 1, 1), Port: 80},
+		closeCh: testutils.NewChannel(),
+	}
+	lis.acceptCh <- connAndErr{conn: fc}
+	if _, err := fc.closeCh.Receive(ctx); err != nil {
+		t.Fatalf("error when waiting for conn to be closed on no filter chain match: %v", err)
+	}
+
+	// Push a fakeConn which matches the filter chains configured on the
+	// received Listener resource. Verify that Accept() returns.
+	fc = &fakeConn{
+		local:   &net.TCPAddr{IP: net.IPv4(192, 168, 1, 2)},
+		remote:  &net.TCPAddr{IP: net.IPv4(192, 168, 1, 2), Port: 80},
+		closeCh: testutils.NewChannel(),
+	}
+	lis.acceptCh <- connAndErr{conn: fc}
+	if _, err := errCh.Receive(ctx); err != nil {
+		t.Fatalf("error when waiting for Accept() to return the conn on filter chain match: %v", err)
+	}
+}
+
+func marshalAny(m proto.Message) *anypb.Any {
+	a, err := ptypes.MarshalAny(m)
+	if err != nil {
+		panic(fmt.Sprintf("ptypes.MarshalAny(%+v) failed: %v", m, err))
+	}
+	return a
+}

--- a/xds/internal/test/xds_server_integration_test.go
+++ b/xds/internal/test/xds_server_integration_test.go
@@ -252,6 +252,25 @@ func listenerResourceWithSecurityConfig(t *testing.T, lis net.Listener) *v3liste
 		FilterChains: []*v3listenerpb.FilterChain{
 			{
 				Name: "filter-chain-1",
+				FilterChainMatch: &v3listenerpb.FilterChainMatch{
+					PrefixRanges: []*v3corepb.CidrRange{
+						{
+							AddressPrefix: "0.0.0.0",
+							PrefixLen: &wrapperspb.UInt32Value{
+								Value: uint32(0),
+							},
+						},
+					},
+					SourceType: v3listenerpb.FilterChainMatch_SAME_IP_OR_LOOPBACK,
+					SourcePrefixRanges: []*v3corepb.CidrRange{
+						{
+							AddressPrefix: "0.0.0.0",
+							PrefixLen: &wrapperspb.UInt32Value{
+								Value: uint32(0),
+							},
+						},
+					},
+				},
 				TransportSocket: &v3corepb.TransportSocket{
 					Name: "envoy.transport_sockets.tls",
 					ConfigType: &v3corepb.TransportSocket_TypedConfig{


### PR DESCRIPTION
`xds/internal/client` changes
- Implement a `FilterChainManager` type which provides functionality to parse filter chains from incoming `Listener` resources, and lookup matching filter chains at connection time.
- `ListenerUpdate` will no longer carry the filter chain match criteria. It will carry the above `FilterChainManager` whose `Lookup()` method will be used at connection time to match filter chains.
- Logic to identify filter chains which contain overlapping match criteria and NACK such resources.

`xds/internal/server` changes:
- Check whether the address specified in a `ListenerUpdate` matches the one to which the underlying `net.Listener` is bound to.
- Teach `Accept()` to handle certain classes of errors, and drop connections on filter chain match failures.
- `FilterChainManager.Lookup()` is used by `listener_wrapper` to find the matching filter chain and the same is handed over to the `conn_wrapper` to retrieve security configuration at connection handshake time

A whole lot of new tests and additions to existing tests.

#psm-security-server-side-filter-support

