### PR TITLE
interop: add a flag to clients to statically configure grpclb

### DIFF
--- a/interop/client/client.go
+++ b/interop/client/client.go
@@ -185,8 +185,7 @@ func main() {
 		}
 	}
 	if len(*serviceConfigJSON) > 0 {
-		opts = append(opts, grpc.WithDisableServiceConfig())
-		opts = append(opts, grpc.WithDefaultServiceConfig(*serviceConfigJSON))
+		opts = append(opts, grpc.WithDisableServiceConfig(), grpc.WithDefaultServiceConfig(*serviceConfigJSON))
 	}
 	opts = append(opts, grpc.WithBlock())
 	conn, err := grpc.Dial(serverAddr, opts...)

--- a/interop/client/client.go
+++ b/interop/client/client.go
@@ -55,7 +55,7 @@ var (
 	defaultServiceAccount = flag.String("default_service_account", "", "Email of GCE default service account")
 	serverHost            = flag.String("server_host", "localhost", "The server host name")
 	serverPort            = flag.Int("server_port", 10000, "The server port number")
-	serviceConfigJson     = flag.String("service_config_json", "", "Disables service config lookups and sets the provided string as the default service config.")
+	serviceConfigJSON     = flag.String("service_config_json", "", "Disables service config lookups and sets the provided string as the default service config.")
 	tlsServerName         = flag.String("server_host_override", "", "The server name use to verify the hostname returned by TLS handshake if it is not empty. Otherwise, --server_host is used.")
 	testCase              = flag.String("test_case", "large_unary",
 		`Configure different test cases. Valid options are:
@@ -184,9 +184,9 @@ func main() {
 			opts = append(opts, grpc.WithPerRPCCredentials(oauth.NewOauthAccess(interop.GetToken(*serviceAccountKeyFile, *oauthScope))))
 		}
 	}
-	if len(*serviceConfigJson) > 0 {
+	if len(*serviceConfigJSON) > 0 {
 		opts = append(opts, grpc.WithDisableServiceConfig())
-		opts = append(opts, grpc.WithDefaultServiceConfig(*serviceConfigJson))
+		opts = append(opts, grpc.WithDefaultServiceConfig(*serviceConfigJSON))
 	}
 	opts = append(opts, grpc.WithBlock())
 	conn, err := grpc.Dial(serverAddr, opts...)

--- a/interop/client/client.go
+++ b/interop/client/client.go
@@ -55,6 +55,7 @@ var (
 	defaultServiceAccount = flag.String("default_service_account", "", "Email of GCE default service account")
 	serverHost            = flag.String("server_host", "localhost", "The server host name")
 	serverPort            = flag.Int("server_port", 10000, "The server port number")
+	serviceConfigJson     = flag.String("service_config_json", "", "Disables service config lookups and sets the provided string as the default service config.")
 	tlsServerName         = flag.String("server_host_override", "", "The server name use to verify the hostname returned by TLS handshake if it is not empty. Otherwise, --server_host is used.")
 	testCase              = flag.String("test_case", "large_unary",
 		`Configure different test cases. Valid options are:
@@ -182,6 +183,10 @@ func main() {
 		} else if *testCase == "oauth2_auth_token" {
 			opts = append(opts, grpc.WithPerRPCCredentials(oauth.NewOauthAccess(interop.GetToken(*serviceAccountKeyFile, *oauthScope))))
 		}
+	}
+	if len(*serviceConfigJson) > 0 {
+		opts = append(opts, grpc.WithDisableServiceConfig())
+		opts = append(opts, grpc.WithDefaultServiceConfig(*serviceConfigJson))
 	}
 	opts = append(opts, grpc.WithBlock())
 	conn, err := grpc.Dial(serverAddr, opts...)


### PR DESCRIPTION
This is a go analogue of https://github.com/grpc/grpc-java/pull/7957 - https://github.com/grpc/grpc-java/pull/7957#issue-590133307 for more context