### PR TITLE
Allow using interop client for making Traffic Director RPCs

### DIFF
--- a/interop/client/client.go
+++ b/interop/client/client.go
@@ -126,7 +126,10 @@ func main() {
 	}
 
 	resolver.SetDefaultScheme("dns")
-	serverAddr := net.JoinHostPort(*serverHost, strconv.Itoa(*serverPort))
+	serverAddr := *serverHost
+	if *serverPort != 0 {
+		serverAddr = net.JoinHostPort(*serverHost, strconv.Itoa(*serverPort))
+	}
 	var opts []grpc.DialOption
 	switch credsChosen {
 	case credsTLS:

--- a/interop/client/client.go
+++ b/interop/client/client.go
@@ -34,6 +34,7 @@ import (
 	"google.golang.org/grpc/interop"
 	"google.golang.org/grpc/resolver"
 	"google.golang.org/grpc/testdata"
+	_ "google.golang.org/grpc/xds/googledirectpath"
 
 	testgrpc "google.golang.org/grpc/interop/grpc_testing"
 )


### PR DESCRIPTION
This is needed to allow the interop client to be used with Traffic Director load balancing

The behavior of allowing a server_port of zero to mean "no port" was added to the C++ interop client in https://github.com/grpc/grpc/pull/25550 and to the Java interop client in https://github.com/grpc/grpc-java/pull/7994