### PR TITLE
weightedtarget: handle updating child policy name

### DIFF
--- a/xds/internal/balancer/weightedtarget/weightedtarget_config_test.go
+++ b/xds/internal/balancer/weightedtarget/weightedtarget_config_test.go
@@ -25,7 +25,7 @@ import (
 	"google.golang.org/grpc/balancer"
 	internalserviceconfig "google.golang.org/grpc/internal/serviceconfig"
 
-	_ "google.golang.org/grpc/xds/internal/balancer/lrs"
+	_ "google.golang.org/grpc/xds/internal/balancer/lrs" // Register LRS balancer, so we can use it as child policy in the config tests.
 )
 
 const (

--- a/xds/internal/balancer/weightedtarget/weightedtarget_config_test.go
+++ b/xds/internal/balancer/weightedtarget/weightedtarget_config_test.go
@@ -24,7 +24,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/grpc/balancer"
 	internalserviceconfig "google.golang.org/grpc/internal/serviceconfig"
-	_ "google.golang.org/grpc/xds/internal/balancer/cdsbalancer"
+
+	_ "google.golang.org/grpc/xds/internal/balancer/lrs"
 )
 
 const (
@@ -32,24 +33,23 @@ const (
   "targets": {
 	"cluster_1" : {
 	  "weight":75,
-	  "childPolicy":[{"cds_experimental":{"cluster":"cluster_1"}}]
+	  "childPolicy":[{"lrs_experimental":{"clusterName":"cluster_1","lrsLoadReportingServerName":"lrs.server","locality":{"zone":"test-zone-1"}}}]
 	},
 	"cluster_2" : {
 	  "weight":25,
-	  "childPolicy":[{"cds_experimental":{"cluster":"cluster_2"}}]
+	  "childPolicy":[{"lrs_experimental":{"clusterName":"cluster_2","lrsLoadReportingServerName":"lrs.server","locality":{"zone":"test-zone-2"}}}]
 	}
   }
 }`
-
-	cdsName = "cds_experimental"
+	lrsBalancerName = "lrs_experimental"
 )
 
 var (
-	cdsConfigParser = balancer.Get(cdsName).(balancer.ConfigParser)
-	cdsConfigJSON1  = `{"cluster":"cluster_1"}`
-	cdsConfig1, _   = cdsConfigParser.ParseConfig([]byte(cdsConfigJSON1))
-	cdsConfigJSON2  = `{"cluster":"cluster_2"}`
-	cdsConfig2, _   = cdsConfigParser.ParseConfig([]byte(cdsConfigJSON2))
+	lrsConfigParser = balancer.Get(lrsBalancerName).(balancer.ConfigParser)
+	lrsConfigJSON1  = `{"clusterName":"cluster_1","lrsLoadReportingServerName":"lrs.server","locality":{"zone":"test-zone-1"}}`
+	lrsConfig1, _   = lrsConfigParser.ParseConfig([]byte(lrsConfigJSON1))
+	lrsConfigJSON2  = `{"clusterName":"cluster_2","lrsLoadReportingServerName":"lrs.server","locality":{"zone":"test-zone-2"}}`
+	lrsConfig2, _   = lrsConfigParser.ParseConfig([]byte(lrsConfigJSON2))
 )
 
 func Test_parseConfig(t *testing.T) {
@@ -73,15 +73,15 @@ func Test_parseConfig(t *testing.T) {
 					"cluster_1": {
 						Weight: 75,
 						ChildPolicy: &internalserviceconfig.BalancerConfig{
-							Name:   cdsName,
-							Config: cdsConfig1,
+							Name:   lrsBalancerName,
+							Config: lrsConfig1,
 						},
 					},
 					"cluster_2": {
 						Weight: 25,
 						ChildPolicy: &internalserviceconfig.BalancerConfig{
-							Name:   cdsName,
-							Config: cdsConfig2,
+							Name:   lrsBalancerName,
+							Config: lrsConfig2,
 						},
 					},
 				},

--- a/xds/internal/balancer/weightedtarget/weightedtarget_test.go
+++ b/xds/internal/balancer/weightedtarget/weightedtarget_test.go
@@ -215,6 +215,46 @@ func TestWeightedTarget(t *testing.T) {
 	if err := testutils.IsRoundRobin(want, subConnFromPicker(p2)); err != nil {
 		t.Fatalf("want %v, got %v", want, err)
 	}
+
+	// Replace child policy of "cluster_1" to "round_robin".
+	config3, err := wtbParser.ParseConfig([]byte(`{"targets":{"cluster_2":{"weight":1,"childPolicy":[{"round_robin":""}]}}}`))
+	if err != nil {
+		t.Fatalf("failed to parse balancer config: %v", err)
+	}
+
+	// Send the config, and an address with hierarchy path ["cluster_1"].
+	wantAddr4 := resolver.Address{Addr: testBackendAddrStrs[0], Attributes: nil}
+	if err := wtb.UpdateClientConnState(balancer.ClientConnState{
+		ResolverState: resolver.State{Addresses: []resolver.Address{
+			hierarchy.Set(wantAddr4, []string{"cluster_2"}),
+		}},
+		BalancerConfig: config3,
+	}); err != nil {
+		t.Fatalf("failed to update ClientConn state: %v", err)
+	}
+
+	// Verify that a subconn is created with the address, and the hierarchy path
+	// in the address is cleared.
+	addr4 := <-cc.NewSubConnAddrsCh
+	if want := []resolver.Address{
+		hierarchy.Set(wantAddr4, []string{}),
+	}; !cmp.Equal(addr4, want, cmp.AllowUnexported(attributes.Attributes{})) {
+		t.Fatalf("got unexpected new subconn addrs: %v", cmp.Diff(addr4, want, cmp.AllowUnexported(attributes.Attributes{})))
+	}
+
+	// Send subconn state change.
+	sc4 := <-cc.NewSubConnCh
+	wtb.UpdateSubConnState(sc4, balancer.SubConnState{ConnectivityState: connectivity.Connecting})
+	wtb.UpdateSubConnState(sc4, balancer.SubConnState{ConnectivityState: connectivity.Ready})
+
+	// Test pick with one backend.
+	p3 := <-cc.NewPickerCh
+	for i := 0; i < 5; i++ {
+		gotSCSt, _ := p3.Pick(balancer.PickInfo{})
+		if !cmp.Equal(gotSCSt.SubConn, sc4, cmp.AllowUnexported(testutils.TestSubConn{})) {
+			t.Fatalf("picker.Pick, got %v, want SubConn=%v", gotSCSt, sc4)
+		}
+	}
 }
 
 func subConnFromPicker(p balancer.Picker) func() balancer.SubConn {


### PR DESCRIPTION
Also remove dependency on cds from the tests, otherwise later it will cause cycular dependency: weightedtarget -> cds -> eds -> weightedtarget