### PR TITLE
xds/google_default_creds: handshake based on cluster name in address attributes

### DIFF
--- a/credentials/google/google_test.go
+++ b/credentials/google/google_test.go
@@ -1,0 +1,132 @@
+/*
+ *
+ * Copyright 2021 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package google
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/internal"
+	xdsinternal "google.golang.org/grpc/internal/credentials/xds"
+	"google.golang.org/grpc/resolver"
+)
+
+type testCreds struct {
+	credentials.TransportCredentials
+	typ string
+}
+
+func (c *testCreds) ClientHandshake(ctx context.Context, authority string, rawConn net.Conn) (net.Conn, credentials.AuthInfo, error) {
+	return nil, &testAuthInfo{typ: c.typ}, nil
+}
+
+func (c *testCreds) ServerHandshake(conn net.Conn) (net.Conn, credentials.AuthInfo, error) {
+	return nil, &testAuthInfo{typ: c.typ}, nil
+}
+
+type testAuthInfo struct {
+	typ string
+}
+
+func (t *testAuthInfo) AuthType() string {
+	return t.typ
+}
+
+var (
+	testTLS  = &testCreds{typ: "tls"}
+	testALTS = &testCreds{typ: "alts"}
+
+	contextWithHandshakeInfo = internal.NewClientHandshakeInfoContext.(func(context.Context, credentials.ClientHandshakeInfo) context.Context)
+)
+
+func overrideNewCredsFuncs() func() {
+	oldNewTLS := newTLS
+	newTLS = func() credentials.TransportCredentials {
+		return testTLS
+	}
+	oldNewALTS := newALTS
+	newALTS = func() credentials.TransportCredentials {
+		return testALTS
+	}
+	return func() {
+		newTLS = oldNewTLS
+		newALTS = oldNewALTS
+	}
+}
+
+// TestClientHandshakeBasedOnClusterName that by default (without switching
+// modes), ClientHandshake does either tls or alts base on the cluster name in
+// attributes.
+func TestClientHandshakeBasedOnClusterName(t *testing.T) {
+	defer overrideNewCredsFuncs()()
+	for bundleTyp, tc := range map[string]credentials.Bundle{
+		"defaultCreds": NewDefaultCredentials(),
+		"computeCreds": NewComputeEngineCredentials(),
+	} {
+		tests := []struct {
+			name    string
+			ctx     context.Context
+			wantTyp string
+		}{
+			{
+				name:    "no cluster name",
+				ctx:     context.Background(),
+				wantTyp: "tls",
+			},
+			{
+				name: "with non-CFE cluster name",
+				ctx: contextWithHandshakeInfo(context.Background(), credentials.ClientHandshakeInfo{
+					Attributes: xdsinternal.SetHandshakeClusterName(resolver.Address{}, "lalala").Attributes,
+				}),
+				// non-CFE backends should use alts.
+				wantTyp: "alts",
+			},
+			{
+				name: "with CFE cluster name",
+				ctx: contextWithHandshakeInfo(context.Background(), credentials.ClientHandshakeInfo{
+					Attributes: xdsinternal.SetHandshakeClusterName(resolver.Address{}, cfeClusterName).Attributes,
+				}),
+				// CFE should use tls.
+				wantTyp: "tls",
+			},
+		}
+		for _, tt := range tests {
+			t.Run(bundleTyp+" "+tt.name, func(t *testing.T) {
+				_, info, err := tc.TransportCredentials().ClientHandshake(tt.ctx, "", nil)
+				if err != nil {
+					t.Fatalf("ClientHandshake failed: %v", err)
+				}
+				if gotType := info.AuthType(); gotType != tt.wantTyp {
+					t.Fatalf("unexpected authtype: %v, want: %v", gotType, tt.wantTyp)
+				}
+
+				_, infoServer, err := tc.TransportCredentials().ServerHandshake(nil)
+				if err != nil {
+					t.Fatalf("ClientHandshake failed: %v", err)
+				}
+				// ServerHandshake should always do TLS.
+				if gotType := infoServer.AuthType(); gotType != "tls" {
+					t.Fatalf("unexpected server authtype: %v, want: %v", gotType, "tls")
+				}
+			})
+		}
+	}
+}

--- a/credentials/google/xds.go
+++ b/credentials/google/xds.go
@@ -1,0 +1,86 @@
+/*
+ *
+ * Copyright 2021 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package google
+
+import (
+	"context"
+	"net"
+
+	"google.golang.org/grpc/credentials"
+	xdsinternal "google.golang.org/grpc/internal/credentials/xds"
+)
+
+const cfeClusterName = "google-cfe"
+
+// clusterTransportCreds is a combo of TLS + ALTS.
+//
+// On the client, ClientHandshake picks TLS or ALTS based on address attributes.
+// - if attributes has cluster name
+//   - if cluster name is "google_cfe", use TLS
+//   - otherwise, use ALTS
+// - else, do TLS
+//
+// On the server, ServerHandshake always does TLS.
+type clusterTransportCreds struct {
+	tls  credentials.TransportCredentials
+	alts credentials.TransportCredentials
+}
+
+func newClusterTransportCreds(tls, alts credentials.TransportCredentials) *clusterTransportCreds {
+	return &clusterTransportCreds{
+		tls:  tls,
+		alts: alts,
+	}
+}
+
+func (c *clusterTransportCreds) ClientHandshake(ctx context.Context, authority string, rawConn net.Conn) (net.Conn, credentials.AuthInfo, error) {
+	chi := credentials.ClientHandshakeInfoFromContext(ctx)
+	if chi.Attributes == nil {
+		return c.tls.ClientHandshake(ctx, authority, rawConn)
+	}
+	cn, ok := xdsinternal.GetHandshakeClusterName(chi.Attributes)
+	if !ok || cn == cfeClusterName {
+		return c.tls.ClientHandshake(ctx, authority, rawConn)
+	}
+	// If attributes have cluster name, and cluster name is not cfe, it's a
+	// backend address, use ALTS.
+	return c.alts.ClientHandshake(ctx, authority, rawConn)
+}
+
+func (c *clusterTransportCreds) ServerHandshake(conn net.Conn) (net.Conn, credentials.AuthInfo, error) {
+	return c.tls.ServerHandshake(conn)
+}
+
+func (c *clusterTransportCreds) Info() credentials.ProtocolInfo {
+	return c.tls.Info()
+}
+
+func (c *clusterTransportCreds) Clone() credentials.TransportCredentials {
+	return &clusterTransportCreds{
+		tls:  c.tls.Clone(),
+		alts: c.alts.Clone(),
+	}
+}
+
+func (c *clusterTransportCreds) OverrideServerName(s string) error {
+	if err := c.tls.OverrideServerName(s); err != nil {
+		return err
+	}
+	return c.alts.OverrideServerName(s)
+}

--- a/credentials/google/xds.go
+++ b/credentials/google/xds.go
@@ -68,6 +68,10 @@ func (c *clusterTransportCreds) ServerHandshake(conn net.Conn) (net.Conn, creden
 }
 
 func (c *clusterTransportCreds) Info() credentials.ProtocolInfo {
+	// TODO: this always returns tls.Info now, because we don't have a cluster
+	// name to check when this method is called. This method doesn't affect
+	// anything important now. We may want to revisit this if it becomes more
+	// important later.
 	return c.tls.Info()
 }
 

--- a/internal/credentials/xds/handshake_cluster.go
+++ b/internal/credentials/xds/handshake_cluster.go
@@ -37,6 +37,6 @@ func SetHandshakeClusterName(addr resolver.Address, clusterName string) resolver
 // GetHandshakeClusterName returns cluster name stored in attr.
 func GetHandshakeClusterName(attr *attributes.Attributes) (string, bool) {
 	v := attr.Value(handshakeClusterNameKey{})
-	hi, ok := v.(string)
-	return hi, ok
+	name, ok := v.(string)
+	return name, ok
 }

--- a/internal/credentials/xds/handshake_cluster.go
+++ b/internal/credentials/xds/handshake_cluster.go
@@ -1,0 +1,42 @@
+/*
+ *
+ * Copyright 2021 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package xds
+
+import (
+	"google.golang.org/grpc/attributes"
+	"google.golang.org/grpc/resolver"
+)
+
+// handshakeClusterNameKey is the type used as the key to store cluster name in
+// the Attributes field of resolver.Address.
+type handshakeClusterNameKey struct{}
+
+// SetHandshakeClusterName returns a copy of addr in which the Attributes field
+// is updated with the cluster name.
+func SetHandshakeClusterName(addr resolver.Address, clusterName string) resolver.Address {
+	addr.Attributes = addr.Attributes.WithValues(handshakeClusterNameKey{}, clusterName)
+	return addr
+}
+
+// GetHandshakeClusterName returns cluster name stored in attr.
+func GetHandshakeClusterName(attr *attributes.Attributes) (string, bool) {
+	v := attr.Value(handshakeClusterNameKey{})
+	hi, ok := v.(string)
+	return hi, ok
+}

--- a/xds/internal/balancer/clusterimpl/balancer_test.go
+++ b/xds/internal/balancer/clusterimpl/balancer_test.go
@@ -421,7 +421,6 @@ func TestClusterNameInAddressAttributes(t *testing.T) {
 
 	b.UpdateSubConnState(sc1, balancer.SubConnState{ConnectivityState: connectivity.Ready})
 	// Test pick with one backend.
-	// Test pick with one backend.
 	p1 := <-cc.NewPickerCh
 	const rpcCount = 20
 	for i := 0; i < rpcCount; i++ {

--- a/xds/internal/balancer/edsbalancer/eds.go
+++ b/xds/internal/balancer/edsbalancer/eds.go
@@ -116,6 +116,9 @@ type edsBalancerImplInterface interface {
 	// updateServiceRequestsConfig updates the service requests counter to the
 	// one for the given service name.
 	updateServiceRequestsConfig(serviceName string, max *uint32)
+	// updateClusterName updates the cluster name that will be attaches to the
+	// address attributes.
+	updateClusterName(name string)
 	// close closes the eds balancer.
 	close()
 }
@@ -250,6 +253,7 @@ func (x *edsBalancer) handleServiceConfigUpdate(config *EDSConfig) error {
 		// This is OK for now, because we don't actually expect edsServiceName
 		// to change. Fix this (a bigger change) will happen later.
 		x.lsw.updateServiceName(x.edsServiceName)
+		x.edsImpl.updateClusterName(x.edsServiceName)
 	}
 
 	// Restart load reporting when the loadReportServer name has changed.

--- a/xds/internal/balancer/edsbalancer/eds.go
+++ b/xds/internal/balancer/edsbalancer/eds.go
@@ -116,7 +116,7 @@ type edsBalancerImplInterface interface {
 	// updateServiceRequestsConfig updates the service requests counter to the
 	// one for the given service name.
 	updateServiceRequestsConfig(serviceName string, max *uint32)
-	// updateClusterName updates the cluster name that will be attaches to the
+	// updateClusterName updates the cluster name that will be attached to the
 	// address attributes.
 	updateClusterName(name string)
 	// close closes the eds balancer.

--- a/xds/internal/balancer/edsbalancer/eds_test.go
+++ b/xds/internal/balancer/edsbalancer/eds_test.go
@@ -117,6 +117,7 @@ type fakeEDSBalancer struct {
 	edsUpdate          *testutils.Channel
 	serviceName        *testutils.Channel
 	serviceRequestMax  *testutils.Channel
+	clusterName        *testutils.Channel
 }
 
 func (f *fakeEDSBalancer) handleSubConnStateChange(sc balancer.SubConn, state connectivity.State) {
@@ -136,6 +137,10 @@ func (f *fakeEDSBalancer) updateState(priority priorityType, s balancer.State) {
 func (f *fakeEDSBalancer) updateServiceRequestsConfig(serviceName string, max *uint32) {
 	f.serviceName.Send(serviceName)
 	f.serviceRequestMax.Send(max)
+}
+
+func (f *fakeEDSBalancer) updateClusterName(name string) {
+	f.clusterName.Send(name)
 }
 
 func (f *fakeEDSBalancer) close() {}
@@ -207,6 +212,18 @@ func (f *fakeEDSBalancer) waitForCountMaxUpdate(ctx context.Context, want *uint3
 	return fmt.Errorf("got countMax %+v, want %+v", got, want)
 }
 
+func (f *fakeEDSBalancer) waitForClusterNameUpdate(ctx context.Context, wantClusterName string) error {
+	val, err := f.clusterName.Receive(ctx)
+	if err != nil {
+		return err
+	}
+	gotServiceName := val.(string)
+	if gotServiceName != wantClusterName {
+		return fmt.Errorf("got clusterName %v, want %v", gotServiceName, wantClusterName)
+	}
+	return nil
+}
+
 func newFakeEDSBalancer(cc balancer.ClientConn) edsBalancerImplInterface {
 	return &fakeEDSBalancer{
 		cc:                 cc,
@@ -215,6 +232,7 @@ func newFakeEDSBalancer(cc balancer.ClientConn) edsBalancerImplInterface {
 		edsUpdate:          testutils.NewChannelWithSize(10),
 		serviceName:        testutils.NewChannelWithSize(10),
 		serviceRequestMax:  testutils.NewChannelWithSize(10),
+		clusterName:        testutils.NewChannelWithSize(10),
 	}
 }
 
@@ -653,6 +671,59 @@ func (s) TestCounterUpdate(t *testing.T) {
 		t.Fatal(err)
 	}
 	if err := edsI.waitForCountMaxUpdate(ctx, &testCountMax); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestClusterNameUpdateInAddressAttributes verifies that cluster name update in
+// edsImpl is triggered with the update from a new service config.
+func (s) TestClusterNameUpdateInAddressAttributes(t *testing.T) {
+	edsLBCh := testutils.NewChannel()
+	xdsC, cleanup := setup(edsLBCh)
+	defer cleanup()
+
+	builder := balancer.Get(edsName)
+	edsB := builder.Build(newNoopTestClientConn(), balancer.BuildOptions{Target: resolver.Target{Endpoint: testServiceName}})
+	if edsB == nil {
+		t.Fatalf("builder.Build(%s) failed and returned nil", edsName)
+	}
+	defer edsB.Close()
+
+	// Update should trigger counter update with provided service name.
+	if err := edsB.UpdateClientConnState(balancer.ClientConnState{
+		BalancerConfig: &EDSConfig{
+			EDSServiceName: "foobar-1",
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	gotCluster, err := xdsC.WaitForWatchEDS(ctx)
+	if err != nil || gotCluster != "foobar-1" {
+		t.Fatalf("unexpected EDS watch: %v, %v", gotCluster, err)
+	}
+	edsI := edsB.(*edsBalancer).edsImpl.(*fakeEDSBalancer)
+	if err := edsI.waitForClusterNameUpdate(ctx, "foobar-1"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Update should trigger counter update with provided service name.
+	if err := edsB.UpdateClientConnState(balancer.ClientConnState{
+		BalancerConfig: &EDSConfig{
+			EDSServiceName: "foobar-2",
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := xdsC.WaitForCancelEDSWatch(ctx); err != nil {
+		t.Fatalf("failed to wait for EDS cancel: %v", err)
+	}
+	gotCluster2, err := xdsC.WaitForWatchEDS(ctx)
+	if err != nil || gotCluster2 != "foobar-2" {
+		t.Fatalf("unexpected EDS watch: %v, %v", gotCluster2, err)
+	}
+	if err := edsI.waitForClusterNameUpdate(ctx, "foobar-2"); err != nil {
 		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
- set cluster name in address's attributes
  - done in both EDS and cluster_impl
- update google creds to read cluster name
  - in default mode, handshake will be either TLS or ALTS based on the cluster name
  - other modes are not affected