### PR TITLE
xds: server-side listener network filter validation

### DIFF
--- a/internal/testutils/marshal_any.go
+++ b/internal/testutils/marshal_any.go
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2020 gRPC authors.
+ * Copyright 2021 gRPC authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xds/internal/client/filter_chain_test.go
+++ b/xds/internal/client/filter_chain_test.go
@@ -31,7 +31,7 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
-	"google.golang.org/grpc/xds/internal/testutils"
+	testutils2 "google.golang.org/grpc/internal/testutils"
 	"google.golang.org/grpc/xds/internal/version"
 )
 
@@ -248,7 +248,7 @@ func TestNewFilterChainImpl_Failure_BadSecurityConfig(t *testing.T) {
 						TransportSocket: &v3corepb.TransportSocket{
 							Name: "envoy.transport_sockets.tls",
 							ConfigType: &v3corepb.TransportSocket_TypedConfig{
-								TypedConfig: testutils.MarshalAny(&v3tlspb.UpstreamTlsContext{}),
+								TypedConfig: testutils2.MarshalAny(&v3tlspb.UpstreamTlsContext{}),
 							},
 						},
 					},
@@ -283,7 +283,7 @@ func TestNewFilterChainImpl_Failure_BadSecurityConfig(t *testing.T) {
 						TransportSocket: &v3corepb.TransportSocket{
 							Name: "envoy.transport_sockets.tls",
 							ConfigType: &v3corepb.TransportSocket_TypedConfig{
-								TypedConfig: testutils.MarshalAny(&v3tlspb.DownstreamTlsContext{}),
+								TypedConfig: testutils2.MarshalAny(&v3tlspb.DownstreamTlsContext{}),
 							},
 						},
 					},
@@ -299,7 +299,7 @@ func TestNewFilterChainImpl_Failure_BadSecurityConfig(t *testing.T) {
 						TransportSocket: &v3corepb.TransportSocket{
 							Name: "envoy.transport_sockets.tls",
 							ConfigType: &v3corepb.TransportSocket_TypedConfig{
-								TypedConfig: testutils.MarshalAny(&v3tlspb.DownstreamTlsContext{
+								TypedConfig: testutils2.MarshalAny(&v3tlspb.DownstreamTlsContext{
 									CommonTlsContext: &v3tlspb.CommonTlsContext{
 										ValidationContextType: &v3tlspb.CommonTlsContext_ValidationContextSdsSecretConfig{
 											ValidationContextSdsSecretConfig: &v3tlspb.SdsSecretConfig{
@@ -323,7 +323,7 @@ func TestNewFilterChainImpl_Failure_BadSecurityConfig(t *testing.T) {
 						TransportSocket: &v3corepb.TransportSocket{
 							Name: "envoy.transport_sockets.tls",
 							ConfigType: &v3corepb.TransportSocket_TypedConfig{
-								TypedConfig: testutils.MarshalAny(&v3tlspb.DownstreamTlsContext{
+								TypedConfig: testutils2.MarshalAny(&v3tlspb.DownstreamTlsContext{
 									RequireClientCertificate: &wrapperspb.BoolValue{Value: true},
 									CommonTlsContext: &v3tlspb.CommonTlsContext{
 										TlsCertificateCertificateProviderInstance: &v3tlspb.CommonTlsContext_CertificateProviderInstance{
@@ -347,7 +347,7 @@ func TestNewFilterChainImpl_Failure_BadSecurityConfig(t *testing.T) {
 						TransportSocket: &v3corepb.TransportSocket{
 							Name: "envoy.transport_sockets.tls",
 							ConfigType: &v3corepb.TransportSocket_TypedConfig{
-								TypedConfig: testutils.MarshalAny(&v3tlspb.DownstreamTlsContext{
+								TypedConfig: testutils2.MarshalAny(&v3tlspb.DownstreamTlsContext{
 									CommonTlsContext: &v3tlspb.CommonTlsContext{},
 								}),
 							},
@@ -415,7 +415,7 @@ func TestNewFilterChainImpl_Success_SecurityConfig(t *testing.T) {
 						TransportSocket: &v3corepb.TransportSocket{
 							Name: "envoy.transport_sockets.tls",
 							ConfigType: &v3corepb.TransportSocket_TypedConfig{
-								TypedConfig: testutils.MarshalAny(&v3tlspb.DownstreamTlsContext{
+								TypedConfig: testutils2.MarshalAny(&v3tlspb.DownstreamTlsContext{
 									CommonTlsContext: &v3tlspb.CommonTlsContext{
 										TlsCertificateCertificateProviderInstance: &v3tlspb.CommonTlsContext_CertificateProviderInstance{
 											InstanceName:    "identityPluginInstance",
@@ -431,7 +431,7 @@ func TestNewFilterChainImpl_Success_SecurityConfig(t *testing.T) {
 					TransportSocket: &v3corepb.TransportSocket{
 						Name: "envoy.transport_sockets.tls",
 						ConfigType: &v3corepb.TransportSocket_TypedConfig{
-							TypedConfig: testutils.MarshalAny(&v3tlspb.DownstreamTlsContext{
+							TypedConfig: testutils2.MarshalAny(&v3tlspb.DownstreamTlsContext{
 								CommonTlsContext: &v3tlspb.CommonTlsContext{
 									TlsCertificateCertificateProviderInstance: &v3tlspb.CommonTlsContext_CertificateProviderInstance{
 										InstanceName:    "defaultIdentityPluginInstance",
@@ -483,7 +483,7 @@ func TestNewFilterChainImpl_Success_SecurityConfig(t *testing.T) {
 						TransportSocket: &v3corepb.TransportSocket{
 							Name: "envoy.transport_sockets.tls",
 							ConfigType: &v3corepb.TransportSocket_TypedConfig{
-								TypedConfig: testutils.MarshalAny(&v3tlspb.DownstreamTlsContext{
+								TypedConfig: testutils2.MarshalAny(&v3tlspb.DownstreamTlsContext{
 									RequireClientCertificate: &wrapperspb.BoolValue{Value: true},
 									CommonTlsContext: &v3tlspb.CommonTlsContext{
 										TlsCertificateCertificateProviderInstance: &v3tlspb.CommonTlsContext_CertificateProviderInstance{
@@ -507,7 +507,7 @@ func TestNewFilterChainImpl_Success_SecurityConfig(t *testing.T) {
 					TransportSocket: &v3corepb.TransportSocket{
 						Name: "envoy.transport_sockets.tls",
 						ConfigType: &v3corepb.TransportSocket_TypedConfig{
-							TypedConfig: testutils.MarshalAny(&v3tlspb.DownstreamTlsContext{
+							TypedConfig: testutils2.MarshalAny(&v3tlspb.DownstreamTlsContext{
 								RequireClientCertificate: &wrapperspb.BoolValue{Value: true},
 								CommonTlsContext: &v3tlspb.CommonTlsContext{
 									TlsCertificateCertificateProviderInstance: &v3tlspb.CommonTlsContext_CertificateProviderInstance{
@@ -962,7 +962,7 @@ func TestLookup_Successes(t *testing.T) {
 				TransportSocket: &v3corepb.TransportSocket{
 					Name: "envoy.transport_sockets.tls",
 					ConfigType: &v3corepb.TransportSocket_TypedConfig{
-						TypedConfig: testutils.MarshalAny(&v3tlspb.DownstreamTlsContext{
+						TypedConfig: testutils2.MarshalAny(&v3tlspb.DownstreamTlsContext{
 							CommonTlsContext: &v3tlspb.CommonTlsContext{
 								TlsCertificateCertificateProviderInstance: &v3tlspb.CommonTlsContext_CertificateProviderInstance{InstanceName: "instance1"},
 							},
@@ -976,7 +976,7 @@ func TestLookup_Successes(t *testing.T) {
 			TransportSocket: &v3corepb.TransportSocket{
 				Name: "envoy.transport_sockets.tls",
 				ConfigType: &v3corepb.TransportSocket_TypedConfig{
-					TypedConfig: testutils.MarshalAny(&v3tlspb.DownstreamTlsContext{
+					TypedConfig: testutils2.MarshalAny(&v3tlspb.DownstreamTlsContext{
 						CommonTlsContext: &v3tlspb.CommonTlsContext{
 							TlsCertificateCertificateProviderInstance: &v3tlspb.CommonTlsContext_CertificateProviderInstance{InstanceName: "default"},
 						},
@@ -1298,7 +1298,7 @@ func transportSocketWithInstanceName(name string) *v3corepb.TransportSocket {
 	return &v3corepb.TransportSocket{
 		Name: "envoy.transport_sockets.tls",
 		ConfigType: &v3corepb.TransportSocket_TypedConfig{
-			TypedConfig: testutils.MarshalAny(&v3tlspb.DownstreamTlsContext{
+			TypedConfig: testutils2.MarshalAny(&v3tlspb.DownstreamTlsContext{
 				CommonTlsContext: &v3tlspb.CommonTlsContext{
 					TlsCertificateCertificateProviderInstance: &v3tlspb.CommonTlsContext_CertificateProviderInstance{InstanceName: name},
 				},

--- a/xds/internal/client/filter_chain_test.go
+++ b/xds/internal/client/filter_chain_test.go
@@ -31,6 +31,7 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
+	"google.golang.org/grpc/xds/internal/testutils"
 	"google.golang.org/grpc/xds/internal/version"
 )
 
@@ -247,7 +248,7 @@ func TestNewFilterChainImpl_Failure_BadSecurityConfig(t *testing.T) {
 						TransportSocket: &v3corepb.TransportSocket{
 							Name: "envoy.transport_sockets.tls",
 							ConfigType: &v3corepb.TransportSocket_TypedConfig{
-								TypedConfig: marshalAny(&v3tlspb.UpstreamTlsContext{}),
+								TypedConfig: testutils.MarshalAny(&v3tlspb.UpstreamTlsContext{}),
 							},
 						},
 					},
@@ -282,7 +283,7 @@ func TestNewFilterChainImpl_Failure_BadSecurityConfig(t *testing.T) {
 						TransportSocket: &v3corepb.TransportSocket{
 							Name: "envoy.transport_sockets.tls",
 							ConfigType: &v3corepb.TransportSocket_TypedConfig{
-								TypedConfig: marshalAny(&v3tlspb.DownstreamTlsContext{}),
+								TypedConfig: testutils.MarshalAny(&v3tlspb.DownstreamTlsContext{}),
 							},
 						},
 					},
@@ -298,7 +299,7 @@ func TestNewFilterChainImpl_Failure_BadSecurityConfig(t *testing.T) {
 						TransportSocket: &v3corepb.TransportSocket{
 							Name: "envoy.transport_sockets.tls",
 							ConfigType: &v3corepb.TransportSocket_TypedConfig{
-								TypedConfig: marshalAny(&v3tlspb.DownstreamTlsContext{
+								TypedConfig: testutils.MarshalAny(&v3tlspb.DownstreamTlsContext{
 									CommonTlsContext: &v3tlspb.CommonTlsContext{
 										ValidationContextType: &v3tlspb.CommonTlsContext_ValidationContextSdsSecretConfig{
 											ValidationContextSdsSecretConfig: &v3tlspb.SdsSecretConfig{
@@ -322,7 +323,7 @@ func TestNewFilterChainImpl_Failure_BadSecurityConfig(t *testing.T) {
 						TransportSocket: &v3corepb.TransportSocket{
 							Name: "envoy.transport_sockets.tls",
 							ConfigType: &v3corepb.TransportSocket_TypedConfig{
-								TypedConfig: marshalAny(&v3tlspb.DownstreamTlsContext{
+								TypedConfig: testutils.MarshalAny(&v3tlspb.DownstreamTlsContext{
 									RequireClientCertificate: &wrapperspb.BoolValue{Value: true},
 									CommonTlsContext: &v3tlspb.CommonTlsContext{
 										TlsCertificateCertificateProviderInstance: &v3tlspb.CommonTlsContext_CertificateProviderInstance{
@@ -346,7 +347,7 @@ func TestNewFilterChainImpl_Failure_BadSecurityConfig(t *testing.T) {
 						TransportSocket: &v3corepb.TransportSocket{
 							Name: "envoy.transport_sockets.tls",
 							ConfigType: &v3corepb.TransportSocket_TypedConfig{
-								TypedConfig: marshalAny(&v3tlspb.DownstreamTlsContext{
+								TypedConfig: testutils.MarshalAny(&v3tlspb.DownstreamTlsContext{
 									CommonTlsContext: &v3tlspb.CommonTlsContext{},
 								}),
 							},
@@ -414,7 +415,7 @@ func TestNewFilterChainImpl_Success_SecurityConfig(t *testing.T) {
 						TransportSocket: &v3corepb.TransportSocket{
 							Name: "envoy.transport_sockets.tls",
 							ConfigType: &v3corepb.TransportSocket_TypedConfig{
-								TypedConfig: marshalAny(&v3tlspb.DownstreamTlsContext{
+								TypedConfig: testutils.MarshalAny(&v3tlspb.DownstreamTlsContext{
 									CommonTlsContext: &v3tlspb.CommonTlsContext{
 										TlsCertificateCertificateProviderInstance: &v3tlspb.CommonTlsContext_CertificateProviderInstance{
 											InstanceName:    "identityPluginInstance",
@@ -430,7 +431,7 @@ func TestNewFilterChainImpl_Success_SecurityConfig(t *testing.T) {
 					TransportSocket: &v3corepb.TransportSocket{
 						Name: "envoy.transport_sockets.tls",
 						ConfigType: &v3corepb.TransportSocket_TypedConfig{
-							TypedConfig: marshalAny(&v3tlspb.DownstreamTlsContext{
+							TypedConfig: testutils.MarshalAny(&v3tlspb.DownstreamTlsContext{
 								CommonTlsContext: &v3tlspb.CommonTlsContext{
 									TlsCertificateCertificateProviderInstance: &v3tlspb.CommonTlsContext_CertificateProviderInstance{
 										InstanceName:    "defaultIdentityPluginInstance",
@@ -482,7 +483,7 @@ func TestNewFilterChainImpl_Success_SecurityConfig(t *testing.T) {
 						TransportSocket: &v3corepb.TransportSocket{
 							Name: "envoy.transport_sockets.tls",
 							ConfigType: &v3corepb.TransportSocket_TypedConfig{
-								TypedConfig: marshalAny(&v3tlspb.DownstreamTlsContext{
+								TypedConfig: testutils.MarshalAny(&v3tlspb.DownstreamTlsContext{
 									RequireClientCertificate: &wrapperspb.BoolValue{Value: true},
 									CommonTlsContext: &v3tlspb.CommonTlsContext{
 										TlsCertificateCertificateProviderInstance: &v3tlspb.CommonTlsContext_CertificateProviderInstance{
@@ -506,7 +507,7 @@ func TestNewFilterChainImpl_Success_SecurityConfig(t *testing.T) {
 					TransportSocket: &v3corepb.TransportSocket{
 						Name: "envoy.transport_sockets.tls",
 						ConfigType: &v3corepb.TransportSocket_TypedConfig{
-							TypedConfig: marshalAny(&v3tlspb.DownstreamTlsContext{
+							TypedConfig: testutils.MarshalAny(&v3tlspb.DownstreamTlsContext{
 								RequireClientCertificate: &wrapperspb.BoolValue{Value: true},
 								CommonTlsContext: &v3tlspb.CommonTlsContext{
 									TlsCertificateCertificateProviderInstance: &v3tlspb.CommonTlsContext_CertificateProviderInstance{
@@ -961,7 +962,7 @@ func TestLookup_Successes(t *testing.T) {
 				TransportSocket: &v3corepb.TransportSocket{
 					Name: "envoy.transport_sockets.tls",
 					ConfigType: &v3corepb.TransportSocket_TypedConfig{
-						TypedConfig: marshalAny(&v3tlspb.DownstreamTlsContext{
+						TypedConfig: testutils.MarshalAny(&v3tlspb.DownstreamTlsContext{
 							CommonTlsContext: &v3tlspb.CommonTlsContext{
 								TlsCertificateCertificateProviderInstance: &v3tlspb.CommonTlsContext_CertificateProviderInstance{InstanceName: "instance1"},
 							},
@@ -975,7 +976,7 @@ func TestLookup_Successes(t *testing.T) {
 			TransportSocket: &v3corepb.TransportSocket{
 				Name: "envoy.transport_sockets.tls",
 				ConfigType: &v3corepb.TransportSocket_TypedConfig{
-					TypedConfig: marshalAny(&v3tlspb.DownstreamTlsContext{
+					TypedConfig: testutils.MarshalAny(&v3tlspb.DownstreamTlsContext{
 						CommonTlsContext: &v3tlspb.CommonTlsContext{
 							TlsCertificateCertificateProviderInstance: &v3tlspb.CommonTlsContext_CertificateProviderInstance{InstanceName: "default"},
 						},
@@ -1297,7 +1298,7 @@ func transportSocketWithInstanceName(name string) *v3corepb.TransportSocket {
 	return &v3corepb.TransportSocket{
 		Name: "envoy.transport_sockets.tls",
 		ConfigType: &v3corepb.TransportSocket_TypedConfig{
-			TypedConfig: marshalAny(&v3tlspb.DownstreamTlsContext{
+			TypedConfig: testutils.MarshalAny(&v3tlspb.DownstreamTlsContext{
 				CommonTlsContext: &v3tlspb.CommonTlsContext{
 					TlsCertificateCertificateProviderInstance: &v3tlspb.CommonTlsContext_CertificateProviderInstance{InstanceName: name},
 				},

--- a/xds/internal/client/filter_chain_test.go
+++ b/xds/internal/client/filter_chain_test.go
@@ -31,7 +31,7 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
-	testutils2 "google.golang.org/grpc/internal/testutils"
+	"google.golang.org/grpc/internal/testutils"
 	"google.golang.org/grpc/xds/internal/version"
 )
 
@@ -248,7 +248,7 @@ func TestNewFilterChainImpl_Failure_BadSecurityConfig(t *testing.T) {
 						TransportSocket: &v3corepb.TransportSocket{
 							Name: "envoy.transport_sockets.tls",
 							ConfigType: &v3corepb.TransportSocket_TypedConfig{
-								TypedConfig: testutils2.MarshalAny(&v3tlspb.UpstreamTlsContext{}),
+								TypedConfig: testutils.MarshalAny(&v3tlspb.UpstreamTlsContext{}),
 							},
 						},
 					},
@@ -283,7 +283,7 @@ func TestNewFilterChainImpl_Failure_BadSecurityConfig(t *testing.T) {
 						TransportSocket: &v3corepb.TransportSocket{
 							Name: "envoy.transport_sockets.tls",
 							ConfigType: &v3corepb.TransportSocket_TypedConfig{
-								TypedConfig: testutils2.MarshalAny(&v3tlspb.DownstreamTlsContext{}),
+								TypedConfig: testutils.MarshalAny(&v3tlspb.DownstreamTlsContext{}),
 							},
 						},
 					},
@@ -299,7 +299,7 @@ func TestNewFilterChainImpl_Failure_BadSecurityConfig(t *testing.T) {
 						TransportSocket: &v3corepb.TransportSocket{
 							Name: "envoy.transport_sockets.tls",
 							ConfigType: &v3corepb.TransportSocket_TypedConfig{
-								TypedConfig: testutils2.MarshalAny(&v3tlspb.DownstreamTlsContext{
+								TypedConfig: testutils.MarshalAny(&v3tlspb.DownstreamTlsContext{
 									CommonTlsContext: &v3tlspb.CommonTlsContext{
 										ValidationContextType: &v3tlspb.CommonTlsContext_ValidationContextSdsSecretConfig{
 											ValidationContextSdsSecretConfig: &v3tlspb.SdsSecretConfig{
@@ -323,7 +323,7 @@ func TestNewFilterChainImpl_Failure_BadSecurityConfig(t *testing.T) {
 						TransportSocket: &v3corepb.TransportSocket{
 							Name: "envoy.transport_sockets.tls",
 							ConfigType: &v3corepb.TransportSocket_TypedConfig{
-								TypedConfig: testutils2.MarshalAny(&v3tlspb.DownstreamTlsContext{
+								TypedConfig: testutils.MarshalAny(&v3tlspb.DownstreamTlsContext{
 									RequireClientCertificate: &wrapperspb.BoolValue{Value: true},
 									CommonTlsContext: &v3tlspb.CommonTlsContext{
 										TlsCertificateCertificateProviderInstance: &v3tlspb.CommonTlsContext_CertificateProviderInstance{
@@ -347,7 +347,7 @@ func TestNewFilterChainImpl_Failure_BadSecurityConfig(t *testing.T) {
 						TransportSocket: &v3corepb.TransportSocket{
 							Name: "envoy.transport_sockets.tls",
 							ConfigType: &v3corepb.TransportSocket_TypedConfig{
-								TypedConfig: testutils2.MarshalAny(&v3tlspb.DownstreamTlsContext{
+								TypedConfig: testutils.MarshalAny(&v3tlspb.DownstreamTlsContext{
 									CommonTlsContext: &v3tlspb.CommonTlsContext{},
 								}),
 							},
@@ -415,7 +415,7 @@ func TestNewFilterChainImpl_Success_SecurityConfig(t *testing.T) {
 						TransportSocket: &v3corepb.TransportSocket{
 							Name: "envoy.transport_sockets.tls",
 							ConfigType: &v3corepb.TransportSocket_TypedConfig{
-								TypedConfig: testutils2.MarshalAny(&v3tlspb.DownstreamTlsContext{
+								TypedConfig: testutils.MarshalAny(&v3tlspb.DownstreamTlsContext{
 									CommonTlsContext: &v3tlspb.CommonTlsContext{
 										TlsCertificateCertificateProviderInstance: &v3tlspb.CommonTlsContext_CertificateProviderInstance{
 											InstanceName:    "identityPluginInstance",
@@ -431,7 +431,7 @@ func TestNewFilterChainImpl_Success_SecurityConfig(t *testing.T) {
 					TransportSocket: &v3corepb.TransportSocket{
 						Name: "envoy.transport_sockets.tls",
 						ConfigType: &v3corepb.TransportSocket_TypedConfig{
-							TypedConfig: testutils2.MarshalAny(&v3tlspb.DownstreamTlsContext{
+							TypedConfig: testutils.MarshalAny(&v3tlspb.DownstreamTlsContext{
 								CommonTlsContext: &v3tlspb.CommonTlsContext{
 									TlsCertificateCertificateProviderInstance: &v3tlspb.CommonTlsContext_CertificateProviderInstance{
 										InstanceName:    "defaultIdentityPluginInstance",
@@ -483,7 +483,7 @@ func TestNewFilterChainImpl_Success_SecurityConfig(t *testing.T) {
 						TransportSocket: &v3corepb.TransportSocket{
 							Name: "envoy.transport_sockets.tls",
 							ConfigType: &v3corepb.TransportSocket_TypedConfig{
-								TypedConfig: testutils2.MarshalAny(&v3tlspb.DownstreamTlsContext{
+								TypedConfig: testutils.MarshalAny(&v3tlspb.DownstreamTlsContext{
 									RequireClientCertificate: &wrapperspb.BoolValue{Value: true},
 									CommonTlsContext: &v3tlspb.CommonTlsContext{
 										TlsCertificateCertificateProviderInstance: &v3tlspb.CommonTlsContext_CertificateProviderInstance{
@@ -507,7 +507,7 @@ func TestNewFilterChainImpl_Success_SecurityConfig(t *testing.T) {
 					TransportSocket: &v3corepb.TransportSocket{
 						Name: "envoy.transport_sockets.tls",
 						ConfigType: &v3corepb.TransportSocket_TypedConfig{
-							TypedConfig: testutils2.MarshalAny(&v3tlspb.DownstreamTlsContext{
+							TypedConfig: testutils.MarshalAny(&v3tlspb.DownstreamTlsContext{
 								RequireClientCertificate: &wrapperspb.BoolValue{Value: true},
 								CommonTlsContext: &v3tlspb.CommonTlsContext{
 									TlsCertificateCertificateProviderInstance: &v3tlspb.CommonTlsContext_CertificateProviderInstance{
@@ -962,7 +962,7 @@ func TestLookup_Successes(t *testing.T) {
 				TransportSocket: &v3corepb.TransportSocket{
 					Name: "envoy.transport_sockets.tls",
 					ConfigType: &v3corepb.TransportSocket_TypedConfig{
-						TypedConfig: testutils2.MarshalAny(&v3tlspb.DownstreamTlsContext{
+						TypedConfig: testutils.MarshalAny(&v3tlspb.DownstreamTlsContext{
 							CommonTlsContext: &v3tlspb.CommonTlsContext{
 								TlsCertificateCertificateProviderInstance: &v3tlspb.CommonTlsContext_CertificateProviderInstance{InstanceName: "instance1"},
 							},
@@ -976,7 +976,7 @@ func TestLookup_Successes(t *testing.T) {
 			TransportSocket: &v3corepb.TransportSocket{
 				Name: "envoy.transport_sockets.tls",
 				ConfigType: &v3corepb.TransportSocket_TypedConfig{
-					TypedConfig: testutils2.MarshalAny(&v3tlspb.DownstreamTlsContext{
+					TypedConfig: testutils.MarshalAny(&v3tlspb.DownstreamTlsContext{
 						CommonTlsContext: &v3tlspb.CommonTlsContext{
 							TlsCertificateCertificateProviderInstance: &v3tlspb.CommonTlsContext_CertificateProviderInstance{InstanceName: "default"},
 						},
@@ -1298,7 +1298,7 @@ func transportSocketWithInstanceName(name string) *v3corepb.TransportSocket {
 	return &v3corepb.TransportSocket{
 		Name: "envoy.transport_sockets.tls",
 		ConfigType: &v3corepb.TransportSocket_TypedConfig{
-			TypedConfig: testutils2.MarshalAny(&v3tlspb.DownstreamTlsContext{
+			TypedConfig: testutils.MarshalAny(&v3tlspb.DownstreamTlsContext{
 				CommonTlsContext: &v3tlspb.CommonTlsContext{
 					TlsCertificateCertificateProviderInstance: &v3tlspb.CommonTlsContext_CertificateProviderInstance{InstanceName: name},
 				},

--- a/xds/internal/client/lds_test.go
+++ b/xds/internal/client/lds_test.go
@@ -27,11 +27,11 @@ import (
 	v1typepb "github.com/cncf/udpa/go/udpa/type/v1"
 	v3routepb "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	"github.com/golang/protobuf/proto"
-	"github.com/golang/protobuf/ptypes"
 	spb "github.com/golang/protobuf/ptypes/struct"
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/grpc/internal/xds/env"
 	"google.golang.org/grpc/xds/internal/httpfilter"
+	"google.golang.org/grpc/xds/internal/testutils"
 	"google.golang.org/grpc/xds/internal/version"
 	"google.golang.org/protobuf/types/known/durationpb"
 
@@ -54,13 +54,14 @@ func (s) TestUnmarshalListener_ClientSide(t *testing.T) {
 		v2RouteConfigName = "v2RouteConfig"
 		v3RouteConfigName = "v3RouteConfig"
 		routeName         = "routeName"
+		testVersion       = "test-version-lds-client"
 	)
 
 	var (
-		v2Lis = &anypb.Any{
-			TypeUrl: version.V2ListenerURL,
-			Value: func() []byte {
-				cm := &v2httppb.HttpConnectionManager{
+		v2Lis = testutils.MarshalAny(&v2xdspb.Listener{
+			Name: v2LDSTarget,
+			ApiListener: &v2listenerpb.ApiListener{
+				ApiListener: testutils.MarshalAny(&v2httppb.HttpConnectionManager{
 					RouteSpecifier: &v2httppb.HttpConnectionManager_Rds{
 						Rds: &v2httppb.Rds{
 							ConfigSource: &v2corepb.ConfigSource{
@@ -69,21 +70,9 @@ func (s) TestUnmarshalListener_ClientSide(t *testing.T) {
 							RouteConfigName: v2RouteConfigName,
 						},
 					},
-				}
-				mcm, _ := proto.Marshal(cm)
-				lis := &v2xdspb.Listener{
-					Name: v2LDSTarget,
-					ApiListener: &v2listenerpb.ApiListener{
-						ApiListener: &anypb.Any{
-							TypeUrl: version.V2HTTPConnManagerURL,
-							Value:   mcm,
-						},
-					},
-				}
-				mLis, _ := proto.Marshal(lis)
-				return mLis
-			}(),
-		}
+				}),
+			},
+		})
 		customFilter = &v3httppb.HttpFilter{
 			Name:       "customFilter",
 			ConfigType: &v3httppb.HttpFilter_TypedConfig{TypedConfig: customFilterConfig},
@@ -132,10 +121,10 @@ func (s) TestUnmarshalListener_ClientSide(t *testing.T) {
 			ConfigType: &v3httppb.HttpFilter_TypedConfig{TypedConfig: unknownFilterConfig},
 			IsOptional: true,
 		}
-		v3LisWithInlineRoute = &anypb.Any{
-			TypeUrl: version.V3ListenerURL,
-			Value: func() []byte {
-				hcm := &v3httppb.HttpConnectionManager{
+		v3LisWithInlineRoute = testutils.MarshalAny(&v3listenerpb.Listener{
+			Name: v3LDSTarget,
+			ApiListener: &v3listenerpb.ApiListener{
+				ApiListener: testutils.MarshalAny(&v3httppb.HttpConnectionManager{
 					RouteSpecifier: &v3httppb.HttpConnectionManager_RouteConfig{
 						RouteConfig: &v3routepb.RouteConfiguration{
 							Name: routeName,
@@ -153,50 +142,40 @@ func (s) TestUnmarshalListener_ClientSide(t *testing.T) {
 					CommonHttpProtocolOptions: &v3corepb.HttpProtocolOptions{
 						MaxStreamDuration: durationpb.New(time.Second),
 					},
-				}
-				mcm := marshalAny(hcm)
-				lis := &v3listenerpb.Listener{
-					Name: v3LDSTarget,
-					ApiListener: &v3listenerpb.ApiListener{
-						ApiListener: mcm,
-					},
-				}
-				mLis, _ := proto.Marshal(lis)
-				return mLis
-			}(),
-		}
+				}),
+			},
+		})
 		v3LisWithFilters = func(fs ...*v3httppb.HttpFilter) *anypb.Any {
-			hcm := &v3httppb.HttpConnectionManager{
-				RouteSpecifier: &v3httppb.HttpConnectionManager_Rds{
-					Rds: &v3httppb.Rds{
-						ConfigSource: &v3corepb.ConfigSource{
-							ConfigSourceSpecifier: &v3corepb.ConfigSource_Ads{Ads: &v3corepb.AggregatedConfigSource{}},
-						},
-						RouteConfigName: v3RouteConfigName,
-					},
+			return testutils.MarshalAny(&v3listenerpb.Listener{
+				Name: v3LDSTarget,
+				ApiListener: &v3listenerpb.ApiListener{
+					ApiListener: testutils.MarshalAny(
+						&v3httppb.HttpConnectionManager{
+							RouteSpecifier: &v3httppb.HttpConnectionManager_Rds{
+								Rds: &v3httppb.Rds{
+									ConfigSource: &v3corepb.ConfigSource{
+										ConfigSourceSpecifier: &v3corepb.ConfigSource_Ads{Ads: &v3corepb.AggregatedConfigSource{}},
+									},
+									RouteConfigName: v3RouteConfigName,
+								},
+							},
+							CommonHttpProtocolOptions: &v3corepb.HttpProtocolOptions{
+								MaxStreamDuration: durationpb.New(time.Second),
+							},
+							HttpFilters: fs,
+						}),
 				},
-				CommonHttpProtocolOptions: &v3corepb.HttpProtocolOptions{
-					MaxStreamDuration: durationpb.New(time.Second),
-				},
-				HttpFilters: fs,
-			}
-			return &anypb.Any{
-				TypeUrl: version.V3ListenerURL,
-				Value: func() []byte {
-					mcm := marshalAny(hcm)
-					lis := &v3listenerpb.Listener{
-						Name: v3LDSTarget,
-						ApiListener: &v3listenerpb.ApiListener{
-							ApiListener: mcm,
-						},
-					}
-					mLis, _ := proto.Marshal(lis)
-					return mLis
-				}(),
-			}
+			})
+		}
+		errMD = UpdateMetadata{
+			Status:  ServiceStatusNACKed,
+			Version: testVersion,
+			ErrState: &UpdateErrorMetadata{
+				Version: testVersion,
+				Err:     errPlaceHolder,
+			},
 		}
 	)
-	const testVersion = "test-version-lds-client"
 
 	tests := []struct {
 		name       string
@@ -209,15 +188,8 @@ func (s) TestUnmarshalListener_ClientSide(t *testing.T) {
 		{
 			name:      "non-listener resource",
 			resources: []*anypb.Any{{TypeUrl: version.V3HTTPConnManagerURL}},
-			wantMD: UpdateMetadata{
-				Status:  ServiceStatusNACKed,
-				Version: testVersion,
-				ErrState: &UpdateErrorMetadata{
-					Version: testVersion,
-					Err:     errPlaceHolder,
-				},
-			},
-			wantErr: true,
+			wantMD:    errMD,
+			wantErr:   true,
 		},
 		{
 			name: "badly marshaled listener resource",
@@ -240,181 +212,80 @@ func (s) TestUnmarshalListener_ClientSide(t *testing.T) {
 				},
 			},
 			wantUpdate: map[string]ListenerUpdate{v3LDSTarget: {}},
-			wantMD: UpdateMetadata{
-				Status:  ServiceStatusNACKed,
-				Version: testVersion,
-				ErrState: &UpdateErrorMetadata{
-					Version: testVersion,
-					Err:     errPlaceHolder,
-				},
-			},
-			wantErr: true,
+			wantMD:     errMD,
+			wantErr:    true,
 		},
 		{
 			name: "wrong type in apiListener",
-			resources: []*anypb.Any{
-				{
-					TypeUrl: version.V3ListenerURL,
-					Value: func() []byte {
-						lis := &v3listenerpb.Listener{
-							Name: v3LDSTarget,
-							ApiListener: &v3listenerpb.ApiListener{
-								ApiListener: &anypb.Any{
-									TypeUrl: version.V2ListenerURL,
-									Value: func() []byte {
-										cm := &v3httppb.HttpConnectionManager{
-											RouteSpecifier: &v3httppb.HttpConnectionManager_Rds{
-												Rds: &v3httppb.Rds{
-													ConfigSource: &v3corepb.ConfigSource{
-														ConfigSourceSpecifier: &v3corepb.ConfigSource_Ads{Ads: &v3corepb.AggregatedConfigSource{}},
-													},
-													RouteConfigName: v3RouteConfigName,
-												},
-											},
-										}
-										mcm, _ := proto.Marshal(cm)
-										return mcm
-									}(),
-								},
-							},
-						}
-						mLis, _ := proto.Marshal(lis)
-						return mLis
-					}(),
+			resources: []*anypb.Any{testutils.MarshalAny(&v3listenerpb.Listener{
+				Name: v3LDSTarget,
+				ApiListener: &v3listenerpb.ApiListener{
+					ApiListener: testutils.MarshalAny(&v2xdspb.Listener{}),
 				},
-			},
+			})},
 			wantUpdate: map[string]ListenerUpdate{v3LDSTarget: {}},
-			wantMD: UpdateMetadata{
-				Status:  ServiceStatusNACKed,
-				Version: testVersion,
-				ErrState: &UpdateErrorMetadata{
-					Version: testVersion,
-					Err:     errPlaceHolder,
-				},
-			},
-			wantErr: true,
+			wantMD:     errMD,
+			wantErr:    true,
 		},
 		{
 			name: "empty httpConnMgr in apiListener",
-			resources: []*anypb.Any{
-				{
-					TypeUrl: version.V3ListenerURL,
-					Value: func() []byte {
-						lis := &v3listenerpb.Listener{
-							Name: v3LDSTarget,
-							ApiListener: &v3listenerpb.ApiListener{
-								ApiListener: &anypb.Any{
-									TypeUrl: version.V2ListenerURL,
-									Value: func() []byte {
-										cm := &v3httppb.HttpConnectionManager{
-											RouteSpecifier: &v3httppb.HttpConnectionManager_Rds{
-												Rds: &v3httppb.Rds{},
-											},
-										}
-										mcm, _ := proto.Marshal(cm)
-										return mcm
-									}(),
-								},
-							},
-						}
-						mLis, _ := proto.Marshal(lis)
-						return mLis
-					}(),
+			resources: []*anypb.Any{testutils.MarshalAny(&v3listenerpb.Listener{
+				Name: v3LDSTarget,
+				ApiListener: &v3listenerpb.ApiListener{
+					ApiListener: testutils.MarshalAny(&v3httppb.HttpConnectionManager{
+						RouteSpecifier: &v3httppb.HttpConnectionManager_Rds{
+							Rds: &v3httppb.Rds{},
+						},
+					}),
 				},
-			},
+			})},
 			wantUpdate: map[string]ListenerUpdate{v3LDSTarget: {}},
-			wantMD: UpdateMetadata{
-				Status:  ServiceStatusNACKed,
-				Version: testVersion,
-				ErrState: &UpdateErrorMetadata{
-					Version: testVersion,
-					Err:     errPlaceHolder,
-				},
-			},
-			wantErr: true,
+			wantMD:     errMD,
+			wantErr:    true,
 		},
 		{
 			name: "scopedRoutes routeConfig in apiListener",
-			resources: []*anypb.Any{
-				{
-					TypeUrl: version.V3ListenerURL,
-					Value: func() []byte {
-						lis := &v3listenerpb.Listener{
-							Name: v3LDSTarget,
-							ApiListener: &v3listenerpb.ApiListener{
-								ApiListener: &anypb.Any{
-									TypeUrl: version.V2ListenerURL,
-									Value: func() []byte {
-										cm := &v3httppb.HttpConnectionManager{
-											RouteSpecifier: &v3httppb.HttpConnectionManager_ScopedRoutes{},
-										}
-										mcm, _ := proto.Marshal(cm)
-										return mcm
-									}(),
-								},
-							},
-						}
-						mLis, _ := proto.Marshal(lis)
-						return mLis
-					}(),
+			resources: []*anypb.Any{testutils.MarshalAny(&v3listenerpb.Listener{
+				Name: v3LDSTarget,
+				ApiListener: &v3listenerpb.ApiListener{
+					ApiListener: &anypb.Any{
+						TypeUrl: version.V2ListenerURL,
+						Value: func() []byte {
+							cm := &v3httppb.HttpConnectionManager{
+								RouteSpecifier: &v3httppb.HttpConnectionManager_ScopedRoutes{},
+							}
+							mcm, _ := proto.Marshal(cm)
+							return mcm
+						}(),
+					},
 				},
-			},
+			})},
 			wantUpdate: map[string]ListenerUpdate{v3LDSTarget: {}},
-			wantMD: UpdateMetadata{
-				Status:  ServiceStatusNACKed,
-				Version: testVersion,
-				ErrState: &UpdateErrorMetadata{
-					Version: testVersion,
-					Err:     errPlaceHolder,
-				},
-			},
-			wantErr: true,
+			wantMD:     errMD,
+			wantErr:    true,
 		},
 		{
 			name: "rds.ConfigSource in apiListener is not ADS",
-			resources: []*anypb.Any{
-				{
-					TypeUrl: version.V3ListenerURL,
-					Value: func() []byte {
-						lis := &v3listenerpb.Listener{
-							Name: v3LDSTarget,
-							ApiListener: &v3listenerpb.ApiListener{
-								ApiListener: &anypb.Any{
-									TypeUrl: version.V2ListenerURL,
-									Value: func() []byte {
-										cm := &v3httppb.HttpConnectionManager{
-											RouteSpecifier: &v3httppb.HttpConnectionManager_Rds{
-												Rds: &v3httppb.Rds{
-													ConfigSource: &v3corepb.ConfigSource{
-														ConfigSourceSpecifier: &v3corepb.ConfigSource_Path{
-															Path: "/some/path",
-														},
-													},
-													RouteConfigName: v3RouteConfigName,
-												},
-											},
-										}
-										mcm, _ := proto.Marshal(cm)
-										return mcm
-									}(),
+			resources: []*anypb.Any{testutils.MarshalAny(&v3listenerpb.Listener{
+				Name: v3LDSTarget,
+				ApiListener: &v3listenerpb.ApiListener{
+					ApiListener: testutils.MarshalAny(&v3httppb.HttpConnectionManager{
+						RouteSpecifier: &v3httppb.HttpConnectionManager_Rds{
+							Rds: &v3httppb.Rds{
+								ConfigSource: &v3corepb.ConfigSource{
+									ConfigSourceSpecifier: &v3corepb.ConfigSource_Path{
+										Path: "/some/path",
+									},
 								},
+								RouteConfigName: v3RouteConfigName,
 							},
-						}
-						mLis, _ := proto.Marshal(lis)
-						return mLis
-					}(),
+						},
+					}),
 				},
-			},
+			})},
 			wantUpdate: map[string]ListenerUpdate{v3LDSTarget: {}},
-			wantMD: UpdateMetadata{
-				Status:  ServiceStatusNACKed,
-				Version: testVersion,
-				ErrState: &UpdateErrorMetadata{
-					Version: testVersion,
-					Err:     errPlaceHolder,
-				},
-			},
-			wantErr: true,
+			wantMD:     errMD,
+			wantErr:    true,
 		},
 		{
 			name: "empty resource list",
@@ -507,15 +378,8 @@ func (s) TestUnmarshalListener_ClientSide(t *testing.T) {
 			name:       "v3 with two filters with same name",
 			resources:  []*anypb.Any{v3LisWithFilters(customFilter, customFilter)},
 			wantUpdate: map[string]ListenerUpdate{v3LDSTarget: {}},
-			wantMD: UpdateMetadata{
-				Status:  ServiceStatusNACKed,
-				Version: testVersion,
-				ErrState: &UpdateErrorMetadata{
-					Version: testVersion,
-					Err:     errPlaceHolder,
-				},
-			},
-			wantErr: true,
+			wantMD:     errMD,
+			wantErr:    true,
 		},
 		{
 			name:      "v3 with two filters - same type different name",
@@ -544,15 +408,8 @@ func (s) TestUnmarshalListener_ClientSide(t *testing.T) {
 			name:       "v3 with server-only filter",
 			resources:  []*anypb.Any{v3LisWithFilters(serverOnlyCustomFilter)},
 			wantUpdate: map[string]ListenerUpdate{v3LDSTarget: {}},
-			wantMD: UpdateMetadata{
-				Status:  ServiceStatusNACKed,
-				Version: testVersion,
-				ErrState: &UpdateErrorMetadata{
-					Version: testVersion,
-					Err:     errPlaceHolder,
-				},
-			},
-			wantErr: true,
+			wantMD:     errMD,
+			wantErr:    true,
 		},
 		{
 			name:      "v3 with optional server-only filter",
@@ -592,43 +449,22 @@ func (s) TestUnmarshalListener_ClientSide(t *testing.T) {
 			name:       "v3 with err filter",
 			resources:  []*anypb.Any{v3LisWithFilters(errFilter)},
 			wantUpdate: map[string]ListenerUpdate{v3LDSTarget: {}},
-			wantMD: UpdateMetadata{
-				Status:  ServiceStatusNACKed,
-				Version: testVersion,
-				ErrState: &UpdateErrorMetadata{
-					Version: testVersion,
-					Err:     errPlaceHolder,
-				},
-			},
-			wantErr: true,
+			wantMD:     errMD,
+			wantErr:    true,
 		},
 		{
 			name:       "v3 with optional err filter",
 			resources:  []*anypb.Any{v3LisWithFilters(errOptionalFilter)},
 			wantUpdate: map[string]ListenerUpdate{v3LDSTarget: {}},
-			wantMD: UpdateMetadata{
-				Status:  ServiceStatusNACKed,
-				Version: testVersion,
-				ErrState: &UpdateErrorMetadata{
-					Version: testVersion,
-					Err:     errPlaceHolder,
-				},
-			},
-			wantErr: true,
+			wantMD:     errMD,
+			wantErr:    true,
 		},
 		{
 			name:       "v3 with unknown filter",
 			resources:  []*anypb.Any{v3LisWithFilters(unknownFilter)},
 			wantUpdate: map[string]ListenerUpdate{v3LDSTarget: {}},
-			wantMD: UpdateMetadata{
-				Status:  ServiceStatusNACKed,
-				Version: testVersion,
-				ErrState: &UpdateErrorMetadata{
-					Version: testVersion,
-					Err:     errPlaceHolder,
-				},
-			},
-			wantErr: true,
+			wantMD:     errMD,
+			wantErr:    true,
 		},
 		{
 			name:      "v3 with unknown filter (optional)",
@@ -745,14 +581,7 @@ func (s) TestUnmarshalListener_ClientSide(t *testing.T) {
 				v3LDSTarget: {RouteConfigName: v3RouteConfigName, MaxStreamDuration: time.Second, Raw: v3LisWithFilters()},
 				"bad":       {},
 			},
-			wantMD: UpdateMetadata{
-				Status:  ServiceStatusNACKed,
-				Version: testVersion,
-				ErrState: &UpdateErrorMetadata{
-					Version: testVersion,
-					Err:     errPlaceHolder,
-				},
-			},
+			wantMD:  errMD,
 			wantErr: true,
 		},
 	}
@@ -778,46 +607,51 @@ func (s) TestUnmarshalListener_ClientSide(t *testing.T) {
 }
 
 func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
-	const v3LDSTarget = "grpc/server?xds.resource.listening_address=0.0.0.0:9999"
+	const (
+		v3LDSTarget = "grpc/server?xds.resource.listening_address=0.0.0.0:9999"
+		testVersion = "test-version-lds-server"
+	)
 
 	var (
-		listenerEmptyTransportSocket = marshalAny(&v3listenerpb.Listener{
-			Name: v3LDSTarget,
-			Address: &v3corepb.Address{
-				Address: &v3corepb.Address_SocketAddress{
-					SocketAddress: &v3corepb.SocketAddress{
-						Address: "0.0.0.0",
-						PortSpecifier: &v3corepb.SocketAddress_PortValue{
-							PortValue: 9999,
-						},
+		emptyValidNetworkFilters = []*v3listenerpb.Filter{
+			{
+				Name: "filter-1",
+				ConfigType: &v3listenerpb.Filter_TypedConfig{
+					TypedConfig: testutils.MarshalAny(&v3httppb.HttpConnectionManager{}),
+				},
+			},
+		}
+		localSocketAddress = &v3corepb.Address{
+			Address: &v3corepb.Address_SocketAddress{
+				SocketAddress: &v3corepb.SocketAddress{
+					Address: "0.0.0.0",
+					PortSpecifier: &v3corepb.SocketAddress_PortValue{
+						PortValue: 9999,
 					},
 				},
 			},
+		}
+		listenerEmptyTransportSocket = testutils.MarshalAny(&v3listenerpb.Listener{
+			Name:    v3LDSTarget,
+			Address: localSocketAddress,
 			FilterChains: []*v3listenerpb.FilterChain{
 				{
-					Name: "filter-chain-1",
+					Name:    "filter-chain-1",
+					Filters: emptyValidNetworkFilters,
 				},
 			},
 		})
-		listenerNoValidationContext = marshalAny(&v3listenerpb.Listener{
-			Name: v3LDSTarget,
-			Address: &v3corepb.Address{
-				Address: &v3corepb.Address_SocketAddress{
-					SocketAddress: &v3corepb.SocketAddress{
-						Address: "0.0.0.0",
-						PortSpecifier: &v3corepb.SocketAddress_PortValue{
-							PortValue: 9999,
-						},
-					},
-				},
-			},
+		listenerNoValidationContext = testutils.MarshalAny(&v3listenerpb.Listener{
+			Name:    v3LDSTarget,
+			Address: localSocketAddress,
 			FilterChains: []*v3listenerpb.FilterChain{
 				{
-					Name: "filter-chain-1",
+					Name:    "filter-chain-1",
+					Filters: emptyValidNetworkFilters,
 					TransportSocket: &v3corepb.TransportSocket{
 						Name: "envoy.transport_sockets.tls",
 						ConfigType: &v3corepb.TransportSocket_TypedConfig{
-							TypedConfig: marshalAny(&v3tlspb.DownstreamTlsContext{
+							TypedConfig: testutils.MarshalAny(&v3tlspb.DownstreamTlsContext{
 								CommonTlsContext: &v3tlspb.CommonTlsContext{
 									TlsCertificateCertificateProviderInstance: &v3tlspb.CommonTlsContext_CertificateProviderInstance{
 										InstanceName:    "identityPluginInstance",
@@ -830,11 +664,12 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 				},
 			},
 			DefaultFilterChain: &v3listenerpb.FilterChain{
-				Name: "default-filter-chain-1",
+				Name:    "default-filter-chain-1",
+				Filters: emptyValidNetworkFilters,
 				TransportSocket: &v3corepb.TransportSocket{
 					Name: "envoy.transport_sockets.tls",
 					ConfigType: &v3corepb.TransportSocket_TypedConfig{
-						TypedConfig: marshalAny(&v3tlspb.DownstreamTlsContext{
+						TypedConfig: testutils.MarshalAny(&v3tlspb.DownstreamTlsContext{
 							CommonTlsContext: &v3tlspb.CommonTlsContext{
 								TlsCertificateCertificateProviderInstance: &v3tlspb.CommonTlsContext_CertificateProviderInstance{
 									InstanceName:    "defaultIdentityPluginInstance",
@@ -846,25 +681,17 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 				},
 			},
 		})
-		listenerWithValidationContext = marshalAny(&v3listenerpb.Listener{
-			Name: v3LDSTarget,
-			Address: &v3corepb.Address{
-				Address: &v3corepb.Address_SocketAddress{
-					SocketAddress: &v3corepb.SocketAddress{
-						Address: "0.0.0.0",
-						PortSpecifier: &v3corepb.SocketAddress_PortValue{
-							PortValue: 9999,
-						},
-					},
-				},
-			},
+		listenerWithValidationContext = testutils.MarshalAny(&v3listenerpb.Listener{
+			Name:    v3LDSTarget,
+			Address: localSocketAddress,
 			FilterChains: []*v3listenerpb.FilterChain{
 				{
-					Name: "filter-chain-1",
+					Name:    "filter-chain-1",
+					Filters: emptyValidNetworkFilters,
 					TransportSocket: &v3corepb.TransportSocket{
 						Name: "envoy.transport_sockets.tls",
 						ConfigType: &v3corepb.TransportSocket_TypedConfig{
-							TypedConfig: marshalAny(&v3tlspb.DownstreamTlsContext{
+							TypedConfig: testutils.MarshalAny(&v3tlspb.DownstreamTlsContext{
 								RequireClientCertificate: &wrapperspb.BoolValue{Value: true},
 								CommonTlsContext: &v3tlspb.CommonTlsContext{
 									TlsCertificateCertificateProviderInstance: &v3tlspb.CommonTlsContext_CertificateProviderInstance{
@@ -884,11 +711,12 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 				},
 			},
 			DefaultFilterChain: &v3listenerpb.FilterChain{
-				Name: "default-filter-chain-1",
+				Name:    "default-filter-chain-1",
+				Filters: emptyValidNetworkFilters,
 				TransportSocket: &v3corepb.TransportSocket{
 					Name: "envoy.transport_sockets.tls",
 					ConfigType: &v3corepb.TransportSocket_TypedConfig{
-						TypedConfig: marshalAny(&v3tlspb.DownstreamTlsContext{
+						TypedConfig: testutils.MarshalAny(&v3tlspb.DownstreamTlsContext{
 							RequireClientCertificate: &wrapperspb.BoolValue{Value: true},
 							CommonTlsContext: &v3tlspb.CommonTlsContext{
 								TlsCertificateCertificateProviderInstance: &v3tlspb.CommonTlsContext_CertificateProviderInstance{
@@ -907,9 +735,15 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 				},
 			},
 		})
+		errMD = UpdateMetadata{
+			Status:  ServiceStatusNACKed,
+			Version: testVersion,
+			ErrState: &UpdateErrorMetadata{
+				Version: testVersion,
+				Err:     errPlaceHolder,
+			},
+		}
 	)
-
-	const testVersion = "test-version-lds-server"
 
 	tests := []struct {
 		name       string
@@ -920,448 +754,366 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 	}{
 		{
 			name: "non-empty listener filters",
-			resources: []*anypb.Any{
-				{
-					TypeUrl: version.V3ListenerURL,
-					Value: func() []byte {
-						lis := &v3listenerpb.Listener{
-							Name: v3LDSTarget,
-							ListenerFilters: []*v3listenerpb.ListenerFilter{
-								{Name: "listener-filter-1"},
-							},
-						}
-						mLis, _ := proto.Marshal(lis)
-						return mLis
-					}(),
+			resources: []*anypb.Any{testutils.MarshalAny(&v3listenerpb.Listener{
+				Name: v3LDSTarget,
+				ListenerFilters: []*v3listenerpb.ListenerFilter{
+					{Name: "listener-filter-1"},
 				},
-			},
+			})},
 			wantUpdate: map[string]ListenerUpdate{v3LDSTarget: {}},
-			wantMD: UpdateMetadata{
-				Status:  ServiceStatusNACKed,
-				Version: testVersion,
-				ErrState: &UpdateErrorMetadata{
-					Version: testVersion,
-					Err:     errPlaceHolder,
-				},
-			},
-			wantErr: "unsupported field 'listener_filters'",
+			wantMD:     errMD,
+			wantErr:    "unsupported field 'listener_filters'",
 		},
 		{
 			name: "use_original_dst is set",
-			resources: []*anypb.Any{
-				{
-					TypeUrl: version.V3ListenerURL,
-					Value: func() []byte {
-						lis := &v3listenerpb.Listener{
-							Name:           v3LDSTarget,
-							UseOriginalDst: &wrapperspb.BoolValue{Value: true},
-						}
-						mLis, _ := proto.Marshal(lis)
-						return mLis
-					}(),
-				},
-			},
+			resources: []*anypb.Any{testutils.MarshalAny(&v3listenerpb.Listener{
+				Name:           v3LDSTarget,
+				UseOriginalDst: &wrapperspb.BoolValue{Value: true},
+			})},
 			wantUpdate: map[string]ListenerUpdate{v3LDSTarget: {}},
-			wantMD: UpdateMetadata{
-				Status:  ServiceStatusNACKed,
-				Version: testVersion,
-				ErrState: &UpdateErrorMetadata{
-					Version: testVersion,
-					Err:     errPlaceHolder,
-				},
-			},
-			wantErr: "unsupported field 'use_original_dst'",
+			wantMD:     errMD,
+			wantErr:    "unsupported field 'use_original_dst'",
 		},
 		{
-			name: "no address field",
-			resources: []*anypb.Any{
-				{
-					TypeUrl: version.V3ListenerURL,
-					Value: func() []byte {
-						lis := &v3listenerpb.Listener{
-							Name: v3LDSTarget,
-						}
-						mLis, _ := proto.Marshal(lis)
-						return mLis
-					}(),
-				},
-			},
+			name:       "no address field",
+			resources:  []*anypb.Any{testutils.MarshalAny(&v3listenerpb.Listener{Name: v3LDSTarget})},
 			wantUpdate: map[string]ListenerUpdate{v3LDSTarget: {}},
-			wantMD: UpdateMetadata{
-				Status:  ServiceStatusNACKed,
-				Version: testVersion,
-				ErrState: &UpdateErrorMetadata{
-					Version: testVersion,
-					Err:     errPlaceHolder,
-				},
-			},
-			wantErr: "no address field in LDS response",
+			wantMD:     errMD,
+			wantErr:    "no address field in LDS response",
 		},
 		{
 			name: "no socket address field",
-			resources: []*anypb.Any{
-				{
-					TypeUrl: version.V3ListenerURL,
-					Value: func() []byte {
-						lis := &v3listenerpb.Listener{
-							Name:    v3LDSTarget,
-							Address: &v3corepb.Address{},
-						}
-						mLis, _ := proto.Marshal(lis)
-						return mLis
-					}(),
-				},
-			},
+			resources: []*anypb.Any{testutils.MarshalAny(&v3listenerpb.Listener{
+				Name:    v3LDSTarget,
+				Address: &v3corepb.Address{},
+			})},
 			wantUpdate: map[string]ListenerUpdate{v3LDSTarget: {}},
-			wantMD: UpdateMetadata{
-				Status:  ServiceStatusNACKed,
-				Version: testVersion,
-				ErrState: &UpdateErrorMetadata{
-					Version: testVersion,
-					Err:     errPlaceHolder,
-				},
-			},
-			wantErr: "no socket_address field in LDS response",
+			wantMD:     errMD,
+			wantErr:    "no socket_address field in LDS response",
 		},
 		{
 			name: "no filter chains and no default filter chain",
-			resources: []*anypb.Any{
-				{
-					TypeUrl: version.V3ListenerURL,
-					Value: func() []byte {
-						lis := &v3listenerpb.Listener{
-							Name: v3LDSTarget,
-							Address: &v3corepb.Address{
-								Address: &v3corepb.Address_SocketAddress{
-									SocketAddress: &v3corepb.SocketAddress{
-										Address: "0.0.0.0",
-										PortSpecifier: &v3corepb.SocketAddress_PortValue{
-											PortValue: 9999,
-										},
-									},
-								},
-							},
-							FilterChains: []*v3listenerpb.FilterChain{
-								{
-									FilterChainMatch: &v3listenerpb.FilterChainMatch{DestinationPort: &wrapperspb.UInt32Value{Value: 666}},
-								},
-							},
-						}
-						mLis, _ := proto.Marshal(lis)
-						return mLis
-					}(),
+			resources: []*anypb.Any{testutils.MarshalAny(&v3listenerpb.Listener{
+				Name:    v3LDSTarget,
+				Address: localSocketAddress,
+				FilterChains: []*v3listenerpb.FilterChain{
+					{
+						FilterChainMatch: &v3listenerpb.FilterChainMatch{DestinationPort: &wrapperspb.UInt32Value{Value: 666}},
+						Filters:          emptyValidNetworkFilters,
+					},
 				},
-			},
+			})},
 			wantUpdate: map[string]ListenerUpdate{v3LDSTarget: {}},
-			wantMD: UpdateMetadata{
-				Status:  ServiceStatusNACKed,
-				Version: testVersion,
-				ErrState: &UpdateErrorMetadata{
-					Version: testVersion,
-					Err:     errPlaceHolder,
+			wantMD:     errMD,
+			wantErr:    "no supported filter chains and no default filter chain",
+		},
+		{
+			name: "missing http connection manager network filter",
+			resources: []*anypb.Any{testutils.MarshalAny(&v3listenerpb.Listener{
+				Name:    v3LDSTarget,
+				Address: localSocketAddress,
+				FilterChains: []*v3listenerpb.FilterChain{
+					{
+						Name: "filter-chain-1",
+					},
 				},
-			},
-			wantErr: "no supported filter chains and no default filter chain",
+			})},
+			wantUpdate: map[string]ListenerUpdate{v3LDSTarget: {}},
+			wantMD:     errMD,
+			wantErr:    "filter chain missing HttpConnectionManager filter",
+		},
+		{
+			name: "missing filter name in http filter",
+			resources: []*anypb.Any{testutils.MarshalAny(&v3listenerpb.Listener{
+				Name:    v3LDSTarget,
+				Address: localSocketAddress,
+				FilterChains: []*v3listenerpb.FilterChain{
+					{
+						Name: "filter-chain-1",
+						Filters: []*v3listenerpb.Filter{
+							{
+								ConfigType: &v3listenerpb.Filter_TypedConfig{
+									TypedConfig: testutils.MarshalAny(&v3httppb.HttpConnectionManager{}),
+								},
+							},
+						},
+					},
+				},
+			})},
+			wantUpdate: map[string]ListenerUpdate{v3LDSTarget: {}},
+			wantMD:     errMD,
+			wantErr:    "filter missing name field",
+		},
+		{
+			name: "duplicate filter names in http filter",
+			resources: []*anypb.Any{testutils.MarshalAny(&v3listenerpb.Listener{
+				Name:    v3LDSTarget,
+				Address: localSocketAddress,
+				FilterChains: []*v3listenerpb.FilterChain{
+					{
+						Name: "filter-chain-1",
+						Filters: []*v3listenerpb.Filter{
+							{
+								Name: "name",
+								ConfigType: &v3listenerpb.Filter_TypedConfig{
+									TypedConfig: testutils.MarshalAny(&v3httppb.HttpConnectionManager{}),
+								},
+							},
+							{
+								Name: "name",
+								ConfigType: &v3listenerpb.Filter_TypedConfig{
+									TypedConfig: testutils.MarshalAny(&v3httppb.HttpConnectionManager{}),
+								},
+							},
+						},
+					},
+				},
+			})},
+			wantUpdate: map[string]ListenerUpdate{v3LDSTarget: {}},
+			wantMD:     errMD,
+			wantErr:    "duplicate filter name",
+		},
+		{
+			name: "unsupported oneof in typed config of http filter",
+			resources: []*anypb.Any{testutils.MarshalAny(&v3listenerpb.Listener{
+				Name:    v3LDSTarget,
+				Address: localSocketAddress,
+				FilterChains: []*v3listenerpb.FilterChain{
+					{
+						Name: "filter-chain-1",
+						Filters: []*v3listenerpb.Filter{
+							{
+								Name:       "name",
+								ConfigType: &v3listenerpb.Filter_ConfigDiscovery{},
+							},
+						},
+					},
+				},
+			})},
+			wantUpdate: map[string]ListenerUpdate{v3LDSTarget: {}},
+			wantMD:     errMD,
+			wantErr:    "unsupported config_type",
 		},
 		{
 			name: "overlapping filter chain match criteria",
-			resources: []*anypb.Any{
-				{
-					TypeUrl: version.V3ListenerURL,
-					Value: func() []byte {
-						lis := &v3listenerpb.Listener{
-							Name: v3LDSTarget,
-							Address: &v3corepb.Address{
-								Address: &v3corepb.Address_SocketAddress{
-									SocketAddress: &v3corepb.SocketAddress{
-										Address: "0.0.0.0",
-										PortSpecifier: &v3corepb.SocketAddress_PortValue{
-											PortValue: 9999,
-										},
+			resources: []*anypb.Any{testutils.MarshalAny(&v3listenerpb.Listener{
+				Name:    v3LDSTarget,
+				Address: localSocketAddress,
+				FilterChains: []*v3listenerpb.FilterChain{
+					{
+						FilterChainMatch: &v3listenerpb.FilterChainMatch{SourcePorts: []uint32{1, 2, 3, 4, 5}},
+						Filters:          emptyValidNetworkFilters,
+					},
+					{
+						FilterChainMatch: &v3listenerpb.FilterChainMatch{},
+						Filters:          emptyValidNetworkFilters,
+					},
+					{
+						FilterChainMatch: &v3listenerpb.FilterChainMatch{SourcePorts: []uint32{5, 6, 7}},
+						Filters:          emptyValidNetworkFilters,
+					},
+				},
+			})},
+			wantUpdate: map[string]ListenerUpdate{v3LDSTarget: {}},
+			wantMD:     errMD,
+			wantErr:    "multiple filter chains with overlapping matching rules are defined",
+		},
+		{
+			name: "unsupported network filter",
+			resources: []*anypb.Any{testutils.MarshalAny(&v3listenerpb.Listener{
+				Name:    v3LDSTarget,
+				Address: localSocketAddress,
+				FilterChains: []*v3listenerpb.FilterChain{
+					{
+						Name: "filter-chain-1",
+						Filters: []*v3listenerpb.Filter{
+							{
+								Name: "name",
+								ConfigType: &v3listenerpb.Filter_TypedConfig{
+									TypedConfig: testutils.MarshalAny(&v3httppb.LocalReplyConfig{}),
+								},
+							},
+						},
+					},
+				},
+			})},
+			wantUpdate: map[string]ListenerUpdate{v3LDSTarget: {}},
+			wantMD:     errMD,
+			wantErr:    "unsupported network filter",
+		},
+		{
+			name: "badly marshaled network filter",
+			resources: []*anypb.Any{testutils.MarshalAny(&v3listenerpb.Listener{
+				Name:    v3LDSTarget,
+				Address: localSocketAddress,
+				FilterChains: []*v3listenerpb.FilterChain{
+					{
+						Name: "filter-chain-1",
+						Filters: []*v3listenerpb.Filter{
+							{
+								Name: "name",
+								ConfigType: &v3listenerpb.Filter_TypedConfig{
+									TypedConfig: &anypb.Any{
+										TypeUrl: version.V3HTTPConnManagerURL,
+										Value:   []byte{1, 2, 3, 4},
 									},
 								},
 							},
-							FilterChains: []*v3listenerpb.FilterChain{
-								{
-									FilterChainMatch: &v3listenerpb.FilterChainMatch{SourcePorts: []uint32{1, 2, 3, 4, 5}},
-								},
-								{
-									FilterChainMatch: &v3listenerpb.FilterChainMatch{},
-								},
-								{
-									FilterChainMatch: &v3listenerpb.FilterChainMatch{SourcePorts: []uint32{5, 6, 7}},
+						},
+					},
+				},
+			})},
+			wantUpdate: map[string]ListenerUpdate{v3LDSTarget: {}},
+			wantMD:     errMD,
+			wantErr:    "failed to unmarshal network filter",
+		},
+		{
+			name: "client only http filter inside the network filter",
+			resources: []*anypb.Any{testutils.MarshalAny(&v3listenerpb.Listener{
+				Name:    v3LDSTarget,
+				Address: localSocketAddress,
+				FilterChains: []*v3listenerpb.FilterChain{
+					{
+						Name: "filter-chain-1",
+						Filters: []*v3listenerpb.Filter{
+							{
+								Name: "hcm",
+								ConfigType: &v3listenerpb.Filter_TypedConfig{
+									TypedConfig: testutils.MarshalAny(&v3httppb.HttpConnectionManager{
+										HttpFilters: []*v3httppb.HttpFilter{
+											{
+												Name:       "clientOnlyCustomFilter",
+												ConfigType: &v3httppb.HttpFilter_TypedConfig{TypedConfig: clientOnlyCustomFilterConfig},
+											},
+										},
+									}),
 								},
 							},
-						}
-						mLis, _ := proto.Marshal(lis)
-						return mLis
-					}(),
+						},
+					},
 				},
-			},
+			})},
 			wantUpdate: map[string]ListenerUpdate{v3LDSTarget: {}},
-			wantMD: UpdateMetadata{
-				Status:  ServiceStatusNACKed,
-				Version: testVersion,
-				ErrState: &UpdateErrorMetadata{
-					Version: testVersion,
-					Err:     errPlaceHolder,
-				},
-			},
-			wantErr: "multiple filter chains with overlapping matching rules are defined",
+			wantMD:     errMD,
+			wantErr:    "not supported server-side",
 		},
 		{
 			name: "unexpected transport socket name",
-			resources: []*anypb.Any{
-				{
-					TypeUrl: version.V3ListenerURL,
-					Value: func() []byte {
-						lis := &v3listenerpb.Listener{
-							Name: v3LDSTarget,
-							Address: &v3corepb.Address{
-								Address: &v3corepb.Address_SocketAddress{
-									SocketAddress: &v3corepb.SocketAddress{
-										Address: "0.0.0.0",
-										PortSpecifier: &v3corepb.SocketAddress_PortValue{
-											PortValue: 9999,
-										},
-									},
-								},
-							},
-							FilterChains: []*v3listenerpb.FilterChain{
-								{
-									Name: "filter-chain-1",
-									TransportSocket: &v3corepb.TransportSocket{
-										Name: "unsupported-transport-socket-name",
-									},
-								},
-							},
-						}
-						mLis, _ := proto.Marshal(lis)
-						return mLis
-					}(),
+			resources: []*anypb.Any{testutils.MarshalAny(&v3listenerpb.Listener{
+				Name:    v3LDSTarget,
+				Address: localSocketAddress,
+				FilterChains: []*v3listenerpb.FilterChain{
+					{
+						Name:    "filter-chain-1",
+						Filters: emptyValidNetworkFilters,
+						TransportSocket: &v3corepb.TransportSocket{
+							Name: "unsupported-transport-socket-name",
+						},
+					},
 				},
-			},
+			})},
 			wantUpdate: map[string]ListenerUpdate{v3LDSTarget: {}},
-			wantMD: UpdateMetadata{
-				Status:  ServiceStatusNACKed,
-				Version: testVersion,
-				ErrState: &UpdateErrorMetadata{
-					Version: testVersion,
-					Err:     errPlaceHolder,
-				},
-			},
-			wantErr: "transport_socket field has unexpected name",
+			wantMD:     errMD,
+			wantErr:    "transport_socket field has unexpected name",
 		},
 		{
 			name: "unexpected transport socket typedConfig URL",
-			resources: []*anypb.Any{
-				{
-					TypeUrl: version.V3ListenerURL,
-					Value: func() []byte {
-						lis := &v3listenerpb.Listener{
-							Name: v3LDSTarget,
-							Address: &v3corepb.Address{
-								Address: &v3corepb.Address_SocketAddress{
-									SocketAddress: &v3corepb.SocketAddress{
-										Address: "0.0.0.0",
-										PortSpecifier: &v3corepb.SocketAddress_PortValue{
-											PortValue: 9999,
-										},
-									},
-								},
+			resources: []*anypb.Any{testutils.MarshalAny(&v3listenerpb.Listener{
+				Name:    v3LDSTarget,
+				Address: localSocketAddress,
+				FilterChains: []*v3listenerpb.FilterChain{
+					{
+						Name:    "filter-chain-1",
+						Filters: emptyValidNetworkFilters,
+						TransportSocket: &v3corepb.TransportSocket{
+							Name: "envoy.transport_sockets.tls",
+							ConfigType: &v3corepb.TransportSocket_TypedConfig{
+								TypedConfig: testutils.MarshalAny(&v3tlspb.UpstreamTlsContext{}),
 							},
-							FilterChains: []*v3listenerpb.FilterChain{
-								{
-									Name: "filter-chain-1",
-									TransportSocket: &v3corepb.TransportSocket{
-										Name: "envoy.transport_sockets.tls",
-										ConfigType: &v3corepb.TransportSocket_TypedConfig{
-											TypedConfig: &anypb.Any{
-												TypeUrl: version.V3UpstreamTLSContextURL,
-											},
-										},
-									},
-								},
-							},
-						}
-						mLis, _ := proto.Marshal(lis)
-						return mLis
-					}(),
+						},
+					},
 				},
-			},
+			})},
 			wantUpdate: map[string]ListenerUpdate{v3LDSTarget: {}},
-			wantMD: UpdateMetadata{
-				Status:  ServiceStatusNACKed,
-				Version: testVersion,
-				ErrState: &UpdateErrorMetadata{
-					Version: testVersion,
-					Err:     errPlaceHolder,
-				},
-			},
-			wantErr: "transport_socket field has unexpected typeURL",
+			wantMD:     errMD,
+			wantErr:    "transport_socket field has unexpected typeURL",
 		},
 		{
 			name: "badly marshaled transport socket",
-			resources: []*anypb.Any{
-				{
-					TypeUrl: version.V3ListenerURL,
-					Value: func() []byte {
-						lis := &v3listenerpb.Listener{
-							Name: v3LDSTarget,
-							Address: &v3corepb.Address{
-								Address: &v3corepb.Address_SocketAddress{
-									SocketAddress: &v3corepb.SocketAddress{
-										Address: "0.0.0.0",
-										PortSpecifier: &v3corepb.SocketAddress_PortValue{
-											PortValue: 9999,
-										},
-									},
+			resources: []*anypb.Any{testutils.MarshalAny(&v3listenerpb.Listener{
+				Name:    v3LDSTarget,
+				Address: localSocketAddress,
+				FilterChains: []*v3listenerpb.FilterChain{
+					{
+						Name:    "filter-chain-1",
+						Filters: emptyValidNetworkFilters,
+						TransportSocket: &v3corepb.TransportSocket{
+							Name: "envoy.transport_sockets.tls",
+							ConfigType: &v3corepb.TransportSocket_TypedConfig{
+								TypedConfig: &anypb.Any{
+									TypeUrl: version.V3DownstreamTLSContextURL,
+									Value:   []byte{1, 2, 3, 4},
 								},
 							},
-							FilterChains: []*v3listenerpb.FilterChain{
-								{
-									Name: "filter-chain-1",
-									TransportSocket: &v3corepb.TransportSocket{
-										Name: "envoy.transport_sockets.tls",
-										ConfigType: &v3corepb.TransportSocket_TypedConfig{
-											TypedConfig: &anypb.Any{
-												TypeUrl: version.V3DownstreamTLSContextURL,
-												Value:   []byte{1, 2, 3, 4},
-											},
-										},
-									},
-								},
-							},
-						}
-						mLis, _ := proto.Marshal(lis)
-						return mLis
-					}(),
+						},
+					},
 				},
-			},
+			})},
 			wantUpdate: map[string]ListenerUpdate{v3LDSTarget: {}},
-			wantMD: UpdateMetadata{
-				Status:  ServiceStatusNACKed,
-				Version: testVersion,
-				ErrState: &UpdateErrorMetadata{
-					Version: testVersion,
-					Err:     errPlaceHolder,
-				},
-			},
-			wantErr: "failed to unmarshal DownstreamTlsContext in LDS response",
+			wantMD:     errMD,
+			wantErr:    "failed to unmarshal DownstreamTlsContext in LDS response",
 		},
 		{
 			name: "missing CommonTlsContext",
-			resources: []*anypb.Any{
-				{
-					TypeUrl: version.V3ListenerURL,
-					Value: func() []byte {
-						lis := &v3listenerpb.Listener{
-							Name: v3LDSTarget,
-							Address: &v3corepb.Address{
-								Address: &v3corepb.Address_SocketAddress{
-									SocketAddress: &v3corepb.SocketAddress{
-										Address: "0.0.0.0",
-										PortSpecifier: &v3corepb.SocketAddress_PortValue{
-											PortValue: 9999,
-										},
-									},
-								},
+			resources: []*anypb.Any{testutils.MarshalAny(&v3listenerpb.Listener{
+				Name:    v3LDSTarget,
+				Address: localSocketAddress,
+				FilterChains: []*v3listenerpb.FilterChain{
+					{
+						Name:    "filter-chain-1",
+						Filters: emptyValidNetworkFilters,
+						TransportSocket: &v3corepb.TransportSocket{
+							Name: "envoy.transport_sockets.tls",
+							ConfigType: &v3corepb.TransportSocket_TypedConfig{
+								TypedConfig: testutils.MarshalAny(&v3tlspb.DownstreamTlsContext{}),
 							},
-							FilterChains: []*v3listenerpb.FilterChain{
-								{
-									Name: "filter-chain-1",
-									TransportSocket: &v3corepb.TransportSocket{
-										Name: "envoy.transport_sockets.tls",
-										ConfigType: &v3corepb.TransportSocket_TypedConfig{
-											TypedConfig: &anypb.Any{
-												TypeUrl: version.V3DownstreamTLSContextURL,
-												Value: func() []byte {
-													tls := &v3tlspb.DownstreamTlsContext{}
-													mtls, _ := proto.Marshal(tls)
-													return mtls
-												}(),
-											},
-										},
-									},
-								},
-							},
-						}
-						mLis, _ := proto.Marshal(lis)
-						return mLis
-					}(),
+						},
+					},
 				},
-			},
+			})},
 			wantUpdate: map[string]ListenerUpdate{v3LDSTarget: {}},
-			wantMD: UpdateMetadata{
-				Status:  ServiceStatusNACKed,
-				Version: testVersion,
-				ErrState: &UpdateErrorMetadata{
-					Version: testVersion,
-					Err:     errPlaceHolder,
-				},
-			},
-			wantErr: "DownstreamTlsContext in LDS response does not contain a CommonTlsContext",
+			wantMD:     errMD,
+			wantErr:    "DownstreamTlsContext in LDS response does not contain a CommonTlsContext",
 		},
 		{
 			name: "unsupported validation context in transport socket",
-			resources: []*anypb.Any{
-				{
-					TypeUrl: version.V3ListenerURL,
-					Value: func() []byte {
-						lis := &v3listenerpb.Listener{
-							Name: v3LDSTarget,
-							Address: &v3corepb.Address{
-								Address: &v3corepb.Address_SocketAddress{
-									SocketAddress: &v3corepb.SocketAddress{
-										Address: "0.0.0.0",
-										PortSpecifier: &v3corepb.SocketAddress_PortValue{
-											PortValue: 9999,
-										},
-									},
-								},
-							},
-							FilterChains: []*v3listenerpb.FilterChain{
-								{
-									Name: "filter-chain-1",
-									TransportSocket: &v3corepb.TransportSocket{
-										Name: "envoy.transport_sockets.tls",
-										ConfigType: &v3corepb.TransportSocket_TypedConfig{
-											TypedConfig: &anypb.Any{
-												TypeUrl: version.V3DownstreamTLSContextURL,
-												Value: func() []byte {
-													tls := &v3tlspb.DownstreamTlsContext{
-														CommonTlsContext: &v3tlspb.CommonTlsContext{
-															ValidationContextType: &v3tlspb.CommonTlsContext_ValidationContextSdsSecretConfig{
-																ValidationContextSdsSecretConfig: &v3tlspb.SdsSecretConfig{
-																	Name: "foo-sds-secret",
-																},
-															},
-														},
-													}
-													mtls, _ := proto.Marshal(tls)
-													return mtls
-												}(),
+			resources: []*anypb.Any{testutils.MarshalAny(&v3listenerpb.Listener{
+				Name:    v3LDSTarget,
+				Address: localSocketAddress,
+				FilterChains: []*v3listenerpb.FilterChain{
+					{
+						Name:    "filter-chain-1",
+						Filters: emptyValidNetworkFilters,
+						TransportSocket: &v3corepb.TransportSocket{
+							Name: "envoy.transport_sockets.tls",
+							ConfigType: &v3corepb.TransportSocket_TypedConfig{
+								TypedConfig: testutils.MarshalAny(&v3tlspb.DownstreamTlsContext{
+									CommonTlsContext: &v3tlspb.CommonTlsContext{
+										ValidationContextType: &v3tlspb.CommonTlsContext_ValidationContextSdsSecretConfig{
+											ValidationContextSdsSecretConfig: &v3tlspb.SdsSecretConfig{
+												Name: "foo-sds-secret",
 											},
 										},
 									},
-								},
+								}),
 							},
-						}
-						mLis, _ := proto.Marshal(lis)
-						return mLis
-					}(),
+						},
+					},
 				},
-			},
+			})},
 			wantUpdate: map[string]ListenerUpdate{v3LDSTarget: {}},
-			wantMD: UpdateMetadata{
-				Status:  ServiceStatusNACKed,
-				Version: testVersion,
-				ErrState: &UpdateErrorMetadata{
-					Version: testVersion,
-					Err:     errPlaceHolder,
-				},
-			},
-			wantErr: "validation context contains unexpected type",
+			wantMD:     errMD,
+			wantErr:    "validation context contains unexpected type",
 		},
 		{
 			name:      "empty transport socket",
@@ -1402,119 +1154,57 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 		},
 		{
 			name: "no identity and root certificate providers",
-			resources: []*anypb.Any{
-				{
-					TypeUrl: version.V3ListenerURL,
-					Value: func() []byte {
-						lis := &v3listenerpb.Listener{
-							Name: v3LDSTarget,
-							Address: &v3corepb.Address{
-								Address: &v3corepb.Address_SocketAddress{
-									SocketAddress: &v3corepb.SocketAddress{
-										Address: "0.0.0.0",
-										PortSpecifier: &v3corepb.SocketAddress_PortValue{
-											PortValue: 9999,
+			resources: []*anypb.Any{testutils.MarshalAny(&v3listenerpb.Listener{
+				Name:    v3LDSTarget,
+				Address: localSocketAddress,
+				FilterChains: []*v3listenerpb.FilterChain{
+					{
+						Name:    "filter-chain-1",
+						Filters: emptyValidNetworkFilters,
+						TransportSocket: &v3corepb.TransportSocket{
+							Name: "envoy.transport_sockets.tls",
+							ConfigType: &v3corepb.TransportSocket_TypedConfig{
+								TypedConfig: testutils.MarshalAny(&v3tlspb.DownstreamTlsContext{
+									RequireClientCertificate: &wrapperspb.BoolValue{Value: true},
+									CommonTlsContext: &v3tlspb.CommonTlsContext{
+										TlsCertificateCertificateProviderInstance: &v3tlspb.CommonTlsContext_CertificateProviderInstance{
+											InstanceName:    "identityPluginInstance",
+											CertificateName: "identityCertName",
 										},
 									},
-								},
+								}),
 							},
-							FilterChains: []*v3listenerpb.FilterChain{
-								{
-									Name: "filter-chain-1",
-									TransportSocket: &v3corepb.TransportSocket{
-										Name: "envoy.transport_sockets.tls",
-										ConfigType: &v3corepb.TransportSocket_TypedConfig{
-											TypedConfig: &anypb.Any{
-												TypeUrl: version.V3DownstreamTLSContextURL,
-												Value: func() []byte {
-													tls := &v3tlspb.DownstreamTlsContext{
-														RequireClientCertificate: &wrapperspb.BoolValue{Value: true},
-														CommonTlsContext: &v3tlspb.CommonTlsContext{
-															TlsCertificateCertificateProviderInstance: &v3tlspb.CommonTlsContext_CertificateProviderInstance{
-																InstanceName:    "identityPluginInstance",
-																CertificateName: "identityCertName",
-															},
-														},
-													}
-													mtls, _ := proto.Marshal(tls)
-													return mtls
-												}(),
-											},
-										},
-									},
-								},
-							},
-						}
-						mLis, _ := proto.Marshal(lis)
-						return mLis
-					}(),
+						},
+					},
 				},
-			},
+			})},
 			wantUpdate: map[string]ListenerUpdate{v3LDSTarget: {}},
-			wantMD: UpdateMetadata{
-				Status:  ServiceStatusNACKed,
-				Version: testVersion,
-				ErrState: &UpdateErrorMetadata{
-					Version: testVersion,
-					Err:     errPlaceHolder,
-				},
-			},
-			wantErr: "security configuration on the server-side does not contain root certificate provider instance name, but require_client_cert field is set",
+			wantMD:     errMD,
+			wantErr:    "security configuration on the server-side does not contain root certificate provider instance name, but require_client_cert field is set",
 		},
 		{
 			name: "no identity certificate provider with require_client_cert",
-			resources: []*anypb.Any{
-				{
-					TypeUrl: version.V3ListenerURL,
-					Value: func() []byte {
-						lis := &v3listenerpb.Listener{
-							Name: v3LDSTarget,
-							Address: &v3corepb.Address{
-								Address: &v3corepb.Address_SocketAddress{
-									SocketAddress: &v3corepb.SocketAddress{
-										Address: "0.0.0.0",
-										PortSpecifier: &v3corepb.SocketAddress_PortValue{
-											PortValue: 9999,
-										},
-									},
-								},
+			resources: []*anypb.Any{testutils.MarshalAny(&v3listenerpb.Listener{
+				Name:    v3LDSTarget,
+				Address: localSocketAddress,
+				FilterChains: []*v3listenerpb.FilterChain{
+					{
+						Name:    "filter-chain-1",
+						Filters: emptyValidNetworkFilters,
+						TransportSocket: &v3corepb.TransportSocket{
+							Name: "envoy.transport_sockets.tls",
+							ConfigType: &v3corepb.TransportSocket_TypedConfig{
+								TypedConfig: testutils.MarshalAny(&v3tlspb.DownstreamTlsContext{
+									CommonTlsContext: &v3tlspb.CommonTlsContext{},
+								}),
 							},
-							FilterChains: []*v3listenerpb.FilterChain{
-								{
-									Name: "filter-chain-1",
-									TransportSocket: &v3corepb.TransportSocket{
-										Name: "envoy.transport_sockets.tls",
-										ConfigType: &v3corepb.TransportSocket_TypedConfig{
-											TypedConfig: &anypb.Any{
-												TypeUrl: version.V3DownstreamTLSContextURL,
-												Value: func() []byte {
-													tls := &v3tlspb.DownstreamTlsContext{
-														CommonTlsContext: &v3tlspb.CommonTlsContext{},
-													}
-													mtls, _ := proto.Marshal(tls)
-													return mtls
-												}(),
-											},
-										},
-									},
-								},
-							},
-						}
-						mLis, _ := proto.Marshal(lis)
-						return mLis
-					}(),
+						},
+					},
 				},
-			},
+			})},
 			wantUpdate: map[string]ListenerUpdate{v3LDSTarget: {}},
-			wantMD: UpdateMetadata{
-				Status:  ServiceStatusNACKed,
-				Version: testVersion,
-				ErrState: &UpdateErrorMetadata{
-					Version: testVersion,
-					Err:     errPlaceHolder,
-				},
-			},
-			wantErr: "security configuration on the server-side does not contain identity certificate provider instance name",
+			wantMD:     errMD,
+			wantErr:    "security configuration on the server-side does not contain identity certificate provider instance name",
 		},
 		{
 			name:      "happy case with no validation context",
@@ -1622,6 +1312,10 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			oldFI := env.FaultInjectionSupport
+			env.FaultInjectionSupport = true
+			defer func() { env.FaultInjectionSupport = oldFI }()
+
 			gotUpdate, md, err := UnmarshalListener(testVersion, test.resources, nil)
 			if (err != nil) != (test.wantErr != "") {
 				t.Fatalf("UnmarshalListener(), got err: %v, wantErr: %v", err, test.wantErr)
@@ -1744,7 +1438,7 @@ var customFilterTypedStructConfig = &v1typepb.TypedStruct{
 var wrappedCustomFilterTypedStructConfig *anypb.Any
 
 func init() {
-	wrappedCustomFilterTypedStructConfig = marshalAny(customFilterTypedStructConfig)
+	wrappedCustomFilterTypedStructConfig = testutils.MarshalAny(customFilterTypedStructConfig)
 }
 
 var unknownFilterConfig = &anypb.Any{
@@ -1753,19 +1447,11 @@ var unknownFilterConfig = &anypb.Any{
 }
 
 func wrappedOptionalFilter(name string) *anypb.Any {
-	return marshalAny(&v3routepb.FilterConfig{
+	return testutils.MarshalAny(&v3routepb.FilterConfig{
 		IsOptional: true,
 		Config: &anypb.Any{
 			TypeUrl: name,
 			Value:   []byte{1, 2, 3},
 		},
 	})
-}
-
-func marshalAny(m proto.Message) *anypb.Any {
-	a, err := ptypes.MarshalAny(m)
-	if err != nil {
-		panic(fmt.Sprintf("ptypes.MarshalAny(%+v) failed: %v", m, err))
-	}
-	return a
 }

--- a/xds/internal/client/lds_test.go
+++ b/xds/internal/client/lds_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/protobuf/types/known/durationpb"
 
-	testutils2 "google.golang.org/grpc/internal/testutils"
+	"google.golang.org/grpc/internal/testutils"
 	"google.golang.org/grpc/internal/xds/env"
 	"google.golang.org/grpc/xds/internal/httpfilter"
 	"google.golang.org/grpc/xds/internal/version"
@@ -59,10 +59,10 @@ func (s) TestUnmarshalListener_ClientSide(t *testing.T) {
 	)
 
 	var (
-		v2Lis = testutils2.MarshalAny(&v2xdspb.Listener{
+		v2Lis = testutils.MarshalAny(&v2xdspb.Listener{
 			Name: v2LDSTarget,
 			ApiListener: &v2listenerpb.ApiListener{
-				ApiListener: testutils2.MarshalAny(&v2httppb.HttpConnectionManager{
+				ApiListener: testutils.MarshalAny(&v2httppb.HttpConnectionManager{
 					RouteSpecifier: &v2httppb.HttpConnectionManager_Rds{
 						Rds: &v2httppb.Rds{
 							ConfigSource: &v2corepb.ConfigSource{
@@ -122,10 +122,10 @@ func (s) TestUnmarshalListener_ClientSide(t *testing.T) {
 			ConfigType: &v3httppb.HttpFilter_TypedConfig{TypedConfig: unknownFilterConfig},
 			IsOptional: true,
 		}
-		v3LisWithInlineRoute = testutils2.MarshalAny(&v3listenerpb.Listener{
+		v3LisWithInlineRoute = testutils.MarshalAny(&v3listenerpb.Listener{
 			Name: v3LDSTarget,
 			ApiListener: &v3listenerpb.ApiListener{
-				ApiListener: testutils2.MarshalAny(&v3httppb.HttpConnectionManager{
+				ApiListener: testutils.MarshalAny(&v3httppb.HttpConnectionManager{
 					RouteSpecifier: &v3httppb.HttpConnectionManager_RouteConfig{
 						RouteConfig: &v3routepb.RouteConfiguration{
 							Name: routeName,
@@ -147,10 +147,10 @@ func (s) TestUnmarshalListener_ClientSide(t *testing.T) {
 			},
 		})
 		v3LisWithFilters = func(fs ...*v3httppb.HttpFilter) *anypb.Any {
-			return testutils2.MarshalAny(&v3listenerpb.Listener{
+			return testutils.MarshalAny(&v3listenerpb.Listener{
 				Name: v3LDSTarget,
 				ApiListener: &v3listenerpb.ApiListener{
-					ApiListener: testutils2.MarshalAny(
+					ApiListener: testutils.MarshalAny(
 						&v3httppb.HttpConnectionManager{
 							RouteSpecifier: &v3httppb.HttpConnectionManager_Rds{
 								Rds: &v3httppb.Rds{
@@ -218,10 +218,10 @@ func (s) TestUnmarshalListener_ClientSide(t *testing.T) {
 		},
 		{
 			name: "wrong type in apiListener",
-			resources: []*anypb.Any{testutils2.MarshalAny(&v3listenerpb.Listener{
+			resources: []*anypb.Any{testutils.MarshalAny(&v3listenerpb.Listener{
 				Name: v3LDSTarget,
 				ApiListener: &v3listenerpb.ApiListener{
-					ApiListener: testutils2.MarshalAny(&v2xdspb.Listener{}),
+					ApiListener: testutils.MarshalAny(&v2xdspb.Listener{}),
 				},
 			})},
 			wantUpdate: map[string]ListenerUpdate{v3LDSTarget: {}},
@@ -230,10 +230,10 @@ func (s) TestUnmarshalListener_ClientSide(t *testing.T) {
 		},
 		{
 			name: "empty httpConnMgr in apiListener",
-			resources: []*anypb.Any{testutils2.MarshalAny(&v3listenerpb.Listener{
+			resources: []*anypb.Any{testutils.MarshalAny(&v3listenerpb.Listener{
 				Name: v3LDSTarget,
 				ApiListener: &v3listenerpb.ApiListener{
-					ApiListener: testutils2.MarshalAny(&v3httppb.HttpConnectionManager{
+					ApiListener: testutils.MarshalAny(&v3httppb.HttpConnectionManager{
 						RouteSpecifier: &v3httppb.HttpConnectionManager_Rds{
 							Rds: &v3httppb.Rds{},
 						},
@@ -246,7 +246,7 @@ func (s) TestUnmarshalListener_ClientSide(t *testing.T) {
 		},
 		{
 			name: "scopedRoutes routeConfig in apiListener",
-			resources: []*anypb.Any{testutils2.MarshalAny(&v3listenerpb.Listener{
+			resources: []*anypb.Any{testutils.MarshalAny(&v3listenerpb.Listener{
 				Name: v3LDSTarget,
 				ApiListener: &v3listenerpb.ApiListener{
 					ApiListener: &anypb.Any{
@@ -267,10 +267,10 @@ func (s) TestUnmarshalListener_ClientSide(t *testing.T) {
 		},
 		{
 			name: "rds.ConfigSource in apiListener is not ADS",
-			resources: []*anypb.Any{testutils2.MarshalAny(&v3listenerpb.Listener{
+			resources: []*anypb.Any{testutils.MarshalAny(&v3listenerpb.Listener{
 				Name: v3LDSTarget,
 				ApiListener: &v3listenerpb.ApiListener{
-					ApiListener: testutils2.MarshalAny(&v3httppb.HttpConnectionManager{
+					ApiListener: testutils.MarshalAny(&v3httppb.HttpConnectionManager{
 						RouteSpecifier: &v3httppb.HttpConnectionManager_Rds{
 							Rds: &v3httppb.Rds{
 								ConfigSource: &v3corepb.ConfigSource{
@@ -618,7 +618,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 			{
 				Name: "filter-1",
 				ConfigType: &v3listenerpb.Filter_TypedConfig{
-					TypedConfig: testutils2.MarshalAny(&v3httppb.HttpConnectionManager{}),
+					TypedConfig: testutils.MarshalAny(&v3httppb.HttpConnectionManager{}),
 				},
 			},
 		}
@@ -632,7 +632,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 				},
 			},
 		}
-		listenerEmptyTransportSocket = testutils2.MarshalAny(&v3listenerpb.Listener{
+		listenerEmptyTransportSocket = testutils.MarshalAny(&v3listenerpb.Listener{
 			Name:    v3LDSTarget,
 			Address: localSocketAddress,
 			FilterChains: []*v3listenerpb.FilterChain{
@@ -642,7 +642,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 				},
 			},
 		})
-		listenerNoValidationContext = testutils2.MarshalAny(&v3listenerpb.Listener{
+		listenerNoValidationContext = testutils.MarshalAny(&v3listenerpb.Listener{
 			Name:    v3LDSTarget,
 			Address: localSocketAddress,
 			FilterChains: []*v3listenerpb.FilterChain{
@@ -652,7 +652,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 					TransportSocket: &v3corepb.TransportSocket{
 						Name: "envoy.transport_sockets.tls",
 						ConfigType: &v3corepb.TransportSocket_TypedConfig{
-							TypedConfig: testutils2.MarshalAny(&v3tlspb.DownstreamTlsContext{
+							TypedConfig: testutils.MarshalAny(&v3tlspb.DownstreamTlsContext{
 								CommonTlsContext: &v3tlspb.CommonTlsContext{
 									TlsCertificateCertificateProviderInstance: &v3tlspb.CommonTlsContext_CertificateProviderInstance{
 										InstanceName:    "identityPluginInstance",
@@ -670,7 +670,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 				TransportSocket: &v3corepb.TransportSocket{
 					Name: "envoy.transport_sockets.tls",
 					ConfigType: &v3corepb.TransportSocket_TypedConfig{
-						TypedConfig: testutils2.MarshalAny(&v3tlspb.DownstreamTlsContext{
+						TypedConfig: testutils.MarshalAny(&v3tlspb.DownstreamTlsContext{
 							CommonTlsContext: &v3tlspb.CommonTlsContext{
 								TlsCertificateCertificateProviderInstance: &v3tlspb.CommonTlsContext_CertificateProviderInstance{
 									InstanceName:    "defaultIdentityPluginInstance",
@@ -682,7 +682,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 				},
 			},
 		})
-		listenerWithValidationContext = testutils2.MarshalAny(&v3listenerpb.Listener{
+		listenerWithValidationContext = testutils.MarshalAny(&v3listenerpb.Listener{
 			Name:    v3LDSTarget,
 			Address: localSocketAddress,
 			FilterChains: []*v3listenerpb.FilterChain{
@@ -692,7 +692,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 					TransportSocket: &v3corepb.TransportSocket{
 						Name: "envoy.transport_sockets.tls",
 						ConfigType: &v3corepb.TransportSocket_TypedConfig{
-							TypedConfig: testutils2.MarshalAny(&v3tlspb.DownstreamTlsContext{
+							TypedConfig: testutils.MarshalAny(&v3tlspb.DownstreamTlsContext{
 								RequireClientCertificate: &wrapperspb.BoolValue{Value: true},
 								CommonTlsContext: &v3tlspb.CommonTlsContext{
 									TlsCertificateCertificateProviderInstance: &v3tlspb.CommonTlsContext_CertificateProviderInstance{
@@ -717,7 +717,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 				TransportSocket: &v3corepb.TransportSocket{
 					Name: "envoy.transport_sockets.tls",
 					ConfigType: &v3corepb.TransportSocket_TypedConfig{
-						TypedConfig: testutils2.MarshalAny(&v3tlspb.DownstreamTlsContext{
+						TypedConfig: testutils.MarshalAny(&v3tlspb.DownstreamTlsContext{
 							RequireClientCertificate: &wrapperspb.BoolValue{Value: true},
 							CommonTlsContext: &v3tlspb.CommonTlsContext{
 								TlsCertificateCertificateProviderInstance: &v3tlspb.CommonTlsContext_CertificateProviderInstance{
@@ -755,7 +755,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 	}{
 		{
 			name: "non-empty listener filters",
-			resources: []*anypb.Any{testutils2.MarshalAny(&v3listenerpb.Listener{
+			resources: []*anypb.Any{testutils.MarshalAny(&v3listenerpb.Listener{
 				Name: v3LDSTarget,
 				ListenerFilters: []*v3listenerpb.ListenerFilter{
 					{Name: "listener-filter-1"},
@@ -767,7 +767,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 		},
 		{
 			name: "use_original_dst is set",
-			resources: []*anypb.Any{testutils2.MarshalAny(&v3listenerpb.Listener{
+			resources: []*anypb.Any{testutils.MarshalAny(&v3listenerpb.Listener{
 				Name:           v3LDSTarget,
 				UseOriginalDst: &wrapperspb.BoolValue{Value: true},
 			})},
@@ -777,14 +777,14 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 		},
 		{
 			name:       "no address field",
-			resources:  []*anypb.Any{testutils2.MarshalAny(&v3listenerpb.Listener{Name: v3LDSTarget})},
+			resources:  []*anypb.Any{testutils.MarshalAny(&v3listenerpb.Listener{Name: v3LDSTarget})},
 			wantUpdate: map[string]ListenerUpdate{v3LDSTarget: {}},
 			wantMD:     errMD,
 			wantErr:    "no address field in LDS response",
 		},
 		{
 			name: "no socket address field",
-			resources: []*anypb.Any{testutils2.MarshalAny(&v3listenerpb.Listener{
+			resources: []*anypb.Any{testutils.MarshalAny(&v3listenerpb.Listener{
 				Name:    v3LDSTarget,
 				Address: &v3corepb.Address{},
 			})},
@@ -794,7 +794,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 		},
 		{
 			name: "no filter chains and no default filter chain",
-			resources: []*anypb.Any{testutils2.MarshalAny(&v3listenerpb.Listener{
+			resources: []*anypb.Any{testutils.MarshalAny(&v3listenerpb.Listener{
 				Name:    v3LDSTarget,
 				Address: localSocketAddress,
 				FilterChains: []*v3listenerpb.FilterChain{
@@ -810,7 +810,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 		},
 		{
 			name: "missing http connection manager network filter",
-			resources: []*anypb.Any{testutils2.MarshalAny(&v3listenerpb.Listener{
+			resources: []*anypb.Any{testutils.MarshalAny(&v3listenerpb.Listener{
 				Name:    v3LDSTarget,
 				Address: localSocketAddress,
 				FilterChains: []*v3listenerpb.FilterChain{
@@ -825,7 +825,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 		},
 		{
 			name: "missing filter name in http filter",
-			resources: []*anypb.Any{testutils2.MarshalAny(&v3listenerpb.Listener{
+			resources: []*anypb.Any{testutils.MarshalAny(&v3listenerpb.Listener{
 				Name:    v3LDSTarget,
 				Address: localSocketAddress,
 				FilterChains: []*v3listenerpb.FilterChain{
@@ -834,7 +834,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 						Filters: []*v3listenerpb.Filter{
 							{
 								ConfigType: &v3listenerpb.Filter_TypedConfig{
-									TypedConfig: testutils2.MarshalAny(&v3httppb.HttpConnectionManager{}),
+									TypedConfig: testutils.MarshalAny(&v3httppb.HttpConnectionManager{}),
 								},
 							},
 						},
@@ -847,7 +847,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 		},
 		{
 			name: "duplicate filter names in http filter",
-			resources: []*anypb.Any{testutils2.MarshalAny(&v3listenerpb.Listener{
+			resources: []*anypb.Any{testutils.MarshalAny(&v3listenerpb.Listener{
 				Name:    v3LDSTarget,
 				Address: localSocketAddress,
 				FilterChains: []*v3listenerpb.FilterChain{
@@ -857,13 +857,13 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 							{
 								Name: "name",
 								ConfigType: &v3listenerpb.Filter_TypedConfig{
-									TypedConfig: testutils2.MarshalAny(&v3httppb.HttpConnectionManager{}),
+									TypedConfig: testutils.MarshalAny(&v3httppb.HttpConnectionManager{}),
 								},
 							},
 							{
 								Name: "name",
 								ConfigType: &v3listenerpb.Filter_TypedConfig{
-									TypedConfig: testutils2.MarshalAny(&v3httppb.HttpConnectionManager{}),
+									TypedConfig: testutils.MarshalAny(&v3httppb.HttpConnectionManager{}),
 								},
 							},
 						},
@@ -876,7 +876,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 		},
 		{
 			name: "unsupported oneof in typed config of http filter",
-			resources: []*anypb.Any{testutils2.MarshalAny(&v3listenerpb.Listener{
+			resources: []*anypb.Any{testutils.MarshalAny(&v3listenerpb.Listener{
 				Name:    v3LDSTarget,
 				Address: localSocketAddress,
 				FilterChains: []*v3listenerpb.FilterChain{
@@ -897,7 +897,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 		},
 		{
 			name: "overlapping filter chain match criteria",
-			resources: []*anypb.Any{testutils2.MarshalAny(&v3listenerpb.Listener{
+			resources: []*anypb.Any{testutils.MarshalAny(&v3listenerpb.Listener{
 				Name:    v3LDSTarget,
 				Address: localSocketAddress,
 				FilterChains: []*v3listenerpb.FilterChain{
@@ -921,7 +921,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 		},
 		{
 			name: "unsupported network filter",
-			resources: []*anypb.Any{testutils2.MarshalAny(&v3listenerpb.Listener{
+			resources: []*anypb.Any{testutils.MarshalAny(&v3listenerpb.Listener{
 				Name:    v3LDSTarget,
 				Address: localSocketAddress,
 				FilterChains: []*v3listenerpb.FilterChain{
@@ -931,7 +931,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 							{
 								Name: "name",
 								ConfigType: &v3listenerpb.Filter_TypedConfig{
-									TypedConfig: testutils2.MarshalAny(&v3httppb.LocalReplyConfig{}),
+									TypedConfig: testutils.MarshalAny(&v3httppb.LocalReplyConfig{}),
 								},
 							},
 						},
@@ -944,7 +944,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 		},
 		{
 			name: "badly marshaled network filter",
-			resources: []*anypb.Any{testutils2.MarshalAny(&v3listenerpb.Listener{
+			resources: []*anypb.Any{testutils.MarshalAny(&v3listenerpb.Listener{
 				Name:    v3LDSTarget,
 				Address: localSocketAddress,
 				FilterChains: []*v3listenerpb.FilterChain{
@@ -970,7 +970,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 		},
 		{
 			name: "client only http filter inside the network filter",
-			resources: []*anypb.Any{testutils2.MarshalAny(&v3listenerpb.Listener{
+			resources: []*anypb.Any{testutils.MarshalAny(&v3listenerpb.Listener{
 				Name:    v3LDSTarget,
 				Address: localSocketAddress,
 				FilterChains: []*v3listenerpb.FilterChain{
@@ -980,7 +980,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 							{
 								Name: "hcm",
 								ConfigType: &v3listenerpb.Filter_TypedConfig{
-									TypedConfig: testutils2.MarshalAny(&v3httppb.HttpConnectionManager{
+									TypedConfig: testutils.MarshalAny(&v3httppb.HttpConnectionManager{
 										HttpFilters: []*v3httppb.HttpFilter{
 											{
 												Name:       "clientOnlyCustomFilter",
@@ -1000,7 +1000,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 		},
 		{
 			name: "unexpected transport socket name",
-			resources: []*anypb.Any{testutils2.MarshalAny(&v3listenerpb.Listener{
+			resources: []*anypb.Any{testutils.MarshalAny(&v3listenerpb.Listener{
 				Name:    v3LDSTarget,
 				Address: localSocketAddress,
 				FilterChains: []*v3listenerpb.FilterChain{
@@ -1019,7 +1019,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 		},
 		{
 			name: "unexpected transport socket typedConfig URL",
-			resources: []*anypb.Any{testutils2.MarshalAny(&v3listenerpb.Listener{
+			resources: []*anypb.Any{testutils.MarshalAny(&v3listenerpb.Listener{
 				Name:    v3LDSTarget,
 				Address: localSocketAddress,
 				FilterChains: []*v3listenerpb.FilterChain{
@@ -1029,7 +1029,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 						TransportSocket: &v3corepb.TransportSocket{
 							Name: "envoy.transport_sockets.tls",
 							ConfigType: &v3corepb.TransportSocket_TypedConfig{
-								TypedConfig: testutils2.MarshalAny(&v3tlspb.UpstreamTlsContext{}),
+								TypedConfig: testutils.MarshalAny(&v3tlspb.UpstreamTlsContext{}),
 							},
 						},
 					},
@@ -1041,7 +1041,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 		},
 		{
 			name: "badly marshaled transport socket",
-			resources: []*anypb.Any{testutils2.MarshalAny(&v3listenerpb.Listener{
+			resources: []*anypb.Any{testutils.MarshalAny(&v3listenerpb.Listener{
 				Name:    v3LDSTarget,
 				Address: localSocketAddress,
 				FilterChains: []*v3listenerpb.FilterChain{
@@ -1066,7 +1066,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 		},
 		{
 			name: "missing CommonTlsContext",
-			resources: []*anypb.Any{testutils2.MarshalAny(&v3listenerpb.Listener{
+			resources: []*anypb.Any{testutils.MarshalAny(&v3listenerpb.Listener{
 				Name:    v3LDSTarget,
 				Address: localSocketAddress,
 				FilterChains: []*v3listenerpb.FilterChain{
@@ -1076,7 +1076,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 						TransportSocket: &v3corepb.TransportSocket{
 							Name: "envoy.transport_sockets.tls",
 							ConfigType: &v3corepb.TransportSocket_TypedConfig{
-								TypedConfig: testutils2.MarshalAny(&v3tlspb.DownstreamTlsContext{}),
+								TypedConfig: testutils.MarshalAny(&v3tlspb.DownstreamTlsContext{}),
 							},
 						},
 					},
@@ -1088,7 +1088,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 		},
 		{
 			name: "unsupported validation context in transport socket",
-			resources: []*anypb.Any{testutils2.MarshalAny(&v3listenerpb.Listener{
+			resources: []*anypb.Any{testutils.MarshalAny(&v3listenerpb.Listener{
 				Name:    v3LDSTarget,
 				Address: localSocketAddress,
 				FilterChains: []*v3listenerpb.FilterChain{
@@ -1098,7 +1098,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 						TransportSocket: &v3corepb.TransportSocket{
 							Name: "envoy.transport_sockets.tls",
 							ConfigType: &v3corepb.TransportSocket_TypedConfig{
-								TypedConfig: testutils2.MarshalAny(&v3tlspb.DownstreamTlsContext{
+								TypedConfig: testutils.MarshalAny(&v3tlspb.DownstreamTlsContext{
 									CommonTlsContext: &v3tlspb.CommonTlsContext{
 										ValidationContextType: &v3tlspb.CommonTlsContext_ValidationContextSdsSecretConfig{
 											ValidationContextSdsSecretConfig: &v3tlspb.SdsSecretConfig{
@@ -1155,7 +1155,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 		},
 		{
 			name: "no identity and root certificate providers",
-			resources: []*anypb.Any{testutils2.MarshalAny(&v3listenerpb.Listener{
+			resources: []*anypb.Any{testutils.MarshalAny(&v3listenerpb.Listener{
 				Name:    v3LDSTarget,
 				Address: localSocketAddress,
 				FilterChains: []*v3listenerpb.FilterChain{
@@ -1165,7 +1165,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 						TransportSocket: &v3corepb.TransportSocket{
 							Name: "envoy.transport_sockets.tls",
 							ConfigType: &v3corepb.TransportSocket_TypedConfig{
-								TypedConfig: testutils2.MarshalAny(&v3tlspb.DownstreamTlsContext{
+								TypedConfig: testutils.MarshalAny(&v3tlspb.DownstreamTlsContext{
 									RequireClientCertificate: &wrapperspb.BoolValue{Value: true},
 									CommonTlsContext: &v3tlspb.CommonTlsContext{
 										TlsCertificateCertificateProviderInstance: &v3tlspb.CommonTlsContext_CertificateProviderInstance{
@@ -1185,7 +1185,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 		},
 		{
 			name: "no identity certificate provider with require_client_cert",
-			resources: []*anypb.Any{testutils2.MarshalAny(&v3listenerpb.Listener{
+			resources: []*anypb.Any{testutils.MarshalAny(&v3listenerpb.Listener{
 				Name:    v3LDSTarget,
 				Address: localSocketAddress,
 				FilterChains: []*v3listenerpb.FilterChain{
@@ -1195,7 +1195,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 						TransportSocket: &v3corepb.TransportSocket{
 							Name: "envoy.transport_sockets.tls",
 							ConfigType: &v3corepb.TransportSocket_TypedConfig{
-								TypedConfig: testutils2.MarshalAny(&v3tlspb.DownstreamTlsContext{
+								TypedConfig: testutils.MarshalAny(&v3tlspb.DownstreamTlsContext{
 									CommonTlsContext: &v3tlspb.CommonTlsContext{},
 								}),
 							},
@@ -1439,7 +1439,7 @@ var customFilterTypedStructConfig = &v1typepb.TypedStruct{
 var wrappedCustomFilterTypedStructConfig *anypb.Any
 
 func init() {
-	wrappedCustomFilterTypedStructConfig = testutils2.MarshalAny(customFilterTypedStructConfig)
+	wrappedCustomFilterTypedStructConfig = testutils.MarshalAny(customFilterTypedStructConfig)
 }
 
 var unknownFilterConfig = &anypb.Any{
@@ -1448,7 +1448,7 @@ var unknownFilterConfig = &anypb.Any{
 }
 
 func wrappedOptionalFilter(name string) *anypb.Any {
-	return testutils2.MarshalAny(&v3routepb.FilterConfig{
+	return testutils.MarshalAny(&v3routepb.FilterConfig{
 		IsOptional: true,
 		Config: &anypb.Any{
 			TypeUrl: name,

--- a/xds/internal/client/lds_test.go
+++ b/xds/internal/client/lds_test.go
@@ -29,11 +29,12 @@ import (
 	"github.com/golang/protobuf/proto"
 	spb "github.com/golang/protobuf/ptypes/struct"
 	"github.com/google/go-cmp/cmp"
+	"google.golang.org/protobuf/types/known/durationpb"
+
+	testutils2 "google.golang.org/grpc/internal/testutils"
 	"google.golang.org/grpc/internal/xds/env"
 	"google.golang.org/grpc/xds/internal/httpfilter"
-	"google.golang.org/grpc/xds/internal/testutils"
 	"google.golang.org/grpc/xds/internal/version"
-	"google.golang.org/protobuf/types/known/durationpb"
 
 	v2xdspb "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	v2corepb "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
@@ -58,10 +59,10 @@ func (s) TestUnmarshalListener_ClientSide(t *testing.T) {
 	)
 
 	var (
-		v2Lis = testutils.MarshalAny(&v2xdspb.Listener{
+		v2Lis = testutils2.MarshalAny(&v2xdspb.Listener{
 			Name: v2LDSTarget,
 			ApiListener: &v2listenerpb.ApiListener{
-				ApiListener: testutils.MarshalAny(&v2httppb.HttpConnectionManager{
+				ApiListener: testutils2.MarshalAny(&v2httppb.HttpConnectionManager{
 					RouteSpecifier: &v2httppb.HttpConnectionManager_Rds{
 						Rds: &v2httppb.Rds{
 							ConfigSource: &v2corepb.ConfigSource{
@@ -121,10 +122,10 @@ func (s) TestUnmarshalListener_ClientSide(t *testing.T) {
 			ConfigType: &v3httppb.HttpFilter_TypedConfig{TypedConfig: unknownFilterConfig},
 			IsOptional: true,
 		}
-		v3LisWithInlineRoute = testutils.MarshalAny(&v3listenerpb.Listener{
+		v3LisWithInlineRoute = testutils2.MarshalAny(&v3listenerpb.Listener{
 			Name: v3LDSTarget,
 			ApiListener: &v3listenerpb.ApiListener{
-				ApiListener: testutils.MarshalAny(&v3httppb.HttpConnectionManager{
+				ApiListener: testutils2.MarshalAny(&v3httppb.HttpConnectionManager{
 					RouteSpecifier: &v3httppb.HttpConnectionManager_RouteConfig{
 						RouteConfig: &v3routepb.RouteConfiguration{
 							Name: routeName,
@@ -146,10 +147,10 @@ func (s) TestUnmarshalListener_ClientSide(t *testing.T) {
 			},
 		})
 		v3LisWithFilters = func(fs ...*v3httppb.HttpFilter) *anypb.Any {
-			return testutils.MarshalAny(&v3listenerpb.Listener{
+			return testutils2.MarshalAny(&v3listenerpb.Listener{
 				Name: v3LDSTarget,
 				ApiListener: &v3listenerpb.ApiListener{
-					ApiListener: testutils.MarshalAny(
+					ApiListener: testutils2.MarshalAny(
 						&v3httppb.HttpConnectionManager{
 							RouteSpecifier: &v3httppb.HttpConnectionManager_Rds{
 								Rds: &v3httppb.Rds{
@@ -217,10 +218,10 @@ func (s) TestUnmarshalListener_ClientSide(t *testing.T) {
 		},
 		{
 			name: "wrong type in apiListener",
-			resources: []*anypb.Any{testutils.MarshalAny(&v3listenerpb.Listener{
+			resources: []*anypb.Any{testutils2.MarshalAny(&v3listenerpb.Listener{
 				Name: v3LDSTarget,
 				ApiListener: &v3listenerpb.ApiListener{
-					ApiListener: testutils.MarshalAny(&v2xdspb.Listener{}),
+					ApiListener: testutils2.MarshalAny(&v2xdspb.Listener{}),
 				},
 			})},
 			wantUpdate: map[string]ListenerUpdate{v3LDSTarget: {}},
@@ -229,10 +230,10 @@ func (s) TestUnmarshalListener_ClientSide(t *testing.T) {
 		},
 		{
 			name: "empty httpConnMgr in apiListener",
-			resources: []*anypb.Any{testutils.MarshalAny(&v3listenerpb.Listener{
+			resources: []*anypb.Any{testutils2.MarshalAny(&v3listenerpb.Listener{
 				Name: v3LDSTarget,
 				ApiListener: &v3listenerpb.ApiListener{
-					ApiListener: testutils.MarshalAny(&v3httppb.HttpConnectionManager{
+					ApiListener: testutils2.MarshalAny(&v3httppb.HttpConnectionManager{
 						RouteSpecifier: &v3httppb.HttpConnectionManager_Rds{
 							Rds: &v3httppb.Rds{},
 						},
@@ -245,7 +246,7 @@ func (s) TestUnmarshalListener_ClientSide(t *testing.T) {
 		},
 		{
 			name: "scopedRoutes routeConfig in apiListener",
-			resources: []*anypb.Any{testutils.MarshalAny(&v3listenerpb.Listener{
+			resources: []*anypb.Any{testutils2.MarshalAny(&v3listenerpb.Listener{
 				Name: v3LDSTarget,
 				ApiListener: &v3listenerpb.ApiListener{
 					ApiListener: &anypb.Any{
@@ -266,10 +267,10 @@ func (s) TestUnmarshalListener_ClientSide(t *testing.T) {
 		},
 		{
 			name: "rds.ConfigSource in apiListener is not ADS",
-			resources: []*anypb.Any{testutils.MarshalAny(&v3listenerpb.Listener{
+			resources: []*anypb.Any{testutils2.MarshalAny(&v3listenerpb.Listener{
 				Name: v3LDSTarget,
 				ApiListener: &v3listenerpb.ApiListener{
-					ApiListener: testutils.MarshalAny(&v3httppb.HttpConnectionManager{
+					ApiListener: testutils2.MarshalAny(&v3httppb.HttpConnectionManager{
 						RouteSpecifier: &v3httppb.HttpConnectionManager_Rds{
 							Rds: &v3httppb.Rds{
 								ConfigSource: &v3corepb.ConfigSource{
@@ -617,7 +618,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 			{
 				Name: "filter-1",
 				ConfigType: &v3listenerpb.Filter_TypedConfig{
-					TypedConfig: testutils.MarshalAny(&v3httppb.HttpConnectionManager{}),
+					TypedConfig: testutils2.MarshalAny(&v3httppb.HttpConnectionManager{}),
 				},
 			},
 		}
@@ -631,7 +632,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 				},
 			},
 		}
-		listenerEmptyTransportSocket = testutils.MarshalAny(&v3listenerpb.Listener{
+		listenerEmptyTransportSocket = testutils2.MarshalAny(&v3listenerpb.Listener{
 			Name:    v3LDSTarget,
 			Address: localSocketAddress,
 			FilterChains: []*v3listenerpb.FilterChain{
@@ -641,7 +642,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 				},
 			},
 		})
-		listenerNoValidationContext = testutils.MarshalAny(&v3listenerpb.Listener{
+		listenerNoValidationContext = testutils2.MarshalAny(&v3listenerpb.Listener{
 			Name:    v3LDSTarget,
 			Address: localSocketAddress,
 			FilterChains: []*v3listenerpb.FilterChain{
@@ -651,7 +652,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 					TransportSocket: &v3corepb.TransportSocket{
 						Name: "envoy.transport_sockets.tls",
 						ConfigType: &v3corepb.TransportSocket_TypedConfig{
-							TypedConfig: testutils.MarshalAny(&v3tlspb.DownstreamTlsContext{
+							TypedConfig: testutils2.MarshalAny(&v3tlspb.DownstreamTlsContext{
 								CommonTlsContext: &v3tlspb.CommonTlsContext{
 									TlsCertificateCertificateProviderInstance: &v3tlspb.CommonTlsContext_CertificateProviderInstance{
 										InstanceName:    "identityPluginInstance",
@@ -669,7 +670,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 				TransportSocket: &v3corepb.TransportSocket{
 					Name: "envoy.transport_sockets.tls",
 					ConfigType: &v3corepb.TransportSocket_TypedConfig{
-						TypedConfig: testutils.MarshalAny(&v3tlspb.DownstreamTlsContext{
+						TypedConfig: testutils2.MarshalAny(&v3tlspb.DownstreamTlsContext{
 							CommonTlsContext: &v3tlspb.CommonTlsContext{
 								TlsCertificateCertificateProviderInstance: &v3tlspb.CommonTlsContext_CertificateProviderInstance{
 									InstanceName:    "defaultIdentityPluginInstance",
@@ -681,7 +682,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 				},
 			},
 		})
-		listenerWithValidationContext = testutils.MarshalAny(&v3listenerpb.Listener{
+		listenerWithValidationContext = testutils2.MarshalAny(&v3listenerpb.Listener{
 			Name:    v3LDSTarget,
 			Address: localSocketAddress,
 			FilterChains: []*v3listenerpb.FilterChain{
@@ -691,7 +692,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 					TransportSocket: &v3corepb.TransportSocket{
 						Name: "envoy.transport_sockets.tls",
 						ConfigType: &v3corepb.TransportSocket_TypedConfig{
-							TypedConfig: testutils.MarshalAny(&v3tlspb.DownstreamTlsContext{
+							TypedConfig: testutils2.MarshalAny(&v3tlspb.DownstreamTlsContext{
 								RequireClientCertificate: &wrapperspb.BoolValue{Value: true},
 								CommonTlsContext: &v3tlspb.CommonTlsContext{
 									TlsCertificateCertificateProviderInstance: &v3tlspb.CommonTlsContext_CertificateProviderInstance{
@@ -716,7 +717,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 				TransportSocket: &v3corepb.TransportSocket{
 					Name: "envoy.transport_sockets.tls",
 					ConfigType: &v3corepb.TransportSocket_TypedConfig{
-						TypedConfig: testutils.MarshalAny(&v3tlspb.DownstreamTlsContext{
+						TypedConfig: testutils2.MarshalAny(&v3tlspb.DownstreamTlsContext{
 							RequireClientCertificate: &wrapperspb.BoolValue{Value: true},
 							CommonTlsContext: &v3tlspb.CommonTlsContext{
 								TlsCertificateCertificateProviderInstance: &v3tlspb.CommonTlsContext_CertificateProviderInstance{
@@ -754,7 +755,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 	}{
 		{
 			name: "non-empty listener filters",
-			resources: []*anypb.Any{testutils.MarshalAny(&v3listenerpb.Listener{
+			resources: []*anypb.Any{testutils2.MarshalAny(&v3listenerpb.Listener{
 				Name: v3LDSTarget,
 				ListenerFilters: []*v3listenerpb.ListenerFilter{
 					{Name: "listener-filter-1"},
@@ -766,7 +767,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 		},
 		{
 			name: "use_original_dst is set",
-			resources: []*anypb.Any{testutils.MarshalAny(&v3listenerpb.Listener{
+			resources: []*anypb.Any{testutils2.MarshalAny(&v3listenerpb.Listener{
 				Name:           v3LDSTarget,
 				UseOriginalDst: &wrapperspb.BoolValue{Value: true},
 			})},
@@ -776,14 +777,14 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 		},
 		{
 			name:       "no address field",
-			resources:  []*anypb.Any{testutils.MarshalAny(&v3listenerpb.Listener{Name: v3LDSTarget})},
+			resources:  []*anypb.Any{testutils2.MarshalAny(&v3listenerpb.Listener{Name: v3LDSTarget})},
 			wantUpdate: map[string]ListenerUpdate{v3LDSTarget: {}},
 			wantMD:     errMD,
 			wantErr:    "no address field in LDS response",
 		},
 		{
 			name: "no socket address field",
-			resources: []*anypb.Any{testutils.MarshalAny(&v3listenerpb.Listener{
+			resources: []*anypb.Any{testutils2.MarshalAny(&v3listenerpb.Listener{
 				Name:    v3LDSTarget,
 				Address: &v3corepb.Address{},
 			})},
@@ -793,7 +794,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 		},
 		{
 			name: "no filter chains and no default filter chain",
-			resources: []*anypb.Any{testutils.MarshalAny(&v3listenerpb.Listener{
+			resources: []*anypb.Any{testutils2.MarshalAny(&v3listenerpb.Listener{
 				Name:    v3LDSTarget,
 				Address: localSocketAddress,
 				FilterChains: []*v3listenerpb.FilterChain{
@@ -809,7 +810,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 		},
 		{
 			name: "missing http connection manager network filter",
-			resources: []*anypb.Any{testutils.MarshalAny(&v3listenerpb.Listener{
+			resources: []*anypb.Any{testutils2.MarshalAny(&v3listenerpb.Listener{
 				Name:    v3LDSTarget,
 				Address: localSocketAddress,
 				FilterChains: []*v3listenerpb.FilterChain{
@@ -820,11 +821,11 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 			})},
 			wantUpdate: map[string]ListenerUpdate{v3LDSTarget: {}},
 			wantMD:     errMD,
-			wantErr:    "filter chain missing HttpConnectionManager filter",
+			wantErr:    "missing HttpConnectionManager filter",
 		},
 		{
 			name: "missing filter name in http filter",
-			resources: []*anypb.Any{testutils.MarshalAny(&v3listenerpb.Listener{
+			resources: []*anypb.Any{testutils2.MarshalAny(&v3listenerpb.Listener{
 				Name:    v3LDSTarget,
 				Address: localSocketAddress,
 				FilterChains: []*v3listenerpb.FilterChain{
@@ -833,7 +834,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 						Filters: []*v3listenerpb.Filter{
 							{
 								ConfigType: &v3listenerpb.Filter_TypedConfig{
-									TypedConfig: testutils.MarshalAny(&v3httppb.HttpConnectionManager{}),
+									TypedConfig: testutils2.MarshalAny(&v3httppb.HttpConnectionManager{}),
 								},
 							},
 						},
@@ -842,11 +843,11 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 			})},
 			wantUpdate: map[string]ListenerUpdate{v3LDSTarget: {}},
 			wantMD:     errMD,
-			wantErr:    "filter missing name field",
+			wantErr:    "missing name field in filter",
 		},
 		{
 			name: "duplicate filter names in http filter",
-			resources: []*anypb.Any{testutils.MarshalAny(&v3listenerpb.Listener{
+			resources: []*anypb.Any{testutils2.MarshalAny(&v3listenerpb.Listener{
 				Name:    v3LDSTarget,
 				Address: localSocketAddress,
 				FilterChains: []*v3listenerpb.FilterChain{
@@ -856,13 +857,13 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 							{
 								Name: "name",
 								ConfigType: &v3listenerpb.Filter_TypedConfig{
-									TypedConfig: testutils.MarshalAny(&v3httppb.HttpConnectionManager{}),
+									TypedConfig: testutils2.MarshalAny(&v3httppb.HttpConnectionManager{}),
 								},
 							},
 							{
 								Name: "name",
 								ConfigType: &v3listenerpb.Filter_TypedConfig{
-									TypedConfig: testutils.MarshalAny(&v3httppb.HttpConnectionManager{}),
+									TypedConfig: testutils2.MarshalAny(&v3httppb.HttpConnectionManager{}),
 								},
 							},
 						},
@@ -875,7 +876,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 		},
 		{
 			name: "unsupported oneof in typed config of http filter",
-			resources: []*anypb.Any{testutils.MarshalAny(&v3listenerpb.Listener{
+			resources: []*anypb.Any{testutils2.MarshalAny(&v3listenerpb.Listener{
 				Name:    v3LDSTarget,
 				Address: localSocketAddress,
 				FilterChains: []*v3listenerpb.FilterChain{
@@ -896,7 +897,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 		},
 		{
 			name: "overlapping filter chain match criteria",
-			resources: []*anypb.Any{testutils.MarshalAny(&v3listenerpb.Listener{
+			resources: []*anypb.Any{testutils2.MarshalAny(&v3listenerpb.Listener{
 				Name:    v3LDSTarget,
 				Address: localSocketAddress,
 				FilterChains: []*v3listenerpb.FilterChain{
@@ -920,7 +921,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 		},
 		{
 			name: "unsupported network filter",
-			resources: []*anypb.Any{testutils.MarshalAny(&v3listenerpb.Listener{
+			resources: []*anypb.Any{testutils2.MarshalAny(&v3listenerpb.Listener{
 				Name:    v3LDSTarget,
 				Address: localSocketAddress,
 				FilterChains: []*v3listenerpb.FilterChain{
@@ -930,7 +931,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 							{
 								Name: "name",
 								ConfigType: &v3listenerpb.Filter_TypedConfig{
-									TypedConfig: testutils.MarshalAny(&v3httppb.LocalReplyConfig{}),
+									TypedConfig: testutils2.MarshalAny(&v3httppb.LocalReplyConfig{}),
 								},
 							},
 						},
@@ -943,7 +944,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 		},
 		{
 			name: "badly marshaled network filter",
-			resources: []*anypb.Any{testutils.MarshalAny(&v3listenerpb.Listener{
+			resources: []*anypb.Any{testutils2.MarshalAny(&v3listenerpb.Listener{
 				Name:    v3LDSTarget,
 				Address: localSocketAddress,
 				FilterChains: []*v3listenerpb.FilterChain{
@@ -965,11 +966,11 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 			})},
 			wantUpdate: map[string]ListenerUpdate{v3LDSTarget: {}},
 			wantMD:     errMD,
-			wantErr:    "failed to unmarshal network filter",
+			wantErr:    "failed unmarshaling of network filter",
 		},
 		{
 			name: "client only http filter inside the network filter",
-			resources: []*anypb.Any{testutils.MarshalAny(&v3listenerpb.Listener{
+			resources: []*anypb.Any{testutils2.MarshalAny(&v3listenerpb.Listener{
 				Name:    v3LDSTarget,
 				Address: localSocketAddress,
 				FilterChains: []*v3listenerpb.FilterChain{
@@ -979,7 +980,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 							{
 								Name: "hcm",
 								ConfigType: &v3listenerpb.Filter_TypedConfig{
-									TypedConfig: testutils.MarshalAny(&v3httppb.HttpConnectionManager{
+									TypedConfig: testutils2.MarshalAny(&v3httppb.HttpConnectionManager{
 										HttpFilters: []*v3httppb.HttpFilter{
 											{
 												Name:       "clientOnlyCustomFilter",
@@ -999,7 +1000,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 		},
 		{
 			name: "unexpected transport socket name",
-			resources: []*anypb.Any{testutils.MarshalAny(&v3listenerpb.Listener{
+			resources: []*anypb.Any{testutils2.MarshalAny(&v3listenerpb.Listener{
 				Name:    v3LDSTarget,
 				Address: localSocketAddress,
 				FilterChains: []*v3listenerpb.FilterChain{
@@ -1018,7 +1019,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 		},
 		{
 			name: "unexpected transport socket typedConfig URL",
-			resources: []*anypb.Any{testutils.MarshalAny(&v3listenerpb.Listener{
+			resources: []*anypb.Any{testutils2.MarshalAny(&v3listenerpb.Listener{
 				Name:    v3LDSTarget,
 				Address: localSocketAddress,
 				FilterChains: []*v3listenerpb.FilterChain{
@@ -1028,7 +1029,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 						TransportSocket: &v3corepb.TransportSocket{
 							Name: "envoy.transport_sockets.tls",
 							ConfigType: &v3corepb.TransportSocket_TypedConfig{
-								TypedConfig: testutils.MarshalAny(&v3tlspb.UpstreamTlsContext{}),
+								TypedConfig: testutils2.MarshalAny(&v3tlspb.UpstreamTlsContext{}),
 							},
 						},
 					},
@@ -1040,7 +1041,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 		},
 		{
 			name: "badly marshaled transport socket",
-			resources: []*anypb.Any{testutils.MarshalAny(&v3listenerpb.Listener{
+			resources: []*anypb.Any{testutils2.MarshalAny(&v3listenerpb.Listener{
 				Name:    v3LDSTarget,
 				Address: localSocketAddress,
 				FilterChains: []*v3listenerpb.FilterChain{
@@ -1065,7 +1066,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 		},
 		{
 			name: "missing CommonTlsContext",
-			resources: []*anypb.Any{testutils.MarshalAny(&v3listenerpb.Listener{
+			resources: []*anypb.Any{testutils2.MarshalAny(&v3listenerpb.Listener{
 				Name:    v3LDSTarget,
 				Address: localSocketAddress,
 				FilterChains: []*v3listenerpb.FilterChain{
@@ -1075,7 +1076,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 						TransportSocket: &v3corepb.TransportSocket{
 							Name: "envoy.transport_sockets.tls",
 							ConfigType: &v3corepb.TransportSocket_TypedConfig{
-								TypedConfig: testutils.MarshalAny(&v3tlspb.DownstreamTlsContext{}),
+								TypedConfig: testutils2.MarshalAny(&v3tlspb.DownstreamTlsContext{}),
 							},
 						},
 					},
@@ -1087,7 +1088,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 		},
 		{
 			name: "unsupported validation context in transport socket",
-			resources: []*anypb.Any{testutils.MarshalAny(&v3listenerpb.Listener{
+			resources: []*anypb.Any{testutils2.MarshalAny(&v3listenerpb.Listener{
 				Name:    v3LDSTarget,
 				Address: localSocketAddress,
 				FilterChains: []*v3listenerpb.FilterChain{
@@ -1097,7 +1098,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 						TransportSocket: &v3corepb.TransportSocket{
 							Name: "envoy.transport_sockets.tls",
 							ConfigType: &v3corepb.TransportSocket_TypedConfig{
-								TypedConfig: testutils.MarshalAny(&v3tlspb.DownstreamTlsContext{
+								TypedConfig: testutils2.MarshalAny(&v3tlspb.DownstreamTlsContext{
 									CommonTlsContext: &v3tlspb.CommonTlsContext{
 										ValidationContextType: &v3tlspb.CommonTlsContext_ValidationContextSdsSecretConfig{
 											ValidationContextSdsSecretConfig: &v3tlspb.SdsSecretConfig{
@@ -1154,7 +1155,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 		},
 		{
 			name: "no identity and root certificate providers",
-			resources: []*anypb.Any{testutils.MarshalAny(&v3listenerpb.Listener{
+			resources: []*anypb.Any{testutils2.MarshalAny(&v3listenerpb.Listener{
 				Name:    v3LDSTarget,
 				Address: localSocketAddress,
 				FilterChains: []*v3listenerpb.FilterChain{
@@ -1164,7 +1165,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 						TransportSocket: &v3corepb.TransportSocket{
 							Name: "envoy.transport_sockets.tls",
 							ConfigType: &v3corepb.TransportSocket_TypedConfig{
-								TypedConfig: testutils.MarshalAny(&v3tlspb.DownstreamTlsContext{
+								TypedConfig: testutils2.MarshalAny(&v3tlspb.DownstreamTlsContext{
 									RequireClientCertificate: &wrapperspb.BoolValue{Value: true},
 									CommonTlsContext: &v3tlspb.CommonTlsContext{
 										TlsCertificateCertificateProviderInstance: &v3tlspb.CommonTlsContext_CertificateProviderInstance{
@@ -1184,7 +1185,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 		},
 		{
 			name: "no identity certificate provider with require_client_cert",
-			resources: []*anypb.Any{testutils.MarshalAny(&v3listenerpb.Listener{
+			resources: []*anypb.Any{testutils2.MarshalAny(&v3listenerpb.Listener{
 				Name:    v3LDSTarget,
 				Address: localSocketAddress,
 				FilterChains: []*v3listenerpb.FilterChain{
@@ -1194,7 +1195,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 						TransportSocket: &v3corepb.TransportSocket{
 							Name: "envoy.transport_sockets.tls",
 							ConfigType: &v3corepb.TransportSocket_TypedConfig{
-								TypedConfig: testutils.MarshalAny(&v3tlspb.DownstreamTlsContext{
+								TypedConfig: testutils2.MarshalAny(&v3tlspb.DownstreamTlsContext{
 									CommonTlsContext: &v3tlspb.CommonTlsContext{},
 								}),
 							},
@@ -1438,7 +1439,7 @@ var customFilterTypedStructConfig = &v1typepb.TypedStruct{
 var wrappedCustomFilterTypedStructConfig *anypb.Any
 
 func init() {
-	wrappedCustomFilterTypedStructConfig = testutils.MarshalAny(customFilterTypedStructConfig)
+	wrappedCustomFilterTypedStructConfig = testutils2.MarshalAny(customFilterTypedStructConfig)
 }
 
 var unknownFilterConfig = &anypb.Any{
@@ -1447,7 +1448,7 @@ var unknownFilterConfig = &anypb.Any{
 }
 
 func wrappedOptionalFilter(name string) *anypb.Any {
-	return testutils.MarshalAny(&v3routepb.FilterConfig{
+	return testutils2.MarshalAny(&v3routepb.FilterConfig{
 		IsOptional: true,
 		Config: &anypb.Any{
 			TypeUrl: name,

--- a/xds/internal/client/xds.go
+++ b/xds/internal/client/xds.go
@@ -291,10 +291,10 @@ func validateNetworkFilterChains(filterChains []*v3listenerpb.FilterChain) error
 		for _, filter := range filterChain.GetFilters() {
 			name := filter.GetName()
 			if name == "" {
-				return errors.New("filter missing name field")
+				return fmt.Errorf("filter chain {%+v} is missing name field in filter: {%+v}", filterChain, filter)
 			}
 			if seenNames[name] {
-				return fmt.Errorf("duplicate filter name %q", name)
+				return fmt.Errorf("filter chain {%+v} has duplicate filter name %q", filterChain, name)
 			}
 			seenNames[name] = true
 
@@ -315,11 +315,11 @@ func validateNetworkFilterChains(filterChains []*v3listenerpb.FilterChain) error
 				// we have for HTTP filters), when we have to support network
 				// filters other than HttpConnectionManager.
 				if tc.GetTypeUrl() != version.V3HTTPConnManagerURL {
-					return fmt.Errorf("unsupported network filter: %s", tc.GetTypeUrl())
+					return fmt.Errorf("filter chain {%+v} has unsupported network filter: %s", filterChain, tc.GetTypeUrl())
 				}
 				hcm := &v3httppb.HttpConnectionManager{}
 				if err := ptypes.UnmarshalAny(tc, hcm); err != nil {
-					return fmt.Errorf("failed to unmarshal network filter: %v", err)
+					return fmt.Errorf("filter chain {%+v} failed unmarshaling of network filter: %v", filterChain, err)
 				}
 				// We currently don't support HTTP filters on the server-side.
 				// We will be adding support for it in the future. So, we want
@@ -329,11 +329,11 @@ func validateNetworkFilterChains(filterChains []*v3listenerpb.FilterChain) error
 				}
 				seenHCM = true
 			default:
-				return fmt.Errorf("unsupported config_type %T in filter %s", typ, filter.GetName())
+				return fmt.Errorf("filter chain {%+v} has unsupported config_type %T in filter %s", filterChain, typ, filter.GetName())
 			}
 		}
 		if !seenHCM {
-			return errors.New("filter chain missing HttpConnectionManager filter")
+			return fmt.Errorf("filter chain {%+v} missing HttpConnectionManager filter", filterChain)
 		}
 	}
 	return nil

--- a/xds/internal/client/xds.go
+++ b/xds/internal/client/xds.go
@@ -269,6 +269,9 @@ func processServerSideListener(lis *v3listenerpb.Listener) (*ListenerUpdate, err
 			Port:    strconv.Itoa(int(sockAddr.GetPortValue())),
 		},
 	}
+	if err := validateNetworkFilterChains(append(lis.GetFilterChains(), lis.GetDefaultFilterChain())); err != nil {
+		return nil, err
+	}
 
 	fcMgr, err := NewFilterChainManager(lis)
 	if err != nil {
@@ -276,6 +279,64 @@ func processServerSideListener(lis *v3listenerpb.Listener) (*ListenerUpdate, err
 	}
 	lu.InboundListenerCfg.FilterChains = fcMgr
 	return lu, nil
+}
+
+func validateNetworkFilterChains(filterChains []*v3listenerpb.FilterChain) error {
+	for _, filterChain := range filterChains {
+		if filterChain == nil {
+			continue
+		}
+		seenNames := make(map[string]bool, len(filterChain.GetFilters()))
+		seenHCM := false
+		for _, filter := range filterChain.GetFilters() {
+			name := filter.GetName()
+			if name == "" {
+				return errors.New("filter missing name field")
+			}
+			if seenNames[name] {
+				return fmt.Errorf("duplicate filter name %q", name)
+			}
+			seenNames[name] = true
+
+			// Network filters have a oneof field named `config_type` where we
+			// only support `TypedConfig` variant.
+			switch typ := filter.GetConfigType().(type) {
+			case *v3listenerpb.Filter_TypedConfig:
+				// The typed_config field has an `anypb.Any` proto which could
+				// directly contain the serialized bytes of the actual filter
+				// configuration, or it could be encoded as a `TypedStruct`.
+				// TODO: Add support for `TypedStruct`.
+				tc := filter.GetTypedConfig()
+
+				// The only network filter that we currently support is the v3
+				// HttpConnectionManager. So, we can directly check the type_url
+				// and unmarshal the config.
+				// TODO: Implement a registry of supported network filters (like
+				// we have for HTTP filters), when we have to support network
+				// filters other than HttpConnectionManager.
+				if tc.GetTypeUrl() != version.V3HTTPConnManagerURL {
+					return fmt.Errorf("unsupported network filter: %s", tc.GetTypeUrl())
+				}
+				hcm := &v3httppb.HttpConnectionManager{}
+				if err := ptypes.UnmarshalAny(tc, hcm); err != nil {
+					return fmt.Errorf("failed to unmarshal network filter: %v", err)
+				}
+				// We currently don't support HTTP filters on the server-side.
+				// We will be adding support for it in the future. So, we want
+				// to make sure that the http_filters configuration is valid.
+				if _, err := processHTTPFilters(hcm.GetHttpFilters(), true); err != nil {
+					return err
+				}
+				seenHCM = true
+			default:
+				return fmt.Errorf("unsupported config_type %T in filter %s", typ, filter.GetName())
+			}
+		}
+		if !seenHCM {
+			return errors.New("filter chain missing HttpConnectionManager filter")
+		}
+	}
+	return nil
 }
 
 // UnmarshalRouteConfig processes resources received in an RDS response,

--- a/xds/internal/httpfilter/httpfilter.go
+++ b/xds/internal/httpfilter/httpfilter.go
@@ -65,9 +65,6 @@ type ClientInterceptorBuilder interface {
 
 // ServerInterceptorBuilder constructs a Server Interceptor.  If this type is
 // implemented by a Filter, it is capable of working on a server.
-//
-// Server side filters are not currently supported, but this interface is
-// defined for clarity.
 type ServerInterceptorBuilder interface {
 	// BuildServerInterceptor uses the FilterConfigs produced above to produce
 	// an HTTP filter interceptor for servers.  config will always be non-nil,

--- a/xds/internal/httpfilter/router/router.go
+++ b/xds/internal/httpfilter/router/router.go
@@ -73,7 +73,10 @@ func (builder) ParseFilterConfigOverride(override proto.Message) (httpfilter.Fil
 	return config{}, nil
 }
 
-var _ httpfilter.ClientInterceptorBuilder = builder{}
+var (
+	_ httpfilter.ClientInterceptorBuilder = builder{}
+	_ httpfilter.ServerInterceptorBuilder = builder{}
+)
 
 func (builder) BuildClientInterceptor(cfg, override httpfilter.FilterConfig) (iresolver.ClientInterceptor, error) {
 	if _, ok := cfg.(config); !ok {
@@ -85,6 +88,18 @@ func (builder) BuildClientInterceptor(cfg, override httpfilter.FilterConfig) (ir
 	// The gRPC router is implemented within the xds resolver's config
 	// selector, not as a separate plugin.  So we return a nil HTTPFilter,
 	// which will not be invoked.
+	return nil, nil
+}
+
+func (builder) BuildServerInterceptor(cfg, override httpfilter.FilterConfig) (iresolver.ServerInterceptor, error) {
+	if _, ok := cfg.(config); !ok {
+		return nil, fmt.Errorf("router: incorrect config type provided (%T): %v", cfg, cfg)
+	}
+	if override != nil {
+		return nil, fmt.Errorf("router: unexpected override configuration specified: %v", override)
+	}
+	// The gRPC router is currently unimplemented on the server side. So we
+	// return a nil HTTPFilter, which will not be invoked.
 	return nil, nil
 }
 

--- a/xds/internal/test/xds_server_integration_test.go
+++ b/xds/internal/test/xds_server_integration_test.go
@@ -33,30 +33,29 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/google/uuid"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/internal/testutils"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/testdata"
+	"google.golang.org/grpc/xds"
+	"google.golang.org/grpc/xds/internal/testutils/e2e"
+	"google.golang.org/grpc/xds/internal/version"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
+
 	v3corepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	v3listenerpb "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	v3httppb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	v3tlspb "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	wrapperspb "github.com/golang/protobuf/ptypes/wrappers"
-	"github.com/google/uuid"
-	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/types/known/anypb"
-
-	"google.golang.org/grpc/internal/testutils"
-	xds2 "google.golang.org/grpc/internal/xds"
-
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/credentials"
-	"google.golang.org/grpc/credentials/insecure"
 	xdscreds "google.golang.org/grpc/credentials/xds"
-	"google.golang.org/grpc/status"
+	xdsinternal "google.golang.org/grpc/internal/xds"
 	testpb "google.golang.org/grpc/test/grpc_testing"
-	"google.golang.org/grpc/testdata"
-	"google.golang.org/grpc/xds"
 	xdstestutils "google.golang.org/grpc/xds/internal/testutils"
-	"google.golang.org/grpc/xds/internal/testutils/e2e"
-	"google.golang.org/grpc/xds/internal/version"
 )
 
 const (
@@ -154,8 +153,8 @@ func commonSetup(t *testing.T) (*e2e.ManagementServer, string, net.Listener, fun
 	cpc := e2e.DefaultFileWatcherConfig(path.Join(tmpdir, certFile), path.Join(tmpdir, keyFile), path.Join(tmpdir, rootFile))
 
 	// Create a bootstrap file in a temporary directory.
-	bootstrapCleanup, err := xds2.SetupBootstrapFile(xds2.BootstrapOptions{
-		Version:                            xds2.TransportV3,
+	bootstrapCleanup, err := xdsinternal.SetupBootstrapFile(xdsinternal.BootstrapOptions{
+		Version:                            xdsinternal.TransportV3,
 		NodeID:                             nodeID,
 		ServerURI:                          fs.Address,
 		CertificateProviders:               cpc,

--- a/xds/internal/test/xds_server_integration_test.go
+++ b/xds/internal/test/xds_server_integration_test.go
@@ -42,7 +42,7 @@ import (
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 
-	testutils2 "google.golang.org/grpc/internal/testutils"
+	"google.golang.org/grpc/internal/testutils"
 	xds2 "google.golang.org/grpc/internal/xds"
 
 	"google.golang.org/grpc"
@@ -54,7 +54,7 @@ import (
 	testpb "google.golang.org/grpc/test/grpc_testing"
 	"google.golang.org/grpc/testdata"
 	"google.golang.org/grpc/xds"
-	"google.golang.org/grpc/xds/internal/testutils"
+	xdstestutils "google.golang.org/grpc/xds/internal/testutils"
 	"google.golang.org/grpc/xds/internal/testutils/e2e"
 	"google.golang.org/grpc/xds/internal/version"
 )
@@ -178,7 +178,7 @@ func commonSetup(t *testing.T) (*e2e.ManagementServer, string, net.Listener, fun
 	testpb.RegisterTestServiceServer(server, &testService{})
 
 	// Create a local listener and pass it to Serve().
-	lis, err := testutils.LocalTCPListener()
+	lis, err := xdstestutils.LocalTCPListener()
 	if err != nil {
 		t.Fatalf("testutils.LocalTCPListener() failed: %v", err)
 	}
@@ -236,7 +236,7 @@ func listenerResourceWithoutSecurityConfig(t *testing.T, lis net.Listener) *v3li
 					{
 						Name: "filter-1",
 						ConfigType: &v3listenerpb.Filter_TypedConfig{
-							TypedConfig: testutils2.MarshalAny(&v3httppb.HttpConnectionManager{}),
+							TypedConfig: testutils.MarshalAny(&v3httppb.HttpConnectionManager{}),
 						},
 					},
 				},
@@ -286,7 +286,7 @@ func listenerResourceWithSecurityConfig(t *testing.T, lis net.Listener) *v3liste
 					{
 						Name: "filter-1",
 						ConfigType: &v3listenerpb.Filter_TypedConfig{
-							TypedConfig: testutils2.MarshalAny(&v3httppb.HttpConnectionManager{}),
+							TypedConfig: testutils.MarshalAny(&v3httppb.HttpConnectionManager{}),
 						},
 					},
 				},

--- a/xds/internal/test/xds_server_integration_test.go
+++ b/xds/internal/test/xds_server_integration_test.go
@@ -35,6 +35,7 @@ import (
 
 	v3corepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	v3listenerpb "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	v3httppb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	v3tlspb "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	wrapperspb "github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/google/uuid"
@@ -229,6 +230,14 @@ func listenerResourceWithoutSecurityConfig(t *testing.T, lis net.Listener) *v3li
 		FilterChains: []*v3listenerpb.FilterChain{
 			{
 				Name: "filter-chain-1",
+				Filters: []*v3listenerpb.Filter{
+					{
+						Name: "filter-1",
+						ConfigType: &v3listenerpb.Filter_TypedConfig{
+							TypedConfig: testutils.MarshalAny(&v3httppb.HttpConnectionManager{}),
+						},
+					},
+				},
 			},
 		},
 	}
@@ -268,6 +277,14 @@ func listenerResourceWithSecurityConfig(t *testing.T, lis net.Listener) *v3liste
 							PrefixLen: &wrapperspb.UInt32Value{
 								Value: uint32(0),
 							},
+						},
+					},
+				},
+				Filters: []*v3listenerpb.Filter{
+					{
+						Name: "filter-1",
+						ConfigType: &v3listenerpb.Filter_TypedConfig{
+							TypedConfig: testutils.MarshalAny(&v3httppb.HttpConnectionManager{}),
 						},
 					},
 				},

--- a/xds/internal/test/xds_server_integration_test.go
+++ b/xds/internal/test/xds_server_integration_test.go
@@ -39,9 +39,11 @@ import (
 	v3tlspb "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	wrapperspb "github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/google/uuid"
-	xds2 "google.golang.org/grpc/internal/xds"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
+
+	testutils2 "google.golang.org/grpc/internal/testutils"
+	xds2 "google.golang.org/grpc/internal/xds"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -234,7 +236,7 @@ func listenerResourceWithoutSecurityConfig(t *testing.T, lis net.Listener) *v3li
 					{
 						Name: "filter-1",
 						ConfigType: &v3listenerpb.Filter_TypedConfig{
-							TypedConfig: testutils.MarshalAny(&v3httppb.HttpConnectionManager{}),
+							TypedConfig: testutils2.MarshalAny(&v3httppb.HttpConnectionManager{}),
 						},
 					},
 				},
@@ -284,7 +286,7 @@ func listenerResourceWithSecurityConfig(t *testing.T, lis net.Listener) *v3liste
 					{
 						Name: "filter-1",
 						ConfigType: &v3listenerpb.Filter_TypedConfig{
-							TypedConfig: testutils.MarshalAny(&v3httppb.HttpConnectionManager{}),
+							TypedConfig: testutils2.MarshalAny(&v3httppb.HttpConnectionManager{}),
 						},
 					},
 				},

--- a/xds/internal/testutils/marshal_any.go
+++ b/xds/internal/testutils/marshal_any.go
@@ -1,0 +1,36 @@
+/*
+ *
+ * Copyright 2020 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package testutils
+
+import (
+	"fmt"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/ptypes"
+	"google.golang.org/protobuf/types/known/anypb"
+)
+
+// MarshalAny is a convenience function to marshal protobuf messages into any
+// protos. It will panic if the marshaling fails.
+func MarshalAny(m proto.Message) *anypb.Any {
+	a, err := ptypes.MarshalAny(m)
+	if err != nil {
+		panic(fmt.Sprintf("ptypes.MarshalAny(%+v) failed: %v", m, err))
+	}
+	return a
+}


### PR DESCRIPTION
Summary of changes:
- Main filter validation change is in the `validateNetworkFilterChains()` function in `xds/internal/client/xds.go`
  - it uses the `processHTTPFilters()` which validates `http_filters` on the client-side
- server-side placeholder support for the `Router` filter
- reduce test bloat

#psm-security-server-side-filter-support

