### PR TITLE
xds/clusterimpl: trigger re-resolution on subconn transient_failure

### DIFF
--- a/xds/internal/balancer/clusterimpl/balancer_test.go
+++ b/xds/internal/balancer/clusterimpl/balancer_test.go
@@ -496,9 +496,6 @@ func TestReResolution(t *testing.T) {
 		t.Fatalf("unexpected error from UpdateClientConnState: %v", err)
 	}
 
-	// ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
-	// defer cancel()
-
 	sc1 := <-cc.NewSubConnCh
 	b.UpdateSubConnState(sc1, balancer.SubConnState{ConnectivityState: connectivity.Connecting})
 	// This should get the connecting picker.

--- a/xds/internal/balancer/clusterimpl/balancer_test.go
+++ b/xds/internal/balancer/clusterimpl/balancer_test.go
@@ -32,6 +32,7 @@ import (
 	"google.golang.org/grpc/internal"
 	internalserviceconfig "google.golang.org/grpc/internal/serviceconfig"
 	"google.golang.org/grpc/resolver"
+	"google.golang.org/grpc/xds/internal/client"
 	"google.golang.org/grpc/xds/internal/client/load"
 	"google.golang.org/grpc/xds/internal/testutils"
 	"google.golang.org/grpc/xds/internal/testutils/fakeclient"
@@ -69,6 +70,7 @@ func init() {
 // TestDropByCategory verifies that the balancer correctly drops the picks, and
 // that the drops are reported.
 func TestDropByCategory(t *testing.T) {
+	defer client.ClearCounterForTesting(testClusterName)
 	xdsC := fakeclient.NewClient()
 	oldNewXDSClient := newXDSClient
 	newXDSClient = func() (xdsClientInterface, error) { return xdsC, nil }
@@ -226,6 +228,7 @@ func TestDropByCategory(t *testing.T) {
 // TestDropCircuitBreaking verifies that the balancer correctly drops the picks
 // due to circuit breaking, and that the drops are reported.
 func TestDropCircuitBreaking(t *testing.T) {
+	defer client.ClearCounterForTesting(testClusterName)
 	xdsC := fakeclient.NewClient()
 	oldNewXDSClient := newXDSClient
 	newXDSClient = func() (xdsClientInterface, error) { return xdsC, nil }
@@ -337,6 +340,7 @@ func TestDropCircuitBreaking(t *testing.T) {
 // picker after it's closed. Because picker updates are sent in the run()
 // goroutine.
 func TestPickerUpdateAfterClose(t *testing.T) {
+	defer client.ClearCounterForTesting(testClusterName)
 	xdsC := fakeclient.NewClient()
 	oldNewXDSClient := newXDSClient
 	newXDSClient = func() (xdsClientInterface, error) { return xdsC, nil }
@@ -381,6 +385,7 @@ func TestPickerUpdateAfterClose(t *testing.T) {
 // TestClusterNameInAddressAttributes covers the case that cluster name is
 // attached to the subconn address attributes.
 func TestClusterNameInAddressAttributes(t *testing.T) {
+	defer client.ClearCounterForTesting(testClusterName)
 	xdsC := fakeclient.NewClient()
 	oldNewXDSClient := newXDSClient
 	newXDSClient = func() (xdsClientInterface, error) { return xdsC, nil }
@@ -471,6 +476,7 @@ func TestClusterNameInAddressAttributes(t *testing.T) {
 // TestReResolution verifies that when a SubConn turns transient failure,
 // re-resolution is triggered.
 func TestReResolution(t *testing.T) {
+	defer client.ClearCounterForTesting(testClusterName)
 	xdsC := fakeclient.NewClient()
 	oldNewXDSClient := newXDSClient
 	newXDSClient = func() (xdsClientInterface, error) { return xdsC, nil }

--- a/xds/internal/balancer/clusterimpl/clusterimpl.go
+++ b/xds/internal/balancer/clusterimpl/clusterimpl.go
@@ -294,13 +294,6 @@ func (cib *clusterImplBalancer) UpdateSubConnState(sc balancer.SubConn, s balanc
 	// EDS (cluster_impl doesn't know if it's DNS or EDS, only the parent
 	// knows). The parent priority policy is configured to ignore re-resolution
 	// signal from the EDS children.
-	//
-	// Another option is to add a boolean to cluster_impl's config, and only
-	// trigger re-resolution if that's true. But this requires changing the
-	// balancer config, and is not consistent for all languages.
-	//
-	// The final goal is to move re-resolution into the leaf policies
-	// (round_robin), so that this won't be necessary.
 	if s.ConnectivityState == connectivity.TransientFailure {
 		cib.ClientConn.ResolveNow(resolver.ResolveNowOptions{})
 	}


### PR DESCRIPTION
This will be triggered for both DNS and EDS children, and the parent priority policy will choose to ignore re-resolution from EDS children. Related to #4275