### PR TITLE
xds: support unspecified and wildcard filter chain prefixes

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1,10 +1,8 @@
 cloud.google.com/go v0.26.0 h1:e0WKqKTd5BnrG8aKH3J3h+QvEIQtSUcf2n5UZ5ZgLtQ=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
-github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/census-instrumentation/opencensus-proto v0.2.1 h1:glEXhBS5PSLLv4IXzLA5yPRVX4bilULVyxxbrfOtDAk=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/client9/misspell v0.3.4 h1:ta993UF76GwbvJcIo3Y68y/M3WxlpEHPWIGDkJYwzJI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403 h1:cqQfy1jclcSy/FwLjemeg3SR1yaINm74aQyupQ0Bl8M=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
@@ -43,7 +41,6 @@ github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
-golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 h1:VklqNMn3ovrHsnt90PveolxSbWFaJdECFbxSq0Mqo2M=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/xds/internal/client/filter_chain.go
+++ b/xds/internal/client/filter_chain.go
@@ -30,13 +30,22 @@ import (
 	"google.golang.org/grpc/xds/internal/version"
 )
 
-// Represents a wildcard IP prefix. Go stdlib `Contains()` method works for both
-// v4 and v6 addresses when used on this wildcard address.
-const emptyAddrMapKey = "0.0.0.0/0"
+const (
+	// Used as the map key for unspecified prefixes. The actual value of this
+	// key is immaterial.
+	unspecifiedPrefixMapKey = "unspecified"
 
-var (
-	// Parsed wildcard IP prefix.
-	_, zeroIP, _ = net.ParseCIDR("0.0.0.0/0")
+	// An unspecified destination or source prefix should be considered a less
+	// specific match than a wildcard prefix, `0.0.0.0/0` or `::/0`. Also, an
+	// unspecified prefix should match most v4 and v6 addresses compared to the
+	// wildcard prefixes which match only a specific network (v4 or v6).
+	//
+	// We use these constants when looking up the most specific prefix match. A
+	// wildcard prefix will match 0 bits, and to make sure that a wildcard
+	// prefix is considered a more specific match than an unspecified prefix, we
+	// use a value of -1 for the latter.
+	noPrefixMatch          = -2
+	unspecifiedPrefixMatch = -1
 )
 
 // FilterChain captures information from within a FilterChain message in a
@@ -108,7 +117,11 @@ type FilterChainManager struct {
 
 // destPrefixEntry is the value type of the map indexed on destination prefixes.
 type destPrefixEntry struct {
-	net *net.IPNet // The actual destination prefix.
+	// The actual destination prefix. Set to nil for unspecified prefixes.
+	net *net.IPNet
+	// Set to true for unspecified prefixes.
+	absent bool
+
 	// We need to keep track of the transport protocols seen as part of the
 	// config validation (and internal structure building) phase. The only two
 	// values that we support are empty string and "raw_buffer", with the latter
@@ -137,7 +150,10 @@ type sourcePrefixes struct {
 
 // sourcePrefixEntry contains match criteria per source prefix.
 type sourcePrefixEntry struct {
-	net *net.IPNet // The actual source prefix.
+	// The actual destination prefix. Set to nil for unspecified prefixes.
+	net *net.IPNet
+	// Set to true for unspecified prefixes.
+	absent bool
 	// Mapping from source ports specified in the match criteria to the actual
 	// filter chain. Unspecified source port matches en up as a wildcard entry
 	// here with a key of 0.
@@ -227,11 +243,11 @@ func (fci *FilterChainManager) addFilterChainsForDestPrefixes(fc *v3listenerpb.F
 	}
 
 	if len(dstPrefixes) == 0 {
-		// Use the wildcard IP when destination prefix is unspecified.
-		if fci.dstPrefixMap[emptyAddrMapKey] == nil {
-			fci.dstPrefixMap[emptyAddrMapKey] = &destPrefixEntry{net: zeroIP}
+		// Use the unspecified entry when destination prefix is unspecified.
+		if fci.dstPrefixMap[unspecifiedPrefixMapKey] == nil {
+			fci.dstPrefixMap[unspecifiedPrefixMapKey] = &destPrefixEntry{absent: true}
 		}
-		return fci.addFilterChainsForServerNames(fci.dstPrefixMap[emptyAddrMapKey], fc)
+		return fci.addFilterChainsForServerNames(fci.dstPrefixMap[unspecifiedPrefixMapKey], fc)
 	}
 	for _, prefix := range dstPrefixes {
 		p := prefix.String()
@@ -326,14 +342,14 @@ func (fci *FilterChainManager) addFilterChainsForSourcePrefixes(srcPrefixMap map
 	}
 
 	if len(srcPrefixes) == 0 {
-		// Use the wildcard IP when source prefix is unspecified.
-		if srcPrefixMap[emptyAddrMapKey] == nil {
-			srcPrefixMap[emptyAddrMapKey] = &sourcePrefixEntry{
-				net:        zeroIP,
+		// Use the unspecified entry when destination prefix is unspecified.
+		if srcPrefixMap[unspecifiedPrefixMapKey] == nil {
+			srcPrefixMap[unspecifiedPrefixMapKey] = &sourcePrefixEntry{
+				absent:     true,
 				srcPortMap: make(map[int]*FilterChain),
 			}
 		}
-		return fci.addFilterChainsForSourcePorts(srcPrefixMap[emptyAddrMapKey], fc)
+		return fci.addFilterChainsForSourcePorts(srcPrefixMap[unspecifiedPrefixMapKey], fc)
 	}
 	for _, prefix := range srcPrefixes {
 		p := prefix.String()
@@ -486,15 +502,24 @@ func filterByDestinationPrefixes(dstPrefixes []*destPrefixEntry, isUnspecified b
 		// bound to the wildcard address.
 		return dstPrefixes
 	}
-	var (
-		matchingDstPrefixes []*destPrefixEntry
-		maxSubnetMatch      int
-	)
+
+	var matchingDstPrefixes []*destPrefixEntry
+	maxSubnetMatch := noPrefixMatch
 	for _, prefix := range dstPrefixes {
-		if !prefix.net.Contains(dstAddr) {
+		var matchSize int
+		switch {
+		case prefix.absent:
+			// For unspecified prefixes, since we do not store a real net.IPNet
+			// inside prefix, we do not perform a match. Instead we simply set
+			// the matchSize to -1, which is less than the matchSize (0) for a
+			// wildcard prefix, but greater than the matchSize (-2) for a not
+			// matching prefix.
+			matchSize = unspecifiedPrefixMatch
+		case !prefix.net.Contains(dstAddr):
 			continue
+		default:
+			matchSize, _ = prefix.net.Mask.Size()
 		}
-		matchSize, _ := prefix.net.Mask.Size()
 		if matchSize < maxSubnetMatch {
 			continue
 		}
@@ -551,16 +576,23 @@ func filterBySourceType(dstPrefixes []*destPrefixEntry, srcType SourceType) []*s
 // algorithm. It trims the filter chains based on the source prefix. At most one
 // filter chain with the most specific match progress to the next stage.
 func filterBySourcePrefixes(srcPrefixes []*sourcePrefixes, srcAddr net.IP) (*sourcePrefixEntry, error) {
-	var (
-		matchingSrcPrefixes []*sourcePrefixEntry
-		maxSubnetMatch      int
-	)
+	var matchingSrcPrefixes []*sourcePrefixEntry
+	maxSubnetMatch := noPrefixMatch
 	for _, sp := range srcPrefixes {
 		for _, prefix := range sp.srcPrefixes {
-			if !prefix.net.Contains(srcAddr) {
+			var matchSize int
+			switch {
+			case prefix.absent:
+				// For unspecified prefixes, since we do not store a real net.IPNet
+				// inside prefix, we do not perform a match. Instead we simply set
+				// the matchSize to -1, which is less than the matchSize (0) for a
+				// wildcard prefix.
+				matchSize = unspecifiedPrefixMatch
+			case !prefix.net.Contains(srcAddr):
 				continue
+			default:
+				matchSize, _ = prefix.net.Mask.Size()
 			}
-			matchSize, _ := prefix.net.Mask.Size()
 			if matchSize < maxSubnetMatch {
 				continue
 			}

--- a/xds/internal/client/filter_chain_test.go
+++ b/xds/internal/client/filter_chain_test.go
@@ -396,12 +396,10 @@ func TestNewFilterChainImpl_Success_SecurityConfig(t *testing.T) {
 			wantFC: &FilterChainManager{
 				dstPrefixMap: map[string]*destPrefixEntry{
 					unspecifiedPrefixMapKey: {
-						absent: true,
 						srcTypeArr: [3]*sourcePrefixes{
 							{
 								srcPrefixMap: map[string]*sourcePrefixEntry{
 									unspecifiedPrefixMapKey: {
-										absent: true,
 										srcPortMap: map[int]*FilterChain{
 											0: {},
 										},
@@ -453,12 +451,10 @@ func TestNewFilterChainImpl_Success_SecurityConfig(t *testing.T) {
 			wantFC: &FilterChainManager{
 				dstPrefixMap: map[string]*destPrefixEntry{
 					unspecifiedPrefixMapKey: {
-						absent: true,
 						srcTypeArr: [3]*sourcePrefixes{
 							{
 								srcPrefixMap: map[string]*sourcePrefixEntry{
 									unspecifiedPrefixMapKey: {
-										absent: true,
 										srcPortMap: map[int]*FilterChain{
 											0: {
 												SecurityCfg: &SecurityConfig{
@@ -535,12 +531,10 @@ func TestNewFilterChainImpl_Success_SecurityConfig(t *testing.T) {
 			wantFC: &FilterChainManager{
 				dstPrefixMap: map[string]*destPrefixEntry{
 					unspecifiedPrefixMapKey: {
-						absent: true,
 						srcTypeArr: [3]*sourcePrefixes{
 							{
 								srcPrefixMap: map[string]*sourcePrefixEntry{
 									unspecifiedPrefixMapKey: {
-										absent: true,
 										srcPortMap: map[int]*FilterChain{
 											0: {
 												SecurityCfg: &SecurityConfig{
@@ -591,12 +585,10 @@ func TestNewFilterChainImpl_Success_SecurityConfig(t *testing.T) {
 // unsupported match fields will be skipped at lookup time.
 func TestNewFilterChainImpl_Success_UnsupportedMatchFields(t *testing.T) {
 	unspecifiedEntry := &destPrefixEntry{
-		absent: true,
 		srcTypeArr: [3]*sourcePrefixes{
 			{
 				srcPrefixMap: map[string]*sourcePrefixEntry{
 					unspecifiedPrefixMapKey: {
-						absent: true,
 						srcPortMap: map[int]*FilterChain{
 							0: {},
 						},
@@ -773,12 +765,10 @@ func TestNewFilterChainImpl_Success_AllCombinations(t *testing.T) {
 			wantFC: &FilterChainManager{
 				dstPrefixMap: map[string]*destPrefixEntry{
 					unspecifiedPrefixMapKey: {
-						absent: true,
 						srcTypeArr: [3]*sourcePrefixes{
 							{
 								srcPrefixMap: map[string]*sourcePrefixEntry{
 									unspecifiedPrefixMapKey: {
-										absent: true,
 										srcPortMap: map[int]*FilterChain{
 											0: {},
 										},
@@ -795,7 +785,6 @@ func TestNewFilterChainImpl_Success_AllCombinations(t *testing.T) {
 							{
 								srcPrefixMap: map[string]*sourcePrefixEntry{
 									unspecifiedPrefixMapKey: {
-										absent: true,
 										srcPortMap: map[int]*FilterChain{
 											0: {},
 										},
@@ -812,7 +801,6 @@ func TestNewFilterChainImpl_Success_AllCombinations(t *testing.T) {
 							{
 								srcPrefixMap: map[string]*sourcePrefixEntry{
 									unspecifiedPrefixMapKey: {
-										absent: true,
 										srcPortMap: map[int]*FilterChain{
 											0: {},
 										},
@@ -827,7 +815,6 @@ func TestNewFilterChainImpl_Success_AllCombinations(t *testing.T) {
 							{
 								srcPrefixMap: map[string]*sourcePrefixEntry{
 									unspecifiedPrefixMapKey: {
-										absent: true,
 										srcPortMap: map[int]*FilterChain{
 											0: {},
 										},
@@ -842,7 +829,6 @@ func TestNewFilterChainImpl_Success_AllCombinations(t *testing.T) {
 							{
 								srcPrefixMap: map[string]*sourcePrefixEntry{
 									unspecifiedPrefixMapKey: {
-										absent: true,
 										srcPortMap: map[int]*FilterChain{
 											0: {},
 										},
@@ -874,13 +860,11 @@ func TestNewFilterChainImpl_Success_AllCombinations(t *testing.T) {
 			wantFC: &FilterChainManager{
 				dstPrefixMap: map[string]*destPrefixEntry{
 					unspecifiedPrefixMapKey: {
-						absent: true,
 						srcTypeArr: [3]*sourcePrefixes{
 							nil,
 							{
 								srcPrefixMap: map[string]*sourcePrefixEntry{
 									unspecifiedPrefixMapKey: {
-										absent: true,
 										srcPortMap: map[int]*FilterChain{
 											0: {},
 										},
@@ -897,7 +881,6 @@ func TestNewFilterChainImpl_Success_AllCombinations(t *testing.T) {
 							{
 								srcPrefixMap: map[string]*sourcePrefixEntry{
 									unspecifiedPrefixMapKey: {
-										absent: true,
 										srcPortMap: map[int]*FilterChain{
 											0: {},
 										},
@@ -929,7 +912,6 @@ func TestNewFilterChainImpl_Success_AllCombinations(t *testing.T) {
 			wantFC: &FilterChainManager{
 				dstPrefixMap: map[string]*destPrefixEntry{
 					unspecifiedPrefixMapKey: {
-						absent: true,
 						srcTypeArr: [3]*sourcePrefixes{
 							{
 								srcPrefixMap: map[string]*sourcePrefixEntry{
@@ -983,12 +965,10 @@ func TestNewFilterChainImpl_Success_AllCombinations(t *testing.T) {
 			wantFC: &FilterChainManager{
 				dstPrefixMap: map[string]*destPrefixEntry{
 					unspecifiedPrefixMapKey: {
-						absent: true,
 						srcTypeArr: [3]*sourcePrefixes{
 							{
 								srcPrefixMap: map[string]*sourcePrefixEntry{
 									unspecifiedPrefixMapKey: {
-										absent: true,
 										srcPortMap: map[int]*FilterChain{
 											1: {},
 											2: {},
@@ -1081,12 +1061,10 @@ func TestNewFilterChainImpl_Success_AllCombinations(t *testing.T) {
 			wantFC: &FilterChainManager{
 				dstPrefixMap: map[string]*destPrefixEntry{
 					unspecifiedPrefixMapKey: {
-						absent: true,
 						srcTypeArr: [3]*sourcePrefixes{
 							{
 								srcPrefixMap: map[string]*sourcePrefixEntry{
 									unspecifiedPrefixMapKey: {
-										absent: true,
 										srcPortMap: map[int]*FilterChain{
 											0: {},
 										},
@@ -1101,7 +1079,6 @@ func TestNewFilterChainImpl_Success_AllCombinations(t *testing.T) {
 							{
 								srcPrefixMap: map[string]*sourcePrefixEntry{
 									unspecifiedPrefixMapKey: {
-										absent: true,
 										srcPortMap: map[int]*FilterChain{
 											0: {},
 										},
@@ -1116,7 +1093,6 @@ func TestNewFilterChainImpl_Success_AllCombinations(t *testing.T) {
 							{
 								srcPrefixMap: map[string]*sourcePrefixEntry{
 									unspecifiedPrefixMapKey: {
-										absent: true,
 										srcPortMap: map[int]*FilterChain{
 											0: {},
 										},

--- a/xds/internal/client/filter_chain_test.go
+++ b/xds/internal/client/filter_chain_test.go
@@ -35,6 +35,8 @@ import (
 	"google.golang.org/grpc/xds/internal/version"
 )
 
+// TestNewFilterChainImpl_Failure_BadMatchFields verifies cases where we have a
+// single filter chain with match criteria that contains unsupported fields.
 func TestNewFilterChainImpl_Failure_BadMatchFields(t *testing.T) {
 	tests := []struct {
 		desc string
@@ -131,6 +133,8 @@ func TestNewFilterChainImpl_Failure_BadMatchFields(t *testing.T) {
 	}
 }
 
+// TestNewFilterChainImpl_Failure_OverlappingMatchingRules verifies cases where
+// there are multiple filter chains and they have overlapping match rules.
 func TestNewFilterChainImpl_Failure_OverlappingMatchingRules(t *testing.T) {
 	tests := []struct {
 		desc string
@@ -218,6 +222,8 @@ func TestNewFilterChainImpl_Failure_OverlappingMatchingRules(t *testing.T) {
 	}
 }
 
+// TestNewFilterChainImpl_Failure_BadSecurityConfig verifies cases where the
+// security configuration in the filter chain is invalid.
 func TestNewFilterChainImpl_Failure_BadSecurityConfig(t *testing.T) {
 	tests := []struct {
 		desc    string
@@ -369,6 +375,8 @@ func TestNewFilterChainImpl_Failure_BadSecurityConfig(t *testing.T) {
 	}
 }
 
+// TestNewFilterChainImpl_Success_SecurityConfig verifies cases where the
+// security configuration in the filter chain contains valid data.
 func TestNewFilterChainImpl_Success_SecurityConfig(t *testing.T) {
 	tests := []struct {
 		desc   string
@@ -387,13 +395,13 @@ func TestNewFilterChainImpl_Success_SecurityConfig(t *testing.T) {
 			},
 			wantFC: &FilterChainManager{
 				dstPrefixMap: map[string]*destPrefixEntry{
-					"0.0.0.0/0": {
-						net: zeroIP,
+					unspecifiedPrefixMapKey: {
+						absent: true,
 						srcTypeArr: [3]*sourcePrefixes{
 							{
 								srcPrefixMap: map[string]*sourcePrefixEntry{
-									"0.0.0.0/0": {
-										net: zeroIP,
+									unspecifiedPrefixMapKey: {
+										absent: true,
 										srcPortMap: map[int]*FilterChain{
 											0: {},
 										},
@@ -444,13 +452,13 @@ func TestNewFilterChainImpl_Success_SecurityConfig(t *testing.T) {
 			},
 			wantFC: &FilterChainManager{
 				dstPrefixMap: map[string]*destPrefixEntry{
-					"0.0.0.0/0": {
-						net: zeroIP,
+					unspecifiedPrefixMapKey: {
+						absent: true,
 						srcTypeArr: [3]*sourcePrefixes{
 							{
 								srcPrefixMap: map[string]*sourcePrefixEntry{
-									"0.0.0.0/0": {
-										net: zeroIP,
+									unspecifiedPrefixMapKey: {
+										absent: true,
 										srcPortMap: map[int]*FilterChain{
 											0: {
 												SecurityCfg: &SecurityConfig{
@@ -526,13 +534,13 @@ func TestNewFilterChainImpl_Success_SecurityConfig(t *testing.T) {
 			},
 			wantFC: &FilterChainManager{
 				dstPrefixMap: map[string]*destPrefixEntry{
-					"0.0.0.0/0": {
-						net: zeroIP,
+					unspecifiedPrefixMapKey: {
+						absent: true,
 						srcTypeArr: [3]*sourcePrefixes{
 							{
 								srcPrefixMap: map[string]*sourcePrefixEntry{
-									"0.0.0.0/0": {
-										net: zeroIP,
+									unspecifiedPrefixMapKey: {
+										absent: true,
 										srcPortMap: map[int]*FilterChain{
 											0: {
 												SecurityCfg: &SecurityConfig{
@@ -576,6 +584,155 @@ func TestNewFilterChainImpl_Success_SecurityConfig(t *testing.T) {
 	}
 }
 
+// TestNewFilterChainImpl_Success_UnsupportedMatchFields verifies cases where
+// there are multiple filter chains, and one of them is valid while the other
+// contains unsupported match fields. These configurations should lead to
+// success at config validation time and the filter chains which contains
+// unsupported match fields will be skipped at lookup time.
+func TestNewFilterChainImpl_Success_UnsupportedMatchFields(t *testing.T) {
+	unspecifiedEntry := &destPrefixEntry{
+		absent: true,
+		srcTypeArr: [3]*sourcePrefixes{
+			{
+				srcPrefixMap: map[string]*sourcePrefixEntry{
+					unspecifiedPrefixMapKey: {
+						absent: true,
+						srcPortMap: map[int]*FilterChain{
+							0: {},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		desc   string
+		lis    *v3listenerpb.Listener
+		wantFC *FilterChainManager
+	}{
+		{
+			desc: "unsupported destination port",
+			lis: &v3listenerpb.Listener{
+				FilterChains: []*v3listenerpb.FilterChain{
+					{
+						Name: "good-chain",
+					},
+					{
+						Name: "unsupported-destination-port",
+						FilterChainMatch: &v3listenerpb.FilterChainMatch{
+							PrefixRanges:    []*v3corepb.CidrRange{cidrRangeFromAddressAndPrefixLen("192.168.1.1", 16)},
+							DestinationPort: &wrapperspb.UInt32Value{Value: 666},
+						},
+					},
+				},
+				DefaultFilterChain: &v3listenerpb.FilterChain{},
+			},
+			wantFC: &FilterChainManager{
+				dstPrefixMap: map[string]*destPrefixEntry{
+					unspecifiedPrefixMapKey: unspecifiedEntry,
+				},
+				def: &FilterChain{},
+			},
+		},
+		{
+			desc: "unsupported server names",
+			lis: &v3listenerpb.Listener{
+				FilterChains: []*v3listenerpb.FilterChain{
+					{
+						Name: "good-chain",
+					},
+					{
+						Name: "unsupported-server-names",
+						FilterChainMatch: &v3listenerpb.FilterChainMatch{
+							PrefixRanges: []*v3corepb.CidrRange{cidrRangeFromAddressAndPrefixLen("192.168.1.1", 16)},
+							ServerNames:  []string{"example-server"},
+						},
+					},
+				},
+				DefaultFilterChain: &v3listenerpb.FilterChain{},
+			},
+			wantFC: &FilterChainManager{
+				dstPrefixMap: map[string]*destPrefixEntry{
+					unspecifiedPrefixMapKey: unspecifiedEntry,
+					"192.168.0.0/16": {
+						net: ipNetFromCIDR("192.168.2.2/16"),
+					},
+				},
+				def: &FilterChain{},
+			},
+		},
+		{
+			desc: "unsupported transport protocol",
+			lis: &v3listenerpb.Listener{
+				FilterChains: []*v3listenerpb.FilterChain{
+					{
+						Name: "good-chain",
+					},
+					{
+						Name: "unsupported-transport-protocol",
+						FilterChainMatch: &v3listenerpb.FilterChainMatch{
+							PrefixRanges:      []*v3corepb.CidrRange{cidrRangeFromAddressAndPrefixLen("192.168.1.1", 16)},
+							TransportProtocol: "tls",
+						},
+					},
+				},
+				DefaultFilterChain: &v3listenerpb.FilterChain{},
+			},
+			wantFC: &FilterChainManager{
+				dstPrefixMap: map[string]*destPrefixEntry{
+					unspecifiedPrefixMapKey: unspecifiedEntry,
+					"192.168.0.0/16": {
+						net: ipNetFromCIDR("192.168.2.2/16"),
+					},
+				},
+				def: &FilterChain{},
+			},
+		},
+		{
+			desc: "unsupported application protocol",
+			lis: &v3listenerpb.Listener{
+				FilterChains: []*v3listenerpb.FilterChain{
+					{
+						Name: "good-chain",
+					},
+					{
+						Name: "unsupported-application-protocol",
+						FilterChainMatch: &v3listenerpb.FilterChainMatch{
+							PrefixRanges:         []*v3corepb.CidrRange{cidrRangeFromAddressAndPrefixLen("192.168.1.1", 16)},
+							ApplicationProtocols: []string{"h2"},
+						},
+					},
+				},
+				DefaultFilterChain: &v3listenerpb.FilterChain{},
+			},
+			wantFC: &FilterChainManager{
+				dstPrefixMap: map[string]*destPrefixEntry{
+					unspecifiedPrefixMapKey: unspecifiedEntry,
+					"192.168.0.0/16": {
+						net: ipNetFromCIDR("192.168.2.2/16"),
+					},
+				},
+				def: &FilterChain{},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			gotFC, err := NewFilterChainManager(test.lis)
+			if err != nil {
+				t.Fatalf("NewFilterChainManager() returned err: %v, wantErr: nil", err)
+			}
+			if !cmp.Equal(gotFC, test.wantFC, cmp.AllowUnexported(FilterChainManager{}, destPrefixEntry{}, sourcePrefixes{}, sourcePrefixEntry{})) {
+				t.Fatalf("NewFilterChainManager() returned %+v, want: %+v", gotFC, test.wantFC)
+			}
+		})
+	}
+}
+
+// TestNewFilterChainImpl_Success_AllCombinations verifies different
+// combinations of the supported match criteria.
 func TestNewFilterChainImpl_Success_AllCombinations(t *testing.T) {
 	tests := []struct {
 		desc   string
@@ -587,7 +744,22 @@ func TestNewFilterChainImpl_Success_AllCombinations(t *testing.T) {
 			lis: &v3listenerpb.Listener{
 				FilterChains: []*v3listenerpb.FilterChain{
 					{
+						// Unspecified destination prefix.
 						FilterChainMatch: &v3listenerpb.FilterChainMatch{},
+					},
+					{
+						// v4 wildcard destination prefix.
+						FilterChainMatch: &v3listenerpb.FilterChainMatch{
+							PrefixRanges: []*v3corepb.CidrRange{cidrRangeFromAddressAndPrefixLen("0.0.0.0", 0)},
+							SourceType:   v3listenerpb.FilterChainMatch_EXTERNAL,
+						},
+					},
+					{
+						// v6 wildcard destination prefix.
+						FilterChainMatch: &v3listenerpb.FilterChainMatch{
+							PrefixRanges: []*v3corepb.CidrRange{cidrRangeFromAddressAndPrefixLen("::", 0)},
+							SourceType:   v3listenerpb.FilterChainMatch_EXTERNAL,
+						},
 					},
 					{
 						FilterChainMatch: &v3listenerpb.FilterChainMatch{PrefixRanges: []*v3corepb.CidrRange{cidrRangeFromAddressAndPrefixLen("192.168.1.1", 16)}},
@@ -600,13 +772,47 @@ func TestNewFilterChainImpl_Success_AllCombinations(t *testing.T) {
 			},
 			wantFC: &FilterChainManager{
 				dstPrefixMap: map[string]*destPrefixEntry{
-					"0.0.0.0/0": {
-						net: zeroIP,
+					unspecifiedPrefixMapKey: {
+						absent: true,
 						srcTypeArr: [3]*sourcePrefixes{
 							{
 								srcPrefixMap: map[string]*sourcePrefixEntry{
-									"0.0.0.0/0": {
-										net: zeroIP,
+									unspecifiedPrefixMapKey: {
+										absent: true,
+										srcPortMap: map[int]*FilterChain{
+											0: {},
+										},
+									},
+								},
+							},
+						},
+					},
+					"0.0.0.0/0": {
+						net: ipNetFromCIDR("0.0.0.0/0"),
+						srcTypeArr: [3]*sourcePrefixes{
+							nil,
+							nil,
+							{
+								srcPrefixMap: map[string]*sourcePrefixEntry{
+									unspecifiedPrefixMapKey: {
+										absent: true,
+										srcPortMap: map[int]*FilterChain{
+											0: {},
+										},
+									},
+								},
+							},
+						},
+					},
+					"::/0": {
+						net: ipNetFromCIDR("::/0"),
+						srcTypeArr: [3]*sourcePrefixes{
+							nil,
+							nil,
+							{
+								srcPrefixMap: map[string]*sourcePrefixEntry{
+									unspecifiedPrefixMapKey: {
+										absent: true,
 										srcPortMap: map[int]*FilterChain{
 											0: {},
 										},
@@ -620,8 +826,8 @@ func TestNewFilterChainImpl_Success_AllCombinations(t *testing.T) {
 						srcTypeArr: [3]*sourcePrefixes{
 							{
 								srcPrefixMap: map[string]*sourcePrefixEntry{
-									"0.0.0.0/0": {
-										net: zeroIP,
+									unspecifiedPrefixMapKey: {
+										absent: true,
 										srcPortMap: map[int]*FilterChain{
 											0: {},
 										},
@@ -635,8 +841,8 @@ func TestNewFilterChainImpl_Success_AllCombinations(t *testing.T) {
 						srcTypeArr: [3]*sourcePrefixes{
 							{
 								srcPrefixMap: map[string]*sourcePrefixEntry{
-									"0.0.0.0/0": {
-										net: zeroIP,
+									unspecifiedPrefixMapKey: {
+										absent: true,
 										srcPortMap: map[int]*FilterChain{
 											0: {},
 										},
@@ -667,14 +873,14 @@ func TestNewFilterChainImpl_Success_AllCombinations(t *testing.T) {
 			},
 			wantFC: &FilterChainManager{
 				dstPrefixMap: map[string]*destPrefixEntry{
-					"0.0.0.0/0": {
-						net: zeroIP,
+					unspecifiedPrefixMapKey: {
+						absent: true,
 						srcTypeArr: [3]*sourcePrefixes{
 							nil,
 							{
 								srcPrefixMap: map[string]*sourcePrefixEntry{
-									"0.0.0.0/0": {
-										net: zeroIP,
+									unspecifiedPrefixMapKey: {
+										absent: true,
 										srcPortMap: map[int]*FilterChain{
 											0: {},
 										},
@@ -690,8 +896,8 @@ func TestNewFilterChainImpl_Success_AllCombinations(t *testing.T) {
 							nil,
 							{
 								srcPrefixMap: map[string]*sourcePrefixEntry{
-									"0.0.0.0/0": {
-										net: zeroIP,
+									unspecifiedPrefixMapKey: {
+										absent: true,
 										srcPortMap: map[int]*FilterChain{
 											0: {},
 										},
@@ -722,8 +928,8 @@ func TestNewFilterChainImpl_Success_AllCombinations(t *testing.T) {
 			},
 			wantFC: &FilterChainManager{
 				dstPrefixMap: map[string]*destPrefixEntry{
-					"0.0.0.0/0": {
-						net: zeroIP,
+					unspecifiedPrefixMapKey: {
+						absent: true,
 						srcTypeArr: [3]*sourcePrefixes{
 							{
 								srcPrefixMap: map[string]*sourcePrefixEntry{
@@ -776,13 +982,13 @@ func TestNewFilterChainImpl_Success_AllCombinations(t *testing.T) {
 			},
 			wantFC: &FilterChainManager{
 				dstPrefixMap: map[string]*destPrefixEntry{
-					"0.0.0.0/0": {
-						net: zeroIP,
+					unspecifiedPrefixMapKey: {
+						absent: true,
 						srcTypeArr: [3]*sourcePrefixes{
 							{
 								srcPrefixMap: map[string]*sourcePrefixEntry{
-									"0.0.0.0/0": {
-										net: zeroIP,
+									unspecifiedPrefixMapKey: {
+										absent: true,
 										srcPortMap: map[int]*FilterChain{
 											1: {},
 											2: {},
@@ -874,13 +1080,13 @@ func TestNewFilterChainImpl_Success_AllCombinations(t *testing.T) {
 			},
 			wantFC: &FilterChainManager{
 				dstPrefixMap: map[string]*destPrefixEntry{
-					"0.0.0.0/0": {
-						net: zeroIP,
+					unspecifiedPrefixMapKey: {
+						absent: true,
 						srcTypeArr: [3]*sourcePrefixes{
 							{
 								srcPrefixMap: map[string]*sourcePrefixEntry{
-									"0.0.0.0/0": {
-										net: zeroIP,
+									unspecifiedPrefixMapKey: {
+										absent: true,
 										srcPortMap: map[int]*FilterChain{
 											0: {},
 										},
@@ -894,8 +1100,8 @@ func TestNewFilterChainImpl_Success_AllCombinations(t *testing.T) {
 						srcTypeArr: [3]*sourcePrefixes{
 							{
 								srcPrefixMap: map[string]*sourcePrefixEntry{
-									"0.0.0.0/0": {
-										net: zeroIP,
+									unspecifiedPrefixMapKey: {
+										absent: true,
 										srcPortMap: map[int]*FilterChain{
 											0: {},
 										},
@@ -909,8 +1115,8 @@ func TestNewFilterChainImpl_Success_AllCombinations(t *testing.T) {
 						srcTypeArr: [3]*sourcePrefixes{
 							{
 								srcPrefixMap: map[string]*sourcePrefixEntry{
-									"0.0.0.0/0": {
-										net: zeroIP,
+									unspecifiedPrefixMapKey: {
+										absent: true,
 										srcPortMap: map[int]*FilterChain{
 											0: {},
 										},
@@ -1128,18 +1334,24 @@ func TestLookup_Successes(t *testing.T) {
 	lisWithoutDefaultChain := &v3listenerpb.Listener{
 		FilterChains: []*v3listenerpb.FilterChain{
 			{
-				TransportSocket: transportSocketWithInstanceName("wildcard"),
+				TransportSocket: transportSocketWithInstanceName("unspecified-dest-and-source-prefix"),
 			},
 			{
 				FilterChainMatch: &v3listenerpb.FilterChainMatch{
-					PrefixRanges: []*v3corepb.CidrRange{cidrRangeFromAddressAndPrefixLen("0.0.0.0", 0)},
-					SourceType:   v3listenerpb.FilterChainMatch_EXTERNAL,
+					PrefixRanges:       []*v3corepb.CidrRange{cidrRangeFromAddressAndPrefixLen("0.0.0.0", 0)},
+					SourcePrefixRanges: []*v3corepb.CidrRange{cidrRangeFromAddressAndPrefixLen("0.0.0.0", 0)},
 				},
-				TransportSocket: transportSocketWithInstanceName("any-destination-prefix"),
+				TransportSocket: transportSocketWithInstanceName("wildcard-prefixes-v4"),
+			},
+			{
+				FilterChainMatch: &v3listenerpb.FilterChainMatch{
+					SourcePrefixRanges: []*v3corepb.CidrRange{cidrRangeFromAddressAndPrefixLen("::", 0)},
+				},
+				TransportSocket: transportSocketWithInstanceName("wildcard-source-prefix-v6"),
 			},
 			{
 				FilterChainMatch: &v3listenerpb.FilterChainMatch{PrefixRanges: []*v3corepb.CidrRange{cidrRangeFromAddressAndPrefixLen("192.168.1.1", 16)}},
-				TransportSocket:  transportSocketWithInstanceName("specific-destination-prefix-wildcard-source-type"),
+				TransportSocket:  transportSocketWithInstanceName("specific-destination-prefix-unspecified-source-type"),
 			},
 			{
 				FilterChainMatch: &v3listenerpb.FilterChainMatch{
@@ -1184,7 +1396,18 @@ func TestLookup_Successes(t *testing.T) {
 			wantFC: &FilterChain{SecurityCfg: &SecurityConfig{IdentityInstanceName: "default"}},
 		},
 		{
-			desc: "wildcard destination match",
+			desc: "unspecified destination match",
+			lis:  lisWithoutDefaultChain,
+			params: FilterChainLookupParams{
+				IsUnspecifiedListener: true,
+				DestAddr:              net.ParseIP("2001:68::db8"),
+				SourceAddr:            net.IPv4(10, 1, 1, 1),
+				SourcePort:            1,
+			},
+			wantFC: &FilterChain{SecurityCfg: &SecurityConfig{IdentityInstanceName: "unspecified-dest-and-source-prefix"}},
+		},
+		{
+			desc: "wildcard destination match v4",
 			lis:  lisWithoutDefaultChain,
 			params: FilterChainLookupParams{
 				IsUnspecifiedListener: true,
@@ -1192,18 +1415,18 @@ func TestLookup_Successes(t *testing.T) {
 				SourceAddr:            net.IPv4(10, 1, 1, 1),
 				SourcePort:            1,
 			},
-			wantFC: &FilterChain{SecurityCfg: &SecurityConfig{IdentityInstanceName: "wildcard"}},
+			wantFC: &FilterChain{SecurityCfg: &SecurityConfig{IdentityInstanceName: "wildcard-prefixes-v4"}},
 		},
 		{
-			desc: "ANY destination match",
+			desc: "wildcard source match v6",
 			lis:  lisWithoutDefaultChain,
 			params: FilterChainLookupParams{
 				IsUnspecifiedListener: true,
-				DestAddr:              net.IPv4(10, 1, 1, 1),
-				SourceAddr:            net.IPv4(10, 1, 1, 2),
+				DestAddr:              net.ParseIP("2001:68::1"),
+				SourceAddr:            net.ParseIP("2001:68::2"),
 				SourcePort:            1,
 			},
-			wantFC: &FilterChain{SecurityCfg: &SecurityConfig{IdentityInstanceName: "any-destination-prefix"}},
+			wantFC: &FilterChain{SecurityCfg: &SecurityConfig{IdentityInstanceName: "wildcard-source-prefix-v6"}},
 		},
 		{
 			desc: "specific destination and wildcard source type match",
@@ -1214,7 +1437,7 @@ func TestLookup_Successes(t *testing.T) {
 				SourceAddr:            net.IPv4(192, 168, 100, 1),
 				SourcePort:            80,
 			},
-			wantFC: &FilterChain{SecurityCfg: &SecurityConfig{IdentityInstanceName: "specific-destination-prefix-wildcard-source-type"}},
+			wantFC: &FilterChain{SecurityCfg: &SecurityConfig{IdentityInstanceName: "specific-destination-prefix-unspecified-source-type"}},
 		},
 		{
 			desc: "specific destination and source type match",

--- a/xds/internal/client/lds_test.go
+++ b/xds/internal/client/lds_test.go
@@ -1127,12 +1127,10 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 						FilterChains: &FilterChainManager{
 							dstPrefixMap: map[string]*destPrefixEntry{
 								unspecifiedPrefixMapKey: {
-									absent: true,
 									srcTypeArr: [3]*sourcePrefixes{
 										{
 											srcPrefixMap: map[string]*sourcePrefixEntry{
 												unspecifiedPrefixMapKey: {
-													absent: true,
 													srcPortMap: map[int]*FilterChain{
 														0: {},
 													},
@@ -1217,12 +1215,10 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 						FilterChains: &FilterChainManager{
 							dstPrefixMap: map[string]*destPrefixEntry{
 								unspecifiedPrefixMapKey: {
-									absent: true,
 									srcTypeArr: [3]*sourcePrefixes{
 										{
 											srcPrefixMap: map[string]*sourcePrefixEntry{
 												unspecifiedPrefixMapKey: {
-													absent: true,
 													srcPortMap: map[int]*FilterChain{
 														0: {
 															SecurityCfg: &SecurityConfig{
@@ -1264,12 +1260,10 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 						FilterChains: &FilterChainManager{
 							dstPrefixMap: map[string]*destPrefixEntry{
 								unspecifiedPrefixMapKey: {
-									absent: true,
 									srcTypeArr: [3]*sourcePrefixes{
 										{
 											srcPrefixMap: map[string]*sourcePrefixEntry{
 												unspecifiedPrefixMapKey: {
-													absent: true,
 													srcPortMap: map[int]*FilterChain{
 														0: {
 															SecurityCfg: &SecurityConfig{

--- a/xds/internal/client/lds_test.go
+++ b/xds/internal/client/lds_test.go
@@ -1126,13 +1126,13 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 						Port:    "9999",
 						FilterChains: &FilterChainManager{
 							dstPrefixMap: map[string]*destPrefixEntry{
-								"0.0.0.0/0": {
-									net: zeroIP,
+								unspecifiedPrefixMapKey: {
+									absent: true,
 									srcTypeArr: [3]*sourcePrefixes{
 										{
 											srcPrefixMap: map[string]*sourcePrefixEntry{
-												"0.0.0.0/0": {
-													net: zeroIP,
+												unspecifiedPrefixMapKey: {
+													absent: true,
 													srcPortMap: map[int]*FilterChain{
 														0: {},
 													},
@@ -1216,13 +1216,13 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 						Port:    "9999",
 						FilterChains: &FilterChainManager{
 							dstPrefixMap: map[string]*destPrefixEntry{
-								"0.0.0.0/0": {
-									net: zeroIP,
+								unspecifiedPrefixMapKey: {
+									absent: true,
 									srcTypeArr: [3]*sourcePrefixes{
 										{
 											srcPrefixMap: map[string]*sourcePrefixEntry{
-												"0.0.0.0/0": {
-													net: zeroIP,
+												unspecifiedPrefixMapKey: {
+													absent: true,
 													srcPortMap: map[int]*FilterChain{
 														0: {
 															SecurityCfg: &SecurityConfig{
@@ -1263,13 +1263,13 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 						Port:    "9999",
 						FilterChains: &FilterChainManager{
 							dstPrefixMap: map[string]*destPrefixEntry{
-								"0.0.0.0/0": {
-									net: zeroIP,
+								unspecifiedPrefixMapKey: {
+									absent: true,
 									srcTypeArr: [3]*sourcePrefixes{
 										{
 											srcPrefixMap: map[string]*sourcePrefixEntry{
-												"0.0.0.0/0": {
-													net: zeroIP,
+												unspecifiedPrefixMapKey: {
+													absent: true,
 													srcPortMap: map[int]*FilterChain{
 														0: {
 															SecurityCfg: &SecurityConfig{


### PR DESCRIPTION
Summary of changes:
- Differentiate between unspecified and wildcard prefixes.
  - unspecified prefixes match both v4 and v6 addresses, while wildcard prefixes are network specific
  - unspecified prefix match is considered less specific than a wildcard prefix match
- Test for v4 and v6 wildcards

In a follow-up PR, I will change `testutils.LocalListener()` to accept a network type, and change the tests to run for both v4 and v6, and skip tests in unsupported environments.