### PR TITLE
xds/balancers: export balancer names and config structs

### DIFF
--- a/xds/internal/balancer/clusterimpl/balancer_test.go
+++ b/xds/internal/balancer/clusterimpl/balancer_test.go
@@ -67,7 +67,7 @@ func TestDropByCategory(t *testing.T) {
 	newXDSClient = func() (xdsClientInterface, error) { return xdsC, nil }
 	defer func() { newXDSClient = oldNewXDSClient }()
 
-	builder := balancer.Get(clusterImplName)
+	builder := balancer.Get(Name)
 	cc := testutils.NewTestClientConn(t)
 	b := builder.Build(cc, balancer.BuildOptions{})
 	defer b.Close()
@@ -81,11 +81,11 @@ func TestDropByCategory(t *testing.T) {
 		ResolverState: resolver.State{
 			Addresses: testBackendAddrs,
 		},
-		BalancerConfig: &lbConfig{
+		BalancerConfig: &LBConfig{
 			Cluster:                    testClusterName,
 			EDSServiceName:             testServiceName,
 			LRSLoadReportingServerName: newString(testLRSServerName),
-			DropCategories: []dropCategory{{
+			DropCategories: []DropCategory{{
 				Category:           dropReason,
 				RequestsPerMillion: million * dropNumerator / dropDenominator,
 			}},
@@ -168,11 +168,11 @@ func TestDropByCategory(t *testing.T) {
 		ResolverState: resolver.State{
 			Addresses: testBackendAddrs,
 		},
-		BalancerConfig: &lbConfig{
+		BalancerConfig: &LBConfig{
 			Cluster:                    testClusterName,
 			EDSServiceName:             testServiceName,
 			LRSLoadReportingServerName: newString(testLRSServerName),
-			DropCategories: []dropCategory{{
+			DropCategories: []DropCategory{{
 				Category:           dropReason2,
 				RequestsPerMillion: million * dropNumerator2 / dropDenominator2,
 			}},
@@ -224,7 +224,7 @@ func TestDropCircuitBreaking(t *testing.T) {
 	newXDSClient = func() (xdsClientInterface, error) { return xdsC, nil }
 	defer func() { newXDSClient = oldNewXDSClient }()
 
-	builder := balancer.Get(clusterImplName)
+	builder := balancer.Get(Name)
 	cc := testutils.NewTestClientConn(t)
 	b := builder.Build(cc, balancer.BuildOptions{})
 	defer b.Close()
@@ -234,7 +234,7 @@ func TestDropCircuitBreaking(t *testing.T) {
 		ResolverState: resolver.State{
 			Addresses: testBackendAddrs,
 		},
-		BalancerConfig: &lbConfig{
+		BalancerConfig: &LBConfig{
 			Cluster:                    testClusterName,
 			EDSServiceName:             testServiceName,
 			LRSLoadReportingServerName: newString(testLRSServerName),
@@ -335,7 +335,7 @@ func TestPickerUpdateAfterClose(t *testing.T) {
 	newXDSClient = func() (xdsClientInterface, error) { return xdsC, nil }
 	defer func() { newXDSClient = oldNewXDSClient }()
 
-	builder := balancer.Get(clusterImplName)
+	builder := balancer.Get(Name)
 	cc := testutils.NewTestClientConn(t)
 	b := builder.Build(cc, balancer.BuildOptions{})
 
@@ -344,7 +344,7 @@ func TestPickerUpdateAfterClose(t *testing.T) {
 		ResolverState: resolver.State{
 			Addresses: testBackendAddrs,
 		},
-		BalancerConfig: &lbConfig{
+		BalancerConfig: &LBConfig{
 			Cluster:               testClusterName,
 			EDSServiceName:        testServiceName,
 			MaxConcurrentRequests: &maxRequest,

--- a/xds/internal/balancer/clusterimpl/balancer_test.go
+++ b/xds/internal/balancer/clusterimpl/balancer_test.go
@@ -82,10 +82,10 @@ func TestDropByCategory(t *testing.T) {
 			Addresses: testBackendAddrs,
 		},
 		BalancerConfig: &LBConfig{
-			Cluster:                    testClusterName,
-			EDSServiceName:             testServiceName,
-			LRSLoadReportingServerName: newString(testLRSServerName),
-			DropCategories: []DropCategory{{
+			Cluster:                 testClusterName,
+			EDSServiceName:          testServiceName,
+			LoadReportingServerName: newString(testLRSServerName),
+			DropCategories: []DropConfig{{
 				Category:           dropReason,
 				RequestsPerMillion: million * dropNumerator / dropDenominator,
 			}},
@@ -169,10 +169,10 @@ func TestDropByCategory(t *testing.T) {
 			Addresses: testBackendAddrs,
 		},
 		BalancerConfig: &LBConfig{
-			Cluster:                    testClusterName,
-			EDSServiceName:             testServiceName,
-			LRSLoadReportingServerName: newString(testLRSServerName),
-			DropCategories: []DropCategory{{
+			Cluster:                 testClusterName,
+			EDSServiceName:          testServiceName,
+			LoadReportingServerName: newString(testLRSServerName),
+			DropCategories: []DropConfig{{
 				Category:           dropReason2,
 				RequestsPerMillion: million * dropNumerator2 / dropDenominator2,
 			}},
@@ -235,10 +235,10 @@ func TestDropCircuitBreaking(t *testing.T) {
 			Addresses: testBackendAddrs,
 		},
 		BalancerConfig: &LBConfig{
-			Cluster:                    testClusterName,
-			EDSServiceName:             testServiceName,
-			LRSLoadReportingServerName: newString(testLRSServerName),
-			MaxConcurrentRequests:      &maxRequest,
+			Cluster:                 testClusterName,
+			EDSServiceName:          testServiceName,
+			LoadReportingServerName: newString(testLRSServerName),
+			MaxConcurrentRequests:   &maxRequest,
 			ChildPolicy: &internalserviceconfig.BalancerConfig{
 				Name: roundrobin.Name,
 			},

--- a/xds/internal/balancer/clusterimpl/balancer_test.go
+++ b/xds/internal/balancer/clusterimpl/balancer_test.go
@@ -379,7 +379,7 @@ func TestClusterNameInAddressAttributes(t *testing.T) {
 	newXDSClient = func() (xdsClientInterface, error) { return xdsC, nil }
 	defer func() { newXDSClient = oldNewXDSClient }()
 
-	builder := balancer.Get(clusterImplName)
+	builder := balancer.Get(Name)
 	cc := testutils.NewTestClientConn(t)
 	b := builder.Build(cc, balancer.BuildOptions{})
 	defer b.Close()
@@ -388,7 +388,7 @@ func TestClusterNameInAddressAttributes(t *testing.T) {
 		ResolverState: resolver.State{
 			Addresses: testBackendAddrs,
 		},
-		BalancerConfig: &lbConfig{
+		BalancerConfig: &LBConfig{
 			Cluster:        testClusterName,
 			EDSServiceName: testServiceName,
 			ChildPolicy: &internalserviceconfig.BalancerConfig{
@@ -439,7 +439,7 @@ func TestClusterNameInAddressAttributes(t *testing.T) {
 		ResolverState: resolver.State{
 			Addresses: []resolver.Address{addr2},
 		},
-		BalancerConfig: &lbConfig{
+		BalancerConfig: &LBConfig{
 			Cluster:        testClusterName2,
 			EDSServiceName: testServiceName,
 			ChildPolicy: &internalserviceconfig.BalancerConfig{

--- a/xds/internal/balancer/clusterimpl/clusterimpl.go
+++ b/xds/internal/balancer/clusterimpl/clusterimpl.go
@@ -41,7 +41,8 @@ import (
 )
 
 const (
-	clusterImplName        = "xds_cluster_impl_experimental"
+	// Name is the name of the cluster_impl balancer.
+	Name                   = "xds_cluster_impl_experimental"
 	defaultRequestCountMax = 1024
 )
 
@@ -77,7 +78,7 @@ func (clusterImplBB) Build(cc balancer.ClientConn, bOpts balancer.BuildOptions) 
 }
 
 func (clusterImplBB) Name() string {
-	return clusterImplName
+	return Name
 }
 
 func (clusterImplBB) ParseConfig(c json.RawMessage) (serviceconfig.LoadBalancingConfig, error) {
@@ -109,7 +110,7 @@ type clusterImplBalancer struct {
 	logger *grpclog.PrefixLogger
 	xdsC   xdsClientInterface
 
-	config           *lbConfig
+	config           *LBConfig
 	childLB          balancer.Balancer
 	cancelLoadReport func()
 	edsServiceName   string
@@ -131,7 +132,7 @@ type clusterImplBalancer struct {
 
 // updateLoadStore checks the config for load store, and decides whether it
 // needs to restart the load reporting stream.
-func (cib *clusterImplBalancer) updateLoadStore(newConfig *lbConfig) error {
+func (cib *clusterImplBalancer) updateLoadStore(newConfig *LBConfig) error {
 	var updateLoadClusterAndService bool
 
 	// ClusterName is different, restart. ClusterName is from ClusterName and
@@ -187,7 +188,7 @@ func (cib *clusterImplBalancer) UpdateClientConnState(s balancer.ClientConnState
 		return nil
 	}
 
-	newConfig, ok := s.BalancerConfig.(*lbConfig)
+	newConfig, ok := s.BalancerConfig.(*LBConfig)
 	if !ok {
 		return fmt.Errorf("unexpected balancer config with type: %T", s.BalancerConfig)
 	}

--- a/xds/internal/balancer/clusterimpl/clusterimpl.go
+++ b/xds/internal/balancer/clusterimpl/clusterimpl.go
@@ -136,7 +136,7 @@ func (cib *clusterImplBalancer) updateLoadStore(newConfig *LBConfig) error {
 	var updateLoadClusterAndService bool
 
 	// ClusterName is different, restart. ClusterName is from ClusterName and
-	// EdsServiceName.
+	// EDSServiceName.
 	clusterName := cib.getClusterName()
 	if clusterName != newConfig.Cluster {
 		updateLoadClusterAndService = true
@@ -161,11 +161,11 @@ func (cib *clusterImplBalancer) updateLoadStore(newConfig *LBConfig) error {
 
 	// Check if it's necessary to restart load report.
 	var newLRSServerName string
-	if newConfig.LRSLoadReportingServerName != nil {
-		newLRSServerName = *newConfig.LRSLoadReportingServerName
+	if newConfig.LoadReportingServerName != nil {
+		newLRSServerName = *newConfig.LoadReportingServerName
 	}
 	if cib.lrsServerName != newLRSServerName {
-		// LrsLoadReportingServerName is different, load should be report to a
+		// LoadReportingServerName is different, load should be report to a
 		// different server, restart.
 		cib.lrsServerName = newLRSServerName
 		if cib.cancelLoadReport != nil {

--- a/xds/internal/balancer/clusterimpl/config.go
+++ b/xds/internal/balancer/clusterimpl/config.go
@@ -25,8 +25,8 @@ import (
 	"google.golang.org/grpc/serviceconfig"
 )
 
-// DropCategory contains the category, and drop ratio.
-type DropCategory struct {
+// DropConfig contains the category, and drop ratio.
+type DropConfig struct {
 	Category           string
 	RequestsPerMillion uint32
 }
@@ -35,12 +35,12 @@ type DropCategory struct {
 type LBConfig struct {
 	serviceconfig.LoadBalancingConfig `json:"-"`
 
-	Cluster                    string                                `json:"cluster,omitempty"`
-	EDSServiceName             string                                `json:"edsServiceName,omitempty"`
-	LRSLoadReportingServerName *string                               `json:"lrsLoadReportingServerName,omitempty"`
-	MaxConcurrentRequests      *uint32                               `json:"maxConcurrentRequests,omitempty"`
-	DropCategories             []DropCategory                        `json:"dropCategories,omitempty"`
-	ChildPolicy                *internalserviceconfig.BalancerConfig `json:"childPolicy,omitempty"`
+	Cluster                 string                                `json:"cluster,omitempty"`
+	EDSServiceName          string                                `json:"edsServiceName,omitempty"`
+	LoadReportingServerName *string                               `json:"lrsLoadReportingServerName,omitempty"`
+	MaxConcurrentRequests   *uint32                               `json:"maxConcurrentRequests,omitempty"`
+	DropCategories          []DropConfig                          `json:"dropCategories,omitempty"`
+	ChildPolicy             *internalserviceconfig.BalancerConfig `json:"childPolicy,omitempty"`
 }
 
 func parseConfig(c json.RawMessage) (*LBConfig, error) {
@@ -51,7 +51,7 @@ func parseConfig(c json.RawMessage) (*LBConfig, error) {
 	return &cfg, nil
 }
 
-func equalDropCategories(a, b []DropCategory) bool {
+func equalDropCategories(a, b []DropConfig) bool {
 	if len(a) != len(b) {
 		return false
 	}

--- a/xds/internal/balancer/clusterimpl/config.go
+++ b/xds/internal/balancer/clusterimpl/config.go
@@ -25,32 +25,33 @@ import (
 	"google.golang.org/grpc/serviceconfig"
 )
 
-type dropCategory struct {
+// DropCategory contains the category, and drop ratio.
+type DropCategory struct {
 	Category           string
 	RequestsPerMillion uint32
 }
 
-// lbConfig is the balancer config for weighted_target.
-type lbConfig struct {
-	serviceconfig.LoadBalancingConfig
+// LBConfig is the balancer config for cluster_impl balancer.
+type LBConfig struct {
+	serviceconfig.LoadBalancingConfig `json:"-"`
 
-	Cluster                    string
-	EDSServiceName             string
-	LRSLoadReportingServerName *string
-	MaxConcurrentRequests      *uint32
-	DropCategories             []dropCategory
-	ChildPolicy                *internalserviceconfig.BalancerConfig
+	Cluster                    string                                `json:"cluster,omitempty"`
+	EDSServiceName             string                                `json:"edsServiceName,omitempty"`
+	LRSLoadReportingServerName *string                               `json:"lrsLoadReportingServerName,omitempty"`
+	MaxConcurrentRequests      *uint32                               `json:"maxConcurrentRequests,omitempty"`
+	DropCategories             []DropCategory                        `json:"dropCategories,omitempty"`
+	ChildPolicy                *internalserviceconfig.BalancerConfig `json:"childPolicy,omitempty"`
 }
 
-func parseConfig(c json.RawMessage) (*lbConfig, error) {
-	var cfg lbConfig
+func parseConfig(c json.RawMessage) (*LBConfig, error) {
+	var cfg LBConfig
 	if err := json.Unmarshal(c, &cfg); err != nil {
 		return nil, err
 	}
 	return &cfg, nil
 }
 
-func equalDropCategories(a, b []dropCategory) bool {
+func equalDropCategories(a, b []DropCategory) bool {
 	if len(a) != len(b) {
 		return false
 	}

--- a/xds/internal/balancer/clusterimpl/config_test.go
+++ b/xds/internal/balancer/clusterimpl/config_test.go
@@ -87,7 +87,7 @@ func TestParseConfig(t *testing.T) {
 	tests := []struct {
 		name    string
 		js      string
-		want    *lbConfig
+		want    *LBConfig
 		wantErr bool
 	}{
 		{
@@ -105,12 +105,12 @@ func TestParseConfig(t *testing.T) {
 		{
 			name: "OK",
 			js:   testJSONConfig,
-			want: &lbConfig{
+			want: &LBConfig{
 				Cluster:                    "test_cluster",
 				EDSServiceName:             "test-eds",
 				LRSLoadReportingServerName: newString("lrs_server"),
 				MaxConcurrentRequests:      newUint32(123),
-				DropCategories: []dropCategory{
+				DropCategories: []DropCategory{
 					{Category: "drop-1", RequestsPerMillion: 314},
 					{Category: "drop-2", RequestsPerMillion: 159},
 				},

--- a/xds/internal/balancer/clusterimpl/config_test.go
+++ b/xds/internal/balancer/clusterimpl/config_test.go
@@ -106,11 +106,11 @@ func TestParseConfig(t *testing.T) {
 			name: "OK",
 			js:   testJSONConfig,
 			want: &LBConfig{
-				Cluster:                    "test_cluster",
-				EDSServiceName:             "test-eds",
-				LRSLoadReportingServerName: newString("lrs_server"),
-				MaxConcurrentRequests:      newUint32(123),
-				DropCategories: []DropCategory{
+				Cluster:                 "test_cluster",
+				EDSServiceName:          "test-eds",
+				LoadReportingServerName: newString("lrs_server"),
+				MaxConcurrentRequests:   newUint32(123),
+				DropCategories: []DropConfig{
 					{Category: "drop-1", RequestsPerMillion: 314},
 					{Category: "drop-2", RequestsPerMillion: 159},
 				},

--- a/xds/internal/balancer/clusterimpl/picker.go
+++ b/xds/internal/balancer/clusterimpl/picker.go
@@ -47,7 +47,7 @@ func gcd(a, b uint32) uint32 {
 	return a
 }
 
-func newDropper(c dropCategory) *dropper {
+func newDropper(c DropCategory) *dropper {
 	w := newRandomWRR()
 	gcdv := gcd(c.RequestsPerMillion, million)
 	// Return true for RequestPerMillion, false for the rest.

--- a/xds/internal/balancer/clusterimpl/picker.go
+++ b/xds/internal/balancer/clusterimpl/picker.go
@@ -47,7 +47,7 @@ func gcd(a, b uint32) uint32 {
 	return a
 }
 
-func newDropper(c DropCategory) *dropper {
+func newDropper(c DropConfig) *dropper {
 	w := newRandomWRR()
 	gcdv := gcd(c.RequestsPerMillion, million)
 	// Return true for RequestPerMillion, false for the rest.

--- a/xds/internal/balancer/edsbalancer/eds_test.go
+++ b/xds/internal/balancer/edsbalancer/eds_test.go
@@ -818,7 +818,7 @@ func (s) TestBalancerConfigParsing(t *testing.T) {
 			},
 		},
 		{
-			// json with no lrs server name, LrsLoadReportingServerName should
+			// json with no lrs server name, LoadReportingServerName should
 			// be nil (not an empty string).
 			name: "no-lrs-server-name",
 			js: json.RawMessage(`

--- a/xds/internal/balancer/lrs/balancer.go
+++ b/xds/internal/balancer/lrs/balancer.go
@@ -190,14 +190,14 @@ func (w *xdsClientWrapper) update(newConfig *LBConfig) error {
 	)
 
 	// ClusterName is different, restart. ClusterName is from ClusterName and
-	// EdsServiceName.
+	// EDSServiceName.
 	if w.clusterName != newConfig.ClusterName {
 		updateLoadClusterAndService = true
 		w.clusterName = newConfig.ClusterName
 	}
-	if w.edsServiceName != newConfig.EdsServiceName {
+	if w.edsServiceName != newConfig.EDSServiceName {
 		updateLoadClusterAndService = true
-		w.edsServiceName = newConfig.EdsServiceName
+		w.edsServiceName = newConfig.EDSServiceName
 	}
 
 	if updateLoadClusterAndService {
@@ -212,11 +212,11 @@ func (w *xdsClientWrapper) update(newConfig *LBConfig) error {
 		w.loadWrapper.UpdateClusterAndService(w.clusterName, w.edsServiceName)
 	}
 
-	if w.lrsServerName != newConfig.LrsLoadReportingServerName {
-		// LrsLoadReportingServerName is different, load should be report to a
+	if w.lrsServerName != newConfig.LoadReportingServerName {
+		// LoadReportingServerName is different, load should be report to a
 		// different server, restart.
 		restartLoadReport = true
-		w.lrsServerName = newConfig.LrsLoadReportingServerName
+		w.lrsServerName = newConfig.LoadReportingServerName
 	}
 
 	if restartLoadReport {

--- a/xds/internal/balancer/lrs/balancer.go
+++ b/xds/internal/balancer/lrs/balancer.go
@@ -37,7 +37,8 @@ func init() {
 
 var newXDSClient = func() (xdsClientInterface, error) { return xdsclient.New() }
 
-const lrsBalancerName = "lrs_experimental"
+// Name is the name of the LRS balancer.
+const Name = "lrs_experimental"
 
 type lrsBB struct{}
 
@@ -60,7 +61,7 @@ func (l *lrsBB) Build(cc balancer.ClientConn, opts balancer.BuildOptions) balanc
 }
 
 func (l *lrsBB) Name() string {
-	return lrsBalancerName
+	return Name
 }
 
 func (l *lrsBB) ParseConfig(c json.RawMessage) (serviceconfig.LoadBalancingConfig, error) {
@@ -74,12 +75,12 @@ type lrsBalancer struct {
 	logger *grpclog.PrefixLogger
 	client *xdsClientWrapper
 
-	config *lbConfig
+	config *LBConfig
 	lb     balancer.Balancer // The sub balancer.
 }
 
 func (b *lrsBalancer) UpdateClientConnState(s balancer.ClientConnState) error {
-	newConfig, ok := s.BalancerConfig.(*lbConfig)
+	newConfig, ok := s.BalancerConfig.(*LBConfig)
 	if !ok {
 		return fmt.Errorf("unexpected balancer config with type: %T", s.BalancerConfig)
 	}
@@ -182,7 +183,7 @@ func newXDSClientWrapper(c xdsClientInterface) *xdsClientWrapper {
 
 // update checks the config and xdsclient, and decides whether it needs to
 // restart the load reporting stream.
-func (w *xdsClientWrapper) update(newConfig *lbConfig) error {
+func (w *xdsClientWrapper) update(newConfig *LBConfig) error {
 	var (
 		restartLoadReport           bool
 		updateLoadClusterAndService bool

--- a/xds/internal/balancer/lrs/balancer_test.go
+++ b/xds/internal/balancer/lrs/balancer_test.go
@@ -49,7 +49,7 @@ var (
 )
 
 // TestLoadReporting verifies that the lrs balancer starts the loadReport
-// stream when the lbConfig passed to it contains a valid value for the LRS
+// stream when the LBConfig passed to it contains a valid value for the LRS
 // server (empty string).
 func TestLoadReporting(t *testing.T) {
 	xdsC := fakeclient.NewClient()
@@ -57,7 +57,7 @@ func TestLoadReporting(t *testing.T) {
 	newXDSClient = func() (xdsClientInterface, error) { return xdsC, nil }
 	defer func() { newXDSClient = oldNewXDSClient }()
 
-	builder := balancer.Get(lrsBalancerName)
+	builder := balancer.Get(Name)
 	cc := testutils.NewTestClientConn(t)
 	lrsB := builder.Build(cc, balancer.BuildOptions{})
 	defer lrsB.Close()
@@ -66,7 +66,7 @@ func TestLoadReporting(t *testing.T) {
 		ResolverState: resolver.State{
 			Addresses: testBackendAddrs,
 		},
-		BalancerConfig: &lbConfig{
+		BalancerConfig: &LBConfig{
 			ClusterName:                testClusterName,
 			EdsServiceName:             testServiceName,
 			LrsLoadReportingServerName: testLRSServerName,

--- a/xds/internal/balancer/lrs/balancer_test.go
+++ b/xds/internal/balancer/lrs/balancer_test.go
@@ -67,10 +67,10 @@ func TestLoadReporting(t *testing.T) {
 			Addresses: testBackendAddrs,
 		},
 		BalancerConfig: &LBConfig{
-			ClusterName:                testClusterName,
-			EdsServiceName:             testServiceName,
-			LrsLoadReportingServerName: testLRSServerName,
-			Locality:                   testLocality,
+			ClusterName:             testClusterName,
+			EDSServiceName:          testServiceName,
+			LoadReportingServerName: testLRSServerName,
+			Locality:                testLocality,
 			ChildPolicy: &internalserviceconfig.BalancerConfig{
 				Name: roundrobin.Name,
 			},

--- a/xds/internal/balancer/lrs/config.go
+++ b/xds/internal/balancer/lrs/config.go
@@ -27,17 +27,19 @@ import (
 	"google.golang.org/grpc/xds/internal"
 )
 
-type lbConfig struct {
-	serviceconfig.LoadBalancingConfig
-	ClusterName                string
-	EdsServiceName             string
-	LrsLoadReportingServerName string
-	Locality                   *internal.LocalityID
-	ChildPolicy                *internalserviceconfig.BalancerConfig
+// LBConfig is the balancer config for lrs balancer.
+type LBConfig struct {
+	serviceconfig.LoadBalancingConfig `json:"-"`
+
+	ClusterName                string                                `json:"clusterName,omitempty"`
+	EdsServiceName             string                                `json:"edsServiceName,omitempty"`
+	LrsLoadReportingServerName string                                `json:"lrsLoadReportingServerName,omitempty"`
+	Locality                   *internal.LocalityID                  `json:"locality,omitempty"`
+	ChildPolicy                *internalserviceconfig.BalancerConfig `json:"childPolicy,omitempty"`
 }
 
-func parseConfig(c json.RawMessage) (*lbConfig, error) {
-	var cfg lbConfig
+func parseConfig(c json.RawMessage) (*LBConfig, error) {
+	var cfg LBConfig
 	if err := json.Unmarshal(c, &cfg); err != nil {
 		return nil, err
 	}

--- a/xds/internal/balancer/lrs/config.go
+++ b/xds/internal/balancer/lrs/config.go
@@ -31,11 +31,11 @@ import (
 type LBConfig struct {
 	serviceconfig.LoadBalancingConfig `json:"-"`
 
-	ClusterName                string                                `json:"clusterName,omitempty"`
-	EdsServiceName             string                                `json:"edsServiceName,omitempty"`
-	LrsLoadReportingServerName string                                `json:"lrsLoadReportingServerName,omitempty"`
-	Locality                   *internal.LocalityID                  `json:"locality,omitempty"`
-	ChildPolicy                *internalserviceconfig.BalancerConfig `json:"childPolicy,omitempty"`
+	ClusterName             string                                `json:"clusterName,omitempty"`
+	EDSServiceName          string                                `json:"edsServiceName,omitempty"`
+	LoadReportingServerName string                                `json:"lrsLoadReportingServerName,omitempty"`
+	Locality                *internal.LocalityID                  `json:"locality,omitempty"`
+	ChildPolicy             *internalserviceconfig.BalancerConfig `json:"childPolicy,omitempty"`
 }
 
 func parseConfig(c json.RawMessage) (*LBConfig, error) {
@@ -46,8 +46,8 @@ func parseConfig(c json.RawMessage) (*LBConfig, error) {
 	if cfg.ClusterName == "" {
 		return nil, fmt.Errorf("required ClusterName is not set in %+v", cfg)
 	}
-	if cfg.LrsLoadReportingServerName == "" {
-		return nil, fmt.Errorf("required LrsLoadReportingServerName is not set in %+v", cfg)
+	if cfg.LoadReportingServerName == "" {
+		return nil, fmt.Errorf("required LoadReportingServerName is not set in %+v", cfg)
 	}
 	if cfg.Locality == nil {
 		return nil, fmt.Errorf("required Locality is not set in %+v", cfg)

--- a/xds/internal/balancer/lrs/config_test.go
+++ b/xds/internal/balancer/lrs/config_test.go
@@ -96,9 +96,9 @@ func TestParseConfig(t *testing.T) {
 }
 			`,
 			want: &LBConfig{
-				ClusterName:                testClusterName,
-				EdsServiceName:             testServiceName,
-				LrsLoadReportingServerName: testLRSServerName,
+				ClusterName:             testClusterName,
+				EDSServiceName:          testServiceName,
+				LoadReportingServerName: testLRSServerName,
 				Locality: &xdsinternal.LocalityID{
 					Region:  "test-region",
 					Zone:    "test-zone",

--- a/xds/internal/balancer/lrs/config_test.go
+++ b/xds/internal/balancer/lrs/config_test.go
@@ -37,7 +37,7 @@ func TestParseConfig(t *testing.T) {
 	tests := []struct {
 		name    string
 		js      string
-		want    *lbConfig
+		want    *LBConfig
 		wantErr bool
 	}{
 		{
@@ -95,7 +95,7 @@ func TestParseConfig(t *testing.T) {
   "childPolicy":[{"round_robin":{}}]
 }
 			`,
-			want: &lbConfig{
+			want: &LBConfig{
 				ClusterName:                testClusterName,
 				EdsServiceName:             testServiceName,
 				LrsLoadReportingServerName: testLRSServerName,

--- a/xds/internal/balancer/priority/balancer_test.go
+++ b/xds/internal/balancer/priority/balancer_test.go
@@ -83,7 +83,7 @@ func subConnFromPicker(t *testing.T, p balancer.Picker) func() balancer.SubConn 
 // Init 0 and 1; 0 is up, use 0; add 2, use 0; remove 2, use 0.
 func (s) TestPriority_HighPriorityReady(t *testing.T) {
 	cc := testutils.NewTestClientConn(t)
-	bb := balancer.Get(priorityBalancerName)
+	bb := balancer.Get(Name)
 	pb := bb.Build(cc, balancer.BuildOptions{})
 	defer pb.Close()
 
@@ -95,8 +95,8 @@ func (s) TestPriority_HighPriorityReady(t *testing.T) {
 				hierarchy.Set(resolver.Address{Addr: testBackendAddrStrs[1]}, []string{"child-1"}),
 			},
 		},
-		BalancerConfig: &lbConfig{
-			Children: map[string]*child{
+		BalancerConfig: &LBConfig{
+			Children: map[string]*Child{
 				"child-0": {&internalserviceconfig.BalancerConfig{Name: roundrobin.Name}},
 				"child-1": {&internalserviceconfig.BalancerConfig{Name: roundrobin.Name}},
 			},
@@ -132,8 +132,8 @@ func (s) TestPriority_HighPriorityReady(t *testing.T) {
 				hierarchy.Set(resolver.Address{Addr: testBackendAddrStrs[2]}, []string{"child-2"}),
 			},
 		},
-		BalancerConfig: &lbConfig{
-			Children: map[string]*child{
+		BalancerConfig: &LBConfig{
+			Children: map[string]*Child{
 				"child-0": {&internalserviceconfig.BalancerConfig{Name: roundrobin.Name}},
 				"child-1": {&internalserviceconfig.BalancerConfig{Name: roundrobin.Name}},
 				"child-2": {&internalserviceconfig.BalancerConfig{Name: roundrobin.Name}},
@@ -162,8 +162,8 @@ func (s) TestPriority_HighPriorityReady(t *testing.T) {
 				hierarchy.Set(resolver.Address{Addr: testBackendAddrStrs[1]}, []string{"child-1"}),
 			},
 		},
-		BalancerConfig: &lbConfig{
-			Children: map[string]*child{
+		BalancerConfig: &LBConfig{
+			Children: map[string]*Child{
 				"child-0": {&internalserviceconfig.BalancerConfig{Name: roundrobin.Name}},
 				"child-1": {&internalserviceconfig.BalancerConfig{Name: roundrobin.Name}},
 			},
@@ -190,7 +190,7 @@ func (s) TestPriority_HighPriorityReady(t *testing.T) {
 // down, use 2; remove 2, use 1.
 func (s) TestPriority_SwitchPriority(t *testing.T) {
 	cc := testutils.NewTestClientConn(t)
-	bb := balancer.Get(priorityBalancerName)
+	bb := balancer.Get(Name)
 	pb := bb.Build(cc, balancer.BuildOptions{})
 	defer pb.Close()
 
@@ -202,8 +202,8 @@ func (s) TestPriority_SwitchPriority(t *testing.T) {
 				hierarchy.Set(resolver.Address{Addr: testBackendAddrStrs[1]}, []string{"child-1"}),
 			},
 		},
-		BalancerConfig: &lbConfig{
-			Children: map[string]*child{
+		BalancerConfig: &LBConfig{
+			Children: map[string]*Child{
 				"child-0": {&internalserviceconfig.BalancerConfig{Name: roundrobin.Name}},
 				"child-1": {&internalserviceconfig.BalancerConfig{Name: roundrobin.Name}},
 			},
@@ -269,8 +269,8 @@ func (s) TestPriority_SwitchPriority(t *testing.T) {
 				hierarchy.Set(resolver.Address{Addr: testBackendAddrStrs[2]}, []string{"child-2"}),
 			},
 		},
-		BalancerConfig: &lbConfig{
-			Children: map[string]*child{
+		BalancerConfig: &LBConfig{
+			Children: map[string]*Child{
 				"child-0": {&internalserviceconfig.BalancerConfig{Name: roundrobin.Name}},
 				"child-1": {&internalserviceconfig.BalancerConfig{Name: roundrobin.Name}},
 				"child-2": {&internalserviceconfig.BalancerConfig{Name: roundrobin.Name}},
@@ -328,8 +328,8 @@ func (s) TestPriority_SwitchPriority(t *testing.T) {
 				hierarchy.Set(resolver.Address{Addr: testBackendAddrStrs[1]}, []string{"child-1"}),
 			},
 		},
-		BalancerConfig: &lbConfig{
-			Children: map[string]*child{
+		BalancerConfig: &LBConfig{
+			Children: map[string]*Child{
 				"child-0": {&internalserviceconfig.BalancerConfig{Name: roundrobin.Name}},
 				"child-1": {&internalserviceconfig.BalancerConfig{Name: roundrobin.Name}},
 			},
@@ -373,7 +373,7 @@ func (s) TestPriority_SwitchPriority(t *testing.T) {
 // use 0.
 func (s) TestPriority_HighPriorityToConnectingFromReady(t *testing.T) {
 	cc := testutils.NewTestClientConn(t)
-	bb := balancer.Get(priorityBalancerName)
+	bb := balancer.Get(Name)
 	pb := bb.Build(cc, balancer.BuildOptions{})
 	defer pb.Close()
 
@@ -385,8 +385,8 @@ func (s) TestPriority_HighPriorityToConnectingFromReady(t *testing.T) {
 				hierarchy.Set(resolver.Address{Addr: testBackendAddrStrs[1]}, []string{"child-1"}),
 			},
 		},
-		BalancerConfig: &lbConfig{
-			Children: map[string]*child{
+		BalancerConfig: &LBConfig{
+			Children: map[string]*Child{
 				"child-0": {&internalserviceconfig.BalancerConfig{Name: roundrobin.Name}},
 				"child-1": {&internalserviceconfig.BalancerConfig{Name: roundrobin.Name}},
 			},
@@ -468,7 +468,7 @@ func (s) TestPriority_HighPriorityToConnectingFromReady(t *testing.T) {
 // Init 0 and 1; 0 and 1 both down; add 2, use 2.
 func (s) TestPriority_HigherDownWhileAddingLower(t *testing.T) {
 	cc := testutils.NewTestClientConn(t)
-	bb := balancer.Get(priorityBalancerName)
+	bb := balancer.Get(Name)
 	pb := bb.Build(cc, balancer.BuildOptions{})
 	defer pb.Close()
 
@@ -480,8 +480,8 @@ func (s) TestPriority_HigherDownWhileAddingLower(t *testing.T) {
 				hierarchy.Set(resolver.Address{Addr: testBackendAddrStrs[1]}, []string{"child-1"}),
 			},
 		},
-		BalancerConfig: &lbConfig{
-			Children: map[string]*child{
+		BalancerConfig: &LBConfig{
+			Children: map[string]*Child{
 				"child-0": {&internalserviceconfig.BalancerConfig{Name: roundrobin.Name}},
 				"child-1": {&internalserviceconfig.BalancerConfig{Name: roundrobin.Name}},
 			},
@@ -534,8 +534,8 @@ func (s) TestPriority_HigherDownWhileAddingLower(t *testing.T) {
 				hierarchy.Set(resolver.Address{Addr: testBackendAddrStrs[2]}, []string{"child-2"}),
 			},
 		},
-		BalancerConfig: &lbConfig{
-			Children: map[string]*child{
+		BalancerConfig: &LBConfig{
+			Children: map[string]*Child{
 				"child-0": {&internalserviceconfig.BalancerConfig{Name: roundrobin.Name}},
 				"child-1": {&internalserviceconfig.BalancerConfig{Name: roundrobin.Name}},
 				"child-2": {&internalserviceconfig.BalancerConfig{Name: roundrobin.Name}},
@@ -579,7 +579,7 @@ func (s) TestPriority_HigherReadyCloseAllLower(t *testing.T) {
 	// defer time.Sleep(10 * time.Millisecond)
 
 	cc := testutils.NewTestClientConn(t)
-	bb := balancer.Get(priorityBalancerName)
+	bb := balancer.Get(Name)
 	pb := bb.Build(cc, balancer.BuildOptions{})
 	defer pb.Close()
 
@@ -592,8 +592,8 @@ func (s) TestPriority_HigherReadyCloseAllLower(t *testing.T) {
 				hierarchy.Set(resolver.Address{Addr: testBackendAddrStrs[2]}, []string{"child-2"}),
 			},
 		},
-		BalancerConfig: &lbConfig{
-			Children: map[string]*child{
+		BalancerConfig: &LBConfig{
+			Children: map[string]*Child{
 				"child-0": {&internalserviceconfig.BalancerConfig{Name: roundrobin.Name}},
 				"child-1": {&internalserviceconfig.BalancerConfig{Name: roundrobin.Name}},
 				"child-2": {&internalserviceconfig.BalancerConfig{Name: roundrobin.Name}},
@@ -695,7 +695,7 @@ func (s) TestPriority_InitTimeout(t *testing.T) {
 	}()()
 
 	cc := testutils.NewTestClientConn(t)
-	bb := balancer.Get(priorityBalancerName)
+	bb := balancer.Get(Name)
 	pb := bb.Build(cc, balancer.BuildOptions{})
 	defer pb.Close()
 
@@ -707,8 +707,8 @@ func (s) TestPriority_InitTimeout(t *testing.T) {
 				hierarchy.Set(resolver.Address{Addr: testBackendAddrStrs[1]}, []string{"child-1"}),
 			},
 		},
-		BalancerConfig: &lbConfig{
-			Children: map[string]*child{
+		BalancerConfig: &LBConfig{
+			Children: map[string]*Child{
 				"child-0": {&internalserviceconfig.BalancerConfig{Name: roundrobin.Name}},
 				"child-1": {&internalserviceconfig.BalancerConfig{Name: roundrobin.Name}},
 			},
@@ -765,7 +765,7 @@ func (s) TestPriority_RemovesAllPriorities(t *testing.T) {
 	}()()
 
 	cc := testutils.NewTestClientConn(t)
-	bb := balancer.Get(priorityBalancerName)
+	bb := balancer.Get(Name)
 	pb := bb.Build(cc, balancer.BuildOptions{})
 	defer pb.Close()
 
@@ -777,8 +777,8 @@ func (s) TestPriority_RemovesAllPriorities(t *testing.T) {
 				hierarchy.Set(resolver.Address{Addr: testBackendAddrStrs[1]}, []string{"child-1"}),
 			},
 		},
-		BalancerConfig: &lbConfig{
-			Children: map[string]*child{
+		BalancerConfig: &LBConfig{
+			Children: map[string]*Child{
 				"child-0": {&internalserviceconfig.BalancerConfig{Name: roundrobin.Name}},
 				"child-1": {&internalserviceconfig.BalancerConfig{Name: roundrobin.Name}},
 			},
@@ -808,7 +808,7 @@ func (s) TestPriority_RemovesAllPriorities(t *testing.T) {
 		ResolverState: resolver.State{
 			Addresses: nil,
 		},
-		BalancerConfig: &lbConfig{
+		BalancerConfig: &LBConfig{
 			Children:   nil,
 			Priorities: nil,
 		},
@@ -838,8 +838,8 @@ func (s) TestPriority_RemovesAllPriorities(t *testing.T) {
 				hierarchy.Set(resolver.Address{Addr: testBackendAddrStrs[3]}, []string{"child-1"}),
 			},
 		},
-		BalancerConfig: &lbConfig{
-			Children: map[string]*child{
+		BalancerConfig: &LBConfig{
+			Children: map[string]*Child{
 				"child-0": {&internalserviceconfig.BalancerConfig{Name: roundrobin.Name}},
 				"child-1": {&internalserviceconfig.BalancerConfig{Name: roundrobin.Name}},
 			},
@@ -882,8 +882,8 @@ func (s) TestPriority_RemovesAllPriorities(t *testing.T) {
 				hierarchy.Set(resolver.Address{Addr: testBackendAddrStrs[2]}, []string{"child-0"}),
 			},
 		},
-		BalancerConfig: &lbConfig{
-			Children: map[string]*child{
+		BalancerConfig: &LBConfig{
+			Children: map[string]*Child{
 				"child-0": {&internalserviceconfig.BalancerConfig{Name: roundrobin.Name}},
 			},
 			Priorities: []string{"child-0"},
@@ -933,7 +933,7 @@ func (s) TestPriority_RemovesAllPriorities(t *testing.T) {
 // will be used.
 func (s) TestPriority_HighPriorityNoEndpoints(t *testing.T) {
 	cc := testutils.NewTestClientConn(t)
-	bb := balancer.Get(priorityBalancerName)
+	bb := balancer.Get(Name)
 	pb := bb.Build(cc, balancer.BuildOptions{})
 	defer pb.Close()
 
@@ -945,8 +945,8 @@ func (s) TestPriority_HighPriorityNoEndpoints(t *testing.T) {
 				hierarchy.Set(resolver.Address{Addr: testBackendAddrStrs[1]}, []string{"child-1"}),
 			},
 		},
-		BalancerConfig: &lbConfig{
-			Children: map[string]*child{
+		BalancerConfig: &LBConfig{
+			Children: map[string]*Child{
 				"child-0": {&internalserviceconfig.BalancerConfig{Name: roundrobin.Name}},
 				"child-1": {&internalserviceconfig.BalancerConfig{Name: roundrobin.Name}},
 			},
@@ -980,8 +980,8 @@ func (s) TestPriority_HighPriorityNoEndpoints(t *testing.T) {
 				hierarchy.Set(resolver.Address{Addr: testBackendAddrStrs[1]}, []string{"child-1"}),
 			},
 		},
-		BalancerConfig: &lbConfig{
-			Children: map[string]*child{
+		BalancerConfig: &LBConfig{
+			Children: map[string]*Child{
 				"child-0": {&internalserviceconfig.BalancerConfig{Name: roundrobin.Name}},
 				"child-1": {&internalserviceconfig.BalancerConfig{Name: roundrobin.Name}},
 			},
@@ -1032,7 +1032,7 @@ func (s) TestPriority_FirstPriorityUnavailable(t *testing.T) {
 	defaultPriorityInitTimeout = testPriorityInitTimeout
 
 	cc := testutils.NewTestClientConn(t)
-	bb := balancer.Get(priorityBalancerName)
+	bb := balancer.Get(Name)
 	pb := bb.Build(cc, balancer.BuildOptions{})
 	defer pb.Close()
 
@@ -1043,8 +1043,8 @@ func (s) TestPriority_FirstPriorityUnavailable(t *testing.T) {
 				hierarchy.Set(resolver.Address{Addr: testBackendAddrStrs[0]}, []string{"child-0"}),
 			},
 		},
-		BalancerConfig: &lbConfig{
-			Children: map[string]*child{
+		BalancerConfig: &LBConfig{
+			Children: map[string]*Child{
 				"child-0": {&internalserviceconfig.BalancerConfig{Name: roundrobin.Name}},
 			},
 			Priorities: []string{"child-0"},
@@ -1058,7 +1058,7 @@ func (s) TestPriority_FirstPriorityUnavailable(t *testing.T) {
 		ResolverState: resolver.State{
 			Addresses: nil,
 		},
-		BalancerConfig: &lbConfig{
+		BalancerConfig: &LBConfig{
 			Children:   nil,
 			Priorities: nil,
 		},
@@ -1075,7 +1075,7 @@ func (s) TestPriority_FirstPriorityUnavailable(t *testing.T) {
 // Init a(p0) and b(p1); a(p0) is up, use a; move b to p0, a to p1, use b.
 func (s) TestPriority_MoveChildToHigherPriority(t *testing.T) {
 	cc := testutils.NewTestClientConn(t)
-	bb := balancer.Get(priorityBalancerName)
+	bb := balancer.Get(Name)
 	pb := bb.Build(cc, balancer.BuildOptions{})
 	defer pb.Close()
 
@@ -1087,8 +1087,8 @@ func (s) TestPriority_MoveChildToHigherPriority(t *testing.T) {
 				hierarchy.Set(resolver.Address{Addr: testBackendAddrStrs[1]}, []string{"child-1"}),
 			},
 		},
-		BalancerConfig: &lbConfig{
-			Children: map[string]*child{
+		BalancerConfig: &LBConfig{
+			Children: map[string]*Child{
 				"child-0": {&internalserviceconfig.BalancerConfig{Name: roundrobin.Name}},
 				"child-1": {&internalserviceconfig.BalancerConfig{Name: roundrobin.Name}},
 			},
@@ -1124,8 +1124,8 @@ func (s) TestPriority_MoveChildToHigherPriority(t *testing.T) {
 				hierarchy.Set(resolver.Address{Addr: testBackendAddrStrs[1]}, []string{"child-1"}),
 			},
 		},
-		BalancerConfig: &lbConfig{
-			Children: map[string]*child{
+		BalancerConfig: &LBConfig{
+			Children: map[string]*Child{
 				"child-0": {&internalserviceconfig.BalancerConfig{Name: roundrobin.Name}},
 				"child-1": {&internalserviceconfig.BalancerConfig{Name: roundrobin.Name}},
 			},
@@ -1176,7 +1176,7 @@ func (s) TestPriority_MoveChildToHigherPriority(t *testing.T) {
 // Init a(p0) and b(p1); a(p0) is down, use b; move b to p0, a to p1, use b.
 func (s) TestPriority_MoveReadyChildToHigherPriority(t *testing.T) {
 	cc := testutils.NewTestClientConn(t)
-	bb := balancer.Get(priorityBalancerName)
+	bb := balancer.Get(Name)
 	pb := bb.Build(cc, balancer.BuildOptions{})
 	defer pb.Close()
 
@@ -1188,8 +1188,8 @@ func (s) TestPriority_MoveReadyChildToHigherPriority(t *testing.T) {
 				hierarchy.Set(resolver.Address{Addr: testBackendAddrStrs[1]}, []string{"child-1"}),
 			},
 		},
-		BalancerConfig: &lbConfig{
-			Children: map[string]*child{
+		BalancerConfig: &LBConfig{
+			Children: map[string]*Child{
 				"child-0": {&internalserviceconfig.BalancerConfig{Name: roundrobin.Name}},
 				"child-1": {&internalserviceconfig.BalancerConfig{Name: roundrobin.Name}},
 			},
@@ -1240,8 +1240,8 @@ func (s) TestPriority_MoveReadyChildToHigherPriority(t *testing.T) {
 				hierarchy.Set(resolver.Address{Addr: testBackendAddrStrs[1]}, []string{"child-1"}),
 			},
 		},
-		BalancerConfig: &lbConfig{
-			Children: map[string]*child{
+		BalancerConfig: &LBConfig{
+			Children: map[string]*Child{
 				"child-0": {&internalserviceconfig.BalancerConfig{Name: roundrobin.Name}},
 				"child-1": {&internalserviceconfig.BalancerConfig{Name: roundrobin.Name}},
 			},
@@ -1276,7 +1276,7 @@ func (s) TestPriority_MoveReadyChildToHigherPriority(t *testing.T) {
 // Init a(p0) and b(p1); a(p0) is down, use b; move b to p0, a to p1, use b.
 func (s) TestPriority_RemoveReadyLowestChild(t *testing.T) {
 	cc := testutils.NewTestClientConn(t)
-	bb := balancer.Get(priorityBalancerName)
+	bb := balancer.Get(Name)
 	pb := bb.Build(cc, balancer.BuildOptions{})
 	defer pb.Close()
 
@@ -1288,8 +1288,8 @@ func (s) TestPriority_RemoveReadyLowestChild(t *testing.T) {
 				hierarchy.Set(resolver.Address{Addr: testBackendAddrStrs[1]}, []string{"child-1"}),
 			},
 		},
-		BalancerConfig: &lbConfig{
-			Children: map[string]*child{
+		BalancerConfig: &LBConfig{
+			Children: map[string]*Child{
 				"child-0": {&internalserviceconfig.BalancerConfig{Name: roundrobin.Name}},
 				"child-1": {&internalserviceconfig.BalancerConfig{Name: roundrobin.Name}},
 			},
@@ -1338,8 +1338,8 @@ func (s) TestPriority_RemoveReadyLowestChild(t *testing.T) {
 				hierarchy.Set(resolver.Address{Addr: testBackendAddrStrs[0]}, []string{"child-0"}),
 			},
 		},
-		BalancerConfig: &lbConfig{
-			Children: map[string]*child{
+		BalancerConfig: &LBConfig{
+			Children: map[string]*Child{
 				"child-0": {&internalserviceconfig.BalancerConfig{Name: roundrobin.Name}},
 			},
 			Priorities: []string{"child-0"},
@@ -1384,7 +1384,7 @@ func (s) TestPriority_ReadyChildRemovedButInCache(t *testing.T) {
 	}()()
 
 	cc := testutils.NewTestClientConn(t)
-	bb := balancer.Get(priorityBalancerName)
+	bb := balancer.Get(Name)
 	pb := bb.Build(cc, balancer.BuildOptions{})
 	defer pb.Close()
 
@@ -1395,8 +1395,8 @@ func (s) TestPriority_ReadyChildRemovedButInCache(t *testing.T) {
 				hierarchy.Set(resolver.Address{Addr: testBackendAddrStrs[0]}, []string{"child-0"}),
 			},
 		},
-		BalancerConfig: &lbConfig{
-			Children: map[string]*child{
+		BalancerConfig: &LBConfig{
+			Children: map[string]*Child{
 				"child-0": {&internalserviceconfig.BalancerConfig{Name: roundrobin.Name}},
 			},
 			Priorities: []string{"child-0"},
@@ -1426,7 +1426,7 @@ func (s) TestPriority_ReadyChildRemovedButInCache(t *testing.T) {
 	// be different.
 	if err := pb.UpdateClientConnState(balancer.ClientConnState{
 		ResolverState:  resolver.State{},
-		BalancerConfig: &lbConfig{},
+		BalancerConfig: &LBConfig{},
 	}); err != nil {
 		t.Fatalf("failed to update ClientConn state: %v", err)
 	}
@@ -1454,8 +1454,8 @@ func (s) TestPriority_ReadyChildRemovedButInCache(t *testing.T) {
 				hierarchy.Set(resolver.Address{Addr: testBackendAddrStrs[0]}, []string{"child-0"}),
 			},
 		},
-		BalancerConfig: &lbConfig{
-			Children: map[string]*child{
+		BalancerConfig: &LBConfig{
+			Children: map[string]*Child{
 				"child-0": {&internalserviceconfig.BalancerConfig{Name: roundrobin.Name}},
 			},
 			Priorities: []string{"child-0"},
@@ -1487,7 +1487,7 @@ func (s) TestPriority_ReadyChildRemovedButInCache(t *testing.T) {
 // Init 0; 0 is up, use 0; change 0's policy, 0 is used.
 func (s) TestPriority_ChildPolicyChange(t *testing.T) {
 	cc := testutils.NewTestClientConn(t)
-	bb := balancer.Get(priorityBalancerName)
+	bb := balancer.Get(Name)
 	pb := bb.Build(cc, balancer.BuildOptions{})
 	defer pb.Close()
 
@@ -1498,8 +1498,8 @@ func (s) TestPriority_ChildPolicyChange(t *testing.T) {
 				hierarchy.Set(resolver.Address{Addr: testBackendAddrStrs[0]}, []string{"child-0"}),
 			},
 		},
-		BalancerConfig: &lbConfig{
-			Children: map[string]*child{
+		BalancerConfig: &LBConfig{
+			Children: map[string]*Child{
 				"child-0": {&internalserviceconfig.BalancerConfig{Name: roundrobin.Name}},
 			},
 			Priorities: []string{"child-0"},
@@ -1533,8 +1533,8 @@ func (s) TestPriority_ChildPolicyChange(t *testing.T) {
 				hierarchy.Set(resolver.Address{Addr: testBackendAddrStrs[0]}, []string{"child-0"}),
 			},
 		},
-		BalancerConfig: &lbConfig{
-			Children: map[string]*child{
+		BalancerConfig: &LBConfig{
+			Children: map[string]*Child{
 				"child-0": {&internalserviceconfig.BalancerConfig{Name: testRRBalancerName}},
 			},
 			Priorities: []string{"child-0"},
@@ -1587,7 +1587,7 @@ func init() {
 // by acquiring a locked mutex.
 func (s) TestPriority_ChildPolicyUpdatePickerInline(t *testing.T) {
 	cc := testutils.NewTestClientConn(t)
-	bb := balancer.Get(priorityBalancerName)
+	bb := balancer.Get(Name)
 	pb := bb.Build(cc, balancer.BuildOptions{})
 	defer pb.Close()
 
@@ -1598,8 +1598,8 @@ func (s) TestPriority_ChildPolicyUpdatePickerInline(t *testing.T) {
 				hierarchy.Set(resolver.Address{Addr: testBackendAddrStrs[0]}, []string{"child-0"}),
 			},
 		},
-		BalancerConfig: &lbConfig{
-			Children: map[string]*child{
+		BalancerConfig: &LBConfig{
+			Children: map[string]*Child{
 				"child-0": {&internalserviceconfig.BalancerConfig{Name: inlineUpdateBalancerName}},
 			},
 			Priorities: []string{"child-0"},

--- a/xds/internal/balancer/priority/config.go
+++ b/xds/internal/balancer/priority/config.go
@@ -26,24 +26,26 @@ import (
 	"google.golang.org/grpc/serviceconfig"
 )
 
-type child struct {
-	Config *internalserviceconfig.BalancerConfig
+// Child is a child of priority balancer.
+type Child struct {
+	Config *internalserviceconfig.BalancerConfig `json:"config,omitempty"`
 }
 
-type lbConfig struct {
-	serviceconfig.LoadBalancingConfig
+// LBConfig represents priority balancer's config.
+type LBConfig struct {
+	serviceconfig.LoadBalancingConfig `json:"-"`
 
 	// Children is a map from the child balancer names to their configs. Child
 	// names can be found in field Priorities.
-	Children map[string]*child
+	Children map[string]*Child `json:"children,omitempty"`
 	// Priorities is a list of child balancer names. They are sorted from
 	// highest priority to low. The type/config for each child can be found in
 	// field Children, with the balancer name as the key.
-	Priorities []string
+	Priorities []string `json:"priorities,omitempty"`
 }
 
-func parseConfig(c json.RawMessage) (*lbConfig, error) {
-	var cfg lbConfig
+func parseConfig(c json.RawMessage) (*LBConfig, error) {
+	var cfg LBConfig
 	if err := json.Unmarshal(c, &cfg); err != nil {
 		return nil, err
 	}

--- a/xds/internal/balancer/priority/config_test.go
+++ b/xds/internal/balancer/priority/config_test.go
@@ -30,7 +30,7 @@ func TestParseConfig(t *testing.T) {
 	tests := []struct {
 		name    string
 		js      string
-		want    *lbConfig
+		want    *LBConfig
 		wantErr bool
 	}{
 		{
@@ -69,8 +69,8 @@ func TestParseConfig(t *testing.T) {
   }
 }
 			`,
-			want: &lbConfig{
-				Children: map[string]*child{
+			want: &LBConfig{
+				Children: map[string]*Child{
 					"child-1": {
 						&internalserviceconfig.BalancerConfig{
 							Name: roundrobin.Name,

--- a/xds/internal/balancer/weightedtarget/weightedtarget.go
+++ b/xds/internal/balancer/weightedtarget/weightedtarget.go
@@ -33,7 +33,8 @@ import (
 	"google.golang.org/grpc/xds/internal/balancer/weightedtarget/weightedaggregator"
 )
 
-const weightedTargetName = "weighted_target_experimental"
+// Name is the name of the weighted_target balancer.
+const Name = "weighted_target_experimental"
 
 // newRandomWRR is the WRR constructor used to pick sub-pickers from
 // sub-balancers. It's to be modified in tests.
@@ -57,7 +58,7 @@ func (wt *weightedTargetBB) Build(cc balancer.ClientConn, bOpts balancer.BuildOp
 }
 
 func (wt *weightedTargetBB) Name() string {
-	return weightedTargetName
+	return Name
 }
 
 func (wt *weightedTargetBB) ParseConfig(c json.RawMessage) (serviceconfig.LoadBalancingConfig, error) {
@@ -75,14 +76,14 @@ type weightedTargetBalancer struct {
 	bg              *balancergroup.BalancerGroup
 	stateAggregator *weightedaggregator.Aggregator
 
-	targets map[string]target
+	targets map[string]Target
 }
 
 // UpdateClientConnState takes the new targets in balancer group,
 // creates/deletes sub-balancers and sends them update. Addresses are split into
 // groups based on hierarchy path.
 func (w *weightedTargetBalancer) UpdateClientConnState(s balancer.ClientConnState) error {
-	newConfig, ok := s.BalancerConfig.(*lbConfig)
+	newConfig, ok := s.BalancerConfig.(*LBConfig)
 	if !ok {
 		return fmt.Errorf("unexpected balancer config with type: %T", s.BalancerConfig)
 	}

--- a/xds/internal/balancer/weightedtarget/weightedtarget_config.go
+++ b/xds/internal/balancer/weightedtarget/weightedtarget_config.go
@@ -25,30 +25,23 @@ import (
 	"google.golang.org/grpc/serviceconfig"
 )
 
-type target struct {
+// Target represents one target with the weight and the child policy.
+type Target struct {
 	// Weight is the weight of the child policy.
-	Weight uint32
+	Weight uint32 `json:"weight,omitempty"`
 	// ChildPolicy is the child policy and it's config.
-	ChildPolicy *internalserviceconfig.BalancerConfig
+	ChildPolicy *internalserviceconfig.BalancerConfig `json:"childPolicy,omitempty"`
 }
 
-// lbConfig is the balancer config for weighted_target. The proto representation
-// is:
-//
-// message WeightedTargetConfig {
-//   message Target {
-//     uint32 weight = 1;
-//     repeated LoadBalancingConfig child_policy = 2;
-//   }
-//   map<string, Target> targets = 1;
-// }
-type lbConfig struct {
-	serviceconfig.LoadBalancingConfig
-	Targets map[string]target
+// LBConfig is the balancer config for weighted_target.
+type LBConfig struct {
+	serviceconfig.LoadBalancingConfig `json:"-"`
+
+	Targets map[string]Target `json:"targets,omitempty"`
 }
 
-func parseConfig(c json.RawMessage) (*lbConfig, error) {
-	var cfg lbConfig
+func parseConfig(c json.RawMessage) (*LBConfig, error) {
+	var cfg LBConfig
 	if err := json.Unmarshal(c, &cfg); err != nil {
 		return nil, err
 	}

--- a/xds/internal/balancer/weightedtarget/weightedtarget_config_test.go
+++ b/xds/internal/balancer/weightedtarget/weightedtarget_config_test.go
@@ -56,7 +56,7 @@ func Test_parseConfig(t *testing.T) {
 	tests := []struct {
 		name    string
 		js      string
-		want    *lbConfig
+		want    *LBConfig
 		wantErr bool
 	}{
 		{
@@ -68,8 +68,8 @@ func Test_parseConfig(t *testing.T) {
 		{
 			name: "OK",
 			js:   testJSONConfig,
-			want: &lbConfig{
-				Targets: map[string]target{
+			want: &LBConfig{
+				Targets: map[string]Target{
 					"cluster_1": {
 						Weight: 75,
 						ChildPolicy: &internalserviceconfig.BalancerConfig{

--- a/xds/internal/balancer/weightedtarget/weightedtarget_test.go
+++ b/xds/internal/balancer/weightedtarget/weightedtarget_test.go
@@ -103,7 +103,7 @@ func init() {
 	for i := 0; i < testBackendAddrsCount; i++ {
 		testBackendAddrStrs = append(testBackendAddrStrs, fmt.Sprintf("%d.%d.%d.%d:%d", i, i, i, i, i))
 	}
-	wtbBuilder = balancer.Get(weightedTargetName)
+	wtbBuilder = balancer.Get(Name)
 	wtbParser = wtbBuilder.(balancer.ConfigParser)
 
 	balancergroup.DefaultSubBalancerCloseTimeout = time.Millisecond


### PR DESCRIPTION
This PR exports `Name` and `LBConfig` from the balancers that will be used as children by `cluster_impl`. The configs are also made json-ready.