### PR TITLE
reflection: accept interface instead of grpc.Server struct in Register()

### DIFF
--- a/reflection/serverreflection.go
+++ b/reflection/serverreflection.go
@@ -65,13 +65,20 @@ type serverReflectionServer struct {
 
 // Register registers the server reflection service on the given gRPC server.
 func Register(s *grpc.Server) {
-	RegisterWithRegistrar(s, s.GetServiceInfo)
+	register(s, s.GetServiceInfo)
 }
 
 // RegisterWithRegistrar registers the server reflection service with the given registrar.
-// The given function is invoked to determine the services that will be exposed. It is not
-// invoked until the service impl is actually used.
-func RegisterWithRegistrar(r grpc.ServiceRegistrar, queryServices func() map[string]grpc.ServiceInfo) {
+// The given map describes the services that will be exposed via reflection.
+func RegisterWithRegistrar(r grpc.ServiceRegistrar, svcs map[string]grpc.ServiceInfo) {
+	rpb.RegisterServerReflectionServer(r, &serverReflectionServer{
+		queryServices: func() map[string]grpc.ServiceInfo {
+			return svcs
+		},
+	})
+}
+
+func register(r grpc.ServiceRegistrar, queryServices func() map[string]grpc.ServiceInfo) {
 	rpb.RegisterServerReflectionServer(r, &serverReflectionServer{
 		queryServices: queryServices,
 	})


### PR DESCRIPTION
Recently-ish (~6 months ago) a new `grpc.ServiceRegistrar` interface was added, which allows generated code to interact with service registries other than the concrete `*grpc.Server`. Awesome!

But now I need to use the reflection service with something other than a concrete `*grpc.Server`. So this PR enables it. You can provide a different type of registrar but must also provide an accessor for the actual services exposed, so it can compute the reflection info/descriptors.

Hopefully this is a non-controversial addition. Without this, I'm having to resort to reflection+unsafe, to access unexported fields in the `*grpc.Server`, to dig out a reflection server impl registered in there 🤮.