### PR TITLE
Using bitwise operation to determine even

### DIFF
--- a/balancer/rls/internal/adaptive/adaptive_test.go
+++ b/balancer/rls/internal/adaptive/adaptive_test.go
@@ -194,7 +194,7 @@ func TestParallel(t *testing.T) {
 					throttles[num] = throttle
 					return
 				default:
-					if i%2 == 0 {
+					if i&1 == 0 {
 						th.RegisterBackendResponse(true)
 						throttle++
 					} else {

--- a/benchmark/primitives/primitives_test.go
+++ b/benchmark/primitives/primitives_test.go
@@ -427,24 +427,24 @@ func BenchmarkRLockUnlock(b *testing.B) {
 }
 
 func BenchmarkEvenBit(b *testing.B) {
-	n := 1 << 33
+	n := int64(1 << 33)
 	b.ResetTimer()
-	for i := 0; i <= n; i++ {
+	for i := int64(0); i <= n; i++ {
 		runBit(i)
 	}
 	b.StopTimer()
 }
-func runBit(i int) bool {
+func runBit(i int64) bool {
 	return i&1 == 0
 }
 func BenchmarkEvenMod(b *testing.B) {
-	n := 1 << 33
+	n := int64(1 << 33)
 	b.ResetTimer()
-	for i := 0; i <= n; i++ {
+	for i := int64(0); i <= n; i++ {
 		runMod(i)
 	}
 	b.StopTimer()
 }
-func runMod(i int) bool {
+func runMod(i int64) bool {
 	return i%2 == 0
 }

--- a/benchmark/primitives/primitives_test.go
+++ b/benchmark/primitives/primitives_test.go
@@ -430,21 +430,21 @@ func BenchmarkEvenBit(b *testing.B) {
 	n := 1 << 33
 	b.ResetTimer()
 	for i := 0; i <= n; i++ {
-		bit(i)
+		runBit(i)
 	}
 	b.StopTimer()
 }
-func bit(i int) bool {
+func runBit(i int) bool {
 	return i&1 == 0
 }
 func BenchmarkEvenMod(b *testing.B) {
 	n := 1 << 33
 	b.ResetTimer()
 	for i := 0; i <= n; i++ {
-		mod(i)
+		runMod(i)
 	}
 	b.StopTimer()
 }
-func mod(i int) bool {
+func runMod(i int) bool {
 	return i%2 == 0
 }

--- a/benchmark/primitives/primitives_test.go
+++ b/benchmark/primitives/primitives_test.go
@@ -425,3 +425,26 @@ func BenchmarkRLockUnlock(b *testing.B) {
 		}
 	})
 }
+
+func BenchmarkEvenBit(b *testing.B) {
+	n := 1 << 33
+	b.ResetTimer()
+	for i := 0; i <= n; i++ {
+		bit(i)
+	}
+	b.StopTimer()
+}
+func bit(i int) bool {
+	return i&1 == 0
+}
+func BenchmarkEvenMod(b *testing.B) {
+	n := 1 << 33
+	b.ResetTimer()
+	for i := 0; i <= n; i++ {
+		mod(i)
+	}
+	b.StopTimer()
+}
+func mod(i int) bool {
+	return i%2 == 0
+}

--- a/internal/profiling/profiling_test.go
+++ b/internal/profiling/profiling_test.go
@@ -46,7 +46,7 @@ func (s) TestProfiling(t *testing.T) {
 	stat := NewStat("foo")
 	cb.Push(stat)
 	bar := func(n int) {
-		if n%2 == 0 {
+		if n&1 == 0 {
 			defer stat.NewTimer(strconv.Itoa(n)).Egress()
 		} else {
 			timer := NewTimer(strconv.Itoa(n))
@@ -100,7 +100,7 @@ func (s) TestProfilingRace(t *testing.T) {
 	for i := 0; i < numTimers; i++ {
 		go func(n int) {
 			defer wg.Done()
-			if n%2 == 0 {
+			if n&1 == 0 {
 				defer stat.NewTimer(strconv.Itoa(n)).Egress()
 			} else {
 				timer := NewTimer(strconv.Itoa(n))

--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -518,7 +518,7 @@ func (t *http2Client) createHeaderFields(ctx context.Context, callHdr *CallHdr) 
 		}
 		for _, vv := range added {
 			for i, v := range vv {
-				if i%2 == 0 {
+				if i&1 == 0 {
 					k = strings.ToLower(v)
 					continue
 				}

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -77,7 +77,7 @@ func Pairs(kv ...string) MD {
 	md := MD{}
 	var key string
 	for i, s := range kv {
-		if i%2 == 0 {
+		if i&1 == 0 {
 			key = strings.ToLower(s)
 			continue
 		}

--- a/xds/internal/balancer/clusterimpl/balancer_test.go
+++ b/xds/internal/balancer/clusterimpl/balancer_test.go
@@ -126,7 +126,7 @@ func TestDropByCategory(t *testing.T) {
 	for i := 0; i < rpcCount; i++ {
 		gotSCSt, err := p1.Pick(balancer.PickInfo{})
 		// Even RPCs are dropped.
-		if i%2 == 0 {
+		if i&1 == 0 {
 			if err == nil || !strings.Contains(err.Error(), "dropped") {
 				t.Fatalf("pick.Pick, got %v, %v, want error RPC dropped", gotSCSt, err)
 			}


### PR DESCRIPTION
This PR uses bitwise operation `n&1 == 0` to determine even instead of `n%2 == 0`,  this change brings a very small performance improvement(1%~3%).

PLMK if there is a better way to optimize.