### PR TITLE
Make `MaxPingStrikes` configurable by the keepalive EnforcementPolicy

### DIFF
--- a/internal/transport/defaults.go
+++ b/internal/transport/defaults.go
@@ -38,6 +38,7 @@ const (
 	defaultServerKeepaliveTime    = 2 * time.Hour
 	defaultServerKeepaliveTimeout = 20 * time.Second
 	defaultKeepalivePolicyMinTime = 5 * time.Minute
+	defaultMaxPingStrikes         = uint8(2)
 	// max window limit set by HTTP2 Specs.
 	maxWindowSize = math.MaxInt32
 	// defaultWriteQuota is the default value for number of data

--- a/keepalive/keepalive.go
+++ b/keepalive/keepalive.go
@@ -82,4 +82,12 @@ type EnforcementPolicy struct {
 	// streams(RPCs). If false, and client sends ping when there are no active
 	// streams, server will send GOAWAY and close the connection.
 	PermitWithoutStream bool // false by default.
+	// MaxPingStrikes is the total number of ping strikes that a server will
+	// tolerate before sending a GOAWAY frame and closing the connection.
+	// If set to high, servers run the risk of allowing too much load from
+	// clients behaving badly. If set to low, servers risk cutting off clients
+	// due to network bumps or latency. By default, this setting is 2 but
+	// should be tuned to specific network environments. 0 implies infinite
+	// ping strikes can be tolerated.
+	MaxPingStrikes *uint8 // 2 by default.
 }


### PR DESCRIPTION
Fixes #4348 by making `MaxPingStrikes` configureable.

Adds two tests to cover the new behavior:
* One sets the `MaxPingStrikes` to 5, tests that a GOAWAY is sent, and confirms that the operation took the expected amount of time (implying that the keepalive strikes were the expected number).
* The other tests that infinite `MaxPingStrikes` is infinite, and does not sent a GOAWAY after a reasonable amount of time where ping strikes would have accumulated.