### PR TITLE
xds/lrs: server name is not required to be non-empty

### DIFF
--- a/xds/internal/balancer/lrs/config.go
+++ b/xds/internal/balancer/lrs/config.go
@@ -46,9 +46,6 @@ func parseConfig(c json.RawMessage) (*LBConfig, error) {
 	if cfg.ClusterName == "" {
 		return nil, fmt.Errorf("required ClusterName is not set in %+v", cfg)
 	}
-	if cfg.LoadReportingServerName == "" {
-		return nil, fmt.Errorf("required LoadReportingServerName is not set in %+v", cfg)
-	}
 	if cfg.Locality == nil {
 		return nil, fmt.Errorf("required Locality is not set in %+v", cfg)
 	}

--- a/xds/internal/balancer/lrs/config_test.go
+++ b/xds/internal/balancer/lrs/config_test.go
@@ -56,21 +56,6 @@ func TestParseConfig(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "no LRS server name",
-			js: `{
-  "clusterName": "test-cluster",
-  "edsServiceName": "test-eds-service",
-  "locality": {
-    "region": "test-region",
-    "zone": "test-zone",
-    "subZone": "test-sub-zone"
-  },
-  "childPolicy":[{"round_robin":{}}]
-}
-			`,
-			wantErr: true,
-		},
-		{
 			name: "no locality",
 			js: `{
   "clusterName": "test-cluster",


### PR DESCRIPTION
It's valid for `LoadReportingServerName` to be an empty string in LRS's balancer config. It means the loads will be sent to the xDS server.

If LRS is disabled, the parent balancer will not include lrs as a child policy (it will use e.g. round_robin directly, instead of LRS and then round_robin).