### PR TITLE
metadata: reduce memory footprint in FromOutgoingContext

### DIFF
--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -75,13 +75,9 @@ func Pairs(kv ...string) MD {
 		panic(fmt.Sprintf("metadata: Pairs got the odd number of input pairs for metadata: %d", len(kv)))
 	}
 	md := MD{}
-	var key string
-	for i, s := range kv {
-		if i%2 == 0 {
-			key = strings.ToLower(s)
-			continue
-		}
-		md[key] = append(md[key], s)
+	for i := 0; i < len(kv); i += 2 {
+		key := strings.ToLower(kv[i])
+		md[key] = append(md[key], kv[i+1])
 	}
 	return md
 }
@@ -195,12 +191,18 @@ func FromOutgoingContext(ctx context.Context) (MD, bool) {
 		return nil, false
 	}
 
-	mds := make([]MD, 0, len(raw.added)+1)
-	mds = append(mds, raw.md)
-	for _, vv := range raw.added {
-		mds = append(mds, Pairs(vv...))
+	out := raw.md.Copy()
+	for _, added := range raw.added {
+		if len(added)%2 == 1 {
+			panic(fmt.Sprintf("metadata: FromOutgoingContext got an odd number of input pairs for metadata: %d", len(added)))
+		}
+
+		for i := 0; i < len(added); i += 2 {
+			key := strings.ToLower(added[i])
+			out[key] = append(out[key], added[i+1])
+		}
 	}
-	return Join(mds...), ok
+	return out, ok
 }
 
 type rawMD struct {


### PR DESCRIPTION
When Looking at memory profiles for cockroachdb/cockroach, we observed
that the intermediate metadata.MD array constructed to iterate over
appended metadata escaped to the heap. Fortunately, this is easily
rectifiable.
```
  go build -gcflags '-m' google.golang.org/grpc/metadata
  ...
  google.golang.org/grpc/metadata/metadata.go:198:13: make([]MD, 0, len(raw.added) + 1) escapes to heap
```