### PR TITLE
Add retract directive for v1.33.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,3 +15,6 @@ require (
 	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013
 	google.golang.org/protobuf v1.25.0
 )
+
+// 1.33.0 was retracted, explanation: https://github.com/grpc/grpc-go/issues/3945
+retract v1.33.0


### PR DESCRIPTION
This leverages the new `retract` directive from go 1.16.

This will break on go 1.15 and below, so given that this library
promises to support the last three major versions of `go`, this
shouldn't be merged until `go` `1.19` is released.

Which is a pity, as by that time most folks will be bitten/have had to dig
to find out why they can't pull in `v1.33.0` anymore.

But at least this sets a good example in case any other versions are later retracted as well.