### PR TITLE
serviceconfig: support marshalling BalancerConfig to JSON

### DIFF
--- a/internal/serviceconfig/serviceconfig.go
+++ b/internal/serviceconfig/serviceconfig.go
@@ -46,6 +46,22 @@ type BalancerConfig struct {
 
 type intermediateBalancerConfig []map[string]json.RawMessage
 
+// MarshalJSON implements the json.Marshaler interface.
+//
+// It marshals the balancer and config into a length-1 slice
+// ([]map[string]config).
+func (bc *BalancerConfig) MarshalJSON() ([]byte, error) {
+	if bc.Config == nil {
+		// If config is nil, return empty config `{}`.
+		return []byte(fmt.Sprintf(`[{%q: %v}]`, bc.Name, "{}")), nil
+	}
+	c, err := json.Marshal(bc.Config)
+	if err != nil {
+		return nil, err
+	}
+	return []byte(fmt.Sprintf(`[{%q: %s}]`, bc.Name, c)), nil
+}
+
 // UnmarshalJSON implements the json.Unmarshaler interface.
 //
 // ServiceConfig contains a list of loadBalancingConfigs, each with a name and

--- a/internal/serviceconfig/serviceconfig_test.go
+++ b/internal/serviceconfig/serviceconfig_test.go
@@ -148,23 +148,15 @@ func TestBalancerConfigMarshalJSON(t *testing.T) {
 				Name:   testBalancerBuilderName,
 				Config: testBalancerConfig,
 			},
-			wantJSON: fmt.Sprintf("[{%q: %v}]", testBalancerBuilderName, testBalancerConfigJSON),
+			wantJSON: fmt.Sprintf(`[{"test-bb": {"check":true}}]`),
 		},
 		{
-			name: "first balancer not registered",
-			bc: BalancerConfig{
-				Name:   testBalancerBuilderName,
-				Config: testBalancerConfig,
-			},
-			wantJSON: fmt.Sprintf("[{%q: %v}]", testBalancerBuilderName, testBalancerConfigJSON),
-		},
-		{
-			name: "balancer registered but builder not parser",
+			name: "OK config is nil",
 			bc: BalancerConfig{
 				Name:   testBalancerBuilderNotParserName,
-				Config: nil,
+				Config: nil, // nil should be marshalled to an empty config "{}".
 			},
-			wantJSON: fmt.Sprintf("[{%q: %v}]", testBalancerBuilderNotParserName, "{}"),
+			wantJSON: fmt.Sprintf(`[{"test-bb-not-parser": {}}]`),
 		},
 	}
 	for _, tt := range tests {
@@ -174,8 +166,7 @@ func TestBalancerConfigMarshalJSON(t *testing.T) {
 				t.Fatalf("failed to marshal: %v", err)
 			}
 
-			str := string(b)
-			if str != tt.wantJSON {
+			if str := string(b); str != tt.wantJSON {
 				t.Fatalf("got str %q, want %q", str, tt.wantJSON)
 			}
 

--- a/internal/serviceconfig/serviceconfig_test.go
+++ b/internal/serviceconfig/serviceconfig_test.go
@@ -29,16 +29,18 @@ import (
 )
 
 type testBalancerConfigType struct {
-	externalserviceconfig.LoadBalancingConfig
+	externalserviceconfig.LoadBalancingConfig `json:"-"`
+
+	Check bool `json:"check"`
 }
 
-var testBalancerConfig = testBalancerConfigType{}
+var testBalancerConfig = testBalancerConfigType{Check: true}
 
 const (
 	testBalancerBuilderName          = "test-bb"
 	testBalancerBuilderNotParserName = "test-bb-not-parser"
 
-	testBalancerConfigJSON = `{"test-balancer-config":"true"}`
+	testBalancerConfigJSON = `{"check":true}`
 )
 
 type testBalancerBuilder struct {
@@ -129,6 +131,60 @@ func TestBalancerConfigUnmarshalJSON(t *testing.T) {
 			}
 			if !cmp.Equal(bc, tt.want) {
 				t.Errorf("diff: %v", cmp.Diff(bc, tt.want))
+			}
+		})
+	}
+}
+
+func TestBalancerConfigMarshalJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		bc       BalancerConfig
+		wantJSON string
+	}{
+		{
+			name: "OK",
+			bc: BalancerConfig{
+				Name:   testBalancerBuilderName,
+				Config: testBalancerConfig,
+			},
+			wantJSON: fmt.Sprintf("[{%q: %v}]", testBalancerBuilderName, testBalancerConfigJSON),
+		},
+		{
+			name: "first balancer not registered",
+			bc: BalancerConfig{
+				Name:   testBalancerBuilderName,
+				Config: testBalancerConfig,
+			},
+			wantJSON: fmt.Sprintf("[{%q: %v}]", testBalancerBuilderName, testBalancerConfigJSON),
+		},
+		{
+			name: "balancer registered but builder not parser",
+			bc: BalancerConfig{
+				Name:   testBalancerBuilderNotParserName,
+				Config: nil,
+			},
+			wantJSON: fmt.Sprintf("[{%q: %v}]", testBalancerBuilderNotParserName, "{}"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b, err := tt.bc.MarshalJSON()
+			if err != nil {
+				t.Fatalf("failed to marshal: %v", err)
+			}
+
+			str := string(b)
+			if str != tt.wantJSON {
+				t.Fatalf("got str %q, want %q", str, tt.wantJSON)
+			}
+
+			var bc BalancerConfig
+			if err := bc.UnmarshalJSON(b); err != nil {
+				t.Errorf("failed to mnmarshal: %v", err)
+			}
+			if !cmp.Equal(bc, tt.bc) {
+				t.Errorf("diff: %v", cmp.Diff(bc, tt.bc))
 			}
 		})
 	}


### PR DESCRIPTION
For balancer config with `{name: "abc", config: ...}`, the marshal result will be `[{"abc": ...}]`.

The result is a slice (`[]map[string]config`) of length 1.
The result can be unmarshalled back to a BalancerConfig (by the already defined `UnmarshalJSON()`).