### PR TITLE
testing: print something explicit when tests fail due to logs

### DIFF
--- a/internal/grpctest/tlogger.go
+++ b/internal/grpctest/tlogger.go
@@ -91,6 +91,7 @@ func (g *tLogger) log(ltype logType, depth int, format string, args ...interface
 			if g.expected(fmt.Sprintln(args...)) {
 				g.t.Log(args...)
 			} else {
+				g.t.Error("Saw error log:")
 				g.t.Error(args...)
 			}
 		case fatalLog:
@@ -106,6 +107,7 @@ func (g *tLogger) log(ltype logType, depth int, format string, args ...interface
 			if g.expected(fmt.Sprintf(format, args...)) {
 				g.t.Logf(format, args...)
 			} else {
+				g.t.Error("Saw error log:")
 				g.t.Errorf(format, args...)
 			}
 		case fatalLog:

--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -396,7 +396,7 @@ func newHTTP2Client(connectCtx, ctx context.Context, addr resolver.Address, opts
 		err := t.loopy.run()
 		if err != nil {
 			if logger.V(logLevel) {
-				logger.Errorf("transport: loopyWriter.run returning. Err: %v", err)
+				logger.Warningf("transport: loopyWriter.run returning. Err: %v", err)
 			}
 		}
 		// If it's a connection error, let reader goroutine handle it

--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -396,7 +396,7 @@ func newHTTP2Client(connectCtx, ctx context.Context, addr resolver.Address, opts
 		err := t.loopy.run()
 		if err != nil {
 			if logger.V(logLevel) {
-				logger.Warningf("transport: loopyWriter.run returning. Err: %v", err)
+				logger.Infof("transport: loopyWriter.run returning. Err: %v", err)
 			}
 		}
 		// If it's a connection error, let reader goroutine handle it

--- a/internal/transport/http2_server.go
+++ b/internal/transport/http2_server.go
@@ -884,7 +884,7 @@ func (t *http2Server) WriteStatus(s *Stream, st *status.Status) error {
 		stBytes, err := proto.Marshal(p)
 		if err != nil {
 			// TODO: return error instead, when callers are able to handle it.
-			logger.Warningf("transport: failed to marshal rpc status: %v, error: %v", p, err)
+			logger.Errorf("transport: failed to marshal rpc status: %v, error: %v", p, err)
 		} else {
 			headerFields = append(headerFields, hpack.HeaderField{Name: "grpc-status-details-bin", Value: encodeBinHeader(stBytes)})
 		}

--- a/internal/transport/http2_server.go
+++ b/internal/transport/http2_server.go
@@ -884,7 +884,7 @@ func (t *http2Server) WriteStatus(s *Stream, st *status.Status) error {
 		stBytes, err := proto.Marshal(p)
 		if err != nil {
 			// TODO: return error instead, when callers are able to handle it.
-			logger.Errorf("transport: failed to marshal rpc status: %v, error: %v", p, err)
+			logger.Warningf("transport: failed to marshal rpc status: %v, error: %v", p, err)
 		} else {
 			headerFields = append(headerFields, hpack.HeaderField{Name: "grpc-status-details-bin", Value: encodeBinHeader(stBytes)})
 		}

--- a/internal/transport/http_util.go
+++ b/internal/transport/http_util.go
@@ -373,7 +373,7 @@ func (d *decodeState) processHeaderField(f hpack.HeaderField) {
 		v, err := decodeMetadataHeader(f.Name, f.Value)
 		if err != nil {
 			if logger.V(logLevel) {
-				logger.Errorf("Failed to decode metadata header (%q, %q): %v", f.Name, f.Value, err)
+				logger.Infof("Failed to decode metadata header (%q, %q): %v", f.Name, f.Value, err)
 			}
 			return
 		}

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -6425,8 +6425,6 @@ func (s) TestStatusInvalidUTF8Message(t *testing.T) {
 // will fail to marshal the status because of the invalid utf8 message. Details
 // will be dropped when sending.
 func (s) TestStatusInvalidUTF8Details(t *testing.T) {
-	grpctest.TLogger.ExpectError("transport: failed to marshal rpc status")
-
 	var (
 		origMsg = string([]byte{0xff, 0xfe, 0xfd})
 		wantMsg = "���"


### PR DESCRIPTION
Also, reduce transport errors into info.