### PR TITLE
xds/eds: restart EDS watch after previous was canceled

### DIFF
--- a/xds/internal/balancer/edsbalancer/eds.go
+++ b/xds/internal/balancer/edsbalancer/eds.go
@@ -314,10 +314,12 @@ func (x *edsBalancer) cancelWatch() {
 	x.loadReportServer = nil
 	if x.cancelLoadReport != nil {
 		x.cancelLoadReport()
+		x.cancelLoadReport = nil
 	}
-	x.edsServiceName = ""
 	if x.cancelEndpointsWatch != nil {
+		x.edsToWatch = ""
 		x.cancelEndpointsWatch()
+		x.cancelEndpointsWatch = nil
 	}
 }
 
@@ -331,6 +333,7 @@ func (x *edsBalancer) startLoadReport(loadReportServer *string) *load.Store {
 	x.loadReportServer = loadReportServer
 	if x.cancelLoadReport != nil {
 		x.cancelLoadReport()
+		x.cancelLoadReport = nil
 	}
 	if loadReportServer == nil {
 		return nil


### PR DESCRIPTION
This is a regression caused by #4352.

The real change is
```diff
- x.edsServiceName = ""
+ x.edsToWatch = ""
```

Setting a wrong value caused the EDS to not restart watch after the previous one was canceled.