### PR TITLE
Revert "xds/cds: add separate fields for cluster name and eds service name"

### DIFF
--- a/xds/internal/balancer/cdsbalancer/cdsbalancer.go
+++ b/xds/internal/balancer/cdsbalancer/cdsbalancer.go
@@ -340,8 +340,7 @@ func (b *cdsBalancer) handleWatchUpdate(update *watchUpdate) {
 		b.logger.Infof("Created child policy %p of type %s", b.edsLB, edsName)
 	}
 	lbCfg := &edsbalancer.EDSConfig{
-		ClusterName:           update.cds.ClusterName,
-		EDSServiceName:        update.cds.EDSServiceName,
+		EDSServiceName:        update.cds.ServiceName,
 		MaxConcurrentRequests: update.cds.MaxRequests,
 	}
 	if update.cds.EnableLRS {

--- a/xds/internal/balancer/cdsbalancer/cdsbalancer_security_test.go
+++ b/xds/internal/balancer/cdsbalancer/cdsbalancer_security_test.go
@@ -60,7 +60,7 @@ var (
 	fpb1, fpb2                   *fakeProviderBuilder
 	bootstrapConfig              *bootstrap.Config
 	cdsUpdateWithGoodSecurityCfg = xdsclient.ClusterUpdate{
-		ClusterName: serviceName,
+		ServiceName: serviceName,
 		SecurityCfg: &xdsclient.SecurityConfig{
 			RootInstanceName:       "default1",
 			IdentityInstanceName:   "default2",
@@ -68,7 +68,7 @@ var (
 		},
 	}
 	cdsUpdateWithMissingSecurityCfg = xdsclient.ClusterUpdate{
-		ClusterName: serviceName,
+		ServiceName: serviceName,
 		SecurityCfg: &xdsclient.SecurityConfig{
 			RootInstanceName: "not-default",
 		},
@@ -256,7 +256,7 @@ func (s) TestSecurityConfigWithoutXDSCreds(t *testing.T) {
 	// create a new EDS balancer. The fake EDS balancer created above will be
 	// returned to the CDS balancer, because we have overridden the
 	// newEDSBalancer function as part of test setup.
-	cdsUpdate := xdsclient.ClusterUpdate{ClusterName: serviceName}
+	cdsUpdate := xdsclient.ClusterUpdate{ServiceName: serviceName}
 	wantCCS := edsCCS(serviceName, nil, false)
 	ctx, ctxCancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer ctxCancel()
@@ -312,7 +312,7 @@ func (s) TestNoSecurityConfigWithXDSCreds(t *testing.T) {
 	// returned to the CDS balancer, because we have overridden the
 	// newEDSBalancer function as part of test setup. No security config is
 	// passed to the CDS balancer as part of this update.
-	cdsUpdate := xdsclient.ClusterUpdate{ClusterName: serviceName}
+	cdsUpdate := xdsclient.ClusterUpdate{ServiceName: serviceName}
 	wantCCS := edsCCS(serviceName, nil, false)
 	ctx, ctxCancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer ctxCancel()
@@ -572,7 +572,7 @@ func (s) TestSecurityConfigUpdate_GoodToFallback(t *testing.T) {
 	// an update which contains bad security config. So, we expect the CDS
 	// balancer to forward this error to the EDS balancer and eventually the
 	// channel needs to be put in a bad state.
-	cdsUpdate := xdsclient.ClusterUpdate{ClusterName: serviceName}
+	cdsUpdate := xdsclient.ClusterUpdate{ServiceName: serviceName}
 	if err := invokeWatchCbAndWait(ctx, xdsC, cdsWatchInfo{cdsUpdate, nil}, wantCCS, edsB); err != nil {
 		t.Fatal(err)
 	}
@@ -678,7 +678,7 @@ func (s) TestSecurityConfigUpdate_GoodToGood(t *testing.T) {
 	// returned to the CDS balancer, because we have overridden the
 	// newEDSBalancer function as part of test setup.
 	cdsUpdate := xdsclient.ClusterUpdate{
-		ClusterName: serviceName,
+		ServiceName: serviceName,
 		SecurityCfg: &xdsclient.SecurityConfig{
 			RootInstanceName:       "default1",
 			SubjectAltNameMatchers: testSANMatchers,
@@ -703,7 +703,7 @@ func (s) TestSecurityConfigUpdate_GoodToGood(t *testing.T) {
 
 	// Push another update with a new security configuration.
 	cdsUpdate = xdsclient.ClusterUpdate{
-		ClusterName: serviceName,
+		ServiceName: serviceName,
 		SecurityCfg: &xdsclient.SecurityConfig{
 			RootInstanceName:       "default2",
 			SubjectAltNameMatchers: testSANMatchers,

--- a/xds/internal/balancer/cdsbalancer/cdsbalancer_test.go
+++ b/xds/internal/balancer/cdsbalancer/cdsbalancer_test.go
@@ -197,7 +197,7 @@ func cdsCCS(cluster string) balancer.ClientConnState {
 // cdsBalancer to the edsBalancer.
 func edsCCS(service string, countMax *uint32, enableLRS bool) balancer.ClientConnState {
 	lbCfg := &edsbalancer.EDSConfig{
-		ClusterName:           service,
+		EDSServiceName:        service,
 		MaxConcurrentRequests: countMax,
 	}
 	if enableLRS {
@@ -354,12 +354,12 @@ func (s) TestHandleClusterUpdate(t *testing.T) {
 	}{
 		{
 			name:      "happy-case-with-lrs",
-			cdsUpdate: xdsclient.ClusterUpdate{ClusterName: serviceName, EnableLRS: true},
+			cdsUpdate: xdsclient.ClusterUpdate{ServiceName: serviceName, EnableLRS: true},
 			wantCCS:   edsCCS(serviceName, nil, true),
 		},
 		{
 			name:      "happy-case-without-lrs",
-			cdsUpdate: xdsclient.ClusterUpdate{ClusterName: serviceName},
+			cdsUpdate: xdsclient.ClusterUpdate{ServiceName: serviceName},
 			wantCCS:   edsCCS(serviceName, nil, false),
 		},
 	}
@@ -427,7 +427,7 @@ func (s) TestHandleClusterUpdateError(t *testing.T) {
 	// create a new EDS balancer. The fake EDS balancer created above will be
 	// returned to the CDS balancer, because we have overridden the
 	// newEDSBalancer function as part of test setup.
-	cdsUpdate := xdsclient.ClusterUpdate{ClusterName: serviceName}
+	cdsUpdate := xdsclient.ClusterUpdate{ServiceName: serviceName}
 	wantCCS := edsCCS(serviceName, nil, false)
 	if err := invokeWatchCbAndWait(ctx, xdsC, cdsWatchInfo{cdsUpdate, nil}, wantCCS, edsB); err != nil {
 		t.Fatal(err)
@@ -512,7 +512,7 @@ func (s) TestResolverError(t *testing.T) {
 	// create a new EDS balancer. The fake EDS balancer created above will be
 	// returned to the CDS balancer, because we have overridden the
 	// newEDSBalancer function as part of test setup.
-	cdsUpdate := xdsclient.ClusterUpdate{ClusterName: serviceName}
+	cdsUpdate := xdsclient.ClusterUpdate{ServiceName: serviceName}
 	wantCCS := edsCCS(serviceName, nil, false)
 	if err := invokeWatchCbAndWait(ctx, xdsC, cdsWatchInfo{cdsUpdate, nil}, wantCCS, edsB); err != nil {
 		t.Fatal(err)
@@ -561,7 +561,7 @@ func (s) TestUpdateSubConnState(t *testing.T) {
 	// create a new EDS balancer. The fake EDS balancer created above will be
 	// returned to the CDS balancer, because we have overridden the
 	// newEDSBalancer function as part of test setup.
-	cdsUpdate := xdsclient.ClusterUpdate{ClusterName: serviceName}
+	cdsUpdate := xdsclient.ClusterUpdate{ServiceName: serviceName}
 	wantCCS := edsCCS(serviceName, nil, false)
 	ctx, ctxCancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer ctxCancel()
@@ -596,7 +596,7 @@ func (s) TestCircuitBreaking(t *testing.T) {
 	// will trigger the watch handler on the CDS balancer, which will update
 	// the service's counter with the new max requests.
 	var maxRequests uint32 = 1
-	cdsUpdate := xdsclient.ClusterUpdate{ClusterName: serviceName, MaxRequests: &maxRequests}
+	cdsUpdate := xdsclient.ClusterUpdate{ServiceName: serviceName, MaxRequests: &maxRequests}
 	wantCCS := edsCCS(serviceName, &maxRequests, false)
 	ctx, ctxCancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer ctxCancel()
@@ -629,7 +629,7 @@ func (s) TestClose(t *testing.T) {
 	// create a new EDS balancer. The fake EDS balancer created above will be
 	// returned to the CDS balancer, because we have overridden the
 	// newEDSBalancer function as part of test setup.
-	cdsUpdate := xdsclient.ClusterUpdate{ClusterName: serviceName}
+	cdsUpdate := xdsclient.ClusterUpdate{ServiceName: serviceName}
 	wantCCS := edsCCS(serviceName, nil, false)
 	ctx, ctxCancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer ctxCancel()

--- a/xds/internal/balancer/edsbalancer/config.go
+++ b/xds/internal/balancer/edsbalancer/config.go
@@ -35,10 +35,8 @@ type EDSConfig struct {
 	// FallBackPolicy represents the load balancing config for the
 	// fallback.
 	FallBackPolicy *loadBalancingConfig
-	// ClusterName is the cluster name.
-	ClusterName string
-	// EDSServiceName is the name to use in EDS query. If not set, use
-	// ClusterName.
+	// Name to use in EDS query.  If not present, defaults to the server
+	// name from the target URI.
 	EDSServiceName string
 	// MaxConcurrentRequests is the max number of concurrent request allowed for
 	// this service. If unset, default value 1024 is used.
@@ -61,7 +59,6 @@ type EDSConfig struct {
 type edsConfigJSON struct {
 	ChildPolicy                []*loadBalancingConfig
 	FallbackPolicy             []*loadBalancingConfig
-	ClusterName                string
 	EDSServiceName             string
 	MaxConcurrentRequests      *uint32
 	LRSLoadReportingServerName *string
@@ -76,7 +73,6 @@ func (l *EDSConfig) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	l.ClusterName = configJSON.ClusterName
 	l.EDSServiceName = configJSON.EDSServiceName
 	l.MaxConcurrentRequests = configJSON.MaxConcurrentRequests
 	l.LrsLoadReportingServerName = configJSON.LRSLoadReportingServerName

--- a/xds/internal/balancer/edsbalancer/eds.go
+++ b/xds/internal/balancer/edsbalancer/eds.go
@@ -219,7 +219,7 @@ func (x *edsBalancer) handleGRPCUpdate(update interface{}) {
 			x.logger.Warningf("failed to update xDS client: %v", err)
 		}
 
-		x.edsImpl.updateServiceRequestsConfig(cfg.ClusterName, cfg.MaxConcurrentRequests)
+		x.edsImpl.updateServiceRequestsConfig(cfg.EDSServiceName, cfg.MaxConcurrentRequests)
 
 		// We will update the edsImpl with the new child policy, if we got a
 		// different one.

--- a/xds/internal/balancer/edsbalancer/eds.go
+++ b/xds/internal/balancer/edsbalancer/eds.go
@@ -314,12 +314,10 @@ func (x *edsBalancer) cancelWatch() {
 	x.loadReportServer = nil
 	if x.cancelLoadReport != nil {
 		x.cancelLoadReport()
-		x.cancelLoadReport = nil
 	}
+	x.edsServiceName = ""
 	if x.cancelEndpointsWatch != nil {
-		x.edsToWatch = ""
 		x.cancelEndpointsWatch()
-		x.cancelEndpointsWatch = nil
 	}
 }
 
@@ -333,7 +331,6 @@ func (x *edsBalancer) startLoadReport(loadReportServer *string) *load.Store {
 	x.loadReportServer = loadReportServer
 	if x.cancelLoadReport != nil {
 		x.cancelLoadReport()
-		x.cancelLoadReport = nil
 	}
 	if loadReportServer == nil {
 		return nil

--- a/xds/internal/balancer/edsbalancer/eds.go
+++ b/xds/internal/balancer/edsbalancer/eds.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"google.golang.org/grpc/xds/internal/balancer/loadstore"
 
 	"google.golang.org/grpc/balancer"
 	"google.golang.org/grpc/balancer/roundrobin"
@@ -69,7 +68,7 @@ func (b *edsBalancerBuilder) Build(cc balancer.ClientConn, opts balancer.BuildOp
 		grpcUpdate:        make(chan interface{}),
 		xdsClientUpdate:   make(chan *edsUpdate),
 		childPolicyUpdate: buffer.NewUnbounded(),
-		loadWrapper:       loadstore.NewWrapper(),
+		lsw:               &loadStoreWrapper{},
 		config:            &EDSConfig{},
 	}
 	x.logger = prefixLogger(x)
@@ -81,7 +80,7 @@ func (b *edsBalancerBuilder) Build(cc balancer.ClientConn, opts balancer.BuildOp
 	}
 
 	x.xdsClient = client
-	x.edsImpl = newEDSBalancer(x.cc, opts, x.enqueueChildBalancerState, x.loadWrapper, x.logger)
+	x.edsImpl = newEDSBalancer(x.cc, opts, x.enqueueChildBalancerState, x.lsw, x.logger)
 	x.logger.Infof("Created")
 	go x.run()
 	return x
@@ -139,14 +138,14 @@ type edsBalancer struct {
 	xdsClientUpdate   chan *edsUpdate
 	childPolicyUpdate *buffer.Unbounded
 
-	xdsClient   xdsClientInterface
-	loadWrapper *loadstore.Wrapper
-	config      *EDSConfig // may change when passed a different service config
-	edsImpl     edsBalancerImplInterface
+	xdsClient xdsClientInterface
+	lsw       *loadStoreWrapper
+	config    *EDSConfig // may change when passed a different service config
+	edsImpl   edsBalancerImplInterface
 
-	clusterName          string
+	// edsServiceName is the edsServiceName currently being watched, not
+	// necessary the edsServiceName from service config.
 	edsServiceName       string
-	edsToWatch           string // this is edsServiceName if it's set, otherwise, it's clusterName.
 	cancelEndpointsWatch func()
 	loadReportServer     *string // LRS is disabled if loadReporterServer is nil.
 	cancelLoadReport     func()
@@ -242,35 +241,10 @@ func (x *edsBalancer) handleGRPCUpdate(update interface{}) {
 // handleServiceConfigUpdate applies the service config update, watching a new
 // EDS service name and restarting LRS stream, as required.
 func (x *edsBalancer) handleServiceConfigUpdate(config *EDSConfig) error {
-	var updateLoadClusterAndService bool
-	if x.clusterName != config.ClusterName {
-		updateLoadClusterAndService = true
-		x.clusterName = config.ClusterName
-		x.edsImpl.updateClusterName(x.clusterName)
-	}
+	// Restart EDS watch when the edsServiceName has changed.
 	if x.edsServiceName != config.EDSServiceName {
-		updateLoadClusterAndService = true
 		x.edsServiceName = config.EDSServiceName
-	}
-
-	// If EDSServiceName is set, use it to watch EDS. Otherwise, use the cluster
-	// name.
-	newEDSToWatch := config.EDSServiceName
-	if newEDSToWatch == "" {
-		newEDSToWatch = config.ClusterName
-	}
-	var restartEDSWatch bool
-	if x.edsToWatch != newEDSToWatch {
-		restartEDSWatch = true
-		x.edsToWatch = newEDSToWatch
-	}
-
-	// Restart EDS watch when the eds name has changed.
-	if restartEDSWatch {
 		x.startEndpointsWatch()
-	}
-
-	if updateLoadClusterAndService {
 		// TODO: this update for the LRS service name is too early. It should
 		// only apply to the new EDS response. But this is applied to the RPCs
 		// before the new EDS response. To fully fix this, the EDS balancer
@@ -278,13 +252,14 @@ func (x *edsBalancer) handleServiceConfigUpdate(config *EDSConfig) error {
 		//
 		// This is OK for now, because we don't actually expect edsServiceName
 		// to change. Fix this (a bigger change) will happen later.
-		x.loadWrapper.UpdateClusterAndService(x.clusterName, x.edsServiceName)
+		x.lsw.updateServiceName(x.edsServiceName)
+		x.edsImpl.updateClusterName(x.edsServiceName)
 	}
 
 	// Restart load reporting when the loadReportServer name has changed.
 	if !equalStringPointers(x.loadReportServer, config.LrsLoadReportingServerName) {
 		loadStore := x.startLoadReport(config.LrsLoadReportingServerName)
-		x.loadWrapper.UpdateLoadStore(loadStore)
+		x.lsw.updateLoadStore(loadStore)
 	}
 
 	return nil
@@ -298,15 +273,14 @@ func (x *edsBalancer) startEndpointsWatch() {
 	if x.cancelEndpointsWatch != nil {
 		x.cancelEndpointsWatch()
 	}
-	edsToWatch := x.edsToWatch
-	cancelEDSWatch := x.xdsClient.WatchEndpoints(edsToWatch, func(update xdsclient.EndpointsUpdate, err error) {
+	cancelEDSWatch := x.xdsClient.WatchEndpoints(x.edsServiceName, func(update xdsclient.EndpointsUpdate, err error) {
 		x.logger.Infof("Watch update from xds-client %p, content: %+v", x.xdsClient, update)
 		x.handleEDSUpdate(update, err)
 	})
-	x.logger.Infof("Watch started on resource name %v with xds-client %p", edsToWatch, x.xdsClient)
+	x.logger.Infof("Watch started on resource name %v with xds-client %p", x.edsServiceName, x.xdsClient)
 	x.cancelEndpointsWatch = func() {
 		cancelEDSWatch()
-		x.logger.Infof("Watch cancelled on resource name %v with xds-client %p", edsToWatch, x.xdsClient)
+		x.logger.Infof("Watch cancelled on resource name %v with xds-client %p", x.edsServiceName, x.xdsClient)
 	}
 }
 

--- a/xds/internal/balancer/edsbalancer/eds_impl_test.go
+++ b/xds/internal/balancer/edsbalancer/eds_impl_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"google.golang.org/grpc/internal"
-	"google.golang.org/grpc/xds/internal/balancer/loadstore"
 
 	"google.golang.org/grpc/balancer"
 	"google.golang.org/grpc/balancer/roundrobin"
@@ -821,9 +820,9 @@ func (s) TestEDS_LoadReport(t *testing.T) {
 	// implements the LoadStore() method to return the underlying load.Store to
 	// be used.
 	loadStore := load.NewStore()
-	lsWrapper := loadstore.NewWrapper()
-	lsWrapper.UpdateClusterAndService(testClusterNames[0], "")
-	lsWrapper.UpdateLoadStore(loadStore)
+	lsWrapper := &loadStoreWrapper{}
+	lsWrapper.updateServiceName(testClusterNames[0])
+	lsWrapper.updateLoadStore(loadStore)
 
 	cc := testutils.NewTestClientConn(t)
 	edsb := newEDSBalancerImpl(cc, balancer.BuildOptions{}, nil, lsWrapper, nil)
@@ -914,8 +913,8 @@ func (s) TestEDS_LoadReport(t *testing.T) {
 // TestEDS_LoadReportDisabled covers the case that LRS is disabled. It makes
 // sure the EDS implementation isn't broken (doesn't panic).
 func (s) TestEDS_LoadReportDisabled(t *testing.T) {
-	lsWrapper := loadstore.NewWrapper()
-	lsWrapper.UpdateClusterAndService(testClusterNames[0], "")
+	lsWrapper := &loadStoreWrapper{}
+	lsWrapper.updateServiceName(testClusterNames[0])
 	// Not calling lsWrapper.updateLoadStore(loadStore) because LRS is disabled.
 
 	cc := testutils.NewTestClientConn(t)

--- a/xds/internal/balancer/edsbalancer/eds_test.go
+++ b/xds/internal/balancer/edsbalancer/eds_test.go
@@ -512,18 +512,6 @@ func (s) TestErrorFromXDSClientUpdate(t *testing.T) {
 	if err := edsLB.waitForEDSResponse(ctx, xdsclient.EndpointsUpdate{}); err != nil {
 		t.Fatalf("eds impl expecting empty update, got %v", err)
 	}
-
-	// An update with the same service name should not trigger a new watch.
-	if err := edsB.UpdateClientConnState(balancer.ClientConnState{
-		BalancerConfig: &EDSConfig{EDSServiceName: testServiceName},
-	}); err != nil {
-		t.Fatal(err)
-	}
-	sCtx, sCancel = context.WithTimeout(context.Background(), defaultTestShortTimeout)
-	defer sCancel()
-	if _, err := xdsC.WaitForWatchEDS(sCtx); err != context.DeadlineExceeded {
-		t.Fatal("got unexpected new EDS watch")
-	}
 }
 
 // TestErrorFromResolver verifies that resolver errors are handled correctly.
@@ -588,17 +576,6 @@ func (s) TestErrorFromResolver(t *testing.T) {
 	}
 	if err := edsLB.waitForEDSResponse(ctx, xdsclient.EndpointsUpdate{}); err != nil {
 		t.Fatalf("EDS impl got unexpected EDS response: %v", err)
-	}
-
-	// An update with the same service name should trigger a new watch, because
-	// the previous watch was canceled.
-	if err := edsB.UpdateClientConnState(balancer.ClientConnState{
-		BalancerConfig: &EDSConfig{EDSServiceName: testServiceName},
-	}); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := xdsC.WaitForWatchEDS(ctx); err != nil {
-		t.Fatalf("xdsClient.WatchEndpoints failed with error: %v", err)
 	}
 }
 

--- a/xds/internal/balancer/edsbalancer/eds_test.go
+++ b/xds/internal/balancer/edsbalancer/eds_test.go
@@ -354,7 +354,6 @@ func (s) TestConfigChildPolicyUpdate(t *testing.T) {
 	if err := edsB.UpdateClientConnState(balancer.ClientConnState{
 		BalancerConfig: &EDSConfig{
 			ChildPolicy:    lbCfgA,
-			ClusterName:    testEDSClusterName,
 			EDSServiceName: testServiceName,
 		},
 	}); err != nil {
@@ -368,7 +367,7 @@ func (s) TestConfigChildPolicyUpdate(t *testing.T) {
 	if err := edsLB.waitForChildPolicy(ctx, lbCfgA); err != nil {
 		t.Fatal(err)
 	}
-	if err := edsLB.waitForCounterUpdate(ctx, testEDSClusterName); err != nil {
+	if err := edsLB.waitForCounterUpdate(ctx, testServiceName); err != nil {
 		t.Fatal(err)
 	}
 	if err := edsLB.waitForCountMaxUpdate(ctx, nil); err != nil {
@@ -383,7 +382,6 @@ func (s) TestConfigChildPolicyUpdate(t *testing.T) {
 	if err := edsB.UpdateClientConnState(balancer.ClientConnState{
 		BalancerConfig: &EDSConfig{
 			ChildPolicy:           lbCfgB,
-			ClusterName:           testEDSClusterName,
 			EDSServiceName:        testServiceName,
 			MaxConcurrentRequests: &testCountMax,
 		},
@@ -393,7 +391,7 @@ func (s) TestConfigChildPolicyUpdate(t *testing.T) {
 	if err := edsLB.waitForChildPolicy(ctx, lbCfgB); err != nil {
 		t.Fatal(err)
 	}
-	if err := edsLB.waitForCounterUpdate(ctx, testEDSClusterName); err != nil {
+	if err := edsLB.waitForCounterUpdate(ctx, testServiceName); err != nil {
 		// Counter is updated even though the service name didn't change. The
 		// eds_impl will compare the service names, and skip if it didn't change.
 		t.Fatal(err)
@@ -672,7 +670,7 @@ func (s) TestCounterUpdate(t *testing.T) {
 	// Update should trigger counter update with provided service name.
 	if err := edsB.UpdateClientConnState(balancer.ClientConnState{
 		BalancerConfig: &EDSConfig{
-			ClusterName:           "foobar-1",
+			EDSServiceName:        "foobar-1",
 			MaxConcurrentRequests: &testCountMax,
 		},
 	}); err != nil {

--- a/xds/internal/balancer/edsbalancer/load_store_wrapper.go
+++ b/xds/internal/balancer/edsbalancer/load_store_wrapper.go
@@ -1,0 +1,88 @@
+/*
+ *
+ * Copyright 2019 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package edsbalancer
+
+import (
+	"sync"
+
+	"google.golang.org/grpc/xds/internal/client/load"
+)
+
+type loadStoreWrapper struct {
+	mu      sync.RWMutex
+	service string
+	// Both store and perCluster will be nil if load reporting is disabled (EDS
+	// response doesn't have LRS server name). Note that methods on Store and
+	// perCluster all handle nil, so there's no need to check nil before calling
+	// them.
+	store      *load.Store
+	perCluster load.PerClusterReporter
+}
+
+func (lsw *loadStoreWrapper) updateServiceName(service string) {
+	lsw.mu.Lock()
+	defer lsw.mu.Unlock()
+	if lsw.service == service {
+		return
+	}
+	lsw.service = service
+	lsw.perCluster = lsw.store.PerCluster(lsw.service, "")
+}
+
+func (lsw *loadStoreWrapper) updateLoadStore(store *load.Store) {
+	lsw.mu.Lock()
+	defer lsw.mu.Unlock()
+	if store == lsw.store {
+		return
+	}
+	lsw.store = store
+	lsw.perCluster = lsw.store.PerCluster(lsw.service, "")
+}
+
+func (lsw *loadStoreWrapper) CallStarted(locality string) {
+	lsw.mu.RLock()
+	defer lsw.mu.RUnlock()
+	if lsw.perCluster != nil {
+		lsw.perCluster.CallStarted(locality)
+	}
+}
+
+func (lsw *loadStoreWrapper) CallFinished(locality string, err error) {
+	lsw.mu.RLock()
+	defer lsw.mu.RUnlock()
+	if lsw.perCluster != nil {
+		lsw.perCluster.CallFinished(locality, err)
+	}
+}
+
+func (lsw *loadStoreWrapper) CallServerLoad(locality, name string, val float64) {
+	lsw.mu.RLock()
+	defer lsw.mu.RUnlock()
+	if lsw.perCluster != nil {
+		lsw.perCluster.CallServerLoad(locality, name, val)
+	}
+}
+
+func (lsw *loadStoreWrapper) CallDropped(category string) {
+	lsw.mu.RLock()
+	defer lsw.mu.RUnlock()
+	if lsw.perCluster != nil {
+		lsw.perCluster.CallDropped(category)
+	}
+}

--- a/xds/internal/client/client.go
+++ b/xds/internal/client/client.go
@@ -375,23 +375,22 @@ const (
 // interest to the registered CDS watcher.
 type ClusterUpdate struct {
 	ClusterType ClusterType
-	// ClusterName is the clusterName being watched for through CDS.
-	ClusterName string
-	// EDSServiceName is an optional name for EDS. If it's not set, the balancer
-	// should watch ClusterName for the EDS resources.
-	EDSServiceName string
+	// ServiceName is the service name corresponding to the clusterName which
+	// is being watched for through CDS.
+	ServiceName string
 	// EnableLRS indicates whether or not load should be reported through LRS.
 	EnableLRS bool
 	// SecurityCfg contains security configuration sent by the control plane.
 	SecurityCfg *SecurityConfig
 	// MaxRequests for circuit breaking, if any (otherwise nil).
 	MaxRequests *uint32
-	// PrioritizedClusterNames is used only for cluster type aggregate. It represents
-	// a prioritized list of cluster names.
-	PrioritizedClusterNames []string
 
 	// Raw is the resource from the xds response.
 	Raw *anypb.Any
+
+	// PrioritizedClusterNames is used only for cluster type aggregate. It represents
+	// a prioritized list of cluster names.
+	PrioritizedClusterNames []string
 }
 
 // OverloadDropConfig contains the config to drop overloads.

--- a/xds/internal/client/client_test.go
+++ b/xds/internal/client/client_test.go
@@ -185,13 +185,13 @@ func (s) TestWatchCallAnotherWatch(t *testing.T) {
 		t.Fatalf("want new watch to start, got error %v", err)
 	}
 
-	wantUpdate := ClusterUpdate{ClusterName: testEDSName}
+	wantUpdate := ClusterUpdate{ServiceName: testEDSName}
 	client.NewClusters(map[string]ClusterUpdate{testCDSName: wantUpdate}, UpdateMetadata{})
 	if err := verifyClusterUpdate(ctx, clusterUpdateCh, wantUpdate); err != nil {
 		t.Fatal(err)
 	}
 
-	wantUpdate2 := ClusterUpdate{ClusterName: testEDSName + "2"}
+	wantUpdate2 := ClusterUpdate{ServiceName: testEDSName + "2"}
 	client.NewClusters(map[string]ClusterUpdate{testCDSName: wantUpdate2}, UpdateMetadata{})
 	if err := verifyClusterUpdate(ctx, clusterUpdateCh, wantUpdate2); err != nil {
 		t.Fatal(err)

--- a/xds/internal/client/v2/cds_test.go
+++ b/xds/internal/client/v2/cds_test.go
@@ -151,7 +151,7 @@ func (s) TestCDSHandleResponse(t *testing.T) {
 			cdsResponse: goodCDSResponse2,
 			wantErr:     false,
 			wantUpdate: map[string]xdsclient.ClusterUpdate{
-				goodClusterName2: {ClusterName: goodClusterName2, EDSServiceName: serviceName2, Raw: marshaledCluster2},
+				goodClusterName2: {ServiceName: serviceName2, Raw: marshaledCluster2},
 			},
 			wantUpdateMD: xdsclient.UpdateMetadata{
 				Status: xdsclient.ServiceStatusACKed,
@@ -164,7 +164,7 @@ func (s) TestCDSHandleResponse(t *testing.T) {
 			cdsResponse: goodCDSResponse1,
 			wantErr:     false,
 			wantUpdate: map[string]xdsclient.ClusterUpdate{
-				goodClusterName1: {ClusterName: goodClusterName1, EDSServiceName: serviceName1, EnableLRS: true, Raw: marshaledCluster1},
+				goodClusterName1: {ServiceName: serviceName1, EnableLRS: true, Raw: marshaledCluster1},
 			},
 			wantUpdateMD: xdsclient.UpdateMetadata{
 				Status: xdsclient.ServiceStatusACKed,

--- a/xds/internal/client/watchers_cluster_test.go
+++ b/xds/internal/client/watchers_cluster_test.go
@@ -64,7 +64,7 @@ func (s) TestClusterWatch(t *testing.T) {
 		t.Fatalf("want new watch to start, got error %v", err)
 	}
 
-	wantUpdate := ClusterUpdate{ClusterName: testEDSName}
+	wantUpdate := ClusterUpdate{ServiceName: testEDSName}
 	client.NewClusters(map[string]ClusterUpdate{testCDSName: wantUpdate}, UpdateMetadata{})
 	if err := verifyClusterUpdate(ctx, clusterUpdateCh, wantUpdate); err != nil {
 		t.Fatal(err)
@@ -128,7 +128,7 @@ func (s) TestClusterTwoWatchSameResourceName(t *testing.T) {
 		}
 	}
 
-	wantUpdate := ClusterUpdate{ClusterName: testEDSName}
+	wantUpdate := ClusterUpdate{ServiceName: testEDSName}
 	client.NewClusters(map[string]ClusterUpdate{testCDSName: wantUpdate}, UpdateMetadata{})
 	for i := 0; i < count; i++ {
 		if err := verifyClusterUpdate(ctx, clusterUpdateChs[i], wantUpdate); err != nil {
@@ -200,8 +200,8 @@ func (s) TestClusterThreeWatchDifferentResourceName(t *testing.T) {
 		t.Fatalf("want new watch to start, got error %v", err)
 	}
 
-	wantUpdate1 := ClusterUpdate{ClusterName: testEDSName + "1"}
-	wantUpdate2 := ClusterUpdate{ClusterName: testEDSName + "2"}
+	wantUpdate1 := ClusterUpdate{ServiceName: testEDSName + "1"}
+	wantUpdate2 := ClusterUpdate{ServiceName: testEDSName + "2"}
 	client.NewClusters(map[string]ClusterUpdate{
 		testCDSName + "1": wantUpdate1,
 		testCDSName + "2": wantUpdate2,
@@ -245,7 +245,7 @@ func (s) TestClusterWatchAfterCache(t *testing.T) {
 		t.Fatalf("want new watch to start, got error %v", err)
 	}
 
-	wantUpdate := ClusterUpdate{ClusterName: testEDSName}
+	wantUpdate := ClusterUpdate{ServiceName: testEDSName}
 	client.NewClusters(map[string]ClusterUpdate{
 		testCDSName: wantUpdate,
 	}, UpdateMetadata{})
@@ -345,7 +345,7 @@ func (s) TestClusterWatchExpiryTimerStop(t *testing.T) {
 		t.Fatalf("want new watch to start, got error %v", err)
 	}
 
-	wantUpdate := ClusterUpdate{ClusterName: testEDSName}
+	wantUpdate := ClusterUpdate{ServiceName: testEDSName}
 	client.NewClusters(map[string]ClusterUpdate{
 		testCDSName: wantUpdate,
 	}, UpdateMetadata{})
@@ -402,8 +402,8 @@ func (s) TestClusterResourceRemoved(t *testing.T) {
 		t.Fatalf("want new watch to start, got error %v", err)
 	}
 
-	wantUpdate1 := ClusterUpdate{ClusterName: testEDSName + "1"}
-	wantUpdate2 := ClusterUpdate{ClusterName: testEDSName + "2"}
+	wantUpdate1 := ClusterUpdate{ServiceName: testEDSName + "1"}
+	wantUpdate2 := ClusterUpdate{ServiceName: testEDSName + "2"}
 	client.NewClusters(map[string]ClusterUpdate{
 		testCDSName + "1": wantUpdate1,
 		testCDSName + "2": wantUpdate2,


### PR DESCRIPTION
This reverts PRs #4352 (and two follow up fixes #4372 #4378).
Because the xds interop tests were flaky.

Revert before the branch cut.