### PR TITLE
Revert "grpc: call balancer.Close() before returning from ccBalancerWrapper.close()"

### DIFF
--- a/balancer_conn_wrappers.go
+++ b/balancer_conn_wrappers.go
@@ -69,10 +69,10 @@ func (ccb *ccBalancerWrapper) watcher() {
 		select {
 		case t := <-ccb.scBuffer.Get():
 			ccb.scBuffer.Load()
-			ccb.balancerMu.Lock()
 			if ccb.done.HasFired() {
 				break
 			}
+			ccb.balancerMu.Lock()
 			su := t.(*scStateUpdate)
 			ccb.balancer.UpdateSubConnState(su.sc, balancer.SubConnState{ConnectivityState: su.state, ConnectionError: su.err})
 			ccb.balancerMu.Unlock()
@@ -80,6 +80,7 @@ func (ccb *ccBalancerWrapper) watcher() {
 		}
 
 		if ccb.done.HasFired() {
+			ccb.balancer.Close()
 			ccb.mu.Lock()
 			scs := ccb.subConns
 			ccb.subConns = nil
@@ -94,9 +95,6 @@ func (ccb *ccBalancerWrapper) watcher() {
 }
 
 func (ccb *ccBalancerWrapper) close() {
-	ccb.balancerMu.Lock()
-	defer ccb.balancerMu.Unlock()
-	ccb.balancer.Close()
 	ccb.done.Fire()
 }
 
@@ -121,19 +119,13 @@ func (ccb *ccBalancerWrapper) handleSubConnStateChange(sc balancer.SubConn, s co
 func (ccb *ccBalancerWrapper) updateClientConnState(ccs *balancer.ClientConnState) error {
 	ccb.balancerMu.Lock()
 	defer ccb.balancerMu.Unlock()
-	if ccb.done.HasFired() {
-		return nil
-	}
 	return ccb.balancer.UpdateClientConnState(*ccs)
 }
 
 func (ccb *ccBalancerWrapper) resolverError(err error) {
 	ccb.balancerMu.Lock()
-	defer ccb.balancerMu.Unlock()
-	if ccb.done.HasFired() {
-		return
-	}
 	ccb.balancer.ResolverError(err)
+	ccb.balancerMu.Unlock()
 }
 
 func (ccb *ccBalancerWrapper) NewSubConn(addrs []resolver.Address, opts balancer.NewSubConnOptions) (balancer.SubConn, error) {


### PR DESCRIPTION
Reverts grpc/grpc-go#4364

The reverted PR moved `balancer.Close()` to `balancer_wrapper.close()`, which can cause a deadlock if `balancer.Close()` also `RemoveSubConn()`.

The failure was caught by xds interop tests, when the `xds_resolver` sends an empty service config, causing switching balancer (from `cluster_manager` to `pick_first`):

```go
cc_resolver_wrapper.UpdateState()
cc.updateResolverState()
cc.mu.Lock() // this hold cc.mu
cc.applyServiceConfigAndBalancer()
cc.switchBalancer() // this is to switch to pick_first
cc.balancerWrapper.close() // this is to close cluster_manager
ccb.balancerMu.Lock() // _this is not important_
clusterManager.Close()
balancergroup.Close()
bg.incomingMu.Lock() // _this is not important_
bg.cc.RemoveSubConn()
ccBalancerWrapper.RemoveSubConn()
ccb.mu.Lock // _this is not important_
ccb.cc.removeAddrConn()
cc.mu.Lock() // this is trying to take cc.mu again, causing a deadlock
```

http://docs/document/d/1sojOLUvfLBouPcZUoQpHvXZCrElVgdeqobRKNazi6vU