### PR TITLE
client: initialize safe config selector when creating ClientConn

### DIFF
--- a/clientconn.go
+++ b/clientconn.go
@@ -143,6 +143,7 @@ func DialContext(ctx context.Context, target string, opts ...DialOption) (conn *
 		firstResolveEvent: grpcsync.NewEvent(),
 	}
 	cc.retryThrottler.Store((*retryThrottler)(nil))
+	cc.safeConfigSelector.UpdateConfigSelector(&defaultConfigSelector{nil})
 	cc.ctx, cc.cancel = context.WithCancel(context.Background())
 
 	for _, opt := range opts {


### PR DESCRIPTION
Fixes #4343 

I have identified a race that can happen during initialization time:
1. ClientConn created
2. Stream is created
3. Resolver calls into the ClientConn
4. During a small window of time here, if the ClientConn is closed, no config selector will be applied due to https://github.com/grpc/grpc-go/blob/c7ea734087dbbcdb22137ab3b7d8b16842b080bf/clientconn.go#L607-L616
   This will perform the `defer cc.firstResolveEvent.Fire()` a few lines up.
5. The stream from step 2 is blocked at https://github.com/grpc/grpc-go/blob/c7ea734087dbbcdb22137ab3b7d8b16842b080bf/stream.go#L171
6. If the `firstResolveEvent` case of https://github.com/grpc/grpc-go/blob/c7ea734087dbbcdb22137ab3b7d8b16842b080bf/clientconn.go#L575-L582
   wins over the `cc.ctx.Done()` case, `nil` will be returned and `cc.safeConfigSelector` will be queried.  But since it has never been set, it will panic.

There are several options here:
1. Don't fire `firstResolveEvent` if `cc` is already closed (move the `defer` down a few lines).
   - This seems a little dubious to me since there actually _was_ a resolve event.
2. Fix the race in step 6 and double-check `cc.ctx.Err()` before returning if `firstResolveEvent` wins.
   - This would impact every RPC for a very rare race at startup time.
3. Set the `safeConfigSelector` to some default before returning in step 4.
   - This seems pretty reasonable.
4. Ensure `safeConfigSelector` is set on every path out of `updateResolverState`.
   - This is possible to do through inspection (I did this initially but ignored this path, not noticing the race above), though it is tedious and new paths could be introduced that forget to set it.  We could do this via a `defer`, but this is not as nice as it sounds, as there are currently two other paths out that don't update the config selector because we are certain there already is one.  Without a major refactor, I don't think this can fit in well with the way the code currently works.
5. Always initialize `safeConfigSelector`
   - This seems best, as it means we don't have to be paranoid about `safeConfigSelector` being set after every call to `updateResolverState`.  It is very low risk, and very simple.  Even using a `defer` for option 4 doesn't prevent other kinds of bugs, like setting the config selector to the wrong value.

This PR is option 5.
