### PR TITLE
example: correct the default value for server_host_override

### DIFF
--- a/examples/features/encryption/README.md
+++ b/examples/features/encryption/README.md
@@ -42,8 +42,8 @@ configure TLS and create the server credential using
 On client side, we provide the path to the "ca_cert.pem" to configure TLS and create
 the client credential using
 [`credentials.NewClientTLSFromFile`](https://godoc.org/google.golang.org/grpc/credentials#NewClientTLSFromFile).
-Note that we override the server name with "x.test.youtube.com", as the server
-certificate is valid for *.test.youtube.com but not localhost. It is solely for
+Note that we override the server name with "x.test.example.com", as the server
+certificate is valid for *.test.example.com but not localhost. It is solely for
 the convenience of making an example.
 
 Once the credentials have been created at both sides, we can start the server

--- a/examples/route_guide/client/client.go
+++ b/examples/route_guide/client/client.go
@@ -40,7 +40,7 @@ var (
 	tls                = flag.Bool("tls", false, "Connection uses TLS if true, else plain TCP")
 	caFile             = flag.String("ca_file", "", "The file containing the CA root cert file")
 	serverAddr         = flag.String("server_addr", "localhost:10000", "The server address in the format of host:port")
-	serverHostOverride = flag.String("server_host_override", "x.test.youtube.com", "The server name used to verify the hostname returned by the TLS handshake")
+	serverHostOverride = flag.String("server_host_override", "x.test.example.com", "The server name used to verify the hostname returned by the TLS handshake")
 )
 
 // printFeature gets the feature for the given point.


### PR DESCRIPTION
Fixes: #4396

The SAN of the test certificate is changed from `*.test.youtube.com` to `*.test.example.com` in #3786, most of the parts are updated accordingly, but a few places are omitted.