### PR TITLE
xds/cds: fix LOGICAL_DNS cluster semantics

### DIFF
--- a/xds/internal/client/cds_test.go
+++ b/xds/internal/client/cds_test.go
@@ -131,7 +131,7 @@ func (s) TestValidateCluster_Failure(t *testing.T) {
 				LbPolicy:             v3clusterpb.Cluster_ROUND_ROBIN,
 				LoadAssignment: &v3endpointpb.ClusterLoadAssignment{
 					Endpoints: []*v3endpointpb.LocalityLbEndpoints{
-						// Invalid if there are more than localities.
+						// Invalid if there are more than one locality.
 						{LbEndpoints: nil},
 						{LbEndpoints: nil},
 					},

--- a/xds/internal/client/client.go
+++ b/xds/internal/client/client.go
@@ -389,6 +389,9 @@ type ClusterUpdate struct {
 	SecurityCfg *SecurityConfig
 	// MaxRequests for circuit breaking, if any (otherwise nil).
 	MaxRequests *uint32
+	// DNSHostName is used only for cluster type DNS. It's the DNS name to
+	// resolve in "host:port" form
+	DNSHostName string
 	// PrioritizedClusterNames is used only for cluster type aggregate. It represents
 	// a prioritized list of cluster names.
 	PrioritizedClusterNames []string

--- a/xds/internal/client/xds.go
+++ b/xds/internal/client/xds.go
@@ -616,6 +616,37 @@ func validateClusterAndConstructClusterUpdate(cluster *v3clusterpb.Cluster) (Clu
 		return ret, nil
 	case cluster.GetType() == v3clusterpb.Cluster_LOGICAL_DNS:
 		ret.ClusterType = ClusterTypeLogicalDNS
+		loadAssignment := cluster.GetLoadAssignment()
+		if loadAssignment == nil {
+			return ClusterUpdate{}, fmt.Errorf("load_assignment not present for LOGICAL_DNS cluster")
+		}
+		if len(loadAssignment.GetEndpoints()) != 1 {
+			return ClusterUpdate{}, fmt.Errorf("load_assignment for LOGICAL_DNS cluster must have exactly one locality, got: %+v", loadAssignment)
+		}
+		endpoints := loadAssignment.GetEndpoints()[0].GetLbEndpoints()
+		if len(endpoints) != 1 {
+			return ClusterUpdate{}, fmt.Errorf("locality for LOGICAL_DNS cluster must have exactly one endpoint, got: %+v", endpoints)
+		}
+		endpoint := endpoints[0].GetEndpoint()
+		if endpoint == nil {
+			return ClusterUpdate{}, fmt.Errorf("endpoint for LOGICAL_DNS cluster not set")
+		}
+		socketAddr := endpoint.GetAddress().GetSocketAddress()
+		if socketAddr == nil {
+			return ClusterUpdate{}, fmt.Errorf("socket address for endpoint for LOGICAL_DNS cluster not set")
+		}
+		if socketAddr.GetResolverName() != "" {
+			return ClusterUpdate{}, fmt.Errorf("socket address for endpoint for LOGICAL_DNS cluster not set has unexpected custom resolver name: %v", socketAddr.GetResolverName())
+		}
+		host := socketAddr.GetAddress()
+		if host == "" {
+			return ClusterUpdate{}, fmt.Errorf("host for endpoint for LOGICAL_DNS cluster not set")
+		}
+		port := socketAddr.GetPortValue()
+		if port == 0 {
+			return ClusterUpdate{}, fmt.Errorf("port for endpoint for LOGICAL_DNS cluster not set")
+		}
+		ret.DNSHostName = net.JoinHostPort(host, strconv.Itoa(int(port)))
 		return ret, nil
 	case cluster.GetClusterType() != nil && cluster.GetClusterType().Name == "envoy.clusters.aggregate":
 		clusters := &v3aggregateclusterpb.ClusterConfig{}

--- a/xds/internal/client/xds.go
+++ b/xds/internal/client/xds.go
@@ -616,37 +616,11 @@ func validateClusterAndConstructClusterUpdate(cluster *v3clusterpb.Cluster) (Clu
 		return ret, nil
 	case cluster.GetType() == v3clusterpb.Cluster_LOGICAL_DNS:
 		ret.ClusterType = ClusterTypeLogicalDNS
-		loadAssignment := cluster.GetLoadAssignment()
-		if loadAssignment == nil {
-			return ClusterUpdate{}, fmt.Errorf("load_assignment not present for LOGICAL_DNS cluster")
+		dnsHN, err := dnsHostNameFromCluster(cluster)
+		if err != nil {
+			return ClusterUpdate{}, err
 		}
-		if len(loadAssignment.GetEndpoints()) != 1 {
-			return ClusterUpdate{}, fmt.Errorf("load_assignment for LOGICAL_DNS cluster must have exactly one locality, got: %+v", loadAssignment)
-		}
-		endpoints := loadAssignment.GetEndpoints()[0].GetLbEndpoints()
-		if len(endpoints) != 1 {
-			return ClusterUpdate{}, fmt.Errorf("locality for LOGICAL_DNS cluster must have exactly one endpoint, got: %+v", endpoints)
-		}
-		endpoint := endpoints[0].GetEndpoint()
-		if endpoint == nil {
-			return ClusterUpdate{}, fmt.Errorf("endpoint for LOGICAL_DNS cluster not set")
-		}
-		socketAddr := endpoint.GetAddress().GetSocketAddress()
-		if socketAddr == nil {
-			return ClusterUpdate{}, fmt.Errorf("socket address for endpoint for LOGICAL_DNS cluster not set")
-		}
-		if socketAddr.GetResolverName() != "" {
-			return ClusterUpdate{}, fmt.Errorf("socket address for endpoint for LOGICAL_DNS cluster not set has unexpected custom resolver name: %v", socketAddr.GetResolverName())
-		}
-		host := socketAddr.GetAddress()
-		if host == "" {
-			return ClusterUpdate{}, fmt.Errorf("host for endpoint for LOGICAL_DNS cluster not set")
-		}
-		port := socketAddr.GetPortValue()
-		if port == 0 {
-			return ClusterUpdate{}, fmt.Errorf("port for endpoint for LOGICAL_DNS cluster not set")
-		}
-		ret.DNSHostName = net.JoinHostPort(host, strconv.Itoa(int(port)))
+		ret.DNSHostName = dnsHN
 		return ret, nil
 	case cluster.GetClusterType() != nil && cluster.GetClusterType().Name == "envoy.clusters.aggregate":
 		clusters := &v3aggregateclusterpb.ClusterConfig{}
@@ -659,6 +633,45 @@ func validateClusterAndConstructClusterUpdate(cluster *v3clusterpb.Cluster) (Clu
 	default:
 		return ClusterUpdate{}, fmt.Errorf("unexpected cluster type (%v, %v) in response: %+v", cluster.GetType(), cluster.GetClusterType(), cluster)
 	}
+}
+
+// dnsHostNameFromCluster extracts the DNS host name from the cluster's load
+// assignment.
+//
+// There should be exactly one locality, with one endpoint, whose address
+// contains the address and port.
+func dnsHostNameFromCluster(cluster *v3clusterpb.Cluster) (string, error) {
+	loadAssignment := cluster.GetLoadAssignment()
+	if loadAssignment == nil {
+		return "", fmt.Errorf("load_assignment not present for LOGICAL_DNS cluster")
+	}
+	if len(loadAssignment.GetEndpoints()) != 1 {
+		return "", fmt.Errorf("load_assignment for LOGICAL_DNS cluster must have exactly one locality, got: %+v", loadAssignment)
+	}
+	endpoints := loadAssignment.GetEndpoints()[0].GetLbEndpoints()
+	if len(endpoints) != 1 {
+		return "", fmt.Errorf("locality for LOGICAL_DNS cluster must have exactly one endpoint, got: %+v", endpoints)
+	}
+	endpoint := endpoints[0].GetEndpoint()
+	if endpoint == nil {
+		return "", fmt.Errorf("endpoint for LOGICAL_DNS cluster not set")
+	}
+	socketAddr := endpoint.GetAddress().GetSocketAddress()
+	if socketAddr == nil {
+		return "", fmt.Errorf("socket address for endpoint for LOGICAL_DNS cluster not set")
+	}
+	if socketAddr.GetResolverName() != "" {
+		return "", fmt.Errorf("socket address for endpoint for LOGICAL_DNS cluster not set has unexpected custom resolver name: %v", socketAddr.GetResolverName())
+	}
+	host := socketAddr.GetAddress()
+	if host == "" {
+		return "", fmt.Errorf("host for endpoint for LOGICAL_DNS cluster not set")
+	}
+	port := socketAddr.GetPortValue()
+	if port == 0 {
+		return "", fmt.Errorf("port for endpoint for LOGICAL_DNS cluster not set")
+	}
+	return net.JoinHostPort(host, strconv.Itoa(int(port))), nil
 }
 
 // securityConfigFromCluster extracts the relevant security configuration from


### PR DESCRIPTION
The dns host name to be resolved is encoded in the CDS response's load assignments.
This change adds a field in CDS update for it.

https://github.com/grpc/proposal/pull/236
https://github.com/grpc/grpc/pull/26147