### PR TITLE
transport: unblock read throttling when controlbuf exits

### DIFF
--- a/internal/transport/controlbuf.go
+++ b/internal/transport/controlbuf.go
@@ -433,11 +433,11 @@ func (c *controlBuffer) finish() {
 	// In case throttle() is currently in flight, it needs to be unblocked.
 	// Otherwise, the transport may not close, since the transport is closed by
 	// the reader encountering the connection error.
-	ch, _ := c.trfChan.Load().(*chan struct{})
+	ch, _ := c.trfChan.Load().(chan struct{})
 	if ch != nil {
-		close(*ch)
+		close(ch)
 	}
-	c.trfChan.Store((*chan struct{})(nil))
+	c.trfChan.Store((chan struct{})(nil))
 	c.mu.Unlock()
 }
 

--- a/internal/transport/controlbuf.go
+++ b/internal/transport/controlbuf.go
@@ -406,7 +406,6 @@ func (c *controlBuffer) get(block bool) (interface{}, error) {
 		select {
 		case <-c.ch:
 		case <-c.done:
-			c.finish()
 			return nil, ErrConnClosing
 		}
 	}
@@ -431,6 +430,14 @@ func (c *controlBuffer) finish() {
 			hdr.onOrphaned(ErrConnClosing)
 		}
 	}
+	// In case throttle() is currently in flight, it needs to be unblocked.
+	// Otherwise, the transport may not close, since the transport is closed by
+	// the reader encountering the connection error.
+	ch, _ := c.trfChan.Load().(*chan struct{})
+	if ch != nil {
+		close(*ch)
+	}
+	c.trfChan.Store((*chan struct{})(nil))
 	c.mu.Unlock()
 }
 

--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -402,6 +402,7 @@ func newHTTP2Client(connectCtx, ctx context.Context, addr resolver.Address, opts
 		// Do not close the transport.  Let reader goroutine handle it since
 		// there might be data in the buffers.
 		t.conn.Close()
+		t.controlBuf.finish()
 		close(t.writerDone)
 	}()
 	return t, nil

--- a/internal/transport/http2_server.go
+++ b/internal/transport/http2_server.go
@@ -295,6 +295,7 @@ func newHTTP2Server(conn net.Conn, config *ServerConfig) (_ ServerTransport, err
 			}
 		}
 		t.conn.Close()
+		t.controlBuf.finish()
 		close(t.writerDone)
 	}()
 	go t.keepalive()


### PR DESCRIPTION
If the transport reader is blocked due to throttling caused by a backlog of pending transport response frames, it is possible it could never unblock in the event the `loopyWriter` encounters an error and exits.  This PR fixes that race and adds a test.

Also, now that we are calling `finish` when `run` returns, we don't need to call `finish()` in `get` in one random specific case.
