### PR TITLE
use depth logging from the e2e package

### DIFF
--- a/xds/internal/test/xds_server_serving_mode_test.go
+++ b/xds/internal/test/xds_server_serving_mode_test.go
@@ -182,8 +182,8 @@ func (s) TestServerSideXDS_ServingModeChanges(t *testing.T) {
 		t.Fatalf("rpc EmptyCall() failed: %v", err)
 	}
 
-	// Update the management server to remove the second listener resource. This should
-	// push the only the second listener into "not-serving" mode.
+	// Update the management server to remove the second listener resource. This
+	// should push the only the second listener into "not-serving" mode.
 	if err := managementServer.Update(e2e.UpdateOptions{
 		NodeID:    xdsClientNodeID,
 		Listeners: []*v3listenerpb.Listener{listener1},
@@ -240,8 +240,7 @@ func (s) TestServerSideXDS_ServingModeChanges(t *testing.T) {
 	// short timeout since we expect this to fail.
 	sCtx, sCancel := context.WithTimeout(ctx, defaultTestShortTimeout)
 	defer sCancel()
-	_, err = grpc.DialContext(sCtx, lis1.Addr().String(), grpc.WithBlock(), grpc.WithTransportCredentials(insecure.NewCredentials()))
-	if err == nil {
+	if _, err := grpc.DialContext(sCtx, lis1.Addr().String(), grpc.WithBlock(), grpc.WithTransportCredentials(insecure.NewCredentials())); err == nil {
 		t.Fatal("successfully created clientConn to a server in \"not-serving\" state")
 	}
 

--- a/xds/internal/test/xds_server_serving_mode_test.go
+++ b/xds/internal/test/xds_server_serving_mode_test.go
@@ -183,7 +183,7 @@ func (s) TestServerSideXDS_ServingModeChanges(t *testing.T) {
 	}
 
 	// Update the management server to remove the second listener resource. This
-	// should push the only the second listener into "not-serving" mode.
+	// should push only the second listener into "not-serving" mode.
 	if err := managementServer.Update(e2e.UpdateOptions{
 		NodeID:    xdsClientNodeID,
 		Listeners: []*v3listenerpb.Listener{listener1},

--- a/xds/internal/testutils/e2e/server.go
+++ b/xds/internal/testutils/e2e/server.go
@@ -45,10 +45,22 @@ var logger = grpclog.Component("xds-e2e")
 // envoyproxy/go-control-plane/pkg/log. This is passed to the Snapshot cache.
 type serverLogger struct{}
 
-func (l serverLogger) Debugf(format string, args ...interface{}) { logger.Infof(format, args...) }
-func (l serverLogger) Infof(format string, args ...interface{})  { logger.Infof(format, args...) }
-func (l serverLogger) Warnf(format string, args ...interface{})  { logger.Warningf(format, args...) }
-func (l serverLogger) Errorf(format string, args ...interface{}) { logger.Errorf(format, args...) }
+func (l serverLogger) Debugf(format string, args ...interface{}) {
+	msg := fmt.Sprintf(format, args...)
+	logger.InfoDepth(1, msg)
+}
+func (l serverLogger) Infof(format string, args ...interface{}) {
+	msg := fmt.Sprintf(format, args...)
+	logger.InfoDepth(1, msg)
+}
+func (l serverLogger) Warnf(format string, args ...interface{}) {
+	msg := fmt.Sprintf(format, args...)
+	logger.WarningDepth(1, msg)
+}
+func (l serverLogger) Errorf(format string, args ...interface{}) {
+	msg := fmt.Sprintf(format, args...)
+	logger.ErrorDepth(1, msg)
+}
 
 // ManagementServer is a thin wrapper around the xDS control plane
 // implementation provided by envoyproxy/go-control-plane.


### PR DESCRIPTION
- Using depth logging will ensure that the actual file generating the log line will be printed instead of simply `server.go`.
- Couple of other minor cleanups.

Addresses https://github.com/grpc/grpc-go/issues/4403.