### PR TITLE
internal: fix test unset env var AggregateAndDNSSupportEnv

### DIFF
--- a/xds/internal/client/cds_test.go
+++ b/xds/internal/client/cds_test.go
@@ -126,7 +126,7 @@ func (s) TestValidateCluster_Failure(t *testing.T) {
 
 	oldAggregateAndDNSSupportEnv := env.AggregateAndDNSSupportEnv
 	env.AggregateAndDNSSupportEnv = true
-	defer func() { env.CircuitBreakingSupport = oldAggregateAndDNSSupportEnv }()
+	defer func() { env.AggregateAndDNSSupportEnv = oldAggregateAndDNSSupportEnv }()
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			if update, err := validateClusterAndConstructClusterUpdate(test.cluster); err == nil {
@@ -266,7 +266,7 @@ func (s) TestValidateCluster_Success(t *testing.T) {
 	defer func() { env.CircuitBreakingSupport = origCircuitBreakingSupport }()
 	oldAggregateAndDNSSupportEnv := env.AggregateAndDNSSupportEnv
 	env.AggregateAndDNSSupportEnv = true
-	defer func() { env.CircuitBreakingSupport = oldAggregateAndDNSSupportEnv }()
+	defer func() { env.AggregateAndDNSSupportEnv = oldAggregateAndDNSSupportEnv }()
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			update, err := validateClusterAndConstructClusterUpdate(test.cluster)


### PR DESCRIPTION
Found when backporting to v1.38.x