### PR TITLE
internal/transport: skip log on EOF when reading client preface

### DIFF
--- a/call_test.go
+++ b/call_test.go
@@ -160,7 +160,7 @@ func (s *server) start(t *testing.T, port int, maxStreams uint32) {
 		config := &transport.ServerConfig{
 			MaxStreams: maxStreams,
 		}
-		st, err := transport.NewServerTransport("http2", conn, config)
+		st, err := transport.NewServerTransport(conn, config)
 		if err != nil {
 			continue
 		}

--- a/internal/transport/http2_server.go
+++ b/internal/transport/http2_server.go
@@ -125,9 +125,14 @@ type http2Server struct {
 	connectionID uint64
 }
 
-// newHTTP2Server constructs a ServerTransport based on HTTP2. ConnectionError is
-// returned if something goes wrong.
-func newHTTP2Server(conn net.Conn, config *ServerConfig) (_ ServerTransport, err error) {
+// NewServerTransport creates a http2 transport with conn and configuration
+// options from config.
+//
+// It returns a non-nil transport and a nil error on success. On failure, it
+// returns a non-nil transport and a nil-error. For a special case where the
+// underlying conn gets closed before the client preface could be read, it
+// returns a nil transport and a nil error.
+func NewServerTransport(conn net.Conn, config *ServerConfig) (_ ServerTransport, err error) {
 	writeBufSize := config.WriteBufferSize
 	readBufSize := config.ReadBufferSize
 	maxHeaderListSize := defaultServerMaxHeaderListSize

--- a/internal/transport/transport.go
+++ b/internal/transport/transport.go
@@ -532,12 +532,6 @@ type ServerConfig struct {
 	HeaderTableSize       *uint32
 }
 
-// NewServerTransport creates a ServerTransport with conn or non-nil error
-// if it fails.
-func NewServerTransport(protocol string, conn net.Conn, config *ServerConfig) (ServerTransport, error) {
-	return newHTTP2Server(conn, config)
-}
-
 // ConnectOptions covers all relevant options for communicating with the server.
 type ConnectOptions struct {
 	// UserAgent is the application user agent.

--- a/internal/transport/transport_test.go
+++ b/internal/transport/transport_test.go
@@ -323,7 +323,7 @@ func (s *server) start(t *testing.T, port int, serverConfig *ServerConfig, ht hT
 		if err != nil {
 			return
 		}
-		transport, err := NewServerTransport("http2", conn, serverConfig)
+		transport, err := NewServerTransport(conn, serverConfig)
 		if err != nil {
 			return
 		}

--- a/server.go
+++ b/server.go
@@ -897,7 +897,7 @@ func (s *Server) newHTTP2Transport(c net.Conn, authInfo credentials.AuthInfo) tr
 		MaxHeaderListSize:     s.opts.maxHeaderListSize,
 		HeaderTableSize:       s.opts.headerTableSize,
 	}
-	st, err := transport.NewServerTransport("http2", c, config)
+	st, err := transport.NewServerTransport(c, config)
 	if err != nil {
 		s.mu.Lock()
 		s.errorf("NewServerTransport(%q) failed: %v", c.RemoteAddr(), err)


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc-go/issues/4234.

RELEASE NOTES: N/A