### PR TITLE
example: improve hello world server with starting msg

### DIFF
--- a/examples/helloworld/greeter_server/main.go
+++ b/examples/helloworld/greeter_server/main.go
@@ -50,6 +50,7 @@ func main() {
 	}
 	s := grpc.NewServer()
 	pb.RegisterGreeterServer(s, &server{})
+	log.Printf("server listening at %v", lis.Addr())
 	if err := s.Serve(lis); err != nil {
 		log.Fatalf("failed to serve: %v", err)
 	}


### PR DESCRIPTION
Same as the other examples in `examples/features`, it is preferable to display the server starting message. When I ran the hello world server, I got the impression that the server was stuck on network connection or initialization.

RELEASE NOTES:
* examples: print message when hello world server starts