### PR TITLE
xds: add test-only injection of xds config to client and server

### DIFF
--- a/internal/xds/bootstrap.go
+++ b/internal/xds/bootstrap.go
@@ -65,11 +65,32 @@ type BootstrapOptions struct {
 // completed successfully. It is the responsibility of the caller to invoke the
 // cleanup function at the end of the test.
 func SetupBootstrapFile(opts BootstrapOptions) (func(), error) {
+	bootstrapContents, err := BootstrapContents(opts)
+	if err != nil {
+		return nil, err
+	}
 	f, err := ioutil.TempFile("", "test_xds_bootstrap_*")
 	if err != nil {
 		return nil, fmt.Errorf("failed to created bootstrap file: %v", err)
 	}
 
+	if err := ioutil.WriteFile(f.Name(), bootstrapContents, 0644); err != nil {
+		return nil, fmt.Errorf("failed to created bootstrap file: %v", err)
+	}
+	logger.Infof("Created bootstrap file at %q with contents: %s\n", f.Name(), bootstrapContents)
+
+	origBootstrapFileName := env.BootstrapFileName
+	env.BootstrapFileName = f.Name()
+	return func() {
+		os.Remove(f.Name())
+		env.BootstrapFileName = origBootstrapFileName
+	}, nil
+}
+
+// BootstrapContents returns the contents to go into a bootstrap file,
+// environment, or configuration passed to
+// xds.NewXDSResolverWithConfigForTesting.
+func BootstrapContents(opts BootstrapOptions) ([]byte, error) {
 	cfg := &bootstrapConfig{
 		XdsServers: []server{
 			{
@@ -100,17 +121,7 @@ func SetupBootstrapFile(opts BootstrapOptions) (func(), error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to created bootstrap file: %v", err)
 	}
-	if err := ioutil.WriteFile(f.Name(), bootstrapContents, 0644); err != nil {
-		return nil, fmt.Errorf("failed to created bootstrap file: %v", err)
-	}
-	logger.Infof("Created bootstrap file at %q with contents: %s\n", f.Name(), bootstrapContents)
-
-	origBootstrapFileName := env.BootstrapFileName
-	env.BootstrapFileName = f.Name()
-	return func() {
-		os.Remove(f.Name())
-		env.BootstrapFileName = origBootstrapFileName
-	}, nil
+	return bootstrapContents, nil
 }
 
 type bootstrapConfig struct {

--- a/xds/internal/balancer/cdsbalancer/cdsbalancer.go
+++ b/xds/internal/balancer/cdsbalancer/cdsbalancer.go
@@ -363,6 +363,9 @@ func (b *cdsBalancer) handleWatchUpdate(update *watchUpdate) {
 
 	}
 	resolverState := resolver.State{}
+	// Include the xds client for the child LB policies to use.  For unit
+	// tests, b.xdsClient may not be a full *xdsclient.Client, but it will
+	// always be in production.
 	if c, ok := b.xdsClient.(*xdsclient.Client); ok {
 		resolverState = xdsclient.SetClient(resolverState, c)
 	}

--- a/xds/internal/balancer/edsbalancer/eds.go
+++ b/xds/internal/balancer/edsbalancer/eds.go
@@ -53,7 +53,7 @@ var (
 	newEDSBalancer = func(cc balancer.ClientConn, opts balancer.BuildOptions, enqueueState func(priorityType, balancer.State), lw load.PerClusterReporter, logger *grpclog.PrefixLogger) edsBalancerImplInterface {
 		return newEDSBalancerImpl(cc, opts, enqueueState, lw, logger)
 	}
-	newXDSClient = func() (xdsClientInterface, error) { return xdsclient.New() }
+	newXDSClient func() (xdsClientInterface, error)
 )
 
 func init() {
@@ -76,13 +76,16 @@ func (b *edsBalancerBuilder) Build(cc balancer.ClientConn, opts balancer.BuildOp
 	}
 	x.logger = prefixLogger(x)
 
-	client, err := newXDSClient()
-	if err != nil {
-		x.logger.Errorf("xds: failed to create xds-client: %v", err)
-		return nil
+	if newXDSClient != nil {
+		// For tests
+		client, err := newXDSClient()
+		if err != nil {
+			x.logger.Errorf("xds: failed to create xds-client: %v", err)
+			return nil
+		}
+		x.xdsClient = client
 	}
 
-	x.xdsClient = client
 	x.edsImpl = newEDSBalancer(x.cc, opts, x.enqueueChildBalancerState, x.loadWrapper, x.logger)
 	x.logger.Infof("Created")
 	go x.run()
@@ -172,7 +175,9 @@ func (x *edsBalancer) run() {
 			x.edsImpl.updateState(u.priority, u.s)
 		case <-x.closed.Done():
 			x.cancelWatch()
-			x.xdsClient.Close()
+			if newXDSClient != nil {
+				x.xdsClient.Close()
+			}
 			x.edsImpl.close()
 			x.logger.Infof("Shutdown")
 			x.done.Fire()
@@ -380,6 +385,14 @@ func (x *edsBalancer) ResolverError(err error) {
 }
 
 func (x *edsBalancer) UpdateClientConnState(s balancer.ClientConnState) error {
+	if x.xdsClient == nil {
+		c := xdsclient.FromResolverState(s.ResolverState)
+		if c == nil {
+			return balancer.ErrBadResolverState
+		}
+		x.xdsClient = c
+	}
+
 	select {
 	case x.grpcUpdate <- &s:
 	case <-x.closed.Done():

--- a/xds/internal/balancer/lrs/balancer.go
+++ b/xds/internal/balancer/lrs/balancer.go
@@ -36,7 +36,7 @@ func init() {
 	balancer.Register(&lrsBB{})
 }
 
-var newXDSClient = func() (xdsClientInterface, error) { return xdsclient.New() }
+var newXDSClient func() (xdsClientInterface, error)
 
 // Name is the name of the LRS balancer.
 const Name = "lrs_experimental"
@@ -51,12 +51,15 @@ func (l *lrsBB) Build(cc balancer.ClientConn, opts balancer.BuildOptions) balanc
 	b.logger = prefixLogger(b)
 	b.logger.Infof("Created")
 
-	client, err := newXDSClient()
-	if err != nil {
-		b.logger.Errorf("failed to create xds-client: %v", err)
-		return nil
+	if newXDSClient != nil {
+		// For tests
+		client, err := newXDSClient()
+		if err != nil {
+			b.logger.Errorf("failed to create xds-client: %v", err)
+			return nil
+		}
+		b.client = newXDSClientWrapper(client)
 	}
-	b.client = newXDSClientWrapper(client)
 
 	return b
 }
@@ -85,6 +88,14 @@ func (b *lrsBalancer) UpdateClientConnState(s balancer.ClientConnState) error {
 	newConfig, ok := s.BalancerConfig.(*LBConfig)
 	if !ok {
 		return fmt.Errorf("unexpected balancer config with type: %T", s.BalancerConfig)
+	}
+
+	if b.client == nil {
+		c := xdsclient.FromResolverState(s.ResolverState)
+		if c == nil {
+			return balancer.ErrBadResolverState
+		}
+		b.client = newXDSClientWrapper(c)
 	}
 
 	// Update load reporting config or xds client. This needs to be done before
@@ -245,5 +256,7 @@ func (w *xdsClientWrapper) close() {
 		w.cancelLoadReport()
 		w.cancelLoadReport = nil
 	}
-	w.c.Close()
+	if newXDSClient != nil {
+		w.c.Close()
+	}
 }

--- a/xds/internal/client/attributes.go
+++ b/xds/internal/client/attributes.go
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2021 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package client
+
+import "google.golang.org/grpc/resolver"
+
+type clientKeyType string
+
+const clientKey = clientKeyType("grpc.xds.internal.client.Client")
+
+// FromResolverState returns the Client from state, or nil if not present.
+func FromResolverState(state resolver.State) *Client {
+	cs, _ := state.Attributes.Value(clientKey).(*Client)
+	return cs
+}
+
+// SetClient sets c in state and returns the new state.
+func SetClient(state resolver.State, c *Client) resolver.State {
+	state.Attributes = state.Attributes.WithValues(clientKey, c)
+	return state
+}

--- a/xds/internal/client/bootstrap/bootstrap.go
+++ b/xds/internal/client/bootstrap/bootstrap.go
@@ -160,13 +160,19 @@ func bootstrapConfigFromEnvVariable() ([]byte, error) {
 // fields left unspecified, in which case the caller should use some sane
 // defaults.
 func NewConfig() (*Config, error) {
-	config := &Config{}
-
 	data, err := bootstrapConfigFromEnvVariable()
 	if err != nil {
 		return nil, fmt.Errorf("xds: Failed to read bootstrap config: %v", err)
 	}
 	logger.Debugf("Bootstrap content: %s", data)
+	return NewConfigFromContents(data)
+}
+
+// NewConfigFromContents returns a new Config using the specified bootstrap
+// file contents instead of reading the environment variable.  This is only
+// suitable for testing purposes.
+func NewConfigFromContents(data []byte) (*Config, error) {
+	config := &Config{}
 
 	var jsonData map[string]json.RawMessage
 	if err := json.Unmarshal(data, &jsonData); err != nil {

--- a/xds/internal/resolver/xds_resolver.go
+++ b/xds/internal/resolver/xds_resolver.go
@@ -36,6 +36,17 @@ import (
 
 const xdsScheme = "xds"
 
+// NewBuilder creates a new xds resolver builder using a specific xds bootstrap
+// config, so tests can use multiple xds clients in different ClientConns at
+// the same time.
+func NewBuilder(config []byte) (resolver.Builder, error) {
+	return &xdsResolverBuilder{
+		newXDSClient: func() (xdsClientInterface, error) {
+			return xdsclient.NewClientWithBootstrapContents(config)
+		},
+	}, nil
+}
+
 // For overriding in unittests.
 var newXDSClient = func() (xdsClientInterface, error) { return xdsclient.New() }
 
@@ -43,7 +54,9 @@ func init() {
 	resolver.Register(&xdsResolverBuilder{})
 }
 
-type xdsResolverBuilder struct{}
+type xdsResolverBuilder struct {
+	newXDSClient func() (xdsClientInterface, error)
+}
 
 // Build helps implement the resolver.Builder interface.
 //
@@ -59,6 +72,11 @@ func (b *xdsResolverBuilder) Build(t resolver.Target, cc resolver.ClientConn, op
 	}
 	r.logger = prefixLogger((r))
 	r.logger.Infof("Creating resolver for target: %+v", t)
+
+	newXDSClient := newXDSClient
+	if b.newXDSClient != nil {
+		newXDSClient = b.newXDSClient
+	}
 
 	client, err := newXDSClient()
 	if err != nil {
@@ -178,6 +196,13 @@ func (r *xdsResolver) sendNewServiceConfig(cs *configSelector) bool {
 	state := iresolver.SetConfigSelector(resolver.State{
 		ServiceConfig: r.cc.ParseServiceConfig(string(sc)),
 	}, cs)
+
+	// Include the xds client for the LB policies to use.  For unit tests,
+	// r.client may not be a full *xdsclient.Client, but it will always be in
+	// production.
+	if c, ok := r.client.(*xdsclient.Client); ok {
+		state = xdsclient.SetClient(state, c)
+	}
 	r.cc.UpdateState(state)
 	return true
 }

--- a/xds/internal/test/xds_client_integration_test.go
+++ b/xds/internal/test/xds_client_integration_test.go
@@ -68,7 +68,7 @@ func (s) TestClientSideXDS(t *testing.T) {
 	port, cleanup := clientSetup(t)
 	defer cleanup()
 
-	serviceName := xdsServiceName + "-client-side-xds"
+	const serviceName = "my-service-client-side-xds"
 	resources := e2e.DefaultClientResources(e2e.ResourceParams{
 		DialTarget: serviceName,
 		NodeID:     xdsClientNodeID,
@@ -81,7 +81,7 @@ func (s) TestClientSideXDS(t *testing.T) {
 	}
 
 	// Create a ClientConn and make a successful RPC.
-	cc, err := grpc.Dial(fmt.Sprintf("xds:///%s", serviceName), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	cc, err := grpc.Dial(fmt.Sprintf("xds:///%s", serviceName), grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithResolvers(xdsResolverBuilder))
 	if err != nil {
 		t.Fatalf("failed to dial local test server: %v", err)
 	}

--- a/xds/internal/test/xds_server_serving_mode_test.go
+++ b/xds/internal/test/xds_server_serving_mode_test.go
@@ -105,7 +105,7 @@ func (s) TestServerSideXDS_ServingModeChanges(t *testing.T) {
 	})
 
 	// Initialize an xDS-enabled gRPC server and register the stubServer on it.
-	server := xds.NewGRPCServer(grpc.Creds(creds), modeChangeOpt)
+	server := xds.NewGRPCServer(grpc.Creds(creds), modeChangeOpt, xds.BootstrapContentsForTesting(bootstrapContents))
 	defer server.Stop()
 	testpb.RegisterTestServiceServer(server, &testService{})
 

--- a/xds/xds.go
+++ b/xds/xds.go
@@ -38,6 +38,7 @@ import (
 	v3statusgrpc "github.com/envoyproxy/go-control-plane/envoy/service/status/v3"
 	"google.golang.org/grpc"
 	internaladmin "google.golang.org/grpc/internal/admin"
+	"google.golang.org/grpc/resolver"
 	"google.golang.org/grpc/xds/csds"
 
 	_ "google.golang.org/grpc/credentials/tls/certprovider/pemfile" // Register the file watcher certificate provider plugin.
@@ -45,7 +46,7 @@ import (
 	_ "google.golang.org/grpc/xds/internal/client/v2"               // Register the v2 xDS API client.
 	_ "google.golang.org/grpc/xds/internal/client/v3"               // Register the v3 xDS API client.
 	_ "google.golang.org/grpc/xds/internal/httpfilter/fault"        // Register the fault injection filter.
-	_ "google.golang.org/grpc/xds/internal/resolver"                // Register the xds_resolver.
+	xdsresolver "google.golang.org/grpc/xds/internal/resolver"      // Register the xds_resolver.
 )
 
 func init() {
@@ -75,4 +76,17 @@ func init() {
 		v3statusgrpc.RegisterClientStatusDiscoveryServiceServer(grpcServer, csdss)
 		return csdss.Close, nil
 	})
+}
+
+// NewXDSResolverWithConfigForTesting creates a new xds resolver builder using
+// the provided xds bootstrap config instead of the global configuration from
+// the supported environment variables.  The resolver.Builder is meant to be
+// used in conjunction with the grpc.WithResolvers DialOption.
+//
+// Testing Only
+//
+// This function should ONLY be used for testing and may not work with some
+// other features, including the CSDS service.
+func NewXDSResolverWithConfigForTesting(bootstrapConfig []byte) (resolver.Builder, error) {
+	return xdsresolver.NewBuilder(bootstrapConfig)
 }


### PR DESCRIPTION
Fixes #4124

RELEASE NOTES:
* xds: add `NewXDSResolverWithConfigForTesting` and `BootstrapContentsForTesting` to inject xds config