### PR TITLE
client: Clarify that WaitForReady will block for CONNECTING channels

### DIFF
--- a/rpc_util.go
+++ b/rpc_util.go
@@ -258,7 +258,8 @@ func (o PeerCallOption) after(c *callInfo, attempt *csAttempt) {
 }
 
 // WaitForReady configures the action to take when an RPC is attempted on broken
-// connections or unreachable servers. If waitForReady is false, the RPC will fail
+// connections or unreachable servers. If waitForReady is false and the
+// connection is in the TRANSIENT_FAILURE or SHUTDOWN states, the RPC will fail
 // immediately. Otherwise, the RPC client will block the call until a
 // connection is available (or the call is canceled or times out) and will
 // retry the call if it fails due to a transient error.  gRPC will not retry if

--- a/rpc_util.go
+++ b/rpc_util.go
@@ -259,7 +259,7 @@ func (o PeerCallOption) after(c *callInfo, attempt *csAttempt) {
 
 // WaitForReady configures the action to take when an RPC is attempted on broken
 // connections or unreachable servers. If waitForReady is false and the
-// connection is in the TRANSIENT_FAILURE or SHUTDOWN states, the RPC will fail
+// connection is in the TRANSIENT_FAILURE state, the RPC will fail
 // immediately. Otherwise, the RPC client will block the call until a
 // connection is available (or the call is canceled or times out) and will
 // retry the call if it fails due to a transient error.  gRPC will not retry if


### PR DESCRIPTION
The WaitForReady option documentation was not clear to me, until I
read the linked documentation [1]. Include the channel state names
that cause an RPC to fail immediately to attempt to clarify how this
works.

[1] https://github.com/grpc/grpc/blob/master/doc/wait-for-ready.md


Feel free to reject this: I just found this confusing, and had to read it multiple times. I'm attempting to clarify it so others don't make the same mistake I did. Thanks!

RELEASE NOTES:
* client: Clarify that WaitForReady will block for CONNECTING channels