### PR TITLE
client: ensure LB policy is closed before closing resolver

### DIFF
--- a/clientconn.go
+++ b/clientconn.go
@@ -1046,11 +1046,11 @@ func (cc *ClientConn) Close() error {
 
 	cc.blockingpicker.close()
 
-	if rWrapper != nil {
-		rWrapper.close()
-	}
 	if bWrapper != nil {
 		bWrapper.close()
+	}
+	if rWrapper != nil {
+		rWrapper.close()
 	}
 
 	for ac := range conns {


### PR DESCRIPTION
This is a slightly different approach to #4364.