### PR TITLE
mergeable: update relnotes regex

### DIFF
--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -14,7 +14,7 @@ mergeable:
           #
           # RELEASE NOTES:
           # * <text>
-          regex: '^RELEASE NOTES:\\s*([Nn][Oo][Nn][Ee]|[Nn]/[Aa]|\n\\*\\s*.+)$'
+          regex: '^RELEASE NOTES:\s*([Nn][Oo][Nn][Ee]|[Nn]/[Aa]|\n\*\s*.+)$'
           regex_flag: 'm'
       - do: milestone
         must_include:

--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -7,7 +7,15 @@ mergeable:
           regex: '^Type:'
       - do: description
         must_include:
-          regex: 'RELEASE NOTES:'
+          # Allow:
+          # RELEASE NOTES: none (case insensitive)
+          #
+          # RELEASE NOTES: N/A (case insensitive)
+          #
+          # RELEASE NOTES:
+          # * <text>
+          regex: '^RELEASE NOTES:\\s*([Nn][Oo][Nn][Ee]|[Nn]/[Aa]|\n\\*\\s*.+)$'
+          regex_flag: 'm'
       - do: milestone
         must_include:
           regex: 'Release$'

--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -14,7 +14,7 @@ mergeable:
           #
           # RELEASE NOTES:
           # * <text>
-          regex: '^RELEASE NOTES:\s*([Nn][Oo][Nn][Ee]|[Nn]/[Aa]|\n\*\s*.+)$'
+          regex: '^RELEASE NOTES:\s*([Nn][Oo][Nn][Ee]|[Nn]/[Aa]|\n(\*|-)\s*.+)$'
           regex_flag: 'm'
       - do: milestone
         must_include:


### PR DESCRIPTION
Tested using https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/multiline demo w/input:
```
const regex = new RegExp('^RELEASE NOTES:\\s*([Nn][Oo][Nn][Ee]|[Nn]/[Aa]|\n\\*\\s*.+)$', 'm');

console.log(regex.test('fixes #4400\nRELEASE NOTES:\n* admin: skip CSDS if xDS bootstrap config isn\'t set'));
console.log(regex.test('RELEASE NOTES: none'));
console.log(regex.test('RELEASE NOTES:  n/a'));
console.log(regex.test('RELEASE NOTES: nope'));
console.log(regex.test('here are the RELEASE NOTES: none'));
console.log(regex.test('here are the RELEASE NOTES:\n* stuff'));
console.log(regex.test('also bad\nRELEASE NOTES:'));
```

```
> true
> true
> true
> false
> false
> false
> false
```