### PR TITLE
Remove the UpdateAddresses() method from balancer.SubConn interface

### DIFF
--- a/balancer/balancer.go
+++ b/balancer/balancer.go
@@ -94,17 +94,6 @@ func Get(name string) Builder {
 // testing, the new implementation should embed this interface. This allows
 // gRPC to add new methods to this interface.
 type SubConn interface {
-	// UpdateAddresses updates the addresses used in this SubConn.
-	// gRPC checks if currently-connected address is still in the new list.
-	// If it's in the list, the connection will be kept.
-	// If it's not in the list, the connection will gracefully closed, and
-	// a new connection will be created.
-	//
-	// This will trigger a state transition for the SubConn.
-	//
-	// Deprecated: This method is now part of the ClientConn interface and will
-	// eventually be removed from here.
-	UpdateAddresses([]resolver.Address)
 	// Connect starts the connecting for this SubConn.
 	Connect()
 }

--- a/balancer/base/balancer_test.go
+++ b/balancer/base/balancer_test.go
@@ -40,8 +40,6 @@ func (c *testClientConn) UpdateState(balancer.State) {}
 
 type testSubConn struct{}
 
-func (sc *testSubConn) UpdateAddresses(addresses []resolver.Address) {}
-
 func (sc *testSubConn) Connect() {}
 
 // testPickBuilder creates balancer.Picker for test.

--- a/balancer_conn_wrappers.go
+++ b/balancer_conn_wrappers.go
@@ -177,7 +177,7 @@ func (ccb *ccBalancerWrapper) UpdateAddresses(sc balancer.SubConn, addrs []resol
 	if !ok {
 		return
 	}
-	acbw.UpdateAddresses(addrs)
+	acbw.updateAddresses(addrs)
 }
 
 func (ccb *ccBalancerWrapper) UpdateState(s balancer.State) {
@@ -210,7 +210,7 @@ type acBalancerWrapper struct {
 	ac *addrConn
 }
 
-func (acbw *acBalancerWrapper) UpdateAddresses(addrs []resolver.Address) {
+func (acbw *acBalancerWrapper) updateAddresses(addrs []resolver.Address) {
 	acbw.mu.Lock()
 	defer acbw.mu.Unlock()
 	if len(addrs) <= 0 {
@@ -237,7 +237,7 @@ func (acbw *acBalancerWrapper) UpdateAddresses(addrs []resolver.Address) {
 
 		ac, err := cc.newAddrConn(addrs, opts)
 		if err != nil {
-			channelz.Warningf(logger, acbw.ac.channelzID, "acBalancerWrapper: UpdateAddresses: failed to newAddrConn: %v", err)
+			channelz.Warningf(logger, acbw.ac.channelzID, "acBalancerWrapper: updateAddresses: failed to newAddrConn: %v", err)
 			return
 		}
 		acbw.ac = ac

--- a/clientconn.go
+++ b/clientconn.go
@@ -1082,7 +1082,7 @@ type addrConn struct {
 
 	cc     *ClientConn
 	dopts  dialOptions
-	acbw   balancer.SubConn
+	acbw   *acBalancerWrapper
 	scopts balancer.NewSubConnOptions
 
 	// transport is set when there's a viable transport (note: ac state may not be READY as LB channel

--- a/clientconn_test.go
+++ b/clientconn_test.go
@@ -1011,7 +1011,7 @@ func (s) TestUpdateAddresses_RetryFromFirstAddr(t *testing.T) {
 	}
 	client.mu.Unlock()
 
-	ac.acbw.UpdateAddresses(addrsList)
+	ac.acbw.updateAddresses(addrsList)
 
 	// We've called tryUpdateAddrs - now let's make server2 close the
 	// connection and check that it goes back to server1 instead of continuing

--- a/xds/internal/balancer/edsbalancer/eds_test.go
+++ b/xds/internal/balancer/edsbalancer/eds_test.go
@@ -240,8 +240,7 @@ func newFakeEDSBalancer(cc balancer.ClientConn) edsBalancerImplInterface {
 
 type fakeSubConn struct{}
 
-func (*fakeSubConn) UpdateAddresses([]resolver.Address) { panic("implement me") }
-func (*fakeSubConn) Connect()                           { panic("implement me") }
+func (*fakeSubConn) Connect() { panic("implement me") }
 
 // waitForNewEDSLB makes sure that a new edsLB is created by the top-level
 // edsBalancer.


### PR DESCRIPTION
This is the second and last change as outlined in this [issue](https://github.com/grpc/grpc-go/issues/4207)

Summary of changes:
- Remove the `UpdateAddresses()` method from the `balancer.SubConn` interface
- Unexport the `UpdateAddresses()` method on the `acBalancerWrapper` type.
- Store the concrete type `*acBalancerWrapper` in `addrConn` instead of the `balancer.SubConn` interface
- Remove no-op implementations of this method from fake/test subConn implementations used in tests

Fixes https://github.com/grpc/grpc-go/issues/4207

RELEASE NOTES:
* balancer: remove `UpdateAddresses()` from `SubConn` interface; use `ClientConn.UpdateAddresses` instead.  See #4207 for details.