### PR TITLE
Add GetServiceInfo to xds.GRPCServer

### DIFF
--- a/xds/server.go
+++ b/xds/server.go
@@ -73,6 +73,7 @@ type grpcServerInterface interface {
 	Serve(net.Listener) error
 	Stop()
 	GracefulStop()
+	GetServiceInfo() map[string]grpc.ServiceInfo
 }
 
 // GRPCServer wraps a gRPC server and provides server-side xDS functionality, by
@@ -143,6 +144,12 @@ func handleServerOptions(opts []grpc.ServerOption) *serverOptions {
 // before invoking Serve.
 func (s *GRPCServer) RegisterService(sd *grpc.ServiceDesc, ss interface{}) {
 	s.gs.RegisterService(sd, ss)
+}
+
+// GetServiceInfo returns a map from service names to ServiceInfo.
+// Service names include the package names, in the form of <package>.<service>.
+func (s *GRPCServer) GetServiceInfo() map[string]grpc.ServiceInfo {
+	return s.gs.GetServiceInfo()
 }
 
 // initXDSClient creates a new xdsClient if there is no existing one available.

--- a/xds/server_test.go
+++ b/xds/server_test.go
@@ -86,6 +86,10 @@ func (f *fakeGRPCServer) GracefulStop() {
 	f.gracefulStopCh.Send(nil)
 }
 
+func (f *fakeGRPCServer) GetServiceInfo() map[string]grpc.ServiceInfo {
+	panic("implement me")
+}
+
 func newFakeGRPCServer() *fakeGRPCServer {
 	return &fakeGRPCServer{
 		done:              make(chan struct{}),


### PR DESCRIPTION
`xds.GRPCServer` is missing now `GetServiceInfo` and this is vital for [registering metrics for example](https://github.com/grpc-ecosystem/go-grpc-prometheus/pull/102/files)

RELEASE NOTES:
* xds: Add GetServiceInfo() to xds.GRPCServer