### PR TITLE
xds/resolver: test xds client closed by resolver Close

### DIFF
--- a/xds/internal/resolver/xds_resolver_test.go
+++ b/xds/internal/resolver/xds_resolver_test.go
@@ -281,6 +281,20 @@ func (s) TestXDSResolverWatchCallbackAfterClose(t *testing.T) {
 	}
 }
 
+// TestXDSResolverCloseClosesXDSClient tests that the XDS resolver's Close
+// method closes the XDS client.
+func (s) TestXDSResolverCloseClosesXDSClient(t *testing.T) {
+	xdsC := fakeclient.NewClient()
+	xdsR, _, cancel := testSetup(t, setupOpts{
+		xdsClientFunc: func() (xdsClient, error) { return xdsC, nil },
+	})
+	defer cancel()
+	xdsR.Close()
+	if !xdsC.Closed.HasFired() {
+		t.Fatalf("xds client not closed by xds resolver Close method")
+	}
+}
+
 // TestXDSResolverBadServiceUpdate tests the case the xdsClient returns a bad
 // service update.
 func (s) TestXDSResolverBadServiceUpdate(t *testing.T) {

--- a/xds/internal/testutils/fakeclient/client.go
+++ b/xds/internal/testutils/fakeclient/client.go
@@ -42,7 +42,6 @@ type Client struct {
 	cdsCancelCh  *testutils.Channel
 	edsCancelCh  *testutils.Channel
 	loadReportCh *testutils.Channel
-	closeCh      *testutils.Channel
 	loadStore    *load.Store
 	bootstrapCfg *bootstrap.Config
 
@@ -271,7 +270,6 @@ func NewClientWithName(name string) *Client {
 		cdsCancelCh:  testutils.NewChannelWithSize(10),
 		edsCancelCh:  testutils.NewChannel(),
 		loadReportCh: testutils.NewChannel(),
-		closeCh:      testutils.NewChannel(),
 		loadStore:    load.NewStore(),
 		cdsCbs:       make(map[string]func(xdsclient.ClusterUpdate, error)),
 		Closed:       grpcsync.NewEvent(),


### PR DESCRIPTION
Includes #4479 which noticed this missing test case.

RELEASE NOTES: none