### PR TITLE
cleanup: remove "Interface" as suffix of (almost all) interface names

### DIFF
--- a/internal/xds/matcher/matcher_header.go
+++ b/internal/xds/matcher/matcher_header.go
@@ -27,10 +27,10 @@ import (
 	"google.golang.org/grpc/metadata"
 )
 
-// HeaderMatcherInterface is an interface for header matchers. These are
+// HeaderMatcher is an interface for header matchers. These are
 // documented in (EnvoyProxy link here?). These matchers will match on different
 // aspects of HTTP header name/value pairs.
-type HeaderMatcherInterface interface {
+type HeaderMatcher interface {
 	Match(metadata.MD) bool
 	String() string
 }
@@ -234,11 +234,11 @@ func (hcm *HeaderContainsMatcher) String() string {
 
 // InvertMatcher inverts the match result of the underlying header matcher.
 type InvertMatcher struct {
-	m HeaderMatcherInterface
+	m HeaderMatcher
 }
 
 // NewInvertMatcher returns a new InvertMatcher.
-func NewInvertMatcher(m HeaderMatcherInterface) *InvertMatcher {
+func NewInvertMatcher(m HeaderMatcher) *InvertMatcher {
 	return &InvertMatcher{m: m}
 }
 

--- a/internal/xds/matcher/matcher_header_test.go
+++ b/internal/xds/matcher/matcher_header_test.go
@@ -309,7 +309,7 @@ func TestHeaderSuffixMatcherMatch(t *testing.T) {
 func TestInvertMatcherMatch(t *testing.T) {
 	tests := []struct {
 		name string
-		m    HeaderMatcherInterface
+		m    HeaderMatcher
 		md   metadata.MD
 	}{
 		{

--- a/internal/xds/rbac/matchers.go
+++ b/internal/xds/rbac/matchers.go
@@ -251,11 +251,11 @@ func (nm *notMatcher) match(data *RPCData) bool {
 // headerMatcher is a matcher that matches on incoming HTTP Headers present
 // in the incoming RPC. headerMatcher implements the matcher interface.
 type headerMatcher struct {
-	matcher internalmatcher.HeaderMatcherInterface
+	matcher internalmatcher.HeaderMatcher
 }
 
 func newHeaderMatcher(headerMatcherConfig *v3route_componentspb.HeaderMatcher) (*headerMatcher, error) {
-	var m internalmatcher.HeaderMatcherInterface
+	var m internalmatcher.HeaderMatcher
 	switch headerMatcherConfig.HeaderMatchSpecifier.(type) {
 	case *v3route_componentspb.HeaderMatcher_ExactMatch:
 		m = internalmatcher.NewHeaderExactMatcher(headerMatcherConfig.Name, headerMatcherConfig.GetExactMatch())

--- a/xds/csds/csds.go
+++ b/xds/csds/csds.go
@@ -45,9 +45,9 @@ import (
 	_ "google.golang.org/grpc/xds/internal/xdsclient/v3" // Register v3 xds_client.
 )
 
-// xdsClientInterface contains methods from xdsClient.Client which are used by
+// xdsClient contains methods from xdsClient.Client which are used by
 // the server. This is useful for overriding in unit tests.
-type xdsClientInterface interface {
+type xdsClient interface {
 	DumpLDS() (string, map[string]xdsclient.UpdateWithMD)
 	DumpRDS() (string, map[string]xdsclient.UpdateWithMD)
 	DumpCDS() (string, map[string]xdsclient.UpdateWithMD)
@@ -58,7 +58,7 @@ type xdsClientInterface interface {
 
 var (
 	logger       = grpclog.Component("xds")
-	newXDSClient = func() xdsClientInterface {
+	newXDSClient = func() xdsClient {
 		c, err := xdsclient.New()
 		if err != nil {
 			// If err is not nil, c is a typed nil (of type *xdsclient.Client).
@@ -76,7 +76,7 @@ var (
 type ClientStatusDiscoveryServer struct {
 	// xdsClient will always be the same in practice. But we keep a copy in each
 	// server instance for testing.
-	xdsClient xdsClientInterface
+	xdsClient xdsClient
 }
 
 // NewClientStatusDiscoveryServer returns an implementation of the CSDS server that can be

--- a/xds/csds/csds_test.go
+++ b/xds/csds/csds_test.go
@@ -59,7 +59,7 @@ const (
 	defaultTestTimeout = 10 * time.Second
 )
 
-type xdsClientInterfaceWithWatch interface {
+type xdsClientWithWatch interface {
 	WatchListener(string, func(xdsclient.ListenerUpdate, error)) func()
 	WatchRouteConfig(string, func(xdsclient.RouteConfigUpdate, error)) func()
 	WatchCluster(string, func(xdsclient.ClusterUpdate, error)) func()
@@ -250,7 +250,7 @@ func TestCSDS(t *testing.T) {
 	}
 }
 
-func commonSetup(t *testing.T) (xdsClientInterfaceWithWatch, *e2e.ManagementServer, string, v3statuspbgrpc.ClientStatusDiscoveryService_StreamClientStatusClient, func()) {
+func commonSetup(t *testing.T) (xdsClientWithWatch, *e2e.ManagementServer, string, v3statuspbgrpc.ClientStatusDiscoveryService_StreamClientStatusClient, func()) {
 	t.Helper()
 
 	// Spin up a xDS management server on a local port.
@@ -275,7 +275,7 @@ func commonSetup(t *testing.T) (xdsClientInterfaceWithWatch, *e2e.ManagementServ
 		t.Fatalf("failed to create xds client: %v", err)
 	}
 	oldNewXDSClient := newXDSClient
-	newXDSClient = func() xdsClientInterface { return xdsC }
+	newXDSClient = func() xdsClient { return xdsC }
 
 	// Initialize an gRPC server and register CSDS on it.
 	server := grpc.NewServer()
@@ -635,7 +635,7 @@ func protoToJSON(p proto.Message) string {
 
 func TestCSDSNoXDSClient(t *testing.T) {
 	oldNewXDSClient := newXDSClient
-	newXDSClient = func() xdsClientInterface { return nil }
+	newXDSClient = func() xdsClient { return nil }
 	defer func() { newXDSClient = oldNewXDSClient }()
 
 	// Initialize an gRPC server and register CSDS on it.

--- a/xds/googledirectpath/googlec2p.go
+++ b/xds/googledirectpath/googlec2p.go
@@ -61,7 +61,7 @@ const (
 	dnsName, xdsName = "dns", "xds"
 )
 
-type xdsClientInterface interface {
+type xdsClient interface {
 	Close()
 }
 
@@ -69,7 +69,7 @@ type xdsClientInterface interface {
 var (
 	onGCE = googlecloud.OnGCE
 
-	newClientWithConfig = func(config *bootstrap.Config) (xdsClientInterface, error) {
+	newClientWithConfig = func(config *bootstrap.Config) (xdsClient, error) {
 		return xdsclient.NewWithConfig(config)
 	}
 
@@ -138,7 +138,7 @@ func (c2pResolverBuilder) Scheme() string {
 
 type c2pResolver struct {
 	resolver.Resolver
-	client xdsClientInterface
+	client xdsClient
 }
 
 func (r *c2pResolver) Close() {

--- a/xds/googledirectpath/googlec2p_test.go
+++ b/xds/googledirectpath/googlec2p_test.go
@@ -177,7 +177,7 @@ func TestBuildXDS(t *testing.T) {
 
 			configCh := make(chan *bootstrap.Config, 1)
 			oldNewClient := newClientWithConfig
-			newClientWithConfig = func(config *bootstrap.Config) (xdsClientInterface, error) {
+			newClientWithConfig = func(config *bootstrap.Config) (xdsClient, error) {
 				configCh <- config
 				return tXDSClient, nil
 			}

--- a/xds/internal/balancer/cdsbalancer/cdsbalancer.go
+++ b/xds/internal/balancer/cdsbalancer/cdsbalancer.go
@@ -59,7 +59,7 @@ var (
 		// not deal with subConns.
 		return builder.Build(cc, opts), nil
 	}
-	newXDSClient  func() (xdsClientInterface, error)
+	newXDSClient  func() (xdsClient, error)
 	buildProvider = buildProviderFunc
 )
 
@@ -138,9 +138,9 @@ func (cdsBB) ParseConfig(c json.RawMessage) (serviceconfig.LoadBalancingConfig, 
 	return &cfg, nil
 }
 
-// xdsClientInterface contains methods from xdsClient.Client which are used by
+// xdsClient contains methods from xdsClient.Client which are used by
 // the cdsBalancer. This will be faked out in unittests.
-type xdsClientInterface interface {
+type xdsClient interface {
 	WatchCluster(string, func(xdsclient.ClusterUpdate, error)) func()
 	BootstrapConfig() *bootstrap.Config
 	Close()
@@ -185,7 +185,7 @@ type cdsBalancer struct {
 	ccw            *ccWrapper            // ClientConn interface passed to child LB.
 	bOpts          balancer.BuildOptions // BuildOptions passed to child LB.
 	updateCh       *buffer.Unbounded     // Channel for gRPC and xdsClient updates.
-	xdsClient      xdsClientInterface    // xDS client to watch Cluster resource.
+	xdsClient      xdsClient             // xDS client to watch Cluster resource.
 	cancelWatch    func()                // Cluster watch cancel func.
 	edsLB          balancer.Balancer     // EDS child policy.
 	clusterToWatch string

--- a/xds/internal/balancer/cdsbalancer/cdsbalancer_security_test.go
+++ b/xds/internal/balancer/cdsbalancer/cdsbalancer_security_test.go
@@ -136,7 +136,7 @@ func setupWithXDSCreds(t *testing.T) (*fakeclient.Client, *cdsBalancer, *testEDS
 
 	xdsC := fakeclient.NewClient()
 	oldNewXDSClient := newXDSClient
-	newXDSClient = func() (xdsClientInterface, error) { return xdsC, nil }
+	newXDSClient = func() (xdsClient, error) { return xdsC, nil }
 
 	builder := balancer.Get(cdsName)
 	if builder == nil {

--- a/xds/internal/balancer/cdsbalancer/cdsbalancer_test.go
+++ b/xds/internal/balancer/cdsbalancer/cdsbalancer_test.go
@@ -214,7 +214,7 @@ func setup(t *testing.T) (*fakeclient.Client, *cdsBalancer, *testEDSBalancer, *x
 
 	xdsC := fakeclient.NewClient()
 	oldNewXDSClient := newXDSClient
-	newXDSClient = func() (xdsClientInterface, error) { return xdsC, nil }
+	newXDSClient = func() (xdsClient, error) { return xdsC, nil }
 
 	builder := balancer.Get(cdsName)
 	if builder == nil {

--- a/xds/internal/balancer/cdsbalancer/cluster_handler.go
+++ b/xds/internal/balancer/cdsbalancer/cluster_handler.go
@@ -40,7 +40,7 @@ type clusterHandler struct {
 	// CDS Balancer cares about is the most recent update.
 	updateChannel chan clusterHandlerUpdate
 
-	xdsClient xdsClientInterface
+	xdsClient xdsClient
 }
 
 func (ch *clusterHandler) updateRootCluster(rootClusterName string) {
@@ -112,7 +112,7 @@ type clusterNode struct {
 
 // CreateClusterNode creates a cluster node from a given clusterName. This will
 // also start the watch for that cluster.
-func createClusterNode(clusterName string, xdsClient xdsClientInterface, topLevelHandler *clusterHandler) *clusterNode {
+func createClusterNode(clusterName string, xdsClient xdsClient, topLevelHandler *clusterHandler) *clusterNode {
 	c := &clusterNode{
 		clusterHandler: topLevelHandler,
 	}

--- a/xds/internal/balancer/clusterimpl/balancer_test.go
+++ b/xds/internal/balancer/clusterimpl/balancer_test.go
@@ -75,7 +75,7 @@ func TestDropByCategory(t *testing.T) {
 	defer xdsclient.ClearCounterForTesting(testClusterName)
 	xdsC := fakeclient.NewClient()
 	oldNewXDSClient := newXDSClient
-	newXDSClient = func() (xdsClientInterface, error) { return xdsC, nil }
+	newXDSClient = func() (xdsClient, error) { return xdsC, nil }
 	defer func() { newXDSClient = oldNewXDSClient }()
 
 	builder := balancer.Get(Name)
@@ -233,7 +233,7 @@ func TestDropCircuitBreaking(t *testing.T) {
 	defer xdsclient.ClearCounterForTesting(testClusterName)
 	xdsC := fakeclient.NewClient()
 	oldNewXDSClient := newXDSClient
-	newXDSClient = func() (xdsClientInterface, error) { return xdsC, nil }
+	newXDSClient = func() (xdsClient, error) { return xdsC, nil }
 	defer func() { newXDSClient = oldNewXDSClient }()
 
 	builder := balancer.Get(Name)
@@ -345,7 +345,7 @@ func TestPickerUpdateAfterClose(t *testing.T) {
 	defer xdsclient.ClearCounterForTesting(testClusterName)
 	xdsC := fakeclient.NewClient()
 	oldNewXDSClient := newXDSClient
-	newXDSClient = func() (xdsClientInterface, error) { return xdsC, nil }
+	newXDSClient = func() (xdsClient, error) { return xdsC, nil }
 	defer func() { newXDSClient = oldNewXDSClient }()
 
 	builder := balancer.Get(Name)
@@ -390,7 +390,7 @@ func TestClusterNameInAddressAttributes(t *testing.T) {
 	defer xdsclient.ClearCounterForTesting(testClusterName)
 	xdsC := fakeclient.NewClient()
 	oldNewXDSClient := newXDSClient
-	newXDSClient = func() (xdsClientInterface, error) { return xdsC, nil }
+	newXDSClient = func() (xdsClient, error) { return xdsC, nil }
 	defer func() { newXDSClient = oldNewXDSClient }()
 
 	builder := balancer.Get(Name)
@@ -481,7 +481,7 @@ func TestReResolution(t *testing.T) {
 	defer xdsclient.ClearCounterForTesting(testClusterName)
 	xdsC := fakeclient.NewClient()
 	oldNewXDSClient := newXDSClient
-	newXDSClient = func() (xdsClientInterface, error) { return xdsC, nil }
+	newXDSClient = func() (xdsClient, error) { return xdsC, nil }
 	defer func() { newXDSClient = oldNewXDSClient }()
 
 	builder := balancer.Get(Name)

--- a/xds/internal/balancer/clusterimpl/clusterimpl.go
+++ b/xds/internal/balancer/clusterimpl/clusterimpl.go
@@ -52,7 +52,7 @@ func init() {
 	balancer.Register(clusterImplBB{})
 }
 
-var newXDSClient func() (xdsClientInterface, error)
+var newXDSClient func() (xdsClient, error)
 
 type clusterImplBB struct{}
 
@@ -91,9 +91,9 @@ func (clusterImplBB) ParseConfig(c json.RawMessage) (serviceconfig.LoadBalancing
 	return parseConfig(c)
 }
 
-// xdsClientInterface contains only the xds_client methods needed by LRS
+// xdsClient contains only the xds_client methods needed by LRS
 // balancer. It's defined so we can override xdsclient in tests.
-type xdsClientInterface interface {
+type xdsClient interface {
 	ReportLoad(server string) (*load.Store, func())
 	Close()
 }
@@ -115,7 +115,7 @@ type clusterImplBalancer struct {
 
 	bOpts  balancer.BuildOptions
 	logger *grpclog.PrefixLogger
-	xdsC   xdsClientInterface
+	xdsC   xdsClient
 
 	config           *LBConfig
 	childLB          balancer.Balancer

--- a/xds/internal/balancer/edsbalancer/eds.go
+++ b/xds/internal/balancer/edsbalancer/eds.go
@@ -41,9 +41,9 @@ import (
 
 const edsName = "eds_experimental"
 
-// xdsClientInterface contains only the xds_client methods needed by EDS
+// xdsClient contains only the xds_client methods needed by EDS
 // balancer. It's defined so we can override xdsclient.New function in tests.
-type xdsClientInterface interface {
+type xdsClient interface {
 	WatchEndpoints(clusterName string, edsCb func(xdsclient.EndpointsUpdate, error)) (cancel func())
 	ReportLoad(server string) (loadStore *load.Store, cancel func())
 	Close()
@@ -53,7 +53,7 @@ var (
 	newEDSBalancer = func(cc balancer.ClientConn, opts balancer.BuildOptions, enqueueState func(priorityType, balancer.State), lw load.PerClusterReporter, logger *grpclog.PrefixLogger) edsBalancerImplInterface {
 		return newEDSBalancerImpl(cc, opts, enqueueState, lw, logger)
 	}
-	newXDSClient func() (xdsClientInterface, error)
+	newXDSClient func() (xdsClient, error)
 )
 
 func init() {
@@ -145,7 +145,7 @@ type edsBalancer struct {
 	xdsClientUpdate   chan *edsUpdate
 	childPolicyUpdate *buffer.Unbounded
 
-	xdsClient   xdsClientInterface
+	xdsClient   xdsClient
 	loadWrapper *loadstore.Wrapper
 	config      *EDSConfig // may change when passed a different service config
 	edsImpl     edsBalancerImplInterface

--- a/xds/internal/balancer/edsbalancer/eds_impl_test.go
+++ b/xds/internal/balancer/edsbalancer/eds_impl_test.go
@@ -816,7 +816,7 @@ func (s) TestEDS_LoadReport(t *testing.T) {
 	env.CircuitBreakingSupport = true
 	defer func() { env.CircuitBreakingSupport = origCircuitBreakingSupport }()
 
-	// We create an xdsClientWrapper with a dummy xdsClientInterface which only
+	// We create an xdsClientWrapper with a dummy xdsClient which only
 	// implements the LoadStore() method to return the underlying load.Store to
 	// be used.
 	loadStore := load.NewStore()

--- a/xds/internal/balancer/edsbalancer/eds_test.go
+++ b/xds/internal/balancer/edsbalancer/eds_test.go
@@ -260,7 +260,7 @@ func waitForNewEDSLB(ctx context.Context, ch *testutils.Channel) (*fakeEDSBalanc
 func setup(edsLBCh *testutils.Channel) (*fakeclient.Client, func()) {
 	xdsC := fakeclient.NewClientWithName(testBalancerNameFooBar)
 	oldNewXDSClient := newXDSClient
-	newXDSClient = func() (xdsClientInterface, error) { return xdsC, nil }
+	newXDSClient = func() (xdsClient, error) { return xdsC, nil }
 
 	origNewEDSBalancer := newEDSBalancer
 	newEDSBalancer = func(cc balancer.ClientConn, _ balancer.BuildOptions, _ func(priorityType, balancer.State), _ load.PerClusterReporter, _ *grpclog.PrefixLogger) edsBalancerImplInterface {

--- a/xds/internal/balancer/edsbalancer/xds_lrs_test.go
+++ b/xds/internal/balancer/edsbalancer/xds_lrs_test.go
@@ -34,7 +34,7 @@ import (
 func (s) TestXDSLoadReporting(t *testing.T) {
 	xdsC := fakeclient.NewClient()
 	oldNewXDSClient := newXDSClient
-	newXDSClient = func() (xdsClientInterface, error) { return xdsC, nil }
+	newXDSClient = func() (xdsClient, error) { return xdsC, nil }
 	defer func() { newXDSClient = oldNewXDSClient }()
 
 	builder := balancer.Get(edsName)

--- a/xds/internal/balancer/lrs/balancer.go
+++ b/xds/internal/balancer/lrs/balancer.go
@@ -36,7 +36,7 @@ func init() {
 	balancer.Register(&lrsBB{})
 }
 
-var newXDSClient func() (xdsClientInterface, error)
+var newXDSClient func() (xdsClient, error)
 
 // Name is the name of the LRS balancer.
 const Name = "lrs_experimental"
@@ -169,15 +169,15 @@ func (ccw *ccWrapper) UpdateState(s balancer.State) {
 	ccw.ClientConn.UpdateState(s)
 }
 
-// xdsClientInterface contains only the xds_client methods needed by LRS
+// xdsClient contains only the xds_client methods needed by LRS
 // balancer. It's defined so we can override xdsclient in tests.
-type xdsClientInterface interface {
+type xdsClient interface {
 	ReportLoad(server string) (*load.Store, func())
 	Close()
 }
 
 type xdsClientWrapper struct {
-	c                xdsClientInterface
+	c                xdsClient
 	cancelLoadReport func()
 	clusterName      string
 	edsServiceName   string
@@ -187,7 +187,7 @@ type xdsClientWrapper struct {
 	loadWrapper *loadstore.Wrapper
 }
 
-func newXDSClientWrapper(c xdsClientInterface) *xdsClientWrapper {
+func newXDSClientWrapper(c xdsClient) *xdsClientWrapper {
 	return &xdsClientWrapper{
 		c:           c,
 		loadWrapper: loadstore.NewWrapper(),

--- a/xds/internal/balancer/lrs/balancer_test.go
+++ b/xds/internal/balancer/lrs/balancer_test.go
@@ -56,7 +56,7 @@ var (
 func TestLoadReporting(t *testing.T) {
 	xdsC := fakeclient.NewClient()
 	oldNewXDSClient := newXDSClient
-	newXDSClient = func() (xdsClientInterface, error) { return xdsC, nil }
+	newXDSClient = func() (xdsClient, error) { return xdsC, nil }
 	defer func() { newXDSClient = oldNewXDSClient }()
 
 	builder := balancer.Get(Name)

--- a/xds/internal/resolver/matcher.go
+++ b/xds/internal/resolver/matcher.go
@@ -31,21 +31,21 @@ import (
 )
 
 func routeToMatcher(r *xdsclient.Route) (*compositeMatcher, error) {
-	var pathMatcher pathMatcherInterface
+	var pm pathMatcher
 	switch {
 	case r.Regex != nil:
-		pathMatcher = newPathRegexMatcher(r.Regex)
+		pm = newPathRegexMatcher(r.Regex)
 	case r.Path != nil:
-		pathMatcher = newPathExactMatcher(*r.Path, r.CaseInsensitive)
+		pm = newPathExactMatcher(*r.Path, r.CaseInsensitive)
 	case r.Prefix != nil:
-		pathMatcher = newPathPrefixMatcher(*r.Prefix, r.CaseInsensitive)
+		pm = newPathPrefixMatcher(*r.Prefix, r.CaseInsensitive)
 	default:
 		return nil, fmt.Errorf("illegal route: missing path_matcher")
 	}
 
-	var headerMatchers []matcher.HeaderMatcherInterface
+	var headerMatchers []matcher.HeaderMatcher
 	for _, h := range r.Headers {
-		var matcherT matcher.HeaderMatcherInterface
+		var matcherT matcher.HeaderMatcher
 		switch {
 		case h.ExactMatch != nil && *h.ExactMatch != "":
 			matcherT = matcher.NewHeaderExactMatcher(h.Name, *h.ExactMatch)
@@ -72,17 +72,17 @@ func routeToMatcher(r *xdsclient.Route) (*compositeMatcher, error) {
 	if r.Fraction != nil {
 		fractionMatcher = newFractionMatcher(*r.Fraction)
 	}
-	return newCompositeMatcher(pathMatcher, headerMatchers, fractionMatcher), nil
+	return newCompositeMatcher(pm, headerMatchers, fractionMatcher), nil
 }
 
 // compositeMatcher.match returns true if all matchers return true.
 type compositeMatcher struct {
-	pm  pathMatcherInterface
-	hms []matcher.HeaderMatcherInterface
+	pm  pathMatcher
+	hms []matcher.HeaderMatcher
 	fm  *fractionMatcher
 }
 
-func newCompositeMatcher(pm pathMatcherInterface, hms []matcher.HeaderMatcherInterface, fm *fractionMatcher) *compositeMatcher {
+func newCompositeMatcher(pm pathMatcher, hms []matcher.HeaderMatcher, fm *fractionMatcher) *compositeMatcher {
 	return &compositeMatcher{pm: pm, hms: hms, fm: fm}
 }
 

--- a/xds/internal/resolver/matcher_path.go
+++ b/xds/internal/resolver/matcher_path.go
@@ -23,7 +23,7 @@ import (
 	"strings"
 )
 
-type pathMatcherInterface interface {
+type pathMatcher interface {
 	match(path string) bool
 	String() string
 }

--- a/xds/internal/resolver/matcher_test.go
+++ b/xds/internal/resolver/matcher_test.go
@@ -34,8 +34,8 @@ import (
 func TestAndMatcherMatch(t *testing.T) {
 	tests := []struct {
 		name string
-		pm   pathMatcherInterface
-		hm   matcher.HeaderMatcherInterface
+		pm   pathMatcher
+		hm   matcher.HeaderMatcher
 		info iresolver.RPCInfo
 		want bool
 	}{
@@ -108,7 +108,7 @@ func TestAndMatcherMatch(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			a := newCompositeMatcher(tt.pm, []matcher.HeaderMatcherInterface{tt.hm}, nil)
+			a := newCompositeMatcher(tt.pm, []matcher.HeaderMatcher{tt.hm}, nil)
 			if got := a.match(tt.info); got != tt.want {
 				t.Errorf("match() = %v, want %v", got, tt.want)
 			}

--- a/xds/internal/resolver/watch_service.go
+++ b/xds/internal/resolver/watch_service.go
@@ -54,7 +54,7 @@ type ldsConfig struct {
 // Note that during race (e.g. an xDS response is received while the user is
 // calling cancel()), there's a small window where the callback can be called
 // after the watcher is canceled. The caller needs to handle this case.
-func watchService(c xdsClientInterface, serviceName string, cb func(serviceUpdate, error), logger *grpclog.PrefixLogger) (cancel func()) {
+func watchService(c xdsClient, serviceName string, cb func(serviceUpdate, error), logger *grpclog.PrefixLogger) (cancel func()) {
 	w := &serviceUpdateWatcher{
 		logger:      logger,
 		c:           c,
@@ -70,7 +70,7 @@ func watchService(c xdsClientInterface, serviceName string, cb func(serviceUpdat
 // callback at the right time.
 type serviceUpdateWatcher struct {
 	logger      *grpclog.PrefixLogger
-	c           xdsClientInterface
+	c           xdsClient
 	serviceName string
 	ldsCancel   func()
 	serviceCb   func(serviceUpdate, error)

--- a/xds/internal/resolver/xds_resolver_test.go
+++ b/xds/internal/resolver/xds_resolver_test.go
@@ -114,19 +114,19 @@ func newTestClientConn() *testClientConn {
 func (s) TestResolverBuilder(t *testing.T) {
 	tests := []struct {
 		name          string
-		xdsClientFunc func() (xdsClientInterface, error)
+		xdsClientFunc func() (xdsClient, error)
 		wantErr       bool
 	}{
 		{
 			name: "simple-good",
-			xdsClientFunc: func() (xdsClientInterface, error) {
+			xdsClientFunc: func() (xdsClient, error) {
 				return fakeclient.NewClient(), nil
 			},
 			wantErr: false,
 		},
 		{
 			name: "newXDSClient-throws-error",
-			xdsClientFunc: func() (xdsClientInterface, error) {
+			xdsClientFunc: func() (xdsClient, error) {
 				return nil, errors.New("newXDSClient-throws-error")
 			},
 			wantErr: true,
@@ -167,7 +167,7 @@ func (s) TestResolverBuilder_xdsCredsBootstrapMismatch(t *testing.T) {
 	// Fake out the xdsClient creation process by providing a fake, which does
 	// not have any certificate provider configuration.
 	oldClientMaker := newXDSClient
-	newXDSClient = func() (xdsClientInterface, error) {
+	newXDSClient = func() (xdsClient, error) {
 		fc := fakeclient.NewClient()
 		fc.SetBootstrapConfig(&bootstrap.Config{})
 		return fc, nil
@@ -194,7 +194,7 @@ func (s) TestResolverBuilder_xdsCredsBootstrapMismatch(t *testing.T) {
 }
 
 type setupOpts struct {
-	xdsClientFunc func() (xdsClientInterface, error)
+	xdsClientFunc func() (xdsClient, error)
 }
 
 func testSetup(t *testing.T, opts setupOpts) (*xdsResolver, *testClientConn, func()) {
@@ -254,7 +254,7 @@ func waitForWatchRouteConfig(ctx context.Context, t *testing.T, xdsC *fakeclient
 func (s) TestXDSResolverWatchCallbackAfterClose(t *testing.T) {
 	xdsC := fakeclient.NewClient()
 	xdsR, tcc, cancel := testSetup(t, setupOpts{
-		xdsClientFunc: func() (xdsClientInterface, error) { return xdsC, nil },
+		xdsClientFunc: func() (xdsClient, error) { return xdsC, nil },
 	})
 	defer cancel()
 
@@ -286,7 +286,7 @@ func (s) TestXDSResolverWatchCallbackAfterClose(t *testing.T) {
 func (s) TestXDSResolverBadServiceUpdate(t *testing.T) {
 	xdsC := fakeclient.NewClient()
 	xdsR, tcc, cancel := testSetup(t, setupOpts{
-		xdsClientFunc: func() (xdsClientInterface, error) { return xdsC, nil },
+		xdsClientFunc: func() (xdsClient, error) { return xdsC, nil },
 	})
 	defer xdsR.Close()
 	defer cancel()
@@ -312,7 +312,7 @@ func (s) TestXDSResolverBadServiceUpdate(t *testing.T) {
 func (s) TestXDSResolverGoodServiceUpdate(t *testing.T) {
 	xdsC := fakeclient.NewClient()
 	xdsR, tcc, cancel := testSetup(t, setupOpts{
-		xdsClientFunc: func() (xdsClientInterface, error) { return xdsC, nil },
+		xdsClientFunc: func() (xdsClient, error) { return xdsC, nil },
 	})
 	defer xdsR.Close()
 	defer cancel()
@@ -446,7 +446,7 @@ func (s) TestXDSResolverGoodServiceUpdate(t *testing.T) {
 func (s) TestXDSResolverRemovedWithRPCs(t *testing.T) {
 	xdsC := fakeclient.NewClient()
 	xdsR, tcc, cancel := testSetup(t, setupOpts{
-		xdsClientFunc: func() (xdsClientInterface, error) { return xdsC, nil },
+		xdsClientFunc: func() (xdsClient, error) { return xdsC, nil },
 	})
 	defer cancel()
 	defer xdsR.Close()
@@ -506,7 +506,7 @@ func (s) TestXDSResolverRemovedWithRPCs(t *testing.T) {
 func (s) TestXDSResolverRemovedResource(t *testing.T) {
 	xdsC := fakeclient.NewClient()
 	xdsR, tcc, cancel := testSetup(t, setupOpts{
-		xdsClientFunc: func() (xdsClientInterface, error) { return xdsC, nil },
+		xdsClientFunc: func() (xdsClient, error) { return xdsC, nil },
 	})
 	defer cancel()
 	defer xdsR.Close()
@@ -614,7 +614,7 @@ func (s) TestXDSResolverRemovedResource(t *testing.T) {
 func (s) TestXDSResolverWRR(t *testing.T) {
 	xdsC := fakeclient.NewClient()
 	xdsR, tcc, cancel := testSetup(t, setupOpts{
-		xdsClientFunc: func() (xdsClientInterface, error) { return xdsC, nil },
+		xdsClientFunc: func() (xdsClient, error) { return xdsC, nil },
 	})
 	defer xdsR.Close()
 	defer cancel()
@@ -675,7 +675,7 @@ func (s) TestXDSResolverMaxStreamDuration(t *testing.T) {
 	defer func(old bool) { env.TimeoutSupport = old }(env.TimeoutSupport)
 	xdsC := fakeclient.NewClient()
 	xdsR, tcc, cancel := testSetup(t, setupOpts{
-		xdsClientFunc: func() (xdsClientInterface, error) { return xdsC, nil },
+		xdsClientFunc: func() (xdsClient, error) { return xdsC, nil },
 	})
 	defer xdsR.Close()
 	defer cancel()
@@ -778,7 +778,7 @@ func (s) TestXDSResolverMaxStreamDuration(t *testing.T) {
 func (s) TestXDSResolverDelayedOnCommitted(t *testing.T) {
 	xdsC := fakeclient.NewClient()
 	xdsR, tcc, cancel := testSetup(t, setupOpts{
-		xdsClientFunc: func() (xdsClientInterface, error) { return xdsC, nil },
+		xdsClientFunc: func() (xdsClient, error) { return xdsC, nil },
 	})
 	defer xdsR.Close()
 	defer cancel()
@@ -927,7 +927,7 @@ func (s) TestXDSResolverDelayedOnCommitted(t *testing.T) {
 func (s) TestXDSResolverGoodUpdateAfterError(t *testing.T) {
 	xdsC := fakeclient.NewClient()
 	xdsR, tcc, cancel := testSetup(t, setupOpts{
-		xdsClientFunc: func() (xdsClientInterface, error) { return xdsC, nil },
+		xdsClientFunc: func() (xdsClient, error) { return xdsC, nil },
 	})
 	defer xdsR.Close()
 	defer cancel()
@@ -981,7 +981,7 @@ func (s) TestXDSResolverGoodUpdateAfterError(t *testing.T) {
 func (s) TestXDSResolverResourceNotFoundError(t *testing.T) {
 	xdsC := fakeclient.NewClient()
 	xdsR, tcc, cancel := testSetup(t, setupOpts{
-		xdsClientFunc: func() (xdsClientInterface, error) { return xdsC, nil },
+		xdsClientFunc: func() (xdsClient, error) { return xdsC, nil },
 	})
 	defer xdsR.Close()
 	defer cancel()
@@ -1027,7 +1027,7 @@ func (s) TestXDSResolverResourceNotFoundError(t *testing.T) {
 func (s) TestXDSResolverMultipleLDSUpdates(t *testing.T) {
 	xdsC := fakeclient.NewClient()
 	xdsR, tcc, cancel := testSetup(t, setupOpts{
-		xdsClientFunc: func() (xdsClientInterface, error) { return xdsC, nil },
+		xdsClientFunc: func() (xdsClient, error) { return xdsC, nil },
 	})
 	defer xdsR.Close()
 	defer cancel()
@@ -1202,7 +1202,7 @@ func (s) TestXDSResolverHTTPFilters(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			xdsC := fakeclient.NewClient()
 			xdsR, tcc, cancel := testSetup(t, setupOpts{
-				xdsClientFunc: func() (xdsClientInterface, error) { return xdsC, nil },
+				xdsClientFunc: func() (xdsClient, error) { return xdsC, nil },
 			})
 			defer xdsR.Close()
 			defer cancel()

--- a/xds/internal/server/conn_wrapper.go
+++ b/xds/internal/server/conn_wrapper.go
@@ -102,7 +102,7 @@ func (c *connWrapper) XDSHandshakeInfo() (*xdsinternal.HandshakeInfo, error) {
 
 	cpc := c.parent.xdsC.BootstrapConfig().CertProviderConfigs
 	// Identity provider name is mandatory on the server-side, and this is
-	// enforced when the resource is received at the xdsClient layer.
+	// enforced when the resource is received at the XDSClient layer.
 	secCfg := c.filterChain.SecurityCfg
 	ip, err := buildProviderFunc(cpc, secCfg.IdentityInstanceName, secCfg.IdentityCertName, true, false)
 	if err != nil {

--- a/xds/internal/server/listener_wrapper.go
+++ b/xds/internal/server/listener_wrapper.go
@@ -88,9 +88,9 @@ func prefixLogger(p *listenerWrapper) *internalgrpclog.PrefixLogger {
 	return internalgrpclog.NewPrefixLogger(logger, fmt.Sprintf("[xds-server-listener %p] ", p))
 }
 
-// XDSClientInterface wraps the methods on the xdsClient which are required by
+// XDSClient wraps the methods on the XDSClient which are required by
 // the listenerWrapper.
-type XDSClientInterface interface {
+type XDSClient interface {
 	WatchListener(string, func(xdsclient.ListenerUpdate, error)) func()
 	BootstrapConfig() *bootstrap.Config
 }
@@ -104,8 +104,8 @@ type ListenerWrapperParams struct {
 	// XDSCredsInUse specifies whether or not the user expressed interest to
 	// receive security configuration from the control plane.
 	XDSCredsInUse bool
-	// XDSClient provides the functionality from the xdsClient required here.
-	XDSClient XDSClientInterface
+	// XDSClient provides the functionality from the XDSClient required here.
+	XDSClient XDSClient
 	// ModeCallback is the callback to invoke when the serving mode changes.
 	ModeCallback ServingModeCallback
 }
@@ -152,7 +152,7 @@ type listenerWrapper struct {
 
 	name          string
 	xdsCredsInUse bool
-	xdsC          XDSClientInterface
+	xdsC          XDSClient
 	cancelWatch   func()
 	modeCallback  ServingModeCallback
 
@@ -168,7 +168,7 @@ type listenerWrapper struct {
 	// instead of a vanilla channel simplifies the update handler as it need not
 	// keep track of whether the received update is the first one or not.
 	goodUpdate *grpcsync.Event
-	// A small race exists in the xdsClient code between the receipt of an xDS
+	// A small race exists in the XDSClient code between the receipt of an xDS
 	// response and the user cancelling the associated watch. In this window,
 	// the registered callback may be invoked after the watch is canceled, and
 	// the user is expected to work around this. This event signifies that the
@@ -299,14 +299,14 @@ func (l *listenerWrapper) handleListenerUpdate(update xdsclient.ListenerUpdate, 
 
 	// Make sure that the socket address on the received Listener resource
 	// matches the address of the net.Listener passed to us by the user. This
-	// check is done here instead of at the xdsClient layer because of the
+	// check is done here instead of at the XDSClient layer because of the
 	// following couple of reasons:
-	// - xdsClient cannot know the listening address of every listener in the
+	// - XDSClient cannot know the listening address of every listener in the
 	//   system, and hence cannot perform this check.
 	// - this is a very context-dependent check and only the server has the
 	//   appropriate context to perform this check.
 	//
-	// What this means is that the xdsClient has ACKed a resource which can push
+	// What this means is that the XDSClient has ACKed a resource which can push
 	// the server into a "not serving" mode. This is not ideal, but this is
 	// what we have decided to do. See gRPC A36 for more details.
 	ilc := update.InboundListenerCfg

--- a/xds/internal/server/listener_wrapper_test.go
+++ b/xds/internal/server/listener_wrapper_test.go
@@ -156,7 +156,7 @@ func (fc *fakeConn) Close() error {
 func newListenerWrapper(t *testing.T) (*listenerWrapper, <-chan struct{}, *fakeclient.Client, *fakeListener, func()) {
 	t.Helper()
 
-	// Create a listener wrapper with a fake listener and fake xdsClient and
+	// Create a listener wrapper with a fake listener and fake XDSClient and
 	// verify that it extracts the host and port from the passed in listener.
 	lis := &fakeListener{
 		acceptCh: make(chan connAndErr, 1),

--- a/xds/server_test.go
+++ b/xds/server_test.go
@@ -133,7 +133,7 @@ func (s) TestNewServer(t *testing.T) {
 			wantServerOpts := len(test.serverOpts) + 2
 
 			origNewGRPCServer := newGRPCServer
-			newGRPCServer = func(opts ...grpc.ServerOption) grpcServerInterface {
+			newGRPCServer = func(opts ...grpc.ServerOption) grpcServer {
 				if got := len(opts); got != wantServerOpts {
 					t.Fatalf("%d ServerOptions passed to grpc.Server, want %d", got, wantServerOpts)
 				}
@@ -161,7 +161,7 @@ func (s) TestRegisterService(t *testing.T) {
 	fs := newFakeGRPCServer()
 
 	origNewGRPCServer := newGRPCServer
-	newGRPCServer = func(opts ...grpc.ServerOption) grpcServerInterface { return fs }
+	newGRPCServer = func(opts ...grpc.ServerOption) grpcServer { return fs }
 	defer func() { newGRPCServer = origNewGRPCServer }()
 
 	s := NewGRPCServer()
@@ -247,7 +247,7 @@ func (p *fakeProvider) Close() {
 func setupOverrides() (*fakeGRPCServer, *testutils.Channel, func()) {
 	clientCh := testutils.NewChannel()
 	origNewXDSClient := newXDSClient
-	newXDSClient = func() (xdsClientInterface, error) {
+	newXDSClient = func() (xdsClient, error) {
 		c := fakeclient.NewClient()
 		c.SetBootstrapConfig(&bootstrap.Config{
 			BalancerName:                       "dummyBalancer",
@@ -262,7 +262,7 @@ func setupOverrides() (*fakeGRPCServer, *testutils.Channel, func()) {
 
 	fs := newFakeGRPCServer()
 	origNewGRPCServer := newGRPCServer
-	newGRPCServer = func(opts ...grpc.ServerOption) grpcServerInterface { return fs }
+	newGRPCServer = func(opts ...grpc.ServerOption) grpcServer { return fs }
 
 	return fs, clientCh, func() {
 		newXDSClient = origNewXDSClient
@@ -277,7 +277,7 @@ func setupOverrides() (*fakeGRPCServer, *testutils.Channel, func()) {
 func setupOverridesForXDSCreds(includeCertProviderCfg bool) (*testutils.Channel, func()) {
 	clientCh := testutils.NewChannel()
 	origNewXDSClient := newXDSClient
-	newXDSClient = func() (xdsClientInterface, error) {
+	newXDSClient = func() (xdsClient, error) {
 		c := fakeclient.NewClient()
 		bc := &bootstrap.Config{
 			BalancerName:                       "dummyBalancer",
@@ -544,7 +544,7 @@ func (s) TestServeBootstrapConfigInvalid(t *testing.T) {
 			// xdsClient with the specified bootstrap configuration.
 			clientCh := testutils.NewChannel()
 			origNewXDSClient := newXDSClient
-			newXDSClient = func() (xdsClientInterface, error) {
+			newXDSClient = func() (xdsClient, error) {
 				c := fakeclient.NewClient()
 				c.SetBootstrapConfig(test.bootstrapConfig)
 				clientCh.Send(c)
@@ -587,7 +587,7 @@ func (s) TestServeBootstrapConfigInvalid(t *testing.T) {
 // verifies that Server() exits with a non-nil error.
 func (s) TestServeNewClientFailure(t *testing.T) {
 	origNewXDSClient := newXDSClient
-	newXDSClient = func() (xdsClientInterface, error) {
+	newXDSClient = func() (xdsClient, error) {
 		return nil, errors.New("xdsClient creation failed")
 	}
 	defer func() { newXDSClient = origNewXDSClient }()


### PR DESCRIPTION
Types aren't supposed to be named by their types, generally.  From #4479.

Should I revert `xds/internal/balancer/eds/**` to avoid conflicting with your other PR?

RELEASE NOTES: none