### PR TITLE
xds: add HashPolicy fields to RDS update

### DIFF
--- a/clientconn.go
+++ b/clientconn.go
@@ -711,7 +711,12 @@ func (cc *ClientConn) switchBalancer(name string) {
 		return
 	}
 	if cc.balancerWrapper != nil {
+		// Don't hold cc.mu while closing the balancers. The balancers may call
+		// methods that require cc.mu (e.g. cc.NewSubConn()). Holding the mutex
+		// would cause a deadlock in that case.
+		cc.mu.Unlock()
 		cc.balancerWrapper.close()
+		cc.mu.Lock()
 	}
 
 	builder := balancer.Get(name)

--- a/clientconn_test.go
+++ b/clientconn_test.go
@@ -735,16 +735,15 @@ func (s) TestClientUpdatesParamsAfterGoAway(t *testing.T) {
 		time.Sleep(10 * time.Millisecond)
 		cc.mu.RLock()
 		v := cc.mkp.Time
+		cc.mu.RUnlock()
 		if v == 20*time.Second {
 			// Success
-			cc.mu.RUnlock()
 			return
 		}
 		if ctx.Err() != nil {
 			// Timeout
 			t.Fatalf("cc.dopts.copts.Keepalive.Time = %v , want 20s", v)
 		}
-		cc.mu.RUnlock()
 	}
 }
 

--- a/internal/grpcrand/grpcrand.go
+++ b/internal/grpcrand/grpcrand.go
@@ -31,26 +31,30 @@ var (
 	mu sync.Mutex
 )
 
+// Int implements rand.Int on the grpcrand global source.
+func Int() int {
+	mu.Lock()
+	defer mu.Unlock()
+	return r.Int()
+}
+
 // Int63n implements rand.Int63n on the grpcrand global source.
 func Int63n(n int64) int64 {
 	mu.Lock()
-	res := r.Int63n(n)
-	mu.Unlock()
-	return res
+	defer mu.Unlock()
+	return r.Int63n(n)
 }
 
 // Intn implements rand.Intn on the grpcrand global source.
 func Intn(n int) int {
 	mu.Lock()
-	res := r.Intn(n)
-	mu.Unlock()
-	return res
+	defer mu.Unlock()
+	return r.Intn(n)
 }
 
 // Float64 implements rand.Float64 on the grpcrand global source.
 func Float64() float64 {
 	mu.Lock()
-	res := r.Float64()
-	mu.Unlock()
-	return res
+	defer mu.Unlock()
+	return r.Float64()
 }

--- a/internal/xds/env/env.go
+++ b/internal/xds/env/env.go
@@ -39,9 +39,6 @@ const (
 	// When both bootstrap FileName and FileContent are set, FileName is used.
 	BootstrapFileContentEnv = "GRPC_XDS_BOOTSTRAP_CONFIG"
 
-	circuitBreakingSupportEnv    = "GRPC_XDS_EXPERIMENTAL_CIRCUIT_BREAKING"
-	timeoutSupportEnv            = "GRPC_XDS_EXPERIMENTAL_ENABLE_TIMEOUT"
-	faultInjectionSupportEnv     = "GRPC_XDS_EXPERIMENTAL_FAULT_INJECTION"
 	clientSideSecuritySupportEnv = "GRPC_XDS_EXPERIMENTAL_SECURITY_SUPPORT"
 	aggregateAndDNSSupportEnv    = "GRPC_XDS_EXPERIMENTAL_ENABLE_AGGREGATE_AND_LOGICAL_DNS_CLUSTER"
 
@@ -63,17 +60,6 @@ var (
 	// When both bootstrap FileName and FileContent are set, FileName is used.
 	BootstrapFileContent = os.Getenv(BootstrapFileContentEnv)
 
-	// CircuitBreakingSupport indicates whether circuit breaking support is
-	// enabled, which can be disabled by setting the environment variable
-	// "GRPC_XDS_EXPERIMENTAL_CIRCUIT_BREAKING" to "false".
-	CircuitBreakingSupport = !strings.EqualFold(os.Getenv(circuitBreakingSupportEnv), "false")
-	// TimeoutSupport indicates whether support for max_stream_duration in
-	// route actions is enabled.  This can be disabled by setting the
-	// environment variable "GRPC_XDS_EXPERIMENTAL_ENABLE_TIMEOUT" to "false".
-	TimeoutSupport = !strings.EqualFold(os.Getenv(timeoutSupportEnv), "false")
-	// FaultInjectionSupport is used to control both fault injection and HTTP
-	// filter support.
-	FaultInjectionSupport = !strings.EqualFold(os.Getenv(faultInjectionSupportEnv), "false")
 	// ClientSideSecuritySupport is used to control processing of security
 	// configuration on the client-side.
 	//

--- a/vet.sh
+++ b/vet.sh
@@ -32,26 +32,14 @@ PATH="${HOME}/go/bin:${GOROOT}/bin:${PATH}"
 go version
 
 if [[ "$1" = "-install" ]]; then
-  # Check for module support
-  if go help mod >& /dev/null; then
-    # Install the pinned versions as defined in module tools.
-    pushd ./test/tools
-    go install \
-      golang.org/x/lint/golint \
-      golang.org/x/tools/cmd/goimports \
-      honnef.co/go/tools/cmd/staticcheck \
-      github.com/client9/misspell/cmd/misspell
-    popd
-  else
-    # Ye olde `go get` incantation.
-    # Note: this gets the latest version of all tools (vs. the pinned versions
-    # with Go modules).
-    go get -u \
-      golang.org/x/lint/golint \
-      golang.org/x/tools/cmd/goimports \
-      honnef.co/go/tools/cmd/staticcheck \
-      github.com/client9/misspell/cmd/misspell
-  fi
+  # Install the pinned versions as defined in module tools.
+  pushd ./test/tools
+  go install \
+    golang.org/x/lint/golint \
+    golang.org/x/tools/cmd/goimports \
+    honnef.co/go/tools/cmd/staticcheck \
+    github.com/client9/misspell/cmd/misspell
+  popd
   if [[ -z "${VET_SKIP_PROTO}" ]]; then
     if [[ "${TRAVIS}" = "true" ]]; then
       PROTOBUF_VERSION=3.14.0

--- a/xds/googledirectpath/googlec2p.go
+++ b/xds/googledirectpath/googlec2p.go
@@ -35,6 +35,7 @@ import (
 	"google.golang.org/grpc/grpclog"
 	"google.golang.org/grpc/internal/googlecloud"
 	internalgrpclog "google.golang.org/grpc/internal/grpclog"
+	"google.golang.org/grpc/internal/grpcrand"
 	"google.golang.org/grpc/internal/xds/env"
 	"google.golang.org/grpc/resolver"
 	_ "google.golang.org/grpc/xds" // To register xds resolvers and balancers.
@@ -152,13 +153,15 @@ var ipv6EnabledMetadata = &structpb.Struct{
 	},
 }
 
+var id = fmt.Sprintf("C2P-%d", grpcrand.Int())
+
 // newNode makes a copy of defaultNode, and populate it's Metadata and
 // Locality fields.
 func newNode(zone string, ipv6Capable bool) *v3corepb.Node {
 	ret := &v3corepb.Node{
 		// Not all required fields are set in defaultNote. Metadata will be set
 		// if ipv6 is enabled. Locality will be set to the value from metadata.
-		Id:                   "C2P",
+		Id:                   id,
 		UserAgentName:        gRPCUserAgentName,
 		UserAgentVersionType: &v3corepb.Node_UserAgentVersion{UserAgentVersion: grpc.Version},
 		ClientFeatures:       []string{clientFeatureNoOverprovisioning},

--- a/xds/googledirectpath/googlec2p.go
+++ b/xds/googledirectpath/googlec2p.go
@@ -62,15 +62,11 @@ const (
 	dnsName, xdsName = "dns", "xds"
 )
 
-type xdsClient interface {
-	Close()
-}
-
 // For overriding in unittests.
 var (
 	onGCE = googlecloud.OnGCE
 
-	newClientWithConfig = func(config *bootstrap.Config) (xdsClient, error) {
+	newClientWithConfig = func(config *bootstrap.Config) (xdsclient.XDSClient, error) {
 		return xdsclient.NewWithConfig(config)
 	}
 
@@ -139,7 +135,7 @@ func (c2pResolverBuilder) Scheme() string {
 
 type c2pResolver struct {
 	resolver.Resolver
-	client xdsClient
+	client xdsclient.XDSClient
 }
 
 func (r *c2pResolver) Close() {

--- a/xds/googledirectpath/googlec2p_test.go
+++ b/xds/googledirectpath/googlec2p_test.go
@@ -32,6 +32,7 @@ import (
 	"google.golang.org/grpc/internal/xds/env"
 	"google.golang.org/grpc/resolver"
 	"google.golang.org/grpc/xds/internal/version"
+	"google.golang.org/grpc/xds/internal/xdsclient"
 	"google.golang.org/grpc/xds/internal/xdsclient/bootstrap"
 	"google.golang.org/protobuf/testing/protocmp"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -130,6 +131,7 @@ func TestBuildNotOnGCE(t *testing.T) {
 }
 
 type testXDSClient struct {
+	xdsclient.XDSClient
 	closed chan struct{}
 }
 
@@ -177,7 +179,7 @@ func TestBuildXDS(t *testing.T) {
 
 			configCh := make(chan *bootstrap.Config, 1)
 			oldNewClient := newClientWithConfig
-			newClientWithConfig = func(config *bootstrap.Config) (xdsClient, error) {
+			newClientWithConfig = func(config *bootstrap.Config) (xdsclient.XDSClient, error) {
 				configCh <- config
 				return tXDSClient, nil
 			}

--- a/xds/googledirectpath/googlec2p_test.go
+++ b/xds/googledirectpath/googlec2p_test.go
@@ -194,7 +194,7 @@ func TestBuildXDS(t *testing.T) {
 			}
 
 			wantNode := &v3corepb.Node{
-				Id:                   "C2P",
+				Id:                   id,
 				Metadata:             nil,
 				Locality:             &v3corepb.Locality{Zone: testZone},
 				UserAgentName:        gRPCUserAgentName,

--- a/xds/internal/balancer/cdsbalancer/cdsbalancer.go
+++ b/xds/internal/balancer/cdsbalancer/cdsbalancer.go
@@ -36,7 +36,6 @@ import (
 	"google.golang.org/grpc/serviceconfig"
 	"google.golang.org/grpc/xds/internal/balancer/edsbalancer"
 	"google.golang.org/grpc/xds/internal/xdsclient"
-	"google.golang.org/grpc/xds/internal/xdsclient/bootstrap"
 )
 
 const (
@@ -59,7 +58,6 @@ var (
 		// not deal with subConns.
 		return builder.Build(cc, opts), nil
 	}
-	newXDSClient  func() (xdsClient, error)
 	buildProvider = buildProviderFunc
 )
 
@@ -84,17 +82,6 @@ func (bb) Build(cc balancer.ClientConn, opts balancer.BuildOptions) balancer.Bal
 	}
 	b.logger = prefixLogger((b))
 	b.logger.Infof("Created")
-
-	if newXDSClient != nil {
-		// For tests
-		client, err := newXDSClient()
-		if err != nil {
-			b.logger.Errorf("failed to create xds-client: %v", err)
-			return nil
-		}
-		b.xdsClient = client
-	}
-
 	var creds credentials.TransportCredentials
 	switch {
 	case opts.DialCreds != nil:
@@ -137,14 +124,6 @@ func (bb) ParseConfig(c json.RawMessage) (serviceconfig.LoadBalancingConfig, err
 	return &cfg, nil
 }
 
-// xdsClient contains methods from xdsClient.Client which are used by
-// the cdsBalancer. This will be faked out in unittests.
-type xdsClient interface {
-	WatchCluster(string, func(xdsclient.ClusterUpdate, error)) func()
-	BootstrapConfig() *bootstrap.Config
-	Close()
-}
-
 // ccUpdate wraps a clientConn update received from gRPC (pushed from the
 // xdsResolver). A valid clusterName causes the cdsBalancer to register a CDS
 // watcher with the xdsClient, while a non-nil error causes it to cancel the
@@ -184,7 +163,7 @@ type cdsBalancer struct {
 	ccw            *ccWrapper            // ClientConn interface passed to child LB.
 	bOpts          balancer.BuildOptions // BuildOptions passed to child LB.
 	updateCh       *buffer.Unbounded     // Channel for gRPC and xdsClient updates.
-	xdsClient      xdsClient             // xDS client to watch Cluster resource.
+	xdsClient      xdsclient.XDSClient   // xDS client to watch Cluster resource.
 	cancelWatch    func()                // Cluster watch cancel func.
 	edsLB          balancer.Balancer     // EDS child policy.
 	clusterToWatch string
@@ -361,15 +340,8 @@ func (b *cdsBalancer) handleWatchUpdate(update *watchUpdate) {
 		lbCfg.LrsLoadReportingServerName = new(string)
 
 	}
-	resolverState := resolver.State{}
-	// Include the xds client for the child LB policies to use.  For unit
-	// tests, b.xdsClient may not be a full *xdsclient.Client, but it will
-	// always be in production.
-	if c, ok := b.xdsClient.(*xdsclient.Client); ok {
-		resolverState = xdsclient.SetClient(resolverState, c)
-	}
 	ccState := balancer.ClientConnState{
-		ResolverState:  resolverState,
+		ResolverState:  xdsclient.SetClient(resolver.State{}, b.xdsClient),
 		BalancerConfig: lbCfg,
 	}
 	if err := b.edsLB.UpdateClientConnState(ccState); err != nil {
@@ -406,9 +378,6 @@ func (b *cdsBalancer) run() {
 			if b.edsLB != nil {
 				b.edsLB.Close()
 				b.edsLB = nil
-			}
-			if newXDSClient != nil {
-				b.xdsClient.Close()
 			}
 			if b.cachedRoot != nil {
 				b.cachedRoot.Close()

--- a/xds/internal/balancer/cdsbalancer/cdsbalancer_test.go
+++ b/xds/internal/balancer/cdsbalancer/cdsbalancer_test.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"google.golang.org/grpc/attributes"
 	"google.golang.org/grpc/balancer"
 	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/internal"
@@ -129,7 +128,10 @@ func (tb *testEDSBalancer) waitForClientConnUpdate(ctx context.Context, wantCCS 
 		return err
 	}
 	gotCCS := ccs.(balancer.ClientConnState)
-	if !cmp.Equal(gotCCS, wantCCS, cmpopts.IgnoreUnexported(attributes.Attributes{})) {
+	if xdsclient.FromResolverState(gotCCS.ResolverState) == nil {
+		return fmt.Errorf("want resolver state with XDSClient attached, got one without")
+	}
+	if !cmp.Equal(gotCCS, wantCCS, cmpopts.IgnoreFields(resolver.State{}, "Attributes")) {
 		return fmt.Errorf("received ClientConnState: %+v, want %+v", gotCCS, wantCCS)
 	}
 	return nil
@@ -173,7 +175,7 @@ func (tb *testEDSBalancer) waitForClose(ctx context.Context) error {
 
 // cdsCCS is a helper function to construct a good update passed from the
 // xdsResolver to the cdsBalancer.
-func cdsCCS(cluster string) balancer.ClientConnState {
+func cdsCCS(cluster string, xdsC xdsclient.XDSClient) balancer.ClientConnState {
 	const cdsLBConfig = `{
       "loadBalancingConfig":[
         {
@@ -185,9 +187,9 @@ func cdsCCS(cluster string) balancer.ClientConnState {
     }`
 	jsonSC := fmt.Sprintf(cdsLBConfig, cluster)
 	return balancer.ClientConnState{
-		ResolverState: resolver.State{
+		ResolverState: xdsclient.SetClient(resolver.State{
 			ServiceConfig: internal.ParseServiceConfigForTesting.(func(string) *serviceconfig.ParseResult)(jsonSC),
-		},
+		}, xdsC),
 		BalancerConfig: &lbConfig{ClusterName: clusterName},
 	}
 }
@@ -211,11 +213,7 @@ func edsCCS(service string, countMax *uint32, enableLRS bool) balancer.ClientCon
 // newEDSBalancer function to return it), and also returns a cleanup function.
 func setup(t *testing.T) (*fakeclient.Client, *cdsBalancer, *testEDSBalancer, *xdstestutils.TestClientConn, func()) {
 	t.Helper()
-
 	xdsC := fakeclient.NewClient()
-	oldNewXDSClient := newXDSClient
-	newXDSClient = func() (xdsClient, error) { return xdsC, nil }
-
 	builder := balancer.Get(cdsName)
 	if builder == nil {
 		t.Fatalf("balancer.Get(%q) returned nil", cdsName)
@@ -232,7 +230,7 @@ func setup(t *testing.T) (*fakeclient.Client, *cdsBalancer, *testEDSBalancer, *x
 
 	return xdsC, cdsB.(*cdsBalancer), edsB, tcc, func() {
 		newEDSBalancer = oldEDSBalancerBuilder
-		newXDSClient = oldNewXDSClient
+		xdsC.Close()
 	}
 }
 
@@ -242,7 +240,7 @@ func setupWithWatch(t *testing.T) (*fakeclient.Client, *cdsBalancer, *testEDSBal
 	t.Helper()
 
 	xdsC, cdsB, edsB, tcc, cancel := setup(t)
-	if err := cdsB.UpdateClientConnState(cdsCCS(clusterName)); err != nil {
+	if err := cdsB.UpdateClientConnState(cdsCCS(clusterName, xdsC)); err != nil {
 		t.Fatalf("cdsBalancer.UpdateClientConnState failed with error: %v", err)
 	}
 
@@ -262,6 +260,9 @@ func setupWithWatch(t *testing.T) (*fakeclient.Client, *cdsBalancer, *testEDSBal
 // cdsBalancer with different inputs and verifies that the CDS watch API on the
 // provided xdsClient is invoked appropriately.
 func (s) TestUpdateClientConnState(t *testing.T) {
+	xdsC := fakeclient.NewClient()
+	defer xdsC.Close()
+
 	tests := []struct {
 		name        string
 		ccs         balancer.ClientConnState
@@ -280,14 +281,14 @@ func (s) TestUpdateClientConnState(t *testing.T) {
 		},
 		{
 			name:        "happy-good-case",
-			ccs:         cdsCCS(clusterName),
+			ccs:         cdsCCS(clusterName, xdsC),
 			wantCluster: clusterName,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			xdsC, cdsB, _, _, cancel := setup(t)
+			_, cdsB, _, _, cancel := setup(t)
 			defer func() {
 				cancel()
 				cdsB.Close()
@@ -324,7 +325,7 @@ func (s) TestUpdateClientConnStateWithSameState(t *testing.T) {
 	}()
 
 	// This is the same clientConn update sent in setupWithWatch().
-	if err := cdsB.UpdateClientConnState(cdsCCS(clusterName)); err != nil {
+	if err := cdsB.UpdateClientConnState(cdsCCS(clusterName, xdsC)); err != nil {
 		t.Fatalf("cdsBalancer.UpdateClientConnState failed with error: %v", err)
 	}
 	// The above update should not result in a new watch being registered.
@@ -660,7 +661,7 @@ func (s) TestClose(t *testing.T) {
 
 	// Make sure that the UpdateClientConnState() method on the CDS balancer
 	// returns error.
-	if err := cdsB.UpdateClientConnState(cdsCCS(clusterName)); err != errBalancerClosed {
+	if err := cdsB.UpdateClientConnState(cdsCCS(clusterName, xdsC)); err != errBalancerClosed {
 		t.Fatalf("UpdateClientConnState() after close returned %v, want %v", err, errBalancerClosed)
 	}
 

--- a/xds/internal/balancer/cdsbalancer/cluster_handler.go
+++ b/xds/internal/balancer/cdsbalancer/cluster_handler.go
@@ -40,7 +40,7 @@ type clusterHandler struct {
 	// CDS Balancer cares about is the most recent update.
 	updateChannel chan clusterHandlerUpdate
 
-	xdsClient xdsClient
+	xdsClient xdsclient.XDSClient
 }
 
 func (ch *clusterHandler) updateRootCluster(rootClusterName string) {
@@ -112,7 +112,7 @@ type clusterNode struct {
 
 // CreateClusterNode creates a cluster node from a given clusterName. This will
 // also start the watch for that cluster.
-func createClusterNode(clusterName string, xdsClient xdsClient, topLevelHandler *clusterHandler) *clusterNode {
+func createClusterNode(clusterName string, xdsClient xdsclient.XDSClient, topLevelHandler *clusterHandler) *clusterNode {
 	c := &clusterNode{
 		clusterHandler: topLevelHandler,
 	}

--- a/xds/internal/balancer/clusterimpl/balancer_test.go
+++ b/xds/internal/balancer/clusterimpl/balancer_test.go
@@ -74,9 +74,7 @@ func init() {
 func TestDropByCategory(t *testing.T) {
 	defer xdsclient.ClearCounterForTesting(testClusterName)
 	xdsC := fakeclient.NewClient()
-	oldNewXDSClient := newXDSClient
-	newXDSClient = func() (xdsClient, error) { return xdsC, nil }
-	defer func() { newXDSClient = oldNewXDSClient }()
+	defer xdsC.Close()
 
 	builder := balancer.Get(Name)
 	cc := testutils.NewTestClientConn(t)
@@ -89,9 +87,7 @@ func TestDropByCategory(t *testing.T) {
 		dropDenominator = 2
 	)
 	if err := b.UpdateClientConnState(balancer.ClientConnState{
-		ResolverState: resolver.State{
-			Addresses: testBackendAddrs,
-		},
+		ResolverState: xdsclient.SetClient(resolver.State{Addresses: testBackendAddrs}, xdsC),
 		BalancerConfig: &LBConfig{
 			Cluster:                 testClusterName,
 			EDSServiceName:          testServiceName,
@@ -176,9 +172,7 @@ func TestDropByCategory(t *testing.T) {
 		dropDenominator2 = 4
 	)
 	if err := b.UpdateClientConnState(balancer.ClientConnState{
-		ResolverState: resolver.State{
-			Addresses: testBackendAddrs,
-		},
+		ResolverState: xdsclient.SetClient(resolver.State{Addresses: testBackendAddrs}, xdsC),
 		BalancerConfig: &LBConfig{
 			Cluster:                 testClusterName,
 			EDSServiceName:          testServiceName,
@@ -232,9 +226,7 @@ func TestDropByCategory(t *testing.T) {
 func TestDropCircuitBreaking(t *testing.T) {
 	defer xdsclient.ClearCounterForTesting(testClusterName)
 	xdsC := fakeclient.NewClient()
-	oldNewXDSClient := newXDSClient
-	newXDSClient = func() (xdsClient, error) { return xdsC, nil }
-	defer func() { newXDSClient = oldNewXDSClient }()
+	defer xdsC.Close()
 
 	builder := balancer.Get(Name)
 	cc := testutils.NewTestClientConn(t)
@@ -243,9 +235,7 @@ func TestDropCircuitBreaking(t *testing.T) {
 
 	var maxRequest uint32 = 50
 	if err := b.UpdateClientConnState(balancer.ClientConnState{
-		ResolverState: resolver.State{
-			Addresses: testBackendAddrs,
-		},
+		ResolverState: xdsclient.SetClient(resolver.State{Addresses: testBackendAddrs}, xdsC),
 		BalancerConfig: &LBConfig{
 			Cluster:                 testClusterName,
 			EDSServiceName:          testServiceName,
@@ -344,9 +334,7 @@ func TestDropCircuitBreaking(t *testing.T) {
 func TestPickerUpdateAfterClose(t *testing.T) {
 	defer xdsclient.ClearCounterForTesting(testClusterName)
 	xdsC := fakeclient.NewClient()
-	oldNewXDSClient := newXDSClient
-	newXDSClient = func() (xdsClient, error) { return xdsC, nil }
-	defer func() { newXDSClient = oldNewXDSClient }()
+	defer xdsC.Close()
 
 	builder := balancer.Get(Name)
 	cc := testutils.NewTestClientConn(t)
@@ -354,9 +342,7 @@ func TestPickerUpdateAfterClose(t *testing.T) {
 
 	var maxRequest uint32 = 50
 	if err := b.UpdateClientConnState(balancer.ClientConnState{
-		ResolverState: resolver.State{
-			Addresses: testBackendAddrs,
-		},
+		ResolverState: xdsclient.SetClient(resolver.State{Addresses: testBackendAddrs}, xdsC),
 		BalancerConfig: &LBConfig{
 			Cluster:               testClusterName,
 			EDSServiceName:        testServiceName,
@@ -389,9 +375,7 @@ func TestPickerUpdateAfterClose(t *testing.T) {
 func TestClusterNameInAddressAttributes(t *testing.T) {
 	defer xdsclient.ClearCounterForTesting(testClusterName)
 	xdsC := fakeclient.NewClient()
-	oldNewXDSClient := newXDSClient
-	newXDSClient = func() (xdsClient, error) { return xdsC, nil }
-	defer func() { newXDSClient = oldNewXDSClient }()
+	defer xdsC.Close()
 
 	builder := balancer.Get(Name)
 	cc := testutils.NewTestClientConn(t)
@@ -399,9 +383,7 @@ func TestClusterNameInAddressAttributes(t *testing.T) {
 	defer b.Close()
 
 	if err := b.UpdateClientConnState(balancer.ClientConnState{
-		ResolverState: resolver.State{
-			Addresses: testBackendAddrs,
-		},
+		ResolverState: xdsclient.SetClient(resolver.State{Addresses: testBackendAddrs}, xdsC),
 		BalancerConfig: &LBConfig{
 			Cluster:        testClusterName,
 			EDSServiceName: testServiceName,
@@ -450,9 +432,7 @@ func TestClusterNameInAddressAttributes(t *testing.T) {
 	const testClusterName2 = "test-cluster-2"
 	var addr2 = resolver.Address{Addr: "2.2.2.2"}
 	if err := b.UpdateClientConnState(balancer.ClientConnState{
-		ResolverState: resolver.State{
-			Addresses: []resolver.Address{addr2},
-		},
+		ResolverState: xdsclient.SetClient(resolver.State{Addresses: []resolver.Address{addr2}}, xdsC),
 		BalancerConfig: &LBConfig{
 			Cluster:        testClusterName2,
 			EDSServiceName: testServiceName,
@@ -480,9 +460,7 @@ func TestClusterNameInAddressAttributes(t *testing.T) {
 func TestReResolution(t *testing.T) {
 	defer xdsclient.ClearCounterForTesting(testClusterName)
 	xdsC := fakeclient.NewClient()
-	oldNewXDSClient := newXDSClient
-	newXDSClient = func() (xdsClient, error) { return xdsC, nil }
-	defer func() { newXDSClient = oldNewXDSClient }()
+	defer xdsC.Close()
 
 	builder := balancer.Get(Name)
 	cc := testutils.NewTestClientConn(t)
@@ -490,9 +468,7 @@ func TestReResolution(t *testing.T) {
 	defer b.Close()
 
 	if err := b.UpdateClientConnState(balancer.ClientConnState{
-		ResolverState: resolver.State{
-			Addresses: testBackendAddrs,
-		},
+		ResolverState: xdsclient.SetClient(resolver.State{Addresses: testBackendAddrs}, xdsC),
 		BalancerConfig: &LBConfig{
 			Cluster:        testClusterName,
 			EDSServiceName: testServiceName,

--- a/xds/internal/balancer/edsbalancer/eds_impl.go
+++ b/xds/internal/balancer/edsbalancer/eds_impl.go
@@ -31,7 +31,6 @@ import (
 	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/internal"
 	"google.golang.org/grpc/internal/grpclog"
-	"google.golang.org/grpc/internal/xds/env"
 	"google.golang.org/grpc/resolver"
 	"google.golang.org/grpc/status"
 	xdsi "google.golang.org/grpc/xds/internal"
@@ -418,9 +417,6 @@ func (edsImpl *edsBalancerImpl) handleSubConnStateChange(sc balancer.SubConn, s 
 
 // updateServiceRequestsConfig handles changes to the circuit breaking configuration.
 func (edsImpl *edsBalancerImpl) updateServiceRequestsConfig(serviceName string, max *uint32) {
-	if !env.CircuitBreakingSupport {
-		return
-	}
 	edsImpl.pickerMu.Lock()
 	var updatePicker bool
 	if edsImpl.serviceRequestsCounter == nil || edsImpl.serviceRequestsCounter.ServiceName != serviceName {

--- a/xds/internal/balancer/edsbalancer/eds_impl_test.go
+++ b/xds/internal/balancer/edsbalancer/eds_impl_test.go
@@ -35,7 +35,6 @@ import (
 	"google.golang.org/grpc/balancer/roundrobin"
 	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/internal/balancer/stub"
-	"google.golang.org/grpc/internal/xds/env"
 	xdsinternal "google.golang.org/grpc/xds/internal"
 	"google.golang.org/grpc/xds/internal/balancer/balancergroup"
 	"google.golang.org/grpc/xds/internal/testutils"
@@ -575,10 +574,6 @@ func (s) TestEDS_UpdateSubBalancerName(t *testing.T) {
 }
 
 func (s) TestEDS_CircuitBreaking(t *testing.T) {
-	origCircuitBreakingSupport := env.CircuitBreakingSupport
-	env.CircuitBreakingSupport = true
-	defer func() { env.CircuitBreakingSupport = origCircuitBreakingSupport }()
-
 	cc := testutils.NewTestClientConn(t)
 	edsb := newEDSBalancerImpl(cc, balancer.BuildOptions{}, nil, nil, nil)
 	edsb.enqueueChildBalancerStateUpdate = edsb.updateState
@@ -812,10 +807,6 @@ func (s) TestDropPicker(t *testing.T) {
 }
 
 func (s) TestEDS_LoadReport(t *testing.T) {
-	origCircuitBreakingSupport := env.CircuitBreakingSupport
-	env.CircuitBreakingSupport = true
-	defer func() { env.CircuitBreakingSupport = origCircuitBreakingSupport }()
-
 	// We create an xdsClientWrapper with a dummy xdsClient which only
 	// implements the LoadStore() method to return the underlying load.Store to
 	// be used.

--- a/xds/internal/balancer/lrs/balancer_test.go
+++ b/xds/internal/balancer/lrs/balancer_test.go
@@ -35,6 +35,7 @@ import (
 	xdsinternal "google.golang.org/grpc/xds/internal"
 	"google.golang.org/grpc/xds/internal/testutils"
 	"google.golang.org/grpc/xds/internal/testutils/fakeclient"
+	"google.golang.org/grpc/xds/internal/xdsclient"
 )
 
 const defaultTestTimeout = 1 * time.Second
@@ -55,9 +56,7 @@ var (
 // server (empty string).
 func TestLoadReporting(t *testing.T) {
 	xdsC := fakeclient.NewClient()
-	oldNewXDSClient := newXDSClient
-	newXDSClient = func() (xdsClient, error) { return xdsC, nil }
-	defer func() { newXDSClient = oldNewXDSClient }()
+	defer xdsC.Close()
 
 	builder := balancer.Get(Name)
 	cc := testutils.NewTestClientConn(t)
@@ -65,9 +64,7 @@ func TestLoadReporting(t *testing.T) {
 	defer lrsB.Close()
 
 	if err := lrsB.UpdateClientConnState(balancer.ClientConnState{
-		ResolverState: resolver.State{
-			Addresses: testBackendAddrs,
-		},
+		ResolverState: xdsclient.SetClient(resolver.State{Addresses: testBackendAddrs}, xdsC),
 		BalancerConfig: &LBConfig{
 			ClusterName:             testClusterName,
 			EDSServiceName:          testServiceName,

--- a/xds/internal/httpfilter/fault/fault.go
+++ b/xds/internal/httpfilter/fault/fault.go
@@ -33,7 +33,6 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/internal/grpcrand"
 	iresolver "google.golang.org/grpc/internal/resolver"
-	"google.golang.org/grpc/internal/xds/env"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 	"google.golang.org/grpc/xds/internal/httpfilter"
@@ -63,9 +62,7 @@ var statusMap = map[int]codes.Code{
 }
 
 func init() {
-	if env.FaultInjectionSupport {
-		httpfilter.Register(builder{})
-	}
+	httpfilter.Register(builder{})
 }
 
 type builder struct {

--- a/xds/internal/httpfilter/fault/fault_test.go
+++ b/xds/internal/httpfilter/fault/fault_test.go
@@ -40,10 +40,8 @@ import (
 	"google.golang.org/grpc/internal/grpctest"
 	"google.golang.org/grpc/internal/testutils"
 	"google.golang.org/grpc/internal/xds"
-	"google.golang.org/grpc/internal/xds/env"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
-	"google.golang.org/grpc/xds/internal/httpfilter"
 	xtestutils "google.golang.org/grpc/xds/internal/testutils"
 	"google.golang.org/grpc/xds/internal/testutils/e2e"
 	"google.golang.org/protobuf/types/known/wrapperspb"
@@ -138,13 +136,6 @@ func clientSetup(t *testing.T) (*e2e.ManagementServer, string, uint32, func()) {
 		bootstrapCleanup()
 		server.Stop()
 	}
-}
-
-func init() {
-	env.FaultInjectionSupport = true
-	// Manually register to avoid a race between this init and the one that
-	// check the env var to register the fault injection filter.
-	httpfilter.Register(builder{})
 }
 
 func (s) TestFaultInjection_Unary(t *testing.T) {

--- a/xds/internal/resolver/serviceconfig.go
+++ b/xds/internal/resolver/serviceconfig.go
@@ -28,7 +28,6 @@ import (
 	"google.golang.org/grpc/codes"
 	iresolver "google.golang.org/grpc/internal/resolver"
 	"google.golang.org/grpc/internal/wrr"
-	"google.golang.org/grpc/internal/xds/env"
 	"google.golang.org/grpc/status"
 	"google.golang.org/grpc/xds/internal/balancer/clustermanager"
 	"google.golang.org/grpc/xds/internal/httpfilter"
@@ -179,7 +178,7 @@ func (cs *configSelector) SelectConfig(rpcInfo iresolver.RPCInfo) (*iresolver.RP
 		Interceptor: interceptor,
 	}
 
-	if env.TimeoutSupport && rt.maxStreamDuration != 0 {
+	if rt.maxStreamDuration != 0 {
 		config.MethodConfig.Timeout = &rt.maxStreamDuration
 	}
 

--- a/xds/internal/resolver/watch_service.go
+++ b/xds/internal/resolver/watch_service.go
@@ -54,7 +54,7 @@ type ldsConfig struct {
 // Note that during race (e.g. an xDS response is received while the user is
 // calling cancel()), there's a small window where the callback can be called
 // after the watcher is canceled. The caller needs to handle this case.
-func watchService(c xdsClient, serviceName string, cb func(serviceUpdate, error), logger *grpclog.PrefixLogger) (cancel func()) {
+func watchService(c xdsclient.XDSClient, serviceName string, cb func(serviceUpdate, error), logger *grpclog.PrefixLogger) (cancel func()) {
 	w := &serviceUpdateWatcher{
 		logger:      logger,
 		c:           c,
@@ -70,7 +70,7 @@ func watchService(c xdsClient, serviceName string, cb func(serviceUpdate, error)
 // callback at the right time.
 type serviceUpdateWatcher struct {
 	logger      *grpclog.PrefixLogger
-	c           xdsClient
+	c           xdsclient.XDSClient
 	serviceName string
 	ldsCancel   func()
 	serviceCb   func(serviceUpdate, error)

--- a/xds/internal/resolver/xds_resolver.go
+++ b/xds/internal/resolver/xds_resolver.go
@@ -27,10 +27,8 @@ import (
 	"google.golang.org/grpc/internal/grpclog"
 	"google.golang.org/grpc/internal/grpcsync"
 	"google.golang.org/grpc/internal/pretty"
-	"google.golang.org/grpc/resolver"
-	"google.golang.org/grpc/xds/internal/xdsclient/bootstrap"
-
 	iresolver "google.golang.org/grpc/internal/resolver"
+	"google.golang.org/grpc/resolver"
 	"google.golang.org/grpc/xds/internal/xdsclient"
 )
 
@@ -41,21 +39,21 @@ const xdsScheme = "xds"
 // the same time.
 func NewBuilder(config []byte) (resolver.Builder, error) {
 	return &xdsResolverBuilder{
-		newXDSClient: func() (xdsClient, error) {
+		newXDSClient: func() (xdsclient.XDSClient, error) {
 			return xdsclient.NewClientWithBootstrapContents(config)
 		},
 	}, nil
 }
 
 // For overriding in unittests.
-var newXDSClient = func() (xdsClient, error) { return xdsclient.New() }
+var newXDSClient = func() (xdsclient.XDSClient, error) { return xdsclient.New() }
 
 func init() {
 	resolver.Register(&xdsResolverBuilder{})
 }
 
 type xdsResolverBuilder struct {
-	newXDSClient func() (xdsClient, error)
+	newXDSClient func() (xdsclient.XDSClient, error)
 }
 
 // Build helps implement the resolver.Builder interface.
@@ -119,15 +117,6 @@ func (*xdsResolverBuilder) Scheme() string {
 	return xdsScheme
 }
 
-// xdsClient contains methods from xdsClient.Client which are used by
-// the resolver. This will be faked out in unittests.
-type xdsClient interface {
-	WatchListener(serviceName string, cb func(xdsclient.ListenerUpdate, error)) func()
-	WatchRouteConfig(routeName string, cb func(xdsclient.RouteConfigUpdate, error)) func()
-	BootstrapConfig() *bootstrap.Config
-	Close()
-}
-
 // suWithError wraps the ServiceUpdate and error received through a watch API
 // callback, so that it can pushed onto the update channel as a single entity.
 type suWithError struct {
@@ -149,7 +138,7 @@ type xdsResolver struct {
 	logger *grpclog.PrefixLogger
 
 	// The underlying xdsClient which performs all xDS requests and responses.
-	client xdsClient
+	client xdsclient.XDSClient
 	// A channel for the watch API callback to write service updates on to. The
 	// updates are read by the run goroutine and passed on to the ClientConn.
 	updateCh chan suWithError
@@ -196,14 +185,7 @@ func (r *xdsResolver) sendNewServiceConfig(cs *configSelector) bool {
 	state := iresolver.SetConfigSelector(resolver.State{
 		ServiceConfig: r.cc.ParseServiceConfig(string(sc)),
 	}, cs)
-
-	// Include the xds client for the LB policies to use.  For unit tests,
-	// r.client may not be a full *xdsclient.Client, but it will always be in
-	// production.
-	if c, ok := r.client.(*xdsclient.Client); ok {
-		state = xdsclient.SetClient(state, c)
-	}
-	r.cc.UpdateState(state)
+	r.cc.UpdateState(xdsclient.SetClient(state, r.client))
 	return true
 }
 

--- a/xds/internal/resolver/xds_resolver_test.go
+++ b/xds/internal/resolver/xds_resolver_test.go
@@ -281,6 +281,20 @@ func (s) TestXDSResolverWatchCallbackAfterClose(t *testing.T) {
 	}
 }
 
+// TestXDSResolverCloseClosesXDSClient tests that the XDS resolver's Close
+// method closes the XDS client.
+func (s) TestXDSResolverCloseClosesXDSClient(t *testing.T) {
+	xdsC := fakeclient.NewClient()
+	xdsR, _, cancel := testSetup(t, setupOpts{
+		xdsClientFunc: func() (xdsClient, error) { return xdsC, nil },
+	})
+	defer cancel()
+	xdsR.Close()
+	if !xdsC.Closed.HasFired() {
+		t.Fatalf("xds client not closed by xds resolver Close method")
+	}
+}
+
 // TestXDSResolverBadServiceUpdate tests the case the xdsClient returns a bad
 // service update.
 func (s) TestXDSResolverBadServiceUpdate(t *testing.T) {

--- a/xds/internal/resolver/xds_resolver_test.go
+++ b/xds/internal/resolver/xds_resolver_test.go
@@ -114,19 +114,19 @@ func newTestClientConn() *testClientConn {
 func (s) TestResolverBuilder(t *testing.T) {
 	tests := []struct {
 		name          string
-		xdsClientFunc func() (xdsClient, error)
+		xdsClientFunc func() (xdsclient.XDSClient, error)
 		wantErr       bool
 	}{
 		{
 			name: "simple-good",
-			xdsClientFunc: func() (xdsClient, error) {
+			xdsClientFunc: func() (xdsclient.XDSClient, error) {
 				return fakeclient.NewClient(), nil
 			},
 			wantErr: false,
 		},
 		{
 			name: "newXDSClient-throws-error",
-			xdsClientFunc: func() (xdsClient, error) {
+			xdsClientFunc: func() (xdsclient.XDSClient, error) {
 				return nil, errors.New("newXDSClient-throws-error")
 			},
 			wantErr: true,
@@ -167,7 +167,7 @@ func (s) TestResolverBuilder_xdsCredsBootstrapMismatch(t *testing.T) {
 	// Fake out the xdsClient creation process by providing a fake, which does
 	// not have any certificate provider configuration.
 	oldClientMaker := newXDSClient
-	newXDSClient = func() (xdsClient, error) {
+	newXDSClient = func() (xdsclient.XDSClient, error) {
 		fc := fakeclient.NewClient()
 		fc.SetBootstrapConfig(&bootstrap.Config{})
 		return fc, nil
@@ -194,7 +194,7 @@ func (s) TestResolverBuilder_xdsCredsBootstrapMismatch(t *testing.T) {
 }
 
 type setupOpts struct {
-	xdsClientFunc func() (xdsClient, error)
+	xdsClientFunc func() (xdsclient.XDSClient, error)
 }
 
 func testSetup(t *testing.T, opts setupOpts) (*xdsResolver, *testClientConn, func()) {
@@ -254,7 +254,7 @@ func waitForWatchRouteConfig(ctx context.Context, t *testing.T, xdsC *fakeclient
 func (s) TestXDSResolverWatchCallbackAfterClose(t *testing.T) {
 	xdsC := fakeclient.NewClient()
 	xdsR, tcc, cancel := testSetup(t, setupOpts{
-		xdsClientFunc: func() (xdsClient, error) { return xdsC, nil },
+		xdsClientFunc: func() (xdsclient.XDSClient, error) { return xdsC, nil },
 	})
 	defer cancel()
 
@@ -286,7 +286,7 @@ func (s) TestXDSResolverWatchCallbackAfterClose(t *testing.T) {
 func (s) TestXDSResolverCloseClosesXDSClient(t *testing.T) {
 	xdsC := fakeclient.NewClient()
 	xdsR, _, cancel := testSetup(t, setupOpts{
-		xdsClientFunc: func() (xdsClient, error) { return xdsC, nil },
+		xdsClientFunc: func() (xdsclient.XDSClient, error) { return xdsC, nil },
 	})
 	defer cancel()
 	xdsR.Close()
@@ -300,7 +300,7 @@ func (s) TestXDSResolverCloseClosesXDSClient(t *testing.T) {
 func (s) TestXDSResolverBadServiceUpdate(t *testing.T) {
 	xdsC := fakeclient.NewClient()
 	xdsR, tcc, cancel := testSetup(t, setupOpts{
-		xdsClientFunc: func() (xdsClient, error) { return xdsC, nil },
+		xdsClientFunc: func() (xdsclient.XDSClient, error) { return xdsC, nil },
 	})
 	defer xdsR.Close()
 	defer cancel()
@@ -326,7 +326,7 @@ func (s) TestXDSResolverBadServiceUpdate(t *testing.T) {
 func (s) TestXDSResolverGoodServiceUpdate(t *testing.T) {
 	xdsC := fakeclient.NewClient()
 	xdsR, tcc, cancel := testSetup(t, setupOpts{
-		xdsClientFunc: func() (xdsClient, error) { return xdsC, nil },
+		xdsClientFunc: func() (xdsclient.XDSClient, error) { return xdsC, nil },
 	})
 	defer xdsR.Close()
 	defer cancel()
@@ -460,7 +460,7 @@ func (s) TestXDSResolverGoodServiceUpdate(t *testing.T) {
 func (s) TestXDSResolverRemovedWithRPCs(t *testing.T) {
 	xdsC := fakeclient.NewClient()
 	xdsR, tcc, cancel := testSetup(t, setupOpts{
-		xdsClientFunc: func() (xdsClient, error) { return xdsC, nil },
+		xdsClientFunc: func() (xdsclient.XDSClient, error) { return xdsC, nil },
 	})
 	defer cancel()
 	defer xdsR.Close()
@@ -520,7 +520,7 @@ func (s) TestXDSResolverRemovedWithRPCs(t *testing.T) {
 func (s) TestXDSResolverRemovedResource(t *testing.T) {
 	xdsC := fakeclient.NewClient()
 	xdsR, tcc, cancel := testSetup(t, setupOpts{
-		xdsClientFunc: func() (xdsClient, error) { return xdsC, nil },
+		xdsClientFunc: func() (xdsclient.XDSClient, error) { return xdsC, nil },
 	})
 	defer cancel()
 	defer xdsR.Close()
@@ -628,7 +628,7 @@ func (s) TestXDSResolverRemovedResource(t *testing.T) {
 func (s) TestXDSResolverWRR(t *testing.T) {
 	xdsC := fakeclient.NewClient()
 	xdsR, tcc, cancel := testSetup(t, setupOpts{
-		xdsClientFunc: func() (xdsClient, error) { return xdsC, nil },
+		xdsClientFunc: func() (xdsclient.XDSClient, error) { return xdsC, nil },
 	})
 	defer xdsR.Close()
 	defer cancel()
@@ -689,7 +689,7 @@ func (s) TestXDSResolverMaxStreamDuration(t *testing.T) {
 	defer func(old bool) { env.TimeoutSupport = old }(env.TimeoutSupport)
 	xdsC := fakeclient.NewClient()
 	xdsR, tcc, cancel := testSetup(t, setupOpts{
-		xdsClientFunc: func() (xdsClient, error) { return xdsC, nil },
+		xdsClientFunc: func() (xdsclient.XDSClient, error) { return xdsC, nil },
 	})
 	defer xdsR.Close()
 	defer cancel()
@@ -792,7 +792,7 @@ func (s) TestXDSResolverMaxStreamDuration(t *testing.T) {
 func (s) TestXDSResolverDelayedOnCommitted(t *testing.T) {
 	xdsC := fakeclient.NewClient()
 	xdsR, tcc, cancel := testSetup(t, setupOpts{
-		xdsClientFunc: func() (xdsClient, error) { return xdsC, nil },
+		xdsClientFunc: func() (xdsclient.XDSClient, error) { return xdsC, nil },
 	})
 	defer xdsR.Close()
 	defer cancel()
@@ -941,7 +941,7 @@ func (s) TestXDSResolverDelayedOnCommitted(t *testing.T) {
 func (s) TestXDSResolverGoodUpdateAfterError(t *testing.T) {
 	xdsC := fakeclient.NewClient()
 	xdsR, tcc, cancel := testSetup(t, setupOpts{
-		xdsClientFunc: func() (xdsClient, error) { return xdsC, nil },
+		xdsClientFunc: func() (xdsclient.XDSClient, error) { return xdsC, nil },
 	})
 	defer xdsR.Close()
 	defer cancel()
@@ -995,7 +995,7 @@ func (s) TestXDSResolverGoodUpdateAfterError(t *testing.T) {
 func (s) TestXDSResolverResourceNotFoundError(t *testing.T) {
 	xdsC := fakeclient.NewClient()
 	xdsR, tcc, cancel := testSetup(t, setupOpts{
-		xdsClientFunc: func() (xdsClient, error) { return xdsC, nil },
+		xdsClientFunc: func() (xdsclient.XDSClient, error) { return xdsC, nil },
 	})
 	defer xdsR.Close()
 	defer cancel()
@@ -1041,7 +1041,7 @@ func (s) TestXDSResolverResourceNotFoundError(t *testing.T) {
 func (s) TestXDSResolverMultipleLDSUpdates(t *testing.T) {
 	xdsC := fakeclient.NewClient()
 	xdsR, tcc, cancel := testSetup(t, setupOpts{
-		xdsClientFunc: func() (xdsClient, error) { return xdsC, nil },
+		xdsClientFunc: func() (xdsclient.XDSClient, error) { return xdsC, nil },
 	})
 	defer xdsR.Close()
 	defer cancel()
@@ -1216,7 +1216,7 @@ func (s) TestXDSResolverHTTPFilters(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			xdsC := fakeclient.NewClient()
 			xdsR, tcc, cancel := testSetup(t, setupOpts{
-				xdsClientFunc: func() (xdsClient, error) { return xdsC, nil },
+				xdsClientFunc: func() (xdsclient.XDSClient, error) { return xdsC, nil },
 			})
 			defer xdsR.Close()
 			defer cancel()

--- a/xds/internal/testutils/fakeclient/client.go
+++ b/xds/internal/testutils/fakeclient/client.go
@@ -32,6 +32,11 @@ import (
 // Client is a fake implementation of an xds client. It exposes a bunch of
 // channels to signal the occurrence of various events.
 type Client struct {
+	// Embed XDSClient so this fake client implements the interface, but it's
+	// never set (it's always nil). This may cause nil panic since not all the
+	// methods are implemented.
+	xdsclient.XDSClient
+
 	name         string
 	ldsWatchCh   *testutils.Channel
 	rdsWatchCh   *testutils.Channel

--- a/xds/internal/testutils/fakeclient/client.go
+++ b/xds/internal/testutils/fakeclient/client.go
@@ -22,6 +22,7 @@ package fakeclient
 import (
 	"context"
 
+	"google.golang.org/grpc/internal/grpcsync"
 	"google.golang.org/grpc/internal/testutils"
 	"google.golang.org/grpc/xds/internal/xdsclient"
 	"google.golang.org/grpc/xds/internal/xdsclient/bootstrap"
@@ -41,7 +42,6 @@ type Client struct {
 	cdsCancelCh  *testutils.Channel
 	edsCancelCh  *testutils.Channel
 	loadReportCh *testutils.Channel
-	closeCh      *testutils.Channel
 	loadStore    *load.Store
 	bootstrapCfg *bootstrap.Config
 
@@ -49,6 +49,8 @@ type Client struct {
 	rdsCb  func(xdsclient.RouteConfigUpdate, error)
 	cdsCbs map[string]func(xdsclient.ClusterUpdate, error)
 	edsCb  func(xdsclient.EndpointsUpdate, error)
+
+	Closed *grpcsync.Event // fired when Close is called.
 }
 
 // WatchListener registers a LDS watch.
@@ -228,16 +230,9 @@ func (xdsC *Client) WaitForReportLoad(ctx context.Context) (ReportLoadArgs, erro
 	return val.(ReportLoadArgs), err
 }
 
-// Close closes the xds client.
+// Close fires xdsC.Closed, indicating it was called.
 func (xdsC *Client) Close() {
-	xdsC.closeCh.Send(nil)
-}
-
-// WaitForClose waits for Close to be invoked on this client and returns
-// context.DeadlineExceeded otherwise.
-func (xdsC *Client) WaitForClose(ctx context.Context) error {
-	_, err := xdsC.closeCh.Receive(ctx)
-	return err
+	xdsC.Closed.Fire()
 }
 
 // BootstrapConfig returns the bootstrap config.
@@ -275,8 +270,8 @@ func NewClientWithName(name string) *Client {
 		cdsCancelCh:  testutils.NewChannelWithSize(10),
 		edsCancelCh:  testutils.NewChannel(),
 		loadReportCh: testutils.NewChannel(),
-		closeCh:      testutils.NewChannel(),
 		loadStore:    load.NewStore(),
 		cdsCbs:       make(map[string]func(xdsclient.ClusterUpdate, error)),
+		Closed:       grpcsync.NewEvent(),
 	}
 }

--- a/xds/internal/xdsclient/attributes.go
+++ b/xds/internal/xdsclient/attributes.go
@@ -17,20 +17,43 @@
 
 package xdsclient
 
-import "google.golang.org/grpc/resolver"
+import (
+	"google.golang.org/grpc/resolver"
+	"google.golang.org/grpc/xds/internal/xdsclient/bootstrap"
+	"google.golang.org/grpc/xds/internal/xdsclient/load"
+)
 
 type clientKeyType string
 
 const clientKey = clientKeyType("grpc.xds.internal.client.Client")
 
+// XDSClient is a full fledged gRPC client which queries a set of discovery APIs
+// (collectively termed as xDS) on a remote management server, to discover
+// various dynamic resources.
+type XDSClient interface {
+	WatchListener(string, func(ListenerUpdate, error)) func()
+	WatchRouteConfig(string, func(RouteConfigUpdate, error)) func()
+	WatchCluster(string, func(ClusterUpdate, error)) func()
+	WatchEndpoints(clusterName string, edsCb func(EndpointsUpdate, error)) (cancel func())
+	ReportLoad(server string) (*load.Store, func())
+
+	DumpLDS() (string, map[string]UpdateWithMD)
+	DumpRDS() (string, map[string]UpdateWithMD)
+	DumpCDS() (string, map[string]UpdateWithMD)
+	DumpEDS() (string, map[string]UpdateWithMD)
+
+	BootstrapConfig() *bootstrap.Config
+	Close()
+}
+
 // FromResolverState returns the Client from state, or nil if not present.
-func FromResolverState(state resolver.State) *Client {
-	cs, _ := state.Attributes.Value(clientKey).(*Client)
+func FromResolverState(state resolver.State) XDSClient {
+	cs, _ := state.Attributes.Value(clientKey).(XDSClient)
 	return cs
 }
 
 // SetClient sets c in state and returns the new state.
-func SetClient(state resolver.State, c *Client) resolver.State {
+func SetClient(state resolver.State, c XDSClient) resolver.State {
 	state.Attributes = state.Attributes.WithValues(clientKey, c)
 	return state
 }

--- a/xds/internal/xdsclient/cds_test.go
+++ b/xds/internal/xdsclient/cds_test.go
@@ -303,9 +303,6 @@ func (s) TestValidateCluster_Success(t *testing.T) {
 		},
 	}
 
-	origCircuitBreakingSupport := env.CircuitBreakingSupport
-	env.CircuitBreakingSupport = true
-	defer func() { env.CircuitBreakingSupport = origCircuitBreakingSupport }()
 	oldAggregateAndDNSSupportEnv := env.AggregateAndDNSSupportEnv
 	env.AggregateAndDNSSupportEnv = true
 	defer func() { env.AggregateAndDNSSupportEnv = oldAggregateAndDNSSupportEnv }()

--- a/xds/internal/xdsclient/client.go
+++ b/xds/internal/xdsclient/client.go
@@ -579,7 +579,7 @@ func newWithConfig(config *bootstrap.Config, watchExpiryTimeout time.Duration) (
 
 // BootstrapConfig returns the configuration read from the bootstrap file.
 // Callers must treat the return value as read-only.
-func (c *Client) BootstrapConfig() *bootstrap.Config {
+func (c *clientRefCounted) BootstrapConfig() *bootstrap.Config {
 	return c.config
 }
 

--- a/xds/internal/xdsclient/client_test.go
+++ b/xds/internal/xdsclient/client_test.go
@@ -263,7 +263,7 @@ func (s) TestClientNewSingleton(t *testing.T) {
 	defer cleanup()
 
 	// The first New(). Should create a Client and a new APIClient.
-	client, err := New()
+	client, err := newRefCounted()
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
@@ -280,7 +280,7 @@ func (s) TestClientNewSingleton(t *testing.T) {
 	// and should not create new API client.
 	const count = 9
 	for i := 0; i < count; i++ {
-		tc, terr := New()
+		tc, terr := newRefCounted()
 		if terr != nil {
 			client.Close()
 			t.Fatalf("%d-th call to New() failed with error: %v", i, terr)
@@ -324,7 +324,7 @@ func (s) TestClientNewSingleton(t *testing.T) {
 
 	// Call New() again after the previous Client is actually closed. Should
 	// create a Client and a new APIClient.
-	client2, err2 := New()
+	client2, err2 := newRefCounted()
 	if err2 != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}

--- a/xds/internal/xdsclient/rds_test.go
+++ b/xds/internal/xdsclient/rds_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"google.golang.org/grpc/internal/testutils"
+	"google.golang.org/grpc/internal/xds/env"
 	"google.golang.org/grpc/xds/internal/httpfilter"
 	"google.golang.org/grpc/xds/internal/version"
 	"google.golang.org/protobuf/types/known/durationpb"

--- a/xds/internal/xdsclient/tests/dump_test.go
+++ b/xds/internal/xdsclient/tests/dump_test.go
@@ -85,6 +85,7 @@ func (s) TestLDSConfigDump(t *testing.T) {
 		t.Fatalf("failed to create client: %v", err)
 	}
 	defer client.Close()
+	updateHandler := client.(xdsclient.UpdateHandler)
 
 	// Expected unknown.
 	if err := compareDump(client.DumpLDS, "", map[string]xdsclient.UpdateWithMD{}); err != nil {
@@ -111,7 +112,7 @@ func (s) TestLDSConfigDump(t *testing.T) {
 			Raw: r,
 		}
 	}
-	client.NewListeners(update0, xdsclient.UpdateMetadata{Version: testVersion})
+	updateHandler.NewListeners(update0, xdsclient.UpdateMetadata{Version: testVersion})
 
 	// Expect ACK.
 	if err := compareDump(client.DumpLDS, testVersion, want0); err != nil {
@@ -120,7 +121,7 @@ func (s) TestLDSConfigDump(t *testing.T) {
 
 	const nackVersion = "lds-version-nack"
 	var nackErr = fmt.Errorf("lds nack error")
-	client.NewListeners(
+	updateHandler.NewListeners(
 		map[string]xdsclient.ListenerUpdate{
 			ldsTargets[0]: {},
 		},
@@ -195,6 +196,7 @@ func (s) TestRDSConfigDump(t *testing.T) {
 		t.Fatalf("failed to create client: %v", err)
 	}
 	defer client.Close()
+	updateHandler := client.(xdsclient.UpdateHandler)
 
 	// Expected unknown.
 	if err := compareDump(client.DumpRDS, "", map[string]xdsclient.UpdateWithMD{}); err != nil {
@@ -221,7 +223,7 @@ func (s) TestRDSConfigDump(t *testing.T) {
 			Raw: r,
 		}
 	}
-	client.NewRouteConfigs(update0, xdsclient.UpdateMetadata{Version: testVersion})
+	updateHandler.NewRouteConfigs(update0, xdsclient.UpdateMetadata{Version: testVersion})
 
 	// Expect ACK.
 	if err := compareDump(client.DumpRDS, testVersion, want0); err != nil {
@@ -230,7 +232,7 @@ func (s) TestRDSConfigDump(t *testing.T) {
 
 	const nackVersion = "rds-version-nack"
 	var nackErr = fmt.Errorf("rds nack error")
-	client.NewRouteConfigs(
+	updateHandler.NewRouteConfigs(
 		map[string]xdsclient.RouteConfigUpdate{
 			rdsTargets[0]: {},
 		},
@@ -305,6 +307,7 @@ func (s) TestCDSConfigDump(t *testing.T) {
 		t.Fatalf("failed to create client: %v", err)
 	}
 	defer client.Close()
+	updateHandler := client.(xdsclient.UpdateHandler)
 
 	// Expected unknown.
 	if err := compareDump(client.DumpCDS, "", map[string]xdsclient.UpdateWithMD{}); err != nil {
@@ -331,7 +334,7 @@ func (s) TestCDSConfigDump(t *testing.T) {
 			Raw: r,
 		}
 	}
-	client.NewClusters(update0, xdsclient.UpdateMetadata{Version: testVersion})
+	updateHandler.NewClusters(update0, xdsclient.UpdateMetadata{Version: testVersion})
 
 	// Expect ACK.
 	if err := compareDump(client.DumpCDS, testVersion, want0); err != nil {
@@ -340,7 +343,7 @@ func (s) TestCDSConfigDump(t *testing.T) {
 
 	const nackVersion = "cds-version-nack"
 	var nackErr = fmt.Errorf("cds nack error")
-	client.NewClusters(
+	updateHandler.NewClusters(
 		map[string]xdsclient.ClusterUpdate{
 			cdsTargets[0]: {},
 		},
@@ -401,6 +404,7 @@ func (s) TestEDSConfigDump(t *testing.T) {
 		t.Fatalf("failed to create client: %v", err)
 	}
 	defer client.Close()
+	updateHandler := client.(xdsclient.UpdateHandler)
 
 	// Expected unknown.
 	if err := compareDump(client.DumpEDS, "", map[string]xdsclient.UpdateWithMD{}); err != nil {
@@ -427,7 +431,7 @@ func (s) TestEDSConfigDump(t *testing.T) {
 			Raw: r,
 		}
 	}
-	client.NewEndpoints(update0, xdsclient.UpdateMetadata{Version: testVersion})
+	updateHandler.NewEndpoints(update0, xdsclient.UpdateMetadata{Version: testVersion})
 
 	// Expect ACK.
 	if err := compareDump(client.DumpEDS, testVersion, want0); err != nil {
@@ -436,7 +440,7 @@ func (s) TestEDSConfigDump(t *testing.T) {
 
 	const nackVersion = "eds-version-nack"
 	var nackErr = fmt.Errorf("eds nack error")
-	client.NewEndpoints(
+	updateHandler.NewEndpoints(
 		map[string]xdsclient.EndpointsUpdate{
 			edsTargets[0]: {},
 		},

--- a/xds/internal/xdsclient/xds.go
+++ b/xds/internal/xdsclient/xds.go
@@ -178,7 +178,7 @@ func validateHTTPFilterConfig(cfg *anypb.Any, lds, optional bool) (httpfilter.Fi
 }
 
 func processHTTPFilterOverrides(cfgs map[string]*anypb.Any) (map[string]httpfilter.FilterConfig, error) {
-	if !env.FaultInjectionSupport || len(cfgs) == 0 {
+	if len(cfgs) == 0 {
 		return nil, nil
 	}
 	m := make(map[string]httpfilter.FilterConfig)
@@ -207,10 +207,6 @@ func processHTTPFilterOverrides(cfgs map[string]*anypb.Any) (map[string]httpfilt
 }
 
 func processHTTPFilters(filters []*v3httppb.HttpFilter, server bool) ([]HTTPFilter, error) {
-	if !env.FaultInjectionSupport {
-		return nil, nil
-	}
-
 	ret := make([]HTTPFilter, 0, len(filters))
 	seenNames := make(map[string]bool, len(filters))
 	for _, filter := range filters {
@@ -776,9 +772,6 @@ func securityConfigFromCommonTLSContext(common *v3tlspb.CommonTlsContext) (*Secu
 // the received cluster resource. Returns nil if no CircuitBreakers or no
 // Thresholds in CircuitBreakers.
 func circuitBreakersFromCluster(cluster *v3clusterpb.Cluster) *uint32 {
-	if !env.CircuitBreakingSupport {
-		return nil
-	}
 	for _, threshold := range cluster.GetCircuitBreakers().GetThresholds() {
 		if threshold.GetPriority() != v3corepb.RoutingPriority_DEFAULT {
 			continue

--- a/xds/server.go
+++ b/xds/server.go
@@ -35,14 +35,13 @@ import (
 	"google.golang.org/grpc/internal/grpcsync"
 	"google.golang.org/grpc/xds/internal/server"
 	"google.golang.org/grpc/xds/internal/xdsclient"
-	"google.golang.org/grpc/xds/internal/xdsclient/bootstrap"
 )
 
 const serverPrefix = "[xds-server %p] "
 
 var (
 	// These new functions will be overridden in unit tests.
-	newXDSClient = func() (xdsClient, error) {
+	newXDSClient = func() (xdsclient.XDSClient, error) {
 		return xdsclient.New()
 	}
 	newGRPCServer = func(opts ...grpc.ServerOption) grpcServer {
@@ -56,14 +55,6 @@ var (
 
 func prefixLogger(p *GRPCServer) *internalgrpclog.PrefixLogger {
 	return internalgrpclog.NewPrefixLogger(logger, fmt.Sprintf(serverPrefix, p))
-}
-
-// xdsClient contains methods from xdsClient.Client which are used by
-// the server. This is useful for overriding in unit tests.
-type xdsClient interface {
-	WatchListener(string, func(xdsclient.ListenerUpdate, error)) func()
-	BootstrapConfig() *bootstrap.Config
-	Close()
 }
 
 // grpcServer contains methods from grpc.Server which are used by the
@@ -90,7 +81,7 @@ type GRPCServer struct {
 	// beginning of Serve(), where we have to decide if we have to create a
 	// client or use an existing one.
 	clientMu sync.Mutex
-	xdsC     xdsClient
+	xdsC     xdsclient.XDSClient
 }
 
 // NewGRPCServer creates an xDS-enabled gRPC server using the passed in opts.
@@ -156,7 +147,7 @@ func (s *GRPCServer) initXDSClient() error {
 
 	newXDSClient := newXDSClient
 	if s.opts.bootstrapContents != nil {
-		newXDSClient = func() (xdsClient, error) {
+		newXDSClient = func() (xdsclient.XDSClient, error) {
 			return xdsclient.NewClientWithBootstrapContents(s.opts.bootstrapContents)
 		}
 	}

--- a/xds/server.go
+++ b/xds/server.go
@@ -64,6 +64,7 @@ type grpcServer interface {
 	Serve(net.Listener) error
 	Stop()
 	GracefulStop()
+	GetServiceInfo() map[string]grpc.ServiceInfo
 }
 
 // GRPCServer wraps a gRPC server and provides server-side xDS functionality, by
@@ -134,6 +135,12 @@ func handleServerOptions(opts []grpc.ServerOption) *serverOptions {
 // before invoking Serve.
 func (s *GRPCServer) RegisterService(sd *grpc.ServiceDesc, ss interface{}) {
 	s.gs.RegisterService(sd, ss)
+}
+
+// GetServiceInfo returns a map from service names to ServiceInfo.
+// Service names include the package names, in the form of <package>.<service>.
+func (s *GRPCServer) GetServiceInfo() map[string]grpc.ServiceInfo {
+	return s.gs.GetServiceInfo()
 }
 
 // initXDSClient creates a new xdsClient if there is no existing one available.

--- a/xds/server_test.go
+++ b/xds/server_test.go
@@ -247,7 +247,7 @@ func (p *fakeProvider) Close() {
 func setupOverrides() (*fakeGRPCServer, *testutils.Channel, func()) {
 	clientCh := testutils.NewChannel()
 	origNewXDSClient := newXDSClient
-	newXDSClient = func() (xdsClient, error) {
+	newXDSClient = func() (xdsclient.XDSClient, error) {
 		c := fakeclient.NewClient()
 		c.SetBootstrapConfig(&bootstrap.Config{
 			BalancerName:                       "dummyBalancer",
@@ -277,7 +277,7 @@ func setupOverrides() (*fakeGRPCServer, *testutils.Channel, func()) {
 func setupOverridesForXDSCreds(includeCertProviderCfg bool) (*testutils.Channel, func()) {
 	clientCh := testutils.NewChannel()
 	origNewXDSClient := newXDSClient
-	newXDSClient = func() (xdsClient, error) {
+	newXDSClient = func() (xdsclient.XDSClient, error) {
 		c := fakeclient.NewClient()
 		bc := &bootstrap.Config{
 			BalancerName:                       "dummyBalancer",
@@ -544,7 +544,7 @@ func (s) TestServeBootstrapConfigInvalid(t *testing.T) {
 			// xdsClient with the specified bootstrap configuration.
 			clientCh := testutils.NewChannel()
 			origNewXDSClient := newXDSClient
-			newXDSClient = func() (xdsClient, error) {
+			newXDSClient = func() (xdsclient.XDSClient, error) {
 				c := fakeclient.NewClient()
 				c.SetBootstrapConfig(test.bootstrapConfig)
 				clientCh.Send(c)
@@ -587,7 +587,7 @@ func (s) TestServeBootstrapConfigInvalid(t *testing.T) {
 // verifies that Server() exits with a non-nil error.
 func (s) TestServeNewClientFailure(t *testing.T) {
 	origNewXDSClient := newXDSClient
-	newXDSClient = func() (xdsClient, error) {
+	newXDSClient = func() (xdsclient.XDSClient, error) {
 		return nil, errors.New("xdsClient creation failed")
 	}
 	defer func() { newXDSClient = origNewXDSClient }()

--- a/xds/server_test.go
+++ b/xds/server_test.go
@@ -86,6 +86,10 @@ func (f *fakeGRPCServer) GracefulStop() {
 	f.gracefulStopCh.Send(nil)
 }
 
+func (f *fakeGRPCServer) GetServiceInfo() map[string]grpc.ServiceInfo {
+	panic("implement me")
+}
+
 func newFakeGRPCServer() *fakeGRPCServer {
 	return &fakeGRPCServer{
 		done:              make(chan struct{}),


### PR DESCRIPTION
This PR adds HashPolicy to RDS update so the xds resolver can generate per request hashes to pass to Cluster Manager LB policy.

RELEASE NOTES: none