### PR TITLE
xds: remove env var protetion of advanced routing features

### DIFF
--- a/internal/xds/env/env.go
+++ b/internal/xds/env/env.go
@@ -39,9 +39,6 @@ const (
 	// When both bootstrap FileName and FileContent are set, FileName is used.
 	BootstrapFileContentEnv = "GRPC_XDS_BOOTSTRAP_CONFIG"
 
-	circuitBreakingSupportEnv    = "GRPC_XDS_EXPERIMENTAL_CIRCUIT_BREAKING"
-	timeoutSupportEnv            = "GRPC_XDS_EXPERIMENTAL_ENABLE_TIMEOUT"
-	faultInjectionSupportEnv     = "GRPC_XDS_EXPERIMENTAL_FAULT_INJECTION"
 	clientSideSecuritySupportEnv = "GRPC_XDS_EXPERIMENTAL_SECURITY_SUPPORT"
 	aggregateAndDNSSupportEnv    = "GRPC_XDS_EXPERIMENTAL_ENABLE_AGGREGATE_AND_LOGICAL_DNS_CLUSTER"
 
@@ -63,17 +60,6 @@ var (
 	// When both bootstrap FileName and FileContent are set, FileName is used.
 	BootstrapFileContent = os.Getenv(BootstrapFileContentEnv)
 
-	// CircuitBreakingSupport indicates whether circuit breaking support is
-	// enabled, which can be disabled by setting the environment variable
-	// "GRPC_XDS_EXPERIMENTAL_CIRCUIT_BREAKING" to "false".
-	CircuitBreakingSupport = !strings.EqualFold(os.Getenv(circuitBreakingSupportEnv), "false")
-	// TimeoutSupport indicates whether support for max_stream_duration in
-	// route actions is enabled.  This can be disabled by setting the
-	// environment variable "GRPC_XDS_EXPERIMENTAL_ENABLE_TIMEOUT" to "false".
-	TimeoutSupport = !strings.EqualFold(os.Getenv(timeoutSupportEnv), "false")
-	// FaultInjectionSupport is used to control both fault injection and HTTP
-	// filter support.
-	FaultInjectionSupport = !strings.EqualFold(os.Getenv(faultInjectionSupportEnv), "false")
 	// ClientSideSecuritySupport is used to control processing of security
 	// configuration on the client-side.
 	//

--- a/xds/internal/balancer/edsbalancer/eds_impl.go
+++ b/xds/internal/balancer/edsbalancer/eds_impl.go
@@ -31,7 +31,6 @@ import (
 	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/internal"
 	"google.golang.org/grpc/internal/grpclog"
-	"google.golang.org/grpc/internal/xds/env"
 	"google.golang.org/grpc/resolver"
 	"google.golang.org/grpc/status"
 	xdsi "google.golang.org/grpc/xds/internal"
@@ -418,9 +417,6 @@ func (edsImpl *edsBalancerImpl) handleSubConnStateChange(sc balancer.SubConn, s 
 
 // updateServiceRequestsConfig handles changes to the circuit breaking configuration.
 func (edsImpl *edsBalancerImpl) updateServiceRequestsConfig(serviceName string, max *uint32) {
-	if !env.CircuitBreakingSupport {
-		return
-	}
 	edsImpl.pickerMu.Lock()
 	var updatePicker bool
 	if edsImpl.serviceRequestsCounter == nil || edsImpl.serviceRequestsCounter.ServiceName != serviceName {

--- a/xds/internal/balancer/edsbalancer/eds_impl_test.go
+++ b/xds/internal/balancer/edsbalancer/eds_impl_test.go
@@ -35,7 +35,6 @@ import (
 	"google.golang.org/grpc/balancer/roundrobin"
 	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/internal/balancer/stub"
-	"google.golang.org/grpc/internal/xds/env"
 	xdsinternal "google.golang.org/grpc/xds/internal"
 	"google.golang.org/grpc/xds/internal/balancer/balancergroup"
 	"google.golang.org/grpc/xds/internal/testutils"
@@ -575,10 +574,6 @@ func (s) TestEDS_UpdateSubBalancerName(t *testing.T) {
 }
 
 func (s) TestEDS_CircuitBreaking(t *testing.T) {
-	origCircuitBreakingSupport := env.CircuitBreakingSupport
-	env.CircuitBreakingSupport = true
-	defer func() { env.CircuitBreakingSupport = origCircuitBreakingSupport }()
-
 	cc := testutils.NewTestClientConn(t)
 	edsb := newEDSBalancerImpl(cc, balancer.BuildOptions{}, nil, nil, nil)
 	edsb.enqueueChildBalancerStateUpdate = edsb.updateState
@@ -812,10 +807,6 @@ func (s) TestDropPicker(t *testing.T) {
 }
 
 func (s) TestEDS_LoadReport(t *testing.T) {
-	origCircuitBreakingSupport := env.CircuitBreakingSupport
-	env.CircuitBreakingSupport = true
-	defer func() { env.CircuitBreakingSupport = origCircuitBreakingSupport }()
-
 	// We create an xdsClientWrapper with a dummy xdsClient which only
 	// implements the LoadStore() method to return the underlying load.Store to
 	// be used.

--- a/xds/internal/httpfilter/fault/fault.go
+++ b/xds/internal/httpfilter/fault/fault.go
@@ -33,7 +33,6 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/internal/grpcrand"
 	iresolver "google.golang.org/grpc/internal/resolver"
-	"google.golang.org/grpc/internal/xds/env"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 	"google.golang.org/grpc/xds/internal/httpfilter"
@@ -63,9 +62,7 @@ var statusMap = map[int]codes.Code{
 }
 
 func init() {
-	if env.FaultInjectionSupport {
-		httpfilter.Register(builder{})
-	}
+	httpfilter.Register(builder{})
 }
 
 type builder struct {

--- a/xds/internal/httpfilter/fault/fault_test.go
+++ b/xds/internal/httpfilter/fault/fault_test.go
@@ -40,10 +40,8 @@ import (
 	"google.golang.org/grpc/internal/grpctest"
 	"google.golang.org/grpc/internal/testutils"
 	"google.golang.org/grpc/internal/xds"
-	"google.golang.org/grpc/internal/xds/env"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
-	"google.golang.org/grpc/xds/internal/httpfilter"
 	xtestutils "google.golang.org/grpc/xds/internal/testutils"
 	"google.golang.org/grpc/xds/internal/testutils/e2e"
 	"google.golang.org/protobuf/types/known/wrapperspb"
@@ -138,13 +136,6 @@ func clientSetup(t *testing.T) (*e2e.ManagementServer, string, uint32, func()) {
 		bootstrapCleanup()
 		server.Stop()
 	}
-}
-
-func init() {
-	env.FaultInjectionSupport = true
-	// Manually register to avoid a race between this init and the one that
-	// check the env var to register the fault injection filter.
-	httpfilter.Register(builder{})
 }
 
 func (s) TestFaultInjection_Unary(t *testing.T) {

--- a/xds/internal/resolver/serviceconfig.go
+++ b/xds/internal/resolver/serviceconfig.go
@@ -28,7 +28,6 @@ import (
 	"google.golang.org/grpc/codes"
 	iresolver "google.golang.org/grpc/internal/resolver"
 	"google.golang.org/grpc/internal/wrr"
-	"google.golang.org/grpc/internal/xds/env"
 	"google.golang.org/grpc/status"
 	"google.golang.org/grpc/xds/internal/balancer/clustermanager"
 	"google.golang.org/grpc/xds/internal/httpfilter"
@@ -179,7 +178,7 @@ func (cs *configSelector) SelectConfig(rpcInfo iresolver.RPCInfo) (*iresolver.RP
 		Interceptor: interceptor,
 	}
 
-	if env.TimeoutSupport && rt.maxStreamDuration != 0 {
+	if rt.maxStreamDuration != 0 {
 		config.MethodConfig.Timeout = &rt.maxStreamDuration
 	}
 

--- a/xds/internal/xdsclient/cds_test.go
+++ b/xds/internal/xdsclient/cds_test.go
@@ -303,9 +303,6 @@ func (s) TestValidateCluster_Success(t *testing.T) {
 		},
 	}
 
-	origCircuitBreakingSupport := env.CircuitBreakingSupport
-	env.CircuitBreakingSupport = true
-	defer func() { env.CircuitBreakingSupport = origCircuitBreakingSupport }()
 	oldAggregateAndDNSSupportEnv := env.AggregateAndDNSSupportEnv
 	env.AggregateAndDNSSupportEnv = true
 	defer func() { env.AggregateAndDNSSupportEnv = oldAggregateAndDNSSupportEnv }()

--- a/xds/internal/xdsclient/xds.go
+++ b/xds/internal/xdsclient/xds.go
@@ -178,7 +178,7 @@ func validateHTTPFilterConfig(cfg *anypb.Any, lds, optional bool) (httpfilter.Fi
 }
 
 func processHTTPFilterOverrides(cfgs map[string]*anypb.Any) (map[string]httpfilter.FilterConfig, error) {
-	if !env.FaultInjectionSupport || len(cfgs) == 0 {
+	if len(cfgs) == 0 {
 		return nil, nil
 	}
 	m := make(map[string]httpfilter.FilterConfig)
@@ -207,10 +207,6 @@ func processHTTPFilterOverrides(cfgs map[string]*anypb.Any) (map[string]httpfilt
 }
 
 func processHTTPFilters(filters []*v3httppb.HttpFilter, server bool) ([]HTTPFilter, error) {
-	if !env.FaultInjectionSupport {
-		return nil, nil
-	}
-
 	ret := make([]HTTPFilter, 0, len(filters))
 	seenNames := make(map[string]bool, len(filters))
 	for _, filter := range filters {
@@ -776,9 +772,6 @@ func securityConfigFromCommonTLSContext(common *v3tlspb.CommonTlsContext) (*Secu
 // the received cluster resource. Returns nil if no CircuitBreakers or no
 // Thresholds in CircuitBreakers.
 func circuitBreakersFromCluster(cluster *v3clusterpb.Cluster) *uint32 {
-	if !env.CircuitBreakingSupport {
-		return nil
-	}
 	for _, threshold := range cluster.GetCircuitBreakers().GetThresholds() {
 		if threshold.GetPriority() != v3corepb.RoutingPriority_DEFAULT {
 			continue


### PR DESCRIPTION
Fault Injection, Timeout, and Circuit Breaking.  One release has been done with these enabled by default, so now we will remove the environment variables entirely.

RELEASE NOTES: none