### PR TITLE
cluster_resolver: fix DiscoveryMechanismType marshal JSON

### DIFF
--- a/xds/internal/balancer/clusterresolver/balancerconfig/type.go
+++ b/xds/internal/balancer/clusterresolver/balancerconfig/type.go
@@ -29,17 +29,20 @@ type DiscoveryMechanismType int
 
 const (
 	// DiscoveryMechanismTypeEDS is eds.
-	DiscoveryMechanismTypeEDS DiscoveryMechanismType = iota // `json:EDS`
+	DiscoveryMechanismTypeEDS DiscoveryMechanismType = iota // `json:"EDS"`
 	// DiscoveryMechanismTypeLogicalDNS is DNS.
-	DiscoveryMechanismTypeLogicalDNS // `json:LOGICAL_DNS`
+	DiscoveryMechanismTypeLogicalDNS // `json:"LOGICAL_DNS"`
 )
 
 // MarshalJSON marshals a DiscoveryMechanismType to a quoted json string.
 //
 // This is necessary to handle enum (as strings) from JSON.
-func (t *DiscoveryMechanismType) MarshalJSON() ([]byte, error) {
+//
+// Note that this needs to be defined on the type not pointer, otherwise the
+// variables of this type will marshal to int not string.
+func (t DiscoveryMechanismType) MarshalJSON() ([]byte, error) {
 	buffer := bytes.NewBufferString(`"`)
-	switch *t {
+	switch t {
 	case DiscoveryMechanismTypeEDS:
 		buffer.WriteString("EDS")
 	case DiscoveryMechanismTypeLogicalDNS:

--- a/xds/internal/balancer/clusterresolver/balancerconfig/type_test.go
+++ b/xds/internal/balancer/clusterresolver/balancerconfig/type_test.go
@@ -44,13 +44,8 @@ func TestDiscoveryMechanismTypeMarshalJSON(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := json.Marshal(tt.typ)
-			if err != nil {
-				t.Errorf("DiscoveryMechanismTypeEDS.MarshalJSON() error = %v, wantErr %v", err, false)
-				return
-			}
-			if gotS := string(got); gotS != tt.want {
-				t.Errorf("DiscoveryMechanismTypeEDS.MarshalJSON() got %q, want %q", gotS, tt.want)
+			if got, err := json.Marshal(tt.typ); err != nil || string(got) != tt.want {
+				t.Fatalf("DiscoveryMechanismTypeEDS.MarshalJSON() = (%v, %v), want (%s, nil)", string(got), err, tt.want)
 			}
 		})
 	}
@@ -83,11 +78,10 @@ func TestDiscoveryMechanismTypeUnmarshalJSON(t *testing.T) {
 			var got DiscoveryMechanismType
 			err := json.Unmarshal([]byte(tt.js), &got)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("parseConfig() error = %v, wantErr %v", err, tt.wantErr)
-				return
+				t.Fatalf("DiscoveryMechanismTypeEDS.UnmarshalJSON() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			if diff := cmp.Diff(got, tt.want); diff != "" {
-				t.Errorf("parseConfig() got unexpected output, diff (-got +want): %v", diff)
+				t.Fatalf("DiscoveryMechanismTypeEDS.UnmarshalJSON() got unexpected output, diff (-got +want): %v", diff)
 			}
 		})
 	}

--- a/xds/internal/balancer/clusterresolver/balancerconfig/type_test.go
+++ b/xds/internal/balancer/clusterresolver/balancerconfig/type_test.go
@@ -1,0 +1,94 @@
+/*
+ *
+ * Copyright 2021 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package balancerconfig
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestDiscoveryMechanismTypeMarshalJSON(t *testing.T) {
+	tests := []struct {
+		name string
+		typ  DiscoveryMechanismType
+		want string
+	}{
+		{
+			name: "eds",
+			typ:  DiscoveryMechanismTypeEDS,
+			want: `"EDS"`,
+		},
+		{
+			name: "dns",
+			typ:  DiscoveryMechanismTypeLogicalDNS,
+			want: `"LOGICAL_DNS"`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := json.Marshal(tt.typ)
+			if err != nil {
+				t.Errorf("DiscoveryMechanismTypeEDS.MarshalJSON() error = %v, wantErr %v", err, false)
+				return
+			}
+			if gotS := string(got); gotS != tt.want {
+				t.Errorf("DiscoveryMechanismTypeEDS.MarshalJSON() got %q, want %q", gotS, tt.want)
+			}
+		})
+	}
+}
+func TestDiscoveryMechanismTypeUnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		js      string
+		want    DiscoveryMechanismType
+		wantErr bool
+	}{
+		{
+			name: "eds",
+			js:   `"EDS"`,
+			want: DiscoveryMechanismTypeEDS,
+		},
+		{
+			name: "dns",
+			js:   `"LOGICAL_DNS"`,
+			want: DiscoveryMechanismTypeLogicalDNS,
+		},
+		{
+			name:    "error",
+			js:      `"1234"`,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got DiscoveryMechanismType
+			err := json.Unmarshal([]byte(tt.js), &got)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseConfig() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if diff := cmp.Diff(got, tt.want); diff != "" {
+				t.Errorf("parseConfig() got unexpected output, diff (-got +want): %v", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The method needs to be implemented on the type, not the pointer.
Otherwise only the pointer will marshal to the string, the type itself
will marshal to int.

RELEASE NOTES: N/A