### PR TITLE
grpc: prevent deadlock in Test/ClientUpdatesParamsAfterGoAway on failure

### DIFF
--- a/clientconn_test.go
+++ b/clientconn_test.go
@@ -735,17 +735,15 @@ func (s) TestClientUpdatesParamsAfterGoAway(t *testing.T) {
 		time.Sleep(10 * time.Millisecond)
 		cc.mu.RLock()
 		v := cc.mkp.Time
+		cc.mu.RUnlock()
 		if v == 20*time.Second {
 			// Success
-			cc.mu.RUnlock()
 			return
 		}
 		if ctx.Err() != nil {
 			// Timeout
-			cc.mu.RUnlock()
 			t.Fatalf("cc.dopts.copts.Keepalive.Time = %v , want 20s", v)
 		}
-		cc.mu.RUnlock()
 	}
 }
 

--- a/clientconn_test.go
+++ b/clientconn_test.go
@@ -742,6 +742,7 @@ func (s) TestClientUpdatesParamsAfterGoAway(t *testing.T) {
 		}
 		if ctx.Err() != nil {
 			// Timeout
+			cc.mu.RUnlock()
 			t.Fatalf("cc.dopts.copts.Keepalive.Time = %v , want 20s", v)
 		}
 		cc.mu.RUnlock()


### PR DESCRIPTION
In cases where `t.Fatalf()` doesn't completely end the program, a `ctx.Err()` will cause the program to wait on a mutex indefinitely. 

Forcing the test to enter this specific `if` condition should reproduce the issue.

Adding an unlock before reporting the error allows the program to fail the test as intended when a network error occurs.

Fixes #4537

RELEASE NOTES: none