### PR TITLE
xdsclient: move tests out of tests directory

### DIFF
--- a/xds/internal/xdsclient/dump_test.go
+++ b/xds/internal/xdsclient/dump_test.go
@@ -18,7 +18,7 @@
  *
  */
 
-package tests_test
+package xdsclient_test
 
 import (
 	"fmt"

--- a/xds/internal/xdsclient/loadreport_test.go
+++ b/xds/internal/xdsclient/loadreport_test.go
@@ -18,7 +18,7 @@
  *
  */
 
-package tests_test
+package xdsclient_test
 
 import (
 	"context"

--- a/xds/internal/xdsclient/tests/README.md
+++ b/xds/internal/xdsclient/tests/README.md
@@ -1,1 +1,0 @@
-This package contains tests which cannot live in the `client` package because they need to import one of the API client packages (which itself has a dependency on the `client` package).

--- a/xds/internal/xdsclient/xdsclient_test.go
+++ b/xds/internal/xdsclient/xdsclient_test.go
@@ -18,7 +18,7 @@
  *
  */
 
-package tests_test
+package xdsclient_test
 
 import (
 	"testing"


### PR DESCRIPTION
Tests can exist in a different package from implementation while still residing in the same directory.  This PR moves `xdsclient/tests/*.go` into `xdsclient/` to avoid an unnecessary separate directory for some of the tests.

RELEASE NOTES: none