### PR TITLE
internal: fix deadlock during switch_balancer and NewSubConn()

### DIFF
--- a/clientconn.go
+++ b/clientconn.go
@@ -711,7 +711,12 @@ func (cc *ClientConn) switchBalancer(name string) {
 		return
 	}
 	if cc.balancerWrapper != nil {
+		// Don't hold cc.mu while closing the balancers. The balancers may call
+		// methods that require cc.mu (e.g. cc.NewSubConn()). Holding the mutex
+		// would cause a deadlock in that case.
+		cc.mu.Unlock()
 		cc.balancerWrapper.close()
+		cc.mu.Lock()
 	}
 
 	builder := balancer.Get(name)


### PR DESCRIPTION
- release cc.mu before closing cc_balancer_wrapper
- synchronize all resolver incoming calls.

This is what I think the cause of the xds interop failures. It's similar to #4478 (+#4504).

RELEASE NOTES: N/A