### PR TITLE
xds: move eds package to cluster_resolver

### DIFF
--- a/xds/internal/balancer/balancer.go
+++ b/xds/internal/balancer/balancer.go
@@ -20,10 +20,10 @@
 package balancer
 
 import (
-	_ "google.golang.org/grpc/xds/internal/balancer/cdsbalancer"    // Register the CDS balancer
-	_ "google.golang.org/grpc/xds/internal/balancer/clusterimpl"    // Register the xds_cluster_impl balancer
-	_ "google.golang.org/grpc/xds/internal/balancer/clustermanager" // Register the xds_cluster_manager balancer
-	_ "google.golang.org/grpc/xds/internal/balancer/edsbalancer"    // Register the EDS balancer
-	_ "google.golang.org/grpc/xds/internal/balancer/priority"       // Register the priority balancer
-	_ "google.golang.org/grpc/xds/internal/balancer/weightedtarget" // Register the weighted_target balancer
+	_ "google.golang.org/grpc/xds/internal/balancer/cdsbalancer"     // Register the CDS balancer
+	_ "google.golang.org/grpc/xds/internal/balancer/clusterimpl"     // Register the xds_cluster_impl balancer
+	_ "google.golang.org/grpc/xds/internal/balancer/clustermanager"  // Register the xds_cluster_manager balancer
+	_ "google.golang.org/grpc/xds/internal/balancer/clusterresolver" // Register the xds_cluster_resolver balancer
+	_ "google.golang.org/grpc/xds/internal/balancer/priority"        // Register the priority balancer
+	_ "google.golang.org/grpc/xds/internal/balancer/weightedtarget"  // Register the weighted_target balancer
 )

--- a/xds/internal/balancer/cdsbalancer/cdsbalancer.go
+++ b/xds/internal/balancer/cdsbalancer/cdsbalancer.go
@@ -34,7 +34,7 @@ import (
 	"google.golang.org/grpc/internal/pretty"
 	"google.golang.org/grpc/resolver"
 	"google.golang.org/grpc/serviceconfig"
-	"google.golang.org/grpc/xds/internal/balancer/edsbalancer"
+	"google.golang.org/grpc/xds/internal/balancer/clusterresolver"
 	"google.golang.org/grpc/xds/internal/xdsclient"
 )
 
@@ -314,7 +314,7 @@ func (b *cdsBalancer) handleWatchUpdate(update clusterHandlerUpdate) {
 	// is updated to cluster_resolver, which has the fallback functionality, we
 	// will fix this to handle all the clusters in list.
 	cds := update.chu[0]
-	lbCfg := &edsbalancer.EDSConfig{
+	lbCfg := &clusterresolver.EDSConfig{
 		ClusterName:           cds.ClusterName,
 		EDSServiceName:        cds.EDSServiceName,
 		MaxConcurrentRequests: cds.MaxRequests,

--- a/xds/internal/balancer/cdsbalancer/cdsbalancer_test.go
+++ b/xds/internal/balancer/cdsbalancer/cdsbalancer_test.go
@@ -35,7 +35,7 @@ import (
 	"google.golang.org/grpc/internal/testutils"
 	"google.golang.org/grpc/resolver"
 	"google.golang.org/grpc/serviceconfig"
-	"google.golang.org/grpc/xds/internal/balancer/edsbalancer"
+	"google.golang.org/grpc/xds/internal/balancer/clusterresolver"
 	xdstestutils "google.golang.org/grpc/xds/internal/testutils"
 	"google.golang.org/grpc/xds/internal/testutils/fakeclient"
 	"google.golang.org/grpc/xds/internal/xdsclient"
@@ -197,7 +197,7 @@ func cdsCCS(cluster string, xdsC xdsclient.XDSClient) balancer.ClientConnState {
 // edsCCS is a helper function to construct a good update passed from the
 // cdsBalancer to the edsBalancer.
 func edsCCS(service string, countMax *uint32, enableLRS bool) balancer.ClientConnState {
-	lbCfg := &edsbalancer.EDSConfig{
+	lbCfg := &clusterresolver.EDSConfig{
 		ClusterName:           service,
 		MaxConcurrentRequests: countMax,
 	}

--- a/xds/internal/balancer/clusterresolver/clusterresolver_test.go
+++ b/xds/internal/balancer/clusterresolver/clusterresolver_test.go
@@ -18,7 +18,7 @@
  *
  */
 
-package edsbalancer
+package clusterresolver
 
 import (
 	"bytes"
@@ -177,7 +177,7 @@ func (*fakeSubConn) UpdateAddresses([]resolver.Address) { panic("implement me") 
 func (*fakeSubConn) Connect()                           { panic("implement me") }
 
 // waitForNewChildLB makes sure that a new child LB is created by the top-level
-// edsBalancer.
+// clusterResolverBalancer.
 func waitForNewChildLB(ctx context.Context, ch *testutils.Channel) (*fakeChildBalancer, error) {
 	val, err := ch.Receive(ctx)
 	if err != nil {
@@ -205,17 +205,17 @@ func setup(childLBCh *testutils.Channel) (*fakeclient.Client, func()) {
 	}
 }
 
-// TestSubConnStateChange verifies if the top-level edsBalancer passes on
+// TestSubConnStateChange verifies if the top-level clusterResolverBalancer passes on
 // the subConnState to appropriate child balancer.
 func (s) TestSubConnStateChange(t *testing.T) {
 	edsLBCh := testutils.NewChannel()
 	xdsC, cleanup := setup(edsLBCh)
 	defer cleanup()
 
-	builder := balancer.Get(edsName)
+	builder := balancer.Get(Name)
 	edsB := builder.Build(newNoopTestClientConn(), balancer.BuildOptions{Target: resolver.Target{Endpoint: testServiceName}})
 	if edsB == nil {
-		t.Fatalf("builder.Build(%s) failed and returned nil", edsName)
+		t.Fatalf("builder.Build(%s) failed and returned nil", Name)
 	}
 	defer edsB.Close()
 
@@ -258,10 +258,10 @@ func (s) TestErrorFromXDSClientUpdate(t *testing.T) {
 	xdsC, cleanup := setup(edsLBCh)
 	defer cleanup()
 
-	builder := balancer.Get(edsName)
+	builder := balancer.Get(Name)
 	edsB := builder.Build(newNoopTestClientConn(), balancer.BuildOptions{Target: resolver.Target{Endpoint: testServiceName}})
 	if edsB == nil {
-		t.Fatalf("builder.Build(%s) failed and returned nil", edsName)
+		t.Fatalf("builder.Build(%s) failed and returned nil", Name)
 	}
 	defer edsB.Close()
 
@@ -303,7 +303,7 @@ func (s) TestErrorFromXDSClientUpdate(t *testing.T) {
 		t.Fatalf("want resolver error, got %v", err)
 	}
 
-	resourceErr := xdsclient.NewErrorf(xdsclient.ErrorTypeResourceNotFound, "edsBalancer resource not found error")
+	resourceErr := xdsclient.NewErrorf(xdsclient.ErrorTypeResourceNotFound, "clusterResolverBalancer resource not found error")
 	xdsC.InvokeWatchEDSCallback(xdsclient.EndpointsUpdate{}, resourceErr)
 	// Even if error is resource not found, watch shouldn't be canceled, because
 	// this is an EDS resource removed (and xds client actually never sends this
@@ -346,10 +346,10 @@ func (s) TestErrorFromResolver(t *testing.T) {
 	xdsC, cleanup := setup(edsLBCh)
 	defer cleanup()
 
-	builder := balancer.Get(edsName)
+	builder := balancer.Get(Name)
 	edsB := builder.Build(newNoopTestClientConn(), balancer.BuildOptions{Target: resolver.Target{Endpoint: testServiceName}})
 	if edsB == nil {
-		t.Fatalf("builder.Build(%s) failed and returned nil", edsName)
+		t.Fatalf("builder.Build(%s) failed and returned nil", Name)
 	}
 	defer edsB.Close()
 
@@ -392,7 +392,7 @@ func (s) TestErrorFromResolver(t *testing.T) {
 		t.Fatalf("want resolver error, got %v", err)
 	}
 
-	resourceErr := xdsclient.NewErrorf(xdsclient.ErrorTypeResourceNotFound, "edsBalancer resource not found error")
+	resourceErr := xdsclient.NewErrorf(xdsclient.ErrorTypeResourceNotFound, "clusterResolverBalancer resource not found error")
 	edsB.ResolverError(resourceErr)
 	if err := xdsC.WaitForCancelEDSWatch(ctx); err != nil {
 		t.Fatalf("want watch to be canceled, waitForCancel failed: %v", err)
@@ -448,10 +448,10 @@ func (s) TestClientWatchEDS(t *testing.T) {
 	xdsC, cleanup := setup(edsLBCh)
 	defer cleanup()
 
-	builder := balancer.Get(edsName)
+	builder := balancer.Get(Name)
 	edsB := builder.Build(newNoopTestClientConn(), balancer.BuildOptions{Target: resolver.Target{Endpoint: testServiceName}})
 	if edsB == nil {
-		t.Fatalf("builder.Build(%s) failed and returned nil", edsName)
+		t.Fatalf("builder.Build(%s) failed and returned nil", Name)
 	}
 	defer edsB.Close()
 

--- a/xds/internal/balancer/clusterresolver/config.go
+++ b/xds/internal/balancer/clusterresolver/config.go
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package edsbalancer
+package clusterresolver
 
 import (
 	"encoding/json"

--- a/xds/internal/balancer/clusterresolver/configbuilder.go
+++ b/xds/internal/balancer/clusterresolver/configbuilder.go
@@ -16,7 +16,7 @@
  *
  */
 
-package edsbalancer
+package clusterresolver
 
 import (
 	internalserviceconfig "google.golang.org/grpc/internal/serviceconfig"

--- a/xds/internal/balancer/clusterresolver/configbuilder_test.go
+++ b/xds/internal/balancer/clusterresolver/configbuilder_test.go
@@ -16,7 +16,7 @@
  *
  */
 
-package edsbalancer
+package clusterresolver
 
 import (
 	"fmt"

--- a/xds/internal/balancer/clusterresolver/eds_watcher.go
+++ b/xds/internal/balancer/clusterresolver/eds_watcher.go
@@ -16,7 +16,7 @@
  *
  */
 
-package edsbalancer
+package clusterresolver
 
 import (
 	"google.golang.org/grpc/xds/internal/xdsclient"
@@ -34,7 +34,7 @@ type watchUpdate struct {
 // edsWatcher takes an EDS balancer config, and use the xds_client to watch EDS
 // updates. The EDS updates are passed back to the balancer via a channel.
 type edsWatcher struct {
-	parent *edsBalancer
+	parent *clusterResolverBalancer
 
 	updateChannel chan *watchUpdate
 

--- a/xds/internal/balancer/clusterresolver/logging.go
+++ b/xds/internal/balancer/clusterresolver/logging.go
@@ -16,7 +16,7 @@
  *
  */
 
-package edsbalancer
+package clusterresolver
 
 import (
 	"fmt"
@@ -25,10 +25,10 @@ import (
 	internalgrpclog "google.golang.org/grpc/internal/grpclog"
 )
 
-const prefix = "[eds-lb %p] "
+const prefix = "[xds-cluster-resolver-lb %p] "
 
 var logger = grpclog.Component("xds")
 
-func prefixLogger(p *edsBalancer) *internalgrpclog.PrefixLogger {
+func prefixLogger(p *clusterResolverBalancer) *internalgrpclog.PrefixLogger {
 	return internalgrpclog.NewPrefixLogger(logger, fmt.Sprintf(prefix, p))
 }

--- a/xds/internal/balancer/clusterresolver/priority_test.go
+++ b/xds/internal/balancer/clusterresolver/priority_test.go
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-package edsbalancer
+package clusterresolver
 
 import (
 	"context"

--- a/xds/internal/balancer/clusterresolver/testutil_test.go
+++ b/xds/internal/balancer/clusterresolver/testutil_test.go
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package edsbalancer
+package clusterresolver
 
 import (
 	"fmt"


### PR DESCRIPTION
This PR moves EDS from the eds package to the new cluster_resolver package. The new policy doesn't have the new features yet, those will be added later.

This PR is part of #4546. It's a renaming only change, that doesn't touch any behavior.

RELEASE NOTES: N/A