### PR TITLE
metadata: add Delete method to MD

### DIFF
--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -123,6 +123,13 @@ func (md MD) Append(k string, vals ...string) {
 	md[k] = append(md[k], vals...)
 }
 
+// Delete removes the values for a given key k which is converted to lowercase
+// before removing it from md.
+func (md MD) Delete(k string) {
+	k = strings.ToLower(k)
+	delete(md, k)
+}
+
 // Join joins any number of mds into a single MD.
 //
 // The order of values for each key is determined by the order in which the mds

--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -169,6 +169,35 @@ func (s) TestAppend(t *testing.T) {
 	}
 }
 
+func (s) TestDelete(t *testing.T) {
+	for _, test := range []struct {
+		md        MD
+		deleteKey string
+		want      MD
+	}{
+		{
+			md:        Pairs("My-Optional-Header", "42"),
+			deleteKey: "My-Optional-Header",
+			want:      Pairs(),
+		},
+		{
+			md:        Pairs("My-Optional-Header", "42"),
+			deleteKey: "Other-Key",
+			want:      Pairs("my-optional-header", "42"),
+		},
+		{
+			md:        Pairs("My-Optional-Header", "42"),
+			deleteKey: "my-OptIoNal-HeAder",
+			want:      Pairs(),
+		},
+	} {
+		test.md.Delete(test.deleteKey)
+		if !reflect.DeepEqual(test.md, test.want) {
+			t.Errorf("value of metadata is %v, want %v", test.md, test.want)
+		}
+	}
+}
+
 func (s) TestAppendToOutgoingContext(t *testing.T) {
 	// Pre-existing metadata
 	tCtx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)


### PR DESCRIPTION
Since `MD` wraps the map type it is possible to call
```go
delete(md, "An-uppercase-key")
```
and it will faily silently since the contract of this data type is to lowercase the key first. I propose a `Delete` method is added too allowing users to remove keys without the need to lowercase them before.

RELEASE NOTES:
- metadata: add Delete method to MD to encapsulate lowercasing