### PR TITLE
xds: require router filter when filters are empty

### DIFF
--- a/xds/internal/resolver/serviceconfig.go
+++ b/xds/internal/resolver/serviceconfig.go
@@ -186,9 +186,6 @@ func (cs *configSelector) SelectConfig(rpcInfo iresolver.RPCInfo) (*iresolver.RP
 }
 
 func (cs *configSelector) newInterceptor(rt *route, cluster *routeCluster) (iresolver.ClientInterceptor, error) {
-	if len(cs.httpFilterConfig) == 0 {
-		return nil, nil
-	}
 	interceptors := make([]iresolver.ClientInterceptor, 0, len(cs.httpFilterConfig))
 	for _, filter := range cs.httpFilterConfig {
 		if router.IsRouterFilter(filter.Filter) {

--- a/xds/internal/resolver/xds_resolver_test.go
+++ b/xds/internal/resolver/xds_resolver_test.go
@@ -1129,6 +1129,11 @@ func (s) TestXDSResolverHTTPFilters(t *testing.T) {
 		newStreamErr string
 	}{
 		{
+			name:       "empty filters",
+			ldsFilters: []xdsclient.HTTPFilter{},
+			selectErr:  "no router filter present",
+		},
+		{
 			name: "no router filter",
 			ldsFilters: []xdsclient.HTTPFilter{
 				{Name: "foo", Filter: &filterBuilder{path: &path}, Config: filterCfg{s: "foo1"}},


### PR DESCRIPTION
Fixes #4547 

RELEASE NOTES:
- xds: always require a router HTTP filter