### PR TITLE
xds: fix test race in cluster_resolver

### DIFF
--- a/xds/internal/balancer/clusterresolver/priority_test.go
+++ b/xds/internal/balancer/clusterresolver/priority_test.go
@@ -37,7 +37,7 @@ import (
 //
 // Init 0 and 1; 0 is up, use 0; add 2, use 0; remove 2, use 0.
 func (s) TestEDSPriority_HighPriorityReady(t *testing.T) {
-	edsb, cc, xdsC, cleanup := setupTestEDS(t)
+	edsb, cc, xdsC, cleanup := setupTestEDS(t, nil)
 	defer cleanup()
 
 	// Two localities, with priorities [0, 1], each with one backend.
@@ -100,7 +100,7 @@ func (s) TestEDSPriority_HighPriorityReady(t *testing.T) {
 // Init 0 and 1; 0 is up, use 0; 0 is down, 1 is up, use 1; add 2, use 1; 1 is
 // down, use 2; remove 2, use 1.
 func (s) TestEDSPriority_SwitchPriority(t *testing.T) {
-	edsb, cc, xdsC, cleanup := setupTestEDS(t)
+	edsb, cc, xdsC, cleanup := setupTestEDS(t, nil)
 	defer cleanup()
 
 	// Two localities, with priorities [0, 1], each with one backend.
@@ -194,7 +194,7 @@ func (s) TestEDSPriority_SwitchPriority(t *testing.T) {
 //
 // Init 0 and 1; 0 and 1 both down; add 2, use 2.
 func (s) TestEDSPriority_HigherDownWhileAddingLower(t *testing.T) {
-	edsb, cc, xdsC, cleanup := setupTestEDS(t)
+	edsb, cc, xdsC, cleanup := setupTestEDS(t, nil)
 	defer cleanup()
 	// Two localities, with different priorities, each with one backend.
 	clab1 := testutils.NewClusterLoadAssignmentBuilder(testClusterNames[0], nil)
@@ -247,7 +247,7 @@ func (s) TestEDSPriority_HigherDownWhileAddingLower(t *testing.T) {
 //
 // Init 0,1,2; 0 and 1 down, use 2; 0 up, close 1 and 2.
 func (s) TestEDSPriority_HigherReadyCloseAllLower(t *testing.T) {
-	edsb, cc, xdsC, cleanup := setupTestEDS(t)
+	edsb, cc, xdsC, cleanup := setupTestEDS(t, nil)
 	defer cleanup()
 	// Two localities, with priorities [0,1,2], each with one backend.
 	clab1 := testutils.NewClusterLoadAssignmentBuilder(testClusterNames[0], nil)
@@ -338,7 +338,7 @@ func (s) TestEDSPriority_InitTimeout(t *testing.T) {
 		}
 	}()()
 
-	edsb, cc, xdsC, cleanup := setupTestEDS(t)
+	edsb, cc, xdsC, cleanup := setupTestEDS(t, nil)
 	defer cleanup()
 	// Two localities, with different priorities, each with one backend.
 	clab1 := testutils.NewClusterLoadAssignmentBuilder(testClusterNames[0], nil)
@@ -381,7 +381,7 @@ func (s) TestEDSPriority_InitTimeout(t *testing.T) {
 //  - start with 2 locality with p0 and p1
 //  - add localities to existing p0 and p1
 func (s) TestEDSPriority_MultipleLocalities(t *testing.T) {
-	edsb, cc, xdsC, cleanup := setupTestEDS(t)
+	edsb, cc, xdsC, cleanup := setupTestEDS(t, nil)
 	defer cleanup()
 	// Two localities, with different priorities, each with one backend.
 	clab0 := testutils.NewClusterLoadAssignmentBuilder(testClusterNames[0], nil)
@@ -478,7 +478,7 @@ func (s) TestEDSPriority_RemovesAllLocalities(t *testing.T) {
 		}
 	}()()
 
-	edsb, cc, xdsC, cleanup := setupTestEDS(t)
+	edsb, cc, xdsC, cleanup := setupTestEDS(t, nil)
 	defer cleanup()
 	// Two localities, with different priorities, each with one backend.
 	clab0 := testutils.NewClusterLoadAssignmentBuilder(testClusterNames[0], nil)
@@ -585,7 +585,7 @@ func (s) TestEDSPriority_RemovesAllLocalities(t *testing.T) {
 // Test the case where the high priority contains no backends. The low priority
 // will be used.
 func (s) TestEDSPriority_HighPriorityNoEndpoints(t *testing.T) {
-	edsb, cc, xdsC, cleanup := setupTestEDS(t)
+	edsb, cc, xdsC, cleanup := setupTestEDS(t, nil)
 	defer cleanup()
 	// Two localities, with priorities [0, 1], each with one backend.
 	clab1 := testutils.NewClusterLoadAssignmentBuilder(testClusterNames[0], nil)
@@ -636,7 +636,7 @@ func (s) TestEDSPriority_HighPriorityNoEndpoints(t *testing.T) {
 // Test the case where the high priority contains no healthy backends. The low
 // priority will be used.
 func (s) TestEDSPriority_HighPriorityAllUnhealthy(t *testing.T) {
-	edsb, cc, xdsC, cleanup := setupTestEDS(t)
+	edsb, cc, xdsC, cleanup := setupTestEDS(t, nil)
 	defer cleanup()
 	// Two localities, with priorities [0, 1], each with one backend.
 	clab1 := testutils.NewClusterLoadAssignmentBuilder(testClusterNames[0], nil)
@@ -697,7 +697,7 @@ func (s) TestEDSPriority_FirstPriorityRemoved(t *testing.T) {
 		}
 	}()()
 
-	_, cc, xdsC, cleanup := setupTestEDS(t)
+	_, cc, xdsC, cleanup := setupTestEDS(t, nil)
 	defer cleanup()
 	// One localities, with priorities [0], each with one backend.
 	clab1 := testutils.NewClusterLoadAssignmentBuilder(testClusterNames[0], nil)


### PR DESCRIPTION
There's a race between update sub-balancer and the first EDS resp. If
sub-balancer is updated after the first EDS resp, the old balancers
(round_robin) will create two lingering SubConns that are not handled,
which will mess up the following SubConn state updates.

fixes #4554

RELEASE NOTES: N/A