### PR TITLE
Revert "xds: require router filter when filters are empty"

### DIFF
--- a/xds/internal/resolver/serviceconfig.go
+++ b/xds/internal/resolver/serviceconfig.go
@@ -255,6 +255,9 @@ func (cs *configSelector) generateHash(rpcInfo iresolver.RPCInfo, hashPolicies [
 }
 
 func (cs *configSelector) newInterceptor(rt *route, cluster *routeCluster) (iresolver.ClientInterceptor, error) {
+	if len(cs.httpFilterConfig) == 0 {
+		return nil, nil
+	}
 	interceptors := make([]iresolver.ClientInterceptor, 0, len(cs.httpFilterConfig))
 	for _, filter := range cs.httpFilterConfig {
 		if router.IsRouterFilter(filter.Filter) {

--- a/xds/internal/resolver/xds_resolver_test.go
+++ b/xds/internal/resolver/xds_resolver_test.go
@@ -1198,11 +1198,6 @@ func (s) TestXDSResolverHTTPFilters(t *testing.T) {
 		newStreamErr string
 	}{
 		{
-			name:       "empty filters",
-			ldsFilters: []xdsclient.HTTPFilter{},
-			selectErr:  "no router filter present",
-		},
-		{
 			name: "no router filter",
 			ldsFilters: []xdsclient.HTTPFilter{
 				{Name: "foo", Filter: &filterBuilder{path: &path}, Config: filterCfg{s: "foo1"}},


### PR DESCRIPTION
Reverts grpc/grpc-go#4553

xdsclient for v2 will not produce any HTTP filters, so this will cause all RPCs to fail with xds v2.

RELEASE NOTES: N/A