### PR TITLE
client: add deadline for TransportCredentials handshaker

### DIFF
--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -241,7 +241,15 @@ func newHTTP2Client(connectCtx, ctx context.Context, addr resolver.Address, opts
 		// and passed to the credential handshaker. This makes it possible for
 		// address specific arbitrary data to reach the credential handshaker.
 		connectCtx = icredentials.NewClientHandshakeInfoContext(connectCtx, credentials.ClientHandshakeInfo{Attributes: addr.Attributes})
+		oldConn := conn
+		// Pull the deadline from the connectCtx, which will be used for
+		// timeouts in the authentication protocol handshake. Can ignore the
+		// boolean as the deadline will return the zero value, which will make
+		// the conn not timeout on I/O operations.
+		deadline, _ := connectCtx.Deadline()
+		conn.SetDeadline(deadline)
 		conn, authInfo, err = transportCreds.ClientHandshake(connectCtx, addr.ServerName, conn)
+		oldConn.SetDeadline(time.Time{})
 		if err != nil {
 			return nil, connectionErrorf(isTemporary(err), err, "transport: authentication handshake failed: %v", err)
 		}

--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -241,15 +241,15 @@ func newHTTP2Client(connectCtx, ctx context.Context, addr resolver.Address, opts
 		// and passed to the credential handshaker. This makes it possible for
 		// address specific arbitrary data to reach the credential handshaker.
 		connectCtx = icredentials.NewClientHandshakeInfoContext(connectCtx, credentials.ClientHandshakeInfo{Attributes: addr.Attributes})
-		oldConn := conn
+		rawConn := conn
 		// Pull the deadline from the connectCtx, which will be used for
 		// timeouts in the authentication protocol handshake. Can ignore the
 		// boolean as the deadline will return the zero value, which will make
 		// the conn not timeout on I/O operations.
 		deadline, _ := connectCtx.Deadline()
-		conn.SetDeadline(deadline)
-		conn, authInfo, err = transportCreds.ClientHandshake(connectCtx, addr.ServerName, conn)
-		oldConn.SetDeadline(time.Time{})
+		rawConn.SetDeadline(deadline)
+		conn, authInfo, err = transportCreds.ClientHandshake(connectCtx, addr.ServerName, rawConn)
+		rawConn.SetDeadline(time.Time{})
 		if err != nil {
 			return nil, connectionErrorf(isTemporary(err), err, "transport: authentication handshake failed: %v", err)
 		}

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -7724,8 +7724,7 @@ func (c *connPersistDeadline) SetDeadline(t time.Time) error {
 }
 
 type credentialsVerifyDeadline struct {
-	credsInvoked                 *testutils.Channel
-	connectionHasCorrectDeadline bool
+	credsInvoked *testutils.Channel
 }
 
 func (cvd *credentialsVerifyDeadline) ServerHandshake(rawConn net.Conn) (net.Conn, credentials.AuthInfo, error) {

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -7676,7 +7676,14 @@ func (s) TestDeadlineSetOnConnectionOnClientCredentialHandshake(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to listen: %v", err)
 	}
-	go lis.Accept()
+	go func() {
+		conn, err := lis.Accept()
+		if err != nil {
+			t.Errorf("Error accepting connection: %v", err)
+			return
+		}
+		defer conn.Close()
+	}()
 	deadlineCh := testutils.NewChannel()
 	cvd := &credentialsVerifyDeadline{
 		deadlineCh: deadlineCh,

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -7676,13 +7676,21 @@ func (s) TestDeadlineSetOnConnectionOnClientCredentialHandshake(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to listen: %v", err)
 	}
+	connCh := make(chan net.Conn, 1)
 	go func() {
+		defer close(connCh)
 		conn, err := lis.Accept()
 		if err != nil {
 			t.Errorf("Error accepting connection: %v", err)
 			return
 		}
-		defer conn.Close()
+		connCh<-conn
+	}()
+	defer func() {
+		conn := <-connCh
+		if conn != nil {
+			conn.Close()
+		}
 	}()
 	deadlineCh := testutils.NewChannel()
 	cvd := &credentialsVerifyDeadline{

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -7684,7 +7684,7 @@ func (s) TestDeadlineSetOnConnectionOnClientCredentialHandshake(t *testing.T) {
 			t.Errorf("Error accepting connection: %v", err)
 			return
 		}
-		connCh<-conn
+		connCh <- conn
 	}()
 	defer func() {
 		conn := <-connCh


### PR DESCRIPTION
Fixes issue #4492.

RELEASE NOTES:
- client: add deadline to connection when calling TransportCredentials handshaker