### PR TITLE
internal/transport: do not mask ConnectionError

### DIFF
--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -877,18 +877,18 @@ func (t *http2Client) Close(err error) {
 	// Append info about previous goaways if there were any, since this may be important
 	// for understanding the root cause for this connection to be closed.
 	_, goAwayDebugMessage := t.GetGoAwayReason()
+
+	var st *status.Status
 	if len(goAwayDebugMessage) > 0 {
-		tmpErr := true
-		originalErr := err
-		if ce, ok := err.(ConnectionError); ok {
-			tmpErr = ce.Temporary()
-			originalErr = ce.Origin()
-		}
-		err = connectionErrorf(tmpErr, originalErr, "closing transport due to: %v, received prior goaway: %v", originalErr, goAwayDebugMessage)
+		st = status.Newf(codes.Unavailable, "closing transport due to: %v, received prior goaway: %v", err, goAwayDebugMessage)
+		err = st.Err()
+	} else {
+		st = status.New(codes.Unavailable, err.Error())
 	}
+
 	// Notify all active streams.
 	for _, s := range streams {
-		t.closeStream(s, err, false, http2.ErrCodeNo, status.New(codes.Unavailable, err.Error()), nil, false)
+		t.closeStream(s, err, false, http2.ErrCodeNo, st, nil, false)
 	}
 	if t.statsHandler != nil {
 		connEnd := &stats.ConnEnd{


### PR DESCRIPTION
Hi everyone! PR #4316 introduces a serious breaking change that is not listed in the 1.38.0 release notes: it is no longer possible to gather meaningful information from the errors returned by the client whenever a `GOAWAY` message has been previously received, because the original `ConnectionError` is wrapped with a `fmt.Errorf` that discards all this information. This is, again, a breaking change that affects projects like the Vitess tablet RPC among others.

This PR contains a potential fix for the issue. The commit message is inlined for your convenience:

```
PR #4316 updates the http2Client `Close` method so it can append
additional debug information about prior GOAWAY messages before this
connection was closed.

However, it is not safe to do this in the general case, as the original
error is propagated through the connection's `Stream` via a `recvMsg`,
and read later on. If the additional metadata is appended by wrapping
the error with `fmt.Errorf`, downstream clients will not be able to
detect meaningful error conditions (such as `io.EOF`) or the temporarity
of the error.

Fix this by properly wrapping the original error with `connectionErrorf`
like it is done for all the other errors in the client.
```

I hope you deem this fix acceptable; if you believe there is a more elegant way to maintain the behavior from 1.37.0 please let me know so I can adjust it accordingly.

Thank you,
vmg

RELEASE NOTES:
- client: fix status code to return Unavailable for servers shutting down instead of Unknown