### PR TITLE
Transport: add base context for gRPC server

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "go.inferGopath": false
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "go.inferGopath": false
+}

--- a/internal/transport/http2_server.go
+++ b/internal/transport/http2_server.go
@@ -215,9 +215,16 @@ func NewServerTransport(conn net.Conn, config *ServerConfig) (_ ServerTransport,
 	if kep.MinTime == 0 {
 		kep.MinTime = defaultKeepalivePolicyMinTime
 	}
+	baseCtx := context.Background()
+	if config.BaseContext != nil {
+		baseCtx = config.BaseContext(conn.LocalAddr(), conn.RemoteAddr())
+		if baseCtx == nil {
+			panic("BaseContext returned a nil context")
+		}
+	}
 	done := make(chan struct{})
 	t := &http2Server{
-		ctx:               context.Background(),
+		ctx:               baseCtx,
 		done:              done,
 		conn:              conn,
 		remoteAddr:        conn.RemoteAddr(),

--- a/internal/transport/transport.go
+++ b/internal/transport/transport.go
@@ -530,6 +530,7 @@ type ServerConfig struct {
 	ChannelzParentID      int64
 	MaxHeaderListSize     *uint32
 	HeaderTableSize       *uint32
+	BaseContext           func(net.Addr, net.Addr) context.Context
 }
 
 // ConnectOptions covers all relevant options for communicating with the server.


### PR DESCRIPTION
By adding basecontext to the server, the stateless ServerInterceptor can get some fixed context information of the server, such as logger, serverName, server's api metadata, etc.

At the same time, we can also align the http server implementation of the golang standard library：https://golang.org/pkg/net/http/ ，which also contains base context implment.