### PR TITLE
transport: add base context for gRPC server

### DIFF
--- a/internal/transport/http2_server.go
+++ b/internal/transport/http2_server.go
@@ -215,9 +215,16 @@ func NewServerTransport(conn net.Conn, config *ServerConfig) (_ ServerTransport,
 	if kep.MinTime == 0 {
 		kep.MinTime = defaultKeepalivePolicyMinTime
 	}
+	baseCtx := context.Background()
+	if config.BaseContext != nil {
+		baseCtx = config.BaseContext(conn.LocalAddr(), conn.RemoteAddr())
+		if baseCtx == nil {
+			panic("BaseContext returned a nil context")
+		}
+	}
 	done := make(chan struct{})
 	t := &http2Server{
-		ctx:               context.Background(),
+		ctx:               baseCtx,
 		done:              done,
 		conn:              conn,
 		remoteAddr:        conn.RemoteAddr(),

--- a/internal/transport/transport.go
+++ b/internal/transport/transport.go
@@ -530,6 +530,7 @@ type ServerConfig struct {
 	ChannelzParentID      int64
 	MaxHeaderListSize     *uint32
 	HeaderTableSize       *uint32
+	BaseContext           func(net.Addr, net.Addr) context.Context
 }
 
 // ConnectOptions covers all relevant options for communicating with the server.


### PR DESCRIPTION
By adding base context to the grpc server, the stateless ServerInterceptor can get some fixed context information (which may be generated by other frameworks,cannot be obtained directly from the configuration ) of the server, such as logger, serverName,local ip\port, server's metadata, etc.

Refer to the design of the official std library ：https://golang.org/pkg/net/http/ ，which also contains base context  implementation for http server.