### PR TITLE
xds/cluster_impl: fix cluster_impl not correctly starting LoadReport stream

### DIFF
--- a/xds/internal/balancer/clusterimpl/balancer_test.go
+++ b/xds/internal/balancer/clusterimpl/balancer_test.go
@@ -651,6 +651,11 @@ func TestLoadReporting(t *testing.T) {
 	if reqStats.InProgress != 0 {
 		t.Errorf("got inProgress %v, want %v", reqStats.InProgress, 0)
 	}
+
+	b.Close()
+	if err := xdsC.WaitForCancelReportLoad(ctx); err != nil {
+		t.Fatalf("unexpected error waiting form load report to be canceled: %v", err)
+	}
 }
 
 // TestUpdateLRSServer covers the cases

--- a/xds/internal/balancer/clusterimpl/clusterimpl.go
+++ b/xds/internal/balancer/clusterimpl/clusterimpl.go
@@ -178,19 +178,17 @@ func (b *clusterImplBalancer) updateLoadStore(newConfig *LBConfig) error {
 			startNewLoadReport = true
 		}
 		// Old is nil, new is nil, do nothing.
+	} else if newConfig.LoadReportingServerName == nil {
+		// Old is not nil, new is nil, stop old, don't start new.
+		b.lrsServerName = newConfig.LoadReportingServerName
+		stopOldLoadReport = true
 	} else {
-		if newConfig.LoadReportingServerName == nil {
-			// Old is not nil, new is nil, stop old, don't start new.
+		// Old is not nil, new is not nil, compare string values, if
+		// different, stop old and start new.
+		if *b.lrsServerName != *newConfig.LoadReportingServerName {
 			b.lrsServerName = newConfig.LoadReportingServerName
 			stopOldLoadReport = true
-		} else {
-			// Old is not nil, new is not nil, compare string values, if
-			// different, stop old and start new.
-			if *b.lrsServerName != *newConfig.LoadReportingServerName {
-				b.lrsServerName = newConfig.LoadReportingServerName
-				stopOldLoadReport = true
-				startNewLoadReport = true
-			}
+			startNewLoadReport = true
 		}
 	}
 

--- a/xds/internal/testutils/fakeclient/client.go
+++ b/xds/internal/testutils/fakeclient/client.go
@@ -47,6 +47,7 @@ type Client struct {
 	cdsCancelCh  *testutils.Channel
 	edsCancelCh  *testutils.Channel
 	loadReportCh *testutils.Channel
+	lrsCancelCh  *testutils.Channel
 	loadStore    *load.Store
 	bootstrapCfg *bootstrap.Config
 
@@ -220,7 +221,16 @@ type ReportLoadArgs struct {
 // ReportLoad starts reporting load about clusterName to server.
 func (xdsC *Client) ReportLoad(server string) (loadStore *load.Store, cancel func()) {
 	xdsC.loadReportCh.Send(ReportLoadArgs{Server: server})
-	return xdsC.loadStore, func() {}
+	return xdsC.loadStore, func() {
+		xdsC.lrsCancelCh.Send(nil)
+	}
+}
+
+// WaitForCancelReportLoad waits for a load report to be cancelled and returns
+// context.DeadlineExceeded otherwise.
+func (xdsC *Client) WaitForCancelReportLoad(ctx context.Context) error {
+	_, err := xdsC.lrsCancelCh.Receive(ctx)
+	return err
 }
 
 // LoadStore returns the underlying load data store.
@@ -232,7 +242,10 @@ func (xdsC *Client) LoadStore() *load.Store {
 // returns the arguments passed to it.
 func (xdsC *Client) WaitForReportLoad(ctx context.Context) (ReportLoadArgs, error) {
 	val, err := xdsC.loadReportCh.Receive(ctx)
-	return val.(ReportLoadArgs), err
+	if err != nil {
+		return ReportLoadArgs{}, err
+	}
+	return val.(ReportLoadArgs), nil
 }
 
 // Close fires xdsC.Closed, indicating it was called.
@@ -275,6 +288,7 @@ func NewClientWithName(name string) *Client {
 		cdsCancelCh:  testutils.NewChannelWithSize(10),
 		edsCancelCh:  testutils.NewChannel(),
 		loadReportCh: testutils.NewChannel(),
+		lrsCancelCh:  testutils.NewChannel(),
 		loadStore:    load.NewStore(),
 		cdsCbs:       make(map[string]func(xdsclient.ClusterUpdate, error)),
 		Closed:       grpcsync.NewEvent(),


### PR DESCRIPTION
This was not as big a problem before, because the LRS policy will start the load report stream (it is still a bug, because the drops will not be reported).

This is a more obvious bug after #4528, and was caught by the interop tests.

RELEASE NOTES: N/A