### PR TITLE
Implement the errors.Unwrap interface as appropriate

### DIFF
--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -151,8 +151,8 @@ func (e *Error) GRPCStatus() *Status {
 	return FromProto(e.e)
 }
 
-// Is implements future error.Is functionality.
-// A Error is equivalent if the code and message are identical.
+// Is implements Go 1.13 errors.Is functionality.
+// An Error is equivalent if the code and message are identical.
 func (e *Error) Is(target error) bool {
 	tse, ok := target.(*Error)
 	if !ok {

--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -619,6 +619,11 @@ func (p PerformedIOError) Error() string {
 	return p.Err.Error()
 }
 
+// Unwrap implements Go 1.13 errors.Unwrap functionality.
+func (p PerformedIOError) Unwrap() error {
+	return p.Err
+}
+
 // NewStream creates a stream and registers it into the transport as "active"
 // streams.
 func (t *http2Client) NewStream(ctx context.Context, callHdr *CallHdr) (_ *Stream, err error) {

--- a/internal/transport/transport.go
+++ b/internal/transport/transport.go
@@ -735,6 +735,11 @@ func (e ConnectionError) Temporary() bool {
 	return e.temp
 }
 
+// Unwrap implements Go 1.13 errors.Unwrap functionality.
+func (e ConnectionError) Unwrap() error {
+	return e.err
+}
+
 // Origin returns the original error of this connection error.
 func (e ConnectionError) Origin() error {
 	// Never return nil error here.


### PR DESCRIPTION
Since Go 1.13, implementations of `error` that wrap another `error` should implement an `Unwrap() error` method, which will make the error be usable with the `errors.Is`, `errors.As`, and `errors.Unwrap` inspection functions.

There is an existing ticket about supporting error unwrapping (https://github.com/grpc/grpc-go/issues/2934) but most of what is being talked about in that ticket is about wrapping for gRPC statuses being sent over the network.  This PR doesn't deal with that.  It just deals with implementing `Wrap` on local error types.

It is tempting to also search for `fmt.Errorf("whatever: %v", err)` and change the `%v` to `%w`, but (1) that would have required either depending on Go 1.13 (compared to the current 1.11) or replacing `fmt.Errorf` with `golang.org/x/xerrors.Errorf`, and (2) seemed tedious and I didn't really want to put in the effort.  The existing PR covers the errors that I happen to care about.

As an example of what this allows: If I dial an AF_UNIX socket that doesn't exist, (`conn, err := grpc.DialContext(ctx, "unix:/path/to/file.sock", ...)`) I can now check for that condition with `errors.Is(err, os.ErrNotExist)`.

RELEASE NOTES:
* Custom error types now implement the interface for `errors.Unwrap` as appropriate.