### PR TITLE
test: fix possible goroutine leaks in unit tests

### DIFF
--- a/internal/resolver/config_selector_test.go
+++ b/internal/resolver/config_selector_test.go
@@ -48,6 +48,8 @@ func (s) TestSafeConfigSelector(t *testing.T) {
 
 	retChan1 := make(chan *RPCConfig)
 	retChan2 := make(chan *RPCConfig)
+	defer close(retChan1)
+	defer close(retChan2)
 
 	one := 1
 	two := 2
@@ -55,8 +57,8 @@ func (s) TestSafeConfigSelector(t *testing.T) {
 	resp1 := &RPCConfig{MethodConfig: serviceconfig.MethodConfig{MaxReqSize: &one}}
 	resp2 := &RPCConfig{MethodConfig: serviceconfig.MethodConfig{MaxReqSize: &two}}
 
-	cs1Called := make(chan struct{})
-	cs2Called := make(chan struct{})
+	cs1Called := make(chan struct{}, 1)
+	cs2Called := make(chan struct{}, 1)
 
 	cs1 := &fakeConfigSelector{
 		selectConfig: func(r RPCInfo) (*RPCConfig, error) {

--- a/xds/internal/httpfilter/fault/fault_test.go
+++ b/xds/internal/httpfilter/fault/fault_test.go
@@ -608,7 +608,7 @@ func (s) TestFaultInjection_MaxActiveFaults(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	streams := make(chan testpb.TestService_FullDuplexCallClient)
+	streams := make(chan testpb.TestService_FullDuplexCallClient, 5) // startStream() is called 5 times
 	startStream := func() {
 		str, err := client.FullDuplexCall(ctx)
 		if err != nil {
@@ -620,7 +620,7 @@ func (s) TestFaultInjection_MaxActiveFaults(t *testing.T) {
 		str := <-streams
 		str.CloseSend()
 		if _, err := str.Recv(); err != io.EOF {
-			t.Fatal("stream error:", err)
+			t.Error("stream error:", err)
 		}
 	}
 	releaseStream := func() {

--- a/xds/internal/server/listener_wrapper_test.go
+++ b/xds/internal/server/listener_wrapper_test.go
@@ -117,7 +117,10 @@ type fakeListener struct {
 }
 
 func (fl *fakeListener) Accept() (net.Conn, error) {
-	cne := <-fl.acceptCh
+	cne, ok := <-fl.acceptCh
+	if !ok {
+		return nil, errors.New("a non-temporary error")
+	}
 	return cne.conn, cne.err
 }
 
@@ -262,6 +265,7 @@ func (s) TestListenerWrapper_Accept(t *testing.T) {
 		}}, nil)
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
+	defer close(lis.acceptCh)
 	select {
 	case <-ctx.Done():
 		t.Fatalf("timeout waiting for the ready channel to be written to after receipt of a good Listener update")


### PR DESCRIPTION
***Description***
This pull request fixes a few goroutine leak problems when unit tests fail. 
When `t.Fatal()` is called, only the goroutine calling it will be killed, which may leave other goroutines in these three unit tests blocking and occupying additional resources.

***The fix in internal/resolver/config_selector_test.go***
This unit test contains four channels that are used in another child goroutine running `cs1` or `cs2`.
If the unit test calls `t.Fatal()`, the child goroutine will be blocked at an operation of one of the four channels.

Since the child goroutine only uses receive of `retChan1` and `retChan2`, we defer the close of them in main goroutine.
Since the child goroutine only uses send of `cs1Called` and `cs2Called` for one time, we add 1 buffer to them.

***The fix in xds/internal/httpfilter/fault/fault_test.go***
The channel `streams` has a send at the end of , and a receive in `endStream()`.
However, when one of the `endStream()` calls `t.Fatal()`, one of the `startStream()` may block.

Since `startStream()` is called 5 times, we add 5 buffer to the channel `streams`.

***The fix in xds/internal/server/listener_wrapper_test.go***
The channel `lis.acceptCh` is used to pass `connAndErr`.
However, when the main testing goroutine timeouts, the goroutine below will be blocked at `cne := <-fl.acceptCh` on line 120:
https://github.com/grpc/grpc-go/blob/83f9def5feb388c4fd7e6586bd55cf6bf6d46a01/xds/internal/server/listener_wrapper_test.go#L283-L284
https://github.com/grpc/grpc-go/blob/83f9def5feb388c4fd7e6586bd55cf6bf6d46a01/xds/internal/server/listener_wrapper.go#L192-L203
https://github.com/grpc/grpc-go/blob/83f9def5feb388c4fd7e6586bd55cf6bf6d46a01/xds/internal/server/listener_wrapper_test.go#L119-L122

To fix this problem, add a `defer close(lis.acceptCh)`. Now when the main goroutine timeouts, the child goroutine will return a non-temporary error and safely return.

RELEASE NOTES: none