### PR TITLE
clientconn: stop automatically connecting to idle subchannels returned by picker

### DIFF
--- a/clientconn.go
+++ b/clientconn.go
@@ -1429,16 +1429,14 @@ func (ac *addrConn) resetConnectBackoff() {
 	ac.mu.Unlock()
 }
 
-// getReadyTransport returns the transport if ac's state is READY.
-// Otherwise it returns nil, false.
-// If ac's state is IDLE, it will trigger ac to connect.
-func (ac *addrConn) getReadyTransport() (transport.ClientTransport, bool) {
+// getReadyTransport returns the transport if ac's state is READY or nil if not.
+func (ac *addrConn) getReadyTransport() transport.ClientTransport {
 	ac.mu.Lock()
 	defer ac.mu.Unlock()
-	if ac.state == connectivity.Ready && ac.transport != nil {
-		return ac.transport, true
+	if ac.state == connectivity.Ready {
+		return ac.transport
 	}
-	return nil, false
+	return nil
 }
 
 // tearDown starts to tear down the addrConn.

--- a/clientconn.go
+++ b/clientconn.go
@@ -1434,19 +1434,9 @@ func (ac *addrConn) resetConnectBackoff() {
 // If ac's state is IDLE, it will trigger ac to connect.
 func (ac *addrConn) getReadyTransport() (transport.ClientTransport, bool) {
 	ac.mu.Lock()
+	defer ac.mu.Unlock()
 	if ac.state == connectivity.Ready && ac.transport != nil {
-		t := ac.transport
-		ac.mu.Unlock()
-		return t, true
-	}
-	var idle bool
-	if ac.state == connectivity.Idle {
-		idle = true
-	}
-	ac.mu.Unlock()
-	// Trigger idle ac to connect.
-	if idle {
-		ac.connect()
+		return ac.transport, true
 	}
 	return nil, false
 }

--- a/picker_wrapper.go
+++ b/picker_wrapper.go
@@ -147,7 +147,7 @@ func (pw *pickerWrapper) pick(ctx context.Context, failfast bool, info balancer.
 			logger.Error("subconn returned from pick is not *acBalancerWrapper")
 			continue
 		}
-		if t, ok := acw.getAddrConn().getReadyTransport(); ok {
+		if t := acw.getAddrConn().getReadyTransport(); t != nil {
 			if channelz.IsOn() {
 				return t, doneChannelzWrapper(acw, pickResult.Done), nil
 			}


### PR DESCRIPTION
RELEASE NOTES:
- balancer: client channel no longer connects to idle subchannels that are returned by the pickers; LB policy should call SubConn.Connect instead.