### PR TITLE
client: improve GOAWAY debug messages

### DIFF
--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -1237,7 +1237,7 @@ func (t *http2Client) setGoAwayReason(f *http2.GoAwayFrame) {
 	if len(f.DebugData()) == 0 {
 		t.goAwayDebugMessage = fmt.Sprintf("code: %s", f.ErrCode)
 	} else {
-		t.goAwayDebugMessage = fmt.Sprintf("code: %s, debug data: %v", f.ErrCode, string(f.DebugData()))
+		t.goAwayDebugMessage = fmt.Sprintf("code: %s, debug data: %q", f.ErrCode, string(f.DebugData()))
 	}
 }
 

--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -1234,7 +1234,11 @@ func (t *http2Client) setGoAwayReason(f *http2.GoAwayFrame) {
 			t.goAwayReason = GoAwayTooManyPings
 		}
 	}
-	t.goAwayDebugMessage = fmt.Sprintf("code: %s, debug data: %v", f.ErrCode, string(f.DebugData()))
+	if len(f.DebugData()) == 0 {
+		t.goAwayDebugMessage = fmt.Sprintf("code: %s", f.ErrCode)
+	} else {
+		t.goAwayDebugMessage = fmt.Sprintf("code: %s, debug data: %v", f.ErrCode, string(f.DebugData()))
+	}
 }
 
 func (t *http2Client) GetGoAwayReason() (GoAwayReason, string) {

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -1453,7 +1453,7 @@ func (s) TestDetailedGoawayErrorOnAbruptClosePropagatesToRPCError(t *testing.T) 
 	if err != nil {
 		t.Fatalf("%v.FullDuplexCall = _, %v, want _, <nil>", ss.Client, err)
 	}
-	const expectedErrorMessageSubstring = "received prior goaway: code: ENHANCE_YOUR_CALM, debug data: too_many_pings"
+	const expectedErrorMessageSubstring = `received prior goaway: code: ENHANCE_YOUR_CALM, debug data: "too_many_pings"`
 	_, err = stream.Recv()
 	close(rpcDoneOnClient)
 	if err == nil || !strings.Contains(err.Error(), expectedErrorMessageSubstring) {


### PR DESCRIPTION
Builds on
https://github.com/grpc/grpc-go/commit/c229922995e2c1af095282ef4d17abcd7300ecaf

Currently we get logs like `closing transport due to: connection error: desc = "error reading from server: EOF", received prior goaway: code: NO_ERROR, debug data:`
which is confusing since there is no debug data. This just cleans it up a bit.

RELEASE NOTES: N/A