### PR TITLE
doc: delete the redundant blank space in license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -181,7 +181,7 @@
       To apply the Apache License to your work, attach the following
       boilerplate notice, with the fields enclosed by brackets "[]"
       replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
+      the brackets!) The text should be enclosed in the appropriate
       comment syntax for the file format. We also recommend that a
       file or class name and description of purpose be included on the
       same "printed page" as the copyright notice for easier


### PR DESCRIPTION
Delete the redundant blank space in the license file.

RELEASE NOTES: none