### PR TITLE
internal/binarylog: Fix data race when calling Write() and Close() in parallel

### DIFF
--- a/internal/binarylog/sink.go
+++ b/internal/binarylog/sink.go
@@ -133,12 +133,12 @@ func (fs *bufferedSink) startFlushGoroutine() {
 }
 
 func (fs *bufferedSink) Close() error {
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
 	if fs.writeTicker != nil {
 		fs.writeTicker.Stop()
 	}
 	close(fs.done)
-	fs.mu.Lock()
-	defer fs.mu.Unlock()
 	if err := fs.buf.Flush(); err != nil {
 		grpclogLogger.Warningf("failed to flush to Sink: %v", err)
 	}


### PR DESCRIPTION
They both touch bufferedSink.writeTicker

RELEASE NOTES: N/A