### PR TITLE
[xds] Add RDS Handler for Server Side Listener

### DIFF
--- a/xds/internal/resolver/watch_service_test.go
+++ b/xds/internal/resolver/watch_service_test.go
@@ -237,7 +237,7 @@ func (s) TestServiceWatchLDSUpdate(t *testing.T) {
 
 	// Another LDS update with a different RDS_name.
 	xdsC.InvokeWatchListenerCallback(xdsclient.ListenerUpdate{RouteConfigName: routeStr + "2"}, nil)
-	if err := xdsC.WaitForCancelRouteConfigWatch(ctx); err != nil {
+	if _, err := xdsC.WaitForCancelRouteConfigWatch(ctx); err != nil {
 		t.Fatalf("wait for cancel route watch failed: %v, want nil", err)
 	}
 	waitForWatchRouteConfig(ctx, t, xdsC, routeStr+"2")
@@ -354,7 +354,7 @@ func (s) TestServiceNotCancelRDSOnSameLDSUpdate(t *testing.T) {
 	xdsC.InvokeWatchListenerCallback(xdsclient.ListenerUpdate{RouteConfigName: routeStr}, nil)
 	sCtx, sCancel := context.WithTimeout(ctx, defaultTestShortTimeout)
 	defer sCancel()
-	if err := xdsC.WaitForCancelRouteConfigWatch(sCtx); err != context.DeadlineExceeded {
+	if _, err := xdsC.WaitForCancelRouteConfigWatch(sCtx); err != context.DeadlineExceeded {
 		t.Fatalf("wait for cancel route watch failed: %v, want nil", err)
 	}
 }
@@ -402,7 +402,7 @@ func (s) TestServiceWatchInlineRDS(t *testing.T) {
 		VirtualHosts: []*xdsclient.VirtualHost{wantVirtualHosts2},
 	}}, nil)
 	// This inline RDS resource should cause the RDS watch to be canceled.
-	if err := xdsC.WaitForCancelRouteConfigWatch(ctx); err != nil {
+	if _, err := xdsC.WaitForCancelRouteConfigWatch(ctx); err != nil {
 		t.Fatalf("wait for cancel route watch failed: %v, want nil", err)
 	}
 	if err := verifyServiceUpdate(ctx, serviceUpdateCh, wantUpdate2); err != nil {
@@ -429,7 +429,7 @@ func (s) TestServiceWatchInlineRDS(t *testing.T) {
 		VirtualHosts: []*xdsclient.VirtualHost{wantVirtualHosts2},
 	}}, nil)
 	// This inline RDS resource should cause the RDS watch to be canceled.
-	if err := xdsC.WaitForCancelRouteConfigWatch(ctx); err != nil {
+	if _, err := xdsC.WaitForCancelRouteConfigWatch(ctx); err != nil {
 		t.Fatalf("wait for cancel route watch failed: %v, want nil", err)
 	}
 	if err := verifyServiceUpdate(ctx, serviceUpdateCh, wantUpdate2); err != nil {

--- a/xds/internal/server/listener_wrapper.go
+++ b/xds/internal/server/listener_wrapper.go
@@ -22,6 +22,7 @@ package server
 
 import (
 	"fmt"
+	v3routepb "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	"net"
 	"sync"
 	"time"
@@ -92,6 +93,7 @@ func prefixLogger(p *listenerWrapper) *internalgrpclog.PrefixLogger {
 // the listenerWrapper.
 type XDSClient interface {
 	WatchListener(string, func(xdsclient.ListenerUpdate, error)) func()
+	WatchRouteConfig(string, func(xdsclient.RouteConfigUpdate, error)) func()
 	BootstrapConfig() *bootstrap.Config
 }
 
@@ -185,6 +187,12 @@ type listenerWrapper struct {
 	mode ServingMode
 	// Filter chains received as part of the last good update.
 	filterChains *xdsclient.FilterChainManager
+
+	routeNamesToWatch map[string]bool
+	// map[routeName] -> RDSUpdate
+	rdsUpdates map[string]xdsclient.RouteConfigUpdate
+	// map[routeName] -> cancel()
+	rdsCancels map[string]func()
 }
 
 // Accept blocks on an Accept() on the underlying listener, and wraps the
@@ -264,6 +272,7 @@ func (l *listenerWrapper) Accept() (net.Conn, error) {
 			conn.Close()
 			continue
 		}
+		// TODO: once matched here, instantiate the filters, pipe it + override (and route) over to the xdsUnary/Stream interceptors
 		return &connWrapper{Conn: conn, filterChain: fc, parent: l}, nil
 	}
 }
@@ -315,9 +324,46 @@ func (l *listenerWrapper) handleListenerUpdate(update xdsclient.ListenerUpdate, 
 		return
 	}
 
+	// persisted map[string]
+	l.routeNamesToWatch // OldChildren
+
+	ilc.FilterChains.RouteConfigNames // NewChildren
+
+	// Add and start watches for any child nodes to routeNamesToWatch
+	for routeName := range ilc.FilterChains.RouteConfigNames {
+		if _, inLisAlready := l.routeNamesToWatch[routeName]; !inLisAlready {
+			l.routeNamesToWatch[routeName] = true
+			// start watch, persist in map here
+			l.rdsCancels[routeName] = l.xdsC.WatchRouteConfig(routeName, l.handleRDSResp)
+			// Delete from FilterChains?
+		}
+	}
+
+	// Delete and cancel watches for any child nodes from routeNamesToWatch
+	for routeName := range l.routeNamesToWatch {
+		if _, stillRDS := l.routeNamesToWatch[routeName]; !stillRDS {
+			l.rdsCancels[routeName]()
+			delete(l.routeNamesToWatch, routeName)
+		}
+	}
+
+	// "The listenerWrapper should move the server to "serving only after receiving all the required
+	// RDS resources"
 	l.switchMode(ilc.FilterChains, ServingModeServing, nil)
 	l.goodUpdate.Fire()
 }
+
+func (l *listenerWrapper) handleRDSResp(update xdsclient.RouteConfigUpdate, err error) {
+	// Persist in map - although does this actually have access to the name?
+	/*rc := v3routepb.RouteConfiguration{}
+	update.Raw.*/ // This is one way to do it
+	// Name is already plumbed around codebase...figure out someway to get it VVV
+	// Error handling here - what to do?
+	// Protect this map memory with some type of mutex
+	l.rdsUpdates[update.RouteConfigName] = update
+}
+
+// Where do I grab the mutex here?
 
 func (l *listenerWrapper) switchMode(fcs *xdsclient.FilterChainManager, newMode ServingMode, err error) {
 	l.mu.Lock()

--- a/xds/internal/server/listener_wrapper_test.go
+++ b/xds/internal/server/listener_wrapper_test.go
@@ -30,6 +30,7 @@ import (
 
 	v3corepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	v3listenerpb "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	v3routepb "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	v3httppb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	v3tlspb "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	wrapperspb "github.com/golang/protobuf/ptypes/wrappers"
@@ -87,7 +88,20 @@ var listenerWithFilterChains = &v3listenerpb.Listener{
 				{
 					Name: "filter-1",
 					ConfigType: &v3listenerpb.Filter_TypedConfig{
-						TypedConfig: testutils.MarshalAny(&v3httppb.HttpConnectionManager{}),
+						TypedConfig: testutils.MarshalAny(&v3httppb.HttpConnectionManager{
+							RouteSpecifier: &v3httppb.HttpConnectionManager_RouteConfig{
+								RouteConfig: &v3routepb.RouteConfiguration{
+									Name: "routeName",
+									VirtualHosts: []*v3routepb.VirtualHost{{
+										Domains: []string{"lds.target.good:3333"},
+										Routes: []*v3routepb.Route{{
+											Match: &v3routepb.RouteMatch{
+												PathSpecifier: &v3routepb.RouteMatch_Prefix{Prefix: "/"},
+											},
+											Action: &v3routepb.Route_NonForwardingAction{},
+										}}}}},
+							},
+						}),
 					},
 				},
 			},

--- a/xds/internal/server/rds_handler.go
+++ b/xds/internal/server/rds_handler.go
@@ -74,6 +74,8 @@ func (rh *rdsHandler) updateRouteNamesToWatch(routeNamesToWatch map[string]bool)
 func (rh *rdsHandler) handleRouteUpdate(update xdsclient.RouteConfigUpdate, err error) {
 	rh.rdsMutex.Lock()
 	defer rh.rdsMutex.Unlock()
+	// Note: this doesn't need a check for if name in RouteConfigUpdate is wrong
+	// (i.e. not started a watch for). This will be validated in xdsclient.
 	if err != nil {
 		// For a rdsHandler update, the only update wrapped listener cares about
 		// is most recent one, so opportunistically drain the update before
@@ -84,6 +86,7 @@ func (rh *rdsHandler) handleRouteUpdate(update xdsclient.RouteConfigUpdate, err 
 		}
 		rh.updateChannel <- rdsHandlerUpdate{err: err}
 		// Should we delete Route Update here? Or use successful Route Update if previously received?
+		return
 	}
 	rh.rdsUpdates[update.RouteConfigName] = update
 

--- a/xds/internal/server/rds_handler.go
+++ b/xds/internal/server/rds_handler.go
@@ -1,3 +1,21 @@
+/*
+ *
+ * Copyright 2021 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package server
 
 import (

--- a/xds/internal/server/rds_handler.go
+++ b/xds/internal/server/rds_handler.go
@@ -33,8 +33,11 @@ type rdsHandler struct {
 // using the function below.
 func newRdsHandler(parent *listenerWrapper) *rdsHandler { // Tell Easwar routeNamesToWatch will be built in FilterChainManager in PR
 	return &rdsHandler{
-		parent:        parent,
-		updateChannel: make(chan rdsHandlerUpdate, 1),
+		parent:            parent,
+		updateChannel:     make(chan rdsHandlerUpdate, 1),
+		routeNamesToWatch: make(map[string]bool),
+		rdsUpdates:        make(map[string]xdsclient.RouteConfigUpdate),
+		rdsCancels:        make(map[string]func()),
 	}
 }
 

--- a/xds/internal/server/rds_handler.go
+++ b/xds/internal/server/rds_handler.go
@@ -1,20 +1,20 @@
 package server
 
 import (
-	"google.golang.org/grpc/xds/internal/xdsclient"
 	"sync"
+
+	"google.golang.org/grpc/xds/internal/xdsclient"
 )
 
+// rdsHandlerUpdate wraps the full RouteConfigUpdate that are dynamically queried for a given
+// server side listener.
 type rdsHandlerUpdate struct {
 	rdsUpdates map[string]xdsclient.RouteConfigUpdate // Should this have inline as well?
 	err        error
 }
 
-// This handler will get constructed on each LDS update
-
 // rdsHandler handles any RDS queries that need to be started for a given server
 // side listeners Filter Chains (i.e. not inline).
-
 type rdsHandler struct {
 	parent *listenerWrapper
 
@@ -24,15 +24,13 @@ type rdsHandler struct {
 	rdsUpdates        map[string]xdsclient.RouteConfigUpdate
 	rdsCancels        map[string]func()
 
-	updatesReceived int // <- accessed atomically, determines when to send an update to listener wrapper
-	updateChannel   chan rdsHandlerUpdate
+	updateChannel chan rdsHandlerUpdate
 }
 
-// Create once on lis wrapper instantiation - built on construction
 // newRdsHandler is expected to called once on instantiation of a wrapped
-// listener. On any LDS updates on the wrapped listener, the listener should
-// update the handler with the route names (which specify dynamic RDS) using the
-// function below.
+// listener. On any LDS updates the wrapped listener receives, the listener
+// should update the handler with the route names (which specify dynamic RDS)
+// using the function below.
 func newRdsHandler(parent *listenerWrapper) *rdsHandler { // Tell Easwar routeNamesToWatch will be built in FilterChainManager in PR
 	return &rdsHandler{
 		parent:        parent,
@@ -40,13 +38,14 @@ func newRdsHandler(parent *listenerWrapper) *rdsHandler { // Tell Easwar routeNa
 	}
 }
 
-// updateRouteNamesToWatch handles a list of route names to watch for a given server side listener (if a filter
-// chain specifies dynamic RDS configuration). This function handles all the logic with respect to any routes that
-// may have been added or deleted as compared to what was previously present.
+// updateRouteNamesToWatch handles a list of route names to watch for a given
+// server side listener (if a filter chain specifies dynamic RDS configuration).
+// This function handles all the logic with respect to any routes that may have
+// been added or deleted as compared to what was previously present.
 func (rh *rdsHandler) updateRouteNamesToWatch(routeNamesToWatch map[string]bool) {
 	rh.rdsMutex.Lock()
 	defer rh.rdsMutex.Unlock()
-	// Add and start watches for any routes for any new routes in routeNamesToWatch
+	// Add and start watches for any routes for any new routes in routeNamesToWatch.
 	for routeName := range routeNamesToWatch {
 		if _, inRHAlready := rh.routeNamesToWatch[routeName]; !inRHAlready {
 			rh.routeNamesToWatch[routeName] = true
@@ -61,29 +60,28 @@ func (rh *rdsHandler) updateRouteNamesToWatch(routeNamesToWatch map[string]bool)
 			rh.rdsCancels[routeName]()
 			delete(rh.rdsCancels, routeName)
 			delete(rh.routeNamesToWatch, routeName)
-			// DELETE FROM UPDATE LIST (IF PRESENT!!!!)
+			delete(rh.rdsUpdates, routeName)
 		}
 	}
-
-	// Anything else...sit down and work this out in notebook
 }
 
-// func (rh *rdsHandler) updateRouteNamesToWatch??
-// update on lis wrapper update?
-
+// handleRouteUpdate persists the route config for a given route name, and also
+// sends an update to the Listener Wrapper on an error received or if the rds
+// handler has a full collection of updates.
 func (rh *rdsHandler) handleRouteUpdate(update xdsclient.RouteConfigUpdate, err error) {
 	rh.rdsMutex.Lock()
 	defer rh.rdsMutex.Unlock()
 	if err != nil {
-		// For a rdsHandler update, the only update lis wrapper cares about is most recent one,
-		// so opportunistically drain the update before sending the new update.
+		// For a rdsHandler update, the only update wrapped listener cares about
+		// is most recent one, so opportunistically drain the update before
+		// sending the new update.
 		select {
 		case <-rh.updateChannel:
 		default:
 		}
 		rh.updateChannel <- rdsHandlerUpdate{err: err}
+		// Should we delete Route Update here? Or use successful Route Update if previously received?
 	}
-	// Error handling here, send handleLDSResp an error
 	rh.rdsUpdates[update.RouteConfigName] = update
 
 	// If the full list (determined by length) of rdsUpdates have successfully updated,
@@ -99,10 +97,11 @@ func (rh *rdsHandler) handleRouteUpdate(update xdsclient.RouteConfigUpdate, err 
 	}
 }
 
+// close() is meant to be called by wrapped listener when the wrapped listener is closed,
+// and it cleans up resources by canceling all the active RDS watches.
 func (rh *rdsHandler) close() {
 	rh.rdsMutex.Lock()
 	defer rh.rdsMutex.Unlock()
-	// logical cleanup, so should cancel all the watches that are present
 	for _, cancel := range rh.rdsCancels {
 		cancel()
 	}

--- a/xds/internal/server/rds_handler.go
+++ b/xds/internal/server/rds_handler.go
@@ -9,7 +9,7 @@ import (
 // rdsHandlerUpdate wraps the full RouteConfigUpdate that are dynamically queried for a given
 // server side listener.
 type rdsHandlerUpdate struct {
-	rdsUpdates map[string]xdsclient.RouteConfigUpdate // Should this have inline as well?
+	rdsUpdates map[string]xdsclient.RouteConfigUpdate
 	err        error
 }
 
@@ -31,7 +31,7 @@ type rdsHandler struct {
 // listener. On any LDS updates the wrapped listener receives, the listener
 // should update the handler with the route names (which specify dynamic RDS)
 // using the function below.
-func newRdsHandler(parent *listenerWrapper) *rdsHandler { // Tell Easwar routeNamesToWatch will be built in FilterChainManager in PR
+func newRdsHandler(parent *listenerWrapper) *rdsHandler {
 	return &rdsHandler{
 		parent:            parent,
 		updateChannel:     make(chan rdsHandlerUpdate, 1),
@@ -85,7 +85,6 @@ func (rh *rdsHandler) handleRouteUpdate(update xdsclient.RouteConfigUpdate, err 
 		default:
 		}
 		rh.updateChannel <- rdsHandlerUpdate{err: err}
-		// Should we delete Route Update here? Or use successful Route Update if previously received?
 		return
 	}
 	rh.rdsUpdates[update.RouteConfigName] = update
@@ -112,8 +111,3 @@ func (rh *rdsHandler) close() {
 		cancel()
 	}
 }
-
-// Watch Service LDS received, starts RDS, in handle RDS is where stuff happens (i.e. logic iterates), similar to what we need
-// here with Serving state.
-
-// (ADDING ROUTE CONFIG NAME WILL BE A SEPERATE PR)..., also maybe should add (list of RDS Names to start a watch for to PR in flight rn)

--- a/xds/internal/server/rds_handler.go
+++ b/xds/internal/server/rds_handler.go
@@ -1,0 +1,114 @@
+package server
+
+import (
+	"google.golang.org/grpc/xds/internal/xdsclient"
+	"sync"
+)
+
+type rdsHandlerUpdate struct {
+	rdsUpdates map[string]xdsclient.RouteConfigUpdate // Should this have inline as well?
+	err        error
+}
+
+// This handler will get constructed on each LDS update
+
+// rdsHandler handles any RDS queries that need to be started for a given server
+// side listeners Filter Chains (i.e. not inline).
+
+type rdsHandler struct {
+	parent *listenerWrapper
+
+	rdsMutex sync.Mutex
+
+	routeNamesToWatch map[string]bool
+	rdsUpdates        map[string]xdsclient.RouteConfigUpdate
+	rdsCancels        map[string]func()
+
+	updatesReceived int // <- accessed atomically, determines when to send an update to listener wrapper
+	updateChannel   chan rdsHandlerUpdate
+}
+
+// Create once on lis wrapper instantiation - built on construction
+// newRdsHandler is expected to called once on instantiation of a wrapped
+// listener. On any LDS updates on the wrapped listener, the listener should
+// update the handler with the route names (which specify dynamic RDS) using the
+// function below.
+func newRdsHandler(parent *listenerWrapper) *rdsHandler { // Tell Easwar routeNamesToWatch will be built in FilterChainManager in PR
+	return &rdsHandler{
+		parent:        parent,
+		updateChannel: make(chan rdsHandlerUpdate, 1),
+	}
+}
+
+// updateRouteNamesToWatch handles a list of route names to watch for a given server side listener (if a filter
+// chain specifies dynamic RDS configuration). This function handles all the logic with respect to any routes that
+// may have been added or deleted as compared to what was previously present.
+func (rh *rdsHandler) updateRouteNamesToWatch(routeNamesToWatch map[string]bool) {
+	rh.rdsMutex.Lock()
+	defer rh.rdsMutex.Unlock()
+	// Add and start watches for any routes for any new routes in routeNamesToWatch
+	for routeName := range routeNamesToWatch {
+		if _, inRHAlready := rh.routeNamesToWatch[routeName]; !inRHAlready {
+			rh.routeNamesToWatch[routeName] = true
+			rh.rdsCancels[routeName] = rh.parent.xdsC.WatchRouteConfig(routeName, rh.handleRouteUpdate)
+		}
+	}
+
+	// Delete and cancel watches for any routes from persisted routeNamesToWatch
+	// that are no longer present.
+	for routeName := range rh.routeNamesToWatch {
+		if _, stillRDS := routeNamesToWatch[routeName]; !stillRDS {
+			rh.rdsCancels[routeName]()
+			delete(rh.rdsCancels, routeName)
+			delete(rh.routeNamesToWatch, routeName)
+			// DELETE FROM UPDATE LIST (IF PRESENT!!!!)
+		}
+	}
+
+	// Anything else...sit down and work this out in notebook
+}
+
+// func (rh *rdsHandler) updateRouteNamesToWatch??
+// update on lis wrapper update?
+
+func (rh *rdsHandler) handleRouteUpdate(update xdsclient.RouteConfigUpdate, err error) {
+	rh.rdsMutex.Lock()
+	defer rh.rdsMutex.Unlock()
+	if err != nil {
+		// For a rdsHandler update, the only update lis wrapper cares about is most recent one,
+		// so opportunistically drain the update before sending the new update.
+		select {
+		case <-rh.updateChannel:
+		default:
+		}
+		rh.updateChannel <- rdsHandlerUpdate{err: err}
+	}
+	// Error handling here, send handleLDSResp an error
+	rh.rdsUpdates[update.RouteConfigName] = update
+
+	// If the full list (determined by length) of rdsUpdates have successfully updated,
+	// the listener is ready to be updated.
+	if len(rh.rdsUpdates) == len(rh.routeNamesToWatch) {
+		// For a rdsHandler update, the only update lis wrapper cares about is most recent one,
+		// so opportunistically drain the update before sending the new update.
+		select {
+		case <-rh.updateChannel:
+		default:
+		}
+		rh.updateChannel <- rdsHandlerUpdate{rdsUpdates: rh.rdsUpdates}
+	}
+}
+
+func (rh *rdsHandler) close() {
+	rh.rdsMutex.Lock()
+	defer rh.rdsMutex.Unlock()
+	// logical cleanup, so should cancel all the watches that are present
+	for _, cancel := range rh.rdsCancels {
+		cancel()
+	}
+}
+
+// Watch Service LDS received, starts RDS, in handle RDS is where stuff happens (i.e. logic iterates), similar to what we need
+// here with Serving state.
+
+// (ADDING ROUTE CONFIG NAME WILL BE A SEPERATE PR)..., also maybe should add (list of RDS Names to start a watch for to PR in flight rn)

--- a/xds/internal/server/rds_handler_test.go
+++ b/xds/internal/server/rds_handler_test.go
@@ -11,6 +11,8 @@ import (
 
 var (
 	route1 = "route1"
+	route2 = "route2"
+	route3 = "route3"
 )
 
 // setupTests creates a rds handler with a fake xds client for control over the
@@ -69,3 +71,156 @@ func (s) TestSuccessCaseOneRDSWatch(t *testing.T) {
 		t.Fatalf("xdsClient.CancelRDS called for route %v, want %v", routeNameDeleted, route1)
 	}
 } // Cleanup (including other files vs. the route config PR I just sent out) + Just get this build working before even trying to add new tests
+
+// test case 1 < A
+
+// test case 2 < A, then AB
+// TestSuccessCaseTwoUpdates tests the case where the rds handler receives an update with a single Route, then receives
+// a second update with two routes. The handler should start a watch for the added route, and if received a RDS update for that
+// route it should send an update with both RDS updates present.
+func (s) TestSuccessCaseTwoUpdates(t *testing.T) {
+	rh, fakeClient := setupTests(t)
+
+	routeNames := map[string]bool{route1: true}
+	rh.updateRouteNamesToWatch(routeNames)
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	_, err := fakeClient.WaitForWatchRouteConfig(ctx)
+	if err != nil {
+		t.Fatalf("xdsClient.WatchRDS failed with error: %v", err)
+	}
+
+	// Update the RDSHandler with route names which adds a route name to watch.
+	// This should trigger the RDSHandler to start a watch for the added route
+	// name to watch.
+	routeNames = map[string]bool{route1: true, route2: true}
+	rh.updateRouteNamesToWatch(routeNames)
+	gotRoute, err := fakeClient.WaitForWatchRouteConfig(ctx)
+	if err != nil {
+		t.Fatalf("xdsClient.WatchRDS failed with error: %v", err)
+	}
+	if gotRoute != route2 {
+		t.Fatalf("xdsClient.WatchRDS called for route: %v, want %v", gotRoute, route2)
+	}
+
+	// Invoke the callback with an update for route 1. This shouldn't cause the
+	// handler to write an update, as it has not received RouteConfigurations
+	// for every RouteName.
+	rdsUpdate1 := xdsclient.RouteConfigUpdate{
+		RouteConfigName: route1,
+	}
+	fakeClient.InvokeWatchRouteConfigCallback(rdsUpdate1, nil)
+
+	// The RDS Handler should not send an update.
+	shouldNotHappenCtx, shouldNotHappenCtxCancel := context.WithTimeout(context.Background(), defaultTestShortTimeout)
+	defer shouldNotHappenCtxCancel()
+	select {
+	case <-rh.updateChannel:
+		t.Fatal("RDS Handler wrote an update to updateChannel when it shouldn't have, as each route name has not received an update yet")
+	case <-shouldNotHappenCtx.Done():
+	}
+
+	// Invoke the callback with an update for route 2. This should cause the
+	// handler to write an update, as it has received RouteConfigurations for
+	// every RouteName.
+	rdsUpdate2 := xdsclient.RouteConfigUpdate{
+		RouteConfigName: route2,
+	}
+	fakeClient.InvokeWatchRouteConfigCallback(rdsUpdate2, nil)
+	// The RDS Handler should then update the listener wrapper with an update
+	// with two route configurations, as both route names the RDS Handler handles
+	// have received an update.
+	rhuWant := map[string]xdsclient.RouteConfigUpdate{route1: rdsUpdate1, route2: rdsUpdate2}
+	select {
+	case rhu := <-rh.updateChannel:
+		if diff := cmp.Diff(rhu.rdsUpdates, rhuWant); diff != "" {
+			t.Fatalf("got unexpected route update, diff (-got, +want): %v", diff)
+		}
+	case <-ctx.Done():
+		t.Fatal("Timed out waiting for the rds handler update to be written to the update buffer.")
+	}
+
+	// Close the rds handler. This is meant to be called when the lis wrapper is
+	// closed, and the call should cancel all the watches present (for this
+	// test, two watches on route1 and route2).
+	rh.close()
+	routeNameDeleted, err := fakeClient.WaitForCancelRouteConfigWatch(ctx)
+	if err != nil {
+		t.Fatalf("xdsClient.CancelRDS failed with error: %v", err)
+	}
+	if routeNameDeleted != route1 && routeNameDeleted != route2 {
+		t.Fatalf("xdsClient.CancelRDS called for route %v, want %v or %v", routeNameDeleted, route1, route2)
+	}
+
+	routeNameDeleted, err = fakeClient.WaitForCancelRouteConfigWatch(ctx)
+	if err != nil {
+		t.Fatalf("xdsClient.CancelRDS failed with error: %v", err)
+	}
+	if routeNameDeleted != route1 && routeNameDeleted != route2 {
+		t.Fatalf("xdsClient.CancelRDS called for route %v, want %v or %v", routeNameDeleted, route1, route2)
+	}
+}
+
+// test case 3 < AB, A
+// TestSuccessCaseDeletedRoute tests the case where the rds handler receives an update with two routes,
+// then receives an update with only
+func (s) TestSuccessCaseDeletedRoute(t *testing.T) {
+	rh, fakeClient := setupTests(t)
+
+	routeNames := map[string]bool{route1: true, route2: true}
+	rh.updateRouteNamesToWatch(routeNames)
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	// Will start two watches.
+	_, err := fakeClient.WaitForWatchRouteConfig(ctx)
+	if err != nil {
+		t.Fatalf("xdsClient.WatchRDS failed with error: %v", err)
+	}
+	_, err = fakeClient.WaitForWatchRouteConfig(ctx)
+	if err != nil {
+		t.Fatalf("xdsClient.WatchRDS failed with error %v", err)
+	}
+
+	// Update the RDSHandler with route names which deletes a route name to
+	// watch. This should trigger the RDSHandler to cancel the watch for the
+	// deleted route name to watch.
+	routeNames = map[string]bool{route1: true}
+	rh.updateRouteNamesToWatch(routeNames)
+	// This should delete the watch for route2.
+	routeNameDeleted, err := fakeClient.WaitForCancelRouteConfigWatch(ctx)
+	if err != nil {
+		t.Fatalf("xdsClient.CancelRDS failed with error %v", err)
+	}
+	if routeNameDeleted != route2 {
+		t.Fatalf("xdsClient.CancelRDS called for route %v, want %v", routeNameDeleted, route2)
+	}
+
+	rh.close()
+	_, err = fakeClient.WaitForCancelRouteConfigWatch(ctx)
+	if err != nil {
+		t.Fatalf("xdsClient.CancelRDS failed with error: %v", err)
+	}
+}
+
+// test case 4 < AB, BC
+// TestSuccessCaseTwoUpdatesAddAndDeleteRoute tests the case where the rds
+// handler receives an update with two routes, and then receives an update with
+// two routes, one previously there and one added (i.e. 12 -> 23). This should
+// cause the route that is no longer there to be deleted and cancelled, and the
+// route that was added should have a watch started for it.
+/*func (s) TestSuccessCaseTwoUpdatesAddAndDeleteRoute(t *testing.T) {
+	rh, fakeClient := setupTests(t)
+
+	routeNames := map[string]bool{route1: true, route2: true}
+	rh.updateRouteNamesToWatch(routeNames)
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	_, err := fakeClient.WaitForWatchRouteConfig(ctx)
+}*/
+
+// Perhaps still test the update buffer to test the three maps present, in case
+// something goes wrong in the logic for the three maps data.
+
+// error case

--- a/xds/internal/server/rds_handler_test.go
+++ b/xds/internal/server/rds_handler_test.go
@@ -1,3 +1,21 @@
+/*
+ *
+ * Copyright 2021 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package server
 
 import (

--- a/xds/internal/server/rds_handler_test.go
+++ b/xds/internal/server/rds_handler_test.go
@@ -1,0 +1,65 @@
+package server
+
+import (
+	"context"
+	"google.golang.org/grpc/xds/internal/testutils/fakeclient"
+	"google.golang.org/grpc/xds/internal/xdsclient"
+	"testing"
+)
+
+var (
+	route1 = "route1"
+)
+
+// setupTests creates a rds handler with a fake xds client for control over the
+// xdsclient. It also starts the rdsHandler with the certain routeNamesToWatch
+// (in practice, this will come from the Filter Chain Manager).
+func setupTests(t *testing.T) (*rdsHandler, *fakeclient.Client) {
+	xdsC := fakeclient.NewClient()
+	rh := newRdsHandler(&listenerWrapper{xdsC: xdsC}) // Will fake the listener component
+	return rh, xdsC
+}
+
+// Simplest test: the rds handler receives a route name of length 1, starts a watch, gets a successful update
+// and then writes an update to update channel.
+func (s) TestSuccessCaseOneRDSWatch(t *testing.T) {
+	rh, fakeClient := setupTests(t)
+	// When you first update the rds handler with a list of a single Route names that needs dynamic RDS Configuration,
+	// this Route name has not been seen before, so the RDS Handler should start a watch on that RouteName.
+	//
+	routeNames := map[string]bool{route1: true}
+	rh.updateRouteNamesToWatch(routeNames)
+	// The RDS Handler should start a watch for that routeName.
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	gotRoute, err := fakeClient.WaitForWatchRouteConfig(ctx)
+	if err != nil {
+		t.Fatalf("xdsClient.WatchRDS failed with error: %v", err)
+	}
+	if gotRoute != route1 {
+		t.Fatalf("xdsClient.WatchRDS called for route: %v, want %v", gotRoute, route1)
+	}
+	rdsUpdate := xdsclient.RouteConfigUpdate{
+		RouteConfigName: "route1",
+	}
+	// Invoke callback with the xds client with a certain route update. Due to this route update
+	// updating every route name that rds handler handles, this should write to the update channel
+	// to send to the listener.
+	fakeClient.InvokeWatchRouteConfigCallback(rdsUpdate, nil)
+	select {
+	case rhu := <-rh.updateChannel:
+
+	case <-ctx.Done():
+		t.Fatal("Timed out waiting for update from update channel.")
+	}
+	// Close the rds handler. This is meant to be called when the lis wrapper is closed, and the call
+	// should cancel all the watches present (for this test, a single watch).
+	rh.close()
+	routeNameDeleted, err := fakeClient.WaitForCancelRouteConfigWatch(ctx)
+	if err != nil {
+		t.Fatalf("xdsClient.CancelRDS failed with error: %v", err)
+	}
+	if routeNmae
+}
+
+// I need to add close() to rdsHandler to clean up and close all the watches

--- a/xds/internal/server/rds_handler_test.go
+++ b/xds/internal/server/rds_handler_test.go
@@ -24,9 +24,10 @@ func setupTests(t *testing.T) (*rdsHandler, *fakeclient.Client) {
 	return rh, xdsC
 }
 
-// Simplest test: the rds handler receives a route name of length 1, starts a
-// watch, gets a successful update, and then writes an update to the update
-// channel for listener to pick up.
+// TestSuccessCaseOneRDSWatch tests the simplest scenario: the rds handler
+// receives a single route name, starts a watch for that route name, gets a
+// successful update, and then writes an update to the update channel for
+// listener to pick up.
 func (s) TestSuccessCaseOneRDSWatch(t *testing.T) {
 	rh, fakeClient := setupTests(t)
 	// When you first update the rds handler with a list of a single Route names
@@ -71,14 +72,12 @@ func (s) TestSuccessCaseOneRDSWatch(t *testing.T) {
 	if routeNameDeleted != route1 {
 		t.Fatalf("xdsClient.CancelRDS called for route %v, want %v", routeNameDeleted, route1)
 	}
-} // Cleanup (including other files vs. the route config PR I just sent out) + Just get this build working before even trying to add new tests
+}
 
-// test case 1 < A
-
-// test case 2 < A, then AB
-// TestSuccessCaseTwoUpdates tests the case where the rds handler receives an update with a single Route, then receives
-// a second update with two routes. The handler should start a watch for the added route, and if received a RDS update for that
-// route it should send an update with both RDS updates present.
+// TestSuccessCaseTwoUpdates tests the case where the rds handler receives an
+// update with a single Route, then receives a second update with two routes.
+// The handler should start a watch for the added route, and if received a RDS
+// update for that route it should send an update with both RDS updates present.
 func (s) TestSuccessCaseTwoUpdates(t *testing.T) {
 	rh, fakeClient := setupTests(t)
 
@@ -163,9 +162,9 @@ func (s) TestSuccessCaseTwoUpdates(t *testing.T) {
 	}
 }
 
-// test case 3 < AB, A
-// TestSuccessCaseDeletedRoute tests the case where the rds handler receives an update with two routes,
-// then receives an update with only
+// TestSuccessCaseDeletedRoute tests the case where the rds handler receives an
+// update with two routes, then receives an update with only one route. The RDS
+// Handler is expected to cancel the watch for the route no longer present.
 func (s) TestSuccessCaseDeletedRoute(t *testing.T) {
 	rh, fakeClient := setupTests(t)
 
@@ -221,7 +220,6 @@ func (s) TestSuccessCaseDeletedRoute(t *testing.T) {
 	}
 }
 
-// test case 4 < AB, BC
 // TestSuccessCaseTwoUpdatesAddAndDeleteRoute tests the case where the rds
 // handler receives an update with two routes, and then receives an update with
 // two routes, one previously there and one added (i.e. 12 -> 23). This should
@@ -325,9 +323,6 @@ func (s) TestSuccessCaseTwoUpdatesAddAndDeleteRoute(t *testing.T) {
 		t.Fatalf("xdsClient.CancelRDS called for route %v, want %v or %v", routeNameDeleted, route2, route3)
 	}
 }
-
-// Perhaps still test the update buffer to test the three maps present, in case
-// something goes wrong in the logic for the three maps data.
 
 // TestErrorReceived tests the case where the rds handler receives a route name
 // to watch, then receives an update with an error. This error should be then

--- a/xds/internal/server/rds_handler_test.go
+++ b/xds/internal/server/rds_handler_test.go
@@ -2,9 +2,11 @@ package server
 
 import (
 	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
 	"google.golang.org/grpc/xds/internal/testutils/fakeclient"
 	"google.golang.org/grpc/xds/internal/xdsclient"
-	"testing"
 )
 
 var (
@@ -12,21 +14,21 @@ var (
 )
 
 // setupTests creates a rds handler with a fake xds client for control over the
-// xdsclient. It also starts the rdsHandler with the certain routeNamesToWatch
-// (in practice, this will come from the Filter Chain Manager).
+// xds client.
 func setupTests(t *testing.T) (*rdsHandler, *fakeclient.Client) {
 	xdsC := fakeclient.NewClient()
-	rh := newRdsHandler(&listenerWrapper{xdsC: xdsC}) // Will fake the listener component
+	rh := newRdsHandler(&listenerWrapper{xdsC: xdsC})
 	return rh, xdsC
 }
 
-// Simplest test: the rds handler receives a route name of length 1, starts a watch, gets a successful update
-// and then writes an update to update channel.
+// Simplest test: the rds handler receives a route name of length 1, starts a
+// watch, gets a successful update, and then writes an update to the update
+// channel for listener to pick up.
 func (s) TestSuccessCaseOneRDSWatch(t *testing.T) {
 	rh, fakeClient := setupTests(t)
-	// When you first update the rds handler with a list of a single Route names that needs dynamic RDS Configuration,
-	// this Route name has not been seen before, so the RDS Handler should start a watch on that RouteName.
-	//
+	// When you first update the rds handler with a list of a single Route names
+	// that needs dynamic RDS Configuration, this Route name has not been seen
+	// before, so the RDS Handler should start a watch on that RouteName.
 	routeNames := map[string]bool{route1: true}
 	rh.updateRouteNamesToWatch(routeNames)
 	// The RDS Handler should start a watch for that routeName.
@@ -40,26 +42,30 @@ func (s) TestSuccessCaseOneRDSWatch(t *testing.T) {
 		t.Fatalf("xdsClient.WatchRDS called for route: %v, want %v", gotRoute, route1)
 	}
 	rdsUpdate := xdsclient.RouteConfigUpdate{
-		RouteConfigName: "route1",
+		RouteConfigName: route1,
 	}
-	// Invoke callback with the xds client with a certain route update. Due to this route update
-	// updating every route name that rds handler handles, this should write to the update channel
-	// to send to the listener.
+	// Invoke callback with the xds client with a certain route update. Due to
+	// this route update updating every route name that rds handler handles,
+	// this should write to the update channel to send to the listener.
 	fakeClient.InvokeWatchRouteConfigCallback(rdsUpdate, nil)
+	rhuWant := map[string]xdsclient.RouteConfigUpdate{route1: rdsUpdate}
 	select {
 	case rhu := <-rh.updateChannel:
-
+		if diff := cmp.Diff(rhu.rdsUpdates, rhuWant); diff != "" {
+			t.Fatalf("got unexpected route update, diff (-got, +want): %v", diff)
+		}
 	case <-ctx.Done():
 		t.Fatal("Timed out waiting for update from update channel.")
 	}
-	// Close the rds handler. This is meant to be called when the lis wrapper is closed, and the call
-	// should cancel all the watches present (for this test, a single watch).
+	// Close the rds handler. This is meant to be called when the lis wrapper is
+	// closed, and the call should cancel all the watches present (for this
+	// test, a single watch).
 	rh.close()
 	routeNameDeleted, err := fakeClient.WaitForCancelRouteConfigWatch(ctx)
 	if err != nil {
 		t.Fatalf("xdsClient.CancelRDS failed with error: %v", err)
 	}
-	if routeNmae
-}
-
-// I need to add close() to rdsHandler to clean up and close all the watches
+	if routeNameDeleted != route1 {
+		t.Fatalf("xdsClient.CancelRDS called for route %v, want %v", routeNameDeleted, route1)
+	}
+} // Cleanup (including other files vs. the route config PR I just sent out) + Just get this build working before even trying to add new tests

--- a/xds/internal/server/rds_handler_test.go
+++ b/xds/internal/server/rds_handler_test.go
@@ -1,3 +1,5 @@
+// +build go1.12
+
 /*
  *
  * Copyright 2021 gRPC authors.

--- a/xds/internal/testutils/e2e/clientresources.go
+++ b/xds/internal/testutils/e2e/clientresources.go
@@ -199,7 +199,20 @@ func DefaultServerListener(host string, port uint32, secLevel SecurityLevel) *v3
 					{
 						Name: "filter-1",
 						ConfigType: &v3listenerpb.Filter_TypedConfig{
-							TypedConfig: testutils.MarshalAny(&v3httppb.HttpConnectionManager{}),
+							TypedConfig: testutils.MarshalAny(&v3httppb.HttpConnectionManager{
+								RouteSpecifier: &v3httppb.HttpConnectionManager_RouteConfig{
+									RouteConfig: &v3routepb.RouteConfiguration{
+										Name: "routeName",
+										VirtualHosts: []*v3routepb.VirtualHost{{
+											Domains: []string{"lds.target.good:3333"},
+											Routes: []*v3routepb.Route{{
+												Match: &v3routepb.RouteMatch{
+													PathSpecifier: &v3routepb.RouteMatch_Prefix{Prefix: "/"},
+												},
+												Action: &v3routepb.Route_NonForwardingAction{},
+											}}}}},
+								},
+							}),
 						},
 					},
 				},
@@ -230,7 +243,20 @@ func DefaultServerListener(host string, port uint32, secLevel SecurityLevel) *v3
 					{
 						Name: "filter-1",
 						ConfigType: &v3listenerpb.Filter_TypedConfig{
-							TypedConfig: testutils.MarshalAny(&v3httppb.HttpConnectionManager{}),
+							TypedConfig: testutils.MarshalAny(&v3httppb.HttpConnectionManager{
+								RouteSpecifier: &v3httppb.HttpConnectionManager_RouteConfig{
+									RouteConfig: &v3routepb.RouteConfiguration{
+										Name: "routeName",
+										VirtualHosts: []*v3routepb.VirtualHost{{
+											Domains: []string{"lds.target.good:3333"},
+											Routes: []*v3routepb.Route{{
+												Match: &v3routepb.RouteMatch{
+													PathSpecifier: &v3routepb.RouteMatch_Prefix{Prefix: "/"},
+												},
+												Action: &v3routepb.Route_NonForwardingAction{},
+											}}}}},
+								},
+							}),
 						},
 					},
 				},

--- a/xds/internal/testutils/fakeclient/client.go
+++ b/xds/internal/testutils/fakeclient/client.go
@@ -296,11 +296,11 @@ func NewClientWithName(name string) *Client {
 	return &Client{
 		name:         name,
 		ldsWatchCh:   testutils.NewChannel(),
-		rdsWatchCh:   testutils.NewChannel(),
+		rdsWatchCh:   testutils.NewChannelWithSize(10),
 		cdsWatchCh:   testutils.NewChannelWithSize(10),
 		edsWatchCh:   testutils.NewChannelWithSize(10),
 		ldsCancelCh:  testutils.NewChannel(),
-		rdsCancelCh:  testutils.NewChannel(),
+		rdsCancelCh:  testutils.NewChannelWithSize(10),
 		cdsCancelCh:  testutils.NewChannelWithSize(10),
 		edsCancelCh:  testutils.NewChannelWithSize(10),
 		loadReportCh: testutils.NewChannel(),

--- a/xds/internal/testutils/fakeclient/client.go
+++ b/xds/internal/testutils/fakeclient/client.go
@@ -122,9 +122,12 @@ func (xdsC *Client) InvokeWatchRouteConfigCallback(update xdsclient.RouteConfigU
 
 // WaitForCancelRouteConfigWatch waits for a RDS watch to be cancelled  and returns
 // context.DeadlineExceeded otherwise.
-func (xdsC *Client) WaitForCancelRouteConfigWatch(ctx context.Context) error {
-	_, err := xdsC.rdsCancelCh.Receive(ctx)
-	return err
+func (xdsC *Client) WaitForCancelRouteConfigWatch(ctx context.Context) (string, error) {
+	val, err := xdsC.rdsCancelCh.Receive(ctx)
+	if err != nil {
+		return "", err
+	}
+	return val.(string), err
 }
 
 // WatchCluster registers a CDS watch.

--- a/xds/internal/testutils/fakeclient/client.go
+++ b/xds/internal/testutils/fakeclient/client.go
@@ -98,7 +98,7 @@ func (xdsC *Client) WatchRouteConfig(routeName string, callback func(xdsclient.R
 	xdsC.rdsCb = callback
 	xdsC.rdsWatchCh.Send(routeName)
 	return func() {
-		xdsC.rdsCancelCh.Send(nil)
+		xdsC.rdsCancelCh.Send(routeName)
 	}
 }
 

--- a/xds/internal/xdsclient/client.go
+++ b/xds/internal/xdsclient/client.go
@@ -250,6 +250,9 @@ type InboundListenerConfig struct {
 // RouteConfigUpdate contains information received in an RDS response, which is
 // of interest to the registered RDS watcher.
 type RouteConfigUpdate struct {
+	// Persist the name here that way we can view it in listener wrapper
+	RouteConfigName string // TODO today <- populate this field
+
 	VirtualHosts []*VirtualHost
 
 	// Raw is the resource from the xds response.

--- a/xds/internal/xdsclient/client.go
+++ b/xds/internal/xdsclient/client.go
@@ -250,8 +250,9 @@ type InboundListenerConfig struct {
 // RouteConfigUpdate contains information received in an RDS response, which is
 // of interest to the registered RDS watcher.
 type RouteConfigUpdate struct {
-	// Persist the name here that way we can view it in listener wrapper
-	RouteConfigName string // TODO today <- populate this field
+	// RouteConfigName - Persist the name here that way we can view it in
+	// listener wrapper
+	RouteConfigName string
 
 	VirtualHosts []*VirtualHost
 

--- a/xds/internal/xdsclient/filter_chain.go
+++ b/xds/internal/xdsclient/filter_chain.go
@@ -54,6 +54,15 @@ type FilterChain struct {
 	SecurityCfg *SecurityConfig
 	// HTTPFilters represent the HTTP Filters that comprise this FilterChain.
 	HTTPFilters []HTTPFilter
+	// RouteConfigName is the route configuration name for this FilterChain.
+	//
+	// Only one of RouteConfigName and InlineRouteConfig is set.
+	RouteConfigName string
+	// InlineRouteConfig is the inline route configuration (RDS response)
+	// returned for this filter chain.
+	//
+	// Only one of RouteConfigName and InlineRouteConfig is set.
+	InlineRouteConfig *RouteConfigUpdate
 }
 
 // SourceType specifies the connection source IP match type.
@@ -393,11 +402,11 @@ func (fci *FilterChainManager) addFilterChainsForSourcePorts(srcEntry *sourcePre
 // filterChainFromProto extracts the relevant information from the FilterChain
 // proto and stores it in our internal representation.
 func filterChainFromProto(fc *v3listenerpb.FilterChain) (*FilterChain, error) {
-	httpFilters, err := processNetworkFilters(fc.GetFilters())
+	filterChain, err := processNetworkFilters(fc.GetFilters())
 	if err != nil {
 		return nil, err
 	}
-	filterChain := &FilterChain{HTTPFilters: httpFilters}
+	// filterChain := &FilterChain{HTTPFilters: httpFilters}
 	// If the transport_socket field is not specified, it means that the control
 	// plane has not sent us any security config. This is fine and the server
 	// will use the fallback credentials configured as part of the

--- a/xds/internal/xdsclient/filter_chain.go
+++ b/xds/internal/xdsclient/filter_chain.go
@@ -215,6 +215,10 @@ func NewFilterChainManager(lis *v3listenerpb.Listener) (*FilterChainManager, err
 	if !fcSeen && fci.def == nil {
 		return nil, fmt.Errorf("no supported filter chains and no default filter chain")
 	}
+
+	// Construct the rds names needed for dynamic configuration here
+	// List of rds names (or set)?
+
 	return fci, nil
 }
 

--- a/xds/internal/xdsclient/filter_chain.go
+++ b/xds/internal/xdsclient/filter_chain.go
@@ -216,9 +216,6 @@ func NewFilterChainManager(lis *v3listenerpb.Listener) (*FilterChainManager, err
 		return nil, fmt.Errorf("no supported filter chains and no default filter chain")
 	}
 
-	// Construct the rds names needed for dynamic configuration here
-	// List of rds names (or set)?
-
 	return fci, nil
 }
 

--- a/xds/internal/xdsclient/filter_chain_test.go
+++ b/xds/internal/xdsclient/filter_chain_test.go
@@ -22,13 +22,13 @@ package xdsclient
 
 import (
 	"fmt"
-	v3routepb "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	"net"
 	"strings"
 	"testing"
 
 	v3corepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	v3listenerpb "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	v3routepb "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	v3httppb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	v3tlspb "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	"github.com/google/go-cmp/cmp"

--- a/xds/internal/xdsclient/lds_test.go
+++ b/xds/internal/xdsclient/lds_test.go
@@ -563,11 +563,30 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 	)
 
 	var (
+		routeConfig = &v3routepb.RouteConfiguration{
+			Name: "routeName",
+			VirtualHosts: []*v3routepb.VirtualHost{{
+				Domains: []string{"lds.target.good:3333"},
+				Routes: []*v3routepb.Route{{
+					Match: &v3routepb.RouteMatch{
+						PathSpecifier: &v3routepb.RouteMatch_Prefix{Prefix: "/"},
+					},
+					Action: &v3routepb.Route_NonForwardingAction{},
+				}}}}}
+		inlineRouteConfig = &RouteConfigUpdate{
+			VirtualHosts: []*VirtualHost{{
+				Domains: []string{"lds.target.good:3333"},
+				Routes:  []*Route{{Prefix: newStringP("/")}},
+			}}}
 		emptyValidNetworkFilters = []*v3listenerpb.Filter{
 			{
 				Name: "filter-1",
 				ConfigType: &v3listenerpb.Filter_TypedConfig{
-					TypedConfig: testutils.MarshalAny(&v3httppb.HttpConnectionManager{}),
+					TypedConfig: testutils.MarshalAny(&v3httppb.HttpConnectionManager{
+						RouteSpecifier: &v3httppb.HttpConnectionManager_RouteConfig{
+							RouteConfig: routeConfig,
+						},
+					}),
 				},
 			},
 		}
@@ -806,13 +825,21 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 							{
 								Name: "name",
 								ConfigType: &v3listenerpb.Filter_TypedConfig{
-									TypedConfig: testutils.MarshalAny(&v3httppb.HttpConnectionManager{}),
+									TypedConfig: testutils.MarshalAny(&v3httppb.HttpConnectionManager{
+										RouteSpecifier: &v3httppb.HttpConnectionManager_RouteConfig{
+											RouteConfig: routeConfig,
+										},
+									}),
 								},
 							},
 							{
 								Name: "name",
 								ConfigType: &v3listenerpb.Filter_TypedConfig{
-									TypedConfig: testutils.MarshalAny(&v3httppb.HttpConnectionManager{}),
+									TypedConfig: testutils.MarshalAny(&v3httppb.HttpConnectionManager{
+										RouteSpecifier: &v3httppb.HttpConnectionManager_RouteConfig{
+											RouteConfig: routeConfig,
+										},
+									}),
 								},
 							},
 						},
@@ -1051,7 +1078,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 											srcPrefixMap: map[string]*sourcePrefixEntry{
 												unspecifiedPrefixMapKey: {
 													srcPortMap: map[int]*FilterChain{
-														0: {},
+														0: {InlineRouteConfig: inlineRouteConfig},
 													},
 												},
 											},
@@ -1144,6 +1171,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 																IdentityInstanceName: "identityPluginInstance",
 																IdentityCertName:     "identityCertName",
 															},
+															InlineRouteConfig: inlineRouteConfig,
 														},
 													},
 												},
@@ -1157,6 +1185,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 									IdentityInstanceName: "defaultIdentityPluginInstance",
 									IdentityCertName:     "defaultIdentityCertName",
 								},
+								InlineRouteConfig: inlineRouteConfig,
 							},
 						},
 					},
@@ -1192,6 +1221,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 																IdentityCertName:     "identityCertName",
 																RequireClientCert:    true,
 															},
+															InlineRouteConfig: inlineRouteConfig,
 														},
 													},
 												},
@@ -1208,6 +1238,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 									IdentityCertName:     "defaultIdentityCertName",
 									RequireClientCert:    true,
 								},
+								InlineRouteConfig: inlineRouteConfig,
 							},
 						},
 					},

--- a/xds/server_test.go
+++ b/xds/server_test.go
@@ -32,6 +32,7 @@ import (
 
 	v3corepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	v3listenerpb "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	v3routepb "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	v3httppb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	v3tlspb "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	"google.golang.org/grpc"
@@ -688,7 +689,20 @@ func (s) TestHandleListenerUpdate_NoXDSCreds(t *testing.T) {
 					{
 						Name: "filter-1",
 						ConfigType: &v3listenerpb.Filter_TypedConfig{
-							TypedConfig: testutils.MarshalAny(&v3httppb.HttpConnectionManager{}),
+							TypedConfig: testutils.MarshalAny(&v3httppb.HttpConnectionManager{
+								RouteSpecifier: &v3httppb.HttpConnectionManager_RouteConfig{
+									RouteConfig: &v3routepb.RouteConfiguration{
+										Name: "routeName",
+										VirtualHosts: []*v3routepb.VirtualHost{{
+											Domains: []string{"lds.target.good:3333"},
+											Routes: []*v3routepb.Route{{
+												Match: &v3routepb.RouteMatch{
+													PathSpecifier: &v3routepb.RouteMatch_Prefix{Prefix: "/"},
+												},
+												Action: &v3routepb.Route_NonForwardingAction{},
+											}}}}},
+								},
+							}),
 						},
 					},
 				},


### PR DESCRIPTION
branched off #4610.

This PR adds an RDS Handler for Server Side, as many dynamic RDS Configuration can be needed for a single listener. Easwar mentioned that we should wait for all of these to be populated before moving Server to ServingModeServing. This PR assumes two things: RouteName added to RDSUpdate, and RouteNamesToWatch populated in FilterChainManager construction (perhaps I should add this to my PR out now). Thus, if this PR is approved, this will be like aggregate clusters PR, where it’s sent out for approval, but won’t be merged until more pieces are there (i.e. those two fields, plus the use of this in Listener Wrapper).

RELEASE NOTES: None