### PR TITLE
xds/cluster_resolver: support RING_HASH as a child of cluster_resolver balancer

### DIFF
--- a/internal/serviceconfig/serviceconfig.go
+++ b/internal/serviceconfig/serviceconfig.go
@@ -78,6 +78,7 @@ func (bc *BalancerConfig) UnmarshalJSON(b []byte) error {
 		return err
 	}
 
+	var names []string
 	for i, lbcfg := range ir {
 		if len(lbcfg) != 1 {
 			return fmt.Errorf("invalid loadBalancingConfig: entry %v does not contain exactly 1 policy/config pair: %q", i, lbcfg)
@@ -92,6 +93,7 @@ func (bc *BalancerConfig) UnmarshalJSON(b []byte) error {
 		for name, jsonCfg = range lbcfg {
 		}
 
+		names = append(names, name)
 		builder := balancer.Get(name)
 		if builder == nil {
 			// If the balancer is not registered, move on to the next config.
@@ -120,7 +122,7 @@ func (bc *BalancerConfig) UnmarshalJSON(b []byte) error {
 	// return. This means we had a loadBalancingConfig slice but did not
 	// encounter a registered policy. The config is considered invalid in this
 	// case.
-	return fmt.Errorf("invalid loadBalancingConfig: no supported policies found")
+	return fmt.Errorf("invalid loadBalancingConfig: no supported policies found in %v", names)
 }
 
 // MethodConfig defines the configuration recommended by the service providers for a

--- a/xds/internal/balancer/clusterresolver/clusterresolver.go
+++ b/xds/internal/balancer/clusterresolver/clusterresolver.go
@@ -209,7 +209,7 @@ func (b *clusterResolverBalancer) updateChildConfig() error {
 		b.child = newChildBalancer(b.priorityBuilder, b.cc, b.bOpts)
 	}
 
-	childCfgBytes, addrs, err := buildPriorityConfigJSON(b.priorities, b.config.EndpointPickingPolicy)
+	childCfgBytes, addrs, err := buildPriorityConfigJSON(b.priorities, b.config.XDSLBPolicy)
 	if err != nil {
 		return fmt.Errorf("failed to build priority balancer config: %v", err)
 	}

--- a/xds/internal/balancer/clusterresolver/config.go
+++ b/xds/internal/balancer/clusterresolver/config.go
@@ -21,6 +21,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	internalserviceconfig "google.golang.org/grpc/internal/serviceconfig"
 	"google.golang.org/grpc/serviceconfig"
@@ -150,29 +151,33 @@ type LBConfig struct {
 	// concatenated together in successive priorities.
 	DiscoveryMechanisms []DiscoveryMechanism `json:"discoveryMechanisms,omitempty"`
 
-	// LocalityPickingPolicy is policy for locality picking.
+	// XDSLBPolicy specifies the policy for locality picking and endpoint picking.
 	//
-	// This policy's config is expected to be in the format used by the
-	// weighted_target policy.  Note that the config should include an empty
-	// value for the "targets" field; that empty value will be replaced by one
-	// that is dynamically generated based on the EDS data. Optional; defaults
-	// to "weighted_target".
-	LocalityPickingPolicy *internalserviceconfig.BalancerConfig `json:"localityPickingPolicy,omitempty"`
-
-	// EndpointPickingPolicy is policy for endpoint picking.
+	// Note that it's not normal balancing policy, and it can only be either
+	// ROUND_ROBIN or RING_HASH.
 	//
-	// This will be configured as the policy for each child in the
-	// locality-policy's config. Optional; defaults to "round_robin".
-	EndpointPickingPolicy *internalserviceconfig.BalancerConfig `json:"endpointPickingPolicy,omitempty"`
-
-	// TODO: read and warn if endpoint is not roundrobin or locality is not
-	// weightedtarget.
+	// For ROUND_ROBIN, the policy name will be "ROUND_ROBIN", and the config
+	// will be empty. This sets the locality-picking policy to weighted_target
+	// and the endpoint-picking policy to round_robin.
+	//
+	// For RING_HASH, the policy name will be "RING_HASH", and the config will
+	// be lb config for the ring_hash_experimental LB Policy. ring_hash policy
+	// is responsible for both locality picking and endpoint picking.
+	XDSLBPolicy *internalserviceconfig.BalancerConfig `json:"xdsLbPolicy,omitempty"`
 }
+
+const (
+	rrName = "ROUND_ROBIN"
+	rhName = "RING_HASH"
+)
 
 func parseConfig(c json.RawMessage) (*LBConfig, error) {
 	var cfg LBConfig
 	if err := json.Unmarshal(c, &cfg); err != nil {
 		return nil, err
+	}
+	if lbp := cfg.XDSLBPolicy; lbp != nil && !strings.EqualFold(lbp.Name, rrName) && !strings.EqualFold(lbp.Name, rhName) {
+		return nil, fmt.Errorf("unsupported child policy with name %q, not one of {%q,%q}", lbp.Name, rrName, rhName)
 	}
 	return &cfg, nil
 }

--- a/xds/internal/balancer/clusterresolver/config_test.go
+++ b/xds/internal/balancer/clusterresolver/config_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"google.golang.org/grpc/internal/balancer/stub"
 	internalserviceconfig "google.golang.org/grpc/internal/serviceconfig"
 )
 
@@ -90,6 +91,14 @@ func TestDiscoveryMechanismTypeUnmarshalJSON(t *testing.T) {
 	}
 }
 
+func init() {
+	// This is needed now for the config parsing tests to pass. Otherwise they
+	// will fail with "RING_HASH unsupported".
+	//
+	// TODO: delete this once ring-hash policy is implemented and imported.
+	stub.Register(rhName, stub.BalancerFuncs{})
+}
+
 const (
 	testJSONConfig1 = `{
   "discoveryMechanisms": [{
@@ -119,8 +128,27 @@ const (
     "type": "EDS",
     "edsServiceName": "test-eds-service-name"
   }],
-  "localityPickingPolicy":[{"pick_first":{}}],
-  "endpointPickingPolicy":[{"pick_first":{}}]
+  "xdsLbPolicy":[{"ROUND_ROBIN":{}}]
+}`
+	testJSONConfig4 = `{
+  "discoveryMechanisms": [{
+    "cluster": "test-cluster-name",
+    "lrsLoadReportingServerName": "test-lrs-server",
+    "maxConcurrentRequests": 314,
+    "type": "EDS",
+    "edsServiceName": "test-eds-service-name"
+  }],
+  "xdsLbPolicy":[{"RING_HASH":{}}]
+}`
+	testJSONConfig5 = `{
+  "discoveryMechanisms": [{
+    "cluster": "test-cluster-name",
+    "lrsLoadReportingServerName": "test-lrs-server",
+    "maxConcurrentRequests": 314,
+    "type": "EDS",
+    "edsServiceName": "test-eds-service-name"
+  }],
+  "xdsLbPolicy":[{"pick_first":{}}]
 }`
 )
 
@@ -150,8 +178,7 @@ func TestParseConfig(t *testing.T) {
 						EDSServiceName:          testEDSServcie,
 					},
 				},
-				LocalityPickingPolicy: nil,
-				EndpointPickingPolicy: nil,
+				XDSLBPolicy: nil,
 			},
 			wantErr: false,
 		},
@@ -171,13 +198,12 @@ func TestParseConfig(t *testing.T) {
 						Type: DiscoveryMechanismTypeLogicalDNS,
 					},
 				},
-				LocalityPickingPolicy: nil,
-				EndpointPickingPolicy: nil,
+				XDSLBPolicy: nil,
 			},
 			wantErr: false,
 		},
 		{
-			name: "OK with picking policy override",
+			name: "OK with picking policy round_robin",
 			js:   testJSONConfig3,
 			want: &LBConfig{
 				DiscoveryMechanisms: []DiscoveryMechanism{
@@ -189,24 +215,44 @@ func TestParseConfig(t *testing.T) {
 						EDSServiceName:          testEDSServcie,
 					},
 				},
-				LocalityPickingPolicy: &internalserviceconfig.BalancerConfig{
-					Name:   "pick_first",
-					Config: nil,
-				},
-				EndpointPickingPolicy: &internalserviceconfig.BalancerConfig{
-					Name:   "pick_first",
+				XDSLBPolicy: &internalserviceconfig.BalancerConfig{
+					Name:   "ROUND_ROBIN",
 					Config: nil,
 				},
 			},
 			wantErr: false,
+		},
+		{
+			name: "OK with picking policy ring_hash",
+			js:   testJSONConfig4,
+			want: &LBConfig{
+				DiscoveryMechanisms: []DiscoveryMechanism{
+					{
+						Cluster:                 testClusterName,
+						LoadReportingServerName: newString(testLRSServer),
+						MaxConcurrentRequests:   newUint32(testMaxRequests),
+						Type:                    DiscoveryMechanismTypeEDS,
+						EDSServiceName:          testEDSServcie,
+					},
+				},
+				XDSLBPolicy: &internalserviceconfig.BalancerConfig{
+					Name:   "RING_HASH",
+					Config: nil,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:    "unsupported picking policy",
+			js:      testJSONConfig5,
+			wantErr: true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := parseConfig([]byte(tt.js))
 			if (err != nil) != tt.wantErr {
-				t.Errorf("parseConfig() error = %v, wantErr %v", err, tt.wantErr)
-				return
+				t.Fatalf("parseConfig() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("parseConfig() got unexpected output, diff (-got +want): %v", diff)

--- a/xds/internal/balancer/clusterresolver/configbuilder.go
+++ b/xds/internal/balancer/clusterresolver/configbuilder.go
@@ -31,6 +31,7 @@ import (
 	"google.golang.org/grpc/xds/internal"
 	"google.golang.org/grpc/xds/internal/balancer/clusterimpl"
 	"google.golang.org/grpc/xds/internal/balancer/priority"
+	"google.golang.org/grpc/xds/internal/balancer/ringhash"
 	"google.golang.org/grpc/xds/internal/balancer/weightedtarget"
 	"google.golang.org/grpc/xds/internal/xdsclient"
 )
@@ -57,6 +58,9 @@ type priorityConfig struct {
 //
 // The built tree of balancers (see test for the output struct).
 //
+// If xds lb policy is ROUND_ROBIN, the children will be weighted_target for
+// locality picking, and round_robin for endpoint picking.
+//
 //                                   ┌────────┐
 //                                   │priority│
 //                                   └┬──────┬┘
@@ -77,15 +81,31 @@ type priorityConfig struct {
 // │endpoint_picking│  │endpoint_picking│  │endpoint_picking│  │endpoint_picking│
 // └────────────────┘  └────────────────┘  └────────────────┘  └────────────────┘
 //
+// If xds lb policy is RING_HASH, the children will be just a ring_hash policy.
+// The endpoints from all localities will be flattened to one addresses list,
+// and the ring_hash policy will pick endpoints from it.
+//
+//           ┌────────┐
+//           │priority│
+//           └┬──────┬┘
+//            │      │
+// ┌──────────▼─┐  ┌─▼──────────┐
+// │cluster_impl│  │cluster_impl│
+// └──────┬─────┘  └─────┬──────┘
+//        │              │
+// ┌──────▼─────┐  ┌─────▼──────┐
+// │ ring_hash  │  │ ring_hash  │
+// └────────────┘  └────────────┘
+//
 // If endpointPickingPolicy is nil, roundrobin will be used.
 //
 // Custom locality picking policy isn't support, and weighted_target is always
 // used.
-//
-// TODO: support setting locality picking policy, and add a parameter for
-// locality picking policy.
-func buildPriorityConfigJSON(priorities []priorityConfig, endpointPickingPolicy *internalserviceconfig.BalancerConfig) ([]byte, []resolver.Address, error) {
-	pc, addrs := buildPriorityConfig(priorities, endpointPickingPolicy)
+func buildPriorityConfigJSON(priorities []priorityConfig, xdsLBPolicy *internalserviceconfig.BalancerConfig) ([]byte, []resolver.Address, error) {
+	pc, addrs, err := buildPriorityConfig(priorities, xdsLBPolicy)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to build priority config: %v", err)
+	}
 	ret, err := json.Marshal(pc)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to marshal built priority config struct into json: %v", err)
@@ -93,7 +113,7 @@ func buildPriorityConfigJSON(priorities []priorityConfig, endpointPickingPolicy 
 	return ret, addrs, nil
 }
 
-func buildPriorityConfig(priorities []priorityConfig, endpointPickingPolicy *internalserviceconfig.BalancerConfig) (*priority.LBConfig, []resolver.Address) {
+func buildPriorityConfig(priorities []priorityConfig, xdsLBPolicy *internalserviceconfig.BalancerConfig) (*priority.LBConfig, []resolver.Address, error) {
 	var (
 		retConfig = &priority.LBConfig{Children: make(map[string]*priority.Child)}
 		retAddrs  []resolver.Address
@@ -101,7 +121,10 @@ func buildPriorityConfig(priorities []priorityConfig, endpointPickingPolicy *int
 	for i, p := range priorities {
 		switch p.mechanism.Type {
 		case DiscoveryMechanismTypeEDS:
-			names, configs, addrs := buildClusterImplConfigForEDS(i, p.edsResp, p.mechanism, endpointPickingPolicy)
+			names, configs, addrs, err := buildClusterImplConfigForEDS(i, p.edsResp, p.mechanism, xdsLBPolicy)
+			if err != nil {
+				return nil, nil, err
+			}
 			retConfig.Priorities = append(retConfig.Priorities, names...)
 			for n, c := range configs {
 				retConfig.Children[n] = &priority.Child{
@@ -123,7 +146,7 @@ func buildPriorityConfig(priorities []priorityConfig, endpointPickingPolicy *int
 			retAddrs = append(retAddrs, addrs...)
 		}
 	}
-	return retConfig, retAddrs
+	return retConfig, retAddrs, nil
 }
 
 func buildClusterImplConfigForDNS(parentPriority int, addrStrs []string) (string, *clusterimpl.LBConfig, []resolver.Address) {
@@ -146,16 +169,12 @@ func buildClusterImplConfigForDNS(parentPriority int, addrStrs []string) (string
 // - map{"p0":p0_config, "p1":p1_config}
 // - [p0_address_0, p0_address_1, p1_address_0, p1_address_1]
 //   - p0 addresses' hierarchy attributes are set to p0
-func buildClusterImplConfigForEDS(parentPriority int, edsResp xdsclient.EndpointsUpdate, mechanism DiscoveryMechanism, endpointPickingPolicy *internalserviceconfig.BalancerConfig) ([]string, map[string]*clusterimpl.LBConfig, []resolver.Address) {
+func buildClusterImplConfigForEDS(parentPriority int, edsResp xdsclient.EndpointsUpdate, mechanism DiscoveryMechanism, xdsLBPolicy *internalserviceconfig.BalancerConfig) ([]string, map[string]*clusterimpl.LBConfig, []resolver.Address, error) {
 	var (
 		retNames   []string
 		retAddrs   []resolver.Address
 		retConfigs = make(map[string]*clusterimpl.LBConfig)
 	)
-
-	if endpointPickingPolicy == nil {
-		endpointPickingPolicy = &internalserviceconfig.BalancerConfig{Name: roundrobin.Name}
-	}
 
 	drops := make([]clusterimpl.DropConfig, 0, len(edsResp.Drops))
 	for _, d := range edsResp.Drops {
@@ -171,19 +190,14 @@ func buildClusterImplConfigForEDS(parentPriority int, edsResp xdsclient.Endpoint
 		// Prepend parent priority to the priority names, to avoid duplicates.
 		pName := fmt.Sprintf("priority-%v-%v", parentPriority, priorityName)
 		retNames = append(retNames, pName)
-		wtConfig, addrs := localitiesToWeightedTarget(priorityLocalities, pName, endpointPickingPolicy, mechanism.Cluster, mechanism.EDSServiceName)
-		retConfigs[pName] = &clusterimpl.LBConfig{
-			Cluster:                 mechanism.Cluster,
-			EDSServiceName:          mechanism.EDSServiceName,
-			ChildPolicy:             &internalserviceconfig.BalancerConfig{Name: weightedtarget.Name, Config: wtConfig},
-			LoadReportingServerName: mechanism.LoadReportingServerName,
-			MaxConcurrentRequests:   mechanism.MaxConcurrentRequests,
-			DropCategories:          drops,
+		cfg, addrs, err := priorityLocalitiesToClusterImpl(priorityLocalities, pName, mechanism, drops, xdsLBPolicy)
+		if err != nil {
+			return nil, nil, nil, err
 		}
+		retConfigs[pName] = cfg
 		retAddrs = append(retAddrs, addrs...)
 	}
-
-	return retNames, retConfigs, retAddrs
+	return retNames, retConfigs, retAddrs, nil
 }
 
 // groupLocalitiesByPriority returns the localities grouped by priority.
@@ -234,12 +248,97 @@ func dedupSortedIntSlice(a []int) []int {
 	return a[:i+1]
 }
 
+// priorityLocalitiesToClusterImpl takes a list of localities (with the same
+// priority), and generates a cluster impl policy config, and a list of
+// addresses.
+func priorityLocalitiesToClusterImpl(localities []xdsclient.Locality, priorityName string, mechanism DiscoveryMechanism, drops []clusterimpl.DropConfig, xdsLBPolicy *internalserviceconfig.BalancerConfig) (*clusterimpl.LBConfig, []resolver.Address, error) {
+	var addrs []resolver.Address
+	clusterImplCfg := &clusterimpl.LBConfig{
+		Cluster:                 mechanism.Cluster,
+		EDSServiceName:          mechanism.EDSServiceName,
+		LoadReportingServerName: mechanism.LoadReportingServerName,
+		MaxConcurrentRequests:   mechanism.MaxConcurrentRequests,
+		DropCategories:          drops,
+		// ChildPolicy is not set. Will be set based on xdsLBPolicy
+	}
+
+	if xdsLBPolicy == nil || xdsLBPolicy.Name == rrName {
+		// If lb policy is ROUND_ROBIN:
+		// - locality-picking policy is weighted_target
+		// - endpoint-picking policy is round_robin
+		logger.Infof("xds lb policy is %q, building config with weighted_target + round_robin", rrName)
+		var wtConfig *weightedtarget.LBConfig
+		wtConfig, addrs = localitiesToWeightedTarget(
+			localities, priorityName,
+			// Child of weighted_target is hardcoded to round_robin.
+			&internalserviceconfig.BalancerConfig{Name: roundrobin.Name},
+		)
+
+		clusterImplCfg.ChildPolicy = &internalserviceconfig.BalancerConfig{Name: weightedtarget.Name, Config: wtConfig}
+		return clusterImplCfg, addrs, nil
+	}
+
+	if xdsLBPolicy.Name == rhName {
+		// If lb policy is RIHG_HASH, will build one ring_hash policy as child.
+		// The endpoints from all localities will be flattened to one addresses
+		// list, and the ring_hash policy will pick endpoints from it.
+		logger.Infof("xds lb policy is %q, building config with ring_hash", rhName)
+		addrs = localitiesToRingHash(localities, priorityName)
+		// Set child to ring_hash, note that the ring_hash config is from
+		// xdsLBPolicy.
+		clusterImplCfg.ChildPolicy = &internalserviceconfig.BalancerConfig{Name: ringhash.Name, Config: xdsLBPolicy.Config}
+		return clusterImplCfg, addrs, nil
+	}
+
+	return nil, nil, fmt.Errorf("unsupported xds LB policy %q, not one of {%q,%q}", xdsLBPolicy.Name, rrName, rhName)
+}
+
+// localitiesToRingHash takes a list of localities (with the same priority), and
+// generates a list of addresses.
+//
+// The addresses have path hierarchy set to [priority-name], so priority knows
+// which child policy they are for.
+func localitiesToRingHash(localities []xdsclient.Locality, priorityName string) []resolver.Address {
+	var addrs []resolver.Address
+	for _, locality := range localities {
+		var lw uint32 = 1
+		if locality.Weight != 0 {
+			lw = locality.Weight
+		}
+		localityStr, err := locality.ID.ToString()
+		if err != nil {
+			localityStr = fmt.Sprintf("%+v", locality.ID)
+		}
+		for _, endpoint := range locality.Endpoints {
+			// Filter out all "unhealthy" endpoints (unknown and healthy are
+			// both considered to be healthy:
+			// https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/core/health_check.proto#envoy-api-enum-core-healthstatus).
+			if endpoint.HealthStatus != xdsclient.EndpointHealthStatusHealthy && endpoint.HealthStatus != xdsclient.EndpointHealthStatusUnknown {
+				continue
+			}
+
+			var ew uint32 = 1
+			if endpoint.Weight != 0 {
+				ew = endpoint.Weight
+			}
+
+			// The weight of each endpoint is locality_weight * endpoint_weight.
+			ai := weightedroundrobin.AddrInfo{Weight: lw * ew}
+			addr := weightedroundrobin.SetAddrInfo(resolver.Address{Addr: endpoint.Address}, ai)
+			addr = hierarchy.Set(addr, []string{priorityName, localityStr})
+			addr = internal.SetLocalityID(addr, locality.ID)
+			addrs = append(addrs, addr)
+		}
+	}
+	return addrs
+}
+
 // localitiesToWeightedTarget takes a list of localities (with the same
 // priority), and generates a weighted target config, and list of addresses.
 //
 // The addresses have path hierarchy set to [priority-name, locality-name], so
 // priority and weighted target know which child policy they are for.
-func localitiesToWeightedTarget(localities []xdsclient.Locality, priorityName string, childPolicy *internalserviceconfig.BalancerConfig, cluster, edsService string) (*weightedtarget.LBConfig, []resolver.Address) {
+func localitiesToWeightedTarget(localities []xdsclient.Locality, priorityName string, childPolicy *internalserviceconfig.BalancerConfig) (*weightedtarget.LBConfig, []resolver.Address) {
 	weightedTargets := make(map[string]weightedtarget.Target)
 	var addrs []resolver.Address
 	for _, locality := range localities {

--- a/xds/internal/balancer/clusterresolver/eds_impl_test.go
+++ b/xds/internal/balancer/clusterresolver/eds_impl_test.go
@@ -28,9 +28,7 @@ import (
 	corepb "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/grpc/balancer"
-	"google.golang.org/grpc/balancer/roundrobin"
 	"google.golang.org/grpc/connectivity"
-	"google.golang.org/grpc/internal/balancer/stub"
 	internalserviceconfig "google.golang.org/grpc/internal/serviceconfig"
 	"google.golang.org/grpc/resolver"
 	"google.golang.org/grpc/xds/internal/balancer/balancergroup"
@@ -77,7 +75,6 @@ func setupTestEDS(t *testing.T, initChild *internalserviceconfig.BalancerConfig)
 				Cluster: testClusterName,
 				Type:    DiscoveryMechanismTypeEDS,
 			}},
-			EndpointPickingPolicy: initChild,
 		},
 	}); err != nil {
 		edsb.Close()
@@ -458,163 +455,6 @@ func (s) TestEDS_EmptyUpdate(t *testing.T) {
 	}
 }
 
-// Create XDS balancer, and update sub-balancer before handling eds responses.
-// Then switch between round-robin and a test stub-balancer after handling first
-// eds response.
-func (s) TestEDS_UpdateSubBalancerName(t *testing.T) {
-	const balancerName = "stubBalancer-TestEDS_UpdateSubBalancerName"
-
-	stub.Register(balancerName, stub.BalancerFuncs{
-		UpdateClientConnState: func(bd *stub.BalancerData, s balancer.ClientConnState) error {
-			m, _ := bd.Data.(map[string]bool)
-			if m == nil {
-				m = make(map[string]bool)
-				bd.Data = m
-			}
-			for _, addr := range s.ResolverState.Addresses {
-				if !m[addr.Addr] {
-					m[addr.Addr] = true
-					bd.ClientConn.NewSubConn([]resolver.Address{addr}, balancer.NewSubConnOptions{})
-				}
-			}
-			return nil
-		},
-		UpdateSubConnState: func(bd *stub.BalancerData, sc balancer.SubConn, state balancer.SubConnState) {
-			bd.ClientConn.UpdateState(balancer.State{
-				ConnectivityState: state.ConnectivityState,
-				Picker:            &testutils.TestConstPicker{Err: testutils.ErrTestConstPicker},
-			})
-		},
-	})
-
-	t.Logf("initialize with sub-balancer: stub-balancer")
-	edsb, cc, xdsC, cleanup := setupTestEDS(t, &internalserviceconfig.BalancerConfig{Name: balancerName})
-	defer cleanup()
-
-	t.Logf("update sub-balancer to stub-balancer")
-	if err := edsb.UpdateClientConnState(balancer.ClientConnState{
-		BalancerConfig: &LBConfig{
-			DiscoveryMechanisms: []DiscoveryMechanism{{
-				Cluster: testClusterName,
-				Type:    DiscoveryMechanismTypeEDS,
-			}},
-			EndpointPickingPolicy: &internalserviceconfig.BalancerConfig{
-				Name: balancerName,
-			},
-		},
-	}); err != nil {
-		t.Fatal(err)
-	}
-
-	// Two localities, each with one backend.
-	clab1 := testutils.NewClusterLoadAssignmentBuilder(testClusterNames[0], nil)
-	clab1.AddLocality(testSubZones[0], 1, 0, testEndpointAddrs[:1], nil)
-	clab1.AddLocality(testSubZones[1], 1, 0, testEndpointAddrs[1:2], nil)
-	xdsC.InvokeWatchEDSCallback("", parseEDSRespProtoForTesting(clab1.Build()), nil)
-
-	for i := 0; i < 2; i++ {
-		sc := <-cc.NewSubConnCh
-		edsb.UpdateSubConnState(sc, balancer.SubConnState{ConnectivityState: connectivity.Ready})
-	}
-
-	if err := testErrPickerFromCh(cc.NewPickerCh, testutils.ErrTestConstPicker); err != nil {
-		t.Fatal(err)
-	}
-
-	t.Logf("update sub-balancer to round-robin")
-	if err := edsb.UpdateClientConnState(balancer.ClientConnState{
-		BalancerConfig: &LBConfig{
-			DiscoveryMechanisms: []DiscoveryMechanism{{
-				Cluster: testClusterName,
-				Type:    DiscoveryMechanismTypeEDS,
-			}},
-			EndpointPickingPolicy: &internalserviceconfig.BalancerConfig{
-				Name: roundrobin.Name,
-			},
-		},
-	}); err != nil {
-		t.Fatal(err)
-	}
-
-	for i := 0; i < 2; i++ {
-		<-cc.RemoveSubConnCh
-	}
-
-	sc1 := <-cc.NewSubConnCh
-	edsb.UpdateSubConnState(sc1, balancer.SubConnState{ConnectivityState: connectivity.Connecting})
-	edsb.UpdateSubConnState(sc1, balancer.SubConnState{ConnectivityState: connectivity.Ready})
-	sc2 := <-cc.NewSubConnCh
-	edsb.UpdateSubConnState(sc2, balancer.SubConnState{ConnectivityState: connectivity.Connecting})
-	edsb.UpdateSubConnState(sc2, balancer.SubConnState{ConnectivityState: connectivity.Ready})
-
-	if err := testRoundRobinPickerFromCh(cc.NewPickerCh, []balancer.SubConn{sc1, sc2}); err != nil {
-		t.Fatal(err)
-	}
-
-	t.Logf("update sub-balancer to stub-balancer")
-	if err := edsb.UpdateClientConnState(balancer.ClientConnState{
-		BalancerConfig: &LBConfig{
-			DiscoveryMechanisms: []DiscoveryMechanism{{
-				Cluster: testClusterName,
-				Type:    DiscoveryMechanismTypeEDS,
-			}},
-			EndpointPickingPolicy: &internalserviceconfig.BalancerConfig{
-				Name: balancerName,
-			},
-		},
-	}); err != nil {
-		t.Fatal(err)
-	}
-
-	for i := 0; i < 2; i++ {
-		scToRemove := <-cc.RemoveSubConnCh
-		if !cmp.Equal(scToRemove, sc1, cmp.AllowUnexported(testutils.TestSubConn{})) &&
-			!cmp.Equal(scToRemove, sc2, cmp.AllowUnexported(testutils.TestSubConn{})) {
-			t.Fatalf("RemoveSubConn, want (%v or %v), got %v", sc1, sc2, scToRemove)
-		}
-		edsb.UpdateSubConnState(scToRemove, balancer.SubConnState{ConnectivityState: connectivity.Shutdown})
-	}
-
-	for i := 0; i < 2; i++ {
-		sc := <-cc.NewSubConnCh
-		edsb.UpdateSubConnState(sc, balancer.SubConnState{ConnectivityState: connectivity.Ready})
-	}
-
-	if err := testErrPickerFromCh(cc.NewPickerCh, testutils.ErrTestConstPicker); err != nil {
-		t.Fatal(err)
-	}
-
-	t.Logf("update sub-balancer to round-robin")
-	if err := edsb.UpdateClientConnState(balancer.ClientConnState{
-		BalancerConfig: &LBConfig{
-			DiscoveryMechanisms: []DiscoveryMechanism{{
-				Cluster: testClusterName,
-				Type:    DiscoveryMechanismTypeEDS,
-			}},
-			EndpointPickingPolicy: &internalserviceconfig.BalancerConfig{
-				Name: roundrobin.Name,
-			},
-		},
-	}); err != nil {
-		t.Fatal(err)
-	}
-
-	for i := 0; i < 2; i++ {
-		<-cc.RemoveSubConnCh
-	}
-
-	sc3 := <-cc.NewSubConnCh
-	edsb.UpdateSubConnState(sc3, balancer.SubConnState{ConnectivityState: connectivity.Connecting})
-	edsb.UpdateSubConnState(sc3, balancer.SubConnState{ConnectivityState: connectivity.Ready})
-	sc4 := <-cc.NewSubConnCh
-	edsb.UpdateSubConnState(sc4, balancer.SubConnState{ConnectivityState: connectivity.Connecting})
-	edsb.UpdateSubConnState(sc4, balancer.SubConnState{ConnectivityState: connectivity.Ready})
-
-	if err := testRoundRobinPickerFromCh(cc.NewPickerCh, []balancer.SubConn{sc3, sc4}); err != nil {
-		t.Fatal(err)
-	}
-}
-
 func (s) TestEDS_CircuitBreaking(t *testing.T) {
 	edsb, cc, xdsC, cleanup := setupTestEDS(t, nil)
 	defer cleanup()
@@ -627,9 +467,6 @@ func (s) TestEDS_CircuitBreaking(t *testing.T) {
 				MaxConcurrentRequests: &maxRequests,
 				Type:                  DiscoveryMechanismTypeEDS,
 			}},
-			EndpointPickingPolicy: &internalserviceconfig.BalancerConfig{
-				Name: roundrobin.Name,
-			},
 		},
 	}); err != nil {
 		t.Fatal(err)
@@ -693,9 +530,6 @@ func (s) TestEDS_CircuitBreaking(t *testing.T) {
 				MaxConcurrentRequests: &maxRequests2,
 				Type:                  DiscoveryMechanismTypeEDS,
 			}},
-			EndpointPickingPolicy: &internalserviceconfig.BalancerConfig{
-				Name: roundrobin.Name,
-			},
 		},
 	}); err != nil {
 		t.Fatal(err)

--- a/xds/internal/balancer/ringhash/config.go
+++ b/xds/internal/balancer/ringhash/config.go
@@ -36,10 +36,21 @@ type LBConfig struct {
 	MaxRingSize uint64 `json:"maxRingSize,omitempty"`
 }
 
+const (
+	defaultMinSize = 1024
+	defaultMaxSize = 8 * 1024 * 1024 // 8M
+)
+
 func parseConfig(c json.RawMessage) (*LBConfig, error) {
 	var cfg LBConfig
 	if err := json.Unmarshal(c, &cfg); err != nil {
 		return nil, err
+	}
+	if cfg.MinRingSize == 0 {
+		cfg.MinRingSize = defaultMaxSize
+	}
+	if cfg.MaxRingSize == 0 {
+		cfg.MaxRingSize = defaultMaxSize
 	}
 	if cfg.MinRingSize > cfg.MaxRingSize {
 		return nil, fmt.Errorf("min %v is greater than max %v", cfg.MinRingSize, cfg.MaxRingSize)

--- a/xds/internal/balancer/ringhash/config.go
+++ b/xds/internal/balancer/ringhash/config.go
@@ -47,7 +47,7 @@ func parseConfig(c json.RawMessage) (*LBConfig, error) {
 		return nil, err
 	}
 	if cfg.MinRingSize == 0 {
-		cfg.MinRingSize = defaultMaxSize
+		cfg.MinRingSize = defaultMinSize
 	}
 	if cfg.MaxRingSize == 0 {
 		cfg.MaxRingSize = defaultMaxSize

--- a/xds/internal/balancer/ringhash/config.go
+++ b/xds/internal/balancer/ringhash/config.go
@@ -1,0 +1,48 @@
+/*
+ *
+ * Copyright 2021 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package ringhash
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"google.golang.org/grpc/serviceconfig"
+)
+
+// Name is the name of the ring_hash balancer.
+const Name = "ring_hash_experimental"
+
+// LBConfig is the balancer config for ring_hash balancer.
+type LBConfig struct {
+	serviceconfig.LoadBalancingConfig `json:"-"`
+
+	MinRingSize uint64 `json:"minRingSize,omitempty"`
+	MaxRingSize uint64 `json:"maxRingSize,omitempty"`
+}
+
+func parseConfig(c json.RawMessage) (*LBConfig, error) {
+	var cfg LBConfig
+	if err := json.Unmarshal(c, &cfg); err != nil {
+		return nil, err
+	}
+	if cfg.MinRingSize > cfg.MaxRingSize {
+		return nil, fmt.Errorf("min %v is greater than max %v", cfg.MinRingSize, cfg.MaxRingSize)
+	}
+	return &cfg, nil
+}

--- a/xds/internal/balancer/ringhash/config_test.go
+++ b/xds/internal/balancer/ringhash/config_test.go
@@ -37,9 +37,14 @@ func TestParseConfig(t *testing.T) {
 			want: &LBConfig{MinRingSize: 1, MaxRingSize: 2},
 		},
 		{
-			name: "OK with default",
-			js:   `{"maxRingSize": 2}`,
-			want: &LBConfig{MinRingSize: 0, MaxRingSize: 2},
+			name: "OK with default min",
+			js:   `{"maxRingSize": 2000}`,
+			want: &LBConfig{MinRingSize: defaultMinSize, MaxRingSize: 2000},
+		},
+		{
+			name: "OK with default max",
+			js:   `{"minRingSize": 2000}`,
+			want: &LBConfig{MinRingSize: 2000, MaxRingSize: defaultMaxSize},
 		},
 		{
 			name:    "min greater than max",

--- a/xds/internal/balancer/ringhash/config_test.go
+++ b/xds/internal/balancer/ringhash/config_test.go
@@ -1,0 +1,63 @@
+/*
+ *
+ * Copyright 2021 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package ringhash
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestParseConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		js      string
+		want    *LBConfig
+		wantErr bool
+	}{
+		{
+			name: "OK",
+			js:   `{"minRingSize": 1, "maxRingSize": 2}`,
+			want: &LBConfig{MinRingSize: 1, MaxRingSize: 2},
+		},
+		{
+			name: "OK with default",
+			js:   `{"maxRingSize": 2}`,
+			want: &LBConfig{MinRingSize: 0, MaxRingSize: 2},
+		},
+		{
+			name:    "min greater than max",
+			js:      `{"minRingSize": 10, "maxRingSize": 2}`,
+			want:    nil,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseConfig([]byte(tt.js))
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseConfig() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if diff := cmp.Diff(got, tt.want); diff != "" {
+				t.Errorf("parseConfig() got unexpected output, diff (-got +want): %v", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
1. merge endpoint picking and localility picking policy to one field in cluster_resolver's balancer config
   - This field only supports ROUND_ROBIN or RING_HASH.
   - This is to support RING_HASH policy, which is responsible both endpoint picking and locality picking.
   - If policy is RING_HASH, endpoints in localities will be flattened to a list of endpoints, and passed to the policy.
1. support building policy config with RING_HASH as a child
   - The config tree has one less layer comparing with ROUND_ROBIN
   - This also need to define RING_HASH's balancer config config
1. Deleted test `TestEDS_UpdateSubBalancerName` because now the balancer doesn't support updating child to a custom policy.

RELEASE NOTES: N/A