### PR TITLE
[xds] Rds in lis wrapper

### DIFF
--- a/xds/internal/resolver/watch_service_test.go
+++ b/xds/internal/resolver/watch_service_test.go
@@ -169,7 +169,7 @@ func (s) TestServiceWatch(t *testing.T) {
 	waitForWatchRouteConfig(ctx, t, xdsC, routeStr)
 
 	wantUpdate := serviceUpdate{virtualHost: &xdsclient.VirtualHost{Domains: []string{"target"}, Routes: []*xdsclient.Route{{Prefix: newStringP(""), WeightedClusters: map[string]xdsclient.WeightedCluster{cluster: {Weight: 1}}}}}}
-	xdsC.InvokeWatchRouteConfigCallback(xdsclient.RouteConfigUpdate{
+	xdsC.InvokeWatchRouteConfigCallback("", xdsclient.RouteConfigUpdate{
 		VirtualHosts: []*xdsclient.VirtualHost{
 			{
 				Domains: []string{targetStr},
@@ -187,7 +187,7 @@ func (s) TestServiceWatch(t *testing.T) {
 			WeightedClusters: map[string]xdsclient.WeightedCluster{cluster: {Weight: 1}},
 		}},
 	}}
-	xdsC.InvokeWatchRouteConfigCallback(xdsclient.RouteConfigUpdate{
+	xdsC.InvokeWatchRouteConfigCallback("", xdsclient.RouteConfigUpdate{
 		VirtualHosts: []*xdsclient.VirtualHost{
 			{
 				Domains: []string{targetStr},
@@ -223,7 +223,7 @@ func (s) TestServiceWatchLDSUpdate(t *testing.T) {
 	waitForWatchRouteConfig(ctx, t, xdsC, routeStr)
 
 	wantUpdate := serviceUpdate{virtualHost: &xdsclient.VirtualHost{Domains: []string{"target"}, Routes: []*xdsclient.Route{{Prefix: newStringP(""), WeightedClusters: map[string]xdsclient.WeightedCluster{cluster: {Weight: 1}}}}}}
-	xdsC.InvokeWatchRouteConfigCallback(xdsclient.RouteConfigUpdate{
+	xdsC.InvokeWatchRouteConfigCallback("", xdsclient.RouteConfigUpdate{
 		VirtualHosts: []*xdsclient.VirtualHost{
 			{
 				Domains: []string{targetStr},
@@ -244,7 +244,7 @@ func (s) TestServiceWatchLDSUpdate(t *testing.T) {
 
 	// RDS update for the new name.
 	wantUpdate2 := serviceUpdate{virtualHost: &xdsclient.VirtualHost{Domains: []string{"target"}, Routes: []*xdsclient.Route{{Prefix: newStringP(""), WeightedClusters: map[string]xdsclient.WeightedCluster{cluster + "2": {Weight: 1}}}}}}
-	xdsC.InvokeWatchRouteConfigCallback(xdsclient.RouteConfigUpdate{
+	xdsC.InvokeWatchRouteConfigCallback(routeStr+"2", xdsclient.RouteConfigUpdate{
 		VirtualHosts: []*xdsclient.VirtualHost{
 			{
 				Domains: []string{targetStr},
@@ -279,7 +279,7 @@ func (s) TestServiceWatchLDSUpdateMaxStreamDuration(t *testing.T) {
 		WeightedClusters: map[string]xdsclient.WeightedCluster{cluster: {Weight: 1}}}}},
 		ldsConfig: ldsConfig{maxStreamDuration: time.Second},
 	}
-	xdsC.InvokeWatchRouteConfigCallback(xdsclient.RouteConfigUpdate{
+	xdsC.InvokeWatchRouteConfigCallback("", xdsclient.RouteConfigUpdate{
 		VirtualHosts: []*xdsclient.VirtualHost{
 			{
 				Domains: []string{targetStr},
@@ -303,7 +303,7 @@ func (s) TestServiceWatchLDSUpdateMaxStreamDuration(t *testing.T) {
 		Prefix:           newStringP(""),
 		WeightedClusters: map[string]xdsclient.WeightedCluster{cluster + "2": {Weight: 1}}}},
 	}}
-	xdsC.InvokeWatchRouteConfigCallback(xdsclient.RouteConfigUpdate{
+	xdsC.InvokeWatchRouteConfigCallback("", xdsclient.RouteConfigUpdate{
 		VirtualHosts: []*xdsclient.VirtualHost{
 			{
 				Domains: []string{targetStr},
@@ -337,7 +337,7 @@ func (s) TestServiceNotCancelRDSOnSameLDSUpdate(t *testing.T) {
 		Prefix:           newStringP(""),
 		WeightedClusters: map[string]xdsclient.WeightedCluster{cluster: {Weight: 1}}}},
 	}}
-	xdsC.InvokeWatchRouteConfigCallback(xdsclient.RouteConfigUpdate{
+	xdsC.InvokeWatchRouteConfigCallback("", xdsclient.RouteConfigUpdate{
 		VirtualHosts: []*xdsclient.VirtualHost{
 			{
 				Domains: []string{targetStr},
@@ -378,7 +378,7 @@ func (s) TestServiceWatchInlineRDS(t *testing.T) {
 	xdsC.InvokeWatchListenerCallback(xdsclient.ListenerUpdate{RouteConfigName: routeStr}, nil)
 	waitForWatchRouteConfig(ctx, t, xdsC, routeStr)
 	wantUpdate := serviceUpdate{virtualHost: &xdsclient.VirtualHost{Domains: []string{"target"}, Routes: []*xdsclient.Route{{Prefix: newStringP(""), WeightedClusters: map[string]xdsclient.WeightedCluster{cluster: {Weight: 1}}}}}}
-	xdsC.InvokeWatchRouteConfigCallback(xdsclient.RouteConfigUpdate{
+	xdsC.InvokeWatchRouteConfigCallback("", xdsclient.RouteConfigUpdate{
 		VirtualHosts: []*xdsclient.VirtualHost{
 			{
 				Domains: []string{targetStr},
@@ -412,7 +412,7 @@ func (s) TestServiceWatchInlineRDS(t *testing.T) {
 	// Switch LDS update back to LDS with RDS name to watch.
 	xdsC.InvokeWatchListenerCallback(xdsclient.ListenerUpdate{RouteConfigName: routeStr}, nil)
 	waitForWatchRouteConfig(ctx, t, xdsC, routeStr)
-	xdsC.InvokeWatchRouteConfigCallback(xdsclient.RouteConfigUpdate{
+	xdsC.InvokeWatchRouteConfigCallback("", xdsclient.RouteConfigUpdate{
 		VirtualHosts: []*xdsclient.VirtualHost{
 			{
 				Domains: []string{targetStr},

--- a/xds/internal/resolver/watch_service_test.go
+++ b/xds/internal/resolver/watch_service_test.go
@@ -237,7 +237,7 @@ func (s) TestServiceWatchLDSUpdate(t *testing.T) {
 
 	// Another LDS update with a different RDS_name.
 	xdsC.InvokeWatchListenerCallback(xdsclient.ListenerUpdate{RouteConfigName: routeStr + "2"}, nil)
-	if err := xdsC.WaitForCancelRouteConfigWatch(ctx); err != nil {
+	if _, err := xdsC.WaitForCancelRouteConfigWatch(ctx); err != nil {
 		t.Fatalf("wait for cancel route watch failed: %v, want nil", err)
 	}
 	waitForWatchRouteConfig(ctx, t, xdsC, routeStr+"2")
@@ -354,7 +354,7 @@ func (s) TestServiceNotCancelRDSOnSameLDSUpdate(t *testing.T) {
 	xdsC.InvokeWatchListenerCallback(xdsclient.ListenerUpdate{RouteConfigName: routeStr}, nil)
 	sCtx, sCancel := context.WithTimeout(ctx, defaultTestShortTimeout)
 	defer sCancel()
-	if err := xdsC.WaitForCancelRouteConfigWatch(sCtx); err != context.DeadlineExceeded {
+	if _, err := xdsC.WaitForCancelRouteConfigWatch(sCtx); err != context.DeadlineExceeded {
 		t.Fatalf("wait for cancel route watch failed: %v, want nil", err)
 	}
 }
@@ -402,7 +402,7 @@ func (s) TestServiceWatchInlineRDS(t *testing.T) {
 		VirtualHosts: []*xdsclient.VirtualHost{wantVirtualHosts2},
 	}}, nil)
 	// This inline RDS resource should cause the RDS watch to be canceled.
-	if err := xdsC.WaitForCancelRouteConfigWatch(ctx); err != nil {
+	if _, err := xdsC.WaitForCancelRouteConfigWatch(ctx); err != nil {
 		t.Fatalf("wait for cancel route watch failed: %v, want nil", err)
 	}
 	if err := verifyServiceUpdate(ctx, serviceUpdateCh, wantUpdate2); err != nil {
@@ -429,7 +429,7 @@ func (s) TestServiceWatchInlineRDS(t *testing.T) {
 		VirtualHosts: []*xdsclient.VirtualHost{wantVirtualHosts2},
 	}}, nil)
 	// This inline RDS resource should cause the RDS watch to be canceled.
-	if err := xdsC.WaitForCancelRouteConfigWatch(ctx); err != nil {
+	if _, err := xdsC.WaitForCancelRouteConfigWatch(ctx); err != nil {
 		t.Fatalf("wait for cancel route watch failed: %v, want nil", err)
 	}
 	if err := verifyServiceUpdate(ctx, serviceUpdateCh, wantUpdate2); err != nil {

--- a/xds/internal/resolver/xds_resolver_test.go
+++ b/xds/internal/resolver/xds_resolver_test.go
@@ -270,7 +270,7 @@ func (s) TestXDSResolverWatchCallbackAfterClose(t *testing.T) {
 	// Call the watchAPI callback after closing the resolver, and make sure no
 	// update is triggerred on the ClientConn.
 	xdsR.Close()
-	xdsC.InvokeWatchRouteConfigCallback(xdsclient.RouteConfigUpdate{
+	xdsC.InvokeWatchRouteConfigCallback("", xdsclient.RouteConfigUpdate{
 		VirtualHosts: []*xdsclient.VirtualHost{
 			{
 				Domains: []string{targetStr},
@@ -317,7 +317,7 @@ func (s) TestXDSResolverBadServiceUpdate(t *testing.T) {
 	// Invoke the watchAPI callback with a bad service update and wait for the
 	// ReportError method to be called on the ClientConn.
 	suErr := errors.New("bad serviceupdate")
-	xdsC.InvokeWatchRouteConfigCallback(xdsclient.RouteConfigUpdate{}, suErr)
+	xdsC.InvokeWatchRouteConfigCallback("", xdsclient.RouteConfigUpdate{}, suErr)
 
 	if gotErrVal, gotErr := tcc.errorCh.Receive(ctx); gotErr != nil || gotErrVal != suErr {
 		t.Fatalf("ClientConn.ReportError() received %v, want %v", gotErrVal, suErr)
@@ -406,7 +406,7 @@ func (s) TestXDSResolverGoodServiceUpdate(t *testing.T) {
 	} {
 		// Invoke the watchAPI callback with a good service update and wait for the
 		// UpdateState method to be called on the ClientConn.
-		xdsC.InvokeWatchRouteConfigCallback(xdsclient.RouteConfigUpdate{
+		xdsC.InvokeWatchRouteConfigCallback("", xdsclient.RouteConfigUpdate{
 			VirtualHosts: []*xdsclient.VirtualHost{
 				{
 					Domains: []string{targetStr},
@@ -480,7 +480,7 @@ func (s) TestXDSResolverRequestHash(t *testing.T) {
 	waitForWatchRouteConfig(ctx, t, xdsC, routeStr)
 	// Invoke watchAPI callback with a good service update (with hash policies
 	// specified) and wait for UpdateState method to be called on ClientConn.
-	xdsC.InvokeWatchRouteConfigCallback(xdsclient.RouteConfigUpdate{
+	xdsC.InvokeWatchRouteConfigCallback("", xdsclient.RouteConfigUpdate{
 		VirtualHosts: []*xdsclient.VirtualHost{
 			{
 				Domains: []string{targetStr},
@@ -541,7 +541,7 @@ func (s) TestXDSResolverRemovedWithRPCs(t *testing.T) {
 
 	// Invoke the watchAPI callback with a good service update and wait for the
 	// UpdateState method to be called on the ClientConn.
-	xdsC.InvokeWatchRouteConfigCallback(xdsclient.RouteConfigUpdate{
+	xdsC.InvokeWatchRouteConfigCallback("", xdsclient.RouteConfigUpdate{
 		VirtualHosts: []*xdsclient.VirtualHost{
 			{
 				Domains: []string{targetStr},
@@ -572,7 +572,7 @@ func (s) TestXDSResolverRemovedWithRPCs(t *testing.T) {
 
 	// Delete the resource
 	suErr := xdsclient.NewErrorf(xdsclient.ErrorTypeResourceNotFound, "resource removed error")
-	xdsC.InvokeWatchRouteConfigCallback(xdsclient.RouteConfigUpdate{}, suErr)
+	xdsC.InvokeWatchRouteConfigCallback("", xdsclient.RouteConfigUpdate{}, suErr)
 
 	if _, err = tcc.stateCh.Receive(ctx); err != nil {
 		t.Fatalf("Error waiting for UpdateState to be called: %v", err)
@@ -601,7 +601,7 @@ func (s) TestXDSResolverRemovedResource(t *testing.T) {
 
 	// Invoke the watchAPI callback with a good service update and wait for the
 	// UpdateState method to be called on the ClientConn.
-	xdsC.InvokeWatchRouteConfigCallback(xdsclient.RouteConfigUpdate{
+	xdsC.InvokeWatchRouteConfigCallback("", xdsclient.RouteConfigUpdate{
 		VirtualHosts: []*xdsclient.VirtualHost{
 			{
 				Domains: []string{targetStr},
@@ -651,7 +651,7 @@ func (s) TestXDSResolverRemovedResource(t *testing.T) {
 	// Delete the resource.  The channel should receive a service config with the
 	// original cluster but with an erroring config selector.
 	suErr := xdsclient.NewErrorf(xdsclient.ErrorTypeResourceNotFound, "resource removed error")
-	xdsC.InvokeWatchRouteConfigCallback(xdsclient.RouteConfigUpdate{}, suErr)
+	xdsC.InvokeWatchRouteConfigCallback("", xdsclient.RouteConfigUpdate{}, suErr)
 
 	if gotState, err = tcc.stateCh.Receive(ctx); err != nil {
 		t.Fatalf("Error waiting for UpdateState to be called: %v", err)
@@ -712,7 +712,7 @@ func (s) TestXDSResolverWRR(t *testing.T) {
 
 	// Invoke the watchAPI callback with a good service update and wait for the
 	// UpdateState method to be called on the ClientConn.
-	xdsC.InvokeWatchRouteConfigCallback(xdsclient.RouteConfigUpdate{
+	xdsC.InvokeWatchRouteConfigCallback("", xdsclient.RouteConfigUpdate{
 		VirtualHosts: []*xdsclient.VirtualHost{
 			{
 				Domains: []string{targetStr},
@@ -772,7 +772,7 @@ func (s) TestXDSResolverMaxStreamDuration(t *testing.T) {
 
 	// Invoke the watchAPI callback with a good service update and wait for the
 	// UpdateState method to be called on the ClientConn.
-	xdsC.InvokeWatchRouteConfigCallback(xdsclient.RouteConfigUpdate{
+	xdsC.InvokeWatchRouteConfigCallback("", xdsclient.RouteConfigUpdate{
 		VirtualHosts: []*xdsclient.VirtualHost{
 			{
 				Domains: []string{targetStr},
@@ -862,7 +862,7 @@ func (s) TestXDSResolverDelayedOnCommitted(t *testing.T) {
 
 	// Invoke the watchAPI callback with a good service update and wait for the
 	// UpdateState method to be called on the ClientConn.
-	xdsC.InvokeWatchRouteConfigCallback(xdsclient.RouteConfigUpdate{
+	xdsC.InvokeWatchRouteConfigCallback("", xdsclient.RouteConfigUpdate{
 		VirtualHosts: []*xdsclient.VirtualHost{
 			{
 				Domains: []string{targetStr},
@@ -912,7 +912,7 @@ func (s) TestXDSResolverDelayedOnCommitted(t *testing.T) {
 
 	// Perform TWO updates to ensure the old config selector does not hold a
 	// reference to test-cluster-1.
-	xdsC.InvokeWatchRouteConfigCallback(xdsclient.RouteConfigUpdate{
+	xdsC.InvokeWatchRouteConfigCallback("", xdsclient.RouteConfigUpdate{
 		VirtualHosts: []*xdsclient.VirtualHost{
 			{
 				Domains: []string{targetStr},
@@ -922,7 +922,7 @@ func (s) TestXDSResolverDelayedOnCommitted(t *testing.T) {
 	}, nil)
 	tcc.stateCh.Receive(ctx) // Ignore the first update.
 
-	xdsC.InvokeWatchRouteConfigCallback(xdsclient.RouteConfigUpdate{
+	xdsC.InvokeWatchRouteConfigCallback("", xdsclient.RouteConfigUpdate{
 		VirtualHosts: []*xdsclient.VirtualHost{
 			{
 				Domains: []string{targetStr},
@@ -961,7 +961,7 @@ func (s) TestXDSResolverDelayedOnCommitted(t *testing.T) {
 	// test-cluster-1.
 	res.OnCommitted()
 
-	xdsC.InvokeWatchRouteConfigCallback(xdsclient.RouteConfigUpdate{
+	xdsC.InvokeWatchRouteConfigCallback("", xdsclient.RouteConfigUpdate{
 		VirtualHosts: []*xdsclient.VirtualHost{
 			{
 				Domains: []string{targetStr},
@@ -1012,7 +1012,7 @@ func (s) TestXDSResolverGoodUpdateAfterError(t *testing.T) {
 	// Invoke the watchAPI callback with a bad service update and wait for the
 	// ReportError method to be called on the ClientConn.
 	suErr := errors.New("bad serviceupdate")
-	xdsC.InvokeWatchRouteConfigCallback(xdsclient.RouteConfigUpdate{}, suErr)
+	xdsC.InvokeWatchRouteConfigCallback("", xdsclient.RouteConfigUpdate{}, suErr)
 
 	if gotErrVal, gotErr := tcc.errorCh.Receive(ctx); gotErr != nil || gotErrVal != suErr {
 		t.Fatalf("ClientConn.ReportError() received %v, want %v", gotErrVal, suErr)
@@ -1020,7 +1020,7 @@ func (s) TestXDSResolverGoodUpdateAfterError(t *testing.T) {
 
 	// Invoke the watchAPI callback with a good service update and wait for the
 	// UpdateState method to be called on the ClientConn.
-	xdsC.InvokeWatchRouteConfigCallback(xdsclient.RouteConfigUpdate{
+	xdsC.InvokeWatchRouteConfigCallback("", xdsclient.RouteConfigUpdate{
 		VirtualHosts: []*xdsclient.VirtualHost{
 			{
 				Domains: []string{targetStr},
@@ -1040,7 +1040,7 @@ func (s) TestXDSResolverGoodUpdateAfterError(t *testing.T) {
 	// Invoke the watchAPI callback with a bad service update and wait for the
 	// ReportError method to be called on the ClientConn.
 	suErr2 := errors.New("bad serviceupdate 2")
-	xdsC.InvokeWatchRouteConfigCallback(xdsclient.RouteConfigUpdate{}, suErr2)
+	xdsC.InvokeWatchRouteConfigCallback("", xdsclient.RouteConfigUpdate{}, suErr2)
 	if gotErrVal, gotErr := tcc.errorCh.Receive(ctx); gotErr != nil || gotErrVal != suErr2 {
 		t.Fatalf("ClientConn.ReportError() received %v, want %v", gotErrVal, suErr2)
 	}
@@ -1066,7 +1066,7 @@ func (s) TestXDSResolverResourceNotFoundError(t *testing.T) {
 	// Invoke the watchAPI callback with a bad service update and wait for the
 	// ReportError method to be called on the ClientConn.
 	suErr := xdsclient.NewErrorf(xdsclient.ErrorTypeResourceNotFound, "resource removed error")
-	xdsC.InvokeWatchRouteConfigCallback(xdsclient.RouteConfigUpdate{}, suErr)
+	xdsC.InvokeWatchRouteConfigCallback("", xdsclient.RouteConfigUpdate{}, suErr)
 
 	if gotErrVal, gotErr := tcc.errorCh.Receive(ctx); gotErr != context.DeadlineExceeded {
 		t.Fatalf("ClientConn.ReportError() received %v, %v, want channel recv timeout", gotErrVal, gotErr)
@@ -1295,7 +1295,7 @@ func (s) TestXDSResolverHTTPFilters(t *testing.T) {
 
 			// Invoke the watchAPI callback with a good service update and wait for the
 			// UpdateState method to be called on the ClientConn.
-			xdsC.InvokeWatchRouteConfigCallback(xdsclient.RouteConfigUpdate{
+			xdsC.InvokeWatchRouteConfigCallback("", xdsclient.RouteConfigUpdate{
 				VirtualHosts: []*xdsclient.VirtualHost{
 					{
 						Domains: []string{targetStr},

--- a/xds/internal/server/listener_wrapper.go
+++ b/xds/internal/server/listener_wrapper.go
@@ -411,8 +411,8 @@ func (l *listenerWrapper) handleLDSUpdate(update ldsUpdateWithError) {
 	// from the management server, this listener has all the configuration
 	// needed, and is ready to be Served on.
 	if len(ilc.FilterChains.RouteConfigNames) == 0 {
-		// Does it even get here? DEBUG TIME
-		l.switchMode(l.filterChains, ServingModeServing, nil)
+		print("route config names are zero, switching mode")
+		l.switchMode(ilc.FilterChains, ServingModeServing, nil)
 		l.goodUpdate.Fire()
 	}
 }

--- a/xds/internal/server/listener_wrapper.go
+++ b/xds/internal/server/listener_wrapper.go
@@ -405,7 +405,6 @@ func (l *listenerWrapper) handleLDSUpdate(update ldsUpdateWithError) {
 	if l.drainCallback != nil {
 		l.drainCallback(l.Listener.Addr())
 	}
-	// A Filter Chain is required to be there
 	l.rdsHandler.updateRouteNamesToWatch(ilc.FilterChains.RouteConfigNames)
 	// If there are no dynamic RDS Configurations still needed to be received
 	// from the management server, this listener has all the configuration

--- a/xds/internal/server/listener_wrapper.go
+++ b/xds/internal/server/listener_wrapper.go
@@ -22,6 +22,7 @@ package server
 
 import (
 	"fmt"
+	v3routepb "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	"net"
 	"sync"
 	"time"
@@ -92,6 +93,7 @@ func prefixLogger(p *listenerWrapper) *internalgrpclog.PrefixLogger {
 // the listenerWrapper.
 type XDSClient interface {
 	WatchListener(string, func(xdsclient.ListenerUpdate, error)) func()
+	WatchRouteConfig(string, func(xdsclient.RouteConfigUpdate, error)) func()
 	BootstrapConfig() *bootstrap.Config
 }
 
@@ -185,6 +187,12 @@ type listenerWrapper struct {
 	mode ServingMode
 	// Filter chains received as part of the last good update.
 	filterChains *xdsclient.FilterChainManager
+
+	routeNamesToWatch map[string]bool
+	// map[routeName] -> RDSUpdate
+	rdsUpdates map[string]xdsclient.RouteConfigUpdate
+	// map[routeName] -> cancel()
+	rdsCancels map[string]func()
 }
 
 // Accept blocks on an Accept() on the underlying listener, and wraps the
@@ -264,6 +272,7 @@ func (l *listenerWrapper) Accept() (net.Conn, error) {
 			conn.Close()
 			continue
 		}
+		// TODO: once matched here, instantiate the filters, pipe it + override (and route) over to the xdsUnary/Stream interceptors
 		return &connWrapper{Conn: conn, filterChain: fc, parent: l}, nil
 	}
 }
@@ -315,9 +324,46 @@ func (l *listenerWrapper) handleListenerUpdate(update xdsclient.ListenerUpdate, 
 		return
 	}
 
+	// persisted map[string]
+	l.routeNamesToWatch // OldChildren
+
+	ilc.FilterChains.RouteConfigNames // NewChildren
+
+	// Add and start watches for any child nodes to routeNamesToWatch
+	for routeName := range ilc.FilterChains.RouteConfigNames {
+		if _, inLisAlready := l.routeNamesToWatch[routeName]; !inLisAlready {
+			l.routeNamesToWatch[routeName] = true
+			// start watch, persist in map here
+			l.rdsCancels[routeName] = l.xdsC.WatchRouteConfig(routeName, l.handleRDSResp)
+			// Delete from FilterChains?
+		}
+	}
+
+	// Delete and cancel watches for any child nodes from routeNamesToWatch
+	for routeName := range l.routeNamesToWatch {
+		if _, stillRDS := l.routeNamesToWatch[routeName]; !stillRDS {
+			l.rdsCancels[routeName]()
+			delete(l.routeNamesToWatch, routeName)
+		}
+	}
+
+	// "The listenerWrapper should move the server to "serving only after receiving all the required
+	// RDS resources"
 	l.switchMode(ilc.FilterChains, ServingModeServing, nil)
 	l.goodUpdate.Fire()
 }
+
+func (l *listenerWrapper) handleRDSResp(update xdsclient.RouteConfigUpdate, err error) {
+	// Persist in map - although does this actually have access to the name?
+	/*rc := v3routepb.RouteConfiguration{}
+	update.Raw.*/ // This is one way to do it
+	// Name is already plumbed around codebase...figure out someway to get it VVV
+	// Error handling here - what to do?
+	// Protect this map memory with some type of mutex
+	l.rdsUpdates[update.RouteConfigName] = update
+}
+
+// Where do I grab the mutex here?
 
 func (l *listenerWrapper) switchMode(fcs *xdsclient.FilterChainManager, newMode ServingMode, err error) {
 	l.mu.Lock()

--- a/xds/internal/server/listener_wrapper.go
+++ b/xds/internal/server/listener_wrapper.go
@@ -78,7 +78,7 @@ func (s ServingMode) String() string {
 	}
 }
 
-// ServingModeCallback is the callback that users can register to get notified
+// ServingModeCallback is the callback that servers can register to get notified
 // about the server's serving mode changes. The callback is invoked with the
 // address of the listener and its new mode. The err parameter is set to a
 // non-nil error if the server has transitioned into not-serving mode.
@@ -347,7 +347,7 @@ func (l *listenerWrapper) handleListenerUpdate(update xdsclient.ListenerUpdate, 
 // configuration (both LDS and RDS) has been received.
 func (l *listenerWrapper) handleRDSUpdate(update rdsHandlerUpdate) {
 	if l.closed.HasFired() {
-		l.logger.Warningf("RDS received update: %v with error: %v, after listener was closed", update.rdsUpdates, update.err)
+		l.logger.Warningf("RDS received update: %v with error: %v, after listener was closed", update.updates, update.err)
 		return
 	}
 	if update.err != nil {
@@ -359,7 +359,7 @@ func (l *listenerWrapper) handleRDSUpdate(update rdsHandlerUpdate) {
 		// continue to use the old configuration.
 		return
 	}
-	l.rdsUpdates = update.rdsUpdates
+	l.rdsUpdates = update.updates
 
 	l.switchMode(l.filterChains, ServingModeServing, nil)
 	l.goodUpdate.Fire()

--- a/xds/internal/server/listener_wrapper.go
+++ b/xds/internal/server/listener_wrapper.go
@@ -313,7 +313,6 @@ func (l *listenerWrapper) Close() error {
 // run is a long running goroutine which handles all xds updates. LDS and RDS
 // push updates onto a channel which is read and acted upon from this goroutine.
 func (l *listenerWrapper) run() {
-	print("run() goroutine started")
 	for {
 		select {
 		case <-l.closed.Done():
@@ -330,7 +329,6 @@ func (l *listenerWrapper) run() {
 // received update to the update channel, which is picked up by the run
 // goroutine.
 func (l *listenerWrapper) handleListenerUpdate(update xdsclient.ListenerUpdate, err error) {
-	print("handleListenerUpdate")
 	if l.closed.HasFired() {
 		l.logger.Warningf("Resource %q received update: %v with error: %v, after listener was closed", l.name, update, err)
 		return
@@ -348,7 +346,6 @@ func (l *listenerWrapper) handleListenerUpdate(update xdsclient.ListenerUpdate, 
 // update, the server will switch to ServingModeServing as the full
 // configuration (both LDS and RDS) has been received.
 func (l *listenerWrapper) handleRDSUpdate(update rdsHandlerUpdate) {
-	print("handleRDSUpdate")
 	if l.closed.HasFired() {
 		l.logger.Warningf("RDS received update: %v with error: %v, after listener was closed", update.rdsUpdates, update.err)
 		return
@@ -369,7 +366,6 @@ func (l *listenerWrapper) handleRDSUpdate(update rdsHandlerUpdate) {
 }
 
 func (l *listenerWrapper) handleLDSUpdate(update ldsUpdateWithError) {
-	print("handleLDSUpdate (from run())")
 	if update.err != nil {
 		l.logger.Warningf("Received error for resource %q: %+v", l.name, update.err)
 		if xdsclient.ErrType(update.err) == xdsclient.ErrorTypeResourceNotFound {
@@ -414,7 +410,6 @@ func (l *listenerWrapper) handleLDSUpdate(update ldsUpdateWithError) {
 	// from the management server, this listener has all the configuration
 	// needed, and is ready to be Served on.
 	if len(ilc.FilterChains.RouteConfigNames) == 0 {
-		print("route config names are zero, switching mode")
 		l.switchMode(ilc.FilterChains, ServingModeServing, nil)
 		l.goodUpdate.Fire()
 	}

--- a/xds/internal/server/listener_wrapper.go
+++ b/xds/internal/server/listener_wrapper.go
@@ -349,6 +349,10 @@ func (l *listenerWrapper) handleListenerUpdate(update xdsclient.ListenerUpdate, 
 // configuration (both LDS and RDS) has been received.
 func (l *listenerWrapper) handleRDSUpdate(update rdsHandlerUpdate) {
 	print("handleRDSUpdate")
+	if l.closed.HasFired() {
+		l.logger.Warningf("RDS received update: %v with error: %v, after listener was closed", update.rdsUpdates, update.err)
+		return
+	}
 	if update.err != nil {
 		l.logger.Warningf("Received error for rds names specified in resource %q: %+v", l.name, update.err)
 		if xdsclient.ErrType(update.err) == xdsclient.ErrorTypeResourceNotFound {

--- a/xds/internal/server/listener_wrapper_test.go
+++ b/xds/internal/server/listener_wrapper_test.go
@@ -30,6 +30,7 @@ import (
 
 	v3corepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	v3listenerpb "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	v3routepb "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	v3httppb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	v3tlspb "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	wrapperspb "github.com/golang/protobuf/ptypes/wrappers"
@@ -87,7 +88,20 @@ var listenerWithFilterChains = &v3listenerpb.Listener{
 				{
 					Name: "filter-1",
 					ConfigType: &v3listenerpb.Filter_TypedConfig{
-						TypedConfig: testutils.MarshalAny(&v3httppb.HttpConnectionManager{}),
+						TypedConfig: testutils.MarshalAny(&v3httppb.HttpConnectionManager{
+							RouteSpecifier: &v3httppb.HttpConnectionManager_RouteConfig{
+								RouteConfig: &v3routepb.RouteConfiguration{
+									Name: "routeName",
+									VirtualHosts: []*v3routepb.VirtualHost{{
+										Domains: []string{"lds.target.good:3333"},
+										Routes: []*v3routepb.Route{{
+											Match: &v3routepb.RouteMatch{
+												PathSpecifier: &v3routepb.RouteMatch_Prefix{Prefix: "/"},
+											},
+											Action: &v3routepb.Route_NonForwardingAction{},
+										}}}}},
+							},
+						}),
 					},
 				},
 			},

--- a/xds/internal/server/listener_wrapper_test.go
+++ b/xds/internal/server/listener_wrapper_test.go
@@ -291,8 +291,8 @@ func (s) TestNewListenerWrapper(t *testing.T) {
 	// listener is bound, and verify that the ready channel is not written to.
 	xdsC.InvokeWatchListenerCallback(xdsclient.ListenerUpdate{
 		InboundListenerCfg: &xdsclient.InboundListenerConfig{
-			Address: "10.0.0.1",
-			Port:    "50051",
+			Address:      "10.0.0.1",
+			Port:         "50051",
 			FilterChains: fcm,
 		}}, nil)
 	timer = time.NewTimer(defaultTestShortTimeout)
@@ -309,8 +309,8 @@ func (s) TestNewListenerWrapper(t *testing.T) {
 	// that it is ready.
 	xdsC.InvokeWatchListenerCallback(xdsclient.ListenerUpdate{
 		InboundListenerCfg: &xdsclient.InboundListenerConfig{
-			Address: fakeListenerHost,
-			Port:    strconv.Itoa(fakeListenerPort),
+			Address:      fakeListenerHost,
+			Port:         strconv.Itoa(fakeListenerPort),
 			FilterChains: fcm,
 		}}, nil)
 
@@ -357,8 +357,8 @@ func (s) TestNewListenerWrapperWithRouteUpdate(t *testing.T) {
 	// xds client for rds name "route-1".
 	xdsC.InvokeWatchListenerCallback(xdsclient.ListenerUpdate{
 		InboundListenerCfg: &xdsclient.InboundListenerConfig{
-			Address: fakeListenerHost,
-			Port:    strconv.Itoa(fakeListenerPort),
+			Address:      fakeListenerHost,
+			Port:         strconv.Itoa(fakeListenerPort),
 			FilterChains: fcm,
 		}}, nil)
 
@@ -376,7 +376,7 @@ func (s) TestNewListenerWrapperWithRouteUpdate(t *testing.T) {
 	select {
 	case <-timer.C:
 		timer.Stop()
-	case <- readyCh:
+	case <-readyCh:
 		t.Fatalf("ready channel written to without rds configuration specified")
 	}
 
@@ -394,7 +394,6 @@ func (s) TestNewListenerWrapperWithRouteUpdate(t *testing.T) {
 		t.Fatalf("timeout waiting for the ready channel to be written to after receipt of a good rds update")
 	case <-readyCh:
 	}
-
 
 	// Write full list of rds updates
 
@@ -454,8 +453,6 @@ func (s) TestNewListenerWrapperWithRouteUpdate(t *testing.T) {
 // that state in the conn in this PR?
 
 // Persist it in wrapped conn + instantiate filters will be next PR
-
-
 
 // We haven't scaled the data in wrapped conn up yet, so we don't need to add anything, as this is all testing Accept()
 func (s) TestListenerWrapper_Accept(t *testing.T) {

--- a/xds/internal/server/listener_wrapper_test.go
+++ b/xds/internal/server/listener_wrapper_test.go
@@ -373,7 +373,7 @@ func (s) TestNewListenerWrapperWithRouteUpdate(t *testing.T) {
 	// received both it's LDS Configuration and also RDS Configuration,
 	// specified in LDS Configuration.
 	xdsC.InvokeWatchRouteConfigCallback(xdsclient.RouteConfigUpdate{
-		RouteConfigName: "route-1",
+		RouteName: "route-1",
 	}, nil)
 
 	// All of the xDS updates have completed, so can expect to send a ping on

--- a/xds/internal/server/listener_wrapper_test.go
+++ b/xds/internal/server/listener_wrapper_test.go
@@ -372,7 +372,7 @@ func (s) TestNewListenerWrapperWithRouteUpdate(t *testing.T) {
 	// should trigger the listener wrapper to fire GoodUpdate, as it has
 	// received both it's LDS Configuration and also RDS Configuration,
 	// specified in LDS Configuration.
-	xdsC.InvokeWatchRouteConfigCallback(xdsclient.RouteConfigUpdate{
+	xdsC.InvokeWatchRouteConfigCallback("route-1", xdsclient.RouteConfigUpdate{
 		RouteName: "route-1",
 	}, nil)
 

--- a/xds/internal/server/rds_handler.go
+++ b/xds/internal/server/rds_handler.go
@@ -74,6 +74,8 @@ func (rh *rdsHandler) updateRouteNamesToWatch(routeNamesToWatch map[string]bool)
 func (rh *rdsHandler) handleRouteUpdate(update xdsclient.RouteConfigUpdate, err error) {
 	rh.rdsMutex.Lock()
 	defer rh.rdsMutex.Unlock()
+	// Note: this doesn't need a check for if name in RouteConfigUpdate is wrong
+	// (i.e. not started a watch for). This will be validated in xdsclient.
 	if err != nil {
 		// For a rdsHandler update, the only update wrapped listener cares about
 		// is most recent one, so opportunistically drain the update before
@@ -84,6 +86,7 @@ func (rh *rdsHandler) handleRouteUpdate(update xdsclient.RouteConfigUpdate, err 
 		}
 		rh.updateChannel <- rdsHandlerUpdate{err: err}
 		// Should we delete Route Update here? Or use successful Route Update if previously received?
+		return
 	}
 	rh.rdsUpdates[update.RouteConfigName] = update
 

--- a/xds/internal/server/rds_handler.go
+++ b/xds/internal/server/rds_handler.go
@@ -1,3 +1,21 @@
+/*
+ *
+ * Copyright 2021 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package server
 
 import (

--- a/xds/internal/server/rds_handler.go
+++ b/xds/internal/server/rds_handler.go
@@ -105,9 +105,7 @@ func (rh *rdsHandler) handleRouteUpdate(update xdsclient.RouteConfigUpdate, err 
 
 	// If the full list (determined by length) of rdsUpdates have successfully updated,
 	// the listener is ready to be updated.
-	print("in handle route update in rds handler")
 	if len(rh.rdsUpdates) == len(rh.rdsCancels) {
-		print("updating updateChannel now")
 		// For a rdsHandler update, the only update lis wrapper cares about is most recent one,
 		// so opportunistically drain the update before sending the new update.
 		select {

--- a/xds/internal/server/rds_handler.go
+++ b/xds/internal/server/rds_handler.go
@@ -33,8 +33,11 @@ type rdsHandler struct {
 // using the function below.
 func newRdsHandler(parent *listenerWrapper) *rdsHandler { // Tell Easwar routeNamesToWatch will be built in FilterChainManager in PR
 	return &rdsHandler{
-		parent:        parent,
-		updateChannel: make(chan rdsHandlerUpdate, 1),
+		parent:            parent,
+		updateChannel:     make(chan rdsHandlerUpdate, 1),
+		routeNamesToWatch: make(map[string]bool),
+		rdsUpdates:        make(map[string]xdsclient.RouteConfigUpdate),
+		rdsCancels:        make(map[string]func()),
 	}
 }
 

--- a/xds/internal/server/rds_handler.go
+++ b/xds/internal/server/rds_handler.go
@@ -101,7 +101,7 @@ func (rh *rdsHandler) handleRouteUpdate(update xdsclient.RouteConfigUpdate, err 
 		rh.updateChannel <- rdsHandlerUpdate{err: err}
 		return
 	}
-	rh.rdsUpdates[update.RouteConfigName] = update
+	rh.rdsUpdates[update.RouteConfigName] = update // BIG TODO: MAKE THIS A CLOSURE TO NOT SCALE UP UPDATE
 
 	// If the full list (determined by length) of rdsUpdates have successfully updated,
 	// the listener is ready to be updated.

--- a/xds/internal/server/rds_handler.go
+++ b/xds/internal/server/rds_handler.go
@@ -1,20 +1,20 @@
 package server
 
 import (
-	"google.golang.org/grpc/xds/internal/xdsclient"
 	"sync"
+
+	"google.golang.org/grpc/xds/internal/xdsclient"
 )
 
+// rdsHandlerUpdate wraps the full RouteConfigUpdate that are dynamically queried for a given
+// server side listener.
 type rdsHandlerUpdate struct {
 	rdsUpdates map[string]xdsclient.RouteConfigUpdate // Should this have inline as well?
 	err        error
 }
 
-// This handler will get constructed on each LDS update
-
 // rdsHandler handles any RDS queries that need to be started for a given server
 // side listeners Filter Chains (i.e. not inline).
-
 type rdsHandler struct {
 	parent *listenerWrapper
 
@@ -24,15 +24,13 @@ type rdsHandler struct {
 	rdsUpdates        map[string]xdsclient.RouteConfigUpdate
 	rdsCancels        map[string]func()
 
-	updatesReceived int // <- accessed atomically, determines when to send an update to listener wrapper
-	updateChannel   chan rdsHandlerUpdate
+	updateChannel chan rdsHandlerUpdate
 }
 
-// Create once on lis wrapper instantiation - built on construction
 // newRdsHandler is expected to called once on instantiation of a wrapped
-// listener. On any LDS updates on the wrapped listener, the listener should
-// update the handler with the route names (which specify dynamic RDS) using the
-// function below.
+// listener. On any LDS updates the wrapped listener receives, the listener
+// should update the handler with the route names (which specify dynamic RDS)
+// using the function below.
 func newRdsHandler(parent *listenerWrapper) *rdsHandler { // Tell Easwar routeNamesToWatch will be built in FilterChainManager in PR
 	return &rdsHandler{
 		parent:        parent,
@@ -40,13 +38,14 @@ func newRdsHandler(parent *listenerWrapper) *rdsHandler { // Tell Easwar routeNa
 	}
 }
 
-// updateRouteNamesToWatch handles a list of route names to watch for a given server side listener (if a filter
-// chain specifies dynamic RDS configuration). This function handles all the logic with respect to any routes that
-// may have been added or deleted as compared to what was previously present.
+// updateRouteNamesToWatch handles a list of route names to watch for a given
+// server side listener (if a filter chain specifies dynamic RDS configuration).
+// This function handles all the logic with respect to any routes that may have
+// been added or deleted as compared to what was previously present.
 func (rh *rdsHandler) updateRouteNamesToWatch(routeNamesToWatch map[string]bool) {
 	rh.rdsMutex.Lock()
 	defer rh.rdsMutex.Unlock()
-	// Add and start watches for any routes for any new routes in routeNamesToWatch
+	// Add and start watches for any routes for any new routes in routeNamesToWatch.
 	for routeName := range routeNamesToWatch {
 		if _, inRHAlready := rh.routeNamesToWatch[routeName]; !inRHAlready {
 			rh.routeNamesToWatch[routeName] = true
@@ -61,29 +60,28 @@ func (rh *rdsHandler) updateRouteNamesToWatch(routeNamesToWatch map[string]bool)
 			rh.rdsCancels[routeName]()
 			delete(rh.rdsCancels, routeName)
 			delete(rh.routeNamesToWatch, routeName)
-			// DELETE FROM UPDATE LIST (IF PRESENT!!!!)
+			delete(rh.rdsUpdates, routeName)
 		}
 	}
-
-	// Anything else...sit down and work this out in notebook
 }
 
-// func (rh *rdsHandler) updateRouteNamesToWatch??
-// update on lis wrapper update?
-
+// handleRouteUpdate persists the route config for a given route name, and also
+// sends an update to the Listener Wrapper on an error received or if the rds
+// handler has a full collection of updates.
 func (rh *rdsHandler) handleRouteUpdate(update xdsclient.RouteConfigUpdate, err error) {
 	rh.rdsMutex.Lock()
 	defer rh.rdsMutex.Unlock()
 	if err != nil {
-		// For a rdsHandler update, the only update lis wrapper cares about is most recent one,
-		// so opportunistically drain the update before sending the new update.
+		// For a rdsHandler update, the only update wrapped listener cares about
+		// is most recent one, so opportunistically drain the update before
+		// sending the new update.
 		select {
 		case <-rh.updateChannel:
 		default:
 		}
 		rh.updateChannel <- rdsHandlerUpdate{err: err}
+		// Should we delete Route Update here? Or use successful Route Update if previously received?
 	}
-	// Error handling here, send handleLDSResp an error
 	rh.rdsUpdates[update.RouteConfigName] = update
 
 	// If the full list (determined by length) of rdsUpdates have successfully updated,
@@ -99,10 +97,11 @@ func (rh *rdsHandler) handleRouteUpdate(update xdsclient.RouteConfigUpdate, err 
 	}
 }
 
+// close() is meant to be called by wrapped listener when the wrapped listener is closed,
+// and it cleans up resources by canceling all the active RDS watches.
 func (rh *rdsHandler) close() {
 	rh.rdsMutex.Lock()
 	defer rh.rdsMutex.Unlock()
-	// logical cleanup, so should cancel all the watches that are present
 	for _, cancel := range rh.rdsCancels {
 		cancel()
 	}

--- a/xds/internal/server/rds_handler.go
+++ b/xds/internal/server/rds_handler.go
@@ -9,7 +9,7 @@ import (
 // rdsHandlerUpdate wraps the full RouteConfigUpdate that are dynamically queried for a given
 // server side listener.
 type rdsHandlerUpdate struct {
-	rdsUpdates map[string]xdsclient.RouteConfigUpdate // Should this have inline as well?
+	rdsUpdates map[string]xdsclient.RouteConfigUpdate
 	err        error
 }
 
@@ -31,7 +31,7 @@ type rdsHandler struct {
 // listener. On any LDS updates the wrapped listener receives, the listener
 // should update the handler with the route names (which specify dynamic RDS)
 // using the function below.
-func newRdsHandler(parent *listenerWrapper) *rdsHandler { // Tell Easwar routeNamesToWatch will be built in FilterChainManager in PR
+func newRdsHandler(parent *listenerWrapper) *rdsHandler {
 	return &rdsHandler{
 		parent:            parent,
 		updateChannel:     make(chan rdsHandlerUpdate, 1),
@@ -85,7 +85,6 @@ func (rh *rdsHandler) handleRouteUpdate(update xdsclient.RouteConfigUpdate, err 
 		default:
 		}
 		rh.updateChannel <- rdsHandlerUpdate{err: err}
-		// Should we delete Route Update here? Or use successful Route Update if previously received?
 		return
 	}
 	rh.rdsUpdates[update.RouteConfigName] = update
@@ -112,8 +111,3 @@ func (rh *rdsHandler) close() {
 		cancel()
 	}
 }
-
-// Watch Service LDS received, starts RDS, in handle RDS is where stuff happens (i.e. logic iterates), similar to what we need
-// here with Serving state.
-
-// (ADDING ROUTE CONFIG NAME WILL BE A SEPERATE PR)..., also maybe should add (list of RDS Names to start a watch for to PR in flight rn)

--- a/xds/internal/server/rds_handler.go
+++ b/xds/internal/server/rds_handler.go
@@ -105,7 +105,9 @@ func (rh *rdsHandler) handleRouteUpdate(update xdsclient.RouteConfigUpdate, err 
 
 	// If the full list (determined by length) of rdsUpdates have successfully updated,
 	// the listener is ready to be updated.
+	print("in handle route update in rds handler")
 	if len(rh.rdsUpdates) == len(rh.rdsCancels) {
+		print("updating updateChannel now")
 		// For a rdsHandler update, the only update lis wrapper cares about is most recent one,
 		// so opportunistically drain the update before sending the new update.
 		select {

--- a/xds/internal/server/rds_handler.go
+++ b/xds/internal/server/rds_handler.go
@@ -1,0 +1,114 @@
+package server
+
+import (
+	"google.golang.org/grpc/xds/internal/xdsclient"
+	"sync"
+)
+
+type rdsHandlerUpdate struct {
+	rdsUpdates map[string]xdsclient.RouteConfigUpdate // Should this have inline as well?
+	err        error
+}
+
+// This handler will get constructed on each LDS update
+
+// rdsHandler handles any RDS queries that need to be started for a given server
+// side listeners Filter Chains (i.e. not inline).
+
+type rdsHandler struct {
+	parent *listenerWrapper
+
+	rdsMutex sync.Mutex
+
+	routeNamesToWatch map[string]bool
+	rdsUpdates        map[string]xdsclient.RouteConfigUpdate
+	rdsCancels        map[string]func()
+
+	updatesReceived int // <- accessed atomically, determines when to send an update to listener wrapper
+	updateChannel   chan rdsHandlerUpdate
+}
+
+// Create once on lis wrapper instantiation - built on construction
+// newRdsHandler is expected to called once on instantiation of a wrapped
+// listener. On any LDS updates on the wrapped listener, the listener should
+// update the handler with the route names (which specify dynamic RDS) using the
+// function below.
+func newRdsHandler(parent *listenerWrapper) *rdsHandler { // Tell Easwar routeNamesToWatch will be built in FilterChainManager in PR
+	return &rdsHandler{
+		parent:        parent,
+		updateChannel: make(chan rdsHandlerUpdate, 1),
+	}
+}
+
+// updateRouteNamesToWatch handles a list of route names to watch for a given server side listener (if a filter
+// chain specifies dynamic RDS configuration). This function handles all the logic with respect to any routes that
+// may have been added or deleted as compared to what was previously present.
+func (rh *rdsHandler) updateRouteNamesToWatch(routeNamesToWatch map[string]bool) {
+	rh.rdsMutex.Lock()
+	defer rh.rdsMutex.Unlock()
+	// Add and start watches for any routes for any new routes in routeNamesToWatch
+	for routeName := range routeNamesToWatch {
+		if _, inRHAlready := rh.routeNamesToWatch[routeName]; !inRHAlready {
+			rh.routeNamesToWatch[routeName] = true
+			rh.rdsCancels[routeName] = rh.parent.xdsC.WatchRouteConfig(routeName, rh.handleRouteUpdate)
+		}
+	}
+
+	// Delete and cancel watches for any routes from persisted routeNamesToWatch
+	// that are no longer present.
+	for routeName := range rh.routeNamesToWatch {
+		if _, stillRDS := routeNamesToWatch[routeName]; !stillRDS {
+			rh.rdsCancels[routeName]()
+			delete(rh.rdsCancels, routeName)
+			delete(rh.routeNamesToWatch, routeName)
+			// DELETE FROM UPDATE LIST (IF PRESENT!!!!)
+		}
+	}
+
+	// Anything else...sit down and work this out in notebook
+}
+
+// func (rh *rdsHandler) updateRouteNamesToWatch??
+// update on lis wrapper update?
+
+func (rh *rdsHandler) handleRouteUpdate(update xdsclient.RouteConfigUpdate, err error) {
+	rh.rdsMutex.Lock()
+	defer rh.rdsMutex.Unlock()
+	if err != nil {
+		// For a rdsHandler update, the only update lis wrapper cares about is most recent one,
+		// so opportunistically drain the update before sending the new update.
+		select {
+		case <-rh.updateChannel:
+		default:
+		}
+		rh.updateChannel <- rdsHandlerUpdate{err: err}
+	}
+	// Error handling here, send handleLDSResp an error
+	rh.rdsUpdates[update.RouteConfigName] = update
+
+	// If the full list (determined by length) of rdsUpdates have successfully updated,
+	// the listener is ready to be updated.
+	if len(rh.rdsUpdates) == len(rh.routeNamesToWatch) {
+		// For a rdsHandler update, the only update lis wrapper cares about is most recent one,
+		// so opportunistically drain the update before sending the new update.
+		select {
+		case <-rh.updateChannel:
+		default:
+		}
+		rh.updateChannel <- rdsHandlerUpdate{rdsUpdates: rh.rdsUpdates}
+	}
+}
+
+func (rh *rdsHandler) close() {
+	rh.rdsMutex.Lock()
+	defer rh.rdsMutex.Unlock()
+	// logical cleanup, so should cancel all the watches that are present
+	for _, cancel := range rh.rdsCancels {
+		cancel()
+	}
+}
+
+// Watch Service LDS received, starts RDS, in handle RDS is where stuff happens (i.e. logic iterates), similar to what we need
+// here with Serving state.
+
+// (ADDING ROUTE CONFIG NAME WILL BE A SEPERATE PR)..., also maybe should add (list of RDS Names to start a watch for to PR in flight rn)

--- a/xds/internal/server/rds_handler.go
+++ b/xds/internal/server/rds_handler.go
@@ -101,7 +101,7 @@ func (rh *rdsHandler) handleRouteUpdate(update xdsclient.RouteConfigUpdate, err 
 		rh.updateChannel <- rdsHandlerUpdate{err: err}
 		return
 	}
-	rh.rdsUpdates[update.RouteConfigName] = update // BIG TODO: MAKE THIS A CLOSURE TO NOT SCALE UP UPDATE
+	rh.rdsUpdates[update.RouteName] = update
 
 	// If the full list (determined by length) of rdsUpdates have successfully updated,
 	// the listener is ready to be updated.

--- a/xds/internal/server/rds_handler_test.go
+++ b/xds/internal/server/rds_handler_test.go
@@ -11,6 +11,8 @@ import (
 
 var (
 	route1 = "route1"
+	route2 = "route2"
+	route3 = "route3"
 )
 
 // setupTests creates a rds handler with a fake xds client for control over the
@@ -69,3 +71,156 @@ func (s) TestSuccessCaseOneRDSWatch(t *testing.T) {
 		t.Fatalf("xdsClient.CancelRDS called for route %v, want %v", routeNameDeleted, route1)
 	}
 } // Cleanup (including other files vs. the route config PR I just sent out) + Just get this build working before even trying to add new tests
+
+// test case 1 < A
+
+// test case 2 < A, then AB
+// TestSuccessCaseTwoUpdates tests the case where the rds handler receives an update with a single Route, then receives
+// a second update with two routes. The handler should start a watch for the added route, and if received a RDS update for that
+// route it should send an update with both RDS updates present.
+func (s) TestSuccessCaseTwoUpdates(t *testing.T) {
+	rh, fakeClient := setupTests(t)
+
+	routeNames := map[string]bool{route1: true}
+	rh.updateRouteNamesToWatch(routeNames)
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	_, err := fakeClient.WaitForWatchRouteConfig(ctx)
+	if err != nil {
+		t.Fatalf("xdsClient.WatchRDS failed with error: %v", err)
+	}
+
+	// Update the RDSHandler with route names which adds a route name to watch.
+	// This should trigger the RDSHandler to start a watch for the added route
+	// name to watch.
+	routeNames = map[string]bool{route1: true, route2: true}
+	rh.updateRouteNamesToWatch(routeNames)
+	gotRoute, err := fakeClient.WaitForWatchRouteConfig(ctx)
+	if err != nil {
+		t.Fatalf("xdsClient.WatchRDS failed with error: %v", err)
+	}
+	if gotRoute != route2 {
+		t.Fatalf("xdsClient.WatchRDS called for route: %v, want %v", gotRoute, route2)
+	}
+
+	// Invoke the callback with an update for route 1. This shouldn't cause the
+	// handler to write an update, as it has not received RouteConfigurations
+	// for every RouteName.
+	rdsUpdate1 := xdsclient.RouteConfigUpdate{
+		RouteConfigName: route1,
+	}
+	fakeClient.InvokeWatchRouteConfigCallback(rdsUpdate1, nil)
+
+	// The RDS Handler should not send an update.
+	shouldNotHappenCtx, shouldNotHappenCtxCancel := context.WithTimeout(context.Background(), defaultTestShortTimeout)
+	defer shouldNotHappenCtxCancel()
+	select {
+	case <-rh.updateChannel:
+		t.Fatal("RDS Handler wrote an update to updateChannel when it shouldn't have, as each route name has not received an update yet")
+	case <-shouldNotHappenCtx.Done():
+	}
+
+	// Invoke the callback with an update for route 2. This should cause the
+	// handler to write an update, as it has received RouteConfigurations for
+	// every RouteName.
+	rdsUpdate2 := xdsclient.RouteConfigUpdate{
+		RouteConfigName: route2,
+	}
+	fakeClient.InvokeWatchRouteConfigCallback(rdsUpdate2, nil)
+	// The RDS Handler should then update the listener wrapper with an update
+	// with two route configurations, as both route names the RDS Handler handles
+	// have received an update.
+	rhuWant := map[string]xdsclient.RouteConfigUpdate{route1: rdsUpdate1, route2: rdsUpdate2}
+	select {
+	case rhu := <-rh.updateChannel:
+		if diff := cmp.Diff(rhu.rdsUpdates, rhuWant); diff != "" {
+			t.Fatalf("got unexpected route update, diff (-got, +want): %v", diff)
+		}
+	case <-ctx.Done():
+		t.Fatal("Timed out waiting for the rds handler update to be written to the update buffer.")
+	}
+
+	// Close the rds handler. This is meant to be called when the lis wrapper is
+	// closed, and the call should cancel all the watches present (for this
+	// test, two watches on route1 and route2).
+	rh.close()
+	routeNameDeleted, err := fakeClient.WaitForCancelRouteConfigWatch(ctx)
+	if err != nil {
+		t.Fatalf("xdsClient.CancelRDS failed with error: %v", err)
+	}
+	if routeNameDeleted != route1 && routeNameDeleted != route2 {
+		t.Fatalf("xdsClient.CancelRDS called for route %v, want %v or %v", routeNameDeleted, route1, route2)
+	}
+
+	routeNameDeleted, err = fakeClient.WaitForCancelRouteConfigWatch(ctx)
+	if err != nil {
+		t.Fatalf("xdsClient.CancelRDS failed with error: %v", err)
+	}
+	if routeNameDeleted != route1 && routeNameDeleted != route2 {
+		t.Fatalf("xdsClient.CancelRDS called for route %v, want %v or %v", routeNameDeleted, route1, route2)
+	}
+}
+
+// test case 3 < AB, A
+// TestSuccessCaseDeletedRoute tests the case where the rds handler receives an update with two routes,
+// then receives an update with only
+func (s) TestSuccessCaseDeletedRoute(t *testing.T) {
+	rh, fakeClient := setupTests(t)
+
+	routeNames := map[string]bool{route1: true, route2: true}
+	rh.updateRouteNamesToWatch(routeNames)
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	// Will start two watches.
+	_, err := fakeClient.WaitForWatchRouteConfig(ctx)
+	if err != nil {
+		t.Fatalf("xdsClient.WatchRDS failed with error: %v", err)
+	}
+	_, err = fakeClient.WaitForWatchRouteConfig(ctx)
+	if err != nil {
+		t.Fatalf("xdsClient.WatchRDS failed with error %v", err)
+	}
+
+	// Update the RDSHandler with route names which deletes a route name to
+	// watch. This should trigger the RDSHandler to cancel the watch for the
+	// deleted route name to watch.
+	routeNames = map[string]bool{route1: true}
+	rh.updateRouteNamesToWatch(routeNames)
+	// This should delete the watch for route2.
+	routeNameDeleted, err := fakeClient.WaitForCancelRouteConfigWatch(ctx)
+	if err != nil {
+		t.Fatalf("xdsClient.CancelRDS failed with error %v", err)
+	}
+	if routeNameDeleted != route2 {
+		t.Fatalf("xdsClient.CancelRDS called for route %v, want %v", routeNameDeleted, route2)
+	}
+
+	rh.close()
+	_, err = fakeClient.WaitForCancelRouteConfigWatch(ctx)
+	if err != nil {
+		t.Fatalf("xdsClient.CancelRDS failed with error: %v", err)
+	}
+}
+
+// test case 4 < AB, BC
+// TestSuccessCaseTwoUpdatesAddAndDeleteRoute tests the case where the rds
+// handler receives an update with two routes, and then receives an update with
+// two routes, one previously there and one added (i.e. 12 -> 23). This should
+// cause the route that is no longer there to be deleted and cancelled, and the
+// route that was added should have a watch started for it.
+/*func (s) TestSuccessCaseTwoUpdatesAddAndDeleteRoute(t *testing.T) {
+	rh, fakeClient := setupTests(t)
+
+	routeNames := map[string]bool{route1: true, route2: true}
+	rh.updateRouteNamesToWatch(routeNames)
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	_, err := fakeClient.WaitForWatchRouteConfig(ctx)
+}*/
+
+// Perhaps still test the update buffer to test the three maps present, in case
+// something goes wrong in the logic for the three maps data.
+
+// error case

--- a/xds/internal/server/rds_handler_test.go
+++ b/xds/internal/server/rds_handler_test.go
@@ -1,3 +1,21 @@
+/*
+ *
+ * Copyright 2021 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package server
 
 import (

--- a/xds/internal/server/rds_handler_test.go
+++ b/xds/internal/server/rds_handler_test.go
@@ -1,0 +1,65 @@
+package server
+
+import (
+	"context"
+	"google.golang.org/grpc/xds/internal/testutils/fakeclient"
+	"google.golang.org/grpc/xds/internal/xdsclient"
+	"testing"
+)
+
+var (
+	route1 = "route1"
+)
+
+// setupTests creates a rds handler with a fake xds client for control over the
+// xdsclient. It also starts the rdsHandler with the certain routeNamesToWatch
+// (in practice, this will come from the Filter Chain Manager).
+func setupTests(t *testing.T) (*rdsHandler, *fakeclient.Client) {
+	xdsC := fakeclient.NewClient()
+	rh := newRdsHandler(&listenerWrapper{xdsC: xdsC}) // Will fake the listener component
+	return rh, xdsC
+}
+
+// Simplest test: the rds handler receives a route name of length 1, starts a watch, gets a successful update
+// and then writes an update to update channel.
+func (s) TestSuccessCaseOneRDSWatch(t *testing.T) {
+	rh, fakeClient := setupTests(t)
+	// When you first update the rds handler with a list of a single Route names that needs dynamic RDS Configuration,
+	// this Route name has not been seen before, so the RDS Handler should start a watch on that RouteName.
+	//
+	routeNames := map[string]bool{route1: true}
+	rh.updateRouteNamesToWatch(routeNames)
+	// The RDS Handler should start a watch for that routeName.
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	gotRoute, err := fakeClient.WaitForWatchRouteConfig(ctx)
+	if err != nil {
+		t.Fatalf("xdsClient.WatchRDS failed with error: %v", err)
+	}
+	if gotRoute != route1 {
+		t.Fatalf("xdsClient.WatchRDS called for route: %v, want %v", gotRoute, route1)
+	}
+	rdsUpdate := xdsclient.RouteConfigUpdate{
+		RouteConfigName: "route1",
+	}
+	// Invoke callback with the xds client with a certain route update. Due to this route update
+	// updating every route name that rds handler handles, this should write to the update channel
+	// to send to the listener.
+	fakeClient.InvokeWatchRouteConfigCallback(rdsUpdate, nil)
+	select {
+	case rhu := <-rh.updateChannel:
+
+	case <-ctx.Done():
+		t.Fatal("Timed out waiting for update from update channel.")
+	}
+	// Close the rds handler. This is meant to be called when the lis wrapper is closed, and the call
+	// should cancel all the watches present (for this test, a single watch).
+	rh.close()
+	routeNameDeleted, err := fakeClient.WaitForCancelRouteConfigWatch(ctx)
+	if err != nil {
+		t.Fatalf("xdsClient.CancelRDS failed with error: %v", err)
+	}
+	if routeNmae
+}
+
+// I need to add close() to rdsHandler to clean up and close all the watches

--- a/xds/internal/server/rds_handler_test.go
+++ b/xds/internal/server/rds_handler_test.go
@@ -24,9 +24,10 @@ func setupTests(t *testing.T) (*rdsHandler, *fakeclient.Client) {
 	return rh, xdsC
 }
 
-// Simplest test: the rds handler receives a route name of length 1, starts a
-// watch, gets a successful update, and then writes an update to the update
-// channel for listener to pick up.
+// TestSuccessCaseOneRDSWatch tests the simplest scenario: the rds handler
+// receives a single route name, starts a watch for that route name, gets a
+// successful update, and then writes an update to the update channel for
+// listener to pick up.
 func (s) TestSuccessCaseOneRDSWatch(t *testing.T) {
 	rh, fakeClient := setupTests(t)
 	// When you first update the rds handler with a list of a single Route names
@@ -71,14 +72,12 @@ func (s) TestSuccessCaseOneRDSWatch(t *testing.T) {
 	if routeNameDeleted != route1 {
 		t.Fatalf("xdsClient.CancelRDS called for route %v, want %v", routeNameDeleted, route1)
 	}
-} // Cleanup (including other files vs. the route config PR I just sent out) + Just get this build working before even trying to add new tests
+}
 
-// test case 1 < A
-
-// test case 2 < A, then AB
-// TestSuccessCaseTwoUpdates tests the case where the rds handler receives an update with a single Route, then receives
-// a second update with two routes. The handler should start a watch for the added route, and if received a RDS update for that
-// route it should send an update with both RDS updates present.
+// TestSuccessCaseTwoUpdates tests the case where the rds handler receives an
+// update with a single Route, then receives a second update with two routes.
+// The handler should start a watch for the added route, and if received a RDS
+// update for that route it should send an update with both RDS updates present.
 func (s) TestSuccessCaseTwoUpdates(t *testing.T) {
 	rh, fakeClient := setupTests(t)
 
@@ -163,9 +162,9 @@ func (s) TestSuccessCaseTwoUpdates(t *testing.T) {
 	}
 }
 
-// test case 3 < AB, A
-// TestSuccessCaseDeletedRoute tests the case where the rds handler receives an update with two routes,
-// then receives an update with only
+// TestSuccessCaseDeletedRoute tests the case where the rds handler receives an
+// update with two routes, then receives an update with only one route. The RDS
+// Handler is expected to cancel the watch for the route no longer present.
 func (s) TestSuccessCaseDeletedRoute(t *testing.T) {
 	rh, fakeClient := setupTests(t)
 
@@ -221,7 +220,6 @@ func (s) TestSuccessCaseDeletedRoute(t *testing.T) {
 	}
 }
 
-// test case 4 < AB, BC
 // TestSuccessCaseTwoUpdatesAddAndDeleteRoute tests the case where the rds
 // handler receives an update with two routes, and then receives an update with
 // two routes, one previously there and one added (i.e. 12 -> 23). This should
@@ -325,9 +323,6 @@ func (s) TestSuccessCaseTwoUpdatesAddAndDeleteRoute(t *testing.T) {
 		t.Fatalf("xdsClient.CancelRDS called for route %v, want %v or %v", routeNameDeleted, route2, route3)
 	}
 }
-
-// Perhaps still test the update buffer to test the three maps present, in case
-// something goes wrong in the logic for the three maps data.
 
 // TestErrorReceived tests the case where the rds handler receives a route name
 // to watch, then receives an update with an error. This error should be then

--- a/xds/internal/server/rds_handler_test.go
+++ b/xds/internal/server/rds_handler_test.go
@@ -40,7 +40,7 @@ var (
 // xds client.
 func setupTests(t *testing.T) (*rdsHandler, *fakeclient.Client) {
 	xdsC := fakeclient.NewClient()
-	rh := newRdsHandler(&listenerWrapper{xdsC: xdsC})
+	rh := newRDSHandler(&listenerWrapper{xdsC: xdsC})
 	return rh, xdsC
 }
 

--- a/xds/internal/server/rds_handler_test.go
+++ b/xds/internal/server/rds_handler_test.go
@@ -66,7 +66,7 @@ func (s) TestSuccessCaseOneRDSWatch(t *testing.T) {
 		t.Fatalf("xdsClient.WatchRDS called for route: %v, want %v", gotRoute, route1)
 	}
 	rdsUpdate := xdsclient.RouteConfigUpdate{
-		RouteConfigName: route1,
+		RouteName: route1,
 	}
 	// Invoke callback with the xds client with a certain route update. Due to
 	// this route update updating every route name that rds handler handles,
@@ -128,7 +128,7 @@ func (s) TestSuccessCaseTwoUpdates(t *testing.T) {
 	// handler to write an update, as it has not received RouteConfigurations
 	// for every RouteName.
 	rdsUpdate1 := xdsclient.RouteConfigUpdate{
-		RouteConfigName: route1,
+		RouteName: route1,
 	}
 	fakeClient.InvokeWatchRouteConfigCallback(rdsUpdate1, nil)
 
@@ -145,7 +145,7 @@ func (s) TestSuccessCaseTwoUpdates(t *testing.T) {
 	// handler to write an update, as it has received RouteConfigurations for
 	// every RouteName.
 	rdsUpdate2 := xdsclient.RouteConfigUpdate{
-		RouteConfigName: route2,
+		RouteName: route2,
 	}
 	fakeClient.InvokeWatchRouteConfigCallback(rdsUpdate2, nil)
 	// The RDS Handler should then update the listener wrapper with an update
@@ -217,7 +217,7 @@ func (s) TestSuccessCaseDeletedRoute(t *testing.T) {
 	}
 
 	rdsUpdate := xdsclient.RouteConfigUpdate{
-		RouteConfigName: route1,
+		RouteName: route1,
 	}
 	// Invoke callback with the xds client with a certain route update. Due to
 	// this route update updating every route name that rds handler handles,
@@ -291,7 +291,7 @@ func (s) TestSuccessCaseTwoUpdatesAddAndDeleteRoute(t *testing.T) {
 	// handler to write an update, as it has not received RouteConfigurations
 	// for every RouteName.
 	rdsUpdate2 := xdsclient.RouteConfigUpdate{
-		RouteConfigName: route2,
+		RouteName: route2,
 	}
 	fakeClient.InvokeWatchRouteConfigCallback(rdsUpdate2, nil)
 
@@ -308,7 +308,7 @@ func (s) TestSuccessCaseTwoUpdatesAddAndDeleteRoute(t *testing.T) {
 	// handler to write an update, as it has received RouteConfigurations for
 	// every RouteName.
 	rdsUpdate3 := xdsclient.RouteConfigUpdate{
-		RouteConfigName: route3,
+		RouteName: route3,
 	}
 	fakeClient.InvokeWatchRouteConfigCallback(rdsUpdate3, nil)
 	// The RDS Handler should then update the listener wrapper with an update

--- a/xds/internal/server/rds_handler_test.go
+++ b/xds/internal/server/rds_handler_test.go
@@ -2,9 +2,11 @@ package server
 
 import (
 	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
 	"google.golang.org/grpc/xds/internal/testutils/fakeclient"
 	"google.golang.org/grpc/xds/internal/xdsclient"
-	"testing"
 )
 
 var (
@@ -12,21 +14,21 @@ var (
 )
 
 // setupTests creates a rds handler with a fake xds client for control over the
-// xdsclient. It also starts the rdsHandler with the certain routeNamesToWatch
-// (in practice, this will come from the Filter Chain Manager).
+// xds client.
 func setupTests(t *testing.T) (*rdsHandler, *fakeclient.Client) {
 	xdsC := fakeclient.NewClient()
-	rh := newRdsHandler(&listenerWrapper{xdsC: xdsC}) // Will fake the listener component
+	rh := newRdsHandler(&listenerWrapper{xdsC: xdsC})
 	return rh, xdsC
 }
 
-// Simplest test: the rds handler receives a route name of length 1, starts a watch, gets a successful update
-// and then writes an update to update channel.
+// Simplest test: the rds handler receives a route name of length 1, starts a
+// watch, gets a successful update, and then writes an update to the update
+// channel for listener to pick up.
 func (s) TestSuccessCaseOneRDSWatch(t *testing.T) {
 	rh, fakeClient := setupTests(t)
-	// When you first update the rds handler with a list of a single Route names that needs dynamic RDS Configuration,
-	// this Route name has not been seen before, so the RDS Handler should start a watch on that RouteName.
-	//
+	// When you first update the rds handler with a list of a single Route names
+	// that needs dynamic RDS Configuration, this Route name has not been seen
+	// before, so the RDS Handler should start a watch on that RouteName.
 	routeNames := map[string]bool{route1: true}
 	rh.updateRouteNamesToWatch(routeNames)
 	// The RDS Handler should start a watch for that routeName.
@@ -40,26 +42,30 @@ func (s) TestSuccessCaseOneRDSWatch(t *testing.T) {
 		t.Fatalf("xdsClient.WatchRDS called for route: %v, want %v", gotRoute, route1)
 	}
 	rdsUpdate := xdsclient.RouteConfigUpdate{
-		RouteConfigName: "route1",
+		RouteConfigName: route1,
 	}
-	// Invoke callback with the xds client with a certain route update. Due to this route update
-	// updating every route name that rds handler handles, this should write to the update channel
-	// to send to the listener.
+	// Invoke callback with the xds client with a certain route update. Due to
+	// this route update updating every route name that rds handler handles,
+	// this should write to the update channel to send to the listener.
 	fakeClient.InvokeWatchRouteConfigCallback(rdsUpdate, nil)
+	rhuWant := map[string]xdsclient.RouteConfigUpdate{route1: rdsUpdate}
 	select {
 	case rhu := <-rh.updateChannel:
-
+		if diff := cmp.Diff(rhu.rdsUpdates, rhuWant); diff != "" {
+			t.Fatalf("got unexpected route update, diff (-got, +want): %v", diff)
+		}
 	case <-ctx.Done():
 		t.Fatal("Timed out waiting for update from update channel.")
 	}
-	// Close the rds handler. This is meant to be called when the lis wrapper is closed, and the call
-	// should cancel all the watches present (for this test, a single watch).
+	// Close the rds handler. This is meant to be called when the lis wrapper is
+	// closed, and the call should cancel all the watches present (for this
+	// test, a single watch).
 	rh.close()
 	routeNameDeleted, err := fakeClient.WaitForCancelRouteConfigWatch(ctx)
 	if err != nil {
 		t.Fatalf("xdsClient.CancelRDS failed with error: %v", err)
 	}
-	if routeNmae
-}
-
-// I need to add close() to rdsHandler to clean up and close all the watches
+	if routeNameDeleted != route1 {
+		t.Fatalf("xdsClient.CancelRDS called for route %v, want %v", routeNameDeleted, route1)
+	}
+} // Cleanup (including other files vs. the route config PR I just sent out) + Just get this build working before even trying to add new tests

--- a/xds/internal/server/rds_handler_test.go
+++ b/xds/internal/server/rds_handler_test.go
@@ -1,3 +1,5 @@
+// +build go1.12
+
 /*
  *
  * Copyright 2021 gRPC authors.

--- a/xds/internal/testutils/e2e/clientresources.go
+++ b/xds/internal/testutils/e2e/clientresources.go
@@ -199,7 +199,20 @@ func DefaultServerListener(host string, port uint32, secLevel SecurityLevel) *v3
 					{
 						Name: "filter-1",
 						ConfigType: &v3listenerpb.Filter_TypedConfig{
-							TypedConfig: testutils.MarshalAny(&v3httppb.HttpConnectionManager{}),
+							TypedConfig: testutils.MarshalAny(&v3httppb.HttpConnectionManager{
+								RouteSpecifier: &v3httppb.HttpConnectionManager_RouteConfig{
+									RouteConfig: &v3routepb.RouteConfiguration{
+										Name: "routeName",
+										VirtualHosts: []*v3routepb.VirtualHost{{
+											Domains: []string{"lds.target.good:3333"},
+											Routes: []*v3routepb.Route{{
+												Match: &v3routepb.RouteMatch{
+													PathSpecifier: &v3routepb.RouteMatch_Prefix{Prefix: "/"},
+												},
+												Action: &v3routepb.Route_NonForwardingAction{},
+											}}}}},
+								},
+							}),
 						},
 					},
 				},
@@ -230,7 +243,20 @@ func DefaultServerListener(host string, port uint32, secLevel SecurityLevel) *v3
 					{
 						Name: "filter-1",
 						ConfigType: &v3listenerpb.Filter_TypedConfig{
-							TypedConfig: testutils.MarshalAny(&v3httppb.HttpConnectionManager{}),
+							TypedConfig: testutils.MarshalAny(&v3httppb.HttpConnectionManager{
+								RouteSpecifier: &v3httppb.HttpConnectionManager_RouteConfig{
+									RouteConfig: &v3routepb.RouteConfiguration{
+										Name: "routeName",
+										VirtualHosts: []*v3routepb.VirtualHost{{
+											Domains: []string{"lds.target.good:3333"},
+											Routes: []*v3routepb.Route{{
+												Match: &v3routepb.RouteMatch{
+													PathSpecifier: &v3routepb.RouteMatch_Prefix{Prefix: "/"},
+												},
+												Action: &v3routepb.Route_NonForwardingAction{},
+											}}}}},
+								},
+							}),
 						},
 					},
 				},

--- a/xds/internal/testutils/fakeclient/client.go
+++ b/xds/internal/testutils/fakeclient/client.go
@@ -296,11 +296,11 @@ func NewClientWithName(name string) *Client {
 	return &Client{
 		name:         name,
 		ldsWatchCh:   testutils.NewChannel(),
-		rdsWatchCh:   testutils.NewChannel(),
+		rdsWatchCh:   testutils.NewChannelWithSize(10),
 		cdsWatchCh:   testutils.NewChannelWithSize(10),
 		edsWatchCh:   testutils.NewChannelWithSize(10),
 		ldsCancelCh:  testutils.NewChannel(),
-		rdsCancelCh:  testutils.NewChannel(),
+		rdsCancelCh:  testutils.NewChannelWithSize(10),
 		cdsCancelCh:  testutils.NewChannelWithSize(10),
 		edsCancelCh:  testutils.NewChannelWithSize(10),
 		loadReportCh: testutils.NewChannel(),

--- a/xds/internal/testutils/fakeclient/client.go
+++ b/xds/internal/testutils/fakeclient/client.go
@@ -52,7 +52,7 @@ type Client struct {
 	bootstrapCfg *bootstrap.Config
 
 	ldsCb  func(xdsclient.ListenerUpdate, error)
-	rdsCb  func(xdsclient.RouteConfigUpdate, error)
+	rdsCbs map[string]func(xdsclient.RouteConfigUpdate, error)
 	cdsCbs map[string]func(xdsclient.ClusterUpdate, error)
 	edsCbs map[string]func(xdsclient.EndpointsUpdate, error)
 
@@ -95,7 +95,7 @@ func (xdsC *Client) WaitForCancelListenerWatch(ctx context.Context) error {
 
 // WatchRouteConfig registers a RDS watch.
 func (xdsC *Client) WatchRouteConfig(routeName string, callback func(xdsclient.RouteConfigUpdate, error)) func() {
-	xdsC.rdsCb = callback
+	xdsC.rdsCbs[routeName] = callback
 	xdsC.rdsWatchCh.Send(routeName)
 	return func() {
 		xdsC.rdsCancelCh.Send(routeName)
@@ -116,8 +116,18 @@ func (xdsC *Client) WaitForWatchRouteConfig(ctx context.Context) (string, error)
 //
 // Not thread safe with WatchRouteConfig. Only call this after
 // WaitForWatchRouteConfig.
-func (xdsC *Client) InvokeWatchRouteConfigCallback(update xdsclient.RouteConfigUpdate, err error) {
-	xdsC.rdsCb(update, err)
+func (xdsC *Client) InvokeWatchRouteConfigCallback(name string, update xdsclient.RouteConfigUpdate, err error) {
+	if len(xdsC.rdsCbs) != 1 {
+		xdsC.rdsCbs[name](update, err)
+		return
+	}
+	// Keeps functionality with previous usage of this on client side, if single
+	// callback call that callback.
+	var routeName string
+	for route := range xdsC.rdsCbs {
+		routeName = route
+	}
+	xdsC.rdsCbs[routeName](update, err)
 }
 
 // WaitForCancelRouteConfigWatch waits for a RDS watch to be cancelled  and returns
@@ -306,6 +316,7 @@ func NewClientWithName(name string) *Client {
 		loadReportCh: testutils.NewChannel(),
 		lrsCancelCh:  testutils.NewChannel(),
 		loadStore:    load.NewStore(),
+		rdsCbs:       make(map[string]func(xdsclient.RouteConfigUpdate, error)),
 		cdsCbs:       make(map[string]func(xdsclient.ClusterUpdate, error)),
 		edsCbs:       make(map[string]func(xdsclient.EndpointsUpdate, error)),
 		Closed:       grpcsync.NewEvent(),

--- a/xds/internal/testutils/fakeclient/client.go
+++ b/xds/internal/testutils/fakeclient/client.go
@@ -122,9 +122,12 @@ func (xdsC *Client) InvokeWatchRouteConfigCallback(update xdsclient.RouteConfigU
 
 // WaitForCancelRouteConfigWatch waits for a RDS watch to be cancelled  and returns
 // context.DeadlineExceeded otherwise.
-func (xdsC *Client) WaitForCancelRouteConfigWatch(ctx context.Context) error {
-	_, err := xdsC.rdsCancelCh.Receive(ctx)
-	return err
+func (xdsC *Client) WaitForCancelRouteConfigWatch(ctx context.Context) (string, error) {
+	val, err := xdsC.rdsCancelCh.Receive(ctx)
+	if err != nil {
+		return "", err
+	}
+	return val.(string), err
 }
 
 // WatchCluster registers a CDS watch.

--- a/xds/internal/testutils/fakeclient/client.go
+++ b/xds/internal/testutils/fakeclient/client.go
@@ -98,7 +98,7 @@ func (xdsC *Client) WatchRouteConfig(routeName string, callback func(xdsclient.R
 	xdsC.rdsCb = callback
 	xdsC.rdsWatchCh.Send(routeName)
 	return func() {
-		xdsC.rdsCancelCh.Send(nil)
+		xdsC.rdsCancelCh.Send(routeName)
 	}
 }
 

--- a/xds/internal/xdsclient/client.go
+++ b/xds/internal/xdsclient/client.go
@@ -250,8 +250,10 @@ type InboundListenerConfig struct {
 // RouteConfigUpdate contains information received in an RDS response, which is
 // of interest to the registered RDS watcher.
 type RouteConfigUpdate struct {
+	// Name is the RDS resource name for this response, which is specified in
+	// LDS Response (RouteConfigName).
+	RouteName    string
 	VirtualHosts []*VirtualHost
-
 	// Raw is the resource from the xds response.
 	Raw *anypb.Any
 }

--- a/xds/internal/xdsclient/client.go
+++ b/xds/internal/xdsclient/client.go
@@ -298,19 +298,19 @@ type HashPolicy struct {
 type RouteAction int
 
 const (
-	// RouteActionUnsupported are routing types currently unsupported by grpc.
-	// According to A36, "A Route with an inappropriate action causes RPCs
-	// matching that route to fail."
-	RouteActionUnsupported RouteAction = iota
 	// RouteActionRoute is the expected route type on the client side. Route
 	// represents routing a request to some upstream cluster. On the client
 	// side, if an RPC matches to a route that is not RouteActionRoute, the RPC
 	// will fail according to A36.
-	RouteActionRoute
+	RouteActionRoute RouteAction = iota
 	// RouteActionNonForwardingAction is the expected route type on the server
 	// side. NonForwardingAction represents when a route will generate a
 	// response directly, without forwarding to an upstream host.
 	RouteActionNonForwardingAction
+	// RouteActionUnsupported are routing types currently unsupported by grpc.
+	// According to A36, "A Route with an inappropriate action causes RPCs
+	// matching that route to fail."
+	RouteActionUnsupported
 )
 
 // Route is both a specification of how to match a request as well as an

--- a/xds/internal/xdsclient/client.go
+++ b/xds/internal/xdsclient/client.go
@@ -294,6 +294,25 @@ type HashPolicy struct {
 	RegexSubstitution string
 }
 
+// RouteAction is the action of the route from a received RDS response.
+type RouteAction int
+
+const (
+	// RouteActionUnsupported are routing types currently unsupported by grpc.
+	// According to A36, "A Route with an inappropriate action causes RPCs
+	// matching that route to fail."
+	RouteActionUnsupported RouteAction = iota
+	// RouteActionRoute is the expected route type on the client side. Route
+	// represents routing a request to some upstream cluster. On the client
+	// side, if an RPC matches to a route that is not RouteActionRoute, the RPC
+	// will fail according to A36.
+	RouteActionRoute
+	// RouteActionNonForwardingAction is the expected route type on the server
+	// side. NonForwardingAction represents when a route will generate a
+	// response directly, without forwarding to an upstream host.
+	RouteActionNonForwardingAction
+)
+
 // Route is both a specification of how to match a request as well as an
 // indication of the action to take upon match.
 type Route struct {
@@ -321,6 +340,8 @@ type Route struct {
 	// unused if the matching WeightedCluster contains an override for that
 	// filter.
 	HTTPFilterConfigOverride map[string]httpfilter.FilterConfig
+
+	RouteAction RouteAction
 }
 
 // WeightedCluster contains settings for an xds RouteAction.WeightedCluster.

--- a/xds/internal/xdsclient/filter_chain.go
+++ b/xds/internal/xdsclient/filter_chain.go
@@ -218,9 +218,6 @@ func NewFilterChainManager(lis *v3listenerpb.Listener) (*FilterChainManager, err
 		return nil, fmt.Errorf("no supported filter chains and no default filter chain")
 	}
 
-	// Construct the rds names needed for dynamic configuration here
-	// List of rds names (or set)?
-
 	return fci, nil
 }
 

--- a/xds/internal/xdsclient/filter_chain.go
+++ b/xds/internal/xdsclient/filter_chain.go
@@ -54,6 +54,15 @@ type FilterChain struct {
 	SecurityCfg *SecurityConfig
 	// HTTPFilters represent the HTTP Filters that comprise this FilterChain.
 	HTTPFilters []HTTPFilter
+	// RouteConfigName is the route configuration name for this FilterChain.
+	//
+	// Only one of RouteConfigName and InlineRouteConfig is set.
+	RouteConfigName string
+	// InlineRouteConfig is the inline route configuration (RDS response)
+	// returned for this filter chain.
+	//
+	// Only one of RouteConfigName and InlineRouteConfig is set.
+	InlineRouteConfig *RouteConfigUpdate
 }
 
 // SourceType specifies the connection source IP match type.
@@ -393,11 +402,11 @@ func (fci *FilterChainManager) addFilterChainsForSourcePorts(srcEntry *sourcePre
 // filterChainFromProto extracts the relevant information from the FilterChain
 // proto and stores it in our internal representation.
 func filterChainFromProto(fc *v3listenerpb.FilterChain) (*FilterChain, error) {
-	httpFilters, err := processNetworkFilters(fc.GetFilters())
+	filterChain, err := processNetworkFilters(fc.GetFilters())
 	if err != nil {
 		return nil, err
 	}
-	filterChain := &FilterChain{HTTPFilters: httpFilters}
+	// filterChain := &FilterChain{HTTPFilters: httpFilters}
 	// If the transport_socket field is not specified, it means that the control
 	// plane has not sent us any security config. This is fine and the server
 	// will use the fallback credentials configured as part of the

--- a/xds/internal/xdsclient/filter_chain.go
+++ b/xds/internal/xdsclient/filter_chain.go
@@ -217,6 +217,10 @@ func NewFilterChainManager(lis *v3listenerpb.Listener) (*FilterChainManager, err
 	if !fcSeen && fci.def == nil {
 		return nil, fmt.Errorf("no supported filter chains and no default filter chain")
 	}
+
+	// Construct the rds names needed for dynamic configuration here
+	// List of rds names (or set)?
+
 	return fci, nil
 }
 

--- a/xds/internal/xdsclient/filter_chain_test.go
+++ b/xds/internal/xdsclient/filter_chain_test.go
@@ -22,13 +22,13 @@ package xdsclient
 
 import (
 	"fmt"
-	v3routepb "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	"net"
 	"strings"
 	"testing"
 
 	v3corepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	v3listenerpb "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	v3routepb "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	v3httppb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	v3tlspb "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	"github.com/google/go-cmp/cmp"

--- a/xds/internal/xdsclient/filter_chain_test.go
+++ b/xds/internal/xdsclient/filter_chain_test.go
@@ -53,6 +53,7 @@ var (
 				Action: &v3routepb.Route_NonForwardingAction{},
 			}}}}}
 	inlineRouteConfig = &RouteConfigUpdate{
+		RouteName: "routeName",
 		VirtualHosts: []*VirtualHost{{
 			Domains: []string{"lds.target.good:3333"},
 			Routes:  []*Route{{Prefix: newStringP("/"), RouteAction: RouteActionNonForwardingAction}},

--- a/xds/internal/xdsclient/filter_chain_test.go
+++ b/xds/internal/xdsclient/filter_chain_test.go
@@ -55,7 +55,7 @@ var (
 	inlineRouteConfig = &RouteConfigUpdate{
 		VirtualHosts: []*VirtualHost{{
 			Domains: []string{"lds.target.good:3333"},
-			Routes:  []*Route{{Prefix: newStringP("/")}},
+			Routes:  []*Route{{Prefix: newStringP("/"), RouteAction: RouteActionNonForwardingAction}},
 		}}}
 	emptyValidNetworkFilters = []*v3listenerpb.Filter{
 		{
@@ -668,35 +668,6 @@ func TestNewFilterChainImpl_Failure_BadRouteUpdate(t *testing.T) {
 		lis     *v3listenerpb.Listener
 		wantErr string
 	}{
-		{
-			name: "no-route-specifier",
-			lis: &v3listenerpb.Listener{
-				FilterChains: []*v3listenerpb.FilterChain{
-					{
-						Name: "filter-chain-1",
-						Filters: []*v3listenerpb.Filter{
-							{
-								Name: "hcm",
-								ConfigType: &v3listenerpb.Filter_TypedConfig{
-									TypedConfig: testutils.MarshalAny(&v3httppb.HttpConnectionManager{}),
-								},
-							},
-						},
-					},
-				},
-				DefaultFilterChain: &v3listenerpb.FilterChain{
-					Filters: []*v3listenerpb.Filter{
-						{
-							Name: "hcm",
-							ConfigType: &v3listenerpb.Filter_TypedConfig{
-								TypedConfig: testutils.MarshalAny(&v3httppb.HttpConnectionManager{}),
-							},
-						},
-					},
-				},
-			},
-			wantErr: "no RouteSpecifier",
-		},
 		{
 			name: "not-ads",
 			lis: &v3listenerpb.Listener{

--- a/xds/internal/xdsclient/lds_test.go
+++ b/xds/internal/xdsclient/lds_test.go
@@ -491,6 +491,7 @@ func (s) TestUnmarshalListener_ClientSide(t *testing.T) {
 			wantUpdate: map[string]ListenerUpdate{
 				v3LDSTarget: {
 					InlineRouteConfig: &RouteConfigUpdate{
+						RouteName: routeName,
 						VirtualHosts: []*VirtualHost{{
 							Domains: []string{v3LDSTarget},
 							Routes:  []*Route{{Prefix: newStringP("/"), WeightedClusters: map[string]WeightedCluster{clusterName: {Weight: 1}}}},
@@ -574,6 +575,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 					Action: &v3routepb.Route_NonForwardingAction{},
 				}}}}}
 		inlineRouteConfig = &RouteConfigUpdate{
+			RouteName: "routeName",
 			VirtualHosts: []*VirtualHost{{
 				Domains: []string{"lds.target.good:3333"},
 				Routes:  []*Route{{Prefix: newStringP("/"), RouteAction: RouteActionNonForwardingAction}},

--- a/xds/internal/xdsclient/lds_test.go
+++ b/xds/internal/xdsclient/lds_test.go
@@ -576,7 +576,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 		inlineRouteConfig = &RouteConfigUpdate{
 			VirtualHosts: []*VirtualHost{{
 				Domains: []string{"lds.target.good:3333"},
-				Routes:  []*Route{{Prefix: newStringP("/")}},
+				Routes:  []*Route{{Prefix: newStringP("/"), RouteAction: RouteActionNonForwardingAction}},
 			}}}
 		emptyValidNetworkFilters = []*v3listenerpb.Filter{
 			{

--- a/xds/internal/xdsclient/lds_test.go
+++ b/xds/internal/xdsclient/lds_test.go
@@ -563,11 +563,30 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 	)
 
 	var (
+		routeConfig = &v3routepb.RouteConfiguration{
+			Name: "routeName",
+			VirtualHosts: []*v3routepb.VirtualHost{{
+				Domains: []string{"lds.target.good:3333"},
+				Routes: []*v3routepb.Route{{
+					Match: &v3routepb.RouteMatch{
+						PathSpecifier: &v3routepb.RouteMatch_Prefix{Prefix: "/"},
+					},
+					Action: &v3routepb.Route_NonForwardingAction{},
+				}}}}}
+		inlineRouteConfig = &RouteConfigUpdate{
+			VirtualHosts: []*VirtualHost{{
+				Domains: []string{"lds.target.good:3333"},
+				Routes:  []*Route{{Prefix: newStringP("/")}},
+			}}}
 		emptyValidNetworkFilters = []*v3listenerpb.Filter{
 			{
 				Name: "filter-1",
 				ConfigType: &v3listenerpb.Filter_TypedConfig{
-					TypedConfig: testutils.MarshalAny(&v3httppb.HttpConnectionManager{}),
+					TypedConfig: testutils.MarshalAny(&v3httppb.HttpConnectionManager{
+						RouteSpecifier: &v3httppb.HttpConnectionManager_RouteConfig{
+							RouteConfig: routeConfig,
+						},
+					}),
 				},
 			},
 		}
@@ -806,13 +825,21 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 							{
 								Name: "name",
 								ConfigType: &v3listenerpb.Filter_TypedConfig{
-									TypedConfig: testutils.MarshalAny(&v3httppb.HttpConnectionManager{}),
+									TypedConfig: testutils.MarshalAny(&v3httppb.HttpConnectionManager{
+										RouteSpecifier: &v3httppb.HttpConnectionManager_RouteConfig{
+											RouteConfig: routeConfig,
+										},
+									}),
 								},
 							},
 							{
 								Name: "name",
 								ConfigType: &v3listenerpb.Filter_TypedConfig{
-									TypedConfig: testutils.MarshalAny(&v3httppb.HttpConnectionManager{}),
+									TypedConfig: testutils.MarshalAny(&v3httppb.HttpConnectionManager{
+										RouteSpecifier: &v3httppb.HttpConnectionManager_RouteConfig{
+											RouteConfig: routeConfig,
+										},
+									}),
 								},
 							},
 						},
@@ -1051,7 +1078,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 											srcPrefixMap: map[string]*sourcePrefixEntry{
 												unspecifiedPrefixMapKey: {
 													srcPortMap: map[int]*FilterChain{
-														0: {},
+														0: {InlineRouteConfig: inlineRouteConfig},
 													},
 												},
 											},
@@ -1144,6 +1171,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 																IdentityInstanceName: "identityPluginInstance",
 																IdentityCertName:     "identityCertName",
 															},
+															InlineRouteConfig: inlineRouteConfig,
 														},
 													},
 												},
@@ -1157,6 +1185,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 									IdentityInstanceName: "defaultIdentityPluginInstance",
 									IdentityCertName:     "defaultIdentityCertName",
 								},
+								InlineRouteConfig: inlineRouteConfig,
 							},
 						},
 					},
@@ -1192,6 +1221,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 																IdentityCertName:     "identityCertName",
 																RequireClientCert:    true,
 															},
+															InlineRouteConfig: inlineRouteConfig,
 														},
 													},
 												},
@@ -1208,6 +1238,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 									IdentityCertName:     "defaultIdentityCertName",
 									RequireClientCert:    true,
 								},
+								InlineRouteConfig: inlineRouteConfig,
 							},
 						},
 					},

--- a/xds/internal/xdsclient/rds_test.go
+++ b/xds/internal/xdsclient/rds_test.go
@@ -71,6 +71,7 @@ func (s) TestRDSGenerateRDSUpdateFromRouteConfiguration(t *testing.T) {
 		}
 		goodUpdateWithFilterConfigs = func(cfgs map[string]httpfilter.FilterConfig) RouteConfigUpdate {
 			return RouteConfigUpdate{
+				RouteName: routeName,
 				VirtualHosts: []*VirtualHost{{
 					Domains: []string{ldsTarget},
 					Routes: []*Route{{
@@ -175,6 +176,7 @@ func (s) TestRDSGenerateRDSUpdateFromRouteConfiguration(t *testing.T) {
 								ClusterSpecifier: &v3routepb.RouteAction_Cluster{Cluster: clusterName},
 							}}}}}}},
 			wantUpdate: RouteConfigUpdate{
+				RouteName: routeName,
 				VirtualHosts: []*VirtualHost{
 					{
 						Domains: []string{ldsTarget},
@@ -217,6 +219,7 @@ func (s) TestRDSGenerateRDSUpdateFromRouteConfiguration(t *testing.T) {
 				},
 			},
 			wantUpdate: RouteConfigUpdate{
+				RouteName: routeName,
 				VirtualHosts: []*VirtualHost{
 					{
 						Domains: []string{uninterestingDomain},
@@ -251,6 +254,7 @@ func (s) TestRDSGenerateRDSUpdateFromRouteConfiguration(t *testing.T) {
 				},
 			},
 			wantUpdate: RouteConfigUpdate{
+				RouteName: routeName,
 				VirtualHosts: []*VirtualHost{
 					{
 						Domains: []string{ldsTarget},
@@ -321,6 +325,7 @@ func (s) TestRDSGenerateRDSUpdateFromRouteConfiguration(t *testing.T) {
 				},
 			},
 			wantUpdate: RouteConfigUpdate{
+				RouteName: routeName,
 				VirtualHosts: []*VirtualHost{
 					{
 						Domains: []string{ldsTarget},
@@ -358,6 +363,7 @@ func (s) TestRDSGenerateRDSUpdateFromRouteConfiguration(t *testing.T) {
 				},
 			},
 			wantUpdate: RouteConfigUpdate{
+				RouteName: routeName,
 				VirtualHosts: []*VirtualHost{
 					{
 						Domains: []string{ldsTarget},
@@ -392,6 +398,7 @@ func (s) TestRDSGenerateRDSUpdateFromRouteConfiguration(t *testing.T) {
 				},
 			},
 			wantUpdate: RouteConfigUpdate{
+				RouteName: routeName,
 				VirtualHosts: []*VirtualHost{
 					{
 						Domains: []string{ldsTarget},
@@ -426,6 +433,7 @@ func (s) TestRDSGenerateRDSUpdateFromRouteConfiguration(t *testing.T) {
 				},
 			},
 			wantUpdate: RouteConfigUpdate{
+				RouteName: routeName,
 				VirtualHosts: []*VirtualHost{
 					{
 						Domains: []string{ldsTarget},
@@ -618,6 +626,7 @@ func (s) TestUnmarshalRouteConfig(t *testing.T) {
 			resources: []*anypb.Any{v2RouteConfig},
 			wantUpdate: map[string]RouteConfigUpdate{
 				v2RouteConfigName: {
+					RouteName: v2RouteConfigName,
 					VirtualHosts: []*VirtualHost{
 						{
 							Domains: []string{uninterestingDomain},
@@ -641,6 +650,7 @@ func (s) TestUnmarshalRouteConfig(t *testing.T) {
 			resources: []*anypb.Any{v3RouteConfig},
 			wantUpdate: map[string]RouteConfigUpdate{
 				v3RouteConfigName: {
+					RouteName: v3RouteConfigName,
 					VirtualHosts: []*VirtualHost{
 						{
 							Domains: []string{uninterestingDomain},
@@ -664,6 +674,7 @@ func (s) TestUnmarshalRouteConfig(t *testing.T) {
 			resources: []*anypb.Any{v2RouteConfig, v3RouteConfig},
 			wantUpdate: map[string]RouteConfigUpdate{
 				v3RouteConfigName: {
+					RouteName: v3RouteConfigName,
 					VirtualHosts: []*VirtualHost{
 						{
 							Domains: []string{uninterestingDomain},
@@ -677,6 +688,7 @@ func (s) TestUnmarshalRouteConfig(t *testing.T) {
 					Raw: v3RouteConfig,
 				},
 				v2RouteConfigName: {
+					RouteName: v2RouteConfigName,
 					VirtualHosts: []*VirtualHost{
 						{
 							Domains: []string{uninterestingDomain},
@@ -711,6 +723,7 @@ func (s) TestUnmarshalRouteConfig(t *testing.T) {
 			},
 			wantUpdate: map[string]RouteConfigUpdate{
 				v3RouteConfigName: {
+					RouteName: v3RouteConfigName,
 					VirtualHosts: []*VirtualHost{
 						{
 							Domains: []string{uninterestingDomain},
@@ -724,6 +737,7 @@ func (s) TestUnmarshalRouteConfig(t *testing.T) {
 					Raw: v3RouteConfig,
 				},
 				v2RouteConfigName: {
+					RouteName: v2RouteConfigName,
 					VirtualHosts: []*VirtualHost{
 						{
 							Domains: []string{uninterestingDomain},

--- a/xds/internal/xdsclient/v2/rds_test.go
+++ b/xds/internal/xdsclient/v2/rds_test.go
@@ -92,6 +92,7 @@ func (s) TestRDSHandleResponseWithRouting(t *testing.T) {
 			wantErr:     false,
 			wantUpdate: map[string]xdsclient.RouteConfigUpdate{
 				goodRouteName1: {
+					RouteName:    goodRouteName1,
 					VirtualHosts: nil,
 					Raw:          marshaledNoVirtualHostsRouteConfig,
 				},
@@ -108,6 +109,7 @@ func (s) TestRDSHandleResponseWithRouting(t *testing.T) {
 			wantErr:     false,
 			wantUpdate: map[string]xdsclient.RouteConfigUpdate{
 				goodRouteName2: {
+					RouteName: goodRouteName2,
 					VirtualHosts: []*xdsclient.VirtualHost{
 						{
 							Domains: []string{uninterestingDomain},
@@ -133,6 +135,7 @@ func (s) TestRDSHandleResponseWithRouting(t *testing.T) {
 			wantErr:     false,
 			wantUpdate: map[string]xdsclient.RouteConfigUpdate{
 				goodRouteName1: {
+					RouteName: goodRouteName1,
 					VirtualHosts: []*xdsclient.VirtualHost{
 						{
 							Domains: []string{uninterestingDomain},

--- a/xds/internal/xdsclient/xds.go
+++ b/xds/internal/xdsclient/xds.go
@@ -277,92 +277,6 @@ func processServerSideListener(lis *v3listenerpb.Listener) (*ListenerUpdate, err
 	return lu, nil
 }
 
-func processNetworkFilters(filters []*v3listenerpb.Filter) (*FilterChain, error) {
-	filterChain := &FilterChain{}
-	seenNames := make(map[string]bool, len(filters))
-	seenHCM := false
-	for _, filter := range filters {
-		name := filter.GetName()
-		if name == "" {
-			return nil, fmt.Errorf("network filters {%+v} is missing name field in filter: {%+v}", filters, filter)
-		}
-		if seenNames[name] {
-			return nil, fmt.Errorf("network filters {%+v} has duplicate filter name %q", filters, name)
-		}
-		seenNames[name] = true
-
-		// Network filters have a oneof field named `config_type` where we
-		// only support `TypedConfig` variant.
-		switch typ := filter.GetConfigType().(type) {
-		case *v3listenerpb.Filter_TypedConfig:
-			// The typed_config field has an `anypb.Any` proto which could
-			// directly contain the serialized bytes of the actual filter
-			// configuration, or it could be encoded as a `TypedStruct`.
-			// TODO: Add support for `TypedStruct`.
-			tc := filter.GetTypedConfig()
-
-			// The only network filter that we currently support is the v3
-			// HttpConnectionManager. So, we can directly check the type_url
-			// and unmarshal the config.
-			// TODO: Implement a registry of supported network filters (like
-			// we have for HTTP filters), when we have to support network
-			// filters other than HttpConnectionManager.
-			if tc.GetTypeUrl() != version.V3HTTPConnManagerURL {
-				return nil, fmt.Errorf("network filters {%+v} has unsupported network filter %q in filter {%+v}", filters, tc.GetTypeUrl(), filter)
-			}
-			hcm := &v3httppb.HttpConnectionManager{}
-			if err := ptypes.UnmarshalAny(tc, hcm); err != nil {
-				return nil, fmt.Errorf("network filters {%+v} failed unmarshaling of network filter {%+v}: %v", filters, filter, err)
-			}
-			// "Any filters after HttpConnectionManager should be ignored during
-			// connection processing but still be considered for validity.
-			// HTTPConnectionManager must have valid http_filters." - A36
-			filters, err := processHTTPFilters(hcm.GetHttpFilters(), true)
-			if err != nil {
-				return nil, fmt.Errorf("network filters {%+v} had invalid server side HTTP Filters {%+v}", filters, hcm.GetHttpFilters())
-			}
-			if !seenHCM {
-				// TODO: Implement terminal filter logic, as per A36.
-				filterChain.HTTPFilters = filters
-				seenHCM = true
-				switch hcm.RouteSpecifier.(type) {
-				case *v3httppb.HttpConnectionManager_Rds:
-					if hcm.GetRds().GetConfigSource().GetAds() == nil {
-						return nil, fmt.Errorf("ConfigSource is not ADS: %+v", hcm)
-					}
-					name := hcm.GetRds().GetRouteConfigName()
-					if name == "" {
-						return nil, fmt.Errorf("empty route_config_name: %+v", hcm)
-					}
-					filterChain.RouteConfigName = name
-				case *v3httppb.HttpConnectionManager_RouteConfig:
-					// "RouteConfiguration validation logic inherits all
-					// previous validations made for client-side usage as RDS
-					// does not distinguish between client-side and
-					// server-side." - A36
-					// Can specify v3 here, as will never get to this function
-					// if v2.
-					routeU, err := generateRDSUpdateFromRouteConfiguration(hcm.GetRouteConfig(), nil, false)
-					if err != nil {
-						return nil, fmt.Errorf("failed to parse inline RDS resp: %v", err)
-					}
-					filterChain.InlineRouteConfig = &routeU // Now that all this is here, scale up listener inputs in test to persist route update
-				case nil:
-					return nil, fmt.Errorf("no RouteSpecifier: +%v", hcm)
-				default:
-					return nil, fmt.Errorf("unsupported type %T for RouteSpecifier", hcm.RouteSpecifier)
-				}
-			}
-		default:
-			return nil, fmt.Errorf("network filters {%+v} has unsupported config_type %T in filter %s", filters, typ, filter.GetName())
-		}
-	}
-	if !seenHCM {
-		return nil, fmt.Errorf("network filters {%+v} missing HttpConnectionManager filter", filters)
-	}
-	return filterChain, nil
-}
-
 // UnmarshalRouteConfig processes resources received in an RDS response,
 // validates them, and transforms them into a native struct which contains only
 // fields we are interested in. The provided hostname determines the route
@@ -580,10 +494,12 @@ func routesProtoToSlice(routes []*v3routepb.Route, logger *grpclog.PrefixLogger,
 				d := dur.AsDuration()
 				route.MaxStreamDuration = &d
 			}
+			route.RouteAction = RouteActionRoute
 		case *v3routepb.Route_NonForwardingAction:
 			// Expected to be used on server side.
+			route.RouteAction = RouteActionNonForwardingAction
 		default:
-			return nil, fmt.Errorf("route %+v has invalid action %+v", r, r.GetAction())
+			route.RouteAction = RouteActionUnsupported
 		}
 
 		if !v2 {

--- a/xds/internal/xdsclient/xds.go
+++ b/xds/internal/xdsclient/xds.go
@@ -343,7 +343,7 @@ func generateRDSUpdateFromRouteConfiguration(rc *v3routepb.RouteConfiguration, l
 		}
 		vhs = append(vhs, vhOut)
 	}
-	return RouteConfigUpdate{VirtualHosts: vhs}, nil
+	return RouteConfigUpdate{RouteName: rc.Name, VirtualHosts: vhs}, nil
 }
 
 func routesProtoToSlice(routes []*v3routepb.Route, logger *grpclog.PrefixLogger, v2 bool) ([]*Route, error) {

--- a/xds/server.go
+++ b/xds/server.go
@@ -233,6 +233,11 @@ func (s *GRPCServer) Serve(lis net.Listener) error {
 				err:  err,
 			})
 		},
+		DrainCallback: func(addr net.Addr) {
+			if gs, ok := s.gs.(*grpc.Server); ok {
+				drainServerTransports(gs, addr.String())
+			}
+		},
 	})
 
 	// Block until a good LDS response is received or the server is stopped.

--- a/xds/server_test.go
+++ b/xds/server_test.go
@@ -135,9 +135,10 @@ func (f *fakeGRPCServer) RegisterService(*grpc.ServiceDesc, interface{}) {
 	f.registerServiceCh.Send(nil)
 }
 
-func (f *fakeGRPCServer) Serve(net.Listener) error {
+func (f *fakeGRPCServer) Serve(lis net.Listener) error {
 	f.serveCh.Send(nil)
 	<-f.done
+	lis.Close()
 	return nil
 }
 

--- a/xds/server_test.go
+++ b/xds/server_test.go
@@ -32,6 +32,7 @@ import (
 
 	v3corepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	v3listenerpb "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	v3routepb "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	v3httppb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	v3tlspb "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	"google.golang.org/grpc"
@@ -688,7 +689,20 @@ func (s) TestHandleListenerUpdate_NoXDSCreds(t *testing.T) {
 					{
 						Name: "filter-1",
 						ConfigType: &v3listenerpb.Filter_TypedConfig{
-							TypedConfig: testutils.MarshalAny(&v3httppb.HttpConnectionManager{}),
+							TypedConfig: testutils.MarshalAny(&v3httppb.HttpConnectionManager{
+								RouteSpecifier: &v3httppb.HttpConnectionManager_RouteConfig{
+									RouteConfig: &v3routepb.RouteConfiguration{
+										Name: "routeName",
+										VirtualHosts: []*v3routepb.VirtualHost{{
+											Domains: []string{"lds.target.good:3333"},
+											Routes: []*v3routepb.Route{{
+												Match: &v3routepb.RouteMatch{
+													PathSpecifier: &v3routepb.RouteMatch_Prefix{Prefix: "/"},
+												},
+												Action: &v3routepb.Route_NonForwardingAction{},
+											}}}}},
+								},
+							}),
 						},
 					},
 				},

--- a/xds/server_test.go
+++ b/xds/server_test.go
@@ -440,6 +440,9 @@ func (s) TestServeSuccess(t *testing.T) {
 	// Push a good LDS response, and wait for Serve() to be invoked on the
 	// underlying grpc.Server.
 	fcm, err := xdsclient.NewFilterChainManager(listenerWithFilterChains)
+	if err != nil {
+		t.Fatalf("xdsclient.NewFilterChainManager() failed with error: %v", err)
+	}
 	addr, port := splitHostPort(lis.Addr().String())
 	client.InvokeWatchListenerCallback(xdsclient.ListenerUpdate{
 		RouteConfigName: "routeconfig",

--- a/xds/server_test.go
+++ b/xds/server_test.go
@@ -444,8 +444,8 @@ func (s) TestServeSuccess(t *testing.T) {
 	client.InvokeWatchListenerCallback(xdsclient.ListenerUpdate{
 		RouteConfigName: "routeconfig",
 		InboundListenerCfg: &xdsclient.InboundListenerConfig{
-			Address: addr,
-			Port:    port,
+			Address:      addr,
+			Port:         port,
 			FilterChains: fcm,
 		},
 	}, nil)
@@ -468,8 +468,8 @@ func (s) TestServeSuccess(t *testing.T) {
 	client.InvokeWatchListenerCallback(xdsclient.ListenerUpdate{
 		RouteConfigName: "routeconfig",
 		InboundListenerCfg: &xdsclient.InboundListenerConfig{
-			Address: "10.20.30.40",
-			Port:    "666",
+			Address:      "10.20.30.40",
+			Port:         "666",
 			FilterChains: fcm,
 		},
 	}, nil)


### PR DESCRIPTION
This PR adds RDS to Listener Wrapper. This is for any Filter Chains which specify dynamic RDS Responses. This PR is scoped only to Persisting RDS Configuration/Dynamic logic, and only the persistence in Listener Wrapper. Future functionality involves actually instantiating filters using this configuration, and matching (routing) + running through HTTP Filters in xds(Unary|Stream)Interceptor.

Note, this is branched off https://github.com/grpc/grpc-go/pull/4610.

RELEASE NOTES: None