### PR TITLE
github: update stale bot to v4

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,7 +13,7 @@ jobs:
       pull-requests: write
 
     steps:
-    - uses: actions/stale@v3
+    - uses: actions/stale@v4
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         days-before-stale: 6
@@ -21,7 +21,7 @@ jobs:
         only-labels: 'Status: Requires Reporter Clarification'
         stale-issue-label: 'stale'
         stale-pr-label: 'stale'
-        operations-per-run: 60
+        operations-per-run: 999
         stale-issue-message: >
           This issue is labeled as requiring an update from the reporter, and no update has been received
           after 6 days.  If no update is provided in the next 7 days, this issue will be automatically closed.


### PR DESCRIPTION
The v4 release of the stale bot fixes a bug that makes the bot ignore updates by the user that created the stale bot workflow (me).  This release also fixes the `operations-per-run` option so it will work as intended.  Unfortunately, that means low values will limit the number of issues it can inspect, so this PR also increases the operations per run to something much larger than we should need (I'd expect us to need at most 100-200 per run).

RELEASE NOTES: N/A