### PR TITLE
server: fix leaked net.Conn

### DIFF
--- a/server.go
+++ b/server.go
@@ -863,6 +863,7 @@ func (s *Server) handleRawConn(lisAddr string, rawConn net.Conn) {
 	// Finish handshaking (HTTP2)
 	st := s.newHTTP2Transport(conn, authInfo)
 	if st == nil {
+		conn.Close()
 		return
 	}
 


### PR DESCRIPTION
This happens when NewServerTransport() returns nil, nil. The rawConn is
closed when the transport is closed, which will never happen in this
case (since the returned transport is nil).

This is a backport of #4633

RELEASE NOTES:
- server: fix bug that net.Conn is leaked if the connection is closed (io.EOF) immediately with no traffic