### PR TITLE
server: fix net.conn closed twice

### DIFF
--- a/server.go
+++ b/server.go
@@ -909,7 +909,6 @@ func (s *Server) newHTTP2Transport(c net.Conn, authInfo credentials.AuthInfo) tr
 		s.mu.Lock()
 		s.errorf("NewServerTransport(%q) failed: %v", c.RemoteAddr(), err)
 		s.mu.Unlock()
-		c.Close()
 		channelz.Warning(logger, s.channelzID, "grpc: Server.Serve failed to create ServerTransport: ", err)
 		return nil
 	}


### PR DESCRIPTION
closed twice for conn.net when NewServerTransport() returns nil, err.


<img width="965" alt="截屏2021-08-11 上午10 37 31" src="https://user-images.githubusercontent.com/36129334/128961000-5c9bf13b-01b8-44b6-8938-bf810f29150d.png">


<img width="571" alt="截屏2021-08-11 上午10 36 07" src="https://user-images.githubusercontent.com/36129334/128960914-b700ddc0-fad0-4908-bd45-a5de729d7a4e.png">


whether ServerTransport returns nil or err returns not nil，we only need to call close once .

Related PR:
[4661](https://github.com/grpc/grpc-go/pull/4644)

RELEASE NOTES: N/A
