### PR TITLE
Copy the tag_and_push_docker_image method to grpc-go

### DIFF
--- a/test/kokoro/xds_k8s.sh
+++ b/test/kokoro/xds_k8s.sh
@@ -45,10 +45,8 @@ build_test_app_docker_images() {
   docker push "${SERVER_IMAGE_NAME}:${GIT_COMMIT}"
   if [[ -n $KOKORO_JOB_NAME ]]; then
     branch_name=$(echo "$KOKORO_JOB_NAME" | sed -E 's|^grpc/go/([^/]+)/.*|\1|')
-    docker tag "${CLIENT_IMAGE_NAME}:${GIT_COMMIT}" "${CLIENT_IMAGE_NAME}:${branch_name}"
-    docker tag "${SERVER_IMAGE_NAME}:${GIT_COMMIT}" "${SERVER_IMAGE_NAME}:${branch_name}"
-    docker push "${CLIENT_IMAGE_NAME}:${branch_name}"
-    docker push "${SERVER_IMAGE_NAME}:${branch_name}"
+    tag_and_push_docker_image "${CLIENT_IMAGE_NAME}" "${GIT_COMMIT}" "${branch_name}"
+    tag_and_push_docker_image "${SERVER_IMAGE_NAME}" "${GIT_COMMIT}" "${branch_name}"
   fi
 }
 

--- a/test/kokoro/xds_k8s.sh
+++ b/test/kokoro/xds_k8s.sh
@@ -45,8 +45,10 @@ build_test_app_docker_images() {
   docker push "${SERVER_IMAGE_NAME}:${GIT_COMMIT}"
   if [[ -n $KOKORO_JOB_NAME ]]; then
     branch_name=$(echo "$KOKORO_JOB_NAME" | sed -E 's|^grpc/go/([^/]+)/.*|\1|')
-    tag_and_push_docker_image "${CLIENT_IMAGE_NAME}" "${GIT_COMMIT}" "${branch_name}"
-    tag_and_push_docker_image "${SERVER_IMAGE_NAME}" "${GIT_COMMIT}" "${branch_name}"
+    docker tag "${CLIENT_IMAGE_NAME}:${GIT_COMMIT}" "${CLIENT_IMAGE_NAME}:${branch_name}"
+    docker tag "${SERVER_IMAGE_NAME}:${GIT_COMMIT}" "${SERVER_IMAGE_NAME}:${branch_name}"
+    docker push "${CLIENT_IMAGE_NAME}:${branch_name}"
+    docker push "${SERVER_IMAGE_NAME}:${branch_name}"
   fi
 }
 

--- a/test/kokoro/xds_k8s_install_test_driver.sh
+++ b/test/kokoro/xds_k8s_install_test_driver.sh
@@ -360,3 +360,21 @@ local_setup_test_driver() {
   readonly TEST_XML_OUTPUT_DIR="${TEST_DRIVER_FULL_DIR}/out"
   mkdir -p "${TEST_XML_OUTPUT_DIR}"
 }
+
+#######################################
+# Tag and push the given Docker image
+# Arguments:
+#   The Docker image name
+#   The Docker image original tag name
+#   The Docker image new tag name
+# Outputs:
+#   Writes the output to stdout, stderr, files
+#######################################
+tag_and_push_docker_image() {
+  local image_name="$1"
+  local from_tag="$2"
+  local to_tag="$3"
+
+  docker tag "${image_name}:${from_tag}" "${image_name}:${to_tag}"
+  docker push "${image_name}:${to_tag}"
+}


### PR DESCRIPTION
Related https://github.com/grpc/grpc-go/pull/4661 b/196202377

Somehow, the Kokoro script failed to pick up the checked-in function for tag_and_push_docker_image in grpc/grpc master. So, this PR uses Docker command directly.

https://fusion2.corp.google.com/invocations/f198d36f-5def-4296-b76a-387993b6d941/targets

RELEASE NOTES: N/A