### PR TITLE
xds: Instantiate HTTP Filters on Server Side

### DIFF
--- a/xds/internal/resolver/serviceconfig.go
+++ b/xds/internal/resolver/serviceconfig.go
@@ -117,7 +117,7 @@ type routeCluster struct {
 }
 
 type route struct {
-	m                 *compositeMatcher // converted from route matchers
+	m                 *xdsclient.CompositeMatcher // converted from route matchers
 	clusters          wrr.WRR           // holds *routeCluster entries
 	maxStreamDuration time.Duration
 	// map from filter name to its config
@@ -146,7 +146,7 @@ func (cs *configSelector) SelectConfig(rpcInfo iresolver.RPCInfo) (*iresolver.RP
 	var rt *route
 	// Loop through routes in order and select first match.
 	for _, r := range cs.routes {
-		if r.m.match(rpcInfo) {
+		if r.m.Match(rpcInfo) {
 			rt = &r
 			break
 		}
@@ -350,7 +350,7 @@ func (r *xdsResolver) newConfigSelector(su serviceUpdate) (*configSelector, erro
 		cs.routes[i].clusters = clusters
 
 		var err error
-		cs.routes[i].m, err = routeToMatcher(rt)
+		cs.routes[i].m, err = xdsclient.RouteToMatcher(rt)
 		if err != nil {
 			return nil, err
 		}

--- a/xds/internal/resolver/watch_service_test.go
+++ b/xds/internal/resolver/watch_service_test.go
@@ -169,7 +169,7 @@ func (s) TestServiceWatch(t *testing.T) {
 	waitForWatchRouteConfig(ctx, t, xdsC, routeStr)
 
 	wantUpdate := serviceUpdate{virtualHost: &xdsclient.VirtualHost{Domains: []string{"target"}, Routes: []*xdsclient.Route{{Prefix: newStringP(""), WeightedClusters: map[string]xdsclient.WeightedCluster{cluster: {Weight: 1}}}}}}
-	xdsC.InvokeWatchRouteConfigCallback(xdsclient.RouteConfigUpdate{
+	xdsC.InvokeWatchRouteConfigCallback("", xdsclient.RouteConfigUpdate{
 		VirtualHosts: []*xdsclient.VirtualHost{
 			{
 				Domains: []string{targetStr},
@@ -187,7 +187,7 @@ func (s) TestServiceWatch(t *testing.T) {
 			WeightedClusters: map[string]xdsclient.WeightedCluster{cluster: {Weight: 1}},
 		}},
 	}}
-	xdsC.InvokeWatchRouteConfigCallback(xdsclient.RouteConfigUpdate{
+	xdsC.InvokeWatchRouteConfigCallback("", xdsclient.RouteConfigUpdate{
 		VirtualHosts: []*xdsclient.VirtualHost{
 			{
 				Domains: []string{targetStr},
@@ -223,7 +223,7 @@ func (s) TestServiceWatchLDSUpdate(t *testing.T) {
 	waitForWatchRouteConfig(ctx, t, xdsC, routeStr)
 
 	wantUpdate := serviceUpdate{virtualHost: &xdsclient.VirtualHost{Domains: []string{"target"}, Routes: []*xdsclient.Route{{Prefix: newStringP(""), WeightedClusters: map[string]xdsclient.WeightedCluster{cluster: {Weight: 1}}}}}}
-	xdsC.InvokeWatchRouteConfigCallback(xdsclient.RouteConfigUpdate{
+	xdsC.InvokeWatchRouteConfigCallback("", xdsclient.RouteConfigUpdate{
 		VirtualHosts: []*xdsclient.VirtualHost{
 			{
 				Domains: []string{targetStr},
@@ -237,14 +237,14 @@ func (s) TestServiceWatchLDSUpdate(t *testing.T) {
 
 	// Another LDS update with a different RDS_name.
 	xdsC.InvokeWatchListenerCallback(xdsclient.ListenerUpdate{RouteConfigName: routeStr + "2"}, nil)
-	if err := xdsC.WaitForCancelRouteConfigWatch(ctx); err != nil {
+	if _, err := xdsC.WaitForCancelRouteConfigWatch(ctx); err != nil {
 		t.Fatalf("wait for cancel route watch failed: %v, want nil", err)
 	}
 	waitForWatchRouteConfig(ctx, t, xdsC, routeStr+"2")
 
 	// RDS update for the new name.
 	wantUpdate2 := serviceUpdate{virtualHost: &xdsclient.VirtualHost{Domains: []string{"target"}, Routes: []*xdsclient.Route{{Prefix: newStringP(""), WeightedClusters: map[string]xdsclient.WeightedCluster{cluster + "2": {Weight: 1}}}}}}
-	xdsC.InvokeWatchRouteConfigCallback(xdsclient.RouteConfigUpdate{
+	xdsC.InvokeWatchRouteConfigCallback(routeStr+"2", xdsclient.RouteConfigUpdate{
 		VirtualHosts: []*xdsclient.VirtualHost{
 			{
 				Domains: []string{targetStr},
@@ -279,7 +279,7 @@ func (s) TestServiceWatchLDSUpdateMaxStreamDuration(t *testing.T) {
 		WeightedClusters: map[string]xdsclient.WeightedCluster{cluster: {Weight: 1}}}}},
 		ldsConfig: ldsConfig{maxStreamDuration: time.Second},
 	}
-	xdsC.InvokeWatchRouteConfigCallback(xdsclient.RouteConfigUpdate{
+	xdsC.InvokeWatchRouteConfigCallback("", xdsclient.RouteConfigUpdate{
 		VirtualHosts: []*xdsclient.VirtualHost{
 			{
 				Domains: []string{targetStr},
@@ -303,7 +303,7 @@ func (s) TestServiceWatchLDSUpdateMaxStreamDuration(t *testing.T) {
 		Prefix:           newStringP(""),
 		WeightedClusters: map[string]xdsclient.WeightedCluster{cluster + "2": {Weight: 1}}}},
 	}}
-	xdsC.InvokeWatchRouteConfigCallback(xdsclient.RouteConfigUpdate{
+	xdsC.InvokeWatchRouteConfigCallback("", xdsclient.RouteConfigUpdate{
 		VirtualHosts: []*xdsclient.VirtualHost{
 			{
 				Domains: []string{targetStr},
@@ -337,7 +337,7 @@ func (s) TestServiceNotCancelRDSOnSameLDSUpdate(t *testing.T) {
 		Prefix:           newStringP(""),
 		WeightedClusters: map[string]xdsclient.WeightedCluster{cluster: {Weight: 1}}}},
 	}}
-	xdsC.InvokeWatchRouteConfigCallback(xdsclient.RouteConfigUpdate{
+	xdsC.InvokeWatchRouteConfigCallback("", xdsclient.RouteConfigUpdate{
 		VirtualHosts: []*xdsclient.VirtualHost{
 			{
 				Domains: []string{targetStr},
@@ -354,7 +354,7 @@ func (s) TestServiceNotCancelRDSOnSameLDSUpdate(t *testing.T) {
 	xdsC.InvokeWatchListenerCallback(xdsclient.ListenerUpdate{RouteConfigName: routeStr}, nil)
 	sCtx, sCancel := context.WithTimeout(ctx, defaultTestShortTimeout)
 	defer sCancel()
-	if err := xdsC.WaitForCancelRouteConfigWatch(sCtx); err != context.DeadlineExceeded {
+	if _, err := xdsC.WaitForCancelRouteConfigWatch(sCtx); err != context.DeadlineExceeded {
 		t.Fatalf("wait for cancel route watch failed: %v, want nil", err)
 	}
 }
@@ -378,7 +378,7 @@ func (s) TestServiceWatchInlineRDS(t *testing.T) {
 	xdsC.InvokeWatchListenerCallback(xdsclient.ListenerUpdate{RouteConfigName: routeStr}, nil)
 	waitForWatchRouteConfig(ctx, t, xdsC, routeStr)
 	wantUpdate := serviceUpdate{virtualHost: &xdsclient.VirtualHost{Domains: []string{"target"}, Routes: []*xdsclient.Route{{Prefix: newStringP(""), WeightedClusters: map[string]xdsclient.WeightedCluster{cluster: {Weight: 1}}}}}}
-	xdsC.InvokeWatchRouteConfigCallback(xdsclient.RouteConfigUpdate{
+	xdsC.InvokeWatchRouteConfigCallback("", xdsclient.RouteConfigUpdate{
 		VirtualHosts: []*xdsclient.VirtualHost{
 			{
 				Domains: []string{targetStr},
@@ -402,7 +402,7 @@ func (s) TestServiceWatchInlineRDS(t *testing.T) {
 		VirtualHosts: []*xdsclient.VirtualHost{wantVirtualHosts2},
 	}}, nil)
 	// This inline RDS resource should cause the RDS watch to be canceled.
-	if err := xdsC.WaitForCancelRouteConfigWatch(ctx); err != nil {
+	if _, err := xdsC.WaitForCancelRouteConfigWatch(ctx); err != nil {
 		t.Fatalf("wait for cancel route watch failed: %v, want nil", err)
 	}
 	if err := verifyServiceUpdate(ctx, serviceUpdateCh, wantUpdate2); err != nil {
@@ -412,7 +412,7 @@ func (s) TestServiceWatchInlineRDS(t *testing.T) {
 	// Switch LDS update back to LDS with RDS name to watch.
 	xdsC.InvokeWatchListenerCallback(xdsclient.ListenerUpdate{RouteConfigName: routeStr}, nil)
 	waitForWatchRouteConfig(ctx, t, xdsC, routeStr)
-	xdsC.InvokeWatchRouteConfigCallback(xdsclient.RouteConfigUpdate{
+	xdsC.InvokeWatchRouteConfigCallback("", xdsclient.RouteConfigUpdate{
 		VirtualHosts: []*xdsclient.VirtualHost{
 			{
 				Domains: []string{targetStr},
@@ -429,7 +429,7 @@ func (s) TestServiceWatchInlineRDS(t *testing.T) {
 		VirtualHosts: []*xdsclient.VirtualHost{wantVirtualHosts2},
 	}}, nil)
 	// This inline RDS resource should cause the RDS watch to be canceled.
-	if err := xdsC.WaitForCancelRouteConfigWatch(ctx); err != nil {
+	if _, err := xdsC.WaitForCancelRouteConfigWatch(ctx); err != nil {
 		t.Fatalf("wait for cancel route watch failed: %v, want nil", err)
 	}
 	if err := verifyServiceUpdate(ctx, serviceUpdateCh, wantUpdate2); err != nil {

--- a/xds/internal/resolver/xds_resolver_test.go
+++ b/xds/internal/resolver/xds_resolver_test.go
@@ -1393,13 +1393,13 @@ func (s) TestXDSResolverHTTPFilters(t *testing.T) {
 
 func replaceRandNumGenerator(start int64) func() {
 	nextInt := start
-	grpcrandInt63n = func(int64) (ret int64) {
+	xdsclient.GrpcrandInt63n = func(int64) (ret int64) {
 		ret = nextInt
 		nextInt++
 		return
 	}
 	return func() {
-		grpcrandInt63n = grpcrand.Int63n
+		xdsclient.GrpcrandInt63n = grpcrand.Int63n
 	}
 }
 

--- a/xds/internal/resolver/xds_resolver_test.go
+++ b/xds/internal/resolver/xds_resolver_test.go
@@ -270,7 +270,7 @@ func (s) TestXDSResolverWatchCallbackAfterClose(t *testing.T) {
 	// Call the watchAPI callback after closing the resolver, and make sure no
 	// update is triggerred on the ClientConn.
 	xdsR.Close()
-	xdsC.InvokeWatchRouteConfigCallback(xdsclient.RouteConfigUpdate{
+	xdsC.InvokeWatchRouteConfigCallback("", xdsclient.RouteConfigUpdate{
 		VirtualHosts: []*xdsclient.VirtualHost{
 			{
 				Domains: []string{targetStr},
@@ -317,7 +317,7 @@ func (s) TestXDSResolverBadServiceUpdate(t *testing.T) {
 	// Invoke the watchAPI callback with a bad service update and wait for the
 	// ReportError method to be called on the ClientConn.
 	suErr := errors.New("bad serviceupdate")
-	xdsC.InvokeWatchRouteConfigCallback(xdsclient.RouteConfigUpdate{}, suErr)
+	xdsC.InvokeWatchRouteConfigCallback("", xdsclient.RouteConfigUpdate{}, suErr)
 
 	if gotErrVal, gotErr := tcc.errorCh.Receive(ctx); gotErr != nil || gotErrVal != suErr {
 		t.Fatalf("ClientConn.ReportError() received %v, want %v", gotErrVal, suErr)
@@ -406,7 +406,7 @@ func (s) TestXDSResolverGoodServiceUpdate(t *testing.T) {
 	} {
 		// Invoke the watchAPI callback with a good service update and wait for the
 		// UpdateState method to be called on the ClientConn.
-		xdsC.InvokeWatchRouteConfigCallback(xdsclient.RouteConfigUpdate{
+		xdsC.InvokeWatchRouteConfigCallback("", xdsclient.RouteConfigUpdate{
 			VirtualHosts: []*xdsclient.VirtualHost{
 				{
 					Domains: []string{targetStr},
@@ -480,7 +480,7 @@ func (s) TestXDSResolverRequestHash(t *testing.T) {
 	waitForWatchRouteConfig(ctx, t, xdsC, routeStr)
 	// Invoke watchAPI callback with a good service update (with hash policies
 	// specified) and wait for UpdateState method to be called on ClientConn.
-	xdsC.InvokeWatchRouteConfigCallback(xdsclient.RouteConfigUpdate{
+	xdsC.InvokeWatchRouteConfigCallback("", xdsclient.RouteConfigUpdate{
 		VirtualHosts: []*xdsclient.VirtualHost{
 			{
 				Domains: []string{targetStr},
@@ -541,7 +541,7 @@ func (s) TestXDSResolverRemovedWithRPCs(t *testing.T) {
 
 	// Invoke the watchAPI callback with a good service update and wait for the
 	// UpdateState method to be called on the ClientConn.
-	xdsC.InvokeWatchRouteConfigCallback(xdsclient.RouteConfigUpdate{
+	xdsC.InvokeWatchRouteConfigCallback("", xdsclient.RouteConfigUpdate{
 		VirtualHosts: []*xdsclient.VirtualHost{
 			{
 				Domains: []string{targetStr},
@@ -572,7 +572,7 @@ func (s) TestXDSResolverRemovedWithRPCs(t *testing.T) {
 
 	// Delete the resource
 	suErr := xdsclient.NewErrorf(xdsclient.ErrorTypeResourceNotFound, "resource removed error")
-	xdsC.InvokeWatchRouteConfigCallback(xdsclient.RouteConfigUpdate{}, suErr)
+	xdsC.InvokeWatchRouteConfigCallback("", xdsclient.RouteConfigUpdate{}, suErr)
 
 	if _, err = tcc.stateCh.Receive(ctx); err != nil {
 		t.Fatalf("Error waiting for UpdateState to be called: %v", err)
@@ -601,7 +601,7 @@ func (s) TestXDSResolverRemovedResource(t *testing.T) {
 
 	// Invoke the watchAPI callback with a good service update and wait for the
 	// UpdateState method to be called on the ClientConn.
-	xdsC.InvokeWatchRouteConfigCallback(xdsclient.RouteConfigUpdate{
+	xdsC.InvokeWatchRouteConfigCallback("", xdsclient.RouteConfigUpdate{
 		VirtualHosts: []*xdsclient.VirtualHost{
 			{
 				Domains: []string{targetStr},
@@ -651,7 +651,7 @@ func (s) TestXDSResolverRemovedResource(t *testing.T) {
 	// Delete the resource.  The channel should receive a service config with the
 	// original cluster but with an erroring config selector.
 	suErr := xdsclient.NewErrorf(xdsclient.ErrorTypeResourceNotFound, "resource removed error")
-	xdsC.InvokeWatchRouteConfigCallback(xdsclient.RouteConfigUpdate{}, suErr)
+	xdsC.InvokeWatchRouteConfigCallback("", xdsclient.RouteConfigUpdate{}, suErr)
 
 	if gotState, err = tcc.stateCh.Receive(ctx); err != nil {
 		t.Fatalf("Error waiting for UpdateState to be called: %v", err)
@@ -712,7 +712,7 @@ func (s) TestXDSResolverWRR(t *testing.T) {
 
 	// Invoke the watchAPI callback with a good service update and wait for the
 	// UpdateState method to be called on the ClientConn.
-	xdsC.InvokeWatchRouteConfigCallback(xdsclient.RouteConfigUpdate{
+	xdsC.InvokeWatchRouteConfigCallback("", xdsclient.RouteConfigUpdate{
 		VirtualHosts: []*xdsclient.VirtualHost{
 			{
 				Domains: []string{targetStr},
@@ -772,7 +772,7 @@ func (s) TestXDSResolverMaxStreamDuration(t *testing.T) {
 
 	// Invoke the watchAPI callback with a good service update and wait for the
 	// UpdateState method to be called on the ClientConn.
-	xdsC.InvokeWatchRouteConfigCallback(xdsclient.RouteConfigUpdate{
+	xdsC.InvokeWatchRouteConfigCallback("", xdsclient.RouteConfigUpdate{
 		VirtualHosts: []*xdsclient.VirtualHost{
 			{
 				Domains: []string{targetStr},
@@ -862,7 +862,7 @@ func (s) TestXDSResolverDelayedOnCommitted(t *testing.T) {
 
 	// Invoke the watchAPI callback with a good service update and wait for the
 	// UpdateState method to be called on the ClientConn.
-	xdsC.InvokeWatchRouteConfigCallback(xdsclient.RouteConfigUpdate{
+	xdsC.InvokeWatchRouteConfigCallback("", xdsclient.RouteConfigUpdate{
 		VirtualHosts: []*xdsclient.VirtualHost{
 			{
 				Domains: []string{targetStr},
@@ -912,7 +912,7 @@ func (s) TestXDSResolverDelayedOnCommitted(t *testing.T) {
 
 	// Perform TWO updates to ensure the old config selector does not hold a
 	// reference to test-cluster-1.
-	xdsC.InvokeWatchRouteConfigCallback(xdsclient.RouteConfigUpdate{
+	xdsC.InvokeWatchRouteConfigCallback("", xdsclient.RouteConfigUpdate{
 		VirtualHosts: []*xdsclient.VirtualHost{
 			{
 				Domains: []string{targetStr},
@@ -922,7 +922,7 @@ func (s) TestXDSResolverDelayedOnCommitted(t *testing.T) {
 	}, nil)
 	tcc.stateCh.Receive(ctx) // Ignore the first update.
 
-	xdsC.InvokeWatchRouteConfigCallback(xdsclient.RouteConfigUpdate{
+	xdsC.InvokeWatchRouteConfigCallback("", xdsclient.RouteConfigUpdate{
 		VirtualHosts: []*xdsclient.VirtualHost{
 			{
 				Domains: []string{targetStr},
@@ -961,7 +961,7 @@ func (s) TestXDSResolverDelayedOnCommitted(t *testing.T) {
 	// test-cluster-1.
 	res.OnCommitted()
 
-	xdsC.InvokeWatchRouteConfigCallback(xdsclient.RouteConfigUpdate{
+	xdsC.InvokeWatchRouteConfigCallback("", xdsclient.RouteConfigUpdate{
 		VirtualHosts: []*xdsclient.VirtualHost{
 			{
 				Domains: []string{targetStr},
@@ -1012,7 +1012,7 @@ func (s) TestXDSResolverGoodUpdateAfterError(t *testing.T) {
 	// Invoke the watchAPI callback with a bad service update and wait for the
 	// ReportError method to be called on the ClientConn.
 	suErr := errors.New("bad serviceupdate")
-	xdsC.InvokeWatchRouteConfigCallback(xdsclient.RouteConfigUpdate{}, suErr)
+	xdsC.InvokeWatchRouteConfigCallback("", xdsclient.RouteConfigUpdate{}, suErr)
 
 	if gotErrVal, gotErr := tcc.errorCh.Receive(ctx); gotErr != nil || gotErrVal != suErr {
 		t.Fatalf("ClientConn.ReportError() received %v, want %v", gotErrVal, suErr)
@@ -1020,7 +1020,7 @@ func (s) TestXDSResolverGoodUpdateAfterError(t *testing.T) {
 
 	// Invoke the watchAPI callback with a good service update and wait for the
 	// UpdateState method to be called on the ClientConn.
-	xdsC.InvokeWatchRouteConfigCallback(xdsclient.RouteConfigUpdate{
+	xdsC.InvokeWatchRouteConfigCallback("", xdsclient.RouteConfigUpdate{
 		VirtualHosts: []*xdsclient.VirtualHost{
 			{
 				Domains: []string{targetStr},
@@ -1040,7 +1040,7 @@ func (s) TestXDSResolverGoodUpdateAfterError(t *testing.T) {
 	// Invoke the watchAPI callback with a bad service update and wait for the
 	// ReportError method to be called on the ClientConn.
 	suErr2 := errors.New("bad serviceupdate 2")
-	xdsC.InvokeWatchRouteConfigCallback(xdsclient.RouteConfigUpdate{}, suErr2)
+	xdsC.InvokeWatchRouteConfigCallback("", xdsclient.RouteConfigUpdate{}, suErr2)
 	if gotErrVal, gotErr := tcc.errorCh.Receive(ctx); gotErr != nil || gotErrVal != suErr2 {
 		t.Fatalf("ClientConn.ReportError() received %v, want %v", gotErrVal, suErr2)
 	}
@@ -1066,7 +1066,7 @@ func (s) TestXDSResolverResourceNotFoundError(t *testing.T) {
 	// Invoke the watchAPI callback with a bad service update and wait for the
 	// ReportError method to be called on the ClientConn.
 	suErr := xdsclient.NewErrorf(xdsclient.ErrorTypeResourceNotFound, "resource removed error")
-	xdsC.InvokeWatchRouteConfigCallback(xdsclient.RouteConfigUpdate{}, suErr)
+	xdsC.InvokeWatchRouteConfigCallback("", xdsclient.RouteConfigUpdate{}, suErr)
 
 	if gotErrVal, gotErr := tcc.errorCh.Receive(ctx); gotErr != context.DeadlineExceeded {
 		t.Fatalf("ClientConn.ReportError() received %v, %v, want channel recv timeout", gotErrVal, gotErr)
@@ -1295,7 +1295,7 @@ func (s) TestXDSResolverHTTPFilters(t *testing.T) {
 
 			// Invoke the watchAPI callback with a good service update and wait for the
 			// UpdateState method to be called on the ClientConn.
-			xdsC.InvokeWatchRouteConfigCallback(xdsclient.RouteConfigUpdate{
+			xdsC.InvokeWatchRouteConfigCallback("", xdsclient.RouteConfigUpdate{
 				VirtualHosts: []*xdsclient.VirtualHost{
 					{
 						Domains: []string{targetStr},

--- a/xds/internal/server/conn_wrapper.go
+++ b/xds/internal/server/conn_wrapper.go
@@ -58,6 +58,8 @@ type connWrapper struct {
 	// completing the HTTP2 handshake.
 	deadlineMu sync.Mutex
 	deadline   time.Time
+
+	virtualHosts []xdsclient.VirtualHostWithInterceptors
 }
 
 // SetDeadline makes a copy of the passed in deadline and forwards the call to

--- a/xds/internal/server/listener_wrapper.go
+++ b/xds/internal/server/listener_wrapper.go
@@ -211,9 +211,14 @@ type listenerWrapper struct {
 	// rdsHandler is used for any dynamic RDS resources specified in a LDS
 	// update.
 	rdsHandler *rdsHandler
+	// rdsMu guards access to the rdsUpdates. The reason for using an rw lock
+	// here is that these fields are read in Accept() for all incoming
+	// connections, but writes happen rarely (when we get all the RDS resources
+	// needed).
+	rdsMu sync.RWMutex
 	// rdsUpdates are the RDS resources received from the management
 	// server, keyed on the RouteName of the RDS resource.
-	rdsUpdates map[string]xdsclient.RouteConfigUpdate // TODO: if this will be read in accept, this will need a read lock as well.
+	rdsUpdates map[string]xdsclient.RouteConfigUpdate
 	// ldsUpdateCh is a channel for XDSClient LDS updates.
 	ldsUpdateCh chan ldsUpdateWithError
 	// rdsUpdateCh is a channel for XDSClient RDS updates.
@@ -297,11 +302,20 @@ func (l *listenerWrapper) Accept() (net.Conn, error) {
 			conn.Close()
 			continue
 		}
-		// TODO: once matched an accepted connection to a filter chain,
-		// instantiate the HTTP filters in the filter chain + the filter
-		// overrides, pipe filters and route into connection, which will
-		// eventually be passed to xdsUnary/Stream interceptors.
-		return &connWrapper{Conn: conn, filterChain: fc, parent: l}, nil
+		var rc xdsclient.RouteConfigUpdate
+		if fc.InlineRouteConfig != nil {
+			rc = *fc.InlineRouteConfig
+		} else {
+			l.rdsMu.RLock()
+			rc = l.rdsUpdates[fc.RouteConfigName]
+			l.rdsMu.RUnlock()
+		}
+
+		if err := fc.ConstructUsableRouteConfiguration(rc); err != nil {
+			// TODO: is this correct? Will this invoke the right behavior in GRPCServer?
+			return nil, fmt.Errorf("error constructing usable route configuration: %v", err)
+		}
+		return &connWrapper{Conn: conn, filterChain: fc, parent: l, virtualHosts: fc.VirtualHosts}, nil
 	}
 }
 

--- a/xds/internal/server/listener_wrapper.go
+++ b/xds/internal/server/listener_wrapper.go
@@ -84,6 +84,11 @@ func (s ServingMode) String() string {
 // non-nil error if the server has transitioned into not-serving mode.
 type ServingModeCallback func(addr net.Addr, mode ServingMode, err error)
 
+// DrainCallback is the callback that servers can register to get pinged whenever
+// a new listener update gets received, and we want any clients to reconnect to
+// get the updated configuration.
+type DrainCallback func(addr net.Addr)
+
 func prefixLogger(p *listenerWrapper) *internalgrpclog.PrefixLogger {
 	return internalgrpclog.NewPrefixLogger(logger, fmt.Sprintf("[xds-server-listener %p] ", p))
 }
@@ -92,6 +97,7 @@ func prefixLogger(p *listenerWrapper) *internalgrpclog.PrefixLogger {
 // the listenerWrapper.
 type XDSClient interface {
 	WatchListener(string, func(xdsclient.ListenerUpdate, error)) func()
+	WatchRouteConfig(string, func(xdsclient.RouteConfigUpdate, error)) func()
 	BootstrapConfig() *bootstrap.Config
 }
 
@@ -108,6 +114,8 @@ type ListenerWrapperParams struct {
 	XDSClient XDSClient
 	// ModeCallback is the callback to invoke when the serving mode changes.
 	ModeCallback ServingModeCallback
+	// DrainCallback is the callback to invoke when the Listener gets a new update.
+	DrainCallback DrainCallback
 }
 
 // NewListenerWrapper creates a new listenerWrapper with params. It returns a
@@ -122,10 +130,12 @@ func NewListenerWrapper(params ListenerWrapperParams) (net.Listener, <-chan stru
 		xdsCredsInUse:     params.XDSCredsInUse,
 		xdsC:              params.XDSClient,
 		modeCallback:      params.ModeCallback,
+		drainCallback:     params.DrainCallback,
 		isUnspecifiedAddr: params.Listener.Addr().(*net.TCPAddr).IP.IsUnspecified(),
 
 		closed:     grpcsync.NewEvent(),
 		goodUpdate: grpcsync.NewEvent(),
+		updateCh:   make(chan ldsUpdateWithError, 1),
 	}
 	lw.logger = prefixLogger(lw)
 
@@ -134,13 +144,21 @@ func NewListenerWrapper(params ListenerWrapperParams) (net.Listener, <-chan stru
 	lisAddr := lw.Listener.Addr().String()
 	lw.addr, lw.port, _ = net.SplitHostPort(lisAddr)
 
+	lw.rdsHandler = newRDSHandler(lw)
+
 	cancelWatch := lw.xdsC.WatchListener(lw.name, lw.handleListenerUpdate)
 	lw.logger.Infof("Watch started on resource name %v", lw.name)
 	lw.cancelWatch = func() {
 		cancelWatch()
 		lw.logger.Infof("Watch cancelled on resource name %v", lw.name)
 	}
+	go lw.run()
 	return lw, lw.goodUpdate.Done()
+}
+
+type ldsUpdateWithError struct {
+	update xdsclient.ListenerUpdate
+	err    error
 }
 
 // listenerWrapper wraps the net.Listener associated with the listening address
@@ -155,6 +173,7 @@ type listenerWrapper struct {
 	xdsC          XDSClient
 	cancelWatch   func()
 	modeCallback  ServingModeCallback
+	drainCallback DrainCallback
 
 	// Set to true if the listener is bound to the IP_ANY address (which is
 	// "0.0.0.0" for IPv4 and "::" for IPv6).
@@ -185,6 +204,12 @@ type listenerWrapper struct {
 	mode ServingMode
 	// Filter chains received as part of the last good update.
 	filterChains *xdsclient.FilterChainManager
+
+	rdsHandler *rdsHandler
+
+	rdsUpdates map[string]xdsclient.RouteConfigUpdate // TODO: if this will be read in accept, this will need a read lock as well.
+
+	updateCh chan ldsUpdateWithError
 }
 
 // Accept blocks on an Accept() on the underlying listener, and wraps the
@@ -264,6 +289,10 @@ func (l *listenerWrapper) Accept() (net.Conn, error) {
 			conn.Close()
 			continue
 		}
+		// TODO: once matched an accepted connection to a filter chain,
+		// instantiate the HTTP filters in the filter chain + the filter
+		// overrides, pipe filters and route into connection, which will
+		// eventually be passed to xdsUnary/Stream interceptors.
 		return &connWrapper{Conn: conn, filterChain: fc, parent: l}, nil
 	}
 }
@@ -277,25 +306,76 @@ func (l *listenerWrapper) Close() error {
 	if l.cancelWatch != nil {
 		l.cancelWatch()
 	}
+	l.rdsHandler.close()
 	return nil
 }
 
+// run is a long running goroutine which handles all xds updates. LDS and RDS
+// push updates onto a channel which is read and acted upon from this goroutine.
+func (l *listenerWrapper) run() {
+	for {
+		select {
+		case <-l.closed.Done():
+			return
+		case u := <-l.updateCh:
+			l.handleLDSUpdate(u)
+		case u := <-l.rdsHandler.updateChannel:
+			l.handleRDSUpdate(u)
+		}
+	}
+}
+
+// handleLDSUpdate is the callback which handles LDS Updates. It writes the
+// received update to the update channel, which is picked up by the run
+// goroutine.
 func (l *listenerWrapper) handleListenerUpdate(update xdsclient.ListenerUpdate, err error) {
 	if l.closed.HasFired() {
 		l.logger.Warningf("Resource %q received update: %v with error: %v, after listener was closed", l.name, update, err)
 		return
 	}
+	// Remove any existing entry in updateCh and replace with the new one, as the only update
+	// listener cares about is most recent update.
+	select {
+	case <-l.updateCh:
+	default:
+	}
+	l.updateCh <- ldsUpdateWithError{update: update, err: err}
+}
 
-	if err != nil {
-		l.logger.Warningf("Received error for resource %q: %+v", l.name, err)
-		if xdsclient.ErrType(err) == xdsclient.ErrorTypeResourceNotFound {
-			l.switchMode(nil, ServingModeNotServing, err)
+// handleRDSUpdate handles a full rds update from rds handler. On a successful
+// update, the server will switch to ServingModeServing as the full
+// configuration (both LDS and RDS) has been received.
+func (l *listenerWrapper) handleRDSUpdate(update rdsHandlerUpdate) {
+	if l.closed.HasFired() {
+		l.logger.Warningf("RDS received update: %v with error: %v, after listener was closed", update.updates, update.err)
+		return
+	}
+	if update.err != nil {
+		l.logger.Warningf("Received error for rds names specified in resource %q: %+v", l.name, update.err)
+		if xdsclient.ErrType(update.err) == xdsclient.ErrorTypeResourceNotFound {
+			l.switchMode(nil, ServingModeNotServing, update.err)
 		}
 		// For errors which are anything other than "resource-not-found", we
 		// continue to use the old configuration.
 		return
 	}
-	l.logger.Infof("Received update for resource %q: %+v", l.name, update)
+	l.rdsUpdates = update.updates
+
+	l.switchMode(l.filterChains, ServingModeServing, nil)
+	l.goodUpdate.Fire()
+}
+
+func (l *listenerWrapper) handleLDSUpdate(update ldsUpdateWithError) {
+	if update.err != nil {
+		l.logger.Warningf("Received error for resource %q: %+v", l.name, update.err)
+		if xdsclient.ErrType(update.err) == xdsclient.ErrorTypeResourceNotFound {
+			l.switchMode(nil, ServingModeNotServing, update.err)
+		}
+		// For errors which are anything other than "resource-not-found", we
+		// continue to use the old configuration.
+		return
+	}
+	l.logger.Infof("Received update for resource %q: %+v", l.name, update.update)
 
 	// Make sure that the socket address on the received Listener resource
 	// matches the address of the net.Listener passed to us by the user. This
@@ -309,14 +389,30 @@ func (l *listenerWrapper) handleListenerUpdate(update xdsclient.ListenerUpdate, 
 	// What this means is that the XDSClient has ACKed a resource which can push
 	// the server into a "not serving" mode. This is not ideal, but this is
 	// what we have decided to do. See gRPC A36 for more details.
-	ilc := update.InboundListenerCfg
+	ilc := update.update.InboundListenerCfg
 	if ilc.Address != l.addr || ilc.Port != l.port {
 		l.switchMode(nil, ServingModeNotServing, fmt.Errorf("address (%s:%s) in Listener update does not match listening address: (%s:%s)", ilc.Address, ilc.Port, l.addr, l.port))
 		return
 	}
 
-	l.switchMode(ilc.FilterChains, ServingModeServing, nil)
-	l.goodUpdate.Fire()
+	// "Updates to a Listener cause all older connections on that Listener to be
+	// gracefully shut down with a grace period of 10 minutes for long-lived
+	// RPC's, such that clients will reconnect and have the updated
+	// configuration apply." - A36 Note that this is not the same as moving the
+	// Server's state to ServingModeNotServing. That prevents new connections
+	// from being accepted, whereas here we simply want the clients to reconnect
+	// to get the updated configuration.
+	if l.drainCallback != nil {
+		l.drainCallback(l.Listener.Addr())
+	}
+	l.rdsHandler.updateRouteNamesToWatch(ilc.FilterChains.RouteConfigNames)
+	// If there are no dynamic RDS Configurations still needed to be received
+	// from the management server, this listener has all the configuration
+	// needed, and is ready to be Served on.
+	if len(ilc.FilterChains.RouteConfigNames) == 0 {
+		l.switchMode(ilc.FilterChains, ServingModeServing, nil)
+		l.goodUpdate.Fire()
+	}
 }
 
 func (l *listenerWrapper) switchMode(fcs *xdsclient.FilterChainManager, newMode ServingMode, err error) {

--- a/xds/internal/server/listener_wrapper_test.go
+++ b/xds/internal/server/listener_wrapper_test.go
@@ -48,6 +48,50 @@ const (
 	defaultTestShortTimeout  = 10 * time.Millisecond
 )
 
+var listenerWithRouteConfiguration = &v3listenerpb.Listener{
+	FilterChains: []*v3listenerpb.FilterChain{
+		{
+			FilterChainMatch: &v3listenerpb.FilterChainMatch{
+				PrefixRanges: []*v3corepb.CidrRange{
+					{
+						AddressPrefix: "192.168.0.0",
+						PrefixLen: &wrapperspb.UInt32Value{
+							Value: uint32(16),
+						},
+					},
+				},
+				SourceType: v3listenerpb.FilterChainMatch_SAME_IP_OR_LOOPBACK,
+				SourcePrefixRanges: []*v3corepb.CidrRange{
+					{
+						AddressPrefix: "192.168.0.0",
+						PrefixLen: &wrapperspb.UInt32Value{
+							Value: uint32(16),
+						},
+					},
+				},
+				SourcePorts: []uint32{80},
+			},
+			Filters: []*v3listenerpb.Filter{
+				{
+					Name: "filter-1",
+					ConfigType: &v3listenerpb.Filter_TypedConfig{
+						TypedConfig: testutils.MarshalAny(&v3httppb.HttpConnectionManager{
+							RouteSpecifier: &v3httppb.HttpConnectionManager_Rds{
+								Rds: &v3httppb.Rds{
+									ConfigSource: &v3corepb.ConfigSource{
+										ConfigSourceSpecifier: &v3corepb.ConfigSource_Ads{Ads: &v3corepb.AggregatedConfigSource{}},
+									},
+									RouteConfigName: "route-1",
+								},
+							},
+						}),
+					},
+				},
+			},
+		},
+	},
+}
+
 var listenerWithFilterChains = &v3listenerpb.Listener{
 	FilterChains: []*v3listenerpb.FilterChain{
 		{
@@ -221,7 +265,7 @@ func (s) TestNewListenerWrapper(t *testing.T) {
 		t.Fatalf("error when waiting for a watch on a Listener resource: %v", err)
 	}
 	if name != testListenerResourceName {
-		t.Fatalf("listenerWrapper registered a watch on %s, want %s", name, testListenerResourceName)
+		t.Fatalf("listenerWrapper registered a lds watch on %s, want %s", name, testListenerResourceName)
 	}
 
 	// Push an error to the listener update handler.
@@ -234,12 +278,18 @@ func (s) TestNewListenerWrapper(t *testing.T) {
 		t.Fatalf("ready channel written to after receipt of a bad Listener update")
 	}
 
+	fcm, err := xdsclient.NewFilterChainManager(listenerWithFilterChains)
+	if err != nil {
+		t.Fatalf("xdsclient.NewFilterChainManager() failed with error: %v", err)
+	}
+
 	// Push an update whose address does not match the address to which our
 	// listener is bound, and verify that the ready channel is not written to.
 	xdsC.InvokeWatchListenerCallback(xdsclient.ListenerUpdate{
 		InboundListenerCfg: &xdsclient.InboundListenerConfig{
-			Address: "10.0.0.1",
-			Port:    "50051",
+			Address:      "10.0.0.1",
+			Port:         "50051",
+			FilterChains: fcm,
 		}}, nil)
 	timer = time.NewTimer(defaultTestShortTimeout)
 	select {
@@ -250,14 +300,85 @@ func (s) TestNewListenerWrapper(t *testing.T) {
 	}
 
 	// Push a good update, and verify that the ready channel is written to.
+	// Since there are no dynamic RDS updates needed to be received, the
+	// ListenerWrapper does not have to wait for anything else before telling
+	// that it is ready.
 	xdsC.InvokeWatchListenerCallback(xdsclient.ListenerUpdate{
 		InboundListenerCfg: &xdsclient.InboundListenerConfig{
-			Address: fakeListenerHost,
-			Port:    strconv.Itoa(fakeListenerPort),
+			Address:      fakeListenerHost,
+			Port:         strconv.Itoa(fakeListenerPort),
+			FilterChains: fcm,
 		}}, nil)
+
 	select {
 	case <-ctx.Done():
 		t.Fatalf("timeout waiting for the ready channel to be written to after receipt of a good Listener update")
+	case <-readyCh:
+	}
+}
+
+// TestNewListenerWrapperWithRouteUpdate tests the scenario where the listener
+// gets built, starts a watch, that watch returns a list of Route Names to
+// return, than receives an update from the rds handler. Only after receiving
+// the update from the rds handler should it move the server to
+// ServingModeServing.
+func (s) TestNewListenerWrapperWithRouteUpdate(t *testing.T) {
+	_, readyCh, xdsC, _, cleanup := newListenerWrapper(t)
+	defer cleanup()
+
+	// Verify that the listener wrapper registers a listener watch for the
+	// expected Listener resource name.
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	_, err := xdsC.WaitForWatchListener(ctx)
+	if err != nil {
+		t.Fatalf("error when waiting for a watch on a Listener resource: %v", err)
+	}
+	fcm, err := xdsclient.NewFilterChainManager(listenerWithRouteConfiguration)
+	if err != nil {
+		t.Fatalf("xdsclient.NewFilterChainManager() failed with error: %v", err)
+	}
+
+	// Push a good update which contains a Filter Chain that specifies dynamic
+	// RDS Resources that need to be received. This should ping rds handler
+	// about which rds names to start, which will eventually start a watch on
+	// xds client for rds name "route-1".
+	xdsC.InvokeWatchListenerCallback(xdsclient.ListenerUpdate{
+		InboundListenerCfg: &xdsclient.InboundListenerConfig{
+			Address:      fakeListenerHost,
+			Port:         strconv.Itoa(fakeListenerPort),
+			FilterChains: fcm,
+		}}, nil)
+
+	// This should start a watch on xds client for rds name "route-1".
+	routeName, err := xdsC.WaitForWatchRouteConfig(ctx)
+	if err != nil {
+		t.Fatalf("error when waiting for a watch on a Route resource: %v", err)
+	}
+	if routeName != "route-1" {
+		t.Fatalf("listenerWrapper registered a lds watch on %s, want %s", routeName, "route-1")
+	}
+
+	// This shouldn't invoke good update channel, as has not received rds updates yet.
+	timer := time.NewTimer(defaultTestShortTimeout)
+	select {
+	case <-timer.C:
+		timer.Stop()
+	case <-readyCh:
+		t.Fatalf("ready channel written to without rds configuration specified")
+	}
+
+	// Invoke rds callback for the started rds watch. This valid rds callback
+	// should trigger the listener wrapper to fire GoodUpdate, as it has
+	// received both it's LDS Configuration and also RDS Configuration,
+	// specified in LDS Configuration.
+	xdsC.InvokeWatchRouteConfigCallback("route-1", xdsclient.RouteConfigUpdate{}, nil)
+
+	// All of the xDS updates have completed, so can expect to send a ping on
+	// good update channel.
+	select {
+	case <-ctx.Done():
+		t.Fatalf("timeout waiting for the ready channel to be written to after receipt of a good rds update")
 	case <-readyCh:
 	}
 }

--- a/xds/internal/server/listener_wrapper_test.go
+++ b/xds/internal/server/listener_wrapper_test.go
@@ -330,9 +330,12 @@ func (s) TestNewListenerWrapperWithRouteUpdate(t *testing.T) {
 	// expected Listener resource name.
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
-	_, err := xdsC.WaitForWatchListener(ctx)
+	name, err := xdsC.WaitForWatchListener(ctx)
 	if err != nil {
 		t.Fatalf("error when waiting for a watch on a Listener resource: %v", err)
+	}
+	if name != testListenerResourceName {
+		t.Fatalf("listenerWrapper registered a lds watch on %s, want %s", name, testListenerResourceName)
 	}
 	fcm, err := xdsclient.NewFilterChainManager(listenerWithRouteConfiguration)
 	if err != nil {

--- a/xds/internal/server/rds_handler.go
+++ b/xds/internal/server/rds_handler.go
@@ -1,0 +1,137 @@
+/*
+ *
+ * Copyright 2021 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package server
+
+import (
+	"sync"
+
+	"google.golang.org/grpc/xds/internal/xdsclient"
+)
+
+// rdsHandlerUpdate wraps the full RouteConfigUpdate that are dynamically queried for a given
+// server side listener.
+type rdsHandlerUpdate struct {
+	updates map[string]xdsclient.RouteConfigUpdate
+	err     error
+}
+
+// rdsHandler handles any RDS queries that need to be started for a given server
+// side listeners Filter Chains (i.e. not inline).
+type rdsHandler struct {
+	parent *listenerWrapper
+
+	mu sync.Mutex
+
+	rdsUpdates map[string]xdsclient.RouteConfigUpdate
+	rdsCancels map[string]func()
+
+	// For a rdsHandler update, the only update wrapped listener cares about is
+	// most recent one, so this channel will be opportunistically drained before
+	// sending any new updates.
+	updateChannel chan rdsHandlerUpdate
+}
+
+// newRDSHandler is expected to called once on instantiation of a wrapped
+// listener. On any LDS updates the wrapped listener receives, the listener
+// should update the handler with the route names (which specify dynamic RDS)
+// using the function below.
+func newRDSHandler(parent *listenerWrapper) *rdsHandler {
+	return &rdsHandler{
+		parent:        parent,
+		updateChannel: make(chan rdsHandlerUpdate, 1),
+		rdsUpdates:    make(map[string]xdsclient.RouteConfigUpdate),
+		rdsCancels:    make(map[string]func()),
+	}
+}
+
+// updateRouteNamesToWatch handles a list of route names to watch for a given
+// server side listener (if a filter chain specifies dynamic RDS configuration).
+// This function handles all the logic with respect to any routes that may have
+// been added or deleted as compared to what was previously present.
+func (rh *rdsHandler) updateRouteNamesToWatch(routeNamesToWatch map[string]bool) {
+	rh.mu.Lock()
+	defer rh.mu.Unlock()
+	// Add and start watches for any routes for any new routes in routeNamesToWatch.
+	for routeName := range routeNamesToWatch {
+		if _, ok := rh.rdsCancels[routeName]; !ok {
+			func(routeName string) {
+				rh.rdsCancels[routeName] = rh.parent.xdsC.WatchRouteConfig(routeName, func(update xdsclient.RouteConfigUpdate, err error) {
+					rh.handleRouteUpdate(routeName, update, err)
+				})
+			}(routeName)
+		}
+	}
+
+	// Delete and cancel watches for any routes from persisted routeNamesToWatch
+	// that are no longer present.
+	for routeName := range rh.rdsCancels {
+		if _, ok := routeNamesToWatch[routeName]; !ok {
+			rh.rdsCancels[routeName]()
+			delete(rh.rdsCancels, routeName)
+			delete(rh.rdsUpdates, routeName)
+		}
+	}
+
+	// If the full list (determined by length) of updates are now successfully
+	// updated, the listener is ready to be updated.
+	if len(rh.rdsUpdates) == len(rh.rdsCancels) && len(routeNamesToWatch) != 0 {
+		select {
+		case <-rh.updateChannel:
+		default:
+		}
+		rh.updateChannel <- rdsHandlerUpdate{updates: rh.rdsUpdates}
+	}
+}
+
+// handleRouteUpdate persists the route config for a given route name, and also
+// sends an update to the Listener Wrapper on an error received or if the rds
+// handler has a full collection of updates.
+func (rh *rdsHandler) handleRouteUpdate(routeName string, update xdsclient.RouteConfigUpdate, err error) {
+	if err != nil {
+		select {
+		case <-rh.updateChannel:
+		default:
+		}
+		rh.updateChannel <- rdsHandlerUpdate{err: err}
+		return
+	}
+	rh.mu.Lock()
+	defer rh.mu.Unlock()
+	rh.rdsUpdates[routeName] = update
+
+	// If the full list (determined by length) of updates have successfully
+	// updated, the listener is ready to be updated.
+	if len(rh.rdsUpdates) == len(rh.rdsCancels) {
+		select {
+		case <-rh.updateChannel:
+		default:
+		}
+		rh.updateChannel <- rdsHandlerUpdate{updates: rh.rdsUpdates}
+	}
+}
+
+// close() is meant to be called by wrapped listener when the wrapped listener is closed,
+// and it cleans up resources by canceling all the active RDS watches.
+func (rh *rdsHandler) close() {
+	rh.mu.Lock()
+	defer rh.mu.Unlock()
+	for _, cancel := range rh.rdsCancels {
+		cancel()
+	}
+}

--- a/xds/internal/server/rds_handler_test.go
+++ b/xds/internal/server/rds_handler_test.go
@@ -1,0 +1,423 @@
+// +build go1.12
+
+/*
+ *
+ * Copyright 2021 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package server
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/grpc/xds/internal/testutils/fakeclient"
+	"google.golang.org/grpc/xds/internal/xdsclient"
+)
+
+var (
+	route1 = "route1"
+	route2 = "route2"
+	route3 = "route3"
+)
+
+// setupTests creates a rds handler with a fake xds client for control over the
+// xds client.
+func setupTests(t *testing.T) (*rdsHandler, *fakeclient.Client) {
+	xdsC := fakeclient.NewClient()
+	rh := newRDSHandler(&listenerWrapper{xdsC: xdsC})
+	return rh, xdsC
+}
+
+// TestSuccessCaseOneRDSWatch tests the simplest scenario: the rds handler
+// receives a single route name, starts a watch for that route name, gets a
+// successful update, and then writes an update to the update channel for
+// listener to pick up.
+func (s) TestSuccessCaseOneRDSWatch(t *testing.T) {
+	rh, fakeClient := setupTests(t)
+	// When you first update the rds handler with a list of a single Route names
+	// that needs dynamic RDS Configuration, this Route name has not been seen
+	// before, so the RDS Handler should start a watch on that RouteName.
+	routeNames := map[string]bool{route1: true}
+	rh.updateRouteNamesToWatch(routeNames)
+	// The RDS Handler should start a watch for that routeName.
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	gotRoute, err := fakeClient.WaitForWatchRouteConfig(ctx)
+	if err != nil {
+		t.Fatalf("xdsClient.WatchRDS failed with error: %v", err)
+	}
+	if gotRoute != route1 {
+		t.Fatalf("xdsClient.WatchRDS called for route: %v, want %v", gotRoute, route1)
+	}
+	rdsUpdate := xdsclient.RouteConfigUpdate{}
+	// Invoke callback with the xds client with a certain route update. Due to
+	// this route update updating every route name that rds handler handles,
+	// this should write to the update channel to send to the listener.
+	fakeClient.InvokeWatchRouteConfigCallback(route1, rdsUpdate, nil)
+	rhuWant := map[string]xdsclient.RouteConfigUpdate{route1: rdsUpdate}
+	select {
+	case rhu := <-rh.updateChannel:
+		if diff := cmp.Diff(rhu.updates, rhuWant); diff != "" {
+			t.Fatalf("got unexpected route update, diff (-got, +want): %v", diff)
+		}
+	case <-ctx.Done():
+		t.Fatal("Timed out waiting for update from update channel.")
+	}
+	// Close the rds handler. This is meant to be called when the lis wrapper is
+	// closed, and the call should cancel all the watches present (for this
+	// test, a single watch).
+	rh.close()
+	routeNameDeleted, err := fakeClient.WaitForCancelRouteConfigWatch(ctx)
+	if err != nil {
+		t.Fatalf("xdsClient.CancelRDS failed with error: %v", err)
+	}
+	if routeNameDeleted != route1 {
+		t.Fatalf("xdsClient.CancelRDS called for route %v, want %v", routeNameDeleted, route1)
+	}
+}
+
+// TestSuccessCaseTwoUpdates tests the case where the rds handler receives an
+// update with a single Route, then receives a second update with two routes.
+// The handler should start a watch for the added route, and if received a RDS
+// update for that route it should send an update with both RDS updates present.
+func (s) TestSuccessCaseTwoUpdates(t *testing.T) {
+	rh, fakeClient := setupTests(t)
+
+	routeNames := map[string]bool{route1: true}
+	rh.updateRouteNamesToWatch(routeNames)
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	_, err := fakeClient.WaitForWatchRouteConfig(ctx)
+	if err != nil {
+		t.Fatalf("xdsClient.WatchRDS failed with error: %v", err)
+	}
+
+	// Update the RDSHandler with route names which adds a route name to watch.
+	// This should trigger the RDSHandler to start a watch for the added route
+	// name to watch.
+	routeNames = map[string]bool{route1: true, route2: true}
+	rh.updateRouteNamesToWatch(routeNames)
+	gotRoute, err := fakeClient.WaitForWatchRouteConfig(ctx)
+	if err != nil {
+		t.Fatalf("xdsClient.WatchRDS failed with error: %v", err)
+	}
+	if gotRoute != route2 {
+		t.Fatalf("xdsClient.WatchRDS called for route: %v, want %v", gotRoute, route2)
+	}
+
+	// Invoke the callback with an update for route 1. This shouldn't cause the
+	// handler to write an update, as it has not received RouteConfigurations
+	// for every RouteName.
+	rdsUpdate1 := xdsclient.RouteConfigUpdate{}
+	fakeClient.InvokeWatchRouteConfigCallback(route1, rdsUpdate1, nil)
+
+	// The RDS Handler should not send an update.
+	shouldNotHappenCtx, shouldNotHappenCtxCancel := context.WithTimeout(context.Background(), defaultTestShortTimeout)
+	defer shouldNotHappenCtxCancel()
+	select {
+	case <-rh.updateChannel:
+		t.Fatal("RDS Handler wrote an update to updateChannel when it shouldn't have, as each route name has not received an update yet")
+	case <-shouldNotHappenCtx.Done():
+	}
+
+	// Invoke the callback with an update for route 2. This should cause the
+	// handler to write an update, as it has received RouteConfigurations for
+	// every RouteName.
+	rdsUpdate2 := xdsclient.RouteConfigUpdate{}
+	fakeClient.InvokeWatchRouteConfigCallback(route2, rdsUpdate2, nil)
+	// The RDS Handler should then update the listener wrapper with an update
+	// with two route configurations, as both route names the RDS Handler handles
+	// have received an update.
+	rhuWant := map[string]xdsclient.RouteConfigUpdate{route1: rdsUpdate1, route2: rdsUpdate2}
+	select {
+	case rhu := <-rh.updateChannel:
+		if diff := cmp.Diff(rhu.updates, rhuWant); diff != "" {
+			t.Fatalf("got unexpected route update, diff (-got, +want): %v", diff)
+		}
+	case <-ctx.Done():
+		t.Fatal("Timed out waiting for the rds handler update to be written to the update buffer.")
+	}
+
+	// Close the rds handler. This is meant to be called when the lis wrapper is
+	// closed, and the call should cancel all the watches present (for this
+	// test, two watches on route1 and route2).
+	rh.close()
+	routeNameDeleted, err := fakeClient.WaitForCancelRouteConfigWatch(ctx)
+	if err != nil {
+		t.Fatalf("xdsClient.CancelRDS failed with error: %v", err)
+	}
+	if routeNameDeleted != route1 && routeNameDeleted != route2 {
+		t.Fatalf("xdsClient.CancelRDS called for route %v, want %v or %v", routeNameDeleted, route1, route2)
+	}
+
+	routeNameDeleted, err = fakeClient.WaitForCancelRouteConfigWatch(ctx)
+	if err != nil {
+		t.Fatalf("xdsClient.CancelRDS failed with error: %v", err)
+	}
+	if routeNameDeleted != route1 && routeNameDeleted != route2 {
+		t.Fatalf("xdsClient.CancelRDS called for route %v, want %v or %v", routeNameDeleted, route1, route2)
+	}
+}
+
+// TestSuccessCaseDeletedRoute tests the case where the rds handler receives an
+// update with two routes, then receives an update with only one route. The RDS
+// Handler is expected to cancel the watch for the route no longer present.
+func (s) TestSuccessCaseDeletedRoute(t *testing.T) {
+	rh, fakeClient := setupTests(t)
+
+	routeNames := map[string]bool{route1: true, route2: true}
+	rh.updateRouteNamesToWatch(routeNames)
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	// Will start two watches.
+	_, err := fakeClient.WaitForWatchRouteConfig(ctx)
+	if err != nil {
+		t.Fatalf("xdsClient.WatchRDS failed with error: %v", err)
+	}
+	_, err = fakeClient.WaitForWatchRouteConfig(ctx)
+	if err != nil {
+		t.Fatalf("xdsClient.WatchRDS failed with error %v", err)
+	}
+
+	// Update the RDSHandler with route names which deletes a route name to
+	// watch. This should trigger the RDSHandler to cancel the watch for the
+	// deleted route name to watch.
+	routeNames = map[string]bool{route1: true}
+	rh.updateRouteNamesToWatch(routeNames)
+	// This should delete the watch for route2.
+	routeNameDeleted, err := fakeClient.WaitForCancelRouteConfigWatch(ctx)
+	if err != nil {
+		t.Fatalf("xdsClient.CancelRDS failed with error %v", err)
+	}
+	if routeNameDeleted != route2 {
+		t.Fatalf("xdsClient.CancelRDS called for route %v, want %v", routeNameDeleted, route2)
+	}
+
+	rdsUpdate := xdsclient.RouteConfigUpdate{}
+	// Invoke callback with the xds client with a certain route update. Due to
+	// this route update updating every route name that rds handler handles,
+	// this should write to the update channel to send to the listener.
+	fakeClient.InvokeWatchRouteConfigCallback(route1, rdsUpdate, nil)
+	rhuWant := map[string]xdsclient.RouteConfigUpdate{route1: rdsUpdate}
+	select {
+	case rhu := <-rh.updateChannel:
+		if diff := cmp.Diff(rhu.updates, rhuWant); diff != "" {
+			t.Fatalf("got unexpected route update, diff (-got, +want): %v", diff)
+		}
+	case <-ctx.Done():
+		t.Fatal("Timed out waiting for update from update channel.")
+	}
+
+	rh.close()
+	_, err = fakeClient.WaitForCancelRouteConfigWatch(ctx)
+	if err != nil {
+		t.Fatalf("xdsClient.CancelRDS failed with error: %v", err)
+	}
+}
+
+// TestSuccessCaseTwoUpdatesAddAndDeleteRoute tests the case where the rds
+// handler receives an update with two routes, and then receives an update with
+// two routes, one previously there and one added (i.e. 12 -> 23). This should
+// cause the route that is no longer there to be deleted and cancelled, and the
+// route that was added should have a watch started for it.
+func (s) TestSuccessCaseTwoUpdatesAddAndDeleteRoute(t *testing.T) {
+	rh, fakeClient := setupTests(t)
+
+	routeNames := map[string]bool{route1: true, route2: true}
+	rh.updateRouteNamesToWatch(routeNames)
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	_, err := fakeClient.WaitForWatchRouteConfig(ctx)
+	if err != nil {
+		t.Fatalf("xdsClient.WatchRDS failed with error: %v", err)
+	}
+	_, err = fakeClient.WaitForWatchRouteConfig(ctx)
+	if err != nil {
+		t.Fatalf("xdsClient.WatchRDS failed with error: %v", err)
+	}
+
+	// Update the rds handler with two routes, one which was already there and a new route.
+	// This should cause the rds handler to delete/cancel watch for route 1 and start a watch
+	// for route 3.
+	routeNames = map[string]bool{route2: true, route3: true}
+	rh.updateRouteNamesToWatch(routeNames)
+
+	// Start watch comes first, which should be for route3 as was just added.
+	gotRoute, err := fakeClient.WaitForWatchRouteConfig(ctx)
+	if err != nil {
+		t.Fatalf("xdsClient.WatchRDS failed with error: %v", err)
+	}
+	if gotRoute != route3 {
+		t.Fatalf("xdsClient.WatchRDS called for route: %v, want %v", gotRoute, route3)
+	}
+
+	// Then route 1 should be deleted/cancelled watch for, as it is no longer present
+	// in the new RouteName to watch map.
+	routeNameDeleted, err := fakeClient.WaitForCancelRouteConfigWatch(ctx)
+	if err != nil {
+		t.Fatalf("xdsClient.CancelRDS failed with error: %v", err)
+	}
+	if routeNameDeleted != route1 {
+		t.Fatalf("xdsClient.CancelRDS called for route %v, want %v", routeNameDeleted, route1)
+	}
+
+	// Invoke the callback with an update for route 2. This shouldn't cause the
+	// handler to write an update, as it has not received RouteConfigurations
+	// for every RouteName.
+	rdsUpdate2 := xdsclient.RouteConfigUpdate{}
+	fakeClient.InvokeWatchRouteConfigCallback(route2, rdsUpdate2, nil)
+
+	// The RDS Handler should not send an update.
+	shouldNotHappenCtx, shouldNotHappenCtxCancel := context.WithTimeout(context.Background(), defaultTestShortTimeout)
+	defer shouldNotHappenCtxCancel()
+	select {
+	case <-rh.updateChannel:
+		t.Fatalf("RDS Handler wrote an update to updateChannel when it shouldn't have, as each route name has not received an update yet")
+	case <-shouldNotHappenCtx.Done():
+	}
+
+	// Invoke the callback with an update for route 3. This should cause the
+	// handler to write an update, as it has received RouteConfigurations for
+	// every RouteName.
+	rdsUpdate3 := xdsclient.RouteConfigUpdate{}
+	fakeClient.InvokeWatchRouteConfigCallback(route3, rdsUpdate3, nil)
+	// The RDS Handler should then update the listener wrapper with an update
+	// with two route configurations, as both route names the RDS Handler handles
+	// have received an update.
+	rhuWant := map[string]xdsclient.RouteConfigUpdate{route2: rdsUpdate2, route3: rdsUpdate3}
+	select {
+	case rhu := <-rh.updateChannel:
+		if diff := cmp.Diff(rhu.updates, rhuWant); diff != "" {
+			t.Fatalf("got unexpected route update, diff (-got, +want): %v", diff)
+		}
+	case <-ctx.Done():
+		t.Fatal("Timed out waiting for the rds handler update to be written to the update buffer.")
+	}
+	// Close the rds handler. This is meant to be called when the lis wrapper is
+	// closed, and the call should cancel all the watches present (for this
+	// test, two watches on route2 and route3).
+	rh.close()
+	routeNameDeleted, err = fakeClient.WaitForCancelRouteConfigWatch(ctx)
+	if err != nil {
+		t.Fatalf("xdsClient.CancelRDS failed with error: %v", err)
+	}
+	if routeNameDeleted != route2 && routeNameDeleted != route3 {
+		t.Fatalf("xdsClient.CancelRDS called for route %v, want %v or %v", routeNameDeleted, route2, route3)
+	}
+
+	routeNameDeleted, err = fakeClient.WaitForCancelRouteConfigWatch(ctx)
+	if err != nil {
+		t.Fatalf("xdsClient.CancelRDS failed with error: %v", err)
+	}
+	if routeNameDeleted != route2 && routeNameDeleted != route3 {
+		t.Fatalf("xdsClient.CancelRDS called for route %v, want %v or %v", routeNameDeleted, route2, route3)
+	}
+}
+
+// TestSuccessCaseSecondUpdateMakesRouteFull tests the scenario where the rds handler gets
+// told to watch three rds configurations, gets two successful updates, then gets told to watch
+// only those two. The rds handler should then write an update to update buffer.
+func (s) TestSuccessCaseSecondUpdateMakesRouteFull(t *testing.T) {
+	rh, fakeClient := setupTests(t)
+
+	routeNames := map[string]bool{route1: true, route2: true, route3: true}
+	rh.updateRouteNamesToWatch(routeNames)
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	_, err := fakeClient.WaitForWatchRouteConfig(ctx)
+	if err != nil {
+		t.Fatalf("xdsClient.WatchRDS failed with error: %v", err)
+	}
+	_, err = fakeClient.WaitForWatchRouteConfig(ctx)
+	if err != nil {
+		t.Fatalf("xdsClient.WatchRDS failed with error: %v", err)
+	}
+	_, err = fakeClient.WaitForWatchRouteConfig(ctx)
+	if err != nil {
+		t.Fatalf("xdsClient.WatchRDS failed with error: %v", err)
+	}
+
+	// Invoke the callbacks for two of the three watches. Since RDS is not full,
+	// this shouldn't trigger rds handler to write an update to update buffer.
+	fakeClient.InvokeWatchRouteConfigCallback(route1, xdsclient.RouteConfigUpdate{}, nil)
+	fakeClient.InvokeWatchRouteConfigCallback(route2, xdsclient.RouteConfigUpdate{}, nil)
+
+	// The RDS Handler should not send an update.
+	shouldNotHappenCtx, shouldNotHappenCtxCancel := context.WithTimeout(context.Background(), defaultTestShortTimeout)
+	defer shouldNotHappenCtxCancel()
+	select {
+	case <-rh.updateChannel:
+		t.Fatalf("RDS Handler wrote an update to updateChannel when it shouldn't have, as each route name has not received an update yet")
+	case <-shouldNotHappenCtx.Done():
+	}
+
+	// Tell the rds handler to now only watch Route 1 and Route 2. This should
+	// trigger the rds handler to write an update to the update buffer as it now
+	// has full rds configuration.
+	routeNames = map[string]bool{route1: true, route2: true}
+	rh.updateRouteNamesToWatch(routeNames)
+	// Route 3 should be deleted/cancelled watch for, as it is no longer present
+	// in the new RouteName to watch map.
+	routeNameDeleted, err := fakeClient.WaitForCancelRouteConfigWatch(ctx)
+	if err != nil {
+		t.Fatalf("xdsClient.CancelRDS failed with error: %v", err)
+	}
+	if routeNameDeleted != route3 {
+		t.Fatalf("xdsClient.CancelRDS called for route %v, want %v", routeNameDeleted, route1)
+	}
+	rhuWant := map[string]xdsclient.RouteConfigUpdate{route1: {}, route2: {}}
+	select {
+	case rhu := <-rh.updateChannel:
+		if diff := cmp.Diff(rhu.updates, rhuWant); diff != "" {
+			t.Fatalf("got unexpected route update, diff (-got, +want): %v", diff)
+		}
+	case <-ctx.Done():
+		t.Fatal("Timed out waiting for the rds handler update to be written to the update buffer.")
+	}
+}
+
+// TestErrorReceived tests the case where the rds handler receives a route name
+// to watch, then receives an update with an error. This error should be then
+// written to the update channel.
+func (s) TestErrorReceived(t *testing.T) {
+	rh, fakeClient := setupTests(t)
+
+	routeNames := map[string]bool{route1: true}
+	rh.updateRouteNamesToWatch(routeNames)
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	_, err := fakeClient.WaitForWatchRouteConfig(ctx)
+	if err != nil {
+		t.Fatalf("xdsClient.WatchRDS failed with error %v", err)
+	}
+
+	rdsErr := errors.New("some error")
+	fakeClient.InvokeWatchRouteConfigCallback(route1, xdsclient.RouteConfigUpdate{}, rdsErr)
+	select {
+	case rhu := <-rh.updateChannel:
+		if rhu.err.Error() != "some error" {
+			t.Fatalf("Did not receive the expected error, instead received: %v", rhu.err.Error())
+		}
+	case <-ctx.Done():
+		t.Fatal("Timed out waiting for update from update channel")
+	}
+}

--- a/xds/internal/xdsclient/client.go
+++ b/xds/internal/xdsclient/client.go
@@ -250,8 +250,10 @@ type InboundListenerConfig struct {
 // RouteConfigUpdate contains information received in an RDS response, which is
 // of interest to the registered RDS watcher.
 type RouteConfigUpdate struct {
+	// Name is the RDS resource name for this response, which is specified in
+	// LDS Response (RouteConfigName).
+	RouteName    string
 	VirtualHosts []*VirtualHost
-
 	// Raw is the resource from the xds response.
 	Raw *anypb.Any
 }

--- a/xds/internal/xdsclient/client.go
+++ b/xds/internal/xdsclient/client.go
@@ -250,9 +250,6 @@ type InboundListenerConfig struct {
 // RouteConfigUpdate contains information received in an RDS response, which is
 // of interest to the registered RDS watcher.
 type RouteConfigUpdate struct {
-	// Name is the RDS resource name for this response, which is specified in
-	// LDS Response (RouteConfigName).
-	RouteName    string
 	VirtualHosts []*VirtualHost
 	// Raw is the resource from the xds response.
 	Raw *anypb.Any

--- a/xds/internal/xdsclient/filter_chain.go
+++ b/xds/internal/xdsclient/filter_chain.go
@@ -28,6 +28,8 @@ import (
 	v3tlspb "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
+	"google.golang.org/grpc/xds/internal/httpfilter"
+	"google.golang.org/grpc/internal/resolver"
 	"google.golang.org/grpc/xds/internal/version"
 )
 
@@ -65,6 +67,92 @@ type FilterChain struct {
 	//
 	// Only one of RouteConfigName and InlineRouteConfig is set.
 	InlineRouteConfig *RouteConfigUpdate
+
+	// InstantiatedFilters represents whether the xds client data has been
+	// converted to something usable for routing. Since this usable data will be
+	// used for any accepted connections that match to this filter chain, it is
+	// best to persist here.
+	InstantiatedFilters bool // Any mutexes?
+	// VirtualHosts are the virtual hosts ready to be used in the xds interceptors.
+	// It contains a way to match routes using a matcher and also instantiates
+	// HTTPFilter overrides to simply run incoming RPC's through if they are selected.
+	VirtualHosts []VirtualHostWithInterceptors
+}
+
+// VirtualHostWithInteceptors captures information present in a VirtualHost
+// update, and also contains routes with instantiated HTTP Filters.
+type VirtualHostWithInterceptors struct {
+	// Domains are the domain names which map to this Virtual Host. On the
+	// server side, this will be dictated by the :authority header of the
+	// incoming RPC.
+	Domains []string
+	// Routes are the Routes for this Virtual Host.
+	Routes []RouteWithInterceptors
+}
+
+// RouteWithInterceptors captures information in a Route, and contains
+// a usable matcher and also instantiated HTTP Filters.
+type RouteWithInterceptors struct {
+	// M is the matcher used to match to this route.
+	M *CompositeMatcher
+	// Interceptors are interceptors instantiated for this route. These will be
+	// constructed from a combination of the top level configuration and any
+	// HTTP Filter overrides present in Virtual Host or Route.
+	Interceptors []resolver.ServerInterceptor
+}
+
+func (f *FilterChain) ConstructUsableRouteConfiguration(config RouteConfigUpdate) error {
+	if f.InstantiatedFilters {
+		return nil
+	}
+	f.InstantiatedFilters = true
+
+	vhs := make([]VirtualHostWithInterceptors, len(config.VirtualHosts))
+	for _, vh := range config.VirtualHosts {
+		vhwi, err := f.convertVirtualHost(vh)
+		if err != nil {
+			return fmt.Errorf("error constructing virtual host: %v", err)
+		}
+		vhs = append(vhs, vhwi)
+	}
+	f.VirtualHosts = vhs
+	return nil
+}
+
+func (f *FilterChain) convertVirtualHost(virtualHost *VirtualHost) (VirtualHostWithInterceptors, error) {
+	var vh VirtualHostWithInterceptors
+	vh.Domains = virtualHost.Domains
+	rs := make([]RouteWithInterceptors, len(virtualHost.Routes))
+	var err error
+	for i, r := range virtualHost.Routes {
+		rs[i].M, err = RouteToMatcher(r)
+		if err != nil {
+			return VirtualHostWithInterceptors{}, fmt.Errorf("error constructing matcher: %v", err)
+		}
+		for _, filter := range f.HTTPFilters {
+			// Route is highest priority on Server Side, as there is no concept
+			// of an upstream cluster on server side.
+			override := r.HTTPFilterConfigOverride[filter.Name]
+			if override == nil {
+				// Virtual Host is second priority.
+				override = virtualHost.HTTPFilterConfigOverride[filter.Name]
+			}
+			sb, ok := filter.Filter.(httpfilter.ServerInterceptorBuilder)
+			if !ok {
+				// Should not happen if it passed xdsClient validation.
+				return VirtualHostWithInterceptors{}, fmt.Errorf("filter does not support use in server")
+			}
+			si, err := sb.BuildServerInterceptor(filter.Config, override)
+			if err != nil {
+				return VirtualHostWithInterceptors{}, fmt.Errorf("error constructing filter: %v", err)
+			}
+			if si != nil {
+				rs[i].Interceptors = append(rs[i].Interceptors, si)
+			}
+		}
+	}
+	vh.Routes = rs
+	return vh, nil
 }
 
 // SourceType specifies the connection source IP match type.

--- a/xds/internal/xdsclient/filter_chain.go
+++ b/xds/internal/xdsclient/filter_chain.go
@@ -217,6 +217,7 @@ func NewFilterChainManager(lis *v3listenerpb.Listener) (*FilterChainManager, err
 	if !fcSeen && fci.def == nil {
 		return nil, fmt.Errorf("no supported filter chains and no default filter chain")
 	}
+
 	return fci, nil
 }
 

--- a/xds/internal/xdsclient/filter_chain.go
+++ b/xds/internal/xdsclient/filter_chain.go
@@ -217,7 +217,6 @@ func NewFilterChainManager(lis *v3listenerpb.Listener) (*FilterChainManager, err
 	if !fcSeen && fci.def == nil {
 		return nil, fmt.Errorf("no supported filter chains and no default filter chain")
 	}
-
 	return fci, nil
 }
 

--- a/xds/internal/xdsclient/filter_chain_test.go
+++ b/xds/internal/xdsclient/filter_chain_test.go
@@ -21,6 +21,8 @@
 package xdsclient
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"net"
 	"strings"
@@ -37,7 +39,9 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
+	iresolver "google.golang.org/grpc/internal/resolver"
 	"google.golang.org/grpc/internal/testutils"
+	"google.golang.org/grpc/xds/internal/httpfilter"
 	"google.golang.org/grpc/xds/internal/version"
 )
 
@@ -2294,6 +2298,203 @@ func TestLookup_Successes(t *testing.T) {
 			}
 			if !cmp.Equal(gotFC, test.wantFC, cmpopts.EquateEmpty()) {
 				t.Fatalf("FilterChainManager.Lookup(%v) = %v, want %v", test.params, gotFC, test.wantFC)
+			}
+		})
+	}
+}
+
+type filterCfg struct {
+	httpfilter.FilterConfig
+	// Level is what differentiates top level filters ("top-level") vs. second
+	// level ("virtual-host-level"), and third level ("route-level").
+	level string
+}
+
+type filterBuilder struct {
+	httpfilter.Filter
+
+}
+
+var _ httpfilter.ServerInterceptorBuilder = &filterBuilder{}
+
+func (fb *filterBuilder) BuildServerInterceptor(config httpfilter.FilterConfig, override httpfilter.FilterConfig) (iresolver.ServerInterceptor, error) {
+	var level string
+	level = config.(filterCfg).level
+
+	if override != nil {
+		level = override.(filterCfg).level
+	}
+	return &serverInterceptor{level: level}, nil
+}
+
+type serverInterceptor struct {
+	level string
+}
+
+func (si *serverInterceptor) AllowedToProceed(_ context.Context) error {
+	return errors.New(si.level)
+}
+
+func TestHTTPFilterInstantiation(t *testing.T) {
+	tests := []struct {
+		name string
+		filters []HTTPFilter
+		routeConfig RouteConfigUpdate
+		// A list of strings which will be built from iterating through the
+		// filters ["top-level", "vh-level", "route-level", "route-level"...]
+		// wantListOfErrors is the list of error strings that will be
+		// constructed from the deterministic iteration through the vh list and
+		// route list. The error string will be determined by the level of
+		// config that the filter builder receives (i.e. top level, vs. virtual
+		// host level vs. route level).
+		wantListOfErrors []string
+	}{
+		{
+			name: "one http filter no overrides",
+			filters: []HTTPFilter{
+				{Name: "server-interceptor", Filter: &filterBuilder{}, Config: filterCfg{level: "top-level"}},
+			},
+			routeConfig: RouteConfigUpdate{
+				VirtualHosts: []*VirtualHost{
+					{
+						Domains: []string{"target"},
+						Routes: []*Route{{
+							Prefix: newStringP("1"),
+						},
+						},
+					},
+				}},
+			wantListOfErrors: []string{"top-level"},
+		},
+		{
+			name: "one http filter vh override",
+			filters: []HTTPFilter{
+				{Name: "server-interceptor", Filter: &filterBuilder{}, Config: filterCfg{level: "top-level"}},
+			},
+			routeConfig: RouteConfigUpdate{
+				VirtualHosts: []*VirtualHost{
+					{
+						Domains: []string{"target"},
+						Routes: []*Route{{
+							Prefix: newStringP("1"),
+						},
+						},
+						HTTPFilterConfigOverride: map[string]httpfilter.FilterConfig{
+							"server-interceptor": filterCfg{level: "virtual-host-level"},
+						},
+					},
+				}},
+			wantListOfErrors: []string{"virtual-host-level"},
+		},
+		{
+			name: "one http filter route override",
+			filters: []HTTPFilter{
+				{Name: "server-interceptor", Filter: &filterBuilder{}, Config: filterCfg{level: "top-level"}},
+			},
+			routeConfig: RouteConfigUpdate{
+				VirtualHosts: []*VirtualHost{
+					{
+						Domains: []string{"target"},
+						Routes: []*Route{{
+							Prefix: newStringP("1"),
+							HTTPFilterConfigOverride: map[string]httpfilter.FilterConfig{
+								"server-interceptor": filterCfg{level: "route-level"},
+							},
+						},
+						},
+					},
+				}},
+			wantListOfErrors: []string{"route-level"},
+		},
+		// This tests the scenario where there are three http filters, and one
+		// gets overriden by route and one by virtual host.
+		{
+			name: "three http filters vh override route override",
+			filters: []HTTPFilter{
+				{Name: "server-interceptor1", Filter: &filterBuilder{}, Config: filterCfg{level: "top-level"}},
+				{Name: "server-interceptor2", Filter: &filterBuilder{}, Config: filterCfg{level: "top-level"}},
+				{Name: "server-interceptor3", Filter: &filterBuilder{}, Config: filterCfg{level: "top-level"}},
+			},
+			routeConfig: RouteConfigUpdate{
+				VirtualHosts: []*VirtualHost{
+					{
+						Domains: []string{"target"},
+						Routes: []*Route{{
+							Prefix: newStringP("1"),
+							HTTPFilterConfigOverride: map[string]httpfilter.FilterConfig{
+								"server-interceptor3": filterCfg{level: "route-level"},
+							},
+						},
+						},
+						HTTPFilterConfigOverride: map[string]httpfilter.FilterConfig{
+							"server-interceptor2": filterCfg{level: "virtual-host-level"},
+						},
+					},
+				}},
+			wantListOfErrors: []string{"top-level", "virtual-host-level", "route-level"},
+		},
+		// This tests the scenario where there are three http filters, and two
+		// virtual hosts with different vh + route overrides for each virtual
+		// host.
+		{
+			name: "three http filters two vh",
+			filters: []HTTPFilter{
+				{Name: "server-interceptor1", Filter: &filterBuilder{}, Config: filterCfg{level: "top-level"}},
+				{Name: "server-interceptor2", Filter: &filterBuilder{}, Config: filterCfg{level: "top-level"}},
+				{Name: "server-interceptor3", Filter: &filterBuilder{}, Config: filterCfg{level: "top-level"}},
+			},
+			routeConfig: RouteConfigUpdate{
+				VirtualHosts: []*VirtualHost{
+					{
+						Domains: []string{"target"},
+						Routes: []*Route{{
+							Prefix: newStringP("1"),
+							HTTPFilterConfigOverride: map[string]httpfilter.FilterConfig{
+								"server-interceptor3": filterCfg{level: "route-level"},
+							},
+						},
+						},
+						HTTPFilterConfigOverride: map[string]httpfilter.FilterConfig{
+							"server-interceptor2": filterCfg{level: "virtual-host-level"},
+						},
+					},
+					{
+						Domains: []string{"target"},
+						Routes: []*Route{{
+							Prefix: newStringP("1"),
+							HTTPFilterConfigOverride: map[string]httpfilter.FilterConfig{
+								"server-interceptor1": filterCfg{level: "route-level"},
+								"server-interceptor2": filterCfg{level: "route-level"},
+							},
+						},
+						},
+						HTTPFilterConfigOverride: map[string]httpfilter.FilterConfig{
+							"server-interceptor2": filterCfg{level: "virtual-host-level"},
+							"server-interceptor3": filterCfg{level: "virtual-host-level"},
+						},
+					},
+				}},
+			wantListOfErrors: []string{"top-level", "virtual-host-level", "route-level", "route-level", "route-level", "virtual-host-level"},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fc := FilterChain{
+				HTTPFilters: test.filters,
+			}
+			fc.ConstructUsableRouteConfiguration(test.routeConfig)
+			// Build out list of errors by iterating through the virtual hosts and routes,
+			// and running the filters in route configurations.
+			var listOfErrors []string
+			for _, vh := range fc.VirtualHosts {
+				for _, r := range vh.Routes {
+					for _, int := range r.Interceptors {
+						listOfErrors = append(listOfErrors, int.AllowedToProceed(context.Background()).Error())
+					}
+				}
+			}
+			if !cmp.Equal(listOfErrors, test.wantListOfErrors) {
+				t.Fatalf("List of errors %v, want %v", listOfErrors, test.wantListOfErrors)
 			}
 		})
 	}

--- a/xds/internal/xdsclient/matcher.go
+++ b/xds/internal/xdsclient/matcher.go
@@ -16,7 +16,7 @@
  *
  */
 
-package resolver
+package xdsclient
 
 import (
 	"fmt"
@@ -27,10 +27,9 @@ import (
 	iresolver "google.golang.org/grpc/internal/resolver"
 	"google.golang.org/grpc/internal/xds/matcher"
 	"google.golang.org/grpc/metadata"
-	"google.golang.org/grpc/xds/internal/xdsclient"
 )
 
-func routeToMatcher(r *xdsclient.Route) (*compositeMatcher, error) {
+func RouteToMatcher(r *Route) (*CompositeMatcher, error) {
 	var pm pathMatcher
 	switch {
 	case r.Regex != nil:
@@ -75,18 +74,18 @@ func routeToMatcher(r *xdsclient.Route) (*compositeMatcher, error) {
 	return newCompositeMatcher(pm, headerMatchers, fractionMatcher), nil
 }
 
-// compositeMatcher.match returns true if all matchers return true.
-type compositeMatcher struct {
+// CompositeMatcher.match returns true if all matchers return true.
+type CompositeMatcher struct {
 	pm  pathMatcher
 	hms []matcher.HeaderMatcher
 	fm  *fractionMatcher
 }
 
-func newCompositeMatcher(pm pathMatcher, hms []matcher.HeaderMatcher, fm *fractionMatcher) *compositeMatcher {
-	return &compositeMatcher{pm: pm, hms: hms, fm: fm}
+func newCompositeMatcher(pm pathMatcher, hms []matcher.HeaderMatcher, fm *fractionMatcher) *CompositeMatcher {
+	return &CompositeMatcher{pm: pm, hms: hms, fm: fm}
 }
 
-func (a *compositeMatcher) match(info iresolver.RPCInfo) bool {
+func (a *CompositeMatcher) Match(info iresolver.RPCInfo) bool {
 	if a.pm != nil && !a.pm.match(info.Method) {
 		return false
 	}
@@ -119,7 +118,7 @@ func (a *compositeMatcher) match(info iresolver.RPCInfo) bool {
 	return true
 }
 
-func (a *compositeMatcher) String() string {
+func (a *CompositeMatcher) String() string {
 	var ret string
 	if a.pm != nil {
 		ret += a.pm.String()
@@ -141,10 +140,10 @@ func newFractionMatcher(fraction uint32) *fractionMatcher {
 	return &fractionMatcher{fraction: int64(fraction)}
 }
 
-var grpcrandInt63n = grpcrand.Int63n
+var GrpcrandInt63n = grpcrand.Int63n
 
 func (fm *fractionMatcher) match() bool {
-	t := grpcrandInt63n(1000000)
+	t := GrpcrandInt63n(1000000)
 	return t <= fm.fraction
 }
 

--- a/xds/internal/xdsclient/matcher_path.go
+++ b/xds/internal/xdsclient/matcher_path.go
@@ -16,7 +16,7 @@
  *
  */
 
-package resolver
+package xdsclient
 
 import (
 	"regexp"

--- a/xds/internal/xdsclient/matcher_path_test.go
+++ b/xds/internal/xdsclient/matcher_path_test.go
@@ -18,7 +18,7 @@
  *
  */
 
-package resolver
+package xdsclient
 
 import (
 	"regexp"

--- a/xds/internal/xdsclient/matcher_test.go
+++ b/xds/internal/xdsclient/matcher_test.go
@@ -18,7 +18,7 @@
  *
  */
 
-package resolver
+package xdsclient
 
 import (
 	"context"
@@ -109,7 +109,7 @@ func TestAndMatcherMatch(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			a := newCompositeMatcher(tt.pm, []matcher.HeaderMatcher{tt.hm}, nil)
-			if got := a.match(tt.info); got != tt.want {
+			if got := a.Match(tt.info); got != tt.want {
 				t.Errorf("match() = %v, want %v", got, tt.want)
 			}
 		})
@@ -120,11 +120,11 @@ func TestFractionMatcherMatch(t *testing.T) {
 	const fraction = 500000
 	fm := newFractionMatcher(fraction)
 	defer func() {
-		grpcrandInt63n = grpcrand.Int63n
+		GrpcrandInt63n = grpcrand.Int63n
 	}()
 
 	// rand > fraction, should return false.
-	grpcrandInt63n = func(n int64) int64 {
+	GrpcrandInt63n = func(n int64) int64 {
 		return fraction + 1
 	}
 	if matched := fm.match(); matched {
@@ -132,7 +132,7 @@ func TestFractionMatcherMatch(t *testing.T) {
 	}
 
 	// rand == fraction, should return true.
-	grpcrandInt63n = func(n int64) int64 {
+	GrpcrandInt63n = func(n int64) int64 {
 		return fraction
 	}
 	if matched := fm.match(); !matched {
@@ -140,7 +140,7 @@ func TestFractionMatcherMatch(t *testing.T) {
 	}
 
 	// rand < fraction, should return true.
-	grpcrandInt63n = func(n int64) int64 {
+	GrpcrandInt63n = func(n int64) int64 {
 		return fraction - 1
 	}
 	if matched := fm.match(); !matched {

--- a/xds/server.go
+++ b/xds/server.go
@@ -233,6 +233,11 @@ func (s *GRPCServer) Serve(lis net.Listener) error {
 				err:  err,
 			})
 		},
+		DrainCallback: func(addr net.Addr) {
+			if gs, ok := s.gs.(*grpc.Server); ok {
+				drainServerTransports(gs, addr.String())
+			}
+		},
 	})
 
 	// Block until a good LDS response is received or the server is stopped.

--- a/xds/server_test.go
+++ b/xds/server_test.go
@@ -35,6 +35,7 @@ import (
 	v3routepb "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	v3httppb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	v3tlspb "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
+	wrapperspb "github.com/golang/protobuf/ptypes/wrappers"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/credentials/tls/certprovider"
@@ -52,6 +53,67 @@ const (
 	defaultTestShortTimeout                = 10 * time.Millisecond
 	testServerListenerResourceNameTemplate = "/path/to/resource/%s/%s"
 )
+
+var listenerWithFilterChains = &v3listenerpb.Listener{
+	FilterChains: []*v3listenerpb.FilterChain{
+		{
+			FilterChainMatch: &v3listenerpb.FilterChainMatch{
+				PrefixRanges: []*v3corepb.CidrRange{
+					{
+						AddressPrefix: "192.168.0.0",
+						PrefixLen: &wrapperspb.UInt32Value{
+							Value: uint32(16),
+						},
+					},
+				},
+				SourceType: v3listenerpb.FilterChainMatch_SAME_IP_OR_LOOPBACK,
+				SourcePrefixRanges: []*v3corepb.CidrRange{
+					{
+						AddressPrefix: "192.168.0.0",
+						PrefixLen: &wrapperspb.UInt32Value{
+							Value: uint32(16),
+						},
+					},
+				},
+				SourcePorts: []uint32{80},
+			},
+			TransportSocket: &v3corepb.TransportSocket{
+				Name: "envoy.transport_sockets.tls",
+				ConfigType: &v3corepb.TransportSocket_TypedConfig{
+					TypedConfig: testutils.MarshalAny(&v3tlspb.DownstreamTlsContext{
+						CommonTlsContext: &v3tlspb.CommonTlsContext{
+							TlsCertificateCertificateProviderInstance: &v3tlspb.CommonTlsContext_CertificateProviderInstance{
+								InstanceName:    "identityPluginInstance",
+								CertificateName: "identityCertName",
+							},
+						},
+					}),
+				},
+			},
+			Filters: []*v3listenerpb.Filter{
+				{
+					Name: "filter-1",
+					ConfigType: &v3listenerpb.Filter_TypedConfig{
+						TypedConfig: testutils.MarshalAny(&v3httppb.HttpConnectionManager{
+							RouteSpecifier: &v3httppb.HttpConnectionManager_RouteConfig{
+								RouteConfig: &v3routepb.RouteConfiguration{
+									Name: "routeName",
+									VirtualHosts: []*v3routepb.VirtualHost{{
+										Domains: []string{"lds.target.good:3333"},
+										Routes: []*v3routepb.Route{{
+											Match: &v3routepb.RouteMatch{
+												PathSpecifier: &v3routepb.RouteMatch_Prefix{Prefix: "/"},
+											},
+											Action: &v3routepb.Route_NonForwardingAction{},
+										}}}}},
+							},
+						}),
+					},
+				},
+			},
+		},
+	},
+}
 
 type s struct {
 	grpctest.Tester
@@ -73,9 +135,10 @@ func (f *fakeGRPCServer) RegisterService(*grpc.ServiceDesc, interface{}) {
 	f.registerServiceCh.Send(nil)
 }
 
-func (f *fakeGRPCServer) Serve(net.Listener) error {
+func (f *fakeGRPCServer) Serve(lis net.Listener) error {
 	f.serveCh.Send(nil)
 	<-f.done
+	lis.Close()
 	return nil
 }
 
@@ -377,12 +440,17 @@ func (s) TestServeSuccess(t *testing.T) {
 
 	// Push a good LDS response, and wait for Serve() to be invoked on the
 	// underlying grpc.Server.
+	fcm, err := xdsclient.NewFilterChainManager(listenerWithFilterChains)
+	if err != nil {
+		t.Fatalf("xdsclient.NewFilterChainManager() failed with error: %v", err)
+	}
 	addr, port := splitHostPort(lis.Addr().String())
 	client.InvokeWatchListenerCallback(xdsclient.ListenerUpdate{
 		RouteConfigName: "routeconfig",
 		InboundListenerCfg: &xdsclient.InboundListenerConfig{
-			Address: addr,
-			Port:    port,
+			Address:      addr,
+			Port:         port,
+			FilterChains: fcm,
 		},
 	}, nil)
 	if _, err := fs.serveCh.Receive(ctx); err != nil {
@@ -404,8 +472,9 @@ func (s) TestServeSuccess(t *testing.T) {
 	client.InvokeWatchListenerCallback(xdsclient.ListenerUpdate{
 		RouteConfigName: "routeconfig",
 		InboundListenerCfg: &xdsclient.InboundListenerConfig{
-			Address: "10.20.30.40",
-			Port:    "666",
+			Address:      "10.20.30.40",
+			Port:         "666",
+			FilterChains: fcm,
 		},
 	}, nil)
 	sCtx, sCancel = context.WithTimeout(context.Background(), defaultTestShortTimeout)


### PR DESCRIPTION
This PR instantiates HTTP Filters on server side and converts route to something usable, which get put into wrapped conn which eventually will make its way to xds(Unary|Stream)Interceptors for routing.

RELEASE_NOTES: None