### PR TITLE
balancer: add ExitIdle optional interface

### DIFF
--- a/balancer/balancer.go
+++ b/balancer/balancer.go
@@ -326,6 +326,15 @@ type Balancer interface {
 	Close()
 }
 
+// ExitIdle is an optional interface for balancers to implement.  If
+// implemented, ExitIdle will be called when ClientConn.Connect is called, if
+// the ClientConn is idle.
+type ExitIdle interface {
+	// ExitIdle instructs the LB policy to reconnect to backends / exit the
+	// IDLE state, if appropriate and possible.
+	ExitIdle()
+}
+
 // SubConnState describes the state of a SubConn.
 type SubConnState struct {
 	// ConnectivityState is the connectivity state of the SubConn.

--- a/balancer/balancer.go
+++ b/balancer/balancer.go
@@ -75,24 +75,29 @@ func Get(name string) Builder {
 	return nil
 }
 
-// SubConn represents a gRPC sub connection.
-// Each sub connection contains a list of addresses. gRPC will
-// try to connect to them (in sequence), and stop trying the
-// remainder once one connection is successful.
+// A SubConn represents a single connection to a gRPC backend service.
+//
+// Each SubConn contains a list of addresses.
+//
+// All SubConns start in IDLE, and will not try to connect. To trigger the
+// connecting, Balancers must call Connect.
+//
+// gRPC will try to connect to the addresses in sequence, and stop trying the
+// remainder once the first connection is successful. If an attempt to connect
+// to all addresses encounters an error, the SubConn will automatically attempt
+// to reconnect after an increasing backoff period.
 //
 // The reconnect backoff will be applied on the list, not a single address.
 // For example, try_on_all_addresses -> backoff -> try_on_all_addresses.
 //
-// All SubConns start in IDLE, and will not try to connect. To trigger
-// the connecting, Balancers must call Connect.
-// When the connection encounters an error, it will reconnect immediately.
-// When the connection becomes IDLE, it will not reconnect unless Connect is
-// called.
+// Once established, if a connection is lost, the SubConn will transition to
+// IDLE. When the connection becomes IDLE, it will not reconnect unless Connect
+// is called.
 //
-// This interface is to be implemented by gRPC. Users should not need a
-// brand new implementation of this interface. For the situations like
-// testing, the new implementation should embed this interface. This allows
-// gRPC to add new methods to this interface.
+// This interface is to be implemented by gRPC. Users should not need their own
+// implementation of this interface. For situations like testing, any
+// implementations should embed this interface. This allows gRPC to add new
+// methods to this interface.
 type SubConn interface {
 	// UpdateAddresses updates the addresses used in this SubConn.
 	// gRPC checks if currently-connected address is still in the new list.
@@ -328,10 +333,15 @@ type Balancer interface {
 
 // ExitIdle is an optional interface for balancers to implement.  If
 // implemented, ExitIdle will be called when ClientConn.Connect is called, if
-// the ClientConn is idle.
+// the ClientConn is idle.  If unimplemented, ClientConn.Connect will cause
+// all SubConns to connect.
+//
+// Notice: it will be required for all balancers to implement this in a future
+// release.
 type ExitIdle interface {
 	// ExitIdle instructs the LB policy to reconnect to backends / exit the
-	// IDLE state, if appropriate and possible.
+	// IDLE state, if appropriate and possible.  Note that SubConns that enter
+	// the IDLE state will not reconnect until SubConn.Connect is called.
 	ExitIdle()
 }
 

--- a/balancer/base/balancer.go
+++ b/balancer/base/balancer.go
@@ -251,6 +251,11 @@ func (b *baseBalancer) UpdateSubConnState(sc balancer.SubConn, state balancer.Su
 func (b *baseBalancer) Close() {
 }
 
+// ExitIdle is a nop because the base balancer attempts to stay connected to
+// all SubConns at all times.
+func (b *baseBalancer) ExitIdle() {
+}
+
 // NewErrPicker returns a Picker that always returns err on Pick().
 func NewErrPicker(err error) balancer.Picker {
 	return &errPicker{err: err}

--- a/balancer/grpclb/grpclb.go
+++ b/balancer/grpclb/grpclb.go
@@ -488,3 +488,5 @@ func (lb *lbBalancer) Close() {
 	}
 	lb.cc.close()
 }
+
+func (lb *lbBalancer) ExitIdle() {}

--- a/balancer/rls/internal/balancer.go
+++ b/balancer/rls/internal/balancer.go
@@ -129,6 +129,10 @@ func (lb *rlsBalancer) Close() {
 	}
 }
 
+func (lb *rlsBalancer) ExitIdle() {
+	// TODO: are we 100% sure this should be a nop?
+}
+
 // updateControlChannel updates the RLS client if required.
 // Caller must hold lb.mu.
 func (lb *rlsBalancer) updateControlChannel(newCfg *lbConfig) {

--- a/balancer_conn_wrappers.go
+++ b/balancer_conn_wrappers.go
@@ -138,6 +138,10 @@ func (ccb *ccBalancerWrapper) close() {
 	<-ccb.done.Done()
 }
 
+func (ccb *ccBalancerWrapper) exitIdle() {
+	cc.balancerWrapper.updateCh.Put(exitIdle{})
+}
+
 func (ccb *ccBalancerWrapper) handleSubConnStateChange(sc balancer.SubConn, s connectivity.State, err error) {
 	// When updating addresses for a SubConn, if the address in use is not in
 	// the new addresses, the old ac will be tearDown() and a new ac will be

--- a/balancer_conn_wrappers.go
+++ b/balancer_conn_wrappers.go
@@ -66,7 +66,7 @@ func newCCBalancerWrapper(cc *ClientConn, b balancer.Builder, bopts balancer.Bui
 	}
 	go ccb.watcher()
 	ccb.balancer = b.Build(ccb, bopts)
-	_, ccb.hasExitIdle = ccb.balancer.(balancer.ExitIdle)
+	_, ccb.hasExitIdle = ccb.balancer.(balancer.ExitIdler)
 	return ccb
 }
 
@@ -94,7 +94,7 @@ func (ccb *ccBalancerWrapper) watcher() {
 				ccb.mu.Unlock()
 			case exitIdle:
 				if ccb.cc.GetState() == connectivity.Idle {
-					if ei, ok := ccb.balancer.(balancer.ExitIdle); ok {
+					if ei, ok := ccb.balancer.(balancer.ExitIdler); ok {
 						// We already checked that the balancer implements
 						// ExitIdle before pushing the event to updateCh, but
 						// check conditionally again as defensive programming.

--- a/balancer_conn_wrappers.go
+++ b/balancer_conn_wrappers.go
@@ -139,7 +139,7 @@ func (ccb *ccBalancerWrapper) close() {
 }
 
 func (ccb *ccBalancerWrapper) exitIdle() {
-	cc.balancerWrapper.updateCh.Put(exitIdle{})
+	ccb.updateCh.Put(exitIdle{})
 }
 
 func (ccb *ccBalancerWrapper) handleSubConnStateChange(sc balancer.SubConn, s connectivity.State, err error) {

--- a/balancer_switching_test.go
+++ b/balancer_switching_test.go
@@ -58,6 +58,8 @@ func (b *magicalLB) UpdateClientConnState(balancer.ClientConnState) error {
 
 func (b *magicalLB) Close() {}
 
+func (b *magicalLB) ExitIdle() {}
+
 func init() {
 	balancer.Register(&magicalLB{})
 }

--- a/clientconn.go
+++ b/clientconn.go
@@ -557,8 +557,11 @@ func (cc *ClientConn) GetState() connectivity.State {
 func (cc *ClientConn) Connect() {
 	cc.mu.Lock()
 	defer cc.mu.Unlock()
-	if cc.balancerWrapper != nil {
-		cc.balancerWrapper.exitIdle()
+	if cc.balancerWrapper != nil && cc.balancerWrapper.exitIdle() {
+		return
+	}
+	for ac := range cc.conns {
+		go ac.connect()
 	}
 }
 

--- a/clientconn.go
+++ b/clientconn.go
@@ -556,10 +556,10 @@ func (cc *ClientConn) GetState() connectivity.State {
 // release.
 func (cc *ClientConn) Connect() {
 	cc.mu.Lock()
+	defer cc.mu.Unlock()
 	if cc.balancerWrapper != nil {
-		cc.balancerWrapper.updateCh.Put(exitIdle{})
+		cc.balancerWrapper.exitIdle()
 	}
-	cc.mu.Unlock()
 }
 
 func (cc *ClientConn) scWatcher() {

--- a/clientconn.go
+++ b/clientconn.go
@@ -555,14 +555,11 @@ func (cc *ClientConn) GetState() connectivity.State {
 // Notice: This API is EXPERIMENTAL and may be changed or removed in a later
 // release.
 func (cc *ClientConn) Connect() {
-	if cc.GetState() == connectivity.Idle {
-		cc.mu.Lock()
-		for ac := range cc.conns {
-			// TODO: should this be a signal to the LB policy instead?
-			go ac.connect()
-		}
-		cc.mu.Unlock()
+	cc.mu.Lock()
+	if cc.balancerWrapper != nil {
+		cc.balancerWrapper.updateCh.Put(exitIdle{})
 	}
+	cc.mu.Unlock()
 }
 
 func (cc *ClientConn) scWatcher() {

--- a/internal/balancer/stub/stub.go
+++ b/internal/balancer/stub/stub.go
@@ -33,6 +33,7 @@ type BalancerFuncs struct {
 	ResolverError         func(*BalancerData, error)
 	UpdateSubConnState    func(*BalancerData, balancer.SubConn, balancer.SubConnState)
 	Close                 func(*BalancerData)
+	ExitIdle              func(*BalancerData)
 }
 
 // BalancerData contains data relevant to a stub balancer.
@@ -72,6 +73,12 @@ func (b *bal) UpdateSubConnState(sc balancer.SubConn, scs balancer.SubConnState)
 func (b *bal) Close() {
 	if b.bf.Close != nil {
 		b.bf.Close(b.bd)
+	}
+}
+
+func (b *bal) ExitIdle() {
+	if b.bf.ExitIdle != nil {
+		b.bf.ExitIdle(b.bd)
 	}
 }
 

--- a/pickfirst.go
+++ b/pickfirst.go
@@ -124,6 +124,12 @@ func (b *pickfirstBalancer) UpdateSubConnState(sc balancer.SubConn, s balancer.S
 func (b *pickfirstBalancer) Close() {
 }
 
+func (b *pickfirstBalancer) ExitIdle() {
+	if b.state == connectivity.Idle {
+		b.sc.Connect()
+	}
+}
+
 type picker struct {
 	result balancer.PickResult
 	err    error

--- a/test/balancer_test.go
+++ b/test/balancer_test.go
@@ -116,6 +116,8 @@ func (b *testBalancer) UpdateSubConnState(sc balancer.SubConn, s balancer.SubCon
 
 func (b *testBalancer) Close() {}
 
+func (b *testBalancer) ExitIdle() {}
+
 type picker struct {
 	err error
 	sc  balancer.SubConn
@@ -373,8 +375,9 @@ func (testBalancerKeepAddresses) UpdateSubConnState(sc balancer.SubConn, s balan
 	panic("not used")
 }
 
-func (testBalancerKeepAddresses) Close() {
-}
+func (testBalancerKeepAddresses) Close() {}
+
+func (testBalancerKeepAddresses) ExitIdle() {}
 
 // Make sure that non-grpclb balancers don't get grpclb addresses even if name
 // resolver sends them

--- a/xds/internal/balancer/balancergroup/balancergroup.go
+++ b/xds/internal/balancer/balancergroup/balancergroup.go
@@ -109,7 +109,7 @@ func (sbc *subBalancerWrapper) exitIdle() {
 	if b == nil {
 		return
 	}
-	if ei, ok := b.(balancer.ExitIdle); ok {
+	if ei, ok := b.(balancer.ExitIdler); ok {
 		ei.ExitIdle()
 		return
 	}

--- a/xds/internal/balancer/balancergroup/balancergroup.go
+++ b/xds/internal/balancer/balancergroup/balancergroup.go
@@ -104,6 +104,22 @@ func (sbc *subBalancerWrapper) startBalancer() {
 	}
 }
 
+func (sbc *subBalancerWrapper) exitIdle() {
+	b := sbc.balancer
+	if b == nil {
+		return
+	}
+	if ei, ok := b.(balancer.ExitIdle); ok {
+		ei.ExitIdle()
+		return
+	}
+	for sc, b := range sbc.group.scToSubBalancer {
+		if b == sbc {
+			sc.Connect()
+		}
+	}
+}
+
 func (sbc *subBalancerWrapper) updateSubConnState(sc balancer.SubConn, state balancer.SubConnState) {
 	b := sbc.balancer
 	if b == nil {
@@ -489,6 +505,17 @@ func (bg *BalancerGroup) Close() {
 		for _, config := range bg.idToBalancerConfig {
 			config.stopBalancer()
 		}
+	}
+	bg.outgoingMu.Unlock()
+}
+
+// ExitIdle should be invoked when the parent LB policy's ExitIdle is invoked.
+// It will trigger this on all sub-balancers, or reconnect their subconns if
+// not supported.
+func (bg *BalancerGroup) ExitIdle() {
+	bg.outgoingMu.Lock()
+	for _, config := range bg.idToBalancerConfig {
+		config.exitIdle()
 	}
 	bg.outgoingMu.Unlock()
 }

--- a/xds/internal/balancer/cdsbalancer/cdsbalancer.go
+++ b/xds/internal/balancer/cdsbalancer/cdsbalancer.go
@@ -383,6 +383,10 @@ func (b *cdsBalancer) run() {
 					b.logger.Errorf("xds: received ExitIdle with no child balancer")
 					break
 				}
+				// This implementation assumes the child balancer supports
+				// ExitIdle (but still checks for the interface's existence to
+				// avoid a panic if not).  If the child does not, no subconns
+				// will be connected.
 				if ei, ok := b.childLB.(balancer.ExitIdle); ok {
 					ei.ExitIdle()
 				}

--- a/xds/internal/balancer/cdsbalancer/cdsbalancer.go
+++ b/xds/internal/balancer/cdsbalancer/cdsbalancer.go
@@ -141,6 +141,8 @@ type scUpdate struct {
 	state   balancer.SubConnState
 }
 
+type exitIdle struct{}
+
 // cdsBalancer implements a CDS based LB policy. It instantiates a
 // cluster_resolver balancer to further resolve the serviceName received from
 // CDS, into localities and endpoints. Implements the balancer.Balancer
@@ -376,6 +378,14 @@ func (b *cdsBalancer) run() {
 					break
 				}
 				b.childLB.UpdateSubConnState(update.subConn, update.state)
+			case exitIdle:
+				if b.childLB == nil {
+					b.logger.Errorf("xds: received ExitIdle with no child balancer")
+					break
+				}
+				if ei, ok := b.childLB.(balancer.ExitIdle); ok {
+					ei.ExitIdle()
+				}
 			}
 		case u := <-b.clusterHandler.updateChannel:
 			b.handleWatchUpdate(u)
@@ -492,6 +502,10 @@ func (b *cdsBalancer) UpdateSubConnState(sc balancer.SubConn, state balancer.Sub
 func (b *cdsBalancer) Close() {
 	b.closed.Fire()
 	<-b.done.Done()
+}
+
+func (b *cdsBalancer) ExitIdle() {
+	b.updateCh.Put(exitIdle{})
 }
 
 // ccWrapper wraps the balancer.ClientConn passed to the CDS balancer at

--- a/xds/internal/balancer/cdsbalancer/cdsbalancer.go
+++ b/xds/internal/balancer/cdsbalancer/cdsbalancer.go
@@ -387,7 +387,7 @@ func (b *cdsBalancer) run() {
 				// ExitIdle (but still checks for the interface's existence to
 				// avoid a panic if not).  If the child does not, no subconns
 				// will be connected.
-				if ei, ok := b.childLB.(balancer.ExitIdle); ok {
+				if ei, ok := b.childLB.(balancer.ExitIdler); ok {
 					ei.ExitIdle()
 				}
 			}

--- a/xds/internal/balancer/cdsbalancer/cdsbalancer_test.go
+++ b/xds/internal/balancer/cdsbalancer/cdsbalancer_test.go
@@ -1,3 +1,4 @@
+//go:build go1.12
 // +build go1.12
 
 /*
@@ -120,6 +121,10 @@ func (tb *testEDSBalancer) UpdateSubConnState(sc balancer.SubConn, state balance
 
 func (tb *testEDSBalancer) Close() {
 	tb.closeCh.Send(struct{}{})
+}
+
+func (tb *testEDSBalancer) ExitIdle() {
+	// TODO: test
 }
 
 // waitForClientConnUpdate verifies if the testEDSBalancer receives the

--- a/xds/internal/balancer/cdsbalancer/cdsbalancer_test.go
+++ b/xds/internal/balancer/cdsbalancer/cdsbalancer_test.go
@@ -86,7 +86,8 @@ type testEDSBalancer struct {
 	// resolverErrCh is a channel used to signal a resolver error.
 	resolverErrCh *testutils.Channel
 	// closeCh is a channel used to signal the closing of this balancer.
-	closeCh *testutils.Channel
+	closeCh    *testutils.Channel
+	exitIdleCh *testutils.Channel
 	// parentCC is the balancer.ClientConn passed to this test balancer as part
 	// of the Build() call.
 	parentCC balancer.ClientConn
@@ -103,6 +104,7 @@ func newTestEDSBalancer() *testEDSBalancer {
 		scStateCh:     testutils.NewChannel(),
 		resolverErrCh: testutils.NewChannel(),
 		closeCh:       testutils.NewChannel(),
+		exitIdleCh:    testutils.NewChannel(),
 	}
 }
 
@@ -124,7 +126,7 @@ func (tb *testEDSBalancer) Close() {
 }
 
 func (tb *testEDSBalancer) ExitIdle() {
-	// TODO: test
+	tb.exitIdleCh.Send(struct{}{})
 }
 
 // waitForClientConnUpdate verifies if the testEDSBalancer receives the
@@ -708,6 +710,35 @@ func (s) TestClose(t *testing.T) {
 	if err := edsB.waitForResolverError(sCtx, rErr); err != context.DeadlineExceeded {
 		t.Fatal("ResolverError() forwarded to EDS balancer after Close()")
 	}
+}
+
+func (s) TestExitIdle(t *testing.T) {
+	// This creates a CDS balancer, pushes a ClientConnState update with a fake
+	// xdsClient, and makes sure that the CDS balancer registers a watch on the
+	// provided xdsClient.
+	xdsC, cdsB, edsB, _, cancel := setupWithWatch(t)
+	defer func() {
+		cancel()
+		cdsB.Close()
+	}()
+
+	// Here we invoke the watch callback registered on the fake xdsClient. This
+	// will trigger the watch handler on the CDS balancer, which will attempt to
+	// create a new EDS balancer. The fake EDS balancer created above will be
+	// returned to the CDS balancer, because we have overridden the
+	// newChildBalancer function as part of test setup.
+	cdsUpdate := xdsclient.ClusterUpdate{ClusterName: serviceName}
+	wantCCS := edsCCS(serviceName, nil, false)
+	ctx, ctxCancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer ctxCancel()
+	if err := invokeWatchCbAndWait(ctx, xdsC, cdsWatchInfo{cdsUpdate, nil}, wantCCS, edsB); err != nil {
+		t.Fatal(err)
+	}
+
+	// Call ExitIdle on the CDS balancer.
+	cdsB.ExitIdle()
+
+	edsB.exitIdleCh.Receive(ctx)
 }
 
 // TestParseConfig verifies the ParseConfig() method in the CDS balancer.

--- a/xds/internal/balancer/cdsbalancer/cdsbalancer_test.go
+++ b/xds/internal/balancer/cdsbalancer/cdsbalancer_test.go
@@ -728,7 +728,7 @@ func (s) TestExitIdle(t *testing.T) {
 	// returned to the CDS balancer, because we have overridden the
 	// newChildBalancer function as part of test setup.
 	cdsUpdate := xdsclient.ClusterUpdate{ClusterName: serviceName}
-	wantCCS := edsCCS(serviceName, nil, false)
+	wantCCS := edsCCS(serviceName, nil, false, nil)
 	ctx, ctxCancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer ctxCancel()
 	if err := invokeWatchCbAndWait(ctx, xdsC, cdsWatchInfo{cdsUpdate, nil}, wantCCS, edsB); err != nil {

--- a/xds/internal/balancer/clusterimpl/clusterimpl.go
+++ b/xds/internal/balancer/clusterimpl/clusterimpl.go
@@ -339,7 +339,7 @@ func (b *clusterImplBalancer) ExitIdle() {
 	if b.childLB == nil {
 		return
 	}
-	if ei, ok := b.childLB.(balancer.ExitIdle); ok {
+	if ei, ok := b.childLB.(balancer.ExitIdler); ok {
 		ei.ExitIdle()
 		return
 	}

--- a/xds/internal/balancer/clusterimpl/clusterimpl.go
+++ b/xds/internal/balancer/clusterimpl/clusterimpl.go
@@ -335,6 +335,21 @@ func (b *clusterImplBalancer) Close() {
 	b.logger.Infof("Shutdown")
 }
 
+func (b *clusterImplBalancer) ExitIdle() {
+	if b.childLB == nil {
+		return
+	}
+	if ei, ok := b.childLB.(balancer.ExitIdle); ok {
+		ei.ExitIdle()
+		return
+	}
+	// Fallback for children that don't support ExitIdle -- connect to all
+	// SubConns.
+	for _, sc := range b.scWrappers {
+		sc.Connect()
+	}
+}
+
 // Override methods to accept updates from the child LB.
 
 func (b *clusterImplBalancer) UpdateState(state balancer.State) {

--- a/xds/internal/balancer/clustermanager/clustermanager.go
+++ b/xds/internal/balancer/clustermanager/clustermanager.go
@@ -136,6 +136,10 @@ func (b *bal) Close() {
 	b.logger.Infof("Shutdown")
 }
 
+func (b *bal) ExitIdle() {
+	b.bg.ExitIdle()
+}
+
 const prefix = "[xds-cluster-manager-lb %p] "
 
 var logger = grpclog.Component("xds")

--- a/xds/internal/balancer/clusterresolver/clusterresolver.go
+++ b/xds/internal/balancer/clusterresolver/clusterresolver.go
@@ -286,6 +286,10 @@ func (b *clusterResolverBalancer) run() {
 					b.logger.Errorf("xds: received ExitIdle with no child balancer")
 					break
 				}
+				// This implementation assumes the child balancer supports
+				// ExitIdle (but still checks for the interface's existence to
+				// avoid a panic if not).  If the child does not, no subconns
+				// will be connected.
 				if ei, ok := b.child.(balancer.ExitIdle); ok {
 					ei.ExitIdle()
 				}

--- a/xds/internal/balancer/clusterresolver/clusterresolver.go
+++ b/xds/internal/balancer/clusterresolver/clusterresolver.go
@@ -290,7 +290,7 @@ func (b *clusterResolverBalancer) run() {
 				// ExitIdle (but still checks for the interface's existence to
 				// avoid a panic if not).  If the child does not, no subconns
 				// will be connected.
-				if ei, ok := b.child.(balancer.ExitIdle); ok {
+				if ei, ok := b.child.(balancer.ExitIdler); ok {
 					ei.ExitIdle()
 				}
 			}

--- a/xds/internal/balancer/clusterresolver/clusterresolver_test.go
+++ b/xds/internal/balancer/clusterresolver/clusterresolver_test.go
@@ -1,3 +1,4 @@
+//go:build go1.12
 // +build go1.12
 
 /*
@@ -127,6 +128,8 @@ func (f *fakeChildBalancer) UpdateSubConnState(sc balancer.SubConn, state balanc
 }
 
 func (f *fakeChildBalancer) Close() {}
+
+func (f *fakeChildBalancer) ExitIdle() {}
 
 func (f *fakeChildBalancer) waitForClientConnStateChange(ctx context.Context) error {
 	_, err := f.clientConnState.Receive(ctx)

--- a/xds/internal/balancer/priority/balancer.go
+++ b/xds/internal/balancer/priority/balancer.go
@@ -201,6 +201,10 @@ func (b *priorityBalancer) Close() {
 	b.stopPriorityInitTimer()
 }
 
+func (b *priorityBalancer) ExitIdle() {
+	b.bg.ExitIdle()
+}
+
 // stopPriorityInitTimer stops the priorityInitTimer if it's not nil, and set it
 // to nil.
 //

--- a/xds/internal/balancer/weightedtarget/weightedtarget.go
+++ b/xds/internal/balancer/weightedtarget/weightedtarget.go
@@ -172,3 +172,7 @@ func (b *weightedTargetBalancer) Close() {
 	b.stateAggregator.Stop()
 	b.bg.Close()
 }
+
+func (b *weightedTargetBalancer) ExitIdle() {
+	b.bg.ExitIdle()
+}


### PR DESCRIPTION
RELEASE NOTES:
- balancer: add ExitIdle interface to instruct the balancer to attempt to leave the IDLE state by connecting SubConns if appropriate.  The method will be required by the Balancer interface in the future.
