### PR TITLE
interop-testing: add soak test cases to interop client

### DIFF
--- a/interop/client/client.go
+++ b/interop/client/client.go
@@ -61,10 +61,10 @@ var (
 	serverHost                             = flag.String("server_host", "localhost", "The server host name")
 	serverPort                             = flag.Int("server_port", 10000, "The server port number")
 	serviceConfigJSON                      = flag.String("service_config_json", "", "Disables service config lookups and sets the provided string as the default service config.")
-	soakIterations                         = flag.Int("soak_iterations", 0, "The number of iterations to use for the two soak tests: rpc_soak and channel_soak")
+	soakIterations                         = flag.Int("soak_iterations", 10, "The number of iterations to use for the two soak tests: rpc_soak and channel_soak")
 	soakMaxFailures                        = flag.Int("soak_max_failures", 0, "The number of iterations in soak tests that are allowed to fail (either due to non-OK status code or exceeding the per-iteration max acceptable latency).")
-	soakPerIterationMaxAcceptableLatencyMs = flag.Int("soak_per_iteration_max_acceptable_latency_ms", 0, "The number of milliseconds a single iteration in the two soak tests (rpc_soak and channel_soak) should take.")
-	soakOverallTimeoutSeconds              = flag.Int("soak_overall_timeout_seconds", 0, "The overall number of seconds after which a soak test should stop and fail, if the desired number of iterations have not yet completed.")
+	soakPerIterationMaxAcceptableLatencyMs = flag.Int("soak_per_iteration_max_acceptable_latency_ms", 1000, "The number of milliseconds a single iteration in the two soak tests (rpc_soak and channel_soak) should take.")
+	soakOverallTimeoutSeconds              = flag.Int("soak_overall_timeout_seconds", 10, "The overall number of seconds after which a soak test should stop and fail, if the desired number of iterations have not yet completed.")
 	tlsServerName                          = flag.String("server_host_override", "", "The server name used to verify the hostname returned by TLS handshake if it is not empty. Otherwise, --server_host is used.")
 	testCase                               = flag.String("test_case", "large_unary",
 		`Configure different test cases. Valid options are:

--- a/interop/test_utils.go
+++ b/interop/test_utils.go
@@ -734,17 +734,17 @@ func DoSoakTest(tc testgrpc.TestServiceClient, serverAddr string, dopts []grpc.D
 	h := stats.NewHistogram(hopts)
 	for i := 0; i < len(results); i++ {
 		err := results[i].err
-		latency := results[i].latency
+		latencyMs := int64(results[i].latency / time.Millisecond)
 		if err != nil {
 			totalFailures++
-			fmt.Fprintf(os.Stderr, "soak iteration: %d elapsed_ms: %d failed: %s\n", i, latency.Milliseconds(), err)
-		} else if latency > perIterationMaxAcceptableLatency {
+			fmt.Fprintf(os.Stderr, "soak iteration: %d elapsed_ms: %d failed: %s\n", i, latencyMs, err)
+		} else if results[i].latency > perIterationMaxAcceptableLatency {
 			totalFailures++
-			fmt.Fprintf(os.Stderr, "soak iteration: %d elapsed_ms: %d exceeds max acceptable latency: %d\n", i, latency.Milliseconds(), perIterationMaxAcceptableLatency.Milliseconds())
+			fmt.Fprintf(os.Stderr, "soak iteration: %d elapsed_ms: %d exceeds max acceptable latency: %d\n", i, latencyMs, perIterationMaxAcceptableLatency.Milliseconds())
 		} else {
-			fmt.Fprintf(os.Stderr, "soak iteration: %d elapsed_ms: %d succeeded\n", i, latency.Milliseconds())
+			fmt.Fprintf(os.Stderr, "soak iteration: %d elapsed_ms: %d succeeded\n", i, latencyMs)
 		}
-		h.Add(latency.Milliseconds())
+		h.Add(latencyMs)
 	}
 	var b bytes.Buffer
 	h.Print(&b)

--- a/interop/test_utils.go
+++ b/interop/test_utils.go
@@ -678,8 +678,6 @@ func DoPickFirstUnary(tc testgrpc.TestServiceClient) {
 
 func doOneSoakIteration(ctx context.Context, tc testgrpc.TestServiceClient, resetChannel bool, serverAddr string, dopts []grpc.DialOption) (latency time.Duration, err error) {
 	start := time.Now()
-	// per test spec, don't include channel shutdown in latency measurement
-	defer func() { latency = time.Since(start) }()
 	client := tc
 	if resetChannel {
 		var conn *grpc.ClientConn
@@ -690,6 +688,8 @@ func doOneSoakIteration(ctx context.Context, tc testgrpc.TestServiceClient, rese
 		defer conn.Close()
 		client = testgrpc.NewTestServiceClient(conn)
 	}
+	// per test spec, don't include channel shutdown in latency measurement
+	defer func() { latency = time.Since(start) }()
 	// do a large-unary RPC
 	pl := ClientNewPayload(testpb.PayloadType_COMPRESSABLE, largeReqSize)
 	req := &testpb.SimpleRequest{

--- a/interop/test_utils.go
+++ b/interop/test_utils.go
@@ -705,7 +705,7 @@ func doOneSoakIteration(tc testgrpc.TestServiceClient, resetChannel bool, server
 	t := reply.GetPayload().GetType()
 	s := len(reply.GetPayload().GetBody())
 	if t != testpb.PayloadType_COMPRESSABLE || s != largeRespSize {
-		return fmt.Errorf("Got the reply with type %d len %d; want %d, %d", t, s, testpb.PayloadType_COMPRESSABLE, largeRespSize)
+		return fmt.Errorf("got the reply with type %d len %d; want %d, %d", t, s, testpb.PayloadType_COMPRESSABLE, largeRespSize)
 	}
 	return nil
 }
@@ -722,7 +722,7 @@ func DoSoakTest(tc testgrpc.TestServiceClient, serverAddr string, dopts []grpc.D
 		}
 		start := time.Now()
 		err := doOneSoakIteration(tc, resetChannel, serverAddr, dopts)
-		results = append(results, soakIterationResult{err: err, latency: time.Now().Sub(start)})
+		results = append(results, soakIterationResult{err: err, latency: time.Since(start)})
 	}
 	totalFailures := 0
 	hopts := stats.HistogramOptions{

--- a/interop/test_utils.go
+++ b/interop/test_utils.go
@@ -755,7 +755,7 @@ func DoSoakTest(tc testgrpc.TestServiceClient, serverAddr string, dopts []grpc.D
 	} else if totalFailures > maxFailures {
 		logger.Fatalf("soak test ran: %d iterations. total failures: %d exceeds max failures threshold: %d. See breakdown above for which iterations succeeded, failed, and why for more info.", soakIterations, totalFailures, maxFailures)
 	} else {
-		fmt.Fprintln(os.Stderr, "soak test ran: %d iterations. total failures: %d is within max failures threshold: %d. See breakdown above for which iterations succeeded, failed, and why for more info.\n", soakIterations, totalFailures, maxFailures)
+		fmt.Fprintf(os.Stderr, "soak test ran: %d iterations. total failures: %d is within max failures threshold: %d. See breakdown above for which iterations succeeded, failed, and why for more info.\n", soakIterations, totalFailures, maxFailures)
 	}
 }
 

--- a/interop/test_utils.go
+++ b/interop/test_utils.go
@@ -751,11 +751,11 @@ func DoSoakTest(tc testgrpc.TestServiceClient, serverAddr string, dopts []grpc.D
 	fmt.Fprintln(os.Stderr, "Histogram of per-iteration latencies in milliseconds:")
 	fmt.Fprintln(os.Stderr, b.String())
 	if len(results) < soakIterations {
-		fmt.Fprintf(os.Stderr, "soak test consumed all %f seconds of time and quit early, only having ran %d out of desired %d iterations. total failures: %d. max failures threshold: %d. Some or all of the iterations that did run were unexpectedly slow. See breakdown above for which iterations succeeded, failed, and why for more info.\n", overallDeadline.Sub(start).Seconds(), len(results), soakIterations, totalFailures, maxFailures)
+		logger.Fatalf("soak test consumed all %f seconds of time and quit early, only having ran %d out of desired %d iterations. total failures: %d. max failures threshold: %d. Some or all of the iterations that did run were unexpectedly slow. See breakdown above for which iterations succeeded, failed, and why for more info.", overallDeadline.Sub(start).Seconds(), len(results), soakIterations, totalFailures, maxFailures)
 	} else if totalFailures > maxFailures {
-		fmt.Fprintf(os.Stderr, "soak test ran: %d iterations. total failures: %d exceeds max failures threshold: %d. See breakdown above for which iterations succeeded, failed, and why for more info.\n", soakIterations, totalFailures, maxFailures)
+		logger.Fatalf("soak test ran: %d iterations. total failures: %d exceeds max failures threshold: %d. See breakdown above for which iterations succeeded, failed, and why for more info.", soakIterations, totalFailures, maxFailures)
 	} else {
-		fmt.Fprintf(os.Stderr, "soak test ran: %d iterations. total failures: %d is within max failures threshold: %d. See breakdown above for which iterations succeeded, failed, and why for more info.\n", soakIterations, totalFailures, maxFailures)
+		fmt.Fprintln(os.Stderr, "soak test ran: %d iterations. total failures: %d is within max failures threshold: %d. See breakdown above for which iterations succeeded, failed, and why for more info.\n", soakIterations, totalFailures, maxFailures)
 	}
 }
 

--- a/interop/test_utils.go
+++ b/interop/test_utils.go
@@ -676,11 +676,6 @@ func DoPickFirstUnary(tc testgrpc.TestServiceClient) {
 	}
 }
 
-type soakIterationResult struct {
-	err     error
-	latency time.Duration
-}
-
 func doOneSoakIteration(ctx context.Context, tc testgrpc.TestServiceClient, resetChannel bool, serverAddr string, dopts []grpc.DialOption) (latency time.Duration, err error) {
 	start := time.Now()
 	// per test spec, don't include channel shutdown in latency measurement


### PR DESCRIPTION
This is a Go analogue of Java PR: https://github.com/grpc/grpc-java/pull/8407

Documentation PR: https://github.com/grpc/grpc/pull/27030 adds cross language documentation for this test

FWIW, C++  [channel_soak test case is here](https://github.com/grpc/grpc/blob/3e34e3aac790a256943b4b7dada269209c60fe44/test/cpp/interop/client.cc#L55) and [rpc_soak test case is here](https://github.com/grpc/grpc/blob/3e34e3aac790a256943b4b7dada269209c60fe44/test/cpp/interop/client.cc#L72) (for which the code is mainly in https://github.com/grpc/grpc/blob/3e34e3aac790a256943b4b7dada269209c60fe44/test/cpp/interop/interop_client.cc#L1120).

RELEASE NOTES: N/A