### PR TITLE
xds: use the defaultTestTimeout instead of the short one in TestV2ClientBackoffAfterRecvError

### DIFF
--- a/xds/internal/xdsclient/v2/client_test.go
+++ b/xds/internal/xdsclient/v2/client_test.go
@@ -528,7 +528,7 @@ func (s) TestV2ClientBackoffAfterRecvError(t *testing.T) {
 	fakeServer.XDSResponseChan <- &fakeserver.Response{Err: errors.New("RPC error")}
 	t.Log("Bad LDS response pushed to fakeServer...")
 
-	timer := time.NewTimer(defaultTestShortTimeout)
+	timer := time.NewTimer(defaultTestTimeout)
 	select {
 	case <-timer.C:
 		t.Fatal("Timeout when expecting LDS update")


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc-go/issues/4452

In google3, without the fix, the test failed 8/10000 times, and with the fix, it passed all the time.

RELEASE NOTES: N/A