### PR TITLE
test: use non blocking dials in end2end_test

### DIFF
--- a/test/balancer_test.go
+++ b/test/balancer_test.go
@@ -19,7 +19,6 @@
 package test
 
 import (
-
 	"context"
 	"errors"
 	"fmt"

--- a/test/balancer_test.go
+++ b/test/balancer_test.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/attributes"
 	"google.golang.org/grpc/balancer"
@@ -87,7 +88,7 @@ func (b *testBalancer) UpdateClientConnState(state balancer.ClientConnState) err
 			logger.Errorf("testBalancer: failed to NewSubConn: %v", err)
 			return nil
 		}
-		b.cc.UpdateState(balancer.State{ConnectivityState: connectivity.Connecting, Picker: &picker{sc: b.sc, bal: b}})
+		b.cc.UpdateState(balancer.State{ConnectivityState: connectivity.Connecting, Picker: &picker{err: balancer.ErrNoSubConnAvailable, bal: b}})
 		b.sc.Connect()
 	}
 	return nil
@@ -105,8 +106,10 @@ func (b *testBalancer) UpdateSubConnState(sc balancer.SubConn, s balancer.SubCon
 	}
 
 	switch s.ConnectivityState {
-	case connectivity.Ready, connectivity.Idle:
+	case connectivity.Ready:
 		b.cc.UpdateState(balancer.State{ConnectivityState: s.ConnectivityState, Picker: &picker{sc: sc, bal: b}})
+	case connectivity.Idle:
+		b.cc.UpdateState(balancer.State{ConnectivityState: s.ConnectivityState, Picker: &picker{sc: sc, bal: b, idle: true}})
 	case connectivity.Connecting:
 		b.cc.UpdateState(balancer.State{ConnectivityState: s.ConnectivityState, Picker: &picker{err: balancer.ErrNoSubConnAvailable, bal: b}})
 	case connectivity.TransientFailure:
@@ -117,14 +120,18 @@ func (b *testBalancer) UpdateSubConnState(sc balancer.SubConn, s balancer.SubCon
 func (b *testBalancer) Close() {}
 
 type picker struct {
-	err error
-	sc  balancer.SubConn
-	bal *testBalancer
+	err  error
+	sc   balancer.SubConn
+	bal  *testBalancer
+	idle bool
 }
 
 func (p *picker) Pick(info balancer.PickInfo) (balancer.PickResult, error) {
 	if p.err != nil {
 		return balancer.PickResult{}, p.err
+	}
+	if p.idle {
+		p.sc.Connect()
 	}
 	extraMD, _ := grpcutil.ExtraMetadata(info.Ctx)
 	info.Ctx = nil // Do not validate context.
@@ -194,14 +201,14 @@ func testPickExtraMetadata(t *testing.T, e env) {
 	cc := te.clientConn()
 	tc := testpb.NewTestServiceClient(cc)
 
-	// The RPCs will fail, but we don't care. We just need the pick to happen.
-	ctx1, cancel1 := context.WithTimeout(context.Background(), time.Second)
-	defer cancel1()
-	tc.EmptyCall(ctx1, &testpb.Empty{})
-
-	ctx2, cancel2 := context.WithTimeout(context.Background(), time.Second)
-	defer cancel2()
-	tc.EmptyCall(ctx2, &testpb.Empty{}, grpc.CallContentSubtype(testSubContentType))
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	if _, err := tc.EmptyCall(ctx, &testpb.Empty{}, grpc.WaitForReady(true)); err != nil {
+		t.Fatalf("TestService/EmptyCall(_, _) = _, %v, want _, %v", err, nil)
+	}
+	if _, err := tc.EmptyCall(ctx, &testpb.Empty{}, grpc.CallContentSubtype(testSubContentType)); err != nil {
+		t.Fatalf("TestService/EmptyCall(_, _) = _, %v, want _, %v", err, nil)
+	}
 
 	want := []metadata.MD{
 		// First RPC doesn't have sub-content-type.

--- a/test/balancer_test.go
+++ b/test/balancer_test.go
@@ -19,6 +19,7 @@
 package test
 
 import (
+
 	"context"
 	"errors"
 	"fmt"
@@ -132,6 +133,7 @@ func (p *picker) Pick(info balancer.PickInfo) (balancer.PickResult, error) {
 	}
 	if p.idle {
 		p.sc.Connect()
+		return balancer.PickResult{}, balancer.ErrNoSubConnAvailable
 	}
 	extraMD, _ := grpcutil.ExtraMetadata(info.Ctx)
 	info.Ctx = nil // Do not validate context.

--- a/test/balancer_test.go
+++ b/test/balancer_test.go
@@ -209,9 +209,8 @@ func testPickExtraMetadata(t *testing.T, e env) {
 		// Second RPC has sub-content-type "proto".
 		{"content-type": []string{"application/grpc+proto"}},
 	}
-
-	if !cmp.Equal(b.pickExtraMDs, want) {
-		t.Fatalf("%s", cmp.Diff(b.pickExtraMDs, want))
+	if diff := cmp.Diff(want, b.pickExtraMDs); diff != "" {
+		t.Fatalf("unexpected diff in metadata (-want, +got): %s", diff)
 	}
 }
 

--- a/test/creds_test.go
+++ b/test/creds_test.go
@@ -165,7 +165,6 @@ func (c *clientTimeoutCreds) Clone() credentials.TransportCredentials {
 func (s) TestNonFailFastRPCSucceedOnTimeoutCreds(t *testing.T) {
 	te := newTest(t, env{name: "timeout-cred", network: "tcp", security: "empty"})
 	te.userAgent = testAppUA
-	te.nonBlockingDial = true
 	te.startServer(&testServer{security: te.e.security})
 	defer te.tearDown()
 

--- a/test/insecure_creds_test.go
+++ b/test/insecure_creds_test.go
@@ -197,7 +197,7 @@ func (s) TestInsecureCredsWithPerRPCCredentials(t *testing.T) {
 			}
 			defer cc.Close()
 
-			wantErr := "transport: cannot send secure credentials on an insecure connection"
+			const wantErr = "transport: cannot send secure credentials on an insecure connection"
 			c := testpb.NewTestServiceClient(cc)
 			if _, err = c.EmptyCall(ctx, &testpb.Empty{}, copts...); err == nil || !strings.Contains(err.Error(), wantErr) {
 				t.Fatalf("InsecureCredsWithPerRPCCredentials/send_PerRPCCredentials_via_CallOptions  = %v; want %s", err, wantErr)


### PR DESCRIPTION
end2end_tests are frequently causing the overall 7m timeout to fire as they wait in their blocking `Dial()` calls. 

A blocking `Dial()` should hardly ever be used, especially in tests. This PR switches most of these calls to non blocking `Dial()`s and adds a `WaitForReady` call option wherever appropriate.

RELEASE NOTES: N/A