### PR TITLE
xds: deflake Test/ServerSideXDS_ServingModeChanges

### DIFF
--- a/xds/internal/test/xds_server_serving_mode_test.go
+++ b/xds/internal/test/xds_server_serving_mode_test.go
@@ -186,7 +186,7 @@ func (s) TestServerSideXDS_ServingModeChanges(t *testing.T) {
 	}
 
 	// Make sure RPCs succeed on cc1 and fail on cc2.
-	waitForSuccessfulRPC(ctx, t, cc2)
+	waitForSuccessfulRPC(ctx, t, cc1)
 	waitForFailedRPC(ctx, t, cc2)
 
 	// Update the management server to remove the first listener resource as

--- a/xds/internal/test/xds_server_serving_mode_test.go
+++ b/xds/internal/test/xds_server_serving_mode_test.go
@@ -194,9 +194,10 @@ func (s) TestServerSideXDS_ServingModeChanges(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Make sure cc1 is still in READY state, while cc2 has moved out of READY.
-	if s := cc1.GetState(); s != connectivity.Ready {
-		t.Fatalf("clientConn1 state is %s, want %s", s, connectivity.Ready)
+	// Make sure cc1 is still in READY state (or IDLE, since we support IDLE
+	// now), while cc2 has moved out of READY.
+	if s := cc1.GetState(); s != connectivity.Ready && s != connectivity.Idle {
+		t.Fatalf("clientConn1 state is %s, want READY or IDLE", s)
 	}
 	if !cc2.WaitForStateChange(ctx, connectivity.Ready) {
 		t.Fatal("clientConn2 failed to move out of READY")


### PR DESCRIPTION
The test creates two listeners, and both are in `serving` mode initially. We also have two clientConns to the two servers (backed by those two listeners), and these are initially in `READY` state and are able to make a successful RPC. 

Then we remove one of the listener resources, which gets one of the servers into `not-serving` mode. At this point, we check if one of the clientConns has moved out of `READY` (because the server is not serving anymore) and the other one remains in `READY` (since this server is not affected and is still serving).

Currently, grpc-go does not suppress xds resource updates which change only in the *version* number. Therefore, the test receives a `Listener` update even for the resource which has not been updated, and since we updated the A36 spec recently to say the following:
```
Updates to a Listener cause all older connections on that Listener to be
gracefully shut down with a grace period of 10 minutes for long-lived
RPC's, such that clients will reconnect and have the updated
configuration apply.
```
we drain existing transports, which moves the `ClientConn` to `IDLE`. 

This PR fixes the test to rely solely on the outcome of RPCs and not on the channel state.

RELEASE NOTES: N/A