### PR TITLE
Move Server Credentials Handshake to transport

### DIFF
--- a/internal/transport/http2_server.go
+++ b/internal/transport/http2_server.go
@@ -144,7 +144,6 @@ func NewServerTransport(conn net.Conn, config *ServerConfig) (_ ServerTransport,
 			if err == credentials.ErrConnDispatched {
 				return nil, err
 			}
-			rawConn.Close()
 			return nil, connectionErrorf(false, err, "ServerHandshake(%q) failed: %v", rawConn.RemoteAddr(), err)
 		}
 	}

--- a/internal/transport/http2_server.go
+++ b/internal/transport/http2_server.go
@@ -141,13 +141,10 @@ func NewServerTransport(conn net.Conn, config *ServerConfig) (_ ServerTransport,
 		if err != nil {
 			// ErrConnDispatched means that the connection was dispatched away from
 			// gRPC; those connections should be left open.
-			if err != credentials.ErrConnDispatched {
-				rawConn.Close()
-			}
 			if err == credentials.ErrConnDispatched {
 				return nil, err
 			}
-			rawConn.SetDeadline(time.Time{})
+			rawConn.Close()
 			return nil, connectionErrorf(false, err, "ServerHandshake(%q) failed: %v", rawConn.RemoteAddr(), err)
 		}
 	}

--- a/internal/transport/transport.go
+++ b/internal/transport/transport.go
@@ -30,6 +30,7 @@ import (
 	"net"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
@@ -518,7 +519,8 @@ const (
 // ServerConfig consists of all the configurations to establish a server transport.
 type ServerConfig struct {
 	MaxStreams            uint32
-	AuthInfo              credentials.AuthInfo
+	ConnectionTimeout     time.Duration
+	Credentials           credentials.TransportCredentials
 	InTapHandle           tap.ServerInHandle
 	StatsHandler          stats.Handler
 	KeepaliveParams       keepalive.ServerParameters

--- a/server.go
+++ b/server.go
@@ -835,12 +835,11 @@ func (s *Server) handleRawConn(lisAddr string, rawConn net.Conn) {
 
 	// Finish handshaking (HTTP2)
 	st := s.newHTTP2Transport(rawConn)
-
+	rawConn.SetDeadline(time.Time{})
 	if st == nil {
 		return
 	}
 
-	rawConn.SetDeadline(time.Time{})
 	if !s.addConn(lisAddr, st) {
 		return
 	}

--- a/server.go
+++ b/server.go
@@ -710,13 +710,6 @@ func (s *Server) GetServiceInfo() map[string]ServiceInfo {
 // the server being stopped.
 var ErrServerStopped = errors.New("grpc: the server has been stopped")
 
-func (s *Server) useTransportAuthenticator(rawConn net.Conn) (net.Conn, credentials.AuthInfo, error) {
-	if s.opts.creds == nil {
-		return rawConn, nil, nil
-	}
-	return s.opts.creds.ServerHandshake(rawConn)
-}
-
 type listenSocket struct {
 	net.Listener
 	channelzID int64
@@ -839,31 +832,11 @@ func (s *Server) handleRawConn(lisAddr string, rawConn net.Conn) {
 		return
 	}
 	rawConn.SetDeadline(time.Now().Add(s.opts.connectionTimeout))
-	conn, authInfo, err := s.useTransportAuthenticator(rawConn)
-	if err != nil {
-		// ErrConnDispatched means that the connection was dispatched away from
-		// gRPC; those connections should be left open.
-		if err != credentials.ErrConnDispatched {
-			// In deployments where a gRPC server runs behind a cloud load
-			// balancer which performs regular TCP level health checks, the
-			// connection is closed immediately by the latter. Skipping the
-			// error here will help reduce log clutter.
-			if err != io.EOF {
-				s.mu.Lock()
-				s.errorf("ServerHandshake(%q) failed: %v", rawConn.RemoteAddr(), err)
-				s.mu.Unlock()
-				channelz.Warningf(logger, s.channelzID, "grpc: Server.Serve failed to complete security handshake from %q: %v", rawConn.RemoteAddr(), err)
-			}
-			rawConn.Close()
-		}
-		rawConn.SetDeadline(time.Time{})
-		return
-	}
 
 	// Finish handshaking (HTTP2)
-	st := s.newHTTP2Transport(conn, authInfo)
+	st := s.newHTTP2Transport(rawConn)
+
 	if st == nil {
-		conn.Close()
 		return
 	}
 
@@ -888,10 +861,11 @@ func (s *Server) drainServerTransports(addr string) {
 
 // newHTTP2Transport sets up a http/2 transport (using the
 // gRPC http2 server transport in transport/http2_server.go).
-func (s *Server) newHTTP2Transport(c net.Conn, authInfo credentials.AuthInfo) transport.ServerTransport {
+func (s *Server) newHTTP2Transport(c net.Conn) transport.ServerTransport {
 	config := &transport.ServerConfig{
 		MaxStreams:            s.opts.maxConcurrentStreams,
-		AuthInfo:              authInfo,
+		ConnectionTimeout:     s.opts.connectionTimeout,
+		Credentials:           s.opts.creds,
 		InTapHandle:           s.opts.inTapHandle,
 		StatsHandler:          s.opts.statsHandler,
 		KeepaliveParams:       s.opts.keepaliveParams,
@@ -909,6 +883,11 @@ func (s *Server) newHTTP2Transport(c net.Conn, authInfo credentials.AuthInfo) tr
 		s.mu.Lock()
 		s.errorf("NewServerTransport(%q) failed: %v", c.RemoteAddr(), err)
 		s.mu.Unlock()
+		// ErrConnDispatched means that the connection was dispatched away from
+		// gRPC; those connections should be left open.
+		if err != credentials.ErrConnDispatched {
+			c.Close()
+		}
 		channelz.Warning(logger, s.channelzID, "grpc: Server.Serve failed to create ServerTransport: ", err)
 		return nil
 	}


### PR DESCRIPTION
This PR moves the Server Credentials Handshake from Server to Transport. This accomplishes a few things. One, it starts moving functionality best handled by the transport level from the server (grpc layer). Two, it makes this consistent with client side. Three, it allows the rawconn (and not a potentially returned authenticated conn) to be piped into the transports context, which will be used for xds routing.

RELEASE NOTES: none