### PR TITLE
grpc: fix stayConnected function to connect upon entry

### DIFF
--- a/clientconn_test.go
+++ b/clientconn_test.go
@@ -1122,7 +1122,10 @@ func stayConnected(cc *ClientConn) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	for state := cc.GetState(); state != connectivity.Shutdown && cc.WaitForStateChange(ctx, state); state = cc.GetState() {
+	for {
 		cc.Connect()
+		if state := cc.GetState(); state == connectivity.Shutdown || !cc.WaitForStateChange(ctx, state) {
+			return
+		}
 	}
 }


### PR DESCRIPTION
Fixes #4698

If `stayConnected` was called while the `ClientConn` was in IDLE already, it would never call `Connect`, and stay stuck in that state.  This change ensures `cc.Connect` is always called at least once.

RELEASE NOTES: N/A