### PR TITLE
xds: pass empty balancer.BuildOptions in clusterresolver_test

### DIFF
--- a/xds/internal/balancer/clusterresolver/clusterresolver_test.go
+++ b/xds/internal/balancer/clusterresolver/clusterresolver_test.go
@@ -207,7 +207,7 @@ func (s) TestSubConnStateChange(t *testing.T) {
 	defer cleanup()
 
 	builder := balancer.Get(Name)
-	edsB := builder.Build(newNoopTestClientConn(), balancer.BuildOptions{Target: resolver.Target{Endpoint: testEDSServcie}})
+	edsB := builder.Build(newNoopTestClientConn(), balancer.BuildOptions{})
 	if edsB == nil {
 		t.Fatalf("builder.Build(%s) failed and returned nil", Name)
 	}
@@ -253,7 +253,7 @@ func (s) TestErrorFromXDSClientUpdate(t *testing.T) {
 	defer cleanup()
 
 	builder := balancer.Get(Name)
-	edsB := builder.Build(newNoopTestClientConn(), balancer.BuildOptions{Target: resolver.Target{Endpoint: testEDSServcie}})
+	edsB := builder.Build(newNoopTestClientConn(), balancer.BuildOptions{})
 	if edsB == nil {
 		t.Fatalf("builder.Build(%s) failed and returned nil", Name)
 	}
@@ -341,7 +341,7 @@ func (s) TestErrorFromResolver(t *testing.T) {
 	defer cleanup()
 
 	builder := balancer.Get(Name)
-	edsB := builder.Build(newNoopTestClientConn(), balancer.BuildOptions{Target: resolver.Target{Endpoint: testEDSServcie}})
+	edsB := builder.Build(newNoopTestClientConn(), balancer.BuildOptions{})
 	if edsB == nil {
 		t.Fatalf("builder.Build(%s) failed and returned nil", Name)
 	}
@@ -443,7 +443,7 @@ func (s) TestClientWatchEDS(t *testing.T) {
 	defer cleanup()
 
 	builder := balancer.Get(Name)
-	edsB := builder.Build(newNoopTestClientConn(), balancer.BuildOptions{Target: resolver.Target{Endpoint: testEDSServcie}})
+	edsB := builder.Build(newNoopTestClientConn(), balancer.BuildOptions{})
 	if edsB == nil {
 		t.Fatalf("builder.Build(%s) failed and returned nil", Name)
 	}


### PR DESCRIPTION
Landed here when I was looking around the codebase for how the `resolver.Target` passed in `balancer.BuildOptions` is used by different LB policies. And figured that the `Target` field set in these tests is useless. Hence getting rid of them.

RELEASE NOTES: N/A