### PR TITLE
xds: use separate update channels for listeners in test

### DIFF
--- a/xds/internal/test/xds_server_serving_mode_test.go
+++ b/xds/internal/test/xds_server_serving_mode_test.go
@@ -116,18 +116,20 @@ func (s) TestServerSideXDS_ServingModeChanges(t *testing.T) {
 	}()
 
 	// Wait for both listeners to move to "serving" mode.
-	for i := 0; i < 2; i++ {
-		select {
-		case <-ctx.Done():
-			t.Fatalf("timed out waiting for a mode change update: %v", err)
-		case mode := <-updateCh1:
-			if mode != xds.ServingModeServing {
-				t.Errorf("listener received new mode %v, want %v", mode, xds.ServingModeServing)
-			}
-		case mode := <-updateCh2:
-			if mode != xds.ServingModeServing {
-				t.Errorf("listener received new mode %v, want %v", mode, xds.ServingModeServing)
-			}
+	select {
+	case <-ctx.Done():
+		t.Fatalf("timed out waiting for a mode change update: %v", err)
+	case mode := <-updateCh1:
+		if mode != xds.ServingModeServing {
+			t.Errorf("listener received new mode %v, want %v", mode, xds.ServingModeServing)
+		}
+	}
+	select {
+	case <-ctx.Done():
+		t.Fatalf("timed out waiting for a mode change update: %v", err)
+	case mode := <-updateCh2:
+		if mode != xds.ServingModeServing {
+			t.Errorf("listener received new mode %v, want %v", mode, xds.ServingModeServing)
 		}
 	}
 
@@ -159,18 +161,20 @@ func (s) TestServerSideXDS_ServingModeChanges(t *testing.T) {
 	// Wait for lis2 to move to "not-serving" mode. lis1 also receives an update
 	// here even though it stays in "serving" mode.
 	// See https://github.com/grpc/grpc-go/issues/4695.
-	for i := 0; i < 2; i++ {
-		select {
-		case <-ctx.Done():
-			t.Fatalf("timed out waiting for a mode change update: %v", err)
-		case mode := <-updateCh1:
-			if mode != xds.ServingModeServing {
-				t.Errorf("listener received new mode %v, want %v", mode, xds.ServingModeServing)
-			}
-		case mode := <-updateCh2:
-			if mode != xds.ServingModeNotServing {
-				t.Errorf("listener received new mode %v, want %v", mode, xds.ServingModeNotServing)
-			}
+	select {
+	case <-ctx.Done():
+		t.Fatalf("timed out waiting for a mode change update: %v", err)
+	case mode := <-updateCh1:
+		if mode != xds.ServingModeServing {
+			t.Errorf("listener received new mode %v, want %v", mode, xds.ServingModeServing)
+		}
+	}
+	select {
+	case <-ctx.Done():
+		t.Fatalf("timed out waiting for a mode change update: %v", err)
+	case mode := <-updateCh2:
+		if mode != xds.ServingModeNotServing {
+			t.Errorf("listener received new mode %v, want %v", mode, xds.ServingModeNotServing)
 		}
 	}
 
@@ -221,18 +225,20 @@ func (s) TestServerSideXDS_ServingModeChanges(t *testing.T) {
 	}
 
 	// Wait for both listeners to move to "serving" mode.
-	for i := 0; i < 2; i++ {
-		select {
-		case <-ctx.Done():
-			t.Fatalf("timed out waiting for a mode change update: %v", err)
-		case mode := <-updateCh1:
-			if mode != xds.ServingModeServing {
-				t.Errorf("listener received new mode %v, want %v", mode, xds.ServingModeServing)
-			}
-		case mode := <-updateCh2:
-			if mode != xds.ServingModeServing {
-				t.Errorf("listener received new mode %v, want %v", mode, xds.ServingModeServing)
-			}
+	select {
+	case <-ctx.Done():
+		t.Fatalf("timed out waiting for a mode change update: %v", err)
+	case mode := <-updateCh1:
+		if mode != xds.ServingModeServing {
+			t.Errorf("listener received new mode %v, want %v", mode, xds.ServingModeServing)
+		}
+	}
+	select {
+	case <-ctx.Done():
+		t.Fatalf("timed out waiting for a mode change update: %v", err)
+	case mode := <-updateCh2:
+		if mode != xds.ServingModeServing {
+			t.Errorf("listener received new mode %v, want %v", mode, xds.ServingModeServing)
 		}
 	}
 

--- a/xds/internal/test/xds_server_serving_mode_test.go
+++ b/xds/internal/test/xds_server_serving_mode_test.go
@@ -42,8 +42,9 @@ import (
 
 // A convenience typed used to keep track of mode changes on multiple listeners.
 type modeTracker struct {
-	mu       sync.Mutex
-	modes    map[string]xds.ServingMode
+	mu    sync.Mutex
+	modes map[string]xds.ServingMode
+
 	updateCh *testutils.Channel
 }
 
@@ -56,9 +57,9 @@ func newModeTracker() *modeTracker {
 
 func (mt *modeTracker) updateMode(ctx context.Context, addr net.Addr, mode xds.ServingMode) {
 	mt.mu.Lock()
-	defer mt.mu.Unlock()
-
 	mt.modes[addr.String()] = mode
+	mt.mu.Unlock()
+
 	// Sometimes we could get state updates which are not expected by the test.
 	// Using `Send()` here would block in that case and cause the whole test to
 	// hang and will eventually only timeout when the `-timeout` passed to `go


### PR DESCRIPTION
- Use separate update channels for listeners in test. This makes the test a little bit more verbose, but it gets rid of the flakes.
- While waiting for RPCs to start failing after the listener moves to "not-serving", reduce the frequency of trying.

With these two fixes, I was able to run the test 100k times without a single flake.

RELEASE NOTES: N/A