### PR TITLE
oauth: Allow access to Google API regional endpoints via Google Default Credentials

### DIFF
--- a/credentials/oauth/oauth.go
+++ b/credentials/oauth/oauth.go
@@ -77,7 +77,7 @@ func NewJWTAccessFromKey(jsonKey []byte) (credentials.PerRPCCredentials, error) 
 }
 
 func (j jwtAccess) GetRequestMetadata(ctx context.Context, uri ...string) (map[string]string, error) {
-	aud, err := credinternal.RemoveServiceNameFromJwtUri(uri[0])
+	aud, err := credinternal.RemoveServiceNameFromJwtURI(uri[0])
 	if err != nil {
 		return nil, err
 	}

--- a/credentials/oauth/oauth_test.go
+++ b/credentials/oauth/oauth_test.go
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2020 gRPC authors.
+ * Copyright 2021 gRPC authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@ func checkErrorMsg(err error, msg string) bool {
 	return false
 }
 
-func TestRemoveServiceNameFromJwtURI(t *testing.T) {
+func TestRemoveServiceNameFromJWTURI(t *testing.T) {
 	tests := []struct {
 		name         string
 		uri          string
@@ -42,14 +42,12 @@ func TestRemoveServiceNameFromJwtURI(t *testing.T) {
 		{
 			name:         "invalid URI",
 			uri:          "ht tp://foo.com",
-			wantedURI:    "",
 			wantedErrMsg: "first path segment in URL cannot contain colon",
 		},
 		{
-			name:         "valid URI",
-			uri:          "https://foo.com/go/",
-			wantedURI:    "https://foo.com/",
-			wantedErrMsg: "",
+			name:      "valid URI",
+			uri:       "https://foo.com/go/",
+			wantedURI: "https://foo.com/",
 		},
 	}
 	for _, tt := range tests {

--- a/credentials/oauth/oauth_test.go
+++ b/credentials/oauth/oauth_test.go
@@ -1,0 +1,62 @@
+/*
+ *
+ * Copyright 2020 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package oauth
+
+import (
+	"strings"
+	"testing"
+)
+
+func checkErrorMsg(err error, msg string) bool {
+	if err == nil && msg == "" {
+		return true
+	} else if err != nil {
+		return strings.Contains(err.Error(), msg)
+	}
+	return false
+}
+
+func TestRemoveServiceNameFromJwtURI(t *testing.T) {
+	tests := []struct {
+		name         string
+		uri          string
+		wantedURI    string
+		wantedErrMsg string
+	}{
+		{
+			name:         "invalid URI",
+			uri:          "ht tp://foo.com",
+			wantedURI:    "",
+			wantedErrMsg: "first path segment in URL cannot contain colon",
+		},
+		{
+			name:         "valid URI",
+			uri:          "https://foo.com/go/",
+			wantedURI:    "https://foo.com/",
+			wantedErrMsg: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got, err := removeServiceNameFromJWTURI(tt.uri); got != tt.wantedURI || !checkErrorMsg(err, tt.wantedErrMsg) {
+				t.Errorf("RemoveServiceNameFromJWTURI() = %s, %v, want %s, %v", got, err, tt.wantedURI, tt.wantedErrMsg)
+			}
+		})
+	}
+}

--- a/internal/credentials/util.go
+++ b/internal/credentials/util.go
@@ -18,7 +18,10 @@
 
 package credentials
 
-import "crypto/tls"
+import (
+	"crypto/tls"
+	"net/url"
+)
 
 const alpnProtoStrH2 = "h2"
 
@@ -47,4 +50,15 @@ func CloneTLSConfig(cfg *tls.Config) *tls.Config {
 	}
 
 	return cfg.Clone()
+}
+
+// RemoveServiceNameFromJwtUri removes RPC service name
+// from URI that will be used as audience in a self-signed
+// JWT token. It follows https://google.aip.dev/auth/4111.
+func RemoveServiceNameFromJwtUri(uri string) (string, error) {
+	parsed, err := url.Parse(uri)
+	if err != nil {
+		return "", err
+	}
+	return parsed.Scheme + "://" + parsed.Host + "/", nil
 }

--- a/internal/credentials/util.go
+++ b/internal/credentials/util.go
@@ -20,7 +20,6 @@ package credentials
 
 import (
 	"crypto/tls"
-	"net/url"
 )
 
 const alpnProtoStrH2 = "h2"
@@ -50,15 +49,4 @@ func CloneTLSConfig(cfg *tls.Config) *tls.Config {
 	}
 
 	return cfg.Clone()
-}
-
-// RemoveServiceNameFromJwtURI removes RPC service name
-// from URI that will be used as audience in a self-signed
-// JWT token. It follows https://google.aip.dev/auth/4111.
-func RemoveServiceNameFromJwtURI(uri string) (string, error) {
-	parsed, err := url.Parse(uri)
-	if err != nil {
-		return "", err
-	}
-	return parsed.Scheme + "://" + parsed.Host + "/", nil
 }

--- a/internal/credentials/util.go
+++ b/internal/credentials/util.go
@@ -52,10 +52,10 @@ func CloneTLSConfig(cfg *tls.Config) *tls.Config {
 	return cfg.Clone()
 }
 
-// RemoveServiceNameFromJwtUri removes RPC service name
+// RemoveServiceNameFromJwtURI removes RPC service name
 // from URI that will be used as audience in a self-signed
 // JWT token. It follows https://google.aip.dev/auth/4111.
-func RemoveServiceNameFromJwtUri(uri string) (string, error) {
+func RemoveServiceNameFromJwtURI(uri string) (string, error) {
 	parsed, err := url.Parse(uri)
 	if err != nil {
 		return "", err

--- a/internal/credentials/util_test.go
+++ b/internal/credentials/util_test.go
@@ -58,29 +58,3 @@ func (s) TestAppendH2ToNextProtos(t *testing.T) {
 		})
 	}
 }
-
-func (s) TestRemoveServiceNameFromJwtURI(t *testing.T) {
-	tests := []struct {
-		name string
-		uri  string
-		want string
-	}{
-		{
-			name: "invalid URI",
-			uri:  "ht tp://foo.com",
-			want: "",
-		},
-		{
-			name: "valid URI",
-			uri:  "https://foo.com/go/",
-			want: "https://foo.com/",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got, _ := RemoveServiceNameFromJwtURI(tt.uri); got != tt.want {
-				t.Errorf("RemoveServiceNameFromJwtURI() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}

--- a/internal/credentials/util_test.go
+++ b/internal/credentials/util_test.go
@@ -58,3 +58,29 @@ func (s) TestAppendH2ToNextProtos(t *testing.T) {
 		})
 	}
 }
+
+func (s) TestRemoveServiceNameFromJwtUri(t *testing.T) {
+	tests := []struct {
+		name string
+		uri  string
+		want string
+	}{
+		{
+			name: "invalid URI",
+			uri:  "ht tp://foo.com",
+			want: "",
+		},
+		{
+			name: "valid URI",
+			uri:  "https://foo.com/go/",
+			want: "https://foo.com/",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got, _ := RemoveServiceNameFromJwtUri(tt.uri); got != tt.want {
+				t.Errorf("RemoveServiceNameFromJwtUri() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/credentials/util_test.go
+++ b/internal/credentials/util_test.go
@@ -59,7 +59,7 @@ func (s) TestAppendH2ToNextProtos(t *testing.T) {
 	}
 }
 
-func (s) TestRemoveServiceNameFromJwtUri(t *testing.T) {
+func (s) TestRemoveServiceNameFromJwtURI(t *testing.T) {
 	tests := []struct {
 		name string
 		uri  string
@@ -78,8 +78,8 @@ func (s) TestRemoveServiceNameFromJwtUri(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got, _ := RemoveServiceNameFromJwtUri(tt.uri); got != tt.want {
-				t.Errorf("RemoveServiceNameFromJwtUri() = %v, want %v", got, tt.want)
+			if got, _ := RemoveServiceNameFromJwtURI(tt.uri); got != tt.want {
+				t.Errorf("RemoveServiceNameFromJwtURI() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
The self-signed JWT used to access Google API regional endpoints do not have a correct audience format dictated in https://google.aip.dev/auth/4111. That is, it includes a trailing RPC service name while the spec requires only the presence of hostname (or endpoint).

RELEASE NOTES:
* oauth: Allow access to Google API regional endpoints via Google Default Credentials