### PR TITLE
[Backport v1.40.x] Change to a non-workload-identity GKE cluster

### DIFF
--- a/test/kokoro/xds_url_map.sh
+++ b/test/kokoro/xds_url_map.sh
@@ -18,8 +18,8 @@ set -eo pipefail
 # Constants
 readonly GITHUB_REPOSITORY_NAME="grpc-go"
 # GKE Cluster
-readonly GKE_CLUSTER_NAME="interop-test-psm-sec-v2-us-central1-a"
-readonly GKE_CLUSTER_ZONE="us-central1-a"
+readonly GKE_CLUSTER_NAME="interop-test-psm-basic"
+readonly GKE_CLUSTER_ZONE="us-central1-c"
 ## xDS test client Docker images
 readonly CLIENT_IMAGE_NAME="gcr.io/grpc-testing/xds-interop/go-client"
 readonly FORCE_IMAGE_BUILD="${FORCE_IMAGE_BUILD:-0}"


### PR DESCRIPTION
Part of grpc/grpc#27189 and b/198291728.

By disabling the workload identity, we should be able to run tests faster and avoid future IAM policy size issue.

@menghanl PTAL.

Kokoro run: https://fusion2.corp.google.com/invocations/b61ca6a7-a99c-43f6-9740-00c8bf592a6f