### PR TITLE
ringhash: the picker

### DIFF
--- a/xds/internal/balancer/ringhash/config.go
+++ b/xds/internal/balancer/ringhash/config.go
@@ -25,9 +25,6 @@ import (
 	"google.golang.org/grpc/serviceconfig"
 )
 
-// Name is the name of the ring_hash balancer.
-const Name = "ring_hash_experimental"
-
 // LBConfig is the balancer config for ring_hash balancer.
 type LBConfig struct {
 	serviceconfig.LoadBalancingConfig `json:"-"`

--- a/xds/internal/balancer/ringhash/picker.go
+++ b/xds/internal/balancer/ringhash/picker.go
@@ -40,11 +40,11 @@ type handleRICSResult struct {
 	err error
 }
 
-// handleRICS generates pick result if the entry is in Ready, IDLE, Connecting
+// handleRICS generates pick result if the entry is in Ready, Idle, Connecting
 // or Shutdown. TransientFailure will be handled specifically after this
 // function returns.
 //
-// The first return value indicates if the state is in Ready, IDLE, Connecting
+// The first return value indicates if the state is in Ready, Idle, Connecting
 // or Shutdown. If it's true, the PickResult and error should be returned from
 // Pick() as is.
 func handleRICS(e *ringEntry) (handleRICSResult, bool) {
@@ -93,7 +93,7 @@ func (p *picker) handleTransientFailure(e *ringEntry) (balancer.PickResult, erro
 		return balancer.PickResult{}, fmt.Errorf("the only SubConn is in Transient Failure")
 	}
 
-	// For the second SubConn, also check Ready/IDLE/Connecting as if it's the
+	// For the second SubConn, also check Ready/Idle/Connecting as if it's the
 	// first entry.
 	if hr, ok := handleRICS(e2); ok {
 		return hr.pr, hr.err
@@ -130,7 +130,7 @@ func (p *picker) handleTransientFailure(e *ringEntry) (balancer.PickResult, erro
 		// seen. After this, Pick() will never trigger any SubConn to Connect().
 		firstNonFailedFound = true
 		if scState == connectivity.Idle {
-			// This is the first non-failed SubConn, and it is in a real IDLE
+			// This is the first non-failed SubConn, and it is in a real Idle
 			// state. Trigger it to Connect().
 			ee.sc.queueConnect()
 		}

--- a/xds/internal/balancer/ringhash/picker.go
+++ b/xds/internal/balancer/ringhash/picker.go
@@ -31,14 +31,6 @@ type picker struct {
 	ring *ring
 }
 
-// FIXME: uncomment this. This is commented out because staticcheck complains
-// about unused functions. Keeping this here for completeness. Will be
-// uncommented in a future PR.
-//
-// func newPicker(ring *ring) *picker {
-// 	return &picker{ring: ring}
-// }
-
 // handleRICSResult is the return type of handleRICS. It's needed to wrap the
 // returned error from Pick() in a struct. With this, if the return values are
 // `balancer.PickResult, error, bool`, linter complains because error is not the

--- a/xds/internal/balancer/ringhash/picker.go
+++ b/xds/internal/balancer/ringhash/picker.go
@@ -31,9 +31,13 @@ type picker struct {
 	ring *ring
 }
 
-func newPicker(ring *ring) *picker {
-	return &picker{ring: ring}
-}
+// FIXME: uncomment this. This is commented out because staticcheck complains
+// about unused functions. Keeping this here for completeness. Will be
+// uncommented in a future PR.
+//
+// func newPicker(ring *ring) *picker {
+// 	return &picker{ring: ring}
+// }
 
 // handleRICS generates pick result if the entry is in Ready, IDLE, Connecting
 // or Shutdown. TransientFailure will be handled specifically after this

--- a/xds/internal/balancer/ringhash/picker.go
+++ b/xds/internal/balancer/ringhash/picker.go
@@ -1,0 +1,140 @@
+/*
+ *
+ * Copyright 2021 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package ringhash
+
+import (
+	"google.golang.org/grpc/balancer"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/connectivity"
+	"google.golang.org/grpc/status"
+)
+
+type picker struct {
+	ring *ring
+}
+
+func newPicker(ring *ring) *picker {
+	return &picker{ring: ring}
+}
+
+// handleRICS generates pick result if the entry is in Ready, IDLE, Connecting
+// or Shutdown. TransientFailure will be handled specifically after this
+// function returns.
+//
+// The first return value indicates if the state is in Ready, IDLE, Connecting
+// or Shutdown. If it's true, the PickResult and error should be returned from
+// Pick() as is.
+func handleRICS(e *ringEntry) (bool, balancer.PickResult, error) {
+	switch state := e.sc.effectiveState(); state {
+	case connectivity.Ready:
+		return true, balancer.PickResult{SubConn: e.sc.sc}, nil
+	case connectivity.Idle:
+		// Trigger Connect() and queue the pick.
+		e.sc.connect()
+		return true, balancer.PickResult{}, balancer.ErrNoSubConnAvailable
+	case connectivity.Connecting:
+		return true, balancer.PickResult{}, balancer.ErrNoSubConnAvailable
+	case connectivity.TransientFailure:
+		// Return ok==false, so TransientFailure will be handled afterwards.
+		return false, balancer.PickResult{}, nil
+	case connectivity.Shutdown:
+		// Shutdown can happen in a race where the old picker is called. A new
+		// picker should already be sent.
+		return true, balancer.PickResult{}, balancer.ErrNoSubConnAvailable
+	default:
+		// Should never reach this. All the connectivity states are already
+		// handled in the cases.
+		return true, balancer.PickResult{}, status.Errorf(codes.Unavailable, "SubConn has undefined connectivity state: %v", state)
+	}
+}
+
+func (p *picker) Pick(info balancer.PickInfo) (balancer.PickResult, error) {
+	e := p.ring.pick(getRequestHash(info.Ctx))
+	if ok, pr, err := handleRICS(e); ok {
+		return pr, err
+	}
+	// ok was false, the entry is in transient failure.
+	return p.handleTransientFailure(e)
+}
+
+func (p *picker) handleTransientFailure(e *ringEntry) (balancer.PickResult, error) {
+	// Queue a connect on the first picked SubConn.
+	e.sc.connect()
+
+	// Find next entry in the ring, skipping duplicate SubConns.
+	e2 := nextSkippingDuplicates(p.ring, e)
+	if e2 == nil {
+		// There's no next entry available, fail the pick.
+		return balancer.PickResult{}, status.Errorf(codes.Unavailable, "the only SubConn is not Ready")
+	}
+
+	// For the second SubConn, also check Ready/IDLE/Connecting as if it's the
+	// first entry.
+	if ok, pr, err := handleRICS(e2); ok {
+		return pr, err
+	}
+
+	// The second SubConn is also in TransientFailure. Queue a connect on it.
+	e2.sc.connect()
+
+	// If it gets here, this is after the second SubConn, and the second SubConn
+	// was in TransientFailure.
+	//
+	// Loop over all other SubConns:
+	// - If all SubConns so far are all TransientFailure, trigger Connect() on
+	// the TransientFailure SubConns, and keep going.
+	// - If there's one SubConn that's not in TransientFailure, keep checking
+	// the remaining SubConns (in case there's a Ready, which will be returned),
+	// but don't not trigger Connect() on the other SubConns.
+	var firstNonFailedFound bool
+	for ee := nextSkippingDuplicates(p.ring, e2); ee != e; ee = nextSkippingDuplicates(p.ring, ee) {
+		scState := ee.sc.effectiveState()
+		if scState == connectivity.Ready {
+			return balancer.PickResult{SubConn: ee.sc.sc}, nil
+		}
+		if firstNonFailedFound {
+			continue
+		}
+		if scState == connectivity.TransientFailure {
+			// This will queue a connect.
+			ee.sc.connect()
+			continue
+		}
+		// This is a SubConn in a non-failure state. We continue to check the
+		// other SubConns, but remember that there was a non-failed SubConn
+		// seen. After this, Pick() will never trigger any SubConn to Connect().
+		firstNonFailedFound = true
+		if scState == connectivity.Idle {
+			// This is the first non-failed SubConn, and it is in a real IDLE
+			// state. Trigger it to Connect().
+			ee.sc.connect()
+		}
+	}
+	return balancer.PickResult{}, status.Errorf(codes.Unavailable, "no connection is Ready")
+}
+
+func nextSkippingDuplicates(ring *ring, cur *ringEntry) *ringEntry {
+	for next := ring.next(cur); next != cur; next = ring.next(next) {
+		if next.sc != cur.sc {
+			return next
+		}
+	}
+	// There's no qualifying next entry.
+	return nil
+}

--- a/xds/internal/balancer/ringhash/picker_test.go
+++ b/xds/internal/balancer/ringhash/picker_test.go
@@ -1,0 +1,284 @@
+/*
+ *
+ * Copyright 2021 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package ringhash
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/grpc/balancer"
+	"google.golang.org/grpc/connectivity"
+	"google.golang.org/grpc/xds/internal/testutils"
+)
+
+func newTestRing(cStats []connectivity.State) *ring {
+	var items []*ringEntry
+	for i, st := range cStats {
+		testSC := testutils.TestSubConns[i]
+		items = append(items, &ringEntry{
+			idx:  i,
+			hash: uint64((i + 1) * 10),
+			sc: &subConn{
+				addr:  testSC.String(),
+				sc:    testSC,
+				state: st,
+			},
+		})
+	}
+	return &ring{items: items}
+}
+
+func TestPickerPickFirstTwo(t *testing.T) {
+	tests := []struct {
+		name            string
+		ring            *ring
+		hash            uint64
+		wantSC          balancer.SubConn
+		wantErr         error
+		wantSCToConnect balancer.SubConn
+	}{
+		{
+			name:   "picked is Ready",
+			ring:   newTestRing([]connectivity.State{connectivity.Ready, connectivity.Idle}),
+			hash:   5,
+			wantSC: testutils.TestSubConns[0],
+		},
+		{
+			name:    "picked is connecting, queue",
+			ring:    newTestRing([]connectivity.State{connectivity.Connecting, connectivity.Idle}),
+			hash:    5,
+			wantErr: balancer.ErrNoSubConnAvailable,
+		},
+		{
+			name:            "picked is IDLE, connect and queue",
+			ring:            newTestRing([]connectivity.State{connectivity.Idle, connectivity.Idle}),
+			hash:            5,
+			wantErr:         balancer.ErrNoSubConnAvailable,
+			wantSCToConnect: testutils.TestSubConns[0],
+		},
+		{
+			name:   "picked is TransientFailure, next is ready, return",
+			ring:   newTestRing([]connectivity.State{connectivity.TransientFailure, connectivity.Ready}),
+			hash:   5,
+			wantSC: testutils.TestSubConns[1],
+		},
+		{
+			name:    "picked is TransientFailure, next is connecting, queue",
+			ring:    newTestRing([]connectivity.State{connectivity.TransientFailure, connectivity.Connecting}),
+			hash:    5,
+			wantErr: balancer.ErrNoSubConnAvailable,
+		},
+		{
+			name:            "picked is TransientFailure, next is IDLE, connect and queue",
+			ring:            newTestRing([]connectivity.State{connectivity.TransientFailure, connectivity.Idle}),
+			hash:            5,
+			wantErr:         balancer.ErrNoSubConnAvailable,
+			wantSCToConnect: testutils.TestSubConns[1],
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &picker{ring: tt.ring}
+			got, err := p.Pick(balancer.PickInfo{
+				Ctx: SetRequestHash(context.Background(), tt.hash),
+			})
+			if err != tt.wantErr {
+				t.Errorf("Pick() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !cmp.Equal(got, balancer.PickResult{SubConn: tt.wantSC}, cmpOpts) {
+				t.Errorf("Pick() got = %v, want picked SubConn: %v", got, tt.wantSC)
+			}
+			if sc := tt.wantSCToConnect; sc != nil {
+				select {
+				case <-sc.(*testutils.TestSubConn).ConnectCh:
+				case <-time.After(defaultTestShortTimeout):
+					t.Errorf("timeout waiting for Connect() from SubConn %v", sc)
+				}
+			}
+		})
+	}
+}
+
+// TestPickerPickTriggerTFConnect covers that if the picked SubConn is
+// TransientFailures, all SubConns until a non-TransientFailure are queued for
+// Connect().
+func TestPickerPickTriggerTFConnect(t *testing.T) {
+	ring := newTestRing([]connectivity.State{
+		connectivity.TransientFailure, connectivity.TransientFailure, connectivity.TransientFailure, connectivity.TransientFailure,
+		connectivity.Idle, connectivity.TransientFailure, connectivity.TransientFailure, connectivity.TransientFailure,
+	})
+	p := &picker{ring: ring}
+	_, err := p.Pick(balancer.PickInfo{Ctx: SetRequestHash(context.Background(), 5)})
+	if err == nil {
+		t.Fatalf("Pick() error = %v, want non-nil", err)
+	}
+	// The first 4 SubConns, all in TransientFailure, should be queued to
+	// connect.
+	for i := 0; i < 4; i++ {
+		it := ring.items[i]
+		if !it.sc.connectQueued {
+			t.Errorf("the %d-th SubConn is not queued for connect", i)
+		}
+	}
+	// The other SubConns, after the first IDLE, should not be queued to
+	// connect.
+	for i := 5; i < len(ring.items); i++ {
+		it := ring.items[i]
+		if it.sc.connectQueued {
+			t.Errorf("the %d-th SubConn is unexpected queued for connect", i)
+		}
+	}
+}
+
+// TestPickerPickTriggerTFReturnReady covers that if the picked SubConn is
+// TransientFailure, SubConn 2 and 3 are TransientFailure, 4 is Ready. SubConn 2
+// and 3 will Connect(), and 4 will be returned.
+func TestPickerPickTriggerTFReturnReady(t *testing.T) {
+	ring := newTestRing([]connectivity.State{
+		connectivity.TransientFailure, connectivity.TransientFailure, connectivity.TransientFailure, connectivity.Ready,
+	})
+	p := &picker{ring: ring}
+	pr, err := p.Pick(balancer.PickInfo{Ctx: SetRequestHash(context.Background(), 5)})
+	if err != nil {
+		t.Fatalf("Pick() error = %v, want nil", err)
+	}
+	if wantSC := testutils.TestSubConns[3]; pr.SubConn != wantSC {
+		t.Fatalf("Pick() = %v, want %v", pr.SubConn, wantSC)
+	}
+	// The first 3 SubConns, all in TransientFailure, should be queued to
+	// connect.
+	for i := 0; i < 3; i++ {
+		it := ring.items[i]
+		if !it.sc.connectQueued {
+			t.Errorf("the %d-th SubConn is not queued for connect", i)
+		}
+	}
+}
+
+// TestPickerPickTriggerTFWithIDLE covers that if the picked SubConn is
+// TransientFailure, SubConn 2 is TransientFailure, 3 is IDLE (init IDLE). Pick
+// will be queue, SubConn 3 will Connect(), SubConn 4 and 5 (in TransientFailre)
+// will not queue a Connect.
+func TestPickerPickTriggerTFWithIDLE(t *testing.T) {
+	ring := newTestRing([]connectivity.State{
+		connectivity.TransientFailure, connectivity.TransientFailure, connectivity.Idle, connectivity.TransientFailure, connectivity.TransientFailure,
+	})
+	p := &picker{ring: ring}
+	_, err := p.Pick(balancer.PickInfo{Ctx: SetRequestHash(context.Background(), 5)})
+	if err == balancer.ErrNoSubConnAvailable {
+		t.Fatalf("Pick() error = %v, want %v", err, balancer.ErrNoSubConnAvailable)
+	}
+	// The first 2 SubConns, all in TransientFailure, should be queued to
+	// connect.
+	for i := 0; i < 2; i++ {
+		it := ring.items[i]
+		if !it.sc.connectQueued {
+			t.Errorf("the %d-th SubConn is not queued for connect", i)
+		}
+	}
+	// SubConn 3 was in IDLE, so should Connect()
+	select {
+	case <-testutils.TestSubConns[2].ConnectCh:
+	case <-time.After(defaultTestShortTimeout):
+		t.Errorf("timeout waiting for Connect() from SubConn %v", testutils.TestSubConns[2])
+	}
+	// The other SubConns, after the first IDLE, should not be queued to
+	// connect.
+	for i := 3; i < len(ring.items); i++ {
+		it := ring.items[i]
+		if it.sc.connectQueued {
+			t.Errorf("the %d-th SubConn is unexpected queued for connect", i)
+		}
+	}
+}
+
+func TestNextSkippingDuplicatesNoDup(t *testing.T) {
+	testRing := newTestRing([]connectivity.State{connectivity.Idle, connectivity.Idle})
+	tests := []struct {
+		name string
+		ring *ring
+		cur  *ringEntry
+		want *ringEntry
+	}{
+		{
+			name: "no dup",
+			ring: testRing,
+			cur:  testRing.items[0],
+			want: testRing.items[1],
+		},
+		{
+			name: "only one entry",
+			ring: &ring{items: []*ringEntry{testRing.items[0]}},
+			cur:  testRing.items[0],
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := nextSkippingDuplicates(tt.ring, tt.cur); !cmp.Equal(got, tt.want, cmpOpts) {
+				t.Errorf("nextSkippingDuplicates() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// addDups adds duplicates of items[0] to the ring.
+func addDups(r *ring, count int) *ring {
+	var (
+		items []*ringEntry
+		idx   int
+	)
+	for i, it := range r.items {
+		itt := *it
+		itt.idx = idx
+		items = append(items, &itt)
+		idx++
+		if i == 0 {
+			// Add duplicate of items[0] to the ring
+			for j := 0; j < count; j++ {
+				itt2 := *it
+				itt2.idx = idx
+				items = append(items, &itt2)
+				idx++
+			}
+		}
+	}
+	return &ring{items: items}
+}
+
+func TestNextSkippingDuplicatesMoreDup(t *testing.T) {
+	testRing := newTestRing([]connectivity.State{connectivity.Idle, connectivity.Idle})
+	// Make a new ring with duplicate SubConns.
+	dupTestRing := addDups(testRing, 3)
+	if got := nextSkippingDuplicates(dupTestRing, dupTestRing.items[0]); !cmp.Equal(got, dupTestRing.items[len(dupTestRing.items)-1], cmpOpts) {
+		t.Errorf("nextSkippingDuplicates() = %v, want %v", got, dupTestRing.items[len(dupTestRing.items)-1])
+	}
+}
+
+func TestNextSkippingDuplicatesOnlyDup(t *testing.T) {
+	testRing := newTestRing([]connectivity.State{connectivity.Idle})
+	dupTestRing := addDups(testRing, 3)
+	// This ring only has duplicates of items[0], should return nil.
+	if got := nextSkippingDuplicates(dupTestRing, dupTestRing.items[0]); got != nil {
+		t.Errorf("nextSkippingDuplicates() = %v, want nil", got)
+	}
+}

--- a/xds/internal/balancer/ringhash/picker_test.go
+++ b/xds/internal/balancer/ringhash/picker_test.go
@@ -68,7 +68,7 @@ func TestPickerPickFirstTwo(t *testing.T) {
 			wantErr: balancer.ErrNoSubConnAvailable,
 		},
 		{
-			name:            "picked is IDLE, connect and queue",
+			name:            "picked is Idle, connect and queue",
 			ring:            newTestRing([]connectivity.State{connectivity.Idle, connectivity.Idle}),
 			hash:            5,
 			wantErr:         balancer.ErrNoSubConnAvailable,
@@ -87,7 +87,7 @@ func TestPickerPickFirstTwo(t *testing.T) {
 			wantErr: balancer.ErrNoSubConnAvailable,
 		},
 		{
-			name:            "picked is TransientFailure, next is IDLE, connect and queue",
+			name:            "picked is TransientFailure, next is Idle, connect and queue",
 			ring:            newTestRing([]connectivity.State{connectivity.TransientFailure, connectivity.Idle}),
 			hash:            5,
 			wantErr:         balancer.ErrNoSubConnAvailable,
@@ -139,7 +139,7 @@ func TestPickerPickTriggerTFConnect(t *testing.T) {
 			t.Errorf("the %d-th SubConn is not queued for connect", i)
 		}
 	}
-	// The other SubConns, after the first IDLE, should not be queued to
+	// The other SubConns, after the first Idle, should not be queued to
 	// connect.
 	for i := 5; i < len(ring.items); i++ {
 		it := ring.items[i]
@@ -174,11 +174,11 @@ func TestPickerPickTriggerTFReturnReady(t *testing.T) {
 	}
 }
 
-// TestPickerPickTriggerTFWithIDLE covers that if the picked SubConn is
-// TransientFailure, SubConn 2 is TransientFailure, 3 is IDLE (init IDLE). Pick
+// TestPickerPickTriggerTFWithIdle covers that if the picked SubConn is
+// TransientFailure, SubConn 2 is TransientFailure, 3 is Idle (init Idle). Pick
 // will be queue, SubConn 3 will Connect(), SubConn 4 and 5 (in TransientFailre)
 // will not queue a Connect.
-func TestPickerPickTriggerTFWithIDLE(t *testing.T) {
+func TestPickerPickTriggerTFWithIdle(t *testing.T) {
 	ring := newTestRing([]connectivity.State{
 		connectivity.TransientFailure, connectivity.TransientFailure, connectivity.Idle, connectivity.TransientFailure, connectivity.TransientFailure,
 	})
@@ -195,13 +195,13 @@ func TestPickerPickTriggerTFWithIDLE(t *testing.T) {
 			t.Errorf("the %d-th SubConn is not queued for connect", i)
 		}
 	}
-	// SubConn 3 was in IDLE, so should Connect()
+	// SubConn 3 was in Idle, so should Connect()
 	select {
 	case <-testutils.TestSubConns[2].ConnectCh:
 	case <-time.After(defaultTestShortTimeout):
 		t.Errorf("timeout waiting for Connect() from SubConn %v", testutils.TestSubConns[2])
 	}
-	// The other SubConns, after the first IDLE, should not be queued to
+	// The other SubConns, after the first Idle, should not be queued to
 	// connect.
 	for i := 3; i < len(ring.items); i++ {
 		it := ring.items[i]

--- a/xds/internal/balancer/ringhash/picker_test.go
+++ b/xds/internal/balancer/ringhash/picker_test.go
@@ -276,6 +276,7 @@ func TestNextSkippingDuplicatesMoreDup(t *testing.T) {
 
 func TestNextSkippingDuplicatesOnlyDup(t *testing.T) {
 	testRing := newTestRing([]connectivity.State{connectivity.Idle})
+	// Make a new ring with only duplicate SubConns.
 	dupTestRing := addDups(testRing, 3)
 	// This ring only has duplicates of items[0], should return nil.
 	if got := nextSkippingDuplicates(dupTestRing, dupTestRing.items[0]); got != nil {

--- a/xds/internal/balancer/ringhash/ring.go
+++ b/xds/internal/balancer/ringhash/ring.go
@@ -28,13 +28,6 @@ import (
 	"google.golang.org/grpc/resolver"
 )
 
-// subConn is a placeholder struct needed by the ring. It will be moved to the
-// balancer file, and will add more fields (balancer.SubConn, connectivity state
-// and so on).
-type subConn struct {
-	addr string
-}
-
 type ring struct {
 	items []*ringEntry
 }

--- a/xds/internal/balancer/ringhash/ringhash.go
+++ b/xds/internal/balancer/ringhash/ringhash.go
@@ -1,0 +1,108 @@
+/*
+ *
+ * Copyright 2021 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// Package ringhash implements the ringhash balancer.
+package ringhash
+
+import (
+	"sync"
+
+	"google.golang.org/grpc/balancer"
+	"google.golang.org/grpc/connectivity"
+)
+
+// Name is the name of the ring_hash balancer.
+const Name = "ring_hash_experimental"
+
+type subConn struct {
+	addr string
+	sc   balancer.SubConn
+
+	mu sync.RWMutex
+	// This is the actual state of this SubConn (as updated by the ClientConn).
+	// The effective state can be different, see comment of attemptedToConnect.
+	state connectivity.State
+	// attemptedToConnect is whether this SubConn has attempted to connect.
+	//
+	// This affect the effective connectivity state of this SubConn, e.g. if the
+	// actual state is IDLE, but this SubConn has attempted to connect, the
+	// effective state is TransientFailure.
+	//
+	// This is used in pick(). E.g. if a subConn is IDLE, but has
+	// attemptedToConnect as true, pick() will
+	// - consider this SubConn as TransientFailure, and check the state of the
+	// next SubConn.
+	// - trigger Connect() (note that normally a SubConn in real
+	// TransientFailure cannot Connect())
+	//
+	// Note this should only be set when updating the state (from IDLE to
+	// anything else), not when Connect() is called, because there's a small
+	// window after the first Connect(), before the state switches to something
+	// else.
+	attemptedToConnect bool
+	// connectQueued is true if a Connect() was queued for this SubConn while
+	// it's not in IDLE (most likely was in TransientFailure). A Connect() will
+	// be triggered on this SubConn when it turns IDLE.
+	//
+	// When connectivity state is updated to IDLE for this SubConn, if
+	// connectQueued is true, Connect() will be called on the SubConn.
+	connectQueued bool
+}
+
+// setState updates the state of this SubConn.
+//
+// It also handles the queued Connect(). If the new state is IDLE, and a
+// Connect() was queued, this SubConn will be triggered to Connect().
+func (sc *subConn) setState(s connectivity.State) {
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+	// Any state change means there was an attempt to connect.
+	if s != connectivity.Idle {
+		sc.attemptedToConnect = true
+	}
+	// Trigger Connect() if new state is IDLE, and there is a queued connect.
+	if s == connectivity.Idle && sc.connectQueued {
+		sc.connectQueued = false
+		sc.sc.Connect()
+	}
+	sc.state = s
+}
+
+// effectiveState returns the effective state of this SubConn. It can be
+// different from the actual state, e.g. IDLE after any attempt to connect (any
+// IDLE other than the initial IDLE) is considered TransientFailure.
+func (sc *subConn) effectiveState() connectivity.State {
+	sc.mu.RLock()
+	defer sc.mu.RUnlock()
+	if sc.state == connectivity.Idle && sc.attemptedToConnect {
+		return connectivity.TransientFailure
+	}
+	return sc.state
+}
+
+func (sc *subConn) connect() {
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+	if sc.state == connectivity.Idle {
+		sc.sc.Connect()
+		return
+	}
+	// Queue this connect, and when this SubConn switches back to IDLE (happens
+	// after backoff in TransientFailure), it will Connect().
+	sc.connectQueued = true
+}

--- a/xds/internal/balancer/ringhash/ringhash.go
+++ b/xds/internal/balancer/ringhash/ringhash.go
@@ -42,33 +42,33 @@ type subConn struct {
 	// following Idles are all TransientFailure.
 	//
 	// This affects the effective connectivity state of this SubConn, e.g. if
-	// the actual state is IDLE, but this SubConn has attempted to connect, the
+	// the actual state is Idle, but this SubConn has attempted to connect, the
 	// effective state is TransientFailure.
 	//
-	// This is used in pick(). E.g. if a subConn is IDLE, but has
+	// This is used in pick(). E.g. if a subConn is Idle, but has
 	// attemptedToConnect as true, pick() will
 	// - consider this SubConn as TransientFailure, and check the state of the
 	// next SubConn.
 	// - trigger Connect() (note that normally a SubConn in real
 	// TransientFailure cannot Connect())
 	//
-	// Note this should only be set when updating the state (from IDLE to
+	// Note this should only be set when updating the state (from Idle to
 	// anything else), not when Connect() is called, because there's a small
 	// window after the first Connect(), before the state switches to something
 	// else.
 	attemptedToConnect bool
 	// connectQueued is true if a Connect() was queued for this SubConn while
-	// it's not in IDLE (most likely was in TransientFailure). A Connect() will
-	// be triggered on this SubConn when it turns IDLE.
+	// it's not in Idle (most likely was in TransientFailure). A Connect() will
+	// be triggered on this SubConn when it turns Idle.
 	//
-	// When connectivity state is updated to IDLE for this SubConn, if
+	// When connectivity state is updated to Idle for this SubConn, if
 	// connectQueued is true, Connect() will be called on the SubConn.
 	connectQueued bool
 }
 
 // SetState updates the state of this SubConn.
 //
-// It also handles the queued Connect(). If the new state is IDLE, and a
+// It also handles the queued Connect(). If the new state is Idle, and a
 // Connect() was queued, this SubConn will be triggered to Connect().
 //
 // FIXME: unexport this. It's exported so that staticcheck doesn't complain
@@ -82,7 +82,7 @@ func (sc *subConn) SetState(s connectivity.State) {
 	}
 	switch s {
 	case connectivity.Idle:
-		// Trigger Connect() if new state is IDLE, and there is a queued connect.
+		// Trigger Connect() if new state is Idle, and there is a queued connect.
 		if sc.connectQueued {
 			sc.connectQueued = false
 			sc.sc.Connect()
@@ -96,8 +96,8 @@ func (sc *subConn) SetState(s connectivity.State) {
 }
 
 // effectiveState returns the effective state of this SubConn. It can be
-// different from the actual state, e.g. IDLE after any attempt to connect (any
-// IDLE other than the initial IDLE) is considered TransientFailure.
+// different from the actual state, e.g. Idle after any attempt to connect (any
+// Idle other than the initial Idle) is considered TransientFailure.
 func (sc *subConn) effectiveState() connectivity.State {
 	sc.mu.RLock()
 	defer sc.mu.RUnlock()
@@ -117,7 +117,7 @@ func (sc *subConn) queueConnect() {
 		sc.sc.Connect()
 		return
 	}
-	// Queue this connect, and when this SubConn switches back to IDLE (happens
+	// Queue this connect, and when this SubConn switches back to Idle (happens
 	// after backoff in TransientFailure), it will Connect().
 	sc.connectQueued = true
 }

--- a/xds/internal/balancer/ringhash/ringhash.go
+++ b/xds/internal/balancer/ringhash/ringhash.go
@@ -64,24 +64,28 @@ type subConn struct {
 	connectQueued bool
 }
 
-// setState updates the state of this SubConn.
+// FIXME: uncomment this. This is commented out because staticcheck complains
+// about unused functions. Keeping this here for completeness. Will be
+// uncommented in a future PR.
 //
-// It also handles the queued Connect(). If the new state is IDLE, and a
-// Connect() was queued, this SubConn will be triggered to Connect().
-func (sc *subConn) setState(s connectivity.State) {
-	sc.mu.Lock()
-	defer sc.mu.Unlock()
-	// Any state change means there was an attempt to connect.
-	if s != connectivity.Idle {
-		sc.attemptedToConnect = true
-	}
-	// Trigger Connect() if new state is IDLE, and there is a queued connect.
-	if s == connectivity.Idle && sc.connectQueued {
-		sc.connectQueued = false
-		sc.sc.Connect()
-	}
-	sc.state = s
-}
+// // setState updates the state of this SubConn.
+// //
+// // It also handles the queued Connect(). If the new state is IDLE, and a
+// // Connect() was queued, this SubConn will be triggered to Connect().
+// func (sc *subConn) setState(s connectivity.State) {
+// 	sc.mu.Lock()
+// 	defer sc.mu.Unlock()
+// 	// Any state change means there was an attempt to connect.
+// 	if s != connectivity.Idle {
+// 		sc.attemptedToConnect = true
+// 	}
+// 	// Trigger Connect() if new state is IDLE, and there is a queued connect.
+// 	if s == connectivity.Idle && sc.connectQueued {
+// 		sc.connectQueued = false
+// 		sc.sc.Connect()
+// 	}
+// 	sc.state = s
+// }
 
 // effectiveState returns the effective state of this SubConn. It can be
 // different from the actual state, e.g. IDLE after any attempt to connect (any

--- a/xds/internal/balancer/ringhash/ringhash.go
+++ b/xds/internal/balancer/ringhash/ringhash.go
@@ -99,7 +99,10 @@ func (sc *subConn) effectiveState() connectivity.State {
 	return sc.state
 }
 
-func (sc *subConn) connect() {
+// queueConnect sets a boolean so that when the SubConn state changes to Idle,
+// it's Connect() will be triggered. If the SubConn state is already Idle, it
+// will just call Connect().
+func (sc *subConn) queueConnect() {
 	sc.mu.Lock()
 	defer sc.mu.Unlock()
 	if sc.state == connectivity.Idle {

--- a/xds/internal/balancer/ringhash/ringhash.go
+++ b/xds/internal/balancer/ringhash/ringhash.go
@@ -66,11 +66,14 @@ type subConn struct {
 	connectQueued bool
 }
 
-// setState updates the state of this SubConn.
+// SetState updates the state of this SubConn.
 //
 // It also handles the queued Connect(). If the new state is IDLE, and a
 // Connect() was queued, this SubConn will be triggered to Connect().
-func (sc *subConn) setState(s connectivity.State) {
+//
+// FIXME: unexport this. It's exported so that staticcheck doesn't complain
+// about unused functions.
+func (sc *subConn) SetState(s connectivity.State) {
 	sc.mu.Lock()
 	defer sc.mu.Unlock()
 	// Any state change to non-Idle means there was an attempt to connect.

--- a/xds/internal/balancer/ringhash/ringhash_test.go
+++ b/xds/internal/balancer/ringhash/ringhash_test.go
@@ -18,23 +18,21 @@
 
 package ringhash
 
-import "context"
+import (
+	"time"
 
-type clusterKey struct{}
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"google.golang.org/grpc/xds/internal/testutils"
+)
 
-func getRequestHash(ctx context.Context) uint64 {
-	requestHash, _ := ctx.Value(clusterKey{}).(uint64)
-	return requestHash
-}
+var (
+	cmpOpts = cmp.Options{
+		cmp.AllowUnexported(testutils.TestSubConn{}, ringEntry{}, subConn{}),
+		cmpopts.IgnoreFields(subConn{}, "mu"),
+	}
+)
 
-// GetRequestHashForTesting returns the request hash in the context; to be used
-// for testing only.
-func GetRequestHashForTesting(ctx context.Context) uint64 {
-	return getRequestHash(ctx)
-}
-
-// SetRequestHash adds the request hash to the context for use in Ring Hash Load
-// Balancing.
-func SetRequestHash(ctx context.Context, requestHash uint64) context.Context {
-	return context.WithValue(ctx, clusterKey{}, requestHash)
-}
+const (
+	defaultTestShortTimeout = 10 * time.Millisecond
+)

--- a/xds/internal/testutils/balancer.go
+++ b/xds/internal/testutils/balancer.go
@@ -46,21 +46,28 @@ var TestSubConns []*TestSubConn
 func init() {
 	for i := 0; i < TestSubConnsCount; i++ {
 		TestSubConns = append(TestSubConns, &TestSubConn{
-			id: fmt.Sprintf("sc%d", i),
+			id:        fmt.Sprintf("sc%d", i),
+			ConnectCh: make(chan struct{}, 1),
 		})
 	}
 }
 
 // TestSubConn implements the SubConn interface, to be used in tests.
 type TestSubConn struct {
-	id string
+	id        string
+	ConnectCh chan struct{}
 }
 
 // UpdateAddresses is a no-op.
 func (tsc *TestSubConn) UpdateAddresses([]resolver.Address) {}
 
 // Connect is a no-op.
-func (tsc *TestSubConn) Connect() {}
+func (tsc *TestSubConn) Connect() {
+	select {
+	case tsc.ConnectCh <- struct{}{}:
+	default:
+	}
+}
 
 // String implements stringer to print human friendly error message.
 func (tsc *TestSubConn) String() string {


### PR DESCRIPTION
A picker has a ring. It retrieves the hash from the context, and find the SubConn from the ring.
The picker also handles the situation where the first picked SubConn isn't ready, by falling back to other available SubConns in the ring.

RELEASE NOTES: N/A