### PR TITLE
priority: forward the first IDLE state and picker

### DIFF
--- a/xds/internal/balancer/priority/balancer_priority.go
+++ b/xds/internal/balancer/priority/balancer_priority.go
@@ -359,10 +359,10 @@ func (b *priorityBalancer) handlePriorityWithNewStateConnecting(child *childBala
 	}
 }
 
-// handlePriorityWithNewStateIdle handles state Ready from a higher or equal
+// handlePriorityWithNewStateIdle handles state Idle from a higher or equal
 // priority.
 //
-// An update with state Ready:
+// An update with state Idle:
 // - If it's from higher priority:
 //   - Do nothing
 //   - It actually shouldn't happen, no balancer switches back to Idle.

--- a/xds/internal/balancer/priority/balancer_priority.go
+++ b/xds/internal/balancer/priority/balancer_priority.go
@@ -231,6 +231,8 @@ func (b *priorityBalancer) handleChildStateUpdate(childName string, s balancer.S
 		b.handlePriorityWithNewStateTransientFailure(child, priority)
 	case connectivity.Connecting:
 		b.handlePriorityWithNewStateConnecting(child, priority, oldState)
+	case connectivity.Idle:
+		b.handlePriorityWithNewStateIDLE(child, priority)
 	default:
 		// New state is Idle, should never happen. Don't forward.
 	}
@@ -355,4 +357,26 @@ func (b *priorityBalancer) handlePriorityWithNewStateConnecting(child *childBala
 	default:
 		// Old state is Connecting, TransientFailure or Shutdown. Don't forward.
 	}
+}
+
+// handlePriorityWithNewStateIDLE handles state Ready from a higher or equal
+// priority.
+//
+// An update with state Ready:
+// - If it's from higher priority:
+//   - Do nothing
+//   - It actually shouldn't happen, no balancer switches back to IDLE.
+// - If it's from priorityInUse:
+//   - Forward only
+//
+// Caller must make sure priorityInUse is not higher than priority.
+//
+// Caller must hold mu.
+func (b *priorityBalancer) handlePriorityWithNewStateIDLE(child *childBalancer, priority int) {
+	// priorityInUse is lower than this priority, do nothing.
+	if b.priorityInUse > priority {
+		return
+	}
+	// Forward the update.
+	b.cc.UpdateState(child.state)
 }

--- a/xds/internal/balancer/priority/balancer_priority.go
+++ b/xds/internal/balancer/priority/balancer_priority.go
@@ -232,7 +232,7 @@ func (b *priorityBalancer) handleChildStateUpdate(childName string, s balancer.S
 	case connectivity.Connecting:
 		b.handlePriorityWithNewStateConnecting(child, priority, oldState)
 	case connectivity.Idle:
-		b.handlePriorityWithNewStateIDLE(child, priority)
+		b.handlePriorityWithNewStateIdle(child, priority)
 	default:
 		// New state is Idle, should never happen. Don't forward.
 	}
@@ -359,20 +359,20 @@ func (b *priorityBalancer) handlePriorityWithNewStateConnecting(child *childBala
 	}
 }
 
-// handlePriorityWithNewStateIDLE handles state Ready from a higher or equal
+// handlePriorityWithNewStateIdle handles state Ready from a higher or equal
 // priority.
 //
 // An update with state Ready:
 // - If it's from higher priority:
 //   - Do nothing
-//   - It actually shouldn't happen, no balancer switches back to IDLE.
+//   - It actually shouldn't happen, no balancer switches back to Idle.
 // - If it's from priorityInUse:
 //   - Forward only
 //
 // Caller must make sure priorityInUse is not higher than priority.
 //
 // Caller must hold mu.
-func (b *priorityBalancer) handlePriorityWithNewStateIDLE(child *childBalancer, priority int) {
+func (b *priorityBalancer) handlePriorityWithNewStateIdle(child *childBalancer, priority int) {
 	// priorityInUse is lower than this priority, do nothing.
 	if b.priorityInUse > priority {
 		return

--- a/xds/internal/balancer/priority/balancer_test.go
+++ b/xds/internal/balancer/priority/balancer_test.go
@@ -1779,17 +1779,17 @@ func (s) TestPriority_IgnoreReresolutionRequestTwoChildren(t *testing.T) {
 	}
 }
 
-const initIDLEBalancerName = "test-init-IDLE-balancer"
+const initIdleBalancerName = "test-init-Idle-balancer"
 
-var errsTestInitIDLE = []error{
-	fmt.Errorf("init IDLE balancer error 0"),
-	fmt.Errorf("init IDLE balancer error 1"),
+var errsTestInitIdle = []error{
+	fmt.Errorf("init Idle balancer error 0"),
+	fmt.Errorf("init Idle balancer error 1"),
 }
 
 func init() {
 	for i := 0; i < 2; i++ {
 		ii := i
-		stub.Register(fmt.Sprintf("%s-%d", initIDLEBalancerName, ii), stub.BalancerFuncs{
+		stub.Register(fmt.Sprintf("%s-%d", initIdleBalancerName, ii), stub.BalancerFuncs{
 			UpdateClientConnState: func(bd *stub.BalancerData, opts balancer.ClientConnState) error {
 				bd.ClientConn.NewSubConn(opts.ResolverState.Addresses, balancer.NewSubConnOptions{})
 				return nil
@@ -1797,7 +1797,7 @@ func init() {
 			UpdateSubConnState: func(bd *stub.BalancerData, sc balancer.SubConn, state balancer.SubConnState) {
 				err := fmt.Errorf("wrong picker error")
 				if state.ConnectivityState == connectivity.Idle {
-					err = errsTestInitIDLE[ii]
+					err = errsTestInitIdle[ii]
 				}
 				bd.ClientConn.UpdateState(balancer.State{
 					ConnectivityState: state.ConnectivityState,
@@ -1808,12 +1808,12 @@ func init() {
 	}
 }
 
-// If the high priorities send initial pickers with IDLE state, their pickers
-// should get picks, because policies like ringhash starts in IDLE, and doesn't
+// If the high priorities send initial pickers with Idle state, their pickers
+// should get picks, because policies like ringhash starts in Idle, and doesn't
 // connect.
 //
-// Init 0, 1; 0 is IDLE, use 0; 0 is down, start 1; 1 is IDLE, use 1.
-func (s) TestPriority_HighPriorityInitIDLE(t *testing.T) {
+// Init 0, 1; 0 is Idle, use 0; 0 is down, start 1; 1 is Idle, use 1.
+func (s) TestPriority_HighPriorityInitIdle(t *testing.T) {
 	cc := testutils.NewTestClientConn(t)
 	bb := balancer.Get(Name)
 	pb := bb.Build(cc, balancer.BuildOptions{})
@@ -1829,8 +1829,8 @@ func (s) TestPriority_HighPriorityInitIDLE(t *testing.T) {
 		},
 		BalancerConfig: &LBConfig{
 			Children: map[string]*Child{
-				"child-0": {Config: &internalserviceconfig.BalancerConfig{Name: fmt.Sprintf("%s-%d", initIDLEBalancerName, 0)}},
-				"child-1": {Config: &internalserviceconfig.BalancerConfig{Name: fmt.Sprintf("%s-%d", initIDLEBalancerName, 1)}},
+				"child-0": {Config: &internalserviceconfig.BalancerConfig{Name: fmt.Sprintf("%s-%d", initIdleBalancerName, 0)}},
+				"child-1": {Config: &internalserviceconfig.BalancerConfig{Name: fmt.Sprintf("%s-%d", initIdleBalancerName, 1)}},
 			},
 			Priorities: []string{"child-0", "child-1"},
 		},
@@ -1844,11 +1844,11 @@ func (s) TestPriority_HighPriorityInitIDLE(t *testing.T) {
 	}
 	sc0 := <-cc.NewSubConnCh
 
-	// Send an IDLE state update to trigger an IDLE picker update.
+	// Send an Idle state update to trigger an Idle picker update.
 	pb.UpdateSubConnState(sc0, balancer.SubConnState{ConnectivityState: connectivity.Idle})
 	p0 := <-cc.NewPickerCh
-	if pr, err := p0.Pick(balancer.PickInfo{}); err != errsTestInitIDLE[0] {
-		t.Fatalf("pick returned %v, %v, want _, %v", pr, err, errsTestInitIDLE[0])
+	if pr, err := p0.Pick(balancer.PickInfo{}); err != errsTestInitIdle[0] {
+		t.Fatalf("pick returned %v, %v, want _, %v", pr, err, errsTestInitIdle[0])
 	}
 
 	// Turn p0 down, to start p1.
@@ -1867,10 +1867,10 @@ func (s) TestPriority_HighPriorityInitIDLE(t *testing.T) {
 		t.Fatalf("sc is created with addr %v, want %v", got, want)
 	}
 	sc1 := <-cc.NewSubConnCh
-	// IDLE picker from p1 should also be forwarded.
+	// Idle picker from p1 should also be forwarded.
 	pb.UpdateSubConnState(sc1, balancer.SubConnState{ConnectivityState: connectivity.Idle})
 	p2 := <-cc.NewPickerCh
-	if pr, err := p2.Pick(balancer.PickInfo{}); err != errsTestInitIDLE[1] {
-		t.Fatalf("pick returned %v, %v, want _, %v", pr, err, errsTestInitIDLE[1])
+	if pr, err := p2.Pick(balancer.PickInfo{}); err != errsTestInitIdle[1] {
+		t.Fatalf("pick returned %v, %v, want _, %v", pr, err, errsTestInitIdle[1])
 	}
 }

--- a/xds/internal/balancer/priority/balancer_test.go
+++ b/xds/internal/balancer/priority/balancer_test.go
@@ -1778,3 +1778,99 @@ func (s) TestPriority_IgnoreReresolutionRequestTwoChildren(t *testing.T) {
 		t.Fatalf("timeout waiting for ResolveNow()")
 	}
 }
+
+const initIDLEBalancerName = "test-init-IDLE-balancer"
+
+var errsTestInitIDLE = []error{
+	fmt.Errorf("init IDLE balancer error 0"),
+	fmt.Errorf("init IDLE balancer error 1"),
+}
+
+func init() {
+	for i := 0; i < 2; i++ {
+		ii := i
+		stub.Register(fmt.Sprintf("%s-%d", initIDLEBalancerName, ii), stub.BalancerFuncs{
+			UpdateClientConnState: func(bd *stub.BalancerData, opts balancer.ClientConnState) error {
+				bd.ClientConn.NewSubConn(opts.ResolverState.Addresses, balancer.NewSubConnOptions{})
+				return nil
+			},
+			UpdateSubConnState: func(bd *stub.BalancerData, sc balancer.SubConn, state balancer.SubConnState) {
+				err := fmt.Errorf("wrong picker error")
+				if state.ConnectivityState == connectivity.Idle {
+					err = errsTestInitIDLE[ii]
+				}
+				bd.ClientConn.UpdateState(balancer.State{
+					ConnectivityState: state.ConnectivityState,
+					Picker:            &testutils.TestConstPicker{Err: err},
+				})
+			},
+		})
+	}
+}
+
+// If the high priorities send initial pickers with IDLE state, their pickers
+// should get picks, because policies like ringhash starts in IDLE, and doesn't
+// connect.
+//
+// Init 0, 1; 0 is IDLE, use 0; 0 is down, start 1; 1 is IDLE, use 1.
+func (s) TestPriority_HighPriorityInitIDLE(t *testing.T) {
+	cc := testutils.NewTestClientConn(t)
+	bb := balancer.Get(Name)
+	pb := bb.Build(cc, balancer.BuildOptions{})
+	defer pb.Close()
+
+	// Two children, with priorities [0, 1], each with one backend.
+	if err := pb.UpdateClientConnState(balancer.ClientConnState{
+		ResolverState: resolver.State{
+			Addresses: []resolver.Address{
+				hierarchy.Set(resolver.Address{Addr: testBackendAddrStrs[0]}, []string{"child-0"}),
+				hierarchy.Set(resolver.Address{Addr: testBackendAddrStrs[1]}, []string{"child-1"}),
+			},
+		},
+		BalancerConfig: &LBConfig{
+			Children: map[string]*Child{
+				"child-0": {Config: &internalserviceconfig.BalancerConfig{Name: fmt.Sprintf("%s-%d", initIDLEBalancerName, 0)}},
+				"child-1": {Config: &internalserviceconfig.BalancerConfig{Name: fmt.Sprintf("%s-%d", initIDLEBalancerName, 1)}},
+			},
+			Priorities: []string{"child-0", "child-1"},
+		},
+	}); err != nil {
+		t.Fatalf("failed to update ClientConn state: %v", err)
+	}
+
+	addrs0 := <-cc.NewSubConnAddrsCh
+	if got, want := addrs0[0].Addr, testBackendAddrStrs[0]; got != want {
+		t.Fatalf("sc is created with addr %v, want %v", got, want)
+	}
+	sc0 := <-cc.NewSubConnCh
+
+	// Send an IDLE state update to trigger an IDLE picker update.
+	pb.UpdateSubConnState(sc0, balancer.SubConnState{ConnectivityState: connectivity.Idle})
+	p0 := <-cc.NewPickerCh
+	if pr, err := p0.Pick(balancer.PickInfo{}); err != errsTestInitIDLE[0] {
+		t.Fatalf("pick returned %v, %v, want _, %v", pr, err, errsTestInitIDLE[0])
+	}
+
+	// Turn p0 down, to start p1.
+	pb.UpdateSubConnState(sc0, balancer.SubConnState{ConnectivityState: connectivity.TransientFailure})
+	// Before 1 gets READY, picker should return NoSubConnAvailable, so RPCs
+	// will retry.
+	p1 := <-cc.NewPickerCh
+	for i := 0; i < 5; i++ {
+		if _, err := p1.Pick(balancer.PickInfo{}); err != balancer.ErrNoSubConnAvailable {
+			t.Fatalf("want pick error %v, got %v", balancer.ErrNoSubConnAvailable, err)
+		}
+	}
+
+	addrs1 := <-cc.NewSubConnAddrsCh
+	if got, want := addrs1[0].Addr, testBackendAddrStrs[1]; got != want {
+		t.Fatalf("sc is created with addr %v, want %v", got, want)
+	}
+	sc1 := <-cc.NewSubConnCh
+	// IDLE picker from p1 should also be forwarded.
+	pb.UpdateSubConnState(sc1, balancer.SubConnState{ConnectivityState: connectivity.Idle})
+	p2 := <-cc.NewPickerCh
+	if pr, err := p2.Pick(balancer.PickInfo{}); err != errsTestInitIDLE[1] {
+		t.Fatalf("pick returned %v, %v, want _, %v", pr, err, errsTestInitIDLE[1])
+	}
+}


### PR DESCRIPTION
This is needed so that balancers start with an IDLE picker (like
ring_hash) will get picks.

RELEASE NOTES: N/A