### PR TITLE
xds/affinity: fix bugs in clusterresolver and xds-resolver

### DIFF
--- a/xds/internal/balancer/clusterresolver/config.go
+++ b/xds/internal/balancer/clusterresolver/config.go
@@ -23,8 +23,10 @@ import (
 	"fmt"
 	"strings"
 
+	"google.golang.org/grpc/balancer/roundrobin"
 	internalserviceconfig "google.golang.org/grpc/internal/serviceconfig"
 	"google.golang.org/grpc/serviceconfig"
+	"google.golang.org/grpc/xds/internal/balancer/ringhash"
 )
 
 // DiscoveryMechanismType is the type of discovery mechanism.
@@ -167,8 +169,8 @@ type LBConfig struct {
 }
 
 const (
-	rrName = "ROUND_ROBIN"
-	rhName = "RING_HASH"
+	rrName = roundrobin.Name
+	rhName = ringhash.Name
 )
 
 func parseConfig(c json.RawMessage) (*LBConfig, error) {

--- a/xds/internal/balancer/clusterresolver/config_test.go
+++ b/xds/internal/balancer/clusterresolver/config_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/grpc/internal/balancer/stub"
 	internalserviceconfig "google.golang.org/grpc/internal/serviceconfig"
+	"google.golang.org/grpc/xds/internal/balancer/ringhash"
 )
 
 func TestDiscoveryMechanismTypeMarshalJSON(t *testing.T) {
@@ -136,7 +137,7 @@ const (
     "type": "EDS",
     "edsServiceName": "test-eds-service-name"
   }],
-  "xdsLbPolicy":[{"RING_HASH":{}}]
+  "xdsLbPolicy":[{"ring_hash_experimental":{}}]
 }`
 	testJSONConfig5 = `{
   "discoveryMechanisms": [{
@@ -234,7 +235,7 @@ func TestParseConfig(t *testing.T) {
 					},
 				},
 				XDSLBPolicy: &internalserviceconfig.BalancerConfig{
-					Name:   "RING_HASH",
+					Name:   ringhash.Name,
 					Config: nil,
 				},
 			},

--- a/xds/internal/resolver/serviceconfig.go
+++ b/xds/internal/resolver/serviceconfig.go
@@ -226,7 +226,7 @@ func (cs *configSelector) generateHash(rpcInfo iresolver.RPCInfo, hashPolicies [
 		var generatedPolicyHash bool
 		switch policy.HashPolicyType {
 		case xdsclient.HashPolicyTypeHeader:
-			md, ok := metadata.FromIncomingContext(rpcInfo.Context)
+			md, ok := metadata.FromOutgoingContext(rpcInfo.Context)
 			if !ok {
 				continue
 			}

--- a/xds/internal/resolver/serviceconfig_test.go
+++ b/xds/internal/resolver/serviceconfig_test.go
@@ -73,7 +73,7 @@ func (s) TestGenerateRequestHash(t *testing.T) {
 			}},
 			requestHashWant: xxhash.Sum64String("/new-products"),
 			rpcInfo: iresolver.RPCInfo{
-				Context: metadata.NewIncomingContext(context.Background(), metadata.Pairs(":path", "/products")),
+				Context: metadata.NewOutgoingContext(context.Background(), metadata.Pairs(":path", "/products")),
 				Method:  "/some-method",
 			},
 		},
@@ -101,7 +101,7 @@ func (s) TestGenerateRequestHash(t *testing.T) {
 			}},
 			requestHashWant: xxhash.Sum64String("eaebece"),
 			rpcInfo: iresolver.RPCInfo{
-				Context: metadata.NewIncomingContext(context.Background(), metadata.Pairs(":path", "abc")),
+				Context: metadata.NewOutgoingContext(context.Background(), metadata.Pairs(":path", "abc")),
 				Method:  "/some-method",
 			},
 		},

--- a/xds/internal/resolver/xds_resolver_test.go
+++ b/xds/internal/resolver/xds_resolver_test.go
@@ -510,7 +510,7 @@ func (s) TestXDSResolverRequestHash(t *testing.T) {
 	}
 	// Selecting a config when there was a hash policy specified in the route
 	// that will be selected should put a request hash in the config's context.
-	res, err := cs.SelectConfig(iresolver.RPCInfo{Context: metadata.NewIncomingContext(context.Background(), metadata.Pairs(":path", "/products"))})
+	res, err := cs.SelectConfig(iresolver.RPCInfo{Context: metadata.NewOutgoingContext(context.Background(), metadata.Pairs(":path", "/products"))})
 	if err != nil {
 		t.Fatalf("Unexpected error from cs.SelectConfig(_): %v", err)
 	}


### PR DESCRIPTION
Found by interop tests.

clusterresolver
 - use real balancer names

xds-resolver
 - s/`FromIncomingContext`/`FromOutgoingContext`

RELEASE NOTES: N/A