### PR TITLE
server: optimize chain interceptors (-1 allocation, -10% time/call)

### DIFF
--- a/server.go
+++ b/server.go
@@ -1101,16 +1101,21 @@ func chainUnaryServerInterceptors(s *Server) {
 
 func chainUnaryInterceptors(interceptors []UnaryServerInterceptor) UnaryServerInterceptor {
 	return func(ctx context.Context, req interface{}, info *UnaryServerInfo, handler UnaryHandler) (interface{}, error) {
-		var i int
-		var next UnaryHandler
-		next = func(ctx context.Context, req interface{}) (interface{}, error) {
-			if i == len(interceptors)-1 {
-				return interceptors[i](ctx, req, info, handler)
-			}
-			i++
-			return interceptors[i-1](ctx, req, info, next)
+		// the struct ensures the variables are allocated together, rather than separately, since we
+		// know they should be garbage collected together. This saves 1 allocation and decreases
+		// time/call by about 10% on the microbenchmark.
+		var state struct {
+			i    int
+			next UnaryHandler
 		}
-		return next(ctx, req)
+		state.next = func(ctx context.Context, req interface{}) (interface{}, error) {
+			if state.i == len(interceptors)-1 {
+				return interceptors[state.i](ctx, req, info, handler)
+			}
+			state.i++
+			return interceptors[state.i-1](ctx, req, info, state.next)
+		}
+		return state.next(ctx, req)
 	}
 }
 
@@ -1386,16 +1391,21 @@ func chainStreamServerInterceptors(s *Server) {
 
 func chainStreamInterceptors(interceptors []StreamServerInterceptor) StreamServerInterceptor {
 	return func(srv interface{}, ss ServerStream, info *StreamServerInfo, handler StreamHandler) error {
-		var i int
-		var next StreamHandler
-		next = func(srv interface{}, ss ServerStream) error {
-			if i == len(interceptors)-1 {
-				return interceptors[i](srv, ss, info, handler)
-			}
-			i++
-			return interceptors[i-1](srv, ss, info, next)
+		// the struct ensures the variables are allocated together, rather than separately, since we
+		// know they should be garbage collected together. This saves 1 allocation and decreases
+		// time/call by about 10% on the microbenchmark.
+		var state struct {
+			i    int
+			next StreamHandler
 		}
-		return next(srv, ss)
+		state.next = func(srv interface{}, ss ServerStream) error {
+			if state.i == len(interceptors)-1 {
+				return interceptors[state.i](srv, ss, info, handler)
+			}
+			state.i++
+			return interceptors[state.i-1](srv, ss, info, state.next)
+		}
+		return state.next(srv, ss)
 	}
 }
 


### PR DESCRIPTION
Removes one allocation from the unary and stream chained interceptors
by combining them into a struct. This saves about 10% time/call on
the microbenchmark (see below).

The unary and stream chain interceptors must allocate on each call to
track the current position in the interceptor stack, and to create
the closure. By default, Go allocates each variable in a closure in a
separate heap allocation, so they can be garbage collected
independently. However, we know the index and next handler callbacks
should be garbage collected together, so we can force them to be
allocated together by combining them in a struct.

The benchmark results on my laptop are below:

BEFORE

```
$ go test . -bench=BenchmarkChain -benchtime=10s -benchmem -run=none
goos: darwin
goarch: amd64
pkg: google.golang.org/grpc
cpu: Intel(R) Core(TM) i7-8569U CPU @ 2.80GHz
BenchmarkChainUnaryInterceptor/1-8    1000000000       2.496 ns/op        0 B/op        0 allocs/op
BenchmarkChainUnaryInterceptor/3-8     429451994       83.81 ns/op       80 B/op        3 allocs/op
BenchmarkChainUnaryInterceptor/5-8     373575196       93.27 ns/op       80 B/op        3 allocs/op
BenchmarkChainUnaryInterceptor/10-8    319072203       114.9 ns/op       80 B/op        3 allocs/op

BenchmarkChainStreamInterceptor/1-8   1000000000       3.309 ns/op        0 B/op        0 allocs/op
BenchmarkChainStreamInterceptor/3-8    126448209       95.44 ns/op       80 B/op        3 allocs/op
BenchmarkChainStreamInterceptor/5-8    100000000       107.4 ns/op       80 B/op        3 allocs/op
BenchmarkChainStreamInterceptor/10-8    87687106       130.0 ns/op       80 B/op        3 allocs/op
```

AFTER

```
BenchmarkChainUnaryInterceptor/1-8    1000000000       2.490 ns/op        0 B/op        0 allocs/op
BenchmarkChainUnaryInterceptor/3-8     171483990       71.20 ns/op       80 B/op        2 allocs/op
BenchmarkChainUnaryInterceptor/5-8     152261647       81.86 ns/op       80 B/op        2 allocs/op
BenchmarkChainUnaryInterceptor/10-8    120358930       99.78 ns/op       80 B/op        2 allocs/op

BenchmarkChainStreamInterceptor/1-8   1000000000       2.938 ns/op        0 B/op        0 allocs/op
BenchmarkChainStreamInterceptor/3-8    161130258       74.99 ns/op       80 B/op        2 allocs/op
BenchmarkChainStreamInterceptor/5-8    138256909       83.65 ns/op       80 B/op        2 allocs/op
BenchmarkChainStreamInterceptor/10-8   120324680       100.7 ns/op       80 B/op        2 allocs/op
```

RELEASE NOTES: none