### PR TITLE
xds: support new fields to fetch security configuration

### DIFF
--- a/xds/internal/xdsclient/cds_test.go
+++ b/xds/internal/xdsclient/cds_test.go
@@ -727,6 +727,43 @@ func (s) TestValidateClusterWithSecurityConfig(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "invalid-regex-in-matching-SAN-with-new-fields",
+			cluster: &v3clusterpb.Cluster{
+				ClusterDiscoveryType: &v3clusterpb.Cluster_Type{Type: v3clusterpb.Cluster_EDS},
+				EdsClusterConfig: &v3clusterpb.Cluster_EdsClusterConfig{
+					EdsConfig: &v3corepb.ConfigSource{
+						ConfigSourceSpecifier: &v3corepb.ConfigSource_Ads{
+							Ads: &v3corepb.AggregatedConfigSource{},
+						},
+					},
+					ServiceName: serviceName,
+				},
+				LbPolicy: v3clusterpb.Cluster_ROUND_ROBIN,
+				TransportSocket: &v3corepb.TransportSocket{
+					ConfigType: &v3corepb.TransportSocket_TypedConfig{
+						TypedConfig: testutils.MarshalAny(&v3tlspb.UpstreamTlsContext{
+							CommonTlsContext: &v3tlspb.CommonTlsContext{
+								ValidationContextType: &v3tlspb.CommonTlsContext_CombinedValidationContext{
+									CombinedValidationContext: &v3tlspb.CommonTlsContext_CombinedCertificateValidationContext{
+										DefaultValidationContext: &v3tlspb.CertificateValidationContext{
+											MatchSubjectAltNames: []*v3matcherpb.StringMatcher{
+												{MatchPattern: &v3matcherpb.StringMatcher_SafeRegex{SafeRegex: &v3matcherpb.RegexMatcher{Regex: sanRegexBad}}},
+											},
+											CaCertificateProviderInstance: &v3tlspb.CertificateProviderPluginInstance{
+												InstanceName:    rootPluginInstance,
+												CertificateName: rootCertName,
+											},
+										},
+									},
+								},
+							},
+						}),
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
 			name: "happy-case-with-no-identity-certs-using-deprecated-fields",
 			cluster: &v3clusterpb.Cluster{
 				Name:                 clusterName,

--- a/xds/internal/xdsclient/client.go
+++ b/xds/internal/xdsclient/client.go
@@ -425,6 +425,38 @@ type SecurityConfig struct {
 	RequireClientCert bool
 }
 
+// Equal returns true if sc is equal to other.
+func (sc *SecurityConfig) Equal(other *SecurityConfig) bool {
+	switch {
+	case sc == nil && other == nil:
+		return true
+	case (sc != nil) != (other != nil):
+		return false
+	}
+	switch {
+	case sc.RootInstanceName != other.RootInstanceName:
+		return false
+	case sc.RootCertName != other.RootCertName:
+		return false
+	case sc.IdentityInstanceName != other.IdentityInstanceName:
+		return false
+	case sc.IdentityCertName != other.IdentityCertName:
+		return false
+	case sc.RequireClientCert != other.RequireClientCert:
+		return false
+	default:
+		if len(sc.SubjectAltNameMatchers) != len(other.SubjectAltNameMatchers) {
+			return false
+		}
+		for i := 0; i < len(sc.SubjectAltNameMatchers); i++ {
+			if !sc.SubjectAltNameMatchers[i].Equal(other.SubjectAltNameMatchers[i]) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
 // ClusterType is the type of cluster from a received CDS response.
 type ClusterType int
 

--- a/xds/internal/xdsclient/lds_test.go
+++ b/xds/internal/xdsclient/lds_test.go
@@ -658,7 +658,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 				},
 			},
 		})
-		listenerNoValidationContext = testutils.MarshalAny(&v3listenerpb.Listener{
+		listenerNoValidationContextDeprecatedFields = testutils.MarshalAny(&v3listenerpb.Listener{
 			Name:    v3LDSTarget,
 			Address: localSocketAddress,
 			FilterChains: []*v3listenerpb.FilterChain{
@@ -698,7 +698,47 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 				},
 			},
 		})
-		listenerWithValidationContext = testutils.MarshalAny(&v3listenerpb.Listener{
+		listenerNoValidationContextNewFields = testutils.MarshalAny(&v3listenerpb.Listener{
+			Name:    v3LDSTarget,
+			Address: localSocketAddress,
+			FilterChains: []*v3listenerpb.FilterChain{
+				{
+					Name:    "filter-chain-1",
+					Filters: emptyValidNetworkFilters,
+					TransportSocket: &v3corepb.TransportSocket{
+						Name: "envoy.transport_sockets.tls",
+						ConfigType: &v3corepb.TransportSocket_TypedConfig{
+							TypedConfig: testutils.MarshalAny(&v3tlspb.DownstreamTlsContext{
+								CommonTlsContext: &v3tlspb.CommonTlsContext{
+									TlsCertificateProviderInstance: &v3tlspb.CertificateProviderPluginInstance{
+										InstanceName:    "identityPluginInstance",
+										CertificateName: "identityCertName",
+									},
+								},
+							}),
+						},
+					},
+				},
+			},
+			DefaultFilterChain: &v3listenerpb.FilterChain{
+				Name:    "default-filter-chain-1",
+				Filters: emptyValidNetworkFilters,
+				TransportSocket: &v3corepb.TransportSocket{
+					Name: "envoy.transport_sockets.tls",
+					ConfigType: &v3corepb.TransportSocket_TypedConfig{
+						TypedConfig: testutils.MarshalAny(&v3tlspb.DownstreamTlsContext{
+							CommonTlsContext: &v3tlspb.CommonTlsContext{
+								TlsCertificateProviderInstance: &v3tlspb.CertificateProviderPluginInstance{
+									InstanceName:    "defaultIdentityPluginInstance",
+									CertificateName: "defaultIdentityCertName",
+								},
+							},
+						}),
+					},
+				},
+			},
+		})
+		listenerWithValidationContextDeprecatedFields = testutils.MarshalAny(&v3listenerpb.Listener{
 			Name:    v3LDSTarget,
 			Address: localSocketAddress,
 			FilterChains: []*v3listenerpb.FilterChain{
@@ -744,6 +784,66 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 									ValidationContextCertificateProviderInstance: &v3tlspb.CommonTlsContext_CertificateProviderInstance{
 										InstanceName:    "defaultRootPluginInstance",
 										CertificateName: "defaultRootCertName",
+									},
+								},
+							},
+						}),
+					},
+				},
+			},
+		})
+		listenerWithValidationContextNewFields = testutils.MarshalAny(&v3listenerpb.Listener{
+			Name:    v3LDSTarget,
+			Address: localSocketAddress,
+			FilterChains: []*v3listenerpb.FilterChain{
+				{
+					Name:    "filter-chain-1",
+					Filters: emptyValidNetworkFilters,
+					TransportSocket: &v3corepb.TransportSocket{
+						Name: "envoy.transport_sockets.tls",
+						ConfigType: &v3corepb.TransportSocket_TypedConfig{
+							TypedConfig: testutils.MarshalAny(&v3tlspb.DownstreamTlsContext{
+								RequireClientCertificate: &wrapperspb.BoolValue{Value: true},
+								CommonTlsContext: &v3tlspb.CommonTlsContext{
+									TlsCertificateProviderInstance: &v3tlspb.CertificateProviderPluginInstance{
+										InstanceName:    "identityPluginInstance",
+										CertificateName: "identityCertName",
+									},
+									ValidationContextType: &v3tlspb.CommonTlsContext_ValidationContext{
+										ValidationContext: &v3tlspb.CertificateValidationContext{
+											CaCertificateProviderInstance: &v3tlspb.CertificateProviderPluginInstance{
+												InstanceName:    "rootPluginInstance",
+												CertificateName: "rootCertName",
+											},
+										},
+									},
+								},
+							}),
+						},
+					},
+				},
+			},
+			DefaultFilterChain: &v3listenerpb.FilterChain{
+				Name:    "default-filter-chain-1",
+				Filters: emptyValidNetworkFilters,
+				TransportSocket: &v3corepb.TransportSocket{
+					Name: "envoy.transport_sockets.tls",
+					ConfigType: &v3corepb.TransportSocket_TypedConfig{
+						TypedConfig: testutils.MarshalAny(&v3tlspb.DownstreamTlsContext{
+							RequireClientCertificate: &wrapperspb.BoolValue{Value: true},
+							CommonTlsContext: &v3tlspb.CommonTlsContext{
+								TlsCertificateProviderInstance: &v3tlspb.CertificateProviderPluginInstance{
+									InstanceName:    "defaultIdentityPluginInstance",
+									CertificateName: "defaultIdentityCertName",
+								},
+								ValidationContextType: &v3tlspb.CommonTlsContext_CombinedValidationContext{
+									CombinedValidationContext: &v3tlspb.CommonTlsContext_CombinedCertificateValidationContext{
+										DefaultValidationContext: &v3tlspb.CertificateValidationContext{
+											CaCertificateProviderInstance: &v3tlspb.CertificateProviderPluginInstance{
+												InstanceName:    "defaultRootPluginInstance",
+												CertificateName: "defaultRootCertName",
+											},
+										},
 									},
 								},
 							},
@@ -1233,7 +1333,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 			},
 		},
 		{
-			name: "no identity and root certificate providers",
+			name: "no identity and root certificate providers using deprecated fields",
 			resources: []*anypb.Any{testutils.MarshalAny(&v3listenerpb.Listener{
 				Name:    v3LDSTarget,
 				Address: localSocketAddress,
@@ -1248,6 +1348,36 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 									RequireClientCertificate: &wrapperspb.BoolValue{Value: true},
 									CommonTlsContext: &v3tlspb.CommonTlsContext{
 										TlsCertificateCertificateProviderInstance: &v3tlspb.CommonTlsContext_CertificateProviderInstance{
+											InstanceName:    "identityPluginInstance",
+											CertificateName: "identityCertName",
+										},
+									},
+								}),
+							},
+						},
+					},
+				},
+			})},
+			wantUpdate: map[string]ListenerUpdate{v3LDSTarget: {}},
+			wantMD:     errMD,
+			wantErr:    "security configuration on the server-side does not contain root certificate provider instance name, but require_client_cert field is set",
+		},
+		{
+			name: "no identity and root certificate providers using new fields",
+			resources: []*anypb.Any{testutils.MarshalAny(&v3listenerpb.Listener{
+				Name:    v3LDSTarget,
+				Address: localSocketAddress,
+				FilterChains: []*v3listenerpb.FilterChain{
+					{
+						Name:    "filter-chain-1",
+						Filters: emptyValidNetworkFilters,
+						TransportSocket: &v3corepb.TransportSocket{
+							Name: "envoy.transport_sockets.tls",
+							ConfigType: &v3corepb.TransportSocket_TypedConfig{
+								TypedConfig: testutils.MarshalAny(&v3tlspb.DownstreamTlsContext{
+									RequireClientCertificate: &wrapperspb.BoolValue{Value: true},
+									CommonTlsContext: &v3tlspb.CommonTlsContext{
+										TlsCertificateProviderInstance: &v3tlspb.CertificateProviderPluginInstance{
 											InstanceName:    "identityPluginInstance",
 											CertificateName: "identityCertName",
 										},
@@ -1287,8 +1417,8 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 			wantErr:    "security configuration on the server-side does not contain identity certificate provider instance name",
 		},
 		{
-			name:      "happy case with no validation context",
-			resources: []*anypb.Any{listenerNoValidationContext},
+			name:      "happy case with no validation context using deprecated fields",
+			resources: []*anypb.Any{listenerNoValidationContextDeprecatedFields},
 			wantUpdate: map[string]ListenerUpdate{
 				v3LDSTarget: {
 					InboundListenerCfg: &InboundListenerConfig{
@@ -1327,7 +1457,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 							},
 						},
 					},
-					Raw: listenerNoValidationContext,
+					Raw: listenerNoValidationContextDeprecatedFields,
 				},
 			},
 			wantMD: UpdateMetadata{
@@ -1336,8 +1466,57 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 			},
 		},
 		{
-			name:      "happy case with validation context provider instance",
-			resources: []*anypb.Any{listenerWithValidationContext},
+			name:      "happy case with no validation context using new fields",
+			resources: []*anypb.Any{listenerNoValidationContextNewFields},
+			wantUpdate: map[string]ListenerUpdate{
+				v3LDSTarget: {
+					InboundListenerCfg: &InboundListenerConfig{
+						Address: "0.0.0.0",
+						Port:    "9999",
+						FilterChains: &FilterChainManager{
+							dstPrefixMap: map[string]*destPrefixEntry{
+								unspecifiedPrefixMapKey: {
+									srcTypeArr: [3]*sourcePrefixes{
+										{
+											srcPrefixMap: map[string]*sourcePrefixEntry{
+												unspecifiedPrefixMapKey: {
+													srcPortMap: map[int]*FilterChain{
+														0: {
+															SecurityCfg: &SecurityConfig{
+																IdentityInstanceName: "identityPluginInstance",
+																IdentityCertName:     "identityCertName",
+															},
+															InlineRouteConfig: inlineRouteConfig,
+															HTTPFilters:       routerFilterList,
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+							def: &FilterChain{
+								SecurityCfg: &SecurityConfig{
+									IdentityInstanceName: "defaultIdentityPluginInstance",
+									IdentityCertName:     "defaultIdentityCertName",
+								},
+								InlineRouteConfig: inlineRouteConfig,
+								HTTPFilters:       routerFilterList,
+							},
+						},
+					},
+					Raw: listenerNoValidationContextNewFields,
+				},
+			},
+			wantMD: UpdateMetadata{
+				Status:  ServiceStatusACKed,
+				Version: testVersion,
+			},
+		},
+		{
+			name:      "happy case with validation context provider instance with deprecated fields",
+			resources: []*anypb.Any{listenerWithValidationContextDeprecatedFields},
 			wantUpdate: map[string]ListenerUpdate{
 				v3LDSTarget: {
 					InboundListenerCfg: &InboundListenerConfig{
@@ -1382,7 +1561,62 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 							},
 						},
 					},
-					Raw: listenerWithValidationContext,
+					Raw: listenerWithValidationContextDeprecatedFields,
+				},
+			},
+			wantMD: UpdateMetadata{
+				Status:  ServiceStatusACKed,
+				Version: testVersion,
+			},
+		},
+		{
+			name:      "happy case with validation context provider instance with new fields",
+			resources: []*anypb.Any{listenerWithValidationContextNewFields},
+			wantUpdate: map[string]ListenerUpdate{
+				v3LDSTarget: {
+					InboundListenerCfg: &InboundListenerConfig{
+						Address: "0.0.0.0",
+						Port:    "9999",
+						FilterChains: &FilterChainManager{
+							dstPrefixMap: map[string]*destPrefixEntry{
+								unspecifiedPrefixMapKey: {
+									srcTypeArr: [3]*sourcePrefixes{
+										{
+											srcPrefixMap: map[string]*sourcePrefixEntry{
+												unspecifiedPrefixMapKey: {
+													srcPortMap: map[int]*FilterChain{
+														0: {
+															SecurityCfg: &SecurityConfig{
+																RootInstanceName:     "rootPluginInstance",
+																RootCertName:         "rootCertName",
+																IdentityInstanceName: "identityPluginInstance",
+																IdentityCertName:     "identityCertName",
+																RequireClientCert:    true,
+															},
+															InlineRouteConfig: inlineRouteConfig,
+															HTTPFilters:       routerFilterList,
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+							def: &FilterChain{
+								SecurityCfg: &SecurityConfig{
+									RootInstanceName:     "defaultRootPluginInstance",
+									RootCertName:         "defaultRootCertName",
+									IdentityInstanceName: "defaultIdentityPluginInstance",
+									IdentityCertName:     "defaultIdentityCertName",
+									RequireClientCert:    true,
+								},
+								InlineRouteConfig: inlineRouteConfig,
+								HTTPFilters:       routerFilterList,
+							},
+						},
+					},
+					Raw: listenerWithValidationContextNewFields,
 				},
 			},
 			wantMD: UpdateMetadata{


### PR DESCRIPTION
The new method is documented at https://github.com/grpc/proposal/blob/master/A29-xds-tls-security.md and based on envoyproxy/envoy#17201. The old fields are still supported and are used as fallback when the new fields don't provide the required data.

TL;dr
- Identity certs used to be fetched from the `tls_certificate_certificate_provider_instance` field [here](https://github.com/envoyproxy/envoy/blob/ff68b337d038acccb770fcceec57441cf0c740e2/api/envoy/extensions/transport_sockets/tls/v3/tls.proto#L256).
  - Going forward, they will be fetched from the `tls_certificate_provider_instance` field [here](https://github.com/envoyproxy/envoy/blob/ff68b337d038acccb770fcceec57441cf0c740e2/api/envoy/extensions/transport_sockets/tls/v3/tls.proto#L247).
- Validation context used to be fetched from `validation_context_certificate_provider_instance` field [here](https://github.com/envoyproxy/envoy/blob/ff68b337d038acccb770fcceec57441cf0c740e2/api/envoy/extensions/transport_sockets/tls/v3/tls.proto#L283) or from the `validation_context_certificate_provider_instance` field of `CombinedCertificateValidationContext` [here](https://github.com/envoyproxy/envoy/blob/ff68b337d038acccb770fcceec57441cf0c740e2/api/envoy/extensions/transport_sockets/tls/v3/tls.proto#L205)
  - Going forward, they will be fetched from the `ca_certificate_provider_instance` field of `CertificateValidationContext` [here](https://github.com/envoyproxy/envoy/blob/ff68b337d038acccb770fcceec57441cf0c740e2/api/envoy/extensions/transport_sockets/tls/v3/common.proto#L315)
  - The `CertificateValidationContext` can be fetched either from the `validation_context` field of the `validation_context_type` oneof [here](https://github.com/envoyproxy/envoy/blob/ff68b337d038acccb770fcceec57441cf0c740e2/api/envoy/extensions/transport_sockets/tls/v3/tls.proto#L261) or from the `default_validation_context` field of the `combined_validation_context` [here](https://github.com/envoyproxy/envoy/blob/ff68b337d038acccb770fcceec57441cf0c740e2/api/envoy/extensions/transport_sockets/tls/v3/tls.proto#L188).


RELEASE NOTES:
- Support fetching of security configuration from newly added fields in envoyproxy/envoy#17201