### PR TITLE
create Status.ValidDetails method to ignore unmarshaling errors

### DIFF
--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -136,6 +136,23 @@ func (s *Status) Details() []interface{} {
 	return details
 }
 
+// ValidDetails returns a slice of details messages attached to the status.
+// If a detail cannot be decoded, it is omitted from the returned slice and
+// the corresponding error is ignored.
+func (s *Status) ValidDetails() []proto.Message {
+	if s == nil || s.s == nil {
+		return nil
+	}
+	details := make([]proto.Message, 0, len(s.s.Details))
+	for _, any := range s.s.Details {
+		detail := &ptypes.DynamicAny{}
+		if err := ptypes.UnmarshalAny(any, detail); err == nil {
+			details = append(details, detail.Message)
+		}
+	}
+	return details
+}
+
 func (s *Status) String() string {
 	return fmt.Sprintf("rpc error: code = %s desc = %s", s.Code(), s.Message())
 }


### PR DESCRIPTION
My team has found it difficult to work with:
```
func (s *Status) Details() []interface{} {
```

I've read over the discussion at:
https://github.com/grpc/grpc-go/pull/1358#discussion_r128062950 

And decided to implement a `ValidDetails()` method, as suggested here:
https://github.com/grpc/grpc-go/pull/1358#discussion_r128559423

-----------

More concretely, we want to easily be able to deconstruct and reconstruct `Status` structs.

Currently, this isn't very clean:
After calling `Details()`, one needs to iterate through the returned `[]interface{}`, remove any errors, and cast any non-errors to a proto message. 

Type-asserting on errors and filtering them out isn't really an issue. What I don't like is that I need to import
`"github.com/golang/protobuf/proto" //nolint: staticcheck`
and add it to my dependencies. Additionally, the `proto` library used here is "deprecated", and importing it causes the linter to fail.

-----

With the addition of the `ValidDetails()` method, going reconstructing `Status` structs is a lot cleaner, and doesn't require the `proto` import. E.g.


Before:
```
details := status1.Details()
validDetails := make([]proto.Message, 0, len(details))

for _, detail := range details {
  if _, ok := detail.(error); !ok {
    detailsOnly = append(detailsOnly, proto.MessageV1(detail))
  }
}
status2.WithDetails(validDetails...)

```

After:
```
status2.WithDetails(status1.ValidDetails()...)
```

------

Open Question:

Should there be any sort of signal that `ValidDetails` encountered an error? such as 
```
func (s *Status) ValidDetails() ([]proto.Message, bool) {
```

I've found that the actual error(s) aren't actually useful. In practice I only expect it to happen when theres a proto file mis-match between upstream and downstream. So I really just want to know if there was a mis match or not.

However, I felt the above API was a bit odd, so I left it as 

```
func (s *Status) ValidDetails() []proto.Message {
```