### PR TITLE
balancer: fix aggregated state to not report idle with zero subconns

### DIFF
--- a/balancer/base/balancer.go
+++ b/balancer/base/balancer.go
@@ -214,10 +214,14 @@ func (b *baseBalancer) UpdateSubConnState(sc balancer.SubConn, state balancer.Su
 		}
 		return
 	}
-	if oldS == connectivity.TransientFailure && s == connectivity.Connecting {
-		// Once a subconn enters TRANSIENT_FAILURE, ignore subsequent
+	if oldS == connectivity.TransientFailure &&
+		(s == connectivity.Connecting || s == connectivity.Idle) {
+		// Once a subconn enters TRANSIENT_FAILURE, ignore subsequent IDLE or
 		// CONNECTING transitions to prevent the aggregated state from being
 		// always CONNECTING when many backends exist but are all down.
+		if s == connectivity.Idle {
+			sc.Connect()
+		}
 		return
 	}
 	b.scStates[sc] = s

--- a/balancer/base/balancer.go
+++ b/balancer/base/balancer.go
@@ -133,6 +133,7 @@ func (b *baseBalancer) UpdateClientConnState(s balancer.ClientConnState) error {
 			}
 			b.subConns[aNoAttrs] = subConnInfo{subConn: sc, attrs: a.Attributes}
 			b.scStates[sc] = connectivity.Idle
+			b.csEvltr.RecordTransition(connectivity.Shutdown, connectivity.Idle)
 			sc.Connect()
 		} else {
 			// Always update the subconn's address in case the attributes
@@ -242,7 +243,6 @@ func (b *baseBalancer) UpdateSubConnState(sc balancer.SubConn, state balancer.Su
 		b.state == connectivity.TransientFailure {
 		b.regeneratePicker()
 	}
-
 	b.cc.UpdateState(balancer.State{ConnectivityState: b.state, Picker: b.picker})
 }
 

--- a/balancer/roundrobin/roundrobin.go
+++ b/balancer/roundrobin/roundrobin.go
@@ -47,7 +47,7 @@ func init() {
 type rrPickerBuilder struct{}
 
 func (*rrPickerBuilder) Build(info base.PickerBuildInfo) balancer.Picker {
-	logger.Infof("roundrobinPicker: newPicker called with info: %v", info)
+	logger.Infof("roundrobinPicker: Build called with info: %v", info)
 	if len(info.ReadySCs) == 0 {
 		return base.NewErrPicker(balancer.ErrNoSubConnAvailable)
 	}


### PR DESCRIPTION
Generally, channels with zero subconns are not usable and should report `TransientFailure`.  This matches previous behavior before Idle support.

Also fix a bug that the base balancer was not accounting for newly created subchannels' idleness.  When the first subchannel transitioned from Idle to Connecting, the number of idle subconns would become `MaxUInt64` due to underflow.

Finally, fix another idleness bug that broke the logic of "stick transient failure" where a subconn that goes to TransientFailure should stay in that state until it goes Ready or Shutdown.

Fixes #4740

(No release notes since this fixes a regression introduced after the last release.)

RELEASE NOTES: none