### PR TITLE
xds: validations for security config, as specified in A29

### DIFF
--- a/xds/internal/xdsclient/cds_test.go
+++ b/xds/internal/xdsclient/cds_test.go
@@ -634,7 +634,7 @@ func (s) TestSecurityConfigFromCommonTLSContextUsingNewFields_ErrorCases(t *test
 				},
 			},
 			server:  true,
-			wantErr: "match_subject_alt_names field in validation context is not on the server",
+			wantErr: "match_subject_alt_names field in validation context is not supported on the server",
 		},
 	}
 

--- a/xds/internal/xdsclient/cds_test.go
+++ b/xds/internal/xdsclient/cds_test.go
@@ -642,7 +642,7 @@ func (s) TestSecurityConfigFromCommonTLSContextUsingNewFields_ErrorCases(t *test
 		t.Run(test.name, func(t *testing.T) {
 			_, err := securityConfigFromCommonTLSContextUsingNewFields(test.common, test.server)
 			if err == nil {
-				t.Fatal("securityConfigFromCommonTLSContextUsingNewFields() succeded when expected to fail")
+				t.Fatal("securityConfigFromCommonTLSContextUsingNewFields() succeeded when expected to fail")
 			}
 			if !strings.Contains(err.Error(), test.wantErr) {
 				t.Fatalf("securityConfigFromCommonTLSContextUsingNewFields() returned err: %v, wantErr: %v", err, test.wantErr)

--- a/xds/internal/xdsclient/filter_chain.go
+++ b/xds/internal/xdsclient/filter_chain.go
@@ -519,7 +519,7 @@ func (fci *FilterChainManager) filterChainFromProto(fc *v3listenerpb.FilterChain
 	if err := proto.Unmarshal(any.GetValue(), downstreamCtx); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal DownstreamTlsContext in LDS response: %v", err)
 	}
-	if downstreamCtx.GetRequireSni().GetValue() == true {
+	if downstreamCtx.GetRequireSni().GetValue() {
 		return nil, fmt.Errorf("require_sni field set to true in DownstreamTlsContext message: %v", downstreamCtx)
 	}
 	if downstreamCtx.GetOcspStaplePolicy() != v3tlspb.DownstreamTlsContext_LENIENT_STAPLING {

--- a/xds/internal/xdsclient/filter_chain.go
+++ b/xds/internal/xdsclient/filter_chain.go
@@ -519,6 +519,17 @@ func (fci *FilterChainManager) filterChainFromProto(fc *v3listenerpb.FilterChain
 	if err := proto.Unmarshal(any.GetValue(), downstreamCtx); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal DownstreamTlsContext in LDS response: %v", err)
 	}
+	if downstreamCtx.GetRequireSni().GetValue() == true {
+		return nil, fmt.Errorf("require_sni field set to true in DownstreamTlsContext message: %v", downstreamCtx)
+	}
+	if downstreamCtx.GetOcspStaplePolicy() != v3tlspb.DownstreamTlsContext_LENIENT_STAPLING {
+		return nil, fmt.Errorf("ocsp_staple_policy field set to unsupported value in DownstreamTlsContext message: %v", downstreamCtx)
+	}
+	// The following fields from `DownstreamTlsContext` are ignore:
+	// - disable_stateless_session_resumption
+	// - session_ticket_keys
+	// - session_ticket_keys_sds_secret_config
+	// - session_timeout
 	if downstreamCtx.GetCommonTlsContext() == nil {
 		return nil, errors.New("DownstreamTlsContext in LDS response does not contain a CommonTlsContext")
 	}

--- a/xds/internal/xdsclient/xds.go
+++ b/xds/internal/xdsclient/xds.go
@@ -897,7 +897,7 @@ func securityConfigFromCommonTLSContextWithDeprecatedFields(common *v3tlspb.Comm
 			}
 		}
 		if server && len(matchers) != 0 {
-			return nil, fmt.Errorf("match_subject_alt_names field in validation context is not on the server: %v", common)
+			return nil, fmt.Errorf("match_subject_alt_names field in validation context is not supported on the server: %v", common)
 		}
 		sc.SubjectAltNameMatchers = matchers
 		if pi := combined.GetValidationContextCertificateProviderInstance(); pi != nil {
@@ -1014,7 +1014,7 @@ func securityConfigFromCommonTLSContextUsingNewFields(common *v3tlspb.CommonTlsC
 		matchers = append(matchers, matcher)
 	}
 	if server && len(matchers) != 0 {
-		return nil, fmt.Errorf("match_subject_alt_names field in validation context is not on the server: %v", common)
+		return nil, fmt.Errorf("match_subject_alt_names field in validation context is not supported on the server: %v", common)
 	}
 	sc.SubjectAltNameMatchers = matchers
 	return sc, nil

--- a/xds/internal/xdsclient/xds.go
+++ b/xds/internal/xdsclient/xds.go
@@ -993,7 +993,7 @@ func securityConfigFromCommonTLSContextUsingNewFields(common *v3tlspb.CommonTlsC
 		return nil, fmt.Errorf("unsupported verify_certificate_spki field in CommonTlsContext message: %+v", common)
 	case len(validationCtx.GetVerifyCertificateHash()) != 0:
 		return nil, fmt.Errorf("unsupported verify_certificate_hash field in CommonTlsContext message: %+v", common)
-	case validationCtx.GetRequireSignedCertificateTimestamp().GetValue() == true:
+	case validationCtx.GetRequireSignedCertificateTimestamp().GetValue():
 		return nil, fmt.Errorf("unsupported require_sugned_ceritificate_timestamp field in CommonTlsContext message: %+v", common)
 	case validationCtx.GetCrl() != nil:
 		return nil, fmt.Errorf("unsupported crl field in CommonTlsContext message: %+v", common)


### PR DESCRIPTION
This PR adds the following validations, as specified in A29:
- `transport_socket_matches` field in `Cluster` message is not supported
- Following fields of `CommonTlsContext` are not supported:
  - `tls_params`
  - `custom_handshaker`
  - `validation_context_sds_secret_config` field inside `validation_context_type` is not supported
  - `tls_certificates` or `tls_certificate_sds_secret_configs` fields are set and `tls_certificate_provider_instance` field is unset
- Following fields of `DownstreamTlsContext` are not supported:
  - `require_sni`
  - Only allowed value for `ocsp_staple_policy` field is `LENIENT_STAPLING`
  - `match_subject_alt_names` is not supported on the server
- Following fields of `CertificateValidationContext` are not supported:
  - `verify_certificate_spki`
  - `verify_certificate_hash`
  - `require_signed_certificate_timestamp`
  - `crl`
  - `custom_validator_config`

Only one validation specified in A29 is remaining, which is to make sure that the certificate provider instance name specified in the configuration is available in the bootstrap file. This will be done in a follow-up PR.

RELEASE NOTES: N/A
