### PR TITLE
priority: handle Idle children the same way as Ready

### DIFF
--- a/xds/internal/balancer/priority/balancer_priority.go
+++ b/xds/internal/balancer/priority/balancer_priority.go
@@ -235,7 +235,7 @@ func (b *priorityBalancer) handleChildStateUpdate(childName string, s balancer.S
 	case connectivity.Connecting:
 		b.handlePriorityWithNewStateConnecting(child, priority, oldState)
 	default:
-		// New state is Idle, should never happen. Don't forward.
+		// New state is Shutdown, should never happen. Don't forward.
 	}
 }
 

--- a/xds/internal/balancer/priority/balancer_priority.go
+++ b/xds/internal/balancer/priority/balancer_priority.go
@@ -225,14 +225,15 @@ func (b *priorityBalancer) handleChildStateUpdate(childName string, s balancer.S
 	child.state = s
 
 	switch s.ConnectivityState {
-	case connectivity.Ready:
+	case connectivity.Ready, connectivity.Idle:
+		// Note that idle is also handled as if it's Ready. It will close the
+		// lower priorities (which will be kept in a cache, not deleted), and
+		// new picks will use the Idle picker.
 		b.handlePriorityWithNewStateReady(child, priority)
 	case connectivity.TransientFailure:
 		b.handlePriorityWithNewStateTransientFailure(child, priority)
 	case connectivity.Connecting:
 		b.handlePriorityWithNewStateConnecting(child, priority, oldState)
-	case connectivity.Idle:
-		b.handlePriorityWithNewStateIdle(child, priority)
 	default:
 		// New state is Idle, should never happen. Don't forward.
 	}
@@ -357,26 +358,4 @@ func (b *priorityBalancer) handlePriorityWithNewStateConnecting(child *childBala
 	default:
 		// Old state is Connecting, TransientFailure or Shutdown. Don't forward.
 	}
-}
-
-// handlePriorityWithNewStateIdle handles state Idle from a higher or equal
-// priority.
-//
-// An update with state Idle:
-// - If it's from higher priority:
-//   - Do nothing
-//   - It actually shouldn't happen, no balancer switches back to Idle.
-// - If it's from priorityInUse:
-//   - Forward only
-//
-// Caller must make sure priorityInUse is not higher than priority.
-//
-// Caller must hold mu.
-func (b *priorityBalancer) handlePriorityWithNewStateIdle(child *childBalancer, priority int) {
-	// priorityInUse is lower than this priority, do nothing.
-	if b.priorityInUse > priority {
-		return
-	}
-	// Forward the update.
-	b.cc.UpdateState(child.state)
 }


### PR DESCRIPTION
Previously, Idle won't stop lower priorities (#4731). Now it will.

RELEASE NOTES: N/A