### PR TITLE
transport/server: add :method POST to incoming metadata

### DIFF
--- a/binarylog/binarylog_end2end_test.go
+++ b/binarylog/binarylog_end2end_test.go
@@ -869,6 +869,7 @@ func equalLogEntry(entries ...*pb.GrpcLogEntry) (equal bool) {
 				if entry.Key == ":method" {
 					h.Metadata.Entry = append(h.Metadata.Entry[:i], h.Metadata.Entry[i+1:]...)
 				}
+				break
 			}
 		}
 		if h := e.GetTrailer(); h != nil {

--- a/binarylog/binarylog_end2end_test.go
+++ b/binarylog/binarylog_end2end_test.go
@@ -855,6 +855,7 @@ func equalLogEntry(entries ...*pb.GrpcLogEntry) (equal bool) {
 			for i, entry := range h.Metadata.Entry {
 				if entry.Key == ":method" {
 					h.Metadata.Entry = append(h.Metadata.Entry[:i], h.Metadata.Entry[i+1:]...)
+					break
 				}
 			}
 		}

--- a/binarylog/binarylog_end2end_test.go
+++ b/binarylog/binarylog_end2end_test.go
@@ -868,8 +868,8 @@ func equalLogEntry(entries ...*pb.GrpcLogEntry) (equal bool) {
 			for i, entry := range h.Metadata.Entry {
 				if entry.Key == ":method" {
 					h.Metadata.Entry = append(h.Metadata.Entry[:i], h.Metadata.Entry[i+1:]...)
+					break
 				}
-				break
 			}
 		}
 		if h := e.GetTrailer(); h != nil {

--- a/binarylog/binarylog_end2end_test.go
+++ b/binarylog/binarylog_end2end_test.go
@@ -850,11 +850,25 @@ func equalLogEntry(entries ...*pb.GrpcLogEntry) (equal bool) {
 			tmp := append(h.Metadata.Entry[:0], h.Metadata.Entry...)
 			h.Metadata.Entry = tmp
 			sort.Slice(h.Metadata.Entry, func(i, j int) bool { return h.Metadata.Entry[i].Key < h.Metadata.Entry[j].Key })
+			// Delete headers that have POST values here since we cannot control
+			// this.
+			for i, entry := range h.Metadata.Entry {
+				if entry.Key == ":method" {
+					h.Metadata.Entry = append(h.Metadata.Entry[:i], h.Metadata.Entry[i+1:]...)
+				}
+			}
 		}
 		if h := e.GetServerHeader(); h != nil {
 			tmp := append(h.Metadata.Entry[:0], h.Metadata.Entry...)
 			h.Metadata.Entry = tmp
 			sort.Slice(h.Metadata.Entry, func(i, j int) bool { return h.Metadata.Entry[i].Key < h.Metadata.Entry[j].Key })
+			// Delete headers that have POST values here since we cannot control
+			// this.
+			for i, entry := range h.Metadata.Entry {
+				if entry.Key == ":method" {
+					h.Metadata.Entry = append(h.Metadata.Entry[:i], h.Metadata.Entry[i+1:]...)
+				}
+			}
 		}
 		if h := e.GetTrailer(); h != nil {
 			sort.Slice(h.Metadata.Entry, func(i, j int) bool { return h.Metadata.Entry[i].Key < h.Metadata.Entry[j].Key })

--- a/internal/transport/http2_server.go
+++ b/internal/transport/http2_server.go
@@ -380,6 +380,7 @@ func (t *http2Server) operateHeaders(frame *http2.MetaHeadersFrame, handle func(
 			s.recvCompress = hf.Value
 		case ":method":
 			httpMethod = hf.Value
+			mdata[":method"] = append(mdata[":method"], hf.Value)
 		case ":path":
 			s.method = hf.Value
 		case "grpc-timeout":


### PR DESCRIPTION
This PR adds a hardcoded :method POST to Server's metadata as per A41 in support of the RBAC HTTP Filter.

The transport verifies and makes sure the only accepted :method is POST.

RELEASE NOTES: None