### PR TITLE
xds: Transport layer logic specified in A41

### DIFF
--- a/internal/transport/controlbuf.go
+++ b/internal/transport/controlbuf.go
@@ -773,7 +773,7 @@ func (l *loopyWriter) earlyAbortStreamHandler(eas *earlyAbortStream) error {
 	}
 
 	headerFields := []hpack.HeaderField{
-		{Name: ":status", Value: "200"},
+		{Name: ":status", Value: "200"}, // This needs to be 400
 		{Name: "content-type", Value: grpcutil.ContentType(eas.contentSubtype)},
 		{Name: "grpc-status", Value: strconv.Itoa(int(eas.status.Code()))},
 		{Name: "grpc-message", Value: encodeGrpcMessage(eas.status.Message())},

--- a/internal/transport/controlbuf.go
+++ b/internal/transport/controlbuf.go
@@ -772,8 +772,8 @@ func (l *loopyWriter) earlyAbortStreamHandler(eas *earlyAbortStream) error {
 		return errors.New("earlyAbortStream not handled on client")
 	}
 
-	headerFields := []hpack.HeaderField{
-		{Name: ":status", Value: "200"}, // This needs to be 400
+	headerFields := []hpack.HeaderField{ //
+		{Name: ":status", Value: "200"}, // This needs to be 400 - simply make it a variable if you want
 		{Name: "content-type", Value: grpcutil.ContentType(eas.contentSubtype)},
 		{Name: "grpc-status", Value: strconv.Itoa(int(eas.status.Code()))},
 		{Name: "grpc-message", Value: encodeGrpcMessage(eas.status.Message())},

--- a/internal/transport/http2_server.go
+++ b/internal/transport/http2_server.go
@@ -455,17 +455,17 @@ func (t *http2Server) operateHeaders(frame *http2.MetaHeadersFrame, handle func(
 	}
 
 	// "If :authority is missing, Host must be renamed to :authority." - A41
-	if len(mdata["authority"]) == 0 {
+	if len(mdata[":authority"]) == 0 {
 		// No-op if host isn't present, no eventual :authority header is a valid
 		// RPC.
 		if host, ok := mdata["host"]; ok {
-			mdata["authority"] = host
+			mdata[":authority"] = host
 			delete(mdata, "host")
 		}
 		delete(mdata, "host")
 	}
 	// "If :authority is present, Host must be discarded" - A41
-	if len(mdata["authority"]) != 0 {
+	if len(mdata[":authority"]) != 0 {
 		delete(mdata, "host")
 	}
 	// No eventual :authority header is a valid RPC.

--- a/internal/transport/http2_server.go
+++ b/internal/transport/http2_server.go
@@ -414,6 +414,7 @@ func (t *http2Server) operateHeaders(frame *http2.MetaHeadersFrame, handle func(
 				return false
 			}
 			seenAuthority = true
+			mdata[":authority"] = append(mdata[":authority"], hf.Value)
 		case "host":
 			if seenHost {
 				t.controlBuf.put(&cleanupStream{
@@ -425,6 +426,7 @@ func (t *http2Server) operateHeaders(frame *http2.MetaHeadersFrame, handle func(
 				return false
 			}
 			seenHost = true
+			mdata["host"] = append(mdata["host"], hf.Value)
 		default:
 			if isReservedHeader(hf.Name) && !isWhitelistedHeader(hf.Name) {
 				break

--- a/internal/transport/transport_test.go
+++ b/internal/transport/transport_test.go
@@ -1736,7 +1736,6 @@ func (s) TestHeadersCausingStreamError(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			print("running test casee")
 			server := setUpServerOnly(t, 0, &ServerConfig{}, suspended)
 			defer server.stop()
 			// Create a client directly to not tie what you can send to API of

--- a/internal/transport/transport_test.go
+++ b/internal/transport/transport_test.go
@@ -1663,81 +1663,150 @@ func (s) TestReadGivesSameErrorAfterAnyErrorOccurs(t *testing.T) {
 	}
 }
 
-// If the client sends an HTTP/2 request with a :method header with a value other than POST, as specified in
-// the gRPC over HTTP/2 specification, the server should close the stream.
-func (s) TestServerWithClientSendingWrongMethod(t *testing.T) {
-	server := setUpServerOnly(t, 0, &ServerConfig{}, suspended)
-	defer server.stop()
-	// Create a client directly to not couple what you can send to API of http2_client.go.
-	mconn, err := net.Dial("tcp", server.lis.Addr().String())
-	if err != nil {
-		t.Fatalf("Client failed to dial: %v", err)
-	}
-	defer mconn.Close()
-
-	if n, err := mconn.Write(clientPreface); err != nil || n != len(clientPreface) {
-		t.Fatalf("mconn.Write(clientPreface) = %d, %v, want %d, <nil>", n, err, len(clientPreface))
-	}
-
-	framer := http2.NewFramer(mconn, mconn)
-	if err := framer.WriteSettings(); err != nil {
-		t.Fatalf("Error while writing settings: %v", err)
-	}
-
-	// success chan indicates that reader received a RSTStream from server.
-	// An error will be passed on it if any other frame is received.
-	success := testutils.NewChannel()
-
-	// Launch a reader goroutine.
-	go func() {
-		for {
-			frame, err := framer.ReadFrame()
-			if err != nil {
-				return
-			}
-			switch frame := frame.(type) {
-			case *http2.SettingsFrame:
-				// Do nothing. A settings frame is expected from server preface.
-			case *http2.RSTStreamFrame:
-				if frame.Header().StreamID != 1 || http2.ErrCode(frame.ErrCode) != http2.ErrCodeProtocol {
-					// Client only created a single stream, so RST Stream should be for that single stream.
-					t.Errorf("RST stream received with streamID: %d and code %v, want streamID: 1 and code: http.ErrCodeFlowControl", frame.Header().StreamID, http2.ErrCode(frame.ErrCode))
-				}
-				// Records that client successfully received RST Stream frame.
-				success.Send(nil)
-				return
-			default:
-				// The server should send nothing but a single RST Stream frame.
-				success.Send(errors.New("The client received a frame other than RST Stream"))
-			}
+// TestHeadersCausingStreamError tests headers that should cause a stream protocol
+// error, which would end up with a RST_STREAM being sent to the client and also
+// the server closing the stream.
+func (s) TestHeadersCausingStreamError(t *testing.T) {
+	tests := []struct {
+		name    string
+		headers []struct {
+			name   string
+			values []string
 		}
-	}()
+	}{
+		// If the client sends an HTTP/2 request with a :method header with a
+		// value other than POST, as specified in the gRPC over HTTP/2
+		// specification, the server should close the stream.
+		{
+			name: "ClientSendingWrongMethod",
+			headers: []struct {
+				name   string
+				values []string
+			}{
+				{name: ":method", values: []string{"PUT"}},
+				{name: ":path", values: []string{"foo"}},
+				{name: ":authority", values: []string{"localhost"}},
+				{name: "content-type", values: []string{"application/grpc"}},
+			},
+		},
+		// "Transports must consider requests containing the Connection header
+		// as malformed" - A41 Malformed requests map to a stream error of type
+		// PROTOCOL_ERROR.
+		{
+			name: "Connection header present",
+			headers: []struct {
+				name   string
+				values []string
+			}{
+				{name: ":method", values: []string{"POST"}},
+				{name: ":path", values: []string{"foo"}},
+				{name: ":authority", values: []string{"localhost"}},
+				{name: "content-type", values: []string{"application/grpc"}},
+				{name: "connection", values: []string{"not-supported"}},
+			},
+		},
+		// multiple :authority or multiple Host headers would make the eventual
+		// :authority ambiguous as per A41.
+		{
+			name: "Multiple authority headers",
+			headers: []struct {
+				name   string
+				values []string
+			}{
+				{name: ":method", values: []string{"POST"}},
+				{name: ":path", values: []string{"foo"}},
+				{name: ":authority", values: []string{"localhost", "localhost2"}},
+				{name: "content-type", values: []string{"application/grpc"}},
+				{name: "host", values: []string{"localhost"}},
+			},
+		},
+		{
+			name: "Multiple host headers",
+			headers: []struct {
+				name   string
+				values []string
+			}{
+				{name: ":method", values: []string{"POST"}},
+				{name: ":path", values: []string{"foo"}},
+				{name: ":authority", values: []string{"localhost"}},
+				{name: "content-type", values: []string{"application/grpc"}},
+				{name: "host", values: []string{"localhost", "localhost2"}},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			print("running test casee")
+			server := setUpServerOnly(t, 0, &ServerConfig{}, suspended)
+			defer server.stop()
+			// Create a client directly to not tie what you can send to API of
+			// http2_client.go (i.e. control headers being sent).
+			mconn, err := net.Dial("tcp", server.lis.Addr().String())
+			if err != nil {
+				t.Fatalf("Client failed to dial: %v", err)
+			}
+			defer mconn.Close()
 
-	// Done with HTTP/2 setup - now create a stream with a bad method header.
-	var buf bytes.Buffer
-	henc := hpack.NewEncoder(&buf)
-	// Method is required to be POST in a gRPC call.
-	if err := henc.WriteField(hpack.HeaderField{Name: ":method", Value: "PUT"}); err != nil {
-		t.Fatalf("Error while encoding header: %v", err)
-	}
-	// Have the rest of the headers be ok and within the gRPC over HTTP/2 spec.
-	if err := henc.WriteField(hpack.HeaderField{Name: ":path", Value: "foo"}); err != nil {
-		t.Fatalf("Error while encoding header: %v", err)
-	}
-	if err := henc.WriteField(hpack.HeaderField{Name: ":authority", Value: "localhost"}); err != nil {
-		t.Fatalf("Error while encoding header: %v", err)
-	}
-	if err := henc.WriteField(hpack.HeaderField{Name: "content-type", Value: "application/grpc"}); err != nil {
-		t.Fatalf("Error while encoding header: %v", err)
-	}
+			if n, err := mconn.Write(clientPreface); err != nil || n != len(clientPreface) {
+				t.Fatalf("mconn.Write(clientPreface) = %d, %v, want %d, <nil>", n, err, len(clientPreface))
+			}
 
-	if err := framer.WriteHeaders(http2.HeadersFrameParam{StreamID: 1, BlockFragment: buf.Bytes(), EndHeaders: true}); err != nil {
-		t.Fatalf("Error while writing headers: %v", err)
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
-	defer cancel()
-	if e, err := success.Receive(ctx); e != nil || err != nil {
-		t.Fatalf("Error in frame server should send: %v. Error receiving from channel: %v", e, err)
+			framer := http2.NewFramer(mconn, mconn)
+			if err := framer.WriteSettings(); err != nil {
+				t.Fatalf("Error while writing settings: %v", err)
+			}
+
+			// success chan indicates that reader received a RSTStream from server.
+			// An error will be passed on it if any other frame is received.
+			success := testutils.NewChannel()
+
+			// Launch a reader goroutine.
+			go func() {
+				for {
+					frame, err := framer.ReadFrame()
+					if err != nil {
+						return
+					}
+					switch frame := frame.(type) {
+					case *http2.SettingsFrame:
+						// Do nothing. A settings frame is expected from server preface.
+					case *http2.RSTStreamFrame:
+						if frame.Header().StreamID != 1 || http2.ErrCode(frame.ErrCode) != http2.ErrCodeProtocol {
+							// Client only created a single stream, so RST Stream should be for that single stream.
+							t.Errorf("RST stream received with streamID: %d and code %v, want streamID: 1 and code: http.ErrCodeFlowControl", frame.Header().StreamID, http2.ErrCode(frame.ErrCode))
+						}
+						// Records that client successfully received RST Stream frame.
+						success.Send(nil)
+						return
+					default:
+						// The server should send nothing but a single RST Stream frame.
+						success.Send(errors.New("the client received a frame other than RST Stream"))
+					}
+				}
+			}()
+
+			var buf bytes.Buffer
+			henc := hpack.NewEncoder(&buf)
+
+			// Needs to build headers deterministically to conform to gRPC over
+			// HTTP/2 spec.
+			for _, header := range test.headers {
+				for _, value := range header.values {
+					if err := henc.WriteField(hpack.HeaderField{Name: header.name, Value: value}); err != nil {
+						t.Fatalf("Error while encoding header: %v", err)
+					}
+				}
+			}
+
+			if err := framer.WriteHeaders(http2.HeadersFrameParam{StreamID: 1, BlockFragment: buf.Bytes(), EndHeaders: true}); err != nil {
+				t.Fatalf("Error while writing headers: %v", err)
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+			defer cancel()
+			if e, err := success.Receive(ctx); e != nil || err != nil {
+				t.Fatalf("Error in frame server should send: %v. Error receiving from channel: %v", e, err)
+			}
+		})
 	}
 }
 

--- a/internal/transport/transport_test.go
+++ b/internal/transport/transport_test.go
@@ -1678,7 +1678,7 @@ func (s) TestHeadersCausingStreamError(t *testing.T) {
 		// value other than POST, as specified in the gRPC over HTTP/2
 		// specification, the server should close the stream.
 		{
-			name: "ClientSendingWrongMethod",
+			name: "Client Sending Wrong Method",
 			headers: []struct {
 				name   string
 				values []string
@@ -1723,18 +1723,6 @@ func (s) TestHeadersCausingStreamError(t *testing.T) {
 				{name: ":path", values: []string{"foo"}},
 				{name: ":authority", values: []string{"localhost", "localhost2"}},
 				{name: "host", values: []string{"localhost"}},
-			},
-		},
-		{
-			name: "Multiple host headers",
-			headers: []struct {
-				name   string
-				values []string
-			}{
-				{name: ":method", values: []string{"POST"}},
-				{name: ":path", values: []string{"foo"}},
-				{name: ":authority", values: []string{"localhost"}},
-				{name: "host", values: []string{"localhost", "localhost2"}},
 			},
 		},
 	}
@@ -1826,27 +1814,16 @@ func (s) TestHeadersGRPCRequest(t *testing.T) {
 			values []string
 		}
 	}{
-		// multiple :authority or multiple Host headers would make the eventual
-		// :authority ambiguous as per A41. On requests where you know that it is
-		// from a grpc client, this should be rejected with grpc-status Internal.
-		/*{
-			name: "Multiple authority headers",
-			headers: []struct {
-				name   string
-				values []string
-			}{
-				{name: ":method", values: []string{"POST"}},
-				{name: ":path", values: []string{"foo"}},
-				{name: ":authority", values: []string{"localhost", "localhost2"}},
-				{name: "content-type", values: []string{"application/grpc"}},
-				{name: "host", values: []string{"localhost"}},
-			},
-		},*/
 		// Note: multiple authority headers are handled by the framer itself,
 		// which will cause a stream error. Thus, it will never get to
 		// operateHeaders with the check in operateHeaders for possible grpc-status sent back.
+
+		// multiple :authority or multiple Host headers would make the eventual
+		// :authority ambiguous as per A41. This takes precedence even over the
+		// fact a request is non grpc. All of these requests should be rejected
+		// with grpc-status Internal.
 		{
-			name: "Multiple host headers",
+			name: "Multiple host headers non grpc",
 			headers: []struct {
 				name   string
 				values []string
@@ -1854,8 +1831,20 @@ func (s) TestHeadersGRPCRequest(t *testing.T) {
 				{name: ":method", values: []string{"POST"}},
 				{name: ":path", values: []string{"foo"}},
 				{name: ":authority", values: []string{"localhost"}},
-				{name: "content-type", values: []string{"application/grpc"}}, // What branches in terms of what gets sent back to client
-				{name: "host", values: []string{"localhost", "localhost2"}}, // Is the right in encoding?
+				{name: "host", values: []string{"localhost", "localhost2"}},
+			},
+		},
+		{
+			name: "Multiple host headers grpc",
+			headers: []struct {
+				name   string
+				values []string
+			}{
+				{name: ":method", values: []string{"POST"}},
+				{name: ":path", values: []string{"foo"}},
+				{name: ":authority", values: []string{"localhost"}},
+				{name: "content-type", values: []string{"application/grpc"}},
+				{name: "host", values: []string{"localhost", "localhost2"}},
 			},
 		},
 	}

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -7884,3 +7884,6 @@ func (s) TestUnaryInterceptorGetsPost(t *testing.T) {
 		t.Fatalf("ss.Client.EmptyCall(_, _) = _, %v, want _, error code %s", err, codes.OK)
 	}
 }
+
+
+// Plumb in server_tester.go (see examples

--- a/test/servertester.go
+++ b/test/servertester.go
@@ -273,3 +273,4 @@ func (st *serverTester) writeRSTStream(streamID uint32, code http2.ErrCode) {
 		st.t.Fatalf("Error writing RST_STREAM: %v", err)
 	}
 }
+// Link this in and test :authority header that gets spit out to the interceptor

--- a/test/servertester.go
+++ b/test/servertester.go
@@ -273,4 +273,8 @@ func (st *serverTester) writeRSTStream(streamID uint32, code http2.ErrCode) {
 		st.t.Fatalf("Error writing RST_STREAM: %v", err)
 	}
 }
+
 // Link this in and test :authority header that gets spit out to the interceptor
+// (knobs) headers frame -> (handled in http/2 transport) -> interceptor, a fully fledged RPC because it calls this before it creates a stream?
+// Have it ping enough of a header frame for it to actually call into the interceptor, but have to set up an interceptor to test it, and have the headers frame match to a logical RPC in the service set up
+// Find examples...?


### PR DESCRIPTION
This PR adds logic from A41 at the transport layer. Each line from the spec is commented in the code. There is no official test for the eventual :authority header, but I'm trying my best.

RELEASE NOTES: None