### PR TITLE
xds: disable drains on new Listener resource at server

### DIFF
--- a/xds/server.go
+++ b/xds/server.go
@@ -239,11 +239,17 @@ func (s *GRPCServer) Serve(lis net.Listener) error {
 				err:  err,
 			})
 		},
-		DrainCallback: func(addr net.Addr) {
-			if gs, ok := s.gs.(*grpc.Server); ok {
-				drainServerTransports(gs, addr.String())
-			}
-		},
+		// TODO: Uncomment after https://github.com/grpc/grpc-go/issues/4695 is
+		// fixed. Without a fix for that issue, we would be draining server
+		// transports everytime we get a Listener resource, even if the control
+		// plane sends the same resource again and again.
+		/*
+			DrainCallback: func(addr net.Addr) {
+				if gs, ok := s.gs.(*grpc.Server); ok {
+					drainServerTransports(gs, addr.String())
+				}
+			},
+		*/
 	})
 
 	// Block until a good LDS response is received or the server is stopped.


### PR DESCRIPTION
This was added for the RBAC feature, which is not yet fully ready. But
without the fix for https://github.com/grpc/grpc-go/issues/4695, this
causes unnecessary draining of server transports when the control plane
sends redundant updates.

RELEASE NOTES: N/A