### PR TITLE
xds/test: delete use of removed types

### DIFF
--- a/internal/xds/matcher/string_matcher_test.go
+++ b/internal/xds/matcher/string_matcher_test.go
@@ -68,13 +68,6 @@ func TestStringMatcherFromProto(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			desc: "invalid deprecated regex",
-			inputProto: &v3matcherpb.StringMatcher{
-				MatchPattern: &v3matcherpb.StringMatcher_HiddenEnvoyDeprecatedRegex{},
-			},
-			wantErr: true,
-		},
-		{
 			desc: "happy case exact",
 			inputProto: &v3matcherpb.StringMatcher{
 				MatchPattern: &v3matcherpb.StringMatcher_Exact{Exact: "exact"},

--- a/xds/internal/xdsclient/rds_test.go
+++ b/xds/internal/xdsclient/rds_test.go
@@ -1146,7 +1146,7 @@ func (s) TestRoutesProtoToSlice(t *testing.T) {
 						Headers: []*v3routepb.HeaderMatcher{
 							{
 								Name:                 "th",
-								HeaderMatchSpecifier: &v3routepb.HeaderMatcher_HiddenEnvoyDeprecatedRegexMatch{},
+								HeaderMatchSpecifier: &v3routepb.HeaderMatcher_StringMatch{},
 							},
 						},
 					},


### PR DESCRIPTION
They were deprecated, and removed later.

RELEASE NOTES: N/A