### PR TITLE
transport: fix transparent retries when per-RPC credentials are in use

### DIFF
--- a/stream.go
+++ b/stream.go
@@ -547,7 +547,7 @@ func (cs *clientStream) shouldRetry(err error) (bool, error) {
 		// In the event of a non-IO operation error from NewStream, we never
 		// attempted to write anything to the wire, so we can retry
 		// indefinitely.
-		if !nse.PerformedIO {
+		if !nse.DoNotTransparentRetry {
 			return true, nil
 		}
 	}


### PR DESCRIPTION
Fixes a regression caused by #3677 

RELEASE NOTES:
* transport: fix transparent retries when per-RPC credentials are in use