### PR TITLE
xds: Added validations for HCM to support xDS RBAC Filter

### DIFF
--- a/internal/xds/rbac/matchers.go
+++ b/internal/xds/rbac/matchers.go
@@ -183,7 +183,7 @@ func matchersFromPrincipals(principals []*v3rbacpb.Principal) ([]matcher, error)
 			// The source ip principal identifier is deprecated. Thus, a
 			// principal typed as a source ip in the identifier will be a no-op.
 			// The config should use DirectRemoteIp instead.
-		case *v3rbacpb.Principal_RemoteIp:
+		case *v3rbacpb.Principal_RemoteIp: // Allow equating RBAC's direct_remote_ip...do we need this?
 			// Not supported in gRPC RBAC currently - a principal typed as
 			// Remote Ip in the initial config will be a no-op.
 		case *v3rbacpb.Principal_Metadata:

--- a/xds/internal/xdsclient/filter_chain.go
+++ b/xds/internal/xdsclient/filter_chain.go
@@ -601,8 +601,11 @@ func processNetworkFilters(filters []*v3listenerpb.Filter) (*FilterChain, error)
 				// "HttpConnectionManager.xff_num_trusted_hops must be unset or zero and
 				// HttpConnectionManager.original_ip_detection_extensions must be empty. If
 				// either field has an incorrect value, the Listener must be NACKed." - A41
-				if hcm.XffNumTrustedHops != 0 || len(hcm.OriginalIpDetectionExtensions) != 0 {
-					return nil, fmt.Errorf("xff_num_trusted_hops must be unset or zero and original_ip_detection_extensions must be empty %+v", hcm)
+				if hcm.XffNumTrustedHops != 0 {
+					return nil, fmt.Errorf("xff_num_trusted_hops must be unset or zero %+v", hcm)
+				}
+				if len(hcm.OriginalIpDetectionExtensions) != 0 {
+					return nil, fmt.Errorf("original_ip_detection_extensions must be empty %+v", hcm)
 				}
 
 				// TODO: Implement terminal filter logic, as per A36.

--- a/xds/internal/xdsclient/filter_chain.go
+++ b/xds/internal/xdsclient/filter_chain.go
@@ -596,6 +596,15 @@ func processNetworkFilters(filters []*v3listenerpb.Filter) (*FilterChain, error)
 				return nil, fmt.Errorf("network filters {%+v} had invalid server side HTTP Filters {%+v}: %v", filters, hcm.GetHttpFilters(), err)
 			}
 			if !seenHCM {
+				// Validate for RBAC in only the HCM that will be used, since this isn't a logical validation failure,
+				// it's simply a validation to support RBAC HTTP Filter.
+				// "HttpConnectionManager.xff_num_trusted_hops must be unset or zero and
+				// HttpConnectionManager.original_ip_detection_extensions must be empty. If
+				// either field has an incorrect value, the Listener must be NACKed." - A41
+				if hcm.XffNumTrustedHops != 0 || len(hcm.OriginalIpDetectionExtensions) != 0 {
+					return nil, fmt.Errorf("xff_num_trusted_hops must be unset or zero and original_ip_detection_extensions must be empty %+v", hcm)
+				}
+
 				// TODO: Implement terminal filter logic, as per A36.
 				filterChain.HTTPFilters = filters
 				seenHCM = true

--- a/xds/internal/xdsclient/lds_test.go
+++ b/xds/internal/xdsclient/lds_test.go
@@ -1407,14 +1407,14 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 			resources:  []*anypb.Any{v3LisToTestRBAC(1, nil)},
 			wantUpdate: map[string]ListenerUpdateErrTuple{v3LDSTarget: {Err: cmpopts.AnyError}},
 			wantMD:     errMD,
-			wantErr:    "xff_num_trusted_hops must be unset or zero and original_ip_detection_extensions must be empty",
+			wantErr:    "xff_num_trusted_hops must be unset or zero",
 		},
 		{
 			name:       "rbac-allow-equating-direct-remote-ip-and-remote-ip-invalid-original-ip-detection-extension",
 			resources:  []*anypb.Any{v3LisToTestRBAC(0, []*v3corepb.TypedExtensionConfig{{Name: "something"}})},
 			wantUpdate: map[string]ListenerUpdateErrTuple{v3LDSTarget: {Err: cmpopts.AnyError}},
 			wantMD:     errMD,
-			wantErr:    "xff_num_trusted_hops must be unset or zero and original_ip_detection_extensions must be empty",
+			wantErr:    "original_ip_detection_extensions must be empty",
 		},
 		{
 			name: "unsupported validation context in transport socket",

--- a/xds/internal/xdsclient/lds_test.go
+++ b/xds/internal/xdsclient/lds_test.go
@@ -173,6 +173,30 @@ func (s) TestUnmarshalListener_ClientSide(t *testing.T) {
 				},
 			})
 		}
+		v3LisToTestRBAC = func(xffNumTrustedHops uint32, originalIpDetectionExtensions []*v3corepb.TypedExtensionConfig) *anypb.Any {
+			return testutils.MarshalAny(&v3listenerpb.Listener{
+				Name: v3LDSTarget,
+				ApiListener: &v3listenerpb.ApiListener{
+					ApiListener: testutils.MarshalAny(
+						&v3httppb.HttpConnectionManager{
+							RouteSpecifier: &v3httppb.HttpConnectionManager_Rds{
+								Rds: &v3httppb.Rds{
+									ConfigSource: &v3corepb.ConfigSource{
+										ConfigSourceSpecifier: &v3corepb.ConfigSource_Ads{Ads: &v3corepb.AggregatedConfigSource{}},
+									},
+									RouteConfigName: v3RouteConfigName,
+								},
+							},
+							CommonHttpProtocolOptions: &v3corepb.HttpProtocolOptions{
+								MaxStreamDuration: durationpb.New(time.Second),
+							},
+							HttpFilters:                   []*v3httppb.HttpFilter{emptyRouterFilter},
+							XffNumTrustedHops:             xffNumTrustedHops,
+							OriginalIpDetectionExtensions: originalIpDetectionExtensions,
+						}),
+				},
+			})
+		}
 		errMD = UpdateMetadata{
 			Status:  ServiceStatusNACKed,
 			Version: testVersion,
@@ -529,6 +553,49 @@ func (s) TestUnmarshalListener_ClientSide(t *testing.T) {
 				Version: testVersion,
 			},
 		},
+		// "To allow equating RBAC's direct_remote_ip and
+		// remote_ip...HttpConnectionManager.xff_num_trusted_hops must be unset
+		// or zero and HttpConnectionManager.original_ip_detection_extensions
+		// must be empty." - A41
+		{
+			name:      "rbac-allow-equating-direct-remote-ip-and-remote-ip-valid",
+			resources: []*anypb.Any{v3LisToTestRBAC(0, nil)},
+			wantUpdate: map[string]ListenerUpdateErrTuple{
+				v3LDSTarget: {Update: ListenerUpdate{
+					RouteConfigName:   v3RouteConfigName,
+					MaxStreamDuration: time.Second,
+					HTTPFilters:       []HTTPFilter{routerFilter},
+					Raw:               v3LisToTestRBAC(0, nil),
+				}},
+			},
+			wantMD: UpdateMetadata{
+				Status:  ServiceStatusACKed,
+				Version: testVersion,
+			},
+		},
+		// In order to support xDS Configured RBAC HTTPFilter equating direct
+		// remote ip and remote ip, xffNumTrustedHops cannot be greater than
+		// zero. This is because if you can trust a ingress proxy hop when
+		// determining an origin clients ip address, direct remote ip != remote
+		// ip.
+		{
+			name:       "rbac-allow-equating-direct-remote-ip-and-remote-ip-invalid-num-untrusted-hops",
+			resources:  []*anypb.Any{v3LisToTestRBAC(1, nil)},
+			wantUpdate: map[string]ListenerUpdateErrTuple{v3LDSTarget: {Err: cmpopts.AnyError}},
+			wantMD:     errMD,
+			wantErr:    true,
+		},
+		// In order to support xDS Configured RBAC HTTPFilter equating direct
+		// remote ip and remote ip, originalIpDetectionExtensions must be empty.
+		// This is because if you have to ask ip-detection-extension for the
+		// original ip, direct remote ip might not equal remote ip.
+		{
+			name:       "rbac-allow-equating-direct-remote-ip-and-remote-ip-invalid-original-ip-detection-extension",
+			resources:  []*anypb.Any{v3LisToTestRBAC(0, []*v3corepb.TypedExtensionConfig{{Name: "something"}})},
+			wantUpdate: map[string]ListenerUpdateErrTuple{v3LDSTarget: {Err: cmpopts.AnyError}},
+			wantMD:     errMD,
+			wantErr:    true,
+		},
 		{
 			name:      "v3 listener with inline route configuration",
 			resources: []*anypb.Any{v3LisWithInlineRoute},
@@ -868,6 +935,32 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 			},
 		}
 	)
+	v3LisToTestRBAC := func(xffNumTrustedHops uint32, originalIpDetectionExtensions []*v3corepb.TypedExtensionConfig) *anypb.Any {
+		return testutils.MarshalAny(&v3listenerpb.Listener{
+			Name:    v3LDSTarget,
+			Address: localSocketAddress,
+			FilterChains: []*v3listenerpb.FilterChain{
+				{
+					Name: "filter-chain-1",
+					Filters: []*v3listenerpb.Filter{
+						{
+							Name: "filter-1",
+							ConfigType: &v3listenerpb.Filter_TypedConfig{
+								TypedConfig: testutils.MarshalAny(&v3httppb.HttpConnectionManager{
+									RouteSpecifier: &v3httppb.HttpConnectionManager_RouteConfig{
+										RouteConfig: routeConfig,
+									},
+									HttpFilters:                   []*v3httppb.HttpFilter{e2e.RouterHTTPFilter},
+									XffNumTrustedHops:             xffNumTrustedHops,
+									OriginalIpDetectionExtensions: originalIpDetectionExtensions,
+								}),
+							},
+						},
+					},
+				},
+			},
+		})
+	}
 
 	tests := []struct {
 		name       string
@@ -1271,6 +1364,57 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 			wantUpdate: map[string]ListenerUpdateErrTuple{v3LDSTarget: {Err: cmpopts.AnyError}},
 			wantMD:     errMD,
 			wantErr:    "DownstreamTlsContext in LDS response does not contain a CommonTlsContext",
+		},
+		{
+			name:      "rbac-allow-equating-direct-remote-ip-and-remote-ip-valid",
+			resources: []*anypb.Any{v3LisToTestRBAC(0, nil)},
+			wantUpdate: map[string]ListenerUpdateErrTuple{
+				v3LDSTarget: {Update: ListenerUpdate{
+					InboundListenerCfg: &InboundListenerConfig{
+						Address: "0.0.0.0",
+						Port:    "9999",
+						FilterChains: &FilterChainManager{
+							dstPrefixMap: map[string]*destPrefixEntry{
+								unspecifiedPrefixMapKey: {
+									srcTypeArr: [3]*sourcePrefixes{
+										{
+											srcPrefixMap: map[string]*sourcePrefixEntry{
+												unspecifiedPrefixMapKey: {
+													srcPortMap: map[int]*FilterChain{
+														0: {
+															InlineRouteConfig: inlineRouteConfig,
+															HTTPFilters:       routerFilterList,
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					Raw: listenerEmptyTransportSocket,
+				}},
+			},
+			wantMD: UpdateMetadata{
+				Status:  ServiceStatusACKed,
+				Version: testVersion,
+			},
+		},
+		{
+			name:       "rbac-allow-equating-direct-remote-ip-and-remote-ip-invalid-num-untrusted-hops",
+			resources:  []*anypb.Any{v3LisToTestRBAC(1, nil)},
+			wantUpdate: map[string]ListenerUpdateErrTuple{v3LDSTarget: {Err: cmpopts.AnyError}},
+			wantMD:     errMD,
+			wantErr:    "xff_num_trusted_hops must be unset or zero and original_ip_detection_extensions must be empty",
+		},
+		{
+			name:       "rbac-allow-equating-direct-remote-ip-and-remote-ip-invalid-original-ip-detection-extension",
+			resources:  []*anypb.Any{v3LisToTestRBAC(0, []*v3corepb.TypedExtensionConfig{{Name: "something"}})},
+			wantUpdate: map[string]ListenerUpdateErrTuple{v3LDSTarget: {Err: cmpopts.AnyError}},
+			wantMD:     errMD,
+			wantErr:    "xff_num_trusted_hops must be unset or zero and original_ip_detection_extensions must be empty",
 		},
 		{
 			name: "unsupported validation context in transport socket",

--- a/xds/internal/xdsclient/xds.go
+++ b/xds/internal/xdsclient/xds.go
@@ -104,6 +104,12 @@ func processClientSideListener(lis *v3listenerpb.Listener, logger *grpclog.Prefi
 	if err := proto.Unmarshal(apiLisAny.GetValue(), apiLis); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal api_listner: %v", err)
 	}
+	// "HttpConnectionManager.xff_num_trusted_hops must be unset or zero and
+	// HttpConnectionManager.original_ip_detection_extensions must be empty. If
+	// either field has an incorrect value, the Listener must be NACKed." - A41
+	if apiLis.XffNumTrustedHops != 0 || len(apiLis.OriginalIpDetectionExtensions) != 0 {
+		return nil, fmt.Errorf("xff_num_trusted_hops must be unset or zero and original_ip_detection_extensions must be empty %+v", apiLis)
+	}
 
 	switch apiLis.RouteSpecifier.(type) {
 	case *v3httppb.HttpConnectionManager_Rds:

--- a/xds/internal/xdsclient/xds.go
+++ b/xds/internal/xdsclient/xds.go
@@ -107,8 +107,11 @@ func processClientSideListener(lis *v3listenerpb.Listener, logger *grpclog.Prefi
 	// "HttpConnectionManager.xff_num_trusted_hops must be unset or zero and
 	// HttpConnectionManager.original_ip_detection_extensions must be empty. If
 	// either field has an incorrect value, the Listener must be NACKed." - A41
-	if apiLis.XffNumTrustedHops != 0 || len(apiLis.OriginalIpDetectionExtensions) != 0 {
-		return nil, fmt.Errorf("xff_num_trusted_hops must be unset or zero and original_ip_detection_extensions must be empty %+v", apiLis)
+	if apiLis.XffNumTrustedHops != 0 {
+		return nil, fmt.Errorf("xff_num_trusted_hops must be unset or zero %+v", apiLis)
+	}
+	if len(apiLis.OriginalIpDetectionExtensions) != 0 {
+		return nil, fmt.Errorf("original_ip_detection_extensions must be empty %+v", apiLis)
 	}
 
 	switch apiLis.RouteSpecifier.(type) {


### PR DESCRIPTION
This implements the paragraph in A41: "New validation should occur for HttpConnectionManager to allow equating direct_remote_ip and remote_ip. If the implementation does not distinguish between these fields, then xff_num_trusted_hops must be unset or zero and original_ip_detection_extensions must be empty. If either field has an incorrect value, the Listener must be NACKed. For simplicity, this behavior applies independent of the Listener type (both client-side and server-side)."

RELEASE NOTES: None