### PR TITLE
xds/rds: NACK unknown route action cluster specifier

### DIFF
--- a/xds/internal/test/xds_server_integration_test.go
+++ b/xds/internal/test/xds_server_integration_test.go
@@ -439,7 +439,9 @@ func (s) TestServerSideXDS_RouteConfiguration(t *testing.T) {
 						// "Fully-qualified RPC method name with leading slash. Same as :path header".
 					},
 					// Incorrect Action, so RPC's that match this route should get denied.
-					Action: &v3routepb.Route_Route{},
+					Action: &v3routepb.Route_Route{
+						Route: &v3routepb.RouteAction{ClusterSpecifier: &v3routepb.RouteAction_Cluster{Cluster: ""}},
+					},
 				},
 				// Another routing rule that can be selectively triggered based on incoming RPC.
 				{
@@ -447,7 +449,9 @@ func (s) TestServerSideXDS_RouteConfiguration(t *testing.T) {
 						PathSpecifier: &v3routepb.RouteMatch_Prefix{Prefix: "/grpc.testing.TestService/UnaryCall"},
 					},
 					// Wrong action (!Non_Forwarding_Action) so RPC's that match this route should get denied.
-					Action: &v3routepb.Route_Route{},
+					Action: &v3routepb.Route_Route{
+						Route: &v3routepb.RouteAction{ClusterSpecifier: &v3routepb.RouteAction_Cluster{Cluster: ""}},
+					},
 				},
 				// Another routing rule that can be selectively triggered based on incoming RPC.
 				{
@@ -455,7 +459,9 @@ func (s) TestServerSideXDS_RouteConfiguration(t *testing.T) {
 						PathSpecifier: &v3routepb.RouteMatch_Prefix{Prefix: "/grpc.testing.TestService/StreamingInputCall"},
 					},
 					// Wrong action (!Non_Forwarding_Action) so RPC's that match this route should get denied.
-					Action: &v3routepb.Route_Route{},
+					Action: &v3routepb.Route_Route{
+						Route: &v3routepb.RouteAction{ClusterSpecifier: &v3routepb.RouteAction_Cluster{Cluster: ""}},
+					},
 				},
 				// Not matching route, this is be able to get invoked logically (i.e. doesn't have to match the Route configurations above).
 			}},

--- a/xds/internal/xdsclient/rds_test.go
+++ b/xds/internal/xdsclient/rds_test.go
@@ -1232,6 +1232,20 @@ func (s) TestRoutesProtoToSlice(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "unsupported cluster specifier",
+			routes: []*v3routepb.Route{
+				{
+					Match: &v3routepb.RouteMatch{
+						PathSpecifier: &v3routepb.RouteMatch_Prefix{Prefix: "/a/"},
+					},
+					Action: &v3routepb.Route_Route{
+						Route: &v3routepb.RouteAction{
+							ClusterSpecifier: &v3routepb.RouteAction_ClusterSpecifierPlugin{}}},
+				},
+			},
+			wantErr: true,
+		},
+		{
 			name: "default totalWeight is 100 in weighted clusters action",
 			routes: []*v3routepb.Route{
 				{

--- a/xds/internal/xdsclient/xds.go
+++ b/xds/internal/xdsclient/xds.go
@@ -555,6 +555,8 @@ func routesProtoToSlice(routes []*v3routepb.Route, logger *grpclog.PrefixLogger,
 				}
 			case *v3routepb.RouteAction_ClusterHeader:
 				continue
+			default:
+				return nil, fmt.Errorf("route %+v, has an unknown ClusterSpecifier: %+v", r, a)
 			}
 
 			msd := action.GetMaxStreamDuration()


### PR DESCRIPTION
Before this, the response is ACKed, but the unknown cluster specifier is ignored. The RPCs picking this route will fail because there's no valid action to take.

RELEASE NOTES:
* xds/rds: NACK the RDS response if it contains unknown cluster specifier