### PR TITLE
channelz: recommend using admin.Register instead

### DIFF
--- a/admin/admin.go
+++ b/admin/admin.go
@@ -20,6 +20,7 @@
 // administration services to a gRPC server. The services registered are:
 //
 // - Channelz: https://github.com/grpc/proposal/blob/master/A14-channelz.md
+//
 // - CSDS: https://github.com/grpc/proposal/blob/master/A40-csds-support.md
 //
 // Experimental

--- a/channelz/service/service.go
+++ b/channelz/service/service.go
@@ -43,6 +43,10 @@ func init() {
 var logger = grpclog.Component("channelz")
 
 // RegisterChannelzServiceToServer registers the channelz service to the given server.
+//
+// Note: it is preferred to use the admin API
+// (https://pkg.go.dev/google.golang.org/grpc/admin#Register) instead to
+// register Channelz and other administrative services.
 func RegisterChannelzServiceToServer(s grpc.ServiceRegistrar) {
 	channelzgrpc.RegisterChannelzServer(s, newCZServer())
 }


### PR DESCRIPTION
Is it also time to remove "Experimental" from the admin API?

RELEASE NOTES: none