### PR TITLE
transport: fix log spam from Server Authentication Handshake errors

### DIFF
--- a/internal/transport/http2_server.go
+++ b/internal/transport/http2_server.go
@@ -144,6 +144,10 @@ func NewServerTransport(conn net.Conn, config *ServerConfig) (_ ServerTransport,
 			if err == credentials.ErrConnDispatched {
 				return nil, err
 			}
+			// To prevent log spam, return directly.
+			if err == io.EOF {
+				return nil, err
+			}
 			return nil, connectionErrorf(false, err, "ServerHandshake(%q) failed: %v", rawConn.RemoteAddr(), err)
 		}
 	}

--- a/internal/transport/http2_server.go
+++ b/internal/transport/http2_server.go
@@ -140,8 +140,9 @@ func NewServerTransport(conn net.Conn, config *ServerConfig) (_ ServerTransport,
 		conn, authInfo, err = config.Credentials.ServerHandshake(rawConn)
 		if err != nil {
 			// ErrConnDispatched means that the connection was dispatched away
-			// from gRPC; those connections should be left open. To prevent log
-			// spam, return these errors directly.
+			// from gRPC; those connections should be left open. io.EOF means
+			// the connection was closed before handshaking completed, which can
+			// happen naturally from probers. Return these errors directly.
 			if err == credentials.ErrConnDispatched || err == io.EOF {
 				return nil, err
 			}

--- a/internal/transport/http2_server.go
+++ b/internal/transport/http2_server.go
@@ -139,13 +139,10 @@ func NewServerTransport(conn net.Conn, config *ServerConfig) (_ ServerTransport,
 		var err error
 		conn, authInfo, err = config.Credentials.ServerHandshake(rawConn)
 		if err != nil {
-			// ErrConnDispatched means that the connection was dispatched away from
-			// gRPC; those connections should be left open.
-			if err == credentials.ErrConnDispatched {
-				return nil, err
-			}
-			// To prevent log spam, return directly.
-			if err == io.EOF {
+			// ErrConnDispatched means that the connection was dispatched away
+			// from gRPC; those connections should be left open. To prevent log
+			// spam, return these errors directly.
+			if err == credentials.ErrConnDispatched || err == io.EOF {
 				return nil, err
 			}
 			return nil, connectionErrorf(false, err, "ServerHandshake(%q) failed: %v", rawConn.RemoteAddr(), err)

--- a/server.go
+++ b/server.go
@@ -888,8 +888,10 @@ func (s *Server) newHTTP2Transport(c net.Conn) transport.ServerTransport {
 			c.Close()
 		}
 		// Don't log on ErrConnDispatched and io.EOF to prevent log spam.
-		if err != credentials.ErrConnDispatched && err != io.EOF {
-			channelz.Warning(logger, s.channelzID, "grpc: Server.Serve failed to create ServerTransport: ", err)
+		if err != credentials.ErrConnDispatched {
+			if err != io.EOF {
+				channelz.Warning(logger, s.channelzID, "grpc: Server.Serve failed to create ServerTransport: ", err)
+			}
 		}
 		return nil
 	}

--- a/server.go
+++ b/server.go
@@ -887,7 +887,10 @@ func (s *Server) newHTTP2Transport(c net.Conn) transport.ServerTransport {
 		if err != credentials.ErrConnDispatched {
 			c.Close()
 		}
-		channelz.Warning(logger, s.channelzID, "grpc: Server.Serve failed to create ServerTransport: ", err)
+		// Don't log on ErrConnDispatched and io.EOF to prevent log spam.
+		if err != credentials.ErrConnDispatched && err != io.EOF {
+			channelz.Warning(logger, s.channelzID, "grpc: Server.Serve failed to create ServerTransport: ", err)
+		}
 		return nil
 	}
 


### PR DESCRIPTION
This PR fixes log spam, which was introduced by #4692. This PR didn't prevent logging on errConnDispatched and io.EOF, which this PR adds.

RELEASE NOTES: None