### PR TITLE
interop: don't use WithBlock dial option in the client

### DIFF
--- a/interop/client/client.go
+++ b/interop/client/client.go
@@ -202,7 +202,6 @@ func main() {
 	if len(*serviceConfigJSON) > 0 {
 		opts = append(opts, grpc.WithDisableServiceConfig(), grpc.WithDefaultServiceConfig(*serviceConfigJSON))
 	}
-	opts = append(opts, grpc.WithBlock())
 	conn, err := grpc.Dial(serverAddr, opts...)
 	if err != nil {
 		logger.Fatalf("Fail to dial: %v", err)


### PR DESCRIPTION
This is mainly needed to use the interop client in scenarios where it uses an XDS ring hash LB policy - which won't become "Ready" unless an RPC is started. This was originally added in https://github.com/grpc/grpc-go/pull/1559 but shouldn't be needed now.

RELEASE NOTES: N/A