### PR TITLE
xds: Small changes at xDS RBAC Layer

### DIFF
--- a/internal/xds/rbac/rbac_engine.go
+++ b/internal/xds/rbac/rbac_engine.go
@@ -148,6 +148,11 @@ func newRPCData(ctx context.Context) (*rpcData, error) {
 	if !ok {
 		return nil, errors.New("missing metadata in incoming context")
 	}
+	// ":method can be hard-coded to POST if unavailable" - A41
+	md[":method"] = []string{"POST"}
+	// "If the transport exposes TE in Metadata, then RBAC must special-case the
+	// header to treat it as not present." - A41
+	delete(md, "TE")
 
 	pi, ok := peer.FromContext(ctx)
 	if !ok {

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -174,31 +174,6 @@ func AppendToOutgoingContext(ctx context.Context, kv ...string) context.Context 
 	return context.WithValue(ctx, mdOutgoingKey{}, rawMD{md: md.md, added: added})
 }
 
-// AppendToIncomingContext returns a new context with the provided kv merged
-// with any existing metadata in the context. Please refer to the documentation
-// of Pairs for a description of kv.
-func AppendToIncomingContext(ctx context.Context, kv ...string) context.Context {
-	if len(kv)%2 == 1 {
-		panic(fmt.Sprintf("metadata: AppendToIncomingContext got an odd number of input pairs for metadata: %d", len(kv)))
-	}
-	md, _ := ctx.Value(mdIncomingKey{}).(MD)
-	for i := 0; i < len(kv); i += 2 {
-		key := strings.ToLower(kv[i])
-		md[key] = append(md[key], kv[i+1])
-	}
-	return context.WithValue(ctx, mdIncomingKey{}, md)
-}
-
-// DeleteFromIncomingContext returns a new context with metadata that was
-// previously present with the provided values deleted.
-func DeleteFromIncomingContext(ctx context.Context, vs ...string) context.Context {
-	md, _ := ctx.Value(mdIncomingKey{}).(MD)
-	for _, v := range vs {
-		delete(md, v)
-	}
-	return context.WithValue(ctx, mdIncomingKey{}, md)
-}
-
 // FromIncomingContext returns the incoming metadata in ctx if it exists.
 //
 // All keys in the returned MD are lowercase.

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -174,6 +174,31 @@ func AppendToOutgoingContext(ctx context.Context, kv ...string) context.Context 
 	return context.WithValue(ctx, mdOutgoingKey{}, rawMD{md: md.md, added: added})
 }
 
+// AppendToIncomingContext returns a new context with the provided kv merged
+// with any existing metadata in the context. Please refer to the documentation
+// of Pairs for a description of kv.
+func AppendToIncomingContext(ctx context.Context, kv ...string) context.Context {
+	if len(kv)%2 == 1 {
+		panic(fmt.Sprintf("metadata: AppendToIncomingContext got an odd number of input pairs for metadata: %d", len(kv)))
+	}
+	md, _ := ctx.Value(mdIncomingKey{}).(MD)
+	for i := 0; i < len(kv); i += 2 {
+		key := strings.ToLower(kv[i])
+		md[key] = append(md[key], kv[i+1])
+	}
+	return context.WithValue(ctx, mdIncomingKey{}, md)
+}
+
+// DeleteFromIncomingContext returns a new context with metadata that was
+// previously present with the provided values deleted.
+func DeleteFromIncomingContext(ctx context.Context, vs ...string) context.Context {
+	md, _ := ctx.Value(mdIncomingKey{}).(MD)
+	for _, v := range vs {
+		delete(md, v)
+	}
+	return context.WithValue(ctx, mdIncomingKey{}, md)
+}
+
 // FromIncomingContext returns the incoming metadata in ctx if it exists.
 //
 // All keys in the returned MD are lowercase.

--- a/xds/internal/httpfilter/rbac/rbac.go
+++ b/xds/internal/httpfilter/rbac/rbac.go
@@ -30,7 +30,6 @@ import (
 	"google.golang.org/grpc/internal/resolver"
 	"google.golang.org/grpc/internal/xds/env"
 	"google.golang.org/grpc/internal/xds/rbac"
-	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/xds/internal/httpfilter"
 	"google.golang.org/protobuf/types/known/anypb"
 
@@ -211,12 +210,5 @@ type interceptor struct {
 }
 
 func (i *interceptor) AllowRPC(ctx context.Context) error {
-	// ":method can be hard-coded to POST if unavailable" - A41
-	ctx = metadata.AppendToIncomingContext(ctx, ":method", "POST")
-
-	// "If the transport exposes TE in Metadata, then RBAC must special-case the
-	// header to treat it as not present." - A41
-	ctx = metadata.DeleteFromIncomingContext(ctx, "TE")
-
 	return i.chainEngine.IsAuthorized(ctx)
 }


### PR DESCRIPTION
This PR implements these lines from A41:
1. "As documented for HeaderMatcher, Envoy aliases :authority and Host in its header map implementation, so they should be treated equivalent for the RBAC matchers; there must be no behavior change depending on which of the two header names is used in the RBAC policy."
2. ":method can be hard-coded to POST if unavailable and a code audit confirms the server denies requests for all other method types."
3. "If the transport exposes te: trailers in Metadata, then RBAC must special-case the header to treat it as not present."

RELEASE NOTES: None