### PR TITLE
transport: call stats handler for trailers before closeStream

### DIFF
--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -1403,26 +1403,6 @@ func (t *http2Client) operateHeaders(frame *http2.MetaHeadersFrame) {
 	}
 
 	isHeader := false
-	defer func() {
-		if t.statsHandler != nil {
-			if isHeader {
-				inHeader := &stats.InHeader{
-					Client:      true,
-					WireLength:  int(frame.Header().Length),
-					Header:      s.header.Copy(),
-					Compression: s.recvCompress,
-				}
-				t.statsHandler.HandleRPC(s.ctx, inHeader)
-			} else {
-				inTrailer := &stats.InTrailer{
-					Client:     true,
-					WireLength: int(frame.Header().Length),
-					Trailer:    s.trailer.Copy(),
-				}
-				t.statsHandler.HandleRPC(s.ctx, inTrailer)
-			}
-		}
-	}()
 
 	// If headerChan hasn't been closed yet
 	if atomic.CompareAndSwapUint32(&s.headerChanClosed, 0, 1) {
@@ -1442,6 +1422,25 @@ func (t *http2Client) operateHeaders(frame *http2.MetaHeadersFrame) {
 			s.noHeaders = true
 		}
 		close(s.headerChan)
+	}
+
+	if t.statsHandler != nil {
+		if isHeader {
+			inHeader := &stats.InHeader{
+				Client:      true,
+				WireLength:  int(frame.Header().Length),
+				Header:      metadata.MD(mdata).Copy(),
+				Compression: s.recvCompress,
+			}
+			t.statsHandler.HandleRPC(s.ctx, inHeader)
+		} else {
+			inTrailer := &stats.InTrailer{
+				Client:     true,
+				WireLength: int(frame.Header().Length),
+				Trailer:    metadata.MD(mdata).Copy(),
+			}
+			t.statsHandler.HandleRPC(s.ctx, inTrailer)
+		}
 	}
 
 	if !endStream {


### PR DESCRIPTION
Fixes #4808 (the second race).

By calling `closeStream` first, it was possible to end up calling the stats handler with the `End` stat before the `InTrailer` stat.  While this is valid, it does not seem desirable, and this change makes it so that is no longer possible.

This also corrects a very minor bug where the stats handler would receive the contents of `s.trailer`, which _might_ not be the same as `mdata` if a race led to `closeStream` being called on that stream before `operateHeaders` was able to call `closeStream`.

RELEASE NOTES: none