### PR TITLE
xds: Small RBAC Changes defined in A41

### DIFF
--- a/internal/xds/rbac/matchers.go
+++ b/internal/xds/rbac/matchers.go
@@ -183,7 +183,9 @@ func matchersFromPrincipals(principals []*v3rbacpb.Principal) ([]matcher, error)
 			// The source ip principal identifier is deprecated. Thus, a
 			// principal typed as a source ip in the identifier will be a no-op.
 			// The config should use DirectRemoteIp instead.
-		case *v3rbacpb.Principal_RemoteIp: // "...allow equating RBAC's direct_remote_ip and remote_ip" - A41
+		case *v3rbacpb.Principal_RemoteIp:
+			// RBAC in gRPC treats direct_remote_ip and remote_ip as logically
+			// equivalent, as per A41.
 			m, err := newSourceIPMatcher(principal.GetRemoteIp())
 			if err != nil {
 				return nil, err

--- a/internal/xds/rbac/matchers.go
+++ b/internal/xds/rbac/matchers.go
@@ -183,9 +183,12 @@ func matchersFromPrincipals(principals []*v3rbacpb.Principal) ([]matcher, error)
 			// The source ip principal identifier is deprecated. Thus, a
 			// principal typed as a source ip in the identifier will be a no-op.
 			// The config should use DirectRemoteIp instead.
-		case *v3rbacpb.Principal_RemoteIp: // Allow equating RBAC's direct_remote_ip...do we need this?
-			// Not supported in gRPC RBAC currently - a principal typed as
-			// Remote Ip in the initial config will be a no-op.
+		case *v3rbacpb.Principal_RemoteIp: // "...allow equating RBAC's direct_remote_ip and remote_ip" - A41
+			m, err := newSourceIPMatcher(principal.GetRemoteIp())
+			if err != nil {
+				return nil, err
+			}
+			matchers = append(matchers, m)
 		case *v3rbacpb.Principal_Metadata:
 			// Not supported in gRPC RBAC currently - a principal typed as
 			// Metadata in the initial config will be a no-op.
@@ -395,9 +398,11 @@ func (am *authenticatedMatcher) match(data *rpcData) bool {
 	if am.stringMatcher == nil {
 		return len(data.certs) != 0
 	}
-	// No certificate present, so will never successfully match.
+	// "If there is no client certificate (thus no SAN nor Subject), check if ""
+	// (empty string) matches. If it matches, the principal_name is said to
+	// match" - A41
 	if len(data.certs) == 0 {
-		return false
+		return am.stringMatcher.Match("")
 	}
 	cert := data.certs[0]
 	// The order of matching as per the RBAC documentation (see package-level comments)

--- a/internal/xds/rbac/rbac_engine.go
+++ b/internal/xds/rbac/rbac_engine.go
@@ -195,7 +195,7 @@ func newRPCData(ctx context.Context) (*rpcData, error) {
 		peerInfo:        pi,
 		fullMethod:      mn,
 		destinationPort: uint32(dp),
-		destinationAddr: conn.LocalAddr(),
+		localAddr:       conn.LocalAddr(),
 		certs:           peerCertificates,
 	}, nil
 }
@@ -212,8 +212,8 @@ type rpcData struct {
 	// destinationPort is the port that the RPC is being sent to on the
 	// server.
 	destinationPort uint32
-	// destinationAddr is the address that the RPC is being sent to.
-	destinationAddr net.Addr
+	// localAddr is the address that the RPC is being sent to.
+	localAddr net.Addr
 	// certs are the certificates presented by the peer during a TLS
 	// handshake.
 	certs []*x509.Certificate

--- a/xds/internal/httpfilter/rbac/rbac.go
+++ b/xds/internal/httpfilter/rbac/rbac.go
@@ -173,6 +173,12 @@ func (builder) BuildServerInterceptor(cfg httpfilter.FilterConfig, override http
 		return nil, nil
 	}
 
+	// "At this time, if the RBAC.action is Action.LOG then the policy will be
+	// completely ignored, as if RBAC was not configurated." - A41
+	if icfg.Rules.Action == v3rbacpb.RBAC_LOG {
+		return nil, nil
+	}
+
 	// "Envoy aliases :authority and Host in its header map implementation, so
 	// they should be treated equivalent for the RBAC matchers; there must be no
 	// behavior change depending on which of the two header names is used in the

--- a/xds/internal/test/xds_server_integration_test.go
+++ b/xds/internal/test/xds_server_integration_test.go
@@ -890,6 +890,30 @@ func (s) TestRBACHTTPFilter(t *testing.T) {
 			wantStatusEmptyCall: codes.PermissionDenied,
 			wantStatusUnaryCall: codes.PermissionDenied,
 		},
+		// This test tests that an RBAC Config with Action.LOG configured allows
+		// every RPC through. This maps to the line "At this time, if the
+		// RBAC.action is Action.LOG then the policy will be completely ignored,
+		// as if RBAC was not configurated." from A41
+		{
+			name: "action-log",
+			rbacCfg: &rpb.RBAC{
+				Rules: &v3rbacpb.RBAC{
+					Action: v3rbacpb.RBAC_LOG,
+					Policies: map[string]*v3rbacpb.Policy{
+						"anyone": {
+							Permissions: []*v3rbacpb.Permission{
+								{Rule: &v3rbacpb.Permission_Any{Any: true}},
+							},
+							Principals: []*v3rbacpb.Principal{
+								{Identifier: &v3rbacpb.Principal_Any{Any: true}},
+							},
+						},
+					},
+				},
+			},
+			wantStatusEmptyCall: codes.OK,
+			wantStatusUnaryCall: codes.OK,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
This PR implements these three lines from A41:
"to allow equating RBAC's direct_remote_ip and remote_ip."
"At this time, if the RBAC.action is Action.LOG then the policy will be completely ignored, as if RBAC was not configurated."
"If there is no client certificate (thus no SAN nor Subject), check if "" (empty string) matches. If it matches, the principal_name is said to match"

RELEASE NOTES: None