### PR TITLE
test: fix stayConnected to call Connect after state reports IDLE

### DIFF
--- a/clientconn_test.go
+++ b/clientconn_test.go
@@ -1067,8 +1067,14 @@ func stayConnected(cc *ClientConn) {
 	defer cancel()
 
 	for {
-		cc.Connect()
-		if state := cc.GetState(); state == connectivity.Shutdown || !cc.WaitForStateChange(ctx, state) {
+		state := cc.GetState()
+		switch state {
+		case connectivity.Idle:
+			cc.Connect()
+		case connectivity.Shutdown:
+			return
+		}
+		if !cc.WaitForStateChange(ctx, state) {
 			return
 		}
 	}


### PR DESCRIPTION
Fixes #4729 (I hope)

I noticed a potential race:
1. `stayConnected` calls `cc.Connect()`
1. `cc` is not `IDLE` so does nothing
1. `ac` goes `IDLE` for any reason
1. `cc.GetState()` reports `IDLE`
1. `stayConnected` waits for the state to change from `IDLE`, which will never happen
1. `<not reached>`

The fix is to call `cc.GetState()` first, then call `cc.Connect()` if `IDLE`, and then wait for the state to change before doing anything else otherwise.

RELEASE NOTES: none