### PR TITLE
creds/google: replace NewComputeEngineCredsWithOptions with NewDefaultCredentialsWithOptions

### DIFF
--- a/credentials/google/google.go
+++ b/credentials/google/google.go
@@ -37,7 +37,7 @@ var logger = grpclog.Component("credentials")
 
 // DefaultCredentialsOptions constructs options to build DefaultCredentials.
 type DefaultCredentialsOptions struct {
-	// PerRPCCreds is a  per RPC credentials that is passed to a bundle.
+	// PerRPCCreds is a per RPC credentials that is passed to a bundle.
 	PerRPCCreds credentials.PerRPCCredentials
 }
 
@@ -53,7 +53,7 @@ func NewDefaultCredentialsWithOptions(opts DefaultCredentialsOptions) credential
 		var err error
 		perRPC, err = oauth.NewApplicationDefault(ctx)
 		if err != nil {
-			logger.Warningf("google default creds: failed to create application oauth: %v", err)
+			logger.Warningf("NewDefaultCredentialsWithOptions: failed to create application oauth: %v", err)
 		}
 	}
 	c := &creds{
@@ -63,7 +63,7 @@ func NewDefaultCredentialsWithOptions(opts DefaultCredentialsOptions) credential
 	}
 	bundle, err := c.NewWithMode(internal.CredsBundleModeFallback)
 	if err != nil {
-		logger.Warningf("google default creds with per rpc: failed to create new creds: %v", err)
+		logger.Warningf("NewDefaultCredentialsWithOptions: failed to create new creds: %v", err)
 	}
 	return bundle
 }

--- a/credentials/google/google.go
+++ b/credentials/google/google.go
@@ -35,8 +35,8 @@ const tokenRequestTimeout = 30 * time.Second
 
 var logger = grpclog.Component("credentials")
 
-// DefaultCredsOptions constructs options to build DefaultCreds.
-type DefaultCredsOptions struct {
+// DefaultCredentialsOptions constructs options to build DefaultCredentials.
+type DefaultCredentialsOptions struct {
 	// PerRPCCreds is a  per RPC credentials that is passed to a bundle.
 	PerRPCCreds credentials.PerRPCCredentials
 }
@@ -45,7 +45,7 @@ type DefaultCredsOptions struct {
 // configured to work with google services.
 //
 // This API is experimental.
-func NewDefaultCredentialsWithOptions(opts DefaultCredsOptions) credentials.Bundle {
+func NewDefaultCredentialsWithOptions(opts DefaultCredentialsOptions) credentials.Bundle {
 	perRPC := opts.PerRPCCreds
 	if perRPC == nil {
 		ctx, cancel := context.WithTimeout(context.Background(), tokenRequestTimeout)
@@ -73,7 +73,7 @@ func NewDefaultCredentialsWithOptions(opts DefaultCredsOptions) credentials.Bund
 //
 // This API is experimental.
 func NewDefaultCredentials() credentials.Bundle {
-	return NewDefaultCredentialsWithOptions(DefaultCredsOptions{})
+	return NewDefaultCredentialsWithOptions(DefaultCredentialsOptions{})
 }
 
 // NewComputeEngineCredentials returns a credentials bundle that is configured to work
@@ -82,7 +82,7 @@ func NewDefaultCredentials() credentials.Bundle {
 //
 // This API is experimental.
 func NewComputeEngineCredentials() credentials.Bundle {
-	return NewDefaultCredentialsWithOptions(DefaultCredsOptions{
+	return NewDefaultCredentialsWithOptions(DefaultCredentialsOptions{
 		PerRPCCreds: oauth.NewComputeEngine(),
 	})
 }

--- a/credentials/google/google.go
+++ b/credentials/google/google.go
@@ -63,7 +63,7 @@ func NewDefaultCredentialsWithOptions(opts DefaultCredentialsOptions) credential
 	}
 	bundle, err := c.NewWithMode(internal.CredsBundleModeFallback)
 	if err != nil {
-		logger.Warningf("compute engine creds with per rpc: failed to create new creds: %v", err)
+		logger.Warningf("google default creds with per rpc: failed to create new creds: %v", err)
 	}
 	return bundle
 }

--- a/credentials/google/google.go
+++ b/credentials/google/google.go
@@ -88,9 +88,9 @@ type creds struct {
 
 	// Supported modes are defined in internal/internal.go.
 	mode string
-	// The transport credentials associated with this bundle.
+	// The active transport credentials associated with this bundle.
 	transportCreds credentials.TransportCredentials
-	// The per RPC credentials associated with this bundle.
+	// The active per RPC credentials associated with this bundle.
 	perRPCCreds credentials.PerRPCCredentials
 }
 

--- a/credentials/google/google_test.go
+++ b/credentials/google/google_test.go
@@ -76,9 +76,9 @@ func overrideNewCredsFuncs() func() {
 func TestClientHandshakeBasedOnClusterName(t *testing.T) {
 	defer overrideNewCredsFuncs()()
 	for bundleTyp, tc := range map[string]credentials.Bundle{
-		"defaultCreds":       NewDefaultCredentials(),
-		"computeCreds":       NewComputeEngineCredentials(),
-		"computeCredsPerRPC": NewComputeEngineCredsWithOptions(ComputeEngineCredsOptions{}),
+		"defaultCredsWithOptions": NewDefaultCredentialsWithOptions(DefaultCredentialsOptions{}),
+		"defaultCreds":            NewDefaultCredentials(),
+		"computeCreds":            NewComputeEngineCredentials(),
 	} {
 		tests := []struct {
 			name    string


### PR DESCRIPTION
The new bundle built with options not only works on GCE.
See #4767 for the previous change

RELEASE NOTES:
* creds/google: add NewDefaultCredentialsWithOptions() to support custom per-RPC creds