### PR TITLE
xds: Added imports for HTTP Filters

### DIFF
--- a/xds/xds.go
+++ b/xds/xds.go
@@ -39,6 +39,8 @@ import (
 	_ "google.golang.org/grpc/credentials/tls/certprovider/pemfile" // Register the file watcher certificate provider plugin.
 	_ "google.golang.org/grpc/xds/internal/balancer"                // Register the balancers.
 	_ "google.golang.org/grpc/xds/internal/httpfilter/fault"        // Register the fault injection filter.
+	_ "google.golang.org/grpc/xds/internal/httpfilter/rbac"         // Register the RBAC filter.
+	_ "google.golang.org/grpc/xds/internal/httpfilter/router"       // Register the router filter.
 	xdsresolver "google.golang.org/grpc/xds/internal/resolver"      // Register the xds_resolver.
 	_ "google.golang.org/grpc/xds/internal/xdsclient/v2"            // Register the v2 xDS API client.
 	_ "google.golang.org/grpc/xds/internal/xdsclient/v3"            // Register the v3 xDS API client.


### PR DESCRIPTION
This PR imports the HTTP Filters RBAC and Router, so that in non testing scenarios the two filters get registered.

RELEASE NOTES: None