### PR TITLE
xds/clusterimpl: fix SubConn wrapper returned by picker during race

### DIFF
--- a/xds/internal/balancer/clusterimpl/picker.go
+++ b/xds/internal/balancer/clusterimpl/picker.go
@@ -102,17 +102,15 @@ func newPicker(s balancer.State, config *dropConfigs, loadStore load.PerClusterR
 func (d *picker) Pick(info balancer.PickInfo) (balancer.PickResult, error) {
 	// Don't drop unless the inner picker is READY. Similar to
 	// https://github.com/grpc/grpc-go/issues/2622.
-	if d.s.ConnectivityState != connectivity.Ready {
-		return d.s.Picker.Pick(info)
-	}
-
-	// Check if this RPC should be dropped by category.
-	for _, dp := range d.drops {
-		if dp.drop() {
-			if d.loadStore != nil {
-				d.loadStore.CallDropped(dp.category)
+	if d.s.ConnectivityState == connectivity.Ready {
+		// Check if this RPC should be dropped by category.
+		for _, dp := range d.drops {
+			if dp.drop() {
+				if d.loadStore != nil {
+					d.loadStore.CallDropped(dp.category)
+				}
+				return balancer.PickResult{}, status.Errorf(codes.Unavailable, "RPC is dropped")
 			}
-			return balancer.PickResult{}, status.Errorf(codes.Unavailable, "RPC is dropped")
 		}
 	}
 


### PR DESCRIPTION
The previous logic is that the picker updated with a non-Ready state
should always return error, so the clusterimpl picker doesn't try to
unwrap the SubConn.

The assumption is not true, in cases like ring_hash (where the picker is
mutable, and could start to return SubConns before the overall state is
updated to Ready during races).

fixes #4778

RELEASE NOTES: N/A