### PR TITLE
xds/federation: support populating resource template in xds-resolver

### DIFF
--- a/xds/internal/resolver/xds_resolver_test.go
+++ b/xds/internal/resolver/xds_resolver_test.go
@@ -21,6 +21,7 @@ package resolver
 import (
 	"context"
 	"errors"
+	"net/url"
 	"reflect"
 	"strings"
 	"testing"
@@ -62,7 +63,7 @@ const (
 	defaultTestShortTimeout = 100 * time.Microsecond
 )
 
-var target = resolver.Target{Endpoint: targetStr}
+var target = resolver.Target{Endpoint: targetStr, URL: url.URL{Scheme: "xds", Path: "/" + targetStr}}
 
 var routerFilter = xdsresource.HTTPFilter{Name: "rtr", Filter: httpfilter.Get(router.TypeURL)}
 var routerFilterList = []xdsresource.HTTPFilter{routerFilter}
@@ -117,6 +118,7 @@ func (s) TestResolverBuilder(t *testing.T) {
 	tests := []struct {
 		name          string
 		xdsClientFunc func() (xdsclient.XDSClient, error)
+		target        resolver.Target
 		wantErr       bool
 	}{
 		{
@@ -124,12 +126,36 @@ func (s) TestResolverBuilder(t *testing.T) {
 			xdsClientFunc: func() (xdsclient.XDSClient, error) {
 				return fakeclient.NewClient(), nil
 			},
+			target:  target,
 			wantErr: false,
 		},
 		{
 			name: "newXDSClient-throws-error",
 			xdsClientFunc: func() (xdsclient.XDSClient, error) {
 				return nil, errors.New("newXDSClient-throws-error")
+			},
+			target:  target,
+			wantErr: true,
+		},
+		{
+			name: "authority not defined in bootstrap",
+			xdsClientFunc: func() (xdsclient.XDSClient, error) {
+				c := fakeclient.NewClient()
+				c.SetBootstrapConfig(&bootstrap.Config{
+					ClientDefaultListenerResourceNameTemplate: "%s",
+					Authorities: map[string]*bootstrap.Authority{
+						"test-authority": {
+							ClientListenerResourceNameTemplate: "xdstp://test-authority/%s",
+						},
+					},
+				})
+				return c, nil
+			},
+			target: resolver.Target{
+				URL: url.URL{
+					Host: "non-existing-authority",
+					Path: "/" + targetStr,
+				},
 			},
 			wantErr: true,
 		},
@@ -148,7 +174,7 @@ func (s) TestResolverBuilder(t *testing.T) {
 				t.Fatalf("resolver.Get(%v) returned nil", xdsScheme)
 			}
 
-			r, err := builder.Build(target, newTestClientConn(), resolver.BuildOptions{})
+			r, err := builder.Build(test.target, newTestClientConn(), resolver.BuildOptions{})
 			if (err != nil) != test.wantErr {
 				t.Fatalf("builder.Build(%v) returned err: %v, wantErr: %v", target, err, test.wantErr)
 			}
@@ -197,6 +223,7 @@ func (s) TestResolverBuilder_xdsCredsBootstrapMismatch(t *testing.T) {
 
 type setupOpts struct {
 	xdsClientFunc func() (xdsclient.XDSClient, error)
+	target        *resolver.Target
 }
 
 func testSetup(t *testing.T, opts setupOpts) (*xdsResolver, *testClientConn, func()) {
@@ -214,7 +241,11 @@ func testSetup(t *testing.T, opts setupOpts) (*xdsResolver, *testClientConn, fun
 	}
 
 	tcc := newTestClientConn()
-	r, err := builder.Build(target, tcc, resolver.BuildOptions{})
+	tgt := target
+	if opts.target != nil {
+		tgt = *opts.target
+	}
+	r, err := builder.Build(tgt, tcc, resolver.BuildOptions{})
 	if err != nil {
 		t.Fatalf("builder.Build(%v) returned err: %v", target, err)
 	}
@@ -248,6 +279,95 @@ func waitForWatchRouteConfig(ctx context.Context, t *testing.T, xdsC *fakeclient
 	}
 	if gotTarget != wantTarget {
 		t.Fatalf("xdsClient.WatchService() called with target: %v, want %v", gotTarget, wantTarget)
+	}
+}
+
+// TestXDSResolverResourceNameToWatch tests that the correct resource name is
+// used to watch for the service. This covers cases with different bootstrap
+// config, and different authority.
+func (s) TestXDSResolverResourceNameToWatch(t *testing.T) {
+	tests := []struct {
+		name   string
+		bc     *bootstrap.Config
+		target *resolver.Target
+		want   string
+	}{
+		{
+			name: "default %s old style",
+			bc: &bootstrap.Config{
+				ClientDefaultListenerResourceNameTemplate: "%s",
+			},
+			target: &resolver.Target{
+				URL: url.URL{Path: "/" + targetStr},
+			},
+			want: targetStr,
+		},
+		{
+			name: "old style no percent encoding",
+			bc: &bootstrap.Config{
+				ClientDefaultListenerResourceNameTemplate: "/path/to/%s",
+			},
+			target: &resolver.Target{
+				URL: url.URL{Path: "/" + targetStr},
+			},
+			want: "/path/to/" + targetStr,
+		},
+		{
+			name: "new style with %s",
+			bc: &bootstrap.Config{
+				ClientDefaultListenerResourceNameTemplate: "xdstp://authority.com/%s",
+				Authorities: nil,
+			},
+			target: &resolver.Target{
+				URL: url.URL{Path: "/0.0.0.0:8080"},
+			},
+			want: "xdstp://authority.com/0.0.0.0:8080",
+		},
+		{
+			name: "new style percent encoding",
+			bc: &bootstrap.Config{
+				ClientDefaultListenerResourceNameTemplate: "xdstp://authority.com/%s",
+				Authorities: nil,
+			},
+			target: &resolver.Target{
+				URL: url.URL{Path: "/[::1]:8080"},
+			},
+			want: "xdstp://authority.com/%5B::1%5D:8080",
+		},
+		{
+			name: "new style different authority",
+			bc: &bootstrap.Config{
+				ClientDefaultListenerResourceNameTemplate: "xdstp://authority.com/%s",
+				Authorities: map[string]*bootstrap.Authority{
+					"test-authority": {
+						ClientListenerResourceNameTemplate: "xdstp://test-authority/%s",
+					},
+				},
+			},
+			target: &resolver.Target{
+				URL: url.URL{
+					Host: "test-authority",
+					Path: "/" + targetStr,
+				},
+			},
+			want: "xdstp://test-authority/" + targetStr,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			xdsC := fakeclient.NewClient()
+			xdsC.SetBootstrapConfig(tt.bc)
+			xdsR, _, cancel := testSetup(t, setupOpts{
+				xdsClientFunc: func() (xdsclient.XDSClient, error) { return xdsC, nil },
+				target:        tt.target,
+			})
+			defer cancel()
+			defer xdsR.Close()
+
+			ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+			defer cancel()
+			waitForWatchListener(ctx, t, xdsC, tt.want)
+		})
 	}
 }
 

--- a/xds/internal/testutils/fakeclient/client.go
+++ b/xds/internal/testutils/fakeclient/client.go
@@ -306,11 +306,11 @@ func NewClient() *Client {
 func NewClientWithName(name string) *Client {
 	return &Client{
 		name:         name,
-		ldsWatchCh:   testutils.NewChannel(),
+		ldsWatchCh:   testutils.NewChannelWithSize(10),
 		rdsWatchCh:   testutils.NewChannelWithSize(10),
 		cdsWatchCh:   testutils.NewChannelWithSize(10),
 		edsWatchCh:   testutils.NewChannelWithSize(10),
-		ldsCancelCh:  testutils.NewChannel(),
+		ldsCancelCh:  testutils.NewChannelWithSize(10),
 		rdsCancelCh:  testutils.NewChannelWithSize(10),
 		cdsCancelCh:  testutils.NewChannelWithSize(10),
 		edsCancelCh:  testutils.NewChannelWithSize(10),

--- a/xds/internal/testutils/fakeclient/client.go
+++ b/xds/internal/testutils/fakeclient/client.go
@@ -317,6 +317,7 @@ func NewClientWithName(name string) *Client {
 		loadReportCh: testutils.NewChannel(),
 		lrsCancelCh:  testutils.NewChannel(),
 		loadStore:    load.NewStore(),
+		bootstrapCfg: &bootstrap.Config{ClientDefaultListenerResourceNameTemplate: "%s"},
 		rdsCbs:       make(map[string]func(xdsresource.RouteConfigUpdate, error)),
 		cdsCbs:       make(map[string]func(xdsresource.ClusterUpdate, error)),
 		edsCbs:       make(map[string]func(xdsresource.EndpointsUpdate, error)),

--- a/xds/internal/xdsclient/bootstrap/template.go
+++ b/xds/internal/xdsclient/bootstrap/template.go
@@ -1,0 +1,47 @@
+/*
+ *
+ * Copyright 2021 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package bootstrap
+
+import (
+	"net/url"
+	"strings"
+)
+
+// PopulateResourceTemplate populates the given template using the target
+// string. "%s", if exists in the template, will be replaced with target.
+//
+// If the template starts with "xdstp:", the replaced string will be %-encoded.
+// But note that "/" is not percent encoded.
+func PopulateResourceTemplate(template, target string) string {
+	if !strings.Contains(template, "%s") {
+		return template
+	}
+	if strings.HasPrefix(template, "xdstp:") {
+		target = percentEncode(target)
+	}
+	return strings.Replace(template, "%s", target, -1)
+}
+
+// percentEncode percent encode t, except for "/". See the tests for examples.
+func percentEncode(t string) string {
+	segs := strings.Split(t, "/")
+	for i := range segs {
+		segs[i] = url.PathEscape(segs[i])
+	}
+	return strings.Join(segs, "/")
+}

--- a/xds/internal/xdsclient/bootstrap/template_test.go
+++ b/xds/internal/xdsclient/bootstrap/template_test.go
@@ -21,34 +21,34 @@ import "testing"
 
 func Test_percentEncode(t *testing.T) {
 	tests := []struct {
-		name string
-		t    string
-		want string
+		name   string
+		target string
+		want   string
 	}{
 		{
-			name: "normal name",
-			t:    "server.example.com",
-			want: "server.example.com",
+			name:   "normal name",
+			target: "server.example.com",
+			want:   "server.example.com",
 		},
 		{
-			name: "ipv4",
-			t:    "0.0.0.0:8080",
-			want: "0.0.0.0:8080",
+			name:   "ipv4",
+			target: "0.0.0.0:8080",
+			want:   "0.0.0.0:8080",
 		},
 		{
-			name: "ipv6",
-			t:    "[::1]:8080",
-			want: "%5B::1%5D:8080", // [ and ] are percent encoded.
+			name:   "ipv6",
+			target: "[::1]:8080",
+			want:   "%5B::1%5D:8080", // [ and ] are percent encoded.
 		},
 		{
-			name: "/ should not be percent encoded",
-			t:    "my/service/region",
-			want: "my/service/region", // "/"s are kept.
+			name:   "/ should not be percent encoded",
+			target: "my/service/region",
+			want:   "my/service/region", // "/"s are kept.
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := percentEncode(tt.t); got != tt.want {
+			if got := percentEncode(tt.target); got != tt.want {
 				t.Errorf("percentEncode() = %v, want %v", got, tt.want)
 			}
 		})
@@ -59,37 +59,37 @@ func TestPopulateResourceTemplate(t *testing.T) {
 	tests := []struct {
 		name     string
 		template string
-		t        string
+		target   string
 		want     string
 	}{
 		{
 			name:     "no %s",
 			template: "/name/template",
-			t:        "[::1]:8080",
+			target:   "[::1]:8080",
 			want:     "/name/template",
 		},
 		{
 			name:     "with %s, no xdstp: prefix, ipv6",
 			template: "/name/template/%s",
-			t:        "[::1]:8080",
+			target:   "[::1]:8080",
 			want:     "/name/template/[::1]:8080",
 		},
 		{
 			name:     "with %s, with xdstp: prefix",
 			template: "xdstp://authority.com/%s",
-			t:        "0.0.0.0:8080",
+			target:   "0.0.0.0:8080",
 			want:     "xdstp://authority.com/0.0.0.0:8080",
 		},
 		{
 			name:     "with %s, with xdstp: prefix, and ipv6",
 			template: "xdstp://authority.com/%s",
-			t:        "[::1]:8080",
+			target:   "[::1]:8080",
 			want:     "xdstp://authority.com/%5B::1%5D:8080",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := PopulateResourceTemplate(tt.template, tt.t); got != tt.want {
+			if got := PopulateResourceTemplate(tt.template, tt.target); got != tt.want {
 				t.Errorf("PopulateResourceTemplate() = %v, want %v", got, tt.want)
 			}
 		})

--- a/xds/internal/xdsclient/bootstrap/template_test.go
+++ b/xds/internal/xdsclient/bootstrap/template_test.go
@@ -1,0 +1,97 @@
+/*
+ *
+ * Copyright 2021 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package bootstrap
+
+import "testing"
+
+func Test_percentEncode(t *testing.T) {
+	tests := []struct {
+		name string
+		t    string
+		want string
+	}{
+		{
+			name: "normal name",
+			t:    "server.example.com",
+			want: "server.example.com",
+		},
+		{
+			name: "ipv4",
+			t:    "0.0.0.0:8080",
+			want: "0.0.0.0:8080",
+		},
+		{
+			name: "ipv6",
+			t:    "[::1]:8080",
+			want: "%5B::1%5D:8080", // [ and ] are percent encoded.
+		},
+		{
+			name: "/ should not be percent encoded",
+			t:    "my/service/region",
+			want: "my/service/region", // "/"s are kept.
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := percentEncode(tt.t); got != tt.want {
+				t.Errorf("percentEncode() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPopulateResourceTemplate(t *testing.T) {
+	tests := []struct {
+		name     string
+		template string
+		t        string
+		want     string
+	}{
+		{
+			name:     "no %s",
+			template: "/name/template",
+			t:        "[::1]:8080",
+			want:     "/name/template",
+		},
+		{
+			name:     "with %s, no xdstp: prefix, ipv6",
+			template: "/name/template/%s",
+			t:        "[::1]:8080",
+			want:     "/name/template/[::1]:8080",
+		},
+		{
+			name:     "with %s, with xdstp: prefix",
+			template: "xdstp://authority.com/%s",
+			t:        "0.0.0.0:8080",
+			want:     "xdstp://authority.com/0.0.0.0:8080",
+		},
+		{
+			name:     "with %s, with xdstp: prefix, and ipv6",
+			template: "xdstp://authority.com/%s",
+			t:        "[::1]:8080",
+			want:     "xdstp://authority.com/%5B::1%5D:8080",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := PopulateResourceTemplate(tt.template, tt.t); got != tt.want {
+				t.Errorf("PopulateResourceTemplate() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/xds/server.go
+++ b/xds/server.go
@@ -23,7 +23,6 @@ import (
 	"errors"
 	"fmt"
 	"net"
-	"strings"
 	"sync"
 
 	"google.golang.org/grpc"
@@ -42,6 +41,7 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/grpc/xds/internal/server"
 	"google.golang.org/grpc/xds/internal/xdsclient"
+	"google.golang.org/grpc/xds/internal/xdsclient/bootstrap"
 	"google.golang.org/grpc/xds/internal/xdsclient/xdsresource"
 )
 
@@ -217,10 +217,7 @@ func (s *GRPCServer) Serve(lis net.Listener) error {
 	if cfg.ServerListenerResourceNameTemplate == "" {
 		return errors.New("missing server_listener_resource_name_template in the bootstrap configuration")
 	}
-	name := cfg.ServerListenerResourceNameTemplate
-	if strings.Contains(cfg.ServerListenerResourceNameTemplate, "%s") {
-		name = strings.Replace(cfg.ServerListenerResourceNameTemplate, "%s", lis.Addr().String(), -1)
-	}
+	name := bootstrap.PopulateResourceTemplate(cfg.ServerListenerResourceNameTemplate, lis.Addr().String())
 
 	modeUpdateCh := buffer.NewUnbounded()
 	go func() {


### PR DESCRIPTION
And also handle percent encoding for new style resource names.

RELEASE NOTES:
* [bug]xds/resolver: release leaked ClientConn if resolver initialization fails