### PR TITLE
xds: Set RBAC on by default

### DIFF
--- a/internal/xds/env/env.go
+++ b/internal/xds/env/env.go
@@ -83,8 +83,10 @@ var (
 	// RetrySupport indicates whether xDS retry is enabled.
 	RetrySupport = !strings.EqualFold(os.Getenv(retrySupportEnv), "false")
 
-	// RBACSupport indicates whether xDS configured RBAC HTTP Filter is enabled.
-	RBACSupport = strings.EqualFold(os.Getenv(rbacSupportEnv), "true")
+	// RBACSupport indicates whether xDS configured RBAC HTTP Filter is enabled,
+	// which can be disabled by setting the environment variable
+	// "GRPC_XDS_EXPERIMENTAL_RBAC" to "false".
+	RBACSupport = !strings.EqualFold(os.Getenv(rbacSupportEnv), "false")
 
 	// C2PResolverSupport indicates whether support for C2P resolver is enabled.
 	// This can be enabled by setting the environment variable


### PR DESCRIPTION
This PR sets the xDS configured RBAC on by default. Now, a user will have to disable RBAC explicitly, which used to be the default behavior.

RELEASE NOTES: None