### PR TITLE
codes: Add Code.WellDefinedString for formatting aligned with the GRPC documentation

### DIFF
--- a/codes/code_string.go
+++ b/codes/code_string.go
@@ -60,3 +60,50 @@ func (c Code) String() string {
 		return "Code(" + strconv.FormatInt(int64(c), 10) + ")"
 	}
 }
+
+// WellDefinedString returns the name given for c in the GRPC Core
+// documentation. Unlike the String method, which returns a value corresponding
+// to the Go constant corresponding to c, this method returns the form used in
+// the definition of GRPC codes.
+//
+// See https://grpc.github.io/grpc/core/md_doc_statuscodes.html
+func (c Code) WellDefinedString() string {
+	switch c {
+	case OK:
+		return "OK"
+	case Canceled:
+		return "CANCELLED"
+	case Unknown:
+		return "UNKNOWN"
+	case InvalidArgument:
+		return "INVALID_ARGUMENT"
+	case DeadlineExceeded:
+		return "DEADLINE_EXCEEDED"
+	case NotFound:
+		return "NOT_FOUND"
+	case AlreadyExists:
+		return "ALREADY_EXISTS"
+	case PermissionDenied:
+		return "PERMISSION_DENIED"
+	case ResourceExhausted:
+		return "RESOURCE_EXHAUSTED"
+	case FailedPrecondition:
+		return "FAILED_PRECONDITION"
+	case Aborted:
+		return "ABORTED"
+	case OutOfRange:
+		return "OUT_OF_RANGE"
+	case Unimplemented:
+		return "UNIMPLEMENTED"
+	case Internal:
+		return "INTERNAL"
+	case Unavailable:
+		return "UNAVAILABLE"
+	case DataLoss:
+		return "DATA_LOSS"
+	case Unauthenticated:
+		return "UNAUTHENTICATED"
+	default:
+		return "CODE(" + strconv.FormatInt(int64(c), 10) + ")"
+	}
+}

--- a/codes/codes_test.go
+++ b/codes/codes_test.go
@@ -20,6 +20,7 @@ package codes
 
 import (
 	"encoding/json"
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -89,5 +90,26 @@ func (s) TestUnmarshalJSON_MarshalUnmarshal(t *testing.T) {
 		if c != cUnMarshaled {
 			t.Errorf("code is %q after marshalling/unmarshalling, expected %q", cUnMarshaled, c)
 		}
+	}
+}
+
+func TestWellDefinedString(t *testing.T) {
+	for _, test := range []struct {
+		code Code
+		want string
+	}{
+		// We don't exhaustively re-test the completeness of the table in the
+		// WellDefinedString implementation itself. Rather, we check the zero
+		// value OK (zeroes are always worth some attention), a non-zero but
+		// defined code, and a code not yet known to this library.
+		{OK, "OK"},
+		{PermissionDenied, "PERMISSION_DENIED"},
+		{Code(uint32(4242)), "CODE(4242)"},
+	} {
+		t.Run(fmt.Sprintf("code_%d", test.code), func(t *testing.T) {
+			if got := test.code.WellDefinedString(); got != test.want {
+				t.Errorf("wanted %q but got %q", test.want, got)
+			}
+		})
 	}
 }


### PR DESCRIPTION
This change adds a method `Codes.WellDefinedString` to return the string form of a `Code` corresponding to the one found in [the GRPC Code documentation](https://grpc.github.io/grpc/core/md_doc_statuscodes.html). The current `String` method returns a value meaningful in the context of Go source code (reasonable!), but in some applications, particularly those logging code strings as event tags for use with metrics, having access to the canonical version is preferable.
