### PR TITLE
xds: NACK missing route specifier server side

### DIFF
--- a/xds/internal/xdsclient/client.go
+++ b/xds/internal/xdsclient/client.go
@@ -206,12 +206,12 @@ type ListenerUpdate struct {
 	// RouteConfigName is the route configuration name corresponding to the
 	// target which is being watched through LDS.
 	//
-	// Only one of RouteConfigName and InlineRouteConfig is set.
+	// Exactly one of RouteConfigName and InlineRouteConfig is set.
 	RouteConfigName string
 	// InlineRouteConfig is the inline route configuration (RDS response)
 	// returned inside LDS.
 	//
-	// Only one of RouteConfigName and InlineRouteConfig is set.
+	// Exactly one of RouteConfigName and InlineRouteConfig is set.
 	InlineRouteConfig *RouteConfigUpdate
 
 	// MaxStreamDuration contains the HTTP connection manager's

--- a/xds/internal/xdsclient/filter_chain.go
+++ b/xds/internal/xdsclient/filter_chain.go
@@ -637,8 +637,7 @@ func processNetworkFilters(filters []*v3listenerpb.Filter) (*FilterChain, error)
 					}
 					filterChain.InlineRouteConfig = &routeU
 				case nil:
-					// No-op, as no route specifier is a valid configuration on
-					// the server side.
+					return nil, fmt.Errorf("no RouteSpecifier: %+v", hcm)
 				default:
 					return nil, fmt.Errorf("unsupported type %T for RouteSpecifier", hcm.RouteSpecifier)
 				}

--- a/xds/internal/xdsclient/filter_chain_test.go
+++ b/xds/internal/xdsclient/filter_chain_test.go
@@ -771,6 +771,40 @@ func TestNewFilterChainImpl_Failure_BadRouteUpdate(t *testing.T) {
 		wantErr string
 	}{
 		{
+			name: "missing-route-specifier",
+			lis: &v3listenerpb.Listener{
+				FilterChains: []*v3listenerpb.FilterChain{
+					{
+						Name: "filter-chain-1",
+						Filters: []*v3listenerpb.Filter{
+							{
+								Name: "hcm",
+								ConfigType: &v3listenerpb.Filter_TypedConfig{
+
+									TypedConfig: testutils.MarshalAny(&v3httppb.HttpConnectionManager{
+										HttpFilters: []*v3httppb.HttpFilter{emptyRouterFilter},
+									}),
+								},
+							},
+						},
+					},
+				},
+				DefaultFilterChain: &v3listenerpb.FilterChain{
+					Filters: []*v3listenerpb.Filter{
+						{
+							Name: "hcm",
+							ConfigType: &v3listenerpb.Filter_TypedConfig{
+								TypedConfig: testutils.MarshalAny(&v3httppb.HttpConnectionManager{
+									HttpFilters: []*v3httppb.HttpFilter{emptyRouterFilter},
+								}),
+							},
+						},
+					},
+				},
+			},
+			wantErr: "no RouteSpecifier",
+		},
+		{
 			name: "not-ads",
 			lis: &v3listenerpb.Listener{
 				FilterChains: []*v3listenerpb.FilterChain{


### PR DESCRIPTION
This PR NACKs a missing route specifier server side, as it is required in Envoy. https://github.com/envoyproxy/envoy/blob/56e8c45b1b340c4a4f8f02ec2488354c31806d59/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#L317. A nil route specifier actually caused a bug, as my RBAC HTTP Filter addition didn't have the correct logic when Route Specifier was nil (see #4924). Luckily, this situation is gatekeeped by the requirement that RouteSpecifier be present.

cc: @ejona86, @lidizheng

RELEASE NOTES: None