### PR TITLE
transport: set max frame size

### DIFF
--- a/dialoptions.go
+++ b/dialoptions.go
@@ -555,6 +555,14 @@ func WithMaxHeaderListSize(s uint32) DialOption {
 	})
 }
 
+// WithMaxFrameSize returns a DialOption that specifies the maximum
+// (uncompressed) size of frame that the client is prepared to accept.
+func WithMaxFrameSize(s uint32) DialOption {
+	return newFuncDialOption(func(o *dialOptions) {
+		o.copts.MaxFrameSize = &s
+	})
+}
+
 // WithDisableHealthCheck disables the LB channel health checking for all
 // SubConns of this ClientConn.
 //

--- a/dialoptions.go
+++ b/dialoptions.go
@@ -559,7 +559,7 @@ func WithMaxHeaderListSize(s uint32) DialOption {
 // (uncompressed) size of frame that the client is prepared to accept.
 func WithMaxFrameSize(s uint32) DialOption {
 	return newFuncDialOption(func(o *dialOptions) {
-		o.copts.MaxFrameSize = &s
+		o.copts.MaxFrameSize = s
 	})
 }
 

--- a/internal/transport/controlbuf.go
+++ b/internal/transport/controlbuf.go
@@ -693,8 +693,8 @@ func (l *loopyWriter) writeHeader(streamID uint32, endStream bool, hf []hpack.He
 	first = true
 	for !endHeaders {
 		size := l.hBuf.Len()
-		if size > http2MaxFrameLen {
-			size = http2MaxFrameLen
+		if size > int(defaultFrameSize) {
+			size = int(defaultFrameSize)
 		} else {
 			endHeaders = true
 		}
@@ -908,7 +908,7 @@ func (l *loopyWriter) processData() (bool, error) {
 		buf []byte
 	)
 	// Figure out the maximum size we can send
-	maxSize := http2MaxFrameLen
+	maxSize := int(defaultFrameSize)
 	if strQuota := int(l.oiws) - str.bytesOutStanding; strQuota <= 0 { // stream-level flow control.
 		str.state = waitingOnStreamQuota
 		return false, nil
@@ -927,7 +927,7 @@ func (l *loopyWriter) processData() (bool, error) {
 		} else {
 			// We can add some data to grpc message header to distribute bytes more equally across frames.
 			// Copy on the stack to avoid generating garbage
-			var localBuf [http2MaxFrameLen]byte
+			var localBuf [defaultFrameSize]byte
 			copy(localBuf[:hSize], dataItem.h)
 			copy(localBuf[hSize:], dataItem.d[:dSize])
 			buf = localBuf[:hSize+dSize]

--- a/internal/transport/defaults.go
+++ b/internal/transport/defaults.go
@@ -46,5 +46,5 @@ const (
 	defaultWriteQuota              = 64 * 1024
 	defaultClientMaxHeaderListSize = uint32(16 << 20)
 	defaultServerMaxHeaderListSize = uint32(16 << 20)
-	defaultFrameSize               = uint32(16384)
+	defaultFrameSize               = uint32(16 * 1024)
 )

--- a/internal/transport/defaults.go
+++ b/internal/transport/defaults.go
@@ -46,4 +46,5 @@ const (
 	defaultWriteQuota              = 64 * 1024
 	defaultClientMaxHeaderListSize = uint32(16 << 20)
 	defaultServerMaxHeaderListSize = uint32(16 << 20)
+	defaultFrameSize               = uint32(16384)
 )

--- a/internal/transport/http_util.go
+++ b/internal/transport/http_util.go
@@ -43,8 +43,6 @@ import (
 )
 
 const (
-	// http2MaxFrameLen specifies the max length of a HTTP2 frame.
-	http2MaxFrameLen = 16384 // 16KB frame
 	// http://http2.github.io/http2-spec/#SettingValues
 	http2InitHeaderTableSize = 4096
 	// baseContentType is the base content-type for gRPC.  This is a valid
@@ -373,7 +371,7 @@ type framer struct {
 	fr     *http2.Framer
 }
 
-func newFramer(conn net.Conn, writeBufferSize, readBufferSize int, maxHeaderListSize uint32) *framer {
+func newFramer(conn net.Conn, writeBufferSize, readBufferSize int, maxHeaderListSize, maxFrameSize uint32) *framer {
 	if writeBufferSize < 0 {
 		writeBufferSize = 0
 	}
@@ -386,7 +384,7 @@ func newFramer(conn net.Conn, writeBufferSize, readBufferSize int, maxHeaderList
 		writer: w,
 		fr:     http2.NewFramer(w, r),
 	}
-	f.fr.SetMaxReadFrameSize(http2MaxFrameLen)
+	f.fr.SetMaxReadFrameSize(maxFrameSize)
 	// Opt-in to Frame reuse API on framer to reduce garbage.
 	// Frames aren't safe to read from after a subsequent call to ReadFrame.
 	f.fr.SetReuseFrames()

--- a/internal/transport/keepalive_test.go
+++ b/internal/transport/keepalive_test.go
@@ -185,7 +185,7 @@ func (s) TestKeepaliveServerClosesUnresponsiveClient(t *testing.T) {
 	if n, err := conn.Write(clientPreface); err != nil || n != len(clientPreface) {
 		t.Fatalf("conn.Write(clientPreface) failed: n=%v, err=%v", n, err)
 	}
-	framer := newFramer(conn, defaultWriteBufSize, defaultReadBufSize, 0, 0)
+	framer := newFramer(conn, defaultWriteBufSize, defaultReadBufSize, 0, defaultFrameSize)
 	if err := framer.fr.WriteSettings(http2.Setting{}); err != nil {
 		t.Fatal("framer.WriteSettings(http2.Setting{}) failed:", err)
 	}

--- a/internal/transport/keepalive_test.go
+++ b/internal/transport/keepalive_test.go
@@ -185,7 +185,7 @@ func (s) TestKeepaliveServerClosesUnresponsiveClient(t *testing.T) {
 	if n, err := conn.Write(clientPreface); err != nil || n != len(clientPreface) {
 		t.Fatalf("conn.Write(clientPreface) failed: n=%v, err=%v", n, err)
 	}
-	framer := newFramer(conn, defaultWriteBufSize, defaultReadBufSize, 0)
+	framer := newFramer(conn, defaultWriteBufSize, defaultReadBufSize, 0, 0)
 	if err := framer.fr.WriteSettings(http2.Setting{}); err != nil {
 		t.Fatal("framer.WriteSettings(http2.Setting{}) failed:", err)
 	}

--- a/internal/transport/transport.go
+++ b/internal/transport/transport.go
@@ -531,7 +531,7 @@ type ServerConfig struct {
 	ReadBufferSize        int
 	ChannelzParentID      int64
 	MaxHeaderListSize     *uint32
-	MaxFrameSize          *uint32
+	MaxFrameSize          uint32
 	HeaderTableSize       *uint32
 }
 
@@ -568,7 +568,7 @@ type ConnectOptions struct {
 	// MaxHeaderListSize sets the max (uncompressed) size of header list that is prepared to be received.
 	MaxHeaderListSize *uint32
 	// MaxFrameSize sets the max size of frame size
-	MaxFrameSize *uint32
+	MaxFrameSize uint32
 	// UseProxy specifies if a proxy should be used.
 	UseProxy bool
 }

--- a/internal/transport/transport.go
+++ b/internal/transport/transport.go
@@ -531,6 +531,7 @@ type ServerConfig struct {
 	ReadBufferSize        int
 	ChannelzParentID      int64
 	MaxHeaderListSize     *uint32
+	MaxFrameSize          *uint32
 	HeaderTableSize       *uint32
 }
 
@@ -566,6 +567,8 @@ type ConnectOptions struct {
 	ChannelzParentID int64
 	// MaxHeaderListSize sets the max (uncompressed) size of header list that is prepared to be received.
 	MaxHeaderListSize *uint32
+	// MaxFrameSize sets the max size of frame size
+	MaxFrameSize *uint32
 	// UseProxy specifies if a proxy should be used.
 	UseProxy bool
 }

--- a/server.go
+++ b/server.go
@@ -163,6 +163,7 @@ type serverOptions struct {
 	readBufferSize        int
 	connectionTimeout     time.Duration
 	maxHeaderListSize     *uint32
+	maxFrameSize          *uint32
 	headerTableSize       *uint32
 	numServerWorkers      uint32
 }
@@ -477,6 +478,14 @@ func ConnectionTimeout(d time.Duration) ServerOption {
 func MaxHeaderListSize(s uint32) ServerOption {
 	return newFuncServerOption(func(o *serverOptions) {
 		o.maxHeaderListSize = &s
+	})
+}
+
+// MaxFrameSize returns a ServerOption that sets the max (uncompressed) size
+// of header list that the server is prepared to accept.
+func MaxFrameSize(s uint32) ServerOption {
+	return newFuncServerOption(func(o *serverOptions) {
+		o.maxFrameSize = &s
 	})
 }
 
@@ -875,6 +884,7 @@ func (s *Server) newHTTP2Transport(c net.Conn) transport.ServerTransport {
 		ReadBufferSize:        s.opts.readBufferSize,
 		ChannelzParentID:      s.channelzID,
 		MaxHeaderListSize:     s.opts.maxHeaderListSize,
+		MaxFrameSize:          s.opts.maxFrameSize,
 		HeaderTableSize:       s.opts.headerTableSize,
 	}
 	st, err := transport.NewServerTransport(c, config)

--- a/server.go
+++ b/server.go
@@ -163,7 +163,7 @@ type serverOptions struct {
 	readBufferSize        int
 	connectionTimeout     time.Duration
 	maxHeaderListSize     *uint32
-	maxFrameSize          *uint32
+	maxFrameSize          uint32
 	headerTableSize       *uint32
 	numServerWorkers      uint32
 }
@@ -485,7 +485,7 @@ func MaxHeaderListSize(s uint32) ServerOption {
 // of header list that the server is prepared to accept.
 func MaxFrameSize(s uint32) ServerOption {
 	return newFuncServerOption(func(o *serverOptions) {
-		o.maxFrameSize = &s
+		o.maxFrameSize = s
 	})
 }
 


### PR DESCRIPTION
see: #4932 
this change add set max frame size api 

RELEASE NOTES:
* grpc: add WithMaxFrameSize and MaxFrameSize to allow higher HTTP/2 frame sizes