### PR TITLE
kokoro: Enable xds authz_test (#4954) (v1.42.x backport)

### DIFF
--- a/test/kokoro/xds_k8s.cfg
+++ b/test/kokoro/xds_k8s.cfg
@@ -2,7 +2,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc-go/test/kokoro/xds_k8s.sh"
-timeout_mins: 120
+timeout_mins: 180
 
 action {
   define_artifacts {

--- a/test/kokoro/xds_k8s.sh
+++ b/test/kokoro/xds_k8s.sh
@@ -150,6 +150,7 @@ main() {
   cd "${TEST_DRIVER_FULL_DIR}"
   run_test baseline_test
   run_test security_test
+  run_test authz_test
 }
 
 main "$@"


### PR DESCRIPTION
* kokoro: Enable xds authz_test

Backport of #4954

RELEASE NOTES: None