### PR TITLE
xds: Added validation and construction of RBAC matcher engine to ParseConfig

### DIFF
--- a/internal/xds/rbac/rbac_engine.go
+++ b/internal/xds/rbac/rbac_engine.go
@@ -108,7 +108,7 @@ type engine struct {
 // newEngine creates an RBAC Engine based on the contents of policy. Returns a
 // non-nil error if the policy is invalid.
 func newEngine(config *v3rbacpb.RBAC) (*engine, error) {
-	a := *config.GetAction().Enum()
+	a := config.GetAction()
 	if a != v3rbacpb.RBAC_ALLOW && a != v3rbacpb.RBAC_DENY {
 		return nil, fmt.Errorf("unsupported action %s", config.Action)
 	}

--- a/internal/xds/rbac/rbac_engine.go
+++ b/internal/xds/rbac/rbac_engine.go
@@ -108,13 +108,13 @@ type engine struct {
 // newEngine creates an RBAC Engine based on the contents of policy. Returns a
 // non-nil error if the policy is invalid.
 func newEngine(config *v3rbacpb.RBAC) (*engine, error) {
-	a := *config.Action.Enum()
+	a := *config.GetAction().Enum()
 	if a != v3rbacpb.RBAC_ALLOW && a != v3rbacpb.RBAC_DENY {
 		return nil, fmt.Errorf("unsupported action %s", config.Action)
 	}
 
-	policies := make(map[string]*policyMatcher, len(config.Policies))
-	for name, policy := range config.Policies {
+	policies := make(map[string]*policyMatcher, len(config.GetPolicies()))
+	for name, policy := range config.GetPolicies() {
 		matcher, err := newPolicyMatcher(policy)
 		if err != nil {
 			return nil, err

--- a/xds/internal/httpfilter/rbac/rbac.go
+++ b/xds/internal/httpfilter/rbac/rbac.go
@@ -65,6 +65,7 @@ type builder struct {
 type config struct {
 	httpfilter.FilterConfig
 	config *rpb.RBAC
+	ce     *rbac.ChainEngine
 }
 
 func (builder) TypeURLs() []string {
@@ -106,7 +107,42 @@ func parseConfig(rbacCfg *rpb.RBAC) (httpfilter.FilterConfig, error) {
 			}
 		}
 	}
-	return config{config: rbacCfg}, nil
+
+	// "Envoy aliases :authority and Host in its header map implementation, so
+	// they should be treated equivalent for the RBAC matchers; there must be no
+	// behavior change depending on which of the two header names is used in the
+	// RBAC policy." - A41. Loop through config's principals and policies, change
+	// any header matcher with value "host" to :authority", as that is what
+	// grpc-go shifts both headers to in transport layer.
+	for _, policy := range rbacCfg.GetRules().GetPolicies() {
+		for _, principal := range policy.Principals {
+			if principal.GetHeader() != nil {
+				name := principal.GetHeader().GetName()
+				if name == "host" {
+					principal.GetHeader().Name = ":authority"
+				}
+			}
+		}
+		for _, permission := range policy.Permissions {
+			if permission.GetHeader() != nil {
+				name := permission.GetHeader().GetName()
+				if name == "host" {
+					permission.GetHeader().Name = ":authority"
+				}
+			}
+		}
+	}
+
+	ce, err := rbac.NewChainEngine([]*v3rbacpb.RBAC{rbacCfg.GetRules()})
+	if err != nil {
+		// "At this time, if the RBAC.action is Action.LOG then the policy will be
+		// completely ignored, as if RBAC was not configurated." - A41
+		if rbacCfg.GetRules().Action != v3rbacpb.RBAC_LOG {
+			return nil, fmt.Errorf("rbac: error constructing matching engine: %v", err)
+		}
+	}
+
+	return config{config: rbacCfg, ce: ce}, nil
 }
 
 func (builder) ParseFilterConfig(cfg proto.Message) (httpfilter.FilterConfig, error) {
@@ -179,36 +215,7 @@ func (builder) BuildServerInterceptor(cfg httpfilter.FilterConfig, override http
 		return nil, nil
 	}
 
-	// "Envoy aliases :authority and Host in its header map implementation, so
-	// they should be treated equivalent for the RBAC matchers; there must be no
-	// behavior change depending on which of the two header names is used in the
-	// RBAC policy." - A41. Loop through config's principals and policies, change
-	// any header matcher with value "host" to :authority", as that is what
-	// grpc-go shifts both headers to in transport layer.
-	for _, policy := range icfg.Rules.GetPolicies() {
-		for _, principal := range policy.Principals {
-			if principal.GetHeader() != nil {
-				name := principal.GetHeader().GetName()
-				if name == "host" {
-					principal.GetHeader().Name = ":authority"
-				}
-			}
-		}
-		for _, permission := range policy.Permissions {
-			if permission.GetHeader() != nil {
-				name := permission.GetHeader().GetName()
-				if name == "host" {
-					permission.GetHeader().Name = ":authority"
-				}
-			}
-		}
-	}
-
-	ce, err := rbac.NewChainEngine([]*v3rbacpb.RBAC{icfg.Rules})
-	if err != nil {
-		return nil, fmt.Errorf("error constructing matching engine: %v", err)
-	}
-	return &interceptor{chainEngine: ce}, nil
+	return &interceptor{chainEngine: c.ce}, nil
 }
 
 type interceptor struct {

--- a/xds/internal/httpfilter/rbac/rbac.go
+++ b/xds/internal/httpfilter/rbac/rbac.go
@@ -64,7 +64,6 @@ type builder struct {
 
 type config struct {
 	httpfilter.FilterConfig
-	config      *rpb.RBAC
 	chainEngine *rbac.ChainEngine
 }
 
@@ -112,19 +111,24 @@ func parseConfig(rbacCfg *rpb.RBAC) (httpfilter.FilterConfig, error) {
 	// grpc-go shifts both headers to in transport layer.
 	for _, policy := range rbacCfg.GetRules().GetPolicies() {
 		for _, principal := range policy.Principals {
-			if principal.GetHeader() != nil {
-				if principal.GetHeader().GetName() == "host" {
-					principal.GetHeader().Name = ":authority"
-				}
+			if principal.GetHeader().GetName() == "host" {
+				principal.GetHeader().Name = ":authority"
 			}
 		}
 		for _, permission := range policy.Permissions {
-			if permission.GetHeader() != nil {
-				if permission.GetHeader().GetName() == "host" {
-					permission.GetHeader().Name = ":authority"
-				}
+			if permission.GetHeader().GetName() == "host" {
+				permission.GetHeader().Name = ":authority"
 			}
 		}
+	}
+
+	// Two cases where this HTTP Filter is a no op:
+	// "If absent, no enforcing RBAC policy will be applied" - RBAC
+	// Documentation for Rules field.
+	// "At this time, if the RBAC.action is Action.LOG then the policy will be
+	// completely ignored, as if RBAC was not configurated." - A41
+	if rbacCfg.Rules == nil || rbacCfg.GetRules().GetAction() == v3rbacpb.RBAC_LOG {
+		return config{}, nil
 	}
 
 	ce, err := rbac.NewChainEngine([]*v3rbacpb.RBAC{rbacCfg.GetRules()})
@@ -136,7 +140,7 @@ func parseConfig(rbacCfg *rpb.RBAC) (httpfilter.FilterConfig, error) {
 		}
 	}
 
-	return config{config: rbacCfg, chainEngine: ce}, nil
+	return config{chainEngine: ce}, nil
 }
 
 func (builder) ParseFilterConfig(cfg proto.Message) (httpfilter.FilterConfig, error) {
@@ -196,19 +200,14 @@ func (builder) BuildServerInterceptor(cfg httpfilter.FilterConfig, override http
 		}
 	}
 
-	icfg := c.config
+	// RBAC HTTP Filter is a no op from one of these two cases:
 	// "If absent, no enforcing RBAC policy will be applied" - RBAC
 	// Documentation for Rules field.
-	if icfg.Rules == nil {
-		return nil, nil
-	}
-
 	// "At this time, if the RBAC.action is Action.LOG then the policy will be
 	// completely ignored, as if RBAC was not configurated." - A41
-	if icfg.Rules.Action == v3rbacpb.RBAC_LOG {
+	if c.chainEngine == nil {
 		return nil, nil
 	}
-
 	return &interceptor{chainEngine: c.chainEngine}, nil
 }
 


### PR DESCRIPTION
This PR moves the validation and construction of the RBAC Matcher engine to ParseConfig. This makes it so that if a xds resource is received with some invalid RBAC matcher, the resource gets explicitly NACKed. Previously, the server would continue to serve, and then fail on a connection accept as the filter chain that the accepted connection matched to attempted to be constructed.

cc @ejona86

RELEASE NOTES: None