### PR TITLE
pickfirst: check b.sc before calling Connect

### DIFF
--- a/pickfirst.go
+++ b/pickfirst.go
@@ -125,7 +125,7 @@ func (b *pickfirstBalancer) Close() {
 }
 
 func (b *pickfirstBalancer) ExitIdle() {
-	if b.state == connectivity.Idle {
+	if b.sc != nil && b.state == connectivity.Idle {
 		b.sc.Connect()
 	}
 }


### PR DESCRIPTION
Fixes #4965

RELEASE NOTES:
* client: fix nil panic in rare race conditions with the pick first LB policy