### PR TITLE
internal: add log when service config is disabled

### DIFF
--- a/clientconn.go
+++ b/clientconn.go
@@ -633,8 +633,10 @@ func (cc *ClientConn) updateResolverState(s resolver.State, err error) error {
 	}
 
 	var ret error
-	if cc.dopts.disableServiceConfig || s.ServiceConfig == nil {
-		channelz.Infof(logger, cc.channelzID, "ignoring service config from resolver (%v) and applying default service. dopts.disableServiceConfig is %v", s.ServiceConfig, cc.dopts.disableServiceConfig)
+	if cc.dopts.disableServiceConfig {
+		channelz.Infof(logger, cc.channelzID, "ignoring service config from resolver (%v) and applying default service because service config is disabled", s.ServiceConfig)
+		cc.maybeApplyDefaultServiceConfig(s.Addresses)
+	} else if s.ServiceConfig == nil {
 		cc.maybeApplyDefaultServiceConfig(s.Addresses)
 		// TODO: do we need to apply a failing LB policy if there is no
 		// default, per the error handling design?

--- a/clientconn.go
+++ b/clientconn.go
@@ -634,7 +634,7 @@ func (cc *ClientConn) updateResolverState(s resolver.State, err error) error {
 
 	var ret error
 	if cc.dopts.disableServiceConfig {
-		channelz.Infof(logger, cc.channelzID, "ignoring service config from resolver (%v) and applying default service because service config is disabled", s.ServiceConfig)
+		channelz.Infof(logger, cc.channelzID, "ignoring service config from resolver (%v) and applying the default because service config is disabled", s.ServiceConfig)
 		cc.maybeApplyDefaultServiceConfig(s.Addresses)
 	} else if s.ServiceConfig == nil {
 		cc.maybeApplyDefaultServiceConfig(s.Addresses)

--- a/clientconn.go
+++ b/clientconn.go
@@ -634,6 +634,7 @@ func (cc *ClientConn) updateResolverState(s resolver.State, err error) error {
 
 	var ret error
 	if cc.dopts.disableServiceConfig || s.ServiceConfig == nil {
+		channelz.Infof(logger, cc.channelzID, "ignoring service config from resolver (%v) and applying default service. dopts.disableServiceConfig is %v", s.ServiceConfig, cc.dopts.disableServiceConfig)
 		cc.maybeApplyDefaultServiceConfig(s.Addresses)
 		// TODO: do we need to apply a failing LB policy if there is no
 		// default, per the error handling design?


### PR DESCRIPTION
Without this, it's confusing when the service config is sent by the
resolver, but not used by the ClientConn (in cases like xDS resolver).

RELEASE NOTES: N/A