### PR TITLE
examples: Fix server port in route_guide example to work with client

### DIFF
--- a/examples/route_guide/client/client.go
+++ b/examples/route_guide/client/client.go
@@ -39,7 +39,7 @@ import (
 var (
 	tls                = flag.Bool("tls", false, "Connection uses TLS if true, else plain TCP")
 	caFile             = flag.String("ca_file", "", "The file containing the CA root cert file")
-	serverAddr         = flag.String("addr", "localhost:10000", "The server address in the format of host:port")
+	serverAddr         = flag.String("addr", "localhost:50051", "The server address in the format of host:port")
 	serverHostOverride = flag.String("server_host_override", "x.test.example.com", "The server name used to verify the hostname returned by the TLS handshake")
 )
 

--- a/examples/route_guide/client/client.go
+++ b/examples/route_guide/client/client.go
@@ -39,7 +39,7 @@ import (
 var (
 	tls                = flag.Bool("tls", false, "Connection uses TLS if true, else plain TCP")
 	caFile             = flag.String("ca_file", "", "The file containing the CA root cert file")
-	serverAddr         = flag.String("addr", "localhost:50051", "The server address in the format of host:port")
+	serverAddr         = flag.String("addr", "localhost:10000", "The server address in the format of host:port")
 	serverHostOverride = flag.String("server_host_override", "x.test.example.com", "The server name used to verify the hostname returned by the TLS handshake")
 )
 

--- a/examples/route_guide/server/server.go
+++ b/examples/route_guide/server/server.go
@@ -50,7 +50,7 @@ var (
 	certFile   = flag.String("cert_file", "", "The TLS cert file")
 	keyFile    = flag.String("key_file", "", "The TLS key file")
 	jsonDBFile = flag.String("json_db_file", "", "A json file containing a list of features")
-	port       = flag.Int("port", 10000, "The server port")
+	port       = flag.Int("port", 50051, "The server port")
 )
 
 type routeGuideServer struct {


### PR DESCRIPTION
Currently the example doesn't work following the `README.md` since the server port should be `10000`.

This fixes the following error:
```
2021/11/11 21:52:52 Getting feature for point (409146138, -746188906)
2021/11/11 21:52:52 &{0x140001c0a80}.GetFeatures(_) = _, rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing dial tcp [::1]:50051: connect: connection refused": 
exit status 1

```

RELEASE NOTES: None