### PR TITLE
xds/resolver: Add support for cluster specifier plugins

### DIFF
--- a/xds/internal/balancer/cdsbalancer/cdsbalancer.go
+++ b/xds/internal/balancer/cdsbalancer/cdsbalancer.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 
 	"google.golang.org/grpc/balancer"
 	"google.golang.org/grpc/balancer/base"
@@ -42,7 +43,8 @@ import (
 )
 
 const (
-	cdsName = "cds_experimental"
+	cdsName       = "cds_experimental"
+	clusterPrefix = "cluster:"
 )
 
 var (
@@ -179,7 +181,7 @@ func (b *cdsBalancer) handleClientConnUpdate(update *ccUpdate) {
 		b.handleErrorFromUpdate(err, true)
 		return
 	}
-	b.clusterHandler.updateRootCluster(update.clusterName)
+	b.clusterHandler.updateRootCluster(strings.TrimPrefix(update.clusterName, clusterPrefix))
 }
 
 // handleSecurityConfig processes the security configuration received from the

--- a/xds/internal/balancer/cdsbalancer/cdsbalancer.go
+++ b/xds/internal/balancer/cdsbalancer/cdsbalancer.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"strings"
 
 	"google.golang.org/grpc/balancer"
 	"google.golang.org/grpc/balancer/base"
@@ -43,8 +42,7 @@ import (
 )
 
 const (
-	cdsName       = "cds_experimental"
-	clusterPrefix = "cluster:"
+	cdsName = "cds_experimental"
 )
 
 var (
@@ -181,7 +179,7 @@ func (b *cdsBalancer) handleClientConnUpdate(update *ccUpdate) {
 		b.handleErrorFromUpdate(err, true)
 		return
 	}
-	b.clusterHandler.updateRootCluster(strings.TrimPrefix(update.clusterName, clusterPrefix))
+	b.clusterHandler.updateRootCluster(update.clusterName)
 }
 
 // handleSecurityConfig processes the security configuration received from the

--- a/xds/internal/resolver/cluster_specifier_plugin_test.go
+++ b/xds/internal/resolver/cluster_specifier_plugin_test.go
@@ -314,7 +314,7 @@ func (s) TestXDSResolverDelayedOnCommittedCSP(t *testing.T) {
         "cluster_specifier_plugin:cspA":{
           "childPolicy":[{"csp_experimental":{"arbitrary_field":"anythingA"}}]
         },
-		"cluster_specifier_plugin:cspB":{
+        "cluster_specifier_plugin:cspB":{
           "childPolicy":[{"csp_experimental":{"arbitrary_field":"anythingB"}}]
         }
       }
@@ -353,7 +353,7 @@ func (s) TestXDSResolverDelayedOnCommittedCSP(t *testing.T) {
 	wantJSON3 := `{"loadBalancingConfig":[{
     "xds_cluster_manager_experimental":{
       "children":{
-		"cluster_specifier_plugin:cspB":{
+        "cluster_specifier_plugin:cspB":{
           "childPolicy":[{"csp_experimental":{"arbitrary_field":"anythingB"}}]
         }
       }

--- a/xds/internal/resolver/cluster_specifier_plugin_test.go
+++ b/xds/internal/resolver/cluster_specifier_plugin_test.go
@@ -1,0 +1,368 @@
+/*
+ *
+ * Copyright 2021 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package resolver
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/grpc/balancer"
+	"google.golang.org/grpc/internal"
+	iresolver "google.golang.org/grpc/internal/resolver"
+	"google.golang.org/grpc/resolver"
+	"google.golang.org/grpc/serviceconfig"
+	"google.golang.org/grpc/xds/internal/balancer/clustermanager"
+	"google.golang.org/grpc/xds/internal/clusterspecifier"
+	"google.golang.org/grpc/xds/internal/xdsclient/xdsresource"
+)
+
+func init() {
+	balancer.Register(cspB{})
+}
+
+type cspB struct{}
+
+func (cspB) Build(cc balancer.ClientConn, opts balancer.BuildOptions) balancer.Balancer {
+	return nil
+}
+
+func (cspB) Name() string {
+	return "csp_experimental"
+}
+
+type cspConfig struct {
+	ArbitraryField string `json:"arbitrary_field"`
+}
+
+// TestXDSResolverClusterSpecifierPlugin tests that cluster specifier plugins
+// produce the correct service config, and that the config selector routes to a
+// cluster specifier plugin supported by this service config (i.e. prefixed with
+// a cluster specifier plugin prefix).
+func (s) TestXDSResolverClusterSpecifierPlugin(t *testing.T) {
+	xdsR, xdsC, tcc, cancel := testSetup(t, setupOpts{target: target})
+	defer xdsR.Close()
+	defer cancel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	waitForWatchListener(ctx, t, xdsC, targetStr)
+	xdsC.InvokeWatchListenerCallback(xdsresource.ListenerUpdate{RouteConfigName: routeStr, HTTPFilters: routerFilterList}, nil)
+
+	waitForWatchRouteConfig(ctx, t, xdsC, routeStr)
+	xdsC.InvokeWatchRouteConfigCallback("", xdsresource.RouteConfigUpdate{
+		VirtualHosts: []*xdsresource.VirtualHost{
+			{
+				Domains: []string{targetStr},
+				Routes:  []*xdsresource.Route{{Prefix: newStringP(""), ClusterSpecifierPlugin: "cspA"}},
+			},
+		},
+		// Top level csp config here - the value of cspA should get directly
+		// placed as a child policy of xds cluster manager.
+		ClusterSpecifierPlugins: map[string]clusterspecifier.BalancerConfig{"cspA": []map[string]interface{}{{"csp_experimental": cspConfig{ArbitraryField: "anything"}}}},
+	}, nil)
+
+	gotState, err := tcc.stateCh.Receive(ctx)
+	if err != nil {
+		t.Fatalf("Error waiting for UpdateState to be called: %v", err)
+	}
+	rState := gotState.(resolver.State)
+	if err := rState.ServiceConfig.Err; err != nil {
+		t.Fatalf("ClientConn.UpdateState received error in service config: %v", rState.ServiceConfig.Err)
+	}
+	wantJSON := `{"loadBalancingConfig":[{
+    "xds_cluster_manager_experimental":{
+      "children":{
+        "cluster_specifier_plugin:cspA":{
+          "childPolicy":[{"csp_experimental":{"arbitrary_field":"anything"}}]
+        }
+      }
+    }}]}`
+
+	wantSCParsed := internal.ParseServiceConfigForTesting.(func(string) *serviceconfig.ParseResult)(wantJSON)
+	if !internal.EqualServiceConfigForTesting(rState.ServiceConfig.Config, wantSCParsed.Config) {
+		t.Errorf("ClientConn.UpdateState received different service config")
+		t.Error("got: ", cmp.Diff(nil, rState.ServiceConfig.Config))
+		t.Fatal("want: ", cmp.Diff(nil, wantSCParsed.Config))
+	}
+
+	cs := iresolver.GetConfigSelector(rState)
+	if cs == nil {
+		t.Fatal("received nil config selector")
+	}
+
+	res, err := cs.SelectConfig(iresolver.RPCInfo{Context: context.Background()})
+	if err != nil {
+		t.Fatalf("Unexpected error from cs.SelectConfig(_): %v", err)
+	}
+
+	cluster := clustermanager.GetPickedClusterForTesting(res.Context)
+	clusterWant := clusterSpecifierPluginPrefix + "cspA"
+	if cluster != clusterWant {
+		t.Fatalf("cluster: %+v, want: %+v", cluster, clusterWant)
+	}
+}
+
+// TestXDSResolverClusterSpecifierPluginConfigUpdate tests that cluster
+// specifier plugins produce the correct service config, and that on an update
+// to the CSP Configuration, the new config is accounted for in the output
+// service config.
+func (s) TestXDSResolverClusterSpecifierPluginConfigUpdate(t *testing.T) {
+	xdsR, xdsC, tcc, cancel := testSetup(t, setupOpts{target: target})
+	defer xdsR.Close()
+	defer cancel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	waitForWatchListener(ctx, t, xdsC, targetStr)
+	xdsC.InvokeWatchListenerCallback(xdsresource.ListenerUpdate{RouteConfigName: routeStr, HTTPFilters: routerFilterList}, nil)
+
+	waitForWatchRouteConfig(ctx, t, xdsC, routeStr)
+	xdsC.InvokeWatchRouteConfigCallback("", xdsresource.RouteConfigUpdate{
+		VirtualHosts: []*xdsresource.VirtualHost{
+			{
+				Domains: []string{targetStr},
+				Routes:  []*xdsresource.Route{{Prefix: newStringP(""), ClusterSpecifierPlugin: "cspA"}},
+			},
+		},
+		// Top level csp config here - the value of cspA should get directly
+		// placed as a child policy of xds cluster manager.
+		ClusterSpecifierPlugins: map[string]clusterspecifier.BalancerConfig{"cspA": []map[string]interface{}{{"csp_experimental": cspConfig{ArbitraryField: "anything"}}}},
+	}, nil)
+
+	gotState, err := tcc.stateCh.Receive(ctx)
+	if err != nil {
+		t.Fatalf("Error waiting for UpdateState to be called: %v", err)
+	}
+	rState := gotState.(resolver.State)
+	if err := rState.ServiceConfig.Err; err != nil {
+		t.Fatalf("ClientConn.UpdateState received error in service config: %v", rState.ServiceConfig.Err)
+	}
+	wantJSON := `{"loadBalancingConfig":[{
+    "xds_cluster_manager_experimental":{
+      "children":{
+        "cluster_specifier_plugin:cspA":{
+          "childPolicy":[{"csp_experimental":{"arbitrary_field":"anything"}}]
+        }
+      }
+    }}]}`
+
+	wantSCParsed := internal.ParseServiceConfigForTesting.(func(string) *serviceconfig.ParseResult)(wantJSON)
+	if !internal.EqualServiceConfigForTesting(rState.ServiceConfig.Config, wantSCParsed.Config) {
+		t.Errorf("ClientConn.UpdateState received different service config")
+		t.Error("got: ", cmp.Diff(nil, rState.ServiceConfig.Config))
+		t.Fatal("want: ", cmp.Diff(nil, wantSCParsed.Config))
+	}
+
+	xdsC.InvokeWatchRouteConfigCallback("", xdsresource.RouteConfigUpdate{
+		VirtualHosts: []*xdsresource.VirtualHost{
+			{
+				Domains: []string{targetStr},
+				Routes:  []*xdsresource.Route{{Prefix: newStringP(""), ClusterSpecifierPlugin: "cspA"}},
+			},
+		},
+		// Top level csp config here - the value of cspA should get directly
+		// placed as a child policy of xds cluster manager.
+		ClusterSpecifierPlugins: map[string]clusterspecifier.BalancerConfig{"cspA": []map[string]interface{}{{"csp_experimental": cspConfig{ArbitraryField: "changed"}}}},
+	}, nil)
+
+	gotState, err = tcc.stateCh.Receive(ctx)
+	if err != nil {
+		t.Fatalf("Error waiting for UpdateState to be called: %v", err)
+	}
+	rState = gotState.(resolver.State)
+	if err := rState.ServiceConfig.Err; err != nil {
+		t.Fatalf("ClientConn.UpdateState received error in service config: %v", rState.ServiceConfig.Err)
+	}
+	wantJSON = `{"loadBalancingConfig":[{
+    "xds_cluster_manager_experimental":{
+      "children":{
+        "cluster_specifier_plugin:cspA":{
+          "childPolicy":[{"csp_experimental":{"arbitrary_field":"changed"}}]
+        }
+      }
+    }}]}`
+
+	wantSCParsed = internal.ParseServiceConfigForTesting.(func(string) *serviceconfig.ParseResult)(wantJSON)
+	if !internal.EqualServiceConfigForTesting(rState.ServiceConfig.Config, wantSCParsed.Config) {
+		t.Errorf("ClientConn.UpdateState received different service config")
+		t.Error("got: ", cmp.Diff(nil, rState.ServiceConfig.Config))
+		t.Fatal("want: ", cmp.Diff(nil, wantSCParsed.Config))
+	}
+}
+
+// TestXDSResolverDelayedOnCommittedCSP tests that cluster specifier plugins and
+// their corresponding configurations remain in service config if RPCs are in
+// flight.
+func (s) TestXDSResolverDelayedOnCommittedCSP(t *testing.T) {
+	xdsR, xdsC, tcc, cancel := testSetup(t, setupOpts{target: target})
+	defer xdsR.Close()
+	defer cancel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	waitForWatchListener(ctx, t, xdsC, targetStr)
+	xdsC.InvokeWatchListenerCallback(xdsresource.ListenerUpdate{RouteConfigName: routeStr, HTTPFilters: routerFilterList}, nil)
+	waitForWatchRouteConfig(ctx, t, xdsC, routeStr)
+
+	xdsC.InvokeWatchRouteConfigCallback("", xdsresource.RouteConfigUpdate{
+		VirtualHosts: []*xdsresource.VirtualHost{
+			{
+				Domains: []string{targetStr},
+				Routes:  []*xdsresource.Route{{Prefix: newStringP(""), ClusterSpecifierPlugin: "cspA"}},
+			},
+		},
+		// Top level csp config here - the value of cspA should get directly
+		// placed as a child policy of xds cluster manager.
+		ClusterSpecifierPlugins: map[string]clusterspecifier.BalancerConfig{"cspA": []map[string]interface{}{{"csp_experimental": cspConfig{ArbitraryField: "anythingA"}}}},
+	}, nil)
+
+	gotState, err := tcc.stateCh.Receive(ctx)
+	if err != nil {
+		t.Fatalf("Error waiting for UpdateState to be called: %v", err)
+	}
+	rState := gotState.(resolver.State)
+	if err := rState.ServiceConfig.Err; err != nil {
+		t.Fatalf("ClientConn.UpdateState received error in service config: %v", rState.ServiceConfig.Err)
+	}
+	wantJSON := `{"loadBalancingConfig":[{
+    "xds_cluster_manager_experimental":{
+      "children":{
+        "cluster_specifier_plugin:cspA":{
+          "childPolicy":[{"csp_experimental":{"arbitrary_field":"anythingA"}}]
+        }
+      }
+    }}]}`
+
+	wantSCParsed := internal.ParseServiceConfigForTesting.(func(string) *serviceconfig.ParseResult)(wantJSON)
+	if !internal.EqualServiceConfigForTesting(rState.ServiceConfig.Config, wantSCParsed.Config) {
+		t.Errorf("ClientConn.UpdateState received different service config")
+		t.Error("got: ", cmp.Diff(nil, rState.ServiceConfig.Config))
+		t.Fatal("want: ", cmp.Diff(nil, wantSCParsed.Config))
+	}
+
+	cs := iresolver.GetConfigSelector(rState)
+	if cs == nil {
+		t.Fatal("received nil config selector")
+	}
+
+	res, err := cs.SelectConfig(iresolver.RPCInfo{Context: context.Background()})
+	if err != nil {
+		t.Fatalf("Unexpected error from cs.SelectConfig(_): %v", err)
+	}
+
+	cluster := clustermanager.GetPickedClusterForTesting(res.Context)
+	clusterWant := clusterSpecifierPluginPrefix + "cspA"
+	if cluster != clusterWant {
+		t.Fatalf("cluster: %+v, want: %+v", cluster, clusterWant)
+	}
+	// delay res.OnCommitted()
+
+	// Perform TWO updates to ensure the old config selector does not hold a reference to cspA
+	xdsC.InvokeWatchRouteConfigCallback("", xdsresource.RouteConfigUpdate{
+		VirtualHosts: []*xdsresource.VirtualHost{
+			{
+				Domains: []string{targetStr},
+				Routes:  []*xdsresource.Route{{Prefix: newStringP(""), ClusterSpecifierPlugin: "cspB"}},
+			},
+		},
+		// Top level csp config here - the value of cspB should get directly
+		// placed as a child policy of xds cluster manager.
+		ClusterSpecifierPlugins: map[string]clusterspecifier.BalancerConfig{"cspB": []map[string]interface{}{{"csp_experimental": cspConfig{ArbitraryField: "anythingB"}}}},
+	}, nil)
+	tcc.stateCh.Receive(ctx) // Ignore the first update.
+
+	xdsC.InvokeWatchRouteConfigCallback("", xdsresource.RouteConfigUpdate{
+		VirtualHosts: []*xdsresource.VirtualHost{
+			{
+				Domains: []string{targetStr},
+				Routes:  []*xdsresource.Route{{Prefix: newStringP(""), ClusterSpecifierPlugin: "cspB"}},
+			},
+		},
+		// Top level csp config here - the value of cspB should get directly
+		// placed as a child policy of xds cluster manager.
+		ClusterSpecifierPlugins: map[string]clusterspecifier.BalancerConfig{"cspB": []map[string]interface{}{{"csp_experimental": cspConfig{ArbitraryField: "anythingB"}}}},
+	}, nil)
+
+	gotState, err = tcc.stateCh.Receive(ctx)
+	if err != nil {
+		t.Fatalf("Error waiting for UpdateState to be called: %v", err)
+	}
+	rState = gotState.(resolver.State)
+	if err := rState.ServiceConfig.Err; err != nil {
+		t.Fatalf("ClientConn.UpdateState received error in service config: %v", rState.ServiceConfig.Err)
+	}
+	wantJSON2 := `{"loadBalancingConfig":[{
+    "xds_cluster_manager_experimental":{
+      "children":{
+        "cluster_specifier_plugin:cspA":{
+          "childPolicy":[{"csp_experimental":{"arbitrary_field":"anythingA"}}]
+        },
+		"cluster_specifier_plugin:cspB":{
+          "childPolicy":[{"csp_experimental":{"arbitrary_field":"anythingB"}}]
+        }
+      }
+    }}]}`
+
+	wantSCParsed2 := internal.ParseServiceConfigForTesting.(func(string) *serviceconfig.ParseResult)(wantJSON2)
+	if !internal.EqualServiceConfigForTesting(rState.ServiceConfig.Config, wantSCParsed2.Config) {
+		t.Errorf("ClientConn.UpdateState received different service config")
+		t.Error("got: ", cmp.Diff(nil, rState.ServiceConfig.Config))
+		t.Fatal("want: ", cmp.Diff(nil, wantSCParsed2.Config))
+	}
+
+	// Invoke OnCommitted; should lead to a service config update that deletes
+	// cspA.
+	res.OnCommitted()
+
+	xdsC.InvokeWatchRouteConfigCallback("", xdsresource.RouteConfigUpdate{
+		VirtualHosts: []*xdsresource.VirtualHost{
+			{
+				Domains: []string{targetStr},
+				Routes:  []*xdsresource.Route{{Prefix: newStringP(""), ClusterSpecifierPlugin: "cspB"}},
+			},
+		},
+		// Top level csp config here - the value of cspB should get directly
+		// placed as a child policy of xds cluster manager.
+		ClusterSpecifierPlugins: map[string]clusterspecifier.BalancerConfig{"cspB": []map[string]interface{}{{"csp_experimental": cspConfig{ArbitraryField: "anythingB"}}}},
+	}, nil)
+	gotState, err = tcc.stateCh.Receive(ctx)
+	if err != nil {
+		t.Fatalf("Error waiting for UpdateState to be called: %v", err)
+	}
+	rState = gotState.(resolver.State)
+	if err := rState.ServiceConfig.Err; err != nil {
+		t.Fatalf("ClientConn.UpdateState received error in service config: %v", rState.ServiceConfig.Err)
+	}
+	wantJSON3 := `{"loadBalancingConfig":[{
+    "xds_cluster_manager_experimental":{
+      "children":{
+		"cluster_specifier_plugin:cspB":{
+          "childPolicy":[{"csp_experimental":{"arbitrary_field":"anythingB"}}]
+        }
+      }
+    }}]}`
+
+	wantSCParsed3 := internal.ParseServiceConfigForTesting.(func(string) *serviceconfig.ParseResult)(wantJSON3)
+	if !internal.EqualServiceConfigForTesting(rState.ServiceConfig.Config, wantSCParsed3.Config) {
+		t.Errorf("ClientConn.UpdateState received different service config")
+		t.Error("got: ", cmp.Diff(nil, rState.ServiceConfig.Config))
+		t.Fatal("want: ", cmp.Diff(nil, wantSCParsed3.Config))
+	}
+}

--- a/xds/internal/resolver/serviceconfig.go
+++ b/xds/internal/resolver/serviceconfig.go
@@ -92,7 +92,7 @@ func serviceConfigJSON(activeClusters map[string]*clusterInfo, clusterSpecifierP
 	for cluster := range activeClusters {
 		// Look into cluster specifier plugins, which hasn't had any prefix attached to it's cluster specifier plugin names,
 		// to determine the LB Config if the cluster is a CSP.
-		cspCfg, ok := clusterSpecifierPlugins[strings.TrimPrefix(cluster, "cluster_specifier_plugin:")]
+		cspCfg, ok := clusterSpecifierPlugins[strings.TrimPrefix(cluster, clusterSpecifierPluginPrefix)]
 		if ok {
 			children[cluster] = xdsChildConfig{
 				ChildPolicy: balancerConfig(cspCfg),
@@ -366,9 +366,10 @@ func (r *xdsResolver) newConfigSelector(su serviceUpdate) (*configSelector, erro
 			httpFilterConfigOverride: su.virtualHost.HTTPFilterConfigOverride,
 			retryConfig:              su.virtualHost.RetryConfig,
 		},
-		routes:           make([]route, len(su.virtualHost.Routes)),
-		clusters:         make(map[string]*clusterInfo),
-		httpFilterConfig: su.ldsConfig.httpFilterConfig,
+		routes:                  make([]route, len(su.virtualHost.Routes)),
+		clusters:                make(map[string]*clusterInfo),
+		clusterSpecifierPlugins: su.clusterSpecifierPlugins,
+		httpFilterConfig:        su.ldsConfig.httpFilterConfig,
 	}
 
 	for i, rt := range su.virtualHost.Routes {

--- a/xds/internal/resolver/watch_service.go
+++ b/xds/internal/resolver/watch_service.go
@@ -124,7 +124,7 @@ func (w *serviceUpdateWatcher) handleLDSResp(update xdsresource.ListenerUpdate, 
 		}
 
 		// Handle the inline RDS update as if it's from an RDS watch.
-		w.updateVirtualHostsFromRDS(*update.InlineRouteConfig)
+		w.applyRouteConfigUpdate(*update.InlineRouteConfig)
 		return
 	}
 
@@ -155,7 +155,7 @@ func (w *serviceUpdateWatcher) handleLDSResp(update xdsresource.ListenerUpdate, 
 	w.rdsCancel = w.c.WatchRouteConfig(update.RouteConfigName, w.handleRDSResp)
 }
 
-func (w *serviceUpdateWatcher) updateVirtualHostsFromRDS(update xdsresource.RouteConfigUpdate) {
+func (w *serviceUpdateWatcher) applyRouteConfigUpdate(update xdsresource.RouteConfigUpdate) {
 	matchVh := xdsresource.FindBestMatchingVirtualHost(w.serviceName, update.VirtualHosts)
 	if matchVh == nil {
 		// No matching virtual host found.
@@ -184,7 +184,7 @@ func (w *serviceUpdateWatcher) handleRDSResp(update xdsresource.RouteConfigUpdat
 		w.serviceCb(serviceUpdate{}, err)
 		return
 	}
-	w.updateVirtualHostsFromRDS(update)
+	w.applyRouteConfigUpdate(update)
 }
 
 func (w *serviceUpdateWatcher) close() {

--- a/xds/internal/resolver/watch_service.go
+++ b/xds/internal/resolver/watch_service.go
@@ -36,7 +36,7 @@ import (
 type serviceUpdate struct {
 	// virtualHost contains routes and other configuration to route RPCs.
 	virtualHost *xdsresource.VirtualHost
-	// clusterSpecifierPlugins contain the configurations for any cluster
+	// clusterSpecifierPlugins contains the configurations for any cluster
 	// specifier plugins emitted by the xdsclient.
 	clusterSpecifierPlugins map[string]clusterspecifier.BalancerConfig
 	// ldsConfig contains configuration that applies to all routes.

--- a/xds/internal/resolver/watch_service.go
+++ b/xds/internal/resolver/watch_service.go
@@ -25,6 +25,7 @@ import (
 
 	"google.golang.org/grpc/internal/grpclog"
 	"google.golang.org/grpc/internal/pretty"
+	"google.golang.org/grpc/xds/internal/clusterspecifier"
 	"google.golang.org/grpc/xds/internal/xdsclient"
 	"google.golang.org/grpc/xds/internal/xdsclient/xdsresource"
 )
@@ -35,6 +36,9 @@ import (
 type serviceUpdate struct {
 	// virtualHost contains routes and other configuration to route RPCs.
 	virtualHost *xdsresource.VirtualHost
+	// clusterSpecifierPlugins contain the configurations for any cluster
+	// specifier plugins emitted by the xdsclient.
+	clusterSpecifierPlugins map[string]clusterspecifier.BalancerConfig
 	// ldsConfig contains configuration that applies to all routes.
 	ldsConfig ldsConfig
 }
@@ -160,6 +164,7 @@ func (w *serviceUpdateWatcher) updateVirtualHostsFromRDS(update xdsresource.Rout
 	}
 
 	w.lastUpdate.virtualHost = matchVh
+	w.lastUpdate.clusterSpecifierPlugins = update.ClusterSpecifierPlugins
 	w.serviceCb(w.lastUpdate, nil)
 }
 

--- a/xds/internal/resolver/xds_resolver.go
+++ b/xds/internal/resolver/xds_resolver.go
@@ -206,7 +206,7 @@ func (r *xdsResolver) sendNewServiceConfig(cs *configSelector) bool {
 	}
 
 	// Produce the service config.
-	sc, err := serviceConfigJSON(r.activeClusters)
+	sc, err := serviceConfigJSON(r.activeClusters, cs.clusterSpecifierPlugins)
 	if err != nil {
 		// JSON marshal error; should never happen.
 		r.logger.Errorf("%v", err)

--- a/xds/internal/resolver/xds_resolver.go
+++ b/xds/internal/resolver/xds_resolver.go
@@ -30,7 +30,6 @@ import (
 	"google.golang.org/grpc/internal/pretty"
 	iresolver "google.golang.org/grpc/internal/resolver"
 	"google.golang.org/grpc/resolver"
-	"google.golang.org/grpc/xds/internal/clusterspecifier"
 	"google.golang.org/grpc/xds/internal/xdsclient"
 	"google.golang.org/grpc/xds/internal/xdsclient/bootstrap"
 	"google.golang.org/grpc/xds/internal/xdsclient/xdsresource"
@@ -206,12 +205,7 @@ func (r *xdsResolver) sendNewServiceConfig(cs *configSelector) bool {
 		return true
 	}
 
-	// Produce the service config.
-	csps := make(map[string]clusterspecifier.BalancerConfig)
-	if cs != nil {
-		csps = cs.clusterSpecifierPlugins
-	}
-	sc, err := serviceConfigJSON(r.activeClusters, csps)
+	sc, err := serviceConfigJSON(r.activeClusters)
 	if err != nil {
 		// JSON marshal error; should never happen.
 		r.logger.Errorf("%v", err)

--- a/xds/internal/resolver/xds_resolver.go
+++ b/xds/internal/resolver/xds_resolver.go
@@ -30,6 +30,7 @@ import (
 	"google.golang.org/grpc/internal/pretty"
 	iresolver "google.golang.org/grpc/internal/resolver"
 	"google.golang.org/grpc/resolver"
+	"google.golang.org/grpc/xds/internal/clusterspecifier"
 	"google.golang.org/grpc/xds/internal/xdsclient"
 	"google.golang.org/grpc/xds/internal/xdsclient/bootstrap"
 	"google.golang.org/grpc/xds/internal/xdsclient/xdsresource"
@@ -206,7 +207,11 @@ func (r *xdsResolver) sendNewServiceConfig(cs *configSelector) bool {
 	}
 
 	// Produce the service config.
-	sc, err := serviceConfigJSON(r.activeClusters, cs.clusterSpecifierPlugins)
+	csps := make(map[string]clusterspecifier.BalancerConfig)
+	if cs != nil {
+		csps = cs.clusterSpecifierPlugins
+	}
+	sc, err := serviceConfigJSON(r.activeClusters, csps)
 	if err != nil {
 		// JSON marshal error; should never happen.
 		r.logger.Errorf("%v", err)

--- a/xds/internal/resolver/xds_resolver_test.go
+++ b/xds/internal/resolver/xds_resolver_test.go
@@ -29,7 +29,6 @@ import (
 
 	xxhash "github.com/cespare/xxhash/v2"
 	"github.com/google/go-cmp/cmp"
-	"google.golang.org/grpc/balancer"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
 	xdscreds "google.golang.org/grpc/credentials/xds"
@@ -47,7 +46,6 @@ import (
 	_ "google.golang.org/grpc/xds/internal/balancer/cdsbalancer" // To parse LB config
 	"google.golang.org/grpc/xds/internal/balancer/clustermanager"
 	"google.golang.org/grpc/xds/internal/balancer/ringhash"
-	"google.golang.org/grpc/xds/internal/clusterspecifier"
 	"google.golang.org/grpc/xds/internal/httpfilter"
 	"google.golang.org/grpc/xds/internal/httpfilter/router"
 	"google.golang.org/grpc/xds/internal/testutils/fakeclient"
@@ -865,88 +863,6 @@ func (s) TestXDSResolverWRR(t *testing.T) {
 	}
 }
 
-func init() {
-	balancer.Register(cspB{})
-}
-
-type cspB struct{}
-
-func (cspB) Build(cc balancer.ClientConn, opts balancer.BuildOptions) balancer.Balancer {
-	return nil
-}
-
-func (cspB) Name() string {
-	return "csp_experimental"
-}
-
-type cspConfig struct {
-	ArbitraryField string `json:"arbitrary_field"`
-}
-
-func TestXDSResolverClusterSpecifierPlugin(t *testing.T) {
-	xdsR, xdsC, tcc, cancel := testSetup(t, setupOpts{target: target})
-	defer xdsR.Close()
-	defer cancel()
-
-	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
-	defer cancel()
-	waitForWatchListener(ctx, t, xdsC, targetStr)
-	xdsC.InvokeWatchListenerCallback(xdsresource.ListenerUpdate{RouteConfigName: routeStr, HTTPFilters: routerFilterList}, nil)
-
-	waitForWatchRouteConfig(ctx, t, xdsC, routeStr)
-	xdsC.InvokeWatchRouteConfigCallback("", xdsresource.RouteConfigUpdate{
-		VirtualHosts: []*xdsresource.VirtualHost{
-			{
-				Domains: []string{targetStr},
-				Routes:  []*xdsresource.Route{{Prefix: newStringP(""), ClusterSpecifierPlugin: "cspA"}},
-			},
-		},
-		// Top level csp config here - the value of cspA should get directly
-		// placed as a child policy of xds cluster manager.
-		ClusterSpecifierPlugins: map[string]clusterspecifier.BalancerConfig{"cspA": []map[string]interface{}{{"csp_experimental": cspConfig{ArbitraryField: "anything"}}}},
-	}, nil)
-
-	gotState, err := tcc.stateCh.Receive(ctx)
-	if err != nil {
-		t.Fatalf("Error waiting for UpdateState to be called: %v", err)
-	}
-	rState := gotState.(resolver.State)
-	if err := rState.ServiceConfig.Err; err != nil {
-		t.Fatalf("ClientConn.UpdateState received error in service config: %v", rState.ServiceConfig.Err)
-	}
-	wantJSON := `{"loadBalancingConfig":[{
-    "xds_cluster_manager_experimental":{
-      "children":{
-        "cluster_specifier_plugin:cspA":{
-          "childPolicy":[{"csp_experimental":{"arbitrary_field":"anything"}}]
-        }
-      }
-    }}]}`
-
-	wantSCParsed := internal.ParseServiceConfigForTesting.(func(string) *serviceconfig.ParseResult)(wantJSON)
-	if !internal.EqualServiceConfigForTesting(rState.ServiceConfig.Config, wantSCParsed.Config) {
-		t.Errorf("ClientConn.UpdateState received different service config")
-		t.Error("got: ", cmp.Diff(nil, rState.ServiceConfig.Config))
-		t.Fatal("want: ", cmp.Diff(nil, wantSCParsed.Config))
-	}
-
-	cs := iresolver.GetConfigSelector(rState)
-	if cs == nil {
-		t.Fatal("received nil config selector")
-	}
-
-	res, err := cs.SelectConfig(iresolver.RPCInfo{Context: context.Background()})
-	if err != nil {
-		t.Fatalf("Unexpected error from cs.SelectConfig(_): %v", err)
-	}
-
-	cluster := clustermanager.GetPickedClusterForTesting(res.Context)
-	clusterWant := clusterSpecifierPluginPrefix + "cspA"
-	if cluster != clusterWant {
-		t.Fatalf("cluster: %+v, want: %+v", cluster, clusterWant)
-	}
-}
-
 func (s) TestXDSResolverMaxStreamDuration(t *testing.T) {
 	xdsR, xdsC, tcc, cancel := testSetup(t, setupOpts{target: target})
 	defer xdsR.Close()
@@ -1173,166 +1089,6 @@ func (s) TestXDSResolverDelayedOnCommitted(t *testing.T) {
         }
       }
     }}]}`
-	wantSCParsed3 := internal.ParseServiceConfigForTesting.(func(string) *serviceconfig.ParseResult)(wantJSON3)
-	if !internal.EqualServiceConfigForTesting(rState.ServiceConfig.Config, wantSCParsed3.Config) {
-		t.Errorf("ClientConn.UpdateState received different service config")
-		t.Error("got: ", cmp.Diff(nil, rState.ServiceConfig.Config))
-		t.Fatal("want: ", cmp.Diff(nil, wantSCParsed3.Config))
-	}
-}
-
-// TestXDSResolverDelayedOnCommittedCSP tests that cluster specifier plugins and
-// their corresponding configurations remain in service config if RPCs are in
-// flight.
-func (s) TestXDSResolverDelayedOnCommittedCSP(t *testing.T) {
-	xdsR, xdsC, tcc, cancel := testSetup(t, setupOpts{target: target})
-	defer xdsR.Close()
-	defer cancel()
-
-	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
-	defer cancel()
-	waitForWatchListener(ctx, t, xdsC, targetStr)
-	xdsC.InvokeWatchListenerCallback(xdsresource.ListenerUpdate{RouteConfigName: routeStr, HTTPFilters: routerFilterList}, nil)
-	waitForWatchRouteConfig(ctx, t, xdsC, routeStr)
-
-	xdsC.InvokeWatchRouteConfigCallback("", xdsresource.RouteConfigUpdate{
-		VirtualHosts: []*xdsresource.VirtualHost{
-			{
-				Domains: []string{targetStr},
-				Routes:  []*xdsresource.Route{{Prefix: newStringP(""), ClusterSpecifierPlugin: "cspA"}},
-			},
-		},
-		// Top level csp config here - the value of cspA should get directly
-		// placed as a child policy of xds cluster manager.
-		ClusterSpecifierPlugins: map[string]clusterspecifier.BalancerConfig{"cspA": []map[string]interface{}{{"csp_experimental": cspConfig{ArbitraryField: "anythingA"}}}},
-	}, nil)
-
-	gotState, err := tcc.stateCh.Receive(ctx)
-	if err != nil {
-		t.Fatalf("Error waiting for UpdateState to be called: %v", err)
-	}
-	rState := gotState.(resolver.State)
-	if err := rState.ServiceConfig.Err; err != nil {
-		t.Fatalf("ClientConn.UpdateState received error in service config: %v", rState.ServiceConfig.Err)
-	}
-	wantJSON := `{"loadBalancingConfig":[{
-    "xds_cluster_manager_experimental":{
-      "children":{
-        "cluster_specifier_plugin:cspA":{
-          "childPolicy":[{"csp_experimental":{"arbitrary_field":"anythingA"}}]
-        }
-      }
-    }}]}`
-
-	wantSCParsed := internal.ParseServiceConfigForTesting.(func(string) *serviceconfig.ParseResult)(wantJSON)
-	if !internal.EqualServiceConfigForTesting(rState.ServiceConfig.Config, wantSCParsed.Config) {
-		t.Errorf("ClientConn.UpdateState received different service config")
-		t.Error("got: ", cmp.Diff(nil, rState.ServiceConfig.Config))
-		t.Fatal("want: ", cmp.Diff(nil, wantSCParsed.Config))
-	}
-
-	cs := iresolver.GetConfigSelector(rState)
-	if cs == nil {
-		t.Fatal("received nil config selector")
-	}
-
-	res, err := cs.SelectConfig(iresolver.RPCInfo{Context: context.Background()})
-	if err != nil {
-		t.Fatalf("Unexpected error from cs.SelectConfig(_): %v", err)
-	}
-
-	cluster := clustermanager.GetPickedClusterForTesting(res.Context)
-	clusterWant := clusterSpecifierPluginPrefix + "cspA"
-	if cluster != clusterWant {
-		t.Fatalf("cluster: %+v, want: %+v", cluster, clusterWant)
-	}
-	// delay res.OnCommitted()
-
-	// Perform TWO updates to ensure the old config selector does not hold a reference to cspA
-	xdsC.InvokeWatchRouteConfigCallback("", xdsresource.RouteConfigUpdate{
-		VirtualHosts: []*xdsresource.VirtualHost{
-			{
-				Domains: []string{targetStr},
-				Routes:  []*xdsresource.Route{{Prefix: newStringP(""), ClusterSpecifierPlugin: "cspB"}},
-			},
-		},
-		// Top level csp config here - the value of cspB should get directly
-		// placed as a child policy of xds cluster manager.
-		ClusterSpecifierPlugins: map[string]clusterspecifier.BalancerConfig{"cspB": []map[string]interface{}{{"csp_experimental": cspConfig{ArbitraryField: "anythingB"}}}},
-	}, nil)
-	tcc.stateCh.Receive(ctx) // Ignore the first update.
-
-	xdsC.InvokeWatchRouteConfigCallback("", xdsresource.RouteConfigUpdate{
-		VirtualHosts: []*xdsresource.VirtualHost{
-			{
-				Domains: []string{targetStr},
-				Routes:  []*xdsresource.Route{{Prefix: newStringP(""), ClusterSpecifierPlugin: "cspB"}},
-			},
-		},
-		// Top level csp config here - the value of cspB should get directly
-		// placed as a child policy of xds cluster manager.
-		ClusterSpecifierPlugins: map[string]clusterspecifier.BalancerConfig{"cspB": []map[string]interface{}{{"csp_experimental": cspConfig{ArbitraryField: "anythingB"}}}},
-	}, nil)
-
-	gotState, err = tcc.stateCh.Receive(ctx)
-	if err != nil {
-		t.Fatalf("Error waiting for UpdateState to be called: %v", err)
-	}
-	rState = gotState.(resolver.State)
-	if err := rState.ServiceConfig.Err; err != nil {
-		t.Fatalf("ClientConn.UpdateState received error in service config: %v", rState.ServiceConfig.Err)
-	}
-	wantJSON2 := `{"loadBalancingConfig":[{
-    "xds_cluster_manager_experimental":{
-      "children":{
-        "cluster_specifier_plugin:cspA":{
-          "childPolicy":[{"csp_experimental":{"arbitrary_field":"anythingA"}}]
-        },
-		"cluster_specifier_plugin:cspB":{
-          "childPolicy":[{"csp_experimental":{"arbitrary_field":"anythingB"}}]
-        }
-      }
-    }}]}`
-
-	wantSCParsed2 := internal.ParseServiceConfigForTesting.(func(string) *serviceconfig.ParseResult)(wantJSON2)
-	if !internal.EqualServiceConfigForTesting(rState.ServiceConfig.Config, wantSCParsed2.Config) {
-		t.Errorf("ClientConn.UpdateState received different service config")
-		t.Error("got: ", cmp.Diff(nil, rState.ServiceConfig.Config))
-		t.Fatal("want: ", cmp.Diff(nil, wantSCParsed2.Config))
-	}
-
-	// Invoke OnCommitted; should lead to a service config update that deletes
-	// cspA.
-	res.OnCommitted()
-
-	xdsC.InvokeWatchRouteConfigCallback("", xdsresource.RouteConfigUpdate{
-		VirtualHosts: []*xdsresource.VirtualHost{
-			{
-				Domains: []string{targetStr},
-				Routes:  []*xdsresource.Route{{Prefix: newStringP(""), ClusterSpecifierPlugin: "cspB"}},
-			},
-		},
-		// Top level csp config here - the value of cspB should get directly
-		// placed as a child policy of xds cluster manager.
-		ClusterSpecifierPlugins: map[string]clusterspecifier.BalancerConfig{"cspB": []map[string]interface{}{{"csp_experimental": cspConfig{ArbitraryField: "anythingB"}}}},
-	}, nil)
-	gotState, err = tcc.stateCh.Receive(ctx)
-	if err != nil {
-		t.Fatalf("Error waiting for UpdateState to be called: %v", err)
-	}
-	rState = gotState.(resolver.State)
-	if err := rState.ServiceConfig.Err; err != nil {
-		t.Fatalf("ClientConn.UpdateState received error in service config: %v", rState.ServiceConfig.Err)
-	}
-	wantJSON3 := `{"loadBalancingConfig":[{
-    "xds_cluster_manager_experimental":{
-      "children":{
-		"cluster_specifier_plugin:cspB":{
-          "childPolicy":[{"csp_experimental":{"arbitrary_field":"anythingB"}}]
-        }
-      }
-    }}]}`
-
 	wantSCParsed3 := internal.ParseServiceConfigForTesting.(func(string) *serviceconfig.ParseResult)(wantJSON3)
 	if !internal.EqualServiceConfigForTesting(rState.ServiceConfig.Config, wantSCParsed3.Config) {
 		t.Errorf("ClientConn.UpdateState received different service config")


### PR DESCRIPTION
This PR adds support for cluster specifier specifier plugins in the xds resolver/config selector, as per RLS in xDS design. The functionality still left to implement is the RLS Cluster Specifier Plugin.

RELEASE NOTES: None