### PR TITLE
balancergroup: add method to exitIdle a sub-balancer

### DIFF
--- a/internal/balancergroup/balancergroup.go
+++ b/internal/balancergroup/balancergroup.go
@@ -506,3 +506,13 @@ func (bg *BalancerGroup) ExitIdle() {
 	}
 	bg.outgoingMu.Unlock()
 }
+
+// ExitIdleOne instructs the sub-balancer `id` to exit IDLE state, if
+// appropriate and possible.
+func (bg *BalancerGroup) ExitIdleOne(id string) {
+	bg.outgoingMu.Lock()
+	if config := bg.idToBalancerConfig[id]; config != nil {
+		config.exitIdle()
+	}
+	bg.outgoingMu.Unlock()
+}


### PR DESCRIPTION
This is required for the RLS LB policy. At pick time, if the RLS picker
finds one of its child policies in IDLE, it needs to be able to ask it
to exit idle.

RELEASE NOTES: n/a