### PR TITLE
xds: Add RLS Cluster Specifier Plugin

### DIFF
--- a/balancer/rls/rls.go
+++ b/balancer/rls/rls.go
@@ -20,6 +20,6 @@
 package rls
 
 import (
-	// Blank import to init the rls lb policy for testing purposes.
+	// Blank import to init the rls lb policy for external use.
 	_ "google.golang.org/grpc/balancer/rls/internal"
 )

--- a/balancer/rls/rls.go
+++ b/balancer/rls/rls.go
@@ -1,0 +1,25 @@
+/*
+ *
+ * Copyright 2021 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// Package rls imports to init the rls lb policy for testing purposes.
+package rls
+
+import (
+	// Blank import to init the rls lb policy for testing purposes.
+	_ "google.golang.org/grpc/balancer/rls/internal"
+)

--- a/xds/internal/clusterspecifier/rls/rls.go
+++ b/xds/internal/clusterspecifier/rls/rls.go
@@ -26,6 +26,7 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
 	"google.golang.org/grpc/balancer"
+	"google.golang.org/grpc/internal/envconfig"
 	"google.golang.org/grpc/internal/proto/grpc_lookup_v1"
 	"google.golang.org/grpc/xds/internal/clusterspecifier"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -38,7 +39,9 @@ import (
 const rlsBalancerName = "rls"
 
 func init() {
-	clusterspecifier.Register(rls{})
+	if envconfig.XDSRLS {
+		clusterspecifier.Register(rls{})
+	}
 }
 
 type rls struct{}

--- a/xds/internal/clusterspecifier/rls/rls.go
+++ b/xds/internal/clusterspecifier/rls/rls.go
@@ -36,7 +36,7 @@ import (
 	_ "google.golang.org/grpc/balancer/rls"
 )
 
-const rlsBalancerName = "rls"
+const rlsBalancerName = "rls_experimental"
 
 func init() {
 	if envconfig.XDSRLS {

--- a/xds/internal/clusterspecifier/rls/rls.go
+++ b/xds/internal/clusterspecifier/rls/rls.go
@@ -1,0 +1,100 @@
+/*
+ *
+ * Copyright 2021 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// Package rls implements the RLS cluster specifier plugin.
+package rls
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/ptypes"
+	"google.golang.org/grpc/balancer"
+	"google.golang.org/grpc/internal/proto/grpc_lookup_v1"
+	"google.golang.org/grpc/xds/internal/clusterspecifier"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/types/known/anypb"
+)
+
+func init() {
+	clusterspecifier.Register(rls{})
+}
+
+type rls struct{}
+
+func (rls) TypeURLs() []string {
+	return []string{"type.googleapis.com/grpc.lookup.v1.RouteLookupClusterSpecifier"}
+}
+
+// lbConfigJSON is the RLS LB Policies configuration in JSON format.
+// RouteLookupConfig will be a raw JSON string from the passed in proto
+// configuration, and the other fields will be hardcoded.
+type lbConfigJSON struct {
+	RouteLookupConfig                json.RawMessage              `json:"routeLookupConfig"`
+	ChildPolicy                      []map[string]json.RawMessage `json:"childPolicy"`
+	ChildPolicyConfigTargetFieldName string                       `json:"childPolicyConfigTargetFieldName"`
+}
+
+func (rls) ParseClusterSpecifierConfig(cfg proto.Message) (clusterspecifier.BalancerConfig, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("rls_csp: nil configuration message provided")
+	}
+	any, ok := cfg.(*anypb.Any)
+	if !ok {
+		return nil, fmt.Errorf("rls_csp: error parsing config %v: unknown type %T", cfg, cfg)
+	}
+	rlcs := new(grpc_lookup_v1.RouteLookupClusterSpecifier)
+
+	if err := ptypes.UnmarshalAny(any, rlcs); err != nil {
+		return nil, fmt.Errorf("rls_csp: error parsing config %v: %v", cfg, err)
+	}
+	rlcJSON, err := protojson.Marshal(rlcs.GetRouteLookupConfig())
+	if err != nil {
+		return nil, fmt.Errorf("rls_csp: error marshaling route lookup config: %v: %v", rlcs.GetRouteLookupConfig(), err)
+	}
+	emptyJSON, err := json.Marshal(struct{}{})
+	if err != nil {
+		return nil, fmt.Errorf("rls_csp: error marshaling empty JSON")
+	}
+	lbCfgJSON := &lbConfigJSON{
+		RouteLookupConfig: rlcJSON, // "JSON form of RouteLookupClusterSpecifier.config" - RLS in xDS Design Doc
+		ChildPolicy: []map[string]json.RawMessage{
+			{
+				"cds_experimental": emptyJSON,
+			},
+		},
+		ChildPolicyConfigTargetFieldName: "cluster",
+	}
+
+	rawJSON, err := json.Marshal(lbCfgJSON)
+	if err != nil {
+		return nil, fmt.Errorf("rls_csp: error marshaling load balancing config %v: %v", lbCfgJSON, err)
+	}
+
+	rlsBB := balancer.Get("rls")
+	if rlsBB == nil {
+		return nil, fmt.Errorf("RLS LB policy not registered")
+	}
+	_, err = rlsBB.(balancer.ConfigParser).ParseConfig(rawJSON)
+	if err != nil {
+		return nil, fmt.Errorf("rls_csp: validation error from rls lb policy parsing %v", err)
+	}
+
+	return clusterspecifier.BalancerConfig{{"rls_experimental": lbCfgJSON}}, nil
+}

--- a/xds/internal/clusterspecifier/rls/rls_test.go
+++ b/xds/internal/clusterspecifier/rls/rls_test.go
@@ -99,8 +99,8 @@ func (s) TestParseClusterSpecifierConfig(t *testing.T) {
 		if err != nil {
 			t.Fatalf("json.Unmarshal(%+v) returned err %v", lbCfgJSON, err)
 		}
-		if !cmp.Equal(want, got, cmpopts.EquateEmpty()) {
-			t.Fatalf("ParseClusterSpecifierConfig(%+v) returned expected, diff (-want +got):\\n%s", test.rlcs, cmp.Diff(want, got, cmpopts.EquateEmpty()))
+		if diff := cmp.Diff(want, got, cmpopts.EquateEmpty()); diff != "" {
+			t.Fatalf("ParseClusterSpecifierConfig(%+v) returned expected, diff (-want +got) %v", test.rlcs, diff)
 		}
 	}
 }

--- a/xds/internal/clusterspecifier/rls/rls_test.go
+++ b/xds/internal/clusterspecifier/rls/rls_test.go
@@ -1,0 +1,123 @@
+/*
+ *
+ * Copyright 2021 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package rls
+
+import (
+	"testing"
+
+	"github.com/golang/protobuf/proto"
+	_ "google.golang.org/grpc/balancer/rls"
+	"google.golang.org/grpc/internal/grpctest"
+	"google.golang.org/grpc/internal/proto/grpc_lookup_v1"
+	"google.golang.org/grpc/internal/testutils"
+	_ "google.golang.org/grpc/xds/internal/balancer/cdsbalancer"
+	"google.golang.org/grpc/xds/internal/clusterspecifier"
+	"google.golang.org/protobuf/types/known/durationpb"
+)
+
+type s struct {
+	grpctest.Tester
+}
+
+func Test(t *testing.T) {
+	grpctest.RunSubTests(t, s{})
+}
+
+// TestParseClusterSpecifierConfig tests the parsing functionality of the RLS
+// Cluster Specifier Plugin.
+func (s) TestParseClusterSpecifierConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		rlcs    proto.Message
+		wantErr bool
+	}{
+		{
+			name:    "invalid-rls-cluster-specifier",
+			rlcs:    rlsClusterSpecifierConfigError,
+			wantErr: true,
+		},
+		{
+			name: "valid-rls-cluster-specifier",
+			rlcs: rlsClusterSpecifierConfigWithoutTransformations,
+		},
+	}
+	for _, test := range tests {
+		cs := clusterspecifier.Get("type.googleapis.com/grpc.lookup.v1.RouteLookupClusterSpecifier")
+		if cs == nil {
+			t.Fatal("Error getting cluster specifier")
+		}
+		_, err := cs.ParseClusterSpecifierConfig(test.rlcs)
+
+		if (err != nil) != test.wantErr {
+			t.Fatalf("ParseClusterSpecifierConfig(%+v) returned err: %v, wantErr: %v", test.rlcs, err, test.wantErr)
+		}
+	}
+}
+
+// This will error because the required match field is set in grpc key builder.
+var rlsClusterSpecifierConfigError = testutils.MarshalAny(&grpc_lookup_v1.RouteLookupClusterSpecifier{
+	RouteLookupConfig: &grpc_lookup_v1.RouteLookupConfig{
+		GrpcKeybuilders: []*grpc_lookup_v1.GrpcKeyBuilder{
+			{
+				Names: []*grpc_lookup_v1.GrpcKeyBuilder_Name{
+					{
+						Service: "service",
+						Method:  "method",
+					},
+				},
+				Headers: []*grpc_lookup_v1.NameMatcher{
+					{
+						Key:           "k1",
+						RequiredMatch: true,
+						Names:         []string{"v1"},
+					},
+				},
+			},
+		},
+	},
+})
+
+// Corresponds to the rls unit test case in
+// balancer/rls/internal/config_test.go.
+var rlsClusterSpecifierConfigWithoutTransformations = testutils.MarshalAny(&grpc_lookup_v1.RouteLookupClusterSpecifier{
+	RouteLookupConfig: &grpc_lookup_v1.RouteLookupConfig{
+		GrpcKeybuilders: []*grpc_lookup_v1.GrpcKeyBuilder{
+			{
+				Names: []*grpc_lookup_v1.GrpcKeyBuilder_Name{
+					{
+						Service: "service",
+						Method:  "method",
+					},
+				},
+				Headers: []*grpc_lookup_v1.NameMatcher{
+					{
+						Key:   "k1",
+						Names: []string{"v1"},
+					},
+				},
+			},
+		},
+		LookupService:        "target",
+		LookupServiceTimeout: &durationpb.Duration{Seconds: 100},
+		MaxAge:               &durationpb.Duration{Seconds: 60},
+		StaleAge:             &durationpb.Duration{Seconds: 50},
+		CacheSizeBytes:       1000,
+		DefaultTarget:        "passthrough:///default",
+	},
+})


### PR DESCRIPTION
This PR adds the RLS Cluster Specifier Plugin. This is branched off #4987. The RLS Cluster Specifier Plugin will not be functional until the RLS LB Policy itself gets completed, as right now the call into the RLS LB Policies ParseConfig() for validation purposes is commented out.

RELEASE NOTES: None