### PR TITLE
xds/c2p: fix default client resource template, and xds-client target scheme

### DIFF
--- a/xds/googledirectpath/googlec2p.go
+++ b/xds/googledirectpath/googlec2p.go
@@ -49,7 +49,7 @@ import (
 const (
 	c2pScheme = "google-c2p"
 
-	tdURL          = "directpath-pa.googleapis.com"
+	tdURL          = "dns:///directpath-pa.googleapis.com"
 	httpReqTimeout = 10 * time.Second
 	zoneURL        = "http://metadata.google.internal/computeMetadata/v1/instance/zone"
 	ipv6URL        = "http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/ipv6s"
@@ -110,6 +110,7 @@ func (c2pResolverBuilder) Build(t resolver.Target, cc resolver.ClientConn, opts 
 			TransportAPI: version.TransportV3,
 			NodeProto:    newNode(<-zoneCh, <-ipv6CapableCh),
 		},
+		ClientDefaultListenerResourceNameTemplate: "%s",
 	}
 
 	// Create singleton xds client with this config. The xds client will be

--- a/xds/googledirectpath/googlec2p_test.go
+++ b/xds/googledirectpath/googlec2p_test.go
@@ -217,6 +217,7 @@ func TestBuildXDS(t *testing.T) {
 					TransportAPI: version.TransportV3,
 					NodeProto:    wantNode,
 				},
+				ClientDefaultListenerResourceNameTemplate: "%s",
 			}
 			if tt.tdURI != "" {
 				wantConfig.XDSServer.ServerURI = tt.tdURI


### PR DESCRIPTION
Default client resource scheme should be %s, otherwise the client will watch an empty string LDS resource.

RELEASE NOTES: N/A