### PR TITLE
fix possible nil before casting

### DIFF
--- a/xds/internal/balancer/clustermanager/clustermanager_test.go
+++ b/xds/internal/balancer/clustermanager/clustermanager_test.go
@@ -560,6 +560,9 @@ func TestClusterManagerForwardsBalancerBuildOptions(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
 	if v, err := ccsCh.Receive(ctx); err != nil {
+		if v == nil {
+			t.Fatalf("received nil")
+		}
 		err2 := v.(error)
 		t.Fatal(err2)
 	}

--- a/xds/internal/balancer/clustermanager/clustermanager_test.go
+++ b/xds/internal/balancer/clustermanager/clustermanager_test.go
@@ -559,12 +559,12 @@ func TestClusterManagerForwardsBalancerBuildOptions(t *testing.T) {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
-	if v, err := ccsCh.Receive(ctx); err != nil {
-		if v == nil {
-			t.Fatalf("received nil")
-		}
-		err2 := v.(error)
-		t.Fatal(err2)
+	v, err := ccsCh.Receive(ctx)
+	if err != nil {
+		t.Fatalf("timed out waiting for UpdateClientConnState result: %v", err)
+	}
+	if v != nil {
+		t.Fatal(v)
 	}
 }
 


### PR DESCRIPTION
This PR aims to fix a possible nil before casting to error.



```
--- FAIL: TestClusterManagerForwardsBalancerBuildOptions (1.00s)
panic: interface conversion: interface is nil, not error [recovered]
	panic: interface conversion: interface is nil, not error

goroutine 93 [running]:
testing.tRunner.func1.2(0xceec40, 0xc00020f230)
	/usr/local/go/src/testing/testing.go:1143 +0x335
testing.tRunner.func1(0xc0003be280)
	/usr/local/go/src/testing/testing.go:1146 +0x4c2
panic(0xceec40, 0xc00020f230)
	/usr/local/go/src/runtime/panic.go:965 +0x1b9
google.golang.org/grpc/xds/internal/balancer/clustermanager.TestClusterManagerForwardsBalancerBuildOptions(0xc0003be280)
	/fuzz/target/xds/internal/balancer/clustermanager/clustermanager_test.go:635 +0x68f
testing.tRunner(0xc0003be280, 0xe8bbb0)
	/usr/local/go/src/testing/testing.go:1193 +0xef
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1238 +0x2b5
```

RELEASE NOTES: none