### PR TITLE
backport PRs to v1.41.x

### DIFF
--- a/credentials/google/google.go
+++ b/credentials/google/google.go
@@ -35,27 +35,40 @@ const tokenRequestTimeout = 30 * time.Second
 
 var logger = grpclog.Component("credentials")
 
+// DefaultCredentialsOptions constructs options to build DefaultCredentials.
+type DefaultCredentialsOptions struct {
+	// PerRPCCreds is a per RPC credentials that is passed to a bundle.
+	PerRPCCreds credentials.PerRPCCredentials
+}
+
+// NewDefaultCredentialsWithOptions returns a credentials bundle that is
+// configured to work with google services.
+//
+// This API is experimental.
+func NewDefaultCredentialsWithOptions(opts DefaultCredentialsOptions) credentials.Bundle {
+	if opts.PerRPCCreds == nil {
+		ctx, cancel := context.WithTimeout(context.Background(), tokenRequestTimeout)
+		defer cancel()
+		var err error
+		opts.PerRPCCreds, err = oauth.NewApplicationDefault(ctx)
+		if err != nil {
+			logger.Warningf("NewDefaultCredentialsWithOptions: failed to create application oauth: %v", err)
+		}
+	}
+	c := &creds{opts: opts}
+	bundle, err := c.NewWithMode(internal.CredsBundleModeFallback)
+	if err != nil {
+		logger.Warningf("NewDefaultCredentialsWithOptions: failed to create new creds: %v", err)
+	}
+	return bundle
+}
+
 // NewDefaultCredentials returns a credentials bundle that is configured to work
 // with google services.
 //
 // This API is experimental.
 func NewDefaultCredentials() credentials.Bundle {
-	c := &creds{
-		newPerRPCCreds: func() credentials.PerRPCCredentials {
-			ctx, cancel := context.WithTimeout(context.Background(), tokenRequestTimeout)
-			defer cancel()
-			perRPCCreds, err := oauth.NewApplicationDefault(ctx)
-			if err != nil {
-				logger.Warningf("google default creds: failed to create application oauth: %v", err)
-			}
-			return perRPCCreds
-		},
-	}
-	bundle, err := c.NewWithMode(internal.CredsBundleModeFallback)
-	if err != nil {
-		logger.Warningf("google default creds: failed to create new creds: %v", err)
-	}
-	return bundle
+	return NewDefaultCredentialsWithOptions(DefaultCredentialsOptions{})
 }
 
 // NewComputeEngineCredentials returns a credentials bundle that is configured to work
@@ -64,46 +77,21 @@ func NewDefaultCredentials() credentials.Bundle {
 //
 // This API is experimental.
 func NewComputeEngineCredentials() credentials.Bundle {
-	return NewComputeEngineCredsWithOptions(ComputeEngineCredsOptions{})
-}
-
-// ComputeEngineCredsOptions constructs compite engine credentials with options.
-type ComputeEngineCredsOptions struct {
-	// PerRPCCreds is a  per RPC credentials that is passed to a bundle.
-	PerRPCCreds credentials.PerRPCCredentials
-}
-
-// NewComputeEngineCredsWithOptions returns a credentials bundle that is configured to work
-// with google services. This API must only be used when running on GCE.
-//
-// This API is experimental.
-func NewComputeEngineCredsWithOptions(perRPCOpts ComputeEngineCredsOptions) credentials.Bundle {
-	perRPC := oauth.NewComputeEngine()
-	if perRPCOpts.PerRPCCreds != nil {
-		perRPC = perRPCOpts.PerRPCCreds
-	}
-	c := &creds{
-		newPerRPCCreds: func() credentials.PerRPCCredentials {
-			return perRPC
-		},
-	}
-	bundle, err := c.NewWithMode(internal.CredsBundleModeFallback)
-	if err != nil {
-		logger.Warningf("compute engine creds with per rpc: failed to create new creds: %v", err)
-	}
-	return bundle
+	return NewDefaultCredentialsWithOptions(DefaultCredentialsOptions{
+		PerRPCCreds: oauth.NewComputeEngine(),
+	})
 }
 
 // creds implements credentials.Bundle.
 type creds struct {
+	opts DefaultCredentialsOptions
+
 	// Supported modes are defined in internal/internal.go.
 	mode string
-	// The transport credentials associated with this bundle.
+	// The active transport credentials associated with this bundle.
 	transportCreds credentials.TransportCredentials
-	// The per RPC credentials associated with this bundle.
+	// The active per RPC credentials associated with this bundle.
 	perRPCCreds credentials.PerRPCCredentials
-	// Creates new per RPC credentials
-	newPerRPCCreds func() credentials.PerRPCCredentials
 }
 
 func (c *creds) TransportCredentials() credentials.TransportCredentials {
@@ -130,8 +118,8 @@ var (
 // existing Bundle may cause races.
 func (c *creds) NewWithMode(mode string) (credentials.Bundle, error) {
 	newCreds := &creds{
-		mode:           mode,
-		newPerRPCCreds: c.newPerRPCCreds,
+		opts: c.opts,
+		mode: mode,
 	}
 
 	// Create transport credentials.
@@ -147,7 +135,7 @@ func (c *creds) NewWithMode(mode string) (credentials.Bundle, error) {
 	}
 
 	if mode == internal.CredsBundleModeFallback || mode == internal.CredsBundleModeBackendFromBalancer {
-		newCreds.perRPCCreds = newCreds.newPerRPCCreds()
+		newCreds.perRPCCreds = newCreds.opts.PerRPCCreds
 	}
 
 	return newCreds, nil

--- a/credentials/google/google.go
+++ b/credentials/google/google.go
@@ -64,14 +64,32 @@ func NewDefaultCredentials() credentials.Bundle {
 //
 // This API is experimental.
 func NewComputeEngineCredentials() credentials.Bundle {
+	return NewComputeEngineCredsWithOptions(ComputeEngineCredsOptions{})
+}
+
+// ComputeEngineCredsOptions constructs compite engine credentials with options.
+type ComputeEngineCredsOptions struct {
+	// PerRPCCreds is a  per RPC credentials that is passed to a bundle.
+	PerRPCCreds credentials.PerRPCCredentials
+}
+
+// NewComputeEngineCredsWithOptions returns a credentials bundle that is configured to work
+// with google services. This API must only be used when running on GCE.
+//
+// This API is experimental.
+func NewComputeEngineCredsWithOptions(perRPCOpts ComputeEngineCredsOptions) credentials.Bundle {
+	perRPC := oauth.NewComputeEngine()
+	if perRPCOpts.PerRPCCreds != nil {
+		perRPC = perRPCOpts.PerRPCCreds
+	}
 	c := &creds{
 		newPerRPCCreds: func() credentials.PerRPCCredentials {
-			return oauth.NewComputeEngine()
+			return perRPC
 		},
 	}
 	bundle, err := c.NewWithMode(internal.CredsBundleModeFallback)
 	if err != nil {
-		logger.Warningf("compute engine creds: failed to create new creds: %v", err)
+		logger.Warningf("compute engine creds with per rpc: failed to create new creds: %v", err)
 	}
 	return bundle
 }

--- a/credentials/google/google_test.go
+++ b/credentials/google/google_test.go
@@ -76,9 +76,9 @@ func overrideNewCredsFuncs() func() {
 func TestClientHandshakeBasedOnClusterName(t *testing.T) {
 	defer overrideNewCredsFuncs()()
 	for bundleTyp, tc := range map[string]credentials.Bundle{
-		"defaultCreds":       NewDefaultCredentials(),
-		"computeCreds":       NewComputeEngineCredentials(),
-		"computeCredsPerRPC": NewComputeEngineCredsWithOptions(ComputeEngineCredsOptions{}),
+		"defaultCredsWithOptions": NewDefaultCredentialsWithOptions(DefaultCredentialsOptions{}),
+		"defaultCreds":            NewDefaultCredentials(),
+		"computeCreds":            NewComputeEngineCredentials(),
 	} {
 		tests := []struct {
 			name    string

--- a/credentials/google/google_test.go
+++ b/credentials/google/google_test.go
@@ -76,8 +76,9 @@ func overrideNewCredsFuncs() func() {
 func TestClientHandshakeBasedOnClusterName(t *testing.T) {
 	defer overrideNewCredsFuncs()()
 	for bundleTyp, tc := range map[string]credentials.Bundle{
-		"defaultCreds": NewDefaultCredentials(),
-		"computeCreds": NewComputeEngineCredentials(),
+		"defaultCreds":       NewDefaultCredentials(),
+		"computeCreds":       NewComputeEngineCredentials(),
+		"computeCredsPerRPC": NewComputeEngineCredsWithOptions(ComputeEngineCredsOptions{}),
 	} {
 		tests := []struct {
 			name    string

--- a/pickfirst.go
+++ b/pickfirst.go
@@ -125,7 +125,7 @@ func (b *pickfirstBalancer) Close() {
 }
 
 func (b *pickfirstBalancer) ExitIdle() {
-	if b.state == connectivity.Idle {
+	if b.sc != nil && b.state == connectivity.Idle {
 		b.sc.Connect()
 	}
 }


### PR DESCRIPTION
- creds/google: add NewDefaultCredentialsWithOptions() to support custom per-RPC creds (#4767, #4830)
- pickfirst: check b.sc before calling Connect (#4971)