### PR TITLE
fix possible blocked send when cancel watch

### DIFF
--- a/xds/internal/testutils/fakeclient/client.go
+++ b/xds/internal/testutils/fakeclient/client.go
@@ -197,7 +197,7 @@ func (xdsC *Client) WatchEndpoints(clusterName string, callback func(xdsresource
 	xdsC.edsCbs[clusterName] = callback
 	xdsC.edsWatchCh.Send(clusterName)
 	return func() {
-		xdsC.edsCancelCh.Send(clusterName)
+		xdsC.edsCancelCh.SendOrFail(clusterName)
 	}
 }
 


### PR DESCRIPTION
=== RUN   TestClientWatchEDS
eds_test.go:xxx: timed out when expecting resource ""

-- FAIL: TestClientWatchEDS (2.00s)

FAIL

If we tweak the some selects in TestClientWatchEDS, for example, delay select in UpdateClientConnState for about 1 seconds to `x.grpcUpdate <- &s`, context in test will timeout, cause cancel watch to be triggered. However, not always `xdsC.edsCancelCh` will have receiver. It will make send operation blocked forever. This fix aims to make an unblocking send operation for notifying xdsC.edsCancelCh. 

The following stack is coming from the old version of gRPC. 
```
goroutine 113 [chan send]:
google.golang.org/grpc/internal/testutils.(*Channel).Send(0xc00000e428, 0x0, 0x0)
	/fuzz/target/internal/testutils/channel.go:41 +0xc5
google.golang.org/grpc/xds/internal/testutils/fakeclient.(*Client).WatchEndpoints.func1()
	/fuzz/target/xds/internal/testutils/fakeclient/client.go:181 +0x36
google.golang.org/grpc/xds/internal/balancer/edsbalancer.(*edsxds/internal/balancer/edsbalancer/eds.go:388Balancer).startEndpointsWatch.func2()
	/fuzz/target/ +0x33
google.golang.org/grpc/xds/internal/balancer/edsbalancer.(*edsBalancer).cancelWatch(0xc000218c60)
	/fuzz/target/xds/internal/balancer/edsbalancer/eds.go:401 +0xa2
google.golang.org/grpc/xds/internal/balancer/edsbalancer.(*edsBalancer).run(0xc000218c60)
	/fuzz/target/xds/internal/balancer/edsbalancer/eds.go:283 +0xbcb
created by google.golang.org/grpc/xds/internal/balancer/edsbalancer.(*edsBalancerBuilder).Build
	/fuzz/target/xds/internal/balancer/edsbalancer/eds.go:87 +0x68b
```