### PR TITLE
grpclb: fix possible nil before conversion in TestDropRequest

### DIFF
--- a/balancer/grpclb/grpclb_test.go
+++ b/balancer/grpclb/grpclb_test.go
@@ -656,7 +656,7 @@ func (s) TestDropRequest(t *testing.T) {
 	for i := 0; i < 3; i++ {
 		var p peer.Peer
 		if _, err := testC.EmptyCall(ctx, &testpb.Empty{}, grpc.WaitForReady(true), grpc.Peer(&p)); err != nil {
-			t.Errorf("%v.EmptyCall(_, _) = _, %v, want _, <nil>", testC, err)
+			t.Fatalf("%v.EmptyCall(_, _) = _, %v, want _, <nil>", testC, err)
 		}
 		if want := tss.bePorts[1]; p.Addr.(*net.TCPAddr).Port != want {
 			t.Errorf("got peer: %v, want peer port: %v", p.Addr, want)
@@ -667,7 +667,7 @@ func (s) TestDropRequest(t *testing.T) {
 		}
 
 		if _, err := testC.EmptyCall(ctx, &testpb.Empty{}, grpc.WaitForReady(true), grpc.Peer(&p)); err != nil {
-			t.Errorf("%v.EmptyCall(_, _) = _, %v, want _, <nil>", testC, err)
+			t.Fatalf("%v.EmptyCall(_, _) = _, %v, want _, <nil>", testC, err)
 		}
 		if want := tss.bePorts[1]; p.Addr.(*net.TCPAddr).Port != want {
 			t.Errorf("got peer: %v, want peer port: %v", p.Addr, want)


### PR DESCRIPTION
If previous testC.EmptyCall failed, which caused error like
```
EmptyCall(_, _) = _, rpc error: code = DeadlineExceeded desc = context deadline exceeded, want _, <nil>
```

Next p.Addr could be nil.

--- FAIL: TestDropRequest (11.01s)
panic: interface conversion: net.Addr is nil, not *net.TCPAddr [recovered]
	panic: interface conversion: net.Addr is nil, not *net.TCPAddr

goroutine 21 [running]:
testing.tRunner.func1.2(0x8ff3c0, 0xc000282660)
	/usr/local/go/src/testing/testing.go:1143 +0x335
testing.tRunner.func1(0xc000276c80)
	/usr/local/go/src/testing/testing.go:1146 +0x4c2
panic(0x8ff3c0, 0xc000282660)
	/usr/local/go/src/runtime/panic.go:965 +0x1b9
google.golang.org/grpc/balancer/grpclb.TestDropRequest(0xc000276c80)
	/fuzz/target/balancer/grpclb/grpclb_test.go:831 +0x23dc
testing.tRunner(0xc000276c80, 0x9b34e8)
	/usr/local/go/src/testing/testing.go:1193 +0xef
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1238 +0x2b5

RELEASE NOTES: none