### PR TITLE
xds/bootstrap_config: add a string function to server config

### DIFF
--- a/xds/internal/xdsclient/bootstrap/bootstrap.go
+++ b/xds/internal/xdsclient/bootstrap/bootstrap.go
@@ -88,9 +88,13 @@ type ServerConfig struct {
 
 // String returns the string representation of the ServerConfig.
 //
-// Note that it covers (almost) all the fields so the string can be used map
-// keys. Except NodeProto because NodeProto isn't used by federation (and this
-// is only used as key in federation).
+// This string representation will be used as map keys in federation
+// (`map[ServerConfig]authority`), so that the xDS ClientConn and stream will be
+// shared by authorities with different names but the same server config.
+//
+// It covers (almost) all the fields so the string can represent the config
+// content. It doesn't cover NodeProto because NodeProto isn't used by
+// federation.
 func (sc *ServerConfig) String() string {
 	var ver string
 	switch sc.TransportAPI {

--- a/xds/internal/xdsclient/bootstrap/bootstrap.go
+++ b/xds/internal/xdsclient/bootstrap/bootstrap.go
@@ -71,8 +71,8 @@ type ServerConfig struct {
 	// Creds contains the credentials to be used while talking to the xDS
 	// server, as a grpc.DialOption.
 	Creds grpc.DialOption
-	// credsType is the type of the creds. It will be used to dedup servers.
-	credsType string
+	// CredsType is the type of the creds. It will be used to dedup servers.
+	CredsType string
 	// TransportAPI indicates the API version of xDS transport protocol to use.
 	// This describes the xDS gRPC endpoint and version of
 	// DiscoveryRequest/Response used on the wire.
@@ -84,6 +84,22 @@ type ServerConfig struct {
 	// but we keep it in each server config so that its type (e.g. *v2pb.Node or
 	// *v3pb.Node) is consistent with the transport API version.
 	NodeProto proto.Message
+}
+
+// String returns the string representation of the ServerConfig.
+//
+// Note that it covers (almost) all the fields so the string can be used map
+// keys. Except NodeProto because NodeProto isn't used by federation (and this
+// is only used as key in federation).
+func (sc *ServerConfig) String() string {
+	var ver string
+	switch sc.TransportAPI {
+	case version.TransportV3:
+		ver = "xDSv3"
+	case version.TransportV2:
+		ver = "xDSv2"
+	}
+	return strings.Join([]string{sc.ServerURI, sc.CredsType, ver}, "-")
 }
 
 // UnmarshalJSON takes the json data (a list of servers) and unmarshals the
@@ -100,7 +116,7 @@ func (sc *ServerConfig) UnmarshalJSON(data []byte) error {
 	sc.ServerURI = xs.ServerURI
 	for _, cc := range xs.ChannelCreds {
 		// We stop at the first credential type that we support.
-		sc.credsType = cc.Type
+		sc.CredsType = cc.Type
 		if cc.Type == credsGoogleDefault {
 			sc.Creds = grpc.WithCredentialsBundle(google.NewDefaultCredentials())
 			break

--- a/xds/internal/xdsclient/bootstrap/bootstrap_test.go
+++ b/xds/internal/xdsclient/bootstrap/bootstrap_test.go
@@ -212,7 +212,7 @@ var (
 		XDSServer: &ServerConfig{
 			ServerURI: "trafficdirector.googleapis.com:443",
 			Creds:     grpc.WithTransportCredentials(insecure.NewCredentials()),
-			credsType: "insecure",
+			CredsType: "insecure",
 			NodeProto: v2NodeProto,
 		},
 		ClientDefaultListenerResourceNameTemplate: "%s",
@@ -221,7 +221,7 @@ var (
 		XDSServer: &ServerConfig{
 			ServerURI: "trafficdirector.googleapis.com:443",
 			Creds:     grpc.WithCredentialsBundle(google.NewComputeEngineCredentials()),
-			credsType: "google_default",
+			CredsType: "google_default",
 			NodeProto: v2NodeProto,
 		},
 		ClientDefaultListenerResourceNameTemplate: "%s",
@@ -230,7 +230,7 @@ var (
 		XDSServer: &ServerConfig{
 			ServerURI:    "trafficdirector.googleapis.com:443",
 			Creds:        grpc.WithCredentialsBundle(google.NewComputeEngineCredentials()),
-			credsType:    "google_default",
+			CredsType:    "google_default",
 			TransportAPI: version.TransportV3,
 			NodeProto:    v3NodeProto,
 		},
@@ -395,7 +395,7 @@ func TestNewConfigV2ProtoSuccess(t *testing.T) {
 				XDSServer: &ServerConfig{
 					ServerURI: "trafficdirector.googleapis.com:443",
 					Creds:     grpc.WithTransportCredentials(insecure.NewCredentials()),
-					credsType: "insecure",
+					CredsType: "insecure",
 					NodeProto: &v2corepb.Node{
 						BuildVersion:         gRPCVersion,
 						UserAgentName:        gRPCUserAgentName,
@@ -665,7 +665,7 @@ func TestNewConfigWithCertificateProviders(t *testing.T) {
 		XDSServer: &ServerConfig{
 			ServerURI:    "trafficdirector.googleapis.com:443",
 			Creds:        grpc.WithCredentialsBundle(google.NewComputeEngineCredentials()),
-			credsType:    "google_default",
+			CredsType:    "google_default",
 			TransportAPI: version.TransportV3,
 			NodeProto:    v3NodeProto,
 		},
@@ -759,7 +759,7 @@ func TestNewConfigWithServerListenerResourceNameTemplate(t *testing.T) {
 				XDSServer: &ServerConfig{
 					ServerURI:    "trafficdirector.googleapis.com:443",
 					Creds:        grpc.WithCredentialsBundle(google.NewComputeEngineCredentials()),
-					credsType:    "google_default",
+					CredsType:    "google_default",
 					TransportAPI: version.TransportV2,
 					NodeProto:    v2NodeProto,
 				},
@@ -908,7 +908,7 @@ func TestNewConfigWithFederation(t *testing.T) {
 				XDSServer: &ServerConfig{
 					ServerURI:    "trafficdirector.googleapis.com:443",
 					Creds:        grpc.WithCredentialsBundle(google.NewComputeEngineCredentials()),
-					credsType:    "google_default",
+					CredsType:    "google_default",
 					TransportAPI: version.TransportV2,
 					NodeProto:    v2NodeProto,
 				},
@@ -920,7 +920,7 @@ func TestNewConfigWithFederation(t *testing.T) {
 						XDSServer: &ServerConfig{
 							ServerURI:    "td.com",
 							Creds:        grpc.WithCredentialsBundle(google.NewComputeEngineCredentials()),
-							credsType:    "google_default",
+							CredsType:    "google_default",
 							TransportAPI: version.TransportV3,
 							NodeProto:    v3NodeProto,
 						},
@@ -934,7 +934,7 @@ func TestNewConfigWithFederation(t *testing.T) {
 				XDSServer: &ServerConfig{
 					ServerURI:    "trafficdirector.googleapis.com:443",
 					Creds:        grpc.WithCredentialsBundle(google.NewComputeEngineCredentials()),
-					credsType:    "google_default",
+					CredsType:    "google_default",
 					TransportAPI: version.TransportV2,
 					NodeProto:    v2NodeProto,
 				},
@@ -947,7 +947,7 @@ func TestNewConfigWithFederation(t *testing.T) {
 				XDSServer: &ServerConfig{
 					ServerURI:    "trafficdirector.googleapis.com:443",
 					Creds:        grpc.WithCredentialsBundle(google.NewComputeEngineCredentials()),
-					credsType:    "google_default",
+					CredsType:    "google_default",
 					TransportAPI: version.TransportV2,
 					NodeProto:    v2NodeProto,
 				},
@@ -965,7 +965,7 @@ func TestNewConfigWithFederation(t *testing.T) {
 				XDSServer: &ServerConfig{
 					ServerURI:    "trafficdirector.googleapis.com:443",
 					Creds:        grpc.WithCredentialsBundle(google.NewComputeEngineCredentials()),
-					credsType:    "google_default",
+					CredsType:    "google_default",
 					TransportAPI: version.TransportV2,
 					NodeProto:    v2NodeProto,
 				},


### PR DESCRIPTION
This string representation of the server config will be used as map
keys, so that xds client can be shared by authorities with the same
config.

Also exported a field so it can be set by tests.

RELEASE NOTES: N/A