### PR TITLE
xds/client: send NewStream errors to the watchers

### DIFF
--- a/xds/internal/xdsclient/controller/transport.go
+++ b/xds/internal/xdsclient/controller/transport.go
@@ -81,6 +81,7 @@ func (t *Controller) run(ctx context.Context) {
 		retries++
 		stream, err := t.vClient.NewStream(ctx, t.cc)
 		if err != nil {
+			t.updateHandler.NewConnectionError(err)
 			t.logger.Warningf("xds: ADS stream creation failed: %v", err)
 			continue
 		}


### PR DESCRIPTION
fixes #5020

RELEASE NOTES:
* xds/client:notify watchers of errors creating new xDS stream