### PR TITLE
authz: fix regex expression match

### DIFF
--- a/authz/rbac_translator.go
+++ b/authz/rbac_translator.go
@@ -95,7 +95,7 @@ func getStringMatcher(value string) *v3matcherpb.StringMatcher {
 	case value == "*":
 		return &v3matcherpb.StringMatcher{
 			MatchPattern: &v3matcherpb.StringMatcher_SafeRegex{
-				SafeRegex: &v3matcherpb.RegexMatcher{Regex: ".*"}},
+				SafeRegex: &v3matcherpb.RegexMatcher{Regex: "^\\S+$"}},
 		}
 	case strings.HasSuffix(value, "*"):
 		prefix := strings.TrimSuffix(value, "*")
@@ -120,7 +120,7 @@ func getHeaderMatcher(key, value string) *v3routepb.HeaderMatcher {
 		return &v3routepb.HeaderMatcher{
 			Name: key,
 			HeaderMatchSpecifier: &v3routepb.HeaderMatcher_SafeRegexMatch{
-				SafeRegexMatch: &v3matcherpb.RegexMatcher{Regex: ".*"}},
+				SafeRegexMatch: &v3matcherpb.RegexMatcher{Regex: "^\\S+$"}},
 		}
 	case strings.HasSuffix(value, "*"):
 		prefix := strings.TrimSuffix(value, "*")

--- a/authz/rbac_translator.go
+++ b/authz/rbac_translator.go
@@ -94,7 +94,8 @@ func getStringMatcher(value string) *v3matcherpb.StringMatcher {
 	switch {
 	case value == "*":
 		return &v3matcherpb.StringMatcher{
-			MatchPattern: &v3matcherpb.StringMatcher_SafeRegex{},
+			MatchPattern: &v3matcherpb.StringMatcher_SafeRegex{
+				SafeRegex: &v3matcherpb.RegexMatcher{Regex: ".*"}},
 		}
 	case strings.HasSuffix(value, "*"):
 		prefix := strings.TrimSuffix(value, "*")
@@ -117,8 +118,9 @@ func getHeaderMatcher(key, value string) *v3routepb.HeaderMatcher {
 	switch {
 	case value == "*":
 		return &v3routepb.HeaderMatcher{
-			Name:                 key,
-			HeaderMatchSpecifier: &v3routepb.HeaderMatcher_SafeRegexMatch{},
+			Name: key,
+			HeaderMatchSpecifier: &v3routepb.HeaderMatcher_SafeRegexMatch{
+				SafeRegexMatch: &v3matcherpb.RegexMatcher{Regex: ".*"}},
 		}
 	case strings.HasSuffix(value, "*"):
 		prefix := strings.TrimSuffix(value, "*")

--- a/authz/rbac_translator.go
+++ b/authz/rbac_translator.go
@@ -95,7 +95,7 @@ func getStringMatcher(value string) *v3matcherpb.StringMatcher {
 	case value == "*":
 		return &v3matcherpb.StringMatcher{
 			MatchPattern: &v3matcherpb.StringMatcher_SafeRegex{
-				SafeRegex: &v3matcherpb.RegexMatcher{Regex: "^\\S+$"}},
+				SafeRegex: &v3matcherpb.RegexMatcher{Regex: ".+"}},
 		}
 	case strings.HasSuffix(value, "*"):
 		prefix := strings.TrimSuffix(value, "*")
@@ -120,7 +120,7 @@ func getHeaderMatcher(key, value string) *v3routepb.HeaderMatcher {
 		return &v3routepb.HeaderMatcher{
 			Name: key,
 			HeaderMatchSpecifier: &v3routepb.HeaderMatcher_SafeRegexMatch{
-				SafeRegexMatch: &v3matcherpb.RegexMatcher{Regex: "^\\S+$"}},
+				SafeRegexMatch: &v3matcherpb.RegexMatcher{Regex: ".+"}},
 		}
 	case strings.HasSuffix(value, "*"):
 		prefix := strings.TrimSuffix(value, "*")

--- a/authz/rbac_translator_test.go
+++ b/authz/rbac_translator_test.go
@@ -127,7 +127,7 @@ func TestTranslatePolicy(t *testing.T) {
 									Ids: []*v3rbacpb.Principal{
 										{Identifier: &v3rbacpb.Principal_Authenticated_{
 											Authenticated: &v3rbacpb.Principal_Authenticated{PrincipalName: &v3matcherpb.StringMatcher{
-												MatchPattern: &v3matcherpb.StringMatcher_SafeRegex{},
+												MatchPattern: &v3matcherpb.StringMatcher_SafeRegex{SafeRegex: &v3matcherpb.RegexMatcher{Regex: ".*"}},
 											}},
 										}},
 									},

--- a/authz/rbac_translator_test.go
+++ b/authz/rbac_translator_test.go
@@ -127,7 +127,7 @@ func TestTranslatePolicy(t *testing.T) {
 									Ids: []*v3rbacpb.Principal{
 										{Identifier: &v3rbacpb.Principal_Authenticated_{
 											Authenticated: &v3rbacpb.Principal_Authenticated{PrincipalName: &v3matcherpb.StringMatcher{
-												MatchPattern: &v3matcherpb.StringMatcher_SafeRegex{SafeRegex: &v3matcherpb.RegexMatcher{Regex: ".*"}},
+												MatchPattern: &v3matcherpb.StringMatcher_SafeRegex{SafeRegex: &v3matcherpb.RegexMatcher{Regex: "^\\S+$"}},
 											}},
 										}},
 									},

--- a/authz/rbac_translator_test.go
+++ b/authz/rbac_translator_test.go
@@ -127,7 +127,7 @@ func TestTranslatePolicy(t *testing.T) {
 									Ids: []*v3rbacpb.Principal{
 										{Identifier: &v3rbacpb.Principal_Authenticated_{
 											Authenticated: &v3rbacpb.Principal_Authenticated{PrincipalName: &v3matcherpb.StringMatcher{
-												MatchPattern: &v3matcherpb.StringMatcher_SafeRegex{SafeRegex: &v3matcherpb.RegexMatcher{Regex: "^\\S+$"}},
+												MatchPattern: &v3matcherpb.StringMatcher_SafeRegex{SafeRegex: &v3matcherpb.RegexMatcher{Regex: ".+"}},
 											}},
 										}},
 									},

--- a/authz/sdk_end2end_test.go
+++ b/authz/sdk_end2end_test.go
@@ -299,6 +299,35 @@ var sdkTests = map[string]struct {
 			}`,
 		wantStatus: status.New(codes.PermissionDenied, "unauthorized RPC request rejected"),
 	},
+	"DeniesRPCRequestNoMatchInAllowFailsPresenceMatch": {
+		authzPolicy: `{
+				"name": "authz",
+				"allow_rules":
+				[
+					{
+						"name": "allow_TestServiceCalls",
+						"request": {
+							"paths":
+							[
+								"/grpc.testing.TestService/*"
+							],
+							"headers":
+							[
+								{
+									"key": "key-abc",
+									"values":
+									[
+										"*"
+									]
+								}
+							]
+						}
+					}
+				]
+			}`,
+		md:         metadata.Pairs("key-abc", ""),
+		wantStatus: status.New(codes.PermissionDenied, "unauthorized RPC request rejected"),
+	},
 }
 
 func (s) TestSDKStaticPolicyEnd2End(t *testing.T) {

--- a/authz/sdk_end2end_test.go
+++ b/authz/sdk_end2end_test.go
@@ -95,8 +95,7 @@ var sdkTests = map[string]struct {
 						"request": {
 							"paths":
 							[
-								"/grpc.testing.TestService/UnaryCall",
-								"/grpc.testing.TestService/StreamingInputCall"
+								"/grpc.testing.TestService/*"
 							],
 							"headers":
 							[
@@ -122,11 +121,11 @@ var sdkTests = map[string]struct {
 				"allow_rules":
 				[
 					{
-						"name": "allow_TestServiceCalls",
+						"name": "allow_all",
 						"request": {
 							"paths":
 							[
-								"/grpc.testing.TestService/*"
+								"*"
 							]
 						}
 					}
@@ -134,11 +133,11 @@ var sdkTests = map[string]struct {
 				"deny_rules":
 				[
 					{
-						"name": "deny_TestServiceCalls",
+						"name": "deny_all",
 						"request": {
 							"paths":
 							[
-								"/grpc.testing.TestService/*"
+								"*"
 							]
 						}
 					}

--- a/internal/grpcutil/regex.go
+++ b/internal/grpcutil/regex.go
@@ -20,9 +20,12 @@ package grpcutil
 
 import "regexp"
 
-// FullMatchWithRegex returns whether the full string matches the regex provided.
-func FullMatchWithRegex(re *regexp.Regexp, string string) bool {
+// FullMatchWithRegex returns whether the full text matches the regex provided.
+func FullMatchWithRegex(re *regexp.Regexp, text string) bool {
+	if len(text) == 0 {
+		return re.Match([]byte(text))
+	}
 	re.Longest()
-	rem := re.FindString(string)
-	return len(rem) == len(string)
+	rem := re.FindString(text)
+	return len(rem) == len(text)
 }

--- a/internal/grpcutil/regex.go
+++ b/internal/grpcutil/regex.go
@@ -23,7 +23,7 @@ import "regexp"
 // FullMatchWithRegex returns whether the full text matches the regex provided.
 func FullMatchWithRegex(re *regexp.Regexp, text string) bool {
 	if len(text) == 0 {
-		return re.Match([]byte(text))
+		return re.MatchString(text)
 	}
 	re.Longest()
 	rem := re.FindString(text)

--- a/internal/grpcutil/regex_test.go
+++ b/internal/grpcutil/regex_test.go
@@ -56,7 +56,7 @@ func TestFullMatchWithRegex(t *testing.T) {
 		},
 		{
 			name:     "matches non-empty strings",
-			regexStr: "^\\S+$",
+			regexStr: ".+",
 			string:   "",
 			want:     false,
 		},

--- a/internal/grpcutil/regex_test.go
+++ b/internal/grpcutil/regex_test.go
@@ -48,6 +48,18 @@ func TestFullMatchWithRegex(t *testing.T) {
 			string:   "ab",
 			want:     true,
 		},
+		{
+			name:     "match all",
+			regexStr: ".*",
+			string:   "",
+			want:     true,
+		},
+		{
+			name:     "matches non-empty strings",
+			regexStr: "^\\S+$",
+			string:   "",
+			want:     false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
In SDK authorization policy, "*" value represents presence match i.e. it will match when the value is not empty. This PR fixes presence match. Additionally, it updates underlying regex code to correctly handle match with empty string values.

RELEASE NOTES:

- authz: fixes regex expression match