### PR TITLE
grpclog.DepthLoggerV2: Correct comment: formats like fmt.Println

### DIFF
--- a/grpclog/loggerv2.go
+++ b/grpclog/loggerv2.go
@@ -248,12 +248,12 @@ func (g *loggerT) V(l int) bool {
 // later release.
 type DepthLoggerV2 interface {
 	LoggerV2
-	// InfoDepth logs to INFO log at the specified depth. Arguments are handled in the manner of fmt.Print.
+	// InfoDepth logs to INFO log at the specified depth. Arguments are handled in the manner of fmt.Println.
 	InfoDepth(depth int, args ...interface{})
-	// WarningDepth logs to WARNING log at the specified depth. Arguments are handled in the manner of fmt.Print.
+	// WarningDepth logs to WARNING log at the specified depth. Arguments are handled in the manner of fmt.Println.
 	WarningDepth(depth int, args ...interface{})
-	// ErrorDetph logs to ERROR log at the specified depth. Arguments are handled in the manner of fmt.Print.
+	// ErrorDepth logs to ERROR log at the specified depth. Arguments are handled in the manner of fmt.Println.
 	ErrorDepth(depth int, args ...interface{})
-	// FatalDepth logs to FATAL log at the specified depth. Arguments are handled in the manner of fmt.Print.
+	// FatalDepth logs to FATAL log at the specified depth. Arguments are handled in the manner of fmt.Println.
 	FatalDepth(depth int, args ...interface{})
 }

--- a/internal/grpclog/grpclog.go
+++ b/internal/grpclog/grpclog.go
@@ -115,12 +115,12 @@ type LoggerV2 interface {
 // Notice: This type is EXPERIMENTAL and may be changed or removed in a
 // later release.
 type DepthLoggerV2 interface {
-	// InfoDepth logs to INFO log at the specified depth. Arguments are handled in the manner of fmt.Print.
+	// InfoDepth logs to INFO log at the specified depth. Arguments are handled in the manner of fmt.Println.
 	InfoDepth(depth int, args ...interface{})
-	// WarningDepth logs to WARNING log at the specified depth. Arguments are handled in the manner of fmt.Print.
+	// WarningDepth logs to WARNING log at the specified depth. Arguments are handled in the manner of fmt.Println.
 	WarningDepth(depth int, args ...interface{})
-	// ErrorDetph logs to ERROR log at the specified depth. Arguments are handled in the manner of fmt.Print.
+	// ErrorDepth logs to ERROR log at the specified depth. Arguments are handled in the manner of fmt.Println.
 	ErrorDepth(depth int, args ...interface{})
-	// FatalDepth logs to FATAL log at the specified depth. Arguments are handled in the manner of fmt.Print.
+	// FatalDepth logs to FATAL log at the specified depth. Arguments are handled in the manner of fmt.Println.
 	FatalDepth(depth int, args ...interface{})
 }


### PR DESCRIPTION
The documentation comments stated that arguments were handled like
fmt.Print, when they are actually handled like fmt.Println. For
example, the "fallback" implementation in
internal/grpclog/grpclog.go for InfoDepth calls Logger.Infoln.

RELEASE NOTES: N/A