### PR TITLE
[v1.37.x] Increase xDS v3 interop Kokoro timeout

### DIFF
--- a/test/kokoro/xds_v3.cfg
+++ b/test/kokoro/xds_v3.cfg
@@ -2,7 +2,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc-go/test/kokoro/xds_v3.sh"
-timeout_mins: 120
+timeout_mins: 180
 action {
   define_artifacts {
     regex: "**/*sponge_log.*"


### PR DESCRIPTION
For the past few weeks three failures due to 120 min test timeout, and nearly every run successful was close to 120 min.