### PR TITLE
Backport "xds/c2p: replace C2P resolver env var with experimental scheme suffix #5044" to 1.43.x

### DIFF
--- a/internal/envconfig/xds.go
+++ b/internal/envconfig/xds.go
@@ -43,7 +43,6 @@ const (
 	rbacSupportEnv               = "GRPC_XDS_EXPERIMENTAL_RBAC"
 	federationEnv                = "GRPC_EXPERIMENTAL_XDS_FEDERATION"
 
-	c2pResolverSupportEnv                    = "GRPC_EXPERIMENTAL_GOOGLE_C2P_RESOLVER"
 	c2pResolverTestOnlyTrafficDirectorURIEnv = "GRPC_TEST_ONLY_GOOGLE_C2P_RESOLVER_TRAFFIC_DIRECTOR_URI"
 )
 
@@ -86,10 +85,6 @@ var (
 	// XDSFederation indicates whether federation support is enabled.
 	XDSFederation = strings.EqualFold(os.Getenv(federationEnv), "true")
 
-	// C2PResolver indicates whether support for C2P resolver is enabled.
-	// This can be enabled by setting the environment variable
-	// "GRPC_EXPERIMENTAL_GOOGLE_C2P_RESOLVER" to "true".
-	C2PResolver = strings.EqualFold(os.Getenv(c2pResolverSupportEnv), "true")
 	// C2PResolverTestOnlyTrafficDirectorURI is the TD URI for testing.
 	C2PResolverTestOnlyTrafficDirectorURI = os.Getenv(c2pResolverTestOnlyTrafficDirectorURIEnv)
 )

--- a/xds/googledirectpath/googlec2p.go
+++ b/xds/googledirectpath/googlec2p.go
@@ -47,7 +47,7 @@ import (
 )
 
 const (
-	c2pScheme = "google-c2p"
+	c2pScheme = "google-c2p-experimental"
 
 	tdURL          = "dns:///directpath-pa.googleapis.com"
 	httpReqTimeout = 10 * time.Second
@@ -75,9 +75,7 @@ var (
 )
 
 func init() {
-	if envconfig.C2PResolver {
-		resolver.Register(c2pResolverBuilder{})
-	}
+	resolver.Register(c2pResolverBuilder{})
 }
 
 type c2pResolverBuilder struct{}


### PR DESCRIPTION
Backports #5044

RELEASE NOTES: none