### PR TITLE
xds: Added env var for RLS in xDS

### DIFF
--- a/internal/envconfig/xds.go
+++ b/internal/envconfig/xds.go
@@ -42,6 +42,7 @@ const (
 	aggregateAndDNSSupportEnv    = "GRPC_XDS_EXPERIMENTAL_ENABLE_AGGREGATE_AND_LOGICAL_DNS_CLUSTER"
 	rbacSupportEnv               = "GRPC_XDS_EXPERIMENTAL_RBAC"
 	federationEnv                = "GRPC_EXPERIMENTAL_XDS_FEDERATION"
+	rlsInXDSEnv                  = "GRPC_EXPERIMENTAL_XDS_RLS_LB"
 
 	c2pResolverTestOnlyTrafficDirectorURIEnv = "GRPC_TEST_ONLY_GOOGLE_C2P_RESOLVER_TRAFFIC_DIRECTOR_URI"
 )
@@ -84,6 +85,12 @@ var (
 
 	// XDSFederation indicates whether federation support is enabled.
 	XDSFederation = strings.EqualFold(os.Getenv(federationEnv), "true")
+
+	// XDSRLS indicates whether processing of Cluster Specifier plugins and
+	// support for the RLS CLuster Specifier is enabled, which can be enabled by
+	// setting the environment variable "GRPC_EXPERIMENTAL_XDS_RLS_LB" to
+	// "true".
+	XDSRLS = strings.EqualFold(os.Getenv(rlsInXDSEnv), "true")
 
 	// C2PResolverTestOnlyTrafficDirectorURI is the TD URI for testing.
 	C2PResolverTestOnlyTrafficDirectorURI = os.Getenv(c2pResolverTestOnlyTrafficDirectorURIEnv)

--- a/xds/internal/xdsclient/xdsresource/unmarshal_rds.go
+++ b/xds/internal/xdsclient/xdsresource/unmarshal_rds.go
@@ -84,8 +84,8 @@ func unmarshalRouteConfigResource(r *anypb.Any, logger *grpclog.PrefixLogger) (s
 func generateRDSUpdateFromRouteConfiguration(rc *v3routepb.RouteConfiguration, logger *grpclog.PrefixLogger, v2 bool) (RouteConfigUpdate, error) {
 	vhs := make([]*VirtualHost, 0, len(rc.GetVirtualHosts()))
 	csps := make(map[string]clusterspecifier.BalancerConfig)
-	var err error
 	if envconfig.XDSRLS {
+		var err error
 		csps, err = processClusterSpecifierPlugins(rc.ClusterSpecifierPlugins)
 		if err != nil {
 			return RouteConfigUpdate{}, fmt.Errorf("received route is invalid %v", err)

--- a/xds/internal/xdsclient/xdsresource/unmarshal_rds.go
+++ b/xds/internal/xdsclient/xdsresource/unmarshal_rds.go
@@ -83,9 +83,13 @@ func unmarshalRouteConfigResource(r *anypb.Any, logger *grpclog.PrefixLogger) (s
 // we are looking for.
 func generateRDSUpdateFromRouteConfiguration(rc *v3routepb.RouteConfiguration, logger *grpclog.PrefixLogger, v2 bool) (RouteConfigUpdate, error) {
 	vhs := make([]*VirtualHost, 0, len(rc.GetVirtualHosts()))
-	csps, err := processClusterSpecifierPlugins(rc.ClusterSpecifierPlugins)
-	if err != nil {
-		return RouteConfigUpdate{}, fmt.Errorf("received route is invalid %v", err)
+	csps := make(map[string]clusterspecifier.BalancerConfig)
+	var err error
+	if envconfig.XDSRLS {
+		csps, err = processClusterSpecifierPlugins(rc.ClusterSpecifierPlugins)
+		if err != nil {
+			return RouteConfigUpdate{}, fmt.Errorf("received route is invalid %v", err)
+		}
 	}
 	// cspNames represents all the cluster specifiers referenced by Route
 	// Actions - any cluster specifiers not referenced by a Route Action can be
@@ -348,6 +352,9 @@ func routesProtoToSlice(routes []*v3routepb.Route, csps map[string]clusterspecif
 			case *v3routepb.RouteAction_ClusterHeader:
 				continue
 			case *v3routepb.RouteAction_ClusterSpecifierPlugin:
+				if !envconfig.XDSRLS {
+					return nil, nil, fmt.Errorf("route %+v, has an unknown ClusterSpecifier: %+v", r, a)
+				}
 				if _, ok := csps[a.ClusterSpecifierPlugin]; !ok {
 					// "When processing RouteActions, if any action includes a
 					// cluster_specifier_plugin value that is not in

--- a/xds/internal/xdsclient/xdsresource/unmarshal_rds_test.go
+++ b/xds/internal/xdsclient/xdsresource/unmarshal_rds_test.go
@@ -166,6 +166,12 @@ func (s) TestRDSGenerateRDSUpdateFromRouteConfiguration(t *testing.T) {
 		defaultRetryBackoff = RetryBackoff{BaseInterval: 25 * time.Millisecond, MaxInterval: 250 * time.Millisecond}
 	)
 
+	oldRLS := envconfig.XDSRLS
+	envconfig.XDSRLS = true
+	defer func() {
+		envconfig.XDSRLS = oldRLS
+	}()
+
 	tests := []struct {
 		name       string
 		rc         *v3routepb.RouteConfiguration


### PR DESCRIPTION
This PR adds an env var for RLS in xDS, protecting the cluster specifier plugin parsing functionality in xdsclient and also the RLS Cluster Specifier Plugin itself.

RELEASE NOTES: None