### PR TITLE
authz: update representation of allow authenticated in SDK

### DIFF
--- a/authz/rbac_translator.go
+++ b/authz/rbac_translator.go
@@ -157,7 +157,7 @@ func parsePrincipalNames(principalNames []string) []*v3rbacpb.Principal {
 }
 
 func parsePeer(source peer) *v3rbacpb.Principal {
-	if source.Principals == nil || len(source.Principals) == 0 {
+	if len(source.Principals) == 0 {
 		return &v3rbacpb.Principal{
 			Identifier: &v3rbacpb.Principal_Any{
 				Any: true,

--- a/authz/rbac_translator.go
+++ b/authz/rbac_translator.go
@@ -157,18 +157,12 @@ func parsePrincipalNames(principalNames []string) []*v3rbacpb.Principal {
 }
 
 func parsePeer(source peer) *v3rbacpb.Principal {
-	if source.Principals == nil {
+	if source.Principals == nil || len(source.Principals) == 0 {
 		return &v3rbacpb.Principal{
 			Identifier: &v3rbacpb.Principal_Any{
 				Any: true,
 			},
 		}
-	}
-	if len(source.Principals) == 0 {
-		return &v3rbacpb.Principal{
-			Identifier: &v3rbacpb.Principal_Authenticated_{
-				Authenticated: &v3rbacpb.Principal_Authenticated{},
-			}}
 	}
 	return principalOr(parsePrincipalNames(source.Principals))
 }

--- a/authz/rbac_translator_test.go
+++ b/authz/rbac_translator_test.go
@@ -205,6 +205,46 @@ func TestTranslatePolicy(t *testing.T) {
 				},
 			},
 		},
+		"allow authenticated": {
+			authzPolicy: `{
+						"name": "authz",
+						"allow_rules": [
+						{
+							"name": "allow_authenticated",
+							"source": {
+								"principals":["*", ""]
+							}
+						}]
+					}`,
+			wantPolicies: []*v3rbacpb.RBAC{
+				{
+					Action: v3rbacpb.RBAC_ALLOW,
+					Policies: map[string]*v3rbacpb.Policy{
+						"authz_allow_authenticated": {
+							Principals: []*v3rbacpb.Principal{
+								{Identifier: &v3rbacpb.Principal_OrIds{OrIds: &v3rbacpb.Principal_Set{
+									Ids: []*v3rbacpb.Principal{
+										{Identifier: &v3rbacpb.Principal_Authenticated_{
+											Authenticated: &v3rbacpb.Principal_Authenticated{PrincipalName: &v3matcherpb.StringMatcher{
+												MatchPattern: &v3matcherpb.StringMatcher_SafeRegex{SafeRegex: &v3matcherpb.RegexMatcher{Regex: ".+"}},
+											}},
+										}},
+										{Identifier: &v3rbacpb.Principal_Authenticated_{
+											Authenticated: &v3rbacpb.Principal_Authenticated{PrincipalName: &v3matcherpb.StringMatcher{
+												MatchPattern: &v3matcherpb.StringMatcher_Exact{Exact: ""},
+											}},
+										}},
+									},
+								}}},
+							},
+							Permissions: []*v3rbacpb.Permission{
+								{Rule: &v3rbacpb.Permission_Any{Any: true}},
+							},
+						},
+					},
+				},
+			},
+		},
 		"unknown field": {
 			authzPolicy: `{"random": 123}`,
 			wantErr:     "failed to unmarshal policy",

--- a/authz/rbac_translator_test.go
+++ b/authz/rbac_translator_test.go
@@ -205,32 +205,6 @@ func TestTranslatePolicy(t *testing.T) {
 				},
 			},
 		},
-		"empty principal field": {
-			authzPolicy: `{
-				"name": "authz",
-				"allow_rules": [{
-					"name": "allow_authenticated",
-					"source": {"principals":[]}
-				}]
-			}`,
-			wantPolicies: []*v3rbacpb.RBAC{
-				{
-					Action: v3rbacpb.RBAC_ALLOW,
-					Policies: map[string]*v3rbacpb.Policy{
-						"authz_allow_authenticated": {
-							Principals: []*v3rbacpb.Principal{
-								{Identifier: &v3rbacpb.Principal_Authenticated_{
-									Authenticated: &v3rbacpb.Principal_Authenticated{},
-								}},
-							},
-							Permissions: []*v3rbacpb.Permission{
-								{Rule: &v3rbacpb.Permission_Any{Any: true}},
-							},
-						},
-					},
-				},
-			},
-		},
 		"unknown field": {
 			authzPolicy: `{"random": 123}`,
 			wantErr:     "failed to unmarshal policy",

--- a/authz/sdk_end2end_test.go
+++ b/authz/sdk_end2end_test.go
@@ -268,7 +268,7 @@ var sdkTests = map[string]struct {
 					{
 						"name": "allow_authenticated",
 						"source": {
-							"principals": ["*"]
+							"principals": ["*", ""]
 						}
 					}
 				]

--- a/authz/sdk_end2end_test.go
+++ b/authz/sdk_end2end_test.go
@@ -266,33 +266,9 @@ var sdkTests = map[string]struct {
 				"allow_rules":
 				[
 					{
-						"name": "allow_TestServiceCalls",
-						"source": {
-							"principals":
-							[
-								"foo"
-							]
-						},
-						"request": {
-							"paths":
-							[
-								"/grpc.testing.TestService/*"
-							]
-						}
-					}
-				]
-			}`,
-		wantStatus: status.New(codes.PermissionDenied, "unauthorized RPC request rejected"),
-	},
-	"DeniesRPCRequestWithEmptyPrincipalsOnUnauthenticatedConnection": {
-		authzPolicy: `{
-				"name": "authz",
-				"allow_rules":
-				[
-					{
 						"name": "allow_authenticated",
 						"source": {
-							"principals": []
+							"principals": ["*"]
 						}
 					}
 				]
@@ -394,7 +370,7 @@ func (s) TestSDKAllowsRPCRequestWithEmptyPrincipalsOnTLSAuthenticatedConnection(
 					{
 						"name": "allow_authenticated",
 						"source": {
-							"principals": []
+							"principals": ["*"]
 						}
 					}
 				]
@@ -446,7 +422,7 @@ func (s) TestSDKAllowsRPCRequestWithEmptyPrincipalsOnMTLSAuthenticatedConnection
 					{
 						"name": "allow_authenticated",
 						"source": {
-							"principals": []
+							"principals": ["*"]
 						}
 					}
 				]

--- a/authz/sdk_end2end_test.go
+++ b/authz/sdk_end2end_test.go
@@ -362,7 +362,7 @@ func (s) TestSDKStaticPolicyEnd2End(t *testing.T) {
 	}
 }
 
-func (s) TestSDKAllowsRPCRequestWithEmptyPrincipalsOnTLSAuthenticatedConnection(t *testing.T) {
+func (s) TestSDKAllowsRPCRequestWithPrincipalsFieldOnTLSAuthenticatedConnection(t *testing.T) {
 	authzPolicy := `{
 				"name": "authz",
 				"allow_rules":
@@ -370,7 +370,7 @@ func (s) TestSDKAllowsRPCRequestWithEmptyPrincipalsOnTLSAuthenticatedConnection(
 					{
 						"name": "allow_authenticated",
 						"source": {
-							"principals": ["*"]
+							"principals": ["*", ""]
 						}
 					}
 				]
@@ -414,7 +414,7 @@ func (s) TestSDKAllowsRPCRequestWithEmptyPrincipalsOnTLSAuthenticatedConnection(
 	}
 }
 
-func (s) TestSDKAllowsRPCRequestWithEmptyPrincipalsOnMTLSAuthenticatedConnection(t *testing.T) {
+func (s) TestSDKAllowsRPCRequestWithPrincipalsFieldOnMTLSAuthenticatedConnection(t *testing.T) {
 	authzPolicy := `{
 				"name": "authz",
 				"allow_rules":
@@ -422,7 +422,7 @@ func (s) TestSDKAllowsRPCRequestWithEmptyPrincipalsOnMTLSAuthenticatedConnection
 					{
 						"name": "allow_authenticated",
 						"source": {
-							"principals": ["*"]
+							"principals": ["*", ""]
 						}
 					}
 				]


### PR DESCRIPTION
With the changes in this PR, allow authenticated can be represented using `principals: ["*", ""]` instead of `principals: []`.
This way we can avoid special semantics.

Related discussion
https://github.com/grpc/proposal/pull/246#discussion_r756496245

RELEASE NOTES:
- authz: update representation of allow authenticated in SDK