### PR TITLE
xds/client: send connection errors to all watchers

### DIFF
--- a/xds/internal/xdsclient/pubsub/update.go
+++ b/xds/internal/xdsclient/pubsub/update.go
@@ -295,6 +295,21 @@ func (pb *Pubsub) NewConnectionError(err error) {
 	pb.mu.Lock()
 	defer pb.mu.Unlock()
 
+	for _, s := range pb.ldsWatchers {
+		for wi := range s {
+			wi.newError(xdsresource.NewErrorf(xdsresource.ErrorTypeConnection, "xds: error received from xDS stream: %v", err))
+		}
+	}
+	for _, s := range pb.rdsWatchers {
+		for wi := range s {
+			wi.newError(xdsresource.NewErrorf(xdsresource.ErrorTypeConnection, "xds: error received from xDS stream: %v", err))
+		}
+	}
+	for _, s := range pb.cdsWatchers {
+		for wi := range s {
+			wi.newError(xdsresource.NewErrorf(xdsresource.ErrorTypeConnection, "xds: error received from xDS stream: %v", err))
+		}
+	}
 	for _, s := range pb.edsWatchers {
 		for wi := range s {
 			wi.newError(xdsresource.NewErrorf(xdsresource.ErrorTypeConnection, "xds: error received from xDS stream: %v", err))


### PR DESCRIPTION
#5020

RELEASE NOTES:
* xds/client: notify all resource watchers of connection errors