### PR TITLE
cmd/protoc-gen-go-grpc: add hooks to allow overriding generated code

### DIFF
--- a/cmd/protoc-gen-go-grpc/grpc.go
+++ b/cmd/protoc-gen-go-grpc/grpc.go
@@ -41,7 +41,7 @@ type serviceGenerateHelperInterface interface {
 	generateServerFunctions(gen *protogen.Plugin, file *protogen.File, g *protogen.GeneratedFile, service *protogen.Service, serverType string, serviceDescVar string)
 }
 
-type serviceGenerateHelper struct {}
+type serviceGenerateHelper struct{}
 
 func (serviceGenerateHelper) formatFullMethodName(service *protogen.Service, method *protogen.Method) string {
 	return fmt.Sprintf("/%s/%s", service.Desc.FullName(), method.Desc.Name())

--- a/cmd/protoc-gen-go-grpc/grpc.go
+++ b/cmd/protoc-gen-go-grpc/grpc.go
@@ -41,12 +41,10 @@ type serviceGenerateHelperInterface interface {
 	generateServerFunctions(gen *protogen.Plugin, file *protogen.File, g *protogen.GeneratedFile, service *protogen.Service, serverType string, serviceDescVar string)
 }
 
-type serviceGenerateHelper struct {
-	serviceGenerateHelperInterface
-}
+type serviceGenerateHelper struct {}
 
 func (serviceGenerateHelper) formatServiceName(service *protogen.Service) string {
-	return fmt.Sprintf("%s", service.Desc.FullName())
+	return service.Desc.FullName()
 }
 
 func (serviceGenerateHelper) generateNewClientDefinitions(g *protogen.GeneratedFile, service *protogen.Service, clientName string) {
@@ -81,7 +79,7 @@ func (serviceGenerateHelper) generateUnimplementedServerType(gen *protogen.Plugi
 func (serviceGenerateHelper) generateServerFunctions(gen *protogen.Plugin, file *protogen.File, g *protogen.GeneratedFile, service *protogen.Service, serverType string, serviceDescVar string) {
 }
 
-var helper serviceGenerateHelperInterface = new(serviceGenerateHelper)
+var helper serviceGenerateHelperInterface = serviceGenerateHelper{}
 
 // generateFile generates a _grpc.pb.go file containing gRPC service definitions.
 func generateFile(gen *protogen.Plugin, file *protogen.File) *protogen.GeneratedFile {

--- a/cmd/protoc-gen-go-grpc/grpc.go
+++ b/cmd/protoc-gen-go-grpc/grpc.go
@@ -34,6 +34,55 @@ const (
 	statusPackage  = protogen.GoImportPath("google.golang.org/grpc/status")
 )
 
+type serviceGenerateHelperInterface interface {
+	formatServiceName(service *protogen.Service) string
+	generateNewClientDefinitions(g *protogen.GeneratedFile, service *protogen.Service, clientName string)
+	generateUnimplementedServerType(gen *protogen.Plugin, file *protogen.File, g *protogen.GeneratedFile, service *protogen.Service)
+	generateServerFunctions(gen *protogen.Plugin, file *protogen.File, g *protogen.GeneratedFile, service *protogen.Service, serverType string, serviceDescVar string)
+}
+
+type serviceGenerateHelper struct {
+	serviceGenerateHelperInterface
+}
+
+func (serviceGenerateHelper) formatServiceName(service *protogen.Service) string {
+	return fmt.Sprintf("%s", service.Desc.FullName())
+}
+
+func (serviceGenerateHelper) generateNewClientDefinitions(g *protogen.GeneratedFile, service *protogen.Service, clientName string) {
+}
+
+func (serviceGenerateHelper) generateUnimplementedServerType(gen *protogen.Plugin, file *protogen.File, g *protogen.GeneratedFile, service *protogen.Service) {
+	serverType := service.GoName + "Server"
+	mustOrShould := "must"
+	if !*requireUnimplemented {
+		mustOrShould = "should"
+	}
+	// Server Unimplemented struct for forward compatibility.
+	g.P("// Unimplemented", serverType, " ", mustOrShould, " be embedded to have forward compatible implementations.")
+	g.P("type Unimplemented", serverType, " struct {")
+	g.P("}")
+	g.P()
+	for _, method := range service.Methods {
+		nilArg := ""
+		if !method.Desc.IsStreamingClient() && !method.Desc.IsStreamingServer() {
+			nilArg = "nil,"
+		}
+		g.P("func (Unimplemented", serverType, ") ", serverSignature(g, method), "{")
+		g.P("return ", nilArg, statusPackage.Ident("Errorf"), "(", codesPackage.Ident("Unimplemented"), `, "method `, method.GoName, ` not implemented")`)
+		g.P("}")
+	}
+	if *requireUnimplemented {
+		g.P("func (Unimplemented", serverType, ") mustEmbedUnimplemented", serverType, "() {}")
+	}
+	g.P()
+}
+
+func (serviceGenerateHelper) generateServerFunctions(gen *protogen.Plugin, file *protogen.File, g *protogen.GeneratedFile, service *protogen.Service, serverType string, serviceDescVar string) {
+}
+
+var helper serviceGenerateHelperInterface = new(serviceGenerateHelper)
+
 // generateFile generates a _grpc.pb.go file containing gRPC service definitions.
 func generateFile(gen *protogen.Plugin, file *protogen.File) *protogen.GeneratedFile {
 	if len(file.Services) == 0 {
@@ -121,6 +170,7 @@ func genService(gen *protogen.Plugin, file *protogen.File, g *protogen.Generated
 		g.P(deprecationComment)
 	}
 	g.P("func New", clientName, " (cc ", grpcPackage.Ident("ClientConnInterface"), ") ", clientName, " {")
+	helper.generateNewClientDefinitions(g, service, clientName)
 	g.P("return &", unexport(clientName), "{cc}")
 	g.P("}")
 	g.P()
@@ -170,23 +220,7 @@ func genService(gen *protogen.Plugin, file *protogen.File, g *protogen.Generated
 	g.P()
 
 	// Server Unimplemented struct for forward compatibility.
-	g.P("// Unimplemented", serverType, " ", mustOrShould, " be embedded to have forward compatible implementations.")
-	g.P("type Unimplemented", serverType, " struct {")
-	g.P("}")
-	g.P()
-	for _, method := range service.Methods {
-		nilArg := ""
-		if !method.Desc.IsStreamingClient() && !method.Desc.IsStreamingServer() {
-			nilArg = "nil,"
-		}
-		g.P("func (Unimplemented", serverType, ") ", serverSignature(g, method), "{")
-		g.P("return ", nilArg, statusPackage.Ident("Errorf"), "(", codesPackage.Ident("Unimplemented"), `, "method `, method.GoName, ` not implemented")`)
-		g.P("}")
-	}
-	if *requireUnimplemented {
-		g.P("func (Unimplemented", serverType, ") mustEmbedUnimplemented", serverType, "() {}")
-	}
-	g.P()
+	helper.generateUnimplementedServerType(gen, file, g, service)
 
 	// Unsafe Server interface to opt-out of forward compatibility.
 	g.P("// Unsafe", serverType, " may be embedded to opt out of forward compatibility for this service.")
@@ -205,6 +239,8 @@ func genService(gen *protogen.Plugin, file *protogen.File, g *protogen.Generated
 	g.P("s.RegisterService(&", serviceDescVar, `, srv)`)
 	g.P("}")
 	g.P()
+
+	helper.generateServerFunctions(gen, file, g, service, serverType, serviceDescVar)
 
 	// Server handler implementations.
 	handlerNames := make([]string, 0, len(service.Methods))
@@ -270,7 +306,8 @@ func clientSignature(g *protogen.GeneratedFile, method *protogen.Method) string 
 
 func genClientMethod(gen *protogen.Plugin, file *protogen.File, g *protogen.GeneratedFile, method *protogen.Method, index int) {
 	service := method.Parent
-	sname := fmt.Sprintf("/%s/%s", service.Desc.FullName(), method.Desc.Name())
+	serviceName := helper.formatServiceName(service)
+	sname := fmt.Sprintf("/%s/%s", serviceName, method.Desc.Name())
 
 	if method.Desc.Options().(*descriptorpb.MethodOptions).GetDeprecated() {
 		g.P(deprecationComment)
@@ -374,7 +411,8 @@ func genServerMethod(gen *protogen.Plugin, file *protogen.File, g *protogen.Gene
 		g.P("if interceptor == nil { return srv.(", service.GoName, "Server).", method.GoName, "(ctx, in) }")
 		g.P("info := &", grpcPackage.Ident("UnaryServerInfo"), "{")
 		g.P("Server: srv,")
-		g.P("FullMethod: ", strconv.Quote(fmt.Sprintf("/%s/%s", service.Desc.FullName(), method.Desc.Name())), ",")
+		serviceName := helper.formatServiceName(service)
+		g.P("FullMethod: \"", fmt.Sprintf("/%s/%s", serviceName, method.Desc.Name()), "\",")
 		g.P("}")
 		g.P("handler := func(ctx ", contextPackage.Ident("Context"), ", req interface{}) (interface{}, error) {")
 		g.P("return srv.(", service.GoName, "Server).", method.GoName, "(ctx, req.(*", method.Input.GoIdent, "))")


### PR DESCRIPTION
This PR adds a hook which users can implement and insert helper codes to the codegen, eg service renaming.

RELEASE NOTES: N/A