### PR TITLE
internal/resolver: fix possible goroutine leak in TestSafeConfigSelector

### DIFF
--- a/internal/resolver/config_selector_test.go
+++ b/internal/resolver/config_selector_test.go
@@ -112,7 +112,7 @@ func (s) TestSafeConfigSelector(t *testing.T) {
 
 	cs1Done := false // set when cs2 is first called
 	for dl := time.Now().Add(150 * time.Millisecond); !time.Now().After(dl); {
-		gotConfigChan := make(chan *RPCConfig)
+		gotConfigChan := make(chan *RPCConfig, 1)
 		go func() {
 			cfg, _ := scs.SelectConfig(testRPCInfo)
 			gotConfigChan <- cfg


### PR DESCRIPTION
If line 121 timeout happened first, there is no receiver for this channel. Thus, the goroutine created at line 116 blocks at the last send operation. 

RELEASE NOTES: n/a