### PR TITLE
rls: minor config processing changes

### DIFF
--- a/balancer/rls/internal/builder.go
+++ b/balancer/rls/internal/builder.go
@@ -20,11 +20,7 @@
 package rls
 
 import (
-	"encoding/json"
-
 	"google.golang.org/grpc/balancer"
-	"google.golang.org/grpc/internal/pretty"
-	"google.golang.org/grpc/serviceconfig"
 )
 
 const rlsBalancerName = "rls_experimental"
@@ -46,9 +42,4 @@ func (rlsBB) Name() string {
 func (rlsBB) Build(cc balancer.ClientConn, opts balancer.BuildOptions) balancer.Balancer {
 	// TODO(easwars): Fix this once the LB policy implementation is pulled in.
 	return &rlsBalancer{}
-}
-
-func (rlsBB) ParseConfig(c json.RawMessage) (serviceconfig.LoadBalancingConfig, error) {
-	logger.Infof("Received JSON service config: %v", pretty.ToJSON(c))
-	return parseConfig(c)
 }

--- a/balancer/rls/internal/builder.go
+++ b/balancer/rls/internal/builder.go
@@ -30,7 +30,7 @@ import (
 const rlsBalancerName = "rls_experimental"
 
 func init() {
-	balancer.Register(&rlsBB{})
+	balancer.Register(rlsBB{})
 }
 
 // rlsBB helps build RLS load balancers and parse the service config to be
@@ -39,16 +39,16 @@ type rlsBB struct{}
 
 // Name returns the name of the RLS LB policy and helps implement the
 // balancer.Balancer interface.
-func (*rlsBB) Name() string {
+func (rlsBB) Name() string {
 	return rlsBalancerName
 }
 
-func (*rlsBB) Build(cc balancer.ClientConn, opts balancer.BuildOptions) balancer.Balancer {
+func (rlsBB) Build(cc balancer.ClientConn, opts balancer.BuildOptions) balancer.Balancer {
 	// TODO(easwars): Fix this once the LB policy implementation is pulled in.
 	return &rlsBalancer{}
 }
 
-func (*rlsBB) ParseConfig(c json.RawMessage) (serviceconfig.LoadBalancingConfig, error) {
+func (rlsBB) ParseConfig(c json.RawMessage) (serviceconfig.LoadBalancingConfig, error) {
 	logger.Infof("Received JSON service config: %v", pretty.ToJSON(c))
 	return parseConfig(c)
 }

--- a/balancer/rls/internal/builder.go
+++ b/balancer/rls/internal/builder.go
@@ -20,7 +20,11 @@
 package rls
 
 import (
+	"encoding/json"
+
 	"google.golang.org/grpc/balancer"
+	"google.golang.org/grpc/internal/pretty"
+	"google.golang.org/grpc/serviceconfig"
 )
 
 const rlsBalancerName = "rls_experimental"
@@ -42,4 +46,9 @@ func (*rlsBB) Name() string {
 func (*rlsBB) Build(cc balancer.ClientConn, opts balancer.BuildOptions) balancer.Balancer {
 	// TODO(easwars): Fix this once the LB policy implementation is pulled in.
 	return &rlsBalancer{}
+}
+
+func (*rlsBB) ParseConfig(c json.RawMessage) (serviceconfig.LoadBalancingConfig, error) {
+	logger.Infof("Received JSON service config: %v", pretty.ToJSON(c))
+	return parseConfig(c)
 }

--- a/balancer/rls/internal/config.go
+++ b/balancer/rls/internal/config.go
@@ -25,7 +25,6 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/golang/protobuf/jsonpb"
 	"github.com/golang/protobuf/ptypes"
 	durationpb "github.com/golang/protobuf/ptypes/duration"
 	"google.golang.org/grpc/balancer"
@@ -33,34 +32,32 @@ import (
 	rlspb "google.golang.org/grpc/internal/proto/grpc_lookup_v1"
 	"google.golang.org/grpc/resolver"
 	"google.golang.org/grpc/serviceconfig"
+	"google.golang.org/protobuf/encoding/protojson"
 )
 
 const (
-	// This is max duration that we are willing to cache RLS responses. If the
-	// service config doesn't specify a value for max_age or if it specified a
-	// value greater that this, we will use this value instead.
+	// Default max_age if not specified (or greater than this value) in the
+	// service config.
 	maxMaxAge = 5 * time.Minute
-	// If lookup_service_timeout is not specified in the service config, we use
-	// a default of 10 seconds.
+	// Upper limit for cache_size since we don't fully trust the service config.
+	maxCacheSize = 5 * 1024 * 1024 * 8 // 5MB in bytes
+	// Default lookup_service_timeout if not specified in the service config.
 	defaultLookupServiceTimeout = 10 * time.Second
-	// This is set to the targetNameField in the child policy config during
+	// Default value for targetNameField in the child policy config during
 	// service config validation.
 	dummyChildPolicyTarget = "target_name_to_be_filled_in_later"
 )
 
-// lbConfig contains the parsed and validated contents of the
-// loadBalancingConfig section of the service config. The RLS LB policy will
-// use this to directly access config data instead of ploughing through proto
-// fields.
+// lbConfig is the internal representation of the RLS LB policy's config.
 type lbConfig struct {
 	serviceconfig.LoadBalancingConfig
 
+	cacheSizeBytes       int64 // Keep this field 64-bit aligned.
 	kbMap                keys.BuilderMap
 	lookupService        string
 	lookupServiceTimeout time.Duration
 	maxAge               time.Duration
 	staleAge             time.Duration
-	cacheSizeBytes       int64
 	defaultTarget        string
 
 	childPolicyName        string
@@ -88,7 +85,6 @@ func childPolicyConfigEqual(a, b map[string]json.RawMessage) bool {
 	if len(b) != len(a) {
 		return false
 	}
-
 	for k, jsonA := range a {
 		jsonB, ok := b[k]
 		if !ok {
@@ -109,37 +105,49 @@ type lbConfigJSON struct {
 	ChildPolicyConfigTargetFieldName string
 }
 
-// ParseConfig parses and validates the JSON representation of the service
-// config and returns the loadBalancingConfig to be used by the RLS LB policy.
-//
-// Helps implement the balancer.ConfigParser interface.
-// * childPolicy field:
-//  - must find a valid child policy with a valid config (the child policy must
-//    be able to parse the provided config successfully when we pass it a dummy
-//    target name in the target_field provided by the
-//    childPolicyConfigTargetFieldName field)
-// * childPolicyConfigTargetFieldName field:
+// When parsing a config update, the following validations are performed:
+// - routeLookupConfig:
+//   - grpc_keybuilders field:
+//     - must have at least one entry
+//     - must not have two entries with the same `Name`
+//     - within each entry:
+//       - must have at least one `Name`
+//       - must not have a `Name` with the `service` field unset or empty
+//       - within each `headers` entry:
+//         - must not have `required_match` set
+//         - must not have `key` unset or empty
+//       - across all `headers`, `constant_keys` and `extra_keys` fields:
+//         - must not have the same `key` specified twice
+//         - no `key` must be the empty string
+//   - `lookup_service` field must be set and and must parse as a target URI
+//   - if `max_age` > 5m, it should be set to 5 minutes
+//   - if `stale_age` > `max_age`, ignore it
+//   - if `stale_age` is set, then `max_age` must also be set
+//   - ignore `valid_targets` field
+//   - `cache_size_bytes` field must have a value greater than 0, and if its
+//      value is greater than 5M, we cap it at 5M
+// - childPolicy:
+//   - must find a valid child policy with a valid config
+// - childPolicyConfigTargetFieldName:
 //   - must be set and non-empty
-func (*rlsBB) ParseConfig(c json.RawMessage) (serviceconfig.LoadBalancingConfig, error) {
+func parseConfig(c json.RawMessage) (serviceconfig.LoadBalancingConfig, error) {
 	cfgJSON := &lbConfigJSON{}
 	if err := json.Unmarshal(c, cfgJSON); err != nil {
-		return nil, fmt.Errorf("rls: json unmarshal failed for service config {%+v}: %v", string(c), err)
+		return nil, fmt.Errorf("rls: json unmarshal failed for service config %+v: %v", string(c), err)
 	}
 
-	// Unmarshal and validate contents of the RLS proto.
-	m := jsonpb.Unmarshaler{AllowUnknownFields: true}
+	m := protojson.UnmarshalOptions{DiscardUnknown: true}
 	rlsProto := &rlspb.RouteLookupConfig{}
-	if err := m.Unmarshal(bytes.NewReader(cfgJSON.RouteLookupConfig), rlsProto); err != nil {
-		return nil, fmt.Errorf("rls: bad RouteLookupConfig proto {%+v}: %v", string(cfgJSON.RouteLookupConfig), err)
+	if err := m.Unmarshal(cfgJSON.RouteLookupConfig, rlsProto); err != nil {
+		return nil, fmt.Errorf("rls: bad RouteLookupConfig proto %+v: %v", string(cfgJSON.RouteLookupConfig), err)
 	}
 	lbCfg, err := parseRLSProto(rlsProto)
 	if err != nil {
 		return nil, err
 	}
 
-	// Unmarshal and validate child policy configs.
 	if cfgJSON.ChildPolicyConfigTargetFieldName == "" {
-		return nil, fmt.Errorf("rls: childPolicyConfigTargetFieldName field is not set in service config {%+v}", string(c))
+		return nil, fmt.Errorf("rls: childPolicyConfigTargetFieldName field is not set in service config %+v", string(c))
 	}
 	name, config, err := parseChildPolicyConfigs(cfgJSON.ChildPolicy, cfgJSON.ChildPolicyConfigTargetFieldName)
 	if err != nil {
@@ -151,87 +159,74 @@ func (*rlsBB) ParseConfig(c json.RawMessage) (serviceconfig.LoadBalancingConfig,
 	return lbCfg, nil
 }
 
-// parseRLSProto fetches relevant information from the RouteLookupConfig proto
-// and validates the values in the process.
-//
-// The following validation checks are performed:
-// ** grpc_keybuilders field:
-//    - must have at least one entry
-//    - must not have two entries with the same Name
-//    - must not have any entry with a Name with the service field unset or
-//      empty
-//    - must not have any entries without a Name
-//    - must not have a headers entry that has required_match set
-//    - must not have two headers entries with the same key within one entry
-// ** lookup_service field:
-//    - must be set and non-empty and must parse as a target URI
-// ** max_age field:
-//    - if not specified or is greater than maxMaxAge, it will be reset to
-//      maxMaxAge
-// ** stale_age field:
-//    - if the value is greater than or equal to max_age, it is ignored
-//    - if set, then max_age must also be set
-// ** valid_targets field:
-//    - will be ignored
-// ** cache_size_bytes field:
-//    - must be greater than zero
-//    - TODO(easwars): Define a minimum value for this field, to be used when
-//      left unspecified
 func parseRLSProto(rlsProto *rlspb.RouteLookupConfig) (*lbConfig, error) {
+	// Validations specified on the `grpc_keybuilders` field are performed here.
 	kbMap, err := keys.MakeBuilderMap(rlsProto)
 	if err != nil {
 		return nil, err
 	}
 
+	// `lookup_service` field must be set and and must parse as a target URI.
 	lookupService := rlsProto.GetLookupService()
 	if lookupService == "" {
-		return nil, fmt.Errorf("rls: empty lookup_service in route lookup config {%+v}", rlsProto)
+		return nil, fmt.Errorf("rls: empty lookup_service in route lookup config %+v", rlsProto)
 	}
 	parsedTarget, err := url.Parse(lookupService)
 	if err != nil {
-		// If the first attempt failed because of a missing scheme, try again
-		// with the default scheme.
+		// url.Parse() fails if scheme is missing. Retry with default scheme.
 		parsedTarget, err = url.Parse(resolver.GetDefaultScheme() + ":///" + lookupService)
 		if err != nil {
-			return nil, fmt.Errorf("rls: invalid target URI in lookup_service {%s}", lookupService)
+			return nil, fmt.Errorf("rls: invalid target URI in lookup_service %s", lookupService)
 		}
 	}
 	if parsedTarget.Scheme == "" {
 		parsedTarget.Scheme = resolver.GetDefaultScheme()
 	}
 	if resolver.Get(parsedTarget.Scheme) == nil {
-		return nil, fmt.Errorf("rls: unregistered scheme in lookup_service {%s}", lookupService)
+		return nil, fmt.Errorf("rls: unregistered scheme in lookup_service %s", lookupService)
 	}
 
 	lookupServiceTimeout, err := convertDuration(rlsProto.GetLookupServiceTimeout())
 	if err != nil {
-		return nil, fmt.Errorf("rls: failed to parse lookup_service_timeout in route lookup config {%+v}: %v", rlsProto, err)
+		return nil, fmt.Errorf("rls: failed to parse lookup_service_timeout in route lookup config %+v: %v", rlsProto, err)
 	}
 	if lookupServiceTimeout == 0 {
 		lookupServiceTimeout = defaultLookupServiceTimeout
 	}
+
+	// Validations performed here:
+	// - if `max_age` > 5m, it should be set to 5 minutes
+	// - if `stale_age` > `max_age`, ignore it
+	// - if `stale_age` is set, then `max_age` must also be set
 	maxAge, err := convertDuration(rlsProto.GetMaxAge())
 	if err != nil {
-		return nil, fmt.Errorf("rls: failed to parse max_age in route lookup config {%+v}: %v", rlsProto, err)
+		return nil, fmt.Errorf("rls: failed to parse max_age in route lookup config %+v: %v", rlsProto, err)
 	}
 	staleAge, err := convertDuration(rlsProto.GetStaleAge())
 	if err != nil {
-		return nil, fmt.Errorf("rls: failed to parse staleAge in route lookup config {%+v}: %v", rlsProto, err)
+		return nil, fmt.Errorf("rls: failed to parse staleAge in route lookup config %+v: %v", rlsProto, err)
 	}
 	if staleAge != 0 && maxAge == 0 {
-		return nil, fmt.Errorf("rls: stale_age is set, but max_age is not in route lookup config {%+v}", rlsProto)
+		return nil, fmt.Errorf("rls: stale_age is set, but max_age is not in route lookup config %+v", rlsProto)
 	}
 	if staleAge >= maxAge {
-		logger.Info("rls: stale_age {%v} is greater than max_age {%v}, ignoring it", staleAge, maxAge)
+		logger.Infof("rls: stale_age %v is not less than max_age %v, ignoring it", staleAge, maxAge)
 		staleAge = 0
 	}
 	if maxAge == 0 || maxAge > maxMaxAge {
 		logger.Infof("rls: max_age in route lookup config is %v, using %v", maxAge, maxMaxAge)
 		maxAge = maxMaxAge
 	}
+
+	// `cache_size_bytes` field must have a value greater than 0, and if its
+	// value is greater than 5M, we cap it at 5M
 	cacheSizeBytes := rlsProto.GetCacheSizeBytes()
 	if cacheSizeBytes <= 0 {
-		return nil, fmt.Errorf("rls: cache_size_bytes must be greater than 0 in route lookup config {%+v}", rlsProto)
+		return nil, fmt.Errorf("rls: cache_size_bytes must be set to a non-zero value: %+v", rlsProto)
+	}
+	if cacheSizeBytes > maxCacheSize {
+		logger.Info("rls: cache_size_bytes %v is too large, setting it to: %v", cacheSizeBytes, maxCacheSize)
+		cacheSizeBytes = maxCacheSize
 	}
 	return &lbConfig{
 		kbMap:                kbMap,

--- a/balancer/rls/internal/config.go
+++ b/balancer/rls/internal/config.go
@@ -29,6 +29,7 @@ import (
 	durationpb "github.com/golang/protobuf/ptypes/duration"
 	"google.golang.org/grpc/balancer"
 	"google.golang.org/grpc/balancer/rls/internal/keys"
+	"google.golang.org/grpc/internal/pretty"
 	rlspb "google.golang.org/grpc/internal/proto/grpc_lookup_v1"
 	"google.golang.org/grpc/resolver"
 	"google.golang.org/grpc/serviceconfig"
@@ -130,7 +131,8 @@ type lbConfigJSON struct {
 //   - must find a valid child policy with a valid config
 // - childPolicyConfigTargetFieldName:
 //   - must be set and non-empty
-func parseConfig(c json.RawMessage) (serviceconfig.LoadBalancingConfig, error) {
+func (rlsBB) ParseConfig(c json.RawMessage) (serviceconfig.LoadBalancingConfig, error) {
+	logger.Infof("Received JSON service config: %v", pretty.ToJSON(c))
 	cfgJSON := &lbConfigJSON{}
 	if err := json.Unmarshal(c, cfgJSON); err != nil {
 		return nil, fmt.Errorf("rls: json unmarshal failed for service config %+v: %v", string(c), err)

--- a/balancer/rls/internal/config_test.go
+++ b/balancer/rls/internal/config_test.go
@@ -134,7 +134,7 @@ func (s) TestParseConfig(t *testing.T) {
 		},
 	}
 
-	builder := &rlsBB{}
+	builder := rlsBB{}
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
 			lbCfg, err := builder.ParseConfig(test.input)
@@ -393,7 +393,7 @@ func (s) TestParseConfigErrors(t *testing.T) {
 		},
 	}
 
-	builder := &rlsBB{}
+	builder := rlsBB{}
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
 			lbCfg, err := builder.ParseConfig(test.input)

--- a/balancer/rls/internal/config_test.go
+++ b/balancer/rls/internal/config_test.go
@@ -25,24 +25,9 @@ import (
 	"testing"
 	"time"
 
-	"google.golang.org/grpc/balancer"
 	_ "google.golang.org/grpc/balancer/grpclb"               // grpclb for config parsing.
 	_ "google.golang.org/grpc/internal/resolver/passthrough" // passthrough resolver.
 )
-
-const balancerWithoutConfigParserName = "dummy_balancer"
-
-type dummyBB struct {
-	balancer.Builder
-}
-
-func (*dummyBB) Name() string {
-	return balancerWithoutConfigParserName
-}
-
-func init() {
-	balancer.Register(&dummyBB{})
-}
 
 // testEqual reports whether the lbCfgs a and b are equal. This is to be used
 // only from tests. This ignores the keyBuilderMap field because its internals
@@ -61,6 +46,7 @@ func testEqual(a, b *lbConfig) bool {
 		childPolicyConfigEqual(a.childPolicyConfig, b.childPolicyConfig)
 }
 
+// TestParseConfig verifies successful config parsing scenarios.
 func (s) TestParseConfig(t *testing.T) {
 	childPolicyTargetFieldVal, _ := json.Marshal(dummyChildPolicyTarget)
 	tests := []struct {
@@ -68,14 +54,15 @@ func (s) TestParseConfig(t *testing.T) {
 		input   []byte
 		wantCfg *lbConfig
 	}{
-		// This input validates a few cases:
-		// - A top-level unknown field should not fail.
-		// - An unknown field in routeLookupConfig proto should not fail.
-		// - lookupServiceTimeout is set to its default value, since it is not specified in the input.
-		// - maxAge is set to maxMaxAge since the value is too large in the input.
-		// - staleAge is ignore because it is higher than maxAge in the input.
 		{
-			desc: "with transformations",
+			// This input validates a few cases:
+			// - A top-level unknown field should not fail.
+			// - An unknown field in routeLookupConfig proto should not fail.
+			// - lookupServiceTimeout is set to its default value, since it is not specified in the input.
+			// - maxAge is set to maxMaxAge since the value is too large in the input.
+			// - staleAge is ignore because it is higher than maxAge in the input.
+			// - cacheSizeBytes is greater than the hard upper limit of 5MB
+			desc: "with transformations 1",
 			input: []byte(`{
 				"top-level-unknown-field": "unknown-value",
 				"routeLookupConfig": {
@@ -87,7 +74,7 @@ func (s) TestParseConfig(t *testing.T) {
 					"lookupService": ":///target",
 					"maxAge" : "500s",
 					"staleAge": "600s",
-					"cacheSizeBytes": 1000,
+					"cacheSizeBytes": 100000000,
 					"defaultTarget": "passthrough:///default"
 				},
 				"childPolicy": [
@@ -102,7 +89,7 @@ func (s) TestParseConfig(t *testing.T) {
 				lookupServiceTimeout:   10 * time.Second, // This is the default value.
 				maxAge:                 5 * time.Minute,  // This is max maxAge.
 				staleAge:               time.Duration(0), // StaleAge is ignore because it was higher than maxAge.
-				cacheSizeBytes:         1000,
+				cacheSizeBytes:         maxCacheSize,
 				defaultTarget:          "passthrough:///default",
 				childPolicyName:        "grpclb",
 				childPolicyTargetField: "service_name",
@@ -158,6 +145,7 @@ func (s) TestParseConfig(t *testing.T) {
 	}
 }
 
+// TestParseConfigErrors verifies config parsing failure scenarios.
 func (s) TestParseConfigErrors(t *testing.T) {
 	tests := []struct {
 		desc    string
@@ -223,7 +211,7 @@ func (s) TestParseConfigErrors(t *testing.T) {
 					"lookupServiceTimeout" : "315576000001s"
 				}
 			}`),
-			wantErr: "bad Duration: time: invalid duration",
+			wantErr: "google.protobuf.Duration value out of range",
 		},
 		{
 			desc: "invalid max age",
@@ -238,7 +226,7 @@ func (s) TestParseConfigErrors(t *testing.T) {
 					"maxAge" : "315576000001s"
 				}
 			}`),
-			wantErr: "bad Duration: time: invalid duration",
+			wantErr: "google.protobuf.Duration value out of range",
 		},
 		{
 			desc: "invalid stale age",
@@ -254,7 +242,7 @@ func (s) TestParseConfigErrors(t *testing.T) {
 					"staleAge" : "315576000001s"
 				}
 			}`),
-			wantErr: "bad Duration: time: invalid duration",
+			wantErr: "google.protobuf.Duration value out of range",
 		},
 		{
 			desc: "invalid max age stale age combo",
@@ -272,7 +260,7 @@ func (s) TestParseConfigErrors(t *testing.T) {
 			wantErr: "rls: stale_age is set, but max_age is not in route lookup config",
 		},
 		{
-			desc: "invalid cache size",
+			desc: "cache_size_bytes field is not set",
 			input: []byte(`{
 				"routeLookupConfig": {
 					"grpcKeybuilders": [{
@@ -282,10 +270,12 @@ func (s) TestParseConfigErrors(t *testing.T) {
 					"lookupService": "passthrough:///target",
 					"lookupServiceTimeout" : "10s",
 					"maxAge": "30s",
-					"staleAge" : "25s"
-				}
+					"staleAge" : "25s",
+					"defaultTarget": "passthrough:///default"
+				},
+				"childPolicyConfigTargetFieldName": "service_name"
 			}`),
-			wantErr: "rls: cache_size_bytes must be greater than 0 in route lookup config",
+			wantErr: "rls: cache_size_bytes must be set to a non-zero value",
 		},
 		{
 			desc: "no child policy",


### PR DESCRIPTION
- enforce a max cache size of 5MB
- 64-bit align the cacheSizeBytes field in the lbConfig struct
- minor changes to comments and error messages

RELEASE NOTES: n/a