### PR TITLE
xds: Add xds dependency to the fallback test client

### DIFF
--- a/interop/grpclb_fallback/client_linux.go
+++ b/interop/grpclb_fallback/client_linux.go
@@ -35,6 +35,7 @@ import (
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/alts"
 	"google.golang.org/grpc/credentials/google"
+	_ "google3/third_party/golang/grpc/xds/googledirectpath/googledirectpath"
 
 	testgrpc "google.golang.org/grpc/interop/grpc_testing"
 	testpb "google.golang.org/grpc/interop/grpc_testing"

--- a/interop/grpclb_fallback/client_linux.go
+++ b/interop/grpclb_fallback/client_linux.go
@@ -35,7 +35,7 @@ import (
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/alts"
 	"google.golang.org/grpc/credentials/google"
-	_ "google3/third_party/golang/grpc/xds/googledirectpath/googledirectpath"
+  _ "google.golang.org/grpc/xds/googledirectpath"
 
 	testgrpc "google.golang.org/grpc/interop/grpc_testing"
 	testpb "google.golang.org/grpc/interop/grpc_testing"

--- a/interop/grpclb_fallback/client_linux.go
+++ b/interop/grpclb_fallback/client_linux.go
@@ -35,7 +35,7 @@ import (
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/alts"
 	"google.golang.org/grpc/credentials/google"
-  _ "google.golang.org/grpc/xds/googledirectpath"
+	_ "google.golang.org/grpc/xds/googledirectpath"
 
 	testgrpc "google.golang.org/grpc/interop/grpc_testing"
 	testpb "google.golang.org/grpc/interop/grpc_testing"


### PR DESCRIPTION
We are setting up fallback test based on TD, and we need to add xds dependency to the fallback test client.

RELEASE NOTES: N/A