### PR TITLE
grpc: enhance client interceptor documentation

### DIFF
--- a/dialoptions.go
+++ b/dialoptions.go
@@ -446,6 +446,11 @@ func WithKeepaliveParams(kp keepalive.ClientParameters) DialOption {
 
 // WithUnaryInterceptor returns a DialOption that specifies the interceptor for
 // unary RPCs.
+//
+// At most one UnaryClientInterceptor DialOption may be passed when dialing.
+// The last WithUnaryInterceptor option wins in case multiple are passed.  If
+// you want more than one interceptor attached, use WithChainUnaryInterceptor
+// instead.
 func WithUnaryInterceptor(f UnaryClientInterceptor) DialOption {
 	return newFuncDialOption(func(o *dialOptions) {
 		o.unaryInt = f
@@ -465,6 +470,11 @@ func WithChainUnaryInterceptor(interceptors ...UnaryClientInterceptor) DialOptio
 
 // WithStreamInterceptor returns a DialOption that specifies the interceptor for
 // streaming RPCs.
+//
+// At most one StreamClientInterceptor DialOption may be passed when dialing.
+// The last WithStreamInterceptor option wins in case multiple are passed.  If
+// you want more than one interceptor attached, use WithChainStreamInterceptor
+// instead.
 func WithStreamInterceptor(f StreamClientInterceptor) DialOption {
 	return newFuncDialOption(func(o *dialOptions) {
 		o.streamInt = f

--- a/interceptor.go
+++ b/interceptor.go
@@ -40,6 +40,14 @@ type UnaryInvoker func(ctx context.Context, method string, req, reply interface{
 // defaults from the ClientConn as well as per-call options.
 //
 // The returned error must be compatible with the status package.
+//
+// A simple example that logs the method name when called and then invokes the
+// the unary method.
+//
+//	func Interceptor(ctx context.Context, method string, req, reply interface{}, cc *ClientConn, invoker UnaryInvoker, opts ...CallOption) error {
+//		log.Println("Intercepting:", method)
+//		return invoker(ctx, method, req, reply, cc, opts...)
+//	}
 type UnaryClientInterceptor func(ctx context.Context, method string, req, reply interface{}, cc *ClientConn, invoker UnaryInvoker, opts ...CallOption) error
 
 // Streamer is called by StreamClientInterceptor to create a ClientStream.
@@ -60,6 +68,14 @@ type Streamer func(ctx context.Context, desc *StreamDesc, cc *ClientConn, method
 //
 // StreamClientInterceptor may return a custom ClientStream to intercept all I/O
 // operations. The returned error must be compatible with the status package.
+//
+// A simple example that logs the method name when called and then invokes the
+// the stream.
+//
+//	func Interceptor(ctx context.Context, desc *StreamDesc, cc *ClientConn, method string, streamer Streamer, opts ...CallOption) (ClientStream, error) {
+//		log.Println("Intercepting:", method)
+//		return streamer(ctx, deesc, cc, method, opts...)
+//	}
 type StreamClientInterceptor func(ctx context.Context, desc *StreamDesc, cc *ClientConn, method string, streamer Streamer, opts ...CallOption) (ClientStream, error)
 
 // UnaryServerInfo consists of various information about a unary RPC on


### PR DESCRIPTION
Explain that only one interceptor may be attached with the
WithUnaryInterceptor and WithStreamInterceptor DialOptions and that
their respective Chain DialOptions should be used if more than one is
desired. Furthermore, explain what happens if either of the
aforementioned DialOptions are passed more than once to a dial call.
The reason for doing this is that in the course of addressing whether
interceptors would suffice for #5055, it was unclear what happened if
multiple were attached.

Provide a snippet for what an effectively trivial interceptor would be
in the documentation.  The motivation similarly is to illuminate a path
for users.

RELEASE NOTES: None