### PR TITLE
xds: Remove WithBlock option from the fallback test client

### DIFF
--- a/interop/grpclb_fallback/client_linux.go
+++ b/interop/grpclb_fallback/client_linux.go
@@ -99,7 +99,6 @@ func dialTCPUserTimeout(ctx context.Context, addr string) (net.Conn, error) {
 func createTestConn() *grpc.ClientConn {
 	opts := []grpc.DialOption{
 		grpc.WithContextDialer(dialTCPUserTimeout),
-		grpc.WithBlock(),
 	}
 	switch *customCredentialsType {
 	case "tls":


### PR DESCRIPTION
Remove "WithBlock" from the fallback test client as it is not compatible with RING_HASH policy used by XDS.

RELEASE NOTES: N/A