### PR TITLE
wrr:  improve randomWRR performance

### DIFF
--- a/internal/wrr/random.go
+++ b/internal/wrr/random.go
@@ -27,7 +27,7 @@ import (
 
 // weightedItem is a wrapped weighted item that is used to implement weighted random algorithm.
 type weightedItem struct {
-	item interface{}
+	item              interface{}
 	accumulatedWeight int64
 }
 
@@ -37,8 +37,8 @@ func (w *weightedItem) String() string {
 
 // randomWRR is a struct that contains weighted items implement weighted random algorithm.
 type randomWRR struct {
-	mu           sync.RWMutex
-	items        []*weightedItem
+	mu    sync.RWMutex
+	items []*weightedItem
 	// Are all item's weights equal
 	equalWeights bool
 }

--- a/internal/wrr/random.go
+++ b/internal/wrr/random.go
@@ -19,6 +19,7 @@ package wrr
 
 import (
 	"fmt"
+	"sort"
 	"sync"
 
 	"google.golang.org/grpc/internal/grpcrand"
@@ -26,8 +27,13 @@ import (
 
 // weightedItem is a wrapped weighted item that is used to implement weighted random algorithm.
 type weightedItem struct {
-	Item   interface{}
-	Weight int64
+	Item interface{}
+	// TODO Delete Weight? This field is not necessary for randomWRR to work.
+	// But without this field, if we want to know an item's weight in randomWRR.Add , we have to
+	// calculate it (i.e. weight = items.AccumulatedWeight - previousItem.AccumulatedWeight)
+	// which is a bit less concise than items.Weight
+	Weight            int64
+	AccumulatedWeight int64
 }
 
 func (w *weightedItem) String() string {
@@ -38,7 +44,7 @@ func (w *weightedItem) String() string {
 type randomWRR struct {
 	mu           sync.RWMutex
 	items        []*weightedItem
-	sumOfWeights int64
+	equalWeights bool
 }
 
 // NewRandom creates a new WRR with random.
@@ -47,31 +53,40 @@ func NewRandom() WRR {
 }
 
 var grpcrandInt63n = grpcrand.Int63n
+var grpcrandIntn = grpcrand.Intn
 
 func (rw *randomWRR) Next() (item interface{}) {
 	rw.mu.RLock()
 	defer rw.mu.RUnlock()
-	if rw.sumOfWeights == 0 {
+	sumOfWeights := rw.items[len(rw.items)-1].AccumulatedWeight
+	if sumOfWeights == 0 {
 		return nil
 	}
-	// Random number in [0, sum).
-	randomWeight := grpcrandInt63n(rw.sumOfWeights)
-	for _, item := range rw.items {
-		randomWeight = randomWeight - item.Weight
-		if randomWeight < 0 {
-			return item.Item
-		}
+	if rw.equalWeights {
+		return rw.items[grpcrandIntn(len(rw.items))].Item
 	}
-
-	return rw.items[len(rw.items)-1].Item
+	// Random number in [0, sumOfWeights).
+	randomWeight := grpcrandInt63n(sumOfWeights)
+	// Item's accumulated weights are in ascending order, because item's weight >= 0.
+	// Binary search rw.items to find first item whose AccumulatedWeight > randomWeight
+	// The return i is guaranteed to be in range [0, len(rw.items)) because randomWeight < last item's AccumulatedWeight
+	i := sort.Search(len(rw.items), func(i int) bool { return rw.items[i].AccumulatedWeight > randomWeight })
+	return rw.items[i].Item
 }
 
 func (rw *randomWRR) Add(item interface{}, weight int64) {
 	rw.mu.Lock()
 	defer rw.mu.Unlock()
-	rItem := &weightedItem{Item: item, Weight: weight}
+	accumulatedWeight := weight
+	equalWeights := true
+	if len(rw.items) > 0 {
+		lastItem := rw.items[len(rw.items)-1]
+		accumulatedWeight = lastItem.AccumulatedWeight + weight
+		equalWeights = rw.equalWeights && weight == lastItem.Weight
+	}
+	rw.equalWeights = equalWeights
+	rItem := &weightedItem{Item: item, Weight: weight, AccumulatedWeight: accumulatedWeight}
 	rw.items = append(rw.items, rItem)
-	rw.sumOfWeights += weight
 }
 
 func (rw *randomWRR) String() string {

--- a/internal/wrr/random.go
+++ b/internal/wrr/random.go
@@ -57,10 +57,10 @@ func (rw *randomWRR) Next() (item interface{}) {
 	if len(rw.items) == 0 {
 		return nil
 	}
-	sumOfWeights = rw.items[len(rw.items)-1].accumulatedWeight
 	if rw.equalWeights {
 		return rw.items[grpcrandInt63n(int64(len(rw.items)))].item
 	}
+	sumOfWeights = rw.items[len(rw.items)-1].accumulatedWeight
 	// Random number in [0, sumOfWeights).
 	randomWeight := grpcrandInt63n(sumOfWeights)
 	// Item's accumulated weights are in ascending order, because item's weight >= 0.

--- a/internal/wrr/random.go
+++ b/internal/wrr/random.go
@@ -61,8 +61,7 @@ func (rw *randomWRR) Next() (item interface{}) {
 		return rw.items[grpcrandInt63n(int64(len(rw.items)))].item
 	}
 
-	var sumOfWeights int64
-	sumOfWeights = rw.items[len(rw.items)-1].accumulatedWeight
+	sumOfWeights := rw.items[len(rw.items)-1].accumulatedWeight
 	// Random number in [0, sumOfWeights).
 	randomWeight := grpcrandInt63n(sumOfWeights)
 	// Item's accumulated weights are in ascending order, because item's weight >= 0.

--- a/internal/wrr/random.go
+++ b/internal/wrr/random.go
@@ -53,7 +53,6 @@ func NewRandom() WRR {
 }
 
 var grpcrandInt63n = grpcrand.Int63n
-var grpcrandIntn = grpcrand.Intn
 
 func (rw *randomWRR) Next() (item interface{}) {
 	rw.mu.RLock()
@@ -63,7 +62,7 @@ func (rw *randomWRR) Next() (item interface{}) {
 		return nil
 	}
 	if rw.equalWeights {
-		return rw.items[grpcrandIntn(len(rw.items))].Item
+		return rw.items[grpcrandInt63n(int64(len(rw.items)))].Item
 	}
 	// Random number in [0, sumOfWeights).
 	randomWeight := grpcrandInt63n(sumOfWeights)

--- a/internal/wrr/wrr_test.go
+++ b/internal/wrr/wrr_test.go
@@ -78,19 +78,18 @@ func testWRRNext(t *testing.T, newWRR func() WRR) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var sumOfWeights int64
-
 			w := newWRR()
+			if len(tt.weights) == 0 {
+				if next := w.Next(); next != nil {
+					t.Fatalf("w.Next returns non nil value:%v when there is no item", next)
+				}
+				return
+			}
+
+			var sumOfWeights int64
 			for i, weight := range tt.weights {
 				w.Add(i, weight)
 				sumOfWeights += weight
-			}
-			if len(tt.weights) == 0 {
-				if w.Next() != nil {
-					t.Fatalf("w.Next returns non nil value when there is no item")
-				} else {
-					return
-				}
 			}
 
 			results := make(map[int]int)

--- a/internal/wrr/wrr_test.go
+++ b/internal/wrr/wrr_test.go
@@ -71,6 +71,10 @@ func testWRRNext(t *testing.T, newWRR func() WRR) {
 			name:    "17-23-37",
 			weights: []int64{17, 23, 37},
 		},
+		{
+			name: "no items",
+			weights: []int64{},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -80,6 +84,13 @@ func testWRRNext(t *testing.T, newWRR func() WRR) {
 			for i, weight := range tt.weights {
 				w.Add(i, weight)
 				sumOfWeights += weight
+			}
+			if len(tt.weights) == 0 {
+				if w.Next() != nil {
+					t.Fatalf("w.Next returns non nil value when there is no item")
+				} else {
+					return
+				}
 			}
 
 			results := make(map[int]int)
@@ -116,7 +127,7 @@ func (s) TestEdfWrrNext(t *testing.T) {
 func BenchmarkRandomWRRNext(b *testing.B) {
 	for _, n := range []int{100, 500, 1000} {
 		b.Run("equal-weights-"+strconv.Itoa(n)+"-items", func(b *testing.B) {
-			w := NewRandom().(*randomWRR)
+			w := NewRandom()
 			sumOfWeights := n
 			for i := 0; i < n; i++ {
 				w.Add(i, 1)

--- a/internal/wrr/wrr_test.go
+++ b/internal/wrr/wrr_test.go
@@ -115,4 +115,5 @@ func (s) TestEdfWrrNext(t *testing.T) {
 func init() {
 	r := rand.New(rand.NewSource(0))
 	grpcrandInt63n = r.Int63n
+	grpcrandIntn = r.Intn
 }

--- a/internal/wrr/wrr_test.go
+++ b/internal/wrr/wrr_test.go
@@ -115,5 +115,4 @@ func (s) TestEdfWrrNext(t *testing.T) {
 func init() {
 	r := rand.New(rand.NewSource(0))
 	grpcrandInt63n = r.Int63n
-	grpcrandIntn = r.Intn
 }

--- a/internal/wrr/wrr_test.go
+++ b/internal/wrr/wrr_test.go
@@ -72,7 +72,7 @@ func testWRRNext(t *testing.T, newWRR func() WRR) {
 			weights: []int64{17, 23, 37},
 		},
 		{
-			name: "no items",
+			name:    "no items",
 			weights: []int64{},
 		},
 	}


### PR DESCRIPTION
This PR improves `randomWRR.Next` performance by
1. using binary search when weights are not equal
2. picking item randomly when weights are equal

In general, this PR performs better than current implementation and has a more stable performance characteristics while the previous approach is more sensitive to weights distribution but it works better in some cases (i.e. small number of items with different weights)

RELEASE NOTES: n/a
