### PR TITLE
grpc: minor improvement on WithInsecure() document

### DIFF
--- a/dialoptions.go
+++ b/dialoptions.go
@@ -304,7 +304,7 @@ func WithReturnConnectionError() DialOption {
 // WithCredentialsBundle or WithPerRPCCredentials) which require transport
 // security is incompatible and will cause grpc.Dial() to fail.
 //
-// Deprecated: use insecure.NewCredentials() instead.
+// Deprecated: use WithTransportCredentials and insecure.NewCredentials() instead.
 // Will be supported throughout 1.x.
 func WithInsecure() DialOption {
 	return newFuncDialOption(func(o *dialOptions) {


### PR DESCRIPTION
Current document asks to replace `WithInsecure()` with `insecure.NewCredentials()`.
But it causes confusion because function signatures for `WithInsecure()` and `insecure.NewCredentials()` are different.

Instead, using `insecure.NewCredentials()` as a parameter for `WithTransportCredentials` replicate the deprecated `WithInsecure` function.

So I propose a minor improvement to mention `WithTransportCredentials` in the comment.

RELEASE NOTES: None