### PR TITLE
test/kokoro: use xds-test-server-5 as GCE interop image (backport v1.34.x)

### DIFF
--- a/test/kokoro/xds.sh
+++ b/test/kokoro/xds.sh
@@ -29,7 +29,7 @@ GRPC_GO_LOG_VERBOSITY_LEVEL=99 GRPC_GO_LOG_SEVERITY_LEVEL=info \
   python3 grpc/tools/run_tests/run_xds_tests.py \
     --test_case="all,path_matching,header_matching" \
     --project_id=grpc-testing \
-    --source_image=projects/grpc-testing/global/images/xds-test-server-2 \
+    --source_image=projects/grpc-testing/global/images/xds-test-server-5 \
     --path_to_server_binary=/java_server/grpc-java/interop-testing/build/install/grpc-interop-testing/bin/xds-test-server \
     --gcp_suffix=$(date '+%s') \
     --verbose \


### PR DESCRIPTION
Backports #5071
RELEASE NOTES: N/A