### PR TITLE
Add test for race condition

### DIFF
--- a/internal/transport/flowcontrol_test.go
+++ b/internal/transport/flowcontrol_test.go
@@ -1,0 +1,71 @@
+/*
+ *
+ * Copyright 2014 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package transport
+
+import (
+	"testing"
+	"time"
+)
+
+func TestWriteQuotaRaceCondition(t *testing.T) {
+	done := make(chan struct{})
+
+	wq := newWriteQuota(5, done)
+
+	// Acquire all of the space in the write quota
+	// so that subsequent acquirers will be blocked
+	// until replenish.
+	if err := wq.get(5); err != nil {
+		t.Fatal(err)
+	}
+
+	acquirer1 := make(chan struct{})
+	acquirer2 := make(chan struct{})
+
+	go func() {
+		if err := wq.get(5); err != nil {
+			panic(err)
+		}
+		close(acquirer1)
+	}()
+	go func() {
+		if err := wq.get(5); err != nil {
+			panic(err)
+		}
+		close(acquirer2)
+	}()
+
+	// Add a sleep statement to ensure that both goroutines are blocked
+	// on [w.ch].
+	time.Sleep(time.Second)
+	wq.replenish(20)
+
+	finished := make(chan struct{})
+	go func() {
+		<-acquirer1
+		<-acquirer2
+		close(finished)
+	}()
+
+	select {
+	case <-finished:
+	case <-time.After(time.Second):
+		t.Fatal("replenish failed to unblock concurrently waiting goroutines")
+	}
+}


### PR DESCRIPTION
Creating a PR to check with the authors if this is a legitimate bug. There seems to be a race condition in the writeQuota that could cause a goroutine attempting to acquire some size from the write quota to not be awoken by a call to replenish that provides enough space for it.

It seems possible to me that this assumption could break application level code someplace, but I am not familiar enough with this codebase to be able to tell. Please let me know what you think and I'd be happy to create a fix as well if you think that this is a legitimate issue.