### PR TITLE
Let helloworld example listen to all hosts 

### DIFF
--- a/examples/helloworld/greeter_server/main.go
+++ b/examples/helloworld/greeter_server/main.go
@@ -47,7 +47,7 @@ func (s *server) SayHello(ctx context.Context, in *pb.HelloRequest) (*pb.HelloRe
 
 func main() {
 	flag.Parse()
-	lis, err := net.Listen("tcp", fmt.Sprintf("localhost:%d", *port))
+	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", *port))
 	if err != nil {
 		log.Fatalf("failed to listen: %v", err)
 	}


### PR DESCRIPTION
This PR changes the address that the helloworld greeter_server is
listening to from "localhost:<port>" to just ":<port>", thus enabling
the server to be used in setups where the request stem from another
host.

RELEASE NOTES: N/A