### PR TITLE
Fix goroutine leaks due to wrong reference counting

### DIFF
--- a/xds/internal/xdsclient/singleton.go
+++ b/xds/internal/xdsclient/singleton.go
@@ -75,6 +75,8 @@ func newRefCounted() (*clientRefCounted, error) {
 	if singletonClient.clientImpl != nil {
 		singletonClient.refCount++
 		return singletonClient, nil
+	} else {
+		singletonClient.refCount = 0
 	}
 
 	// Create the new client implementation.


### PR DESCRIPTION
When `singletonClient.clientImpl` is nil, `singletonClient.refCount` should also be set to 0. This bug can be reproduced easily by unit-test:
```
go test -v -count 2 -run ^TestCSDS$ ./xds/csds/
```

If we introduce [goleak](https://github.com/uber-go/goleak) into `TestCSDS`, we can see:
```
    leaks.go:78: found unexpected goroutines:
        [Goroutine 296 in state select, with google.golang.org/grpc.(*ccBalancerWrapper).watcher on top of the stack:
        goroutine 296 [select]:
        google.golang.org/grpc.(*ccBalancerWrapper).watcher(0xc00073f0e0)
                /home/yuanting/work/dev/fix-goprojects/grpc-go/balancer_conn_wrappers.go:77 +0xa7
        created by google.golang.org/grpc.newCCBalancerWrapper
                /home/yuanting/work/dev/fix-goprojects/grpc-go/balancer_conn_wrappers.go:67 +0x246

         Goroutine 295 in state select, with google.golang.org/grpc/xds/internal/xdsclient/pubsub.(*Pubsub).run on top of the stack:
        goroutine 295 [select]:
        google.golang.org/grpc/xds/internal/xdsclient/pubsub.(*Pubsub).run(0xc000a5fa70)
                /home/yuanting/work/dev/fix-goprojects/grpc-go/xds/internal/xdsclient/pubsub/pubsub.go:171 +0x8c
        created by google.golang.org/grpc/xds/internal/xdsclient/pubsub.New
                /home/yuanting/work/dev/fix-goprojects/grpc-go/xds/internal/xdsclient/pubsub/pubsub.go:83 +0x35b

         Goroutine 298 in state select, with google.golang.org/grpc.(*pickerWrapper).pick on top of the stack:
        goroutine 298 [select]:
        google.golang.org/grpc.(*pickerWrapper).pick(0xc000880030, {0xf3b3c0, 0xc0006d38f0}, 0x0, {{0xe3eb8c, 0xc0000ed920}, {0xf3b3c0, 0xc0006d38f0}})
                /home/yuanting/work/dev/fix-goprojects/grpc-go/picker_wrapper.go:103 +0x21b
        google.golang.org/grpc.(*ClientConn).getTransport(0xc0006d38f0, {0xf3b3c0, 0xc0006d38f0}, 0x70, {0xe3eb8c, 0xc000c26260})
                /home/yuanting/work/dev/fix-goprojects/grpc-go/clientconn.go:962 +0x35
        google.golang.org/grpc.(*clientStream).newAttemptLocked(0xc000abc100, 0x0)
                /home/yuanting/work/dev/fix-goprojects/grpc-go/stream.go:408 +0x84c
        google.golang.org/grpc.newClientStreamWithParams({0xf3b318, 0xc000734fc0}, 0x1752c60, 0xc0004c5900, {0xe3eb8c, 0x920840}, {0x0, 0x0, 0x0, 0x0, ...}, ...)
                /home/yuanting/work/dev/fix-goprojects/grpc-go/stream.go:298 +0x8f5
        google.golang.org/grpc.newClientStream.func2({0xf3b318, 0xc000734fc0}, 0xc000734fc0)
                /home/yuanting/work/dev/fix-goprojects/grpc-go/stream.go:184 +0x9f
        google.golang.org/grpc.newClientStream({0xf3b318, 0xc000734fc0}, 0x1752c60, 0xc0004c5900, {0xe3eb8c, 0xaa4c30}, {0xc000c26240, 0x1, 0x1})
                /home/yuanting/work/dev/fix-goprojects/grpc-go/stream.go:212 +0x48e
        google.golang.org/grpc.(*ClientConn).NewStream(0x7fe82ac085b8, {0xf3b318, 0xc000734fc0}, 0xc000c26240, {0xe3eb8c, 0x1}, {0xc000c26240, 0x40f067, 0x10})
                /home/yuanting/work/dev/fix-goprojects/grpc-go/stream.go:158 +0x1ae
        github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3.(*aggregatedDiscoveryServiceClient).StreamAggregatedResources(0xf2c858, {0xf3b318, 0xc000734fc0}, {0xc000c26240, 0xc56380, 0x16d6060})
                /home/yuanting/work/dev/fix-goprojects/grpc-go/vendor/github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3/ads.pb.go:214 +0x6f
        google.golang.org/grpc/xds/internal/xdsclient/controller/version/v3.(*client).NewStream(0xc000a5fb00, {0xf3b318, 0xc000734fc0}, 0x0)
                /home/yuanting/work/dev/fix-goprojects/grpc-go/xds/internal/xdsclient/controller/version/v3/client.go:77 +0xb9
        google.golang.org/grpc/xds/internal/xdsclient/controller.(*Controller).run(0xc000a5fb00, {0xf3b318, 0xc000734fc0})
                /home/yuanting/work/dev/fix-goprojects/grpc-go/xds/internal/xdsclient/controller/transport.go:82 +0x1c3
        created by google.golang.org/grpc/xds/internal/xdsclient/controller.New
                /home/yuanting/work/dev/fix-goprojects/grpc-go/xds/internal/xdsclient/controller/controller.go:152 +0x51e

         Goroutine 578 in state select, with google.golang.org/grpc.(*addrConn).resetTransport on top of the stack:
        goroutine 578 [select]:
        google.golang.org/grpc.(*addrConn).resetTransport(0xc0006e0000)
                /home/yuanting/work/dev/fix-goprojects/grpc-go/clientconn.go:1207 +0x3c7
        google.golang.org/grpc.(*addrConn).connect(0xc0006e0000)
                /home/yuanting/work/dev/fix-goprojects/grpc-go/clientconn.go:852 +0x10f
        created by google.golang.org/grpc.(*acBalancerWrapper).Connect
                /home/yuanting/work/dev/fix-goprojects/grpc-go/balancer_conn_wrappers.go:285 +0xc5

         Goroutine 91 in state select, with google.golang.org/grpc/xds/internal/xdsclient/controller.(*Controller).send on top of the stack:
        goroutine 91 [select]:
        google.golang.org/grpc/xds/internal/xdsclient/controller.(*Controller).send(0xc000a5fb00, {0xf3b318, 0xc000734fc0})
                /home/yuanting/work/dev/fix-goprojects/grpc-go/xds/internal/xdsclient/controller/transport.go:120 +0x11b
        created by google.golang.org/grpc/xds/internal/xdsclient/controller.(*Controller).run
                /home/yuanting/work/dev/fix-goprojects/grpc-go/xds/internal/xdsclient/controller/transport.go:57 +0xb1
        ]
--- FAIL: TestCSDS (0.73s)
```

RELEASE NOTES: None