### PR TITLE
test/kokoro: use xds-test-server-5 as GCE interop image (backport v1.43.x)

### DIFF
--- a/test/kokoro/xds.sh
+++ b/test/kokoro/xds.sh
@@ -36,7 +36,7 @@ GRPC_GO_LOG_VERBOSITY_LEVEL=99 GRPC_GO_LOG_SEVERITY_LEVEL=info \
     --test_case="all,circuit_breaking,timeout,fault_injection,csds" \
     --project_id=grpc-testing \
     --project_num=830293263384 \
-    --source_image=projects/grpc-testing/global/images/xds-test-server-4 \
+    --source_image=projects/grpc-testing/global/images/xds-test-server-5 \
     --path_to_server_binary=/java_server/grpc-java/interop-testing/build/install/grpc-interop-testing/bin/xds-test-server \
     --gcp_suffix=$(date '+%s') \
     --verbose \


### PR DESCRIPTION
Backports #5071
RELEASE NOTES: N/A