### PR TITLE
Bump module required go version

### DIFF
--- a/cmd/protoc-gen-go-grpc/go.mod
+++ b/cmd/protoc-gen-go-grpc/go.mod
@@ -1,5 +1,5 @@
 module google.golang.org/grpc/cmd/protoc-gen-go-grpc
 
-go 1.9
+go 1.15
 
 require google.golang.org/protobuf v1.27.1

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -1,6 +1,6 @@
 module google.golang.org/grpc/examples
 
-go 1.14
+go 1.15
 
 require (
 	github.com/golang/protobuf v1.4.3

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module google.golang.org/grpc
 
-go 1.14
+go 1.15
 
 require (
 	github.com/cespare/xxhash/v2 v2.1.1

--- a/security/advancedtls/go.mod
+++ b/security/advancedtls/go.mod
@@ -1,6 +1,6 @@
 module google.golang.org/grpc/security/advancedtls
 
-go 1.14
+go 1.15
 
 require (
 	github.com/google/go-cmp v0.5.1 // indirect

--- a/security/authorization/go.mod
+++ b/security/authorization/go.mod
@@ -1,6 +1,6 @@
 module google.golang.org/grpc/security/authorization
 
-go 1.14
+go 1.15
 
 require (
 	github.com/envoyproxy/go-control-plane v0.9.5

--- a/test/tools/go.mod
+++ b/test/tools/go.mod
@@ -1,6 +1,6 @@
 module google.golang.org/grpc/test/tools
 
-go 1.14
+go 1.15
 
 require (
 	github.com/client9/misspell v0.3.4


### PR DESCRIPTION
The README mentions it should be used with `any one of the three latest
major releases.` ([link](https://github.com/grpc/grpc-go#prerequisites))

This change bumps the minimum go version to 1.15 as currently 1.17 is
the latest major release.

RELEASE NOTES:
- Bump required Go version to 1.15 as per README prerequisites