### PR TITLE
fix potential not-closed resource in TestXDSResolverWatchCallbackAfterClose

### DIFF
--- a/xds/internal/resolver/xds_resolver_test.go
+++ b/xds/internal/resolver/xds_resolver_test.go
@@ -390,8 +390,8 @@ func (s) TestXDSResolverResourceNameToWatch(t *testing.T) {
 // from the underlying xdsClient is received after the resolver is closed.
 func (s) TestXDSResolverWatchCallbackAfterClose(t *testing.T) {
 	xdsR, xdsC, tcc, cancel := testSetup(t, setupOpts{target: target})
+	defer xdsR.Close()
 	defer cancel()
-
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
 	waitForWatchListener(ctx, t, xdsC, targetStr)


### PR DESCRIPTION
waitForWatchListener and waitForWatchRouteConfig could fatal this test. If that happened, line 3 will not be executed, which leads to a goroutine leak.

```
goroutine 27 [select]: 
google.golang.org/grpc/xds/internal/resolver.(*xdsResolver).run(0xc0004a2a80) 
    /repos/grpc-go/xds/internal/resolver/xds_resolver.go:297 +0x707 
created by google.golang.org/grpc/xds/internal/resolver.(*xdsResolverBuilder).Build
    /repos/grpc-go/xds/internal/resolver/xds_resolver.go:96 +0x6a5
```
