### PR TITLE
testing: fix potential problems in testFlowControlAccountCheck

### DIFF
--- a/internal/transport/transport_test.go
+++ b/internal/transport/transport_test.go
@@ -1546,6 +1546,7 @@ func testFlowControlAccountCheck(t *testing.T, msgSize int, wc windowSizeConfig)
 	loopyServerStreams := map[uint32]*outStream{}
 	// Get all the streams from server reader and writer and client writer.
 	st.mu.Lock()
+	client.mu.Lock()
 	for _, stream := range clientStreams {
 		id := stream.id
 		serverStreams[id] = st.activeStreams[id]
@@ -1553,6 +1554,7 @@ func testFlowControlAccountCheck(t *testing.T, msgSize int, wc windowSizeConfig)
 		loopyClientStreams[id] = client.loopy.estdStreams[id]
 
 	}
+	client.mu.Unlock()
 	st.mu.Unlock()
 	// Close all streams
 	for _, stream := range clientStreams {

--- a/internal/transport/transport_test.go
+++ b/internal/transport/transport_test.go
@@ -1574,6 +1574,9 @@ func testFlowControlAccountCheck(t *testing.T, msgSize int, wc windowSizeConfig)
 		sstream := serverStreams[id]
 		loopyServerStream := loopyServerStreams[id]
 		loopyClientStream := loopyClientStreams[id]
+		if loopyServerStream == nil {
+			t.Fatalf("Unexpected nil loopyServerStream")
+		}
 		// Check stream flow control.
 		if int(cstream.fc.limit+cstream.fc.delta-cstream.fc.pendingData-cstream.fc.pendingUpdate) != int(st.loopy.oiws)-loopyServerStream.bytesOutStanding {
 			t.Fatalf("Account mismatch: client stream inflow limit(%d) + delta(%d) - pendingData(%d) - pendingUpdate(%d) != server outgoing InitialWindowSize(%d) - outgoingStream.bytesOutStanding(%d)", cstream.fc.limit, cstream.fc.delta, cstream.fc.pendingData, cstream.fc.pendingUpdate, st.loopy.oiws, loopyServerStream.bytesOutStanding)


### PR DESCRIPTION
This PR is mainly for 2 following issues:

1. concurrent map access
```
fatal error: concurrent map read and map write
 
goroutine 35 [running]:
runtime.throw(0x8bb64d, 0x21)
   /usr/local/go/src/runtime/panic.go:1117 +0x72 fp=0xc0003cf8f8 sp=0xc0003cf8c8 pc=0x441f12
runtime.mapaccess1_fast32(0x838d40, 0xc0000545a0, 0xc00000000d, 0xc0003cfe30)
   /usr/local/go/src/runtime/map_fast32.go:21 +0x196 fp=0xc0003cf920 sp=0xc0003cf8f8 pc=0x414956
google.golang.org/grpc/internal/transport.testFlowControlAccountCheck(0xc0002a2000, 0x100000, 0xc0000000a00000, 0x80000000600000)
   /repos/grpc-go/internal/transport/transport_test.go:2160 +0x954 fp=0xc0003cff38 sp=0xc0003cf920 pc=0x7ceeb4
google.golang.org/grpc/internal/transport.TestAccountCheckWindowSizeWithLargeWindow(0xc0002a2000)
   /repos/grpc-go/internal/transport/transport_test.go:2043 +0x85 fp=0xc0003cff80 
```

2. nil interface conversion
`` client.Write` or `stream.Read` return error will cause `st.loopy.estdStreams[id]` to assign nil to loopyServerStreams map.
So when line 4 is executed, loopyServerStream is nil, so loopyServerStream.bytesOutStanding caused nil pointer.

```
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
   panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x7ca19f]
 
goroutine 35 [running]:
testing.tRunner.func1.2(0x836620, 0xb8dba0)
   /usr/local/go/src/testing/testing.go:1143 +0x335
testing.tRunner.func1(0xc0002aa000)
   /usr/local/go/src/testing/testing.go:1146 +0x4c2
panic(0x836620, 0xb8dba0)
   /usr/local/go/src/runtime/panic.go:965 +0x1b9
google.golang.org/grpc/internal/transport.testFlowControlAccountCheck(0xc0002aa000, 0x400, 0x0, 0x0)
   /repos/grpc-go/internal/transport/transport_test.go:2180 +0xf5f
google.golang.org/grpc/internal/transport.TestAccountCheckDynamicWindowSmallMessage(0xc0002aa000)
   /repos/grpc-go/internal/transport/transport_test.go:2048 +0x6c
testing.tRunner(0xc0002aa000, 0x8c7928)
   /usr/local/go/src/testing/testing.go:1193 +0xef
created by testing.(*T).Run
   /usr/local/go/src/testing/testing.go:1238 +0x2b5
```

(the line number is not matched because of instrumentation)

RELEASE NOTES: N/A