### PR TITLE
xdsclient: allow overriding grpc.Dial function for the xDS controller.

### DIFF
--- a/xds/internal/xdsclient/controller/controller.go
+++ b/xds/internal/xdsclient/controller/controller.go
@@ -88,7 +88,7 @@ type Controller struct {
 	lrsClients map[string]*lrsClient
 }
 
-var dialer = grpc.Dial
+var grpcDial = grpc.Dial
 
 // SetDialInterceptor sets an interceptor for the controller. The interceptor
 // can be used to manipulate the dial options or change the target if needed.
@@ -96,7 +96,7 @@ var dialer = grpc.Dial
 // all the controllers created.
 // To reset any dial interceptor set, pass in grpc.Dial as the parameter.
 func SetDialInterceptor(interceptor func(target string, opts ...grpc.DialOption) (*grpc.ClientConn, error)) {
-	dialer = interceptor
+	grpcDial = interceptor
 }
 
 // New creates a new controller.
@@ -141,7 +141,7 @@ func New(config *bootstrap.ServerConfig, updateHandler pubsub.UpdateHandler, val
 		}
 	}()
 
-	cc, err := dialer(config.ServerURI, dopts...)
+	cc, err := grpcDial(config.ServerURI, dopts...)
 	if err != nil {
 		// An error from a non-blocking dial indicates something serious.
 		return nil, fmt.Errorf("xds: failed to dial control plane {%s}: %v", config.ServerURI, err)

--- a/xds/internal/xdsclient/controller/controller.go
+++ b/xds/internal/xdsclient/controller/controller.go
@@ -92,15 +92,11 @@ var interceptor func(target string, opts ...grpc.DialOption) (*grpc.ClientConn, 
 
 // SetDialInterceptor sets an interceptor for the controller. The interceptor
 // can be used to manipulate the dial options or change the target if needed.
-// The SetDialInterceptor must be called before the controller is created
-// otherwise this is a no-op.
+// The SetDialInterceptor must be called before gRPC to make sure it affects
+// all the controllers created.
+// To reset any dial interceptor set, pass in grpc.Dial as the parameter.
 func SetDialInterceptor(dialer func(target string, opts ...grpc.DialOption) (*grpc.ClientConn, error)) {
 	interceptor = dialer
-}
-
-// ResetDialInterceptor resets any dial interceptors for the controller.
-func ResetDialInterceptor() {
-	interceptor = nil
 }
 
 // New creates a new controller.

--- a/xds/internal/xdsclient/controller/controller.go
+++ b/xds/internal/xdsclient/controller/controller.go
@@ -90,8 +90,8 @@ type Controller struct {
 
 var grpcDial = grpc.Dial
 
-// SetGRPCDial sets the dialer for the controller. The dial
-// can be used to manipulate the dial options or change the target if needed.
+// SetGRPCDial sets the dialer for the controller. The dial can be used to
+// manipulate the dial options or change the target if needed.
 // The SetGRPCDial must be called before gRPC initialization to make sure it
 // affects all the controllers created.
 // To reset any dialer set, pass in grpc.Dial as the parameter.

--- a/xds/internal/xdsclient/controller/controller.go
+++ b/xds/internal/xdsclient/controller/controller.go
@@ -90,13 +90,13 @@ type Controller struct {
 
 var grpcDial = grpc.Dial
 
-// SetDialInterceptor sets an interceptor for the controller. The interceptor
+// SetGRPCDial sets the dialer for the controller. The dial
 // can be used to manipulate the dial options or change the target if needed.
-// The SetDialInterceptor must be called before gRPC to make sure it affects
-// all the controllers created.
-// To reset any dial interceptor set, pass in grpc.Dial as the parameter.
-func SetDialInterceptor(interceptor func(target string, opts ...grpc.DialOption) (*grpc.ClientConn, error)) {
-	grpcDial = interceptor
+// The SetGRPCDial must be called before gRPC initialization to make sure it
+// affects all the controllers created.
+// To reset any dialer set, pass in grpc.Dial as the parameter.
+func SetGRPCDial(dialer func(target string, opts ...grpc.DialOption) (*grpc.ClientConn, error)) {
+	grpcDial = dialer
 }
 
 // New creates a new controller.

--- a/xds/internal/xdsclient/controller/controller_test.go
+++ b/xds/internal/xdsclient/controller/controller_test.go
@@ -130,7 +130,7 @@ func (s) TestNewWithInterceptor(t *testing.T) {
 	interceptorCalled = false
 
 	// Reset the interceptor and make sure it is not called.
-	ResetDialInterceptor()
+	SetDialInterceptor(grpc.Dial)
 	c, err = New(config, nil, nil, nil)
 	defer func() {
 		if c != nil {

--- a/xds/internal/xdsclient/controller/controller_test.go
+++ b/xds/internal/xdsclient/controller/controller_test.go
@@ -101,7 +101,7 @@ func (s) TestNew(t *testing.T) {
 	}
 }
 
-func (s) TestNewWithInterceptor(t *testing.T) {
+func (s) TestNewWithGRPCDial(t *testing.T) {
 	config := &bootstrap.ServerConfig{
 		ServerURI: testXDSServer,
 		Creds:     grpc.WithInsecure(),
@@ -114,8 +114,8 @@ func (s) TestNewWithInterceptor(t *testing.T) {
 		return grpc.Dial(target, opts...)
 	}
 
-	// Set an interceptor and make sure it is called.
-	SetDialInterceptor(interceptor)
+	// Set the dialer and make sure it is called.
+	SetGRPCDial(interceptor)
 	c, err := New(config, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("New(%+v) = %v, want no error", config, err)
@@ -129,8 +129,8 @@ func (s) TestNewWithInterceptor(t *testing.T) {
 	}
 	interceptorCalled = false
 
-	// Reset the interceptor and make sure it is not called.
-	SetDialInterceptor(grpc.Dial)
+	// Reset the dialer and make sure it is not called.
+	SetGRPCDial(grpc.Dial)
 	c, err = New(config, nil, nil, nil)
 	defer func() {
 		if c != nil {

--- a/xds/internal/xdsclient/controller/controller_test.go
+++ b/xds/internal/xdsclient/controller/controller_test.go
@@ -108,14 +108,14 @@ func (s) TestNewWithGRPCDial(t *testing.T) {
 		NodeProto: testutils.EmptyNodeProtoV2,
 	}
 
-	interceptorCalled := false
-	interceptor := func(target string, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
-		interceptorCalled = true
+	customDialerCalled := false
+	customDialer := func(target string, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
+		customDialerCalled = true
 		return grpc.Dial(target, opts...)
 	}
 
 	// Set the dialer and make sure it is called.
-	SetGRPCDial(interceptor)
+	SetGRPCDial(customDialer)
 	c, err := New(config, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("New(%+v) = %v, want no error", config, err)
@@ -124,10 +124,10 @@ func (s) TestNewWithGRPCDial(t *testing.T) {
 		c.Close()
 	}
 
-	if !interceptorCalled {
-		t.Errorf("New(%+v) interceptor called = false, want true", config)
+	if !customDialerCalled {
+		t.Errorf("New(%+v) custom dialer called = false, want true", config)
 	}
-	interceptorCalled = false
+	customDialerCalled = false
 
 	// Reset the dialer and make sure it is not called.
 	SetGRPCDial(grpc.Dial)
@@ -141,7 +141,7 @@ func (s) TestNewWithGRPCDial(t *testing.T) {
 		t.Fatalf("New(%+v) = %v, want no error", config, err)
 	}
 
-	if interceptorCalled {
+	if customDialerCalled {
 		t.Errorf("New(%+v) interceptor called = true, want false", config)
 	}
 }


### PR DESCRIPTION
This feature can be used control xDS client behavior through a Dial
interceptor set from users.

Users can SetDialInterceptor on the controller package to intercept the
grpc.Dial call and inject/modify the target or the options.

ResetDialInterceptor can be used to reset and set the dialler back to
grpc.Dial.

Both of these calls will only take affect if they are called before the
controller is created using New.

RELEASE NOTES: none