### PR TITLE
credentials/google: stub out the oauth package in test

### DIFF
--- a/credentials/google/google.go
+++ b/credentials/google/google.go
@@ -50,7 +50,7 @@ func NewDefaultCredentialsWithOptions(opts DefaultCredentialsOptions) credential
 		ctx, cancel := context.WithTimeout(context.Background(), tokenRequestTimeout)
 		defer cancel()
 		var err error
-		opts.PerRPCCreds, err = oauth.NewApplicationDefault(ctx)
+		opts.PerRPCCreds, err = newADC(ctx)
 		if err != nil {
 			logger.Warningf("NewDefaultCredentialsWithOptions: failed to create application oauth: %v", err)
 		}
@@ -111,6 +111,9 @@ var (
 	}
 	newALTS = func() credentials.TransportCredentials {
 		return alts.NewClientCreds(alts.DefaultClientOptions())
+	}
+	newADC = func(ctx context.Context) (credentials.PerRPCCredentials, error) {
+		return oauth.NewApplicationDefault(ctx)
 	}
 )
 

--- a/credentials/google/google_test.go
+++ b/credentials/google/google_test.go
@@ -59,10 +59,6 @@ func (t *testAuthInfo) AuthType() string {
 	return t.typ
 }
 
-type testPerRPCCreds struct {
-	credentials.PerRPCCredentials
-}
-
 var (
 	testTLS  = &testCreds{typ: "tls"}
 	testALTS = &testCreds{typ: "alts"}
@@ -79,7 +75,8 @@ func overrideNewCredsFuncs() func() {
 	}
 	origNewADC := newADC
 	newADC = func(context.Context) (credentials.PerRPCCredentials, error) {
-		return &testPerRPCCreds{}, nil
+		// We do not use perRPC creds in this test. It is safe to return nil here.
+		return nil, nil
 	}
 
 	return func() {


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc-go/issues/5091

The `oauth` package, as part of checking whether it is running on GCE,
creates a persistent connection to the metadata server. This persistent
connection spawns a couple of goroutines, one to read and one to write.
And these goroutines show up in our leakchecker.

We are not testing perRPC credentials in this test and can safely stub
out the `oauth` package to make the leakchecker happy.

RELEASE NOTES: none