### PR TITLE
xds/clusterresolver: set ClusterName for DNS child

### DIFF
--- a/xds/internal/balancer/cdsbalancer/cdsbalancer.go
+++ b/xds/internal/balancer/cdsbalancer/cdsbalancer.go
@@ -328,6 +328,7 @@ func (b *cdsBalancer) handleWatchUpdate(update clusterHandlerUpdate) {
 		case xdsresource.ClusterTypeLogicalDNS:
 			dms[i] = clusterresolver.DiscoveryMechanism{
 				Type:        clusterresolver.DiscoveryMechanismTypeLogicalDNS,
+				Cluster:     cu.ClusterName,
 				DNSHostname: cu.DNSHostName,
 			}
 		default:

--- a/xds/internal/balancer/clusterresolver/clusterresolver_test.go
+++ b/xds/internal/balancer/clusterresolver/clusterresolver_test.go
@@ -43,6 +43,7 @@ const (
 	defaultTestShortTimeout = 10 * time.Millisecond
 	testEDSServcie          = "test-eds-service-name"
 	testClusterName         = "test-cluster-name"
+	testClusterName2        = "google_cfe_some-name"
 )
 
 var (

--- a/xds/internal/balancer/clusterresolver/configbuilder.go
+++ b/xds/internal/balancer/clusterresolver/configbuilder.go
@@ -135,7 +135,7 @@ func buildPriorityConfig(priorities []priorityConfig, xdsLBPolicy *internalservi
 			}
 			retAddrs = append(retAddrs, addrs...)
 		case DiscoveryMechanismTypeLogicalDNS:
-			name, config, addrs := buildClusterImplConfigForDNS(i, p.addresses)
+			name, config, addrs := buildClusterImplConfigForDNS(i, p.addresses, p.mechanism)
 			retConfig.Priorities = append(retConfig.Priorities, name)
 			retConfig.Children[name] = &priority.Child{
 				Config: &internalserviceconfig.BalancerConfig{Name: clusterimpl.Name, Config: config},
@@ -149,7 +149,7 @@ func buildPriorityConfig(priorities []priorityConfig, xdsLBPolicy *internalservi
 	return retConfig, retAddrs, nil
 }
 
-func buildClusterImplConfigForDNS(parentPriority int, addrStrs []string) (string, *clusterimpl.LBConfig, []resolver.Address) {
+func buildClusterImplConfigForDNS(parentPriority int, addrStrs []string, mechanism DiscoveryMechanism) (string, *clusterimpl.LBConfig, []resolver.Address) {
 	// Endpoint picking policy for DNS is hardcoded to pick_first.
 	const childPolicy = "pick_first"
 	retAddrs := make([]resolver.Address, 0, len(addrStrs))
@@ -157,7 +157,10 @@ func buildClusterImplConfigForDNS(parentPriority int, addrStrs []string) (string
 	for _, addrStr := range addrStrs {
 		retAddrs = append(retAddrs, hierarchy.Set(resolver.Address{Addr: addrStr}, []string{pName}))
 	}
-	return pName, &clusterimpl.LBConfig{ChildPolicy: &internalserviceconfig.BalancerConfig{Name: childPolicy}}, retAddrs
+	return pName, &clusterimpl.LBConfig{
+		Cluster:     mechanism.Cluster,
+		ChildPolicy: &internalserviceconfig.BalancerConfig{Name: childPolicy},
+	}, retAddrs
 }
 
 // buildClusterImplConfigForEDS returns a list of cluster_impl configs, one for

--- a/xds/internal/balancer/clusterresolver/configbuilder_test.go
+++ b/xds/internal/balancer/clusterresolver/configbuilder_test.go
@@ -199,7 +199,8 @@ func TestBuildPriorityConfig(t *testing.T) {
 		},
 		{
 			mechanism: DiscoveryMechanism{
-				Type: DiscoveryMechanismTypeLogicalDNS,
+				Cluster: testClusterName2,
+				Type:    DiscoveryMechanismTypeLogicalDNS,
 			},
 			addresses: testAddressStrs[4],
 		},
@@ -277,6 +278,7 @@ func TestBuildPriorityConfig(t *testing.T) {
 				Config: &internalserviceconfig.BalancerConfig{
 					Name: clusterimpl.Name,
 					Config: &clusterimpl.LBConfig{
+						Cluster:     testClusterName2,
 						ChildPolicy: &internalserviceconfig.BalancerConfig{Name: "pick_first"},
 					},
 				},
@@ -307,9 +309,10 @@ func TestBuildPriorityConfig(t *testing.T) {
 }
 
 func TestBuildClusterImplConfigForDNS(t *testing.T) {
-	gotName, gotConfig, gotAddrs := buildClusterImplConfigForDNS(3, testAddressStrs[0])
+	gotName, gotConfig, gotAddrs := buildClusterImplConfigForDNS(3, testAddressStrs[0], DiscoveryMechanism{Cluster: testClusterName2, Type: DiscoveryMechanismTypeLogicalDNS})
 	wantName := "priority-3"
 	wantConfig := &clusterimpl.LBConfig{
+		Cluster: testClusterName2,
 		ChildPolicy: &internalserviceconfig.BalancerConfig{
 			Name: "pick_first",
 		},


### PR DESCRIPTION
DNS child policies also need the cluster name, because the cluster name are attached to the addresses, which may affect creds handshake.

RELEASE NOTES:
* xds/clusterresolver: fix that DNS child does wrong creds handshake because ClusterName isn't set correctly.