### PR TITLE
transport: improve recvBuffer performance by using ring buffer

### DIFF
--- a/vet.sh
+++ b/vet.sh
@@ -78,7 +78,7 @@ not git grep -l 'x/net/context' -- "*.go"
 
 # - Do not import math/rand for real library code.  Use internal/grpcrand for
 #   thread safety.
-git grep -l '"math/rand"' -- "*.go" 2>&1 | not grep -v '^examples\|^stress\|grpcrand\|^benchmark\|wrr_test'
+git grep -l '"math/rand"' -- "*.go" 2>&1 | not grep -v '^examples\|^stress\|grpcrand\|^benchmark\|wrr_test\|transport_test'
 
 # - Do not call grpclog directly. Use grpclog.Component instead.
 git grep -l 'grpclog.I\|grpclog.W\|grpclog.E\|grpclog.F\|grpclog.V' -- "*.go" | not grep -v '^grpclog/component.go\|^internal/grpctest/tlogger_test.go'


### PR DESCRIPTION
This PR improves `recvBuffer` performance by using ring buffer