### PR TITLE
test/kokoro: set psm-security test timeout to 3h

### DIFF
--- a/test/kokoro/psm-security.cfg
+++ b/test/kokoro/psm-security.cfg
@@ -2,7 +2,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc-go/test/kokoro/psm-security.sh"
-timeout_mins: 120
+timeout_mins: 180
 
 action {
   define_artifacts {


### PR DESCRIPTION
Recent runs for the entire xds_k8s test suite takes
around 110 minutes, and one run exceeds the deadline.

No obvious regression was found.
Before we have more concrete improvement,
this PR increases the timeout to stop similar flakes.

Similar to https://github.com/grpc/grpc/pull/28027.

@easwars 

RELEASE NOTES: none