### PR TITLE
transport: Add an Unwrap method to ConnectionError

### DIFF
--- a/internal/transport/transport.go
+++ b/internal/transport/transport.go
@@ -741,6 +741,12 @@ func (e ConnectionError) Origin() error {
 	return e.err
 }
 
+// Unwrap returns the original error of this connection error or nil when the
+// origin is nil.
+func (e ConnectionError) Unwrap() error {
+	return e.err
+}
+
 var (
 	// ErrConnClosing indicates that the transport is closing.
 	ErrConnClosing = connectionErrorf(true, nil, "transport is closing")

--- a/internal/transport/transport_test.go
+++ b/internal/transport/transport_test.go
@@ -27,6 +27,7 @@ import (
 	"io"
 	"math"
 	"net"
+	"os"
 	"runtime"
 	"strconv"
 	"strings"
@@ -2397,5 +2398,12 @@ func (s) TestClientDecodeHeaderStatusErr(t *testing.T) {
 				t.Fatalf("operateHeaders(%v); status = \ngot: %s\nwant: %s", test.metaHeaderFrame, got, want)
 			}
 		})
+	}
+}
+
+func TestConnectionError_Unwrap(t *testing.T) {
+	err := connectionErrorf(false, os.ErrNotExist, "unwrap me")
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Error("ConnectionError does not unwrap")
 	}
 }


### PR DESCRIPTION
Adds an `Unwrap` method to enable error checking with `errors.Is`.

RELEASE NOTES: N/A