### PR TITLE
xds/resource: accept Self as LDS's RDS config source and CDS's EDS config source

### DIFF
--- a/xds/internal/xdsclient/xdsresource/unmarshal_cds.go
+++ b/xds/internal/xdsclient/xdsresource/unmarshal_cds.go
@@ -136,8 +136,8 @@ func validateClusterAndConstructClusterUpdate(cluster *v3clusterpb.Cluster) (Clu
 	// Validate and set cluster type from the response.
 	switch {
 	case cluster.GetType() == v3clusterpb.Cluster_EDS:
-		if cluster.GetEdsClusterConfig().GetEdsConfig().GetAds() == nil {
-			return ClusterUpdate{}, fmt.Errorf("unexpected edsConfig in response: %+v", cluster)
+		if configsource := cluster.GetEdsClusterConfig().GetEdsConfig(); configsource.GetAds() == nil && configsource.GetSelf() == nil {
+			return ClusterUpdate{}, fmt.Errorf("CDS's EDS config source is not ADS or Self: %+v", cluster)
 		}
 		ret.ClusterType = ClusterTypeEDS
 		ret.EDSServiceName = cluster.GetEdsClusterConfig().GetServiceName()

--- a/xds/internal/xdsclient/xdsresource/unmarshal_cds_test.go
+++ b/xds/internal/xdsclient/xdsresource/unmarshal_cds_test.go
@@ -1421,6 +1421,23 @@ func (s) TestUnmarshalCluster(t *testing.T) {
 				},
 			},
 		})
+
+		v3ClusterAnyWithEDSConfigSourceSelf = testutils.MarshalAny(&v3clusterpb.Cluster{
+			Name:                 v3ClusterName,
+			ClusterDiscoveryType: &v3clusterpb.Cluster_Type{Type: v3clusterpb.Cluster_EDS},
+			EdsClusterConfig: &v3clusterpb.Cluster_EdsClusterConfig{
+				EdsConfig: &v3corepb.ConfigSource{
+					ConfigSourceSpecifier: &v3corepb.ConfigSource_Self{},
+				},
+				ServiceName: v3Service,
+			},
+			LbPolicy: v3clusterpb.Cluster_ROUND_ROBIN,
+			LrsServer: &v3corepb.ConfigSource{
+				ConfigSourceSpecifier: &v3corepb.ConfigSource_Self{
+					Self: &v3corepb.SelfConfigSource{},
+				},
+			},
+		})
 	)
 	const testVersion = "test-version-cds"
 
@@ -1506,6 +1523,21 @@ func (s) TestUnmarshalCluster(t *testing.T) {
 					ClusterName:    v3ClusterName,
 					EDSServiceName: v3Service, EnableLRS: true,
 					Raw: v3ClusterAny,
+				}},
+			},
+			wantMD: UpdateMetadata{
+				Status:  ServiceStatusACKed,
+				Version: testVersion,
+			},
+		},
+		{
+			name:      "v3 cluster with EDS config source self",
+			resources: []*anypb.Any{v3ClusterAnyWithEDSConfigSourceSelf},
+			wantUpdate: map[string]ClusterUpdateErrTuple{
+				v3ClusterName: {Update: ClusterUpdate{
+					ClusterName:    v3ClusterName,
+					EDSServiceName: v3Service, EnableLRS: true,
+					Raw: v3ClusterAnyWithEDSConfigSourceSelf,
 				}},
 			},
 			wantMD: UpdateMetadata{

--- a/xds/internal/xdsclient/xdsresource/unmarshal_lds.go
+++ b/xds/internal/xdsclient/xdsresource/unmarshal_lds.go
@@ -102,8 +102,8 @@ func processClientSideListener(lis *v3listenerpb.Listener, logger *grpclog.Prefi
 
 	switch apiLis.RouteSpecifier.(type) {
 	case *v3httppb.HttpConnectionManager_Rds:
-		if apiLis.GetRds().GetConfigSource().GetAds() == nil {
-			return nil, fmt.Errorf("ConfigSource is not ADS: %+v", lis)
+		if configsource := apiLis.GetRds().GetConfigSource(); configsource.GetAds() == nil && configsource.GetSelf() == nil {
+			return nil, fmt.Errorf("LDS's RDS configSource is not ADS or Self: %+v", lis)
 		}
 		name := apiLis.GetRds().GetRouteConfigName()
 		if name == "" {


### PR DESCRIPTION
RELEASE NOTES:
* xds/resource: accept Self as LDS's RDS config source and CDS's EDS config source