### PR TITLE
rls: return status error from server interceptor in test

### DIFF
--- a/balancer/rls/control_channel_test.go
+++ b/balancer/rls/control_channel_test.go
@@ -108,10 +108,9 @@ func (s) TestLookupFailure(t *testing.T) {
 // TestLookupDeadlineExceeded tests the case where the RLS server does not
 // respond within the configured rpc timeout.
 func (s) TestLookupDeadlineExceeded(t *testing.T) {
-	// A unary interceptor which blocks until the test is done.
+	// A unary interceptor which returns a status error with DeadlineExceeded.
 	interceptor := func(ctx context.Context, req interface{}, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, err error) {
-		<-ctx.Done()
-		return nil, ctx.Err()
+		return nil, status.Error(codes.DeadlineExceeded, "deadline exceeded")
 	}
 
 	// Start an RLS server and set the throttler to never throttle.


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc-go/issues/5145.

[UnaryHandler](https://pkg.go.dev/google.golang.org/grpc#UnaryHandler) says:
```
If a UnaryHandler returns an error, it should be produced by the status package, or else 
gRPC will use codes.Unknown as the status code and err.Error() as the status message of the RPC.
```

Since we were not returning an error produced by the `status` package, the test was sometimes seeing errors with `codes.Unknown` instead of the expected `codes.DeadlineExceeded`. This fix should take care of the flakiness.

RELEASE NOTES: none