### PR TITLE
rls: make the data cache purge ticker a field in rlsBalancer

### DIFF
--- a/balancer/rls/balancer_test.go
+++ b/balancer/rls/balancer_test.go
@@ -586,9 +586,11 @@ func (s) TestConfigUpdate_DataCacheSizeDecrease(t *testing.T) {
 // entries from the data cache.
 func (s) TestDataCachePurging(t *testing.T) {
 	// Override the frequency of the data cache purger to a small one.
-	origPurgeFreq := periodicCachePurgeFreq
-	periodicCachePurgeFreq = defaultTestShortTimeout
-	defer func() { periodicCachePurgeFreq = origPurgeFreq }()
+	origDataCachePurgeTicker := dataCachePurgeTicker
+	ticker := time.NewTicker(defaultTestShortTimeout)
+	defer ticker.Stop()
+	dataCachePurgeTicker = func() *time.Ticker { return ticker }
+	defer func() { dataCachePurgeTicker = origDataCachePurgeTicker }()
 
 	// Override the data cache purge hook to get notified.
 	dataCachePurgeDone := make(chan struct{}, 1)


### PR DESCRIPTION
The race detector was complaining about a data race on the
`periodicCachePurgeFreq` var which was being overridden in tests. This
commit changes things around a little bit by putting the ticker inside
the rlsBalancer and constructing it at build time. Since I have been
unable to reproduce this data race locally, hoping that this will help.

Fixes https://github.com/grpc/grpc-go/issues/5146.

RELEASE NOTES: none