### PR TITLE
protoc-gen-go-grpc: Fixed option typo in README.md file

### DIFF
--- a/cmd/protoc-gen-go-grpc/README.md
+++ b/cmd/protoc-gen-go-grpc/README.md
@@ -14,7 +14,7 @@ To restore this behavior, set the option `require_unimplemented_servers=false`.
 E.g.:
 
 ```
-  protoc --go-grpc_out=require_unimplemented_servers=false[,other options...]:. \
+  protoc --go-grpc_opt=require_unimplemented_servers=false[,other options...]:. \
 ```
 
 Note that this is not recommended, and the option is only provided to restore

--- a/cmd/protoc-gen-go-grpc/README.md
+++ b/cmd/protoc-gen-go-grpc/README.md
@@ -14,7 +14,7 @@ To restore this behavior, set the option `require_unimplemented_servers=false`.
 E.g.:
 
 ```
-  protoc --go-grpc_opt=require_unimplemented_servers=false[,other options...]:. \
+  protoc --go-grpc_out=. --go-grpc_opt=require_unimplemented_servers=false[,other options...]
 ```
 
 Note that this is not recommended, and the option is only provided to restore


### PR DESCRIPTION
RELEASE NOTES: N/A