### PR TITLE
xds/bootstrap: escape authority when populating resource name template

### DIFF
--- a/xds/internal/xdsclient/bootstrap/bootstrap.go
+++ b/xds/internal/xdsclient/bootstrap/bootstrap.go
@@ -25,6 +25,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"net/url"
 	"strings"
 
 	"github.com/golang/protobuf/jsonpb"
@@ -401,7 +402,7 @@ func NewConfigFromContents(data []byte) (*Config, error) {
 	// - if set, it must start with "xdstp://<authority_name>/"
 	// - if not set, it defaults to "xdstp://<authority_name>/envoy.config.listener.v3.Listener/%s"
 	for name, authority := range config.Authorities {
-		prefix := fmt.Sprintf("xdstp://%s", name)
+		prefix := fmt.Sprintf("xdstp://%s", url.PathEscape(name))
 		if authority.ClientListenerResourceNameTemplate == "" {
 			authority.ClientListenerResourceNameTemplate = prefix + "/envoy.config.listener.v3.Listener/%s"
 			continue

--- a/xds/internal/xdsclient/bootstrap/bootstrap_test.go
+++ b/xds/internal/xdsclient/bootstrap/bootstrap_test.go
@@ -862,7 +862,8 @@ func TestNewConfigWithFederation(t *testing.T) {
 			}],
 			"client_default_listener_resource_name_template": "xdstp://xds.example.com/envoy.config.listener.v3.Listener/%s",
 			"authorities": {
-				"xds.td.com": { }
+				"xds.td.com": { },
+				"#.com": { }
 			}
 		}`,
 		// It's OK for an authority to not have servers. The top-level server
@@ -955,6 +956,9 @@ func TestNewConfigWithFederation(t *testing.T) {
 				Authorities: map[string]*Authority{
 					"xds.td.com": {
 						ClientListenerResourceNameTemplate: "xdstp://xds.td.com/envoy.config.listener.v3.Listener/%s",
+					},
+					"#.com": {
+						ClientListenerResourceNameTemplate: "xdstp://%23.com/envoy.config.listener.v3.Listener/%s",
 					},
 				},
 			},


### PR DESCRIPTION
RELEASE NOTES: N/A