### PR TITLE
transport/http2_server: Make it possible to configure GOAWAY thresholds

### DIFF
--- a/keepalive/keepalive.go
+++ b/keepalive/keepalive.go
@@ -82,4 +82,16 @@ type EnforcementPolicy struct {
 	// streams(RPCs). If false, and client sends ping when there are no active
 	// streams, server will send GOAWAY and close the connection.
 	PermitWithoutStream bool // false by default.
+
+	// MaxPingStrikes is the maximum number of pings that will be allowed to
+	// be exceeded before the server sends a GOAWAY and closes the connection.
+	MaxPingStrikes uint
+	// KeepaliveTime is the length of the period when a keepalive should have been sent.
+	KeepaliveTime time.Duration
+
+	// DisableEnforcement disables the enforcement of the keepalive policy.
+	// As described in https://github.com/grpc/grpc/blob/master/doc/keepalive.md,
+	// "There should ideally be no such restriction on the keepalive ping and we
+	// plan to deprecate it in the future."
+	DisableEnforcement bool // false by default
 }


### PR DESCRIPTION
As discussed in https://github.com/grpc/grpc/issues/25713, it's very
easy to wreak havoc by tweaking the gRPC keepalive interval on the
client. Previously the limit of 2 pings within 2 hours was hard-coded;
if a client went over this limit, the server sends a GOAWAY message is
sent and closes the connection.

https://github.com/grpc/grpc/blob/master/doc/keepalive.md recommends
that `GRPC_ARG_HTTP2_MAX_PINGS_WITHOUT_DATA` should be set to 0, and
that enforcement of this policy will be deprecated in the future. This
commit allows disabling of this enforcement.

Closes https://github.com/grpc/grpc-go/issues/5161