### PR TITLE
grpclb: rename LB policy config field to `serviceName`

### DIFF
--- a/balancer/grpclb/grpclb.go
+++ b/balancer/grpclb/grpclb.go
@@ -413,8 +413,8 @@ func (lb *lbBalancer) handleServiceConfig(gc *grpclbServiceConfig) {
 	// this target is sent in the first message on the stream.
 	if gc != nil {
 		target := lb.dialTarget
-		if gc.TargetName != "" {
-			target = gc.TargetName
+		if gc.ServiceName != "" {
+			target = gc.ServiceName
 		}
 		if target != lb.target {
 			lb.target = target

--- a/balancer/grpclb/grpclb_config.go
+++ b/balancer/grpclb/grpclb_config.go
@@ -34,7 +34,7 @@ const (
 type grpclbServiceConfig struct {
 	serviceconfig.LoadBalancingConfig
 	ChildPolicy *[]map[string]json.RawMessage
-	TargetName  string
+	ServiceName string
 }
 
 func (b *lbBuilder) ParseConfig(lbConfig json.RawMessage) (serviceconfig.LoadBalancingConfig, error) {

--- a/balancer/grpclb/grpclb_config_test.go
+++ b/balancer/grpclb/grpclb_config_test.go
@@ -46,13 +46,13 @@ func (s) TestParse(t *testing.T) {
 	"childPolicy": [
 		{"pick_first":{}}
 	],
-	"targetName": "foo-service"
+	"serviceName": "foo-service"
 }`,
 			want: &grpclbServiceConfig{
 				ChildPolicy: &[]map[string]json.RawMessage{
 					{"pick_first": json.RawMessage("{}")},
 				},
-				TargetName: "foo-service",
+				ServiceName: "foo-service",
 			},
 		},
 		{
@@ -63,14 +63,14 @@ func (s) TestParse(t *testing.T) {
 		{"round_robin":{}},
 		{"pick_first":{}}
 	],
-	"targetName": "foo-service"
+	"serviceName": "foo-service"
 }`,
 			want: &grpclbServiceConfig{
 				ChildPolicy: &[]map[string]json.RawMessage{
 					{"round_robin": json.RawMessage("{}")},
 					{"pick_first": json.RawMessage("{}")},
 				},
-				TargetName: "foo-service",
+				ServiceName: "foo-service",
 			},
 		},
 	}

--- a/balancer/grpclb/grpclb_test.go
+++ b/balancer/grpclb/grpclb_test.go
@@ -1404,7 +1404,7 @@ func (s) TestGRPCLBWithTargetNameFieldInConfig(t *testing.T) {
 	// Push the resolver update with target_field changed.
 	// Push a resolver update with grpclb configuration containing the
 	// target_name field. Our fake remote balancer has been updated above to expect the newServerName in the initial request.
-	lbCfg := fmt.Sprintf(`{"loadBalancingConfig": [{"grpclb": {"targetName": "%s"}}]}`, newServerName)
+	lbCfg := fmt.Sprintf(`{"loadBalancingConfig": [{"grpclb": {"serviceName": "%s"}}]}`, newServerName)
 	rs = grpclbstate.Set(resolver.State{ServiceConfig: r.CC.ParseServiceConfig(lbCfg)},
 		&grpclbstate.State{BalancerAddresses: []resolver.Address{{
 			Addr:       tss.lbAddr,

--- a/balancer/rls/config_test.go
+++ b/balancer/rls/config_test.go
@@ -82,7 +82,7 @@ func (s) TestParseConfig(t *testing.T) {
 					{"unknown-policy": {"unknown-field": "unknown-value"}},
 					{"grpclb": {"childPolicy": [{"pickfirst": {}}]}}
 				],
-				"childPolicyConfigTargetFieldName": "service_name"
+				"childPolicyConfigTargetFieldName": "serviceName"
 			}`),
 			wantCfg: &lbConfig{
 				lookupService:          ":///target",
@@ -92,10 +92,10 @@ func (s) TestParseConfig(t *testing.T) {
 				cacheSizeBytes:         maxCacheSize,
 				defaultTarget:          "passthrough:///default",
 				childPolicyName:        "grpclb",
-				childPolicyTargetField: "service_name",
+				childPolicyTargetField: "serviceName",
 				childPolicyConfig: map[string]json.RawMessage{
-					"childPolicy":  json.RawMessage(`[{"pickfirst": {}}]`),
-					"service_name": json.RawMessage(childPolicyTargetFieldVal),
+					"childPolicy": json.RawMessage(`[{"pickfirst": {}}]`),
+					"serviceName": json.RawMessage(childPolicyTargetFieldVal),
 				},
 			},
 		},
@@ -115,7 +115,7 @@ func (s) TestParseConfig(t *testing.T) {
 					"defaultTarget": "passthrough:///default"
 				},
 				"childPolicy": [{"grpclb": {"childPolicy": [{"pickfirst": {}}]}}],
-				"childPolicyConfigTargetFieldName": "service_name"
+				"childPolicyConfigTargetFieldName": "serviceName"
 			}`),
 			wantCfg: &lbConfig{
 				lookupService:          "target",
@@ -125,10 +125,10 @@ func (s) TestParseConfig(t *testing.T) {
 				cacheSizeBytes:         1000,
 				defaultTarget:          "passthrough:///default",
 				childPolicyName:        "grpclb",
-				childPolicyTargetField: "service_name",
+				childPolicyTargetField: "serviceName",
 				childPolicyConfig: map[string]json.RawMessage{
-					"childPolicy":  json.RawMessage(`[{"pickfirst": {}}]`),
-					"service_name": json.RawMessage(childPolicyTargetFieldVal),
+					"childPolicy": json.RawMessage(`[{"pickfirst": {}}]`),
+					"serviceName": json.RawMessage(childPolicyTargetFieldVal),
 				},
 			},
 		},
@@ -273,7 +273,7 @@ func (s) TestParseConfigErrors(t *testing.T) {
 					"staleAge" : "25s",
 					"defaultTarget": "passthrough:///default"
 				},
-				"childPolicyConfigTargetFieldName": "service_name"
+				"childPolicyConfigTargetFieldName": "serviceName"
 			}`),
 			wantErr: "rls: cache_size_bytes must be set to a non-zero value",
 		},
@@ -292,7 +292,7 @@ func (s) TestParseConfigErrors(t *testing.T) {
 					"cacheSizeBytes": 1000,
 					"defaultTarget": "passthrough:///default"
 				},
-				"childPolicyConfigTargetFieldName": "service_name"
+				"childPolicyConfigTargetFieldName": "serviceName"
 			}`),
 			wantErr: "rls: invalid childPolicy config: no supported policies found",
 		},
@@ -315,7 +315,7 @@ func (s) TestParseConfigErrors(t *testing.T) {
 					{"cds_experimental": {"Cluster": "my-fav-cluster"}},
 					{"unknown-policy": {"unknown-field": "unknown-value"}}
 				],
-				"childPolicyConfigTargetFieldName": "service_name"
+				"childPolicyConfigTargetFieldName": "serviceName"
 			}`),
 			wantErr: "rls: invalid childPolicy config: no supported policies found",
 		},
@@ -340,7 +340,7 @@ func (s) TestParseConfigErrors(t *testing.T) {
 						"unknown-policy": {"unknown-field": "unknown-value"}
 					}
 				],
-				"childPolicyConfigTargetFieldName": "service_name"
+				"childPolicyConfigTargetFieldName": "serviceName"
 			}`),
 			wantErr: "does not contain exactly 1 policy/config pair",
 		},
@@ -387,7 +387,7 @@ func (s) TestParseConfigErrors(t *testing.T) {
 					{"unknown-policy": {"unknown-field": "unknown-value"}},
 					{"grpclb": {"childPolicy": "not-an-array"}}
 				],
-				"childPolicyConfigTargetFieldName": "service_name"
+				"childPolicyConfigTargetFieldName": "serviceName"
 			}`),
 			wantErr: "rls: childPolicy config validation failed",
 		},


### PR DESCRIPTION
The field in the LB policy config which identifies the target was initially named `targetName` in the design doc. But when the service config proto change was made, it was renamed to `serviceName`. This update wasn't propagated to the design doc at the time. Java/C have used `serviceName`.

RELEASE NOTES: none