### PR TITLE
rls: support `routeLookupChannelServiceConfig` field

### DIFF
--- a/balancer/rls/balancer.go
+++ b/balancer/rls/balancer.go
@@ -254,7 +254,7 @@ func (b *rlsBalancer) handleControlChannelUpdate(newCfg *lbConfig) {
 
 	// Create a new control channel and close the existing one.
 	b.logger.Infof("Creating control channel to RLS server at: %v", newCfg.lookupService)
-	ctrlCh, err := newControlChannel(newCfg.lookupService, newCfg.lookupServiceTimeout, b.bopts, b.connectivityStateCh)
+	ctrlCh, err := newControlChannel(newCfg.lookupService, newCfg.controlChannelServiceConfig, newCfg.lookupServiceTimeout, b.bopts, b.connectivityStateCh)
 	if err != nil {
 		// This is very uncommon and usually represents a non-transient error.
 		// There is not much we can do here other than wait for another update

--- a/balancer/rls/config.go
+++ b/balancer/rls/config.go
@@ -160,7 +160,7 @@ func (rlsBB) ParseConfig(c json.RawMessage) (serviceconfig.LoadBalancingConfig, 
 	if sc := string(cfgJSON.RouteLookupChannelServiceConfig); sc != "" {
 		parsed := internal.ParseServiceConfig.(func(string) *serviceconfig.ParseResult)(sc)
 		if parsed.Err != nil {
-			return nil, fmt.Errorf("rls: bad control channel service config %s: %v", sc, parsed.Err)
+			return nil, fmt.Errorf("rls: bad control channel service config %q: %v", sc, parsed.Err)
 		}
 		lbCfg.controlChannelServiceConfig = sc
 	}

--- a/balancer/rls/config.go
+++ b/balancer/rls/config.go
@@ -29,6 +29,7 @@ import (
 	durationpb "github.com/golang/protobuf/ptypes/duration"
 	"google.golang.org/grpc/balancer"
 	"google.golang.org/grpc/balancer/rls/internal/keys"
+	"google.golang.org/grpc/internal"
 	"google.golang.org/grpc/internal/pretty"
 	rlspb "google.golang.org/grpc/internal/proto/grpc_lookup_v1"
 	"google.golang.org/grpc/resolver"
@@ -61,9 +62,10 @@ type lbConfig struct {
 	staleAge             time.Duration
 	defaultTarget        string
 
-	childPolicyName        string
-	childPolicyConfig      map[string]json.RawMessage
-	childPolicyTargetField string
+	childPolicyName             string
+	childPolicyConfig           map[string]json.RawMessage
+	childPolicyTargetField      string
+	controlChannelServiceConfig string
 }
 
 func (lbCfg *lbConfig) Equal(other *lbConfig) bool {
@@ -76,6 +78,7 @@ func (lbCfg *lbConfig) Equal(other *lbConfig) bool {
 		lbCfg.defaultTarget == other.defaultTarget &&
 		lbCfg.childPolicyName == other.childPolicyName &&
 		lbCfg.childPolicyTargetField == other.childPolicyTargetField &&
+		lbCfg.controlChannelServiceConfig == other.controlChannelServiceConfig &&
 		childPolicyConfigEqual(lbCfg.childPolicyConfig, other.childPolicyConfig)
 }
 
@@ -102,10 +105,14 @@ func childPolicyConfigEqual(a, b map[string]json.RawMessage) bool {
 // and makes it easier to unmarshal.
 type lbConfigJSON struct {
 	RouteLookupConfig                json.RawMessage
+	RouteLookupChannelServiceConfig  json.RawMessage
 	ChildPolicy                      []map[string]json.RawMessage
 	ChildPolicyConfigTargetFieldName string
 }
 
+// ParseConfig parses the JSON load balancer config provided into an
+// internal form or returns an error if the config is invalid.
+//
 // When parsing a config update, the following validations are performed:
 // - routeLookupConfig:
 //   - grpc_keybuilders field:
@@ -127,6 +134,8 @@ type lbConfigJSON struct {
 //   - ignore `valid_targets` field
 //   - `cache_size_bytes` field must have a value greater than 0, and if its
 //      value is greater than 5M, we cap it at 5M
+// - routeLookupChannelServiceConfig:
+//   - if specified, must parse as valid service config
 // - childPolicy:
 //   - must find a valid child policy with a valid config
 // - childPolicyConfigTargetFieldName:
@@ -146,6 +155,14 @@ func (rlsBB) ParseConfig(c json.RawMessage) (serviceconfig.LoadBalancingConfig, 
 	lbCfg, err := parseRLSProto(rlsProto)
 	if err != nil {
 		return nil, err
+	}
+
+	if sc := string(cfgJSON.RouteLookupChannelServiceConfig); sc != "" {
+		parsed := internal.ParseServiceConfig.(func(string) *serviceconfig.ParseResult)(sc)
+		if parsed.Err != nil {
+			return nil, fmt.Errorf("rls: bad control channel service config %s: %v", sc, parsed.Err)
+		}
+		lbCfg.controlChannelServiceConfig = sc
 	}
 
 	if cfgJSON.ChildPolicyConfigTargetFieldName == "" {

--- a/balancer/rls/control_channel.go
+++ b/balancer/rls/control_channel.go
@@ -123,6 +123,7 @@ func (cc *controlChannel) dialOpts(bOpts balancer.BuildOptions, serviceConfig st
 	// control channel, use that and disable service config fetching via the name
 	// resolver for the control channel.
 	if serviceConfig != "" {
+		cc.logger.Infof("Disabling service config from the name resolver and instead using: %s", serviceConfig)
 		dopts = append(dopts, grpc.WithDisableServiceConfig(), grpc.WithDefaultServiceConfig(serviceConfig))
 	}
 

--- a/balancer/rls/control_channel_test.go
+++ b/balancer/rls/control_channel_test.go
@@ -51,7 +51,7 @@ func (s) TestControlChannelThrottled(t *testing.T) {
 	overrideAdaptiveThrottler(t, alwaysThrottlingThrottler())
 
 	// Create a control channel to the fake RLS server.
-	ctrlCh, err := newControlChannel(rlsServer.Address, defaultTestTimeout, balancer.BuildOptions{}, nil)
+	ctrlCh, err := newControlChannel(rlsServer.Address, "", defaultTestTimeout, balancer.BuildOptions{}, nil)
 	if err != nil {
 		t.Fatalf("Failed to create control channel to RLS server: %v", err)
 	}
@@ -79,7 +79,7 @@ func (s) TestLookupFailure(t *testing.T) {
 	})
 
 	// Create a control channel to the fake RLS server.
-	ctrlCh, err := newControlChannel(rlsServer.Address, defaultTestTimeout, balancer.BuildOptions{}, nil)
+	ctrlCh, err := newControlChannel(rlsServer.Address, "", defaultTestTimeout, balancer.BuildOptions{}, nil)
 	if err != nil {
 		t.Fatalf("Failed to create control channel to RLS server: %v", err)
 	}
@@ -118,7 +118,7 @@ func (s) TestLookupDeadlineExceeded(t *testing.T) {
 	overrideAdaptiveThrottler(t, neverThrottlingThrottler())
 
 	// Create a control channel with a small deadline.
-	ctrlCh, err := newControlChannel(rlsServer.Address, defaultTestShortTimeout, balancer.BuildOptions{}, nil)
+	ctrlCh, err := newControlChannel(rlsServer.Address, "", defaultTestShortTimeout, balancer.BuildOptions{}, nil)
 	if err != nil {
 		t.Fatalf("Failed to create control channel to RLS server: %v", err)
 	}
@@ -272,7 +272,7 @@ func testControlChannelCredsSuccess(t *testing.T, sopts []grpc.ServerOption, bop
 	})
 
 	// Create a control channel to the fake server.
-	ctrlCh, err := newControlChannel(rlsServer.Address, defaultTestTimeout, bopts, nil)
+	ctrlCh, err := newControlChannel(rlsServer.Address, "", defaultTestTimeout, bopts, nil)
 	if err != nil {
 		t.Fatalf("Failed to create control channel to RLS server: %v", err)
 	}
@@ -360,7 +360,7 @@ func testControlChannelCredsFailure(t *testing.T, sopts []grpc.ServerOption, bop
 	overrideAdaptiveThrottler(t, neverThrottlingThrottler())
 
 	// Create the control channel to the fake server.
-	ctrlCh, err := newControlChannel(rlsServer.Address, defaultTestTimeout, bopts, nil)
+	ctrlCh, err := newControlChannel(rlsServer.Address, "", defaultTestTimeout, bopts, nil)
 	if err != nil {
 		t.Fatalf("Failed to create control channel to RLS server: %v", err)
 	}
@@ -457,7 +457,7 @@ func (s) TestNewControlChannelUnsupportedCredsBundle(t *testing.T) {
 	rlsServer, _ := setupFakeRLSServer(t, nil)
 
 	// Create the control channel to the fake server.
-	ctrlCh, err := newControlChannel(rlsServer.Address, defaultTestTimeout, balancer.BuildOptions{CredsBundle: &unsupportedCredsBundle{}}, nil)
+	ctrlCh, err := newControlChannel(rlsServer.Address, "", defaultTestTimeout, balancer.BuildOptions{CredsBundle: &unsupportedCredsBundle{}}, nil)
 	if err == nil {
 		ctrlCh.close()
 		t.Fatal("newControlChannel succeeded when expected to fail")

--- a/balancer/rls/helpers_test.go
+++ b/balancer/rls/helpers_test.go
@@ -197,7 +197,7 @@ func setupFakeRLSServer(t *testing.T, lis net.Listener, opts ...grpc.ServerOptio
 }
 
 // buildBasicRLSConfig constructs a basic service config for the RLS LB policy
-// which header matching rules. This expects the passed child policy name to
+// with header matching rules. This expects the passed child policy name to
 // have been registered by the caller.
 func buildBasicRLSConfig(childPolicyName, rlsServerAddress string) *e2e.RLSConfig {
 	return &e2e.RLSConfig{
@@ -215,6 +215,7 @@ func buildBasicRLSConfig(childPolicyName, rlsServerAddress string) *e2e.RLSConfi
 			LookupServiceTimeout: durationpb.New(defaultTestTimeout),
 			CacheSizeBytes:       1024,
 		},
+		RouteLookupChannelServiceConfig:  `{"loadBalancingConfig": [{"pick_first": {}}]}`,
 		ChildPolicy:                      &internalserviceconfig.BalancerConfig{Name: childPolicyName},
 		ChildPolicyConfigTargetFieldName: e2e.RLSChildPolicyTargetNameField,
 	}
@@ -235,6 +236,7 @@ func buildBasicRLSConfigWithChildPolicy(t *testing.T, childPolicyName, rlsServer
 			LookupServiceTimeout: durationpb.New(defaultTestTimeout),
 			CacheSizeBytes:       1024,
 		},
+		RouteLookupChannelServiceConfig:  `{"loadBalancingConfig": [{"pick_first": {}}]}`,
 		ChildPolicy:                      &internalserviceconfig.BalancerConfig{Name: childPolicyName},
 		ChildPolicyConfigTargetFieldName: e2e.RLSChildPolicyTargetNameField,
 	}
@@ -275,7 +277,7 @@ func startManualResolverWithConfig(t *testing.T, rlsConfig *e2e.RLSConfig) *manu
 		t.Fatal(err)
 	}
 
-	sc := internal.ParseServiceConfigForTesting.(func(string) *serviceconfig.ParseResult)(scJSON)
+	sc := internal.ParseServiceConfig.(func(string) *serviceconfig.ParseResult)(scJSON)
 	r := manual.NewBuilderWithScheme("rls-e2e")
 	r.InitialState(resolver.State{ServiceConfig: sc})
 	t.Cleanup(r.Close)

--- a/balancer/rls/internal/test/e2e/rls_lb_config.go
+++ b/balancer/rls/internal/test/e2e/rls_lb_config.go
@@ -33,6 +33,7 @@ import (
 // RLSConfig is a utility type to build service config for the RLS LB policy.
 type RLSConfig struct {
 	RouteLookupConfig                *rlspb.RouteLookupConfig
+	RouteLookupChannelServiceConfig  string
 	ChildPolicy                      *internalserviceconfig.BalancerConfig
 	ChildPolicyConfigTargetFieldName string
 }
@@ -60,12 +61,13 @@ func (c *RLSConfig) ServiceConfigJSON() (string, error) {
     {
       "rls_experimental": {
         "routeLookupConfig": %s,
+				"routeLookupChannelServiceConfig": %s,
         "childPolicy": %s,
         "childPolicyConfigTargetFieldName": %q
       }
     }
   ]
-}`, string(routeLookupCfg), string(childPolicy), c.ChildPolicyConfigTargetFieldName), nil
+}`, string(routeLookupCfg), c.RouteLookupChannelServiceConfig, string(childPolicy), c.ChildPolicyConfigTargetFieldName), nil
 }
 
 // LoadBalancingConfig generates load balancing config which can used as part of
@@ -87,9 +89,10 @@ func (c *RLSConfig) LoadBalancingConfig() (serviceconfig.LoadBalancingConfig, er
 	lbConfigJSON := fmt.Sprintf(`
 {
   "routeLookupConfig": %s,
+  "routeLookupChannelServiceConfig": %s,
   "childPolicy": %s,
   "childPolicyConfigTargetFieldName": %q
-}`, string(routeLookupCfg), string(childPolicy), c.ChildPolicyConfigTargetFieldName)
+}`, string(routeLookupCfg), c.RouteLookupChannelServiceConfig, string(childPolicy), c.ChildPolicyConfigTargetFieldName)
 
 	builder := balancer.Get("rls_experimental")
 	if builder == nil {

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -38,11 +38,10 @@ var (
 	// KeepaliveMinPingTime is the minimum ping interval.  This must be 10s by
 	// default, but tests may wish to set it lower for convenience.
 	KeepaliveMinPingTime = 10 * time.Second
-	// ParseServiceConfigForTesting is for creating a fake
-	// ClientConn for resolver testing only
-	ParseServiceConfigForTesting interface{} // func(string) *serviceconfig.ParseResult
+	// ParseServiceConfig parses a JSON representation of the service config.
+	ParseServiceConfig interface{} // func(string) *serviceconfig.ParseResult
 	// EqualServiceConfigForTesting is for testing service config generation and
-	// parsing. Both a and b should be returned by ParseServiceConfigForTesting.
+	// parsing. Both a and b should be returned by ParseServiceConfig.
 	// This function compares the config without rawJSON stripped, in case the
 	// there's difference in white space.
 	EqualServiceConfigForTesting func(a, b serviceconfig.Config) bool

--- a/service_config.go
+++ b/service_config.go
@@ -218,7 +218,7 @@ type jsonSC struct {
 }
 
 func init() {
-	internal.ParseServiceConfigForTesting = parseServiceConfig
+	internal.ParseServiceConfig = parseServiceConfig
 }
 func parseServiceConfig(js string) *serviceconfig.ParseResult {
 	if len(js) == 0 {

--- a/xds/internal/balancer/cdsbalancer/cdsbalancer_test.go
+++ b/xds/internal/balancer/cdsbalancer/cdsbalancer_test.go
@@ -200,7 +200,7 @@ func cdsCCS(cluster string, xdsC xdsclient.XDSClient) balancer.ClientConnState {
 	jsonSC := fmt.Sprintf(cdsLBConfig, cluster)
 	return balancer.ClientConnState{
 		ResolverState: xdsclient.SetClient(resolver.State{
-			ServiceConfig: internal.ParseServiceConfigForTesting.(func(string) *serviceconfig.ParseResult)(jsonSC),
+			ServiceConfig: internal.ParseServiceConfig.(func(string) *serviceconfig.ParseResult)(jsonSC),
 		}, xdsC),
 		BalancerConfig: &lbConfig{ClusterName: clusterName},
 	}

--- a/xds/internal/resolver/cluster_specifier_plugin_test.go
+++ b/xds/internal/resolver/cluster_specifier_plugin_test.go
@@ -95,7 +95,7 @@ func (s) TestXDSResolverClusterSpecifierPlugin(t *testing.T) {
       }
     }}]}`
 
-	wantSCParsed := internal.ParseServiceConfigForTesting.(func(string) *serviceconfig.ParseResult)(wantJSON)
+	wantSCParsed := internal.ParseServiceConfig.(func(string) *serviceconfig.ParseResult)(wantJSON)
 	if !internal.EqualServiceConfigForTesting(rState.ServiceConfig.Config, wantSCParsed.Config) {
 		t.Errorf("ClientConn.UpdateState received different service config")
 		t.Error("got: ", cmp.Diff(nil, rState.ServiceConfig.Config))
@@ -163,7 +163,7 @@ func (s) TestXDSResolverClusterSpecifierPluginConfigUpdate(t *testing.T) {
       }
     }}]}`
 
-	wantSCParsed := internal.ParseServiceConfigForTesting.(func(string) *serviceconfig.ParseResult)(wantJSON)
+	wantSCParsed := internal.ParseServiceConfig.(func(string) *serviceconfig.ParseResult)(wantJSON)
 	if !internal.EqualServiceConfigForTesting(rState.ServiceConfig.Config, wantSCParsed.Config) {
 		t.Errorf("ClientConn.UpdateState received different service config")
 		t.Error("got: ", cmp.Diff(nil, rState.ServiceConfig.Config))
@@ -199,7 +199,7 @@ func (s) TestXDSResolverClusterSpecifierPluginConfigUpdate(t *testing.T) {
       }
     }}]}`
 
-	wantSCParsed = internal.ParseServiceConfigForTesting.(func(string) *serviceconfig.ParseResult)(wantJSON)
+	wantSCParsed = internal.ParseServiceConfig.(func(string) *serviceconfig.ParseResult)(wantJSON)
 	if !internal.EqualServiceConfigForTesting(rState.ServiceConfig.Config, wantSCParsed.Config) {
 		t.Errorf("ClientConn.UpdateState received different service config")
 		t.Error("got: ", cmp.Diff(nil, rState.ServiceConfig.Config))
@@ -250,7 +250,7 @@ func (s) TestXDSResolverDelayedOnCommittedCSP(t *testing.T) {
       }
     }}]}`
 
-	wantSCParsed := internal.ParseServiceConfigForTesting.(func(string) *serviceconfig.ParseResult)(wantJSON)
+	wantSCParsed := internal.ParseServiceConfig.(func(string) *serviceconfig.ParseResult)(wantJSON)
 	if !internal.EqualServiceConfigForTesting(rState.ServiceConfig.Config, wantSCParsed.Config) {
 		t.Errorf("ClientConn.UpdateState received different service config")
 		t.Error("got: ", cmp.Diff(nil, rState.ServiceConfig.Config))
@@ -320,7 +320,7 @@ func (s) TestXDSResolverDelayedOnCommittedCSP(t *testing.T) {
       }
     }}]}`
 
-	wantSCParsed2 := internal.ParseServiceConfigForTesting.(func(string) *serviceconfig.ParseResult)(wantJSON2)
+	wantSCParsed2 := internal.ParseServiceConfig.(func(string) *serviceconfig.ParseResult)(wantJSON2)
 	if !internal.EqualServiceConfigForTesting(rState.ServiceConfig.Config, wantSCParsed2.Config) {
 		t.Errorf("ClientConn.UpdateState received different service config")
 		t.Error("got: ", cmp.Diff(nil, rState.ServiceConfig.Config))
@@ -359,7 +359,7 @@ func (s) TestXDSResolverDelayedOnCommittedCSP(t *testing.T) {
       }
     }}]}`
 
-	wantSCParsed3 := internal.ParseServiceConfigForTesting.(func(string) *serviceconfig.ParseResult)(wantJSON3)
+	wantSCParsed3 := internal.ParseServiceConfig.(func(string) *serviceconfig.ParseResult)(wantJSON3)
 	if !internal.EqualServiceConfigForTesting(rState.ServiceConfig.Config, wantSCParsed3.Config) {
 		t.Errorf("ClientConn.UpdateState received different service config")
 		t.Error("got: ", cmp.Diff(nil, rState.ServiceConfig.Config))

--- a/xds/internal/resolver/xds_resolver_test.go
+++ b/xds/internal/resolver/xds_resolver_test.go
@@ -101,7 +101,7 @@ func (t *testClientConn) ReportError(err error) {
 }
 
 func (t *testClientConn) ParseServiceConfig(jsonSC string) *serviceconfig.ParseResult {
-	return internal.ParseServiceConfigForTesting.(func(string) *serviceconfig.ParseResult)(jsonSC)
+	return internal.ParseServiceConfig.(func(string) *serviceconfig.ParseResult)(jsonSC)
 }
 
 func newTestClientConn() *testClientConn {
@@ -548,7 +548,7 @@ func (s) TestXDSResolverGoodServiceUpdate(t *testing.T) {
 			t.Fatalf("ClientConn.UpdateState received error in service config: %v", rState.ServiceConfig.Err)
 		}
 
-		wantSCParsed := internal.ParseServiceConfigForTesting.(func(string) *serviceconfig.ParseResult)(tt.wantJSON)
+		wantSCParsed := internal.ParseServiceConfig.(func(string) *serviceconfig.ParseResult)(tt.wantJSON)
 		if !internal.EqualServiceConfigForTesting(rState.ServiceConfig.Config, wantSCParsed.Config) {
 			t.Errorf("ClientConn.UpdateState received different service config")
 			t.Error("got: ", cmp.Diff(nil, rState.ServiceConfig.Config))
@@ -730,7 +730,7 @@ func (s) TestXDSResolverRemovedResource(t *testing.T) {
         }
       }
     }}]}`
-	wantSCParsed := internal.ParseServiceConfigForTesting.(func(string) *serviceconfig.ParseResult)(wantJSON)
+	wantSCParsed := internal.ParseServiceConfig.(func(string) *serviceconfig.ParseResult)(wantJSON)
 
 	gotState, err := tcc.stateCh.Receive(ctx)
 	if err != nil {
@@ -798,7 +798,7 @@ func (s) TestXDSResolverRemovedResource(t *testing.T) {
 	if err := rState.ServiceConfig.Err; err != nil {
 		t.Fatalf("ClientConn.UpdateState received error in service config: %v", rState.ServiceConfig.Err)
 	}
-	wantSCParsed = internal.ParseServiceConfigForTesting.(func(string) *serviceconfig.ParseResult)("{}")
+	wantSCParsed = internal.ParseServiceConfig.(func(string) *serviceconfig.ParseResult)("{}")
 	if !internal.EqualServiceConfigForTesting(rState.ServiceConfig.Config, wantSCParsed.Config) {
 		t.Errorf("ClientConn.UpdateState received different service config")
 		t.Error("got: ", cmp.Diff(nil, rState.ServiceConfig.Config))
@@ -992,7 +992,7 @@ func (s) TestXDSResolverDelayedOnCommitted(t *testing.T) {
         }
       }
     }}]}`
-	wantSCParsed := internal.ParseServiceConfigForTesting.(func(string) *serviceconfig.ParseResult)(wantJSON)
+	wantSCParsed := internal.ParseServiceConfig.(func(string) *serviceconfig.ParseResult)(wantJSON)
 	if !internal.EqualServiceConfigForTesting(rState.ServiceConfig.Config, wantSCParsed.Config) {
 		t.Errorf("ClientConn.UpdateState received different service config")
 		t.Error("got: ", cmp.Diff(nil, rState.ServiceConfig.Config))
@@ -1054,7 +1054,7 @@ func (s) TestXDSResolverDelayedOnCommitted(t *testing.T) {
         }
       }
     }}]}`
-	wantSCParsed2 := internal.ParseServiceConfigForTesting.(func(string) *serviceconfig.ParseResult)(wantJSON2)
+	wantSCParsed2 := internal.ParseServiceConfig.(func(string) *serviceconfig.ParseResult)(wantJSON2)
 	if !internal.EqualServiceConfigForTesting(rState.ServiceConfig.Config, wantSCParsed2.Config) {
 		t.Errorf("ClientConn.UpdateState received different service config")
 		t.Error("got: ", cmp.Diff(nil, rState.ServiceConfig.Config))
@@ -1089,7 +1089,7 @@ func (s) TestXDSResolverDelayedOnCommitted(t *testing.T) {
         }
       }
     }}]}`
-	wantSCParsed3 := internal.ParseServiceConfigForTesting.(func(string) *serviceconfig.ParseResult)(wantJSON3)
+	wantSCParsed3 := internal.ParseServiceConfig.(func(string) *serviceconfig.ParseResult)(wantJSON3)
 	if !internal.EqualServiceConfigForTesting(rState.ServiceConfig.Config, wantSCParsed3.Config) {
 		t.Errorf("ClientConn.UpdateState received different service config")
 		t.Error("got: ", cmp.Diff(nil, rState.ServiceConfig.Config))
@@ -1177,7 +1177,7 @@ func (s) TestXDSResolverResourceNotFoundError(t *testing.T) {
 		t.Fatalf("Error waiting for UpdateState to be called: %v", err)
 	}
 	rState := gotState.(resolver.State)
-	wantParsedConfig := internal.ParseServiceConfigForTesting.(func(string) *serviceconfig.ParseResult)("{}")
+	wantParsedConfig := internal.ParseServiceConfig.(func(string) *serviceconfig.ParseResult)("{}")
 	if !internal.EqualServiceConfigForTesting(rState.ServiceConfig.Config, wantParsedConfig.Config) {
 		t.Error("ClientConn.UpdateState got wrong service config")
 		t.Errorf("gotParsed: %s", cmp.Diff(nil, rState.ServiceConfig.Config))


### PR DESCRIPTION
Summary of changes:
- Add `routeLookupChannelServiceConfig` to RLS LB policy's service config to serve as the service config for the control channel
  - This will make it possible for the control channel to be used in directpath deployments with grpclb and TD
- Unit tests for config validation
- E2E test to ensure that the injected service config gets used for the control channel

Also, renamed `internal.ParseServiceConfigForTesting` to `internal.ParseServiceConfig` so that it can be used to parse and validate the specified service config.
 
RELEASE NOTES: none