### PR TITLE
channelz: include channelz identifier in logs

### DIFF
--- a/balancer/balancer.go
+++ b/balancer/balancer.go
@@ -27,6 +27,7 @@ import (
 	"net"
 	"strings"
 
+	"google.golang.org/grpc/channelz"
 	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/internal"
@@ -192,7 +193,7 @@ type BuildOptions struct {
 	// server can ignore this field.
 	Authority string
 	// ChannelzParentID is the parent ClientConn's channelz ID.
-	ChannelzParentID int64
+	ChannelzParentID *channelz.Identifier
 	// CustomUserAgent is the custom user agent set on the parent ClientConn.
 	// The balancer should set the same custom user agent if it creates a
 	// ClientConn.

--- a/balancer/grpclb/grpclb_remote_balancer.go
+++ b/balancer/grpclb/grpclb_remote_balancer.go
@@ -35,7 +35,6 @@ import (
 	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/internal/backoff"
-	"google.golang.org/grpc/internal/channelz"
 	imetadata "google.golang.org/grpc/internal/metadata"
 	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/metadata"
@@ -240,9 +239,7 @@ func (lb *lbBalancer) newRemoteBalancerCCWrapper() {
 	// Explicitly set pickfirst as the balancer.
 	dopts = append(dopts, grpc.WithDefaultServiceConfig(`{"loadBalancingPolicy":"pick_first"}`))
 	dopts = append(dopts, grpc.WithResolvers(lb.manualResolver))
-	if channelz.IsOn() {
-		dopts = append(dopts, grpc.WithChannelzParentID(lb.opt.ChannelzParentID))
-	}
+	dopts = append(dopts, grpc.WithChannelzParentID(lb.opt.ChannelzParentID))
 
 	// Enable Keepalive for grpclb client.
 	dopts = append(dopts, grpc.WithKeepaliveParams(keepalive.ClientParameters{

--- a/balancer_conn_wrappers.go
+++ b/balancer_conn_wrappers.go
@@ -184,6 +184,7 @@ func (ccb *ccBalancerWrapper) NewSubConn(addrs []resolver.Address, opts balancer
 	}
 	ac, err := ccb.cc.newAddrConn(addrs, opts)
 	if err != nil {
+		channelz.Warningf(logger, ccb.cc.channelzID, "acBalancerWrapper: NewSubConn: failed to newAddrConn: %v", err)
 		return nil, err
 	}
 	acbw := &acBalancerWrapper{ac: ac}

--- a/channelz/channelz.go
+++ b/channelz/channelz.go
@@ -1,0 +1,36 @@
+/*
+ *
+ * Copyright 2020 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// Package channelz exports internals of the channelz implementation as required
+// by other gRPC packages.
+//
+// The implementation of the channelz spec as defined in
+// https://github.com/grpc/proposal/blob/master/A14-channelz.md, is provided by
+// the `internal/channelz` package.
+//
+// Experimental
+//
+// Notice: All APIs in this package are experimental and may be removed in a
+// later release.
+package channelz
+
+import "google.golang.org/grpc/internal/channelz"
+
+// Identifier is an opaque identifier which uniquely identifies an entity in the
+// channelz database.
+type Identifier = channelz.Identifier

--- a/channelz/service/service_sktopt_test.go
+++ b/channelz/service/service_sktopt_test.go
@@ -28,15 +28,17 @@ package service
 
 import (
 	"context"
-	"reflect"
 	"strconv"
 	"testing"
 
 	"github.com/golang/protobuf/ptypes"
 	durpb "github.com/golang/protobuf/ptypes/duration"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"golang.org/x/sys/unix"
 	channelzpb "google.golang.org/grpc/channelz/grpc_channelz_v1"
 	"google.golang.org/grpc/internal/channelz"
+	"google.golang.org/protobuf/testing/protocmp"
 )
 
 func init() {
@@ -139,20 +141,27 @@ func (s) TestGetSocketOptions(t *testing.T) {
 		},
 	}
 	svr := newCZServer()
-	ids := make([]int64, len(ss))
+	ids := make([]*channelz.Identifier, len(ss))
 	svrID := channelz.RegisterServer(&dummyServer{}, "")
 	defer channelz.RemoveEntry(svrID)
 	for i, s := range ss {
-		ids[i] = channelz.RegisterNormalSocket(s, svrID, strconv.Itoa(i))
+		ids[i], _ = channelz.RegisterNormalSocket(s, svrID, strconv.Itoa(i))
 		defer channelz.RemoveEntry(ids[i])
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
 	for i, s := range ss {
-		resp, _ := svr.GetSocket(ctx, &channelzpb.GetSocketRequest{SocketId: ids[i]})
-		metrics := resp.GetSocket()
-		if !reflect.DeepEqual(metrics.GetRef(), &channelzpb.SocketRef{SocketId: ids[i], Name: strconv.Itoa(i)}) || !reflect.DeepEqual(socketProtoToStruct(metrics), s) {
-			t.Fatalf("resp.GetSocket() want: metrics.GetRef() = %#v and %#v, got: metrics.GetRef() = %#v and %#v", &channelzpb.SocketRef{SocketId: ids[i], Name: strconv.Itoa(i)}, s, metrics.GetRef(), socketProtoToStruct(metrics))
+		resp, _ := svr.GetSocket(ctx, &channelzpb.GetSocketRequest{SocketId: ids[i].Int()})
+		got, want := resp.GetSocket().GetRef(), &channelzpb.SocketRef{SocketId: ids[i].Int(), Name: strconv.Itoa(i)}
+		if !cmp.Equal(got, want, cmpopts.IgnoreUnexported(channelzpb.SocketRef{})) {
+			t.Fatalf("resp.GetSocket() returned metrics.GetRef() = %#v, want %#v", got, want)
+		}
+		socket, err := socketProtoToStruct(resp.GetSocket())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if diff := cmp.Diff(s, socket, protocmp.Transform(), cmp.AllowUnexported(dummySocket{})); diff != "" {
+			t.Fatalf("unexpected socket, diff (-want +got):\n%s", diff)
 		}
 	}
 }

--- a/clientconn.go
+++ b/clientconn.go
@@ -38,7 +38,6 @@ import (
 	"google.golang.org/grpc/internal/backoff"
 	"google.golang.org/grpc/internal/channelz"
 	"google.golang.org/grpc/internal/grpcsync"
-	"google.golang.org/grpc/internal/pretty"
 	iresolver "google.golang.org/grpc/internal/resolver"
 	"google.golang.org/grpc/internal/transport"
 	"google.golang.org/grpc/keepalive"
@@ -1319,7 +1318,7 @@ func (ac *addrConn) createTransport(addr resolver.Address, copts transport.Conne
 	newTr, err := transport.NewClientTransport(connectCtx, ac.cc.ctx, addr, copts, func() { prefaceReceived.Fire() }, onGoAway, onClose)
 	if err != nil {
 		// newTr is either nil, or closed.
-		channelz.Warningf(logger, ac.channelzID, "grpc: addrConn.createTransport failed to connect to %s. Err: %v", pretty.ToJSON(addr), err)
+		channelz.Warningf(logger, ac.channelzID, "grpc: addrConn.createTransport failed to connect to %s. Err: %v", addr, err)
 		return err
 	}
 
@@ -1332,7 +1331,7 @@ func (ac *addrConn) createTransport(addr resolver.Address, copts transport.Conne
 		newTr.Close(transport.ErrConnClosing)
 		if connectCtx.Err() == context.DeadlineExceeded {
 			err := errors.New("failed to receive server preface within timeout")
-			channelz.Warningf(logger, ac.channelzID, "grpc: addrConn.createTransport failed to connect to %s: %v", pretty.ToJSON(addr), err)
+			channelz.Warningf(logger, ac.channelzID, "grpc: addrConn.createTransport failed to connect to %s: %v", addr, err)
 			return err
 		}
 		return nil

--- a/clientconn.go
+++ b/clientconn.go
@@ -1314,9 +1314,7 @@ func (ac *addrConn) createTransport(addr resolver.Address, copts transport.Conne
 
 	connectCtx, cancel := context.WithDeadline(ac.ctx, connectDeadline)
 	defer cancel()
-	if channelz.IsOn() {
-		copts.ChannelzParentID = ac.channelzID
-	}
+	copts.ChannelzParentID = ac.channelzID
 
 	newTr, err := transport.NewClientTransport(connectCtx, ac.cc.ctx, addr, copts, func() { prefaceReceived.Fire() }, onGoAway, onClose)
 	if err != nil {

--- a/clientconn.go
+++ b/clientconn.go
@@ -162,7 +162,7 @@ func DialContext(ctx context.Context, target string, opts ...DialOption) (conn *
 	pid := cc.dopts.channelzParentID
 	cc.channelzID = channelz.RegisterChannel(&channelzChannel{cc}, pid, target)
 	ted := &channelz.TraceEventDesc{
-		Desc:     fmt.Sprintf("Channel(id:%d) created", cc.channelzID.Int()),
+		Desc:     "Channel created",
 		Severity: channelz.CtInfo,
 	}
 	if cc.dopts.channelzParentID != nil {
@@ -772,7 +772,7 @@ func (cc *ClientConn) newAddrConn(addrs []resolver.Address, opts balancer.NewSub
 		return nil, err
 	}
 	channelz.AddTraceEvent(logger, ac.channelzID, 0, &channelz.TraceEventDesc{
-		Desc:     fmt.Sprintf("Subchannel(id:%d) created", ac.channelzID.Int()),
+		Desc:     "Subchannel created",
 		Severity: channelz.CtInfo,
 		Parent: &channelz.TraceEventDesc{
 			Desc:     fmt.Sprintf("Subchannel(id:%d) created", ac.channelzID.Int()),
@@ -1087,7 +1087,7 @@ func (cc *ClientConn) Close() error {
 		ac.tearDown(ErrClientConnClosing)
 	}
 	ted := &channelz.TraceEventDesc{
-		Desc:     fmt.Sprintf("Channel(id:%d) deleted", cc.channelzID.Int()),
+		Desc:     "Channel deleted",
 		Severity: channelz.CtInfo,
 	}
 	if cc.dopts.channelzParentID != nil {
@@ -1497,7 +1497,7 @@ func (ac *addrConn) tearDown(err error) {
 		ac.mu.Lock()
 	}
 	channelz.AddTraceEvent(logger, ac.channelzID, 0, &channelz.TraceEventDesc{
-		Desc:     fmt.Sprintf("Subchannel(id:%d) deleted", ac.channelzID.Int()),
+		Desc:     "Subchannel deleted",
 		Severity: channelz.CtInfo,
 		Parent: &channelz.TraceEventDesc{
 			Desc:     fmt.Sprintf("Subchannel(id:%d) deleted", ac.channelzID.Int()),

--- a/dialoptions.go
+++ b/dialoptions.go
@@ -26,6 +26,7 @@ import (
 
 	"google.golang.org/grpc/backoff"
 	"google.golang.org/grpc/balancer"
+	"google.golang.org/grpc/channelz"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/internal"
@@ -57,7 +58,7 @@ type dialOptions struct {
 	callOptions     []CallOption
 	// This is used by WithBalancerName dial option.
 	balancerBuilder             balancer.Builder
-	channelzParentID            int64
+	channelzParentID            *channelz.Identifier
 	disableServiceConfig        bool
 	disableRetry                bool
 	disableHealthCheck          bool
@@ -498,7 +499,7 @@ func WithAuthority(a string) DialOption {
 //
 // Notice: This API is EXPERIMENTAL and may be changed or removed in a
 // later release.
-func WithChannelzParentID(id int64) DialOption {
+func WithChannelzParentID(id *channelz.Identifier) DialOption {
 	return newFuncDialOption(func(o *dialOptions) {
 		o.channelzParentID = id
 	})

--- a/internal/balancergroup/balancergroup_test.go
+++ b/internal/balancergroup/balancergroup_test.go
@@ -28,6 +28,7 @@ import (
 	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/internal/balancer/stub"
+	"google.golang.org/grpc/internal/channelz"
 	"google.golang.org/grpc/internal/grpctest"
 	"google.golang.org/grpc/internal/testutils"
 	"google.golang.org/grpc/resolver"
@@ -474,17 +475,15 @@ func (s) TestBalancerGroup_CloseStopsBalancerInCache(t *testing.T) {
 // to the balancergroup at creation time is passed to child policies.
 func (s) TestBalancerGroupBuildOptions(t *testing.T) {
 	const (
-		balancerName       = "stubBalancer-TestBalancerGroupBuildOptions"
-		parent             = int64(1234)
-		userAgent          = "ua"
-		defaultTestTimeout = 1 * time.Second
+		balancerName = "stubBalancer-TestBalancerGroupBuildOptions"
+		userAgent    = "ua"
 	)
 
 	// Setup the stub balancer such that we can read the build options passed to
 	// it in the UpdateClientConnState method.
 	bOpts := balancer.BuildOptions{
 		DialCreds:        insecure.NewCredentials(),
-		ChannelzParentID: parent,
+		ChannelzParentID: channelz.NewIdentifierForTesting(channelz.RefChannel, 1234, nil),
 		CustomUserAgent:  userAgent,
 	}
 	stub.Register(balancerName, stub.BalancerFuncs{

--- a/internal/channelz/funcs.go
+++ b/internal/channelz/funcs.go
@@ -191,18 +191,18 @@ func GetServer(id int64) *ServerMetric {
 //
 // Returns a unique channelz identifier assigned to this channel.
 //
-// If channelz is not turned ON, this function is a no-op.
+// If channelz is not turned ON, the channelz database is not mutated.
 func RegisterChannel(c Channel, pid *Identifier, ref string) *Identifier {
-	if !IsOn() {
-		return nil
-	}
-
 	id := idGen.genID()
 	parent := int64(0)
 	isTopChannel := true
 	if pid != nil {
 		isTopChannel = false
 		parent = pid.Int()
+	}
+
+	if !IsOn() {
+		return newIdentifer(RefChannel, id, pid)
 	}
 
 	cn := &channel{
@@ -224,16 +224,16 @@ func RegisterChannel(c Channel, pid *Identifier, ref string) *Identifier {
 //
 // Returns a unique channelz identifier assigned to this subChannel.
 //
-// If channelz is not turned ON, this function is a no-op.
+// If channelz is not turned ON, the channelz database is not mutated.
 func RegisterSubChannel(c Channel, pid *Identifier, ref string) (*Identifier, error) {
-	if !IsOn() {
-		return nil, nil
-	}
-
 	if pid == nil {
 		return nil, errors.New("a SubChannel's parent id cannot be nil")
 	}
 	id := idGen.genID()
+	if !IsOn() {
+		return newIdentifer(RefSubChannel, id, pid), nil
+	}
+
 	sc := &subChannel{
 		refName: ref,
 		c:       c,
@@ -249,13 +249,13 @@ func RegisterSubChannel(c Channel, pid *Identifier, ref string) (*Identifier, er
 // RegisterServer registers the given server s in channelz database. It returns
 // the unique channelz tracking id assigned to this server.
 //
-// If channelz is not turned ON, this function is a no-op.
+// If channelz is not turned ON, the channelz database is not mutated.
 func RegisterServer(s Server, ref string) *Identifier {
+	id := idGen.genID()
 	if !IsOn() {
-		return nil
+		return newIdentifer(RefServer, id, nil)
 	}
 
-	id := idGen.genID()
 	svr := &server{
 		refName:       ref,
 		s:             s,
@@ -272,16 +272,16 @@ func RegisterServer(s Server, ref string) *Identifier {
 // (identified by pid). It returns the unique channelz tracking id assigned to
 // this listen socket.
 //
-// If channelz is not turned ON, this function is a no-op.
+// If channelz is not turned ON, the channelz database is not mutated.
 func RegisterListenSocket(s Socket, pid *Identifier, ref string) (*Identifier, error) {
-	if !IsOn() {
-		return nil, nil
-	}
-
 	if pid == nil {
 		return nil, errors.New("a ListenSocket's parent id cannot be 0")
 	}
 	id := idGen.genID()
+	if !IsOn() {
+		return newIdentifer(RefListenSocket, id, pid), nil
+	}
+
 	ls := &listenSocket{refName: ref, s: s, id: id, pid: pid.Int()}
 	db.get().addListenSocket(id, ls, pid.Int())
 	return newIdentifer(RefListenSocket, id, pid), nil
@@ -292,16 +292,16 @@ func RegisterListenSocket(s Socket, pid *Identifier, ref string) (*Identifier, e
 // (identified by pid). It returns the unique channelz tracking id assigned to
 // this normal socket.
 //
-// If channelz is not turned ON, this function is a no-op.
+// If channelz is not turned ON, the channelz database is not mutated.
 func RegisterNormalSocket(s Socket, pid *Identifier, ref string) (*Identifier, error) {
-	if !IsOn() {
-		return nil, nil
-	}
-
 	if pid == nil {
 		return nil, errors.New("a NormalSocket's parent id cannot be 0")
 	}
 	id := idGen.genID()
+	if !IsOn() {
+		return newIdentifer(RefNormalSocket, id, pid), nil
+	}
+
 	ns := &normalSocket{refName: ref, s: s, id: id, pid: pid.Int()}
 	db.get().addNormalSocket(id, ns, pid.Int())
 	return newIdentifer(RefNormalSocket, id, pid), nil

--- a/internal/channelz/funcs.go
+++ b/internal/channelz/funcs.go
@@ -25,6 +25,7 @@ package channelz
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"sync"
@@ -184,36 +185,53 @@ func GetServer(id int64) *ServerMetric {
 	return db.get().GetServer(id)
 }
 
-// RegisterChannel registers the given channel c in channelz database with ref
-// as its reference name, and add it to the child list of its parent (identified
-// by pid). pid = 0 means no parent. It returns the unique channelz tracking id
-// assigned to this channel.
-func RegisterChannel(c Channel, pid int64, ref string) int64 {
+// RegisterChannel registers the given channel c in the channelz database with
+// ref as its reference name, and adds it to the child list of its parent
+// (identified by pid). pid == nil means no parent.
+//
+// Returns a unique channelz identifier assigned to this channel.
+//
+// If channelz is not turned ON, this function is a no-op.
+func RegisterChannel(c Channel, pid *Identifier, ref string) *Identifier {
+	if !IsOn() {
+		return nil
+	}
+
 	id := idGen.genID()
+	parent := int64(0)
+	isTopChannel := true
+	if pid != nil {
+		isTopChannel = false
+		parent = pid.Int()
+	}
+
 	cn := &channel{
 		refName:     ref,
 		c:           c,
 		subChans:    make(map[int64]string),
 		nestedChans: make(map[int64]string),
 		id:          id,
-		pid:         pid,
+		pid:         parent,
 		trace:       &channelTrace{createdTime: time.Now(), events: make([]*TraceEvent, 0, getMaxTraceEntry())},
 	}
-	if pid == 0 {
-		db.get().addChannel(id, cn, true, pid)
-	} else {
-		db.get().addChannel(id, cn, false, pid)
-	}
-	return id
+	db.get().addChannel(id, cn, isTopChannel, parent)
+	return newIdentifer(RefChannel, id, pid)
 }
 
-// RegisterSubChannel registers the given channel c in channelz database with ref
-// as its reference name, and add it to the child list of its parent (identified
-// by pid). It returns the unique channelz tracking id assigned to this subchannel.
-func RegisterSubChannel(c Channel, pid int64, ref string) int64 {
-	if pid == 0 {
-		logger.Error("a SubChannel's parent id cannot be 0")
-		return 0
+// RegisterSubChannel registers the given subChannel c in the channelz database
+// with ref as its reference name, and adds it to the child list of its parent
+// (identified by pid).
+//
+// Returns a unique channelz identifier assigned to this subChannel.
+//
+// If channelz is not turned ON, this function is a no-op.
+func RegisterSubChannel(c Channel, pid *Identifier, ref string) (*Identifier, error) {
+	if !IsOn() {
+		return nil, nil
+	}
+
+	if pid == nil {
+		return nil, errors.New("a SubChannel's parent id cannot be nil")
 	}
 	id := idGen.genID()
 	sc := &subChannel{
@@ -221,16 +239,22 @@ func RegisterSubChannel(c Channel, pid int64, ref string) int64 {
 		c:       c,
 		sockets: make(map[int64]string),
 		id:      id,
-		pid:     pid,
+		pid:     pid.Int(),
 		trace:   &channelTrace{createdTime: time.Now(), events: make([]*TraceEvent, 0, getMaxTraceEntry())},
 	}
-	db.get().addSubChannel(id, sc, pid)
-	return id
+	db.get().addSubChannel(id, sc, pid.Int())
+	return newIdentifer(RefSubChannel, id, pid), nil
 }
 
 // RegisterServer registers the given server s in channelz database. It returns
 // the unique channelz tracking id assigned to this server.
-func RegisterServer(s Server, ref string) int64 {
+//
+// If channelz is not turned ON, this function is a no-op.
+func RegisterServer(s Server, ref string) *Identifier {
+	if !IsOn() {
+		return nil
+	}
+
 	id := idGen.genID()
 	svr := &server{
 		refName:       ref,
@@ -240,57 +264,76 @@ func RegisterServer(s Server, ref string) int64 {
 		id:            id,
 	}
 	db.get().addServer(id, svr)
-	return id
+	return newIdentifer(RefServer, id, nil)
 }
 
 // RegisterListenSocket registers the given listen socket s in channelz database
 // with ref as its reference name, and add it to the child list of its parent
 // (identified by pid). It returns the unique channelz tracking id assigned to
 // this listen socket.
-func RegisterListenSocket(s Socket, pid int64, ref string) int64 {
-	if pid == 0 {
-		logger.Error("a ListenSocket's parent id cannot be 0")
-		return 0
+//
+// If channelz is not turned ON, this function is a no-op.
+func RegisterListenSocket(s Socket, pid *Identifier, ref string) (*Identifier, error) {
+	if !IsOn() {
+		return nil, nil
+	}
+
+	if pid == nil {
+		return nil, errors.New("a ListenSocket's parent id cannot be 0")
 	}
 	id := idGen.genID()
-	ls := &listenSocket{refName: ref, s: s, id: id, pid: pid}
-	db.get().addListenSocket(id, ls, pid)
-	return id
+	ls := &listenSocket{refName: ref, s: s, id: id, pid: pid.Int()}
+	db.get().addListenSocket(id, ls, pid.Int())
+	return newIdentifer(RefListenSocket, id, pid), nil
 }
 
 // RegisterNormalSocket registers the given normal socket s in channelz database
-// with ref as its reference name, and add it to the child list of its parent
+// with ref as its reference name, and adds it to the child list of its parent
 // (identified by pid). It returns the unique channelz tracking id assigned to
 // this normal socket.
-func RegisterNormalSocket(s Socket, pid int64, ref string) int64 {
-	if pid == 0 {
-		logger.Error("a NormalSocket's parent id cannot be 0")
-		return 0
+//
+// If channelz is not turned ON, this function is a no-op.
+func RegisterNormalSocket(s Socket, pid *Identifier, ref string) (*Identifier, error) {
+	if !IsOn() {
+		return nil, nil
+	}
+
+	if pid == nil {
+		return nil, errors.New("a NormalSocket's parent id cannot be 0")
 	}
 	id := idGen.genID()
-	ns := &normalSocket{refName: ref, s: s, id: id, pid: pid}
-	db.get().addNormalSocket(id, ns, pid)
-	return id
+	ns := &normalSocket{refName: ref, s: s, id: id, pid: pid.Int()}
+	db.get().addNormalSocket(id, ns, pid.Int())
+	return newIdentifer(RefNormalSocket, id, pid), nil
 }
 
 // RemoveEntry removes an entry with unique channelz tracking id to be id from
 // channelz database.
-func RemoveEntry(id int64) {
-	db.get().removeEntry(id)
+//
+// If channelz is not turned ON, this function is a no-op.
+func RemoveEntry(id *Identifier) {
+	if !IsOn() {
+		return
+	}
+	db.get().removeEntry(id.Int())
 }
 
-// TraceEventDesc is what the caller of AddTraceEvent should provide to describe the event to be added
-// to the channel trace.
-// The Parent field is optional. It is used for event that will be recorded in the entity's parent
-// trace also.
+// TraceEventDesc is what the caller of AddTraceEvent should provide to describe
+// the event to be added to the channel trace.
+//
+// The Parent field is optional. It is used for an event that will be recorded
+// in the entity's parent trace.
 type TraceEventDesc struct {
 	Desc     string
 	Severity Severity
 	Parent   *TraceEventDesc
 }
 
-// AddTraceEvent adds trace related to the entity with specified id, using the provided TraceEventDesc.
-func AddTraceEvent(l grpclog.DepthLoggerV2, id int64, depth int, desc *TraceEventDesc) {
+// AddTraceEvent adds trace related to the entity with specified id, using the
+// provided TraceEventDesc.
+//
+// If channelz is not turned ON, this will simply log the event descriptions.
+func AddTraceEvent(l grpclog.DepthLoggerV2, id *Identifier, depth int, desc *TraceEventDesc) {
 	for d := desc; d != nil; d = d.Parent {
 		switch d.Severity {
 		case CtUnknown, CtInfo:
@@ -304,7 +347,9 @@ func AddTraceEvent(l grpclog.DepthLoggerV2, id int64, depth int, desc *TraceEven
 	if getMaxTraceEntry() == 0 {
 		return
 	}
-	db.get().traceEvent(id, desc)
+	if IsOn() {
+		db.get().traceEvent(id.Int(), desc)
+	}
 }
 
 // channelMap is the storage data structure for channelz.

--- a/internal/channelz/funcs.go
+++ b/internal/channelz/funcs.go
@@ -334,16 +334,16 @@ type TraceEventDesc struct {
 //
 // If channelz is not turned ON, this will simply log the event descriptions.
 func AddTraceEvent(l grpclog.DepthLoggerV2, id *Identifier, depth int, desc *TraceEventDesc) {
-	for d := desc; d != nil; d = d.Parent {
-		switch d.Severity {
-		case CtUnknown, CtInfo:
-			l.InfoDepth(depth+1, withParens(id)+d.Desc)
-		case CtWarning:
-			l.WarningDepth(depth+1, withParens(id)+d.Desc)
-		case CtError:
-			l.ErrorDepth(depth+1, withParens(id)+d.Desc)
-		}
+	// Log only the trace description associated with the bottom most entity.
+	switch desc.Severity {
+	case CtUnknown, CtInfo:
+		l.InfoDepth(depth+1, withParens(id)+desc.Desc)
+	case CtWarning:
+		l.WarningDepth(depth+1, withParens(id)+desc.Desc)
+	case CtError:
+		l.ErrorDepth(depth+1, withParens(id)+desc.Desc)
 	}
+
 	if getMaxTraceEntry() == 0 {
 		return
 	}

--- a/internal/channelz/funcs.go
+++ b/internal/channelz/funcs.go
@@ -194,7 +194,7 @@ func GetServer(id int64) *ServerMetric {
 // If channelz is not turned ON, the channelz database is not mutated.
 func RegisterChannel(c Channel, pid *Identifier, ref string) *Identifier {
 	id := idGen.genID()
-	parent := int64(0)
+	var parent int64
 	isTopChannel := true
 	if pid != nil {
 		isTopChannel = false

--- a/internal/channelz/funcs.go
+++ b/internal/channelz/funcs.go
@@ -337,11 +337,11 @@ func AddTraceEvent(l grpclog.DepthLoggerV2, id *Identifier, depth int, desc *Tra
 	for d := desc; d != nil; d = d.Parent {
 		switch d.Severity {
 		case CtUnknown, CtInfo:
-			l.InfoDepth(depth+1, d.Desc)
+			l.InfoDepth(depth+1, withParens(id)+d.Desc)
 		case CtWarning:
-			l.WarningDepth(depth+1, d.Desc)
+			l.WarningDepth(depth+1, withParens(id)+d.Desc)
 		case CtError:
-			l.ErrorDepth(depth+1, d.Desc)
+			l.ErrorDepth(depth+1, withParens(id)+d.Desc)
 		}
 	}
 	if getMaxTraceEntry() == 0 {

--- a/internal/channelz/id.go
+++ b/internal/channelz/id.go
@@ -31,30 +31,21 @@ type Identifier struct {
 
 // Type returns the entity type corresponding to id.
 func (id *Identifier) Type() RefChannelType {
-	if id == nil {
-		return RefUnknown
-	}
 	return id.typ
 }
 
 // Int returns the integer identifier corresponding to id.
 func (id *Identifier) Int() int64 {
-	if id == nil {
-		return 0
-	}
 	return id.id
 }
 
 // String returns a string representation of the entity corresponding to id.
-
+//
 // This includes some information about the parent as well. Examples:
 // Top-level channel: [Channel #channel-number]
 // Nested channel:    [Channel #parent-channel-number Channel #channel-number]
 // Sub channel:       [Channel #parent-channel SubChannel #subchannel-number]
 func (id *Identifier) String() string {
-	if id == nil {
-		return ""
-	}
 	return id.str
 }
 

--- a/internal/channelz/id.go
+++ b/internal/channelz/id.go
@@ -1,0 +1,84 @@
+/*
+ *
+ * Copyright 2022 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package channelz
+
+import "fmt"
+
+// Identifier is an opaque identifier which uniquely identifies an entity in the
+// channelz database.
+type Identifier struct {
+	typ RefChannelType
+	id  int64
+	str string
+	pid *Identifier
+}
+
+// Type returns the entity type corresponding to id.
+func (id *Identifier) Type() RefChannelType {
+	if id == nil {
+		return RefUnknown
+	}
+	return id.typ
+}
+
+// Int returns the integer identifier corresponding to id.
+func (id *Identifier) Int() int64 {
+	if id == nil {
+		return 0
+	}
+	return id.id
+}
+
+// String returns a string representation of the entity corresponding to id.
+
+// This includes some information about the parent as well. Examples:
+// Top-level channel: [Channel #channel-number]
+// Nested channel: 		[Channel #parent-channel-number Channel #channel-number]
+// Sub channel: 			[Channel #parent-channel SubChannel #subchannel-number]
+func (id *Identifier) String() string {
+	if id == nil {
+		return ""
+	}
+	return id.str
+}
+
+// Equal returns true if other is the same as id.
+func (id *Identifier) Equal(other *Identifier) bool {
+	if (id != nil) != (other != nil) {
+		return false
+	}
+	if id == nil && other == nil {
+		return true
+	}
+	return id.typ == other.typ && id.id == other.id && id.pid == other.pid
+}
+
+// NewIdentifierForTesting returns a new opaque identifier to be used only for
+// testing purposes.
+func NewIdentifierForTesting(typ RefChannelType, id int64, pid *Identifier) *Identifier {
+	return newIdentifer(typ, id, pid)
+}
+
+func newIdentifer(typ RefChannelType, id int64, pid *Identifier) *Identifier {
+	str := fmt.Sprintf("%s #%d", typ, id)
+	if pid != nil {
+		str = fmt.Sprintf("%s %s", pid, str)
+	}
+	return &Identifier{typ: typ, id: id, str: str, pid: pid}
+}

--- a/internal/channelz/id.go
+++ b/internal/channelz/id.go
@@ -49,8 +49,8 @@ func (id *Identifier) Int() int64 {
 
 // This includes some information about the parent as well. Examples:
 // Top-level channel: [Channel #channel-number]
-// Nested channel: 		[Channel #parent-channel-number Channel #channel-number]
-// Sub channel: 			[Channel #parent-channel SubChannel #subchannel-number]
+// Nested channel:    [Channel #parent-channel-number Channel #channel-number]
+// Sub channel:       [Channel #parent-channel SubChannel #subchannel-number]
 func (id *Identifier) String() string {
 	if id == nil {
 		return ""

--- a/internal/channelz/logging.go
+++ b/internal/channelz/logging.go
@@ -32,72 +32,48 @@ func withParens(id *Identifier) string {
 
 // Info logs and adds a trace event if channelz is on.
 func Info(l grpclog.DepthLoggerV2, id *Identifier, args ...interface{}) {
-	if IsOn() {
-		AddTraceEvent(l, id, 1, &TraceEventDesc{
-			Desc:     fmt.Sprint(args...),
-			Severity: CtInfo,
-		})
-	} else {
-		l.InfoDepth(1, withParens(id)+fmt.Sprint(args...))
-	}
+	AddTraceEvent(l, id, 1, &TraceEventDesc{
+		Desc:     fmt.Sprint(args...),
+		Severity: CtInfo,
+	})
 }
 
 // Infof logs and adds a trace event if channelz is on.
 func Infof(l grpclog.DepthLoggerV2, id *Identifier, format string, args ...interface{}) {
-	if IsOn() {
-		AddTraceEvent(l, id, 1, &TraceEventDesc{
-			Desc:     fmt.Sprintf(format, args...),
-			Severity: CtInfo,
-		})
-	} else {
-		l.InfoDepth(1, withParens(id)+fmt.Sprintf(format, args...))
-	}
+	AddTraceEvent(l, id, 1, &TraceEventDesc{
+		Desc:     fmt.Sprintf(format, args...),
+		Severity: CtInfo,
+	})
 }
 
 // Warning logs and adds a trace event if channelz is on.
 func Warning(l grpclog.DepthLoggerV2, id *Identifier, args ...interface{}) {
-	if IsOn() {
-		AddTraceEvent(l, id, 1, &TraceEventDesc{
-			Desc:     fmt.Sprint(args...),
-			Severity: CtWarning,
-		})
-	} else {
-		l.WarningDepth(1, withParens(id)+fmt.Sprint(args...))
-	}
+	AddTraceEvent(l, id, 1, &TraceEventDesc{
+		Desc:     fmt.Sprint(args...),
+		Severity: CtWarning,
+	})
 }
 
 // Warningf logs and adds a trace event if channelz is on.
 func Warningf(l grpclog.DepthLoggerV2, id *Identifier, format string, args ...interface{}) {
-	if IsOn() {
-		AddTraceEvent(l, id, 1, &TraceEventDesc{
-			Desc:     fmt.Sprintf(format, args...),
-			Severity: CtWarning,
-		})
-	} else {
-		l.WarningDepth(1, withParens(id)+fmt.Sprintf(format, args...))
-	}
+	AddTraceEvent(l, id, 1, &TraceEventDesc{
+		Desc:     fmt.Sprintf(format, args...),
+		Severity: CtWarning,
+	})
 }
 
 // Error logs and adds a trace event if channelz is on.
 func Error(l grpclog.DepthLoggerV2, id *Identifier, args ...interface{}) {
-	if IsOn() {
-		AddTraceEvent(l, id, 1, &TraceEventDesc{
-			Desc:     fmt.Sprint(args...),
-			Severity: CtError,
-		})
-	} else {
-		l.ErrorDepth(1, withParens(id)+fmt.Sprint(args...))
-	}
+	AddTraceEvent(l, id, 1, &TraceEventDesc{
+		Desc:     fmt.Sprint(args...),
+		Severity: CtError,
+	})
 }
 
 // Errorf logs and adds a trace event if channelz is on.
 func Errorf(l grpclog.DepthLoggerV2, id *Identifier, format string, args ...interface{}) {
-	if IsOn() {
-		AddTraceEvent(l, id, 1, &TraceEventDesc{
-			Desc:     fmt.Sprintf(format, args...),
-			Severity: CtError,
-		})
-	} else {
-		l.ErrorDepth(1, withParens(id)+fmt.Sprintf(format, args...))
-	}
+	AddTraceEvent(l, id, 1, &TraceEventDesc{
+		Desc:     fmt.Sprintf(format, args...),
+		Severity: CtError,
+	})
 }

--- a/internal/channelz/logging.go
+++ b/internal/channelz/logging.go
@@ -32,78 +32,72 @@ func withParens(id *Identifier) string {
 
 // Info logs and adds a trace event if channelz is on.
 func Info(l grpclog.DepthLoggerV2, id *Identifier, args ...interface{}) {
-	msg := withParens(id) + fmt.Sprint(args...)
 	if IsOn() {
 		AddTraceEvent(l, id, 1, &TraceEventDesc{
-			Desc:     msg,
+			Desc:     fmt.Sprint(args...),
 			Severity: CtInfo,
 		})
 	} else {
-		l.InfoDepth(1, msg)
+		l.InfoDepth(1, withParens(id)+fmt.Sprint(args...))
 	}
 }
 
 // Infof logs and adds a trace event if channelz is on.
 func Infof(l grpclog.DepthLoggerV2, id *Identifier, format string, args ...interface{}) {
-	msg := withParens(id) + fmt.Sprintf(format, args...)
 	if IsOn() {
 		AddTraceEvent(l, id, 1, &TraceEventDesc{
-			Desc:     msg,
+			Desc:     fmt.Sprintf(format, args...),
 			Severity: CtInfo,
 		})
 	} else {
-		l.InfoDepth(1, msg)
+		l.InfoDepth(1, withParens(id)+fmt.Sprintf(format, args...))
 	}
 }
 
 // Warning logs and adds a trace event if channelz is on.
 func Warning(l grpclog.DepthLoggerV2, id *Identifier, args ...interface{}) {
-	msg := withParens(id) + fmt.Sprint(args...)
 	if IsOn() {
 		AddTraceEvent(l, id, 1, &TraceEventDesc{
-			Desc:     msg,
+			Desc:     fmt.Sprint(args...),
 			Severity: CtWarning,
 		})
 	} else {
-		l.WarningDepth(1, msg)
+		l.WarningDepth(1, withParens(id)+fmt.Sprint(args...))
 	}
 }
 
 // Warningf logs and adds a trace event if channelz is on.
 func Warningf(l grpclog.DepthLoggerV2, id *Identifier, format string, args ...interface{}) {
-	msg := withParens(id) + fmt.Sprintf(format, args...)
 	if IsOn() {
 		AddTraceEvent(l, id, 1, &TraceEventDesc{
-			Desc:     msg,
+			Desc:     fmt.Sprintf(format, args...),
 			Severity: CtWarning,
 		})
 	} else {
-		l.WarningDepth(1, msg)
+		l.WarningDepth(1, withParens(id)+fmt.Sprintf(format, args...))
 	}
 }
 
 // Error logs and adds a trace event if channelz is on.
 func Error(l grpclog.DepthLoggerV2, id *Identifier, args ...interface{}) {
-	msg := withParens(id) + fmt.Sprint(args...)
 	if IsOn() {
 		AddTraceEvent(l, id, 1, &TraceEventDesc{
-			Desc:     msg,
+			Desc:     fmt.Sprint(args...),
 			Severity: CtError,
 		})
 	} else {
-		l.ErrorDepth(1, msg)
+		l.ErrorDepth(1, withParens(id)+fmt.Sprint(args...))
 	}
 }
 
 // Errorf logs and adds a trace event if channelz is on.
 func Errorf(l grpclog.DepthLoggerV2, id *Identifier, format string, args ...interface{}) {
-	msg := withParens(id) + fmt.Sprintf(format, args...)
 	if IsOn() {
 		AddTraceEvent(l, id, 1, &TraceEventDesc{
-			Desc:     msg,
+			Desc:     fmt.Sprintf(format, args...),
 			Severity: CtError,
 		})
 	} else {
-		l.ErrorDepth(1, msg)
+		l.ErrorDepth(1, withParens(id)+fmt.Sprintf(format, args...))
 	}
 }

--- a/internal/channelz/logging.go
+++ b/internal/channelz/logging.go
@@ -26,21 +26,26 @@ import (
 
 var logger = grpclog.Component("channelz")
 
+func withParens(id *Identifier) string {
+	return "[" + id.String() + "] "
+}
+
 // Info logs and adds a trace event if channelz is on.
-func Info(l grpclog.DepthLoggerV2, id int64, args ...interface{}) {
+func Info(l grpclog.DepthLoggerV2, id *Identifier, args ...interface{}) {
+	msg := withParens(id) + fmt.Sprint(args...)
 	if IsOn() {
 		AddTraceEvent(l, id, 1, &TraceEventDesc{
-			Desc:     fmt.Sprint(args...),
+			Desc:     msg,
 			Severity: CtInfo,
 		})
 	} else {
-		l.InfoDepth(1, args...)
+		l.InfoDepth(1, msg)
 	}
 }
 
 // Infof logs and adds a trace event if channelz is on.
-func Infof(l grpclog.DepthLoggerV2, id int64, format string, args ...interface{}) {
-	msg := fmt.Sprintf(format, args...)
+func Infof(l grpclog.DepthLoggerV2, id *Identifier, format string, args ...interface{}) {
+	msg := withParens(id) + fmt.Sprintf(format, args...)
 	if IsOn() {
 		AddTraceEvent(l, id, 1, &TraceEventDesc{
 			Desc:     msg,
@@ -52,20 +57,21 @@ func Infof(l grpclog.DepthLoggerV2, id int64, format string, args ...interface{}
 }
 
 // Warning logs and adds a trace event if channelz is on.
-func Warning(l grpclog.DepthLoggerV2, id int64, args ...interface{}) {
+func Warning(l grpclog.DepthLoggerV2, id *Identifier, args ...interface{}) {
+	msg := withParens(id) + fmt.Sprint(args...)
 	if IsOn() {
 		AddTraceEvent(l, id, 1, &TraceEventDesc{
-			Desc:     fmt.Sprint(args...),
+			Desc:     msg,
 			Severity: CtWarning,
 		})
 	} else {
-		l.WarningDepth(1, args...)
+		l.WarningDepth(1, msg)
 	}
 }
 
 // Warningf logs and adds a trace event if channelz is on.
-func Warningf(l grpclog.DepthLoggerV2, id int64, format string, args ...interface{}) {
-	msg := fmt.Sprintf(format, args...)
+func Warningf(l grpclog.DepthLoggerV2, id *Identifier, format string, args ...interface{}) {
+	msg := withParens(id) + fmt.Sprintf(format, args...)
 	if IsOn() {
 		AddTraceEvent(l, id, 1, &TraceEventDesc{
 			Desc:     msg,
@@ -77,20 +83,21 @@ func Warningf(l grpclog.DepthLoggerV2, id int64, format string, args ...interfac
 }
 
 // Error logs and adds a trace event if channelz is on.
-func Error(l grpclog.DepthLoggerV2, id int64, args ...interface{}) {
+func Error(l grpclog.DepthLoggerV2, id *Identifier, args ...interface{}) {
+	msg := withParens(id) + fmt.Sprint(args...)
 	if IsOn() {
 		AddTraceEvent(l, id, 1, &TraceEventDesc{
-			Desc:     fmt.Sprint(args...),
+			Desc:     msg,
 			Severity: CtError,
 		})
 	} else {
-		l.ErrorDepth(1, args...)
+		l.ErrorDepth(1, msg)
 	}
 }
 
 // Errorf logs and adds a trace event if channelz is on.
-func Errorf(l grpclog.DepthLoggerV2, id int64, format string, args ...interface{}) {
-	msg := fmt.Sprintf(format, args...)
+func Errorf(l grpclog.DepthLoggerV2, id *Identifier, format string, args ...interface{}) {
+	msg := withParens(id) + fmt.Sprintf(format, args...)
 	if IsOn() {
 		AddTraceEvent(l, id, 1, &TraceEventDesc{
 			Desc:     msg,

--- a/internal/channelz/types.go
+++ b/internal/channelz/types.go
@@ -696,7 +696,7 @@ const (
 	RefServer
 	// RefListenSocket indicates the referenced entity is a ListenSocket.
 	RefListenSocket
-	// RefNormalSocker indicates the referenced entity is a NormalSocket.
+	// RefNormalSocket indicates the referenced entity is a NormalSocket.
 	RefNormalSocket
 )
 

--- a/internal/channelz/types.go
+++ b/internal/channelz/types.go
@@ -686,11 +686,32 @@ const (
 type RefChannelType int
 
 const (
+	// RefUnknown indicates an unknown entity type, the zero value for this type.
+	RefUnknown RefChannelType = iota
 	// RefChannel indicates the referenced entity is a Channel.
-	RefChannel RefChannelType = iota
+	RefChannel
 	// RefSubChannel indicates the referenced entity is a SubChannel.
 	RefSubChannel
+	// RefServer indicates the referenced entity is a Server.
+	RefServer
+	// RefListenSocket indicates the referenced entity is a ListenSocket.
+	RefListenSocket
+	// RefNormalSocker indicates the referenced entity is a NormalSocket.
+	RefNormalSocket
 )
+
+var refChannelTypeToString = map[RefChannelType]string{
+	RefUnknown:      "Unknown",
+	RefChannel:      "Channel",
+	RefSubChannel:   "SubChannel",
+	RefServer:       "Server",
+	RefListenSocket: "ListenSocket",
+	RefNormalSocket: "NormalSocket",
+}
+
+func (r RefChannelType) String() string {
+	return refChannelTypeToString[r]
+}
 
 func (c *channelTrace) dumpData() *ChannelTrace {
 	c.mu.Lock()

--- a/internal/transport/keepalive_test.go
+++ b/internal/transport/keepalive_test.go
@@ -31,6 +31,7 @@ import (
 	"time"
 
 	"golang.org/x/net/http2"
+	"google.golang.org/grpc/internal/channelz"
 	"google.golang.org/grpc/internal/syscall"
 	"google.golang.org/grpc/keepalive"
 )
@@ -252,11 +253,15 @@ func (s) TestKeepaliveServerWithResponsiveClient(t *testing.T) {
 // logic is running even without any active streams.
 func (s) TestKeepaliveClientClosesUnresponsiveServer(t *testing.T) {
 	connCh := make(chan net.Conn, 1)
-	client, cancel := setUpWithNoPingServer(t, ConnectOptions{KeepaliveParams: keepalive.ClientParameters{
-		Time:                1 * time.Second,
-		Timeout:             1 * time.Second,
-		PermitWithoutStream: true,
-	}}, connCh)
+	copts := ConnectOptions{
+		ChannelzParentID: channelz.NewIdentifierForTesting(channelz.RefSubChannel, time.Now().Unix(), nil),
+		KeepaliveParams: keepalive.ClientParameters{
+			Time:                1 * time.Second,
+			Timeout:             1 * time.Second,
+			PermitWithoutStream: true,
+		},
+	}
+	client, cancel := setUpWithNoPingServer(t, copts, connCh)
 	defer cancel()
 	defer client.Close(fmt.Errorf("closed manually by test"))
 
@@ -284,10 +289,14 @@ func (s) TestKeepaliveClientClosesUnresponsiveServer(t *testing.T) {
 // active streams, and therefore the transport stays open.
 func (s) TestKeepaliveClientOpenWithUnresponsiveServer(t *testing.T) {
 	connCh := make(chan net.Conn, 1)
-	client, cancel := setUpWithNoPingServer(t, ConnectOptions{KeepaliveParams: keepalive.ClientParameters{
-		Time:    1 * time.Second,
-		Timeout: 1 * time.Second,
-	}}, connCh)
+	copts := ConnectOptions{
+		ChannelzParentID: channelz.NewIdentifierForTesting(channelz.RefSubChannel, time.Now().Unix(), nil),
+		KeepaliveParams: keepalive.ClientParameters{
+			Time:    1 * time.Second,
+			Timeout: 1 * time.Second,
+		},
+	}
+	client, cancel := setUpWithNoPingServer(t, copts, connCh)
 	defer cancel()
 	defer client.Close(fmt.Errorf("closed manually by test"))
 
@@ -313,10 +322,14 @@ func (s) TestKeepaliveClientOpenWithUnresponsiveServer(t *testing.T) {
 // transport even when there is an active stream.
 func (s) TestKeepaliveClientClosesWithActiveStreams(t *testing.T) {
 	connCh := make(chan net.Conn, 1)
-	client, cancel := setUpWithNoPingServer(t, ConnectOptions{KeepaliveParams: keepalive.ClientParameters{
-		Time:    1 * time.Second,
-		Timeout: 1 * time.Second,
-	}}, connCh)
+	copts := ConnectOptions{
+		ChannelzParentID: channelz.NewIdentifierForTesting(channelz.RefSubChannel, time.Now().Unix(), nil),
+		KeepaliveParams: keepalive.ClientParameters{
+			Time:    1 * time.Second,
+			Timeout: 1 * time.Second,
+		},
+	}
+	client, cancel := setUpWithNoPingServer(t, copts, connCh)
 	defer cancel()
 	defer client.Close(fmt.Errorf("closed manually by test"))
 

--- a/internal/transport/transport.go
+++ b/internal/transport/transport.go
@@ -34,6 +34,7 @@ import (
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/internal/channelz"
 	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/resolver"
@@ -529,7 +530,7 @@ type ServerConfig struct {
 	InitialConnWindowSize int32
 	WriteBufferSize       int
 	ReadBufferSize        int
-	ChannelzParentID      int64
+	ChannelzParentID      *channelz.Identifier
 	MaxHeaderListSize     *uint32
 	HeaderTableSize       *uint32
 }
@@ -563,7 +564,7 @@ type ConnectOptions struct {
 	// ReadBufferSize sets the size of read buffer, which in turn determines how much data can be read at most for one read syscall.
 	ReadBufferSize int
 	// ChannelzParentID sets the addrConn id which initiate the creation of this client transport.
-	ChannelzParentID int64
+	ChannelzParentID *channelz.Identifier
 	// MaxHeaderListSize sets the max (uncompressed) size of header list that is prepared to be received.
 	MaxHeaderListSize *uint32
 	// UseProxy specifies if a proxy should be used.

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -27,6 +27,7 @@ import (
 
 	"google.golang.org/grpc/attributes"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/internal/pretty"
 	"google.golang.org/grpc/serviceconfig"
 )
 
@@ -139,11 +140,16 @@ type Address struct {
 
 // Equal returns whether a and o are identical.  Metadata is compared directly,
 // not with any recursive introspection.
-func (a *Address) Equal(o Address) bool {
+func (a Address) Equal(o Address) bool {
 	return a.Addr == o.Addr && a.ServerName == o.ServerName &&
 		a.Attributes.Equal(o.Attributes) &&
 		a.BalancerAttributes.Equal(o.BalancerAttributes) &&
 		a.Type == o.Type && a.Metadata == o.Metadata
+}
+
+// String returns JSON formatted string representation of the address.
+func (a Address) String() string {
+	return pretty.ToJSON(a)
 }
 
 // BuildOptions includes additional information for the builder to create

--- a/resolver_conn_wrapper.go
+++ b/resolver_conn_wrapper.go
@@ -19,7 +19,6 @@
 package grpc
 
 import (
-	"fmt"
 	"strings"
 	"sync"
 
@@ -27,6 +26,7 @@ import (
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/internal/channelz"
 	"google.golang.org/grpc/internal/grpcsync"
+	"google.golang.org/grpc/internal/pretty"
 	"google.golang.org/grpc/resolver"
 	"google.golang.org/grpc/serviceconfig"
 )
@@ -97,10 +97,7 @@ func (ccr *ccResolverWrapper) UpdateState(s resolver.State) error {
 	if ccr.done.HasFired() {
 		return nil
 	}
-	channelz.Infof(logger, ccr.cc.channelzID, "ccResolverWrapper: sending update to cc: %v", s)
-	if channelz.IsOn() {
-		ccr.addChannelzTraceEvent(s)
-	}
+	ccr.addChannelzTraceEvent(s)
 	ccr.curState = s
 	if err := ccr.cc.updateResolverState(ccr.curState, nil); err == balancer.ErrBadResolverState {
 		return balancer.ErrBadResolverState
@@ -125,10 +122,7 @@ func (ccr *ccResolverWrapper) NewAddress(addrs []resolver.Address) {
 	if ccr.done.HasFired() {
 		return
 	}
-	channelz.Infof(logger, ccr.cc.channelzID, "ccResolverWrapper: sending new addresses to cc: %v", addrs)
-	if channelz.IsOn() {
-		ccr.addChannelzTraceEvent(resolver.State{Addresses: addrs, ServiceConfig: ccr.curState.ServiceConfig})
-	}
+	ccr.addChannelzTraceEvent(resolver.State{Addresses: addrs, ServiceConfig: ccr.curState.ServiceConfig})
 	ccr.curState.Addresses = addrs
 	ccr.cc.updateResolverState(ccr.curState, nil)
 }
@@ -141,7 +135,7 @@ func (ccr *ccResolverWrapper) NewServiceConfig(sc string) {
 	if ccr.done.HasFired() {
 		return
 	}
-	channelz.Infof(logger, ccr.cc.channelzID, "ccResolverWrapper: got new service config: %v", sc)
+	channelz.Infof(logger, ccr.cc.channelzID, "ccResolverWrapper: got new service config: %s", sc)
 	if ccr.cc.dopts.disableServiceConfig {
 		channelz.Info(logger, ccr.cc.channelzID, "Service config lookups disabled; ignoring config")
 		return
@@ -151,9 +145,7 @@ func (ccr *ccResolverWrapper) NewServiceConfig(sc string) {
 		channelz.Warningf(logger, ccr.cc.channelzID, "ccResolverWrapper: error parsing service config: %v", scpr.Err)
 		return
 	}
-	if channelz.IsOn() {
-		ccr.addChannelzTraceEvent(resolver.State{Addresses: ccr.curState.Addresses, ServiceConfig: scpr})
-	}
+	ccr.addChannelzTraceEvent(resolver.State{Addresses: ccr.curState.Addresses, ServiceConfig: scpr})
 	ccr.curState.ServiceConfig = scpr
 	ccr.cc.updateResolverState(ccr.curState, nil)
 }
@@ -180,8 +172,5 @@ func (ccr *ccResolverWrapper) addChannelzTraceEvent(s resolver.State) {
 	} else if len(ccr.curState.Addresses) == 0 && len(s.Addresses) > 0 {
 		updates = append(updates, "resolver returned new addresses")
 	}
-	channelz.AddTraceEvent(logger, ccr.cc.channelzID, 0, &channelz.TraceEventDesc{
-		Desc:     fmt.Sprintf("Resolver state updated: %+v (%v)", s, strings.Join(updates, "; ")),
-		Severity: channelz.CtInfo,
-	})
+	channelz.Infof(logger, ccr.cc.channelzID, "Resolver state updated: %s (%v)", pretty.ToJSON(s), strings.Join(updates, "; "))
 }

--- a/server.go
+++ b/server.go
@@ -755,15 +755,6 @@ func (s *Server) Serve(lis net.Listener) error {
 	ls := &listenSocket{Listener: lis}
 	s.lis[ls] = true
 
-	var err error
-	ls.channelzID, err = channelz.RegisterListenSocket(ls, s.channelzID, lis.Addr().String())
-	if err != nil {
-		s.mu.Unlock()
-		lis.Close()
-		return err
-	}
-	s.mu.Unlock()
-
 	defer func() {
 		s.mu.Lock()
 		if s.lis != nil && s.lis[ls] {
@@ -772,6 +763,14 @@ func (s *Server) Serve(lis net.Listener) error {
 		}
 		s.mu.Unlock()
 	}()
+
+	var err error
+	ls.channelzID, err = channelz.RegisterListenSocket(ls, s.channelzID, lis.Addr().String())
+	if err != nil {
+		s.mu.Unlock()
+		return err
+	}
+	s.mu.Unlock()
 
 	var tempDelay time.Duration // how long to sleep on accept failure
 	for {

--- a/server.go
+++ b/server.go
@@ -585,6 +585,7 @@ func NewServer(opt ...ServerOption) *Server {
 	}
 
 	s.channelzID = channelz.RegisterServer(&channelzServer{s}, "")
+	channelz.Info(logger, s.channelzID, "Server created")
 	return s
 }
 
@@ -723,6 +724,7 @@ func (l *listenSocket) ChannelzMetric() *channelz.SocketInternalMetric {
 func (l *listenSocket) Close() error {
 	err := l.Listener.Close()
 	channelz.RemoveEntry(l.channelzID)
+	channelz.Info(logger, l.channelzID, "ListenSocket deleted")
 	return err
 }
 
@@ -771,6 +773,7 @@ func (s *Server) Serve(lis net.Listener) error {
 		return err
 	}
 	s.mu.Unlock()
+	channelz.Info(logger, ls.channelzID, "ListenSocket created")
 
 	var tempDelay time.Duration // how long to sleep on accept failure
 	for {

--- a/test/channelz_test.go
+++ b/test/channelz_test.go
@@ -23,12 +23,13 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net"
-	"reflect"
+	"regexp"
 	"strings"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"golang.org/x/net/http2"
 	"google.golang.org/grpc"
 	_ "google.golang.org/grpc/balancer/grpclb"
@@ -455,11 +456,11 @@ func (s) TestCZRecusivelyDeletionOfEntry(t *testing.T) {
 	// Socket1       Socket2
 	czCleanup := channelz.NewChannelzStorageForTesting()
 	defer czCleanupWrapper(czCleanup, t)
-	topChanID := channelz.RegisterChannel(&dummyChannel{}, 0, "")
-	subChanID1 := channelz.RegisterSubChannel(&dummyChannel{}, topChanID, "")
-	subChanID2 := channelz.RegisterSubChannel(&dummyChannel{}, topChanID, "")
-	sktID1 := channelz.RegisterNormalSocket(&dummySocket{}, subChanID1, "")
-	sktID2 := channelz.RegisterNormalSocket(&dummySocket{}, subChanID1, "")
+	topChanID := channelz.RegisterChannel(&dummyChannel{}, nil, "")
+	subChanID1, _ := channelz.RegisterSubChannel(&dummyChannel{}, topChanID, "")
+	subChanID2, _ := channelz.RegisterSubChannel(&dummyChannel{}, topChanID, "")
+	sktID1, _ := channelz.RegisterNormalSocket(&dummySocket{}, subChanID1, "")
+	sktID2, _ := channelz.RegisterNormalSocket(&dummySocket{}, subChanID1, "")
 
 	tcs, _ := channelz.GetTopChannels(0, 0)
 	if tcs == nil || len(tcs) != 1 {
@@ -468,7 +469,7 @@ func (s) TestCZRecusivelyDeletionOfEntry(t *testing.T) {
 	if len(tcs[0].SubChans) != 2 {
 		t.Fatalf("There should be two SubChannel entries")
 	}
-	sc := channelz.GetSubChannel(subChanID1)
+	sc := channelz.GetSubChannel(subChanID1.Int())
 	if sc == nil || len(sc.Sockets) != 2 {
 		t.Fatalf("There should be two Socket entries")
 	}
@@ -1380,7 +1381,7 @@ func (s) TestCZSocketGetSecurityValueTLS(t *testing.T) {
 		if !ok {
 			return false, fmt.Errorf("the SocketData.Security is of type: %T, want: *credentials.TLSChannelzSecurityValue", skt.SocketData.Security)
 		}
-		if !reflect.DeepEqual(securityVal.RemoteCertificate, cert.Certificate[0]) {
+		if !cmp.Equal(securityVal.RemoteCertificate, cert.Certificate[0]) {
 			return false, fmt.Errorf("SocketData.Security.RemoteCertificate got: %v, want: %v", securityVal.RemoteCertificate, cert.Certificate[0])
 		}
 		for _, v := range cipherSuites {
@@ -1397,6 +1398,7 @@ func (s) TestCZSocketGetSecurityValueTLS(t *testing.T) {
 func (s) TestCZChannelTraceCreationDeletion(t *testing.T) {
 	czCleanup := channelz.NewChannelzStorageForTesting()
 	defer czCleanupWrapper(czCleanup, t)
+
 	e := tcpClearRREnv
 	// avoid calling API to set balancer type, which will void service config's change of balancer.
 	e.balancer = ""
@@ -1407,6 +1409,7 @@ func (s) TestCZChannelTraceCreationDeletion(t *testing.T) {
 	te.resolverScheme = r.Scheme()
 	te.clientConn(grpc.WithResolvers(r))
 	defer te.tearDown()
+
 	var nestedConn int64
 	if err := verifyResultWithDelay(func() (bool, error) {
 		tcs, _ := channelz.GetTopChannels(0, 0)
@@ -1431,8 +1434,9 @@ func (s) TestCZChannelTraceCreationDeletion(t *testing.T) {
 		if len(ncm.Trace.Events) == 0 {
 			return false, fmt.Errorf("there should be at least one trace event for nested channel not 0")
 		}
-		if ncm.Trace.Events[0].Desc != "Channel Created" {
-			return false, fmt.Errorf("the first trace event should be \"Channel Created\", not %q", ncm.Trace.Events[0].Desc)
+		pattern := `Channel\(id:[0-9]+\) created`
+		if ok, _ := regexp.MatchString(pattern, ncm.Trace.Events[0].Desc); !ok {
+			return false, fmt.Errorf("the first trace event should be %q, not %q", pattern, ncm.Trace.Events[0].Desc)
 		}
 		return true, nil
 	}); err != nil {
@@ -1460,8 +1464,9 @@ func (s) TestCZChannelTraceCreationDeletion(t *testing.T) {
 		if len(ncm.Trace.Events) == 0 {
 			return false, fmt.Errorf("there should be at least one trace event for nested channel not 0")
 		}
-		if ncm.Trace.Events[len(ncm.Trace.Events)-1].Desc != "Channel Deleted" {
-			return false, fmt.Errorf("the first trace event should be \"Channel Deleted\", not %q", ncm.Trace.Events[0].Desc)
+		pattern := `Channel\(id:[0-9]+\) created`
+		if ok, _ := regexp.MatchString(pattern, ncm.Trace.Events[0].Desc); !ok {
+			return false, fmt.Errorf("the first trace event should be %q, not %q", pattern, ncm.Trace.Events[0].Desc)
 		}
 		return true, nil
 	}); err != nil {
@@ -1509,8 +1514,9 @@ func (s) TestCZSubChannelTraceCreationDeletion(t *testing.T) {
 		if len(scm.Trace.Events) == 0 {
 			return false, fmt.Errorf("there should be at least one trace event for subChannel not 0")
 		}
-		if scm.Trace.Events[0].Desc != "Subchannel Created" {
-			return false, fmt.Errorf("the first trace event should be \"Subchannel Created\", not %q", scm.Trace.Events[0].Desc)
+		pattern := `Subchannel\(id:[0-9]+\) created`
+		if ok, _ := regexp.MatchString(pattern, scm.Trace.Events[0].Desc); !ok {
+			return false, fmt.Errorf("the first trace event should be %q, not %q", pattern, scm.Trace.Events[0].Desc)
 		}
 		return true, nil
 	}); err != nil {
@@ -1551,10 +1557,12 @@ func (s) TestCZSubChannelTraceCreationDeletion(t *testing.T) {
 		if len(scm.Trace.Events) == 0 {
 			return false, fmt.Errorf("there should be at least one trace event for subChannel not 0")
 		}
-		if got, want := scm.Trace.Events[len(scm.Trace.Events)-1].Desc, "Subchannel Deleted"; got != want {
-			return false, fmt.Errorf("the last trace event should be %q, not %q", want, got)
-		}
 
+		pattern := `Subchannel\(id:[0-9]+\) deleted`
+		desc := scm.Trace.Events[len(scm.Trace.Events)-1].Desc
+		if ok, _ := regexp.MatchString(pattern, desc); !ok {
+			return false, fmt.Errorf("the last trace event should be %q, not %q", pattern, desc)
+		}
 		return true, nil
 	}); err != nil {
 		t.Fatal(err)
@@ -1600,7 +1608,7 @@ func (s) TestCZChannelAddressResolutionChange(t *testing.T) {
 	if err := verifyResultWithDelay(func() (bool, error) {
 		cm := channelz.GetChannel(cid)
 		for i := len(cm.Trace.Events) - 1; i >= 0; i-- {
-			if cm.Trace.Events[i].Desc == fmt.Sprintf("Channel switches to new LB policy %q", roundrobin.Name) {
+			if strings.Contains(cm.Trace.Events[i].Desc, fmt.Sprintf("Channel switches to new LB policy %q", roundrobin.Name)) {
 				break
 			}
 			if i == 0 {
@@ -1725,7 +1733,7 @@ func (s) TestCZSubChannelPickedNewAddress(t *testing.T) {
 			return false, fmt.Errorf("there should be at least one trace event for subChannel not 0")
 		}
 		for i := len(scm.Trace.Events) - 1; i >= 0; i-- {
-			if scm.Trace.Events[i].Desc == fmt.Sprintf("Subchannel picks a new address %q to connect", te.srvAddrs[2]) {
+			if strings.Contains(scm.Trace.Events[i].Desc, fmt.Sprintf("Subchannel picks a new address %q to connect", te.srvAddrs[2])) {
 				break
 			}
 			if i == 0 {
@@ -1756,9 +1764,9 @@ func (s) TestCZSubChannelConnectivityState(t *testing.T) {
 	if _, err := tc.EmptyCall(ctx, &testpb.Empty{}); err != nil {
 		t.Fatalf("TestService/EmptyCall(_, _) = _, %v, want _, <nil>", err)
 	}
-	var subConn int64
 	te.srv.Stop()
 
+	var subConn int64
 	if err := verifyResultWithDelay(func() (bool, error) {
 		// we need to obtain the SubChannel id before it gets deleted from Channel's children list (due
 		// to effect of r.UpdateState(resolver.State{Addresses:[]resolver.Address{}}))
@@ -1773,6 +1781,7 @@ func (s) TestCZSubChannelConnectivityState(t *testing.T) {
 			for k := range tcs[0].SubChans {
 				// get the SubChannel id for further trace inquiry.
 				subConn = k
+				t.Logf("SubChannel Id is %d", subConn)
 			}
 		}
 		scm := channelz.GetSubChannel(subConn)
@@ -1786,8 +1795,10 @@ func (s) TestCZSubChannelConnectivityState(t *testing.T) {
 			return false, fmt.Errorf("there should be at least one trace event for subChannel not 0")
 		}
 		var ready, connecting, transient, shutdown int
+		t.Log("SubChannel trace events seen so far...")
 		for _, e := range scm.Trace.Events {
-			if e.Desc == fmt.Sprintf("Subchannel Connectivity change to %v", connectivity.TransientFailure) {
+			t.Log(e.Desc)
+			if strings.Contains(e.Desc, fmt.Sprintf("Subchannel Connectivity change to %v", connectivity.TransientFailure)) {
 				transient++
 			}
 		}
@@ -1798,17 +1809,19 @@ func (s) TestCZSubChannelConnectivityState(t *testing.T) {
 		}
 		transient = 0
 		r.UpdateState(resolver.State{Addresses: []resolver.Address{{Addr: "fake address"}}})
+		t.Log("SubChannel trace events seen so far...")
 		for _, e := range scm.Trace.Events {
-			if e.Desc == fmt.Sprintf("Subchannel Connectivity change to %v", connectivity.Ready) {
+			t.Log(e.Desc)
+			if strings.Contains(e.Desc, fmt.Sprintf("Subchannel Connectivity change to %v", connectivity.Ready)) {
 				ready++
 			}
-			if e.Desc == fmt.Sprintf("Subchannel Connectivity change to %v", connectivity.Connecting) {
+			if strings.Contains(e.Desc, fmt.Sprintf("Subchannel Connectivity change to %v", connectivity.Connecting)) {
 				connecting++
 			}
-			if e.Desc == fmt.Sprintf("Subchannel Connectivity change to %v", connectivity.TransientFailure) {
+			if strings.Contains(e.Desc, fmt.Sprintf("Subchannel Connectivity change to %v", connectivity.TransientFailure)) {
 				transient++
 			}
-			if e.Desc == fmt.Sprintf("Subchannel Connectivity change to %v", connectivity.Shutdown) {
+			if strings.Contains(e.Desc, fmt.Sprintf("Subchannel Connectivity change to %v", connectivity.Shutdown)) {
 				shutdown++
 			}
 		}
@@ -1851,6 +1864,7 @@ func (s) TestCZChannelConnectivityState(t *testing.T) {
 		t.Fatalf("TestService/EmptyCall(_, _) = _, %v, want _, <nil>", err)
 	}
 	te.srv.Stop()
+
 	if err := verifyResultWithDelay(func() (bool, error) {
 		tcs, _ := channelz.GetTopChannels(0, 0)
 		if len(tcs) != 1 {
@@ -1858,14 +1872,16 @@ func (s) TestCZChannelConnectivityState(t *testing.T) {
 		}
 
 		var ready, connecting, transient int
+		t.Log("Channel trace events seen so far...")
 		for _, e := range tcs[0].Trace.Events {
-			if e.Desc == fmt.Sprintf("Channel Connectivity change to %v", connectivity.Ready) {
+			t.Log(e.Desc)
+			if strings.Contains(e.Desc, fmt.Sprintf("Channel Connectivity change to %v", connectivity.Ready)) {
 				ready++
 			}
-			if e.Desc == fmt.Sprintf("Channel Connectivity change to %v", connectivity.Connecting) {
+			if strings.Contains(e.Desc, fmt.Sprintf("Channel Connectivity change to %v", connectivity.Connecting)) {
 				connecting++
 			}
-			if e.Desc == fmt.Sprintf("Channel Connectivity change to %v", connectivity.TransientFailure) {
+			if strings.Contains(e.Desc, fmt.Sprintf("Channel Connectivity change to %v", connectivity.TransientFailure)) {
 				transient++
 			}
 		}

--- a/test/channelz_test.go
+++ b/test/channelz_test.go
@@ -1434,7 +1434,7 @@ func (s) TestCZChannelTraceCreationDeletion(t *testing.T) {
 		if len(ncm.Trace.Events) == 0 {
 			return false, fmt.Errorf("there should be at least one trace event for nested channel not 0")
 		}
-		pattern := `Channel\(id:[0-9]+\) created`
+		pattern := `Channel created`
 		if ok, _ := regexp.MatchString(pattern, ncm.Trace.Events[0].Desc); !ok {
 			return false, fmt.Errorf("the first trace event should be %q, not %q", pattern, ncm.Trace.Events[0].Desc)
 		}
@@ -1464,7 +1464,7 @@ func (s) TestCZChannelTraceCreationDeletion(t *testing.T) {
 		if len(ncm.Trace.Events) == 0 {
 			return false, fmt.Errorf("there should be at least one trace event for nested channel not 0")
 		}
-		pattern := `Channel\(id:[0-9]+\) created`
+		pattern := `Channel created`
 		if ok, _ := regexp.MatchString(pattern, ncm.Trace.Events[0].Desc); !ok {
 			return false, fmt.Errorf("the first trace event should be %q, not %q", pattern, ncm.Trace.Events[0].Desc)
 		}
@@ -1514,7 +1514,7 @@ func (s) TestCZSubChannelTraceCreationDeletion(t *testing.T) {
 		if len(scm.Trace.Events) == 0 {
 			return false, fmt.Errorf("there should be at least one trace event for subChannel not 0")
 		}
-		pattern := `Subchannel\(id:[0-9]+\) created`
+		pattern := `Subchannel created`
 		if ok, _ := regexp.MatchString(pattern, scm.Trace.Events[0].Desc); !ok {
 			return false, fmt.Errorf("the first trace event should be %q, not %q", pattern, scm.Trace.Events[0].Desc)
 		}
@@ -1558,7 +1558,7 @@ func (s) TestCZSubChannelTraceCreationDeletion(t *testing.T) {
 			return false, fmt.Errorf("there should be at least one trace event for subChannel not 0")
 		}
 
-		pattern := `Subchannel\(id:[0-9]+\) deleted`
+		pattern := `Subchannel deleted`
 		desc := scm.Trace.Events[len(scm.Trace.Events)-1].Desc
 		if ok, _ := regexp.MatchString(pattern, desc); !ok {
 			return false, fmt.Errorf("the last trace event should be %q, not %q", pattern, desc)

--- a/xds/internal/balancer/clustermanager/clustermanager_test.go
+++ b/xds/internal/balancer/clustermanager/clustermanager_test.go
@@ -32,6 +32,7 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/internal/balancer/stub"
 	"google.golang.org/grpc/internal/balancergroup"
+	"google.golang.org/grpc/internal/channelz"
 	"google.golang.org/grpc/internal/grpctest"
 	"google.golang.org/grpc/internal/hierarchy"
 	"google.golang.org/grpc/internal/testutils"
@@ -516,7 +517,6 @@ func TestRoutingConfigUpdateDeleteAll(t *testing.T) {
 func TestClusterManagerForwardsBalancerBuildOptions(t *testing.T) {
 	const (
 		balancerName       = "stubBalancer-TestClusterManagerForwardsBalancerBuildOptions"
-		parent             = int64(1234)
 		userAgent          = "ua"
 		defaultTestTimeout = 1 * time.Second
 	)
@@ -526,7 +526,7 @@ func TestClusterManagerForwardsBalancerBuildOptions(t *testing.T) {
 	ccsCh := testutils.NewChannel()
 	bOpts := balancer.BuildOptions{
 		DialCreds:        insecure.NewCredentials(),
-		ChannelzParentID: parent,
+		ChannelzParentID: channelz.NewIdentifierForTesting(channelz.RefChannel, 1234, nil),
 		CustomUserAgent:  userAgent,
 	}
 	stub.Register(balancerName, stub.BalancerFuncs{


### PR DESCRIPTION
Summary of changes:
- channelz package
  - Define an opaque `Identifier` to uniquely identify entities in the channelz database.
    - This type will be returned from `RegisterXxx` functions and will be accepted by log/trace functions.
  - Make `RegisterXxx` and `RemoveEntry` functions work gracefully when channelz is not turned ON. 
  - logging functions will prefix channel identifiers to all log messages
- Change the `WithChannelzParentID` dialoption to accept a `*channelz.Identifier`.
- Change `ChannelzParentID` field in balancer.BuildOptions to be of type `*channelz.Identifier`.
- Define a type alias in the external channelz package pointing to the identifier type defined in internal channelz package. This is required since the channelz identifier can be specified through a `DialOption` and through `balancer.BuildOptions`.
- Cleanup some channelz tests.

RELEASE NOTES: 
- TBD