### PR TITLE
xds: minor cleanup in xdsclient bootstrap code

### DIFF
--- a/internal/envconfig/xds.go
+++ b/internal/envconfig/xds.go
@@ -26,13 +26,13 @@ import (
 const (
 	// XDSBootstrapFileNameEnv is the env variable to set bootstrap file name.
 	// Do not use this and read from env directly. Its value is read and kept in
-	// variable BootstrapFileName.
+	// variable XDSBootstrapFileName.
 	//
 	// When both bootstrap FileName and FileContent are set, FileName is used.
 	XDSBootstrapFileNameEnv = "GRPC_XDS_BOOTSTRAP"
-	// XDSBootstrapFileContentEnv is the env variable to set bootstrapp file
+	// XDSBootstrapFileContentEnv is the env variable to set bootstrap file
 	// content. Do not use this and read from env directly. Its value is read
-	// and kept in variable BootstrapFileName.
+	// and kept in variable XDSBootstrapFileContent.
 	//
 	// When both bootstrap FileName and FileContent are set, FileName is used.
 	XDSBootstrapFileContentEnv = "GRPC_XDS_BOOTSTRAP_CONFIG"

--- a/xds/internal/resolver/xds_resolver.go
+++ b/xds/internal/resolver/xds_resolver.go
@@ -37,13 +37,13 @@ import (
 
 const xdsScheme = "xds"
 
-// NewBuilder creates a new xds resolver builder using a specific xds bootstrap
-// config, so tests can use multiple xds clients in different ClientConns at
-// the same time.
-func NewBuilder(config []byte) (resolver.Builder, error) {
+// NewBuilderForTesting creates a new xds resolver builder using a specific xds
+// bootstrap config, so tests can use multiple xds clients in different
+// ClientConns at the same time.
+func NewBuilderForTesting(config []byte) (resolver.Builder, error) {
 	return &xdsResolverBuilder{
 		newXDSClient: func() (xdsclient.XDSClient, error) {
-			return xdsclient.NewClientWithBootstrapContents(config)
+			return xdsclient.NewWithBootstrapContentsForTesting(config)
 		},
 	}, nil
 }

--- a/xds/internal/xdsclient/singleton.go
+++ b/xds/internal/xdsclient/singleton.go
@@ -160,10 +160,10 @@ func (c *clientRefCounted) Close() {
 	}
 }
 
-// NewWithConfigForTesting is exported for testing only.
+// NewWithConfigForTesting returns an xdsClient for the specified bootstrap
+// config, separate from the global singleton.
 //
-// Note that this function doesn't set the singleton, so that the testing states
-// don't leak.
+// This should be used for testing purposes only.
 func NewWithConfigForTesting(config *bootstrap.Config, watchExpiryTimeout time.Duration) (XDSClient, error) {
 	cl, err := newWithConfig(config, watchExpiryTimeout, defaultIdleAuthorityDeleteTimeout)
 	if err != nil {
@@ -172,10 +172,11 @@ func NewWithConfigForTesting(config *bootstrap.Config, watchExpiryTimeout time.D
 	return &clientRefCounted{clientImpl: cl, refCount: 1}, nil
 }
 
-// NewClientWithBootstrapContents returns an xds client for this config,
-// separate from the global singleton.  This should be used for testing
-// purposes only.
-func NewClientWithBootstrapContents(contents []byte) (XDSClient, error) {
+// NewWithBootstrapContentsForTesting returns an xdsClient for this config,
+// separate from the global singleton.
+//
+// This should be used for testing purposes only.
+func NewWithBootstrapContentsForTesting(contents []byte) (XDSClient, error) {
 	// Normalize the contents
 	buf := bytes.Buffer{}
 	err := json.Indent(&buf, contents, "", "")
@@ -198,7 +199,7 @@ func NewClientWithBootstrapContents(contents []byte) (XDSClient, error) {
 		c.mu.Unlock()
 	}
 
-	bcfg, err := bootstrap.NewConfigFromContents(contents)
+	bcfg, err := bootstrap.NewConfigFromContentsForTesting(contents)
 	if err != nil {
 		return nil, fmt.Errorf("xds: error with bootstrap config: %v", err)
 	}

--- a/xds/server.go
+++ b/xds/server.go
@@ -161,11 +161,13 @@ func (s *GRPCServer) initXDSClient() error {
 	}
 
 	newXDSClient := newXDSClient
-	if s.opts.bootstrapContents != nil {
+	if s.opts.bootstrapContentsForTesting != nil {
+		// Bootstrap file contents may be specified as a server option for tests.
 		newXDSClient = func() (xdsclient.XDSClient, error) {
-			return xdsclient.NewClientWithBootstrapContents(s.opts.bootstrapContents)
+			return xdsclient.NewWithBootstrapContentsForTesting(s.opts.bootstrapContentsForTesting)
 		}
 	}
+
 	client, err := newXDSClient()
 	if err != nil {
 		return fmt.Errorf("xds: failed to create xds-client: %v", err)

--- a/xds/server_options.go
+++ b/xds/server_options.go
@@ -26,8 +26,8 @@ import (
 )
 
 type serverOptions struct {
-	modeCallback      ServingModeCallbackFunc
-	bootstrapContents []byte
+	modeCallback                ServingModeCallbackFunc
+	bootstrapContentsForTesting []byte
 }
 
 type serverOption struct {
@@ -72,5 +72,5 @@ type ServingModeChangeArgs struct {
 // Notice: This API is EXPERIMENTAL and may be changed or removed in a
 // later release.
 func BootstrapContentsForTesting(contents []byte) grpc.ServerOption {
-	return &serverOption{apply: func(o *serverOptions) { o.bootstrapContents = contents }}
+	return &serverOption{apply: func(o *serverOptions) { o.bootstrapContentsForTesting = contents }}
 }

--- a/xds/xds.go
+++ b/xds/xds.go
@@ -90,5 +90,5 @@ func init() {
 // Notice: This API is EXPERIMENTAL and may be changed or removed in a
 // later release.
 func NewXDSResolverWithConfigForTesting(bootstrapConfig []byte) (resolver.Builder, error) {
-	return xdsresolver.NewBuilder(bootstrapConfig)
+	return xdsresolver.NewBuilderForTesting(bootstrapConfig)
 }


### PR DESCRIPTION
Summary of changes:
- Make testing only functions more explicit by using `ForTesting` suffix in their name
- Make a testing only server option explicit by using the `ForTesting` suffix in its name
- Clarify some comments, fix typos etc

RELEASE NOTES: none