### PR TITLE
reflection: improve server implementation

### DIFF
--- a/reflection/serverreflection.go
+++ b/reflection/serverreflection.go
@@ -54,7 +54,14 @@ import (
 // services to expose.
 //
 // The reflection service is only interested in the service names, but the
-// signature is this way so that *grpc.Server implements it.
+// signature is this way so that *grpc.Server implements it. So it is okay
+// for a custom implementation to return zero values for the
+// grpc.ServiceInfo values in the map.
+//
+// Experimental
+//
+// Notice: This type is EXPERIMENTAL and may be changed or removed in a
+// later release.
 type ServiceInfoProvider interface {
 	GetServiceInfo() map[string]grpc.ServiceInfo
 }
@@ -69,6 +76,11 @@ type GRPCServer interface {
 
 // ExtensionResolver is the interface used to query details about extensions.
 // This interface is satisfied by protoregistry.GlobalTypes.
+//
+// Experimental
+//
+// Notice: This type is EXPERIMENTAL and may be changed or removed in a
+// later release.
 type ExtensionResolver interface {
 	protoregistry.ExtensionTypeResolver
 	RangeExtensionsByMessage(message protoreflect.FullName, f func(protoreflect.ExtensionType) bool)
@@ -96,8 +108,6 @@ type ServerOptions struct {
 	// This value will typically be a *grpc.Server. But the set of advertised
 	// services can be customized by wrapping a *grpc.Server or using an
 	// alternate implementation that returns a custom set of service names.
-	// It is okay for a custom implementation to return zero values for the
-	// grpc.ServiceInfo values in the map.
 	Services ServiceInfoProvider
 	// Optional resolver used to load descriptors. If not specified,
 	// protoregistry.GlobalFiles will be used.

--- a/reflection/serverreflection_test.go
+++ b/reflection/serverreflection_test.go
@@ -131,7 +131,7 @@ func (x) TestFileDescContainingExtension(t *testing.T) {
 		{"grpc.testing.ToBeExtended", 23, fdProto2Ext2},
 		{"grpc.testing.ToBeExtended", 29, fdProto2Ext2},
 	} {
-		fd, err := s.fileDescEncodingContainingExtension(test.st, test.extNum, map[string]struct{}{})
+		fd, err := s.fileDescEncodingContainingExtension(test.st, test.extNum, map[string]bool{})
 		if err != nil {
 			t.Errorf("fileDescContainingExtension(%q) return error: %v", test.st, err)
 			continue

--- a/reflection/serverreflection_test.go
+++ b/reflection/serverreflection_test.go
@@ -42,7 +42,7 @@ import (
 )
 
 var (
-	s *serverReflectionServer
+	s = NewServer(ServerOptions{}).(*serverReflectionServer)
 	// fileDescriptor of each test proto file.
 	fdTest       *descriptorpb.FileDescriptorProto
 	fdTestv3     *descriptorpb.FileDescriptorProto
@@ -60,14 +60,6 @@ var (
 	fdProto2Ext2Byte []byte
 	fdDynamicByte    []byte
 )
-
-func init() {
-	svr, err := NewServer(ServerOptions{})
-	if err != nil {
-		panic(err)
-	}
-	s = svr.(*serverReflectionServer)
-}
 
 const defaultTestTimeout = 10 * time.Second
 

--- a/reflection/serverreflection_test.go
+++ b/reflection/serverreflection_test.go
@@ -27,14 +27,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/protobuf/proto"
-	dpb "github.com/golang/protobuf/protoc-gen-go/descriptor"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/internal/grpctest"
 	rpb "google.golang.org/grpc/reflection/grpc_reflection_v1alpha"
 	pb "google.golang.org/grpc/reflection/grpc_testing"
 	pbv3 "google.golang.org/grpc/reflection/grpc_testing_not_regenerate"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protodesc"
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/reflect/protoregistry"
@@ -43,14 +42,14 @@ import (
 )
 
 var (
-	s = &serverReflectionServer{}
+	s *serverReflectionServer
 	// fileDescriptor of each test proto file.
-	fdTest       *dpb.FileDescriptorProto
-	fdTestv3     *dpb.FileDescriptorProto
-	fdProto2     *dpb.FileDescriptorProto
-	fdProto2Ext  *dpb.FileDescriptorProto
-	fdProto2Ext2 *dpb.FileDescriptorProto
-	fdDynamic    *dpb.FileDescriptorProto
+	fdTest       *descriptorpb.FileDescriptorProto
+	fdTestv3     *descriptorpb.FileDescriptorProto
+	fdProto2     *descriptorpb.FileDescriptorProto
+	fdProto2Ext  *descriptorpb.FileDescriptorProto
+	fdProto2Ext2 *descriptorpb.FileDescriptorProto
+	fdDynamic    *descriptorpb.FileDescriptorProto
 	// reflection descriptors.
 	fdDynamicFile protoreflect.FileDescriptor
 	// fileDescriptor marshalled.
@@ -62,6 +61,14 @@ var (
 	fdDynamicByte    []byte
 )
 
+func init() {
+	svr, err := NewServer(ServerOptions{})
+	if err != nil {
+		panic(err)
+	}
+	s = svr.(*serverReflectionServer)
+}
+
 const defaultTestTimeout = 10 * time.Second
 
 type x struct {
@@ -72,23 +79,20 @@ func Test(t *testing.T) {
 	grpctest.RunSubTests(t, x{})
 }
 
-func loadFileDesc(filename string) (*dpb.FileDescriptorProto, []byte) {
-	enc := proto.FileDescriptor(filename)
-	if enc == nil {
-		panic(fmt.Sprintf("failed to find fd for file: %v", filename))
-	}
-	fd, err := decodeFileDesc(enc)
+func loadFileDesc(filename string) (*descriptorpb.FileDescriptorProto, []byte) {
+	fd, err := protoregistry.GlobalFiles.FindFileByPath(filename)
 	if err != nil {
-		panic(fmt.Sprintf("failed to decode enc: %v", err))
+		panic(err)
 	}
-	b, err := proto.Marshal(fd)
+	fdProto := protodesc.ToFileDescriptorProto(fd)
+	b, err := proto.Marshal(fdProto)
 	if err != nil {
 		panic(fmt.Sprintf("failed to marshal fd: %v", err))
 	}
-	return fd, b
+	return fdProto, b
 }
 
-func loadFileDescDynamic(b []byte) (*dpb.FileDescriptorProto, protoreflect.FileDescriptor, []byte) {
+func loadFileDescDynamic(b []byte) (*descriptorpb.FileDescriptorProto, protoreflect.FileDescriptor, []byte) {
 	m := new(descriptorpb.FileDescriptorProto)
 	if err := proto.Unmarshal(b, m); err != nil {
 		panic(fmt.Sprintf("failed to unmarshal dynamic proto raw descriptor"))
@@ -127,7 +131,7 @@ func (x) TestFileDescContainingExtension(t *testing.T) {
 	for _, test := range []struct {
 		st     string
 		extNum int32
-		want   *dpb.FileDescriptorProto
+		want   *descriptorpb.FileDescriptorProto
 	}{
 		{"grpc.testing.ToBeExtended", 13, fdProto2Ext},
 		{"grpc.testing.ToBeExtended", 17, fdProto2Ext},
@@ -135,9 +139,18 @@ func (x) TestFileDescContainingExtension(t *testing.T) {
 		{"grpc.testing.ToBeExtended", 23, fdProto2Ext2},
 		{"grpc.testing.ToBeExtended", 29, fdProto2Ext2},
 	} {
-		fd, err := fileDescContainingExtension(test.st, test.extNum)
-		if err != nil || !proto.Equal(fd, test.want) {
-			t.Errorf("fileDescContainingExtension(%q) = %q, %v, want %q, <nil>", test.st, fd, err, test.want)
+		fd, err := s.fileDescEncodingContainingExtension(test.st, test.extNum, map[string]struct{}{})
+		if err != nil {
+			t.Errorf("fileDescContainingExtension(%q) return error: %v", test.st, err)
+			continue
+		}
+		var actualFd descriptorpb.FileDescriptorProto
+		if err := proto.Unmarshal(fd[0], &actualFd); err != nil {
+			t.Errorf("fileDescContainingExtension(%q) return invalid bytes: %v", test.st, err)
+			continue
+		}
+		if !proto.Equal(&actualFd, test.want) {
+			t.Errorf("fileDescContainingExtension(%q) returned %q, but wanted %q", test.st, &actualFd, test.want)
 		}
 	}
 }
@@ -348,7 +361,7 @@ func testFileContainingSymbol(t *testing.T, stream rpb.ServerReflection_ServerRe
 		{"grpc.testingv3.SearchResponseV3.Result.Value.val", fdTestv3Byte},
 		{"grpc.testingv3.SearchResponseV3.Result.Value.str", fdTestv3Byte},
 		{"grpc.testingv3.SearchResponseV3.State", fdTestv3Byte},
-		{"grpc.testingv3.SearchResponseV3.State.FRESH", fdTestv3Byte},
+		{"grpc.testingv3.SearchResponseV3.FRESH", fdTestv3Byte},
 		// Test dynamic symbols
 		{"grpc.testing.DynamicService", fdDynamicByte},
 		{"grpc.testing.DynamicReq", fdDynamicByte},
@@ -578,7 +591,7 @@ func testListServices(t *testing.T, stream rpb.ServerReflection_ServerReflection
 	}
 }
 
-func registerDynamicProto(srv *grpc.Server, fdp *dpb.FileDescriptorProto, fd protoreflect.FileDescriptor) {
+func registerDynamicProto(srv *grpc.Server, fdp *descriptorpb.FileDescriptorProto, fd protoreflect.FileDescriptor) {
 	type emptyInterface interface{}
 
 	for i := 0; i < fd.Services().Len(); i++ {


### PR DESCRIPTION
This updates the server reflection implementation in two key ways:
1. Support alternate source of descriptors, like for RPC servers that get their descriptors dynamically and are dynamic proxies.
    * Instead of always getting descriptors from the set of global registered files (when generated code is linked into the calling program), this allows caller to supply custom resolvers.
    * This also allows caller to supply a set of service names instead of supplying a `*grpc.Server`.
2. Use the new protobuf API v2 stuff to get the descriptors, which is much more sane than the old APIs.
    * This allows much of the code to be eliminated since standard APIs now support symbol and descriptor lookup.
    * The potential downside of this simplification is that encoded descriptors (pre-serialized to bytes) are no longer retained, so descriptor protos are re-created and marshaled with each call. Given the expected frequency of reflection requests, this is likely a non-issue and not worth adding back some sort of cache.
    
RELEASE NOTES:
* A new `NewServer(ServerOptions)` function has been added to the `google.golang.org/grpc/reflection` package that allows creating the reflection server with customizations to the list of advertised services and to the mechanism used to lookup descriptors and extensions.