### PR TITLE
Change version to 1.46.0

### DIFF
--- a/version.go
+++ b/version.go
@@ -19,4 +19,4 @@
 package grpc
 
 // Version is the current grpc version.
-const Version = "1.45.0-dev"
+const Version = "1.46.0"


### PR DESCRIPTION
[skip ci] Skipping Travis. Version number change only

RELEASE NOTES: none