### PR TITLE
xds: rename rls proto import

### DIFF
--- a/xds/internal/clusterspecifier/rls/rls.go
+++ b/xds/internal/clusterspecifier/rls/rls.go
@@ -27,7 +27,7 @@ import (
 	"github.com/golang/protobuf/ptypes"
 	"google.golang.org/grpc/balancer"
 	"google.golang.org/grpc/internal/envconfig"
-	"google.golang.org/grpc/internal/proto/grpc_lookup_v1"
+	rlspb "google.golang.org/grpc/internal/proto/grpc_lookup_v1"
 	"google.golang.org/grpc/xds/internal/clusterspecifier"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/anypb"
@@ -65,7 +65,7 @@ func (rls) ParseClusterSpecifierConfig(cfg proto.Message) (clusterspecifier.Bala
 	if !ok {
 		return nil, fmt.Errorf("rls_csp: error parsing config %v: unknown type %T", cfg, cfg)
 	}
-	rlcs := new(grpc_lookup_v1.RouteLookupClusterSpecifier)
+	rlcs := new(rlspb.RouteLookupClusterSpecifier)
 
 	if err := ptypes.UnmarshalAny(any, rlcs); err != nil {
 		return nil, fmt.Errorf("rls_csp: error parsing config %v: %v", cfg, err)

--- a/xds/internal/clusterspecifier/rls/rls_test.go
+++ b/xds/internal/clusterspecifier/rls/rls_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	_ "google.golang.org/grpc/balancer/rls"
 	"google.golang.org/grpc/internal/grpctest"
-	"google.golang.org/grpc/internal/proto/grpc_lookup_v1"
+	rlspb "google.golang.org/grpc/internal/proto/grpc_lookup_v1"
 	"google.golang.org/grpc/internal/testutils"
 	_ "google.golang.org/grpc/xds/internal/balancer/cdsbalancer"
 	"google.golang.org/grpc/xds/internal/clusterspecifier"
@@ -106,17 +106,17 @@ func (s) TestParseClusterSpecifierConfig(t *testing.T) {
 }
 
 // This will error because the required match field is set in grpc key builder.
-var rlsClusterSpecifierConfigError = testutils.MarshalAny(&grpc_lookup_v1.RouteLookupClusterSpecifier{
-	RouteLookupConfig: &grpc_lookup_v1.RouteLookupConfig{
-		GrpcKeybuilders: []*grpc_lookup_v1.GrpcKeyBuilder{
+var rlsClusterSpecifierConfigError = testutils.MarshalAny(&rlspb.RouteLookupClusterSpecifier{
+	RouteLookupConfig: &rlspb.RouteLookupConfig{
+		GrpcKeybuilders: []*rlspb.GrpcKeyBuilder{
 			{
-				Names: []*grpc_lookup_v1.GrpcKeyBuilder_Name{
+				Names: []*rlspb.GrpcKeyBuilder_Name{
 					{
 						Service: "service",
 						Method:  "method",
 					},
 				},
-				Headers: []*grpc_lookup_v1.NameMatcher{
+				Headers: []*rlspb.NameMatcher{
 					{
 						Key:           "k1",
 						RequiredMatch: true,
@@ -130,17 +130,17 @@ var rlsClusterSpecifierConfigError = testutils.MarshalAny(&grpc_lookup_v1.RouteL
 
 // Corresponds to the rls unit test case in
 // balancer/rls/internal/config_test.go.
-var rlsClusterSpecifierConfigWithoutTransformations = testutils.MarshalAny(&grpc_lookup_v1.RouteLookupClusterSpecifier{
-	RouteLookupConfig: &grpc_lookup_v1.RouteLookupConfig{
-		GrpcKeybuilders: []*grpc_lookup_v1.GrpcKeyBuilder{
+var rlsClusterSpecifierConfigWithoutTransformations = testutils.MarshalAny(&rlspb.RouteLookupClusterSpecifier{
+	RouteLookupConfig: &rlspb.RouteLookupConfig{
+		GrpcKeybuilders: []*rlspb.GrpcKeyBuilder{
 			{
-				Names: []*grpc_lookup_v1.GrpcKeyBuilder_Name{
+				Names: []*rlspb.GrpcKeyBuilder_Name{
 					{
 						Service: "service",
 						Method:  "method",
 					},
 				},
-				Headers: []*grpc_lookup_v1.NameMatcher{
+				Headers: []*rlspb.NameMatcher{
 					{
 						Key:   "k1",
 						Names: []string{"v1"},


### PR DESCRIPTION
This is required for copybara rules which will point to the canonical copy of the proto in google3.

RELEASE NOTES: none