### PR TITLE
grpc: delete deprecated API WithBalancerName()

### DIFF
--- a/balancer_switching_test.go
+++ b/balancer_switching_test.go
@@ -26,7 +26,7 @@ import (
 	"time"
 
 	"google.golang.org/grpc/balancer"
-	"google.golang.org/grpc/balancer/roundrobin"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/internal"
 	"google.golang.org/grpc/internal/balancer/stub"
 	"google.golang.org/grpc/resolver"
@@ -161,7 +161,7 @@ func (s) TestSwitchBalancer(t *testing.T) {
 	servers, scleanup := startServers(t, numServers, math.MaxInt32)
 	defer scleanup()
 
-	cc, err := Dial(r.Scheme()+":///test.server", WithInsecure(), WithResolvers(r), WithCodec(testCodec{}))
+	cc, err := Dial(r.Scheme()+":///test.server", WithTransportCredentials(insecure.NewCredentials()), WithResolvers(r), WithCodec(testCodec{}))
 	if err != nil {
 		t.Fatalf("failed to dial: %v", err)
 	}
@@ -184,38 +184,11 @@ func (s) TestSwitchBalancer(t *testing.T) {
 	}
 }
 
-// Test that balancer specified by dial option will not be overridden.
-func (s) TestBalancerDialOption(t *testing.T) {
-	r := manual.NewBuilderWithScheme("whatever")
-
-	const numServers = 2
-	servers, scleanup := startServers(t, numServers, math.MaxInt32)
-	defer scleanup()
-
-	cc, err := Dial(r.Scheme()+":///test.server", WithInsecure(), WithResolvers(r), WithCodec(testCodec{}), WithBalancerName(roundrobin.Name))
-	if err != nil {
-		t.Fatalf("failed to dial: %v", err)
-	}
-	defer cc.Close()
-	addrs := []resolver.Address{{Addr: servers[0].addr}, {Addr: servers[1].addr}}
-	r.UpdateState(resolver.State{Addresses: addrs})
-	// The init balancer is roundrobin.
-	if err := checkRoundRobin(cc, servers); err != nil {
-		t.Fatalf("check roundrobin returned non-nil error: %v", err)
-	}
-	// Switch to pickfirst.
-	cc.updateResolverState(resolver.State{ServiceConfig: parseCfg(r, `{"loadBalancingPolicy": "pick_first"}`), Addresses: addrs}, nil)
-	// Balancer is still roundrobin.
-	if err := checkRoundRobin(cc, servers); err != nil {
-		t.Fatalf("check roundrobin returned non-nil error: %v", err)
-	}
-}
-
 // First addr update contains grpclb.
 func (s) TestSwitchBalancerGRPCLBFirst(t *testing.T) {
 	r := manual.NewBuilderWithScheme("whatever")
 
-	cc, err := Dial(r.Scheme()+":///test.server", WithInsecure(), WithResolvers(r), WithCodec(testCodec{}))
+	cc, err := Dial(r.Scheme()+":///test.server", WithTransportCredentials(insecure.NewCredentials()), WithResolvers(r), WithCodec(testCodec{}))
 	if err != nil {
 		t.Fatalf("failed to dial: %v", err)
 	}
@@ -275,7 +248,7 @@ func (s) TestSwitchBalancerGRPCLBFirst(t *testing.T) {
 func (s) TestSwitchBalancerGRPCLBSecond(t *testing.T) {
 	r := manual.NewBuilderWithScheme("whatever")
 
-	cc, err := Dial(r.Scheme()+":///test.server", WithInsecure(), WithResolvers(r), WithCodec(testCodec{}))
+	cc, err := Dial(r.Scheme()+":///test.server", WithTransportCredentials(insecure.NewCredentials()), WithResolvers(r), WithCodec(testCodec{}))
 	if err != nil {
 		t.Fatalf("failed to dial: %v", err)
 	}
@@ -351,7 +324,7 @@ func (s) TestSwitchBalancerGRPCLBSecond(t *testing.T) {
 func (s) TestSwitchBalancerGRPCLBRoundRobin(t *testing.T) {
 	r := manual.NewBuilderWithScheme("whatever")
 
-	cc, err := Dial(r.Scheme()+":///test.server", WithInsecure(), WithResolvers(r), WithCodec(testCodec{}))
+	cc, err := Dial(r.Scheme()+":///test.server", WithTransportCredentials(insecure.NewCredentials()), WithResolvers(r), WithCodec(testCodec{}))
 	if err != nil {
 		t.Fatalf("failed to dial: %v", err)
 	}
@@ -413,7 +386,7 @@ func (s) TestSwitchBalancerGRPCLBRoundRobin(t *testing.T) {
 func (s) TestSwitchBalancerGRPCLBServiceConfig(t *testing.T) {
 	r := manual.NewBuilderWithScheme("whatever")
 
-	cc, err := Dial(r.Scheme()+":///test.server", WithInsecure(), WithResolvers(r), WithCodec(testCodec{}))
+	cc, err := Dial(r.Scheme()+":///test.server", WithTransportCredentials(insecure.NewCredentials()), WithResolvers(r), WithCodec(testCodec{}))
 	if err != nil {
 		t.Fatalf("failed to dial: %v", err)
 	}
@@ -503,7 +476,7 @@ func (s) TestSwitchBalancerGRPCLBWithGRPCLBNotRegistered(t *testing.T) {
 	servers, scleanup := startServers(t, numServers, math.MaxInt32)
 	defer scleanup()
 
-	cc, err := Dial(r.Scheme()+":///test.server", WithInsecure(), WithResolvers(r), WithCodec(testCodec{}))
+	cc, err := Dial(r.Scheme()+":///test.server", WithTransportCredentials(insecure.NewCredentials()), WithResolvers(r), WithCodec(testCodec{}))
 	if err != nil {
 		t.Fatalf("failed to dial: %v", err)
 	}
@@ -550,7 +523,7 @@ func init() {
 // This test is to make sure this close doesn't cause a deadlock.
 func (s) TestSwitchBalancerOldRemoveSubConn(t *testing.T) {
 	r := manual.NewBuilderWithScheme("whatever")
-	cc, err := Dial(r.Scheme()+":///test.server", WithInsecure(), WithResolvers(r))
+	cc, err := Dial(r.Scheme()+":///test.server", WithTransportCredentials(insecure.NewCredentials()), WithResolvers(r))
 	if err != nil {
 		t.Fatalf("failed to dial: %v", err)
 	}

--- a/dialoptions.go
+++ b/dialoptions.go
@@ -20,12 +20,10 @@ package grpc
 
 import (
 	"context"
-	"fmt"
 	"net"
 	"time"
 
 	"google.golang.org/grpc/backoff"
-	"google.golang.org/grpc/balancer"
 	"google.golang.org/grpc/channelz"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
@@ -46,18 +44,16 @@ type dialOptions struct {
 	chainUnaryInts  []UnaryClientInterceptor
 	chainStreamInts []StreamClientInterceptor
 
-	cp              Compressor
-	dc              Decompressor
-	bs              internalbackoff.Strategy
-	block           bool
-	returnLastError bool
-	timeout         time.Duration
-	scChan          <-chan ServiceConfig
-	authority       string
-	copts           transport.ConnectOptions
-	callOptions     []CallOption
-	// This is used by WithBalancerName dial option.
-	balancerBuilder             balancer.Builder
+	cp                          Compressor
+	dc                          Decompressor
+	bs                          internalbackoff.Strategy
+	block                       bool
+	returnLastError             bool
+	timeout                     time.Duration
+	scChan                      <-chan ServiceConfig
+	authority                   string
+	copts                       transport.ConnectOptions
+	callOptions                 []CallOption
 	channelzParentID            *channelz.Identifier
 	disableServiceConfig        bool
 	disableRetry                bool
@@ -193,25 +189,6 @@ func WithCompressor(cp Compressor) DialOption {
 func WithDecompressor(dc Decompressor) DialOption {
 	return newFuncDialOption(func(o *dialOptions) {
 		o.dc = dc
-	})
-}
-
-// WithBalancerName sets the balancer that the ClientConn will be initialized
-// with. Balancer registered with balancerName will be used. This function
-// panics if no balancer was registered by balancerName.
-//
-// The balancer cannot be overridden by balancer option specified by service
-// config.
-//
-// Deprecated: use WithDefaultServiceConfig and WithDisableServiceConfig
-// instead.  Will be removed in a future 1.x release.
-func WithBalancerName(balancerName string) DialOption {
-	builder := balancer.Get(balancerName)
-	if builder == nil {
-		panic(fmt.Sprintf("grpc.WithBalancerName: no balancer is registered for name %v", balancerName))
-	}
-	return newFuncDialOption(func(o *dialOptions) {
-		o.balancerBuilder = builder
 	})
 }
 

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -812,7 +812,7 @@ func (te *test) configDial(opts ...grpc.DialOption) ([]grpc.DialOption, string) 
 		scheme = te.resolverScheme + ":///"
 	}
 	if te.e.balancer != "" {
-		opts = append(opts, grpc.WithBalancerName(te.e.balancer))
+		opts = append(opts, grpc.WithDefaultServiceConfig(fmt.Sprintf(`{"loadBalancingConfig": [{"%s":{}}]}`, te.e.balancer)))
 	}
 	if te.clientInitialWindowSize > 0 {
 		opts = append(opts, grpc.WithInitialWindowSize(te.clientInitialWindowSize))


### PR DESCRIPTION
Summary of changes:
- Deleted the `WithBalancerName()` API which has been deprecated for ages now.
  - This simplifies code in the `ClientConn` since we no longer need to handle special cases around balancer name being specified through a dial option
- Test cleanups
  - Use `WithDefaultServiceConfig` instead of `WithBalancerName` wherever applicable
  - Use `WithTransportCredentials(insecure.NewCredentials())` instead of `WithInsecure()` in tests already touched by the above change
  - Use `defaultTestTimeout` wherever applicable
  - Turn `setupClient` and `setupServer` functions into test helpers and significantly reduce boiler plate in individual tests in `healthcheck_test.go`

RELEASE NOTES:
- grpc: delete `WithBalancerName()` API, deprecated over 4 years ago in #1697