### PR TITLE
grpc: handle invalid service configs by applying the default, if applicable

### DIFF
--- a/balancer_conn_wrappers.go
+++ b/balancer_conn_wrappers.go
@@ -131,11 +131,17 @@ func (ccb *ccBalancerWrapper) watcher() {
 }
 
 func (ccb *ccBalancerWrapper) close() {
+	if ccb == nil {
+		return
+	}
 	ccb.closed.Fire()
 	<-ccb.done.Done()
 }
 
 func (ccb *ccBalancerWrapper) exitIdle() bool {
+	if ccb == nil {
+		return true
+	}
 	if !ccb.hasExitIdle {
 		return false
 	}
@@ -168,6 +174,9 @@ func (ccb *ccBalancerWrapper) updateClientConnState(ccs *balancer.ClientConnStat
 }
 
 func (ccb *ccBalancerWrapper) resolverError(err error) {
+	if ccb == nil {
+		return
+	}
 	ccb.balancerMu.Lock()
 	defer ccb.balancerMu.Unlock()
 	ccb.balancer.ResolverError(err)


### PR DESCRIPTION
If the name resolver returns an invalid service config, and if there is no current service config on the channel, this PR attempts to apply the default service config, if one is available. 

This aligns grpc-go with https://github.com/grpc/proposal/blob/master/A21-service-config-error-handling.md, specifically [#4.2](https://github.com/grpc/proposal/blob/master/A21-service-config-error-handling.md)

This PR also makes the following changes:
- handle `nil` receiver in `ccBalancerWrapper`
- remove `cc.balancerWrapper != nil` checks before calling methods on the balancerWrapper
- use `cc.sc != nil` as the condition representing presence of current service config instead of `cc.balancerWrapper != nil`

RELEASE NOTES:
- handle invalid service configs by applying the default, if applicable