### PR TITLE
cmd/protoc-gen-go-grpc: allow hooks to modify client structs and service handlers

### DIFF
--- a/cmd/protoc-gen-go-grpc/grpc.go
+++ b/cmd/protoc-gen-go-grpc/grpc.go
@@ -36,7 +36,7 @@ const (
 
 type serviceGenerateHelperInterface interface {
 	formatFullMethodName(service *protogen.Service, method *protogen.Method) string
-	generateNewClientConnInterface(g *protogen.GeneratedFile, clientName string)
+	generateClientStruct(g *protogen.GeneratedFile, clientName string)
 	generateNewClientDefinitions(g *protogen.GeneratedFile, service *protogen.Service, clientName string)
 	generateUnimplementedServerType(gen *protogen.Plugin, file *protogen.File, g *protogen.GeneratedFile, service *protogen.Service)
 	generateServerFunctions(gen *protogen.Plugin, file *protogen.File, g *protogen.GeneratedFile, service *protogen.Service, serverType string, serviceDescVar string) []string
@@ -49,7 +49,7 @@ func (serviceGenerateHelper) formatFullMethodName(service *protogen.Service, met
 	return fmt.Sprintf("/%s/%s", service.Desc.FullName(), method.Desc.Name())
 }
 
-func (serviceGenerateHelper) generateNewClientConnInterface(g *protogen.GeneratedFile, clientName string) {
+func (serviceGenerateHelper) generateClientStruct(g *protogen.GeneratedFile, clientName string) {
 	g.P("type ", unexport(clientName), " struct {")
 	g.P("cc ", grpcPackage.Ident("ClientConnInterface"))
 	g.P("}")
@@ -182,7 +182,7 @@ func genService(gen *protogen.Plugin, file *protogen.File, g *protogen.Generated
 	g.P()
 
 	// Client structure.
-	helper.generateNewClientConnInterface(g, clientName)
+	helper.generateClientStruct(g, clientName)
 
 	// NewClient factory.
 	if service.Desc.Options().(*descriptorpb.ServiceOptions).GetDeprecated() {

--- a/cmd/protoc-gen-go-grpc/grpc.go
+++ b/cmd/protoc-gen-go-grpc/grpc.go
@@ -190,7 +190,6 @@ func genService(gen *protogen.Plugin, file *protogen.File, g *protogen.Generated
 	}
 	g.P("func New", clientName, " (cc ", grpcPackage.Ident("ClientConnInterface"), ") ", clientName, " {")
 	helper.generateNewClientDefinitions(g, service, clientName)
-	g.P("return &", unexport(clientName), "{cc}")
 	g.P("}")
 	g.P()
 

--- a/cmd/protoc-gen-go-grpc/grpc.go
+++ b/cmd/protoc-gen-go-grpc/grpc.go
@@ -96,7 +96,6 @@ func (serviceGenerateHelper) generateServerFunctions(gen *protogen.Plugin, file 
 		handlerNames = append(handlerNames, hname)
 	}
 	genServiceDesc(file, g, serviceDescVar, serverType, service, handlerNames)
-	return handlerNames
 }
 
 func (serviceGenerateHelper) formatHandlerFuncName(service *protogen.Service, hname string) string {

--- a/cmd/protoc-gen-go-grpc/grpc.go
+++ b/cmd/protoc-gen-go-grpc/grpc.go
@@ -39,7 +39,7 @@ type serviceGenerateHelperInterface interface {
 	generateClientStruct(g *protogen.GeneratedFile, clientName string)
 	generateNewClientDefinitions(g *protogen.GeneratedFile, service *protogen.Service, clientName string)
 	generateUnimplementedServerType(gen *protogen.Plugin, file *protogen.File, g *protogen.GeneratedFile, service *protogen.Service)
-	generateServerFunctions(gen *protogen.Plugin, file *protogen.File, g *protogen.GeneratedFile, service *protogen.Service, serverType string, serviceDescVar string) []string
+	generateServerFunctions(gen *protogen.Plugin, file *protogen.File, g *protogen.GeneratedFile, service *protogen.Service, serverType string, serviceDescVar string)
 	formatHandlerFuncName(service *protogen.Service, hname string) string
 }
 
@@ -86,7 +86,7 @@ func (serviceGenerateHelper) generateUnimplementedServerType(gen *protogen.Plugi
 	g.P()
 }
 
-func (serviceGenerateHelper) generateServerFunctions(gen *protogen.Plugin, file *protogen.File, g *protogen.GeneratedFile, service *protogen.Service, serverType string, serviceDescVar string) []string {
+func (serviceGenerateHelper) generateServerFunctions(gen *protogen.Plugin, file *protogen.File, g *protogen.GeneratedFile, service *protogen.Service, serverType string, serviceDescVar string) {
 	// Server handler implementations.
 	handlerNames := make([]string, 0, len(service.Methods))
 	for _, method := range service.Methods {


### PR DESCRIPTION
We are supporting the service renaming by using a global variables which will cause issues in some scenarios.

This change allows us to modify the ClientConn interface and handlers, which allows us to store the renamed service name by each clientconn. This matches how the internal service renaming is implemented.

RELEASE NOTES: n/a