### PR TITLE
binarylog: generalize binarylog's MethodLogger preparing for new observability features

### DIFF
--- a/internal/binarylog/binarylog.go
+++ b/internal/binarylog/binarylog.go
@@ -31,7 +31,7 @@ import (
 // Logger is the global binary logger. It can be used to get binary logger for
 // each method.
 type Logger interface {
-	getMethodLogger(methodName string) *MethodLogger
+	GetMethodLogger(methodName string) MethodLogger
 }
 
 // binLogger is the global binary logger for the binary. One of this should be
@@ -49,17 +49,24 @@ func SetLogger(l Logger) {
 	binLogger = l
 }
 
+// GetLogger gets the binarg logger.
+//
+// Only call this at init time.
+func GetLogger() Logger {
+	return binLogger
+}
+
 // GetMethodLogger returns the methodLogger for the given methodName.
 //
 // methodName should be in the format of "/service/method".
 //
 // Each methodLogger returned by this method is a new instance. This is to
 // generate sequence id within the call.
-func GetMethodLogger(methodName string) *MethodLogger {
+func GetMethodLogger(methodName string) MethodLogger {
 	if binLogger == nil {
 		return nil
 	}
-	return binLogger.getMethodLogger(methodName)
+	return binLogger.GetMethodLogger(methodName)
 }
 
 func init() {
@@ -148,7 +155,7 @@ func (l *logger) setBlacklist(method string) error {
 //
 // Each methodLogger returned by this method is a new instance. This is to
 // generate sequence id within the call.
-func (l *logger) getMethodLogger(methodName string) *MethodLogger {
+func (l *logger) GetMethodLogger(methodName string) MethodLogger {
 	s, m, err := grpcutil.ParseMethod(methodName)
 	if err != nil {
 		grpclogLogger.Infof("binarylogging: failed to parse %q: %v", methodName, err)

--- a/internal/binarylog/binarylog_test.go
+++ b/internal/binarylog/binarylog_test.go
@@ -93,7 +93,7 @@ func (s) TestGetMethodLogger(t *testing.T) {
 			t.Errorf("in: %q, failed to create logger from config string", tc.in)
 			continue
 		}
-		ml := l.getMethodLogger(tc.method)
+		ml := l.GetMethodLogger(tc.method).(*methodLogger)
 		if ml == nil {
 			t.Errorf("in: %q, method logger is nil, want non-nil", tc.in)
 			continue
@@ -149,7 +149,7 @@ func (s) TestGetMethodLoggerOff(t *testing.T) {
 			t.Errorf("in: %q, failed to create logger from config string", tc.in)
 			continue
 		}
-		ml := l.getMethodLogger(tc.method)
+		ml := l.GetMethodLogger(tc.method)
 		if ml != nil {
 			t.Errorf("in: %q, method logger is non-nil, want nil", tc.in)
 		}

--- a/internal/binarylog/method_logger_test.go
+++ b/internal/binarylog/method_logger_test.go
@@ -350,7 +350,7 @@ func (s) TestLog(t *testing.T) {
 
 func (s) TestTruncateMetadataNotTruncated(t *testing.T) {
 	testCases := []struct {
-		ml   *MethodLogger
+		ml   *methodLogger
 		mpPb *pb.Metadata
 	}{
 		{
@@ -417,7 +417,7 @@ func (s) TestTruncateMetadataNotTruncated(t *testing.T) {
 
 func (s) TestTruncateMetadataTruncated(t *testing.T) {
 	testCases := []struct {
-		ml   *MethodLogger
+		ml   *methodLogger
 		mpPb *pb.Metadata
 
 		entryLen int
@@ -478,7 +478,7 @@ func (s) TestTruncateMetadataTruncated(t *testing.T) {
 
 func (s) TestTruncateMessageNotTruncated(t *testing.T) {
 	testCases := []struct {
-		ml    *MethodLogger
+		ml    *methodLogger
 		msgPb *pb.Message
 	}{
 		{
@@ -511,7 +511,7 @@ func (s) TestTruncateMessageNotTruncated(t *testing.T) {
 
 func (s) TestTruncateMessageTruncated(t *testing.T) {
 	testCases := []struct {
-		ml    *MethodLogger
+		ml    *methodLogger
 		msgPb *pb.Message
 
 		oldLength uint32

--- a/stream.go
+++ b/stream.go
@@ -462,7 +462,7 @@ type clientStream struct {
 
 	retryThrottler *retryThrottler // The throttler active when the RPC began.
 
-	binlog *binarylog.MethodLogger // Binary logger, can be nil.
+	binlog binarylog.MethodLogger // Binary logger, can be nil.
 	// serverHeaderBinlogged is a boolean for whether server header has been
 	// logged. Server header will be logged when the first time one of those
 	// happens: stream.Header(), stream.Recv().
@@ -1434,7 +1434,7 @@ type serverStream struct {
 
 	statsHandler stats.Handler
 
-	binlog *binarylog.MethodLogger
+	binlog binarylog.MethodLogger
 	// serverHeaderBinlogged indicates whether server header has been logged. It
 	// will happen when one of the following two happens: stream.SendHeader(),
 	// stream.Send().


### PR DESCRIPTION
As discussed offline, we want to utilize the pre-existing state-storing object `MethodLogger` for gRPC Observability. This object has the same life span as each RPC, and we can conveniently store extra context information about the RPC in it to generate better logs.

Child PR: https://github.com/grpc/grpc-go/pull/5196 

RELEASE NOTES: N/A