### PR TITLE
balancergroup: Switched subBalancerWrapper to wrap a gracefulswitch.Balancer

### DIFF
--- a/internal/balancergroup/balancergroup.go
+++ b/internal/balancergroup/balancergroup.go
@@ -94,6 +94,9 @@ func (sbc *subBalancerWrapper) updateBalancerStateWithCachedPicker() {
 }
 
 func (sbc *subBalancerWrapper) startBalancer() {
+	if sbc.balancer == nil {
+		sbc.balancer = gracefulswitch.NewBalancer(sbc, sbc.buildOpts)
+	}
 	sbc.group.logger.Infof("Creating child policy of type %v", sbc.builder.Name())
 	sbc.balancer.SwitchTo(sbc.builder)
 	if sbc.ccState != nil {
@@ -275,9 +278,6 @@ func (bg *BalancerGroup) Start() {
 	}
 
 	for _, config := range bg.idToBalancerConfig {
-		if config.balancer == nil {
-			config.balancer = gracefulswitch.NewBalancer(config, bg.buildOpts)
-		}
 		config.startBalancer()
 	}
 	bg.outgoingStarted = true
@@ -318,7 +318,6 @@ func (bg *BalancerGroup) Add(id string, builder balancer.Builder) {
 			builder:    builder,
 			buildOpts:  bg.buildOpts,
 		}
-		sbc.balancer = gracefulswitch.NewBalancer(sbc, bg.buildOpts)
 		if bg.outgoingStarted {
 			// Only start the balancer if bg is started. Otherwise, we only keep the
 			// static data.

--- a/internal/balancergroup/balancergroup.go
+++ b/internal/balancergroup/balancergroup.go
@@ -25,6 +25,7 @@ import (
 
 	"google.golang.org/grpc/balancer"
 	"google.golang.org/grpc/connectivity"
+	"google.golang.org/grpc/internal/balancer/gracefulswitch"
 	"google.golang.org/grpc/internal/cache"
 	"google.golang.org/grpc/internal/grpclog"
 	"google.golang.org/grpc/resolver"
@@ -67,7 +68,7 @@ type subBalancerWrapper struct {
 	ccState *balancer.ClientConnState
 	// The dynamic part of sub-balancer. Only used when balancer group is
 	// started. Gets cleared when sub-balancer is closed.
-	balancer balancer.Balancer
+	balancer *gracefulswitch.Balancer
 }
 
 // UpdateState overrides balancer.ClientConn, to keep state and picker.
@@ -93,11 +94,10 @@ func (sbc *subBalancerWrapper) updateBalancerStateWithCachedPicker() {
 }
 
 func (sbc *subBalancerWrapper) startBalancer() {
-	b := sbc.builder.Build(sbc, sbc.buildOpts)
-	sbc.group.logger.Infof("Created child policy %p of type %v", b, sbc.builder.Name())
-	sbc.balancer = b
+	sbc.group.logger.Infof("Creating child policy of type %v", sbc.builder.Name())
+	sbc.balancer.SwitchTo(sbc.builder)
 	if sbc.ccState != nil {
-		b.UpdateClientConnState(*sbc.ccState)
+		sbc.balancer.UpdateClientConnState(*sbc.ccState)
 	}
 }
 
@@ -108,11 +108,8 @@ func (sbc *subBalancerWrapper) exitIdle() (complete bool) {
 	if b == nil {
 		return true
 	}
-	if ei, ok := b.(balancer.ExitIdler); ok {
-		ei.ExitIdle()
-		return true
-	}
-	return false
+	b.ExitIdle()
+	return true
 }
 
 func (sbc *subBalancerWrapper) updateSubConnState(sc balancer.SubConn, state balancer.SubConnState) {
@@ -278,6 +275,9 @@ func (bg *BalancerGroup) Start() {
 	}
 
 	for _, config := range bg.idToBalancerConfig {
+		if config.balancer == nil {
+			config.balancer = gracefulswitch.NewBalancer(config, bg.buildOpts)
+		}
 		config.startBalancer()
 	}
 	bg.outgoingStarted = true
@@ -318,6 +318,7 @@ func (bg *BalancerGroup) Add(id string, builder balancer.Builder) {
 			builder:    builder,
 			buildOpts:  bg.buildOpts,
 		}
+		sbc.balancer = gracefulswitch.NewBalancer(sbc, bg.buildOpts)
 		if bg.outgoingStarted {
 			// Only start the balancer if bg is started. Otherwise, we only keep the
 			// static data.
@@ -374,7 +375,6 @@ func (bg *BalancerGroup) cleanupSubConns(config *subBalancerWrapper) {
 	// sub-balancers.
 	for sc, b := range bg.scToSubBalancer {
 		if b == config {
-			bg.cc.RemoveSubConn(sc)
 			delete(bg.scToSubBalancer, sc)
 		}
 	}


### PR DESCRIPTION
This PR is a logical no-op and doesn't change any current flow. However, this sets up my future PR with the blobs of functionality of a. the decision to make the graceful switch for a child (I think best to leave up to the caller) and b. the actual plumbing in the balancer group and subBalancerWrapper which would call SwitchTo a second time triggering the Graceful Switch.

RELEASE NOTES: None