### PR TITLE
workflows: bump Go versions for testing workflows

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15
+          go-version: 1.18
       - name: Checkout repo
         uses: actions/checkout@v2
 
@@ -43,28 +43,28 @@ jobs:
       matrix:
         include:
           - type: vet+tests
-            goversion: 1.17
+            goversion: 1.18
 
           - type: tests
-            goversion: 1.17
+            goversion: 1.18
             testflags: -race
 
           - type: extras
-            goversion: 1.17
+            goversion: 1.18
 
           - type: tests
-            goversion: 1.17
+            goversion: 1.18
             goarch: 386
 
           - type: tests
-            goversion: 1.17
+            goversion: 1.18
             goarch: arm64
 
           - type: tests
-            goversion: 1.16
+            goversion: 1.17
 
           - type: tests
-            goversion: 1.15
+            goversion: 1.16
 
     steps:
       # Setup the environment.


### PR DESCRIPTION
Use Go 1.18 for the "proto-vet" tests. For the regular tests, bump all the Go versions by one release: 1.18 for most things, plus 1.17 and 1.16. Drop Go 1.15.

RELEASE NOTES: N/A