### PR TITLE
xds: suppress redundant updates only when we are SERVING

### DIFF
--- a/xds/internal/server/listener_wrapper.go
+++ b/xds/internal/server/listener_wrapper.go
@@ -438,7 +438,12 @@ func (l *listenerWrapper) switchMode(fcs *xdsresource.FilterChainManager, newMod
 	defer l.mu.Unlock()
 
 	l.filterChains = fcs
-	if l.mode == newMode {
+	if l.mode == newMode && l.mode == connectivity.ServingModeServing {
+		// Redundant updates are suppressed only when we are SERVING and the new
+		// mode is also SERVING. In the other case (where we are NOT_SERVING and the
+		// new mode is also NOT_SERVING), the update is not suppressed as:
+		//   1. the error may have change
+		//   2. it provides a timestamp of the last backoff attempt
 		return
 	}
 	l.mode = newMode


### PR DESCRIPTION
#5215 made changes to avoid log spam as a result of changes to the xdsServer's serving mode. But it also suppressed more updates than it should have. This PR addresses the issue raised in https://github.com/grpc/grpc-go/pull/5215#issuecomment-1071555329.

Fixes https://github.com/grpc/grpc-go/issues/4939

RELEASE NOTES: none