### PR TITLE
make the RLS LB policy name available in the internal package

### DIFF
--- a/balancer/rls/balancer.go
+++ b/balancer/rls/balancer.go
@@ -30,6 +30,7 @@ import (
 	"google.golang.org/grpc/balancer"
 	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/grpclog"
+	"google.golang.org/grpc/internal"
 	"google.golang.org/grpc/internal/backoff"
 	"google.golang.org/grpc/internal/balancergroup"
 	"google.golang.org/grpc/internal/buffer"
@@ -40,7 +41,10 @@ import (
 
 const (
 	// Name is the name of the RLS LB policy.
-	Name = "rls_experimental"
+	//
+	// It currently has an experimental suffix which would be removed once
+	// end-to-end testing of the policy is completed.
+	Name = internal.RLSLoadBalancingPolicyName
 	// Default frequency for data cache purging.
 	periodicCachePurgeFreq = time.Minute
 )

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -85,3 +85,9 @@ const (
 	// that supports backend returned by grpclb balancer.
 	CredsBundleModeBackendFromBalancer = "backend-from-balancer"
 )
+
+// RLSLoadBalancingPolicyName is the name of the RLS LB policy.
+//
+// It currently has an experimental suffix which would be removed once
+// end-to-end testing of the policy is completed.
+const RLSLoadBalancingPolicyName = "rls_experimental"

--- a/xds/internal/clusterspecifier/rls/rls_test.go
+++ b/xds/internal/clusterspecifier/rls/rls_test.go
@@ -25,13 +25,14 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	_ "google.golang.org/grpc/balancer/rls"
 	"google.golang.org/grpc/internal/grpctest"
 	rlspb "google.golang.org/grpc/internal/proto/grpc_lookup_v1"
 	"google.golang.org/grpc/internal/testutils"
-	_ "google.golang.org/grpc/xds/internal/balancer/cdsbalancer"
 	"google.golang.org/grpc/xds/internal/clusterspecifier"
 	"google.golang.org/protobuf/types/known/durationpb"
+
+	_ "google.golang.org/grpc/balancer/rls"                      // Register the RLS LB policy.
+	_ "google.golang.org/grpc/xds/internal/balancer/cdsbalancer" // Register the CDS LB policy.
 )
 
 func init() {

--- a/xds/xds.go
+++ b/xds/xds.go
@@ -38,7 +38,7 @@ import (
 
 	_ "google.golang.org/grpc/credentials/tls/certprovider/pemfile"         // Register the file watcher certificate provider plugin.
 	_ "google.golang.org/grpc/xds/internal/balancer"                        // Register the balancers.
-	_ "google.golang.org/grpc/xds/internal/clusterspecifier/rls"            // Register the RLS cluster specifier plugin.
+	_ "google.golang.org/grpc/xds/internal/clusterspecifier/rls"            // Register the RLS cluster specifier plugin. Note that this does not register the RLS LB policy.
 	_ "google.golang.org/grpc/xds/internal/httpfilter/fault"                // Register the fault injection filter.
 	_ "google.golang.org/grpc/xds/internal/httpfilter/rbac"                 // Register the RBAC filter.
 	_ "google.golang.org/grpc/xds/internal/httpfilter/router"               // Register the router filter.

--- a/xds/xds.go
+++ b/xds/xds.go
@@ -38,6 +38,7 @@ import (
 
 	_ "google.golang.org/grpc/credentials/tls/certprovider/pemfile"         // Register the file watcher certificate provider plugin.
 	_ "google.golang.org/grpc/xds/internal/balancer"                        // Register the balancers.
+	_ "google.golang.org/grpc/xds/internal/clusterspecifier/rls"            // Register the RLS cluster specifier plugin.
 	_ "google.golang.org/grpc/xds/internal/httpfilter/fault"                // Register the fault injection filter.
 	_ "google.golang.org/grpc/xds/internal/httpfilter/rbac"                 // Register the RBAC filter.
 	_ "google.golang.org/grpc/xds/internal/httpfilter/router"               // Register the router filter.


### PR DESCRIPTION
Summary of changes:
- Introduce a const in the `internal` package to hold the name of the RLS LB policy
- Refer to this name from the actual package implementing the LB policy and from the xds cluster specifier package

Why do we need this?
- This change makes it clear/simple what needs to be imported:
  - When one needs to use the RLS lb policy, they need to import the `balancer/rls` pacakge (whether they want to use RLS as a standalone LB policy or they want to use RLS in the context of xDS)
- Include the RLS cluster specifier in the list of packages imported by the externally visible `xds` package 
  - The implementation of the cluster specifier for RLS imports the `rls` package solely for the purpose of referring to the name of the RLS LB policy. Putting the name in the `internal` package lets us get rid of this dependency.
- The `balancer/rls` package currently has an exported symbol `Name` which stores the name of the policy. But this package was not marked experimental when added it (and there has been a release from the time we added it). So, we cannot remove this symbol. But we can make it refer to the one defined in the `internal` package.

When RLS is being used from the client libraries, they will need to import the following:
- `balancer/rls` package
- `xds` package to use RLS with xDS

RELEASE NOTES: none
