### PR TITLE
test: use `t.Fatal` instead of `panic` for service config parsing errors

### DIFF
--- a/internal/testutils/lbcfg.go
+++ b/internal/testutils/lbcfg.go
@@ -1,0 +1,1 @@
+package testutils

--- a/internal/testutils/lbcfg.go
+++ b/internal/testutils/lbcfg.go
@@ -1,1 +1,0 @@
-package testutils

--- a/test/channelz_test.go
+++ b/test/channelz_test.go
@@ -231,7 +231,10 @@ func (s) TestCZNestedChannelRegistrationAndDeletion(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	r.UpdateState(resolver.State{Addresses: []resolver.Address{{Addr: "127.0.0.1:0"}}, ServiceConfig: parseCfg(r, `{"loadBalancingPolicy": "round_robin"}`)})
+	r.UpdateState(resolver.State{
+		Addresses:     []resolver.Address{{Addr: "127.0.0.1:0"}},
+		ServiceConfig: parseServiceConfig(t, r, `{"loadBalancingPolicy": "round_robin"}`),
+	})
 
 	// wait for the shutdown of grpclb balancer
 	if err := verifyResultWithDelay(func() (bool, error) {
@@ -1443,7 +1446,10 @@ func (s) TestCZChannelTraceCreationDeletion(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	r.UpdateState(resolver.State{Addresses: []resolver.Address{{Addr: "127.0.0.1:0"}}, ServiceConfig: parseCfg(r, `{"loadBalancingPolicy": "round_robin"}`)})
+	r.UpdateState(resolver.State{
+		Addresses:     []resolver.Address{{Addr: "127.0.0.1:0"}},
+		ServiceConfig: parseServiceConfig(t, r, `{"loadBalancingPolicy": "round_robin"}`),
+	})
 
 	// wait for the shutdown of grpclb balancer
 	if err := verifyResultWithDelay(func() (bool, error) {
@@ -1603,7 +1609,10 @@ func (s) TestCZChannelAddressResolutionChange(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	r.UpdateState(resolver.State{Addresses: addrs, ServiceConfig: parseCfg(r, `{"loadBalancingPolicy": "round_robin"}`)})
+	r.UpdateState(resolver.State{
+		Addresses:     addrs,
+		ServiceConfig: parseServiceConfig(t, r, `{"loadBalancingPolicy": "round_robin"}`),
+	})
 
 	if err := verifyResultWithDelay(func() (bool, error) {
 		cm := channelz.GetChannel(cid)
@@ -1620,7 +1629,7 @@ func (s) TestCZChannelAddressResolutionChange(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	newSC := parseCfg(r, `{
+	newSC := parseServiceConfig(t, r, `{
     "methodConfig": [
         {
             "name": [
@@ -1937,7 +1946,10 @@ func (s) TestCZTraceOverwriteChannelDeletion(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	r.UpdateState(resolver.State{Addresses: []resolver.Address{{Addr: "127.0.0.1:0"}}, ServiceConfig: parseCfg(r, `{"loadBalancingPolicy": "round_robin"}`)})
+	r.UpdateState(resolver.State{
+		Addresses:     []resolver.Address{{Addr: "127.0.0.1:0"}},
+		ServiceConfig: parseServiceConfig(t, r, `{"loadBalancingPolicy": "round_robin"}`),
+	})
 
 	// wait for the shutdown of grpclb balancer
 	if err := verifyResultWithDelay(func() (bool, error) {
@@ -1955,7 +1967,10 @@ func (s) TestCZTraceOverwriteChannelDeletion(t *testing.T) {
 
 	// If nested channel deletion is last trace event before the next validation, it will fail, as the top channel will hold a reference to it.
 	// This line forces a trace event on the top channel in that case.
-	r.UpdateState(resolver.State{Addresses: []resolver.Address{{Addr: "127.0.0.1:0"}}, ServiceConfig: parseCfg(r, `{"loadBalancingPolicy": "round_robin"}`)})
+	r.UpdateState(resolver.State{
+		Addresses:     []resolver.Address{{Addr: "127.0.0.1:0"}},
+		ServiceConfig: parseServiceConfig(t, r, `{"loadBalancingPolicy": "round_robin"}`),
+	})
 
 	// verify that the nested channel no longer exist due to trace referencing it got overwritten.
 	if err := verifyResultWithDelay(func() (bool, error) {

--- a/test/config_selector_test.go
+++ b/test/config_selector_test.go
@@ -145,7 +145,7 @@ func (s) TestConfigSelector(t *testing.T) {
 			var gotInfo *iresolver.RPCInfo
 			state := iresolver.SetConfigSelector(resolver.State{
 				Addresses:     []resolver.Address{{Addr: ss.Address}},
-				ServiceConfig: parseCfg(ss.R, "{}"),
+				ServiceConfig: parseServiceConfig(t, ss.R, "{}"),
 			}, funcConfigSelector{
 				f: func(i iresolver.RPCInfo) (*iresolver.RPCConfig, error) {
 					gotInfo = &i

--- a/test/healthcheck_test.go
+++ b/test/healthcheck_test.go
@@ -201,7 +201,7 @@ func (s) TestHealthCheckWatchStateChange(t *testing.T) {
 	cc, r := setupClient(t, nil)
 	r.UpdateState(resolver.State{
 		Addresses: []resolver.Address{{Addr: lis.Addr().String()}},
-		ServiceConfig: parseCfg(r, `{
+		ServiceConfig: parseServiceConfig(t, r, `{
 	"healthCheckConfig": {
 		"serviceName": "foo"
 	},
@@ -267,7 +267,7 @@ func (s) TestHealthCheckHealthServerNotRegistered(t *testing.T) {
 	cc, r := setupClient(t, nil)
 	r.UpdateState(resolver.State{
 		Addresses: []resolver.Address{{Addr: lis.Addr().String()}},
-		ServiceConfig: parseCfg(r, `{
+		ServiceConfig: parseServiceConfig(t, r, `{
 	"healthCheckConfig": {
 		"serviceName": "foo"
 	},
@@ -298,7 +298,7 @@ func (s) TestHealthCheckWithGoAway(t *testing.T) {
 	tc := testpb.NewTestServiceClient(cc)
 	r.UpdateState(resolver.State{
 		Addresses: []resolver.Address{{Addr: lis.Addr().String()}},
-		ServiceConfig: parseCfg(r, `{
+		ServiceConfig: parseServiceConfig(t, r, `{
 	"healthCheckConfig": {
 		"serviceName": "foo"
 	},
@@ -376,7 +376,7 @@ func (s) TestHealthCheckWithConnClose(t *testing.T) {
 	tc := testpb.NewTestServiceClient(cc)
 	r.UpdateState(resolver.State{
 		Addresses: []resolver.Address{{Addr: lis.Addr().String()}},
-		ServiceConfig: parseCfg(r, `{
+		ServiceConfig: parseServiceConfig(t, r, `{
 	"healthCheckConfig": {
 		"serviceName": "foo"
 	},
@@ -424,7 +424,7 @@ func (s) TestHealthCheckWithAddrConnDrain(t *testing.T) {
 	hcEnterChan, hcExitChan, testHealthCheckFuncWrapper := setupHealthCheckWrapper()
 	cc, r := setupClient(t, &clientConfig{testHealthCheckFuncWrapper: testHealthCheckFuncWrapper})
 	tc := testpb.NewTestServiceClient(cc)
-	sc := parseCfg(r, `{
+	sc := parseServiceConfig(t, r, `{
 	"healthCheckConfig": {
 		"serviceName": "foo"
 	},
@@ -506,7 +506,7 @@ func (s) TestHealthCheckWithClientConnClose(t *testing.T) {
 	tc := testpb.NewTestServiceClient(cc)
 	r.UpdateState(resolver.State{
 		Addresses: []resolver.Address{{Addr: lis.Addr().String()}},
-		ServiceConfig: parseCfg(r, `{
+		ServiceConfig: parseServiceConfig(t, r, `{
 	"healthCheckConfig": {
 		"serviceName": "foo"
 	},
@@ -573,7 +573,7 @@ func (s) TestHealthCheckWithoutSetConnectivityStateCalledAddrConnShutDown(t *tes
 	// The serviceName "delay" is specially handled at server side, where response will not be sent
 	// back to client immediately upon receiving the request (client should receive no response until
 	// test ends).
-	sc := parseCfg(r, `{
+	sc := parseServiceConfig(t, r, `{
 	"healthCheckConfig": {
 		"serviceName": "delay"
 	},
@@ -638,7 +638,7 @@ func (s) TestHealthCheckWithoutSetConnectivityStateCalled(t *testing.T) {
 	// test ends).
 	r.UpdateState(resolver.State{
 		Addresses: []resolver.Address{{Addr: lis.Addr().String()}},
-		ServiceConfig: parseCfg(r, `{
+		ServiceConfig: parseServiceConfig(t, r, `{
 	"healthCheckConfig": {
 		"serviceName": "delay"
 	},
@@ -679,7 +679,7 @@ func testHealthCheckDisableWithDialOption(t *testing.T, addr string) {
 	tc := testpb.NewTestServiceClient(cc)
 	r.UpdateState(resolver.State{
 		Addresses: []resolver.Address{{Addr: addr}},
-		ServiceConfig: parseCfg(r, `{
+		ServiceConfig: parseServiceConfig(t, r, `{
 	"healthCheckConfig": {
 		"serviceName": "foo"
 	},
@@ -713,7 +713,7 @@ func testHealthCheckDisableWithBalancer(t *testing.T, addr string) {
 	tc := testpb.NewTestServiceClient(cc)
 	r.UpdateState(resolver.State{
 		Addresses: []resolver.Address{{Addr: addr}},
-		ServiceConfig: parseCfg(r, `{
+		ServiceConfig: parseServiceConfig(t, r, `{
 	"healthCheckConfig": {
 		"serviceName": "foo"
 	},
@@ -787,7 +787,7 @@ func (s) TestHealthCheckChannelzCountingCallSuccess(t *testing.T) {
 	_, r := setupClient(t, nil)
 	r.UpdateState(resolver.State{
 		Addresses: []resolver.Address{{Addr: lis.Addr().String()}},
-		ServiceConfig: parseCfg(r, `{
+		ServiceConfig: parseServiceConfig(t, r, `{
 	"healthCheckConfig": {
 		"serviceName": "channelzSuccess"
 	},
@@ -834,7 +834,7 @@ func (s) TestHealthCheckChannelzCountingCallFailure(t *testing.T) {
 	_, r := setupClient(t, nil)
 	r.UpdateState(resolver.State{
 		Addresses: []resolver.Address{{Addr: lis.Addr().String()}},
-		ServiceConfig: parseCfg(r, `{
+		ServiceConfig: parseServiceConfig(t, r, `{
 	"healthCheckConfig": {
 		"serviceName": "channelzFailure"
 	},

--- a/test/parse_config.go
+++ b/test/parse_config.go
@@ -1,0 +1,38 @@
+/*
+ *
+ * Copyright 2022 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package test
+
+import (
+	"testing"
+
+	"google.golang.org/grpc/resolver/manual"
+	"google.golang.org/grpc/serviceconfig"
+)
+
+// parseServiceConfig is a test helper which uses the manual resolver to parse
+// the given service config. It calls t.Fatal() if service config parsing fails.
+func parseServiceConfig(t *testing.T, r *manual.Resolver, sc string) *serviceconfig.ParseResult {
+	t.Helper()
+
+	scpr := r.CC.ParseServiceConfig(sc)
+	if scpr.Err != nil {
+		t.Fatalf("Failed to parse service config %q: %v", sc, scpr.Err)
+	}
+	return scpr
+}


### PR DESCRIPTION
RELEASE NOTES: none