### PR TITLE
metadata: copy slices in FromContext() functions

### DIFF
--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -188,7 +188,9 @@ func FromIncomingContext(ctx context.Context) (MD, bool) {
 		// map, and there's no guarantee that the MD attached to the context is
 		// created using our helper functions.
 		key := strings.ToLower(k)
-		out[key] = append(out[key], v...)
+		s := make([]string, len(v))
+		copy(s, v)
+		out[key] = s
 	}
 	return out, true
 }
@@ -226,7 +228,9 @@ func FromOutgoingContext(ctx context.Context) (MD, bool) {
 		// map, and there's no guarantee that the MD attached to the context is
 		// created using our helper functions.
 		key := strings.ToLower(k)
-		out[key] = append(out[key], v...)
+		s := make([]string, len(v))
+		copy(s, v)
+		out[key] = s
 	}
 	for _, added := range raw.added {
 		if len(added)%2 == 1 {

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -188,7 +188,7 @@ func FromIncomingContext(ctx context.Context) (MD, bool) {
 		// map, and there's no guarantee that the MD attached to the context is
 		// created using our helper functions.
 		key := strings.ToLower(k)
-		out[key] = v
+		out[key] = append(out[key], v...)
 	}
 	return out, true
 }
@@ -226,7 +226,7 @@ func FromOutgoingContext(ctx context.Context) (MD, bool) {
 		// map, and there's no guarantee that the MD attached to the context is
 		// created using our helper functions.
 		key := strings.ToLower(k)
-		out[key] = v
+		out[key] = append(out[key], v...)
 	}
 	for _, added := range raw.added {
 		if len(added)%2 == 1 {


### PR DESCRIPTION
https://github.com/grpc/grpc-go/commit/32d5490aee8dd29a6fbfe75dc8caade5b6aa5d87#commitcomment-69226467

RELEASE NOTES:
* metadata: make a copy of the value slices in FromContext() functions so that modifications won't be made to the original copy