### PR TITLE
advancedtls: reduce the flakiness of advancedtls integration tests

### DIFF
--- a/security/advancedtls/advancedtls_integration_test.go
+++ b/security/advancedtls/advancedtls_integration_test.go
@@ -45,7 +45,7 @@ const (
 	// Default timeout for failed connections.
 	defaultTestShortTimeout = 10 * time.Millisecond
 	// Intervals that set to monitor the credential updates.
-	credRefreshingInterval = 200 * time.Millisecond
+	credRefreshingInterval = 100 * time.Millisecond
 	// Time we wait for the credential updates to be picked up.
 	sleepInterval = 400 * time.Millisecond
 )


### PR DESCRIPTION
This is to fix the bug reported in https://github.com/grpc/grpc-go/issues/5273, or at least mitigate it.
From the bug it seems the failure happens because the client failed to connect to the server. Most likely this was due to the file update wasn't picked up by the monitoring goroutine. I decreased the monitoring internal to help mitigate that.
Since the behavior being tested against is the file monitoring logic itself, replacing the content updating function with some other functions won't help that much. If this still happens in the future, I think we can just delete these tests.

RELEASE NOTES: n/a