### PR TITLE
xdsclient: always backoff between new streams even after successful stream

### DIFF
--- a/xds/internal/xdsclient/authority.go
+++ b/xds/internal/xdsclient/authority.go
@@ -108,7 +108,7 @@ func (c *clientImpl) newAuthority(config *bootstrap.ServerConfig) (_ *authority,
 			ret.close()
 		}
 	}()
-	ctr, err := newController(config, ret.pubsub, c.updateValidator, c.logger)
+	ctr, err := newController(config, ret.pubsub, c.updateValidator, c.logger, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/xds/internal/xdsclient/client_test.go
+++ b/xds/internal/xdsclient/client_test.go
@@ -102,7 +102,7 @@ type testController struct {
 func overrideNewController(t *testing.T) *testutils.Channel {
 	origNewController := newController
 	ch := testutils.NewChannel()
-	newController = func(config *bootstrap.ServerConfig, pubsub *pubsub.Pubsub, validator xdsresource.UpdateValidatorFunc, logger *grpclog.PrefixLogger) (controllerInterface, error) {
+	newController = func(config *bootstrap.ServerConfig, pubsub *pubsub.Pubsub, validator xdsresource.UpdateValidatorFunc, logger *grpclog.PrefixLogger, _ func(int) time.Duration) (controllerInterface, error) {
 		ret := newTestController(config)
 		ch.Send(ret)
 		return ret, nil

--- a/xds/internal/xdsclient/controller.go
+++ b/xds/internal/xdsclient/controller.go
@@ -18,6 +18,8 @@
 package xdsclient
 
 import (
+	"time"
+
 	"google.golang.org/grpc/internal/grpclog"
 	"google.golang.org/grpc/xds/internal/xdsclient/bootstrap"
 	"google.golang.org/grpc/xds/internal/xdsclient/controller"
@@ -33,6 +35,6 @@ type controllerInterface interface {
 	Close()
 }
 
-var newController = func(config *bootstrap.ServerConfig, pubsub *pubsub.Pubsub, validator xdsresource.UpdateValidatorFunc, logger *grpclog.PrefixLogger) (controllerInterface, error) {
-	return controller.New(config, pubsub, validator, logger)
+var newController = func(config *bootstrap.ServerConfig, pubsub *pubsub.Pubsub, validator xdsresource.UpdateValidatorFunc, logger *grpclog.PrefixLogger, boff func(int) time.Duration) (controllerInterface, error) {
+	return controller.New(config, pubsub, validator, logger, boff)
 }

--- a/xds/internal/xdsclient/controller/controller_test.go
+++ b/xds/internal/xdsclient/controller/controller_test.go
@@ -95,7 +95,7 @@ func (s) TestNew(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			c, err := New(test.config, noopUpdateHandler, nil, nil) // Only testing the config, other inputs are left as nil.
+			c, err := New(test.config, noopUpdateHandler, nil, nil, nil) // Only testing the config, other inputs are left as nil.
 			defer func() {
 				if c != nil {
 					c.Close()
@@ -123,7 +123,7 @@ func (s) TestNewWithGRPCDial(t *testing.T) {
 
 	// Set the dialer and make sure it is called.
 	SetGRPCDial(customDialer)
-	c, err := New(config, noopUpdateHandler, nil, nil)
+	c, err := New(config, noopUpdateHandler, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("New(%+v) = %v, want no error", config, err)
 	}
@@ -138,7 +138,7 @@ func (s) TestNewWithGRPCDial(t *testing.T) {
 
 	// Reset the dialer and make sure it is not called.
 	SetGRPCDial(grpc.Dial)
-	c, err = New(config, noopUpdateHandler, nil, nil)
+	c, err = New(config, noopUpdateHandler, nil, nil, nil)
 	defer func() {
 		if c != nil {
 			c.Close()

--- a/xds/internal/xdsclient/controller/v2_testutils_test.go
+++ b/xds/internal/xdsclient/controller/v2_testutils_test.go
@@ -458,13 +458,10 @@ func newTestController(p pubsub.UpdateHandler, controlPlanAddr string, n *basepb
 		Creds:        grpc.WithTransportCredentials(insecure.NewCredentials()),
 		TransportAPI: version.TransportV2,
 		NodeProto:    n,
-	}, p, nil, l)
+	}, p, nil, l, b)
 	if err != nil {
 		return nil, err
 	}
-	// This direct setting backoff seems a bit hacky, but should be OK for the
-	// tests. Or we need to make it configurable in New().
-	c.backoff = b
 	return c, nil
 }
 


### PR DESCRIPTION
Also: receiving from a stopped timer channel is unnecessary unless the timer is going to be reused via `Reset`.

RELEASE NOTES:
* xds: the xds client will now apply a 1 second backoff before recreating ADS or LRS streams