### PR TITLE
grpc: perform graceful switching of LB policies in the `ClientConn` by default

### DIFF
--- a/balancer_conn_wrappers.go
+++ b/balancer_conn_wrappers.go
@@ -20,15 +20,79 @@ package grpc
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 
 	"google.golang.org/grpc/balancer"
 	"google.golang.org/grpc/connectivity"
+	"google.golang.org/grpc/internal/balancer/gracefulswitch"
 	"google.golang.org/grpc/internal/buffer"
 	"google.golang.org/grpc/internal/channelz"
 	"google.golang.org/grpc/internal/grpcsync"
 	"google.golang.org/grpc/resolver"
 )
+
+// ccBalancerWrapper is a wrapper on top of cc for balancers. It ensures that
+// method invocations on the underlying balancer happen synchronously and in the
+// same order in which they were received from grpc.
+//
+// It uses the gracefulswitch.Balancer internally to ensure that balancer
+// switches happen in a graceful manner.
+//
+// It implements balancer.ClientConn interface.
+type ccBalancerWrapper struct {
+	cc *ClientConn
+
+	// balancerMu protects access to the following fields. Any calls on the
+	// underlying balancer must be made with the mutex held. This ensures that we
+	// never call the underlying balancer methods concurrently.
+	balancerMu      sync.Mutex
+	balancer        *gracefulswitch.Balancer
+	curBalancerName string
+
+	updateCh *buffer.Unbounded // Updates written on this channel are processed by watcher().
+	resultCh *buffer.Unbounded // Results of calls to UpdateClientConnState() are pushed here.
+	closed   *grpcsync.Event   // Indicates if close has been called.
+	done     *grpcsync.Event   // Indicates if close has completed its work.
+
+	mu       sync.Mutex
+	subConns map[*acBalancerWrapper]struct{}
+}
+
+// newCCBalancerWrapper creates a new balancer wrapper. The underlying balancer
+// is not created until the switchTo() method is invoked.
+func newCCBalancerWrapper(cc *ClientConn, bopts balancer.BuildOptions) *ccBalancerWrapper {
+	ccb := &ccBalancerWrapper{
+		cc:       cc,
+		updateCh: buffer.NewUnbounded(),
+		resultCh: buffer.NewUnbounded(),
+		closed:   grpcsync.NewEvent(),
+		done:     grpcsync.NewEvent(),
+		subConns: make(map[*acBalancerWrapper]struct{}),
+	}
+	go ccb.watcher()
+	ccb.balancer = gracefulswitch.NewBalancer(ccb, bopts)
+	return ccb
+}
+
+// updateType indicates the type of update pushed to the watcher goroutine.
+type updateType int
+
+const (
+	updateTypeClientConnState updateType = iota // clientConn state change from grpc
+	updateTypeSubConnState                      // subConn state change from grpc
+	updateTypeExitIdle                          // exitIdle from grpc
+	updateTypeResolverError                     // resolver error from grpc
+	updateTypeSwitchTo                          // balancer switch update from grpc
+	updateTypeSubConn                           // removeSubConn from the balancer
+)
+
+// watcherUpdate wraps the actual update to be passed to the watcher goroutine
+// with a type indicating the kind of update being wrapped.
+type watcherUpdate struct {
+	typ    updateType
+	update interface{}
+}
 
 // scStateUpdate contains the subConn and the new state it changed to.
 type scStateUpdate struct {
@@ -37,119 +101,90 @@ type scStateUpdate struct {
 	err   error
 }
 
-// exitIdle contains no data and is just a signal sent on the updateCh in
-// ccBalancerWrapper to instruct the balancer to exit idle.
-type exitIdle struct{}
-
-// ccBalancerWrapper is a wrapper on top of cc for balancers.
-// It implements balancer.ClientConn interface.
-type ccBalancerWrapper struct {
-	cc          *ClientConn
-	balancerMu  sync.Mutex // synchronizes calls to the balancer
-	balancer    balancer.Balancer
-	hasExitIdle bool
-	updateCh    *buffer.Unbounded
-	closed      *grpcsync.Event
-	done        *grpcsync.Event
-
-	mu       sync.Mutex
-	subConns map[*acBalancerWrapper]struct{}
-}
-
-func newCCBalancerWrapper(cc *ClientConn, b balancer.Builder, bopts balancer.BuildOptions) *ccBalancerWrapper {
-	ccb := &ccBalancerWrapper{
-		cc:       cc,
-		updateCh: buffer.NewUnbounded(),
-		closed:   grpcsync.NewEvent(),
-		done:     grpcsync.NewEvent(),
-		subConns: make(map[*acBalancerWrapper]struct{}),
-	}
-	go ccb.watcher()
-	ccb.balancer = b.Build(ccb, bopts)
-	_, ccb.hasExitIdle = ccb.balancer.(balancer.ExitIdler)
-	return ccb
-}
-
-// watcher balancer functions sequentially, so the balancer can be implemented
-// lock-free.
+// watcher is a long-running goroutine which reads updates from a channel and
+// invokes corresponding methods on the underlying balancer. It ensures that
+// these methods are invoked in a synchronous fashion. It also ensures that
+// these methods are invoked in the order in which the updates were received.
 func (ccb *ccBalancerWrapper) watcher() {
 	for {
 		select {
-		case t := <-ccb.updateCh.Get():
+		case u := <-ccb.updateCh.Get():
 			ccb.updateCh.Load()
 			if ccb.closed.HasFired() {
 				break
 			}
-			switch u := t.(type) {
-			case *scStateUpdate:
-				ccb.balancerMu.Lock()
-				ccb.balancer.UpdateSubConnState(u.sc, balancer.SubConnState{ConnectivityState: u.state, ConnectionError: u.err})
-				ccb.balancerMu.Unlock()
-			case *acBalancerWrapper:
-				ccb.mu.Lock()
-				if ccb.subConns != nil {
-					delete(ccb.subConns, u)
-					ccb.cc.removeAddrConn(u.getAddrConn(), errConnDrain)
-				}
-				ccb.mu.Unlock()
-			case exitIdle:
-				if ccb.cc.GetState() == connectivity.Idle {
-					if ei, ok := ccb.balancer.(balancer.ExitIdler); ok {
-						// We already checked that the balancer implements
-						// ExitIdle before pushing the event to updateCh, but
-						// check conditionally again as defensive programming.
-						ccb.balancerMu.Lock()
-						ei.ExitIdle()
-						ccb.balancerMu.Unlock()
-					}
-				}
+			update := u.(watcherUpdate)
+			switch update.typ {
+			case updateTypeClientConnState:
+				ccb.handleClientConnStateChange(update.update.(*balancer.ClientConnState))
+			case updateTypeSubConnState:
+				ccb.handleSubConnStateChange(update.update.(*scStateUpdate))
+			case updateTypeExitIdle:
+				ccb.handleExitIdle()
+			case updateTypeResolverError:
+				ccb.handleResolverError(update.update.(error))
+			case updateTypeSwitchTo:
+				ccb.handleSwitchTo(update.update.(string))
+			case updateTypeSubConn:
+				ccb.handleRemoveSubConn(update.update.(*acBalancerWrapper))
 			default:
-				logger.Errorf("ccBalancerWrapper.watcher: unknown update %+v, type %T", t, t)
+				logger.Errorf("ccBalancerWrapper.watcher: unknown update %+v, type %T", update, update)
 			}
 		case <-ccb.closed.Done():
 		}
 
 		if ccb.closed.HasFired() {
-			ccb.balancerMu.Lock()
-			ccb.balancer.Close()
-			ccb.balancerMu.Unlock()
-			ccb.mu.Lock()
-			scs := ccb.subConns
-			ccb.subConns = nil
-			ccb.mu.Unlock()
-			ccb.UpdateState(balancer.State{ConnectivityState: connectivity.Connecting, Picker: nil})
-			ccb.done.Fire()
-			// Fire done before removing the addr conns.  We can safely unblock
-			// ccb.close and allow the removeAddrConns to happen
-			// asynchronously.
-			for acbw := range scs {
-				ccb.cc.removeAddrConn(acbw.getAddrConn(), errConnDrain)
-			}
+			ccb.handleClose()
 			return
 		}
 	}
 }
 
-func (ccb *ccBalancerWrapper) close() {
+// updateClientConnState is invoked by grpc to push a ClientConnState update to
+// the underlying balancer.
+//
+// Unlike other methods invoked by grpc to push updates to the underlying
+// balancer, this method cannot simply push the update onto the update channel
+// and return. It needs to return the error returned by the underlying balancer
+// back to grpc which propagates that to the resolver.
+func (ccb *ccBalancerWrapper) updateClientConnState(ccs *balancer.ClientConnState) error {
 	if ccb == nil {
-		return
+		return nil
 	}
-	ccb.closed.Fire()
-	<-ccb.done.Done()
+	ccb.updateCh.Put(watcherUpdate{typ: updateTypeClientConnState, update: ccs})
+	res := <-ccb.resultCh.Get()
+	ccb.resultCh.Load()
+	// If the returned error is nil, attempting to type assert to error leads to
+	// panic. So, this needs to handled separately.
+	if res == nil {
+		return nil
+	}
+	return res.(error)
 }
 
-func (ccb *ccBalancerWrapper) exitIdle() bool {
-	if ccb == nil {
-		return true
+// handleClientConnStateChange handles a ClientConnState update from the update
+// channel and invokes the appropriate method on the underlying balancer.
+func (ccb *ccBalancerWrapper) handleClientConnStateChange(ccs *balancer.ClientConnState) {
+	ccb.balancerMu.Lock()
+	defer ccb.balancerMu.Unlock()
+
+	if ccb.curBalancerName != grpclbName {
+		// Filter any grpclb addresses since we don't have the grpclb balancer.
+		var addrs []resolver.Address
+		for _, addr := range ccs.ResolverState.Addresses {
+			if addr.Type == resolver.GRPCLB {
+				continue
+			}
+			addrs = append(addrs, addr)
+		}
+		ccs.ResolverState.Addresses = addrs
 	}
-	if !ccb.hasExitIdle {
-		return false
-	}
-	ccb.updateCh.Put(exitIdle{})
-	return true
+	ccb.resultCh.Put(ccb.balancer.UpdateClientConnState(*ccs))
 }
 
-func (ccb *ccBalancerWrapper) handleSubConnStateChange(sc balancer.SubConn, s connectivity.State, err error) {
+// updateSubConnState is invoked by grpc to push a subConn state update to the
+// underlying balancer.
+func (ccb *ccBalancerWrapper) updateSubConnState(sc balancer.SubConn, s connectivity.State, err error) {
 	// When updating addresses for a SubConn, if the address in use is not in
 	// the new addresses, the old ac will be tearDown() and a new ac will be
 	// created. tearDown() generates a state change with Shutdown state, we
@@ -160,35 +195,133 @@ func (ccb *ccBalancerWrapper) handleSubConnStateChange(sc balancer.SubConn, s co
 	if sc == nil {
 		return
 	}
-	ccb.updateCh.Put(&scStateUpdate{
+	ccb.updateCh.Put(watcherUpdate{typ: updateTypeSubConnState, update: &scStateUpdate{
 		sc:    sc,
 		state: s,
 		err:   err,
-	})
+	}})
 }
 
-// updateClientConnState forwards the clientConn update to the wrapped balancer
-// synchronously.
-//
-// Other calls from the channel like exitIdle() and handleSubConnStateChange()
-// are handled asynchronously by pushing the update onto a channel, which is
-// picked up by the watcher() goroutine and forwarded to the wrapped balancer.
-// That approach cannot be taken here because the corresponding API on the
-// balancer returns an error which needs to be sent back to the channel to be
-// forward to the resolver.
-func (ccb *ccBalancerWrapper) updateClientConnState(ccs *balancer.ClientConnState) error {
+// handleSubConnStateChange handles a SubConnState update from the update
+// channel and invokes the appropriate method on the underlying balancer.
+func (ccb *ccBalancerWrapper) handleSubConnStateChange(update *scStateUpdate) {
 	ccb.balancerMu.Lock()
-	defer ccb.balancerMu.Unlock()
-	return ccb.balancer.UpdateClientConnState(*ccs)
+	ccb.balancer.UpdateSubConnState(update.sc, balancer.SubConnState{ConnectivityState: update.state, ConnectionError: update.err})
+	ccb.balancerMu.Unlock()
+}
+
+func (ccb *ccBalancerWrapper) exitIdle() {
+	if ccb == nil || ccb.cc.GetState() != connectivity.Idle {
+		return
+	}
+	ccb.updateCh.Put(watcherUpdate{typ: updateTypeExitIdle})
+}
+
+func (ccb *ccBalancerWrapper) handleExitIdle() {
+	ccb.balancerMu.Lock()
+	ccb.balancer.ExitIdle()
+	ccb.balancerMu.Unlock()
 }
 
 func (ccb *ccBalancerWrapper) resolverError(err error) {
 	if ccb == nil {
 		return
 	}
+	ccb.updateCh.Put(watcherUpdate{typ: updateTypeResolverError, update: err})
+}
+
+func (ccb *ccBalancerWrapper) handleResolverError(err error) {
+	ccb.balancerMu.Lock()
+	ccb.balancer.ResolverError(err)
+	ccb.balancerMu.Unlock()
+}
+
+// switchTo is invoked by grpc to instruct the balancer wrapper to switch to the
+// LB policy identified by name.
+//
+// ClientConn calls newCCBalancerWrapper() at creation time. Upon receipt of the
+// first good update from the name resolver, it determines the LB policy to use
+// and invokes the switchTo() method. Upon receipt of every subsequent update
+// from the name resolver, it invokes this method.
+//
+// the ccBalancerWrapper keeps track of the current LB policy name, and skips
+// the graceful balancer switching process if the name does not change.
+func (ccb *ccBalancerWrapper) switchTo(name string) {
+	if ccb == nil {
+		return
+	}
+	ccb.updateCh.Put(watcherUpdate{typ: updateTypeSwitchTo, update: name})
+}
+
+// handleSwitchTo handles a balancer switch update from the update channel. It
+// calls the SwitchTo() method on the gracefulswitch.Balancer with a
+// balancer.Builder corresponding to name. If no balancer.Builder is registered
+// for the given name, it uses the default LB policy which is "pick_first".
+func (ccb *ccBalancerWrapper) handleSwitchTo(name string) {
 	ccb.balancerMu.Lock()
 	defer ccb.balancerMu.Unlock()
-	ccb.balancer.ResolverError(err)
+
+	if strings.EqualFold(ccb.curBalancerName, name) {
+		return
+	}
+
+	channelz.Infof(logger, ccb.cc.channelzID, "ClientConn switching balancer to %q", name)
+	builder := balancer.Get(name)
+	if builder == nil {
+		channelz.Warningf(logger, ccb.cc.channelzID, "Channel switches to new LB policy %q due to fallback from invalid balancer name", PickFirstBalancerName)
+		channelz.Infof(logger, ccb.cc.channelzID, "failed to get balancer builder for: %v, using pick_first instead", name)
+		builder = newPickfirstBuilder()
+	} else {
+		channelz.Infof(logger, ccb.cc.channelzID, "Channel switches to new LB policy %q", name)
+	}
+
+	if err := ccb.balancer.SwitchTo(builder); err != nil {
+		channelz.Errorf(logger, ccb.cc.channelzID, "Channel failed to build new LB policy %q: %v", name, err)
+		return
+	}
+	ccb.curBalancerName = builder.Name()
+}
+
+// handleRemoveSucConn handles a request from the underlying balancer to remove
+// a subConn.
+//
+// See comments in RemoveSubConn() for more details.
+func (ccb *ccBalancerWrapper) handleRemoveSubConn(acbw *acBalancerWrapper) {
+	ccb.mu.Lock()
+	if ccb.subConns != nil {
+		delete(ccb.subConns, acbw)
+		ccb.cc.removeAddrConn(acbw.getAddrConn(), errConnDrain)
+	}
+	ccb.mu.Unlock()
+}
+
+func (ccb *ccBalancerWrapper) close() {
+	if ccb == nil {
+		return
+	}
+	ccb.closed.Fire()
+	<-ccb.done.Done()
+}
+
+func (ccb *ccBalancerWrapper) handleClose() {
+	ccb.balancerMu.Lock()
+	ccb.balancer.Close()
+	ccb.balancerMu.Unlock()
+
+	ccb.mu.Lock()
+	scs := ccb.subConns
+	ccb.subConns = nil
+	ccb.mu.Unlock()
+
+	ccb.UpdateState(balancer.State{ConnectivityState: connectivity.Connecting, Picker: nil})
+	ccb.done.Fire()
+	// Fire done before removing the addr conns.  We can safely unblock
+	// ccb.close and allow the removeAddrConns to happen
+	// asynchronously.
+	for acbw := range scs {
+		ccb.cc.removeAddrConn(acbw.getAddrConn(), errConnDrain)
+	}
+	return
 }
 
 func (ccb *ccBalancerWrapper) NewSubConn(addrs []resolver.Address, opts balancer.NewSubConnOptions) (balancer.SubConn, error) {
@@ -214,10 +347,17 @@ func (ccb *ccBalancerWrapper) NewSubConn(addrs []resolver.Address, opts balancer
 }
 
 func (ccb *ccBalancerWrapper) RemoveSubConn(sc balancer.SubConn) {
-	// The RemoveSubConn() is handled in the run() goroutine, to avoid deadlock
-	// during switchBalancer() if the old balancer calls RemoveSubConn() in its
-	// Close().
-	ccb.updateCh.Put(sc)
+	// Before we switched the ccBalancerWrapper to use gracefulswitch.Balancer, it
+	// was required to handle the RemoveSubConn() method asynchronously by pushing
+	// the update onto the update channel. This was done to avoid a deadlock as
+	// switchBalancer() was holding cc.mu when calling Close() on the old
+	// balancer, which would in turn call RemoveSubConn().
+	//
+	// With the use of gracefulswitch.Balancer in ccBalancerWrapper, handling this
+	// asynchronously is probably not required anymore since the switchTo() method
+	// handles the balancer switch by pushing the update onto the channel.
+	// TODO(easwars): Handle this inline.
+	ccb.updateCh.Put(watcherUpdate{typ: updateTypeSubConn, update: sc})
 }
 
 func (ccb *ccBalancerWrapper) UpdateAddresses(sc balancer.SubConn, addrs []resolver.Address) {

--- a/balancer_conn_wrappers.go
+++ b/balancer_conn_wrappers.go
@@ -32,14 +32,19 @@ import (
 	"google.golang.org/grpc/resolver"
 )
 
-// ccBalancerWrapper is a wrapper on top of cc for balancers. It ensures that
-// method invocations on the underlying balancer happen synchronously and in the
-// same order in which they were received from grpc.
+// ccBalancerWrapper sits between the ClientConn and the Balancer.
+//
+// ccBalancerWrapper implements methods corresponding to the ones on the
+// balancer.Balancer interface. The ClientConn is free to call these methods
+// concurrently and the ccBalancerWrapper ensures that calls from the ClientConn
+// to the Balancer happen synchronously and in order.
+//
+// ccBalancerWrapper also implements the balancer.ClientConn interface and is
+// passed to the Balancer implementations. It invokes unexported methods on the
+// ClientConn to handle these calls from the Balancer.
 //
 // It uses the gracefulswitch.Balancer internally to ensure that balancer
 // switches happen in a graceful manner.
-//
-// It implements balancer.ClientConn interface.
 type ccBalancerWrapper struct {
 	cc *ClientConn
 

--- a/clientconn.go
+++ b/clientconn.go
@@ -278,7 +278,7 @@ func DialContext(ctx context.Context, target string, opts ...DialOption) (conn *
 	if creds := cc.dopts.copts.TransportCredentials; creds != nil {
 		credsClone = creds.Clone()
 	}
-	cc.balancerBuildOpts = balancer.BuildOptions{
+	cc.balancerWrapper = newCCBalancerWrapper(cc, balancer.BuildOptions{
 		DialCreds:        credsClone,
 		CredsBundle:      cc.dopts.copts.CredsBundle,
 		Dialer:           cc.dopts.copts.Dialer,
@@ -286,7 +286,7 @@ func DialContext(ctx context.Context, target string, opts ...DialOption) (conn *
 		CustomUserAgent:  cc.dopts.copts.UserAgent,
 		ChannelzParentID: cc.channelzID,
 		Target:           cc.parsedTarget,
-	}
+	})
 
 	// Build the resolver.
 	rWrapper, err := newCCResolverWrapper(cc, resolverBuilder)
@@ -465,12 +465,12 @@ type ClientConn struct {
 	cancel context.CancelFunc // Cancelled on close.
 
 	// The following are initialized at dial time, and are read-only after that.
-	target            string                // User's dial target.
-	parsedTarget      resolver.Target       // See parseTargetAndFindResolver().
-	authority         string                // See determineAuthority().
-	dopts             dialOptions           // Default and user specified dial options.
-	balancerBuildOpts balancer.BuildOptions // TODO: delete once we move to the gracefulswitch balancer.
-	channelzID        *channelz.Identifier  // Channelz identifier for the channel.
+	target          string               // User's dial target.
+	parsedTarget    resolver.Target      // See parseTargetAndFindResolver().
+	authority       string               // See determineAuthority().
+	dopts           dialOptions          // Default and user specified dial options.
+	channelzID      *channelz.Identifier // Channelz identifier for the channel.
+	balancerWrapper *ccBalancerWrapper   // Uses gracefulswitch.balancer underneath.
 
 	// The following provide their own synchronization, and therefore don't
 	// require cc.mu to be held to access them.
@@ -491,8 +491,6 @@ type ClientConn struct {
 	sc              *ServiceConfig             // Latest service config received from the resolver.
 	conns           map[*addrConn]struct{}     // Set to nil on close.
 	mkp             keepalive.ClientParameters // May be updated upon receipt of a GoAway.
-	curBalancerName string                     // TODO: delete as part of https://github.com/grpc/grpc-go/issues/5229.
-	balancerWrapper *ccBalancerWrapper         // TODO: Use gracefulswitch balancer to be able to initialize this once and never rewrite.
 
 	lceMu               sync.Mutex // protects lastConnectionError
 	lastConnectionError error
@@ -539,12 +537,7 @@ func (cc *ClientConn) GetState() connectivity.State {
 func (cc *ClientConn) Connect() {
 	cc.mu.Lock()
 	defer cc.mu.Unlock()
-	if cc.balancerWrapper.exitIdle() {
-		return
-	}
-	for ac := range cc.conns {
-		go ac.connect()
-	}
+	cc.balancerWrapper.exitIdle()
 }
 
 func (cc *ClientConn) scWatcher() {
@@ -666,21 +659,9 @@ func (cc *ClientConn) updateResolverState(s resolver.State, err error) error {
 	if cc.sc != nil && cc.sc.lbConfig != nil {
 		balCfg = cc.sc.lbConfig.cfg
 	}
-
-	cbn := cc.curBalancerName
 	bw := cc.balancerWrapper
 	cc.mu.Unlock()
-	if cbn != grpclbName {
-		// Filter any grpclb addresses since we don't have the grpclb balancer.
-		var addrs []resolver.Address
-		for _, addr := range s.Addresses {
-			if addr.Type == resolver.GRPCLB {
-				continue
-			}
-			addrs = append(addrs, addr)
-		}
-		s.Addresses = addrs
-	}
+
 	uccsErr := bw.updateClientConnState(&balancer.ClientConnState{ResolverState: s, BalancerConfig: balCfg})
 	if ret == nil {
 		ret = uccsErr // prefer ErrBadResolver state since any other error is
@@ -709,49 +690,13 @@ func (cc *ClientConn) applyFailingLB(sc *serviceconfig.ParseResult) {
 	cc.csMgr.updateState(connectivity.TransientFailure)
 }
 
-// switchBalancer starts the switching from current balancer to the balancer
-// with the given name.
-//
-// It will NOT send the current address list to the new balancer. If needed,
-// caller of this function should send address list to the new balancer after
-// this function returns.
-//
-// Caller must hold cc.mu.
-func (cc *ClientConn) switchBalancer(name string) {
-	if strings.EqualFold(cc.curBalancerName, name) {
-		return
-	}
-
-	channelz.Infof(logger, cc.channelzID, "ClientConn switching balancer to %q", name)
-	// Don't hold cc.mu while closing the balancers. The balancers may call
-	// methods that require cc.mu (e.g. cc.NewSubConn()). Holding the mutex
-	// would cause a deadlock in that case.
-	cc.mu.Unlock()
-	cc.balancerWrapper.close()
-	cc.mu.Lock()
-
-	builder := balancer.Get(name)
-	if builder == nil {
-		channelz.Warningf(logger, cc.channelzID, "Channel switches to new LB policy %q due to fallback from invalid balancer name", PickFirstBalancerName)
-		channelz.Infof(logger, cc.channelzID, "failed to get balancer builder for: %v, using pick_first instead", name)
-		builder = newPickfirstBuilder()
-	} else {
-		channelz.Infof(logger, cc.channelzID, "Channel switches to new LB policy %q", name)
-	}
-
-	cc.curBalancerName = builder.Name()
-	cc.balancerWrapper = newCCBalancerWrapper(cc, builder, cc.balancerBuildOpts)
-}
-
 func (cc *ClientConn) handleSubConnStateChange(sc balancer.SubConn, s connectivity.State, err error) {
 	cc.mu.Lock()
 	if cc.conns == nil {
 		cc.mu.Unlock()
 		return
 	}
-	// TODO(bar switching) send updates to all balancer wrappers when balancer
-	// gracefully switching is supported.
-	cc.balancerWrapper.handleSubConnStateChange(sc, s, err)
+	cc.balancerWrapper.updateSubConnState(sc, s, err)
 	cc.mu.Unlock()
 }
 
@@ -1002,8 +947,6 @@ func (cc *ClientConn) applyServiceConfigAndBalancer(sc *ServiceConfig, configSel
 		cc.retryThrottler.Store((*retryThrottler)(nil))
 	}
 
-	// Only look at balancer types and switch balancer if balancer dial
-	// option is not set.
 	var newBalancerName string
 	if cc.sc != nil && cc.sc.lbConfig != nil {
 		newBalancerName = cc.sc.lbConfig.name
@@ -1023,7 +966,7 @@ func (cc *ClientConn) applyServiceConfigAndBalancer(sc *ServiceConfig, configSel
 			newBalancerName = PickFirstBalancerName
 		}
 	}
-	cc.switchBalancer(newBalancerName)
+	cc.balancerWrapper.switchTo(newBalancerName)
 }
 
 func (cc *ClientConn) resolveNow(o resolver.ResolveNowOptions) {

--- a/clientconn.go
+++ b/clientconn.go
@@ -692,10 +692,6 @@ func (cc *ClientConn) applyFailingLB(sc *serviceconfig.ParseResult) {
 
 func (cc *ClientConn) handleSubConnStateChange(sc balancer.SubConn, s connectivity.State, err error) {
 	cc.mu.Lock()
-	if cc.conns == nil {
-		cc.mu.Unlock()
-		return
-	}
 	cc.balancerWrapper.updateSubConnState(sc, s, err)
 	cc.mu.Unlock()
 }
@@ -1017,7 +1013,6 @@ func (cc *ClientConn) Close() error {
 	rWrapper := cc.resolverWrapper
 	cc.resolverWrapper = nil
 	bWrapper := cc.balancerWrapper
-	cc.balancerWrapper = nil
 	cc.mu.Unlock()
 
 	cc.blockingpicker.close()

--- a/clientconn_test.go
+++ b/clientconn_test.go
@@ -845,9 +845,13 @@ func (s) TestBackoffCancel(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create ClientConn: %v", err)
 	}
-	<-dialStrCh
-	cc.Close()
-	// Should not leak. May need -count 5000 to exercise.
+	defer cc.Close()
+
+	select {
+	case <-time.After(defaultTestTimeout):
+		t.Fatal("Timeout when waiting for custom dialer to be invoked during Dial")
+	case <-dialStrCh:
+	}
 }
 
 // UpdateAddresses should cause the next reconnect to begin from the top of the

--- a/internal/balancer/gracefulswitch/gracefulswitch.go
+++ b/internal/balancer/gracefulswitch/gracefulswitch.go
@@ -179,9 +179,8 @@ func (gsb *Balancer) ResolverError(err error) {
 
 // ExitIdle forwards the call to the latest balancer created.
 //
-// If the latest balancer does not support ExitIdle, the subConns need to be
-// re-connected manually. This used to be done in the ClientConn earlier, but
-// is done here now since the ClientConn uses gsb by default.
+// If the latest balancer does not support ExitIdle, the subConns are
+// re-connected to manually.
 func (gsb *Balancer) ExitIdle() {
 	balToUpdate := gsb.latestBalancer()
 	if balToUpdate == nil {

--- a/test/balancer_switching_test.go
+++ b/test/balancer_switching_test.go
@@ -482,11 +482,11 @@ func (s) TestBalancerSwitch_grpclbAddressOverridesLoadBalancingPolicy(t *testing
 	// Switch to "round_robin" by removing the address of type "grpclb".
 	now = time.Now()
 	r.UpdateState(resolver.State{Addresses: addrs})
-	if err := checkRoundRobin(ctx, cc, addrs); err != nil {
-		t.Fatal(err)
-	}
 	if err := checkForTraceEvent(ctx, wantRoundRobinTraceDesc, now); err != nil {
 		t.Fatalf("timeout when waiting for a trace event: %s, err: %v", wantRoundRobinTraceDesc, err)
+	}
+	if err := checkRoundRobin(ctx, cc, addrs); err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/test/balancer_switching_test.go
+++ b/test/balancer_switching_test.go
@@ -269,9 +269,6 @@ func (s) TestBalancerSwitch_pickFirstToGRPCLB(t *testing.T) {
 	if err := checkForTraceEvent(ctx, wantGRPCLBTraceDesc, now); err != nil {
 		t.Fatalf("timeout when waiting for a trace event: %s, err: %v", wantGRPCLBTraceDesc, err)
 	}
-	if err := checkRoundRobin(ctx, cc, addrs); err != nil {
-		t.Fatal(err)
-	}
 
 	// Push a resolver update containing a non-existent grpclb server address.
 	// This should not lead to a balancer switch.
@@ -353,9 +350,6 @@ func (s) TestBalancerSwitch_RoundRobinToGRPCLB(t *testing.T) {
 	})
 	if err := checkForTraceEvent(ctx, wantGRPCLBTraceDesc, now); err != nil {
 		t.Fatalf("timeout when waiting for a trace event: %s, err: %v", wantGRPCLBTraceDesc, err)
-	}
-	if err := checkRoundRobin(ctx, cc, addrs); err != nil {
-		t.Fatal(err)
 	}
 
 	// Switch back to "round_robin".
@@ -464,9 +458,6 @@ func (s) TestBalancerSwitch_grpclbAddressOverridesLoadBalancingPolicy(t *testing
 	})
 	if err := checkForTraceEvent(ctx, wantGRPCLBTraceDesc, now); err != nil {
 		t.Fatalf("timeout when waiting for a trace event: %s, err: %v", wantGRPCLBTraceDesc, err)
-	}
-	if err := checkRoundRobin(ctx, cc, addrs); err != nil {
-		t.Fatal(err)
 	}
 
 	// Push a resolver update with a service config using the deprecated


### PR DESCRIPTION
This PR changes the default behavior of `ClientConn` when it ends up switching the LB policy. 
- Earlier, it used to close the old policy and start the new one, when it received a service config update pointing to a new LB policy. 
- Now, it uses the [gracefulswitch.Balancer](https://github.com/grpc/grpc-go/blob/99aae3442dbe8495247dda07a6b1c8cda98accca/internal/balancer/gracefulswitch/gracefulswitch.go#L46) to gracefully switch from the old balancer to the new one.

Summary of code changes:
- Use a `gracefulswitch.Balancer` in `ccBalancerWrapper` instead of `balancer.Balancer`
  - Add a `switchTo` method to the balancer wrapper which calls `SwitchTo` on the `gracefulswitch.Balancer` 
  - Ensure calls from grpc to the underlying balancers are ordered
    - For every type of update from grpc, we now have:
      - a method which pushes the update into the update channel
      - a method which handles the update, when processed by the `watcher` goroutine
    - An enum to represent the type of grpc update pushed into the update channel
  - The `watcher` goroutine is now merely a skeleton, with functionality moved to appropriate handlers
  - Add more comments to the balancer wrapper code
- The following functionality has been moved out of `ClientConn`:
  - Falling back to the default LB policy when the specified LB policy is not registered is moved to the `ccBalancerWrapper` 
  - Filtering of addresses of type `GRPCLB` is now handled by the `ccBalancerWrapper`
  - Manually calling `Connect` on the `subConns` if the underlying balancer does not support `ExitIdle` is moved to the `gracefulswitch.Balancer`

Summary of test changes:
- Added a test in `test/balancer_switching_test.go` to exercise the graceful switching functionality e2e
- While I was adding the above mentioned test, I figured out that I can make the `stubBalancer` wrap a real balancer. Updated an existing test in `test/resolver_update_test.go` which was using a custom balancer for the same to use the `stubBalancer` instead.
- Added `ParseConfig` functionality to the `stubBalancer`
- Updated a test in `clientconn_test.go` to fail within a reasonable amount of time. (This test was timing out initially when I was making my changes, so had to fix it).

Fixes https://github.com/grpc/grpc-go/issues/5270

RELEASE NOTES: 
- perform graceful switching of LB policies in the `ClientConn` by default