### PR TITLE
[v1.38.x] xds/kokoro: install go 1.17, and retry go build (#5015)

### DIFF
--- a/test/kokoro/xds.sh
+++ b/test/kokoro/xds.sh
@@ -19,7 +19,13 @@ shopt -s extglob
 branch="${branch//[[:space:]]}"
 branch="${branch##remotes/origin/}"
 shopt -u extglob
-go build
+# Install a version of Go supported by gRPC for the new features, e.g.
+# errors.Is()
+curl --retry 3 -O -L https://go.dev/dl/go1.17.3.linux-amd64.tar.gz
+sudo tar -C /usr/local -xf go1.17.3.linux-amd64.tar.gz
+sudo ln -s /usr/local/go/bin/go /usr/bin/go
+# Retry go build on errors (e.g. go get connection errors), for at most 3 times
+for i in 1 2 3; do go build && break || sleep 5; done
 popd
 
 git clone -b "${branch}" --single-branch --depth=1 https://github.com/grpc/grpc.git


### PR DESCRIPTION
1.38 xds tests are failing with 
```
# [golang.org/x/net/http2](https://www.google.com/url?q=http://golang.org/x/net/http2&sa=D)
/home/kbuilder/gopath/pkg/mod/[golang.org/x/net@v0.0.0-20220127200216-cd36cc0744dd/http2/client_conn_pool.go:302:6](https://www.google.com/url?q=http://golang.org/x/net@v0.0.0-20220127200216-cd36cc0744dd/http2/client_conn_pool.go:302:6&sa=D): undefined: errors.Is
/home/kbuilder/gopath/pkg/mod/[golang.org/x/net@v0.0.0-20220127200216-cd36cc0744dd/http2/transport.go:417:30](https://www.google.com/url?q=http://golang.org/x/net@v0.0.0-20220127200216-cd36cc0744dd/http2/transport.go:417:30&sa=D): undefined: errors.Is
/home/kbuilder/gopath/pkg/mod/[golang.org/x/net@v0.0.0-20220127200216-cd36cc0744dd/http2/transport.go:417:45](https://www.google.com/url?q=http://golang.org/x/net@v0.0.0-20220127200216-cd36cc0744dd/http2/transport.go:417:45&sa=D): undefined: os.ErrDeadlineExceeded
/home/kbuilder/gopath/pkg/mod/[golang.org/x/net@v0.0.0-20220127200216-cd36cc0744dd/http2/transport.go:2076:5](https://www.google.com/url?q=http://golang.org/x/net@v0.0.0-20220127200216-cd36cc0744dd/http2/transport.go:2076:5&sa=D): undefined: errors.Is
/home/kbuilder/gopath/pkg/mod/[golang.org/x/net@v0.0.0-20220127200216-cd36cc0744dd/http2/transport.go:2080:5](https://www.google.com/url?q=http://golang.org/x/net@v0.0.0-20220127200216-cd36cc0744dd/http2/transport.go:2080:5&sa=D): undefined: errors.Is
/home/kbuilder/gopath/pkg/mod/[golang.org/x/net@v0.0.0-20220127200216-cd36cc0744dd/http2/transport.go:2084:5](https://www.google.com/url?q=http://golang.org/x/net@v0.0.0-20220127200216-cd36cc0744dd/http2/transport.go:2084:5&sa=D): undefined: errors.Is
note: module requires Go 1.17
```

RELEASE NOTES: N/A