### PR TITLE
server: return better status for context err when writing header

### DIFF
--- a/internal/transport/http2_server.go
+++ b/internal/transport/http2_server.go
@@ -959,7 +959,7 @@ func (t *http2Server) WriteHeader(s *Stream, md metadata.MD) error {
 	}
 	if err := t.writeHeaderLocked(s); err != nil {
 		s.hdrMu.Unlock()
-		return status.Errorf(codes.Internal, "transport: %+v", err)
+		return status.Convert(err).Err()
 	}
 	s.hdrMu.Unlock()
 	return nil

--- a/internal/transport/http2_server.go
+++ b/internal/transport/http2_server.go
@@ -950,7 +950,7 @@ func (t *http2Server) WriteHeader(s *Stream, md metadata.MD) error {
 	}
 	if err := t.writeHeaderLocked(s); err != nil {
 		s.hdrMu.Unlock()
-		return err
+		return status.Errorf(codes.Internal, "transport: %+v", err)
 	}
 	s.hdrMu.Unlock()
 	return nil

--- a/internal/transport/http2_server.go
+++ b/internal/transport/http2_server.go
@@ -1065,6 +1065,9 @@ func (t *http2Server) Write(s *Stream, hdr []byte, data []byte, opts *Options) e
 			if _, ok := err.(ConnectionError); ok {
 				return err
 			}
+			if s.ctx.Err() != nil {
+				return ContextErr(s.ctx.Err())
+			}
 			// TODO(mmukhi, dfawley): Make sure this is the right code to return.
 			return status.Errorf(codes.Internal, "transport: %v", err)
 		}

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -4964,8 +4964,8 @@ func testClientSendDataAfterCloseSend(t *testing.T, e env) {
 		}
 		if err := stream.SendMsg(nil); err == nil {
 			t.Error("expected error sending message on stream after stream closed due to illegal data")
-		} else if status.Code(err) != codes.Internal {
-			t.Errorf("expected internal error, instead received '%v'", err)
+		} else if status.Code(err) != codes.Canceled {
+			t.Errorf("expected cancel error, instead received '%v'", err)
 		}
 		return nil
 	}}


### PR DESCRIPTION
I think this closes https://github.com/grpc/grpc-go/issues/4696

It looks like `Write` unconditionally returns `status.Errorf(codes.Internal, "transport: %v", err)` when we see an error writing the headers. However, in certain cases we'll actually have an overriding context error here, like a cancellation. This PR changes the behavior to return that instead if it's present.

This matches the behavior in the other branch of the conditional (https://github.com/grpc/grpc-go/blob/1f12bf44284e6ba4be72cd028a2a1eb01c2d18bb/internal/transport/http2_server.go#L1028), where if the stream is in state `streamDone`, this either returns `ErrConnClosing` or the `s.ctx.Err()`. We already check for the stream being `streamDone` inside `WriteHeader`, so I opted not to duplicate that check and instead just return the ctx error if it's present. 

If we wanted a more specific fix, this could change 
```Go
if s.ctx.Err() != nil {
    return ContextErr(s.ctx.Err())
}
``` 
to
```Go
if s.getState() == streamDone && s.ctx.Err() != nil {
    return ContextErr(s.ctx.Err())
}
```

but it duplicates the check inside `WriteHeader`.

(This is my first gRPC contribution, so apologies if I haven't followed the right process or I've overlooked something)

RELEASE NOTES:
* server: return Canceled or DeadlineExceeded status code when writing headers to a stream that is already closed