### PR TITLE
client: fix potential panic during RPC retries

### DIFF
--- a/clientconn.go
+++ b/clientconn.go
@@ -907,14 +907,10 @@ func (cc *ClientConn) healthCheckConfig() *healthCheckConfig {
 }
 
 func (cc *ClientConn) getTransport(ctx context.Context, failfast bool, method string) (transport.ClientTransport, func(balancer.DoneInfo), error) {
-	t, done, err := cc.blockingpicker.pick(ctx, failfast, balancer.PickInfo{
+	return cc.blockingpicker.pick(ctx, failfast, balancer.PickInfo{
 		Ctx:            ctx,
 		FullMethodName: method,
 	})
-	if err != nil {
-		return nil, nil, toRPCErr(err)
-	}
-	return t, done, nil
 }
 
 func (cc *ClientConn) applyServiceConfigAndBalancer(sc *ServiceConfig, configSelector iresolver.ConfigSelector, addrs []resolver.Address) {

--- a/picker_wrapper.go
+++ b/picker_wrapper.go
@@ -131,7 +131,7 @@ func (pw *pickerWrapper) pick(ctx context.Context, failfast bool, info balancer.
 			}
 			if _, ok := status.FromError(err); ok {
 				// Status error: end the RPC unconditionally with this status.
-				return nil, nil, err
+				return nil, nil, dropError{error: err}
 			}
 			// For all other errors, wait for ready RPCs should block and other
 			// RPCs should fail with unavailable.
@@ -174,4 +174,10 @@ func (pw *pickerWrapper) close() {
 	}
 	pw.done = true
 	close(pw.blockingCh)
+}
+
+// dropError is a wrapper error that indicates the LB policy wishes to drop the
+// RPC and not retry it.
+type dropError struct {
+	error
 }

--- a/stream.go
+++ b/stream.go
@@ -673,7 +673,6 @@ func (cs *clientStream) retryLocked(attempt *csAttempt, lastErr error) error {
 		if err != nil {
 			// Only returns error if the clientconn is closed or the context of
 			// the stream is canceled.
-			cs.finish(err)
 			return err
 		}
 		// Note that the first op in the replay buffer always sets cs.attempt

--- a/stream.go
+++ b/stream.go
@@ -816,7 +816,6 @@ func (cs *clientStream) SendMsg(m interface{}) (err error) {
 	if len(payload) > *cs.callInfo.maxSendMessageSize {
 		return status.Errorf(codes.ResourceExhausted, "trying to send message larger than max (%d vs. %d)", len(payload), *cs.callInfo.maxSendMessageSize)
 	}
-	msgBytes := data // Store the pointer before setting to nil. For binary logging.
 	op := func(a *csAttempt) error {
 		return a.sendMsg(m, hdr, payload, data)
 	}
@@ -824,7 +823,7 @@ func (cs *clientStream) SendMsg(m interface{}) (err error) {
 	if cs.binlog != nil && err == nil {
 		cs.binlog.Log(&binarylog.ClientMessage{
 			OnClientSide: true,
-			Message:      msgBytes,
+			Message:      data,
 		})
 	}
 	return err

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -1508,7 +1508,7 @@ func testFailFast(t *testing.T, e env) {
 
 	cc := te.clientConn()
 	tc := testpb.NewTestServiceClient(cc)
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
 	if _, err := tc.EmptyCall(ctx, &testpb.Empty{}); err != nil {
 		t.Fatalf("TestService/EmptyCall(_, _) = _, %v, want _, <nil>", err)
@@ -1517,9 +1517,10 @@ func testFailFast(t *testing.T, e env) {
 	te.srv.Stop()
 	// Loop until the server teardown is propagated to the client.
 	for {
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		if err := ctx.Err(); err != nil {
+			t.Fatalf("EmptyCall did not return UNAVAILABLE before timeout")
+		}
 		_, err := tc.EmptyCall(ctx, &testpb.Empty{})
-		cancel()
 		if status.Code(err) == codes.Unavailable {
 			break
 		}

--- a/test/retry_test.go
+++ b/test/retry_test.go
@@ -34,6 +34,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/internal/grpcsync"
 	"google.golang.org/grpc/internal/stubserver"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/stats"
@@ -44,7 +45,8 @@ import (
 func (s) TestRetryUnary(t *testing.T) {
 	i := -1
 	ss := &stubserver.StubServer{
-		EmptyCallF: func(context.Context, *testpb.Empty) (*testpb.Empty, error) {
+		EmptyCallF: func(context.Context, *testpb.Empty) (r *testpb.Empty, err error) {
+			defer func() { t.Logf("server call %v returning err %v", i, err) }()
 			i++
 			switch i {
 			case 0, 2, 5:
@@ -55,11 +57,8 @@ func (s) TestRetryUnary(t *testing.T) {
 			return nil, status.New(codes.AlreadyExists, "retryable error").Err()
 		},
 	}
-	if err := ss.Start([]grpc.ServerOption{}); err != nil {
-		t.Fatalf("Error starting endpoint server: %v", err)
-	}
-	defer ss.Stop()
-	ss.NewServiceConfig(`{
+	if err := ss.Start([]grpc.ServerOption{},
+		grpc.WithDefaultServiceConfig(`{
     "methodConfig": [{
       "name": [{"service": "grpc.testing.TestService"}],
       "waitForReady": true,
@@ -70,18 +69,10 @@ func (s) TestRetryUnary(t *testing.T) {
         "BackoffMultiplier": 1.0,
         "RetryableStatusCodes": [ "ALREADY_EXISTS" ]
       }
-    }]}`)
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	for {
-		if ctx.Err() != nil {
-			t.Fatalf("Timed out waiting for service config update")
-		}
-		if ss.CC.GetMethodConfig("/grpc.testing.TestService/EmptyCall").WaitForReady != nil {
-			break
-		}
-		time.Sleep(time.Millisecond)
+    }]}`)); err != nil {
+		t.Fatalf("Error starting endpoint server: %v", err)
 	}
-	cancel()
+	defer ss.Stop()
 
 	testCases := []struct {
 		code  codes.Code
@@ -95,7 +86,8 @@ func (s) TestRetryUnary(t *testing.T) {
 		{codes.Internal, 11},
 		{codes.AlreadyExists, 15},
 	}
-	for _, tc := range testCases {
+	for num, tc := range testCases {
+		t.Log("Case", num)
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		_, err := ss.Client.EmptyCall(ctx, &testpb.Empty{})
 		cancel()
@@ -120,11 +112,8 @@ func (s) TestRetryThrottling(t *testing.T) {
 			return nil, status.New(codes.Unavailable, "retryable error").Err()
 		},
 	}
-	if err := ss.Start([]grpc.ServerOption{}); err != nil {
-		t.Fatalf("Error starting endpoint server: %v", err)
-	}
-	defer ss.Stop()
-	ss.NewServiceConfig(`{
+	if err := ss.Start([]grpc.ServerOption{},
+		grpc.WithDefaultServiceConfig(`{
     "methodConfig": [{
       "name": [{"service": "grpc.testing.TestService"}],
       "waitForReady": true,
@@ -140,18 +129,10 @@ func (s) TestRetryThrottling(t *testing.T) {
       "maxTokens": 10,
       "tokenRatio": 0.5
     }
-  }`)
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	for {
-		if ctx.Err() != nil {
-			t.Fatalf("Timed out waiting for service config update")
-		}
-		if ss.CC.GetMethodConfig("/grpc.testing.TestService/EmptyCall").WaitForReady != nil {
-			break
-		}
-		time.Sleep(time.Millisecond)
+    }`)); err != nil {
+		t.Fatalf("Error starting endpoint server: %v", err)
 	}
-	cancel()
+	defer ss.Stop()
 
 	testCases := []struct {
 		code  codes.Code
@@ -430,11 +411,8 @@ func (s) TestRetryStreaming(t *testing.T) {
 			return nil
 		},
 	}
-	if err := ss.Start([]grpc.ServerOption{}, grpc.WithDefaultCallOptions(grpc.MaxRetryRPCBufferSize(200))); err != nil {
-		t.Fatalf("Error starting endpoint server: %v", err)
-	}
-	defer ss.Stop()
-	ss.NewServiceConfig(`{
+	if err := ss.Start([]grpc.ServerOption{}, grpc.WithDefaultCallOptions(grpc.MaxRetryRPCBufferSize(200)),
+		grpc.WithDefaultServiceConfig(`{
     "methodConfig": [{
       "name": [{"service": "grpc.testing.TestService"}],
       "waitForReady": true,
@@ -445,7 +423,10 @@ func (s) TestRetryStreaming(t *testing.T) {
           "BackoffMultiplier": 1.0,
           "RetryableStatusCodes": [ "UNAVAILABLE" ]
       }
-    }]}`)
+    }]}`)); err != nil {
+		t.Fatalf("Error starting endpoint server: %v", err)
+	}
+	defer ss.Stop()
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	for {
 		if ctx.Err() != nil {
@@ -643,4 +624,86 @@ func (s) TestRetryStats(t *testing.T) {
 	if diff < 10*time.Millisecond || diff > 50*time.Millisecond {
 		t.Fatalf("pushback time before final attempt = %v; want ~10ms", diff)
 	}
+}
+
+func (s) TestRetryTransparentWhenCommitted(t *testing.T) {
+	// With MaxConcurrentStreams=1:
+	//
+	// 1. Create stream 1 that is retriable.
+	// 2. Stream 1 is created and fails with a retriable code.
+	// 3. Create dummy stream 2, blocking indefinitely.
+	// 4. Stream 1 retries (and blocks until stream 2 finishes)
+	// 5. Stream 1 is canceled manually.
+	//
+	// If there is no bug, the stream is done and errors with CANCELED.  With a bug:
+	//
+	// 6. Stream 1 has a nil stream (attempt.s).  Operations like CloseSend will panic.
+
+	first := grpcsync.NewEvent()
+	ss := &stubserver.StubServer{
+		FullDuplexCallF: func(stream testpb.TestService_FullDuplexCallServer) error {
+			// signal?
+			if !first.HasFired() {
+				first.Fire()
+				t.Log("returned first error")
+				return status.Error(codes.AlreadyExists, "first attempt fails and is retriable")
+			}
+			t.Log("blocking")
+			<-stream.Context().Done()
+			return stream.Context().Err()
+		},
+	}
+
+	if err := ss.Start([]grpc.ServerOption{grpc.MaxConcurrentStreams(1)},
+		grpc.WithDefaultServiceConfig(`{
+    "methodConfig": [{
+      "name": [{"service": "grpc.testing.TestService"}],
+      "waitForReady": true,
+      "retryPolicy": {
+        "MaxAttempts": 2,
+        "InitialBackoff": ".1s",
+        "MaxBackoff": ".1s",
+        "BackoffMultiplier": 1.0,
+        "RetryableStatusCodes": [ "ALREADY_EXISTS" ]
+      }
+    }]}`)); err != nil {
+		t.Fatalf("Error starting endpoint server: %v", err)
+	}
+	defer ss.Stop()
+
+	ctx1, cancel1 := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel1()
+	ctx2, cancel2 := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel2()
+
+	stream1, err := ss.Client.FullDuplexCall(ctx1)
+	if err != nil {
+		t.Fatalf("Error creating stream 1: %v", err)
+	}
+
+	// Create dummy stream to block indefinitely.
+	_, err = ss.Client.FullDuplexCall(ctx2)
+	if err != nil {
+		t.Errorf("Error creating stream 2: %v", err)
+	}
+
+	stream1Closed := grpcsync.NewEvent()
+	go func() {
+		_, err := stream1.Recv()
+		// Will trigger a retry when it sees the ALREADY_EXISTS error
+		if status.Code(err) != codes.Canceled {
+			t.Errorf("Expected stream1 to be canceled; got error: %v", err)
+		}
+		stream1Closed.Fire()
+	}()
+
+	// Wait longer than the retry backoff timer.
+	time.Sleep(200 * time.Millisecond)
+	cancel1()
+
+	// Operations on the stream should not panic.
+	<-stream1Closed.Done()
+	stream1.CloseSend()
+	stream1.Recv()
+	stream1.Send(&testpb.StreamingOutputCallRequest{})
 }


### PR DESCRIPTION
Fixes #5315

Before this change, there was a very narrow window where a stream could fail to be created on a retry attempt, and subsequent stream operations could panic when this occurred.  This change is a fairly substantial restructuring of the retry code in order to guarantee that for all clientStreams returned to the user, `cs.attempt.s` is always non-nil.  New attempts that don't yet have a stream are created in `cs.newAttempt` until they pick a transport and create a stream, at which time they are promoted to `cs.attempt`.

This also allows us to run balancer pick results through the retry code, meaning UNAVAILABLE errors can be retried by the retry policy, as intended.  It also handles drop results that should explicitly avoid the retry code.

RELEASE NOTES:
* client: fix potential panic during RPC retries