### PR TITLE
internal/transport: clarify server maxStream default

### DIFF
--- a/internal/transport/defaults.go
+++ b/internal/transport/defaults.go
@@ -35,6 +35,7 @@ const (
 	defaultMaxConnectionIdle      = infinity
 	defaultMaxConnectionAge       = infinity
 	defaultMaxConnectionAgeGrace  = infinity
+	defaultMaxStreamsServer       = math.MaxUint32
 	defaultServerKeepaliveTime    = 2 * time.Hour
 	defaultServerKeepaliveTimeout = 20 * time.Second
 	defaultKeepalivePolicyMinTime = 5 * time.Minute

--- a/internal/transport/http2_server.go
+++ b/internal/transport/http2_server.go
@@ -169,7 +169,7 @@ func NewServerTransport(conn net.Conn, config *ServerConfig) (_ ServerTransport,
 	// permitted in the HTTP2 spec.
 	maxStreams := config.MaxStreams
 	if maxStreams == 0 {
-		maxStreams = math.MaxUint32
+		maxStreams = defaultMaxStreamsServer
 	} else {
 		isettings = append(isettings, http2.Setting{
 			ID:  http2.SettingMaxConcurrentStreams,

--- a/server.go
+++ b/server.go
@@ -360,6 +360,7 @@ func MaxSendMsgSize(m int) ServerOption {
 
 // MaxConcurrentStreams returns a ServerOption that will apply a limit on the number
 // of concurrent streams to each ServerTransport.
+// If this is not set, gRPC uses the default `math.MaxInt32`.
 func MaxConcurrentStreams(n uint32) ServerOption {
 	return newFuncServerOption(func(o *serverOptions) {
 		o.maxConcurrentStreams = n


### PR DESCRIPTION
The current maxStream default for the server is not documented in the same way as the client and leads to some confusion. This PR adds clarification of the server defaults. 

RELEASE NOTES:

- server: improve documentation of maxStream default