### PR TITLE
stats: add support for multiple stats handlers in a single client or server

### DIFF
--- a/dialoptions.go
+++ b/dialoptions.go
@@ -380,7 +380,7 @@ func WithDialer(f func(string, time.Duration) (net.Conn, error)) DialOption {
 // all the RPCs and underlying network connections in this ClientConn.
 func WithStatsHandler(h stats.Handler) DialOption {
 	return newFuncDialOption(func(o *dialOptions) {
-		o.copts.StatsHandler = h
+		o.copts.StatsHandler = append(o.copts.StatsHandler, h)
 	})
 }
 

--- a/dialoptions.go
+++ b/dialoptions.go
@@ -380,7 +380,7 @@ func WithDialer(f func(string, time.Duration) (net.Conn, error)) DialOption {
 // all the RPCs and underlying network connections in this ClientConn.
 func WithStatsHandler(h stats.Handler) DialOption {
 	return newFuncDialOption(func(o *dialOptions) {
-		o.copts.StatsHandler = append(o.copts.StatsHandler, h)
+		o.copts.StatsHandlers = append(o.copts.StatsHandlers, h)
 	})
 }
 

--- a/internal/transport/handler_server.go
+++ b/internal/transport/handler_server.go
@@ -49,7 +49,7 @@ import (
 // NewServerHandlerTransport returns a ServerTransport handling gRPC
 // from inside an http.Handler. It requires that the http Server
 // supports HTTP/2.
-func NewServerHandlerTransport(w http.ResponseWriter, r *http.Request, stats stats.Handler) (ServerTransport, error) {
+func NewServerHandlerTransport(w http.ResponseWriter, r *http.Request, stats []stats.Handler) (ServerTransport, error) {
 	if r.ProtoMajor != 2 {
 		return nil, errors.New("gRPC requires HTTP/2")
 	}
@@ -138,7 +138,7 @@ type serverHandlerTransport struct {
 	// TODO make sure this is consistent across handler_server and http2_server
 	contentSubtype string
 
-	stats stats.Handler
+	stats []stats.Handler
 }
 
 func (ht *serverHandlerTransport) Close() {
@@ -228,12 +228,14 @@ func (ht *serverHandlerTransport) WriteStatus(s *Stream, st *status.Status) erro
 	})
 
 	if err == nil { // transport has not been closed
-		if ht.stats != nil {
+		if len(ht.stats) != 0 {
 			// Note: The trailer fields are compressed with hpack after this call returns.
 			// No WireLength field is set here.
-			ht.stats.HandleRPC(s.Context(), &stats.OutTrailer{
-				Trailer: s.trailer.Copy(),
-			})
+			for _, sh := range ht.stats {
+				sh.HandleRPC(s.Context(), &stats.OutTrailer{
+					Trailer: s.trailer.Copy(),
+				})
+			}
 		}
 	}
 	ht.Close()
@@ -314,13 +316,15 @@ func (ht *serverHandlerTransport) WriteHeader(s *Stream, md metadata.MD) error {
 	})
 
 	if err == nil {
-		if ht.stats != nil {
-			// Note: The header fields are compressed with hpack after this call returns.
-			// No WireLength field is set here.
-			ht.stats.HandleRPC(s.Context(), &stats.OutHeader{
-				Header:      md.Copy(),
-				Compression: s.sendCompress,
-			})
+		if len(ht.stats) != 0 {
+			for _, sh := range ht.stats {
+				// Note: The header fields are compressed with hpack after this call returns.
+				// No WireLength field is set here.
+				sh.HandleRPC(s.Context(), &stats.OutHeader{
+					Header:      md.Copy(),
+					Compression: s.sendCompress,
+				})
+			}
 		}
 	}
 	return err
@@ -369,14 +373,16 @@ func (ht *serverHandlerTransport) HandleStreams(startStream func(*Stream), trace
 	}
 	ctx = metadata.NewIncomingContext(ctx, ht.headerMD)
 	s.ctx = peer.NewContext(ctx, pr)
-	if ht.stats != nil {
-		s.ctx = ht.stats.TagRPC(s.ctx, &stats.RPCTagInfo{FullMethodName: s.method})
-		inHeader := &stats.InHeader{
-			FullMethod:  s.method,
-			RemoteAddr:  ht.RemoteAddr(),
-			Compression: s.recvCompress,
+	if len(ht.stats) != 0 {
+		for _, sh := range ht.stats {
+			s.ctx = sh.TagRPC(s.ctx, &stats.RPCTagInfo{FullMethodName: s.method})
+			inHeader := &stats.InHeader{
+				FullMethod:  s.method,
+				RemoteAddr:  ht.RemoteAddr(),
+				Compression: s.recvCompress,
+			}
+			sh.HandleRPC(s.ctx, inHeader)
 		}
-		ht.stats.HandleRPC(s.ctx, inHeader)
 	}
 	s.trReader = &transportReader{
 		reader:        &recvBufferReader{ctx: s.ctx, ctxDone: s.ctx.Done(), recv: s.buf, freeBuffer: func(*bytes.Buffer) {}},

--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -90,7 +90,7 @@ type http2Client struct {
 	kp               keepalive.ClientParameters
 	keepaliveEnabled bool
 
-	statsHandler stats.Handler
+	statsHandler []stats.Handler
 
 	initialWindowSize int32
 
@@ -341,15 +341,17 @@ func newHTTP2Client(connectCtx, ctx context.Context, addr resolver.Address, opts
 			updateFlowControl: t.updateFlowControl,
 		}
 	}
-	if t.statsHandler != nil {
-		t.ctx = t.statsHandler.TagConn(t.ctx, &stats.ConnTagInfo{
-			RemoteAddr: t.remoteAddr,
-			LocalAddr:  t.localAddr,
-		})
-		connBegin := &stats.ConnBegin{
-			Client: true,
+	if len(t.statsHandler) != 0 {
+		for _, sh := range t.statsHandler {
+			t.ctx = sh.TagConn(t.ctx, &stats.ConnTagInfo{
+				RemoteAddr: t.remoteAddr,
+				LocalAddr:  t.localAddr,
+			})
+			connBegin := &stats.ConnBegin{
+				Client: true,
+			}
+			sh.HandleConn(t.ctx, connBegin)
 		}
-		t.statsHandler.HandleConn(t.ctx, connBegin)
 	}
 	t.channelzID, err = channelz.RegisterNormalSocket(t, opts.ChannelzParentID, fmt.Sprintf("%s -> %s", t.localAddr, t.remoteAddr))
 	if err != nil {
@@ -773,24 +775,27 @@ func (t *http2Client) NewStream(ctx context.Context, callHdr *CallHdr) (*Stream,
 			return nil, &NewStreamError{Err: ErrConnClosing, AllowTransparentRetry: true}
 		}
 	}
-	if t.statsHandler != nil {
+	if len(t.statsHandler) != 0 {
 		header, ok := metadata.FromOutgoingContext(ctx)
 		if ok {
 			header.Set("user-agent", t.userAgent)
 		} else {
 			header = metadata.Pairs("user-agent", t.userAgent)
 		}
-		// Note: The header fields are compressed with hpack after this call returns.
-		// No WireLength field is set here.
-		outHeader := &stats.OutHeader{
-			Client:      true,
-			FullMethod:  callHdr.Method,
-			RemoteAddr:  t.remoteAddr,
-			LocalAddr:   t.localAddr,
-			Compression: callHdr.SendCompress,
-			Header:      header,
+		for _, sh := range t.statsHandler {
+			// Note: The header fields are compressed with hpack after this call returns.
+			// No WireLength field is set here.
+			// Note: Creating a new stats object to prevent pollution.
+			outHeader := &stats.OutHeader{
+				Client:      true,
+				FullMethod:  callHdr.Method,
+				RemoteAddr:  t.remoteAddr,
+				LocalAddr:   t.localAddr,
+				Compression: callHdr.SendCompress,
+				Header:      header,
+			}
+			sh.HandleRPC(s.ctx, outHeader)
 		}
-		t.statsHandler.HandleRPC(s.ctx, outHeader)
 	}
 	return s, nil
 }
@@ -916,11 +921,13 @@ func (t *http2Client) Close(err error) {
 	for _, s := range streams {
 		t.closeStream(s, err, false, http2.ErrCodeNo, st, nil, false)
 	}
-	if t.statsHandler != nil {
-		connEnd := &stats.ConnEnd{
-			Client: true,
+	if len(t.statsHandler) != 0 {
+		for _, sh := range t.statsHandler {
+			connEnd := &stats.ConnEnd{
+				Client: true,
+			}
+			sh.HandleConn(t.ctx, connEnd)
 		}
-		t.statsHandler.HandleConn(t.ctx, connEnd)
 	}
 }
 
@@ -1432,22 +1439,24 @@ func (t *http2Client) operateHeaders(frame *http2.MetaHeadersFrame) {
 		close(s.headerChan)
 	}
 
-	if t.statsHandler != nil {
-		if isHeader {
-			inHeader := &stats.InHeader{
-				Client:      true,
-				WireLength:  int(frame.Header().Length),
-				Header:      metadata.MD(mdata).Copy(),
-				Compression: s.recvCompress,
+	if len(t.statsHandler) != 0 {
+		for _, sh := range t.statsHandler {
+			if isHeader {
+				inHeader := &stats.InHeader{
+					Client:      true,
+					WireLength:  int(frame.Header().Length),
+					Header:      metadata.MD(mdata).Copy(),
+					Compression: s.recvCompress,
+				}
+				sh.HandleRPC(s.ctx, inHeader)
+			} else {
+				inTrailer := &stats.InTrailer{
+					Client:     true,
+					WireLength: int(frame.Header().Length),
+					Trailer:    metadata.MD(mdata).Copy(),
+				}
+				sh.HandleRPC(s.ctx, inTrailer)
 			}
-			t.statsHandler.HandleRPC(s.ctx, inHeader)
-		} else {
-			inTrailer := &stats.InTrailer{
-				Client:     true,
-				WireLength: int(frame.Header().Length),
-				Trailer:    metadata.MD(mdata).Copy(),
-			}
-			t.statsHandler.HandleRPC(s.ctx, inTrailer)
 		}
 	}
 

--- a/internal/transport/transport.go
+++ b/internal/transport/transport.go
@@ -523,7 +523,7 @@ type ServerConfig struct {
 	ConnectionTimeout     time.Duration
 	Credentials           credentials.TransportCredentials
 	InTapHandle           tap.ServerInHandle
-	StatsHandler          stats.Handler
+	StatsHandler          []stats.Handler
 	KeepaliveParams       keepalive.ServerParameters
 	KeepalivePolicy       keepalive.EnforcementPolicy
 	InitialWindowSize     int32
@@ -554,7 +554,7 @@ type ConnectOptions struct {
 	// KeepaliveParams stores the keepalive parameters.
 	KeepaliveParams keepalive.ClientParameters
 	// StatsHandler stores the handler for stats.
-	StatsHandler stats.Handler
+	StatsHandler []stats.Handler
 	// InitialWindowSize sets the initial window size for a stream.
 	InitialWindowSize int32
 	// InitialConnWindowSize sets the initial window size for a connection.

--- a/internal/transport/transport.go
+++ b/internal/transport/transport.go
@@ -523,7 +523,7 @@ type ServerConfig struct {
 	ConnectionTimeout     time.Duration
 	Credentials           credentials.TransportCredentials
 	InTapHandle           tap.ServerInHandle
-	StatsHandler          []stats.Handler
+	StatsHandlers         []stats.Handler
 	KeepaliveParams       keepalive.ServerParameters
 	KeepalivePolicy       keepalive.EnforcementPolicy
 	InitialWindowSize     int32
@@ -553,8 +553,8 @@ type ConnectOptions struct {
 	CredsBundle credentials.Bundle
 	// KeepaliveParams stores the keepalive parameters.
 	KeepaliveParams keepalive.ClientParameters
-	// StatsHandler stores the handler for stats.
-	StatsHandler []stats.Handler
+	// StatsHandlers stores the handler for stats.
+	StatsHandlers []stats.Handler
 	// InitialWindowSize sets the initial window size for a stream.
 	InitialWindowSize int32
 	// InitialConnWindowSize sets the initial window size for a connection.

--- a/stats/stats_test.go
+++ b/stats/stats_test.go
@@ -1391,6 +1391,26 @@ func (s) TestMultipleClientStatsHandler(t *testing.T) {
 	te.cc.Close()
 	te.srv.GracefulStop() // Wait for the server to stop.
 
+	for start := time.Now(); time.Since(start) < defaultTestTimeout; {
+		h.mu.Lock()
+		if _, ok := h.gotRPC[len(h.gotRPC)-1].s.(*stats.End); ok {
+			h.mu.Unlock()
+			break
+		}
+		h.mu.Unlock()
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	for start := time.Now(); time.Since(start) < defaultTestTimeout; {
+		h.mu.Lock()
+		if _, ok := h.gotConn[len(h.gotConn)-1].s.(*stats.ConnEnd); ok {
+			h.mu.Unlock()
+			break
+		}
+		h.mu.Unlock()
+		time.Sleep(10 * time.Millisecond)
+	}
+
 	// Each RPC generates 6 stats events on the client-side, times 2 StatsHandler
 	if len(h.gotRPC) != 12 {
 		t.Fatalf("h.gotRPC: unexpected amount of RPCStats: %v != %v", len(h.gotRPC), 12)
@@ -1416,6 +1436,26 @@ func (s) TestMultipleServerStatsHandler(t *testing.T) {
 	}
 	te.cc.Close()
 	te.srv.GracefulStop() // Wait for the server to stop.
+
+	for start := time.Now(); time.Since(start) < defaultTestTimeout; {
+		h.mu.Lock()
+		if _, ok := h.gotRPC[len(h.gotRPC)-1].s.(*stats.End); ok {
+			h.mu.Unlock()
+			break
+		}
+		h.mu.Unlock()
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	for start := time.Now(); time.Since(start) < defaultTestTimeout; {
+		h.mu.Lock()
+		if _, ok := h.gotConn[len(h.gotConn)-1].s.(*stats.ConnEnd); ok {
+			h.mu.Unlock()
+			break
+		}
+		h.mu.Unlock()
+		time.Sleep(10 * time.Millisecond)
+	}
 
 	// Each RPC generates 6 stats events on the server-side, times 2 StatsHandler
 	if len(h.gotRPC) != 12 {


### PR DESCRIPTION
As title.

The user-facing interface is unchanged, but the behavior is slightly different. (We discussed this) If a user application intentionally sets StatsHandler repeatedly and only expects the last one to be effective, we will break them.

RELEASE NOTES:
* stats: add support for multiple stats handlers in a single client or server