### PR TITLE
xds/resolver: use correct resource name in log message

### DIFF
--- a/xds/internal/resolver/watch_service.go
+++ b/xds/internal/resolver/watch_service.go
@@ -58,6 +58,10 @@ type ldsConfig struct {
 // Note that during race (e.g. an xDS response is received while the user is
 // calling cancel()), there's a small window where the callback can be called
 // after the watcher is canceled. The caller needs to handle this case.
+//
+// TODO(easwars): Make this function a method on the xdsResolver type.
+// Currently, there is a single call site for this function, and all arguments
+// passed to it are fields of the xdsResolver type.
 func watchService(c xdsclient.XDSClient, serviceName string, cb func(serviceUpdate, error), logger *grpclog.PrefixLogger) (cancel func()) {
 	w := &serviceUpdateWatcher{
 		logger:      logger,

--- a/xds/internal/resolver/xds_resolver.go
+++ b/xds/internal/resolver/xds_resolver.go
@@ -63,9 +63,8 @@ type xdsResolverBuilder struct {
 //
 // The xds bootstrap process is performed (and a new xds client is built) every
 // time an xds resolver is built.
-func (b *xdsResolverBuilder) Build(t resolver.Target, cc resolver.ClientConn, opts resolver.BuildOptions) (_ resolver.Resolver, retErr error) {
+func (b *xdsResolverBuilder) Build(target resolver.Target, cc resolver.ClientConn, opts resolver.BuildOptions) (_ resolver.Resolver, retErr error) {
 	r := &xdsResolver{
-		target:         t,
 		cc:             cc,
 		closed:         grpcsync.NewEvent(),
 		updateCh:       make(chan suWithError, 1),
@@ -77,7 +76,7 @@ func (b *xdsResolverBuilder) Build(t resolver.Target, cc resolver.ClientConn, op
 		}
 	}()
 	r.logger = prefixLogger(r)
-	r.logger.Infof("Creating resolver for target: %+v", t)
+	r.logger.Infof("Creating resolver for target: %+v", target)
 
 	newXDSClient := newXDSClient
 	if b.newXDSClient != nil {
@@ -115,7 +114,7 @@ func (b *xdsResolverBuilder) Build(t resolver.Target, cc resolver.ClientConn, op
 	// - If authority is not set in the target, use the top level template
 	// - If authority is set, use the template from the authority map.
 	template := bootstrapConfig.ClientDefaultListenerResourceNameTemplate
-	if authority := r.target.URL.Host; authority != "" {
+	if authority := target.URL.Host; authority != "" {
 		a := bootstrapConfig.Authorities[authority]
 		if a == nil {
 			return nil, fmt.Errorf("xds: authority %q is not found in the bootstrap file", authority)
@@ -127,19 +126,19 @@ func (b *xdsResolverBuilder) Build(t resolver.Target, cc resolver.ClientConn, op
 			template = a.ClientListenerResourceNameTemplate
 		}
 	}
-	endpoint := r.target.URL.Path
+	endpoint := target.URL.Path
 	if endpoint == "" {
-		endpoint = r.target.URL.Opaque
+		endpoint = target.URL.Opaque
 	}
 	endpoint = strings.TrimPrefix(endpoint, "/")
-	resourceName := bootstrap.PopulateResourceTemplate(template, endpoint)
+	r.ldsResourceName = bootstrap.PopulateResourceTemplate(template, endpoint)
 
 	// Register a watch on the xdsClient for the resource name determined above.
-	cancelWatch := watchService(r.client, resourceName, r.handleServiceUpdate, r.logger)
-	r.logger.Infof("Watch started on resource name %v with xds-client %p", resourceName, r.client)
+	cancelWatch := watchService(r.client, r.ldsResourceName, r.handleServiceUpdate, r.logger)
+	r.logger.Infof("Watch started on resource name %v with xds-client %p", r.ldsResourceName, r.client)
 	r.cancelWatch = func() {
 		cancelWatch()
-		r.logger.Infof("Watch cancel on resource name %v with xds-client %p", resourceName, r.client)
+		r.logger.Infof("Watch cancel on resource name %v with xds-client %p", r.ldsResourceName, r.client)
 	}
 
 	go r.run()
@@ -165,11 +164,10 @@ type suWithError struct {
 // (which performs LDS/RDS queries for the same), and passes the received
 // updates to the ClientConn.
 type xdsResolver struct {
-	target resolver.Target
-	cc     resolver.ClientConn
-	closed *grpcsync.Event
-
-	logger *grpclog.PrefixLogger
+	cc              resolver.ClientConn
+	closed          *grpcsync.Event
+	logger          *grpclog.PrefixLogger
+	ldsResourceName string
 
 	// The underlying xdsClient which performs all xDS requests and responses.
 	client xdsclient.XDSClient
@@ -212,7 +210,7 @@ func (r *xdsResolver) sendNewServiceConfig(cs *configSelector) bool {
 		r.cc.ReportError(err)
 		return false
 	}
-	r.logger.Infof("Received update on resource %v from xds-client %p, generated service config: %v", r.target.Endpoint, r.client, pretty.FormatJSON(sc))
+	r.logger.Infof("Received update on resource %v from xds-client %p, generated service config: %v", r.ldsResourceName, r.client, pretty.FormatJSON(sc))
 
 	// Send the update to the ClientConn.
 	state := iresolver.SetConfigSelector(resolver.State{
@@ -231,7 +229,7 @@ func (r *xdsResolver) run() {
 			return
 		case update := <-r.updateCh:
 			if update.err != nil {
-				r.logger.Warningf("Watch error on resource %v from xds-client %p, %v", r.target.Endpoint, r.client, update.err)
+				r.logger.Warningf("Watch error on resource %v from xds-client %p, %v", r.ldsResourceName, r.client, update.err)
 				if xdsresource.ErrType(update.err) == xdsresource.ErrorTypeResourceNotFound {
 					// If error is resource-not-found, it means the LDS
 					// resource was removed. Ultimately send an empty service
@@ -259,7 +257,7 @@ func (r *xdsResolver) run() {
 			// Create the config selector for this update.
 			cs, err := r.newConfigSelector(update.su)
 			if err != nil {
-				r.logger.Warningf("Error parsing update on resource %v from xds-client %p: %v", r.target.Endpoint, r.client, err)
+				r.logger.Warningf("Error parsing update on resource %v from xds-client %p: %v", r.ldsResourceName, r.client, err)
 				r.cc.ReportError(err)
 				continue
 			}

--- a/xds/internal/resolver/xds_resolver.go
+++ b/xds/internal/resolver/xds_resolver.go
@@ -134,12 +134,12 @@ func (b *xdsResolverBuilder) Build(t resolver.Target, cc resolver.ClientConn, op
 	endpoint = strings.TrimPrefix(endpoint, "/")
 	resourceName := bootstrap.PopulateResourceTemplate(template, endpoint)
 
-	// Register a watch on the xdsClient for the user's dial target.
+	// Register a watch on the xdsClient for the resource name determined above.
 	cancelWatch := watchService(r.client, resourceName, r.handleServiceUpdate, r.logger)
-	r.logger.Infof("Watch started on resource name %v with xds-client %p", r.target.Endpoint, r.client)
+	r.logger.Infof("Watch started on resource name %v with xds-client %p", resourceName, r.client)
 	r.cancelWatch = func() {
 		cancelWatch()
-		r.logger.Infof("Watch cancel on resource name %v with xds-client %p", r.target.Endpoint, r.client)
+		r.logger.Infof("Watch cancel on resource name %v with xds-client %p", resourceName, r.client)
 	}
 
 	go r.run()


### PR DESCRIPTION
With federation support, `resourceName` could be different from the user's dial target.

RELEASE NOTES: none