### PR TITLE
Don't call cmp in non-testing file

### DIFF
--- a/xds/internal/balancer/cdsbalancer/cdsbalancer.go
+++ b/xds/internal/balancer/cdsbalancer/cdsbalancer.go
@@ -272,12 +272,12 @@ func buildProviderFunc(configs map[string]*certprovider.BuildableConfig, instanc
 	return provider, nil
 }
 
-func outlierDetectionToConfig(od *xdsresource.OutlierDetection) *outlierdetection.LBConfig { // Already validated - no need to return error
+func outlierDetectionToConfig(od *xdsresource.OutlierDetection) *outlierdetection.ODConfig { // Already validated - no need to return error
 	if od == nil {
 		// "If the outlier_detection field is not set in the Cluster message, a
 		// "no-op" outlier_detection config will be generated, with interval set
 		// to the maximum possible value and all other fields unset." - A50
-		return &outlierdetection.LBConfig{
+		return &outlierdetection.ODConfig{
 			Interval: 1<<63 - 1,
 		}
 	}
@@ -308,7 +308,7 @@ func outlierDetectionToConfig(od *xdsresource.OutlierDetection) *outlierdetectio
 		}
 	}
 
-	return &outlierdetection.LBConfig{
+	return &outlierdetection.ODConfig{
 		Interval:                  od.Interval,
 		BaseEjectionTime:          od.BaseEjectionTime,
 		MaxEjectionTime:           od.MaxEjectionTime,

--- a/xds/internal/balancer/cdsbalancer/cdsbalancer_test.go
+++ b/xds/internal/balancer/cdsbalancer/cdsbalancer_test.go
@@ -56,7 +56,7 @@ var (
 		ServerURI: "self_server",
 		CredsType: "self_creds",
 	}
-	noopODLBCfg = &outlierdetection.LBConfig{
+	noopODLBCfg = &outlierdetection.ODConfig{
 		Interval: 1<<63 - 1,
 	}
 )
@@ -215,7 +215,7 @@ func cdsCCS(cluster string, xdsC xdsclient.XDSClient) balancer.ClientConnState {
 
 // edsCCS is a helper function to construct a good update passed from the
 // cdsBalancer to the edsBalancer.
-func edsCCS(service string, countMax *uint32, enableLRS bool, xdslbpolicy *internalserviceconfig.BalancerConfig, odConfig *outlierdetection.LBConfig) balancer.ClientConnState {
+func edsCCS(service string, countMax *uint32, enableLRS bool, xdslbpolicy *internalserviceconfig.BalancerConfig, odConfig *outlierdetection.ODConfig) balancer.ClientConnState {
 	discoveryMechanism := clusterresolver.DiscoveryMechanism{
 		Type:                  clusterresolver.DiscoveryMechanismTypeEDS,
 		Cluster:               service,
@@ -421,7 +421,7 @@ func (s) TestHandleClusterUpdate(t *testing.T) {
 				FailurePercentageMinimumHosts:  5,
 				FailurePercentageRequestVolume: 50,
 			}},
-			wantCCS: edsCCS(serviceName, nil, false, nil, &outlierdetection.LBConfig{
+			wantCCS: edsCCS(serviceName, nil, false, nil, &outlierdetection.ODConfig{
 				Interval:           10 * time.Second,
 				BaseEjectionTime:   30 * time.Second,
 				MaxEjectionTime:    300 * time.Second,
@@ -846,7 +846,7 @@ func (s) TestOutlierDetectionToConfig(t *testing.T) {
 	tests := []struct {
 		name        string
 		od          *xdsresource.OutlierDetection
-		odLBCfgWant *outlierdetection.LBConfig
+		odLBCfgWant *outlierdetection.ODConfig
 	}{
 		// "if the outlier_detection field is not set in the Cluster resource,
 		// a "no-op" outlier_detection config will be generated in the
@@ -876,7 +876,7 @@ func (s) TestOutlierDetectionToConfig(t *testing.T) {
 				FailurePercentageMinimumHosts:  5,
 				FailurePercentageRequestVolume: 50,
 			},
-			odLBCfgWant: &outlierdetection.LBConfig{
+			odLBCfgWant: &outlierdetection.ODConfig{
 				Interval:            10 * time.Second,
 				BaseEjectionTime:    30 * time.Second,
 				MaxEjectionTime:     300 * time.Second,
@@ -909,7 +909,7 @@ func (s) TestOutlierDetectionToConfig(t *testing.T) {
 				FailurePercentageMinimumHosts:  5,
 				FailurePercentageRequestVolume: 50,
 			},
-			odLBCfgWant: &outlierdetection.LBConfig{
+			odLBCfgWant: &outlierdetection.ODConfig{
 				Interval:           10 * time.Second,
 				BaseEjectionTime:   30 * time.Second,
 				MaxEjectionTime:    300 * time.Second,
@@ -939,7 +939,7 @@ func (s) TestOutlierDetectionToConfig(t *testing.T) {
 				FailurePercentageMinimumHosts:  5,
 				FailurePercentageRequestVolume: 50,
 			},
-			odLBCfgWant: &outlierdetection.LBConfig{
+			odLBCfgWant: &outlierdetection.ODConfig{
 				Interval:           10 * time.Second,
 				BaseEjectionTime:   30 * time.Second,
 				MaxEjectionTime:    300 * time.Second,

--- a/xds/internal/balancer/clusterresolver/config.go
+++ b/xds/internal/balancer/clusterresolver/config.go
@@ -103,9 +103,9 @@ type DiscoveryMechanism struct {
 	// DNSHostname is the DNS name to resolve in "host:port" form. For type
 	// LOGICAL_DNS only.
 	DNSHostname string `json:"dnsHostname,omitempty"`
-	// OutlierDetection is the Outlier Detection LB configuration for this
+	// OutlierDetection is the Outlier Detection configuration for this
 	// priority.
-	OutlierDetection *outlierdetection.LBConfig `json:"outlierDetection,omitempty"`
+	OutlierDetection *outlierdetection.ODConfig `json:"outlierDetection,omitempty"`
 }
 
 // Equal returns whether the DiscoveryMechanism is the same with the parameter.

--- a/xds/internal/balancer/outlierdetection/config.go
+++ b/xds/internal/balancer/outlierdetection/config.go
@@ -22,7 +22,6 @@ package outlierdetection
 import (
 	"time"
 
-	"github.com/google/go-cmp/cmp"
 	internalserviceconfig "google.golang.org/grpc/internal/serviceconfig"
 	"google.golang.org/grpc/serviceconfig"
 )
@@ -154,7 +153,9 @@ type LBConfig struct {
 	ChildPolicy *internalserviceconfig.BalancerConfig `json:"childPolicy,omitempty"`
 }
 
-// Equal returns whether the LBConfig is the same with the parameter.
+// Equal returns whether the LBConfig is the same with the parameter, outside of
+// the child policy. The child policy will need to be manually compared in tests
+// (to avoid cmp in this non-testing file).
 func (lbc *LBConfig) Equal(lbc2 *LBConfig) bool {
 	if lbc == nil && lbc2 == nil {
 		return true
@@ -177,8 +178,5 @@ func (lbc *LBConfig) Equal(lbc2 *LBConfig) bool {
 	if !lbc.SuccessRateEjection.Equal(lbc2.SuccessRateEjection) {
 		return false
 	}
-	if !lbc.FailurePercentageEjection.Equal(lbc2.FailurePercentageEjection) {
-		return false
-	}
-	return cmp.Equal(lbc.ChildPolicy, lbc2.ChildPolicy)
+	return lbc.FailurePercentageEjection.Equal(lbc2.FailurePercentageEjection)
 }

--- a/xds/internal/balancer/outlierdetection/config.go
+++ b/xds/internal/balancer/outlierdetection/config.go
@@ -124,9 +124,8 @@ func (fpe *FailurePercentageEjection) Equal(fpe2 *FailurePercentageEjection) boo
 	return fpe.RequestVolume == fpe2.RequestVolume
 }
 
-// LBConfig is the config for the outlier detection balancer.
-type LBConfig struct {
-	serviceconfig.LoadBalancingConfig `json:"-"`
+// ODConfig is the config for outlier detection behavior.
+type ODConfig struct {
 	// Interval is the time interval between ejection analysis sweeps. This can
 	// result in both new ejections as well as addresses being returned to
 	// service. Defaults to 10s.
@@ -149,34 +148,41 @@ type LBConfig struct {
 	// FailurePercentageEjection is the parameters for the failure percentage
 	// algorithm. If set, failure rate ejections will be performed.
 	FailurePercentageEjection *FailurePercentageEjection `json:"failurePercentageEjection,omitempty"`
-	// ChildPolicy is the config for the child policy.
-	ChildPolicy *internalserviceconfig.BalancerConfig `json:"childPolicy,omitempty"`
 }
 
 // Equal returns whether the LBConfig is the same with the parameter, outside of
 // the child policy. The child policy will need to be manually compared in tests
 // (to avoid cmp in this non-testing file).
-func (lbc *LBConfig) Equal(lbc2 *LBConfig) bool {
-	if lbc == nil && lbc2 == nil {
+func (odc *ODConfig) Equal(odc2 *ODConfig) bool {
+	if odc == nil && odc2 == nil {
 		return true
 	}
-	if (lbc != nil) != (lbc2 != nil) {
+	if (odc != nil) != (odc2 != nil) {
 		return false
 	}
-	if lbc.Interval != lbc2.Interval {
+	if odc.Interval != odc2.Interval {
 		return false
 	}
-	if lbc.BaseEjectionTime != lbc2.BaseEjectionTime {
+	if odc.BaseEjectionTime != odc2.BaseEjectionTime {
 		return false
 	}
-	if lbc.MaxEjectionTime != lbc2.MaxEjectionTime {
+	if odc.MaxEjectionTime != odc2.MaxEjectionTime {
 		return false
 	}
-	if lbc.MaxEjectionPercent != lbc2.MaxEjectionPercent {
+	if odc.MaxEjectionPercent != odc2.MaxEjectionPercent {
 		return false
 	}
-	if !lbc.SuccessRateEjection.Equal(lbc2.SuccessRateEjection) {
+	if !odc.SuccessRateEjection.Equal(odc2.SuccessRateEjection) {
 		return false
 	}
-	return lbc.FailurePercentageEjection.Equal(lbc2.FailurePercentageEjection)
+	return odc.FailurePercentageEjection.Equal(odc2.FailurePercentageEjection)
+}
+
+// LBConfig is the config for the outlier detection balancer.
+type LBConfig struct {
+	serviceconfig.LoadBalancingConfig `json:"-"`
+	// ODConfig is the Outlier Detection specific configuration.
+	ODConfig *ODConfig `json:"odConfig,omitempty"`
+	// ChildPolicy is the config for the child policy.
+	ChildPolicy *internalserviceconfig.BalancerConfig `json:"childPolicy,omitempty"`
 }


### PR DESCRIPTION
Fixes issue #5353.

The config's Equal method is called by CDS to check the equality of discovery mechanisms. However, due to the fact that the Child Policy will not be prepared by the CDS Balancer, but will be prepared by the Cluster Resolver balancer, getting rid of the check is a logical no-op.

The config's Equal method is also called by the cmp package for testing purposes. However, to not have it call cmp.Equal to compare the child policy, I will switch my PR out (#5304) to manually compare the child policies in tests.

RELEASE NOTES: None