### PR TITLE
xds: Outlier Detection configuration in Cluster Resolver Balancer

### DIFF
--- a/xds/internal/balancer/cdsbalancer/cdsbalancer.go
+++ b/xds/internal/balancer/cdsbalancer/cdsbalancer.go
@@ -272,12 +272,12 @@ func buildProviderFunc(configs map[string]*certprovider.BuildableConfig, instanc
 	return provider, nil
 }
 
-func outlierDetectionToConfig(od *xdsresource.OutlierDetection) *outlierdetection.LBConfig { // Already validated - no need to return error
+func outlierDetectionToConfig(od *xdsresource.OutlierDetection) *outlierdetection.ODConfig { // Already validated - no need to return error
 	if od == nil {
 		// "If the outlier_detection field is not set in the Cluster message, a
 		// "no-op" outlier_detection config will be generated, with interval set
 		// to the maximum possible value and all other fields unset." - A50
-		return &outlierdetection.LBConfig{
+		return &outlierdetection.ODConfig{
 			Interval: 1<<63 - 1,
 		}
 	}
@@ -308,7 +308,7 @@ func outlierDetectionToConfig(od *xdsresource.OutlierDetection) *outlierdetectio
 		}
 	}
 
-	return &outlierdetection.LBConfig{
+	return &outlierdetection.ODConfig{
 		Interval:                  od.Interval,
 		BaseEjectionTime:          od.BaseEjectionTime,
 		MaxEjectionTime:           od.MaxEjectionTime,

--- a/xds/internal/balancer/cdsbalancer/cdsbalancer_test.go
+++ b/xds/internal/balancer/cdsbalancer/cdsbalancer_test.go
@@ -56,7 +56,7 @@ var (
 		ServerURI: "self_server",
 		CredsType: "self_creds",
 	}
-	noopODLBCfg = &outlierdetection.LBConfig{
+	noopODLBCfg = &outlierdetection.ODConfig{
 		Interval: 1<<63 - 1,
 	}
 )
@@ -215,7 +215,7 @@ func cdsCCS(cluster string, xdsC xdsclient.XDSClient) balancer.ClientConnState {
 
 // edsCCS is a helper function to construct a good update passed from the
 // cdsBalancer to the edsBalancer.
-func edsCCS(service string, countMax *uint32, enableLRS bool, xdslbpolicy *internalserviceconfig.BalancerConfig, odConfig *outlierdetection.LBConfig) balancer.ClientConnState {
+func edsCCS(service string, countMax *uint32, enableLRS bool, xdslbpolicy *internalserviceconfig.BalancerConfig, odConfig *outlierdetection.ODConfig) balancer.ClientConnState {
 	discoveryMechanism := clusterresolver.DiscoveryMechanism{
 		Type:                  clusterresolver.DiscoveryMechanismTypeEDS,
 		Cluster:               service,
@@ -421,7 +421,7 @@ func (s) TestHandleClusterUpdate(t *testing.T) {
 				FailurePercentageMinimumHosts:  5,
 				FailurePercentageRequestVolume: 50,
 			}},
-			wantCCS: edsCCS(serviceName, nil, false, nil, &outlierdetection.LBConfig{
+			wantCCS: edsCCS(serviceName, nil, false, nil, &outlierdetection.ODConfig{
 				Interval:           10 * time.Second,
 				BaseEjectionTime:   30 * time.Second,
 				MaxEjectionTime:    300 * time.Second,
@@ -846,7 +846,7 @@ func (s) TestOutlierDetectionToConfig(t *testing.T) {
 	tests := []struct {
 		name        string
 		od          *xdsresource.OutlierDetection
-		odLBCfgWant *outlierdetection.LBConfig
+		odLBCfgWant *outlierdetection.ODConfig
 	}{
 		// "if the outlier_detection field is not set in the Cluster resource,
 		// a "no-op" outlier_detection config will be generated in the
@@ -876,7 +876,7 @@ func (s) TestOutlierDetectionToConfig(t *testing.T) {
 				FailurePercentageMinimumHosts:  5,
 				FailurePercentageRequestVolume: 50,
 			},
-			odLBCfgWant: &outlierdetection.LBConfig{
+			odLBCfgWant: &outlierdetection.ODConfig{
 				Interval:            10 * time.Second,
 				BaseEjectionTime:    30 * time.Second,
 				MaxEjectionTime:     300 * time.Second,
@@ -909,7 +909,7 @@ func (s) TestOutlierDetectionToConfig(t *testing.T) {
 				FailurePercentageMinimumHosts:  5,
 				FailurePercentageRequestVolume: 50,
 			},
-			odLBCfgWant: &outlierdetection.LBConfig{
+			odLBCfgWant: &outlierdetection.ODConfig{
 				Interval:           10 * time.Second,
 				BaseEjectionTime:   30 * time.Second,
 				MaxEjectionTime:    300 * time.Second,
@@ -939,7 +939,7 @@ func (s) TestOutlierDetectionToConfig(t *testing.T) {
 				FailurePercentageMinimumHosts:  5,
 				FailurePercentageRequestVolume: 50,
 			},
-			odLBCfgWant: &outlierdetection.LBConfig{
+			odLBCfgWant: &outlierdetection.ODConfig{
 				Interval:           10 * time.Second,
 				BaseEjectionTime:   30 * time.Second,
 				MaxEjectionTime:    300 * time.Second,

--- a/xds/internal/balancer/clusterresolver/clusterresolver_test.go
+++ b/xds/internal/balancer/clusterresolver/clusterresolver_test.go
@@ -25,12 +25,20 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"google.golang.org/grpc/balancer"
+	"google.golang.org/grpc/balancer/roundrobin"
+	"google.golang.org/grpc/balancer/weightedtarget"
 	"google.golang.org/grpc/connectivity"
+	"google.golang.org/grpc/internal/envconfig"
 	"google.golang.org/grpc/internal/grpctest"
+	internalserviceconfig "google.golang.org/grpc/internal/serviceconfig"
 	"google.golang.org/grpc/internal/testutils"
 	"google.golang.org/grpc/resolver"
 	"google.golang.org/grpc/xds/internal"
+	"google.golang.org/grpc/xds/internal/balancer/clusterimpl"
+	"google.golang.org/grpc/xds/internal/balancer/outlierdetection"
+	"google.golang.org/grpc/xds/internal/balancer/priority"
 	"google.golang.org/grpc/xds/internal/testutils/fakeclient"
 	"google.golang.org/grpc/xds/internal/xdsclient"
 	"google.golang.org/grpc/xds/internal/xdsclient/xdsresource"
@@ -129,6 +137,18 @@ func (f *fakeChildBalancer) UpdateSubConnState(sc balancer.SubConn, state balanc
 func (f *fakeChildBalancer) Close() {}
 
 func (f *fakeChildBalancer) ExitIdle() {}
+
+func (f *fakeChildBalancer) waitForClientConnStateChangeVerifyBalancerConfig(ctx context.Context, wantCCS balancer.ClientConnState) error {
+	ccs, err := f.clientConnState.Receive(ctx)
+	if err != nil {
+		return err
+	}
+	gotCCS := ccs.(balancer.ClientConnState)
+	if diff := cmp.Diff(gotCCS, wantCCS, cmpopts.IgnoreFields(resolver.State{}, "Addresses", "ServiceConfig", "Attributes")); diff != "" {
+		return fmt.Errorf("received unexpected ClientConnState, diff (-got +want): %v", diff)
+	}
+	return nil
+}
 
 func (f *fakeChildBalancer) waitForClientConnStateChange(ctx context.Context) error {
 	_, err := f.clientConnState.Receive(ctx)
@@ -498,5 +518,102 @@ func newLBConfigWithOneEDS(edsServiceName string) *LBConfig {
 			Type:           DiscoveryMechanismTypeEDS,
 			EDSServiceName: edsServiceName,
 		}},
+	}
+}
+
+func newLBConfigWithOneEDSAndOutlierDetection(edsServiceName string, odCfg *outlierdetection.ODConfig) *LBConfig {
+	lbCfg := newLBConfigWithOneEDS(edsServiceName)
+	lbCfg.DiscoveryMechanisms[0].OutlierDetection = odCfg
+	return lbCfg
+}
+
+// TestOutlierDetection tests the Balancer Config sent down to the child
+// priority balancer when Outlier Detection is turned on. The Priority
+// Configuration sent downward should have a top level Outlier Detection Policy
+// for each priority.
+func (s) TestOutlierDetection(t *testing.T) {
+	oldOutlierDetection := envconfig.XDSOutlierDetection
+	envconfig.XDSOutlierDetection = true
+	defer func() {
+		envconfig.XDSOutlierDetection = oldOutlierDetection
+	}()
+
+	edsLBCh := testutils.NewChannel()
+	xdsC, cleanup := setup(edsLBCh)
+	defer cleanup()
+	builder := balancer.Get(Name)
+	edsB := builder.Build(newNoopTestClientConn(), balancer.BuildOptions{})
+	if edsB == nil {
+		t.Fatalf("builder.Build(%s) failed and returned nil", Name)
+	}
+	defer edsB.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+
+	// Update Cluster Resolver with Client Conn State with Outlier Detection
+	// configuration present. This is what will be passed down to this balancer,
+	// as CDS Balancer gets the Cluster Update and converts the Outlier
+	// Detection data to an Outlier Detection configuration and sends it to this
+	// level.
+	if err := edsB.UpdateClientConnState(balancer.ClientConnState{
+		ResolverState:  xdsclient.SetClient(resolver.State{}, xdsC),
+		BalancerConfig: newLBConfigWithOneEDSAndOutlierDetection(testEDSServcie, noopODCfg),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := xdsC.WaitForWatchEDS(ctx); err != nil {
+		t.Fatalf("xdsClient.WatchEndpoints failed with error: %v", err)
+	}
+
+	// Invoke EDS Callback - causes child balancer to be built and then
+	// UpdateClientConnState called on it with Outlier Detection as a direct
+	// child.
+	xdsC.InvokeWatchEDSCallback("", defaultEndpointsUpdate, nil)
+	edsLB, err := waitForNewChildLB(ctx, edsLBCh)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	localityID := internal.LocalityID{Zone: "zone"}
+	// The priority configuration generated should have Outlier Detection as a
+	// direct child due to Outlier Detection being turned on.
+	pCfgWant := &priority.LBConfig{
+		Children: map[string]*priority.Child{
+			"priority-0-1": {
+				Config: &internalserviceconfig.BalancerConfig{
+					Name: outlierdetection.Name,
+					Config: &outlierdetection.LBConfig{
+						ODConfig: noopODCfg,
+						ChildPolicy: &internalserviceconfig.BalancerConfig{
+							Name: clusterimpl.Name,
+							Config: &clusterimpl.LBConfig{
+								Cluster:        testClusterName,
+								EDSServiceName: "test-eds-service-name",
+								ChildPolicy: &internalserviceconfig.BalancerConfig{
+									Name: weightedtarget.Name,
+									Config: &weightedtarget.LBConfig{
+										Targets: map[string]weightedtarget.Target{
+											assertString(localityID.ToString): {
+												Weight:      100,
+												ChildPolicy: &internalserviceconfig.BalancerConfig{Name: roundrobin.Name},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				IgnoreReresolutionRequests: true,
+			},
+		},
+		Priorities: []string{"priority-0-1"},
+	}
+
+	if err := edsLB.waitForClientConnStateChangeVerifyBalancerConfig(ctx, balancer.ClientConnState{
+		BalancerConfig: pCfgWant,
+	}); err != nil {
+		t.Fatalf("EDS impl got unexpected update: %v", err)
 	}
 }

--- a/xds/internal/balancer/clusterresolver/config.go
+++ b/xds/internal/balancer/clusterresolver/config.go
@@ -103,9 +103,9 @@ type DiscoveryMechanism struct {
 	// DNSHostname is the DNS name to resolve in "host:port" form. For type
 	// LOGICAL_DNS only.
 	DNSHostname string `json:"dnsHostname,omitempty"`
-	// OutlierDetection is the Outlier Detection LB configuration for this
+	// OutlierDetection is the Outlier Detection configuration for this
 	// priority.
-	OutlierDetection *outlierdetection.LBConfig `json:"outlierDetection,omitempty"`
+	OutlierDetection *outlierdetection.ODConfig `json:"outlierDetection,omitempty"`
 }
 
 // Equal returns whether the DiscoveryMechanism is the same with the parameter.

--- a/xds/internal/balancer/clusterresolver/configbuilder.go
+++ b/xds/internal/balancer/clusterresolver/configbuilder.go
@@ -26,11 +26,13 @@ import (
 	"google.golang.org/grpc/balancer/roundrobin"
 	"google.golang.org/grpc/balancer/weightedroundrobin"
 	"google.golang.org/grpc/balancer/weightedtarget"
+	"google.golang.org/grpc/internal/envconfig"
 	"google.golang.org/grpc/internal/hierarchy"
 	internalserviceconfig "google.golang.org/grpc/internal/serviceconfig"
 	"google.golang.org/grpc/resolver"
 	"google.golang.org/grpc/xds/internal"
 	"google.golang.org/grpc/xds/internal/balancer/clusterimpl"
+	"google.golang.org/grpc/xds/internal/balancer/outlierdetection"
 	"google.golang.org/grpc/xds/internal/balancer/priority"
 	"google.golang.org/grpc/xds/internal/balancer/ringhash"
 	"google.golang.org/grpc/xds/internal/xdsclient/xdsresource"
@@ -125,28 +127,72 @@ func buildPriorityConfig(priorities []priorityConfig, xdsLBPolicy *internalservi
 			if err != nil {
 				return nil, nil, err
 			}
+			var odCfgs map[string]*outlierdetection.LBConfig
+			if envconfig.XDSOutlierDetection {
+				odCfgs = convertClusterImplMapToOutlierDetection(configs, p.mechanism.OutlierDetection)
+			}
 			retConfig.Priorities = append(retConfig.Priorities, names...)
+			retAddrs = append(retAddrs, addrs...)
+
+			if envconfig.XDSOutlierDetection {
+				for n, c := range odCfgs {
+					retConfig.Children[n] = &priority.Child{
+						Config: &internalserviceconfig.BalancerConfig{Name: outlierdetection.Name, Config: c},
+						// Ignore all re-resolution from EDS children.
+						IgnoreReresolutionRequests: true,
+					}
+				}
+				continue
+			}
 			for n, c := range configs {
 				retConfig.Children[n] = &priority.Child{
 					Config: &internalserviceconfig.BalancerConfig{Name: clusterimpl.Name, Config: c},
 					// Ignore all re-resolution from EDS children.
 					IgnoreReresolutionRequests: true,
 				}
+
 			}
-			retAddrs = append(retAddrs, addrs...)
 		case DiscoveryMechanismTypeLogicalDNS:
 			name, config, addrs := buildClusterImplConfigForDNS(i, p.addresses, p.mechanism)
+			var odCfg *outlierdetection.LBConfig
+			if envconfig.XDSOutlierDetection {
+				odCfg = makeClusterImplOutlierDetectionChild(*config, *p.mechanism.OutlierDetection)
+			}
 			retConfig.Priorities = append(retConfig.Priorities, name)
+			retAddrs = append(retAddrs, addrs...)
+			if envconfig.XDSOutlierDetection {
+				retConfig.Children[name] = &priority.Child{
+					Config: &internalserviceconfig.BalancerConfig{Name: outlierdetection.Name, Config: odCfg},
+					// Not ignore re-resolution from DNS children, they will trigger
+					// DNS to re-resolve.
+					IgnoreReresolutionRequests: false,
+				}
+				continue
+			}
 			retConfig.Children[name] = &priority.Child{
 				Config: &internalserviceconfig.BalancerConfig{Name: clusterimpl.Name, Config: config},
 				// Not ignore re-resolution from DNS children, they will trigger
 				// DNS to re-resolve.
 				IgnoreReresolutionRequests: false,
 			}
-			retAddrs = append(retAddrs, addrs...)
 		}
 	}
 	return retConfig, retAddrs, nil
+}
+
+func convertClusterImplMapToOutlierDetection(ciCfgs map[string]*clusterimpl.LBConfig, odCfg *outlierdetection.ODConfig) map[string]*outlierdetection.LBConfig {
+	odCfgs := make(map[string]*outlierdetection.LBConfig)
+	for n, c := range ciCfgs {
+		odCfgs[n] = makeClusterImplOutlierDetectionChild(*c, *odCfg)
+	}
+	return odCfgs
+}
+
+func makeClusterImplOutlierDetectionChild(ciCfg clusterimpl.LBConfig, odCfg outlierdetection.ODConfig) *outlierdetection.LBConfig {
+	return &outlierdetection.LBConfig{
+		ODConfig:    &odCfg,
+		ChildPolicy: &internalserviceconfig.BalancerConfig{Name: clusterimpl.Name, Config: &ciCfg},
+	}
 }
 
 func buildClusterImplConfigForDNS(parentPriority int, addrStrs []string, mechanism DiscoveryMechanism) (string, *clusterimpl.LBConfig, []resolver.Address) {

--- a/xds/internal/balancer/clusterresolver/configbuilder_test.go
+++ b/xds/internal/balancer/clusterresolver/configbuilder_test.go
@@ -31,11 +31,13 @@ import (
 	"google.golang.org/grpc/balancer/roundrobin"
 	"google.golang.org/grpc/balancer/weightedroundrobin"
 	"google.golang.org/grpc/balancer/weightedtarget"
+	"google.golang.org/grpc/internal/envconfig"
 	"google.golang.org/grpc/internal/hierarchy"
 	internalserviceconfig "google.golang.org/grpc/internal/serviceconfig"
 	"google.golang.org/grpc/resolver"
 	"google.golang.org/grpc/xds/internal"
 	"google.golang.org/grpc/xds/internal/balancer/clusterimpl"
+	"google.golang.org/grpc/xds/internal/balancer/outlierdetection"
 	"google.golang.org/grpc/xds/internal/balancer/priority"
 	"google.golang.org/grpc/xds/internal/balancer/ringhash"
 	"google.golang.org/grpc/xds/internal/xdsclient/xdsresource"
@@ -68,6 +70,10 @@ var (
 			})
 			return out
 		})}
+
+	noopODCfg = &outlierdetection.ODConfig{
+		Interval: 1<<63 - 1,
+	}
 )
 
 func init() {
@@ -304,6 +310,140 @@ func TestBuildPriorityConfig(t *testing.T) {
 		t.Errorf("buildPriorityConfig() diff (-got +want) %v", diff)
 	}
 	if diff := cmp.Diff(gotAddrs, wantAddrs, addrCmpOpts); diff != "" {
+		t.Errorf("buildPriorityConfig() diff (-got +want) %v", diff)
+	}
+}
+
+// TestBuildPriorityConfigWithOutlierDetection tests the priority config
+// generation with Outlier Detection toggled on. Each top level balancer per
+// priority should be an Outlier Detection balancer, with a Cluster Impl
+// Balancer as a child.
+func TestBuildPriorityConfigWithOutlierDetection(t *testing.T) {
+	oldOutlierDetection := envconfig.XDSOutlierDetection
+	envconfig.XDSOutlierDetection = true
+	defer func() {
+		envconfig.XDSOutlierDetection = oldOutlierDetection
+	}()
+
+	gotConfig, _, _ := buildPriorityConfig([]priorityConfig{
+		{
+			// EDS - OD config should be the top level for both of the EDS
+			// priorities balancer This EDS priority will have multiple sub
+			// priorities. The Outlier Detection configuration specified in the
+			// Discovery Mechanism should be the top level for each sub
+			// priorities balancer.
+			mechanism: DiscoveryMechanism{
+				Cluster:          testClusterName,
+				Type:             DiscoveryMechanismTypeEDS,
+				EDSServiceName:   testEDSServiceName,
+				OutlierDetection: noopODCfg,
+			},
+			edsResp: xdsresource.EndpointsUpdate{
+				Localities: []xdsresource.Locality{
+					testLocalitiesP0[0],
+					testLocalitiesP0[1],
+					testLocalitiesP1[0],
+					testLocalitiesP1[1],
+				},
+			},
+		},
+		{
+			// This OD config should wrap the Logical DNS priorities balancer.
+			mechanism: DiscoveryMechanism{
+				Cluster:          testClusterName2,
+				Type:             DiscoveryMechanismTypeLogicalDNS,
+				OutlierDetection: noopODCfg,
+			},
+			addresses: testAddressStrs[4],
+		},
+	}, nil)
+
+	wantConfig := &priority.LBConfig{
+		Children: map[string]*priority.Child{
+			"priority-0-0": {
+				Config: &internalserviceconfig.BalancerConfig{
+					Name: outlierdetection.Name,
+					Config: &outlierdetection.LBConfig{
+						ODConfig: noopODCfg,
+						ChildPolicy: &internalserviceconfig.BalancerConfig{
+							Name: clusterimpl.Name,
+							Config: &clusterimpl.LBConfig{
+								Cluster:        testClusterName,
+								EDSServiceName: testEDSServiceName,
+								DropCategories: []clusterimpl.DropConfig{},
+								ChildPolicy: &internalserviceconfig.BalancerConfig{
+									Name: weightedtarget.Name,
+									Config: &weightedtarget.LBConfig{
+										Targets: map[string]weightedtarget.Target{
+											assertString(testLocalityIDs[0].ToString): {
+												Weight:      20,
+												ChildPolicy: &internalserviceconfig.BalancerConfig{Name: roundrobin.Name},
+											},
+											assertString(testLocalityIDs[1].ToString): {
+												Weight:      80,
+												ChildPolicy: &internalserviceconfig.BalancerConfig{Name: roundrobin.Name},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				IgnoreReresolutionRequests: true,
+			},
+			"priority-0-1": {
+				Config: &internalserviceconfig.BalancerConfig{
+					Name: outlierdetection.Name,
+					Config: &outlierdetection.LBConfig{
+						ODConfig: noopODCfg,
+						ChildPolicy: &internalserviceconfig.BalancerConfig{
+							Name: clusterimpl.Name,
+							Config: &clusterimpl.LBConfig{
+								Cluster:        testClusterName,
+								EDSServiceName: testEDSServiceName,
+								DropCategories: []clusterimpl.DropConfig{},
+								ChildPolicy: &internalserviceconfig.BalancerConfig{
+									Name: weightedtarget.Name,
+									Config: &weightedtarget.LBConfig{
+										Targets: map[string]weightedtarget.Target{
+											assertString(testLocalityIDs[2].ToString): {
+												Weight:      20,
+												ChildPolicy: &internalserviceconfig.BalancerConfig{Name: roundrobin.Name},
+											},
+											assertString(testLocalityIDs[3].ToString): {
+												Weight:      80,
+												ChildPolicy: &internalserviceconfig.BalancerConfig{Name: roundrobin.Name},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				IgnoreReresolutionRequests: true,
+			},
+			"priority-1": {
+				Config: &internalserviceconfig.BalancerConfig{
+					Name: outlierdetection.Name,
+					Config: &outlierdetection.LBConfig{
+						ODConfig: noopODCfg,
+						ChildPolicy: &internalserviceconfig.BalancerConfig{
+							Name: clusterimpl.Name,
+							Config: &clusterimpl.LBConfig{
+								Cluster:     testClusterName2,
+								ChildPolicy: &internalserviceconfig.BalancerConfig{Name: "pick_first"},
+							},
+						},
+					},
+				},
+				IgnoreReresolutionRequests: false,
+			},
+		},
+		Priorities: []string{"priority-0-0", "priority-0-1", "priority-1"},
+	}
+	if diff := cmp.Diff(gotConfig, wantConfig); diff != "" {
 		t.Errorf("buildPriorityConfig() diff (-got +want) %v", diff)
 	}
 }
@@ -979,4 +1119,74 @@ func testAddrWithAttrs(addrStr string, weight *uint32, priority string, lID *int
 	}
 	addr = hierarchy.Set(addr, path)
 	return addr
+}
+
+func TestConvertClusterImplMapToOutlierDetection(t *testing.T) {
+	tests := []struct {
+		name          string
+		ciCfgsMap     map[string]*clusterimpl.LBConfig
+		odCfg         *outlierdetection.ODConfig
+		odCfgsMapWant map[string]*outlierdetection.LBConfig
+	}{
+		{
+			name: "single-entry-noop",
+			ciCfgsMap: map[string]*clusterimpl.LBConfig{
+				"child1": {
+					Cluster: "cluster1",
+				},
+			},
+			odCfg: noopODCfg,
+			odCfgsMapWant: map[string]*outlierdetection.LBConfig{
+				"child1": {
+					ODConfig: noopODCfg,
+					ChildPolicy: &internalserviceconfig.BalancerConfig{
+						Name: clusterimpl.Name,
+						Config: &clusterimpl.LBConfig{
+							Cluster: "cluster1",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "multiple-entries-noop",
+			ciCfgsMap: map[string]*clusterimpl.LBConfig{
+				"child1": {
+					Cluster: "cluster1",
+				},
+				"child2": {
+					Cluster: "cluster2",
+				},
+			},
+			odCfg: noopODCfg,
+			odCfgsMapWant: map[string]*outlierdetection.LBConfig{
+				"child1": {
+					ODConfig: noopODCfg,
+					ChildPolicy: &internalserviceconfig.BalancerConfig{
+						Name: clusterimpl.Name,
+						Config: &clusterimpl.LBConfig{
+							Cluster: "cluster1",
+						},
+					},
+				},
+				"child2": {
+					ODConfig: noopODCfg,
+					ChildPolicy: &internalserviceconfig.BalancerConfig{
+						Name: clusterimpl.Name,
+						Config: &clusterimpl.LBConfig{
+							Cluster: "cluster2",
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := convertClusterImplMapToOutlierDetection(test.ciCfgsMap, test.odCfg)
+			if diff := cmp.Diff(got, test.odCfgsMapWant); diff != "" {
+				t.Fatalf("convertClusterImplMapToOutlierDetection() diff(-got +want) %v", diff)
+			}
+		})
+	}
 }

--- a/xds/internal/balancer/outlierdetection/balancer.go
+++ b/xds/internal/balancer/outlierdetection/balancer.go
@@ -1,0 +1,125 @@
+/*
+ *
+ * Copyright 2022 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// Package outlierdetection implements a balancer that implements
+// Outlier Detection.
+package outlierdetection
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"google.golang.org/grpc/balancer"
+	"google.golang.org/grpc/serviceconfig"
+)
+
+// Name is the name of the outlier detection balancer.
+const Name = "outlier_detection_experimental"
+
+func init() {
+	balancer.Register(bb{})
+}
+
+type bb struct{}
+
+func (bb) Build(cc balancer.ClientConn, bOpts balancer.BuildOptions) balancer.Balancer {
+	return &outlierDetectionBalancer{}
+}
+
+func (bb) ParseConfig(s json.RawMessage) (serviceconfig.LoadBalancingConfig, error) {
+	var lbCfg *LBConfig
+	if err := json.Unmarshal(s, &lbCfg); err != nil {
+		return nil, fmt.Errorf("xds: unable to unmarshal LBconfig: %s, error: %v", string(s), err)
+	}
+	if lbCfg.ODConfig == nil {
+		return nil, errors.New("xds: no ODConfig present in LBConfig")
+	}
+
+	// Note: in the xds flow, these validations will never fail. The xdsclient
+	// performs the same validations as here on the xds Outlier Detection
+	// resource before parsing into the internal struct which gets marshaled
+	// into JSON before calling this function. A50 defines two separate places
+	// for these validations to take place, the xdsclient and this ParseConfig
+	// method. "When parsing a config from JSON, if any of these requirements is
+	// violated, that should be treated as a parsing error." - A50
+
+	// "The google.protobuf.Duration fields interval, base_ejection_time, and
+	// max_ejection_time must obey the restrictions in the
+	// google.protobuf.Duration documentation and they must have non-negative
+	// values." - A50
+
+	// Approximately 290 years is the maximum time that time.Duration (int64)
+	// can represent. The restrictions on the protobuf.Duration field are to be
+	// within +-10000 years. Thus, just check for negative values.
+	if lbCfg.ODConfig.Interval < 0 {
+		return nil, fmt.Errorf("LBConfig.Interval = %v; must be >= 0", lbCfg.ODConfig.Interval)
+	}
+	if lbCfg.ODConfig.BaseEjectionTime < 0 {
+		return nil, fmt.Errorf("LBConfig.BaseEjectionTime = %v; must be >= 0", lbCfg.ODConfig.BaseEjectionTime)
+	}
+	if lbCfg.ODConfig.MaxEjectionTime < 0 {
+		return nil, fmt.Errorf("LBConfig.MaxEjectionTime = %v; must be >= 0", lbCfg.ODConfig.MaxEjectionTime)
+	}
+
+	// "The fields max_ejection_percent,
+	// success_rate_ejection.enforcement_percentage,
+	// failure_percentage_ejection.threshold, and
+	// failure_percentage.enforcement_percentage must have values less than or
+	// equal to 100." - A50
+	if lbCfg.ODConfig.MaxEjectionPercent > 100 {
+		return nil, fmt.Errorf("LBConfig.MaxEjectionPercent = %v; must be <= 100", lbCfg.ODConfig.MaxEjectionPercent)
+	}
+	if lbCfg.ODConfig.SuccessRateEjection != nil && lbCfg.ODConfig.SuccessRateEjection.EnforcementPercentage > 100 {
+		return nil, fmt.Errorf("LBConfig.SuccessRateEjection.EnforcementPercentage = %v; must be <= 100", lbCfg.ODConfig.SuccessRateEjection.EnforcementPercentage)
+	}
+	if lbCfg.ODConfig.FailurePercentageEjection != nil && lbCfg.ODConfig.FailurePercentageEjection.Threshold > 100 {
+		return nil, fmt.Errorf("LBConfig.FailurePercentageEjection.Threshold = %v; must be <= 100", lbCfg.ODConfig.FailurePercentageEjection.Threshold)
+	}
+	if lbCfg.ODConfig.FailurePercentageEjection != nil && lbCfg.ODConfig.FailurePercentageEjection.EnforcementPercentage > 100 {
+		return nil, fmt.Errorf("LBConfig.FailurePercentageEjection.EnforcementPercentage = %v; must be <= 100", lbCfg.ODConfig.FailurePercentageEjection.EnforcementPercentage)
+	}
+	return lbCfg, nil
+}
+
+func (bb) Name() string {
+	return Name
+}
+
+type outlierDetectionBalancer struct {
+}
+
+func (b *outlierDetectionBalancer) UpdateClientConnState(s balancer.ClientConnState) error {
+	return nil
+}
+
+func (b *outlierDetectionBalancer) ResolverError(err error) {
+
+}
+
+func (b *outlierDetectionBalancer) UpdateSubConnState(sc balancer.SubConn, state balancer.SubConnState) {
+
+}
+
+func (b *outlierDetectionBalancer) Close() {
+
+}
+
+func (b *outlierDetectionBalancer) ExitIdle() {
+
+}

--- a/xds/internal/balancer/outlierdetection/balancer_test.go
+++ b/xds/internal/balancer/outlierdetection/balancer_test.go
@@ -1,0 +1,223 @@
+/*
+ *
+ * Copyright 2022 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package outlierdetection
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/grpc/balancer"
+	"google.golang.org/grpc/internal/grpctest"
+	internalserviceconfig "google.golang.org/grpc/internal/serviceconfig"
+	"google.golang.org/grpc/serviceconfig"
+	"google.golang.org/grpc/xds/internal/balancer/clusterimpl"
+)
+
+type s struct {
+	grpctest.Tester
+}
+
+func Test(t *testing.T) {
+	grpctest.RunSubTests(t, s{})
+}
+
+// TestParseConfig verifies the ParseConfig() method in the CDS balancer.
+func (s) TestParseConfig(t *testing.T) {
+	bb := balancer.Get(Name)
+	if bb == nil {
+		t.Fatalf("balancer.Get(%q) returned nil", Name)
+	}
+	parser, ok := bb.(balancer.ConfigParser)
+	if !ok {
+		t.Fatalf("balancer %q does not implement the ConfigParser interface", Name)
+	}
+
+	tests := []struct {
+		name    string
+		input   json.RawMessage // s both of these to data -> field inside odConfig
+		wantCfg serviceconfig.LoadBalancingConfig
+		wantErr bool
+	}{
+		{
+			name: "noop-lb-config",
+			input: json.RawMessage(`{
+				"odConfig": {
+					"interval": 9223372036854775807
+				}
+			}`),
+			wantCfg: &LBConfig{ODConfig: &ODConfig{Interval: 1<<63 - 1}},
+		},
+		{
+			name: "good-lb-config",
+			input: json.RawMessage(`{
+				"odConfig": {
+					"interval": 10000000000,
+					"baseEjectionTime": 30000000000,
+					"maxEjectionTime": 300000000000,
+					"maxEjectionPercent": 10,
+					"successRateEjection": {
+						"stdevFactor": 1900,
+						"enforcementPercentage": 100,
+						"minimumHosts": 5,
+						"requestVolume": 100
+					},
+					"failurePercentageEjection": {
+						"threshold": 85,
+						"enforcementPercentage": 5,
+						"minimumHosts": 5,
+						"requestVolume": 50
+					}
+				}
+			}`),
+			wantCfg: &LBConfig{
+				ODConfig: &ODConfig{
+					Interval:           10 * time.Second,
+					BaseEjectionTime:   30 * time.Second,
+					MaxEjectionTime:    300 * time.Second,
+					MaxEjectionPercent: 10,
+					SuccessRateEjection: &SuccessRateEjection{
+						StdevFactor:           1900,
+						EnforcementPercentage: 100,
+						MinimumHosts:          5,
+						RequestVolume:         100,
+					},
+					FailurePercentageEjection: &FailurePercentageEjection{
+						Threshold:             85,
+						EnforcementPercentage: 5,
+						MinimumHosts:          5,
+						RequestVolume:         50,
+					},
+				},
+			},
+		},
+		{
+			name: "interval-is-negative",
+			input: json.RawMessage(`{
+				"odConfig": { "interval": -10}
+			}`),
+			wantErr: true,
+		},
+		{
+			name: "base-ejection-time-is-negative",
+			input: json.RawMessage(`{
+				"odConfig": { "baseEjectionTime": -10}
+			}`),
+			wantErr: true,
+		},
+		{
+			name: "max-ejection-time-is-negative",
+			input: json.RawMessage(`{
+				"odConfig": { "maxEjectionTime": -10}
+			}`),
+			wantErr: true,
+		},
+		{
+			name: "max-ejection-percent-is-greater-than-100",
+			input: json.RawMessage(`{
+				"odConfig": { "maxEjectionPercent": 150}
+			}`),
+			wantErr: true,
+		},
+		{
+			name: "enforcing-success-rate-is-greater-than-100",
+			input: json.RawMessage(`{
+				"odConfig": {
+					"successRateEjection": {
+						"enforcingSuccessRate": 150,
+					}
+				}
+			}`),
+			wantErr: true,
+		},
+		{
+			name: "failure-percentage-threshold-is-greater-than-100",
+			input: json.RawMessage(`{
+				"odConfig": {
+					"failurePercentageEjection": {
+						"threshold": 150,
+					}
+				}
+			}`),
+			wantErr: true,
+		},
+		{
+			name: "enforcing-failure-percentage-is-greater-than-100",
+			input: json.RawMessage(`{
+				"odConfig": {
+					"enforcingFailurePercentage": {
+						"threshold": 150,
+					}
+				}
+			}`),
+			wantErr: true,
+		},
+		{
+			name: "child-policy",
+			input: json.RawMessage(`{
+				"odConfig": { "interval": 9223372036854775807},
+				"childPolicy": [
+				{
+					"xds_cluster_impl_experimental": {
+						"cluster": "test_cluster"
+					}
+				}
+			]
+			}`),
+			wantCfg: &LBConfig{
+				ODConfig: &ODConfig{Interval: 1<<63 - 1},
+				ChildPolicy: &internalserviceconfig.BalancerConfig{
+					Name: "xds_cluster_impl_experimental",
+					Config: &clusterimpl.LBConfig{
+						Cluster: "test_cluster",
+					},
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			gotCfg, gotErr := parser.ParseConfig(test.input)
+			if (gotErr != nil) != test.wantErr {
+				t.Fatalf("ParseConfig(%v) = %v, wantErr %v", string(test.input), gotErr, test.wantErr)
+			}
+			if test.wantErr {
+				return
+			}
+			if diff := cmp.Diff(gotCfg, test.wantCfg); diff != "" {
+				t.Fatalf("parseConfig(%v) got unexpected output, diff (-got +want): %v", string(test.input), diff)
+			}
+		})
+	}
+}
+
+// Equal returns whether the LBConfig is the same with the parameter.
+func (lbc *LBConfig) Equal(lbc2 *LBConfig) bool {
+	if lbc == nil && lbc2 == nil {
+		return true
+	}
+	if (lbc != nil) != (lbc2 != nil) {
+		return false
+	}
+	if !lbc.ODConfig.Equal(lbc2.ODConfig) {
+		return false
+	}
+	return cmp.Equal(lbc.ChildPolicy, lbc2.ChildPolicy)
+}

--- a/xds/internal/balancer/outlierdetection/config.go
+++ b/xds/internal/balancer/outlierdetection/config.go
@@ -182,7 +182,7 @@ func (odc *ODConfig) Equal(odc2 *ODConfig) bool {
 type LBConfig struct {
 	serviceconfig.LoadBalancingConfig `json:"-"`
 	// ODConfig is the Outlier Detection specific configuration.
-	ODConfig ODConfig `json:"odConfig,omitempty"`
+	ODConfig *ODConfig `json:"odConfig,omitempty"`
 	// ChildPolicy is the config for the child policy.
 	ChildPolicy *internalserviceconfig.BalancerConfig `json:"childPolicy,omitempty"`
 }

--- a/xds/internal/balancer/outlierdetection/config.go
+++ b/xds/internal/balancer/outlierdetection/config.go
@@ -124,9 +124,8 @@ func (fpe *FailurePercentageEjection) Equal(fpe2 *FailurePercentageEjection) boo
 	return fpe.RequestVolume == fpe2.RequestVolume
 }
 
-// LBConfig is the config for the outlier detection balancer.
-type LBConfig struct {
-	serviceconfig.LoadBalancingConfig `json:"-"`
+// ODConfig is the config for outlier detection behavior.
+type ODConfig struct {
 	// Interval is the time interval between ejection analysis sweeps. This can
 	// result in both new ejections as well as addresses being returned to
 	// service. Defaults to 10s.
@@ -149,34 +148,41 @@ type LBConfig struct {
 	// FailurePercentageEjection is the parameters for the failure percentage
 	// algorithm. If set, failure rate ejections will be performed.
 	FailurePercentageEjection *FailurePercentageEjection `json:"failurePercentageEjection,omitempty"`
-	// ChildPolicy is the config for the child policy.
-	ChildPolicy *internalserviceconfig.BalancerConfig `json:"childPolicy,omitempty"`
 }
 
 // Equal returns whether the LBConfig is the same with the parameter, outside of
 // the child policy. The child policy will need to be manually compared in tests
 // (to avoid cmp in this non-testing file).
-func (lbc *LBConfig) Equal(lbc2 *LBConfig) bool {
-	if lbc == nil && lbc2 == nil {
+func (odc *ODConfig) Equal(odc2 *ODConfig) bool {
+	if odc == nil && odc2 == nil {
 		return true
 	}
-	if (lbc != nil) != (lbc2 != nil) {
+	if (odc != nil) != (odc2 != nil) {
 		return false
 	}
-	if lbc.Interval != lbc2.Interval {
+	if odc.Interval != odc2.Interval {
 		return false
 	}
-	if lbc.BaseEjectionTime != lbc2.BaseEjectionTime {
+	if odc.BaseEjectionTime != odc2.BaseEjectionTime {
 		return false
 	}
-	if lbc.MaxEjectionTime != lbc2.MaxEjectionTime {
+	if odc.MaxEjectionTime != odc2.MaxEjectionTime {
 		return false
 	}
-	if lbc.MaxEjectionPercent != lbc2.MaxEjectionPercent {
+	if odc.MaxEjectionPercent != odc2.MaxEjectionPercent {
 		return false
 	}
-	if !lbc.SuccessRateEjection.Equal(lbc2.SuccessRateEjection) {
+	if !odc.SuccessRateEjection.Equal(odc2.SuccessRateEjection) {
 		return false
 	}
-	return lbc.FailurePercentageEjection.Equal(lbc2.FailurePercentageEjection)
+	return odc.FailurePercentageEjection.Equal(odc2.FailurePercentageEjection)
+}
+
+// LBConfig is the config for the outlier detection balancer.
+type LBConfig struct {
+	serviceconfig.LoadBalancingConfig `json:"-"`
+	// ODConfig is the Outlier Detection specific configuration.
+	ODConfig ODConfig `json:"odConfig,omitempty"`
+	// ChildPolicy is the config for the child policy.
+	ChildPolicy *internalserviceconfig.BalancerConfig `json:"childPolicy,omitempty"`
 }

--- a/xds/internal/balancer/outlierdetection/config.go
+++ b/xds/internal/balancer/outlierdetection/config.go
@@ -22,7 +22,6 @@ package outlierdetection
 import (
 	"time"
 
-	"github.com/google/go-cmp/cmp"
 	internalserviceconfig "google.golang.org/grpc/internal/serviceconfig"
 	"google.golang.org/grpc/serviceconfig"
 )
@@ -154,7 +153,9 @@ type LBConfig struct {
 	ChildPolicy *internalserviceconfig.BalancerConfig `json:"childPolicy,omitempty"`
 }
 
-// Equal returns whether the LBConfig is the same with the parameter.
+// Equal returns whether the LBConfig is the same with the parameter, outside of
+// the child policy. The child policy will need to be manually compared in tests
+// (to avoid cmp in this non-testing file).
 func (lbc *LBConfig) Equal(lbc2 *LBConfig) bool {
 	if lbc == nil && lbc2 == nil {
 		return true
@@ -177,8 +178,5 @@ func (lbc *LBConfig) Equal(lbc2 *LBConfig) bool {
 	if !lbc.SuccessRateEjection.Equal(lbc2.SuccessRateEjection) {
 		return false
 	}
-	if !lbc.FailurePercentageEjection.Equal(lbc2.FailurePercentageEjection) {
-		return false
-	}
-	return cmp.Equal(lbc.ChildPolicy, lbc2.ChildPolicy)
+	return lbc.FailurePercentageEjection.Equal(lbc2.FailurePercentageEjection)
 }


### PR DESCRIPTION
This PR adds branching logic for constructing the Priority LB's config. In the case that Outlier Detection is configured on with the corresponding Environment variable, the top level balancer's configuration for each priority will be of type Outlier Detection with a Cluster Impl child rather than a Cluster Impl. This had to include the Outlier Detection's balancer to pass Cluster Resolver tests, as the Outlier Detection policy needed to be registered. This PR is branched off #5359, which switched the Outlier Detection configuration to two structs.

RELEASE NOTES: None