### PR TITLE
xds/clusterresolver: reuse child policy names for the same locality

### DIFF
--- a/xds/internal/balancer/clusterresolver/configbuilder_childname.go
+++ b/xds/internal/balancer/clusterresolver/configbuilder_childname.go
@@ -1,0 +1,88 @@
+/*
+ *
+ * Copyright 2022 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package clusterresolver
+
+import (
+	"fmt"
+
+	"google.golang.org/grpc/xds/internal"
+	"google.golang.org/grpc/xds/internal/xdsclient/xdsresource"
+)
+
+// nameGenerator generates a child name for a list of priorities (each priority
+// is a list of localities).
+//
+// The purpose of this generator is to reuse names between updates. So the
+// struct keeps state between generate() calls, and a later generate() might
+// return names returned by the previous call.
+type nameGenerator struct {
+	existingNames map[internal.LocalityID]string
+	prefix        uint64
+	nextID        uint64
+}
+
+func newNameGenerator(prefix uint64) *nameGenerator {
+	return &nameGenerator{prefix: prefix}
+}
+
+// generate returns a list of names for the given list of priorities.
+//
+// Each priority is a list of localities. The name for the priority is picked as
+// - for each locality in this priority, if it exists in the existing names,
+// this priority will reuse the name
+// - if no reusable name is found for this priority, a new name is generated
+//
+// For example:
+// - update 1: [[L1], [L2], [L3]] --> ["0", "1", "2"]
+// - update 2: [[L1], [L2], [L3]] --> ["0", "1", "2"]
+// - update 3: [[L1, L2], [L3]] --> ["0", "2"]   (Two priorities were merged)
+// - update 4: [[L1], [L4]] --> ["0", "3",]      (A priority was split, and a new priority was added)
+func (ng *nameGenerator) generate(priorities [][]xdsresource.Locality) []string {
+	var ret []string
+	usedNames := make(map[string]bool)
+	newNames := make(map[internal.LocalityID]string)
+	for _, priority := range priorities {
+		var nameFound string
+		for _, locality := range priority {
+			if name, ok := ng.existingNames[locality.ID]; ok {
+				if !usedNames[name] {
+					nameFound = name
+					// Found a name to use. No need to process the remaining
+					// localities.
+					break
+				}
+			}
+		}
+
+		if nameFound == "" {
+			// No appropriate used name is found. Make a new name.
+			nameFound = fmt.Sprintf("priority-%d-%d", ng.prefix, ng.nextID)
+			ng.nextID++
+		}
+
+		ret = append(ret, nameFound)
+		// All localities in this priority share the same name. Add them all to
+		// the new map.
+		for _, l := range priority {
+			newNames[l.ID] = nameFound
+		}
+		usedNames[nameFound] = true
+	}
+	ng.existingNames = newNames
+	return ret
+}

--- a/xds/internal/balancer/clusterresolver/configbuilder_childname_test.go
+++ b/xds/internal/balancer/clusterresolver/configbuilder_childname_test.go
@@ -35,15 +35,17 @@ func Test_nameGenerator_generate(t *testing.T) {
 	}{
 		{
 			name:   "init, two new priorities",
+			prefix: 3,
 			input1: nil,
 			input2: [][]xdsresource.Locality{
 				{{ID: internal.LocalityID{Zone: "L0"}}},
 				{{ID: internal.LocalityID{Zone: "L1"}}},
 			},
-			want: []string{"priority-0-0", "priority-0-1"},
+			want: []string{"priority-3-0", "priority-3-1"},
 		},
 		{
-			name: "one new priority",
+			name:   "one new priority",
+			prefix: 1,
 			input1: [][]xdsresource.Locality{
 				{{ID: internal.LocalityID{Zone: "L0"}}},
 			},
@@ -51,10 +53,11 @@ func Test_nameGenerator_generate(t *testing.T) {
 				{{ID: internal.LocalityID{Zone: "L0"}}},
 				{{ID: internal.LocalityID{Zone: "L1"}}},
 			},
-			want: []string{"priority-0-0", "priority-0-1"},
+			want: []string{"priority-1-0", "priority-1-1"},
 		},
 		{
-			name: "merge two priorities",
+			name:   "merge two priorities",
+			prefix: 4,
 			input1: [][]xdsresource.Locality{
 				{{ID: internal.LocalityID{Zone: "L0"}}},
 				{{ID: internal.LocalityID{Zone: "L1"}}},
@@ -64,7 +67,7 @@ func Test_nameGenerator_generate(t *testing.T) {
 				{{ID: internal.LocalityID{Zone: "L0"}}, {ID: internal.LocalityID{Zone: "L1"}}},
 				{{ID: internal.LocalityID{Zone: "L2"}}},
 			},
-			want: []string{"priority-0-0", "priority-0-2"},
+			want: []string{"priority-4-0", "priority-4-2"},
 		},
 		{
 			name: "swap two priorities",

--- a/xds/internal/balancer/clusterresolver/configbuilder_childname_test.go
+++ b/xds/internal/balancer/clusterresolver/configbuilder_childname_test.go
@@ -1,0 +1,108 @@
+/*
+ *
+ * Copyright 2022 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package clusterresolver
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/grpc/xds/internal"
+	"google.golang.org/grpc/xds/internal/xdsclient/xdsresource"
+)
+
+func Test_nameGenerator_generate(t *testing.T) {
+	tests := []struct {
+		name   string
+		prefix uint64
+		input1 [][]xdsresource.Locality
+		input2 [][]xdsresource.Locality
+		want   []string
+	}{
+		{
+			name:   "init, two new priorities",
+			input1: nil,
+			input2: [][]xdsresource.Locality{
+				{{ID: internal.LocalityID{Zone: "L0"}}},
+				{{ID: internal.LocalityID{Zone: "L1"}}},
+			},
+			want: []string{"priority-0-0", "priority-0-1"},
+		},
+		{
+			name: "one new priority",
+			input1: [][]xdsresource.Locality{
+				{{ID: internal.LocalityID{Zone: "L0"}}},
+			},
+			input2: [][]xdsresource.Locality{
+				{{ID: internal.LocalityID{Zone: "L0"}}},
+				{{ID: internal.LocalityID{Zone: "L1"}}},
+			},
+			want: []string{"priority-0-0", "priority-0-1"},
+		},
+		{
+			name: "merge two priorities",
+			input1: [][]xdsresource.Locality{
+				{{ID: internal.LocalityID{Zone: "L0"}}},
+				{{ID: internal.LocalityID{Zone: "L1"}}},
+				{{ID: internal.LocalityID{Zone: "L2"}}},
+			},
+			input2: [][]xdsresource.Locality{
+				{{ID: internal.LocalityID{Zone: "L0"}}, {ID: internal.LocalityID{Zone: "L1"}}},
+				{{ID: internal.LocalityID{Zone: "L2"}}},
+			},
+			want: []string{"priority-0-0", "priority-0-2"},
+		},
+		{
+			name: "swap two priorities",
+			input1: [][]xdsresource.Locality{
+				{{ID: internal.LocalityID{Zone: "L0"}}},
+				{{ID: internal.LocalityID{Zone: "L1"}}},
+				{{ID: internal.LocalityID{Zone: "L2"}}},
+			},
+			input2: [][]xdsresource.Locality{
+				{{ID: internal.LocalityID{Zone: "L1"}}},
+				{{ID: internal.LocalityID{Zone: "L0"}}},
+				{{ID: internal.LocalityID{Zone: "L2"}}},
+			},
+			want: []string{"priority-0-1", "priority-0-0", "priority-0-2"},
+		},
+		{
+			name: "split priority",
+			input1: [][]xdsresource.Locality{
+				{{ID: internal.LocalityID{Zone: "L0"}}, {ID: internal.LocalityID{Zone: "L1"}}},
+				{{ID: internal.LocalityID{Zone: "L2"}}},
+			},
+			input2: [][]xdsresource.Locality{
+				{{ID: internal.LocalityID{Zone: "L0"}}},
+				{{ID: internal.LocalityID{Zone: "L1"}}}, // This gets a newly generated name, sice "0-0" was already picked.
+				{{ID: internal.LocalityID{Zone: "L2"}}},
+			},
+			want: []string{"priority-0-0", "priority-0-2", "priority-0-1"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ng := newNameGenerator(tt.prefix)
+			got1 := ng.generate(tt.input1)
+			t.Logf("%v", got1)
+			got := ng.generate(tt.input2)
+			if diff := cmp.Diff(got, tt.want); diff != "" {
+				t.Errorf("generate() = got: %v, want: %v, diff (-got +want): %s", got, tt.want, diff)
+			}
+		})
+	}
+}

--- a/xds/internal/balancer/clusterresolver/resource_resolver.go
+++ b/xds/internal/balancer/clusterresolver/resource_resolver.go
@@ -210,13 +210,7 @@ func (rr *resourceResolver) stop() {
 func (rr *resourceResolver) generate() {
 	var ret []priorityConfig
 	for _, rDM := range rr.children {
-		r, ok := rr.childrenMap[rDM.dmKey]
-		if !ok {
-			rr.parent.logger.Infof("resolver for %+v not found, should never happen", rDM.dmKey)
-			continue
-		}
-
-		u, ok := r.r.lastUpdate()
+		u, ok := rDM.r.lastUpdate()
 		if !ok {
 			// Don't send updates to parent until all resolvers have update to
 			// send.

--- a/xds/internal/balancer/clusterresolver/resource_resolver.go
+++ b/xds/internal/balancer/clusterresolver/resource_resolver.go
@@ -67,7 +67,7 @@ type resourceResolver struct {
 	mu         sync.Mutex
 	mechanisms []DiscoveryMechanism
 	children   []resolverMechanismTuple
-	// childrenMap's key only needs the resolver implementation (type
+	// childrenMap's value only needs the resolver implementation (type
 	// discoveryMechanism) and the childNameGen. The other two fields are not
 	// used.
 	//
@@ -137,7 +137,7 @@ func (rr *resourceResolver) updateMechanisms(mechanisms []DiscoveryMechanism) {
 				rr.childNameGeneratorSeqID++
 			} else {
 				// If this is not new, keep the fields (especially
-				// childNameGen), and only update te DiscoveryMechanism.
+				// childNameGen), and only update the DiscoveryMechanism.
 				//
 				// Note that the same dmKey doesn't mean the same
 				// DiscoveryMechanism. There are fields (e.g.


### PR DESCRIPTION
To avoid recreating SubConns if possible

fixes #5268

RELEASE NOTES: N/A