### PR TITLE
Don't call cmp in non testing file

### DIFF
--- a/xds/internal/balancer/clusterresolver/config.go
+++ b/xds/internal/balancer/clusterresolver/config.go
@@ -121,7 +121,7 @@ func (dm DiscoveryMechanism) Equal(b DiscoveryMechanism) bool {
 		return false
 	case dm.DNSHostname != b.DNSHostname:
 		return false
-	case !dm.OutlierDetection.Equal(b.OutlierDetection):
+	case !dm.OutlierDetection.EqualODOnly(b.OutlierDetection):
 		return false
 	}
 

--- a/xds/internal/balancer/clusterresolver/config.go
+++ b/xds/internal/balancer/clusterresolver/config.go
@@ -121,7 +121,7 @@ func (dm DiscoveryMechanism) Equal(b DiscoveryMechanism) bool {
 		return false
 	case dm.DNSHostname != b.DNSHostname:
 		return false
-	case !dm.OutlierDetection.EqualODOnly(b.OutlierDetection):
+	case !dm.OutlierDetection.EqualIgnoringChildPolicy(b.OutlierDetection):
 		return false
 	}
 

--- a/xds/internal/balancer/outlierdetection/config.go
+++ b/xds/internal/balancer/outlierdetection/config.go
@@ -153,10 +153,10 @@ type LBConfig struct {
 	ChildPolicy *internalserviceconfig.BalancerConfig `json:"childPolicy,omitempty"`
 }
 
-// EqualODOnly returns whether the LBConfig is same with the parameter outside
-// of the child policy, only comparing the Outlier Detection specific
-// configuration.
-func (lbc *LBConfig) EqualODOnly(lbc2 *LBConfig) bool {
+// EqualIgnoringChildPolicy returns whether the LBConfig is same with the
+// parameter outside of the child policy, only comparing the Outlier Detection
+// specific configuration.
+func (lbc *LBConfig) EqualIgnoringChildPolicy(lbc2 *LBConfig) bool {
 	if lbc == nil && lbc2 == nil {
 		return true
 	}

--- a/xds/internal/balancer/outlierdetection/config.go
+++ b/xds/internal/balancer/outlierdetection/config.go
@@ -22,7 +22,6 @@ package outlierdetection
 import (
 	"time"
 
-	"github.com/google/go-cmp/cmp"
 	internalserviceconfig "google.golang.org/grpc/internal/serviceconfig"
 	"google.golang.org/grpc/serviceconfig"
 )
@@ -154,8 +153,10 @@ type LBConfig struct {
 	ChildPolicy *internalserviceconfig.BalancerConfig `json:"childPolicy,omitempty"`
 }
 
-// Equal returns whether the LBConfig is the same with the parameter.
-func (lbc *LBConfig) Equal(lbc2 *LBConfig) bool {
+// EqualODOnly returns whether the LBConfig is same with the parameter outside
+// of the child policy, only comparing the Outlier Detection specific
+// configuration.
+func (lbc *LBConfig) EqualODOnly(lbc2 *LBConfig) bool {
 	if lbc == nil && lbc2 == nil {
 		return true
 	}
@@ -177,8 +178,5 @@ func (lbc *LBConfig) Equal(lbc2 *LBConfig) bool {
 	if !lbc.SuccessRateEjection.Equal(lbc2.SuccessRateEjection) {
 		return false
 	}
-	if !lbc.FailurePercentageEjection.Equal(lbc2.FailurePercentageEjection) {
-		return false
-	}
-	return cmp.Equal(lbc.ChildPolicy, lbc2.ChildPolicy)
+	return lbc.FailurePercentageEjection.Equal(lbc2.FailurePercentageEjection)
 }

--- a/xds/internal/balancer/outlierdetection/config_test.go
+++ b/xds/internal/balancer/outlierdetection/config_test.go
@@ -1,0 +1,72 @@
+/*
+ *
+ * Copyright 2022 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package outlierdetection
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSuccessRateEjection(t *testing.T) {
+	fields := map[string]bool{
+		"StdevFactor":           true,
+		"EnforcementPercentage": true,
+		"MinimumHosts":          true,
+		"RequestVolume":         true,
+	}
+	typ := reflect.TypeOf(SuccessRateEjection{})
+	for i := 0; i < typ.NumField(); i++ {
+		if n := typ.Field(i).Name; !fields[n] {
+			t.Errorf("New field in SuccessRateEjection %q, update this test and Equal", n)
+		}
+	}
+}
+
+func TestEqualFieldsFailurePercentageEjection(t *testing.T) {
+	fields := map[string]bool{
+		"Threshold":             true,
+		"EnforcementPercentage": true,
+		"MinimumHosts":          true,
+		"RequestVolume":         true,
+	}
+	typ := reflect.TypeOf(FailurePercentageEjection{})
+	for i := 0; i < typ.NumField(); i++ {
+		if n := typ.Field(i).Name; !fields[n] {
+			t.Errorf("New field in FailurePercentageEjection %q, update this test and Equal", n)
+		}
+	}
+}
+
+func TestEqualFieldsLBConfig(t *testing.T) {
+	fields := map[string]bool{
+		"LoadBalancingConfig":       true,
+		"Interval":                  true,
+		"BaseEjectionTime":          true,
+		"MaxEjectionTime":           true,
+		"MaxEjectionPercent":        true,
+		"SuccessRateEjection":       true,
+		"FailurePercentageEjection": true,
+		"ChildPolicy":               true,
+	}
+	typ := reflect.TypeOf(LBConfig{})
+	for i := 0; i < typ.NumField(); i++ {
+		if n := typ.Field(i).Name; !fields[n] {
+			t.Errorf("New field in LBConfig %q, update this test and EqualIgnoringChildPolicy", n)
+		}
+	}
+}


### PR DESCRIPTION
Fixes issue #5353.

The config's Equal method is called by CDS to check the equality of discovery mechanisms. However, due to the fact that the Child Policy will not be prepared by the CDS Balancer, but will be prepared by the Cluster Resolver balancer, getting rid of the check is a logical no-op.

RELEASE NOTES: None