### PR TITLE
client/SubConn: do not recreate addrConn if UpdateAddresses is called with the same addresses

### DIFF
--- a/clientconn.go
+++ b/clientconn.go
@@ -801,15 +801,30 @@ func (ac *addrConn) connect() error {
 	return nil
 }
 
+func equalAddresses(a, b []resolver.Address) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i, v := range a {
+		if !v.Equal(b[i]) {
+			return false
+		}
+	}
+	return true
+}
+
 // tryUpdateAddrs tries to update ac.addrs with the new addresses list.
-//
-// If ac is Connecting, it returns false. The caller should tear down the ac and
-// create a new one. Note that the backoff will be reset when this happens.
 //
 // If ac is TransientFailure, it updates ac.addrs and returns true. The updated
 // addresses will be picked up by retry in the next iteration after backoff.
 //
 // If ac is Shutdown or Idle, it updates ac.addrs and returns true.
+//
+// If the addresses is the same as the old list, it does nothing and returns
+// true.
+//
+// If ac is Connecting, it returns false. The caller should tear down the ac and
+// create a new one. Note that the backoff will be reset when this happens.
 //
 // If ac is Ready, it checks whether current connected address of ac is in the
 // new addrs list.
@@ -824,6 +839,10 @@ func (ac *addrConn) tryUpdateAddrs(addrs []resolver.Address) bool {
 		ac.state == connectivity.TransientFailure ||
 		ac.state == connectivity.Idle {
 		ac.addrs = addrs
+		return true
+	}
+
+	if equalAddresses(ac.addrs, addrs) {
 		return true
 	}
 

--- a/clientconn_test.go
+++ b/clientconn_test.go
@@ -970,7 +970,7 @@ func (s) TestUpdateAddresses_RetryFromFirstAddr(t *testing.T) {
 		{Addr: lis3.Addr().String()},
 	}
 	rb := manual.NewBuilderWithScheme("whatever")
-	rb.InitialState(resolver.State{Addresses: addrsList})
+	rb.InitialState(resolver.State{Addresses: addrsList[0:2]})
 
 	client, err := Dial("whatever:///this-gets-overwritten",
 		WithTransportCredentials(insecure.NewCredentials()),

--- a/pickfirst.go
+++ b/pickfirst.go
@@ -24,7 +24,6 @@ import (
 
 	"google.golang.org/grpc/balancer"
 	"google.golang.org/grpc/connectivity"
-	"google.golang.org/grpc/resolver"
 )
 
 // PickFirstBalancerName is the name of the pick_first balancer.
@@ -48,7 +47,6 @@ type pickfirstBalancer struct {
 	state   connectivity.State
 	cc      balancer.ClientConn
 	subConn balancer.SubConn
-	addrs   []resolver.Address
 }
 
 func (b *pickfirstBalancer) ResolverError(err error) {
@@ -70,18 +68,6 @@ func (b *pickfirstBalancer) ResolverError(err error) {
 	})
 }
 
-func equalAddresses(a, b []resolver.Address) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i, v := range a {
-		if !v.Equal(b[i]) {
-			return false
-		}
-	}
-	return true
-}
-
 func (b *pickfirstBalancer) UpdateClientConnState(state balancer.ClientConnState) error {
 	if len(state.ResolverState.Addresses) == 0 {
 		// The resolver reported an empty address list. Treat it like an error by
@@ -95,21 +81,6 @@ func (b *pickfirstBalancer) UpdateClientConnState(state balancer.ClientConnState
 		b.ResolverError(errors.New("produced zero addresses"))
 		return balancer.ErrBadResolverState
 	}
-
-	if equalAddresses(b.addrs, state.ResolverState.Addresses) {
-		// Avoid updating SubConn addresses if the addresses are the same.
-		//
-		// Usually SubConns can compare the new addresses with the address in
-		// use, and will not recreate the connection if not necessary.
-		//
-		// A special case is if the SubConn is in Connecting (so it's still
-		// trying to connect the addresses, and there's no address in use).
-		// Calling update addresses, even with the same set of Addresses, cause
-		// the SubConn to stop connecting, and retry with the new (same) set of
-		// addresses.
-		return nil
-	}
-	b.addrs = state.ResolverState.Addresses
 
 	if b.subConn != nil {
 		b.cc.UpdateAddresses(b.subConn, state.ResolverState.Addresses)


### PR DESCRIPTION
Even if the SubConn is Connecting (there's no curAddr).

RELEASE NOTES:
* client/SubConn: do not recreate addrConn if UpdateAddresses is called with the same addresses