### PR TITLE
test/xds: move tests to a package with _test suffix

### DIFF
--- a/test/xds/xds_client_affinity_test.go
+++ b/test/xds/xds_client_affinity_test.go
@@ -16,7 +16,7 @@
  *
  */
 
-package xds
+package xds_test
 
 import (
 	"context"

--- a/test/xds/xds_client_federation_test.go
+++ b/test/xds/xds_client_federation_test.go
@@ -13,9 +13,10 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
-package xds
+package xds_test
 
 import (
 	"context"

--- a/test/xds/xds_client_integration_test.go
+++ b/test/xds/xds_client_integration_test.go
@@ -16,7 +16,7 @@
  *
  */
 
-package xds
+package xds_test
 
 import (
 	"context"

--- a/test/xds/xds_client_retry_test.go
+++ b/test/xds/xds_client_retry_test.go
@@ -16,7 +16,7 @@
  *
  */
 
-package xds
+package xds_test
 
 import (
 	"context"

--- a/test/xds/xds_rls_clusterspecifier_plugin_test.go
+++ b/test/xds/xds_rls_clusterspecifier_plugin_test.go
@@ -16,7 +16,7 @@
  *
  */
 
-package xds
+package xds_test
 
 import (
 	"context"

--- a/test/xds/xds_security_config_nack_test.go
+++ b/test/xds/xds_security_config_nack_test.go
@@ -16,7 +16,7 @@
  *
  */
 
-package xds
+package xds_test
 
 import (
 	"context"

--- a/test/xds/xds_server_integration_test.go
+++ b/test/xds/xds_server_integration_test.go
@@ -16,7 +16,7 @@
  *
  */
 
-package xds
+package xds_test
 
 import (
 	"context"

--- a/test/xds/xds_server_rbac_test.go
+++ b/test/xds/xds_server_rbac_test.go
@@ -16,7 +16,7 @@
  *
  */
 
-package xds
+package xds_test
 
 import (
 	"context"

--- a/test/xds/xds_server_serving_mode_test.go
+++ b/test/xds/xds_server_serving_mode_test.go
@@ -16,7 +16,7 @@
  *
  */
 
-package xds
+package xds_test
 
 import (
 	"context"


### PR DESCRIPTION
The internal build environment is not happy with a package which contains only test files. The recommended approach is to add a `_test` suffix to the package name. See internal link: go/go-style/decisions#test-different-package

RELEASE NOTES: none