### PR TITLE
interop: remove duplicated xDS tests in GCE framework

### DIFF
--- a/test/kokoro/xds.sh
+++ b/test/kokoro/xds.sh
@@ -7,12 +7,6 @@ cd github
 
 export GOPATH="${HOME}/gopath"
 pushd grpc-go/interop/xds/client
-branch=$(git branch --all --no-color --contains "${KOKORO_GITHUB_COMMIT}" \
-    | grep -v HEAD | head -1)
-shopt -s extglob
-branch="${branch//[[:space:]]}"
-branch="${branch##remotes/origin/}"
-shopt -u extglob
 # Install a version of Go supported by gRPC for the new features, e.g.
 # errors.Is()
 curl --retry 3 -O -L https://go.dev/dl/go1.17.3.linux-amd64.tar.gz
@@ -22,7 +16,7 @@ sudo ln -s /usr/local/go/bin/go /usr/bin/go
 for i in 1 2 3; do go build && break || sleep 5; done
 popd
 
-git clone -b "${branch}" --single-branch --depth=1 https://github.com/grpc/grpc.git
+git clone -b master --single-branch --depth=1 https://github.com/grpc/grpc.git
 
 grpc/tools/run_tests/helper_scripts/prep_xds.sh
 
@@ -33,7 +27,7 @@ grpc/tools/run_tests/helper_scripts/prep_xds.sh
 # they are added into "all".
 GRPC_GO_LOG_VERBOSITY_LEVEL=99 GRPC_GO_LOG_SEVERITY_LEVEL=info \
   python3 grpc/tools/run_tests/run_xds_tests.py \
-    --test_case="all,circuit_breaking,timeout,fault_injection,csds" \
+    --test_case="ping_pong,circuit_breaking" \
     --project_id=grpc-testing \
     --project_num=830293263384 \
     --source_image=projects/grpc-testing/global/images/xds-test-server-5 \
@@ -48,4 +42,3 @@ GRPC_GO_LOG_VERBOSITY_LEVEL=99 GRPC_GO_LOG_SEVERITY_LEVEL=info \
       {fail_on_failed_rpc} \
       {rpcs_to_send} \
       {metadata_to_send}"
-


### PR DESCRIPTION
This PR removes the duplicated xDS tests in GCE (all except circuit_breaking). The ideal (complete coverage & faster & more reliable) set of tests for each branch will be:

- GCE xDS v2: ping_pong
- GCE xDS v3: ping_pong, circuit_breaking
- GKE UrlMap Tests: all
- GKE PSM Security: all
- GKE K8s LB: all

After this PR is merged, I will start to fix each release one by one.

The manual triggered runs for this PR:

* [xds](http://sponge/54dfe351-d40b-44c6-808c-bf12e44d907c)
* [xds_v3](http://sponge/462557d7-4d60-47f5-9672-fb7f6d27dc81)

---

Accidentally removed commits from https://github.com/grpc/grpc-go/pull/5015, took me a while to figure out.


RELEASE NOTES: n/a