### PR TITLE
client: use better function to tear down the addrConn

### DIFF
--- a/clientconn.go
+++ b/clientconn.go
@@ -1041,7 +1041,7 @@ func (cc *ClientConn) Close() error {
 	}
 
 	for ac := range conns {
-		ac.tearDown(ErrClientConnClosing)
+		cc.removeAddrConn(ac, ErrClientConnClosing)
 	}
 	ted := &channelz.TraceEventDesc{
 		Desc:     "Channel deleted",


### PR DESCRIPTION
I noted there is a function `removeAddrConn` that better than `tearDown`. `tearDown` doesn't remove ac from ac.cc.conns, so the addrConn struct will leak. And `removeAddrConn` is a new method relative to `tearDown`.

RELEASE NOTES: None