### PR TITLE
xds/priority: bug fix and minor behavior change

### DIFF
--- a/balancer/base/balancer.go
+++ b/balancer/base/balancer.go
@@ -45,6 +45,7 @@ func (bb *baseBuilder) Build(cc balancer.ClientConn, opt balancer.BuildOptions) 
 		scStates: make(map[balancer.SubConn]connectivity.State),
 		csEvltr:  &balancer.ConnectivityStateEvaluator{},
 		config:   bb.config,
+		state:    connectivity.Connecting,
 	}
 	// Initialize picker to a picker that always returns
 	// ErrNoSubConnAvailable, because when state of a SubConn changes, we
@@ -134,6 +135,9 @@ func (b *baseBalancer) UpdateClientConnState(s balancer.ClientConnState) error {
 		b.ResolverError(errors.New("produced zero addresses"))
 		return balancer.ErrBadResolverState
 	}
+
+	b.regeneratePicker()
+	b.cc.UpdateState(balancer.State{ConnectivityState: b.state, Picker: b.picker})
 	return nil
 }
 

--- a/xds/internal/balancer/clusterresolver/eds_impl_test.go
+++ b/xds/internal/balancer/clusterresolver/eds_impl_test.go
@@ -456,6 +456,9 @@ func (s) TestEDS_EmptyUpdate(t *testing.T) {
 }
 
 func (s) TestEDS_CircuitBreaking(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+
 	edsb, cc, xdsC, cleanup := setupTestEDS(t, nil)
 	defer cleanup()
 
@@ -481,44 +484,46 @@ func (s) TestEDS_CircuitBreaking(t *testing.T) {
 	edsb.UpdateSubConnState(sc1, balancer.SubConnState{ConnectivityState: connectivity.Ready})
 
 	// Picks with drops.
-	dones := []func(){}
-	p := <-cc.NewPickerCh
-	for i := 0; i < 100; i++ {
-		pr, err := p.Pick(balancer.PickInfo{})
-		if i < 50 && err != nil {
-			t.Errorf("The first 50%% picks should be non-drops, got error %v", err)
-		} else if i > 50 && err == nil {
-			t.Errorf("The second 50%% picks should be drops, got error <nil>")
-		}
-		dones = append(dones, func() {
-			if pr.Done != nil {
-				pr.Done(balancer.DoneInfo{})
+	cc.WaitForPicker(ctx, func(p balancer.Picker) error {
+		dones := []func(){}
+		for i := 0; i < 100; i++ {
+			pr, err := p.Pick(balancer.PickInfo{})
+			if i < 50 && err != nil {
+				return fmt.Errorf("The first 50%% picks should be non-drops, got error %v", err)
+			} else if i > 50 && err == nil {
+				return fmt.Errorf("The second 50%% picks should be drops, got error <nil>")
 			}
-		})
-	}
-
-	for _, done := range dones {
-		done()
-	}
-	dones = []func(){}
-
-	// Pick without drops.
-	for i := 0; i < 50; i++ {
-		pr, err := p.Pick(balancer.PickInfo{})
-		if err != nil {
-			t.Errorf("The third 50%% picks should be non-drops, got error %v", err)
+			dones = append(dones, func() {
+				if pr.Done != nil {
+					pr.Done(balancer.DoneInfo{})
+				}
+			})
 		}
-		dones = append(dones, func() {
-			if pr.Done != nil {
-				pr.Done(balancer.DoneInfo{})
-			}
-		})
-	}
 
-	// Without this, future tests with the same service name will fail.
-	for _, done := range dones {
-		done()
-	}
+		for _, done := range dones {
+			done()
+		}
+		dones = []func(){}
+
+		// Pick without drops.
+		for i := 0; i < 50; i++ {
+			pr, err := p.Pick(balancer.PickInfo{})
+			if err != nil {
+				return fmt.Errorf("The third 50%% picks should be non-drops, got error %v", err)
+			}
+			dones = append(dones, func() {
+				if pr.Done != nil {
+					pr.Done(balancer.DoneInfo{})
+				}
+			})
+		}
+
+		// Without this, future tests with the same service name will fail.
+		for _, done := range dones {
+			done()
+		}
+		return nil
+	})
 
 	// Send another update, with only circuit breaking update (and no picker
 	// update afterwards). Make sure the new picker uses the new configs.
@@ -536,42 +541,44 @@ func (s) TestEDS_CircuitBreaking(t *testing.T) {
 	}
 
 	// Picks with drops.
-	dones = []func(){}
-	p2 := <-cc.NewPickerCh
-	for i := 0; i < 100; i++ {
-		pr, err := p2.Pick(balancer.PickInfo{})
-		if i < 10 && err != nil {
-			t.Errorf("The first 10%% picks should be non-drops, got error %v", err)
-		} else if i > 10 && err == nil {
-			t.Errorf("The next 90%% picks should be drops, got error <nil>")
-		}
-		dones = append(dones, func() {
-			if pr.Done != nil {
-				pr.Done(balancer.DoneInfo{})
+	cc.WaitForPicker(ctx, func(p balancer.Picker) error {
+		dones := []func(){}
+		for i := 0; i < 100; i++ {
+			pr, err := p.Pick(balancer.PickInfo{})
+			if i < 10 && err != nil {
+				return fmt.Errorf("The first 10%% picks should be non-drops, got error %v", err)
+			} else if i > 10 && err == nil {
+				return fmt.Errorf("The next 90%% picks should be drops, got error <nil>")
 			}
-		})
-	}
-
-	for _, done := range dones {
-		done()
-	}
-	dones = []func(){}
-
-	// Pick without drops.
-	for i := 0; i < 10; i++ {
-		pr, err := p2.Pick(balancer.PickInfo{})
-		if err != nil {
-			t.Errorf("The next 10%% picks should be non-drops, got error %v", err)
+			dones = append(dones, func() {
+				if pr.Done != nil {
+					pr.Done(balancer.DoneInfo{})
+				}
+			})
 		}
-		dones = append(dones, func() {
-			if pr.Done != nil {
-				pr.Done(balancer.DoneInfo{})
-			}
-		})
-	}
 
-	// Without this, future tests with the same service name will fail.
-	for _, done := range dones {
-		done()
-	}
+		for _, done := range dones {
+			done()
+		}
+		dones = []func(){}
+
+		// Pick without drops.
+		for i := 0; i < 10; i++ {
+			pr, err := p.Pick(balancer.PickInfo{})
+			if err != nil {
+				return fmt.Errorf("The next 10%% picks should be non-drops, got error %v", err)
+			}
+			dones = append(dones, func() {
+				if pr.Done != nil {
+					pr.Done(balancer.DoneInfo{})
+				}
+			})
+		}
+
+		// Without this, future tests with the same service name will fail.
+		for _, done := range dones {
+			done()
+		}
+		return nil
+	})
 }

--- a/xds/internal/balancer/clusterresolver/priority_test.go
+++ b/xds/internal/balancer/clusterresolver/priority_test.go
@@ -69,13 +69,23 @@ func (s) TestEDSPriority_HighPriorityReady(t *testing.T) {
 	xdsC.InvokeWatchEDSCallback("", parseEDSRespProtoForTesting(clab2.Build()), nil)
 
 	select {
-	case <-cc.NewPickerCh:
-		t.Fatalf("got unexpected new picker")
 	case <-cc.NewSubConnCh:
 		t.Fatalf("got unexpected new SubConn")
 	case <-cc.RemoveSubConnCh:
 		t.Fatalf("got unexpected remove SubConn")
 	case <-time.After(defaultTestShortTimeout):
+	}
+
+	select {
+	case p := <-cc.NewPickerCh:
+		// If we do get a new picker, ensure it is still a p1 picker.
+		if err := testutils.IsRoundRobin([]balancer.SubConn{sc1}, subConnFromPicker(p)); err != nil {
+			t.Fatal(err.Error())
+		}
+	default:
+		// No new picker; we were previously using p1 and should still be using
+		// p1, so this is okay.  No need to wait for defaultTestShortTimeout
+		// since we just waited immediately above.
 	}
 
 	// Remove p2, no updates.
@@ -85,14 +95,25 @@ func (s) TestEDSPriority_HighPriorityReady(t *testing.T) {
 	xdsC.InvokeWatchEDSCallback("", parseEDSRespProtoForTesting(clab3.Build()), nil)
 
 	select {
-	case <-cc.NewPickerCh:
-		t.Fatalf("got unexpected new picker")
 	case <-cc.NewSubConnCh:
 		t.Fatalf("got unexpected new SubConn")
 	case <-cc.RemoveSubConnCh:
 		t.Fatalf("got unexpected remove SubConn")
 	case <-time.After(defaultTestShortTimeout):
 	}
+
+	select {
+	case p := <-cc.NewPickerCh:
+		// If we do get a new picker, ensure it is still a p1 picker.
+		if err := testutils.IsRoundRobin([]balancer.SubConn{sc1}, subConnFromPicker(p)); err != nil {
+			t.Fatal(err.Error())
+		}
+	default:
+		// No new picker; we were previously using p1 and should still be using
+		// p1, so this is okay.  No need to wait for defaultTestShortTimeout
+		// since we just waited immediately above.
+	}
+
 }
 
 // Lower priority is used when higher priority is not ready.
@@ -147,13 +168,23 @@ func (s) TestEDSPriority_SwitchPriority(t *testing.T) {
 	xdsC.InvokeWatchEDSCallback("", parseEDSRespProtoForTesting(clab2.Build()), nil)
 
 	select {
-	case <-cc.NewPickerCh:
-		t.Fatalf("got unexpected new picker")
 	case <-cc.NewSubConnCh:
 		t.Fatalf("got unexpected new SubConn")
 	case <-cc.RemoveSubConnCh:
 		t.Fatalf("got unexpected remove SubConn")
 	case <-time.After(defaultTestShortTimeout):
+	}
+
+	select {
+	case p := <-cc.NewPickerCh:
+		// If we do get a new picker, ensure it is still a p1 picker.
+		if err := testutils.IsRoundRobin([]balancer.SubConn{sc1}, subConnFromPicker(p)); err != nil {
+			t.Fatal(err.Error())
+		}
+	default:
+		// No new picker; we were previously using p1 and should still be using
+		// p1, so this is okay.  No need to wait for defaultTestShortTimeout
+		// since we just waited immediately above.
 	}
 
 	// Turn down 1, use 2

--- a/xds/internal/balancer/priority/balancer.go
+++ b/xds/internal/balancer/priority/balancer.go
@@ -30,6 +30,8 @@ import (
 	"time"
 
 	"google.golang.org/grpc/balancer"
+	"google.golang.org/grpc/balancer/base"
+	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/internal/balancergroup"
 	"google.golang.org/grpc/internal/buffer"
 	"google.golang.org/grpc/internal/grpclog"
@@ -53,7 +55,6 @@ func (bb) Build(cc balancer.ClientConn, bOpts balancer.BuildOptions) balancer.Ba
 	b := &priorityBalancer{
 		cc:                       cc,
 		done:                     grpcsync.NewEvent(),
-		childToPriority:          make(map[string]int),
 		children:                 make(map[string]*childBalancer),
 		childBalancerStateUpdate: buffer.NewUnbounded(),
 	}
@@ -90,16 +91,17 @@ type priorityBalancer struct {
 
 	mu         sync.Mutex
 	childInUse string
-	// priority of the child that's current in use. Int starting from 0, and 0
-	// is the higher priority.
-	priorityInUse int
 	// priorities is a list of child names from higher to lower priority.
 	priorities []string
-	// childToPriority is a map from the child name to it's priority. Priority
-	// is an int start from 0, and 0 is the higher priority.
-	childToPriority map[string]int
 	// children is a map from child name to sub-balancers.
 	children map[string]*childBalancer
+
+	// Set during UpdateClientConnState when calling into sub-balancers.
+	// Prevents child updates from recomputing the active priority or sending
+	// an update of the aggregated picker to the parent.  Cleared after all
+	// sub-balancers have finished UpdateClientConnState, after which
+	// syncPriority is called manually.
+	inhibitChildUpdates bool
 }
 
 func (b *priorityBalancer) UpdateClientConnState(s balancer.ClientConnState) error {
@@ -111,7 +113,6 @@ func (b *priorityBalancer) UpdateClientConnState(s balancer.ClientConnState) err
 	addressesSplit := hierarchy.Group(s.ResolverState.Addresses)
 
 	b.mu.Lock()
-	defer b.mu.Unlock()
 	// Create and remove children, since we know all children from the config
 	// are used by some priority.
 	for name, newSubConfig := range newConfig.Children {
@@ -146,15 +147,14 @@ func (b *priorityBalancer) UpdateClientConnState(s balancer.ClientConnState) err
 		}
 
 		// Update config and address, but note that this doesn't send the
-		// updates to child balancer (the child balancer might not be built, if
-		// it's a low priority).
+		// updates to non-started child balancers (the child balancer might not
+		// be built, if it's a low priority).
 		currentChild.updateConfig(newSubConfig, resolver.State{
 			Addresses:     addressesSplit[name],
 			ServiceConfig: s.ResolverState.ServiceConfig,
 			Attributes:    s.ResolverState.Attributes,
 		})
 	}
-
 	// Remove child from children if it's not in new config.
 	for name, oldChild := range b.children {
 		if _, ok := newConfig.Children[name]; !ok {
@@ -164,13 +164,25 @@ func (b *priorityBalancer) UpdateClientConnState(s balancer.ClientConnState) err
 
 	// Update priorities and handle priority changes.
 	b.priorities = newConfig.Priorities
-	b.childToPriority = make(map[string]int, len(newConfig.Priorities))
-	for pi, pName := range newConfig.Priorities {
-		b.childToPriority[pName] = pi
+
+	// Everything was removed by the update.
+	if len(b.priorities) == 0 {
+		b.childInUse = ""
+		b.cc.UpdateState(balancer.State{
+			ConnectivityState: connectivity.TransientFailure,
+			Picker:            base.NewErrPicker(ErrAllPrioritiesRemoved),
+		})
+		b.mu.Unlock()
+		return nil
 	}
-	// Sync the states of all children to the new updated priorities. This
-	// include starting/stopping child balancers when necessary.
-	b.syncPriority(true)
+
+	b.inhibitChildUpdates = true
+	b.mu.Unlock()
+	// This will sync the states of all children to the new updated
+	// priorities. Includes starting/stopping child balancers when necessary.
+	done := make(chan struct{})
+	b.childBalancerStateUpdate.Put(clearInhibitChildUpdates{done: done})
+	<-done
 
 	return nil
 }
@@ -206,7 +218,7 @@ func (b *priorityBalancer) ExitIdle() {
 // UpdateState implements balancergroup.BalancerStateAggregator interface. The
 // balancer group sends new connectivity state and picker here.
 func (b *priorityBalancer) UpdateState(childName string, state balancer.State) {
-	b.childBalancerStateUpdate.Put(&childBalancerState{
+	b.childBalancerStateUpdate.Put(childBalancerState{
 		name: childName,
 		s:    state,
 	})
@@ -217,6 +229,10 @@ type childBalancerState struct {
 	s    balancer.State
 }
 
+type clearInhibitChildUpdates struct {
+	done chan struct{}
+}
+
 // run handles child update in a separate goroutine, so if the child sends
 // updates inline (when called by parent), it won't cause deadlocks (by trying
 // to hold the same mutex).
@@ -225,11 +241,22 @@ func (b *priorityBalancer) run() {
 		select {
 		case u := <-b.childBalancerStateUpdate.Get():
 			b.childBalancerStateUpdate.Load()
-			s := u.(*childBalancerState)
 			// Needs to handle state update in a goroutine, because each state
 			// update needs to start/close child policy, could result in
 			// deadlock.
-			b.handleChildStateUpdate(s.name, s.s)
+			b.mu.Lock()
+			if b.done.HasFired() {
+				return
+			}
+			switch s := u.(type) {
+			case childBalancerState:
+				b.handleChildStateUpdate(s.name, s.s)
+			case clearInhibitChildUpdates:
+				b.inhibitChildUpdates = false
+				b.syncPriority("")
+				close(s.done)
+			}
+			b.mu.Unlock()
 		case <-b.done.Done():
 			return
 		}

--- a/xds/internal/balancer/priority/balancer_child.go
+++ b/xds/internal/balancer/priority/balancer_child.go
@@ -44,7 +44,8 @@ type childBalancer struct {
 	// will be restarted if the child has not reported TF more recently than it
 	// reported Ready or Idle.
 	reportedTF bool
-	state      balancer.State
+	// The latest state the child balancer provided.
+	state balancer.State
 	// The timer to give a priority some time to connect. And if the priority
 	// doesn't go into Ready/Failure, the next priority will be started.
 	initTimer *timerWrapper
@@ -79,6 +80,9 @@ func (cb *childBalancer) updateConfig(child *Child, rState resolver.State) {
 	cb.ignoreReresolutionRequests = child.IgnoreReresolutionRequests
 	cb.config = child.Config.Config
 	cb.rState = rState
+	if cb.started {
+		cb.sendUpdate()
+	}
 }
 
 // start builds the child balancer if it's not already started.
@@ -91,6 +95,7 @@ func (cb *childBalancer) start() {
 	cb.started = true
 	cb.parent.bg.Add(cb.name, cb.bb)
 	cb.startInitTimer()
+	cb.sendUpdate()
 }
 
 // sendUpdate sends the addresses and config to the child balancer.
@@ -145,7 +150,7 @@ func (cb *childBalancer) startInitTimer() {
 		// Re-sync the priority. This will switch to the next priority if
 		// there's any. Note that it's important sync() is called after setting
 		// initTimer to nil.
-		cb.parent.syncPriority(false)
+		cb.parent.syncPriority("")
 	})
 }
 

--- a/xds/internal/balancer/priority/balancer_child.go
+++ b/xds/internal/balancer/priority/balancer_child.go
@@ -75,7 +75,7 @@ func (cb *childBalancer) updateBuilder(bb balancer.Builder) {
 }
 
 // updateConfig sets childBalancer's config and state, but doesn't send update to
-// the child balancer.
+// the child balancer unless it is started.
 func (cb *childBalancer) updateConfig(child *Child, rState resolver.State) {
 	cb.ignoreReresolutionRequests = child.IgnoreReresolutionRequests
 	cb.config = child.Config.Config

--- a/xds/internal/balancer/priority/balancer_priority.go
+++ b/xds/internal/balancer/priority/balancer_priority.go
@@ -68,7 +68,7 @@ var (
 //
 // Caller must hold b.mu.
 func (b *priorityBalancer) syncPriority(childUpdating string) {
-	if b.inhibitChildUpdates {
+	if b.inhibitPickerUpdates {
 		return
 	}
 	for p, name := range b.priorities {

--- a/xds/internal/balancer/priority/balancer_priority.go
+++ b/xds/internal/balancer/priority/balancer_priority.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	"google.golang.org/grpc/balancer"
-	"google.golang.org/grpc/balancer/base"
 	"google.golang.org/grpc/connectivity"
 )
 
@@ -59,7 +58,7 @@ var (
 //     - If balancer is Connecting and has non-nil initTimer (meaning it
 //       transitioned from Ready or Idle to connecting, not from TF, so we
 //       should give it init-time to connect).
-//     - If balancer is READY
+//     - If balancer is READY or IDLE
 //     - If this is the lowest priority
 //   - do the following:
 //     - if this is not the old childInUse, override picker so old picker is no
@@ -68,18 +67,10 @@ var (
 //     - forward the new addresses and config
 //
 // Caller must hold b.mu.
-func (b *priorityBalancer) syncPriority(forceUpdate bool) {
-	// Everything was removed by the update.
-	if len(b.priorities) == 0 {
-		b.childInUse = ""
-		b.priorityInUse = 0
-		b.cc.UpdateState(balancer.State{
-			ConnectivityState: connectivity.TransientFailure,
-			Picker:            base.NewErrPicker(ErrAllPrioritiesRemoved),
-		})
+func (b *priorityBalancer) syncPriority(childUpdating string) {
+	if b.inhibitChildUpdates {
 		return
 	}
-
 	for p, name := range b.priorities {
 		child, ok := b.children[name]
 		if !ok {
@@ -92,23 +83,14 @@ func (b *priorityBalancer) syncPriority(forceUpdate bool) {
 			child.state.ConnectivityState == connectivity.Idle ||
 			(child.state.ConnectivityState == connectivity.Connecting && child.initTimer != nil) ||
 			p == len(b.priorities)-1 {
-			if b.childInUse != "" && b.childInUse != child.name {
-				// childInUse was set and is different from this child, will
-				// change childInUse later. We need to update picker here
-				// immediately so parent stops using the old picker.
+			if b.childInUse != child.name || child.name == childUpdating {
+				logger.Warningf("ciu, cn, cu: %v, %v, %v", b.childInUse, child.name, childUpdating)
+				// If we switch children or the child in use just updated its
+				// picker, push the child's picker to the parent.
 				b.cc.UpdateState(child.state)
 			}
 			b.logger.Infof("switching to (%q, %v) in syncPriority", child.name, p)
-			oldChildInUse := b.childInUse
 			b.switchToChild(child, p)
-			if b.childInUse != oldChildInUse || forceUpdate {
-				// If child is switched, send the update to the new child.
-				//
-				// Or if forceUpdate is true (when this is triggered by a
-				// ClientConn update), because the ClientConn update might
-				// contain changes for this child.
-				child.sendUpdate()
-			}
 			break
 		}
 	}
@@ -163,7 +145,6 @@ func (b *priorityBalancer) switchToChild(child *childBalancer, priority int) {
 		return
 	}
 	b.childInUse = child.name
-	b.priorityInUse = priority
 
 	if !child.started {
 		child.start()
@@ -173,40 +154,13 @@ func (b *priorityBalancer) switchToChild(child *childBalancer, priority int) {
 // handleChildStateUpdate start/close priorities based on the connectivity
 // state.
 func (b *priorityBalancer) handleChildStateUpdate(childName string, s balancer.State) {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	if b.done.HasFired() {
-		return
-	}
-
-	priority, ok := b.childToPriority[childName]
-	if !ok {
-		b.logger.Warningf("priority: received picker update with unknown child %v", childName)
-		return
-	}
-
-	if b.childInUse == "" {
-		b.logger.Warningf("priority: no child is in use when picker update is received")
-		return
-	}
-
-	// priorityInUse is higher than this priority.
-	if b.priorityInUse < priority {
-		// Lower priorities should all be closed, this is an unexpected update.
-		// Can happen if the child policy sends an update after we tell it to
-		// close.
-		b.logger.Warningf("priority: received picker update from priority %v,  lower than priority in use %v", priority, b.priorityInUse)
-		return
-	}
-
 	// Update state in child. The updated picker will be sent to parent later if
 	// necessary.
 	child, ok := b.children[childName]
 	if !ok {
-		b.logger.Warningf("priority: child balancer not found for child %v, priority %v", childName, priority)
+		b.logger.Warningf("priority: child balancer not found for child %v", childName)
 		return
 	}
-	oldChildState := child.state
 	child.state = s
 
 	// We start/stop the init timer of this child based on the new connectivity
@@ -227,36 +181,5 @@ func (b *priorityBalancer) handleChildStateUpdate(childName string, s balancer.S
 		// New state is Shutdown, should never happen. Don't forward.
 	}
 
-	oldPriorityInUse := b.priorityInUse
-	child.parent.syncPriority(false)
-	// If child is switched by syncPriority(), it also sends the update from the
-	// new child to overwrite the old picker used by the parent.
-	//
-	// But no update is sent if the child is not switches. That means if this
-	// update is from childInUse, and this child is still childInUse after
-	// syncing, the update being handled here is not sent to the parent. In that
-	// case, we need to do an explicit check here to forward the update.
-	if b.priorityInUse == oldPriorityInUse && b.priorityInUse == priority {
-		// Special handling for Connecting. If child was not switched, and this
-		// is a Connecting->Connecting transition, do not send the redundant
-		// update, since all Connecting pickers are the same (they tell the RPCs
-		// to repick).
-		//
-		// This can happen because the initial state of a child (before any
-		// update is received) is Connecting. When the child is started, it's
-		// picker is sent to the parent by syncPriority (to overwrite the old
-		// picker if there's any). When it reports Connecting after being
-		// started, it will send a Connecting update (handled here), causing a
-		// Connecting->Connecting transition.
-		if oldChildState.ConnectivityState == connectivity.Connecting && s.ConnectivityState == connectivity.Connecting {
-			return
-		}
-		// Only forward this update if sync() didn't switch child, and this
-		// child is in use.
-		//
-		// sync() forwards the update if the child was switched, so there's no
-		// need to forward again.
-		b.cc.UpdateState(child.state)
-	}
-
+	child.parent.syncPriority(childName)
 }

--- a/xds/internal/balancer/priority/balancer_test.go
+++ b/xds/internal/balancer/priority/balancer_test.go
@@ -149,8 +149,6 @@ func (s) TestPriority_HighPriorityReady(t *testing.T) {
 	}
 
 	select {
-	case <-cc.NewPickerCh:
-		t.Fatalf("got unexpected new picker")
 	case sc := <-cc.NewSubConnCh:
 		t.Fatalf("got unexpected new SubConn: %s", sc)
 	case sc := <-cc.RemoveSubConnCh:
@@ -1884,5 +1882,111 @@ func (s) TestPriority_AddLowPriorityWhenHighIsInIdle(t *testing.T) {
 	if got, want := addrsNew[0].Addr, testBackendAddrStrs[0]; got != want {
 		// Fail if p1 is started and creates a SubConn.
 		t.Fatalf("got unexpected call to NewSubConn with addr: %v, want %v", addrsNew, want)
+	}
+}
+
+// Lower priority is used when higher priority is not ready; higher priority
+// still gets updates.
+//
+// Init 0 and 1; 0 is down, 1 is up, use 1; update 0; 0 is up, use 0
+func (s) TestPriority_HighPriorityUpdatesWhenLowInUse(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+
+	cc := testutils.NewTestClientConn(t)
+	bb := balancer.Get(Name)
+	pb := bb.Build(cc, balancer.BuildOptions{})
+	defer pb.Close()
+
+	t.Log("Two localities, with priorities [0, 1], each with one backend.")
+	if err := pb.UpdateClientConnState(balancer.ClientConnState{
+		ResolverState: resolver.State{
+			Addresses: []resolver.Address{
+				hierarchy.Set(resolver.Address{Addr: testBackendAddrStrs[0]}, []string{"child-0"}),
+				hierarchy.Set(resolver.Address{Addr: testBackendAddrStrs[1]}, []string{"child-1"}),
+			},
+		},
+		BalancerConfig: &LBConfig{
+			Children: map[string]*Child{
+				"child-0": {Config: &internalserviceconfig.BalancerConfig{Name: roundrobin.Name}},
+				"child-1": {Config: &internalserviceconfig.BalancerConfig{Name: roundrobin.Name}},
+			},
+			Priorities: []string{"child-0", "child-1"},
+		},
+	}); err != nil {
+		t.Fatalf("failed to update ClientConn state: %v", err)
+	}
+
+	addrs0 := <-cc.NewSubConnAddrsCh
+	if got, want := addrs0[0].Addr, testBackendAddrStrs[0]; got != want {
+		t.Fatalf("sc is created with addr %v, want %v", got, want)
+	}
+	sc0 := <-cc.NewSubConnCh
+
+	t.Log("Make p0 fail.")
+	pb.UpdateSubConnState(sc0, balancer.SubConnState{ConnectivityState: connectivity.Connecting})
+	pb.UpdateSubConnState(sc0, balancer.SubConnState{ConnectivityState: connectivity.TransientFailure})
+
+	// Before 1 gets READY, picker should return NoSubConnAvailable, so RPCs
+	// will retry.
+	if err := cc.WaitForPickerWithErr(ctx, balancer.ErrNoSubConnAvailable); err != nil {
+		t.Fatal(err.Error())
+	}
+
+	t.Log("Make p1 ready.")
+	addrs1 := <-cc.NewSubConnAddrsCh
+	if got, want := addrs1[0].Addr, testBackendAddrStrs[1]; got != want {
+		t.Fatalf("sc is created with addr %v, want %v", got, want)
+	}
+	sc1 := <-cc.NewSubConnCh
+	pb.UpdateSubConnState(sc1, balancer.SubConnState{ConnectivityState: connectivity.Connecting})
+	pb.UpdateSubConnState(sc1, balancer.SubConnState{ConnectivityState: connectivity.Ready})
+
+	// Test pick with 1.
+	if err := cc.WaitForRoundRobinPicker(ctx, sc1); err != nil {
+		t.Fatal(err.Error())
+	}
+
+	pb.UpdateSubConnState(sc1, balancer.SubConnState{ConnectivityState: connectivity.Connecting})
+	// Does not change the aggregate state, because round robin does not leave
+	// TRANIENT_FAILURE if a subconn goes CONNECTING.
+	pb.UpdateSubConnState(sc1, balancer.SubConnState{ConnectivityState: connectivity.Ready})
+
+	if err := cc.WaitForRoundRobinPicker(ctx, sc1); err != nil {
+		t.Fatal(err.Error())
+	}
+
+	t.Log("Change p0 to use new address.")
+	if err := pb.UpdateClientConnState(balancer.ClientConnState{
+		ResolverState: resolver.State{
+			Addresses: []resolver.Address{
+				hierarchy.Set(resolver.Address{Addr: testBackendAddrStrs[2]}, []string{"child-0"}),
+				hierarchy.Set(resolver.Address{Addr: testBackendAddrStrs[1]}, []string{"child-1"}),
+			},
+		},
+		BalancerConfig: &LBConfig{
+			Children: map[string]*Child{
+				"child-0": {Config: &internalserviceconfig.BalancerConfig{Name: roundrobin.Name}},
+				"child-1": {Config: &internalserviceconfig.BalancerConfig{Name: roundrobin.Name}},
+			},
+			Priorities: []string{"child-0", "child-1"},
+		},
+	}); err != nil {
+		t.Fatalf("failed to update ClientConn state: %v", err)
+	}
+
+	addrs2 := <-cc.NewSubConnAddrsCh
+	if got, want := addrs2[0].Addr, testBackendAddrStrs[2]; got != want {
+		t.Fatalf("sc is created with addr %v, want %v", got, want)
+	}
+	sc2 := <-cc.NewSubConnCh
+
+	t.Log("Make p0 ready.")
+	pb.UpdateSubConnState(sc2, balancer.SubConnState{ConnectivityState: connectivity.Connecting})
+	pb.UpdateSubConnState(sc2, balancer.SubConnState{ConnectivityState: connectivity.Ready})
+
+	// Test pick with 0.
+	if err := cc.WaitForRoundRobinPicker(ctx, sc2); err != nil {
+		t.Fatal(err.Error())
 	}
 }


### PR DESCRIPTION
#5211

- Bug: push config updates to all child policies, not just the active one.
- Process all child picker updates before determining active priority.

Logic changes are all in `.../balancer/priority/*.go`; the other changes are tests that are too dependent on the priority balancer's behavior (not correctness related; just not allowing for the possibility of duplicate picker updates).

RELEASE NOTES:
* xds/priority: fix bug that could prevent higher priorities from receiving config updates