### PR TITLE
ringhash: use grpctest.Tester in unit tests

### DIFF
--- a/xds/internal/balancer/ringhash/config_test.go
+++ b/xds/internal/balancer/ringhash/config_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-func TestParseConfig(t *testing.T) {
+func (s) TestParseConfig(t *testing.T) {
 	tests := []struct {
 		name    string
 		js      string

--- a/xds/internal/balancer/ringhash/picker_test.go
+++ b/xds/internal/balancer/ringhash/picker_test.go
@@ -46,7 +46,7 @@ func newTestRing(cStats []connectivity.State) *ring {
 	return &ring{items: items}
 }
 
-func TestPickerPickFirstTwo(t *testing.T) {
+func (s) TestPickerPickFirstTwo(t *testing.T) {
 	tests := []struct {
 		name            string
 		ring            *ring
@@ -121,7 +121,7 @@ func TestPickerPickFirstTwo(t *testing.T) {
 // TestPickerPickTriggerTFConnect covers that if the picked SubConn is
 // TransientFailures, all SubConns until a non-TransientFailure are queued for
 // Connect().
-func TestPickerPickTriggerTFConnect(t *testing.T) {
+func (s) TestPickerPickTriggerTFConnect(t *testing.T) {
 	ring := newTestRing([]connectivity.State{
 		connectivity.TransientFailure, connectivity.TransientFailure, connectivity.TransientFailure, connectivity.TransientFailure,
 		connectivity.Idle, connectivity.TransientFailure, connectivity.TransientFailure, connectivity.TransientFailure,
@@ -152,7 +152,7 @@ func TestPickerPickTriggerTFConnect(t *testing.T) {
 // TestPickerPickTriggerTFReturnReady covers that if the picked SubConn is
 // TransientFailure, SubConn 2 and 3 are TransientFailure, 4 is Ready. SubConn 2
 // and 3 will Connect(), and 4 will be returned.
-func TestPickerPickTriggerTFReturnReady(t *testing.T) {
+func (s) TestPickerPickTriggerTFReturnReady(t *testing.T) {
 	ring := newTestRing([]connectivity.State{
 		connectivity.TransientFailure, connectivity.TransientFailure, connectivity.TransientFailure, connectivity.Ready,
 	})
@@ -178,7 +178,7 @@ func TestPickerPickTriggerTFReturnReady(t *testing.T) {
 // TransientFailure, SubConn 2 is TransientFailure, 3 is Idle (init Idle). Pick
 // will be queue, SubConn 3 will Connect(), SubConn 4 and 5 (in TransientFailre)
 // will not queue a Connect.
-func TestPickerPickTriggerTFWithIdle(t *testing.T) {
+func (s) TestPickerPickTriggerTFWithIdle(t *testing.T) {
 	ring := newTestRing([]connectivity.State{
 		connectivity.TransientFailure, connectivity.TransientFailure, connectivity.Idle, connectivity.TransientFailure, connectivity.TransientFailure,
 	})
@@ -211,7 +211,7 @@ func TestPickerPickTriggerTFWithIdle(t *testing.T) {
 	}
 }
 
-func TestNextSkippingDuplicatesNoDup(t *testing.T) {
+func (s) TestNextSkippingDuplicatesNoDup(t *testing.T) {
 	testRing := newTestRing([]connectivity.State{connectivity.Idle, connectivity.Idle})
 	tests := []struct {
 		name string
@@ -265,7 +265,7 @@ func addDups(r *ring, count int) *ring {
 	return &ring{items: items}
 }
 
-func TestNextSkippingDuplicatesMoreDup(t *testing.T) {
+func (s) TestNextSkippingDuplicatesMoreDup(t *testing.T) {
 	testRing := newTestRing([]connectivity.State{connectivity.Idle, connectivity.Idle})
 	// Make a new ring with duplicate SubConns.
 	dupTestRing := addDups(testRing, 3)
@@ -274,7 +274,7 @@ func TestNextSkippingDuplicatesMoreDup(t *testing.T) {
 	}
 }
 
-func TestNextSkippingDuplicatesOnlyDup(t *testing.T) {
+func (s) TestNextSkippingDuplicatesOnlyDup(t *testing.T) {
 	testRing := newTestRing([]connectivity.State{connectivity.Idle})
 	// Make a new ring with only duplicate SubConns.
 	dupTestRing := addDups(testRing, 3)

--- a/xds/internal/balancer/ringhash/ring_test.go
+++ b/xds/internal/balancer/ringhash/ring_test.go
@@ -31,7 +31,7 @@ func testAddr(addr string, weight uint32) resolver.Address {
 	return resolver.Address{Addr: addr, Metadata: weight}
 }
 
-func TestRingNew(t *testing.T) {
+func (s) TestRingNew(t *testing.T) {
 	testAddrs := []resolver.Address{
 		testAddr("a", 3),
 		testAddr("b", 3),
@@ -75,7 +75,7 @@ func equalApproximately(x, y float64) bool {
 	return delta/mean < 0.25
 }
 
-func TestRingPick(t *testing.T) {
+func (s) TestRingPick(t *testing.T) {
 	r, _ := newRing(map[resolver.Address]*subConn{
 		{Addr: "a", Metadata: uint32(3)}: {addr: "a"},
 		{Addr: "b", Metadata: uint32(3)}: {addr: "b"},
@@ -97,7 +97,7 @@ func TestRingPick(t *testing.T) {
 	}
 }
 
-func TestRingNext(t *testing.T) {
+func (s) TestRingNext(t *testing.T) {
 	r, _ := newRing(map[resolver.Address]*subConn{
 		{Addr: "a", Metadata: uint32(3)}: {addr: "a"},
 		{Addr: "b", Metadata: uint32(3)}: {addr: "b"},

--- a/xds/internal/balancer/ringhash/ringhash_test.go
+++ b/xds/internal/balancer/ringhash/ringhash_test.go
@@ -30,6 +30,7 @@ import (
 	"google.golang.org/grpc/balancer"
 	"google.golang.org/grpc/balancer/weightedroundrobin"
 	"google.golang.org/grpc/connectivity"
+	"google.golang.org/grpc/internal/grpctest"
 	"google.golang.org/grpc/internal/testutils"
 	"google.golang.org/grpc/resolver"
 )
@@ -98,7 +99,15 @@ func setupTest(t *testing.T, addrs []resolver.Address) (*testutils.TestClientCon
 	return cc, b, p1
 }
 
-func TestOneSubConn(t *testing.T) {
+type s struct {
+	grpctest.Tester
+}
+
+func Test(t *testing.T) {
+	grpctest.RunSubTests(t, s{})
+}
+
+func (s) TestOneSubConn(t *testing.T) {
 	wantAddr1 := resolver.Address{Addr: testBackendAddrStrs[0]}
 	cc, b, p0 := setupTest(t, []resolver.Address{wantAddr1})
 	ring0 := p0.(*picker).ring
@@ -135,7 +144,7 @@ func TestOneSubConn(t *testing.T) {
 // TestThreeBackendsAffinity covers that there are 3 SubConns, RPCs with the
 // same hash always pick the same SubConn. When the one picked is down, another
 // one will be picked.
-func TestThreeSubConnsAffinity(t *testing.T) {
+func (s) TestThreeSubConnsAffinity(t *testing.T) {
 	wantAddrs := []resolver.Address{
 		{Addr: testBackendAddrStrs[0]},
 		{Addr: testBackendAddrStrs[1]},
@@ -228,7 +237,7 @@ func TestThreeSubConnsAffinity(t *testing.T) {
 // TestThreeBackendsAffinity covers that there are 3 SubConns, RPCs with the
 // same hash always pick the same SubConn. Then try different hash to pick
 // another backend, and verify the first hash still picks the first backend.
-func TestThreeSubConnsAffinityMultiple(t *testing.T) {
+func (s) TestThreeSubConnsAffinityMultiple(t *testing.T) {
 	wantAddrs := []resolver.Address{
 		{Addr: testBackendAddrStrs[0]},
 		{Addr: testBackendAddrStrs[1]},
@@ -299,7 +308,7 @@ func TestThreeSubConnsAffinityMultiple(t *testing.T) {
 	}
 }
 
-func TestAddrWeightChange(t *testing.T) {
+func (s) TestAddrWeightChange(t *testing.T) {
 	wantAddrs := []resolver.Address{
 		{Addr: testBackendAddrStrs[0]},
 		{Addr: testBackendAddrStrs[1]},
@@ -368,7 +377,7 @@ func TestAddrWeightChange(t *testing.T) {
 // overall state is TransientFailure, the SubConns turning Idle will trigger the
 // next SubConn in the ring to Connect(). But not when the overall state is not
 // TransientFailure.
-func TestSubConnToConnectWhenOverallTransientFailure(t *testing.T) {
+func (s) TestSubConnToConnectWhenOverallTransientFailure(t *testing.T) {
 	wantAddrs := []resolver.Address{
 		{Addr: testBackendAddrStrs[0]},
 		{Addr: testBackendAddrStrs[1]},
@@ -431,7 +440,7 @@ func TestSubConnToConnectWhenOverallTransientFailure(t *testing.T) {
 	}
 }
 
-func TestConnectivityStateEvaluatorRecordTransition(t *testing.T) {
+func (s) TestConnectivityStateEvaluatorRecordTransition(t *testing.T) {
 	tests := []struct {
 		name     string
 		from, to []connectivity.State


### PR DESCRIPTION
This change makes the actual balancer logs show up in tests.

RELEASE NOTES: none