### PR TITLE
ringhash: don't recreate subConns when update doesn't change address information

### DIFF
--- a/xds/internal/balancer/ringhash/ring.go
+++ b/xds/internal/balancer/ringhash/ring.go
@@ -43,8 +43,8 @@ type ringEntry struct {
 	sc   *subConn
 }
 
-// newRing creates a ring from the subConns. The ring size is limited by the
-// passed in max/min.
+// newRing creates a ring from the subConns stored in the AddressMap. The ring
+// size is limited by the passed in max/min.
 //
 // ring entries will be created for each subConn, and subConn with high weight
 // (specified by the address) may have multiple entries.
@@ -64,7 +64,7 @@ type ringEntry struct {
 //
 // To pick from a ring, a binary search will be done for the given target hash,
 // and first item with hash >= given hash will be returned.
-func newRing(subConns map[resolver.Address]*subConn, minRingSize, maxRingSize uint64) (*ring, error) {
+func newRing(subConns *resolver.AddressMap, minRingSize, maxRingSize uint64) (*ring, error) {
 	// https://github.com/envoyproxy/envoy/blob/765c970f06a4c962961a0e03a467e165b276d50f/source/common/upstream/ring_hash_lb.cc#L114
 	normalizedWeights, minWeight, err := normalizeWeights(subConns)
 	if err != nil {
@@ -111,26 +111,27 @@ func newRing(subConns map[resolver.Address]*subConn, minRingSize, maxRingSize ui
 
 // normalizeWeights divides all the weights by the sum, so that the total weight
 // is 1.
-func normalizeWeights(subConns map[resolver.Address]*subConn) (_ []subConnWithWeight, min float64, _ error) {
-	if len(subConns) == 0 {
+func normalizeWeights(subConns *resolver.AddressMap) (_ []subConnWithWeight, min float64, _ error) {
+	if subConns.Len() == 0 {
 		return nil, 0, fmt.Errorf("number of subconns is 0")
 	}
 	var weightSum uint32
-	for a := range subConns {
-		// The address weight was moved from attributes to the Metadata field.
-		// This is necessary (all the attributes need to be stripped) for the
-		// balancer to detect identical {address+weight} combination.
-		weightSum += a.Metadata.(uint32)
+	for _, a := range subConns.Keys() {
+		// The address weight was moved from `BalancerAttributes` field to the
+		// `Attributes` field in `updateAddresses()` method.
+		weightSum += getWeightAttribute(a)
 	}
 	if weightSum == 0 {
 		return nil, 0, fmt.Errorf("total weight of all subconns is 0")
 	}
 	weightSumF := float64(weightSum)
-	ret := make([]subConnWithWeight, 0, len(subConns))
+	ret := make([]subConnWithWeight, 0, subConns.Len())
 	min = math.MaxFloat64
-	for a, sc := range subConns {
-		nw := float64(a.Metadata.(uint32)) / weightSumF
-		ret = append(ret, subConnWithWeight{sc: sc, weight: nw})
+	for _, a := range subConns.Keys() {
+		v, _ := subConns.Get(a)
+		scInfo := v.(*subConn)
+		nw := float64(getWeightAttribute(a)) / weightSumF
+		ret = append(ret, subConnWithWeight{sc: scInfo, weight: nw})
 		if nw < min {
 			min = nw
 		}

--- a/xds/internal/balancer/ringhash/ring_test.go
+++ b/xds/internal/balancer/ringhash/ring_test.go
@@ -27,22 +27,27 @@ import (
 	"google.golang.org/grpc/resolver"
 )
 
-func testAddr(addr string, weight uint32) resolver.Address {
-	return resolver.Address{Addr: addr, Metadata: weight}
-}
+var testAddrs []resolver.Address
+var testSubConnMap *resolver.AddressMap
 
-func (s) TestRingNew(t *testing.T) {
-	testAddrs := []resolver.Address{
+func init() {
+	testAddrs = []resolver.Address{
 		testAddr("a", 3),
 		testAddr("b", 3),
 		testAddr("c", 4),
 	}
+	testSubConnMap = resolver.NewAddressMap()
+	testSubConnMap.Set(testAddrs[0], &subConn{addr: "a"})
+	testSubConnMap.Set(testAddrs[1], &subConn{addr: "b"})
+	testSubConnMap.Set(testAddrs[2], &subConn{addr: "c"})
+}
+
+func testAddr(addr string, weight uint32) resolver.Address {
+	return setWeightAttribute(resolver.Address{Addr: addr}, weight)
+}
+
+func (s) TestRingNew(t *testing.T) {
 	var totalWeight float64 = 10
-	testSubConnMap := map[resolver.Address]*subConn{
-		testAddr("a", 3): {addr: "a"},
-		testAddr("b", 3): {addr: "b"},
-		testAddr("c", 4): {addr: "c"},
-	}
 	for _, min := range []uint64{3, 4, 6, 8} {
 		for _, max := range []uint64{20, 8} {
 			t.Run(fmt.Sprintf("size-min-%v-max-%v", min, max), func(t *testing.T) {
@@ -59,7 +64,7 @@ func (s) TestRingNew(t *testing.T) {
 						}
 					}
 					got := float64(count) / float64(totalCount)
-					want := float64(a.Metadata.(uint32)) / totalWeight
+					want := float64(getWeightAttribute(a)) / totalWeight
 					if !equalApproximately(got, want) {
 						t.Fatalf("unexpected item weight in ring: %v != %v", got, want)
 					}
@@ -76,11 +81,7 @@ func equalApproximately(x, y float64) bool {
 }
 
 func (s) TestRingPick(t *testing.T) {
-	r, _ := newRing(map[resolver.Address]*subConn{
-		{Addr: "a", Metadata: uint32(3)}: {addr: "a"},
-		{Addr: "b", Metadata: uint32(3)}: {addr: "b"},
-		{Addr: "c", Metadata: uint32(4)}: {addr: "c"},
-	}, 10, 20)
+	r, _ := newRing(testSubConnMap, 10, 20)
 	for _, h := range []uint64{xxhash.Sum64String("1"), xxhash.Sum64String("2"), xxhash.Sum64String("3"), xxhash.Sum64String("4")} {
 		t.Run(fmt.Sprintf("picking-hash-%v", h), func(t *testing.T) {
 			e := r.pick(h)
@@ -98,11 +99,7 @@ func (s) TestRingPick(t *testing.T) {
 }
 
 func (s) TestRingNext(t *testing.T) {
-	r, _ := newRing(map[resolver.Address]*subConn{
-		{Addr: "a", Metadata: uint32(3)}: {addr: "a"},
-		{Addr: "b", Metadata: uint32(3)}: {addr: "b"},
-		{Addr: "c", Metadata: uint32(4)}: {addr: "c"},
-	}, 10, 20)
+	r, _ := newRing(testSubConnMap, 10, 20)
 
 	for _, e := range r.items {
 		ne := r.next(e)

--- a/xds/internal/balancer/ringhash/weight_attribute.go
+++ b/xds/internal/balancer/ringhash/weight_attribute.go
@@ -1,0 +1,40 @@
+/*
+ *
+ * Copyright 2022 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package ringhash
+
+import "google.golang.org/grpc/resolver"
+
+// weightAttributeKey is used as the attribute key when storing the address
+// weight in the `Attributes` field of the address.
+type weightAttributeKey struct{}
+
+// setWeightAttribute returns a copy of addr in which the Attributes field is
+// updated with weight.
+func setWeightAttribute(addr resolver.Address, weight uint32) resolver.Address {
+	addr.Attributes = addr.Attributes.WithValue(weightAttributeKey{}, weight)
+	return addr
+}
+
+// getWeightAttribute returns the weight stored in the Attributes fields of
+// addr.
+func getWeightAttribute(addr resolver.Address) uint32 {
+	v := addr.Attributes.Value(weightAttributeKey{})
+	weight, _ := v.(uint32)
+	return weight
+}


### PR DESCRIPTION
`Ringhash` LB policy receives address weights in `BalancerAttributes`. Existing code was doing the following:
- set `Attributes` field in received addresses to `nil`
- copy over weight information from `BalancerAttributes` field into deprecated `Metadata` field
- use `resolver.Address` as a map key

As `BalancerAttributes` field was not being set to `nil` (after copying over the information to the `Metadata` field), addresses with the same information were being considered as different map keys, leading to subConns being recreated when there was no need for it.

This change does the following:
- uses a `resolver.AddressMap` to store a map from `resolver.Address` to an internal value
- sets the `Attributes` field to `nil`
- copies over the weight information from `BalancerAttributes` to `Attributes`
- `resolver.AddressMap` ignores `BalancerAttributes`, but takes into account `Attributes`

With this change, the `ringhash` policy is able distinguish between addresses which change only in their weight information, and therefore recreates subConns only when absolutely required. Also, as an added benefit, we stop abusing the deprecated `Metadata` field.

Fixes https://github.com/grpc/grpc-go/issues/5420

RELEASE NOTES:
- ringhash: avoid recreating subChannels when update doesn't change address weight information