### PR TITLE
test/kokoro: add missing xds_url_map build config

### DIFF
--- a/test/kokoro/xds_url_map.cfg
+++ b/test/kokoro/xds_url_map.cfg
@@ -1,4 +1,3 @@
-
 # Config file for internal CI
 
 # Location of the continuous shell script in repository.

--- a/test/kokoro/xds_url_map.cfg
+++ b/test/kokoro/xds_url_map.cfg
@@ -1,0 +1,14 @@
+
+# Config file for internal CI
+
+# Location of the continuous shell script in repository.
+build_file: "grpc-go/test/kokoro/xds_url_map.sh"
+timeout_mins: 60
+
+action {
+  define_artifacts {
+    regex: "artifacts/**/*sponge_log.xml"
+    regex: "artifacts/**/*sponge_log.log"
+    strip_prefix: "artifacts"
+  }
+}


### PR DESCRIPTION
This adds `xds_url_map.cfg`, which was missing from the https://github.com/grpc/grpc-go/pull/5411.
Fixes b/236335183.