### PR TITLE
outlierdetection: fix package level comments

### DIFF
--- a/xds/internal/balancer/outlierdetection/balancer.go
+++ b/xds/internal/balancer/outlierdetection/balancer.go
@@ -16,8 +16,9 @@
  *
  */
 
-// Package outlierdetection implements a balancer that implements
-// Outlier Detection.
+// Package outlierdetection provides an implementation of the outlier detection
+// LB policy, as defined in
+// https://github.com/grpc/proposal/blob/master/A50-xds-outlier-detection.md.
 package outlierdetection
 
 import (

--- a/xds/internal/balancer/outlierdetection/config.go
+++ b/xds/internal/balancer/outlierdetection/config.go
@@ -15,8 +15,6 @@
  * limitations under the License.
  */
 
-// Package outlierdetection implements a balancer that implements
-// Outlier Detection.
 package outlierdetection
 
 import (


### PR DESCRIPTION
`golint` was complaining as part of the weekly import because the package level comments were defined in more than one file.

RELEASE NOTES: none