### PR TITLE
transport: remove unused `bufWriter.onFlush()`

### DIFF
--- a/internal/transport/http_util.go
+++ b/internal/transport/http_util.go
@@ -322,8 +322,6 @@ type bufWriter struct {
 	batchSize int
 	conn      net.Conn
 	err       error
-
-	onFlush func()
 }
 
 func newBufWriter(conn net.Conn, batchSize int) *bufWriter {
@@ -359,9 +357,6 @@ func (w *bufWriter) Flush() error {
 	}
 	if w.offset == 0 {
 		return nil
-	}
-	if w.onFlush != nil {
-		w.onFlush()
 	}
 	_, w.err = w.conn.Write(w.buf[:w.offset])
 	w.offset = 0


### PR DESCRIPTION
The `bufWriter.onFlush()` feature was not used in the initial `bufWriter` PR https://github.com/grpc/grpc-go/pull/1962 from four years ago. It is unclear if there were future plans, but it is clearly not needed today.

RELEASE NOTES: none