### PR TITLE
health: split imports into healthpb and healthgrpc

### DIFF
--- a/examples/features/health/server/main.go
+++ b/examples/features/health/server/main.go
@@ -30,8 +30,8 @@ import (
 	"google.golang.org/grpc"
 	pb "google.golang.org/grpc/examples/features/proto/echo"
 	"google.golang.org/grpc/health"
-	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 	healthgrpc "google.golang.org/grpc/health/grpc_health_v1"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 )
 
 var (

--- a/examples/features/health/server/main.go
+++ b/examples/features/health/server/main.go
@@ -31,6 +31,7 @@ import (
 	pb "google.golang.org/grpc/examples/features/proto/echo"
 	"google.golang.org/grpc/health"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+	healthgrpc "google.golang.org/grpc/health/grpc_health_v1"
 )
 
 var (
@@ -62,7 +63,7 @@ func main() {
 
 	s := grpc.NewServer()
 	healthcheck := health.NewServer()
-	healthpb.RegisterHealthServer(s, healthcheck)
+	healthgrpc.RegisterHealthServer(s, healthcheck)
 	pb.RegisterEchoServer(s, &echoServer{})
 
 	go func() {

--- a/examples/features/xds/server/main.go
+++ b/examples/features/xds/server/main.go
@@ -35,8 +35,8 @@ import (
 	xdscreds "google.golang.org/grpc/credentials/xds"
 	pb "google.golang.org/grpc/examples/helloworld/helloworld"
 	"google.golang.org/grpc/health"
-	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 	healthgrpc "google.golang.org/grpc/health/grpc_health_v1"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/xds"
 )
 

--- a/examples/features/xds/server/main.go
+++ b/examples/features/xds/server/main.go
@@ -36,6 +36,7 @@ import (
 	pb "google.golang.org/grpc/examples/helloworld/helloworld"
 	"google.golang.org/grpc/health"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+	healthgrpc "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/xds"
 )
 
@@ -95,7 +96,7 @@ func main() {
 	grpcServer := grpc.NewServer()
 	healthServer := health.NewServer()
 	healthServer.SetServingStatus("", healthpb.HealthCheckResponse_SERVING)
-	healthpb.RegisterHealthServer(grpcServer, healthServer)
+	healthgrpc.RegisterHealthServer(grpcServer, healthServer)
 
 	log.Printf("Serving GreeterService on %s and HealthService on %s", greeterLis.Addr().String(), healthLis.Addr().String())
 	go func() {

--- a/interop/xds/server/server.go
+++ b/interop/xds/server/server.go
@@ -37,8 +37,8 @@ import (
 	"google.golang.org/grpc/xds"
 
 	xdscreds "google.golang.org/grpc/credentials/xds"
-	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 	healthgrpc "google.golang.org/grpc/health/grpc_health_v1"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 	testgrpc "google.golang.org/grpc/interop/grpc_testing"
 	testpb "google.golang.org/grpc/interop/grpc_testing"
 )

--- a/interop/xds/server/server.go
+++ b/interop/xds/server/server.go
@@ -38,6 +38,7 @@ import (
 
 	xdscreds "google.golang.org/grpc/credentials/xds"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+	healthgrpc "google.golang.org/grpc/health/grpc_health_v1"
 	testgrpc "google.golang.org/grpc/interop/grpc_testing"
 	testpb "google.golang.org/grpc/interop/grpc_testing"
 )
@@ -125,7 +126,7 @@ func main() {
 		server := grpc.NewServer()
 		testgrpc.RegisterTestServiceServer(server, testService)
 		healthServer.SetServingStatus("", healthpb.HealthCheckResponse_SERVING)
-		healthpb.RegisterHealthServer(server, healthServer)
+		healthgrpc.RegisterHealthServer(server, healthServer)
 		testgrpc.RegisterXdsUpdateHealthServiceServer(server, updateHealthService)
 		reflection.Register(server)
 		cleanup, err := admin.Register(server)
@@ -172,7 +173,7 @@ func main() {
 	// it and start serving.
 	maintenanceServer := grpc.NewServer()
 	healthServer.SetServingStatus("", healthpb.HealthCheckResponse_SERVING)
-	healthpb.RegisterHealthServer(maintenanceServer, healthServer)
+	healthgrpc.RegisterHealthServer(maintenanceServer, healthServer)
 	testgrpc.RegisterXdsUpdateHealthServiceServer(maintenanceServer, updateHealthService)
 	reflection.Register(maintenanceServer)
 	cleanup, err := admin.Register(maintenanceServer)

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -470,7 +470,7 @@ type test struct {
 	// expose the server's health using the default health service
 	// implementation. This should only be used when a non-default health service
 	// implementation is required.
-	healthServer            healthpb.HealthServer
+	healthServer            healthgrpc.HealthServer
 	maxStream               uint32
 	tapHandle               tap.ServerInHandle
 	maxServerMsgSize        *int
@@ -512,12 +512,12 @@ type test struct {
 	// These are are set once startServer is called. The common case is to have
 	// only one testServer.
 	srv     stopper
-	hSrv    healthpb.HealthServer
+	hSrv    healthgrpc.HealthServer
 	srvAddr string
 
 	// These are are set once startServers is called.
 	srvs     []stopper
-	hSrvs    []healthpb.HealthServer
+	hSrvs    []healthgrpc.HealthServer
 	srvAddrs []string
 
 	cc          *grpc.ClientConn // nil until requested via clientConn

--- a/test/healthcheck_test.go
+++ b/test/healthcheck_test.go
@@ -86,7 +86,7 @@ func defaultWatchFunc(s *testHealthServer, in *healthpb.HealthCheckRequest, stre
 type healthWatchFunc func(s *testHealthServer, in *healthpb.HealthCheckRequest, stream healthgrpc.Health_WatchServer) error
 
 type testHealthServer struct {
-	healthpb.UnimplementedHealthServer
+	healthgrpc.UnimplementedHealthServer
 	watchFunc healthWatchFunc
 	mu        sync.Mutex
 	status    map[string]healthpb.HealthCheckResponse_ServingStatus


### PR DESCRIPTION
Splitting the imports into pb and grpc is necessary to stop importing these generated files into google3.
 
RELEASE NOTES: none