### PR TITLE
xds: drop localities with zero weight at the xdsClient layer

### DIFF
--- a/xds/internal/balancer/clusterresolver/configbuilder.go
+++ b/xds/internal/balancer/clusterresolver/configbuilder.go
@@ -251,9 +251,6 @@ func groupLocalitiesByPriority(localities []xdsresource.Locality) [][]xdsresourc
 	var priorityIntSlice []int
 	priorities := make(map[int][]xdsresource.Locality)
 	for _, locality := range localities {
-		if locality.Weight == 0 {
-			continue
-		}
 		priority := int(locality.Priority)
 		priorities[priority] = append(priorities[priority], locality)
 		priorityIntSlice = append(priorityIntSlice, priority)

--- a/xds/internal/xdsclient/xdsresource/type_eds.go
+++ b/xds/internal/xdsclient/xdsresource/type_eds.go
@@ -64,7 +64,10 @@ type Locality struct {
 
 // EndpointsUpdate contains an EDS update.
 type EndpointsUpdate struct {
-	Drops      []OverloadDropConfig
+	Drops []OverloadDropConfig
+	// Localities in the EDS response with `load_balancing_weight` field not set
+	// or explicity set to 0 are ignored while parsing the resource, and
+	// therefore do not show up here.
 	Localities []Locality
 
 	// Raw is the resource from the xds response.

--- a/xds/internal/xdsclient/xdsresource/type_eds.go
+++ b/xds/internal/xdsclient/xdsresource/type_eds.go
@@ -66,7 +66,7 @@ type Locality struct {
 type EndpointsUpdate struct {
 	Drops []OverloadDropConfig
 	// Localities in the EDS response with `load_balancing_weight` field not set
-	// or explicity set to 0 are ignored while parsing the resource, and
+	// or explicitly set to 0 are ignored while parsing the resource, and
 	// therefore do not show up here.
 	Localities []Locality
 

--- a/xds/internal/xdsclient/xdsresource/unmarshal_eds_test.go
+++ b/xds/internal/xdsclient/xdsresource/unmarshal_eds_test.go
@@ -76,6 +76,20 @@ func (s) TestEDSParseRespProto(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "missing locality weight",
+			m: func() *v3endpointpb.ClusterLoadAssignment {
+				clab0 := newClaBuilder("test", nil)
+				clab0.addLocality("locality-1", 0, 1, []string{"addr1:314"}, &addLocalityOptions{
+					Health: []v3corepb.HealthStatus{v3corepb.HealthStatus_HEALTHY},
+				})
+				clab0.addLocality("locality-2", 0, 0, []string{"addr2:159"}, &addLocalityOptions{
+					Health: []v3corepb.HealthStatus{v3corepb.HealthStatus_HEALTHY},
+				})
+				return clab0.Build()
+			}(),
+			want: EndpointsUpdate{},
+		},
+		{
 			name: "good",
 			m: func() *v3endpointpb.ClusterLoadAssignment {
 				clab0 := newClaBuilder("test", nil)
@@ -161,7 +175,7 @@ func (s) TestEDSParseRespProto(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := parseEDSRespProto(tt.m)
+			got, err := parseEDSRespProto(tt.m, nil)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("parseEDSRespProto() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc-go/issues/5453

This PR moves the logic of dropping localities, in a received EDS response with weight 0, to the `xdsClient`. This allows the LB policy implementations to function with the assumption that they would only receive localities with non-zero weights as part of any updates from the `xdsClient`. This mirrors C-core behavior.

RELEASE NOTES: none