### PR TITLE
all: update to 'go 1.17' to enable module graph pruning

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module google.golang.org/grpc
 
-go 1.14
+go 1.17
 
 require (
 	github.com/cespare/xxhash/v2 v2.1.1
@@ -16,4 +16,13 @@ require (
 	golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4
 	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013
 	google.golang.org/protobuf v1.27.1
+)
+
+require (
+	cloud.google.com/go v0.34.0 // indirect
+	github.com/census-instrumentation/opencensus-proto v0.2.1 // indirect
+	github.com/envoyproxy/protoc-gen-validate v0.1.0 // indirect
+	golang.org/x/text v0.3.3 // indirect
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
+	google.golang.org/appengine v1.4.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -131,7 +131,6 @@ google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp0
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.27.1 h1:SnqbnDw1V7RiZcXPx5MEeqPv2s79L9i7BJUlG/+RurQ=
 google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.3/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
Updating the 'go' directive to 'go 1.17' will enable module graph
pruning (https://go.dev/ref/mod#graph-pruning), which will allow users
who depend on this module to prune out irrelevant transitive
dependencies (compare #3701).

Note that updating to 'go 1.17' will not break existing users on
versions older than 1.17. (The 'go' version is the version required
for full fidelity — in this case, graph pruning — but older versions
of the Go toolchain will continue to make a best-effort attempt to
compile packages and will not report an error if that attempt
succeeds, as it will in this case.)

RELEASE NOTES: none