### PR TITLE
encoding,protoc: support for message wrappers has been added

### DIFF
--- a/encoding/encoding.go
+++ b/encoding/encoding.go
@@ -128,3 +128,13 @@ func RegisterCodec(codec Codec) {
 func GetCodec(contentSubtype string) Codec {
 	return registeredCodecs[contentSubtype]
 }
+
+// MessageWrapper defines the interface for wrapped messages.
+type MessageWrapper interface {
+	// Interface returns the underlying message.
+	Interface() interface{}
+}
+
+// MessageWrapperHandler wraps a message before it will be encoded/decoded.
+// A new handler can be registered with the generated RegisterMessageWrapper function.
+type MessageWrapperHandler func(v interface{}) MessageWrapper


### PR DESCRIPTION
The given changes aim to facilitate extending the functionality of base messages:

A real-life example, the implementation of a message encoding:
```go
func (c *codec) Marshal(v interface{}) ([]byte, error) {
	var (
		ok bool
		df z.DataFrameInterface
	)
	if df, ok = v.(z.DataFrameInterface); !ok {
		return nil, ErrMustImplementInterface
	}
	return df.Compose()
}
```

```go
func (c *codec) Unmarshal(wire []byte, v interface{}) (err error) {
	var (
		ok bool
		df z.DataFrameInterface
	)
	if df, ok = v.(z.DataFrameInterface); !ok {
		return ErrMustImplementInterface
	}
	if err = df.Parse(wire); err != nil {
		return
	}
	return
}
```
Unmarshal method will receive a wrapped message that will parse encoded wire data, but actual decoding and unmarshaling will happen later, after a middleware handler will provide the required cipher parameters.

I believe there are other cases, where wrapping might be helpful. The PR affects the code generator and adds two new types to the _grpc/encoding_ package.