### PR TITLE
xdsclient: handle empty authority in new style resource names

### DIFF
--- a/xds/internal/xdsclient/xdsresource/name.go
+++ b/xds/internal/xdsclient/xdsresource/name.go
@@ -119,7 +119,7 @@ func (n *Name) String() string {
 
 	path := n.Type
 	if n.ID != "" {
-		path = path + "/" + n.ID
+		path = "/" + path + "/" + n.ID
 	}
 
 	tempURL := &url.URL{


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc-go/issues/5487

RELEASE NOTES:
- xds: request correct resource name from management server when user specifies a new style resource name with empty authority