### PR TITLE
xdsclient: use top-level server list if authority specific list is empty

### DIFF
--- a/xds/internal/xdsclient/authority.go
+++ b/xds/internal/xdsclient/authority.go
@@ -54,7 +54,9 @@ func (c *clientImpl) findAuthority(n *xdsresource.Name) (_ *authority, unref fun
 		if !ok {
 			return nil, nil, fmt.Errorf("xds: failed to find authority %q", authority)
 		}
-		config = cfg.XDSServer
+		if cfg.XDSServer != nil {
+			config = cfg.XDSServer
+		}
 	}
 
 	a, err := c.newAuthorityLocked(config)


### PR DESCRIPTION
Fixes: https://github.com/grpc/grpc-go/issues/5489

RELEASE NOTES:
- TBD