### PR TITLE
internal/xds: generate an entry in the authorities map with empty string key

### DIFF
--- a/internal/xds/bootstrap.go
+++ b/internal/xds/bootstrap.go
@@ -62,6 +62,11 @@ type BootstrapOptions struct {
 	// map[authority-name]ServerURI). The other fields (version, creds,
 	// features) are assumed to be the same as the default authority (they can
 	// be added later if needed).
+	//
+	// If the env var correponding to federation (envconfig.XDSFederation) is
+	// set, an entry with empty string as the key and empty server config as
+	// value will be added. This will be used by new style resource names with
+	// an empty authority.
 	Authorities map[string]string
 }
 
@@ -122,6 +127,11 @@ func BootstrapContents(opts BootstrapOptions) ([]byte, error) {
 	}
 
 	auths := make(map[string]authority)
+	if envconfig.XDSFederation {
+		// This will end up using the top-level server list for new style
+		// resources with empty authority.
+		auths[""] = authority{}
+	}
 	for n, auURI := range opts.Authorities {
 		auths[n] = authority{XdsServers: []server{{
 			ServerURI:      auURI,

--- a/internal/xds/bootstrap.go
+++ b/internal/xds/bootstrap.go
@@ -63,7 +63,7 @@ type BootstrapOptions struct {
 	// features) are assumed to be the same as the default authority (they can
 	// be added later if needed).
 	//
-	// If the env var correponding to federation (envconfig.XDSFederation) is
+	// If the env var corresponding to federation (envconfig.XDSFederation) is
 	// set, an entry with empty string as the key and empty server config as
 	// value will be added. This will be used by new style resource names with
 	// an empty authority.


### PR DESCRIPTION
This is required for tests which use federation and use a resource with an empty authority.

RELEASE NOTES: none