### PR TITLE
Fix race between activeStreams and bdp window size

### DIFF
--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -1213,9 +1213,7 @@ func (t *http2Client) handleGoAway(f *http2.GoAwayFrame) {
 	default:
 		t.setGoAwayReason(f)
 		close(t.goAway)
-		t.mu.Unlock()
-		t.controlBuf.put(&incomingGoAway{})
-		t.mu.Lock()
+		defer t.controlBuf.put(&incomingGoAway{})
 		// Notify the clientconn about the GOAWAY before we set the state to
 		// draining, to allow the client to stop attempting to create streams
 		// before disallowing new streams on this connection.

--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -1217,7 +1217,7 @@ func (t *http2Client) handleGoAway(f *http2.GoAwayFrame) {
 	default:
 		t.setGoAwayReason(f)
 		close(t.goAway)
-		defer t.controlBuf.put(&incomingGoAway{})
+		defer t.controlBuf.put(&incomingGoAway{}) // Defer as t.mu is currently held.
 		// Notify the clientconn about the GOAWAY before we set the state to
 		// draining, to allow the client to stop attempting to create streams
 		// before disallowing new streams on this connection.

--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -748,13 +748,7 @@ func (t *http2Client) NewStream(ctx context.Context, callHdr *CallHdr) (*Stream,
 	}
 	for {
 		success, err := t.controlBuf.executeAndPut(func(it interface{}) bool {
-			if !checkForHeaderListSize(it) {
-				return false
-			}
-			if !checkForStreamQuota(it) {
-				return false
-			}
-			return true
+			return checkForHeaderListSize(it) && checkForStreamQuota(it)
 		}, hdr)
 		if err != nil {
 			// Connection closed.

--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -722,6 +722,7 @@ func (t *http2Client) NewStream(ctx context.Context, callHdr *CallHdr) (*Stream,
 		s.fc = &inFlow{limit: uint32(t.initialWindowSize)}
 		t.mu.Lock()
 		if t.activeStreams == nil { // Can be niled from Close().
+			t.mu.Unlock()
 			return false // Don't create a stream if the transport is already closed.
 		}
 		t.activeStreams[s.id] = s

--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -1219,7 +1219,9 @@ func (t *http2Client) handleGoAway(f *http2.GoAwayFrame) {
 	default:
 		t.setGoAwayReason(f)
 		close(t.goAway)
+		t.mu.Unlock()
 		t.controlBuf.put(&incomingGoAway{})
+		t.mu.Lock()
 		// Notify the clientconn about the GOAWAY before we set the state to
 		// draining, to allow the client to stop attempting to create streams
 		// before disallowing new streams on this connection.

--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -721,11 +721,10 @@ func (t *http2Client) NewStream(ctx context.Context, callHdr *CallHdr) (*Stream,
 		s.id = h.streamID
 		s.fc = &inFlow{limit: uint32(t.initialWindowSize)}
 		t.mu.Lock()
-		if t.activeStreams != nil { // Can be niled from Close().
-			t.activeStreams[s.id] = s
-		} else {
+		if t.activeStreams == nil { // Can be niled from Close().
 			return false // Don't create a stream if the transport is already closed.
 		}
+		t.activeStreams[s.id] = s
 		t.mu.Unlock()
 		if t.streamQuota > 0 && t.waitingStreams > 0 {
 			select {

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -8066,20 +8066,18 @@ func (s) TestUnexpectedEOF(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		// exceeds grpc.DefaultMaxRecvMessageSize, this should error with
 		// RESOURCE_EXHAUSTED error.
-		_, err := ss.Client.UnaryCall(ctx, &testpb.SimpleRequest{ResponseSize: 4194304})
-		if err != nil {
+		if _, err := ss.Client.UnaryCall(ctx, &testpb.SimpleRequest{ResponseSize: 4194304}); err != nil {
 			// This check doesn't fail on a non status error. However, the main
 			// this is testing for is an unexpected EOF with a status code
 			// INTERNAL so this is fine.
 			if code := status.Code(err); code != codes.ResourceExhausted {
-				t.Fatalf("unexpected err in UnaryCall: %v", err)
+				t.Fatalf("UnaryCall RPC returned error: %v, want status code %v", err, codes.ResourceExhausted)
 			}
 		}
 		// Larger response that doesn't exceed DefaultMaxRecvMessageSize, this
 		// should work normally.
-		_, err = ss.Client.UnaryCall(ctx, &testpb.SimpleRequest{ResponseSize: 275075})
-		if err != nil {
-			t.Fatalf("unexpected err in UnaryCall: %v", err)
+		if _, err := ss.Client.UnaryCall(ctx, &testpb.SimpleRequest{ResponseSize: 275075}); err != nil {
+			t.Fatalf("UnaryCall RPC failed: %v", err)
 		}
 	}
 }

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -8068,10 +8068,11 @@ func (s) TestUnexpectedEOF(t *testing.T) {
 		// RESOURCE_EXHAUSTED error.
 		_, err := ss.Client.UnaryCall(ctx, &testpb.SimpleRequest{ResponseSize: 4194304})
 		if err != nil {
-			if e, ok := status.FromError(err); ok {
-				if e.Code() != codes.ResourceExhausted {
-					t.Fatalf("unexpected err in UnaryCall: %v", err)
-				}
+			// This check doesn't fail on a non status error. However, the main
+			// this is testing for is an unexpected EOF with a status code
+			// INTERNAL so this is fine.
+			if code := status.Code(err); code != codes.ResourceExhausted {
+				t.Fatalf("unexpected err in UnaryCall: %v", err)
 			}
 		}
 		// Larger response that doesn't exceed DefaultMaxRecvMessageSize, this

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -8066,13 +8066,9 @@ func (s) TestUnexpectedEOF(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		// exceeds grpc.DefaultMaxRecvMessageSize, this should error with
 		// RESOURCE_EXHAUSTED error.
-		if _, err := ss.Client.UnaryCall(ctx, &testpb.SimpleRequest{ResponseSize: 4194304}); err != nil {
-			// This check doesn't fail on a non status error. However, the main
-			// this is testing for is an unexpected EOF with a status code
-			// INTERNAL so this is fine.
-			if code := status.Code(err); code != codes.ResourceExhausted {
-				t.Fatalf("UnaryCall RPC returned error: %v, want status code %v", err, codes.ResourceExhausted)
-			}
+		_, err := ss.Client.UnaryCall(ctx, &testpb.SimpleRequest{ResponseSize: 4194304})
+		if code := status.Code(err); code != codes.ResourceExhausted {
+			t.Fatalf("UnaryCall RPC returned error: %v, want status code %v", err, codes.ResourceExhausted)
 		}
 		// Larger response that doesn't exceed DefaultMaxRecvMessageSize, this
 		// should work normally.


### PR DESCRIPTION
Fixes #5358.

The test case I added based off the issue test would successfully fail unexpected.EOF. This was caused by a race between when a stream was created and when updateFlowControl() was called. This fix makes sure any created streams has the correct window size on creation.

RELEASE NOTES:
* Fixed dynamic BDP estimation causing unexpected EOF error by fixing race between activeStreams and bdp window size