### PR TITLE
doc: remove comment about obsolete GRPC_GO_RETRY env var

### DIFF
--- a/dialoptions.go
+++ b/dialoptions.go
@@ -527,10 +527,7 @@ func WithDefaultServiceConfig(s string) DialOption {
 // WithDisableRetry returns a DialOption that disables retries, even if the
 // service config enables them.  This does not impact transparent retries, which
 // will happen automatically if no data is written to the wire or if the RPC is
-// unprocessed by the remote server.
-//
-// Retry support is currently enabled by default, but may be disabled by
-// setting the environment variable "GRPC_GO_RETRY" to "off".
+// unprocessed by the remote server. Retry support is enabled by default.
 func WithDisableRetry() DialOption {
 	return newFuncDialOption(func(o *dialOptions) {
 		o.disableRetry = true

--- a/dialoptions.go
+++ b/dialoptions.go
@@ -527,7 +527,7 @@ func WithDefaultServiceConfig(s string) DialOption {
 // WithDisableRetry returns a DialOption that disables retries, even if the
 // service config enables them.  This does not impact transparent retries, which
 // will happen automatically if no data is written to the wire or if the RPC is
-// unprocessed by the remote server. Retry support is enabled by default.
+// unprocessed by the remote server.
 func WithDisableRetry() DialOption {
 	return newFuncDialOption(func(o *dialOptions) {
 		o.disableRetry = true

--- a/examples/features/retry/README.md
+++ b/examples/features/retry/README.md
@@ -18,12 +18,7 @@ First start the server:
 go run server/main.go
 ```
 
-Then run the client.  Note that when running the client, `GRPC_GO_RETRY=on` must be set in
-your environment:
-
-```bash
-GRPC_GO_RETRY=on go run client/main.go
-```
+Then run the client.
 
 ## Usage
 

--- a/examples/features/retry/README.md
+++ b/examples/features/retry/README.md
@@ -18,7 +18,11 @@ First start the server:
 go run server/main.go
 ```
 
-Then run the client.
+Then run the client:
+
+```bash
+go run client/main.go
+```
 
 ## Usage
 


### PR DESCRIPTION
The `WithDisableRetry()` dial option references the `GRPC_GO_RETRY` env var, but that was deleted in https://github.com/grpc/grpc-go/pull/4922.

RELEASE NOTES: none