### PR TITLE
interop client: fixes for interop soak test

### DIFF
--- a/interop/test_utils.go
+++ b/interop/test_utils.go
@@ -741,7 +741,11 @@ func DoSoakTest(tc testgrpc.TestServiceClient, serverAddr string, dopts []grpc.D
 		h.Add(latencyMs)
 		if err != nil {
 			totalFailures++
-			fmt.Fprintf(os.Stderr, "soak iteration: %d elapsed_ms: %d peer: %s failed: %s\n", i, latencyMs, p.Addr.String(), err)
+			addrStr := "nil"
+			if p.Addr != nil {
+				addrStr = p.Addr.String()
+			}
+			fmt.Fprintf(os.Stderr, "soak iteration: %d elapsed_ms: %d peer: %s failed: %s\n", i, latencyMs, addrStr, err)
 			continue
 		}
 		if latency > perIterationMaxAcceptableLatency {

--- a/interop/test_utils.go
+++ b/interop/test_utils.go
@@ -746,11 +746,13 @@ func DoSoakTest(tc testgrpc.TestServiceClient, serverAddr string, dopts []grpc.D
 				addrStr = p.Addr.String()
 			}
 			fmt.Fprintf(os.Stderr, "soak iteration: %d elapsed_ms: %d peer: %s failed: %s\n", i, latencyMs, addrStr, err)
+			<-earliestNextStart
 			continue
 		}
 		if latency > perIterationMaxAcceptableLatency {
 			totalFailures++
 			fmt.Fprintf(os.Stderr, "soak iteration: %d elapsed_ms: %d peer: %s exceeds max acceptable latency: %d\n", i, latencyMs, p.Addr.String(), perIterationMaxAcceptableLatency.Milliseconds())
+			<-earliestNextStart
 			continue
 		}
 		fmt.Fprintf(os.Stderr, "soak iteration: %d elapsed_ms: %d peer: %s succeeded\n", i, latencyMs, p.Addr.String())


### PR DESCRIPTION
* Don't crash if we didn't fill in peer address
* Honor the min time ms between RPCs flag upon failures

RELEASE NOTES: none