### PR TITLE
client: fix stream creation issue with transparent retry

### DIFF
--- a/stream.go
+++ b/stream.go
@@ -140,13 +140,13 @@ type ClientStream interface {
 // To ensure resources are not leaked due to the stream returned, one of the following
 // actions must be performed:
 //
-//      1. Call Close on the ClientConn.
-//      2. Cancel the context provided.
-//      3. Call RecvMsg until a non-nil error is returned. A protobuf-generated
-//         client-streaming RPC, for instance, might use the helper function
-//         CloseAndRecv (note that CloseSend does not Recv, therefore is not
-//         guaranteed to release all resources).
-//      4. Receive a non-nil, non-io.EOF error from Header or SendMsg.
+//  1. Call Close on the ClientConn.
+//  2. Cancel the context provided.
+//  3. Call RecvMsg until a non-nil error is returned. A protobuf-generated
+//     client-streaming RPC, for instance, might use the helper function
+//     CloseAndRecv (note that CloseSend does not Recv, therefore is not
+//     guaranteed to release all resources).
+//  4. Receive a non-nil, non-io.EOF error from Header or SendMsg.
 //
 // If none of the above happen, a goroutine and a context will be leaked, and grpc
 // will not call the optionally-configured stats handler with a stats.End message.
@@ -302,12 +302,6 @@ func newClientStreamWithParams(ctx context.Context, desc *StreamDesc, cc *Client
 		cs.retryThrottler = cc.retryThrottler.Load().(*retryThrottler)
 	}
 	cs.binlog = binarylog.GetMethodLogger(method)
-
-	cs.attempt, err = cs.newAttemptLocked(false /* isTransparent */)
-	if err != nil {
-		cs.finish(err)
-		return nil, err
-	}
 
 	// Pick the transport to use and create a new stream on the transport.
 	// Assign cs.attempt upon success.
@@ -703,6 +697,18 @@ func (cs *clientStream) withRetry(op func(a *csAttempt) error, onSuccess func())
 			// error to allow for further inspection; all other errors should
 			// already be status errors.
 			return toRPCErr(op(cs.attempt))
+		}
+		if len(cs.buffer) == 0 {
+			// For the first op, which controls creation of the stream and
+			// assigns cs.attempt, we need to create a new attempt inline
+			// before executing the first op.  On subsequent ops, the attempt
+			// is created immediately before replaying the ops.
+			var err error
+			if cs.attempt, err = cs.newAttemptLocked(false /* isTransparent */); err != nil {
+				cs.mu.Unlock()
+				cs.finish(err)
+				return err
+			}
 		}
 		a := cs.attempt
 		cs.mu.Unlock()


### PR DESCRIPTION
Note: I am fairly sure the comment formatting change is caused by using a preview version of Go 1.19, meaning we all will see that behavior forced by `gofmt` soon.

Fixes #5341

Description:

We need to create a brand new attempt _every time_ we retry the initial op that gets the transport and creates the stream.  Once that op is committed and added to the replay log, it is handled by the retry+replay logic, but until then, it currently does retries using the original attempt.  This was mostly OK, but leads to a potential infinite loop:

1. `getTransport()` - succeeds
2. `newStream()` - fails with a transparently retryable error, as the transport died at the exact right moment
3. Retry
4. `getTransport` - fails
5. `shouldRetry` should not allow transparent retry in this case, but it does because the original attempt had the field set.

If no transport is ever attainable after this, it will loop until the RPC's context expires.

RELEASE NOTES:
* client: fix an issue that, in the event of an unlikely race, could lead to RPCs timing out instead of failing more quickly with UNAVAILABLE