### PR TITLE
test/kokoro: Add missing secondary_kube_context to xds LB tests (1.48.x backport)

### DIFF
--- a/test/kokoro/xds_k8s_lb.sh
+++ b/test/kokoro/xds_k8s_lb.sh
@@ -83,6 +83,7 @@ build_docker_images_if_needed() {
 # Globals:
 #   TEST_DRIVER_FLAGFILE: Relative path to test driver flagfile
 #   KUBE_CONTEXT: The name of kubectl context with GKE cluster access
+#   SECONDARY_KUBE_CONTEXT: The name of kubectl context with secondary GKE cluster access, if any
 #   TEST_XML_OUTPUT_DIR: Output directory for the test xUnit XML report
 #   SERVER_IMAGE_NAME: Test server Docker image name
 #   CLIENT_IMAGE_NAME: Test client Docker image name
@@ -103,6 +104,7 @@ run_test() {
   python -m "tests.${test_name}" \
     --flagfile="${TEST_DRIVER_FLAGFILE}" \
     --kube_context="${KUBE_CONTEXT}" \
+    --secondary_kube_context="${SECONDARY_KUBE_CONTEXT}" \
     --server_image="${SERVER_IMAGE_NAME}:${GIT_COMMIT}" \
     --client_image="${CLIENT_IMAGE_NAME}:${GIT_COMMIT}" \
     --testing_version="${TESTING_VERSION}" \


### PR DESCRIPTION
Backport of #5508

Secondary cluster was not activated for LB tests.
This resulted in the failover test failing, as it relies on
workloads running in different zones.

ref b/238226704

RELEASE NOTES: n/a