### PR TITLE
gcp/observability: Add support for Environment Variable GRPC_CONFIG_OBSERVABILITY_JSON

### DIFF
--- a/gcp/observability/config.go
+++ b/gcp/observability/config.go
@@ -76,7 +76,7 @@ func validateFilters(config *configpb.ObservabilityConfig) error {
 }
 
 // unmarshalAndVerifyConfig unmarshals a json string representing an
-// observability config into it's protobuf format, and also verifies the
+// observability config into its protobuf format, and also verifies the
 // configuration's fields for validity.
 func unmarshalAndVerifyConfig(rawJSON json.RawMessage) (*configpb.ObservabilityConfig, error) {
 	var config configpb.ObservabilityConfig

--- a/gcp/observability/config.go
+++ b/gcp/observability/config.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"regexp"
 
@@ -94,7 +95,7 @@ func unmarshalAndVerifyConfig(rawJSON json.RawMessage) (*configpb.ObservabilityC
 
 func parseObservabilityConfig() (*configpb.ObservabilityConfig, error) {
 	if fileSystemPath := os.Getenv(envObservabilityConfigJSON); fileSystemPath != "" {
-		content, err := os.ReadFile(fileSystemPath)
+		content, err := ioutil.ReadFile(fileSystemPath) // TODO: Switch to os.ReadFile once dropped support for go 1.15
 		if err != nil {
 			return nil, fmt.Errorf("error reading observability configuration file %q: %v", fileSystemPath, err)
 		}

--- a/gcp/observability/config.go
+++ b/gcp/observability/config.go
@@ -74,9 +74,10 @@ func validateFilters(config *configpb.ObservabilityConfig) error {
 	return nil
 }
 
-// unmarshalConfig unmarshals a json string representing an observability config
-// into it's protobuf format.
-func unmarshalConfig(rawJSON json.RawMessage) (*configpb.ObservabilityConfig, error) {
+// unmarshalAndVerifyConfig unmarshals a json string representing an
+// observability config into it's protobuf format, and also verifies the
+// configuration's fields for validity.
+func unmarshalAndVerifyConfig(rawJSON json.RawMessage) (*configpb.ObservabilityConfig, error) {
 	var config configpb.ObservabilityConfig
 	if err := protojson.Unmarshal(rawJSON, &config); err != nil {
 		return nil, fmt.Errorf("error parsing observability config: %v", err)
@@ -95,11 +96,11 @@ func parseObservabilityConfig() (*configpb.ObservabilityConfig, error) {
 	if fileSystemPath := os.Getenv(envObservabilityConfigJSON); fileSystemPath != "" {
 		content, err := os.ReadFile(fileSystemPath)
 		if err != nil {
-			return nil, fmt.Errorf("error reading file from env var %v: %v", envObservabilityConfigJSON, err)
+			return nil, fmt.Errorf("error reading observability configuration file %q: %v", fileSystemPath, err)
 		}
-		return unmarshalConfig(content)
+		return unmarshalAndVerifyConfig(content)
 	} else if content := os.Getenv(envObservabilityConfig); content != "" {
-		return unmarshalConfig([]byte(content))
+		return unmarshalAndVerifyConfig([]byte(content))
 	}
 	// If the ENV var doesn't exist, do nothing
 	return nil, nil

--- a/gcp/observability/observability_test.go
+++ b/gcp/observability/observability_test.go
@@ -21,7 +21,9 @@ package observability
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net"
 	"os"
 	"sync"
@@ -683,39 +685,39 @@ func (s) TestRefuseStartWithInvalidPatterns(t *testing.T) {
 	}
 }
 
+// createTmpConfigInFileSystem creates a random observability config at a random
+// place in the temporary portion of the file system dependent on system. It
+// also sets the environment variable GRPC_CONFIG_OBSERVABILITY_JSON to point to
+// this created config.
+func createTmpConfigInFileSystem(rawJSON json.RawMessage) (*os.File, error) {
+	configJSONFile, err := ioutil.TempFile(os.TempDir(), "configJSON-")
+	if err != nil {
+		return nil, fmt.Errorf("cannot create file %v: %v", configJSONFile.Name(), err)
+	}
+	defer configJSONFile.Close()
+	_, err = configJSONFile.Write(rawJSON)
+	if err != nil {
+		return nil, fmt.Errorf("cannot write marshalled JSON: %v", err)
+	}
+	os.Setenv(envObservabilityConfigJSON, configJSONFile.Name())
+	return configJSONFile, nil /// do you even need to return this file if you're already closing it here?
+}
+
 // TestJSONEnvVarSet tests a valid observability configuration specified by the
 // GRPC_CONFIG_OBSERVABILITY_JSON environment variable, whose value represents a
 // file path pointing to a JSON encoded config.
 func (s) TestJSONEnvVarSet(t *testing.T) {
-	config := &configpb.ObservabilityConfig{
-		EnableCloudLogging:   true,
-		DestinationProjectId: "fake",
-		LogFilters: []*configpb.ObservabilityConfig_LogFilter{
-			{
-				Pattern:      "*",
-				HeaderBytes:  infinitySizeBytes,
-				MessageBytes: infinitySizeBytes,
-			},
-		},
-	}
-
-	configJSON, err := protojson.Marshal(config)
+	configJSON := json.RawMessage(`{
+		"destinationProjectId": "fake",
+		"logFilters":[{"pattern":"*","headerBytes":1073741824,"messageBytes":1073741824}]
+	}`)
+	_, err := createTmpConfigInFileSystem(configJSON)
 	if err != nil {
-		t.Fatalf("failed to convert config to JSON: %v", err)
+		t.Fatalf("failed to create config in file system: %v", err)
 	}
-
-	configJSONFile, err := os.Create("/tmp/configJSON")
-	if err != nil {
-		t.Fatalf("cannot create file /tmp/configJSON: %v", err)
-	}
-	defer configJSONFile.Close()
-	_, err = configJSONFile.Write(configJSON)
-	if err != nil {
-		t.Fatalf("cannot write marshalled JSON: %v", err)
-	}
-	os.Setenv(envObservabilityConfigJSON, "/tmp/configJSON")
-
-	if err := Start(context.Background()); err != nil {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	if err := Start(ctx); err != nil {
 		t.Fatalf("error starting observability with valid config through file system: %v", err)
 	}
 	defer End()
@@ -723,38 +725,18 @@ func (s) TestJSONEnvVarSet(t *testing.T) {
 
 // TestBothConfigEnvVarsSet tests the scenario where both configuration
 // environment variables are set. The file system environment variable should
-// take precedence, and and error should return in the case of the file system
+// take precedence, and an error should return in the case of the file system
 // configuration being invalid, even if the direct configuration environment
 // variable is set and valid.
 func (s) TestBothConfigEnvVarsSet(t *testing.T) {
-	invalidConfig := &configpb.ObservabilityConfig{
-		EnableCloudLogging:   true,
-		DestinationProjectId: "fake",
-		LogFilters: []*configpb.ObservabilityConfig_LogFilter{
-			{
-				Pattern: ":-)",
-			},
-			{
-				Pattern: "*",
-			},
-		},
-	}
-	invalidConfigJSON, err := protojson.Marshal(invalidConfig)
+	configJSON := json.RawMessage(`{
+		"destinationProjectId":"fake",
+		"logFilters":[{"pattern":":-)"}, {"pattern":"*"}]
+	}`)
+	_, err := createTmpConfigInFileSystem(configJSON)
 	if err != nil {
-		t.Fatalf("failed to convert config to JSON: %v", err)
+		t.Fatalf("failed to create config in file system: %v", err)
 	}
-
-	invalidConfigJSONFile, err := os.Create("/tmp/InvalidConfigJSON")
-	if err != nil {
-		t.Fatalf("cannot create file /tmp/InvalidConfigJSON: %v", err)
-	}
-	defer invalidConfigJSONFile.Close()
-	_, err = invalidConfigJSONFile.Write(invalidConfigJSON)
-	if err != nil {
-		t.Fatalf("cannot write marshalled JSON: %v", err)
-	}
-	os.Setenv(envObservabilityConfigJSON, "/tmp/InvalidConfigJSON")
-
 	// This configuration should be ignored, as precedence 2.
 	validConfig := &configpb.ObservabilityConfig{
 		EnableCloudLogging:   true,


### PR DESCRIPTION
This PR adds support for the Environment Variable GRPC_CONFIG_OBSERVABILITY_JSON, which configures observability through a file at a path specified by the value of this Environment Variable (see private preview 2 document: [go/grpc-observability-ug-2](http://go/grpc-observability-ug-2)). The precedence ordering of this environment variable taking precedence over GRPC_CONFIG_OBSERVABILITY is based on the grpc-java implementation to keep it consistent across languages, and not officially defined in the design document.

RELEASE NOTES:
* gcp/observability: Add support for Environment Variable GRPC_CONFIG_OBSERVABILITY_JSON