### PR TITLE
xds/clustermanager: pause picker updates during UpdateClientConnState

### DIFF
--- a/xds/internal/balancer/clustermanager/balancerstateaggregator.go
+++ b/xds/internal/balancer/clustermanager/balancerstateaggregator.go
@@ -57,6 +57,11 @@ type balancerStateAggregator struct {
 	//
 	// If an ID is not in map, it's either removed or never added.
 	idToPickerState map[string]*subBalancerState
+	// Set when UpdateState call propagation is paused.
+	pauseUpdateState bool
+	// Set when UpdateState call propagation is paused and an UpdateState call
+	// is suppressed.
+	needUpdateStateOnResume bool
 }
 
 func newBalancerStateAggregator(cc balancer.ClientConn, logger *grpclog.PrefixLogger) *balancerStateAggregator {
@@ -118,6 +123,27 @@ func (bsa *balancerStateAggregator) remove(id string) {
 	delete(bsa.idToPickerState, id)
 }
 
+// pauseStateUpdates causes UpdateState calls to not propagate to the parent
+// ClientConn.  The last state will be remembered and propagated when
+// ResumeStateUpdates is called.
+func (bsa *balancerStateAggregator) pauseStateUpdates() {
+	bsa.mu.Lock()
+	defer bsa.mu.Unlock()
+	bsa.pauseUpdateState = true
+	bsa.needUpdateStateOnResume = false
+}
+
+// resumeStateUpdates will resume propagating UpdateState calls to the parent,
+// and call UpdateState on the parent if any UpdateState call was suppressed.
+func (bsa *balancerStateAggregator) resumeStateUpdates() {
+	bsa.mu.Lock()
+	defer bsa.mu.Unlock()
+	bsa.pauseUpdateState = false
+	if bsa.needUpdateStateOnResume {
+		bsa.cc.UpdateState(bsa.build())
+	}
+}
+
 // UpdateState is called to report a balancer state change from sub-balancer.
 // It's usually called by the balancer group.
 //
@@ -143,6 +169,12 @@ func (bsa *balancerStateAggregator) UpdateState(id string, state balancer.State)
 	if !bsa.started {
 		return
 	}
+	if bsa.pauseUpdateState {
+		// If updates are paused, do not call UpdateState, but remember that we
+		// need to call it when they are resumed.
+		bsa.needUpdateStateOnResume = true
+		return
+	}
 	bsa.cc.UpdateState(bsa.build())
 }
 
@@ -166,6 +198,12 @@ func (bsa *balancerStateAggregator) buildAndUpdate() {
 	bsa.mu.Lock()
 	defer bsa.mu.Unlock()
 	if !bsa.started {
+		return
+	}
+	if bsa.pauseUpdateState {
+		// If updates are paused, do not call UpdateState, but remember that we
+		// need to call it when they are resumed.
+		bsa.needUpdateStateOnResume = true
 		return
 	}
 	bsa.cc.UpdateState(bsa.build())

--- a/xds/internal/balancer/clustermanager/clustermanager.go
+++ b/xds/internal/balancer/clustermanager/clustermanager.go
@@ -123,6 +123,8 @@ func (b *bal) UpdateClientConnState(s balancer.ClientConnState) error {
 	}
 	b.logger.Infof("update with config %+v, resolver state %+v", pretty.ToJSON(s.BalancerConfig), s.ResolverState)
 
+	b.stateAggregator.pauseStateUpdates()
+	defer b.stateAggregator.resumeStateUpdates()
 	b.updateChildren(s, newConfig)
 	return nil
 }


### PR DESCRIPTION
#5211

Even though the picker is updated synchronously in `UpdateClientConnState`, multiple updates could result in `UpdateState` calls to the parent if this is not done to suppress them.

RELEASE NOTES: n/a