### PR TITLE
test/interop: increase pick_first timeout

### DIFF
--- a/interop/test_utils.go
+++ b/interop/test_utils.go
@@ -655,7 +655,8 @@ func DoPickFirstUnary(tc testgrpc.TestServiceClient) {
 		Payload:      pl,
 		FillServerId: true,
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	// TODO(mohanli): Revert the timeout back to 10s once TD migrates to xdstp.
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	defer cancel()
 	var serverID string
 	for i := 0; i < rpcCount; i++ {

--- a/interop/test_utils.go
+++ b/interop/test_utils.go
@@ -656,7 +656,7 @@ func DoPickFirstUnary(tc testgrpc.TestServiceClient) {
 		FillServerId: true,
 	}
 	// TODO(mohanli): Revert the timeout back to 10s once TD migrates to xdstp.
-	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	var serverID string
 	for i := 0; i < rpcCount; i++ {


### PR DESCRIPTION
Currently TD is migrating from legacy to xdstp, and RLS server will return both xdstp and legacy cluster. Since the resource watcher timeout is 15s, we need to increase the timeout to make the test pass during the xdstp migration.

RELEASE NOTES: none