### PR TITLE
xds: Fixed GoLang regression for Outlier Detection

### DIFF
--- a/internal/envconfig/xds.go
+++ b/internal/envconfig/xds.go
@@ -41,7 +41,6 @@ const (
 	clientSideSecuritySupportEnv = "GRPC_XDS_EXPERIMENTAL_SECURITY_SUPPORT"
 	aggregateAndDNSSupportEnv    = "GRPC_XDS_EXPERIMENTAL_ENABLE_AGGREGATE_AND_LOGICAL_DNS_CLUSTER"
 	rbacSupportEnv               = "GRPC_XDS_EXPERIMENTAL_RBAC"
-	outlierDetectionSupportEnv   = "GRPC_EXPERIMENTAL_ENABLE_OUTLIER_DETECTION"
 	federationEnv                = "GRPC_EXPERIMENTAL_XDS_FEDERATION"
 	rlsInXDSEnv                  = "GRPC_EXPERIMENTAL_XDS_RLS_LB"
 
@@ -86,7 +85,7 @@ var (
 	// XDSOutlierDetection indicates whether outlier detection support is
 	// enabled, which can be enabled by setting the environment variable
 	// "GRPC_EXPERIMENTAL_ENABLE_OUTLIER_DETECTION" to "true".
-	XDSOutlierDetection = strings.EqualFold(os.Getenv(outlierDetectionSupportEnv), "true")
+	XDSOutlierDetection = false
 	// XDSFederation indicates whether federation support is enabled.
 	XDSFederation = strings.EqualFold(os.Getenv(federationEnv), "true")
 


### PR DESCRIPTION
This PR fixes a bug in Outlier Detection, when Outlier Detection was set to true the configuration would be prepared which would try and Build a placeholder balancer which would fail RPC's. This hardcodes the Environment Variable configuration to false, which will be changed when my full Outlier Detection PR gets merged. This will need to get backported to 1.48, as the bug is present in that branch too.

RELEASE NOTES:
* Fix bug when environment variable GRPC_EXPERIMENTAL_ENABLE_OUTLIER_DETECTION set to true