### PR TITLE
rls: suppress picker updates from children when handling config updates

### DIFF
--- a/balancer/rls/balancer.go
+++ b/balancer/rls/balancer.go
@@ -191,6 +191,8 @@ func (b *rlsBalancer) run() {
 				b.sendNewPickerLocked()
 				close(update.done)
 				b.stateMu.Unlock()
+			default:
+				b.logger.Errorf("Unsupported update type %T", update)
 			}
 		case <-b.done.Done():
 			return

--- a/balancer/rls/balancer_test.go
+++ b/balancer/rls/balancer_test.go
@@ -958,7 +958,7 @@ func (wb *wrappedPickFirstBalancer) UpdateState(state balancer.State) {
 // update is being processed by RLS LB policy and its child policies.
 //
 // The test uses a wrapping balancer as the top-level LB policy on the channel.
-// The wrapping balancing wraps an RLS LB policy as a child policy and forwards
+// The wrapping balancer wraps an RLS LB policy as a child policy and forwards
 // all calls to it. It also records the UpdateState() calls from the RLS LB
 // policy and makes it available for inspection by the test.
 //


### PR DESCRIPTION
Summary of changes:
- Use a single channel to process the different events handled by the `run()` goroutine.
- Handling config updates from parent: `UpdateClientConnState()`
  - Handles config updates inline instead of pushing them on to a channel.
  - Sets a flag to inhibit picker updates.
  - After handling the config changes and pushing the required configs to child policies, queues an event to resume picker updates.
  - Waits for the above event to be acted upon, and then returns a new picker.
- Handling state updates from child: `UpdateState()`
  - Handled asynchronously as before. The only change is that message is pushed on the single channel used by `run()` goroutine.
- Pushing picker updates to the parent: `SendNewPickerLocked()`
  - If picker updates are inhibited (by the flag set in `UpdateClientConnState`), a new picker is built but is not pushed up.

What these change means is that when the RLS LB policy is handling a config update from its parent, no picker updates will be pushed up. This includes picker updates caused by events such as RLS response, cache timer expiry, backoff timer expiry etc.

Fixes https://github.com/grpc/grpc-go/issues/5211

RELEASE NOTES: n/a