### PR TITLE
client: set grpc-accept-encoding to full list of registered compressors

### DIFF
--- a/encoding/encoding.go
+++ b/encoding/encoding.go
@@ -28,6 +28,8 @@ package encoding
 import (
 	"io"
 	"strings"
+
+	"google.golang.org/grpc/internal/grpcutil"
 )
 
 // Identity specifies the optional encoding for uncompressed streams.
@@ -73,6 +75,7 @@ var registeredCompressor = make(map[string]Compressor)
 // registered with the same name, the one registered last will take effect.
 func RegisterCompressor(c Compressor) {
 	registeredCompressor[c.Name()] = c
+	grpcutil.RegisteredCompressorNames = append(grpcutil.RegisteredCompressorNames, c.Name())
 }
 
 // GetCompressor returns Compressor for the given compressor name.

--- a/internal/envconfig/envconfig.go
+++ b/internal/envconfig/envconfig.go
@@ -25,11 +25,15 @@ import (
 )
 
 const (
-	prefix          = "GRPC_GO_"
-	txtErrIgnoreStr = prefix + "IGNORE_TXT_ERRORS"
+	prefix                  = "GRPC_GO_"
+	txtErrIgnoreStr         = prefix + "IGNORE_TXT_ERRORS"
+	advertiseCompressorsStr = prefix + "ADVERTISE_COMPRESSORS"
 )
 
 var (
 	// TXTErrIgnore is set if TXT errors should be ignored ("GRPC_GO_IGNORE_TXT_ERRORS" is not "false").
 	TXTErrIgnore = !strings.EqualFold(os.Getenv(txtErrIgnoreStr), "false")
+	// AdvertiseCompressors is set if registered compressor should be advertised
+	// ("GRPC_GO_ADVERTISE_COMPRESSORS" is not "false").
+	AdvertiseCompressors = !strings.EqualFold(os.Getenv(advertiseCompressorsStr), "false")
 )

--- a/internal/grpcutil/compressor.go
+++ b/internal/grpcutil/compressor.go
@@ -1,0 +1,47 @@
+/*
+ *
+ * Copyright 2022 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package grpcutil
+
+import (
+	"strings"
+
+	"google.golang.org/grpc/internal/envconfig"
+)
+
+// RegisteredCompressorNames holds names of the registered compressors.
+var RegisteredCompressorNames []string
+
+// IsCompressorNameRegistered returns true when name is available in registry.
+func IsCompressorNameRegistered(name string) bool {
+	for _, compressor := range RegisteredCompressorNames {
+		if compressor == name {
+			return true
+		}
+	}
+	return false
+}
+
+// RegisteredCompressors returns a string of registered compressor names
+// separated by comma.
+func RegisteredCompressors() string {
+	if !envconfig.AdvertiseCompressors {
+		return ""
+	}
+	return strings.Join(RegisteredCompressorNames, ",")
+}

--- a/internal/grpcutil/compressor_test.go
+++ b/internal/grpcutil/compressor_test.go
@@ -1,0 +1,46 @@
+/*
+ *
+ * Copyright 2022 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package grpcutil
+
+import (
+	"testing"
+
+	"google.golang.org/grpc/internal/envconfig"
+)
+
+func TestRegisteredCompressors(t *testing.T) {
+	defer func(c []string) { RegisteredCompressorNames = c }(RegisteredCompressorNames)
+	defer func(v bool) { envconfig.AdvertiseCompressors = v }(envconfig.AdvertiseCompressors)
+	RegisteredCompressorNames = []string{"gzip", "snappy"}
+	tests := []struct {
+		desc    string
+		enabled bool
+		want    string
+	}{
+		{desc: "compressor_ad_disabled", enabled: false, want: ""},
+		{desc: "compressor_ad_enabled", enabled: true, want: "gzip,snappy"},
+	}
+	for _, tt := range tests {
+		envconfig.AdvertiseCompressors = tt.enabled
+		compressors := RegisteredCompressors()
+		if compressors != tt.want {
+			t.Fatalf("Unexpected compressors got:%s, want:%s", compressors, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
Part of #2786 (rest fixes in follow-up PRs)

Description:
In the current implementation, we forward `grpc-accept-encoding` only when the client sets compression on the outgoing RPCs. With this pull request, all the compressors registered with `encoding.RegisterCompressor` are added under the `grpc-accept-encoding` header for the outgoing RPCs. 

When the client enables compression using deprecated [`grpc.WithCompressor`](https://pkg.go.dev/google.golang.org/grpc#WithCompressor), stick to the old behaviour of setting the `grpc-accept-header` header to the outgoing compressor.

RELEASE NOTES: 
- client: set grpc-accept-encoding header with all registered compressors