### PR TITLE
priority: sync priority with child in use

### DIFF
--- a/xds/internal/balancer/priority/balancer.go
+++ b/xds/internal/balancer/priority/balancer.go
@@ -260,7 +260,7 @@ func (b *priorityBalancer) run() {
 				b.handleChildStateUpdate(s.name, s.s)
 			case resumePickerUpdates:
 				b.inhibitPickerUpdates = false
-				b.syncPriority("")
+				b.syncPriority(b.childInUse)
 				close(s.done)
 			}
 			b.mu.Unlock()

--- a/xds/internal/balancer/priority/balancer_priority.go
+++ b/xds/internal/balancer/priority/balancer_priority.go
@@ -69,6 +69,7 @@ var (
 // Caller must hold b.mu.
 func (b *priorityBalancer) syncPriority(childUpdating string) {
 	if b.inhibitPickerUpdates {
+		b.logger.Infof("Skipping update from child with name %q", childUpdating)
 		return
 	}
 	for p, name := range b.priorities {
@@ -84,7 +85,7 @@ func (b *priorityBalancer) syncPriority(childUpdating string) {
 			(child.state.ConnectivityState == connectivity.Connecting && child.initTimer != nil) ||
 			p == len(b.priorities)-1 {
 			if b.childInUse != child.name || child.name == childUpdating {
-				logger.Warningf("ciu, cn, cu: %v, %v, %v", b.childInUse, child.name, childUpdating)
+				b.logger.Warningf("childInUse, childUpdating: %q, %q", b.childInUse, child.name)
 				// If we switch children or the child in use just updated its
 				// picker, push the child's picker to the parent.
 				b.cc.UpdateState(child.state)

--- a/xds/internal/balancer/priority/balancer_test.go
+++ b/xds/internal/balancer/priority/balancer_test.go
@@ -176,8 +176,6 @@ func (s) TestPriority_HighPriorityReady(t *testing.T) {
 	}
 
 	select {
-	case <-cc.NewPickerCh:
-		t.Fatalf("got unexpected new picker")
 	case <-cc.NewSubConnCh:
 		t.Fatalf("got unexpected new SubConn")
 	case <-cc.RemoveSubConnCh:
@@ -277,8 +275,6 @@ func (s) TestPriority_SwitchPriority(t *testing.T) {
 	}
 
 	select {
-	case <-cc.NewPickerCh:
-		t.Fatalf("got unexpected new picker")
 	case sc := <-cc.NewSubConnCh:
 		t.Fatalf("got unexpected new SubConn, %s", sc)
 	case <-cc.RemoveSubConnCh:
@@ -1194,8 +1190,6 @@ func (s) TestPriority_MoveReadyChildToHigherPriority(t *testing.T) {
 	// Because this was a ready child moved to a higher priority, no new subconn
 	// or picker should be updated.
 	select {
-	case <-cc.NewPickerCh:
-		t.Fatalf("got unexpected new picker")
 	case <-cc.NewSubConnCh:
 		t.Fatalf("got unexpected new SubConn")
 	case <-cc.RemoveSubConnCh:


### PR DESCRIPTION
Recently, we added functionality to push config updates to all child policies (not just the active one) and process all child picker updates before determining active priority. See: https://github.com/grpc/grpc-go/pull/5417

As part of this change though, we were calling `syncPriority` with an empty child name at the end of the config processing pipeline. This sometimes could lead to the priority LB policy dropping picker updates which could lead to all RPCs getting blocked.

RELEASE NOTES:
- priority: fix bug which could cause priority LB from blocking all traffic after a config update