### PR TITLE
test: move clientconn state transition test to test/ directory

### DIFF
--- a/clientconn_test.go
+++ b/clientconn_test.go
@@ -48,7 +48,7 @@ import (
 
 const (
 	defaultTestTimeout         = 10 * time.Second
-	stateRecordingBalancerName = "state_recoding_balancer"
+	stateRecordingBalancerName = "state_recording_balancer"
 )
 
 var testBalancerBuilder = newStateRecordingBalancerBuilder()

--- a/test/clientconn_state_transition_test.go
+++ b/test/clientconn_state_transition_test.go
@@ -37,7 +37,7 @@ import (
 	"google.golang.org/grpc/resolver/manual"
 )
 
-const stateRecordingBalancerName = "state_recoding_balancer"
+const stateRecordingBalancerName = "state_recording_balancer"
 
 var testBalancerBuilder = newStateRecordingBalancerBuilder()
 
@@ -504,7 +504,7 @@ func keepReading(conn net.Conn) {
 }
 
 // stayConnected makes cc stay connected by repeatedly calling cc.Connect()
-// until the state becomes Shutdown or until 10 seconds elapses.
+// until the state becomes Shutdown or until ithe context expires.
 func stayConnected(ctx context.Context, cc *grpc.ClientConn) {
 	for {
 		state := cc.GetState()


### PR DESCRIPTION
I'm making some other test changes which introduce a dependency on the `grpc` package for `internal/testutils`. Currently the clientconn state transition tests introduce a dependency from package `grpc` to `internal/testutils`. This leads to an import cycle. This PR removes the latter dependency by moving these tests out to the `test` directory. The added benefit of doing this is that we are forced to use the public API instead of relying on some internal APIs.

This also introduces a little bit of code duplication, as some of the test helper functions need to be repeated for tests in `grpc` package and for the `test` package. This can be removed in the future when we switch to using the public API  more frequently in our tests.

RELEASE NOTES: n/a