### PR TITLE
grpc: remove mentions of deleted API, WithBalancerName, from comments

### DIFF
--- a/service_config.go
+++ b/service_config.go
@@ -57,10 +57,9 @@ type lbConfig struct {
 type ServiceConfig struct {
 	serviceconfig.Config
 
-	// LB is the load balancer the service providers recommends. The balancer
-	// specified via grpc.WithBalancerName will override this.  This is deprecated;
-	// lbConfigs is preferred.  If lbConfig and LB are both present, lbConfig
-	// will be used.
+	// LB is the load balancer the service providers recommends.  This is
+	// deprecated; lbConfigs is preferred.  If lbConfig and LB are both present,
+	// lbConfig will be used.
 	LB *string
 
 	// lbConfig is the service config's load balancing configuration.  If

--- a/test/channelz_test.go
+++ b/test/channelz_test.go
@@ -1917,8 +1917,6 @@ func (s) TestCZTraceOverwriteChannelDeletion(t *testing.T) {
 	czCleanup := channelz.NewChannelzStorageForTesting()
 	defer czCleanupWrapper(czCleanup, t)
 	e := tcpClearRREnv
-	// avoid newTest using WithBalancerName, which would override service
-	// config's change of balancer below.
 	e.balancer = ""
 	te := newTest(t, e)
 	channelz.SetMaxTraceEntry(1)

--- a/vet.sh
+++ b/vet.sh
@@ -147,7 +147,6 @@ grpc.NewGZIPDecompressor
 grpc.RPCCompressor
 grpc.RPCDecompressor
 grpc.ServiceConfig
-grpc.WithBalancerName
 grpc.WithCompressor
 grpc.WithDecompressor
 grpc.WithDialer


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc-go/issues/5229

RELEASE NOTES: none