### PR TITLE
xdsclient: NACK endpoint resources with zero weight

### DIFF
--- a/internal/testutils/xds/e2e/clientresources.go
+++ b/internal/testutils/xds/e2e/clientresources.go
@@ -370,6 +370,7 @@ func DefaultEndpoint(clusterName string, host string, ports []uint32) *v3endpoin
 						PortSpecifier: &v3corepb.SocketAddress_PortValue{PortValue: port}},
 				}},
 			}},
+			LoadBalancingWeight: &wrapperspb.UInt32Value{Value: 1},
 		})
 	}
 	return &v3endpointpb.ClusterLoadAssignment{

--- a/xds/internal/testutils/protos.go
+++ b/xds/internal/testutils/protos.go
@@ -118,6 +118,9 @@ func (clab *ClusterLoadAssignmentBuilder) AddLocality(subzone string, weight uin
 				lbe.LoadBalancingWeight = &wrapperspb.UInt32Value{Value: opts.Weight[i]}
 			}
 		}
+		if lbe.LoadBalancingWeight == nil {
+			lbe.LoadBalancingWeight = &wrapperspb.UInt32Value{Value: 1}
+		}
 		lbEndPoints = append(lbEndPoints, lbe)
 	}
 

--- a/xds/internal/xdsclient/controller/v2_eds_test.go
+++ b/xds/internal/xdsclient/controller/v2_eds_test.go
@@ -117,7 +117,7 @@ func (s) TestEDSHandleResponse(t *testing.T) {
 				"not-goodEDSName": {Update: xdsresource.EndpointsUpdate{
 					Localities: []xdsresource.Locality{
 						{
-							Endpoints: []xdsresource.Endpoint{{Address: "addr1:314"}},
+							Endpoints: []xdsresource.Endpoint{{Address: "addr1:314", Weight: 1}},
 							ID:        internal.LocalityID{SubZone: "locality-1"},
 							Priority:  0,
 							Weight:    1,
@@ -140,13 +140,13 @@ func (s) TestEDSHandleResponse(t *testing.T) {
 				goodEDSName: {Update: xdsresource.EndpointsUpdate{
 					Localities: []xdsresource.Locality{
 						{
-							Endpoints: []xdsresource.Endpoint{{Address: "addr1:314"}},
+							Endpoints: []xdsresource.Endpoint{{Address: "addr1:314", Weight: 1}},
 							ID:        internal.LocalityID{SubZone: "locality-1"},
 							Priority:  1,
 							Weight:    1,
 						},
 						{
-							Endpoints: []xdsresource.Endpoint{{Address: "addr2:159"}},
+							Endpoints: []xdsresource.Endpoint{{Address: "addr2:159", Weight: 1}},
 							ID:        internal.LocalityID{SubZone: "locality-2"},
 							Priority:  0,
 							Weight:    1,

--- a/xds/internal/xdsclient/xdsresource/unmarshal_eds_test.go
+++ b/xds/internal/xdsclient/xdsresource/unmarshal_eds_test.go
@@ -65,6 +65,16 @@ func (s) TestEDSParseRespProto(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "zero-endpoint-weight",
+			m: func() *v3endpointpb.ClusterLoadAssignment {
+				clab0 := newClaBuilder("test", nil)
+				clab0.addLocality("locality-0", 1, 0, []string{"addr1:314"}, &addLocalityOptions{Weight: []uint32{0}})
+				return clab0.Build()
+			}(),
+			want:    EndpointsUpdate{},
+			wantErr: true,
+		},
+		{
 			name: "duplicate-locality-in-the-same-priority",
 			m: func() *v3endpointpb.ClusterLoadAssignment {
 				clab0 := newClaBuilder("test", nil)


### PR DESCRIPTION
This is the existing behavior in other languages already (and Envoy), and we are late to the party.

Fixes: https://github.com/grpc/grpc-go/issues/5456

Summary of changes:
- Change the unmarshaling routine in `xdsclient` to error out if it sees an endpoint resource with zero weight
- Change test routines to insert a weight of 1 in all endpoint resources that they use
- Fix existing tests to expect endpoints with weight 1
- Add a test for the zero endpoint case

RELEASE NOTES:
- xds: NACK endpoint resources with zero weight