### PR TITLE
Publish arm64 binaries to GitHub releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         goos: [linux, darwin, windows]
-        goarch: [386, amd64]
+        goarch: [386, amd64, arm64]
         exclude:
           - goos: darwin
             goarch: 386


### PR DESCRIPTION
This updates the release workflow to build and publish arm64 binaries. `arm64` is already tested [here](https://github.com/grpc/grpc-go/blob/master/.github/workflows/testing.yml#L59).

Fixes #5544

RELEASE NOTES: n/a