### PR TITLE
xdsclient: NACK endpoint resource if load_balancing_weight is specified and is zero

### DIFF
--- a/internal/testutils/xds/e2e/clientresources.go
+++ b/internal/testutils/xds/e2e/clientresources.go
@@ -370,7 +370,6 @@ func DefaultEndpoint(clusterName string, host string, ports []uint32) *v3endpoin
 						PortSpecifier: &v3corepb.SocketAddress_PortValue{PortValue: port}},
 				}},
 			}},
-			LoadBalancingWeight: &wrapperspb.UInt32Value{Value: 1},
 		})
 	}
 	return &v3endpointpb.ClusterLoadAssignment{

--- a/xds/internal/testutils/protos.go
+++ b/xds/internal/testutils/protos.go
@@ -118,9 +118,6 @@ func (clab *ClusterLoadAssignmentBuilder) AddLocality(subzone string, weight uin
 				lbe.LoadBalancingWeight = &wrapperspb.UInt32Value{Value: opts.Weight[i]}
 			}
 		}
-		if lbe.LoadBalancingWeight == nil {
-			lbe.LoadBalancingWeight = &wrapperspb.UInt32Value{Value: 1}
-		}
 		lbEndPoints = append(lbEndPoints, lbe)
 	}
 


### PR DESCRIPTION
https://github.com/grpc/grpc-go/pull/5560 introduced the change to NACK EDS resources with endpoints whose `load_balancing_weight` field was set to zero. The correct fix though, is to NACK the resource only when the above field *is* specified and *is* set to zero.

RELEASE NOTES:
- covered by the one in https://github.com/grpc/grpc-go/pull/5560