### PR TITLE
test/kokoro: add missing image tagging to the xDS interop url map buildscript (1.43.x backport)

### DIFF
--- a/test/kokoro/xds_url_map.sh
+++ b/test/kokoro/xds_url_map.sh
@@ -37,6 +37,9 @@ build_test_app_docker_images() {
   docker build -f "${SRC_DIR}/interop/xds/client/Dockerfile" -t "${CLIENT_IMAGE_NAME}:${GIT_COMMIT}" "${SRC_DIR}"
   gcloud -q auth configure-docker
   docker push "${CLIENT_IMAGE_NAME}:${GIT_COMMIT}"
+  if is_version_branch "${TESTING_VERSION}"; then
+    tag_and_push_docker_image "${CLIENT_IMAGE_NAME}" "${GIT_COMMIT}" "${TESTING_VERSION}"
+  fi
 }
 
 #######################################


### PR DESCRIPTION
Backport of #5569

Same as https://github.com/grpc/grpc/pull/30520.

RELEASE NOTES: n/a