### PR TITLE
xds/clusterresolver: prevent deadlock of concurrent Close and UpdateState calls

### DIFF
--- a/xds/internal/balancer/clusterresolver/resource_resolver.go
+++ b/xds/internal/balancer/clusterresolver/resource_resolver.go
@@ -192,13 +192,15 @@ func (rr *resourceResolver) resolveNow() {
 
 func (rr *resourceResolver) stop() {
 	rr.mu.Lock()
-	defer rr.mu.Unlock()
-	for dm, r := range rr.childrenMap {
-		delete(rr.childrenMap, dm)
-		r.r.stop()
-	}
+	cm := rr.childrenMap
+	rr.childrenMap = make(map[discoveryMechanismKey]resolverMechanismTuple)
 	rr.mechanisms = nil
 	rr.children = nil
+	rr.mu.Unlock()
+
+	for _, r := range cm {
+		r.r.stop()
+	}
 }
 
 // generate collects all the updates from all the resolvers, and push the

--- a/xds/internal/balancer/clusterresolver/resource_resolver.go
+++ b/xds/internal/balancer/clusterresolver/resource_resolver.go
@@ -192,6 +192,12 @@ func (rr *resourceResolver) resolveNow() {
 
 func (rr *resourceResolver) stop() {
 	rr.mu.Lock()
+	// Save the previous childrenMap to stop the children outside the mutex,
+	// and reinitialize the map.  We only need to reinitialize to allow for the
+	// policy to be reused if the resource comes back.  In practice, this does
+	// not happen as the parent LB policy will also be closed, causing this to
+	// be removed entirely, but a future use case might want to reuse the
+	// policy instead.
 	cm := rr.childrenMap
 	rr.childrenMap = make(map[discoveryMechanismKey]resolverMechanismTuple)
 	rr.mechanisms = nil


### PR DESCRIPTION
An issue was discovered where, when shutting down, the cluster resolver balancer calls `stop`/`Close` on its DNS child with the lock held.  Meanwhile, the DNS resolver is in its polling loop and then calls `UpdateState` due to a recent update.  This then calls into the cluster resolver's CC wrapper and attempts to acquire the same lock in the cluster resolver.  However, the `Close` method in the DNS resolver blocks until the polling loop exits, but that can't happen because the lock needed to proceed is held by the caller of `Close`.

The solution in this PR is to call `stop`/`Close` on the children without the lock held.

In practice, we don't need to re-initialize the `childrenMap`, as done by this PR, because, when stopped, the parent CDS policy (and its clusterresolver child) is completely deleted.  However, a pre-existing test attempts to re-use the clusterresolver instance by bringing the resource back after it is deleted.  Even though this isn't a real-world use case, it seemed nicer to re-initialize the `childrenMap` (and keep a potential use case possible) instead of deleting the test.

RELEASE NOTES:
* xds: prevent rare client shutdown deadlock with a DNS cluster