### PR TITLE
transport: add peer information to http2Server and http2Client context

### DIFF
--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -326,6 +326,8 @@ func newHTTP2Client(connectCtx, ctx context.Context, addr resolver.Address, opts
 		keepaliveEnabled:      keepaliveEnabled,
 		bufferPool:            newBufferPool(),
 	}
+	// Add peer information to the http2client context.
+	t.ctx = peer.NewContext(t.ctx, t.getPeer())
 
 	if md, ok := addr.Metadata.(*metadata.MD); ok {
 		t.md = *md
@@ -469,7 +471,7 @@ func (t *http2Client) newStream(ctx context.Context, callHdr *CallHdr) *Stream {
 func (t *http2Client) getPeer() *peer.Peer {
 	return &peer.Peer{
 		Addr:     t.remoteAddr,
-		AuthInfo: t.authInfo,
+		AuthInfo: t.authInfo, // Can be nil
 	}
 }
 

--- a/internal/transport/http2_server.go
+++ b/internal/transport/http2_server.go
@@ -265,6 +265,7 @@ func NewServerTransport(conn net.Conn, config *ServerConfig) (_ ServerTransport,
 		czData:            new(channelzData),
 		bufferPool:        newBufferPool(),
 	}
+
 	// Add peer information to the http2server context.
 	t.ctx = peer.NewContext(t.ctx, t.getPeer())
 

--- a/internal/transport/http2_server.go
+++ b/internal/transport/http2_server.go
@@ -1413,14 +1413,10 @@ func (t *http2Server) getOutFlowWindow() int64 {
 }
 
 func (t *http2Server) getPeer() *peer.Peer {
-	pr := &peer.Peer{
-		Addr: t.remoteAddr,
+	return &peer.Peer{
+		Addr:     t.remoteAddr,
+		AuthInfo: t.authInfo, // Can be nil
 	}
-	// Attach Auth info if there is any.
-	if t.authInfo != nil {
-		pr.AuthInfo = t.authInfo
-	}
-	return pr
 }
 
 func getJitter(v time.Duration) time.Duration {

--- a/internal/transport/http2_server.go
+++ b/internal/transport/http2_server.go
@@ -265,7 +265,6 @@ func NewServerTransport(conn net.Conn, config *ServerConfig) (_ ServerTransport,
 		czData:            new(channelzData),
 		bufferPool:        newBufferPool(),
 	}
-
 	// Add peer information to the http2server context.
 	t.ctx = peer.NewContext(t.ctx, t.getPeer())
 

--- a/internal/transport/http2_server.go
+++ b/internal/transport/http2_server.go
@@ -489,9 +489,6 @@ func (t *http2Server) operateHeaders(frame *http2.MetaHeadersFrame, handle func(
 		s.ctx, s.cancel = context.WithCancel(t.ctx)
 	}
 
-	// Add peer information to the stream context.
-	s.ctx = peer.NewContext(s.ctx, t.getPeer())
-
 	// Attach the received metadata to the context.
 	if len(mdata) > 0 {
 		s.ctx = metadata.NewIncomingContext(s.ctx, mdata)

--- a/internal/transport/transport_test.go
+++ b/internal/transport/transport_test.go
@@ -2463,10 +2463,7 @@ func (s) TestPeerSetInServerContext(t *testing.T) {
 	// create a stream with client transport.
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
-	stream, err := client.NewStream(ctx, &CallHdr{
-		Host:   "localhost",
-		Method: "foo.Small",
-	})
+	stream, err := client.NewStream(ctx, &CallHdr{})
 	if err != nil {
 		t.Fatalf("failed to create a stream: %v", err)
 	}

--- a/internal/transport/transport_test.go
+++ b/internal/transport/transport_test.go
@@ -2453,7 +2453,6 @@ func TestConnectionError_Unwrap(t *testing.T) {
 	}
 }
 
-// Verify Peer is set in server context.
 func (s) TestPeerSetInServerContext(t *testing.T) {
 	// create client and server transports.
 	server, client, cancel := setUp(t, 0, math.MaxUint32, normal)
@@ -2472,17 +2471,17 @@ func (s) TestPeerSetInServerContext(t *testing.T) {
 		t.Fatalf("failed to create a stream: %v", err)
 	}
 
-	// verify if peer is set in client transport context.
+	// verify peer is set in client transport context.
 	if _, ok := peer.FromContext(client.ctx); !ok {
 		t.Fatalf("Peer expected in client transport's context, but actually not found.")
 	}
 
-	// verify of peer is set in stream context.
+	// verify peer is set in stream context.
 	if _, ok := peer.FromContext(stream.ctx); !ok {
 		t.Fatalf("Peer expected in stream context, but actually not found.")
 	}
 
-	// verify if peer is set in server transport context.
+	// verify peer is set in server transport context.
 	count := 0
 	for {
 		server.mu.Lock()


### PR DESCRIPTION
Motivation: https://github.com/grpc/grpc-go/issues/5586

Added peer to the http2server context to allow application to access this information when a connection is just established. This frees application from tracking this information on each and every rpc request.

RELEASE NOTES:
* stats: provide peer information in `HandleConn` context