### PR TITLE
xds/resolver: generate channel ID randomly

### DIFF
--- a/xds/internal/resolver/serviceconfig.go
+++ b/xds/internal/resolver/serviceconfig.go
@@ -245,9 +245,7 @@ func (cs *configSelector) generateHash(rpcInfo iresolver.RPCInfo, hashPolicies [
 			generatedHash = true
 			generatedPolicyHash = true
 		case xdsresource.HashPolicyTypeChannelID:
-			// Hash the ClientConn pointer which logically uniquely
-			// identifies the client.
-			policyHash = xxhash.Sum64String(fmt.Sprintf("%p", &cs.r.cc))
+			policyHash = cs.r.clientID
 			generatedHash = true
 			generatedPolicyHash = true
 		}

--- a/xds/internal/resolver/serviceconfig.go
+++ b/xds/internal/resolver/serviceconfig.go
@@ -245,7 +245,8 @@ func (cs *configSelector) generateHash(rpcInfo iresolver.RPCInfo, hashPolicies [
 			generatedHash = true
 			generatedPolicyHash = true
 		case xdsresource.HashPolicyTypeChannelID:
-			policyHash = cs.r.clientID
+			// Use the static channel ID as the hash for this policy.
+			policyHash = cs.r.channelID
 			generatedHash = true
 			generatedPolicyHash = true
 		}

--- a/xds/internal/resolver/serviceconfig_test.go
+++ b/xds/internal/resolver/serviceconfig_test.go
@@ -52,8 +52,8 @@ func (s) TestGenerateRequestHash(t *testing.T) {
 	const channelID = 12378921
 	cs := &configSelector{
 		r: &xdsResolver{
-			cc:       &testClientConn{},
-			clientID: channelID,
+			cc:        &testClientConn{},
+			channelID: channelID,
 		},
 	}
 	tests := []struct {

--- a/xds/internal/resolver/serviceconfig_test.go
+++ b/xds/internal/resolver/serviceconfig_test.go
@@ -20,7 +20,6 @@ package resolver
 
 import (
 	"context"
-	"fmt"
 	"regexp"
 	"testing"
 
@@ -50,9 +49,11 @@ func (s) TestPruneActiveClusters(t *testing.T) {
 }
 
 func (s) TestGenerateRequestHash(t *testing.T) {
+	const channelID = 12378921
 	cs := &configSelector{
 		r: &xdsResolver{
-			cc: &testClientConn{},
+			cc:       &testClientConn{},
+			clientID: channelID,
 		},
 	}
 	tests := []struct {
@@ -85,7 +86,7 @@ func (s) TestGenerateRequestHash(t *testing.T) {
 			hashPolicies: []*xdsresource.HashPolicy{{
 				HashPolicyType: xdsresource.HashPolicyTypeChannelID,
 			}},
-			requestHashWant: xxhash.Sum64String(fmt.Sprintf("%p", &cs.r.cc)),
+			requestHashWant: channelID,
 			rpcInfo:         iresolver.RPCInfo{},
 		},
 		// TestGenerateRequestHashEmptyString tests generating request hashes

--- a/xds/internal/resolver/xds_resolver.go
+++ b/xds/internal/resolver/xds_resolver.go
@@ -27,6 +27,7 @@ import (
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/internal"
 	"google.golang.org/grpc/internal/grpclog"
+	"google.golang.org/grpc/internal/grpcrand"
 	"google.golang.org/grpc/internal/grpcsync"
 	"google.golang.org/grpc/internal/pretty"
 	iresolver "google.golang.org/grpc/internal/resolver"
@@ -71,6 +72,7 @@ func (b *xdsResolverBuilder) Build(target resolver.Target, cc resolver.ClientCon
 		closed:         grpcsync.NewEvent(),
 		updateCh:       make(chan suWithError, 1),
 		activeClusters: make(map[string]*clusterInfo),
+		clientID:       grpcrand.Uint64(),
 	}
 	defer func() {
 		if retErr != nil {
@@ -184,6 +186,9 @@ type xdsResolver struct {
 	activeClusters map[string]*clusterInfo
 
 	curConfigSelector *configSelector
+
+	// A random number which uniquely identifies this client.
+	clientID uint64
 }
 
 // sendNewServiceConfig prunes active clusters, generates a new service config

--- a/xds/internal/resolver/xds_resolver.go
+++ b/xds/internal/resolver/xds_resolver.go
@@ -72,7 +72,7 @@ func (b *xdsResolverBuilder) Build(target resolver.Target, cc resolver.ClientCon
 		closed:         grpcsync.NewEvent(),
 		updateCh:       make(chan suWithError, 1),
 		activeClusters: make(map[string]*clusterInfo),
-		clientID:       grpcrand.Uint64(),
+		channelID:      grpcrand.Uint64(),
 	}
 	defer func() {
 		if retErr != nil {
@@ -187,8 +187,9 @@ type xdsResolver struct {
 
 	curConfigSelector *configSelector
 
-	// A random number which uniquely identifies this client.
-	clientID uint64
+	// A random number which uniquely identifies the channel which owns this
+	// resolver.
+	channelID uint64
 }
 
 // sendNewServiceConfig prunes active clusters, generates a new service config

--- a/xds/internal/xdsclient/xdsresource/type_rds.go
+++ b/xds/internal/xdsclient/xdsresource/type_rds.go
@@ -80,7 +80,7 @@ const (
 	// HashPolicyTypeHeader specifies to hash a Header in the incoming request.
 	HashPolicyTypeHeader HashPolicyType = iota
 	// HashPolicyTypeChannelID specifies to hash a unique Identifier of the
-	// Channel. In grpc-go, this will be done using the ClientConn pointer.
+	// Channel. This is a 64-bit random int computed at initialization time.
 	HashPolicyTypeChannelID
 )
 


### PR DESCRIPTION
This change keeps our code in sync with the spec change at https://github.com/grpc/proposal/pull/320.  We would rather generate a purely random number for this identifier to ensure different clients are extremely unlikely to generate the same identifier.

cc @apolcyn

RELEASE NOTES: none