### PR TITLE
rpc_util: revise limit reader N to maxReceiveMessageSize

### DIFF
--- a/rpc_util.go
+++ b/rpc_util.go
@@ -739,13 +739,13 @@ func decompress(compressor encoding.Compressor, d []byte, maxReceiveMessageSize 
 			// will read more data if available.
 			// +MinRead so ReadFrom will not reallocate if size is correct.
 			buf := bytes.NewBuffer(make([]byte, 0, size+bytes.MinRead))
-			bytesRead, err := buf.ReadFrom(io.LimitReader(dcReader, int64(maxReceiveMessageSize)+1))
+			bytesRead, err := buf.ReadFrom(io.LimitReader(dcReader, int64(maxReceiveMessageSize)))
 			return buf.Bytes(), int(bytesRead), err
 		}
 	}
 	// Read from LimitReader with limit max+1. So if the underlying
 	// reader is over limit, the result will be bigger than max.
-	d, err = ioutil.ReadAll(io.LimitReader(dcReader, int64(maxReceiveMessageSize)+1))
+	d, err = ioutil.ReadAll(io.LimitReader(dcReader, int64(maxReceiveMessageSize)))
 	return d, len(d), err
 }
 


### PR DESCRIPTION
Currently, limitReader's stop bytes in decompress is set to `maxReceiveMessageSize+1`.

However, it seems that received message's length won't exceed maxReceiveMessageSize (we have a check before). It `maxReceiveMessageSize` is set to `maxInt` server can't read any data from decompress function because `maxReceiveMessageSize+1` will overflow MAX_INT64, as the problem in https://github.com/pingcap/tidb-binlog/issues/1152#issuecomment-1216233918.

So I guess we can change this limit to `maxReceiveMessageSize`.