### PR TITLE
metadata: add ValueFromIncomingContext to more efficiently retrieve a single value

### DIFF
--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -194,7 +194,7 @@ func FromIncomingContext(ctx context.Context) (MD, bool) {
 }
 
 // ValueFromIncomingContext returns the metadata value corresponding to the metadata
-// key from the incoming metadata if it exists.
+// key from the incoming metadata if it exists. Key must be lower-case.
 func ValueFromIncomingContext(ctx context.Context, key string) []string {
 	md, ok := ctx.Value(mdIncomingKey{}).(MD)
 	if !ok {
@@ -204,7 +204,6 @@ func ValueFromIncomingContext(ctx context.Context, key string) []string {
 	if v, ok := md[key]; ok {
 		return copyOf(v)
 	}
-	key = strings.ToLower(key)
 	for k, v := range md {
 		// We need to manually convert all keys to lower case, because MD is a
 		// map, and there's no guarantee that the MD attached to the context is

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -197,20 +197,19 @@ func FromIncomingContext(ctx context.Context) (MD, bool) {
 
 // ValueFromIncomingContext returns value from the incoming metadata if exists.
 //
-// This is intended for using as fast access to context value with string constant.
+// ValueFromIncomingContext returns the metadata value corresponding to the metadata
+// key from the incoming metadata if it exists.
 func ValueFromIncomingContext(ctx context.Context, key string) []string {
 	md, ok := ctx.Value(mdIncomingKey{}).(MD)
 	if !ok {
 		return nil
 	}
-	// fastpath
+
 	if v, ok := md[key]; ok {
 		res := make([]string, len(v))
 		copy(res, v)
 		return res
 	}
-
-	// slowpath
 	key = strings.ToLower(key)
 	for k, v := range md {
 		// We need to manually convert all keys to lower case, because MD is a

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -195,6 +195,11 @@ func FromIncomingContext(ctx context.Context) (MD, bool) {
 
 // ValueFromIncomingContext returns the metadata value corresponding to the metadata
 // key from the incoming metadata if it exists. Key must be lower-case.
+//
+// Experimental
+//
+// Notice: This API is EXPERIMENTAL and may be changed or removed in a
+// later release.
 func ValueFromIncomingContext(ctx context.Context, key string) []string {
 	md, ok := ctx.Value(mdIncomingKey{}).(MD)
 	if !ok {
@@ -216,10 +221,10 @@ func ValueFromIncomingContext(ctx context.Context, key string) []string {
 }
 
 // the returned slice must not be modified in place
-func copyOf(v []string) (vals []string) {
-	vals = make([]string, len(v))
+func copyOf(v []string) []string {
+	vals := make([]string, len(v))
 	copy(vals, v)
-	return
+	return vals
 }
 
 // FromOutgoingContextRaw returns the un-merged, intermediary contents of rawMD.

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -195,8 +195,6 @@ func FromIncomingContext(ctx context.Context) (MD, bool) {
 	return out, true
 }
 
-// ValueFromIncomingContext returns value from the incoming metadata if exists.
-//
 // ValueFromIncomingContext returns the metadata value corresponding to the metadata
 // key from the incoming metadata if it exists.
 func ValueFromIncomingContext(ctx context.Context, key string) []string {
@@ -206,9 +204,9 @@ func ValueFromIncomingContext(ctx context.Context, key string) []string {
 	}
 
 	if v, ok := md[key]; ok {
-		res := make([]string, len(v))
-		copy(res, v)
-		return res
+		vals := make([]string, len(v))
+		copy(vals, v)
+		return vals
 	}
 	key = strings.ToLower(key)
 	for k, v := range md {
@@ -216,9 +214,9 @@ func ValueFromIncomingContext(ctx context.Context, key string) []string {
 		// map, and there's no guarantee that the MD attached to the context is
 		// created using our helper functions.
 		if strings.ToLower(k) == key {
-			s := make([]string, len(v))
-			copy(s, v)
-			return s
+			vals := make([]string, len(v))
+			copy(vals, v)
+			return vals
 		}
 	}
 	return nil

--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -206,20 +206,31 @@ func (s) TestValueFromIncomingContext(t *testing.T) {
 	)
 	ctx := NewIncomingContext(context.Background(), md)
 
-	var v []string
-	v = ValueFromIncomingContext(ctx, "X-My-Header-1")
-	if !reflect.DeepEqual(v, []string{"42"}) {
-		t.Errorf("value from context is %v", v)
-	}
-
-	v = ValueFromIncomingContext(ctx, "x-my-header-1")
-	if !reflect.DeepEqual(v, []string{"42"}) {
-		t.Errorf("value from context is %v", v)
-	}
-
-	v = ValueFromIncomingContext(ctx, "x-my-header-2")
-	if !reflect.DeepEqual(v, []string{"43-1", "43-2"}) {
-		t.Errorf("value from context is %v", v)
+	for _, test := range []struct {
+		key  string
+		want []string
+	}{
+		{
+			key:  "X-My-Header-1",
+			want: []string{"42"},
+		},
+		{
+			key:  "x-my-header-1",
+			want: []string{"42"},
+		},
+		{
+			key:  "x-my-header-2",
+			want: []string{"43-1", "43-2"},
+		},
+		{
+			key:  "x-unknown",
+			want: nil,
+		},
+	} {
+		v := ValueFromIncomingContext(ctx, test.key)
+		if !reflect.DeepEqual(v, test.want) {
+			t.Errorf("value of metadata is %v, want %v", v, test.want)
+		}
 	}
 }
 

--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -198,6 +198,31 @@ func (s) TestDelete(t *testing.T) {
 	}
 }
 
+func (s) TestValueFromIncomingContext(t *testing.T) {
+	md := Pairs(
+		"X-My-Header-1", "42",
+		"X-My-Header-2", "43-1",
+		"X-My-Header-2", "43-2",
+	)
+	ctx := NewIncomingContext(context.Background(), md)
+
+	var v []string
+	v = ValueFromIncomingContext(ctx, "X-My-Header-1")
+	if !reflect.DeepEqual(v, []string{"42"}) {
+		t.Errorf("value from context is %v", v)
+	}
+
+	v = ValueFromIncomingContext(ctx, "x-my-header-1")
+	if !reflect.DeepEqual(v, []string{"42"}) {
+		t.Errorf("value from context is %v", v)
+	}
+
+	v = ValueFromIncomingContext(ctx, "x-my-header-2")
+	if !reflect.DeepEqual(v, []string{"43-1", "43-2"}) {
+		t.Errorf("value from context is %v", v)
+	}
+}
+
 func (s) TestAppendToOutgoingContext(t *testing.T) {
 	// Pre-existing metadata
 	tCtx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)

--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -203,6 +203,7 @@ func (s) TestValueFromIncomingContext(t *testing.T) {
 		"X-My-Header-1", "42",
 		"X-My-Header-2", "43-1",
 		"X-My-Header-2", "43-2",
+		"x-my-header-3", "44",
 	)
 	ctx := NewIncomingContext(context.Background(), md)
 
@@ -211,16 +212,16 @@ func (s) TestValueFromIncomingContext(t *testing.T) {
 		want []string
 	}{
 		{
-			key:  "X-My-Header-1",
-			want: []string{"42"},
-		},
-		{
 			key:  "x-my-header-1",
 			want: []string{"42"},
 		},
 		{
 			key:  "x-my-header-2",
 			want: []string{"43-1", "43-2"},
+		},
+		{
+			key:  "x-my-header-3",
+			want: []string{"44"},
 		},
 		{
 			key:  "x-unknown",


### PR DESCRIPTION
FromIncomingContext creates a copy of md every time.
So even if you need a single header value you will get a value and an overhead for this.
Many interceptors and user code doesn't need all values at a time.

I'd like also to add a helper to just check key existence.

RELEASE NOTES:
* metadata: add `ValueFromIncomingContext` to more efficiently retrieve a single value