### PR TITLE
Fix http2 spec document link

### DIFF
--- a/internal/transport/http_util.go
+++ b/internal/transport/http_util.go
@@ -45,7 +45,7 @@ import (
 const (
 	// http2MaxFrameLen specifies the max length of a HTTP2 frame.
 	http2MaxFrameLen = 16384 // 16KB frame
-	// http://http2.github.io/http2-spec/#SettingValues
+	// https://httpwg.org/specs/rfc7540.html#SettingValues
 	http2InitHeaderTableSize = 4096
 )
 


### PR DESCRIPTION
Spec is now available at https://httpwg.org/specs/rfc7540.html.

RELEASE NOTES: n/a