### PR TITLE
Allow STS HttpClient Option

### DIFF
--- a/credentials/sts/sts.go
+++ b/credentials/sts/sts.go
@@ -107,7 +107,7 @@ type Options struct {
 
 	// Custom http.Client for the STS endpoint connection.
 	// If left unset, http.DefaultClient is used
-	HttpClient http.Client // Optional
+	HTTPClient http.Client // Optional
 }
 
 func (o Options) String() string {
@@ -124,12 +124,12 @@ func NewCredentials(opts Options) (credentials.PerRPCCredentials, error) {
 	// DefaultClient.Timeout=0 is no timeout at all.
 	// Note: this code is added in only because prior implementation of sts.go
 	//  statically set Timeout value of stsRequestTimeout=5s
-	if opts.HttpClient.Timeout == http.DefaultClient.Timeout {
-		opts.HttpClient.Timeout = stsRequestTimeout
+	if opts.HTTPClient.Timeout == http.DefaultClient.Timeout {
+		opts.HTTPClient.Timeout = stsRequestTimeout
 	}
 	return &callCreds{
 		opts:   opts,
-		client: makeHTTPDoer(&opts.HttpClient),
+		client: makeHTTPDoer(&opts.HTTPClient),
 	}, nil
 }
 

--- a/credentials/sts/sts_test.go
+++ b/credentials/sts/sts_test.go
@@ -915,7 +915,7 @@ func (s) TestTLS(t *testing.T) {
 				SubjectTokenPath:        testdata.Path("x509/server_ca_cert.pem"), // just read any file data and pretend its the token
 				SubjectTokenType:        subjectTokenType,
 				RequestedTokenType:      requestedTokenType,
-				HttpClient:              test.stsClient,
+				HTTPClient:              test.stsClient,
 			})
 			if err != nil {
 				t.Fatalf("error creating STS Credentials: (%+v)", err)

--- a/credentials/sts/sts_test.go
+++ b/credentials/sts/sts_test.go
@@ -795,7 +795,7 @@ func (s) TestTLS(t *testing.T) {
 					// generate a static response
 					respParams := &responseParameters{
 						AccessToken:     accessTokenContents,
-						IssuedTokenType: requestedTokenType,
+						IssuedTokenType: issuedTokenType,
 						TokenType:       "Bearer",
 						ExpiresIn:       int64(60),
 					}
@@ -881,25 +881,31 @@ func (s) TestTLS(t *testing.T) {
 	tests := []struct {
 		name          string
 		grpcTLSConfig *tls.Config
-		stsClient     http.Client
+		stsClient     *http.Client
 		wantErr       bool
 	}{
 		{
 			name:          "Test STS Server with custom RootCAs",
 			grpcTLSConfig: validServerTLSConfig,
-			stsClient:     *validSTSClient,
+			stsClient:     validSTSClient,
 			wantErr:       false,
 		},
 		{
-			name:          "Test STS Server with default",
+			name:          "Test STS Server with defaultClient",
 			grpcTLSConfig: validServerTLSConfig,
-			stsClient:     *defaultSTSClient,
+			stsClient:     defaultSTSClient,
+			wantErr:       true,
+		},
+		{
+			name:          "Test STS Server with nil client",
+			grpcTLSConfig: validServerTLSConfig,
+			stsClient:     nil,
 			wantErr:       true,
 		},
 		{
 			name:          "Test STS Server with incorrect SNI",
 			grpcTLSConfig: validServerTLSConfig,
-			stsClient:     *invalidSTSClient,
+			stsClient:     invalidSTSClient,
 			wantErr:       true,
 		},
 	}

--- a/credentials/sts/sts_test.go
+++ b/credentials/sts/sts_test.go
@@ -778,6 +778,7 @@ func (s) TestTLS(t *testing.T) {
 			func(w http.ResponseWriter, r *http.Request) {
 				if r.URL.Path != "/token" {
 					w.WriteHeader(http.StatusNotFound)
+					return
 				}
 				// validate the inbound request
 				reqParams := &requestParameters{}


### PR DESCRIPTION
fixes https://github.com/grpc/grpc-go/issues/5099

PR allows STS Credential Option value to set an [HTTPClient](https://pkg.go.dev/net/http#Client) within which the `TLSConfig` and other customized parameters can get set (eg `TimeOut`

Note:

* from  [HTTPClient](https://pkg.go.dev/net/http#Client) :  
   : _"A Client is an HTTP client. Its zero value (DefaultClient) is a usable client that uses DefaultTransport."_

* Existing testcases uses a channel and mocked responses.  The test cases here uses an actual TLS enabled STS and gRPC server for higher fidelity tests

RELEASE NOTES:
- sts: provide an option to use a non-default `http.Client` for communication with the credentials server