### PR TITLE
ringhash: implement a no-op ExitIdle() method

### DIFF
--- a/xds/internal/balancer/ringhash/ringhash.go
+++ b/xds/internal/balancer/ringhash/ringhash.go
@@ -443,6 +443,11 @@ func (b *ringhashBalancer) regeneratePicker() {
 
 func (b *ringhashBalancer) Close() {}
 
+func (b *ringhashBalancer) ExitIdle() {
+	// ExitIdle implementation is a no-op because connections are either
+	// triggers from picks or from subConn state changes.
+}
+
 // connectivityStateEvaluator takes the connectivity states of multiple SubConns
 // and returns one aggregated connectivity state.
 //


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc-go/issues/5602

RELEASE NOTES:
- ringhash: do nothing when asked to exit `IDLE` instead of falling back on the default channel behavior of connecting to all addresses