### PR TITLE
gcp/observability: fix End() to cleanup global state correctly

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -109,7 +109,7 @@ jobs:
           cd "${GITHUB_WORKSPACE}"
           for MOD_FILE in $(find . -name 'go.mod' | grep -Ev '^\./go\.mod'); do
             pushd "$(dirname ${MOD_FILE})"
-            go test ${{ matrix.testflags }} -timeout 2m ./...
+            go test ${{ matrix.testflags }} -cpu 1,4 -timeout 2m ./...
             popd
           done
 

--- a/gcp/observability/observability.go
+++ b/gcp/observability/observability.go
@@ -29,12 +29,7 @@ import (
 	"context"
 	"fmt"
 
-	"contrib.go.opencensus.io/exporter/stackdriver"
-
-	"go.opencensus.io/stats/view"
-	"go.opencensus.io/trace"
 	"google.golang.org/grpc/grpclog"
-	"google.golang.org/grpc/internal"
 )
 
 var logger = grpclog.Component("observability")
@@ -85,18 +80,5 @@ func Start(ctx context.Context) error {
 // Note: this method should only be invoked once.
 func End() {
 	defaultLogger.Close()
-	if exporter != nil {
-		if sdExporter, ok := exporter.(*stackdriver.Exporter); ok {
-			sdExporter.Flush()
-			sdExporter.Close()
-		}
-
-		// Call these unconditionally, doesn't matter if not registered, will be
-		// a noop if not registered.
-		trace.UnregisterExporter(exporter)
-		view.UnregisterExporter(exporter)
-
-		internal.ClearExtraDialOptions()
-		internal.ClearExtraServerOptions()
-	}
+	stopOpenCensus()
 }

--- a/gcp/observability/observability_test.go
+++ b/gcp/observability/observability_test.go
@@ -386,6 +386,12 @@ func (fe *fakeOpenCensusExporter) ExportSpan(vd *trace.SpanData) {
 	fe.t.Logf("Span[%v]", vd.Name)
 }
 
+func (fe *fakeOpenCensusExporter) Flush() {}
+
+func (fe *fakeOpenCensusExporter) Close() error {
+	return nil
+}
+
 func (s) TestLoggingForOkCall(t *testing.T) {
 	te := newTest(t)
 	defer te.tearDown()

--- a/gcp/observability/observability_test.go
+++ b/gcp/observability/observability_test.go
@@ -35,7 +35,6 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	grpclogrecordpb "google.golang.org/grpc/gcp/observability/internal/logging"
-	"google.golang.org/grpc/internal"
 	iblog "google.golang.org/grpc/internal/binarylog"
 	"google.golang.org/grpc/internal/grpctest"
 	"google.golang.org/grpc/internal/leakcheck"
@@ -874,12 +873,6 @@ func (s) TestCustomTagsTracingMetrics(t *testing.T) {
 	}`
 	cleanup, err := createTmpConfigInFileSystem(configJSON)
 	defer cleanup()
-
-	// To clear globally registered tracing and metrics exporters.
-	defer func() {
-		internal.ClearExtraDialOptions()
-		internal.ClearExtraServerOptions()
-	}()
 
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()

--- a/gcp/observability/opencensus.go
+++ b/gcp/observability/opencensus.go
@@ -58,6 +58,8 @@ type tracingMetricsExporter interface {
 	view.Exporter
 }
 
+var exporter tracingMetricsExporter
+
 // global to stub out in tests
 var newExporter = newStackdriverExporter
 
@@ -87,7 +89,8 @@ func startOpenCensus(config *config) error {
 		return nil
 	}
 
-	exporter, err := newExporter(config)
+	var err error
+	exporter, err = newExporter(config)
 	if err != nil {
 		return err
 	}

--- a/gcp/observability/opencensus.go
+++ b/gcp/observability/opencensus.go
@@ -126,17 +126,17 @@ func startOpenCensus(config *config) error {
 // packages if exporter was created.
 func stopOpenCensus() {
 	if exporter != nil {
-		if sdExporter, ok := exporter.(*stackdriver.Exporter); ok {
-			sdExporter.Flush()
-			sdExporter.Close()
-		}
+		internal.ClearExtraDialOptions()
+		internal.ClearExtraServerOptions()
 
 		// Call these unconditionally, doesn't matter if not registered, will be
 		// a noop if not registered.
 		trace.UnregisterExporter(exporter)
 		view.UnregisterExporter(exporter)
 
-		internal.ClearExtraDialOptions()
-		internal.ClearExtraServerOptions()
+		if sdExporter, ok := exporter.(*stackdriver.Exporter); ok {
+			sdExporter.Flush()
+			sdExporter.Close()
+		}
 	}
 }

--- a/gcp/observability/opencensus.go
+++ b/gcp/observability/opencensus.go
@@ -56,6 +56,8 @@ func tagsToTraceAttributes(tags map[string]string) map[string]interface{} {
 type tracingMetricsExporter interface {
 	trace.Exporter
 	view.Exporter
+	Flush()
+	Close() error
 }
 
 var exporter tracingMetricsExporter
@@ -134,9 +136,7 @@ func stopOpenCensus() {
 		trace.UnregisterExporter(exporter)
 		view.UnregisterExporter(exporter)
 
-		if sdExporter, ok := exporter.(*stackdriver.Exporter); ok {
-			sdExporter.Flush()
-			sdExporter.Close()
-		}
+		exporter.Flush()
+		exporter.Close()
 	}
 }

--- a/gcp/observability/opencensus.go
+++ b/gcp/observability/opencensus.go
@@ -121,3 +121,22 @@ func startOpenCensus(config *config) error {
 
 	return nil
 }
+
+// stopOpenCensus flushes the exporter's and cleans up globals across all
+// packages if exporter was created.
+func stopOpenCensus() {
+	if exporter != nil {
+		if sdExporter, ok := exporter.(*stackdriver.Exporter); ok {
+			sdExporter.Flush()
+			sdExporter.Close()
+		}
+
+		// Call these unconditionally, doesn't matter if not registered, will be
+		// a noop if not registered.
+		trace.UnregisterExporter(exporter)
+		view.UnregisterExporter(exporter)
+
+		internal.ClearExtraDialOptions()
+		internal.ClearExtraServerOptions()
+	}
+}


### PR DESCRIPTION
Previously, our metrics and tracing calls would not have the buffer flushed in observability.End(), and also keep the exporters registered globally in another package. Thus, tracing and metrics data would possibly not get uploaded to a backend properly. Also, our tests would break when run more than once due to the trailing exporter.

Fixes https://github.com/grpc/grpc-go/issues/5423, https://github.com/grpc/grpc-go/issues/5558, https://github.com/grpc/grpc-go/issues/5559

RELEASE NOTES:
* gcp/observability: fix End() to cleanup global state correctly