### PR TITLE
vet: update Go version, update ignore list

### DIFF
--- a/admin/test/utils.go
+++ b/admin/test/utils.go
@@ -26,16 +26,17 @@ import (
 	"testing"
 	"time"
 
-	v3statusgrpc "github.com/envoyproxy/go-control-plane/envoy/service/status/v3"
-	v3statuspb "github.com/envoyproxy/go-control-plane/envoy/service/status/v3"
 	"github.com/google/uuid"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/admin"
-	channelzpb "google.golang.org/grpc/channelz/grpc_channelz_v1"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/internal/xds"
 	"google.golang.org/grpc/status"
+
+	v3statusgrpc "github.com/envoyproxy/go-control-plane/envoy/service/status/v3" //lint:ignore ST1019 message and service definitions are in separate packages in google3
+	v3statuspb "github.com/envoyproxy/go-control-plane/envoy/service/status/v3"
+	channelzpb "google.golang.org/grpc/channelz/grpc_channelz_v1"
 )
 
 const (

--- a/balancer/grpclb/grpclb_test.go
+++ b/balancer/grpclb/grpclb_test.go
@@ -48,7 +48,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	durationpb "github.com/golang/protobuf/ptypes/duration"
-	lbgrpc "google.golang.org/grpc/balancer/grpclb/grpc_lb_v1"
+	lbgrpc "google.golang.org/grpc/balancer/grpclb/grpc_lb_v1" //lint:ignore ST1019 message and service definitions are in separate packages in google3
 	lbpb "google.golang.org/grpc/balancer/grpclb/grpc_lb_v1"
 	testpb "google.golang.org/grpc/test/grpc_testing"
 )

--- a/balancer/rls/control_channel.go
+++ b/balancer/rls/control_channel.go
@@ -31,7 +31,8 @@ import (
 	"google.golang.org/grpc/internal"
 	internalgrpclog "google.golang.org/grpc/internal/grpclog"
 	"google.golang.org/grpc/internal/pretty"
-	rlsgrpc "google.golang.org/grpc/internal/proto/grpc_lookup_v1"
+
+	rlsgrpc "google.golang.org/grpc/internal/proto/grpc_lookup_v1" //lint:ignore ST1019 message and service definitions are in separate packages in google3
 	rlspb "google.golang.org/grpc/internal/proto/grpc_lookup_v1"
 )
 

--- a/balancer/rls/helpers_test.go
+++ b/balancer/rls/helpers_test.go
@@ -31,16 +31,17 @@ import (
 	"google.golang.org/grpc/internal"
 	"google.golang.org/grpc/internal/balancergroup"
 	"google.golang.org/grpc/internal/grpctest"
-	rlspb "google.golang.org/grpc/internal/proto/grpc_lookup_v1"
 	internalserviceconfig "google.golang.org/grpc/internal/serviceconfig"
 	"google.golang.org/grpc/internal/stubserver"
 	"google.golang.org/grpc/resolver"
 	"google.golang.org/grpc/resolver/manual"
 	"google.golang.org/grpc/serviceconfig"
 	"google.golang.org/grpc/status"
-	testgrpc "google.golang.org/grpc/test/grpc_testing"
-	testpb "google.golang.org/grpc/test/grpc_testing"
 	"google.golang.org/protobuf/types/known/durationpb"
+
+	rlspb "google.golang.org/grpc/internal/proto/grpc_lookup_v1"
+	testgrpc "google.golang.org/grpc/test/grpc_testing" //lint:ignore ST1019 message and service definitions are in separate packages in google3
+	testpb "google.golang.org/grpc/test/grpc_testing"
 )
 
 const (

--- a/benchmark/benchmain/main.go
+++ b/benchmark/benchmain/main.go
@@ -59,7 +59,6 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/benchmark"
-	bm "google.golang.org/grpc/benchmark"
 	"google.golang.org/grpc/benchmark/flags"
 	"google.golang.org/grpc/benchmark/latency"
 	"google.golang.org/grpc/benchmark/stats"
@@ -70,7 +69,7 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/test/bufconn"
 
-	testgrpc "google.golang.org/grpc/interop/grpc_testing"
+	testgrpc "google.golang.org/grpc/interop/grpc_testing" //lint:ignore ST1019 message and service definitions are in separate packages in google3
 	testpb "google.golang.org/grpc/interop/grpc_testing"
 )
 
@@ -328,8 +327,8 @@ func makeClient(bf stats.Features) (testgrpc.BenchmarkServiceClient, func()) {
 		}))
 	}
 	lis = nw.Listener(lis)
-	stopper := bm.StartServer(bm.ServerInfo{Type: "protobuf", Listener: lis}, sopts...)
-	conn := bm.NewClientConn("" /* target not used */, opts...)
+	stopper := benchmark.StartServer(benchmark.ServerInfo{Type: "protobuf", Listener: lis}, sopts...)
+	conn := benchmark.NewClientConn("" /* target not used */, opts...)
 	return testgrpc.NewBenchmarkServiceClient(conn), func() {
 		conn.Close()
 		stopper()
@@ -419,7 +418,7 @@ func setupUnconstrainedStream(bf stats.Features) ([]testgrpc.BenchmarkService_St
 		streams[i] = stream
 	}
 
-	pl := bm.NewPayload(testpb.PayloadType_COMPRESSABLE, bf.ReqSizeBytes)
+	pl := benchmark.NewPayload(testpb.PayloadType_COMPRESSABLE, bf.ReqSizeBytes)
 	req := &testpb.SimpleRequest{
 		ResponseType: pl.Type,
 		ResponseSize: int32(bf.RespSizeBytes),
@@ -432,13 +431,13 @@ func setupUnconstrainedStream(bf stats.Features) ([]testgrpc.BenchmarkService_St
 // Makes a UnaryCall gRPC request using the given BenchmarkServiceClient and
 // request and response sizes.
 func unaryCaller(client testgrpc.BenchmarkServiceClient, reqSize, respSize int) {
-	if err := bm.DoUnaryCall(client, reqSize, respSize); err != nil {
+	if err := benchmark.DoUnaryCall(client, reqSize, respSize); err != nil {
 		logger.Fatalf("DoUnaryCall failed: %v", err)
 	}
 }
 
 func streamCaller(stream testgrpc.BenchmarkService_StreamingCallClient, reqSize, respSize int) {
-	if err := bm.DoStreamingRoundTrip(stream, reqSize, respSize); err != nil {
+	if err := benchmark.DoStreamingRoundTrip(stream, reqSize, respSize); err != nil {
 		logger.Fatalf("DoStreamingRoundTrip failed: %v", err)
 	}
 }

--- a/benchmark/benchmark.go
+++ b/benchmark/benchmark.go
@@ -34,7 +34,7 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 
-	testgrpc "google.golang.org/grpc/interop/grpc_testing"
+	testgrpc "google.golang.org/grpc/interop/grpc_testing" //lint:ignore ST1019 message and service definitions are in separate packages in google3
 	testpb "google.golang.org/grpc/interop/grpc_testing"
 )
 

--- a/benchmark/client/main.go
+++ b/benchmark/client/main.go
@@ -55,7 +55,7 @@ import (
 	"google.golang.org/grpc/grpclog"
 	"google.golang.org/grpc/internal/syscall"
 
-	testgrpc "google.golang.org/grpc/interop/grpc_testing"
+	testgrpc "google.golang.org/grpc/interop/grpc_testing" //lint:ignore ST1019 message and service definitions are in separate packages in google3
 	testpb "google.golang.org/grpc/interop/grpc_testing"
 )
 

--- a/benchmark/worker/benchmark_client.go
+++ b/benchmark/worker/benchmark_client.go
@@ -36,7 +36,7 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/grpc/testdata"
 
-	testgrpc "google.golang.org/grpc/interop/grpc_testing"
+	testgrpc "google.golang.org/grpc/interop/grpc_testing" //lint:ignore ST1019 message and service definitions are in separate packages in google3
 	testpb "google.golang.org/grpc/interop/grpc_testing"
 
 	_ "google.golang.org/grpc/xds" // To install the xds resolvers and balancers.

--- a/benchmark/worker/main.go
+++ b/benchmark/worker/main.go
@@ -37,7 +37,7 @@ import (
 	"google.golang.org/grpc/grpclog"
 	"google.golang.org/grpc/status"
 
-	testgrpc "google.golang.org/grpc/interop/grpc_testing"
+	testgrpc "google.golang.org/grpc/interop/grpc_testing" //lint:ignore ST1019 message and service definitions are in separate packages in google3
 	testpb "google.golang.org/grpc/interop/grpc_testing"
 )
 

--- a/binarylog/binarylog_end2end_test.go
+++ b/binarylog/binarylog_end2end_test.go
@@ -39,7 +39,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	pb "google.golang.org/grpc/binarylog/grpc_binarylog_v1"
-	testgrpc "google.golang.org/grpc/interop/grpc_testing"
+	testgrpc "google.golang.org/grpc/interop/grpc_testing" //lint:ignore ST1019 message and service definitions are in separate packages in google3
 	testpb "google.golang.org/grpc/interop/grpc_testing"
 )
 

--- a/channelz/service/service.go
+++ b/channelz/service/service.go
@@ -24,16 +24,17 @@ import (
 	"net"
 
 	"github.com/golang/protobuf/ptypes"
-	wrpb "github.com/golang/protobuf/ptypes/wrappers"
 	"google.golang.org/grpc"
-	channelzgrpc "google.golang.org/grpc/channelz/grpc_channelz_v1"
-	channelzpb "google.golang.org/grpc/channelz/grpc_channelz_v1"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/grpclog"
 	"google.golang.org/grpc/internal/channelz"
 	"google.golang.org/grpc/status"
+
+	wrpb "github.com/golang/protobuf/ptypes/wrappers"
+	channelzgrpc "google.golang.org/grpc/channelz/grpc_channelz_v1" //lint:ignore ST1019 message and service definitions are in separate packages in google3
+	channelzpb "google.golang.org/grpc/channelz/grpc_channelz_v1"
 )
 
 func init() {

--- a/credentials/alts/internal/handshaker/handshaker.go
+++ b/credentials/alts/internal/handshaker/handshaker.go
@@ -27,13 +27,14 @@ import (
 	"net"
 	"sync"
 
-	grpc "google.golang.org/grpc"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	core "google.golang.org/grpc/credentials/alts/internal"
 	"google.golang.org/grpc/credentials/alts/internal/authinfo"
 	"google.golang.org/grpc/credentials/alts/internal/conn"
-	altsgrpc "google.golang.org/grpc/credentials/alts/internal/proto/grpc_gcp"
+
+	altsgrpc "google.golang.org/grpc/credentials/alts/internal/proto/grpc_gcp" //lint:ignore ST1019 message and service definitions are in separate packages in google3
 	altspb "google.golang.org/grpc/credentials/alts/internal/proto/grpc_gcp"
 )
 

--- a/health/server.go
+++ b/health/server.go
@@ -25,9 +25,10 @@ import (
 	"sync"
 
 	"google.golang.org/grpc/codes"
-	healthgrpc "google.golang.org/grpc/health/grpc_health_v1"
-	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/status"
+
+	healthgrpc "google.golang.org/grpc/health/grpc_health_v1" //lint:ignore ST1019 message and service definitions are in separate packages in google3
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 )
 
 // Server implements `service Health`.

--- a/internal/testutils/fakegrpclb/server.go
+++ b/internal/testutils/fakegrpclb/server.go
@@ -29,12 +29,13 @@ import (
 	"time"
 
 	"google.golang.org/grpc"
-	lbgrpc "google.golang.org/grpc/balancer/grpclb/grpc_lb_v1"
-	lbpb "google.golang.org/grpc/balancer/grpclb/grpc_lb_v1"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/grpclog"
 	"google.golang.org/grpc/internal/pretty"
 	"google.golang.org/grpc/status"
+
+	lbgrpc "google.golang.org/grpc/balancer/grpclb/grpc_lb_v1" //lint:ignore ST1019 message and service definitions are in separate packages in google3
+	lbpb "google.golang.org/grpc/balancer/grpclb/grpc_lb_v1"
 )
 
 var logger = grpclog.Component("fake_grpclb")

--- a/internal/testutils/rls/fake_rls_server.go
+++ b/internal/testutils/rls/fake_rls_server.go
@@ -27,10 +27,11 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
-	rlsgrpc "google.golang.org/grpc/internal/proto/grpc_lookup_v1"
-	rlspb "google.golang.org/grpc/internal/proto/grpc_lookup_v1"
 	"google.golang.org/grpc/internal/testutils"
 	"google.golang.org/grpc/status"
+
+	rlsgrpc "google.golang.org/grpc/internal/proto/grpc_lookup_v1" //lint:ignore ST1019 message and service definitions are in separate packages in google3
+	rlspb "google.golang.org/grpc/internal/proto/grpc_lookup_v1"
 )
 
 // RouteLookupResponse wraps an RLS response and the associated error to be sent

--- a/internal/testutils/roundrobin/roundrobin.go
+++ b/internal/testutils/roundrobin/roundrobin.go
@@ -32,7 +32,7 @@ import (
 	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/resolver"
 
-	testgrpc "google.golang.org/grpc/test/grpc_testing"
+	testgrpc "google.golang.org/grpc/test/grpc_testing" //lint:ignore ST1019 message and service definitions are in separate packages in google3
 	testpb "google.golang.org/grpc/test/grpc_testing"
 )
 

--- a/internal/testutils/xds/e2e/server.go
+++ b/internal/testutils/xds/e2e/server.go
@@ -26,17 +26,18 @@ import (
 	"reflect"
 	"strconv"
 
+	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
+	"google.golang.org/grpc"
+
 	v3clusterpb "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	v3endpointpb "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 	v3listenerpb "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	v3routepb "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
-	v3discoverygrpc "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+	v3discoverygrpc "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3" //lint:ignore ST1019 message and service definitions are in separate packages in google3
 	v3discoverypb "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
-	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
 	v3cache "github.com/envoyproxy/go-control-plane/pkg/cache/v3"
 	v3resource "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
 	v3server "github.com/envoyproxy/go-control-plane/pkg/server/v3"
-	"google.golang.org/grpc"
 )
 
 // ManagementServer is a thin wrapper around the xDS control plane

--- a/interop/alts/client/client.go
+++ b/interop/alts/client/client.go
@@ -28,7 +28,7 @@ import (
 	"google.golang.org/grpc/credentials/alts"
 	"google.golang.org/grpc/grpclog"
 
-	testgrpc "google.golang.org/grpc/interop/grpc_testing"
+	testgrpc "google.golang.org/grpc/interop/grpc_testing" //lint:ignore ST1019 message and service definitions are in separate packages in google3
 	testpb "google.golang.org/grpc/interop/grpc_testing"
 )
 

--- a/interop/http2/negative_http2_client.go
+++ b/interop/http2/negative_http2_client.go
@@ -38,7 +38,7 @@ import (
 	"google.golang.org/grpc/interop"
 	"google.golang.org/grpc/status"
 
-	testgrpc "google.golang.org/grpc/interop/grpc_testing"
+	testgrpc "google.golang.org/grpc/interop/grpc_testing" //lint:ignore ST1019 message and service definitions are in separate packages in google3
 	testpb "google.golang.org/grpc/interop/grpc_testing"
 )
 

--- a/interop/test_utils.go
+++ b/interop/test_utils.go
@@ -40,7 +40,7 @@ import (
 	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
 
-	testgrpc "google.golang.org/grpc/interop/grpc_testing"
+	testgrpc "google.golang.org/grpc/interop/grpc_testing" //lint:ignore ST1019 message and service definitions are in separate packages in google3
 	testpb "google.golang.org/grpc/interop/grpc_testing"
 )
 

--- a/interop/xds/client/client.go
+++ b/interop/xds/client/client.go
@@ -41,7 +41,7 @@ import (
 	"google.golang.org/grpc/status"
 	_ "google.golang.org/grpc/xds"
 
-	testgrpc "google.golang.org/grpc/interop/grpc_testing"
+	testgrpc "google.golang.org/grpc/interop/grpc_testing" //lint:ignore ST1019 message and service definitions are in separate packages in google3
 	testpb "google.golang.org/grpc/interop/grpc_testing"
 )
 

--- a/interop/xds/server/server.go
+++ b/interop/xds/server/server.go
@@ -37,9 +37,9 @@ import (
 	"google.golang.org/grpc/xds"
 
 	xdscreds "google.golang.org/grpc/credentials/xds"
-	healthgrpc "google.golang.org/grpc/health/grpc_health_v1"
+	healthgrpc "google.golang.org/grpc/health/grpc_health_v1" //lint:ignore ST1019 message and service definitions are in separate packages in google3
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
-	testgrpc "google.golang.org/grpc/interop/grpc_testing"
+	testgrpc "google.golang.org/grpc/interop/grpc_testing" //lint:ignore ST1019 message and service definitions are in separate packages in google3
 	testpb "google.golang.org/grpc/interop/grpc_testing"
 )
 

--- a/orca/call_metric_recorder_test.go
+++ b/orca/call_metric_recorder_test.go
@@ -36,7 +36,7 @@ import (
 	"google.golang.org/grpc/orca"
 
 	v3orcapb "github.com/cncf/xds/go/xds/data/orca/v3"
-	testgrpc "google.golang.org/grpc/test/grpc_testing"
+	testgrpc "google.golang.org/grpc/test/grpc_testing" //lint:ignore ST1019 message and service definitions are in separate packages in google3
 	testpb "google.golang.org/grpc/test/grpc_testing"
 )
 

--- a/orca/service.go
+++ b/orca/service.go
@@ -28,7 +28,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	v3orcapb "github.com/cncf/xds/go/xds/data/orca/v3"
-	v3orcaservicegrpc "github.com/cncf/xds/go/xds/service/orca/v3"
+	v3orcaservicegrpc "github.com/cncf/xds/go/xds/service/orca/v3" //lint:ignore ST1019 message and service definitions are in separate packages in google3
 	v3orcaservicepb "github.com/cncf/xds/go/xds/service/orca/v3"
 )
 

--- a/orca/service_test.go
+++ b/orca/service_test.go
@@ -36,9 +36,9 @@ import (
 	"google.golang.org/protobuf/types/known/durationpb"
 
 	v3orcapb "github.com/cncf/xds/go/xds/data/orca/v3"
-	v3orcaservicegrpc "github.com/cncf/xds/go/xds/service/orca/v3"
+	v3orcaservicegrpc "github.com/cncf/xds/go/xds/service/orca/v3" //lint:ignore ST1019 message and service definitions are in separate packages in google3
 	v3orcaservicepb "github.com/cncf/xds/go/xds/service/orca/v3"
-	testgrpc "google.golang.org/grpc/test/grpc_testing"
+	testgrpc "google.golang.org/grpc/test/grpc_testing" //lint:ignore ST1019 message and service definitions are in separate packages in google3
 	testpb "google.golang.org/grpc/test/grpc_testing"
 )
 

--- a/stats/stats_test.go
+++ b/stats/stats_test.go
@@ -36,7 +36,7 @@ import (
 	"google.golang.org/grpc/stats"
 	"google.golang.org/grpc/status"
 
-	testgrpc "google.golang.org/grpc/interop/grpc_testing"
+	testgrpc "google.golang.org/grpc/interop/grpc_testing" //lint:ignore ST1019 message and service definitions are in separate packages in google3
 	testpb "google.golang.org/grpc/interop/grpc_testing"
 )
 

--- a/test/clientconn_test.go
+++ b/test/clientconn_test.go
@@ -31,7 +31,8 @@ import (
 	"google.golang.org/grpc/internal/channelz"
 	"google.golang.org/grpc/resolver/manual"
 	"google.golang.org/grpc/status"
-	testgrpc "google.golang.org/grpc/test/grpc_testing"
+
+	testgrpc "google.golang.org/grpc/test/grpc_testing" //lint:ignore ST1019 message and service definitions are in separate packages in google3
 	testpb "google.golang.org/grpc/test/grpc_testing"
 )
 

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -42,10 +42,8 @@ import (
 	"time"
 
 	"github.com/golang/protobuf/proto"
-	anypb "github.com/golang/protobuf/ptypes/any"
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/hpack"
-	spb "google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/connectivity"
@@ -54,8 +52,6 @@ import (
 	"google.golang.org/grpc/encoding"
 	_ "google.golang.org/grpc/encoding/gzip"
 	"google.golang.org/grpc/health"
-	healthgrpc "google.golang.org/grpc/health/grpc_health_v1"
-	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/internal"
 	"google.golang.org/grpc/internal/channelz"
 	"google.golang.org/grpc/internal/grpcsync"
@@ -72,8 +68,13 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/grpc/tap"
 	"google.golang.org/grpc/test/bufconn"
-	testpb "google.golang.org/grpc/test/grpc_testing"
 	"google.golang.org/grpc/testdata"
+
+	anypb "github.com/golang/protobuf/ptypes/any"
+	spb "google.golang.org/genproto/googleapis/rpc/status"
+	healthgrpc "google.golang.org/grpc/health/grpc_health_v1" //lint:ignore ST1019 message and service definitions are in separate packages in google3
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+	testpb "google.golang.org/grpc/test/grpc_testing"
 )
 
 const defaultHealthService = "grpc.health.v1.Health"

--- a/test/healthcheck_test.go
+++ b/test/healthcheck_test.go
@@ -31,16 +31,18 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/credentials/insecure"
-	_ "google.golang.org/grpc/health"
-	healthgrpc "google.golang.org/grpc/health/grpc_health_v1"
-	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/internal"
 	"google.golang.org/grpc/internal/channelz"
 	"google.golang.org/grpc/internal/grpctest"
 	"google.golang.org/grpc/resolver"
 	"google.golang.org/grpc/resolver/manual"
 	"google.golang.org/grpc/status"
+
+	healthgrpc "google.golang.org/grpc/health/grpc_health_v1" //lint:ignore ST1019 message and service definitions are in separate packages in google3
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 	testpb "google.golang.org/grpc/test/grpc_testing"
+
+	_ "google.golang.org/grpc/health" // Enable transparent client side health checking.
 )
 
 var testHealthCheckFunc = internal.HealthCheckFunc

--- a/test/pickfirst_test.go
+++ b/test/pickfirst_test.go
@@ -34,7 +34,8 @@ import (
 	"google.golang.org/grpc/resolver"
 	"google.golang.org/grpc/resolver/manual"
 	"google.golang.org/grpc/status"
-	testgrpc "google.golang.org/grpc/test/grpc_testing"
+
+	testgrpc "google.golang.org/grpc/test/grpc_testing" //lint:ignore ST1019 message and service definitions are in separate packages in google3
 	testpb "google.golang.org/grpc/test/grpc_testing"
 )
 

--- a/test/xds/xds_client_ack_nack_test.go
+++ b/test/xds/xds_client_ack_nack_test.go
@@ -31,7 +31,7 @@ import (
 	"google.golang.org/grpc/internal/testutils/xds/e2e"
 
 	v3discoverypb "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
-	testgrpc "google.golang.org/grpc/test/grpc_testing"
+	testgrpc "google.golang.org/grpc/test/grpc_testing" //lint:ignore ST1019 message and service definitions are in separate packages in google3
 	testpb "google.golang.org/grpc/test/grpc_testing"
 )
 

--- a/test/xds/xds_client_affinity_test.go
+++ b/test/xds/xds_client_affinity_test.go
@@ -31,7 +31,7 @@ import (
 	v3clusterpb "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	v3corepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	v3routepb "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
-	testgrpc "google.golang.org/grpc/test/grpc_testing"
+	testgrpc "google.golang.org/grpc/test/grpc_testing" //lint:ignore ST1019 message and service definitions are in separate packages in google3
 	testpb "google.golang.org/grpc/test/grpc_testing"
 )
 

--- a/test/xds/xds_client_federation_test.go
+++ b/test/xds/xds_client_federation_test.go
@@ -23,10 +23,6 @@ import (
 	"fmt"
 	"testing"
 
-	v3clusterpb "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
-	v3endpointpb "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
-	v3listenerpb "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
-	v3routepb "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	"github.com/google/uuid"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -35,7 +31,12 @@ import (
 	"google.golang.org/grpc/internal/testutils/xds/e2e"
 	xdsinternal "google.golang.org/grpc/internal/xds"
 	"google.golang.org/grpc/resolver"
-	testgrpc "google.golang.org/grpc/test/grpc_testing"
+
+	v3clusterpb "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	v3endpointpb "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
+	v3listenerpb "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	v3routepb "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	testgrpc "google.golang.org/grpc/test/grpc_testing" //lint:ignore ST1019 message and service definitions are in separate packages in google3
 	testpb "google.golang.org/grpc/test/grpc_testing"
 )
 

--- a/test/xds/xds_client_integration_test.go
+++ b/test/xds/xds_client_integration_test.go
@@ -32,7 +32,7 @@ import (
 	"google.golang.org/grpc/internal/stubserver"
 	"google.golang.org/grpc/internal/testutils/xds/e2e"
 
-	testgrpc "google.golang.org/grpc/test/grpc_testing"
+	testgrpc "google.golang.org/grpc/test/grpc_testing" //lint:ignore ST1019 message and service definitions are in separate packages in google3
 	testpb "google.golang.org/grpc/test/grpc_testing"
 )
 

--- a/test/xds/xds_client_retry_test.go
+++ b/test/xds/xds_client_retry_test.go
@@ -32,7 +32,7 @@ import (
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	v3routepb "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
-	testgrpc "google.golang.org/grpc/test/grpc_testing"
+	testgrpc "google.golang.org/grpc/test/grpc_testing" //lint:ignore ST1019 message and service definitions are in separate packages in google3
 	testpb "google.golang.org/grpc/test/grpc_testing"
 )
 

--- a/test/xds/xds_rls_clusterspecifier_plugin_test.go
+++ b/test/xds/xds_rls_clusterspecifier_plugin_test.go
@@ -38,7 +38,7 @@ import (
 	v3listenerpb "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	v3routepb "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	rlspb "google.golang.org/grpc/internal/proto/grpc_lookup_v1"
-	testgrpc "google.golang.org/grpc/test/grpc_testing"
+	testgrpc "google.golang.org/grpc/test/grpc_testing" //lint:ignore ST1019 message and service definitions are in separate packages in google3
 	testpb "google.golang.org/grpc/test/grpc_testing"
 
 	_ "google.golang.org/grpc/balancer/rls" // Register the RLS Load Balancing policy.

--- a/test/xds/xds_security_config_nack_test.go
+++ b/test/xds/xds_security_config_nack_test.go
@@ -31,7 +31,7 @@ import (
 
 	v3corepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	v3tlspb "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
-	testgrpc "google.golang.org/grpc/test/grpc_testing"
+	testgrpc "google.golang.org/grpc/test/grpc_testing" //lint:ignore ST1019 message and service definitions are in separate packages in google3
 	testpb "google.golang.org/grpc/test/grpc_testing"
 )
 

--- a/test/xds/xds_server_integration_test.go
+++ b/test/xds/xds_server_integration_test.go
@@ -34,7 +34,7 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/grpc/xds"
 
-	testgrpc "google.golang.org/grpc/test/grpc_testing"
+	testgrpc "google.golang.org/grpc/test/grpc_testing" //lint:ignore ST1019 message and service definitions are in separate packages in google3
 	testpb "google.golang.org/grpc/test/grpc_testing"
 )
 

--- a/test/xds/xds_server_rbac_test.go
+++ b/test/xds/xds_server_rbac_test.go
@@ -26,7 +26,6 @@ import (
 	"strings"
 	"testing"
 
-	v3routerpb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/router/v3"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
@@ -42,10 +41,11 @@ import (
 	v3rbacpb "github.com/envoyproxy/go-control-plane/envoy/config/rbac/v3"
 	v3routepb "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	rpb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/rbac/v3"
+	v3routerpb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/router/v3"
 	v3httppb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	v3matcherpb "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
 	wrapperspb "github.com/golang/protobuf/ptypes/wrappers"
-	testgrpc "google.golang.org/grpc/test/grpc_testing"
+	testgrpc "google.golang.org/grpc/test/grpc_testing" //lint:ignore ST1019 message and service definitions are in separate packages in google3
 	testpb "google.golang.org/grpc/test/grpc_testing"
 )
 

--- a/test/xds/xds_server_serving_mode_test.go
+++ b/test/xds/xds_server_serving_mode_test.go
@@ -34,7 +34,7 @@ import (
 	"google.golang.org/grpc/xds"
 
 	v3listenerpb "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
-	testgrpc "google.golang.org/grpc/test/grpc_testing"
+	testgrpc "google.golang.org/grpc/test/grpc_testing" //lint:ignore ST1019 message and service definitions are in separate packages in google3
 	testpb "google.golang.org/grpc/test/grpc_testing"
 )
 

--- a/vet.sh
+++ b/vet.sh
@@ -117,14 +117,10 @@ done
 
 # - Collection of static analysis checks
 #
-# Ignore ST1019 (Importing the same package multiple times) since we do this all
-# the time for pb/grpc packages. Without this, other valid warnings from
-# staticcheck get lost in the sea of warnings for ST1019.
-#
 # TODO(dfawley): don't use deprecated functions in examples or first-party
 # plugins.
 SC_OUT="$(mktemp)"
-staticcheck -go 1.17 -checks 'inherit,-ST1019' ./... > "${SC_OUT}" || true
+staticcheck -go 1.17 -checks 'inherit' ./... > "${SC_OUT}" || true
 # Error if anything other than deprecation warnings are printed.
 not grep -v "is deprecated:.*SA1019" "${SC_OUT}"
 # Only ignore the following deprecated types/fields/functions.

--- a/vet.sh
+++ b/vet.sh
@@ -117,10 +117,14 @@ done
 
 # - Collection of static analysis checks
 #
+# Ignore ST1019 (Importing the same package multiple times) since we do this all
+# the time for pb/grpc packages. Without this, other valid warnings from
+# staticcheck get lost in the sea of warnings for ST1019.
+#
 # TODO(dfawley): don't use deprecated functions in examples or first-party
 # plugins.
 SC_OUT="$(mktemp)"
-staticcheck -go 1.9 -checks 'inherit,-ST1015' ./... > "${SC_OUT}" || true
+staticcheck -go 1.17 -checks 'inherit,-ST1019' ./... > "${SC_OUT}" || true
 # Error if anything other than deprecation warnings are printed.
 not grep -v "is deprecated:.*SA1019" "${SC_OUT}"
 # Only ignore the following deprecated types/fields/functions.

--- a/xds/csds/csds.go
+++ b/xds/csds/csds.go
@@ -27,11 +27,6 @@ import (
 	"context"
 	"io"
 
-	v3adminpb "github.com/envoyproxy/go-control-plane/envoy/admin/v3"
-	v2corepb "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
-	v3corepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
-	v3statusgrpc "github.com/envoyproxy/go-control-plane/envoy/service/status/v3"
-	v3statuspb "github.com/envoyproxy/go-control-plane/envoy/service/status/v3"
 	"github.com/golang/protobuf/proto"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/grpclog"
@@ -39,6 +34,12 @@ import (
 	"google.golang.org/grpc/xds/internal/xdsclient"
 	"google.golang.org/grpc/xds/internal/xdsclient/xdsresource"
 	"google.golang.org/protobuf/types/known/timestamppb"
+
+	v3adminpb "github.com/envoyproxy/go-control-plane/envoy/admin/v3"
+	v2corepb "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	v3corepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	v3statusgrpc "github.com/envoyproxy/go-control-plane/envoy/service/status/v3" //lint:ignore ST1019 message and service definitions are in separate packages in google3
+	v3statuspb "github.com/envoyproxy/go-control-plane/envoy/service/status/v3"
 
 	_ "google.golang.org/grpc/xds/internal/xdsclient/controller/version/v2" // Register v2 xds_client.
 	_ "google.golang.org/grpc/xds/internal/xdsclient/controller/version/v3" // Register v3 xds_client.

--- a/xds/csds/csds_test.go
+++ b/xds/csds/csds_test.go
@@ -35,7 +35,6 @@ import (
 	"google.golang.org/grpc/internal/testutils"
 	"google.golang.org/grpc/internal/testutils/xds/e2e"
 	"google.golang.org/grpc/internal/xds"
-	_ "google.golang.org/grpc/xds/internal/httpfilter/router"
 	"google.golang.org/grpc/xds/internal/xdsclient"
 	"google.golang.org/grpc/xds/internal/xdsclient/xdsresource"
 	"google.golang.org/protobuf/testing/protocmp"
@@ -48,8 +47,10 @@ import (
 	v3endpointpb "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 	v3listenerpb "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	v3routepb "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
-	v3statuspb "github.com/envoyproxy/go-control-plane/envoy/service/status/v3"
+	v3statuspb "github.com/envoyproxy/go-control-plane/envoy/service/status/v3" //lint:ignore ST1019 message and service definitions are in separate packages in google3
 	v3statuspbgrpc "github.com/envoyproxy/go-control-plane/envoy/service/status/v3"
+
+	_ "google.golang.org/grpc/xds/internal/httpfilter/router" // Register the router filter.
 )
 
 const defaultTestTimeout = 10 * time.Second

--- a/xds/internal/balancer/clusterresolver/e2e_test/eds_impl_test.go
+++ b/xds/internal/balancer/clusterresolver/e2e_test/eds_impl_test.go
@@ -45,7 +45,7 @@ import (
 	v3corepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	v3endpointpb "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 	wrapperspb "github.com/golang/protobuf/ptypes/wrappers"
-	testgrpc "google.golang.org/grpc/test/grpc_testing"
+	testgrpc "google.golang.org/grpc/test/grpc_testing" //lint:ignore ST1019 message and service definitions are in separate packages in google3
 	testpb "google.golang.org/grpc/test/grpc_testing"
 
 	_ "google.golang.org/grpc/xds/internal/balancer/clusterresolver"        // Register the "cluster_resolver_experimental" LB policy.

--- a/xds/internal/balancer/ringhash/e2e/ringhash_balancer_test.go
+++ b/xds/internal/balancer/ringhash/e2e/ringhash_balancer_test.go
@@ -31,7 +31,7 @@ import (
 	"google.golang.org/grpc/resolver"
 	"google.golang.org/grpc/resolver/manual"
 
-	testgrpc "google.golang.org/grpc/test/grpc_testing"
+	testgrpc "google.golang.org/grpc/test/grpc_testing" //lint:ignore ST1019 message and service definitions are in separate packages in google3
 	testpb "google.golang.org/grpc/test/grpc_testing"
 
 	_ "google.golang.org/grpc/xds/internal/balancer/ringhash" // Register the ring_hash_experimental LB policy.

--- a/xds/internal/test/e2e/e2e.go
+++ b/xds/internal/test/e2e/e2e.go
@@ -26,10 +26,11 @@ import (
 	"os/exec"
 
 	"google.golang.org/grpc"
-	channelzgrpc "google.golang.org/grpc/channelz/grpc_channelz_v1"
-	channelzpb "google.golang.org/grpc/channelz/grpc_channelz_v1"
 	"google.golang.org/grpc/credentials/insecure"
-	testgrpc "google.golang.org/grpc/interop/grpc_testing"
+
+	channelzgrpc "google.golang.org/grpc/channelz/grpc_channelz_v1" //lint:ignore ST1019 message and service definitions are in separate packages in google3
+	channelzpb "google.golang.org/grpc/channelz/grpc_channelz_v1"
+	testgrpc "google.golang.org/grpc/interop/grpc_testing" //lint:ignore ST1019 message and service definitions are in separate packages in google3
 	testpb "google.golang.org/grpc/interop/grpc_testing"
 )
 

--- a/xds/internal/testutils/fakeserver/server.go
+++ b/xds/internal/testutils/fakeserver/server.go
@@ -33,7 +33,7 @@ import (
 
 	discoverypb "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	adsgrpc "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2"
-	lrsgrpc "github.com/envoyproxy/go-control-plane/envoy/service/load_stats/v2"
+	lrsgrpc "github.com/envoyproxy/go-control-plane/envoy/service/load_stats/v2" //lint:ignore ST1019 message and service definitions are in separate packages in google3
 	lrspb "github.com/envoyproxy/go-control-plane/envoy/service/load_stats/v2"
 )
 

--- a/xds/internal/xdsclient/controller/transport.go
+++ b/xds/internal/xdsclient/controller/transport.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"google.golang.org/grpc"
-	controllerversion "google.golang.org/grpc/xds/internal/xdsclient/controller/version"
 	xdsresourceversion "google.golang.org/grpc/xds/internal/xdsclient/controller/version"
 	"google.golang.org/grpc/xds/internal/xdsclient/load"
 	"google.golang.org/grpc/xds/internal/xdsclient/xdsresource"
@@ -371,7 +370,7 @@ func (t *Controller) processAckInfo(ack *ackAction, stream grpc.ClientStream) (t
 
 // reportLoad starts an LRS stream to report load data to the management server.
 // It blocks until the context is cancelled.
-func (t *Controller) reportLoad(ctx context.Context, cc *grpc.ClientConn, opts controllerversion.LoadReportingOptions) {
+func (t *Controller) reportLoad(ctx context.Context, cc *grpc.ClientConn, opts xdsresourceversion.LoadReportingOptions) {
 	retries := 0
 	lastStreamStartTime := time.Time{}
 	for ctx.Err() == nil {

--- a/xds/internal/xdsclient/controller/version/v2/loadreport.go
+++ b/xds/internal/xdsclient/controller/version/v2/loadreport.go
@@ -27,15 +27,15 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/internal/pretty"
+	"google.golang.org/grpc/xds/internal"
 	"google.golang.org/grpc/xds/internal/xdsclient/load"
 
 	v2corepb "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	v2endpointpb "github.com/envoyproxy/go-control-plane/envoy/api/v2/endpoint"
-	lrsgrpc "github.com/envoyproxy/go-control-plane/envoy/service/load_stats/v2"
+	lrsgrpc "github.com/envoyproxy/go-control-plane/envoy/service/load_stats/v2" //lint:ignore ST1019 message and service definitions are in separate packages in google3
 	lrspb "github.com/envoyproxy/go-control-plane/envoy/service/load_stats/v2"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/xds/internal"
 )
 
 const clientFeatureLRSSendAllClusters = "envoy.lrs.supports_send_all_clusters"

--- a/xds/internal/xdsclient/controller/version/v3/client.go
+++ b/xds/internal/xdsclient/controller/version/v3/client.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 
 	"github.com/golang/protobuf/proto"
-	statuspb "google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/internal/grpclog"
@@ -35,8 +34,9 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 
 	v3corepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
-	v3adsgrpc "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+	v3adsgrpc "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3" //lint:ignore ST1019 message and service definitions are in separate packages in google3
 	v3discoverypb "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+	statuspb "google.golang.org/genproto/googleapis/rpc/status"
 )
 
 func init() {

--- a/xds/internal/xdsclient/controller/version/v3/loadreport.go
+++ b/xds/internal/xdsclient/controller/version/v3/loadreport.go
@@ -27,15 +27,15 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/internal/pretty"
+	"google.golang.org/grpc/xds/internal"
 	"google.golang.org/grpc/xds/internal/xdsclient/load"
 
 	v3corepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	v3endpointpb "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
-	lrsgrpc "github.com/envoyproxy/go-control-plane/envoy/service/load_stats/v3"
+	lrsgrpc "github.com/envoyproxy/go-control-plane/envoy/service/load_stats/v3" //lint:ignore ST1019 message and service definitions are in separate packages in google3
 	lrspb "github.com/envoyproxy/go-control-plane/envoy/service/load_stats/v3"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/xds/internal"
 )
 
 const clientFeatureLRSSendAllClusters = "envoy.lrs.supports_send_all_clusters"


### PR DESCRIPTION
Update `staticcheck` to the Go version listed in our go.mod.

Also, update the list of checks ignored to remove ST1015 and add ST1019. There are no warnings firing currently from ST1015 and a ton of them firing from ST1019 (because double imports of services and messages for protos).

[ST1015](https://staticcheck.io/docs/checks#ST1015): A switch’s default case should be the first or last case
[ST1019](https://staticcheck.io/docs/checks#ST1019): Importing the same package multiple times

RELEASE NOTES: none