### PR TITLE
client: remove trailing null from unix abstract socket address

### DIFF
--- a/examples/features/unix_abstract/server/main.go
+++ b/examples/features/unix_abstract/server/main.go
@@ -51,7 +51,7 @@ func (s *ecServer) UnaryEcho(ctx context.Context, req *pb.EchoRequest) (*pb.Echo
 func main() {
 	flag.Parse()
 	netw := "unix"
-	socketAddr := fmt.Sprintf("\x00%v", *addr)
+	socketAddr := fmt.Sprintf("@%v", *addr)
 	lis, err := net.Listen(netw, socketAddr)
 	if err != nil {
 		log.Fatalf("net.Listen(%q, %q) failed: %v", netw, socketAddr, err)

--- a/internal/resolver/unix/unix.go
+++ b/internal/resolver/unix/unix.go
@@ -49,8 +49,9 @@ func (b *builder) Build(target resolver.Target, cc resolver.ClientConn, _ resolv
 	}
 	addr := resolver.Address{Addr: endpoint}
 	if b.scheme == unixAbstractScheme {
-		// prepend "\x00" to address for unix-abstract
-		addr.Addr = "\x00" + addr.Addr
+		// We can not prepend \0 as c++ gRPC does, as in Golang '@' is used to signify we do
+		// not want trailing \0 in address.
+		addr.Addr = "@" + addr.Addr
 	}
 	cc.UpdateState(resolver.State{Addresses: []resolver.Address{networktype.Set(addr, "unix")}})
 	return &nopResolver{}, nil

--- a/test/authority_test.go
+++ b/test/authority_test.go
@@ -125,10 +125,10 @@ var authorityTests = []authorityTest{
 	},
 	{
 		name:           "UnixAbstract",
-		address:        "\x00abc efg",
+		address:        "@abc efg",
 		target:         "unix-abstract:abc efg",
 		authority:      "localhost",
-		dialTargetWant: "\x00abc efg",
+		dialTargetWant: "unix:@abc efg",
 	},
 }
 
@@ -155,9 +155,7 @@ func (s) TestUnixCustomDialer(t *testing.T) {
 				if address != test.dialTargetWant {
 					return nil, fmt.Errorf("expected target %v in custom dialer, instead got %v", test.dialTargetWant, address)
 				}
-				if !strings.HasPrefix(test.target, "unix-abstract:") {
-					address = address[len("unix:"):]
-				}
+				address = address[len("unix:"):]
 				return (&net.Dialer{}).DialContext(ctx, "unix", address)
 			}
 			runUnixTest(t, test.address, test.target, test.authority, dialer)


### PR DESCRIPTION
Trailing nul byte is added by golang Dial wrapper. To avoid that one should use '@socket' as address instead of '\0socket' (see [1]).

This change makes go-grpc behave like grpc/grpc (see [2]), making connecting to golang server with grpc_cli possible.

[1]: https://go.googlesource.com/sys/+/master/unix/syscall_linux.go#420
[2]: https://github.com/grpc/grpc/blob/d43511f4af992862ae17c6fce5caa3ab3ce60995/src/core/lib/address_utils/parse_address.cc#L109

RELEASE NOTES:
* client: use proper "@" semantics for connecting to abstract unix sockets.  This is technically a bug fix; the result is that the address used to include a trailing NUL byte, which it should not have.  This may break users creating the socket in Go by prefixing a NUL instead of an "@", though, so calling it out as a behavior change.