### PR TITLE
test: minor test cleanup

### DIFF
--- a/test/authority_test.go
+++ b/test/authority_test.go
@@ -98,10 +98,11 @@ type authorityTest struct {
 
 var authorityTests = []authorityTest{
 	{
-		name:      "UnixRelative",
-		address:   "sock.sock",
-		target:    "unix:sock.sock",
-		authority: "localhost",
+		name:           "UnixRelative",
+		address:        "sock.sock",
+		target:         "unix:sock.sock",
+		authority:      "localhost",
+		dialTargetWant: "unix:sock.sock",
 	},
 	{
 		name:           "UnixAbsolute",
@@ -111,10 +112,11 @@ var authorityTests = []authorityTest{
 		dialTargetWant: "unix:///tmp/sock.sock",
 	},
 	{
-		name:      "UnixAbsoluteAlternate",
-		address:   "/tmp/sock.sock",
-		target:    "unix:///tmp/sock.sock",
-		authority: "localhost",
+		name:           "UnixAbsoluteAlternate",
+		address:        "/tmp/sock.sock",
+		target:         "unix:///tmp/sock.sock",
+		authority:      "localhost",
+		dialTargetWant: "unix:///tmp/sock.sock",
 	},
 	{
 		name:           "UnixPassthrough",
@@ -148,9 +150,6 @@ func (s) TestUnix(t *testing.T) {
 func (s) TestUnixCustomDialer(t *testing.T) {
 	for _, test := range authorityTests {
 		t.Run(test.name+"WithDialer", func(t *testing.T) {
-			if test.dialTargetWant == "" {
-				test.dialTargetWant = test.target
-			}
 			dialer := func(ctx context.Context, address string) (net.Conn, error) {
 				if address != test.dialTargetWant {
 					return nil, fmt.Errorf("expected target %v in custom dialer, instead got %v", test.dialTargetWant, address)


### PR DESCRIPTION
Cleans up a minor nit I discovered while reviewing #5678.  Removes magic setting of `dialTargetWant` and set it explicitly in all test case definitions instead.