### PR TITLE
google-c2p resolver: add authority entry to bootstrap config

### DIFF
--- a/xds/googledirectpath/googlec2p.go
+++ b/xds/googledirectpath/googlec2p.go
@@ -113,7 +113,7 @@ func (c2pResolverBuilder) Build(t resolver.Target, cc resolver.ClientConn, opts 
 		Authorities: map[string]*bootstrap.Authority{
 			"traffic-director-c2p.xds.googleapis.com": &bootstrap.Authority{
 				ClientListenerResourceNameTemplate: "%s",
-				XDSServer: serverConfig,
+				XDSServer:                          serverConfig,
 			},
 		},
 	}

--- a/xds/googledirectpath/googlec2p.go
+++ b/xds/googledirectpath/googlec2p.go
@@ -112,7 +112,7 @@ func (c2pResolverBuilder) Build(t resolver.Target, cc resolver.ClientConn, opts 
 		ClientDefaultListenerResourceNameTemplate: "%s",
 		Authorities: map[string]*bootstrap.Authority{
 			"traffic-director-c2p.xds.googleapis.com": {
-				XDSServer:                          serverConfig,
+				XDSServer: serverConfig,
 			},
 		},
 	}

--- a/xds/googledirectpath/googlec2p.go
+++ b/xds/googledirectpath/googlec2p.go
@@ -111,7 +111,7 @@ func (c2pResolverBuilder) Build(t resolver.Target, cc resolver.ClientConn, opts 
 		XDSServer: serverConfig,
 		ClientDefaultListenerResourceNameTemplate: "%s",
 		Authorities: map[string]*bootstrap.Authority{
-			"traffic-director-c2p.xds.googleapis.com": &bootstrap.Authority{
+			"traffic-director-c2p.xds.googleapis.com": {
 				ClientListenerResourceNameTemplate: "%s",
 				XDSServer:                          serverConfig,
 			},

--- a/xds/googledirectpath/googlec2p.go
+++ b/xds/googledirectpath/googlec2p.go
@@ -101,14 +101,21 @@ func (c2pResolverBuilder) Build(t resolver.Target, cc resolver.ClientConn, opts 
 	if balancerName == "" {
 		balancerName = tdURL
 	}
+	serverConfig := &bootstrap.ServerConfig{
+		ServerURI:    balancerName,
+		Creds:        grpc.WithCredentialsBundle(google.NewDefaultCredentials()),
+		TransportAPI: version.TransportV3,
+		NodeProto:    newNode(<-zoneCh, <-ipv6CapableCh),
+	}
 	config := &bootstrap.Config{
-		XDSServer: &bootstrap.ServerConfig{
-			ServerURI:    balancerName,
-			Creds:        grpc.WithCredentialsBundle(google.NewDefaultCredentials()),
-			TransportAPI: version.TransportV3,
-			NodeProto:    newNode(<-zoneCh, <-ipv6CapableCh),
-		},
+		XDSServer: serverConfig,
 		ClientDefaultListenerResourceNameTemplate: "%s",
+		Authorities: {
+			"traffic-director-c2p.xds.googleapis.com": &bootstrap.Authority{
+				ClientListenerResourceNameTemplate: "%s",
+				XDSServer: serverConfig,
+			}
+		}
 	}
 
 	// Create singleton xds client with this config. The xds client will be

--- a/xds/googledirectpath/googlec2p.go
+++ b/xds/googledirectpath/googlec2p.go
@@ -110,12 +110,12 @@ func (c2pResolverBuilder) Build(t resolver.Target, cc resolver.ClientConn, opts 
 	config := &bootstrap.Config{
 		XDSServer: serverConfig,
 		ClientDefaultListenerResourceNameTemplate: "%s",
-		Authorities: {
+		Authorities: map[string]*bootstrap.Authority{
 			"traffic-director-c2p.xds.googleapis.com": &bootstrap.Authority{
 				ClientListenerResourceNameTemplate: "%s",
 				XDSServer: serverConfig,
-			}
-		}
+			},
+		},
 	}
 
 	// Create singleton xds client with this config. The xds client will be

--- a/xds/googledirectpath/googlec2p.go
+++ b/xds/googledirectpath/googlec2p.go
@@ -112,7 +112,6 @@ func (c2pResolverBuilder) Build(t resolver.Target, cc resolver.ClientConn, opts 
 		ClientDefaultListenerResourceNameTemplate: "%s",
 		Authorities: map[string]*bootstrap.Authority{
 			"traffic-director-c2p.xds.googleapis.com": {
-				ClientListenerResourceNameTemplate: "%s",
 				XDSServer:                          serverConfig,
 			},
 		},

--- a/xds/googledirectpath/googlec2p_test.go
+++ b/xds/googledirectpath/googlec2p_test.go
@@ -211,13 +211,20 @@ func TestBuildXDS(t *testing.T) {
 					},
 				}
 			}
+			serverConfig := &bootstrap.ServerConfig{
+				ServerURI:    tdURL,
+				TransportAPI: version.TransportV3,
+				NodeProto:    wantNode,
+			}
 			wantConfig := &bootstrap.Config{
-				XDSServer: &bootstrap.ServerConfig{
-					ServerURI:    tdURL,
-					TransportAPI: version.TransportV3,
-					NodeProto:    wantNode,
-				},
+				XDSServer: serverConfig,
 				ClientDefaultListenerResourceNameTemplate: "%s",
+				Authorities: map[string]*bootstrap.Authority{
+					"traffic-director-c2p.xds.googleapis.com": {
+						ClientListenerResourceNameTemplate: "%s",
+						XDSServer:                          serverConfig,
+					},
+				},
 			}
 			if tt.tdURI != "" {
 				wantConfig.XDSServer.ServerURI = tt.tdURI

--- a/xds/googledirectpath/googlec2p_test.go
+++ b/xds/googledirectpath/googlec2p_test.go
@@ -221,8 +221,7 @@ func TestBuildXDS(t *testing.T) {
 				ClientDefaultListenerResourceNameTemplate: "%s",
 				Authorities: map[string]*bootstrap.Authority{
 					"traffic-director-c2p.xds.googleapis.com": {
-						ClientListenerResourceNameTemplate: "%s",
-						XDSServer:                          serverConfig,
+						XDSServer: serverConfig,
 					},
 				},
 			}


### PR DESCRIPTION
To properly use xds federation when the env var is set.

C++ PR: https://github.com/grpc/grpc/pull/29732
Java PR: https://github.com/grpc/grpc-java/pull/9576

RELEASE NOTES: none