### PR TITLE
priority: release references to child policies which are removed

### DIFF
--- a/internal/balancergroup/balancergroup.go
+++ b/internal/balancergroup/balancergroup.go
@@ -320,7 +320,7 @@ func (bg *BalancerGroup) AddWithClientConn(id, balancerName string, cc balancer.
 	if bg.outgoingStarted {
 		if old, ok := bg.balancerCache.Remove(id); ok {
 			sbc, _ = old.(*subBalancerWrapper)
-			if sbc != nil && sbc.builder.Name() != builder.Name() {
+			if sbc != nil && sbc.builder != builder {
 				// If the sub-balancer in cache was built with a different
 				// balancer builder, don't use it, cleanup this old-balancer,
 				// and behave as sub-balancer is not found in cache.

--- a/internal/balancergroup/balancergroup_test.go
+++ b/internal/balancergroup/balancergroup_test.go
@@ -374,9 +374,17 @@ func (s) TestBalancerGroup_locality_caching_not_readd_within_timeout(t *testing.
 	}
 }
 
-// Wrap the rr builder, so it behaves the same, but has a different pointer.
+// Wrap the rr builder, so it behaves the same, but has a different name.
 type noopBalancerBuilderWrapper struct {
 	balancer.Builder
+}
+
+func init() {
+	balancer.Register(&noopBalancerBuilderWrapper{Builder: rrBuilder})
+}
+
+func (*noopBalancerBuilderWrapper) Name() string {
+	return "noopBalancerBuilderWrapper"
 }
 
 // After removing a sub-balancer, re-add with same ID, but different balancer

--- a/xds/internal/balancer/clusterimpl/clusterimpl.go
+++ b/xds/internal/balancer/clusterimpl/clusterimpl.go
@@ -331,6 +331,7 @@ func (b *clusterImplBalancer) Close() {
 	if b.childLB != nil {
 		b.childLB.Close()
 		b.childLB = nil
+		b.childState = balancer.State{}
 	}
 	<-b.done.Done()
 	b.logger.Infof("Shutdown")

--- a/xds/internal/balancer/clusterresolver/clusterresolver.go
+++ b/xds/internal/balancer/clusterresolver/clusterresolver.go
@@ -194,7 +194,6 @@ func (b *clusterResolverBalancer) handleWatchUpdate(update *resourceUpdate) {
 		return
 	}
 
-	b.logger.Infof("resource update: %+v", pretty.ToJSON(update.priorities))
 	b.watchUpdateReceived = true
 	b.priorities = update.priorities
 

--- a/xds/internal/balancer/priority/balancer.go
+++ b/xds/internal/balancer/priority/balancer.go
@@ -127,7 +127,7 @@ func (b *priorityBalancer) UpdateClientConnState(s balancer.ClientConnState) err
 			// This is a new child, add it to the children list. But note that
 			// the balancer isn't built, because this child can be a low
 			// priority. If necessary, it will be built when syncing priorities.
-			cb := newChildBalancer(name, b, bb)
+			cb := newChildBalancer(name, b, bb.Name(), b.cc)
 			cb.updateConfig(newSubConfig, resolver.State{
 				Addresses:     addressesSplit[name],
 				ServiceConfig: s.ResolverState.ServiceConfig,
@@ -141,9 +141,9 @@ func (b *priorityBalancer) UpdateClientConnState(s balancer.ClientConnState) err
 
 		// The balancing policy name is changed, close the old child. But don't
 		// rebuild, rebuild will happen when syncing priorities.
-		if currentChild.bb.Name() != bb.Name() {
+		if currentChild.balancerName != bb.Name() {
 			currentChild.stop()
-			currentChild.updateBuilder(bb)
+			currentChild.updateBalancerName(bb.Name())
 		}
 
 		// Update config and address, but note that this doesn't send the
@@ -155,10 +155,11 @@ func (b *priorityBalancer) UpdateClientConnState(s balancer.ClientConnState) err
 			Attributes:    s.ResolverState.Attributes,
 		})
 	}
-	// Remove child from children if it's not in new config.
+	// Cleanup resources used by children removed from the config.
 	for name, oldChild := range b.children {
 		if _, ok := newConfig.Children[name]; !ok {
 			oldChild.stop()
+			delete(b.children, name)
 		}
 	}
 

--- a/xds/internal/balancer/priority/balancer_priority.go
+++ b/xds/internal/balancer/priority/balancer_priority.go
@@ -163,6 +163,7 @@ func (b *priorityBalancer) handleChildStateUpdate(childName string, s balancer.S
 		return
 	}
 	if !child.started {
+		b.logger.Warningf("priority: ignoring update from child %q which is not in started state: %+v", childName, s)
 		return
 	}
 	child.state = s

--- a/xds/internal/balancer/priority/balancer_priority.go
+++ b/xds/internal/balancer/priority/balancer_priority.go
@@ -162,6 +162,9 @@ func (b *priorityBalancer) handleChildStateUpdate(childName string, s balancer.S
 		b.logger.Warningf("priority: child balancer not found for child %v", childName)
 		return
 	}
+	if !child.started {
+		return
+	}
 	child.state = s
 
 	// We start/stop the init timer of this child based on the new connectivity

--- a/xds/internal/balancer/priority/ignore_resolve_now.go
+++ b/xds/internal/balancer/priority/ignore_resolve_now.go
@@ -25,44 +25,29 @@ import (
 	"google.golang.org/grpc/resolver"
 )
 
-type ignoreResolveNowBalancerBuilder struct {
-	balancer.Builder
+// ignoreResolveNowClientConn wraps a balancer.ClientConn and overrides the
+// ResolveNow() method to ignore those calls if the ignoreResolveNow bit is set.
+type ignoreResolveNowClientConn struct {
+	balancer.ClientConn
 	ignoreResolveNow *uint32
 }
 
-// If `ignore` is true, all `ResolveNow()` from the balancer built from this
-// builder will be ignored.
-//
-// `ignore` can be updated later by `updateIgnoreResolveNow`, and the update
-// will be propagated to all the old and new balancers built with this.
-func newIgnoreResolveNowBalancerBuilder(bb balancer.Builder, ignore bool) *ignoreResolveNowBalancerBuilder {
-	ret := &ignoreResolveNowBalancerBuilder{
-		Builder:          bb,
+func newIgnoreResolveNowClientConn(cc balancer.ClientConn, ignore bool) *ignoreResolveNowClientConn {
+	ret := &ignoreResolveNowClientConn{
+		ClientConn:       cc,
 		ignoreResolveNow: new(uint32),
 	}
 	ret.updateIgnoreResolveNow(ignore)
 	return ret
 }
 
-func (irnbb *ignoreResolveNowBalancerBuilder) updateIgnoreResolveNow(b bool) {
+func (i *ignoreResolveNowClientConn) updateIgnoreResolveNow(b bool) {
 	if b {
-		atomic.StoreUint32(irnbb.ignoreResolveNow, 1)
+		atomic.StoreUint32(i.ignoreResolveNow, 1)
 		return
 	}
-	atomic.StoreUint32(irnbb.ignoreResolveNow, 0)
+	atomic.StoreUint32(i.ignoreResolveNow, 0)
 
-}
-
-func (irnbb *ignoreResolveNowBalancerBuilder) Build(cc balancer.ClientConn, opts balancer.BuildOptions) balancer.Balancer {
-	return irnbb.Builder.Build(&ignoreResolveNowClientConn{
-		ClientConn:       cc,
-		ignoreResolveNow: irnbb.ignoreResolveNow,
-	}, opts)
-}
-
-type ignoreResolveNowClientConn struct {
-	balancer.ClientConn
-	ignoreResolveNow *uint32
 }
 
 func (i ignoreResolveNowClientConn) ResolveNow(o resolver.ResolveNowOptions) {

--- a/xds/internal/balancer/ringhash/ringhash.go
+++ b/xds/internal/balancer/ringhash/ringhash.go
@@ -441,7 +441,9 @@ func (b *ringhashBalancer) regeneratePicker() {
 	b.picker = newPicker(b.ring, b.logger)
 }
 
-func (b *ringhashBalancer) Close() {}
+func (b *ringhashBalancer) Close() {
+	b.logger.Infof("Shutdown")
+}
 
 func (b *ringhashBalancer) ExitIdle() {
 	// ExitIdle implementation is a no-op because connections are either


### PR DESCRIPTION
Summary of changes:
- priority balancer
  - remove child policy wrapper from the children map when the child is removed from the configuration
  - stop caching balancer state from child policies which are not `started`
  - store the balancer name in the child policy wrapper instead of the `balancer.Builder` and pass the former to the `balancergroup` when creating child policies
  - wrap the `balancer.ClientConn` passed in from the parent before passing it to the children
    - this wrapper ignores `ResolveNow()` calls from children who are configured with the `IgnoreReresolutionRequests` field set
    - this wrapper also supports updating this field based on changes in configuration
- balancergroup:
  - add a new API to add child policies to the group. Once other lb policies are updated to use this API, it will replace the existing `Add` API
- clusterresolver:
  - release reference to cached child policy state in `Close()` 
    
RELEASE NOTES:
- priority: fix a bug where unreleased references to removed child policies (and associated state) was causing a memory leak