### PR TITLE
xdsclient: improve LDS watchers test

### DIFF
--- a/xds/internal/xdsclient/client_new.go
+++ b/xds/internal/xdsclient/client_new.go
@@ -75,8 +75,12 @@ func newWithConfig(config *bootstrap.Config, watchExpiryTimeout time.Duration, i
 // Testing Only
 //
 // This function should ONLY be used for testing purposes.
-func NewWithConfigForTesting(config *bootstrap.Config, watchExpiryTimeout time.Duration) (XDSClient, error) {
-	cl, err := newWithConfig(config, watchExpiryTimeout, defaultIdleAuthorityDeleteTimeout)
+func NewWithConfigForTesting(config *bootstrap.Config, watchExpiryTimeout, authorityIdleTimeout time.Duration) (XDSClient, error) {
+	idleTimeout := defaultIdleAuthorityDeleteTimeout
+	if authorityIdleTimeout != time.Duration(0) {
+		idleTimeout = authorityIdleTimeout
+	}
+	cl, err := newWithConfig(config, watchExpiryTimeout, idleTimeout)
 	if err != nil {
 		return nil, err
 	}

--- a/xds/internal/xdsclient/client_new.go
+++ b/xds/internal/xdsclient/client_new.go
@@ -76,11 +76,7 @@ func newWithConfig(config *bootstrap.Config, watchExpiryTimeout time.Duration, i
 //
 // This function should ONLY be used for testing purposes.
 func NewWithConfigForTesting(config *bootstrap.Config, watchExpiryTimeout, authorityIdleTimeout time.Duration) (XDSClient, error) {
-	idleTimeout := defaultIdleAuthorityDeleteTimeout
-	if authorityIdleTimeout != time.Duration(0) {
-		idleTimeout = authorityIdleTimeout
-	}
-	cl, err := newWithConfig(config, watchExpiryTimeout, idleTimeout)
+	cl, err := newWithConfig(config, watchExpiryTimeout, authorityIdleTimeout)
 	if err != nil {
 		return nil, err
 	}

--- a/xds/internal/xdsclient/dump_test.go
+++ b/xds/internal/xdsclient/dump_test.go
@@ -78,7 +78,7 @@ func (s) TestLDSConfigDump(t *testing.T) {
 			Creds:     grpc.WithTransportCredentials(insecure.NewCredentials()),
 			NodeProto: xdstestutils.EmptyNodeProtoV2,
 		},
-	}, defaultTestWatchExpiryTimeout)
+	}, defaultTestWatchExpiryTimeout, time.Duration(0))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
@@ -194,7 +194,7 @@ func (s) TestRDSConfigDump(t *testing.T) {
 			Creds:     grpc.WithTransportCredentials(insecure.NewCredentials()),
 			NodeProto: xdstestutils.EmptyNodeProtoV2,
 		},
-	}, defaultTestWatchExpiryTimeout)
+	}, defaultTestWatchExpiryTimeout, time.Duration(0))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
@@ -310,7 +310,7 @@ func (s) TestCDSConfigDump(t *testing.T) {
 			Creds:     grpc.WithTransportCredentials(insecure.NewCredentials()),
 			NodeProto: xdstestutils.EmptyNodeProtoV2,
 		},
-	}, defaultTestWatchExpiryTimeout)
+	}, defaultTestWatchExpiryTimeout, time.Duration(0))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
@@ -412,7 +412,7 @@ func (s) TestEDSConfigDump(t *testing.T) {
 			Creds:     grpc.WithTransportCredentials(insecure.NewCredentials()),
 			NodeProto: xdstestutils.EmptyNodeProtoV2,
 		},
-	}, defaultTestWatchExpiryTimeout)
+	}, defaultTestWatchExpiryTimeout, time.Duration(0))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}

--- a/xds/internal/xdsclient/e2e_test/lds_watchers_test.go
+++ b/xds/internal/xdsclient/e2e_test/lds_watchers_test.go
@@ -569,8 +569,9 @@ func (s) TestLDSWatch_ResourceCaching(t *testing.T) {
 }
 
 // TestLDSWatch_ExpiryTimerFiresBeforeResponse tests the case where the client
-// does not receive an LDS response for the request that it sends. We want the
-// watch callback to be invoked with an error once the watchExpiryTimer fires.
+// does not receive an LDS response for the request that it sends. The test
+// verifies that the watch callback is invoked with an error once the
+// watchExpiryTimer fires.
 func (s) TestLDSWatch_ExpiryTimerFiresBeforeResponse(t *testing.T) {
 	// No need to spin up a management server since we don't want the client to
 	// receive a response for the watch being registered by the test.
@@ -609,11 +610,11 @@ func (s) TestLDSWatch_ExpiryTimerFiresBeforeResponse(t *testing.T) {
 	}
 }
 
-// TestLDSWatch_ExpiryTimerFiresAfterResponse tests the case where the client
-// receives an LDS response for the request that it sends. The test verifies
-// that the timer is canceled and therefore no callback is invoked when the
-// expiry timer's duration elapses.
-func (s) TestLDSWatch_ExpiryTimerFiresAfterResponse(t *testing.T) {
+// TestLDSWatch_ValidResponseCancelsExpiryTimerBehavior tests the case where the
+// client receives a valid LDS response for the request that it sends. The test
+// verifies that the behavior associated with the expiry timer (i.e, callback
+// invocation with error) does not take place.
+func (s) TestLDSWatch_ValidResponseCancelsExpiryTimerBehavior(t *testing.T) {
 	overrideFedEnvVar(t)
 	mgmtServer, err := e2e.StartManagementServer(nil)
 	if err != nil {

--- a/xds/internal/xdsclient/e2e_test/lds_watchers_test.go
+++ b/xds/internal/xdsclient/e2e_test/lds_watchers_test.go
@@ -575,7 +575,7 @@ func (s) TestLDSWatch_ExpiryTimerFiresBeforeResponse(t *testing.T) {
 	// No need to spin up a management server since we don't want the client to
 	// receive a response for the watch being registered by the test.
 
-	// Create an xDS client talking to a non-existant management server.
+	// Create an xDS client talking to a non-existent management server.
 	client, err := xdsclient.NewWithConfigForTesting(&bootstrap.Config{
 		XDSServer: &bootstrap.ServerConfig{
 			ServerURI:    "dummy management server address",

--- a/xds/internal/xdsclient/loadreport_test.go
+++ b/xds/internal/xdsclient/loadreport_test.go
@@ -58,7 +58,7 @@ func (s) TestLRSClient(t *testing.T) {
 			TransportAPI: version.TransportV2,
 			NodeProto:    &v2corepb.Node{},
 		},
-	}, defaultClientWatchExpiryTimeout)
+	}, defaultClientWatchExpiryTimeout, time.Duration(0))
 	if err != nil {
 		t.Fatalf("failed to create xds client: %v", err)
 	}


### PR DESCRIPTION
Improve the existing LDS watchers test:
- For tests which have subtests, move the creation of the xdsclient into `t.Run()`. This will remove the flakiness we have been observing on GitHub Actions.
- Add a couple of more tests. These scenarios were being tested for some of the other xDS watchers. So, I added them here as well.
- Change the `NewWithConfigForTesting` API to allow configuring the authority idle timeout. This will be used in upcoming PRs.

#resource-agnostic-xdsclient-api

Fixes https://github.com/grpc/grpc-go/issues/5643

RELEASE NOTES: n/a