### PR TITLE
xdsclient: switch xdsclient watch deadlock test to e2e style

### DIFF
--- a/internal/testutils/xds/e2e/server.go
+++ b/internal/testutils/xds/e2e/server.go
@@ -106,8 +106,8 @@ type ManagementServerOptions struct {
 // resources allocated by the management server.
 func StartManagementServer(opts *ManagementServerOptions) (*ManagementServer, error) {
 	// Create a snapshot cache. The first parameter controls whether the server
-	// will wait for all resources to explicitly named in the request before
-	// responding to any of them.
+	// should wait for all resources to be explicitly named in the request
+	// before responding to any of them.
 	wait := true
 	if opts != nil {
 		wait = !opts.AllowResourceSubset

--- a/internal/testutils/xds/e2e/server.go
+++ b/internal/testutils/xds/e2e/server.go
@@ -105,13 +105,10 @@ type ManagementServerOptions struct {
 // logic. When the test is done, it should call the Stop() method to cleanup
 // resources allocated by the management server.
 func StartManagementServer(opts *ManagementServerOptions) (*ManagementServer, error) {
-	// Create a snapshot cache. The first parameter controls whether the server
-	// should wait for all resources to be explicitly named in the request
-	// before responding to any of them.
-	wait := true
-	if opts != nil {
-		wait = !opts.AllowResourceSubset
-	}
+	// Create a snapshot cache. The first parameter to NewSnapshotCache()
+	// controls whether the server should wait for all resources to be
+	// explicitly named in the request before responding to any of them.
+	wait := opts == nil || !opts.AllowResourceSubset
 	cache := v3cache.NewSnapshotCache(wait, v3cache.IDHash{}, serverLogger{})
 	logger.Infof("Created new snapshot cache...")
 

--- a/internal/testutils/xds/e2e/server.go
+++ b/internal/testutils/xds/e2e/server.go
@@ -60,6 +60,14 @@ type ManagementServerOptions struct {
 	// will be created and used.
 	Listener net.Listener
 
+	// AllowResourceSubSet allows the management server to respond to requests
+	// before all configured resources are explicitly named in the request. The
+	// default behavior that we want is for the management server to wait for
+	// all configured resources to be requested before responding to any of
+	// them, since this is how we have run our tests historically, and should be
+	// set to true only for tests which explicitly require the other behavior.
+	AllowResourceSubset bool
+
 	// The callbacks defined below correspond to the state of the world (sotw)
 	// version of the xDS API on the management server.
 
@@ -97,8 +105,14 @@ type ManagementServerOptions struct {
 // logic. When the test is done, it should call the Stop() method to cleanup
 // resources allocated by the management server.
 func StartManagementServer(opts *ManagementServerOptions) (*ManagementServer, error) {
-	// Create a snapshot cache.
-	cache := v3cache.NewSnapshotCache(true, v3cache.IDHash{}, serverLogger{})
+	// Create a snapshot cache. The first parameter controls whether the server
+	// will wait for all resources to explicitly named in the request before
+	// responding to any of them.
+	wait := true
+	if opts != nil {
+		wait = !opts.AllowResourceSubset
+	}
+	cache := v3cache.NewSnapshotCache(wait, v3cache.IDHash{}, serverLogger{})
 	logger.Infof("Created new snapshot cache...")
 
 	var lis net.Listener

--- a/xds/internal/xdsclient/e2e_test/misc_watchers_test.go
+++ b/xds/internal/xdsclient/e2e_test/misc_watchers_test.go
@@ -1,0 +1,168 @@
+/*
+ *
+ * Copyright 2022 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package e2e_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"google.golang.org/grpc/internal/testutils"
+	"google.golang.org/grpc/internal/testutils/xds/e2e"
+	"google.golang.org/grpc/xds/internal/xdsclient"
+	"google.golang.org/grpc/xds/internal/xdsclient/xdsresource"
+
+	v3routepb "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+)
+
+// verifyRouteConfigUpdate waits for an update to be received on the provided
+// update channel and verifies that it matches the expected update.
+//
+// Returns an error if no update is received before the context deadline expires
+// or the received update does not match the expected one.
+func verifyRouteConfigUpdate(ctx context.Context, updateCh *testutils.Channel, wantUpdate xdsresource.RouteConfigUpdateErrTuple) error {
+	u, err := updateCh.Receive(ctx)
+	if err != nil {
+		return fmt.Errorf("timeout when waiting for a route configuration resource from the management server: %v", err)
+	}
+	got := u.(xdsresource.RouteConfigUpdateErrTuple)
+	if wantUpdate.Err != nil {
+		if gotType, wantType := xdsresource.ErrType(got.Err), xdsresource.ErrType(wantUpdate.Err); gotType != wantType {
+			return fmt.Errorf("received update with error type %v, want %v", gotType, wantType)
+		}
+	}
+	cmpOpts := []cmp.Option{cmpopts.EquateEmpty(), cmpopts.IgnoreFields(xdsresource.RouteConfigUpdate{}, "Raw")}
+	if diff := cmp.Diff(wantUpdate.Update, got.Update, cmpOpts...); diff != "" {
+		return fmt.Errorf("received unepected diff in the route configuration resource update: (-want, got):\n%s", diff)
+	}
+	return nil
+}
+
+// TestWatchCallAnotherWatch covers the case where watch() is called inline by a
+// callback. It makes sure it doesn't cause a deadlock.
+func (s) TestWatchCallAnotherWatch(t *testing.T) {
+	overrideFedEnvVar(t)
+
+	// Start an xDS management server and set the option to allow it to respond
+	// to request which only specify a subset of the configured resources.
+	mgmtServer, nodeID, bootstrapContents, _, cleanup := e2e.SetupManagementServer(t, &e2e.ManagementServerOptions{AllowResourceSubset: true})
+	defer cleanup()
+
+	// Create an xDS client with the above bootstrap contents.
+	client, err := xdsclient.NewWithBootstrapContentsForTesting(bootstrapContents)
+	if err != nil {
+		t.Fatalf("Failed to create xDS client: %v", err)
+	}
+	defer client.Close()
+
+	// Configure the management server to with route configuration resources.
+	resources := e2e.UpdateOptions{
+		NodeID: nodeID,
+		Routes: []*v3routepb.RouteConfiguration{
+			e2e.DefaultRouteConfig(rdsName, ldsName, cdsName),
+			e2e.DefaultRouteConfig(rdsNameNewStyle, ldsNameNewStyle, cdsName),
+		},
+		SkipValidation: true,
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	if err := mgmtServer.Update(ctx, resources); err != nil {
+		t.Fatalf("Failed to update management server with resources: %v, err: %v", resources, err)
+	}
+
+	// Start a watch for one route configuration resource. From the watch
+	// callback of the first resource, register two more watches (one for the
+	// same resource name, which would be satisfied from the cache, and another
+	// for a different resource name, which would be satisfied from the server).
+	updateCh1 := testutils.NewChannel()
+	updateCh2 := testutils.NewChannel()
+	updateCh3 := testutils.NewChannel()
+	var rdsCancel2, rdsCancel3 func()
+	rdsCancel1 := client.WatchRouteConfig(rdsName, func(u xdsresource.RouteConfigUpdate, err error) {
+		updateCh1.Send(xdsresource.RouteConfigUpdateErrTuple{Update: u, Err: err})
+		// Watch for the same resource name.
+		rdsCancel2 = client.WatchRouteConfig(rdsName, func(u xdsresource.RouteConfigUpdate, err error) {
+			updateCh2.Send(xdsresource.RouteConfigUpdateErrTuple{Update: u, Err: err})
+		})
+		// Watch for a different resource name.
+		rdsCancel3 = client.WatchRouteConfig(rdsNameNewStyle, func(u xdsresource.RouteConfigUpdate, err error) {
+			updateCh3.Send(xdsresource.RouteConfigUpdateErrTuple{Update: u, Err: err})
+		})
+	})
+	defer rdsCancel1()
+	defer func() {
+		if rdsCancel2 != nil {
+			rdsCancel2()
+		}
+		if rdsCancel3 != nil {
+			rdsCancel3()
+		}
+	}()
+
+	// Verify the contents of the received update for the all watchers.
+	wantUpdate12 := xdsresource.RouteConfigUpdateErrTuple{
+		Update: xdsresource.RouteConfigUpdate{
+			VirtualHosts: []*xdsresource.VirtualHost{
+				{
+					Domains: []string{ldsName},
+					Routes: []*xdsresource.Route{
+						{
+							Prefix:           newStringP("/"),
+							ActionType:       xdsresource.RouteActionRoute,
+							WeightedClusters: map[string]xdsresource.WeightedCluster{cdsName: {Weight: 1}},
+						},
+					},
+				},
+			},
+		},
+	}
+	wantUpdate3 := xdsresource.RouteConfigUpdateErrTuple{
+		Update: xdsresource.RouteConfigUpdate{
+			VirtualHosts: []*xdsresource.VirtualHost{
+				{
+					Domains: []string{ldsNameNewStyle},
+					Routes: []*xdsresource.Route{
+						{
+							Prefix:           newStringP("/"),
+							ActionType:       xdsresource.RouteActionRoute,
+							WeightedClusters: map[string]xdsresource.WeightedCluster{cdsName: {Weight: 1}},
+						},
+					},
+				},
+			},
+		},
+	}
+	if err := verifyRouteConfigUpdate(ctx, updateCh1, wantUpdate12); err != nil {
+		t.Fatal(err)
+	}
+	if err := verifyRouteConfigUpdate(ctx, updateCh2, wantUpdate12); err != nil {
+		t.Fatal(err)
+	}
+	if err := verifyRouteConfigUpdate(ctx, updateCh3, wantUpdate3); err != nil {
+		t.Fatal(err)
+	}
+	rdsCancel2()
+	rdsCancel3()
+}
+
+func newStringP(s string) *string {
+	return &s
+}

--- a/xds/internal/xdsclient/e2e_test/misc_watchers_test.go
+++ b/xds/internal/xdsclient/e2e_test/misc_watchers_test.go
@@ -20,11 +20,8 @@ package e2e_test
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"google.golang.org/grpc/internal/testutils"
 	"google.golang.org/grpc/internal/testutils/xds/e2e"
 	"google.golang.org/grpc/xds/internal/xdsclient"
@@ -32,29 +29,6 @@ import (
 
 	v3routepb "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 )
-
-// verifyRouteConfigUpdate waits for an update to be received on the provided
-// update channel and verifies that it matches the expected update.
-//
-// Returns an error if no update is received before the context deadline expires
-// or the received update does not match the expected one.
-func verifyRouteConfigUpdate(ctx context.Context, updateCh *testutils.Channel, wantUpdate xdsresource.RouteConfigUpdateErrTuple) error {
-	u, err := updateCh.Receive(ctx)
-	if err != nil {
-		return fmt.Errorf("timeout when waiting for a route configuration resource from the management server: %v", err)
-	}
-	got := u.(xdsresource.RouteConfigUpdateErrTuple)
-	if wantUpdate.Err != nil {
-		if gotType, wantType := xdsresource.ErrType(got.Err), xdsresource.ErrType(wantUpdate.Err); gotType != wantType {
-			return fmt.Errorf("received update with error type %v, want %v", gotType, wantType)
-		}
-	}
-	cmpOpts := []cmp.Option{cmpopts.EquateEmpty(), cmpopts.IgnoreFields(xdsresource.RouteConfigUpdate{}, "Raw")}
-	if diff := cmp.Diff(wantUpdate.Update, got.Update, cmpOpts...); diff != "" {
-		return fmt.Errorf("received unepected diff in the route configuration resource update: (-want, got):\n%s", diff)
-	}
-	return nil
-}
 
 // TestWatchCallAnotherWatch covers the case where watch() is called inline by a
 // callback. It makes sure it doesn't cause a deadlock.
@@ -161,8 +135,4 @@ func (s) TestWatchCallAnotherWatch(t *testing.T) {
 	}
 	rdsCancel2()
 	rdsCancel3()
-}
-
-func newStringP(s string) *string {
-	return &s
 }


### PR DESCRIPTION
Improve a test which verifies that the xdsclient does not deadlock if a new watch is called inline from a watch callback, by moving to an e2e style test which verifies functionality without relying on any internal state.

This PR is similar to how the LDS watchers test was cleaned up in https://github.com/grpc/grpc-go/pull/5506.

#resource-agnostic-xdsclient-api

RELEASE NOTES: n/a