### PR TITLE
xdsclient: add a convenience type to synchronize execution of callbacks

### DIFF
--- a/xds/internal/xdsclient/callback_serializer.go
+++ b/xds/internal/xdsclient/callback_serializer.go
@@ -1,0 +1,88 @@
+/*
+ *
+ * Copyright 2022 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package xdsclient
+
+import (
+	"google.golang.org/grpc/internal/buffer"
+	"google.golang.org/grpc/internal/grpcsync"
+)
+
+// CallbackSerializer provides a mechanism to schedule callbacks in a
+// synchronized manner. It provides a FIFO guarantee on the order of execution
+// of scheduled callbacks.
+//
+// New callbacks can be scheduled by invoking the Schedule() method. To cleanup
+// resources used by the serializer and to discard any queued callbacks, the
+// Close() method needs to be called.
+//
+// This type is safe for concurrent access.
+type CallbackSerializer struct {
+	closed    *grpcsync.Event
+	done      *grpcsync.Event
+	callbacks *buffer.Unbounded
+}
+
+// NewCallbackSerializer returns a new CallbackSerializer instance.
+func NewCallbackSerializer() *CallbackSerializer {
+	t := &CallbackSerializer{
+		closed:    grpcsync.NewEvent(),
+		done:      grpcsync.NewEvent(),
+		callbacks: buffer.NewUnbounded(),
+	}
+	go t.run()
+	return t
+}
+
+// Close shuts down the CallbackSerializer. It is guaranteed that no callbacks
+// will be scheduled once this function returns. If a callback is currently
+// being executed, this functions blocks until execution of that callback
+// finishes before returning.
+func (t *CallbackSerializer) Close() {
+	if t.closed.HasFired() {
+		return
+	}
+	t.closed.Fire()
+	<-t.done.Done()
+}
+
+// Schedule adds a callback to be scheduled after existing callbacks are run.
+func (t *CallbackSerializer) Schedule(f func()) {
+	if t.closed.HasFired() {
+		return
+	}
+	t.callbacks.Put(f)
+}
+
+func (t *CallbackSerializer) run() {
+	defer func() {
+		t.done.Fire()
+	}()
+	for {
+		select {
+		case <-t.closed.Done():
+			return
+		case callback := <-t.callbacks.Get():
+			if t.closed.HasFired() {
+				return
+			}
+			t.callbacks.Load()
+			callback.(func())()
+		}
+	}
+}

--- a/xds/internal/xdsclient/callback_serializer.go
+++ b/xds/internal/xdsclient/callback_serializer.go
@@ -23,7 +23,7 @@ import (
 	"google.golang.org/grpc/internal/grpcsync"
 )
 
-// CallbackSerializer provides a mechanism to schedule callbacks in a
+// callbackSerializer provides a mechanism to schedule callbacks in a
 // synchronized manner. It provides a FIFO guarantee on the order of execution
 // of scheduled callbacks.
 //
@@ -32,15 +32,15 @@ import (
 // Close() method needs to be called.
 //
 // This type is safe for concurrent access.
-type CallbackSerializer struct {
+type callbackSerializer struct {
 	closed    *grpcsync.Event
 	done      *grpcsync.Event
 	callbacks *buffer.Unbounded
 }
 
-// NewCallbackSerializer returns a new CallbackSerializer instance.
-func NewCallbackSerializer() *CallbackSerializer {
-	t := &CallbackSerializer{
+// newCallbackSerializer returns a new CallbackSerializer instance.
+func newCallbackSerializer() *callbackSerializer {
+	t := &callbackSerializer{
 		closed:    grpcsync.NewEvent(),
 		done:      grpcsync.NewEvent(),
 		callbacks: buffer.NewUnbounded(),
@@ -53,7 +53,7 @@ func NewCallbackSerializer() *CallbackSerializer {
 // will be scheduled once this function returns. If a callback is currently
 // being executed, this functions blocks until execution of that callback
 // finishes before returning.
-func (t *CallbackSerializer) Close() {
+func (t *callbackSerializer) Close() {
 	if t.closed.HasFired() {
 		return
 	}
@@ -62,14 +62,14 @@ func (t *CallbackSerializer) Close() {
 }
 
 // Schedule adds a callback to be scheduled after existing callbacks are run.
-func (t *CallbackSerializer) Schedule(f func()) {
+func (t *callbackSerializer) Schedule(f func()) {
 	if t.closed.HasFired() {
 		return
 	}
 	t.callbacks.Put(f)
 }
 
-func (t *CallbackSerializer) run() {
+func (t *callbackSerializer) run() {
 	defer func() {
 		t.done.Fire()
 	}()

--- a/xds/internal/xdsclient/callback_serializer.go
+++ b/xds/internal/xdsclient/callback_serializer.go
@@ -37,7 +37,7 @@ type callbackSerializer struct {
 // newCallbackSerializer returns a new callbackSerializer instance. The provided
 // context will be passed to the scheduled callbacks. Users should cancel the
 // provided context to shutdown the callbackSerializer. It is guaranteed that no
-// callbacks will be scheduled once this context is canceled.
+// callbacks will be executed once this context is canceled.
 func newCallbackSerializer(ctx context.Context) *callbackSerializer {
 	t := &callbackSerializer{callbacks: buffer.NewUnbounded()}
 	go t.run(ctx)
@@ -53,7 +53,7 @@ func (t *callbackSerializer) Schedule(f func(ctx context.Context)) {
 }
 
 func (t *callbackSerializer) run(ctx context.Context) {
-	for {
+	for ctx.Err() == nil {
 		select {
 		case <-ctx.Done():
 			return

--- a/xds/internal/xdsclient/callback_serializer.go
+++ b/xds/internal/xdsclient/callback_serializer.go
@@ -75,11 +75,9 @@ func (t *callbackSerializer) Close() {
 
 // Schedule adds a callback to be scheduled after existing callbacks are run.
 func (t *callbackSerializer) Schedule(f func()) {
-	t.closedMu.Lock()
-	defer t.closedMu.Unlock()
-	if t.closed {
-		return
-	}
+	// We don't check for closed here because if the serializer is closed, the
+	// run() goroutine would have exited and therefore this callback will never
+	// be processed.
 	t.callbacks.Put(f)
 }
 

--- a/xds/internal/xdsclient/callback_serializer_test.go
+++ b/xds/internal/xdsclient/callback_serializer_test.go
@@ -1,0 +1,213 @@
+/*
+ *
+ * Copyright 2022 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package xdsclient
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/grpc/internal/grpcsync"
+)
+
+// TestCallbackSerializer_Schedule_FIFO verifies that callbacks are executed in
+// the same order in which they were scheduled.
+func (s) TestCallbackSerializer_Schedule_FIFO(t *testing.T) {
+	cs := NewCallbackSerializer()
+	defer cs.Close()
+
+	// We have two channels, one to record the order of scheduling, and the
+	// other to record the order of execution. We spawn a bunch of goroutines
+	// which record the order of scheduling and call the actual Schedule()
+	// method as well.  The callbacks record the order of execution.
+	//
+	// We need to grab a lock to record order of scheduling to guarantee that
+	// the act of recording and the act of calling Schedule() happen atomically.
+	const numCallbacks = 100
+	var mu sync.Mutex
+	scheduleOrderCh := make(chan int, numCallbacks)
+	executionOrderCh := make(chan int, numCallbacks)
+	for i := 0; i < numCallbacks; i++ {
+		go func(id int) {
+			mu.Lock()
+			defer mu.Unlock()
+			scheduleOrderCh <- id
+			cs.Schedule(func() { executionOrderCh <- id })
+		}(i)
+	}
+
+	// Spawn a couple of goroutines to capture the order or scheduling and the
+	// order of execution.
+	scheduleOrder := make([]int, numCallbacks)
+	executionOrder := make([]int, numCallbacks)
+	var wg sync.WaitGroup
+	wg.Add(2)
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < numCallbacks; i++ {
+			select {
+			case <-ctx.Done():
+				return
+			case id := <-scheduleOrderCh:
+				scheduleOrder[i] = id
+			}
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < numCallbacks; i++ {
+			select {
+			case <-ctx.Done():
+				return
+			case id := <-executionOrderCh:
+				executionOrder[i] = id
+			}
+		}
+	}()
+	wg.Wait()
+
+	if diff := cmp.Diff(executionOrder, scheduleOrder); diff != "" {
+		t.Fatalf("Callbacks are not executed in scheduled order. diff(-want, +got):\n%s", diff)
+	}
+}
+
+// TestCallbackSerializer_Schedule_RunToCompletion verifies that all scheduled
+// callbacks are run to completion.
+func (s) TestCallbackSerializer_Schedule_RunToCompletion(t *testing.T) {
+	cs := NewCallbackSerializer()
+	defer cs.Close()
+
+	// We have two channels, one to record the order of scheduling, and the
+	// other to record the order of execution. We spawn a bunch of goroutines
+	// which record the order of scheduling and call the actual Schedule()
+	// method as well.  The callbacks record the order of execution.
+	//
+	// The act of recording the schedule and the act of calling Schedule() are
+	// not guaranteed to happen atomically.
+	const numCallbacks = 100
+	scheduleOrderCh := make(chan int, numCallbacks)
+	executionOrderCh := make(chan int, numCallbacks)
+	for i := 0; i < numCallbacks; i++ {
+		go func(id int) {
+			scheduleOrderCh <- id
+			cs.Schedule(func() { executionOrderCh <- id })
+		}(i)
+	}
+
+	// Spawn a couple of goroutines to capture the order or scheduling and the
+	// order of execution.
+	scheduleOrder := make([]int, numCallbacks)
+	executionOrder := make([]int, numCallbacks)
+	var wg sync.WaitGroup
+	wg.Add(2)
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < numCallbacks; i++ {
+			select {
+			case <-ctx.Done():
+				return
+			case id := <-scheduleOrderCh:
+				scheduleOrder[i] = id
+			}
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < numCallbacks; i++ {
+			select {
+			case <-ctx.Done():
+				return
+			case id := <-executionOrderCh:
+				executionOrder[i] = id
+			}
+		}
+	}()
+	wg.Wait()
+
+	sort.Ints(scheduleOrder)
+	sort.Ints(executionOrder)
+	if diff := cmp.Diff(executionOrder, scheduleOrder); diff != "" {
+		t.Fatalf("Not all scheduled callbacks are executed. diff(-want, +got):\n%s", diff)
+	}
+}
+
+// TestCallbackSerializer_Schedule_Close verifies that callbacks in the queue
+// are not executed once Close() returns.
+func (s) TestCallbackSerializer_Schedule_Close(t *testing.T) {
+	cs := NewCallbackSerializer()
+
+	// Schedule a callback which blocks until signalled by the test to finish.
+	firstCallbackStartedCh := make(chan struct{})
+	firstCallbackBlockCh := make(chan struct{})
+	firstCallbackFinishCh := make(chan struct{})
+	cs.Schedule(func() {
+		close(firstCallbackStartedCh)
+		<-firstCallbackBlockCh
+		close(firstCallbackFinishCh)
+	})
+
+	// Wait for the first callback to start before scheduling the others.
+	<-firstCallbackStartedCh
+
+	// Schedule a bunch of callbacks. These should not be exeuted since the first
+	// one started earlier is blocked.
+	const numCallbacks = 10
+	errCh := make(chan error, numCallbacks)
+	closeReturned := grpcsync.NewEvent()
+	for i := 0; i < numCallbacks; i++ {
+		cs.Schedule(func() {
+			if closeReturned.HasFired() {
+				errCh <- fmt.Errorf("callback %d executed when not expected to", i)
+			}
+		})
+	}
+
+	// Ensure that none of the newer callbacks are executed at this point.
+	select {
+	case <-time.After(defaultTestShortTimeout):
+	case err := <-errCh:
+		t.Fatal(err)
+	}
+
+	// Close will block until the first callback finishes. There is no way to
+	// ensure that the call to Close() in the below goroutines happens before we
+	// unblock the first callback. The best we can do is to ensure that once Close()
+	// returns, none of the other callbacks are executed.
+	go func() {
+		cs.Close()
+		closeReturned.Done()
+	}()
+	close(firstCallbackBlockCh)
+
+	<-firstCallbackFinishCh
+	// Ensure that the newer callbacks are not executed.
+	select {
+	case <-time.After(defaultTestShortTimeout):
+	case err := <-errCh:
+		t.Fatal(err)
+	}
+}

--- a/xds/internal/xdsclient/callback_serializer_test.go
+++ b/xds/internal/xdsclient/callback_serializer_test.go
@@ -33,7 +33,7 @@ import (
 // TestCallbackSerializer_Schedule_FIFO verifies that callbacks are executed in
 // the same order in which they were scheduled.
 func (s) TestCallbackSerializer_Schedule_FIFO(t *testing.T) {
-	cs := NewCallbackSerializer()
+	cs := newCallbackSerializer()
 	defer cs.Close()
 
 	// We have two channels, one to record the order of scheduling, and the
@@ -96,7 +96,7 @@ func (s) TestCallbackSerializer_Schedule_FIFO(t *testing.T) {
 // TestCallbackSerializer_Schedule_RunToCompletion verifies that all scheduled
 // callbacks are run to completion.
 func (s) TestCallbackSerializer_Schedule_RunToCompletion(t *testing.T) {
-	cs := NewCallbackSerializer()
+	cs := newCallbackSerializer()
 	defer cs.Close()
 
 	// We have two channels, one to record the order of scheduling, and the
@@ -158,7 +158,7 @@ func (s) TestCallbackSerializer_Schedule_RunToCompletion(t *testing.T) {
 // TestCallbackSerializer_Schedule_Close verifies that callbacks in the queue
 // are not executed once Close() returns.
 func (s) TestCallbackSerializer_Schedule_Close(t *testing.T) {
-	cs := NewCallbackSerializer()
+	cs := newCallbackSerializer()
 
 	// Schedule a callback which blocks until signalled by the test to finish.
 	firstCallbackStartedCh := make(chan struct{})


### PR DESCRIPTION
We need to guarantee that callbacks scheduled by the xDS client are executed in the order in which they were scheduled. Currently, this is not exactly the case and is the reason for https://github.com/grpc/grpc-go/issues/5429.

This type will get used by the xDS client as part of the refactor effort to support a resource agnostic watch API.

#resource-agnostic-xdsclient-api

RELEASE NOTES: none