### PR TITLE
xds: de-experimentalize google c2p resolver

### DIFF
--- a/xds/googledirectpath/googlec2p.go
+++ b/xds/googledirectpath/googlec2p.go
@@ -47,7 +47,8 @@ import (
 )
 
 const (
-	c2pScheme = "google-c2p-experimental"
+	c2pScheme             = "google-c2p"
+	c2pExperimentalScheme = "google-c2p-experimental"
 
 	tdURL          = "dns:///directpath-pa.googleapis.com"
 	httpReqTimeout = 10 * time.Second
@@ -75,10 +76,18 @@ var (
 )
 
 func init() {
-	resolver.Register(c2pResolverBuilder{})
+	resolver.Register(c2pResolverBuilder{
+		scheme: c2pScheme,
+	})
+	// TODO(apolcyn): remove this experimental scheme before the 1.52 release
+	resolver.Register(c2pResolverBuilder{
+		scheme: c2pExperimentalScheme,
+	})
 }
 
-type c2pResolverBuilder struct{}
+type c2pResolverBuilder struct {
+	scheme string
+}
 
 func (c2pResolverBuilder) Build(t resolver.Target, cc resolver.ClientConn, opts resolver.BuildOptions) (resolver.Resolver, error) {
 	if !runDirectPath() {
@@ -131,8 +140,8 @@ func (c2pResolverBuilder) Build(t resolver.Target, cc resolver.ClientConn, opts 
 	}, nil
 }
 
-func (c2pResolverBuilder) Scheme() string {
-	return c2pScheme
+func (b *c2pResolverBuilder) Scheme() string {
+	return b.scheme
 }
 
 type c2pResolver struct {

--- a/xds/googledirectpath/googlec2p.go
+++ b/xds/googledirectpath/googlec2p.go
@@ -140,7 +140,7 @@ func (c2pResolverBuilder) Build(t resolver.Target, cc resolver.ClientConn, opts 
 	}, nil
 }
 
-func (b *c2pResolverBuilder) Scheme() string {
+func (b c2pResolverBuilder) Scheme() string {
 	return b.scheme
 }
 


### PR DESCRIPTION
Integration tests are passing and known issues are fixed.

Note this PR keeps around the old "-experimental" scheme - the plan is to remove it after removing all usage of it (within the next release cycle or so).

Java PR: https://github.com/grpc/grpc-java/pull/9464
C++: https://github.com/grpc/grpc/pull/30653

RELEASE NOTES:
- xds: de-experimentalize the google-c2p-resolver