### PR TITLE
xds: move bootstrap config generating utility package to testutils

### DIFF
--- a/admin/test/utils.go
+++ b/admin/test/utils.go
@@ -26,16 +26,17 @@ import (
 	"testing"
 	"time"
 
-	v3statusgrpc "github.com/envoyproxy/go-control-plane/envoy/service/status/v3"
-	v3statuspb "github.com/envoyproxy/go-control-plane/envoy/service/status/v3"
 	"github.com/google/uuid"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/admin"
-	channelzpb "google.golang.org/grpc/channelz/grpc_channelz_v1"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
-	"google.golang.org/grpc/internal/xds"
+	"google.golang.org/grpc/internal/testutils/xds/bootstrap"
 	"google.golang.org/grpc/status"
+
+	v3statusgrpc "github.com/envoyproxy/go-control-plane/envoy/service/status/v3"
+	v3statuspb "github.com/envoyproxy/go-control-plane/envoy/service/status/v3"
+	channelzpb "google.golang.org/grpc/channelz/grpc_channelz_v1"
 )
 
 const (
@@ -53,8 +54,8 @@ type ExpectedStatusCodes struct {
 // codes.
 func RunRegisterTests(t *testing.T, ec ExpectedStatusCodes) {
 	nodeID := uuid.New().String()
-	bootstrapCleanup, err := xds.SetupBootstrapFile(xds.BootstrapOptions{
-		Version:   xds.TransportV3,
+	bootstrapCleanup, err := bootstrap.CreateFile(bootstrap.Options{
+		Version:   bootstrap.TransportV3,
 		NodeID:    nodeID,
 		ServerURI: "no.need.for.a.server",
 	})

--- a/internal/testutils/xds/bootstrap/bootstrap.go
+++ b/internal/testutils/xds/bootstrap/bootstrap.go
@@ -16,9 +16,8 @@
  *
  */
 
-// Package xds contains types that need to be shared between code under
-// google.golang.org/grpc/xds/... and the rest of gRPC.
-package xds
+// Package bootstrap provides functionality to generate bootstrap configuration.
+package bootstrap
 
 import (
 	"encoding/json"
@@ -42,8 +41,8 @@ const (
 	TransportV3
 )
 
-// BootstrapOptions wraps the parameters passed to SetupBootstrapFile.
-type BootstrapOptions struct {
+// Options wraps the parameters used to generate bootstrap configuration.
+type Options struct {
 	// Version is the xDS transport protocol version.
 	Version TransportAPI
 	// NodeID is the node identifier of the gRPC client/server node in the
@@ -70,15 +69,15 @@ type BootstrapOptions struct {
 	Authorities map[string]string
 }
 
-// SetupBootstrapFile creates a temporary file with bootstrap contents, based on
-// the passed in options, and updates the bootstrap environment variable to
-// point to this file.
+// CreateFile creates a temporary file with bootstrap contents, based on the
+// passed in options, and updates the bootstrap environment variable to point to
+// this file.
 //
 // Returns a cleanup function which will be non-nil if the setup process was
 // completed successfully. It is the responsibility of the caller to invoke the
 // cleanup function at the end of the test.
-func SetupBootstrapFile(opts BootstrapOptions) (func(), error) {
-	bootstrapContents, err := BootstrapContents(opts)
+func CreateFile(opts Options) (func(), error) {
+	bootstrapContents, err := Contents(opts)
 	if err != nil {
 		return nil, err
 	}
@@ -100,10 +99,9 @@ func SetupBootstrapFile(opts BootstrapOptions) (func(), error) {
 	}, nil
 }
 
-// BootstrapContents returns the contents to go into a bootstrap file,
-// environment, or configuration passed to
-// xds.NewXDSResolverWithConfigForTesting.
-func BootstrapContents(opts BootstrapOptions) ([]byte, error) {
+// Contents returns the contents to go into a bootstrap file, environment, or
+// configuration passed to xds.NewXDSResolverWithConfigForTesting.
+func Contents(opts Options) ([]byte, error) {
 	cfg := &bootstrapConfig{
 		XdsServers: []server{
 			{

--- a/internal/testutils/xds/e2e/setup_management_server.go
+++ b/internal/testutils/xds/e2e/setup_management_server.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/google/uuid"
 	"google.golang.org/grpc/internal"
-	xdsinternal "google.golang.org/grpc/internal/xds"
+	"google.golang.org/grpc/internal/testutils/xds/bootstrap"
 	"google.golang.org/grpc/resolver"
 )
 
@@ -78,8 +78,8 @@ func SetupManagementServer(t *testing.T, opts *ManagementServerOptions) (*Manage
 
 	// Create a bootstrap file in a temporary directory.
 	nodeID := uuid.New().String()
-	bootstrapContents, err := xdsinternal.BootstrapContents(xdsinternal.BootstrapOptions{
-		Version:                            xdsinternal.TransportV3,
+	bootstrapContents, err := bootstrap.Contents(bootstrap.Options{
+		Version:                            bootstrap.TransportV3,
 		NodeID:                             nodeID,
 		ServerURI:                          server.Address,
 		CertificateProviders:               cpc,

--- a/test/xds/xds_client_federation_test.go
+++ b/test/xds/xds_client_federation_test.go
@@ -23,18 +23,19 @@ import (
 	"fmt"
 	"testing"
 
-	v3clusterpb "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
-	v3endpointpb "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
-	v3listenerpb "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
-	v3routepb "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	"github.com/google/uuid"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/internal"
 	"google.golang.org/grpc/internal/envconfig"
+	"google.golang.org/grpc/internal/testutils/xds/bootstrap"
 	"google.golang.org/grpc/internal/testutils/xds/e2e"
-	xdsinternal "google.golang.org/grpc/internal/xds"
 	"google.golang.org/grpc/resolver"
+
+	v3clusterpb "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	v3endpointpb "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
+	v3listenerpb "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	v3routepb "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	testgrpc "google.golang.org/grpc/test/grpc_testing"
 	testpb "google.golang.org/grpc/test/grpc_testing"
 )
@@ -69,8 +70,8 @@ func (s) TestClientSideFederation(t *testing.T) {
 
 	// Create a bootstrap file in a temporary directory.
 	nodeID := uuid.New().String()
-	bootstrapContents, err := xdsinternal.BootstrapContents(xdsinternal.BootstrapOptions{
-		Version:                            xdsinternal.TransportV3,
+	bootstrapContents, err := bootstrap.Contents(bootstrap.Options{
+		Version:                            bootstrap.TransportV3,
 		NodeID:                             nodeID,
 		ServerURI:                          serverDefaultAuth.Address,
 		ServerListenerResourceNameTemplate: e2e.ServerListenerResourceNameTemplate,

--- a/xds/csds/csds_test.go
+++ b/xds/csds/csds_test.go
@@ -33,8 +33,8 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/internal/grpctest"
 	"google.golang.org/grpc/internal/testutils"
+	"google.golang.org/grpc/internal/testutils/xds/bootstrap"
 	"google.golang.org/grpc/internal/testutils/xds/e2e"
-	"google.golang.org/grpc/internal/xds"
 	_ "google.golang.org/grpc/xds/internal/httpfilter/router"
 	"google.golang.org/grpc/xds/internal/xdsclient"
 	"google.golang.org/grpc/xds/internal/xdsclient/xdsresource"
@@ -242,8 +242,8 @@ func commonSetup(ctx context.Context, t *testing.T) (xdsclient.XDSClient, *e2e.M
 	}
 
 	// Create a bootstrap file in a temporary directory.
-	bootstrapCleanup, err := xds.SetupBootstrapFile(xds.BootstrapOptions{
-		Version:   xds.TransportV3,
+	bootstrapCleanup, err := bootstrap.CreateFile(bootstrap.Options{
+		Version:   bootstrap.TransportV3,
 		NodeID:    nodeID,
 		ServerURI: fs.Address,
 	})

--- a/xds/internal/httpfilter/fault/fault_test.go
+++ b/xds/internal/httpfilter/fault/fault_test.go
@@ -39,8 +39,8 @@ import (
 	"google.golang.org/grpc/internal/grpcrand"
 	"google.golang.org/grpc/internal/grpctest"
 	"google.golang.org/grpc/internal/testutils"
+	"google.golang.org/grpc/internal/testutils/xds/bootstrap"
 	"google.golang.org/grpc/internal/testutils/xds/e2e"
-	"google.golang.org/grpc/internal/xds"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/wrapperspb"
@@ -106,8 +106,8 @@ func clientSetup(t *testing.T) (*e2e.ManagementServer, string, uint32, func()) {
 	}
 
 	// Create a bootstrap file in a temporary directory.
-	bootstrapCleanup, err := xds.SetupBootstrapFile(xds.BootstrapOptions{
-		Version:                            xds.TransportV3,
+	bootstrapCleanup, err := bootstrap.CreateFile(bootstrap.Options{
+		Version:                            bootstrap.TransportV3,
 		NodeID:                             nodeID,
 		ServerURI:                          fs.Address,
 		ServerListenerResourceNameTemplate: "grpc/server",

--- a/xds/internal/test/e2e/controlplane.go
+++ b/xds/internal/test/e2e/controlplane.go
@@ -21,8 +21,8 @@ import (
 	"fmt"
 
 	"github.com/google/uuid"
+	"google.golang.org/grpc/internal/testutils/xds/bootstrap"
 	"google.golang.org/grpc/internal/testutils/xds/e2e"
-	xdsinternal "google.golang.org/grpc/internal/xds"
 )
 
 type controlPlane struct {
@@ -39,8 +39,8 @@ func newControlPlane() (*controlPlane, error) {
 	}
 
 	nodeID := uuid.New().String()
-	bootstrapContentBytes, err := xdsinternal.BootstrapContents(xdsinternal.BootstrapOptions{
-		Version:                            xdsinternal.TransportV3,
+	bootstrapContentBytes, err := bootstrap.Contents(bootstrap.Options{
+		Version:                            bootstrap.TransportV3,
 		NodeID:                             nodeID,
 		ServerURI:                          server.Address,
 		ServerListenerResourceNameTemplate: e2e.ServerListenerResourceNameTemplate,


### PR DESCRIPTION
We have a utility package to generate bootstrap configuration. This is being used only by tests, and I don't see them being used by non-test code. This PR moves this package out of `internal/xds` to `internal/testutils/xds/bootstrap`.

RELEASE NOTES: none