### PR TITLE
xds/xdsclient: add EDS resource endpoint address duplication check

### DIFF
--- a/xds/internal/xdsclient/xdsresource/unmarshal_eds_test.go
+++ b/xds/internal/xdsclient/xdsresource/unmarshal_eds_test.go
@@ -112,6 +112,17 @@ func (s) TestEDSParseRespProto(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "duplicate endpoint address",
+			m: func() *v3endpointpb.ClusterLoadAssignment {
+				clab0 := newClaBuilder("test", nil)
+				clab0.addLocality("locality-1", 1, 1, []string{"addr:997"}, nil)
+				clab0.addLocality("locality-2", 1, 0, []string{"addr:997"}, nil)
+				return clab0.Build()
+			}(),
+			want:    EndpointsUpdate{},
+			wantErr: true,
+		},
+		{
 			name: "good",
 			m: func() *v3endpointpb.ClusterLoadAssignment {
 				clab0 := newClaBuilder("test", nil)


### PR DESCRIPTION
This PR adds a check if EDS resource contains a duplicate endpoint with the same address.

Fixes https://github.com/grpc/grpc-go/issues/5710

RELEASE NOTES:
- xds: comply with recent change in xDS spec to NACK EDS resources with duplicate addresses