### PR TITLE
o11y: Fixed o11y bug

### DIFF
--- a/server.go
+++ b/server.go
@@ -74,7 +74,7 @@ func init() {
 		srv.drainServerTransports(addr)
 	}
 	internal.AddGlobalServerOptions = func(opt ...ServerOption) {
-		extraServerOptions = opt
+		extraServerOptions = append(extraServerOptions, opt...)
 	}
 	internal.ClearGlobalServerOptions = func() {
 		extraServerOptions = nil


### PR DESCRIPTION
This PR fixes an o11y bug which was preventing server side traces and metrics from being recorded due to the server option being overwritten by the binary logger global server option. It should append, not replace.

RELEASE NOTES: N/A