### PR TITLE
clientconn: return error if dial target is empty with no custom dialer

### DIFF
--- a/clientconn.go
+++ b/clientconn.go
@@ -1577,6 +1577,10 @@ func (cc *ClientConn) connectionError() error {
 func (cc *ClientConn) parseTargetAndFindResolver() (resolver.Builder, error) {
 	channelz.Infof(logger, cc.channelzID, "original dial target is: %q", cc.target)
 
+	if cc.target == "" && cc.dopts.copts.Dialer == nil {
+		return nil, errors.New("grpc: empty dial target")
+	}
+
 	var rb resolver.Builder
 	parsedTarget, err := parseTarget(cc.target)
 	if err != nil {

--- a/clientconn_parsed_target_test.go
+++ b/clientconn_parsed_target_test.go
@@ -40,7 +40,6 @@ func (s) TestParsedTarget_Success_WithoutCustomDialer(t *testing.T) {
 		wantParsed resolver.Target
 	}{
 		// No scheme is specified.
-		{target: "", badScheme: true, wantParsed: resolver.Target{Scheme: defScheme, Authority: "", Endpoint: ""}},
 		{target: "://", badScheme: true, wantParsed: resolver.Target{Scheme: defScheme, Authority: "", Endpoint: "://"}},
 		{target: ":///", badScheme: true, wantParsed: resolver.Target{Scheme: defScheme, Authority: "", Endpoint: ":///"}},
 		{target: "://a/", badScheme: true, wantParsed: resolver.Target{Scheme: defScheme, Authority: "", Endpoint: "://a/"}},
@@ -110,6 +109,7 @@ func (s) TestParsedTarget_Success_WithoutCustomDialer(t *testing.T) {
 
 func (s) TestParsedTarget_Failure_WithoutCustomDialer(t *testing.T) {
 	targets := []string{
+		"",
 		"unix://a/b/c",
 		"unix://authority",
 		"unix-abstract://authority/a/b/c",
@@ -178,6 +178,12 @@ func (s) TestParsedTarget_WithCustomDialer(t *testing.T) {
 			badScheme:         true,
 			wantParsed:        resolver.Target{Scheme: defScheme, Authority: "", Endpoint: "/unix/socket/address"},
 			wantDialerAddress: "/unix/socket/address",
+		},
+		{
+			target:            "",
+			badScheme:         true,
+			wantParsed:        resolver.Target{Scheme: defScheme, Authority: "", Endpoint: ""},
+			wantDialerAddress: "",
 		},
 		{
 			target:            "passthrough://a.server.com/google.com",


### PR DESCRIPTION
Empty string is clearly not a valid target when no custom dialer set. But `grpc.Dial` will not return error in this case until client starts making RPCs,  user will get errors saying `transport: Error while dialing dial tcp: missing address`.

It would be better fail fast and notify user empty target is invalid before RPC calls.

This PR fixes this issue by checking 1. is target empty 2. is there a custom dialer in `parseTargetAndFindResolver`, if target is empty and there is no custom dialer, an error will be returned.

