### PR TITLE
tests: refactor tests to use testutils helper functions

### DIFF
--- a/balancer/weightedtarget/weightedtarget_test.go
+++ b/balancer/weightedtarget/weightedtarget_test.go
@@ -612,7 +612,7 @@ func (s) TestWeightedTarget_TwoSubBalancers_MoreBackends(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
 	if err := cc.WaitForPicker(ctx, pickAndCheckError(wantSubConnErr)); err != nil {
-		t.Fatal(err.Error())
+		t.Fatal(err)
 	}
 }
 
@@ -854,7 +854,7 @@ func (s) TestWeightedTarget_ThreeSubBalancers_RemoveBalancer(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
 	if err := cc.WaitForPicker(ctx, pickAndCheckError(wantSubConnErr)); err != nil {
-		t.Fatal(err.Error())
+		t.Fatal(err)
 	}
 }
 

--- a/balancer/weightedtarget/weightedtarget_test.go
+++ b/balancer/weightedtarget/weightedtarget_test.go
@@ -19,6 +19,7 @@
 package weightedtarget
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -40,6 +41,10 @@ import (
 	"google.golang.org/grpc/serviceconfig"
 )
 
+const (
+	defaultTestTimeout = 5 * time.Second
+)
+
 type s struct {
 	grpctest.Tester
 }
@@ -55,6 +60,17 @@ type testConfigBalancerBuilder struct {
 func newTestConfigBalancerBuilder() *testConfigBalancerBuilder {
 	return &testConfigBalancerBuilder{
 		Builder: balancer.Get(roundrobin.Name),
+	}
+}
+
+func makeRPCsAndAssertContainsError(rpcCount int, want error) func(balancer.Picker) error {
+	return func(p balancer.Picker) error {
+		for i := 0; i < rpcCount; i++ {
+			if _, err := p.Pick(balancer.PickInfo{}); !strings.Contains(err.Error(), want.Error()) {
+				return fmt.Errorf("want pick error to contain %q, got %q", want, err)
+			}
+		}
+		return nil
 	}
 }
 
@@ -289,13 +305,6 @@ func (s) TestWeightedTarget(t *testing.T) {
 	}
 }
 
-func subConnFromPicker(p balancer.Picker) func() balancer.SubConn {
-	return func() balancer.SubConn {
-		scst, _ := p.Pick(balancer.PickInfo{})
-		return scst.SubConn
-	}
-}
-
 // TestWeightedTarget_OneSubBalancer_AddRemoveBackend tests the case where we
 // have a weighted target balancer will one sub-balancer, and we add and remove
 // backends from the subBalancer.
@@ -366,7 +375,7 @@ func (s) TestWeightedTarget_OneSubBalancer_AddRemoveBackend(t *testing.T) {
 
 	// Test round robin pick.
 	want := []balancer.SubConn{sc1, sc2}
-	if err := testutils.IsRoundRobin(want, subConnFromPicker(p)); err != nil {
+	if err := testutils.IsRoundRobin(want, testutils.SubConnFromPicker(p)); err != nil {
 		t.Fatalf("want %v, got %v", want, err)
 	}
 
@@ -455,7 +464,7 @@ func (s) TestWeightedTarget_TwoSubBalancers_OneBackend(t *testing.T) {
 
 	// Test roundrobin on the last picker.
 	want := []balancer.SubConn{sc1, sc2}
-	if err := testutils.IsRoundRobin(want, subConnFromPicker(p)); err != nil {
+	if err := testutils.IsRoundRobin(want, testutils.SubConnFromPicker(p)); err != nil {
 		t.Fatalf("want %v, got %v", want, err)
 	}
 }
@@ -536,7 +545,7 @@ func (s) TestWeightedTarget_TwoSubBalancers_MoreBackends(t *testing.T) {
 	// Test roundrobin on the last picker. RPCs should be sent equally to all
 	// backends.
 	want := []balancer.SubConn{sc1, sc2, sc3, sc4}
-	if err := testutils.IsRoundRobin(want, subConnFromPicker(p)); err != nil {
+	if err := testutils.IsRoundRobin(want, testutils.SubConnFromPicker(p)); err != nil {
 		t.Fatalf("want %v, got %v", want, err)
 	}
 
@@ -544,7 +553,7 @@ func (s) TestWeightedTarget_TwoSubBalancers_MoreBackends(t *testing.T) {
 	wtb.UpdateSubConnState(sc2, balancer.SubConnState{ConnectivityState: connectivity.TransientFailure})
 	p = <-cc.NewPickerCh
 	want = []balancer.SubConn{sc1, sc1, sc3, sc4}
-	if err := testutils.IsRoundRobin(want, subConnFromPicker(p)); err != nil {
+	if err := testutils.IsRoundRobin(want, testutils.SubConnFromPicker(p)); err != nil {
 		t.Fatalf("want %v, got %v", want, err)
 	}
 
@@ -566,19 +575,19 @@ func (s) TestWeightedTarget_TwoSubBalancers_MoreBackends(t *testing.T) {
 	wtb.UpdateSubConnState(scRemoved, balancer.SubConnState{ConnectivityState: connectivity.Shutdown})
 	p = <-cc.NewPickerCh
 	want = []balancer.SubConn{sc1, sc4}
-	if err := testutils.IsRoundRobin(want, subConnFromPicker(p)); err != nil {
+	if err := testutils.IsRoundRobin(want, testutils.SubConnFromPicker(p)); err != nil {
 		t.Fatalf("want %v, got %v", want, err)
 	}
 
 	// Turn sc1's connection down.
-	scConnErr := errors.New("subConn connection error")
+	wantSubConnErr := errors.New("subConn connection error")
 	wtb.UpdateSubConnState(sc1, balancer.SubConnState{
 		ConnectivityState: connectivity.TransientFailure,
-		ConnectionError:   scConnErr,
+		ConnectionError:   wantSubConnErr,
 	})
 	p = <-cc.NewPickerCh
 	want = []balancer.SubConn{sc4}
-	if err := testutils.IsRoundRobin(want, subConnFromPicker(p)); err != nil {
+	if err := testutils.IsRoundRobin(want, testutils.SubConnFromPicker(p)); err != nil {
 		t.Fatalf("want %v, got %v", want, err)
 	}
 
@@ -594,13 +603,14 @@ func (s) TestWeightedTarget_TwoSubBalancers_MoreBackends(t *testing.T) {
 	// Turn all connections down.
 	wtb.UpdateSubConnState(sc4, balancer.SubConnState{
 		ConnectivityState: connectivity.TransientFailure,
-		ConnectionError:   scConnErr,
+		ConnectionError:   wantSubConnErr,
 	})
-	p = <-cc.NewPickerCh
-	for i := 0; i < 5; i++ {
-		if _, err := p.Pick(balancer.PickInfo{}); err == nil || !strings.Contains(err.Error(), scConnErr.Error()) {
-			t.Fatalf("want pick error %q, got error %q", scConnErr, err)
-		}
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+
+	if err := cc.WaitForPicker(ctx, makeRPCsAndAssertContainsError(5, wantSubConnErr)); err != nil {
+		t.Fatal(err.Error())
 	}
 }
 
@@ -680,7 +690,7 @@ func (s) TestWeightedTarget_TwoSubBalancers_DifferentWeight_MoreBackends(t *test
 	// Test roundrobin on the last picker. Twice the number of RPCs should be
 	// sent to cluster_1 when compared to cluster_2.
 	want := []balancer.SubConn{sc1, sc1, sc2, sc2, sc3, sc4}
-	if err := testutils.IsRoundRobin(want, subConnFromPicker(p)); err != nil {
+	if err := testutils.IsRoundRobin(want, testutils.SubConnFromPicker(p)); err != nil {
 		t.Fatalf("want %v, got %v", want, err)
 	}
 }
@@ -757,7 +767,7 @@ func (s) TestWeightedTarget_ThreeSubBalancers_RemoveBalancer(t *testing.T) {
 	p := <-cc.NewPickerCh
 
 	want := []balancer.SubConn{sc1, sc2, sc3}
-	if err := testutils.IsRoundRobin(want, subConnFromPicker(p)); err != nil {
+	if err := testutils.IsRoundRobin(want, testutils.SubConnFromPicker(p)); err != nil {
 		t.Fatalf("want %v, got %v", want, err)
 	}
 
@@ -797,15 +807,15 @@ func (s) TestWeightedTarget_ThreeSubBalancers_RemoveBalancer(t *testing.T) {
 		t.Fatalf("RemoveSubConn, want %v, got %v", sc2, scRemoved)
 	}
 	want = []balancer.SubConn{sc1, sc3}
-	if err := testutils.IsRoundRobin(want, subConnFromPicker(p)); err != nil {
+	if err := testutils.IsRoundRobin(want, testutils.SubConnFromPicker(p)); err != nil {
 		t.Fatalf("want %v, got %v", want, err)
 	}
 
 	// Move balancer 3 into transient failure.
-	scConnErr := errors.New("subConn connection error")
+	wantSubConnErr := errors.New("subConn connection error")
 	wtb.UpdateSubConnState(sc3, balancer.SubConnState{
 		ConnectivityState: connectivity.TransientFailure,
-		ConnectionError:   scConnErr,
+		ConnectionError:   wantSubConnErr,
 	})
 	<-cc.NewPickerCh
 
@@ -833,16 +843,17 @@ func (s) TestWeightedTarget_ThreeSubBalancers_RemoveBalancer(t *testing.T) {
 
 	// Removing a subBalancer causes the weighted target LB policy to push a new
 	// picker which ensures that the removed subBalancer is not picked for RPCs.
-	p = <-cc.NewPickerCh
 
 	scRemoved = <-cc.RemoveSubConnCh
 	if !cmp.Equal(scRemoved, sc1, cmp.AllowUnexported(testutils.TestSubConn{})) {
 		t.Fatalf("RemoveSubConn, want %v, got %v", sc1, scRemoved)
 	}
-	for i := 0; i < 5; i++ {
-		if _, err := p.Pick(balancer.PickInfo{}); err == nil || !strings.Contains(err.Error(), scConnErr.Error()) {
-			t.Fatalf("want pick error %q, got error %q", scConnErr, err)
-		}
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+
+	if err := cc.WaitForPicker(ctx, makeRPCsAndAssertContainsError(5, wantSubConnErr)); err != nil {
+		t.Fatal(err.Error())
 	}
 }
 
@@ -922,7 +933,7 @@ func (s) TestWeightedTarget_TwoSubBalancers_ChangeWeight_MoreBackends(t *testing
 	// Test roundrobin on the last picker. Twice the number of RPCs should be
 	// sent to cluster_1 when compared to cluster_2.
 	want := []balancer.SubConn{sc1, sc1, sc2, sc2, sc3, sc4}
-	if err := testutils.IsRoundRobin(want, subConnFromPicker(p)); err != nil {
+	if err := testutils.IsRoundRobin(want, testutils.SubConnFromPicker(p)); err != nil {
 		t.Fatalf("want %v, got %v", want, err)
 	}
 
@@ -958,7 +969,7 @@ func (s) TestWeightedTarget_TwoSubBalancers_ChangeWeight_MoreBackends(t *testing
 	// Weight change causes a new picker to be pushed to the channel.
 	p = <-cc.NewPickerCh
 	want = []balancer.SubConn{sc1, sc1, sc1, sc2, sc2, sc2, sc3, sc4}
-	if err := testutils.IsRoundRobin(want, subConnFromPicker(p)); err != nil {
+	if err := testutils.IsRoundRobin(want, testutils.SubConnFromPicker(p)); err != nil {
 		t.Fatalf("want %v, got %v", want, err)
 	}
 }
@@ -1077,21 +1088,21 @@ func (s) TestBalancerGroup_SubBalancerTurnsConnectingFromTransientFailure(t *tes
 
 	// Set both subconn to TransientFailure, this will put both sub-balancers in
 	// transient failure.
-	scConnErr := errors.New("subConn connection error")
+	wantSubConnErr := errors.New("subConn connection error")
 	wtb.UpdateSubConnState(sc1, balancer.SubConnState{
 		ConnectivityState: connectivity.TransientFailure,
-		ConnectionError:   scConnErr,
+		ConnectionError:   wantSubConnErr,
 	})
 	<-cc.NewPickerCh
 	wtb.UpdateSubConnState(sc2, balancer.SubConnState{
 		ConnectivityState: connectivity.TransientFailure,
-		ConnectionError:   scConnErr,
+		ConnectionError:   wantSubConnErr,
 	})
 	p := <-cc.NewPickerCh
 
 	for i := 0; i < 5; i++ {
-		if _, err := p.Pick(balancer.PickInfo{}); err == nil || !strings.Contains(err.Error(), scConnErr.Error()) {
-			t.Fatalf("want pick error %q, got error %q", scConnErr, err)
+		if _, err := p.Pick(balancer.PickInfo{}); err == nil || !strings.Contains(err.Error(), wantSubConnErr.Error()) {
+			t.Fatalf("want pick error %q, got error %q", wantSubConnErr, err)
 		}
 	}
 
@@ -1105,8 +1116,8 @@ func (s) TestBalancerGroup_SubBalancerTurnsConnectingFromTransientFailure(t *tes
 
 	for i := 0; i < 5; i++ {
 		r, err := p.Pick(balancer.PickInfo{})
-		if err == nil || !strings.Contains(err.Error(), scConnErr.Error()) {
-			t.Fatalf("want pick error %q, got result %v, err %q", scConnErr, r, err)
+		if err == nil || !strings.Contains(err.Error(), wantSubConnErr.Error()) {
+			t.Fatalf("want pick error %q, got result %v, err %q", wantSubConnErr, r, err)
 		}
 	}
 }

--- a/balancer/weightedtarget/weightedtarget_test.go
+++ b/balancer/weightedtarget/weightedtarget_test.go
@@ -70,7 +70,7 @@ func pickAndCheckError(want error) func(balancer.Picker) error {
 	return func(p balancer.Picker) error {
 		for i := 0; i < rpcCount; i++ {
 			if _, err := p.Pick(balancer.PickInfo{}); err == nil || !strings.Contains(err.Error(), want.Error()) {
-				return fmt.Errorf("got %q, want error to contain %q, ", want, err)
+				return fmt.Errorf("picker.Pick() returned error: %v, want: %v", err, want)
 			}
 		}
 		return nil
@@ -1103,7 +1103,7 @@ func (s) TestBalancerGroup_SubBalancerTurnsConnectingFromTransientFailure(t *tes
 
 	for i := 0; i < 5; i++ {
 		if _, err := p.Pick(balancer.PickInfo{}); err == nil || !strings.Contains(err.Error(), wantSubConnErr.Error()) {
-			t.Fatalf("got error %q, want pick error %q", wantSubConnErr, err)
+			t.Fatalf("picker.Pick() returned error: %v, want: %v", err, wantSubConnErr)
 		}
 	}
 
@@ -1117,7 +1117,7 @@ func (s) TestBalancerGroup_SubBalancerTurnsConnectingFromTransientFailure(t *tes
 
 	for i := 0; i < 5; i++ {
 		if _, err := p.Pick(balancer.PickInfo{}); err == nil || !strings.Contains(err.Error(), wantSubConnErr.Error()) {
-			t.Fatalf("got result %v, want pick error %q", wantSubConnErr, err)
+			t.Fatalf("picker.Pick() returned error: %v, want: %v", err, wantSubConnErr)
 		}
 	}
 }

--- a/internal/balancergroup/balancergroup_test.go
+++ b/internal/balancergroup/balancergroup_test.go
@@ -67,13 +67,6 @@ func Test(t *testing.T) {
 	grpctest.RunSubTests(t, s{})
 }
 
-func subConnFromPicker(p balancer.Picker) func() balancer.SubConn {
-	return func() balancer.SubConn {
-		scst, _ := p.Pick(balancer.PickInfo{})
-		return scst.SubConn
-	}
-}
-
 // Create a new balancer group, add balancer and backends, but not start.
 // - b1, weight 2, backends [0,1]
 // - b2, weight 1, backends [2,3]
@@ -116,7 +109,7 @@ func (s) TestBalancerGroup_start_close(t *testing.T) {
 		m1[testBackendAddrs[1]], m1[testBackendAddrs[1]],
 		m1[testBackendAddrs[2]], m1[testBackendAddrs[3]],
 	}
-	if err := testutils.IsRoundRobin(want, subConnFromPicker(p1)); err != nil {
+	if err := testutils.IsRoundRobin(want, testutils.SubConnFromPicker(p1)); err != nil {
 		t.Fatalf("want %v, got %v", want, err)
 	}
 
@@ -158,7 +151,7 @@ func (s) TestBalancerGroup_start_close(t *testing.T) {
 		m2[testBackendAddrs[3]], m2[testBackendAddrs[3]], m2[testBackendAddrs[3]],
 		m2[testBackendAddrs[1]], m2[testBackendAddrs[2]],
 	}
-	if err := testutils.IsRoundRobin(want, subConnFromPicker(p2)); err != nil {
+	if err := testutils.IsRoundRobin(want, testutils.SubConnFromPicker(p2)); err != nil {
 		t.Fatalf("want %v, got %v", want, err)
 	}
 }
@@ -241,7 +234,7 @@ func initBalancerGroupForCachingTest(t *testing.T) (*weightedaggregator.Aggregat
 		m1[testBackendAddrs[1]], m1[testBackendAddrs[1]],
 		m1[testBackendAddrs[2]], m1[testBackendAddrs[3]],
 	}
-	if err := testutils.IsRoundRobin(want, subConnFromPicker(p1)); err != nil {
+	if err := testutils.IsRoundRobin(want, testutils.SubConnFromPicker(p1)); err != nil {
 		t.Fatalf("want %v, got %v", want, err)
 	}
 
@@ -263,7 +256,7 @@ func initBalancerGroupForCachingTest(t *testing.T) (*weightedaggregator.Aggregat
 	want = []balancer.SubConn{
 		m1[testBackendAddrs[0]], m1[testBackendAddrs[1]],
 	}
-	if err := testutils.IsRoundRobin(want, subConnFromPicker(p2)); err != nil {
+	if err := testutils.IsRoundRobin(want, testutils.SubConnFromPicker(p2)); err != nil {
 		t.Fatalf("want %v, got %v", want, err)
 	}
 
@@ -304,7 +297,7 @@ func (s) TestBalancerGroup_locality_caching(t *testing.T) {
 		// addr2 is down, b2 only has addr3 in READY state.
 		addrToSC[testBackendAddrs[3]], addrToSC[testBackendAddrs[3]],
 	}
-	if err := testutils.IsRoundRobin(want, subConnFromPicker(p3)); err != nil {
+	if err := testutils.IsRoundRobin(want, testutils.SubConnFromPicker(p3)); err != nil {
 		t.Fatalf("want %v, got %v", want, err)
 	}
 
@@ -452,7 +445,7 @@ func (s) TestBalancerGroup_locality_caching_readd_with_different_builder(t *test
 		addrToSC[testBackendAddrs[1]], addrToSC[testBackendAddrs[1]],
 		addrToSC[testBackendAddrs[4]], addrToSC[testBackendAddrs[5]],
 	}
-	if err := testutils.IsRoundRobin(want, subConnFromPicker(p3)); err != nil {
+	if err := testutils.IsRoundRobin(want, testutils.SubConnFromPicker(p3)); err != nil {
 		t.Fatalf("want %v, got %v", want, err)
 	}
 }
@@ -583,7 +576,7 @@ func (s) TestBalancerGracefulSwitch(t *testing.T) {
 	want := []balancer.SubConn{
 		m1[testBackendAddrs[0]], m1[testBackendAddrs[1]],
 	}
-	if err := testutils.IsRoundRobin(want, subConnFromPicker(p1)); err != nil {
+	if err := testutils.IsRoundRobin(want, testutils.SubConnFromPicker(p1)); err != nil {
 		t.Fatalf("want %v, got %v", want, err)
 	}
 

--- a/internal/testutils/balancer.go
+++ b/internal/testutils/balancer.go
@@ -339,6 +339,9 @@ func IsRoundRobin(want []balancer.SubConn, f func() balancer.SubConn) error {
 	return nil
 }
 
+// SubConnFromPicker returns a function which returns a SubConn by calling the
+// Pick() method of the provided picker. There is no caching of SubConns here.
+// Every invocation of the returned function results in a new pick.
 func SubConnFromPicker(p balancer.Picker) func() balancer.SubConn {
 	return func() balancer.SubConn {
 		scst, _ := p.Pick(balancer.PickInfo{})

--- a/internal/testutils/balancer.go
+++ b/internal/testutils/balancer.go
@@ -339,6 +339,13 @@ func IsRoundRobin(want []balancer.SubConn, f func() balancer.SubConn) error {
 	return nil
 }
 
+func SubConnFromPicker(p balancer.Picker) func() balancer.SubConn {
+	return func() balancer.SubConn {
+		scst, _ := p.Pick(balancer.PickInfo{})
+		return scst.SubConn
+	}
+}
+
 // ErrTestConstPicker is error returned by test const picker.
 var ErrTestConstPicker = fmt.Errorf("const picker error")
 

--- a/xds/internal/balancer/clusterresolver/priority_test.go
+++ b/xds/internal/balancer/clusterresolver/priority_test.go
@@ -120,7 +120,7 @@ func (s) TestEDSPriority_HighPriorityReady(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
 	if err := cc.WaitForRoundRobinPicker(ctx, sc1); err != nil {
-		t.Fatal(err.Error())
+		t.Fatal(err)
 	}
 
 	// Add p2, it shouldn't cause any updates.
@@ -142,7 +142,7 @@ func (s) TestEDSPriority_HighPriorityReady(t *testing.T) {
 	case p := <-cc.NewPickerCh:
 		// If we do get a new picker, ensure it is still a p1 picker.
 		if err := testutils.IsRoundRobin([]balancer.SubConn{sc1}, testutils.SubConnFromPicker(p)); err != nil {
-			t.Fatal(err.Error())
+			t.Fatal(err)
 		}
 	default:
 		// No new picker; we were previously using p1 and should still be using
@@ -168,7 +168,7 @@ func (s) TestEDSPriority_HighPriorityReady(t *testing.T) {
 	case p := <-cc.NewPickerCh:
 		// If we do get a new picker, ensure it is still a p1 picker.
 		if err := testutils.IsRoundRobin([]balancer.SubConn{sc1}, testutils.SubConnFromPicker(p)); err != nil {
-			t.Fatal(err.Error())
+			t.Fatal(err)
 		}
 	default:
 		// No new picker; we were previously using p1 and should still be using
@@ -206,7 +206,7 @@ func (s) TestEDSPriority_SwitchPriority(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
 	if err := cc.WaitForRoundRobinPicker(ctx, sc0); err != nil {
-		t.Fatal(err.Error())
+		t.Fatal(err)
 	}
 
 	// Turn down 0, 1 is used.
@@ -221,7 +221,7 @@ func (s) TestEDSPriority_SwitchPriority(t *testing.T) {
 
 	// Test pick with 1.
 	if err := cc.WaitForRoundRobinPicker(ctx, sc1); err != nil {
-		t.Fatal(err.Error())
+		t.Fatal(err)
 	}
 
 	// Add p2, it shouldn't cause any updates.
@@ -243,7 +243,7 @@ func (s) TestEDSPriority_SwitchPriority(t *testing.T) {
 	case p := <-cc.NewPickerCh:
 		// If we do get a new picker, ensure it is still a p1 picker.
 		if err := testutils.IsRoundRobin([]balancer.SubConn{sc1}, testutils.SubConnFromPicker(p)); err != nil {
-			t.Fatal(err.Error())
+			t.Fatal(err)
 		}
 	default:
 		// No new picker; we were previously using p1 and should still be using
@@ -267,7 +267,7 @@ func (s) TestEDSPriority_SwitchPriority(t *testing.T) {
 
 	// Test pick with 2.
 	if err := cc.WaitForRoundRobinPicker(ctx, sc2); err != nil {
-		t.Fatal(err.Error())
+		t.Fatal(err)
 	}
 
 	// Remove 2, use 1.
@@ -285,7 +285,7 @@ func (s) TestEDSPriority_SwitchPriority(t *testing.T) {
 	// Should get an update with 1's old picker, to override 2's old picker.
 	want := errors.New("last connection error: subConn connection error")
 	if err := cc.WaitForPickerWithErr(ctx, want); err != nil {
-		t.Fatal(err.Error())
+		t.Fatal(err)
 	}
 
 }
@@ -345,7 +345,7 @@ func (s) TestEDSPriority_HigherDownWhileAddingLower(t *testing.T) {
 
 	// Test pick with 2.
 	if err := cc.WaitForRoundRobinPicker(ctx, sc2); err != nil {
-		t.Fatal(err.Error())
+		t.Fatal(err)
 	}
 
 }
@@ -389,7 +389,7 @@ func (s) TestEDSPriority_HigherReadyCloseAllLower(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
 	if err := cc.WaitForRoundRobinPicker(ctx, sc2); err != nil {
-		t.Fatal(err.Error())
+		t.Fatal(err)
 	}
 
 	// When 0 becomes ready, 0 should be used, 1 and 2 should all be closed.
@@ -424,7 +424,7 @@ func (s) TestEDSPriority_HigherReadyCloseAllLower(t *testing.T) {
 
 	// Test pick with 0.
 	if err := cc.WaitForRoundRobinPicker(ctx, sc0); err != nil {
-		t.Fatal(err.Error())
+		t.Fatal(err)
 	}
 }
 
@@ -478,7 +478,7 @@ func (s) TestEDSPriority_InitTimeout(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
 	if err := cc.WaitForRoundRobinPicker(ctx, sc1); err != nil {
-		t.Fatal(err.Error())
+		t.Fatal(err)
 	}
 }
 
@@ -506,7 +506,7 @@ func (s) TestEDSPriority_MultipleLocalities(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
 	if err := cc.WaitForRoundRobinPicker(ctx, sc0); err != nil {
-		t.Fatal(err.Error())
+		t.Fatal(err)
 	}
 
 	// Turn down p0 subconns, p1 subconns will be created.
@@ -522,7 +522,7 @@ func (s) TestEDSPriority_MultipleLocalities(t *testing.T) {
 
 	// Test roundrobin with only p1 subconns.
 	if err := cc.WaitForRoundRobinPicker(ctx, sc1); err != nil {
-		t.Fatal(err.Error())
+		t.Fatal(err)
 	}
 
 	// Reconnect p0 subconns, p1 subconn will be closed.
@@ -535,7 +535,7 @@ func (s) TestEDSPriority_MultipleLocalities(t *testing.T) {
 
 	// Test roundrobin with only p0 subconns.
 	if err := cc.WaitForRoundRobinPicker(ctx, sc0); err != nil {
-		t.Fatal(err.Error())
+		t.Fatal(err)
 	}
 
 	// Add two localities, with two priorities, with one backend.
@@ -555,7 +555,7 @@ func (s) TestEDSPriority_MultipleLocalities(t *testing.T) {
 
 	// Test roundrobin with only two p0 subconns.
 	if err := cc.WaitForRoundRobinPicker(ctx, sc0, sc2); err != nil {
-		t.Fatal(err.Error())
+		t.Fatal(err)
 	}
 
 	// Turn down p0 subconns, p1 subconns will be created.
@@ -571,7 +571,7 @@ func (s) TestEDSPriority_MultipleLocalities(t *testing.T) {
 
 	// Test roundrobin with only p1 subconns.
 	if err := cc.WaitForRoundRobinPicker(ctx, sc3, sc4); err != nil {
-		t.Fatal(err.Error())
+		t.Fatal(err)
 	}
 }
 
@@ -605,7 +605,7 @@ func (s) TestEDSPriority_RemovesAllLocalities(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
 	if err := cc.WaitForRoundRobinPicker(ctx, sc0); err != nil {
-		t.Fatal(err.Error())
+		t.Fatal(err)
 	}
 
 	// Remove all priorities.
@@ -650,7 +650,7 @@ func (s) TestEDSPriority_RemovesAllLocalities(t *testing.T) {
 
 	// Test roundrobin with only p1 subconns.
 	if err := cc.WaitForRoundRobinPicker(ctx, sc11); err != nil {
-		t.Fatal(err.Error())
+		t.Fatal(err)
 	}
 
 	// Remove p1 from EDS, to fallback to p0.
@@ -676,7 +676,7 @@ func (s) TestEDSPriority_RemovesAllLocalities(t *testing.T) {
 
 	// Test roundrobin with only p0 subconns.
 	if err := cc.WaitForRoundRobinPicker(ctx, sc01); err != nil {
-		t.Fatal(err.Error())
+		t.Fatal(err)
 	}
 
 	select {
@@ -714,7 +714,7 @@ func (s) TestEDSPriority_HighPriorityNoEndpoints(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
 	if err := cc.WaitForRoundRobinPicker(ctx, sc1); err != nil {
-		t.Fatal(err.Error())
+		t.Fatal(err)
 	}
 
 	// Remove addresses from priority 0, should use p1.
@@ -739,7 +739,7 @@ func (s) TestEDSPriority_HighPriorityNoEndpoints(t *testing.T) {
 
 	// Test roundrobin with only p1 subconns.
 	if err := cc.WaitForRoundRobinPicker(ctx, sc2); err != nil {
-		t.Fatal(err.Error())
+		t.Fatal(err)
 	}
 }
 
@@ -767,7 +767,7 @@ func (s) TestEDSPriority_HighPriorityAllUnhealthy(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
 	if err := cc.WaitForRoundRobinPicker(ctx, sc1); err != nil {
-		t.Fatal(err.Error())
+		t.Fatal(err)
 	}
 
 	// Set priority 0 endpoints to all unhealthy, should use p1.
@@ -794,7 +794,7 @@ func (s) TestEDSPriority_HighPriorityAllUnhealthy(t *testing.T) {
 
 	// Test roundrobin with only p1 subconns.
 	if err := cc.WaitForRoundRobinPicker(ctx, sc2); err != nil {
-		t.Fatal(err.Error())
+		t.Fatal(err)
 	}
 }
 
@@ -884,7 +884,7 @@ func (s) TestFallbackToDNS(t *testing.T) {
 
 	// Test roundrobin with only p0 subconns.
 	if err := cc.WaitForRoundRobinPicker(ctx, sc0); err != nil {
-		t.Fatal(err.Error())
+		t.Fatal(err)
 	}
 
 	// Turn down 0, p1 (DNS) will be used.
@@ -912,7 +912,7 @@ func (s) TestFallbackToDNS(t *testing.T) {
 
 	// Test pick with 1.
 	if err := cc.WaitForRoundRobinPicker(ctx, sc1); err != nil {
-		t.Fatal(err.Error())
+		t.Fatal(err)
 	}
 
 	// Turn down the DNS endpoint, this should trigger an re-resolve in the DNS


### PR DESCRIPTION
As a reactive from a previous PR (#5711) we want to update certain tests to use helper functions from `internal/testutils/balancer.go`

RELEASE NOTES: n/a