### PR TITLE
interop client: don't override the default scheme

### DIFF
--- a/interop/client/client.go
+++ b/interop/client/client.go
@@ -36,7 +36,6 @@ import (
 	"google.golang.org/grpc/credentials/oauth"
 	"google.golang.org/grpc/grpclog"
 	"google.golang.org/grpc/interop"
-	"google.golang.org/grpc/resolver"
 	"google.golang.org/grpc/testdata"
 
 	_ "google.golang.org/grpc/balancer/grpclb"      // Register the grpclb load balancing policy.
@@ -140,7 +139,6 @@ func main() {
 		credsChosen = credsComputeEngineCreds
 	}
 
-	resolver.SetDefaultScheme("dns")
 	serverAddr := *serverHost
 	if *serverPort != 0 {
 		serverAddr = net.JoinHostPort(*serverHost, strconv.Itoa(*serverPort))


### PR DESCRIPTION
A cleaner alternative to https://github.com/grpc/grpc-go/pull/5727

For tests that need to configure the URI scheme to something, it can already be done by passing `--server_port=0`. For example: `--server_port=dns:///name --server_port=0` for the dns scheme. 

cc @easwars 

RELEASE NOTES: n/a