### PR TITLE
passthrough: return error if endpoint is empty and opt.Dialer is nil when building resolver

### DIFF
--- a/clientconn_parsed_target_test.go
+++ b/clientconn_parsed_target_test.go
@@ -40,7 +40,6 @@ func (s) TestParsedTarget_Success_WithoutCustomDialer(t *testing.T) {
 		wantParsed resolver.Target
 	}{
 		// No scheme is specified.
-		{target: "", badScheme: true, wantParsed: resolver.Target{Scheme: defScheme, Authority: "", Endpoint: ""}},
 		{target: "://", badScheme: true, wantParsed: resolver.Target{Scheme: defScheme, Authority: "", Endpoint: "://"}},
 		{target: ":///", badScheme: true, wantParsed: resolver.Target{Scheme: defScheme, Authority: "", Endpoint: ":///"}},
 		{target: "://a/", badScheme: true, wantParsed: resolver.Target{Scheme: defScheme, Authority: "", Endpoint: "://a/"}},
@@ -110,6 +109,7 @@ func (s) TestParsedTarget_Success_WithoutCustomDialer(t *testing.T) {
 
 func (s) TestParsedTarget_Failure_WithoutCustomDialer(t *testing.T) {
 	targets := []string{
+		"",
 		"unix://a/b/c",
 		"unix://authority",
 		"unix-abstract://authority/a/b/c",
@@ -178,6 +178,12 @@ func (s) TestParsedTarget_WithCustomDialer(t *testing.T) {
 			badScheme:         true,
 			wantParsed:        resolver.Target{Scheme: defScheme, Authority: "", Endpoint: "/unix/socket/address"},
 			wantDialerAddress: "/unix/socket/address",
+		},
+		{
+			target:            "",
+			badScheme:         true,
+			wantParsed:        resolver.Target{Scheme: defScheme, Authority: "", Endpoint: ""},
+			wantDialerAddress: "",
 		},
 		{
 			target:            "passthrough://a.server.com/google.com",

--- a/internal/resolver/passthrough/passthrough.go
+++ b/internal/resolver/passthrough/passthrough.go
@@ -20,13 +20,20 @@
 // name without scheme back to gRPC as resolved address.
 package passthrough
 
-import "google.golang.org/grpc/resolver"
+import (
+	"errors"
+
+	"google.golang.org/grpc/resolver"
+)
 
 const scheme = "passthrough"
 
 type passthroughBuilder struct{}
 
 func (*passthroughBuilder) Build(target resolver.Target, cc resolver.ClientConn, opts resolver.BuildOptions) (resolver.Resolver, error) {
+	if target.Endpoint == "" && opts.Dialer == nil {
+		return nil, errors.New("passthrough resolver：missing address")
+	}
 	r := &passthroughResolver{
 		target: target,
 		cc:     cc,

--- a/internal/resolver/passthrough/passthrough.go
+++ b/internal/resolver/passthrough/passthrough.go
@@ -32,7 +32,7 @@ type passthroughBuilder struct{}
 
 func (*passthroughBuilder) Build(target resolver.Target, cc resolver.ClientConn, opts resolver.BuildOptions) (resolver.Resolver, error) {
 	if target.Endpoint == "" && opts.Dialer == nil {
-		return nil, errors.New("passthrough resolver：missing address")
+		return nil, errors.New("passthrough resolver: missing address")
 	}
 	r := &passthroughResolver{
 		target: target,

--- a/internal/resolver/passthrough/passthrough.go
+++ b/internal/resolver/passthrough/passthrough.go
@@ -32,7 +32,7 @@ type passthroughBuilder struct{}
 
 func (*passthroughBuilder) Build(target resolver.Target, cc resolver.ClientConn, opts resolver.BuildOptions) (resolver.Resolver, error) {
 	if target.Endpoint == "" && opts.Dialer == nil {
-		return nil, errors.New("passthrough resolver: missing address")
+		return nil, errors.New("passthrough: received empty target in Build()")
 	}
 	r := &passthroughResolver{
 		target: target,


### PR DESCRIPTION
Empty string is clearly not a valid target when default scheme is passthrough and no custom dialer set. But grpc.Dial will not return error in this case until client starts making RPCs, user will get errors saying `transport: Error while dialing dial tcp: missing address.`

It would be better fail fast and notify user empty target is invalid before RPC calls.

This PR fixes this issue by checking 1. is endpoint empty 2. is there a custom dialer in `passthroughBuilder.Build`, if endpoint is empty and there is no custom dialer, an error will be returned.

RELEASE NOTES:
* client: return an error from `Dial` if an empty target is passed and no custom dialer is present; the ClientConn would otherwise be unable to connect and perform RPCs