### PR TITLE
balancer/weightedtarget: use ConnectivityStateEvaluator

### DIFF
--- a/balancer/conn_state_evaluator.go
+++ b/balancer/conn_state_evaluator.go
@@ -58,6 +58,7 @@ func (cse *ConnectivityStateEvaluator) RecordTransition(oldState, newState conne
 	return cse.CurrentState()
 }
 
+// CurrentState returns the current aggregate conn state by evaluating the counters
 func (cse *ConnectivityStateEvaluator) CurrentState() connectivity.State {
 	// Evaluate.
 	if cse.numReady > 0 {

--- a/balancer/conn_state_evaluator.go
+++ b/balancer/conn_state_evaluator.go
@@ -55,7 +55,10 @@ func (cse *ConnectivityStateEvaluator) RecordTransition(oldState, newState conne
 			cse.numIdle += updateVal
 		}
 	}
+	return cse.CurrentState()
+}
 
+func (cse *ConnectivityStateEvaluator) CurrentState() connectivity.State {
 	// Evaluate.
 	if cse.numReady > 0 {
 		return connectivity.Ready

--- a/balancer/weightedtarget/weightedaggregator/aggregator.go
+++ b/balancer/weightedtarget/weightedaggregator/aggregator.go
@@ -123,8 +123,8 @@ func (wbsa *Aggregator) Add(id string, weight uint32) {
 	}
 	// Record transition to connectivity.Connecting
 	wbsa.csEvltr.RecordTransition(connectivity.Shutdown, connectivity.Connecting)
-	// Call BuildAndUpdateLocked to update picker state
-	wbsa.BuildAndUpdateLocked()
+	// Call buildAndUpdateLocked to update picker state
+	wbsa.buildAndUpdateLocked()
 }
 
 // Remove removes the sub-balancer state. Future updates from this sub-balancer,
@@ -141,8 +141,8 @@ func (wbsa *Aggregator) Remove(id string) {
 	// Remove id and picker from picker map. This also results in future updates
 	// for this ID to be ignored.
 	delete(wbsa.idToPickerState, id)
-	// Call BuildAndUpdateLocked to update picker state
-	wbsa.BuildAndUpdateLocked()
+	// Call buildAndUpdateLocked to update picker state
+	wbsa.buildAndUpdateLocked()
 }
 
 // UpdateWeight updates the weight for the given id. Note that this doesn't
@@ -236,13 +236,13 @@ func (wbsa *Aggregator) clearStates() {
 func (wbsa *Aggregator) BuildAndUpdate() {
 	wbsa.mu.Lock()
 	defer wbsa.mu.Unlock()
-	wbsa.BuildAndUpdateLocked()
+	wbsa.buildAndUpdateLocked()
 }
 
 // BuildAndUpdateLocked combines the sub-state from each sub-balancer into one
 // state, and update it to parent ClientConn - assuming that the lock on
 // wbsa.mu is already in place
-func (wbsa *Aggregator) BuildAndUpdateLocked() {
+func (wbsa *Aggregator) buildAndUpdateLocked() {
 	if !wbsa.started {
 		return
 	}

--- a/balancer/weightedtarget/weightedaggregator/aggregator.go
+++ b/balancer/weightedtarget/weightedaggregator/aggregator.go
@@ -239,7 +239,7 @@ func (wbsa *Aggregator) BuildAndUpdate() {
 	wbsa.buildAndUpdateLocked()
 }
 
-// BuildAndUpdateLocked combines the sub-state from each sub-balancer into one
+// buildAndUpdateLocked combines the sub-state from each sub-balancer into one
 // state, and update it to parent ClientConn - assuming that the lock on
 // wbsa.mu is already in place
 func (wbsa *Aggregator) buildAndUpdateLocked() {

--- a/balancer/weightedtarget/weightedaggregator/aggregator.go
+++ b/balancer/weightedtarget/weightedaggregator/aggregator.go
@@ -121,9 +121,8 @@ func (wbsa *Aggregator) Add(id string, weight uint32) {
 		},
 		stateToAggregate: connectivity.Connecting,
 	}
-	// Record transition to connectivity.Connecting
 	wbsa.csEvltr.RecordTransition(connectivity.Shutdown, connectivity.Connecting)
-	// Call buildAndUpdateLocked to update picker state
+
 	wbsa.buildAndUpdateLocked()
 }
 
@@ -135,13 +134,13 @@ func (wbsa *Aggregator) Remove(id string) {
 	if _, ok := wbsa.idToPickerState[id]; !ok {
 		return
 	}
-	// Record transition for picker to connectivity.Shutdown to decrement counter
-	// for the picker's previous state
+	// Setting the state of the deleted sub-balancer to Shutdown will get csEvltr
+	// to remove the previous state for any aggregated state evaluations.
+	// transitions to and from connectivity.Shutdown are ignored by csEvltr.
 	wbsa.csEvltr.RecordTransition(wbsa.idToPickerState[id].stateToAggregate, connectivity.Shutdown)
 	// Remove id and picker from picker map. This also results in future updates
 	// for this ID to be ignored.
 	delete(wbsa.idToPickerState, id)
-	// Call buildAndUpdateLocked to update picker state
 	wbsa.buildAndUpdateLocked()
 }
 
@@ -192,8 +191,9 @@ func (wbsa *Aggregator) UpdateState(id string, newState balancer.State) {
 		// it's either removed, or never existed.
 		return
 	}
-	// Record Transition from old state to new state
+
 	wbsa.csEvltr.RecordTransition(oldState.stateToAggregate, newState.ConnectivityState)
+
 	if !(oldState.state.ConnectivityState == connectivity.TransientFailure && newState.ConnectivityState == connectivity.Connecting) {
 		// If old state is TransientFailure, and new state is Connecting, don't
 		// update the state, to prevent the aggregated state from being always
@@ -239,9 +239,10 @@ func (wbsa *Aggregator) BuildAndUpdate() {
 	wbsa.buildAndUpdateLocked()
 }
 
-// buildAndUpdateLocked combines the sub-state from each sub-balancer into one
-// state, and update it to parent ClientConn - assuming that the lock on
-// wbsa.mu is already in place
+// buildAndUpdateLocked aggregates the connectivity states of the sub-balancers,
+// builds a new picker and sends an update to the parent ClientConn.
+//
+// Caller must hold wbsa.mu.
 func (wbsa *Aggregator) buildAndUpdateLocked() {
 	if !wbsa.started {
 		return
@@ -265,26 +266,30 @@ func (wbsa *Aggregator) build() balancer.State {
 	// Make sure picker's return error is consistent with the aggregatedState.
 	pickers := make([]weightedPickerState, 0, len(wbsa.idToPickerState))
 
-	aggState := wbsa.csEvltr.CurrentState()
-	switch aggState {
+	switch aggState := wbsa.csEvltr.CurrentState(); aggState {
 	case connectivity.Connecting:
 		return balancer.State{
 			ConnectivityState: aggState,
 			Picker:            base.NewErrPicker(balancer.ErrNoSubConnAvailable)}
 	case connectivity.TransientFailure:
+		// this means that all sub-balancers are now in TransientFailure.
 		for _, ps := range wbsa.idToPickerState {
-			if ps.stateToAggregate == connectivity.TransientFailure {
-				pickers = append(pickers, *ps)
-			}
+			pickers = append(pickers, *ps)
 		}
+		return balancer.State{
+			ConnectivityState: aggState,
+			Picker:            newWeightedPickerGroup(pickers, wbsa.newWRR)}
 	default:
 		for _, ps := range wbsa.idToPickerState {
 			if ps.stateToAggregate == connectivity.Ready {
 				pickers = append(pickers, *ps)
 			}
 		}
+		return balancer.State{
+			ConnectivityState: aggState,
+			Picker:            newWeightedPickerGroup(pickers, wbsa.newWRR)}
 	}
-	return balancer.State{ConnectivityState: aggState, Picker: newWeightedPickerGroup(pickers, wbsa.newWRR)}
+
 }
 
 type weightedPickerGroup struct {

--- a/balancer/weightedtarget/weightedaggregator/aggregator.go
+++ b/balancer/weightedtarget/weightedaggregator/aggregator.go
@@ -124,6 +124,8 @@ func (wbsa *Aggregator) Add(id string, weight uint32) {
 		stateToAggregate: connectivity.Connecting,
 	}
 	wbsa.state = wbsa.csEvltr.RecordTransition(connectivity.Shutdown, connectivity.Connecting)
+	// Call BuildAndUpdate to update picker state
+	wbsa.cc.UpdateState(wbsa.build())
 }
 
 // Remove removes the sub-balancer state. Future updates from this sub-balancer,
@@ -139,6 +141,8 @@ func (wbsa *Aggregator) Remove(id string) {
 	// Remove id and picker from picker map. This also results in future updates
 	// for this ID to be ignored.
 	delete(wbsa.idToPickerState, id)
+	// Call BuildAndUpdate to update picker state
+	wbsa.cc.UpdateState(wbsa.build())
 }
 
 // UpdateWeight updates the weight for the given id. Note that this doesn't
@@ -183,7 +187,6 @@ func (wbsa *Aggregator) UpdateState(id string, newState balancer.State) {
 	wbsa.mu.Lock()
 	defer wbsa.mu.Unlock()
 	oldState, ok := wbsa.idToPickerState[id]
-
 	if !ok {
 		// All state starts with an entry in pickStateMap. If ID is not in map,
 		// it's either removed, or never existed.

--- a/balancer/weightedtarget/weightedtarget.go
+++ b/balancer/weightedtarget/weightedtarget.go
@@ -88,8 +88,6 @@ func (b *weightedTargetBalancer) UpdateClientConnState(s balancer.ClientConnStat
 	}
 	addressesSplit := hierarchy.Group(s.ResolverState.Addresses)
 
-	var rebuildStateAndPicker bool
-
 	b.stateAggregator.PauseStateUpdates()
 	defer b.stateAggregator.ResumeStateUpdates()
 
@@ -98,9 +96,6 @@ func (b *weightedTargetBalancer) UpdateClientConnState(s balancer.ClientConnStat
 		if _, ok := newConfig.Targets[name]; !ok {
 			b.stateAggregator.Remove(name)
 			b.bg.Remove(name)
-			// Trigger a state/picker update, because we don't want `ClientConn`
-			// to pick this sub-balancer anymore.
-			rebuildStateAndPicker = true
 		}
 	}
 
@@ -119,21 +114,15 @@ func (b *weightedTargetBalancer) UpdateClientConnState(s balancer.ClientConnStat
 			// Not trigger a state/picker update. Wait for the new sub-balancer
 			// to send its updates.
 		} else if newT.ChildPolicy.Name != oldT.ChildPolicy.Name {
-			// If the child policy name is differet, remove from balancer group
+			// If the child policy name is different, remove from balancer group
 			// and re-add.
 			b.stateAggregator.Remove(name)
 			b.bg.Remove(name)
 			b.stateAggregator.Add(name, newT.Weight)
 			b.bg.Add(name, balancer.Get(newT.ChildPolicy.Name))
-			// Trigger a state/picker update, because we don't want `ClientConn`
-			// to pick this sub-balancer anymore.
-			rebuildStateAndPicker = true
 		} else if newT.Weight != oldT.Weight {
 			// If this is an existing sub-balancer, update weight if necessary.
 			b.stateAggregator.UpdateWeight(name, newT.Weight)
-			// Trigger a state/picker update, because we don't want `ClientConn`
-			// should do picks with the new weights now.
-			rebuildStateAndPicker = true
 		}
 
 		// Forwards all the update:
@@ -154,9 +143,8 @@ func (b *weightedTargetBalancer) UpdateClientConnState(s balancer.ClientConnStat
 
 	b.targets = newConfig.Targets
 
-	if rebuildStateAndPicker {
-		b.stateAggregator.BuildAndUpdate()
-	}
+	b.stateAggregator.BuildAndUpdate()
+
 	return nil
 }
 

--- a/balancer/weightedtarget/weightedtarget.go
+++ b/balancer/weightedtarget/weightedtarget.go
@@ -143,8 +143,6 @@ func (b *weightedTargetBalancer) UpdateClientConnState(s balancer.ClientConnStat
 
 	b.targets = newConfig.Targets
 
-	b.stateAggregator.BuildAndUpdate()
-
 	return nil
 }
 

--- a/balancer/weightedtarget/weightedtarget_test.go
+++ b/balancer/weightedtarget/weightedtarget_test.go
@@ -1267,6 +1267,7 @@ func (s) TestUpdateStatePauses(t *testing.T) {
 	balFuncs := stub.BalancerFuncs{
 		UpdateClientConnState: func(bd *stub.BalancerData, s balancer.ClientConnState) error {
 			bd.ClientConn.UpdateState(balancer.State{ConnectivityState: connectivity.TransientFailure, Picker: nil})
+			bd.ClientConn.UpdateState(balancer.State{ConnectivityState: connectivity.Connecting, Picker: nil})
 			bd.ClientConn.UpdateState(balancer.State{ConnectivityState: connectivity.Ready, Picker: nil})
 			return nil
 		},
@@ -1298,8 +1299,10 @@ func (s) TestUpdateStatePauses(t *testing.T) {
 		t.Fatalf("failed to update ClientConn state: %v", err)
 	}
 
-	// Verify that the only state update is the second one called by the child.
-	if len(cc.states) != 1 || cc.states[0].ConnectivityState != connectivity.Ready {
-		t.Fatalf("cc.states = %v; want [connectivity.Ready]", cc.states)
+	// Verify that the only 2 state updates are 1.to connectivity.Connecting when
+	// the sub-balancer is first added and 2. to connectivity.Ready which is the
+	// third one called by the child
+	if len(cc.states) != 2 || cc.states[1].ConnectivityState != connectivity.Ready {
+		t.Fatalf("cc.states = %v; want [connectivity.Connecting, connectivity.Ready]", cc.states)
 	}
 }

--- a/balancer/weightedtarget/weightedtarget_test.go
+++ b/balancer/weightedtarget/weightedtarget_test.go
@@ -1267,7 +1267,6 @@ func (s) TestUpdateStatePauses(t *testing.T) {
 	balFuncs := stub.BalancerFuncs{
 		UpdateClientConnState: func(bd *stub.BalancerData, s balancer.ClientConnState) error {
 			bd.ClientConn.UpdateState(balancer.State{ConnectivityState: connectivity.TransientFailure, Picker: nil})
-			bd.ClientConn.UpdateState(balancer.State{ConnectivityState: connectivity.Connecting, Picker: nil})
 			bd.ClientConn.UpdateState(balancer.State{ConnectivityState: connectivity.Ready, Picker: nil})
 			return nil
 		},
@@ -1299,10 +1298,8 @@ func (s) TestUpdateStatePauses(t *testing.T) {
 		t.Fatalf("failed to update ClientConn state: %v", err)
 	}
 
-	// Verify that the only 2 state updates are 1.to connectivity.Connecting when
-	// the sub-balancer is first added and 2. to connectivity.Ready which is the
-	// third one called by the child
-	if len(cc.states) != 2 || cc.states[1].ConnectivityState != connectivity.Ready {
-		t.Fatalf("cc.states = %v; want [connectivity.Connecting, connectivity.Ready]", cc.states)
+	// Verify that the only state update is the second one called by the child.
+	if len(cc.states) != 1 || cc.states[0].ConnectivityState != connectivity.Ready {
+		t.Fatalf("cc.states = %v; want [connectivity.Ready]", cc.states)
 	}
 }

--- a/internal/balancergroup/balancergroup_test.go
+++ b/internal/balancergroup/balancergroup_test.go
@@ -240,7 +240,6 @@ func initBalancerGroupForCachingTest(t *testing.T) (*weightedaggregator.Aggregat
 
 	gator.Remove(testBalancerIDs[1])
 	bg.Remove(testBalancerIDs[1])
-	gator.BuildAndUpdate()
 	// Don't wait for SubConns to be removed after close, because they are only
 	// removed after close timeout.
 	for i := 0; i < 10; i++ {


### PR DESCRIPTION
use ConnectivityStateEvaluator in weighted target balancer to evaluate the aggregate state of a weighted target group. 

RELEASE NOTES: N/A