### PR TITLE
[DRAFT] Improve caching behavior for CRLs

### DIFF
--- a/security/advancedtls/crl.go
+++ b/security/advancedtls/crl.go
@@ -523,14 +523,20 @@ type TimedCRLCache struct {
 	expirationDurationSeconds int
 }
 
-type cRLCacheEntry struct {
+type timedCRLCacheEntry struct {
 	value     interface{}
 	updatedAt time.Time
 }
 
 func (c TimedCRLCache) Add(key, value interface{}) bool {
-	evicted := c.cache.Add(key, cRLCacheEntry{value, time.Now()})
+	evicted := c.cache.Add(key, timedCRLCacheEntry{value, time.Now()})
 	return evicted
+}
+
+func (c TimedCRLCache) add(key interface{}, value timedCRLCacheEntry) bool {
+	evicted := c.cache.Add(key, value)
+	return evicted
+
 }
 
 func (c TimedCRLCache) Get(key interface{}) (value interface{}, ok bool) {
@@ -540,7 +546,7 @@ func (c TimedCRLCache) Get(key interface{}) (value interface{}, ok bool) {
 		return nil, false
 	}
 
-	cacheEntry, ok := val.(cRLCacheEntry)
+	cacheEntry, ok := val.(timedCRLCacheEntry)
 	if !ok {
 		grpclogLogger.Warningf("Couldn't convert cache entry to cRLCacheEntry key=%v value=%v", key, val)
 		return nil, false

--- a/security/advancedtls/crl.go
+++ b/security/advancedtls/crl.go
@@ -519,7 +519,8 @@ func extractCRLIssuer(crlBytes []byte) ([]byte, error) {
 }
 
 type TimedCRLCache struct {
-	cache *lru.Cache
+	cache                     *lru.Cache
+	expirationDurationSeconds int
 }
 
 type cRLCacheEntry struct {
@@ -546,7 +547,7 @@ func (c TimedCRLCache) Get(key interface{}) (value interface{}, ok bool) {
 	}
 	crl := cacheEntry.value
 	// TODO make this value configurable
-	if cacheEntry.updatedAt.Add(time.Hour).Before(time.Now()) {
+	if cacheEntry.updatedAt.Add(time.Duration(c.expirationDurationSeconds) * time.Second).Before(time.Now()) {
 		// Need to refresh
 		grpclogLogger.Infof("CRLCache entry for key=%v more than 1 hour old, refreshing", key)
 		return nil, false

--- a/security/advancedtls/crl.go
+++ b/security/advancedtls/crl.go
@@ -518,7 +518,7 @@ func extractCRLIssuer(crlBytes []byte) ([]byte, error) {
 	return issuer, nil
 }
 
-type CRLCache struct {
+type TimedCRLCache struct {
 	cache *lru.Cache
 }
 
@@ -527,12 +527,12 @@ type cRLCacheEntry struct {
 	updatedAt time.Time
 }
 
-func (c CRLCache) Add(key, value interface{}) bool {
+func (c TimedCRLCache) Add(key, value interface{}) bool {
 	evicted := c.cache.Add(key, cRLCacheEntry{value, time.Now()})
 	return evicted
 }
 
-func (c CRLCache) Get(key interface{}) (value interface{}, ok bool) {
+func (c TimedCRLCache) Get(key interface{}) (value interface{}, ok bool) {
 	val, ok := c.cache.Get(key)
 	if !ok {
 		grpclogLogger.Infof("Retrieving crl issuer hash %v from cache failed", key)
@@ -554,10 +554,10 @@ func (c CRLCache) Get(key interface{}) (value interface{}, ok bool) {
 	return crl, true
 }
 
-func (c CRLCache) Purge() {
+func (c TimedCRLCache) Purge() {
 	c.cache.Purge()
 }
 
-func (c CRLCache) Len() int {
+func (c TimedCRLCache) Len() int {
 	return c.cache.Len()
 }

--- a/security/advancedtls/crl.go
+++ b/security/advancedtls/crl.go
@@ -35,7 +35,6 @@ import (
 	"strings"
 	"time"
 
-	lru "github.com/hashicorp/golang-lru"
 	"golang.org/x/crypto/cryptobyte"
 	cbasn1 "golang.org/x/crypto/cryptobyte/asn1"
 	"google.golang.org/grpc/grpclog"
@@ -51,6 +50,10 @@ type Cache interface {
 	Add(key, value interface{}) bool
 	// Get looks up a key's value from the cache.
 	Get(key interface{}) (value interface{}, ok bool)
+	// Len returns the number of items in the cache
+	Len() int
+	// Purge is used to clear the cache
+	Purge()
 }
 
 // RevocationConfig contains options for CRL lookup.
@@ -519,7 +522,7 @@ func extractCRLIssuer(crlBytes []byte) ([]byte, error) {
 }
 
 type TimedCRLCache struct {
-	cache                     *lru.Cache
+	cache                     Cache
 	expirationDurationSeconds int
 }
 

--- a/security/advancedtls/crl_test.go
+++ b/security/advancedtls/crl_test.go
@@ -809,10 +809,9 @@ func TestTimedCRLCacheExpiration(t *testing.T) {
 		cache := TimedCRLCache{lru, tt.expirationDurationSeconds}
 
 		var certs = makeChain(t, testdata.Path(tt.certificateFile))
-		// Certs[1] has the same issuer as the revoked cert
+		// Certs[i] has the same issuer as the revoked cert
 		rawIssuer := certs[tt.revokedCertIndex].RawIssuer
 
-		// `3.crl`` revokes `revokedInt.pem`
 		crl := loadCRL(t, testdata.Path(tt.crlFile))
 		// Modify the crl so that the cert is NOT revoked and add it to the cache
 		crl.CertList.TBSCertList.RevokedCertificates = []pkix.RevokedCertificate{}
@@ -877,10 +876,9 @@ func TestTimedCRLCacheExpirationAlternate(t *testing.T) {
 		cache := TimedCRLCache{lru, tt.expirationDurationSeconds}
 
 		var certs = makeChain(t, testdata.Path(tt.certificateFile))
-		// Certs[1] has the same issuer as the revoked cert
+		// Certs[i] has the same issuer as the revoked cert
 		rawIssuer := certs[tt.revokedCertIndex].RawIssuer
 
-		// `3.crl`` revokes `revokedInt.pem`
 		crl := loadCRL(t, testdata.Path(tt.crlFile))
 		// Modify the crl so that the cert is NOT revoked and add it to the cache
 		crl.CertList.TBSCertList.RevokedCertificates = []pkix.RevokedCertificate{}

--- a/security/advancedtls/crl_test.go
+++ b/security/advancedtls/crl_test.go
@@ -359,7 +359,7 @@ func loadCRL(t *testing.T, path string) *certificateListExt {
 
 func TestCachedCRL(t *testing.T) {
 	internal_cache, err := lru.New(5)
-	cache := CRLCache{internal_cache}
+	cache := TimedCRLCache{internal_cache}
 	if err != nil {
 		t.Fatalf("lru.New: err = %v", err)
 	}
@@ -415,7 +415,7 @@ func TestCachedCRL(t *testing.T) {
 
 func TestGetIssuerCRLCache(t *testing.T) {
 	internal_cache, err := lru.New(5)
-	cache := CRLCache{internal_cache}
+	cache := TimedCRLCache{internal_cache}
 	if err != nil {
 		t.Fatalf("lru.New: err = %v", err)
 	}
@@ -526,7 +526,7 @@ func TestRevokedCert(t *testing.T) {
 	revokedLeafChain := makeChain(t, testdata.Path("crl/revokedLeaf.pem"))
 	validChain := makeChain(t, testdata.Path("crl/unrevoked.pem"))
 	internal_cache, err := lru.New(5)
-	cache := CRLCache{internal_cache}
+	cache := TimedCRLCache{internal_cache}
 	if err != nil {
 		t.Fatalf("lru.New: err = %v", err)
 	}

--- a/security/advancedtls/crl_test.go
+++ b/security/advancedtls/crl_test.go
@@ -358,7 +358,8 @@ func loadCRL(t *testing.T, path string) *certificateListExt {
 }
 
 func TestCachedCRL(t *testing.T) {
-	cache, err := lru.New(5)
+	internal_cache, err := lru.New(5)
+	cache := CRLCache{internal_cache}
 	if err != nil {
 		t.Fatalf("lru.New: err = %v", err)
 	}
@@ -413,7 +414,8 @@ func TestCachedCRL(t *testing.T) {
 }
 
 func TestGetIssuerCRLCache(t *testing.T) {
-	cache, err := lru.New(5)
+	internal_cache, err := lru.New(5)
+	cache := CRLCache{internal_cache}
 	if err != nil {
 		t.Fatalf("lru.New: err = %v", err)
 	}
@@ -523,7 +525,8 @@ func TestRevokedCert(t *testing.T) {
 	revokedIntChain := makeChain(t, testdata.Path("crl/revokedInt.pem"))
 	revokedLeafChain := makeChain(t, testdata.Path("crl/revokedLeaf.pem"))
 	validChain := makeChain(t, testdata.Path("crl/unrevoked.pem"))
-	cache, err := lru.New(5)
+	internal_cache, err := lru.New(5)
+	cache := CRLCache{internal_cache}
 	if err != nil {
 		t.Fatalf("lru.New: err = %v", err)
 	}

--- a/security/advancedtls/crl_test.go
+++ b/security/advancedtls/crl_test.go
@@ -735,7 +735,7 @@ func TestIssuerNonPrintableString(t *testing.T) {
 	}
 }
 
-func TestCRLCacheExpiration(t *testing.T) {
+func TestCRLNextUpdateExpiration(t *testing.T) {
 	cache, err := lru.New(5)
 	if err != nil {
 		t.Fatalf("Creating cache failed")


### PR DESCRIPTION
The current implementation will only check for a new CRL if the `NextUpdate` field for a given cached CRL has passed ([grpc code](https://github.com/grpc/grpc-go/blob/28fae96c98813777d02f25b2aa2d701b468b41c0/security/advancedtls/crl.go#L225), calls [Golang crypto](https://github.com/golang/go/blob/6b22572e700235fb7303c7fd6aefcc33c743a130/src/crypto/x509/pkix/pkix.go#L295)).
While this is not necessarily incorrect per RFC5280, it does not state that you cannot consider a newer CRL provided before NextUpdate (room is left for interpretation).
This PR adds a cache implementation that will refresh a given entry based on a configurable duration. For example, one could configure the cache to refresh if the entry is older than an hour).

Marking as draft for now to get feedback on implementation and test options (particularly, I want to make sure I handle time mocking in a way that is consistent with how it is done in grpc-go, I've placed comments around the tests I wrote asking about how best to accomplish these things in grpc-go).

Will fix my editor auto-formatting a few comments as a last fix before merging.