### PR TITLE
doc: fix typo about gRPC

### DIFF
--- a/examples/features/retry/README.md
+++ b/examples/features/retry/README.md
@@ -4,7 +4,7 @@ This example shows how to enable and configure retry on gRPC clients.
 
 ## Documentation
 
-[gRFC for client-side retry support](https://github.com/grpc/proposal/blob/master/A6-client-retries.md)
+[gRPC for client-side retry support](https://github.com/grpc/proposal/blob/master/A6-client-retries.md)
 
 ## Try it
 


### PR DESCRIPTION
fix typo (gRFC -> gRPC)  (feature/retry/README.md)