### PR TITLE
Fix flaky test MultipleClientStatsHandler

### DIFF
--- a/stats/stats_test.go
+++ b/stats/stats_test.go
@@ -1393,7 +1393,7 @@ func (s) TestMultipleClientStatsHandler(t *testing.T) {
 
 	for start := time.Now(); time.Since(start) < defaultTestTimeout; {
 		h.mu.Lock()
-		if _, ok := h.gotRPC[len(h.gotRPC)-1].s.(*stats.End); ok {
+		if _, ok := h.gotRPC[len(h.gotRPC)-1].s.(*stats.End); ok && len(h.gotRPC) == 12 {
 			h.mu.Unlock()
 			break
 		}
@@ -1403,7 +1403,7 @@ func (s) TestMultipleClientStatsHandler(t *testing.T) {
 
 	for start := time.Now(); time.Since(start) < defaultTestTimeout; {
 		h.mu.Lock()
-		if _, ok := h.gotConn[len(h.gotConn)-1].s.(*stats.ConnEnd); ok {
+		if _, ok := h.gotConn[len(h.gotConn)-1].s.(*stats.ConnEnd); ok && len(h.gotConn) == 4 {
 			h.mu.Unlock()
 			break
 		}


### PR DESCRIPTION
In a normal situation, `h.gotConn` ends with:

```
stats.ConnBegin
stats.ConnBegin
stats.ConnEnd
stats.ConnEnd
```

But with the current waiting algorithm, this situation would be enough to stop waiting:
```
stats.ConnBegin
stats.ConnBegin
stats.ConnEnd
```
And the test fails with 
```
stats_test.go:1421: h.gotConn: unexpected amount of ConnStats: 3 != 4
```

I was able to reproduce this behavior with the following command. After the fix, the tests passed:
```
go test -count=10000  -run 'Test/MultipleClientStatsHandler' ./stats
```

Fixes #5695 

RELEASE NOTES: N/A