### PR TITLE
replace deprecated package && fix naming && fix typo

### DIFF
--- a/internal/transport/handler_server_test.go
+++ b/internal/transport/handler_server_test.go
@@ -31,12 +31,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/protobuf/proto"
 	dpb "github.com/golang/protobuf/ptypes/duration"
 	epb "google.golang.org/genproto/googleapis/rpc/errdetails"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 )
 
 func (s) TestHandlerTransport_NewServerHandlerTransport(t *testing.T) {

--- a/status/status_ext_test.go
+++ b/status/status_ext_test.go
@@ -22,11 +22,11 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/golang/protobuf/proto"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/internal/grpctest"
 	"google.golang.org/grpc/status"
 	"google.golang.org/grpc/test/grpc_testing"
+	"google.golang.org/protobuf/proto"
 )
 
 type s struct {

--- a/status/status_test.go
+++ b/status/status_test.go
@@ -24,8 +24,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/golang/protobuf/proto"
-	"github.com/golang/protobuf/ptypes"
 	apb "github.com/golang/protobuf/ptypes/any"
 	dpb "github.com/golang/protobuf/ptypes/duration"
 	"github.com/google/go-cmp/cmp"
@@ -35,6 +33,9 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/internal/grpctest"
 	"google.golang.org/grpc/internal/status"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/runtime/protoimpl"
+	"google.golang.org/protobuf/types/known/anypb"
 )
 
 type s struct {
@@ -311,11 +312,12 @@ func (s) TestStatus_ErrorDetails_Fail(t *testing.T) {
 						ResourceType: "book",
 						ResourceName: "projects/1234/books/5678",
 						Owner:        "User",
-					}),
+					},
+					),
 				},
 			}),
 			[]interface{}{
-				errors.New(`message type url "" is invalid`),
+				protoimpl.X.NewError("invalid empty type URL"),
 				&epb.ResourceInfo{
 					ResourceType: "book",
 					ResourceName: "projects/1234/books/5678",
@@ -348,11 +350,11 @@ func str(s *Status) string {
 
 // mustMarshalAny converts a protobuf message to an any.
 func mustMarshalAny(msg proto.Message) *apb.Any {
-	any, err := ptypes.MarshalAny(msg)
+	a, err := anypb.New(msg)
 	if err != nil {
 		panic(fmt.Sprintf("ptypes.MarshalAny(%+v) failed: %v", msg, err))
 	}
-	return any
+	return a
 }
 
 func (s) TestFromContextError(t *testing.T) {


### PR DESCRIPTION
Hello I've replaced github.com/golang/protobuf/proto to google.golang.org/protobuf/proto cause the linters on my project swears on deprecated dependency if I use status.WithDetails in a separate method with a proto.Message arg.

Have a nice day!

RELEASE NOTES: n/a
