### PR TITLE
google-c2p: use new-style resource name for LDS subscription

### DIFF
--- a/xds/googledirectpath/googlec2p.go
+++ b/xds/googledirectpath/googlec2p.go
@@ -95,6 +95,7 @@ func (c2pResolverBuilder) Build(t resolver.Target, cc resolver.ClientConn, opts 
 	if !runDirectPath() {
 		// If not xDS, fallback to DNS.
 		t.Scheme = dnsName
+		t.URL.Scheme = dnsName
 		return resolver.Get(dnsName).Build(t, cc, opts)
 	}
 
@@ -137,6 +138,7 @@ func (c2pResolverBuilder) Build(t resolver.Target, cc resolver.ClientConn, opts 
 
 	// Create and return an xDS resolver.
 	t.Scheme = xdsName
+	t.URL.Scheme = xdsName
 	if envconfig.XDSFederation {
 		t = resolver.Target{
 			URL: url.URL{


### PR DESCRIPTION
Similar to C++ PR: https://github.com/grpc/grpc/pull/29922

cc @easwars 

Tested manually that this works in an e2e test setup with `GRPC_EXPERIMENTAL_XDS_FEDERATION=true`

RELEASE NOTES: n/a