### PR TITLE
balancer/weightedtarget: fix ConnStateEvltr to ignore transition from TF to Connecting

### DIFF
--- a/balancer/weightedtarget/weightedaggregator/aggregator.go
+++ b/balancer/weightedtarget/weightedaggregator/aggregator.go
@@ -192,13 +192,12 @@ func (wbsa *Aggregator) UpdateState(id string, newState balancer.State) {
 		return
 	}
 
-	wbsa.csEvltr.RecordTransition(oldState.stateToAggregate, newState.ConnectivityState)
-
 	if !(oldState.state.ConnectivityState == connectivity.TransientFailure && newState.ConnectivityState == connectivity.Connecting) {
 		// If old state is TransientFailure, and new state is Connecting, don't
 		// update the state, to prevent the aggregated state from being always
 		// CONNECTING. Otherwise, stateToAggregate is the same as
 		// state.ConnectivityState.
+		wbsa.csEvltr.RecordTransition(oldState.stateToAggregate, newState.ConnectivityState)
 		oldState.stateToAggregate = newState.ConnectivityState
 	}
 	oldState.state = newState

--- a/balancer/weightedtarget/weightedaggregator/aggregator.go
+++ b/balancer/weightedtarget/weightedaggregator/aggregator.go
@@ -185,22 +185,22 @@ func (wbsa *Aggregator) ResumeStateUpdates() {
 func (wbsa *Aggregator) UpdateState(id string, newState balancer.State) {
 	wbsa.mu.Lock()
 	defer wbsa.mu.Unlock()
-	oldState, ok := wbsa.idToPickerState[id]
+	state, ok := wbsa.idToPickerState[id]
 	if !ok {
 		// All state starts with an entry in pickStateMap. If ID is not in map,
 		// it's either removed, or never existed.
 		return
 	}
 
-	if !(oldState.state.ConnectivityState == connectivity.TransientFailure && newState.ConnectivityState == connectivity.Connecting) {
+	if !(state.state.ConnectivityState == connectivity.TransientFailure && newState.ConnectivityState == connectivity.Connecting) {
 		// If old state is TransientFailure, and new state is Connecting, don't
 		// update the state, to prevent the aggregated state from being always
 		// CONNECTING. Otherwise, stateToAggregate is the same as
 		// state.ConnectivityState.
-		wbsa.csEvltr.RecordTransition(oldState.stateToAggregate, newState.ConnectivityState)
-		oldState.stateToAggregate = newState.ConnectivityState
+		wbsa.csEvltr.RecordTransition(state.stateToAggregate, newState.ConnectivityState)
+		state.stateToAggregate = newState.ConnectivityState
 	}
-	oldState.state = newState
+	state.state = newState
 
 	wbsa.buildAndUpdateLocked()
 }

--- a/balancer/weightedtarget/weightedtarget_test.go
+++ b/balancer/weightedtarget/weightedtarget_test.go
@@ -1249,9 +1249,9 @@ func (s) TestInitialIdle(t *testing.T) {
 	}
 }
 
-// TestSubBalancerStateLazyUpdate covers the case that if the child reports a
-// transition from TF to Connection, the overall state will still be TF.
-func (s) TestSubBalancerStateLazyUpdate(t *testing.T) {
+// TestIgnoreSubBalancerStateTransitions covers the case that if the child reports a
+// transition from TF to Connecting, the overall state will still be TF.
+func (s) TestIgnoreSubBalancerStateTransitions(t *testing.T) {
 	cc := &tcc{TestClientConn: testutils.NewTestClientConn(t)}
 
 	wtb := wtbBuilder.Build(cc, balancer.BuildOptions{})

--- a/balancer/weightedtarget/weightedtarget_test.go
+++ b/balancer/weightedtarget/weightedtarget_test.go
@@ -1285,7 +1285,7 @@ func (s) TestSubBalancerStateLazyUpdate(t *testing.T) {
 
 	// Verify that the SubConnState update from TF to Connecting is ignored.
 	if len(cc.states) != 2 || cc.states[0].ConnectivityState != connectivity.Connecting || cc.states[1].ConnectivityState != connectivity.TransientFailure {
-		t.Fatalf("cc.states = %v; want [connectivity.Ready]", cc.states)
+		t.Fatalf("cc.states = %v; want [Connecting, TransientFailure]", cc.states)
 	}
 }
 


### PR DESCRIPTION
#5734's diff works in way that ConnStateEvltr does not ignore transitions from TF to Connecting. This will fix it. Also adding a test to assert this.

RELEASE NOTES: N/A