### PR TITLE
transport: new stream with actual server name

### DIFF
--- a/internal/transport/transport.go
+++ b/internal/transport/transport.go
@@ -657,6 +657,9 @@ type ClientTransport interface {
 	// with a human readable string with debug info.
 	GetGoAwayReason() (GoAwayReason, string)
 
+	// GetUsedResolverAddress return the transport used resolver address meta info
+	GetUsedResolverAddress() resolver.Address
+
 	// RemoteAddr returns the remote network address.
 	RemoteAddr() net.Addr
 

--- a/stream.go
+++ b/stream.go
@@ -455,6 +455,13 @@ func (a *csAttempt) getTransport() error {
 func (a *csAttempt) newStream() error {
 	cs := a.cs
 	cs.callHdr.PreviousAttempts = cs.numRetries
+
+	// Replace with the actual serverName, if it exist
+	addr := a.t.GetUsedResolverAddress()
+	if addr.ServerName != "" {
+		cs.callHdr.Host = addr.ServerName
+	}
+	
 	s, err := a.t.NewStream(a.ctx, cs.callHdr)
 	if err != nil {
 		nse, ok := err.(*transport.NewStreamError)


### PR DESCRIPTION
Transport: replace with the actual serverName, if it exist.

When the resolver-address backend is an HAProxy, we invoked gRPC-methods and got 'code = Internal desc = stream terminated by RST_STREAM with error code: PROTOCOL_ERROR', the reason is header value of ': authority' is not matched in HAProxy.

Example: resolver scheme is 'xxx:///serviceName/methodName', resolver return an HAProxy address like 'grpc-proxy.xxx.com:80', but current transport used to target 'serviceName/methodName' as ':authority' header value, when do invoke, HAProxy is not known which endpoint we need to request.