### PR TITLE
security/advancedtls: add test for crl cache expiration behavior

### DIFF
--- a/security/advancedtls/crl_test.go
+++ b/security/advancedtls/crl_test.go
@@ -731,3 +731,35 @@ func TestIssuerNonPrintableString(t *testing.T) {
 		t.Fatalf("fetchCRL failed: %s", err)
 	}
 }
+
+func TestCRLCacheExpirationReloading(t *testing.T) {
+	cache, err := lru.New(5)
+	if err != nil {
+		t.Fatalf("Creating cache failed")
+	}
+
+	var certs = makeChain(t, testdata.Path("crl/revokedInt.pem"))
+	// Certs[1] has the same issuer as the revoked cert
+	rawIssuer := certs[1].RawIssuer
+
+	// `3.crl`` revokes `revokedInt.pem`
+	crl := loadCRL(t, testdata.Path("crl/3.crl"))
+	// Modify the crl so that the cert is NOT revoked and add it to the cache
+	crl.CertList.TBSCertList.RevokedCertificates = []pkix.RevokedCertificate{}
+	crl.CertList.TBSCertList.NextUpdate = time.Now().Add(time.Hour)
+	cache.Add(hex.EncodeToString(rawIssuer), crl)
+	var cfg = RevocationConfig{RootDir: testdata.Path("crl"), Cache: cache}
+	revocationStatus := checkChain(certs, cfg)
+	if revocationStatus != RevocationUnrevoked {
+		t.Fatalf("Certificate check should be RevocationUnrevoked, was %v", revocationStatus)
+	}
+
+	// Modify the entry in the cache so that the cache will be refreshed
+	crl.CertList.TBSCertList.NextUpdate = time.Now()
+	cache.Add(hex.EncodeToString(rawIssuer), crl)
+
+	revocationStatus = checkChain(certs, cfg)
+	if revocationStatus != RevocationRevoked {
+		t.Fatalf("A certificate should have been `RevocationREvoked` but was not")
+	}
+}

--- a/security/advancedtls/crl_test.go
+++ b/security/advancedtls/crl_test.go
@@ -732,6 +732,14 @@ func TestIssuerNonPrintableString(t *testing.T) {
 	}
 }
 
+// TestCRLCacheExpirationReloading tests the basic expiration and reloading of a
+// cached CRL. The setup places an empty CRL in the cache, and a corresponding
+// CRL with a revocation in the CRL directory. We then validate the certificate
+// to verify that the certificate is not revoked.  Then, we modify the
+// NextUpdate time to be in the past so that when we next check for revocation,
+// the existing cache entry should be seen as expired, and the CRL in the
+// directory showing `revokedInt.pem` as revoked will be loaded, resulting in
+// the check returning `RevocationRevoked`.
 func TestCRLCacheExpirationReloading(t *testing.T) {
 	cache, err := lru.New(5)
 	if err != nil {

--- a/security/advancedtls/crl_test.go
+++ b/security/advancedtls/crl_test.go
@@ -745,7 +745,7 @@ func TestCRLCacheExpirationReloading(t *testing.T) {
 	// `3.crl`` revokes `revokedInt.pem`
 	crl := loadCRL(t, testdata.Path("crl/3.crl"))
 	// Modify the crl so that the cert is NOT revoked and add it to the cache
-	crl.CertList.TBSCertList.RevokedCertificates = []pkix.RevokedCertificate{}
+	crl.CertList.TBSCertList.RevokedCertificates = nil
 	crl.CertList.TBSCertList.NextUpdate = time.Now().Add(time.Hour)
 	cache.Add(hex.EncodeToString(rawIssuer), crl)
 	var cfg = RevocationConfig{RootDir: testdata.Path("crl"), Cache: cache}

--- a/security/advancedtls/crl_test.go
+++ b/security/advancedtls/crl_test.go
@@ -760,6 +760,6 @@ func TestCRLCacheExpirationReloading(t *testing.T) {
 
 	revocationStatus = checkChain(certs, cfg)
 	if revocationStatus != RevocationRevoked {
-		t.Fatalf("A certificate should have been `RevocationREvoked` but was not")
+		t.Fatalf("A certificate should have been `RevocationRevoked` but was %v", revocationStatus)
 	}
 }


### PR DESCRIPTION
This behavior should be covered by a combination of existing unit tests, but I wanted to add a more integration-style test where we test the codepath of the cache entry expiring a crl for which a cert is unrevoked, then fetching a new CRL where a cert in the chain is revoked.

RELEASE NOTES: none