### PR TITLE
transport/test: implement staticcheck suggestion

### DIFF
--- a/internal/transport/transport_test.go
+++ b/internal/transport/transport_test.go
@@ -1297,7 +1297,6 @@ func (s) TestClientHonorsConnectContext(t *testing.T) {
 	}
 
 	// Test context deadline.
-	timeBefore = time.Now()
 	connectCtx, cancel = context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
 	_, err = NewClientTransport(connectCtx, context.Background(), resolver.Address{Addr: lis.Addr().String()}, copts, func(GoAwayReason) {}, func() {})


### PR DESCRIPTION
Reported by StaticCheck while importing into google3:

SA4006 - A value assigned to a variable is never read before being overwritten. Forgotten error check or dead code? 

RELEASE NOTES: n/a