### PR TITLE
xds/google-c2p: validate url for no authorities

### DIFF
--- a/xds/googledirectpath/googlec2p.go
+++ b/xds/googledirectpath/googlec2p.go
@@ -92,6 +92,10 @@ type c2pResolverBuilder struct {
 }
 
 func (c2pResolverBuilder) Build(t resolver.Target, cc resolver.ClientConn, opts resolver.BuildOptions) (resolver.Resolver, error) {
+	if t.URL.Host != "" {
+		return nil, fmt.Errorf("google-c2p URI scheme does not support authorities")
+	}
+
 	if !runDirectPath() {
 		// If not xDS, fallback to DNS.
 		t.Scheme = dnsName

--- a/xds/googledirectpath/googlec2p_test.go
+++ b/xds/googledirectpath/googlec2p_test.go
@@ -267,7 +267,6 @@ func TestBuildFailsWhenCalledWithAuthority(t *testing.T) {
 	}()
 	wantErr := "google-c2p URI scheme does not support authorities"
 	if err == nil || !strings.Contains(err.Error(), wantErr) {
-		cc.Close()
 		t.Fatalf("grpc.Dial(%s) returned error: %v, want: %v", uri, err, wantErr)
 	}
 }

--- a/xds/googledirectpath/googlec2p_test.go
+++ b/xds/googledirectpath/googlec2p_test.go
@@ -19,6 +19,7 @@
 package googledirectpath
 
 import (
+	"net/url"
 	"strconv"
 	"testing"
 	"time"
@@ -249,5 +250,17 @@ func TestBuildXDS(t *testing.T) {
 				t.Fatalf("timeout waiting for client close")
 			}
 		})
+	}
+}
+
+// TestBuildFailsWhenCalledWithAuthority asserts that c2p resolver.build
+// fails when called with a URL with an authority.
+func TestBuildFailsWhenCalledWithAuthority(t *testing.T) {
+	builder := resolver.Get(c2pScheme)
+	targetURL, _ := url.Parse("google-c2p://an-authority/resource")
+
+	_, err := builder.Build(resolver.Target{URL: *targetURL}, nil, resolver.BuildOptions{})
+	if err == nil {
+		t.Fatalf("c2p resolver should not support target's with authorities, but build succeeded")
 	}
 }


### PR DESCRIPTION
As per [gRPC DirectPath C2P Resolver](https://docs.google.com/document/d/1YpKFQHSzG7YoNHXbY74Xc_-oiSDJ3w7XH4WPNDKP9UQ/edit?resourcekey=0-JG5kLNkW3FVwY59_2HSZnA#) doc, The "google-c2p" URI scheme will not support authorities.

This diff will validate that 


RELEASE NOTES:
* xds/google-c2p: validate URI schema for no authorities