### PR TITLE
benchmark: use default buffer sizes

### DIFF
--- a/benchmark/benchmark.go
+++ b/benchmark/benchmark.go
@@ -198,8 +198,6 @@ type ServerInfo struct {
 // StartServer starts a gRPC server serving a benchmark service according to info.
 // It returns a function to stop the server.
 func StartServer(info ServerInfo, opts ...grpc.ServerOption) func() {
-	opts = append(opts, grpc.WriteBufferSize(128*1024))
-	opts = append(opts, grpc.ReadBufferSize(128*1024))
 	s := grpc.NewServer(opts...)
 	switch info.Type {
 	case "protobuf":
@@ -278,8 +276,6 @@ func NewClientConn(addr string, opts ...grpc.DialOption) *grpc.ClientConn {
 
 // NewClientConnWithContext creates a gRPC client connection to addr using ctx.
 func NewClientConnWithContext(ctx context.Context, addr string, opts ...grpc.DialOption) *grpc.ClientConn {
-	opts = append(opts, grpc.WithWriteBufferSize(128*1024))
-	opts = append(opts, grpc.WithReadBufferSize(128*1024))
 	conn, err := grpc.DialContext(ctx, addr, opts...)
 	if err != nil {
 		logger.Fatalf("NewClientConn(%q) failed to create a ClientConn %v", addr, err)


### PR DESCRIPTION
The read and write buffer sizes are currently hardcoded to 128KB instead of the default 32KB. This can potentially lead to misleading benchmark results in the most common case, since most users presumably use the default value.

This change removes the custom value for read and write transport buffer sizes, both client and server side, so that benchmarks use the default values instead.

RELEASE NOTES: none