### PR TITLE
Implement new reflection v1 server and public API

### DIFF
--- a/reflection/serverreflection_test.go
+++ b/reflection/serverreflection_test.go
@@ -30,7 +30,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/internal/grpctest"
-	rpb "google.golang.org/grpc/reflection/grpc_reflection_v1alpha"
+	rv1alphapb "google.golang.org/grpc/reflection/grpc_reflection_v1alpha"
 	pb "google.golang.org/grpc/reflection/grpc_testing"
 	pbv3 "google.golang.org/grpc/reflection/grpc_testing_not_regenerate"
 	"google.golang.org/protobuf/proto"
@@ -216,7 +216,7 @@ func (x) TestReflectionEnd2end(t *testing.T) {
 	}
 	defer conn.Close()
 
-	c := rpb.NewServerReflectionClient(conn)
+	c := rv1alphapb.NewServerReflectionClient(conn)
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
 	stream, err := c.ServerReflectionInfo(ctx, grpc.WaitForReady(true))
@@ -239,10 +239,10 @@ func (x) TestReflectionEnd2end(t *testing.T) {
 	s.Stop()
 }
 
-func testFileByFilenameTransitiveClosure(t *testing.T, stream rpb.ServerReflection_ServerReflectionInfoClient, expectClosure bool) {
+func testFileByFilenameTransitiveClosure(t *testing.T, stream rv1alphapb.ServerReflection_ServerReflectionInfoClient, expectClosure bool) {
 	filename := "reflection/grpc_testing/proto2_ext2.proto"
-	if err := stream.Send(&rpb.ServerReflectionRequest{
-		MessageRequest: &rpb.ServerReflectionRequest_FileByFilename{
+	if err := stream.Send(&rv1alphapb.ServerReflectionRequest{
+		MessageRequest: &rv1alphapb.ServerReflectionRequest_FileByFilename{
 			FileByFilename: filename,
 		},
 	}); err != nil {
@@ -254,7 +254,7 @@ func testFileByFilenameTransitiveClosure(t *testing.T, stream rpb.ServerReflecti
 		t.Fatalf("failed to recv response: %v", err)
 	}
 	switch r.MessageResponse.(type) {
-	case *rpb.ServerReflectionResponse_FileDescriptorResponse:
+	case *rv1alphapb.ServerReflectionResponse_FileDescriptorResponse:
 		if !reflect.DeepEqual(r.GetFileDescriptorResponse().FileDescriptorProto[0], fdProto2Ext2Byte) {
 			t.Errorf("FileByFilename(%v)\nreceived: %q,\nwant: %q", filename, r.GetFileDescriptorResponse().FileDescriptorProto[0], fdProto2Ext2Byte)
 		}
@@ -272,7 +272,7 @@ func testFileByFilenameTransitiveClosure(t *testing.T, stream rpb.ServerReflecti
 	}
 }
 
-func testFileByFilename(t *testing.T, stream rpb.ServerReflection_ServerReflectionInfoClient) {
+func testFileByFilename(t *testing.T, stream rv1alphapb.ServerReflection_ServerReflectionInfoClient) {
 	for _, test := range []struct {
 		filename string
 		want     []byte
@@ -282,8 +282,8 @@ func testFileByFilename(t *testing.T, stream rpb.ServerReflection_ServerReflecti
 		{"reflection/grpc_testing/proto2_ext.proto", fdProto2ExtByte},
 		{"dynamic.proto", fdDynamicByte},
 	} {
-		if err := stream.Send(&rpb.ServerReflectionRequest{
-			MessageRequest: &rpb.ServerReflectionRequest_FileByFilename{
+		if err := stream.Send(&rv1alphapb.ServerReflectionRequest{
+			MessageRequest: &rv1alphapb.ServerReflectionRequest_FileByFilename{
 				FileByFilename: test.filename,
 			},
 		}); err != nil {
@@ -296,7 +296,7 @@ func testFileByFilename(t *testing.T, stream rpb.ServerReflection_ServerReflecti
 		}
 
 		switch r.MessageResponse.(type) {
-		case *rpb.ServerReflectionResponse_FileDescriptorResponse:
+		case *rv1alphapb.ServerReflectionResponse_FileDescriptorResponse:
 			if !reflect.DeepEqual(r.GetFileDescriptorResponse().FileDescriptorProto[0], test.want) {
 				t.Errorf("FileByFilename(%v)\nreceived: %q,\nwant: %q", test.filename, r.GetFileDescriptorResponse().FileDescriptorProto[0], test.want)
 			}
@@ -306,14 +306,14 @@ func testFileByFilename(t *testing.T, stream rpb.ServerReflection_ServerReflecti
 	}
 }
 
-func testFileByFilenameError(t *testing.T, stream rpb.ServerReflection_ServerReflectionInfoClient) {
+func testFileByFilenameError(t *testing.T, stream rv1alphapb.ServerReflection_ServerReflectionInfoClient) {
 	for _, test := range []string{
 		"test.poto",
 		"proo2.proto",
 		"proto2_et.proto",
 	} {
-		if err := stream.Send(&rpb.ServerReflectionRequest{
-			MessageRequest: &rpb.ServerReflectionRequest_FileByFilename{
+		if err := stream.Send(&rv1alphapb.ServerReflectionRequest{
+			MessageRequest: &rv1alphapb.ServerReflectionRequest_FileByFilename{
 				FileByFilename: test,
 			},
 		}); err != nil {
@@ -326,14 +326,14 @@ func testFileByFilenameError(t *testing.T, stream rpb.ServerReflection_ServerRef
 		}
 
 		switch r.MessageResponse.(type) {
-		case *rpb.ServerReflectionResponse_ErrorResponse:
+		case *rv1alphapb.ServerReflectionResponse_ErrorResponse:
 		default:
 			t.Errorf("FileByFilename(%v) = %v, want type <ServerReflectionResponse_ErrorResponse>", test, r.MessageResponse)
 		}
 	}
 }
 
-func testFileContainingSymbol(t *testing.T, stream rpb.ServerReflection_ServerReflectionInfoClient) {
+func testFileContainingSymbol(t *testing.T, stream rv1alphapb.ServerReflection_ServerReflectionInfoClient) {
 	for _, test := range []struct {
 		symbol string
 		want   []byte
@@ -359,8 +359,8 @@ func testFileContainingSymbol(t *testing.T, stream rpb.ServerReflection_ServerRe
 		{"grpc.testing.DynamicReq", fdDynamicByte},
 		{"grpc.testing.DynamicRes", fdDynamicByte},
 	} {
-		if err := stream.Send(&rpb.ServerReflectionRequest{
-			MessageRequest: &rpb.ServerReflectionRequest_FileContainingSymbol{
+		if err := stream.Send(&rv1alphapb.ServerReflectionRequest{
+			MessageRequest: &rv1alphapb.ServerReflectionRequest_FileContainingSymbol{
 				FileContainingSymbol: test.symbol,
 			},
 		}); err != nil {
@@ -373,7 +373,7 @@ func testFileContainingSymbol(t *testing.T, stream rpb.ServerReflection_ServerRe
 		}
 
 		switch r.MessageResponse.(type) {
-		case *rpb.ServerReflectionResponse_FileDescriptorResponse:
+		case *rv1alphapb.ServerReflectionResponse_FileDescriptorResponse:
 			if !reflect.DeepEqual(r.GetFileDescriptorResponse().FileDescriptorProto[0], test.want) {
 				t.Errorf("FileContainingSymbol(%v)\nreceived: %q,\nwant: %q", test.symbol, r.GetFileDescriptorResponse().FileDescriptorProto[0], test.want)
 			}
@@ -383,15 +383,15 @@ func testFileContainingSymbol(t *testing.T, stream rpb.ServerReflection_ServerRe
 	}
 }
 
-func testFileContainingSymbolError(t *testing.T, stream rpb.ServerReflection_ServerReflectionInfoClient) {
+func testFileContainingSymbolError(t *testing.T, stream rv1alphapb.ServerReflection_ServerReflectionInfoClient) {
 	for _, test := range []string{
 		"grpc.testing.SerchService",
 		"grpc.testing.SearchService.SearchE",
 		"grpc.tesing.SearchResponse",
 		"gpc.testing.ToBeExtended",
 	} {
-		if err := stream.Send(&rpb.ServerReflectionRequest{
-			MessageRequest: &rpb.ServerReflectionRequest_FileContainingSymbol{
+		if err := stream.Send(&rv1alphapb.ServerReflectionRequest{
+			MessageRequest: &rv1alphapb.ServerReflectionRequest_FileContainingSymbol{
 				FileContainingSymbol: test,
 			},
 		}); err != nil {
@@ -404,14 +404,14 @@ func testFileContainingSymbolError(t *testing.T, stream rpb.ServerReflection_Ser
 		}
 
 		switch r.MessageResponse.(type) {
-		case *rpb.ServerReflectionResponse_ErrorResponse:
+		case *rv1alphapb.ServerReflectionResponse_ErrorResponse:
 		default:
 			t.Errorf("FileContainingSymbol(%v) = %v, want type <ServerReflectionResponse_ErrorResponse>", test, r.MessageResponse)
 		}
 	}
 }
 
-func testFileContainingExtension(t *testing.T, stream rpb.ServerReflection_ServerReflectionInfoClient) {
+func testFileContainingExtension(t *testing.T, stream rv1alphapb.ServerReflection_ServerReflectionInfoClient) {
 	for _, test := range []struct {
 		typeName string
 		extNum   int32
@@ -423,9 +423,9 @@ func testFileContainingExtension(t *testing.T, stream rpb.ServerReflection_Serve
 		{"grpc.testing.ToBeExtended", 23, fdProto2Ext2Byte},
 		{"grpc.testing.ToBeExtended", 29, fdProto2Ext2Byte},
 	} {
-		if err := stream.Send(&rpb.ServerReflectionRequest{
-			MessageRequest: &rpb.ServerReflectionRequest_FileContainingExtension{
-				FileContainingExtension: &rpb.ExtensionRequest{
+		if err := stream.Send(&rv1alphapb.ServerReflectionRequest{
+			MessageRequest: &rv1alphapb.ServerReflectionRequest_FileContainingExtension{
+				FileContainingExtension: &rv1alphapb.ExtensionRequest{
 					ContainingType:  test.typeName,
 					ExtensionNumber: test.extNum,
 				},
@@ -440,7 +440,7 @@ func testFileContainingExtension(t *testing.T, stream rpb.ServerReflection_Serve
 		}
 
 		switch r.MessageResponse.(type) {
-		case *rpb.ServerReflectionResponse_FileDescriptorResponse:
+		case *rv1alphapb.ServerReflectionResponse_FileDescriptorResponse:
 			if !reflect.DeepEqual(r.GetFileDescriptorResponse().FileDescriptorProto[0], test.want) {
 				t.Errorf("FileContainingExtension(%v, %v)\nreceived: %q,\nwant: %q", test.typeName, test.extNum, r.GetFileDescriptorResponse().FileDescriptorProto[0], test.want)
 			}
@@ -450,7 +450,7 @@ func testFileContainingExtension(t *testing.T, stream rpb.ServerReflection_Serve
 	}
 }
 
-func testFileContainingExtensionError(t *testing.T, stream rpb.ServerReflection_ServerReflectionInfoClient) {
+func testFileContainingExtensionError(t *testing.T, stream rv1alphapb.ServerReflection_ServerReflectionInfoClient) {
 	for _, test := range []struct {
 		typeName string
 		extNum   int32
@@ -458,9 +458,9 @@ func testFileContainingExtensionError(t *testing.T, stream rpb.ServerReflection_
 		{"grpc.testing.ToBExtended", 17},
 		{"grpc.testing.ToBeExtended", 15},
 	} {
-		if err := stream.Send(&rpb.ServerReflectionRequest{
-			MessageRequest: &rpb.ServerReflectionRequest_FileContainingExtension{
-				FileContainingExtension: &rpb.ExtensionRequest{
+		if err := stream.Send(&rv1alphapb.ServerReflectionRequest{
+			MessageRequest: &rv1alphapb.ServerReflectionRequest_FileContainingExtension{
+				FileContainingExtension: &rv1alphapb.ExtensionRequest{
 					ContainingType:  test.typeName,
 					ExtensionNumber: test.extNum,
 				},
@@ -475,14 +475,14 @@ func testFileContainingExtensionError(t *testing.T, stream rpb.ServerReflection_
 		}
 
 		switch r.MessageResponse.(type) {
-		case *rpb.ServerReflectionResponse_ErrorResponse:
+		case *rv1alphapb.ServerReflectionResponse_ErrorResponse:
 		default:
 			t.Errorf("FileContainingExtension(%v, %v) = %v, want type <ServerReflectionResponse_FileDescriptorResponse>", test.typeName, test.extNum, r.MessageResponse)
 		}
 	}
 }
 
-func testAllExtensionNumbersOfType(t *testing.T, stream rpb.ServerReflection_ServerReflectionInfoClient) {
+func testAllExtensionNumbersOfType(t *testing.T, stream rv1alphapb.ServerReflection_ServerReflectionInfoClient) {
 	for _, test := range []struct {
 		typeName string
 		want     []int32
@@ -490,8 +490,8 @@ func testAllExtensionNumbersOfType(t *testing.T, stream rpb.ServerReflection_Ser
 		{"grpc.testing.ToBeExtended", []int32{13, 17, 19, 23, 29}},
 		{"grpc.testing.DynamicReq", nil},
 	} {
-		if err := stream.Send(&rpb.ServerReflectionRequest{
-			MessageRequest: &rpb.ServerReflectionRequest_AllExtensionNumbersOfType{
+		if err := stream.Send(&rv1alphapb.ServerReflectionRequest{
+			MessageRequest: &rv1alphapb.ServerReflectionRequest_AllExtensionNumbersOfType{
 				AllExtensionNumbersOfType: test.typeName,
 			},
 		}); err != nil {
@@ -504,7 +504,7 @@ func testAllExtensionNumbersOfType(t *testing.T, stream rpb.ServerReflection_Ser
 		}
 
 		switch r.MessageResponse.(type) {
-		case *rpb.ServerReflectionResponse_AllExtensionNumbersResponse:
+		case *rv1alphapb.ServerReflectionResponse_AllExtensionNumbersResponse:
 			extNum := r.GetAllExtensionNumbersResponse().ExtensionNumber
 			sort.Sort(intArray(extNum))
 			if r.GetAllExtensionNumbersResponse().BaseTypeName != test.typeName ||
@@ -517,12 +517,12 @@ func testAllExtensionNumbersOfType(t *testing.T, stream rpb.ServerReflection_Ser
 	}
 }
 
-func testAllExtensionNumbersOfTypeError(t *testing.T, stream rpb.ServerReflection_ServerReflectionInfoClient) {
+func testAllExtensionNumbersOfTypeError(t *testing.T, stream rv1alphapb.ServerReflection_ServerReflectionInfoClient) {
 	for _, test := range []string{
 		"grpc.testing.ToBeExtendedE",
 	} {
-		if err := stream.Send(&rpb.ServerReflectionRequest{
-			MessageRequest: &rpb.ServerReflectionRequest_AllExtensionNumbersOfType{
+		if err := stream.Send(&rv1alphapb.ServerReflectionRequest{
+			MessageRequest: &rv1alphapb.ServerReflectionRequest_AllExtensionNumbersOfType{
 				AllExtensionNumbersOfType: test,
 			},
 		}); err != nil {
@@ -535,16 +535,16 @@ func testAllExtensionNumbersOfTypeError(t *testing.T, stream rpb.ServerReflectio
 		}
 
 		switch r.MessageResponse.(type) {
-		case *rpb.ServerReflectionResponse_ErrorResponse:
+		case *rv1alphapb.ServerReflectionResponse_ErrorResponse:
 		default:
 			t.Errorf("AllExtensionNumbersOfType(%v) = %v, want type <ServerReflectionResponse_ErrorResponse>", test, r.MessageResponse)
 		}
 	}
 }
 
-func testListServices(t *testing.T, stream rpb.ServerReflection_ServerReflectionInfoClient) {
-	if err := stream.Send(&rpb.ServerReflectionRequest{
-		MessageRequest: &rpb.ServerReflectionRequest_ListServices{},
+func testListServices(t *testing.T, stream rv1alphapb.ServerReflection_ServerReflectionInfoClient) {
+	if err := stream.Send(&rv1alphapb.ServerReflectionRequest{
+		MessageRequest: &rv1alphapb.ServerReflectionRequest_ListServices{},
 	}); err != nil {
 		t.Fatalf("failed to send request: %v", err)
 	}
@@ -555,7 +555,7 @@ func testListServices(t *testing.T, stream rpb.ServerReflection_ServerReflection
 	}
 
 	switch r.MessageResponse.(type) {
-	case *rpb.ServerReflectionResponse_ListServicesResponse:
+	case *rv1alphapb.ServerReflectionResponse_ListServicesResponse:
 		services := r.GetListServicesResponse().Service
 		want := []string{
 			"grpc.testingv3.SearchServiceV3",

--- a/reflection/serverreflectionv1.go
+++ b/reflection/serverreflectionv1.go
@@ -1,0 +1,263 @@
+/*
+ *
+ * Copyright 2016 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/*
+Package reflection implements server reflection service.
+
+The service implemented is defined in:
+https://github.com/grpc/grpc/blob/master/src/proto/grpc/reflection/v1alpha/reflection.proto.
+
+To register server reflection on a gRPC server:
+
+	import "google.golang.org/grpc/reflection"
+
+	s := grpc.NewServer()
+	pb.RegisterYourOwnServer(s, &server{})
+
+	// Register reflection service on gRPC server.
+	reflection.Register(s)
+
+	s.Serve(lis)
+*/
+package reflection // import "google.golang.org/grpc/reflection"
+
+import (
+	"io"
+	"sort"
+
+	"google.golang.org/grpc/codes"
+	rv1pb "google.golang.org/grpc/reflection/grpc_reflection_v1"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protodesc"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/reflect/protoregistry"
+)
+
+// Register registers the server reflection service on the given gRPC server.
+func RegisterV1(s GRPCServer) {
+	svr := NewServerV1(ServerOptions{Services: s})
+	rv1pb.RegisterServerReflectionServer(s, svr)
+}
+
+// NewServer returns a reflection server implementation using the given options.
+// This can be used to customize behavior of the reflection service. Most usages
+// should prefer to use Register instead.
+//
+// # Experimental
+//
+// Notice: This function is EXPERIMENTAL and may be changed or removed in a
+// later release.
+func NewServerV1(opts ServerOptions) rv1pb.ServerReflectionServer {
+	if opts.DescriptorResolver == nil {
+		opts.DescriptorResolver = protoregistry.GlobalFiles
+	}
+	if opts.ExtensionResolver == nil {
+		opts.ExtensionResolver = protoregistry.GlobalTypes
+	}
+	return &serverReflectionServerV1{
+		s:            opts.Services,
+		descResolver: opts.DescriptorResolver,
+		extResolver:  opts.ExtensionResolver,
+	}
+}
+
+type serverReflectionServerV1 struct {
+	rv1pb.UnimplementedServerReflectionServer
+	s            ServiceInfoProvider
+	descResolver protodesc.Resolver
+	extResolver  ExtensionResolver
+}
+
+// fileDescWithDependencies returns a slice of serialized fileDescriptors in
+// wire format ([]byte). The fileDescriptors will include fd and all the
+// transitive dependencies of fd with names not in sentFileDescriptors.
+func (s *serverReflectionServerV1) fileDescWithDependencies(fd protoreflect.FileDescriptor, sentFileDescriptors map[string]bool) ([][]byte, error) {
+	var r [][]byte
+	queue := []protoreflect.FileDescriptor{fd}
+	for len(queue) > 0 {
+		currentfd := queue[0]
+		queue = queue[1:]
+		if sent := sentFileDescriptors[currentfd.Path()]; len(r) == 0 || !sent {
+			sentFileDescriptors[currentfd.Path()] = true
+			fdProto := protodesc.ToFileDescriptorProto(currentfd)
+			currentfdEncoded, err := proto.Marshal(fdProto)
+			if err != nil {
+				return nil, err
+			}
+			r = append(r, currentfdEncoded)
+		}
+		for i := 0; i < currentfd.Imports().Len(); i++ {
+			queue = append(queue, currentfd.Imports().Get(i))
+		}
+	}
+	return r, nil
+}
+
+// fileDescEncodingContainingSymbol finds the file descriptor containing the
+// given symbol, finds all of its previously unsent transitive dependencies,
+// does marshalling on them, and returns the marshalled result. The given symbol
+// can be a type, a service or a method.
+func (s *serverReflectionServerV1) fileDescEncodingContainingSymbol(name string, sentFileDescriptors map[string]bool) ([][]byte, error) {
+	d, err := s.descResolver.FindDescriptorByName(protoreflect.FullName(name))
+	if err != nil {
+		return nil, err
+	}
+	return s.fileDescWithDependencies(d.ParentFile(), sentFileDescriptors)
+}
+
+// fileDescEncodingContainingExtension finds the file descriptor containing
+// given extension, finds all of its previously unsent transitive dependencies,
+// does marshalling on them, and returns the marshalled result.
+func (s *serverReflectionServerV1) fileDescEncodingContainingExtension(typeName string, extNum int32, sentFileDescriptors map[string]bool) ([][]byte, error) {
+	xt, err := s.extResolver.FindExtensionByNumber(protoreflect.FullName(typeName), protoreflect.FieldNumber(extNum))
+	if err != nil {
+		return nil, err
+	}
+	return s.fileDescWithDependencies(xt.TypeDescriptor().ParentFile(), sentFileDescriptors)
+}
+
+// allExtensionNumbersForTypeName returns all extension numbers for the given type.
+func (s *serverReflectionServerV1) allExtensionNumbersForTypeName(name string) ([]int32, error) {
+	var numbers []int32
+	s.extResolver.RangeExtensionsByMessage(protoreflect.FullName(name), func(xt protoreflect.ExtensionType) bool {
+		numbers = append(numbers, int32(xt.TypeDescriptor().Number()))
+		return true
+	})
+	sort.Slice(numbers, func(i, j int) bool {
+		return numbers[i] < numbers[j]
+	})
+	if len(numbers) == 0 {
+		// maybe return an error if given type name is not known
+		if _, err := s.descResolver.FindDescriptorByName(protoreflect.FullName(name)); err != nil {
+			return nil, err
+		}
+	}
+	return numbers, nil
+}
+
+// listServices returns the names of services this server exposes.
+func (s *serverReflectionServerV1) listServices() []*rv1pb.ServiceResponse {
+	serviceInfo := s.s.GetServiceInfo()
+	resp := make([]*rv1pb.ServiceResponse, 0, len(serviceInfo))
+	for svc := range serviceInfo {
+		resp = append(resp, &rv1pb.ServiceResponse{Name: svc})
+	}
+	sort.Slice(resp, func(i, j int) bool {
+		return resp[i].Name < resp[j].Name
+	})
+	return resp
+}
+
+// ServerReflectionInfo is the reflection service handler.
+func (s *serverReflectionServerV1) ServerReflectionInfo(stream rv1pb.ServerReflection_ServerReflectionInfoServer) error {
+	sentFileDescriptors := make(map[string]bool)
+	for {
+		in, err := stream.Recv()
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+
+		out := &rv1pb.ServerReflectionResponse{
+			ValidHost:       in.Host,
+			OriginalRequest: in,
+		}
+		switch req := in.MessageRequest.(type) {
+		case *rv1pb.ServerReflectionRequest_FileByFilename:
+			var b [][]byte
+			fd, err := s.descResolver.FindFileByPath(req.FileByFilename)
+			if err == nil {
+				b, err = s.fileDescWithDependencies(fd, sentFileDescriptors)
+			}
+			if err != nil {
+				out.MessageResponse = &rv1pb.ServerReflectionResponse_ErrorResponse{
+					ErrorResponse: &rv1pb.ErrorResponse{
+						ErrorCode:    int32(codes.NotFound),
+						ErrorMessage: err.Error(),
+					},
+				}
+			} else {
+				out.MessageResponse = &rv1pb.ServerReflectionResponse_FileDescriptorResponse{
+					FileDescriptorResponse: &rv1pb.FileDescriptorResponse{FileDescriptorProto: b},
+				}
+			}
+		case *rv1pb.ServerReflectionRequest_FileContainingSymbol:
+			b, err := s.fileDescEncodingContainingSymbol(req.FileContainingSymbol, sentFileDescriptors)
+			if err != nil {
+				out.MessageResponse = &rv1pb.ServerReflectionResponse_ErrorResponse{
+					ErrorResponse: &rv1pb.ErrorResponse{
+						ErrorCode:    int32(codes.NotFound),
+						ErrorMessage: err.Error(),
+					},
+				}
+			} else {
+				out.MessageResponse = &rv1pb.ServerReflectionResponse_FileDescriptorResponse{
+					FileDescriptorResponse: &rv1pb.FileDescriptorResponse{FileDescriptorProto: b},
+				}
+			}
+		case *rv1pb.ServerReflectionRequest_FileContainingExtension:
+			typeName := req.FileContainingExtension.ContainingType
+			extNum := req.FileContainingExtension.ExtensionNumber
+			b, err := s.fileDescEncodingContainingExtension(typeName, extNum, sentFileDescriptors)
+			if err != nil {
+				out.MessageResponse = &rv1pb.ServerReflectionResponse_ErrorResponse{
+					ErrorResponse: &rv1pb.ErrorResponse{
+						ErrorCode:    int32(codes.NotFound),
+						ErrorMessage: err.Error(),
+					},
+				}
+			} else {
+				out.MessageResponse = &rv1pb.ServerReflectionResponse_FileDescriptorResponse{
+					FileDescriptorResponse: &rv1pb.FileDescriptorResponse{FileDescriptorProto: b},
+				}
+			}
+		case *rv1pb.ServerReflectionRequest_AllExtensionNumbersOfType:
+			extNums, err := s.allExtensionNumbersForTypeName(req.AllExtensionNumbersOfType)
+			if err != nil {
+				out.MessageResponse = &rv1pb.ServerReflectionResponse_ErrorResponse{
+					ErrorResponse: &rv1pb.ErrorResponse{
+						ErrorCode:    int32(codes.NotFound),
+						ErrorMessage: err.Error(),
+					},
+				}
+			} else {
+				out.MessageResponse = &rv1pb.ServerReflectionResponse_AllExtensionNumbersResponse{
+					AllExtensionNumbersResponse: &rv1pb.ExtensionNumberResponse{
+						BaseTypeName:    req.AllExtensionNumbersOfType,
+						ExtensionNumber: extNums,
+					},
+				}
+			}
+		case *rv1pb.ServerReflectionRequest_ListServices:
+			out.MessageResponse = &rv1pb.ServerReflectionResponse_ListServicesResponse{
+				ListServicesResponse: &rv1pb.ListServiceResponse{
+					Service: s.listServices(),
+				},
+			}
+		default:
+			return status.Errorf(codes.InvalidArgument, "invalid MessageRequest: %v", in.MessageRequest)
+		}
+
+		if err := stream.Send(out); err != nil {
+			return err
+		}
+	}
+}

--- a/reflection/serverreflectionv1_test.go
+++ b/reflection/serverreflectionv1_test.go
@@ -1,0 +1,545 @@
+/*
+*
+* Copyright 2016 gRPC authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+ */
+
+package reflection
+
+import (
+	"context"
+	"net"
+	"reflect"
+	"sort"
+	"testing"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/internal/grpctest"
+	rv1pb "google.golang.org/grpc/reflection/grpc_reflection_v1"
+	pb "google.golang.org/grpc/reflection/grpc_testing"
+	pbv3 "google.golang.org/grpc/reflection/grpc_testing_not_regenerate"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/descriptorpb"
+)
+
+var (
+	sv1 = NewServerV1(ServerOptions{}).(*serverReflectionServerV1)
+)
+
+type xv1 struct {
+	grpctest.Tester
+}
+
+func TestV1(t *testing.T) {
+	grpctest.RunSubTests(t, xv1{})
+}
+
+// func loadFileDesc(filename string) (*descriptorpb.FileDescriptorProto, []byte) {
+// 	fd, err := protoregistry.GlobalFiles.FindFileByPath(filename)
+// 	if err != nil {
+// 		panic(err)
+// 	}
+// 	fdProto := protodesc.ToFileDescriptorProto(fd)
+// 	b, err := proto.Marshal(fdProto)
+// 	if err != nil {
+// 		panic(fmt.Sprintf("failed to marshal fd: %v", err))
+// 	}
+// 	return fdProto, b
+// }
+
+// func loadFileDescDynamic(b []byte) (*descriptorpb.FileDescriptorProto, protoreflect.FileDescriptor, []byte) {
+// 	m := new(descriptorpb.FileDescriptorProto)
+// 	if err := proto.Unmarshal(b, m); err != nil {
+// 		panic("failed to unmarshal dynamic proto raw descriptor")
+// 	}
+
+// 	fd, err := protodesc.NewFile(m, nil)
+// 	if err != nil {
+// 		panic(err)
+// 	}
+
+// 	err = protoregistry.GlobalFiles.RegisterFile(fd)
+// 	if err != nil {
+// 		panic(err)
+// 	}
+
+// 	for i := 0; i < fd.Messages().Len(); i++ {
+// 		m := fd.Messages().Get(i)
+// 		if err := protoregistry.GlobalTypes.RegisterMessage(dynamicpb.NewMessageType(m)); err != nil {
+// 			panic(err)
+// 		}
+// 	}
+
+// 	return m, fd, b
+// }
+
+func (xv1) TestFileDescContainingExtension(t *testing.T) {
+	for _, test := range []struct {
+		st     string
+		extNum int32
+		want   *descriptorpb.FileDescriptorProto
+	}{
+		{"grpc.testing.ToBeExtended", 13, fdProto2Ext},
+		{"grpc.testing.ToBeExtended", 17, fdProto2Ext},
+		{"grpc.testing.ToBeExtended", 19, fdProto2Ext},
+		{"grpc.testing.ToBeExtended", 23, fdProto2Ext2},
+		{"grpc.testing.ToBeExtended", 29, fdProto2Ext2},
+	} {
+		fd, err := sv1.fileDescEncodingContainingExtension(test.st, test.extNum, map[string]bool{})
+		if err != nil {
+			t.Errorf("fileDescContainingExtension(%q) return error: %v", test.st, err)
+			continue
+		}
+		var actualFd descriptorpb.FileDescriptorProto
+		if err := proto.Unmarshal(fd[0], &actualFd); err != nil {
+			t.Errorf("fileDescContainingExtension(%q) return invalid bytes: %v", test.st, err)
+			continue
+		}
+		if !proto.Equal(&actualFd, test.want) {
+			t.Errorf("fileDescContainingExtension(%q) returned %q, but wanted %q", test.st, &actualFd, test.want)
+		}
+	}
+}
+
+func (xv1) TestAllExtensionNumbersForTypeName(t *testing.T) {
+	for _, test := range []struct {
+		st   string
+		want []int32
+	}{
+		{"grpc.testing.ToBeExtended", []int32{13, 17, 19, 23, 29}},
+	} {
+		r, err := sv1.allExtensionNumbersForTypeName(test.st)
+		sort.Sort(intArray(r))
+		if err != nil || !reflect.DeepEqual(r, test.want) {
+			t.Errorf("allExtensionNumbersForType(%q) = %v, %v, want %v, <nil>", test.st, r, err, test.want)
+		}
+	}
+}
+
+// Do end2end tests.
+
+func (xv1) TestReflectionEnd2end(t *testing.T) {
+	// Start server.
+	lis, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+	s := grpc.NewServer()
+	pb.RegisterSearchServiceServer(s, &server{})
+	pbv3.RegisterSearchServiceV3Server(s, &serverV3{})
+
+	registerDynamicProto(s, fdDynamic, fdDynamicFile)
+
+	// Register reflection service on s.
+	RegisterV1(s)
+	go s.Serve(lis)
+
+	// Create client.
+	conn, err := grpc.Dial(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("cannot connect to server: %v", err)
+	}
+	defer conn.Close()
+
+	c := rv1pb.NewServerReflectionClient(conn)
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	stream, err := c.ServerReflectionInfo(ctx, grpc.WaitForReady(true))
+	if err != nil {
+		t.Fatalf("cannot get ServerReflectionInfo: %v", err)
+	}
+
+	testFileByFilenameTransitiveClosureV1(t, stream, true)
+	testFileByFilenameTransitiveClosureV1(t, stream, false)
+	testFileByFilenameV1(t, stream)
+	testFileByFilenameErrorV1(t, stream)
+	testFileContainingSymbolV1(t, stream)
+	testFileContainingSymbolErrorV1(t, stream)
+	testFileContainingExtensionV1(t, stream)
+	testFileContainingExtensionErrorV1(t, stream)
+	testAllExtensionNumbersOfTypeV1(t, stream)
+	testAllExtensionNumbersOfTypeErrorV1(t, stream)
+	testListServicesV1(t, stream)
+
+	s.Stop()
+}
+
+func testFileByFilenameTransitiveClosureV1(t *testing.T, stream rv1pb.ServerReflection_ServerReflectionInfoClient, expectClosure bool) {
+	filename := "reflection/grpc_testing/proto2_ext2.proto"
+	if err := stream.Send(&rv1pb.ServerReflectionRequest{
+		MessageRequest: &rv1pb.ServerReflectionRequest_FileByFilename{
+			FileByFilename: filename,
+		},
+	}); err != nil {
+		t.Fatalf("failed to send request: %v", err)
+	}
+	r, err := stream.Recv()
+	if err != nil {
+		// io.EOF is not ok.
+		t.Fatalf("failed to recv response: %v", err)
+	}
+	switch r.MessageResponse.(type) {
+	case *rv1pb.ServerReflectionResponse_FileDescriptorResponse:
+		if !reflect.DeepEqual(r.GetFileDescriptorResponse().FileDescriptorProto[0], fdProto2Ext2Byte) {
+			t.Errorf("FileByFilename(%v)\nreceived: %q,\nwant: %q", filename, r.GetFileDescriptorResponse().FileDescriptorProto[0], fdProto2Ext2Byte)
+		}
+		if expectClosure {
+			if len(r.GetFileDescriptorResponse().FileDescriptorProto) != 2 {
+				t.Errorf("FileByFilename(%v) returned %v file descriptors, expected 2", filename, len(r.GetFileDescriptorResponse().FileDescriptorProto))
+			} else if !reflect.DeepEqual(r.GetFileDescriptorResponse().FileDescriptorProto[1], fdProto2Byte) {
+				t.Errorf("FileByFilename(%v)\nreceived: %q,\nwant: %q", filename, r.GetFileDescriptorResponse().FileDescriptorProto[1], fdProto2Byte)
+			}
+		} else if len(r.GetFileDescriptorResponse().FileDescriptorProto) != 1 {
+			t.Errorf("FileByFilename(%v) returned %v file descriptors, expected 1", filename, len(r.GetFileDescriptorResponse().FileDescriptorProto))
+		}
+	default:
+		t.Errorf("FileByFilename(%v) = %v, want type <ServerReflectionResponse_FileDescriptorResponse>", filename, r.MessageResponse)
+	}
+}
+
+func testFileByFilenameV1(t *testing.T, stream rv1pb.ServerReflection_ServerReflectionInfoClient) {
+	for _, test := range []struct {
+		filename string
+		want     []byte
+	}{
+		{"reflection/grpc_testing/test.proto", fdTestByte},
+		{"reflection/grpc_testing/proto2.proto", fdProto2Byte},
+		{"reflection/grpc_testing/proto2_ext.proto", fdProto2ExtByte},
+		{"dynamic.proto", fdDynamicByte},
+	} {
+		if err := stream.Send(&rv1pb.ServerReflectionRequest{
+			MessageRequest: &rv1pb.ServerReflectionRequest_FileByFilename{
+				FileByFilename: test.filename,
+			},
+		}); err != nil {
+			t.Fatalf("failed to send request: %v", err)
+		}
+		r, err := stream.Recv()
+		if err != nil {
+			// io.EOF is not ok.
+			t.Fatalf("failed to recv response: %v", err)
+		}
+
+		switch r.MessageResponse.(type) {
+		case *rv1pb.ServerReflectionResponse_FileDescriptorResponse:
+			if !reflect.DeepEqual(r.GetFileDescriptorResponse().FileDescriptorProto[0], test.want) {
+				t.Errorf("FileByFilename(%v)\nreceived: %q,\nwant: %q", test.filename, r.GetFileDescriptorResponse().FileDescriptorProto[0], test.want)
+			}
+		default:
+			t.Errorf("FileByFilename(%v) = %v, want type <ServerReflectionResponse_FileDescriptorResponse>", test.filename, r.MessageResponse)
+		}
+	}
+}
+
+func testFileByFilenameErrorV1(t *testing.T, stream rv1pb.ServerReflection_ServerReflectionInfoClient) {
+	for _, test := range []string{
+		"test.poto",
+		"proo2.proto",
+		"proto2_et.proto",
+	} {
+		if err := stream.Send(&rv1pb.ServerReflectionRequest{
+			MessageRequest: &rv1pb.ServerReflectionRequest_FileByFilename{
+				FileByFilename: test,
+			},
+		}); err != nil {
+			t.Fatalf("failed to send request: %v", err)
+		}
+		r, err := stream.Recv()
+		if err != nil {
+			// io.EOF is not ok.
+			t.Fatalf("failed to recv response: %v", err)
+		}
+
+		switch r.MessageResponse.(type) {
+		case *rv1pb.ServerReflectionResponse_ErrorResponse:
+		default:
+			t.Errorf("FileByFilename(%v) = %v, want type <ServerReflectionResponse_ErrorResponse>", test, r.MessageResponse)
+		}
+	}
+}
+
+func testFileContainingSymbolV1(t *testing.T, stream rv1pb.ServerReflection_ServerReflectionInfoClient) {
+	for _, test := range []struct {
+		symbol string
+		want   []byte
+	}{
+		{"grpc.testing.SearchService", fdTestByte},
+		{"grpc.testing.SearchService.Search", fdTestByte},
+		{"grpc.testing.SearchService.StreamingSearch", fdTestByte},
+		{"grpc.testing.SearchResponse", fdTestByte},
+		{"grpc.testing.ToBeExtended", fdProto2Byte},
+		// Test support package v3.
+		{"grpc.testingv3.SearchServiceV3", fdTestv3Byte},
+		{"grpc.testingv3.SearchServiceV3.Search", fdTestv3Byte},
+		{"grpc.testingv3.SearchServiceV3.StreamingSearch", fdTestv3Byte},
+		{"grpc.testingv3.SearchResponseV3", fdTestv3Byte},
+		// search for field, oneof, enum, and enum value symbols, too
+		{"grpc.testingv3.SearchResponseV3.Result.snippets", fdTestv3Byte},
+		{"grpc.testingv3.SearchResponseV3.Result.Value.val", fdTestv3Byte},
+		{"grpc.testingv3.SearchResponseV3.Result.Value.str", fdTestv3Byte},
+		{"grpc.testingv3.SearchResponseV3.State", fdTestv3Byte},
+		{"grpc.testingv3.SearchResponseV3.FRESH", fdTestv3Byte},
+		// Test dynamic symbols
+		{"grpc.testing.DynamicService", fdDynamicByte},
+		{"grpc.testing.DynamicReq", fdDynamicByte},
+		{"grpc.testing.DynamicRes", fdDynamicByte},
+	} {
+		if err := stream.Send(&rv1pb.ServerReflectionRequest{
+			MessageRequest: &rv1pb.ServerReflectionRequest_FileContainingSymbol{
+				FileContainingSymbol: test.symbol,
+			},
+		}); err != nil {
+			t.Fatalf("failed to send request: %v", err)
+		}
+		r, err := stream.Recv()
+		if err != nil {
+			// io.EOF is not ok.
+			t.Fatalf("failed to recv response: %v", err)
+		}
+
+		switch r.MessageResponse.(type) {
+		case *rv1pb.ServerReflectionResponse_FileDescriptorResponse:
+			if !reflect.DeepEqual(r.GetFileDescriptorResponse().FileDescriptorProto[0], test.want) {
+				t.Errorf("FileContainingSymbol(%v)\nreceived: %q,\nwant: %q", test.symbol, r.GetFileDescriptorResponse().FileDescriptorProto[0], test.want)
+			}
+		default:
+			t.Errorf("FileContainingSymbol(%v) = %v, want type <ServerReflectionResponse_FileDescriptorResponse>", test.symbol, r.MessageResponse)
+		}
+	}
+}
+
+func testFileContainingSymbolErrorV1(t *testing.T, stream rv1pb.ServerReflection_ServerReflectionInfoClient) {
+	for _, test := range []string{
+		"grpc.testing.SerchService",
+		"grpc.testing.SearchService.SearchE",
+		"grpc.tesing.SearchResponse",
+		"gpc.testing.ToBeExtended",
+	} {
+		if err := stream.Send(&rv1pb.ServerReflectionRequest{
+			MessageRequest: &rv1pb.ServerReflectionRequest_FileContainingSymbol{
+				FileContainingSymbol: test,
+			},
+		}); err != nil {
+			t.Fatalf("failed to send request: %v", err)
+		}
+		r, err := stream.Recv()
+		if err != nil {
+			// io.EOF is not ok.
+			t.Fatalf("failed to recv response: %v", err)
+		}
+
+		switch r.MessageResponse.(type) {
+		case *rv1pb.ServerReflectionResponse_ErrorResponse:
+		default:
+			t.Errorf("FileContainingSymbol(%v) = %v, want type <ServerReflectionResponse_ErrorResponse>", test, r.MessageResponse)
+		}
+	}
+}
+
+func testFileContainingExtensionV1(t *testing.T, stream rv1pb.ServerReflection_ServerReflectionInfoClient) {
+	for _, test := range []struct {
+		typeName string
+		extNum   int32
+		want     []byte
+	}{
+		{"grpc.testing.ToBeExtended", 13, fdProto2ExtByte},
+		{"grpc.testing.ToBeExtended", 17, fdProto2ExtByte},
+		{"grpc.testing.ToBeExtended", 19, fdProto2ExtByte},
+		{"grpc.testing.ToBeExtended", 23, fdProto2Ext2Byte},
+		{"grpc.testing.ToBeExtended", 29, fdProto2Ext2Byte},
+	} {
+		if err := stream.Send(&rv1pb.ServerReflectionRequest{
+			MessageRequest: &rv1pb.ServerReflectionRequest_FileContainingExtension{
+				FileContainingExtension: &rv1pb.ExtensionRequest{
+					ContainingType:  test.typeName,
+					ExtensionNumber: test.extNum,
+				},
+			},
+		}); err != nil {
+			t.Fatalf("failed to send request: %v", err)
+		}
+		r, err := stream.Recv()
+		if err != nil {
+			// io.EOF is not ok.
+			t.Fatalf("failed to recv response: %v", err)
+		}
+
+		switch r.MessageResponse.(type) {
+		case *rv1pb.ServerReflectionResponse_FileDescriptorResponse:
+			if !reflect.DeepEqual(r.GetFileDescriptorResponse().FileDescriptorProto[0], test.want) {
+				t.Errorf("FileContainingExtension(%v, %v)\nreceived: %q,\nwant: %q", test.typeName, test.extNum, r.GetFileDescriptorResponse().FileDescriptorProto[0], test.want)
+			}
+		default:
+			t.Errorf("FileContainingExtension(%v, %v) = %v, want type <ServerReflectionResponse_FileDescriptorResponse>", test.typeName, test.extNum, r.MessageResponse)
+		}
+	}
+}
+
+func testFileContainingExtensionErrorV1(t *testing.T, stream rv1pb.ServerReflection_ServerReflectionInfoClient) {
+	for _, test := range []struct {
+		typeName string
+		extNum   int32
+	}{
+		{"grpc.testing.ToBExtended", 17},
+		{"grpc.testing.ToBeExtended", 15},
+	} {
+		if err := stream.Send(&rv1pb.ServerReflectionRequest{
+			MessageRequest: &rv1pb.ServerReflectionRequest_FileContainingExtension{
+				FileContainingExtension: &rv1pb.ExtensionRequest{
+					ContainingType:  test.typeName,
+					ExtensionNumber: test.extNum,
+				},
+			},
+		}); err != nil {
+			t.Fatalf("failed to send request: %v", err)
+		}
+		r, err := stream.Recv()
+		if err != nil {
+			// io.EOF is not ok.
+			t.Fatalf("failed to recv response: %v", err)
+		}
+
+		switch r.MessageResponse.(type) {
+		case *rv1pb.ServerReflectionResponse_ErrorResponse:
+		default:
+			t.Errorf("FileContainingExtension(%v, %v) = %v, want type <ServerReflectionResponse_FileDescriptorResponse>", test.typeName, test.extNum, r.MessageResponse)
+		}
+	}
+}
+
+func testAllExtensionNumbersOfTypeV1(t *testing.T, stream rv1pb.ServerReflection_ServerReflectionInfoClient) {
+	for _, test := range []struct {
+		typeName string
+		want     []int32
+	}{
+		{"grpc.testing.ToBeExtended", []int32{13, 17, 19, 23, 29}},
+		{"grpc.testing.DynamicReq", nil},
+	} {
+		if err := stream.Send(&rv1pb.ServerReflectionRequest{
+			MessageRequest: &rv1pb.ServerReflectionRequest_AllExtensionNumbersOfType{
+				AllExtensionNumbersOfType: test.typeName,
+			},
+		}); err != nil {
+			t.Fatalf("failed to send request: %v", err)
+		}
+		r, err := stream.Recv()
+		if err != nil {
+			// io.EOF is not ok.
+			t.Fatalf("failed to recv response: %v", err)
+		}
+
+		switch r.MessageResponse.(type) {
+		case *rv1pb.ServerReflectionResponse_AllExtensionNumbersResponse:
+			extNum := r.GetAllExtensionNumbersResponse().ExtensionNumber
+			sort.Sort(intArray(extNum))
+			if r.GetAllExtensionNumbersResponse().BaseTypeName != test.typeName ||
+				!reflect.DeepEqual(extNum, test.want) {
+				t.Errorf("AllExtensionNumbersOfType(%v)\nreceived: %v,\nwant: {%q %v}", r.GetAllExtensionNumbersResponse(), test.typeName, test.typeName, test.want)
+			}
+		default:
+			t.Errorf("AllExtensionNumbersOfType(%v) = %v, want type <ServerReflectionResponse_AllExtensionNumbersResponse>", test.typeName, r.MessageResponse)
+		}
+	}
+}
+
+func testAllExtensionNumbersOfTypeErrorV1(t *testing.T, stream rv1pb.ServerReflection_ServerReflectionInfoClient) {
+	for _, test := range []string{
+		"grpc.testing.ToBeExtendedE",
+	} {
+		if err := stream.Send(&rv1pb.ServerReflectionRequest{
+			MessageRequest: &rv1pb.ServerReflectionRequest_AllExtensionNumbersOfType{
+				AllExtensionNumbersOfType: test,
+			},
+		}); err != nil {
+			t.Fatalf("failed to send request: %v", err)
+		}
+		r, err := stream.Recv()
+		if err != nil {
+			// io.EOF is not ok.
+			t.Fatalf("failed to recv response: %v", err)
+		}
+
+		switch r.MessageResponse.(type) {
+		case *rv1pb.ServerReflectionResponse_ErrorResponse:
+		default:
+			t.Errorf("AllExtensionNumbersOfType(%v) = %v, want type <ServerReflectionResponse_ErrorResponse>", test, r.MessageResponse)
+		}
+	}
+}
+
+func testListServicesV1(t *testing.T, stream rv1pb.ServerReflection_ServerReflectionInfoClient) {
+	if err := stream.Send(&rv1pb.ServerReflectionRequest{
+		MessageRequest: &rv1pb.ServerReflectionRequest_ListServices{},
+	}); err != nil {
+		t.Fatalf("failed to send request: %v", err)
+	}
+	r, err := stream.Recv()
+	if err != nil {
+		// io.EOF is not ok.
+		t.Fatalf("failed to recv response: %v", err)
+	}
+
+	switch r.MessageResponse.(type) {
+	case *rv1pb.ServerReflectionResponse_ListServicesResponse:
+		services := r.GetListServicesResponse().Service
+		want := []string{
+			"grpc.testingv3.SearchServiceV3",
+			"grpc.testing.SearchService",
+			"grpc.reflection.v1.ServerReflection",
+			"grpc.testing.DynamicService",
+		}
+		// Compare service names in response with want.
+		if len(services) != len(want) {
+			t.Errorf("= %v, want service names: %v", services, want)
+		}
+		m := make(map[string]int)
+		for _, e := range services {
+			m[e.Name]++
+		}
+		for _, e := range want {
+			if m[e] > 0 {
+				m[e]--
+				continue
+			}
+			t.Errorf("ListService\nreceived: %v,\nwant: %q", services, want)
+		}
+	default:
+		t.Errorf("ListServices = %v, want type <ServerReflectionResponse_ListServicesResponse>", r.MessageResponse)
+	}
+}
+
+// func registerDynamicProto(srv *grpc.Server, fdp *descriptorpb.FileDescriptorProto, fd protoreflect.FileDescriptor) {
+// 	type emptyInterface interface{}
+
+// 	for i := 0; i < fd.Services().Len(); i++ {
+// 		s := fd.Services().Get(i)
+
+// 		sd := &grpc.ServiceDesc{
+// 			ServiceName: string(s.FullName()),
+// 			HandlerType: (*emptyInterface)(nil),
+// 			Metadata:    fdp.GetName(),
+// 		}
+
+// 		for j := 0; j < s.Methods().Len(); j++ {
+// 			m := s.Methods().Get(j)
+// 			sd.Methods = append(sd.Methods, grpc.MethodDesc{
+// 				MethodName: string(m.Name()),
+// 			})
+// 		}
+
+// 		srv.RegisterService(sd, struct{}{})
+// 	}
+// }


### PR DESCRIPTION
CHANGES:
- Re-aliases `rpb` to `rv1alphapb` in reflection implementation. This allows for adding support for v1 into the registration in the future.
- Implement a new type `serverReflectionServerV1` which implements the v1 service
- Implement `NewServerV1` and `RegisterV1` as duplicates that use the v1 server (was necessary for proper testing).

Works on #5684 but will require a future commit that implements both v1alpha and v1.
Depends on merging #5799 (tests will fail until merge and this will be rebased)

RELEASE NOTES:

- Re-aliases `rpb` to `rv1alphapb` in reflection implementation
- Implement a new type `serverReflectionServerV1` and new functions `NewServerV1` and `RegisterV1` which use reflection v1