### PR TITLE
xdsclient: wait for underlying transport to close

### DIFF
--- a/xds/internal/xdsclient/controller/controller.go
+++ b/xds/internal/xdsclient/controller/controller.go
@@ -57,6 +57,11 @@ type Controller struct {
 	cc               *grpc.ClientConn // Connection to the management server.
 	vClient          version.VersionedClient
 	stopRunGoroutine context.CancelFunc
+	// The run goroutine closes this channel when it exits, and we block on this
+	// channel in Close(). This ensures that when Close() returns, the
+	// underlying transport is closed, and we can guarantee that we will not
+	// process any subsequent responses from the management server.
+	runDoneCh chan struct{}
 
 	backoff  func(int) time.Duration
 	streamCh chan grpc.ClientStream
@@ -77,6 +82,7 @@ type Controller struct {
 	versionMap map[xdsresource.ResourceType]string
 	// nonceMap contains the nonce from the most recent received response.
 	nonceMap map[xdsresource.ResourceType]string
+	closed   bool
 
 	// Changes to map lrsClients and the lrsClient inside the map need to be
 	// protected by lrsMu.
@@ -127,6 +133,7 @@ func New(config *bootstrap.ServerConfig, updateHandler pubsub.UpdateHandler, val
 		config:          config,
 		updateValidator: validator,
 		updateHandler:   updateHandler,
+		runDoneCh:       make(chan struct{}),
 
 		backoff:    boff,
 		streamCh:   make(chan grpc.ClientStream, 1),
@@ -170,6 +177,14 @@ func New(config *bootstrap.ServerConfig, updateHandler pubsub.UpdateHandler, val
 
 // Close closes the controller.
 func (t *Controller) Close() {
+	t.mu.Lock()
+	if t.closed {
+		t.mu.Unlock()
+		return
+	}
+	t.closed = true
+	t.mu.Unlock()
+
 	// Note that Close needs to check for nils even if some of them are always
 	// set in the constructor. This is because the constructor defers Close() in
 	// error cases, and the fields might not be set when the error happens.
@@ -178,5 +193,9 @@ func (t *Controller) Close() {
 	}
 	if t.cc != nil {
 		t.cc.Close()
+	}
+	// Wait on the run goroutine to be done only if it was started.
+	if t.stopRunGoroutine != nil {
+		<-t.runDoneCh
 	}
 }

--- a/xds/internal/xdsclient/e2e_test/misc_watchers_test.go
+++ b/xds/internal/xdsclient/e2e_test/misc_watchers_test.go
@@ -85,7 +85,6 @@ func (s) TestWatchCallAnotherWatch(t *testing.T) {
 		})
 		t.Cleanup(rdsCancel3)
 	})
-	// defer rdsCancel1()
 	t.Cleanup(rdsCancel1)
 
 	// Verify the contents of the received update for the all watchers.


### PR DESCRIPTION
Make the `Close()` method on the xDS client object to block until the underlying transport is closed. Without this, our tests are very flaky.

Summary of changes:
- Add a couple of fields to the `Controller` struct which contains all the logic and state required to communicate with a particular xDS management server. This holds the underlying transport to the management server.
- When `Controller.Close()` is called, we wait for the underlying transport to be closed before returning.
- If the `Close()` method is called multiple times, it will be a no-op except for the first time.

RELEASE NOTES: none