### PR TITLE
Cap min and max ring size to 4K

### DIFF
--- a/xds/internal/balancer/clusterresolver/config_test.go
+++ b/xds/internal/balancer/clusterresolver/config_test.go
@@ -249,7 +249,7 @@ func TestParseConfig(t *testing.T) {
 				},
 				XDSLBPolicy: &internalserviceconfig.BalancerConfig{
 					Name:   ringhash.Name,
-					Config: &ringhash.LBConfig{MinRingSize: 1024, MaxRingSize: 8388608}, // Ringhash LB config with default min and max.
+					Config: &ringhash.LBConfig{MinRingSize: 1024, MaxRingSize: 4096}, // Ringhash LB config with default min and max.
 				},
 			},
 			wantErr: false,

--- a/xds/internal/balancer/ringhash/config.go
+++ b/xds/internal/balancer/ringhash/config.go
@@ -35,7 +35,9 @@ type LBConfig struct {
 
 const (
 	defaultMinSize = 1024
-	defaultMaxSize = 8 * 1024 * 1024 // 8M
+	defaultMaxSize = 4096
+	// TODO(apolcyn): make makeRingSizeCap configurable, with either a dial option or global setting
+	maxRingSizeCap = 4096
 )
 
 func parseConfig(c json.RawMessage) (*LBConfig, error) {
@@ -48,6 +50,12 @@ func parseConfig(c json.RawMessage) (*LBConfig, error) {
 	}
 	if cfg.MaxRingSize == 0 {
 		cfg.MaxRingSize = defaultMaxSize
+	}
+	if cfg.MinRingSize > maxRingSizeCap {
+		cfg.MinRingSize = maxRingSizeCap
+	}
+	if cfg.MaxRingSize > maxRingSizeCap {
+		cfg.MaxRingSize = maxRingSizeCap
 	}
 	if cfg.MinRingSize > cfg.MaxRingSize {
 		return nil, fmt.Errorf("min %v is greater than max %v", cfg.MinRingSize, cfg.MaxRingSize)


### PR DESCRIPTION
This follows the settings described in https://github.com/grpc/proposal/pull/338.

Note: a configuration option (preferable taking the form of a dial option, but possibly using a global) is left as a TODO.

Side note: this will mitigate internal issue b/255207468

cc @easwars 

RELEASE NOTES:
- ringhash: impose cap on `max_ring_size` to reduce possibility of OOMs