### PR TITLE
transport: replace bufWriter with bufio.Writer

### DIFF
--- a/dialoptions.go
+++ b/dialoptions.go
@@ -127,9 +127,7 @@ func newJoinDialOption(opts ...DialOption) DialOption {
 }
 
 // WithWriteBufferSize determines how much data can be batched before doing a
-// write on the wire. The corresponding memory allocation for this buffer will
-// be twice the size to keep syscalls low. The default value for this buffer is
-// 32KB.
+// write on the wire. The default value for this buffer is 32KB.
 //
 // Zero or negative values will disable the write buffer such that each write
 // will be on underlying connection. Note: A Send call may not directly

--- a/internal/transport/controlbuf.go
+++ b/internal/transport/controlbuf.go
@@ -563,7 +563,7 @@ func (l *loopyWriter) run() (err error) {
 			}
 			if gosched {
 				gosched = false
-				if l.framer.writer.offset < minBatchSize {
+				if l.framer.writer.Buffered() < minBatchSize {
 					runtime.Gosched()
 					continue hasdata
 				}

--- a/server.go
+++ b/server.go
@@ -234,11 +234,10 @@ func newJoinServerOption(opts ...ServerOption) ServerOption {
 }
 
 // WriteBufferSize determines how much data can be batched before doing a write
-// on the wire. The corresponding memory allocation for this buffer will be
-// twice the size to keep syscalls low. The default value for this buffer is
-// 32KB. Zero or negative values will disable the write buffer such that each
-// write will be on underlying connection.
-// Note: A Send call may not directly translate to a write.
+// on the wire. The default value for this buffer is 32KB.  Zero or negative
+// values will disable the write buffer such that each write will be on
+// underlying connection. Note: A Send call may not directly translate to a
+// write.
 func WriteBufferSize(s int) ServerOption {
 	return newFuncServerOption(func(o *serverOptions) {
 		o.writeBufferSize = s


### PR DESCRIPTION
`transport.bufWriter` allocates twice the size passed as `grpc.WithWriteBufferSize` and
`grpc.WriteBufferSize` options. The default of 32KB results in 64KB used per open transport. Beside
the interface not being very explicit, it is also unclear what benefits we gain from allocating
twice the buffer size. Finally, the standard library already provides buffered IO via
`bufio.Writer`, so there is an opportunity to clean up custom code.

`transport.bufWriter` introduced in this pull request:
https://github.com/grpc/grpc-go/pull/1962. Out of the 3 benchmarks cited in that pull request
description, I was only able to run the OSS benchmarks. That pull request claims 20%+ gains in
latency and throughput, but it also introduces a number of other changes to the control buffer, so
it is unclear whether those benefits are introduced by `bufWriter` itself.

This change replaces `transport.bufWriter` with `bufio.Writer` from the standard library. This
simplifies the code and frees quite a bit of allocated memory per connection (32KB by default). I
ran the benchmarks on master (before) and then with this change (after). The results are marginally
better before:

```
unary-networkMode_none-bufConn_false-keepalive_false-benchTime_5m0s-trace_false-latency_0s-kbps_0-MTU_0-maxConcurrentCalls_1000-reqSize_1B-respSize_1B-compressor_off-channelz_false-preloader_false-clientReadBufferSize_-1-clientWriteBufferSize_32768-serverReadBufferSize_-1-serverWriteBufferSize_32768-
               Title       Before        After Percentage
            TotalOps     21988622     21234195    -3.43%
            Bytes/op      8936.85      8941.62     0.06%
           Allocs/op       160.72       160.92     0.00%
             ReqT/op    586363.25    566245.20    -3.43%
            RespT/op    586363.25    566245.20    -3.43%
            50th-Lat  13.920469ms  14.431288ms     3.67%
            90th-Lat  15.618792ms   16.09928ms     3.08%
            99th-Lat  19.100552ms  19.234865ms     0.70%
             Avg-Lat  13.640907ms  14.123636ms     3.54%
           GoVersion     go1.19.3     go1.19.3
         GrpcVersion   1.52.0-dev   1.52.0-dev

streaming-networkMode_none-bufConn_false-keepalive_false-benchTime_5m0s-trace_false-latency_0s-kbps_0-MTU_0-maxConcurrentCalls_1000-reqSize_1B-respSize_1B-compressor_off-channelz_false-preloader_false-clientReadBufferSize_-1-clientWriteBufferSize_32768-serverReadBufferSize_-1-serverWriteBufferSize_32768-
               Title       Before        After Percentage
            TotalOps    124001230    129178584     4.18%
            Bytes/op       930.58       929.22    -0.11%
           Allocs/op        25.19        25.23     0.00%
             ReqT/op   3306699.47   3444762.24     4.18%
            RespT/op   3306699.47   3444762.24     4.18%
            50th-Lat   2.442992ms   2.295347ms    -6.04%
            90th-Lat   2.873037ms   2.874109ms     0.04%
            99th-Lat   4.536109ms   4.422115ms    -2.51%
             Avg-Lat   2.401134ms   2.302458ms    -4.11%
           GoVersion     go1.19.3     go1.19.3
         GrpcVersion   1.52.0-dev   1.52.0-dev

unary-networkMode_none-bufConn_false-keepalive_false-benchTime_5m0s-trace_false-latency_0s-kbps_0-MTU_0-maxConcurrentCalls_100-reqSize_1B-respSize_1B-compressor_off-channelz_false-preloader_false-clientReadBufferSize_-1-clientWriteBufferSize_32768-serverReadBufferSize_-1-serverWriteBufferSize_32768-
               Title       Before        After Percentage
            TotalOps     20711973     19999378    -3.44%
            Bytes/op      8954.79      8959.08     0.06%
           Allocs/op       161.59       161.76     0.00%
             ReqT/op    552319.28    533316.75    -3.44%
            RespT/op    552319.28    533316.75    -3.44%
            50th-Lat   1.436848ms   1.487147ms     3.50%
            90th-Lat   1.669209ms   1.725372ms     3.36%
            99th-Lat   2.498868ms   2.541844ms     1.72%
             Avg-Lat   1.447501ms   1.499086ms     3.56%
           GoVersion     go1.19.3     go1.19.3
         GrpcVersion   1.52.0-dev   1.52.0-dev

streaming-networkMode_none-bufConn_false-keepalive_false-benchTime_5m0s-trace_false-latency_0s-kbps_0-MTU_0-maxConcurrentCalls_100-reqSize_1B-respSize_1B-compressor_off-channelz_false-preloader_false-clientReadBufferSize_-1-clientWriteBufferSize_32768-serverReadBufferSize_-1-serverWriteBufferSize_32768-
               Title       Before        After Percentage
            TotalOps     90264674     89651791    -0.68%
            Bytes/op       940.32       942.55     0.21%
           Allocs/op        26.21        26.34     0.00%
             ReqT/op   2407057.97   2390714.43    -0.68%
            RespT/op   2407057.97   2390714.43    -0.68%
            50th-Lat    314.726µs    315.446µs     0.23%
            90th-Lat    418.348µs    414.178µs    -1.00%
            99th-Lat    623.294µs    649.817µs     4.26%
             Avg-Lat    329.211µs    331.443µs     0.68%
           GoVersion     go1.19.3     go1.19.3
         GrpcVersion   1.52.0-dev   1.52.0-dev
```

The slight performance decrease is most likely explained by the 64KB of actual write buffer before
vs 32KB after which makes some use of the extra memory when a single write goes over 32KB. How well
utilized is this extra memory? If we want a fair comparison at equal memory consumption, we can pass
16KB as write buffer size with the current code in master, which results in 32KB memory use. Before
with 16KB*2=32KB write buffer size, after with 32KB, the results are also rather inconclusive:

```
unary-Trace_false-Latency_0s-Kbps_0-MTU_0-Callers_1000-ReqSize_1B-RespSize_1B-Compressor_off-Channelz_false-Preloader_false-ClientReadBufferSize_-1-ServerReadBufferSize_-1-
               Title       Before        After Percentage
            TotalOps     21114148     21234195     0.57%
            Bytes/op      8942.31      8941.62    -0.01%
           Allocs/op       160.94       160.92     0.00%
             ReqT/op    563043.95    566245.20     0.57%
            RespT/op    563043.95    566245.20     0.57%
            50th-Lat  14.522146ms  14.431288ms    -0.63%
            90th-Lat  16.234315ms   16.09928ms    -0.83%
            99th-Lat  19.375731ms  19.234865ms    -0.73%
             Avg-Lat  14.204108ms  14.123636ms    -0.57%
           GoVersion     go1.19.3     go1.19.3
         GrpcVersion   1.52.0-dev   1.52.0-dev
```

I also ran a number of other benchmarks with larger payload sizes (1KB, 1MB). All of them are
inconclusive (most results differ less than 5%, sometimes in one or the other direction). See the file
attached to the PR ([benchresults-before_master_after_replace-custom-buffer.txt](https://github.com/grpc/grpc-go/files/10287432/benchresults-before_master_after_replace-custom-buffer.txt)).

Based on this I conclude that there is no real benefit to the custom `bufWriter` implementation.

RELEASE NOTES: none