### PR TITLE
xdsclient: resource-type-agnostic transport layer

### DIFF
--- a/xds/internal/xdsclient/transport/loadreport.go
+++ b/xds/internal/xdsclient/transport/loadreport.go
@@ -37,7 +37,7 @@ import (
 	v3lrspb "github.com/envoyproxy/go-control-plane/envoy/service/load_stats/v3"
 )
 
-type lrsStream v3lrsgrpc.LoadReportingService_StreamLoadStatsClient
+type lrsStream = v3lrsgrpc.LoadReportingService_StreamLoadStatsClient
 
 // ReportLoad starts reporting loads to the management server the transport is
 // configured to use.
@@ -181,7 +181,7 @@ func (t *Transport) recvFirstLoadStatsResponse(stream lrsStream) ([]string, time
 	}
 
 	if resp.ReportEndpointGranularity {
-		// TODO: fixme to support per endpoint loads.
+		// TODO(easwars): Support per endpoint loads.
 		return nil, 0, errors.New("lrs: endpoint loads requested, but not supported by current implementation")
 	}
 

--- a/xds/internal/xdsclient/transport/loadreport.go
+++ b/xds/internal/xdsclient/transport/loadreport.go
@@ -1,0 +1,256 @@
+/*
+ *
+ * Copyright 2022 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package transport
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/golang/protobuf/ptypes"
+	"google.golang.org/grpc/internal/pretty"
+	"google.golang.org/grpc/xds/internal"
+	"google.golang.org/grpc/xds/internal/xdsclient/load"
+	"google.golang.org/protobuf/proto"
+
+	v3corepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	v3endpointpb "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
+	v3lrsgrpc "github.com/envoyproxy/go-control-plane/envoy/service/load_stats/v3"
+	v3lrspb "github.com/envoyproxy/go-control-plane/envoy/service/load_stats/v3"
+)
+
+const clientFeatureLRSSendAllClusters = "envoy.lrs.supports_send_all_clusters"
+
+type lrsStream v3lrsgrpc.LoadReportingService_StreamLoadStatsClient
+
+// ReportLoad starts reporting loads to the management server the transport is
+// configured to talk to.
+//
+// It returns a Store for the user to report loads and a function to cancel the
+// load reporting.
+func (t *Transport) ReportLoad() (*load.Store, func()) {
+	t.lrsMu.Lock()
+	defer t.lrsMu.Unlock()
+
+	t.lrsStartStream()
+	return t.lrsStore, func() {
+		t.lrsMu.Lock()
+		t.lrsStopStream()
+		t.lrsMu.Unlock()
+	}
+}
+
+// lrsStartStream starts an LRS stream to the server, if none exists.
+//
+// Caller must hold t.lrsMu.
+func (t *Transport) lrsStartStream() {
+	t.lrsRefCount++
+	if t.lrsRefCount != 1 {
+		// Return early if the stream has already been started.
+		return
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.lrsCancelStream = cancel
+	go t.reportLoad(ctx)
+}
+
+// lrsStopStream closes the LRS stream, if this is the last user of the stream.
+//
+// Caller must hold t.lrsMu.
+func (t *Transport) lrsStopStream() {
+	t.lrsRefCount--
+	if t.lrsRefCount != 0 {
+		// Return early if the stream has other references.
+		return
+	}
+
+	t.lrsCancelStream()
+	t.logger.Infof("Stopping LRS stream")
+}
+
+// reportLoad starts an LRS stream to report load data to the management server.
+// It reports load at constant intervals (as configured by the management
+// server) until the context is cancelled.
+func (t *Transport) reportLoad(ctx context.Context) {
+	retries := 0
+	lastStreamStartTime := time.Time{}
+	for ctx.Err() == nil {
+		dur := time.Until(lastStreamStartTime.Add(t.backoff(retries)))
+		if dur > 0 {
+			timer := time.NewTimer(dur)
+			select {
+			case <-timer.C:
+			case <-ctx.Done():
+				timer.Stop()
+				return
+			}
+		}
+
+		retries++
+		lastStreamStartTime = time.Now()
+		func() {
+			// streamCtx is created and canceled in case we terminate the stream
+			// early for any reason, to avoid gRPC-Go leaking the RPC's monitoring
+			// goroutine.
+			streamCtx, cancel := context.WithCancel(ctx)
+			defer cancel()
+			stream, err := v3lrsgrpc.NewLoadReportingServiceClient(t.cc).StreamLoadStats(streamCtx)
+			if err != nil {
+				t.logger.Warningf("Failed to create LRS stream: %v", err)
+				return
+			}
+			t.logger.Infof("Created LRS stream to server: %s", t.serverURI)
+
+			if err := t.sendFirstLoadStatsRequest(stream); err != nil {
+				t.logger.Warningf("Failed to send first LRS request: %v", err)
+				return
+			}
+
+			clusters, interval, err := t.recvFirstLoadStatsResponse(stream)
+			if err != nil {
+				t.logger.Warningf("Failed to read from LRS stream: %v", err)
+				return
+			}
+
+			retries = 0
+			t.sendLoads(streamCtx, stream, clusters, interval)
+		}()
+	}
+}
+
+func (t *Transport) sendLoads(ctx context.Context, stream lrsStream, clusterNames []string, interval time.Duration) {
+	tick := time.NewTicker(interval)
+	defer tick.Stop()
+	for {
+		select {
+		case <-tick.C:
+		case <-ctx.Done():
+			return
+		}
+		if err := t.sendLoadStatsRequest(stream, t.lrsStore.Stats(clusterNames)); err != nil {
+			t.logger.Warningf("Failed to write to LRS stream: %v", err)
+			return
+		}
+	}
+}
+
+func (t *Transport) sendFirstLoadStatsRequest(stream lrsStream) error {
+	node := proto.Clone(t.nodeProto).(*v3corepb.Node)
+	node.ClientFeatures = append(node.ClientFeatures, clientFeatureLRSSendAllClusters)
+	req := &v3lrspb.LoadStatsRequest{Node: node}
+	t.logger.Debugf("Sending initial LoadStatsRequest: %s", pretty.ToJSON(req))
+	err := stream.Send(req)
+	if err == io.EOF {
+		return getStreamError(stream)
+	}
+	return err
+}
+
+func (t *Transport) recvFirstLoadStatsResponse(stream lrsStream) ([]string, time.Duration, error) {
+	resp, err := stream.Recv()
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to receive first LoadStatsResponse: %v", err)
+	}
+	t.logger.Debugf("Received first LoadStatsResponse: %s", pretty.ToJSON(resp))
+
+	interval, err := ptypes.Duration(resp.GetLoadReportingInterval())
+	if err != nil {
+		return nil, 0, fmt.Errorf("invalid load_reporting_interval: %v", err)
+	}
+
+	if resp.ReportEndpointGranularity {
+		// TODO: fixme to support per endpoint loads.
+		return nil, 0, errors.New("lrs: endpoint loads requested, but not supported by current implementation")
+	}
+
+	clusters := resp.Clusters
+	if resp.SendAllClusters {
+		// Return nil to send stats for all clusters.
+		clusters = nil
+	}
+
+	return clusters, interval, nil
+}
+
+func (t *Transport) sendLoadStatsRequest(stream lrsStream, loads []*load.Data) error {
+	clusterStats := make([]*v3endpointpb.ClusterStats, 0, len(loads))
+	for _, sd := range loads {
+		droppedReqs := make([]*v3endpointpb.ClusterStats_DroppedRequests, 0, len(sd.Drops))
+		for category, count := range sd.Drops {
+			droppedReqs = append(droppedReqs, &v3endpointpb.ClusterStats_DroppedRequests{
+				Category:     category,
+				DroppedCount: count,
+			})
+		}
+		localityStats := make([]*v3endpointpb.UpstreamLocalityStats, 0, len(sd.LocalityStats))
+		for l, localityData := range sd.LocalityStats {
+			lid, err := internal.LocalityIDFromString(l)
+			if err != nil {
+				return err
+			}
+			loadMetricStats := make([]*v3endpointpb.EndpointLoadMetricStats, 0, len(localityData.LoadStats))
+			for name, loadData := range localityData.LoadStats {
+				loadMetricStats = append(loadMetricStats, &v3endpointpb.EndpointLoadMetricStats{
+					MetricName:                    name,
+					NumRequestsFinishedWithMetric: loadData.Count,
+					TotalMetricValue:              loadData.Sum,
+				})
+			}
+			localityStats = append(localityStats, &v3endpointpb.UpstreamLocalityStats{
+				Locality: &v3corepb.Locality{
+					Region:  lid.Region,
+					Zone:    lid.Zone,
+					SubZone: lid.SubZone,
+				},
+				TotalSuccessfulRequests: localityData.RequestStats.Succeeded,
+				TotalRequestsInProgress: localityData.RequestStats.InProgress,
+				TotalErrorRequests:      localityData.RequestStats.Errored,
+				LoadMetricStats:         loadMetricStats,
+				UpstreamEndpointStats:   nil, // TODO: populate for per endpoint loads.
+			})
+		}
+
+		clusterStats = append(clusterStats, &v3endpointpb.ClusterStats{
+			ClusterName:           sd.Cluster,
+			ClusterServiceName:    sd.Service,
+			UpstreamLocalityStats: localityStats,
+			TotalDroppedRequests:  sd.TotalDrops,
+			DroppedRequests:       droppedReqs,
+			LoadReportInterval:    ptypes.DurationProto(sd.ReportInterval),
+		})
+	}
+
+	req := &v3lrspb.LoadStatsRequest{ClusterStats: clusterStats}
+	t.logger.Debugf("Sending LRS loads: %s", pretty.ToJSON(req))
+	err := stream.Send(req)
+	if err == io.EOF {
+		return getStreamError(stream)
+	}
+	return err
+}
+
+func getStreamError(stream lrsStream) error {
+	for {
+		if _, err := stream.Recv(); err != nil {
+			return err
+		}
+	}
+}

--- a/xds/internal/xdsclient/transport/loadreport.go
+++ b/xds/internal/xdsclient/transport/loadreport.go
@@ -62,7 +62,7 @@ func (t *Transport) lrsStartStream() {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	t.lrsCancelStream = cancel
-	go t.reportLoad(ctx)
+	go t.lrsRunner(ctx)
 }
 
 // lrsStopStream closes the LRS stream, if this is the last user of the stream.
@@ -77,15 +77,15 @@ func (t *Transport) lrsStopStream() {
 	}
 
 	t.lrsCancelStream()
-	<-t.reportLoadDoneCh
+	<-t.lrsRunnerDoneCh
 	t.logger.Infof("Stopping LRS stream")
 }
 
-// reportLoad starts an LRS stream to report load data to the management server.
+// lrsRunner starts an LRS stream to report load data to the management server.
 // It reports load at constant intervals (as configured by the management
 // server) until the context is cancelled.
-func (t *Transport) reportLoad(ctx context.Context) {
-	defer close(t.reportLoadDoneCh)
+func (t *Transport) lrsRunner(ctx context.Context) {
+	defer close(t.lrsRunnerDoneCh)
 
 	// This feature indicates that the client supports the
 	// LoadStatsResponse.send_all_clusters field in the LRS response.

--- a/xds/internal/xdsclient/transport/loadreport.go
+++ b/xds/internal/xdsclient/transport/loadreport.go
@@ -77,8 +77,8 @@ func (t *Transport) lrsStopStream() {
 	}
 
 	t.lrsCancelStream()
-	<-t.lrsRunnerDoneCh
 	t.logger.Infof("Stopping LRS stream")
+	<-t.lrsRunnerDoneCh
 }
 
 // lrsRunner starts an LRS stream to report load data to the management server.

--- a/xds/internal/xdsclient/transport/loadreport_test.go
+++ b/xds/internal/xdsclient/transport/loadreport_test.go
@@ -1,0 +1,193 @@
+/*
+ *
+ * Copyright 2022 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package transport_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	v3corepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/uuid"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/xds/internal/testutils/fakeserver"
+	"google.golang.org/grpc/xds/internal/xdsclient/bootstrap"
+	"google.golang.org/grpc/xds/internal/xdsclient/transport"
+	"google.golang.org/grpc/xds/internal/xdsclient/xdsresource/version"
+	"google.golang.org/protobuf/testing/protocmp"
+	"google.golang.org/protobuf/types/known/durationpb"
+
+	v3endpointpb "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
+	v3lrspb "github.com/envoyproxy/go-control-plane/envoy/service/load_stats/v3"
+)
+
+func (s) TestReportLoad(t *testing.T) {
+	// Create a fake xDS management server listening on a local port.
+	mgmtServer, cleanup := startFakeManagementServer(t)
+	defer cleanup()
+	t.Logf("Started xDS management server on %s", mgmtServer.Address)
+
+	// Construct the server config to represent the management server.
+	nodeProto := &v3corepb.Node{Id: uuid.New().String()}
+	serverCfg := &bootstrap.ServerConfig{
+		ServerURI:    mgmtServer.Address,
+		Creds:        grpc.WithTransportCredentials(insecure.NewCredentials()),
+		CredsType:    "insecure",
+		TransportAPI: version.TransportV3,
+		NodeProto:    nodeProto,
+	}
+
+	// Create a transport to the fake server.
+	tr, err := transport.New(&transport.Options{
+		ServerCfg:          serverCfg,
+		UpdateHandler:      func(transport.ResourceUpdate) error { return nil }, // No ADS validation.
+		StreamErrorHandler: func(error) {},                                      // No ADS stream error handling.
+		Backoff:            func(int) time.Duration { return time.Duration(0) }, // No backoff.
+	})
+	if err != nil {
+		t.Fatalf("Failed to create xDS transport: %v", err)
+	}
+	defer tr.Close()
+
+	// Ensure that a new connection is made to the management server.
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	if _, err := mgmtServer.NewConnChan.Receive(ctx); err != nil {
+		t.Fatalf("Timeout when waiting for a new connection to the management server: %v", err)
+	}
+
+	// Call the load reporting API, and ensure that an LRS stream is created.
+	store1, cancelLRS1 := tr.ReportLoad()
+	if err != nil {
+		t.Fatalf("Failed to start LRS load reporting: %v", err)
+	}
+	if _, err := mgmtServer.LRSStreamOpenChan.Receive(ctx); err != nil {
+		t.Fatalf("Timeout when waiting for LRS stream to be created: %v", err)
+	}
+
+	// Push some loads on the received store.
+	store1.PerCluster("cluster1", "eds1").CallDropped("test")
+
+	// Ensure the initial request is received.
+	req, err := mgmtServer.LRSRequestChan.Receive(ctx)
+	if err != nil {
+		t.Fatalf("Timeout when waiting for initial LRS request: %v", err)
+	}
+	gotInitialReq := req.(*fakeserver.Request).Req.(*v3lrspb.LoadStatsRequest)
+	nodeProto.ClientFeatures = []string{"envoy.lrs.supports_send_all_clusters"}
+	wantInitialReq := &v3lrspb.LoadStatsRequest{Node: nodeProto}
+	if diff := cmp.Diff(gotInitialReq, wantInitialReq, protocmp.Transform()); diff != "" {
+		t.Fatalf("Unexpected diff in initial LRS request (-got, +want):\n%s", diff)
+	}
+
+	// Send a response from the server with a small deadline.
+	mgmtServer.LRSResponseChan <- &fakeserver.Response{
+		Resp: &v3lrspb.LoadStatsResponse{
+			SendAllClusters:       true,
+			LoadReportingInterval: &durationpb.Duration{Nanos: 50000000}, // 50ms
+		},
+	}
+
+	// Ensure that loads are seen on the server.
+	req, err = mgmtServer.LRSRequestChan.Receive(ctx)
+	if err != nil {
+		t.Fatalf("Timeout when waiting for LRS request with loads: %v", err)
+	}
+	gotLoad := req.(*fakeserver.Request).Req.(*v3lrspb.LoadStatsRequest).ClusterStats
+	if l := len(gotLoad); l != 1 {
+		t.Fatalf("Received load for %d clusters, want 1", l)
+	}
+	// This field is set by the client to indicate the actual time elapsed since
+	// the last report was sent. We cannot deterministically compare this, and
+	// we cannot use the cmpopts.IgnoreFields() option on proto structs, since
+	// we already use the protocmp.Transform() which marshals the struct into
+	// another message. Hence setting this field to nil is the best option here.
+	gotLoad[0].LoadReportInterval = nil
+	wantLoad := &v3endpointpb.ClusterStats{
+		ClusterName:          "cluster1",
+		ClusterServiceName:   "eds1",
+		TotalDroppedRequests: 1,
+		DroppedRequests:      []*v3endpointpb.ClusterStats_DroppedRequests{{Category: "test", DroppedCount: 1}},
+	}
+	if diff := cmp.Diff(wantLoad, gotLoad[0], protocmp.Transform()); diff != "" {
+		t.Fatalf("Unexpected diff in LRS request (-got, +want):\n%s", diff)
+	}
+
+	// Make another call to the load reporting API, and ensure that a new LRS
+	// stream is not created.
+	store2, cancelLRS2 := tr.ReportLoad()
+	if err != nil {
+		t.Fatalf("Failed to start LRS load reporting: %v", err)
+	}
+	sCtx, sCancel := context.WithTimeout(context.Background(), defaultTestShortTimeout)
+	defer sCancel()
+	if _, err := mgmtServer.LRSStreamOpenChan.Receive(sCtx); err != context.DeadlineExceeded {
+		t.Fatal("New LRS stream created when expected to use an existing one")
+	}
+
+	// Push more loads.
+	store2.PerCluster("cluster2", "eds2").CallDropped("test")
+
+	// Ensure that loads are seen on the server. We need a loop here because
+	// there could have been some requests from the client in the time between
+	// us reading the first request and now. Those would have been queued in the
+	// request channel that we read out of.
+	for {
+		if ctx.Err() != nil {
+			t.Fatalf("Timeout when waiting for new loads to be seen on the server")
+		}
+
+		req, err = mgmtServer.LRSRequestChan.Receive(ctx)
+		if err != nil {
+			continue
+		}
+		gotLoad = req.(*fakeserver.Request).Req.(*v3lrspb.LoadStatsRequest).ClusterStats
+		if l := len(gotLoad); l != 1 {
+			continue
+		}
+		gotLoad[0].LoadReportInterval = nil
+		wantLoad := &v3endpointpb.ClusterStats{
+			ClusterName:          "cluster2",
+			ClusterServiceName:   "eds2",
+			TotalDroppedRequests: 1,
+			DroppedRequests:      []*v3endpointpb.ClusterStats_DroppedRequests{{Category: "test", DroppedCount: 1}},
+		}
+		if diff := cmp.Diff(wantLoad, gotLoad[0], protocmp.Transform()); diff != "" {
+			t.Logf("Unexpected diff in LRS request (-got, +want):\n%s", diff)
+			continue
+		}
+		break
+	}
+
+	// Cancel the first load reporting call, and ensure that the stream does not
+	// close (because we have aother call open).
+	cancelLRS1()
+	sCtx, sCancel = context.WithTimeout(context.Background(), defaultTestShortTimeout)
+	defer sCancel()
+	if _, err := mgmtServer.LRSStreamCloseChan.Receive(sCtx); err != context.DeadlineExceeded {
+		t.Fatal("LRS stream closed when expected to stay open")
+	}
+
+	// Cancel the second load reporting call, and ensure the stream is closed.
+	cancelLRS2()
+	if _, err := mgmtServer.LRSStreamCloseChan.Receive(ctx); err != nil {
+		t.Fatal("Timeout waiting for LRS stream to close")
+	}
+}

--- a/xds/internal/xdsclient/transport/loadreport_test.go
+++ b/xds/internal/xdsclient/transport/loadreport_test.go
@@ -46,7 +46,7 @@ func (s) TestReportLoad(t *testing.T) {
 
 	// Construct the server config to represent the management server.
 	nodeProto := &v3corepb.Node{Id: uuid.New().String()}
-	serverCfg := &bootstrap.ServerConfig{
+	serverCfg := bootstrap.ServerConfig{
 		ServerURI:    mgmtServer.Address,
 		Creds:        grpc.WithTransportCredentials(insecure.NewCredentials()),
 		CredsType:    "insecure",
@@ -55,7 +55,7 @@ func (s) TestReportLoad(t *testing.T) {
 	}
 
 	// Create a transport to the fake server.
-	tr, err := transport.New(&transport.Options{
+	tr, err := transport.New(transport.Options{
 		ServerCfg:          serverCfg,
 		UpdateHandler:      func(transport.ResourceUpdate) error { return nil }, // No ADS validation.
 		StreamErrorHandler: func(error) {},                                      // No ADS stream error handling.

--- a/xds/internal/xdsclient/transport/transport.go
+++ b/xds/internal/xdsclient/transport/transport.go
@@ -1,0 +1,564 @@
+/*
+ *
+ * Copyright 2022 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package transport implements the xDS transport protocol functionality
+// required by the xdsclient.
+package transport
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/connectivity"
+	"google.golang.org/grpc/internal/backoff"
+	"google.golang.org/grpc/internal/buffer"
+	"google.golang.org/grpc/internal/grpclog"
+	"google.golang.org/grpc/internal/pretty"
+	"google.golang.org/grpc/keepalive"
+	"google.golang.org/grpc/xds/internal/xdsclient/bootstrap"
+	"google.golang.org/grpc/xds/internal/xdsclient/load"
+	"google.golang.org/grpc/xds/internal/xdsclient/xdsresource"
+	"google.golang.org/protobuf/types/known/anypb"
+
+	v3corepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	v3adsgrpc "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+	v3discoverypb "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+	statuspb "google.golang.org/genproto/googleapis/rpc/status"
+)
+
+type adsStream v3adsgrpc.AggregatedDiscoveryService_StreamAggregatedResourcesClient
+
+// Transport provides a resource-type agnostic implementation of the xDS
+// transport protocol. At this layer, resource contents are supposed to be
+// opaque blobs which should be be meaningful only to the xDS data model layer
+// which is implemented by the `xdsresource` package.
+//
+// Under the hood, it owns the gRPC connection to a single management server and
+// manages the lifecycle of ADS/LRS streams. It uses the xDS v3 transport
+// protocol version.
+type Transport struct {
+	// These fields are initialized at creation time and are read-only afterwards.
+	cc                  *grpc.ClientConn        // ClientConn to the mangement server.
+	serverURI           string                  // URI of the management server.
+	stopRunGoroutine    context.CancelFunc      // CancelFunc for the run() goroutine.
+	updateHandler       UpdateHandlerFunc       // Resource update handler. xDS data model layer.
+	adsStreamErrHandler func(error)             // To report underlying stream errors.
+	lrsStore            *load.Store             // Store returned to user for pushing loads.
+	backoff             func(int) time.Duration // Backoff after stream failures.
+	nodeProto           *v3corepb.Node          // Identifies the gRPC application.
+	logger              *grpclog.PrefixLogger   // Prefix logger for transport logs.
+
+	// These channels enable synchronization amongst the different goroutines
+	// spawned by the transport, and between asynchorous events resulting from
+	// receipt of responses from the management server.
+	adsStreamCh  chan adsStream    // New ADS streams are pushed here.
+	adsRequestCh *buffer.Unbounded // Resource and ack requests are pushed here.
+
+	// mu guards the following runtime state maintained by the transport.
+	mu sync.Mutex
+	// resources is map from resource type URL to the set of resource names
+	// being requested for that type. When the ADS stream is restarted, the
+	// transport requests all these resources again from the management server.
+	resources map[string]map[string]bool
+	// versions is a map from resource type URL to the most recently ACKed
+	// version for that resource. Resource versions are a property of the
+	// resource type and not the stream, and will not be reset upon stream
+	// restarts.
+	versions map[string]string
+	// nonces is a map from resource type URL to the most recently received
+	// nonce for that resource type. Nonces are a property of the ADS stream and
+	// will be reset upon stream restarts.
+	nonces map[string]string
+
+	lrsMu           sync.Mutex         // Protects all LRS state.
+	lrsCancelStream context.CancelFunc // CancelFunc for the LRS stream.
+	lrsRefCount     int                // Reference count on the load store.
+}
+
+// UpdateHandlerFunc is the implementation at the xDS data model layer, which
+// determines if the configuration received from the management server can be
+// applied locally or not.
+//
+// A nil error is returned from this function when the data model layer believes
+// that the received configuration is good and can be applied locally. This will
+// cause the transport layer to send an ACK to the management server. A non-nil
+// error is returned from this function when the data model layer believes
+// otherwise, and this will cause the transport layer to send a NACK.
+type UpdateHandlerFunc func(update ResourceUpdate) error
+
+// ResourceUpdate is a representation of the configuration update received from
+// the management server. It only contains fields which are useful to the data
+// model layer, and layers above it.
+type ResourceUpdate struct {
+	// Resources is the list of resources received from the management server.
+	Resources []*anypb.Any
+	// URL is the resource type URL for the above resources.
+	URL string
+	// Version is the resource version, for the above resources, as specified by
+	// the management server.
+	Version string
+}
+
+// Options specifies configuration knobs used when creating a new Transport.
+type Options struct {
+	// ServerCfg contains all the configuration required to connect to the xDS
+	// management server.
+	ServerCfg *bootstrap.ServerConfig
+	// UpdateHandler is the component which makes ACK/NACK decisions based on
+	// the received resources.
+	//
+	// Invoked inline and implementations must not block.
+	UpdateHandler UpdateHandlerFunc
+	// StreamErrorHandler provides a way for the transport layer to report
+	// underlying stream errors. These can be bubbled all the way up to the user
+	// of the xdsClient.
+	//
+	// Invoked inline and implementations must not block.
+	StreamErrorHandler func(error)
+	// Backoff controls the amount of time to backoff before recreating failed
+	// ADS streams. If unspecified, a default exponential backoff implementation
+	// is used. For more details, see:
+	// https://github.com/grpc/grpc/blob/master/doc/connection-backoff.md.
+	Backoff func(retries int) time.Duration
+	// Logger does logging with a prefix.
+	Logger *grpclog.PrefixLogger
+}
+
+// For overriding in unit tests.
+var grpcDial = grpc.Dial
+
+// New creates a new Transport.
+func New(opts *Options) (*Transport, error) {
+	switch {
+	case opts == nil:
+		return nil, errors.New("missing options when creating a new transport")
+	case opts.ServerCfg == nil:
+		return nil, errors.New("missing ServerConfig when creating a new transport")
+	case opts.ServerCfg.ServerURI == "":
+		return nil, errors.New("missing server URI when creating a new transport")
+	case opts.ServerCfg.Creds == nil:
+		return nil, errors.New("missing credentials when creating a new transport")
+	case opts.ServerCfg.NodeProto == nil:
+		return nil, errors.New("missing node proto when creating a new transport")
+	case opts.UpdateHandler == nil:
+		return nil, errors.New("missing update handler when creating a new transport")
+	case opts.StreamErrorHandler == nil:
+		return nil, errors.New("missing stream error handler when creating a new transport")
+	}
+
+	node, ok := opts.ServerCfg.NodeProto.(*v3corepb.Node)
+	if !ok {
+		return nil, fmt.Errorf("unexpected type %T for NodeProto, want %T", opts.ServerCfg.NodeProto, &v3corepb.Node{})
+	}
+
+	// Dial the xDS management with the passed in credentials.
+	dopts := []grpc.DialOption{
+		opts.ServerCfg.Creds,
+		grpc.WithKeepaliveParams(keepalive.ClientParameters{
+			// We decided to use these sane defaults in all languages, and
+			// kicked the can down the road as far making these configurable.
+			Time:    5 * time.Minute,
+			Timeout: 20 * time.Second,
+		}),
+	}
+	cc, err := grpcDial(opts.ServerCfg.ServerURI, dopts...)
+	if err != nil {
+		// An error from a non-blocking dial indicates something serious.
+		return nil, fmt.Errorf("failed to create a transport to the management server %q: %v", opts.ServerCfg.ServerURI, err)
+	}
+
+	boff := opts.Backoff
+	if boff == nil {
+		boff = backoff.DefaultExponential.Backoff
+	}
+	ret := &Transport{
+		cc:                  cc,
+		serverURI:           opts.ServerCfg.ServerURI,
+		updateHandler:       opts.UpdateHandler,
+		adsStreamErrHandler: opts.StreamErrorHandler,
+		lrsStore:            load.NewStore(),
+		backoff:             boff,
+		nodeProto:           node,
+		logger:              opts.Logger,
+
+		adsStreamCh:  make(chan adsStream, 1),
+		adsRequestCh: buffer.NewUnbounded(),
+		resources:    make(map[string]map[string]bool),
+		versions:     make(map[string]string),
+		nonces:       make(map[string]string),
+	}
+
+	// This context is used for sending and receiving RPC requests and
+	// responses. It is also used by all the goroutines spawned by this
+	// Transport. Therefore, cancelling this context when the transport is
+	// closed will essentially cancel any pending RPCs, and cause the goroutines
+	// to terminate.
+	ctx, cancel := context.WithCancel(context.Background())
+	ret.stopRunGoroutine = cancel
+	go ret.run(ctx)
+
+	ret.logger.Infof("Created transport to server %q", ret.serverURI)
+	return ret, nil
+}
+
+// resourceRequest wraps the resource type url and the resource names requested
+// by the user of this transport.
+type resourceRequest struct {
+	resources []string
+	url       string
+}
+
+// SendRequest sends out an ADS request for the provided resources of the
+// specified resource type.
+//
+// The request is sent out asynchronously. If no valid stream exists at the time
+// of processing this request, it is queued and will be sent out once a valid
+// stream exists.
+//
+// If a successful response is received, the update handler callback provided at
+// creation time is invoked. If an error is encountered, the stream error
+// handler callback provided at creation time is invoked.
+func (t *Transport) SendRequest(url string, resources []string) {
+	t.adsRequestCh.Put(&resourceRequest{
+		url:       url,
+		resources: resources,
+	})
+}
+
+func (t *Transport) newAggregatedDiscoveryServiceStream(ctx context.Context, cc *grpc.ClientConn) (adsStream, error) {
+	// The transport retries the stream with an exponential backoff whenever the
+	// stream breaks. But if the channel is broken, we don't want the backoff
+	// logic to continuously retry the stream. Setting WaitForReady() blocks the
+	// stream creation until the channel is READY.
+	//
+	// TODO(easwars): Make changes required to comply with A57:
+	// https://github.com/grpc/proposal/blob/master/A57-xds-client-failure-mode-behavior.md
+	return v3adsgrpc.NewAggregatedDiscoveryServiceClient(cc).StreamAggregatedResources(ctx, grpc.WaitForReady(true))
+}
+
+func (t *Transport) sendAggregatedDiscoveryServiceRequest(stream adsStream, resourceNames []string, resourceURL, version, nonce, errMsg string) error {
+	req := &v3discoverypb.DiscoveryRequest{
+		Node:          t.nodeProto,
+		TypeUrl:       resourceURL,
+		ResourceNames: resourceNames,
+		VersionInfo:   version,
+		ResponseNonce: nonce,
+	}
+	if errMsg != "" {
+		req.ErrorDetail = &statuspb.Status{
+			Code: int32(codes.InvalidArgument), Message: errMsg,
+		}
+	}
+	if err := stream.Send(req); err != nil {
+		return fmt.Errorf("sending ADS request %s failed: %v", pretty.ToJSON(req), err)
+	}
+	t.logger.Debugf("ADS request sent: %v", pretty.ToJSON(req))
+	return nil
+}
+
+func (t *Transport) recvAggregatedDiscoveryServiceResponse(stream adsStream) (resources []*anypb.Any, resourceURL, version, nonce string, err error) {
+	resp, err := stream.Recv()
+	if err != nil {
+		return nil, "", "", "", fmt.Errorf("failed to read ADS response: %v", err)
+	}
+	t.logger.Infof("ADS response received, type: %v", resp.GetTypeUrl())
+	t.logger.Debugf("ADS response received: %v", pretty.ToJSON(resp))
+	return resp.GetResources(), resp.GetTypeUrl(), resp.GetVersionInfo(), resp.GetNonce(), nil
+}
+
+// run starts an ADS stream (and backs off exponentially, if the previous
+// stream failed without receiving a single reply) and runs the sender and
+// receiver routines to send and receive data from the stream respectively.
+func (t *Transport) run(ctx context.Context) {
+	go t.send(ctx)
+	// TODO: start a goroutine monitoring ClientConn's connectivity state, and
+	// report error (and log) when stats is transient failure.
+
+	retries := 0
+	lastStreamStartTime := time.Time{}
+	for ctx.Err() == nil {
+		dur := time.Until(lastStreamStartTime.Add(t.backoff(retries)))
+		if dur > 0 {
+			timer := time.NewTimer(dur)
+			select {
+			case <-timer.C:
+			case <-ctx.Done():
+				timer.Stop()
+				return
+			}
+		}
+
+		retries++
+		lastStreamStartTime = time.Now()
+		stream, err := t.newAggregatedDiscoveryServiceStream(ctx, t.cc)
+		if err != nil {
+			t.adsStreamErrHandler(err)
+			t.logger.Warningf("ADS stream creation failed: %v", err)
+			continue
+		}
+		t.logger.Infof("ADS stream created")
+
+		select {
+		case <-t.adsStreamCh:
+		default:
+		}
+		t.adsStreamCh <- stream
+		if t.recv(stream) {
+			retries = 0
+		}
+	}
+}
+
+// send is a separate goroutine for sending resource requests on the ADS stream.
+//
+// For every new stream received on the stream channel, all existing resources
+// are re-requested from the management server.
+//
+// For every new resource request received on the resources channel, the
+// resources map is updated (this ensures that resend will pick them up when
+// there are new streams) and the appropriate request is sent out.
+func (t *Transport) send(ctx context.Context) {
+	var stream adsStream
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case stream = <-t.adsStreamCh:
+			if !t.sendExisting(stream) {
+				// Send failed, clear the current stream. Attempt to resend will
+				// only be made after a new stream is created.
+				stream = nil
+			}
+		case u := <-t.adsRequestCh.Get():
+			t.adsRequestCh.Load()
+
+			var (
+				resources                   []string
+				url, version, nonce, errMsg string
+				send                        bool
+			)
+			switch update := u.(type) {
+			case *resourceRequest:
+				resources, url, version, nonce = t.processResourceRequest(update)
+			case *ackRequest:
+				resources, url, version, nonce, send = t.processAckRequest(update, stream)
+				if !send {
+					continue
+				}
+				errMsg = update.errMsg
+			}
+			if stream == nil {
+				// There's no stream yet. Skip the request. This request
+				// will be resent to the new streams. If no stream is
+				// created, the watcher will timeout (same as server not
+				// sending response back).
+				continue
+			}
+			if err := t.sendAggregatedDiscoveryServiceRequest(stream, resources, url, version, nonce, errMsg); err != nil {
+				t.logger.Warningf("ADS request for {resources: %q, url: %v, version: %q, nonce: %q} failed: %v", resources, url, version, nonce, err)
+				// Send failed, clear the current stream.
+				stream = nil
+			}
+		}
+	}
+}
+
+// sendExisting sends out xDS requests for existing resources when recovering
+// from a broken stream.
+//
+// We call stream.Send() here with the lock being held. It should be OK to do
+// that here because the stream has just started and Send() usually returns
+// quickly (once it pushes the message onto the transport layer) and is only
+// ever blocked if we don't have enough flow control quota.
+func (t *Transport) sendExisting(stream adsStream) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	// Reset only the nonces map when the stream restarts.
+	//
+	// xDS spec says the following. See section:
+	// https://www.envoyproxy.io/docs/envoy/latest/api-docs/xds_protocol#ack-nack-and-resource-type-instance-version
+	//
+	// Note that the version for a resource type is not a property of an
+	// individual xDS stream but rather a property of the resources themselves. If
+	// the stream becomes broken and the client creates a new stream, the client’s
+	// initial request on the new stream should indicate the most recent version
+	// seen by the client on the previous stream
+	t.nonces = make(map[string]string)
+
+	for url, resources := range t.resources {
+		if err := t.sendAggregatedDiscoveryServiceRequest(stream, mapToSlice(resources), url, t.versions[url], "", ""); err != nil {
+			t.logger.Warningf("ADS request failed: %v", err)
+			return false
+		}
+	}
+
+	return true
+}
+
+// recv receives xDS responses on the provided ADS stream and branches out to
+// message specific handlers.
+func (t *Transport) recv(stream adsStream) bool {
+	msgReceived := false
+	for {
+		resources, url, rVersion, nonce, err := t.recvAggregatedDiscoveryServiceResponse(stream)
+		if err != nil {
+			t.adsStreamErrHandler(err)
+			t.logger.Warningf("ADS stream is closed with error: %v", err)
+			return msgReceived
+		}
+		msgReceived = true
+
+		err = t.updateHandler(ResourceUpdate{
+			Resources: resources,
+			URL:       url,
+			Version:   rVersion,
+		})
+		if e, ok := err.(xdsresource.ErrResourceTypeUnsupported); ok {
+			t.logger.Warningf("%s", e.ErrStr)
+			continue
+		}
+		if err != nil {
+			t.adsRequestCh.Put(&ackRequest{
+				url:     url,
+				version: "",
+				nonce:   nonce,
+				errMsg:  err.Error(),
+				stream:  stream,
+			})
+			t.logger.Warningf("Sending NACK for resource type: %v, version: %v, nonce: %v, reason: %v", url, rVersion, nonce, err)
+			continue
+		}
+		t.adsRequestCh.Put(&ackRequest{
+			url:     url,
+			version: rVersion,
+			nonce:   nonce,
+			stream:  stream,
+		})
+		t.logger.Infof("Sending ACK for resource type: %v, version: %v, nonce: %v", url, rVersion, nonce)
+	}
+}
+
+func mapToSlice(m map[string]bool) []string {
+	ret := make([]string, 0, len(m))
+	for i := range m {
+		ret = append(ret, i)
+	}
+	return ret
+}
+
+func sliceToMap(ss []string) map[string]bool {
+	ret := make(map[string]bool, len(ss))
+	for _, s := range ss {
+		ret[s] = true
+	}
+	return ret
+}
+
+// processResourceRequest pulls the fields needed to send out an ADS request.
+// The resource type and the list of resources to request are provided by the
+// user, while the version and nonce are maintained internally.
+//
+// The resources map, which keeps track of the resources being requested, is
+// updated here. Any subsequent stream failure will re-request resources stored
+// in this map.
+//
+// Returns the list of resources, resource type url, version and nonce.
+func (t *Transport) processResourceRequest(req *resourceRequest) ([]string, string, string, string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	resources := sliceToMap(req.resources)
+	t.resources[req.url] = resources
+	return req.resources, req.url, t.versions[req.url], t.nonces[req.url]
+}
+
+type ackRequest struct {
+	url     string // Resource type URL.
+	version string // NACK if version is an empty string.
+	nonce   string
+	errMsg  string // Empty unless it's a NACK.
+	// ACK/NACK are tagged with the stream it's for. When the stream is down,
+	// all the ACK/NACK for this stream will be dropped, and the version/nonce
+	// won't be updated.
+	stream grpc.ClientStream
+}
+
+// processAckRequest pulls the fields needed to send out an ADS ACK. The nonces
+// and versions map is updated.
+//
+// Returns the list of resources, resource type url, version, nonce, and an
+// indication of whether an ACK should be sent on the wire or not.
+func (t *Transport) processAckRequest(ack *ackRequest, stream grpc.ClientStream) ([]string, string, string, string, bool) {
+	if ack.stream != stream {
+		// If ACK's stream isn't the current sending stream, this means the ACK
+		// was pushed to queue before the old stream broke, and a new stream has
+		// been started since. Return immediately here so we don't update the
+		// nonce for the new stream.
+		return nil, "", "", "", false
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	// Update the nonce irrespective of whether we send the ACK request on wire.
+	// An up-to-date nonce is required for the next request.
+	nonce := ack.nonce
+	t.nonces[ack.url] = nonce
+
+	s, ok := t.resources[ack.url]
+	if !ok || len(s) == 0 {
+		// We don't send the ACK request if there are no resources of this type
+		// in our resources map. This can be either when the server sends
+		// responses before any request, or the resources are removed while the
+		// ackRequest was in queue). If we send a request with an empty
+		// resource name list, the server may treat it as a wild card and send
+		// us everything.
+		return nil, "", "", "", false
+	}
+	resources := mapToSlice(s)
+
+	version := ack.version
+	if version == "" {
+		// This is a NACK. Get the previously ACKed version, which could also be
+		// an empty string.  This can happen if there wasn't any ACK before.
+		version = t.versions[ack.url]
+	} else {
+		// This is an ACK. Update the versions map.
+		t.versions[ack.url] = version
+	}
+	return resources, ack.url, version, nonce, true
+}
+
+// Close closes the Transport and frees any associated resources.
+func (t *Transport) Close() {
+	t.stopRunGoroutine()
+	t.cc.Close()
+}
+
+// ChannelConnectivityStateForTesting returns the connectivity state of the gRPC
+// channel to the management server.
+//
+// Only for testing purposes.
+func (t *Transport) ChannelConnectivityStateForTesting() connectivity.State {
+	return t.cc.GetState()
+}

--- a/xds/internal/xdsclient/transport/transport.go
+++ b/xds/internal/xdsclient/transport/transport.go
@@ -440,8 +440,8 @@ func (t *Transport) recv(stream adsStream) bool {
 			URL:       url,
 			Version:   rVersion,
 		})
-		if e, ok := err.(xdsresource.ErrResourceTypeUnsupported); ok {
-			t.logger.Warningf("%s", e.ErrStr)
+		if xdsresource.ErrType(err) == xdsresource.ErrorTypeResourceTypeUnsupported {
+			t.logger.Warningf("%v", err)
 			continue
 		}
 		// If the data model layer returned an error, we need to NACK the

--- a/xds/internal/xdsclient/transport/transport.go
+++ b/xds/internal/xdsclient/transport/transport.go
@@ -45,7 +45,7 @@ import (
 	statuspb "google.golang.org/genproto/googleapis/rpc/status"
 )
 
-type adsStream v3adsgrpc.AggregatedDiscoveryService_StreamAggregatedResourcesClient
+type adsStream = v3adsgrpc.AggregatedDiscoveryService_StreamAggregatedResourcesClient
 
 // Transport provides a resource-type agnostic implementation of the xDS
 // transport protocol. At this layer, resource contents are supposed to be

--- a/xds/internal/xdsclient/transport/transport.go
+++ b/xds/internal/xdsclient/transport/transport.go
@@ -123,7 +123,7 @@ type ResourceUpdate struct {
 type Options struct {
 	// ServerCfg contains all the configuration required to connect to the xDS
 	// management server.
-	ServerCfg *bootstrap.ServerConfig
+	ServerCfg bootstrap.ServerConfig
 	// UpdateHandler is the component which makes ACK/NACK decisions based on
 	// the received resources.
 	//
@@ -148,18 +148,12 @@ type Options struct {
 var grpcDial = grpc.Dial
 
 // New creates a new Transport.
-func New(opts *Options) (*Transport, error) {
+func New(opts Options) (*Transport, error) {
 	switch {
-	case opts == nil:
-		return nil, errors.New("missing options when creating a new transport")
-	case opts.ServerCfg == nil:
-		return nil, errors.New("missing ServerConfig when creating a new transport")
 	case opts.ServerCfg.ServerURI == "":
 		return nil, errors.New("missing server URI when creating a new transport")
 	case opts.ServerCfg.Creds == nil:
 		return nil, errors.New("missing credentials when creating a new transport")
-	case opts.ServerCfg.NodeProto == nil:
-		return nil, errors.New("missing node proto when creating a new transport")
 	case opts.UpdateHandler == nil:
 		return nil, errors.New("missing update handler when creating a new transport")
 	case opts.StreamErrorHandler == nil:

--- a/xds/internal/xdsclient/transport/transport_ack_nack_test.go
+++ b/xds/internal/xdsclient/transport/transport_ack_nack_test.go
@@ -129,7 +129,7 @@ func (s) TestSimpleAckAndNack(t *testing.T) {
 	})
 
 	// Construct the server config to represent the management server.
-	serverCfg := &bootstrap.ServerConfig{
+	serverCfg := bootstrap.ServerConfig{
 		ServerURI:    mgmtServer.Address,
 		Creds:        grpc.WithTransportCredentials(insecure.NewCredentials()),
 		CredsType:    "insecure",
@@ -138,7 +138,7 @@ func (s) TestSimpleAckAndNack(t *testing.T) {
 	}
 
 	// Create a new transport.
-	tr, err := transport.New(&transport.Options{
+	tr, err := transport.New(transport.Options{
 		ServerCfg:          serverCfg,
 		UpdateHandler:      dataModelValidator,
 		StreamErrorHandler: func(err error) {},
@@ -312,7 +312,7 @@ func (s) TestInvalidFirstResponse(t *testing.T) {
 	})
 
 	// Construct the server config to represent the management server.
-	serverCfg := &bootstrap.ServerConfig{
+	serverCfg := bootstrap.ServerConfig{
 		ServerURI:    mgmtServer.Address,
 		Creds:        grpc.WithTransportCredentials(insecure.NewCredentials()),
 		CredsType:    "insecure",
@@ -321,7 +321,7 @@ func (s) TestInvalidFirstResponse(t *testing.T) {
 	}
 
 	// Create a new transport.
-	tr, err := transport.New(&transport.Options{
+	tr, err := transport.New(transport.Options{
 		ServerCfg:          serverCfg,
 		UpdateHandler:      dataModelValidator,
 		StreamErrorHandler: func(err error) {},
@@ -434,7 +434,7 @@ func (s) TestResourceIsNotRequestedAnymore(t *testing.T) {
 	})
 
 	// Construct the server config to represent the management server.
-	serverCfg := &bootstrap.ServerConfig{
+	serverCfg := bootstrap.ServerConfig{
 		ServerURI:    mgmtServer.Address,
 		Creds:        grpc.WithTransportCredentials(insecure.NewCredentials()),
 		CredsType:    "insecure",
@@ -443,7 +443,7 @@ func (s) TestResourceIsNotRequestedAnymore(t *testing.T) {
 	}
 
 	// Create a new transport.
-	tr, err := transport.New(&transport.Options{
+	tr, err := transport.New(transport.Options{
 		ServerCfg:          serverCfg,
 		UpdateHandler:      dataModelValidator,
 		StreamErrorHandler: func(err error) {},

--- a/xds/internal/xdsclient/transport/transport_ack_nack_test.go
+++ b/xds/internal/xdsclient/transport/transport_ack_nack_test.go
@@ -1,0 +1,525 @@
+/*
+ *
+ * Copyright 2022 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package transport_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/uuid"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/internal/testutils"
+	"google.golang.org/grpc/internal/testutils/xds/e2e"
+	"google.golang.org/grpc/xds/internal/xdsclient/bootstrap"
+	"google.golang.org/grpc/xds/internal/xdsclient/transport"
+	"google.golang.org/grpc/xds/internal/xdsclient/xdsresource/version"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/testing/protocmp"
+	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	v3corepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	v3listenerpb "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	v3httppb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+	v3discoverypb "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+	statuspb "google.golang.org/genproto/googleapis/rpc/status"
+)
+
+var (
+	errWantNack = errors.New("unsupported field 'use_original_dst' is present and set to true")
+
+	// A simple update handler for listener resources which validates only the
+	// `use_original_dst` field.
+	dataModelValidator = func(update transport.ResourceUpdate) error {
+		for _, r := range update.Resources {
+			inner := &v3discoverypb.Resource{}
+			if err := proto.Unmarshal(r.GetValue(), inner); err != nil {
+				return fmt.Errorf("failed to unmarshal DiscoveryResponse: %v", err)
+			}
+			lis := &v3listenerpb.Listener{}
+			if err := proto.Unmarshal(r.GetValue(), lis); err != nil {
+				return fmt.Errorf("failed to unmarshal DiscoveryResponse: %v", err)
+			}
+			if useOrigDst := lis.GetUseOriginalDst(); useOrigDst != nil && useOrigDst.GetValue() {
+				return errWantNack
+			}
+		}
+		return nil
+	}
+)
+
+// TestSimpleAckAndNack tests simple ACK and NACK scenarios.
+//  1. When the data model layer likes a received response, the test verifies
+//     that an ACK is sent matching the version and nonce from the response.
+//  2. When a subsequent response is disliked by the data model layer, the test
+//     verifies that a NACK is sent matching the previously ACKed version and
+//     current nonce from the response.
+//  3. When a subsequent response is liked by the data model layer, the test
+//     verifies that an ACK is sent matching the version and nonce from the
+//     current response.
+func (s) TestSimpleAckAndNack(t *testing.T) {
+	// Create an xDS management server listening on a local port. Configure the
+	// request and response handlers to push on channels which are inspected by
+	// the test goroutine to verify ack version and nonce.
+	streamRequestCh := make(chan *v3discoverypb.DiscoveryRequest, 1)
+	streamResponseCh := make(chan *v3discoverypb.DiscoveryResponse, 1)
+	mgmtServer, err := e2e.StartManagementServer(&e2e.ManagementServerOptions{
+		OnStreamRequest: func(id int64, req *v3discoverypb.DiscoveryRequest) error {
+			streamRequestCh <- req
+			return nil
+		},
+		OnStreamResponse: func(_ context.Context, _ int64, _ *v3discoverypb.DiscoveryRequest, resp *v3discoverypb.DiscoveryResponse) {
+			streamResponseCh <- resp
+		},
+	})
+	if err != nil {
+		t.Fatalf("Failed to start xDS management server: %v", err)
+	}
+	defer mgmtServer.Stop()
+	t.Logf("Started xDS management server on %s", mgmtServer.Address)
+
+	// Configure the management server with appropriate resources.
+	apiListener := &v3listenerpb.ApiListener{
+		ApiListener: func() *anypb.Any {
+			return testutils.MarshalAny(&v3httppb.HttpConnectionManager{
+				RouteSpecifier: &v3httppb.HttpConnectionManager_Rds{
+					Rds: &v3httppb.Rds{
+						ConfigSource: &v3corepb.ConfigSource{
+							ConfigSourceSpecifier: &v3corepb.ConfigSource_Ads{Ads: &v3corepb.AggregatedConfigSource{}},
+						},
+						RouteConfigName: "route-configuration-name",
+					},
+				},
+			})
+		}(),
+	}
+	const resourceName = "resource name 1"
+	listenerResource := &v3listenerpb.Listener{
+		Name:        resourceName,
+		ApiListener: apiListener,
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	nodeID := uuid.New().String()
+	mgmtServer.Update(ctx, e2e.UpdateOptions{
+		NodeID:         nodeID,
+		Listeners:      []*v3listenerpb.Listener{listenerResource},
+		SkipValidation: true,
+	})
+
+	// Construct the server config to represent the management server.
+	serverCfg := &bootstrap.ServerConfig{
+		ServerURI:    mgmtServer.Address,
+		Creds:        grpc.WithTransportCredentials(insecure.NewCredentials()),
+		CredsType:    "insecure",
+		TransportAPI: version.TransportV3,
+		NodeProto:    &v3corepb.Node{Id: nodeID},
+	}
+
+	// Create a new transport.
+	tr, err := transport.New(&transport.Options{
+		ServerCfg:          serverCfg,
+		UpdateHandler:      dataModelValidator,
+		StreamErrorHandler: func(err error) {},
+	})
+	if err != nil {
+		t.Fatalf("Failed to create xDS transport: %v", err)
+	}
+	defer tr.Close()
+
+	// Send a discovery request through the transport.
+	tr.SendRequest(version.V3ListenerURL, []string{resourceName})
+
+	// Verify that the initial discovery request matches expectation.
+	var gotReq *v3discoverypb.DiscoveryRequest
+	select {
+	case gotReq = <-streamRequestCh:
+	case <-ctx.Done():
+		t.Fatalf("Timeout waiting for discovery request on the stream")
+	}
+	wantReq := &v3discoverypb.DiscoveryRequest{
+		VersionInfo:   "",
+		Node:          &v3corepb.Node{Id: nodeID},
+		ResourceNames: []string{resourceName},
+		TypeUrl:       "type.googleapis.com/envoy.config.listener.v3.Listener",
+		ResponseNonce: "",
+	}
+	if diff := cmp.Diff(gotReq, wantReq, protocmp.Transform(), cmpopts.SortSlices(strSort)); diff != "" {
+		t.Fatalf("Unexpected diff in received discovery request, diff (-got, +want):\n%s", diff)
+	}
+
+	// Capture the version and nonce from the response.
+	var gotResp *v3discoverypb.DiscoveryResponse
+	select {
+	case gotResp = <-streamResponseCh:
+	case <-ctx.Done():
+		t.Fatalf("Timeout waiting for discovery response on the stream")
+	}
+
+	// Verify that the ACK contains the appropriate version and nonce.
+	wantReq.VersionInfo = gotResp.GetVersionInfo()
+	wantReq.ResponseNonce = gotResp.GetNonce()
+	select {
+	case gotReq = <-streamRequestCh:
+	case <-ctx.Done():
+		t.Fatalf("Timeout waiting for the discovery request ACK on the stream")
+	}
+	if diff := cmp.Diff(gotReq, wantReq, protocmp.Transform(), cmpopts.SortSlices(strSort)); diff != "" {
+		t.Fatalf("Unexpected diff in received discovery request, diff (-got, +want):\n%s", diff)
+	}
+
+	// Update the management server's copy of the resource to include a field
+	// which will cause the resource to be NACKed.
+	badListener := proto.Clone(listenerResource).(*v3listenerpb.Listener)
+	badListener.UseOriginalDst = &wrapperspb.BoolValue{Value: true}
+	mgmtServer.Update(ctx, e2e.UpdateOptions{
+		NodeID:         nodeID,
+		Listeners:      []*v3listenerpb.Listener{badListener},
+		SkipValidation: true,
+	})
+
+	select {
+	case gotResp = <-streamResponseCh:
+	case <-ctx.Done():
+		t.Fatalf("Timeout waiting for discovery response on the stream")
+	}
+
+	// Verify that the NACK contains the appropriate version, nonce and error.
+	// We expect the version to not change as this is a NACK.
+	wantReq.ResponseNonce = gotResp.GetNonce()
+	wantReq.ErrorDetail = &statuspb.Status{
+		Code:    int32(codes.InvalidArgument),
+		Message: errWantNack.Error(),
+	}
+	select {
+	case gotReq = <-streamRequestCh:
+	case <-ctx.Done():
+		t.Fatalf("Timeout waiting for the discovery request ACK on the stream")
+	}
+	if diff := cmp.Diff(gotReq, wantReq, protocmp.Transform(), cmpopts.SortSlices(strSort)); diff != "" {
+		t.Fatalf("Unexpected diff in received discovery request, diff (-got, +want):\n%s", diff)
+	}
+
+	// Update the management server to send a good resource again.
+	mgmtServer.Update(ctx, e2e.UpdateOptions{
+		NodeID:         nodeID,
+		Listeners:      []*v3listenerpb.Listener{listenerResource},
+		SkipValidation: true,
+	})
+
+	// The envoy-go-control-plane management server keeps resending the same
+	// resource as long as we keep NACK'ing it. So, we will see the bad resource
+	// sent to us a few times here, before receiving the good resource.
+	for {
+		select {
+		case gotResp = <-streamResponseCh:
+		case <-ctx.Done():
+			t.Fatalf("Timeout waiting for discovery response on the stream")
+		}
+
+		// Verify that the ACK contains the appropriate version and nonce.
+		wantReq.VersionInfo = gotResp.GetVersionInfo()
+		wantReq.ResponseNonce = gotResp.GetNonce()
+		wantReq.ErrorDetail = nil
+		select {
+		case gotReq = <-streamRequestCh:
+		case <-ctx.Done():
+			t.Fatalf("Timeout waiting for the discovery request ACK on the stream")
+		}
+		diff := cmp.Diff(gotReq, wantReq, protocmp.Transform(), cmpopts.SortSlices(strSort))
+		if diff == "" {
+			break
+		}
+		t.Logf("Unexpected diff in received discovery request, diff (-got, +want):\n%s", diff)
+	}
+}
+
+// TestInvalidFirstResponse tests the case where the first response is invalid.
+// The test verifies that the NACK contains an empty version string.
+func (s) TestInvalidFirstResponse(t *testing.T) {
+	// Create an xDS management server listening on a local port. Configure the
+	// request and response handlers to push on channels which are inspected by
+	// the test goroutine to verify ack version and nonce.
+	streamRequestCh := make(chan *v3discoverypb.DiscoveryRequest, 1)
+	streamResponseCh := make(chan *v3discoverypb.DiscoveryResponse, 1)
+	mgmtServer, err := e2e.StartManagementServer(&e2e.ManagementServerOptions{
+		OnStreamRequest: func(id int64, req *v3discoverypb.DiscoveryRequest) error {
+			streamRequestCh <- req
+			return nil
+		},
+		OnStreamResponse: func(_ context.Context, _ int64, _ *v3discoverypb.DiscoveryRequest, resp *v3discoverypb.DiscoveryResponse) {
+			select {
+			case streamResponseCh <- resp:
+			default:
+			}
+		},
+	})
+	if err != nil {
+		t.Fatalf("Failed to start xDS management server: %v", err)
+	}
+	defer mgmtServer.Stop()
+	t.Logf("Started xDS management server on %s", mgmtServer.Address)
+
+	// Configure the management server with appropriate resources.
+	apiListener := &v3listenerpb.ApiListener{
+		ApiListener: func() *anypb.Any {
+			return testutils.MarshalAny(&v3httppb.HttpConnectionManager{
+				RouteSpecifier: &v3httppb.HttpConnectionManager_Rds{
+					Rds: &v3httppb.Rds{
+						ConfigSource: &v3corepb.ConfigSource{
+							ConfigSourceSpecifier: &v3corepb.ConfigSource_Ads{Ads: &v3corepb.AggregatedConfigSource{}},
+						},
+						RouteConfigName: "route-configuration-name",
+					},
+				},
+			})
+		}(),
+	}
+	const resourceName = "resource name 1"
+	listenerResource := &v3listenerpb.Listener{
+		Name:           resourceName,
+		ApiListener:    apiListener,
+		UseOriginalDst: &wrapperspb.BoolValue{Value: true}, // This will cause the resource to be NACKed.
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	nodeID := uuid.New().String()
+	mgmtServer.Update(ctx, e2e.UpdateOptions{
+		NodeID:         nodeID,
+		Listeners:      []*v3listenerpb.Listener{listenerResource},
+		SkipValidation: true,
+	})
+
+	// Construct the server config to represent the management server.
+	serverCfg := &bootstrap.ServerConfig{
+		ServerURI:    mgmtServer.Address,
+		Creds:        grpc.WithTransportCredentials(insecure.NewCredentials()),
+		CredsType:    "insecure",
+		TransportAPI: version.TransportV3,
+		NodeProto:    &v3corepb.Node{Id: nodeID},
+	}
+
+	// Create a new transport.
+	tr, err := transport.New(&transport.Options{
+		ServerCfg:          serverCfg,
+		UpdateHandler:      dataModelValidator,
+		StreamErrorHandler: func(err error) {},
+	})
+	if err != nil {
+		t.Fatalf("Failed to create xDS transport: %v", err)
+	}
+	defer tr.Close()
+
+	// Send a discovery request through the transport.
+	tr.SendRequest(version.V3ListenerURL, []string{resourceName})
+
+	// Verify that the initial discovery request matches expectation.
+	var gotReq *v3discoverypb.DiscoveryRequest
+	select {
+	case gotReq = <-streamRequestCh:
+	case <-ctx.Done():
+		t.Fatalf("Timeout waiting for discovery request on the stream")
+	}
+	wantReq := &v3discoverypb.DiscoveryRequest{
+		Node:          &v3corepb.Node{Id: nodeID},
+		ResourceNames: []string{resourceName},
+		TypeUrl:       "type.googleapis.com/envoy.config.listener.v3.Listener",
+	}
+	if diff := cmp.Diff(gotReq, wantReq, protocmp.Transform(), cmpopts.SortSlices(strSort)); diff != "" {
+		t.Fatalf("Unexpected diff in received discovery request, diff (-got, +want):\n%s", diff)
+	}
+
+	var gotResp *v3discoverypb.DiscoveryResponse
+	select {
+	case gotResp = <-streamResponseCh:
+	case <-ctx.Done():
+		t.Fatalf("Timeout waiting for discovery response on the stream")
+	}
+
+	// NACK should contain the appropriate error, nonce, but empty version.
+	wantReq.VersionInfo = ""
+	wantReq.ResponseNonce = gotResp.GetNonce()
+	wantReq.ErrorDetail = &statuspb.Status{
+		Code:    int32(codes.InvalidArgument),
+		Message: errWantNack.Error(),
+	}
+	select {
+	case gotReq = <-streamRequestCh:
+	case <-ctx.Done():
+		t.Fatalf("Timeout waiting for the discovery request ACK on the stream")
+	}
+	if diff := cmp.Diff(gotReq, wantReq, protocmp.Transform(), cmpopts.SortSlices(strSort)); diff != "" {
+		t.Fatalf("Unexpected diff in received discovery request, diff (-got, +want):\n%s", diff)
+	}
+}
+
+// TestResourceIsNotRequestedAnymore tests the scenario where the xDS client is
+// no longer interested in a resource. The following sequence of events are
+// tested:
+//  1. A resource is requested and a good response is received. The test verifies
+//     that an ACK is sent for this resource.
+//  2. The previously requested resource is no longer requested. The test
+//     verifies that a request with no resource names is sent out.
+//  3. The same resource is requested again. The test verifies that the request
+//     is sent with the previously ACKed version.
+func (s) TestResourceIsNotRequestedAnymore(t *testing.T) {
+	// Create an xDS management server listening on a local port. Configure the
+	// request and response handlers to push on channels which are inspected by
+	// the test goroutine to verify ack version and nonce.
+	streamRequestCh := make(chan *v3discoverypb.DiscoveryRequest, 1)
+	streamResponseCh := make(chan *v3discoverypb.DiscoveryResponse, 1)
+	mgmtServer, err := e2e.StartManagementServer(&e2e.ManagementServerOptions{
+		OnStreamRequest: func(id int64, req *v3discoverypb.DiscoveryRequest) error {
+			streamRequestCh <- req
+			return nil
+		},
+		OnStreamResponse: func(_ context.Context, _ int64, _ *v3discoverypb.DiscoveryRequest, resp *v3discoverypb.DiscoveryResponse) {
+			streamResponseCh <- resp
+		},
+	})
+	if err != nil {
+		t.Fatalf("Failed to start xDS management server: %v", err)
+	}
+	defer mgmtServer.Stop()
+	t.Logf("Started xDS management server on %s", mgmtServer.Address)
+
+	// Configure the management server with appropriate resources.
+	apiListener := &v3listenerpb.ApiListener{
+		ApiListener: func() *anypb.Any {
+			return testutils.MarshalAny(&v3httppb.HttpConnectionManager{
+				RouteSpecifier: &v3httppb.HttpConnectionManager_Rds{
+					Rds: &v3httppb.Rds{
+						ConfigSource: &v3corepb.ConfigSource{
+							ConfigSourceSpecifier: &v3corepb.ConfigSource_Ads{Ads: &v3corepb.AggregatedConfigSource{}},
+						},
+						RouteConfigName: "route-configuration-name",
+					},
+				},
+			})
+		}(),
+	}
+	const resourceName = "resource name 1"
+	listenerResource := &v3listenerpb.Listener{
+		Name:        resourceName,
+		ApiListener: apiListener,
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	nodeID := uuid.New().String()
+	mgmtServer.Update(ctx, e2e.UpdateOptions{
+		NodeID:         nodeID,
+		Listeners:      []*v3listenerpb.Listener{listenerResource},
+		SkipValidation: true,
+	})
+
+	// Construct the server config to represent the management server.
+	serverCfg := &bootstrap.ServerConfig{
+		ServerURI:    mgmtServer.Address,
+		Creds:        grpc.WithTransportCredentials(insecure.NewCredentials()),
+		CredsType:    "insecure",
+		TransportAPI: version.TransportV3,
+		NodeProto:    &v3corepb.Node{Id: nodeID},
+	}
+
+	// Create a new transport.
+	tr, err := transport.New(&transport.Options{
+		ServerCfg:          serverCfg,
+		UpdateHandler:      dataModelValidator,
+		StreamErrorHandler: func(err error) {},
+	})
+	if err != nil {
+		t.Fatalf("Failed to create xDS transport: %v", err)
+	}
+	defer tr.Close()
+
+	// Send a discovery request through the transport.
+	tr.SendRequest(version.V3ListenerURL, []string{resourceName})
+
+	// Verify that the initial discovery request matches expectation.
+	var gotReq *v3discoverypb.DiscoveryRequest
+	select {
+	case gotReq = <-streamRequestCh:
+	case <-ctx.Done():
+		t.Fatalf("Timeout waiting for discovery request on the stream")
+	}
+	wantReq := &v3discoverypb.DiscoveryRequest{
+		VersionInfo:   "",
+		Node:          &v3corepb.Node{Id: nodeID},
+		ResourceNames: []string{resourceName},
+		TypeUrl:       "type.googleapis.com/envoy.config.listener.v3.Listener",
+		ResponseNonce: "",
+	}
+	if diff := cmp.Diff(gotReq, wantReq, protocmp.Transform(), cmpopts.SortSlices(strSort)); diff != "" {
+		t.Fatalf("Unexpected diff in received discovery request, diff (-got, +want):\n%s", diff)
+	}
+
+	// Capture the version and nonce from the response.
+	var gotResp *v3discoverypb.DiscoveryResponse
+	select {
+	case gotResp = <-streamResponseCh:
+	case <-ctx.Done():
+		t.Fatalf("Timeout waiting for discovery response on the stream")
+	}
+
+	// Verify that the ACK contains the appropriate version and nonce.
+	wantReq.VersionInfo = gotResp.GetVersionInfo()
+	wantReq.ResponseNonce = gotResp.GetNonce()
+	select {
+	case gotReq = <-streamRequestCh:
+	case <-ctx.Done():
+		t.Fatalf("Timeout waiting for the discovery request ACK on the stream")
+	}
+	if diff := cmp.Diff(gotReq, wantReq, protocmp.Transform(), cmpopts.SortSlices(strSort)); diff != "" {
+		t.Fatalf("Unexpected diff in received discovery request, diff (-got, +want):\n%s", diff)
+	}
+
+	// Send a discovery request with no resource names.
+	tr.SendRequest(version.V3ListenerURL, []string{})
+
+	// Verify that the discovery request matches expectation.
+	select {
+	case gotReq = <-streamRequestCh:
+	case <-ctx.Done():
+		t.Fatalf("Timeout waiting for discovery request on the stream")
+	}
+	wantReq.ResourceNames = nil
+	if diff := cmp.Diff(gotReq, wantReq, protocmp.Transform(), cmpopts.SortSlices(strSort)); diff != "" {
+		t.Fatalf("Unexpected diff in received discovery request, diff (-got, +want):\n%s", diff)
+	}
+
+	// Send a discovery request for the same resource requested earlier.
+	tr.SendRequest(version.V3ListenerURL, []string{resourceName})
+
+	// Verify that the discovery request contains the version from the
+	// previously received response.
+	select {
+	case gotReq = <-streamRequestCh:
+	case <-ctx.Done():
+		t.Fatalf("Timeout waiting for discovery request on the stream")
+	}
+	wantReq.ResourceNames = []string{resourceName}
+	if diff := cmp.Diff(gotReq, wantReq, protocmp.Transform(), cmpopts.SortSlices(strSort)); diff != "" {
+		t.Fatalf("Unexpected diff in received discovery request, diff (-got, +want):\n%s", diff)
+	}
+}

--- a/xds/internal/xdsclient/transport/transport_backoff_test.go
+++ b/xds/internal/xdsclient/transport/transport_backoff_test.go
@@ -100,7 +100,7 @@ func (s) TestTransport_BackoffAfterStreamFailure(t *testing.T) {
 
 	// Construct the server config to represent the management server.
 	nodeID := uuid.New().String()
-	serverCfg := &bootstrap.ServerConfig{
+	serverCfg := bootstrap.ServerConfig{
 		ServerURI:    mgmtServer.Address,
 		Creds:        grpc.WithTransportCredentials(insecure.NewCredentials()),
 		CredsType:    "insecure",
@@ -110,7 +110,7 @@ func (s) TestTransport_BackoffAfterStreamFailure(t *testing.T) {
 
 	// Create a new transport. Since we are only testing backoff behavior here,
 	// we can pass a no-op data model layer implementation.
-	tr, err := transport.New(&transport.Options{
+	tr, err := transport.New(transport.Options{
 		ServerCfg:     serverCfg,
 		UpdateHandler: func(transport.ResourceUpdate) error { return nil }, // No data model layer validation.
 		StreamErrorHandler: func(err error) {
@@ -268,7 +268,7 @@ func (s) TestTransport_RetriesAfterBrokenStream(t *testing.T) {
 	})
 
 	// Construct the server config to represent the management server.
-	serverCfg := &bootstrap.ServerConfig{
+	serverCfg := bootstrap.ServerConfig{
 		ServerURI:    lis.Addr().String(),
 		Creds:        grpc.WithTransportCredentials(insecure.NewCredentials()),
 		CredsType:    "insecure",
@@ -278,7 +278,7 @@ func (s) TestTransport_RetriesAfterBrokenStream(t *testing.T) {
 
 	// Create a new transport. Since we are only testing backoff behavior here,
 	// we can pass a no-op data model layer implementation.
-	tr, err := transport.New(&transport.Options{
+	tr, err := transport.New(transport.Options{
 		ServerCfg:     serverCfg,
 		UpdateHandler: func(transport.ResourceUpdate) error { return nil }, // No data model layer validation.
 		StreamErrorHandler: func(err error) {
@@ -407,7 +407,7 @@ func (s) TestTransport_ResourceRequestedBeforeStreamCreation(t *testing.T) {
 
 	// Construct the server config to represent the management server.
 	nodeID := uuid.New().String()
-	serverCfg := &bootstrap.ServerConfig{
+	serverCfg := bootstrap.ServerConfig{
 		ServerURI:    lis.Addr().String(),
 		Creds:        grpc.WithTransportCredentials(insecure.NewCredentials()),
 		CredsType:    "insecure",
@@ -417,7 +417,7 @@ func (s) TestTransport_ResourceRequestedBeforeStreamCreation(t *testing.T) {
 
 	// Create a new transport. Since we are only testing backoff behavior here,
 	// we can pass a no-op data model layer implementation.
-	tr, err := transport.New(&transport.Options{
+	tr, err := transport.New(transport.Options{
 		ServerCfg:          serverCfg,
 		UpdateHandler:      func(transport.ResourceUpdate) error { return nil }, // No data model layer validation.
 		StreamErrorHandler: func(error) {},                                      // No stream error handling.

--- a/xds/internal/xdsclient/transport/transport_backoff_test.go
+++ b/xds/internal/xdsclient/transport/transport_backoff_test.go
@@ -1,0 +1,467 @@
+/*
+ *
+ * Copyright 2022 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package transport_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/uuid"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/connectivity"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/internal/testutils"
+	"google.golang.org/grpc/internal/testutils/xds/e2e"
+	"google.golang.org/grpc/xds/internal/xdsclient/bootstrap"
+	"google.golang.org/grpc/xds/internal/xdsclient/transport"
+	"google.golang.org/grpc/xds/internal/xdsclient/xdsresource/version"
+	"google.golang.org/protobuf/testing/protocmp"
+	"google.golang.org/protobuf/types/known/anypb"
+
+	v3corepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	v3listenerpb "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	v3httppb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+	v3discoverypb "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+)
+
+var strSort = func(s1, s2 string) bool { return s1 < s2 }
+
+// TestTransport_BackoffAfterStreamFailure tests the case where the management
+// server returns an error in the ADS streaming RPC. The test verifies the
+// following:
+// 1. Initial discovery request matches expectation.
+// 2. RPC error is propagated via the stream error handler.
+// 3. When the stream is closed, the transport backs off.
+// 4. The same discovery request is sent on the newly created stream.
+func (s) TestTransport_BackoffAfterStreamFailure(t *testing.T) {
+	// Channels used for verifying different events in the test.
+	streamCloseCh := make(chan struct{}, 1)                          // ADS stream is closed.
+	streamRequestCh := make(chan *v3discoverypb.DiscoveryRequest, 1) // Discovery request is received.
+	backoffCh := make(chan struct{}, 1)                              // Transport backoff after stream failure.
+	streamErrCh := make(chan error, 1)                               // Stream error seen by the transport.
+
+	// Create an xDS management server listening on a local port.
+	streamErr := errors.New("ADS stream error")
+	mgmtServer, err := e2e.StartManagementServer(&e2e.ManagementServerOptions{
+		// Push on a channel whenever the stream is closed.
+		OnStreamClosed: func(int64) {
+			select {
+			case streamCloseCh <- struct{}{}:
+			default:
+			}
+		},
+
+		// Return an error everytime a request is sent on the stream. This
+		// should cause the transport to backoff before attempting to recreate
+		// the stream.
+		OnStreamRequest: func(id int64, req *v3discoverypb.DiscoveryRequest) error {
+			select {
+			case streamRequestCh <- req:
+			default:
+			}
+			return streamErr
+		},
+	})
+	if err != nil {
+		t.Fatalf("Failed to start xDS management server: %v", err)
+	}
+	defer mgmtServer.Stop()
+	t.Logf("Started xDS management server on %s", mgmtServer.Address)
+
+	// Override the backoff implementation to push on a channel that is read by
+	// the test goroutine.
+	transportBackoff := func(v int) time.Duration {
+		select {
+		case backoffCh <- struct{}{}:
+		default:
+		}
+		return 0
+	}
+
+	// Construct the server config to represent the management server.
+	nodeID := uuid.New().String()
+	serverCfg := &bootstrap.ServerConfig{
+		ServerURI:    mgmtServer.Address,
+		Creds:        grpc.WithTransportCredentials(insecure.NewCredentials()),
+		CredsType:    "insecure",
+		TransportAPI: version.TransportV3,
+		NodeProto:    &v3corepb.Node{Id: nodeID},
+	}
+
+	// Create a new transport. Since we are only testing backoff behavior here,
+	// we can pass a no-op data model layer implementation.
+	tr, err := transport.New(&transport.Options{
+		ServerCfg:     serverCfg,
+		UpdateHandler: func(transport.ResourceUpdate) error { return nil }, // No data model layer validation.
+		StreamErrorHandler: func(err error) {
+			select {
+			case streamErrCh <- err:
+			default:
+			}
+		},
+		Backoff: transportBackoff,
+	})
+	if err != nil {
+		t.Fatalf("Failed to create xDS transport: %v", err)
+	}
+	defer tr.Close()
+
+	// Send a discovery request through the transport.
+	const resourceName = "resource name"
+	tr.SendRequest(version.V3ListenerURL, []string{resourceName})
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+
+	// Verify that the initial discovery request matches expectation.
+	var gotReq *v3discoverypb.DiscoveryRequest
+	select {
+	case gotReq = <-streamRequestCh:
+	case <-ctx.Done():
+		t.Fatalf("Timeout waiting for discovery request on the stream")
+	}
+	wantReq := &v3discoverypb.DiscoveryRequest{
+		VersionInfo:   "",
+		Node:          &v3corepb.Node{Id: nodeID},
+		ResourceNames: []string{resourceName},
+		TypeUrl:       "type.googleapis.com/envoy.config.listener.v3.Listener",
+		ResponseNonce: "",
+	}
+	if diff := cmp.Diff(gotReq, wantReq, protocmp.Transform()); diff != "" {
+		t.Fatalf("Unexpected diff in received discovery request, diff (-got, +want):\n%s", diff)
+	}
+
+	// Verify that the received stream error is reported to the user.
+	var gotErr error
+	select {
+	case gotErr = <-streamErrCh:
+	case <-ctx.Done():
+		t.Fatalf("Timeout waiting for stream error to be reported to the user")
+	}
+	if !strings.Contains(gotErr.Error(), streamErr.Error()) {
+		t.Fatalf("Received stream error: %v, wantErr: %v", gotErr, streamErr)
+	}
+
+	// Verify that the stream is closed.
+	select {
+	case <-streamCloseCh:
+	case <-ctx.Done():
+		t.Fatalf("Timeout waiting for stream to be closed after an error")
+	}
+
+	// Verify that the transport backs off before recreating the stream.
+	select {
+	case <-backoffCh:
+	case <-ctx.Done():
+		t.Fatalf("Timeout waiting for transport to backoff after stream failure")
+	}
+
+	// Verify that the same discovery request is resent on the new stream.
+	select {
+	case gotReq = <-streamRequestCh:
+	case <-ctx.Done():
+		t.Fatalf("Timeout waiting for discovery request on the stream")
+	}
+	if diff := cmp.Diff(gotReq, wantReq, protocmp.Transform()); diff != "" {
+		t.Fatalf("Unexpected diff in received discovery request, diff (-got, +want):\n%s", diff)
+	}
+}
+
+// TestTransport_RetriesAfterBrokenStream tests the case where a stream breaks
+// because the server goes down. The test verifies the following:
+//  1. Initial discovery request matches expectation.
+//  2. Good response from the server leads to an ACK with appropriate version.
+//  3. Management server going down, leads to stream failure.
+//  4. Once the management server comes back up, the same resources are
+//     re-requested, this time with an empty nonce.
+func (s) TestTransport_RetriesAfterBrokenStream(t *testing.T) {
+	// Channels used for verifying different events in the test.
+	streamRequestCh := make(chan *v3discoverypb.DiscoveryRequest, 1)   // Discovery request is received.
+	streamResponseCh := make(chan *v3discoverypb.DiscoveryResponse, 1) // Discovery response is received.
+	streamErrCh := make(chan error, 1)                                 // Stream error seen by the transport.
+
+	// Create an xDS management server listening on a local port.
+	l, err := testutils.LocalTCPListener()
+	if err != nil {
+		t.Fatalf("Failed to create a local listener for the xDS management server: %v", err)
+	}
+	lis := testutils.NewRestartableListener(l)
+	mgmtServer, err := e2e.StartManagementServer(&e2e.ManagementServerOptions{
+		Listener: lis,
+		// Push the received request on to a channel for the test goroutine to
+		// verify that it matches expectations.
+		OnStreamRequest: func(_ int64, req *v3discoverypb.DiscoveryRequest) error {
+			select {
+			case streamRequestCh <- req:
+			default:
+			}
+			return nil
+		},
+		// Push the response that the management server is about to send on to a
+		// channel. The test goroutine to uses this to extract the version and
+		// nonce, expected on subsequent requests.
+		OnStreamResponse: func(_ context.Context, _ int64, _ *v3discoverypb.DiscoveryRequest, resp *v3discoverypb.DiscoveryResponse) {
+			select {
+			case streamResponseCh <- resp:
+			default:
+			}
+		},
+	})
+	if err != nil {
+		t.Fatalf("Failed to start xDS management server: %v", err)
+	}
+	defer mgmtServer.Stop()
+	t.Logf("Started xDS management server on %s", lis.Addr().String())
+
+	// Configure the management server with appropriate resources.
+	apiListener := &v3listenerpb.ApiListener{
+		ApiListener: func() *anypb.Any {
+			return testutils.MarshalAny(&v3httppb.HttpConnectionManager{
+				RouteSpecifier: &v3httppb.HttpConnectionManager_Rds{
+					Rds: &v3httppb.Rds{
+						ConfigSource: &v3corepb.ConfigSource{
+							ConfigSourceSpecifier: &v3corepb.ConfigSource_Ads{Ads: &v3corepb.AggregatedConfigSource{}},
+						},
+						RouteConfigName: "route-configuration-name",
+					},
+				},
+			})
+		}(),
+	}
+	const resourceName1 = "resource name 1"
+	const resourceName2 = "resource name 2"
+	listenerResource1 := &v3listenerpb.Listener{
+		Name:        resourceName1,
+		ApiListener: apiListener,
+	}
+	listenerResource2 := &v3listenerpb.Listener{
+		Name:        resourceName2,
+		ApiListener: apiListener,
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	nodeID := uuid.New().String()
+	mgmtServer.Update(ctx, e2e.UpdateOptions{
+		NodeID:         nodeID,
+		Listeners:      []*v3listenerpb.Listener{listenerResource1, listenerResource2},
+		SkipValidation: true,
+	})
+
+	// Construct the server config to represent the management server.
+	serverCfg := &bootstrap.ServerConfig{
+		ServerURI:    lis.Addr().String(),
+		Creds:        grpc.WithTransportCredentials(insecure.NewCredentials()),
+		CredsType:    "insecure",
+		TransportAPI: version.TransportV3,
+		NodeProto:    &v3corepb.Node{Id: nodeID},
+	}
+
+	// Create a new transport. Since we are only testing backoff behavior here,
+	// we can pass a no-op data model layer implementation.
+	tr, err := transport.New(&transport.Options{
+		ServerCfg:     serverCfg,
+		UpdateHandler: func(transport.ResourceUpdate) error { return nil }, // No data model layer validation.
+		StreamErrorHandler: func(err error) {
+			select {
+			case streamErrCh <- err:
+			default:
+			}
+		},
+		Backoff: func(int) time.Duration { return time.Duration(0) }, // No backoff.
+	})
+	if err != nil {
+		t.Fatalf("Failed to create xDS transport: %v", err)
+	}
+	defer tr.Close()
+
+	// Send a discovery request through the transport.
+	tr.SendRequest(version.V3ListenerURL, []string{resourceName1, resourceName2})
+
+	// Verify that the initial discovery request matches expectation.
+	var gotReq *v3discoverypb.DiscoveryRequest
+	select {
+	case gotReq = <-streamRequestCh:
+	case <-ctx.Done():
+		t.Fatalf("Timeout waiting for discovery request on the stream")
+	}
+	wantReq := &v3discoverypb.DiscoveryRequest{
+		VersionInfo:   "",
+		Node:          &v3corepb.Node{Id: nodeID},
+		ResourceNames: []string{resourceName1, resourceName2},
+		TypeUrl:       "type.googleapis.com/envoy.config.listener.v3.Listener",
+		ResponseNonce: "",
+	}
+	if diff := cmp.Diff(gotReq, wantReq, protocmp.Transform(), cmpopts.SortSlices(strSort)); diff != "" {
+		t.Fatalf("Unexpected diff in received discovery request, diff (-got, +want):\n%s", diff)
+	}
+
+	// Capture the version and nonce from the response.
+	var gotResp *v3discoverypb.DiscoveryResponse
+	select {
+	case gotResp = <-streamResponseCh:
+	case <-ctx.Done():
+		t.Fatalf("Timeout waiting for discovery response on the stream")
+	}
+	version := gotResp.GetVersionInfo()
+	nonce := gotResp.GetNonce()
+
+	// Verify that the ACK contains the appropriate version and nonce.
+	wantReq.VersionInfo = version
+	wantReq.ResponseNonce = nonce
+	select {
+	case gotReq = <-streamRequestCh:
+	case <-ctx.Done():
+		t.Fatalf("Timeout waiting for the discovery request ACK on the stream")
+	}
+	if diff := cmp.Diff(gotReq, wantReq, protocmp.Transform(), cmpopts.SortSlices(strSort)); diff != "" {
+		t.Fatalf("Unexpected diff in received discovery request, diff (-got, +want):\n%s", diff)
+	}
+
+	// Bring down the management server to simulate a broken stream.
+	lis.Stop()
+
+	// We don't care about the exact error here and it can vary based on which
+	// error gets reported first, the Recv() failure or the new stream creation
+	// failure. So, all we check here is whether we get an error or not.
+	select {
+	case <-streamErrCh:
+	case <-ctx.Done():
+		t.Fatalf("Timeout waiting for stream error to be reported to the user")
+	}
+
+	// Bring up the connection to the management server.
+	lis.Restart()
+
+	// Verify that the transport creates a new stream and sends out a new
+	// request which contains the previously acked version, but an empty nonce.
+	wantReq.ResponseNonce = ""
+	select {
+	case gotReq = <-streamRequestCh:
+	case <-ctx.Done():
+		t.Fatalf("Timeout waiting for the discovery request ACK on the stream")
+	}
+	if diff := cmp.Diff(gotReq, wantReq, protocmp.Transform(), cmpopts.SortSlices(strSort)); diff != "" {
+		t.Fatalf("Unexpected diff in received discovery request, diff (-got, +want):\n%s", diff)
+	}
+}
+
+// TestTransport_ResourceRequestedBeforeStreamCreation tests the case where a
+// resource is requested before the transport has a valid stream. Verifies that
+// the transport sends out the request once it has a valid stream.
+func (s) TestTransport_ResourceRequestedBeforeStreamCreation(t *testing.T) {
+	// Channels used for verifying different events in the test.
+	streamRequestCh := make(chan *v3discoverypb.DiscoveryRequest, 1) // Discovery request is received.
+
+	// Create an xDS management server listening on a local port.
+	l, err := testutils.LocalTCPListener()
+	if err != nil {
+		t.Fatalf("Failed to create a local listener for the xDS management server: %v", err)
+	}
+	lis := testutils.NewRestartableListener(l)
+	streamErr := errors.New("ADS stream error")
+
+	mgmtServer, err := e2e.StartManagementServer(&e2e.ManagementServerOptions{
+		Listener: lis,
+
+		// Return an error everytime a request is sent on the stream. This
+		// should cause the transport to backoff before attempting to recreate
+		// the stream.
+		OnStreamRequest: func(id int64, req *v3discoverypb.DiscoveryRequest) error {
+			select {
+			case streamRequestCh <- req:
+			default:
+			}
+			return streamErr
+		},
+	})
+	if err != nil {
+		t.Fatalf("Failed to start xDS management server: %v", err)
+	}
+	defer mgmtServer.Stop()
+	t.Logf("Started xDS management server on %s", lis.Addr().String())
+
+	// Bring down the management server before creating the transport. This
+	// allows us to test the case where SendRequest() is called when there is no
+	// stream to the management server.
+	lis.Stop()
+
+	// Construct the server config to represent the management server.
+	nodeID := uuid.New().String()
+	serverCfg := &bootstrap.ServerConfig{
+		ServerURI:    lis.Addr().String(),
+		Creds:        grpc.WithTransportCredentials(insecure.NewCredentials()),
+		CredsType:    "insecure",
+		TransportAPI: version.TransportV3,
+		NodeProto:    &v3corepb.Node{Id: nodeID},
+	}
+
+	// Create a new transport. Since we are only testing backoff behavior here,
+	// we can pass a no-op data model layer implementation.
+	tr, err := transport.New(&transport.Options{
+		ServerCfg:          serverCfg,
+		UpdateHandler:      func(transport.ResourceUpdate) error { return nil }, // No data model layer validation.
+		StreamErrorHandler: func(error) {},                                      // No stream error handling.
+		Backoff:            func(int) time.Duration { return time.Duration(0) }, // No backoff.
+	})
+	if err != nil {
+		t.Fatalf("Failed to create xDS transport: %v", err)
+	}
+	defer tr.Close()
+
+	// Send a discovery request through the transport.
+	const resourceName = "resource name"
+	tr.SendRequest(version.V3ListenerURL, []string{resourceName})
+
+	// Wait until the transport has attempted to connect to the management
+	// server and has seen the connection fail. In this case, since the
+	// connection is down, and the transport creates streams with WaitForReady()
+	// set to true, stream creation will never fail (unless the context
+	// expires), and therefore we cannot rely on the stream error handler.
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	for ; ctx.Err() == nil; <-time.After(defaultTestShortTimeout) {
+		if tr.ChannelConnectivityStateForTesting() == connectivity.TransientFailure {
+			break
+		}
+	}
+
+	lis.Restart()
+
+	// Verify that the initial discovery request matches expectation.
+	var gotReq *v3discoverypb.DiscoveryRequest
+	select {
+	case gotReq = <-streamRequestCh:
+	case <-ctx.Done():
+		t.Fatalf("Timeout waiting for discovery request on the stream")
+	}
+	wantReq := &v3discoverypb.DiscoveryRequest{
+		VersionInfo:   "",
+		Node:          &v3corepb.Node{Id: nodeID},
+		ResourceNames: []string{resourceName},
+		TypeUrl:       "type.googleapis.com/envoy.config.listener.v3.Listener",
+		ResponseNonce: "",
+	}
+	if diff := cmp.Diff(gotReq, wantReq, protocmp.Transform()); diff != "" {
+		t.Fatalf("Unexpected diff in received discovery request, diff (-got, +want):\n%s", diff)
+	}
+}

--- a/xds/internal/xdsclient/transport/transport_new_test.go
+++ b/xds/internal/xdsclient/transport/transport_new_test.go
@@ -1,0 +1,136 @@
+/*
+ *
+ * Copyright 2022 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package transport_test
+
+import (
+	"strings"
+	"testing"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/xds/internal/xdsclient/bootstrap"
+	"google.golang.org/grpc/xds/internal/xdsclient/transport"
+	"google.golang.org/grpc/xds/internal/xdsclient/xdsresource/version"
+
+	v2corepb "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	v3corepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+)
+
+// TestNew covers that New() returns an error if the input *ServerConfig
+// contains invalid content.
+func (s) TestNew(t *testing.T) {
+	tests := []struct {
+		name       string
+		opts       *transport.Options
+		wantErrStr string
+	}{
+		{
+			name:       "nil options",
+			opts:       nil,
+			wantErrStr: "missing options when creating a new transport",
+		},
+		{
+			name:       "missing server config",
+			opts:       &transport.Options{},
+			wantErrStr: "missing ServerConfig when creating a new transport",
+		},
+		{
+			name:       "missing server URI",
+			opts:       &transport.Options{ServerCfg: &bootstrap.ServerConfig{}},
+			wantErrStr: "missing server URI when creating a new transport",
+		},
+		{
+			name:       "missing credentials",
+			opts:       &transport.Options{ServerCfg: &bootstrap.ServerConfig{ServerURI: "server-address"}},
+			wantErrStr: "missing credentials when creating a new transport",
+		},
+		{
+			name: "missing node proto",
+			opts: &transport.Options{ServerCfg: &bootstrap.ServerConfig{
+				ServerURI: "server-address",
+				Creds:     grpc.WithTransportCredentials(insecure.NewCredentials()),
+			}},
+			wantErrStr: "missing node proto when creating a new transport",
+		},
+		{
+			name: "missing update handler",
+			opts: &transport.Options{ServerCfg: &bootstrap.ServerConfig{
+				ServerURI: "server-address",
+				Creds:     grpc.WithTransportCredentials(insecure.NewCredentials()),
+				NodeProto: &v3corepb.Node{},
+			}},
+			wantErrStr: "missing update handler when creating a new transport",
+		},
+		{
+			name: "missing stream error handler",
+			opts: &transport.Options{
+				ServerCfg: &bootstrap.ServerConfig{
+					ServerURI: "server-address",
+					Creds:     grpc.WithTransportCredentials(insecure.NewCredentials()),
+					NodeProto: &v3corepb.Node{},
+				},
+				UpdateHandler: func(transport.ResourceUpdate) error { return nil },
+			},
+			wantErrStr: "missing stream error handler when creating a new transport",
+		},
+		{
+			name: "node proto version mismatch for v3",
+			opts: &transport.Options{
+				ServerCfg: &bootstrap.ServerConfig{
+					ServerURI:    "server-address",
+					Creds:        grpc.WithTransportCredentials(insecure.NewCredentials()),
+					NodeProto:    &v2corepb.Node{},
+					TransportAPI: version.TransportV3,
+				},
+				UpdateHandler:      func(transport.ResourceUpdate) error { return nil },
+				StreamErrorHandler: func(error) {},
+			},
+			wantErrStr: "unexpected type *core.Node for NodeProto, want *corev3.Node",
+		},
+		{
+			name: "happy case",
+			opts: &transport.Options{
+				ServerCfg: &bootstrap.ServerConfig{
+					ServerURI:    "server-address",
+					Creds:        grpc.WithTransportCredentials(insecure.NewCredentials()),
+					NodeProto:    &v3corepb.Node{},
+					TransportAPI: version.TransportV3,
+				},
+				UpdateHandler:      func(transport.ResourceUpdate) error { return nil },
+				StreamErrorHandler: func(error) {},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c, err := transport.New(test.opts)
+			defer func() {
+				if c != nil {
+					c.Close()
+				}
+			}()
+			if (err != nil) != (test.wantErrStr != "") {
+				t.Fatalf("New(%+v) = %v, wantErr: %v", test.opts, err, test.wantErrStr)
+			}
+			if err != nil && !strings.Contains(err.Error(), test.wantErrStr) {
+				t.Fatalf("New(%+v) = %v, wantErr: %v", test.opts, err, test.wantErrStr)
+			}
+		})
+	}
+}

--- a/xds/internal/xdsclient/transport/transport_new_test.go
+++ b/xds/internal/xdsclient/transport/transport_new_test.go
@@ -36,40 +36,22 @@ import (
 func (s) TestNew(t *testing.T) {
 	tests := []struct {
 		name       string
-		opts       *transport.Options
+		opts       transport.Options
 		wantErrStr string
 	}{
 		{
-			name:       "nil options",
-			opts:       nil,
-			wantErrStr: "missing options when creating a new transport",
-		},
-		{
-			name:       "missing server config",
-			opts:       &transport.Options{},
-			wantErrStr: "missing ServerConfig when creating a new transport",
-		},
-		{
 			name:       "missing server URI",
-			opts:       &transport.Options{ServerCfg: &bootstrap.ServerConfig{}},
+			opts:       transport.Options{ServerCfg: bootstrap.ServerConfig{}},
 			wantErrStr: "missing server URI when creating a new transport",
 		},
 		{
 			name:       "missing credentials",
-			opts:       &transport.Options{ServerCfg: &bootstrap.ServerConfig{ServerURI: "server-address"}},
+			opts:       transport.Options{ServerCfg: bootstrap.ServerConfig{ServerURI: "server-address"}},
 			wantErrStr: "missing credentials when creating a new transport",
 		},
 		{
-			name: "missing node proto",
-			opts: &transport.Options{ServerCfg: &bootstrap.ServerConfig{
-				ServerURI: "server-address",
-				Creds:     grpc.WithTransportCredentials(insecure.NewCredentials()),
-			}},
-			wantErrStr: "missing node proto when creating a new transport",
-		},
-		{
 			name: "missing update handler",
-			opts: &transport.Options{ServerCfg: &bootstrap.ServerConfig{
+			opts: transport.Options{ServerCfg: bootstrap.ServerConfig{
 				ServerURI: "server-address",
 				Creds:     grpc.WithTransportCredentials(insecure.NewCredentials()),
 				NodeProto: &v3corepb.Node{},
@@ -78,8 +60,8 @@ func (s) TestNew(t *testing.T) {
 		},
 		{
 			name: "missing stream error handler",
-			opts: &transport.Options{
-				ServerCfg: &bootstrap.ServerConfig{
+			opts: transport.Options{
+				ServerCfg: bootstrap.ServerConfig{
 					ServerURI: "server-address",
 					Creds:     grpc.WithTransportCredentials(insecure.NewCredentials()),
 					NodeProto: &v3corepb.Node{},
@@ -90,8 +72,8 @@ func (s) TestNew(t *testing.T) {
 		},
 		{
 			name: "node proto version mismatch for v3",
-			opts: &transport.Options{
-				ServerCfg: &bootstrap.ServerConfig{
+			opts: transport.Options{
+				ServerCfg: bootstrap.ServerConfig{
 					ServerURI:    "server-address",
 					Creds:        grpc.WithTransportCredentials(insecure.NewCredentials()),
 					NodeProto:    &v2corepb.Node{},
@@ -104,8 +86,8 @@ func (s) TestNew(t *testing.T) {
 		},
 		{
 			name: "happy case",
-			opts: &transport.Options{
-				ServerCfg: &bootstrap.ServerConfig{
+			opts: transport.Options{
+				ServerCfg: bootstrap.ServerConfig{
 					ServerURI:    "server-address",
 					Creds:        grpc.WithTransportCredentials(insecure.NewCredentials()),
 					NodeProto:    &v3corepb.Node{},

--- a/xds/internal/xdsclient/transport/transport_resource_test.go
+++ b/xds/internal/xdsclient/transport/transport_resource_test.go
@@ -177,7 +177,7 @@ func (s) TestHandleResponseFromManagementServer(t *testing.T) {
 			mgmtServer.XDSResponseChan <- &fakeserver.Response{Resp: test.managementServerResponse}
 
 			// Construct the server config to represent the management server.
-			serverCfg := &bootstrap.ServerConfig{
+			serverCfg := bootstrap.ServerConfig{
 				ServerURI:    mgmtServer.Address,
 				Creds:        grpc.WithTransportCredentials(insecure.NewCredentials()),
 				CredsType:    "insecure",
@@ -187,7 +187,7 @@ func (s) TestHandleResponseFromManagementServer(t *testing.T) {
 
 			// Create a new transport.
 			resourcesCh := testutils.NewChannel()
-			tr, err := transport.New(&transport.Options{
+			tr, err := transport.New(transport.Options{
 				ServerCfg: serverCfg,
 				// No validation. Simply push received resources on a channel.
 				UpdateHandler: func(update transport.ResourceUpdate) error {

--- a/xds/internal/xdsclient/transport/transport_resource_test.go
+++ b/xds/internal/xdsclient/transport/transport_resource_test.go
@@ -1,0 +1,228 @@
+/*
+ *
+ * Copyright 2022 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package transport_test contains e2e style tests for the xDS transport
+// implementation. It uses the envoy-go-control-plane as the management server.
+package transport_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/uuid"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/internal/grpctest"
+	"google.golang.org/grpc/internal/testutils"
+	"google.golang.org/grpc/xds/internal/testutils/fakeserver"
+	"google.golang.org/grpc/xds/internal/xdsclient/bootstrap"
+	"google.golang.org/grpc/xds/internal/xdsclient/transport"
+	"google.golang.org/grpc/xds/internal/xdsclient/xdsresource/version"
+	"google.golang.org/protobuf/testing/protocmp"
+	"google.golang.org/protobuf/types/known/anypb"
+
+	v3corepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	v3listenerpb "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	v3httppb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+	v3discoverypb "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+)
+
+type s struct {
+	grpctest.Tester
+}
+
+func Test(t *testing.T) {
+	grpctest.RunSubTests(t, s{})
+}
+
+const (
+	defaultTestTimeout      = 5 * time.Second
+	defaultTestShortTimeout = 10 * time.Millisecond
+)
+
+// startFakeManagementServer starts a fake xDS management server and returns a
+// cleanup function to close the fake server.
+func startFakeManagementServer(t *testing.T) (*fakeserver.Server, func()) {
+	t.Helper()
+	fs, sCleanup, err := fakeserver.StartServer()
+	if err != nil {
+		t.Fatalf("Failed to start fake xDS server: %v", err)
+	}
+	return fs, sCleanup
+}
+
+// resourcesWithTypeURL wraps resources and type URL received from server.
+type resourcesWithTypeURL struct {
+	resources []*anypb.Any
+	url       string
+}
+
+// TestHandleResponseFromManagementServer covers different scenarios of the
+// transport receiving a response from the management server. In all scenarios,
+// the trasport is expected to pass the received responses as-is to the data
+// model layer for validation and not perform any validation on its own.
+func (s) TestHandleResponseFromManagementServer(t *testing.T) {
+	const (
+		resourceName1 = "resource-name-1"
+		resourceName2 = "resource-name-2"
+	)
+	var (
+		badlyMarshaledResource = &anypb.Any{
+			TypeUrl: "type.googleapis.com/envoy.config.listener.v3.Listener",
+			Value:   []byte{1, 2, 3, 4},
+		}
+		apiListener = &v3listenerpb.ApiListener{
+			ApiListener: func() *anypb.Any {
+				return testutils.MarshalAny(&v3httppb.HttpConnectionManager{
+					RouteSpecifier: &v3httppb.HttpConnectionManager_Rds{
+						Rds: &v3httppb.Rds{
+							ConfigSource: &v3corepb.ConfigSource{
+								ConfigSourceSpecifier: &v3corepb.ConfigSource_Ads{Ads: &v3corepb.AggregatedConfigSource{}},
+							},
+							RouteConfigName: "route-configuration-name",
+						},
+					},
+				})
+			}(),
+		}
+		resource1 = &v3listenerpb.Listener{
+			Name:        resourceName1,
+			ApiListener: apiListener,
+		}
+		resource2 = &v3listenerpb.Listener{
+			Name:        resourceName2,
+			ApiListener: apiListener,
+		}
+	)
+
+	tests := []struct {
+		desc                     string
+		resourceNamesToRequest   []string
+		managementServerResponse *v3discoverypb.DiscoveryResponse
+		wantURL                  string
+		wantResources            []*anypb.Any
+	}{
+		{
+			desc:                   "badly marshaled response",
+			resourceNamesToRequest: []string{resourceName1},
+			managementServerResponse: &v3discoverypb.DiscoveryResponse{
+				TypeUrl:   "type.googleapis.com/envoy.config.listener.v3.Listener",
+				Resources: []*anypb.Any{badlyMarshaledResource},
+			},
+			wantURL:       "type.googleapis.com/envoy.config.listener.v3.Listener",
+			wantResources: []*anypb.Any{badlyMarshaledResource},
+		},
+		{
+			desc:                     "empty response",
+			resourceNamesToRequest:   []string{resourceName1},
+			managementServerResponse: &v3discoverypb.DiscoveryResponse{},
+			wantURL:                  "",
+			wantResources:            nil,
+		},
+		{
+			desc:                   "one good resource",
+			resourceNamesToRequest: []string{resourceName1},
+			managementServerResponse: &v3discoverypb.DiscoveryResponse{
+				TypeUrl:   "type.googleapis.com/envoy.config.listener.v3.Listener",
+				Resources: []*anypb.Any{testutils.MarshalAny(resource1)},
+			},
+			wantURL:       "type.googleapis.com/envoy.config.listener.v3.Listener",
+			wantResources: []*anypb.Any{testutils.MarshalAny(resource1)},
+		},
+		{
+			desc:                   "two good resources",
+			resourceNamesToRequest: []string{resourceName1, resourceName2},
+			managementServerResponse: &v3discoverypb.DiscoveryResponse{
+				TypeUrl:   "type.googleapis.com/envoy.config.listener.v3.Listener",
+				Resources: []*anypb.Any{testutils.MarshalAny(resource1), testutils.MarshalAny(resource2)},
+			},
+			wantURL:       "type.googleapis.com/envoy.config.listener.v3.Listener",
+			wantResources: []*anypb.Any{testutils.MarshalAny(resource1), testutils.MarshalAny(resource2)},
+		},
+		{
+			desc:                   "two resources when we requested one",
+			resourceNamesToRequest: []string{resourceName1},
+			managementServerResponse: &v3discoverypb.DiscoveryResponse{
+				TypeUrl:   "type.googleapis.com/envoy.config.listener.v3.Listener",
+				Resources: []*anypb.Any{testutils.MarshalAny(resource1), testutils.MarshalAny(resource2)},
+			},
+			wantURL:       "type.googleapis.com/envoy.config.listener.v3.Listener",
+			wantResources: []*anypb.Any{testutils.MarshalAny(resource1), testutils.MarshalAny(resource2)},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			// Create a fake xDS management server listening on a local port,
+			// and set it up with the response to send.
+			mgmtServer, cleanup := startFakeManagementServer(t)
+			defer cleanup()
+			t.Logf("Started xDS management server on %s", mgmtServer.Address)
+			mgmtServer.XDSResponseChan <- &fakeserver.Response{Resp: test.managementServerResponse}
+
+			// Construct the server config to represent the management server.
+			serverCfg := &bootstrap.ServerConfig{
+				ServerURI:    mgmtServer.Address,
+				Creds:        grpc.WithTransportCredentials(insecure.NewCredentials()),
+				CredsType:    "insecure",
+				TransportAPI: version.TransportV3,
+				NodeProto:    &v3corepb.Node{Id: uuid.New().String()},
+			}
+
+			// Create a new transport.
+			resourcesCh := testutils.NewChannel()
+			tr, err := transport.New(&transport.Options{
+				ServerCfg: serverCfg,
+				// No validation. Simply push received resources on a channel.
+				UpdateHandler: func(update transport.ResourceUpdate) error {
+					resourcesCh.Send(&resourcesWithTypeURL{
+						resources: update.Resources,
+						url:       update.URL,
+						// Ignore resource version here.
+					})
+					return nil
+				},
+				StreamErrorHandler: func(error) {},                                      // No stream error handling.
+				Backoff:            func(int) time.Duration { return time.Duration(0) }, // No backoff.
+			})
+			if err != nil {
+				t.Fatalf("Failed to create xDS transport: %v", err)
+			}
+			defer tr.Close()
+
+			// Send the request, and validate that the response sent by the
+			// management server is propagated to the data model layer.
+			tr.SendRequest(version.V3ListenerURL, test.resourceNamesToRequest)
+			ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+			defer cancel()
+			v, err := resourcesCh.Receive(ctx)
+			if err != nil {
+				t.Fatalf("Failed to receive resources at the data model layer: %v", err)
+			}
+			gotURL := v.(*resourcesWithTypeURL).url
+			gotResources := v.(*resourcesWithTypeURL).resources
+			if gotURL != test.wantURL {
+				t.Fatalf("Received resource URL in response: %s, want %s", gotURL, test.wantURL)
+			}
+			if diff := cmp.Diff(gotResources, test.wantResources, protocmp.Transform()); diff != "" {
+				t.Fatalf("Received unexpected resources. Diff (-got, +want):\n%s", diff)
+			}
+		})
+	}
+}

--- a/xds/internal/xdsclient/transport/transport_test.go
+++ b/xds/internal/xdsclient/transport/transport_test.go
@@ -48,8 +48,8 @@ func (s) TestNewWithGRPCDial(t *testing.T) {
 	defer func() { grpcDial = oldDial }()
 
 	// Create a new transport and ensure that the custom dialer was called.
-	opts := &Options{
-		ServerCfg: &bootstrap.ServerConfig{
+	opts := Options{
+		ServerCfg: bootstrap.ServerConfig{
 			ServerURI:    "server-address",
 			Creds:        grpc.WithTransportCredentials(insecure.NewCredentials()),
 			NodeProto:    &v3corepb.Node{},

--- a/xds/internal/xdsclient/transport/transport_test.go
+++ b/xds/internal/xdsclient/transport/transport_test.go
@@ -1,0 +1,88 @@
+/*
+ *
+ * Copyright 2022 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package transport
+
+import (
+	"testing"
+
+	v3corepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/internal/grpctest"
+	"google.golang.org/grpc/xds/internal/xdsclient/bootstrap"
+	"google.golang.org/grpc/xds/internal/xdsclient/xdsresource/version"
+)
+
+type s struct {
+	grpctest.Tester
+}
+
+func Test(t *testing.T) {
+	grpctest.RunSubTests(t, s{})
+}
+
+func (s) TestNewWithGRPCDial(t *testing.T) {
+	// Override the dialer with a custom one.
+	customDialerCalled := false
+	customDialer := func(target string, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
+		customDialerCalled = true
+		return grpc.Dial(target, opts...)
+	}
+	oldDial := grpcDial
+	grpcDial = customDialer
+	defer func() { grpcDial = oldDial }()
+
+	// Create a new transport and ensure that the custom dialer was called.
+	opts := &Options{
+		ServerCfg: &bootstrap.ServerConfig{
+			ServerURI:    "server-address",
+			Creds:        grpc.WithTransportCredentials(insecure.NewCredentials()),
+			NodeProto:    &v3corepb.Node{},
+			TransportAPI: version.TransportV3,
+		},
+		UpdateHandler:      func(ResourceUpdate) error { return nil },
+		StreamErrorHandler: func(error) {},
+	}
+	c, err := New(opts)
+	if err != nil {
+		t.Fatalf("New(%v) failed: %v", opts, err)
+	}
+	defer c.Close()
+
+	if !customDialerCalled {
+		t.Fatalf("New(%+v) custom dialer called = false, want true", opts)
+	}
+	customDialerCalled = false
+
+	// Reset the dialer, create a new transport and ensure that our custom
+	// dialer is no longer called.
+	grpcDial = grpc.Dial
+	c, err = New(opts)
+	defer func() {
+		if c != nil {
+			c.Close()
+		}
+	}()
+	if err != nil {
+		t.Fatalf("New(%v) failed: %v", opts, err)
+	}
+
+	if customDialerCalled {
+		t.Fatalf("New(%+v) custom dialer called = true, want false", opts)
+	}
+}

--- a/xds/internal/xdsclient/xdsresource/errors.go
+++ b/xds/internal/xdsclient/xdsresource/errors.go
@@ -34,9 +34,9 @@ const (
 	// response. It's typically returned if the resource is removed in the xds
 	// server.
 	ErrorTypeResourceNotFound
-	// ErrTypeResourceTypeUnsupported indicates is an error used to indicate an unsupported xDS
-	// resource type. The wrapped ErrStr contains the details.
-	ErrTypeResourceTypeUnsupported
+	// ErrorTypeResourceTypeUnsupported indicates the receipt of a message from
+	// the management server with resources of an unsupported resource type.
+	ErrorTypeResourceTypeUnsupported
 )
 
 type xdsClientError struct {
@@ -60,15 +60,4 @@ func ErrType(e error) ErrorType {
 		return xe.t
 	}
 	return ErrorTypeUnknown
-}
-
-// ErrResourceTypeUnsupported is an error used to indicate an unsupported xDS
-// resource type. The wrapped ErrStr contains the details.
-type ErrResourceTypeUnsupported struct {
-	ErrStr string
-}
-
-// Error helps implements the error interface.
-func (e ErrResourceTypeUnsupported) Error() string {
-	return e.ErrStr
 }

--- a/xds/internal/xdsclient/xdsresource/errors.go
+++ b/xds/internal/xdsclient/xdsresource/errors.go
@@ -34,6 +34,9 @@ const (
 	// response. It's typically returned if the resource is removed in the xds
 	// server.
 	ErrorTypeResourceNotFound
+	// ErrTypeResourceTypeUnsupported indicates is an error used to indicate an unsupported xDS
+	// resource type. The wrapped ErrStr contains the details.
+	ErrTypeResourceTypeUnsupported
 )
 
 type xdsClientError struct {

--- a/xds/internal/xdsclient/xdsresource/errors.go
+++ b/xds/internal/xdsclient/xdsresource/errors.go
@@ -58,3 +58,14 @@ func ErrType(e error) ErrorType {
 	}
 	return ErrorTypeUnknown
 }
+
+// ErrResourceTypeUnsupported is an error used to indicate an unsupported xDS
+// resource type. The wrapped ErrStr contains the details.
+type ErrResourceTypeUnsupported struct {
+	ErrStr string
+}
+
+// Error helps implements the error interface.
+func (e ErrResourceTypeUnsupported) Error() string {
+	return e.ErrStr
+}


### PR DESCRIPTION
This PR is a full-fledged refactor of the transport layer implementation of the xdsclient. It does not touch the existing implementation, and therefore existing implementation will be used until subsequent refactors which will involve the authority/controller/pubsub components.

Summary of changes:
- New transport implementation in `xds/internal/xdsclient/transport` which supports only xDS v3 transport protocol. We are getting rid of v2 support. So, it does not make sense to add v2 support here. 
  - Existing implementation is found in `xds/internal/xdsclient/controller/`.
- New implementation strictly deals only with transport protocol functionality.
  - It exposes an API to send requests for xDS resources. Existing implementation exposes a watch style API. A watch should be a higher layer abstraction and not a transport layer one.
  - The API to send requests needs to contain all the resources to be requested. Transport layer still needs to keep track of the resources being requested because it needs to re-request them upon stream failure.
  - Load reporting API is changed to not accept a server parameter. This is as per federation design. Each transport instance is supposed to talk to *one* management server for both ADS and LRS.
- New Transport API has the following key details
  - Accepts a function to report received resources. This function will be implemented by the data model layer to validate the received resources. The `authority` layer will also keep track of what resources it requested and will cache the received resources.
  - Accepts a function to report stream failures. This is used to propagate stream failures up to the resource watchers at the `authority` layer.
- Tests are in the same directory but in a different package, to ensure that they rely only on functionality and not internal details/state.

This refactor ensures that the transport layer has the following properties:
- Has very few dependencies on other parts of the xdsClient.
- Does not look into the resources. That will be the duty of the data model layer.

#resource-agnostic-xdsclient-api

RELEASE NOTES: none