### PR TITLE
xDS: Deflake Outlier Detection xDS e2e test

### DIFF
--- a/test/xds/xds_client_outlier_detection_test.go
+++ b/test/xds/xds_client_outlier_detection_test.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 	"testing"
 	"time"
 
@@ -30,10 +29,13 @@ import (
 	v3endpointpb "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 	v3listenerpb "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	v3routepb "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	"github.com/google/go-cmp/cmp"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/internal/stubserver"
 	"google.golang.org/grpc/internal/testutils/xds/e2e"
+	"google.golang.org/grpc/peer"
+	"google.golang.org/grpc/resolver"
 	testgrpc "google.golang.org/grpc/test/grpc_testing"
 	testpb "google.golang.org/grpc/test/grpc_testing"
 	"google.golang.org/protobuf/types/known/durationpb"
@@ -107,52 +109,91 @@ func clusterWithOutlierDetection(clusterName, edsServiceName string, secLevel e2
 		MaxEjectionPercent:             &wrapperspb.UInt32Value{Value: 1},
 		FailurePercentageThreshold:     &wrapperspb.UInt32Value{Value: 50},
 		EnforcingFailurePercentage:     &wrapperspb.UInt32Value{Value: 100},
-		FailurePercentageRequestVolume: &wrapperspb.UInt32Value{Value: 1},
-		FailurePercentageMinimumHosts:  &wrapperspb.UInt32Value{Value: 1},
+		FailurePercentageRequestVolume: &wrapperspb.UInt32Value{Value: 8},
+		FailurePercentageMinimumHosts:  &wrapperspb.UInt32Value{Value: 3},
 	}
 	return cluster
+}
+
+// checkRoundRobinRPCs verifies that EmptyCall RPCs on the given ClientConn,
+// connected to a server exposing the test.grpc_testing.TestService, are
+// roundrobined across the given backend addresses.
+//
+// Returns a non-nil error if context deadline expires before RPCs start to get
+// roundrobined across the given backends.
+func checkRoundRobinRPCs(ctx context.Context, client testpb.TestServiceClient, addrs []resolver.Address) error {
+	wantAddrCount := make(map[string]int)
+	for _, addr := range addrs {
+		wantAddrCount[addr.Addr]++
+	}
+	for ; ctx.Err() == nil; <-time.After(time.Millisecond) {
+		// Perform 3 iterations.
+		var iterations [][]string
+		for i := 0; i < 3; i++ {
+			iteration := make([]string, len(addrs))
+			for c := 0; c < len(addrs); c++ {
+				var peer peer.Peer
+				client.EmptyCall(ctx, &testpb.Empty{}, grpc.Peer(&peer))
+				if peer.Addr != nil {
+					iteration[c] = peer.Addr.String()
+				}
+			}
+			iterations = append(iterations, iteration)
+		}
+		// Ensure the the first iteration contains all addresses in addrs.
+		gotAddrCount := make(map[string]int)
+		for _, addr := range iterations[0] {
+			gotAddrCount[addr]++
+		}
+		if diff := cmp.Diff(gotAddrCount, wantAddrCount); diff != "" {
+			continue
+		}
+		// Ensure all three iterations contain the same addresses.
+		if !cmp.Equal(iterations[0], iterations[1]) || !cmp.Equal(iterations[0], iterations[2]) {
+			continue
+		}
+		return nil
+	}
+	return fmt.Errorf("timeout when waiting for roundrobin distribution of RPCs across addresses: %v", addrs)
 }
 
 // TestOutlierDetectionWithOutlier tests the Outlier Detection Balancer e2e. It
 // spins up three backends, one which consistently errors, and configures the
 // ClientConn using xDS to connect to all three of those backends. The Outlier
 // Detection Balancer should eject the connection to the backend which
-// constantly errors, and thus RPC's should mainly go to backend 1 and 2.
+// constantly errors, causing RPC's to not be routed to that upstream, and only
+// be Round Robined across the two healthy upstreams. Other than the intervals
+// the unhealthy upstream is ejected, RPC's should regularly round robin across
+// all three upstreams.
 func (s) TestOutlierDetectionWithOutlier(t *testing.T) {
-	managementServer, nodeID, _, resolver, cleanup := e2e.SetupManagementServer(t, nil)
+	managementServer, nodeID, _, r, cleanup := e2e.SetupManagementServer(t, nil)
 	defer cleanup()
 
-	// Counters for how many times backends got called.
-	var count1, count2, count3 int
-
 	// Working backend 1.
-	port1, cleanup1 := startTestService(t, &stubserver.StubServer{
-		EmptyCallF: func(context.Context, *testpb.Empty) (*testpb.Empty, error) {
-			count1++
+	backend1 := &stubserver.StubServer{
+		EmptyCallF: func(ctx context.Context, in *testpb.Empty) (*testpb.Empty, error) {
 			return &testpb.Empty{}, nil
 		},
-		Address: "localhost:0",
-	})
+	}
+	port1, cleanup1 := startTestService(t, backend1)
 	defer cleanup1()
 
 	// Working backend 2.
-	port2, cleanup2 := startTestService(t, &stubserver.StubServer{
-		EmptyCallF: func(context.Context, *testpb.Empty) (*testpb.Empty, error) {
-			count2++
+	backend2 := &stubserver.StubServer{
+		EmptyCallF: func(ctx context.Context, in *testpb.Empty) (*testpb.Empty, error) {
 			return &testpb.Empty{}, nil
 		},
-		Address: "localhost:0",
-	})
+	}
+	port2, cleanup2 := startTestService(t, backend2)
 	defer cleanup2()
 
 	// Backend 3 that will always return an error and eventually ejected.
-	port3, cleanup3 := startTestService(t, &stubserver.StubServer{
-		EmptyCallF: func(context.Context, *testpb.Empty) (*testpb.Empty, error) {
-			count3++
+	backend3 := &stubserver.StubServer{
+		EmptyCallF: func(ctx context.Context, in *testpb.Empty) (*testpb.Empty, error) {
 			return nil, errors.New("some error")
 		},
-		Address: "localhost:0",
-	})
+	}
+	port3, cleanup3 := startTestService(t, backend3)
 	defer cleanup3()
 
 	const serviceName = "my-service-client-side-xds"
@@ -168,34 +209,35 @@ func (s) TestOutlierDetectionWithOutlier(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cc, err := grpc.Dial(fmt.Sprintf("xds:///%s", serviceName), grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithResolvers(resolver))
+	cc, err := grpc.Dial(fmt.Sprintf("xds:///%s", serviceName), grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithResolvers(r))
 	if err != nil {
 		t.Fatalf("failed to dial local test server: %v", err)
 	}
 	defer cc.Close()
 
 	client := testgrpc.NewTestServiceClient(cc)
-	for i := 0; i < 2000; i++ {
-		// Can either error or not depending on the backend called.
-		if _, err := client.EmptyCall(ctx, &testpb.Empty{}, grpc.WaitForReady(true)); err != nil && !strings.Contains(err.Error(), "some error") {
-			t.Fatalf("rpc EmptyCall() failed: %v", err)
-		}
-		time.Sleep(time.Millisecond)
+
+	fullAddresses := []resolver.Address{
+		{Addr: backend1.Address},
+		{Addr: backend2.Address},
+		{Addr: backend3.Address},
+	}
+	// At first, due to no statistics on each of the backends, the 3
+	// upstreams should all be round robined across.
+	if err = checkRoundRobinRPCs(ctx, client, fullAddresses); err != nil {
+		t.Fatalf("error in expected round robin: %v", err)
 	}
 
-	// Backend 1 should've gotten more than 1/3rd of the load as backend 3
-	// should get ejected, leaving only 1 and 2.
-	if count1 < 700 {
-		t.Fatalf("backend 1 should've gotten more than 1/3rd of the load")
+	// The addresses which don't return errors.
+	okAddresses := []resolver.Address{
+		{Addr: backend1.Address},
+		{Addr: backend2.Address},
 	}
-	// Backend 2 should've gotten more than 1/3rd of the load as backend 3
-	// should get ejected, leaving only 1 and 2.
-	if count2 < 700 {
-		t.Fatalf("backend 2 should've gotten more than 1/3rd of the load")
-	}
-	// Backend 3 should've gotten less than 1/3rd of the load since it gets
-	// ejected.
-	if count3 > 650 {
-		t.Fatalf("backend 1 should've gotten more than 1/3rd of the load")
+	// After calling the three upstreams, one of them constantly error
+	// and should eventually be ejected for a period of time. This
+	// period of time should cause the RPC's to be round robined only
+	// across the two that are healthy.
+	if err = checkRoundRobinRPCs(ctx, client, okAddresses); err != nil {
+		t.Fatalf("error in expected round robin: %v", err)
 	}
 }

--- a/xds/internal/balancer/outlierdetection/e2e_test/outlierdetection_test.go
+++ b/xds/internal/balancer/outlierdetection/e2e_test/outlierdetection_test.go
@@ -140,9 +140,9 @@ func checkRoundRobinRPCs(ctx context.Context, client testpb.TestServiceClient, a
 // Balancer is configured as the top level LB Policy of the channel with a Round
 // Robin child, and connects to three upstreams. Two of the upstreams are healthy and
 // one is unhealthy. The two algorithms should at some point eject the failing
-// upstream, causing RPC's to not be routed to those two upstreams, and only be
+// upstream, causing RPC's to not be routed to that upstream, and only be
 // Round Robined across the two healthy upstreams. Other than the intervals the
-// two unhealthy upstreams are ejected, RPC's should regularly round robin
+// unhealthy upstream is ejected, RPC's should regularly round robin
 // across all three upstreams.
 func (s) TestOutlierDetectionAlgorithmsE2E(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
Fixes #5709. The test was flaking due to time.Sleep(ms), which wasn't really guaranteed to be exactly 1ms on certain systems. This would cause the test to timeout due to numerous time.Sleep(ms) calls exceeding the context deadline. I rewrote the test to verify expected Round Robin distribution instead for the verification step of the ejection, which simply expects calls to be routed across all upstreams and then eventually only round robined to the healthy upstreams.

Doesn't flake on google3/100k runs.

RELEASE NOTES: N/A