### PR TITLE
transport/server: flush GOAWAY before closing conn due to max age

### DIFF
--- a/internal/transport/controlbuf.go
+++ b/internal/transport/controlbuf.go
@@ -209,6 +209,10 @@ type outFlowControlSizeRequest struct {
 
 func (*outFlowControlSizeRequest) isTransportResponseFrame() bool { return false }
 
+// closeConnection is an instruction to tell the loopy writer to flush the
+// framer and exit, which will cause the transport's connection to be closed
+// (by the client or server).  The transport itself will close after the reader
+// encounters the EOF caused by the connection closure.
 type closeConnection struct{}
 
 func (closeConnection) isTransportResponseFrame() bool { return false }
@@ -823,6 +827,9 @@ func (l *loopyWriter) goAwayHandler(g *goAway) error {
 
 func (l *loopyWriter) closeConnectionHandler() error {
 	l.framer.writer.Flush()
+	// Exit loopyWriter entirely by returning an error here.  This will lead to
+	// the transport closing the conneciton, and, ultimately, transport
+	// closure.
 	return ErrConnClosing
 }
 

--- a/internal/transport/controlbuf.go
+++ b/internal/transport/controlbuf.go
@@ -828,7 +828,7 @@ func (l *loopyWriter) goAwayHandler(g *goAway) error {
 func (l *loopyWriter) closeConnectionHandler() error {
 	l.framer.writer.Flush()
 	// Exit loopyWriter entirely by returning an error here.  This will lead to
-	// the transport closing the conneciton, and, ultimately, transport
+	// the transport closing the connection, and, ultimately, transport
 	// closure.
 	return ErrConnClosing
 }

--- a/internal/transport/http2_server.go
+++ b/internal/transport/http2_server.go
@@ -1154,14 +1154,6 @@ func (t *http2Server) keepalive() {
 					logger.Infof("transport: closing server transport due to maximum connection age.")
 				}
 				t.controlBuf.put(closeConnection{})
-				// Allow some time for the connection to close via the above
-				// signal, then hard close eventually if it doesn't happen.
-				ageTimer.Reset(5 * time.Second)
-				select {
-				case <-ageTimer.C:
-					t.Close()
-				case <-t.done:
-				}
 			case <-t.done:
 			}
 			return

--- a/test/goaway_test.go
+++ b/test/goaway_test.go
@@ -97,7 +97,7 @@ func (s) TestDetailedGoAwayErrorOnGracefulClosePropagatesToRPCError(t *testing.T
 	sopts := []grpc.ServerOption{
 		grpc.KeepaliveParams(keepalive.ServerParameters{
 			MaxConnectionAge:      time.Millisecond * 100,
-			MaxConnectionAgeGrace: time.Millisecond,
+			MaxConnectionAgeGrace: time.Nanosecond, // ~instantaneously, but non-zero to avoid default
 		}),
 	}
 	if err := ss.Start(sopts); err != nil {


### PR DESCRIPTION
Fixes #4859

By changing the grace period in the test, I was able to stimulate this bug much more reliably, and can confirm this fix makes it pass in 100% of subsequent runs.

~This PR currently includes a 5s sleep before an eventual hard close in case the TCP connection is completely stuck.  It's unclear to me whether this is necessary or desirable, or if it should be a shorter time.  (cc @ejona86)~

RELEASE NOTES: none