### PR TITLE
testutils/pickfirst: move helper function to testutils

### DIFF
--- a/internal/testutils/pickfirst/pickfirst.go
+++ b/internal/testutils/pickfirst/pickfirst.go
@@ -37,7 +37,7 @@ import (
 // if the RPCs are routed to a peer matching wantAddr.
 //
 // Returns a non-nil error if context deadline expires before all RPCs begin to
-// be routed to the peer matching wantAddr.
+// be routed to the peer matching wantAddr, or if the backend returns RPC errors.
 func CheckRPCsToBackend(ctx context.Context, cc *grpc.ClientConn, wantAddr resolver.Address) error {
 	client := testgrpc.NewTestServiceClient(cc)
 	peer := &peer.Peer{}

--- a/internal/testutils/pickfirst/pickfirst.go
+++ b/internal/testutils/pickfirst/pickfirst.go
@@ -1,0 +1,72 @@
+/*
+ *
+ * Copyright 2022 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// Package pickfirst contains helper functions to check for pickfirst load
+// balancing of RPCs in tests.
+package pickfirst
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/peer"
+	"google.golang.org/grpc/resolver"
+
+	testgrpc "google.golang.org/grpc/test/grpc_testing"
+	testpb "google.golang.org/grpc/test/grpc_testing"
+)
+
+// CheckRPCsToBackend makes a bunch of RPCs on the given ClientConn and verifies
+// if the RPCs are routed to a peer matching wantAddr.
+//
+// Returns a non-nil error if context deadline expires before all RPCs begin to
+// be routed to the peer matching wantAddr.
+func CheckRPCsToBackend(ctx context.Context, cc *grpc.ClientConn, wantAddr resolver.Address) error {
+	client := testgrpc.NewTestServiceClient(cc)
+	peer := &peer.Peer{}
+	// Make sure the RPC reaches the expected backend once.
+	for {
+		time.Sleep(time.Millisecond)
+		if ctx.Err() != nil {
+			return fmt.Errorf("timeout waiting for RPC to be routed to %s", wantAddr.Addr)
+		}
+		if _, err := client.EmptyCall(ctx, &testpb.Empty{}, grpc.Peer(peer)); err != nil {
+			// Some tests remove backends and check if pick_first is happening across
+			// the remaining backends. In such cases, RPCs can initially fail on the
+			// connection using the removed backend. Just keep retrying and eventually
+			// the connection using the removed backend will shutdown and will be
+			// removed.
+			continue
+		}
+		if peer.Addr.String() == wantAddr.Addr {
+			break
+		}
+	}
+	// Make sure subsequent RPCs are all routed to the same backend.
+	for i := 0; i < 10; i++ {
+		if _, err := client.EmptyCall(ctx, &testpb.Empty{}, grpc.Peer(peer)); err != nil {
+			return fmt.Errorf("EmptyCall() = %v, want <nil>", err)
+		}
+		if gotAddr := peer.Addr.String(); gotAddr != wantAddr.Addr {
+			return fmt.Errorf("rpc sent to peer %q, want peer %q", gotAddr, wantAddr)
+		}
+	}
+	return nil
+}

--- a/test/balancer_switching_test.go
+++ b/test/balancer_switching_test.go
@@ -31,6 +31,7 @@ import (
 	"google.golang.org/grpc/internal/channelz"
 	"google.golang.org/grpc/internal/stubserver"
 	"google.golang.org/grpc/internal/testutils/fakegrpclb"
+	"google.golang.org/grpc/internal/testutils/pickfirst"
 	rrutil "google.golang.org/grpc/internal/testutils/roundrobin"
 	"google.golang.org/grpc/resolver"
 	"google.golang.org/grpc/resolver/manual"
@@ -127,7 +128,7 @@ func (s) TestBalancerSwitch_Basic(t *testing.T) {
 	r.UpdateState(resolver.State{Addresses: addrs})
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
-	if err := checkPickFirst(ctx, cc, addrs[0].Addr); err != nil {
+	if err := pickfirst.CheckRPCsToBackend(ctx, cc, addrs[0]); err != nil {
 		t.Fatal(err)
 	}
 
@@ -146,7 +147,7 @@ func (s) TestBalancerSwitch_Basic(t *testing.T) {
 		Addresses:     addrs,
 		ServiceConfig: parseServiceConfig(t, r, pickFirstServiceConfig),
 	})
-	if err := checkPickFirst(ctx, cc, addrs[0].Addr); err != nil {
+	if err := pickfirst.CheckRPCsToBackend(ctx, cc, addrs[0]); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -191,7 +192,7 @@ func (s) TestBalancerSwitch_grpclbToPickFirst(t *testing.T) {
 	// returned by the "grpclb" balancer. So, we should see RPCs going to the
 	// newly configured backends, as part of the balancer switch.
 	r.UpdateState(resolver.State{Addresses: addrs[1:]})
-	if err := checkPickFirst(ctx, cc, addrs[1].Addr); err != nil {
+	if err := pickfirst.CheckRPCsToBackend(ctx, cc, addrs[1]); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -216,7 +217,7 @@ func (s) TestBalancerSwitch_pickFirstToGRPCLB(t *testing.T) {
 	r.UpdateState(resolver.State{Addresses: addrs[1:]})
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
-	if err := checkPickFirst(ctx, cc, addrs[1].Addr); err != nil {
+	if err := pickfirst.CheckRPCsToBackend(ctx, cc, addrs[1]); err != nil {
 		t.Fatal(err)
 	}
 
@@ -238,7 +239,7 @@ func (s) TestBalancerSwitch_pickFirstToGRPCLB(t *testing.T) {
 
 	// Switch to "pick_first" again by sending no grpclb server addresses.
 	r.UpdateState(resolver.State{Addresses: addrs[1:]})
-	if err := checkPickFirst(ctx, cc, addrs[1].Addr); err != nil {
+	if err := pickfirst.CheckRPCsToBackend(ctx, cc, addrs[1]); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -332,7 +333,7 @@ func (s) TestBalancerSwitch_grpclbNotRegistered(t *testing.T) {
 	r.UpdateState(resolver.State{Addresses: addrs})
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
-	if err := checkPickFirst(ctx, cc, addrs[1].Addr); err != nil {
+	if err := pickfirst.CheckRPCsToBackend(ctx, cc, addrs[1]); err != nil {
 		t.Fatal(err)
 	}
 
@@ -371,7 +372,7 @@ func (s) TestBalancerSwitch_grpclbAddressOverridesLoadBalancingPolicy(t *testing
 	r.UpdateState(resolver.State{Addresses: addrs[1:]})
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
-	if err := checkPickFirst(ctx, cc, addrs[1].Addr); err != nil {
+	if err := pickfirst.CheckRPCsToBackend(ctx, cc, addrs[1]); err != nil {
 		t.Fatal(err)
 	}
 
@@ -609,7 +610,7 @@ func (s) TestBalancerSwitch_Graceful(t *testing.T) {
 	// underlying "pick_first" balancer which will result in a healthy picker
 	// being reported to the channel. RPCs should start using the new balancer.
 	close(waitToProceed)
-	if err := checkPickFirst(ctx, cc, addrs[0].Addr); err != nil {
+	if err := pickfirst.CheckRPCsToBackend(ctx, cc, addrs[0]); err != nil {
 		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
In prep for the actual fix for https://github.com/grpc/grpc-go/issues/4392.

This PR moves a helper function out of `test/pickfirst_test.go` into a `pickfirst` package inside `internal/testutils`. This resembles the helper functions we have for checking roundrobin RPCs in `internal/testutils/roundrobin`. This function will be used by the grpclb tests and it seems to help with the flakiness.

RELEASE NOTES: none