### PR TITLE
pickfirst: do not return initial subconn while connecting

### DIFF
--- a/clientconn.go
+++ b/clientconn.go
@@ -788,10 +788,16 @@ func (cc *ClientConn) incrCallsFailed() {
 func (ac *addrConn) connect() error {
 	ac.mu.Lock()
 	if ac.state == connectivity.Shutdown {
+		if logger.V(2) {
+			logger.Infof("connect called on shutdown addrConn; ignoring.")
+		}
 		ac.mu.Unlock()
 		return errConnClosing
 	}
 	if ac.state != connectivity.Idle {
+		if logger.V(2) {
+			logger.Infof("connect called on addrConn in non-idle state (%v); ignoring.", ac.state)
+		}
 		ac.mu.Unlock()
 		return nil
 	}

--- a/pickfirst.go
+++ b/pickfirst.go
@@ -102,8 +102,8 @@ func (b *pickfirstBalancer) UpdateClientConnState(state balancer.ClientConnState
 	b.subConn = subConn
 	b.state = connectivity.Idle
 	b.cc.UpdateState(balancer.State{
-		ConnectivityState: connectivity.Idle,
-		Picker:            &picker{result: balancer.PickResult{SubConn: b.subConn}},
+		ConnectivityState: connectivity.Connecting,
+		Picker:            &picker{err: balancer.ErrNoSubConnAvailable},
 	})
 	b.subConn.Connect()
 	return nil


### PR DESCRIPTION
Fixes #5663

It is incorrect for a picker to return a SubConn that isn't believed to be READY.  However, the system in gRPC copes with this situation mostly just fine, as long as a new picker is returned when the state becomes READY (which pickfirst does).  This behavior caused a rare test failure, however, because the test was assuming the state of the ClientConn would be READY (non-IDLE, technically) if an RPC happened, and a race around here could lead to an RPC during IDLE.

This PR fixes pickfirst behavior to return a connecting picker while connecting, and also improves the test and some logs.

RELEASE NOTES: none