### PR TITLE
grpclb: improve grpclb tests

### DIFF
--- a/balancer/grpclb/grpclb.go
+++ b/balancer/grpclb/grpclb.go
@@ -32,7 +32,7 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/balancer"
-	grpclbstate "google.golang.org/grpc/balancer/grpclb/state"
+	"google.golang.org/grpc/balancer/grpclb/grpclbstate"
 	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/grpclog"

--- a/balancer/grpclb/grpclb_test.go
+++ b/balancer/grpclb/grpclb_test.go
@@ -66,8 +66,6 @@ var (
 	// Dialer replaces fakeName with localhost when dialing.
 	// This will test that custom dialer is passed from Dial to grpclb.
 	fakeName = "fake.Name"
-
-	grpclbSC = internal.ParseServiceConfig.(func(string) *serviceconfig.ParseResult)(grpclbConfig)
 )
 
 const (

--- a/balancer/grpclb/grpclbstate/state.go
+++ b/balancer/grpclb/grpclbstate/state.go
@@ -16,9 +16,9 @@
  *
  */
 
-// Package state declares grpclb types to be set by resolvers wishing to pass
-// information to grpclb via resolver.State Attributes.
-package state
+// Package grpclbstate declares grpclb types to be set by resolvers wishing to
+// pass information to grpclb via resolver.State Attributes.
+package grpclbstate
 
 import (
 	"google.golang.org/grpc/resolver"
@@ -27,7 +27,7 @@ import (
 // keyType is the key to use for storing State in Attributes.
 type keyType string
 
-const key = keyType("grpc.grpclb.state")
+const key = keyType("grpc.grpclb.grpclbstate")
 
 // State contains gRPCLB-relevant data passed from the name resolver.
 type State struct {

--- a/internal/resolver/dns/dns_resolver.go
+++ b/internal/resolver/dns/dns_resolver.go
@@ -32,7 +32,7 @@ import (
 	"sync"
 	"time"
 
-	grpclbstate "google.golang.org/grpc/balancer/grpclb/state"
+	grpclbstate "google.golang.org/grpc/balancer/grpclb/grpclbstate"
 	"google.golang.org/grpc/grpclog"
 	"google.golang.org/grpc/internal/backoff"
 	"google.golang.org/grpc/internal/envconfig"

--- a/internal/resolver/dns/dns_resolver_test.go
+++ b/internal/resolver/dns/dns_resolver_test.go
@@ -34,7 +34,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"google.golang.org/grpc/balancer"
-	grpclbstate "google.golang.org/grpc/balancer/grpclb/state"
+	grpclbstate "google.golang.org/grpc/balancer/grpclb/grpclbstate"
 	"google.golang.org/grpc/internal/envconfig"
 	"google.golang.org/grpc/internal/leakcheck"
 	"google.golang.org/grpc/internal/testutils"


### PR DESCRIPTION
There is more cleanup that *can* be done on these tests, but given that we don't care that much about grpclb, I had to stop here. I was able to get it down to `1` failure in `100K` across all tests in this package, and that too looked like some infra flake where a backend did not spin up properly.

Fixes https://github.com/grpc/grpc-go/issues/4392.

RELEASE NOTES: n/a