### PR TITLE
ringhash: add logs to surface information about ring creation

### DIFF
--- a/xds/internal/balancer/ringhash/ring.go
+++ b/xds/internal/balancer/ringhash/ring.go
@@ -24,6 +24,7 @@ import (
 	"strconv"
 
 	xxhash "github.com/cespare/xxhash/v2"
+	"google.golang.org/grpc/internal/grpclog"
 	"google.golang.org/grpc/resolver"
 )
 
@@ -65,9 +66,12 @@ type ringEntry struct {
 // and first item with hash >= given hash will be returned.
 //
 // Must be called with a non-empty subConns map.
-func newRing(subConns *resolver.AddressMap, minRingSize, maxRingSize uint64) *ring {
+func newRing(subConns *resolver.AddressMap, minRingSize, maxRingSize uint64, logger *grpclog.PrefixLogger) *ring {
+	logger.Debugf("newRing: number of subConns is %d, minRingSize is %d, maxRingSize is %d", subConns.Len(), minRingSize, maxRingSize)
+
 	// https://github.com/envoyproxy/envoy/blob/765c970f06a4c962961a0e03a467e165b276d50f/source/common/upstream/ring_hash_lb.cc#L114
 	normalizedWeights, minWeight := normalizeWeights(subConns)
+	logger.Debugf("newRing: normalized subConn weights is %v", normalizedWeights)
 
 	// Normalized weights for {3,3,4} is {0.3,0.3,0.4}.
 
@@ -78,6 +82,7 @@ func newRing(subConns *resolver.AddressMap, minRingSize, maxRingSize uint64) *ri
 	scale := math.Min(math.Ceil(minWeight*float64(minRingSize))/minWeight, float64(maxRingSize))
 	ringSize := math.Ceil(scale)
 	items := make([]*ringEntry, 0, int(ringSize))
+	logger.Debugf("newRing: creating new ring of size %v", ringSize)
 
 	// For each entry, scale*weight nodes are generated in the ring.
 	//

--- a/xds/internal/balancer/ringhash/ring_test.go
+++ b/xds/internal/balancer/ringhash/ring_test.go
@@ -52,7 +52,7 @@ func (s) TestRingNew(t *testing.T) {
 	for _, min := range []uint64{3, 4, 6, 8} {
 		for _, max := range []uint64{20, 8} {
 			t.Run(fmt.Sprintf("size-min-%v-max-%v", min, max), func(t *testing.T) {
-				r := newRing(testSubConnMap, min, max)
+				r := newRing(testSubConnMap, min, max, nil)
 				totalCount := len(r.items)
 				if totalCount < int(min) || totalCount > int(max) {
 					t.Fatalf("unexpect size %v, want min %v, max %v", totalCount, min, max)
@@ -82,7 +82,7 @@ func equalApproximately(x, y float64) bool {
 }
 
 func (s) TestRingPick(t *testing.T) {
-	r := newRing(testSubConnMap, 10, 20)
+	r := newRing(testSubConnMap, 10, 20, nil)
 	for _, h := range []uint64{xxhash.Sum64String("1"), xxhash.Sum64String("2"), xxhash.Sum64String("3"), xxhash.Sum64String("4")} {
 		t.Run(fmt.Sprintf("picking-hash-%v", h), func(t *testing.T) {
 			e := r.pick(h)
@@ -100,7 +100,7 @@ func (s) TestRingPick(t *testing.T) {
 }
 
 func (s) TestRingNext(t *testing.T) {
-	r := newRing(testSubConnMap, 10, 20)
+	r := newRing(testSubConnMap, 10, 20, nil)
 
 	for _, e := range r.items {
 		ne := r.next(e)

--- a/xds/internal/balancer/ringhash/ringhash.go
+++ b/xds/internal/balancer/ringhash/ringhash.go
@@ -293,7 +293,7 @@ func (b *ringhashBalancer) UpdateClientConnState(s balancer.ClientConnState) err
 	if regenerateRing {
 		// Ring creation is guaranteed to not fail because we call newRing()
 		// with a non-empty subConns map.
-		b.ring = newRing(b.subConns, b.config.MinRingSize, b.config.MaxRingSize)
+		b.ring = newRing(b.subConns, b.config.MinRingSize, b.config.MaxRingSize, b.logger)
 		b.regeneratePicker()
 		b.cc.UpdateState(balancer.State{ConnectivityState: b.state, Picker: b.picker})
 	}


### PR DESCRIPTION
The newly added logs like this:
```
ring.go:70 [xds] [ring-hash-lb 0xc000148080] newRing: number of subConns is 1, minRingSize is 1024, maxRingSize is 4096  (t=+3.468892ms)
ring.go:74 [xds] [ring-hash-lb 0xc000148080] newRing: normalized subConn weights is [{0xc0001145a0 1}]  (t=+3.485234ms)
ring.go:85 [xds] [ring-hash-lb 0xc000148080] newRing: creating new ring of size 1024  (t=+3.497625ms)
```

Fixes https://github.com/grpc/grpc-go/issues/5781

RELEASE NOTES: none