### PR TITLE
test: remove use of deprecated WithInsecure() API

### DIFF
--- a/test/authority_test.go
+++ b/test/authority_test.go
@@ -227,7 +227,7 @@ func (s) TestAuthorityReplacedWithResolverAddress(t *testing.T) {
 
 	r := manual.NewBuilderWithScheme("whatever")
 	r.InitialState(resolver.State{Addresses: []resolver.Address{{Addr: ss.Address, ServerName: expectedAuthority}}})
-	cc, err := grpc.Dial(r.Scheme()+":///whatever", grpc.WithInsecure(), grpc.WithResolvers(r))
+	cc, err := grpc.Dial(r.Scheme()+":///whatever", grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithResolvers(r))
 	if err != nil {
 		t.Fatalf("grpc.Dial(%q) = %v", ss.Address, err)
 	}


### PR DESCRIPTION
This got added in a recent commit and I did not notice it at that time. Noticed it only at the time of the import.

I don't know why `vet` didn't flag this though.

RELEASE NOTES: none