### PR TITLE
Added logs for reasons causing connection and transport close

### DIFF
--- a/clientconn.go
+++ b/clientconn.go
@@ -1274,6 +1274,9 @@ func (ac *addrConn) createTransport(addr resolver.Address, copts transport.Conne
 
 	newTr, err := transport.NewClientTransport(connectCtx, ac.cc.ctx, addr, copts, onGoAway, onClose)
 	if err != nil {
+		if logger.V(2) {
+			logger.Errorf("NewClientTransport failed to connect to %s. Err: %v", addr, err)
+		}
 		// newTr is either nil, or closed.
 		hcancel()
 		channelz.Warningf(logger, ac.channelzID, "grpc: addrConn.createTransport failed to connect to %s. Err: %v", addr, err)

--- a/clientconn.go
+++ b/clientconn.go
@@ -1275,7 +1275,7 @@ func (ac *addrConn) createTransport(addr resolver.Address, copts transport.Conne
 	newTr, err := transport.NewClientTransport(connectCtx, ac.cc.ctx, addr, copts, onGoAway, onClose)
 	if err != nil {
 		if logger.V(2) {
-			logger.Errorf("NewClientTransport failed to connect to %s. Err: %v", addr, err)
+			logger.Errorf("Creating new client transport to %q: %v", addr, err)
 		}
 		// newTr is either nil, or closed.
 		hcancel()

--- a/clientconn.go
+++ b/clientconn.go
@@ -1275,7 +1275,7 @@ func (ac *addrConn) createTransport(addr resolver.Address, copts transport.Conne
 	newTr, err := transport.NewClientTransport(connectCtx, ac.cc.ctx, addr, copts, onGoAway, onClose)
 	if err != nil {
 		if logger.V(2) {
-			logger.Errorf("Creating new client transport to %q: %v", addr, err)
+			logger.Infof("Creating new client transport to %q: %v", addr, err)
 		}
 		// newTr is either nil, or closed.
 		hcancel()

--- a/internal/transport/controlbuf.go
+++ b/internal/transport/controlbuf.go
@@ -585,7 +585,6 @@ func (l *loopyWriter) run() (err error) {
 			}
 			l.framer.writer.Flush()
 			break hasdata
-
 		}
 	}
 }
@@ -673,11 +672,10 @@ func (l *loopyWriter) headerHandler(h *headerFrame) error {
 func (l *loopyWriter) originateStream(str *outStream) error {
 	hdr := str.itl.dequeue().(*headerFrame)
 	if err := hdr.initStream(str.id); err != nil {
-		if err == ErrConnClosing {
-			return err
+		if err == errStreamDrain { // errStreamDrain need not close transport
+			return nil
 		}
-		// Other errors(errStreamDrain) need not close transport.
-		return nil
+		return err
 	}
 	if err := l.writeHeader(str.id, hdr.endStream, hdr.hf, hdr.onWrite); err != nil {
 		return err

--- a/internal/transport/controlbuf.go
+++ b/internal/transport/controlbuf.go
@@ -191,7 +191,7 @@ type goAway struct {
 	code      http2.ErrCode
 	debugData []byte
 	headsUp   bool
-	closeConn error
+	closeConn error // if set, loopyWriter will exit, resulting in conn closure
 }
 
 func (*goAway) isTransportResponseFrame() bool { return false }

--- a/internal/transport/controlbuf.go
+++ b/internal/transport/controlbuf.go
@@ -758,7 +758,7 @@ func (l *loopyWriter) cleanupStreamHandler(c *cleanupStream) error {
 		}
 	}
 	if l.side == clientSide && l.draining && len(l.estdStreams) == 0 {
-		return errors.New("finished processing active streams while in draining mode, no more streams to finish processing")
+		return errors.New("finished processing active streams while in draining mode")
 	}
 	return nil
 }
@@ -793,7 +793,7 @@ func (l *loopyWriter) incomingGoAwayHandler(*incomingGoAway) error {
 	if l.side == clientSide {
 		l.draining = true
 		if len(l.estdStreams) == 0 {
-			return errors.New("no active streams left to process when GOAWAY frame received, so can trigger closure")
+			return errors.New("received GOAWAY with no active streams")
 		}
 	}
 	return nil

--- a/internal/transport/controlbuf.go
+++ b/internal/transport/controlbuf.go
@@ -416,6 +416,9 @@ func (c *controlBuffer) get(block bool) (interface{}, error) {
 		select {
 		case <-c.ch:
 		case <-c.done:
+			if logger.V(logLevel) {
+				logger.Infof("transport: trigger loopy to exit (with a subsequent conn closure) because transports context expired.")
+			}
 			return nil, ErrConnClosing
 		}
 	}
@@ -772,6 +775,9 @@ func (l *loopyWriter) cleanupStreamHandler(c *cleanupStream) error {
 		}
 	}
 	if l.side == clientSide && l.draining && len(l.estdStreams) == 0 {
+		if logger.V(logLevel) {
+			logger.Infof("transport: trigger loopy to exit (with a subsequent conn closure) because no active streams left to finish processing while in draining mode.")
+		}
 		return ErrConnClosing
 	}
 	return nil
@@ -807,6 +813,9 @@ func (l *loopyWriter) incomingGoAwayHandler(*incomingGoAway) error {
 	if l.side == clientSide {
 		l.draining = true
 		if len(l.estdStreams) == 0 {
+			if logger.V(logLevel) {
+				logger.Infof("transport: trigger loopy to exit (with a subsequent conn closure) because no active streams to wait to finish processing when GOAWAY frame received.")
+			}
 			return ErrConnClosing
 		}
 	}

--- a/internal/transport/controlbuf.go
+++ b/internal/transport/controlbuf.go
@@ -191,7 +191,7 @@ type goAway struct {
 	code      http2.ErrCode
 	debugData []byte
 	headsUp   bool
-	closeConn bool
+	closeConn error
 }
 
 func (*goAway) isTransportResponseFrame() bool { return false }
@@ -417,7 +417,7 @@ func (c *controlBuffer) get(block bool) (interface{}, error) {
 		case <-c.ch:
 		case <-c.done:
 			if logger.V(logLevel) {
-				logger.Infof("transport: trigger loopy to exit (with a subsequent conn closure) because transports context expired.")
+				logger.Infof("transport: trigger loopy to exit (with a subsequent conn closure) because transport's context expired.")
 			}
 			return nil, ErrConnClosing
 		}

--- a/internal/transport/controlbuf.go
+++ b/internal/transport/controlbuf.go
@@ -416,7 +416,7 @@ func (c *controlBuffer) get(block bool) (interface{}, error) {
 		select {
 		case <-c.ch:
 		case <-c.done:
-			return nil, errors.New("transport's context expired")
+			return nil, errors.New("transport closed by client")
 		}
 	}
 }

--- a/internal/transport/handler_server.go
+++ b/internal/transport/handler_server.go
@@ -146,11 +146,9 @@ func (ht *serverHandlerTransport) Close(err error) {
 		if logger.V(logLevel) {
 			logger.Infof("Closing serverHandlerTransport: %v", err)
 		}
-		ht.closeCloseChanOnce()
+		close(ht.closedCh)
 	})
 }
-
-func (ht *serverHandlerTransport) closeCloseChanOnce() { close(ht.closedCh) }
 
 func (ht *serverHandlerTransport) RemoteAddr() net.Addr { return strAddr(ht.req.RemoteAddr) }
 

--- a/internal/transport/handler_server.go
+++ b/internal/transport/handler_server.go
@@ -141,7 +141,10 @@ type serverHandlerTransport struct {
 	stats []stats.Handler
 }
 
-func (ht *serverHandlerTransport) Close() {
+func (ht *serverHandlerTransport) Close(err error) {
+	if logger.V(logLevel) {
+		logger.Infof("closing serverHandlerTransport due to err: %v", err)
+	}
 	ht.closeOnce.Do(ht.closeCloseChanOnce)
 }
 
@@ -236,7 +239,7 @@ func (ht *serverHandlerTransport) WriteStatus(s *Stream, st *status.Status) erro
 			})
 		}
 	}
-	ht.Close()
+	ht.Close(fmt.Errorf("finished writing status"))
 	return err
 }
 
@@ -346,7 +349,7 @@ func (ht *serverHandlerTransport) HandleStreams(startStream func(*Stream), trace
 		case <-ht.req.Context().Done():
 		}
 		cancel()
-		ht.Close()
+		ht.Close(fmt.Errorf("request is done processing"))
 	}()
 
 	req := ht.req

--- a/internal/transport/handler_server.go
+++ b/internal/transport/handler_server.go
@@ -142,10 +142,12 @@ type serverHandlerTransport struct {
 }
 
 func (ht *serverHandlerTransport) Close(err error) {
-	if logger.V(logLevel) {
-		logger.Infof("Closing serverHandlerTransport: %v", err)
-	}
-	ht.closeOnce.Do(ht.closeCloseChanOnce)
+	ht.closeOnce.Do(func() {
+		if logger.V(logLevel) {
+			logger.Infof("Closing serverHandlerTransport: %v", err)
+		}
+		ht.closeCloseChanOnce()
+	})
 }
 
 func (ht *serverHandlerTransport) closeCloseChanOnce() { close(ht.closedCh) }

--- a/internal/transport/handler_server.go
+++ b/internal/transport/handler_server.go
@@ -143,7 +143,7 @@ type serverHandlerTransport struct {
 
 func (ht *serverHandlerTransport) Close(err error) {
 	if logger.V(logLevel) {
-		logger.Infof("closing serverHandlerTransport due to err: %v", err)
+		logger.Infof("Closing serverHandlerTransport: %v", err)
 	}
 	ht.closeOnce.Do(ht.closeCloseChanOnce)
 }
@@ -239,7 +239,7 @@ func (ht *serverHandlerTransport) WriteStatus(s *Stream, st *status.Status) erro
 			})
 		}
 	}
-	ht.Close(fmt.Errorf("finished writing status"))
+	ht.Close(errors.New("finished writing status"))
 	return err
 }
 
@@ -349,7 +349,7 @@ func (ht *serverHandlerTransport) HandleStreams(startStream func(*Stream), trace
 		case <-ht.req.Context().Done():
 		}
 		cancel()
-		ht.Close(fmt.Errorf("request is done processing"))
+		ht.Close(errors.New("request is done processing"))
 	}()
 
 	req := ht.req

--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -953,7 +953,7 @@ func (t *http2Client) Close(err error) {
 		return
 	}
 	if logger.V(logLevel) {
-		logger.Infof("Closing transport, will close the connection: %v", err)
+		logger.Infof("transport: closing: %v", err)
 	}
 	// Call t.onClose ASAP to prevent the client from attempting to create new
 	// streams.

--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -242,10 +242,10 @@ func newHTTP2Client(connectCtx, ctx context.Context, addr resolver.Address, opts
 	go func(conn net.Conn) {
 		defer ctxMonitorDone.Fire() // Signal this goroutine has exited.
 		<-newClientCtx.Done()       // Block until connectCtx expires or the defer above executes.
-		if connectCtx.Err() != nil {
+		if err := connectCtx.Err(); err != nil {
 			// connectCtx expired before exiting the function.  Hard close the connection.
 			if logger.V(logLevel) {
-				logger.Infof("newClientTransport: closing connection due to connect context expiring.")
+				logger.Infof("newClientTransport: aborting due to connectCtx: %v", err)
 			}
 			conn.Close()
 		}
@@ -1008,7 +1008,7 @@ func (t *http2Client) GracefulClose() {
 		return
 	}
 	if logger.V(logLevel) {
-		logger.Infof("transport: GracefulClose called, transport switched to draining")
+		logger.Infof("transport: GracefulClose called")
 	}
 	t.state = draining
 	active := len(t.activeStreams)

--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -450,7 +450,7 @@ func newHTTP2Client(connectCtx, ctx context.Context, addr resolver.Address, opts
 		err := t.loopy.run()
 		if err != nil {
 			if logger.V(logLevel) {
-				logger.Errorf("transport: loopyWriter exited. Closing connection. Err: %v", err)
+				logger.Infof("transport: loopyWriter exited. Closing connection. Err: %v", err)
 			}
 		}
 		// Do not close the transport.  Let reader goroutine handle it since

--- a/internal/transport/http2_server.go
+++ b/internal/transport/http2_server.go
@@ -334,7 +334,7 @@ func NewServerTransport(conn net.Conn, config *ServerConfig) (_ ServerTransport,
 		t.loopy.ssGoAwayHandler = t.outgoingGoAwayHandler
 		if err := t.loopy.run(); err != nil {
 			if logger.V(logLevel) {
-				logger.Errorf("transport: loopyWriter exited. Closing connection. Err: %v", err)
+				logger.Infof("transport: loopyWriter exited. Closing connection. Err: %v", err)
 			}
 		}
 		t.conn.Close()

--- a/internal/transport/http2_server.go
+++ b/internal/transport/http2_server.go
@@ -367,7 +367,7 @@ func (t *http2Server) operateHeaders(frame *http2.MetaHeadersFrame, handle func(
 
 	if streamID%2 != 1 || streamID <= t.maxStreamID {
 		// illegal gRPC stream id.
-		return fmt.Errorf("received an illegal stream id: %v", streamID)
+		return fmt.Errorf("received an illegal stream id: %v. headers frame: %+v", streamID, frame)
 	}
 	t.maxStreamID = streamID
 
@@ -1195,7 +1195,7 @@ func (t *http2Server) Close(err error) {
 		return
 	}
 	if logger.V(logLevel) {
-		logger.Infof("Closing transport, will close the connection: %v", err)
+		logger.Infof("transport: closing: %v", err)
 	}
 	t.state = closing
 	streams := t.activeStreams

--- a/internal/transport/transport.go
+++ b/internal/transport/transport.go
@@ -701,7 +701,7 @@ type ServerTransport interface {
 	// Close tears down the transport. Once it is called, the transport
 	// should not be accessed any more. All the pending streams and their
 	// handlers will be terminated asynchronously.
-	Close()
+	Close(err error)
 
 	// RemoteAddr returns the remote network address.
 	RemoteAddr() net.Addr

--- a/internal/transport/transport.go
+++ b/internal/transport/transport.go
@@ -761,10 +761,6 @@ func (e ConnectionError) Unwrap() error {
 var (
 	// ErrConnClosing indicates that the transport is closing.
 	ErrConnClosing = connectionErrorf(true, nil, "transport is closing")
-	// errNoStreamsDraining indicates that this transport is finished processing
-	// while in draining mode due to no more active streams to process, thus
-	// making the transport and connection immediately ready to close.
-	errNoStreamsDraining = connectionErrorf(true, nil, "no active streams left to process while draining")
 	// errStreamDrain indicates that the stream is rejected because the
 	// connection is draining. This could be caused by goaway or balancer
 	// removing the address.

--- a/internal/transport/transport.go
+++ b/internal/transport/transport.go
@@ -761,6 +761,10 @@ func (e ConnectionError) Unwrap() error {
 var (
 	// ErrConnClosing indicates that the transport is closing.
 	ErrConnClosing = connectionErrorf(true, nil, "transport is closing")
+	// errNoStreamsDraining indicates that this transport is finished processing
+	// while in draining mode due to no more active streams to process, thus
+	// making the transport and connection immediately ready to close.
+	errNoStreamsDraining = connectionErrorf(true, nil, "no active streams left to process while draining")
 	// errStreamDrain indicates that the stream is rejected because the
 	// connection is draining. This could be caused by goaway or balancer
 	// removing the address.

--- a/internal/transport/transport_test.go
+++ b/internal/transport/transport_test.go
@@ -343,7 +343,7 @@ func (s *server) start(t *testing.T, port int, serverConfig *ServerConfig, ht hT
 		s.mu.Lock()
 		if s.conns == nil {
 			s.mu.Unlock()
-			transport.Close()
+			transport.Close(fmt.Errorf("s.conns is nil"))
 			return
 		}
 		s.conns[transport] = true
@@ -421,7 +421,7 @@ func (s *server) stop() {
 	s.lis.Close()
 	s.mu.Lock()
 	for c := range s.conns {
-		c.Close()
+		c.Close(fmt.Errorf("server Stop called"))
 	}
 	s.conns = nil
 	s.mu.Unlock()
@@ -1650,7 +1650,7 @@ func testFlowControlAccountCheck(t *testing.T, msgSize int, wc windowSizeConfig)
 	// Close down both server and client so that their internals can be read without data
 	// races.
 	client.Close(fmt.Errorf("closed manually by test"))
-	st.Close()
+	st.Close(fmt.Errorf("closed manually by test"))
 	<-st.readerDone
 	<-st.writerDone
 	<-client.readerDone

--- a/internal/transport/transport_test.go
+++ b/internal/transport/transport_test.go
@@ -343,7 +343,7 @@ func (s *server) start(t *testing.T, port int, serverConfig *ServerConfig, ht hT
 		s.mu.Lock()
 		if s.conns == nil {
 			s.mu.Unlock()
-			transport.Close(fmt.Errorf("s.conns is nil"))
+			transport.Close(errors.New("s.conns is nil"))
 			return
 		}
 		s.conns[transport] = true
@@ -421,7 +421,7 @@ func (s *server) stop() {
 	s.lis.Close()
 	s.mu.Lock()
 	for c := range s.conns {
-		c.Close(fmt.Errorf("server Stop called"))
+		c.Close(errors.New("server Stop called"))
 	}
 	s.conns = nil
 	s.mu.Unlock()
@@ -1649,8 +1649,8 @@ func testFlowControlAccountCheck(t *testing.T, msgSize int, wc windowSizeConfig)
 	}
 	// Close down both server and client so that their internals can be read without data
 	// races.
-	client.Close(fmt.Errorf("closed manually by test"))
-	st.Close(fmt.Errorf("closed manually by test"))
+	client.Close(errors.New("closed manually by test"))
+	st.Close(errors.New("closed manually by test"))
 	<-st.readerDone
 	<-st.writerDone
 	<-client.readerDone

--- a/server.go
+++ b/server.go
@@ -942,7 +942,7 @@ func (s *Server) newHTTP2Transport(c net.Conn) transport.ServerTransport {
 }
 
 func (s *Server) serveStreams(st transport.ServerTransport) {
-	defer st.Close(fmt.Errorf("finished serving streams for the server transport"))
+	defer st.Close(errors.New("finished serving streams for the server transport"))
 	var wg sync.WaitGroup
 
 	var roundRobinCounter uint32
@@ -1046,7 +1046,7 @@ func (s *Server) addConn(addr string, st transport.ServerTransport) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.conns == nil {
-		st.Close(fmt.Errorf("s.conns (representing active server transports) is nil"))
+		st.Close(errors.New("s.conns (representing active server transports) is nil"))
 		return false
 	}
 	if s.drain {
@@ -1809,7 +1809,7 @@ func (s *Server) Stop() {
 	}
 	for _, cs := range conns {
 		for st := range cs {
-			st.Close(fmt.Errorf("server Stop called"))
+			st.Close(errors.New("server Stop called"))
 		}
 	}
 	if s.opts.numServerWorkers > 0 {

--- a/server.go
+++ b/server.go
@@ -942,7 +942,7 @@ func (s *Server) newHTTP2Transport(c net.Conn) transport.ServerTransport {
 }
 
 func (s *Server) serveStreams(st transport.ServerTransport) {
-	defer st.Close()
+	defer st.Close(fmt.Errorf("finished serving streams for the server transport"))
 	var wg sync.WaitGroup
 
 	var roundRobinCounter uint32
@@ -1046,7 +1046,7 @@ func (s *Server) addConn(addr string, st transport.ServerTransport) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.conns == nil {
-		st.Close()
+		st.Close(fmt.Errorf("s.conns (representing active server transports) is nil"))
 		return false
 	}
 	if s.drain {
@@ -1809,7 +1809,7 @@ func (s *Server) Stop() {
 	}
 	for _, cs := range conns {
 		for st := range cs {
-			st.Close()
+			st.Close(fmt.Errorf("server Stop called"))
 		}
 	}
 	if s.opts.numServerWorkers > 0 {

--- a/server.go
+++ b/server.go
@@ -1809,7 +1809,7 @@ func (s *Server) Stop() {
 	}
 	for _, cs := range conns {
 		for st := range cs {
-			st.Close(errors.New("server Stop called"))
+			st.Close(errors.New("Server.Stop called"))
 		}
 	}
 	if s.opts.numServerWorkers > 0 {

--- a/server.go
+++ b/server.go
@@ -1046,7 +1046,7 @@ func (s *Server) addConn(addr string, st transport.ServerTransport) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.conns == nil {
-		st.Close(errors.New("s.conns (representing active server transports) is nil"))
+		st.Close(errors.New("Server.addConn called when server has already been stopped"))
 		return false
 	}
 	if s.drain {


### PR DESCRIPTION
A flaky keepalive test is trying to read and write to a closed network connection. In some of the cases, the server was receiving too many pings, which led to one of the root causes of flakiness and the subsequent fix, but I couldn't figure out why the network connection was closing for any other case. Discussing this, the go team realized that the transport layer logs with respect to transport and connection closure were very sparse, and populating logs with information as to why transports and connections were triggered to close could help a user debug.

RELEASE NOTES:
* transport: Added logs for transport and connection closure