### PR TITLE
balancer: support injection of per-call metadata from LB policies

### DIFF
--- a/balancer/balancer.go
+++ b/balancer/balancer.go
@@ -233,11 +233,6 @@ type PickInfo struct {
 	FullMethodName string
 	// Ctx is the RPC's context, and may contain relevant RPC-level information
 	// like the outgoing header metadata.
-	//
-	// If an LB policy wishes to mutate the outgoing header metadata on a
-	// per-call basis, it could get the existing outgoing metadata from this
-	// context using a call to metadata.FromOutgoingContext(), mutate it and
-	// pass it back in the Metadata field of PickResult.
 	Ctx context.Context
 }
 
@@ -286,9 +281,8 @@ type PickResult struct {
 	Done func(DoneInfo)
 
 	// Metadata provides a way for LB policies to inject arbitrary per-call
-	// metadata. If this is non-nil, it will be used as-is and will overwrite
-	// any existing metadata stored in the RPC context. LB policies are advised
-	// to use this with caution. See PickInfo.Ctx for more details.
+	// metadata. Any metadata returned here will be merged with existing
+	// metadata added by the client application.
 	//
 	// LB policies with child policies are responsible for propagating metadata
 	// injected by their children to the ClientConn, as part of Pick().

--- a/balancer/balancer.go
+++ b/balancer/balancer.go
@@ -233,6 +233,11 @@ type PickInfo struct {
 	FullMethodName string
 	// Ctx is the RPC's context, and may contain relevant RPC-level information
 	// like the outgoing header metadata.
+	//
+	// If an LB policy wishes to mutate the outgoing header metadata on a
+	// per-call basis, it could get the existing outgoing metadata from this
+	// context using a call to metadata.FromOutgoingContext(), mutate it and
+	// pass it back in the Metadata field of PickResult.
 	Ctx context.Context
 }
 
@@ -279,6 +284,15 @@ type PickResult struct {
 	// type, Done may not be called.  May be nil if the balancer does not wish
 	// to be notified when the RPC completes.
 	Done func(DoneInfo)
+
+	// Metadata provides a way for LB policies to inject arbitrary per-call
+	// metadata. If this is non-nil, it will be used as-is and will overwrite
+	// any existing metadata stored in the RPC context. LB policies are advised
+	// to use this with caution. See PickInfo.Ctx for more details.
+	//
+	// LB policies with child policies are responsible for propagating metadata
+	// injected by their children to the ClientConn, as part of Pick().
+	Metatada metadata.MD
 }
 
 // TransientFailureError returns e.  It exists for backward compatibility and

--- a/clientconn.go
+++ b/clientconn.go
@@ -934,7 +934,7 @@ func (cc *ClientConn) healthCheckConfig() *healthCheckConfig {
 	return cc.sc.healthCheckConfig
 }
 
-func (cc *ClientConn) getTransport(ctx context.Context, failfast bool, method string) (transport.ClientTransport, func(balancer.DoneInfo), error) {
+func (cc *ClientConn) getTransport(ctx context.Context, failfast bool, method string) (transport.ClientTransport, balancer.PickResult, error) {
 	return cc.blockingpicker.pick(ctx, failfast, balancer.PickInfo{
 		Ctx:            ctx,
 		FullMethodName: method,

--- a/picker_wrapper.go
+++ b/picker_wrapper.go
@@ -58,12 +58,18 @@ func (pw *pickerWrapper) updatePicker(p balancer.Picker) {
 	pw.mu.Unlock()
 }
 
-func doneChannelzWrapper(acw *acBalancerWrapper, done func(balancer.DoneInfo)) func(balancer.DoneInfo) {
+// doneChannelzWrapper performs the following:
+//   - increments the calls started channelz counter
+//   - wraps the done function in the passed in result to increment the calls
+//     failed or calls succeeded channelz counter before invoking the actual
+//     done function.
+func doneChannelzWrapper(acw *acBalancerWrapper, result *balancer.PickResult) {
 	acw.mu.Lock()
 	ac := acw.ac
 	acw.mu.Unlock()
 	ac.incrCallsStarted()
-	return func(b balancer.DoneInfo) {
+	done := result.Done
+	result.Done = func(b balancer.DoneInfo) {
 		if b.Err != nil && b.Err != io.EOF {
 			ac.incrCallsFailed()
 		} else {
@@ -82,7 +88,7 @@ func doneChannelzWrapper(acw *acBalancerWrapper, done func(balancer.DoneInfo)) f
 // - the current picker returns other errors and failfast is false.
 // - the subConn returned by the current picker is not READY
 // When one of these situations happens, pick blocks until the picker gets updated.
-func (pw *pickerWrapper) pick(ctx context.Context, failfast bool, info balancer.PickInfo) (transport.ClientTransport, func(balancer.DoneInfo), error) {
+func (pw *pickerWrapper) pick(ctx context.Context, failfast bool, info balancer.PickInfo) (transport.ClientTransport, balancer.PickResult, error) {
 	var ch chan struct{}
 
 	var lastPickErr error
@@ -90,7 +96,7 @@ func (pw *pickerWrapper) pick(ctx context.Context, failfast bool, info balancer.
 		pw.mu.Lock()
 		if pw.done {
 			pw.mu.Unlock()
-			return nil, nil, ErrClientConnClosing
+			return nil, balancer.PickResult{}, ErrClientConnClosing
 		}
 
 		if pw.picker == nil {
@@ -111,9 +117,9 @@ func (pw *pickerWrapper) pick(ctx context.Context, failfast bool, info balancer.
 				}
 				switch ctx.Err() {
 				case context.DeadlineExceeded:
-					return nil, nil, status.Error(codes.DeadlineExceeded, errStr)
+					return nil, balancer.PickResult{}, status.Error(codes.DeadlineExceeded, errStr)
 				case context.Canceled:
-					return nil, nil, status.Error(codes.Canceled, errStr)
+					return nil, balancer.PickResult{}, status.Error(codes.Canceled, errStr)
 				}
 			case <-ch:
 			}
@@ -125,7 +131,6 @@ func (pw *pickerWrapper) pick(ctx context.Context, failfast bool, info balancer.
 		pw.mu.Unlock()
 
 		pickResult, err := p.Pick(info)
-
 		if err != nil {
 			if err == balancer.ErrNoSubConnAvailable {
 				continue
@@ -136,7 +141,7 @@ func (pw *pickerWrapper) pick(ctx context.Context, failfast bool, info balancer.
 				if istatus.IsRestrictedControlPlaneCode(st) {
 					err = status.Errorf(codes.Internal, "received picker error with illegal status: %v", err)
 				}
-				return nil, nil, dropError{error: err}
+				return nil, balancer.PickResult{}, dropError{error: err}
 			}
 			// For all other errors, wait for ready RPCs should block and other
 			// RPCs should fail with unavailable.
@@ -144,7 +149,7 @@ func (pw *pickerWrapper) pick(ctx context.Context, failfast bool, info balancer.
 				lastPickErr = err
 				continue
 			}
-			return nil, nil, status.Error(codes.Unavailable, err.Error())
+			return nil, balancer.PickResult{}, status.Error(codes.Unavailable, err.Error())
 		}
 
 		acw, ok := pickResult.SubConn.(*acBalancerWrapper)
@@ -154,9 +159,10 @@ func (pw *pickerWrapper) pick(ctx context.Context, failfast bool, info balancer.
 		}
 		if t := acw.getAddrConn().getReadyTransport(); t != nil {
 			if channelz.IsOn() {
-				return t, doneChannelzWrapper(acw, pickResult.Done), nil
+				doneChannelzWrapper(acw, &pickResult)
+				return t, pickResult, nil
 			}
-			return t, pickResult.Done, nil
+			return t, pickResult, nil
 		}
 		if pickResult.Done != nil {
 			// Calling done with nil error, no bytes sent and no bytes received.

--- a/stream.go
+++ b/stream.go
@@ -460,7 +460,7 @@ func (a *csAttempt) newStream() error {
 	ctx := a.ctx
 	if a.pickResult.Metatada != nil {
 		// We currently do not have a function it the metadata package which
-		// merges given metadata with existing metadata in a context. Exising
+		// merges given metadata with existing metadata in a context. Existing
 		// function `AppendToOutgoingContext()` takes a variadic argument of key
 		// value pairs.
 		//

--- a/stream.go
+++ b/stream.go
@@ -467,7 +467,8 @@ func (a *csAttempt) newStream() error {
 		// value pairs.
 		//
 		// TODO: Make it possible to retrieve key value pairs from metadata.MD
-		// in a form passable to AppendToOutgoingContext().
+		// in a form passable to AppendToOutgoingContext(), or create a version
+		// of AppendToOutgoingContext() that accepts a metadata.MD.
 		md, _ := metadata.FromOutgoingContext(a.ctx)
 		md = metadata.Join(md, a.pickResult.Metatada)
 		a.ctx = metadata.NewOutgoingContext(a.ctx, md)

--- a/test/balancer_test.go
+++ b/test/balancer_test.go
@@ -988,14 +988,14 @@ func (s) TestMetadataInPickResult(t *testing.T) {
 		t.Fatalf("Timed out waiting for custom metadata to be received at the test backend")
 	}
 
-	t.Log("Veirfying custom metadata added by the client application is recieved at the test backend...")
+	t.Log("Verifying custom metadata added by the client application is received at the test backend...")
 	wantMDVal := []string{metadataValueInjectedByApplication}
 	gotMDVal := gotMD.Get(metadataHeaderInjectedByApplication)
 	if !cmp.Equal(gotMDVal, wantMDVal) {
 		t.Fatalf("Mismatch in custom metadata received at test backend, got: %v, want %v", gotMDVal, wantMDVal)
 	}
 
-	t.Log("Veirfying custom metadata added by the LB policy is recieved at the test backend...")
+	t.Log("Verifying custom metadata added by the LB policy is received at the test backend...")
 	wantMDVal = []string{metadataValueInjectedByBalancer}
 	gotMDVal = gotMD.Get(metadataHeaderInjectedByBalancer)
 	if !cmp.Equal(gotMDVal, wantMDVal) {

--- a/test/balancer_test.go
+++ b/test/balancer_test.go
@@ -902,8 +902,10 @@ func (wb *wrappedPickFirstBalancer) UpdateState(state balancer.State) {
 }
 
 const (
-	metadataHeaderInjectedByWrappedBalancer = "metadata-header-injected-by-wrapped-balancer"
-	metadataValueInjectedByWrappedBalancer  = "metadata-value-injected-by-wrapped-balancer"
+	metadataHeaderInjectedByBalancer    = "metadata-header-injected-by-balancer"
+	metadataHeaderInjectedByApplication = "metadata-header-injected-by-application"
+	metadataValueInjectedByBalancer     = "metadata-value-injected-by-balancer"
+	metadataValueInjectedByApplication  = "metadata-value-injected-by-application"
 )
 
 // wrappedPicker wraps the picker returned by the pick_first
@@ -918,9 +920,9 @@ func (wp *wrappedPicker) Pick(info balancer.PickInfo) (balancer.PickResult, erro
 	}
 
 	if res.Metatada == nil {
-		res.Metatada = metadata.Pairs(metadataHeaderInjectedByWrappedBalancer, metadataValueInjectedByWrappedBalancer)
+		res.Metatada = metadata.Pairs(metadataHeaderInjectedByBalancer, metadataValueInjectedByBalancer)
 	} else {
-		res.Metatada.Append(metadataHeaderInjectedByWrappedBalancer, metadataValueInjectedByWrappedBalancer)
+		res.Metatada.Append(metadataHeaderInjectedByBalancer, metadataValueInjectedByBalancer)
 	}
 	return res, nil
 }
@@ -929,16 +931,15 @@ func (wp *wrappedPicker) Pick(info balancer.PickInfo) (balancer.PickResult, erro
 // arbitrary metadata on a per-call basis and verifies that the injected
 // metadata makes it all the way to the server RPC handler.
 func (s) TestMetadataInPickResult(t *testing.T) {
-	mdChan := make(chan []string, 1)
+	t.Log("Starting test backend...")
+	mdChan := make(chan metadata.MD, 1)
 	ss := &stubserver.StubServer{
 		EmptyCallF: func(ctx context.Context, _ *testpb.Empty) (*testpb.Empty, error) {
-			md, ok := metadata.FromIncomingContext(ctx)
-			if ok {
-				select {
-				case mdChan <- md[metadataHeaderInjectedByWrappedBalancer]:
-				case <-ctx.Done():
-					return nil, ctx.Err()
-				}
+			md, _ := metadata.FromIncomingContext(ctx)
+			select {
+			case mdChan <- md:
+			case <-ctx.Done():
+				return nil, ctx.Err()
 			}
 			return &testpb.Empty{}, nil
 		},
@@ -949,10 +950,12 @@ func (s) TestMetadataInPickResult(t *testing.T) {
 	defer ss.Stop()
 	t.Logf("Started test backend at %q", ss.Address)
 
+	name := t.Name() + "wrappedPickFirstBalancer"
+	t.Logf("Registering test balancer with name %q...", name)
 	b := &wrappedPickFirstBalancerBuilder{name: t.Name() + "wrappedPickFirstBalancer"}
 	balancer.Register(b)
-	t.Logf("Registered test balancer with name %q", b.Name())
 
+	t.Log("Creating ClientConn to test backend...")
 	r := manual.NewBuilderWithScheme("whatever")
 	r.InitialState(resolver.State{Addresses: []resolver.Address{{Addr: ss.Address}}})
 	dopts := []grpc.DialOption{
@@ -966,23 +969,36 @@ func (s) TestMetadataInPickResult(t *testing.T) {
 	}
 	defer cc.Close()
 	tc := testpb.NewTestServiceClient(cc)
-	t.Log("Created ClientConn to test backend")
 
+	t.Log("Making EmptyCall() RPC with custom metadata...")
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
+	md := metadata.Pairs(metadataHeaderInjectedByApplication, metadataValueInjectedByApplication)
+	ctx = metadata.NewOutgoingContext(ctx, md)
 	if _, err := tc.EmptyCall(ctx, &testpb.Empty{}); err != nil {
 		t.Fatalf("EmptyCall() RPC: %v", err)
 	}
 	t.Log("EmptyCall() RPC succeeded")
 
-	var gotMD []string
+	t.Log("Waiting for custom metadata to be received at the test backend...")
+	var gotMD metadata.MD
 	select {
 	case gotMD = <-mdChan:
 	case <-ctx.Done():
-		t.Fatalf("Timed out waiting for custom metadata in test backend")
+		t.Fatalf("Timed out waiting for custom metadata to be received at the test backend")
 	}
-	wantMD := []string{metadataValueInjectedByWrappedBalancer}
-	if !cmp.Equal(gotMD, wantMD) {
-		t.Fatalf("Mismatch in custom metadata received at test backend, got: %v, want %v", gotMD, wantMD)
+
+	t.Log("Veirfying custom metadata added by the client application is recieved at the test backend...")
+	wantMDVal := []string{metadataValueInjectedByApplication}
+	gotMDVal := gotMD.Get(metadataHeaderInjectedByApplication)
+	if !cmp.Equal(gotMDVal, wantMDVal) {
+		t.Fatalf("Mismatch in custom metadata received at test backend, got: %v, want %v", gotMDVal, wantMDVal)
+	}
+
+	t.Log("Veirfying custom metadata added by the LB policy is recieved at the test backend...")
+	wantMDVal = []string{metadataValueInjectedByBalancer}
+	gotMDVal = gotMD.Get(metadataHeaderInjectedByBalancer)
+	if !cmp.Equal(gotMDVal, wantMDVal) {
+		t.Fatalf("Mismatch in custom metadata received at test backend, got: %v, want %v", gotMDVal, wantMDVal)
 	}
 }


### PR DESCRIPTION
Summary of changes:
- New field added to `balancer.PickResult`. LB policies can use this to inject per-call arbitrary metadata.
- Arbitrary metadata returned by LB policies is then plumbed all the way to the place where new streams are created, and these are sent out as part of the HEADERS frame.

RELEASE NOTES:
- balancer: support injection of per-call metadata from LB policies