### PR TITLE
transport: Fix closing a closed channel panic in handlePing

### DIFF
--- a/internal/transport/http2_server.go
+++ b/internal/transport/http2_server.go
@@ -42,6 +42,7 @@ import (
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/internal/channelz"
 	"google.golang.org/grpc/internal/grpcrand"
+	"google.golang.org/grpc/internal/grpcsync"
 	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/peer"
@@ -102,16 +103,15 @@ type http2Server struct {
 
 	mu sync.Mutex // guard the following
 
-	// drainChan is initialized when Drain() is called the first time.
-	// After which the server writes out the first GoAway(with ID 2^31-1) frame.
-	// Then an independent goroutine will be launched to later send the second GoAway.
-	// During this time we don't want to write another first GoAway(with ID 2^31 -1) frame.
-	// Thus call to Drain() will be a no-op if drainChan is already initialized since draining is
-	// already underway.
-	drainChan               chan struct{}
-	firstGoAwayPingReceived bool
-	state                   transportState
-	activeStreams           map[uint32]*Stream
+	// drainEvent is initialized when Drain() is called the first time. After
+	// which the server writes out the first GoAway(with ID 2^31-1) frame. Then
+	// an independent goroutine will be launched to later send the second
+	// GoAway. During this time we don't want to write another first GoAway(with
+	// ID 2^31 -1) frame. Thus call to Drain() will be a no-op if drainEvent is
+	// already initialized since draining is already underway.
+	drainEvent    *grpcsync.Event
+	state         transportState
+	activeStreams map[uint32]*Stream
 	// idle is the time instant when the connection went idle.
 	// This is either the beginning of the connection or when the number of
 	// RPCs go down to 0.
@@ -839,11 +839,8 @@ const (
 
 func (t *http2Server) handlePing(f *http2.PingFrame) {
 	if f.IsAck() {
-		if f.Data == goAwayPing.data && t.drainChan != nil {
-			if !t.firstGoAwayPingReceived {
-				close(t.drainChan)
-			}
-			t.firstGoAwayPingReceived = true
+		if f.Data == goAwayPing.data && t.drainEvent != nil {
+			t.drainEvent.Fire()
 			return
 		}
 		// Maybe it's a BDP ping.
@@ -1291,10 +1288,10 @@ func (t *http2Server) RemoteAddr() net.Addr {
 func (t *http2Server) Drain() {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	if t.drainChan != nil {
+	if t.drainEvent != nil {
 		return
 	}
-	t.drainChan = make(chan struct{})
+	t.drainEvent = grpcsync.NewEvent()
 	t.controlBuf.put(&goAway{code: http2.ErrCodeNo, debugData: []byte{}, headsUp: true})
 }
 
@@ -1350,7 +1347,7 @@ func (t *http2Server) outgoingGoAwayHandler(g *goAway) (bool, error) {
 		timer := time.NewTimer(time.Minute)
 		defer timer.Stop()
 		select {
-		case <-t.drainChan:
+		case <-t.drainEvent.Done():
 		case <-timer.C:
 		case <-t.done:
 			return

--- a/test/goaway_test.go
+++ b/test/goaway_test.go
@@ -741,7 +741,7 @@ func (s) TestTwoGoAwayPingFrames(t *testing.T) {
 			case *http2.PingFrame:
 				pingReceivedClientSide.Send(nil)
 			default:
-				t.Fatalf("server tester received unexpected frame type %T", f)
+				t.Errorf("server tester received unexpected frame type %T", f)
 			}
 		}
 	}()

--- a/test/goaway_test.go
+++ b/test/goaway_test.go
@@ -720,6 +720,7 @@ func (s) TestTwoGoAwayPingFrames(t *testing.T) {
 	}
 	defer lis.Close()
 	s := grpc.NewServer()
+	defer s.Stop()
 	go s.Serve(lis)
 
 	conn, err := net.DialTimeout("tcp", lis.Addr().String(), defaultTestTimeout)
@@ -756,8 +757,8 @@ func (s) TestTwoGoAwayPingFrames(t *testing.T) {
 		t.Fatalf("Error waiting for ping frame client side from graceful shutdown: %v", err)
 	}
 	// Write two goaway pings here.
-	st.writeGoAwayPing(true, [8]byte{1, 6, 1, 8, 0, 3, 3, 9})
-	st.writeGoAwayPing(true, [8]byte{1, 6, 1, 8, 0, 3, 3, 9})
+	st.writePing(true, [8]byte{1, 6, 1, 8, 0, 3, 3, 9})
+	st.writePing(true, [8]byte{1, 6, 1, 8, 0, 3, 3, 9})
 	// Close the conn to finish up the Graceful Shutdown process.
 	conn.Close()
 	if _, err := gsDone.Receive(ctx); err != nil {

--- a/test/goaway_test.go
+++ b/test/goaway_test.go
@@ -363,6 +363,7 @@ func testServerMultipleGoAwayPendingRPC(t *testing.T, e env) {
 		close(ch2)
 	}()
 	// Loop until the server side GoAway signal is propagated to the client.
+
 	for {
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
 		if _, err := tc.EmptyCall(ctx, &testpb.Empty{}, grpc.WaitForReady(true)); err != nil {
@@ -402,6 +403,7 @@ func testServerMultipleGoAwayPendingRPC(t *testing.T, e env) {
 	if err := stream.CloseSend(); err != nil {
 		t.Fatalf("%v.CloseSend() = %v, want <nil>", stream, err)
 	}
+
 	<-ch1
 	<-ch2
 	cancel()
@@ -706,4 +708,59 @@ func (s) TestGoAwayStreamIDSmallerThanCreatedStreams(t *testing.T) {
 	<-someStreamsCreated.Done()
 	ct.writeGoAway(1, http2.ErrCodeNo, []byte{})
 	goAwayWritten.Fire()
+}
+
+// TestTwoGoAwayPingFrames tests the scenario where you get two go away ping
+// frames from the client during graceful shutdown. This should not crash the
+// server.
+func (s) TestTwoGoAwayPingFrames(t *testing.T) {
+	lis, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("Failed to listen: %v", err)
+	}
+	defer lis.Close()
+	s := grpc.NewServer()
+	go s.Serve(lis)
+
+	conn, err := net.DialTimeout("tcp", lis.Addr().String(), defaultTestTimeout)
+	if err != nil {
+		t.Fatalf("Failed to dial: %v", err)
+	}
+
+	st := newServerTesterFromConn(t, conn)
+	st.greet()
+	pingReceivedClientSide := testutils.NewChannel()
+	go func() {
+		for {
+			f, err := st.readFrame()
+			if err != nil {
+				return
+			}
+			switch f.(type) {
+			case *http2.GoAwayFrame:
+			case *http2.PingFrame:
+				pingReceivedClientSide.Send(nil)
+			default:
+				t.Fatalf("server tester received unexpected frame type %T", f)
+			}
+		}
+	}()
+	gsDone := testutils.NewChannel()
+	go func() {
+		s.GracefulStop()
+		gsDone.Send(nil)
+	}()
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	if _, err := pingReceivedClientSide.Receive(ctx); err != nil {
+		t.Fatalf("Error waiting for ping frame client side from graceful shutdown: %v", err)
+	}
+	// Write two goaway pings here.
+	st.writeGoAwayPing(true, [8]byte{1, 6, 1, 8, 0, 3, 3, 9})
+	st.writeGoAwayPing(true, [8]byte{1, 6, 1, 8, 0, 3, 3, 9})
+	// Close the conn to finish up the Graceful Shutdown process.
+	conn.Close()
+	if _, err := gsDone.Receive(ctx); err != nil {
+		t.Fatalf("Error waiting for graceful shutdown of the server: %v", err)
+	}
 }

--- a/test/servertester.go
+++ b/test/servertester.go
@@ -274,7 +274,7 @@ func (st *serverTester) writeRSTStream(streamID uint32, code http2.ErrCode) {
 	}
 }
 
-func (st *serverTester) writeGoAwayPing(ack bool, data [8]byte) {
+func (st *serverTester) writePing(ack bool, data [8]byte) {
 	if err := st.fr.WritePing(ack, data); err != nil {
 		st.t.Fatalf("Error writing PING: %v", err)
 	}

--- a/test/servertester.go
+++ b/test/servertester.go
@@ -273,3 +273,9 @@ func (st *serverTester) writeRSTStream(streamID uint32, code http2.ErrCode) {
 		st.t.Fatalf("Error writing RST_STREAM: %v", err)
 	}
 }
+
+func (st *serverTester) writeGoAwayPing(ack bool, data [8]byte) {
+	if err := st.fr.WritePing(ack, data); err != nil {
+		st.t.Fatalf("Error writing PING: %v", err)
+	}
+}


### PR DESCRIPTION
Partially addresses #5786. Two GoAway pings were previously closing a closed channel, this PR adds protection with respect to the drainChan closing (used as a signal to write second GoAway frame). We still to derive the underlying root cause as to why two goaway ping acks are being sent from the Swift client.


RELEASE NOTES:
* transport: Fixed closing a closed channel panic in handlePing