### PR TITLE
balancer: cleanup of deprecated ClientConn.Target()

### DIFF
--- a/clientconn_parsed_target_test.go
+++ b/clientconn_parsed_target_test.go
@@ -40,46 +40,50 @@ func (s) TestParsedTarget_Success_WithoutCustomDialer(t *testing.T) {
 		wantParsed resolver.Target
 	}{
 		// No scheme is specified.
-		{target: "://", badScheme: true, wantParsed: resolver.Target{Scheme: defScheme, Authority: "", Endpoint: "://"}},
-		{target: ":///", badScheme: true, wantParsed: resolver.Target{Scheme: defScheme, Authority: "", Endpoint: ":///"}},
-		{target: "://a/", badScheme: true, wantParsed: resolver.Target{Scheme: defScheme, Authority: "", Endpoint: "://a/"}},
-		{target: ":///a", badScheme: true, wantParsed: resolver.Target{Scheme: defScheme, Authority: "", Endpoint: ":///a"}},
-		{target: "://a/b", badScheme: true, wantParsed: resolver.Target{Scheme: defScheme, Authority: "", Endpoint: "://a/b"}},
-		{target: "/", badScheme: true, wantParsed: resolver.Target{Scheme: defScheme, Authority: "", Endpoint: "/"}},
-		{target: "a/b", badScheme: true, wantParsed: resolver.Target{Scheme: defScheme, Authority: "", Endpoint: "a/b"}},
-		{target: "a//b", badScheme: true, wantParsed: resolver.Target{Scheme: defScheme, Authority: "", Endpoint: "a//b"}},
-		{target: "google.com", badScheme: true, wantParsed: resolver.Target{Scheme: defScheme, Authority: "", Endpoint: "google.com"}},
-		{target: "google.com/?a=b", badScheme: true, wantParsed: resolver.Target{Scheme: defScheme, Authority: "", Endpoint: "google.com/"}},
-		{target: "/unix/socket/address", badScheme: true, wantParsed: resolver.Target{Scheme: defScheme, Authority: "", Endpoint: "/unix/socket/address"}},
+		{target: "://", badScheme: true, wantParsed: resolver.Target{URL: url.URL{Scheme: defScheme, Host: "", Path: "/://"}}},
+		{target: ":///", badScheme: true, wantParsed: resolver.Target{URL: url.URL{Scheme: defScheme, Host: "", Path: "/:///"}}},
+		{target: "://a/", badScheme: true, wantParsed: resolver.Target{URL: url.URL{Scheme: defScheme, Host: "", Path: "/://a/"}}},
+		{target: ":///a", badScheme: true, wantParsed: resolver.Target{URL: url.URL{Scheme: defScheme, Host: "", Path: "/:///a"}}},
+		{target: "://a/b", badScheme: true, wantParsed: resolver.Target{URL: url.URL{Scheme: defScheme, Host: "", Path: "/://a/b"}}},
+		{target: "/", badScheme: true, wantParsed: resolver.Target{URL: url.URL{Scheme: defScheme, Host: "", Path: "//"}}},
+		{target: "a/b", badScheme: true, wantParsed: resolver.Target{URL: url.URL{Scheme: defScheme, Host: "", Path: "/a/b"}}},
+		{target: "a//b", badScheme: true, wantParsed: resolver.Target{URL: url.URL{Scheme: defScheme, Host: "", Path: "/a//b"}}},
+		{target: "google.com", badScheme: true, wantParsed: resolver.Target{URL: url.URL{Scheme: defScheme, Host: "", Path: "/google.com"}}},
+		{target: "google.com/?a=b", badScheme: true, wantParsed: resolver.Target{
+			URL: url.URL{Scheme: defScheme, Host: "", Path: "/google.com/", RawQuery: "a=b"}}},
+		{target: "/unix/socket/address", badScheme: true, wantParsed: resolver.Target{
+			URL: url.URL{Scheme: defScheme, Host: "", Path: "//unix/socket/address"}}},
 
 		// An unregistered scheme is specified.
-		{target: "a:///", badScheme: true, wantParsed: resolver.Target{Scheme: defScheme, Authority: "", Endpoint: "a:///"}},
-		{target: "a://b/", badScheme: true, wantParsed: resolver.Target{Scheme: defScheme, Authority: "", Endpoint: "a://b/"}},
-		{target: "a:///b", badScheme: true, wantParsed: resolver.Target{Scheme: defScheme, Authority: "", Endpoint: "a:///b"}},
-		{target: "a://b/c", badScheme: true, wantParsed: resolver.Target{Scheme: defScheme, Authority: "", Endpoint: "a://b/c"}},
-		{target: "a:b", badScheme: true, wantParsed: resolver.Target{Scheme: defScheme, Authority: "", Endpoint: "a:b"}},
-		{target: "a:/b", badScheme: true, wantParsed: resolver.Target{Scheme: defScheme, Authority: "", Endpoint: "a:/b"}},
-		{target: "a://b", badScheme: true, wantParsed: resolver.Target{Scheme: defScheme, Authority: "", Endpoint: "a://b"}},
+		{target: "a:///", badScheme: true, wantParsed: resolver.Target{URL: url.URL{Scheme: defScheme, Host: "", Path: "/a:///"}}},
+		{target: "a://b/", badScheme: true, wantParsed: resolver.Target{URL: url.URL{Scheme: defScheme, Host: "", Path: "/a://b/"}}},
+		{target: "a:///b", badScheme: true, wantParsed: resolver.Target{URL: url.URL{Scheme: defScheme, Host: "", Path: "/a:///b"}}},
+		{target: "a://b/c", badScheme: true, wantParsed: resolver.Target{URL: url.URL{Scheme: defScheme, Host: "", Path: "/a://b/c"}}},
+		{target: "a:b", badScheme: true, wantParsed: resolver.Target{URL: url.URL{Scheme: defScheme, Host: "", Path: "/a:b"}}},
+		{target: "a:/b", badScheme: true, wantParsed: resolver.Target{URL: url.URL{Scheme: defScheme, Host: "", Path: "/a:/b"}}},
+		{target: "a://b", badScheme: true, wantParsed: resolver.Target{URL: url.URL{Scheme: defScheme, Host: "", Path: "/a://b"}}},
 
 		// A registered scheme is specified.
-		{target: "dns:///google.com", wantParsed: resolver.Target{Scheme: "dns", Authority: "", Endpoint: "google.com"}},
-		{target: "dns://a.server.com/google.com", wantParsed: resolver.Target{Scheme: "dns", Authority: "a.server.com", Endpoint: "google.com"}},
-		{target: "dns://a.server.com/google.com/?a=b", wantParsed: resolver.Target{Scheme: "dns", Authority: "a.server.com", Endpoint: "google.com/"}},
-		{target: "unix:///a/b/c", wantParsed: resolver.Target{Scheme: "unix", Authority: "", Endpoint: "a/b/c"}},
-		{target: "unix-abstract:a/b/c", wantParsed: resolver.Target{Scheme: "unix-abstract", Authority: "", Endpoint: "a/b/c"}},
-		{target: "unix-abstract:a b", wantParsed: resolver.Target{Scheme: "unix-abstract", Authority: "", Endpoint: "a b"}},
-		{target: "unix-abstract:a:b", wantParsed: resolver.Target{Scheme: "unix-abstract", Authority: "", Endpoint: "a:b"}},
-		{target: "unix-abstract:a-b", wantParsed: resolver.Target{Scheme: "unix-abstract", Authority: "", Endpoint: "a-b"}},
-		{target: "unix-abstract:/ a///://::!@#$%25^&*()b", wantParsed: resolver.Target{Scheme: "unix-abstract", Authority: "", Endpoint: " a///://::!@"}},
-		{target: "unix-abstract:passthrough:abc", wantParsed: resolver.Target{Scheme: "unix-abstract", Authority: "", Endpoint: "passthrough:abc"}},
-		{target: "unix-abstract:unix:///abc", wantParsed: resolver.Target{Scheme: "unix-abstract", Authority: "", Endpoint: "unix:///abc"}},
-		{target: "unix-abstract:///a/b/c", wantParsed: resolver.Target{Scheme: "unix-abstract", Authority: "", Endpoint: "a/b/c"}},
-		{target: "unix-abstract:///", wantParsed: resolver.Target{Scheme: "unix-abstract", Authority: "", Endpoint: ""}},
-		{target: "passthrough:///unix:///a/b/c", wantParsed: resolver.Target{Scheme: "passthrough", Authority: "", Endpoint: "unix:///a/b/c"}},
+		{target: "dns:///google.com", wantParsed: resolver.Target{URL: url.URL{Scheme: "dns", Host: "", Path: "/google.com"}}},
+		{target: "dns://a.server.com/google.com", wantParsed: resolver.Target{
+			URL: url.URL{Scheme: "dns", Host: "a.server.com", Path: "/google.com"}}},
+		{target: "dns://a.server.com/google.com/?a=b", wantParsed: resolver.Target{
+			URL: url.URL{Scheme: "dns", Host: "a.server.com", Path: "/google.com/", RawQuery: "a=b"}}},
+		{target: "unix:///a/b/c", wantParsed: resolver.Target{URL: url.URL{Scheme: "unix", Host: "", Path: "/a/b/c"}}},
+		{target: "unix-abstract:a/b/c", wantParsed: resolver.Target{URL: url.URL{Scheme: "unix-abstract", Host: "", Opaque: "a/b/c"}}},
+		{target: "unix-abstract:a b", wantParsed: resolver.Target{URL: url.URL{Scheme: "unix-abstract", Host: "", Opaque: "a b"}}},
+		{target: "unix-abstract:a:b", wantParsed: resolver.Target{URL: url.URL{Scheme: "unix-abstract", Host: "", Opaque: "a:b"}}},
+		{target: "unix-abstract:a-b", wantParsed: resolver.Target{}},
+		{target: "unix-abstract:/ a///://::!@#$%25^&*()b", wantParsed: resolver.Target{}},
+		{target: "unix-abstract:passthrough:abc", wantParsed: resolver.Target{URL: url.URL{Scheme: "unix-abstract", Opaque: "passthrough:abc"}}},
+		{target: "unix-abstract:unix:///abc", wantParsed: resolver.Target{URL: url.URL{Scheme: "unix-abstract", Opaque: "unix:///abc"}}},
+		{target: "unix-abstract:///a/b/c", wantParsed: resolver.Target{URL: url.URL{Scheme: "unix-abstract", Path: "/a/b/c"}}},
+		{target: "unix-abstract:///", wantParsed: resolver.Target{URL: url.URL{Scheme: "unix-abstract", Path: "/"}}},
+		{target: "passthrough:///unix:///a/b/c", wantParsed: resolver.Target{URL: url.URL{Scheme: "passthrough", Path: "/unix:///a/b/c"}}},
 
 		// Cases for `scheme:absolute-path`.
-		{target: "dns:/a/b/c", wantParsed: resolver.Target{Scheme: "dns", Authority: "", Endpoint: "a/b/c"}},
-		{target: "unregistered:/a/b/c", badScheme: true, wantParsed: resolver.Target{Scheme: defScheme, Authority: "", Endpoint: "unregistered:/a/b/c"}},
+		{target: "dns:/a/b/c", wantParsed: resolver.Target{URL: url.URL{Scheme: "dns", Path: "/a/b/c", OmitHost: true}}},
+		{target: "unregistered:/a/b/c", badScheme: true, wantParsed: resolver.Target{URL: url.URL{Scheme: defScheme, Path: "/unregistered:/a/b/c"}}},
 	}
 
 	for _, test := range tests {
@@ -92,7 +96,9 @@ func (s) TestParsedTarget_Success_WithoutCustomDialer(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Unexpected error parsing URL: %v", err)
 			}
-			test.wantParsed.URL = *url
+			if test.wantParsed.URL.Scheme == "" {
+				test.wantParsed.URL = *url
+			}
 
 			cc, err := Dial(test.target, WithTransportCredentials(insecure.NewCredentials()))
 			if err != nil {
@@ -100,8 +106,8 @@ func (s) TestParsedTarget_Success_WithoutCustomDialer(t *testing.T) {
 			}
 			defer cc.Close()
 
-			if !cmp.Equal(cc.parsedTarget, test.wantParsed) {
-				t.Errorf("cc.parsedTarget for dial target %q = %+v, want %+v", test.target, cc.parsedTarget, test.wantParsed)
+			if !cmp.Equal(cc.parsedTarget.URL, test.wantParsed.URL) {
+				t.Errorf("cc.parsedTarget.URL for dial target %q = %+v, want %+v", test.target, cc.parsedTarget.URL, test.wantParsed.URL)
 			}
 		})
 	}
@@ -138,56 +144,62 @@ func (s) TestParsedTarget_WithCustomDialer(t *testing.T) {
 		// different behaviors with a custom dialer.
 		{
 			target:            "unix:a/b/c",
-			wantParsed:        resolver.Target{Scheme: "unix", Authority: "", Endpoint: "a/b/c"},
+			wantParsed:        resolver.Target{URL: url.URL{Scheme: "unix", Host: "", Opaque: "a/b/c"}},
 			wantDialerAddress: "unix:a/b/c",
 		},
 		{
 			target:            "unix:/a/b/c",
-			wantParsed:        resolver.Target{Scheme: "unix", Authority: "", Endpoint: "a/b/c"},
+			wantParsed:        resolver.Target{URL: url.URL{Scheme: "unix", Host: "", OmitHost: true, Path: "/a/b/c"}},
 			wantDialerAddress: "unix:///a/b/c",
 		},
 		{
 			target:            "unix:///a/b/c",
-			wantParsed:        resolver.Target{Scheme: "unix", Authority: "", Endpoint: "a/b/c"},
+			wantParsed:        resolver.Target{URL: url.URL{Scheme: "unix", Host: "", Path: "/a/b/c"}},
 			wantDialerAddress: "unix:///a/b/c",
 		},
+
 		{
 			target:            "dns:///127.0.0.1:50051",
-			wantParsed:        resolver.Target{Scheme: "dns", Authority: "", Endpoint: "127.0.0.1:50051"},
+			wantParsed:        resolver.Target{URL: url.URL{Scheme: "dns", Host: "", Path: "/127.0.0.1:50051"}},
 			wantDialerAddress: "127.0.0.1:50051",
 		},
+
 		{
 			target:            ":///127.0.0.1:50051",
 			badScheme:         true,
-			wantParsed:        resolver.Target{Scheme: defScheme, Authority: "", Endpoint: ":///127.0.0.1:50051"},
+			wantParsed:        resolver.Target{URL: url.URL{Scheme: defScheme, Host: "", Path: "/:///127.0.0.1:50051"}},
 			wantDialerAddress: ":///127.0.0.1:50051",
 		},
+
 		{
 			target:            "dns://authority/127.0.0.1:50051",
-			wantParsed:        resolver.Target{Scheme: "dns", Authority: "authority", Endpoint: "127.0.0.1:50051"},
+			wantParsed:        resolver.Target{URL: url.URL{Scheme: "dns", Host: "authority", Path: "/127.0.0.1:50051"}},
 			wantDialerAddress: "127.0.0.1:50051",
 		},
+
 		{
 			target:            "://authority/127.0.0.1:50051",
 			badScheme:         true,
-			wantParsed:        resolver.Target{Scheme: defScheme, Authority: "", Endpoint: "://authority/127.0.0.1:50051"},
+			wantParsed:        resolver.Target{URL: url.URL{Scheme: defScheme, Host: "", Path: "/://authority/127.0.0.1:50051"}},
 			wantDialerAddress: "://authority/127.0.0.1:50051",
 		},
+
 		{
 			target:            "/unix/socket/address",
 			badScheme:         true,
-			wantParsed:        resolver.Target{Scheme: defScheme, Authority: "", Endpoint: "/unix/socket/address"},
+			wantParsed:        resolver.Target{URL: url.URL{Scheme: defScheme, Host: "", Path: "//unix/socket/address"}},
 			wantDialerAddress: "/unix/socket/address",
 		},
+
 		{
 			target:            "",
 			badScheme:         true,
-			wantParsed:        resolver.Target{Scheme: defScheme, Authority: "", Endpoint: ""},
+			wantParsed:        resolver.Target{URL: url.URL{Scheme: defScheme, Host: "", Path: "/"}},
 			wantDialerAddress: "",
 		},
 		{
 			target:            "passthrough://a.server.com/google.com",
-			wantParsed:        resolver.Target{Scheme: "passthrough", Authority: "a.server.com", Endpoint: "google.com"},
+			wantParsed:        resolver.Target{URL: url.URL{Scheme: "passthrough", Host: "a.server.com", Path: "/google.com"}},
 			wantDialerAddress: "google.com",
 		},
 	}
@@ -202,11 +214,14 @@ func (s) TestParsedTarget_WithCustomDialer(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Unexpected error parsing URL: %v", err)
 			}
-			test.wantParsed.URL = *url
+			if test.wantParsed.URL.Scheme == "" {
+				test.wantParsed.URL = *url
+			}
 
 			addrCh := make(chan string, 1)
 			dialer := func(ctx context.Context, address string) (net.Conn, error) {
 				addrCh <- address
+				t.Log("passsing address:", address)
 				return nil, errors.New("dialer error")
 			}
 
@@ -224,8 +239,8 @@ func (s) TestParsedTarget_WithCustomDialer(t *testing.T) {
 			case <-time.After(time.Second):
 				t.Fatal("timeout when waiting for custom dialer to be invoked")
 			}
-			if !cmp.Equal(cc.parsedTarget, test.wantParsed) {
-				t.Errorf("cc.parsedTarget for dial target %q = %+v, want %+v", test.target, cc.parsedTarget, test.wantParsed)
+			if !cmp.Equal(cc.parsedTarget.URL, test.wantParsed.URL) {
+				t.Errorf("cc.parsedTarget.URL for dial target %q = %+v, want %+v", test.target, cc.parsedTarget.URL, test.wantParsed.URL)
 			}
 		})
 	}

--- a/internal/balancer/gracefulswitch/gracefulswitch.go
+++ b/internal/balancer/gracefulswitch/gracefulswitch.go
@@ -380,5 +380,5 @@ func (bw *balancerWrapper) UpdateAddresses(sc balancer.SubConn, addrs []resolver
 }
 
 func (bw *balancerWrapper) Target() string {
-	return bw.gsb.cc.Target()
+	return bw.gsb.bOpts.Target.URL.String()
 }

--- a/xds/internal/balancer/outlierdetection/balancer.go
+++ b/xds/internal/balancer/outlierdetection/balancer.go
@@ -62,6 +62,7 @@ type bb struct{}
 
 func (bb) Build(cc balancer.ClientConn, bOpts balancer.BuildOptions) balancer.Balancer {
 	b := &outlierDetectionBalancer{
+		bOpts:          bOpts,
 		cc:             cc,
 		closed:         grpcsync.NewEvent(),
 		done:           grpcsync.NewEvent(),
@@ -161,6 +162,7 @@ type outlierDetectionBalancer struct {
 
 	closed *grpcsync.Event
 	done   *grpcsync.Event
+	bOpts  balancer.BuildOptions
 	cc     balancer.ClientConn
 	logger *grpclog.PrefixLogger
 
@@ -577,7 +579,7 @@ func (b *outlierDetectionBalancer) ResolveNow(opts resolver.ResolveNowOptions) {
 }
 
 func (b *outlierDetectionBalancer) Target() string {
-	return b.cc.Target()
+	return b.bOpts.Target.URL.String()
 }
 
 func max(x, y int64) int64 {


### PR DESCRIPTION
use Target field in the BuildOptions instead.

RELEASE NOTES: none