### PR TITLE
grpc: Add join Dial Option and OpenCensus instrumentation scaffolding

### DIFF
--- a/dialoptions.go
+++ b/dialoptions.go
@@ -44,6 +44,7 @@ func init() {
 		extraDialOptions = nil
 	}
 	internal.WithBinaryLogger = withBinaryLogger
+	internal.JoinDialOptions = newJoinDialOption
 }
 
 // dialOptions configure a Dial call. dialOptions are set by the DialOption
@@ -109,6 +110,20 @@ func newFuncDialOption(f func(*dialOptions)) *funcDialOption {
 	return &funcDialOption{
 		f: f,
 	}
+}
+
+type joinDialOption struct {
+	opts []DialOption
+}
+
+func (jdo *joinDialOption) apply(do *dialOptions) {
+	for _, opt := range jdo.opts {
+		opt.apply(do)
+	}
+}
+
+func newJoinDialOption(opts ...DialOption) DialOption {
+	return &joinDialOption{opts: opts}
 }
 
 // WithWriteBufferSize determines how much data can be batched before doing a

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -77,6 +77,9 @@ var (
 	// ClearGlobalDialOptions clears the array of extra DialOption. This
 	// method is useful in testing and benchmarking.
 	ClearGlobalDialOptions func()
+	// JoinDialOptions combines the dial options passed as arguments into a
+	// single dial option.
+	JoinDialOptions interface{}
 	// JoinServerOptions combines the server options passed as arguments into a
 	// single server option.
 	JoinServerOptions interface{} // func(...grpc.ServerOption) grpc.ServerOption

--- a/opencensus/opencensus.go
+++ b/opencensus/opencensus.go
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2022 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package opencensus implements opencensus instrumentation code for gRPC-Go
+// clients and servers.
+package opencensus
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/internal"
+	"google.golang.org/grpc/stats"
+)
+
+var (
+	joinDialOptions = internal.JoinDialOptions.(func(...grpc.DialOption) grpc.DialOption)
+)
+
+// DialOption returns a dial option which enables OpenCensus instrumentation
+// code for a grpc.ClientConn.
+//
+// Client Applications interested in instrumenting their grpc.ClientConn should
+// pass the dial option returned from this function as the first dial option to
+// grpc.Dial().
+//
+// Using this option will always lead to instrumentation, however in order to
+// use the data an exporter must be registered with the OpenCensus trace package
+// for traces and the OpenCensus view package for metrics. Client Side has
+// retries, so a Unary and Streaming Interceptor are registered to handle per
+// RPC traces/metrics, and a Stats Handler is registered to handle per RPC
+// attempt trace/metrics. These three components registered work together in
+// conjunction, and do not work standalone.
+func DialOption() grpc.DialOption {
+	return joinDialOptions(grpc.WithChainUnaryInterceptor(unaryInterceptor), grpc.WithChainStreamInterceptor(streamInterceptor), grpc.WithStatsHandler(&clientStatsHandler{}))
+}
+
+// ServerOption returns a server option which enables OpenCensus instrumentation
+// code for a grpc.Server.
+//
+// Server applications interested in instrumenting their grpc.Server should
+// pass the server option returned from this function as the first argument to
+// grpc.NewServer().
+//
+// Using this option will always lead to instrumentation, however in order to
+// use the data an exporter must be registered with the OpenCensus trace package
+// for traces and the OpenCensus view package for metrics. Server Side does not
+// have retries, so a registered Stats Handler is the only component you need
+// for RPC traces/metrics.
+func ServerOption() grpc.ServerOption {
+	return grpc.StatsHandler(&serverStatsHandler{})
+}
+
+// unaryInterceptor handles per RPC context management. It also handles per RPC
+// tracing and stats.
+func unaryInterceptor(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+	return invoker(ctx, method, req, reply, cc, opts...)
+}
+
+// streamInterceptor handles per RPC context management. It also handles per RPC
+// tracing and stats.
+func streamInterceptor(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+	return streamer(ctx, desc, cc, method, opts...)
+}
+
+type clientStatsHandler struct{}
+
+// TagConn exists to satisfy stats.Handler.
+func (csh *clientStatsHandler) TagConn(ctx context.Context, _ *stats.ConnTagInfo) context.Context {
+	return ctx
+}
+
+// HandleConn exists to satisfy stats.Handler.
+func (csh *clientStatsHandler) HandleConn(context.Context, stats.ConnStats) {}
+
+// TagRPC implements per RPC attempt context management.
+func (csh *clientStatsHandler) TagRPC(ctx context.Context, _ *stats.RPCTagInfo) context.Context {
+	return ctx
+}
+
+// HandleRPC handles per RPC attempt tracing and stats instrumentation.
+func (csh *clientStatsHandler) HandleRPC(context.Context, stats.RPCStats) {}
+
+type serverStatsHandler struct{}
+
+// TagConn exists to satisfy stats.Handler.
+func (ssh *serverStatsHandler) TagConn(ctx context.Context, _ *stats.ConnTagInfo) context.Context {
+	return ctx
+}
+
+// HandleConn exists to satisfy stats.Handler.
+func (ssh *serverStatsHandler) HandleConn(context.Context, stats.ConnStats) {}
+
+// TagRPC implements per RPC context management.
+func (ssh *serverStatsHandler) TagRPC(ctx context.Context, _ *stats.RPCTagInfo) context.Context {
+	return ctx
+}
+
+// HandleRPC implements per RPC tracing and stats implementation.
+func (ssh *serverStatsHandler) HandleRPC(context.Context, stats.RPCStats) {}


### PR DESCRIPTION
This PR adds a join Dial Option and OpenCensus instrumentation scaffolding. The components are no-ops, with the correct docstrings which describe what each component does.

RELEASE NOTES: N/A