### PR TITLE
xdsclient: log node ID with verbosity INFO

### DIFF
--- a/xds/internal/xdsclient/singleton.go
+++ b/xds/internal/xdsclient/singleton.go
@@ -91,8 +91,8 @@ func newRefCountedWithConfig(config *bootstrap.Config) (XDSClient, error) {
 	singletonClient.refCount++
 	singletonClientImplCreateHook()
 	nodeID := "<unknown>"
-	if id, ok := config.XDSServer.NodeProto.(interface{ GetId() string }); ok {
-		nodeID = id.GetId()
+	if node, ok := config.XDSServer.NodeProto.(interface{ GetId() string }); ok {
+		nodeID = node.GetId()
 	}
 	logger.Infof("xDS node ID: %s", nodeID)
 	return &onceClosingClient{XDSClient: singletonClient}, nil

--- a/xds/internal/xdsclient/singleton.go
+++ b/xds/internal/xdsclient/singleton.go
@@ -90,7 +90,11 @@ func newRefCountedWithConfig(config *bootstrap.Config) (XDSClient, error) {
 	singletonClient.clientImpl = c
 	singletonClient.refCount++
 	singletonClientImplCreateHook()
-	logger.Info("xDS bootstrap: %s", c.BootstrapConfig().XDSServer.NodeProto.String())
+	nodeID := "<unknown>"
+	if id, ok := config.XDSServer.NodeProto.(interface{ GetId() string }); ok {
+		nodeID = id.GetId()
+	}
+	logger.Infof("xDS node ID: %s", nodeID)
 	return &onceClosingClient{XDSClient: singletonClient}, nil
 }
 

--- a/xds/internal/xdsclient/singleton.go
+++ b/xds/internal/xdsclient/singleton.go
@@ -90,6 +90,7 @@ func newRefCountedWithConfig(config *bootstrap.Config) (XDSClient, error) {
 	singletonClient.clientImpl = c
 	singletonClient.refCount++
 	singletonClientImplCreateHook()
+	logger.Info("xDS bootstrap: %s", c.BootstrapConfig().XDSServer.NodeProto.String())
 	return &onceClosingClient{XDSClient: singletonClient}, nil
 }
 


### PR DESCRIPTION
Log xDS bootstrap so that we can better debug DirectPath issues.

C++: https://github.com/grpc/grpc/pull/31797
Java: https://github.com/grpc/grpc-java/pull/9731

RELEASE NOTES:
* xdsclient: log node ID with verbosity INFO