### PR TITLE
rpc_util: Reuse memory buffer for receiving message

### DIFF
--- a/dialoptions.go
+++ b/dialoptions.go
@@ -76,6 +76,7 @@ type dialOptions struct {
 	defaultServiceConfig        *ServiceConfig // defaultServiceConfig is parsed from defaultServiceConfigRawJSON.
 	defaultServiceConfigRawJSON *string
 	resolvers                   []resolver.Builder
+	useBytesPoolForParser       bool
 }
 
 // DialOption configures how we set up the connection.
@@ -633,5 +634,19 @@ func withMinConnectDeadline(f func() time.Duration) DialOption {
 func WithResolvers(rs ...resolver.Builder) DialOption {
 	return newFuncDialOption(func(o *dialOptions) {
 		o.resolvers = append(o.resolvers, rs...)
+	})
+}
+
+// WithUseBytesPoolForParser returns a DialOption that specifies whether to use
+// a bytes pool for parsing. Setting this to true will reduce the memory allocation
+// in the parser.
+//
+// # Experimental
+//
+// Notice: This API is EXPERIMENTAL and may be changed or removed in a
+// later release.
+func WithUseBytesPoolForParser(useBytesPoolForParser bool) DialOption {
+	return newFuncDialOption(func(o *dialOptions) {
+		o.useBytesPoolForParser = useBytesPoolForParser
 	})
 }

--- a/rpc_util.go
+++ b/rpc_util.go
@@ -994,9 +994,9 @@ func (p *bytesPool) Get(size int) []byte {
 	if cap(*bs) < size {
 		*bs = make([]byte, size)
 		return *bs
-	} else {
-		return (*bs)[:size]
 	}
+
+	return (*bs)[:size]
 }
 
 func (p *bytesPool) Put(bs *[]byte) {

--- a/rpc_util.go
+++ b/rpc_util.go
@@ -760,7 +760,7 @@ func recv(p *parser, c baseCodec, s *transport.Stream, dc Decompressor, m interf
 	if err := c.Unmarshal(buf, m); err != nil {
 		return status.Errorf(codes.Internal, "grpc: failed to unmarshal the received message: %v", err)
 	}
-	if payInfo != nil {
+	if payInfo != nil && len(buf) != 0 {
 		payInfo.uncompressedBytes = make([]byte, len(buf))
 		copy(payInfo.uncompressedBytes, buf)
 	}

--- a/server.go
+++ b/server.go
@@ -174,6 +174,7 @@ type serverOptions struct {
 	maxHeaderListSize     *uint32
 	headerTableSize       *uint32
 	numServerWorkers      uint32
+	useBytesPoolForParser bool
 }
 
 var defaultServerOptions = serverOptions{
@@ -549,6 +550,19 @@ func NumStreamWorkers(numServerWorkers uint32) ServerOption {
 	// number of CPUs available is most performant; requires thorough testing.
 	return newFuncServerOption(func(o *serverOptions) {
 		o.numServerWorkers = numServerWorkers
+	})
+}
+
+// UseBytesPoolForParser returns a ServerOption that sets whether to use a bytes pool
+// for the parser. Setting this to true will reduce the memory allocation in the parser.
+//
+// # Experimental
+//
+// Notice: This API is EXPERIMENTAL and may be changed or removed in a
+// later release.
+func UseBytesPoolForParser(useBytesPoolForParser bool) ServerOption {
+	return newFuncServerOption(func(o *serverOptions) {
+		o.useBytesPoolForParser = useBytesPoolForParser
 	})
 }
 

--- a/stream.go
+++ b/stream.go
@@ -490,7 +490,7 @@ func (a *csAttempt) newStream() error {
 		return toRPCErr(nse.Err)
 	}
 	a.s = s
-	a.p = &parser{r: s}
+	a.p = &parser{r: s, useBytesPool: a.cs.cc.dopts.useBytesPoolForParser}
 	return nil
 }
 
@@ -1249,7 +1249,7 @@ func newNonRetryClientStream(ctx context.Context, desc *StreamDesc, method strin
 		return nil, err
 	}
 	as.s = s
-	as.p = &parser{r: s}
+	as.p = &parser{r: s, useBytesPool: ac.dopts.useBytesPoolForParser}
 	ac.incrCallsStarted()
 	if desc != unaryStreamDesc {
 		// Listen on cc and stream contexts to cleanup when the user closes the


### PR DESCRIPTION
This PR aims to reduce memory allocation in the receive message process. Using this with a stream-heavy workload can improve performance significantly.

RELEASE NOTES:

- rpc_util: reduce memory allocation for the message parsing process in streaming RPC