### PR TITLE
test: fix raceyness check to deflake test http server

### DIFF
--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -1055,7 +1055,7 @@ func (s) TestDetailedConnectionCloseErrorPropagatesToRpcError(t *testing.T) {
 	// The precise behavior of this test is subject to raceyness around the timing
 	// of when TCP packets are sent from client to server, and when we tell the
 	// server to stop, so we need to account for both possible error messages.
-	if _, err := stream.Recv(); !isConnClosedErr(err) {
+	if _, err := stream.Recv(); err == io.EOF || !isConnClosedErr(err) {
 		t.Fatalf("%v.Recv() = _, %v, want _, rpc error containing substring: %q OR %q", stream, err, possibleConnResetMsg, possibleEOFMsg)
 	}
 	close(rpcDoneOnClient)


### PR DESCRIPTION
The precise behavior of the test https server is subject a raceyness around the timing of when TCP packets are sent from client to server, and when we tell the server to stop, so we need to account for both of possible error messages

1. If the call to ss.S.Stop() causes the server's sockets to close while there's still in-fight data from the client on the TCP connection, then the kernel can send an RST back to the client (also see https://stackoverflow.com/questions/33053507/econnreset-in-send-linux-c). Note that while this condition is expected to be rare due to the rpcStartedOnServer synchronization, in theory it should be possible, e.g. if the client sends a BDP ping at the right time.
2. If, for example, the call to ss.S.Stop() happens after the RPC headers have been received at the server, then the TCP connection can shutdown gracefully when the server's socket closes. raceyness around checks if the error message when checking reading frames

This was accounted for in another end2end test. Had to replicate the same for the test HTTP server created in this package

Ran the test for 50K times on forge and no flakes found 

```
blaze test third_party/golang/grpc/test:test_test  --test_filter=Test/HTTPHeaderFrameErrorHandlingNormalTrailer --runs_per_test=50000 --test_env="GRPC_GO_LOG_SEVERITY_LEVEL=INFO" --test_env="GRPC_GO_LOG_VERBOSITY_LEVEL=99" --config=gotsan
Starting local Blaze server and connecting to it...
INFO: Streaming build results to: http://sponge2/d7546792-027d-449d-b60c-b89927a8c8b7
INFO: Analyzed target //third_party/golang/grpc/test:test_test (491 packages loaded, 13066 targets configured).
INFO: Found 1 test target...
Target //third_party/golang/grpc/test:test_test up-to-date:
  blaze-bin/third_party/golang/grpc/test/test_test
INFO: Elapsed time: 321.757s, Forge stats: 1847/51865 actions cached, 5.1h CPU used, 2.7m queue time, 1.53 GB ObjFS output (novel bytes: 120.3 MB), 0.0 MB local output, Critical Path: 157.26s, Remote (97.96% of the time): [queue: 0.00%, setup: 4.33%, process: 3.83%, retry: 77.95%]
//third_party/golang/grpc/test:test_test                                 PASSED in 128.9s
  Stats over 50000 runs: max = 128.9s, min = 0.4s, avg = 2.3s, dev = 7.2s

Executed 1 out of 1 test: 1 test passes.
There were tests whose specified size is too big. Use the --test_verbose_timeout_warnings command line option to see which ones these are.
INFO: Streaming build results to: http://sponge2/d7546792-027d-449d-b60c-b89927a8c8b7
INFO: Build completed successfully, 51845 total actions
```

Fixes #4990 

RELEASE NOTES:
* test: deflake test