### PR TITLE
rls: deflake tests

### DIFF
--- a/balancer/rls/balancer.go
+++ b/balancer/rls/balancer.go
@@ -436,6 +436,8 @@ func (b *rlsBalancer) Close() {
 	b.cacheMu.Lock()
 	b.dataCache.stop()
 	b.cacheMu.Unlock()
+
+	<-b.done.Done()
 }
 
 func (b *rlsBalancer) ExitIdle() {

--- a/balancer/rls/balancer_test.go
+++ b/balancer/rls/balancer_test.go
@@ -1080,7 +1080,9 @@ func (s) TestUpdateStatePauses(t *testing.T) {
 	//    ensures that the test does not flake because of this rare sequence of
 	//    events.
 	for s := cc.GetState(); s != connectivity.Ready; s = cc.GetState() {
-		cc.WaitForStateChange(ctx, s)
+		if !cc.WaitForStateChange(ctx, s) {
+			t.Fatal("Timeout when waiting for connectivity state to reach READY")
+		}
 	}
 
 	// Cache the state changes seen up to this point.

--- a/balancer/rls/helpers_test.go
+++ b/balancer/rls/helpers_test.go
@@ -21,7 +21,6 @@ package rls
 import (
 	"context"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -30,6 +29,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/internal"
 	"google.golang.org/grpc/internal/balancergroup"
+	"google.golang.org/grpc/internal/grpcsync"
 	"google.golang.org/grpc/internal/grpctest"
 	rlspb "google.golang.org/grpc/internal/proto/grpc_lookup_v1"
 	internalserviceconfig "google.golang.org/grpc/internal/serviceconfig"
@@ -104,15 +104,17 @@ func neverThrottlingThrottler() *fakeThrottler {
 	}
 }
 
-// oneTimeAllowingThrottler returns a fake throttler which does not throttle the
-// first request, but throttles everything that comes after. This is useful for
-// tests which need to set up a valid cache entry before testing other cases.
-func oneTimeAllowingThrottler() *fakeThrottler {
-	var once sync.Once
+// oneTimeAllowingThrottler returns a fake throttler which does not throttle
+// requests until the client RPC succeeds, but throttles everything that comes
+// after. This is useful for tests which need to set up a valid cache entry
+// before testing other cases.
+func oneTimeAllowingThrottler(firstRPCDone *grpcsync.Event) *fakeThrottler {
 	return &fakeThrottler{
 		throttleFunc: func() bool {
 			throttle := true
-			once.Do(func() { throttle = false })
+			if !firstRPCDone.HasFired() {
+				throttle = false
+			}
 			return throttle
 		},
 		throttleCh: make(chan struct{}, 1),

--- a/balancer/rls/helpers_test.go
+++ b/balancer/rls/helpers_test.go
@@ -110,14 +110,8 @@ func neverThrottlingThrottler() *fakeThrottler {
 // before testing other cases.
 func oneTimeAllowingThrottler(firstRPCDone *grpcsync.Event) *fakeThrottler {
 	return &fakeThrottler{
-		throttleFunc: func() bool {
-			throttle := true
-			if !firstRPCDone.HasFired() {
-				throttle = false
-			}
-			return throttle
-		},
-		throttleCh: make(chan struct{}, 1),
+		throttleFunc: firstRPCDone.HasFired,
+		throttleCh:   make(chan struct{}, 1),
 	}
 }
 

--- a/balancer/rls/picker_test.go
+++ b/balancer/rls/picker_test.go
@@ -791,14 +791,8 @@ func (s) TestPick_DataCacheHit_PendingEntryExists_ExpiredEntry(t *testing.T) {
 			// force us to send an RLS request which would block on the server,
 			// giving us a pending cache entry for the duration of the test.
 			go func() {
-				client := testgrpc.NewTestServiceClient(cc)
-				for {
-					select {
-					case <-ctx.Done():
-						return
-					default:
-						client.EmptyCall(ctx, &testpb.Empty{})
-					}
+				for client := testgrpc.NewTestServiceClient(cc); ctx.Err() == nil; <-time.After(defaultTestShortTimeout) {
+					client.EmptyCall(ctx, &testpb.Empty{})
 				}
 			}()
 			verifyRLSRequest(t, rlsReqCh, true)


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc-go/issues/5845.

Summary of changes:
- Split the close `called` and `done` events. This is required to ensure that all goroutines are shut down by the time `Close()` returns. This is pattern is followed in many other places in our codebase.
- Add a `dataCachePurgeHook` field to the `rlsBalancer` type, which is populated from the package global variable of the same name. This variable is overridden in tests to get notified when the data cache is purged. Without this change, the race detector was complaining of a data race.
- `TestUpdateStatePauses` uses a wrapped top-level LB policy which captures state updates returned by the RLS LB policy.  It was flaky because it was possible to miss the `READY` state update. The fix waits for the channel to be `READY` after the first successful RPC, before proceeding further.
- Multiple tests use `oneTimeAllowingThrottler()` helper function to return a throttler which allows only the first RLS request. But it turns out that more than one RLS request could be sent out as part of the first successful RPC (because the cache entry could expire before the child policy becomes `READY`). The fix is to change `oneTimeAllowingThrottler()` to allow all RLS requests until the first RPC is successful.
- `TestPick_DataCacheMiss_PendingEntryExists` verifies the scenario where a user RPC results in a data cache miss, but a pending entry exists. The test was flaky because it was not guaranteeing that the pending entry existed. The reason for this being `makeTestRPCAndVerifyError()` helper function, which uses a short context to make RPCs. The fix is to spawn a goroutine which makes an RPC with the test's context. This ensures that the pending entry exists for the duration of the test.
- `TestPick_DataCacheHit_PendingEntryExists_{Stale|Expired}Entry` verifies the scenario where a user RPC results in a data cache hit (which is either stale or expired), but the pending entry exists. This test was flaky because of how the interceptor was deciding whether to block the RLS request or not. The fix is to ensure that the first RPC is successful before starting to block incoming RPC requests. This fix is similar in logic to the fix made to `oneTimeAllowingThrottler()`.
- `TestConfigUpdate_ControlChannel` was flaky because of a rare race in `balancergroup` leading to a leak of a sub-balancer. The race is described in detail [here](https://github.com/grpc/grpc-go/issues/5845#issuecomment-1343806462). The fix is to unconditionally remove sub-balancers from the timeout cache eviction callback.
- `TestPick_DataCacheHit_PendingEntryExists_ExpiredEntry` was flaking because not being able to guarantee the pending cache entry. The fix ensures that a pending entry exists for the duration of the test.

With these fixes, I was able to run all tests under `grpc/balancer/rls` 100k without any flakes. The only test flaking currently is the one where we monitor the control channel connectivity state. Since that would require adding an internal API to get state changes in a lossless manner, I did not work on it as part of these fixes.

RELEASE NOTES: none