### PR TITLE
oauth: mark `NewOauthAccess` as deprecated and update examples to use `TokenSource`

### DIFF
--- a/Documentation/grpc-auth-support.md
+++ b/Documentation/grpc-auth-support.md
@@ -53,7 +53,7 @@ Alternatively, a client may also use the `grpc.CallOption`
 on each invocation of an RPC.
 
 To create a `credentials.PerRPCCredentials`, use
-[oauth.NewOauthAccess](https://godoc.org/google.golang.org/grpc/credentials/oauth#NewOauthAccess).
+[oauth.TokenSource](https://godoc.org/google.golang.org/grpc/credentials/oauth#TokenSource).
 Note, the OAuth2 implementation of `grpc.PerRPCCredentials` requires a client to use
 [grpc.WithTransportCredentials](https://godoc.org/google.golang.org/grpc#WithTransportCredentials)
 to prevent any insecure transmission of tokens.

--- a/credentials/oauth/oauth.go
+++ b/credentials/oauth/oauth.go
@@ -121,6 +121,8 @@ type oauthAccess struct {
 }
 
 // NewOauthAccess constructs the PerRPCCredentials using a given token.
+//
+// Deprecated: use oauth.TokenSource instead.
 func NewOauthAccess(token *oauth2.Token) credentials.PerRPCCredentials {
 	return oauthAccess{token: *token}
 }

--- a/examples/features/authentication/README.md
+++ b/examples/features/authentication/README.md
@@ -29,9 +29,9 @@ https://godoc.org/google.golang.org/grpc/credentials/oauth for details.
 
 #### Client
 
-On client side, users should first get a valid oauth token, and then call
-[`credentials.NewOauthAccess`](https://godoc.org/google.golang.org/grpc/credentials/oauth#NewOauthAccess)
-to initialize a `credentials.PerRPCCredentials` with it. Next, if user wants to
+On client side, users should first get a valid oauth token, and then initialize a
+[`oauth.TokenSource`](https://godoc.org/google.golang.org/grpc/credentials/oauth#TokenSource)
+which implements `credentials.PerRPCCredentials`. Next, if user wants to
 apply a single OAuth token for all RPC calls on the same connection, then
 configure grpc `Dial` with `DialOption`
 [`WithPerRPCCredentials`](https://godoc.org/google.golang.org/grpc#WithPerRPCCredentials).

--- a/examples/features/authentication/client/main.go
+++ b/examples/features/authentication/client/main.go
@@ -50,7 +50,7 @@ func main() {
 	flag.Parse()
 
 	// Set up the credentials for the connection.
-	perRPC := oauth.NewOauthAccess(fetchToken())
+	perRPC := oauth.TokenSource{oauth2.StaticTokenSource(fetchToken())}
 	creds, err := credentials.NewClientTLSFromFile(data.Path("x509/ca_cert.pem"), "x.test.example.com")
 	if err != nil {
 		log.Fatalf("failed to load credentials: %v", err)
@@ -61,7 +61,7 @@ func main() {
 		// itself.
 		// See: https://godoc.org/google.golang.org/grpc#PerRPCCredentials
 		grpc.WithPerRPCCredentials(perRPC),
-		// oauth.NewOauthAccess requires the configuration of transport
+		// oauth.TokenSource requires the configuration of transport
 		// credentials.
 		grpc.WithTransportCredentials(creds),
 	}

--- a/examples/features/authentication/client/main.go
+++ b/examples/features/authentication/client/main.go
@@ -50,7 +50,7 @@ func main() {
 	flag.Parse()
 
 	// Set up the credentials for the connection.
-	perRPC := oauth.TokenSource{oauth2.StaticTokenSource(fetchToken())}
+	perRPC := oauth.TokenSource{TokenSource: oauth2.StaticTokenSource(fetchToken())}
 	creds, err := credentials.NewClientTLSFromFile(data.Path("x509/ca_cert.pem"), "x.test.example.com")
 	if err != nil {
 		log.Fatalf("failed to load credentials: %v", err)

--- a/examples/features/interceptor/client/main.go
+++ b/examples/features/interceptor/client/main.go
@@ -55,9 +55,9 @@ func unaryInterceptor(ctx context.Context, method string, req, reply interface{}
 		}
 	}
 	if !credsConfigured {
-		opts = append(opts, grpc.PerRPCCredentials(oauth.NewOauthAccess(&oauth2.Token{
-			AccessToken: fallbackToken,
-		})))
+		opts = append(opts, grpc.PerRPCCredentials(oauth.TokenSource{
+			oauth2.StaticTokenSource(&oauth2.Token{AccessToken: fallbackToken}),
+		}))
 	}
 	start := time.Now()
 	err := invoker(ctx, method, req, reply, cc, opts...)
@@ -97,9 +97,9 @@ func streamInterceptor(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.Clie
 		}
 	}
 	if !credsConfigured {
-		opts = append(opts, grpc.PerRPCCredentials(oauth.NewOauthAccess(&oauth2.Token{
-			AccessToken: fallbackToken,
-		})))
+		opts = append(opts, grpc.PerRPCCredentials(oauth.TokenSource{
+			oauth2.StaticTokenSource(&oauth2.Token{AccessToken: fallbackToken}),
+		}))
 	}
 	s, err := streamer(ctx, desc, cc, method, opts...)
 	if err != nil {

--- a/examples/features/interceptor/client/main.go
+++ b/examples/features/interceptor/client/main.go
@@ -56,7 +56,7 @@ func unaryInterceptor(ctx context.Context, method string, req, reply interface{}
 	}
 	if !credsConfigured {
 		opts = append(opts, grpc.PerRPCCredentials(oauth.TokenSource{
-			oauth2.StaticTokenSource(&oauth2.Token{AccessToken: fallbackToken}),
+			TokenSource: oauth2.StaticTokenSource(&oauth2.Token{AccessToken: fallbackToken}),
 		}))
 	}
 	start := time.Now()
@@ -98,7 +98,7 @@ func streamInterceptor(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.Clie
 	}
 	if !credsConfigured {
 		opts = append(opts, grpc.PerRPCCredentials(oauth.TokenSource{
-			oauth2.StaticTokenSource(&oauth2.Token{AccessToken: fallbackToken}),
+			TokenSource: oauth2.StaticTokenSource(&oauth2.Token{AccessToken: fallbackToken}),
 		}))
 	}
 	s, err := streamer(ctx, desc, cc, method, opts...)

--- a/interop/client/client.go
+++ b/interop/client/client.go
@@ -28,6 +28,7 @@ import (
 	"strconv"
 	"time"
 
+	"golang.org/x/oauth2"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/alts"
@@ -201,7 +202,7 @@ func main() {
 			}
 			opts = append(opts, grpc.WithPerRPCCredentials(jwtCreds))
 		} else if *testCase == "oauth2_auth_token" {
-			opts = append(opts, grpc.WithPerRPCCredentials(oauth.NewOauthAccess(interop.GetToken(*serviceAccountKeyFile, *oauthScope))))
+			opts = append(opts, grpc.WithPerRPCCredentials(oauth.TokenSource{oauth2.StaticTokenSource(interop.GetToken(*serviceAccountKeyFile, *oauthScope))}))
 		}
 	}
 	if len(*serviceConfigJSON) > 0 {

--- a/interop/client/client.go
+++ b/interop/client/client.go
@@ -202,7 +202,7 @@ func main() {
 			}
 			opts = append(opts, grpc.WithPerRPCCredentials(jwtCreds))
 		} else if *testCase == "oauth2_auth_token" {
-			opts = append(opts, grpc.WithPerRPCCredentials(oauth.TokenSource{oauth2.StaticTokenSource(interop.GetToken(*serviceAccountKeyFile, *oauthScope))}))
+			opts = append(opts, grpc.WithPerRPCCredentials(oauth.TokenSource{TokenSource: oauth2.StaticTokenSource(interop.GetToken(*serviceAccountKeyFile, *oauthScope))}))
 		}
 	}
 	if len(*serviceConfigJSON) > 0 {


### PR DESCRIPTION
Fixes #5415

SUMMARY OF CHANGES
* Mark `oauth.NewOauthAccess` as deprecated, pointing to `oauth.TokenSource`
* Change authentication and interceptor example clients to use `oauth.TokenSource`
* Change interop to use `oauth.TokenSource`

RELEASE NOTES:
* Mark `oauth.NewOauthAccess` as deprecated