### PR TITLE
cmd/protoc-gen-go-grpc: export consts for full method names

### DIFF
--- a/balancer/grpclb/grpc_lb_v1/load_balancer_grpc.pb.go
+++ b/balancer/grpclb/grpc_lb_v1/load_balancer_grpc.pb.go
@@ -54,7 +54,7 @@ func NewLoadBalancerClient(cc grpc.ClientConnInterface) LoadBalancerClient {
 }
 
 func (c *loadBalancerClient) BalanceLoad(ctx context.Context, opts ...grpc.CallOption) (LoadBalancer_BalanceLoadClient, error) {
-	stream, err := c.cc.NewStream(ctx, &LoadBalancer_ServiceDesc.Streams[0], "/grpc.lb.v1.LoadBalancer/BalanceLoad", opts...)
+	stream, err := c.cc.NewStream(ctx, &LoadBalancer_ServiceDesc.Streams[0], LoadBalancer_BalanceLoad_FullMethodName, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -156,9 +156,5 @@ var LoadBalancer_ServiceDesc = grpc.ServiceDesc{
 }
 
 const (
-	LoadBalancer_BalanceLoad_FullMethod = "/grpc.lb.v1.LoadBalancer/BalanceLoad"
+	LoadBalancer_BalanceLoad_FullMethodName = "/grpc.lb.v1.LoadBalancer/BalanceLoad"
 )
-
-var LoadBalancer_FullMethods = []string{
-	LoadBalancer_BalanceLoad_FullMethod,
-}

--- a/balancer/grpclb/grpc_lb_v1/load_balancer_grpc.pb.go
+++ b/balancer/grpclb/grpc_lb_v1/load_balancer_grpc.pb.go
@@ -37,6 +37,10 @@ import (
 // Requires gRPC-Go v1.32.0 or later.
 const _ = grpc.SupportPackageIsVersion7
 
+const (
+	LoadBalancer_BalanceLoad_FullMethodName = "/grpc.lb.v1.LoadBalancer/BalanceLoad"
+)
+
 // LoadBalancerClient is the client API for LoadBalancer service.
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
@@ -154,7 +158,3 @@ var LoadBalancer_ServiceDesc = grpc.ServiceDesc{
 	},
 	Metadata: "grpc/lb/v1/load_balancer.proto",
 }
-
-const (
-	LoadBalancer_BalanceLoad_FullMethodName = "/grpc.lb.v1.LoadBalancer/BalanceLoad"
-)

--- a/balancer/grpclb/grpc_lb_v1/load_balancer_grpc.pb.go
+++ b/balancer/grpclb/grpc_lb_v1/load_balancer_grpc.pb.go
@@ -154,3 +154,11 @@ var LoadBalancer_ServiceDesc = grpc.ServiceDesc{
 	},
 	Metadata: "grpc/lb/v1/load_balancer.proto",
 }
+
+const (
+	LoadBalancer_BalanceLoad_FullMethod = "/grpc.lb.v1.LoadBalancer/BalanceLoad"
+)
+
+var LoadBalancer_FullMethods = []string{
+	LoadBalancer_BalanceLoad_FullMethod,
+}

--- a/channelz/grpc_channelz_v1/channelz_grpc.pb.go
+++ b/channelz/grpc_channelz_v1/channelz_grpc.pb.go
@@ -70,7 +70,7 @@ func NewChannelzClient(cc grpc.ClientConnInterface) ChannelzClient {
 
 func (c *channelzClient) GetTopChannels(ctx context.Context, in *GetTopChannelsRequest, opts ...grpc.CallOption) (*GetTopChannelsResponse, error) {
 	out := new(GetTopChannelsResponse)
-	err := c.cc.Invoke(ctx, "/grpc.channelz.v1.Channelz/GetTopChannels", in, out, opts...)
+	err := c.cc.Invoke(ctx, Channelz_GetTopChannels_FullMethodName, in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -79,7 +79,7 @@ func (c *channelzClient) GetTopChannels(ctx context.Context, in *GetTopChannelsR
 
 func (c *channelzClient) GetServers(ctx context.Context, in *GetServersRequest, opts ...grpc.CallOption) (*GetServersResponse, error) {
 	out := new(GetServersResponse)
-	err := c.cc.Invoke(ctx, "/grpc.channelz.v1.Channelz/GetServers", in, out, opts...)
+	err := c.cc.Invoke(ctx, Channelz_GetServers_FullMethodName, in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -88,7 +88,7 @@ func (c *channelzClient) GetServers(ctx context.Context, in *GetServersRequest, 
 
 func (c *channelzClient) GetServer(ctx context.Context, in *GetServerRequest, opts ...grpc.CallOption) (*GetServerResponse, error) {
 	out := new(GetServerResponse)
-	err := c.cc.Invoke(ctx, "/grpc.channelz.v1.Channelz/GetServer", in, out, opts...)
+	err := c.cc.Invoke(ctx, Channelz_GetServer_FullMethodName, in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -97,7 +97,7 @@ func (c *channelzClient) GetServer(ctx context.Context, in *GetServerRequest, op
 
 func (c *channelzClient) GetServerSockets(ctx context.Context, in *GetServerSocketsRequest, opts ...grpc.CallOption) (*GetServerSocketsResponse, error) {
 	out := new(GetServerSocketsResponse)
-	err := c.cc.Invoke(ctx, "/grpc.channelz.v1.Channelz/GetServerSockets", in, out, opts...)
+	err := c.cc.Invoke(ctx, Channelz_GetServerSockets_FullMethodName, in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -106,7 +106,7 @@ func (c *channelzClient) GetServerSockets(ctx context.Context, in *GetServerSock
 
 func (c *channelzClient) GetChannel(ctx context.Context, in *GetChannelRequest, opts ...grpc.CallOption) (*GetChannelResponse, error) {
 	out := new(GetChannelResponse)
-	err := c.cc.Invoke(ctx, "/grpc.channelz.v1.Channelz/GetChannel", in, out, opts...)
+	err := c.cc.Invoke(ctx, Channelz_GetChannel_FullMethodName, in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -115,7 +115,7 @@ func (c *channelzClient) GetChannel(ctx context.Context, in *GetChannelRequest, 
 
 func (c *channelzClient) GetSubchannel(ctx context.Context, in *GetSubchannelRequest, opts ...grpc.CallOption) (*GetSubchannelResponse, error) {
 	out := new(GetSubchannelResponse)
-	err := c.cc.Invoke(ctx, "/grpc.channelz.v1.Channelz/GetSubchannel", in, out, opts...)
+	err := c.cc.Invoke(ctx, Channelz_GetSubchannel_FullMethodName, in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -124,7 +124,7 @@ func (c *channelzClient) GetSubchannel(ctx context.Context, in *GetSubchannelReq
 
 func (c *channelzClient) GetSocket(ctx context.Context, in *GetSocketRequest, opts ...grpc.CallOption) (*GetSocketResponse, error) {
 	out := new(GetSocketResponse)
-	err := c.cc.Invoke(ctx, "/grpc.channelz.v1.Channelz/GetSocket", in, out, opts...)
+	err := c.cc.Invoke(ctx, Channelz_GetSocket_FullMethodName, in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -199,7 +199,7 @@ func _Channelz_GetTopChannels_Handler(srv interface{}, ctx context.Context, dec 
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/grpc.channelz.v1.Channelz/GetTopChannels",
+		FullMethod: Channelz_GetTopChannels_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(ChannelzServer).GetTopChannels(ctx, req.(*GetTopChannelsRequest))
@@ -217,7 +217,7 @@ func _Channelz_GetServers_Handler(srv interface{}, ctx context.Context, dec func
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/grpc.channelz.v1.Channelz/GetServers",
+		FullMethod: Channelz_GetServers_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(ChannelzServer).GetServers(ctx, req.(*GetServersRequest))
@@ -235,7 +235,7 @@ func _Channelz_GetServer_Handler(srv interface{}, ctx context.Context, dec func(
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/grpc.channelz.v1.Channelz/GetServer",
+		FullMethod: Channelz_GetServer_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(ChannelzServer).GetServer(ctx, req.(*GetServerRequest))
@@ -253,7 +253,7 @@ func _Channelz_GetServerSockets_Handler(srv interface{}, ctx context.Context, de
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/grpc.channelz.v1.Channelz/GetServerSockets",
+		FullMethod: Channelz_GetServerSockets_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(ChannelzServer).GetServerSockets(ctx, req.(*GetServerSocketsRequest))
@@ -271,7 +271,7 @@ func _Channelz_GetChannel_Handler(srv interface{}, ctx context.Context, dec func
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/grpc.channelz.v1.Channelz/GetChannel",
+		FullMethod: Channelz_GetChannel_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(ChannelzServer).GetChannel(ctx, req.(*GetChannelRequest))
@@ -289,7 +289,7 @@ func _Channelz_GetSubchannel_Handler(srv interface{}, ctx context.Context, dec f
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/grpc.channelz.v1.Channelz/GetSubchannel",
+		FullMethod: Channelz_GetSubchannel_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(ChannelzServer).GetSubchannel(ctx, req.(*GetSubchannelRequest))
@@ -307,7 +307,7 @@ func _Channelz_GetSocket_Handler(srv interface{}, ctx context.Context, dec func(
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/grpc.channelz.v1.Channelz/GetSocket",
+		FullMethod: Channelz_GetSocket_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(ChannelzServer).GetSocket(ctx, req.(*GetSocketRequest))
@@ -356,21 +356,11 @@ var Channelz_ServiceDesc = grpc.ServiceDesc{
 }
 
 const (
-	Channelz_GetTopChannels_FullMethod   = "/grpc.channelz.v1.Channelz/GetTopChannels"
-	Channelz_GetServers_FullMethod       = "/grpc.channelz.v1.Channelz/GetServers"
-	Channelz_GetServer_FullMethod        = "/grpc.channelz.v1.Channelz/GetServer"
-	Channelz_GetServerSockets_FullMethod = "/grpc.channelz.v1.Channelz/GetServerSockets"
-	Channelz_GetChannel_FullMethod       = "/grpc.channelz.v1.Channelz/GetChannel"
-	Channelz_GetSubchannel_FullMethod    = "/grpc.channelz.v1.Channelz/GetSubchannel"
-	Channelz_GetSocket_FullMethod        = "/grpc.channelz.v1.Channelz/GetSocket"
+	Channelz_GetTopChannels_FullMethodName   = "/grpc.channelz.v1.Channelz/GetTopChannels"
+	Channelz_GetServers_FullMethodName       = "/grpc.channelz.v1.Channelz/GetServers"
+	Channelz_GetServer_FullMethodName        = "/grpc.channelz.v1.Channelz/GetServer"
+	Channelz_GetServerSockets_FullMethodName = "/grpc.channelz.v1.Channelz/GetServerSockets"
+	Channelz_GetChannel_FullMethodName       = "/grpc.channelz.v1.Channelz/GetChannel"
+	Channelz_GetSubchannel_FullMethodName    = "/grpc.channelz.v1.Channelz/GetSubchannel"
+	Channelz_GetSocket_FullMethodName        = "/grpc.channelz.v1.Channelz/GetSocket"
 )
-
-var Channelz_FullMethods = []string{
-	Channelz_GetTopChannels_FullMethod,
-	Channelz_GetServers_FullMethod,
-	Channelz_GetServer_FullMethod,
-	Channelz_GetServerSockets_FullMethod,
-	Channelz_GetChannel_FullMethod,
-	Channelz_GetSubchannel_FullMethod,
-	Channelz_GetSocket_FullMethod,
-}

--- a/channelz/grpc_channelz_v1/channelz_grpc.pb.go
+++ b/channelz/grpc_channelz_v1/channelz_grpc.pb.go
@@ -39,6 +39,16 @@ import (
 // Requires gRPC-Go v1.32.0 or later.
 const _ = grpc.SupportPackageIsVersion7
 
+const (
+	Channelz_GetTopChannels_FullMethodName   = "/grpc.channelz.v1.Channelz/GetTopChannels"
+	Channelz_GetServers_FullMethodName       = "/grpc.channelz.v1.Channelz/GetServers"
+	Channelz_GetServer_FullMethodName        = "/grpc.channelz.v1.Channelz/GetServer"
+	Channelz_GetServerSockets_FullMethodName = "/grpc.channelz.v1.Channelz/GetServerSockets"
+	Channelz_GetChannel_FullMethodName       = "/grpc.channelz.v1.Channelz/GetChannel"
+	Channelz_GetSubchannel_FullMethodName    = "/grpc.channelz.v1.Channelz/GetSubchannel"
+	Channelz_GetSocket_FullMethodName        = "/grpc.channelz.v1.Channelz/GetSocket"
+)
+
 // ChannelzClient is the client API for Channelz service.
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
@@ -354,13 +364,3 @@ var Channelz_ServiceDesc = grpc.ServiceDesc{
 	Streams:  []grpc.StreamDesc{},
 	Metadata: "grpc/channelz/v1/channelz.proto",
 }
-
-const (
-	Channelz_GetTopChannels_FullMethodName   = "/grpc.channelz.v1.Channelz/GetTopChannels"
-	Channelz_GetServers_FullMethodName       = "/grpc.channelz.v1.Channelz/GetServers"
-	Channelz_GetServer_FullMethodName        = "/grpc.channelz.v1.Channelz/GetServer"
-	Channelz_GetServerSockets_FullMethodName = "/grpc.channelz.v1.Channelz/GetServerSockets"
-	Channelz_GetChannel_FullMethodName       = "/grpc.channelz.v1.Channelz/GetChannel"
-	Channelz_GetSubchannel_FullMethodName    = "/grpc.channelz.v1.Channelz/GetSubchannel"
-	Channelz_GetSocket_FullMethodName        = "/grpc.channelz.v1.Channelz/GetSocket"
-)

--- a/channelz/grpc_channelz_v1/channelz_grpc.pb.go
+++ b/channelz/grpc_channelz_v1/channelz_grpc.pb.go
@@ -354,3 +354,23 @@ var Channelz_ServiceDesc = grpc.ServiceDesc{
 	Streams:  []grpc.StreamDesc{},
 	Metadata: "grpc/channelz/v1/channelz.proto",
 }
+
+const (
+	Channelz_GetTopChannels_FullMethod   = "/grpc.channelz.v1.Channelz/GetTopChannels"
+	Channelz_GetServers_FullMethod       = "/grpc.channelz.v1.Channelz/GetServers"
+	Channelz_GetServer_FullMethod        = "/grpc.channelz.v1.Channelz/GetServer"
+	Channelz_GetServerSockets_FullMethod = "/grpc.channelz.v1.Channelz/GetServerSockets"
+	Channelz_GetChannel_FullMethod       = "/grpc.channelz.v1.Channelz/GetChannel"
+	Channelz_GetSubchannel_FullMethod    = "/grpc.channelz.v1.Channelz/GetSubchannel"
+	Channelz_GetSocket_FullMethod        = "/grpc.channelz.v1.Channelz/GetSocket"
+)
+
+var Channelz_FullMethods = []string{
+	Channelz_GetTopChannels_FullMethod,
+	Channelz_GetServers_FullMethod,
+	Channelz_GetServer_FullMethod,
+	Channelz_GetServerSockets_FullMethod,
+	Channelz_GetChannel_FullMethod,
+	Channelz_GetSubchannel_FullMethod,
+	Channelz_GetSocket_FullMethod,
+}

--- a/cmd/protoc-gen-go-grpc/grpc.go
+++ b/cmd/protoc-gen-go-grpc/grpc.go
@@ -97,6 +97,8 @@ func (serviceGenerateHelper) generateServerFunctions(gen *protogen.Plugin, file 
 		handlerNames = append(handlerNames, hname)
 	}
 	genServiceDesc(file, g, serviceDescVar, serverType, service, handlerNames)
+
+	genFullMethods(g, service)
 }
 
 func (serviceGenerateHelper) formatHandlerFuncName(service *protogen.Service, hname string) string {
@@ -513,6 +515,25 @@ func genLeadingComments(g *protogen.GeneratedFile, loc protoreflect.SourceLocati
 		g.P(protogen.Comments(s))
 		g.P()
 	}
+}
+
+func genFullMethods(g *protogen.GeneratedFile, service *protogen.Service) {
+	g.P("const (")
+	cNames := make([]string, len(service.Methods))
+	for i, method := range service.Methods {
+		cName := fmt.Sprintf("%s_%s_FullMethod", service.GoName, method.GoName)
+		cNames[i] = cName
+		fmName := helper.formatFullMethodName(service, method)
+		g.P(cName, ` = "`, fmName, `"`)
+	}
+	g.P(")")
+	g.P()
+	g.P("var ", service.GoName, "_FullMethods = []string{")
+	for _, cName := range cNames {
+		g.P(cName, ",")
+	}
+	g.P("}")
+	g.P()
 }
 
 const deprecationComment = "// Deprecated: Do not use."

--- a/credentials/alts/internal/proto/grpc_gcp/handshaker_grpc.pb.go
+++ b/credentials/alts/internal/proto/grpc_gcp/handshaker_grpc.pb.go
@@ -57,7 +57,7 @@ func NewHandshakerServiceClient(cc grpc.ClientConnInterface) HandshakerServiceCl
 }
 
 func (c *handshakerServiceClient) DoHandshake(ctx context.Context, opts ...grpc.CallOption) (HandshakerService_DoHandshakeClient, error) {
-	stream, err := c.cc.NewStream(ctx, &HandshakerService_ServiceDesc.Streams[0], "/grpc.gcp.HandshakerService/DoHandshake", opts...)
+	stream, err := c.cc.NewStream(ctx, &HandshakerService_ServiceDesc.Streams[0], HandshakerService_DoHandshake_FullMethodName, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -166,9 +166,5 @@ var HandshakerService_ServiceDesc = grpc.ServiceDesc{
 }
 
 const (
-	HandshakerService_DoHandshake_FullMethod = "/grpc.gcp.HandshakerService/DoHandshake"
+	HandshakerService_DoHandshake_FullMethodName = "/grpc.gcp.HandshakerService/DoHandshake"
 )
-
-var HandshakerService_FullMethods = []string{
-	HandshakerService_DoHandshake_FullMethod,
-}

--- a/credentials/alts/internal/proto/grpc_gcp/handshaker_grpc.pb.go
+++ b/credentials/alts/internal/proto/grpc_gcp/handshaker_grpc.pb.go
@@ -35,6 +35,10 @@ import (
 // Requires gRPC-Go v1.32.0 or later.
 const _ = grpc.SupportPackageIsVersion7
 
+const (
+	HandshakerService_DoHandshake_FullMethodName = "/grpc.gcp.HandshakerService/DoHandshake"
+)
+
 // HandshakerServiceClient is the client API for HandshakerService service.
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
@@ -164,7 +168,3 @@ var HandshakerService_ServiceDesc = grpc.ServiceDesc{
 	},
 	Metadata: "grpc/gcp/handshaker.proto",
 }
-
-const (
-	HandshakerService_DoHandshake_FullMethodName = "/grpc.gcp.HandshakerService/DoHandshake"
-)

--- a/credentials/alts/internal/proto/grpc_gcp/handshaker_grpc.pb.go
+++ b/credentials/alts/internal/proto/grpc_gcp/handshaker_grpc.pb.go
@@ -164,3 +164,11 @@ var HandshakerService_ServiceDesc = grpc.ServiceDesc{
 	},
 	Metadata: "grpc/gcp/handshaker.proto",
 }
+
+const (
+	HandshakerService_DoHandshake_FullMethod = "/grpc.gcp.HandshakerService/DoHandshake"
+)
+
+var HandshakerService_FullMethods = []string{
+	HandshakerService_DoHandshake_FullMethod,
+}

--- a/examples/features/proto/echo/echo_grpc.pb.go
+++ b/examples/features/proto/echo/echo_grpc.pb.go
@@ -35,6 +35,13 @@ import (
 // Requires gRPC-Go v1.32.0 or later.
 const _ = grpc.SupportPackageIsVersion7
 
+const (
+	Echo_UnaryEcho_FullMethodName                  = "/grpc.examples.echo.Echo/UnaryEcho"
+	Echo_ServerStreamingEcho_FullMethodName        = "/grpc.examples.echo.Echo/ServerStreamingEcho"
+	Echo_ClientStreamingEcho_FullMethodName        = "/grpc.examples.echo.Echo/ClientStreamingEcho"
+	Echo_BidirectionalStreamingEcho_FullMethodName = "/grpc.examples.echo.Echo/BidirectionalStreamingEcho"
+)
+
 // EchoClient is the client API for Echo service.
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
@@ -330,10 +337,3 @@ var Echo_ServiceDesc = grpc.ServiceDesc{
 	},
 	Metadata: "examples/features/proto/echo/echo.proto",
 }
-
-const (
-	Echo_UnaryEcho_FullMethodName                  = "/grpc.examples.echo.Echo/UnaryEcho"
-	Echo_ServerStreamingEcho_FullMethodName        = "/grpc.examples.echo.Echo/ServerStreamingEcho"
-	Echo_ClientStreamingEcho_FullMethodName        = "/grpc.examples.echo.Echo/ClientStreamingEcho"
-	Echo_BidirectionalStreamingEcho_FullMethodName = "/grpc.examples.echo.Echo/BidirectionalStreamingEcho"
-)

--- a/examples/features/proto/echo/echo_grpc.pb.go
+++ b/examples/features/proto/echo/echo_grpc.pb.go
@@ -330,3 +330,17 @@ var Echo_ServiceDesc = grpc.ServiceDesc{
 	},
 	Metadata: "examples/features/proto/echo/echo.proto",
 }
+
+const (
+	Echo_UnaryEcho_FullMethod                  = "/grpc.examples.echo.Echo/UnaryEcho"
+	Echo_ServerStreamingEcho_FullMethod        = "/grpc.examples.echo.Echo/ServerStreamingEcho"
+	Echo_ClientStreamingEcho_FullMethod        = "/grpc.examples.echo.Echo/ClientStreamingEcho"
+	Echo_BidirectionalStreamingEcho_FullMethod = "/grpc.examples.echo.Echo/BidirectionalStreamingEcho"
+)
+
+var Echo_FullMethods = []string{
+	Echo_UnaryEcho_FullMethod,
+	Echo_ServerStreamingEcho_FullMethod,
+	Echo_ClientStreamingEcho_FullMethod,
+	Echo_BidirectionalStreamingEcho_FullMethod,
+}

--- a/examples/features/proto/echo/echo_grpc.pb.go
+++ b/examples/features/proto/echo/echo_grpc.pb.go
@@ -59,7 +59,7 @@ func NewEchoClient(cc grpc.ClientConnInterface) EchoClient {
 
 func (c *echoClient) UnaryEcho(ctx context.Context, in *EchoRequest, opts ...grpc.CallOption) (*EchoResponse, error) {
 	out := new(EchoResponse)
-	err := c.cc.Invoke(ctx, "/grpc.examples.echo.Echo/UnaryEcho", in, out, opts...)
+	err := c.cc.Invoke(ctx, Echo_UnaryEcho_FullMethodName, in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -67,7 +67,7 @@ func (c *echoClient) UnaryEcho(ctx context.Context, in *EchoRequest, opts ...grp
 }
 
 func (c *echoClient) ServerStreamingEcho(ctx context.Context, in *EchoRequest, opts ...grpc.CallOption) (Echo_ServerStreamingEchoClient, error) {
-	stream, err := c.cc.NewStream(ctx, &Echo_ServiceDesc.Streams[0], "/grpc.examples.echo.Echo/ServerStreamingEcho", opts...)
+	stream, err := c.cc.NewStream(ctx, &Echo_ServiceDesc.Streams[0], Echo_ServerStreamingEcho_FullMethodName, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -99,7 +99,7 @@ func (x *echoServerStreamingEchoClient) Recv() (*EchoResponse, error) {
 }
 
 func (c *echoClient) ClientStreamingEcho(ctx context.Context, opts ...grpc.CallOption) (Echo_ClientStreamingEchoClient, error) {
-	stream, err := c.cc.NewStream(ctx, &Echo_ServiceDesc.Streams[1], "/grpc.examples.echo.Echo/ClientStreamingEcho", opts...)
+	stream, err := c.cc.NewStream(ctx, &Echo_ServiceDesc.Streams[1], Echo_ClientStreamingEcho_FullMethodName, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -133,7 +133,7 @@ func (x *echoClientStreamingEchoClient) CloseAndRecv() (*EchoResponse, error) {
 }
 
 func (c *echoClient) BidirectionalStreamingEcho(ctx context.Context, opts ...grpc.CallOption) (Echo_BidirectionalStreamingEchoClient, error) {
-	stream, err := c.cc.NewStream(ctx, &Echo_ServiceDesc.Streams[2], "/grpc.examples.echo.Echo/BidirectionalStreamingEcho", opts...)
+	stream, err := c.cc.NewStream(ctx, &Echo_ServiceDesc.Streams[2], Echo_BidirectionalStreamingEcho_FullMethodName, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -217,7 +217,7 @@ func _Echo_UnaryEcho_Handler(srv interface{}, ctx context.Context, dec func(inte
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/grpc.examples.echo.Echo/UnaryEcho",
+		FullMethod: Echo_UnaryEcho_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(EchoServer).UnaryEcho(ctx, req.(*EchoRequest))
@@ -332,15 +332,8 @@ var Echo_ServiceDesc = grpc.ServiceDesc{
 }
 
 const (
-	Echo_UnaryEcho_FullMethod                  = "/grpc.examples.echo.Echo/UnaryEcho"
-	Echo_ServerStreamingEcho_FullMethod        = "/grpc.examples.echo.Echo/ServerStreamingEcho"
-	Echo_ClientStreamingEcho_FullMethod        = "/grpc.examples.echo.Echo/ClientStreamingEcho"
-	Echo_BidirectionalStreamingEcho_FullMethod = "/grpc.examples.echo.Echo/BidirectionalStreamingEcho"
+	Echo_UnaryEcho_FullMethodName                  = "/grpc.examples.echo.Echo/UnaryEcho"
+	Echo_ServerStreamingEcho_FullMethodName        = "/grpc.examples.echo.Echo/ServerStreamingEcho"
+	Echo_ClientStreamingEcho_FullMethodName        = "/grpc.examples.echo.Echo/ClientStreamingEcho"
+	Echo_BidirectionalStreamingEcho_FullMethodName = "/grpc.examples.echo.Echo/BidirectionalStreamingEcho"
 )
-
-var Echo_FullMethods = []string{
-	Echo_UnaryEcho_FullMethod,
-	Echo_ServerStreamingEcho_FullMethod,
-	Echo_ClientStreamingEcho_FullMethod,
-	Echo_BidirectionalStreamingEcho_FullMethod,
-}

--- a/examples/helloworld/helloworld/helloworld_grpc.pb.go
+++ b/examples/helloworld/helloworld/helloworld_grpc.pb.go
@@ -32,6 +32,10 @@ import (
 // Requires gRPC-Go v1.32.0 or later.
 const _ = grpc.SupportPackageIsVersion7
 
+const (
+	Greeter_SayHello_FullMethodName = "/helloworld.Greeter/SayHello"
+)
+
 // GreeterClient is the client API for Greeter service.
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
@@ -119,7 +123,3 @@ var Greeter_ServiceDesc = grpc.ServiceDesc{
 	Streams:  []grpc.StreamDesc{},
 	Metadata: "examples/helloworld/helloworld/helloworld.proto",
 }
-
-const (
-	Greeter_SayHello_FullMethodName = "/helloworld.Greeter/SayHello"
-)

--- a/examples/helloworld/helloworld/helloworld_grpc.pb.go
+++ b/examples/helloworld/helloworld/helloworld_grpc.pb.go
@@ -50,7 +50,7 @@ func NewGreeterClient(cc grpc.ClientConnInterface) GreeterClient {
 
 func (c *greeterClient) SayHello(ctx context.Context, in *HelloRequest, opts ...grpc.CallOption) (*HelloReply, error) {
 	out := new(HelloReply)
-	err := c.cc.Invoke(ctx, "/helloworld.Greeter/SayHello", in, out, opts...)
+	err := c.cc.Invoke(ctx, Greeter_SayHello_FullMethodName, in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -96,7 +96,7 @@ func _Greeter_SayHello_Handler(srv interface{}, ctx context.Context, dec func(in
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/helloworld.Greeter/SayHello",
+		FullMethod: Greeter_SayHello_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(GreeterServer).SayHello(ctx, req.(*HelloRequest))
@@ -121,9 +121,5 @@ var Greeter_ServiceDesc = grpc.ServiceDesc{
 }
 
 const (
-	Greeter_SayHello_FullMethod = "/helloworld.Greeter/SayHello"
+	Greeter_SayHello_FullMethodName = "/helloworld.Greeter/SayHello"
 )
-
-var Greeter_FullMethods = []string{
-	Greeter_SayHello_FullMethod,
-}

--- a/examples/helloworld/helloworld/helloworld_grpc.pb.go
+++ b/examples/helloworld/helloworld/helloworld_grpc.pb.go
@@ -119,3 +119,11 @@ var Greeter_ServiceDesc = grpc.ServiceDesc{
 	Streams:  []grpc.StreamDesc{},
 	Metadata: "examples/helloworld/helloworld/helloworld.proto",
 }
+
+const (
+	Greeter_SayHello_FullMethod = "/helloworld.Greeter/SayHello"
+)
+
+var Greeter_FullMethods = []string{
+	Greeter_SayHello_FullMethod,
+}

--- a/examples/route_guide/routeguide/route_guide_grpc.pb.go
+++ b/examples/route_guide/routeguide/route_guide_grpc.pb.go
@@ -32,6 +32,13 @@ import (
 // Requires gRPC-Go v1.32.0 or later.
 const _ = grpc.SupportPackageIsVersion7
 
+const (
+	RouteGuide_GetFeature_FullMethodName   = "/routeguide.RouteGuide/GetFeature"
+	RouteGuide_ListFeatures_FullMethodName = "/routeguide.RouteGuide/ListFeatures"
+	RouteGuide_RecordRoute_FullMethodName  = "/routeguide.RouteGuide/RecordRoute"
+	RouteGuide_RouteChat_FullMethodName    = "/routeguide.RouteGuide/RouteChat"
+)
+
 // RouteGuideClient is the client API for RouteGuide service.
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
@@ -359,10 +366,3 @@ var RouteGuide_ServiceDesc = grpc.ServiceDesc{
 	},
 	Metadata: "examples/route_guide/routeguide/route_guide.proto",
 }
-
-const (
-	RouteGuide_GetFeature_FullMethodName   = "/routeguide.RouteGuide/GetFeature"
-	RouteGuide_ListFeatures_FullMethodName = "/routeguide.RouteGuide/ListFeatures"
-	RouteGuide_RecordRoute_FullMethodName  = "/routeguide.RouteGuide/RecordRoute"
-	RouteGuide_RouteChat_FullMethodName    = "/routeguide.RouteGuide/RouteChat"
-)

--- a/examples/route_guide/routeguide/route_guide_grpc.pb.go
+++ b/examples/route_guide/routeguide/route_guide_grpc.pb.go
@@ -359,3 +359,17 @@ var RouteGuide_ServiceDesc = grpc.ServiceDesc{
 	},
 	Metadata: "examples/route_guide/routeguide/route_guide.proto",
 }
+
+const (
+	RouteGuide_GetFeature_FullMethod   = "/routeguide.RouteGuide/GetFeature"
+	RouteGuide_ListFeatures_FullMethod = "/routeguide.RouteGuide/ListFeatures"
+	RouteGuide_RecordRoute_FullMethod  = "/routeguide.RouteGuide/RecordRoute"
+	RouteGuide_RouteChat_FullMethod    = "/routeguide.RouteGuide/RouteChat"
+)
+
+var RouteGuide_FullMethods = []string{
+	RouteGuide_GetFeature_FullMethod,
+	RouteGuide_ListFeatures_FullMethod,
+	RouteGuide_RecordRoute_FullMethod,
+	RouteGuide_RouteChat_FullMethod,
+}

--- a/examples/route_guide/routeguide/route_guide_grpc.pb.go
+++ b/examples/route_guide/routeguide/route_guide_grpc.pb.go
@@ -72,7 +72,7 @@ func NewRouteGuideClient(cc grpc.ClientConnInterface) RouteGuideClient {
 
 func (c *routeGuideClient) GetFeature(ctx context.Context, in *Point, opts ...grpc.CallOption) (*Feature, error) {
 	out := new(Feature)
-	err := c.cc.Invoke(ctx, "/routeguide.RouteGuide/GetFeature", in, out, opts...)
+	err := c.cc.Invoke(ctx, RouteGuide_GetFeature_FullMethodName, in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -80,7 +80,7 @@ func (c *routeGuideClient) GetFeature(ctx context.Context, in *Point, opts ...gr
 }
 
 func (c *routeGuideClient) ListFeatures(ctx context.Context, in *Rectangle, opts ...grpc.CallOption) (RouteGuide_ListFeaturesClient, error) {
-	stream, err := c.cc.NewStream(ctx, &RouteGuide_ServiceDesc.Streams[0], "/routeguide.RouteGuide/ListFeatures", opts...)
+	stream, err := c.cc.NewStream(ctx, &RouteGuide_ServiceDesc.Streams[0], RouteGuide_ListFeatures_FullMethodName, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -112,7 +112,7 @@ func (x *routeGuideListFeaturesClient) Recv() (*Feature, error) {
 }
 
 func (c *routeGuideClient) RecordRoute(ctx context.Context, opts ...grpc.CallOption) (RouteGuide_RecordRouteClient, error) {
-	stream, err := c.cc.NewStream(ctx, &RouteGuide_ServiceDesc.Streams[1], "/routeguide.RouteGuide/RecordRoute", opts...)
+	stream, err := c.cc.NewStream(ctx, &RouteGuide_ServiceDesc.Streams[1], RouteGuide_RecordRoute_FullMethodName, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -146,7 +146,7 @@ func (x *routeGuideRecordRouteClient) CloseAndRecv() (*RouteSummary, error) {
 }
 
 func (c *routeGuideClient) RouteChat(ctx context.Context, opts ...grpc.CallOption) (RouteGuide_RouteChatClient, error) {
-	stream, err := c.cc.NewStream(ctx, &RouteGuide_ServiceDesc.Streams[2], "/routeguide.RouteGuide/RouteChat", opts...)
+	stream, err := c.cc.NewStream(ctx, &RouteGuide_ServiceDesc.Streams[2], RouteGuide_RouteChat_FullMethodName, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -246,7 +246,7 @@ func _RouteGuide_GetFeature_Handler(srv interface{}, ctx context.Context, dec fu
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/routeguide.RouteGuide/GetFeature",
+		FullMethod: RouteGuide_GetFeature_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(RouteGuideServer).GetFeature(ctx, req.(*Point))
@@ -361,15 +361,8 @@ var RouteGuide_ServiceDesc = grpc.ServiceDesc{
 }
 
 const (
-	RouteGuide_GetFeature_FullMethod   = "/routeguide.RouteGuide/GetFeature"
-	RouteGuide_ListFeatures_FullMethod = "/routeguide.RouteGuide/ListFeatures"
-	RouteGuide_RecordRoute_FullMethod  = "/routeguide.RouteGuide/RecordRoute"
-	RouteGuide_RouteChat_FullMethod    = "/routeguide.RouteGuide/RouteChat"
+	RouteGuide_GetFeature_FullMethodName   = "/routeguide.RouteGuide/GetFeature"
+	RouteGuide_ListFeatures_FullMethodName = "/routeguide.RouteGuide/ListFeatures"
+	RouteGuide_RecordRoute_FullMethodName  = "/routeguide.RouteGuide/RecordRoute"
+	RouteGuide_RouteChat_FullMethodName    = "/routeguide.RouteGuide/RouteChat"
 )
-
-var RouteGuide_FullMethods = []string{
-	RouteGuide_GetFeature_FullMethod,
-	RouteGuide_ListFeatures_FullMethod,
-	RouteGuide_RecordRoute_FullMethod,
-	RouteGuide_RouteChat_FullMethod,
-}

--- a/health/grpc_health_v1/health_grpc.pb.go
+++ b/health/grpc_health_v1/health_grpc.pb.go
@@ -70,7 +70,7 @@ func NewHealthClient(cc grpc.ClientConnInterface) HealthClient {
 
 func (c *healthClient) Check(ctx context.Context, in *HealthCheckRequest, opts ...grpc.CallOption) (*HealthCheckResponse, error) {
 	out := new(HealthCheckResponse)
-	err := c.cc.Invoke(ctx, "/grpc.health.v1.Health/Check", in, out, opts...)
+	err := c.cc.Invoke(ctx, Health_Check_FullMethodName, in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -78,7 +78,7 @@ func (c *healthClient) Check(ctx context.Context, in *HealthCheckRequest, opts .
 }
 
 func (c *healthClient) Watch(ctx context.Context, in *HealthCheckRequest, opts ...grpc.CallOption) (Health_WatchClient, error) {
-	stream, err := c.cc.NewStream(ctx, &Health_ServiceDesc.Streams[0], "/grpc.health.v1.Health/Watch", opts...)
+	stream, err := c.cc.NewStream(ctx, &Health_ServiceDesc.Streams[0], Health_Watch_FullMethodName, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -166,7 +166,7 @@ func _Health_Check_Handler(srv interface{}, ctx context.Context, dec func(interf
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/grpc.health.v1.Health/Check",
+		FullMethod: Health_Check_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(HealthServer).Check(ctx, req.(*HealthCheckRequest))
@@ -218,11 +218,6 @@ var Health_ServiceDesc = grpc.ServiceDesc{
 }
 
 const (
-	Health_Check_FullMethod = "/grpc.health.v1.Health/Check"
-	Health_Watch_FullMethod = "/grpc.health.v1.Health/Watch"
+	Health_Check_FullMethodName = "/grpc.health.v1.Health/Check"
+	Health_Watch_FullMethodName = "/grpc.health.v1.Health/Watch"
 )
-
-var Health_FullMethods = []string{
-	Health_Check_FullMethod,
-	Health_Watch_FullMethod,
-}

--- a/health/grpc_health_v1/health_grpc.pb.go
+++ b/health/grpc_health_v1/health_grpc.pb.go
@@ -35,6 +35,11 @@ import (
 // Requires gRPC-Go v1.32.0 or later.
 const _ = grpc.SupportPackageIsVersion7
 
+const (
+	Health_Check_FullMethodName = "/grpc.health.v1.Health/Check"
+	Health_Watch_FullMethodName = "/grpc.health.v1.Health/Watch"
+)
+
 // HealthClient is the client API for Health service.
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
@@ -216,8 +221,3 @@ var Health_ServiceDesc = grpc.ServiceDesc{
 	},
 	Metadata: "grpc/health/v1/health.proto",
 }
-
-const (
-	Health_Check_FullMethodName = "/grpc.health.v1.Health/Check"
-	Health_Watch_FullMethodName = "/grpc.health.v1.Health/Watch"
-)

--- a/health/grpc_health_v1/health_grpc.pb.go
+++ b/health/grpc_health_v1/health_grpc.pb.go
@@ -216,3 +216,13 @@ var Health_ServiceDesc = grpc.ServiceDesc{
 	},
 	Metadata: "grpc/health/v1/health.proto",
 }
+
+const (
+	Health_Check_FullMethod = "/grpc.health.v1.Health/Check"
+	Health_Watch_FullMethod = "/grpc.health.v1.Health/Watch"
+)
+
+var Health_FullMethods = []string{
+	Health_Check_FullMethod,
+	Health_Watch_FullMethod,
+}

--- a/internal/proto/grpc_lookup_v1/rls_grpc.pb.go
+++ b/internal/proto/grpc_lookup_v1/rls_grpc.pb.go
@@ -119,3 +119,11 @@ var RouteLookupService_ServiceDesc = grpc.ServiceDesc{
 	Streams:  []grpc.StreamDesc{},
 	Metadata: "grpc/lookup/v1/rls.proto",
 }
+
+const (
+	RouteLookupService_RouteLookup_FullMethod = "/grpc.lookup.v1.RouteLookupService/RouteLookup"
+)
+
+var RouteLookupService_FullMethods = []string{
+	RouteLookupService_RouteLookup_FullMethod,
+}

--- a/internal/proto/grpc_lookup_v1/rls_grpc.pb.go
+++ b/internal/proto/grpc_lookup_v1/rls_grpc.pb.go
@@ -50,7 +50,7 @@ func NewRouteLookupServiceClient(cc grpc.ClientConnInterface) RouteLookupService
 
 func (c *routeLookupServiceClient) RouteLookup(ctx context.Context, in *RouteLookupRequest, opts ...grpc.CallOption) (*RouteLookupResponse, error) {
 	out := new(RouteLookupResponse)
-	err := c.cc.Invoke(ctx, "/grpc.lookup.v1.RouteLookupService/RouteLookup", in, out, opts...)
+	err := c.cc.Invoke(ctx, RouteLookupService_RouteLookup_FullMethodName, in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -96,7 +96,7 @@ func _RouteLookupService_RouteLookup_Handler(srv interface{}, ctx context.Contex
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/grpc.lookup.v1.RouteLookupService/RouteLookup",
+		FullMethod: RouteLookupService_RouteLookup_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(RouteLookupServiceServer).RouteLookup(ctx, req.(*RouteLookupRequest))
@@ -121,9 +121,5 @@ var RouteLookupService_ServiceDesc = grpc.ServiceDesc{
 }
 
 const (
-	RouteLookupService_RouteLookup_FullMethod = "/grpc.lookup.v1.RouteLookupService/RouteLookup"
+	RouteLookupService_RouteLookup_FullMethodName = "/grpc.lookup.v1.RouteLookupService/RouteLookup"
 )
-
-var RouteLookupService_FullMethods = []string{
-	RouteLookupService_RouteLookup_FullMethod,
-}

--- a/internal/proto/grpc_lookup_v1/rls_grpc.pb.go
+++ b/internal/proto/grpc_lookup_v1/rls_grpc.pb.go
@@ -32,6 +32,10 @@ import (
 // Requires gRPC-Go v1.32.0 or later.
 const _ = grpc.SupportPackageIsVersion7
 
+const (
+	RouteLookupService_RouteLookup_FullMethodName = "/grpc.lookup.v1.RouteLookupService/RouteLookup"
+)
+
 // RouteLookupServiceClient is the client API for RouteLookupService service.
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
@@ -119,7 +123,3 @@ var RouteLookupService_ServiceDesc = grpc.ServiceDesc{
 	Streams:  []grpc.StreamDesc{},
 	Metadata: "grpc/lookup/v1/rls.proto",
 }
-
-const (
-	RouteLookupService_RouteLookup_FullMethodName = "/grpc.lookup.v1.RouteLookupService/RouteLookup"
-)

--- a/interop/grpc_testing/benchmark_service_grpc.pb.go
+++ b/interop/grpc_testing/benchmark_service_grpc.pb.go
@@ -412,3 +412,19 @@ var BenchmarkService_ServiceDesc = grpc.ServiceDesc{
 	},
 	Metadata: "grpc/testing/benchmark_service.proto",
 }
+
+const (
+	BenchmarkService_UnaryCall_FullMethod           = "/grpc.testing.BenchmarkService/UnaryCall"
+	BenchmarkService_StreamingCall_FullMethod       = "/grpc.testing.BenchmarkService/StreamingCall"
+	BenchmarkService_StreamingFromClient_FullMethod = "/grpc.testing.BenchmarkService/StreamingFromClient"
+	BenchmarkService_StreamingFromServer_FullMethod = "/grpc.testing.BenchmarkService/StreamingFromServer"
+	BenchmarkService_StreamingBothWays_FullMethod   = "/grpc.testing.BenchmarkService/StreamingBothWays"
+)
+
+var BenchmarkService_FullMethods = []string{
+	BenchmarkService_UnaryCall_FullMethod,
+	BenchmarkService_StreamingCall_FullMethod,
+	BenchmarkService_StreamingFromClient_FullMethod,
+	BenchmarkService_StreamingFromServer_FullMethod,
+	BenchmarkService_StreamingBothWays_FullMethod,
+}

--- a/interop/grpc_testing/benchmark_service_grpc.pb.go
+++ b/interop/grpc_testing/benchmark_service_grpc.pb.go
@@ -67,7 +67,7 @@ func NewBenchmarkServiceClient(cc grpc.ClientConnInterface) BenchmarkServiceClie
 
 func (c *benchmarkServiceClient) UnaryCall(ctx context.Context, in *SimpleRequest, opts ...grpc.CallOption) (*SimpleResponse, error) {
 	out := new(SimpleResponse)
-	err := c.cc.Invoke(ctx, "/grpc.testing.BenchmarkService/UnaryCall", in, out, opts...)
+	err := c.cc.Invoke(ctx, BenchmarkService_UnaryCall_FullMethodName, in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -75,7 +75,7 @@ func (c *benchmarkServiceClient) UnaryCall(ctx context.Context, in *SimpleReques
 }
 
 func (c *benchmarkServiceClient) StreamingCall(ctx context.Context, opts ...grpc.CallOption) (BenchmarkService_StreamingCallClient, error) {
-	stream, err := c.cc.NewStream(ctx, &BenchmarkService_ServiceDesc.Streams[0], "/grpc.testing.BenchmarkService/StreamingCall", opts...)
+	stream, err := c.cc.NewStream(ctx, &BenchmarkService_ServiceDesc.Streams[0], BenchmarkService_StreamingCall_FullMethodName, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -106,7 +106,7 @@ func (x *benchmarkServiceStreamingCallClient) Recv() (*SimpleResponse, error) {
 }
 
 func (c *benchmarkServiceClient) StreamingFromClient(ctx context.Context, opts ...grpc.CallOption) (BenchmarkService_StreamingFromClientClient, error) {
-	stream, err := c.cc.NewStream(ctx, &BenchmarkService_ServiceDesc.Streams[1], "/grpc.testing.BenchmarkService/StreamingFromClient", opts...)
+	stream, err := c.cc.NewStream(ctx, &BenchmarkService_ServiceDesc.Streams[1], BenchmarkService_StreamingFromClient_FullMethodName, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -140,7 +140,7 @@ func (x *benchmarkServiceStreamingFromClientClient) CloseAndRecv() (*SimpleRespo
 }
 
 func (c *benchmarkServiceClient) StreamingFromServer(ctx context.Context, in *SimpleRequest, opts ...grpc.CallOption) (BenchmarkService_StreamingFromServerClient, error) {
-	stream, err := c.cc.NewStream(ctx, &BenchmarkService_ServiceDesc.Streams[2], "/grpc.testing.BenchmarkService/StreamingFromServer", opts...)
+	stream, err := c.cc.NewStream(ctx, &BenchmarkService_ServiceDesc.Streams[2], BenchmarkService_StreamingFromServer_FullMethodName, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -172,7 +172,7 @@ func (x *benchmarkServiceStreamingFromServerClient) Recv() (*SimpleResponse, err
 }
 
 func (c *benchmarkServiceClient) StreamingBothWays(ctx context.Context, opts ...grpc.CallOption) (BenchmarkService_StreamingBothWaysClient, error) {
-	stream, err := c.cc.NewStream(ctx, &BenchmarkService_ServiceDesc.Streams[3], "/grpc.testing.BenchmarkService/StreamingBothWays", opts...)
+	stream, err := c.cc.NewStream(ctx, &BenchmarkService_ServiceDesc.Streams[3], BenchmarkService_StreamingBothWays_FullMethodName, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -267,7 +267,7 @@ func _BenchmarkService_UnaryCall_Handler(srv interface{}, ctx context.Context, d
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/grpc.testing.BenchmarkService/UnaryCall",
+		FullMethod: BenchmarkService_UnaryCall_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(BenchmarkServiceServer).UnaryCall(ctx, req.(*SimpleRequest))
@@ -414,17 +414,9 @@ var BenchmarkService_ServiceDesc = grpc.ServiceDesc{
 }
 
 const (
-	BenchmarkService_UnaryCall_FullMethod           = "/grpc.testing.BenchmarkService/UnaryCall"
-	BenchmarkService_StreamingCall_FullMethod       = "/grpc.testing.BenchmarkService/StreamingCall"
-	BenchmarkService_StreamingFromClient_FullMethod = "/grpc.testing.BenchmarkService/StreamingFromClient"
-	BenchmarkService_StreamingFromServer_FullMethod = "/grpc.testing.BenchmarkService/StreamingFromServer"
-	BenchmarkService_StreamingBothWays_FullMethod   = "/grpc.testing.BenchmarkService/StreamingBothWays"
+	BenchmarkService_UnaryCall_FullMethodName           = "/grpc.testing.BenchmarkService/UnaryCall"
+	BenchmarkService_StreamingCall_FullMethodName       = "/grpc.testing.BenchmarkService/StreamingCall"
+	BenchmarkService_StreamingFromClient_FullMethodName = "/grpc.testing.BenchmarkService/StreamingFromClient"
+	BenchmarkService_StreamingFromServer_FullMethodName = "/grpc.testing.BenchmarkService/StreamingFromServer"
+	BenchmarkService_StreamingBothWays_FullMethodName   = "/grpc.testing.BenchmarkService/StreamingBothWays"
 )
-
-var BenchmarkService_FullMethods = []string{
-	BenchmarkService_UnaryCall_FullMethod,
-	BenchmarkService_StreamingCall_FullMethod,
-	BenchmarkService_StreamingFromClient_FullMethod,
-	BenchmarkService_StreamingFromServer_FullMethod,
-	BenchmarkService_StreamingBothWays_FullMethod,
-}

--- a/interop/grpc_testing/benchmark_service_grpc.pb.go
+++ b/interop/grpc_testing/benchmark_service_grpc.pb.go
@@ -35,6 +35,14 @@ import (
 // Requires gRPC-Go v1.32.0 or later.
 const _ = grpc.SupportPackageIsVersion7
 
+const (
+	BenchmarkService_UnaryCall_FullMethodName           = "/grpc.testing.BenchmarkService/UnaryCall"
+	BenchmarkService_StreamingCall_FullMethodName       = "/grpc.testing.BenchmarkService/StreamingCall"
+	BenchmarkService_StreamingFromClient_FullMethodName = "/grpc.testing.BenchmarkService/StreamingFromClient"
+	BenchmarkService_StreamingFromServer_FullMethodName = "/grpc.testing.BenchmarkService/StreamingFromServer"
+	BenchmarkService_StreamingBothWays_FullMethodName   = "/grpc.testing.BenchmarkService/StreamingBothWays"
+)
+
 // BenchmarkServiceClient is the client API for BenchmarkService service.
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
@@ -412,11 +420,3 @@ var BenchmarkService_ServiceDesc = grpc.ServiceDesc{
 	},
 	Metadata: "grpc/testing/benchmark_service.proto",
 }
-
-const (
-	BenchmarkService_UnaryCall_FullMethodName           = "/grpc.testing.BenchmarkService/UnaryCall"
-	BenchmarkService_StreamingCall_FullMethodName       = "/grpc.testing.BenchmarkService/StreamingCall"
-	BenchmarkService_StreamingFromClient_FullMethodName = "/grpc.testing.BenchmarkService/StreamingFromClient"
-	BenchmarkService_StreamingFromServer_FullMethodName = "/grpc.testing.BenchmarkService/StreamingFromServer"
-	BenchmarkService_StreamingBothWays_FullMethodName   = "/grpc.testing.BenchmarkService/StreamingBothWays"
-)

--- a/interop/grpc_testing/report_qps_scenario_service_grpc.pb.go
+++ b/interop/grpc_testing/report_qps_scenario_service_grpc.pb.go
@@ -35,6 +35,10 @@ import (
 // Requires gRPC-Go v1.32.0 or later.
 const _ = grpc.SupportPackageIsVersion7
 
+const (
+	ReportQpsScenarioService_ReportScenario_FullMethodName = "/grpc.testing.ReportQpsScenarioService/ReportScenario"
+)
+
 // ReportQpsScenarioServiceClient is the client API for ReportQpsScenarioService service.
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
@@ -123,7 +127,3 @@ var ReportQpsScenarioService_ServiceDesc = grpc.ServiceDesc{
 	Streams:  []grpc.StreamDesc{},
 	Metadata: "grpc/testing/report_qps_scenario_service.proto",
 }
-
-const (
-	ReportQpsScenarioService_ReportScenario_FullMethodName = "/grpc.testing.ReportQpsScenarioService/ReportScenario"
-)

--- a/interop/grpc_testing/report_qps_scenario_service_grpc.pb.go
+++ b/interop/grpc_testing/report_qps_scenario_service_grpc.pb.go
@@ -53,7 +53,7 @@ func NewReportQpsScenarioServiceClient(cc grpc.ClientConnInterface) ReportQpsSce
 
 func (c *reportQpsScenarioServiceClient) ReportScenario(ctx context.Context, in *ScenarioResult, opts ...grpc.CallOption) (*Void, error) {
 	out := new(Void)
-	err := c.cc.Invoke(ctx, "/grpc.testing.ReportQpsScenarioService/ReportScenario", in, out, opts...)
+	err := c.cc.Invoke(ctx, ReportQpsScenarioService_ReportScenario_FullMethodName, in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -100,7 +100,7 @@ func _ReportQpsScenarioService_ReportScenario_Handler(srv interface{}, ctx conte
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/grpc.testing.ReportQpsScenarioService/ReportScenario",
+		FullMethod: ReportQpsScenarioService_ReportScenario_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(ReportQpsScenarioServiceServer).ReportScenario(ctx, req.(*ScenarioResult))
@@ -125,9 +125,5 @@ var ReportQpsScenarioService_ServiceDesc = grpc.ServiceDesc{
 }
 
 const (
-	ReportQpsScenarioService_ReportScenario_FullMethod = "/grpc.testing.ReportQpsScenarioService/ReportScenario"
+	ReportQpsScenarioService_ReportScenario_FullMethodName = "/grpc.testing.ReportQpsScenarioService/ReportScenario"
 )
-
-var ReportQpsScenarioService_FullMethods = []string{
-	ReportQpsScenarioService_ReportScenario_FullMethod,
-}

--- a/interop/grpc_testing/report_qps_scenario_service_grpc.pb.go
+++ b/interop/grpc_testing/report_qps_scenario_service_grpc.pb.go
@@ -123,3 +123,11 @@ var ReportQpsScenarioService_ServiceDesc = grpc.ServiceDesc{
 	Streams:  []grpc.StreamDesc{},
 	Metadata: "grpc/testing/report_qps_scenario_service.proto",
 }
+
+const (
+	ReportQpsScenarioService_ReportScenario_FullMethod = "/grpc.testing.ReportQpsScenarioService/ReportScenario"
+)
+
+var ReportQpsScenarioService_FullMethods = []string{
+	ReportQpsScenarioService_ReportScenario_FullMethod,
+}

--- a/interop/grpc_testing/test_grpc.pb.go
+++ b/interop/grpc_testing/test_grpc.pb.go
@@ -77,7 +77,7 @@ func NewTestServiceClient(cc grpc.ClientConnInterface) TestServiceClient {
 
 func (c *testServiceClient) EmptyCall(ctx context.Context, in *Empty, opts ...grpc.CallOption) (*Empty, error) {
 	out := new(Empty)
-	err := c.cc.Invoke(ctx, "/grpc.testing.TestService/EmptyCall", in, out, opts...)
+	err := c.cc.Invoke(ctx, TestService_EmptyCall_FullMethodName, in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -86,7 +86,7 @@ func (c *testServiceClient) EmptyCall(ctx context.Context, in *Empty, opts ...gr
 
 func (c *testServiceClient) UnaryCall(ctx context.Context, in *SimpleRequest, opts ...grpc.CallOption) (*SimpleResponse, error) {
 	out := new(SimpleResponse)
-	err := c.cc.Invoke(ctx, "/grpc.testing.TestService/UnaryCall", in, out, opts...)
+	err := c.cc.Invoke(ctx, TestService_UnaryCall_FullMethodName, in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -95,7 +95,7 @@ func (c *testServiceClient) UnaryCall(ctx context.Context, in *SimpleRequest, op
 
 func (c *testServiceClient) CacheableUnaryCall(ctx context.Context, in *SimpleRequest, opts ...grpc.CallOption) (*SimpleResponse, error) {
 	out := new(SimpleResponse)
-	err := c.cc.Invoke(ctx, "/grpc.testing.TestService/CacheableUnaryCall", in, out, opts...)
+	err := c.cc.Invoke(ctx, TestService_CacheableUnaryCall_FullMethodName, in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -103,7 +103,7 @@ func (c *testServiceClient) CacheableUnaryCall(ctx context.Context, in *SimpleRe
 }
 
 func (c *testServiceClient) StreamingOutputCall(ctx context.Context, in *StreamingOutputCallRequest, opts ...grpc.CallOption) (TestService_StreamingOutputCallClient, error) {
-	stream, err := c.cc.NewStream(ctx, &TestService_ServiceDesc.Streams[0], "/grpc.testing.TestService/StreamingOutputCall", opts...)
+	stream, err := c.cc.NewStream(ctx, &TestService_ServiceDesc.Streams[0], TestService_StreamingOutputCall_FullMethodName, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -135,7 +135,7 @@ func (x *testServiceStreamingOutputCallClient) Recv() (*StreamingOutputCallRespo
 }
 
 func (c *testServiceClient) StreamingInputCall(ctx context.Context, opts ...grpc.CallOption) (TestService_StreamingInputCallClient, error) {
-	stream, err := c.cc.NewStream(ctx, &TestService_ServiceDesc.Streams[1], "/grpc.testing.TestService/StreamingInputCall", opts...)
+	stream, err := c.cc.NewStream(ctx, &TestService_ServiceDesc.Streams[1], TestService_StreamingInputCall_FullMethodName, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -169,7 +169,7 @@ func (x *testServiceStreamingInputCallClient) CloseAndRecv() (*StreamingInputCal
 }
 
 func (c *testServiceClient) FullDuplexCall(ctx context.Context, opts ...grpc.CallOption) (TestService_FullDuplexCallClient, error) {
-	stream, err := c.cc.NewStream(ctx, &TestService_ServiceDesc.Streams[2], "/grpc.testing.TestService/FullDuplexCall", opts...)
+	stream, err := c.cc.NewStream(ctx, &TestService_ServiceDesc.Streams[2], TestService_FullDuplexCall_FullMethodName, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -200,7 +200,7 @@ func (x *testServiceFullDuplexCallClient) Recv() (*StreamingOutputCallResponse, 
 }
 
 func (c *testServiceClient) HalfDuplexCall(ctx context.Context, opts ...grpc.CallOption) (TestService_HalfDuplexCallClient, error) {
-	stream, err := c.cc.NewStream(ctx, &TestService_ServiceDesc.Streams[3], "/grpc.testing.TestService/HalfDuplexCall", opts...)
+	stream, err := c.cc.NewStream(ctx, &TestService_ServiceDesc.Streams[3], TestService_HalfDuplexCall_FullMethodName, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -232,7 +232,7 @@ func (x *testServiceHalfDuplexCallClient) Recv() (*StreamingOutputCallResponse, 
 
 func (c *testServiceClient) UnimplementedCall(ctx context.Context, in *Empty, opts ...grpc.CallOption) (*Empty, error) {
 	out := new(Empty)
-	err := c.cc.Invoke(ctx, "/grpc.testing.TestService/UnimplementedCall", in, out, opts...)
+	err := c.cc.Invoke(ctx, TestService_UnimplementedCall_FullMethodName, in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -323,7 +323,7 @@ func _TestService_EmptyCall_Handler(srv interface{}, ctx context.Context, dec fu
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/grpc.testing.TestService/EmptyCall",
+		FullMethod: TestService_EmptyCall_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(TestServiceServer).EmptyCall(ctx, req.(*Empty))
@@ -341,7 +341,7 @@ func _TestService_UnaryCall_Handler(srv interface{}, ctx context.Context, dec fu
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/grpc.testing.TestService/UnaryCall",
+		FullMethod: TestService_UnaryCall_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(TestServiceServer).UnaryCall(ctx, req.(*SimpleRequest))
@@ -359,7 +359,7 @@ func _TestService_CacheableUnaryCall_Handler(srv interface{}, ctx context.Contex
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/grpc.testing.TestService/CacheableUnaryCall",
+		FullMethod: TestService_CacheableUnaryCall_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(TestServiceServer).CacheableUnaryCall(ctx, req.(*SimpleRequest))
@@ -476,7 +476,7 @@ func _TestService_UnimplementedCall_Handler(srv interface{}, ctx context.Context
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/grpc.testing.TestService/UnimplementedCall",
+		FullMethod: TestService_UnimplementedCall_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(TestServiceServer).UnimplementedCall(ctx, req.(*Empty))
@@ -536,26 +536,15 @@ var TestService_ServiceDesc = grpc.ServiceDesc{
 }
 
 const (
-	TestService_EmptyCall_FullMethod           = "/grpc.testing.TestService/EmptyCall"
-	TestService_UnaryCall_FullMethod           = "/grpc.testing.TestService/UnaryCall"
-	TestService_CacheableUnaryCall_FullMethod  = "/grpc.testing.TestService/CacheableUnaryCall"
-	TestService_StreamingOutputCall_FullMethod = "/grpc.testing.TestService/StreamingOutputCall"
-	TestService_StreamingInputCall_FullMethod  = "/grpc.testing.TestService/StreamingInputCall"
-	TestService_FullDuplexCall_FullMethod      = "/grpc.testing.TestService/FullDuplexCall"
-	TestService_HalfDuplexCall_FullMethod      = "/grpc.testing.TestService/HalfDuplexCall"
-	TestService_UnimplementedCall_FullMethod   = "/grpc.testing.TestService/UnimplementedCall"
+	TestService_EmptyCall_FullMethodName           = "/grpc.testing.TestService/EmptyCall"
+	TestService_UnaryCall_FullMethodName           = "/grpc.testing.TestService/UnaryCall"
+	TestService_CacheableUnaryCall_FullMethodName  = "/grpc.testing.TestService/CacheableUnaryCall"
+	TestService_StreamingOutputCall_FullMethodName = "/grpc.testing.TestService/StreamingOutputCall"
+	TestService_StreamingInputCall_FullMethodName  = "/grpc.testing.TestService/StreamingInputCall"
+	TestService_FullDuplexCall_FullMethodName      = "/grpc.testing.TestService/FullDuplexCall"
+	TestService_HalfDuplexCall_FullMethodName      = "/grpc.testing.TestService/HalfDuplexCall"
+	TestService_UnimplementedCall_FullMethodName   = "/grpc.testing.TestService/UnimplementedCall"
 )
-
-var TestService_FullMethods = []string{
-	TestService_EmptyCall_FullMethod,
-	TestService_UnaryCall_FullMethod,
-	TestService_CacheableUnaryCall_FullMethod,
-	TestService_StreamingOutputCall_FullMethod,
-	TestService_StreamingInputCall_FullMethod,
-	TestService_FullDuplexCall_FullMethod,
-	TestService_HalfDuplexCall_FullMethod,
-	TestService_UnimplementedCall_FullMethod,
-}
 
 // UnimplementedServiceClient is the client API for UnimplementedService service.
 //
@@ -575,7 +564,7 @@ func NewUnimplementedServiceClient(cc grpc.ClientConnInterface) UnimplementedSer
 
 func (c *unimplementedServiceClient) UnimplementedCall(ctx context.Context, in *Empty, opts ...grpc.CallOption) (*Empty, error) {
 	out := new(Empty)
-	err := c.cc.Invoke(ctx, "/grpc.testing.UnimplementedService/UnimplementedCall", in, out, opts...)
+	err := c.cc.Invoke(ctx, UnimplementedService_UnimplementedCall_FullMethodName, in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -621,7 +610,7 @@ func _UnimplementedService_UnimplementedCall_Handler(srv interface{}, ctx contex
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/grpc.testing.UnimplementedService/UnimplementedCall",
+		FullMethod: UnimplementedService_UnimplementedCall_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(UnimplementedServiceServer).UnimplementedCall(ctx, req.(*Empty))
@@ -646,12 +635,8 @@ var UnimplementedService_ServiceDesc = grpc.ServiceDesc{
 }
 
 const (
-	UnimplementedService_UnimplementedCall_FullMethod = "/grpc.testing.UnimplementedService/UnimplementedCall"
+	UnimplementedService_UnimplementedCall_FullMethodName = "/grpc.testing.UnimplementedService/UnimplementedCall"
 )
-
-var UnimplementedService_FullMethods = []string{
-	UnimplementedService_UnimplementedCall_FullMethod,
-}
 
 // ReconnectServiceClient is the client API for ReconnectService service.
 //
@@ -671,7 +656,7 @@ func NewReconnectServiceClient(cc grpc.ClientConnInterface) ReconnectServiceClie
 
 func (c *reconnectServiceClient) Start(ctx context.Context, in *ReconnectParams, opts ...grpc.CallOption) (*Empty, error) {
 	out := new(Empty)
-	err := c.cc.Invoke(ctx, "/grpc.testing.ReconnectService/Start", in, out, opts...)
+	err := c.cc.Invoke(ctx, ReconnectService_Start_FullMethodName, in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -680,7 +665,7 @@ func (c *reconnectServiceClient) Start(ctx context.Context, in *ReconnectParams,
 
 func (c *reconnectServiceClient) Stop(ctx context.Context, in *Empty, opts ...grpc.CallOption) (*ReconnectInfo, error) {
 	out := new(ReconnectInfo)
-	err := c.cc.Invoke(ctx, "/grpc.testing.ReconnectService/Stop", in, out, opts...)
+	err := c.cc.Invoke(ctx, ReconnectService_Stop_FullMethodName, in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -729,7 +714,7 @@ func _ReconnectService_Start_Handler(srv interface{}, ctx context.Context, dec f
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/grpc.testing.ReconnectService/Start",
+		FullMethod: ReconnectService_Start_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(ReconnectServiceServer).Start(ctx, req.(*ReconnectParams))
@@ -747,7 +732,7 @@ func _ReconnectService_Stop_Handler(srv interface{}, ctx context.Context, dec fu
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/grpc.testing.ReconnectService/Stop",
+		FullMethod: ReconnectService_Stop_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(ReconnectServiceServer).Stop(ctx, req.(*Empty))
@@ -776,14 +761,9 @@ var ReconnectService_ServiceDesc = grpc.ServiceDesc{
 }
 
 const (
-	ReconnectService_Start_FullMethod = "/grpc.testing.ReconnectService/Start"
-	ReconnectService_Stop_FullMethod  = "/grpc.testing.ReconnectService/Stop"
+	ReconnectService_Start_FullMethodName = "/grpc.testing.ReconnectService/Start"
+	ReconnectService_Stop_FullMethodName  = "/grpc.testing.ReconnectService/Stop"
 )
-
-var ReconnectService_FullMethods = []string{
-	ReconnectService_Start_FullMethod,
-	ReconnectService_Stop_FullMethod,
-}
 
 // LoadBalancerStatsServiceClient is the client API for LoadBalancerStatsService service.
 //
@@ -805,7 +785,7 @@ func NewLoadBalancerStatsServiceClient(cc grpc.ClientConnInterface) LoadBalancer
 
 func (c *loadBalancerStatsServiceClient) GetClientStats(ctx context.Context, in *LoadBalancerStatsRequest, opts ...grpc.CallOption) (*LoadBalancerStatsResponse, error) {
 	out := new(LoadBalancerStatsResponse)
-	err := c.cc.Invoke(ctx, "/grpc.testing.LoadBalancerStatsService/GetClientStats", in, out, opts...)
+	err := c.cc.Invoke(ctx, LoadBalancerStatsService_GetClientStats_FullMethodName, in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -814,7 +794,7 @@ func (c *loadBalancerStatsServiceClient) GetClientStats(ctx context.Context, in 
 
 func (c *loadBalancerStatsServiceClient) GetClientAccumulatedStats(ctx context.Context, in *LoadBalancerAccumulatedStatsRequest, opts ...grpc.CallOption) (*LoadBalancerAccumulatedStatsResponse, error) {
 	out := new(LoadBalancerAccumulatedStatsResponse)
-	err := c.cc.Invoke(ctx, "/grpc.testing.LoadBalancerStatsService/GetClientAccumulatedStats", in, out, opts...)
+	err := c.cc.Invoke(ctx, LoadBalancerStatsService_GetClientAccumulatedStats_FullMethodName, in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -866,7 +846,7 @@ func _LoadBalancerStatsService_GetClientStats_Handler(srv interface{}, ctx conte
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/grpc.testing.LoadBalancerStatsService/GetClientStats",
+		FullMethod: LoadBalancerStatsService_GetClientStats_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(LoadBalancerStatsServiceServer).GetClientStats(ctx, req.(*LoadBalancerStatsRequest))
@@ -884,7 +864,7 @@ func _LoadBalancerStatsService_GetClientAccumulatedStats_Handler(srv interface{}
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/grpc.testing.LoadBalancerStatsService/GetClientAccumulatedStats",
+		FullMethod: LoadBalancerStatsService_GetClientAccumulatedStats_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(LoadBalancerStatsServiceServer).GetClientAccumulatedStats(ctx, req.(*LoadBalancerAccumulatedStatsRequest))
@@ -913,14 +893,9 @@ var LoadBalancerStatsService_ServiceDesc = grpc.ServiceDesc{
 }
 
 const (
-	LoadBalancerStatsService_GetClientStats_FullMethod            = "/grpc.testing.LoadBalancerStatsService/GetClientStats"
-	LoadBalancerStatsService_GetClientAccumulatedStats_FullMethod = "/grpc.testing.LoadBalancerStatsService/GetClientAccumulatedStats"
+	LoadBalancerStatsService_GetClientStats_FullMethodName            = "/grpc.testing.LoadBalancerStatsService/GetClientStats"
+	LoadBalancerStatsService_GetClientAccumulatedStats_FullMethodName = "/grpc.testing.LoadBalancerStatsService/GetClientAccumulatedStats"
 )
-
-var LoadBalancerStatsService_FullMethods = []string{
-	LoadBalancerStatsService_GetClientStats_FullMethod,
-	LoadBalancerStatsService_GetClientAccumulatedStats_FullMethod,
-}
 
 // XdsUpdateHealthServiceClient is the client API for XdsUpdateHealthService service.
 //
@@ -940,7 +915,7 @@ func NewXdsUpdateHealthServiceClient(cc grpc.ClientConnInterface) XdsUpdateHealt
 
 func (c *xdsUpdateHealthServiceClient) SetServing(ctx context.Context, in *Empty, opts ...grpc.CallOption) (*Empty, error) {
 	out := new(Empty)
-	err := c.cc.Invoke(ctx, "/grpc.testing.XdsUpdateHealthService/SetServing", in, out, opts...)
+	err := c.cc.Invoke(ctx, XdsUpdateHealthService_SetServing_FullMethodName, in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -949,7 +924,7 @@ func (c *xdsUpdateHealthServiceClient) SetServing(ctx context.Context, in *Empty
 
 func (c *xdsUpdateHealthServiceClient) SetNotServing(ctx context.Context, in *Empty, opts ...grpc.CallOption) (*Empty, error) {
 	out := new(Empty)
-	err := c.cc.Invoke(ctx, "/grpc.testing.XdsUpdateHealthService/SetNotServing", in, out, opts...)
+	err := c.cc.Invoke(ctx, XdsUpdateHealthService_SetNotServing_FullMethodName, in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -999,7 +974,7 @@ func _XdsUpdateHealthService_SetServing_Handler(srv interface{}, ctx context.Con
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/grpc.testing.XdsUpdateHealthService/SetServing",
+		FullMethod: XdsUpdateHealthService_SetServing_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(XdsUpdateHealthServiceServer).SetServing(ctx, req.(*Empty))
@@ -1017,7 +992,7 @@ func _XdsUpdateHealthService_SetNotServing_Handler(srv interface{}, ctx context.
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/grpc.testing.XdsUpdateHealthService/SetNotServing",
+		FullMethod: XdsUpdateHealthService_SetNotServing_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(XdsUpdateHealthServiceServer).SetNotServing(ctx, req.(*Empty))
@@ -1046,14 +1021,9 @@ var XdsUpdateHealthService_ServiceDesc = grpc.ServiceDesc{
 }
 
 const (
-	XdsUpdateHealthService_SetServing_FullMethod    = "/grpc.testing.XdsUpdateHealthService/SetServing"
-	XdsUpdateHealthService_SetNotServing_FullMethod = "/grpc.testing.XdsUpdateHealthService/SetNotServing"
+	XdsUpdateHealthService_SetServing_FullMethodName    = "/grpc.testing.XdsUpdateHealthService/SetServing"
+	XdsUpdateHealthService_SetNotServing_FullMethodName = "/grpc.testing.XdsUpdateHealthService/SetNotServing"
 )
-
-var XdsUpdateHealthService_FullMethods = []string{
-	XdsUpdateHealthService_SetServing_FullMethod,
-	XdsUpdateHealthService_SetNotServing_FullMethod,
-}
 
 // XdsUpdateClientConfigureServiceClient is the client API for XdsUpdateClientConfigureService service.
 //
@@ -1073,7 +1043,7 @@ func NewXdsUpdateClientConfigureServiceClient(cc grpc.ClientConnInterface) XdsUp
 
 func (c *xdsUpdateClientConfigureServiceClient) Configure(ctx context.Context, in *ClientConfigureRequest, opts ...grpc.CallOption) (*ClientConfigureResponse, error) {
 	out := new(ClientConfigureResponse)
-	err := c.cc.Invoke(ctx, "/grpc.testing.XdsUpdateClientConfigureService/Configure", in, out, opts...)
+	err := c.cc.Invoke(ctx, XdsUpdateClientConfigureService_Configure_FullMethodName, in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -1120,7 +1090,7 @@ func _XdsUpdateClientConfigureService_Configure_Handler(srv interface{}, ctx con
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/grpc.testing.XdsUpdateClientConfigureService/Configure",
+		FullMethod: XdsUpdateClientConfigureService_Configure_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(XdsUpdateClientConfigureServiceServer).Configure(ctx, req.(*ClientConfigureRequest))
@@ -1145,9 +1115,5 @@ var XdsUpdateClientConfigureService_ServiceDesc = grpc.ServiceDesc{
 }
 
 const (
-	XdsUpdateClientConfigureService_Configure_FullMethod = "/grpc.testing.XdsUpdateClientConfigureService/Configure"
+	XdsUpdateClientConfigureService_Configure_FullMethodName = "/grpc.testing.XdsUpdateClientConfigureService/Configure"
 )
-
-var XdsUpdateClientConfigureService_FullMethods = []string{
-	XdsUpdateClientConfigureService_Configure_FullMethod,
-}

--- a/interop/grpc_testing/test_grpc.pb.go
+++ b/interop/grpc_testing/test_grpc.pb.go
@@ -535,6 +535,28 @@ var TestService_ServiceDesc = grpc.ServiceDesc{
 	Metadata: "grpc/testing/test.proto",
 }
 
+const (
+	TestService_EmptyCall_FullMethod           = "/grpc.testing.TestService/EmptyCall"
+	TestService_UnaryCall_FullMethod           = "/grpc.testing.TestService/UnaryCall"
+	TestService_CacheableUnaryCall_FullMethod  = "/grpc.testing.TestService/CacheableUnaryCall"
+	TestService_StreamingOutputCall_FullMethod = "/grpc.testing.TestService/StreamingOutputCall"
+	TestService_StreamingInputCall_FullMethod  = "/grpc.testing.TestService/StreamingInputCall"
+	TestService_FullDuplexCall_FullMethod      = "/grpc.testing.TestService/FullDuplexCall"
+	TestService_HalfDuplexCall_FullMethod      = "/grpc.testing.TestService/HalfDuplexCall"
+	TestService_UnimplementedCall_FullMethod   = "/grpc.testing.TestService/UnimplementedCall"
+)
+
+var TestService_FullMethods = []string{
+	TestService_EmptyCall_FullMethod,
+	TestService_UnaryCall_FullMethod,
+	TestService_CacheableUnaryCall_FullMethod,
+	TestService_StreamingOutputCall_FullMethod,
+	TestService_StreamingInputCall_FullMethod,
+	TestService_FullDuplexCall_FullMethod,
+	TestService_HalfDuplexCall_FullMethod,
+	TestService_UnimplementedCall_FullMethod,
+}
+
 // UnimplementedServiceClient is the client API for UnimplementedService service.
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
@@ -621,6 +643,14 @@ var UnimplementedService_ServiceDesc = grpc.ServiceDesc{
 	},
 	Streams:  []grpc.StreamDesc{},
 	Metadata: "grpc/testing/test.proto",
+}
+
+const (
+	UnimplementedService_UnimplementedCall_FullMethod = "/grpc.testing.UnimplementedService/UnimplementedCall"
+)
+
+var UnimplementedService_FullMethods = []string{
+	UnimplementedService_UnimplementedCall_FullMethod,
 }
 
 // ReconnectServiceClient is the client API for ReconnectService service.
@@ -743,6 +773,16 @@ var ReconnectService_ServiceDesc = grpc.ServiceDesc{
 	},
 	Streams:  []grpc.StreamDesc{},
 	Metadata: "grpc/testing/test.proto",
+}
+
+const (
+	ReconnectService_Start_FullMethod = "/grpc.testing.ReconnectService/Start"
+	ReconnectService_Stop_FullMethod  = "/grpc.testing.ReconnectService/Stop"
+)
+
+var ReconnectService_FullMethods = []string{
+	ReconnectService_Start_FullMethod,
+	ReconnectService_Stop_FullMethod,
 }
 
 // LoadBalancerStatsServiceClient is the client API for LoadBalancerStatsService service.
@@ -872,6 +912,16 @@ var LoadBalancerStatsService_ServiceDesc = grpc.ServiceDesc{
 	Metadata: "grpc/testing/test.proto",
 }
 
+const (
+	LoadBalancerStatsService_GetClientStats_FullMethod            = "/grpc.testing.LoadBalancerStatsService/GetClientStats"
+	LoadBalancerStatsService_GetClientAccumulatedStats_FullMethod = "/grpc.testing.LoadBalancerStatsService/GetClientAccumulatedStats"
+)
+
+var LoadBalancerStatsService_FullMethods = []string{
+	LoadBalancerStatsService_GetClientStats_FullMethod,
+	LoadBalancerStatsService_GetClientAccumulatedStats_FullMethod,
+}
+
 // XdsUpdateHealthServiceClient is the client API for XdsUpdateHealthService service.
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
@@ -995,6 +1045,16 @@ var XdsUpdateHealthService_ServiceDesc = grpc.ServiceDesc{
 	Metadata: "grpc/testing/test.proto",
 }
 
+const (
+	XdsUpdateHealthService_SetServing_FullMethod    = "/grpc.testing.XdsUpdateHealthService/SetServing"
+	XdsUpdateHealthService_SetNotServing_FullMethod = "/grpc.testing.XdsUpdateHealthService/SetNotServing"
+)
+
+var XdsUpdateHealthService_FullMethods = []string{
+	XdsUpdateHealthService_SetServing_FullMethod,
+	XdsUpdateHealthService_SetNotServing_FullMethod,
+}
+
 // XdsUpdateClientConfigureServiceClient is the client API for XdsUpdateClientConfigureService service.
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
@@ -1082,4 +1142,12 @@ var XdsUpdateClientConfigureService_ServiceDesc = grpc.ServiceDesc{
 	},
 	Streams:  []grpc.StreamDesc{},
 	Metadata: "grpc/testing/test.proto",
+}
+
+const (
+	XdsUpdateClientConfigureService_Configure_FullMethod = "/grpc.testing.XdsUpdateClientConfigureService/Configure"
+)
+
+var XdsUpdateClientConfigureService_FullMethods = []string{
+	XdsUpdateClientConfigureService_Configure_FullMethod,
 }

--- a/interop/grpc_testing/test_grpc.pb.go
+++ b/interop/grpc_testing/test_grpc.pb.go
@@ -35,6 +35,17 @@ import (
 // Requires gRPC-Go v1.32.0 or later.
 const _ = grpc.SupportPackageIsVersion7
 
+const (
+	TestService_EmptyCall_FullMethodName           = "/grpc.testing.TestService/EmptyCall"
+	TestService_UnaryCall_FullMethodName           = "/grpc.testing.TestService/UnaryCall"
+	TestService_CacheableUnaryCall_FullMethodName  = "/grpc.testing.TestService/CacheableUnaryCall"
+	TestService_StreamingOutputCall_FullMethodName = "/grpc.testing.TestService/StreamingOutputCall"
+	TestService_StreamingInputCall_FullMethodName  = "/grpc.testing.TestService/StreamingInputCall"
+	TestService_FullDuplexCall_FullMethodName      = "/grpc.testing.TestService/FullDuplexCall"
+	TestService_HalfDuplexCall_FullMethodName      = "/grpc.testing.TestService/HalfDuplexCall"
+	TestService_UnimplementedCall_FullMethodName   = "/grpc.testing.TestService/UnimplementedCall"
+)
+
 // TestServiceClient is the client API for TestService service.
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
@@ -536,14 +547,7 @@ var TestService_ServiceDesc = grpc.ServiceDesc{
 }
 
 const (
-	TestService_EmptyCall_FullMethodName           = "/grpc.testing.TestService/EmptyCall"
-	TestService_UnaryCall_FullMethodName           = "/grpc.testing.TestService/UnaryCall"
-	TestService_CacheableUnaryCall_FullMethodName  = "/grpc.testing.TestService/CacheableUnaryCall"
-	TestService_StreamingOutputCall_FullMethodName = "/grpc.testing.TestService/StreamingOutputCall"
-	TestService_StreamingInputCall_FullMethodName  = "/grpc.testing.TestService/StreamingInputCall"
-	TestService_FullDuplexCall_FullMethodName      = "/grpc.testing.TestService/FullDuplexCall"
-	TestService_HalfDuplexCall_FullMethodName      = "/grpc.testing.TestService/HalfDuplexCall"
-	TestService_UnimplementedCall_FullMethodName   = "/grpc.testing.TestService/UnimplementedCall"
+	UnimplementedService_UnimplementedCall_FullMethodName = "/grpc.testing.UnimplementedService/UnimplementedCall"
 )
 
 // UnimplementedServiceClient is the client API for UnimplementedService service.
@@ -635,7 +639,8 @@ var UnimplementedService_ServiceDesc = grpc.ServiceDesc{
 }
 
 const (
-	UnimplementedService_UnimplementedCall_FullMethodName = "/grpc.testing.UnimplementedService/UnimplementedCall"
+	ReconnectService_Start_FullMethodName = "/grpc.testing.ReconnectService/Start"
+	ReconnectService_Stop_FullMethodName  = "/grpc.testing.ReconnectService/Stop"
 )
 
 // ReconnectServiceClient is the client API for ReconnectService service.
@@ -761,8 +766,8 @@ var ReconnectService_ServiceDesc = grpc.ServiceDesc{
 }
 
 const (
-	ReconnectService_Start_FullMethodName = "/grpc.testing.ReconnectService/Start"
-	ReconnectService_Stop_FullMethodName  = "/grpc.testing.ReconnectService/Stop"
+	LoadBalancerStatsService_GetClientStats_FullMethodName            = "/grpc.testing.LoadBalancerStatsService/GetClientStats"
+	LoadBalancerStatsService_GetClientAccumulatedStats_FullMethodName = "/grpc.testing.LoadBalancerStatsService/GetClientAccumulatedStats"
 )
 
 // LoadBalancerStatsServiceClient is the client API for LoadBalancerStatsService service.
@@ -893,8 +898,8 @@ var LoadBalancerStatsService_ServiceDesc = grpc.ServiceDesc{
 }
 
 const (
-	LoadBalancerStatsService_GetClientStats_FullMethodName            = "/grpc.testing.LoadBalancerStatsService/GetClientStats"
-	LoadBalancerStatsService_GetClientAccumulatedStats_FullMethodName = "/grpc.testing.LoadBalancerStatsService/GetClientAccumulatedStats"
+	XdsUpdateHealthService_SetServing_FullMethodName    = "/grpc.testing.XdsUpdateHealthService/SetServing"
+	XdsUpdateHealthService_SetNotServing_FullMethodName = "/grpc.testing.XdsUpdateHealthService/SetNotServing"
 )
 
 // XdsUpdateHealthServiceClient is the client API for XdsUpdateHealthService service.
@@ -1021,8 +1026,7 @@ var XdsUpdateHealthService_ServiceDesc = grpc.ServiceDesc{
 }
 
 const (
-	XdsUpdateHealthService_SetServing_FullMethodName    = "/grpc.testing.XdsUpdateHealthService/SetServing"
-	XdsUpdateHealthService_SetNotServing_FullMethodName = "/grpc.testing.XdsUpdateHealthService/SetNotServing"
+	XdsUpdateClientConfigureService_Configure_FullMethodName = "/grpc.testing.XdsUpdateClientConfigureService/Configure"
 )
 
 // XdsUpdateClientConfigureServiceClient is the client API for XdsUpdateClientConfigureService service.
@@ -1113,7 +1117,3 @@ var XdsUpdateClientConfigureService_ServiceDesc = grpc.ServiceDesc{
 	Streams:  []grpc.StreamDesc{},
 	Metadata: "grpc/testing/test.proto",
 }
-
-const (
-	XdsUpdateClientConfigureService_Configure_FullMethodName = "/grpc.testing.XdsUpdateClientConfigureService/Configure"
-)

--- a/interop/grpc_testing/worker_service_grpc.pb.go
+++ b/interop/grpc_testing/worker_service_grpc.pb.go
@@ -35,6 +35,13 @@ import (
 // Requires gRPC-Go v1.32.0 or later.
 const _ = grpc.SupportPackageIsVersion7
 
+const (
+	WorkerService_RunServer_FullMethodName  = "/grpc.testing.WorkerService/RunServer"
+	WorkerService_RunClient_FullMethodName  = "/grpc.testing.WorkerService/RunClient"
+	WorkerService_CoreCount_FullMethodName  = "/grpc.testing.WorkerService/CoreCount"
+	WorkerService_QuitWorker_FullMethodName = "/grpc.testing.WorkerService/QuitWorker"
+)
+
 // WorkerServiceClient is the client API for WorkerService service.
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
@@ -321,10 +328,3 @@ var WorkerService_ServiceDesc = grpc.ServiceDesc{
 	},
 	Metadata: "grpc/testing/worker_service.proto",
 }
-
-const (
-	WorkerService_RunServer_FullMethodName  = "/grpc.testing.WorkerService/RunServer"
-	WorkerService_RunClient_FullMethodName  = "/grpc.testing.WorkerService/RunClient"
-	WorkerService_CoreCount_FullMethodName  = "/grpc.testing.WorkerService/CoreCount"
-	WorkerService_QuitWorker_FullMethodName = "/grpc.testing.WorkerService/QuitWorker"
-)

--- a/interop/grpc_testing/worker_service_grpc.pb.go
+++ b/interop/grpc_testing/worker_service_grpc.pb.go
@@ -321,3 +321,17 @@ var WorkerService_ServiceDesc = grpc.ServiceDesc{
 	},
 	Metadata: "grpc/testing/worker_service.proto",
 }
+
+const (
+	WorkerService_RunServer_FullMethod  = "/grpc.testing.WorkerService/RunServer"
+	WorkerService_RunClient_FullMethod  = "/grpc.testing.WorkerService/RunClient"
+	WorkerService_CoreCount_FullMethod  = "/grpc.testing.WorkerService/CoreCount"
+	WorkerService_QuitWorker_FullMethod = "/grpc.testing.WorkerService/QuitWorker"
+)
+
+var WorkerService_FullMethods = []string{
+	WorkerService_RunServer_FullMethod,
+	WorkerService_RunClient_FullMethod,
+	WorkerService_CoreCount_FullMethod,
+	WorkerService_QuitWorker_FullMethod,
+}

--- a/interop/grpc_testing/worker_service_grpc.pb.go
+++ b/interop/grpc_testing/worker_service_grpc.pb.go
@@ -68,7 +68,7 @@ func NewWorkerServiceClient(cc grpc.ClientConnInterface) WorkerServiceClient {
 }
 
 func (c *workerServiceClient) RunServer(ctx context.Context, opts ...grpc.CallOption) (WorkerService_RunServerClient, error) {
-	stream, err := c.cc.NewStream(ctx, &WorkerService_ServiceDesc.Streams[0], "/grpc.testing.WorkerService/RunServer", opts...)
+	stream, err := c.cc.NewStream(ctx, &WorkerService_ServiceDesc.Streams[0], WorkerService_RunServer_FullMethodName, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -99,7 +99,7 @@ func (x *workerServiceRunServerClient) Recv() (*ServerStatus, error) {
 }
 
 func (c *workerServiceClient) RunClient(ctx context.Context, opts ...grpc.CallOption) (WorkerService_RunClientClient, error) {
-	stream, err := c.cc.NewStream(ctx, &WorkerService_ServiceDesc.Streams[1], "/grpc.testing.WorkerService/RunClient", opts...)
+	stream, err := c.cc.NewStream(ctx, &WorkerService_ServiceDesc.Streams[1], WorkerService_RunClient_FullMethodName, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -131,7 +131,7 @@ func (x *workerServiceRunClientClient) Recv() (*ClientStatus, error) {
 
 func (c *workerServiceClient) CoreCount(ctx context.Context, in *CoreRequest, opts ...grpc.CallOption) (*CoreResponse, error) {
 	out := new(CoreResponse)
-	err := c.cc.Invoke(ctx, "/grpc.testing.WorkerService/CoreCount", in, out, opts...)
+	err := c.cc.Invoke(ctx, WorkerService_CoreCount_FullMethodName, in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -140,7 +140,7 @@ func (c *workerServiceClient) CoreCount(ctx context.Context, in *CoreRequest, op
 
 func (c *workerServiceClient) QuitWorker(ctx context.Context, in *Void, opts ...grpc.CallOption) (*Void, error) {
 	out := new(Void)
-	err := c.cc.Invoke(ctx, "/grpc.testing.WorkerService/QuitWorker", in, out, opts...)
+	err := c.cc.Invoke(ctx, WorkerService_QuitWorker_FullMethodName, in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -263,7 +263,7 @@ func _WorkerService_CoreCount_Handler(srv interface{}, ctx context.Context, dec 
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/grpc.testing.WorkerService/CoreCount",
+		FullMethod: WorkerService_CoreCount_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(WorkerServiceServer).CoreCount(ctx, req.(*CoreRequest))
@@ -281,7 +281,7 @@ func _WorkerService_QuitWorker_Handler(srv interface{}, ctx context.Context, dec
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/grpc.testing.WorkerService/QuitWorker",
+		FullMethod: WorkerService_QuitWorker_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(WorkerServiceServer).QuitWorker(ctx, req.(*Void))
@@ -323,15 +323,8 @@ var WorkerService_ServiceDesc = grpc.ServiceDesc{
 }
 
 const (
-	WorkerService_RunServer_FullMethod  = "/grpc.testing.WorkerService/RunServer"
-	WorkerService_RunClient_FullMethod  = "/grpc.testing.WorkerService/RunClient"
-	WorkerService_CoreCount_FullMethod  = "/grpc.testing.WorkerService/CoreCount"
-	WorkerService_QuitWorker_FullMethod = "/grpc.testing.WorkerService/QuitWorker"
+	WorkerService_RunServer_FullMethodName  = "/grpc.testing.WorkerService/RunServer"
+	WorkerService_RunClient_FullMethodName  = "/grpc.testing.WorkerService/RunClient"
+	WorkerService_CoreCount_FullMethodName  = "/grpc.testing.WorkerService/CoreCount"
+	WorkerService_QuitWorker_FullMethodName = "/grpc.testing.WorkerService/QuitWorker"
 )
-
-var WorkerService_FullMethods = []string{
-	WorkerService_RunServer_FullMethod,
-	WorkerService_RunClient_FullMethod,
-	WorkerService_CoreCount_FullMethod,
-	WorkerService_QuitWorker_FullMethod,
-}

--- a/profiling/proto/service_grpc.pb.go
+++ b/profiling/proto/service_grpc.pb.go
@@ -32,6 +32,11 @@ import (
 // Requires gRPC-Go v1.32.0 or later.
 const _ = grpc.SupportPackageIsVersion7
 
+const (
+	Profiling_Enable_FullMethodName         = "/grpc.go.profiling.v1alpha.Profiling/Enable"
+	Profiling_GetStreamStats_FullMethodName = "/grpc.go.profiling.v1alpha.Profiling/GetStreamStats"
+)
+
 // ProfilingClient is the client API for Profiling service.
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
@@ -157,8 +162,3 @@ var Profiling_ServiceDesc = grpc.ServiceDesc{
 	Streams:  []grpc.StreamDesc{},
 	Metadata: "profiling/proto/service.proto",
 }
-
-const (
-	Profiling_Enable_FullMethodName         = "/grpc.go.profiling.v1alpha.Profiling/Enable"
-	Profiling_GetStreamStats_FullMethodName = "/grpc.go.profiling.v1alpha.Profiling/GetStreamStats"
-)

--- a/profiling/proto/service_grpc.pb.go
+++ b/profiling/proto/service_grpc.pb.go
@@ -157,3 +157,13 @@ var Profiling_ServiceDesc = grpc.ServiceDesc{
 	Streams:  []grpc.StreamDesc{},
 	Metadata: "profiling/proto/service.proto",
 }
+
+const (
+	Profiling_Enable_FullMethod         = "/grpc.go.profiling.v1alpha.Profiling/Enable"
+	Profiling_GetStreamStats_FullMethod = "/grpc.go.profiling.v1alpha.Profiling/GetStreamStats"
+)
+
+var Profiling_FullMethods = []string{
+	Profiling_Enable_FullMethod,
+	Profiling_GetStreamStats_FullMethod,
+}

--- a/profiling/proto/service_grpc.pb.go
+++ b/profiling/proto/service_grpc.pb.go
@@ -53,7 +53,7 @@ func NewProfilingClient(cc grpc.ClientConnInterface) ProfilingClient {
 
 func (c *profilingClient) Enable(ctx context.Context, in *EnableRequest, opts ...grpc.CallOption) (*EnableResponse, error) {
 	out := new(EnableResponse)
-	err := c.cc.Invoke(ctx, "/grpc.go.profiling.v1alpha.Profiling/Enable", in, out, opts...)
+	err := c.cc.Invoke(ctx, Profiling_Enable_FullMethodName, in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -62,7 +62,7 @@ func (c *profilingClient) Enable(ctx context.Context, in *EnableRequest, opts ..
 
 func (c *profilingClient) GetStreamStats(ctx context.Context, in *GetStreamStatsRequest, opts ...grpc.CallOption) (*GetStreamStatsResponse, error) {
 	out := new(GetStreamStatsResponse)
-	err := c.cc.Invoke(ctx, "/grpc.go.profiling.v1alpha.Profiling/GetStreamStats", in, out, opts...)
+	err := c.cc.Invoke(ctx, Profiling_GetStreamStats_FullMethodName, in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -112,7 +112,7 @@ func _Profiling_Enable_Handler(srv interface{}, ctx context.Context, dec func(in
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/grpc.go.profiling.v1alpha.Profiling/Enable",
+		FullMethod: Profiling_Enable_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(ProfilingServer).Enable(ctx, req.(*EnableRequest))
@@ -130,7 +130,7 @@ func _Profiling_GetStreamStats_Handler(srv interface{}, ctx context.Context, dec
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/grpc.go.profiling.v1alpha.Profiling/GetStreamStats",
+		FullMethod: Profiling_GetStreamStats_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(ProfilingServer).GetStreamStats(ctx, req.(*GetStreamStatsRequest))
@@ -159,11 +159,6 @@ var Profiling_ServiceDesc = grpc.ServiceDesc{
 }
 
 const (
-	Profiling_Enable_FullMethod         = "/grpc.go.profiling.v1alpha.Profiling/Enable"
-	Profiling_GetStreamStats_FullMethod = "/grpc.go.profiling.v1alpha.Profiling/GetStreamStats"
+	Profiling_Enable_FullMethodName         = "/grpc.go.profiling.v1alpha.Profiling/Enable"
+	Profiling_GetStreamStats_FullMethodName = "/grpc.go.profiling.v1alpha.Profiling/GetStreamStats"
 )
-
-var Profiling_FullMethods = []string{
-	Profiling_Enable_FullMethod,
-	Profiling_GetStreamStats_FullMethod,
-}

--- a/reflection/grpc_reflection_v1/reflection_grpc.pb.go
+++ b/reflection/grpc_reflection_v1/reflection_grpc.pb.go
@@ -39,6 +39,10 @@ import (
 // Requires gRPC-Go v1.32.0 or later.
 const _ = grpc.SupportPackageIsVersion7
 
+const (
+	ServerReflection_ServerReflectionInfo_FullMethodName = "/grpc.reflection.v1.ServerReflection/ServerReflectionInfo"
+)
+
 // ServerReflectionClient is the client API for ServerReflection service.
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
@@ -158,7 +162,3 @@ var ServerReflection_ServiceDesc = grpc.ServiceDesc{
 	},
 	Metadata: "grpc/reflection/v1/reflection.proto",
 }
-
-const (
-	ServerReflection_ServerReflectionInfo_FullMethodName = "/grpc.reflection.v1.ServerReflection/ServerReflectionInfo"
-)

--- a/reflection/grpc_reflection_v1/reflection_grpc.pb.go
+++ b/reflection/grpc_reflection_v1/reflection_grpc.pb.go
@@ -57,7 +57,7 @@ func NewServerReflectionClient(cc grpc.ClientConnInterface) ServerReflectionClie
 }
 
 func (c *serverReflectionClient) ServerReflectionInfo(ctx context.Context, opts ...grpc.CallOption) (ServerReflection_ServerReflectionInfoClient, error) {
-	stream, err := c.cc.NewStream(ctx, &ServerReflection_ServiceDesc.Streams[0], "/grpc.reflection.v1.ServerReflection/ServerReflectionInfo", opts...)
+	stream, err := c.cc.NewStream(ctx, &ServerReflection_ServiceDesc.Streams[0], ServerReflection_ServerReflectionInfo_FullMethodName, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -160,9 +160,5 @@ var ServerReflection_ServiceDesc = grpc.ServiceDesc{
 }
 
 const (
-	ServerReflection_ServerReflectionInfo_FullMethod = "/grpc.reflection.v1.ServerReflection/ServerReflectionInfo"
+	ServerReflection_ServerReflectionInfo_FullMethodName = "/grpc.reflection.v1.ServerReflection/ServerReflectionInfo"
 )
-
-var ServerReflection_FullMethods = []string{
-	ServerReflection_ServerReflectionInfo_FullMethod,
-}

--- a/reflection/grpc_reflection_v1/reflection_grpc.pb.go
+++ b/reflection/grpc_reflection_v1/reflection_grpc.pb.go
@@ -158,3 +158,11 @@ var ServerReflection_ServiceDesc = grpc.ServiceDesc{
 	},
 	Metadata: "grpc/reflection/v1/reflection.proto",
 }
+
+const (
+	ServerReflection_ServerReflectionInfo_FullMethod = "/grpc.reflection.v1.ServerReflection/ServerReflectionInfo"
+)
+
+var ServerReflection_FullMethods = []string{
+	ServerReflection_ServerReflectionInfo_FullMethod,
+}

--- a/reflection/grpc_reflection_v1alpha/reflection_grpc.pb.go
+++ b/reflection/grpc_reflection_v1alpha/reflection_grpc.pb.go
@@ -54,7 +54,7 @@ func NewServerReflectionClient(cc grpc.ClientConnInterface) ServerReflectionClie
 }
 
 func (c *serverReflectionClient) ServerReflectionInfo(ctx context.Context, opts ...grpc.CallOption) (ServerReflection_ServerReflectionInfoClient, error) {
-	stream, err := c.cc.NewStream(ctx, &ServerReflection_ServiceDesc.Streams[0], "/grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo", opts...)
+	stream, err := c.cc.NewStream(ctx, &ServerReflection_ServiceDesc.Streams[0], ServerReflection_ServerReflectionInfo_FullMethodName, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -157,9 +157,5 @@ var ServerReflection_ServiceDesc = grpc.ServiceDesc{
 }
 
 const (
-	ServerReflection_ServerReflectionInfo_FullMethod = "/grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo"
+	ServerReflection_ServerReflectionInfo_FullMethodName = "/grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo"
 )
-
-var ServerReflection_FullMethods = []string{
-	ServerReflection_ServerReflectionInfo_FullMethod,
-}

--- a/reflection/grpc_reflection_v1alpha/reflection_grpc.pb.go
+++ b/reflection/grpc_reflection_v1alpha/reflection_grpc.pb.go
@@ -155,3 +155,11 @@ var ServerReflection_ServiceDesc = grpc.ServiceDesc{
 	},
 	Metadata: "grpc/reflection/v1alpha/reflection.proto",
 }
+
+const (
+	ServerReflection_ServerReflectionInfo_FullMethod = "/grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo"
+)
+
+var ServerReflection_FullMethods = []string{
+	ServerReflection_ServerReflectionInfo_FullMethod,
+}

--- a/reflection/grpc_reflection_v1alpha/reflection_grpc.pb.go
+++ b/reflection/grpc_reflection_v1alpha/reflection_grpc.pb.go
@@ -36,6 +36,10 @@ import (
 // Requires gRPC-Go v1.32.0 or later.
 const _ = grpc.SupportPackageIsVersion7
 
+const (
+	ServerReflection_ServerReflectionInfo_FullMethodName = "/grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo"
+)
+
 // ServerReflectionClient is the client API for ServerReflection service.
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
@@ -155,7 +159,3 @@ var ServerReflection_ServiceDesc = grpc.ServiceDesc{
 	},
 	Metadata: "grpc/reflection/v1alpha/reflection.proto",
 }
-
-const (
-	ServerReflection_ServerReflectionInfo_FullMethodName = "/grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo"
-)

--- a/reflection/grpc_testing/test_grpc.pb.go
+++ b/reflection/grpc_testing/test_grpc.pb.go
@@ -186,3 +186,13 @@ var SearchService_ServiceDesc = grpc.ServiceDesc{
 	},
 	Metadata: "reflection/grpc_testing/test.proto",
 }
+
+const (
+	SearchService_Search_FullMethod          = "/grpc.testing.SearchService/Search"
+	SearchService_StreamingSearch_FullMethod = "/grpc.testing.SearchService/StreamingSearch"
+)
+
+var SearchService_FullMethods = []string{
+	SearchService_Search_FullMethod,
+	SearchService_StreamingSearch_FullMethod,
+}

--- a/reflection/grpc_testing/test_grpc.pb.go
+++ b/reflection/grpc_testing/test_grpc.pb.go
@@ -50,7 +50,7 @@ func NewSearchServiceClient(cc grpc.ClientConnInterface) SearchServiceClient {
 
 func (c *searchServiceClient) Search(ctx context.Context, in *SearchRequest, opts ...grpc.CallOption) (*SearchResponse, error) {
 	out := new(SearchResponse)
-	err := c.cc.Invoke(ctx, "/grpc.testing.SearchService/Search", in, out, opts...)
+	err := c.cc.Invoke(ctx, SearchService_Search_FullMethodName, in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -58,7 +58,7 @@ func (c *searchServiceClient) Search(ctx context.Context, in *SearchRequest, opt
 }
 
 func (c *searchServiceClient) StreamingSearch(ctx context.Context, opts ...grpc.CallOption) (SearchService_StreamingSearchClient, error) {
-	stream, err := c.cc.NewStream(ctx, &SearchService_ServiceDesc.Streams[0], "/grpc.testing.SearchService/StreamingSearch", opts...)
+	stream, err := c.cc.NewStream(ctx, &SearchService_ServiceDesc.Streams[0], SearchService_StreamingSearch_FullMethodName, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -130,7 +130,7 @@ func _SearchService_Search_Handler(srv interface{}, ctx context.Context, dec fun
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/grpc.testing.SearchService/Search",
+		FullMethod: SearchService_Search_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(SearchServiceServer).Search(ctx, req.(*SearchRequest))
@@ -188,11 +188,6 @@ var SearchService_ServiceDesc = grpc.ServiceDesc{
 }
 
 const (
-	SearchService_Search_FullMethod          = "/grpc.testing.SearchService/Search"
-	SearchService_StreamingSearch_FullMethod = "/grpc.testing.SearchService/StreamingSearch"
+	SearchService_Search_FullMethodName          = "/grpc.testing.SearchService/Search"
+	SearchService_StreamingSearch_FullMethodName = "/grpc.testing.SearchService/StreamingSearch"
 )
-
-var SearchService_FullMethods = []string{
-	SearchService_Search_FullMethod,
-	SearchService_StreamingSearch_FullMethod,
-}

--- a/reflection/grpc_testing/test_grpc.pb.go
+++ b/reflection/grpc_testing/test_grpc.pb.go
@@ -32,6 +32,11 @@ import (
 // Requires gRPC-Go v1.32.0 or later.
 const _ = grpc.SupportPackageIsVersion7
 
+const (
+	SearchService_Search_FullMethodName          = "/grpc.testing.SearchService/Search"
+	SearchService_StreamingSearch_FullMethodName = "/grpc.testing.SearchService/StreamingSearch"
+)
+
 // SearchServiceClient is the client API for SearchService service.
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
@@ -186,8 +191,3 @@ var SearchService_ServiceDesc = grpc.ServiceDesc{
 	},
 	Metadata: "reflection/grpc_testing/test.proto",
 }
-
-const (
-	SearchService_Search_FullMethodName          = "/grpc.testing.SearchService/Search"
-	SearchService_StreamingSearch_FullMethodName = "/grpc.testing.SearchService/StreamingSearch"
-)

--- a/stress/grpc_testing/metrics_grpc.pb.go
+++ b/stress/grpc_testing/metrics_grpc.pb.go
@@ -39,6 +39,11 @@ import (
 // Requires gRPC-Go v1.32.0 or later.
 const _ = grpc.SupportPackageIsVersion7
 
+const (
+	MetricsService_GetAllGauges_FullMethodName = "/grpc.testing.MetricsService/GetAllGauges"
+	MetricsService_GetGauge_FullMethodName     = "/grpc.testing.MetricsService/GetGauge"
+)
+
 // MetricsServiceClient is the client API for MetricsService service.
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
@@ -194,8 +199,3 @@ var MetricsService_ServiceDesc = grpc.ServiceDesc{
 	},
 	Metadata: "stress/grpc_testing/metrics.proto",
 }
-
-const (
-	MetricsService_GetAllGauges_FullMethodName = "/grpc.testing.MetricsService/GetAllGauges"
-	MetricsService_GetGauge_FullMethodName     = "/grpc.testing.MetricsService/GetGauge"
-)

--- a/stress/grpc_testing/metrics_grpc.pb.go
+++ b/stress/grpc_testing/metrics_grpc.pb.go
@@ -194,3 +194,13 @@ var MetricsService_ServiceDesc = grpc.ServiceDesc{
 	},
 	Metadata: "stress/grpc_testing/metrics.proto",
 }
+
+const (
+	MetricsService_GetAllGauges_FullMethod = "/grpc.testing.MetricsService/GetAllGauges"
+	MetricsService_GetGauge_FullMethod     = "/grpc.testing.MetricsService/GetGauge"
+)
+
+var MetricsService_FullMethods = []string{
+	MetricsService_GetAllGauges_FullMethod,
+	MetricsService_GetGauge_FullMethod,
+}

--- a/stress/grpc_testing/metrics_grpc.pb.go
+++ b/stress/grpc_testing/metrics_grpc.pb.go
@@ -59,7 +59,7 @@ func NewMetricsServiceClient(cc grpc.ClientConnInterface) MetricsServiceClient {
 }
 
 func (c *metricsServiceClient) GetAllGauges(ctx context.Context, in *EmptyMessage, opts ...grpc.CallOption) (MetricsService_GetAllGaugesClient, error) {
-	stream, err := c.cc.NewStream(ctx, &MetricsService_ServiceDesc.Streams[0], "/grpc.testing.MetricsService/GetAllGauges", opts...)
+	stream, err := c.cc.NewStream(ctx, &MetricsService_ServiceDesc.Streams[0], MetricsService_GetAllGauges_FullMethodName, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -92,7 +92,7 @@ func (x *metricsServiceGetAllGaugesClient) Recv() (*GaugeResponse, error) {
 
 func (c *metricsServiceClient) GetGauge(ctx context.Context, in *GaugeRequest, opts ...grpc.CallOption) (*GaugeResponse, error) {
 	out := new(GaugeResponse)
-	err := c.cc.Invoke(ctx, "/grpc.testing.MetricsService/GetGauge", in, out, opts...)
+	err := c.cc.Invoke(ctx, MetricsService_GetGauge_FullMethodName, in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -165,7 +165,7 @@ func _MetricsService_GetGauge_Handler(srv interface{}, ctx context.Context, dec 
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/grpc.testing.MetricsService/GetGauge",
+		FullMethod: MetricsService_GetGauge_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(MetricsServiceServer).GetGauge(ctx, req.(*GaugeRequest))
@@ -196,11 +196,6 @@ var MetricsService_ServiceDesc = grpc.ServiceDesc{
 }
 
 const (
-	MetricsService_GetAllGauges_FullMethod = "/grpc.testing.MetricsService/GetAllGauges"
-	MetricsService_GetGauge_FullMethod     = "/grpc.testing.MetricsService/GetGauge"
+	MetricsService_GetAllGauges_FullMethodName = "/grpc.testing.MetricsService/GetAllGauges"
+	MetricsService_GetGauge_FullMethodName     = "/grpc.testing.MetricsService/GetGauge"
 )
-
-var MetricsService_FullMethods = []string{
-	MetricsService_GetAllGauges_FullMethod,
-	MetricsService_GetGauge_FullMethod,
-}

--- a/test/grpc_testing/test_grpc.pb.go
+++ b/test/grpc_testing/test_grpc.pb.go
@@ -71,7 +71,7 @@ func NewTestServiceClient(cc grpc.ClientConnInterface) TestServiceClient {
 
 func (c *testServiceClient) EmptyCall(ctx context.Context, in *Empty, opts ...grpc.CallOption) (*Empty, error) {
 	out := new(Empty)
-	err := c.cc.Invoke(ctx, "/grpc.testing.TestService/EmptyCall", in, out, opts...)
+	err := c.cc.Invoke(ctx, TestService_EmptyCall_FullMethodName, in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -80,7 +80,7 @@ func (c *testServiceClient) EmptyCall(ctx context.Context, in *Empty, opts ...gr
 
 func (c *testServiceClient) UnaryCall(ctx context.Context, in *SimpleRequest, opts ...grpc.CallOption) (*SimpleResponse, error) {
 	out := new(SimpleResponse)
-	err := c.cc.Invoke(ctx, "/grpc.testing.TestService/UnaryCall", in, out, opts...)
+	err := c.cc.Invoke(ctx, TestService_UnaryCall_FullMethodName, in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -88,7 +88,7 @@ func (c *testServiceClient) UnaryCall(ctx context.Context, in *SimpleRequest, op
 }
 
 func (c *testServiceClient) StreamingOutputCall(ctx context.Context, in *StreamingOutputCallRequest, opts ...grpc.CallOption) (TestService_StreamingOutputCallClient, error) {
-	stream, err := c.cc.NewStream(ctx, &TestService_ServiceDesc.Streams[0], "/grpc.testing.TestService/StreamingOutputCall", opts...)
+	stream, err := c.cc.NewStream(ctx, &TestService_ServiceDesc.Streams[0], TestService_StreamingOutputCall_FullMethodName, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -120,7 +120,7 @@ func (x *testServiceStreamingOutputCallClient) Recv() (*StreamingOutputCallRespo
 }
 
 func (c *testServiceClient) StreamingInputCall(ctx context.Context, opts ...grpc.CallOption) (TestService_StreamingInputCallClient, error) {
-	stream, err := c.cc.NewStream(ctx, &TestService_ServiceDesc.Streams[1], "/grpc.testing.TestService/StreamingInputCall", opts...)
+	stream, err := c.cc.NewStream(ctx, &TestService_ServiceDesc.Streams[1], TestService_StreamingInputCall_FullMethodName, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -154,7 +154,7 @@ func (x *testServiceStreamingInputCallClient) CloseAndRecv() (*StreamingInputCal
 }
 
 func (c *testServiceClient) FullDuplexCall(ctx context.Context, opts ...grpc.CallOption) (TestService_FullDuplexCallClient, error) {
-	stream, err := c.cc.NewStream(ctx, &TestService_ServiceDesc.Streams[2], "/grpc.testing.TestService/FullDuplexCall", opts...)
+	stream, err := c.cc.NewStream(ctx, &TestService_ServiceDesc.Streams[2], TestService_FullDuplexCall_FullMethodName, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -185,7 +185,7 @@ func (x *testServiceFullDuplexCallClient) Recv() (*StreamingOutputCallResponse, 
 }
 
 func (c *testServiceClient) HalfDuplexCall(ctx context.Context, opts ...grpc.CallOption) (TestService_HalfDuplexCallClient, error) {
-	stream, err := c.cc.NewStream(ctx, &TestService_ServiceDesc.Streams[3], "/grpc.testing.TestService/HalfDuplexCall", opts...)
+	stream, err := c.cc.NewStream(ctx, &TestService_ServiceDesc.Streams[3], TestService_HalfDuplexCall_FullMethodName, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -287,7 +287,7 @@ func _TestService_EmptyCall_Handler(srv interface{}, ctx context.Context, dec fu
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/grpc.testing.TestService/EmptyCall",
+		FullMethod: TestService_EmptyCall_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(TestServiceServer).EmptyCall(ctx, req.(*Empty))
@@ -305,7 +305,7 @@ func _TestService_UnaryCall_Handler(srv interface{}, ctx context.Context, dec fu
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/grpc.testing.TestService/UnaryCall",
+		FullMethod: TestService_UnaryCall_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(TestServiceServer).UnaryCall(ctx, req.(*SimpleRequest))
@@ -456,19 +456,10 @@ var TestService_ServiceDesc = grpc.ServiceDesc{
 }
 
 const (
-	TestService_EmptyCall_FullMethod           = "/grpc.testing.TestService/EmptyCall"
-	TestService_UnaryCall_FullMethod           = "/grpc.testing.TestService/UnaryCall"
-	TestService_StreamingOutputCall_FullMethod = "/grpc.testing.TestService/StreamingOutputCall"
-	TestService_StreamingInputCall_FullMethod  = "/grpc.testing.TestService/StreamingInputCall"
-	TestService_FullDuplexCall_FullMethod      = "/grpc.testing.TestService/FullDuplexCall"
-	TestService_HalfDuplexCall_FullMethod      = "/grpc.testing.TestService/HalfDuplexCall"
+	TestService_EmptyCall_FullMethodName           = "/grpc.testing.TestService/EmptyCall"
+	TestService_UnaryCall_FullMethodName           = "/grpc.testing.TestService/UnaryCall"
+	TestService_StreamingOutputCall_FullMethodName = "/grpc.testing.TestService/StreamingOutputCall"
+	TestService_StreamingInputCall_FullMethodName  = "/grpc.testing.TestService/StreamingInputCall"
+	TestService_FullDuplexCall_FullMethodName      = "/grpc.testing.TestService/FullDuplexCall"
+	TestService_HalfDuplexCall_FullMethodName      = "/grpc.testing.TestService/HalfDuplexCall"
 )
-
-var TestService_FullMethods = []string{
-	TestService_EmptyCall_FullMethod,
-	TestService_UnaryCall_FullMethod,
-	TestService_StreamingOutputCall_FullMethod,
-	TestService_StreamingInputCall_FullMethod,
-	TestService_FullDuplexCall_FullMethod,
-	TestService_HalfDuplexCall_FullMethod,
-}

--- a/test/grpc_testing/test_grpc.pb.go
+++ b/test/grpc_testing/test_grpc.pb.go
@@ -35,6 +35,15 @@ import (
 // Requires gRPC-Go v1.32.0 or later.
 const _ = grpc.SupportPackageIsVersion7
 
+const (
+	TestService_EmptyCall_FullMethodName           = "/grpc.testing.TestService/EmptyCall"
+	TestService_UnaryCall_FullMethodName           = "/grpc.testing.TestService/UnaryCall"
+	TestService_StreamingOutputCall_FullMethodName = "/grpc.testing.TestService/StreamingOutputCall"
+	TestService_StreamingInputCall_FullMethodName  = "/grpc.testing.TestService/StreamingInputCall"
+	TestService_FullDuplexCall_FullMethodName      = "/grpc.testing.TestService/FullDuplexCall"
+	TestService_HalfDuplexCall_FullMethodName      = "/grpc.testing.TestService/HalfDuplexCall"
+)
+
 // TestServiceClient is the client API for TestService service.
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
@@ -454,12 +463,3 @@ var TestService_ServiceDesc = grpc.ServiceDesc{
 	},
 	Metadata: "test/grpc_testing/test.proto",
 }
-
-const (
-	TestService_EmptyCall_FullMethodName           = "/grpc.testing.TestService/EmptyCall"
-	TestService_UnaryCall_FullMethodName           = "/grpc.testing.TestService/UnaryCall"
-	TestService_StreamingOutputCall_FullMethodName = "/grpc.testing.TestService/StreamingOutputCall"
-	TestService_StreamingInputCall_FullMethodName  = "/grpc.testing.TestService/StreamingInputCall"
-	TestService_FullDuplexCall_FullMethodName      = "/grpc.testing.TestService/FullDuplexCall"
-	TestService_HalfDuplexCall_FullMethodName      = "/grpc.testing.TestService/HalfDuplexCall"
-)

--- a/test/grpc_testing/test_grpc.pb.go
+++ b/test/grpc_testing/test_grpc.pb.go
@@ -454,3 +454,21 @@ var TestService_ServiceDesc = grpc.ServiceDesc{
 	},
 	Metadata: "test/grpc_testing/test.proto",
 }
+
+const (
+	TestService_EmptyCall_FullMethod           = "/grpc.testing.TestService/EmptyCall"
+	TestService_UnaryCall_FullMethod           = "/grpc.testing.TestService/UnaryCall"
+	TestService_StreamingOutputCall_FullMethod = "/grpc.testing.TestService/StreamingOutputCall"
+	TestService_StreamingInputCall_FullMethod  = "/grpc.testing.TestService/StreamingInputCall"
+	TestService_FullDuplexCall_FullMethod      = "/grpc.testing.TestService/FullDuplexCall"
+	TestService_HalfDuplexCall_FullMethod      = "/grpc.testing.TestService/HalfDuplexCall"
+)
+
+var TestService_FullMethods = []string{
+	TestService_EmptyCall_FullMethod,
+	TestService_UnaryCall_FullMethod,
+	TestService_StreamingOutputCall_FullMethod,
+	TestService_StreamingInputCall_FullMethod,
+	TestService_FullDuplexCall_FullMethod,
+	TestService_HalfDuplexCall_FullMethod,
+}


### PR DESCRIPTION
Original issue: https://github.com/grpc/grpc-go/issues/5876

# Changes:
- The principal change is an update to the `cmd/protoc-gen-go-grpc/grpc.go` command to export additional symbols for all full method paths. Existing behaviour is untouched beyond the additional symbols.
- Updated generated protos to include new symbols throughout the repo for all `*.pb.go`

# Remaining questions
- Assuming the proposed change is acceptable, should I put it behind a command option or leave it on by default?

All feedback welcome! :)

RELEASE NOTES:
- TBD