### PR TITLE
test/xds: add tests for scenarios where authority in resource name is not specified in bootstrap config

### DIFF
--- a/test/xds/xds_client_federation_test.go
+++ b/test/xds/xds_client_federation_test.go
@@ -153,7 +153,7 @@ func (s) TestFederation_UnknownAuthorityInDialTarget(t *testing.T) {
 	envconfig.XDSFederation = true
 	defer func() { envconfig.XDSFederation = oldXDSFederation }()
 
-	// Setting up the management server it not *really* required for this test
+	// Setting up the management server is not *really* required for this test
 	// case. All we need is a bootstrap configuration which does not contain the
 	// authority mentioned in the dial target. But setting up the management
 	// server and actually making an RPC ensures that the xDS client is
@@ -196,9 +196,10 @@ func (s) TestFederation_UnknownAuthorityInDialTarget(t *testing.T) {
 
 	target = fmt.Sprintf("xds://unknown-authority/%s", serviceName)
 	t.Logf("Dialing target %q with unknown authority which is expected to fail", target)
+	const wantErr = `authority "unknown-authority" is not found in the bootstrap file`
 	_, err = grpc.Dial(target, grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithResolvers(resolver))
-	if err == nil || !strings.Contains(err.Error(), `authority "unknown-authority" is not found in the bootstrap file`) {
-		t.Fatal("grpc.Dial() for target with unknown authority succeeded when expected to fail")
+	if err == nil || !strings.Contains(err.Error(), wantErr) {
+		t.Fatalf("grpc.Dial(%q) returned %v, want: %s", target, err, wantErr)
 	}
 }
 

--- a/test/xds/xds_client_federation_test.go
+++ b/test/xds/xds_client_federation_test.go
@@ -21,16 +21,19 @@ package xds_test
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/google/uuid"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/internal"
 	"google.golang.org/grpc/internal/envconfig"
 	"google.golang.org/grpc/internal/testutils/xds/bootstrap"
 	"google.golang.org/grpc/internal/testutils/xds/e2e"
 	"google.golang.org/grpc/resolver"
+	"google.golang.org/grpc/status"
 
 	v3clusterpb "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	v3endpointpb "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
@@ -138,5 +141,135 @@ func (s) TestClientSideFederation(t *testing.T) {
 	client := testgrpc.NewTestServiceClient(cc)
 	if _, err := client.EmptyCall(ctx, &testpb.Empty{}, grpc.WaitForReady(true)); err != nil {
 		t.Fatalf("rpc EmptyCall() failed: %v", err)
+	}
+}
+
+// TestFederation_UnknownAuthorityInDialTarget tests the case where a ClientConn
+// is created with a dial target containing an authority which is not specified
+// in the bootstrap configuration. The test verifies that RPCs on the ClientConn
+// fail with an appropriate error.
+func (s) TestFederation_UnknownAuthorityInDialTarget(t *testing.T) {
+	oldXDSFederation := envconfig.XDSFederation
+	envconfig.XDSFederation = true
+	defer func() { envconfig.XDSFederation = oldXDSFederation }()
+
+	// Setting up the management server it not *really* required for this test
+	// case. All we need is a bootstrap configuration which does not contain the
+	// authority mentioned in the dial target. But setting up the management
+	// server and actually making an RPC ensures that the xDS client is
+	// configured properly, and when we dial with an unknown authority in the
+	// next step, we can be sure that the error we receive is legitimate.
+	managementServer, nodeID, _, resolver, cleanup1 := e2e.SetupManagementServer(t, e2e.ManagementServerOptions{})
+	defer cleanup1()
+
+	port, cleanup2 := startTestService(t, nil)
+	defer cleanup2()
+
+	const serviceName = "my-service-client-side-xds"
+	resources := e2e.DefaultClientResources(e2e.ResourceParams{
+		DialTarget: serviceName,
+		NodeID:     nodeID,
+		Host:       "localhost",
+		Port:       port,
+		SecLevel:   e2e.SecurityLevelNone,
+	})
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	if err := managementServer.Update(ctx, resources); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a ClientConn and make a successful RPC.
+	target := fmt.Sprintf("xds:///%s", serviceName)
+	cc, err := grpc.Dial(target, grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithResolvers(resolver))
+	if err != nil {
+		t.Fatalf("Dialing target %q: %v", target, err)
+	}
+	defer cc.Close()
+	t.Log("Created ClientConn to test service")
+
+	client := testpb.NewTestServiceClient(cc)
+	if _, err := client.EmptyCall(ctx, &testpb.Empty{}); err != nil {
+		t.Fatalf("EmptyCall() RPC: %v", err)
+	}
+	t.Log("Successfully performed an EmptyCall RPC")
+
+	target = fmt.Sprintf("xds://unknown-authority/%s", serviceName)
+	t.Logf("Dialing target %q with unknown authority which is expected to fail", target)
+	_, err = grpc.Dial(target, grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithResolvers(resolver))
+	if err == nil || !strings.Contains(err.Error(), `authority "unknown-authority" is not found in the bootstrap file`) {
+		t.Fatal("grpc.Dial() for target with unknown authority succeeded when expected to fail")
+	}
+}
+
+// TestFederation_UnknownAuthorityInReceivedResponse tests the case where the
+// LDS resource associated with the dial target contains an RDS resource name
+// with an authority which is not specified in the bootstrap configuration. The
+// test verifies that RPCs fail with an appropriate error.
+func (s) TestFederation_UnknownAuthorityInReceivedResponse(t *testing.T) {
+	oldXDSFederation := envconfig.XDSFederation
+	envconfig.XDSFederation = true
+	defer func() { envconfig.XDSFederation = oldXDSFederation }()
+
+	mgmtServer, err := e2e.StartManagementServer(e2e.ManagementServerOptions{})
+	if err != nil {
+		t.Fatalf("Failed to spin up the xDS management server: %v", err)
+	}
+	defer mgmtServer.Stop()
+
+	nodeID := uuid.New().String()
+	bootstrapContents, err := bootstrap.Contents(bootstrap.Options{
+		Version:                            bootstrap.TransportV3,
+		NodeID:                             nodeID,
+		ServerURI:                          mgmtServer.Address,
+		ServerListenerResourceNameTemplate: e2e.ServerListenerResourceNameTemplate,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resolverBuilder := internal.NewXDSResolverWithConfigForTesting.(func([]byte) (resolver.Builder, error))
+	resolver, err := resolverBuilder(bootstrapContents)
+	if err != nil {
+		t.Fatalf("Creating xDS resolver for testing: %v", err)
+	}
+
+	// LDS is old style name.
+	// RDS is new style, with an unknown authority.
+	const serviceName = "my-service-client-side-xds"
+	const unknownAuthority = "unknown-authority"
+	ldsName := serviceName
+	rdsName := fmt.Sprintf("xdstp://%s/envoy.config.route.v3.RouteConfiguration/%s", unknownAuthority, "route-"+serviceName)
+
+	resources := e2e.UpdateOptions{
+		NodeID:         nodeID,
+		Listeners:      []*v3listenerpb.Listener{e2e.DefaultClientListener(ldsName, rdsName)},
+		Routes:         []*v3routepb.RouteConfiguration{e2e.DefaultRouteConfig(rdsName, ldsName, "cluster-"+serviceName)},
+		SkipValidation: true, // This update has only LDS and RDS resources.
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	if err := mgmtServer.Update(ctx, resources); err != nil {
+		t.Fatal(err)
+	}
+
+	target := fmt.Sprintf("xds:///%s", serviceName)
+	cc, err := grpc.Dial(target, grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithResolvers(resolver))
+	if err != nil {
+		t.Fatalf("Dialing target %q: %v", target, err)
+	}
+	defer cc.Close()
+	t.Log("Created ClientConn to test service")
+
+	client := testpb.NewTestServiceClient(cc)
+	_, err = client.EmptyCall(ctx, &testpb.Empty{})
+	if err == nil {
+		t.Fatal("EmptyCall RPC succeeded for target with unknown authority when expected to fail")
+	}
+	if got, want := status.Code(err), codes.Unavailable; got != want {
+		t.Fatalf("EmptyCall RPC returned status code: %v, want %v", got, want)
+	}
+	if wantErr := `failed to find authority "unknown-authority"`; !strings.Contains(err.Error(), wantErr) {
+		t.Fatalf("EmptyCall RPC returned error: %v, want %v", err, wantErr)
 	}
 }

--- a/test/xds/xds_client_integration_test.go
+++ b/test/xds/xds_client_integration_test.go
@@ -70,6 +70,7 @@ func startTestService(t *testing.T, server *stubserver.StubServer) (uint32, func
 	if err != nil {
 		t.Fatalf("invalid serving port for stub server: %v", err)
 	}
+	t.Logf("Started test service backend at %q", server.Address)
 	return uint32(port), server.Stop
 }
 


### PR DESCRIPTION
https://github.com/grpc/grpc-go/issues/5429 was taken care of by https://github.com/grpc/grpc-go/pull/5776.

This PR one adds tests alone.

Fixes https://github.com/grpc/grpc-go/issues/5429

RELEASE NOTES: n/a