### PR TITLE
Deprecate use of `ioutil` package

### DIFF
--- a/authz/grpc_authz_end2end_test.go
+++ b/authz/grpc_authz_end2end_test.go
@@ -23,7 +23,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"io"
-	"io/ioutil"
 	"net"
 	"os"
 	"testing"
@@ -602,8 +601,8 @@ func (s) TestFileWatcher_ValidPolicyRefresh(t *testing.T) {
 
 	// Rewrite the file with a different valid authorization policy.
 	valid2 := authzTests["AllowsRPCEmptyDenyMatchInAllow"]
-	if err := ioutil.WriteFile(file, []byte(valid2.authzPolicy), os.ModePerm); err != nil {
-		t.Fatalf("ioutil.WriteFile(%q) failed: %v", file, err)
+	if err := os.WriteFile(file, []byte(valid2.authzPolicy), os.ModePerm); err != nil {
+		t.Fatalf("os.WriteFile(%q) failed: %v", file, err)
 	}
 
 	// Verifying authorization decision.
@@ -649,8 +648,8 @@ func (s) TestFileWatcher_InvalidPolicySkipReload(t *testing.T) {
 	}
 
 	// Skips the invalid policy update, and continues to use the valid policy.
-	if err := ioutil.WriteFile(file, []byte("{}"), os.ModePerm); err != nil {
-		t.Fatalf("ioutil.WriteFile(%q) failed: %v", file, err)
+	if err := os.WriteFile(file, []byte("{}"), os.ModePerm); err != nil {
+		t.Fatalf("os.WriteFile(%q) failed: %v", file, err)
 	}
 
 	// Wait 40 ms for background go routine to read updated files.
@@ -700,8 +699,8 @@ func (s) TestFileWatcher_RecoversFromReloadFailure(t *testing.T) {
 	}
 
 	// Skips the invalid policy update, and continues to use the valid policy.
-	if err := ioutil.WriteFile(file, []byte("{}"), os.ModePerm); err != nil {
-		t.Fatalf("ioutil.WriteFile(%q) failed: %v", file, err)
+	if err := os.WriteFile(file, []byte("{}"), os.ModePerm); err != nil {
+		t.Fatalf("os.WriteFile(%q) failed: %v", file, err)
 	}
 
 	// Wait 120 ms for background go routine to read updated files.
@@ -715,8 +714,8 @@ func (s) TestFileWatcher_RecoversFromReloadFailure(t *testing.T) {
 
 	// Rewrite the file with a different valid authorization policy.
 	valid2 := authzTests["AllowsRPCEmptyDenyMatchInAllow"]
-	if err := ioutil.WriteFile(file, []byte(valid2.authzPolicy), os.ModePerm); err != nil {
-		t.Fatalf("ioutil.WriteFile(%q) failed: %v", file, err)
+	if err := os.WriteFile(file, []byte(valid2.authzPolicy), os.ModePerm); err != nil {
+		t.Fatalf("os.WriteFile(%q) failed: %v", file, err)
 	}
 
 	// Verifying authorization decision.

--- a/authz/grpc_authz_end2end_test.go
+++ b/authz/grpc_authz_end2end_test.go
@@ -434,9 +434,9 @@ func (s) TestAllowsRPCRequestWithPrincipalsFieldOnMTLSAuthenticatedConnection(t 
 	if err != nil {
 		t.Fatalf("tls.LoadX509KeyPair(x509/server1_cert.pem, x509/server1_key.pem) failed: %v", err)
 	}
-	ca, err := ioutil.ReadFile(testdata.Path("x509/client_ca_cert.pem"))
+	ca, err := os.ReadFile(testdata.Path("x509/client_ca_cert.pem"))
 	if err != nil {
-		t.Fatalf("ioutil.ReadFile(x509/client_ca_cert.pem) failed: %v", err)
+		t.Fatalf("os.ReadFile(x509/client_ca_cert.pem) failed: %v", err)
 	}
 	certPool := x509.NewCertPool()
 	if !certPool.AppendCertsFromPEM(ca) {
@@ -464,9 +464,9 @@ func (s) TestAllowsRPCRequestWithPrincipalsFieldOnMTLSAuthenticatedConnection(t 
 	if err != nil {
 		t.Fatalf("tls.LoadX509KeyPair(x509/client1_cert.pem, x509/client1_key.pem) failed: %v", err)
 	}
-	ca, err = ioutil.ReadFile(testdata.Path("x509/server_ca_cert.pem"))
+	ca, err = os.ReadFile(testdata.Path("x509/server_ca_cert.pem"))
 	if err != nil {
-		t.Fatalf("ioutil.ReadFile(x509/server_ca_cert.pem) failed: %v", err)
+		t.Fatalf("os.ReadFile(x509/server_ca_cert.pem) failed: %v", err)
 	}
 	roots := x509.NewCertPool()
 	if !roots.AppendCertsFromPEM(ca) {

--- a/authz/grpc_authz_server_interceptors.go
+++ b/authz/grpc_authz_server_interceptors.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"sync/atomic"
 	"time"
 	"unsafe"
@@ -140,7 +140,7 @@ func (i *FileWatcherInterceptor) run(ctx context.Context) {
 // constructor, if there is an error in reading the file or parsing the policy, the
 // previous internalInterceptors will not be replaced.
 func (i *FileWatcherInterceptor) updateInternalInterceptor() error {
-	policyContents, err := ioutil.ReadFile(i.policyFile)
+	policyContents, err := os.ReadFile(i.policyFile)
 	if err != nil {
 		return fmt.Errorf("policyFile(%s) read failed: %v", i.policyFile, err)
 	}

--- a/authz/grpc_authz_server_interceptors_test.go
+++ b/authz/grpc_authz_server_interceptors_test.go
@@ -41,8 +41,8 @@ func createTmpPolicyFile(t *testing.T, dirSuffix string, policy []byte) string {
 	t.Logf("Using tmpdir: %s", dir)
 	// Write policy into file.
 	filename := path.Join(dir, "policy.json")
-	if err := ioutil.WriteFile(filename, policy, os.ModePerm); err != nil {
-		t.Fatalf("ioutil.WriteFile(%q) failed: %v", filename, err)
+	if err := os.WriteFile(filename, policy, os.ModePerm); err != nil {
+		t.Fatalf("os.WriteFile(%q) failed: %v", filename, err)
 	}
 	t.Logf("Wrote policy %s to file at %s", string(policy), filename)
 	return filename

--- a/authz/grpc_authz_server_interceptors_test.go
+++ b/authz/grpc_authz_server_interceptors_test.go
@@ -20,7 +20,6 @@ package authz_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -34,9 +33,9 @@ func createTmpPolicyFile(t *testing.T, dirSuffix string, policy []byte) string {
 
 	// Create a temp directory. Passing an empty string for the first argument
 	// uses the system temp directory.
-	dir, err := ioutil.TempDir("", dirSuffix)
+	dir, err := os.MkdirTemp("", dirSuffix)
 	if err != nil {
-		t.Fatalf("ioutil.TempDir() failed: %v", err)
+		t.Fatalf("os.MkdirTemp() failed: %v", err)
 	}
 	t.Logf("Using tmpdir: %s", dir)
 	// Write policy into file.

--- a/balancer/rls/control_channel_test.go
+++ b/balancer/rls/control_channel_test.go
@@ -24,7 +24,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"regexp"
 	"testing"
 	"time"
@@ -215,9 +215,9 @@ func makeTLSCreds(t *testing.T, certPath, keyPath, rootsPath string) credentials
 	if err != nil {
 		t.Fatalf("tls.LoadX509KeyPair(%q, %q) failed: %v", certPath, keyPath, err)
 	}
-	b, err := ioutil.ReadFile(testdata.Path(rootsPath))
+	b, err := os.ReadFile(testdata.Path(rootsPath))
 	if err != nil {
-		t.Fatalf("ioutil.ReadFile(%q) failed: %v", rootsPath, err)
+		t.Fatalf("os.ReadFile(%q) failed: %v", rootsPath, err)
 	}
 	roots := x509.NewCertPool()
 	if !roots.AppendCertsFromPEM(b) {

--- a/benchmark/benchmain/main.go
+++ b/benchmark/benchmain/main.go
@@ -46,7 +46,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net"
 	"os"
@@ -881,5 +880,5 @@ func (nopCompressor) Type() string { return compModeNop }
 // nopDecompressor is a decompressor that just copies data.
 type nopDecompressor struct{}
 
-func (nopDecompressor) Do(r io.Reader) ([]byte, error) { return ioutil.ReadAll(r) }
+func (nopDecompressor) Do(r io.Reader) ([]byte, error) { return io.ReadAll(r) }
 func (nopDecompressor) Type() string                   { return compModeNop }

--- a/benchmark/stats/curve.go
+++ b/benchmark/stats/curve.go
@@ -23,7 +23,6 @@ import (
 	"encoding/csv"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"math/rand"
 	"os"
@@ -81,7 +80,7 @@ func (pcr *payloadCurveRange) chooseRandom() int {
 // sha256file is a helper function that returns a hex string matching the
 // SHA-256 sum of the input file.
 func sha256file(file string) (string, error) {
-	data, err := ioutil.ReadFile(file)
+	data, err := os.ReadFile(file)
 	if err != nil {
 		return "", err
 	}

--- a/binarylog/sink.go
+++ b/binarylog/sink.go
@@ -24,7 +24,7 @@ package binarylog
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	pb "google.golang.org/grpc/binarylog/grpc_binarylog_v1"
 	iblog "google.golang.org/grpc/internal/binarylog"
@@ -60,7 +60,7 @@ func NewTempFileSink() (Sink, error) {
 	// Two other options to replace this function:
 	// 1. take filename as input.
 	// 2. export NewBufferedSink().
-	tempFile, err := ioutil.TempFile("/tmp", "grpcgo_binarylog_*.txt")
+	tempFile, err := os.CreateTemp("/tmp", "grpcgo_binarylog_*.txt")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create temp file: %v", err)
 	}

--- a/credentials/oauth/oauth.go
+++ b/credentials/oauth/oauth.go
@@ -22,8 +22,8 @@ package oauth
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net/url"
+	"os"
 	"sync"
 
 	"golang.org/x/oauth2"
@@ -73,7 +73,7 @@ type jwtAccess struct {
 
 // NewJWTAccessFromFile creates PerRPCCredentials from the given keyFile.
 func NewJWTAccessFromFile(keyFile string) (credentials.PerRPCCredentials, error) {
-	jsonKey, err := ioutil.ReadFile(keyFile)
+	jsonKey, err := os.ReadFile(keyFile)
 	if err != nil {
 		return nil, fmt.Errorf("credentials: failed to read the service account key file: %v", err)
 	}
@@ -192,7 +192,7 @@ func NewServiceAccountFromKey(jsonKey []byte, scope ...string) (credentials.PerR
 // NewServiceAccountFromFile constructs the PerRPCCredentials using the JSON key file
 // of a Google Developers service account.
 func NewServiceAccountFromFile(keyFile string, scope ...string) (credentials.PerRPCCredentials, error) {
-	jsonKey, err := ioutil.ReadFile(keyFile)
+	jsonKey, err := os.ReadFile(keyFile)
 	if err != nil {
 		return nil, fmt.Errorf("credentials: failed to read the service account key file: %v", err)
 	}

--- a/credentials/sts/sts.go
+++ b/credentials/sts/sts.go
@@ -36,6 +36,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"os"
 	"sync"
 	"time"
 
@@ -58,8 +59,8 @@ const (
 var (
 	loadSystemCertPool   = x509.SystemCertPool
 	makeHTTPDoer         = makeHTTPClient
-	readSubjectTokenFrom = ioutil.ReadFile
-	readActorTokenFrom   = ioutil.ReadFile
+	readSubjectTokenFrom = os.ReadFile
+	readActorTokenFrom   = os.ReadFile
 	logger               = grpclog.Component("credentials")
 )
 

--- a/credentials/sts/sts.go
+++ b/credentials/sts/sts.go
@@ -33,7 +33,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -307,7 +307,7 @@ func sendRequest(client httpDoer, req *http.Request) ([]byte, error) {
 	// When the http.Client returns a non-nil error, it is the
 	// responsibility of the caller to read the response body till an EOF is
 	// encountered and to close it.
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	resp.Body.Close()
 	if err != nil {
 		return nil, err

--- a/credentials/sts/sts_test.go
+++ b/credentials/sts/sts_test.go
@@ -25,7 +25,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httputil"
 	"strings"
@@ -123,7 +123,7 @@ func makeGoodResponse() *http.Response {
 		TokenType:       "Bearer",
 		ExpiresIn:       3600,
 	})
-	respBody := ioutil.NopCloser(bytes.NewReader(respJSON))
+	respBody := io.NopCloser(bytes.NewReader(respJSON))
 	return &http.Response{
 		Status:     "200 OK",
 		StatusCode: http.StatusOK,
@@ -330,7 +330,7 @@ func (s) TestGetRequestMetadataCacheExpiry(t *testing.T) {
 			TokenType:       "Bearer",
 			ExpiresIn:       expiresInSecs,
 		})
-		respBody := ioutil.NopCloser(bytes.NewReader(respJSON))
+		respBody := io.NopCloser(bytes.NewReader(respJSON))
 		resp := &http.Response{
 			Status:     "200 OK",
 			StatusCode: http.StatusOK,
@@ -366,7 +366,7 @@ func (s) TestGetRequestMetadataBadResponses(t *testing.T) {
 			response: &http.Response{
 				Status:     "200 OK",
 				StatusCode: http.StatusOK,
-				Body:       ioutil.NopCloser(strings.NewReader("not JSON")),
+				Body:       io.NopCloser(strings.NewReader("not JSON")),
 			},
 		},
 		{
@@ -374,7 +374,7 @@ func (s) TestGetRequestMetadataBadResponses(t *testing.T) {
 			response: &http.Response{
 				Status:     "200 OK",
 				StatusCode: http.StatusOK,
-				Body:       ioutil.NopCloser(strings.NewReader("{}")),
+				Body:       io.NopCloser(strings.NewReader("{}")),
 			},
 		},
 	}
@@ -669,7 +669,7 @@ func (s) TestSendRequest(t *testing.T) {
 			resp: &http.Response{
 				Status:     "200 OK",
 				StatusCode: http.StatusOK,
-				Body:       ioutil.NopCloser(errReader{}),
+				Body:       io.NopCloser(errReader{}),
 			},
 			wantErr: true,
 		},
@@ -678,7 +678,7 @@ func (s) TestSendRequest(t *testing.T) {
 			resp: &http.Response{
 				Status:     "400 BadRequest",
 				StatusCode: http.StatusBadRequest,
-				Body:       ioutil.NopCloser(strings.NewReader("")),
+				Body:       io.NopCloser(strings.NewReader("")),
 			},
 			wantErr: true,
 		},

--- a/credentials/tls.go
+++ b/credentials/tls.go
@@ -23,9 +23,9 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/url"
+	"os"
 
 	credinternal "google.golang.org/grpc/internal/credentials"
 )
@@ -166,7 +166,7 @@ func NewClientTLSFromCert(cp *x509.CertPool, serverNameOverride string) Transpor
 // it will override the virtual host name of authority (e.g. :authority header
 // field) in requests.
 func NewClientTLSFromFile(certFile, serverNameOverride string) (TransportCredentials, error) {
-	b, err := ioutil.ReadFile(certFile)
+	b, err := os.ReadFile(certFile)
 	if err != nil {
 		return nil, err
 	}

--- a/credentials/tls/certprovider/pemfile/watcher.go
+++ b/credentials/tls/certprovider/pemfile/watcher.go
@@ -32,7 +32,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"time"
 
@@ -154,12 +154,12 @@ func (w *watcher) updateIdentityDistributor() {
 		return
 	}
 
-	certFileContents, err := ioutil.ReadFile(w.opts.CertFile)
+	certFileContents, err := os.ReadFile(w.opts.CertFile)
 	if err != nil {
 		logger.Warningf("certFile (%s) read failed: %v", w.opts.CertFile, err)
 		return
 	}
-	keyFileContents, err := ioutil.ReadFile(w.opts.KeyFile)
+	keyFileContents, err := os.ReadFile(w.opts.KeyFile)
 	if err != nil {
 		logger.Warningf("keyFile (%s) read failed: %v", w.opts.KeyFile, err)
 		return
@@ -191,7 +191,7 @@ func (w *watcher) updateRootDistributor() {
 		return
 	}
 
-	rootFileContents, err := ioutil.ReadFile(w.opts.RootFile)
+	rootFileContents, err := os.ReadFile(w.opts.RootFile)
 	if err != nil {
 		logger.Warningf("rootFile (%s) read failed: %v", w.opts.RootFile, err)
 		return

--- a/credentials/tls/certprovider/pemfile/watcher_test.go
+++ b/credentials/tls/certprovider/pemfile/watcher_test.go
@@ -165,8 +165,8 @@ func createTmpFile(t *testing.T, src, dst string) {
 	if err != nil {
 		t.Fatalf("os.ReadFile(%q) failed: %v", src, err)
 	}
-	if err := ioutil.WriteFile(dst, data, os.ModePerm); err != nil {
-		t.Fatalf("ioutil.WriteFile(%q) failed: %v", dst, err)
+	if err := os.WriteFile(dst, data, os.ModePerm); err != nil {
+		t.Fatalf("os.WriteFile(%q) failed: %v", dst, err)
 	}
 	t.Logf("Wrote file at: %s", dst)
 	t.Logf("%s", string(data))

--- a/credentials/tls/certprovider/pemfile/watcher_test.go
+++ b/credentials/tls/certprovider/pemfile/watcher_test.go
@@ -161,9 +161,9 @@ func (wd *wrappedDistributor) Set(km *certprovider.KeyMaterial, err error) {
 func createTmpFile(t *testing.T, src, dst string) {
 	t.Helper()
 
-	data, err := ioutil.ReadFile(src)
+	data, err := os.ReadFile(src)
 	if err != nil {
-		t.Fatalf("ioutil.ReadFile(%q) failed: %v", src, err)
+		t.Fatalf("os.ReadFile(%q) failed: %v", src, err)
 	}
 	if err := ioutil.WriteFile(dst, data, os.ModePerm); err != nil {
 		t.Fatalf("ioutil.WriteFile(%q) failed: %v", dst, err)

--- a/credentials/tls/certprovider/pemfile/watcher_test.go
+++ b/credentials/tls/certprovider/pemfile/watcher_test.go
@@ -21,7 +21,6 @@ package pemfile
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -181,9 +180,9 @@ func createTmpDirWithFiles(t *testing.T, dirSuffix, certSrc, keySrc, rootSrc str
 
 	// Create a temp directory. Passing an empty string for the first argument
 	// uses the system temp directory.
-	dir, err := ioutil.TempDir("", dirSuffix)
+	dir, err := os.MkdirTemp("", dirSuffix)
 	if err != nil {
-		t.Fatalf("ioutil.TempDir() failed: %v", err)
+		t.Fatalf("os.MkdirTemp() failed: %v", err)
 	}
 	t.Logf("Using tmpdir: %s", dir)
 
@@ -323,9 +322,9 @@ func (s) TestProvider_UpdateSuccessWithSymlink(t *testing.T) {
 	dir2 := createTmpDirWithFiles(t, "update_with_symlink2_*", "x509/server1_cert.pem", "x509/server1_key.pem", "x509/server_ca_cert.pem")
 
 	// Create a symlink under a new tempdir, and make it point to dir1.
-	tmpdir, err := ioutil.TempDir("", "test_symlink_*")
+	tmpdir, err := os.MkdirTemp("", "test_symlink_*")
 	if err != nil {
-		t.Fatalf("ioutil.TempDir() failed: %v", err)
+		t.Fatalf("os.MkdirTemp() failed: %v", err)
 	}
 	symLinkName := path.Join(tmpdir, "test_symlink")
 	if err := os.Symlink(dir1, symLinkName); err != nil {

--- a/credentials/tls/certprovider/store_test.go
+++ b/credentials/tls/certprovider/store_test.go
@@ -24,7 +24,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 	"time"
 
@@ -126,7 +126,7 @@ func loadKeyMaterials(t *testing.T, cert, key, ca string) *KeyMaterial {
 		t.Fatalf("Failed to load keyPair: %v", err)
 	}
 
-	pemData, err := ioutil.ReadFile(testdata.Path(ca))
+	pemData, err := os.ReadFile(testdata.Path(ca))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/credentials/xds/xds_client_test.go
+++ b/credentials/xds/xds_client_test.go
@@ -24,8 +24,8 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -159,7 +159,7 @@ func testServerMutualTLSHandshake(rawConn net.Conn) handshakeResult {
 	if err != nil {
 		return handshakeResult{err: err}
 	}
-	pemData, err := ioutil.ReadFile(testdata.Path("x509/client_ca_cert.pem"))
+	pemData, err := os.ReadFile(testdata.Path("x509/client_ca_cert.pem"))
 	if err != nil {
 		return handshakeResult{err: err}
 	}
@@ -204,7 +204,7 @@ func makeIdentityProvider(t *testing.T, certPath, keyPath string) certprovider.P
 // makeRootProvider creates a new instance of the fakeProvider returning the
 // root key material specified in the provider file paths.
 func makeRootProvider(t *testing.T, caPath string) *fakeProvider {
-	pemData, err := ioutil.ReadFile(testdata.Path(caPath))
+	pemData, err := os.ReadFile(testdata.Path(caPath))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/credentials/xds/xds_server_test.go
+++ b/credentials/xds/xds_server_test.go
@@ -24,8 +24,8 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -39,7 +39,7 @@ import (
 func makeClientTLSConfig(t *testing.T, mTLS bool) *tls.Config {
 	t.Helper()
 
-	pemData, err := ioutil.ReadFile(testdata.Path("x509/server_ca_cert.pem"))
+	pemData, err := os.ReadFile(testdata.Path("x509/server_ca_cert.pem"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/encoding/gzip/gzip.go
+++ b/encoding/gzip/gzip.go
@@ -30,7 +30,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"sync"
 
 	"google.golang.org/grpc/encoding"
@@ -42,7 +41,7 @@ const Name = "gzip"
 func init() {
 	c := &compressor{}
 	c.poolCompressor.New = func() interface{} {
-		return &writer{Writer: gzip.NewWriter(ioutil.Discard), pool: &c.poolCompressor}
+		return &writer{Writer: gzip.NewWriter(io.Discard), pool: &c.poolCompressor}
 	}
 	encoding.RegisterCompressor(c)
 }
@@ -63,7 +62,7 @@ func SetLevel(level int) error {
 	}
 	c := encoding.GetCompressor(Name).(*compressor)
 	c.poolCompressor.New = func() interface{} {
-		w, err := gzip.NewWriterLevel(ioutil.Discard, level)
+		w, err := gzip.NewWriterLevel(io.Discard, level)
 		if err != nil {
 			panic(err)
 		}

--- a/examples/features/encryption/mTLS/client/main.go
+++ b/examples/features/encryption/mTLS/client/main.go
@@ -25,8 +25,8 @@ import (
 	"crypto/x509"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
+	"os"
 	"time"
 
 	"google.golang.org/grpc"
@@ -57,7 +57,7 @@ func main() {
 
 	ca := x509.NewCertPool()
 	caFilePath := data.Path("x509/ca_cert.pem")
-	caBytes, err := ioutil.ReadFile(caFilePath)
+	caBytes, err := os.ReadFile(caFilePath)
 	if err != nil {
 		log.Fatalf("failed to read ca cert %q: %v", caFilePath, err)
 	}

--- a/examples/features/encryption/mTLS/server/main.go
+++ b/examples/features/encryption/mTLS/server/main.go
@@ -25,9 +25,9 @@ import (
 	"crypto/x509"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net"
+	"os"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -56,7 +56,7 @@ func main() {
 
 	ca := x509.NewCertPool()
 	caFilePath := data.Path("x509/client_ca_cert.pem")
-	caBytes, err := ioutil.ReadFile(caFilePath)
+	caBytes, err := os.ReadFile(caFilePath)
 	if err != nil {
 		log.Fatalf("failed to read ca cert %q: %v", caFilePath, err)
 	}

--- a/examples/route_guide/server/server.go
+++ b/examples/route_guide/server/server.go
@@ -28,10 +28,10 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"math"
 	"net"
+	"os"
 	"sync"
 	"time"
 
@@ -155,7 +155,7 @@ func (s *routeGuideServer) loadFeatures(filePath string) {
 	var data []byte
 	if filePath != "" {
 		var err error
-		data, err = ioutil.ReadFile(filePath)
+		data, err = os.ReadFile(filePath)
 		if err != nil {
 			log.Fatalf("Failed to load default features: %v", err)
 		}

--- a/gcp/observability/config.go
+++ b/gcp/observability/config.go
@@ -23,7 +23,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"regexp"
 
@@ -116,7 +115,7 @@ func parseObservabilityConfig() (*config, error) {
 		if envconfig.ObservabilityConfig != "" {
 			logger.Warning("Ignoring GRPC_GCP_OBSERVABILITY_CONFIG and using GRPC_GCP_OBSERVABILITY_CONFIG_FILE contents.")
 		}
-		content, err := ioutil.ReadFile(f) // TODO: Switch to os.ReadFile once dropped support for go 1.15
+		content, err := os.ReadFile(f)
 		if err != nil {
 			return nil, fmt.Errorf("error reading observability configuration file %q: %v", f, err)
 		}

--- a/gcp/observability/observability_test.go
+++ b/gcp/observability/observability_test.go
@@ -23,7 +23,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"sync"
 	"testing"

--- a/gcp/observability/observability_test.go
+++ b/gcp/observability/observability_test.go
@@ -188,7 +188,7 @@ func (s) TestRefuseStartWithExcludeAndWildCardAll(t *testing.T) {
 // also sets the environment variable GRPC_CONFIG_OBSERVABILITY_JSON to point to
 // this created config.
 func createTmpConfigInFileSystem(rawJSON string) (func(), error) {
-	configJSONFile, err := ioutil.TempFile(os.TempDir(), "configJSON-")
+	configJSONFile, err := os.CreateTemp(os.TempDir(), "configJSON-")
 	if err != nil {
 		return nil, fmt.Errorf("cannot create file %v: %v", configJSONFile.Name(), err)
 	}

--- a/grpclog/loggerv2.go
+++ b/grpclog/loggerv2.go
@@ -22,7 +22,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"strconv"
@@ -140,9 +139,9 @@ func newLoggerV2WithConfig(infoW, warningW, errorW io.Writer, c loggerV2Config) 
 // newLoggerV2 creates a loggerV2 to be used as default logger.
 // All logs are written to stderr.
 func newLoggerV2() LoggerV2 {
-	errorW := ioutil.Discard
-	warningW := ioutil.Discard
-	infoW := ioutil.Discard
+	errorW := io.Discard
+	warningW := io.Discard
+	infoW := io.Discard
 
 	logLevel := os.Getenv("GRPC_GO_LOG_SEVERITY_LEVEL")
 	switch logLevel {

--- a/internal/credentials/spiffe_test.go
+++ b/internal/credentials/spiffe_test.go
@@ -22,8 +22,8 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
-	"io/ioutil"
 	"net/url"
+	"os"
 	"testing"
 
 	"google.golang.org/grpc/internal/grpctest"
@@ -209,9 +209,9 @@ func (s) TestSPIFFEIDFromCert(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			data, err := ioutil.ReadFile(testdata.Path(tt.dataPath))
+			data, err := os.ReadFile(testdata.Path(tt.dataPath))
 			if err != nil {
-				t.Fatalf("ioutil.ReadFile(%s) failed: %v", testdata.Path(tt.dataPath), err)
+				t.Fatalf("os.ReadFile(%s) failed: %v", testdata.Path(tt.dataPath), err)
 			}
 			block, _ := pem.Decode(data)
 			if block == nil {

--- a/internal/googlecloud/manufacturer_linux.go
+++ b/internal/googlecloud/manufacturer_linux.go
@@ -18,10 +18,10 @@
 
 package googlecloud
 
-import "io/ioutil"
+import "os"
 
 const linuxProductNameFile = "/sys/class/dmi/id/product_name"
 
 func manufacturer() ([]byte, error) {
-	return ioutil.ReadFile(linuxProductNameFile)
+	return os.ReadFile(linuxProductNameFile)
 }

--- a/internal/testutils/xds/bootstrap/bootstrap.go
+++ b/internal/testutils/xds/bootstrap/bootstrap.go
@@ -22,7 +22,6 @@ package bootstrap
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"google.golang.org/grpc/grpclog"
@@ -81,7 +80,7 @@ func CreateFile(opts Options) (func(), error) {
 	if err != nil {
 		return nil, err
 	}
-	f, err := ioutil.TempFile("", "test_xds_bootstrap_*")
+	f, err := os.CreateTemp("", "test_xds_bootstrap_*")
 	if err != nil {
 		return nil, fmt.Errorf("failed to created bootstrap file: %v", err)
 	}

--- a/internal/testutils/xds/bootstrap/bootstrap.go
+++ b/internal/testutils/xds/bootstrap/bootstrap.go
@@ -86,7 +86,7 @@ func CreateFile(opts Options) (func(), error) {
 		return nil, fmt.Errorf("failed to created bootstrap file: %v", err)
 	}
 
-	if err := ioutil.WriteFile(f.Name(), bootstrapContents, 0644); err != nil {
+	if err := os.WriteFile(f.Name(), bootstrapContents, 0644); err != nil {
 		return nil, fmt.Errorf("failed to created bootstrap file: %v", err)
 	}
 	logger.Infof("Created bootstrap file at %q with contents: %s\n", f.Name(), bootstrapContents)

--- a/internal/testutils/xds/e2e/setup_certs.go
+++ b/internal/testutils/xds/e2e/setup_certs.go
@@ -22,7 +22,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -56,9 +55,9 @@ func createTmpFile(src, dst string) error {
 func createTmpDirWithFiles(dirSuffix, certSrc, keySrc, rootSrc string) (string, error) {
 	// Create a temp directory. Passing an empty string for the first argument
 	// uses the system temp directory.
-	dir, err := ioutil.TempDir("", dirSuffix)
+	dir, err := os.MkdirTemp("", dirSuffix)
 	if err != nil {
-		return "", fmt.Errorf("ioutil.TempDir() failed: %v", err)
+		return "", fmt.Errorf("os.MkdirTemp() failed: %v", err)
 	}
 
 	if err := createTmpFile(testdata.Path(certSrc), path.Join(dir, certFile)); err != nil {

--- a/internal/testutils/xds/e2e/setup_certs.go
+++ b/internal/testutils/xds/e2e/setup_certs.go
@@ -43,8 +43,8 @@ func createTmpFile(src, dst string) error {
 	if err != nil {
 		return fmt.Errorf("os.ReadFile(%q) failed: %v", src, err)
 	}
-	if err := ioutil.WriteFile(dst, data, os.ModePerm); err != nil {
-		return fmt.Errorf("ioutil.WriteFile(%q) failed: %v", dst, err)
+	if err := os.WriteFile(dst, data, os.ModePerm); err != nil {
+		return fmt.Errorf("os.WriteFile(%q) failed: %v", dst, err)
 	}
 	return nil
 }

--- a/internal/testutils/xds/e2e/setup_certs.go
+++ b/internal/testutils/xds/e2e/setup_certs.go
@@ -39,9 +39,9 @@ const (
 )
 
 func createTmpFile(src, dst string) error {
-	data, err := ioutil.ReadFile(src)
+	data, err := os.ReadFile(src)
 	if err != nil {
-		return fmt.Errorf("ioutil.ReadFile(%q) failed: %v", src, err)
+		return fmt.Errorf("os.ReadFile(%q) failed: %v", src, err)
 	}
 	if err := ioutil.WriteFile(dst, data, os.ModePerm); err != nil {
 		return fmt.Errorf("ioutil.WriteFile(%q) failed: %v", dst, err)
@@ -82,9 +82,9 @@ func CreateClientTLSCredentials(t *testing.T) credentials.TransportCredentials {
 	if err != nil {
 		t.Fatalf("tls.LoadX509KeyPair(x509/client1_cert.pem, x509/client1_key.pem) failed: %v", err)
 	}
-	b, err := ioutil.ReadFile(testdata.Path("x509/server_ca_cert.pem"))
+	b, err := os.ReadFile(testdata.Path("x509/server_ca_cert.pem"))
 	if err != nil {
-		t.Fatalf("ioutil.ReadFile(x509/server_ca_cert.pem) failed: %v", err)
+		t.Fatalf("os.ReadFile(x509/server_ca_cert.pem) failed: %v", err)
 	}
 	roots := x509.NewCertPool()
 	if !roots.AppendCertsFromPEM(b) {

--- a/interop/client/client.go
+++ b/interop/client/client.go
@@ -23,8 +23,8 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"flag"
-	"io/ioutil"
 	"net"
+	"os"
 	"strconv"
 	"time"
 
@@ -154,7 +154,7 @@ func main() {
 			if *caFile == "" {
 				*caFile = testdata.Path("ca.pem")
 			}
-			b, err := ioutil.ReadFile(*caFile)
+			b, err := os.ReadFile(*caFile)
 			if err != nil {
 				logger.Fatalf("Failed to read root certificate file %q: %v", *caFile, err)
 			}

--- a/interop/test_utils.go
+++ b/interop/test_utils.go
@@ -24,7 +24,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 	"time"
@@ -279,7 +278,7 @@ func DoComputeEngineCreds(tc testgrpc.TestServiceClient, serviceAccount, oauthSc
 }
 
 func getServiceAccountJSONKey(keyFile string) []byte {
-	jsonKey, err := ioutil.ReadFile(keyFile)
+	jsonKey, err := os.ReadFile(keyFile)
 	if err != nil {
 		logger.Fatalf("Failed to read the service account key file: %v", err)
 	}

--- a/rpc_util.go
+++ b/rpc_util.go
@@ -25,7 +25,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"strings"
 	"sync"
@@ -143,7 +142,7 @@ func (d *gzipDecompressor) Do(r io.Reader) ([]byte, error) {
 		z.Close()
 		d.pool.Put(z)
 	}()
-	return ioutil.ReadAll(z)
+	return io.ReadAll(z)
 }
 
 func (d *gzipDecompressor) Type() string {
@@ -746,7 +745,7 @@ func decompress(compressor encoding.Compressor, d []byte, maxReceiveMessageSize 
 	}
 	// Read from LimitReader with limit max+1. So if the underlying
 	// reader is over limit, the result will be bigger than max.
-	d, err = ioutil.ReadAll(io.LimitReader(dcReader, int64(maxReceiveMessageSize)+1))
+	d, err = io.ReadAll(io.LimitReader(dcReader, int64(maxReceiveMessageSize)+1))
 	return d, len(d), err
 }
 

--- a/rpc_util.go
+++ b/rpc_util.go
@@ -77,7 +77,7 @@ func NewGZIPCompressorWithLevel(level int) (Compressor, error) {
 	return &gzipCompressor{
 		pool: sync.Pool{
 			New: func() interface{} {
-				w, err := gzip.NewWriterLevel(ioutil.Discard, level)
+				w, err := gzip.NewWriterLevel(io.Discard, level)
 				if err != nil {
 					panic(err)
 				}

--- a/security/advancedtls/advancedtls_integration_test.go
+++ b/security/advancedtls/advancedtls_integration_test.go
@@ -500,7 +500,7 @@ func copyFileContents(sourceFile, destinationFile string) error {
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(destinationFile, input, 0644)
+	err = os.WriteFile(destinationFile, input, 0644)
 	if err != nil {
 		return err
 	}

--- a/security/advancedtls/advancedtls_integration_test.go
+++ b/security/advancedtls/advancedtls_integration_test.go
@@ -436,27 +436,27 @@ type tmpCredsFiles struct {
 func createTmpFiles() (*tmpCredsFiles, error) {
 	tmpFiles := &tmpCredsFiles{}
 	var err error
-	tmpFiles.clientCertTmp, err = ioutil.TempFile(os.TempDir(), "pre-")
+	tmpFiles.clientCertTmp, err = os.CreateTemp(os.TempDir(), "pre-")
 	if err != nil {
 		return nil, err
 	}
-	tmpFiles.clientKeyTmp, err = ioutil.TempFile(os.TempDir(), "pre-")
+	tmpFiles.clientKeyTmp, err = os.CreateTemp(os.TempDir(), "pre-")
 	if err != nil {
 		return nil, err
 	}
-	tmpFiles.clientTrustTmp, err = ioutil.TempFile(os.TempDir(), "pre-")
+	tmpFiles.clientTrustTmp, err = os.CreateTemp(os.TempDir(), "pre-")
 	if err != nil {
 		return nil, err
 	}
-	tmpFiles.serverCertTmp, err = ioutil.TempFile(os.TempDir(), "pre-")
+	tmpFiles.serverCertTmp, err = os.CreateTemp(os.TempDir(), "pre-")
 	if err != nil {
 		return nil, err
 	}
-	tmpFiles.serverKeyTmp, err = ioutil.TempFile(os.TempDir(), "pre-")
+	tmpFiles.serverKeyTmp, err = os.CreateTemp(os.TempDir(), "pre-")
 	if err != nil {
 		return nil, err
 	}
-	tmpFiles.serverTrustTmp, err = ioutil.TempFile(os.TempDir(), "pre-")
+	tmpFiles.serverTrustTmp, err = os.CreateTemp(os.TempDir(), "pre-")
 	if err != nil {
 		return nil, err
 	}

--- a/security/advancedtls/advancedtls_integration_test.go
+++ b/security/advancedtls/advancedtls_integration_test.go
@@ -23,7 +23,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"sync"

--- a/security/advancedtls/advancedtls_integration_test.go
+++ b/security/advancedtls/advancedtls_integration_test.go
@@ -496,7 +496,7 @@ func (tmpFiles *tmpCredsFiles) removeFiles() {
 }
 
 func copyFileContents(sourceFile, destinationFile string) error {
-	input, err := ioutil.ReadFile(sourceFile)
+	input, err := os.ReadFile(sourceFile)
 	if err != nil {
 		return err
 	}

--- a/security/advancedtls/crl.go
+++ b/security/advancedtls/crl.go
@@ -30,7 +30,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -434,7 +434,7 @@ func fetchCRL(rawIssuer []byte, cfg RevocationConfig) (*certificateListExt, erro
 			return nil, fmt.Errorf("asn1.Unmarshal(Issuer) len(rest) = %v, err = %v", len(rest), err)
 		}
 		crlPath := fmt.Sprintf("%s.r%d", filepath.Join(cfg.RootDir, x509NameHash(r)), i)
-		crlBytes, err := ioutil.ReadFile(crlPath)
+		crlBytes, err := os.ReadFile(crlPath)
 		if err != nil {
 			// Break when we can't read a CRL file.
 			grpclogLogger.Infof("readFile: %v", err)

--- a/security/advancedtls/crl_test.go
+++ b/security/advancedtls/crl_test.go
@@ -320,9 +320,9 @@ func makeChain(t *testing.T, name string) []*x509.Certificate {
 
 	certChain := make([]*x509.Certificate, 0)
 
-	rest, err := ioutil.ReadFile(name)
+	rest, err := os.ReadFile(name)
 	if err != nil {
-		t.Fatalf("ioutil.ReadFile(%v) failed %v", name, err)
+		t.Fatalf("os.ReadFile(%v) failed %v", name, err)
 	}
 	for len(rest) > 0 {
 		var block *pem.Block
@@ -338,7 +338,7 @@ func makeChain(t *testing.T, name string) []*x509.Certificate {
 }
 
 func loadCRL(t *testing.T, path string) *certificateListExt {
-	b, err := ioutil.ReadFile(path)
+	b, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatalf("readFile(%v) failed err = %v", path, err)
 	}

--- a/security/advancedtls/crl_test.go
+++ b/security/advancedtls/crl_test.go
@@ -29,7 +29,6 @@ import (
 	"encoding/hex"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"net"
 	"os"

--- a/security/advancedtls/crl_test.go
+++ b/security/advancedtls/crl_test.go
@@ -693,9 +693,9 @@ func TestVerifyConnection(t *testing.T) {
 				t.Fatalf("templ.CreateCRL failed err = %v", err)
 			}
 
-			err = ioutil.WriteFile(path.Join(dir, fmt.Sprintf("%s.r0", x509NameHash(cert.Subject.ToRDNSequence()))), crl, 0777)
+			err = os.WriteFile(path.Join(dir, fmt.Sprintf("%s.r0", x509NameHash(cert.Subject.ToRDNSequence()))), crl, 0777)
 			if err != nil {
-				t.Fatalf("ioutil.WriteFile failed err = %v", err)
+				t.Fatalf("os.WriteFile failed err = %v", err)
 			}
 
 			cp := x509.NewCertPool()

--- a/security/advancedtls/crl_test.go
+++ b/security/advancedtls/crl_test.go
@@ -682,9 +682,9 @@ func TestVerifyConnection(t *testing.T) {
 				}
 			}()
 
-			dir, err := ioutil.TempDir("", "crl_dir")
+			dir, err := os.MkdirTemp("", "crl_dir")
 			if err != nil {
-				t.Fatalf("ioutil.TempDir failed err = %v", err)
+				t.Fatalf("os.MkdirTemp failed err = %v", err)
 			}
 			defer os.RemoveAll(dir)
 

--- a/security/advancedtls/internal/testutils/testutils.go
+++ b/security/advancedtls/internal/testutils/testutils.go
@@ -22,7 +22,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"google.golang.org/grpc/security/advancedtls/testdata"
 )
@@ -58,7 +58,7 @@ type CertStore struct {
 }
 
 func readTrustCert(fileName string) (*x509.CertPool, error) {
-	trustData, err := ioutil.ReadFile(fileName)
+	trustData, err := os.ReadFile(fileName)
 	if err != nil {
 		return nil, err
 	}

--- a/xds/googledirectpath/utils.go
+++ b/xds/googledirectpath/utils.go
@@ -21,7 +21,7 @@ package googledirectpath
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"sync"
@@ -47,7 +47,7 @@ func getFromMetadata(timeout time.Duration, urlStr string) ([]byte, error) {
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("metadata server returned resp with non-OK: %v", resp)
 	}
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("failed reading from metadata server: %v", err)
 	}

--- a/xds/internal/xdsclient/bootstrap/bootstrap.go
+++ b/xds/internal/xdsclient/bootstrap/bootstrap.go
@@ -24,8 +24,8 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/url"
+	"os"
 	"strings"
 
 	"github.com/golang/protobuf/jsonpb"
@@ -64,7 +64,7 @@ func init() {
 var gRPCVersion = fmt.Sprintf("%s %s", gRPCUserAgentName, grpc.Version)
 
 // For overriding in unit tests.
-var bootstrapFileReadFunc = ioutil.ReadFile
+var bootstrapFileReadFunc = os.ReadFile
 
 // insecureCredsBuilder implements the `Credentials` interface defined in
 // package `xds/bootstrap` and encapsulates an insecure credential.


### PR DESCRIPTION
Use of all `ioutil` functions was deprecated in Go versions 1.16 and 1.17. Some functions were moved to package `io` while others were moved to package `os`.

SUMMARY OF CHANGES:

* Replace `ioutil.ReadFile` with `os.ReadFile`
* Replace `ioutil.Discard` with `io.Discard`
* Replace `ioutil.ReadAll` with `io.ReadAll`
* Replace `ioutil.WriteFile` with `os.WriteFile`
* Replace `ioutil.TempDir` with `os.MkdirTemp`
* Replace `ioutil.TempFile` with `os.CreateTemp`
* Replace `ioutil.NopCloser` with `io.NopCloser`

Resolves #5897 

RELEASE NOTES: 
* N/A