### PR TITLE
transport: send a trailers only-response if no messages or headers are sent

### DIFF
--- a/internal/transport/http2_server.go
+++ b/internal/transport/http2_server.go
@@ -1012,7 +1012,7 @@ func (t *http2Server) WriteStatus(s *Stream, st *status.Status) error {
 	// first and create a slice of that exact size.
 	headerFields := make([]hpack.HeaderField, 0, 2) // grpc-status and grpc-message will be there if none else.
 	if !s.updateHeaderSent() {                      // No headers have been sent.
-		if len(s.header) > 0 { // Send a separate header frame.
+		if len(s.header) > 0 && st.Err() == nil { // Send a separate header frame if the stream is closed without an error.
 			if err := t.writeHeaderLocked(s); err != nil {
 				return err
 			}


### PR DESCRIPTION
This PR adds a check if a stream is closed with an error. If so, and no messages or headers are sent, a trailers only-response is sent.

Fixes: https://github.com/grpc/grpc-go/issues/3125

RELEASE NOTES:
- transport: send a trailers only-response if no messages or headers are sent