### PR TITLE
*: add missing colon to errorf messages to improve readability

### DIFF
--- a/balancer/grpclb/grpclb_remote_balancer.go
+++ b/balancer/grpclb/grpclb_remote_balancer.go
@@ -332,7 +332,7 @@ func (ccw *remoteBalancerCCWrapper) callRemoteBalancer(ctx context.Context) (bac
 	lbClient := &loadBalancerClient{cc: ccw.cc}
 	stream, err := lbClient.BalanceLoad(ctx, grpc.WaitForReady(true))
 	if err != nil {
-		return true, fmt.Errorf("grpclb: failed to perform RPC to the remote balancer %v", err)
+		return true, fmt.Errorf("grpclb: failed to perform RPC to the remote balancer: %v", err)
 	}
 	ccw.lb.mu.Lock()
 	ccw.lb.remoteBalancerConnected = true

--- a/benchmark/benchmain/main.go
+++ b/benchmark/benchmain/main.go
@@ -870,7 +870,7 @@ func (nopCompressor) Do(w io.Writer, p []byte) error {
 		return err
 	}
 	if n != len(p) {
-		return fmt.Errorf("nopCompressor.Write: wrote %v bytes; want %v", n, len(p))
+		return fmt.Errorf("nopCompressor.Write: wrote %d bytes; want %d", n, len(p))
 	}
 	return nil
 }

--- a/benchmark/benchmark.go
+++ b/benchmark/benchmark.go
@@ -278,7 +278,7 @@ func NewClientConn(addr string, opts ...grpc.DialOption) *grpc.ClientConn {
 func NewClientConnWithContext(ctx context.Context, addr string, opts ...grpc.DialOption) *grpc.ClientConn {
 	conn, err := grpc.DialContext(ctx, addr, opts...)
 	if err != nil {
-		logger.Fatalf("NewClientConn(%q) failed to create a ClientConn %v", addr, err)
+		logger.Fatalf("NewClientConn(%q) failed to create a ClientConn: %v", addr, err)
 	}
 	return conn
 }

--- a/benchmark/client/main.go
+++ b/benchmark/client/main.go
@@ -86,7 +86,7 @@ var (
 func main() {
 	flag.Parse()
 	if *testName == "" {
-		logger.Fatalf("test_name not set")
+		logger.Fatal("-test_name not set")
 	}
 	req := &testpb.SimpleRequest{
 		ResponseType: testpb.PayloadType_COMPRESSABLE,

--- a/benchmark/server/main.go
+++ b/benchmark/server/main.go
@@ -54,7 +54,7 @@ var (
 func main() {
 	flag.Parse()
 	if *testName == "" {
-		logger.Fatalf("test name not set")
+		logger.Fatal("-test_name not set")
 	}
 	lis, err := net.Listen("tcp", ":"+*port)
 	if err != nil {

--- a/benchmark/worker/benchmark_client.go
+++ b/benchmark/worker/benchmark_client.go
@@ -132,7 +132,7 @@ func createConns(config *testpb.ClientConfig) ([]*grpc.ClientConn, func(), error
 		}
 		creds, err := credentials.NewClientTLSFromFile(*caFile, config.SecurityParams.ServerHostOverride)
 		if err != nil {
-			return nil, nil, status.Errorf(codes.InvalidArgument, "failed to create TLS credentials %v", err)
+			return nil, nil, status.Errorf(codes.InvalidArgument, "failed to create TLS credentials: %v", err)
 		}
 		opts = append(opts, grpc.WithTransportCredentials(creds))
 	} else {

--- a/benchmark/worker/benchmark_server.go
+++ b/benchmark/worker/benchmark_server.go
@@ -101,7 +101,7 @@ func startBenchmarkServer(config *testpb.ServerConfig, serverPort int) (*benchma
 		}
 		creds, err := credentials.NewServerTLSFromFile(*certFile, *keyFile)
 		if err != nil {
-			logger.Fatalf("failed to generate credentials %v", err)
+			logger.Fatalf("failed to generate credentials: %v", err)
 		}
 		opts = append(opts, grpc.Creds(creds))
 	}

--- a/clientconn.go
+++ b/clientconn.go
@@ -1376,7 +1376,7 @@ func (ac *addrConn) startHealthCheck(ctx context.Context) {
 			if status.Code(err) == codes.Unimplemented {
 				channelz.Error(logger, ac.channelzID, "Subchannel health check is unimplemented at server side, thus health check is disabled")
 			} else {
-				channelz.Errorf(logger, ac.channelzID, "HealthCheckFunc exits with unexpected error %v", err)
+				channelz.Errorf(logger, ac.channelzID, "Health checking failed: %v", err)
 			}
 		}
 	}()

--- a/examples/features/health/client/main.go
+++ b/examples/features/health/client/main.go
@@ -74,7 +74,7 @@ func main() {
 
 	conn, err := grpc.Dial(address, options...)
 	if err != nil {
-		log.Fatalf("did not connect %v", err)
+		log.Fatalf("grpc.Dial(%q): %v", address, err)
 	}
 	defer conn.Close()
 

--- a/examples/features/interceptor/server/main.go
+++ b/examples/features/interceptor/server/main.go
@@ -98,7 +98,7 @@ func unaryInterceptor(ctx context.Context, req interface{}, info *grpc.UnaryServ
 	}
 	m, err := handler(ctx, req)
 	if err != nil {
-		logger("RPC failed with error %v", err)
+		logger("RPC failed with error: %v", err)
 	}
 	return m, err
 }
@@ -135,7 +135,7 @@ func streamInterceptor(srv interface{}, ss grpc.ServerStream, info *grpc.StreamS
 
 	err := handler(srv, newWrappedStream(ss))
 	if err != nil {
-		logger("RPC failed with error %v", err)
+		logger("RPC failed with error: %v", err)
 	}
 	return err
 }

--- a/examples/features/metadata_interceptor/client/main.go
+++ b/examples/features/metadata_interceptor/client/main.go
@@ -38,7 +38,7 @@ var addr = flag.String("addr", "localhost:50051", "the address to connect to")
 func callUnaryEcho(ctx context.Context, client pb.EchoClient) {
 	resp, err := client.UnaryEcho(ctx, &pb.EchoRequest{Message: "hello world"})
 	if err != nil {
-		log.Fatalf("UnaryEcho %v", err)
+		log.Fatalf("UnaryEcho: %v", err)
 	}
 	fmt.Println("UnaryEcho: ", resp.Message)
 }
@@ -46,7 +46,7 @@ func callUnaryEcho(ctx context.Context, client pb.EchoClient) {
 func callBidiStreamingEcho(ctx context.Context, client pb.EchoClient) {
 	c, err := client.BidirectionalStreamingEcho(ctx)
 	if err != nil {
-		log.Fatalf("BidiStreamingEcho %v", err)
+		log.Fatalf("BidiStreamingEcho: %v", err)
 	}
 
 	if err := c.Send(&pb.EchoRequest{Message: "hello world"}); err != nil {

--- a/examples/route_guide/client/client.go
+++ b/examples/route_guide/client/client.go
@@ -161,7 +161,7 @@ func main() {
 		}
 		creds, err := credentials.NewClientTLSFromFile(*caFile, *serverHostOverride)
 		if err != nil {
-			log.Fatalf("Failed to create TLS credentials %v", err)
+			log.Fatalf("Failed to create TLS credentials: %v", err)
 		}
 		opts = append(opts, grpc.WithTransportCredentials(creds))
 	} else {

--- a/examples/route_guide/server/server.go
+++ b/examples/route_guide/server/server.go
@@ -233,7 +233,7 @@ func main() {
 		}
 		creds, err := credentials.NewServerTLSFromFile(*certFile, *keyFile)
 		if err != nil {
-			log.Fatalf("Failed to generate credentials %v", err)
+			log.Fatalf("Failed to generate credentials: %v", err)
 		}
 		opts = []grpc.ServerOption{grpc.Creds(creds)}
 	}

--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -216,7 +216,7 @@ func newHTTP2Client(connectCtx, ctx context.Context, addr resolver.Address, opts
 		if opts.FailOnNonTempDialError {
 			return nil, connectionErrorf(isTemporary(err), err, "transport: error while dialing: %v", err)
 		}
-		return nil, connectionErrorf(true, err, "transport: Error while dialing %v", err)
+		return nil, connectionErrorf(true, err, "transport: Error while dialing: %v", err)
 	}
 
 	// Any further errors will close the underlying connection
@@ -1173,7 +1173,7 @@ func (t *http2Client) handleRSTStream(f *http2.RSTStreamFrame) {
 	statusCode, ok := http2ErrConvTab[f.ErrCode]
 	if !ok {
 		if logger.V(logLevel) {
-			logger.Warningf("transport: http2Client.handleRSTStream found no mapped gRPC status for the received http2 error %v", f.ErrCode)
+			logger.Warningf("transport: http2Client.handleRSTStream found no mapped gRPC status for the received http2 error: %v", f.ErrCode)
 		}
 		statusCode = codes.Unknown
 	}

--- a/interop/fake_grpclb/fake_grpclb.go
+++ b/interop/fake_grpclb/fake_grpclb.go
@@ -53,7 +53,7 @@ func main() {
 		keyFile := testdata.Path("server1.key")
 		creds, err := credentials.NewServerTLSFromFile(certFile, keyFile)
 		if err != nil {
-			logger.Fatalf("Failed to generate credentials %v", err)
+			logger.Fatalf("Failed to generate credentials: %v", err)
 		}
 		opts = append(opts, grpc.Creds(creds))
 	} else if *useALTS {

--- a/interop/http2/negative_http2_client.go
+++ b/interop/http2/negative_http2_client.go
@@ -81,7 +81,7 @@ func rstAfterHeader(tc testgrpc.TestServiceClient) {
 	req := largeSimpleRequest()
 	reply, err := tc.UnaryCall(context.Background(), req)
 	if reply != nil {
-		logger.Fatalf("Client received reply despite server sending rst stream after header")
+		logger.Fatal("Client received reply despite server sending rst stream after header")
 	}
 	if status.Code(err) != codes.Internal {
 		logger.Fatalf("%v.UnaryCall() = _, %v, want _, %v", tc, status.Code(err), codes.Internal)
@@ -92,7 +92,7 @@ func rstDuringData(tc testgrpc.TestServiceClient) {
 	req := largeSimpleRequest()
 	reply, err := tc.UnaryCall(context.Background(), req)
 	if reply != nil {
-		logger.Fatalf("Client received reply despite server sending rst stream during data")
+		logger.Fatal("Client received reply despite server sending rst stream during data")
 	}
 	if status.Code(err) != codes.Unknown {
 		logger.Fatalf("%v.UnaryCall() = _, %v, want _, %v", tc, status.Code(err), codes.Unknown)
@@ -103,7 +103,7 @@ func rstAfterData(tc testgrpc.TestServiceClient) {
 	req := largeSimpleRequest()
 	reply, err := tc.UnaryCall(context.Background(), req)
 	if reply != nil {
-		logger.Fatalf("Client received reply despite server sending rst stream after data")
+		logger.Fatal("Client received reply despite server sending rst stream after data")
 	}
 	if status.Code(err) != codes.Internal {
 		logger.Fatalf("%v.UnaryCall() = _, %v, want _, %v", tc, status.Code(err), codes.Internal)

--- a/interop/server/server.go
+++ b/interop/server/server.go
@@ -48,7 +48,7 @@ var (
 func main() {
 	flag.Parse()
 	if *useTLS && *useALTS {
-		logger.Fatalf("use_tls and use_alts cannot be both set to true")
+		logger.Fatal("-use_tls and -use_alts cannot be both set to true")
 	}
 	p := strconv.Itoa(*port)
 	lis, err := net.Listen("tcp", ":"+p)
@@ -66,7 +66,7 @@ func main() {
 		}
 		creds, err := credentials.NewServerTLSFromFile(*certFile, *keyFile)
 		if err != nil {
-			logger.Fatalf("Failed to generate credentials %v", err)
+			logger.Fatalf("Failed to generate credentials: %v", err)
 		}
 		opts = append(opts, grpc.Creds(creds))
 	} else if *useALTS {

--- a/interop/xds/server/server.go
+++ b/interop/xds/server/server.go
@@ -118,9 +118,10 @@ func main() {
 	// If -secure_mode is not set, expose all services on -port with a regular
 	// gRPC server.
 	if !*secureMode {
-		lis, err := net.Listen("tcp4", fmt.Sprintf(":%d", *port))
+		addr := fmt.Sprintf(":%d", *port)
+		lis, err := net.Listen("tcp4", addr)
 		if err != nil {
-			logger.Fatalf("net.Listen(%s) failed: %v", fmt.Sprintf(":%d", *port), err)
+			logger.Fatalf("net.Listen(%s) failed: %v", addr, err)
 		}
 
 		server := grpc.NewServer()
@@ -141,9 +142,10 @@ func main() {
 	}
 
 	// Create a listener on -port to expose the test service.
-	testLis, err := net.Listen("tcp4", fmt.Sprintf(":%d", *port))
+	addr := fmt.Sprintf(":%d", *port)
+	testLis, err := net.Listen("tcp4", addr)
 	if err != nil {
-		logger.Fatalf("net.Listen(%s) failed: %v", fmt.Sprintf(":%d", *port), err)
+		logger.Fatalf("net.Listen(%s) failed: %v", addr, err)
 	}
 
 	// Create server-side xDS credentials with a plaintext fallback.
@@ -164,9 +166,10 @@ func main() {
 	defer testServer.Stop()
 
 	// Create a listener on -maintenance_port to expose other services.
-	maintenanceLis, err := net.Listen("tcp4", fmt.Sprintf(":%d", *maintenancePort))
+	addr = fmt.Sprintf(":%d", *maintenancePort)
+	maintenanceLis, err := net.Listen("tcp4", addr)
 	if err != nil {
-		logger.Fatalf("net.Listen(%s) failed: %v", fmt.Sprintf(":%d", *maintenancePort), err)
+		logger.Fatalf("net.Listen(%s) failed: %v", addr, err)
 	}
 
 	// Create a regular gRPC server and register the maintenance services on

--- a/pickfirst.go
+++ b/pickfirst.go
@@ -51,7 +51,7 @@ type pickfirstBalancer struct {
 
 func (b *pickfirstBalancer) ResolverError(err error) {
 	if logger.V(2) {
-		logger.Infof("pickfirstBalancer: ResolverError called with error %v", err)
+		logger.Infof("pickfirstBalancer: ResolverError called with error: %v", err)
 	}
 	if b.subConn == nil {
 		b.state = connectivity.TransientFailure

--- a/rpc_util.go
+++ b/rpc_util.go
@@ -710,7 +710,7 @@ func recvAndDecompress(p *parser, s *transport.Stream, dc Decompressor, maxRecei
 			d, size, err = decompress(compressor, d, maxReceiveMessageSize)
 		}
 		if err != nil {
-			return nil, status.Errorf(codes.Internal, "grpc: failed to decompress the received message %v", err)
+			return nil, status.Errorf(codes.Internal, "grpc: failed to decompress the received message: %v", err)
 		}
 		if size > maxReceiveMessageSize {
 			// TODO: Revisit the error code. Currently keep it consistent with java
@@ -758,7 +758,7 @@ func recv(p *parser, c baseCodec, s *transport.Stream, dc Decompressor, m interf
 		return err
 	}
 	if err := c.Unmarshal(d, m); err != nil {
-		return status.Errorf(codes.Internal, "grpc: failed to unmarshal the received message %v", err)
+		return status.Errorf(codes.Internal, "grpc: failed to unmarshal the received message: %v", err)
 	}
 	if payInfo != nil {
 		payInfo.uncompressedBytes = d

--- a/server.go
+++ b/server.go
@@ -1299,7 +1299,7 @@ func (s *Server) processUnaryRPC(t transport.ServerTransport, stream *transport.
 	d, err := recvAndDecompress(&parser{r: stream}, stream, dc, s.opts.maxReceiveMessageSize, payInfo, decomp)
 	if err != nil {
 		if e := t.WriteStatus(stream, status.Convert(err)); e != nil {
-			channelz.Warningf(logger, s.channelzID, "grpc: Server.processUnaryRPC failed to write status %v", e)
+			channelz.Warningf(logger, s.channelzID, "grpc: Server.processUnaryRPC failed to write status: %v", e)
 		}
 		return err
 	}

--- a/service_config.go
+++ b/service_config.go
@@ -226,7 +226,7 @@ func parseServiceConfig(js string) *serviceconfig.ParseResult {
 	var rsc jsonSC
 	err := json.Unmarshal([]byte(js), &rsc)
 	if err != nil {
-		logger.Warningf("grpc: parseServiceConfig error unmarshaling %s due to %v", js, err)
+		logger.Warningf("grpc: unmarshaling service config %s: %v", js, err)
 		return &serviceconfig.ParseResult{Err: err}
 	}
 	sc := ServiceConfig{
@@ -254,7 +254,7 @@ func parseServiceConfig(js string) *serviceconfig.ParseResult {
 		}
 		d, err := parseDuration(m.Timeout)
 		if err != nil {
-			logger.Warningf("grpc: parseServiceConfig error unmarshaling %s due to %v", js, err)
+			logger.Warningf("grpc: unmarshaling service config %s: %v", js, err)
 			return &serviceconfig.ParseResult{Err: err}
 		}
 
@@ -263,7 +263,7 @@ func parseServiceConfig(js string) *serviceconfig.ParseResult {
 			Timeout:      d,
 		}
 		if mc.RetryPolicy, err = convertRetryPolicy(m.RetryPolicy); err != nil {
-			logger.Warningf("grpc: parseServiceConfig error unmarshaling %s due to %v", js, err)
+			logger.Warningf("grpc: unmarshaling service config %s: %v", js, err)
 			return &serviceconfig.ParseResult{Err: err}
 		}
 		if m.MaxRequestMessageBytes != nil {
@@ -283,13 +283,13 @@ func parseServiceConfig(js string) *serviceconfig.ParseResult {
 		for i, n := range *m.Name {
 			path, err := n.generatePath()
 			if err != nil {
-				logger.Warningf("grpc: parseServiceConfig error unmarshaling %s due to methodConfig[%d]: %v", js, i, err)
+				logger.Warningf("grpc: error unmarshaling service config %s due to methodConfig[%d]: %v", js, i, err)
 				return &serviceconfig.ParseResult{Err: err}
 			}
 
 			if _, ok := paths[path]; ok {
 				err = errDuplicatedName
-				logger.Warningf("grpc: parseServiceConfig error unmarshaling %s due to methodConfig[%d]: %v", js, i, err)
+				logger.Warningf("grpc: error unmarshaling service config %s due to methodConfig[%d]: %v", js, i, err)
 				return &serviceconfig.ParseResult{Err: err}
 			}
 			paths[path] = struct{}{}

--- a/stress/client/main.go
+++ b/stress/client/main.go
@@ -287,7 +287,7 @@ func newConn(address string, useTLS, testCA bool, tlsServerName string) (*grpc.C
 			}
 			creds, err = credentials.NewClientTLSFromFile(*caFile, sn)
 			if err != nil {
-				logger.Fatalf("Failed to create TLS credentials %v", err)
+				logger.Fatalf("Failed to create TLS credentials: %v", err)
 			}
 		} else {
 			creds = credentials.NewClientTLSFromCert(nil, sn)

--- a/stress/metrics_client/main.go
+++ b/stress/metrics_client/main.go
@@ -72,7 +72,7 @@ func printMetrics(client metricspb.MetricsServiceClient, totalOnly bool) {
 func main() {
 	flag.Parse()
 	if *metricsServerAddress == "" {
-		logger.Fatalf("Metrics server address is empty.")
+		logger.Fatal("-metrics_server_address is unset")
 	}
 
 	conn, err := grpc.Dial(*metricsServerAddress, grpc.WithTransportCredentials(insecure.NewCredentials()))

--- a/xds/internal/balancer/cdsbalancer/cdsbalancer.go
+++ b/xds/internal/balancer/cdsbalancer/cdsbalancer.go
@@ -349,7 +349,7 @@ func (b *cdsBalancer) handleWatchUpdate(update clusterHandlerUpdate) {
 	if b.childLB == nil {
 		childLB, err := newChildBalancer(b.ccw, b.bOpts)
 		if err != nil {
-			b.logger.Errorf("Failed to create child policy of type %s, %v", clusterresolver.Name, err)
+			b.logger.Errorf("Failed to create child policy of type %s: %v", clusterresolver.Name, err)
 			return
 		}
 		b.childLB = childLB

--- a/xds/internal/clusterspecifier/rls/rls.go
+++ b/xds/internal/clusterspecifier/rls/rls.go
@@ -102,7 +102,7 @@ func (rls) ParseClusterSpecifierConfig(cfg proto.Message) (clusterspecifier.Bala
 		return nil, fmt.Errorf("RLS LB policy not registered")
 	}
 	if _, err = rlsBB.(balancer.ConfigParser).ParseConfig(rawJSON); err != nil {
-		return nil, fmt.Errorf("rls_csp: validation error from rls lb policy parsing %v", err)
+		return nil, fmt.Errorf("rls_csp: validation error from rls lb policy parsing: %v", err)
 	}
 
 	return clusterspecifier.BalancerConfig{{internal.RLSLoadBalancingPolicyName: lbCfgJSON}}, nil

--- a/xds/internal/xdsclient/xdsresource/unmarshal_cds.go
+++ b/xds/internal/xdsclient/xdsresource/unmarshal_cds.go
@@ -503,7 +503,7 @@ func outlierConfigFromCluster(cluster *v3clusterpb.Cluster) (*OutlierDetection, 
 	interval := defaultInterval
 	if i := od.GetInterval(); i != nil {
 		if err := i.CheckValid(); err != nil {
-			return nil, fmt.Errorf("outlier_detection.interval is invalid with error %v", err)
+			return nil, fmt.Errorf("outlier_detection.interval is invalid with error: %v", err)
 		}
 		if interval = i.AsDuration(); interval < 0 {
 			return nil, fmt.Errorf("outlier_detection.interval = %v; must be a valid duration and >= 0", interval)
@@ -513,7 +513,7 @@ func outlierConfigFromCluster(cluster *v3clusterpb.Cluster) (*OutlierDetection, 
 	baseEjectionTime := defaultBaseEjectionTime
 	if bet := od.GetBaseEjectionTime(); bet != nil {
 		if err := bet.CheckValid(); err != nil {
-			return nil, fmt.Errorf("outlier_detection.base_ejection_time is invalid with error %v", err)
+			return nil, fmt.Errorf("outlier_detection.base_ejection_time is invalid with error: %v", err)
 		}
 		if baseEjectionTime = bet.AsDuration(); baseEjectionTime < 0 {
 			return nil, fmt.Errorf("outlier_detection.base_ejection_time = %v; must be >= 0", baseEjectionTime)
@@ -523,7 +523,7 @@ func outlierConfigFromCluster(cluster *v3clusterpb.Cluster) (*OutlierDetection, 
 	maxEjectionTime := defaultMaxEjectionTime
 	if met := od.GetMaxEjectionTime(); met != nil {
 		if err := met.CheckValid(); err != nil {
-			return nil, fmt.Errorf("outlier_detection.max_ejection_time is invalid with error %v", err)
+			return nil, fmt.Errorf("outlier_detection.max_ejection_time is invalid: %v", err)
 		}
 		if maxEjectionTime = met.AsDuration(); maxEjectionTime < 0 {
 			return nil, fmt.Errorf("outlier_detection.max_ejection_time = %v; must be >= 0", maxEjectionTime)

--- a/xds/internal/xdsclient/xdsresource/unmarshal_rds.go
+++ b/xds/internal/xdsclient/xdsresource/unmarshal_rds.go
@@ -83,7 +83,7 @@ func generateRDSUpdateFromRouteConfiguration(rc *v3routepb.RouteConfiguration, l
 		var err error
 		csps, err = processClusterSpecifierPlugins(rc.ClusterSpecifierPlugins)
 		if err != nil {
-			return RouteConfigUpdate{}, fmt.Errorf("received route is invalid %v", err)
+			return RouteConfigUpdate{}, fmt.Errorf("received route is invalid: %v", err)
 		}
 	}
 	// cspNames represents all the cluster specifiers referenced by Route


### PR DESCRIPTION
Mostly add missing colons but also address few other minor issues.

It's confusing to read an error message without a colon for nesting, so that was the main motivation for the change. Happened to me couple of times and I couldn't find the whole string anywhere in code, wasted some time on it.

RELEASE NOTES:
* none