### PR TITLE
xdsclient: handle resource not found errors correctly

### DIFF
--- a/xds/internal/xdsclient/clientimpl_watchers.go
+++ b/xds/internal/xdsclient/clientimpl_watchers.go
@@ -42,7 +42,7 @@ func (l *listenerWatcher) OnError(err error) {
 }
 
 func (l *listenerWatcher) OnResourceDoesNotExist() {
-	err := xdsresource.NewErrorf(xdsresource.ErrorTypeResourceNotFound, "Resource name %q of type Listener not found in received response", l.resourceName)
+	err := xdsresource.NewErrorf(xdsresource.ErrorTypeResourceNotFound, "resource name %q of type Listener not found in received response", l.resourceName)
 	l.cb(xdsresource.ListenerUpdate{}, err)
 }
 
@@ -74,7 +74,7 @@ func (r *routeConfigWatcher) OnError(err error) {
 }
 
 func (r *routeConfigWatcher) OnResourceDoesNotExist() {
-	err := xdsresource.NewErrorf(xdsresource.ErrorTypeResourceNotFound, "Resource name %q of type RouteConfiguration not found in received response", r.resourceName)
+	err := xdsresource.NewErrorf(xdsresource.ErrorTypeResourceNotFound, "resource name %q of type RouteConfiguration not found in received response", r.resourceName)
 	r.cb(xdsresource.RouteConfigUpdate{}, err)
 }
 
@@ -106,7 +106,7 @@ func (c *clusterWatcher) OnError(err error) {
 }
 
 func (c *clusterWatcher) OnResourceDoesNotExist() {
-	err := xdsresource.NewErrorf(xdsresource.ErrorTypeResourceNotFound, "Resource name %q of type Cluster not found in received response", c.resourceName)
+	err := xdsresource.NewErrorf(xdsresource.ErrorTypeResourceNotFound, "resource name %q of type Cluster not found in received response", c.resourceName)
 	c.cb(xdsresource.ClusterUpdate{}, err)
 }
 
@@ -141,7 +141,7 @@ func (c *endpointsWatcher) OnError(err error) {
 }
 
 func (c *endpointsWatcher) OnResourceDoesNotExist() {
-	err := xdsresource.NewErrorf(xdsresource.ErrorTypeResourceNotFound, "Resource name %q of type Endpoints not found in received response", c.resourceName)
+	err := xdsresource.NewErrorf(xdsresource.ErrorTypeResourceNotFound, "resource name %q of type Endpoints not found in received response", c.resourceName)
 	c.cb(xdsresource.EndpointsUpdate{}, err)
 }
 

--- a/xds/internal/xdsclient/e2e_test/cds_watchers_test.go
+++ b/xds/internal/xdsclient/e2e_test/cds_watchers_test.go
@@ -944,7 +944,7 @@ func (s) TestCDSWatch_PartialResponse(t *testing.T) {
 		t.Fatalf("Failed to update management server with resources: %v, err: %v", resources, err)
 	}
 
-	// Verify the contents of the received update for th second watcher.
+	// Verify the contents of the received update for the second watcher.
 	wantUpdate2 := xdsresource.ClusterUpdateErrTuple{
 		Update: xdsresource.ClusterUpdate{
 			ClusterName:    resourceName2,

--- a/xds/internal/xdsclient/e2e_test/cds_watchers_test.go
+++ b/xds/internal/xdsclient/e2e_test/cds_watchers_test.go
@@ -559,7 +559,7 @@ func (s) TestCDSWatch_ExpiryTimerFiresBeforeResponse(t *testing.T) {
 	// Verify that an empty update with the expected error is received.
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
-	wantErr := fmt.Errorf("watch for resource %q of type Cluster timed out", cdsName)
+	wantErr := xdsresource.NewErrorf(xdsresource.ErrorTypeResourceNotFound, "")
 	if err := verifyClusterUpdate(ctx, updateCh, xdsresource.ClusterUpdateErrTuple{Err: wantErr}); err != nil {
 		t.Fatal(err)
 	}
@@ -863,6 +863,101 @@ func (s) TestCDSWatch_PartialValid(t *testing.T) {
 		},
 	}
 	if err := verifyClusterUpdate(ctx, updateCh2, wantUpdate); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestCDSWatch_PartialResponse covers the case where a response from the
+// management server does not contain all requested resources. CDS responses are
+// supposed to contain all requested resources, and the absense of one usually
+// indicates that the management server does not know about it. In cases where
+// the server has never responded with this resource before, the xDS client is
+// expected to wait for the watch timeout to expire before concluding that the
+// resource does not exist on the server
+func (s) TestCDSWatch_PartialResponse(t *testing.T) {
+	overrideFedEnvVar(t)
+	mgmtServer, nodeID, bootstrapContents, _, cleanup := e2e.SetupManagementServer(t, e2e.ManagementServerOptions{})
+	defer cleanup()
+
+	// Create an xDS client with the above bootstrap contents.
+	client, err := xdsclient.NewWithBootstrapContentsForTesting(bootstrapContents)
+	if err != nil {
+		t.Fatalf("Failed to create xDS client: %v", err)
+	}
+	defer client.Close()
+
+	// Register two watches for two cluster resources and have the
+	// callbacks push the received updates on to a channel.
+	resourceName1 := cdsName
+	updateCh1 := testutils.NewChannel()
+	cdsCancel1 := client.WatchCluster(resourceName1, func(u xdsresource.ClusterUpdate, err error) {
+		updateCh1.Send(xdsresource.ClusterUpdateErrTuple{Update: u, Err: err})
+	})
+	defer cdsCancel1()
+	resourceName2 := cdsNameNewStyle
+	updateCh2 := testutils.NewChannel()
+	cdsCancel2 := client.WatchCluster(resourceName2, func(u xdsresource.ClusterUpdate, err error) {
+		updateCh2.Send(xdsresource.ClusterUpdateErrTuple{Update: u, Err: err})
+	})
+	defer cdsCancel2()
+
+	// Configure the management server to return only one of the two cluster
+	// resources, corresponding to the registered watches.
+	resources := e2e.UpdateOptions{
+		NodeID:         nodeID,
+		Clusters:       []*v3clusterpb.Cluster{e2e.DefaultCluster(resourceName1, edsName, e2e.SecurityLevelNone)},
+		SkipValidation: true,
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	if err := mgmtServer.Update(ctx, resources); err != nil {
+		t.Fatalf("Failed to update management server with resources: %v, err: %v", resources, err)
+	}
+
+	// Verify the contents of the received update for first watcher.
+	wantUpdate1 := xdsresource.ClusterUpdateErrTuple{
+		Update: xdsresource.ClusterUpdate{
+			ClusterName:    resourceName1,
+			EDSServiceName: edsName,
+		},
+	}
+	if err := verifyClusterUpdate(ctx, updateCh1, wantUpdate1); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify that the second watcher does not get an update with an error.
+	if err := verifyNoClusterUpdate(ctx, updateCh2); err != nil {
+		t.Fatal(err)
+	}
+
+	// Configure the management server to return two cluster resources,
+	// corresponding to the registered watches.
+	resources = e2e.UpdateOptions{
+		NodeID: nodeID,
+		Clusters: []*v3clusterpb.Cluster{
+			e2e.DefaultCluster(resourceName1, edsName, e2e.SecurityLevelNone),
+			e2e.DefaultCluster(resourceName2, edsNameNewStyle, e2e.SecurityLevelNone),
+		},
+		SkipValidation: true,
+	}
+	if err := mgmtServer.Update(ctx, resources); err != nil {
+		t.Fatalf("Failed to update management server with resources: %v, err: %v", resources, err)
+	}
+
+	// Verify the contents of the received update for th second watcher.
+	wantUpdate2 := xdsresource.ClusterUpdateErrTuple{
+		Update: xdsresource.ClusterUpdate{
+			ClusterName:    resourceName2,
+			EDSServiceName: edsNameNewStyle,
+		},
+	}
+	if err := verifyClusterUpdate(ctx, updateCh2, wantUpdate2); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify that the first watcher gets no update, as the first resource did
+	// not change.
+	if err := verifyNoClusterUpdate(ctx, updateCh1); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/xds/internal/xdsclient/e2e_test/cds_watchers_test.go
+++ b/xds/internal/xdsclient/e2e_test/cds_watchers_test.go
@@ -869,7 +869,7 @@ func (s) TestCDSWatch_PartialValid(t *testing.T) {
 
 // TestCDSWatch_PartialResponse covers the case where a response from the
 // management server does not contain all requested resources. CDS responses are
-// supposed to contain all requested resources, and the absense of one usually
+// supposed to contain all requested resources, and the absence of one usually
 // indicates that the management server does not know about it. In cases where
 // the server has never responded with this resource before, the xDS client is
 // expected to wait for the watch timeout to expire before concluding that the

--- a/xds/internal/xdsclient/e2e_test/eds_watchers_test.go
+++ b/xds/internal/xdsclient/e2e_test/eds_watchers_test.go
@@ -616,7 +616,7 @@ func (s) TestEDSWatch_ExpiryTimerFiresBeforeResponse(t *testing.T) {
 	// Verify that an empty update with the expected error is received.
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
-	wantErr := fmt.Errorf("watch for resource %q of type ClusterLoadAssignment timed out", rdsName)
+	wantErr := xdsresource.NewErrorf(xdsresource.ErrorTypeResourceNotFound, "")
 	if err := verifyEndpointsUpdate(ctx, updateCh, xdsresource.EndpointsUpdateErrTuple{Err: wantErr}); err != nil {
 		t.Fatal(err)
 	}

--- a/xds/internal/xdsclient/e2e_test/lds_watchers_test.go
+++ b/xds/internal/xdsclient/e2e_test/lds_watchers_test.go
@@ -919,7 +919,7 @@ func (s) TestLDSWatch_PartialValid(t *testing.T) {
 
 // TestLDSWatch_PartialResponse covers the case where a response from the
 // management server does not contain all requested resources. LDS responses are
-// supposed to contain all requested resources, and the absense of one usually
+// supposed to contain all requested resources, and the absence of one usually
 // indicates that the management server does not know about it. In cases where
 // the server has never responded with this resource before, the xDS client is
 // expected to wait for the watch timeout to expire before concluding that the

--- a/xds/internal/xdsclient/e2e_test/lds_watchers_test.go
+++ b/xds/internal/xdsclient/e2e_test/lds_watchers_test.go
@@ -997,7 +997,7 @@ func (s) TestLDSWatch_PartialResponse(t *testing.T) {
 		t.Fatalf("Failed to update management server with resources: %v, err: %v", resources, err)
 	}
 
-	// Verify the contents of the received update for th second watcher.
+	// Verify the contents of the received update for the second watcher.
 	wantUpdate2 := xdsresource.ListenerUpdateErrTuple{
 		Update: xdsresource.ListenerUpdate{
 			RouteConfigName: rdsName,

--- a/xds/internal/xdsclient/e2e_test/rds_watchers_test.go
+++ b/xds/internal/xdsclient/e2e_test/rds_watchers_test.go
@@ -649,7 +649,7 @@ func (s) TestRDSWatch_ExpiryTimerFiresBeforeResponse(t *testing.T) {
 	// Verify that an empty update with the expected error is received.
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
-	wantErr := fmt.Errorf("watch for resource %q of type RouteConfiguration timed out", rdsName)
+	wantErr := xdsresource.NewErrorf(xdsresource.ErrorTypeResourceNotFound, "")
 	if err := verifyRouteConfigUpdate(ctx, updateCh, xdsresource.RouteConfigUpdateErrTuple{Err: wantErr}); err != nil {
 		t.Fatal(err)
 	}

--- a/xds/internal/xdsclient/e2e_test/resource_update_test.go
+++ b/xds/internal/xdsclient/e2e_test/resource_update_test.go
@@ -387,9 +387,9 @@ func (s) TestHandleRouteConfigResponseFromManagementServer(t *testing.T) {
 					Value:   []byte{1, 2, 3, 4},
 				}},
 			},
-			wantErr: fmt.Sprintf("watch for resource %q of type RouteConfigResource timed out", resourceName1),
+			wantErr: "RouteConfiguration not found in received response",
 			wantUpdateMetadata: map[string]xdsresource.UpdateWithMD{
-				"resource-name-1": {MD: xdsresource.UpdateMetadata{Status: xdsresource.ServiceStatusRequested}},
+				"resource-name-1": {MD: xdsresource.UpdateMetadata{Status: xdsresource.ServiceStatusNotExist}},
 			},
 		},
 		{
@@ -399,9 +399,9 @@ func (s) TestHandleRouteConfigResponseFromManagementServer(t *testing.T) {
 				TypeUrl:     "type.googleapis.com/envoy.config.route.v3.RouteConfiguration",
 				VersionInfo: "1",
 			},
-			wantErr: fmt.Sprintf("watch for resource %q of type RouteConfigResource timed out", resourceName1),
+			wantErr: "RouteConfiguration not found in received response",
 			wantUpdateMetadata: map[string]xdsresource.UpdateWithMD{
-				"resource-name-1": {MD: xdsresource.UpdateMetadata{Status: xdsresource.ServiceStatusRequested}},
+				"resource-name-1": {MD: xdsresource.UpdateMetadata{Status: xdsresource.ServiceStatusNotExist}},
 			},
 		},
 		{
@@ -412,9 +412,9 @@ func (s) TestHandleRouteConfigResponseFromManagementServer(t *testing.T) {
 				VersionInfo: "1",
 				Resources:   []*anypb.Any{testutils.MarshalAny(&v3clusterpb.Cluster{})},
 			},
-			wantErr: fmt.Sprintf("watch for resource %q of type RouteConfigResource timed out", resourceName1),
+			wantErr: "RouteConfiguration not found in received response",
 			wantUpdateMetadata: map[string]xdsresource.UpdateWithMD{
-				"resource-name-1": {MD: xdsresource.UpdateMetadata{Status: xdsresource.ServiceStatusRequested}},
+				"resource-name-1": {MD: xdsresource.UpdateMetadata{Status: xdsresource.ServiceStatusNotExist}},
 			},
 		},
 		{
@@ -926,9 +926,9 @@ func (s) TestHandleEndpointsResponseFromManagementServer(t *testing.T) {
 					Value:   []byte{1, 2, 3, 4},
 				}},
 			},
-			wantErr: fmt.Sprintf("watch for resource %q of type EndpointsResource timed out", resourceName1),
+			wantErr: "Endpoints not found in received response",
 			wantUpdateMetadata: map[string]xdsresource.UpdateWithMD{
-				"resource-name-1": {MD: xdsresource.UpdateMetadata{Status: xdsresource.ServiceStatusRequested}},
+				"resource-name-1": {MD: xdsresource.UpdateMetadata{Status: xdsresource.ServiceStatusNotExist}},
 			},
 		},
 		{
@@ -938,9 +938,9 @@ func (s) TestHandleEndpointsResponseFromManagementServer(t *testing.T) {
 				TypeUrl:     "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment",
 				VersionInfo: "1",
 			},
-			wantErr: fmt.Sprintf("watch for resource %q of type EndpointsResource timed out", resourceName1),
+			wantErr: "Endpoints not found in received response",
 			wantUpdateMetadata: map[string]xdsresource.UpdateWithMD{
-				"resource-name-1": {MD: xdsresource.UpdateMetadata{Status: xdsresource.ServiceStatusRequested}},
+				"resource-name-1": {MD: xdsresource.UpdateMetadata{Status: xdsresource.ServiceStatusNotExist}},
 			},
 		},
 		{
@@ -951,9 +951,9 @@ func (s) TestHandleEndpointsResponseFromManagementServer(t *testing.T) {
 				VersionInfo: "1",
 				Resources:   []*anypb.Any{testutils.MarshalAny(&v3listenerpb.Listener{})},
 			},
-			wantErr: fmt.Sprintf("watch for resource %q of type EndpointsResource timed out", resourceName1),
+			wantErr: "Endpoints not found in received response",
 			wantUpdateMetadata: map[string]xdsresource.UpdateWithMD{
-				"resource-name-1": {MD: xdsresource.UpdateMetadata{Status: xdsresource.ServiceStatusRequested}},
+				"resource-name-1": {MD: xdsresource.UpdateMetadata{Status: xdsresource.ServiceStatusNotExist}},
 			},
 		},
 		{


### PR DESCRIPTION
This PR contains fixes to the following couple of issues:
- When an LDS/CDS response does not contain a requested resource, the xDS client should not throw the `resource-not-found` error unless the server had responded with that resource earlier (and therefore the resource can be found in the cache). In this scenario, the xDS client should wait for the resource watch timer to expire before throwing the `resource-not-found` error. 
  - This handles the following scenario:
    - xDS client requests resources `{A, B}` at time `T0`.
    - xDS client requests resources `{A, B, C}` at time `T1`.
    - Management server receives first request and responds with resources `{A, B}` at `T2`.
    - Management server receives second request and responds with resources `{A, B, C}` at `T3`.
  - With this fix, the xDS client will not throw the `resource-not-found` error for resource `C` at `T2`, but will instead wait for the watch expiry timer to expire, before which it receives an update containing `C` from the server.
- When the watch expiry timer fires, the xDS client must treat it as a `resource-not-found` error and invoke the `OnResourceDoesNotExist()` callback instead of the `OnError()` callback.
  - There is no way for the management server to inform the xDS client about a missing resource in the SotW protocol variants, and the watch expiry timer was added exactly to handle this case. Earlier, we were not differentiating between other errors and resource not found in terms of the callback being invoked. But with the generic xDS API changes, we have separate callbacks for these two types of errors, and the appropriate callback should be invoked.

Other minor changes included in this PR:
- fix an error string capitalization issue when throwing the `resource-not-found` error.
- e2e tests for LDS/CDS responses with a partial set of requested resources.
- fix expected error type in existing e2e tests for watch timer expiry.
- fix expected error and expected resource metadata in tests which end up hitting the watch expiry timer.

This fixes an [internal P1 issue](https://b.corp.google.com/issues/264441533) which tracks directpath fallback tests.

(We don't need a release note because the generic xDS API changes haven't made it to any release yet).

RELEASE NOTES: n/a