### PR TITLE
rls: fix a data race involving the LRU cache

### DIFF
--- a/balancer/rls/balancer.go
+++ b/balancer/rls/balancer.go
@@ -125,8 +125,11 @@ type rlsBalancer struct {
 	// fact that in places where we need to acquire both the locks, we always
 	// start off reading the cache.
 
-	// cacheMu guards access to the data cache and pending requests map.
-	cacheMu    sync.RWMutex
+	// cacheMu guards access to the data cache and pending requests map. We
+	// cannot use an RWMutex here since even a operation like
+	// dataCache.getEntry() modifies the underlying LRU, which is implemented as
+	// a doubly linked list.
+	cacheMu    sync.Mutex
 	dataCache  *dataCache                 // Cache of RLS data.
 	pendingMap map[cacheKey]*backoffState // Map of pending RLS requests.
 
@@ -263,16 +266,15 @@ func (b *rlsBalancer) UpdateClientConnState(ccs balancer.ClientConnState) error 
 	// channels, we also swap out the throttling state.
 	b.handleControlChannelUpdate(newCfg)
 
-	// If the new config changes the size of the data cache, we might have to
-	// evict entries to get the cache size down to the newly specified size.
-	if newCfg.cacheSizeBytes != b.lbCfg.cacheSizeBytes {
-		b.dataCache.resize(newCfg.cacheSizeBytes)
-	}
-
 	// Any changes to child policy name or configuration needs to be handled by
 	// either creating new child policies or pushing updates to existing ones.
 	b.resolverState = ccs.ResolverState
 	b.handleChildPolicyConfigUpdate(newCfg, &ccs)
+
+	resizeCache := false
+	if newCfg.cacheSizeBytes != b.lbCfg.cacheSizeBytes {
+		resizeCache = true
+	}
 
 	// Update the copy of the config in the LB policy before releasing the lock.
 	b.lbCfg = newCfg
@@ -284,6 +286,14 @@ func (b *rlsBalancer) UpdateClientConnState(ccs balancer.ClientConnState) error 
 	b.updateCh.Put(resumePickerUpdates{done: done})
 	b.stateMu.Unlock()
 	<-done
+
+	if resizeCache {
+		// If the new config changes the size of the data cache, we might have to
+		// evict entries to get the cache size down to the newly specified size.
+		b.cacheMu.Lock()
+		b.dataCache.resize(newCfg.cacheSizeBytes)
+		b.cacheMu.Unlock()
+	}
 	return nil
 }
 

--- a/balancer/rls/cache_test.go
+++ b/balancer/rls/cache_test.go
@@ -117,39 +117,6 @@ func (s) TestLRU_BasicOperations(t *testing.T) {
 	}
 }
 
-func (s) TestLRU_IterateAndRun(t *testing.T) {
-	initCacheEntries()
-	// Create an LRU and add some entries to it.
-	lru := newLRU()
-	for _, k := range cacheKeys {
-		lru.addEntry(k)
-	}
-
-	// Iterate through the lru to make sure that entries are returned in the
-	// least recently used order.
-	var gotKeys []cacheKey
-	lru.iterateAndRun(func(key cacheKey) {
-		gotKeys = append(gotKeys, key)
-	})
-	if !cmp.Equal(gotKeys, cacheKeys, cmp.AllowUnexported(cacheKey{})) {
-		t.Fatalf("lru.iterateAndRun returned %v, want %v", gotKeys, cacheKeys)
-	}
-
-	// Make sure that removing entries from the lru while iterating through it
-	// is a safe operation.
-	lru.iterateAndRun(func(key cacheKey) {
-		lru.removeEntry(key)
-	})
-
-	// Check the lru internals to make sure we freed up all the memory.
-	if len := lru.ll.Len(); len != 0 {
-		t.Fatalf("Number of entries in the lru's underlying list is %d, want 0", len)
-	}
-	if len := len(lru.m); len != 0 {
-		t.Fatalf("Number of entries in the lru's underlying map is %d, want 0", len)
-	}
-}
-
 func (s) TestDataCache_BasicOperations(t *testing.T) {
 	initCacheEntries()
 	dc := newDataCache(5, nil)


### PR DESCRIPTION
Summary of changes:
- The data cache and the pending request map were guarded by a `sync.RWMutex`. In the RPC path, the cache lookup was done under a read-lock, while most of the other operations were done under a write-lock. This was under the assumption that a cache lookup was a read operation. But as it turns out, the cache lookup modifies the LRU cache because it makes the matched entry the most-recently-used.
  - With this change, we are getting rid of the `sync.RWMutex` and moving to a regular `sync.Mutex`.
- When handling a config update, the RLS policy could end up resizing the data cache. This was being done without holding the lock. This change brings the resize operation under the lock.
- Get rid of the `iterateAndRun` method on the `dataCache` type. 
  - I'm still not sure whether deleting an item from the list while traversing it is safe. So, I tried other options and it turns out that it is easier to traverse the map and perform the corresponding operations.
- Get rid of the `onEvict` field in the `cacheEntry` type. This was not being used.
- Simplify code in the picker because we don't have a read-write lock anymore.

This takes care of a [P1 internal issue](https://b.corp.google.com/issues/262918539).

RELEASE NOTES:
- rls: fix a data race involving the LRU cache