### PR TITLE
xdsclient: fix race in load report implementation

### DIFF
--- a/xds/internal/xdsclient/clientimpl_loadreport.go
+++ b/xds/internal/xdsclient/clientimpl_loadreport.go
@@ -30,13 +30,15 @@ import (
 func (c *clientImpl) ReportLoad(server *bootstrap.ServerConfig) (*load.Store, func()) {
 	c.authorityMu.Lock()
 	a, err := c.newAuthorityLocked(server)
-	c.authorityMu.Unlock()
 	if err != nil {
+		c.authorityMu.Unlock()
 		c.logger.Infof("xds: failed to connect to the control plane to do load reporting for authority %q: %v", server, err)
 		return nil, func() {}
 	}
 	// Hold the ref before starting load reporting.
 	a.refLocked()
+	c.authorityMu.Unlock()
+
 	store, cancelF := a.reportLoad()
 	return store, func() {
 		cancelF()


### PR DESCRIPTION
In `clientImpl.ReportLoad()`, once we get a reference to the appropriate `authority` object, we are supposed to increment the reference count using a call to `authority.refLocked()`. 

The documentation on this function says:
```golang
// Increments the reference count. Caller must hold parent's authorityMu.
```

We were releasing the mutex right before incrementing the reference count, and this was not caught by any of our unit tests. It was only caught when I ran a prober binary with the race flag enabled.

RELEASE NOTES:
- xdsclient: fix race which can happen when multiple load reporting calls are made at the same time.