### PR TITLE
binarylog: consistently rename imports for binarylog proto

### DIFF
--- a/binarylog/sink.go
+++ b/binarylog/sink.go
@@ -26,7 +26,7 @@ import (
 	"fmt"
 	"os"
 
-	pb "google.golang.org/grpc/binarylog/grpc_binarylog_v1"
+	binlogpb "google.golang.org/grpc/binarylog/grpc_binarylog_v1"
 	iblog "google.golang.org/grpc/internal/binarylog"
 )
 
@@ -48,7 +48,7 @@ type Sink interface {
 	// entry. Some options are: proto bytes, or proto json.
 	//
 	// Note this function needs to be thread-safe.
-	Write(*pb.GrpcLogEntry) error
+	Write(*binlogpb.GrpcLogEntry) error
 	// Close closes this sink and cleans up resources (e.g. the flushing
 	// goroutine).
 	Close() error

--- a/internal/binarylog/method_logger.go
+++ b/internal/binarylog/method_logger.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
-	pb "google.golang.org/grpc/binarylog/grpc_binarylog_v1"
+	binlogpb "google.golang.org/grpc/binarylog/grpc_binarylog_v1"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 )
@@ -79,7 +79,7 @@ func NewTruncatingMethodLogger(h, m uint64) *TruncatingMethodLogger {
 // Build is an internal only method for building the proto message out of the
 // input event. It's made public to enable other library to reuse as much logic
 // in TruncatingMethodLogger as possible.
-func (ml *TruncatingMethodLogger) Build(c LogEntryConfig) *pb.GrpcLogEntry {
+func (ml *TruncatingMethodLogger) Build(c LogEntryConfig) *binlogpb.GrpcLogEntry {
 	m := c.toProto()
 	timestamp, _ := ptypes.TimestampProto(time.Now())
 	m.Timestamp = timestamp
@@ -87,11 +87,11 @@ func (ml *TruncatingMethodLogger) Build(c LogEntryConfig) *pb.GrpcLogEntry {
 	m.SequenceIdWithinCall = ml.idWithinCallGen.next()
 
 	switch pay := m.Payload.(type) {
-	case *pb.GrpcLogEntry_ClientHeader:
+	case *binlogpb.GrpcLogEntry_ClientHeader:
 		m.PayloadTruncated = ml.truncateMetadata(pay.ClientHeader.GetMetadata())
-	case *pb.GrpcLogEntry_ServerHeader:
+	case *binlogpb.GrpcLogEntry_ServerHeader:
 		m.PayloadTruncated = ml.truncateMetadata(pay.ServerHeader.GetMetadata())
-	case *pb.GrpcLogEntry_Message:
+	case *binlogpb.GrpcLogEntry_Message:
 		m.PayloadTruncated = ml.truncateMessage(pay.Message)
 	}
 	return m
@@ -102,7 +102,7 @@ func (ml *TruncatingMethodLogger) Log(c LogEntryConfig) {
 	ml.sink.Write(ml.Build(c))
 }
 
-func (ml *TruncatingMethodLogger) truncateMetadata(mdPb *pb.Metadata) (truncated bool) {
+func (ml *TruncatingMethodLogger) truncateMetadata(mdPb *binlogpb.Metadata) (truncated bool) {
 	if ml.headerMaxLen == maxUInt {
 		return false
 	}
@@ -132,7 +132,7 @@ func (ml *TruncatingMethodLogger) truncateMetadata(mdPb *pb.Metadata) (truncated
 	return truncated
 }
 
-func (ml *TruncatingMethodLogger) truncateMessage(msgPb *pb.Message) (truncated bool) {
+func (ml *TruncatingMethodLogger) truncateMessage(msgPb *binlogpb.Message) (truncated bool) {
 	if ml.messageMaxLen == maxUInt {
 		return false
 	}
@@ -145,7 +145,7 @@ func (ml *TruncatingMethodLogger) truncateMessage(msgPb *pb.Message) (truncated 
 
 // LogEntryConfig represents the configuration for binary log entry.
 type LogEntryConfig interface {
-	toProto() *pb.GrpcLogEntry
+	toProto() *binlogpb.GrpcLogEntry
 }
 
 // ClientHeader configs the binary log entry to be a ClientHeader entry.
@@ -159,10 +159,10 @@ type ClientHeader struct {
 	PeerAddr net.Addr
 }
 
-func (c *ClientHeader) toProto() *pb.GrpcLogEntry {
+func (c *ClientHeader) toProto() *binlogpb.GrpcLogEntry {
 	// This function doesn't need to set all the fields (e.g. seq ID). The Log
 	// function will set the fields when necessary.
-	clientHeader := &pb.ClientHeader{
+	clientHeader := &binlogpb.ClientHeader{
 		Metadata:   mdToMetadataProto(c.Header),
 		MethodName: c.MethodName,
 		Authority:  c.Authority,
@@ -170,16 +170,16 @@ func (c *ClientHeader) toProto() *pb.GrpcLogEntry {
 	if c.Timeout > 0 {
 		clientHeader.Timeout = ptypes.DurationProto(c.Timeout)
 	}
-	ret := &pb.GrpcLogEntry{
-		Type: pb.GrpcLogEntry_EVENT_TYPE_CLIENT_HEADER,
-		Payload: &pb.GrpcLogEntry_ClientHeader{
+	ret := &binlogpb.GrpcLogEntry{
+		Type: binlogpb.GrpcLogEntry_EVENT_TYPE_CLIENT_HEADER,
+		Payload: &binlogpb.GrpcLogEntry_ClientHeader{
 			ClientHeader: clientHeader,
 		},
 	}
 	if c.OnClientSide {
-		ret.Logger = pb.GrpcLogEntry_LOGGER_CLIENT
+		ret.Logger = binlogpb.GrpcLogEntry_LOGGER_CLIENT
 	} else {
-		ret.Logger = pb.GrpcLogEntry_LOGGER_SERVER
+		ret.Logger = binlogpb.GrpcLogEntry_LOGGER_SERVER
 	}
 	if c.PeerAddr != nil {
 		ret.Peer = addrToProto(c.PeerAddr)
@@ -195,19 +195,19 @@ type ServerHeader struct {
 	PeerAddr net.Addr
 }
 
-func (c *ServerHeader) toProto() *pb.GrpcLogEntry {
-	ret := &pb.GrpcLogEntry{
-		Type: pb.GrpcLogEntry_EVENT_TYPE_SERVER_HEADER,
-		Payload: &pb.GrpcLogEntry_ServerHeader{
-			ServerHeader: &pb.ServerHeader{
+func (c *ServerHeader) toProto() *binlogpb.GrpcLogEntry {
+	ret := &binlogpb.GrpcLogEntry{
+		Type: binlogpb.GrpcLogEntry_EVENT_TYPE_SERVER_HEADER,
+		Payload: &binlogpb.GrpcLogEntry_ServerHeader{
+			ServerHeader: &binlogpb.ServerHeader{
 				Metadata: mdToMetadataProto(c.Header),
 			},
 		},
 	}
 	if c.OnClientSide {
-		ret.Logger = pb.GrpcLogEntry_LOGGER_CLIENT
+		ret.Logger = binlogpb.GrpcLogEntry_LOGGER_CLIENT
 	} else {
-		ret.Logger = pb.GrpcLogEntry_LOGGER_SERVER
+		ret.Logger = binlogpb.GrpcLogEntry_LOGGER_SERVER
 	}
 	if c.PeerAddr != nil {
 		ret.Peer = addrToProto(c.PeerAddr)
@@ -223,7 +223,7 @@ type ClientMessage struct {
 	Message interface{}
 }
 
-func (c *ClientMessage) toProto() *pb.GrpcLogEntry {
+func (c *ClientMessage) toProto() *binlogpb.GrpcLogEntry {
 	var (
 		data []byte
 		err  error
@@ -238,19 +238,19 @@ func (c *ClientMessage) toProto() *pb.GrpcLogEntry {
 	} else {
 		grpclogLogger.Infof("binarylogging: message to log is neither proto.message nor []byte")
 	}
-	ret := &pb.GrpcLogEntry{
-		Type: pb.GrpcLogEntry_EVENT_TYPE_CLIENT_MESSAGE,
-		Payload: &pb.GrpcLogEntry_Message{
-			Message: &pb.Message{
+	ret := &binlogpb.GrpcLogEntry{
+		Type: binlogpb.GrpcLogEntry_EVENT_TYPE_CLIENT_MESSAGE,
+		Payload: &binlogpb.GrpcLogEntry_Message{
+			Message: &binlogpb.Message{
 				Length: uint32(len(data)),
 				Data:   data,
 			},
 		},
 	}
 	if c.OnClientSide {
-		ret.Logger = pb.GrpcLogEntry_LOGGER_CLIENT
+		ret.Logger = binlogpb.GrpcLogEntry_LOGGER_CLIENT
 	} else {
-		ret.Logger = pb.GrpcLogEntry_LOGGER_SERVER
+		ret.Logger = binlogpb.GrpcLogEntry_LOGGER_SERVER
 	}
 	return ret
 }
@@ -263,7 +263,7 @@ type ServerMessage struct {
 	Message interface{}
 }
 
-func (c *ServerMessage) toProto() *pb.GrpcLogEntry {
+func (c *ServerMessage) toProto() *binlogpb.GrpcLogEntry {
 	var (
 		data []byte
 		err  error
@@ -278,19 +278,19 @@ func (c *ServerMessage) toProto() *pb.GrpcLogEntry {
 	} else {
 		grpclogLogger.Infof("binarylogging: message to log is neither proto.message nor []byte")
 	}
-	ret := &pb.GrpcLogEntry{
-		Type: pb.GrpcLogEntry_EVENT_TYPE_SERVER_MESSAGE,
-		Payload: &pb.GrpcLogEntry_Message{
-			Message: &pb.Message{
+	ret := &binlogpb.GrpcLogEntry{
+		Type: binlogpb.GrpcLogEntry_EVENT_TYPE_SERVER_MESSAGE,
+		Payload: &binlogpb.GrpcLogEntry_Message{
+			Message: &binlogpb.Message{
 				Length: uint32(len(data)),
 				Data:   data,
 			},
 		},
 	}
 	if c.OnClientSide {
-		ret.Logger = pb.GrpcLogEntry_LOGGER_CLIENT
+		ret.Logger = binlogpb.GrpcLogEntry_LOGGER_CLIENT
 	} else {
-		ret.Logger = pb.GrpcLogEntry_LOGGER_SERVER
+		ret.Logger = binlogpb.GrpcLogEntry_LOGGER_SERVER
 	}
 	return ret
 }
@@ -300,15 +300,15 @@ type ClientHalfClose struct {
 	OnClientSide bool
 }
 
-func (c *ClientHalfClose) toProto() *pb.GrpcLogEntry {
-	ret := &pb.GrpcLogEntry{
-		Type:    pb.GrpcLogEntry_EVENT_TYPE_CLIENT_HALF_CLOSE,
+func (c *ClientHalfClose) toProto() *binlogpb.GrpcLogEntry {
+	ret := &binlogpb.GrpcLogEntry{
+		Type:    binlogpb.GrpcLogEntry_EVENT_TYPE_CLIENT_HALF_CLOSE,
 		Payload: nil, // No payload here.
 	}
 	if c.OnClientSide {
-		ret.Logger = pb.GrpcLogEntry_LOGGER_CLIENT
+		ret.Logger = binlogpb.GrpcLogEntry_LOGGER_CLIENT
 	} else {
-		ret.Logger = pb.GrpcLogEntry_LOGGER_SERVER
+		ret.Logger = binlogpb.GrpcLogEntry_LOGGER_SERVER
 	}
 	return ret
 }
@@ -324,7 +324,7 @@ type ServerTrailer struct {
 	PeerAddr net.Addr
 }
 
-func (c *ServerTrailer) toProto() *pb.GrpcLogEntry {
+func (c *ServerTrailer) toProto() *binlogpb.GrpcLogEntry {
 	st, ok := status.FromError(c.Err)
 	if !ok {
 		grpclogLogger.Info("binarylogging: error in trailer is not a status error")
@@ -340,10 +340,10 @@ func (c *ServerTrailer) toProto() *pb.GrpcLogEntry {
 			grpclogLogger.Infof("binarylogging: failed to marshal status proto: %v", err)
 		}
 	}
-	ret := &pb.GrpcLogEntry{
-		Type: pb.GrpcLogEntry_EVENT_TYPE_SERVER_TRAILER,
-		Payload: &pb.GrpcLogEntry_Trailer{
-			Trailer: &pb.Trailer{
+	ret := &binlogpb.GrpcLogEntry{
+		Type: binlogpb.GrpcLogEntry_EVENT_TYPE_SERVER_TRAILER,
+		Payload: &binlogpb.GrpcLogEntry_Trailer{
+			Trailer: &binlogpb.Trailer{
 				Metadata:      mdToMetadataProto(c.Trailer),
 				StatusCode:    uint32(st.Code()),
 				StatusMessage: st.Message(),
@@ -352,9 +352,9 @@ func (c *ServerTrailer) toProto() *pb.GrpcLogEntry {
 		},
 	}
 	if c.OnClientSide {
-		ret.Logger = pb.GrpcLogEntry_LOGGER_CLIENT
+		ret.Logger = binlogpb.GrpcLogEntry_LOGGER_CLIENT
 	} else {
-		ret.Logger = pb.GrpcLogEntry_LOGGER_SERVER
+		ret.Logger = binlogpb.GrpcLogEntry_LOGGER_SERVER
 	}
 	if c.PeerAddr != nil {
 		ret.Peer = addrToProto(c.PeerAddr)
@@ -367,15 +367,15 @@ type Cancel struct {
 	OnClientSide bool
 }
 
-func (c *Cancel) toProto() *pb.GrpcLogEntry {
-	ret := &pb.GrpcLogEntry{
-		Type:    pb.GrpcLogEntry_EVENT_TYPE_CANCEL,
+func (c *Cancel) toProto() *binlogpb.GrpcLogEntry {
+	ret := &binlogpb.GrpcLogEntry{
+		Type:    binlogpb.GrpcLogEntry_EVENT_TYPE_CANCEL,
 		Payload: nil,
 	}
 	if c.OnClientSide {
-		ret.Logger = pb.GrpcLogEntry_LOGGER_CLIENT
+		ret.Logger = binlogpb.GrpcLogEntry_LOGGER_CLIENT
 	} else {
-		ret.Logger = pb.GrpcLogEntry_LOGGER_SERVER
+		ret.Logger = binlogpb.GrpcLogEntry_LOGGER_SERVER
 	}
 	return ret
 }
@@ -392,15 +392,15 @@ func metadataKeyOmit(key string) bool {
 	return strings.HasPrefix(key, "grpc-")
 }
 
-func mdToMetadataProto(md metadata.MD) *pb.Metadata {
-	ret := &pb.Metadata{}
+func mdToMetadataProto(md metadata.MD) *binlogpb.Metadata {
+	ret := &binlogpb.Metadata{}
 	for k, vv := range md {
 		if metadataKeyOmit(k) {
 			continue
 		}
 		for _, v := range vv {
 			ret.Entry = append(ret.Entry,
-				&pb.MetadataEntry{
+				&binlogpb.MetadataEntry{
 					Key:   k,
 					Value: []byte(v),
 				},
@@ -410,26 +410,26 @@ func mdToMetadataProto(md metadata.MD) *pb.Metadata {
 	return ret
 }
 
-func addrToProto(addr net.Addr) *pb.Address {
-	ret := &pb.Address{}
+func addrToProto(addr net.Addr) *binlogpb.Address {
+	ret := &binlogpb.Address{}
 	switch a := addr.(type) {
 	case *net.TCPAddr:
 		if a.IP.To4() != nil {
-			ret.Type = pb.Address_TYPE_IPV4
+			ret.Type = binlogpb.Address_TYPE_IPV4
 		} else if a.IP.To16() != nil {
-			ret.Type = pb.Address_TYPE_IPV6
+			ret.Type = binlogpb.Address_TYPE_IPV6
 		} else {
-			ret.Type = pb.Address_TYPE_UNKNOWN
+			ret.Type = binlogpb.Address_TYPE_UNKNOWN
 			// Do not set address and port fields.
 			break
 		}
 		ret.Address = a.IP.String()
 		ret.IpPort = uint32(a.Port)
 	case *net.UnixAddr:
-		ret.Type = pb.Address_TYPE_UNIX
+		ret.Type = binlogpb.Address_TYPE_UNIX
 		ret.Address = a.String()
 	default:
-		ret.Type = pb.Address_TYPE_UNKNOWN
+		ret.Type = binlogpb.Address_TYPE_UNKNOWN
 	}
 	return ret
 }

--- a/internal/binarylog/method_logger_test.go
+++ b/internal/binarylog/method_logger_test.go
@@ -26,10 +26,10 @@ import (
 	"time"
 
 	"github.com/golang/protobuf/proto"
-	dpb "github.com/golang/protobuf/ptypes/duration"
-	pb "google.golang.org/grpc/binarylog/grpc_binarylog_v1"
+	binlogpb "google.golang.org/grpc/binarylog/grpc_binarylog_v1"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/durationpb"
 )
 
 func (s) TestLog(t *testing.T) {
@@ -46,7 +46,7 @@ func (s) TestLog(t *testing.T) {
 	port6 := 796
 	tcpAddr6, _ := net.ResolveTCPAddr("tcp", fmt.Sprintf("[%v]:%d", addr6, port6))
 
-	testProtoMsg := &pb.Message{
+	testProtoMsg := &binlogpb.Message{
 		Length: 1,
 		Data:   []byte{'a'},
 	}
@@ -54,7 +54,7 @@ func (s) TestLog(t *testing.T) {
 
 	testCases := []struct {
 		config LogEntryConfig
-		want   *pb.GrpcLogEntry
+		want   *binlogpb.GrpcLogEntry
 	}{
 		{
 			config: &ClientHeader{
@@ -67,31 +67,31 @@ func (s) TestLog(t *testing.T) {
 				Timeout:    2*time.Second + 3*time.Nanosecond,
 				PeerAddr:   tcpAddr,
 			},
-			want: &pb.GrpcLogEntry{
+			want: &binlogpb.GrpcLogEntry{
 				Timestamp:            nil,
 				CallId:               1,
 				SequenceIdWithinCall: 0,
-				Type:                 pb.GrpcLogEntry_EVENT_TYPE_CLIENT_HEADER,
-				Logger:               pb.GrpcLogEntry_LOGGER_SERVER,
-				Payload: &pb.GrpcLogEntry_ClientHeader{
-					ClientHeader: &pb.ClientHeader{
-						Metadata: &pb.Metadata{
-							Entry: []*pb.MetadataEntry{
+				Type:                 binlogpb.GrpcLogEntry_EVENT_TYPE_CLIENT_HEADER,
+				Logger:               binlogpb.GrpcLogEntry_LOGGER_SERVER,
+				Payload: &binlogpb.GrpcLogEntry_ClientHeader{
+					ClientHeader: &binlogpb.ClientHeader{
+						Metadata: &binlogpb.Metadata{
+							Entry: []*binlogpb.MetadataEntry{
 								{Key: "a", Value: []byte{'b'}},
 								{Key: "a", Value: []byte{'b', 'b'}},
 							},
 						},
 						MethodName: "testservice/testmethod",
 						Authority:  "test.service.io",
-						Timeout: &dpb.Duration{
+						Timeout: &durationpb.Duration{
 							Seconds: 2,
 							Nanos:   3,
 						},
 					},
 				},
 				PayloadTruncated: false,
-				Peer: &pb.Address{
-					Type:    pb.Address_TYPE_IPV4,
+				Peer: &binlogpb.Address{
+					Type:    binlogpb.Address_TYPE_IPV4,
 					Address: addr,
 					IpPort:  uint32(port),
 				},
@@ -103,15 +103,15 @@ func (s) TestLog(t *testing.T) {
 				MethodName:   "testservice/testmethod",
 				Authority:    "test.service.io",
 			},
-			want: &pb.GrpcLogEntry{
+			want: &binlogpb.GrpcLogEntry{
 				Timestamp:            nil,
 				CallId:               1,
 				SequenceIdWithinCall: 0,
-				Type:                 pb.GrpcLogEntry_EVENT_TYPE_CLIENT_HEADER,
-				Logger:               pb.GrpcLogEntry_LOGGER_SERVER,
-				Payload: &pb.GrpcLogEntry_ClientHeader{
-					ClientHeader: &pb.ClientHeader{
-						Metadata:   &pb.Metadata{},
+				Type:                 binlogpb.GrpcLogEntry_EVENT_TYPE_CLIENT_HEADER,
+				Logger:               binlogpb.GrpcLogEntry_LOGGER_SERVER,
+				Payload: &binlogpb.GrpcLogEntry_ClientHeader{
+					ClientHeader: &binlogpb.ClientHeader{
+						Metadata:   &binlogpb.Metadata{},
 						MethodName: "testservice/testmethod",
 						Authority:  "test.service.io",
 					},
@@ -127,16 +127,16 @@ func (s) TestLog(t *testing.T) {
 				},
 				PeerAddr: tcpAddr6,
 			},
-			want: &pb.GrpcLogEntry{
+			want: &binlogpb.GrpcLogEntry{
 				Timestamp:            nil,
 				CallId:               1,
 				SequenceIdWithinCall: 0,
-				Type:                 pb.GrpcLogEntry_EVENT_TYPE_SERVER_HEADER,
-				Logger:               pb.GrpcLogEntry_LOGGER_CLIENT,
-				Payload: &pb.GrpcLogEntry_ServerHeader{
-					ServerHeader: &pb.ServerHeader{
-						Metadata: &pb.Metadata{
-							Entry: []*pb.MetadataEntry{
+				Type:                 binlogpb.GrpcLogEntry_EVENT_TYPE_SERVER_HEADER,
+				Logger:               binlogpb.GrpcLogEntry_LOGGER_CLIENT,
+				Payload: &binlogpb.GrpcLogEntry_ServerHeader{
+					ServerHeader: &binlogpb.ServerHeader{
+						Metadata: &binlogpb.Metadata{
+							Entry: []*binlogpb.MetadataEntry{
 								{Key: "a", Value: []byte{'b'}},
 								{Key: "a", Value: []byte{'b', 'b'}},
 							},
@@ -144,8 +144,8 @@ func (s) TestLog(t *testing.T) {
 					},
 				},
 				PayloadTruncated: false,
-				Peer: &pb.Address{
-					Type:    pb.Address_TYPE_IPV6,
+				Peer: &binlogpb.Address{
+					Type:    binlogpb.Address_TYPE_IPV6,
 					Address: addr6,
 					IpPort:  uint32(port6),
 				},
@@ -156,14 +156,14 @@ func (s) TestLog(t *testing.T) {
 				OnClientSide: true,
 				Message:      testProtoMsg,
 			},
-			want: &pb.GrpcLogEntry{
+			want: &binlogpb.GrpcLogEntry{
 				Timestamp:            nil,
 				CallId:               1,
 				SequenceIdWithinCall: 0,
-				Type:                 pb.GrpcLogEntry_EVENT_TYPE_CLIENT_MESSAGE,
-				Logger:               pb.GrpcLogEntry_LOGGER_CLIENT,
-				Payload: &pb.GrpcLogEntry_Message{
-					Message: &pb.Message{
+				Type:                 binlogpb.GrpcLogEntry_EVENT_TYPE_CLIENT_MESSAGE,
+				Logger:               binlogpb.GrpcLogEntry_LOGGER_CLIENT,
+				Payload: &binlogpb.GrpcLogEntry_Message{
+					Message: &binlogpb.Message{
 						Length: uint32(len(testProtoBytes)),
 						Data:   testProtoBytes,
 					},
@@ -177,14 +177,14 @@ func (s) TestLog(t *testing.T) {
 				OnClientSide: false,
 				Message:      testProtoMsg,
 			},
-			want: &pb.GrpcLogEntry{
+			want: &binlogpb.GrpcLogEntry{
 				Timestamp:            nil,
 				CallId:               1,
 				SequenceIdWithinCall: 0,
-				Type:                 pb.GrpcLogEntry_EVENT_TYPE_SERVER_MESSAGE,
-				Logger:               pb.GrpcLogEntry_LOGGER_SERVER,
-				Payload: &pb.GrpcLogEntry_Message{
-					Message: &pb.Message{
+				Type:                 binlogpb.GrpcLogEntry_EVENT_TYPE_SERVER_MESSAGE,
+				Logger:               binlogpb.GrpcLogEntry_LOGGER_SERVER,
+				Payload: &binlogpb.GrpcLogEntry_Message{
+					Message: &binlogpb.Message{
 						Length: uint32(len(testProtoBytes)),
 						Data:   testProtoBytes,
 					},
@@ -197,12 +197,12 @@ func (s) TestLog(t *testing.T) {
 			config: &ClientHalfClose{
 				OnClientSide: false,
 			},
-			want: &pb.GrpcLogEntry{
+			want: &binlogpb.GrpcLogEntry{
 				Timestamp:            nil,
 				CallId:               1,
 				SequenceIdWithinCall: 0,
-				Type:                 pb.GrpcLogEntry_EVENT_TYPE_CLIENT_HALF_CLOSE,
-				Logger:               pb.GrpcLogEntry_LOGGER_SERVER,
+				Type:                 binlogpb.GrpcLogEntry_EVENT_TYPE_CLIENT_HALF_CLOSE,
+				Logger:               binlogpb.GrpcLogEntry_LOGGER_SERVER,
 				Payload:              nil,
 				PayloadTruncated:     false,
 				Peer:                 nil,
@@ -214,23 +214,23 @@ func (s) TestLog(t *testing.T) {
 				Err:          status.Errorf(codes.Unavailable, "test"),
 				PeerAddr:     tcpAddr,
 			},
-			want: &pb.GrpcLogEntry{
+			want: &binlogpb.GrpcLogEntry{
 				Timestamp:            nil,
 				CallId:               1,
 				SequenceIdWithinCall: 0,
-				Type:                 pb.GrpcLogEntry_EVENT_TYPE_SERVER_TRAILER,
-				Logger:               pb.GrpcLogEntry_LOGGER_CLIENT,
-				Payload: &pb.GrpcLogEntry_Trailer{
-					Trailer: &pb.Trailer{
-						Metadata:      &pb.Metadata{},
+				Type:                 binlogpb.GrpcLogEntry_EVENT_TYPE_SERVER_TRAILER,
+				Logger:               binlogpb.GrpcLogEntry_LOGGER_CLIENT,
+				Payload: &binlogpb.GrpcLogEntry_Trailer{
+					Trailer: &binlogpb.Trailer{
+						Metadata:      &binlogpb.Metadata{},
 						StatusCode:    uint32(codes.Unavailable),
 						StatusMessage: "test",
 						StatusDetails: nil,
 					},
 				},
 				PayloadTruncated: false,
-				Peer: &pb.Address{
-					Type:    pb.Address_TYPE_IPV4,
+				Peer: &binlogpb.Address{
+					Type:    binlogpb.Address_TYPE_IPV4,
 					Address: addr,
 					IpPort:  uint32(port),
 				},
@@ -240,15 +240,15 @@ func (s) TestLog(t *testing.T) {
 			config: &ServerTrailer{
 				OnClientSide: true,
 			},
-			want: &pb.GrpcLogEntry{
+			want: &binlogpb.GrpcLogEntry{
 				Timestamp:            nil,
 				CallId:               1,
 				SequenceIdWithinCall: 0,
-				Type:                 pb.GrpcLogEntry_EVENT_TYPE_SERVER_TRAILER,
-				Logger:               pb.GrpcLogEntry_LOGGER_CLIENT,
-				Payload: &pb.GrpcLogEntry_Trailer{
-					Trailer: &pb.Trailer{
-						Metadata:      &pb.Metadata{},
+				Type:                 binlogpb.GrpcLogEntry_EVENT_TYPE_SERVER_TRAILER,
+				Logger:               binlogpb.GrpcLogEntry_LOGGER_CLIENT,
+				Payload: &binlogpb.GrpcLogEntry_Trailer{
+					Trailer: &binlogpb.Trailer{
+						Metadata:      &binlogpb.Metadata{},
 						StatusCode:    uint32(codes.OK),
 						StatusMessage: "",
 						StatusDetails: nil,
@@ -262,12 +262,12 @@ func (s) TestLog(t *testing.T) {
 			config: &Cancel{
 				OnClientSide: true,
 			},
-			want: &pb.GrpcLogEntry{
+			want: &binlogpb.GrpcLogEntry{
 				Timestamp:            nil,
 				CallId:               1,
 				SequenceIdWithinCall: 0,
-				Type:                 pb.GrpcLogEntry_EVENT_TYPE_CANCEL,
-				Logger:               pb.GrpcLogEntry_LOGGER_CLIENT,
+				Type:                 binlogpb.GrpcLogEntry_EVENT_TYPE_CANCEL,
+				Logger:               binlogpb.GrpcLogEntry_LOGGER_CLIENT,
 				Payload:              nil,
 				PayloadTruncated:     false,
 				Peer:                 nil,
@@ -284,16 +284,16 @@ func (s) TestLog(t *testing.T) {
 					"a":             {"b", "bb"},
 				},
 			},
-			want: &pb.GrpcLogEntry{
+			want: &binlogpb.GrpcLogEntry{
 				Timestamp:            nil,
 				CallId:               1,
 				SequenceIdWithinCall: 0,
-				Type:                 pb.GrpcLogEntry_EVENT_TYPE_CLIENT_HEADER,
-				Logger:               pb.GrpcLogEntry_LOGGER_SERVER,
-				Payload: &pb.GrpcLogEntry_ClientHeader{
-					ClientHeader: &pb.ClientHeader{
-						Metadata: &pb.Metadata{
-							Entry: []*pb.MetadataEntry{
+				Type:                 binlogpb.GrpcLogEntry_EVENT_TYPE_CLIENT_HEADER,
+				Logger:               binlogpb.GrpcLogEntry_LOGGER_SERVER,
+				Payload: &binlogpb.GrpcLogEntry_ClientHeader{
+					ClientHeader: &binlogpb.ClientHeader{
+						Metadata: &binlogpb.Metadata{
+							Entry: []*binlogpb.MetadataEntry{
 								{Key: "a", Value: []byte{'b'}},
 								{Key: "a", Value: []byte{'b', 'b'}},
 							},
@@ -312,16 +312,16 @@ func (s) TestLog(t *testing.T) {
 					"a":             {"b", "bb"},
 				},
 			},
-			want: &pb.GrpcLogEntry{
+			want: &binlogpb.GrpcLogEntry{
 				Timestamp:            nil,
 				CallId:               1,
 				SequenceIdWithinCall: 0,
-				Type:                 pb.GrpcLogEntry_EVENT_TYPE_SERVER_HEADER,
-				Logger:               pb.GrpcLogEntry_LOGGER_CLIENT,
-				Payload: &pb.GrpcLogEntry_ServerHeader{
-					ServerHeader: &pb.ServerHeader{
-						Metadata: &pb.Metadata{
-							Entry: []*pb.MetadataEntry{
+				Type:                 binlogpb.GrpcLogEntry_EVENT_TYPE_SERVER_HEADER,
+				Logger:               binlogpb.GrpcLogEntry_LOGGER_CLIENT,
+				Payload: &binlogpb.GrpcLogEntry_ServerHeader{
+					ServerHeader: &binlogpb.ServerHeader{
+						Metadata: &binlogpb.Metadata{
+							Entry: []*binlogpb.MetadataEntry{
 								{Key: "a", Value: []byte{'b'}},
 								{Key: "a", Value: []byte{'b', 'b'}},
 							},
@@ -336,7 +336,7 @@ func (s) TestLog(t *testing.T) {
 		buf.Reset()
 		tc.want.SequenceIdWithinCall = uint64(i + 1)
 		ml.Log(tc.config)
-		inSink := new(pb.GrpcLogEntry)
+		inSink := new(binlogpb.GrpcLogEntry)
 		if err := proto.Unmarshal(buf.Bytes()[4:], inSink); err != nil {
 			t.Errorf("failed to unmarshal bytes in sink to proto: %v", err)
 			continue
@@ -351,44 +351,44 @@ func (s) TestLog(t *testing.T) {
 func (s) TestTruncateMetadataNotTruncated(t *testing.T) {
 	testCases := []struct {
 		ml   *TruncatingMethodLogger
-		mpPb *pb.Metadata
+		mpPb *binlogpb.Metadata
 	}{
 		{
 			ml: NewTruncatingMethodLogger(maxUInt, maxUInt),
-			mpPb: &pb.Metadata{
-				Entry: []*pb.MetadataEntry{
+			mpPb: &binlogpb.Metadata{
+				Entry: []*binlogpb.MetadataEntry{
 					{Key: "", Value: []byte{1}},
 				},
 			},
 		},
 		{
 			ml: NewTruncatingMethodLogger(2, maxUInt),
-			mpPb: &pb.Metadata{
-				Entry: []*pb.MetadataEntry{
+			mpPb: &binlogpb.Metadata{
+				Entry: []*binlogpb.MetadataEntry{
 					{Key: "", Value: []byte{1}},
 				},
 			},
 		},
 		{
 			ml: NewTruncatingMethodLogger(1, maxUInt),
-			mpPb: &pb.Metadata{
-				Entry: []*pb.MetadataEntry{
+			mpPb: &binlogpb.Metadata{
+				Entry: []*binlogpb.MetadataEntry{
 					{Key: "", Value: nil},
 				},
 			},
 		},
 		{
 			ml: NewTruncatingMethodLogger(2, maxUInt),
-			mpPb: &pb.Metadata{
-				Entry: []*pb.MetadataEntry{
+			mpPb: &binlogpb.Metadata{
+				Entry: []*binlogpb.MetadataEntry{
 					{Key: "", Value: []byte{1, 1}},
 				},
 			},
 		},
 		{
 			ml: NewTruncatingMethodLogger(2, maxUInt),
-			mpPb: &pb.Metadata{
-				Entry: []*pb.MetadataEntry{
+			mpPb: &binlogpb.Metadata{
+				Entry: []*binlogpb.MetadataEntry{
 					{Key: "", Value: []byte{1}},
 					{Key: "", Value: []byte{1}},
 				},
@@ -398,8 +398,8 @@ func (s) TestTruncateMetadataNotTruncated(t *testing.T) {
 		// limit.
 		{
 			ml: NewTruncatingMethodLogger(1, maxUInt),
-			mpPb: &pb.Metadata{
-				Entry: []*pb.MetadataEntry{
+			mpPb: &binlogpb.Metadata{
+				Entry: []*binlogpb.MetadataEntry{
 					{Key: "", Value: []byte{1}},
 					{Key: "grpc-trace-bin", Value: []byte("some.trace.key")},
 				},
@@ -418,14 +418,14 @@ func (s) TestTruncateMetadataNotTruncated(t *testing.T) {
 func (s) TestTruncateMetadataTruncated(t *testing.T) {
 	testCases := []struct {
 		ml   *TruncatingMethodLogger
-		mpPb *pb.Metadata
+		mpPb *binlogpb.Metadata
 
 		entryLen int
 	}{
 		{
 			ml: NewTruncatingMethodLogger(2, maxUInt),
-			mpPb: &pb.Metadata{
-				Entry: []*pb.MetadataEntry{
+			mpPb: &binlogpb.Metadata{
+				Entry: []*binlogpb.MetadataEntry{
 					{Key: "", Value: []byte{1, 1, 1}},
 				},
 			},
@@ -433,8 +433,8 @@ func (s) TestTruncateMetadataTruncated(t *testing.T) {
 		},
 		{
 			ml: NewTruncatingMethodLogger(2, maxUInt),
-			mpPb: &pb.Metadata{
-				Entry: []*pb.MetadataEntry{
+			mpPb: &binlogpb.Metadata{
+				Entry: []*binlogpb.MetadataEntry{
 					{Key: "", Value: []byte{1}},
 					{Key: "", Value: []byte{1}},
 					{Key: "", Value: []byte{1}},
@@ -444,8 +444,8 @@ func (s) TestTruncateMetadataTruncated(t *testing.T) {
 		},
 		{
 			ml: NewTruncatingMethodLogger(2, maxUInt),
-			mpPb: &pb.Metadata{
-				Entry: []*pb.MetadataEntry{
+			mpPb: &binlogpb.Metadata{
+				Entry: []*binlogpb.MetadataEntry{
 					{Key: "", Value: []byte{1, 1}},
 					{Key: "", Value: []byte{1}},
 				},
@@ -454,8 +454,8 @@ func (s) TestTruncateMetadataTruncated(t *testing.T) {
 		},
 		{
 			ml: NewTruncatingMethodLogger(2, maxUInt),
-			mpPb: &pb.Metadata{
-				Entry: []*pb.MetadataEntry{
+			mpPb: &binlogpb.Metadata{
+				Entry: []*binlogpb.MetadataEntry{
 					{Key: "", Value: []byte{1}},
 					{Key: "", Value: []byte{1, 1}},
 				},
@@ -479,23 +479,23 @@ func (s) TestTruncateMetadataTruncated(t *testing.T) {
 func (s) TestTruncateMessageNotTruncated(t *testing.T) {
 	testCases := []struct {
 		ml    *TruncatingMethodLogger
-		msgPb *pb.Message
+		msgPb *binlogpb.Message
 	}{
 		{
 			ml: NewTruncatingMethodLogger(maxUInt, maxUInt),
-			msgPb: &pb.Message{
+			msgPb: &binlogpb.Message{
 				Data: []byte{1},
 			},
 		},
 		{
 			ml: NewTruncatingMethodLogger(maxUInt, 3),
-			msgPb: &pb.Message{
+			msgPb: &binlogpb.Message{
 				Data: []byte{1, 1},
 			},
 		},
 		{
 			ml: NewTruncatingMethodLogger(maxUInt, 2),
-			msgPb: &pb.Message{
+			msgPb: &binlogpb.Message{
 				Data: []byte{1, 1},
 			},
 		},
@@ -512,13 +512,13 @@ func (s) TestTruncateMessageNotTruncated(t *testing.T) {
 func (s) TestTruncateMessageTruncated(t *testing.T) {
 	testCases := []struct {
 		ml    *TruncatingMethodLogger
-		msgPb *pb.Message
+		msgPb *binlogpb.Message
 
 		oldLength uint32
 	}{
 		{
 			ml: NewTruncatingMethodLogger(maxUInt, 2),
-			msgPb: &pb.Message{
+			msgPb: &binlogpb.Message{
 				Length: 3,
 				Data:   []byte{1, 1, 1},
 			},

--- a/internal/binarylog/sink.go
+++ b/internal/binarylog/sink.go
@@ -26,7 +26,7 @@ import (
 	"time"
 
 	"github.com/golang/protobuf/proto"
-	pb "google.golang.org/grpc/binarylog/grpc_binarylog_v1"
+	binlogpb "google.golang.org/grpc/binarylog/grpc_binarylog_v1"
 )
 
 var (
@@ -42,15 +42,15 @@ type Sink interface {
 	// Write will be called to write the log entry into the sink.
 	//
 	// It should be thread-safe so it can be called in parallel.
-	Write(*pb.GrpcLogEntry) error
+	Write(*binlogpb.GrpcLogEntry) error
 	// Close will be called when the Sink is replaced by a new Sink.
 	Close() error
 }
 
 type noopSink struct{}
 
-func (ns *noopSink) Write(*pb.GrpcLogEntry) error { return nil }
-func (ns *noopSink) Close() error                 { return nil }
+func (ns *noopSink) Write(*binlogpb.GrpcLogEntry) error { return nil }
+func (ns *noopSink) Close() error                       { return nil }
 
 // newWriterSink creates a binary log sink with the given writer.
 //
@@ -66,7 +66,7 @@ type writerSink struct {
 	out io.Writer
 }
 
-func (ws *writerSink) Write(e *pb.GrpcLogEntry) error {
+func (ws *writerSink) Write(e *binlogpb.GrpcLogEntry) error {
 	b, err := proto.Marshal(e)
 	if err != nil {
 		grpclogLogger.Errorf("binary logging: failed to marshal proto message: %v", err)
@@ -96,7 +96,7 @@ type bufferedSink struct {
 	done        chan struct{}
 }
 
-func (fs *bufferedSink) Write(e *pb.GrpcLogEntry) error {
+func (fs *bufferedSink) Write(e *binlogpb.GrpcLogEntry) error {
 	fs.mu.Lock()
 	defer fs.mu.Unlock()
 	if !fs.flusherStarted {


### PR DESCRIPTION
The binarylog proto is currently used by the `binarylog` package and also by the `observability` module. The latter renames this import as `binlogpb`, while the former currently renames it as `pb`. Renaming it as `binlogpb` is more readable, and having it being consistently renamed will help us with import renaming in google3.

RELEASE NOTES: none