### PR TITLE
Revert "xds interop: Fix buildscripts not continuing on a failed test suite"

### DIFF
--- a/test/kokoro/psm-security.sh
+++ b/test/kokoro/psm-security.sh
@@ -158,7 +158,7 @@ main() {
   local failed_tests=0
   test_suites=("baseline_test" "security_test" "authz_test")
   for test in "${test_suites[@]}"; do
-    run_test $test || (( failed_tests++ )) && true
+    run_test $test || (( failed_tests++ ))
   done
   echo "Failed test suites: ${failed_tests}"
   if (( failed_tests > 0 )); then

--- a/test/kokoro/xds_k8s_lb.sh
+++ b/test/kokoro/xds_k8s_lb.sh
@@ -160,7 +160,7 @@ main() {
   local failed_tests=0
   test_suites=("api_listener_test" "change_backend_service_test" "failover_test" "remove_neg_test" "round_robin_test" "affinity_test" "outlier_detection_test")
   for test in "${test_suites[@]}"; do
-    run_test $test || (( failed_tests++ )) && true
+    run_test $test || (( failed_tests++ ))
   done
   echo "Failed test suites: ${failed_tests}"
   if (( failed_tests > 0 )); then


### PR DESCRIPTION
Reverts grpc/grpc-go#5932.

Reverted in favor of better syntax suggested here: https://github.com/grpc/grpc-node/pull/2323#pullrequestreview-1248043432. This fix will be sent as another PR for the convenience of backporting.

RELEASE NOTES: n/a