### PR TITLE
transport: fix maxStreamID to align with http2 spec

### DIFF
--- a/internal/transport/defaults.go
+++ b/internal/transport/defaults.go
@@ -52,4 +52,4 @@ const (
 // transport gracefully closes and new transport is created for subsequent RPCs.
 // This is set to 75% of 2^31-1. Streams are identified with an unsigned 31-bit
 // integer. It's exported so that tests can override it.
-var MaxStreamID = uint32(1_610_612_735)
+var MaxStreamID = uint32(math.MaxInt32 * 3 / 4)

--- a/internal/transport/defaults.go
+++ b/internal/transport/defaults.go
@@ -50,5 +50,6 @@ const (
 
 // MaxStreamID is the upper bound for the stream ID before the current
 // transport gracefully closes and new transport is created for subsequent RPCs.
-// This is set to 75% of math.MaxUint32. It's exported so that tests can override it.
-var MaxStreamID = uint32(3_221_225_472)
+// This is set to 75% of 2^31-1. Streams are identified with an unsigned 31-bit
+// integer. It's exported so that tests can override it.
+var MaxStreamID = uint32(1_610_612_735)


### PR DESCRIPTION
In [this](https://github.com/grpc/grpc-go/pull/5889) previous change, `maxStreamID` was set to 75% of uint32. But according to the http2 spec. Stream are identified with an unsigned 31-bit integer

This PR will fix it

RELEASE NOTES: N/A