### PR TITLE
all: change fmt.Errorf to errors.New when there is no formatting required

### DIFF
--- a/balancer_conn_wrappers.go
+++ b/balancer_conn_wrappers.go
@@ -20,7 +20,7 @@ package grpc
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"strings"
 	"sync"
 
@@ -301,7 +301,7 @@ func (ccb *ccBalancerWrapper) handleClose() {
 
 func (ccb *ccBalancerWrapper) NewSubConn(addrs []resolver.Address, opts balancer.NewSubConnOptions) (balancer.SubConn, error) {
 	if len(addrs) <= 0 {
-		return nil, fmt.Errorf("grpc: cannot create SubConn with empty address list")
+		return nil, errors.New("grpc: cannot create SubConn with empty address list")
 	}
 	ac, err := ccb.cc.newAddrConn(addrs, opts)
 	if err != nil {

--- a/clientconn_test.go
+++ b/clientconn_test.go
@@ -854,7 +854,7 @@ func (s) TestBackoffCancel(t *testing.T) {
 	dialStrCh := make(chan string)
 	cc, err := Dial("any", WithTransportCredentials(insecure.NewCredentials()), WithDialer(func(t string, _ time.Duration) (net.Conn, error) {
 		dialStrCh <- t
-		return nil, fmt.Errorf("test dialer, always error")
+		return nil, errors.New("test dialer, always error")
 	}))
 	if err != nil {
 		t.Fatalf("Failed to create ClientConn: %v", err)

--- a/picker_wrapper_test.go
+++ b/picker_wrapper_test.go
@@ -20,7 +20,7 @@ package grpc
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -57,7 +57,7 @@ type testingPicker struct {
 
 func (p *testingPicker) Pick(info balancer.PickInfo) (balancer.PickResult, error) {
 	if atomic.AddInt64(&p.maxCalled, -1) < 0 {
-		return balancer.PickResult{}, fmt.Errorf("pick called to many times (> goroutineCount)")
+		return balancer.PickResult{}, errors.New("pick called to many times (> goroutineCount)")
 	}
 	if p.err != nil {
 		return balancer.PickResult{}, p.err

--- a/service_config.go
+++ b/service_config.go
@@ -221,7 +221,7 @@ func init() {
 }
 func parseServiceConfig(js string) *serviceconfig.ParseResult {
 	if len(js) == 0 {
-		return &serviceconfig.ParseResult{Err: fmt.Errorf("no JSON service config provided")}
+		return &serviceconfig.ParseResult{Err: errors.New("no JSON service config provided")}
 	}
 	var rsc jsonSC
 	err := json.Unmarshal([]byte(js), &rsc)


### PR DESCRIPTION
Change fmt.Errorf to errors.New when there is no formatting required.

RELEASE NOTES: N/A