### PR TITLE
gcp/observability: update method name validation

### DIFF
--- a/gcp/observability/config.go
+++ b/gcp/observability/config.go
@@ -24,19 +24,14 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"regexp"
+	"strings"
 
 	gcplogging "cloud.google.com/go/logging"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/grpc/internal/envconfig"
 )
 
-const (
-	envProjectID          = "GOOGLE_CLOUD_PROJECT"
-	methodStringRegexpStr = `^([\w./]+)/((?:\w+)|[*])$`
-)
-
-var methodStringRegexp = regexp.MustCompile(methodStringRegexpStr)
+const envProjectID = "GOOGLE_CLOUD_PROJECT"
 
 // fetchDefaultProjectID fetches the default GCP project id from environment.
 func fetchDefaultProjectID(ctx context.Context) string {
@@ -59,6 +54,28 @@ func fetchDefaultProjectID(ctx context.Context) string {
 	return credentials.ProjectID
 }
 
+// validateMethodString validates whether the string passed in is a valid
+// pattern.
+func validateMethodString(method string) error {
+	if method == "*" {
+		return nil
+	}
+	if strings.HasPrefix(method, "/") {
+		return errors.New("cannot have a leading slash")
+	}
+	serviceMethod := strings.Split(method, "/")
+	if len(serviceMethod) != 2 {
+		return errors.New("/ must come in between service and method, only one /")
+	}
+	if serviceMethod[1] == "" {
+		return errors.New("method name must be non empty")
+	}
+	if serviceMethod[0] == "*" {
+		return errors.New("cannot have service wildcard * i.e. (*/m)")
+	}
+	return nil
+}
+
 func validateLogEventMethod(methods []string, exclude bool) error {
 	for _, method := range methods {
 		if method == "*" {
@@ -67,9 +84,8 @@ func validateLogEventMethod(methods []string, exclude bool) error {
 			}
 			continue
 		}
-		match := methodStringRegexp.FindStringSubmatch(method)
-		if match == nil {
-			return fmt.Errorf("invalid method string: %v", method)
+		if err := validateMethodString(method); err != nil {
+			return fmt.Errorf("invalid method string: %v, err: %v", method, err)
 		}
 	}
 	return nil

--- a/gcp/observability/config.go
+++ b/gcp/observability/config.go
@@ -57,9 +57,6 @@ func fetchDefaultProjectID(ctx context.Context) string {
 // validateMethodString validates whether the string passed in is a valid
 // pattern.
 func validateMethodString(method string) error {
-	if method == "*" {
-		return nil
-	}
 	if strings.HasPrefix(method, "/") {
 		return errors.New("cannot have a leading slash")
 	}

--- a/gcp/observability/logging.go
+++ b/gcp/observability/logging.go
@@ -22,6 +22,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -322,6 +323,7 @@ func (bml *binaryMethodLogger) Log(c iblog.LogEntryConfig) {
 }
 
 type eventConfig struct {
+	// ServiceMethod has /s/m syntax for fast matching.
 	ServiceMethod map[string]bool
 	Services      map[string]bool
 	MatchAll      bool
@@ -364,6 +366,17 @@ func (bl *binaryLogger) GetMethodLogger(methodName string) iblog.MethodLogger {
 	return nil
 }
 
+// parseMethod splits service and method from the input. It expects format
+// "service/method".
+func parseMethod(method string) (string, string, error) {
+	pos := strings.LastIndex(method, "/")
+	if pos < 0 {
+		// Shouldn't happen, config already validated.
+		return "", "", errors.New("invalid method name: no / found")
+	}
+	return method[:pos], method[pos+1:], nil
+}
+
 func registerClientRPCEvents(clientRPCEvents []clientRPCEvents, exporter loggingExporter) {
 	if len(clientRPCEvents) == 0 {
 		return
@@ -382,7 +395,7 @@ func registerClientRPCEvents(clientRPCEvents []clientRPCEvents, exporter logging
 				eventConfig.MatchAll = true
 				continue
 			}
-			s, m, err := grpcutil.ParseMethod(method)
+			s, m, err := parseMethod(method)
 			if err != nil {
 				continue
 			}
@@ -390,7 +403,7 @@ func registerClientRPCEvents(clientRPCEvents []clientRPCEvents, exporter logging
 				eventConfig.Services[s] = true
 				continue
 			}
-			eventConfig.ServiceMethod[method] = true
+			eventConfig.ServiceMethod["/"+method] = true
 		}
 		eventConfigs = append(eventConfigs, eventConfig)
 	}
@@ -419,15 +432,15 @@ func registerServerRPCEvents(serverRPCEvents []serverRPCEvents, exporter logging
 				eventConfig.MatchAll = true
 				continue
 			}
-			s, m, err := grpcutil.ParseMethod(method)
-			if err != nil { // Shouldn't happen, already validated at this point.
+			s, m, err := parseMethod(method)
+			if err != nil {
 				continue
 			}
 			if m == "*" {
 				eventConfig.Services[s] = true
 				continue
 			}
-			eventConfig.ServiceMethod[method] = true
+			eventConfig.ServiceMethod["/"+method] = true
 		}
 		eventConfigs = append(eventConfigs, eventConfig)
 	}

--- a/gcp/observability/logging.go
+++ b/gcp/observability/logging.go
@@ -369,7 +369,7 @@ func (bl *binaryLogger) GetMethodLogger(methodName string) iblog.MethodLogger {
 // parseMethod splits service and method from the input. It expects format
 // "service/method".
 func parseMethod(method string) (string, string, error) {
-	pos := strings.LastIndex(method, "/")
+	pos := strings.Index(method, "/")
 	if pos < 0 {
 		// Shouldn't happen, config already validated.
 		return "", "", errors.New("invalid method name: no / found")


### PR DESCRIPTION
This PR iterates what a valid method name is in the observability config, according to offline discussions.

From Doug, this can be summarized as:
```
Allowed patterns:
- *
- service/*
- service/method

- service and method may not contain slash
```

RELEASE NOTES:
* gcp/observability: update method name validation