### PR TITLE
xds: fix panic involving double close of channel in xDS transport

### DIFF
--- a/xds/internal/xdsclient/transport/loadreport.go
+++ b/xds/internal/xdsclient/transport/loadreport.go
@@ -84,10 +84,9 @@ func (t *Transport) lrsStopStream() {
 	t.lrsCancelStream()
 	t.logger.Infof("Stopping LRS stream")
 
-	// Wait for the runner goroutine to exit, and set the done channel to nil.
-	// The done channel will be recreated when a new stream is created.
+	// Wait for the runner goroutine to exit. The done channel will be
+	// recreated when a new stream is created.
 	<-t.lrsRunnerDoneCh
-	t.lrsRunnerDoneCh = nil
 }
 
 // lrsRunner starts an LRS stream to report load data to the management server.

--- a/xds/internal/xdsclient/transport/loadreport_test.go
+++ b/xds/internal/xdsclient/transport/loadreport_test.go
@@ -54,7 +54,7 @@ func (s) TestReportLoad(t *testing.T) {
 		NodeProto:    nodeProto,
 	}
 
-	// Create a transport to the fake server.
+	// Create a transport to the fake management server.
 	tr, err := transport.New(transport.Options{
 		ServerCfg:          serverCfg,
 		UpdateHandler:      func(transport.ResourceUpdate) error { return nil }, // No ADS validation.
@@ -190,4 +190,16 @@ func (s) TestReportLoad(t *testing.T) {
 	if _, err := mgmtServer.LRSStreamCloseChan.Receive(ctx); err != nil {
 		t.Fatal("Timeout waiting for LRS stream to close")
 	}
+
+	// Calling the load reporting API again should result in the creation of a
+	// new LRS stream. This ensures that creating and closing multiple streams
+	// works smoothly.
+	_, cancelLRS3 := tr.ReportLoad()
+	if err != nil {
+		t.Fatalf("Failed to start LRS load reporting: %v", err)
+	}
+	if _, err := mgmtServer.LRSStreamOpenChan.Receive(ctx); err != nil {
+		t.Fatalf("Timeout when waiting for LRS stream to be created: %v", err)
+	}
+	cancelLRS3()
 }

--- a/xds/internal/xdsclient/transport/transport.go
+++ b/xds/internal/xdsclient/transport/transport.go
@@ -202,7 +202,6 @@ func New(opts Options) (*Transport, error) {
 		versions:        make(map[string]string),
 		nonces:          make(map[string]string),
 		adsRunnerDoneCh: make(chan struct{}),
-		lrsRunnerDoneCh: make(chan struct{}),
 	}
 
 	// This context is used for sending and receiving RPC requests and


### PR DESCRIPTION
Existing code was using a single channel in the xDS `Transport` type to ensure that the LRS goroutine exited when closing LRS streams. This was leading to a double close of the associated channel when multiple streams were started and closed. This PR changes the logic such that a new channel is created every time a new stream is created. Since we know that there can be only one active stream per transport, this approach works perfectly.

Fixes [internal P1 issue](https://buganizer.corp.google.com/issues/266436373).

This also needs to be backported to `v1.52.x`.

RELEASE NOTES:
- xds: fix panic involving double close of channel in xDS transport