### PR TITLE
Cherry pick: grpclb: rename `grpclbstate` package back to `state` (#5962)

### DIFF
--- a/balancer/grpclb/grpclb.go
+++ b/balancer/grpclb/grpclb.go
@@ -32,7 +32,7 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/balancer"
-	"google.golang.org/grpc/balancer/grpclb/grpclbstate"
+	grpclbstate "google.golang.org/grpc/balancer/grpclb/state"
 	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/grpclog"

--- a/balancer/grpclb/grpclb_test.go
+++ b/balancer/grpclb/grpclb_test.go
@@ -36,7 +36,7 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/balancer"
-	"google.golang.org/grpc/balancer/grpclb/grpclbstate"
+	grpclbstate "google.golang.org/grpc/balancer/grpclb/state"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/internal"

--- a/balancer/grpclb/state/state.go
+++ b/balancer/grpclb/state/state.go
@@ -16,9 +16,9 @@
  *
  */
 
-// Package grpclbstate declares grpclb types to be set by resolvers wishing to
-// pass information to grpclb via resolver.State Attributes.
-package grpclbstate
+// Package state declares grpclb types to be set by resolvers wishing to pass
+// information to grpclb via resolver.State Attributes.
+package state
 
 import (
 	"google.golang.org/grpc/resolver"
@@ -27,7 +27,7 @@ import (
 // keyType is the key to use for storing State in Attributes.
 type keyType string
 
-const key = keyType("grpc.grpclb.grpclbstate")
+const key = keyType("grpc.grpclb.state")
 
 // State contains gRPCLB-relevant data passed from the name resolver.
 type State struct {

--- a/internal/resolver/dns/dns_resolver.go
+++ b/internal/resolver/dns/dns_resolver.go
@@ -32,7 +32,7 @@ import (
 	"sync"
 	"time"
 
-	grpclbstate "google.golang.org/grpc/balancer/grpclb/grpclbstate"
+	grpclbstate "google.golang.org/grpc/balancer/grpclb/state"
 	"google.golang.org/grpc/grpclog"
 	"google.golang.org/grpc/internal/backoff"
 	"google.golang.org/grpc/internal/envconfig"

--- a/internal/resolver/dns/dns_resolver_test.go
+++ b/internal/resolver/dns/dns_resolver_test.go
@@ -34,7 +34,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"google.golang.org/grpc/balancer"
-	grpclbstate "google.golang.org/grpc/balancer/grpclb/grpclbstate"
+	grpclbstate "google.golang.org/grpc/balancer/grpclb/state"
 	"google.golang.org/grpc/internal/envconfig"
 	"google.golang.org/grpc/internal/leakcheck"
 	"google.golang.org/grpc/internal/testutils"


### PR DESCRIPTION
RELEASE NOTES:
* grpclb: rename grpclbstate package back to state