### PR TITLE
tests: fix spelling of variable

### DIFF
--- a/xds/internal/balancer/clusterresolver/clusterresolver_test.go
+++ b/xds/internal/balancer/clusterresolver/clusterresolver_test.go
@@ -46,7 +46,7 @@ import (
 const (
 	defaultTestTimeout      = 5 * time.Second
 	defaultTestShortTimeout = 10 * time.Millisecond
-	testEDSServcie          = "test-eds-service-name"
+	testEDSService          = "test-eds-service-name"
 	testClusterName         = "test-cluster-name"
 	testClusterName2        = "google_cfe_some-name"
 )
@@ -104,7 +104,7 @@ func (t *noopTestClientConn) NewSubConn([]resolver.Address, balancer.NewSubConnO
 	return nil, nil
 }
 
-func (noopTestClientConn) Target() string { return testEDSServcie }
+func (noopTestClientConn) Target() string { return testEDSService }
 
 type scStateChange struct {
 	sc    balancer.SubConn
@@ -234,7 +234,7 @@ func (s) TestSubConnStateChange(t *testing.T) {
 
 	if err := edsB.UpdateClientConnState(balancer.ClientConnState{
 		ResolverState:  xdsclient.SetClient(resolver.State{}, xdsC),
-		BalancerConfig: newLBConfigWithOneEDS(testEDSServcie),
+		BalancerConfig: newLBConfigWithOneEDS(testEDSService),
 	}); err != nil {
 		t.Fatalf("edsB.UpdateClientConnState() failed: %v", err)
 	}
@@ -282,7 +282,7 @@ func (s) TestErrorFromXDSClientUpdate(t *testing.T) {
 	defer cancel()
 	if err := edsB.UpdateClientConnState(balancer.ClientConnState{
 		ResolverState:  xdsclient.SetClient(resolver.State{}, xdsC),
-		BalancerConfig: newLBConfigWithOneEDS(testEDSServcie),
+		BalancerConfig: newLBConfigWithOneEDS(testEDSService),
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -336,7 +336,7 @@ func (s) TestErrorFromXDSClientUpdate(t *testing.T) {
 	// An update with the same service name should not trigger a new watch.
 	if err := edsB.UpdateClientConnState(balancer.ClientConnState{
 		ResolverState:  xdsclient.SetClient(resolver.State{}, xdsC),
-		BalancerConfig: newLBConfigWithOneEDS(testEDSServcie),
+		BalancerConfig: newLBConfigWithOneEDS(testEDSService),
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -370,7 +370,7 @@ func (s) TestErrorFromResolver(t *testing.T) {
 	defer cancel()
 	if err := edsB.UpdateClientConnState(balancer.ClientConnState{
 		ResolverState:  xdsclient.SetClient(resolver.State{}, xdsC),
-		BalancerConfig: newLBConfigWithOneEDS(testEDSServcie),
+		BalancerConfig: newLBConfigWithOneEDS(testEDSService),
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -421,7 +421,7 @@ func (s) TestErrorFromResolver(t *testing.T) {
 	// the previous watch was canceled.
 	if err := edsB.UpdateClientConnState(balancer.ClientConnState{
 		ResolverState:  xdsclient.SetClient(resolver.State{}, xdsC),
-		BalancerConfig: newLBConfigWithOneEDS(testEDSServcie),
+		BalancerConfig: newLBConfigWithOneEDS(testEDSService),
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -549,7 +549,7 @@ func (s) TestOutlierDetection(t *testing.T) {
 	// level.
 	if err := edsB.UpdateClientConnState(balancer.ClientConnState{
 		ResolverState:  xdsclient.SetClient(resolver.State{}, xdsC),
-		BalancerConfig: newLBConfigWithOneEDSAndOutlierDetection(testEDSServcie, noopODCfg),
+		BalancerConfig: newLBConfigWithOneEDSAndOutlierDetection(testEDSService, noopODCfg),
 	}); err != nil {
 		t.Fatal(err)
 	}

--- a/xds/internal/balancer/clusterresolver/config_test.go
+++ b/xds/internal/balancer/clusterresolver/config_test.go
@@ -187,7 +187,7 @@ func TestParseConfig(t *testing.T) {
 						LoadReportingServer:   testLRSServerConfig,
 						MaxConcurrentRequests: newUint32(testMaxRequests),
 						Type:                  DiscoveryMechanismTypeEDS,
-						EDSServiceName:        testEDSServcie,
+						EDSServiceName:        testEDSService,
 					},
 				},
 				XDSLBPolicy: nil,
@@ -204,7 +204,7 @@ func TestParseConfig(t *testing.T) {
 						LoadReportingServer:   testLRSServerConfig,
 						MaxConcurrentRequests: newUint32(testMaxRequests),
 						Type:                  DiscoveryMechanismTypeEDS,
-						EDSServiceName:        testEDSServcie,
+						EDSServiceName:        testEDSService,
 					},
 					{
 						Type: DiscoveryMechanismTypeLogicalDNS,
@@ -224,7 +224,7 @@ func TestParseConfig(t *testing.T) {
 						LoadReportingServer:   testLRSServerConfig,
 						MaxConcurrentRequests: newUint32(testMaxRequests),
 						Type:                  DiscoveryMechanismTypeEDS,
-						EDSServiceName:        testEDSServcie,
+						EDSServiceName:        testEDSService,
 					},
 				},
 				XDSLBPolicy: &internalserviceconfig.BalancerConfig{
@@ -244,7 +244,7 @@ func TestParseConfig(t *testing.T) {
 						LoadReportingServer:   testLRSServerConfig,
 						MaxConcurrentRequests: newUint32(testMaxRequests),
 						Type:                  DiscoveryMechanismTypeEDS,
-						EDSServiceName:        testEDSServcie,
+						EDSServiceName:        testEDSService,
 					},
 				},
 				XDSLBPolicy: &internalserviceconfig.BalancerConfig{

--- a/xds/internal/balancer/clusterresolver/configbuilder_test.go
+++ b/xds/internal/balancer/clusterresolver/configbuilder_test.go
@@ -588,12 +588,12 @@ func TestPriorityLocalitiesToClusterImpl(t *testing.T) {
 		mechanism: DiscoveryMechanism{
 			Cluster:        testClusterName,
 			Type:           DiscoveryMechanismTypeEDS,
-			EDSServiceName: testEDSServcie,
+			EDSServiceName: testEDSService,
 		},
 		// lrsServer is nil, so LRS policy will not be used.
 		wantConfig: &clusterimpl.LBConfig{
 			Cluster:        testClusterName,
-			EDSServiceName: testEDSServcie,
+			EDSServiceName: testEDSService,
 			ChildPolicy: &internalserviceconfig.BalancerConfig{
 				Name: weightedtarget.Name,
 				Config: &weightedtarget.LBConfig{

--- a/xds/internal/balancer/clusterresolver/priority_test.go
+++ b/xds/internal/balancer/clusterresolver/priority_test.go
@@ -62,8 +62,7 @@ func setupTestEDS(t *testing.T, initChild *internalserviceconfig.BalancerConfig)
 	xdsC := fakeclient.NewClientWithName(testBalancerNameFooBar)
 	cc := testutils.NewTestClientConn(t)
 	builder := balancer.Get(Name)
-	// TODO: @kylejb will fix typo for 'testEDSServcie' in another PR
-	edsb := builder.Build(cc, balancer.BuildOptions{Target: resolver.Target{URL: *testutils.MustParseURL("dns:///" + testEDSServcie)}})
+	edsb := builder.Build(cc, balancer.BuildOptions{Target: resolver.Target{URL: *testutils.MustParseURL("dns:///" + testEDSService)}})
 	if edsb == nil {
 		t.Fatalf("builder.Build(%s) failed and returned nil", Name)
 	}

--- a/xds/internal/balancer/clusterresolver/resource_resolver_test.go
+++ b/xds/internal/balancer/clusterresolver/resource_resolver_test.go
@@ -60,14 +60,14 @@ func (s) TestResourceResolverOneEDSResource(t *testing.T) {
 	}{
 		{name: "watch EDS",
 			clusterName: testClusterName,
-			edsName:     testEDSServcie,
-			wantName:    testEDSServcie,
+			edsName:     testEDSService,
+			wantName:    testEDSService,
 			edsUpdate:   testEDSUpdates[0],
 			want: []priorityConfig{{
 				mechanism: DiscoveryMechanism{
 					Type:           DiscoveryMechanismTypeEDS,
 					Cluster:        testClusterName,
-					EDSServiceName: testEDSServcie,
+					EDSServiceName: testEDSService,
 				},
 				edsResp:      testEDSUpdates[0],
 				childNameGen: newNameGenerator(0),
@@ -123,7 +123,7 @@ func (s) TestResourceResolverOneEDSResource(t *testing.T) {
 				t.Fatalf("xdsClient.CancelCDS failed with error: %v", err)
 			}
 			if edsNameCanceled != test.wantName {
-				t.Fatalf("xdsClient.CancelEDS called for %v, want: %v", edsNameCanceled, testEDSServcie)
+				t.Fatalf("xdsClient.CancelEDS called for %v, want: %v", edsNameCanceled, testEDSService)
 			}
 		})
 	}
@@ -225,7 +225,7 @@ func (s) TestResourceResolverChangeEDSName(t *testing.T) {
 	rr.updateMechanisms([]DiscoveryMechanism{{
 		Type:           DiscoveryMechanismTypeEDS,
 		Cluster:        testClusterName,
-		EDSServiceName: testEDSServcie,
+		EDSServiceName: testEDSService,
 	}})
 	ctx, ctxCancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer ctxCancel()
@@ -233,8 +233,8 @@ func (s) TestResourceResolverChangeEDSName(t *testing.T) {
 	if err != nil {
 		t.Fatalf("xdsClient.WatchCDS failed with error: %v", err)
 	}
-	if gotEDSName1 != testEDSServcie {
-		t.Fatalf("xdsClient.WatchEDS called for cluster: %v, want: %v", gotEDSName1, testEDSServcie)
+	if gotEDSName1 != testEDSService {
+		t.Fatalf("xdsClient.WatchEDS called for cluster: %v, want: %v", gotEDSName1, testEDSService)
 	}
 
 	// Invoke callback, should get an update.
@@ -245,7 +245,7 @@ func (s) TestResourceResolverChangeEDSName(t *testing.T) {
 			mechanism: DiscoveryMechanism{
 				Type:           DiscoveryMechanismTypeEDS,
 				Cluster:        testClusterName,
-				EDSServiceName: testEDSServcie,
+				EDSServiceName: testEDSService,
 			},
 			edsResp:      testEDSUpdates[0],
 			childNameGen: newNameGenerator(0),
@@ -266,7 +266,7 @@ func (s) TestResourceResolverChangeEDSName(t *testing.T) {
 		t.Fatalf("xdsClient.CancelCDS failed with error: %v", err)
 	}
 	if edsNameCanceled1 != gotEDSName1 {
-		t.Fatalf("xdsClient.CancelEDS called for %v, want: %v", edsNameCanceled1, testEDSServcie)
+		t.Fatalf("xdsClient.CancelEDS called for %v, want: %v", edsNameCanceled1, testEDSService)
 	}
 	gotEDSName2, err := fakeClient.WaitForWatchEDS(ctx)
 	if err != nil {


### PR DESCRIPTION
Addresses [this TODO comment](https://github.com/grpc/grpc-go/blob/3930549b38c0fc4cd94a95efccf7cef5f90515fd/xds/internal/balancer/clusterresolver/priority_test.go#L65) from https://github.com/grpc/grpc-go/pull/5852.

Summary of Changes

- [x] Fix spelling of variable in several test files.

RELEASE NOTES: N/A