### PR TITLE
testing: add helpers to configure cluster specifier plugin type

### DIFF
--- a/internal/testutils/xds/e2e/clientresources.go
+++ b/internal/testutils/xds/e2e/clientresources.go
@@ -26,6 +26,7 @@ import (
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	"github.com/golang/protobuf/proto"
 	"google.golang.org/grpc/internal/testutils"
+	"google.golang.org/protobuf/types/known/anypb"
 
 	v3clusterpb "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	v3corepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -307,6 +308,121 @@ func DefaultRouteConfig(routeName, ldsTarget, clusterName string) *v3routepb.Rou
 				}},
 			}},
 		}},
+	}
+}
+
+// RouteConfigClusterSpecifierType determines the cluster specifier type for the
+// route actions configured in the returned RouteConfiguration resource.
+type RouteConfigClusterSpecifierType int
+
+const (
+	// RouteConfigClusterSpecifierTypeCluster results in the cluster specifier
+	// being set to a RouteAction_Cluster.
+	RouteConfigClusterSpecifierTypeCluster RouteConfigClusterSpecifierType = iota
+	// RouteConfigClusterSpecifierTypeWeightedCluster results in the cluster
+	// specifier being set to RouteAction_WeightedClusters.
+	RouteConfigClusterSpecifierTypeWeightedCluster
+	// RouteConfigClusterSpecifierTypeClusterSpecifierPlugin results in the
+	// cluster specifier being set to a RouteAction_ClusterSpecifierPlugin.
+	RouteConfigClusterSpecifierTypeClusterSpecifierPlugin
+)
+
+// RouteConfigOptions contains options to configure a RouteConfiguration
+// resource.
+type RouteConfigOptions struct {
+	// RouteConfigName is the name of the RouteConfiguration resource.
+	RouteConfigName string
+	// ListenerName is the name of the Listener resource which uses this
+	// RouteConfiguration.
+	ListenerName string
+	// ClusterSpecifierType determines the cluster specifier plugin type.
+	ClusterSpecifierType RouteConfigClusterSpecifierType
+
+	// ClusterName is name of the cluster resource used when the cluster
+	// specifier plugin type is set to RouteConfigClusterSpecifierTypeCluster.
+	//
+	// Default value of "A" is used if left unspecified.
+	ClusterName string
+	// WeightedClusters is a map from cluster name to weights, and is used when
+	// the cluster specifier plugin type is set to
+	// RouteConfigClusterSpecifierTypeWeightedCluster.
+	//
+	// Default value of {"A": 75, "B": 25} is used if left unspecified.
+	WeightedClusters map[string]int
+	// The below two fields specify the name of the cluster specifier plugin and
+	// its configuration, and is used when the cluster specifier plugin type is
+	// set to RouteConfigClusterSpecifierTypeClusterSpecifierPlugin. Tests are
+	// expected to provide valid values for these fields when appropriate.
+	ClusterSpecifierPluginName   string
+	ClusterSpecifierPluginConfig *anypb.Any
+}
+
+// RouteConfigResourceWithOptions returns a RouteConfiguration resource
+// configured with the provided options.
+func RouteConfigResourceWithOptions(opts RouteConfigOptions) *v3routepb.RouteConfiguration {
+	switch opts.ClusterSpecifierType {
+	case RouteConfigClusterSpecifierTypeCluster:
+		clusterName := opts.ClusterName
+		if clusterName == "" {
+			clusterName = "A"
+		}
+		return &v3routepb.RouteConfiguration{
+			Name: opts.RouteConfigName,
+			VirtualHosts: []*v3routepb.VirtualHost{{
+				Domains: []string{opts.ListenerName},
+				Routes: []*v3routepb.Route{{
+					Match: &v3routepb.RouteMatch{PathSpecifier: &v3routepb.RouteMatch_Prefix{Prefix: "/"}},
+					Action: &v3routepb.Route_Route{Route: &v3routepb.RouteAction{
+						ClusterSpecifier: &v3routepb.RouteAction_Cluster{Cluster: clusterName},
+					}},
+				}},
+			}},
+		}
+	case RouteConfigClusterSpecifierTypeWeightedCluster:
+		weightedClusters := opts.WeightedClusters
+		if weightedClusters == nil {
+			weightedClusters = map[string]int{"A": 75, "B": 25}
+		}
+		clusters := []*v3routepb.WeightedCluster_ClusterWeight{}
+		for name, weight := range weightedClusters {
+			clusters = append(clusters, &v3routepb.WeightedCluster_ClusterWeight{
+				Name:   name,
+				Weight: &wrapperspb.UInt32Value{Value: uint32(weight)},
+			})
+		}
+		return &v3routepb.RouteConfiguration{
+			Name: opts.RouteConfigName,
+			VirtualHosts: []*v3routepb.VirtualHost{{
+				Domains: []string{opts.ListenerName},
+				Routes: []*v3routepb.Route{{
+					Match: &v3routepb.RouteMatch{PathSpecifier: &v3routepb.RouteMatch_Prefix{Prefix: "/"}},
+					Action: &v3routepb.Route_Route{Route: &v3routepb.RouteAction{
+						ClusterSpecifier: &v3routepb.RouteAction_WeightedClusters{WeightedClusters: &v3routepb.WeightedCluster{Clusters: clusters}},
+					}},
+				}},
+			}},
+		}
+	case RouteConfigClusterSpecifierTypeClusterSpecifierPlugin:
+		return &v3routepb.RouteConfiguration{
+			Name: opts.RouteConfigName,
+			ClusterSpecifierPlugins: []*v3routepb.ClusterSpecifierPlugin{{
+				Extension: &v3corepb.TypedExtensionConfig{
+					Name:        opts.ClusterSpecifierPluginName,
+					TypedConfig: opts.ClusterSpecifierPluginConfig,
+				}},
+			},
+			VirtualHosts: []*v3routepb.VirtualHost{{
+				Domains: []string{opts.ListenerName},
+				Routes: []*v3routepb.Route{{
+					Match: &v3routepb.RouteMatch{PathSpecifier: &v3routepb.RouteMatch_Prefix{Prefix: "/"}},
+					Action: &v3routepb.Route_Route{Route: &v3routepb.RouteAction{
+						ClusterSpecifier: &v3routepb.RouteAction_ClusterSpecifierPlugin{ClusterSpecifierPlugin: opts.ClusterSpecifierPluginName},
+					}},
+				}},
+			}},
+		}
+	default:
+		panic(fmt.Sprintf("unsupported cluster specifier plugin type: %v", opts.ClusterSpecifierType))
 	}
 }
 

--- a/internal/testutils/xds/e2e/clientresources.go
+++ b/internal/testutils/xds/e2e/clientresources.go
@@ -335,24 +335,24 @@ type RouteConfigOptions struct {
 	// ListenerName is the name of the Listener resource which uses this
 	// RouteConfiguration.
 	ListenerName string
-	// ClusterSpecifierType determines the cluster specifier plugin type.
+	// ClusterSpecifierType determines the cluster specifier type.
 	ClusterSpecifierType RouteConfigClusterSpecifierType
 
 	// ClusterName is name of the cluster resource used when the cluster
-	// specifier plugin type is set to RouteConfigClusterSpecifierTypeCluster.
+	// specifier type is set to RouteConfigClusterSpecifierTypeCluster.
 	//
 	// Default value of "A" is used if left unspecified.
 	ClusterName string
 	// WeightedClusters is a map from cluster name to weights, and is used when
-	// the cluster specifier plugin type is set to
+	// the cluster specifier type is set to
 	// RouteConfigClusterSpecifierTypeWeightedCluster.
 	//
 	// Default value of {"A": 75, "B": 25} is used if left unspecified.
 	WeightedClusters map[string]int
 	// The below two fields specify the name of the cluster specifier plugin and
-	// its configuration, and is used when the cluster specifier plugin type is
-	// set to RouteConfigClusterSpecifierTypeClusterSpecifierPlugin. Tests are
-	// expected to provide valid values for these fields when appropriate.
+	// its configuration, and are used when the cluster specifier type is set to
+	// RouteConfigClusterSpecifierTypeClusterSpecifierPlugin. Tests are expected
+	// to provide valid values for these fields when appropriate.
 	ClusterSpecifierPluginName   string
 	ClusterSpecifierPluginConfig *anypb.Any
 }

--- a/test/xds/xds_rls_clusterspecifier_plugin_test.go
+++ b/test/xds/xds_rls_clusterspecifier_plugin_test.go
@@ -33,7 +33,6 @@ import (
 	"google.golang.org/protobuf/types/known/durationpb"
 
 	v3clusterpb "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
-	v3corepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	v3endpointpb "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 	v3listenerpb "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	v3routepb "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
@@ -53,7 +52,15 @@ func defaultClientResourcesWithRLSCSP(lb e2e.LoadBalancingPolicy, params e2e.Res
 	return e2e.UpdateOptions{
 		NodeID:    params.NodeID,
 		Listeners: []*v3listenerpb.Listener{e2e.DefaultClientListener(params.DialTarget, routeConfigName)},
-		Routes:    []*v3routepb.RouteConfiguration{defaultRouteConfigWithRLSCSP(routeConfigName, params.DialTarget, rlsProto)},
+		Routes: []*v3routepb.RouteConfiguration{e2e.RouteConfigResourceWithOptions(e2e.RouteConfigOptions{
+			RouteConfigName:            routeConfigName,
+			ListenerName:               params.DialTarget,
+			ClusterSpecifierType:       e2e.RouteConfigClusterSpecifierTypeClusterSpecifierPlugin,
+			ClusterSpecifierPluginName: "rls-csp",
+			ClusterSpecifierPluginConfig: testutils.MarshalAny(&rlspb.RouteLookupClusterSpecifier{
+				RouteLookupConfig: rlsProto,
+			}),
+		})},
 		Clusters: []*v3clusterpb.Cluster{e2e.ClusterResourceWithOptions(&e2e.ClusterOptions{
 			ClusterName:   clusterName,
 			ServiceName:   endpointsName,
@@ -61,33 +68,6 @@ func defaultClientResourcesWithRLSCSP(lb e2e.LoadBalancingPolicy, params e2e.Res
 			SecurityLevel: params.SecLevel,
 		})},
 		Endpoints: []*v3endpointpb.ClusterLoadAssignment{e2e.DefaultEndpoint(endpointsName, params.Host, []uint32{params.Port})},
-	}
-}
-
-// defaultRouteConfigWithRLSCSP returns a basic xds RouteConfig resource with an
-// RLS Cluster Specifier Plugin configured as the route.
-func defaultRouteConfigWithRLSCSP(routeName, ldsTarget string, rlsProto *rlspb.RouteLookupConfig) *v3routepb.RouteConfiguration {
-	return &v3routepb.RouteConfiguration{
-		Name: routeName,
-		ClusterSpecifierPlugins: []*v3routepb.ClusterSpecifierPlugin{
-			{
-				Extension: &v3corepb.TypedExtensionConfig{
-					Name: "rls-csp",
-					TypedConfig: testutils.MarshalAny(&rlspb.RouteLookupClusterSpecifier{
-						RouteLookupConfig: rlsProto,
-					}),
-				},
-			},
-		},
-		VirtualHosts: []*v3routepb.VirtualHost{{
-			Domains: []string{ldsTarget},
-			Routes: []*v3routepb.Route{{
-				Match: &v3routepb.RouteMatch{PathSpecifier: &v3routepb.RouteMatch_Prefix{Prefix: "/"}},
-				Action: &v3routepb.Route_Route{Route: &v3routepb.RouteAction{
-					ClusterSpecifier: &v3routepb.RouteAction_ClusterSpecifierPlugin{ClusterSpecifierPlugin: "rls-csp"},
-				}},
-			}},
-		}},
 	}
 }
 

--- a/xds/internal/resolver/cluster_specifier_plugin_test.go
+++ b/xds/internal/resolver/cluster_specifier_plugin_test.go
@@ -20,190 +20,249 @@ package resolver
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"testing"
 
+	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/ptypes"
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/uuid"
 	"google.golang.org/grpc/balancer"
 	"google.golang.org/grpc/internal"
+	"google.golang.org/grpc/internal/envconfig"
 	iresolver "google.golang.org/grpc/internal/resolver"
+	"google.golang.org/grpc/internal/testutils"
+	xdsbootstrap "google.golang.org/grpc/internal/testutils/xds/bootstrap"
+	"google.golang.org/grpc/internal/testutils/xds/e2e"
 	"google.golang.org/grpc/resolver"
 	"google.golang.org/grpc/serviceconfig"
 	"google.golang.org/grpc/xds/internal/balancer/clustermanager"
 	"google.golang.org/grpc/xds/internal/clusterspecifier"
-	"google.golang.org/grpc/xds/internal/xdsclient/xdsresource"
+	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	v3listenerpb "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	v3routepb "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 )
 
 func init() {
-	balancer.Register(cspB{})
+	balancer.Register(cspBalancerBuilder{})
+	clusterspecifier.Register(testClusterSpecifierPlugin{})
 }
 
-type cspB struct{}
+// cspBalancerBuilder is a no-op LB policy which is referenced by the
+// testClusterSpecifierPlugin.
+type cspBalancerBuilder struct{}
 
-func (cspB) Build(cc balancer.ClientConn, opts balancer.BuildOptions) balancer.Balancer {
+func (cspBalancerBuilder) Build(cc balancer.ClientConn, opts balancer.BuildOptions) balancer.Balancer {
 	return nil
 }
 
-func (cspB) Name() string {
+func (cspBalancerBuilder) Name() string {
 	return "csp_experimental"
 }
 
-type cspConfig struct {
+type cspBalancerConfig struct {
+	serviceconfig.LoadBalancingConfig
 	ArbitraryField string `json:"arbitrary_field"`
 }
 
-// TestXDSResolverClusterSpecifierPlugin tests that cluster specifier plugins
-// produce the correct service config, and that the config selector routes to a
-// cluster specifier plugin supported by this service config (i.e. prefixed with
-// a cluster specifier plugin prefix).
-func (s) TestXDSResolverClusterSpecifierPlugin(t *testing.T) {
-	xdsR, xdsC, tcc, cancel := testSetup(t, setupOpts{target: target})
-	defer xdsR.Close()
-	defer cancel()
+func (cspBalancerBuilder) ParseConfig(lbCfg json.RawMessage) (serviceconfig.LoadBalancingConfig, error) {
+	cfg := &cspBalancerConfig{}
+	if err := json.Unmarshal(lbCfg, cfg); err != nil {
+		return nil, err
+	}
+	return cfg, nil
 
+}
+
+// testClusterSpecifierPlugin is a test cluster specifier plugin which returns
+// an LB policy configuration specifying the cspBalancer.
+type testClusterSpecifierPlugin struct {
+}
+
+func (testClusterSpecifierPlugin) TypeURLs() []string {
+	// The config for this plugin contains a wrapperspb.StringValue, and since
+	// we marshal that proto as an Any proto, the type URL on the latter gets
+	// set to "type.googleapis.com/google.protobuf.StringValue". If we wanted a
+	// more descriptive type URL for this test plugin, we would have to define a
+	// proto package with a message for the configuration. That would be
+	// overkill for a test. Therefore, this seems to be an acceptable tradeoff.
+	return []string{"type.googleapis.com/google.protobuf.StringValue"}
+}
+
+func (testClusterSpecifierPlugin) ParseClusterSpecifierConfig(cfg proto.Message) (clusterspecifier.BalancerConfig, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("testClusterSpecifierPlugin: nil configuration message provided")
+	}
+	any, ok := cfg.(*anypb.Any)
+	if !ok {
+		return nil, fmt.Errorf("testClusterSpecifierPlugin: error parsing config %v: unknown type %T", cfg, cfg)
+	}
+	lbCfg := new(wrapperspb.StringValue)
+	if err := ptypes.UnmarshalAny(any, lbCfg); err != nil {
+		return nil, fmt.Errorf("testClusterSpecifierPlugin: error parsing config %v: %v", cfg, err)
+	}
+	return []map[string]interface{}{{"csp_experimental": cspBalancerConfig{ArbitraryField: lbCfg.GetValue()}}}, nil
+}
+
+// TestResolverClusterSpecifierPlugin tests the case where a route configuration
+// containing cluster specifier plugins is sent by the management server. The
+// test verifies that the service config output by the resolver contains the LB
+// policy specified by the cluster specifier plugin, and the config selector
+// returns the cluster associated with the cluster specifier plugin.
+//
+// The test also verifies that a change in the cluster specifier plugin config
+// result in appropriate change in the service config pushed by the resolver.
+func (s) TestResolverClusterSpecifierPlugin(t *testing.T) {
+	// Env var GRPC_EXPERIMENTAL_XDS_RLS_LB controls whether the xDS client
+	// allows routes with cluster specifier plugin as their route action.
+	oldRLS := envconfig.XDSRLS
+	envconfig.XDSRLS = true
+	defer func() {
+		envconfig.XDSRLS = oldRLS
+	}()
+
+	mgmtServer, err := e2e.StartManagementServer(e2e.ManagementServerOptions{})
+	if err != nil {
+		t.Fatalf("Failed to start xDS management server: %v", err)
+	}
+	defer mgmtServer.Stop()
+
+	// Create a bootstrap configuration specifying the above management server.
+	nodeID := uuid.New().String()
+	cleanup, err := xdsbootstrap.CreateFile(xdsbootstrap.Options{
+		NodeID:    nodeID,
+		ServerURI: mgmtServer.Address,
+		Version:   xdsbootstrap.TransportV3,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	// Configure listener and route configuration resources on the management
+	// server.
+	const serviceName = "my-service-client-side-xds"
+	rdsName := "route-" + serviceName
+	resources := e2e.UpdateOptions{
+		NodeID:    nodeID,
+		Listeners: []*v3listenerpb.Listener{e2e.DefaultClientListener(serviceName, rdsName)},
+		Routes: []*v3routepb.RouteConfiguration{e2e.RouteConfigResourceWithOptions(e2e.RouteConfigOptions{
+			RouteConfigName:              rdsName,
+			ListenerName:                 serviceName,
+			ClusterSpecifierType:         e2e.RouteConfigClusterSpecifierTypeClusterSpecifierPlugin,
+			ClusterSpecifierPluginName:   "cspA",
+			ClusterSpecifierPluginConfig: testutils.MarshalAny(&wrapperspb.StringValue{Value: "anything"}),
+		})},
+		SkipValidation: true,
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
-	waitForWatchListener(ctx, t, xdsC, targetStr)
-	xdsC.InvokeWatchListenerCallback(xdsresource.ListenerUpdate{RouteConfigName: routeStr, HTTPFilters: routerFilterList}, nil)
+	if err := mgmtServer.Update(ctx, resources); err != nil {
+		t.Fatal(err)
+	}
 
-	waitForWatchRouteConfig(ctx, t, xdsC, routeStr)
-	xdsC.InvokeWatchRouteConfigCallback("", xdsresource.RouteConfigUpdate{
-		VirtualHosts: []*xdsresource.VirtualHost{
-			{
-				Domains: []string{targetStr},
-				Routes:  []*xdsresource.Route{{Prefix: newStringP(""), ClusterSpecifierPlugin: "cspA"}},
-			},
-		},
-		// Top level csp config here - the value of cspA should get directly
-		// placed as a child policy of xds cluster manager.
-		ClusterSpecifierPlugins: map[string]clusterspecifier.BalancerConfig{"cspA": []map[string]interface{}{{"csp_experimental": cspConfig{ArbitraryField: "anything"}}}},
-	}, nil)
+	tcc, rClose := buildResolverForTarget(t, resolver.Target{URL: *testutils.MustParseURL("xds:///" + serviceName)})
+	defer rClose()
 
-	gotState, err := tcc.stateCh.Receive(ctx)
+	// Wait for an update from the resolver, and verify the service config.
+	val, err := tcc.stateCh.Receive(ctx)
 	if err != nil {
-		t.Fatalf("Error waiting for UpdateState to be called: %v", err)
+		t.Fatalf("Timeout waiting for an update from the resolver: %v", err)
 	}
-	rState := gotState.(resolver.State)
+	rState := val.(resolver.State)
 	if err := rState.ServiceConfig.Err; err != nil {
-		t.Fatalf("ClientConn.UpdateState received error in service config: %v", rState.ServiceConfig.Err)
+		t.Fatalf("Received error in service config: %v", rState.ServiceConfig.Err)
 	}
-	wantJSON := `{"loadBalancingConfig":[{
-    "xds_cluster_manager_experimental":{
-      "children":{
-        "cluster_specifier_plugin:cspA":{
-          "childPolicy":[{"csp_experimental":{"arbitrary_field":"anything"}}]
-        }
-      }
-    }}]}`
-
-	wantSCParsed := internal.ParseServiceConfig.(func(string) *serviceconfig.ParseResult)(wantJSON)
+	wantSCParsed := internal.ParseServiceConfig.(func(string) *serviceconfig.ParseResult)(`
+{
+	"loadBalancingConfig": [
+		{
+		  "xds_cluster_manager_experimental": {
+			"children": {
+			  "cluster_specifier_plugin:cspA": {
+				"childPolicy": [
+				  {
+					"csp_experimental": {
+					  "arbitrary_field": "anything"
+					}
+				  }
+				]
+			  }
+			}
+		  }
+		}
+	  ]
+}`)
 	if !internal.EqualServiceConfigForTesting(rState.ServiceConfig.Config, wantSCParsed.Config) {
-		t.Errorf("ClientConn.UpdateState received different service config")
-		t.Error("got: ", cmp.Diff(nil, rState.ServiceConfig.Config))
-		t.Fatal("want: ", cmp.Diff(nil, wantSCParsed.Config))
+		t.Fatalf("Got service config:\n%s \nWant service config:\n%s", cmp.Diff(nil, rState.ServiceConfig.Config), cmp.Diff(nil, wantSCParsed.Config))
 	}
 
 	cs := iresolver.GetConfigSelector(rState)
 	if cs == nil {
-		t.Fatal("received nil config selector")
+		t.Fatal("Received nil config selector in update from resolver")
 	}
-
-	res, err := cs.SelectConfig(iresolver.RPCInfo{Context: context.Background()})
+	res, err := cs.SelectConfig(iresolver.RPCInfo{Context: ctx, Method: "/service/method"})
 	if err != nil {
-		t.Fatalf("Unexpected error from cs.SelectConfig(_): %v", err)
+		t.Fatalf("cs.SelectConfig(): %v", err)
 	}
 
-	cluster := clustermanager.GetPickedClusterForTesting(res.Context)
-	clusterWant := clusterSpecifierPluginPrefix + "cspA"
-	if cluster != clusterWant {
-		t.Fatalf("cluster: %+v, want: %+v", cluster, clusterWant)
+	gotCluster := clustermanager.GetPickedClusterForTesting(res.Context)
+	wantCluster := "cluster_specifier_plugin:cspA"
+	if gotCluster != wantCluster {
+		t.Fatalf("config selector returned cluster: %v, want: %v", gotCluster, wantCluster)
 	}
-}
 
-// TestXDSResolverClusterSpecifierPluginConfigUpdate tests that cluster
-// specifier plugins produce the correct service config, and that on an update
-// to the CSP Configuration, the new config is accounted for in the output
-// service config.
-func (s) TestXDSResolverClusterSpecifierPluginConfigUpdate(t *testing.T) {
-	xdsR, xdsC, tcc, cancel := testSetup(t, setupOpts{target: target})
-	defer xdsR.Close()
-	defer cancel()
+	// Change the cluster specifier plugin configuration.
+	resources = e2e.UpdateOptions{
+		NodeID:    nodeID,
+		Listeners: []*v3listenerpb.Listener{e2e.DefaultClientListener(serviceName, rdsName)},
+		Routes: []*v3routepb.RouteConfiguration{e2e.RouteConfigResourceWithOptions(e2e.RouteConfigOptions{
+			RouteConfigName:              rdsName,
+			ListenerName:                 serviceName,
+			ClusterSpecifierType:         e2e.RouteConfigClusterSpecifierTypeClusterSpecifierPlugin,
+			ClusterSpecifierPluginName:   "cspA",
+			ClusterSpecifierPluginConfig: testutils.MarshalAny(&wrapperspb.StringValue{Value: "changed"}),
+		})},
+		SkipValidation: true,
+	}
+	if err := mgmtServer.Update(ctx, resources); err != nil {
+		t.Fatal(err)
+	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
-	defer cancel()
-	waitForWatchListener(ctx, t, xdsC, targetStr)
-	xdsC.InvokeWatchListenerCallback(xdsresource.ListenerUpdate{RouteConfigName: routeStr, HTTPFilters: routerFilterList}, nil)
-
-	waitForWatchRouteConfig(ctx, t, xdsC, routeStr)
-	xdsC.InvokeWatchRouteConfigCallback("", xdsresource.RouteConfigUpdate{
-		VirtualHosts: []*xdsresource.VirtualHost{
-			{
-				Domains: []string{targetStr},
-				Routes:  []*xdsresource.Route{{Prefix: newStringP(""), ClusterSpecifierPlugin: "cspA"}},
-			},
-		},
-		// Top level csp config here - the value of cspA should get directly
-		// placed as a child policy of xds cluster manager.
-		ClusterSpecifierPlugins: map[string]clusterspecifier.BalancerConfig{"cspA": []map[string]interface{}{{"csp_experimental": cspConfig{ArbitraryField: "anything"}}}},
-	}, nil)
-
-	gotState, err := tcc.stateCh.Receive(ctx)
+	// Wait for an update from the resolver, and verify the service config.
+	val, err = tcc.stateCh.Receive(ctx)
 	if err != nil {
-		t.Fatalf("Error waiting for UpdateState to be called: %v", err)
+		t.Fatalf("Timeout waiting for an update from the resolver: %v", err)
 	}
-	rState := gotState.(resolver.State)
+	rState = val.(resolver.State)
 	if err := rState.ServiceConfig.Err; err != nil {
-		t.Fatalf("ClientConn.UpdateState received error in service config: %v", rState.ServiceConfig.Err)
+		t.Fatalf("Received error in service config: %v", rState.ServiceConfig.Err)
 	}
-	wantJSON := `{"loadBalancingConfig":[{
-    "xds_cluster_manager_experimental":{
-      "children":{
-        "cluster_specifier_plugin:cspA":{
-          "childPolicy":[{"csp_experimental":{"arbitrary_field":"anything"}}]
-        }
-      }
-    }}]}`
-
-	wantSCParsed := internal.ParseServiceConfig.(func(string) *serviceconfig.ParseResult)(wantJSON)
+	wantSCParsed = internal.ParseServiceConfig.(func(string) *serviceconfig.ParseResult)(`
+{
+	"loadBalancingConfig": [
+		{
+		  "xds_cluster_manager_experimental": {
+			"children": {
+			  "cluster_specifier_plugin:cspA": {
+				"childPolicy": [
+				  {
+					"csp_experimental": {
+					  "arbitrary_field": "changed"
+					}
+				  }
+				]
+			  }
+			}
+		  }
+		}
+	  ]
+}`)
 	if !internal.EqualServiceConfigForTesting(rState.ServiceConfig.Config, wantSCParsed.Config) {
-		t.Errorf("ClientConn.UpdateState received different service config")
-		t.Error("got: ", cmp.Diff(nil, rState.ServiceConfig.Config))
-		t.Fatal("want: ", cmp.Diff(nil, wantSCParsed.Config))
-	}
-
-	xdsC.InvokeWatchRouteConfigCallback("", xdsresource.RouteConfigUpdate{
-		VirtualHosts: []*xdsresource.VirtualHost{
-			{
-				Domains: []string{targetStr},
-				Routes:  []*xdsresource.Route{{Prefix: newStringP(""), ClusterSpecifierPlugin: "cspA"}},
-			},
-		},
-		// Top level csp config here - the value of cspA should get directly
-		// placed as a child policy of xds cluster manager.
-		ClusterSpecifierPlugins: map[string]clusterspecifier.BalancerConfig{"cspA": []map[string]interface{}{{"csp_experimental": cspConfig{ArbitraryField: "changed"}}}},
-	}, nil)
-
-	gotState, err = tcc.stateCh.Receive(ctx)
-	if err != nil {
-		t.Fatalf("Error waiting for UpdateState to be called: %v", err)
-	}
-	rState = gotState.(resolver.State)
-	if err := rState.ServiceConfig.Err; err != nil {
-		t.Fatalf("ClientConn.UpdateState received error in service config: %v", rState.ServiceConfig.Err)
-	}
-	wantJSON = `{"loadBalancingConfig":[{
-    "xds_cluster_manager_experimental":{
-      "children":{
-        "cluster_specifier_plugin:cspA":{
-          "childPolicy":[{"csp_experimental":{"arbitrary_field":"changed"}}]
-        }
-      }
-    }}]}`
-
-	wantSCParsed = internal.ParseServiceConfig.(func(string) *serviceconfig.ParseResult)(wantJSON)
-	if !internal.EqualServiceConfigForTesting(rState.ServiceConfig.Config, wantSCParsed.Config) {
-		t.Errorf("ClientConn.UpdateState received different service config")
-		t.Error("got: ", cmp.Diff(nil, rState.ServiceConfig.Config))
-		t.Fatal("want: ", cmp.Diff(nil, wantSCParsed.Config))
+		t.Fatalf("Got service config:\n%s \nWant service config:\n%s", cmp.Diff(nil, rState.ServiceConfig.Config), cmp.Diff(nil, wantSCParsed.Config))
 	}
 }
 
@@ -211,158 +270,216 @@ func (s) TestXDSResolverClusterSpecifierPluginConfigUpdate(t *testing.T) {
 // their corresponding configurations remain in service config if RPCs are in
 // flight.
 func (s) TestXDSResolverDelayedOnCommittedCSP(t *testing.T) {
-	xdsR, xdsC, tcc, cancel := testSetup(t, setupOpts{target: target})
-	defer xdsR.Close()
-	defer cancel()
+	// Env var GRPC_EXPERIMENTAL_XDS_RLS_LB controls whether the xDS client
+	// allows routes with cluster specifier plugin as their route action.
+	oldRLS := envconfig.XDSRLS
+	envconfig.XDSRLS = true
+	defer func() {
+		envconfig.XDSRLS = oldRLS
+	}()
 
+	mgmtServer, err := e2e.StartManagementServer(e2e.ManagementServerOptions{})
+	if err != nil {
+		t.Fatalf("Failed to start xDS management server: %v", err)
+	}
+	defer mgmtServer.Stop()
+
+	// Create a bootstrap configuration specifying the above management server.
+	nodeID := uuid.New().String()
+	cleanup, err := xdsbootstrap.CreateFile(xdsbootstrap.Options{
+		NodeID:    nodeID,
+		ServerURI: mgmtServer.Address,
+		Version:   xdsbootstrap.TransportV3,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	// Configure listener and route configuration resources on the management
+	// server.
+	const serviceName = "my-service-client-side-xds"
+	rdsName := "route-" + serviceName
+	resources := e2e.UpdateOptions{
+		NodeID:    nodeID,
+		Listeners: []*v3listenerpb.Listener{e2e.DefaultClientListener(serviceName, rdsName)},
+		Routes: []*v3routepb.RouteConfiguration{e2e.RouteConfigResourceWithOptions(e2e.RouteConfigOptions{
+			RouteConfigName:              rdsName,
+			ListenerName:                 serviceName,
+			ClusterSpecifierType:         e2e.RouteConfigClusterSpecifierTypeClusterSpecifierPlugin,
+			ClusterSpecifierPluginName:   "cspA",
+			ClusterSpecifierPluginConfig: testutils.MarshalAny(&wrapperspb.StringValue{Value: "anythingA"}),
+		})},
+		SkipValidation: true,
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
-	waitForWatchListener(ctx, t, xdsC, targetStr)
-	xdsC.InvokeWatchListenerCallback(xdsresource.ListenerUpdate{RouteConfigName: routeStr, HTTPFilters: routerFilterList}, nil)
-	waitForWatchRouteConfig(ctx, t, xdsC, routeStr)
+	if err := mgmtServer.Update(ctx, resources); err != nil {
+		t.Fatal(err)
+	}
 
-	xdsC.InvokeWatchRouteConfigCallback("", xdsresource.RouteConfigUpdate{
-		VirtualHosts: []*xdsresource.VirtualHost{
-			{
-				Domains: []string{targetStr},
-				Routes:  []*xdsresource.Route{{Prefix: newStringP(""), ClusterSpecifierPlugin: "cspA"}},
-			},
-		},
-		// Top level csp config here - the value of cspA should get directly
-		// placed as a child policy of xds cluster manager.
-		ClusterSpecifierPlugins: map[string]clusterspecifier.BalancerConfig{"cspA": []map[string]interface{}{{"csp_experimental": cspConfig{ArbitraryField: "anythingA"}}}},
-	}, nil)
+	tcc, rClose := buildResolverForTarget(t, resolver.Target{URL: *testutils.MustParseURL("xds:///" + serviceName)})
+	defer rClose()
 
-	gotState, err := tcc.stateCh.Receive(ctx)
+	// Wait for an update from the resolver, and verify the service config.
+	val, err := tcc.stateCh.Receive(ctx)
 	if err != nil {
-		t.Fatalf("Error waiting for UpdateState to be called: %v", err)
+		t.Fatalf("Timeout waiting for an update from the resolver: %v", err)
 	}
-	rState := gotState.(resolver.State)
+	rState := val.(resolver.State)
 	if err := rState.ServiceConfig.Err; err != nil {
-		t.Fatalf("ClientConn.UpdateState received error in service config: %v", rState.ServiceConfig.Err)
+		t.Fatalf("Received error in service config: %v", rState.ServiceConfig.Err)
 	}
-	wantJSON := `{"loadBalancingConfig":[{
-    "xds_cluster_manager_experimental":{
-      "children":{
-        "cluster_specifier_plugin:cspA":{
-          "childPolicy":[{"csp_experimental":{"arbitrary_field":"anythingA"}}]
-        }
-      }
-    }}]}`
-
-	wantSCParsed := internal.ParseServiceConfig.(func(string) *serviceconfig.ParseResult)(wantJSON)
+	wantSCParsed := internal.ParseServiceConfig.(func(string) *serviceconfig.ParseResult)(`
+{
+	"loadBalancingConfig": [
+		{
+		  "xds_cluster_manager_experimental": {
+			"children": {
+			  "cluster_specifier_plugin:cspA": {
+				"childPolicy": [
+				  {
+					"csp_experimental": {
+					  "arbitrary_field": "anythingA"
+					}
+				  }
+				]
+			  }
+			}
+		  }
+		}
+	  ]
+}`)
 	if !internal.EqualServiceConfigForTesting(rState.ServiceConfig.Config, wantSCParsed.Config) {
-		t.Errorf("ClientConn.UpdateState received different service config")
-		t.Error("got: ", cmp.Diff(nil, rState.ServiceConfig.Config))
-		t.Fatal("want: ", cmp.Diff(nil, wantSCParsed.Config))
+		t.Fatalf("Got service config:\n%s \nWant service config:\n%s", cmp.Diff(nil, rState.ServiceConfig.Config), cmp.Diff(nil, wantSCParsed.Config))
 	}
 
 	cs := iresolver.GetConfigSelector(rState)
 	if cs == nil {
-		t.Fatal("received nil config selector")
+		t.Fatal("Received nil config selector in update from resolver")
 	}
-
-	res, err := cs.SelectConfig(iresolver.RPCInfo{Context: context.Background()})
+	resOld, err := cs.SelectConfig(iresolver.RPCInfo{Context: ctx, Method: "/service/method"})
 	if err != nil {
-		t.Fatalf("Unexpected error from cs.SelectConfig(_): %v", err)
+		t.Fatalf("cs.SelectConfig(): %v", err)
 	}
 
-	cluster := clustermanager.GetPickedClusterForTesting(res.Context)
-	clusterWant := clusterSpecifierPluginPrefix + "cspA"
-	if cluster != clusterWant {
-		t.Fatalf("cluster: %+v, want: %+v", cluster, clusterWant)
+	gotCluster := clustermanager.GetPickedClusterForTesting(resOld.Context)
+	wantCluster := "cluster_specifier_plugin:cspA"
+	if gotCluster != wantCluster {
+		t.Fatalf("config selector returned cluster: %v, want: %v", gotCluster, wantCluster)
 	}
-	// delay res.OnCommitted()
 
-	// Perform TWO updates to ensure the old config selector does not hold a reference to cspA
-	xdsC.InvokeWatchRouteConfigCallback("", xdsresource.RouteConfigUpdate{
-		VirtualHosts: []*xdsresource.VirtualHost{
-			{
-				Domains: []string{targetStr},
-				Routes:  []*xdsresource.Route{{Prefix: newStringP(""), ClusterSpecifierPlugin: "cspB"}},
-			},
-		},
-		// Top level csp config here - the value of cspB should get directly
-		// placed as a child policy of xds cluster manager.
-		ClusterSpecifierPlugins: map[string]clusterspecifier.BalancerConfig{"cspB": []map[string]interface{}{{"csp_experimental": cspConfig{ArbitraryField: "anythingB"}}}},
-	}, nil)
-	tcc.stateCh.Receive(ctx) // Ignore the first update.
+	// Delay resOld.OnCommitted(). As long as there are pending RPCs to removed
+	// clusters, they still appear in the service config.
 
-	xdsC.InvokeWatchRouteConfigCallback("", xdsresource.RouteConfigUpdate{
-		VirtualHosts: []*xdsresource.VirtualHost{
-			{
-				Domains: []string{targetStr},
-				Routes:  []*xdsresource.Route{{Prefix: newStringP(""), ClusterSpecifierPlugin: "cspB"}},
-			},
-		},
-		// Top level csp config here - the value of cspB should get directly
-		// placed as a child policy of xds cluster manager.
-		ClusterSpecifierPlugins: map[string]clusterspecifier.BalancerConfig{"cspB": []map[string]interface{}{{"csp_experimental": cspConfig{ArbitraryField: "anythingB"}}}},
-	}, nil)
+	// Change the cluster specifier plugin configuration.
+	resources = e2e.UpdateOptions{
+		NodeID:    nodeID,
+		Listeners: []*v3listenerpb.Listener{e2e.DefaultClientListener(serviceName, rdsName)},
+		Routes: []*v3routepb.RouteConfiguration{e2e.RouteConfigResourceWithOptions(e2e.RouteConfigOptions{
+			RouteConfigName:              rdsName,
+			ListenerName:                 serviceName,
+			ClusterSpecifierType:         e2e.RouteConfigClusterSpecifierTypeClusterSpecifierPlugin,
+			ClusterSpecifierPluginName:   "cspB",
+			ClusterSpecifierPluginConfig: testutils.MarshalAny(&wrapperspb.StringValue{Value: "anythingB"}),
+		})},
+		SkipValidation: true,
+	}
+	if err := mgmtServer.Update(ctx, resources); err != nil {
+		t.Fatal(err)
+	}
 
-	gotState, err = tcc.stateCh.Receive(ctx)
+	// Wait for an update from the resolver, and verify the service config.
+	val, err = tcc.stateCh.Receive(ctx)
 	if err != nil {
-		t.Fatalf("Error waiting for UpdateState to be called: %v", err)
+		t.Fatalf("Timeout waiting for an update from the resolver: %v", err)
 	}
-	rState = gotState.(resolver.State)
+	rState = val.(resolver.State)
 	if err := rState.ServiceConfig.Err; err != nil {
-		t.Fatalf("ClientConn.UpdateState received error in service config: %v", rState.ServiceConfig.Err)
+		t.Fatalf("Received error in service config: %v", rState.ServiceConfig.Err)
 	}
-	wantJSON2 := `{"loadBalancingConfig":[{
-    "xds_cluster_manager_experimental":{
-      "children":{
-        "cluster_specifier_plugin:cspA":{
-          "childPolicy":[{"csp_experimental":{"arbitrary_field":"anythingA"}}]
-        },
-        "cluster_specifier_plugin:cspB":{
-          "childPolicy":[{"csp_experimental":{"arbitrary_field":"anythingB"}}]
-        }
-      }
-    }}]}`
-
-	wantSCParsed2 := internal.ParseServiceConfig.(func(string) *serviceconfig.ParseResult)(wantJSON2)
-	if !internal.EqualServiceConfigForTesting(rState.ServiceConfig.Config, wantSCParsed2.Config) {
-		t.Errorf("ClientConn.UpdateState received different service config")
-		t.Error("got: ", cmp.Diff(nil, rState.ServiceConfig.Config))
-		t.Fatal("want: ", cmp.Diff(nil, wantSCParsed2.Config))
+	wantSCParsed = internal.ParseServiceConfig.(func(string) *serviceconfig.ParseResult)(`
+{
+	"loadBalancingConfig": [
+		{
+		  "xds_cluster_manager_experimental": {
+			"children": {
+			  "cluster_specifier_plugin:cspA": {
+				"childPolicy": [
+				  {
+					"csp_experimental": {
+					  "arbitrary_field": "anythingA"
+					}
+				  }
+				]
+			  },
+			  "cluster_specifier_plugin:cspB": {
+				"childPolicy": [
+				  {
+					"csp_experimental": {
+					  "arbitrary_field": "anythingB"
+					}
+				  }
+				]
+			  }
+			}
+		  }
+		}
+	  ]
+}`)
+	if !internal.EqualServiceConfigForTesting(rState.ServiceConfig.Config, wantSCParsed.Config) {
+		t.Fatalf("Got service config:\n%s \nWant service config:\n%s", cmp.Diff(nil, rState.ServiceConfig.Config), cmp.Diff(nil, wantSCParsed.Config))
 	}
 
-	// Invoke OnCommitted; should lead to a service config update that deletes
+	// Perform an RPC and ensure that it is routed to the new cluster.
+	cs = iresolver.GetConfigSelector(rState)
+	if cs == nil {
+		t.Fatal("Received nil config selector in update from resolver")
+	}
+	resNew, err := cs.SelectConfig(iresolver.RPCInfo{Context: ctx, Method: "/service/method"})
+	if err != nil {
+		t.Fatalf("cs.SelectConfig(): %v", err)
+	}
+
+	gotCluster = clustermanager.GetPickedClusterForTesting(resNew.Context)
+	wantCluster = "cluster_specifier_plugin:cspB"
+	if gotCluster != wantCluster {
+		t.Fatalf("config selector returned cluster: %v, want: %v", gotCluster, wantCluster)
+	}
+
+	// Invoke resOld.OnCommitted; should lead to a service config update that deletes
 	// cspA.
-	res.OnCommitted()
+	resOld.OnCommitted()
 
-	xdsC.InvokeWatchRouteConfigCallback("", xdsresource.RouteConfigUpdate{
-		VirtualHosts: []*xdsresource.VirtualHost{
-			{
-				Domains: []string{targetStr},
-				Routes:  []*xdsresource.Route{{Prefix: newStringP(""), ClusterSpecifierPlugin: "cspB"}},
-			},
-		},
-		// Top level csp config here - the value of cspB should get directly
-		// placed as a child policy of xds cluster manager.
-		ClusterSpecifierPlugins: map[string]clusterspecifier.BalancerConfig{"cspB": []map[string]interface{}{{"csp_experimental": cspConfig{ArbitraryField: "anythingB"}}}},
-	}, nil)
-	gotState, err = tcc.stateCh.Receive(ctx)
+	val, err = tcc.stateCh.Receive(ctx)
 	if err != nil {
-		t.Fatalf("Error waiting for UpdateState to be called: %v", err)
+		t.Fatalf("Timeout waiting for an update from the resolver: %v", err)
 	}
-	rState = gotState.(resolver.State)
+	rState = val.(resolver.State)
 	if err := rState.ServiceConfig.Err; err != nil {
-		t.Fatalf("ClientConn.UpdateState received error in service config: %v", rState.ServiceConfig.Err)
+		t.Fatalf("Received error in service config: %v", rState.ServiceConfig.Err)
 	}
-	wantJSON3 := `{"loadBalancingConfig":[{
-    "xds_cluster_manager_experimental":{
-      "children":{
-        "cluster_specifier_plugin:cspB":{
-          "childPolicy":[{"csp_experimental":{"arbitrary_field":"anythingB"}}]
-        }
-      }
-    }}]}`
-
-	wantSCParsed3 := internal.ParseServiceConfig.(func(string) *serviceconfig.ParseResult)(wantJSON3)
-	if !internal.EqualServiceConfigForTesting(rState.ServiceConfig.Config, wantSCParsed3.Config) {
-		t.Errorf("ClientConn.UpdateState received different service config")
-		t.Error("got: ", cmp.Diff(nil, rState.ServiceConfig.Config))
-		t.Fatal("want: ", cmp.Diff(nil, wantSCParsed3.Config))
+	wantSCParsed = internal.ParseServiceConfig.(func(string) *serviceconfig.ParseResult)(`
+{
+	"loadBalancingConfig": [
+		{
+		  "xds_cluster_manager_experimental": {
+			"children": {
+			  "cluster_specifier_plugin:cspB": {
+				"childPolicy": [
+				  {
+					"csp_experimental": {
+					  "arbitrary_field": "anythingB"
+					}
+				  }
+				]
+			  }
+			}
+		  }
+		}
+	  ]
+}`)
+	if !internal.EqualServiceConfigForTesting(rState.ServiceConfig.Config, wantSCParsed.Config) {
+		t.Fatalf("Got service config:\n%s \nWant service config:\n%s", cmp.Diff(nil, rState.ServiceConfig.Config), cmp.Diff(nil, wantSCParsed.Config))
 	}
 }

--- a/xds/internal/resolver/cluster_specifier_plugin_test.go
+++ b/xds/internal/resolver/cluster_specifier_plugin_test.go
@@ -135,7 +135,6 @@ func (s) TestResolverClusterSpecifierPlugin(t *testing.T) {
 	cleanup, err := xdsbootstrap.CreateFile(xdsbootstrap.Options{
 		NodeID:    nodeID,
 		ServerURI: mgmtServer.Address,
-		Version:   xdsbootstrap.TransportV3,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -289,7 +288,6 @@ func (s) TestXDSResolverDelayedOnCommittedCSP(t *testing.T) {
 	cleanup, err := xdsbootstrap.CreateFile(xdsbootstrap.Options{
 		NodeID:    nodeID,
 		ServerURI: mgmtServer.Address,
-		Version:   xdsbootstrap.TransportV3,
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/xds/internal/resolver/cluster_specifier_plugin_test.go
+++ b/xds/internal/resolver/cluster_specifier_plugin_test.go
@@ -98,7 +98,7 @@ func (testClusterSpecifierPlugin) ParseClusterSpecifierConfig(cfg proto.Message)
 	}
 	any, ok := cfg.(*anypb.Any)
 	if !ok {
-		return nil, fmt.Errorf("testClusterSpecifierPlugin: error parsing config %v: unknown type %T", cfg, cfg)
+		return nil, fmt.Errorf("testClusterSpecifierPlugin: error parsing config %v: got type %T, want *anypb.Any", cfg, cfg)
 	}
 	lbCfg := new(wrapperspb.StringValue)
 	if err := ptypes.UnmarshalAny(any, lbCfg); err != nil {

--- a/xds/internal/resolver/xds_resolver_test.go
+++ b/xds/internal/resolver/xds_resolver_test.go
@@ -108,11 +108,17 @@ type testClientConn struct {
 }
 
 func (t *testClientConn) UpdateState(s resolver.State) error {
-	t.stateCh.Replace(s)
+	// Tests should ideally consume all state updates, and if one happens
+	// unexpectedly, tests should catch it. Hence using `Send()` here.
+	t.stateCh.Send(s)
 	return nil
 }
 
 func (t *testClientConn) ReportError(err error) {
+	// When used with a go-control-plane management server that continuously
+	// resends resources which are NACKed by the xDS client, using a `Replace()`
+	// here simplifies tests which will have access to the most recently
+	// received error.
 	t.errorCh.Replace(err)
 }
 

--- a/xds/internal/resolver/xds_resolver_test.go
+++ b/xds/internal/resolver/xds_resolver_test.go
@@ -708,25 +708,12 @@ func (s) TestResolverGoodServiceUpdate(t *testing.T) {
 	}{
 		{
 			// A route configuration with a single cluster.
-			routeConfig: &v3routepb.RouteConfiguration{
-				Name: rdsName,
-				VirtualHosts: []*v3routepb.VirtualHost{{
-					Domains: []string{ldsName},
-					Routes: []*v3routepb.Route{{
-						Match: &v3routepb.RouteMatch{PathSpecifier: &v3routepb.RouteMatch_Prefix{Prefix: "/"}},
-						Action: &v3routepb.Route_Route{Route: &v3routepb.RouteAction{
-							ClusterSpecifier: &v3routepb.RouteAction_WeightedClusters{WeightedClusters: &v3routepb.WeightedCluster{
-								Clusters: []*v3routepb.WeightedCluster_ClusterWeight{
-									{
-										Name:   "test-cluster-1",
-										Weight: &wrapperspb.UInt32Value{Value: 100},
-									},
-								},
-							}},
-						}},
-					}},
-				}},
-			},
+			routeConfig: e2e.RouteConfigResourceWithOptions(e2e.RouteConfigOptions{
+				RouteConfigName:      rdsName,
+				ListenerName:         ldsName,
+				ClusterSpecifierType: e2e.RouteConfigClusterSpecifierTypeCluster,
+				ClusterName:          "test-cluster-1",
+			}),
 			wantServiceConfig: `
 {
   "loadBalancingConfig": [{
@@ -747,29 +734,12 @@ func (s) TestResolverGoodServiceUpdate(t *testing.T) {
 		},
 		{
 			// A route configuration with a two new clusters.
-			routeConfig: &v3routepb.RouteConfiguration{
-				Name: rdsName,
-				VirtualHosts: []*v3routepb.VirtualHost{{
-					Domains: []string{ldsName},
-					Routes: []*v3routepb.Route{{
-						Match: &v3routepb.RouteMatch{PathSpecifier: &v3routepb.RouteMatch_Prefix{Prefix: "/"}},
-						Action: &v3routepb.Route_Route{Route: &v3routepb.RouteAction{
-							ClusterSpecifier: &v3routepb.RouteAction_WeightedClusters{WeightedClusters: &v3routepb.WeightedCluster{
-								Clusters: []*v3routepb.WeightedCluster_ClusterWeight{
-									{
-										Name:   "cluster_1",
-										Weight: &wrapperspb.UInt32Value{Value: 75},
-									},
-									{
-										Name:   "cluster_2",
-										Weight: &wrapperspb.UInt32Value{Value: 25},
-									},
-								},
-							}},
-						}},
-					}},
-				}},
-			},
+			routeConfig: e2e.RouteConfigResourceWithOptions(e2e.RouteConfigOptions{
+				RouteConfigName:      rdsName,
+				ListenerName:         ldsName,
+				ClusterSpecifierType: e2e.RouteConfigClusterSpecifierTypeWeightedCluster,
+				WeightedClusters:     map[string]int{"cluster_1": 75, "cluster_2": 25},
+			}),
 			// This update contains the cluster from the previous update as well
 			// as this update, as the previous config selector still references
 			// the old cluster when the new one is pushed.
@@ -805,62 +775,7 @@ func (s) TestResolverGoodServiceUpdate(t *testing.T) {
 }`,
 			wantClusters: map[string]bool{"cluster:cluster_1": true, "cluster:cluster_2": true},
 		},
-		{
-			// A redundant route configuration update.
-			// TODO(easwars): Do we need this, or can we do something else? Because the xds client might swallow this update.
-			routeConfig: &v3routepb.RouteConfiguration{
-				Name: rdsName,
-				VirtualHosts: []*v3routepb.VirtualHost{{
-					Domains: []string{ldsName},
-					Routes: []*v3routepb.Route{{
-						Match: &v3routepb.RouteMatch{PathSpecifier: &v3routepb.RouteMatch_Prefix{Prefix: "/"}},
-						Action: &v3routepb.Route_Route{Route: &v3routepb.RouteAction{
-							ClusterSpecifier: &v3routepb.RouteAction_WeightedClusters{WeightedClusters: &v3routepb.WeightedCluster{
-								Clusters: []*v3routepb.WeightedCluster_ClusterWeight{
-									{
-										Name:   "cluster_1",
-										Weight: &wrapperspb.UInt32Value{Value: 75},
-									},
-									{
-										Name:   "cluster_2",
-										Weight: &wrapperspb.UInt32Value{Value: 25},
-									},
-								},
-							}},
-						}},
-					}},
-				}},
-			},
-			// With this redundant update, the old config selector has been
-			// stopped, so there are no more references to the first cluster.
-			// Only the second update's clusters should remain.
-			wantServiceConfig: `
-{
-  "loadBalancingConfig": [{
-    "xds_cluster_manager_experimental": {
-      "children": {
-        "cluster:cluster_1": {
-          "childPolicy": [{
-			"cds_experimental": {
-			  "cluster": "cluster_1"
-			}
-		  }]
-        },
-        "cluster:cluster_2": {
-          "childPolicy": [{
-			"cds_experimental": {
-			  "cluster": "cluster_2"
-			}
-		  }]
-        }
-      }
-    }
-  }]
-}`,
-			wantClusters: map[string]bool{"cluster:cluster_1": true, "cluster:cluster_2": true},
-		},
 	} {
-
 		// Configure the management server with a good listener resource and a
 		// route configuration resource, as specified by the test case.
 		resources := e2e.UpdateOptions{
@@ -887,9 +802,7 @@ func (s) TestResolverGoodServiceUpdate(t *testing.T) {
 
 		wantSCParsed := internal.ParseServiceConfig.(func(string) *serviceconfig.ParseResult)(tt.wantServiceConfig)
 		if !internal.EqualServiceConfigForTesting(rState.ServiceConfig.Config, wantSCParsed.Config) {
-			t.Errorf("Received unexpected service config")
-			t.Error("got: ", cmp.Diff(nil, rState.ServiceConfig.Config))
-			t.Fatal("want: ", cmp.Diff(nil, wantSCParsed.Config))
+			t.Fatalf("Got service config:\n%s \nWant service config:\n%s", cmp.Diff(nil, rState.ServiceConfig.Config), cmp.Diff(nil, wantSCParsed.Config))
 		}
 
 		cs := iresolver.GetConfigSelector(rState)
@@ -1322,29 +1235,12 @@ func (s) TestResolverWRR(t *testing.T) {
 	resources := e2e.UpdateOptions{
 		NodeID:    nodeID,
 		Listeners: []*v3listenerpb.Listener{e2e.DefaultClientListener(ldsName, rdsName)},
-		Routes: []*v3routepb.RouteConfiguration{{
-			Name: rdsName,
-			VirtualHosts: []*v3routepb.VirtualHost{{
-				Domains: []string{ldsName},
-				Routes: []*v3routepb.Route{{
-					Match: &v3routepb.RouteMatch{PathSpecifier: &v3routepb.RouteMatch_Prefix{Prefix: "/"}},
-					Action: &v3routepb.Route_Route{Route: &v3routepb.RouteAction{
-						ClusterSpecifier: &v3routepb.RouteAction_WeightedClusters{WeightedClusters: &v3routepb.WeightedCluster{
-							Clusters: []*v3routepb.WeightedCluster_ClusterWeight{
-								{
-									Name:   "A",
-									Weight: &wrapperspb.UInt32Value{Value: 75},
-								},
-								{
-									Name:   "B",
-									Weight: &wrapperspb.UInt32Value{Value: 25},
-								},
-							},
-						}},
-					}},
-				}},
-			}},
-		}},
+		Routes: []*v3routepb.RouteConfiguration{e2e.RouteConfigResourceWithOptions(e2e.RouteConfigOptions{
+			RouteConfigName:      rdsName,
+			ListenerName:         ldsName,
+			ClusterSpecifierType: e2e.RouteConfigClusterSpecifierTypeWeightedCluster,
+			WeightedClusters:     map[string]int{"A": 75, "B": 25},
+		})},
 		SkipValidation: true,
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)

--- a/xds/internal/resolver/xds_resolver_test.go
+++ b/xds/internal/resolver/xds_resolver_test.go
@@ -82,7 +82,6 @@ const (
 var target = resolver.Target{URL: *testutils.MustParseURL("xds:///" + targetStr)}
 
 var routerFilter = xdsresource.HTTPFilter{Name: "rtr", Filter: httpfilter.Get(router.TypeURL)}
-var routerFilterList = []xdsresource.HTTPFilter{routerFilter}
 
 type s struct {
 	grpctest.Tester


### PR DESCRIPTION
Summary of changes:
- Make it possible to configure the cluster specifier type in RouteConfiguration resources created by the `e2e` package. This is in the same style of how Cluster resources are configurable currently.
- Change test in `test/xds/xds_rls_clusterspecifier_plugin_test.go` to use the new helpers.
- Change tests in `xds/internal/resolver/cluster_specifier_plugin_test.go` to use the new helpers and thereby use a real management server and a real xDS client instead of fake ones.
  - Also merge tests `TestXDSResolverClusterSpecifierPlugin` and `TestXDSResolverClusterSpecifierPluginConfigUpdate` into one, as the latter performs all steps in the former followed by an additional step.
- Change tests in `xds/internal/resolver/xds_resolver_test.go` to use the new helpers where possible.

RELEASE NOTES: none