### PR TITLE
Add disable global dial option

### DIFF
--- a/clientconn.go
+++ b/clientconn.go
@@ -146,12 +146,14 @@ func DialContext(ctx context.Context, target string, opts ...DialOption) (conn *
 	cc.safeConfigSelector.UpdateConfigSelector(&defaultConfigSelector{nil})
 	cc.ctx, cc.cancel = context.WithCancel(context.Background())
 
-	for _, opt := range extraDialOptions {
+	for _, opt := range opts {
 		opt.apply(&cc.dopts)
 	}
 
-	for _, opt := range opts {
-		opt.apply(&cc.dopts)
+	if !cc.dopts.disableGlobalOptions {
+		for _, opt := range globalDialOptions {
+			opt.apply(&cc.dopts)
+		}
 	}
 
 	chainUnaryClientInterceptors(cc)

--- a/dialoptions.go
+++ b/dialoptions.go
@@ -38,13 +38,14 @@ import (
 
 func init() {
 	internal.AddGlobalDialOptions = func(opt ...DialOption) {
-		extraDialOptions = append(extraDialOptions, opt...)
+		globalDialOptions = append(globalDialOptions, opt...)
 	}
 	internal.ClearGlobalDialOptions = func() {
-		extraDialOptions = nil
+		globalDialOptions = nil
 	}
 	internal.WithBinaryLogger = withBinaryLogger
 	internal.JoinDialOptions = newJoinDialOption
+	internal.WithDisableGlobalOptions = withDisableGlobalOptions
 }
 
 // dialOptions configure a Dial call. dialOptions are set by the DialOption
@@ -68,6 +69,7 @@ type dialOptions struct {
 	copts                       transport.ConnectOptions
 	callOptions                 []CallOption
 	channelzParentID            *channelz.Identifier
+	disableGlobalOptions        bool
 	disableServiceConfig        bool
 	disableRetry                bool
 	disableHealthCheck          bool
@@ -83,7 +85,7 @@ type DialOption interface {
 	apply(*dialOptions)
 }
 
-var extraDialOptions []DialOption
+var globalDialOptions []DialOption
 
 // EmptyDialOption does not alter the dial configuration. It can be embedded in
 // another structure to build custom dial options.
@@ -184,6 +186,14 @@ func WithMaxMsgSize(s int) DialOption {
 func WithDefaultCallOptions(cos ...CallOption) DialOption {
 	return newFuncDialOption(func(o *dialOptions) {
 		o.callOptions = append(o.callOptions, cos...)
+	})
+}
+
+// withDisableGlobalOptions returns a DialOption which sets the
+// disableGlobalOptions bool to true.
+func withDisableGlobalOptions() DialOption {
+	return newFuncDialOption(func(o *dialOptions) {
+		o.disableGlobalOptions = true
 	})
 }
 

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -83,7 +83,9 @@ var (
 	// JoinServerOptions combines the server options passed as arguments into a
 	// single server option.
 	JoinServerOptions interface{} // func(...grpc.ServerOption) grpc.ServerOption
-
+	// WithDisableGlobalOptions returns a DialOption which sets the
+	// disableGlobalOptions bool to true.
+	WithDisableGlobalOptions interface{} // func() grpc.DialOption
 	// WithBinaryLogger returns a DialOption that specifies the binary logger
 	// for a ClientConn.
 	WithBinaryLogger interface{} // func(binarylog.Logger) grpc.DialOption

--- a/server.go
+++ b/server.go
@@ -74,10 +74,10 @@ func init() {
 		srv.drainServerTransports(addr)
 	}
 	internal.AddGlobalServerOptions = func(opt ...ServerOption) {
-		extraServerOptions = append(extraServerOptions, opt...)
+		globalServerOptions = append(globalServerOptions, opt...)
 	}
 	internal.ClearGlobalServerOptions = func() {
-		extraServerOptions = nil
+		globalServerOptions = nil
 	}
 	internal.BinaryLogger = binaryLogger
 	internal.JoinServerOptions = newJoinServerOption
@@ -183,7 +183,7 @@ var defaultServerOptions = serverOptions{
 	writeBufferSize:       defaultWriteBufSize,
 	readBufferSize:        defaultReadBufSize,
 }
-var extraServerOptions []ServerOption
+var globalServerOptions []ServerOption
 
 // A ServerOption sets options such as credentials, codec and keepalive parameters, etc.
 type ServerOption interface {
@@ -600,7 +600,7 @@ func (s *Server) stopServerWorkers() {
 // started to accept requests yet.
 func NewServer(opt ...ServerOption) *Server {
 	opts := defaultServerOptions
-	for _, o := range extraServerOptions {
+	for _, o := range globalServerOptions {
 		o.apply(&opts)
 	}
 	for _, o := range opt {


### PR DESCRIPTION
This PR adds a dial option to disable global dial options. This will be used in the observability module only, thus it is kept internal. The intended use case is to replace the observability modules instrumentation components registered globally (binary logger, in future: interceptor, and stats handler) to new components (just the interceptor and stats handler) for certain Client Conns (disableGlobalDialOptions + opencensus.DialOption(disableTrace = true). This is to avoid a loop where exporters using grpc.ClientConns create their own telemetry data due to the global registration of instrumentation components.

RELEASE NOTES: N/A