### PR TITLE
client: add an option to disable global dial options

### DIFF
--- a/dialoptions.go
+++ b/dialoptions.go
@@ -38,11 +38,12 @@ import (
 
 func init() {
 	internal.AddGlobalDialOptions = func(opt ...DialOption) {
-		extraDialOptions = append(extraDialOptions, opt...)
+		globalDialOptions = append(globalDialOptions, opt...)
 	}
 	internal.ClearGlobalDialOptions = func() {
-		extraDialOptions = nil
+		globalDialOptions = nil
 	}
+	internal.DialWithGlobalOptions = dialWithGlobalOptions
 	internal.WithBinaryLogger = withBinaryLogger
 	internal.JoinDialOptions = newJoinDialOption
 }
@@ -83,7 +84,7 @@ type DialOption interface {
 	apply(*dialOptions)
 }
 
-var extraDialOptions []DialOption
+var globalDialOptions []DialOption
 
 // EmptyDialOption does not alter the dial configuration. It can be embedded in
 // another structure to build custom dial options.

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -29,6 +29,9 @@ import (
 )
 
 var (
+	// DialWithGlobalOptions dials with a knob on whether to disable global dial
+	// options (set via AddGlobalDialOptions).
+	DialWithGlobalOptions interface{} // func (context.Context, string, bool, ...DialOption) (*ClientConn, error)
 	// WithHealthCheckFunc is set by dialoptions.go
 	WithHealthCheckFunc interface{} // func (HealthChecker) DialOption
 	// HealthCheckFunc is used to provide client-side LB channel health checking

--- a/server.go
+++ b/server.go
@@ -74,10 +74,10 @@ func init() {
 		srv.drainServerTransports(addr)
 	}
 	internal.AddGlobalServerOptions = func(opt ...ServerOption) {
-		extraServerOptions = append(extraServerOptions, opt...)
+		globalServerOptions = append(globalServerOptions, opt...)
 	}
 	internal.ClearGlobalServerOptions = func() {
-		extraServerOptions = nil
+		globalServerOptions = nil
 	}
 	internal.BinaryLogger = binaryLogger
 	internal.JoinServerOptions = newJoinServerOption
@@ -183,7 +183,7 @@ var defaultServerOptions = serverOptions{
 	writeBufferSize:       defaultWriteBufSize,
 	readBufferSize:        defaultReadBufSize,
 }
-var extraServerOptions []ServerOption
+var globalServerOptions []ServerOption
 
 // A ServerOption sets options such as credentials, codec and keepalive parameters, etc.
 type ServerOption interface {
@@ -600,7 +600,7 @@ func (s *Server) stopServerWorkers() {
 // started to accept requests yet.
 func NewServer(opt ...ServerOption) *Server {
 	opts := defaultServerOptions
-	for _, o := range extraServerOptions {
+	for _, o := range globalServerOptions {
 		o.apply(&opts)
 	}
 	for _, o := range opt {


### PR DESCRIPTION
This pr pulls out the logic for dialing into a new internal only dial function which takes a knob on whether to apply global dial options or not. This will be used by the observability module to prevent cyclic emissions of telemetry data due to the telemetry data being exported to a backend.

RELEASE NOTES: N/A