### PR TITLE
xdsclient/bootstrap: reduce chattiness of logs

### DIFF
--- a/xds/internal/xdsclient/bootstrap/bootstrap.go
+++ b/xds/internal/xdsclient/bootstrap/bootstrap.go
@@ -317,7 +317,7 @@ func bootstrapConfigFromEnvVariable() ([]byte, error) {
 		//
 		// Note that even if the content is invalid, we don't failover to the
 		// file content env variable.
-		logger.Debugf("xds: using bootstrap file with name %q", fName)
+		logger.Debugf("Using bootstrap file with name %q", fName)
 		return bootstrapFileReadFunc(fName)
 	}
 
@@ -349,7 +349,6 @@ func NewConfig() (*Config, error) {
 	if err != nil {
 		return nil, fmt.Errorf("xds: Failed to read bootstrap config: %v", err)
 	}
-	logger.Debugf("Bootstrap content: %s", data)
 	return newConfigFromContents(data)
 }
 
@@ -425,7 +424,7 @@ func newConfigFromContents(data []byte) (*Config, error) {
 			}
 		case "client_default_listener_resource_name_template":
 			if !envconfig.XDSFederation {
-				logger.Warningf("xds: bootstrap field %v is not support when Federation is disabled", k)
+				logger.Warningf("Bootstrap field %v is not support when Federation is disabled", k)
 				continue
 			}
 			if err := json.Unmarshal(v, &config.ClientDefaultListenerResourceNameTemplate); err != nil {
@@ -433,7 +432,7 @@ func newConfigFromContents(data []byte) (*Config, error) {
 			}
 		case "authorities":
 			if !envconfig.XDSFederation {
-				logger.Warningf("xds: bootstrap field %v is not support when Federation is disabled", k)
+				logger.Warningf("Bootstrap field %v is not support when Federation is disabled", k)
 				continue
 			}
 			if err := json.Unmarshal(v, &config.Authorities); err != nil {
@@ -477,7 +476,7 @@ func newConfigFromContents(data []byte) (*Config, error) {
 	if err := config.updateNodeProto(node); err != nil {
 		return nil, err
 	}
-	logger.Infof("Bootstrap config for creating xds-client: %v", pretty.ToJSON(config))
+	logger.Debugf("Bootstrap config for creating xds-client: %v", pretty.ToJSON(config))
 	return config, nil
 }
 


### PR DESCRIPTION
This is the first in a set of PRs to reduce chattiness of xdsclient logs. Addresses https://github.com/grpc/grpc-go/issues/5839.

This PR addresses logs in the `xdsclient/bootstrap` package:
- Removes the `xds: ` prefix for log messages. These are used only for error strings in general.
- Bootstrap content was being logged two times. Removed the redundancy.
- Made bootstrap logs use the `Debugf()` method on the prefix logger which logs at severity `INFO` and verbosity `2`.

RELEASE NOTES: none