### PR TITLE
xdsclient/transport: reduce chattiness of logs

### DIFF
--- a/internal/grpclog/prefixLogger.go
+++ b/internal/grpclog/prefixLogger.go
@@ -63,6 +63,9 @@ func (pl *PrefixLogger) Errorf(format string, args ...interface{}) {
 
 // Debugf does info logging at verbose level 2.
 func (pl *PrefixLogger) Debugf(format string, args ...interface{}) {
+	// TODO(6044): Refactor interfaces LoggerV2 and DepthLogger, and maybe
+	// rewrite PrefixLogger a little to ensure that we don't use the global
+	// `Logger` here, and instead use the `logger` field.
 	if !Logger.V(2) {
 		return
 	}
@@ -78,6 +81,9 @@ func (pl *PrefixLogger) Debugf(format string, args ...interface{}) {
 
 // V reports whether verbosity level l is at least the requested verbose level.
 func (pl *PrefixLogger) V(l int) bool {
+	// TODO(6044): Refactor interfaces LoggerV2 and DepthLogger, and maybe
+	// rewrite PrefixLogger a little to ensure that we don't use the global
+	// `Logger` here, and instead use the `logger` field.
 	return Logger.V(l)
 }
 

--- a/internal/grpclog/prefixLogger.go
+++ b/internal/grpclog/prefixLogger.go
@@ -73,6 +73,12 @@ func (pl *PrefixLogger) Debugf(format string, args ...interface{}) {
 		return
 	}
 	InfoDepth(1, fmt.Sprintf(format, args...))
+
+}
+
+// V reports whether verbosity level l is at least the requested verbose level.
+func (pl *PrefixLogger) V(l int) bool {
+	return Logger.V(l)
 }
 
 // NewPrefixLogger creates a prefix logger with the given prefix.

--- a/xds/internal/xdsclient/transport/loadreport.go
+++ b/xds/internal/xdsclient/transport/loadreport.go
@@ -120,19 +120,19 @@ func (t *Transport) lrsRunner(ctx context.Context) {
 			defer cancel()
 			stream, err := v3lrsgrpc.NewLoadReportingServiceClient(t.cc).StreamLoadStats(streamCtx)
 			if err != nil {
-				t.logger.Warningf("Creating LRS stream to server %q: %v", t.serverURI, err)
+				t.logger.Warningf("Creating LRS stream to server %q failed: %v", t.serverURI, err)
 				return false
 			}
 			t.logger.Infof("Created LRS stream to server %q", t.serverURI)
 
 			if err := t.sendFirstLoadStatsRequest(stream, node); err != nil {
-				t.logger.Warningf("Send first LRS request: %v", err)
+				t.logger.Warningf("Sending first LRS request failed: %v", err)
 				return false
 			}
 
 			clusters, interval, err := t.recvFirstLoadStatsResponse(stream)
 			if err != nil {
-				t.logger.Warningf("Reading from LRS stream: %v", err)
+				t.logger.Warningf("Reading from LRS stream failed: %v", err)
 				return false
 			}
 
@@ -160,7 +160,7 @@ func (t *Transport) sendLoads(ctx context.Context, stream lrsStream, clusterName
 			return
 		}
 		if err := t.sendLoadStatsRequest(stream, t.lrsStore.Stats(clusterNames)); err != nil {
-			t.logger.Warningf("Writing to LRS stream: %v", err)
+			t.logger.Warningf("Writing to LRS stream failed: %v", err)
 			return
 		}
 	}
@@ -169,7 +169,7 @@ func (t *Transport) sendLoads(ctx context.Context, stream lrsStream, clusterName
 func (t *Transport) sendFirstLoadStatsRequest(stream lrsStream, node *v3corepb.Node) error {
 	req := &v3lrspb.LoadStatsRequest{Node: node}
 	if t.logger.V(perRPCVerbosityLevel) {
-		t.logger.Debugf("Sending initial LoadStatsRequest: %s", pretty.ToJSON(req))
+		t.logger.Infof("Sending initial LoadStatsRequest: %s", pretty.ToJSON(req))
 	}
 	err := stream.Send(req)
 	if err == io.EOF {
@@ -184,7 +184,7 @@ func (t *Transport) recvFirstLoadStatsResponse(stream lrsStream) ([]string, time
 		return nil, 0, fmt.Errorf("failed to receive first LoadStatsResponse: %v", err)
 	}
 	if t.logger.V(perRPCVerbosityLevel) {
-		t.logger.Debugf("Received first LoadStatsResponse: %s", pretty.ToJSON(resp))
+		t.logger.Infof("Received first LoadStatsResponse: %s", pretty.ToJSON(resp))
 	}
 
 	interval, err := ptypes.Duration(resp.GetLoadReportingInterval())
@@ -256,7 +256,7 @@ func (t *Transport) sendLoadStatsRequest(stream lrsStream, loads []*load.Data) e
 
 	req := &v3lrspb.LoadStatsRequest{ClusterStats: clusterStats}
 	if t.logger.V(perRPCVerbosityLevel) {
-		t.logger.Debugf("Sending LRS loads: %s", pretty.ToJSON(req))
+		t.logger.Infof("Sending LRS loads: %s", pretty.ToJSON(req))
 	}
 	err := stream.Send(req)
 	if err == io.EOF {

--- a/xds/internal/xdsclient/transport/loadreport.go
+++ b/xds/internal/xdsclient/transport/loadreport.go
@@ -120,19 +120,19 @@ func (t *Transport) lrsRunner(ctx context.Context) {
 			defer cancel()
 			stream, err := v3lrsgrpc.NewLoadReportingServiceClient(t.cc).StreamLoadStats(streamCtx)
 			if err != nil {
-				t.logger.Warningf("Failed to create LRS stream: %v", err)
+				t.logger.Warningf("Creating LRS stream to server %q: %v", t.serverURI, err)
 				return false
 			}
-			t.logger.Infof("Created LRS stream to server: %s", t.serverURI)
+			t.logger.Infof("Created LRS stream to server %q", t.serverURI)
 
 			if err := t.sendFirstLoadStatsRequest(stream, node); err != nil {
-				t.logger.Warningf("Failed to send first LRS request: %v", err)
+				t.logger.Warningf("Send first LRS request: %v", err)
 				return false
 			}
 
 			clusters, interval, err := t.recvFirstLoadStatsResponse(stream)
 			if err != nil {
-				t.logger.Warningf("Failed to read from LRS stream: %v", err)
+				t.logger.Warningf("Reading from LRS stream: %v", err)
 				return false
 			}
 
@@ -160,7 +160,7 @@ func (t *Transport) sendLoads(ctx context.Context, stream lrsStream, clusterName
 			return
 		}
 		if err := t.sendLoadStatsRequest(stream, t.lrsStore.Stats(clusterNames)); err != nil {
-			t.logger.Warningf("Failed to write to LRS stream: %v", err)
+			t.logger.Warningf("Writing to LRS stream: %v", err)
 			return
 		}
 	}
@@ -168,7 +168,9 @@ func (t *Transport) sendLoads(ctx context.Context, stream lrsStream, clusterName
 
 func (t *Transport) sendFirstLoadStatsRequest(stream lrsStream, node *v3corepb.Node) error {
 	req := &v3lrspb.LoadStatsRequest{Node: node}
-	t.logger.Debugf("Sending initial LoadStatsRequest: %s", pretty.ToJSON(req))
+	if t.logger.V(perRPCVerbosityLevel) {
+		t.logger.Debugf("Sending initial LoadStatsRequest: %s", pretty.ToJSON(req))
+	}
 	err := stream.Send(req)
 	if err == io.EOF {
 		return getStreamError(stream)
@@ -181,7 +183,9 @@ func (t *Transport) recvFirstLoadStatsResponse(stream lrsStream) ([]string, time
 	if err != nil {
 		return nil, 0, fmt.Errorf("failed to receive first LoadStatsResponse: %v", err)
 	}
-	t.logger.Debugf("Received first LoadStatsResponse: %s", pretty.ToJSON(resp))
+	if t.logger.V(perRPCVerbosityLevel) {
+		t.logger.Debugf("Received first LoadStatsResponse: %s", pretty.ToJSON(resp))
+	}
 
 	interval, err := ptypes.Duration(resp.GetLoadReportingInterval())
 	if err != nil {
@@ -251,7 +255,9 @@ func (t *Transport) sendLoadStatsRequest(stream lrsStream, loads []*load.Data) e
 	}
 
 	req := &v3lrspb.LoadStatsRequest{ClusterStats: clusterStats}
-	t.logger.Debugf("Sending LRS loads: %s", pretty.ToJSON(req))
+	if t.logger.V(perRPCVerbosityLevel) {
+		t.logger.Debugf("Sending LRS loads: %s", pretty.ToJSON(req))
+	}
 	err := stream.Send(req)
 	if err == io.EOF {
 		return getStreamError(stream)

--- a/xds/internal/xdsclient/transport/transport.go
+++ b/xds/internal/xdsclient/transport/transport.go
@@ -272,7 +272,7 @@ func (t *Transport) sendAggregatedDiscoveryServiceRequest(stream adsStream, reso
 		return fmt.Errorf("sending ADS request %s failed: %v", pretty.ToJSON(req), err)
 	}
 	if t.logger.V(perRPCVerbosityLevel) {
-		t.logger.Debugf("ADS request sent: %v", pretty.ToJSON(req))
+		t.logger.Infof("ADS request sent: %v", pretty.ToJSON(req))
 	} else {
 		t.logger.Debugf("ADS request sent for type %q, resources: %v, version %q, nonce %q", resourceURL, resourceNames, version, nonce)
 	}
@@ -285,7 +285,7 @@ func (t *Transport) recvAggregatedDiscoveryServiceResponse(stream adsStream) (re
 		return nil, "", "", "", fmt.Errorf("failed to read ADS response: %v", err)
 	}
 	if t.logger.V(perRPCVerbosityLevel) {
-		t.logger.Debugf("ADS response received: %v", pretty.ToJSON(resp))
+		t.logger.Infof("ADS response received: %v", pretty.ToJSON(resp))
 	} else {
 		t.logger.Debugf("ADS response received for type %q, version %q, nonce %q", resp.GetTypeUrl(), resp.GetVersionInfo(), resp.GetNonce())
 	}
@@ -319,7 +319,7 @@ func (t *Transport) adsRunner(ctx context.Context) {
 			stream, err := t.newAggregatedDiscoveryServiceStream(ctx, t.cc)
 			if err != nil {
 				t.adsStreamErrHandler(err)
-				t.logger.Warningf("Creating new ADS stream: %v", err)
+				t.logger.Warningf("Creating new ADS stream failed: %v", err)
 				return false
 			}
 			t.logger.Infof("ADS stream created")
@@ -389,7 +389,7 @@ func (t *Transport) send(ctx context.Context) {
 				continue
 			}
 			if err := t.sendAggregatedDiscoveryServiceRequest(stream, resources, url, version, nonce, nackErr); err != nil {
-				t.logger.Warningf("Sending ADS request: %v", err)
+				t.logger.Warningf("Sending ADS request for resources: %q, url: %q, version: %q, nonce: %q failed: %v", resources, url, version, nonce, err)
 				// Send failed, clear the current stream.
 				stream = nil
 			}
@@ -422,7 +422,7 @@ func (t *Transport) sendExisting(stream adsStream) bool {
 
 	for url, resources := range t.resources {
 		if err := t.sendAggregatedDiscoveryServiceRequest(stream, mapToSlice(resources), url, t.versions[url], "", nil); err != nil {
-			t.logger.Warningf("Sending ADS request: %v", err)
+			t.logger.Warningf("Sending ADS request for resources: %q, url: %q, version: %q, nonce: %q failed: %v", resources, url, t.versions[url], "", err)
 			return false
 		}
 	}

--- a/xds/internal/xdsclient/transport/transport.go
+++ b/xds/internal/xdsclient/transport/transport.go
@@ -285,7 +285,7 @@ func (t *Transport) sendAggregatedDiscoveryServiceRequest(stream adsStream, reso
 func (t *Transport) recvAggregatedDiscoveryServiceResponse(stream adsStream) (resources []*anypb.Any, resourceURL, version, nonce string, err error) {
 	resp, err := stream.Recv()
 	if err != nil {
-		return nil, "", "", "", fmt.Errorf("failed to read ADS response: %v", err)
+		return nil, "", "", "", err
 	}
 	if t.logger.V(perRPCVerbosityLevel) {
 		t.logger.Infof("ADS response received: %v", pretty.ToJSON(resp))

--- a/xds/internal/xdsclient/transport/transport.go
+++ b/xds/internal/xdsclient/transport/transport.go
@@ -45,7 +45,10 @@ import (
 	statuspb "google.golang.org/genproto/googleapis/rpc/status"
 )
 
-// Extremely verbose per-RPC level logs should check for this verbosity level.
+// Any per-RPC level logs which print complete request or response messages
+// should be gated at this verbosity level. Other per-RPC level logs which print
+// terse output should be at `INFO` and verbosity 2, which corresponds to using
+// the `Debugf` method on the logger.
 const perRPCVerbosityLevel = 9
 
 type adsStream = v3adsgrpc.AggregatedDiscoveryService_StreamAggregatedResourcesClient
@@ -269,7 +272,7 @@ func (t *Transport) sendAggregatedDiscoveryServiceRequest(stream adsStream, reso
 		}
 	}
 	if err := stream.Send(req); err != nil {
-		return fmt.Errorf("sending ADS request %s failed: %v", pretty.ToJSON(req), err)
+		return err
 	}
 	if t.logger.V(perRPCVerbosityLevel) {
 		t.logger.Infof("ADS request sent: %v", pretty.ToJSON(req))


### PR DESCRIPTION
This is one among a set of PRs to reduce chattiness of xdsclient logs. Addresses https://github.com/grpc/grpc-go/issues/5839.

This PR addresses logs in the `xdsclient/transport` package:
- Adds a `V` method to the `PrefixLogger` type to make it possible to log at specified verbosity.
- Transport logs which represent infrequent events like creating a transport, creating a stream, closing a stream etc are logged at `Info`.
- Transport logs which represent per request/response events take the following approach
  - if the set verbosity level is less than `perRPCVerbosityLevel`, a terse message at `Debug` is logged
  - otherwise, a detailed message containing the full request/response message is logged at `Debug`

With this change, if the user sets severity to `INFO` and does not set verbosity levels, transport logs will only contain entries for events like transport creation, stream creation, stream closing etc.

RELEASE NOTES: none