### PR TITLE
xds/server: reduce chattiness of logs

### DIFF
--- a/xds/internal/server/listener_wrapper.go
+++ b/xds/internal/server/listener_wrapper.go
@@ -66,10 +66,6 @@ type ServingModeCallback func(addr net.Addr, mode connectivity.ServingMode, err 
 // connections.
 type DrainCallback func(addr net.Addr)
 
-func prefixLogger(p *listenerWrapper) *internalgrpclog.PrefixLogger {
-	return internalgrpclog.NewPrefixLogger(logger, fmt.Sprintf("[xds-server-listener %p] ", p))
-}
-
 // XDSClient wraps the methods on the XDSClient which are required by
 // the listenerWrapper.
 type XDSClient interface {
@@ -117,7 +113,7 @@ func NewListenerWrapper(params ListenerWrapperParams) (net.Listener, <-chan stru
 		ldsUpdateCh: make(chan ldsUpdateWithError, 1),
 		rdsUpdateCh: make(chan rdsHandlerUpdate, 1),
 	}
-	lw.logger = prefixLogger(lw)
+	lw.logger = internalgrpclog.NewPrefixLogger(logger, fmt.Sprintf("[xds-server-listener %p] ", lw))
 
 	// Serve() verifies that Addr() returns a valid TCPAddr. So, it is safe to
 	// ignore the error from SplitHostPort().
@@ -125,13 +121,7 @@ func NewListenerWrapper(params ListenerWrapperParams) (net.Listener, <-chan stru
 	lw.addr, lw.port, _ = net.SplitHostPort(lisAddr)
 
 	lw.rdsHandler = newRDSHandler(lw.xdsC, lw.rdsUpdateCh)
-
-	cancelWatch := lw.xdsC.WatchListener(lw.name, lw.handleListenerUpdate)
-	lw.logger.Infof("Watch started on resource name %v", lw.name)
-	lw.cancelWatch = func() {
-		cancelWatch()
-		lw.logger.Infof("Watch cancelled on resource name %v", lw.name)
-	}
+	lw.cancelWatch = lw.xdsC.WatchListener(lw.name, lw.handleListenerUpdate)
 	go lw.run()
 	return lw, lw.goodUpdate.Done()
 }
@@ -270,7 +260,7 @@ func (l *listenerWrapper) Accept() (net.Conn, error) {
 			// error, `grpc.Serve()` method sleeps for a small duration and
 			// therefore ends up blocking all connection attempts during that
 			// time frame, which is also not ideal for an error like this.
-			l.logger.Warningf("connection from %s to %s failed to find any matching filter chain", conn.RemoteAddr().String(), conn.LocalAddr().String())
+			l.logger.Warningf("Connection from %s to %s failed to find any matching filter chain", conn.RemoteAddr().String(), conn.LocalAddr().String())
 			conn.Close()
 			continue
 		}
@@ -302,7 +292,7 @@ func (l *listenerWrapper) Accept() (net.Conn, error) {
 		// tradeoff for simplicity.
 		vhswi, err := fc.ConstructUsableRouteConfiguration(rc)
 		if err != nil {
-			l.logger.Warningf("route configuration construction: %v", err)
+			l.logger.Warningf("Constructing usable route configuration: %v", err)
 			conn.Close()
 			continue
 		}
@@ -388,7 +378,6 @@ func (l *listenerWrapper) handleLDSUpdate(update ldsUpdateWithError) {
 		// continue to use the old configuration.
 		return
 	}
-	l.logger.Infof("Received update for resource %q: %+v", l.name, update.update)
 
 	// Make sure that the socket address on the received Listener resource
 	// matches the address of the net.Listener passed to us by the user. This

--- a/xds/internal/server/listener_wrapper.go
+++ b/xds/internal/server/listener_wrapper.go
@@ -292,7 +292,7 @@ func (l *listenerWrapper) Accept() (net.Conn, error) {
 		// tradeoff for simplicity.
 		vhswi, err := fc.ConstructUsableRouteConfiguration(rc)
 		if err != nil {
-			l.logger.Warningf("Constructing usable route configuration: %v", err)
+			l.logger.Warningf("Failed to construct usable route configuration: %v", err)
 			conn.Close()
 			continue
 		}

--- a/xds/server.go
+++ b/xds/server.go
@@ -61,10 +61,6 @@ var (
 	logger                = grpclog.Component("xds")
 )
 
-func prefixLogger(p *GRPCServer) *internalgrpclog.PrefixLogger {
-	return internalgrpclog.NewPrefixLogger(logger, fmt.Sprintf(serverPrefix, p))
-}
-
 // grpcServer contains methods from grpc.Server which are used by the
 // GRPCServer type here. This is useful for overriding in unit tests.
 type grpcServer interface {
@@ -107,7 +103,7 @@ func NewGRPCServer(opts ...grpc.ServerOption) *GRPCServer {
 		gs:   newGRPCServer(newOpts...),
 		quit: grpcsync.NewEvent(),
 	}
-	s.logger = prefixLogger(s)
+	s.logger = internalgrpclog.NewPrefixLogger(logger, fmt.Sprintf(serverPrefix, s))
 	s.logger.Infof("Created xds.GRPCServer")
 	s.handleServerOptions(opts)
 
@@ -196,7 +192,6 @@ func (s *GRPCServer) initXDSClient() error {
 	}
 	s.xdsC = client
 	s.xdsClientClose = close
-	s.logger.Infof("Created an xdsClient")
 	return nil
 }
 

--- a/xds/xds.go
+++ b/xds/xds.go
@@ -63,7 +63,7 @@ func init() {
 		default:
 			// Returning an error would cause the top level admin.Register() to
 			// fail. Log a warning instead.
-			logger.Warningf("server to register service on is neither a *grpc.Server or a *xds.GRPCServer, CSDS will not be registered")
+			logger.Warningf("Server to register service on is neither a *grpc.Server or a *xds.GRPCServer, CSDS will not be registered")
 			return nil, nil
 		}
 

--- a/xds/xds.go
+++ b/xds/xds.go
@@ -56,14 +56,14 @@ func init() {
 		case *GRPCServer:
 			sss, ok := ss.gs.(*grpc.Server)
 			if !ok {
-				logger.Warningf("grpc server within xds.GRPCServer is not *grpc.Server, CSDS will not be registered")
+				logger.Warning("grpc server within xds.GRPCServer is not *grpc.Server, CSDS will not be registered")
 				return nil, nil
 			}
 			grpcServer = sss
 		default:
 			// Returning an error would cause the top level admin.Register() to
 			// fail. Log a warning instead.
-			logger.Warningf("Server to register service on is neither a *grpc.Server or a *xds.GRPCServer, CSDS will not be registered")
+			logger.Error("Server to register service on is neither a *grpc.Server or a *xds.GRPCServer, CSDS will not be registered")
 			return nil, nil
 		}
 


### PR DESCRIPTION
Addresses https://github.com/grpc/grpc-go/issues/5839

Minor log cleanup for xDS servers:
- Remove logs about registering and cancelling watches. These are anyways logged by the `authority` struct in the `xdsclient` package.
- Stop logging the update for the resource being watched. This is also logged at lower levels of the xDS stack.

RELEASE NOTES: none