### PR TITLE
resolver: document handling UpdateState errors by resolvers

### DIFF
--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -203,6 +203,15 @@ type State struct {
 // gRPC to add new methods to this interface.
 type ClientConn interface {
 	// UpdateState updates the state of the ClientConn appropriately.
+	//
+	// If an error is returned, the resolver should try to resolve the
+	// target again. The resolver should use a backoff timer to prevent
+	// overloading the server with requests. If a resolver is certain that
+	// reresolving will not change the result, e.g. because it is
+	// a watch-based resolver, returned errors can be ignored.
+	//
+	// If the resolved State is the same as the last reported one, calling
+	// UpdateState can be omitted.
 	UpdateState(State) error
 	// ReportError notifies the ClientConn that the Resolver encountered an
 	// error.  The ClientConn will notify the load balancer and begin calling


### PR DESCRIPTION
Extend the Godoc for resolver.ClientConn.UpdateState with a description of how resolvers should handle returned errors.

The description is based on the explanation of dfawley in https://github.com/grpc/grpc-go/issues/5048

RELEASE NOTES:

- resolver: document expected error handling of UpdateState errors
