### PR TITLE
tests: reduce the degree of stress testing in long running tests

### DIFF
--- a/clientconn_test.go
+++ b/clientconn_test.go
@@ -335,7 +335,7 @@ func (s) TestCloseConnectionWhenServerPrefaceNotReceived(t *testing.T) {
 func (s) TestBackoffWhenNoServerPrefaceReceived(t *testing.T) {
 	lis, err := net.Listen("tcp", "localhost:0")
 	if err != nil {
-		t.Fatalf("net.Listen() = %v", err)
+		t.Fatalf("Unexpected error from net.Listen(%q, %q): %v", "tcp", "localhost:0", err)
 	}
 	defer lis.Close()
 	done := make(chan struct{})
@@ -379,7 +379,7 @@ func (s) TestBackoffWhenNoServerPrefaceReceived(t *testing.T) {
 	}
 	cc, err := Dial(lis.Addr().String(), WithTransportCredentials(insecure.NewCredentials()), WithConnectParams(cp))
 	if err != nil {
-		t.Fatalf("Dial() = %v", err)
+		t.Fatalf("Unexpected error from Dial(%v) = %v", lis.Addr(), err)
 	}
 	defer cc.Close()
 	go stayConnected(cc)

--- a/clientconn_test.go
+++ b/clientconn_test.go
@@ -335,7 +335,7 @@ func (s) TestCloseConnectionWhenServerPrefaceNotReceived(t *testing.T) {
 func (s) TestBackoffWhenNoServerPrefaceReceived(t *testing.T) {
 	lis, err := net.Listen("tcp", "localhost:0")
 	if err != nil {
-		t.Fatalf("Error while listening. Err: %v", err)
+		t.Fatalf("net.Listen() = %v", err)
 	}
 	defer lis.Close()
 	done := make(chan struct{})
@@ -367,9 +367,19 @@ func (s) TestBackoffWhenNoServerPrefaceReceived(t *testing.T) {
 			prevAt = meow
 		}
 	}()
-	cc, err := Dial(lis.Addr().String(), WithTransportCredentials(insecure.NewCredentials()))
+	bc := backoff.Config{
+		BaseDelay:  200 * time.Millisecond,
+		Multiplier: 1.1,
+		Jitter:     0,
+		MaxDelay:   120 * time.Second,
+	}
+	cp := ConnectParams{
+		Backoff:           bc,
+		MinConnectTimeout: 1 * time.Second,
+	}
+	cc, err := Dial(lis.Addr().String(), WithTransportCredentials(insecure.NewCredentials()), WithConnectParams(cp))
 	if err != nil {
-		t.Fatalf("Error while dialing. Err: %v", err)
+		t.Fatalf("Dial() = %v", err)
 	}
 	defer cc.Close()
 	go stayConnected(cc)
@@ -1192,7 +1202,7 @@ func keepReading(conn net.Conn) {
 // stayConnected makes cc stay connected by repeatedly calling cc.Connect()
 // until the state becomes Shutdown or until 10 seconds elapses.
 func stayConnected(cc *ClientConn) {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
 
 	for {

--- a/internal/transport/transport_test.go
+++ b/internal/transport/transport_test.go
@@ -2189,32 +2189,25 @@ func runPingPongTest(t *testing.T, msgSize int) {
 	opts := &Options{}
 	incomingHeader := make([]byte, 5)
 
-	done := make(chan struct{})
-	time.AfterFunc(time.Second, func() {
-		close(done)
-	})
-
-	for {
-		select {
-		case <-done:
-			client.Write(stream, nil, nil, &Options{Last: true})
-			if _, err := stream.Read(incomingHeader); err != io.EOF {
-				t.Fatalf("Client expected EOF from the server. Got: %v", err)
-			}
-			return
-		default:
-			if err := client.Write(stream, outgoingHeader, msg, opts); err != nil {
-				t.Fatalf("Error on client while writing message. Err: %v", err)
-			}
-			if _, err := stream.Read(incomingHeader); err != nil {
-				t.Fatalf("Error on client while reading data header. Err: %v", err)
-			}
-			sz := binary.BigEndian.Uint32(incomingHeader[1:])
-			recvMsg := make([]byte, int(sz))
-			if _, err := stream.Read(recvMsg); err != nil {
-				t.Fatalf("Error on client while reading data. Err: %v", err)
-			}
+	ctx, cancel = context.WithTimeout(ctx, time.Second)
+	defer cancel()
+	for ctx.Err() == nil {
+		if err := client.Write(stream, outgoingHeader, msg, opts); err != nil {
+			t.Fatalf("Error on client while writing message. Err: %v", err)
 		}
+		if _, err := stream.Read(incomingHeader); err != nil {
+			t.Fatalf("Error on client while reading data header. Err: %v", err)
+		}
+		sz := binary.BigEndian.Uint32(incomingHeader[1:])
+		recvMsg := make([]byte, int(sz))
+		if _, err := stream.Read(recvMsg); err != nil {
+			t.Fatalf("Error on client while reading data. Err: %v", err)
+		}
+	}
+
+	client.Write(stream, nil, nil, &Options{Last: true})
+	if _, err := stream.Read(incomingHeader); err != io.EOF {
+		t.Fatalf("Client expected EOF from the server. Got: %v", err)
 	}
 }
 

--- a/internal/transport/transport_test.go
+++ b/internal/transport/transport_test.go
@@ -667,7 +667,7 @@ func (s) TestClientMix(t *testing.T) {
 		<-ct.Error()
 		ct.Close(fmt.Errorf("closed manually by test"))
 	}(ct)
-	for i := 0; i < 1000; i++ {
+	for i := 0; i < 500; i++ {
 		time.Sleep(10 * time.Millisecond)
 		go performOneRPC(ct)
 	}
@@ -2191,15 +2191,10 @@ func runPingPongTest(t *testing.T, msgSize int) {
 	binary.BigEndian.PutUint32(outgoingHeader[1:], uint32(msgSize))
 	opts := &Options{}
 	incomingHeader := make([]byte, 5)
-	done := make(chan struct{})
-	go func() {
-		timer := time.NewTimer(time.Second * 5)
-		<-timer.C
-		close(done)
-	}()
+	timer := time.NewTimer(time.Second * 1)
 	for {
 		select {
-		case <-done:
+		case <-timer.C:
 			client.Write(stream, nil, nil, &Options{Last: true})
 			if _, err := stream.Read(incomingHeader); err != io.EOF {
 				t.Fatalf("Client expected EOF from the server. Got: %v", err)

--- a/internal/transport/transport_test.go
+++ b/internal/transport/transport_test.go
@@ -664,7 +664,7 @@ func (s) TestClientMix(t *testing.T) {
 		<-ct.Error()
 		ct.Close(fmt.Errorf("closed manually by test"))
 	}(ct)
-	for i := 0; i < 500; i++ {
+	for i := 0; i < 750; i++ {
 		time.Sleep(2 * time.Millisecond)
 		go performOneRPC(ct)
 	}


### PR DESCRIPTION
We are noticing a timeout issue in tests. The degree of stress test on some of them can be reduced since 1. we haven't seen these tests fail in a long time. 2. Shortening them doesn't completely invalidate the test case. 

Here are some tests that are taking longer than expected

```
Test/PingPong1KB 5.00s
Test/PingPong64KB 5.00s
Test/PingPong1B 5.05s
Test/PingPong1MB 5.05s
Test/BackoffWhenNoServerPrefaceReceived 5.45s
Test/ClientMix 10.57s
```


After the modification here is the new time taken per tests

```
Test/PingPong1B (1.06s)
Test/PingPong1KB (1.05s)
Test/PingPong1MB (1.00s)
Test/PingPong64KB (1.00s)
Test/BackoffWhenNoServerPrefaceReceived (1.73s)
Test/ClientMix (1.14s)
```

So yay, this diff reduces 25 seconds in a test run. @dfawley let me know your thoughts. 

RELEASE NOTES:
* tests: reduce the degree of stress testing in long running tests