### PR TITLE
xds: http header match with string matcher

### DIFF
--- a/internal/xds/matcher/string_matcher.go
+++ b/internal/xds/matcher/string_matcher.go
@@ -46,6 +46,30 @@ type StringMatcher struct {
 	ignoreCase bool
 }
 
+func (sm StringMatcher) String() string {
+	typ := ""
+	value := ""
+	switch {
+	case sm.exactMatch != nil:
+		typ = "exactMatch"
+		value = *sm.exactMatch
+	case sm.prefixMatch != nil:
+		typ = "prefixMatch"
+		value = *sm.prefixMatch
+	case sm.suffixMatch != nil:
+		typ = "suffixMatch"
+		value = *sm.suffixMatch
+	case sm.regexMatch != nil:
+		typ = "regexMatch"
+		value = sm.regexMatch.String()
+	case sm.containsMatch != nil:
+		typ = "containsMatch"
+		value = *sm.containsMatch
+	}
+
+	return fmt.Sprintf("stringMatcher:%s:%s:%v", typ, value, sm.ignoreCase)
+}
+
 // Match returns true if input matches the criteria in the given StringMatcher.
 func (sm StringMatcher) Match(input string) bool {
 	if sm.ignoreCase {

--- a/internal/xds/rbac/matchers.go
+++ b/internal/xds/rbac/matchers.go
@@ -285,6 +285,12 @@ func newHeaderMatcher(headerMatcherConfig *v3route_componentspb.HeaderMatcher) (
 		m = internalmatcher.NewHeaderSuffixMatcher(headerMatcherConfig.Name, headerMatcherConfig.GetSuffixMatch(), headerMatcherConfig.InvertMatch)
 	case *v3route_componentspb.HeaderMatcher_ContainsMatch:
 		m = internalmatcher.NewHeaderContainsMatcher(headerMatcherConfig.Name, headerMatcherConfig.GetContainsMatch(), headerMatcherConfig.InvertMatch)
+	case *v3route_componentspb.HeaderMatcher_StringMatch:
+		sm, err := internalmatcher.NewHeaderStringMatcher(headerMatcherConfig.Name, headerMatcherConfig.GetStringMatch(), headerMatcherConfig.InvertMatch)
+		if err != nil {
+			return nil, err
+		}
+		m = sm
 	default:
 		return nil, errors.New("unknown header matcher type")
 	}

--- a/xds/internal/xdsclient/xdsresource/matcher.go
+++ b/xds/internal/xdsclient/xdsresource/matcher.go
@@ -59,6 +59,12 @@ func RouteToMatcher(r *Route) (*CompositeMatcher, error) {
 			matcherT = matcher.NewHeaderRangeMatcher(h.Name, h.RangeMatch.Start, h.RangeMatch.End, invert)
 		case h.PresentMatch != nil:
 			matcherT = matcher.NewHeaderPresentMatcher(h.Name, *h.PresentMatch, invert)
+		case h.StringMatch != nil:
+			mch, err := matcher.NewHeaderStringMatcher(h.Name, h.StringMatch, invert)
+			if err != nil {
+				return nil, err
+			}
+			matcherT = mch
 		default:
 			return nil, fmt.Errorf("illegal route: missing header_match_specifier")
 		}

--- a/xds/internal/xdsclient/xdsresource/type_rds.go
+++ b/xds/internal/xdsclient/xdsresource/type_rds.go
@@ -21,6 +21,7 @@ import (
 	"regexp"
 	"time"
 
+	v3matcherpb "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/internal/xds/matcher"
 	"google.golang.org/grpc/xds/internal/clusterspecifier"
@@ -171,6 +172,7 @@ type HeaderMatcher struct {
 	SuffixMatch  *string
 	RangeMatch   *Int64Range
 	PresentMatch *bool
+	StringMatch  *v3matcherpb.StringMatcher
 }
 
 // Int64Range is a range for header range match.

--- a/xds/internal/xdsclient/xdsresource/unmarshal_rds.go
+++ b/xds/internal/xdsclient/xdsresource/unmarshal_rds.go
@@ -277,6 +277,8 @@ func routesProtoToSlice(routes []*v3routepb.Route, csps map[string]clusterspecif
 				header.PrefixMatch = &ht.PrefixMatch
 			case *v3routepb.HeaderMatcher_SuffixMatch:
 				header.SuffixMatch = &ht.SuffixMatch
+			case *v3routepb.HeaderMatcher_StringMatch:
+				header.StringMatch = ht.StringMatch
 			default:
 				return nil, nil, fmt.Errorf("route %+v has an unrecognized header matcher: %+v", r, ht)
 			}

--- a/xds/internal/xdsclient/xdsresource/unmarshal_rds_test.go
+++ b/xds/internal/xdsclient/xdsresource/unmarshal_rds_test.go
@@ -1294,7 +1294,7 @@ func (s) TestRoutesProtoToSlice(t *testing.T) {
 						Headers: []*v3routepb.HeaderMatcher{
 							{
 								Name:                 "th",
-								HeaderMatchSpecifier: &v3routepb.HeaderMatcher_StringMatch{},
+								HeaderMatchSpecifier: &v3routepb.HeaderMatcher_ContainsMatch{},
 							},
 						},
 					},


### PR DESCRIPTION
Client requests type.googleapis.com/envoy.config.route.v3.RouteConfiguration from xds server, the result type of HeadMatcher maybe  [StringMatcher](https://github.com/envoyproxy/go-control-plane/blob/main/envoy/type/matcher/string.pb.go#L28), the commit aims to support it.

RELEASE NOTES: 

-  xds: http header match with string matcher