### PR TITLE
github: update codeQL action to v2

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -27,9 +27,9 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: go
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
I noticed that even though codeQL runs have green, there is an error in logs which is due to the usage of codeQL action v1 which is deprecated. [Here is an example of the error](https://github.com/grpc/grpc-go/actions/runs/4068816780).

This diff bumps up the version to v2 as per the instructions [here](https://github.blog/changelog/2023-01-18-code-scanning-codeql-action-v1-is-now-deprecated/)

RELEASE NOTES: n/a

