### PR TITLE
client: Revert dialWithGlobalOption

### DIFF
--- a/clientconn.go
+++ b/clientconn.go
@@ -133,10 +133,6 @@ func (dcs *defaultConfigSelector) SelectConfig(rpcInfo iresolver.RPCInfo) (*ires
 // https://github.com/grpc/grpc/blob/master/doc/naming.md.
 // e.g. to use dns resolver, a "dns:///" prefix should be applied to the target.
 func DialContext(ctx context.Context, target string, opts ...DialOption) (conn *ClientConn, err error) {
-	return dialWithGlobalOptions(ctx, target, false, opts...)
-}
-
-func dialWithGlobalOptions(ctx context.Context, target string, disableGlobalOptions bool, opts ...DialOption) (conn *ClientConn, err error) {
 	cc := &ClientConn{
 		target:            target,
 		csMgr:             &connectivityStateManager{},
@@ -150,10 +146,8 @@ func dialWithGlobalOptions(ctx context.Context, target string, disableGlobalOpti
 	cc.safeConfigSelector.UpdateConfigSelector(&defaultConfigSelector{nil})
 	cc.ctx, cc.cancel = context.WithCancel(context.Background())
 
-	if !disableGlobalOptions {
-		for _, opt := range globalDialOptions {
-			opt.apply(&cc.dopts)
-		}
+	for _, opt := range globalDialOptions {
+		opt.apply(&cc.dopts)
 	}
 
 	for _, opt := range opts {

--- a/default_dial_option_server_option_test.go
+++ b/default_dial_option_server_option_test.go
@@ -19,7 +19,6 @@
 package grpc
 
 import (
-	"context"
 	"strings"
 	"testing"
 
@@ -57,24 +56,6 @@ func (s) TestAddGlobalDialOptions(t *testing.T) {
 	if len(globalDialOptions) != 0 {
 		t.Fatalf("Unexpected len of globalDialOptions: %d != 0", len(globalDialOptions))
 	}
-}
-
-// TestDisableGlobalOptions tests dialing with a bit that disables global
-// options. Dialing with this bit set should not pick up global options.
-func (s) TestDisableGlobalOptions(t *testing.T) {
-	// Set transport credentials as a global option.
-	internal.AddGlobalDialOptions.(func(opt ...DialOption))(WithTransportCredentials(insecure.NewCredentials()))
-	// Dial with disable global options set to true. This Dial should fail due
-	// to the global dial options with credentials not being picked up due to it
-	// being disabled.
-	if _, err := internal.DialWithGlobalOptions.(func(context.Context, string, bool, ...DialOption) (*ClientConn, error))(context.Background(), "fake", true); err == nil {
-		t.Fatalf("Dialing without a credential did not fail")
-	} else {
-		if !strings.Contains(err.Error(), "no transport security set") {
-			t.Fatalf("Dialing failed with unexpected error: %v", err)
-		}
-	}
-	internal.ClearGlobalDialOptions()
 }
 
 func (s) TestAddGlobalServerOptions(t *testing.T) {

--- a/dialoptions.go
+++ b/dialoptions.go
@@ -43,7 +43,6 @@ func init() {
 	internal.ClearGlobalDialOptions = func() {
 		globalDialOptions = nil
 	}
-	internal.DialWithGlobalOptions = dialWithGlobalOptions
 	internal.WithBinaryLogger = withBinaryLogger
 	internal.JoinDialOptions = newJoinDialOption
 }

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -29,9 +29,6 @@ import (
 )
 
 var (
-	// DialWithGlobalOptions dials with a knob on whether to disable global dial
-	// options (set via AddGlobalDialOptions).
-	DialWithGlobalOptions interface{} // func (context.Context, string, bool, ...DialOption) (*ClientConn, error)
 	// WithHealthCheckFunc is set by dialoptions.go
 	WithHealthCheckFunc interface{} // func (HealthChecker) DialOption
 	// HealthCheckFunc is used to provide client-side LB channel health checking


### PR DESCRIPTION
This PR reverts dialWithGlobalOption. We decided to do this with a dial option instead for seamless integration with gRPC-Go Client Libraries. This will be manually added to the import.

RELEASE NOTES: N/A