### PR TITLE
client: Add dial option to disable global dial options

### DIFF
--- a/clientconn.go
+++ b/clientconn.go
@@ -146,8 +146,18 @@ func DialContext(ctx context.Context, target string, opts ...DialOption) (conn *
 	cc.safeConfigSelector.UpdateConfigSelector(&defaultConfigSelector{nil})
 	cc.ctx, cc.cancel = context.WithCancel(context.Background())
 
-	for _, opt := range globalDialOptions {
-		opt.apply(&cc.dopts)
+	disableGlobalOpts := false
+	for _, opt := range opts {
+		if _, ok := opt.(*disableGlobalDialOptions); ok {
+			disableGlobalOpts = true
+			break
+		}
+	}
+
+	if !disableGlobalOpts {
+		for _, opt := range globalDialOptions {
+			opt.apply(&cc.dopts)
+		}
 	}
 
 	for _, opt := range opts {

--- a/default_dial_option_server_option_test.go
+++ b/default_dial_option_server_option_test.go
@@ -19,6 +19,7 @@
 package grpc
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -66,12 +67,9 @@ func (s) TestDisableGlobalOptions(t *testing.T) {
 	// Dial with the disable global options dial option. This dial should fail
 	// due to the global dial options with credentials not being picked up due
 	// to global options being disabled.
-	if _, err := Dial("fake", internal.DisableGlobalDialOptions.(func() DialOption)()); err == nil {
-		t.Fatalf("Dialing without a credential did not fail")
-	} else {
-		if !strings.Contains(err.Error(), "no transport security set") {
-			t.Fatalf("Dialing failed with unexpected error: %v", err)
-		}
+	noTSecStr := "no transport security set"
+	if _, err := Dial("fake", internal.DisableGlobalDialOptions.(func() DialOption)()); !strings.Contains(fmt.Sprint(err), noTSecStr) {
+		t.Fatalf("Dialing received unexpected error: %v, want error containing \"%v\"", err, noTSecStr)
 	}
 	internal.ClearGlobalDialOptions()
 }

--- a/default_dial_option_server_option_test.go
+++ b/default_dial_option_server_option_test.go
@@ -58,6 +58,24 @@ func (s) TestAddGlobalDialOptions(t *testing.T) {
 	}
 }
 
+// TestDisableGlobalOptions tests dialing with the disableGlobalDialOptions dial
+// option. Dialing with this set should not pick up global options.
+func (s) TestDisableGlobalOptions(t *testing.T) {
+	// Set transport credentials as a global option.
+	internal.AddGlobalDialOptions.(func(opt ...DialOption))(WithTransportCredentials(insecure.NewCredentials()))
+	// Dial with the disable global options dial option. This dial should fail
+	// due to the global dial options with credentials not being picked up due
+	// to global options being disabled.
+	if _, err := Dial("fake", internal.DisableGlobalDialOptions.(func() DialOption)()); err == nil {
+		t.Fatalf("Dialing without a credential did not fail")
+	} else {
+		if !strings.Contains(err.Error(), "no transport security set") {
+			t.Fatalf("Dialing failed with unexpected error: %v", err)
+		}
+	}
+	internal.ClearGlobalDialOptions()
+}
+
 func (s) TestAddGlobalServerOptions(t *testing.T) {
 	const maxRecvSize = 998765
 	// Set and check the ServerOptions

--- a/dialoptions.go
+++ b/dialoptions.go
@@ -45,6 +45,7 @@ func init() {
 	}
 	internal.WithBinaryLogger = withBinaryLogger
 	internal.JoinDialOptions = newJoinDialOption
+	internal.DisableGlobalDialOptions = newDisableGlobalDialOptions
 }
 
 // dialOptions configure a Dial call. dialOptions are set by the DialOption
@@ -95,6 +96,16 @@ var globalDialOptions []DialOption
 type EmptyDialOption struct{}
 
 func (EmptyDialOption) apply(*dialOptions) {}
+
+type disableGlobalDialOptions struct{}
+
+func (disableGlobalDialOptions) apply(*dialOptions) {}
+
+// newDisableGlobalDialOptions returns a DialOption that prevents the ClientConn
+// from applying the global DialOptions (set via AddGlobalDialOptions).
+func newDisableGlobalDialOptions() DialOption {
+	return &disableGlobalDialOptions{}
+}
 
 // funcDialOption wraps a function that modifies dialOptions into an
 // implementation of the DialOption interface.

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -77,6 +77,10 @@ var (
 	// globally for newly created client channels. The priority will be: 1.
 	// user-provided; 2. this method; 3. default values.
 	AddGlobalDialOptions interface{} // func(opt ...DialOption)
+	// DisableGlobalDialOptions returns a DialOption that prevents the
+	// ClientConn from applying the global DialOptions (set via
+	// AddGlobalDialOptions).
+	DisableGlobalDialOptions interface{} // func() grpc.DialOption
 	// ClearGlobalDialOptions clears the array of extra DialOption. This
 	// method is useful in testing and benchmarking.
 	ClearGlobalDialOptions func()


### PR DESCRIPTION
This PR adds a dial option to disable global dial options. This will be used in the observability module only, thus it is kept internal. The intended use case is to replace the observability modules instrumentation components registered globally (binary logger, in future: interceptor, and stats handler) to new components (just the interceptor and stats handler) for certain Client Conns (disableGlobalDialOptions + opencensus.DialOption(disableTrace = true). This is to avoid a loop where exporters using grpc.ClientConns create their own telemetry data due to the global registration of instrumentation components.

RELEASE NOTES: N/A