### PR TITLE
stats/opencensus: Add per call latency metric

### DIFF
--- a/rpc_util.go
+++ b/rpc_util.go
@@ -298,9 +298,10 @@ func (o FailFastCallOption) after(c *callInfo, attempt *csAttempt) {}
 
 // OnFinish returns a CallOption that configures a callback to be called when
 // the call completes. The error passed to the callback is the status of the
-// RPC, and may be nil. Must only be called once. This is mainly used in the
-// context of streaming interceptors, to be notified when the RPC completes
-// along with information about the status of the RPC.
+// RPC, and may be nil. The onFinish callback provided will only be called once
+// by gRPC. This is mainly used to be used by streaming interceptors, to be
+// notified when the RPC completes along with information about the status of
+// the RPC.
 //
 // # Experimental
 //

--- a/rpc_util.go
+++ b/rpc_util.go
@@ -159,7 +159,7 @@ type callInfo struct {
 	contentSubtype        string
 	codec                 baseCodec
 	maxRetryRPCBufferSize int
-	onFinish              func(err error)
+	onFinish              []func(err error)
 }
 
 func defaultCallInfo() *callInfo {
@@ -324,7 +324,7 @@ type OnFinishCallOption struct {
 }
 
 func (o OnFinishCallOption) before(c *callInfo) error {
-	c.onFinish = o.OnFinish
+	c.onFinish = append(c.onFinish, o.OnFinish)
 	return nil
 }
 

--- a/rpc_util.go
+++ b/rpc_util.go
@@ -159,6 +159,7 @@ type callInfo struct {
 	contentSubtype        string
 	codec                 baseCodec
 	maxRetryRPCBufferSize int
+	onFinish              func(err error)
 }
 
 func defaultCallInfo() *callInfo {
@@ -294,6 +295,27 @@ func (o FailFastCallOption) before(c *callInfo) error {
 	return nil
 }
 func (o FailFastCallOption) after(c *callInfo, attempt *csAttempt) {}
+
+// OnFinish returns a CallOption that configures a callback to be called when
+// the call completes.
+func OnFinish(onFinish func(err error)) CallOption {
+	return OnFinishCallOption{
+		onFinish: onFinish,
+	}
+}
+
+// OnFinishCallOption is CallOption that indicates a callback to be called when
+// the call completes.
+type OnFinishCallOption struct {
+	onFinish func(error)
+}
+
+func (o OnFinishCallOption) before(c *callInfo) error {
+	c.onFinish = o.onFinish
+	return nil
+}
+
+func (o OnFinishCallOption) after(c *callInfo, attempt *csAttempt) {}
 
 // MaxCallRecvMsgSize returns a CallOption which sets the maximum message size
 // in bytes the client can receive. If this is not set, gRPC uses the default

--- a/rpc_util.go
+++ b/rpc_util.go
@@ -297,21 +297,34 @@ func (o FailFastCallOption) before(c *callInfo) error {
 func (o FailFastCallOption) after(c *callInfo, attempt *csAttempt) {}
 
 // OnFinish returns a CallOption that configures a callback to be called when
-// the call completes.
+// the call completes. The error passed to the callback is the status of the
+// RPC, and may be nil. Must only be called once. This is mainly used in the
+// context of streaming interceptors, to be notified when the RPC completes
+// along with information about the status of the RPC.
+//
+// # Experimental
+//
+// Notice: This API is EXPERIMENTAL and may be changed or removed in a
+// later release.
 func OnFinish(onFinish func(err error)) CallOption {
 	return OnFinishCallOption{
-		onFinish: onFinish,
+		OnFinish: onFinish,
 	}
 }
 
 // OnFinishCallOption is CallOption that indicates a callback to be called when
 // the call completes.
+//
+// # Experimental
+//
+// Notice: This type is EXPERIMENTAL and may be changed or removed in a
+// later release.
 type OnFinishCallOption struct {
-	onFinish func(error)
+	OnFinish func(error)
 }
 
 func (o OnFinishCallOption) before(c *callInfo) error {
-	c.onFinish = o.onFinish
+	c.onFinish = o.OnFinish
 	return nil
 }
 

--- a/stats/opencensus/client_metrics.go
+++ b/stats/opencensus/client_metrics.go
@@ -38,6 +38,8 @@ var (
 	clientRoundtripLatency       = stats.Float64("grpc.io/client/roundtrip_latency", "Time between first byte of request sent to last byte of response received, or terminal error.", stats.UnitMilliseconds)
 	clientStartedRPCs            = stats.Int64("grpc.io/client/started_rpcs", "The total number of client RPCs ever opened, including those that have not completed.", stats.UnitDimensionless)
 	clientServerLatency          = stats.Float64("grpc.io/client/server_latency", `Propagated from the server and should have the same value as "grpc.io/server/latency".`, stats.UnitMilliseconds)
+	// Per call measure:
+	clientAPILatency = stats.Float64("grpc.io/client/api_latency", "The end-to-end time the gRPC library takes to complete an RPC from the application’s perspective", stats.UnitMilliseconds)
 )
 
 var (
@@ -101,6 +103,18 @@ var (
 		Name:        "grpc.io/client/roundtrip_latency",
 		Description: "Distribution of round-trip latency, by method.",
 		TagKeys:     []tag.Key{keyClientMethod},
+		Aggregation: millisecondsDistribution,
+	}
+
+	// The following metric is per call:
+
+	// ClientAPILatencyView is the distribution of client api latency for the
+	// full RPC call, keyed on method and status.
+	ClientAPILatencyView = &view.View{
+		Measure:     clientAPILatency,
+		Name:        "grpc.io/client/api_latency",
+		Description: "Distribution of client api latency, by method and status",
+		TagKeys:     []tag.Key{keyClientMethod, keyClientStatus},
 		Aggregation: millisecondsDistribution,
 	}
 )

--- a/stats/opencensus/e2e_test.go
+++ b/stats/opencensus/e2e_test.go
@@ -242,6 +242,7 @@ func (s) TestAllMetricsOneFunction(t *testing.T) {
 		ServerReceivedMessagesPerRPCView,
 		ClientRoundtripLatencyView,
 		ServerLatencyView,
+		ClientAPILatencyView,
 	}
 	view.Register(allViews...)
 	// Unregister unconditionally in this defer to correctly cleanup globals in
@@ -758,6 +759,10 @@ func (s) TestAllMetricsOneFunction(t *testing.T) {
 		{
 			metric: ServerLatencyView,
 		},
+		// Per call metrics:
+		{
+			metric: ClientAPILatencyView,
+		},
 	}
 	// Unregister all the views. Unregistering a view causes a synchronous
 	// upload of any collected data for the view to any registered exporters.
@@ -778,7 +783,7 @@ func (s) TestAllMetricsOneFunction(t *testing.T) {
 		// declare the exact data you want, make sure the latency
 		// measurement points for the two RPCs above fall within buckets
 		// that fall into less than 5 seconds, which is the rpc timeout.
-		if metricName == "grpc.io/client/roundtrip_latency" || metricName == "grpc.io/server/server_latency" {
+		if metricName == "grpc.io/client/roundtrip_latency" || metricName == "grpc.io/server/server_latency" || metricName == "grpc.io/client/api_latency" {
 			// RPCs have a context timeout of 5s, so all the recorded
 			// measurements (one per RPC - two total) should fall within 5
 			// second buckets.

--- a/stats/opencensus/opencensus.go
+++ b/stats/opencensus/opencensus.go
@@ -119,8 +119,7 @@ func streamInterceptor(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.Clie
 		)
 	}
 
-	callOption := grpc.OnFinish(callback)
-	opts = append(opts, callOption)
+	opts = append([]grpc.CallOption{grpc.OnFinish(callback)}, opts...)
 
 	s, err := streamer(ctx, desc, cc, method, opts...)
 	if err != nil {

--- a/stream.go
+++ b/stream.go
@@ -971,6 +971,9 @@ func (cs *clientStream) finish(err error) {
 		return
 	}
 	cs.finished = true
+	if cs.callInfo.onFinish != nil {
+		cs.callInfo.onFinish(err)
+	}
 	cs.commitAttemptLocked()
 	if cs.attempt != nil {
 		cs.attempt.finish(err)

--- a/stream.go
+++ b/stream.go
@@ -971,8 +971,8 @@ func (cs *clientStream) finish(err error) {
 		return
 	}
 	cs.finished = true
-	if cs.callInfo.onFinish != nil {
-		cs.callInfo.onFinish(err)
+	for _, onFinish := range cs.callInfo.onFinish {
+		onFinish(err)
 	}
 	cs.commitAttemptLocked()
 	if cs.attempt != nil {


### PR DESCRIPTION
This PR adds per call latency metric in the open census interceptor.

RELEASE NOTES:
* stats/opencensus: Add per call latency metric