### PR TITLE
github: update tests to use go version 1.20

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.19
+          go-version: 1.20
       - name: Checkout repo
         uses: actions/checkout@v2
 
@@ -46,31 +46,31 @@ jobs:
       matrix:
         include:
           - type: vet
-            goversion: 1.19
+            goversion: 1.20
 
           - type: tests
-            goversion: 1.19
+            goversion: 1.20
 
           - type: tests
-            goversion: 1.19
+            goversion: 1.20
             testflags: -race
 
           - type: tests
-            goversion: 1.19
+            goversion: 1.20
             goarch: 386
 
           - type: tests
-            goversion: 1.19
+            goversion: 1.20
             goarch: arm64
+
+          - type: tests
+            goversion: 1.19
 
           - type: tests
             goversion: 1.18
 
-          - type: tests
-            goversion: 1.17
-
           - type: extras
-            goversion: 1.19
+            goversion: 1.20
 
     steps:
       # Setup the environment.

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.20
+          go-version: '1.20'
       - name: Checkout repo
         uses: actions/checkout@v2
 
@@ -46,21 +46,21 @@ jobs:
       matrix:
         include:
           - type: vet
-            goversion: 1.20
+            goversion: '1.20'
 
           - type: tests
-            goversion: 1.20
+            goversion: '1.20'
 
           - type: tests
-            goversion: 1.20
+            goversion: '1.20'
             testflags: -race
 
           - type: tests
-            goversion: 1.20
+            goversion: '1.20'
             goarch: 386
 
           - type: tests
-            goversion: 1.20
+            goversion: '1.20'
             goarch: arm64
 
           - type: tests
@@ -70,7 +70,7 @@ jobs:
             goversion: 1.18
 
           - type: extras
-            goversion: 1.20
+            goversion: '1.20'
 
     steps:
       # Setup the environment.

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -64,10 +64,10 @@ jobs:
             goarch: arm64
 
           - type: tests
-            goversion: 1.19
+            goversion: '1.19'
 
           - type: tests
-            goversion: 1.18
+            goversion: '1.18'
 
           - type: extras
             goversion: '1.20'


### PR DESCRIPTION
The latest Go release, v 1.20, was released on Feb-01-2020. Modifying tests to support v1.20 and remove tests for v.17.

Note for GitHub Action users: the Go version must be quoted ('1.20') otherwise it is interpreted as a float (1.2).

Test with new version run on my fork: https://github.com/arvindbr8/grpc-go/actions/runs/4168025844

PS (+TIL): seems like GH picked up the new tests from the yml file. And did not run the old tests in this PR itself. 

RELEASE NOTES:

* github: update tests to use go latest release 1.20