### PR TITLE
gcp/observability: Switch observability module to use new opencensus instrumentation code

### DIFF
--- a/gcp/observability/go.mod
+++ b/gcp/observability/go.mod
@@ -9,7 +9,8 @@ require (
 	github.com/google/uuid v1.3.0
 	go.opencensus.io v0.24.0
 	golang.org/x/oauth2 v0.4.0
-	google.golang.org/grpc v1.51.0
+	google.golang.org/grpc v1.52.0
+	google.golang.org/grpc/stats/opencensus v0.0.0-20230214213552-081499f2e8a4
 )
 
 require (

--- a/gcp/observability/go.sum
+++ b/gcp/observability/go.sum
@@ -1056,6 +1056,8 @@ google.golang.org/genproto v0.0.0-20221202195650-67e5cbc046fd/go.mod h1:cTsE614G
 google.golang.org/genproto v0.0.0-20230110181048-76db0878b65f h1:BWUVssLB0HVOSY78gIdvk1dTVYtT1y8SBWtPYuTJ/6w=
 google.golang.org/genproto v0.0.0-20230110181048-76db0878b65f/go.mod h1:RGgjbofJ8xD9Sq1VVhDM1Vok1vRONV+rg+CjzG4SZKM=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0/go.mod h1:6Kw0yEErY5E/yWrBtf03jp27GLLJujG4z/JK95pnjjw=
+google.golang.org/grpc/stats/opencensus v0.0.0-20230214213552-081499f2e8a4 h1:JfKOhIhejpMhny1RYnvFO5QxXdVOEFSE12OSTgQvFus=
+google.golang.org/grpc/stats/opencensus v0.0.0-20230214213552-081499f2e8a4/go.mod h1:l7+BYcyrDJFQo8nh4v8h5TJ6VfQ9QGBfFqVO7xoqQzI=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=


### PR DESCRIPTION
This PR switches the gcp/observability module to use the newly written opencensus instrumentation code rather than the instrumentation code in their respository.

RELEASE NOTES: N/A