### PR TITLE
gcp/observability: Disable logging and traces on channels to cloud ops backends

### DIFF
--- a/gcp/observability/go.mod
+++ b/gcp/observability/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/google/uuid v1.3.0
 	go.opencensus.io v0.24.0
 	golang.org/x/oauth2 v0.4.0
+	google.golang.org/api v0.103.0
 	google.golang.org/grpc v1.52.0
 	google.golang.org/grpc/stats/opencensus v0.0.0-20230214213552-081499f2e8a4
 )
@@ -32,7 +33,6 @@ require (
 	golang.org/x/sync v0.1.0 // indirect
 	golang.org/x/sys v0.4.0 // indirect
 	golang.org/x/text v0.6.0 // indirect
-	google.golang.org/api v0.103.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20230110181048-76db0878b65f // indirect
 	google.golang.org/protobuf v1.28.1 // indirect

--- a/gcp/observability/logging.go
+++ b/gcp/observability/logging.go
@@ -340,11 +340,6 @@ type binaryLogger struct {
 }
 
 func (bl *binaryLogger) GetMethodLogger(methodName string) iblog.MethodLogger {
-	// Prevent logging from logging, traces, and metrics API calls.
-	if strings.HasPrefix(methodName, "/google.logging.v2.LoggingServiceV2/") || strings.HasPrefix(methodName, "/google.monitoring.v3.MetricService/") ||
-		strings.HasPrefix(methodName, "/google.devtools.cloudtrace.v2.TraceService/") {
-		return nil
-	}
 	s, _, err := grpcutil.ParseMethod(methodName)
 	if err != nil {
 		logger.Infof("binarylogging: failed to parse %q: %v", methodName, err)

--- a/gcp/observability/logging_test.go
+++ b/gcp/observability/logging_test.go
@@ -1062,65 +1062,6 @@ func (s) TestTranslateMetadata(t *testing.T) {
 	}
 }
 
-// TestCloudLoggingAPICallsFiltered tests that the observability plugin does not
-// emit logs for cloud logging API calls.
-func (s) TestCloudLoggingAPICallsFiltered(t *testing.T) {
-	fle := &fakeLoggingExporter{
-		t: t,
-	}
-
-	defer func(ne func(ctx context.Context, config *config) (loggingExporter, error)) {
-		newLoggingExporter = ne
-	}(newLoggingExporter)
-
-	newLoggingExporter = func(ctx context.Context, config *config) (loggingExporter, error) {
-		return fle, nil
-	}
-	configLogAll := &config{
-		ProjectID: "fake",
-		CloudLogging: &cloudLogging{
-			ClientRPCEvents: []clientRPCEvents{
-				{
-					Methods:          []string{"*"},
-					MaxMetadataBytes: 30,
-					MaxMessageBytes:  30,
-				},
-			},
-		},
-	}
-	cleanup, err := setupObservabilitySystemWithConfig(configLogAll)
-	if err != nil {
-		t.Fatalf("error setting up observability %v", err)
-	}
-	defer cleanup()
-
-	ss := &stubserver.StubServer{}
-	if err := ss.Start(nil); err != nil {
-		t.Fatalf("Error starting endpoint server: %v", err)
-	}
-	defer ss.Stop()
-
-	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
-	defer cancel()
-
-	// Any of the three cloud logging API calls should not cause any logs to be
-	// emitted, even though the configuration specifies to log any rpc
-	// regardless of method.
-	req := &grpc_testing.SimpleRequest{}
-	resp := &grpc_testing.SimpleResponse{}
-
-	ss.CC.Invoke(ctx, "/google.logging.v2.LoggingServiceV2/some-method", req, resp)
-	ss.CC.Invoke(ctx, "/google.monitoring.v3.MetricService/some-method", req, resp)
-	ss.CC.Invoke(ctx, "/google.devtools.cloudtrace.v2.TraceService/some-method", req, resp)
-	// The exporter should have received no new log entries due to these three
-	// calls, as they should be filtered out.
-	fle.mu.Lock()
-	defer fle.mu.Unlock()
-	if len(fle.entries) != 0 {
-		t.Fatalf("Unexpected length of entries %v, want 0", len(fle.entries))
-	}
-}
-
 func (s) TestMarshalJSON(t *testing.T) {
 	logEntry := &grpcLogEntry{
 		CallID:     "300-300-300",

--- a/gcp/observability/opencensus.go
+++ b/gcp/observability/opencensus.go
@@ -75,6 +75,8 @@ func newStackdriverExporter(config *config) (tracingMetricsExporter, error) {
 		MonitoredResource:       mr,
 		DefaultMonitoringLabels: labelsToMonitoringLabels(config.Labels),
 		DefaultTraceAttributes:  labelsToTraceAttributes(config.Labels),
+		MonitoringClientOptions: cOptsDisableLogTrace,
+		TraceClientOptions:      cOptsDisableLogTrace,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create Stackdriver exporter: %v", err)


### PR DESCRIPTION
This PR disables logging and traces on channels to cloud ops backends, preventing infinite recursive loops of logging and tracing if the probability sampler is 1.

RELEASE NOTES: N/A