### PR TITLE
Remove 'testing' package dependency from xds and channelz

### DIFF
--- a/xds/internal/balancer/clusterresolver/resource_resolver_dns.go
+++ b/xds/internal/balancer/clusterresolver/resource_resolver_dns.go
@@ -20,8 +20,8 @@ package clusterresolver
 
 import (
 	"fmt"
+	"net/url"
 
-	"google.golang.org/grpc/internal/testutils"
 	"google.golang.org/grpc/resolver"
 	"google.golang.org/grpc/serviceconfig"
 )
@@ -51,7 +51,10 @@ func newDNSResolver(target string, topLevelResolver *resourceResolver) *dnsDisco
 		target:           target,
 		topLevelResolver: topLevelResolver,
 	}
-	r, err := newDNS(resolver.Target{Scheme: "dns", URL: *testutils.MustParseURL("dns:///" + target)}, ret, resolver.BuildOptions{})
+	u, err := url.Parse("dns:///" + target)
+	if err == nil {
+		ret.r, err = newDNS(resolver.Target{Scheme: "dns", URL: *u}, ret, resolver.BuildOptions{})
+	}
 	if err != nil {
 		select {
 		case <-topLevelResolver.updateChannel:
@@ -59,7 +62,6 @@ func newDNSResolver(target string, topLevelResolver *resourceResolver) *dnsDisco
 		}
 		topLevelResolver.updateChannel <- &resourceUpdate{err: err}
 	}
-	ret.r = r
 	return ret
 }
 


### PR DESCRIPTION
Move `MarshalAny` and `MustParseURL` to a new `internals/utils` package; rename `MarshalAny` to `MustMarshalAny`.
This change will effectively remove the `testing` dependency from any non-testing code downstream.

NOTE: I would suggest adding a CI check (in the GitHub workflow) to prevent future introductions of the same dependency.

Fixes #6015

RELEASE NOTES: none