### PR TITLE
stats/opencensus: Add top level call span

### DIFF
--- a/stats/opencensus/trace.go
+++ b/stats/opencensus/trace.go
@@ -39,7 +39,7 @@ type traceInfo struct {
 // about this span into gRPC Metadata.
 func (csh *clientStatsHandler) traceTagRPC(ctx context.Context, rti *stats.RPCTagInfo) (context.Context, *traceInfo) {
 	// TODO: get consensus on whether this method name of "s.m" is correct.
-	mn := strings.Replace(removeLeadingSlash(rti.FullMethodName), "/", ".", -1)
+	mn := "Attempt." + strings.Replace(removeLeadingSlash(rti.FullMethodName), "/", ".", -1)
 	_, span := trace.StartSpan(ctx, mn, trace.WithSampler(csh.to.TS), trace.WithSpanKind(trace.SpanKindClient))
 
 	tcBin := propagation.Binary(span.SpanContext())


### PR DESCRIPTION
This PR adds top level call span defined in A45. This is needed to correctly link logs and traces for observabliltiy GA. Note that this doesn't add the attributes defined in A45, as that is not important for observability GA. Also note that I couldn't avoid sticking span directly in context and use the shared wrapper data to avoid the o(n) search up the context tree as the span needs to be in the context for StartSpan() in TagRPC() called from the rpc attempt to work.

RELEASE NOTES:
* stats/opencensus: Add top level call span