### PR TITLE
status: handle wrapped errors

### DIFF
--- a/status/status.go
+++ b/status/status.go
@@ -77,7 +77,8 @@ func FromProto(s *spb.Status) *Status {
 // FromError returns a Status representation of err.
 //
 //   - If err was produced by this package or implements the method `GRPCStatus()
-//     *Status`, the appropriate Status is returned.
+//     *Status`, or if err wraps a type satisfying this, the appropriate Status is
+//     returned.
 //
 //   - If err is nil, a Status is returned with codes.OK and no message.
 //
@@ -88,9 +89,8 @@ func FromError(err error) (s *Status, ok bool) {
 	if err == nil {
 		return nil, true
 	}
-	if se, ok := err.(interface {
-		GRPCStatus() *Status
-	}); ok {
+	var se interface{ GRPCStatus() *Status }
+	if errors.As(err, &se) {
 		return se.GRPCStatus(), true
 	}
 	return New(codes.Unknown, err.Error()), false
@@ -103,19 +103,16 @@ func Convert(err error) *Status {
 	return s
 }
 
-// Code returns the Code of the error if it is a Status error, codes.OK if err
-// is nil, or codes.Unknown otherwise.
+// Code returns the Code of the error if it is a Status error or if it wraps a
+// Status error. If that is not the case, it returns codes.OK if err is nil, or
+// codes.Unknown otherwise.
 func Code(err error) codes.Code {
 	// Don't use FromError to avoid allocation of OK status.
 	if err == nil {
 		return codes.OK
 	}
-	if se, ok := err.(interface {
-		GRPCStatus() *Status
-	}); ok {
-		return se.GRPCStatus().Code()
-	}
-	return codes.Unknown
+
+	return Convert(err).Code()
 }
 
 // FromContextError converts a context error or wrapped context error into a


### PR DESCRIPTION
RELEASE NOTES:

- status: `status.Code` and `status.FromError` handle wrapped errors