### PR TITLE
Add documentation on some anti-patterns

### DIFF
--- a/Documentation/error-handling.md
+++ b/Documentation/error-handling.md
@@ -1,0 +1,94 @@
+## Using `FailOnNonTempDialError`, `WithBlock`, and `WithReturnConnectionError`
+
+The gRPC API provides several options that can be used to configure the behavior of dialing and connecting to a gRPC server. Some of these options, such as `FailOnNonTempDialError`, `WithBlock`, and `WithReturnConnectionError`, rely on failures at dial time. However, we strongly discourage developers from using these options, as they can introduce race conditions and result in unreliable and difficult-to-debug code.
+
+### Why we discourage using `FailOnNonTempDialError`, `WithBlock`, and `WithReturnConnectionError`
+
+When a client attempts to connect to a gRPC server, it can encounter a variety of errors, including network connectivity issues, server-side errors, and incorrect usage of the gRPC API. The options `FailOnNonTempDialError`, `WithBlock`, and `WithReturnConnectionError` are designed to handle some of these errors, but they do so by relying on failures at dial time. This means that they may not provide reliable or accurate information about the status of the connection.
+
+For example, if a client uses `WithBlock` to wait for a connection to be established, it may end up waiting indefinitely if the server is not responding. Similarly, if a client uses `WithReturnConnectionError` to return a connection error if dialing fails, it may miss opportunities to recover from transient network issues that are resolved shortly after the initial dial attempt.
+
+### Best practices for error handling in gRPC
+
+Instead of relying on failures at dial time, we strongly encourage developers to rely on errors from RPCs. When a client makes an RPC, it can receive an error response from the server. These errors can provide valuable information about what went wrong, including information about network issues, server-side errors, and incorrect usage of the gRPC API.
+
+By handling errors from RPCs correctly, developers can write more reliable and robust gRPC applications. Here are some best practices for error handling in gRPC:
+
+-   Always check for error responses from RPCs and handle them appropriately.
+-   Use the `status` field of the error response to determine the type of error that occurred.
+-   When retrying failed RPCs, use a backoff strategy to avoid overwhelming the server or exacerbating network issues.
+-   Avoid using `FailOnNonTempDialError`, `WithBlock`, and `WithReturnConnectionError`, as these options can introduce race conditions and result in unreliable and difficult-to-debug code.
+
+### Example: Handling errors from an RPC
+The following code snippet demonstrates how to handle errors from an RPC in gRPC:
+```go
+ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+defer cancel()
+
+res, err := client.MyRPC(ctx, &MyRequest{})
+if err != nil {
+    // Handle the error appropriately, e.g. log it, return an error to the caller, etc.
+    log.Printf("Error calling MyRPC: %v", err)
+    return nil, err
+}
+// Use the response as appropriate
+log.Printf("MyRPC response: %v", res)
+```
+
+To determine the type of error that occurred, you can use the status field of the error response:
+```go
+resp, err := client.MakeRPC(context.Background(), request)
+if err != nil {
+    status, ok := status.FromError(err)
+    if ok {
+        // Handle the error based on its status code
+        if status.Code() == codes.NotFound {
+            log.Println("Requested resource not found")
+        } else {
+            log.Printf("RPC error: %v", status.Message())
+        }
+    } else {
+        // Handle non-RPC errors
+        log.Printf("Non-RPC error: %v", err)
+    }
+    return
+}
+// Use the response as needed
+log.Printf("Response received: %v", resp)
+```
+
+### Example: Using a backoff strategy
+When retrying failed RPCs, use a backoff strategy to avoid overwhelming the server or exacerbating network issues:
+```go
+var res *MyResponse
+var err error
+
+for i := 0; i < maxRetries; i++ {
+    ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+    defer cancel()
+
+    res, err = client.MyRPC(ctx, &MyRequest{})
+    if err == nil {
+        // The RPC was successful, so break out of the loop
+        break
+    }
+    // The RPC failed, so wait for a backoff period before retrying
+    backoff := time.Duration(i) * time.Second
+    log.Printf("Error calling MyRPC: %v; retrying in %v", err, backoff)
+    time.Sleep(backoff)
+}
+
+if err != nil {
+    // All retries failed, so handle the error appropriately
+    log.Printf("Error calling MyRPC: %v", err)
+    return nil, err
+}
+
+// Use the response as appropriate
+log.Printf("MyRPC response: %v", res)
+
+```
+
+### Conclusion
+
+The `FailOnNonTempDialError`, `WithBlock`, and `WithReturnConnectionError` options are designed to handle errors at dial time, but they can introduce race conditions and result in unreliable and difficult-to-debug code. Instead of relying on these options, we strongly encourage developers to rely on errors from RPCs for error handling. By following best practices for error handling in gRPC, developers can write more reliable and robust gRPC applications.


### PR DESCRIPTION
Created error handling documentation,

To rely on RPC errors instead of 

grpc.FailOnNonTempDialError

grpc.WithBlock

grpc.WithReturnConnectionError

 #6028

RELEASE NOTES: none