### PR TITLE
panic prevention: check if CallOptions is nil

### DIFF
--- a/call.go
+++ b/call.go
@@ -37,7 +37,15 @@ func (cc *ClientConn) Invoke(ctx context.Context, method string, args, reply int
 	return invoke(ctx, method, args, reply, cc, opts...)
 }
 
+// isNilInSlice tells whether a slice is [nil]
+func isNilInSlice(o []CallOption) bool {
+	return len(o) == 1 && o[0] == nil
+}
+
 func combine(o1 []CallOption, o2 []CallOption) []CallOption {
+	if isNilInSlice(o2) {
+		return o1
+	}
 	// we don't use append because o1 could have extra capacity whose
 	// elements would be overwritten, which could cause inadvertent
 	// sharing (and race conditions) between concurrent calls


### PR DESCRIPTION
When a programmer writes some code like this:

```
grpcClient.Query(context.TODO(), &Empty{},nil)
```
The program will panic since the `CallOption` part is [nil] instead of nil.

Below is a code snippet showing how Go's variadic functions can lead a programmer to an unexpected situation.

```
type Runner interface {
	Run()
}

func combine(o1 []Runner, o2 []Runner) []Runner {  // a copy from call.go
	if len(o1) == 0 {
		return o2
	} else if len(o2) == 0 {
		return o1
	}
	ret := make([]Runner, len(o1)+len(o2))
	copy(ret, o1)
	copy(ret[len(o1):], o2)
	return ret
}

func call(r ...Runner) []Runner {
	var o1 []Runner
	return combine(o1, r)
}

func main() {
	fmt.Println(call(nil)) // instead of [], the result is [<nil>]
}
```
People make mistakes, maybe we should improve the logic here a little bit.