### PR TITLE
stats/opencensus: Add client api latency and upgrade go.mod

### DIFF
--- a/gcp/observability/go.mod
+++ b/gcp/observability/go.mod
@@ -10,7 +10,7 @@ require (
 	go.opencensus.io v0.24.0
 	golang.org/x/oauth2 v0.4.0
 	google.golang.org/grpc v1.52.0
-	google.golang.org/grpc/stats/opencensus v0.0.0-20230214213552-081499f2e8a4
+	google.golang.org/grpc/stats/opencensus v0.0.0-20230221205128-8702a2ebf4b0
 )
 
 require (

--- a/gcp/observability/go.sum
+++ b/gcp/observability/go.sum
@@ -1056,8 +1056,8 @@ google.golang.org/genproto v0.0.0-20221202195650-67e5cbc046fd/go.mod h1:cTsE614G
 google.golang.org/genproto v0.0.0-20230110181048-76db0878b65f h1:BWUVssLB0HVOSY78gIdvk1dTVYtT1y8SBWtPYuTJ/6w=
 google.golang.org/genproto v0.0.0-20230110181048-76db0878b65f/go.mod h1:RGgjbofJ8xD9Sq1VVhDM1Vok1vRONV+rg+CjzG4SZKM=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0/go.mod h1:6Kw0yEErY5E/yWrBtf03jp27GLLJujG4z/JK95pnjjw=
-google.golang.org/grpc/stats/opencensus v0.0.0-20230214213552-081499f2e8a4 h1:JfKOhIhejpMhny1RYnvFO5QxXdVOEFSE12OSTgQvFus=
-google.golang.org/grpc/stats/opencensus v0.0.0-20230214213552-081499f2e8a4/go.mod h1:l7+BYcyrDJFQo8nh4v8h5TJ6VfQ9QGBfFqVO7xoqQzI=
+google.golang.org/grpc/stats/opencensus v0.0.0-20230221205128-8702a2ebf4b0 h1:v7h+HONu0plE0b3y9fBiOWlsqTdQQ5A9l9Ag2LXbEoE=
+google.golang.org/grpc/stats/opencensus v0.0.0-20230221205128-8702a2ebf4b0/go.mod h1:l7+BYcyrDJFQo8nh4v8h5TJ6VfQ9QGBfFqVO7xoqQzI=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=

--- a/gcp/observability/observability_test.go
+++ b/gcp/observability/observability_test.go
@@ -375,6 +375,9 @@ func (s) TestOpenCensusIntegration(t *testing.T) {
 	for ctx.Err() == nil {
 		errs = nil
 		fe.mu.RLock()
+		if value := fe.SeenViews["grpc.io/client/api_latency"]; value != TypeOpenCensusViewDistribution {
+			errs = append(errs, fmt.Errorf("unexpected type for grpc.io/client/api_latency: %s != %s", value, TypeOpenCensusViewDistribution))
+		}
 		if value := fe.SeenViews["grpc.io/client/started_rpcs"]; value != TypeOpenCensusViewCount {
 			errs = append(errs, fmt.Errorf("unexpected type for grpc.io/client/started_rpcs: %s != %s", value, TypeOpenCensusViewCount))
 		}

--- a/gcp/observability/opencensus.go
+++ b/gcp/observability/opencensus.go
@@ -104,7 +104,7 @@ func startOpenCensus(config *config) error {
 	}
 
 	if config.CloudMonitoring != nil {
-		if err := view.Register(opencensus.ClientStartedRPCsView, opencensus.ClientCompletedRPCsView, opencensus.ClientRoundtripLatencyView); err != nil {
+		if err := view.Register(opencensus.ClientAPILatencyView, opencensus.ClientStartedRPCsView, opencensus.ClientCompletedRPCsView, opencensus.ClientRoundtripLatencyView); err != nil {
 			return fmt.Errorf("failed to register default client views: %v", err)
 		}
 		if err := view.Register(opencensus.ServerStartedRPCsView, opencensus.ServerCompletedRPCsView, opencensus.ServerLatencyView); err != nil {


### PR DESCRIPTION
This PR adds client api latency (full call latency) to o11y callsite and updates go.mod to point to latest commit of stats/opencensus.

RELEASE NOTES:
* gcp/observability: Add Client API Latency to registered views