### PR TITLE
server/transport: add connection level interceptor, similar to net/http.Server.ConnContext

### DIFF
--- a/internal/transport/transport.go
+++ b/internal/transport/transport.go
@@ -562,6 +562,7 @@ type ServerConfig struct {
 	ChannelzParentID      *channelz.Identifier
 	MaxHeaderListSize     *uint32
 	HeaderTableSize       *uint32
+	ConnContext           func(ctx context.Context, c net.Conn) context.Context
 }
 
 // ConnectOptions covers all relevant options for communicating with the server.

--- a/server.go
+++ b/server.go
@@ -124,7 +124,8 @@ type serverWorkerData struct {
 
 // Server is a gRPC server to serve RPC requests.
 type Server struct {
-	opts serverOptions
+	opts        serverOptions
+	ConnContext func(ctx context.Context, c net.Conn) context.Context
 
 	mu  sync.Mutex // guards following
 	lis map[net.Listener]bool
@@ -921,6 +922,7 @@ func (s *Server) newHTTP2Transport(c net.Conn) transport.ServerTransport {
 		ChannelzParentID:      s.channelzID,
 		MaxHeaderListSize:     s.opts.maxHeaderListSize,
 		HeaderTableSize:       s.opts.headerTableSize,
+		ConnContext:           s.ConnContext,
 	}
 	st, err := transport.NewServerTransport(c, config)
 	if err != nil {


### PR DESCRIPTION
RELEASE NOTES:

Provide an internal-only API to report connectivity state changes on the ClientConn

#4683