### PR TITLE
stats/opencensus: New uncompressed metrics and align with tracing spec

### DIFF
--- a/rpc_util.go
+++ b/rpc_util.go
@@ -694,12 +694,13 @@ func msgHeader(data, compData []byte) (hdr []byte, payload []byte) {
 
 func outPayload(client bool, msg interface{}, data, payload []byte, t time.Time) *stats.OutPayload {
 	return &stats.OutPayload{
-		Client:     client,
-		Payload:    msg,
-		Data:       data,
-		Length:     len(data),
-		WireLength: len(payload) + headerLen,
-		SentTime:   t,
+		Client:           client,
+		Payload:          msg,
+		Data:             data,
+		Length:           len(data),
+		WireLength:       len(payload) + headerLen,
+		CompressedLength: len(payload),
+		SentTime:         t,
 	}
 }
 
@@ -720,7 +721,7 @@ func checkRecvPayload(pf payloadFormat, recvCompress string, haveCompressor bool
 }
 
 type payloadInfo struct {
-	wireLength        int // The compressed length got from wire.
+	compressedLength  int // The compressed length got from wire.
 	uncompressedBytes []byte
 }
 
@@ -730,7 +731,7 @@ func recvAndDecompress(p *parser, s *transport.Stream, dc Decompressor, maxRecei
 		return nil, err
 	}
 	if payInfo != nil {
-		payInfo.wireLength = len(d)
+		payInfo.compressedLength = len(d)
 	}
 
 	if st := checkRecvPayload(pf, s.RecvCompress(), compressor != nil || dc != nil); st != nil {

--- a/server.go
+++ b/server.go
@@ -1320,11 +1320,12 @@ func (s *Server) processUnaryRPC(t transport.ServerTransport, stream *transport.
 		}
 		for _, sh := range shs {
 			sh.HandleRPC(stream.Context(), &stats.InPayload{
-				RecvTime:   time.Now(),
-				Payload:    v,
-				WireLength: payInfo.wireLength + headerLen,
-				Data:       d,
-				Length:     len(d),
+				RecvTime:         time.Now(),
+				Payload:          v,
+				Length:           len(d),
+				WireLength:       payInfo.compressedLength + headerLen,
+				CompressedLength: payInfo.compressedLength,
+				Data:             d,
 			})
 		}
 		if len(binlogs) != 0 {

--- a/stats/opencensus/client_metrics.go
+++ b/stats/opencensus/client_metrics.go
@@ -31,13 +31,15 @@ var (
 // nature of how stats handlers are called on gRPC's client side, the per rpc
 // unit is actually per attempt throughout this definition file.
 var (
-	clientSentMessagesPerRPC     = stats.Int64("grpc.io/client/sent_messages_per_rpc", "Number of messages sent in the RPC (always 1 for non-streaming RPCs).", stats.UnitDimensionless)
-	clientSentBytesPerRPC        = stats.Int64("grpc.io/client/sent_bytes_per_rpc", "Total bytes sent across all request messages per RPC.", stats.UnitBytes)
-	clientReceivedMessagesPerRPC = stats.Int64("grpc.io/client/received_messages_per_rpc", "Number of response messages received per RPC (always 1 for non-streaming RPCs).", stats.UnitDimensionless)
-	clientReceivedBytesPerRPC    = stats.Int64("grpc.io/client/received_bytes_per_rpc", "Total bytes received across all response messages per RPC.", stats.UnitBytes)
-	clientRoundtripLatency       = stats.Float64("grpc.io/client/roundtrip_latency", "Time between first byte of request sent to last byte of response received, or terminal error.", stats.UnitMilliseconds)
-	clientStartedRPCs            = stats.Int64("grpc.io/client/started_rpcs", "The total number of client RPCs ever opened, including those that have not completed.", stats.UnitDimensionless)
-	clientServerLatency          = stats.Float64("grpc.io/client/server_latency", `Propagated from the server and should have the same value as "grpc.io/server/latency".`, stats.UnitMilliseconds)
+	clientSentMessagesPerRPC            = stats.Int64("grpc.io/client/sent_messages_per_rpc", "Number of messages sent in the RPC (always 1 for non-streaming RPCs).", stats.UnitDimensionless)
+	clientSentBytesPerRPC               = stats.Int64("grpc.io/client/sent_bytes_per_rpc", "Total bytes sent across all request messages per RPC.", stats.UnitBytes)
+	clientSentCompressedBytesPerRPC     = stats.Int64("grpc.io/client/sent_compressed_message_bytes_per_rpc", "Total compressed bytes sent across all request messages per RPC.", stats.UnitBytes)
+	clientReceivedMessagesPerRPC        = stats.Int64("grpc.io/client/received_messages_per_rpc", "Number of response messages received per RPC (always 1 for non-streaming RPCs).", stats.UnitDimensionless)
+	clientReceivedBytesPerRPC           = stats.Int64("grpc.io/client/received_bytes_per_rpc", "Total bytes received across all response messages per RPC.", stats.UnitBytes)
+	clientReceivedCompressedBytesPerRPC = stats.Int64("grpc.io/client/received_compressed_message_bytes_per_rpc", "Total compressed bytes received across all response messages per RPC.", stats.UnitBytes)
+	clientRoundtripLatency              = stats.Float64("grpc.io/client/roundtrip_latency", "Time between first byte of request sent to last byte of response received, or terminal error.", stats.UnitMilliseconds)
+	clientStartedRPCs                   = stats.Int64("grpc.io/client/started_rpcs", "The total number of client RPCs ever opened, including those that have not completed.", stats.UnitDimensionless)
+	clientServerLatency                 = stats.Float64("grpc.io/client/server_latency", `Propagated from the server and should have the same value as "grpc.io/server/latency".`, stats.UnitMilliseconds)
 	// Per call measure:
 	clientAPILatency = stats.Float64("grpc.io/client/api_latency", "The end-to-end time the gRPC library takes to complete an RPC from the application’s perspective", stats.UnitMilliseconds)
 )
@@ -70,12 +72,30 @@ var (
 		TagKeys:     []tag.Key{keyClientMethod},
 		Aggregation: bytesDistribution,
 	}
+	// ClientSentCompressedBytesPerRPCView is the distribution of compressed
+	// sent bytes per RPC, keyed on method.
+	ClientSentCompressedBytesPerRPCView = &view.View{
+		Measure:     clientSentCompressedBytesPerRPC,
+		Name:        "grpc.io/client/sent_compressed_bytes_per_rpc",
+		Description: "Distribution of sent compressed bytes per RPC, by method.",
+		TagKeys:     []tag.Key{keyClientMethod},
+		Aggregation: bytesDistribution,
+	}
 	// ClientReceivedBytesPerRPCView is the distribution of received bytes per
 	// RPC, keyed on method.
 	ClientReceivedBytesPerRPCView = &view.View{
 		Measure:     clientReceivedBytesPerRPC,
 		Name:        "grpc.io/client/received_bytes_per_rpc",
 		Description: "Distribution of received bytes per RPC, by method.",
+		TagKeys:     []tag.Key{keyClientMethod},
+		Aggregation: bytesDistribution,
+	}
+	// ClientReceivedCompressedBytesPerRPCView is the distribution of compressed
+	// received bytes per RPC, keyed on method.
+	ClientReceivedCompressedBytesPerRPCView = &view.View{
+		Measure:     clientReceivedCompressedBytesPerRPC,
+		Name:        "grpc.io/client/received_compressed_bytes_per_rpc",
+		Description: "Distribution of received compressed bytes per RPC, by method.",
 		TagKeys:     []tag.Key{keyClientMethod},
 		Aggregation: bytesDistribution,
 	}

--- a/stats/opencensus/e2e_test.go
+++ b/stats/opencensus/e2e_test.go
@@ -235,9 +235,13 @@ func (s) TestAllMetricsOneFunction(t *testing.T) {
 		ClientCompletedRPCsView,
 		ServerCompletedRPCsView,
 		ClientSentBytesPerRPCView,
+		ClientSentCompressedBytesPerRPCView,
 		ServerSentBytesPerRPCView,
+		ServerSentCompressedBytesPerRPCView,
 		ClientReceivedBytesPerRPCView,
+		ClientReceivedCompressedBytesPerRPCView,
 		ServerReceivedBytesPerRPCView,
+		ServerReceivedCompressedBytesPerRPCView,
 		ClientSentMessagesPerRPCView,
 		ServerSentMessagesPerRPCView,
 		ClientReceivedMessagesPerRPCView,
@@ -496,6 +500,43 @@ func (s) TestAllMetricsOneFunction(t *testing.T) {
 			},
 		},
 		{
+			metric: ClientSentCompressedBytesPerRPCView,
+			wantVI: &viewInformation{
+				aggType:    view.AggTypeDistribution,
+				aggBuckets: bytesDistributionBounds,
+				desc:       "Distribution of sent compressed bytes per RPC, by method.",
+				tagKeys: []tag.Key{
+					cmtk,
+				},
+				rows: []*view.Row{
+					{
+						Tags: []tag.Tag{
+							{
+								Key:   cmtk,
+								Value: "grpc.testing.TestService/UnaryCall",
+							},
+						},
+						Data: &view.DistributionData{
+							Count:          1,
+							CountPerBucket: []int64{1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+						},
+					},
+					{
+						Tags: []tag.Tag{
+							{
+								Key:   cmtk,
+								Value: "grpc.testing.TestService/FullDuplexCall",
+							},
+						},
+						Data: &view.DistributionData{
+							Count:          1,
+							CountPerBucket: []int64{1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+						},
+					},
+				},
+			},
+		},
+		{
 			metric: ServerSentBytesPerRPCView,
 			wantVI: &viewInformation{
 				aggType:    view.AggTypeDistribution,
@@ -532,7 +573,43 @@ func (s) TestAllMetricsOneFunction(t *testing.T) {
 				},
 			},
 		},
-
+		{
+			metric: ServerSentCompressedBytesPerRPCView,
+			wantVI: &viewInformation{
+				aggType:    view.AggTypeDistribution,
+				aggBuckets: bytesDistributionBounds,
+				desc:       "Distribution of sent compressed bytes per RPC, by method.",
+				tagKeys: []tag.Key{
+					smtk,
+				},
+				rows: []*view.Row{
+					{
+						Tags: []tag.Tag{
+							{
+								Key:   smtk,
+								Value: "grpc.testing.TestService/UnaryCall",
+							},
+						},
+						Data: &view.DistributionData{
+							Count:          1,
+							CountPerBucket: []int64{1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+						},
+					},
+					{
+						Tags: []tag.Tag{
+							{
+								Key:   smtk,
+								Value: "grpc.testing.TestService/FullDuplexCall",
+							},
+						},
+						Data: &view.DistributionData{
+							Count:          1,
+							CountPerBucket: []int64{1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+						},
+					},
+				},
+			},
+		},
 		{
 			metric: ClientReceivedBytesPerRPCView,
 			wantVI: &viewInformation{
@@ -571,11 +648,85 @@ func (s) TestAllMetricsOneFunction(t *testing.T) {
 			},
 		},
 		{
+			metric: ClientReceivedCompressedBytesPerRPCView,
+			wantVI: &viewInformation{
+				aggType:    view.AggTypeDistribution,
+				aggBuckets: bytesDistributionBounds,
+				desc:       "Distribution of received compressed bytes per RPC, by method.",
+				tagKeys: []tag.Key{
+					cmtk,
+				},
+				rows: []*view.Row{
+					{
+						Tags: []tag.Tag{
+							{
+								Key:   cmtk,
+								Value: "grpc.testing.TestService/UnaryCall",
+							},
+						},
+						Data: &view.DistributionData{
+							Count:          1,
+							CountPerBucket: []int64{1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+						},
+					},
+					{
+						Tags: []tag.Tag{
+							{
+								Key:   cmtk,
+								Value: "grpc.testing.TestService/FullDuplexCall",
+							},
+						},
+						Data: &view.DistributionData{
+							Count:          1,
+							CountPerBucket: []int64{1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+						},
+					},
+				},
+			},
+		},
+		{
 			metric: ServerReceivedBytesPerRPCView,
 			wantVI: &viewInformation{
 				aggType:    view.AggTypeDistribution,
 				aggBuckets: bytesDistributionBounds,
 				desc:       "Distribution of received bytes per RPC, by method.",
+				tagKeys: []tag.Key{
+					smtk,
+				},
+				rows: []*view.Row{
+					{
+						Tags: []tag.Tag{
+							{
+								Key:   smtk,
+								Value: "grpc.testing.TestService/UnaryCall",
+							},
+						},
+						Data: &view.DistributionData{
+							Count:          1,
+							CountPerBucket: []int64{1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+						},
+					},
+					{
+						Tags: []tag.Tag{
+							{
+								Key:   smtk,
+								Value: "grpc.testing.TestService/FullDuplexCall",
+							},
+						},
+						Data: &view.DistributionData{
+							Count:          1,
+							CountPerBucket: []int64{1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+						},
+					},
+				},
+			},
+		},
+		{
+			metric: ServerReceivedCompressedBytesPerRPCView,
+			wantVI: &viewInformation{
+				aggType:    view.AggTypeDistribution,
+				aggBuckets: bytesDistributionBounds,
+				desc:       "Distribution of received compressed bytes per RPC, by method.",
 				tagKeys: []tag.Key{
 					smtk,
 				},
@@ -1186,12 +1337,11 @@ func (s) TestSpan(t *testing.T) {
 					EventType:            trace.MessageEventTypeRecv,
 					MessageID:            1, // First msg recv so 1 (see comment above)
 					UncompressedByteSize: 2,
-					CompressedByteSize:   7,
+					CompressedByteSize:   2,
 				},
 				{
-					EventType:          trace.MessageEventTypeSent,
-					MessageID:          1, // First msg send so 1 (see comment above)
-					CompressedByteSize: 5,
+					EventType: trace.MessageEventTypeSent,
+					MessageID: 1, // First msg send so 1 (see comment above)
 				},
 			},
 			links: []trace.Link{
@@ -1215,12 +1365,11 @@ func (s) TestSpan(t *testing.T) {
 					EventType:            trace.MessageEventTypeSent,
 					MessageID:            1, // First msg send so 1 (see comment above)
 					UncompressedByteSize: 2,
-					CompressedByteSize:   7,
+					CompressedByteSize:   2,
 				},
 				{
-					EventType:          trace.MessageEventTypeRecv,
-					MessageID:          1, // First msg recv so 1 (see comment above)
-					CompressedByteSize: 5,
+					EventType: trace.MessageEventTypeRecv,
+					MessageID: 1, // First msg recv so 1 (see comment above)
 				},
 			},
 			hasRemoteParent: false,
@@ -1285,14 +1434,12 @@ func (s) TestSpan(t *testing.T) {
 			},
 			messageEvents: []trace.MessageEvent{
 				{
-					EventType:          trace.MessageEventTypeRecv,
-					MessageID:          1, // First msg recv so 1
-					CompressedByteSize: 5,
+					EventType: trace.MessageEventTypeRecv,
+					MessageID: 1, // First msg recv so 1
 				},
 				{
-					EventType:          trace.MessageEventTypeRecv,
-					MessageID:          2, // Second msg recv so 2
-					CompressedByteSize: 5,
+					EventType: trace.MessageEventTypeRecv,
+					MessageID: 2, // Second msg recv so 2
 				},
 			},
 			hasRemoteParent: true,
@@ -1314,14 +1461,12 @@ func (s) TestSpan(t *testing.T) {
 			name:     "Attempt.grpc.testing.TestService.FullDuplexCall",
 			messageEvents: []trace.MessageEvent{
 				{
-					EventType:          trace.MessageEventTypeSent,
-					MessageID:          1, // First msg send so 1
-					CompressedByteSize: 5,
+					EventType: trace.MessageEventTypeSent,
+					MessageID: 1, // First msg send so 1
 				},
 				{
-					EventType:          trace.MessageEventTypeSent,
-					MessageID:          2, // Second msg send so 2
-					CompressedByteSize: 5,
+					EventType: trace.MessageEventTypeSent,
+					MessageID: 2, // Second msg send so 2
 				},
 			},
 			hasRemoteParent: false,

--- a/stats/opencensus/e2e_test.go
+++ b/stats/opencensus/e2e_test.go
@@ -33,6 +33,7 @@ import (
 	"go.opencensus.io/trace"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/encoding/gzip"
 	"google.golang.org/grpc/internal/grpctest"
 	"google.golang.org/grpc/internal/leakcheck"
 	"google.golang.org/grpc/internal/stubserver"
@@ -263,7 +264,9 @@ func (s) TestAllMetricsOneFunction(t *testing.T) {
 
 	ss := &stubserver.StubServer{
 		UnaryCallF: func(ctx context.Context, in *grpc_testing.SimpleRequest) (*grpc_testing.SimpleResponse, error) {
-			return &grpc_testing.SimpleResponse{}, nil
+			return &grpc_testing.SimpleResponse{Payload: &grpc_testing.Payload{
+				Body: make([]byte, 10000),
+			}}, nil
 		},
 		FullDuplexCallF: func(stream grpc_testing.TestService_FullDuplexCallServer) error {
 			for {
@@ -282,7 +285,9 @@ func (s) TestAllMetricsOneFunction(t *testing.T) {
 	defer cancel()
 	// Make two RPC's, a unary RPC and a streaming RPC. These should cause
 	// certain metrics to be emitted.
-	if _, err := ss.Client.UnaryCall(ctx, &grpc_testing.SimpleRequest{Payload: &grpc_testing.Payload{}}); err != nil {
+	if _, err := ss.Client.UnaryCall(ctx, &grpc_testing.SimpleRequest{Payload: &grpc_testing.Payload{
+		Body: make([]byte, 10000),
+	}}, grpc.UseCompressor(gzip.Name)); err != nil {
 		t.Fatalf("Unexpected error from UnaryCall: %v", err)
 	}
 	stream, err := ss.Client.FullDuplexCall(ctx)
@@ -481,7 +486,7 @@ func (s) TestAllMetricsOneFunction(t *testing.T) {
 						},
 						Data: &view.DistributionData{
 							Count:          1,
-							CountPerBucket: []int64{1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+							CountPerBucket: []int64{0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
 						},
 					},
 					{
@@ -555,7 +560,7 @@ func (s) TestAllMetricsOneFunction(t *testing.T) {
 						},
 						Data: &view.DistributionData{
 							Count:          1,
-							CountPerBucket: []int64{1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+							CountPerBucket: []int64{0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
 						},
 					},
 					{
@@ -629,7 +634,7 @@ func (s) TestAllMetricsOneFunction(t *testing.T) {
 						},
 						Data: &view.DistributionData{
 							Count:          1,
-							CountPerBucket: []int64{1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+							CountPerBucket: []int64{0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
 						},
 					},
 					{
@@ -703,7 +708,7 @@ func (s) TestAllMetricsOneFunction(t *testing.T) {
 						},
 						Data: &view.DistributionData{
 							Count:          1,
-							CountPerBucket: []int64{1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+							CountPerBucket: []int64{0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
 						},
 					},
 					{

--- a/stats/opencensus/server_metrics.go
+++ b/stats/opencensus/server_metrics.go
@@ -31,12 +31,14 @@ var (
 // server side, the per rpc unit is truly per rpc, as there is no concept of a
 // rpc attempt server side.
 var (
-	serverReceivedMessagesPerRPC = stats.Int64("grpc.io/server/received_messages_per_rpc", "Number of messages received in each RPC. Has value 1 for non-streaming RPCs.", stats.UnitDimensionless) // the collection/measurement point of this measure handles the /rpc aspect of it
-	serverReceivedBytesPerRPC    = stats.Int64("grpc.io/server/received_bytes_per_rpc", "Total bytes received across all messages per RPC.", stats.UnitBytes)
-	serverSentMessagesPerRPC     = stats.Int64("grpc.io/server/sent_messages_per_rpc", "Number of messages sent in each RPC. Has value 1 for non-streaming RPCs.", stats.UnitDimensionless)
-	serverSentBytesPerRPC        = stats.Int64("grpc.io/server/sent_bytes_per_rpc", "Total bytes sent in across all response messages per RPC.", stats.UnitBytes)
-	serverStartedRPCs            = stats.Int64("grpc.io/server/started_rpcs", "The total number of server RPCs ever opened, including those that have not completed.", stats.UnitDimensionless)
-	serverLatency                = stats.Float64("grpc.io/server/server_latency", "Time between first byte of request received to last byte of response sent, or terminal error.", stats.UnitMilliseconds)
+	serverReceivedMessagesPerRPC        = stats.Int64("grpc.io/server/received_messages_per_rpc", "Number of messages received in each RPC. Has value 1 for non-streaming RPCs.", stats.UnitDimensionless) // the collection/measurement point of this measure handles the /rpc aspect of it
+	serverReceivedBytesPerRPC           = stats.Int64("grpc.io/server/received_bytes_per_rpc", "Total bytes received across all messages per RPC.", stats.UnitBytes)
+	serverReceivedCompressedBytesPerRPC = stats.Int64("grpc.io/server/received_compressed_bytes_per_rpc", "Total compressed bytes received across all messages per RPC.", stats.UnitBytes)
+	serverSentMessagesPerRPC            = stats.Int64("grpc.io/server/sent_messages_per_rpc", "Number of messages sent in each RPC. Has value 1 for non-streaming RPCs.", stats.UnitDimensionless)
+	serverSentBytesPerRPC               = stats.Int64("grpc.io/server/sent_bytes_per_rpc", "Total bytes sent in across all response messages per RPC.", stats.UnitBytes)
+	serverSentCompressedBytesPerRPC     = stats.Int64("grpc.io/server/sent_compressed_bytes_per_rpc", "Total compressed bytes sent in across all response messages per RPC.", stats.UnitBytes)
+	serverStartedRPCs                   = stats.Int64("grpc.io/server/started_rpcs", "The total number of server RPCs ever opened, including those that have not completed.", stats.UnitDimensionless)
+	serverLatency                       = stats.Float64("grpc.io/server/server_latency", "Time between first byte of request received to last byte of response sent, or terminal error.", stats.UnitMilliseconds)
 )
 
 var (
@@ -61,9 +63,18 @@ var (
 	// ServerSentBytesPerRPCView is the distribution of received bytes per RPC,
 	// keyed on method.
 	ServerSentBytesPerRPCView = &view.View{
-		Name:        "grpc.io/server/sent_bytes_per_rpc",
+		Name:        "grpc.io/server/sent_compressed_bytes_per_rpc",
 		Description: "Distribution of sent bytes per RPC, by method.",
 		Measure:     serverSentBytesPerRPC,
+		TagKeys:     []tag.Key{keyServerMethod},
+		Aggregation: bytesDistribution,
+	}
+	// ServerSentCompressedBytesPerRPCView is the distribution of received
+	// compressed bytes per RPC, keyed on method.
+	ServerSentCompressedBytesPerRPCView = &view.View{
+		Name:        "grpc.io/server/sent_bytes_per_rpc",
+		Description: "Distribution of sent compressed bytes per RPC, by method.",
+		Measure:     serverSentCompressedBytesPerRPC,
 		TagKeys:     []tag.Key{keyServerMethod},
 		Aggregation: bytesDistribution,
 	}
@@ -73,6 +84,15 @@ var (
 		Name:        "grpc.io/server/received_bytes_per_rpc",
 		Description: "Distribution of received bytes per RPC, by method.",
 		Measure:     serverReceivedBytesPerRPC,
+		TagKeys:     []tag.Key{keyServerMethod},
+		Aggregation: bytesDistribution,
+	}
+	// ServerReceivedCompressedBytesPerRPCView is the distribution of sent bytes
+	// per RPC, keyed on method.
+	ServerReceivedCompressedBytesPerRPCView = &view.View{
+		Name:        "grpc.io/server/received_compressed_bytes_per_rpc",
+		Description: "Distribution of received compressed bytes per RPC, by method.",
+		Measure:     serverReceivedCompressedBytesPerRPC,
 		TagKeys:     []tag.Key{keyServerMethod},
 		Aggregation: bytesDistribution,
 	}

--- a/stats/opencensus/trace.go
+++ b/stats/opencensus/trace.go
@@ -100,10 +100,10 @@ func populateSpan(ctx context.Context, rs stats.RPCStats, ti *traceInfo) {
 		// message id - "must be calculated as two different counters starting
 		// from 1 one for sent messages and one for received messages."
 		mi := atomic.AddUint32(&ti.countRecvMsg, 1)
-		span.AddMessageReceiveEvent(int64(mi), int64(rs.Length), int64(rs.WireLength))
+		span.AddMessageReceiveEvent(int64(mi), int64(rs.Length), int64(rs.CompressedLength))
 	case *stats.OutPayload:
 		mi := atomic.AddUint32(&ti.countSentMsg, 1)
-		span.AddMessageSendEvent(int64(mi), int64(rs.Length), int64(rs.WireLength))
+		span.AddMessageSendEvent(int64(mi), int64(rs.Length), int64(rs.CompressedLength))
 	case *stats.End:
 		if rs.Error != nil {
 			// "The mapping between gRPC canonical codes and OpenCensus codes

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -67,10 +67,19 @@ type InPayload struct {
 	Payload interface{}
 	// Data is the serialized message payload.
 	Data []byte
-	// Length is the length of uncompressed data.
+
+	// None of these lengths contain the transport framing bytes (HTTP/2
+	// specific).
+	// Length is the length of uncompressed data. Does not include gRPC framing
+	// bytes (1 byte compressed flag and 4 byte message length).
 	Length int
-	// WireLength is the length of data on wire (compressed, signed, encrypted).
+	// WireLength is the length of tbe compressed data, alongside gRPC framing
+	// bytes (1 byte compressed flag and 4 byte message length).
 	WireLength int
+	// CompressedLength is the length of the compressed data. Does not include
+	// gRPC framing bytes (1 byte compressed flag and 4 byte message length).
+	CompressedLength int
+
 	// RecvTime is the time when the payload is received.
 	RecvTime time.Time
 }
@@ -129,10 +138,17 @@ type OutPayload struct {
 	Payload interface{}
 	// Data is the serialized message payload.
 	Data []byte
-	// Length is the length of uncompressed data.
+	// None of these lengths contain the transport framing bytes (HTTP/2
+	// specific).
+	// Length is the length of uncompressed data. Does not include gRPC framing
+	// bytes (1 byte compressed flag and 4 byte message length).
 	Length int
-	// WireLength is the length of data on wire (compressed, signed, encrypted).
+	// WireLength is the length of tbe compressed data, alongside gRPC
+	// framing bytes (1 byte compressed flag and 4 byte message length).
 	WireLength int
+	// CompressedLength is the length of the uncompressed data. Doesn't include
+	// gRPC framing bytes (1 byte compressed flag and 4 byte message length).
+	CompressedLength int
 	// SentTime is the time when the payload is sent.
 	SentTime time.Time
 }

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -68,17 +68,16 @@ type InPayload struct {
 	// Data is the serialized message payload.
 	Data []byte
 
-	// None of these lengths contain the transport framing bytes (HTTP/2
-	// specific).
-	// Length is the length of uncompressed data. Does not include gRPC framing
-	// bytes (1 byte compressed flag and 4 byte message length).
+	// Length is the size of the uncompressed payload data. Does not include any
+	// framing (gRPC or HTTP/2).
 	Length int
-	// WireLength is the length of tbe compressed data, alongside gRPC framing
-	// bytes (1 byte compressed flag and 4 byte message length).
-	WireLength int
-	// CompressedLength is the length of the compressed data. Does not include
-	// gRPC framing bytes (1 byte compressed flag and 4 byte message length).
+	// CompressedLength is the size of the compressed payload data. Does not
+	// include any framing (gRPC or HTTP/2). Same as Length if compression not
+	// enabled.
 	CompressedLength int
+	// WireLength is the size of the compressed payload data plus gRPC framing.
+	// Does not include HTTP/2 framing.
+	WireLength int
 
 	// RecvTime is the time when the payload is received.
 	RecvTime time.Time
@@ -138,17 +137,16 @@ type OutPayload struct {
 	Payload interface{}
 	// Data is the serialized message payload.
 	Data []byte
-	// None of these lengths contain the transport framing bytes (HTTP/2
-	// specific).
-	// Length is the length of uncompressed data. Does not include gRPC framing
-	// bytes (1 byte compressed flag and 4 byte message length).
+	// Length is the size of the uncompressed payload data. Does not include any
+	// framing (gRPC or HTTP/2).
 	Length int
-	// WireLength is the length of tbe compressed data, alongside gRPC
-	// framing bytes (1 byte compressed flag and 4 byte message length).
-	WireLength int
-	// CompressedLength is the length of the uncompressed data. Doesn't include
-	// gRPC framing bytes (1 byte compressed flag and 4 byte message length).
+	// CompressedLength is the size of the compressed payload data. Does not
+	// include any framing (gRPC or HTTP/2). Same as Length if compression not
+	// enabled.
 	CompressedLength int
+	// WireLength is the size of the compressed payload data plus gRPC framing.
+	// Does not include HTTP/2 framing.
+	WireLength int
 	// SentTime is the time when the payload is sent.
 	SentTime time.Time
 }

--- a/stats/stats_test.go
+++ b/stats/stats_test.go
@@ -568,9 +568,9 @@ func checkInPayload(t *testing.T, d *gotData, e *expectedData) {
 	}
 	// Below are sanity checks that WireLength and RecvTime are populated.
 	// TODO: check values of WireLength and RecvTime.
-	if len(st.Data) > 0 && st.WireLength == 0 {
+	if len(st.Data) > 0 && st.CompressedLength == 0 {
 		t.Fatalf("st.WireLength = %v with non-empty data, want <non-zero>",
-			st.WireLength)
+			st.CompressedLength)
 	}
 	if st.RecvTime.IsZero() {
 		t.Fatalf("st.ReceivedTime = %v, want <non-zero>", st.RecvTime)

--- a/stream.go
+++ b/stream.go
@@ -1084,9 +1084,10 @@ func (a *csAttempt) recvMsg(m interface{}, payInfo *payloadInfo) (err error) {
 			RecvTime: time.Now(),
 			Payload:  m,
 			// TODO truncate large payload.
-			Data:       payInfo.uncompressedBytes,
-			WireLength: payInfo.wireLength + headerLen,
-			Length:     len(payInfo.uncompressedBytes),
+			Data:             payInfo.uncompressedBytes,
+			WireLength:       payInfo.compressedLength + headerLen,
+			CompressedLength: payInfo.compressedLength,
+			Length:           len(payInfo.uncompressedBytes),
 		})
 	}
 	if channelz.IsOn() {
@@ -1707,9 +1708,10 @@ func (ss *serverStream) RecvMsg(m interface{}) (err error) {
 				RecvTime: time.Now(),
 				Payload:  m,
 				// TODO truncate large payload.
-				Data:       payInfo.uncompressedBytes,
-				WireLength: payInfo.wireLength + headerLen,
-				Length:     len(payInfo.uncompressedBytes),
+				Data:             payInfo.uncompressedBytes,
+				Length:           len(payInfo.uncompressedBytes),
+				WireLength:       payInfo.compressedLength + headerLen,
+				CompressedLength: payInfo.compressedLength,
 			})
 		}
 	}


### PR DESCRIPTION
This PR does a few things:
* Fixes the docstrings (the docstrings for WireLength In and Out Payload were incorrect with respect to what they were recording) of InPayload and OutPayload
* Adds a new field (don't change WireLength to not break users) that records the compressed bytes of a message, not including gRPC framing bytes (1 byte compressed flag and 4 byte message length), and transport framing bytes (HTTP/2 framing headers and padding length byte if applicable and padding)
* Uses this new field to record new client and server uncompressed bytes sent/recv metrics
* Uses this new field instead of the previously used WireLength to align with the tracing specs language: "Compressed bytes: Total bytes (compressed) [sent/received] per message; does omit grpc and transport framing bytes."

RELEASE NOTES:
* stats/opencensus: Add new uncompressed bytes sent and received metrics for client and server