### PR TITLE
clusterresolver: cleanup resource resolver implementation

### DIFF
--- a/xds/internal/balancer/clusterresolver/clusterresolver.go
+++ b/xds/internal/balancer/clusterresolver/clusterresolver.go
@@ -16,7 +16,9 @@
  *
  */
 
-// Package clusterresolver contains EDS balancer implementation.
+// Package clusterresolver contains the implementation of the
+// xds_cluster_resolver_experimental LB policy which resolves endpoint addresses
+// using a list of one or more discovery mechanisms.
 package clusterresolver
 
 import (
@@ -62,12 +64,12 @@ type bb struct{}
 func (bb) Build(cc balancer.ClientConn, opts balancer.BuildOptions) balancer.Balancer {
 	priorityBuilder := balancer.Get(priority.Name)
 	if priorityBuilder == nil {
-		logger.Errorf("priority balancer is needed but not registered")
+		logger.Errorf("%q LB policy is needed but not registered", priority.Name)
 		return nil
 	}
 	priorityConfigParser, ok := priorityBuilder.(balancer.ConfigParser)
 	if !ok {
-		logger.Errorf("priority balancer builder is not a config parser")
+		logger.Errorf("%q LB policy does not implement a config parser", priority.Name)
 		return nil
 	}
 
@@ -108,15 +110,14 @@ func (bb) ParseConfig(c json.RawMessage) (serviceconfig.LoadBalancingConfig, err
 	return &cfg, nil
 }
 
-// ccUpdate wraps a clientConn update received from gRPC (pushed from the
-// xdsResolver).
+// ccUpdate wraps a clientConn update received from gRPC.
 type ccUpdate struct {
 	state balancer.ClientConnState
 	err   error
 }
 
 // scUpdate wraps a subConn update received from gRPC. This is directly passed
-// on to the child balancer.
+// on to the child policy.
 type scUpdate struct {
 	subConn balancer.SubConn
 	state   balancer.SubConnState
@@ -124,10 +125,8 @@ type scUpdate struct {
 
 type exitIdle struct{}
 
-// clusterResolverBalancer manages xdsClient and the actual EDS balancer implementation that
-// does load balancing.
-//
-// It currently has only an clusterResolverBalancer. Later, we may add fallback.
+// clusterResolverBalancer resolves endpoint addresses using a list of one or
+// more discovery mechanisms.
 type clusterResolverBalancer struct {
 	cc              balancer.ClientConn
 	bOpts           balancer.BuildOptions
@@ -150,22 +149,21 @@ type clusterResolverBalancer struct {
 	watchUpdateReceived bool
 }
 
-// handleClientConnUpdate handles a ClientConnUpdate received from gRPC. Good
-// updates lead to registration of EDS and DNS watches. Updates with error lead
-// to cancellation of existing watch and propagation of the same error to the
-// child balancer.
+// handleClientConnUpdate handles a ClientConnUpdate received from gRPC.
+//
+// A good update results in creation of endpoint resolvers for the configured
+// discovery mechanisms. An update with an error results in cancellation of any
+// existing endpoint resolution and propagation of the same to the child policy.
 func (b *clusterResolverBalancer) handleClientConnUpdate(update *ccUpdate) {
-	// We first handle errors, if any, and then proceed with handling the
-	// update, only if the status quo has changed.
 	if err := update.err; err != nil {
 		b.handleErrorFromUpdate(err, true)
 		return
 	}
 
-	b.logger.Infof("Receive update from resolver, balancer config: %v", pretty.ToJSON(update.state.BalancerConfig))
+	b.logger.Infof("Received new balancer config: %v", pretty.ToJSON(update.state.BalancerConfig))
 	cfg, _ := update.state.BalancerConfig.(*LBConfig)
 	if cfg == nil {
-		b.logger.Warningf("xds: unexpected LoadBalancingConfig type: %T", update.state.BalancerConfig)
+		b.logger.Warningf("Ignoring unsupported balancer configuration of type: %T", update.state.BalancerConfig)
 		return
 	}
 
@@ -173,23 +171,19 @@ func (b *clusterResolverBalancer) handleClientConnUpdate(update *ccUpdate) {
 	b.configRaw = update.state.ResolverState.ServiceConfig
 	b.resourceWatcher.updateMechanisms(cfg.DiscoveryMechanisms)
 
+	// The child policy is created only after all configured discovery
+	// mechanisms have been successfully returned endpoints. If that is not the
+	// case, we return early.
 	if !b.watchUpdateReceived {
-		// If update was not received, wait for it.
 		return
 	}
-	// If eds resp was received before this, the child policy was created. We
-	// need to generate a new balancer config and send it to the child, because
-	// certain fields (unrelated to EDS watch) might have changed.
-	if err := b.updateChildConfig(); err != nil {
-		b.logger.Warningf("failed to update child policy config: %v", err)
-	}
+	b.updateChildConfig()
 }
 
-// handleWatchUpdate handles a watch update from the xDS Client. Good updates
-// lead to clientConn updates being invoked on the underlying child balancer.
-func (b *clusterResolverBalancer) handleWatchUpdate(update *resourceUpdate) {
+// handleResourceUpdate handles a resource update or error from the resource
+// resolver by propagating the same to the child LB policy.
+func (b *clusterResolverBalancer) handleResourceUpdate(update *resourceUpdate) {
 	if err := update.err; err != nil {
-		b.logger.Warningf("Watch error from xds-client %p: %v", b.xdsClient, err)
 		b.handleErrorFromUpdate(err, false)
 		return
 	}
@@ -197,80 +191,77 @@ func (b *clusterResolverBalancer) handleWatchUpdate(update *resourceUpdate) {
 	b.watchUpdateReceived = true
 	b.priorities = update.priorities
 
-	// A new EDS update triggers new child configs (e.g. different priorities
-	// for the priority balancer), and new addresses (the endpoints come from
-	// the EDS response).
-	if err := b.updateChildConfig(); err != nil {
-		b.logger.Warningf("failed to update child policy's balancer config: %v", err)
-	}
+	// An update from the resource resolver contains resolved endpoint addresses
+	// for all configured discovery mechanisms ordered by priority. This is used
+	// to generate configuration for the priority LB policy.
+	b.updateChildConfig()
 }
 
-// updateChildConfig builds a balancer config from eb's cached eds resp and
-// service config, and sends that to the child balancer. Note that it also
-// generates the addresses, because the endpoints come from the EDS resp.
+// updateChildConfig builds child policy configuration using endpoint addresses
+// returned by the resource resolver and child policy configuration provided by
+// parent LB policy.
 //
-// If child balancer doesn't already exist, one will be created.
-func (b *clusterResolverBalancer) updateChildConfig() error {
-	// Child was build when the first EDS resp was received, so we just build
-	// the config and addresses.
+// A child policy is created if one doesn't already exist. The newly built
+// configuration is then pushed to the child policy.
+func (b *clusterResolverBalancer) updateChildConfig() {
 	if b.child == nil {
 		b.child = newChildBalancer(b.priorityBuilder, b.cc, b.bOpts)
 	}
 
 	childCfgBytes, addrs, err := buildPriorityConfigJSON(b.priorities, b.config.XDSLBPolicy)
 	if err != nil {
-		return fmt.Errorf("failed to build priority balancer config: %v", err)
+		b.logger.Warningf("Failed to build child policy config: %v", err)
+		return
 	}
 	childCfg, err := b.priorityConfigParser.ParseConfig(childCfgBytes)
 	if err != nil {
-		return fmt.Errorf("failed to parse generated priority balancer config, this should never happen because the config is generated: %v", err)
+		b.logger.Warningf("Failed to parse child policy config. This should never happen because the config was generated: %v", err)
+		return
 	}
-	b.logger.Infof("build balancer config: %v", pretty.ToJSON(childCfg))
-	return b.child.UpdateClientConnState(balancer.ClientConnState{
+	b.logger.Infof("Built child policy config: %v", pretty.ToJSON(childCfg))
+
+	if err := b.child.UpdateClientConnState(balancer.ClientConnState{
 		ResolverState: resolver.State{
 			Addresses:     addrs,
 			ServiceConfig: b.configRaw,
 			Attributes:    b.attrsWithClient,
 		},
 		BalancerConfig: childCfg,
+	}); err != nil {
+		b.logger.Warningf("Failed to push config to child policy: %v", err)
+	}
+}
+
+// handleErrorFromUpdate handles errors from the parent LB policy and endpoint
+// resolvers. fromParent is true if error is from the parent LB policy. In both
+// cases, the error is propagated to the child policy, if one exists.
+func (b *clusterResolverBalancer) handleErrorFromUpdate(err error, fromParent bool) {
+	b.logger.Warningf("Received error: %v", err)
+
+	// A resource-not-found error from the parent LB policy means that the LDS
+	// or CDS resource was removed. This should result in endpoint resolvers
+	// being stopped here.
+	//
+	// A resource-not-found error from the EDS endpoint resolver means that the
+	// EDS resource was removed. No action needs to be taken for this, and we
+	// should continue watching the same EDS resource.
+	if fromParent && xdsresource.ErrType(err) == xdsresource.ErrorTypeResourceNotFound {
+		b.resourceWatcher.stop()
+	}
+
+	if b.child != nil {
+		b.child.ResolverError(err)
+		return
+	}
+	b.cc.UpdateState(balancer.State{
+		ConnectivityState: connectivity.TransientFailure,
+		Picker:            base.NewErrPicker(err),
 	})
 }
 
-// handleErrorFromUpdate handles both the error from parent ClientConn (from CDS
-// balancer) and the error from xds client (from the watcher). fromParent is
-// true if error is from parent ClientConn.
-//
-// If the error is connection error, it should be handled for fallback purposes.
-//
-// If the error is resource-not-found:
-// - If it's from CDS balancer (shows as a resolver error), it means LDS or CDS
-// resources were removed. The EDS watch should be canceled.
-// - If it's from xds client, it means EDS resource were removed. The EDS
-// watcher should keep watching.
-// In both cases, the sub-balancers will be receive the error.
-func (b *clusterResolverBalancer) handleErrorFromUpdate(err error, fromParent bool) {
-	b.logger.Warningf("Received error: %v", err)
-	if fromParent && xdsresource.ErrType(err) == xdsresource.ErrorTypeResourceNotFound {
-		// This is an error from the parent ClientConn (can be the parent CDS
-		// balancer), and is a resource-not-found error. This means the resource
-		// (can be either LDS or CDS) was removed. Stop the EDS watch.
-		b.resourceWatcher.stop()
-	}
-	if b.child != nil {
-		b.child.ResolverError(err)
-	} else {
-		// If eds balancer was never created, fail the RPCs with errors.
-		b.cc.UpdateState(balancer.State{
-			ConnectivityState: connectivity.TransientFailure,
-			Picker:            base.NewErrPicker(err),
-		})
-	}
-
-}
-
-// run is a long-running goroutine which handles all updates from gRPC and
-// xdsClient. All methods which are invoked directly by gRPC or xdsClient simply
-// push an update onto a channel which is read and acted upon right here.
+// run is a long-running goroutine that handles updates from gRPC and endpoint
+// resolvers. The methods handling the individual updates simply push them onto
+// a channel which is read and acted upon from here.
 func (b *clusterResolverBalancer) run() {
 	for {
 		select {
@@ -283,7 +274,7 @@ func (b *clusterResolverBalancer) run() {
 				// SubConn updates are simply handed over to the underlying
 				// child balancer.
 				if b.child == nil {
-					b.logger.Errorf("xds: received scUpdate {%+v} with no child balancer", update)
+					b.logger.Errorf("Received a SubConn update {%+v} with no child policy", update)
 					break
 				}
 				b.child.UpdateSubConnState(update.subConn, update.state)
@@ -301,9 +292,9 @@ func (b *clusterResolverBalancer) run() {
 				}
 			}
 		case u := <-b.resourceWatcher.updateChannel:
-			b.handleWatchUpdate(u)
+			b.handleResourceUpdate(u)
 
-		// Close results in cancellation of the EDS watch and closing of the
+		// Close results in stopping the endpoint resolvers and closing the
 		// underlying child policy and is the only way to exit this goroutine.
 		case <-b.closed.Done():
 			b.resourceWatcher.stop()
@@ -322,12 +313,9 @@ func (b *clusterResolverBalancer) run() {
 
 // Following are methods to implement the balancer interface.
 
-// UpdateClientConnState receives the serviceConfig (which contains the
-// clusterName to watch for in CDS) and the xdsClient object from the
-// xdsResolver.
 func (b *clusterResolverBalancer) UpdateClientConnState(state balancer.ClientConnState) error {
 	if b.closed.HasFired() {
-		b.logger.Warningf("xds: received ClientConnState {%+v} after clusterResolverBalancer was closed", state)
+		b.logger.Warningf("Received update from gRPC {%+v} after close", state)
 		return errBalancerClosed
 	}
 
@@ -347,7 +335,7 @@ func (b *clusterResolverBalancer) UpdateClientConnState(state balancer.ClientCon
 // ResolverError handles errors reported by the xdsResolver.
 func (b *clusterResolverBalancer) ResolverError(err error) {
 	if b.closed.HasFired() {
-		b.logger.Warningf("xds: received resolver error {%v} after clusterResolverBalancer was closed", err)
+		b.logger.Warningf("Received resolver error {%v} after close", err)
 		return
 	}
 	b.updateCh.Put(&ccUpdate{err: err})
@@ -356,7 +344,7 @@ func (b *clusterResolverBalancer) ResolverError(err error) {
 // UpdateSubConnState handles subConn updates from gRPC.
 func (b *clusterResolverBalancer) UpdateSubConnState(sc balancer.SubConn, state balancer.SubConnState) {
 	if b.closed.HasFired() {
-		b.logger.Warningf("xds: received subConn update {%v, %v} after clusterResolverBalancer was closed", sc, state)
+		b.logger.Warningf("Received subConn update {%v, %v} after close", sc, state)
 		return
 	}
 	b.updateCh.Put(&scUpdate{subConn: sc, state: state})

--- a/xds/internal/balancer/clusterresolver/resource_resolver.go
+++ b/xds/internal/balancer/clusterresolver/resource_resolver.go
@@ -21,7 +21,6 @@ package clusterresolver
 import (
 	"sync"
 
-	"google.golang.org/grpc/xds/internal/xdsclient"
 	"google.golang.org/grpc/xds/internal/xdsclient/xdsresource"
 )
 
@@ -32,9 +31,33 @@ type resourceUpdate struct {
 	err        error
 }
 
-type discoveryMechanism interface {
+// topLevelResolver is used by concrete endpointsResolver implementations for
+// reporting updates and errors. The `resourceResolver` type implements this
+// interface and takes appropriate actions upon receipt of updates and errors
+// from underlying concrete resolvers.
+type topLevelResolver interface {
+	onUpdate()
+	onError(error)
+}
+
+// endpointsResolver wraps the functionality to resolve a given resource name to
+// a set of endpoints. The mechanism used by concrete implementations depend on
+// the supported discovery mechanism type.
+type endpointsResolver interface {
+	// lastUpdate returns endpoint results from the most recent resolution.
+	//
+	// The type of the first return result is dependent on the resolver
+	// implementation.
+	//
+	// The second return result indicates whether the resolver was able to
+	// successfully resolve the resource name to endpoints. If set to false, the
+	// first return result is invalid and must not be used.
 	lastUpdate() (interface{}, bool)
+
+	// resolverNow triggers re-resolution of the resource.
 	resolveNow()
+
+	// stop stops resolution of the resource
 	stop()
 }
 
@@ -47,14 +70,13 @@ type discoveryMechanismKey struct {
 	name string
 }
 
-// resolverMechanismTuple is needed to keep the resolver and the discovery
-// mechanism together, because resolvers can be shared. And we need the
-// mechanism for fields like circuit breaking, LRS etc when generating the
+// discoveryMechanismAndResolver is needed to keep the resolver and the
+// discovery mechanism together, because resolvers can be shared. And we need
+// the mechanism for fields like circuit breaking, LRS etc when generating the
 // balancer config.
-type resolverMechanismTuple struct {
-	dm    DiscoveryMechanism
-	dmKey discoveryMechanismKey
-	r     discoveryMechanism
+type discoveryMechanismAndResolver struct {
+	dm DiscoveryMechanism
+	r  endpointsResolver
 
 	childNameGen *nameGenerator
 }
@@ -66,14 +88,14 @@ type resourceResolver struct {
 	// mu protects the slice and map, and content of the resolvers in the slice.
 	mu         sync.Mutex
 	mechanisms []DiscoveryMechanism
-	children   []resolverMechanismTuple
+	children   []discoveryMechanismAndResolver
 	// childrenMap's value only needs the resolver implementation (type
 	// discoveryMechanism) and the childNameGen. The other two fields are not
 	// used.
 	//
 	// TODO(cleanup): maybe we can make a new type with just the necessary
 	// fields, and use it here instead.
-	childrenMap map[discoveryMechanismKey]resolverMechanismTuple
+	childrenMap map[discoveryMechanismKey]discoveryMechanismAndResolver
 	// Each new discovery mechanism needs a child name generator to reuse child
 	// policy names. But to make sure the names across discover mechanism
 	// doesn't conflict, we need a seq ID. This ID is incremented for each new
@@ -85,7 +107,7 @@ func newResourceResolver(parent *clusterResolverBalancer) *resourceResolver {
 	return &resourceResolver{
 		parent:        parent,
 		updateChannel: make(chan *resourceUpdate, 1),
-		childrenMap:   make(map[discoveryMechanismKey]resolverMechanismTuple),
+		childrenMap:   make(map[discoveryMechanismKey]discoveryMechanismAndResolver),
 	}
 }
 
@@ -102,6 +124,21 @@ func equalDiscoveryMechanisms(a, b []DiscoveryMechanism) bool {
 	return true
 }
 
+func discoveryMechanismToKey(dm DiscoveryMechanism) discoveryMechanismKey {
+	switch dm.Type {
+	case DiscoveryMechanismTypeEDS:
+		nameToWatch := dm.EDSServiceName
+		if nameToWatch == "" {
+			nameToWatch = dm.Cluster
+		}
+		return discoveryMechanismKey{typ: dm.Type, name: nameToWatch}
+	case DiscoveryMechanismTypeLogicalDNS:
+		return discoveryMechanismKey{typ: dm.Type, name: dm.DNSHostname}
+	default:
+		return discoveryMechanismKey{}
+	}
+}
+
 func (rr *resourceResolver) updateMechanisms(mechanisms []DiscoveryMechanism) {
 	rr.mu.Lock()
 	defer rr.mu.Unlock()
@@ -109,65 +146,45 @@ func (rr *resourceResolver) updateMechanisms(mechanisms []DiscoveryMechanism) {
 		return
 	}
 	rr.mechanisms = mechanisms
-	rr.children = make([]resolverMechanismTuple, len(mechanisms))
+	rr.children = make([]discoveryMechanismAndResolver, len(mechanisms))
 	newDMs := make(map[discoveryMechanismKey]bool)
 
 	// Start one watch for each new discover mechanism {type+resource_name}.
 	for i, dm := range mechanisms {
+		dmKey := discoveryMechanismToKey(dm)
+		newDMs[dmKey] = true
+		dmAndResolver, ok := rr.childrenMap[dmKey]
+		if ok {
+			// If this is not new, keep the fields (especially childNameGen),
+			// and only update the DiscoveryMechanism.
+			//
+			// Note that the same dmKey doesn't mean the same
+			// DiscoveryMechanism. There are fields (e.g.
+			// MaxConcurrentRequests) in DiscoveryMechanism that are not copied
+			// to dmKey, we need to keep those updated.
+			dmAndResolver.dm = dm
+			rr.children[i] = dmAndResolver
+			continue
+		}
+
+		// Create resolver for a newly seen resource.
+		var resolver endpointsResolver
 		switch dm.Type {
 		case DiscoveryMechanismTypeEDS:
-			// If EDSServiceName is not set, use the cluster name as EDS service
-			// name to watch.
-			nameToWatch := dm.EDSServiceName
-			if nameToWatch == "" {
-				nameToWatch = dm.Cluster
-			}
-			dmKey := discoveryMechanismKey{typ: dm.Type, name: nameToWatch}
-			newDMs[dmKey] = true
-
-			r, ok := rr.childrenMap[dmKey]
-			if !ok {
-				r = resolverMechanismTuple{
-					dm:           dm,
-					dmKey:        dmKey,
-					r:            newEDSResolver(nameToWatch, rr.parent.xdsClient, rr),
-					childNameGen: newNameGenerator(rr.childNameGeneratorSeqID),
-				}
-				rr.childrenMap[dmKey] = r
-				rr.childNameGeneratorSeqID++
-			} else {
-				// If this is not new, keep the fields (especially
-				// childNameGen), and only update the DiscoveryMechanism.
-				//
-				// Note that the same dmKey doesn't mean the same
-				// DiscoveryMechanism. There are fields (e.g.
-				// MaxConcurrentRequests) in DiscoveryMechanism that are not
-				// copied to dmKey, we need to keep those updated.
-				r.dm = dm
-			}
-			rr.children[i] = r
+			resolver = newEDSResolver(dmKey.name, rr.parent.xdsClient, rr)
 		case DiscoveryMechanismTypeLogicalDNS:
-			// Name to resolve in DNS is the hostname, not the ClientConn
-			// target.
-			dmKey := discoveryMechanismKey{typ: dm.Type, name: dm.DNSHostname}
-			newDMs[dmKey] = true
-
-			r, ok := rr.childrenMap[dmKey]
-			if !ok {
-				r = resolverMechanismTuple{
-					dm:           dm,
-					dmKey:        dmKey,
-					r:            newDNSResolver(dm.DNSHostname, rr),
-					childNameGen: newNameGenerator(rr.childNameGeneratorSeqID),
-				}
-				rr.childrenMap[dmKey] = r
-				rr.childNameGeneratorSeqID++
-			} else {
-				r.dm = dm
-			}
-			rr.children[i] = r
+			resolver = newDNSResolver(dmKey.name, rr)
 		}
+		dmAndResolver = discoveryMechanismAndResolver{
+			dm:           dm,
+			r:            resolver,
+			childNameGen: newNameGenerator(rr.childNameGeneratorSeqID),
+		}
+		rr.childrenMap[dmKey] = dmAndResolver
+		rr.children[i] = dmAndResolver
+		rr.childNameGeneratorSeqID++
 	}
+
 	// Stop the resources that were removed.
 	for dm, r := range rr.childrenMap {
 		if !newDMs[dm] {
@@ -177,7 +194,7 @@ func (rr *resourceResolver) updateMechanisms(mechanisms []DiscoveryMechanism) {
 	}
 	// Regenerate even if there's no change in discovery mechanism, in case
 	// priority order changed.
-	rr.generate()
+	rr.generateLocked()
 }
 
 // resolveNow is typically called to trigger re-resolve of DNS. The EDS
@@ -199,7 +216,7 @@ func (rr *resourceResolver) stop() {
 	// be removed entirely, but a future use case might want to reuse the
 	// policy instead.
 	cm := rr.childrenMap
-	rr.childrenMap = make(map[discoveryMechanismKey]resolverMechanismTuple)
+	rr.childrenMap = make(map[discoveryMechanismKey]discoveryMechanismAndResolver)
 	rr.mechanisms = nil
 	rr.children = nil
 	rr.mu.Unlock()
@@ -209,13 +226,12 @@ func (rr *resourceResolver) stop() {
 	}
 }
 
-// generate collects all the updates from all the resolvers, and push the
-// combined result into the update channel. It only pushes the update when all
-// the child resolvers have received at least one update, otherwise it will
-// wait.
+// generateLocked collects updates from all resolvers. It pushes the combined
+// result on the update channel if all child resolvers have received at least
+// one update. Otherwise it returns early.
 //
 // caller must hold rr.mu.
-func (rr *resourceResolver) generate() {
+func (rr *resourceResolver) generateLocked() {
 	var ret []priorityConfig
 	for _, rDM := range rr.children {
 		u, ok := rDM.r.lastUpdate()
@@ -238,49 +254,16 @@ func (rr *resourceResolver) generate() {
 	rr.updateChannel <- &resourceUpdate{priorities: ret}
 }
 
-type edsDiscoveryMechanism struct {
-	cancel func()
-
-	update         xdsresource.EndpointsUpdate
-	updateReceived bool
+func (rr *resourceResolver) onUpdate() {
+	rr.mu.Lock()
+	rr.generateLocked()
+	rr.mu.Unlock()
 }
 
-func (er *edsDiscoveryMechanism) lastUpdate() (interface{}, bool) {
-	if !er.updateReceived {
-		return nil, false
+func (rr *resourceResolver) onError(err error) {
+	select {
+	case <-rr.updateChannel:
+	default:
 	}
-	return er.update, true
-}
-
-func (er *edsDiscoveryMechanism) resolveNow() {
-}
-
-func (er *edsDiscoveryMechanism) stop() {
-	er.cancel()
-}
-
-// newEDSResolver starts the EDS watch on the given xds client.
-func newEDSResolver(nameToWatch string, xdsc xdsclient.XDSClient, topLevelResolver *resourceResolver) *edsDiscoveryMechanism {
-	ret := &edsDiscoveryMechanism{}
-	topLevelResolver.parent.logger.Infof("EDS watch started on %v", nameToWatch)
-	cancel := xdsc.WatchEndpoints(nameToWatch, func(update xdsresource.EndpointsUpdate, err error) {
-		topLevelResolver.mu.Lock()
-		defer topLevelResolver.mu.Unlock()
-		if err != nil {
-			select {
-			case <-topLevelResolver.updateChannel:
-			default:
-			}
-			topLevelResolver.updateChannel <- &resourceUpdate{err: err}
-			return
-		}
-		ret.update = update
-		ret.updateReceived = true
-		topLevelResolver.generate()
-	})
-	ret.cancel = func() {
-		topLevelResolver.parent.logger.Infof("EDS watch canceled on %v", nameToWatch)
-		cancel()
-	}
-	return ret
+	rr.updateChannel <- &resourceUpdate{err: err}
 }

--- a/xds/internal/balancer/clusterresolver/resource_resolver.go
+++ b/xds/internal/balancer/clusterresolver/resource_resolver.go
@@ -57,7 +57,7 @@ type endpointsResolver interface {
 	// resolverNow triggers re-resolution of the resource.
 	resolveNow()
 
-	// stop stops resolution of the resource
+	// stop stops resolution of the resource.
 	stop()
 }
 

--- a/xds/internal/balancer/clusterresolver/resource_resolver_dns.go
+++ b/xds/internal/balancer/clusterresolver/resource_resolver_dns.go
@@ -20,8 +20,8 @@ package clusterresolver
 
 import (
 	"fmt"
+	"net/url"
 
-	"google.golang.org/grpc/internal/testutils"
 	"google.golang.org/grpc/resolver"
 	"google.golang.org/grpc/serviceconfig"
 )
@@ -39,27 +39,46 @@ var (
 // It implements resolver.ClientConn interface to work with the DNS resolver.
 type dnsDiscoveryMechanism struct {
 	target           string
-	topLevelResolver *resourceResolver
-	r                resolver.Resolver
+	topLevelResolver topLevelResolver
+	dnsR             resolver.Resolver
 
 	addrs          []string
 	updateReceived bool
 }
 
-func newDNSResolver(target string, topLevelResolver *resourceResolver) *dnsDiscoveryMechanism {
+// newDNSResolver creates an endpoints resolver which uses a DNS resolver under
+// the hood.
+//
+// An error in parsing the provided target string or an error in creating a DNS
+// resolver means that we will never be able to resolve the provided target
+// strings to endpoints. The topLevelResolver propagates address updates to the
+// clusterresolver LB policy **only** after it receives updates from all its
+// child resolvers. Therefore, an error here means that the topLevelResolver
+// will never send address updates to the clusterresolver LB policy.
+//
+// Calling the onError() callback will ensure that this error is
+// propagated to the child policy which eventually move the channel to
+// transient failure.
+//
+// The `dnsR` field is unset if we run into erros in this function. Therefore, a
+// nil check is required wherever we access that field.
+func newDNSResolver(target string, topLevelResolver topLevelResolver) *dnsDiscoveryMechanism {
 	ret := &dnsDiscoveryMechanism{
 		target:           target,
 		topLevelResolver: topLevelResolver,
 	}
-	r, err := newDNS(resolver.Target{Scheme: "dns", URL: *testutils.MustParseURL("dns:///" + target)}, ret, resolver.BuildOptions{})
+	u, err := url.Parse("dns:///" + target)
 	if err != nil {
-		select {
-		case <-topLevelResolver.updateChannel:
-		default:
-		}
-		topLevelResolver.updateChannel <- &resourceUpdate{err: err}
+		topLevelResolver.onError(fmt.Errorf("failed to parse dns hostname %q in clusterresolver LB policy", target))
+		return ret
 	}
-	ret.r = r
+
+	r, err := newDNS(resolver.Target{Scheme: "dns", URL: *u}, ret, resolver.BuildOptions{})
+	if err != nil {
+		topLevelResolver.onError(fmt.Errorf("failed to build DNS resolver for target %q: %v", target, err))
+		return ret
+	}
+	ret.dnsR = r
 	return ret
 }
 
@@ -71,35 +90,33 @@ func (dr *dnsDiscoveryMechanism) lastUpdate() (interface{}, bool) {
 }
 
 func (dr *dnsDiscoveryMechanism) resolveNow() {
-	dr.r.ResolveNow(resolver.ResolveNowOptions{})
+	if dr.dnsR != nil {
+		dr.dnsR.ResolveNow(resolver.ResolveNowOptions{})
+	}
 }
 
 func (dr *dnsDiscoveryMechanism) stop() {
-	dr.r.Close()
+	if dr.dnsR != nil {
+		dr.dnsR.Close()
+	}
 }
 
 // dnsDiscoveryMechanism needs to implement resolver.ClientConn interface to receive
 // updates from the real DNS resolver.
 
 func (dr *dnsDiscoveryMechanism) UpdateState(state resolver.State) error {
-	dr.topLevelResolver.mu.Lock()
-	defer dr.topLevelResolver.mu.Unlock()
 	addrs := make([]string, len(state.Addresses))
 	for i, a := range state.Addresses {
 		addrs[i] = a.Addr
 	}
 	dr.addrs = addrs
 	dr.updateReceived = true
-	dr.topLevelResolver.generate()
+	dr.topLevelResolver.onUpdate()
 	return nil
 }
 
 func (dr *dnsDiscoveryMechanism) ReportError(err error) {
-	select {
-	case <-dr.topLevelResolver.updateChannel:
-	default:
-	}
-	dr.topLevelResolver.updateChannel <- &resourceUpdate{err: err}
+	dr.topLevelResolver.onError(err)
 }
 
 func (dr *dnsDiscoveryMechanism) NewAddress(addresses []resolver.Address) {

--- a/xds/internal/balancer/clusterresolver/resource_resolver_eds.go
+++ b/xds/internal/balancer/clusterresolver/resource_resolver_eds.go
@@ -1,0 +1,64 @@
+/*
+ *
+ * Copyright 2023 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package clusterresolver
+
+import (
+	"google.golang.org/grpc/xds/internal/xdsclient/xdsresource"
+)
+
+type edsResourceWatcher interface {
+	WatchEndpoints(string, func(xdsresource.EndpointsUpdate, error)) func()
+}
+
+type edsDiscoveryMechanism struct {
+	cancel func()
+
+	update         xdsresource.EndpointsUpdate
+	updateReceived bool
+}
+
+func (er *edsDiscoveryMechanism) lastUpdate() (interface{}, bool) {
+	if !er.updateReceived {
+		return nil, false
+	}
+	return er.update, true
+}
+
+func (er *edsDiscoveryMechanism) resolveNow() {
+}
+
+func (er *edsDiscoveryMechanism) stop() {
+	er.cancel()
+}
+
+// newEDSResolver returns an implementation of the endpointsResolver interface
+// that uses EDS to resolve the given name to endpoints.
+func newEDSResolver(nameToWatch string, watcher edsResourceWatcher, topLevelResolver topLevelResolver) *edsDiscoveryMechanism {
+	ret := &edsDiscoveryMechanism{}
+	ret.cancel = watcher.WatchEndpoints(nameToWatch, func(update xdsresource.EndpointsUpdate, err error) {
+		if err != nil {
+			topLevelResolver.onError(err)
+			return
+		}
+		ret.update = update
+		ret.updateReceived = true
+		topLevelResolver.onUpdate()
+	})
+	return ret
+}

--- a/xds/internal/balancer/clusterresolver/resource_resolver_eds.go
+++ b/xds/internal/balancer/clusterresolver/resource_resolver_eds.go
@@ -19,6 +19,8 @@
 package clusterresolver
 
 import (
+	"sync"
+
 	"google.golang.org/grpc/xds/internal/xdsclient/xdsresource"
 )
 
@@ -27,13 +29,18 @@ type edsResourceWatcher interface {
 }
 
 type edsDiscoveryMechanism struct {
-	cancel func()
+	cancel           func()
+	topLevelResolver topLevelResolver
 
+	mu             sync.Mutex
 	update         xdsresource.EndpointsUpdate
 	updateReceived bool
 }
 
 func (er *edsDiscoveryMechanism) lastUpdate() (interface{}, bool) {
+	er.mu.Lock()
+	defer er.mu.Unlock()
+
 	if !er.updateReceived {
 		return nil, false
 	}
@@ -47,18 +54,24 @@ func (er *edsDiscoveryMechanism) stop() {
 	er.cancel()
 }
 
+func (er *edsDiscoveryMechanism) handleEndpointsUpdate(update xdsresource.EndpointsUpdate, err error) {
+	if err != nil {
+		er.topLevelResolver.onError(err)
+		return
+	}
+
+	er.mu.Lock()
+	er.update = update
+	er.updateReceived = true
+	er.mu.Unlock()
+
+	er.topLevelResolver.onUpdate()
+}
+
 // newEDSResolver returns an implementation of the endpointsResolver interface
 // that uses EDS to resolve the given name to endpoints.
 func newEDSResolver(nameToWatch string, watcher edsResourceWatcher, topLevelResolver topLevelResolver) *edsDiscoveryMechanism {
-	ret := &edsDiscoveryMechanism{}
-	ret.cancel = watcher.WatchEndpoints(nameToWatch, func(update xdsresource.EndpointsUpdate, err error) {
-		if err != nil {
-			topLevelResolver.onError(err)
-			return
-		}
-		ret.update = update
-		ret.updateReceived = true
-		topLevelResolver.onUpdate()
-	})
+	ret := &edsDiscoveryMechanism{topLevelResolver: topLevelResolver}
+	ret.cancel = watcher.WatchEndpoints(nameToWatch, ret.handleEndpointsUpdate)
 	return ret
 }


### PR DESCRIPTION
Summary of changes:
- Define a new `topLevelResolver` interface for the concrete resolver implementations to use
  - This ensures that the resolver implementations don't have to grab locks on the top level resolver and access internal fields.
- Rename existing interface `discoveryMechanism` to `endpointsResolver`.
  - The new name better describes the interface being implemented
  - We currently have too many other names which contain some form of `discovery mechanism` in there. So, renaming this also helps with distinguishing existing types in a better way. 
- Rename existing type `resolverMechanismTuple` to `discoveryMechanismAndResolver`
  - The new name is more descriptive and clearly indicates what it contains
  - Remove the `dmKey` field from this type as this was unused.  
- Handle errors during creation of a DNS discovery mechanism appropriately.
  - This also removes the unnecessary dependency on the `internal/testutils` package.
- Move the implementation of the EDS discovery mechanism to a separate file `resource_resolver_eds.go`
- Update comments in the main `clusterresolver` balancer implementation. Most of the comments were out of date.
- Improve log messages thrown from the main `clusterresolver` balancer implementation.

Fixes https://github.com/grpc/grpc-go/issues/6015

RELEASE NOTES: none