### PR TITLE
gcp/observability: Link logs and traces by logging Trace and Span IDs

### DIFF
--- a/gcp/observability/go.mod
+++ b/gcp/observability/go.mod
@@ -10,7 +10,7 @@ require (
 	go.opencensus.io v0.24.0
 	golang.org/x/oauth2 v0.4.0
 	google.golang.org/grpc v1.52.0
-	google.golang.org/grpc/stats/opencensus v0.0.0-20230214213552-081499f2e8a4
+	google.golang.org/grpc/stats/opencensus v0.0.0-20230222033013-5353eaa44095
 )
 
 require (
@@ -39,3 +39,5 @@ require (
 )
 
 replace google.golang.org/grpc => ../../
+
+replace google.golang.org/grpc/stats/opencensus => ../../stats/opencensus

--- a/gcp/observability/go.sum
+++ b/gcp/observability/go.sum
@@ -1056,8 +1056,6 @@ google.golang.org/genproto v0.0.0-20221202195650-67e5cbc046fd/go.mod h1:cTsE614G
 google.golang.org/genproto v0.0.0-20230110181048-76db0878b65f h1:BWUVssLB0HVOSY78gIdvk1dTVYtT1y8SBWtPYuTJ/6w=
 google.golang.org/genproto v0.0.0-20230110181048-76db0878b65f/go.mod h1:RGgjbofJ8xD9Sq1VVhDM1Vok1vRONV+rg+CjzG4SZKM=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0/go.mod h1:6Kw0yEErY5E/yWrBtf03jp27GLLJujG4z/JK95pnjjw=
-google.golang.org/grpc/stats/opencensus v0.0.0-20230214213552-081499f2e8a4 h1:JfKOhIhejpMhny1RYnvFO5QxXdVOEFSE12OSTgQvFus=
-google.golang.org/grpc/stats/opencensus v0.0.0-20230214213552-081499f2e8a4/go.mod h1:l7+BYcyrDJFQo8nh4v8h5TJ6VfQ9QGBfFqVO7xoqQzI=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=

--- a/gcp/observability/logging.go
+++ b/gcp/observability/logging.go
@@ -37,6 +37,7 @@ import (
 	"google.golang.org/grpc/internal/binarylog"
 	iblog "google.golang.org/grpc/internal/binarylog"
 	"google.golang.org/grpc/internal/grpcutil"
+	"google.golang.org/grpc/stats/opencensus"
 )
 
 var lExporter loggingExporter
@@ -336,7 +337,7 @@ func (bml *binaryMethodLogger) LogWithContext(ctx context.Context, c iblog.LogEn
 		}
 	} else {
 		// server side span, populated through stats/opencensus package.
-		if tID, sID, ok := internal.GetTraceIDAndSpanID.(func(context.Context) (trace.TraceID, trace.SpanID, bool))(ctx); ok {
+		if tID, sID, ok := opencensus.GetTraceAndSpanID(ctx); ok {
 			gcploggingEntry.Trace = "projects/" + bml.projectID + "/traces/" + fmt.Sprintf("%x", tID)
 			gcploggingEntry.SpanID = fmt.Sprintf("%x", sID)
 		}

--- a/gcp/observability/logging_test.go
+++ b/gcp/observability/logging_test.go
@@ -68,6 +68,8 @@ type fakeLoggingExporter struct {
 
 	mu      sync.Mutex
 	entries []*grpcLogEntry
+
+	idsSeen []*traceAndSpanIDString
 }
 
 func (fle *fakeLoggingExporter) EmitGcpLoggingEntry(entry gcplogging.Entry) {
@@ -76,6 +78,13 @@ func (fle *fakeLoggingExporter) EmitGcpLoggingEntry(entry gcplogging.Entry) {
 	if entry.Severity != 100 {
 		fle.t.Errorf("entry.Severity is not 100, this should be hardcoded")
 	}
+
+	ids := &traceAndSpanIDString{
+		traceID: entry.Trace,
+		spanID:  entry.SpanID,
+	}
+	fle.idsSeen = append(fle.idsSeen, ids)
+
 	grpcLogEntry, ok := entry.Payload.(*grpcLogEntry)
 	if !ok {
 		fle.t.Errorf("payload passed in isn't grpcLogEntry")

--- a/internal/binarylog/method_logger.go
+++ b/internal/binarylog/method_logger.go
@@ -59,17 +59,6 @@ type MethodLoggerWithContext interface {
 	LogWithContext(context.Context, LogEntryConfig)
 }
 
-// BinLogWithContext is a helper to pass a context to the binary logger's Log
-// function if binary logger has support. If not, it calls the log method that
-// doesn't take a context.
-func BinLogWithContext(ctx context.Context, binLogger MethodLogger, lec LogEntryConfig) {
-	if mlwc, ok := binLogger.(MethodLoggerWithContext); ok {
-		mlwc.LogWithContext(ctx, lec)
-	} else {
-		binLogger.Log(lec)
-	}
-}
-
 // TruncatingMethodLogger is a method logger that truncates headers and messages
 // based on configured fields.
 type TruncatingMethodLogger struct {

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -45,9 +45,6 @@ var (
 	// This function compares the config without rawJSON stripped, in case the
 	// there's difference in white space.
 	EqualServiceConfigForTesting func(a, b serviceconfig.Config) bool
-	// GetTraceIDAndSpanID returns the trace and span ID of the span in the
-	// context. Returns true if IDs present and false if IDs not present.
-	GetTraceIDAndSpanID interface{} // func(context.Context) (trace.TraceID, trace.SpanID, bool)
 	// GetCertificateProviderBuilder returns the registered builder for the
 	// given name. This is set by package certprovider for use from xDS
 	// bootstrap code while parsing certificate provider configs in the

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -45,6 +45,9 @@ var (
 	// This function compares the config without rawJSON stripped, in case the
 	// there's difference in white space.
 	EqualServiceConfigForTesting func(a, b serviceconfig.Config) bool
+	// GetTraceIDAndSpanID returns the trace and span ID of the span in the
+	// context. Returns true if IDs present and false if IDs not present.
+	GetTraceIDAndSpanID interface{} // func(context.Context) (trace.TraceID, trace.SpanID, bool)
 	// GetCertificateProviderBuilder returns the registered builder for the
 	// given name. This is set by package certprovider for use from xDS
 	// bootstrap code while parsing certificate provider configs in the

--- a/server.go
+++ b/server.go
@@ -1253,7 +1253,7 @@ func (s *Server) processUnaryRPC(t transport.ServerTransport, stream *transport.
 			logEntry.PeerAddr = peer.Addr
 		}
 		for _, binlog := range binlogs {
-			binlog.Log(logEntry)
+			binarylog.BinLogWithContext(ctx, binlog, logEntry)
 		}
 	}
 
@@ -1332,7 +1332,7 @@ func (s *Server) processUnaryRPC(t transport.ServerTransport, stream *transport.
 				Message: d,
 			}
 			for _, binlog := range binlogs {
-				binlog.Log(cm)
+				binarylog.BinLogWithContext(stream.Context(), binlog, cm)
 			}
 		}
 		if trInfo != nil {
@@ -1365,7 +1365,7 @@ func (s *Server) processUnaryRPC(t transport.ServerTransport, stream *transport.
 					Header: h,
 				}
 				for _, binlog := range binlogs {
-					binlog.Log(sh)
+					binarylog.BinLogWithContext(stream.Context(), binlog, sh)
 				}
 			}
 			st := &binarylog.ServerTrailer{
@@ -1373,7 +1373,7 @@ func (s *Server) processUnaryRPC(t transport.ServerTransport, stream *transport.
 				Err:     appErr,
 			}
 			for _, binlog := range binlogs {
-				binlog.Log(st)
+				binarylog.BinLogWithContext(stream.Context(), binlog, st)
 			}
 		}
 		return appErr
@@ -1415,8 +1415,8 @@ func (s *Server) processUnaryRPC(t transport.ServerTransport, stream *transport.
 				Err:     appErr,
 			}
 			for _, binlog := range binlogs {
-				binlog.Log(sh)
-				binlog.Log(st)
+				binarylog.BinLogWithContext(stream.Context(), binlog, sh)
+				binarylog.BinLogWithContext(stream.Context(), binlog, st)
 			}
 		}
 		return err
@@ -1430,8 +1430,8 @@ func (s *Server) processUnaryRPC(t transport.ServerTransport, stream *transport.
 			Message: reply,
 		}
 		for _, binlog := range binlogs {
-			binlog.Log(sh)
-			binlog.Log(sm)
+			binarylog.BinLogWithContext(stream.Context(), binlog, sh)
+			binarylog.BinLogWithContext(stream.Context(), binlog, sm)
 		}
 	}
 	if channelz.IsOn() {
@@ -1450,7 +1450,7 @@ func (s *Server) processUnaryRPC(t transport.ServerTransport, stream *transport.
 			Err:     appErr,
 		}
 		for _, binlog := range binlogs {
-			binlog.Log(st)
+			binarylog.BinLogWithContext(stream.Context(), binlog, st)
 		}
 	}
 	return err
@@ -1587,7 +1587,7 @@ func (s *Server) processStreamingRPC(t transport.ServerTransport, stream *transp
 			logEntry.PeerAddr = peer.Addr
 		}
 		for _, binlog := range ss.binlogs {
-			binlog.Log(logEntry)
+			binarylog.BinLogWithContext(stream.Context(), binlog, logEntry)
 		}
 	}
 
@@ -1666,7 +1666,7 @@ func (s *Server) processStreamingRPC(t transport.ServerTransport, stream *transp
 				Err:     appErr,
 			}
 			for _, binlog := range ss.binlogs {
-				binlog.Log(st)
+				binarylog.BinLogWithContext(stream.Context(), binlog, st)
 			}
 		}
 		// TODO: Should we log an error from WriteStatus here and below?
@@ -1684,7 +1684,7 @@ func (s *Server) processStreamingRPC(t transport.ServerTransport, stream *transp
 			Err:     appErr,
 		}
 		for _, binlog := range ss.binlogs {
-			binlog.Log(st)
+			binarylog.BinLogWithContext(stream.Context(), binlog, st)
 		}
 	}
 	return err

--- a/stats/opencensus/e2e_test.go
+++ b/stats/opencensus/e2e_test.go
@@ -1327,11 +1327,11 @@ func (s) TestSpan(t *testing.T) {
 			hasRemoteParent: false,
 		},
 	}
+	fe.mu.Lock()
+	defer fe.mu.Unlock()
 	if diff := cmp.Diff(fe.seenSpans, wantSI); diff != "" {
 		t.Fatalf("got unexpected spans, diff (-got, +want): %v", diff)
 	}
-	fe.mu.Lock()
-	defer fe.mu.Unlock()
 	if err := validateTraceAndSpanIDs(fe.seenSpans); err != nil {
 		t.Fatalf("Error in runtime data assertions: %v", err)
 	}

--- a/stats/opencensus/opencensus.go
+++ b/stats/opencensus/opencensus.go
@@ -33,10 +33,6 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-func init() {
-	internal.GetTraceIDAndSpanID = getTraceAndSpanID
-}
-
 var (
 	joinDialOptions = internal.JoinDialOptions.(func(...grpc.DialOption) grpc.DialOption)
 )
@@ -163,9 +159,9 @@ func getRPCInfo(ctx context.Context) *rpcInfo {
 	return ri
 }
 
-// getTraceAndSpanID returns the trace and span ID of the span in the context.
+// GetTraceAndSpanID returns the trace and span ID of the span in the context.
 // Returns true if IDs present and false if IDs not present.
-func getTraceAndSpanID(ctx context.Context) (trace.TraceID, trace.SpanID, bool) {
+func GetTraceAndSpanID(ctx context.Context) (trace.TraceID, trace.SpanID, bool) {
 	ri, ok := ctx.Value(rpcInfoKey{}).(*rpcInfo)
 	if !ok {
 		return [16]byte{}, [8]byte{}, false

--- a/stats/opencensus/trace.go
+++ b/stats/opencensus/trace.go
@@ -40,6 +40,8 @@ type traceInfo struct {
 func (csh *clientStatsHandler) traceTagRPC(ctx context.Context, rti *stats.RPCTagInfo) (context.Context, *traceInfo) {
 	// TODO: get consensus on whether this method name of "s.m" is correct.
 	mn := "Attempt." + strings.Replace(removeLeadingSlash(rti.FullMethodName), "/", ".", -1)
+	// Returned context is ignored because will populate context with data
+	// that wraps the span instead.
 	_, span := trace.StartSpan(ctx, mn, trace.WithSampler(csh.to.TS), trace.WithSpanKind(trace.SpanKindClient))
 
 	tcBin := propagation.Binary(span.SpanContext())

--- a/stream.go
+++ b/stream.go
@@ -352,7 +352,7 @@ func newClientStreamWithParams(ctx context.Context, desc *StreamDesc, cc *Client
 			}
 		}
 		for _, binlog := range cs.binlogs {
-			binlog.Log(logEntry)
+			binarylog.BinLogWithContext(cs.ctx, binlog, logEntry)
 		}
 	}
 
@@ -800,7 +800,7 @@ func (cs *clientStream) Header() (metadata.MD, error) {
 		}
 		cs.serverHeaderBinlogged = true
 		for _, binlog := range cs.binlogs {
-			binlog.Log(logEntry)
+			binarylog.BinLogWithContext(cs.ctx, binlog, logEntry)
 		}
 	}
 	return m, nil
@@ -881,7 +881,7 @@ func (cs *clientStream) SendMsg(m interface{}) (err error) {
 			Message:      data,
 		}
 		for _, binlog := range cs.binlogs {
-			binlog.Log(cm)
+			binarylog.BinLogWithContext(cs.ctx, binlog, cm)
 		}
 	}
 	return err
@@ -905,7 +905,7 @@ func (cs *clientStream) RecvMsg(m interface{}) error {
 			Message:      recvInfo.uncompressedBytes,
 		}
 		for _, binlog := range cs.binlogs {
-			binlog.Log(sm)
+			binarylog.BinLogWithContext(cs.ctx, binlog, sm)
 		}
 	}
 	if err != nil || !cs.desc.ServerStreams {
@@ -926,7 +926,7 @@ func (cs *clientStream) RecvMsg(m interface{}) error {
 				logEntry.PeerAddr = peer.Addr
 			}
 			for _, binlog := range cs.binlogs {
-				binlog.Log(logEntry)
+				binarylog.BinLogWithContext(cs.ctx, binlog, logEntry)
 			}
 		}
 	}
@@ -953,7 +953,7 @@ func (cs *clientStream) CloseSend() error {
 			OnClientSide: true,
 		}
 		for _, binlog := range cs.binlogs {
-			binlog.Log(chc)
+			binarylog.BinLogWithContext(cs.ctx, binlog, chc)
 		}
 	}
 	// We never returned an error here for reasons.
@@ -995,7 +995,7 @@ func (cs *clientStream) finish(err error) {
 			OnClientSide: true,
 		}
 		for _, binlog := range cs.binlogs {
-			binlog.Log(c)
+			binarylog.BinLogWithContext(cs.ctx, binlog, c)
 		}
 	}
 	if err == nil {
@@ -1563,7 +1563,7 @@ func (ss *serverStream) SendHeader(md metadata.MD) error {
 		}
 		ss.serverHeaderBinlogged = true
 		for _, binlog := range ss.binlogs {
-			binlog.Log(sh)
+			binarylog.BinLogWithContext(ss.ctx, binlog, sh)
 		}
 	}
 	return err
@@ -1636,14 +1636,14 @@ func (ss *serverStream) SendMsg(m interface{}) (err error) {
 			}
 			ss.serverHeaderBinlogged = true
 			for _, binlog := range ss.binlogs {
-				binlog.Log(sh)
+				binarylog.BinLogWithContext(ss.ctx, binlog, sh)
 			}
 		}
 		sm := &binarylog.ServerMessage{
 			Message: data,
 		}
 		for _, binlog := range ss.binlogs {
-			binlog.Log(sm)
+			binarylog.BinLogWithContext(ss.ctx, binlog, sm)
 		}
 	}
 	if len(ss.statsHandler) != 0 {
@@ -1691,7 +1691,7 @@ func (ss *serverStream) RecvMsg(m interface{}) (err error) {
 			if len(ss.binlogs) != 0 {
 				chc := &binarylog.ClientHalfClose{}
 				for _, binlog := range ss.binlogs {
-					binlog.Log(chc)
+					binarylog.BinLogWithContext(ss.ctx, binlog, chc)
 				}
 			}
 			return err
@@ -1718,7 +1718,7 @@ func (ss *serverStream) RecvMsg(m interface{}) (err error) {
 			Message: payInfo.uncompressedBytes,
 		}
 		for _, binlog := range ss.binlogs {
-			binlog.Log(cm)
+			binarylog.BinLogWithContext(ss.ctx, binlog, cm)
 		}
 	}
 	return nil


### PR DESCRIPTION
This PR links logs and traces. Client Logs will contain the top level Call Span corresponding to RPC, Server Logs will contain the Server Span corresponding to RPC. This is done through a new optional binary logging interface that takes a context being declared, and switching the calls to binarylog.Log in the codebase to call the new optional interface if applicable. Note that binary loggers should take a context for logs, in order to wrap blocking operations such as reads and writes to file system with a context.

RELEASE NOTES:
* gcp/observability: Link logs and traces by logging Trace and Span IDs