### PR TITLE
internal/transport: Fix flaky keep alive test

### DIFF
--- a/internal/transport/keepalive_test.go
+++ b/internal/transport/keepalive_test.go
@@ -363,6 +363,7 @@ func (s) TestKeepaliveClientStaysHealthyWithResponsiveServer(t *testing.T) {
 	server, client, cancel := setUpWithOptions(t, 0,
 		&ServerConfig{
 			KeepalivePolicy: keepalive.EnforcementPolicy{
+				MinTime: 50 * time.Millisecond,
 				PermitWithoutStream: true,
 			},
 		},

--- a/internal/transport/keepalive_test.go
+++ b/internal/transport/keepalive_test.go
@@ -363,7 +363,7 @@ func (s) TestKeepaliveClientStaysHealthyWithResponsiveServer(t *testing.T) {
 	server, client, cancel := setUpWithOptions(t, 0,
 		&ServerConfig{
 			KeepalivePolicy: keepalive.EnforcementPolicy{
-				MinTime: 50 * time.Millisecond,
+				MinTime:             50 * time.Millisecond,
 				PermitWithoutStream: true,
 			},
 		},


### PR DESCRIPTION
This PR fixes the flaky keep alive test. This test would flake since the MinTime configuration set on the server used the default of 5 times, so it would count the client pings after the first (configured to send every second) as a ping strike, which once it hit 3 (why race was infrequent - right on the 4s line that time.Sleep is sleeping for in test) would cause a GO_AWAY to be sent, closing the connection.

Verified on google3 with 10k runs.

RELEASE NOTES: N/A