### PR TITLE
channelz: use protocmp.Transform() to compare protos

### DIFF
--- a/channelz/service/service_sktopt_test.go
+++ b/channelz/service/service_sktopt_test.go
@@ -32,13 +32,13 @@ import (
 	"testing"
 
 	"github.com/golang/protobuf/ptypes"
-	durpb "github.com/golang/protobuf/ptypes/duration"
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"golang.org/x/sys/unix"
-	channelzpb "google.golang.org/grpc/channelz/grpc_channelz_v1"
 	"google.golang.org/grpc/internal/channelz"
 	"google.golang.org/protobuf/testing/protocmp"
+
+	durpb "github.com/golang/protobuf/ptypes/duration"
+	channelzpb "google.golang.org/grpc/channelz/grpc_channelz_v1"
 )
 
 func init() {
@@ -153,7 +153,7 @@ func (s) TestGetSocketOptions(t *testing.T) {
 	for i, s := range ss {
 		resp, _ := svr.GetSocket(ctx, &channelzpb.GetSocketRequest{SocketId: ids[i].Int()})
 		got, want := resp.GetSocket().GetRef(), &channelzpb.SocketRef{SocketId: ids[i].Int(), Name: strconv.Itoa(i)}
-		if !cmp.Equal(got, want, cmpopts.IgnoreUnexported(channelzpb.SocketRef{})) {
+		if !cmp.Equal(got, want, protocmp.Transform()) {
 			t.Fatalf("resp.GetSocket() returned metrics.GetRef() = %#v, want %#v", got, want)
 		}
 		socket, err := socketProtoToStruct(resp.GetSocket())

--- a/channelz/service/service_test.go
+++ b/channelz/service/service_test.go
@@ -30,13 +30,13 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	channelzpb "google.golang.org/grpc/channelz/grpc_channelz_v1"
 	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/internal/channelz"
 	"google.golang.org/grpc/internal/grpctest"
 	"google.golang.org/protobuf/testing/protocmp"
+
+	channelzpb "google.golang.org/grpc/channelz/grpc_channelz_v1"
 )
 
 func init() {
@@ -748,7 +748,7 @@ func (s) TestGetSocket(t *testing.T) {
 	for i, s := range ss {
 		resp, _ := svr.GetSocket(ctx, &channelzpb.GetSocketRequest{SocketId: ids[i].Int()})
 		got, want := resp.GetSocket().GetRef(), &channelzpb.SocketRef{SocketId: ids[i].Int(), Name: strconv.Itoa(i)}
-		if !cmp.Equal(got, want, cmpopts.IgnoreUnexported(channelzpb.SocketRef{})) {
+		if !cmp.Equal(got, want, protocmp.Transform()) {
 			t.Fatalf("resp.GetSocket() returned metrics.GetRef() = %#v, want %#v", got, want)
 		}
 		socket, err := socketProtoToStruct(resp.GetSocket())


### PR DESCRIPTION
Code in google3 panics when `cmpopts.IgnoreUnexported` is used for protos instead of `protocmp.Transform`. The internal version of the `cmp` package is smarter. See [here](https://g3doc.corp.google.com/third_party/golang/cmp/g3doc/protocmp.md?cl=head).

RELEASE NOTES: none