### PR TITLE
xdsclient: move tests from `e2e_test` to `tests` directory

### DIFF
--- a/xds/internal/xdsclient/tests/authority_test.go
+++ b/xds/internal/xdsclient/tests/authority_test.go
@@ -16,7 +16,7 @@
  *
  */
 
-package e2e_test
+package xdsclient_test
 
 import (
 	"context"

--- a/xds/internal/xdsclient/tests/cds_watchers_test.go
+++ b/xds/internal/xdsclient/tests/cds_watchers_test.go
@@ -16,7 +16,7 @@
  *
  */
 
-package e2e_test
+package xdsclient_test
 
 import (
 	"context"

--- a/xds/internal/xdsclient/tests/dump_test.go
+++ b/xds/internal/xdsclient/tests/dump_test.go
@@ -16,7 +16,7 @@
  *
  */
 
-package e2e_test
+package xdsclient_test
 
 import (
 	"context"

--- a/xds/internal/xdsclient/tests/eds_watchers_test.go
+++ b/xds/internal/xdsclient/tests/eds_watchers_test.go
@@ -16,7 +16,7 @@
  *
  */
 
-package e2e_test
+package xdsclient_test
 
 import (
 	"context"

--- a/xds/internal/xdsclient/tests/federation_watchers_test.go
+++ b/xds/internal/xdsclient/tests/federation_watchers_test.go
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package e2e_test
+package xdsclient_test
 
 import (
 	"context"

--- a/xds/internal/xdsclient/tests/lds_watchers_test.go
+++ b/xds/internal/xdsclient/tests/lds_watchers_test.go
@@ -16,7 +16,7 @@
  *
  */
 
-package e2e_test
+package xdsclient_test
 
 import (
 	"context"

--- a/xds/internal/xdsclient/tests/misc_watchers_test.go
+++ b/xds/internal/xdsclient/tests/misc_watchers_test.go
@@ -16,7 +16,7 @@
  *
  */
 
-package e2e_test
+package xdsclient_test
 
 import (
 	"context"

--- a/xds/internal/xdsclient/tests/rds_watchers_test.go
+++ b/xds/internal/xdsclient/tests/rds_watchers_test.go
@@ -16,7 +16,7 @@
  *
  */
 
-package e2e_test
+package xdsclient_test
 
 import (
 	"context"

--- a/xds/internal/xdsclient/tests/resource_update_test.go
+++ b/xds/internal/xdsclient/tests/resource_update_test.go
@@ -16,7 +16,7 @@
  *
  */
 
-package e2e_test
+package xdsclient_test
 
 import (
 	"context"


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc-go/issues/5771

This was raised during one of the code reviews when these tests were rewritten. The idea being, we should try to use the term `e2e_tests` for gRPC-level end to end tests, and not for package level end to end tests.

RELEASE NOTES: none