### PR TITLE
grpc: Log server trailers before writing status

### DIFF
--- a/server.go
+++ b/server.go
@@ -1443,7 +1443,6 @@ func (s *Server) processUnaryRPC(t transport.ServerTransport, stream *transport.
 	// TODO: Should we be logging if writing status failed here, like above?
 	// Should the logging be in WriteStatus?  Should we ignore the WriteStatus
 	// error or allow the stats handler to see it?
-	err = t.WriteStatus(stream, statusOK)
 	if len(binlogs) != 0 {
 		st := &binarylog.ServerTrailer{
 			Trailer: stream.Trailer(),
@@ -1453,7 +1452,7 @@ func (s *Server) processUnaryRPC(t transport.ServerTransport, stream *transport.
 			binlog.Log(st)
 		}
 	}
-	return err
+	return t.WriteStatus(stream, statusOK)
 }
 
 // chainStreamServerInterceptors chains all stream server interceptors into one.
@@ -1659,7 +1658,6 @@ func (s *Server) processStreamingRPC(t transport.ServerTransport, stream *transp
 			ss.trInfo.tr.SetError()
 			ss.mu.Unlock()
 		}
-		t.WriteStatus(ss.s, appStatus)
 		if len(ss.binlogs) != 0 {
 			st := &binarylog.ServerTrailer{
 				Trailer: ss.s.Trailer(),
@@ -1669,6 +1667,7 @@ func (s *Server) processStreamingRPC(t transport.ServerTransport, stream *transp
 				binlog.Log(st)
 			}
 		}
+		t.WriteStatus(ss.s, appStatus)
 		// TODO: Should we log an error from WriteStatus here and below?
 		return appErr
 	}
@@ -1677,7 +1676,6 @@ func (s *Server) processStreamingRPC(t transport.ServerTransport, stream *transp
 		ss.trInfo.tr.LazyLog(stringer("OK"), false)
 		ss.mu.Unlock()
 	}
-	err = t.WriteStatus(ss.s, statusOK)
 	if len(ss.binlogs) != 0 {
 		st := &binarylog.ServerTrailer{
 			Trailer: ss.s.Trailer(),
@@ -1687,7 +1685,7 @@ func (s *Server) processStreamingRPC(t transport.ServerTransport, stream *transp
 			binlog.Log(st)
 		}
 	}
-	return err
+	return t.WriteStatus(ss.s, statusOK)
 }
 
 func (s *Server) handleStream(t transport.ServerTransport, stream *transport.Stream, trInfo *traceInfo) {


### PR DESCRIPTION
Fixes #5785
Fixes #5815

Before fix: Test/GlobalBinaryLoggingOptions failed 7/10k runs in forge. After fix: 0 failures. (observability test couldn't be reproduced in Forge as per Arvind, but the missing log entry in those tests is the ServerTrailer logging atom, so should be fixed as well).

This PR switches the binary logging call of the server trailer to occur before writing the status. This is to guarantee that when a server logs a server trailer it will happen before the RPC "completes" client side (i.e. returns).

RELEASE NOTES: N/A