### PR TITLE
credentials/alts: defer ALTS stream creation until handshake time

### DIFF
--- a/credentials/alts/internal/handshaker/handshaker.go
+++ b/credentials/alts/internal/handshaker/handshaker.go
@@ -43,7 +43,7 @@ const (
 	rekeyRecordProtocolName = "ALTSRP_GCM_AES128_REKEY"
 	// maxPendingHandshakes represents the maximum number of concurrent
 	// handshakes.
-	maxPendingHandshakes = 40
+	maxPendingHandshakes = 100
 )
 
 var (

--- a/credentials/alts/internal/handshaker/handshaker.go
+++ b/credentials/alts/internal/handshaker/handshaker.go
@@ -247,8 +247,8 @@ func (h *altsHandshaker) ServerHandshake(ctx context.Context) (net.Conn, credent
 		return nil, nil, errors.New("only handshakers created using NewServerHandshaker can perform a server handshaker")
 	}
 
-        // TODO(matthewstevenson88): Change unit tests to use public APIs so
-        // that h.stream can unconditionally be set based on h.clientConn.
+	// TODO(matthewstevenson88): Change unit tests to use public APIs so
+	// that h.stream can unconditionally be set based on h.clientConn.
 	if h.stream == nil {
 		stream, err := altsgrpc.NewHandshakerServiceClient(h.clientConn).DoHandshake(ctx)
 		if err != nil {

--- a/credentials/alts/internal/handshaker/handshaker.go
+++ b/credentials/alts/internal/handshaker/handshaker.go
@@ -194,6 +194,8 @@ func (h *altsHandshaker) ClientHandshake(ctx context.Context) (net.Conn, credent
 		return nil, nil, errors.New("only handshakers created using NewClientHandshaker can perform a client handshaker")
 	}
 
+	// TODO(matthewstevenson88): Change unit tests to use public APIs so
+	// that h.stream can unconditionally be set based on h.clientConn.
 	if h.stream == nil {
 		stream, err := altsgrpc.NewHandshakerServiceClient(h.clientConn).DoHandshake(ctx)
 		if err != nil {
@@ -245,6 +247,8 @@ func (h *altsHandshaker) ServerHandshake(ctx context.Context) (net.Conn, credent
 		return nil, nil, errors.New("only handshakers created using NewServerHandshaker can perform a server handshaker")
 	}
 
+        // TODO(matthewstevenson88): Change unit tests to use public APIs so
+        // that h.stream can unconditionally be set based on h.clientConn.
 	if h.stream == nil {
 		stream, err := altsgrpc.NewHandshakerServiceClient(h.clientConn).DoHandshake(ctx)
 		if err != nil {

--- a/credentials/alts/internal/handshaker/handshaker.go
+++ b/credentials/alts/internal/handshaker/handshaker.go
@@ -182,7 +182,7 @@ func NewServerHandshaker(ctx context.Context, conn *grpc.ClientConn, c net.Conn,
 	}, nil
 }
 
-// ClientHandshake starts and completes a client ALTS handshaking for GCP. Once
+// ClientHandshake starts and completes a client ALTS handshake for GCP. Once
 // done, ClientHandshake returns a secure connection.
 func (h *altsHandshaker) ClientHandshake(ctx context.Context) (net.Conn, credentials.AuthInfo, error) {
 	if !acquire() {
@@ -233,7 +233,7 @@ func (h *altsHandshaker) ClientHandshake(ctx context.Context) (net.Conn, credent
 	return conn, authInfo, nil
 }
 
-// ServerHandshake starts and completes a server ALTS handshaking for GCP. Once
+// ServerHandshake starts and completes a server ALTS handshake for GCP. Once
 // done, ServerHandshake returns a secure connection.
 func (h *altsHandshaker) ServerHandshake(ctx context.Context) (net.Conn, credentials.AuthInfo, error) {
 	if !acquire() {

--- a/credentials/alts/internal/handshaker/handshaker_test.go
+++ b/credentials/alts/internal/handshaker/handshaker_test.go
@@ -283,3 +283,62 @@ func (s) TestPeerNotResponding(t *testing.T) {
 		t.Errorf("ClientHandshake() = %v, want %v", got, want)
 	}
 }
+
+func (s) TestNewClientHandshaker(t *testing.T) {
+	conn := testutil.NewTestConn(nil, nil)
+	clientConn := &grpc.ClientConn{}
+	opts := &ClientHandshakerOptions{}
+	hs, err := NewClientHandshaker(context.Background(), clientConn, conn, opts)
+	if err != nil {
+		t.Errorf("NextClientHandshaker returned unexpected error: %v", err)
+	}
+	altsHs := hs.(*altsHandshaker)
+	if altsHs.stream != nil {
+		t.Errorf("altsHandshaker.stream is non-nil")
+	}
+	if got, want := altsHs.conn, conn; got != want {
+		t.Errorf("altsHandshaker.conn: %v, want: %v", got, want)
+	}
+	if got, want := altsHs.clientConn, clientConn; got != want {
+		t.Errorf("altsHandshaker.clientConn: %v, want: %v", got, want)
+	}
+	if got, want := altsHs.clientOpts, opts; got != want {
+		t.Errorf("altsHandshaker.clientOpts: %v, want: %v", got, want)
+	}
+	if altsHs.serverOpts != nil {
+		t.Errorf("altsHandshaker.serverOpts is non-nil")
+	}
+	if got, want := altsHs.side, core.ClientSide; got != want {
+		t.Errorf("altsHandshaker.side: %v, want: %v", got, want)
+	}
+}
+
+func (s) TestNewServerHandshaker(t *testing.T) {
+	conn := testutil.NewTestConn(nil, nil)
+	clientConn := &grpc.ClientConn{}
+	opts := &ServerHandshakerOptions{}
+	hs, err := NewServerHandshaker(context.Background(), clientConn, conn, opts)
+	if err != nil {
+		t.Errorf("NextServerHandshaker returned unexpected error: %v", err)
+	}
+	altsHs := hs.(*altsHandshaker)
+	if altsHs.stream != nil {
+		t.Errorf("altsHandshaker.stream is non-nil")
+	}
+	if got, want := altsHs.conn, conn; got != want {
+		t.Errorf("altsHandshaker.conn: %v, want: %v", got, want)
+	}
+	if got, want := altsHs.clientConn, clientConn; got != want {
+		t.Errorf("altsHandshaker.clientConn: %v, want: %v", got, want)
+	}
+	if altsHs.clientOpts != nil {
+		t.Errorf("altsHandshaker.clientOpts is non-nil")
+	}
+	if got, want := altsHs.serverOpts, opts; got != want {
+		t.Errorf("altsHandshaker.serverOpts: %v, want: %v", got, want)
+	}
+	if got, want := altsHs.side, core.ServerSide; got != want {
+		t.Errorf("altsHandshaker.side: %v, want: %v", got, want)
+	}
+}
+

--- a/credentials/alts/internal/handshaker/handshaker_test.go
+++ b/credentials/alts/internal/handshaker/handshaker_test.go
@@ -341,4 +341,3 @@ func (s) TestNewServerHandshaker(t *testing.T) {
 		t.Errorf("altsHandshaker.side: %v, want: %v", got, want)
 	}
 }
-


### PR DESCRIPTION
The existing code creates the stream to the ALTS handshaker service before checking that we are not exceeding the max number of concurrent connections, which defeats the purpose of having the max pending handshakes cap.

~While we're here, I also lower the `maxPendingHandshakes` cap to 40, to match up with the C-core code and with the current expectations of the ALTS handshaker service. (We will be lowering this cap again in the future.)~

RELEASE NOTES: none