### PR TITLE
credentials/xds: improve error message upon SAN matching failure

### DIFF
--- a/credentials/xds/xds.go
+++ b/credentials/xds/xds.go
@@ -162,8 +162,10 @@ func (c *credsImpl) ClientHandshake(ctx context.Context, authority string, rawCo
 		}
 		// The SANs sent by the MeshCA are encoded as SPIFFE IDs. We need to
 		// only look at the SANs on the leaf cert.
-		if !hi.MatchingSANExists(certs[0]) {
-			return fmt.Errorf("SANs received in leaf certificate %+v does not match any of the accepted SANs", certs[0])
+		if cert := certs[0]; !hi.MatchingSANExists(cert) {
+			// TODO: Print the complete certificate once the x509 package
+			// supports a String() method on the Certificate type.
+			return fmt.Errorf("Received SANs {DNSNames: %v, EmailAddresses: %v, IPAddresses: %v, URIs: %v} do not match any of the accepted SANs", cert.DNSNames, cert.EmailAddresses, cert.IPAddresses, cert.URIs)
 		}
 		return nil
 	}

--- a/credentials/xds/xds_client_test.go
+++ b/credentials/xds/xds_client_test.go
@@ -476,7 +476,7 @@ func (s) TestClientCredsHandshakeFailure(t *testing.T) {
 			handshakeFunc: testServerTLSHandshake,
 			rootProvider:  makeRootProvider(t, "x509/server_ca_cert.pem"),
 			san:           "bad-san",
-			wantErr:       "does not match any of the accepted SANs",
+			wantErr:       "do not match any of the accepted SANs",
 		},
 	}
 


### PR DESCRIPTION
RELEASE NOTES: none