### PR TITLE
gcp/observability: Add compressed metrics to observability module and synchronize View data with exporter

### DIFF
--- a/gcp/observability/observability_test.go
+++ b/gcp/observability/observability_test.go
@@ -436,8 +436,6 @@ func (s) TestOpenCensusIntegration(t *testing.T) {
 		if value := fe.SeenViews["grpc.io/server/server_latency"]; value != TypeOpenCensusViewDistribution {
 			errs = append(errs, fmt.Errorf("grpc.io/server/server_latency: %s != %s", value, TypeOpenCensusViewDistribution))
 		}
-
-		// *** 4 new metrics
 		if value := fe.SeenViews["grpc.io/client/sent_compressed_bytes_per_rpc"]; value != TypeOpenCensusViewDistribution {
 			errs = append(errs, fmt.Errorf("unexpected type for grpc.io/client/sent_compressed_bytes_per_rpc: %s != %s", value, TypeOpenCensusViewDistribution))
 		}
@@ -450,8 +448,6 @@ func (s) TestOpenCensusIntegration(t *testing.T) {
 		if value := fe.SeenViews["grpc.io/server/received_compressed_bytes_per_rpc"]; value != TypeOpenCensusViewDistribution {
 			errs = append(errs, fmt.Errorf("unexpected type for grpc.io/server/received_compressed_bytes_per_rpc: %s != %s", value, TypeOpenCensusViewDistribution))
 		}
-		// ***
-
 		if fe.SeenSpans <= 0 {
 			errs = append(errs, fmt.Errorf("unexpected number of seen spans: %v <= 0", fe.SeenSpans))
 		}

--- a/gcp/observability/observability_test.go
+++ b/gcp/observability/observability_test.go
@@ -436,6 +436,22 @@ func (s) TestOpenCensusIntegration(t *testing.T) {
 		if value := fe.SeenViews["grpc.io/server/server_latency"]; value != TypeOpenCensusViewDistribution {
 			errs = append(errs, fmt.Errorf("grpc.io/server/server_latency: %s != %s", value, TypeOpenCensusViewDistribution))
 		}
+
+		// *** 4 new metrics
+		if value := fe.SeenViews["grpc.io/client/sent_compressed_bytes_per_rpc"]; value != TypeOpenCensusViewDistribution {
+			errs = append(errs, fmt.Errorf("unexpected type for grpc.io/client/sent_compressed_bytes_per_rpc: %s != %s", value, TypeOpenCensusViewDistribution))
+		}
+		if value := fe.SeenViews["grpc.io/client/received_compressed_bytes_per_rpc"]; value != TypeOpenCensusViewDistribution {
+			errs = append(errs, fmt.Errorf("unexpected type for grpc.io/client/received_compressed_bytes_per_rpc: %s != %s", value, TypeOpenCensusViewDistribution))
+		}
+		if value := fe.SeenViews["grpc.io/server/sent_compressed_bytes_per_rpc"]; value != TypeOpenCensusViewDistribution {
+			errs = append(errs, fmt.Errorf("unexpected type for grpc.io/server/sent_compressed_bytes_per_rpc: %s != %s", value, TypeOpenCensusViewDistribution))
+		}
+		if value := fe.SeenViews["grpc.io/server/received_compressed_bytes_per_rpc"]; value != TypeOpenCensusViewDistribution {
+			errs = append(errs, fmt.Errorf("unexpected type for grpc.io/server/received_compressed_bytes_per_rpc: %s != %s", value, TypeOpenCensusViewDistribution))
+		}
+		// ***
+
 		if fe.SeenSpans <= 0 {
 			errs = append(errs, fmt.Errorf("unexpected number of seen spans: %v <= 0", fe.SeenSpans))
 		}

--- a/gcp/observability/opencensus.go
+++ b/gcp/observability/opencensus.go
@@ -35,7 +35,7 @@ import (
 var (
 	// It's a variable instead of const to speed up testing
 	defaultMetricsReportingInterval = time.Second * 30
-	o11yMetrics                     = []*view.View{
+	defaultViews                    = []*view.View{
 		opencensus.ClientStartedRPCsView,
 		opencensus.ClientCompletedRPCsView,
 		opencensus.ClientRoundtripLatencyView,
@@ -119,7 +119,7 @@ func startOpenCensus(config *config) error {
 	}
 
 	if config.CloudMonitoring != nil {
-		if err := view.Register(o11yMetrics...); err != nil {
+		if err := view.Register(defaultViews...); err != nil {
 			return fmt.Errorf("failed to register observability views: %v", err)
 		}
 		view.SetReportingPeriod(defaultMetricsReportingInterval)
@@ -140,9 +140,10 @@ func stopOpenCensus() {
 	if exporter != nil {
 		internal.ClearGlobalDialOptions()
 		internal.ClearGlobalServerOptions()
-		// This Unregister call guarantees the data recorded gets sent to exporter,
-		// synchronising the view package and exporter.
-		view.Unregister(o11yMetrics...)
+		// This Unregister call guarantees the data recorded gets sent to
+		// exporter, synchronising the view package and exporter. Doesn't matter
+		// if views not registered, will be a noop if not registered.
+		view.Unregister(defaultViews...)
 		// Call these unconditionally, doesn't matter if not registered, will be
 		// a noop if not registered.
 		trace.UnregisterExporter(exporter)

--- a/gcp/observability/opencensus.go
+++ b/gcp/observability/opencensus.go
@@ -39,7 +39,7 @@ var (
 		opencensus.ClientStartedRPCsView,
 		opencensus.ClientCompletedRPCsView,
 		opencensus.ClientRoundtripLatencyView,
-		opencensus.ClientSentCompressedBytesPerRPCView, // need to add verifications for this in test
+		opencensus.ClientSentCompressedBytesPerRPCView,
 		opencensus.ClientReceivedCompressedBytesPerRPCView,
 		opencensus.ClientAPILatencyView,
 		opencensus.ServerStartedRPCsView,

--- a/stats/opencensus/server_metrics.go
+++ b/stats/opencensus/server_metrics.go
@@ -63,7 +63,7 @@ var (
 	// ServerSentBytesPerRPCView is the distribution of received bytes per RPC,
 	// keyed on method.
 	ServerSentBytesPerRPCView = &view.View{
-		Name:        "grpc.io/server/sent_compressed_bytes_per_rpc",
+		Name:        "grpc.io/server/sent_bytes_per_rpc",
 		Description: "Distribution of sent bytes per RPC, by method.",
 		Measure:     serverSentBytesPerRPC,
 		TagKeys:     []tag.Key{keyServerMethod},
@@ -72,7 +72,7 @@ var (
 	// ServerSentCompressedBytesPerRPCView is the distribution of received
 	// compressed bytes per RPC, keyed on method.
 	ServerSentCompressedBytesPerRPCView = &view.View{
-		Name:        "grpc.io/server/sent_bytes_per_rpc",
+		Name:        "grpc.io/server/sent_compressed_bytes_per_rpc",
 		Description: "Distribution of sent compressed bytes per RPC, by method.",
 		Measure:     serverSentCompressedBytesPerRPC,
 		TagKeys:     []tag.Key{keyServerMethod},


### PR DESCRIPTION
This PR adds compressed metrics to observability module, and also unregisters the views on module closure, synchronizing any recorded data with any exporters registered. It also fixes a naming bug in stats/opencensus. This was not caught in unit tests, as the unit tests in stats/opencensus verified keyed on name. However, the compression/uncompressed bytes measurements are technically correct. After this is merged I will need to get rid of go.mod import directive in gcp/observability and stats/opencensus as this fixes bug in stats/opencensus, which will create new commit hash in that package.

RELEASE NOTES:
* gcp/observability: Add compressed metrics to observability module and synchronize View data with exporter