### PR TITLE
transport: stop always closing connections when loopy returns

### DIFF
--- a/internal/transport/controlbuf.go
+++ b/internal/transport/controlbuf.go
@@ -857,7 +857,7 @@ func (l *loopyWriter) handle(i interface{}) error {
 		l.outFlowControlSizeRequestHandler(i)
 	case closeConnection:
 		// Just return a non-I/O error and run() will flush and close the
-		// conneciton.
+		// connection.
 		return ErrConnClosing
 	default:
 		return fmt.Errorf("transport: unknown control message type %T", i)

--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -444,15 +444,8 @@ func newHTTP2Client(connectCtx, ctx context.Context, addr resolver.Address, opts
 		return nil, err
 	}
 	go func() {
-		t.loopy = newLoopyWriter(clientSide, t.framer, t.controlBuf, t.bdpEst)
-		err := t.loopy.run()
-		if logger.V(logLevel) {
-			logger.Infof("transport: loopyWriter exited. Closing connection. Err: %v", err)
-		}
-		// Do not close the transport.  Let reader goroutine handle it since
-		// there might be data in the buffers.
-		t.conn.Close()
-		t.controlBuf.finish()
+		t.loopy = newLoopyWriter(clientSide, t.framer, t.controlBuf, t.bdpEst, t.conn)
+		t.loopy.run()
 		close(t.writerDone)
 	}()
 	return t, nil

--- a/internal/transport/http2_server.go
+++ b/internal/transport/http2_server.go
@@ -1347,7 +1347,7 @@ func (t *http2Server) outgoingGoAwayHandler(g *goAway) (bool, error) {
 		t.mu.Unlock()
 		t.maxStreamMu.Unlock()
 		if err := t.framer.fr.WriteGoAway(sid, g.code, g.debugData); err != nil {
-			return false, toIOError(err)
+			return false, err
 		}
 		if retErr != nil {
 			return false, retErr
@@ -1363,10 +1363,10 @@ func (t *http2Server) outgoingGoAwayHandler(g *goAway) (bool, error) {
 	// After getting the ack or timer expiration send out another GoAway this
 	// time with an ID of the max stream server intends to process.
 	if err := t.framer.fr.WriteGoAway(math.MaxUint32, http2.ErrCodeNo, []byte{}); err != nil {
-		return false, toIOError(err)
+		return false, err
 	}
 	if err := t.framer.fr.WritePing(false, goAwayPing.data); err != nil {
-		return false, toIOError(err)
+		return false, err
 	}
 	go func() {
 		timer := time.NewTimer(time.Minute)

--- a/internal/transport/http_util.go
+++ b/internal/transport/http_util.go
@@ -21,6 +21,7 @@ package transport
 import (
 	"bufio"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -330,7 +331,8 @@ func (w *bufWriter) Write(b []byte) (n int, err error) {
 		return 0, w.err
 	}
 	if w.batchSize == 0 { // Buffer has been disabled.
-		return w.conn.Write(b)
+		n, err = w.conn.Write(b)
+		return n, toIOError(err)
 	}
 	for len(b) > 0 {
 		nn := copy(w.buf[w.offset:], b)
@@ -352,8 +354,28 @@ func (w *bufWriter) Flush() error {
 		return nil
 	}
 	_, w.err = w.conn.Write(w.buf[:w.offset])
+	w.err = toIOError(w.err)
 	w.offset = 0
 	return w.err
+}
+
+type ioError struct {
+	error
+}
+
+func (i ioError) Unwrap() error {
+	return i.error
+}
+
+func isIOError(err error) bool {
+	return errors.As(err, &ioError{})
+}
+
+func toIOError(err error) error {
+	if err == nil {
+		return nil
+	}
+	return ioError{error: err}
 }
 
 type framer struct {


### PR DESCRIPTION
Fixes #6019

As discovered in #6019, closing a connection upon encountering an I/O error can result in loss of data that was sent before the connection was closed.  We previously believed that any data in the TCP connection would still be available to the reader indefinitely, but it appears that is not the case.  This change makes it so we only close the connection from the loopy writer in non-I/O error situations.  If an I/O error causes the loopy writer to exit, we don't need to close the connection, as the reader goroutine will also encounter an I/O error once it is done consuming all the data.

RELEASE NOTES:
* transport: do not close connections when we encounter I/O errors until after all data is consumed