### PR TITLE
gcp/observability: Change logging schema and set queue size limit for logs and batching delay

### DIFF
--- a/gcp/observability/exporting.go
+++ b/gcp/observability/exporting.go
@@ -21,6 +21,7 @@ package observability
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"google.golang.org/api/option"
 	"google.golang.org/grpc"
@@ -72,7 +73,7 @@ func newCloudLoggingExporter(ctx context.Context, config *config) (loggingExport
 	return &cloudLoggingExporter{
 		projectID: config.ProjectID,
 		client:    c,
-		logger:    c.Logger("microservices.googleapis.com/observability/grpc", gcplogging.CommonLabels(config.Labels)),
+		logger:    c.Logger("microservices.googleapis.com/observability/grpc", gcplogging.CommonLabels(config.Labels), gcplogging.BufferedByteLimit(1024*1024*50), gcplogging.DelayThreshold(time.Second*10)),
 	}, nil
 }
 

--- a/gcp/observability/logging_test.go
+++ b/gcp/observability/logging_test.go
@@ -231,7 +231,8 @@ func (s) TestClientRPCEventsLogAll(t *testing.T) {
 			SequenceID:  5,
 			Authority:   ss.Address,
 			Payload: payload{
-				Metadata: map[string]string{},
+				Metadata:   map[string]string{},
+				StatusCode: "OK",
 			},
 		},
 	}
@@ -319,7 +320,8 @@ func (s) TestClientRPCEventsLogAll(t *testing.T) {
 			Authority:   ss.Address,
 			SequenceID:  6,
 			Payload: payload{
-				Metadata: map[string]string{},
+				Metadata:   map[string]string{},
+				StatusCode: "OK",
 			},
 		},
 	}
@@ -438,7 +440,8 @@ func (s) TestServerRPCEventsLogAll(t *testing.T) {
 			SequenceID:  5,
 			Authority:   ss.Address,
 			Payload: payload{
-				Metadata: map[string]string{},
+				Metadata:   map[string]string{},
+				StatusCode: "OK",
 			},
 		},
 	}
@@ -525,7 +528,8 @@ func (s) TestServerRPCEventsLogAll(t *testing.T) {
 			Authority:   ss.Address,
 			SequenceID:  6,
 			Payload: payload{
-				Metadata: map[string]string{},
+				Metadata:   map[string]string{},
+				StatusCode: "OK",
 			},
 		},
 	}
@@ -745,7 +749,8 @@ func (s) TestClientRPCEventsTruncateHeaderAndMetadata(t *testing.T) {
 			SequenceID:  5,
 			Authority:   ss.Address,
 			Payload: payload{
-				Metadata: map[string]string{},
+				Metadata:   map[string]string{},
+				StatusCode: "OK",
 			},
 		},
 	}
@@ -892,7 +897,8 @@ func (s) TestPrecedenceOrderingInConfiguration(t *testing.T) {
 			SequenceID:  5,
 			Authority:   ss.Address,
 			Payload: payload{
-				Metadata: map[string]string{},
+				Metadata:   map[string]string{},
+				StatusCode: "OK",
 			},
 		},
 	}
@@ -959,7 +965,8 @@ func (s) TestPrecedenceOrderingInConfiguration(t *testing.T) {
 			Authority:   ss.Address,
 			SequenceID:  3,
 			Payload: payload{
-				Metadata: map[string]string{},
+				Metadata:   map[string]string{},
+				StatusCode: "OK",
 			},
 		},
 	}
@@ -1080,14 +1087,14 @@ func (s) TestMarshalJSON(t *testing.T) {
 		Payload: payload{
 			Metadata:      map[string]string{"header1": "value1"},
 			Timeout:       20,
-			StatusCode:    3,
+			StatusCode:    "UNKNOWN",
 			StatusMessage: "ok",
 			StatusDetails: []byte("ok"),
 			MessageLength: 3,
 			Message:       []byte("wow"),
 		},
 		Peer: address{
-			Type:    typeIPv4,
+			Type:    ipv4,
 			Address: "localhost",
 			IPPort:  16000,
 		},
@@ -1214,7 +1221,8 @@ func (s) TestMetadataTruncationAccountsKey(t *testing.T) {
 			SequenceID:  5,
 			Authority:   ss.Address,
 			Payload: payload{
-				Metadata: map[string]string{},
+				Metadata:   map[string]string{},
+				StatusCode: "OK",
 			},
 		},
 	}


### PR DESCRIPTION
This PR implements Eric logging design changes needed for Observability GA. It a. iterates on the logging schema and b. sets the queueing limit for logs (which when exceeded, logs then write to standard output) and batching delay (how often the data is sent to the backend). This is nicely outlined in the "Changes Since Public Preview" section of Eric's design document.

RELEASE NOTES:
* gcp/observability: Change logging schema and set queue size limit for logs and batching delay