### PR TITLE
stats/opencensus: Add message prefix to metrics names

### DIFF
--- a/gcp/observability/observability_test.go
+++ b/gcp/observability/observability_test.go
@@ -436,17 +436,17 @@ func (s) TestOpenCensusIntegration(t *testing.T) {
 		if value := fe.SeenViews["grpc.io/server/server_latency"]; value != TypeOpenCensusViewDistribution {
 			errs = append(errs, fmt.Errorf("grpc.io/server/server_latency: %s != %s", value, TypeOpenCensusViewDistribution))
 		}
-		if value := fe.SeenViews["grpc.io/client/sent_compressed_bytes_per_rpc"]; value != TypeOpenCensusViewDistribution {
-			errs = append(errs, fmt.Errorf("unexpected type for grpc.io/client/sent_compressed_bytes_per_rpc: %s != %s", value, TypeOpenCensusViewDistribution))
+		if value := fe.SeenViews["grpc.io/client/sent_compressed_message_bytes_per_rpc"]; value != TypeOpenCensusViewDistribution {
+			errs = append(errs, fmt.Errorf("unexpected type for grpc.io/client/sent_compressed_message_bytes_per_rpc: %s != %s", value, TypeOpenCensusViewDistribution))
 		}
-		if value := fe.SeenViews["grpc.io/client/received_compressed_bytes_per_rpc"]; value != TypeOpenCensusViewDistribution {
-			errs = append(errs, fmt.Errorf("unexpected type for grpc.io/client/received_compressed_bytes_per_rpc: %s != %s", value, TypeOpenCensusViewDistribution))
+		if value := fe.SeenViews["grpc.io/client/received_compressed_message_bytes_per_rpc"]; value != TypeOpenCensusViewDistribution {
+			errs = append(errs, fmt.Errorf("unexpected type for grpc.io/client/received_compressed_message_bytes_per_rpc: %s != %s", value, TypeOpenCensusViewDistribution))
 		}
-		if value := fe.SeenViews["grpc.io/server/sent_compressed_bytes_per_rpc"]; value != TypeOpenCensusViewDistribution {
-			errs = append(errs, fmt.Errorf("unexpected type for grpc.io/server/sent_compressed_bytes_per_rpc: %s != %s", value, TypeOpenCensusViewDistribution))
+		if value := fe.SeenViews["grpc.io/server/sent_compressed_message_bytes_per_rpc"]; value != TypeOpenCensusViewDistribution {
+			errs = append(errs, fmt.Errorf("unexpected type for grpc.io/server/sent_compressed_message_bytes_per_rpc: %s != %s", value, TypeOpenCensusViewDistribution))
 		}
-		if value := fe.SeenViews["grpc.io/server/received_compressed_bytes_per_rpc"]; value != TypeOpenCensusViewDistribution {
-			errs = append(errs, fmt.Errorf("unexpected type for grpc.io/server/received_compressed_bytes_per_rpc: %s != %s", value, TypeOpenCensusViewDistribution))
+		if value := fe.SeenViews["grpc.io/server/received_compressed_message_bytes_per_rpc"]; value != TypeOpenCensusViewDistribution {
+			errs = append(errs, fmt.Errorf("unexpected type for grpc.io/server/received_compressed_message_bytes_per_rpc: %s != %s", value, TypeOpenCensusViewDistribution))
 		}
 		if fe.SeenSpans <= 0 {
 			errs = append(errs, fmt.Errorf("unexpected number of seen spans: %v <= 0", fe.SeenSpans))

--- a/gcp/observability/opencensus.go
+++ b/gcp/observability/opencensus.go
@@ -39,13 +39,13 @@ var (
 		opencensus.ClientStartedRPCsView,
 		opencensus.ClientCompletedRPCsView,
 		opencensus.ClientRoundtripLatencyView,
-		opencensus.ClientSentCompressedBytesPerRPCView,
-		opencensus.ClientReceivedCompressedBytesPerRPCView,
+		opencensus.ClientSentCompressedMessageBytesPerRPCView,
+		opencensus.ClientReceivedCompressedMessageBytesPerRPCView,
 		opencensus.ClientAPILatencyView,
 		opencensus.ServerStartedRPCsView,
 		opencensus.ServerCompletedRPCsView,
-		opencensus.ServerSentCompressedBytesPerRPCView,
-		opencensus.ServerReceivedCompressedBytesPerRPCView,
+		opencensus.ServerSentCompressedMessageBytesPerRPCView,
+		opencensus.ServerReceivedCompressedMessageBytesPerRPCView,
 		opencensus.ServerLatencyView,
 	}
 )

--- a/stats/opencensus/client_metrics.go
+++ b/stats/opencensus/client_metrics.go
@@ -72,12 +72,12 @@ var (
 		TagKeys:     []tag.Key{keyClientMethod},
 		Aggregation: bytesDistribution,
 	}
-	// ClientSentCompressedBytesPerRPCView is the distribution of compressed
-	// sent bytes per RPC, keyed on method.
-	ClientSentCompressedBytesPerRPCView = &view.View{
+	// ClientSentCompressedMessageBytesPerRPCView is the distribution of
+	// compressed sent message bytes per RPC, keyed on method.
+	ClientSentCompressedMessageBytesPerRPCView = &view.View{
 		Measure:     clientSentCompressedBytesPerRPC,
-		Name:        "grpc.io/client/sent_compressed_bytes_per_rpc",
-		Description: "Distribution of sent compressed bytes per RPC, by method.",
+		Name:        "grpc.io/client/sent_compressed_message_bytes_per_rpc",
+		Description: "Distribution of sent compressed message bytes per RPC, by method.",
 		TagKeys:     []tag.Key{keyClientMethod},
 		Aggregation: bytesDistribution,
 	}
@@ -90,12 +90,12 @@ var (
 		TagKeys:     []tag.Key{keyClientMethod},
 		Aggregation: bytesDistribution,
 	}
-	// ClientReceivedCompressedBytesPerRPCView is the distribution of compressed
-	// received bytes per RPC, keyed on method.
-	ClientReceivedCompressedBytesPerRPCView = &view.View{
+	// ClientReceivedCompressedMessageBytesPerRPCView is the distribution of
+	// compressed received message bytes per RPC, keyed on method.
+	ClientReceivedCompressedMessageBytesPerRPCView = &view.View{
 		Measure:     clientReceivedCompressedBytesPerRPC,
-		Name:        "grpc.io/client/received_compressed_bytes_per_rpc",
-		Description: "Distribution of received compressed bytes per RPC, by method.",
+		Name:        "grpc.io/client/received_compressed_message_bytes_per_rpc",
+		Description: "Distribution of received compressed message bytes per RPC, by method.",
 		TagKeys:     []tag.Key{keyClientMethod},
 		Aggregation: bytesDistribution,
 	}

--- a/stats/opencensus/e2e_test.go
+++ b/stats/opencensus/e2e_test.go
@@ -509,7 +509,7 @@ func (s) TestAllMetricsOneFunction(t *testing.T) {
 			wantVI: &viewInformation{
 				aggType:    view.AggTypeDistribution,
 				aggBuckets: bytesDistributionBounds,
-				desc:       "Distribution of sent compressed bytes per RPC, by method.",
+				desc:       "Distribution of sent compressed message bytes per RPC, by method.",
 				tagKeys: []tag.Key{
 					cmtk,
 				},
@@ -583,7 +583,7 @@ func (s) TestAllMetricsOneFunction(t *testing.T) {
 			wantVI: &viewInformation{
 				aggType:    view.AggTypeDistribution,
 				aggBuckets: bytesDistributionBounds,
-				desc:       "Distribution of sent compressed bytes per RPC, by method.",
+				desc:       "Distribution of sent compressed message bytes per RPC, by method.",
 				tagKeys: []tag.Key{
 					smtk,
 				},
@@ -657,7 +657,7 @@ func (s) TestAllMetricsOneFunction(t *testing.T) {
 			wantVI: &viewInformation{
 				aggType:    view.AggTypeDistribution,
 				aggBuckets: bytesDistributionBounds,
-				desc:       "Distribution of received compressed bytes per RPC, by method.",
+				desc:       "Distribution of received compressed message bytes per RPC, by method.",
 				tagKeys: []tag.Key{
 					cmtk,
 				},
@@ -731,7 +731,7 @@ func (s) TestAllMetricsOneFunction(t *testing.T) {
 			wantVI: &viewInformation{
 				aggType:    view.AggTypeDistribution,
 				aggBuckets: bytesDistributionBounds,
-				desc:       "Distribution of received compressed bytes per RPC, by method.",
+				desc:       "Distribution of received compressed message bytes per RPC, by method.",
 				tagKeys: []tag.Key{
 					smtk,
 				},

--- a/stats/opencensus/e2e_test.go
+++ b/stats/opencensus/e2e_test.go
@@ -236,13 +236,13 @@ func (s) TestAllMetricsOneFunction(t *testing.T) {
 		ClientCompletedRPCsView,
 		ServerCompletedRPCsView,
 		ClientSentBytesPerRPCView,
-		ClientSentCompressedBytesPerRPCView,
+		ClientSentCompressedMessageBytesPerRPCView,
 		ServerSentBytesPerRPCView,
-		ServerSentCompressedBytesPerRPCView,
+		ServerSentCompressedMessageBytesPerRPCView,
 		ClientReceivedBytesPerRPCView,
-		ClientReceivedCompressedBytesPerRPCView,
+		ClientReceivedCompressedMessageBytesPerRPCView,
 		ServerReceivedBytesPerRPCView,
-		ServerReceivedCompressedBytesPerRPCView,
+		ServerReceivedCompressedMessageBytesPerRPCView,
 		ClientSentMessagesPerRPCView,
 		ServerSentMessagesPerRPCView,
 		ClientReceivedMessagesPerRPCView,
@@ -505,7 +505,7 @@ func (s) TestAllMetricsOneFunction(t *testing.T) {
 			},
 		},
 		{
-			metric: ClientSentCompressedBytesPerRPCView,
+			metric: ClientSentCompressedMessageBytesPerRPCView,
 			wantVI: &viewInformation{
 				aggType:    view.AggTypeDistribution,
 				aggBuckets: bytesDistributionBounds,
@@ -579,7 +579,7 @@ func (s) TestAllMetricsOneFunction(t *testing.T) {
 			},
 		},
 		{
-			metric: ServerSentCompressedBytesPerRPCView,
+			metric: ServerSentCompressedMessageBytesPerRPCView,
 			wantVI: &viewInformation{
 				aggType:    view.AggTypeDistribution,
 				aggBuckets: bytesDistributionBounds,
@@ -653,7 +653,7 @@ func (s) TestAllMetricsOneFunction(t *testing.T) {
 			},
 		},
 		{
-			metric: ClientReceivedCompressedBytesPerRPCView,
+			metric: ClientReceivedCompressedMessageBytesPerRPCView,
 			wantVI: &viewInformation{
 				aggType:    view.AggTypeDistribution,
 				aggBuckets: bytesDistributionBounds,
@@ -727,7 +727,7 @@ func (s) TestAllMetricsOneFunction(t *testing.T) {
 			},
 		},
 		{
-			metric: ServerReceivedCompressedBytesPerRPCView,
+			metric: ServerReceivedCompressedMessageBytesPerRPCView,
 			wantVI: &viewInformation{
 				aggType:    view.AggTypeDistribution,
 				aggBuckets: bytesDistributionBounds,

--- a/stats/opencensus/server_metrics.go
+++ b/stats/opencensus/server_metrics.go
@@ -69,11 +69,11 @@ var (
 		TagKeys:     []tag.Key{keyServerMethod},
 		Aggregation: bytesDistribution,
 	}
-	// ServerSentCompressedBytesPerRPCView is the distribution of received
-	// compressed bytes per RPC, keyed on method.
-	ServerSentCompressedBytesPerRPCView = &view.View{
-		Name:        "grpc.io/server/sent_compressed_bytes_per_rpc",
-		Description: "Distribution of sent compressed bytes per RPC, by method.",
+	// ServerSentCompressedMessageBytesPerRPCView is the distribution of
+	// received compressed message bytes per RPC, keyed on method.
+	ServerSentCompressedMessageBytesPerRPCView = &view.View{
+		Name:        "grpc.io/server/sent_compressed_message_bytes_per_rpc",
+		Description: "Distribution of sent compressed message bytes per RPC, by method.",
 		Measure:     serverSentCompressedBytesPerRPC,
 		TagKeys:     []tag.Key{keyServerMethod},
 		Aggregation: bytesDistribution,
@@ -87,11 +87,11 @@ var (
 		TagKeys:     []tag.Key{keyServerMethod},
 		Aggregation: bytesDistribution,
 	}
-	// ServerReceivedCompressedBytesPerRPCView is the distribution of sent bytes
-	// per RPC, keyed on method.
-	ServerReceivedCompressedBytesPerRPCView = &view.View{
-		Name:        "grpc.io/server/received_compressed_bytes_per_rpc",
-		Description: "Distribution of received compressed bytes per RPC, by method.",
+	// ServerReceivedCompressedMessageBytesPerRPCView is the distribution of
+	// sent compressed message bytes per RPC, keyed on method.
+	ServerReceivedCompressedMessageBytesPerRPCView = &view.View{
+		Name:        "grpc.io/server/received_compressed_message_bytes_per_rpc",
+		Description: "Distribution of received compressed message bytes per RPC, by method.",
 		Measure:     serverReceivedCompressedBytesPerRPC,
 		TagKeys:     []tag.Key{keyServerMethod},
 		Aggregation: bytesDistribution,


### PR DESCRIPTION
This PR adds the message prefix to certain metrics, which was an inconsistency of our repository vs. the metrics spec.

RELEASE NOTES: N/A