### PR TITLE
gcp/observability: Switch hex encoding to string() method

### DIFF
--- a/gcp/observability/logging.go
+++ b/gcp/observability/logging.go
@@ -327,14 +327,14 @@ func (bml *binaryMethodLogger) buildGCPLoggingEntry(ctx context.Context, c iblog
 		// client side span, populated through opencensus trace package.
 		if span := trace.FromContext(ctx); span != nil {
 			sc := span.SpanContext()
-			gcploggingEntry.Trace = "projects/" + bml.projectID + "/traces/" + fmt.Sprintf("%x", sc.TraceID)
-			gcploggingEntry.SpanID = fmt.Sprintf("%x", sc.SpanID)
+			gcploggingEntry.Trace = "projects/" + bml.projectID + "/traces/" + sc.TraceID.String()
+			gcploggingEntry.SpanID = sc.SpanID.String()
 		}
 	} else {
 		// server side span, populated through stats/opencensus package.
 		if tID, sID, ok := opencensus.GetTraceAndSpanID(ctx); ok {
-			gcploggingEntry.Trace = "projects/" + bml.projectID + "/traces/" + fmt.Sprintf("%x", tID)
-			gcploggingEntry.SpanID = fmt.Sprintf("%x", sID)
+			gcploggingEntry.Trace = "projects/" + bml.projectID + "/traces/" + tID.String()
+			gcploggingEntry.SpanID = sID.String()
 		}
 	}
 	return gcploggingEntry

--- a/gcp/observability/observability_test.go
+++ b/gcp/observability/observability_test.go
@@ -121,12 +121,11 @@ type traceAndSpanIDString struct {
 }
 
 // idsToString is a helper that converts from generated trace and span IDs to
-// the string version stored in trace message events. (hex 16 lowercase encoded,
-// and extra data attached to trace id).
+// the string version stored in trace message events.
 func idsToString(tasi traceAndSpanID, projectID string) traceAndSpanIDString {
 	return traceAndSpanIDString{
-		traceID: "projects/" + projectID + "/traces/" + fmt.Sprintf("%x", tasi.traceID),
-		spanID:  fmt.Sprintf("%x", tasi.spanID),
+		traceID: "projects/" + projectID + "/traces/" + tasi.traceID.String(),
+		spanID:  tasi.spanID.String(),
 	}
 }
 


### PR DESCRIPTION
This PR switches the hex encoding of trace and span ids to encode using string(). This is how the tracing exporter does it, so this keeps logging and traces correctly consistent and allows them to be linked in gcp backends.

RELEASE NOTES: N/A