### PR TITLE
CONTRIBUTING.md: remove duplicated bullet point

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,10 +20,6 @@ How to get your contributions merged smoothly and quickly.
   both author's & review's time is wasted. Create more PRs to address different
   concerns and everyone will be happy.
 
-- For speculative changes, consider opening an issue and discussing it first. If
-  you are suggesting a behavioral or API change, consider starting with a [gRFC 
-  proposal](https://github.com/grpc/proposal).
-
 - If you are searching for features to work on, issues labeled [Status: Help
   Wanted](https://github.com/grpc/grpc-go/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22Status%3A+Help+Wanted%22)
   is a great place to start. These issues are well-documented and usually can be


### PR DESCRIPTION
The bullet point list of guidelines contained a duplicated bullet point regarding speculative changes. This removes the duplicated bullet point.

RELEASE NOTES: None