### PR TITLE
stats/opencensus: remove leading slash for per call metrics

### DIFF
--- a/stats/opencensus/opencensus.go
+++ b/stats/opencensus/opencensus.go
@@ -104,7 +104,7 @@ func perCallTracesAndMetrics(err error, span *trace.Span, startTime time.Time, m
 	callLatency := float64(time.Since(startTime)) / float64(time.Millisecond)
 	ocstats.RecordWithOptions(context.Background(),
 		ocstats.WithTags(
-			tag.Upsert(keyClientMethod, method),
+			tag.Upsert(keyClientMethod, removeLeadingSlash(method)),
 			tag.Upsert(keyClientStatus, canonicalString(s.Code())),
 		),
 		ocstats.WithMeasurements(


### PR DESCRIPTION
This PR adds the removal of the leading slash when taking per call metrics (api_latency). This was speced as a team in previous observability discussions. This was causing problems in tests, which expect the leading slash to be removed.

RELEASE NOTES: N/A