### PR TITLE
status: FromError: return entire error message text for wrapped errors

### DIFF
--- a/status/status_test.go
+++ b/status/status_test.go
@@ -197,7 +197,7 @@ func (s) TestFromErrorWrapped(t *testing.T) {
 	const code, message = codes.Internal, "test description"
 	err := fmt.Errorf("wrapped error: %w", Error(code, message))
 	s, ok := FromError(err)
-	if !ok || s.Code() != code || s.Message() != message || s.Err() == nil {
+	if !ok || s.Code() != code || s.Message() != err.Error() || s.Err() == nil {
 		t.Fatalf("FromError(%v) = %v, %v; want <Code()=%s, Message()=%q, Err()!=nil>, true", err, s, ok, code, message)
 	}
 }
@@ -206,7 +206,7 @@ func (s) TestFromErrorImplementsInterfaceWrapped(t *testing.T) {
 	const code, message = codes.Internal, "test description"
 	err := fmt.Errorf("wrapped error: %w", customError{Code: code, Message: message})
 	s, ok := FromError(err)
-	if !ok || s.Code() != code || s.Message() != message || s.Err() == nil {
+	if !ok || s.Code() != code || s.Message() != err.Error() || s.Err() == nil {
 		t.Fatalf("FromError(%v) = %v, %v; want <Code()=%s, Message()=%q, Err()!=nil>, true", err, s, ok, code, message)
 	}
 }


### PR DESCRIPTION
Many users would prefer to see the entire error message along with the wrapped status's code & details, so that data is not "lost".  This change implements that preference.

I'm not convinced this is "correct" or "better", but it may be, and I wanted to discuss.

cc @psyhatter 

RELEASE NOTES:
* status: FromError: return entire error message text for wrapped errors