### PR TITLE
xds: enable XDS federation by default

### DIFF
--- a/internal/envconfig/xds.go
+++ b/internal/envconfig/xds.go
@@ -79,7 +79,7 @@ var (
 	// XDSFederation indicates whether federation support is enabled, which can
 	// be enabled by setting the environment variable
 	// "GRPC_EXPERIMENTAL_XDS_FEDERATION" to "true".
-	XDSFederation = boolFromEnv("GRPC_EXPERIMENTAL_XDS_FEDERATION", false)
+	XDSFederation = boolFromEnv("GRPC_EXPERIMENTAL_XDS_FEDERATION", true)
 
 	// XDSRLS indicates whether processing of Cluster Specifier plugins and
 	// support for the RLS CLuster Specifier is enabled, which can be enabled by

--- a/xds/internal/xdsclient/xdsresource/name_test.go
+++ b/xds/internal/xdsclient/xdsresource/name_test.go
@@ -92,13 +92,11 @@ func TestParseName(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if !tt.env {
-				defer func() func() {
-					oldEnv := envconfig.XDSFederation
-					envconfig.XDSFederation = false
-					return func() { envconfig.XDSFederation = oldEnv }
-				}()()
-			}
+			defer func() func() {
+				oldEnv := envconfig.XDSFederation
+				envconfig.XDSFederation = tt.env
+				return func() { envconfig.XDSFederation = oldEnv }
+			}()()
 			got := ParseName(tt.in)
 			if !cmp.Equal(got, tt.want, cmpopts.IgnoreFields(Name{}, "processingDirective")) {
 				t.Errorf("ParseName() = %#v, want %#v", got, tt.want)
@@ -113,10 +111,6 @@ func TestParseName(t *testing.T) {
 // TestNameStringCtxParamsOrder covers the case that if two names differ only in
 // context parameter __order__, the parsed name.String() has the same value.
 func TestNameStringCtxParamsOrder(t *testing.T) {
-	oldEnv := envconfig.XDSFederation
-	envconfig.XDSFederation = true
-	defer func() { envconfig.XDSFederation = oldEnv }()
-
 	const (
 		a = "xdstp://auth/type/id?a=1&b=2"
 		b = "xdstp://auth/type/id?b=2&a=1"

--- a/xds/internal/xdsclient/xdsresource/name_test.go
+++ b/xds/internal/xdsclient/xdsresource/name_test.go
@@ -92,10 +92,10 @@ func TestParseName(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.env {
+			if !tt.env {
 				defer func() func() {
 					oldEnv := envconfig.XDSFederation
-					envconfig.XDSFederation = true
+					envconfig.XDSFederation = false
 					return func() { envconfig.XDSFederation = oldEnv }
 				}()()
 			}


### PR DESCRIPTION
Integration tests have been green, so let's enable this (verification of recent test results in https://b.corp.google.com/issues/262593165#comment31).

cc @easwars 

RELEASE NOTES:
- federation: enable support variable by default