### PR TITLE
gcp/observability: Set the opencensus_task label only for metrics, not tracing and logging

### DIFF
--- a/gcp/observability/opencensus.go
+++ b/gcp/observability/opencensus.go
@@ -88,7 +88,7 @@ func newStackdriverExporter(config *config) (tracingMetricsExporter, error) {
 	// library, including their label that uniquely identifies the process.
 	// Thus, generate a unique process identifier here to uniquely identify
 	// process for metrics exporting to function correctly.
-	metricsLabels := make(map[string]string, len(config.Labels))
+	metricsLabels := make(map[string]string, len(config.Labels) + 1)
 	for k, v := range config.Labels {
 		metricsLabels[k] = v
 	}

--- a/gcp/observability/opencensus.go
+++ b/gcp/observability/opencensus.go
@@ -88,7 +88,7 @@ func newStackdriverExporter(config *config) (tracingMetricsExporter, error) {
 	// library, including their label that uniquely identifies the process.
 	// Thus, generate a unique process identifier here to uniquely identify
 	// process for metrics exporting to function correctly.
-	metricsLabels := make(map[string]string, len(config.Labels) + 1)
+	metricsLabels := make(map[string]string, len(config.Labels)+1)
 	for k, v := range config.Labels {
 		metricsLabels[k] = v
 	}

--- a/gcp/observability/opencensus.go
+++ b/gcp/observability/opencensus.go
@@ -88,16 +88,16 @@ func newStackdriverExporter(config *config) (tracingMetricsExporter, error) {
 	// library, including their label that uniquely identifies the process.
 	// Thus, generate a unique process identifier here to uniquely identify
 	// process for metrics exporting to function correctly.
-	traceLabels := make(map[string]string, len(config.Labels))
+	metricsLabels := make(map[string]string, len(config.Labels))
 	for k, v := range config.Labels {
-		traceLabels[k] = v
+		metricsLabels[k] = v
 	}
-	traceLabels["opencensus_task"] = generateUniqueProcessIdentifier()
+	metricsLabels["opencensus_task"] = generateUniqueProcessIdentifier()
 	exporter, err := stackdriver.NewExporter(stackdriver.Options{
 		ProjectID:               config.ProjectID,
 		MonitoredResource:       mr,
-		DefaultMonitoringLabels: labelsToMonitoringLabels(config.Labels),
-		DefaultTraceAttributes:  labelsToTraceAttributes(traceLabels),
+		DefaultMonitoringLabels: labelsToMonitoringLabels(metricsLabels),
+		DefaultTraceAttributes:  labelsToTraceAttributes(config.Labels),
 		MonitoringClientOptions: cOptsDisableLogTrace,
 		TraceClientOptions:      cOptsDisableLogTrace,
 	})

--- a/gcp/observability/opencensus.go
+++ b/gcp/observability/opencensus.go
@@ -87,13 +87,17 @@ func newStackdriverExporter(config *config) (tracingMetricsExporter, error) {
 	// Custom labels completly overwrite any labels generated in the OpenCensus
 	// library, including their label that uniquely identifies the process.
 	// Thus, generate a unique process identifier here to uniquely identify
-	// process.
-	config.Labels["opencensus_task"] = generateUniqueProcessIdentifier()
+	// process for metrics exporting to function correctly.
+	traceLabels := make(map[string]string, len(config.Labels))
+	for k, v := range config.Labels {
+		traceLabels[k] = v
+	}
+	traceLabels["opencensus_task"] = generateUniqueProcessIdentifier()
 	exporter, err := stackdriver.NewExporter(stackdriver.Options{
 		ProjectID:               config.ProjectID,
 		MonitoredResource:       mr,
 		DefaultMonitoringLabels: labelsToMonitoringLabels(config.Labels),
-		DefaultTraceAttributes:  labelsToTraceAttributes(config.Labels),
+		DefaultTraceAttributes:  labelsToTraceAttributes(traceLabels),
 		MonitoringClientOptions: cOptsDisableLogTrace,
 		TraceClientOptions:      cOptsDisableLogTrace,
 	})


### PR DESCRIPTION
Java and C++ only set this label for metrics, as this is what was causing the time series issue, which is how client libraries actually export data to backends. Go was setting it for logging, traces, and metrics.

RELEASE NOTES: N/A