### PR TITLE
stats/opencensus: Switch helper to return Span Context from context

### DIFF
--- a/interop/observability/go.mod
+++ b/interop/observability/go.mod
@@ -42,5 +42,3 @@ require (
 replace google.golang.org/grpc => ../..
 
 replace google.golang.org/grpc/gcp/observability => ../../gcp/observability
-
-replace google.golang.org/grpc/stats/opencensus => ../../stats/opencensus

--- a/interop/observability/go.sum
+++ b/interop/observability/go.sum
@@ -1305,6 +1305,8 @@ google.golang.org/genproto v0.0.0-20230222225845-10f96fb3dbec/go.mod h1:3Dl5ZL0q
 google.golang.org/genproto v0.0.0-20230306155012-7f2fa6fef1f4 h1:DdoeryqhaXp1LtT/emMP1BRJPHHKFi5akj/nbx/zNTA=
 google.golang.org/genproto v0.0.0-20230306155012-7f2fa6fef1f4/go.mod h1:NWraEVixdDnqcqQ30jipen1STv2r/n24Wb7twVTGR4s=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0/go.mod h1:6Kw0yEErY5E/yWrBtf03jp27GLLJujG4z/JK95pnjjw=
+google.golang.org/grpc/stats/opencensus v0.0.0-20230317183452-b638faff2204 h1:MeDNVH2KmQ9Z3AbXKsvU9UcbRR8LfpZVLmZAVWIX0nI=
+google.golang.org/grpc/stats/opencensus v0.0.0-20230317183452-b638faff2204/go.mod h1:Dg7VaOjf0r9QhRn/YpwSf3vKQz1ixulffTlhEarxEXA=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=

--- a/stats/opencensus/opencensus.go
+++ b/stats/opencensus/opencensus.go
@@ -166,6 +166,9 @@ func SpanContextFromContext(ctx context.Context) (trace.SpanContext, bool) {
 	if !ok {
 		return trace.SpanContext{}, false
 	}
+	if ri.ti == nil || ri.ti.span == nil {
+		return trace.SpanContext{}, false
+	}
 	sc := ri.ti.span.SpanContext()
 	return sc, true
 }

--- a/stats/opencensus/opencensus.go
+++ b/stats/opencensus/opencensus.go
@@ -159,15 +159,16 @@ func getRPCInfo(ctx context.Context) *rpcInfo {
 	return ri
 }
 
-// GetTraceAndSpanID returns the trace and span ID of the span in the context.
-// Returns true if IDs present and false if IDs not present.
-func GetTraceAndSpanID(ctx context.Context) (trace.TraceID, trace.SpanID, bool) {
+// GetTraceAndSpanIDAndIsSampled returns the trace and span ID of the span in
+// the context, and if the span is sampled. Returns true (as the last bool) if
+// IDs present and false if IDs not present.
+func GetTraceAndSpanIDAndIsSampled(ctx context.Context) (trace.TraceID, trace.SpanID, bool, bool) {
 	ri, ok := ctx.Value(rpcInfoKey{}).(*rpcInfo)
 	if !ok {
-		return trace.TraceID{}, trace.SpanID{}, false
+		return trace.TraceID{}, trace.SpanID{}, false, false
 	}
 	sc := ri.ti.span.SpanContext()
-	return sc.TraceID, sc.SpanID, true
+	return sc.TraceID, sc.SpanID, sc.IsSampled(), true
 }
 
 type clientStatsHandler struct {

--- a/stats/opencensus/opencensus.go
+++ b/stats/opencensus/opencensus.go
@@ -159,16 +159,29 @@ func getRPCInfo(ctx context.Context) *rpcInfo {
 	return ri
 }
 
-// GetTraceAndSpanIDAndIsSampled returns the trace and span ID of the span in
-// the context, and if the span is sampled. Returns true (as the last bool) if
-// IDs present and false if IDs not present.
-func GetTraceAndSpanIDAndIsSampled(ctx context.Context) (trace.TraceID, trace.SpanID, bool, bool) {
+// SpanInfo is information about a Span.
+type SpanInfo struct {
+	// TraceID is the TraceID of the Span
+	TraceID trace.TraceID
+	// SpanID is the SpanID of the Span in the context.
+	SpanID trace.SpanID
+	// IsSampled represents whether the Span was sampled or not.
+	IsSampled bool
+}
+
+// SpanInfoFromContext returns Span Information about the Span in the context.
+// Returns false if no Span in the context.
+func SpanInfoFromContext(ctx context.Context) (*SpanInfo, bool) {
 	ri, ok := ctx.Value(rpcInfoKey{}).(*rpcInfo)
 	if !ok {
-		return trace.TraceID{}, trace.SpanID{}, false, false
+		return nil, false
 	}
 	sc := ri.ti.span.SpanContext()
-	return sc.TraceID, sc.SpanID, sc.IsSampled(), true
+	return &SpanInfo{
+		TraceID:   sc.TraceID,
+		SpanID:    sc.SpanID,
+		IsSampled: sc.IsSampled(),
+	}, true
 }
 
 type clientStatsHandler struct {

--- a/stats/opencensus/opencensus.go
+++ b/stats/opencensus/opencensus.go
@@ -161,7 +161,7 @@ func getRPCInfo(ctx context.Context) *rpcInfo {
 
 // SpanContextFromContext returns the Span Context about the Span in the
 // context. Returns false if no Span in the context.
-func SpanInfoFromContext(ctx context.Context) (trace.SpanContext, bool) {
+func SpanContextFromContext(ctx context.Context) (trace.SpanContext, bool) {
 	ri, ok := ctx.Value(rpcInfoKey{}).(*rpcInfo)
 	if !ok {
 		return trace.SpanContext{}, false

--- a/stats/opencensus/opencensus.go
+++ b/stats/opencensus/opencensus.go
@@ -159,29 +159,15 @@ func getRPCInfo(ctx context.Context) *rpcInfo {
 	return ri
 }
 
-// SpanInfo is information about a Span.
-type SpanInfo struct {
-	// TraceID is the TraceID of the Span
-	TraceID trace.TraceID
-	// SpanID is the SpanID of the Span in the context.
-	SpanID trace.SpanID
-	// IsSampled represents whether the Span was sampled or not.
-	IsSampled bool
-}
-
-// SpanInfoFromContext returns Span Information about the Span in the context.
-// Returns false if no Span in the context.
-func SpanInfoFromContext(ctx context.Context) (*SpanInfo, bool) {
+// SpanContextFromContext returns the Span Context about the Span in the
+// context. Returns false if no Span in the context.
+func SpanInfoFromContext(ctx context.Context) (trace.SpanContext, bool) {
 	ri, ok := ctx.Value(rpcInfoKey{}).(*rpcInfo)
 	if !ok {
-		return nil, false
+		return trace.SpanContext{}, false
 	}
 	sc := ri.ti.span.SpanContext()
-	return &SpanInfo{
-		TraceID:   sc.TraceID,
-		SpanID:    sc.SpanID,
-		IsSampled: sc.IsSampled(),
-	}, true
+	return sc, true
 }
 
 type clientStatsHandler struct {


### PR DESCRIPTION
This PR plumbs back if the span is sampled or not in the helper observability logging calls in stats/opencensus. This is needed to connect logs to traces in the cloud ops backend.

RELEASE NOTES: N/A