### PR TITLE
draft gcp/observability: Show how to populate isSampled in logs

### DIFF
--- a/gcp/observability/logging.go
+++ b/gcp/observability/logging.go
@@ -329,12 +329,14 @@ func (bml *binaryMethodLogger) buildGCPLoggingEntry(ctx context.Context, c iblog
 			sc := span.SpanContext()
 			gcploggingEntry.Trace = "projects/" + bml.projectID + "/traces/" + sc.TraceID.String()
 			gcploggingEntry.SpanID = sc.SpanID.String()
+			gcploggingEntry.TraceSampled = sc.IsSampled()
 		}
 	} else {
 		// server side span, populated through stats/opencensus package.
-		if tID, sID, ok := opencensus.GetTraceAndSpanID(ctx); ok {
+		if tID, sID, isSampled, ok := opencensus.GetTraceAndSpanIDAndIsSampled(ctx); ok {
 			gcploggingEntry.Trace = "projects/" + bml.projectID + "/traces/" + tID.String()
 			gcploggingEntry.SpanID = sID.String()
+			gcploggingEntry.TraceSampled = isSampled
 		}
 	}
 	return gcploggingEntry


### PR DESCRIPTION
We pull the trace ID and span ID for logs differently client and server side. This PR shows how to pull whether the span was actually sampled or not. This needs https://github.com/grpc/grpc-go/pull/6156 to be merged first.

RELEASE NOTES: N/A