### PR TITLE
xdsclient/test: deflake TestWatchResourceTimerCanRestartOnIgnoredADSRecvError

### DIFF
--- a/xds/internal/testutils/resource_watcher.go
+++ b/xds/internal/testutils/resource_watcher.go
@@ -31,6 +31,8 @@ type TestResourceWatcher struct {
 	UpdateCh chan *xdsresource.ResourceData
 	// ErrorCh is the channel on which errors from the xDS client are delivered.
 	ErrorCh chan error
+	// ResourceDoesNotExistCh is the channel used to indicate calls to OnResourceDoesNotExist
+	ResourceDoesNotExistCh chan struct{}
 }
 
 // OnUpdate is invoked by the xDS client to report an update on the resource
@@ -52,7 +54,12 @@ func (w *TestResourceWatcher) OnError(err error) {
 
 // OnResourceDoesNotExist is used by the xDS client to report that the resource
 // being watched no longer exists.
-func (w *TestResourceWatcher) OnResourceDoesNotExist() {}
+func (w *TestResourceWatcher) OnResourceDoesNotExist() {
+	select {
+	case w.ResourceDoesNotExistCh <- struct{}{}:
+	default:
+	}
+}
 
 // NewTestResourceWatcher returns a TestResourceWatcher to watch for resources
 // via the xDS client.

--- a/xds/internal/xdsclient/authority_test.go
+++ b/xds/internal/xdsclient/authority_test.go
@@ -197,7 +197,7 @@ func (s) TestWatchResourceTimerCanRestartOnIgnoredADSRecvError(t *testing.T) {
 		t.Fatalf("testutils.LocalTCPListener() failed: %v", err)
 	}
 	lis := util.NewRestartableListener(l)
-
+	defer lis.Close()
 	streamRestarted := grpcsync.NewEvent()
 	serverOpt := e2e.ManagementServerOptions{
 		Listener: lis,
@@ -209,9 +209,6 @@ func (s) TestWatchResourceTimerCanRestartOnIgnoredADSRecvError(t *testing.T) {
 	a, ms, nodeID := setupTest(ctx, t, serverOpt, defaultTestTimeout)
 	defer ms.Stop()
 	defer a.close()
-	//if _, err := lis.Accept(); err != nil {
-	//	t.Fatal(err)
-	//}
 
 	nameA := "xdsclient-test-lds-resourceA"
 	watcherA := testutils.NewTestResourceWatcher()
@@ -243,7 +240,6 @@ func (s) TestWatchResourceTimerCanRestartOnIgnoredADSRecvError(t *testing.T) {
 	// connectivity issue when reconnecting because the mgmt server was already been
 	// stopped. Also verifying that OnResourceDoesNotExist() method was not invoked
 	// on the watcher.
-	cancelA()
 	select {
 	case <-ctx.Done():
 		t.Fatal("Test timed out before mgmt server got the request.")


### PR DESCRIPTION
We have been having frequent flakes for this test [TestWatchResourceTimerCanRestartOnIgnoredADSRecvError](https://github.com/grpc/grpc-go/blob/master/xds/internal/xdsclient/authority_test.go#L184). 

The test is trying to do the following:
1. setup mgmt server + update for resource A on server
2. create watch for resource A and verify that the watcher got an successful update
3. create watch for resource B
4. Stop the mgmt server 
5. Verify that resource B's watcher only gets a connection error (which is the error when trying to reconnect to the mgmt server)
6. verify that the watch timer for resource B is in  WatchStateStarted state.


But step 6 is causes a race. This is because the underlying transport only sends a conn err when send() or recv() fails. This means the watch state for resource B momentarily flips from started to requested and again back to started. 

i think we can take a better approach at testing this scenario. In this PR im trying to recreate the actual scenario where the mgmt server drops requests and send a error response based on a boolean flag. this way we can test the resource watch's functionality when the mgmt server is brought back.

This deflakes and fixes: #6070 

RELEASE NOTES: None