### PR TITLE
gcp/observability: Add isSampled bool to log entries

### DIFF
--- a/gcp/observability/go.mod
+++ b/gcp/observability/go.mod
@@ -11,7 +11,7 @@ require (
 	golang.org/x/oauth2 v0.5.0
 	google.golang.org/api v0.109.0
 	google.golang.org/grpc v1.53.0-dev.0.20230315171901-a1e657ce53ba
-	google.golang.org/grpc/stats/opencensus v0.0.0-20230317183452-b638faff2204
+	google.golang.org/grpc/stats/opencensus v0.0.0-20230330193705-4a12595692ae
 )
 
 require (

--- a/gcp/observability/go.sum
+++ b/gcp/observability/go.sum
@@ -598,8 +598,8 @@ google.golang.org/grpc v1.40.0/go.mod h1:ogyxbiOoUXAkP+4+xa6PZSE9DZgIHtSpzjDTB9K
 google.golang.org/grpc v1.53.0-dev.0.20230315171901-a1e657ce53ba h1:puuDphNHQZRngQpzUGvfXMBFBv6DuahfWMZaj0jVtjw=
 google.golang.org/grpc v1.53.0-dev.0.20230315171901-a1e657ce53ba/go.mod h1:PUSEXI6iWghWaB6lXM4knEgpJNu2qUcKfDtNci3EC2g=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0/go.mod h1:6Kw0yEErY5E/yWrBtf03jp27GLLJujG4z/JK95pnjjw=
-google.golang.org/grpc/stats/opencensus v0.0.0-20230317183452-b638faff2204 h1:MeDNVH2KmQ9Z3AbXKsvU9UcbRR8LfpZVLmZAVWIX0nI=
-google.golang.org/grpc/stats/opencensus v0.0.0-20230317183452-b638faff2204/go.mod h1:Dg7VaOjf0r9QhRn/YpwSf3vKQz1ixulffTlhEarxEXA=
+google.golang.org/grpc/stats/opencensus v0.0.0-20230330193705-4a12595692ae h1:40UWCQ40A2NTDabsmbZNznFf9SUftDlaBASj7OCdKDY=
+google.golang.org/grpc/stats/opencensus v0.0.0-20230330193705-4a12595692ae/go.mod h1:qPsHQZhltTPryCUC0naykSpbIJDodlCLM/vNa607CrE=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=

--- a/gcp/observability/logging.go
+++ b/gcp/observability/logging.go
@@ -329,12 +329,14 @@ func (bml *binaryMethodLogger) buildGCPLoggingEntry(ctx context.Context, c iblog
 			sc := span.SpanContext()
 			gcploggingEntry.Trace = "projects/" + bml.projectID + "/traces/" + sc.TraceID.String()
 			gcploggingEntry.SpanID = sc.SpanID.String()
+			gcploggingEntry.TraceSampled = sc.IsSampled()
 		}
 	} else {
 		// server side span, populated through stats/opencensus package.
-		if tID, sID, ok := opencensus.GetTraceAndSpanID(ctx); ok {
-			gcploggingEntry.Trace = "projects/" + bml.projectID + "/traces/" + tID.String()
-			gcploggingEntry.SpanID = sID.String()
+		if sc, ok := opencensus.SpanContextFromContext(ctx); ok {
+			gcploggingEntry.Trace = "projects/" + bml.projectID + "/traces/" + sc.TraceID.String()
+			gcploggingEntry.SpanID = sc.SpanID.String()
+			gcploggingEntry.TraceSampled = sc.IsSampled()
 		}
 	}
 	return gcploggingEntry

--- a/gcp/observability/logging.go
+++ b/gcp/observability/logging.go
@@ -318,26 +318,28 @@ func (bml *binaryMethodLogger) buildGCPLoggingEntry(ctx context.Context, c iblog
 	grpcLogEntry.MethodName = bml.methodName
 	grpcLogEntry.Authority = bml.authority
 
+	var scPresent *trace.SpanContext
+	if bml.clientSide {
+		// client side span, populated through opencensus trace package.
+		if span := trace.FromContext(ctx); span != nil {
+			sc := span.SpanContext()
+			scPresent = &sc
+		}
+	} else {
+		// server side span, populated through stats/opencensus package.
+		if sc, ok := opencensus.SpanContextFromContext(ctx); ok {
+			scPresent = &sc
+		}
+	}
 	gcploggingEntry := gcplogging.Entry{
 		Timestamp: binLogEntry.GetTimestamp().AsTime(),
 		Severity:  100,
 		Payload:   grpcLogEntry,
 	}
-	if bml.clientSide {
-		// client side span, populated through opencensus trace package.
-		if span := trace.FromContext(ctx); span != nil {
-			sc := span.SpanContext()
-			gcploggingEntry.Trace = "projects/" + bml.projectID + "/traces/" + sc.TraceID.String()
-			gcploggingEntry.SpanID = sc.SpanID.String()
-			gcploggingEntry.TraceSampled = sc.IsSampled()
-		}
-	} else {
-		// server side span, populated through stats/opencensus package.
-		if sc, ok := opencensus.SpanContextFromContext(ctx); ok {
-			gcploggingEntry.Trace = "projects/" + bml.projectID + "/traces/" + sc.TraceID.String()
-			gcploggingEntry.SpanID = sc.SpanID.String()
-			gcploggingEntry.TraceSampled = sc.IsSampled()
-		}
+	if scPresent != nil {
+		gcploggingEntry.Trace = "projects/" + bml.projectID + "/traces/" + scPresent.TraceID.String()
+		gcploggingEntry.SpanID = scPresent.SpanID.String()
+		gcploggingEntry.TraceSampled = scPresent.IsSampled()
 	}
 	return gcploggingEntry
 }

--- a/gcp/observability/logging_test.go
+++ b/gcp/observability/logging_test.go
@@ -80,8 +80,9 @@ func (fle *fakeLoggingExporter) EmitGcpLoggingEntry(entry gcplogging.Entry) {
 	}
 
 	ids := &traceAndSpanIDString{
-		traceID: entry.Trace,
-		spanID:  entry.SpanID,
+		traceID:   entry.Trace,
+		spanID:    entry.SpanID,
+		isSampled: entry.TraceSampled,
 	}
 	fle.idsSeen = append(fle.idsSeen, ids)
 

--- a/interop/observability/go.mod
+++ b/interop/observability/go.mod
@@ -35,7 +35,7 @@ require (
 	google.golang.org/api v0.110.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20230306155012-7f2fa6fef1f4 // indirect
-	google.golang.org/grpc/stats/opencensus v0.0.0-20230317183452-b638faff2204 // indirect
+	google.golang.org/grpc/stats/opencensus v0.0.0-20230330193705-4a12595692ae // indirect
 	google.golang.org/protobuf v1.30.0 // indirect
 )
 

--- a/interop/observability/go.sum
+++ b/interop/observability/go.sum
@@ -1305,8 +1305,8 @@ google.golang.org/genproto v0.0.0-20230222225845-10f96fb3dbec/go.mod h1:3Dl5ZL0q
 google.golang.org/genproto v0.0.0-20230306155012-7f2fa6fef1f4 h1:DdoeryqhaXp1LtT/emMP1BRJPHHKFi5akj/nbx/zNTA=
 google.golang.org/genproto v0.0.0-20230306155012-7f2fa6fef1f4/go.mod h1:NWraEVixdDnqcqQ30jipen1STv2r/n24Wb7twVTGR4s=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0/go.mod h1:6Kw0yEErY5E/yWrBtf03jp27GLLJujG4z/JK95pnjjw=
-google.golang.org/grpc/stats/opencensus v0.0.0-20230317183452-b638faff2204 h1:MeDNVH2KmQ9Z3AbXKsvU9UcbRR8LfpZVLmZAVWIX0nI=
-google.golang.org/grpc/stats/opencensus v0.0.0-20230317183452-b638faff2204/go.mod h1:Dg7VaOjf0r9QhRn/YpwSf3vKQz1ixulffTlhEarxEXA=
+google.golang.org/grpc/stats/opencensus v0.0.0-20230330193705-4a12595692ae h1:40UWCQ40A2NTDabsmbZNznFf9SUftDlaBASj7OCdKDY=
+google.golang.org/grpc/stats/opencensus v0.0.0-20230330193705-4a12595692ae/go.mod h1:qPsHQZhltTPryCUC0naykSpbIJDodlCLM/vNa607CrE=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=


### PR DESCRIPTION
This PR adds the isSampled bool to log entries. This information is pulled from the Span Context both client and server side. This entry is needed to link logs to traces on the LogsExplorer Google Cloud Platform front end.

RELEASE NOTES: N/A