### PR TITLE
Use string instead of enum for xds resource type

### DIFF
--- a/xds/internal/testutils/testutils.go
+++ b/xds/internal/testutils/testutils.go
@@ -29,16 +29,16 @@ import (
 
 // BuildResourceName returns the resource name in the format of an xdstp://
 // resource.
-func BuildResourceName(typ xdsresource.ResourceType, auth, id string, ctxParams map[string]string) string {
+func BuildResourceName(typeName, auth, id string, ctxParams map[string]string) string {
 	var typS string
-	switch typ {
-	case xdsresource.ListenerResource:
+	switch typeName {
+	case xdsresource.ListenerResourceTypeName:
 		typS = version.V3ListenerType
-	case xdsresource.RouteConfigResource:
+	case xdsresource.RouteConfigTypeName:
 		typS = version.V3RouteConfigType
-	case xdsresource.ClusterResource:
+	case xdsresource.ClusterResourceTypeName:
 		typS = version.V3ClusterType
-	case xdsresource.EndpointsResource:
+	case xdsresource.EndpointsResourceTypeName:
 		typS = version.V3EndpointsType
 	}
 	return (&xdsresource.Name{

--- a/xds/internal/testutils/testutils.go
+++ b/xds/internal/testutils/testutils.go
@@ -40,6 +40,10 @@ func BuildResourceName(typeName, auth, id string, ctxParams map[string]string) s
 		typS = version.V3ClusterType
 	case xdsresource.EndpointsResourceTypeName:
 		typS = version.V3EndpointsType
+	default:
+		// If the name doesn't match any of the standard resources fallback
+		// to the type name.
+		typS = typeName
 	}
 	return (&xdsresource.Name{
 		Scheme:        "xdstp",

--- a/xds/internal/xdsclient/authority.go
+++ b/xds/internal/xdsclient/authority.go
@@ -327,9 +327,8 @@ func decodeAllResources(opts *xdsresource.DecodeOptions, rType xdsresource.Type,
 		return ret, md, nil
 	}
 
-	typeName := rType.TypeName()
 	md.Status = xdsresource.ServiceStatusNACKed
-	errRet := combineErrors(typeName, topLevelErrors, perResourceErrors)
+	errRet := combineErrors(rType.TypeName(), topLevelErrors, perResourceErrors)
 	md.ErrState = &xdsresource.UpdateErrorMetadata{
 		Version:   update.Version,
 		Err:       errRet,

--- a/xds/internal/xdsclient/authority.go
+++ b/xds/internal/xdsclient/authority.go
@@ -215,7 +215,7 @@ func (a *authority) updateResourceStateAndScheduleCallbacks(rType xdsresource.Ty
 
 			if state.deletionIgnored {
 				state.deletionIgnored = false
-				a.logger.Infof("A valid update was received for resource %q of type %q after previously ignoring a deletion", name, rType.TypeEnum())
+				a.logger.Infof("A valid update was received for resource %q of type %q after previously ignoring a deletion", name, rType.TypeName())
 			}
 			// Notify watchers only if this is a first time update or it is different
 			// from the one currently cached.
@@ -284,7 +284,7 @@ func (a *authority) updateResourceStateAndScheduleCallbacks(rType xdsresource.Ty
 			if a.serverCfg.IgnoreResourceDeletion {
 				if !state.deletionIgnored {
 					state.deletionIgnored = true
-					a.logger.Warningf("Ignoring resource deletion for resource %q of type %q", name, rType.TypeEnum())
+					a.logger.Warningf("Ignoring resource deletion for resource %q of type %q", name, rType.TypeName())
 				}
 				continue
 			}

--- a/xds/internal/xdsclient/clientimpl_watchers.go
+++ b/xds/internal/xdsclient/clientimpl_watchers.go
@@ -156,12 +156,12 @@ func (c *clientImpl) WatchResource(rType xdsresource.Type, resourceName string, 
 	// ref-counted client sets its pointer to `nil`. And if any watch APIs are
 	// made on such a closed client, we will get here with a `nil` receiver.
 	if c == nil || c.done.HasFired() {
-		logger.Warningf("Watch registered for name %q of type %q, but client is closed", rType.TypeEnum().String(), resourceName)
+		logger.Warningf("Watch registered for name %q of type %q, but client is closed", rType.TypeName(), resourceName)
 		return func() {}
 	}
 
 	if err := c.resourceTypes.maybeRegister(rType); err != nil {
-		logger.Warningf("Watch registered for name %q of type %q which is already registered", rType.TypeEnum().String(), resourceName)
+		logger.Warningf("Watch registered for name %q of type %q which is already registered", rType.TypeName(), resourceName)
 		c.serializer.Schedule(func(context.Context) { watcher.OnError(err) })
 		return func() {}
 	}
@@ -180,7 +180,7 @@ func (c *clientImpl) WatchResource(rType xdsresource.Type, resourceName string, 
 	n := xdsresource.ParseName(resourceName)
 	a, unref, err := c.findAuthority(n)
 	if err != nil {
-		logger.Warningf("Watch registered for name %q of type %q, authority %q is not found", rType.TypeEnum().String(), resourceName, n.Authority)
+		logger.Warningf("Watch registered for name %q of type %q, authority %q is not found", rType.TypeName(), resourceName, n.Authority)
 		c.serializer.Schedule(func(context.Context) { watcher.OnError(err) })
 		return func() {}
 	}
@@ -216,7 +216,7 @@ func (r *resourceTypeRegistry) maybeRegister(rType xdsresource.Type) error {
 	url := rType.TypeURL()
 	typ, ok := r.types[url]
 	if ok && typ != rType {
-		return fmt.Errorf("attempt to re-register a resource type implementation for %v", rType.TypeEnum())
+		return fmt.Errorf("attempt to re-register a resource type implementation for %v", rType.TypeName())
 	}
 	r.types[url] = rType
 	return nil

--- a/xds/internal/xdsclient/tests/authority_test.go
+++ b/xds/internal/xdsclient/tests/authority_test.go
@@ -45,16 +45,16 @@ var (
 	// These two resources use `testAuthority1`, which contains an empty server
 	// config in the bootstrap file, and therefore will use the default
 	// management server.
-	authorityTestResourceName11 = xdstestutils.BuildResourceName(xdsresource.ClusterResource, testAuthority1, cdsName+"1", nil)
-	authorityTestResourceName12 = xdstestutils.BuildResourceName(xdsresource.ClusterResource, testAuthority1, cdsName+"2", nil)
+	authorityTestResourceName11 = xdstestutils.BuildResourceName(xdsresource.ClusterResourceTypeName, testAuthority1, cdsName+"1", nil)
+	authorityTestResourceName12 = xdstestutils.BuildResourceName(xdsresource.ClusterResourceTypeName, testAuthority1, cdsName+"2", nil)
 	// This resource uses `testAuthority2`, which contains an empty server
 	// config in the bootstrap file, and therefore will use the default
 	// management server.
-	authorityTestResourceName2 = xdstestutils.BuildResourceName(xdsresource.ClusterResource, testAuthority2, cdsName+"3", nil)
+	authorityTestResourceName2 = xdstestutils.BuildResourceName(xdsresource.ClusterResourceTypeName, testAuthority2, cdsName+"3", nil)
 	// This resource uses `testAuthority3`, which contains a non-empty server
 	// config in the bootstrap file, and therefore will use the non-default
 	// management server.
-	authorityTestResourceName3 = xdstestutils.BuildResourceName(xdsresource.ClusterResource, testAuthority3, cdsName+"3", nil)
+	authorityTestResourceName3 = xdstestutils.BuildResourceName(xdsresource.ClusterResourceTypeName, testAuthority3, cdsName+"3", nil)
 )
 
 // setupForAuthorityTests spins up two management servers, one to act as the

--- a/xds/internal/xdsclient/xdsresource/cluster_resource_type.go
+++ b/xds/internal/xdsclient/xdsresource/cluster_resource_type.go
@@ -24,6 +24,12 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 )
 
+const (
+	// ClusterResourceTypeName represents the transport agnostic name for the
+	// cluster resource.
+	ClusterResourceTypeName = "ClusterResource"
+)
+
 var (
 	// Compile time interface checks.
 	_ Type         = clusterResourceType{}
@@ -33,7 +39,7 @@ var (
 	clusterType = clusterResourceType{
 		resourceTypeState: resourceTypeState{
 			typeURL:                    version.V3ClusterURL,
-			typeEnum:                   ClusterResource,
+			typeName:                   ClusterResourceTypeName,
 			allResourcesRequiredInSotW: true,
 		},
 	}

--- a/xds/internal/xdsclient/xdsresource/endpoints_resource_type.go
+++ b/xds/internal/xdsclient/xdsresource/endpoints_resource_type.go
@@ -24,6 +24,12 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 )
 
+const (
+	// EndpointsResourceTypeName represents the transport agnostic name for the
+	// endpoint resource.
+	EndpointsResourceTypeName = "EndpointsResource"
+)
+
 var (
 	// Compile time interface checks.
 	_ Type         = endpointsResourceType{}
@@ -33,7 +39,7 @@ var (
 	endpointsType = endpointsResourceType{
 		resourceTypeState: resourceTypeState{
 			typeURL:                    version.V3EndpointsURL,
-			typeEnum:                   EndpointsResource,
+			typeName:                   "EndpointsResource",
 			allResourcesRequiredInSotW: false,
 		},
 	}

--- a/xds/internal/xdsclient/xdsresource/listener_resource_type.go
+++ b/xds/internal/xdsclient/xdsresource/listener_resource_type.go
@@ -27,6 +27,12 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 )
 
+const (
+	// ListenerResourceTypeName represents the transport agnostic name for the
+	// listener resource.
+	ListenerResourceTypeName = "ListenerResource"
+)
+
 var (
 	// Compile time interface checks.
 	_ Type         = listenerResourceType{}
@@ -36,7 +42,7 @@ var (
 	listenerType = listenerResourceType{
 		resourceTypeState: resourceTypeState{
 			typeURL:                    version.V3ListenerURL,
-			typeEnum:                   ListenerResource,
+			typeName:                   ListenerResourceTypeName,
 			allResourcesRequiredInSotW: true,
 		},
 	}

--- a/xds/internal/xdsclient/xdsresource/resource_type.go
+++ b/xds/internal/xdsclient/xdsresource/resource_type.go
@@ -84,14 +84,14 @@ type Type interface {
 	// TypeURL is the xDS type URL of this resource type for v3 transport.
 	TypeURL() string
 
-	// TypeEnum is an enumerated value for this resource type. This can be used
-	// for logging/debugging purposes, as well in cases where the resource type
-	// is to be uniquely identified but the actual functionality provided by the
-	// resource type is not required.
+	// TypeName identifies resources in a transport protocol agnostic way. This
+	// can be used for logging/debugging purposes, as well in cases where the
+	// resource type name is to be uniquely identified but the actual
+	// functionality provided by the resource type is not required.
 	//
-	// TODO: once Type is renamed to ResourceType, rename ResourceType to
-	// ResourceTypeEnum.
-	TypeEnum() ResourceType
+	// TODO: once Type is renamed to ResourceType, rename TypeName to
+	// ResourceTypeName.
+	TypeName() string
 
 	// AllResourcesRequiredInSotW indicates whether this resource type requires
 	// that all resources be present in every SotW response from the server. If
@@ -147,7 +147,7 @@ type DecodeResult struct {
 // implemented here for free.
 type resourceTypeState struct {
 	typeURL                    string
-	typeEnum                   ResourceType
+	typeName                   string
 	allResourcesRequiredInSotW bool
 }
 
@@ -155,8 +155,8 @@ func (r resourceTypeState) TypeURL() string {
 	return r.typeURL
 }
 
-func (r resourceTypeState) TypeEnum() ResourceType {
-	return r.typeEnum
+func (r resourceTypeState) TypeName() string {
+	return r.typeName
 }
 
 func (r resourceTypeState) AllResourcesRequiredInSotW() bool {

--- a/xds/internal/xdsclient/xdsresource/route_config_resource_type.go
+++ b/xds/internal/xdsclient/xdsresource/route_config_resource_type.go
@@ -24,6 +24,12 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 )
 
+const (
+	// RouteConfigTypeName represents the transport agnostic name for the
+	// route config resource.
+	RouteConfigTypeName = "RouteConfigResource"
+)
+
 var (
 	// Compile time interface checks.
 	_ Type         = routeConfigResourceType{}
@@ -33,7 +39,7 @@ var (
 	routeConfigType = routeConfigResourceType{
 		resourceTypeState: resourceTypeState{
 			typeURL:                    version.V3RouteConfigURL,
-			typeEnum:                   RouteConfigResource,
+			typeName:                   "RouteConfigResource",
 			allResourcesRequiredInSotW: false,
 		},
 	}

--- a/xds/internal/xdsclient/xdsresource/type.go
+++ b/xds/internal/xdsclient/xdsresource/type.go
@@ -133,35 +133,3 @@ type UpdateWithMD struct {
 	MD  UpdateMetadata
 	Raw *anypb.Any
 }
-
-// ResourceType identifies resources in a transport protocol agnostic way. These
-// will be used in transport version agnostic code, while the versioned API
-// clients will map these to appropriate version URLs.
-type ResourceType int
-
-// Version agnostic resource type constants.
-const (
-	UnknownResource ResourceType = iota
-	ListenerResource
-	HTTPConnManagerResource
-	RouteConfigResource
-	ClusterResource
-	EndpointsResource
-)
-
-func (r ResourceType) String() string {
-	switch r {
-	case ListenerResource:
-		return "ListenerResource"
-	case HTTPConnManagerResource:
-		return "HTTPConnManagerResource"
-	case RouteConfigResource:
-		return "RouteConfigResource"
-	case ClusterResource:
-		return "ClusterResource"
-	case EndpointsResource:
-		return "EndpointsResource"
-	default:
-		return "UnknownResource"
-	}
-}


### PR DESCRIPTION
Currently the xdsresource interface defines a function to get an enum associated with the resource. But as the enum is defined in xdsresource package it is not easy to extend it for custom xds resources.

The type enum is mostly utilized for coming up a version agnostic name for a type and so using a string is cleaner and allows custom xds resources to specify their own names. 

cc: @easwars 

RELEASE NOTES: none