### PR TITLE
Remove implication that ResourceData is internal to the package 

### DIFF
--- a/xds/internal/xdsclient/xdsresource/cluster_resource_type.go
+++ b/xds/internal/xdsclient/xdsresource/cluster_resource_type.go
@@ -74,8 +74,6 @@ func (clusterResourceType) Decode(opts *DecodeOptions, resource *anypb.Any) (*De
 //
 // Implements the ResourceData interface.
 type ClusterResourceData struct {
-	ResourceData
-
 	// TODO: We have always stored update structs by value. See if this can be
 	// switched to a pointer?
 	Resource ClusterUpdate

--- a/xds/internal/xdsclient/xdsresource/endpoints_resource_type.go
+++ b/xds/internal/xdsclient/xdsresource/endpoints_resource_type.go
@@ -69,8 +69,6 @@ func (endpointsResourceType) Decode(opts *DecodeOptions, resource *anypb.Any) (*
 //
 // Implements the ResourceData interface.
 type EndpointsResourceData struct {
-	ResourceData
-
 	// TODO: We have always stored update structs by value. See if this can be
 	// switched to a pointer?
 	Resource EndpointsUpdate

--- a/xds/internal/xdsclient/xdsresource/listener_resource_type.go
+++ b/xds/internal/xdsclient/xdsresource/listener_resource_type.go
@@ -106,8 +106,6 @@ func (listenerResourceType) Decode(opts *DecodeOptions, resource *anypb.Any) (*D
 //
 // Implements the ResourceData interface.
 type ListenerResourceData struct {
-	ResourceData
-
 	// TODO: We have always stored update structs by value. See if this can be
 	// switched to a pointer?
 	Resource ListenerUpdate

--- a/xds/internal/xdsclient/xdsresource/resource_type.go
+++ b/xds/internal/xdsclient/xdsresource/resource_type.go
@@ -113,8 +113,6 @@ type Type interface {
 // provide an implementation of this interface to represent the configuration
 // received from the xDS management server.
 type ResourceData interface {
-	isResourceData()
-
 	// Equal returns true if the passed in resource data is equal to that of the
 	// receiver.
 	Equal(ResourceData) bool

--- a/xds/internal/xdsclient/xdsresource/route_config_resource_type.go
+++ b/xds/internal/xdsclient/xdsresource/route_config_resource_type.go
@@ -69,8 +69,6 @@ func (routeConfigResourceType) Decode(opts *DecodeOptions, resource *anypb.Any) 
 //
 // Implements the ResourceData interface.
 type RouteConfigResourceData struct {
-	ResourceData
-
 	// TODO: We have always stored update structs by value. See if this can be
 	// switched to a pointer?
 	Resource RouteConfigUpdate


### PR DESCRIPTION
Currently users can only create their own ResourceData by embedding the interface as it has an un-exported method, this unexported method is not used anywhere though.

By removing the unexported method, it becomes truly an exported interface making it easy for users to define their own custom xds resources. 

cc: @easwars , @dfawley 

RELEASE NOTES: none