### PR TITLE
xds: add stop to avoid hanging in TestServeWithStop

### DIFF
--- a/xds/server_test.go
+++ b/xds/server_test.go
@@ -508,6 +508,7 @@ func (s) TestServeWithStop(t *testing.T) {
 
 	lis, err := testutils.LocalTCPListener()
 	if err != nil {
+		server.Stop()
 		t.Fatalf("testutils.LocalTCPListener() failed: %v", err)
 	}
 
@@ -525,6 +526,7 @@ func (s) TestServeWithStop(t *testing.T) {
 	defer cancel()
 	c, err := clientCh.Receive(ctx)
 	if err != nil {
+		server.Stop()
 		t.Fatalf("error when waiting for new xdsClient to be created: %v", err)
 	}
 	client := c.(*fakeclient.Client)


### PR DESCRIPTION
This pr fix a small problem in `TestServeWithStop`. 
There is a leak at this test when there is any error occurs calling `clientCh.Receive`
https://github.com/grpc/grpc-go/blob/a51779dfbf331faa37864cd80fa2166dbc102dfc/xds/server_test.go#L523-L529
which causes a hanging at `handleServingModeChanges` around server.go:296
https://github.com/grpc/grpc-go/blob/a51779dfbf331faa37864cd80fa2166dbc102dfc/xds/server.go#L293-L324
The fix add a `serve.Stop` before `t.Fatal`  as `Fatal` only terminates current routine but the hanging is at another. 

It can be repro by leak check in grpc with a small modification to trigger the error. 
```
=== RUN   TestServeWithStop
    server_test.go:530: error when waiting for new xdsClient to be created: <nil>
    leakcheck.go:115: Leaked goroutine: goroutine 18 [select]:
        google.golang.org/grpc/xds.(*GRPCServer).handleServingModeChanges(0xc000401720, 0xc00011e270)
        	C:/Users/Msk/Documents/GitHub/grpc-go/xds/server.go:295 +0xb7
        google.golang.org/grpc/xds.(*GRPCServer).Serve.func1()
        	C:/Users/Msk/Documents/GitHub/grpc-go/xds/server.go:244 +0x25
        created by google.golang.org/grpc/xds.(*GRPCServer).Serve
        	C:/Users/Msk/Documents/GitHub/grpc-go/xds/server.go:243 +0x26c
    leakcheck.go:115: Leaked goroutine: goroutine 19 [select]:
        google.golang.org/grpc/xds/internal/server.(*listenerWrapper).run(0xc000134000)
        	C:/Users/Msk/Documents/GitHub/grpc-go/xds/internal/server/listener_wrapper.go:320 +0xfc
        created by google.golang.org/grpc/xds/internal/server.NewListenerWrapper
        	C:/Users/Msk/Documents/GitHub/grpc-go/xds/internal/server/listener_wrapper.go:125 +0x605
    leakcheck.go:115: Leaked goroutine: goroutine 9 [select]:
        google.golang.org/grpc/xds.(*GRPCServer).Serve(0xc000401720, {0x1e88530, 0xc0003e1218})
        	C:/Users/Msk/Documents/GitHub/grpc-go/xds/server.go:269 +0x448
        google.golang.org/grpc/xds.TestServeWithStop.func1()
        	C:/Users/Msk/Documents/GitHub/grpc-go/xds/server_test.go:519 +0x3b
        created by google.golang.org/grpc/xds.TestServeWithStop
        	C:/Users/Msk/Documents/GitHub/grpc-go/xds/server_test.go:518 +0x23b
--- FAIL: TestServeWithStop (10.06s)
```

RELEASE NOTES: none