### PR TITLE
alts: Perform full handshake in ALTS tests.

### DIFF
--- a/credentials/alts/alts_test.go
+++ b/credentials/alts/alts_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/golang/protobuf/proto"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/alts/internal/handshaker/service"
+	altsgrpc "google.golang.org/grpc/credentials/alts/internal/proto/grpc_gcp"
 	altspb "google.golang.org/grpc/credentials/alts/internal/proto/grpc_gcp"
 	"google.golang.org/grpc/credentials/alts/internal/testutil"
 	"google.golang.org/grpc/internal/grpctest"
@@ -341,8 +342,8 @@ func TestFullHandshake(t *testing.T) {
 	}
 
 	// Close open connections to the fake handshaker service.
-	if err := service.Close(); err != nil {
-		t.Errorf("service.Close() failed: %v", err)
+	if err := service.CloseForTesting(); err != nil {
+		t.Errorf("service.CloseForTesting() failed: %v", err)
 	}
 }
 
@@ -366,7 +367,7 @@ func startFakeHandshakerService(t *testing.T, wait *sync.WaitGroup) (stop func()
 		t.Fatalf("LocalTCPListener() failed: %v", err)
 	}
 	s := grpc.NewServer()
-	altspb.RegisterHandshakerServiceServer(s, &testutil.FakeHandshaker{})
+	altsgrpc.RegisterHandshakerServiceServer(s, &testutil.FakeHandshaker{})
 	wait.Add(1)
 	go func() {
 		defer wait.Done()

--- a/credentials/alts/alts_test.go
+++ b/credentials/alts/alts_test.go
@@ -328,7 +328,7 @@ func TestFullHandshake(t *testing.T) {
 	// Start the server and make a unary RPC.
 	ss := &stubserver.StubServer{UnaryCallF: unaryCall}
 	if err := ss.Start(serverOpts, grpc.WithTransportCredentials(clientCreds)); err != nil {
-		t.Errorf("ss.Start() failed: %v", err)
+		t.Fatalf("ss.Start() failed: %v", err)
 	}
 	defer ss.Stop()
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)

--- a/credentials/alts/alts_test.go
+++ b/credentials/alts/alts_test.go
@@ -327,14 +327,14 @@ func TestFullHandshake(t *testing.T) {
 
 	// Start the server and make a unary RPC.
 	ss := &stubserver.StubServer{UnaryCallF: unaryCall}
-        if err := ss.Start(serverOpts, grpc.WithTransportCredentials(clientCreds)); err != nil {
-                t.Errorf("ss.Start() failed: %v", err)
-        }
+	if err := ss.Start(serverOpts, grpc.WithTransportCredentials(clientCreds)); err != nil {
+		t.Errorf("ss.Start() failed: %v", err)
+	}
 	defer ss.Stop()
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-        defer cancel()
+	defer cancel()
 	if _, err := ss.Client.UnaryCall(ctx, &testpb.SimpleRequest{}); err != nil {
-              t.Errorf("c.UnaryCall() failed: %v", err)
+		t.Errorf("c.UnaryCall() failed: %v", err)
 	}
 
 	// Close open connections to the fake handshaker service.

--- a/credentials/alts/alts_test.go
+++ b/credentials/alts/alts_test.go
@@ -25,6 +25,7 @@ import (
 	"context"
 	"net"
 	"reflect"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -296,6 +297,13 @@ func (s) TestCheckRPCVersions(t *testing.T) {
 }
 
 func TestFullHandshake(t *testing.T) {
+	// If GOMAXPROCS is set to less than 2, do not run this test. This test
+	// requires at least 2 goroutines to succeed (one goroutine where a
+	// server listens, another goroutine where a client runs).
+	if runtime.GOMAXPROCS(0) < 2 {
+		return
+	}
+
 	// Start the fake handshaker service and the server.
 	var wait sync.WaitGroup
 	defer wait.Wait()

--- a/credentials/alts/internal/handshaker/service/service.go
+++ b/credentials/alts/internal/handshaker/service/service.go
@@ -60,6 +60,8 @@ func Dial(hsAddress string) (*grpc.ClientConn, error) {
 }
 
 // Close closes all open connections to the handshaker service.
+//
+// For testing purposes only.
 func Close() error {
 	for _, hsConn := range hsConnMap {
 		if hsConn == nil {

--- a/credentials/alts/internal/handshaker/service/service.go
+++ b/credentials/alts/internal/handshaker/service/service.go
@@ -59,10 +59,10 @@ func Dial(hsAddress string) (*grpc.ClientConn, error) {
 	return hsConn, nil
 }
 
-// Close closes all open connections to the handshaker service.
+// CloseForTesting closes all open connections to the handshaker service.
 //
 // For testing purposes only.
-func Close() error {
+func CloseForTesting() error {
 	for _, hsConn := range hsConnMap {
 		if hsConn == nil {
 			continue

--- a/credentials/alts/internal/handshaker/service/service.go
+++ b/credentials/alts/internal/handshaker/service/service.go
@@ -58,3 +58,19 @@ func Dial(hsAddress string) (*grpc.ClientConn, error) {
 	}
 	return hsConn, nil
 }
+
+// Close closes all open connections to the handshaker service.
+func Close() error {
+	for _, hsConn := range hsConnMap {
+		if hsConn == nil {
+			continue
+		}
+		if err := hsConn.Close(); err != nil {
+			return err
+		}
+	}
+
+	// Reset the connection map.
+	hsConnMap = make(map[string]*grpc.ClientConn)
+	return nil
+}

--- a/credentials/alts/internal/handshaker/service/service_test.go
+++ b/credentials/alts/internal/handshaker/service/service_test.go
@@ -80,4 +80,12 @@ func TestDial(t *testing.T) {
 	if got, want := conn2 == conn3, false; got != want {
 		t.Fatalf("(conn2==conn3)=%v, want %v", got, want)
 	}
+
+	// Check that the connection map is empty after calling Close.
+	if err := Close(); err != nil {
+		t.Errorf("Close() failed: %v", err)
+	}
+	if len(hsConnMap) != 0 {
+		t.Errorf("len(hsConnMap) is nonzero: %v", len(hsConnMap))
+	}
 }

--- a/credentials/alts/internal/handshaker/service/service_test.go
+++ b/credentials/alts/internal/handshaker/service/service_test.go
@@ -80,12 +80,4 @@ func TestDial(t *testing.T) {
 	if got, want := conn2 == conn3, false; got != want {
 		t.Fatalf("(conn2==conn3)=%v, want %v", got, want)
 	}
-
-	// Check that the connection map is empty after calling Close.
-	if err := Close(); err != nil {
-		t.Errorf("Close() failed: %v", err)
-	}
-	if len(hsConnMap) != 0 {
-		t.Errorf("len(hsConnMap) is nonzero: %v", len(hsConnMap))
-	}
 }

--- a/credentials/alts/internal/testutil/testutil.go
+++ b/credentials/alts/internal/testutil/testutil.go
@@ -29,6 +29,7 @@ import (
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/alts/internal/conn"
+	altsgrpc "google.golang.org/grpc/credentials/alts/internal/proto/grpc_gcp"
 	altspb "google.golang.org/grpc/credentials/alts/internal/proto/grpc_gcp"
 )
 
@@ -129,11 +130,11 @@ func MakeFrame(pl string) []byte {
 
 // FakeHandshaker is a fake implementation of the ALTS handshaker service.
 type FakeHandshaker struct {
-	altspb.HandshakerServiceServer
+	altsgrpc.HandshakerServiceServer
 }
 
 // DoHandshake performs a fake ALTS handshake.
-func (h *FakeHandshaker) DoHandshake(stream altspb.HandshakerService_DoHandshakeServer) error {
+func (h *FakeHandshaker) DoHandshake(stream altsgrpc.HandshakerService_DoHandshakeServer) error {
 	var isAssistingClient bool
 	for {
 		req, err := stream.Recv()

--- a/credentials/alts/internal/testutil/testutil.go
+++ b/credentials/alts/internal/testutil/testutil.go
@@ -22,11 +22,14 @@ package testutil
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
 	"io"
 	"net"
 	"sync"
 
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/alts/internal/conn"
+	altspb "google.golang.org/grpc/credentials/alts/internal/proto/grpc_gcp"
 )
 
 // Stats is used to collect statistics about concurrent handshake calls.
@@ -122,4 +125,155 @@ func MakeFrame(pl string) []byte {
 	binary.LittleEndian.PutUint32(f, uint32(len(pl)))
 	copy(f[conn.MsgLenFieldSize:], []byte(pl))
 	return f
+}
+
+// FakeHandshaker is a fake implementation of the ALTS handshaker service.
+type FakeHandshaker struct {
+	altspb.HandshakerServiceServer
+}
+
+// DoHandshake performs a fake ALTS handshake.
+func (h *FakeHandshaker) DoHandshake(stream altspb.HandshakerService_DoHandshakeServer) error {
+	var isAssistingClient bool
+	for {
+		req, err := stream.Recv()
+		if err != nil {
+			if err == io.EOF {
+				return nil
+			}
+			return fmt.Errorf("stream recv failure: %v", err)
+		}
+		var resp *altspb.HandshakerResp
+		switch req := req.ReqOneof.(type) {
+		case *altspb.HandshakerReq_ClientStart:
+			isAssistingClient = true
+			resp, err = h.processStartClient(req.ClientStart)
+			if err != nil {
+				return fmt.Errorf("processStartClient failure: %v", err)
+			}
+		case *altspb.HandshakerReq_ServerStart:
+			isAssistingClient = false
+			resp, err = h.processServerStart(req.ServerStart)
+			if err != nil {
+				return fmt.Errorf("processServerClient failure: %v", err)
+			}
+		case *altspb.HandshakerReq_Next:
+			resp, err = h.processNext(req.Next, isAssistingClient)
+			if err != nil {
+				return fmt.Errorf("processNext failure: %v", err)
+			}
+		default:
+			return fmt.Errorf("handshake request has unexpected type: %v", req)
+		}
+
+		if err = stream.Send(resp); err != nil {
+			return fmt.Errorf("stream send failure: %v", err)
+		}
+	}
+}
+
+func (h *FakeHandshaker) processStartClient(req *altspb.StartClientHandshakeReq) (*altspb.HandshakerResp, error) {
+	if req.HandshakeSecurityProtocol != altspb.HandshakeProtocol_ALTS {
+		return nil, fmt.Errorf("unexpected handshake security protocol: %v", req.HandshakeSecurityProtocol)
+	}
+	if len(req.ApplicationProtocols) != 1 || req.ApplicationProtocols[0] != "grpc" {
+		return nil, fmt.Errorf("unexpected application protocols: %v", req.ApplicationProtocols)
+	}
+	if len(req.RecordProtocols) != 1 || req.RecordProtocols[0] != "ALTSRP_GCM_AES128_REKEY" {
+		return nil, fmt.Errorf("unexpected record protocols: %v", req.RecordProtocols)
+	}
+	return &altspb.HandshakerResp{
+		OutFrames:     []byte("ClientInit"),
+		BytesConsumed: 0,
+		Status: &altspb.HandshakerStatus{
+			Code: uint32(codes.OK),
+		},
+	}, nil
+}
+
+func (h *FakeHandshaker) processServerStart(req *altspb.StartServerHandshakeReq) (*altspb.HandshakerResp, error) {
+	if len(req.ApplicationProtocols) != 1 || req.ApplicationProtocols[0] != "grpc" {
+		return nil, fmt.Errorf("unexpected application protocols: %v", req.ApplicationProtocols)
+	}
+	parameters, ok := req.GetHandshakeParameters()[int32(altspb.HandshakeProtocol_ALTS)]
+	if !ok {
+		return nil, fmt.Errorf("missing ALTS handshake parameters")
+	}
+	if len(parameters.RecordProtocols) != 1 || parameters.RecordProtocols[0] != "ALTSRP_GCM_AES128_REKEY" {
+		return nil, fmt.Errorf("unexpected record protocols: %v", parameters.RecordProtocols)
+	}
+	if string(req.InBytes) != "ClientInit" {
+		return nil, fmt.Errorf("unexpected in bytes: %v", req.InBytes)
+	}
+	return &altspb.HandshakerResp{
+		OutFrames:     []byte("ServerInitServerFinished"),
+		BytesConsumed: 10,
+		Status: &altspb.HandshakerStatus{
+			Code: uint32(codes.OK),
+		},
+	}, nil
+}
+
+func (h *FakeHandshaker) processNext(req *altspb.NextHandshakeMessageReq, isAssistingClient bool) (*altspb.HandshakerResp, error) {
+	if isAssistingClient {
+		if !bytes.Equal(req.InBytes, []byte("ServerInitServerFinished")) {
+			return nil, fmt.Errorf("unexpected in bytes: got: %v, want: %v", req.InBytes, []byte("ServerInitServerFinished"))
+		}
+		return &altspb.HandshakerResp{
+			OutFrames:     []byte("ClientFinished"),
+			BytesConsumed: 24,
+			Result: &altspb.HandshakerResult{
+				ApplicationProtocol: "grpc",
+				RecordProtocol:      "ALTSRP_GCM_AES128_REKEY",
+				KeyData:             []byte("negotiated-key-data-for-altsrp-gcm-aes128-rekey"),
+				PeerIdentity: &altspb.Identity{
+					IdentityOneof: &altspb.Identity_ServiceAccount{
+						ServiceAccount: "server@bar.com",
+					},
+				},
+				PeerRpcVersions: &altspb.RpcProtocolVersions{
+					MaxRpcVersion: &altspb.RpcProtocolVersions_Version{
+						Minor: 1,
+						Major: 2,
+					},
+					MinRpcVersion: &altspb.RpcProtocolVersions_Version{
+						Minor: 1,
+						Major: 2,
+					},
+				},
+			},
+			Status: &altspb.HandshakerStatus{
+				Code: uint32(codes.OK),
+			},
+		}, nil
+	}
+	if !bytes.Equal(req.InBytes, []byte("ClientFinished")) {
+		return nil, fmt.Errorf("unexpected in bytes: got: %v, want: %v", req.InBytes, []byte("ClientFinished"))
+	}
+	return &altspb.HandshakerResp{
+		BytesConsumed: 14,
+		Result: &altspb.HandshakerResult{
+			ApplicationProtocol: "grpc",
+			RecordProtocol:      "ALTSRP_GCM_AES128_REKEY",
+			KeyData:             []byte("negotiated-key-data-for-altsrp-gcm-aes128-rekey"),
+			PeerIdentity: &altspb.Identity{
+				IdentityOneof: &altspb.Identity_ServiceAccount{
+					ServiceAccount: "client@baz.com",
+				},
+			},
+			PeerRpcVersions: &altspb.RpcProtocolVersions{
+				MaxRpcVersion: &altspb.RpcProtocolVersions_Version{
+					Minor: 1,
+					Major: 2,
+				},
+				MinRpcVersion: &altspb.RpcProtocolVersions_Version{
+					Minor: 1,
+					Major: 2,
+				},
+			},
+		},
+		Status: &altspb.HandshakerStatus{
+			Code: uint32(codes.OK),
+		},
+	}, nil
 }


### PR DESCRIPTION
The ALTS tests in this repo do not perform full ALTS handshakes against a fake handshaker service. This leads to changes in this repo breaking e2e/interop tests once the change is imported internally. This PR will (hopefully) reduce the frequency with which that happens.

RELEASE NOTES: none