### PR TITLE
test: Close client to avoid leak in TestHealthCheckHealthServerNotRegistered

### DIFF
--- a/test/healthcheck_test.go
+++ b/test/healthcheck_test.go
@@ -265,6 +265,7 @@ func (s) TestHealthCheckHealthServerNotRegistered(t *testing.T) {
 	defer s.Stop()
 
 	cc, r := setupClient(t, nil)
+	defer cc.Close()
 	r.UpdateState(resolver.State{
 		Addresses: []resolver.Address{{Addr: lis.Addr().String()}},
 		ServiceConfig: parseServiceConfig(t, r, `{


### PR DESCRIPTION
This pr fixes a leak routine problem in TestHealthCheckHealthServerNotRegistered. The client create by `cc, r := setupClient(t, nil)` is not closed later. That cause a hanging, which can be repro by leakcheck. It can be eliminated by adding a `defer cc.Close` after the creation.

leakcheck report:
```
=== RUN   TestHealthCheckHealthServerNotRegistered
2023/04/06 09:16:43 ERROR: [core] [Channel #2 SubChannel #4] Subchannel health check is unimplemented at server side, thus health check is disabled
    leakcheck.go:115: Leaked goroutine: goroutine 10 [select]:
        google.golang.org/grpc.(*ccBalancerWrapper).watcher(0xc00006f740)
        	C:/Users/Msk/Documents/GitHub/grpc-go/balancer_conn_wrappers.go:115 +0x73
        created by google.golang.org/grpc.newCCBalancerWrapper
        	C:/Users/Msk/Documents/GitHub/grpc-go/balancer_conn_wrappers.go:76 +0x22a
    leakcheck.go:115: Leaked goroutine: goroutine 26 [select]:
        google.golang.org/grpc.(*addrConn).resetTransport(0xc000139600)
        	C:/Users/Msk/Documents/GitHub/grpc-go/clientconn.go:1184 +0x3b8
        google.golang.org/grpc.(*addrConn).connect(0xc000139600)
        	C:/Users/Msk/Documents/GitHub/grpc-go/clientconn.go:819 +0x185
        created by google.golang.org/grpc.(*acBalancerWrapper).Connect
        	C:/Users/Msk/Documents/GitHub/grpc-go/balancer_conn_wrappers.go:413 +0xbc
--- FAIL: TestHealthCheckHealthServerNotRegistered (10.08s)
```