### PR TITLE
test/xds: Fix test_grpc import path

### DIFF
--- a/test/xds/xds_client_ignore_resource_deletion_test.go
+++ b/test/xds/xds_client_ignore_resource_deletion_test.go
@@ -307,7 +307,7 @@ func setupGRPCServerWithModeChangeChannelAndServe(t *testing.T, bootstrapContent
 	})
 	server := xds.NewGRPCServer(grpc.Creds(insecure.NewCredentials()), modeChangeOpt, xds.BootstrapContentsForTesting(bootstrapContents))
 	t.Cleanup(server.Stop)
-	testpb.RegisterTestServiceServer(server, &testService{})
+	testgrpc.RegisterTestServiceServer(server, &testService{})
 
 	// Serve.
 	go func() {


### PR DESCRIPTION
This testpb.RegisterTestServiceServer causes the import into Google3 to point to the wrong generated package. This needs to point to testgrpc.