### PR TITLE
Export the unwrapResource method, to allow callers outside of the package

### DIFF
--- a/xds/internal/xdsclient/xdsresource/type.go
+++ b/xds/internal/xdsclient/xdsresource/type.go
@@ -78,9 +78,9 @@ func IsEndpointsResource(url string) bool {
 	return url == version.V3EndpointsURL
 }
 
-// unwrapResource unwraps and returns the inner resource if it's in a resource
+// UnwrapResource unwraps and returns the inner resource if it's in a resource
 // wrapper. The original resource is returned if it's not wrapped.
-func unwrapResource(r *anypb.Any) (*anypb.Any, error) {
+func UnwrapResource(r *anypb.Any) (*anypb.Any, error) {
 	url := r.GetTypeUrl()
 	if url != version.V3ResourceWrapperURL {
 		// Not wrapped.

--- a/xds/internal/xdsclient/xdsresource/unmarshal_cds.go
+++ b/xds/internal/xdsclient/xdsresource/unmarshal_cds.go
@@ -40,7 +40,7 @@ import (
 const transportSocketName = "envoy.transport_sockets.tls"
 
 func unmarshalClusterResource(r *anypb.Any) (string, ClusterUpdate, error) {
-	r, err := unwrapResource(r)
+	r, err := UnwrapResource(r)
 	if err != nil {
 		return "", ClusterUpdate{}, fmt.Errorf("failed to unwrap resource: %v", err)
 	}

--- a/xds/internal/xdsclient/xdsresource/unmarshal_eds.go
+++ b/xds/internal/xdsclient/xdsresource/unmarshal_eds.go
@@ -33,7 +33,7 @@ import (
 )
 
 func unmarshalEndpointsResource(r *anypb.Any) (string, EndpointsUpdate, error) {
-	r, err := unwrapResource(r)
+	r, err := UnwrapResource(r)
 	if err != nil {
 		return "", EndpointsUpdate{}, fmt.Errorf("failed to unwrap resource: %v", err)
 	}

--- a/xds/internal/xdsclient/xdsresource/unmarshal_lds.go
+++ b/xds/internal/xdsclient/xdsresource/unmarshal_lds.go
@@ -34,7 +34,7 @@ import (
 )
 
 func unmarshalListenerResource(r *anypb.Any) (string, ListenerUpdate, error) {
-	r, err := unwrapResource(r)
+	r, err := UnwrapResource(r)
 	if err != nil {
 		return "", ListenerUpdate{}, fmt.Errorf("failed to unwrap resource: %v", err)
 	}

--- a/xds/internal/xdsclient/xdsresource/unmarshal_rds.go
+++ b/xds/internal/xdsclient/xdsresource/unmarshal_rds.go
@@ -34,7 +34,7 @@ import (
 )
 
 func unmarshalRouteConfigResource(r *anypb.Any) (string, RouteConfigUpdate, error) {
-	r, err := unwrapResource(r)
+	r, err := UnwrapResource(r)
 	if err != nil {
 		return "", RouteConfigUpdate{}, fmt.Errorf("failed to unwrap resource: %v", err)
 	}


### PR DESCRIPTION
The unwrap resource method will be called by internal packages to unwrap resources, so exporting this allows reuse.

@easwars 

RELEASE NOTES: none