### PR TITLE
alts: Add retry loop when making RPC in ALTS's TestFullHandshake.

### DIFF
--- a/credentials/alts/alts_test.go
+++ b/credentials/alts/alts_test.go
@@ -329,7 +329,7 @@ func TestFullHandshake(t *testing.T) {
 
 	// Ping the server, authenticating with ALTS.
 	clientCreds := NewClientCreds(&ClientOptions{HandshakerServiceAddress: handshakerAddress})
-	conn, err := grpc.Dial(serverAddress, grpc.WithTransportCredentials(clientCreds))
+	conn, err := grpc.Dial(serverAddress, grpc.WithTransportCredentials(clientCreds), grpc.WithBlock())
 	if err != nil {
 		t.Fatalf("grpc.Dial(%v) failed: %v", serverAddress, err)
 	}

--- a/credentials/alts/alts_test.go
+++ b/credentials/alts/alts_test.go
@@ -331,7 +331,7 @@ func (s) TestFullHandshake(t *testing.T) {
 
 	// Ping the server, authenticating with ALTS.
 	clientCreds := NewClientCreds(&ClientOptions{HandshakerServiceAddress: handshakerAddress})
-	conn, err := grpc.Dial(serverAddress, grpc.WithTransportCredentials(clientCreds), grpc.WithBlock())
+	conn, err := grpc.Dial(serverAddress, grpc.WithTransportCredentials(clientCreds))
 	if err != nil {
 		t.Fatalf("grpc.Dial(%v) failed: %v", serverAddress, err)
 	}
@@ -339,7 +339,7 @@ func (s) TestFullHandshake(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	c := testgrpc.NewTestServiceClient(conn)
-	for ; ctx.Err() == nil; <-time.After(10 * time.Second) {
+	for ; ctx.Err() == nil; <-time.After(5 * time.Second) {
 		if _, err = c.UnaryCall(ctx, &testpb.SimpleRequest{}, grpc.WaitForReady(true)); err != nil {
 			status, ok := status.FromError(err)
 			if ok && status.Code() == codes.DeadlineExceeded {

--- a/credentials/alts/alts_test.go
+++ b/credentials/alts/alts_test.go
@@ -341,7 +341,7 @@ func (s) TestFullHandshake(t *testing.T) {
 		t.Fatalf("grpc.Dial(%v) failed: %v", serverAddress, err)
 	}
 	defer conn.Close()
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestLongTimeout)
 	defer cancel()
 	c := testgrpc.NewTestServiceClient(conn)
 	for ; ctx.Err() == nil; <-time.After(defaultTestShortTimeout) {

--- a/credentials/alts/alts_test.go
+++ b/credentials/alts/alts_test.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/alts/internal/handshaker/service"
 	altsgrpc "google.golang.org/grpc/credentials/alts/internal/proto/grpc_gcp"
 	altspb "google.golang.org/grpc/credentials/alts/internal/proto/grpc_gcp"
@@ -39,6 +40,7 @@ import (
 	"google.golang.org/grpc/internal/testutils"
 	testgrpc "google.golang.org/grpc/interop/grpc_testing"
 	testpb "google.golang.org/grpc/interop/grpc_testing"
+	"google.golang.org/grpc/status"
 )
 
 type s struct {
@@ -301,7 +303,7 @@ func (s) TestCheckRPCVersions(t *testing.T) {
 // TestFullHandshake performs a full ALTS handshake between a test client and
 // server, where both client and server offload to a local, fake handshaker
 // service.
-func TestFullHandshake(t *testing.T) {
+func (s) TestFullHandshake(t *testing.T) {
 	// If GOMAXPROCS is set to less than 2, do not run this test. This test
 	// requires at least 2 goroutines to succeed (one goroutine where a
 	// server listens, another goroutine where a client runs).
@@ -337,8 +339,15 @@ func TestFullHandshake(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	c := testgrpc.NewTestServiceClient(conn)
-	if _, err = c.UnaryCall(ctx, &testpb.SimpleRequest{}, grpc.WaitForReady(true)); err != nil {
-		t.Errorf("c.UnaryCall() failed: %v", err)
+	for ; ctx.Err() == nil; <-time.After(10 * time.Second) {
+		if _, err = c.UnaryCall(ctx, &testpb.SimpleRequest{}, grpc.WaitForReady(true)); err != nil {
+			status, ok := status.FromError(err)
+			if ok && status.Code() == codes.DeadlineExceeded {
+				continue
+			} else {
+				t.Errorf("c.UnaryCall() failed: %v", err)
+			}
+		}
 	}
 
 	// Close open connections to the fake handshaker service.


### PR DESCRIPTION
This fixes the flaky test introduced in #6177 and flagged in #6182. Before this PR, I could reproduce the flake ~1.7% of time on local runs. With this PR, I cannot reproduce the flake locally.

Fixes https://github.com/grpc/grpc-go/issues/6182

RELEASE NOTES: none