### PR TITLE
grpc: ClientConn cleanup in prep for channel idleness

### DIFF
--- a/clientconn.go
+++ b/clientconn.go
@@ -176,7 +176,6 @@ func DialContext(ctx context.Context, target string, opts ...DialOption) (conn *
 	// Register ClientConn with channelz.
 	cc.channelzRegistration(target)
 
-	// Validate configured transport credentials.
 	if err := cc.validateTransportCredentials(); err != nil {
 		return nil, err
 	}
@@ -224,8 +223,6 @@ func DialContext(ctx context.Context, target string, opts ...DialOption) (conn *
 	if err := cc.parseTargetAndFindResolver(); err != nil {
 		return nil, err
 	}
-
-	// Determine the channel authority.
 	if err = cc.determineAuthority(); err != nil {
 		return nil, err
 	}
@@ -1661,6 +1658,9 @@ func parseTarget(target string) (resolver.Target, error) {
 // - endpoint from dial target of the form "scheme://[authority]/endpoint"
 //
 // Stores the determined authority in `cc.authority`.
+//
+// Returns a non-nil error if the authority returned by the transport
+// credentials do not match the authority configured through the dial option.
 //
 // Doesn't grab cc.mu as this method is expected to be called only at Dial time.
 func (cc *ClientConn) determineAuthority() error {


### PR DESCRIPTION
Minor cleanup in the ClientConn code:
- add well documented helper methods that enable hiding complexity from `Dial`
  - a method to perform channelz registration
  - a method to validate transport credentials configuration
- modify existing `parseTargetAndFindResolver` and `determineAuthority` to directly set fields in the `ClientConn` instead of returning them and having `Dial` set appropriate fields
- refactor the `ccResolverWrapper` type and incorporate the principle of least privilege
  - the `ccResolverWrapper` is now passed all the arguments that it needs instead of reaching over and getting them from the parent `ClientConn`
  - the `ccResolverWrapper` now defines an interface that contains a single method that it calls on the `ClientConn`, thereby it need not hold on to a `ClientConn`
- add a field in the `ClientConn` to store the `resolver.Builder`
  - this will save us the effort of parsing the target string and figuring out the resolver builder when we have to restart the name resolver (i.e moving the channel out of its idle state)

RELEASE NOTES: none