### PR TITLE
stubserver: Stop server when StartClient failed

### DIFF
--- a/internal/stubserver/stubserver.go
+++ b/internal/stubserver/stubserver.go
@@ -86,7 +86,11 @@ func (ss *StubServer) Start(sopts []grpc.ServerOption, dopts ...grpc.DialOption)
 	if err := ss.StartServer(sopts...); err != nil {
 		return err
 	}
-	return ss.StartClient(dopts...)
+	if err := ss.StartClient(dopts...); err != nil {
+		ss.Stop()
+		return err
+	}
+	return nil
 }
 
 // StartServer only starts the server. It does not create a client to it.


### PR DESCRIPTION
In the code below, it seems the error of `StartServer` and `StartClient` can not be simply distinguished from caller of `Start`
https://github.com/grpc/grpc-go/blob/fe72db9589696a625af72117a600ba191227b7c5/internal/stubserver/stubserver.go#L85-L90
It is used in project as:
https://github.com/grpc/grpc-go/blob/fe72db9589696a625af72117a600ba191227b7c5/stats/opencensus/e2e_test.go#L294-L297
There is a problem that,  we should call `ss.Stop` when `StartServer` success but `StartClient` failed in the error handling branch, which is not easy to handle in caller. So close it in `Start` when it occurs to avoid leak.

RELEASE NOTES: none