### PR TITLE
test/kokoro: increase PSM Security test timeout to 4h (v1.45.x backport)

### DIFF
--- a/test/kokoro/psm-security.cfg
+++ b/test/kokoro/psm-security.cfg
@@ -2,7 +2,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc-go/test/kokoro/psm-security.sh"
-timeout_mins: 180
+timeout_mins: 240
 
 action {
   define_artifacts {


### PR DESCRIPTION
Backport of #6193 to v1.45.x.
---
The total time PSM Security takes to run was getting close to 3h lately. About ~4% of weekly test runs exceed the 3h limit. Adding an extra hour to allow for a larger margin of error.

ref b/259690410

RELEASE NOTES: N/A