### PR TITLE
gcp/observability: Point o11y to gRPC 1.54

### DIFF
--- a/gcp/observability/go.mod
+++ b/gcp/observability/go.mod
@@ -10,7 +10,7 @@ require (
 	go.opencensus.io v0.24.0
 	golang.org/x/oauth2 v0.6.0
 	google.golang.org/api v0.110.0
-	google.golang.org/grpc v1.54.1-0.20230322004705-d200af566284
+	google.golang.org/grpc v1.54.0
 	google.golang.org/grpc/stats/opencensus v0.0.0-20230414222620-eab9e20d1bbe
 )
 

--- a/gcp/observability/go.mod
+++ b/gcp/observability/go.mod
@@ -10,8 +10,8 @@ require (
 	go.opencensus.io v0.24.0
 	golang.org/x/oauth2 v0.6.0
 	google.golang.org/api v0.110.0
-	google.golang.org/grpc v1.53.0
-	google.golang.org/grpc/stats/opencensus v0.0.0-20230330193705-4a12595692ae
+	google.golang.org/grpc v1.54.1-0.20230322004705-d200af566284
+	google.golang.org/grpc/stats/opencensus v0.0.0-20230414222620-eab9e20d1bbe
 )
 
 require (
@@ -39,5 +39,3 @@ require (
 )
 
 replace google.golang.org/grpc => ../..
-
-replace google.golang.org/grpc/stats/opencensus => ../../stats/opencensus

--- a/gcp/observability/go.sum
+++ b/gcp/observability/go.sum
@@ -1305,6 +1305,8 @@ google.golang.org/genproto v0.0.0-20230222225845-10f96fb3dbec/go.mod h1:3Dl5ZL0q
 google.golang.org/genproto v0.0.0-20230306155012-7f2fa6fef1f4 h1:DdoeryqhaXp1LtT/emMP1BRJPHHKFi5akj/nbx/zNTA=
 google.golang.org/genproto v0.0.0-20230306155012-7f2fa6fef1f4/go.mod h1:NWraEVixdDnqcqQ30jipen1STv2r/n24Wb7twVTGR4s=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0/go.mod h1:6Kw0yEErY5E/yWrBtf03jp27GLLJujG4z/JK95pnjjw=
+google.golang.org/grpc/stats/opencensus v0.0.0-20230414222620-eab9e20d1bbe h1:kZRsDpa5Y1mdGF+TdAcI8W8gpNA5lTZ0HUTgTbZjPb0=
+google.golang.org/grpc/stats/opencensus v0.0.0-20230414222620-eab9e20d1bbe/go.mod h1:FhdkeYvN43wLYUnapVuRJJ9JXkNwe403iLUW2LKSnjs=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=

--- a/interop/observability/go.mod
+++ b/interop/observability/go.mod
@@ -3,7 +3,7 @@ module google.golang.org/grpc/interop/observability
 go 1.17
 
 require (
-	google.golang.org/grpc v1.54.1-0.20230322004705-d200af566284
+	google.golang.org/grpc v1.54.0
 	google.golang.org/grpc/gcp/observability v0.0.0-20230214181353-f4feddb37523
 )
 

--- a/interop/observability/go.mod
+++ b/interop/observability/go.mod
@@ -3,7 +3,7 @@ module google.golang.org/grpc/interop/observability
 go 1.17
 
 require (
-	google.golang.org/grpc v1.53.0
+	google.golang.org/grpc v1.54.1-0.20230322004705-d200af566284
 	google.golang.org/grpc/gcp/observability v0.0.0-20230214181353-f4feddb37523
 )
 
@@ -35,7 +35,7 @@ require (
 	google.golang.org/api v0.110.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20230306155012-7f2fa6fef1f4 // indirect
-	google.golang.org/grpc/stats/opencensus v0.0.0-20230330193705-4a12595692ae // indirect
+	google.golang.org/grpc/stats/opencensus v0.0.0-20230414222620-eab9e20d1bbe // indirect
 	google.golang.org/protobuf v1.30.0 // indirect
 )
 


### PR DESCRIPTION
This PR points gcp/observability to gRPC 1.54. Previously, it was pointing to 1.53, so if a user built the binary with 1.53 version of gRPC, it would be missing some metrics released in 1.54.

RELEASE NOTES: N/A