### PR TITLE
alts: Queue ALTS handshakes rather than failing once the cap is reached.

### DIFF
--- a/credentials/alts/alts_test.go
+++ b/credentials/alts/alts_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/golang/protobuf/proto"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/alts/internal/handshaker"
 	"google.golang.org/grpc/credentials/alts/internal/handshaker/service"
 	altsgrpc "google.golang.org/grpc/credentials/alts/internal/proto/grpc_gcp"
 	altspb "google.golang.org/grpc/credentials/alts/internal/proto/grpc_gcp"
@@ -335,6 +336,80 @@ func (s) TestFullHandshake(t *testing.T) {
 	defer stopServer()
 
 	// Ping the server, authenticating with ALTS.
+	establishAltsConnection(t, handshakerAddress, serverAddress)
+
+	// Close open connections to the fake handshaker service.
+	if err := service.CloseForTesting(); err != nil {
+		t.Errorf("service.CloseForTesting() failed: %v", err)
+	}
+}
+
+// TestFullHandshake performs a several, concurrent ALTS handshakes between a
+// test client and server, where both client and server offload to a local,
+// fake handshaker service.
+func (s) TestConcurrentHandshakes(t *testing.T) {
+	// If GOMAXPROCS is set to less than 3, do not run this test. This test
+	// requires at least 2 goroutines to succeed (one goroutine where a
+	// server listens, another goroutine where a client runs).
+	if runtime.GOMAXPROCS(0) < 3 {
+		return
+	}
+
+	// The vmOnGCP global variable MUST be reset to true after the client
+	// or server credentials have been created, but before the ALTS
+	// handshake begins. If vmOnGCP is not reset and this test is run
+	// anywhere except for a GCP VM, then the ALTS handshake will
+	// immediately fail.
+	once.Do(func() {
+		vmOnGCP = true
+	})
+	vmOnGCP = true
+
+	// Set the max number of concurrent handshakes to 3, so that we can
+	// test the handshaker behavior when handshakes are queued by
+	// performing more than 3 concurrent handshakes (specifically, 10).
+	handshaker.SetMaxConcurrentHandshakesForTesting(int64(3))
+
+	// Start the fake handshaker service and the server.
+	var wait sync.WaitGroup
+	defer wait.Wait()
+	stopHandshaker, handshakerAddress := startFakeHandshakerService(t, &wait)
+	defer stopHandshaker()
+	stopServer, serverAddress := startServer(t, handshakerAddress, &wait)
+	defer stopServer()
+
+	// Ping the server, authenticating with ALTS.
+	var waitForConnections sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		waitForConnections.Add(1)
+		go func() {
+			establishAltsConnection(t, handshakerAddress, serverAddress)
+			waitForConnections.Done()
+		}()
+	}
+	waitForConnections.Wait()
+
+	// Close open connections to the fake handshaker service.
+	if err := service.CloseForTesting(); err != nil {
+		t.Errorf("service.CloseForTesting() failed: %v", err)
+	}
+}
+
+func version(major, minor uint32) *altspb.RpcProtocolVersions_Version {
+	return &altspb.RpcProtocolVersions_Version{
+		Major: major,
+		Minor: minor,
+	}
+}
+
+func versions(minMajor, minMinor, maxMajor, maxMinor uint32) *altspb.RpcProtocolVersions {
+	return &altspb.RpcProtocolVersions{
+		MinRpcVersion: version(minMajor, minMinor),
+		MaxRpcVersion: version(maxMajor, maxMinor),
+	}
+}
+
+func establishAltsConnection(t *testing.T, handshakerAddress, serverAddress string) {
 	clientCreds := NewClientCreds(&ClientOptions{HandshakerServiceAddress: handshakerAddress})
 	conn, err := grpc.Dial(serverAddress, grpc.WithTransportCredentials(clientCreds))
 	if err != nil {
@@ -354,25 +429,6 @@ func (s) TestFullHandshake(t *testing.T) {
 			continue
 		}
 		t.Fatalf("c.UnaryCall() failed: %v", err)
-	}
-
-	// Close open connections to the fake handshaker service.
-	if err := service.CloseForTesting(); err != nil {
-		t.Errorf("service.CloseForTesting() failed: %v", err)
-	}
-}
-
-func version(major, minor uint32) *altspb.RpcProtocolVersions_Version {
-	return &altspb.RpcProtocolVersions_Version{
-		Major: major,
-		Minor: minor,
-	}
-}
-
-func versions(minMajor, minMinor, maxMajor, maxMinor uint32) *altspb.RpcProtocolVersions {
-	return &altspb.RpcProtocolVersions{
-		MinRpcVersion: version(minMajor, minMinor),
-		MaxRpcVersion: version(maxMajor, maxMinor),
 	}
 }
 

--- a/credentials/alts/internal/handshaker/handshaker_test.go
+++ b/credentials/alts/internal/handshaker/handshaker_test.go
@@ -134,7 +134,7 @@ func (s) TestClientHandshake(t *testing.T) {
 		numberOfHandshakes int
 	}{
 		{0 * time.Millisecond, 1},
-		{100 * time.Millisecond, 10 * maxPendingHandshakes},
+		{100 * time.Millisecond, 10 * int(maxPendingHandshakes)},
 	} {
 		errc := make(chan error)
 		stat.Reset()
@@ -182,7 +182,7 @@ func (s) TestClientHandshake(t *testing.T) {
 		}
 
 		// Ensure that there are no concurrent calls more than the limit.
-		if stat.MaxConcurrentCalls > maxPendingHandshakes {
+		if stat.MaxConcurrentCalls > int(maxPendingHandshakes) {
 			t.Errorf("Observed %d concurrent handshakes; want <= %d", stat.MaxConcurrentCalls, maxPendingHandshakes)
 		}
 	}
@@ -194,7 +194,7 @@ func (s) TestServerHandshake(t *testing.T) {
 		numberOfHandshakes int
 	}{
 		{0 * time.Millisecond, 1},
-		{100 * time.Millisecond, 10 * maxPendingHandshakes},
+		{100 * time.Millisecond, 10 * int(maxPendingHandshakes)},
 	} {
 		errc := make(chan error)
 		stat.Reset()
@@ -239,8 +239,8 @@ func (s) TestServerHandshake(t *testing.T) {
 		}
 
 		// Ensure that there are no concurrent calls more than the limit.
-		if stat.MaxConcurrentCalls > maxPendingHandshakes {
-			t.Errorf("Observed %d concurrent handshakes; want <= %d", stat.MaxConcurrentCalls, maxPendingHandshakes)
+		if stat.MaxConcurrentCalls > int(maxPendingHandshakes) {
+			t.Errorf("Observed %d concurrent handshakes; want <= %d", stat.MaxConcurrentCalls, int(maxPendingHandshakes))
 		}
 	}
 }


### PR DESCRIPTION
The current behavior is to fail ALTS handshakes once we have reached the max number of concurrent handshakes. This is different than the behavior in C++ and Java, where we queue handshakes once the max has been reached. This PR fixes the behavior in Go to queue handshakes instead of failing, aligning it with the behavior of the C++ and Java stacks.