### PR TITLE
internal: Document gcp/observability 1.0 dependencies in /internal

### DIFF
--- a/internal/binarylog/binarylog.go
+++ b/internal/binarylog/binarylog.go
@@ -32,6 +32,9 @@ var grpclogLogger = grpclog.Component("binarylog")
 
 // Logger specifies MethodLoggers for method names with a Log call that
 // takes a context.
+//
+// This is used in the 1.0 release of gcp/observability, and thus must not be
+// deleted or changed.
 type Logger interface {
 	GetMethodLogger(methodName string) MethodLogger
 }

--- a/internal/binarylog/method_logger.go
+++ b/internal/binarylog/method_logger.go
@@ -49,6 +49,9 @@ func (g *callIDGenerator) reset() {
 var idGen callIDGenerator
 
 // MethodLogger is the sub-logger for each method.
+//
+// This is used in the 1.0 release of gcp/observability, and thus must not be
+// deleted or changed.
 type MethodLogger interface {
 	Log(context.Context, LogEntryConfig)
 }
@@ -65,6 +68,9 @@ type TruncatingMethodLogger struct {
 }
 
 // NewTruncatingMethodLogger returns a new truncating method logger.
+//
+// This is used in the 1.0 release of gcp/observability, and thus must not be
+// deleted or changed.
 func NewTruncatingMethodLogger(h, m uint64) *TruncatingMethodLogger {
 	return &TruncatingMethodLogger{
 		headerMaxLen:  h,
@@ -145,6 +151,9 @@ func (ml *TruncatingMethodLogger) truncateMessage(msgPb *binlogpb.Message) (trun
 }
 
 // LogEntryConfig represents the configuration for binary log entry.
+//
+// This is used in the 1.0 release of gcp/observability, and thus must not be
+// deleted or changed.
 type LogEntryConfig interface {
 	toProto() *binlogpb.GrpcLogEntry
 }

--- a/internal/envconfig/observability.go
+++ b/internal/envconfig/observability.go
@@ -28,9 +28,15 @@ const (
 var (
 	// ObservabilityConfig is the json configuration for the gcp/observability
 	// package specified directly in the envObservabilityConfig env var.
+	//
+	// This is used in the 1.0 release of gcp/observability, and thus must not be
+	// deleted or changed.
 	ObservabilityConfig = os.Getenv(envObservabilityConfig)
 	// ObservabilityConfigFile is the json configuration for the
 	// gcp/observability specified in a file with the location specified in
 	// envObservabilityConfigFile env var.
+	//
+	// This is used in the 1.0 release of gcp/observability, and thus must not be
+	// deleted or changed.
 	ObservabilityConfigFile = os.Getenv(envObservabilityConfigFile)
 )

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -60,6 +60,9 @@ var (
 	GetServerCredentials interface{} // func (*grpc.Server) credentials.TransportCredentials
 	// CanonicalString returns the canonical string of the code defined here:
 	// https://github.com/grpc/grpc/blob/master/doc/statuscodes.md.
+	//
+	// This is used in the 1.0 release of gcp/observability, and thus must not be
+	// deleted or changed.
 	CanonicalString interface{} // func (codes.Code) string
 	// DrainServerTransports initiates a graceful close of existing connections
 	// on a gRPC server accepted on the provided listener address. An
@@ -69,20 +72,35 @@ var (
 	// AddGlobalServerOptions adds an array of ServerOption that will be
 	// effective globally for newly created servers. The priority will be: 1.
 	// user-provided; 2. this method; 3. default values.
+	//
+	// This is used in the 1.0 release of gcp/observability, and thus must not be
+	// deleted or changed.
 	AddGlobalServerOptions interface{} // func(opt ...ServerOption)
 	// ClearGlobalServerOptions clears the array of extra ServerOption. This
 	// method is useful in testing and benchmarking.
+	//
+	// This is used in the 1.0 release of gcp/observability, and thus must not be
+	// deleted or changed.
 	ClearGlobalServerOptions func()
 	// AddGlobalDialOptions adds an array of DialOption that will be effective
 	// globally for newly created client channels. The priority will be: 1.
 	// user-provided; 2. this method; 3. default values.
+	//
+	// This is used in the 1.0 release of gcp/observability, and thus must not be
+	// deleted or changed.
 	AddGlobalDialOptions interface{} // func(opt ...DialOption)
 	// DisableGlobalDialOptions returns a DialOption that prevents the
 	// ClientConn from applying the global DialOptions (set via
 	// AddGlobalDialOptions).
+	//
+	// This is used in the 1.0 release of gcp/observability, and thus must not be
+	// deleted or changed.
 	DisableGlobalDialOptions interface{} // func() grpc.DialOption
 	// ClearGlobalDialOptions clears the array of extra DialOption. This
 	// method is useful in testing and benchmarking.
+	//
+	// This is used in the 1.0 release of gcp/observability, and thus must not be
+	// deleted or changed.
 	ClearGlobalDialOptions func()
 	// JoinDialOptions combines the dial options passed as arguments into a
 	// single dial option.
@@ -93,9 +111,15 @@ var (
 
 	// WithBinaryLogger returns a DialOption that specifies the binary logger
 	// for a ClientConn.
+	//
+	// This is used in the 1.0 release of gcp/observability, and thus must not be
+	// deleted or changed.
 	WithBinaryLogger interface{} // func(binarylog.Logger) grpc.DialOption
 	// BinaryLogger returns a ServerOption that can set the binary logger for a
 	// server.
+	//
+	// This is used in the 1.0 release of gcp/observability, and thus must not be
+	// deleted or changed.
 	BinaryLogger interface{} // func(binarylog.Logger) grpc.ServerOption
 
 	// NewXDSResolverWithConfigForTesting creates a new xds resolver builder using


### PR DESCRIPTION
We recently release gcp/observability as 1.0, with a dependency on grpc. However, this release used internal symbols which are not guaranteed to be stable over time. However, in order not to break users of gcp/observability 1.0 in the future (they can use any version of grpc >= the grpc version specified in go.mod) we need to explicitly document this in internal symbols and behaviors being depended upon.

RELEASE NOTES: N/A