### PR TITLE
xds: make glaze happy for test packages

### DIFF
--- a/xds/internal/xdsclient/xdslbregistry/tests/converter_test.go
+++ b/xds/internal/xdsclient/xdslbregistry/tests/converter_test.go
@@ -16,8 +16,8 @@
  *
  */
 
-// Package test contains test cases for the xDS LB Policy Registry.
-package test
+// Package tests_test contains test cases for the xDS LB Policy Registry.
+package tests_test
 
 import (
 	"encoding/json"

--- a/xds/internal/xdsclient/xdsresource/tests/unmarshal_cds_test.go
+++ b/xds/internal/xdsclient/xdsresource/tests/unmarshal_cds_test.go
@@ -16,8 +16,8 @@
  *
  */
 
-// Package test contains test cases for unmarshalling of CDS resources.
-package test
+// Package tests_test contains test cases for unmarshalling of CDS resources.
+package tests_test
 
 import (
 	"encoding/json"


### PR DESCRIPTION
When running the import, I figured out that `glaze` doesn't like packages named `test`. The suggestion is to call it `tests_test`.

RELEASE NOTES: none