### PR TITLE
multiple: standardize import renaming for typed structs

### DIFF
--- a/authz/rbac_translator.go
+++ b/authz/rbac_translator.go
@@ -28,7 +28,7 @@ import (
 	"fmt"
 	"strings"
 
-	v1typepb "github.com/cncf/xds/go/udpa/type/v1"
+	v1xdsudpatypepb "github.com/cncf/xds/go/udpa/type/v1"
 	v3corepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	v3rbacpb "github.com/envoyproxy/go-control-plane/envoy/config/rbac/v3"
 	v3routepb "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
@@ -307,7 +307,7 @@ func (options *auditLoggingOptions) toProtos() (allow *v3rbacpb.RBAC_AuditLoggin
 		if config.Config == nil {
 			return nil, nil, fmt.Errorf("AuditLogger Config field cannot be nil")
 		}
-		typedStruct := &v1typepb.TypedStruct{
+		typedStruct := &v1xdsudpatypepb.TypedStruct{
 			TypeUrl: typedURLPrefix + config.Name,
 			Value:   config.Config,
 		}

--- a/authz/rbac_translator_test.go
+++ b/authz/rbac_translator_test.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 	"testing"
 
-	v1typepb "github.com/cncf/xds/go/udpa/type/v1"
+	v1xdsudpatypepb "github.com/cncf/xds/go/udpa/type/v1"
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/protobuf/testing/protocmp"
 	"google.golang.org/protobuf/types/known/anypb"
@@ -945,7 +945,7 @@ func TestTranslatePolicy(t *testing.T) {
 func anyPbHelper(t *testing.T, in map[string]interface{}, name string) *anypb.Any {
 	t.Helper()
 	pb, err := structpb.NewStruct(in)
-	typedStruct := &v1typepb.TypedStruct{
+	typedStruct := &v1xdsudpatypepb.TypedStruct{
 		TypeUrl: typedURLPrefix + name,
 		Value:   pb,
 	}

--- a/xds/internal/xdsclient/xdslbregistry/converter.go
+++ b/xds/internal/xdsclient/xdslbregistry/converter.go
@@ -26,8 +26,8 @@ import (
 	"fmt"
 	"strings"
 
-	v1udpatypepb "github.com/cncf/xds/go/udpa/type/v1"
-	v3cncftypepb "github.com/cncf/xds/go/xds/type/v3"
+	v1xdsudpatypepb "github.com/cncf/xds/go/udpa/type/v1"
+	v3xdsxdstypepb "github.com/cncf/xds/go/xds/type/v3"
 	v3clusterpb "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	v3ringhashpb "github.com/envoyproxy/go-control-plane/envoy/extensions/load_balancing_policies/ring_hash/v3"
 	v3wrrlocalitypb "github.com/envoyproxy/go-control-plane/envoy/extensions/load_balancing_policies/wrr_locality/v3"
@@ -86,13 +86,13 @@ func convertToServiceConfig(lbPolicy *v3clusterpb.LoadBalancingPolicy, depth int
 			}
 			return convertWrrLocality(wrrlProto, depth)
 		case "type.googleapis.com/xds.type.v3.TypedStruct":
-			tsProto := &v3cncftypepb.TypedStruct{}
+			tsProto := &v3xdsxdstypepb.TypedStruct{}
 			if err := proto.Unmarshal(policy.GetTypedExtensionConfig().GetTypedConfig().GetValue(), tsProto); err != nil {
 				return nil, fmt.Errorf("failed to unmarshal resource: %v", err)
 			}
 			return convertCustomPolicy(tsProto.GetTypeUrl(), tsProto.GetValue())
 		case "type.googleapis.com/udpa.type.v1.TypedStruct":
-			tsProto := &v1udpatypepb.TypedStruct{}
+			tsProto := &v1xdsudpatypepb.TypedStruct{}
 			if err := proto.Unmarshal(policy.GetTypedExtensionConfig().GetTypedConfig().GetValue(), tsProto); err != nil {
 				return nil, fmt.Errorf("failed to unmarshal resource: %v", err)
 			}

--- a/xds/internal/xdsclient/xdslbregistry/tests/converter_test.go
+++ b/xds/internal/xdsclient/xdslbregistry/tests/converter_test.go
@@ -24,8 +24,8 @@ import (
 	"strings"
 	"testing"
 
-	v1udpatypepb "github.com/cncf/xds/go/udpa/type/v1"
-	v3cncftypepb "github.com/cncf/xds/go/xds/type/v3"
+	v1xdsudpatypepb "github.com/cncf/xds/go/udpa/type/v1"
+	v3xdsxdstypepb "github.com/cncf/xds/go/xds/type/v3"
 	v3clusterpb "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	v3corepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	v3leastrequestpb "github.com/envoyproxy/go-control-plane/envoy/extensions/load_balancing_policies/least_request/v3"
@@ -172,7 +172,7 @@ func (s) TestConvertToServiceConfigSuccess(t *testing.T) {
 				Policies: []*v3clusterpb.LoadBalancingPolicy_Policy{
 					{
 						TypedExtensionConfig: &v3corepb.TypedExtensionConfig{
-							TypedConfig: testutils.MarshalAny(&v3cncftypepb.TypedStruct{
+							TypedConfig: testutils.MarshalAny(&v3xdsxdstypepb.TypedStruct{
 								TypeUrl: "type.googleapis.com/myorg.MyCustomLeastRequestPolicy",
 								Value:   &structpb.Struct{},
 							}),
@@ -191,7 +191,7 @@ func (s) TestConvertToServiceConfigSuccess(t *testing.T) {
 				Policies: []*v3clusterpb.LoadBalancingPolicy_Policy{
 					{
 						TypedExtensionConfig: &v3corepb.TypedExtensionConfig{
-							TypedConfig: testutils.MarshalAny(&v1udpatypepb.TypedStruct{
+							TypedConfig: testutils.MarshalAny(&v1xdsudpatypepb.TypedStruct{
 								TypeUrl: "type.googleapis.com/myorg.MyCustomLeastRequestPolicy",
 								Value:   &structpb.Struct{},
 							}),
@@ -230,7 +230,7 @@ func (s) TestConvertToServiceConfigSuccess(t *testing.T) {
 				Policies: []*v3clusterpb.LoadBalancingPolicy_Policy{
 					{
 						TypedExtensionConfig: &v3corepb.TypedExtensionConfig{
-							TypedConfig: wrrLocalityAny(&v3cncftypepb.TypedStruct{
+							TypedConfig: wrrLocalityAny(&v3xdsxdstypepb.TypedStruct{
 								TypeUrl: "type.googleapis.com/myorg.MyCustomLeastRequestPolicy",
 								Value:   &structpb.Struct{},
 							}),

--- a/xds/internal/xdsclient/xdsresource/tests/unmarshal_cds_test.go
+++ b/xds/internal/xdsclient/xdsresource/tests/unmarshal_cds_test.go
@@ -37,7 +37,7 @@ import (
 	"google.golang.org/grpc/xds/internal/xdsclient/xdsresource"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
-	v3cncftypepb "github.com/cncf/xds/go/xds/type/v3"
+	v3xdsxdstypepb "github.com/cncf/xds/go/xds/type/v3"
 	v3clusterpb "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	v3corepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	v3endpointpb "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
@@ -457,7 +457,7 @@ func (s) TestValidateCluster_Success(t *testing.T) {
 					Policies: []*v3clusterpb.LoadBalancingPolicy_Policy{
 						{
 							TypedExtensionConfig: &v3corepb.TypedExtensionConfig{
-								TypedConfig: wrrLocalityAny(&v3cncftypepb.TypedStruct{
+								TypedConfig: wrrLocalityAny(&v3xdsxdstypepb.TypedStruct{
 									TypeUrl: "type.googleapis.com/myorg.MyCustomLeastRequestPolicy",
 									Value:   &structpb.Struct{},
 								}),

--- a/xds/internal/xdsclient/xdsresource/unmarshal_lds.go
+++ b/xds/internal/xdsclient/xdsresource/unmarshal_lds.go
@@ -22,8 +22,8 @@ import (
 	"fmt"
 	"strconv"
 
-	v1udpatypepb "github.com/cncf/udpa/go/udpa/type/v1"
-	v3cncftypepb "github.com/cncf/xds/go/xds/type/v3"
+	v1udpaudpatypepb "github.com/cncf/udpa/go/udpa/type/v1"
+	v3xdsxdstypepb "github.com/cncf/xds/go/xds/type/v3"
 	v3listenerpb "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	v3routepb "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	v3httppb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
@@ -121,16 +121,16 @@ func processClientSideListener(lis *v3listenerpb.Listener) (*ListenerUpdate, err
 
 func unwrapHTTPFilterConfig(config *anypb.Any) (proto.Message, string, error) {
 	switch {
-	case ptypes.Is(config, &v3cncftypepb.TypedStruct{}):
+	case ptypes.Is(config, &v3xdsxdstypepb.TypedStruct{}):
 		// The real type name is inside the new TypedStruct message.
-		s := new(v3cncftypepb.TypedStruct)
+		s := new(v3xdsxdstypepb.TypedStruct)
 		if err := ptypes.UnmarshalAny(config, s); err != nil {
 			return nil, "", fmt.Errorf("error unmarshalling TypedStruct filter config: %v", err)
 		}
 		return s, s.GetTypeUrl(), nil
-	case ptypes.Is(config, &v1udpatypepb.TypedStruct{}):
+	case ptypes.Is(config, &v1udpaudpatypepb.TypedStruct{}):
 		// The real type name is inside the old TypedStruct message.
-		s := new(v1udpatypepb.TypedStruct)
+		s := new(v1udpaudpatypepb.TypedStruct)
 		if err := ptypes.UnmarshalAny(config, s); err != nil {
 			return nil, "", fmt.Errorf("error unmarshalling TypedStruct filter config: %v", err)
 		}

--- a/xds/internal/xdsclient/xdsresource/unmarshal_lds_test.go
+++ b/xds/internal/xdsclient/xdsresource/unmarshal_lds_test.go
@@ -34,8 +34,8 @@ import (
 	"google.golang.org/grpc/xds/internal/xdsclient/xdsresource/version"
 	"google.golang.org/protobuf/types/known/durationpb"
 
-	v1udpatypepb "github.com/cncf/udpa/go/udpa/type/v1"
-	v3cncftypepb "github.com/cncf/xds/go/xds/type/v3"
+	v1udpaudpatypepb "github.com/cncf/udpa/go/udpa/type/v1"
+	v3xdsxdstypepb "github.com/cncf/xds/go/xds/type/v3"
 	v3corepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	v3listenerpb "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	rpb "github.com/envoyproxy/go-control-plane/envoy/config/rbac/v3"
@@ -1830,7 +1830,7 @@ var clientOnlyCustomFilterConfig = &anypb.Any{
 }
 
 // This custom filter uses the old TypedStruct message from the cncf/udpa repo.
-var customFilterOldTypedStructConfig = &v1udpatypepb.TypedStruct{
+var customFilterOldTypedStructConfig = &v1udpaudpatypepb.TypedStruct{
 	TypeUrl: "custom.filter",
 	Value: &spb.Struct{
 		Fields: map[string]*spb.Value{
@@ -1841,7 +1841,7 @@ var customFilterOldTypedStructConfig = &v1udpatypepb.TypedStruct{
 var wrappedCustomFilterOldTypedStructConfig *anypb.Any
 
 // This custom filter uses the new TypedStruct message from the cncf/xds repo.
-var customFilterNewTypedStructConfig = &v3cncftypepb.TypedStruct{
+var customFilterNewTypedStructConfig = &v3xdsxdstypepb.TypedStruct{
 	TypeUrl: "custom.filter",
 	Value: &spb.Struct{
 		Fields: map[string]*spb.Value{


### PR DESCRIPTION
We have a bunch of imports that need to be standardized so that we can rename them appropriately at import time.

- github.com/cncf/udpa/go/udpa/type/v1: v1udpaudpatypepb
- github.com/cncf/xds/go/udpa/type/v1: v1xdsudpatypepb
- github.com/cncf/xds/go/xds/type/v3: v3xdsxdstypepb

This change needs to be followed up by a change to our import configuration.

RELEASE NOTES: none