### PR TITLE
orca: minor cleanups

### DIFF
--- a/orca/call_metric_recorder_test.go
+++ b/orca/call_metric_recorder_test.go
@@ -34,6 +34,7 @@ import (
 	"google.golang.org/grpc/internal/stubserver"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/orca"
+	"google.golang.org/grpc/orca/internal"
 
 	v3orcapb "github.com/cncf/xds/go/xds/data/orca/v3"
 	testgrpc "google.golang.org/grpc/interop/grpc_testing"
@@ -58,7 +59,6 @@ func (s) TestE2ECallMetricsUnary(t *testing.T) {
 		desc          string
 		injectMetrics bool
 		wantProto     *v3orcapb.OrcaLoadReport
-		wantErr       error
 	}{
 		{
 			desc:          "with custom backend metrics",
@@ -73,7 +73,6 @@ func (s) TestE2ECallMetricsUnary(t *testing.T) {
 		{
 			desc:          "with no custom backend metrics",
 			injectMetrics: false,
-			wantErr:       orca.ErrLoadReportMissing,
 		},
 	}
 
@@ -146,9 +145,9 @@ func (s) TestE2ECallMetricsUnary(t *testing.T) {
 				t.Fatalf("EmptyCall failed: %v", err)
 			}
 
-			gotProto, err := orca.ToLoadReport(trailer)
-			if test.wantErr != nil && !errors.Is(err, test.wantErr) {
-				t.Fatalf("When retrieving load report, got error: %v, want: %v", err, orca.ErrLoadReportMissing)
+			gotProto, err := internal.ToLoadReport(trailer)
+			if err != nil {
+				t.Fatalf("When retrieving load report, got error: %v, want: <nil>", err)
 			}
 			if test.wantProto != nil && !cmp.Equal(gotProto, test.wantProto, cmp.Comparer(proto.Equal)) {
 				t.Fatalf("Received load report in trailer: %s, want: %s", pretty.ToJSON(gotProto), pretty.ToJSON(test.wantProto))
@@ -165,7 +164,6 @@ func (s) TestE2ECallMetricsStreaming(t *testing.T) {
 		desc          string
 		injectMetrics bool
 		wantProto     *v3orcapb.OrcaLoadReport
-		wantErr       error
 	}{
 		{
 			desc:          "with custom backend metrics",
@@ -180,7 +178,6 @@ func (s) TestE2ECallMetricsStreaming(t *testing.T) {
 		{
 			desc:          "with no custom backend metrics",
 			injectMetrics: false,
-			wantErr:       orca.ErrLoadReportMissing,
 		},
 	}
 
@@ -288,9 +285,9 @@ func (s) TestE2ECallMetricsStreaming(t *testing.T) {
 				}
 			}
 
-			gotProto, err := orca.ToLoadReport(stream.Trailer())
-			if test.wantErr != nil && !errors.Is(err, test.wantErr) {
-				t.Fatalf("When retrieving load report, got error: %v, want: %v", err, orca.ErrLoadReportMissing)
+			gotProto, err := internal.ToLoadReport(stream.Trailer())
+			if err != nil {
+				t.Fatalf("When retrieving load report, got error: %v, want: <nil>", err)
 			}
 			if test.wantProto != nil && !cmp.Equal(gotProto, test.wantProto, cmp.Comparer(proto.Equal)) {
 				t.Fatalf("Received load report in trailer: %s, want: %s", pretty.ToJSON(gotProto), pretty.ToJSON(test.wantProto))

--- a/orca/internal/internal.go
+++ b/orca/internal/internal.go
@@ -50,8 +50,9 @@ const TrailerMetadataKey = "endpoint-load-metrics-bin"
 // from md and returns the corresponding struct. The load report is expected to
 // be stored as the value for key "endpoint-load-metrics-bin".
 //
-// If no load report was found in the provided metadata, if it cannot be
-// parsed, or if multiple are found, an error is returned.
+// If no load report was found in the provided metadata, if multiple load
+// reports are found, or if the load report found cannot be parsed, an error is
+// returned.
 //
 // [ORCA LoadReport]: (https://github.com/cncf/xds/blob/main/xds/data/orca/v3/orca_load_report.proto#L15)
 func ToLoadReport(md metadata.MD) (*v3orcapb.OrcaLoadReport, error) {

--- a/orca/orca_test.go
+++ b/orca/orca_test.go
@@ -31,6 +31,12 @@ import (
 )
 
 func TestToLoadReport(t *testing.T) {
+	goodReport := &v3orcapb.OrcaLoadReport{
+		CpuUtilization: 1.0,
+		MemUtilization: 50.0,
+		RequestCost:    map[string]float64{"queryCost": 25.0},
+		Utilization:    map[string]float64{"queueSize": 75.0},
+	}
 	tests := []struct {
 		name    string
 		md      metadata.MD
@@ -50,22 +56,20 @@ func TestToLoadReport(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "multiple load reports",
+			md: func() metadata.MD {
+				b, _ := proto.Marshal(goodReport)
+				return metadata.Pairs("endpoint-load-metrics-bin", string(b), "endpoint-load-metrics-bin", string(b))
+			}(),
+			wantErr: true,
+		},
+		{
 			name: "good load report",
 			md: func() metadata.MD {
-				b, _ := proto.Marshal(&v3orcapb.OrcaLoadReport{
-					CpuUtilization: 1.0,
-					MemUtilization: 50.0,
-					RequestCost:    map[string]float64{"queryCost": 25.0},
-					Utilization:    map[string]float64{"queueSize": 75.0},
-				})
+				b, _ := proto.Marshal(goodReport)
 				return metadata.Pairs("endpoint-load-metrics-bin", string(b))
 			}(),
-			want: &v3orcapb.OrcaLoadReport{
-				CpuUtilization: 1.0,
-				MemUtilization: 50.0,
-				RequestCost:    map[string]float64{"queryCost": 25.0},
-				Utilization:    map[string]float64{"queueSize": 75.0},
-			},
+			want: goodReport,
 		},
 	}
 

--- a/orca/orca_test.go
+++ b/orca/orca_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/grpc/internal/pretty"
 	"google.golang.org/grpc/metadata"
-	"google.golang.org/grpc/orca"
+	"google.golang.org/grpc/orca/internal"
 
 	v3orcapb "github.com/cncf/xds/go/xds/data/orca/v3"
 )
@@ -40,7 +40,7 @@ func TestToLoadReport(t *testing.T) {
 		{
 			name:    "no load report in metadata",
 			md:      metadata.MD{},
-			wantErr: true,
+			wantErr: false,
 		},
 		{
 			name: "badly marshaled load report",
@@ -71,7 +71,7 @@ func TestToLoadReport(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := orca.ToLoadReport(test.md)
+			got, err := internal.ToLoadReport(test.md)
 			if (err != nil) != test.wantErr {
 				t.Fatalf("orca.ToLoadReport(%v) = %v, wantErr: %v", test.md, err, test.wantErr)
 			}

--- a/orca/service.go
+++ b/orca/service.go
@@ -120,7 +120,7 @@ func (s *Service) determineReportingInterval(req *v3orcaservicepb.OrcaLoadReport
 	}
 	dur := req.GetReportInterval().AsDuration()
 	if dur < s.minReportingInterval {
-		logger.Warningf("Received reporting interval %q is less than configured minimum: %v. Using default: %s", dur, s.minReportingInterval)
+		logger.Warningf("Received reporting interval %q is less than configured minimum: %v. Using minimum", dur, s.minReportingInterval)
 		return s.minReportingInterval
 	}
 	return dur


### PR DESCRIPTION
* Move `ToReportProto` to `internal` - it was never meant to be exported / part of the ORCA API, but it is tested from another package (`orca_test`) so it still needs to be exported.  (This is also done in #6223, so they will technically conflict but both are ~the same.)
* Don't error in `ToReportProto` if there is no load report present.  This will prevent error log spam which occurs whenever the ORCA package is imported and a `Done` callback is set by a picker.
* Minor log line fix to remove unused %-format item.
* Downgrade error log to info for ORCA parse error.

RELEASE NOTES: none