### PR TITLE
googledirectpatph: enable ignore_resource_deletion in bootstrap

### DIFF
--- a/xds/googledirectpath/googlec2p.go
+++ b/xds/googledirectpath/googlec2p.go
@@ -120,7 +120,7 @@ func (c2pResolverBuilder) Build(t resolver.Target, cc resolver.ClientConn, opts 
 	{
 		"server_uri": "%s",
 		"channel_creds": [{"type": "google_default"}],
-		"server_features": ["xds_v3"]
+		"server_features": ["xds_v3", "ignore_resource_deletion"]
 	}`, balancerName)))
 	if err != nil {
 		return nil, fmt.Errorf("failed to build bootstrap configuration: %v", err)

--- a/xds/googledirectpath/googlec2p_test.go
+++ b/xds/googledirectpath/googlec2p_test.go
@@ -216,7 +216,7 @@ func TestBuildXDS(t *testing.T) {
 			wantServerConfig, err := bootstrap.ServerConfigFromJSON([]byte(fmt.Sprintf(`{
 				"server_uri": "%s",
 				"channel_creds": [{"type": "google_default"}],
-				"server_features": ["xds_v3"]
+				"server_features": ["xds_v3", "ignore_resource_deletion"]
 			}`, tdURL)))
 			if err != nil {
 				t.Fatalf("Failed to build server bootstrap config: %v", err)


### PR DESCRIPTION
This will need to be cherry-picked to the release branch before performing the release.

CC @veblush, @apolcyn, @mohanli-ml

RELEASE NOTES:
* googledirectpath: enable `ignore_resource_deletion` server feature in bootstrap