### PR TITLE
orca: fix race when calling listeners coincides with updating the run goroutine

### DIFF
--- a/orca/producer.go
+++ b/orca/producer.go
@@ -161,13 +161,13 @@ func (p *producer) updateRunLocked() {
 		var ctx context.Context
 		ctx, p.stop = context.WithCancel(context.Background())
 		p.stopped = make(chan struct{})
-		go p.run(ctx, p.minInterval)
+		go p.run(ctx, p.stopped, p.minInterval)
 	}
 }
 
 // run manages the ORCA OOB stream on the subchannel.
-func (p *producer) run(ctx context.Context, interval time.Duration) {
-	defer close(p.stopped)
+func (p *producer) run(ctx context.Context, done chan struct{}, interval time.Duration) {
+	defer close(done)
 
 	backoffAttempt := 0
 	backoffTimer := time.NewTimer(0)

--- a/orca/producer.go
+++ b/orca/producer.go
@@ -44,7 +44,9 @@ func (*producerBuilder) Build(cci interface{}) (balancer.Producer, func()) {
 		listeners: make(map[OOBListener]struct{}),
 		backoff:   internal.DefaultBackoffFunc,
 	}
-	return p, func() {}
+	return p, func() {
+		<-p.stopped
+	}
 }
 
 var producerBuilderSingleton = &producerBuilder{}
@@ -153,7 +155,6 @@ func (p *producer) recomputeMinInterval() {
 func (p *producer) updateRunLocked() {
 	if p.stop != nil {
 		p.stop()
-		<-p.stopped
 		p.stop = nil
 	}
 	if len(p.listeners) > 0 {


### PR DESCRIPTION
Blocking on `p.stopped` while holding `p.mu` can race if the `run` goroutine had just received a report and is trying to acquire `p.mu` in order to call the listeners.

Waiting for the run goroutine to exit before starting a new one is not necessary.  This change will start a new one without waiting, and only wait during producer shutdown (which is also not strictly necessary, but is a good idea to ensure all resources are cleaned up).

RELEASE NOTES: none