### PR TITLE
grpc: support channel idleness

### DIFF
--- a/balancer_conn_wrappers.go
+++ b/balancer_conn_wrappers.go
@@ -210,23 +210,23 @@ func (ccb *ccBalancerWrapper) buildLoadBalancingPolicy(name string) {
 
 func (ccb *ccBalancerWrapper) close() {
 	channelz.Info(logger, ccb.cc.channelzID, "ccBalancerWrapper: closing")
-	ccb.handleCloseAndEnterIdle(ccbModeClosed)
+	ccb.closeBalancer(ccbModeClosed)
 }
 
 // enterIdleMode is invoked by grpc when the channel enters idle mode upon
 // expiry of idle_timeout. This call blocks until the balancer is closed.
 func (ccb *ccBalancerWrapper) enterIdleMode() {
 	channelz.Info(logger, ccb.cc.channelzID, "ccBalancerWrapper: entering idle mode")
-	ccb.handleCloseAndEnterIdle(ccbModeIdle)
+	ccb.closeBalancer(ccbModeIdle)
 }
 
-// handleCloseAndEnterIdle is invoked when the channel is being closed or when
-// it enters idle mode upon expiry of idle_timeout.
+// closeBalancer is invoked when the channel is being closed or when it enters
+// idle mode upon expiry of idle_timeout.
 //
 // This call is not scheduled on the serializer because we need to ensure that
 // the current serializer is completely shutdown before the next one is created
 // (when exiting idle).
-func (ccb *ccBalancerWrapper) handleCloseAndEnterIdle(m ccbMode) {
+func (ccb *ccBalancerWrapper) closeBalancer(m ccbMode) {
 	ccb.mu.Lock()
 	if ccb.mode == ccbModeClosed || ccb.mode == ccbModeIdle {
 		ccb.mu.Unlock()

--- a/balancer_conn_wrappers.go
+++ b/balancer_conn_wrappers.go
@@ -241,9 +241,11 @@ func (ccb *ccBalancerWrapper) handleCloseAndEnterIdle(m ccbMode) {
 	b := ccb.balancer
 	ccb.mu.Unlock()
 
-	// Give enqueued callbacks a chance to finish before closing the balancer.
+	// Give enqueued callbacks a chance to finish.
 	<-done
-	b.Close()
+	// Spawn a goroutine to close the balancer (since it may block trying to
+	// cleanup all allocated resources) and return early.
+	go b.Close()
 }
 
 // exitIdleMode is invoked by grpc when the channel exits idle mode either

--- a/balancer_conn_wrappers.go
+++ b/balancer_conn_wrappers.go
@@ -32,6 +32,15 @@ import (
 	"google.golang.org/grpc/resolver"
 )
 
+type ccbMode int
+
+const (
+	ccbModeActive = iota
+	ccbModeIdle
+	ccbModeClosed
+	ccbModeExitingIdle
+)
+
 // ccBalancerWrapper sits between the ClientConn and the Balancer.
 //
 // ccBalancerWrapper implements methods corresponding to the ones on the
@@ -46,16 +55,25 @@ import (
 // It uses the gracefulswitch.Balancer internally to ensure that balancer
 // switches happen in a graceful manner.
 type ccBalancerWrapper struct {
-	cc *ClientConn
+	// The following fields are initialized when the wrapper is created and are
+	// read-only afterwards, and therefore can be accessed without a mutex.
+	cc   *ClientConn
+	opts balancer.BuildOptions
 
 	// Outgoing (gRPC --> balancer) calls are guaranteed to execute in a
-	// mutually exclusive manner as they are scheduled on the
-	// CallbackSerializer. Fields accessed *only* in serializer callbacks, can
-	// therefore be accessed without a mutex.
-	serializer       *grpcsync.CallbackSerializer
-	serializerCancel context.CancelFunc
-	balancer         *gracefulswitch.Balancer
-	curBalancerName  string
+	// mutually exclusive manner as they are scheduled in the serializer. Fields
+	// accessed *only* in these serializer callbacks, can therefore be accessed
+	// without a mutex.
+	balancer        *gracefulswitch.Balancer
+	curBalancerName string
+
+	// mu guards access to the below fields. Access to the serializer and its
+	// cancel function needs to be mutex protected because they are overwritten
+	// when the wrapper exits idle mode.
+	mu               sync.Mutex
+	serializer       *grpcsync.CallbackSerializer // To serialize all outoing calls.
+	serializerCancel context.CancelFunc           // To close the seralizer at close/enterIdle time.
+	mode             ccbMode                      // Tracks the current mode of the wrapper.
 }
 
 // newCCBalancerWrapper creates a new balancer wrapper. The underlying balancer
@@ -64,6 +82,7 @@ func newCCBalancerWrapper(cc *ClientConn, bopts balancer.BuildOptions) *ccBalanc
 	ctx, cancel := context.WithCancel(context.Background())
 	ccb := &ccBalancerWrapper{
 		cc:               cc,
+		opts:             bopts,
 		serializer:       grpcsync.NewCallbackSerializer(ctx),
 		serializerCancel: cancel,
 	}
@@ -74,8 +93,12 @@ func newCCBalancerWrapper(cc *ClientConn, bopts balancer.BuildOptions) *ccBalanc
 // updateClientConnState is invoked by grpc to push a ClientConnState update to
 // the underlying balancer.
 func (ccb *ccBalancerWrapper) updateClientConnState(ccs *balancer.ClientConnState) error {
+	ccb.mu.Lock()
 	errCh := make(chan error, 1)
-	ccb.serializer.Schedule(func(_ context.Context) {
+	// Here and everywhere else where Schedule() is called, it is done with the
+	// lock held. But the lock guards only the scheduling part. The actual
+	// callback is called asynchronously without the lock being held.
+	ok := ccb.serializer.Schedule(func(_ context.Context) {
 		// If the addresses specified in the update contain addresses of type
 		// "grpclb" and the selected LB policy is not "grpclb", these addresses
 		// will be filtered out and ccs will be modified with the updated
@@ -92,16 +115,19 @@ func (ccb *ccBalancerWrapper) updateClientConnState(ccs *balancer.ClientConnStat
 		}
 		errCh <- ccb.balancer.UpdateClientConnState(*ccs)
 	})
-
-	// If the balancer wrapper is closed when waiting for this state update to
-	// be handled, the callback serializer will be closed as well, and we can
-	// rely on its Done channel to ensure that we don't block here forever.
-	select {
-	case err := <-errCh:
-		return err
-	case <-ccb.serializer.Done:
-		return nil
+	if !ok {
+		// If we are unable to schedule a function with the serializer, it
+		// indicates that it has been closed. A serializer is only closed when
+		// the wrapper is closed or is in idle.
+		ccb.mu.Unlock()
+		return fmt.Errorf("grpc: cannot send state update to a closed or idle balancer")
 	}
+	ccb.mu.Unlock()
+
+	// We get here only if the above call to Schedule succeeds, in which case it
+	// is guaranteed that the scheduled function will run. Therefore it is safe
+	// to block on this channel.
+	return <-errCh
 }
 
 // updateSubConnState is invoked by grpc to push a subConn state update to the
@@ -120,21 +146,19 @@ func (ccb *ccBalancerWrapper) updateSubConnState(sc balancer.SubConn, s connecti
 	if sc == nil {
 		return
 	}
+	ccb.mu.Lock()
 	ccb.serializer.Schedule(func(_ context.Context) {
 		ccb.balancer.UpdateSubConnState(sc, balancer.SubConnState{ConnectivityState: s, ConnectionError: err})
 	})
-}
-
-func (ccb *ccBalancerWrapper) exitIdle() {
-	ccb.serializer.Schedule(func(_ context.Context) {
-		ccb.balancer.ExitIdle()
-	})
+	ccb.mu.Unlock()
 }
 
 func (ccb *ccBalancerWrapper) resolverError(err error) {
+	ccb.mu.Lock()
 	ccb.serializer.Schedule(func(_ context.Context) {
 		ccb.balancer.ResolverError(err)
 	})
+	ccb.mu.Unlock()
 }
 
 // switchTo is invoked by grpc to instruct the balancer wrapper to switch to the
@@ -148,42 +172,142 @@ func (ccb *ccBalancerWrapper) resolverError(err error) {
 // the ccBalancerWrapper keeps track of the current LB policy name, and skips
 // the graceful balancer switching process if the name does not change.
 func (ccb *ccBalancerWrapper) switchTo(name string) {
+	ccb.mu.Lock()
 	ccb.serializer.Schedule(func(_ context.Context) {
 		// TODO: Other languages use case-sensitive balancer registries. We should
 		// switch as well. See: https://github.com/grpc/grpc-go/issues/5288.
 		if strings.EqualFold(ccb.curBalancerName, name) {
 			return
 		}
-
-		// Use the default LB policy, pick_first, if no LB policy with name is
-		// found in the registry.
-		builder := balancer.Get(name)
-		if builder == nil {
-			channelz.Warningf(logger, ccb.cc.channelzID, "Channel switches to new LB policy %q, since the specified LB policy %q was not registered", PickFirstBalancerName, name)
-			builder = newPickfirstBuilder()
-		} else {
-			channelz.Infof(logger, ccb.cc.channelzID, "Channel switches to new LB policy %q", name)
-		}
-
-		if err := ccb.balancer.SwitchTo(builder); err != nil {
-			channelz.Errorf(logger, ccb.cc.channelzID, "Channel failed to build new LB policy %q: %v", name, err)
-			return
-		}
-		ccb.curBalancerName = builder.Name()
+		ccb.buildLoadBalancingPolicy(name)
 	})
+	ccb.mu.Unlock()
+}
+
+// buildLoadBalancingPolicy performs the following:
+//   - retrieve a balancer builder for the given name. Use the default LB
+//     policy, pick_first, if no LB policy with name is found in the registry.
+//   - instruct the gracefulswitch balancer to switch to the above builder. This
+//     will actually build the new balancer.
+//   - update the `curBalancerName` field
+//
+// Must be called from a serializer callback.
+func (ccb *ccBalancerWrapper) buildLoadBalancingPolicy(name string) {
+	builder := balancer.Get(name)
+	if builder == nil {
+		channelz.Warningf(logger, ccb.cc.channelzID, "Channel switches to new LB policy %q, since the specified LB policy %q was not registered", PickFirstBalancerName, name)
+		builder = newPickfirstBuilder()
+	} else {
+		channelz.Infof(logger, ccb.cc.channelzID, "Channel switches to new LB policy %q", name)
+	}
+
+	if err := ccb.balancer.SwitchTo(builder); err != nil {
+		channelz.Errorf(logger, ccb.cc.channelzID, "Channel failed to build new LB policy %q: %v", name, err)
+		return
+	}
+	ccb.curBalancerName = builder.Name()
 }
 
 func (ccb *ccBalancerWrapper) close() {
-	// Close the serializer to ensure that no more calls from gRPC are sent to
-	// the balancer. We don't have to worry about suppressing calls from a
-	// closed balancer because these are handled by the ClientConn (balancer
-	// wrapper is only ever closed when the ClientConn is closed).
+	channelz.Info(logger, ccb.cc.channelzID, "ccBalancerWrapper: closing")
+	ccb.handleCloseAndEnterIdle(ccbModeClosed)
+}
+
+// enterIdleMode is invoked by grpc when the channel enters idle mode upon
+// expiry of idle_timeout. This call blocks until the balancer is closed.
+func (ccb *ccBalancerWrapper) enterIdleMode() {
+	channelz.Info(logger, ccb.cc.channelzID, "ccBalancerWrapper: entering idle mode")
+	ccb.handleCloseAndEnterIdle(ccbModeIdle)
+}
+
+// handleCloseAndEnterIdle is invoked when the channel is being closed or when
+// it enters idle mode upon expiry of idle_timeout.
+//
+// This call is not scheduled on the serializer because we need to ensure that
+// the current serializer is completely shutdown before the next one is created
+// (when exiting idle).
+func (ccb *ccBalancerWrapper) handleCloseAndEnterIdle(m ccbMode) {
+	ccb.mu.Lock()
+	if ccb.mode == ccbModeClosed || ccb.mode == ccbModeIdle {
+		ccb.mu.Unlock()
+		return
+	}
+
+	// Close the serializer to ensure that no more calls from gRPC are sent
+	// to the balancer.
 	ccb.serializerCancel()
-	<-ccb.serializer.Done
-	ccb.balancer.Close()
+	ccb.mode = m
+	done := ccb.serializer.Done
+	b := ccb.balancer
+	ccb.mu.Unlock()
+
+	// Give enqueued callbacks a chance to finish before closing the balancer.
+	<-done
+	b.Close()
+}
+
+// exitIdleMode is invoked by grpc when the channel exits idle mode either
+// because of an RPC or because of an invocation of the Connect() API. This
+// recreates the balancer that was closed previously when entering idle mode.
+//
+// If the channel is not in idle mode, we know for a fact that we are here as a
+// result of the user calling the Connect() method on the ClientConn. In this
+// case, we can simply forward the call to the underlying balancer, instructing
+// it to reconnect to the backends.
+func (ccb *ccBalancerWrapper) exitIdleMode() {
+	ccb.mu.Lock()
+	if ccb.mode == ccbModeClosed {
+		// Request to exit idle is a no-op when wrapper is already closed.
+		ccb.mu.Unlock()
+		return
+	}
+
+	if ccb.mode == ccbModeIdle {
+		// Recreate the serializer which was closed when we entered idle.
+		ctx, cancel := context.WithCancel(context.Background())
+		ccb.serializer = grpcsync.NewCallbackSerializer(ctx)
+		ccb.serializerCancel = cancel
+	}
+
+	// The ClientConn guarantees that mutual exclusion between close() and
+	// exitIdleMode(), and since we just created a new serializer, we can be
+	// sure that the below function will be scheduled.
+	done := make(chan struct{})
+	ccb.serializer.Schedule(func(_ context.Context) {
+		defer close(done)
+
+		ccb.mu.Lock()
+		defer ccb.mu.Unlock()
+
+		if ccb.mode != ccbModeIdle {
+			ccb.balancer.ExitIdle()
+			return
+		}
+
+		// Gracefulswitch balancer does not support a switchTo operation after
+		// being closed. Hence we need to create a new one here.
+		ccb.balancer = gracefulswitch.NewBalancer(ccb, ccb.opts)
+		ccb.buildLoadBalancingPolicy(ccb.curBalancerName)
+		ccb.mode = ccbModeActive
+		channelz.Info(logger, ccb.cc.channelzID, "ccBalancerWrapper: exiting idle mode")
+
+	})
+	ccb.mu.Unlock()
+
+	<-done
+}
+
+func (ccb *ccBalancerWrapper) isIdleOrClosed() bool {
+	ccb.mu.Lock()
+	defer ccb.mu.Unlock()
+	return ccb.mode == ccbModeIdle || ccb.mode == ccbModeClosed
 }
 
 func (ccb *ccBalancerWrapper) NewSubConn(addrs []resolver.Address, opts balancer.NewSubConnOptions) (balancer.SubConn, error) {
+	if ccb.isIdleOrClosed() {
+		return nil, fmt.Errorf("grpc: cannot create SubConn when balancer is closed or idle")
+	}
+
 	if len(addrs) <= 0 {
 		return nil, fmt.Errorf("grpc: cannot create SubConn with empty address list")
 	}
@@ -200,6 +324,18 @@ func (ccb *ccBalancerWrapper) NewSubConn(addrs []resolver.Address, opts balancer
 }
 
 func (ccb *ccBalancerWrapper) RemoveSubConn(sc balancer.SubConn) {
+	if ccb.isIdleOrClosed() {
+		// It it safe to ignore this call when the balancer is closed or in idle
+		// because the ClientConn takes care of closing the connections.
+		//
+		// Not returning early from here when the balancer is closed or in idle
+		// leads to a deadlock though, because of the following sequence of
+		// calls when holding cc.mu:
+		// cc.exitIdleMode --> ccb.enterIdleMode --> gsw.Close -->
+		// ccb.RemoveAddrConn --> cc.removeAddrConn
+		return
+	}
+
 	acbw, ok := sc.(*acBalancerWrapper)
 	if !ok {
 		return
@@ -208,6 +344,10 @@ func (ccb *ccBalancerWrapper) RemoveSubConn(sc balancer.SubConn) {
 }
 
 func (ccb *ccBalancerWrapper) UpdateAddresses(sc balancer.SubConn, addrs []resolver.Address) {
+	if ccb.isIdleOrClosed() {
+		return
+	}
+
 	acbw, ok := sc.(*acBalancerWrapper)
 	if !ok {
 		return
@@ -216,6 +356,10 @@ func (ccb *ccBalancerWrapper) UpdateAddresses(sc balancer.SubConn, addrs []resol
 }
 
 func (ccb *ccBalancerWrapper) UpdateState(s balancer.State) {
+	if ccb.isIdleOrClosed() {
+		return
+	}
+
 	// Update picker before updating state.  Even though the ordering here does
 	// not matter, it can lead to multiple calls of Pick in the common start-up
 	// case where we wait for ready and then perform an RPC.  If the picker is
@@ -226,6 +370,10 @@ func (ccb *ccBalancerWrapper) UpdateState(s balancer.State) {
 }
 
 func (ccb *ccBalancerWrapper) ResolveNow(o resolver.ResolveNowOptions) {
+	if ccb.isIdleOrClosed() {
+		return
+	}
+
 	ccb.cc.resolveNow(o)
 }
 

--- a/balancer_conn_wrappers.go
+++ b/balancer_conn_wrappers.go
@@ -289,7 +289,9 @@ func (ccb *ccBalancerWrapper) exitIdleMode() {
 		// Gracefulswitch balancer does not support a switchTo operation after
 		// being closed. Hence we need to create a new one here.
 		ccb.balancer = gracefulswitch.NewBalancer(ccb, ccb.opts)
-		ccb.buildLoadBalancingPolicy(ccb.curBalancerName)
+		// Reset the current balancer name so that we act on the next call to
+		// switchTo by creating a new balancer specified by the new resolver.
+		ccb.curBalancerName = ""
 		ccb.mode = ccbModeActive
 		channelz.Info(logger, ccb.cc.channelzID, "ccBalancerWrapper: exiting idle mode")
 

--- a/call.go
+++ b/call.go
@@ -30,19 +30,16 @@ func (cc *ClientConn) Invoke(ctx context.Context, method string, args, reply int
 	if err := cc.idlenessMgr.onCallBegin(); err != nil {
 		return err
 	}
+	defer cc.idlenessMgr.onCallEnd()
 
 	// allow interceptor to see all applicable call options, which means those
 	// configured as defaults from dial option as well as per-call options
 	opts = combine(cc.dopts.callOptions, opts)
 
-	var err error
 	if cc.dopts.unaryInt != nil {
-		err = cc.dopts.unaryInt(ctx, method, args, reply, cc, invoke, opts...)
-	} else {
-		err = invoke(ctx, method, args, reply, cc, opts...)
+		return cc.dopts.unaryInt(ctx, method, args, reply, cc, invoke, opts...)
 	}
-	cc.idlenessMgr.onCallEnd()
-	return err
+	return invoke(ctx, method, args, reply, cc, opts...)
 }
 
 func combine(o1 []CallOption, o2 []CallOption) []CallOption {

--- a/clientconn.go
+++ b/clientconn.go
@@ -411,6 +411,12 @@ func (cc *ClientConn) enterIdleMode() error {
 	conns := cc.conns
 	cc.conns = make(map[*addrConn]struct{})
 
+	// TODO: Currently, we close the resolver wrapper upon entering idle mode
+	// and create a new one upon exiting idle mode. This means that the
+	// `cc.resolverWrapper` field would be overwritten everytime we exit idle
+	// mode. While this means that we need to hold `cc.mu` when accessing
+	// `cc.resolverWrapper`, it makes the code simpler in the wrapper. We should
+	// try to do the same for the balancer and picker wrappers too.
 	cc.resolverWrapper.close()
 	cc.blockingpicker.enterIdleMode()
 	cc.balancerWrapper.enterIdleMode()

--- a/clientconn.go
+++ b/clientconn.go
@@ -266,11 +266,7 @@ func DialContext(ctx context.Context, target string, opts ...DialOption) (conn *
 	// Configure idleness support with configured idle timeout or default idle
 	// timeout duration. Idleness can be explicitly disabled by the user, by
 	// setting the dial option to 0.
-	if cc.dopts.idleTimeout == 0 {
-		cc.idlenessMgr = newDisabledIdlenessManager()
-	} else {
-		cc.idlenessMgr = newAtomicIdlenessManager(cc, cc.dopts.idleTimeout)
-	}
+	cc.idlenessMgr = newIdlenessManager(cc, cc.dopts.idleTimeout)
 
 	// Return early for non-blocking dials.
 	if !cc.dopts.block {

--- a/clientconn.go
+++ b/clientconn.go
@@ -297,8 +297,10 @@ func DialContext(ctx context.Context, target string, opts ...DialOption) (conn *
 
 	// A blocking dial blocks until the clientConn is ready.
 	for {
-		cc.Connect()
 		s := cc.GetState()
+		if s == connectivity.Idle {
+			cc.Connect()
+		}
 		if s == connectivity.Ready {
 			return cc, nil
 		} else if cc.dopts.copts.FailOnNonTempDialError && s == connectivity.TransientFailure {

--- a/clientconn.go
+++ b/clientconn.go
@@ -330,7 +330,6 @@ func (cc *ClientConn) exitIdleMode() error {
 		return errConnClosing
 	}
 	if cc.idlenessState != ccIdlenessStateIdle {
-		// TODO: Switch this to warning once idleness implementation is stable.
 		logger.Error("ClientConn asked to exit idle mode when not in idle mode")
 		return nil
 	}
@@ -402,7 +401,6 @@ func (cc *ClientConn) enterIdleMode() error {
 		return ErrClientConnClosing
 	}
 	if cc.idlenessState != ccIdlenessStateActive {
-		// TODO: Switch this to warning once idleness implementation is stable.
 		logger.Error("ClientConn asked to enter idle mode when not active")
 		return nil
 	}

--- a/clientconn.go
+++ b/clientconn.go
@@ -355,6 +355,7 @@ func (cc *ClientConn) exitIdleMode() error {
 	if cc.idlenessState != ccIdlenessStateIdle {
 		// TODO: Switch this to warning once idleness implementation is stable.
 		logger.Error("ClientConn asked to exit idle mode when not in idle mode")
+		return nil
 	}
 
 	cc.idlenessState = ccIdlenessStateExitingIdle
@@ -398,7 +399,7 @@ func (cc *ClientConn) enterIdleMode() error {
 	if cc.idlenessState != ccIdlenessStateActive {
 		// TODO: Switch this to warning once idleness implementation is stable.
 		logger.Error("ClientConn asked to enter idle mode when not active")
-
+		return nil
 	}
 
 	// cc.conns == nil is a proxy for the ClientConn being closed. So, instead

--- a/clientconn_test.go
+++ b/clientconn_test.go
@@ -370,7 +370,7 @@ func (s) TestBackoffWhenNoServerPrefaceReceived(t *testing.T) {
 	}()
 	bc := backoff.Config{
 		BaseDelay:  200 * time.Millisecond,
-		Multiplier: 1.1,
+		Multiplier: 2.0,
 		Jitter:     0,
 		MaxDelay:   120 * time.Second,
 	}

--- a/dialoptions.go
+++ b/dialoptions.go
@@ -77,6 +77,7 @@ type dialOptions struct {
 	defaultServiceConfig        *ServiceConfig // defaultServiceConfig is parsed from defaultServiceConfigRawJSON.
 	defaultServiceConfigRawJSON *string
 	resolvers                   []resolver.Builder
+	idleTimeout                 time.Duration
 }
 
 // DialOption configures how we set up the connection.
@@ -627,6 +628,7 @@ func defaultDialOptions() dialOptions {
 			ReadBufferSize:  defaultReadBufSize,
 			UseProxy:        true,
 		},
+		idleTimeout: 30 * time.Minute,
 	}
 }
 
@@ -653,5 +655,25 @@ func withMinConnectDeadline(f func() time.Duration) DialOption {
 func WithResolvers(rs ...resolver.Builder) DialOption {
 	return newFuncDialOption(func(o *dialOptions) {
 		o.resolvers = append(o.resolvers, rs...)
+	})
+}
+
+// WithIdleTimeout returns a DialOption that configures an idle timeout for the
+// channel. If the channel is idle for the configured timeout, i.e there are no
+// ongoing RPCs and no new RPCs are initiated, the channel will enter idle mode
+// and as a result the name resolver and load balancer will be shut down. The
+// channel will exit idle mode when the Connect() method is called or when an
+// RPC is initiated.
+//
+// A default timeout of 30 min will be used if this dial option is not set at
+// dial time and idleness can be disabled by passing a timeout of zero.
+//
+// # Experimental
+//
+// Notice: This API is EXPERIMENTAL and may be changed or removed in a
+// later release.
+func WithIdleTimeout(d time.Duration) DialOption {
+	return newFuncDialOption(func(o *dialOptions) {
+		o.idleTimeout = d
 	})
 }

--- a/idle.go
+++ b/idle.go
@@ -19,15 +19,17 @@
 package grpc
 
 import (
+	"math"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/internal/status"
+	"google.golang.org/grpc/status"
 )
 
 // For overriding in unit tests.
-var newTimer = func(d time.Duration, f func()) *time.Timer {
+var timeAfterFunc = func(d time.Duration, f func()) *time.Timer {
 	return time.AfterFunc(d, f)
 }
 
@@ -38,16 +40,30 @@ type idlenessEnforcer interface {
 	enterIdleMode() error
 }
 
-// idlenessManager contains functionality to track RPC activity on the channel
-// and uses this to instruct the channel to enter or exit idle mode as
-// appropriate.
-type idlenessManager struct {
+// idlenessManager defines the functionality required to track RPC activity on a
+// channel.
+type idlenessManager interface {
+	onCallBegin() error
+	onCallEnd()
+	close()
+}
+
+type disabledIdlenessManager struct{}
+
+func (disabledIdlenessManager) onCallBegin() error { return nil }
+func (disabledIdlenessManager) onCallEnd()         {}
+func (disabledIdlenessManager) close()             {}
+
+func newDisabledIdlenessManager() idlenessManager { return disabledIdlenessManager{} }
+
+// mutexIdlenessManager implements the idlenessManager interface and uses a
+// mutex to synchronize access to shared state.
+type mutexIdlenessManager struct {
 	// The following fields are set when the manager is created and are never
 	// written to after that. Therefore these can be accessed without a mutex.
 
-	enforcer   idlenessEnforcer // Functionality provided by grpc.ClientConn.
-	timeout    int64            // Idle timeout duration nanos stored as an int64.
-	isDisabled bool             // Disabled if idle_timeout is set to 0.
+	enforcer idlenessEnforcer // Functionality provided by grpc.ClientConn.
+	timeout  int64            // Idle timeout duration nanos stored as an int64.
 
 	// All state maintained by the manager is guarded by this mutex.
 	mu                        sync.Mutex
@@ -58,27 +74,19 @@ type idlenessManager struct {
 	timer                     *time.Timer // Expires when the idle_timeout fires.
 }
 
-// newIdlenessManager creates a new idleness state manager which attempts to put
-// the channel in idle mode when there is no RPC activity for the configured
-// idleTimeout.
-//
-// Idleness support can be disabled by passing a value of 0 for idleTimeout.
-func newIdlenessManager(enforcer idlenessEnforcer, idleTimeout time.Duration) *idlenessManager {
-	if idleTimeout == 0 {
-		logger.Infof("Channel idleness support explicitly disabled")
-		return &idlenessManager{isDisabled: true}
-	}
-
-	i := &idlenessManager{
+// newMutexIdlenessManager creates a new mutexIdlennessManager. A non-zero value
+// must be passed for idle timeout.
+func newMutexIdlenessManager(enforcer idlenessEnforcer, idleTimeout time.Duration) idlenessManager {
+	i := &mutexIdlenessManager{
 		enforcer: enforcer,
 		timeout:  int64(idleTimeout),
 	}
-	i.timer = newTimer(idleTimeout, i.handleIdleTimeout)
+	i.timer = timeAfterFunc(idleTimeout, i.handleIdleTimeout)
 	return i
 }
 
 // handleIdleTimeout is the timer callback when idle_timeout expires.
-func (i *idlenessManager) handleIdleTimeout() {
+func (i *mutexIdlenessManager) handleIdleTimeout() {
 	i.mu.Lock()
 	defer i.mu.Unlock()
 
@@ -114,33 +122,28 @@ func (i *idlenessManager) handleIdleTimeout() {
 // channel is currently in idle mode, the manager asks the ClientConn to exit
 // idle mode, and restarts the timer. The active calls count is incremented and
 // the activeness bit is set to true.
-func (i *idlenessManager) onCallBegin() error {
-	if i.isDisabled {
-		return nil
-	}
-
+func (i *mutexIdlenessManager) onCallBegin() error {
 	i.mu.Lock()
 	defer i.mu.Unlock()
 
-	if i.isIdle {
-		if err := i.enforcer.exitIdleMode(); err != nil {
-			return status.Errorf(codes.Internal, "grpc: ClientConn failed to exit idle mode: %v", err)
-		}
-		i.timer = newTimer(time.Duration(i.timeout), i.handleIdleTimeout)
-		i.isIdle = false
-	}
 	i.activeCallsCount++
 	i.activeSinceLastTimerCheck = true
+
+	if !i.isIdle {
+		return nil
+	}
+
+	if err := i.enforcer.exitIdleMode(); err != nil {
+		return status.Errorf(codes.Internal, "grpc: ClientConn failed to exit idle mode: %v", err)
+	}
+	i.timer = timeAfterFunc(time.Duration(i.timeout), i.handleIdleTimeout)
+	i.isIdle = false
 	return nil
 }
 
 // onCallEnd is invoked by the ClientConn at the end of every RPC. The active
 // calls count is decremented and `i.lastCallEndTime` is updated.
-func (i *idlenessManager) onCallEnd() {
-	if i.isDisabled {
-		return
-	}
-
+func (i *mutexIdlenessManager) onCallEnd() {
 	i.mu.Lock()
 	defer i.mu.Unlock()
 
@@ -151,11 +154,210 @@ func (i *idlenessManager) onCallEnd() {
 	i.lastCallEndTime = time.Now().UnixNano()
 }
 
-func (i *idlenessManager) close() {
-	if i.isDisabled {
-		return
-	}
+func (i *mutexIdlenessManager) close() {
 	i.mu.Lock()
 	i.timer.Stop()
 	i.mu.Unlock()
+}
+
+// atomicIdlenessManger implements the idlenessManager interface. It uses atomic
+// operations to synchronize access to shared state and a mutex to guarantee
+// mutual exclusion in a critical section.
+type atomicIdlenessManager struct {
+	enforcer idlenessEnforcer // Functionality provided by grpc.ClientConn.
+	timeout  int64            // Idle timeout duration nanos stored as an int64.
+
+	// State accessed atomically.
+	activeCallsCount          int32        // Count of active RPCs; math.MinInt32 indicates channel is idle.
+	activeSinceLastTimerCheck int32        // Boolean; True if there was an RPC since the last timer callback.
+	closed                    int32        // Boolean; True when the manager is closed.
+	lastCallEndTime           int64        // Unix timestamp in nanos; time when the most recent RPC completed.
+	timer                     atomic.Value // Of type `*time.Timer`
+
+	// idleMu is used to guarantee mutual exclusion in two scenarios:
+	// - Opposing intentions. One is trying to put the channel in idle mode
+	//   after a period of inactivity, while the other is trying to keep the
+	//   channel from moving into idle mode to service an incoming RPC.
+	// - Competing intentions. When the channel is in idle mode and there
+	//   are multiple RPCs starting at the same time, all trying to move the
+	//   channel out of idle, we want a single one to succeed in doing so, while
+	//   the other RPCs should still be successfully handled.
+	idleMu sync.RWMutex
+}
+
+// newAtomicIdlenessManager creates a new atomicIdlenessManager. A non-zero
+// value must be passed for idle timeout.
+func newAtomicIdlenessManager(enforcer idlenessEnforcer, idleTimeout time.Duration) idlenessManager {
+	i := &atomicIdlenessManager{
+		enforcer: enforcer,
+		timeout:  int64(idleTimeout),
+	}
+	i.timer.Store(timeAfterFunc(idleTimeout, i.handleIdleTimeout))
+	return i
+}
+
+// enterIdleMode instructs the ClientConn to enter idle mode. But before that,
+// it performs a couple of last minute checks, to ensure that it is safe to
+// instruct the ClientConn to enter idle mode.
+//
+// Return value indicates whether or not the ClientConn moved to idle mode.
+//
+// Holds idleMu which ensures mutual exclusion with exitIdleMode.
+func (i *atomicIdlenessManager) enterIdleMode() bool {
+	i.idleMu.Lock()
+	defer i.idleMu.Unlock()
+
+	// Compare-and-swap the active calls count with an old value of `0` and a
+	// new value of `minInt32`. If this succeeds, it means that the active calls
+	// count is still zero, i.e no RPCs are ongoing since we last checked the
+	// count in the timer callback. If this fails, it means that RPCs have
+	// started since we last checked the count in the timer callback, and
+	// therefore we should not ask the ClientConn to enter idle mode.
+	if !atomic.CompareAndSwapInt32(&i.activeCallsCount, 0, math.MinInt32) {
+		return false
+	}
+	// It is possibile that one or more RPCs started and finished since the last
+	// time we checked the calls count and activity in the timer callback. In
+	// this case, the calls count would be zero and the above compare-and-swap
+	// operation would have succeeded. The `activeSinceLastTimerCheck` field is
+	// set to false only from the timer callback and is set to true in
+	// onCallBegin. Therefore, if one or more RPCs started and finished before
+	// we got here, this field would be set to true. And in this case, we don't
+	// want to enter idle mode.
+	if active := atomic.LoadInt32(&i.activeSinceLastTimerCheck); active == 1 {
+		return false
+	}
+	if err := i.enforcer.enterIdleMode(); err != nil {
+		logger.Errorf("Failed to enter idle mode: %v", err)
+		return false
+	}
+	// We are in enter idle mode now. Set the active calls count appropriately.
+	atomic.StoreInt32(&i.activeCallsCount, math.MinInt32)
+	return true
+}
+
+// exitIdleMode instructs the ClientConn to exit idle mode.
+//
+// Holds idleMu which ensures mutual exclusion with enterIdleMode.
+func (i *atomicIdlenessManager) exitIdleMode() error {
+	i.idleMu.Lock()
+	defer i.idleMu.Unlock()
+
+	// When the channel enters idle mode, the active calls count is set to
+	// math.MinInt32. RPCs that start when the channel is in idle mode increment
+	// the active calls count in onCallBegin. If there are multiple RPCs
+	// competing to get the channel out of idle mode, the first one to grab the
+	// lock here gets to do so and sets the active calls count back to 1. So, if
+	// the count is not negative here, we know that someone else won the race
+	// and moved the channel out of idle mode, and we have nothing to do here.
+	if count := atomic.LoadInt32(&i.activeCallsCount); count >= 0 {
+		atomic.AddInt32(&i.activeCallsCount, 1)
+		return nil
+	}
+
+	// The first one to grab the lock will get here to instruct the channel to
+	// move out of idle mode.
+	if err := i.enforcer.exitIdleMode(); err != nil {
+		return status.Errorf(codes.Internal, "grpc: ClientConn failed to exit idle mode: %v", err)
+	}
+
+	// Reset the calls count to 1 and reset the timer to fire after a duration
+	// of the configured idle timeout.
+	atomic.StoreInt32(&i.activeCallsCount, 1)
+	i.timer.Store(timeAfterFunc(time.Duration(i.timeout), i.handleIdleTimeout))
+	return nil
+}
+
+// handleIdleTimeout is the timer callback that is invoked upon expiry of the
+// configured idle timeout. The channel is considered inactive if there are no
+// ongoing calls and no RPC activity since the last time the timer fired.
+func (i *atomicIdlenessManager) handleIdleTimeout() {
+	if i.isClosed() {
+		return
+	}
+
+	var timeoutDuration time.Duration
+	if count := atomic.LoadInt32(&i.activeCallsCount); count > 0 {
+		// Since the channel is currently active, reset the timer to the full
+		// configured idle timeout duration.
+		timeoutDuration = time.Duration(i.timeout)
+	} else if active := atomic.LoadInt32(&i.activeSinceLastTimerCheck); active == 1 {
+		// The channel is not currently active, but saw some activity since the
+		// last time the timer fired. We set the timer to fire after a duration
+		// of idle timeout, calculated from the time the most recent RPC
+		// completed.
+		atomic.StoreInt32(&i.activeSinceLastTimerCheck, 0)
+		timeoutDuration = time.Duration(atomic.LoadInt64(&i.lastCallEndTime) + i.timeout - time.Now().UnixNano())
+	} else {
+		// Channel is inactive, try to move it idle. If we succeed in doing so,
+		// we don't have to reset the timer. It will be done when the channel
+		// moves out of idle.
+		if i.enterIdleMode() {
+			return
+		}
+		// We didn't move out of the idle because some RPC raced with us and
+		// kept the channel active. Give the timer the full configured idle
+		// timeout duration.
+		timeoutDuration = time.Duration(i.timeout)
+	}
+
+	// It is safe to ignore the return value from Reset() because we are
+	// already in the timer callback and this is only place from where we
+	// reset the timer.
+	timer := i.timer.Load().(*time.Timer)
+	timer.Reset(timeoutDuration)
+}
+
+// onCallBegin is invoked at the start of every RPC.
+func (i *atomicIdlenessManager) onCallBegin() error {
+	if i.isClosed() {
+		return nil
+	}
+
+	// Set RPC activity on the channel to true.
+	atomic.StoreInt32(&i.activeSinceLastTimerCheck, 1)
+
+	// Increment the calls count and if the new value is positive, it means that
+	// the channel is not in idle mode. So, we can return early.
+	if count := atomic.AddInt32(&i.activeCallsCount, 1); count > 0 {
+		return nil
+	}
+
+	// The active calls count is set to math.MinIn32 when the channel enters
+	// idle. So, if the channel is still in idle mode, we expect this value to
+	// be negative at this point. If there are more than 2 billion RPCs that
+	// start at the same time (when the channel is in idle mode), this count
+	// could become positive, but it is highly unlikey to ever hit that case.
+	//
+	// Ask the ClientConn to exit idle mode now.
+	return i.exitIdleMode()
+}
+
+// onCallEnd is invoked at the end of every RPC.
+func (i *atomicIdlenessManager) onCallEnd() {
+	if i.isClosed() {
+		return
+	}
+
+	// Record the time at which the most recent call finished.
+	atomic.StoreInt64(&i.lastCallEndTime, time.Now().UnixNano())
+
+	// Decrement the active calls count. We expect this count to never go
+	// negative. This count should be negative only when the channel is in idle
+	// mode, and we cannot be in idle mode at this moment because we are
+	// handling the completion of an RPC.
+	if n := atomic.AddInt32(&i.activeCallsCount, -1); n < 0 {
+		logger.Errorf("Number of active calls tracked by idleness manager is negative: %d", n)
+	}
+}
+
+func (i *atomicIdlenessManager) isClosed() bool {
+	closed := atomic.LoadInt32(&i.closed)
+	return closed == 1
+}
+
+func (i *atomicIdlenessManager) close() {
+	atomic.StoreInt32(&i.closed, 1)
+	timer := i.timer.Load().(*time.Timer)
+	timer.Stop()
 }

--- a/idle.go
+++ b/idle.go
@@ -24,9 +24,6 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
-
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 // For overriding in unit tests.
@@ -56,110 +53,6 @@ func (disabledIdlenessManager) onCallEnd()         {}
 func (disabledIdlenessManager) close()             {}
 
 func newDisabledIdlenessManager() idlenessManager { return disabledIdlenessManager{} }
-
-// mutexIdlenessManager implements the idlenessManager interface and uses a
-// mutex to synchronize access to shared state.
-type mutexIdlenessManager struct {
-	// The following fields are set when the manager is created and are never
-	// written to after that. Therefore these can be accessed without a mutex.
-
-	enforcer idlenessEnforcer // Functionality provided by grpc.ClientConn.
-	timeout  int64            // Idle timeout duration nanos stored as an int64.
-
-	// All state maintained by the manager is guarded by this mutex.
-	mu                        sync.Mutex
-	activeCallsCount          int         // Count of active RPCs.
-	activeSinceLastTimerCheck bool        // True if there was an RPC since the last timer callback.
-	lastCallEndTime           int64       // Time when the most recent RPC finished, stored as unix nanos.
-	isIdle                    bool        // True if the channel is in idle mode.
-	timer                     *time.Timer // Expires when the idle_timeout fires.
-}
-
-// newMutexIdlenessManager creates a new mutexIdlennessManager. A non-zero value
-// must be passed for idle timeout.
-func newMutexIdlenessManager(enforcer idlenessEnforcer, idleTimeout time.Duration) idlenessManager {
-	i := &mutexIdlenessManager{
-		enforcer: enforcer,
-		timeout:  int64(idleTimeout),
-	}
-	i.timer = timeAfterFunc(idleTimeout, i.handleIdleTimeout)
-	return i
-}
-
-// handleIdleTimeout is the timer callback when idle_timeout expires.
-func (i *mutexIdlenessManager) handleIdleTimeout() {
-	i.mu.Lock()
-	defer i.mu.Unlock()
-
-	// If there are ongoing RPCs, it means the channel is active. Reset the
-	// timer to fire after a duration of idle_timeout, and return early.
-	if i.activeCallsCount > 0 {
-		i.timer.Reset(time.Duration(i.timeout))
-		return
-	}
-
-	// There were some RPCs made since the last time we were here. So, the
-	// channel is still active.  Reschedule the timer to fire after a duration
-	// of idle_timeout from the time the last call ended.
-	if i.activeSinceLastTimerCheck {
-		i.activeSinceLastTimerCheck = false
-		// It is safe to ignore the return value from Reset() because we are
-		// already in the timer callback and this is only place from where we
-		// reset the timer.
-		i.timer.Reset(time.Duration(i.lastCallEndTime + i.timeout - time.Now().UnixNano()))
-		return
-	}
-
-	// There are no ongoing RPCs, and there were no RPCs since the last time we
-	// were here, we are all set to enter idle mode.
-	if err := i.enforcer.enterIdleMode(); err != nil {
-		logger.Warningf("Failed to enter idle mode: %v", err)
-		return
-	}
-	i.isIdle = true
-}
-
-// onCallBegin is invoked by the ClientConn at the start of every RPC. If the
-// channel is currently in idle mode, the manager asks the ClientConn to exit
-// idle mode, and restarts the timer. The active calls count is incremented and
-// the activeness bit is set to true.
-func (i *mutexIdlenessManager) onCallBegin() error {
-	i.mu.Lock()
-	defer i.mu.Unlock()
-
-	i.activeCallsCount++
-	i.activeSinceLastTimerCheck = true
-
-	if !i.isIdle {
-		return nil
-	}
-
-	if err := i.enforcer.exitIdleMode(); err != nil {
-		return status.Errorf(codes.Internal, "grpc: ClientConn failed to exit idle mode: %v", err)
-	}
-	i.timer = timeAfterFunc(time.Duration(i.timeout), i.handleIdleTimeout)
-	i.isIdle = false
-	return nil
-}
-
-// onCallEnd is invoked by the ClientConn at the end of every RPC. The active
-// calls count is decremented and `i.lastCallEndTime` is updated.
-func (i *mutexIdlenessManager) onCallEnd() {
-	i.mu.Lock()
-	defer i.mu.Unlock()
-
-	i.activeCallsCount--
-	if i.activeCallsCount < 0 {
-		logger.Errorf("Number of active calls tracked by idleness manager is negative: %d", i.activeCallsCount)
-	}
-	i.lastCallEndTime = time.Now().UnixNano()
-}
-
-func (i *mutexIdlenessManager) close() {
-	i.mu.Lock()
-	i.timer.Stop()
-	i.mu.Unlock()
-}
 
 // atomicIdlenessManger implements the idlenessManager interface. It uses atomic
 // operations to synchronize access to shared state and a mutex to guarantee
@@ -379,8 +272,7 @@ func (i *atomicIdlenessManager) onCallEnd() {
 }
 
 func (i *atomicIdlenessManager) isClosed() bool {
-	closed := atomic.LoadInt32(&i.closed)
-	return closed == 1
+	return atomic.LoadInt32(&i.closed) == 1
 }
 
 func (i *atomicIdlenessManager) close() {

--- a/idle.go
+++ b/idle.go
@@ -218,7 +218,7 @@ func (i *atomicIdlenessManager) enterIdleMode() bool {
 	if !atomic.CompareAndSwapInt32(&i.activeCallsCount, 0, math.MinInt32) {
 		return false
 	}
-	// It is possibile that one or more RPCs started and finished since the last
+	// It is possible that one or more RPCs started and finished since the last
 	// time we checked the calls count and activity in the timer callback. In
 	// this case, the calls count would be zero and the above compare-and-swap
 	// operation would have succeeded. The `activeSinceLastTimerCheck` field is
@@ -329,7 +329,7 @@ func (i *atomicIdlenessManager) onCallBegin() error {
 	// idle. So, if the channel is still in idle mode, we expect this value to
 	// be negative at this point. If there are more than 2 billion RPCs that
 	// start at the same time (when the channel is in idle mode), this count
-	// could become positive, but it is highly unlikey to ever hit that case.
+	// could become positive, but it is highly unlikely to ever hit that case.
 	//
 	// Ask the ClientConn to exit idle mode now.
 	return i.exitIdleMode()

--- a/idle.go
+++ b/idle.go
@@ -1,0 +1,161 @@
+/*
+ *
+ * Copyright 2023 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package grpc
+
+import (
+	"sync"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/internal/status"
+)
+
+// For overriding in unit tests.
+var newTimer = func(d time.Duration, f func()) *time.Timer {
+	return time.AfterFunc(d, f)
+}
+
+// idlenessEnforcer is the functionality provided by grpc.ClientConn to enter
+// and exit from idle mode.
+type idlenessEnforcer interface {
+	exitIdleMode() error
+	enterIdleMode() error
+}
+
+// idlenessManager contains functionality to track RPC activity on the channel
+// and uses this to instruct the channel to enter or exit idle mode as
+// appropriate.
+type idlenessManager struct {
+	// The following fields are set when the manager is created and are never
+	// written to after that. Therefore these can be accessed without a mutex.
+
+	enforcer   idlenessEnforcer // Functionality provided by grpc.ClientConn.
+	timeout    int64            // Idle timeout duration nanos stored as an int64.
+	isDisabled bool             // Disabled if idle_timeout is set to 0.
+
+	// All state maintained by the manager is guarded by this mutex.
+	mu                        sync.Mutex
+	activeCallsCount          int         // Count of active RPCs.
+	activeSinceLastTimerCheck bool        // True if there was an RPC since the last timer callback.
+	lastCallEndTime           int64       // Time when the most recent RPC finished, stored as unix nanos.
+	isIdle                    bool        // True if the channel is in idle mode.
+	timer                     *time.Timer // Expires when the idle_timeout fires.
+}
+
+// newIdlenessManager creates a new idleness state manager which attempts to put
+// the channel in idle mode when there is no RPC activity for the configured
+// idleTimeout.
+//
+// Idleness support can be disabled by passing a value of 0 for idleTimeout.
+func newIdlenessManager(enforcer idlenessEnforcer, idleTimeout time.Duration) *idlenessManager {
+	if idleTimeout == 0 {
+		logger.Infof("Channel idleness support explicitly disabled")
+		return &idlenessManager{isDisabled: true}
+	}
+
+	i := &idlenessManager{
+		enforcer: enforcer,
+		timeout:  int64(idleTimeout),
+	}
+	i.timer = newTimer(idleTimeout, i.handleIdleTimeout)
+	return i
+}
+
+// handleIdleTimeout is the timer callback when idle_timeout expires.
+func (i *idlenessManager) handleIdleTimeout() {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
+	// If there are ongoing RPCs, it means the channel is active. Reset the
+	// timer to fire after a duration of idle_timeout, and return early.
+	if i.activeCallsCount > 0 {
+		i.timer.Reset(time.Duration(i.timeout))
+		return
+	}
+
+	// There were some RPCs made since the last time we were here. So, the
+	// channel is still active.  Reschedule the timer to fire after a duration
+	// of idle_timeout from the time the last call ended.
+	if i.activeSinceLastTimerCheck {
+		i.activeSinceLastTimerCheck = false
+		// It is safe to ignore the return value from Reset() because we are
+		// already in the timer callback and this is only place from where we
+		// reset the timer.
+		i.timer.Reset(time.Duration(i.lastCallEndTime + i.timeout - time.Now().UnixNano()))
+		return
+	}
+
+	// There are no ongoing RPCs, and there were no RPCs since the last time we
+	// were here, we are all set to enter idle mode.
+	if err := i.enforcer.enterIdleMode(); err != nil {
+		logger.Warningf("Failed to enter idle mode: %v", err)
+		return
+	}
+	i.isIdle = true
+}
+
+// onCallBegin is invoked by the ClientConn at the start of every RPC. If the
+// channel is currently in idle mode, the manager asks the ClientConn to exit
+// idle mode, and restarts the timer. The active calls count is incremented and
+// the activeness bit is set to true.
+func (i *idlenessManager) onCallBegin() error {
+	if i.isDisabled {
+		return nil
+	}
+
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
+	if i.isIdle {
+		if err := i.enforcer.exitIdleMode(); err != nil {
+			return status.Errorf(codes.Internal, "grpc: ClientConn failed to exit idle mode: %v", err)
+		}
+		i.timer = newTimer(time.Duration(i.timeout), i.handleIdleTimeout)
+		i.isIdle = false
+	}
+	i.activeCallsCount++
+	i.activeSinceLastTimerCheck = true
+	return nil
+}
+
+// onCallEnd is invoked by the ClientConn at the end of every RPC. The active
+// calls count is decremented and `i.lastCallEndTime` is updated.
+func (i *idlenessManager) onCallEnd() {
+	if i.isDisabled {
+		return
+	}
+
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
+	i.activeCallsCount--
+	if i.activeCallsCount < 0 {
+		logger.Errorf("Number of active calls tracked by idleness manager is negative: %d", i.activeCallsCount)
+	}
+	i.lastCallEndTime = time.Now().UnixNano()
+}
+
+func (i *idlenessManager) close() {
+	if i.isDisabled {
+		return
+	}
+	i.mu.Lock()
+	i.timer.Stop()
+	i.mu.Unlock()
+}

--- a/idle_test.go
+++ b/idle_test.go
@@ -1,0 +1,263 @@
+/*
+ *
+ * Copyright 2023 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package grpc
+
+import (
+	"testing"
+	"time"
+)
+
+const (
+	defaultTestIdleTimeout  = 500 * time.Millisecond // A short idle_timeout for tests.
+	defaultTestShortTimeout = 10 * time.Millisecond  // A small deadline to wait for events expected to not happen.
+)
+
+type testIdlenessEnforcer struct {
+	exitIdleCh  chan struct{}
+	enterIdleCh chan struct{}
+}
+
+func (ti *testIdlenessEnforcer) exitIdleMode() error {
+	ti.exitIdleCh <- struct{}{}
+	return nil
+
+}
+
+func (ti *testIdlenessEnforcer) enterIdleMode() error {
+	ti.enterIdleCh <- struct{}{}
+	return nil
+
+}
+
+func newTestIdlenessEnforcer() *testIdlenessEnforcer {
+	return &testIdlenessEnforcer{
+		exitIdleCh:  make(chan struct{}, 1),
+		enterIdleCh: make(chan struct{}, 1),
+	}
+}
+
+// overrideNewTimer overrides the new timer creation function by ensuring that a
+// message is pushed on the returned channel everytime the timer fires.
+func overrideNewTimer(t *testing.T) <-chan struct{} {
+	t.Helper()
+
+	ch := make(chan struct{}, 1)
+	origNewTimer := newTimer
+	newTimer = func(d time.Duration, callback func()) *time.Timer {
+		return time.AfterFunc(d, func() {
+			select {
+			case ch <- struct{}{}:
+			default:
+			}
+			callback()
+		})
+	}
+	t.Cleanup(func() { newTimer = origNewTimer })
+	return ch
+}
+
+// TestIdlenessManager_Disabled tests the case where the idleness manager is
+// disabled by passing an idle_timeout of 0. Verifies the following things:
+//   - timer callback does not fire
+//   - an RPC does not trigger a call to exitIdleMode on the ClientConn
+//   - more calls to RPC termination (as compared to RPC initiation) does not
+//     result in an error log
+func (s) TestIdlenessManager_Disabled(t *testing.T) {
+	callbackCh := overrideNewTimer(t)
+
+	// Create an idleness manager that is disabled because of idleTimeout being
+	// set to `0`.
+	enforcer := newTestIdlenessEnforcer()
+	mgr := newIdlenessManager(enforcer, time.Duration(0))
+
+	// Ensure that the timer callback does not fire within a short deadline.
+	select {
+	case <-callbackCh:
+		t.Fatal("Idle timer callback fired when manager is disabled")
+	case <-time.After(defaultTestShortTimeout):
+	}
+
+	// The first invocation of onCallBegin() would lead to a call to
+	// exitIdleMode() on the enforcer, unless the idleness manager is disabled.
+	mgr.onCallBegin()
+	select {
+	case <-enforcer.exitIdleCh:
+		t.Fatalf("exitIdleMode() called on enforcer when manager is disabled")
+	case <-time.After(defaultTestShortTimeout):
+	}
+
+	// If the number of calls to onCallEnd() exceeds the number of calls to
+	// onCallBegin(), the idleness manager is expected to throw an error log
+	// (which will cause our TestLogger to fail the test). But since the manager
+	// is disabled, this should not happen.
+	mgr.onCallEnd()
+	mgr.onCallEnd()
+
+	// The idleness manager is explicitly not closed here. But since the manager
+	// is disabled, it will not start the run goroutine, and hence we expect the
+	// leakchecker to not find any leaked goroutines.
+}
+
+// TestIdlenessManager_Enabled_TimerFires tests the case where the idle manager
+// is enabled. Ensures that when there are no RPCs, the timer callback is
+// invoked and the enterIdleMode() method is invoked on the enforcer.
+func (s) TestIdlenessManager_Enabled_TimerFires(t *testing.T) {
+	callbackCh := overrideNewTimer(t)
+
+	enforcer := newTestIdlenessEnforcer()
+	mgr := newIdlenessManager(enforcer, time.Duration(defaultTestIdleTimeout))
+	defer mgr.close()
+
+	// Ensure that the timer callback fires within a appropriate amount of time.
+	select {
+	case <-callbackCh:
+	case <-time.After(2 * defaultTestIdleTimeout):
+		t.Fatal("Timeout waiting for idle timer callback to fire")
+	}
+
+	// Ensure that the channel moves to idle mode eventually.
+	select {
+	case <-enforcer.enterIdleCh:
+	case <-time.After(defaultTestTimeout):
+		t.Fatal("Timeout waiting for channel to move to idle")
+	}
+}
+
+// TestIdlenessManager_Enabled_OngoingCall tests the case where the idle manager
+// is enabled. Ensures that when there is an ongoing RPC, the channel does not
+// enter idle mode.
+func (s) TestIdlenessManager_Enabled_OngoingCall(t *testing.T) {
+	callbackCh := overrideNewTimer(t)
+
+	enforcer := newTestIdlenessEnforcer()
+	mgr := newIdlenessManager(enforcer, time.Duration(defaultTestIdleTimeout))
+	defer mgr.close()
+
+	// Fire up a goroutine that simulates an ongoing RPC that is terminated
+	// after the timer callback fires for the first time.
+	timerFired := make(chan struct{})
+	go func() {
+		mgr.onCallBegin()
+		<-timerFired
+		mgr.onCallEnd()
+	}()
+
+	// Ensure that the timer callback fires and unblock the above goroutine.
+	select {
+	case <-callbackCh:
+		close(timerFired)
+	case <-time.After(2 * defaultTestIdleTimeout):
+		t.Fatal("Timeout waiting for idle timer callback to fire")
+	}
+
+	// The invocation of the timer callback should not put the channel in idle
+	// mode since we had an ongoing RPC.
+	select {
+	case <-enforcer.enterIdleCh:
+		t.Fatalf("enterIdleMode() called on enforcer when active RPC exists")
+	case <-time.After(defaultTestShortTimeout):
+	}
+
+	// Since we terminated the ongoing RPC and we have no other active RPCs, the
+	// channel must move to idle eventually.
+	select {
+	case <-enforcer.enterIdleCh:
+	case <-time.After(defaultTestTimeout):
+		t.Fatal("Timeout waiting for channel to move to idle")
+	}
+}
+
+// TestIdlenessManager_Enabled_ActiveSinceLastCheck tests the case where the
+// idle manager is enabled. Ensures that when there are active RPCs in the last
+// period (even though there is no active call when the timer fires), the
+// channel does not enter idle mode.
+func (s) TestIdlenessManager_Enabled_ActiveSinceLastCheck(t *testing.T) {
+	callbackCh := overrideNewTimer(t)
+
+	enforcer := newTestIdlenessEnforcer()
+	mgr := newIdlenessManager(enforcer, time.Duration(defaultTestIdleTimeout))
+	defer mgr.close()
+
+	// Fire up a goroutine that simulates unary RPCs until the timer callback
+	// fires.
+	timerFired := make(chan struct{})
+	go func() {
+		for ; ; <-time.After(defaultTestShortTimeout) {
+			mgr.onCallBegin()
+			mgr.onCallEnd()
+
+			select {
+			case <-timerFired:
+				return
+			default:
+			}
+		}
+	}()
+
+	// Ensure that the timer callback fires, and that we don't enter idle as
+	// part of this invocation of the timer callback, since we had some RPCs in
+	// this period.
+	select {
+	case <-callbackCh:
+		close(timerFired)
+	case <-time.After(2 * defaultTestIdleTimeout):
+		t.Fatal("Timeout waiting for idle timer callback to fire")
+	}
+	select {
+	case <-enforcer.enterIdleCh:
+		t.Fatalf("enterIdleMode() called on enforcer when one RPC completed in the last period")
+	case <-time.After(defaultTestShortTimeout):
+	}
+
+	// Since the unrary RPC terminated and we have no other active RPCs, the
+	// channel must move to idle eventually.
+	select {
+	case <-enforcer.enterIdleCh:
+	case <-time.After(defaultTestTimeout):
+		t.Fatal("Timeout waiting for channel to move to idle")
+	}
+}
+
+// TestIdlenessManager_Enabled_ExitIdleOnRPC tests the case where the idle
+// manager is enabled. Ensures that the channel moves out of idle when an RPC is
+// initiated.
+func (s) TestIdlenessManager_Enabled_ExitIdleOnRPC(t *testing.T) {
+	overrideNewTimer(t)
+
+	enforcer := newTestIdlenessEnforcer()
+	mgr := newIdlenessManager(enforcer, time.Duration(defaultTestIdleTimeout))
+	defer mgr.close()
+
+	// Ensure that the channel moves to idle since there are no RPCs.
+	select {
+	case <-enforcer.enterIdleCh:
+	case <-time.After(2 * defaultTestIdleTimeout):
+		t.Fatal("Timeout waiting for channel to move to idle mode")
+	}
+
+	mgr.onCallBegin()
+	mgr.onCallEnd()
+
+	// Ensure that the channel moves out of idle as a result of the above RPC.
+	select {
+	case <-enforcer.exitIdleCh:
+	case <-time.After(2 * defaultTestIdleTimeout):
+		t.Fatal("Timeout waiting for channel to move out of idle mode")
+	}
+}

--- a/idle_test.go
+++ b/idle_test.go
@@ -88,7 +88,7 @@ func (s) TestIdlenessManager_Disabled(t *testing.T) {
 	// Create an idleness manager that is disabled because of idleTimeout being
 	// set to `0`.
 	enforcer := newTestIdlenessEnforcer()
-	mgr := newDisabledIdlenessManager()
+	mgr := newIdlenessManager(enforcer, time.Duration(0))
 
 	// Ensure that the timer callback does not fire within a short deadline.
 	select {
@@ -125,7 +125,7 @@ func (s) TestIdlenessManager_Enabled_TimerFires(t *testing.T) {
 	callbackCh := overrideNewTimer(t)
 
 	enforcer := newTestIdlenessEnforcer()
-	mgr := newAtomicIdlenessManager(enforcer, time.Duration(defaultTestIdleTimeout))
+	mgr := newIdlenessManager(enforcer, time.Duration(defaultTestIdleTimeout))
 	defer mgr.close()
 
 	// Ensure that the timer callback fires within a appropriate amount of time.
@@ -150,7 +150,7 @@ func (s) TestIdlenessManager_Enabled_OngoingCall(t *testing.T) {
 	callbackCh := overrideNewTimer(t)
 
 	enforcer := newTestIdlenessEnforcer()
-	mgr := newAtomicIdlenessManager(enforcer, time.Duration(defaultTestIdleTimeout))
+	mgr := newIdlenessManager(enforcer, time.Duration(defaultTestIdleTimeout))
 	defer mgr.close()
 
 	// Fire up a goroutine that simulates an ongoing RPC that is terminated
@@ -195,7 +195,7 @@ func (s) TestIdlenessManager_Enabled_ActiveSinceLastCheck(t *testing.T) {
 	callbackCh := overrideNewTimer(t)
 
 	enforcer := newTestIdlenessEnforcer()
-	mgr := newAtomicIdlenessManager(enforcer, time.Duration(defaultTestIdleTimeout))
+	mgr := newIdlenessManager(enforcer, time.Duration(defaultTestIdleTimeout))
 	defer mgr.close()
 
 	// Fire up a goroutine that simulates unary RPCs until the timer callback
@@ -245,7 +245,7 @@ func (s) TestIdlenessManager_Enabled_ExitIdleOnRPC(t *testing.T) {
 	overrideNewTimer(t)
 
 	enforcer := newTestIdlenessEnforcer()
-	mgr := newAtomicIdlenessManager(enforcer, time.Duration(defaultTestIdleTimeout))
+	mgr := newIdlenessManager(enforcer, time.Duration(defaultTestIdleTimeout))
 	defer mgr.close()
 
 	// Ensure that the channel moves to idle since there are no RPCs.
@@ -329,7 +329,7 @@ func (s) TestIdlenessManager_IdleTimeoutRacesWithOnCallBegin(t *testing.T) {
 
 			// Configure a large idle timeout so that we can control the
 			// race between the timer callback and RPCs.
-			mgr := newAtomicIdlenessManager(enforcer, time.Duration(10*time.Minute))
+			mgr := newIdlenessManager(enforcer, time.Duration(10*time.Minute))
 			defer mgr.close()
 
 			var wg sync.WaitGroup

--- a/idle_test.go
+++ b/idle_test.go
@@ -351,15 +351,13 @@ func (ri *racyIdlenessEnforcer) enterIdleMode() error {
 	return nil
 }
 
-// TestIdlenessManager_IdleTimeoutRacesWithOnCallBeing tests the case where
+// TestIdlenessManager_IdleTimeoutRacesWithOnCallBegin tests the case where
 // firing of the idle timeout races with an incoming RPC. The test verifies that
 // if the timer callback win the race and puts the channel in idle, the RPCs can
 // kick it out of idle. And if the RPCs win the race and keep the channel
 // active, then the timer callback should not attempt to put the channel in idle
 // mode.
-func (s) TestIdlenessManager_IdleTimeoutRacesWithOnCallBeing(t *testing.T) {
-	overrideNewTimer(t)
-
+func (s) TestIdlenessManager_IdleTimeoutRacesWithOnCallBegin(t *testing.T) {
 	// Run multiple iterations to simulate different possibilities.
 	for i := 0; i < 10; i++ {
 		t.Run(fmt.Sprintf("iteration=%d", i), func(t *testing.T) {

--- a/internal/grpcsync/callback_serializer.go
+++ b/internal/grpcsync/callback_serializer.go
@@ -20,6 +20,7 @@ package grpcsync
 
 import (
 	"context"
+	"sync"
 
 	"google.golang.org/grpc/internal/buffer"
 )
@@ -31,19 +32,21 @@ import (
 //
 // This type is safe for concurrent access.
 type CallbackSerializer struct {
-	// Done is closed once the serializer is shut down completely, i.e a
-	// scheduled callback, if any, that was running when the context passed to
-	// NewCallbackSerializer is cancelled, has completed and the serializer has
-	// deallocated all its resources.
+	// Done is closed once the serializer is shut down completely, i.e all
+	// scheduled callbacks are executed and the serializer has deallocated all
+	// its resources.
 	Done chan struct{}
 
 	callbacks *buffer.Unbounded
+	closedMu  sync.Mutex
+	closed    bool
 }
 
 // NewCallbackSerializer returns a new CallbackSerializer instance. The provided
 // context will be passed to the scheduled callbacks. Users should cancel the
 // provided context to shutdown the CallbackSerializer. It is guaranteed that no
-// callbacks will be executed once this context is canceled.
+// callbacks will be added once this context is canceled, and any pending un-run
+// callbacks will be executed before the serializer is shut down.
 func NewCallbackSerializer(ctx context.Context) *CallbackSerializer {
 	t := &CallbackSerializer{
 		Done:      make(chan struct{}),
@@ -57,23 +60,60 @@ func NewCallbackSerializer(ctx context.Context) *CallbackSerializer {
 //
 // Callbacks are expected to honor the context when performing any blocking
 // operations, and should return early when the context is canceled.
-func (t *CallbackSerializer) Schedule(f func(ctx context.Context)) {
+//
+// Return value indicates if the callback was successfully added to the list of
+// callbacks to be executed by the serializer. It is not possible to add
+// callbacks once the context passed to NewCallbackSerializer is cancelled.
+func (t *CallbackSerializer) Schedule(f func(ctx context.Context)) bool {
+	t.closedMu.Lock()
+	defer t.closedMu.Unlock()
+
+	if t.closed {
+		return false
+	}
 	t.callbacks.Put(f)
+	return true
 }
 
 func (t *CallbackSerializer) run(ctx context.Context) {
+	var backlog []func(context.Context)
+
 	defer close(t.Done)
 	for ctx.Err() == nil {
 		select {
 		case <-ctx.Done():
-			t.callbacks.Close()
-			return
+			// Do nothing here. Next iteration of the for loop will not happen,
+			// since ctx.Err() would be non-nil.
 		case callback, ok := <-t.callbacks.Get():
 			if !ok {
 				return
 			}
 			t.callbacks.Load()
 			callback.(func(ctx context.Context))(ctx)
+		}
+	}
+
+	// Fetch pending callbacks if any, and execute them before returning from
+	// this method and closing t.Done.
+	t.closedMu.Lock()
+	t.closed = true
+	backlog = t.fetchPendingCallbacks()
+	t.callbacks.Close()
+	t.closedMu.Unlock()
+	for _, b := range backlog {
+		b(ctx)
+	}
+}
+
+func (t *CallbackSerializer) fetchPendingCallbacks() []func(context.Context) {
+	var backlog []func(context.Context)
+	for {
+		select {
+		case b := <-t.callbacks.Get():
+			backlog = append(backlog, b.(func(context.Context)))
+			t.callbacks.Load()
+		default:
+			return backlog
 		}
 	}
 }

--- a/internal/grpcsync/callback_serializer_test.go
+++ b/internal/grpcsync/callback_serializer_test.go
@@ -20,7 +20,6 @@ package grpcsync
 
 import (
 	"context"
-	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -141,7 +140,10 @@ func (s) TestCallbackSerializer_Schedule_Concurrent(t *testing.T) {
 // are not executed once Close() returns.
 func (s) TestCallbackSerializer_Schedule_Close(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
-	cs := NewCallbackSerializer(ctx)
+	defer cancel()
+
+	serializerCtx, serializerCancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	cs := NewCallbackSerializer(serializerCtx)
 
 	// Schedule a callback which blocks until the context passed to it is
 	// canceled. It also closes a channel to signal that it has started.
@@ -151,36 +153,54 @@ func (s) TestCallbackSerializer_Schedule_Close(t *testing.T) {
 		<-ctx.Done()
 	})
 
-	// Schedule a bunch of callbacks. These should not be exeuted since the first
-	// one started earlier is blocked.
+	// Schedule a bunch of callbacks. These should be exeuted since the are
+	// scheduled before the serializer is closed.
 	const numCallbacks = 10
-	errCh := make(chan error, numCallbacks)
+	callbackCh := make(chan int, numCallbacks)
 	for i := 0; i < numCallbacks; i++ {
-		cs.Schedule(func(_ context.Context) {
-			errCh <- fmt.Errorf("callback %d executed when not expected to", i)
-		})
+		num := i
+		if !cs.Schedule(func(context.Context) { callbackCh <- num }) {
+			t.Fatal("Schedule failed to accept a callback when the serializer is yet to be closed")
+		}
 	}
 
 	// Ensure that none of the newer callbacks are executed at this point.
 	select {
 	case <-time.After(defaultTestShortTimeout):
-	case err := <-errCh:
-		t.Fatal(err)
+	case <-callbackCh:
+		t.Fatal("Newer callback executed when older one is still executing")
 	}
 
 	// Wait for the first callback to start before closing the scheduler.
 	<-firstCallbackStartedCh
 
-	// Cancel the context which will unblock the first callback. None of the
+	// Cancel the context which will unblock the first callback. All of the
 	// other callbacks (which have not started executing at this point) should
 	// be executed after this.
-	cancel()
+	serializerCancel()
+
+	// Ensure that the newer callbacks are executed.
+	for i := 0; i < numCallbacks; i++ {
+		select {
+		case <-ctx.Done():
+			t.Fatal("Timeout when waiting for callback scheduled before close to be executed")
+		case num := <-callbackCh:
+			if num != i {
+				t.Fatalf("Executing callback %d, want %d", num, i)
+			}
+		}
+	}
 	<-cs.Done
 
-	// Ensure that the newer callbacks are not executed.
+	done := make(chan struct{})
+	if cs.Schedule(func(context.Context) { close(done) }) {
+		t.Fatal("Scheduled a callback after closing the serializer")
+	}
+
+	// Ensure that the lates callback is executed at this point.
 	select {
 	case <-time.After(defaultTestShortTimeout):
-	case err := <-errCh:
-		t.Fatal(err)
+	case <-done:
+		t.Fatal("Newer callback executed when scheduled after closing serializer")
 	}
 }

--- a/resolver_conn_wrapper.go
+++ b/resolver_conn_wrapper.go
@@ -158,16 +158,11 @@ func (ccr *ccResolverWrapper) handleCloseAndEnterIdle() {
 	r := ccr.resolver
 	ccr.mu.Unlock()
 
-	// Give enqueued callbacks a chance to finish before closing the balancer.
+	// Give enqueued callbacks a chance to finish.
 	<-done
 
-	// Resolver close needs to be called outside the lock because these methods
-	// are generally blocking and don't return until they stop any pending
-	// goroutines and cleanup allocated resources. And since the main goroutine
-	// of the resolver might be reporting an error or state update at the same
-	// time as close, and the former needs to grab the lock to schedule a
-	// callback on the serializer, it will lead to a deadlock if we hold the
-	// lock here.
+	// Spawn a goroutine to close the resolver (since it may block trying to
+	// cleanup all allocated resources) and return early.
 	r.Close()
 }
 

--- a/resolver_conn_wrapper.go
+++ b/resolver_conn_wrapper.go
@@ -37,14 +37,6 @@ type resolverStateUpdater interface {
 	updateResolverState(s resolver.State, err error) error
 }
 
-type ccrMode int
-
-const (
-	ccrModeActive = iota
-	ccrModeIdleOrClosed
-	ccrModeExitingIdle
-)
-
 // ccResolverWrapper is a wrapper on top of cc for resolvers.
 // It implements resolver.ClientConn interface.
 type ccResolverWrapper struct {

--- a/stream.go
+++ b/stream.go
@@ -158,20 +158,16 @@ func (cc *ClientConn) NewStream(ctx context.Context, desc *StreamDesc, method st
 	if err := cc.idlenessMgr.onCallBegin(); err != nil {
 		return nil, err
 	}
+	defer cc.idlenessMgr.onCallEnd()
 
 	// allow interceptor to see all applicable call options, which means those
 	// configured as defaults from dial option as well as per-call options
 	opts = combine(cc.dopts.callOptions, opts)
 
-	var cs ClientStream
-	var err error
 	if cc.dopts.streamInt != nil {
-		cs, err = cc.dopts.streamInt(ctx, desc, cc, method, newClientStream, opts...)
-	} else {
-		cs, err = newClientStream(ctx, desc, cc, method, opts...)
+		return cc.dopts.streamInt(ctx, desc, cc, method, newClientStream, opts...)
 	}
-	cc.idlenessMgr.onCallEnd()
-	return cs, err
+	return newClientStream(ctx, desc, cc, method, opts...)
 }
 
 // NewClientStream is a wrapper for ClientConn.NewStream.

--- a/test/clientconn_state_transition_test.go
+++ b/test/clientconn_state_transition_test.go
@@ -537,3 +537,10 @@ func awaitNotState(ctx context.Context, t *testing.T, cc *grpc.ClientConn, state
 		}
 	}
 }
+
+func awaitNoStateChange(ctx context.Context, t *testing.T, cc *grpc.ClientConn, currState connectivity.State) {
+	t.Helper()
+	if cc.WaitForStateChange(ctx, currState) {
+		t.Fatalf("State changed from %q to %q when no state change was expected", currState, cc.GetState())
+	}
+}

--- a/test/idleness_test.go
+++ b/test/idleness_test.go
@@ -1,0 +1,408 @@
+/*
+ *
+ * Copyright 2023 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/connectivity"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/internal/channelz"
+	"google.golang.org/grpc/internal/stubserver"
+	"google.golang.org/grpc/resolver"
+	"google.golang.org/grpc/resolver/manual"
+	"google.golang.org/grpc/status"
+
+	testgrpc "google.golang.org/grpc/interop/grpc_testing"
+	testpb "google.golang.org/grpc/interop/grpc_testing"
+)
+
+const defaultTestShortIdleTimeout = 500 * time.Millisecond
+
+// channelzTraceEventFound looks up the top-channels in channelz (expects a
+// single one), and checks if there is a trace event on the channel matching the
+// provided description string.
+func channelzTraceEventFound(ctx context.Context, wantDesc string) error {
+	for ctx.Err() == nil {
+		tcs, _ := channelz.GetTopChannels(0, 0)
+		if l := len(tcs); l != 1 {
+			return fmt.Errorf("when looking for channelz trace event with description %q, found %d top-level channels, want 1", wantDesc, l)
+		}
+		if tcs[0].Trace == nil {
+			return fmt.Errorf("when looking for channelz trace event with description %q, no trace events found for top-level channel", wantDesc)
+		}
+
+		for _, e := range tcs[0].Trace.Events {
+			if strings.Contains(e.Desc, wantDesc) {
+				return nil
+			}
+		}
+	}
+	return fmt.Errorf("when looking for channelz trace event with description %q, %w", wantDesc, ctx.Err())
+}
+
+// channelzTraceEventNotFound looks up the top-channels in channelz (expects a
+// single one), and verifies that there is no trace event on the channel
+// matching the provided description string.
+func channelzTraceEventNotFound(ctx context.Context, wantDesc string) error {
+	sCtx, sCancel := context.WithTimeout(ctx, defaultTestShortTimeout)
+	defer sCancel()
+
+	err := channelzTraceEventFound(sCtx, wantDesc)
+	if err == nil {
+		return fmt.Errorf("found channelz trace event with description %q, when expected not to", wantDesc)
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		return err
+	}
+	return nil
+}
+
+// Tests the case where channel idleness is disabled by passing an idle_timeout
+// of 0. Verifies that a READY channel with no RPCs does not move to IDLE.
+func (s) TestChannelIdleness_Disabled_NoActivity(t *testing.T) {
+	// Setup channelz for testing.
+	czCleanup := channelz.NewChannelzStorageForTesting()
+	t.Cleanup(func() { czCleanupWrapper(czCleanup, t) })
+
+	// Create a ClientConn with idle_timeout set to 0.
+	r := manual.NewBuilderWithScheme("whatever")
+	dopts := []grpc.DialOption{
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithResolvers(r),
+		grpc.WithIdleTimeout(0), // Disable idleness.
+		grpc.WithDefaultServiceConfig(`{"loadBalancingConfig": [{"round_robin":{}}]}`),
+	}
+	cc, err := grpc.Dial(r.Scheme()+":///test.server", dopts...)
+	if err != nil {
+		t.Fatalf("grpc.Dial() failed: %v", err)
+	}
+	t.Cleanup(func() { cc.Close() })
+
+	// Start a test backend and push an address update via the resolver.
+	backend := stubserver.StartTestService(t, nil)
+	t.Cleanup(func() { backend.Stop() })
+	r.UpdateState(resolver.State{Addresses: []resolver.Address{{Addr: backend.Address}}})
+
+	// Veirfy that the ClientConn moves to READY.
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	for state := cc.GetState(); state != connectivity.Ready; state = cc.GetState() {
+		if !cc.WaitForStateChange(ctx, state) {
+			t.Fatal("Timeout when waiting for channel to switch to READY")
+		}
+	}
+
+	// Veirfy that the ClientConn stay in READY.
+	sCtx, sCancel := context.WithTimeout(ctx, 3*defaultTestShortIdleTimeout)
+	defer sCancel()
+	if cc.WaitForStateChange(sCtx, connectivity.Ready) {
+		t.Fatalf("Connectivity state changed to %q when expected to stay in READY", cc.GetState())
+	}
+
+	// Verify that there are no idleness related channelz events.
+	if err := channelzTraceEventNotFound(ctx, "entering idle mode"); err != nil {
+		t.Fatal(err)
+	}
+	if err := channelzTraceEventNotFound(ctx, "exiting idle mode"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Tests the case where channel idleness is enabled by passing a small value for
+// idle_timeout. Verifies that a READY channel with no RPCs moves to IDLE.
+func (s) TestChannelIdleness_Enabled_NoActivity(t *testing.T) {
+	// Setup channelz for testing.
+	czCleanup := channelz.NewChannelzStorageForTesting()
+	t.Cleanup(func() { czCleanupWrapper(czCleanup, t) })
+
+	// Create a ClientConn with a short idle_timeout.
+	r := manual.NewBuilderWithScheme("whatever")
+	dopts := []grpc.DialOption{
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithResolvers(r),
+		grpc.WithIdleTimeout(defaultTestShortIdleTimeout),
+		grpc.WithDefaultServiceConfig(`{"loadBalancingConfig": [{"round_robin":{}}]}`),
+	}
+	cc, err := grpc.Dial(r.Scheme()+":///test.server", dopts...)
+	if err != nil {
+		t.Fatalf("grpc.Dial() failed: %v", err)
+	}
+	t.Cleanup(func() { cc.Close() })
+
+	// Start a test backend and push an address update via the resolver.
+	backend := stubserver.StartTestService(t, nil)
+	t.Cleanup(func() { backend.Stop() })
+	r.UpdateState(resolver.State{Addresses: []resolver.Address{{Addr: backend.Address}}})
+
+	// Veirfy that the ClientConn moves to READY.
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	for state := cc.GetState(); state != connectivity.Ready; state = cc.GetState() {
+		if !cc.WaitForStateChange(ctx, state) {
+			t.Fatal("Timeout when waiting for channel to switch to READY")
+		}
+	}
+
+	// Veirfy that the ClientConn moves to IDLE as there is no activity.
+	for state := connectivity.Ready; state != connectivity.Idle; state = cc.GetState() {
+		if !cc.WaitForStateChange(ctx, state) {
+			t.Fatal("Timeout when waiting for channel to switch to READY")
+		}
+	}
+
+	// Verify idleness related channelz events.
+	if err := channelzTraceEventFound(ctx, "entering idle mode"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Tests the case where channel idleness is enabled by passing a small value for
+// idle_timeout. Verifies that a READY channel with an ongoing RPC stays READY.
+func (s) TestChannelIdleness_Enabled_OngoingCall(t *testing.T) {
+	// Setup channelz for testing.
+	czCleanup := channelz.NewChannelzStorageForTesting()
+	t.Cleanup(func() { czCleanupWrapper(czCleanup, t) })
+
+	// Create a ClientConn with a short idle_timeout.
+	r := manual.NewBuilderWithScheme("whatever")
+	dopts := []grpc.DialOption{
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithResolvers(r),
+		grpc.WithIdleTimeout(defaultTestShortIdleTimeout),
+		grpc.WithDefaultServiceConfig(`{"loadBalancingConfig": [{"round_robin":{}}]}`),
+	}
+	cc, err := grpc.Dial(r.Scheme()+":///test.server", dopts...)
+	if err != nil {
+		t.Fatalf("grpc.Dial() failed: %v", err)
+	}
+	t.Cleanup(func() { cc.Close() })
+
+	// Start a test backend which keeps a unary RPC call active by blocking on a
+	// channel that is closed by the test later on. Also push an address update
+	// via the resolver.
+	blockCh := make(chan struct{})
+	backend := &stubserver.StubServer{
+		EmptyCallF: func(ctx context.Context, in *testpb.Empty) (*testpb.Empty, error) {
+			<-blockCh
+			return &testpb.Empty{}, nil
+		},
+	}
+	if err := backend.StartServer(); err != nil {
+		t.Fatalf("Failed to start backend: %v", err)
+	}
+	t.Cleanup(func() { backend.Stop() })
+	r.UpdateState(resolver.State{Addresses: []resolver.Address{{Addr: backend.Address}}})
+
+	// Veirfy that the ClientConn moves to READY.
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	for state := cc.GetState(); state != connectivity.Ready; state = cc.GetState() {
+		if !cc.WaitForStateChange(ctx, state) {
+			t.Fatal("Timeout when waiting for channel to switch to READY")
+		}
+	}
+
+	// Spawn a goroutine which checks expected state transitions and idleness
+	// channelz trace events. It eventually closes `blockCh`, thereby unblocking
+	// the server RPC handler and the unary call below.
+	errCh := make(chan error, 1)
+	go func() {
+		// Veirfy that the ClientConn stay in READY.
+		sCtx, sCancel := context.WithTimeout(ctx, 3*defaultTestShortIdleTimeout)
+		defer sCancel()
+		if cc.WaitForStateChange(sCtx, connectivity.Ready) {
+			errCh <- fmt.Errorf("Connectivity state changed to %q when expected to stay in READY", cc.GetState())
+			return
+		}
+
+		// Verify that there are no idleness related channelz events.
+		if err := channelzTraceEventNotFound(ctx, "entering idle mode"); err != nil {
+			errCh <- err
+			return
+		}
+		if err := channelzTraceEventNotFound(ctx, "exiting idle mode"); err != nil {
+			errCh <- err
+			return
+		}
+
+		// Unblock the unary RPC on the server.
+		close(blockCh)
+		errCh <- nil
+	}()
+
+	// Make a unary RPC that blocks on the server, thereby ensuring that the
+	// count of active RPCs on the client is non-zero.
+	client := testgrpc.NewTestServiceClient(cc)
+	if _, err := client.EmptyCall(ctx, &testpb.Empty{}); err != nil {
+		t.Errorf("EmptyCall RPC failed: %v", err)
+	}
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-ctx.Done():
+		t.Fatalf("Timeout when trying to verify that an active RPC keeps channel from moving to IDLE")
+	}
+}
+
+// Tests the case where channel idleness is enabled by passing a small value for
+// idle_timeout. Verifies that activity on a READY channel (frequent and short
+// RPCs) keeps it from moving to IDLE.
+func (s) TestChannelIdleness_Enabled_ActiveSinceLastCheck(t *testing.T) {
+	// Setup channelz for testing.
+	czCleanup := channelz.NewChannelzStorageForTesting()
+	t.Cleanup(func() { czCleanupWrapper(czCleanup, t) })
+
+	// Create a ClientConn with a short idle_timeout.
+	r := manual.NewBuilderWithScheme("whatever")
+	dopts := []grpc.DialOption{
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithResolvers(r),
+		grpc.WithIdleTimeout(defaultTestShortIdleTimeout),
+		grpc.WithDefaultServiceConfig(`{"loadBalancingConfig": [{"round_robin":{}}]}`),
+	}
+	cc, err := grpc.Dial(r.Scheme()+":///test.server", dopts...)
+	if err != nil {
+		t.Fatalf("grpc.Dial() failed: %v", err)
+	}
+	t.Cleanup(func() { cc.Close() })
+
+	// Start a test backend and push an address update via the resolver.
+	backend := stubserver.StartTestService(t, nil)
+	t.Cleanup(func() { backend.Stop() })
+	r.UpdateState(resolver.State{Addresses: []resolver.Address{{Addr: backend.Address}}})
+
+	// Veirfy that the ClientConn moves to READY.
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	for state := cc.GetState(); state != connectivity.Ready; state = cc.GetState() {
+		if !cc.WaitForStateChange(ctx, state) {
+			t.Fatal("Timeout when waiting for channel to switch to READY")
+		}
+	}
+
+	// For a duration of three times the configured idle timeout, making RPCs
+	// every now and then and ensure that the channel does not move out of
+	// READY.
+	sCtx, sCancel := context.WithTimeout(ctx, 3*defaultTestShortIdleTimeout)
+	defer sCancel()
+	go func() {
+		for ; sCtx.Err() == nil; <-time.After(defaultTestShortTimeout) {
+			client := testgrpc.NewTestServiceClient(cc)
+			if _, err := client.EmptyCall(sCtx, &testpb.Empty{}); err != nil {
+				// While iterating through this for loop, at some point in time,
+				// the context deadline will expire. It is safe to ignore that
+				// error code.
+				if status.Code(err) != codes.DeadlineExceeded {
+					t.Errorf("EmptyCall RPC failed: %v", err)
+					return
+				}
+			}
+		}
+	}()
+
+	// Veirfy that the ClientConn stay in READY.
+	if cc.WaitForStateChange(sCtx, connectivity.Ready) {
+		t.Fatalf("Connectivity state changed to %q when expected to stay in READY", cc.GetState())
+	}
+
+	// Verify that there are no idleness related channelz events.
+	if err := channelzTraceEventNotFound(ctx, "entering idle mode"); err != nil {
+		t.Fatal(err)
+	}
+	if err := channelzTraceEventNotFound(ctx, "exiting idle mode"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Tests the case where channel idleness is enabled by passing a small value for
+// idle_timeout. Verifies that a READY channel with no RPCs moves to IDLE. Also
+// verifies that a subsequent RPC on the IDLE channel kicks it out of IDLE.
+func (s) TestChannelIdleness_Enabled_ExitIdleOnRPC(t *testing.T) {
+	// Setup channelz for testing.
+	czCleanup := channelz.NewChannelzStorageForTesting()
+	t.Cleanup(func() { czCleanupWrapper(czCleanup, t) })
+
+	// Start a test backend and set the bootstrap state of the resolver to
+	// include this address. This will ensure that when the resolver is
+	// restarted when exiting idle, it will push the same address to grpc again.
+	r := manual.NewBuilderWithScheme("whatever")
+	backend := stubserver.StartTestService(t, nil)
+	t.Cleanup(func() { backend.Stop() })
+	r.InitialState(resolver.State{Addresses: []resolver.Address{{Addr: backend.Address}}})
+
+	// Create a ClientConn with a short idle_timeout.
+	dopts := []grpc.DialOption{
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithResolvers(r),
+		grpc.WithIdleTimeout(defaultTestShortIdleTimeout),
+		grpc.WithDefaultServiceConfig(`{"loadBalancingConfig": [{"round_robin":{}}]}`),
+	}
+	cc, err := grpc.Dial(r.Scheme()+":///test.server", dopts...)
+	if err != nil {
+		t.Fatalf("grpc.Dial() failed: %v", err)
+	}
+	t.Cleanup(func() { cc.Close() })
+
+	// Veirfy that the ClientConn moves to READY.
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	for state := cc.GetState(); state != connectivity.Ready; state = cc.GetState() {
+		if !cc.WaitForStateChange(ctx, state) {
+			t.Fatal("Timeout when waiting for channel to switch to READY")
+		}
+	}
+
+	// Veirfy that the ClientConn moves to IDLE as there is no activity.
+	for state := connectivity.Ready; state != connectivity.Idle; state = cc.GetState() {
+		if !cc.WaitForStateChange(ctx, state) {
+			t.Fatal("Timeout when waiting for channel to switch to IDLE")
+		}
+	}
+
+	// Verify idleness related channelz events.
+	if err := channelzTraceEventFound(ctx, "entering idle mode"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Make an RPC and ensure that it succeeds and moves the channel back to
+	// READY.
+	client := testgrpc.NewTestServiceClient(cc)
+	if _, err := client.EmptyCall(ctx, &testpb.Empty{}); err != nil {
+		t.Fatalf("EmptyCall RPC failed: %v", err)
+	}
+	for state := cc.GetState(); state != connectivity.Ready; state = cc.GetState() {
+		if !cc.WaitForStateChange(ctx, state) {
+			t.Fatal("Timeout when waiting for channel to switch to READY")
+		}
+	}
+	if err := channelzTraceEventFound(ctx, "exiting idle mode"); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/test/idleness_test.go
+++ b/test/idleness_test.go
@@ -288,7 +288,7 @@ func (s) TestChannelIdleness_Enabled_ActiveSinceLastCheck(t *testing.T) {
 	sCtx, sCancel := context.WithTimeout(ctx, 3*defaultTestShortIdleTimeout)
 	defer sCancel()
 	go func() {
-		for ; sCtx.Err() == nil; <-time.After(defaultTestShortIdleTimeout / 2) {
+		for ; sCtx.Err() == nil; <-time.After(defaultTestShortIdleTimeout / 4) {
 			client := testgrpc.NewTestServiceClient(cc)
 			if _, err := client.EmptyCall(sCtx, &testpb.Empty{}); err != nil {
 				// While iterating through this for loop, at some point in time,


### PR DESCRIPTION
This PR adds support for channel idleness. Summary of changes:
- Added a new component `idlenessManager` that
  - keeps track of RPC activity on the channel, and
  - instructs the channel to enter or exit idle mode
- ClientConn
  - methods to enter and exit idle mode
    - these are invoked by the newly added `idlenessManager`
    - these take care of shutting down and recreating the name resolver, load balancer, and blocking picker
    - these also set connectivity state appropriately
  - call into the `idlenessManager` from `Invoke()` and `NewStream()`
    - these are the RPC entry points
  - refactor `DialContext` a little bit for better code flow
  - `addTraceEvent` helper to emit channelz trace events
- Add a `WithIdleTimeout` dial option to set `idle_timeout`
  - Defaults to `30m` if unset (current default used by Java)
  - Disables channel idleness if explicitly set to `0` 
- balancer wrapper
  - methods to enter and exit idle mode by shutting down and recreating the balancer respectively
  - not forwarding calls from the balancer to grpc when the channel is in idle mode
- picker wrapper (or blocking picker) 
  - methods to enter and exit idle mode
  - when in idle mode, drops picker updates
- resolver wrapper 
  - methods to enter and exit idle mode by shutting down and recreating the name resolver respectively

RELEASE NOTES:
- grpc: support channel idleness using `WithIdleTimeout` dial option