### PR TITLE
xds/internal/xdsclient/xdslbregistry: Continue in converter if type not found

### DIFF
--- a/xds/internal/xdsclient/xdslbregistry/converter.go
+++ b/xds/internal/xdsclient/xdslbregistry/converter.go
@@ -34,6 +34,7 @@ import (
 	"github.com/golang/protobuf/proto"
 	structpb "github.com/golang/protobuf/ptypes/struct"
 
+	"google.golang.org/grpc/balancer"
 	"google.golang.org/grpc/internal/envconfig"
 )
 
@@ -87,16 +88,29 @@ func convertToServiceConfig(lbPolicy *v3clusterpb.LoadBalancingPolicy, depth int
 			return convertWrrLocality(wrrlProto, depth)
 		case "type.googleapis.com/xds.type.v3.TypedStruct":
 			tsProto := &v3xdsxdstypepb.TypedStruct{}
+
 			if err := proto.Unmarshal(policy.GetTypedExtensionConfig().GetTypedConfig().GetValue(), tsProto); err != nil {
 				return nil, fmt.Errorf("failed to unmarshal resource: %v", err)
 			}
-			return convertCustomPolicy(tsProto.GetTypeUrl(), tsProto.GetValue())
+			var json json.RawMessage
+			var cont bool
+			var err error
+			if json, cont, err = convertCustomPolicy(tsProto.GetTypeUrl(), tsProto.GetValue()); cont {
+				continue
+			}
+			return json, err
 		case "type.googleapis.com/udpa.type.v1.TypedStruct":
 			tsProto := &v1xdsudpatypepb.TypedStruct{}
 			if err := proto.Unmarshal(policy.GetTypedExtensionConfig().GetTypedConfig().GetValue(), tsProto); err != nil {
 				return nil, fmt.Errorf("failed to unmarshal resource: %v", err)
 			}
-			return convertCustomPolicy(tsProto.GetTypeUrl(), tsProto.GetValue())
+			var json json.RawMessage
+			var cont bool
+			var err error
+			if json, cont, err = convertCustomPolicy(tsProto.GetTypeUrl(), tsProto.GetValue()); cont {
+				continue
+			}
+			return json, err
 		}
 		// Any entry not in the above list is unsupported and will be skipped.
 		// This includes Least Request as well, since grpc-go does not support
@@ -133,20 +147,31 @@ func convertWrrLocality(cfg *v3wrrlocalitypb.WrrLocality, depth int) (json.RawMe
 	return makeBalancerConfigJSON("xds_wrr_locality_experimental", lbCfgJSON), nil
 }
 
-func convertCustomPolicy(typeURL string, s *structpb.Struct) (json.RawMessage, error) {
+// convertCustomPolicy attempts to prepare json configuration for a custom lb
+// proto, which specifies the gRPC balancer type and configuration. Returns the
+// converted json, a bool representing whether the caller should continue to the
+// next policy, which is true if the gRPC Balancer registry does not contain
+// that balancer type, and an error which should cause caller to error if error
+// converting.
+func convertCustomPolicy(typeURL string, s *structpb.Struct) (json.RawMessage, bool, error) {
 	// The gRPC policy name will be the "type name" part of the value of the
 	// type_url field in the TypedStruct. We get this by using the part after
 	// the last / character. Can assume a valid type_url from the control plane.
 	urls := strings.Split(typeURL, "/")
 	name := urls[len(urls)-1]
 
+	if balancer.Get(name) == nil {
+		return nil, true, nil
+	}
+
 	rawJSON, err := json.Marshal(s)
 	if err != nil {
-		return nil, fmt.Errorf("error converting custom lb policy %v: %v for %+v", err, typeURL, s)
+		return nil, false, fmt.Errorf("error converting custom lb policy %v: %v for %+v", err, typeURL, s)
 	}
+
 	// The Struct contained in the TypedStruct will be returned as-is as the
 	// configuration JSON object.
-	return makeBalancerConfigJSON(name, rawJSON), nil
+	return makeBalancerConfigJSON(name, rawJSON), false, nil
 }
 
 func makeBalancerConfigJSON(name string, value json.RawMessage) []byte {

--- a/xds/internal/xdsclient/xdslbregistry/converter.go
+++ b/xds/internal/xdsclient/xdslbregistry/converter.go
@@ -88,14 +88,11 @@ func convertToServiceConfig(lbPolicy *v3clusterpb.LoadBalancingPolicy, depth int
 			return convertWrrLocality(wrrlProto, depth)
 		case "type.googleapis.com/xds.type.v3.TypedStruct":
 			tsProto := &v3xdsxdstypepb.TypedStruct{}
-
 			if err := proto.Unmarshal(policy.GetTypedExtensionConfig().GetTypedConfig().GetValue(), tsProto); err != nil {
 				return nil, fmt.Errorf("failed to unmarshal resource: %v", err)
 			}
-			var json json.RawMessage
-			var cont bool
-			var err error
-			if json, cont, err = convertCustomPolicy(tsProto.GetTypeUrl(), tsProto.GetValue()); cont {
+			json, cont, err := convertCustomPolicy(tsProto.GetTypeUrl(), tsProto.GetValue())
+			if cont {
 				continue
 			}
 			return json, err
@@ -104,10 +101,11 @@ func convertToServiceConfig(lbPolicy *v3clusterpb.LoadBalancingPolicy, depth int
 			if err := proto.Unmarshal(policy.GetTypedExtensionConfig().GetTypedConfig().GetValue(), tsProto); err != nil {
 				return nil, fmt.Errorf("failed to unmarshal resource: %v", err)
 			}
-			var json json.RawMessage
-			var cont bool
-			var err error
-			if json, cont, err = convertCustomPolicy(tsProto.GetTypeUrl(), tsProto.GetValue()); cont {
+			if err := proto.Unmarshal(policy.GetTypedExtensionConfig().GetTypedConfig().GetValue(), tsProto); err != nil {
+				return nil, fmt.Errorf("failed to unmarshal resource: %v", err)
+			}
+			json, cont, err := convertCustomPolicy(tsProto.GetTypeUrl(), tsProto.GetValue())
+			if cont {
 				continue
 			}
 			return json, err

--- a/xds/internal/xdsclient/xdslbregistry/tests/converter_test.go
+++ b/xds/internal/xdsclient/xdslbregistry/tests/converter_test.go
@@ -172,6 +172,16 @@ func (s) TestConvertToServiceConfigSuccess(t *testing.T) {
 				Policies: []*v3clusterpb.LoadBalancingPolicy_Policy{
 					{
 						TypedExtensionConfig: &v3corepb.TypedExtensionConfig{
+							// The type not registered in gRPC Policy registry.
+							// Should fallback to next policy in list.
+							TypedConfig: testutils.MarshalAny(&v3xdsxdstypepb.TypedStruct{
+								TypeUrl: "type.googleapis.com/myorg.ThisTypeDoesNotExist",
+								Value:   &structpb.Struct{},
+							}),
+						},
+					},
+					{
+						TypedExtensionConfig: &v3corepb.TypedExtensionConfig{
 							TypedConfig: testutils.MarshalAny(&v3xdsxdstypepb.TypedStruct{
 								TypeUrl: "type.googleapis.com/myorg.MyCustomLeastRequestPolicy",
 								Value:   &structpb.Struct{},
@@ -318,6 +328,15 @@ func (s) TestConvertToServiceConfigFailure(t *testing.T) {
 			name: "no-supported-policy",
 			policy: &v3clusterpb.LoadBalancingPolicy{
 				Policies: []*v3clusterpb.LoadBalancingPolicy_Policy{
+					{
+						TypedExtensionConfig: &v3corepb.TypedExtensionConfig{
+							// The type not registered in gRPC Policy registry.
+							TypedConfig: testutils.MarshalAny(&v3xdsxdstypepb.TypedStruct{
+								TypeUrl: "type.googleapis.com/myorg.ThisTypeDoesNotExist",
+								Value:   &structpb.Struct{},
+							}),
+						},
+					},
 					{
 						TypedExtensionConfig: &v3corepb.TypedExtensionConfig{
 							// Not supported by gRPC-Go.


### PR DESCRIPTION
Previously, the converter would simply prepare the JSON if a TypedStruct was encountered. However, we want to look at the gRPC name within the TypedStruct, and if the balancer type specified is not found in the gRPC registry, it continues onto the next one in the list. This makes the interop test case for Custom LBs work correctly against our repo.

RELEASE NOTES: N/A