### PR TITLE
weightedroundrobin: fix duration format in lb config

### DIFF
--- a/balancer/weightedroundrobin/balancer.go
+++ b/balancer/weightedroundrobin/balancer.go
@@ -34,6 +34,7 @@ import (
 	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/internal/grpclog"
 	"google.golang.org/grpc/internal/grpcrand"
+	iserviceconfig "google.golang.org/grpc/internal/serviceconfig"
 	"google.golang.org/grpc/orca"
 	"google.golang.org/grpc/resolver"
 	"google.golang.org/grpc/serviceconfig"
@@ -66,10 +67,10 @@ func (bb) Build(cc balancer.ClientConn, bOpts balancer.BuildOptions) balancer.Ba
 func (bb) ParseConfig(js json.RawMessage) (serviceconfig.LoadBalancingConfig, error) {
 	lbCfg := &lbConfig{
 		// Default values as documented in A58.
-		OOBReportingPeriod:      10 * time.Second,
-		BlackoutPeriod:          10 * time.Second,
-		WeightExpirationPeriod:  3 * time.Minute,
-		WeightUpdatePeriod:      time.Second,
+		OOBReportingPeriod:      iserviceconfig.Duration(10 * time.Second),
+		BlackoutPeriod:          iserviceconfig.Duration(10 * time.Second),
+		WeightExpirationPeriod:  iserviceconfig.Duration(3 * time.Minute),
+		WeightUpdatePeriod:      iserviceconfig.Duration(time.Second),
 		ErrorUtilizationPenalty: 1,
 	}
 	if err := json.Unmarshal(js, lbCfg); err != nil {
@@ -87,8 +88,8 @@ func (bb) ParseConfig(js json.RawMessage) (serviceconfig.LoadBalancingConfig, er
 	}
 
 	// Impose lower bound of 100ms on weightUpdatePeriod.
-	if !internal.AllowAnyWeightUpdatePeriod && lbCfg.WeightUpdatePeriod < 100*time.Millisecond {
-		lbCfg.WeightUpdatePeriod = 100 * time.Millisecond
+	if !internal.AllowAnyWeightUpdatePeriod && lbCfg.WeightUpdatePeriod < iserviceconfig.Duration(100*time.Millisecond) {
+		lbCfg.WeightUpdatePeriod = iserviceconfig.Duration(100 * time.Millisecond)
 	}
 
 	return lbCfg, nil
@@ -337,7 +338,7 @@ func (p *picker) scWeights() []float64 {
 	ws := make([]float64, len(p.subConns))
 	now := internal.TimeNow()
 	for i, wsc := range p.subConns {
-		ws[i] = wsc.weight(now, p.cfg.WeightExpirationPeriod, p.cfg.BlackoutPeriod)
+		ws[i] = wsc.weight(now, time.Duration(p.cfg.WeightExpirationPeriod), time.Duration(p.cfg.BlackoutPeriod))
 	}
 	return ws
 }
@@ -358,7 +359,7 @@ func (p *picker) start(ctx context.Context) {
 		return
 	}
 	go func() {
-		ticker := time.NewTicker(p.cfg.WeightUpdatePeriod)
+		ticker := time.NewTicker(time.Duration(p.cfg.WeightUpdatePeriod))
 		for {
 			select {
 			case <-ctx.Done():
@@ -469,7 +470,7 @@ func (w *weightedSubConn) updateConfig(cfg *lbConfig) {
 	if w.logger.V(2) {
 		w.logger.Infof("Registering ORCA listener for %v with interval %v", w.SubConn, newPeriod)
 	}
-	opts := orca.OOBListenerOptions{ReportInterval: newPeriod}
+	opts := orca.OOBListenerOptions{ReportInterval: time.Duration(newPeriod)}
 	w.stopORCAListener = orca.RegisterOOBListener(w.SubConn, w, opts)
 }
 

--- a/balancer/weightedroundrobin/balancer_test.go
+++ b/balancer/weightedroundrobin/balancer_test.go
@@ -52,31 +52,32 @@ func Test(t *testing.T) {
 
 const defaultTestTimeout = 10 * time.Second
 const weightUpdatePeriod = 50 * time.Millisecond
+const weightExpirationPeriod = time.Minute
 const oobReportingInterval = 10 * time.Millisecond
 
 func init() {
 	iwrr.AllowAnyWeightUpdatePeriod = true
 }
 
-func boolp(b bool) *bool                       { return &b }
-func float64p(f float64) *float64              { return &f }
-func durationp(d time.Duration) *time.Duration { return &d }
+func boolp(b bool) *bool          { return &b }
+func float64p(f float64) *float64 { return &f }
+func stringp(s string) *string    { return &s }
 
 var (
 	perCallConfig = iwrr.LBConfig{
 		EnableOOBLoadReport:     boolp(false),
-		OOBReportingPeriod:      durationp(5 * time.Millisecond),
-		BlackoutPeriod:          durationp(0),
-		WeightExpirationPeriod:  durationp(time.Minute),
-		WeightUpdatePeriod:      durationp(weightUpdatePeriod),
+		OOBReportingPeriod:      stringp("0.005s"),
+		BlackoutPeriod:          stringp("0s"),
+		WeightExpirationPeriod:  stringp("60s"),
+		WeightUpdatePeriod:      stringp(".050s"),
 		ErrorUtilizationPenalty: float64p(0),
 	}
 	oobConfig = iwrr.LBConfig{
 		EnableOOBLoadReport:     boolp(true),
-		OOBReportingPeriod:      durationp(5 * time.Millisecond),
-		BlackoutPeriod:          durationp(0),
-		WeightExpirationPeriod:  durationp(time.Minute),
-		WeightUpdatePeriod:      durationp(weightUpdatePeriod),
+		OOBReportingPeriod:      stringp("0.005s"),
+		BlackoutPeriod:          stringp("0s"),
+		WeightExpirationPeriod:  stringp("60s"),
+		WeightUpdatePeriod:      stringp(".050s"),
 		ErrorUtilizationPenalty: float64p(0),
 	}
 )
@@ -456,10 +457,10 @@ func (s) TestBalancer_TwoAddresses_BlackoutPeriod(t *testing.T) {
 	t.Cleanup(func() { iwrr.TimeNow = time.Now })
 
 	testCases := []struct {
-		blackoutPeriodCfg *time.Duration
+		blackoutPeriodCfg *string
 		blackoutPeriod    time.Duration
 	}{{
-		blackoutPeriodCfg: durationp(time.Second),
+		blackoutPeriodCfg: stringp("1s"),
 		blackoutPeriod:    time.Second,
 	}, {
 		blackoutPeriodCfg: nil,
@@ -547,7 +548,7 @@ func (s) TestBalancer_TwoAddresses_WeightExpiration(t *testing.T) {
 	srv2.oobMetrics.SetCPUUtilization(.1)
 
 	cfg := oobConfig
-	cfg.OOBReportingPeriod = durationp(time.Minute)
+	cfg.OOBReportingPeriod = stringp("60s")
 	sc := svcConfig(t, cfg)
 	if err := srv1.StartClient(grpc.WithDefaultServiceConfig(sc)); err != nil {
 		t.Fatalf("Error starting client: %v", err)
@@ -564,7 +565,7 @@ func (s) TestBalancer_TwoAddresses_WeightExpiration(t *testing.T) {
 
 	// Advance what time.Now returns to the weight expiration time minus 1s to
 	// ensure all weights are still honored.
-	setNow(start.Add(*cfg.WeightExpirationPeriod - time.Second))
+	setNow(start.Add(weightExpirationPeriod - time.Second))
 
 	// Wait for the weight update period to allow the new weights to be processed.
 	time.Sleep(weightUpdatePeriod)
@@ -572,7 +573,7 @@ func (s) TestBalancer_TwoAddresses_WeightExpiration(t *testing.T) {
 
 	// Advance what time.Now returns to the weight expiration time plus 1s to
 	// ensure all weights expired and addresses are routed evenly.
-	setNow(start.Add(*cfg.WeightExpirationPeriod + time.Second))
+	setNow(start.Add(weightExpirationPeriod + time.Second))
 
 	// Wait for the weight expiration period so the weights have expired.
 	time.Sleep(weightUpdatePeriod)

--- a/balancer/weightedroundrobin/config.go
+++ b/balancer/weightedroundrobin/config.go
@@ -19,8 +19,7 @@
 package weightedroundrobin
 
 import (
-	"time"
-
+	iserviceconfig "google.golang.org/grpc/internal/serviceconfig"
 	"google.golang.org/grpc/serviceconfig"
 )
 
@@ -34,7 +33,7 @@ type lbConfig struct {
 	// Load reporting interval to request from the server.  Note that the
 	// server may not provide reports as frequently as the client requests.
 	// Used only when enable_oob_load_report is true.  Default is 10 seconds.
-	OOBReportingPeriod time.Duration `json:"oobReportingPeriod,omitempty"`
+	OOBReportingPeriod iserviceconfig.Duration `json:"oobReportingPeriod,omitempty"`
 
 	// A given endpoint must report load metrics continuously for at least this
 	// long before the endpoint weight will be used.  This avoids churn when
@@ -42,17 +41,17 @@ type lbConfig struct {
 	// after we establish a connection to an endpoint and after
 	// weight_expiration_period has caused us to stop using the most recent
 	// load metrics.  Default is 10 seconds.
-	BlackoutPeriod time.Duration `json:"blackoutPeriod,omitempty"`
+	BlackoutPeriod iserviceconfig.Duration `json:"blackoutPeriod,omitempty"`
 
 	// If a given endpoint has not reported load metrics in this long,
 	// then we stop using the reported weight.  This ensures that we do
 	// not continue to use very stale weights.  Once we stop using a stale
 	// value, if we later start seeing fresh reports again, the
 	// blackout_period applies.  Defaults to 3 minutes.
-	WeightExpirationPeriod time.Duration `json:"weightExpirationPeriod,omitempty"`
+	WeightExpirationPeriod iserviceconfig.Duration `json:"weightExpirationPeriod,omitempty"`
 
 	// How often endpoint weights are recalculated.  Default is 1 second.
-	WeightUpdatePeriod time.Duration `json:"weightUpdatePeriod,omitempty"`
+	WeightUpdatePeriod iserviceconfig.Duration `json:"weightUpdatePeriod,omitempty"`
 
 	// The multiplier used to adjust endpoint weights with the error rate
 	// calculated as eps/qps. Default is 1.0.

--- a/balancer/weightedroundrobin/internal/internal.go
+++ b/balancer/weightedroundrobin/internal/internal.go
@@ -31,14 +31,14 @@ var AllowAnyWeightUpdatePeriod bool
 // LBConfig allows tests to produce a JSON form of the config from the struct
 // instead of using a string.
 type LBConfig struct {
-	EnableOOBLoadReport     *bool          `json:"enableOobLoadReport,omitempty"`
-	OOBReportingPeriod      *time.Duration `json:"oobReportingPeriod,omitempty"`
-	BlackoutPeriod          *time.Duration `json:"blackoutPeriod,omitempty"`
-	WeightExpirationPeriod  *time.Duration `json:"weightExpirationPeriod,omitempty"`
-	WeightUpdatePeriod      *time.Duration `json:"weightUpdatePeriod,omitempty"`
-	ErrorUtilizationPenalty *float64       `json:"errorUtilizationPenalty,omitempty"`
+	EnableOOBLoadReport     *bool    `json:"enableOobLoadReport,omitempty"`
+	OOBReportingPeriod      *string  `json:"oobReportingPeriod,omitempty"`
+	BlackoutPeriod          *string  `json:"blackoutPeriod,omitempty"`
+	WeightExpirationPeriod  *string  `json:"weightExpirationPeriod,omitempty"`
+	WeightUpdatePeriod      *string  `json:"weightUpdatePeriod,omitempty"`
+	ErrorUtilizationPenalty *float64 `json:"errorUtilizationPenalty,omitempty"`
 }
 
 // TimeNow can be overridden by tests to return a different value for the
-// current time.
+// current iserviceconfig.
 var TimeNow = time.Now

--- a/internal/serviceconfig/duration.go
+++ b/internal/serviceconfig/duration.go
@@ -1,0 +1,117 @@
+/*
+ *
+ * Copyright 2023 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package serviceconfig
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Duration defines JSON marshal and unmarshal methods to conform to the
+// protobuf JSON spec defined [here].
+//
+// [here]: https://protobuf.dev/reference/protobuf/google.protobuf/#duration
+type Duration time.Duration
+
+func (d Duration) String() string {
+	return fmt.Sprint(time.Duration(d))
+}
+
+// MarshalJSON converts from d to a JSON string output.
+func (d Duration) MarshalJSON() ([]byte, error) {
+	ns := time.Duration(d).Nanoseconds()
+	sec := ns / int64(time.Second)
+	ns = ns % int64(time.Second)
+
+	var sign string
+	if sec < 0 {
+		sign, sec, ns = "-", -1*sec, -1*ns
+	}
+
+	// Generated output always contains 0, 3, 6, or 9 fractional digits,
+	// depending on required precision.
+	str := fmt.Sprintf("%s%d.%09d", sign, sec, ns)
+	str = strings.TrimSuffix(str, "000")
+	str = strings.TrimSuffix(str, "000")
+	str = strings.TrimSuffix(str, ".000")
+	return []byte(fmt.Sprintf("\"%ss\"", str)), nil
+}
+
+// UnmarshalJSON unmarshals b as a duration JSON string into d.
+func (d *Duration) UnmarshalJSON(b []byte) error {
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
+		return err
+	}
+	if !strings.HasSuffix(s, "s") {
+		return fmt.Errorf("malformed duration %q", s)
+	}
+	ss := strings.SplitN(s[:len(s)-1], ".", 3)
+	if len(ss) > 2 {
+		return fmt.Errorf("malformed duration %q", s)
+	}
+	// hasDigits is set if either the whole or fractional part of the number is
+	// present, since both are optional but one is required.
+	hasDigits := false
+	if len(ss[0]) > 0 {
+		sec, err := strconv.ParseInt(ss[0], 10, 64)
+		if err != nil {
+			return fmt.Errorf("malformed duration %q: %v", s, err)
+		}
+		const maxSeconds = math.MaxInt64 / int64(time.Second)
+		const minSeconds = math.MinInt64 / int64(time.Second)
+		if sec > maxSeconds || sec < minSeconds {
+			return fmt.Errorf("out of range: %q", s)
+		}
+		*d = Duration(sec) * Duration(time.Second)
+		hasDigits = true
+	} else {
+		*d = 0
+	}
+	if len(ss) == 2 && len(ss[1]) > 0 {
+		if len(ss[1]) > 9 {
+			return fmt.Errorf("malformed duration %q", s)
+		}
+		f, err := strconv.ParseInt(ss[1], 10, 64)
+		if err != nil {
+			return fmt.Errorf("malformed duration %q: %v", s, err)
+		}
+		neg := false
+		if *d < 0 {
+			neg = true
+			f *= -1
+		}
+		for i := 9; i > len(ss[1]); i-- {
+			f *= 10
+		}
+		*d += Duration(f)
+		if neg != (*d < 0) {
+			return fmt.Errorf("out of range: %q", s)
+		}
+		hasDigits = true
+	}
+	if !hasDigits {
+		return fmt.Errorf("malformed duration %q", s)
+	}
+	return nil
+}

--- a/internal/serviceconfig/duration.go
+++ b/internal/serviceconfig/duration.go
@@ -64,7 +64,7 @@ func (d *Duration) UnmarshalJSON(b []byte) error {
 		return err
 	}
 	if !strings.HasSuffix(s, "s") {
-		return fmt.Errorf("malformed duration %q", s)
+		return fmt.Errorf("malformed duration %q: missing seconds unit", s)
 	}
 	neg := false
 	if s[0] == '-' {
@@ -73,7 +73,7 @@ func (d *Duration) UnmarshalJSON(b []byte) error {
 	}
 	ss := strings.SplitN(s[:len(s)-1], ".", 3)
 	if len(ss) > 2 {
-		return fmt.Errorf("malformed duration %q", s)
+		return fmt.Errorf("malformed duration %q: too many decimals", s)
 	}
 	// hasDigits is set if either the whole or fractional part of the number is
 	// present, since both are optional but one is required.
@@ -98,7 +98,7 @@ func (d *Duration) UnmarshalJSON(b []byte) error {
 	}
 	if len(ss) == 2 && len(ss[1]) > 0 {
 		if len(ss[1]) > 9 {
-			return fmt.Errorf("malformed duration %q", s)
+			return fmt.Errorf("malformed duration %q: too many digits after decimal", s)
 		}
 		f, err := strconv.ParseInt(ss[1], 10, 64)
 		if err != nil {
@@ -117,7 +117,7 @@ func (d *Duration) UnmarshalJSON(b []byte) error {
 		hasDigits = true
 	}
 	if !hasDigits {
-		return fmt.Errorf("malformed duration %q", s)
+		return fmt.Errorf("malformed duration %q: contains no numbers", s)
 	}
 	return nil
 }

--- a/internal/serviceconfig/duration_test.go
+++ b/internal/serviceconfig/duration_test.go
@@ -1,0 +1,77 @@
+/*
+ *
+ * Copyright 2023 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package serviceconfig
+
+import (
+	"fmt"
+	"math"
+	"strings"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc/internal/grpcrand"
+)
+
+// Tests both marshalling and unmarshalling of Durations.
+func TestDuration_MarshalUnmarshal(t *testing.T) {
+	testCases := []struct {
+		json         string
+		td           time.Duration
+		unmarshalErr error
+		noMarshal    bool
+	}{
+		{json: `"1s"`, td: time.Second},
+		{json: `"-100.700s"`, td: -100*time.Second - 700*time.Millisecond},
+		{json: `".050s"`, td: 50 * time.Millisecond, noMarshal: true},
+		{json: `"9223372036.854775807s"`, td: math.MaxInt64},
+		{json: `"9223372036.854775808s"`, unmarshalErr: fmt.Errorf("out of range")},
+		{json: `"-9223372036.854775808s"`, td: math.MinInt64},
+		{json: `"-9223372036.854775809s"`, unmarshalErr: fmt.Errorf("out of range")},
+		{json: `"9223372036s"`, td: 9223372036 * time.Second},
+		{json: `"-9223372036s"`, td: -9223372036 * time.Second},
+		{json: `"9223372037s"`, unmarshalErr: fmt.Errorf("out of range")},
+		{json: `"-9223372037s"`, unmarshalErr: fmt.Errorf("out of range")},
+		{json: `123s`, unmarshalErr: fmt.Errorf("invalid character")},
+		{json: `"5m"`, unmarshalErr: fmt.Errorf("malformed duration")},
+		{json: `"5.3.2s"`, unmarshalErr: fmt.Errorf("malformed duration")},
+		{json: `"x.3s"`, unmarshalErr: fmt.Errorf("malformed duration")},
+		{json: `"3.xs"`, unmarshalErr: fmt.Errorf("malformed duration")},
+		{json: `"3.1234567890s"`, unmarshalErr: fmt.Errorf("malformed duration")},
+		{json: `".s"`, unmarshalErr: fmt.Errorf("malformed duration")},
+		{json: `"s"`, unmarshalErr: fmt.Errorf("malformed duration")},
+	}
+	for _, tc := range testCases {
+		// Seed `got` with a random value to ensure we properly reset it in all
+		// non-error cases.
+		got := Duration(grpcrand.Uint64())
+		err := got.UnmarshalJSON([]byte(tc.json))
+		if (err == nil && time.Duration(got) != tc.td) ||
+			(err != nil) != (tc.unmarshalErr != nil) || !strings.Contains(fmt.Sprint(err), fmt.Sprint(tc.unmarshalErr)) {
+			t.Errorf("UnmarshalJSON of %v = %v, %v; want %v, %v", tc.json, time.Duration(got), err, tc.td, tc.unmarshalErr)
+		}
+
+		if tc.unmarshalErr == nil && !tc.noMarshal {
+			d := Duration(tc.td)
+			got, err := d.MarshalJSON()
+			if string(got) != tc.json || err != nil {
+				t.Errorf("MarshalJSON of %v = %v, %v; want %v, nil", d, string(got), err, tc.json)
+			}
+		}
+	}
+}

--- a/internal/serviceconfig/duration_test.go
+++ b/internal/serviceconfig/duration_test.go
@@ -39,6 +39,7 @@ func TestDuration_MarshalUnmarshal(t *testing.T) {
 		{json: `"1s"`, td: time.Second},
 		{json: `"-100.700s"`, td: -100*time.Second - 700*time.Millisecond},
 		{json: `".050s"`, td: 50 * time.Millisecond, noMarshal: true},
+		{json: `"-.001s"`, td: -1 * time.Millisecond, noMarshal: true},
 		{json: `"-0.200s"`, td: -200 * time.Millisecond},
 		{json: `"9223372036.854775807s"`, td: math.MaxInt64},
 		{json: `"9223372036.854775808s"`, unmarshalErr: fmt.Errorf("out of range")},

--- a/internal/serviceconfig/duration_test.go
+++ b/internal/serviceconfig/duration_test.go
@@ -36,19 +36,27 @@ func TestDuration_MarshalUnmarshal(t *testing.T) {
 		unmarshalErr error
 		noMarshal    bool
 	}{
+		// Basic values.
 		{json: `"1s"`, td: time.Second},
 		{json: `"-100.700s"`, td: -100*time.Second - 700*time.Millisecond},
 		{json: `".050s"`, td: 50 * time.Millisecond, noMarshal: true},
 		{json: `"-.001s"`, td: -1 * time.Millisecond, noMarshal: true},
 		{json: `"-0.200s"`, td: -200 * time.Millisecond},
-		{json: `"9223372036.854775807s"`, td: math.MaxInt64},
-		{json: `"9223372036.854775808s"`, unmarshalErr: fmt.Errorf("out of range")},
-		{json: `"-9223372036.854775808s"`, td: math.MinInt64},
-		{json: `"-9223372036.854775809s"`, unmarshalErr: fmt.Errorf("out of range")},
+		// Positive near / out of bounds.
 		{json: `"9223372036s"`, td: 9223372036 * time.Second},
+		{json: `"9223372037s"`, td: math.MaxInt64, noMarshal: true},
+		{json: `"9223372036.854775807s"`, td: math.MaxInt64},
+		{json: `"9223372036.854775808s"`, td: math.MaxInt64, noMarshal: true},
+		{json: `"315576000000s"`, td: math.MaxInt64, noMarshal: true},
+		{json: `"315576000001s"`, unmarshalErr: fmt.Errorf("out of range")},
+		// Negative near / out of bounds.
 		{json: `"-9223372036s"`, td: -9223372036 * time.Second},
-		{json: `"9223372037s"`, unmarshalErr: fmt.Errorf("out of range")},
-		{json: `"-9223372037s"`, unmarshalErr: fmt.Errorf("out of range")},
+		{json: `"-9223372037s"`, td: math.MinInt64, noMarshal: true},
+		{json: `"-9223372036.854775808s"`, td: math.MinInt64},
+		{json: `"-9223372036.854775809s"`, td: math.MinInt64, noMarshal: true},
+		{json: `"-315576000000s"`, td: math.MinInt64, noMarshal: true},
+		{json: `"-315576000001s"`, unmarshalErr: fmt.Errorf("out of range")},
+		// Parse errors.
 		{json: `123s`, unmarshalErr: fmt.Errorf("invalid character")},
 		{json: `"5m"`, unmarshalErr: fmt.Errorf("malformed duration")},
 		{json: `"5.3.2s"`, unmarshalErr: fmt.Errorf("malformed duration")},

--- a/internal/serviceconfig/duration_test.go
+++ b/internal/serviceconfig/duration_test.go
@@ -39,6 +39,7 @@ func TestDuration_MarshalUnmarshal(t *testing.T) {
 		{json: `"1s"`, td: time.Second},
 		{json: `"-100.700s"`, td: -100*time.Second - 700*time.Millisecond},
 		{json: `".050s"`, td: 50 * time.Millisecond, noMarshal: true},
+		{json: `"-0.200s"`, td: -200 * time.Millisecond},
 		{json: `"9223372036.854775807s"`, td: math.MaxInt64},
 		{json: `"9223372036.854775808s"`, unmarshalErr: fmt.Errorf("out of range")},
 		{json: `"-9223372036.854775808s"`, td: math.MinInt64},


### PR DESCRIPTION
Another option for `Duration` is to make it a struct with a `time.Duration` field (e.g. named `D`) and the "conversion" would be `x.myDurationField.D` instead of `time.Duration(x.myDurationField)`.  I'm not sure which is better, but this is unfortunately somewhat cumbersome because Go won't coerce your types automatically even though they are the same underlying type; it requires a cast.

RELEASE NOTES: none