### PR TITLE
test: fix flaky TimeoutOnDeadServer test; some cleanups

### DIFF
--- a/test/channelz_test.go
+++ b/test/channelz_test.go
@@ -1531,21 +1531,11 @@ func (s) TestCZSubChannelTraceCreationDeletion(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Wait for ready
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	for src := te.cc.GetState(); src != connectivity.Ready; src = te.cc.GetState() {
-		if !te.cc.WaitForStateChange(ctx, src) {
-			t.Fatalf("timed out waiting for state change.  got %v; want %v", src, connectivity.Ready)
-		}
-	}
+	awaitState(ctx, t, te.cc, connectivity.Ready)
 	r.UpdateState(resolver.State{Addresses: []resolver.Address{{Addr: "fake address"}}})
-	// Wait for not-ready.
-	for src := te.cc.GetState(); src == connectivity.Ready; src = te.cc.GetState() {
-		if !te.cc.WaitForStateChange(ctx, src) {
-			t.Fatalf("timed out waiting for state change.  got %v; want !%v", src, connectivity.Ready)
-		}
-	}
+	awaitNotState(ctx, t, te.cc, connectivity.Ready)
 
 	if err := verifyResultWithDelay(func() (bool, error) {
 		tcs, _ := channelz.GetTopChannels(0, 0)
@@ -2016,21 +2006,11 @@ func (s) TestCZTraceOverwriteSubChannelDeletion(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Wait for ready
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	for src := te.cc.GetState(); src != connectivity.Ready; src = te.cc.GetState() {
-		if !te.cc.WaitForStateChange(ctx, src) {
-			t.Fatalf("timed out waiting for state change.  got %v; want %v", src, connectivity.Ready)
-		}
-	}
+	awaitState(ctx, t, te.cc, connectivity.Ready)
 	r.UpdateState(resolver.State{Addresses: []resolver.Address{{Addr: "fake address"}}})
-	// Wait for not-ready.
-	for src := te.cc.GetState(); src == connectivity.Ready; src = te.cc.GetState() {
-		if !te.cc.WaitForStateChange(ctx, src) {
-			t.Fatalf("timed out waiting for state change.  got %v; want !%v", src, connectivity.Ready)
-		}
-	}
+	awaitNotState(ctx, t, te.cc, connectivity.Ready)
 
 	// verify that the subchannel no longer exist due to trace referencing it got overwritten.
 	if err := verifyResultWithDelay(func() (bool, error) {

--- a/test/clientconn_state_transition_test.go
+++ b/test/clientconn_state_transition_test.go
@@ -519,3 +519,21 @@ func stayConnected(ctx context.Context, cc *grpc.ClientConn) {
 		}
 	}
 }
+
+func awaitState(ctx context.Context, t *testing.T, cc *grpc.ClientConn, stateWant connectivity.State) {
+	t.Helper()
+	for state := cc.GetState(); state != stateWant; state = cc.GetState() {
+		if !cc.WaitForStateChange(ctx, state) {
+			t.Fatalf("timed out waiting for state change.  got %v; want %v", state, stateWant)
+		}
+	}
+}
+
+func awaitNotState(ctx context.Context, t *testing.T, cc *grpc.ClientConn, stateDoNotWant connectivity.State) {
+	t.Helper()
+	for state := cc.GetState(); state == stateDoNotWant; state = cc.GetState() {
+		if !cc.WaitForStateChange(ctx, state) {
+			t.Fatalf("timed out waiting for state change.  got %v; want NOT %v", state, stateDoNotWant)
+		}
+	}
+}

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -965,38 +965,25 @@ func (s) TestTimeoutOnDeadServer(t *testing.T) {
 func testTimeoutOnDeadServer(t *testing.T, e env) {
 	te := newTest(t, e)
 	te.userAgent = testAppUA
-	te.declareLogNoise(
-		"transport: http2Client.notifyError got notified that the client transport was broken EOF",
-		"grpc: addrConn.transportMonitor exits due to: grpc: the connection is closing",
-		"grpc: addrConn.resetTransport failed to create client transport: connection error",
-	)
 	te.startServer(&testServer{security: e.security})
 	defer te.tearDown()
 
 	cc := te.clientConn()
 	tc := testgrpc.NewTestServiceClient(cc)
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
 	if _, err := tc.EmptyCall(ctx, &testpb.Empty{}, grpc.WaitForReady(true)); err != nil {
 		t.Fatalf("TestService/EmptyCall(_, _) = _, %v, want _, <nil>", err)
 	}
+	// Wait for the client to report READY, stop the server, then wait for the
+	// client to notice the connection is gone.
+	awaitState(ctx, t, cc, connectivity.Ready)
 	te.srv.Stop()
-	cancel()
-
-	// Wait for the client to notice the connection is gone.
-	ctx, cancel = context.WithTimeout(context.Background(), 500*time.Millisecond)
-	state := cc.GetState()
-	for ; state == connectivity.Ready && cc.WaitForStateChange(ctx, state); state = cc.GetState() {
-	}
-	cancel()
-	if state == connectivity.Ready {
-		t.Fatalf("Timed out waiting for non-ready state")
-	}
-	ctx, cancel = context.WithTimeout(context.Background(), time.Millisecond)
+	awaitNotState(ctx, t, cc, connectivity.Ready)
+	ctx, cancel = context.WithTimeout(ctx, 5*time.Millisecond)
 	_, err := tc.EmptyCall(ctx, &testpb.Empty{}, grpc.WaitForReady(true))
 	cancel()
-	if e.balancer != "" && status.Code(err) != codes.DeadlineExceeded {
-		// If e.balancer == nil, the ac will stop reconnecting because the dialer returns non-temp error,
-		// the error will be an internal error.
+	if status.Code(err) != codes.DeadlineExceeded {
 		t.Fatalf("TestService/EmptyCall(%v, _) = _, %v, want _, error code: %s", ctx, err, codes.DeadlineExceeded)
 	}
 	awaitNewConnLogOutput()
@@ -1070,11 +1057,6 @@ func (s) TestFailFast(t *testing.T) {
 func testFailFast(t *testing.T, e env) {
 	te := newTest(t, e)
 	te.userAgent = testAppUA
-	te.declareLogNoise(
-		"transport: http2Client.notifyError got notified that the client transport was broken EOF",
-		"grpc: addrConn.transportMonitor exits due to: grpc: the connection is closing",
-		"grpc: addrConn.resetTransport failed to create client transport: connection error",
-	)
 	te.startServer(&testServer{security: e.security})
 	defer te.tearDown()
 
@@ -1114,9 +1096,6 @@ func testServiceConfigSetup(t *testing.T, e env) *test {
 	te := newTest(t, e)
 	te.userAgent = testAppUA
 	te.declareLogNoise(
-		"transport: http2Client.notifyError got notified that the client transport was broken EOF",
-		"grpc: addrConn.transportMonitor exits due to: grpc: the connection is closing",
-		"grpc: addrConn.resetTransport failed to create client transport: connection error",
 		"Failed to dial : context canceled; please retry.",
 	)
 	return te
@@ -1746,9 +1725,6 @@ func testPreloaderClientSend(t *testing.T, e env) {
 	te := newTest(t, e)
 	te.userAgent = testAppUA
 	te.declareLogNoise(
-		"transport: http2Client.notifyError got notified that the client transport was broken EOF",
-		"grpc: addrConn.transportMonitor exits due to: grpc: the connection is closing",
-		"grpc: addrConn.resetTransport failed to create client transport: connection error",
 		"Failed to dial : context canceled; please retry.",
 	)
 	te.startServer(&testServer{security: e.security})
@@ -1875,9 +1851,6 @@ func testMaxMsgSizeClientDefault(t *testing.T, e env) {
 	te := newTest(t, e)
 	te.userAgent = testAppUA
 	te.declareLogNoise(
-		"transport: http2Client.notifyError got notified that the client transport was broken EOF",
-		"grpc: addrConn.transportMonitor exits due to: grpc: the connection is closing",
-		"grpc: addrConn.resetTransport failed to create client transport: connection error",
 		"Failed to dial : context canceled; please retry.",
 	)
 	te.startServer(&testServer{security: e.security})
@@ -1942,9 +1915,6 @@ func testMaxMsgSizeClientAPI(t *testing.T, e env) {
 	te.maxClientReceiveMsgSize = newInt(1024)
 	te.maxClientSendMsgSize = newInt(1024)
 	te.declareLogNoise(
-		"transport: http2Client.notifyError got notified that the client transport was broken EOF",
-		"grpc: addrConn.transportMonitor exits due to: grpc: the connection is closing",
-		"grpc: addrConn.resetTransport failed to create client transport: connection error",
 		"Failed to dial : context canceled; please retry.",
 	)
 	te.startServer(&testServer{security: e.security})
@@ -2030,9 +2000,6 @@ func testMaxMsgSizeServerAPI(t *testing.T, e env) {
 	te.maxServerReceiveMsgSize = newInt(1024)
 	te.maxServerSendMsgSize = newInt(1024)
 	te.declareLogNoise(
-		"transport: http2Client.notifyError got notified that the client transport was broken EOF",
-		"grpc: addrConn.transportMonitor exits due to: grpc: the connection is closing",
-		"grpc: addrConn.resetTransport failed to create client transport: connection error",
 		"Failed to dial : context canceled; please retry.",
 	)
 	te.startServer(&testServer{security: e.security})
@@ -2141,11 +2108,6 @@ func testTap(t *testing.T, e env) {
 	te.userAgent = testAppUA
 	ttap := &myTap{}
 	te.tapHandle = ttap.handle
-	te.declareLogNoise(
-		"transport: http2Client.notifyError got notified that the client transport was broken EOF",
-		"grpc: addrConn.transportMonitor exits due to: grpc: the connection is closing",
-		"grpc: addrConn.resetTransport failed to create client transport: connection error",
-	)
 	te.startServer(&testServer{security: e.security})
 	defer te.tearDown()
 
@@ -4878,17 +4840,9 @@ func testWaitForReadyConnection(t *testing.T, e env) {
 
 	cc := te.clientConn() // Non-blocking dial.
 	tc := testgrpc.NewTestServiceClient(cc)
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
-	state := cc.GetState()
-	// Wait for connection to be Ready.
-	for ; state != connectivity.Ready && cc.WaitForStateChange(ctx, state); state = cc.GetState() {
-	}
-	if state != connectivity.Ready {
-		t.Fatalf("Want connection state to be Ready, got %v", state)
-	}
-	ctx, cancel = context.WithTimeout(context.Background(), time.Second)
-	defer cancel()
+	awaitState(ctx, t, cc, connectivity.Ready)
 	// Make a fail-fast RPC.
 	if _, err := tc.EmptyCall(ctx, &testpb.Empty{}); err != nil {
 		t.Fatalf("TestService/EmptyCall(_,_) = _, %v, want _, nil", err)

--- a/test/goaway_test.go
+++ b/test/goaway_test.go
@@ -594,12 +594,7 @@ func (s) TestGoAwayThenClose(t *testing.T) {
 	client := testgrpc.NewTestServiceClient(cc)
 
 	t.Log("Waiting for the ClientConn to enter READY state.")
-	state := cc.GetState()
-	for ; state != connectivity.Ready && cc.WaitForStateChange(ctx, state); state = cc.GetState() {
-	}
-	if ctx.Err() != nil {
-		t.Fatalf("timed out waiting for READY channel state; last state = %v", state)
-	}
+	awaitState(ctx, t, cc, connectivity.Ready)
 
 	// We make a streaming RPC and do an one-message-round-trip to make sure
 	// it's created on connection 1.
@@ -622,11 +617,7 @@ func (s) TestGoAwayThenClose(t *testing.T) {
 	go s1.GracefulStop()
 
 	t.Log("Waiting for the ClientConn to enter IDLE state.")
-	for ; state != connectivity.Idle && cc.WaitForStateChange(ctx, state); state = cc.GetState() {
-	}
-	if ctx.Err() != nil {
-		t.Fatalf("timed out waiting for IDLE channel state; last state = %v", state)
-	}
+	awaitState(ctx, t, cc, connectivity.Idle)
 
 	t.Log("Performing another RPC to create a connection to server 2.")
 	if _, err := client.UnaryCall(ctx, &testpb.SimpleRequest{}); err != nil {

--- a/test/healthcheck_test.go
+++ b/test/healthcheck_test.go
@@ -212,44 +212,33 @@ func (s) TestHealthCheckWatchStateChange(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
-	if ok := cc.WaitForStateChange(ctx, connectivity.Idle); !ok {
-		t.Fatal("ClientConn is still in IDLE state when the context times out.")
-	}
-	if ok := cc.WaitForStateChange(ctx, connectivity.Connecting); !ok {
-		t.Fatal("ClientConn is still in CONNECTING state when the context times out.")
-	}
+	awaitNotState(ctx, t, cc, connectivity.Idle)
+	awaitNotState(ctx, t, cc, connectivity.Connecting)
+	awaitState(ctx, t, cc, connectivity.TransientFailure)
 	if s := cc.GetState(); s != connectivity.TransientFailure {
 		t.Fatalf("ClientConn is in %v state, want TRANSIENT FAILURE", s)
 	}
 
 	ts.SetServingStatus("foo", healthpb.HealthCheckResponse_SERVING)
-	if ok := cc.WaitForStateChange(ctx, connectivity.TransientFailure); !ok {
-		t.Fatal("ClientConn is still in TRANSIENT FAILURE state when the context times out.")
-	}
+	awaitNotState(ctx, t, cc, connectivity.TransientFailure)
 	if s := cc.GetState(); s != connectivity.Ready {
 		t.Fatalf("ClientConn is in %v state, want READY", s)
 	}
 
 	ts.SetServingStatus("foo", healthpb.HealthCheckResponse_SERVICE_UNKNOWN)
-	if ok := cc.WaitForStateChange(ctx, connectivity.Ready); !ok {
-		t.Fatal("ClientConn is still in READY state when the context times out.")
-	}
+	awaitNotState(ctx, t, cc, connectivity.Ready)
 	if s := cc.GetState(); s != connectivity.TransientFailure {
 		t.Fatalf("ClientConn is in %v state, want TRANSIENT FAILURE", s)
 	}
 
 	ts.SetServingStatus("foo", healthpb.HealthCheckResponse_SERVING)
-	if ok := cc.WaitForStateChange(ctx, connectivity.TransientFailure); !ok {
-		t.Fatal("ClientConn is still in TRANSIENT FAILURE state when the context times out.")
-	}
+	awaitNotState(ctx, t, cc, connectivity.TransientFailure)
 	if s := cc.GetState(); s != connectivity.Ready {
 		t.Fatalf("ClientConn is in %v state, want READY", s)
 	}
 
 	ts.SetServingStatus("foo", healthpb.HealthCheckResponse_UNKNOWN)
-	if ok := cc.WaitForStateChange(ctx, connectivity.Ready); !ok {
-		t.Fatal("ClientConn is still in READY state when the context times out.")
-	}
+	awaitNotState(ctx, t, cc, connectivity.Ready)
 	if s := cc.GetState(); s != connectivity.TransientFailure {
 		t.Fatalf("ClientConn is in %v state, want TRANSIENT FAILURE", s)
 	}
@@ -278,12 +267,8 @@ func (s) TestHealthCheckHealthServerNotRegistered(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
-	if ok := cc.WaitForStateChange(ctx, connectivity.Idle); !ok {
-		t.Fatal("ClientConn is still in IDLE state when the context times out.")
-	}
-	if ok := cc.WaitForStateChange(ctx, connectivity.Connecting); !ok {
-		t.Fatal("ClientConn is still in CONNECTING state when the context times out.")
-	}
+	awaitNotState(ctx, t, cc, connectivity.Idle)
+	awaitNotState(ctx, t, cc, connectivity.Connecting)
 	if s := cc.GetState(); s != connectivity.Ready {
 		t.Fatalf("ClientConn is in %v state, want READY", s)
 	}

--- a/test/pickfirst_test.go
+++ b/test/pickfirst_test.go
@@ -250,11 +250,7 @@ func (s) TestPickFirst_NewAddressWhileBlocking(t *testing.T) {
 	// Send a resolver update with no addresses. This should push the channel into
 	// TransientFailure.
 	r.UpdateState(resolver.State{})
-	for state := cc.GetState(); state != connectivity.TransientFailure; state = cc.GetState() {
-		if !cc.WaitForStateChange(ctx, state) {
-			t.Fatalf("timeout waiting for state change. got %v; want %v", state, connectivity.TransientFailure)
-		}
-	}
+	awaitState(ctx, t, cc, connectivity.TransientFailure)
 
 	doneCh := make(chan struct{})
 	client := testgrpc.NewTestServiceClient(cc)

--- a/test/roundrobin_test.go
+++ b/test/roundrobin_test.go
@@ -119,11 +119,7 @@ func (s) TestRoundRobin_AddressesRemoved(t *testing.T) {
 	// Send a resolver update with no addresses. This should push the channel into
 	// TransientFailure.
 	r.UpdateState(resolver.State{Addresses: []resolver.Address{}})
-	for state := cc.GetState(); state != connectivity.TransientFailure; state = cc.GetState() {
-		if !cc.WaitForStateChange(ctx, state) {
-			t.Fatalf("timeout waiting for state change. got %v; want %v", state, connectivity.TransientFailure)
-		}
-	}
+	awaitState(ctx, t, cc, connectivity.TransientFailure)
 
 	const msgWant = "produced zero addresses"
 	client := testgrpc.NewTestServiceClient(cc)
@@ -145,11 +141,7 @@ func (s) TestRoundRobin_NewAddressWhileBlocking(t *testing.T) {
 	// Send a resolver update with no addresses. This should push the channel into
 	// TransientFailure.
 	r.UpdateState(resolver.State{Addresses: []resolver.Address{}})
-	for state := cc.GetState(); state != connectivity.TransientFailure; state = cc.GetState() {
-		if !cc.WaitForStateChange(ctx, state) {
-			t.Fatalf("timeout waiting for state change. got %v; want %v", state, connectivity.TransientFailure)
-		}
-	}
+	awaitState(ctx, t, cc, connectivity.TransientFailure)
 
 	client := testgrpc.NewTestServiceClient(cc)
 	doneCh := make(chan struct{})
@@ -229,12 +221,7 @@ func (s) TestRoundRobin_AllServersDown(t *testing.T) {
 		b.Stop()
 	}
 
-	// Wait for TransientFailure.
-	for state := cc.GetState(); state != connectivity.TransientFailure; state = cc.GetState() {
-		if !cc.WaitForStateChange(ctx, state) {
-			t.Fatalf("timeout waiting for state change. got %v; want %v", state, connectivity.TransientFailure)
-		}
-	}
+	awaitState(ctx, t, cc, connectivity.TransientFailure)
 
 	// Failfast RPCs should fail with Unavailable.
 	client := testgrpc.NewTestServiceClient(cc)


### PR DESCRIPTION
Fixes #4766

- Wait for READY before stopping the server: the picker is updated before the state, so we can race and complete the RPC AND still see a not-yet-READY state from the CC even after the server is stopped.
- Add helpers for waiting for state changes.
- Employ them in all existing uses.
- Remove log noise declarations that don't even exist anymore.
- Use standardized timeouts in more places.

RELEASE NOTES: none