### PR TITLE
interop: hold lock on server for OOB metrics updates; share 30s timeout

### DIFF
--- a/interop/interop_test.sh
+++ b/interop/interop_test.sh
@@ -98,7 +98,12 @@ for case in ${CASES[@]}; do
     echo "$(tput setaf 4) $(date): testing: ${case} $(tput sgr 0)"
 
     CLIENT_LOG="$(mktemp)"
-    if ! GRPC_GO_LOG_SEVERITY_LEVEL=info timeout 20 go run ./interop/client --use_tls --server_host_override=foo.test.google.fr --use_test_ca --test_case="${case}" &> $CLIENT_LOG; then
+    if ! GRPC_GO_LOG_SEVERITY_LEVEL=info timeout 20 go run ./interop/client \
+         --use_tls \
+         --server_host_override=foo.test.google.fr \
+         --use_test_ca --test_case="${case}" \
+         --service_config_json='{loadBalancingConfig:["test_backend_metrics_load_balancer":{}]}' \
+       &> $CLIENT_LOG; then
         fail "FAIL: test case ${case}
         got server log:
         $(cat $SERVER_LOG)

--- a/interop/interop_test.sh
+++ b/interop/interop_test.sh
@@ -70,6 +70,8 @@ CASES=(
   "custom_metadata"
   "unimplemented_method"
   "unimplemented_service"
+  "orca_per_rpc"
+  "orca_oob"
 )
 
 # Build server

--- a/interop/interop_test.sh
+++ b/interop/interop_test.sh
@@ -102,7 +102,7 @@ for case in ${CASES[@]}; do
          --use_tls \
          --server_host_override=foo.test.google.fr \
          --use_test_ca --test_case="${case}" \
-         --service_config_json='{loadBalancingConfig:["test_backend_metrics_load_balancer":{}]}' \
+         --service_config_json='{"loadBalancingConfig":[{"test_backend_metrics_load_balancer":{}}]}' \
        &> $CLIENT_LOG; then
         fail "FAIL: test case ${case}
         got server log:


### PR DESCRIPTION
Per the [interop test spec](https://github.com/grpc/grpc/blob/e97f632886918a5cc603e8a510dd2d6ee4858e01/doc/interop-test-descriptions.md#backend-metrics-report):

> The server implementation should use a lock or similar mechanism to allow only one client to control the server's out-of-band reports until the end of the RPC.

This is needed to allow concurrent tests to run without ruining each others' values.  At the same time, if multiple tests are running, 5 seconds may not be long enough to wait, so share the 30s timeout throughout the test case instead of requiring ORCA reports to be updated in 5s.

Also, remove the OOB report handling from the unary RPC.  This doesn't work (due to similar issues) and isn't used and will be removed from the protobuf per @yifeizhuang.

RELEASE NOTES: none