### PR TITLE
interop: fix interop_test.sh shutdown

### DIFF
--- a/interop/interop_test.sh
+++ b/interop/interop_test.sh
@@ -55,8 +55,14 @@ withTimeout () {
     wpid=$!
     # Kill after 20 seconds.
     sleep $timer && kill $wpid &
+    kpid=$!
     # Wait for the background thread.
     wait $wpid
+    res=$?
+    # Kill the killer pid in case it's still running.
+    kill $kpid || true
+    wait $kpid || true
+    return $res
 }
 
 # Don't run some tests that need a special environment:

--- a/interop/interop_test.sh
+++ b/interop/interop_test.sh
@@ -53,7 +53,7 @@ withTimeout () {
     cmd=$(printf '%q ' "$@")
     eval "$cmd" &
     wpid=$!
-    # Kill after 20 seconds.
+    # Kill after $timer seconds.
     sleep $timer && kill $wpid &
     kpid=$!
     # Wait for the background thread.


### PR DESCRIPTION
Before this change, if we were shutting down and one of these "killer" threads was still running, but finished on its own _right before_ the `clean` function tried to kill it, `xargs pkill` would exit with an error and make the whole test exit with an error.

This will kill the killer job right after the worker job completes, ensuring this race doesn't happen.

RELEASE NOTES: none