### PR TITLE
xds: Replace IsTerminal() check with IsRouterFilter() check

### DIFF
--- a/xds/internal/xdsclient/xdsresource/unmarshal_lds.go
+++ b/xds/internal/xdsclient/xdsresource/unmarshal_lds.go
@@ -30,6 +30,7 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
 	"google.golang.org/grpc/xds/internal/httpfilter"
+	"google.golang.org/grpc/xds/internal/httpfilter/router"
 	"google.golang.org/protobuf/types/known/anypb"
 )
 
@@ -235,14 +236,13 @@ func processHTTPFilters(filters []*v3httppb.HttpFilter, server bool) ([]HTTPFilt
 	if len(ret) == 0 {
 		return nil, fmt.Errorf("http filters list is empty")
 	}
-	var i int
-	for ; i < len(ret)-1; i++ {
+	for i := 0; i < len(ret)-1; i++ {
 		if ret[i].Filter.IsTerminal() {
 			return nil, fmt.Errorf("http filter %q is a terminal filter but it is not last in the filter chain", ret[i].Name)
 		}
 	}
-	if !ret[i].Filter.IsTerminal() {
-		return nil, fmt.Errorf("http filter %q is not a terminal filter", ret[len(ret)-1].Name)
+	if !router.IsRouterFilter(ret[len(ret)-1].Filter) {
+		return nil, fmt.Errorf("http filter %q is not a router filter", ret[len(ret)-1].Name)
 	}
 	return ret, nil
 }

--- a/xds/internal/xdsclient/xdsresource/unmarshal_lds_test.go
+++ b/xds/internal/xdsclient/xdsresource/unmarshal_lds_test.go
@@ -1115,7 +1115,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 			wantErr:  "is a terminal filter but it is not last in the filter chain",
 		},
 		{
-			name: "last not terminal filter",
+			name: "last not router filter",
 			resource: testutils.MarshalAny(&v3listenerpb.Listener{
 				Name:    v3LDSTarget,
 				Address: localSocketAddress,
@@ -1139,7 +1139,7 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 				},
 			}),
 			wantName: v3LDSTarget,
-			wantErr:  "is not a terminal filter",
+			wantErr:  "is not a router filter",
 		},
 		{
 			name: "unsupported oneof in typed config of http filter",


### PR DESCRIPTION
> Since all legal tests in unmarshal_lds_test.go explicitly use a router filter as the terminal filter
> Have accordingly modified the "last not terminal filter" testcase to be the "last not router filter" test

Fixes #6259 
RELEASE NOTES: none