### PR TITLE
test/keepalive: Improve TestKeepaliveClientClosesWithActiveStreams 

### DIFF
--- a/internal/transport/transport_test.go
+++ b/internal/transport/transport_test.go
@@ -509,7 +509,7 @@ func setUpWithNoPingServerWithOptions(t *testing.T, copts ConnectOptions, connCh
 						respondToPing = data
 					default:
 					}
-					// ack the ping if in responsive mode
+					// ack the ping if in responsive mode.
 					if respondToPing {
 						if f, ok := frame.(*http2.PingFrame); ok {
 							lock.Lock()

--- a/internal/transport/transport_test.go
+++ b/internal/transport/transport_test.go
@@ -505,11 +505,11 @@ func setUpWithNoPingServerWithOptions(t *testing.T, copts ConnectOptions, connCh
 						return
 					}
 					select {
-					case data, ok := <-respModeCh:
+					case mode, ok := <-respModeCh:
 						if !ok {
 							return
 						}
-						respondToPing = data
+						respondToPing = mode
 					default:
 					}
 					// ack the ping if in responsive mode.

--- a/internal/transport/transport_test.go
+++ b/internal/transport/transport_test.go
@@ -469,7 +469,7 @@ func setUpWithNoPingServer(t *testing.T, copts ConnectOptions, connCh chan net.C
 // responding to ping acks and not responding based on the writes to the respModeCh
 // channel.
 //
-// * If `true` is written to respModeCh, the server will respond to ping acks. (default) 
+// * If `true` is written to respModeCh, the server will respond to ping acks. (default)
 // * If `false` is written to respModeCh, the server will not respond to ping acks.
 func setUpWithNoPingServerWithOptions(t *testing.T, copts ConnectOptions, connCh chan net.Conn, respModeCh chan bool) (*http2Client, func()) {
 	lis, err := net.Listen("tcp", "localhost:0")

--- a/internal/transport/transport_test.go
+++ b/internal/transport/transport_test.go
@@ -465,9 +465,12 @@ func setUpWithNoPingServer(t *testing.T, copts ConnectOptions, connCh chan net.C
 	return setUpWithNoPingServerWithOptions(t, copts, connCh, nil)
 }
 
-// setUpWithNoPingServerWithOptions setup a server which responsiveness is configurable through respModeCh channel.
-// Adding a true to the respModeCh channel makes the server ack ping messages, while adding false to the respModeCh
-// channel makes the server not to ack ping messages. By default, server acks ping messages until it's toggled.
+// setUpWithNoPingServerWithOptions sets up a server that can be toggled between
+// responding to ping acks and not responding based on the writes to the respModeCh
+// channel.
+//
+// * If `true` is written to respModeCh, the server will respond to ping acks. (default) 
+// * If `false` is written to respModeCh, the server will not respond to ping acks.
 func setUpWithNoPingServerWithOptions(t *testing.T, copts ConnectOptions, connCh chan net.Conn, respModeCh chan bool) (*http2Client, func()) {
 	lis, err := net.Listen("tcp", "localhost:0")
 	if err != nil {


### PR DESCRIPTION
Setup a ping/noping switchable server to use in KeepaliveClientClosesWithActiveStreams test

Fixes #6099

RELEASE NOTES: N/A