### PR TITLE
xds/internal/balancer/outlierdetection: Switch Outlier Detection to use new duration field

### DIFF
--- a/xds/internal/balancer/cdsbalancer/cdsbalancer.go
+++ b/xds/internal/balancer/cdsbalancer/cdsbalancer.go
@@ -308,9 +308,9 @@ func outlierDetectionToConfig(od *xdsresource.OutlierDetection) outlierdetection
 	}
 
 	return outlierdetection.LBConfig{
-		Interval:                  od.Interval,
-		BaseEjectionTime:          od.BaseEjectionTime,
-		MaxEjectionTime:           od.MaxEjectionTime,
+		Interval:                  internalserviceconfig.Duration(od.Interval),
+		BaseEjectionTime:          internalserviceconfig.Duration(od.BaseEjectionTime),
+		MaxEjectionTime:           internalserviceconfig.Duration(od.MaxEjectionTime),
 		MaxEjectionPercent:        od.MaxEjectionPercent,
 		SuccessRateEjection:       sre,
 		FailurePercentageEjection: fpe,

--- a/xds/internal/balancer/cdsbalancer/cdsbalancer_test.go
+++ b/xds/internal/balancer/cdsbalancer/cdsbalancer_test.go
@@ -444,9 +444,9 @@ func (s) TestHandleClusterUpdate(t *testing.T) {
 				LBPolicy: wrrLocalityLBConfigJSON,
 			},
 			wantCCS: edsCCS(serviceName, nil, false, wrrLocalityLBConfig, outlierdetection.LBConfig{
-				Interval:           10 * time.Second,
-				BaseEjectionTime:   30 * time.Second,
-				MaxEjectionTime:    300 * time.Second,
+				Interval:           internalserviceconfig.Duration(10 * time.Second),
+				BaseEjectionTime:   internalserviceconfig.Duration(30 * time.Second),
+				MaxEjectionTime:    internalserviceconfig.Duration(300 * time.Second),
 				MaxEjectionPercent: 10,
 				SuccessRateEjection: &outlierdetection.SuccessRateEjection{
 					StdevFactor:           1900,
@@ -918,9 +918,9 @@ func (s) TestOutlierDetectionToConfig(t *testing.T) {
 				FailurePercentageRequestVolume: 50,
 			},
 			odLBCfgWant: outlierdetection.LBConfig{
-				Interval:            10 * time.Second,
-				BaseEjectionTime:    30 * time.Second,
-				MaxEjectionTime:     300 * time.Second,
+				Interval:            internalserviceconfig.Duration(10 * time.Second),
+				BaseEjectionTime:    internalserviceconfig.Duration(30 * time.Second),
+				MaxEjectionTime:     internalserviceconfig.Duration(300 * time.Second),
 				MaxEjectionPercent:  10,
 				SuccessRateEjection: nil,
 				FailurePercentageEjection: &outlierdetection.FailurePercentageEjection{
@@ -951,9 +951,9 @@ func (s) TestOutlierDetectionToConfig(t *testing.T) {
 				FailurePercentageRequestVolume: 50,
 			},
 			odLBCfgWant: outlierdetection.LBConfig{
-				Interval:           10 * time.Second,
-				BaseEjectionTime:   30 * time.Second,
-				MaxEjectionTime:    300 * time.Second,
+				Interval:           internalserviceconfig.Duration(10 * time.Second),
+				BaseEjectionTime:   internalserviceconfig.Duration(30 * time.Second),
+				MaxEjectionTime:    internalserviceconfig.Duration(300 * time.Second),
 				MaxEjectionPercent: 10,
 				SuccessRateEjection: &outlierdetection.SuccessRateEjection{
 					StdevFactor:           1900,
@@ -981,9 +981,9 @@ func (s) TestOutlierDetectionToConfig(t *testing.T) {
 				FailurePercentageRequestVolume: 50,
 			},
 			odLBCfgWant: outlierdetection.LBConfig{
-				Interval:           10 * time.Second,
-				BaseEjectionTime:   30 * time.Second,
-				MaxEjectionTime:    300 * time.Second,
+				Interval:           internalserviceconfig.Duration(10 * time.Second),
+				BaseEjectionTime:   internalserviceconfig.Duration(30 * time.Second),
+				MaxEjectionTime:    internalserviceconfig.Duration(300 * time.Second),
 				MaxEjectionPercent: 10,
 				SuccessRateEjection: &outlierdetection.SuccessRateEjection{
 					StdevFactor:           1900,

--- a/xds/internal/balancer/outlierdetection/balancer.go
+++ b/xds/internal/balancer/outlierdetection/balancer.go
@@ -225,9 +225,9 @@ func (b *outlierDetectionBalancer) onIntervalConfig() {
 		for _, addrInfo := range b.addrs {
 			addrInfo.callCounter.clear()
 		}
-		interval = b.cfg.Interval
+		interval = time.Duration(b.cfg.Interval)
 	} else {
-		interval = b.cfg.Interval - now().Sub(b.timerStartTime)
+		interval = time.Duration(b.cfg.Interval) - now().Sub(b.timerStartTime)
 		if interval < 0 {
 			interval = 0
 		}
@@ -752,8 +752,8 @@ func (b *outlierDetectionBalancer) intervalTimerAlgorithm() {
 			// to uneject the address below.
 			continue
 		}
-		et := b.cfg.BaseEjectionTime.Nanoseconds() * addrInfo.ejectionTimeMultiplier
-		met := max(b.cfg.BaseEjectionTime.Nanoseconds(), b.cfg.MaxEjectionTime.Nanoseconds())
+		et := time.Duration(b.cfg.BaseEjectionTime).Nanoseconds() * addrInfo.ejectionTimeMultiplier
+		met := max(time.Duration(b.cfg.BaseEjectionTime).Nanoseconds(), time.Duration(b.cfg.MaxEjectionTime).Nanoseconds())
 		curTimeAfterEt := now().After(addrInfo.latestEjectionTimestamp.Add(time.Duration(min(et, met))))
 		if curTimeAfterEt {
 			b.unejectAddress(addrInfo)
@@ -765,7 +765,7 @@ func (b *outlierDetectionBalancer) intervalTimerAlgorithm() {
 	if b.intervalTimer != nil {
 		b.intervalTimer.Stop()
 	}
-	b.intervalTimer = afterFunc(b.cfg.Interval, b.intervalTimerAlgorithm)
+	b.intervalTimer = afterFunc(time.Duration(b.cfg.Interval), b.intervalTimerAlgorithm)
 }
 
 // addrsWithAtLeastRequestVolume returns a slice of address information of all

--- a/xds/internal/balancer/outlierdetection/config.go
+++ b/xds/internal/balancer/outlierdetection/config.go
@@ -18,9 +18,7 @@
 package outlierdetection
 
 import (
-	"time"
-
-	internalserviceconfig "google.golang.org/grpc/internal/serviceconfig"
+	iserviceconfig "google.golang.org/grpc/internal/serviceconfig"
 	"google.golang.org/grpc/serviceconfig"
 )
 
@@ -128,15 +126,15 @@ type LBConfig struct {
 	// Interval is the time interval between ejection analysis sweeps. This can
 	// result in both new ejections as well as addresses being returned to
 	// service. Defaults to 10s.
-	Interval time.Duration `json:"interval,omitempty"`
+	Interval iserviceconfig.Duration `json:"interval,omitempty"`
 	// BaseEjectionTime is the base time that a host is ejected for. The real
 	// time is equal to the base time multiplied by the number of times the host
 	// has been ejected and is capped by MaxEjectionTime. Defaults to 30s.
-	BaseEjectionTime time.Duration `json:"baseEjectionTime,omitempty"`
+	BaseEjectionTime iserviceconfig.Duration `json:"baseEjectionTime,omitempty"`
 	// MaxEjectionTime is the maximum time that an address is ejected for. If
 	// not specified, the default value (300s) or the BaseEjectionTime value is
 	// applied, whichever is larger.
-	MaxEjectionTime time.Duration `json:"maxEjectionTime,omitempty"`
+	MaxEjectionTime iserviceconfig.Duration `json:"maxEjectionTime,omitempty"`
 	// MaxEjectionPercent is the maximum % of an upstream cluster that can be
 	// ejected due to outlier detection. Defaults to 10% but will eject at least
 	// one host regardless of the value.
@@ -148,7 +146,7 @@ type LBConfig struct {
 	// algorithm. If set, failure rate ejections will be performed.
 	FailurePercentageEjection *FailurePercentageEjection `json:"failurePercentageEjection,omitempty"`
 	// ChildPolicy is the config for the child policy.
-	ChildPolicy *internalserviceconfig.BalancerConfig `json:"childPolicy,omitempty"`
+	ChildPolicy *iserviceconfig.BalancerConfig `json:"childPolicy,omitempty"`
 }
 
 // EqualIgnoringChildPolicy returns whether the LBConfig is same with the

--- a/xds/internal/balancer/outlierdetection/e2e_test/outlierdetection_test.go
+++ b/xds/internal/balancer/outlierdetection/e2e_test/outlierdetection_test.go
@@ -159,9 +159,9 @@ func (s) TestOutlierDetectionAlgorithmsE2E(t *testing.T) {
   "loadBalancingConfig": [
     {
       "outlier_detection_experimental": {
-        "interval": 50000000,
-		"baseEjectionTime": 100000000,
-		"maxEjectionTime": 300000000000,
+        "interval": ".05s",
+		"baseEjectionTime": ".1s",
+		"maxEjectionTime": "300s",
 		"maxEjectionPercent": 33,
 		"successRateEjection": {
 			"stdevFactor": 50,
@@ -182,9 +182,9 @@ func (s) TestOutlierDetectionAlgorithmsE2E(t *testing.T) {
   "loadBalancingConfig": [
     {
       "outlier_detection_experimental": {
-        "interval": 50000000,
-		"baseEjectionTime": 100000000,
-		"maxEjectionTime": 300000000000,
+        "interval": ".05s",
+		"baseEjectionTime": ".1s",
+		"maxEjectionTime": "300s",
 		"maxEjectionPercent": 33,
 		"failurePercentageEjection": {
 			"threshold": 50,
@@ -277,9 +277,9 @@ func (s) TestNoopConfiguration(t *testing.T) {
   "loadBalancingConfig": [
     {
       "outlier_detection_experimental": {
-        "interval": 50000000,
-		"baseEjectionTime": 100000000,
-		"maxEjectionTime": 300000000000,
+        "interval": ".05s",
+		"baseEjectionTime": ".1s",
+		"maxEjectionTime": "300s",
 		"maxEjectionPercent": 33,
         "childPolicy": [{"round_robin": {}}]
       }
@@ -325,9 +325,9 @@ func (s) TestNoopConfiguration(t *testing.T) {
   "loadBalancingConfig": [
     {
       "outlier_detection_experimental": {
-        "interval": 50000000,
-		"baseEjectionTime": 100000000,
-		"maxEjectionTime": 300000000000,
+        "interval": ".05s",
+		"baseEjectionTime": ".1s",
+		"maxEjectionTime": "300s",
 		"maxEjectionPercent": 33,
 		"failurePercentageEjection": {
 			"threshold": 50,


### PR DESCRIPTION
This PR switches Outlier Detection to use the new duration field for correct JSON -> internal parsing.

RELEASE NOTES: N/A