### PR TITLE
test/kokoro: Add custom_lb_test to the xds_k8s_lb job

### DIFF
--- a/test/kokoro/xds_k8s_lb.sh
+++ b/test/kokoro/xds_k8s_lb.sh
@@ -158,7 +158,16 @@ main() {
   # Run tests
   cd "${TEST_DRIVER_FULL_DIR}"
   local failed_tests=0
-  test_suites=("api_listener_test" "change_backend_service_test" "failover_test" "remove_neg_test" "round_robin_test" "affinity_test" "outlier_detection_test")
+  test_suites=(
+    "affinity_test"
+    "api_listener_test"
+    "change_backend_service_test"
+    "custom_lb_test"
+    "failover_test"
+    "outlier_detection_test"
+    "remove_neg_test"
+    "round_robin_test"
+  )
   for test in "${test_suites[@]}"; do
     run_test $test || (( ++failed_tests ))
   done


### PR DESCRIPTION
Minor: split and sort the list of test suites.

RELEASE NOTES: n/a