### PR TITLE
[interop client] let the interop client send additional arbitrary metadata, controlled by a flag

### DIFF
--- a/interop/client/client.go
+++ b/interop/client/client.go
@@ -128,7 +128,7 @@ func parseAdditionalMetadataFlag() (metadata.MD, error) {
 		return nil, nil
 	}
 	r := *additionalMetadata
-	addMd := metadata.New()
+	addMd := metadata.New(map[string]string{})
 	for len(r) > 0 {
 		i := strings.Index(r, ":")
 		if i < 0 {

--- a/interop/client/client.go
+++ b/interop/client/client.go
@@ -132,11 +132,11 @@ func parseAdditionalMetadataFlag() (metadata.MD, error) {
 	for len(r) > 0 {
 		i := strings.Index(r, ":")
 		if i < 0 {
-			return nil, errors.New("could not parse --additional_metadata flag: could not find next semi-colon")
+			return nil, errors.New("could not parse --additional_metadata flag: could not find next colon")
 		}
 		key := r[:i]
 		r = r[i+1:]
-		i = strings.Index(r, ",")
+		i = strings.Index(r, ";")
 		if i < 0 {
 			addMd.Set(key, r)
 			break

--- a/interop/client/client.go
+++ b/interop/client/client.go
@@ -125,7 +125,7 @@ const (
 // Return an error if the value is non-empty but fails to parse.
 func parseAdditionalMetadataFlag() (metadata.MD, error) {
 	if len(*additionalMetadata) == 0 {
-		return map[string]string{}, nil
+		return metadata.New(), nil
 	}
 	r := *additionalMetadata
 	addMd := metadata.New()

--- a/interop/client/client.go
+++ b/interop/client/client.go
@@ -27,7 +27,6 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
-	"errors"
 	"flag"
 	"net"
 	"os"
@@ -132,7 +131,7 @@ func parseAdditionalMetadataFlag() []string {
 	for len(r) > 0 {
 		i := strings.Index(r, ":")
 		if i < 0 {
-			logger.Fatalf("Error parsing --additional_metadata flag: %v", err)
+			logger.Fatalf("Error parsing --additional_metadata flag: missing colon separator")
 		}
 		addMd = append(addMd, r[:i]) // append key
 		r = r[i+1:]

--- a/interop/client/client.go
+++ b/interop/client/client.go
@@ -120,7 +120,8 @@ const (
 	credsComputeEngineCreds
 )
 
-// Parses the --additional_metadata flag and returns metadata to send on each RPC.
+// Parses the --additional_metadata flag and returns metadata to send on each RPC,
+// formatted as per https://pkg.go.dev/google.golang.org/grpc/metadata#Pairs.
 // Allow any character but semicolons in values.
 // If the flag is empty, return a nil map with a nil error.
 // Return an error if the value is non-empty but fails to parse.

--- a/interop/client/client.go
+++ b/interop/client/client.go
@@ -121,8 +121,9 @@ const (
 )
 
 // Parses the --additional_metadata flag and returns metadata to send on each RPC.
+// Allow any character but semicolons in values.
 // If the flag is empty, return a nil map with a nil error.
-// Return an error iff the value is non-empty but fails to parse.
+// Return an error if the value is non-empty but fails to parse.
 func parseAdditionalMetadataFlag() (metadata.MD, error) {
 	if len(*additionalMetadata) == 0 {
 		return nil, nil

--- a/interop/client/client.go
+++ b/interop/client/client.go
@@ -121,11 +121,11 @@ const (
 )
 
 // Parses the --additional_metadata flag and returns metadata to send on each RPC.
-// If the flag is empty, return an empty map with a nil error.
-// Return an error if the value is non-empty but fails to parse.
+// If the flag is empty, return a nil map with a nil error.
+// Return an error iff the value is non-empty but fails to parse.
 func parseAdditionalMetadataFlag() (metadata.MD, error) {
 	if len(*additionalMetadata) == 0 {
-		return metadata.New(), nil
+		return nil, nil
 	}
 	r := *additionalMetadata
 	addMd := metadata.New()
@@ -253,7 +253,7 @@ func main() {
 	if err != nil {
 		logger.Fatalf("Error parsing --additional_metadata flag: %v", err)
 	}
-	if addMd.Len() > 0 {
+	if addMd != nil {
 		unaryAddMd := func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
 			ctx = metadata.NewOutgoingContext(ctx, addMd)
 			return invoker(ctx, method, req, reply, cc, opts...)


### PR DESCRIPTION
This is a Go analogue of an old PR in C++: https://github.com/grpc/grpc/pull/18156 

This is needed for RLS integration tests, where we sometimes need to set custom headers for routing purposes.

cc @easwars 

RELEASE NOTES: none