### PR TITLE
stats/opencensus: Fix flaky test span

### DIFF
--- a/stats/opencensus/e2e_test.go
+++ b/stats/opencensus/e2e_test.go
@@ -1403,7 +1403,7 @@ func (s) TestSpan(t *testing.T) {
 			sc: trace.SpanContext{
 				TraceOptions: 1,
 			},
-			name:     "Attempt.grpc.testing.TestService.UnaryCall",
+			name: "Attempt.grpc.testing.TestService.UnaryCall",
 			messageEvents: []trace.MessageEvent{
 				{
 					EventType:            trace.MessageEventTypeSent,
@@ -1519,7 +1519,7 @@ func (s) TestSpan(t *testing.T) {
 			sc: trace.SpanContext{
 				TraceOptions: 1,
 			},
-			name:     "Attempt.grpc.testing.TestService.FullDuplexCall",
+			name: "Attempt.grpc.testing.TestService.FullDuplexCall",
 			messageEvents: []trace.MessageEvent{
 				{
 					EventType: trace.MessageEventTypeSent,

--- a/stats/opencensus/e2e_test.go
+++ b/stats/opencensus/e2e_test.go
@@ -1341,7 +1341,7 @@ func (fe *fakeExporter) ExportSpan(sd *trace.SpanData) {
 // waitForServerSpan waits until a server span appears somewhere in the span
 // list in an exporter. Returns an error if no server span found within the
 // passed context's timeout.
-func waitForServerSpan(fe *fakeExporter, ctx context.Context) error {
+func waitForServerSpan(ctx context.Context, fe *fakeExporter) error {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
 	for ; ctx.Err() == nil; <-time.After(time.Millisecond) {
@@ -1465,7 +1465,7 @@ func (s) TestSpan(t *testing.T) {
 			childSpanCount:  1,
 		},
 	}
-	if err := waitForServerSpan(fe, ctx); err != nil {
+	if err := waitForServerSpan(ctx, fe); err != nil {
 		t.Fatal(err)
 	}
 	var spanInfoSort = func(i, j int) bool {
@@ -1565,7 +1565,7 @@ func (s) TestSpan(t *testing.T) {
 			childSpanCount:  1,
 		},
 	}
-	if err := waitForServerSpan(fe, ctx); err != nil {
+	if err := waitForServerSpan(ctx, fe); err != nil {
 		t.Fatal(err)
 	}
 	fe.mu.Lock()

--- a/stats/opencensus/trace.go
+++ b/stats/opencensus/trace.go
@@ -40,9 +40,10 @@ type traceInfo struct {
 func (csh *clientStatsHandler) traceTagRPC(ctx context.Context, rti *stats.RPCTagInfo) (context.Context, *traceInfo) {
 	// TODO: get consensus on whether this method name of "s.m" is correct.
 	mn := "Attempt." + strings.Replace(removeLeadingSlash(rti.FullMethodName), "/", ".", -1)
-	// Returned context is ignored because will populate context with data
-	// that wraps the span instead.
-	_, span := trace.StartSpan(ctx, mn, trace.WithSampler(csh.to.TS), trace.WithSpanKind(trace.SpanKindClient))
+	// Returned context is ignored because will populate context with data that
+	// wraps the span instead. Don't set span kind client on this attempt span
+	// to prevent backend from prepending span name with "Sent.".
+	_, span := trace.StartSpan(ctx, mn, trace.WithSampler(csh.to.TS))
 
 	tcBin := propagation.Binary(span.SpanContext())
 	return stats.SetTrace(ctx, tcBin), &traceInfo{

--- a/stats/opencensus/trace.go
+++ b/stats/opencensus/trace.go
@@ -42,7 +42,7 @@ func (csh *clientStatsHandler) traceTagRPC(ctx context.Context, rti *stats.RPCTa
 	mn := "Attempt." + strings.Replace(removeLeadingSlash(rti.FullMethodName), "/", ".", -1)
 	// Returned context is ignored because will populate context with data
 	// that wraps the span instead.
-	_, span := trace.StartSpan(ctx, mn, trace.WithSampler(csh.to.TS))
+	_, span := trace.StartSpan(ctx, mn, trace.WithSampler(csh.to.TS), trace.WithSpanKind(trace.SpanKindClient))
 
 	tcBin := propagation.Binary(span.SpanContext())
 	return stats.SetTrace(ctx, tcBin), &traceInfo{


### PR DESCRIPTION
Fixes #6143.

The server side span has no happens before relationship with the RPC Finishing, and thus can come at any time and in any index. The Attempt Span and Server Span are guaranteed to be emitted in that order during the RPC. Thus, add a sync point in the test after the RPC completes to wait for the server span, and then sort the seen spans into server, attempt, then call span to then make assertions on.

RELEASE NOTES: N/A