### PR TITLE
authz: use pointer to to structpb.Struct instead of value

### DIFF
--- a/authz/rbac_translator.go
+++ b/authz/rbac_translator.go
@@ -62,9 +62,9 @@ type rule struct {
 }
 
 type auditLogger struct {
-	Name       string          `json:"name"`
-	Config     structpb.Struct `json:"config"`
-	IsOptional bool            `json:"is_optional"`
+	Name       string           `json:"name"`
+	Config     *structpb.Struct `json:"config"`
+	IsOptional bool             `json:"is_optional"`
 }
 
 type auditLoggingOptions struct {
@@ -306,9 +306,12 @@ func (options *auditLoggingOptions) toProtos() (allow *v3rbacpb.RBAC_AuditLoggin
 		if config.Name == "" {
 			return nil, nil, fmt.Errorf("missing required field: name in audit_logging_options.audit_loggers[%v]", i)
 		}
+		if config.Config == nil {
+			config.Config = &structpb.Struct{}
+		}
 		typedStruct := &v1xdsudpatypepb.TypedStruct{
 			TypeUrl: typeURLPrefix + config.Name,
-			Value:   &config.Config,
+			Value:   config.Config,
 		}
 		customConfig, err := anypb.New(typedStruct)
 		if err != nil {

--- a/authz/rbac_translator_test.go
+++ b/authz/rbac_translator_test.go
@@ -1024,9 +1024,6 @@ func TestTranslatePolicy(t *testing.T) {
 			if gotErr != nil && !strings.HasPrefix(gotErr.Error(), test.wantErr) {
 				t.Fatalf("unexpected error\nwant:%v\ngot:%v", test.wantErr, gotErr)
 			}
-			for _, k := range gotPolicies {
-				t.Logf("%+v", k.AuditLoggingOptions.LoggerConfigs)
-			}
 			if diff := cmp.Diff(gotPolicies, test.wantPolicies, protocmp.Transform()); diff != "" {
 				t.Fatalf("unexpected policy\ndiff (-want +got):\n%s", diff)
 			}

--- a/authz/rbac_translator_test.go
+++ b/authz/rbac_translator_test.go
@@ -1024,8 +1024,13 @@ func TestTranslatePolicy(t *testing.T) {
 			if gotErr != nil && !strings.HasPrefix(gotErr.Error(), test.wantErr) {
 				t.Fatalf("unexpected error\nwant:%v\ngot:%v", test.wantErr, gotErr)
 			}
+			for _, k := range gotPolicies {
+				t.Logf("%+v", k.AuditLoggingOptions.LoggerConfigs)
+			}
+
+			t.Logf("%+v", gotPolicies)
 			if diff := cmp.Diff(gotPolicies, test.wantPolicies, protocmp.Transform()); diff != "" {
-				t.Fatalf("unexpected policy\ndiff (-want +got):\n%s", diff)
+				t.Fatalf("unexpected policy: name:%q \ndiff (-want +got):\n%s", name, diff)
 			}
 			if test.wantPolicyName != "" && gotPolicyName != test.wantPolicyName {
 				t.Fatalf("unexpected policy name\nwant:%v\ngot:%v", test.wantPolicyName, gotPolicyName)

--- a/authz/rbac_translator_test.go
+++ b/authz/rbac_translator_test.go
@@ -1027,10 +1027,8 @@ func TestTranslatePolicy(t *testing.T) {
 			for _, k := range gotPolicies {
 				t.Logf("%+v", k.AuditLoggingOptions.LoggerConfigs)
 			}
-
-			t.Logf("%+v", gotPolicies)
 			if diff := cmp.Diff(gotPolicies, test.wantPolicies, protocmp.Transform()); diff != "" {
-				t.Fatalf("unexpected policy: name:%q \ndiff (-want +got):\n%s", name, diff)
+				t.Fatalf("unexpected policy\ndiff (-want +got):\n%s", diff)
 			}
 			if test.wantPolicyName != "" && gotPolicyName != test.wantPolicyName {
 				t.Fatalf("unexpected policy name\nwant:%v\ngot:%v", test.wantPolicyName, gotPolicyName)


### PR DESCRIPTION
GoProtoAPI tricorder reported this issue in our weekly import CL. Using the value as is in the struct's type field is discouraged because they inherently lend themselves to shallow copies of messages later on. This diff addresses that, and also needs additional logic to check for nil struct Config.

RELEASE NOTES: none