### PR TITLE
Remove interface check related to ResourceData 

### DIFF
--- a/xds/internal/xdsclient/xdsresource/cluster_resource_type.go
+++ b/xds/internal/xdsclient/xdsresource/cluster_resource_type.go
@@ -32,8 +32,7 @@ const (
 
 var (
 	// Compile time interface checks.
-	_ Type         = clusterResourceType{}
-	_ ResourceData = &ClusterResourceData{}
+	_ Type = clusterResourceType{}
 
 	// Singleton instantiation of the resource type implementation.
 	clusterType = clusterResourceType{

--- a/xds/internal/xdsclient/xdsresource/endpoints_resource_type.go
+++ b/xds/internal/xdsclient/xdsresource/endpoints_resource_type.go
@@ -32,8 +32,7 @@ const (
 
 var (
 	// Compile time interface checks.
-	_ Type         = endpointsResourceType{}
-	_ ResourceData = &EndpointsResourceData{}
+	_ Type = endpointsResourceType{}
 
 	// Singleton instantiation of the resource type implementation.
 	endpointsType = endpointsResourceType{

--- a/xds/internal/xdsclient/xdsresource/listener_resource_type.go
+++ b/xds/internal/xdsclient/xdsresource/listener_resource_type.go
@@ -35,8 +35,7 @@ const (
 
 var (
 	// Compile time interface checks.
-	_ Type         = listenerResourceType{}
-	_ ResourceData = &ListenerResourceData{}
+	_ Type = listenerResourceType{}
 
 	// Singleton instantiation of the resource type implementation.
 	listenerType = listenerResourceType{

--- a/xds/internal/xdsclient/xdsresource/route_config_resource_type.go
+++ b/xds/internal/xdsclient/xdsresource/route_config_resource_type.go
@@ -32,8 +32,7 @@ const (
 
 var (
 	// Compile time interface checks.
-	_ Type         = routeConfigResourceType{}
-	_ ResourceData = &RouteConfigResourceData{}
+	_ Type = routeConfigResourceType{}
 
 	// Singleton instantiation of the resource type implementation.
 	routeConfigType = routeConfigResourceType{


### PR DESCRIPTION
The interface checks are unnecessary as the structs ListenerResourceData, RouteConfigResourceData, ClusterResourceData and EndpointsResourceData explicitly embed ResourceData.


@dfawley 


RELEASE NOTES: none