### PR TITLE
Encode the authority by default

### DIFF
--- a/clientconn.go
+++ b/clientconn.go
@@ -1866,7 +1866,12 @@ func (cc *ClientConn) determineAuthority() error {
 		// the channel authority given the user's dial target. For resolvers
 		// which don't implement this interface, we will use the endpoint from
 		// "scheme://authority/endpoint" as the default authority.
-		cc.authority = endpoint
+
+		// Path escape the endpoint to handle use cases where the endpoint
+		// might not be a valid authority by default.
+		// For example an endpoint which has multiple paths like
+		// 'a/b/c', which is not a valid authority by default.
+		cc.authority = url.PathEscape(endpoint)
 	}
 	channelz.Infof(logger, cc.channelzID, "Channel authority set to %q", cc.authority)
 	return nil

--- a/test/authority_test.go
+++ b/test/authority_test.go
@@ -126,7 +126,7 @@ var authorityTests = []authorityTest{
 		name:           "UnixPassthrough",
 		address:        "/tmp/sock.sock",
 		target:         "passthrough:///unix:///tmp/sock.sock",
-		authority:      "unix:///tmp/sock.sock",
+		authority:      "unix:%2F%2F%2Ftmp%2Fsock.sock",
 		dialTargetWant: "unix:///tmp/sock.sock",
 	},
 	{


### PR DESCRIPTION
Currently the endpoint is returned as the authority unless it can be determined by the scheme or from the dial or credentials. In case the endpoint has multiple slashes, this can be invalid. To handle this use case encode the authority by default.

In the future this can be subsumed by adding per resolver builder method that can provide a more sophisticated logic for determining authority.