### PR TITLE
xds: Passthrough filter name to RBAC filters

### DIFF
--- a/xds/internal/httpfilter/rbac/rbac.go
+++ b/xds/internal/httpfilter/rbac/rbac.go
@@ -54,6 +54,7 @@ func init() {
 	}
 }
 
+// Builder is the implementation of httpfilter.Filter for an RBAC filter.
 type Builder struct {
 	Name string
 }

--- a/xds/internal/httpfilter/rbac/rbac.go
+++ b/xds/internal/httpfilter/rbac/rbac.go
@@ -64,6 +64,7 @@ type config struct {
 	chainEngine *rbac.ChainEngine
 }
 
+// TypeURLs are the proto messages supported by the rbac builder/
 func (Builder) TypeURLs() []string {
 	return []string{
 		"type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC",
@@ -140,6 +141,7 @@ func parseConfig(rbacCfg *rpb.RBAC, filterName string) (httpfilter.FilterConfig,
 	return config{chainEngine: ce}, nil
 }
 
+// ParseFilterConfig parses the config proto into the FilterConfig type.
 func (b Builder) ParseFilterConfig(cfg proto.Message) (httpfilter.FilterConfig, error) {
 	if cfg == nil {
 		return nil, fmt.Errorf("rbac: nil configuration message provided")
@@ -155,6 +157,7 @@ func (b Builder) ParseFilterConfig(cfg proto.Message) (httpfilter.FilterConfig, 
 	return parseConfig(msg, b.Name)
 }
 
+// ParseFilterConfigOverride parses and applies the override configuration.
 func (b Builder) ParseFilterConfigOverride(override proto.Message) (httpfilter.FilterConfig, error) {
 	if override == nil {
 		return nil, fmt.Errorf("rbac: nil configuration message provided")
@@ -170,6 +173,7 @@ func (b Builder) ParseFilterConfigOverride(override proto.Message) (httpfilter.F
 	return parseConfig(msg.Rbac, b.Name)
 }
 
+// IsTerminal returns false as the rbac filter is not terminal.
 func (Builder) IsTerminal() bool {
 	return false
 }

--- a/xds/internal/xdsclient/xdsresource/unmarshal_lds.go
+++ b/xds/internal/xdsclient/xdsresource/unmarshal_lds.go
@@ -30,6 +30,7 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
 	"google.golang.org/grpc/xds/internal/httpfilter"
+	"google.golang.org/grpc/xds/internal/httpfilter/rbac"
 	"google.golang.org/protobuf/types/known/anypb"
 )
 
@@ -140,7 +141,7 @@ func unwrapHTTPFilterConfig(config *anypb.Any) (proto.Message, string, error) {
 	}
 }
 
-func validateHTTPFilterConfig(cfg *anypb.Any, lds, optional bool) (httpfilter.Filter, httpfilter.FilterConfig, error) {
+func validateHTTPFilterConfig(cfg *anypb.Any, lds, optional bool, name string) (httpfilter.Filter, httpfilter.FilterConfig, error) {
 	config, typeURL, err := unwrapHTTPFilterConfig(cfg)
 	if err != nil {
 		return nil, nil, err
@@ -151,6 +152,10 @@ func validateHTTPFilterConfig(cfg *anypb.Any, lds, optional bool) (httpfilter.Fi
 			return nil, nil, nil
 		}
 		return nil, nil, fmt.Errorf("no filter implementation found for %q", typeURL)
+	}
+	if rbac, ok := filterBuilder.(rbac.Builder); ok {
+		rbac.Name = name
+		filterBuilder = rbac
 	}
 	parseFunc := filterBuilder.ParseFilterConfig
 	if !lds {
@@ -179,7 +184,7 @@ func processHTTPFilterOverrides(cfgs map[string]*anypb.Any) (map[string]httpfilt
 			optional = s.GetIsOptional()
 		}
 
-		httpFilter, config, err := validateHTTPFilterConfig(cfg, false, optional)
+		httpFilter, config, err := validateHTTPFilterConfig(cfg, false, optional, name)
 		if err != nil {
 			return nil, fmt.Errorf("filter override %q: %v", name, err)
 		}
@@ -205,7 +210,7 @@ func processHTTPFilters(filters []*v3httppb.HttpFilter, server bool) ([]HTTPFilt
 		}
 		seenNames[name] = true
 
-		httpFilter, config, err := validateHTTPFilterConfig(filter.GetTypedConfig(), true, filter.GetIsOptional())
+		httpFilter, config, err := validateHTTPFilterConfig(filter.GetTypedConfig(), true, filter.GetIsOptional(), name)
 		if err != nil {
 			return nil, err
 		}

--- a/xds/internal/xdsclient/xdsresource/unmarshal_lds_test.go
+++ b/xds/internal/xdsclient/xdsresource/unmarshal_lds_test.go
@@ -1721,6 +1721,8 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 	}
 }
 
+// TestRbacNamePassthrough tests that the filter name is properly associated
+// with the RBAC after parsing.
 func TestRbacNamePassthrough(t *testing.T) {
 	filters := []*v3httppb.HttpFilter{
 		{

--- a/xds/internal/xdsclient/xdsresource/unmarshal_lds_test.go
+++ b/xds/internal/xdsclient/xdsresource/unmarshal_lds_test.go
@@ -39,9 +39,11 @@ import (
 	v3corepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	v3listenerpb "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	rpb "github.com/envoyproxy/go-control-plane/envoy/config/rbac/v3"
+	v3baserbacpb "github.com/envoyproxy/go-control-plane/envoy/config/rbac/v3"
 	v3routepb "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	v3rbacpb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/rbac/v3"
 	v3httppb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+	v3auditloggersstreampb "github.com/envoyproxy/go-control-plane/envoy/extensions/rbac/audit_loggers/stream/v3"
 	v3tlspb "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	v3discoverypb "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	v3matcherpb "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
@@ -49,7 +51,7 @@ import (
 	spb "github.com/golang/protobuf/ptypes/struct"
 	wrapperspb "github.com/golang/protobuf/ptypes/wrappers"
 
-	_ "google.golang.org/grpc/xds/internal/httpfilter/rbac"   // Register the RBAC HTTP filter.
+	"google.golang.org/grpc/xds/internal/httpfilter/rbac"
 	_ "google.golang.org/grpc/xds/internal/httpfilter/router" // Register the router filter.
 )
 
@@ -1717,6 +1719,63 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRbacNamePassthrough(t *testing.T) {
+	filters := []*v3httppb.HttpFilter{
+		{
+			Name: "StdoutAuditLogger",
+			ConfigType: &v3httppb.HttpFilter_TypedConfig{
+				TypedConfig: testutils.MarshalAny(&v3rbacpb.RBAC{
+					Rules: &v3baserbacpb.RBAC{
+						Action: v3baserbacpb.RBAC_DENY,
+
+						Policies: map[string]*v3baserbacpb.Policy{
+							"authz_deny_policy_1": {
+								Principals: []*v3baserbacpb.Principal{
+									{Identifier: &v3baserbacpb.Principal_OrIds{OrIds: &v3baserbacpb.Principal_Set{
+										Ids: []*v3baserbacpb.Principal{
+											{Identifier: &v3baserbacpb.Principal_Authenticated_{
+												Authenticated: &v3baserbacpb.Principal_Authenticated{PrincipalName: &v3matcherpb.StringMatcher{
+													MatchPattern: &v3matcherpb.StringMatcher_Exact{Exact: "spiffe://foo.abc"},
+												}},
+											}},
+										},
+									}}},
+								},
+								Permissions: []*v3baserbacpb.Permission{
+									{Rule: &v3baserbacpb.Permission_Any{Any: true}},
+								},
+							},
+						},
+						AuditLoggingOptions: &v3baserbacpb.RBAC_AuditLoggingOptions{
+							AuditCondition: v3baserbacpb.RBAC_AuditLoggingOptions_ON_DENY,
+							LoggerConfigs: []*v3baserbacpb.RBAC_AuditLoggingOptions_AuditLoggerConfig{
+								{AuditLogger: &v3corepb.TypedExtensionConfig{Name: "stdout_logger", TypedConfig: testutils.MarshalAny(&v3auditloggersstreampb.StdoutAuditLog{})},
+									IsOptional: false,
+								},
+							},
+						},
+					},
+				}),
+			},
+			IsOptional: true,
+		},
+		// This filter acts as a terminal filter at the end of the filter chain.
+		e2e.RouterHTTPFilter,
+	}
+	res, err := processHTTPFilters(filters, true)
+	if err != nil {
+		t.Fatalf("processHTTPFilters errors: %v", err)
+	}
+	stdoutFilter, ok := res[0].Filter.(rbac.Builder)
+	if !ok {
+		t.Fatalf("Expected res[0].Filter to be of type rbac.Builder but was not")
+	}
+	if stdoutFilter.Name != "StdoutAuditLogger" {
+		t.Fatalf("Expected filter name to be StdoutAuditLogger but was not")
+	}
+
 }
 
 type filterConfig struct {

--- a/xds/internal/xdsclient/xdsresource/unmarshal_lds_test.go
+++ b/xds/internal/xdsclient/xdsresource/unmarshal_lds_test.go
@@ -1763,7 +1763,7 @@ func TestRbacNamePassthrough(t *testing.T) {
 							LoggerConfigs: []*v3baserbacpb.RBAC_AuditLoggingOptions_AuditLoggerConfig{
 								{
 									AuditLogger: &v3corepb.TypedExtensionConfig{Name: "stdout_logger", TypedConfig: testutils.MarshalAny(&v3auditloggersstreampb.StdoutAuditLog{})},
-									IsOptional: false,
+									IsOptional:  false,
 								},
 							},
 						},

--- a/xds/internal/xdsclient/xdsresource/unmarshal_lds_test.go
+++ b/xds/internal/xdsclient/xdsresource/unmarshal_lds_test.go
@@ -1735,15 +1735,23 @@ func TestRbacNamePassthrough(t *testing.T) {
 						Policies: map[string]*v3baserbacpb.Policy{
 							"authz_deny_policy_1": {
 								Principals: []*v3baserbacpb.Principal{
-									{Identifier: &v3baserbacpb.Principal_OrIds{OrIds: &v3baserbacpb.Principal_Set{
-										Ids: []*v3baserbacpb.Principal{
-											{Identifier: &v3baserbacpb.Principal_Authenticated_{
-												Authenticated: &v3baserbacpb.Principal_Authenticated{PrincipalName: &v3matcherpb.StringMatcher{
-													MatchPattern: &v3matcherpb.StringMatcher_Exact{Exact: "spiffe://foo.abc"},
-												}},
-											}},
+									{
+										Identifier: &v3baserbacpb.Principal_OrIds{
+											OrIds: &v3baserbacpb.Principal_Set{
+												Ids: []*v3baserbacpb.Principal{
+													{
+														Identifier: &v3baserbacpb.Principal_Authenticated_{
+															Authenticated: &v3baserbacpb.Principal_Authenticated{
+																PrincipalName: &v3matcherpb.StringMatcher{
+																	MatchPattern: &v3matcherpb.StringMatcher_Exact{Exact: "spiffe://foo.abc"},
+																},
+															},
+														},
+													},
+												},
+											},
 										},
-									}}},
+									},
 								},
 								Permissions: []*v3baserbacpb.Permission{
 									{Rule: &v3baserbacpb.Permission_Any{Any: true}},
@@ -1753,7 +1761,8 @@ func TestRbacNamePassthrough(t *testing.T) {
 						AuditLoggingOptions: &v3baserbacpb.RBAC_AuditLoggingOptions{
 							AuditCondition: v3baserbacpb.RBAC_AuditLoggingOptions_ON_DENY,
 							LoggerConfigs: []*v3baserbacpb.RBAC_AuditLoggingOptions_AuditLoggerConfig{
-								{AuditLogger: &v3corepb.TypedExtensionConfig{Name: "stdout_logger", TypedConfig: testutils.MarshalAny(&v3auditloggersstreampb.StdoutAuditLog{})},
+								{
+									AuditLogger: &v3corepb.TypedExtensionConfig{Name: "stdout_logger", TypedConfig: testutils.MarshalAny(&v3auditloggersstreampb.StdoutAuditLog{})},
 									IsOptional: false,
 								},
 							},
@@ -1775,7 +1784,7 @@ func TestRbacNamePassthrough(t *testing.T) {
 		t.Fatalf("Expected res[0].Filter to be of type rbac.Builder but was not")
 	}
 	if stdoutFilter.Name != "StdoutAuditLogger" {
-		t.Fatalf("Expected filter name to be StdoutAuditLogger but was not")
+		t.Fatalf("Expected filter name to be StdoutAuditLogger but was not %v", stdoutFilter.Name)
 	}
 
 }


### PR DESCRIPTION
Our filters are named in the input configs, but the overall name was not getting passed through to the rbac config.

This PR makes that name get passed through without requiring breaking changes to protos or non-internal APIs.

I did have to export the `builder` in `rbac.go` so that I could check for it's type in the generic http code.

I ended up adding a new test that tests the first function that gets modified in this call chain. I originally tried to work a test into the existing structures, but it became spaghetti config relatively quickly. If desired I could work on that again, but as it stands I think the existing test is clean.

RELEASE NOTES: N/A