### PR TITLE
reflection: expose both v1 and v1alpha reflection services

### DIFF
--- a/reflection/adapt.go
+++ b/reflection/adapt.go
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2016 gRPC authors.
+ * Copyright 2023 gRPC authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reflection/adapt.go
+++ b/reflection/adapt.go
@@ -1,3 +1,21 @@
+/*
+ *
+ * Copyright 2016 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package reflection
 
 import (

--- a/reflection/adapt.go
+++ b/reflection/adapt.go
@@ -1,0 +1,169 @@
+package reflection
+
+import (
+	v1grpc "google.golang.org/grpc/reflection/grpc_reflection_v1"
+	v1pb "google.golang.org/grpc/reflection/grpc_reflection_v1"
+	v1alphagrpc "google.golang.org/grpc/reflection/grpc_reflection_v1alpha"
+	v1alphapb "google.golang.org/grpc/reflection/grpc_reflection_v1alpha"
+)
+
+// asV1Alpha returns an implementation of the v1alpha version of the reflection
+// interface that delegates all calls to the given v1 version.
+func asV1Alpha(svr v1grpc.ServerReflectionServer) v1alphagrpc.ServerReflectionServer {
+	return v1AlphaServerImpl{svr: svr}
+}
+
+type v1AlphaServerImpl struct {
+	svr v1grpc.ServerReflectionServer
+}
+
+func (s v1AlphaServerImpl) ServerReflectionInfo(stream v1alphagrpc.ServerReflection_ServerReflectionInfoServer) error {
+	return s.svr.ServerReflectionInfo(v1AlphaServerStreamAdapter{stream})
+}
+
+type v1AlphaServerStreamAdapter struct {
+	v1alphagrpc.ServerReflection_ServerReflectionInfoServer
+}
+
+func (s v1AlphaServerStreamAdapter) Send(response *v1pb.ServerReflectionResponse) error {
+	return s.ServerReflection_ServerReflectionInfoServer.Send(v1ToV1AlphaResponse(response))
+}
+
+func (s v1AlphaServerStreamAdapter) Recv() (*v1pb.ServerReflectionRequest, error) {
+	resp, err := s.ServerReflection_ServerReflectionInfoServer.Recv()
+	if err != nil {
+		return nil, err
+	}
+	return v1AlphaToV1Request(resp), nil
+}
+
+func v1ToV1AlphaResponse(v1 *v1pb.ServerReflectionResponse) *v1alphapb.ServerReflectionResponse {
+	var v1alpha v1alphapb.ServerReflectionResponse
+	v1alpha.ValidHost = v1.ValidHost
+	if v1.OriginalRequest != nil {
+		v1alpha.OriginalRequest = v1ToV1AlphaRequest(v1.OriginalRequest)
+	}
+	switch mr := v1.MessageResponse.(type) {
+	case *v1pb.ServerReflectionResponse_FileDescriptorResponse:
+		if mr != nil {
+			v1alpha.MessageResponse = &v1alphapb.ServerReflectionResponse_FileDescriptorResponse{
+				FileDescriptorResponse: &v1alphapb.FileDescriptorResponse{
+					FileDescriptorProto: mr.FileDescriptorResponse.GetFileDescriptorProto(),
+				},
+			}
+		}
+	case *v1pb.ServerReflectionResponse_AllExtensionNumbersResponse:
+		if mr != nil {
+			v1alpha.MessageResponse = &v1alphapb.ServerReflectionResponse_AllExtensionNumbersResponse{
+				AllExtensionNumbersResponse: &v1alphapb.ExtensionNumberResponse{
+					BaseTypeName:    mr.AllExtensionNumbersResponse.GetBaseTypeName(),
+					ExtensionNumber: mr.AllExtensionNumbersResponse.GetExtensionNumber(),
+				},
+			}
+		}
+	case *v1pb.ServerReflectionResponse_ListServicesResponse:
+		if mr != nil {
+			svcs := make([]*v1alphapb.ServiceResponse, len(mr.ListServicesResponse.GetService()))
+			for i, svc := range mr.ListServicesResponse.GetService() {
+				svcs[i] = &v1alphapb.ServiceResponse{
+					Name: svc.GetName(),
+				}
+			}
+			v1alpha.MessageResponse = &v1alphapb.ServerReflectionResponse_ListServicesResponse{
+				ListServicesResponse: &v1alphapb.ListServiceResponse{
+					Service: svcs,
+				},
+			}
+		}
+	case *v1pb.ServerReflectionResponse_ErrorResponse:
+		if mr != nil {
+			v1alpha.MessageResponse = &v1alphapb.ServerReflectionResponse_ErrorResponse{
+				ErrorResponse: &v1alphapb.ErrorResponse{
+					ErrorCode:    mr.ErrorResponse.GetErrorCode(),
+					ErrorMessage: mr.ErrorResponse.GetErrorMessage(),
+				},
+			}
+		}
+	default:
+		// no value set
+	}
+	return &v1alpha
+}
+
+func v1AlphaToV1Request(v1alpha *v1alphapb.ServerReflectionRequest) *v1pb.ServerReflectionRequest {
+	var v1 v1pb.ServerReflectionRequest
+	v1.Host = v1alpha.Host
+	switch mr := v1alpha.MessageRequest.(type) {
+	case *v1alphapb.ServerReflectionRequest_FileByFilename:
+		v1.MessageRequest = &v1pb.ServerReflectionRequest_FileByFilename{
+			FileByFilename: mr.FileByFilename,
+		}
+	case *v1alphapb.ServerReflectionRequest_FileContainingSymbol:
+		v1.MessageRequest = &v1pb.ServerReflectionRequest_FileContainingSymbol{
+			FileContainingSymbol: mr.FileContainingSymbol,
+		}
+	case *v1alphapb.ServerReflectionRequest_FileContainingExtension:
+		if mr.FileContainingExtension != nil {
+			v1.MessageRequest = &v1pb.ServerReflectionRequest_FileContainingExtension{
+				FileContainingExtension: &v1pb.ExtensionRequest{
+					ContainingType:  mr.FileContainingExtension.GetContainingType(),
+					ExtensionNumber: mr.FileContainingExtension.GetExtensionNumber(),
+				},
+			}
+		}
+	case *v1alphapb.ServerReflectionRequest_AllExtensionNumbersOfType:
+		v1.MessageRequest = &v1pb.ServerReflectionRequest_AllExtensionNumbersOfType{
+			AllExtensionNumbersOfType: mr.AllExtensionNumbersOfType,
+		}
+	case *v1alphapb.ServerReflectionRequest_ListServices:
+		v1.MessageRequest = &v1pb.ServerReflectionRequest_ListServices{
+			ListServices: mr.ListServices,
+		}
+	default:
+		// no value set
+	}
+	return &v1
+}
+
+func v1ToV1AlphaRequest(v1 *v1pb.ServerReflectionRequest) *v1alphapb.ServerReflectionRequest {
+	var v1alpha v1alphapb.ServerReflectionRequest
+	v1alpha.Host = v1.Host
+	switch mr := v1.MessageRequest.(type) {
+	case *v1pb.ServerReflectionRequest_FileByFilename:
+		if mr != nil {
+			v1alpha.MessageRequest = &v1alphapb.ServerReflectionRequest_FileByFilename{
+				FileByFilename: mr.FileByFilename,
+			}
+		}
+	case *v1pb.ServerReflectionRequest_FileContainingSymbol:
+		if mr != nil {
+			v1alpha.MessageRequest = &v1alphapb.ServerReflectionRequest_FileContainingSymbol{
+				FileContainingSymbol: mr.FileContainingSymbol,
+			}
+		}
+	case *v1pb.ServerReflectionRequest_FileContainingExtension:
+		if mr != nil {
+			v1alpha.MessageRequest = &v1alphapb.ServerReflectionRequest_FileContainingExtension{
+				FileContainingExtension: &v1alphapb.ExtensionRequest{
+					ContainingType:  mr.FileContainingExtension.GetContainingType(),
+					ExtensionNumber: mr.FileContainingExtension.GetExtensionNumber(),
+				},
+			}
+		}
+	case *v1pb.ServerReflectionRequest_AllExtensionNumbersOfType:
+		if mr != nil {
+			v1alpha.MessageRequest = &v1alphapb.ServerReflectionRequest_AllExtensionNumbersOfType{
+				AllExtensionNumbersOfType: mr.AllExtensionNumbersOfType,
+			}
+		}
+	case *v1pb.ServerReflectionRequest_ListServices:
+		if mr != nil {
+			v1alpha.MessageRequest = &v1alphapb.ServerReflectionRequest_ListServices{
+				ListServices: mr.ListServices,
+			}
+		}
+	default:
+		// no value set
+	}
+	return &v1alpha
+}

--- a/reflection/serverreflection.go
+++ b/reflection/serverreflection.go
@@ -73,18 +73,10 @@ func Register(s GRPCServer) {
 
 // RegisterV1 registers only the v1 version of the server reflection service
 // on the given gRPC server. Many clients may only support v1alpha so most
-// users should use Register instead.
+// users should use Register instead, at least until clients have upgraded.
 func RegisterV1(s GRPCServer) {
 	svr := NewServerV1(ServerOptions{Services: s})
 	v1grpc.RegisterServerReflectionServer(s, svr)
-}
-
-// RegisterV1Alpha registers only the v1alpha version of the server reflection
-// service. Some clients may prefer v1 or only support v1 exclusively, so most
-// users should use Register instead.
-func RegisterV1Alpha(s GRPCServer) {
-	svr := NewServerV1(ServerOptions{Services: s})
-	v1alphagrpc.RegisterServerReflectionServer(s, asV1Alpha(svr))
 }
 
 // ServiceInfoProvider is an interface used to retrieve metadata about the


### PR DESCRIPTION
Resolves #5684.

This adds `RegisterV1` and `RegisterV1Alpha` to provide control over the versions registered. The existing `Register` function registers both versions.

This also adds `NewServerV1` to return a server that implements the new version. `NewServer` continues to return the v1alpha version of the interface.

All of the _core_ logic and types have been updated to refer to the newer definitions in v1. Adapters have been added, to convert between v1 and v1alpha, to provide the v1alpha server. The adapters are also used in tests, so that the end-to-end tests now go through both v1 and v1alpha stubs, to verify both versions work correctly.

RELEASE NOTES:
* reflection: support the v1 reflection service and update Register to register both v1alpha and v1.