### PR TITLE
client: fix Connect to handle channel idleness properly

### DIFF
--- a/clientconn.go
+++ b/clientconn.go
@@ -706,6 +706,9 @@ func (cc *ClientConn) GetState() connectivity.State {
 // Notice: This API is EXPERIMENTAL and may be changed or removed in a later
 // release.
 func (cc *ClientConn) Connect() {
+	cc.exitIdleMode()
+	// If the ClientConn was not in idle mode, we need to call ExitIdle on the
+	// LB policy so that connections can be created.
 	cc.balancerWrapper.exitIdleMode()
 }
 

--- a/clientconn.go
+++ b/clientconn.go
@@ -325,7 +325,8 @@ func (cc *ClientConn) exitIdleMode() error {
 		return errConnClosing
 	}
 	if cc.idlenessState != ccIdlenessStateIdle {
-		logger.Error("ClientConn asked to exit idle mode when not in idle mode")
+		cc.mu.Unlock()
+		logger.Info("ClientConn asked to exit idle mode when not in idle mode")
 		return nil
 	}
 


### PR DESCRIPTION
`ClientConn.Connect()` needs to fully exit idle mode, not just awaken the balancer wrapper.  Before channel idleness, the LB policy was the only thing that needed to be notified, since the name resolver was never stopped.

RELEASE NOTES: none