### PR TITLE
[PSM interop] Don't fail target if sub-target already failed (v1.47.x backport)

### DIFF
--- a/test/kokoro/psm-security.sh
+++ b/test/kokoro/psm-security.sh
@@ -161,9 +161,6 @@ main() {
     run_test $test || (( ++failed_tests ))
   done
   echo "Failed test suites: ${failed_tests}"
-  if (( failed_tests > 0 )); then
-    exit 1
-  fi
 }
 
 main "$@"

--- a/test/kokoro/xds_k8s_lb.sh
+++ b/test/kokoro/xds_k8s_lb.sh
@@ -163,9 +163,6 @@ main() {
     run_test $test || (( ++failed_tests ))
   done
   echo "Failed test suites: ${failed_tests}"
-  if (( failed_tests > 0 )); then
-    exit 1
-  fi
 }
 
 main "$@"


### PR DESCRIPTION
Backport of #6332 to v1.47.x.
---
We configured TestGrid to file bug separately for each failed sub-target, if we still fail the main target, TestGrid will fail duplicate bugs.
The same change in core: https://github.com/grpc/grpc/pull/33222.

RELEASE NOTES: N/A