### PR TITLE
protoc-gen-go-grpc: Update README.md file

### DIFF
--- a/cmd/protoc-gen-go-grpc/README.md
+++ b/cmd/protoc-gen-go-grpc/README.md
@@ -14,7 +14,7 @@ To restore this behavior, set the option `require_unimplemented_servers=false`.
 E.g.:
 
 ```
-  protoc --go-grpc_out=require_unimplemented_servers=false[,other options...]:. \
+  protoc --go-grpc_out=. --go-grpc_opt=require_unimplemented_servers=false[,other options...] \
 ```
 
 Note that this is not recommended, and the option is only provided to restore


### PR DESCRIPTION
I have found these two previous PRs (https://github.com/grpc/grpc-go/pull/4538 https://github.com/grpc/grpc-go/pull/5158) and have also confirmed that the following code actually works.
```
protoc --go-grpc_out=require_unimplemented_servers=false:. \ foo.proto
```
However, since `go-grpc_out` and `go-grpc_opt` are written separately as the protoc command options on the [quick start
guide](https://grpc.io/docs/languages/go/quickstart/#regenerate-grpc-code), isn't this easier to understand?

RELEASE NOTES: N/A
