### PR TITLE
xds/ringhash: cache connectivity state of subchannels inside picker

### DIFF
--- a/xds/internal/balancer/ringhash/e2e/ringhash_balancer_test.go
+++ b/xds/internal/balancer/ringhash/e2e/ringhash_balancer_test.go
@@ -119,10 +119,7 @@ func (s) TestRingHash_ReconnectToMoveOutOfTransientFailure(t *testing.T) {
 	// Make an RPC to get the ring_hash LB policy to reconnect and thereby move
 	// to TRANSIENT_FAILURE upon connection failure.
 	client.EmptyCall(ctx, &testpb.Empty{})
-	for ; ctx.Err() == nil; <-time.After(defaultTestShortTimeout) {
-		if cc.GetState() == connectivity.TransientFailure {
-			break
-		}
+	for state := cc.GetState(); state != connectivity.TransientFailure && cc.WaitForStateChange(ctx, state); state = cc.GetState() {
 	}
 	if err := ctx.Err(); err != nil {
 		t.Fatalf("Timeout waiting for channel to reach %q after server shutdown: %v", connectivity.TransientFailure, err)

--- a/xds/internal/balancer/ringhash/ringhash.go
+++ b/xds/internal/balancer/ringhash/ringhash.go
@@ -359,11 +359,13 @@ func (b *ringhashBalancer) UpdateSubConnState(sc balancer.SubConn, state balance
 		delete(b.scStates, sc)
 	}
 
-	// Because the picker caches the state of the subconns, we always regnerate
-	// and update the picker.
-	b.regeneratePicker()
-	b.logger.Infof("Pushing new state %v and picker %p", b.state, b.picker)
-	b.cc.UpdateState(balancer.State{ConnectivityState: b.state, Picker: b.picker})
+	if oldSCState != newSCState {
+		// Because the picker caches the state of the subconns, we always regnerate
+		// and update the picker when the effective state changes.
+		b.regeneratePicker()
+		b.logger.Infof("Pushing new state %v and picker %p", b.state, b.picker)
+		b.cc.UpdateState(balancer.State{ConnectivityState: b.state, Picker: b.picker})
+	}
 
 	switch b.state {
 	case connectivity.Connecting, connectivity.TransientFailure:

--- a/xds/internal/balancer/ringhash/ringhash.go
+++ b/xds/internal/balancer/ringhash/ringhash.go
@@ -347,40 +347,23 @@ func (b *ringhashBalancer) UpdateSubConnState(sc balancer.SubConn, state balance
 	newSCState := scs.effectiveState()
 	b.logger.Infof("SubConn's effective old state was: %v, new state is %v", oldSCState, newSCState)
 
-	var sendUpdate bool
-	oldBalancerState := b.state
 	b.state = b.csEvltr.recordTransition(oldSCState, newSCState)
-	if oldBalancerState != b.state {
-		sendUpdate = true
-	}
 
 	switch s {
-	case connectivity.Idle:
-		// No need to send an update. No queued RPC can be unblocked. If the
-		// overall state changed because of this, sendUpdate is already true.
-	case connectivity.Connecting:
-		// No need to send an update. No queued RPC can be unblocked. If the
-		// overall state changed because of this, sendUpdate is already true.
-	case connectivity.Ready:
-		// We need to regenerate the picker even if the ring has not changed
-		// because we could be moving from TRANSIENT_FAILURE to READY, in which
-		// case, we need to update the error picker returned earlier.
-		b.regeneratePicker()
-		sendUpdate = true
 	case connectivity.TransientFailure:
 		// Save error to be reported via picker.
 		b.connErr = state.ConnectionError
-		b.regeneratePicker()
 	case connectivity.Shutdown:
 		// When an address was removed by resolver, b called RemoveSubConn but
 		// kept the sc's state in scStates. Remove state for this sc here.
 		delete(b.scStates, sc)
 	}
 
-	if sendUpdate {
-		b.logger.Infof("Pushing new state %v and picker %p", b.state, b.picker)
-		b.cc.UpdateState(balancer.State{ConnectivityState: b.state, Picker: b.picker})
-	}
+	// Because the picker caches the state of the subconns, we always regnerate
+	// and update the picker.
+	b.regeneratePicker()
+	b.logger.Infof("Pushing new state %v and picker %p", b.state, b.picker)
+	b.cc.UpdateState(balancer.State{ConnectivityState: b.state, Picker: b.picker})
 
 	switch b.state {
 	case connectivity.Connecting, connectivity.TransientFailure:

--- a/xds/internal/balancer/ringhash/ringhash.go
+++ b/xds/internal/balancer/ringhash/ringhash.go
@@ -360,8 +360,9 @@ func (b *ringhashBalancer) UpdateSubConnState(sc balancer.SubConn, state balance
 	}
 
 	if oldSCState != newSCState {
-		// Because the picker caches the state of the subconns, we always regnerate
-		// and update the picker when the effective state changes.
+		// Because the picker caches the state of the subconns, we always
+		// regenerate and update the picker when the effective SubConn state
+		// changes.
 		b.regeneratePicker()
 		b.logger.Infof("Pushing new state %v and picker %p", b.state, b.picker)
 		b.cc.UpdateState(balancer.State{ConnectivityState: b.state, Picker: b.picker})


### PR DESCRIPTION
I did not add a new test for this.  The sequence of operations required here is fairly long and specific and requires races that are too difficult to reliably stimulate.  Corresponding change in C++: [grpc/grpc@`98cdac3` (#32326)](https://github.com/grpc/grpc/pull/32326/commits/98cdac31a0196d23a972acd3de027a645daf66ce).  (gRPC-Java always kept a copy of the states in the picker.)

RELEASE NOTES:
* xds/ringhash: cache connectivity state of subchannels inside picker to avoid rare races