### PR TITLE
Revert "client: encode the authority by default (#6318)"

### DIFF
--- a/clientconn.go
+++ b/clientconn.go
@@ -1872,12 +1872,7 @@ func (cc *ClientConn) determineAuthority() error {
 		// the channel authority given the user's dial target. For resolvers
 		// which don't implement this interface, we will use the endpoint from
 		// "scheme://authority/endpoint" as the default authority.
-
-		// Path escape the endpoint to handle use cases where the endpoint
-		// might not be a valid authority by default.
-		// For example an endpoint which has multiple paths like
-		// 'a/b/c', which is not a valid authority by default.
-		cc.authority = url.PathEscape(endpoint)
+		cc.authority = endpoint
 	}
 	channelz.Infof(logger, cc.channelzID, "Channel authority set to %q", cc.authority)
 	return nil

--- a/test/authority_test.go
+++ b/test/authority_test.go
@@ -126,7 +126,7 @@ var authorityTests = []authorityTest{
 		name:           "UnixPassthrough",
 		address:        "/tmp/sock.sock",
 		target:         "passthrough:///unix:///tmp/sock.sock",
-		authority:      "unix:%2F%2F%2Ftmp%2Fsock.sock",
+		authority:      "unix:///tmp/sock.sock",
 		dialTargetWant: "unix:///tmp/sock.sock",
 	},
 	{


### PR DESCRIPTION
This reverts commit 68576b3c42bbecacfeba3bee89f509f1bb7b0072.

RELEASE NOTES: N/A