### PR TITLE
stats/opencensus: Fix flaky metrics test

### DIFF
--- a/stats/opencensus/e2e_test.go
+++ b/stats/opencensus/e2e_test.go
@@ -238,7 +238,7 @@ func distributionDataLatencyCount(vi *viewInformation, countWant int64, wantTags
 }
 
 // waitForServerCompletedRPCs waits until both Unary and Streaming metric rows
-// appear, in two seperate rows, for server completed RPC's view. Returns an
+// appear, in two separate rows, for server completed RPC's view. Returns an
 // error if the Unary and Streaming metric are not found within the passed
 // context's timeout.
 func waitForServerCompletedRPCs(ctx context.Context) error {


### PR DESCRIPTION
Fixes #6231.

This adds a sync point between Unary and Streaming RPCs recording completed RPC's Server Side and the test. The test simply waits for the RPC to finish client side, but stats.End is recorded in a defer for the Unary and Streaming RPC case after status is written to the wire. Thus, previously there was no sync point between the test and this metric being recorded. Sync at the view global level, as that is synced with exporter by Unregistering views, and will stop recording metrics after, thus has to wait for the two row emissions for Unary and Streaming RPCs at the view global level, not at the exporter level.

Verified passes over 10k runs on Forge. Previously was failing 18/10k times on Forge.

RELEASE NOTES: N/A