### PR TITLE
xds: E2E Test for Audit Logging

### DIFF
--- a/test/xds/xds_server_rbac_test.go
+++ b/test/xds/xds_server_rbac_test.go
@@ -979,7 +979,7 @@ func createXDSTypedStruct(t *testing.T, in map[string]interface{}, name string) 
 	t.Helper()
 	pb, err := structpb.NewStruct(in)
 	if err != nil {
-		t.Fatalf("createXDSTypedStruct Failed during structpb.NewStruct: %v", err)
+		t.Fatalf("createXDSTypedStruct failed during structpb.NewStruct: %v", err)
 	}
 	typedStruct := &v3xdsxdstypepb.TypedStruct{
 		TypeUrl: typeURLPrefix + name,
@@ -987,7 +987,7 @@ func createXDSTypedStruct(t *testing.T, in map[string]interface{}, name string) 
 	}
 	customConfig, err := anypb.New(typedStruct)
 	if err != nil {
-		t.Fatalf("createXDSTypedStruct Failed during anypb.New: %v", err)
+		t.Fatalf("createXDSTypedStruct failed during anypb.New: %v", err)
 	}
 	return customConfig
 }

--- a/test/xds/xds_server_rbac_test.go
+++ b/test/xds/xds_server_rbac_test.go
@@ -692,10 +692,13 @@ func (s) TestRBACHTTPFilter(t *testing.T) {
 				// Toggle RBAC back on for next iterations.
 				envconfig.XDSRBAC = true
 
-				if diff := cmp.Diff(lb.authzDecisionStat, test.wantAuthzOutcomes); diff != "" {
-					t.Errorf("Authorization decision do not match\ndiff (-got +want):\n%s", diff)
+				if test.wantAuthzOutcomes != nil {
+					if diff := cmp.Diff(lb.authzDecisionStat, test.wantAuthzOutcomes); diff != "" {
+						t.Errorf("Authorization decision do not match\ndiff (-got +want):\n%s", diff)
+					}
 				}
 				if test.eventContent != nil {
+
 					if diff := cmp.Diff(lb.lastEvent, test.eventContent); diff != "" {
 						t.Errorf("Unexpected Message\ndiff (-got + want):\n%s", diff)
 					}

--- a/test/xds/xds_server_rbac_test.go
+++ b/test/xds/xds_server_rbac_test.go
@@ -696,12 +696,12 @@ func (s) TestRBACHTTPFilter(t *testing.T) {
 
 				if test.wantAuthzOutcomes != nil {
 					if diff := cmp.Diff(lb.authzDecisionStat, test.wantAuthzOutcomes); diff != "" {
-						t.Errorf("Authorization decision do not match\ndiff (-got +want):\n%s", diff)
+						t.Errorf("authorization decision do not match\ndiff (-got +want):\n%s", diff)
 					}
 				}
 				if test.eventContent != nil {
 					if diff := cmp.Diff(lb.lastEvent, test.eventContent); diff != "" {
-						t.Errorf("Unexpected event\ndiff (-got + want):\n%s", diff)
+						t.Errorf("unexpected event\ndiff (-got + want):\n%s", diff)
 					}
 				}
 			}()

--- a/test/xds/xds_server_rbac_test.go
+++ b/test/xds/xds_server_rbac_test.go
@@ -457,6 +457,8 @@ func (s) TestRBACHTTPFilter(t *testing.T) {
 			wantStatusEmptyCall: codes.OK,
 			wantStatusUnaryCall: codes.OK,
 			wantAuthzOutcomes:   map[bool]int{true: 2, false: 0},
+			// TODO(gtcooke94) add policy name (RBAC filter name) once
+			// https://github.com/grpc/grpc-go/pull/6327 is merged.
 			eventContent: &audit.Event{
 				FullMethodName: "/grpc.testing.TestService/UnaryCall",
 				MatchedRule:    "anyone",
@@ -698,9 +700,8 @@ func (s) TestRBACHTTPFilter(t *testing.T) {
 					}
 				}
 				if test.eventContent != nil {
-
 					if diff := cmp.Diff(lb.lastEvent, test.eventContent); diff != "" {
-						t.Errorf("Unexpected Message\ndiff (-got + want):\n%s", diff)
+						t.Errorf("Unexpected event\ndiff (-got + want):\n%s", diff)
 					}
 				}
 			}()
@@ -978,7 +979,7 @@ func createXDSTypedStruct(t *testing.T, in map[string]interface{}, name string) 
 	t.Helper()
 	pb, err := structpb.NewStruct(in)
 	if err != nil {
-		t.Fatalf("createXDSTypedStructFailed during structpb.NewStruct: %v", err)
+		t.Fatalf("createXDSTypedStruct Failed during structpb.NewStruct: %v", err)
 	}
 	typedStruct := &v3xdsxdstypepb.TypedStruct{
 		TypeUrl: typeURLPrefix + name,
@@ -986,7 +987,7 @@ func createXDSTypedStruct(t *testing.T, in map[string]interface{}, name string) 
 	}
 	customConfig, err := anypb.New(typedStruct)
 	if err != nil {
-		t.Fatalf("createXDSTypedStructFailed during anypb.New: %v", err)
+		t.Fatalf("createXDSTypedStruct Failed during anypb.New: %v", err)
 	}
 	return customConfig
 }

--- a/test/xds/xds_server_rbac_test.go
+++ b/test/xds/xds_server_rbac_test.go
@@ -696,12 +696,12 @@ func (s) TestRBACHTTPFilter(t *testing.T) {
 
 				if test.wantAuthzOutcomes != nil {
 					if diff := cmp.Diff(lb.authzDecisionStat, test.wantAuthzOutcomes); diff != "" {
-						t.Errorf("authorization decision do not match\ndiff (-got +want):\n%s", diff)
+						t.Fatalf("authorization decision do not match\ndiff (-got +want):\n%s", diff)
 					}
 				}
 				if test.eventContent != nil {
 					if diff := cmp.Diff(lb.lastEvent, test.eventContent); diff != "" {
-						t.Errorf("unexpected event\ndiff (-got + want):\n%s", diff)
+						t.Fatalf("unexpected event\ndiff (-got +want):\n%s", diff)
 					}
 				}
 			}()

--- a/test/xds/xds_server_rbac_test.go
+++ b/test/xds/xds_server_rbac_test.go
@@ -456,7 +456,7 @@ func (s) TestRBACHTTPFilter(t *testing.T) {
 			},
 			wantStatusEmptyCall: codes.OK,
 			wantStatusUnaryCall: codes.OK,
-			wantAuthzOutcomes:   map[bool]int{true: 4, false: 0},
+			wantAuthzOutcomes:   map[bool]int{true: 2, false: 0},
 			eventContent: &audit.Event{
 				FullMethodName: "/grpc.testing.TestService/UnaryCall",
 				MatchedRule:    "anyone",
@@ -630,9 +630,8 @@ func (s) TestRBACHTTPFilter(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			func() {
-				// TODO add check for these stats
 				lb := &loggerBuilder{
-					authzDecisionStat: map[bool]int{true: 2, false: 0},
+					authzDecisionStat: map[bool]int{true: 0, false: 0},
 					lastEvent:         &audit.Event{},
 				}
 				audit.RegisterLoggerBuilder(lb)


### PR DESCRIPTION
This PR adds testing for audit logging logic to the existing RBAC tests. It very closely matches the tests for the authz path - https://github.com/grpc/grpc-go/pull/6304

I've currently only added a very basic test of the audit logger - the purpose here is to make sure that we can construct an audit logger through the xds path and it works.
I'm open to adding test cases for the various combinations of audit logging and authorization policies, but I think that's not really what we are testing here, and it's a pretty explosive combination and pollutes the test (if it's not necessary). All these cases should be covered in other tests like the unit tests and the authz path tests. @dfawley @easwars what do you think? I see compelling reasons for either choice.

RELEASE NOTES: N/A