### PR TITLE
benchmark: Add support for Poisson load in benchmark client

### DIFF
--- a/benchmark/worker/benchmark_client.go
+++ b/benchmark/worker/benchmark_client.go
@@ -299,7 +299,6 @@ func (bc *benchmarkClient) doCloseLoopUnary(conns []*grpc.ClientConn, rpcCountPe
 					})
 				}
 
-
 			}(idx)
 		}
 	}
@@ -363,7 +362,7 @@ func (bc *benchmarkClient) poissonUnary(client testgrpc.BenchmarkServiceClient, 
 		bc.lockingHistograms[idx].add(int64(elapse))
 	}()
 	timeBetweenRPCs := time.Duration((grpcrand.ExpFloat64() / lambda) * float64(time.Second))
-	time.AfterFunc(timeBetweenRPCs, func(){
+	time.AfterFunc(timeBetweenRPCs, func() {
 		bc.poissonUnary(client, idx, reqSize, respSize, lambda)
 	})
 }
@@ -378,7 +377,7 @@ func (bc *benchmarkClient) poissonStreaming(stream testgrpc.BenchmarkService_Str
 		bc.lockingHistograms[idx].add(int64(elapse))
 	}()
 	timeBetweenRPCs := time.Duration((grpcrand.ExpFloat64() / lambda) * float64(time.Second))
-	time.AfterFunc(timeBetweenRPCs, func(){
+	time.AfterFunc(timeBetweenRPCs, func() {
 		bc.poissonStreaming(stream, idx, reqSize, respSize, lambda, doRPC)
 	})
 }

--- a/internal/grpcrand/grpcrand.go
+++ b/internal/grpcrand/grpcrand.go
@@ -80,6 +80,13 @@ func Uint32() uint32 {
 	return r.Uint32()
 }
 
+// ExpFloat64 implements rand.ExpFloat64 on the grpcrand global source.
+func ExpFloat64() float64 {
+	mu.Lock()
+	defer mu.Unlock()
+	return r.ExpFloat64()
+}
+
 // Shuffle implements rand.Shuffle on the grpcrand global source.
 var Shuffle = func(n int, f func(int, int)) {
 	mu.Lock()

--- a/xds/internal/balancer/outlierdetection/balancer.go
+++ b/xds/internal/balancer/outlierdetection/balancer.go
@@ -47,7 +47,7 @@ import (
 
 // Globals to stub out in tests.
 var (
-	afterFunc = time.AfterFunc
+	afterFunc = time.AfterFunc // it's fine to do a goroutine
 	now       = time.Now
 )
 

--- a/xds/internal/balancer/outlierdetection/balancer.go
+++ b/xds/internal/balancer/outlierdetection/balancer.go
@@ -47,7 +47,7 @@ import (
 
 // Globals to stub out in tests.
 var (
-	afterFunc = time.AfterFunc // it's fine to do a goroutine
+	afterFunc = time.AfterFunc
 	now       = time.Now
 )
 


### PR DESCRIPTION
This PR adds support for Poisson Load in the benchmark client. This is needed to put gRPC-Go on the xDS benchmarking dashboard.

RELEASE NOTES:
* benchmark: Add support for Poisson load in benchmark client