### PR TITLE
xds: clusterresolver e2e test cleanup

### DIFF
--- a/internal/testutils/xds/e2e/clientresources.go
+++ b/internal/testutils/xds/e2e/clientresources.go
@@ -537,7 +537,8 @@ type LocalityOptions struct {
 // BackendOptions contains options to configure individual backends in a
 // locality.
 type BackendOptions struct {
-	// Port number on which the backend is accepting connections.
+	// Port number on which the backend is accepting connections. All backends
+	// are expected to run on localhost, hence host name is not stored here.
 	Port uint32
 	// Health status of the backend. Default is UNKNOWN which is treated the
 	// same as HEALTHY.

--- a/internal/testutils/xds/e2e/clientresources.go
+++ b/internal/testutils/xds/e2e/clientresources.go
@@ -526,10 +526,22 @@ func ClusterResourceWithOptions(opts ClusterOptions) *v3clusterpb.Cluster {
 
 // LocalityOptions contains options to configure a Locality.
 type LocalityOptions struct {
-	// Ports is a set of ports on "localhost" belonging to this locality.
-	Ports []uint32
+	// Name is the unique locality name.
+	Name string
 	// Weight is the weight of the locality, used for load balancing.
 	Weight uint32
+	// Backends is a set of backends belonging to this locality.
+	Backends []BackendOptions
+}
+
+// BackendOptions contains options to configure individual backends in a
+// locality.
+type BackendOptions struct {
+	// Port number on which the backend is accepting connections.
+	Port uint32
+	// Health status of the backend. Default is UNKNOWN which is treated the
+	// same as HEALTHY.
+	HealthStatus v3corepb.HealthStatus
 }
 
 // EndpointOptions contains options to configure an Endpoint (or
@@ -550,13 +562,17 @@ type EndpointOptions struct {
 
 // DefaultEndpoint returns a basic xds Endpoint resource.
 func DefaultEndpoint(clusterName string, host string, ports []uint32) *v3endpointpb.ClusterLoadAssignment {
+	var bOpts []BackendOptions
+	for _, p := range ports {
+		bOpts = append(bOpts, BackendOptions{Port: p})
+	}
 	return EndpointResourceWithOptions(EndpointOptions{
 		ClusterName: clusterName,
 		Host:        host,
 		Localities: []LocalityOptions{
 			{
-				Ports:  ports,
-				Weight: 1,
+				Backends: bOpts,
+				Weight:   1,
 			},
 		},
 	})
@@ -568,16 +584,18 @@ func EndpointResourceWithOptions(opts EndpointOptions) *v3endpointpb.ClusterLoad
 	var endpoints []*v3endpointpb.LocalityLbEndpoints
 	for i, locality := range opts.Localities {
 		var lbEndpoints []*v3endpointpb.LbEndpoint
-		for _, port := range locality.Ports {
+		for _, b := range locality.Backends {
 			lbEndpoints = append(lbEndpoints, &v3endpointpb.LbEndpoint{
 				HostIdentifier: &v3endpointpb.LbEndpoint_Endpoint{Endpoint: &v3endpointpb.Endpoint{
 					Address: &v3corepb.Address{Address: &v3corepb.Address_SocketAddress{
 						SocketAddress: &v3corepb.SocketAddress{
 							Protocol:      v3corepb.SocketAddress_TCP,
 							Address:       opts.Host,
-							PortSpecifier: &v3corepb.SocketAddress_PortValue{PortValue: port}},
+							PortSpecifier: &v3corepb.SocketAddress_PortValue{PortValue: b.Port},
+						},
 					}},
 				}},
+				HealthStatus:        b.HealthStatus,
 				LoadBalancingWeight: &wrapperspb.UInt32Value{Value: 1},
 			})
 		}

--- a/test/xds/xds_client_custom_lb_test.go
+++ b/test/xds/xds_client_custom_lb_test.go
@@ -213,12 +213,12 @@ func (s) TestWrrLocality(t *testing.T) {
 					Host:        "localhost",
 					Localities: []e2e.LocalityOptions{
 						{
-							Ports:  []uint32{port1, port2},
-							Weight: 1,
+							Backends: []e2e.BackendOptions{{Port: port1}, {Port: port2}},
+							Weight:   1,
 						},
 						{
-							Ports:  []uint32{port3, port4, port5},
-							Weight: 2,
+							Backends: []e2e.BackendOptions{{Port: port3}, {Port: port4}, {Port: port5}},
+							Weight:   2,
 						},
 					},
 				})},

--- a/xds/internal/balancer/clusterimpl/tests/balancer_test.go
+++ b/xds/internal/balancer/clusterimpl/tests/balancer_test.go
@@ -116,8 +116,8 @@ func (s) TestConfigUpdateWithSameLoadReportingServerConfig(t *testing.T) {
 			Host:        "localhost",
 			Localities: []e2e.LocalityOptions{
 				{
-					Ports:  []uint32{testutils.ParsePort(t, server.Address)},
-					Weight: 1,
+					Backends: []e2e.BackendOptions{{Port: testutils.ParsePort(t, server.Address)}},
+					Weight:   1,
 				},
 			},
 			DropPercents: map[string]int{"test-drop-everything": 100},


### PR DESCRIPTION
Added better support for locality and backend options in the `e2e` package, and cleaned up custom endpoint resource creation logic in `xds/internal/balancer/clusterresolver/e2e_test/eds_impl_test.go`.

RELEASE NOTES: none