### PR TITLE
[PSM interop] Don't fail target if sub-target already failed (v1.48.x backport)

### DIFF
--- a/test/kokoro/xds_url_map.sh
+++ b/test/kokoro/xds_url_map.sh
@@ -141,7 +141,7 @@ main() {
   build_docker_images_if_needed
   # Run tests
   cd "${TEST_DRIVER_FULL_DIR}"
-  run_test url_map
+  run_test url_map || echo "Failed url_map test"
 }
 
 main "$@"


### PR DESCRIPTION
Backport of #6390 to v1.48.x.
---
We don't want file multiple bugs if any of the sub-tests of the `url_map` test fails.

The same change in core: https://github.com/grpc/grpc/pull/33520.

RELEASE NOTES: N/A