### PR TITLE
xds: Fail xDS Server Serve() if called after Stop() or GracefulStop()

### DIFF
--- a/xds/server.go
+++ b/xds/server.go
@@ -173,6 +173,9 @@ func (s *GRPCServer) GetServiceInfo() map[string]grpc.ServiceInfo {
 func (s *GRPCServer) initXDSClient() error {
 	s.clientMu.Lock()
 	defer s.clientMu.Unlock()
+	if s.quit.HasFired() {
+		return grpc.ErrServerStopped
+	}
 
 	if s.xdsC != nil {
 		return nil
@@ -332,6 +335,8 @@ func (s *GRPCServer) handleServingModeChanges(updateCh *buffer.Unbounded) {
 // corresponding pending RPCs on the client side will get notified by connection
 // errors.
 func (s *GRPCServer) Stop() {
+	s.clientMu.Lock()
+	defer s.clientMu.Unlock()
 	s.quit.Fire()
 	s.gs.Stop()
 	if s.xdsC != nil {
@@ -343,6 +348,8 @@ func (s *GRPCServer) Stop() {
 // from accepting new connections and RPCs and blocks until all the pending RPCs
 // are finished.
 func (s *GRPCServer) GracefulStop() {
+	s.clientMu.Lock()
+	defer s.clientMu.Unlock()
 	s.quit.Fire()
 	s.gs.GracefulStop()
 	if s.xdsC != nil {

--- a/xds/server_test.go
+++ b/xds/server_test.go
@@ -930,7 +930,7 @@ func (s) TestServeReturnsErrorAfterClose(t *testing.T) {
 }
 
 // TestServeAndCloseDoNotRace tests that Serve and Close on the xDS Server do
-// not race and leak the xDS Client. A race would be found by the leak checker.
+// not race and leak the xDS Client. A leak would be found by the leak checker.
 func (s) TestServeAndCloseDoNotRace(t *testing.T) {
 	cleanup := setupClientOverride(t)
 	defer cleanup()


### PR DESCRIPTION
Fixes #5838.

This PR fails Serve() if called after Stop() or GracefulStop(). This is important because Serve() eventually increments the global singleton xDS Client Ref, and thus if called without a corresponding cleanup, Stop() or GracefulStop(), the singleton xDS Client will eventually leak.

RELEASE NOTES: N/A