### PR TITLE
stats: Add RPC event for blocking for a picker update

### DIFF
--- a/clientconn.go
+++ b/clientconn.go
@@ -745,7 +745,7 @@ func (cc *ClientConn) waitForResolvedAddrs(ctx context.Context) error {
 	select {
 	case <-cc.firstResolveEvent.Done():
 		for _, sh := range cc.dopts.copts.StatsHandlers {
-			sh.HandleRPC(ctx, &stats.ResolverResolved{})
+			sh.HandleRPC(ctx, &stats.InitialResolverResult{})
 		}
 		return nil
 	case <-ctx.Done():

--- a/clientconn.go
+++ b/clientconn.go
@@ -42,7 +42,6 @@ import (
 	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/resolver"
 	"google.golang.org/grpc/serviceconfig"
-	"google.golang.org/grpc/stats"
 	"google.golang.org/grpc/status"
 
 	_ "google.golang.org/grpc/balancer/roundrobin"           // To register roundrobin.

--- a/clientconn.go
+++ b/clientconn.go
@@ -744,9 +744,6 @@ func (cc *ClientConn) waitForResolvedAddrs(ctx context.Context) error {
 	}
 	select {
 	case <-cc.firstResolveEvent.Done():
-		for _, sh := range cc.dopts.copts.StatsHandlers {
-			sh.HandleRPC(ctx, &stats.InitialResolverResult{})
-		}
 		return nil
 	case <-ctx.Done():
 		return status.FromContextError(ctx.Err()).Err()

--- a/picker_wrapper.go
+++ b/picker_wrapper.go
@@ -131,7 +131,7 @@ func (pw *pickerWrapper) pick(ctx context.Context, failfast bool, info balancer.
 				}
 			case <-ch:
 				for _, sh := range pw.statsHandlers {
-					sh.HandleRPC(ctx, &stats.PickerPicked{})
+					sh.HandleRPC(ctx, &stats.PickerUpdated{})
 				}
 
 			}

--- a/picker_wrapper.go
+++ b/picker_wrapper.go
@@ -130,7 +130,6 @@ func (pw *pickerWrapper) pick(ctx context.Context, failfast bool, info balancer.
 					return nil, balancer.PickResult{}, status.Error(codes.Canceled, errStr)
 				}
 			case <-ch:
-				print("picker blocking stats handler call sent")
 				for _, sh := range pw.statsHandlers {
 					sh.HandleRPC(ctx, &stats.PickerUpdated{})
 				}

--- a/picker_wrapper.go
+++ b/picker_wrapper.go
@@ -130,6 +130,7 @@ func (pw *pickerWrapper) pick(ctx context.Context, failfast bool, info balancer.
 					return nil, balancer.PickResult{}, status.Error(codes.Canceled, errStr)
 				}
 			case <-ch:
+				print("picker blocking stats handler call sent")
 				for _, sh := range pw.statsHandlers {
 					sh.HandleRPC(ctx, &stats.PickerUpdated{})
 				}

--- a/picker_wrapper.go
+++ b/picker_wrapper.go
@@ -40,7 +40,7 @@ type pickerWrapper struct {
 	idle          bool
 	blockingCh    chan struct{}
 	picker        balancer.Picker
-	statsHandlers []stats.Handler
+	statsHandlers []stats.Handler // to record blocking picker calls
 }
 
 func newPickerWrapper(statsHandlers []stats.Handler) *pickerWrapper {
@@ -133,7 +133,6 @@ func (pw *pickerWrapper) pick(ctx context.Context, failfast bool, info balancer.
 				for _, sh := range pw.statsHandlers {
 					sh.HandleRPC(ctx, &stats.PickerUpdated{})
 				}
-
 			}
 			continue
 		}

--- a/picker_wrapper.go
+++ b/picker_wrapper.go
@@ -136,11 +136,13 @@ func (pw *pickerWrapper) pick(ctx context.Context, failfast bool, info balancer.
 		}
 
 		// If the channel is set, it means that the pick call had to wait for a
-		// new picker at some point. Either there was no picker and it received
-		// a new one, or a picker errored with ErrNoSubConnAvailable or errored
-		// with failfast set to false, which will trigger a continue to the next
-		// iteration. In that second case the only way it gets to this codeblock
-		// is to receive a new picker either in UpdateState or the select above.
+		// new picker at some point. Either it's the first iteration and this
+		// function received the first picker, or a picker errored with
+		// ErrNoSubConnAvailable or errored with failfast set to false, which
+		// will trigger a continue to the next iteration. In the first case this
+		// conditional will hit if this call had to block (the channel is set).
+		// In the second case, the only way it will get to this conditional is
+		// if there is a new picker.
 		if ch != nil {
 			for _, sh := range pw.statsHandlers {
 				sh.HandleRPC(ctx, &stats.PickerUpdated{})

--- a/picker_wrapper.go
+++ b/picker_wrapper.go
@@ -137,9 +137,10 @@ func (pw *pickerWrapper) pick(ctx context.Context, failfast bool, info balancer.
 
 		// If the channel is set, it means that the pick call had to wait for a
 		// new picker at some point. Either there was no picker and it received
-		// a new one, or a picker errored with ErrNoSubConnAvailable/error with
-		// failfast false, then continues to next iteration. In that case the
-		// only way it gets to this codeblock is to receive a new picker.
+		// a new one, or a picker errored with ErrNoSubConnAvailable or errored
+		// with failfast set to false, which will trigger a continue to the next
+		// iteration. In that second case the only way it gets to this codeblock
+		// is to receive a new picker either in UpdateState or the select above.
 		if ch != nil {
 			for _, sh := range pw.statsHandlers {
 				sh.HandleRPC(ctx, &stats.PickerUpdated{})

--- a/picker_wrapper_test.go
+++ b/picker_wrapper_test.go
@@ -66,7 +66,7 @@ func (p *testingPicker) Pick(info balancer.PickInfo) (balancer.PickResult, error
 }
 
 func (s) TestBlockingPickTimeout(t *testing.T) {
-	bp := newPickerWrapper()
+	bp := newPickerWrapper(nil)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
 	defer cancel()
 	if _, _, err := bp.pick(ctx, true, balancer.PickInfo{}); status.Code(err) != codes.DeadlineExceeded {
@@ -75,7 +75,7 @@ func (s) TestBlockingPickTimeout(t *testing.T) {
 }
 
 func (s) TestBlockingPick(t *testing.T) {
-	bp := newPickerWrapper()
+	bp := newPickerWrapper(nil)
 	// All goroutines should block because picker is nil in bp.
 	var finishedCount uint64
 	for i := goroutineCount; i > 0; i-- {
@@ -94,7 +94,7 @@ func (s) TestBlockingPick(t *testing.T) {
 }
 
 func (s) TestBlockingPickNoSubAvailable(t *testing.T) {
-	bp := newPickerWrapper()
+	bp := newPickerWrapper(nil)
 	var finishedCount uint64
 	bp.updatePicker(&testingPicker{err: balancer.ErrNoSubConnAvailable, maxCalled: goroutineCount})
 	// All goroutines should block because picker returns no subConn available.
@@ -114,7 +114,7 @@ func (s) TestBlockingPickNoSubAvailable(t *testing.T) {
 }
 
 func (s) TestBlockingPickTransientWaitforready(t *testing.T) {
-	bp := newPickerWrapper()
+	bp := newPickerWrapper(nil)
 	bp.updatePicker(&testingPicker{err: balancer.ErrTransientFailure, maxCalled: goroutineCount})
 	var finishedCount uint64
 	// All goroutines should block because picker returns transientFailure and
@@ -135,7 +135,7 @@ func (s) TestBlockingPickTransientWaitforready(t *testing.T) {
 }
 
 func (s) TestBlockingPickSCNotReady(t *testing.T) {
-	bp := newPickerWrapper()
+	bp := newPickerWrapper(nil)
 	bp.updatePicker(&testingPicker{sc: testSCNotReady, maxCalled: goroutineCount})
 	var finishedCount uint64
 	// All goroutines should block because subConn is not ready.

--- a/stats/opencensus/trace.go
+++ b/stats/opencensus/trace.go
@@ -99,9 +99,9 @@ func populateSpan(ctx context.Context, rs stats.RPCStats, ti *traceInfo) {
 			trace.BoolAttribute("Client", rs.Client),
 			trace.BoolAttribute("FailFast", rs.FailFast),
 		)
-	case *stats.ResolverResolved:
+	case *stats.InitialResolverResult:
 		span.Annotate(nil, "Delayed name resolution complete")
-	case *stats.PickerPicked:
+	case *stats.PickerUpdated:
 		span.Annotate(nil, "Delayed LB pick complete")
 	case *stats.InPayload:
 		// message id - "must be calculated as two different counters starting

--- a/stats/opencensus/trace.go
+++ b/stats/opencensus/trace.go
@@ -99,9 +99,13 @@ func populateSpan(ctx context.Context, rs stats.RPCStats, ti *traceInfo) {
 			trace.BoolAttribute("Client", rs.Client),
 			trace.BoolAttribute("FailFast", rs.FailFast),
 		)
+	case *stats.ResolverResolved:
+		span.Annotate(nil, "Delayed name resolution complete")
+	case *stats.PickerPicked:
+		span.Annotate(nil, "Delayed LB pick complete")
 	case *stats.InPayload:
 		// message id - "must be calculated as two different counters starting
-		// from 1 one for sent messages and one for received messages."
+		// from one for sent messages and one for received messages."
 		mi := atomic.AddUint32(&ti.countRecvMsg, 1)
 		span.AddMessageReceiveEvent(int64(mi), int64(rs.Length), int64(rs.CompressedLength))
 	case *stats.OutPayload:

--- a/stats/opencensus/trace.go
+++ b/stats/opencensus/trace.go
@@ -99,8 +99,6 @@ func populateSpan(ctx context.Context, rs stats.RPCStats, ti *traceInfo) {
 			trace.BoolAttribute("Client", rs.Client),
 			trace.BoolAttribute("FailFast", rs.FailFast),
 		)
-	case *stats.InitialResolverResult:
-		span.Annotate(nil, "Delayed name resolution complete")
 	case *stats.PickerUpdated:
 		span.Annotate(nil, "Delayed LB pick complete")
 	case *stats.InPayload:

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -59,16 +59,15 @@ func (s *Begin) IsClient() bool { return s.Client }
 
 func (s *Begin) isRPCStats() {}
 
-// InitialResolverResult represents an event that the resolved finished
-// resolving if the ClientConn blocks on resolver resolution while performing a
-// RPC.
+// InitialResolverResult represents an event of a resolver finishing resolving
+// if an RPC occurs before the initial resolver result.
 type InitialResolverResult struct{}
 
 // IsClient indicates if the stats information is from client side. Only Client
 // Side interfaces with a resolver, thus always returns true.
-func (irr *InitialResolverResult) IsClient() bool { return true }
+func (*InitialResolverResult) IsClient() bool { return true }
 
-func (irr *InitialResolverResult) isRPCStats() {}
+func (*InitialResolverResult) isRPCStats() {}
 
 // PickerUpdated represents an event that the picker finished picking if the
 // ClientConn blocks on picker picking while performing a RPC.
@@ -76,9 +75,9 @@ type PickerUpdated struct{}
 
 // IsClient indicates if the stats information is from client side. Only Client
 // Side interfaces with a Picker, thus always returns true.
-func (pu *PickerUpdated) IsClient() bool { return true }
+func (*PickerUpdated) IsClient() bool { return true }
 
-func (pu *PickerUpdated) isRPCStats() {}
+func (*PickerUpdated) isRPCStats() {}
 
 // InPayload contains the information for an incoming payload.
 type InPayload struct {

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -59,25 +59,26 @@ func (s *Begin) IsClient() bool { return s.Client }
 
 func (s *Begin) isRPCStats() {}
 
-// ResolverResolved represents an event that the resolved finished resolving if
-// the ClientConn blocks on resolver resolution while performing a RPC.
-type ResolverResolved struct{}
+// InitialResolverResult represents an event that the resolved finished
+// resolving if the ClientConn blocks on resolver resolution while performing a
+// RPC.
+type InitialResolverResult struct{}
 
 // IsClient indicates if the stats information is from client side. Only Client
 // Side interfaces with a resolver, thus always returns true.
-func (rr *ResolverResolved) IsClient() bool { return true }
+func (irr *InitialResolverResult) IsClient() bool { return true }
 
-func (rr *ResolverResolved) isRPCStats() {}
+func (irr *InitialResolverResult) isRPCStats() {}
 
-// PickerPicked represents an event that the picker finished picking if the ClientConn
-// blocks on picker picking while performing a RPC.
-type PickerPicked struct{}
+// PickerUpdated represents an event that the picker finished picking if the
+// ClientConn blocks on picker picking while performing a RPC.
+type PickerUpdated struct{}
 
 // IsClient indicates if the stats information is from client side. Only Client
 // Side interfaces with a Picker, thus always returns true.
-func (pp *PickerPicked) IsClient() bool { return true }
+func (pu *PickerUpdated) IsClient() bool { return true }
 
-func (pp *PickerPicked) isRPCStats() {}
+func (pu *PickerUpdated) isRPCStats() {}
 
 // InPayload contains the information for an incoming payload.
 type InPayload struct {

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -59,6 +59,26 @@ func (s *Begin) IsClient() bool { return s.Client }
 
 func (s *Begin) isRPCStats() {}
 
+// ResolverResolved represents an event that the resolved finished resolving if
+// the ClientConn blocks on resolver resolution while performing a RPC.
+type ResolverResolved struct{}
+
+// IsClient indicates if the stats information is from client side. Only Client
+// Side interfaces with a resolver, thus always returns true.
+func (rr *ResolverResolved) IsClient() bool { return true }
+
+func (rr *ResolverResolved) isRPCStats() {}
+
+// PickerPicked represents an event that the picker finished picking if the ClientConn
+// blocks on picker picking while performing a RPC.
+type PickerPicked struct{}
+
+// IsClient indicates if the stats information is from client side. Only Client
+// Side interfaces with a Picker, thus always returns true.
+func (pp *PickerPicked) IsClient() bool { return true }
+
+func (pp *PickerPicked) isRPCStats() {}
+
 // InPayload contains the information for an incoming payload.
 type InPayload struct {
 	// Client is true if this InPayload is from client side.

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -59,16 +59,6 @@ func (s *Begin) IsClient() bool { return s.Client }
 
 func (s *Begin) isRPCStats() {}
 
-// InitialResolverResult represents an event of a resolver finishing resolving
-// if an RPC occurs before the initial resolver result.
-type InitialResolverResult struct{}
-
-// IsClient indicates if the stats information is from client side. Only Client
-// Side interfaces with a resolver, thus always returns true.
-func (*InitialResolverResult) IsClient() bool { return true }
-
-func (*InitialResolverResult) isRPCStats() {}
-
 // PickerUpdated represents an event that the picker finished picking if the
 // ClientConn blocks on picker picking while performing a RPC.
 type PickerUpdated struct{}

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -59,8 +59,8 @@ func (s *Begin) IsClient() bool { return s.Client }
 
 func (s *Begin) isRPCStats() {}
 
-// PickerUpdated represents an event that the picker finished picking if the
-// ClientConn blocks on picker picking while performing a RPC.
+// PickerUpdated indicates that the LB policy provided a new picker while the
+// RPC was waiting for one.
 type PickerUpdated struct{}
 
 // IsClient indicates if the stats information is from client side. Only Client

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -6401,6 +6401,7 @@ type triggerRPCBlockPickerBalancerBuilder struct{}
 
 func (triggerRPCBlockPickerBalancerBuilder) Build(cc balancer.ClientConn, bOpts balancer.BuildOptions) balancer.Balancer {
 	b := &triggerRPCBlockBalancer{
+		blockingPickerDone: grpcsync.NewEvent(),
 		ClientConn: cc,
 	}
 	// round_robin child to complete balancer tree with a usable leaf policy and
@@ -6439,7 +6440,6 @@ type triggerRPCBlockBalancer struct {
 }
 
 func (bpb *triggerRPCBlockBalancer) UpdateClientConnState(s balancer.ClientConnState) error {
-	bpb.blockingPickerDone = grpcsync.NewEvent()
 	err := bpb.Balancer.UpdateClientConnState(balancer.ClientConnState{
 		ResolverState: s.ResolverState,
 	})

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -6429,7 +6429,7 @@ type bpbConfig struct {
 }
 
 type triggerRPCBlockBalancer struct {
-	stateMu    sync.Mutex
+	stateMu sync.Mutex
 
 	blockingPickerDone *grpcsync.Event
 	// embed a ClientConn to wrap only UpdateState() operation

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -23,6 +23,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -44,6 +45,8 @@ import (
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/hpack"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/balancer"
+	"google.golang.org/grpc/balancer/roundrobin"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/credentials"
@@ -62,6 +65,7 @@ import (
 	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/resolver"
 	"google.golang.org/grpc/resolver/manual"
+	"google.golang.org/grpc/serviceconfig"
 	"google.golang.org/grpc/stats"
 	"google.golang.org/grpc/status"
 	"google.golang.org/grpc/tap"
@@ -82,6 +86,7 @@ const defaultHealthService = "grpc.health.v1.Health"
 
 func init() {
 	channelz.TurnOn()
+	balancer.Register(blockingPickerBalancerBuilder{})
 }
 
 type s struct {
@@ -6362,3 +6367,221 @@ func (s) TestGlobalBinaryLoggingOptions(t *testing.T) {
 		t.Fatalf("want 8 server side binary logging events, got %v", ssbl.mml.events)
 	}
 }
+
+// It's in same package so can reuse component - no different functionality
+
+/*type retryStatsHandler struct {
+
+}*/
+
+
+
+type retryStatsHandler2 struct {
+	mu sync.Mutex
+	s  []stats.RPCStats
+}
+
+func (*retryStatsHandler2) TagRPC(ctx context.Context, _ *stats.RPCTagInfo) context.Context {
+	return ctx
+}
+func (h *retryStatsHandler2) HandleRPC(_ context.Context, s stats.RPCStats) {
+	h.mu.Lock()
+	h.s = append(h.s, s)
+	h.mu.Unlock()
+}
+func (*retryStatsHandler2) TagConn(ctx context.Context, _ *stats.ConnTagInfo) context.Context {
+	return ctx
+}
+func (*retryStatsHandler2) HandleConn(context.Context, stats.ConnStats) {}
+
+// or could reuse same one in other test but remove it since non deterministic
+// either reuse or fork, but need to deal with branch either way
+
+
+
+// send on a channel that it's received picker update stats handler call, this
+// blocks RPC from proceeding (does this already verify)?
+
+type blockingPicker struct {
+	pickDone func()
+}
+
+func (bp *blockingPicker) Pick(pi balancer.PickInfo) (balancer.PickResult, error) {
+	// Just needs one ErrNoSubConnAvaiable to trigger blocking wait
+	// Trigger another UpdateStateCall with this call - perhaps with channel
+	// defer /*send on balancerclosure*/ // balancer.UpdateState(pick firsts picker?)
+	// no, just differ a signal on channel, update ccs
+	// will read that signal and that'll cause a new picker update...
+	print("in blocking picker pick")
+	defer bp.pickDone()
+	return balancer.PickResult{}, balancer.ErrNoSubConnAvailable
+}
+
+// register in init
+const name = "blockingPickerBalancer"
+
+type blockingPickerBalancerBuilder struct{}
+
+func (blockingPickerBalancerBuilder) Build(cc balancer.ClientConn, bOpts balancer.BuildOptions) balancer.Balancer {
+	b := &blockingPickerBalancer{
+		ClientConn: cc,
+	}
+	// round_robin child to complete balancer tree with a usable leaf policy and
+	// have RPCs actually work.
+	builder := balancer.Get(roundrobin.Name)
+	if builder == nil {
+		// Shouldn't happen, defensive programming. Registered from import of
+		// roundrobin package.
+		return nil
+	}
+	rr := builder.Build(b, bOpts)
+	if rr == nil {
+		// Shouldn't happen, defensive programming.
+		return nil
+	}
+	b.Balancer = rr
+	return b
+}
+
+func (blockingPickerBalancerBuilder) ParseConfig(json.RawMessage) (serviceconfig.LoadBalancingConfig, error) {
+	return &bpbConfig{}, nil
+}
+
+func (blockingPickerBalancerBuilder) Name() string {
+	return name
+}
+
+type bpbConfig struct {
+	serviceconfig.LoadBalancingConfig
+}
+
+type blockingPickerBalancer struct {
+	// accessed synchronously
+	childState balancer.State
+
+	blockingPickerDone *grpcsync.Event
+	// embed a ClientConn to wrap only UpdateState() operation
+	balancer.ClientConn
+	// embed a Balancer to wrap only UpdateClientConnState() operation
+	balancer.Balancer
+}
+
+func (bpb *blockingPickerBalancer) UpdateClientConnState(s balancer.ClientConnState) error {
+	bpb.blockingPickerDone = grpcsync.NewEvent()
+	err := bpb.Balancer.UpdateClientConnState(balancer.ClientConnState{
+		ResolverState: s.ResolverState,
+	})
+	// errNoSubConnSent := grpcsync.NewEvent()
+	print("updating client conn state")
+	bpb.ClientConn.UpdateState(balancer.State{
+		ConnectivityState: connectivity.Connecting, // what will trigger that picker codepath?...if connecting doesn't work try ready...
+		Picker: &blockingPicker{
+			pickDone: func(){
+				print("in pickDone()") // gets here so picker must continue
+				print("child")
+				bpb.blockingPickerDone.Fire()
+				bpb.ClientConn.UpdateState(bpb.childState) // get the persisted first pick first picker update sent....this might be non determinisitic then...
+			},
+		},
+	}) // this isn't triggering a picker pick like I thought...
+	// will this get called again if it fails?
+	return err // needs to return this to proceed normally...
+
+	// <- picker channel it closed on that it send on after pick
+	// if event works no need to switch to channel
+	/*<-errNoSubConnSent.Done()
+
+	// update state with a pick first picker - persisted below
+	bpb.ClientConn.UpdateState(bpb.childState) // I think this read is synchronized with the call below
+	return err*/ // will this work without it sending yet...I think so...
+}
+
+func (bpb *blockingPickerBalancer) UpdateState(state balancer.State) {
+	// Persist picker to send later - I think this write is sync with the read above
+	print("in update state")
+	// this will need a mu
+	bpb.childState = state // can come in any time...so guard this?
+	if bpb.blockingPickerDone.HasFired() { // guard first one to get a picker sending ErrNoSubConnAvailable first
+		bpb.ClientConn.UpdateState(bpb.childState) // after the first rr picker update, cc will trigger more, so actually forward these
+	}
+}
+
+func (s) TestPickerBlockingStatsCall(t *testing.T) {
+	sh := &retryStatsHandler2{}
+	ss := &stubserver.StubServer{
+		UnaryCallF: func(ctx context.Context, in *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
+			return &testpb.SimpleResponse{}, nil
+		},
+	}
+	// Does it even need to pass a ServiceConfig?
+
+
+
+	if err := ss.StartServer(); err != nil {
+		t.Fatalf("Error starting endpoint server: %v", err)
+	}
+	defer ss.Stop()
+
+	lbCfgJSON := `{
+  		"loadBalancingConfig": [
+    		{
+      			"blockingPickerBalancer": {}
+    	}
+  	]
+	}`
+
+	sc := internal.ParseServiceConfig.(func(string) *serviceconfig.ParseResult)(lbCfgJSON)
+	mr := manual.NewBuilderWithScheme("pickerupdatedbalancer")
+	defer mr.Close()
+	print("ss.Address when setting: ", ss.Address)
+	mr.InitialState(resolver.State{
+		Addresses: []resolver.Address{
+			{Addr: ss.Address},
+		},
+		ServiceConfig: sc,
+	})
+
+	cc, err := grpc.Dial(mr.Scheme()+":///", grpc.WithResolvers(mr), grpc.WithStatsHandler(sh), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("grpc.Dial() failed: %v", err)
+	}
+	defer cc.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	/*mr.UpdateState(resolver.State{
+		Addresses: []resolver.Address{
+			{Addr: ss.Address},
+		},
+		ServiceConfig: sc,
+	})*/
+	testServiceClient := testgrpc.NewTestServiceClient(cc)
+	// make an rpc - blocks until returns and completes successfully, sync point, both pickers will have been send at that point
+	if _, err := testServiceClient.UnaryCall(ctx, &testpb.SimpleRequest{}); err != nil {
+		t.Fatalf("Unexpected error from UnaryCall: %v", err)
+	}
+
+	// loop over events stats handler has received and make sure picker Picked is there...
+
+	// don't need to grab a mu I think...nothing coming in concurrently from server side
+	var pickerUpdatedCount uint
+	for _, stat := range sh.s {
+		if _, ok := stat.(*stats.PickerUpdated); ok {
+			pickerUpdatedCount++
+		} // other one needs to ignore this type...
+	}
+	// but a pick first shouldn't need to trigger it...
+	if pickerUpdatedCount == 0 { // i think this is non deterministic...?
+		t.Fatalf("sh.pickerUpdated count: %v, want: >0", pickerUpdatedCount)
+	}
+}
+
+
+// lb policy first pick - err no subconn, return value from that picker will cause? queue
+
+// UpdateState triggered by first picker
+
+// Both of those events have gone through when RPC returns as a result...
+// Corresponding logic in gRPC from picker
+
+
+// run above to make sure not non determinisitic...

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -6430,7 +6430,6 @@ type bpbConfig struct {
 
 type triggerRPCBlockBalancer struct {
 	stateMu    sync.Mutex
-	childState balancer.State
 
 	blockingPickerDone *grpcsync.Event
 	// embed a ClientConn to wrap only UpdateState() operation
@@ -6517,7 +6516,7 @@ func (s) TestRPCBlockingOnPickerStatsCall(t *testing.T) {
 			pickerUpdatedCount++
 		}
 	}
-	if pickerUpdatedCount != 2 {
+	if pickerUpdatedCount != 1 {
 		t.Fatalf("sh.pickerUpdated count: %v, want: %v", pickerUpdatedCount, 2)
 	}
 }

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -6467,10 +6467,10 @@ func (bpb *triggerRPCBlockBalancer) UpdateState(state balancer.State) {
 	}
 }
 
-// TestPickerBlockingStatsCall tests the emission of a stats handler call that
-// represents the RPC had to block waiting for a new picker due to
+// TestRPCBlockingOnPickerStatsCall tests the emission of a stats handler call
+// that represents the RPC had to block waiting for a new picker due to
 // ErrNoSubConnAvailable being returned from the first picker call.
-func (s) TestPickerBlockingStatsCall(t *testing.T) {
+func (s) TestRPCBlockingOnPickerStatsCall(t *testing.T) {
 	sh := &statsHandlerRecordEvents{}
 	ss := &stubserver.StubServer{
 		UnaryCallF: func(ctx context.Context, in *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {

--- a/test/retry_test.go
+++ b/test/retry_test.go
@@ -474,6 +474,10 @@ func (*retryStatsHandler) TagRPC(ctx context.Context, _ *stats.RPCTagInfo) conte
 	return ctx
 }
 func (h *retryStatsHandler) HandleRPC(_ context.Context, s stats.RPCStats) {
+	// these calls come in nondeterministically - so can just ignore
+	if _, ok := s.(*stats.PickerUpdated); ok {
+		return
+	}
 	h.mu.Lock()
 	h.s = append(h.s, s)
 	h.mu.Unlock()
@@ -543,8 +547,6 @@ func (s) TestRetryStats(t *testing.T) {
 	handler.mu.Lock()
 	want := []stats.RPCStats{
 		&stats.Begin{},
-		&stats.PickerUpdated{},
-		&stats.PickerUpdated{},
 		&stats.OutHeader{FullMethod: "/grpc.testing.TestService/EmptyCall"},
 		&stats.OutPayload{WireLength: 5},
 		&stats.End{},
@@ -581,7 +583,7 @@ func (s) TestRetryStats(t *testing.T) {
 	// There is a race between receiving the payload (triggered by the
 	// application / gRPC library) and receiving the trailer (triggered at the
 	// transport layer).  Adjust the received stats accordingly if necessary.
-	const tIdx, pIdx = 15, 16
+	const tIdx, pIdx = 13, 14
 	_, okT := handler.s[tIdx].(*stats.InTrailer)
 	_, okP := handler.s[pIdx].(*stats.InPayload)
 	if okT && okP {
@@ -596,11 +598,7 @@ func (s) TestRetryStats(t *testing.T) {
 			t.Fatalf("at position %v: got %T; want %T", i, s, w)
 		}
 		wv, sv := reflect.ValueOf(w).Elem(), reflect.ValueOf(s).Elem()
-		if sv.NumField() == 0 {
-			// Resolver blocking and Picker blocking events have no fields,
-			// isClient() always returns true.
-			continue
-		}
+
 		// Validate that Client is always true
 		if sv.FieldByName("Client").Interface().(bool) != true {
 			t.Fatalf("at position %v: got Client=false; want true", i)
@@ -626,8 +624,8 @@ func (s) TestRetryStats(t *testing.T) {
 	}
 
 	// Validate timings between last Begin and preceding End.
-	end := handler.s[10].(*stats.End)
-	begin := handler.s[11].(*stats.Begin)
+	end := handler.s[8].(*stats.End)
+	begin := handler.s[9].(*stats.Begin)
 	diff := begin.BeginTime.Sub(end.EndTime)
 	if diff < 10*time.Millisecond || diff > 50*time.Millisecond {
 		t.Fatalf("pushback time before final attempt = %v; want ~10ms", diff)

--- a/test/retry_test.go
+++ b/test/retry_test.go
@@ -543,6 +543,8 @@ func (s) TestRetryStats(t *testing.T) {
 	handler.mu.Lock()
 	want := []stats.RPCStats{
 		&stats.Begin{},
+		&stats.PickerPicked{},
+		&stats.PickerPicked{},
 		&stats.OutHeader{FullMethod: "/grpc.testing.TestService/EmptyCall"},
 		&stats.OutPayload{WireLength: 5},
 		&stats.End{},


### PR DESCRIPTION
This PR adds stats events representing blocking resolver resolve and blocking picker pick. The OpenCensus stats handler uses these callouts to add trace annotations, which provide a timestamp for debugging purposes.

Fixes https://github.com/grpc/grpc-go/issues/6418.

RELEASE NOTES:
* stats: Add an RPC event for blocking caused by the LB policy's picker