### PR TITLE
grpc: report connectivity state changes on the ClientConn for Subscribers

### DIFF
--- a/clientconn.go
+++ b/clientconn.go
@@ -597,8 +597,8 @@ func (csm *connectivityStateManager) getNotifyChan() <-chan struct{} {
 
 func (csm *connectivityStateManager) close() {
 	csm.mu.Lock()
+	defer csm.mu.Unlock()
 	csm.pubSub.Stop()
-	csm.mu.Unlock()
 }
 
 // ClientConnInterface defines the functions clients need to perform unary and

--- a/clientconn.go
+++ b/clientconn.go
@@ -602,8 +602,6 @@ func (csm *connectivityStateManager) getNotifyChan() <-chan struct{} {
 }
 
 func (csm *connectivityStateManager) close() {
-	csm.mu.Lock()
-	defer csm.mu.Unlock()
 	csm.pubSub.Stop()
 }
 

--- a/clientconn.go
+++ b/clientconn.go
@@ -526,8 +526,8 @@ func chainStreamClientInterceptors(cc *ClientConn) {
 		chainedInt = func(ctx context.Context, desc *StreamDesc, cc *ClientConn, method string, streamer Streamer, opts ...CallOption) (ClientStream, error) {
 			return interceptors[0](ctx, desc, cc, method, getChainStreamer(interceptors, 0, streamer), opts...)
 		}
-		cc.dopts.streamInt = chainedInt
 	}
+	cc.dopts.streamInt = chainedInt
 }
 
 // getChainStreamer recursively generate the chained client stream constructor.

--- a/clientconn.go
+++ b/clientconn.go
@@ -1210,13 +1210,6 @@ func (cc *ClientConn) ResetConnectBackoff() {
 func (cc *ClientConn) Close() error {
 	defer cc.cancel()
 
-	cc.csMgr.mu.Lock()
-	if cc.csMgr.connectivityStatePubSub != nil {
-		cc.csMgr.connectivityStatePubSub.Stop()
-		cc.csMgr.connectivityStatePubSub = nil
-	}
-	cc.csMgr.mu.Unlock()
-
 	cc.mu.Lock()
 	if cc.conns == nil {
 		cc.mu.Unlock()
@@ -1230,6 +1223,13 @@ func (cc *ClientConn) Close() error {
 	conns := cc.conns
 	cc.conns = nil
 	cc.csMgr.updateState(connectivity.Shutdown)
+
+	cc.csMgr.mu.Lock()
+	if cc.csMgr.connectivityStatePubSub != nil {
+		cc.csMgr.connectivityStatePubSub.Stop()
+		cc.csMgr.connectivityStatePubSub = nil
+	}
+	cc.csMgr.mu.Unlock()
 
 	pWrapper := cc.blockingpicker
 	rWrapper := cc.resolverWrapper

--- a/clientconn.go
+++ b/clientconn.go
@@ -528,8 +528,8 @@ func chainStreamClientInterceptors(cc *ClientConn) {
 		chainedInt = func(ctx context.Context, desc *StreamDesc, cc *ClientConn, method string, streamer Streamer, opts ...CallOption) (ClientStream, error) {
 			return interceptors[0](ctx, desc, cc, method, getChainStreamer(interceptors, 0, streamer), opts...)
 		}
+		cc.dopts.streamInt = chainedInt
 	}
-	cc.dopts.streamInt = chainedInt
 }
 
 // getChainStreamer recursively generate the chained client stream constructor.
@@ -569,9 +569,8 @@ func (csm *connectivityStateManager) updateState(state connectivity.State) {
 		return
 	}
 	csm.state = state
-	if csm.pubSub != nil {
-		csm.pubSub.Publish(state)
-	}
+	csm.pubSub.Publish(state)
+
 	channelz.Infof(logger, csm.channelzID, "Channel Connectivity change to %v", state)
 	if csm.notifyChan != nil {
 		// There are other goroutines waiting on this channel.

--- a/clientconn_test.go
+++ b/clientconn_test.go
@@ -1139,6 +1139,7 @@ func (s) TestReportStateChangesToSubscriber(t *testing.T) {
 	internal.SubscribeToConnectivityStateChanges.(func(cc *ClientConn, s grpcsync.Subscriber) func())(client, s)
 
 	expectedStates := []connectivity.State{
+		connectivity.Ready,
 		connectivity.Idle,
 		connectivity.Connecting,
 		connectivity.Shutdown,

--- a/clientconn_test.go
+++ b/clientconn_test.go
@@ -1136,7 +1136,7 @@ func (s) TestReportStateChangesToSubscriber(t *testing.T) {
 	}
 
 	s := newTestSubscriber()
-	internal.AddConnectivityStateSubscriber.(func(cc *ClientConn, s grpcsync.Subscriber) func())(client, s)
+	internal.SubscribeToConnectivityStateChanges.(func(cc *ClientConn, s grpcsync.Subscriber) func())(client, s)
 
 	expectedStates := []connectivity.State{
 		connectivity.Idle,

--- a/clientconn_test.go
+++ b/clientconn_test.go
@@ -36,6 +36,7 @@ import (
 	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/internal"
 	internalbackoff "google.golang.org/grpc/internal/backoff"
 	"google.golang.org/grpc/internal/grpcsync"
 	"google.golang.org/grpc/internal/grpctest"
@@ -1077,6 +1078,113 @@ func (s) TestDefaultServiceConfig(t *testing.T) {
 	testDefaultServiceConfigWhenResolverServiceConfigDisabled(t, r, addr, js)
 	testDefaultServiceConfigWhenResolverDoesNotReturnServiceConfig(t, r, addr, js)
 	testDefaultServiceConfigWhenResolverReturnInvalidServiceConfig(t, r, addr, js)
+}
+
+type testSubscriber struct {
+	onMsgCh chan connectivity.State
+}
+
+func newTestSubscriber() *testSubscriber {
+	return &testSubscriber{onMsgCh: make(chan connectivity.State, 1)}
+}
+
+func (ts *testSubscriber) OnMessage(msg interface{}) {
+	select {
+	case ts.onMsgCh <- msg.(connectivity.State):
+	default:
+	}
+}
+
+func (s) TestReportStateChangesToSubscriber(t *testing.T) {
+	lis, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("Error while listening. Err: %v", err)
+	}
+	defer lis.Close()
+
+	done := make(chan struct{})
+	sent := make(chan struct{})
+	dialDone := make(chan struct{})
+
+	// Launch the server.
+	go func() {
+		defer func() {
+			close(done)
+		}()
+		conn, err := lis.Accept()
+		if err != nil {
+			t.Errorf("Error while accepting. Err: %v", err)
+			return
+		}
+		defer conn.Close()
+		// Sleep for a little bit to make sure that Dial on client
+		// side blocks until settings are received.
+		time.Sleep(100 * time.Millisecond)
+		framer := http2.NewFramer(conn, conn)
+		close(sent)
+		if err := framer.WriteSettings(http2.Setting{}); err != nil {
+			t.Errorf("Error while writing settings. Err: %v", err)
+			return
+		}
+		<-dialDone // Close conn only after dial returns.
+	}()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	client, err := DialContext(ctx, lis.Addr().String(), WithTransportCredentials(insecure.NewCredentials()), WithBlock())
+	if err != nil {
+		t.Fatalf("Error while dialing. Err: %v", err)
+	}
+
+	s := newTestSubscriber()
+	internal.AddConnectivityStateSubscriber.(func(cc *ClientConn, s grpcsync.Subscriber) func())(client, s)
+
+	expectedStates := []connectivity.State{
+		connectivity.Idle,
+		connectivity.Connecting,
+		connectivity.Shutdown,
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		for _, expectedState := range expectedStates {
+			select {
+			case actualState := <-s.onMsgCh:
+				if actualState != expectedState {
+					t.Errorf("Received unexpected state: %q; want: %q", actualState, expectedState)
+				}
+			case <-time.After(defaultTestTimeout):
+				t.Error("Timeout when expecting the onMessage() callback to be invoked")
+			}
+			if t.Failed() {
+				break
+			}
+		}
+		wg.Done()
+	}()
+
+	close(dialDone)
+
+	go func() {
+		client.WaitForStateChange(ctx, connectivity.Ready)
+		client.Connect()
+		client.WaitForStateChange(ctx, connectivity.Idle)
+
+		select {
+		case <-sent:
+		default:
+			t.Errorf("Dial returned before server settings were sent")
+		}
+		<-done
+
+		client.Close()
+		wg.Done()
+	}()
+
+	wg.Wait()
+	if t.Failed() {
+		t.FailNow()
+	}
 }
 
 func verifyWaitForReadyEqualsTrue(cc *ClientConn) bool {

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -122,6 +122,9 @@ var (
 	// deleted or changed.
 	BinaryLogger interface{} // func(binarylog.Logger) grpc.ServerOption
 
+	// AddConnectivityStateSubscriber adds a grpcsync.Subscriber to a provided grpc.ClientConn
+	AddConnectivityStateSubscriber interface{} // func(*grpc.ClientConn, grpcsync.Subscriber)
+
 	// NewXDSResolverWithConfigForTesting creates a new xds resolver builder using
 	// the provided xds bootstrap config instead of the global configuration from
 	// the supported environment variables.  The resolver.Builder is meant to be

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -122,8 +122,8 @@ var (
 	// deleted or changed.
 	BinaryLogger interface{} // func(binarylog.Logger) grpc.ServerOption
 
-	// AddConnectivityStateSubscriber adds a grpcsync.Subscriber to a provided grpc.ClientConn
-	AddConnectivityStateSubscriber interface{} // func(*grpc.ClientConn, grpcsync.Subscriber)
+	// SubscribeToConnectivityStateChanges adds a grpcsync.Subscriber to a provided grpc.ClientConn
+	SubscribeToConnectivityStateChanges interface{} // func(*grpc.ClientConn, grpcsync.Subscriber)
 
 	// NewXDSResolverWithConfigForTesting creates a new xds resolver builder using
 	// the provided xds bootstrap config instead of the global configuration from

--- a/test/connectivity_state_updates_test.go
+++ b/test/connectivity_state_updates_test.go
@@ -1,0 +1,121 @@
+/*
+ *
+ * Copyright 2023 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/connectivity"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/internal"
+	"google.golang.org/grpc/internal/grpcsync"
+	"google.golang.org/grpc/internal/stubserver"
+	"google.golang.org/grpc/resolver"
+	"google.golang.org/grpc/resolver/manual"
+)
+
+type testSubscriber struct {
+	onMsgCh chan connectivity.State
+}
+
+func newTestSubscriber() *testSubscriber {
+	return &testSubscriber{onMsgCh: make(chan connectivity.State, 1)}
+}
+
+func (ts *testSubscriber) OnMessage(msg interface{}) {
+	select {
+	case ts.onMsgCh <- msg.(connectivity.State):
+	default:
+	}
+}
+
+func (s) TestConnectivityStateUpdates(t *testing.T) {
+	// Create a ClientConn with a short idle_timeout.
+	r := manual.NewBuilderWithScheme("whatever")
+	dopts := []grpc.DialOption{
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithResolvers(r),
+		grpc.WithIdleTimeout(defaultTestShortIdleTimeout),
+		grpc.WithDefaultServiceConfig(`{"loadBalancingConfig": [{"round_robin":{}}]}`),
+	}
+	cc, err := grpc.Dial(r.Scheme()+":///test.server", dopts...)
+	if err != nil {
+		t.Fatalf("grpc.Dial() failed: %v", err)
+	}
+	t.Cleanup(func() { cc.Close() })
+
+	// Start a test backend and push an address update via the resolver.
+	backend := stubserver.StartTestService(t, nil)
+	t.Cleanup(backend.Stop)
+
+	s := newTestSubscriber()
+	internal.SubscribeToConnectivityStateChanges.(func(cc *grpc.ClientConn, s grpcsync.Subscriber) func())(cc, s)
+
+	expectedStates := []connectivity.State{
+		connectivity.Connecting,
+		connectivity.Ready,
+		connectivity.Idle,
+		connectivity.Shutdown,
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		for _, expectedState := range expectedStates {
+			select {
+			case actualState := <-s.onMsgCh:
+				if actualState != expectedState {
+					t.Errorf("Received unexpected state: %q; want: %q", actualState, expectedState)
+				}
+			case <-time.After(defaultTestTimeout):
+				t.Error("Timeout when expecting the onMessage() callback to be invoked")
+			}
+			if t.Failed() {
+				break
+			}
+		}
+		wg.Done()
+	}()
+
+	go func() {
+		r.UpdateState(resolver.State{Addresses: []resolver.Address{{Addr: backend.Address}}})
+
+		// Verify that the ClientConn moves to READY.
+		ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+		defer cancel()
+		awaitState(ctx, t, cc, connectivity.Ready)
+
+		// Verify that the ClientConn moves to IDLE as there is no activity.
+		awaitState(ctx, t, cc, connectivity.Idle)
+
+		cc.Close()
+		awaitState(ctx, t, cc, connectivity.Shutdown)
+
+		wg.Done()
+	}()
+
+	wg.Wait()
+	if t.Failed() {
+		t.FailNow()
+	}
+}

--- a/test/connectivity_state_updates_test.go
+++ b/test/connectivity_state_updates_test.go
@@ -66,7 +66,6 @@ func (s) TestConnectivityStateUpdates(t *testing.T) {
 	s := newTestSubscriber()
 	internal.SubscribeToConnectivityStateChanges.(func(cc *grpc.ClientConn, s grpcsync.Subscriber) func())(cc, s)
 
-	// Start a test backend and push an address update via the resolver.
 	backend := stubserver.StartTestService(t, nil)
 	t.Cleanup(backend.Stop)
 
@@ -81,11 +80,11 @@ func (s) TestConnectivityStateUpdates(t *testing.T) {
 	wg.Add(2)
 	go func() {
 		defer wg.Done()
-		for _, expectedState := range wantStates {
+		for _, wantState := range wantStates {
 			select {
 			case gotState := <-s.onMsgCh:
-				if gotState != expectedState {
-					t.Errorf("Received unexpected state: %q; want: %q", gotState, expectedState)
+				if gotState != wantState {
+					t.Errorf("Received unexpected state: %q; want: %q", gotState, wantState)
 				}
 			case <-time.After(defaultTestTimeout):
 				t.Error("Timeout when expecting the onMessage() callback to be invoked")

--- a/test/connectivity_state_updates_test.go
+++ b/test/connectivity_state_updates_test.go
@@ -20,7 +20,6 @@ package test
 
 import (
 	"context"
-	"sync"
 	"testing"
 	"time"
 
@@ -105,7 +104,7 @@ func (s) TestConnectivityStateUpdates(t *testing.T) {
 
 	cc.Close()
 	awaitState(ctx, t, cc, connectivity.Shutdown)
-	
+
 	<-doneCh
 	if t.Failed() {
 		t.FailNow()


### PR DESCRIPTION
This PR adds a logic to report connectivity state changes on the ClientConn for Subscribers.

Please refer to https://github.com/grpc/grpc-go/pull/6036#issuecomment-1488895547 in https://github.com/grpc/grpc-go/pull/6036 . Original issue is https://github.com/grpc/grpc-go/issues/5818.

RELEASE NOTES: none