### PR TITLE
xds: require EDS service name in new-style CDS clusters (gRFC A47)

### DIFF
--- a/xds/internal/xdsclient/xdsresource/unmarshal_cds.go
+++ b/xds/internal/xdsclient/xdsresource/unmarshal_cds.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"net"
 	"strconv"
+	"strings"
 	"time"
 
 	v3clusterpb "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
@@ -173,6 +174,9 @@ func validateClusterAndConstructClusterUpdate(cluster *v3clusterpb.Cluster) (Clu
 		}
 		ret.ClusterType = ClusterTypeEDS
 		ret.EDSServiceName = cluster.GetEdsClusterConfig().GetServiceName()
+		if strings.HasPrefix(ret.ClusterName, "xdstp:") && ret.EDSServiceName == "" {
+			return ClusterUpdate{}, fmt.Errorf("CDS's EDS service name is not set with a new-style cluster name: %+v", cluster)
+		}
 		return ret, nil
 	case cluster.GetType() == v3clusterpb.Cluster_LOGICAL_DNS:
 		if !envconfig.XDSAggregateAndDNS {

--- a/xds/internal/xdsclient/xdsresource/unmarshal_cds_test.go
+++ b/xds/internal/xdsclient/xdsresource/unmarshal_cds_test.go
@@ -1347,6 +1347,23 @@ func (s) TestUnmarshalCluster(t *testing.T) {
 				Raw: v3ClusterAnyWithEDSConfigSourceSelf,
 			},
 		},
+		{
+			name: "xdstp cluster resource with unset EDS service name",
+			resource: testutils.MarshalAny(&v3clusterpb.Cluster{
+				Name:                 "xdstp:foo",
+				ClusterDiscoveryType: &v3clusterpb.Cluster_Type{Type: v3clusterpb.Cluster_EDS},
+				EdsClusterConfig: &v3clusterpb.Cluster_EdsClusterConfig{
+					EdsConfig: &v3corepb.ConfigSource{
+						ConfigSourceSpecifier: &v3corepb.ConfigSource_Ads{
+							Ads: &v3corepb.AggregatedConfigSource{},
+						},
+					},
+					ServiceName: "",
+				},
+			}),
+			wantName: "xdstp:foo",
+			wantErr:  true,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
This PR implements the changes described by https://github.com/grpc/proposal/pull/377

RELEASE NOTES:
* xds: require EDS service name to be set in a CDS cluster with an 'xdstp' resource name (gRFC A47)