### PR TITLE
clusterresolver: add logs for dns discovery mechanism error cases

### DIFF
--- a/xds/internal/balancer/clusterresolver/resource_resolver.go
+++ b/xds/internal/balancer/clusterresolver/resource_resolver.go
@@ -177,7 +177,7 @@ func (rr *resourceResolver) updateMechanisms(mechanisms []DiscoveryMechanism) {
 		case DiscoveryMechanismTypeEDS:
 			resolver = newEDSResolver(dmKey.name, rr.parent.xdsClient, rr, rr.logger)
 		case DiscoveryMechanismTypeLogicalDNS:
-			resolver = newDNSResolver(dmKey.name, rr)
+			resolver = newDNSResolver(dmKey.name, rr, rr.logger)
 		}
 		dmAndResolver = discoveryMechanismAndResolver{
 			dm:           dm,

--- a/xds/internal/balancer/clusterresolver/resource_resolver_dns.go
+++ b/xds/internal/balancer/clusterresolver/resource_resolver_dns.go
@@ -23,6 +23,8 @@ import (
 	"net/url"
 	"sync"
 
+	"google.golang.org/grpc/internal/grpclog"
+	"google.golang.org/grpc/internal/pretty"
 	"google.golang.org/grpc/resolver"
 	"google.golang.org/grpc/serviceconfig"
 )
@@ -42,6 +44,7 @@ type dnsDiscoveryMechanism struct {
 	target           string
 	topLevelResolver topLevelResolver
 	dnsR             resolver.Resolver
+	logger           *grpclog.PrefixLogger
 
 	mu             sync.Mutex
 	addrs          []string
@@ -64,10 +67,11 @@ type dnsDiscoveryMechanism struct {
 //
 // The `dnsR` field is unset if we run into erros in this function. Therefore, a
 // nil check is required wherever we access that field.
-func newDNSResolver(target string, topLevelResolver topLevelResolver) *dnsDiscoveryMechanism {
+func newDNSResolver(target string, topLevelResolver topLevelResolver, logger *grpclog.PrefixLogger) *dnsDiscoveryMechanism {
 	ret := &dnsDiscoveryMechanism{
 		target:           target,
 		topLevelResolver: topLevelResolver,
+		logger:           logger,
 	}
 	u, err := url.Parse("dns:///" + target)
 	if err != nil {
@@ -116,6 +120,10 @@ func (dr *dnsDiscoveryMechanism) stop() {
 // updates from the real DNS resolver.
 
 func (dr *dnsDiscoveryMechanism) UpdateState(state resolver.State) error {
+	if dr.logger.V(2) {
+		dr.logger.Infof("DNS discovery mechanism for resource %q reported an update: %s", dr.target, pretty.ToJSON(state))
+	}
+
 	dr.mu.Lock()
 	addrs := make([]string, len(state.Addresses))
 	for i, a := range state.Addresses {
@@ -130,6 +138,10 @@ func (dr *dnsDiscoveryMechanism) UpdateState(state resolver.State) error {
 }
 
 func (dr *dnsDiscoveryMechanism) ReportError(err error) {
+	if dr.logger.V(2) {
+		dr.logger.Infof("DNS discovery mechanism for resource %q reported error: %v", dr.target, err)
+	}
+
 	dr.topLevelResolver.onError(err)
 }
 


### PR DESCRIPTION
Ran into the absence of these logs when debugging a directpath issue. We currently have such logs for the EDS discovery mechanism which were recently added.

RELEASE NOTES: none