### PR TITLE
xds/server: create the xDS client when the xDS enabled gRPC server is created

### DIFF
--- a/examples/features/xds/server/main.go
+++ b/examples/features/xds/server/main.go
@@ -85,7 +85,10 @@ func main() {
 		}
 	}
 
-	greeterServer := xds.NewGRPCServer(grpc.Creds(creds))
+	greeterServer, err := xds.NewGRPCServer(grpc.Creds(creds))
+	if err != nil {
+		log.Fatalf("Failed to create an xDS enabled gRPC server: %v", err)
+	}
 	pb.RegisterGreeterServer(greeterServer, &server{serverName: determineHostname()})
 
 	healthPort := fmt.Sprintf(":%d", *port+1)

--- a/internal/testutils/xds/e2e/setup_management_server.go
+++ b/internal/testutils/xds/e2e/setup_management_server.go
@@ -82,13 +82,13 @@ func DefaultBootstrapContents(nodeID, serverURI string) ([]byte, error) {
 	// Create a directory to hold certs and key files used on the server side.
 	serverDir, err := createTmpDirWithFiles("testServerSideXDS*", "x509/server1_cert.pem", "x509/server1_key.pem", "x509/client_ca_cert.pem")
 	if err != nil {
-		return nil, fmt.Errorf("Failed to create bootstrap configuration: %v", err)
+		return nil, fmt.Errorf("failed to create bootstrap configuration: %v", err)
 	}
 
 	// Create a directory to hold certs and key files used on the client side.
 	clientDir, err := createTmpDirWithFiles("testClientSideXDS*", "x509/client1_cert.pem", "x509/client1_key.pem", "x509/server_ca_cert.pem")
 	if err != nil {
-		return nil, fmt.Errorf("Failed to create bootstrap configuration: %v", err)
+		return nil, fmt.Errorf("failed to create bootstrap configuration: %v", err)
 	}
 
 	// Create certificate providers section of the bootstrap config with entries
@@ -106,7 +106,7 @@ func DefaultBootstrapContents(nodeID, serverURI string) ([]byte, error) {
 		ServerListenerResourceNameTemplate: ServerListenerResourceNameTemplate,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("Failed to create bootstrap configuration: %v", err)
+		return nil, fmt.Errorf("failed to create bootstrap configuration: %v", err)
 	}
 	return bs, nil
 }

--- a/internal/testutils/xds/e2e/setup_management_server.go
+++ b/internal/testutils/xds/e2e/setup_management_server.go
@@ -20,6 +20,7 @@ package e2e
 
 import (
 	"encoding/json"
+	"fmt"
 	"path"
 	"testing"
 
@@ -55,40 +56,12 @@ func SetupManagementServer(t *testing.T, opts ManagementServerOptions) (*Managem
 		}
 	}()
 
-	// Create a directory to hold certs and key files used on the server side.
-	serverDir, err := createTmpDirWithFiles("testServerSideXDS*", "x509/server1_cert.pem", "x509/server1_key.pem", "x509/client_ca_cert.pem")
-	if err != nil {
-		server.Stop()
-		t.Fatal(err)
-	}
-
-	// Create a directory to hold certs and key files used on the client side.
-	clientDir, err := createTmpDirWithFiles("testClientSideXDS*", "x509/client1_cert.pem", "x509/client1_key.pem", "x509/server_ca_cert.pem")
-	if err != nil {
-		server.Stop()
-		t.Fatal(err)
-	}
-
-	// Create certificate providers section of the bootstrap config with entries
-	// for both the client and server sides.
-	cpc := map[string]json.RawMessage{
-		ServerSideCertProviderInstance: DefaultFileWatcherConfig(path.Join(serverDir, certFile), path.Join(serverDir, keyFile), path.Join(serverDir, rootFile)),
-		ClientSideCertProviderInstance: DefaultFileWatcherConfig(path.Join(clientDir, certFile), path.Join(clientDir, keyFile), path.Join(clientDir, rootFile)),
-	}
-
-	// Create a bootstrap file in a temporary directory.
 	nodeID := uuid.New().String()
-	bootstrapContents, err := bootstrap.Contents(bootstrap.Options{
-		NodeID:                             nodeID,
-		ServerURI:                          server.Address,
-		CertificateProviders:               cpc,
-		ServerListenerResourceNameTemplate: ServerListenerResourceNameTemplate,
-	})
+	bootstrapContents, err := DefaultBootstrapContents(nodeID, server.Address)
 	if err != nil {
 		server.Stop()
-		t.Fatalf("Failed to create bootstrap file: %v", err)
+		t.Fatal(err)
 	}
-
 	var rb resolver.Builder
 	if newResolver := internal.NewXDSResolverWithConfigForTesting; newResolver != nil {
 		rb, err = newResolver.(func([]byte) (resolver.Builder, error))(bootstrapContents)
@@ -99,4 +72,41 @@ func SetupManagementServer(t *testing.T, opts ManagementServerOptions) (*Managem
 	}
 
 	return server, nodeID, bootstrapContents, rb, func() { server.Stop() }
+}
+
+// DefaultBootstrapContents creates a default bootstrap configuration with the
+// given node ID and server URI. It also creates certificate provider
+// configuration and sets the listener resource name template to be used on the
+// server side.
+func DefaultBootstrapContents(nodeID, serverURI string) ([]byte, error) {
+	// Create a directory to hold certs and key files used on the server side.
+	serverDir, err := createTmpDirWithFiles("testServerSideXDS*", "x509/server1_cert.pem", "x509/server1_key.pem", "x509/client_ca_cert.pem")
+	if err != nil {
+		return nil, fmt.Errorf("Failed to create bootstrap configuration: %v", err)
+	}
+
+	// Create a directory to hold certs and key files used on the client side.
+	clientDir, err := createTmpDirWithFiles("testClientSideXDS*", "x509/client1_cert.pem", "x509/client1_key.pem", "x509/server_ca_cert.pem")
+	if err != nil {
+		return nil, fmt.Errorf("Failed to create bootstrap configuration: %v", err)
+	}
+
+	// Create certificate providers section of the bootstrap config with entries
+	// for both the client and server sides.
+	cpc := map[string]json.RawMessage{
+		ServerSideCertProviderInstance: DefaultFileWatcherConfig(path.Join(serverDir, certFile), path.Join(serverDir, keyFile), path.Join(serverDir, rootFile)),
+		ClientSideCertProviderInstance: DefaultFileWatcherConfig(path.Join(clientDir, certFile), path.Join(clientDir, keyFile), path.Join(clientDir, rootFile)),
+	}
+
+	// Create the bootstrap configuration.
+	bs, err := bootstrap.Contents(bootstrap.Options{
+		NodeID:                             nodeID,
+		ServerURI:                          serverURI,
+		CertificateProviders:               cpc,
+		ServerListenerResourceNameTemplate: ServerListenerResourceNameTemplate,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("Failed to create bootstrap configuration: %v", err)
+	}
+	return bs, nil
 }

--- a/interop/xds/server/server.go
+++ b/interop/xds/server/server.go
@@ -156,7 +156,10 @@ func main() {
 
 	// Create an xDS enabled gRPC server, register the test service
 	// implementation and start serving.
-	testServer := xds.NewGRPCServer(grpc.Creds(creds), xds.ServingModeCallback(xdsServingModeCallback))
+	testServer, err := xds.NewGRPCServer(grpc.Creds(creds), xds.ServingModeCallback(xdsServingModeCallback))
+	if err != nil {
+		logger.Fatal("Failed to create an xDS enabled gRPC server: %v", err)
+	}
 	testgrpc.RegisterTestServiceServer(testServer, testService)
 	go func() {
 		if err := testServer.Serve(testLis); err != nil {

--- a/test/xds/xds_client_ignore_resource_deletion_test.go
+++ b/test/xds/xds_client_ignore_resource_deletion_test.go
@@ -306,7 +306,10 @@ func setupGRPCServerWithModeChangeChannelAndServe(t *testing.T, bootstrapContent
 		t.Logf("Serving mode for listener %q changed to %q, err: %v", addr.String(), args.Mode, args.Err)
 		updateCh <- args.Mode
 	})
-	server := xds.NewGRPCServer(grpc.Creds(insecure.NewCredentials()), modeChangeOpt, xds.BootstrapContentsForTesting(bootstrapContents))
+	server, err := xds.NewGRPCServer(grpc.Creds(insecure.NewCredentials()), modeChangeOpt, xds.BootstrapContentsForTesting(bootstrapContents))
+	if err != nil {
+		t.Fatalf("Failed to create an xDS enabled gRPC server: %v", err)
+	}
 	t.Cleanup(server.Stop)
 	testgrpc.RegisterTestServiceServer(server, &testService{})
 

--- a/test/xds/xds_server_integration_test.go
+++ b/test/xds/xds_server_integration_test.go
@@ -82,7 +82,10 @@ func setupGRPCServer(t *testing.T, bootstrapContents []byte) (net.Listener, func
 	})
 
 	// Initialize an xDS-enabled gRPC server and register the stubServer on it.
-	server := xds.NewGRPCServer(grpc.Creds(creds), modeChangeOpt, xds.BootstrapContentsForTesting(bootstrapContents))
+	server, err := xds.NewGRPCServer(grpc.Creds(creds), modeChangeOpt, xds.BootstrapContentsForTesting(bootstrapContents))
+	if err != nil {
+		t.Fatalf("Failed to create an xDS enabled gRPC server: %v", err)
+	}
 	testgrpc.RegisterTestServiceServer(server, &testService{})
 
 	// Create a local listener and pass it to Serve().

--- a/test/xds/xds_server_serving_mode_test.go
+++ b/test/xds/xds_server_serving_mode_test.go
@@ -63,7 +63,10 @@ func (s) TestServerSideXDS_RedundantUpdateSuppression(t *testing.T) {
 	})
 
 	// Initialize an xDS-enabled gRPC server and register the stubServer on it.
-	server := xds.NewGRPCServer(grpc.Creds(creds), modeChangeOpt, xds.BootstrapContentsForTesting(bootstrapContents))
+	server, err := xds.NewGRPCServer(grpc.Creds(creds), modeChangeOpt, xds.BootstrapContentsForTesting(bootstrapContents))
+	if err != nil {
+		t.Fatalf("Failed to create an xDS enabled gRPC server: %v", err)
+	}
 	defer server.Stop()
 	testgrpc.RegisterTestServiceServer(server, &testService{})
 
@@ -205,7 +208,10 @@ func (s) TestServerSideXDS_ServingModeChanges(t *testing.T) {
 	})
 
 	// Initialize an xDS-enabled gRPC server and register the stubServer on it.
-	server := xds.NewGRPCServer(grpc.Creds(creds), modeChangeOpt, xds.BootstrapContentsForTesting(bootstrapContents))
+	server, err := xds.NewGRPCServer(grpc.Creds(creds), modeChangeOpt, xds.BootstrapContentsForTesting(bootstrapContents))
+	if err != nil {
+		t.Fatalf("Failed to create an xDS enabled gRPC server: %v", err)
+	}
 	defer server.Stop()
 	testgrpc.RegisterTestServiceServer(server, &testService{})
 

--- a/xds/server.go
+++ b/xds/server.go
@@ -23,7 +23,6 @@ import (
 	"errors"
 	"fmt"
 	"net"
-	"sync"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -76,16 +75,11 @@ type grpcServer interface {
 // grpc.ServiceRegistrar interface and can be passed to service registration
 // functions in IDL generated code.
 type GRPCServer struct {
-	gs            grpcServer
-	quit          *grpcsync.Event
-	logger        *internalgrpclog.PrefixLogger
-	xdsCredsInUse bool
-	opts          *serverOptions
-
-	// clientMu is used only in initXDSClient(), which is called at the
-	// beginning of Serve(), where we have to decide if we have to create a
-	// client or use an existing one.
-	clientMu       sync.Mutex
+	gs             grpcServer
+	quit           *grpcsync.Event
+	logger         *internalgrpclog.PrefixLogger
+	xdsCredsInUse  bool
+	opts           *serverOptions
 	xdsC           xdsclient.XDSClient
 	xdsClientClose func()
 }
@@ -93,7 +87,7 @@ type GRPCServer struct {
 // NewGRPCServer creates an xDS-enabled gRPC server using the passed in opts.
 // The underlying gRPC server has no service registered and has not started to
 // accept requests yet.
-func NewGRPCServer(opts ...grpc.ServerOption) *GRPCServer {
+func NewGRPCServer(opts ...grpc.ServerOption) (*GRPCServer, error) {
 	newOpts := []grpc.ServerOption{
 		grpc.ChainUnaryInterceptor(xdsUnaryInterceptor),
 		grpc.ChainStreamInterceptor(xdsStreamInterceptor),
@@ -103,8 +97,6 @@ func NewGRPCServer(opts ...grpc.ServerOption) *GRPCServer {
 		gs:   newGRPCServer(newOpts...),
 		quit: grpcsync.NewEvent(),
 	}
-	s.logger = internalgrpclog.NewPrefixLogger(logger, fmt.Sprintf(serverPrefix, s))
-	s.logger.Infof("Created xds.GRPCServer")
 	s.handleServerOptions(opts)
 
 	// We type assert our underlying gRPC server to the real grpc.Server here
@@ -119,8 +111,48 @@ func NewGRPCServer(opts ...grpc.ServerOption) *GRPCServer {
 		}
 	}
 
+	// Initializing the xDS client upfront (instead of at serving time)
+	// simplifies the code by eliminating the need for a mutex to protect the
+	// xdsC and xdsClientClose fields.
+	newXDSClient := newXDSClient
+	if s.opts.bootstrapContentsForTesting != nil {
+		// Bootstrap file contents may be specified as a server option for tests.
+		newXDSClient = func() (xdsclient.XDSClient, func(), error) {
+			return xdsclient.NewWithBootstrapContentsForTesting(s.opts.bootstrapContentsForTesting)
+		}
+	}
+	xdsClient, xdsClientClose, err := newXDSClient()
+	if err != nil {
+		return nil, fmt.Errorf("xDS client creation failed: %v", err)
+	}
+
+	// Validate the bootstrap configuration for server specific fields.
+
+	// Listener resource name template is mandatory on the server side.
+	cfg := xdsClient.BootstrapConfig()
+	if cfg.ServerListenerResourceNameTemplate == "" {
+		xdsClientClose()
+		return nil, errors.New("missing server_listener_resource_name_template in the bootstrap configuration")
+	}
+
+	// If xds credentials were specified by the user, but bootstrap configs do
+	// not contain any certificate provider configuration, it is better to fail
+	// right now rather than failing when attempting to create certificate
+	// providers after receiving an LDS response with security configuration.
+	if s.xdsCredsInUse {
+		if len(cfg.CertProviderConfigs) == 0 {
+			xdsClientClose()
+			return nil, fmt.Errorf("xds credentials are passed to the user, but certificate_providers config is missing in the bootstrap configuration")
+		}
+	}
+	s.xdsC = xdsClient
+	s.xdsClientClose = xdsClientClose
+
+	s.logger = internalgrpclog.NewPrefixLogger(logger, fmt.Sprintf(serverPrefix, s))
+	s.logger.Infof("Created xds.GRPCServer")
 	s.logger.Infof("xDS credentials in use: %v", s.xdsCredsInUse)
-	return s
+
+	return s, nil
 }
 
 // handleServerOptions iterates through the list of server options passed in by
@@ -169,35 +201,6 @@ func (s *GRPCServer) GetServiceInfo() map[string]grpc.ServiceInfo {
 	return s.gs.GetServiceInfo()
 }
 
-// initXDSClient creates a new xdsClient if there is no existing one available.
-func (s *GRPCServer) initXDSClient() error {
-	s.clientMu.Lock()
-	defer s.clientMu.Unlock()
-	if s.quit.HasFired() {
-		return grpc.ErrServerStopped
-	}
-
-	if s.xdsC != nil {
-		return nil
-	}
-
-	newXDSClient := newXDSClient
-	if s.opts.bootstrapContentsForTesting != nil {
-		// Bootstrap file contents may be specified as a server option for tests.
-		newXDSClient = func() (xdsclient.XDSClient, func(), error) {
-			return xdsclient.NewWithBootstrapContentsForTesting(s.opts.bootstrapContentsForTesting)
-		}
-	}
-
-	client, close, err := newXDSClient()
-	if err != nil {
-		return fmt.Errorf("xds: failed to create xds-client: %v", err)
-	}
-	s.xdsC = client
-	s.xdsClientClose = close
-	return nil
-}
-
 // Serve gets the underlying gRPC server to accept incoming connections on the
 // listener lis, which is expected to be listening on a TCP port.
 //
@@ -211,35 +214,16 @@ func (s *GRPCServer) Serve(lis net.Listener) error {
 		return fmt.Errorf("xds: GRPCServer expects listener to return a net.TCPAddr. Got %T", lis.Addr())
 	}
 
-	// If this is the first time Serve() is being called, we need to initialize
-	// our xdsClient. If not, we can use the existing one.
-	if err := s.initXDSClient(); err != nil {
-		return err
-	}
-	cfg := s.xdsC.BootstrapConfig()
-	if cfg == nil {
-		return errors.New("bootstrap configuration is empty")
-	}
-
-	// If xds credentials were specified by the user, but bootstrap configs do
-	// not contain any certificate provider configuration, it is better to fail
-	// right now rather than failing when attempting to create certificate
-	// providers after receiving an LDS response with security configuration.
-	if s.xdsCredsInUse {
-		if len(cfg.CertProviderConfigs) == 0 {
-			return errors.New("xds: certificate_providers config missing in bootstrap file")
-		}
+	if s.quit.HasFired() {
+		return grpc.ErrServerStopped
 	}
 
 	// The server listener resource name template from the bootstrap
 	// configuration contains a template for the name of the Listener resource
 	// to subscribe to for a gRPC server. If the token `%s` is present in the
 	// string, it will be replaced with the server's listening "IP:port" (e.g.,
-	// "0.0.0.0:8080", "[::]:8080"). The absence of a template will be treated
-	// as an error since we do not have any default value for this.
-	if cfg.ServerListenerResourceNameTemplate == "" {
-		return errors.New("missing server_listener_resource_name_template in the bootstrap configuration")
-	}
+	// "0.0.0.0:8080", "[::]:8080").
+	cfg := s.xdsC.BootstrapConfig()
 	name := bootstrap.PopulateResourceTemplate(cfg.ServerListenerResourceNameTemplate, lis.Addr().String())
 
 	modeUpdateCh := buffer.NewUnbounded()
@@ -335,8 +319,6 @@ func (s *GRPCServer) handleServingModeChanges(updateCh *buffer.Unbounded) {
 // corresponding pending RPCs on the client side will get notified by connection
 // errors.
 func (s *GRPCServer) Stop() {
-	s.clientMu.Lock()
-	defer s.clientMu.Unlock()
 	s.quit.Fire()
 	s.gs.Stop()
 	if s.xdsC != nil {
@@ -348,8 +330,6 @@ func (s *GRPCServer) Stop() {
 // from accepting new connections and RPCs and blocks until all the pending RPCs
 // are finished.
 func (s *GRPCServer) GracefulStop() {
-	s.clientMu.Lock()
-	defer s.clientMu.Unlock()
 	s.quit.Fire()
 	s.gs.GracefulStop()
 	if s.xdsC != nil {

--- a/xds/server_test.go
+++ b/xds/server_test.go
@@ -20,15 +20,19 @@ package xds
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
 	"reflect"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/uuid"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/credentials/insecure"
@@ -36,89 +40,22 @@ import (
 	"google.golang.org/grpc/credentials/xds"
 	"google.golang.org/grpc/internal/grpctest"
 	"google.golang.org/grpc/internal/testutils"
+	"google.golang.org/grpc/internal/testutils/xds/bootstrap"
 	"google.golang.org/grpc/internal/testutils/xds/e2e"
-	_ "google.golang.org/grpc/xds/internal/httpfilter/router"
-	xdstestutils "google.golang.org/grpc/xds/internal/testutils"
-	"google.golang.org/grpc/xds/internal/testutils/fakeclient"
 	"google.golang.org/grpc/xds/internal/xdsclient"
-	"google.golang.org/grpc/xds/internal/xdsclient/bootstrap"
-	"google.golang.org/grpc/xds/internal/xdsclient/xdsresource"
+	"google.golang.org/grpc/xds/internal/xdsclient/xdsresource/version"
 
-	v3corepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	v3listenerpb "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
-	v3routepb "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
-	v3httppb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
-	v3tlspb "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
-	wrapperspb "github.com/golang/protobuf/ptypes/wrappers"
+	v3discoverypb "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+
+	_ "google.golang.org/grpc/xds/internal/httpfilter/router" // Register the router filter
 )
 
 const (
-	defaultTestTimeout                     = 5 * time.Second
-	defaultTestShortTimeout                = 10 * time.Millisecond
-	testServerListenerResourceNameTemplate = "/path/to/resource/%s/%s"
+	defaultTestTimeout          = 5 * time.Second
+	defaultTestShortTimeout     = 10 * time.Millisecond
+	nonExistentManagementServer = "non-existent-management-server"
 )
-
-var listenerWithFilterChains = &v3listenerpb.Listener{
-	FilterChains: []*v3listenerpb.FilterChain{
-		{
-			FilterChainMatch: &v3listenerpb.FilterChainMatch{
-				PrefixRanges: []*v3corepb.CidrRange{
-					{
-						AddressPrefix: "192.168.0.0",
-						PrefixLen: &wrapperspb.UInt32Value{
-							Value: uint32(16),
-						},
-					},
-				},
-				SourceType: v3listenerpb.FilterChainMatch_SAME_IP_OR_LOOPBACK,
-				SourcePrefixRanges: []*v3corepb.CidrRange{
-					{
-						AddressPrefix: "192.168.0.0",
-						PrefixLen: &wrapperspb.UInt32Value{
-							Value: uint32(16),
-						},
-					},
-				},
-				SourcePorts: []uint32{80},
-			},
-			TransportSocket: &v3corepb.TransportSocket{
-				Name: "envoy.transport_sockets.tls",
-				ConfigType: &v3corepb.TransportSocket_TypedConfig{
-					TypedConfig: testutils.MarshalAny(&v3tlspb.DownstreamTlsContext{
-						CommonTlsContext: &v3tlspb.CommonTlsContext{
-							TlsCertificateCertificateProviderInstance: &v3tlspb.CommonTlsContext_CertificateProviderInstance{
-								InstanceName:    "identityPluginInstance",
-								CertificateName: "identityCertName",
-							},
-						},
-					}),
-				},
-			},
-			Filters: []*v3listenerpb.Filter{
-				{
-					Name: "filter-1",
-					ConfigType: &v3listenerpb.Filter_TypedConfig{
-						TypedConfig: testutils.MarshalAny(&v3httppb.HttpConnectionManager{
-							RouteSpecifier: &v3httppb.HttpConnectionManager_RouteConfig{
-								RouteConfig: &v3routepb.RouteConfiguration{
-									Name: "routeName",
-									VirtualHosts: []*v3routepb.VirtualHost{{
-										Domains: []string{"lds.target.good:3333"},
-										Routes: []*v3routepb.Route{{
-											Match: &v3routepb.RouteMatch{
-												PathSpecifier: &v3routepb.RouteMatch_Prefix{Prefix: "/"},
-											},
-											Action: &v3routepb.Route_NonForwardingAction{},
-										}}}}},
-							},
-							HttpFilters: []*v3httppb.HttpFilter{e2e.RouterHTTPFilter},
-						}),
-					},
-				},
-			},
-		},
-	},
-}
 
 type s struct {
 	grpctest.Tester
@@ -132,8 +69,6 @@ type fakeGRPCServer struct {
 	done              chan struct{}
 	registerServiceCh *testutils.Channel
 	serveCh           *testutils.Channel
-	stopCh            *testutils.Channel
-	gracefulStopCh    *testutils.Channel
 }
 
 func (f *fakeGRPCServer) RegisterService(*grpc.ServiceDesc, interface{}) {
@@ -149,11 +84,9 @@ func (f *fakeGRPCServer) Serve(lis net.Listener) error {
 
 func (f *fakeGRPCServer) Stop() {
 	close(f.done)
-	f.stopCh.Send(nil)
 }
 func (f *fakeGRPCServer) GracefulStop() {
 	close(f.done)
-	f.gracefulStopCh.Send(nil)
 }
 
 func (f *fakeGRPCServer) GetServiceInfo() map[string]grpc.ServiceInfo {
@@ -165,20 +98,20 @@ func newFakeGRPCServer() *fakeGRPCServer {
 		done:              make(chan struct{}),
 		registerServiceCh: testutils.NewChannel(),
 		serveCh:           testutils.NewChannel(),
-		stopCh:            testutils.NewChannel(),
-		gracefulStopCh:    testutils.NewChannel(),
 	}
 }
 
-func splitHostPort(hostport string) (string, string) {
-	addr, port, err := net.SplitHostPort(hostport)
+func generateBootstrapContents(t *testing.T, nodeID, serverURI string) []byte {
+	t.Helper()
+
+	bs, err := e2e.DefaultBootstrapContents(nodeID, serverURI)
 	if err != nil {
-		panic(fmt.Sprintf("listener address %q does not parse: %v", hostport, err))
+		t.Fatal(err)
 	}
-	return addr, port
+	return bs
 }
 
-func (s) TestNewServer(t *testing.T) {
+func (s) TestNewServer_Success(t *testing.T) {
 	xdsCreds, err := xds.NewServerCredentials(xds.ServerOptions{FallbackCreds: insecure.NewCredentials()})
 	if err != nil {
 		t.Fatalf("failed to create xds server credentials: %v", err)
@@ -190,12 +123,18 @@ func (s) TestNewServer(t *testing.T) {
 		wantXDSCredsInUse bool
 	}{
 		{
-			desc:       "without_xds_creds",
-			serverOpts: []grpc.ServerOption{grpc.Creds(insecure.NewCredentials())},
+			desc: "without_xds_creds",
+			serverOpts: []grpc.ServerOption{
+				grpc.Creds(insecure.NewCredentials()),
+				BootstrapContentsForTesting(generateBootstrapContents(t, uuid.NewString(), nonExistentManagementServer)),
+			},
 		},
 		{
-			desc:              "with_xds_creds",
-			serverOpts:        []grpc.ServerOption{grpc.Creds(xdsCreds)},
+			desc: "with_xds_creds",
+			serverOpts: []grpc.ServerOption{
+				grpc.Creds(xdsCreds),
+				BootstrapContentsForTesting(generateBootstrapContents(t, uuid.NewString(), nonExistentManagementServer)),
+			},
 			wantXDSCredsInUse: true,
 		},
 	}
@@ -221,11 +160,92 @@ func (s) TestNewServer(t *testing.T) {
 				newGRPCServer = origNewGRPCServer
 			}()
 
-			s := NewGRPCServer(test.serverOpts...)
+			s, err := NewGRPCServer(test.serverOpts...)
+			if err != nil {
+				t.Fatalf("Failed to create an xDS enabled gRPC server: %v", err)
+			}
 			defer s.Stop()
 
 			if s.xdsCredsInUse != test.wantXDSCredsInUse {
 				t.Fatalf("xdsCredsInUse is %v, want %v", s.xdsCredsInUse, test.wantXDSCredsInUse)
+			}
+		})
+	}
+}
+
+func (s) TestNewServer_Failure(t *testing.T) {
+	xdsCreds, err := xds.NewServerCredentials(xds.ServerOptions{FallbackCreds: insecure.NewCredentials()})
+	if err != nil {
+		t.Fatalf("failed to create xds server credentials: %v", err)
+	}
+
+	tests := []struct {
+		desc       string
+		serverOpts []grpc.ServerOption
+		wantErr    string
+	}{
+		{
+			desc:       "bootstrap env var not set",
+			serverOpts: []grpc.ServerOption{grpc.Creds(xdsCreds)},
+			wantErr:    "bootstrap env vars are unspecified",
+		},
+		{
+			desc: "empty bootstrap config",
+			serverOpts: []grpc.ServerOption{
+				grpc.Creds(xdsCreds),
+				BootstrapContentsForTesting([]byte(`{}`)),
+			},
+			wantErr: "xDS client creation failed",
+		},
+		{
+			desc: "certificate provider config is missing",
+			serverOpts: []grpc.ServerOption{
+				grpc.Creds(xdsCreds),
+				func() grpc.ServerOption {
+					bs, err := bootstrap.Contents(bootstrap.Options{
+						NodeID:                             uuid.New().String(),
+						ServerURI:                          nonExistentManagementServer,
+						ServerListenerResourceNameTemplate: e2e.ServerListenerResourceNameTemplate,
+					})
+					if err != nil {
+						t.Errorf("Failed to create bootstrap configuration: %v", err)
+					}
+					return BootstrapContentsForTesting(bs)
+				}(),
+			},
+			wantErr: "certificate_providers config is missing",
+		},
+		{
+			desc: "server_listener_resource_name_template is missing",
+			serverOpts: []grpc.ServerOption{
+				grpc.Creds(xdsCreds),
+				func() grpc.ServerOption {
+					bs, err := bootstrap.Contents(bootstrap.Options{
+						NodeID:    uuid.New().String(),
+						ServerURI: nonExistentManagementServer,
+						CertificateProviders: map[string]json.RawMessage{
+							"cert-provider-instance": json.RawMessage("{}"),
+						},
+					})
+					if err != nil {
+						t.Errorf("Failed to create bootstrap configuration: %v", err)
+					}
+					return BootstrapContentsForTesting(bs)
+				}(),
+			},
+			wantErr: "missing server_listener_resource_name_template in the bootstrap configuration",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			s, err := NewGRPCServer(test.serverOpts...)
+			if err == nil {
+				s.Stop()
+				t.Fatal("NewGRPCServer() succeeded when expected to fail")
+			}
+			if !strings.Contains(err.Error(), test.wantErr) {
+				t.Fatalf("NewGRPCServer() failed with error: %v, want: %s", err, test.wantErr)
 			}
 		})
 	}
@@ -238,26 +258,29 @@ func (s) TestRegisterService(t *testing.T) {
 	newGRPCServer = func(opts ...grpc.ServerOption) grpcServer { return fs }
 	defer func() { newGRPCServer = origNewGRPCServer }()
 
-	s := NewGRPCServer()
+	s, err := NewGRPCServer(BootstrapContentsForTesting(generateBootstrapContents(t, uuid.NewString(), "non-existent-management-server")))
+	if err != nil {
+		t.Fatalf("Failed to create an xDS enabled gRPC server: %v", err)
+	}
 	defer s.Stop()
 
 	s.RegisterService(&grpc.ServiceDesc{}, nil)
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
 	if _, err := fs.registerServiceCh.Receive(ctx); err != nil {
-		t.Fatalf("timeout when expecting RegisterService() to called on grpc.Server: %v", err)
+		t.Fatalf("Timeout when expecting RegisterService() to called on grpc.Server: %v", err)
 	}
 }
 
 const (
 	fakeProvider1Name = "fake-certificate-provider-1"
 	fakeProvider2Name = "fake-certificate-provider-2"
-	fakeConfig        = "my fake config"
 )
 
 var (
 	fpb1, fpb2          *fakeProviderBuilder
-	certProviderConfigs map[string]*certprovider.BuildableConfig
+	fakeProvider1Config json.RawMessage
+	fakeProvider2Config json.RawMessage
 )
 
 func init() {
@@ -269,14 +292,17 @@ func init() {
 		name:    fakeProvider2Name,
 		buildCh: testutils.NewChannel(),
 	}
-	cfg1, _ := fpb1.ParseConfig(fakeConfig + "1111")
-	cfg2, _ := fpb2.ParseConfig(fakeConfig + "2222")
-	certProviderConfigs = map[string]*certprovider.BuildableConfig{
-		"default1": cfg1,
-		"default2": cfg2,
-	}
 	certprovider.Register(fpb1)
 	certprovider.Register(fpb2)
+
+	fakeProvider1Config = json.RawMessage(fmt.Sprintf(`{
+		"plugin_name": "%s",
+		"config": "my fake config 1"
+	}`, fakeProvider1Name))
+	fakeProvider2Config = json.RawMessage(fmt.Sprintf(`{
+		"plugin_name": "%s",
+		"config": "my fake config 2"
+	}`, fakeProvider2Name))
 }
 
 // fakeProviderBuilder builds new instances of fakeProvider and interprets the
@@ -286,16 +312,16 @@ type fakeProviderBuilder struct {
 	buildCh *testutils.Channel
 }
 
-func (b *fakeProviderBuilder) ParseConfig(config interface{}) (*certprovider.BuildableConfig, error) {
-	s, ok := config.(string)
-	if !ok {
-		return nil, fmt.Errorf("providerBuilder %s received config of type %T, want string", b.name, config)
+func (b *fakeProviderBuilder) ParseConfig(cfg interface{}) (*certprovider.BuildableConfig, error) {
+	var config string
+	if err := json.Unmarshal(cfg.(json.RawMessage), &config); err != nil {
+		return nil, fmt.Errorf("providerBuilder %s failed to unmarshal config: %v", b.name, cfg)
 	}
-	return certprovider.NewBuildableConfig(b.name, []byte(s), func(certprovider.BuildOptions) certprovider.Provider {
+	return certprovider.NewBuildableConfig(b.name, []byte(config), func(certprovider.BuildOptions) certprovider.Provider {
 		b.buildCh.Send(nil)
 		return &fakeProvider{
 			Distributor: certprovider.NewDistributor(),
-			config:      s,
+			config:      config,
 		}
 	}), nil
 }
@@ -316,586 +342,6 @@ func (p *fakeProvider) Close() {
 	p.Distributor.Stop()
 }
 
-// setupClientOverride sets up an override for new xdsClient creation.
-func setupClientOverride(t *testing.T) func() {
-	origNewXDSClient := newXDSClient
-	newXDSClient = func() (xdsclient.XDSClient, func(), error) {
-		c := fakeclient.NewClient()
-		c.SetBootstrapConfig(&bootstrap.Config{
-			XDSServer:                          xdstestutils.ServerConfigForAddress(t, "server-address"),
-			NodeProto:                          xdstestutils.EmptyNodeProtoV3,
-			ServerListenerResourceNameTemplate: testServerListenerResourceNameTemplate,
-			CertProviderConfigs:                certProviderConfigs,
-		})
-		return c, func() {}, nil
-	}
-	return func() {
-		newXDSClient = origNewXDSClient
-	}
-}
-
-// setupOverrides sets up overrides for bootstrap config, new xdsClient creation
-// and new gRPC.Server creation.
-func setupOverrides(t *testing.T) (*fakeGRPCServer, *testutils.Channel, func()) {
-	clientCh := testutils.NewChannel()
-	origNewXDSClient := newXDSClient
-	newXDSClient = func() (xdsclient.XDSClient, func(), error) {
-		c := fakeclient.NewClient()
-		c.SetBootstrapConfig(&bootstrap.Config{
-			XDSServer:                          xdstestutils.ServerConfigForAddress(t, "server-address"),
-			NodeProto:                          xdstestutils.EmptyNodeProtoV3,
-			ServerListenerResourceNameTemplate: testServerListenerResourceNameTemplate,
-			CertProviderConfigs:                certProviderConfigs,
-		})
-		clientCh.Send(c)
-		return c, func() {}, nil
-	}
-
-	fs := newFakeGRPCServer()
-	origNewGRPCServer := newGRPCServer
-	newGRPCServer = func(opts ...grpc.ServerOption) grpcServer { return fs }
-
-	return fs, clientCh, func() {
-		newXDSClient = origNewXDSClient
-		newGRPCServer = origNewGRPCServer
-	}
-}
-
-// setupOverridesForXDSCreds overrides only the xdsClient creation with a fake
-// one. Tests that use xdsCredentials need a real grpc.Server instead of a fake
-// one, because the xDS-enabled server needs to read configured creds from the
-// underlying grpc.Server to confirm whether xdsCreds were configured.
-func setupOverridesForXDSCreds(t *testing.T, includeCertProviderCfg bool) (*testutils.Channel, func()) {
-	clientCh := testutils.NewChannel()
-	origNewXDSClient := newXDSClient
-	newXDSClient = func() (xdsclient.XDSClient, func(), error) {
-		c := fakeclient.NewClient()
-		bc := &bootstrap.Config{
-			XDSServer:                          xdstestutils.ServerConfigForAddress(t, "server-address"),
-			NodeProto:                          xdstestutils.EmptyNodeProtoV3,
-			ServerListenerResourceNameTemplate: testServerListenerResourceNameTemplate,
-		}
-		if includeCertProviderCfg {
-			bc.CertProviderConfigs = certProviderConfigs
-		}
-		c.SetBootstrapConfig(bc)
-		clientCh.Send(c)
-		return c, func() {}, nil
-	}
-
-	return clientCh, func() { newXDSClient = origNewXDSClient }
-}
-
-// TestServeSuccess tests the successful case of calling Serve().
-// The following sequence of events happen:
-//  1. Create a new GRPCServer and call Serve() in a goroutine.
-//  2. Make sure an xdsClient is created, and an LDS watch is registered.
-//  3. Push an error response from the xdsClient, and make sure that Serve() does
-//     not exit.
-//  4. Push a good response from the xdsClient, and make sure that Serve() on the
-//     underlying grpc.Server is called.
-func (s) TestServeSuccess(t *testing.T) {
-	fs, clientCh, cleanup := setupOverrides(t)
-	defer cleanup()
-
-	// Create a new xDS-enabled gRPC server and pass it a server option to get
-	// notified about serving mode changes.
-	modeChangeCh := testutils.NewChannel()
-	modeChangeOption := ServingModeCallback(func(addr net.Addr, args ServingModeChangeArgs) {
-		t.Logf("server mode change callback invoked for listener %q with mode %q and error %v", addr.String(), args.Mode, args.Err)
-		modeChangeCh.Send(args.Mode)
-	})
-	server := NewGRPCServer(modeChangeOption)
-	defer server.Stop()
-
-	lis, err := testutils.LocalTCPListener()
-	if err != nil {
-		t.Fatalf("testutils.LocalTCPListener() failed: %v", err)
-	}
-
-	// Call Serve() in a goroutine, and push on a channel when Serve returns.
-	serveDone := testutils.NewChannel()
-	go func() {
-		if err := server.Serve(lis); err != nil {
-			t.Error(err)
-		}
-		serveDone.Send(nil)
-	}()
-
-	// Wait for an xdsClient to be created.
-	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
-	defer cancel()
-	c, err := clientCh.Receive(ctx)
-	if err != nil {
-		t.Fatalf("error when waiting for new xdsClient to be created: %v", err)
-	}
-	client := c.(*fakeclient.Client)
-
-	// Wait for a listener watch to be registered on the xdsClient.
-	name, err := client.WaitForWatchListener(ctx)
-	if err != nil {
-		t.Fatalf("error when waiting for a ListenerWatch: %v", err)
-	}
-	wantName := strings.Replace(testServerListenerResourceNameTemplate, "%s", lis.Addr().String(), -1)
-	if name != wantName {
-		t.Fatalf("LDS watch registered for name %q, want %q", name, wantName)
-	}
-
-	// Push an error to the registered listener watch callback and make sure
-	// that Serve does not return.
-	client.InvokeWatchListenerCallback(xdsresource.ListenerUpdate{}, xdsresource.NewErrorf(xdsresource.ErrorTypeResourceNotFound, "LDS resource not found"))
-	sCtx, sCancel := context.WithTimeout(context.Background(), defaultTestShortTimeout)
-	defer sCancel()
-	if _, err := serveDone.Receive(sCtx); err != context.DeadlineExceeded {
-		t.Fatal("Serve() returned after a bad LDS response")
-	}
-
-	// Make sure the serving mode changes appropriately.
-	v, err := modeChangeCh.Receive(ctx)
-	if err != nil {
-		t.Fatalf("error when waiting for serving mode to change: %v", err)
-	}
-	if mode := v.(connectivity.ServingMode); mode != connectivity.ServingModeNotServing {
-		t.Fatalf("server mode is %q, want %q", mode, connectivity.ServingModeNotServing)
-	}
-
-	// Push a good LDS response, and wait for Serve() to be invoked on the
-	// underlying grpc.Server.
-	fcm, err := xdsresource.NewFilterChainManager(listenerWithFilterChains)
-	if err != nil {
-		t.Fatalf("xdsclient.NewFilterChainManager() failed with error: %v", err)
-	}
-	addr, port := splitHostPort(lis.Addr().String())
-	client.InvokeWatchListenerCallback(xdsresource.ListenerUpdate{
-		RouteConfigName: "routeconfig",
-		InboundListenerCfg: &xdsresource.InboundListenerConfig{
-			Address:      addr,
-			Port:         port,
-			FilterChains: fcm,
-		},
-	}, nil)
-	if _, err := fs.serveCh.Receive(ctx); err != nil {
-		t.Fatalf("error when waiting for Serve() to be invoked on the grpc.Server")
-	}
-
-	// Make sure the serving mode changes appropriately.
-	v, err = modeChangeCh.Receive(ctx)
-	if err != nil {
-		t.Fatalf("error when waiting for serving mode to change: %v", err)
-	}
-	if mode := v.(connectivity.ServingMode); mode != connectivity.ServingModeServing {
-		t.Fatalf("server mode is %q, want %q", mode, connectivity.ServingModeServing)
-	}
-
-	// Push an update to the registered listener watch callback with a Listener
-	// resource whose host:port does not match the actual listening address and
-	// port. This will push the listener to "not-serving" mode.
-	client.InvokeWatchListenerCallback(xdsresource.ListenerUpdate{
-		RouteConfigName: "routeconfig",
-		InboundListenerCfg: &xdsresource.InboundListenerConfig{
-			Address:      "10.20.30.40",
-			Port:         "666",
-			FilterChains: fcm,
-		},
-	}, nil)
-	sCtx, sCancel = context.WithTimeout(context.Background(), defaultTestShortTimeout)
-	defer sCancel()
-	if _, err := serveDone.Receive(sCtx); err != context.DeadlineExceeded {
-		t.Fatal("Serve() returned after a bad LDS response")
-	}
-
-	// Make sure the serving mode changes appropriately.
-	v, err = modeChangeCh.Receive(ctx)
-	if err != nil {
-		t.Fatalf("error when waiting for serving mode to change: %v", err)
-	}
-	if mode := v.(connectivity.ServingMode); mode != connectivity.ServingModeNotServing {
-		t.Fatalf("server mode is %q, want %q", mode, connectivity.ServingModeNotServing)
-	}
-}
-
-// TestServeWithStop tests the case where Stop() is called before an LDS update
-// is received. This should cause Serve() to exit before calling Serve() on the
-// underlying grpc.Server.
-func (s) TestServeWithStop(t *testing.T) {
-	fs, clientCh, cleanup := setupOverrides(t)
-	defer cleanup()
-
-	// Note that we are not deferring the Stop() here since we explicitly call
-	// it after the LDS watch has been registered.
-	server := NewGRPCServer()
-
-	lis, err := testutils.LocalTCPListener()
-	if err != nil {
-		server.Stop()
-		t.Fatalf("testutils.LocalTCPListener() failed: %v", err)
-	}
-
-	// Call Serve() in a goroutine, and push on a channel when Serve returns.
-	serveDone := testutils.NewChannel()
-	go func() {
-		if err := server.Serve(lis); err != nil {
-			t.Error(err)
-		}
-		serveDone.Send(nil)
-	}()
-
-	// Wait for an xdsClient to be created.
-	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
-	defer cancel()
-	c, err := clientCh.Receive(ctx)
-	if err != nil {
-		server.Stop()
-		t.Fatalf("error when waiting for new xdsClient to be created: %v", err)
-	}
-	client := c.(*fakeclient.Client)
-
-	// Wait for a listener watch to be registered on the xdsClient.
-	name, err := client.WaitForWatchListener(ctx)
-	if err != nil {
-		server.Stop()
-		t.Fatalf("error when waiting for a ListenerWatch: %v", err)
-	}
-	wantName := strings.Replace(testServerListenerResourceNameTemplate, "%s", lis.Addr().String(), -1)
-	if name != wantName {
-		server.Stop()
-		t.Fatalf("LDS watch registered for name %q, wantPrefix %q", name, wantName)
-	}
-
-	// Call Stop() on the server before a listener update is received, and
-	// expect Serve() to exit.
-	server.Stop()
-	if _, err := serveDone.Receive(ctx); err != nil {
-		t.Fatalf("error when waiting for Serve() to exit")
-	}
-
-	// Make sure that Serve() on the underlying grpc.Server is not called.
-	sCtx, sCancel := context.WithTimeout(context.Background(), defaultTestShortTimeout)
-	defer sCancel()
-	if _, err := fs.serveCh.Receive(sCtx); err != context.DeadlineExceeded {
-		t.Fatal("Serve() called on underlying grpc.Server")
-	}
-}
-
-// TestServeBootstrapFailure tests the case where xDS bootstrap fails and
-// verifies that Serve() exits with a non-nil error.
-func (s) TestServeBootstrapFailure(t *testing.T) {
-	// Since we have not setup fakes for anything, this will attempt to do real
-	// xDS bootstrap and that will fail because the bootstrap environment
-	// variable is not set.
-	server := NewGRPCServer()
-	defer server.Stop()
-
-	lis, err := testutils.LocalTCPListener()
-	if err != nil {
-		t.Fatalf("testutils.LocalTCPListener() failed: %v", err)
-	}
-
-	serveDone := testutils.NewChannel()
-	go func() { serveDone.Send(server.Serve(lis)) }()
-
-	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
-	defer cancel()
-	v, err := serveDone.Receive(ctx)
-	if err != nil {
-		t.Fatalf("error when waiting for Serve() to exit: %v", err)
-	}
-	if err, ok := v.(error); !ok || err == nil {
-		t.Fatal("Serve() did not exit with error")
-	}
-}
-
-// TestServeBootstrapConfigInvalid tests the cases where the bootstrap config
-// does not contain expected fields. Verifies that the call to Serve() fails.
-func (s) TestServeBootstrapConfigInvalid(t *testing.T) {
-	tests := []struct {
-		desc            string
-		bootstrapConfig *bootstrap.Config
-	}{
-		{
-			desc:            "bootstrap config is missing",
-			bootstrapConfig: nil,
-		},
-		{
-			desc: "certificate provider config is missing",
-			bootstrapConfig: &bootstrap.Config{
-				XDSServer:                          xdstestutils.ServerConfigForAddress(t, "server-address"),
-				NodeProto:                          xdstestutils.EmptyNodeProtoV3,
-				ServerListenerResourceNameTemplate: testServerListenerResourceNameTemplate,
-			},
-		},
-		{
-			desc: "server_listener_resource_name_template is missing",
-			bootstrapConfig: &bootstrap.Config{
-				XDSServer:           xdstestutils.ServerConfigForAddress(t, "server-address"),
-				NodeProto:           xdstestutils.EmptyNodeProtoV3,
-				CertProviderConfigs: certProviderConfigs,
-			},
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.desc, func(t *testing.T) {
-			// Override the xdsClient creation with one that returns a fake
-			// xdsClient with the specified bootstrap configuration.
-			clientCh := testutils.NewChannel()
-			origNewXDSClient := newXDSClient
-			newXDSClient = func() (xdsclient.XDSClient, func(), error) {
-				c := fakeclient.NewClient()
-				c.SetBootstrapConfig(test.bootstrapConfig)
-				clientCh.Send(c)
-				return c, func() {}, nil
-			}
-			defer func() { newXDSClient = origNewXDSClient }()
-
-			xdsCreds, err := xds.NewServerCredentials(xds.ServerOptions{FallbackCreds: insecure.NewCredentials()})
-			if err != nil {
-				t.Fatalf("failed to create xds server credentials: %v", err)
-			}
-			server := NewGRPCServer(grpc.Creds(xdsCreds))
-			defer server.Stop()
-
-			lis, err := testutils.LocalTCPListener()
-			if err != nil {
-				t.Fatalf("testutils.LocalTCPListener() failed: %v", err)
-			}
-
-			serveDone := testutils.NewChannel()
-			go func() {
-				err := server.Serve(lis)
-				serveDone.Send(err)
-			}()
-
-			ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
-			defer cancel()
-			v, err := serveDone.Receive(ctx)
-			if err != nil {
-				t.Fatalf("error when waiting for Serve() to exit: %v", err)
-			}
-			if err, ok := v.(error); !ok || err == nil {
-				t.Fatal("Serve() did not exit with error")
-			}
-		})
-	}
-}
-
-// TestServeNewClientFailure tests the case where xds client creation fails and
-// verifies that Server() exits with a non-nil error.
-func (s) TestServeNewClientFailure(t *testing.T) {
-	origNewXDSClient := newXDSClient
-	newXDSClient = func() (xdsclient.XDSClient, func(), error) {
-		return nil, nil, errors.New("xdsClient creation failed")
-	}
-	defer func() { newXDSClient = origNewXDSClient }()
-
-	server := NewGRPCServer()
-	defer server.Stop()
-
-	lis, err := testutils.LocalTCPListener()
-	if err != nil {
-		t.Fatalf("testutils.LocalTCPListener() failed: %v", err)
-	}
-
-	serveDone := testutils.NewChannel()
-	go func() {
-		err := server.Serve(lis)
-		serveDone.Send(err)
-	}()
-
-	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
-	defer cancel()
-	v, err := serveDone.Receive(ctx)
-	if err != nil {
-		t.Fatalf("error when waiting for Serve() to exit: %v", err)
-	}
-	if err, ok := v.(error); !ok || err == nil {
-		t.Fatal("Serve() did not exit with error")
-	}
-}
-
-// TestHandleListenerUpdate_NoXDSCreds tests the case where an xds-enabled gRPC
-// server is not configured with xDS credentials. Verifies that the security
-// config received as part of a Listener update is not acted upon.
-func (s) TestHandleListenerUpdate_NoXDSCreds(t *testing.T) {
-	fs, clientCh, cleanup := setupOverrides(t)
-	defer cleanup()
-
-	// Create a server option to get notified about serving mode changes. We don't
-	// do anything other than throwing a log entry here. But this is required,
-	// since the server code emits a log entry at the default level (which is
-	// ERROR) if no callback is registered for serving mode changes. Our
-	// testLogger fails the test if there is any log entry at ERROR level. It does
-	// provide an ExpectError()  method, but that takes a string and it would be
-	// painful to construct the exact error message expected here. Instead this
-	// works just fine.
-	modeChangeOpt := ServingModeCallback(func(addr net.Addr, args ServingModeChangeArgs) {
-		t.Logf("Serving mode for listener %q changed to %q, err: %v", addr.String(), args.Mode, args.Err)
-	})
-	server := NewGRPCServer(modeChangeOpt)
-	defer server.Stop()
-
-	lis, err := testutils.LocalTCPListener()
-	if err != nil {
-		t.Fatalf("testutils.LocalTCPListener() failed: %v", err)
-	}
-
-	// Call Serve() in a goroutine, and push on a channel when Serve returns.
-	serveDone := testutils.NewChannel()
-	go func() {
-		if err := server.Serve(lis); err != nil {
-			t.Error(err)
-		}
-		serveDone.Send(nil)
-	}()
-
-	// Wait for an xdsClient to be created.
-	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
-	defer cancel()
-	c, err := clientCh.Receive(ctx)
-	if err != nil {
-		t.Fatalf("error when waiting for new xdsClient to be created: %v", err)
-	}
-	client := c.(*fakeclient.Client)
-
-	// Wait for a listener watch to be registered on the xdsClient.
-	name, err := client.WaitForWatchListener(ctx)
-	if err != nil {
-		t.Fatalf("error when waiting for a ListenerWatch: %v", err)
-	}
-	wantName := strings.Replace(testServerListenerResourceNameTemplate, "%s", lis.Addr().String(), -1)
-	if name != wantName {
-		t.Fatalf("LDS watch registered for name %q, want %q", name, wantName)
-	}
-
-	// Push a good LDS response with security config, and wait for Serve() to be
-	// invoked on the underlying grpc.Server. Also make sure that certificate
-	// providers are not created.
-	fcm, err := xdsresource.NewFilterChainManager(&v3listenerpb.Listener{
-		FilterChains: []*v3listenerpb.FilterChain{
-			{
-				TransportSocket: &v3corepb.TransportSocket{
-					Name: "envoy.transport_sockets.tls",
-					ConfigType: &v3corepb.TransportSocket_TypedConfig{
-						TypedConfig: testutils.MarshalAny(&v3tlspb.DownstreamTlsContext{
-							CommonTlsContext: &v3tlspb.CommonTlsContext{
-								TlsCertificateCertificateProviderInstance: &v3tlspb.CommonTlsContext_CertificateProviderInstance{
-									InstanceName:    "identityPluginInstance",
-									CertificateName: "identityCertName",
-								},
-							},
-						}),
-					},
-				},
-				Filters: []*v3listenerpb.Filter{
-					{
-						Name: "filter-1",
-						ConfigType: &v3listenerpb.Filter_TypedConfig{
-							TypedConfig: testutils.MarshalAny(&v3httppb.HttpConnectionManager{
-								RouteSpecifier: &v3httppb.HttpConnectionManager_RouteConfig{
-									RouteConfig: &v3routepb.RouteConfiguration{
-										Name: "routeName",
-										VirtualHosts: []*v3routepb.VirtualHost{{
-											Domains: []string{"lds.target.good:3333"},
-											Routes: []*v3routepb.Route{{
-												Match: &v3routepb.RouteMatch{
-													PathSpecifier: &v3routepb.RouteMatch_Prefix{Prefix: "/"},
-												},
-												Action: &v3routepb.Route_NonForwardingAction{},
-											}}}}},
-								},
-								HttpFilters: []*v3httppb.HttpFilter{e2e.RouterHTTPFilter},
-							}),
-						},
-					},
-				},
-			},
-		},
-	})
-	if err != nil {
-		t.Fatalf("xdsclient.NewFilterChainManager() failed with error: %v", err)
-	}
-	addr, port := splitHostPort(lis.Addr().String())
-	client.InvokeWatchListenerCallback(xdsresource.ListenerUpdate{
-		RouteConfigName: "routeconfig",
-		InboundListenerCfg: &xdsresource.InboundListenerConfig{
-			Address:      addr,
-			Port:         port,
-			FilterChains: fcm,
-		},
-	}, nil)
-	if _, err := fs.serveCh.Receive(ctx); err != nil {
-		t.Fatalf("error when waiting for Serve() to be invoked on the grpc.Server")
-	}
-
-	// Make sure the security configuration is not acted upon.
-	if err := verifyCertProviderNotCreated(); err != nil {
-		t.Fatal(err)
-	}
-}
-
-// TestHandleListenerUpdate_ErrorUpdate tests the case where an xds-enabled gRPC
-// server is configured with xDS credentials, but receives a Listener update
-// with an error. Verifies that no certificate providers are created.
-func (s) TestHandleListenerUpdate_ErrorUpdate(t *testing.T) {
-	clientCh, cleanup := setupOverridesForXDSCreds(t, true)
-	defer cleanup()
-
-	xdsCreds, err := xds.NewServerCredentials(xds.ServerOptions{FallbackCreds: insecure.NewCredentials()})
-	if err != nil {
-		t.Fatalf("failed to create xds server credentials: %v", err)
-	}
-
-	server := NewGRPCServer(grpc.Creds(xdsCreds))
-	defer server.Stop()
-
-	lis, err := testutils.LocalTCPListener()
-	if err != nil {
-		t.Fatalf("testutils.LocalTCPListener() failed: %v", err)
-	}
-
-	// Call Serve() in a goroutine, and push on a channel when Serve returns.
-	serveDone := testutils.NewChannel()
-	go func() {
-		if err := server.Serve(lis); err != nil {
-			t.Error(err)
-		}
-		serveDone.Send(nil)
-	}()
-
-	// Wait for an xdsClient to be created.
-	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
-	defer cancel()
-	c, err := clientCh.Receive(ctx)
-	if err != nil {
-		t.Fatalf("error when waiting for new xdsClient to be created: %v", err)
-	}
-	client := c.(*fakeclient.Client)
-
-	// Wait for a listener watch to be registered on the xdsClient.
-	name, err := client.WaitForWatchListener(ctx)
-	if err != nil {
-		t.Fatalf("error when waiting for a ListenerWatch: %v", err)
-	}
-	wantName := strings.Replace(testServerListenerResourceNameTemplate, "%s", lis.Addr().String(), -1)
-	if name != wantName {
-		t.Fatalf("LDS watch registered for name %q, want %q", name, wantName)
-	}
-
-	// Push an error to the registered listener watch callback and make sure
-	// that Serve does not return.
-	client.InvokeWatchListenerCallback(xdsresource.ListenerUpdate{}, errors.New("LDS error"))
-	sCtx, sCancel := context.WithTimeout(context.Background(), defaultTestShortTimeout)
-	defer sCancel()
-	if _, err := serveDone.Receive(sCtx); err != context.DeadlineExceeded {
-		t.Fatal("Serve() returned after a bad LDS response")
-	}
-
-	// Also make sure that no certificate providers are created.
-	if err := verifyCertProviderNotCreated(); err != nil {
-		t.Fatal(err)
-	}
-}
-
 func verifyCertProviderNotCreated() error {
 	sCtx, sCancel := context.WithTimeout(context.Background(), defaultTestShortTimeout)
 	defer sCancel()
@@ -910,18 +356,432 @@ func verifyCertProviderNotCreated() error {
 	return nil
 }
 
+func hostPortFromListener(t *testing.T, lis net.Listener) (string, uint32) {
+	t.Helper()
+
+	host, p, err := net.SplitHostPort(lis.Addr().String())
+	if err != nil {
+		t.Fatalf("net.SplitHostPort(%s) failed: %v", lis.Addr().String(), err)
+	}
+	port, err := strconv.ParseInt(p, 10, 32)
+	if err != nil {
+		t.Fatalf("strconv.ParseInt(%s, 10, 32) failed: %v", p, err)
+	}
+	return host, uint32(port)
+}
+
+// TestServeSuccess tests the successful case of creating an xDS enabled gRPC
+// server and calling Serve() on it. The test verifies that an LDS request is
+// sent out for the expected name, and also verifies that the serving mode
+// changes appropriately.
+func (s) TestServeSuccess(t *testing.T) {
+	// Setup an xDS management server that pushes on a channel when an LDS
+	// request is received by it.
+	ldsRequestCh := make(chan []string, 1)
+	mgmtServer, nodeID, bootstrapContents, _, cancel := e2e.SetupManagementServer(t, e2e.ManagementServerOptions{
+		OnStreamRequest: func(id int64, req *v3discoverypb.DiscoveryRequest) error {
+			if req.GetTypeUrl() == version.V3ListenerURL {
+				select {
+				case ldsRequestCh <- req.GetResourceNames():
+				default:
+				}
+			}
+			return nil
+		},
+	})
+	defer cancel()
+
+	// Override the function to create the underlying grpc.Server to allow the
+	// test to verify that Serve() is called on the underlying server.
+	fs := newFakeGRPCServer()
+	origNewGRPCServer := newGRPCServer
+	newGRPCServer = func(opts ...grpc.ServerOption) grpcServer { return fs }
+	defer func() { newGRPCServer = origNewGRPCServer }()
+
+	// Create a new xDS enabled gRPC server and pass it a server option to get
+	// notified about serving mode changes.
+	modeChangeCh := testutils.NewChannel()
+	modeChangeOption := ServingModeCallback(func(addr net.Addr, args ServingModeChangeArgs) {
+		t.Logf("Server mode change callback invoked for listener %q with mode %q and error %v", addr.String(), args.Mode, args.Err)
+		modeChangeCh.Send(args.Mode)
+	})
+	server, err := NewGRPCServer(modeChangeOption, BootstrapContentsForTesting(bootstrapContents))
+	if err != nil {
+		t.Fatalf("Failed to create an xDS enabled gRPC server: %v", err)
+	}
+	defer server.Stop()
+
+	// Call Serve() in a goroutine.
+	lis, err := testutils.LocalTCPListener()
+	if err != nil {
+		t.Fatalf("testutils.LocalTCPListener() failed: %v", err)
+	}
+	go func() {
+		if err := server.Serve(lis); err != nil {
+			t.Error(err)
+		}
+	}()
+
+	// Ensure that the LDS request is sent out for the expected name.
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	var gotNames []string
+	select {
+	case gotNames = <-ldsRequestCh:
+	case <-ctx.Done():
+		t.Fatalf("Timeout when waiting for an LDS request to be sent out")
+	}
+	wantNames := []string{strings.Replace(e2e.ServerListenerResourceNameTemplate, "%s", lis.Addr().String(), -1)}
+	if !cmp.Equal(gotNames, wantNames) {
+		t.Fatalf("LDS watch registered for names %v, want %v", gotNames, wantNames)
+	}
+
+	// Update the management server with a good listener resource.
+	host, port := hostPortFromListener(t, lis)
+	resources := e2e.UpdateOptions{
+		NodeID:    nodeID,
+		Listeners: []*v3listenerpb.Listener{e2e.DefaultServerListener(host, port, e2e.SecurityLevelNone)},
+	}
+	if err := mgmtServer.Update(ctx, resources); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify the serving mode reports SERVING.
+	v, err := modeChangeCh.Receive(ctx)
+	if err != nil {
+		t.Fatalf("Timeout when waiting for serving mode to change: %v", err)
+	}
+	if mode := v.(connectivity.ServingMode); mode != connectivity.ServingModeServing {
+		t.Fatalf("Serving mode is %q, want %q", mode, connectivity.ServingModeServing)
+	}
+
+	// Verify that Serve() is called on the underlying gRPC server.
+	if _, err := fs.serveCh.Receive(ctx); err != nil {
+		t.Fatalf("Timeout when waiting for Serve() to be invoked on the grpc.Server")
+	}
+
+	// Update the listener resource on the management server in such a way that
+	// it will be NACKed by our xDS client. The listener_filters field is
+	// unsupported and will be NACKed.
+	resources.Listeners[0].ListenerFilters = []*v3listenerpb.ListenerFilter{{Name: "foo"}}
+	if err := mgmtServer.Update(ctx, resources); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify that there is no change in the serving mode. The server should
+	// continue using the previously received good configuration.
+	sCtx, sCancel := context.WithTimeout(context.Background(), defaultTestShortTimeout)
+	defer sCancel()
+	if v, err := modeChangeCh.Receive(sCtx); err != context.DeadlineExceeded {
+		t.Fatalf("Unexpected change in serving mode. New mode is %v", v.(connectivity.ServingMode))
+	}
+
+	// Remove the listener resource from the management server. This should
+	// result in a resource-not-found error from the xDS client and should
+	// result in the server moving to NOT_SERVING mode.
+	resources.Listeners = nil
+	if err := mgmtServer.Update(ctx, resources); err != nil {
+		t.Fatal(err)
+	}
+	v, err = modeChangeCh.Receive(ctx)
+	if err != nil {
+		t.Fatalf("Timeout when waiting for serving mode to change: %v", err)
+	}
+	if mode := v.(connectivity.ServingMode); mode != connectivity.ServingModeNotServing {
+		t.Fatalf("Serving mode is %q, want %q", mode, connectivity.ServingModeNotServing)
+	}
+}
+
+// TestServeWithStop tests the case where Stop() is called before an LDS update
+// is received. This should cause Serve() to exit before calling Serve() on the
+// underlying grpc.Server.
+func (s) TestServeWithStop(t *testing.T) {
+	// Setup an xDS management server that pushes on a channel when an LDS
+	// request is received by it. It also blocks on the incoming LDS request
+	// until unblocked by the test.
+	ldsRequestCh := make(chan []string, 1)
+	ldsRequestBlockCh := make(chan struct{})
+	mgmtServer, nodeID, _, _, cancel := e2e.SetupManagementServer(t, e2e.ManagementServerOptions{
+		OnStreamRequest: func(id int64, req *v3discoverypb.DiscoveryRequest) error {
+			if req.GetTypeUrl() == version.V3ListenerURL {
+				select {
+				case ldsRequestCh <- req.GetResourceNames():
+				default:
+				}
+				<-ldsRequestBlockCh
+			}
+			return nil
+		},
+	})
+	defer cancel()
+	defer close(ldsRequestBlockCh)
+
+	// Override the function to create the underlying grpc.Server to allow the
+	// test to verify that Serve() is called on the underlying server.
+	fs := newFakeGRPCServer()
+	origNewGRPCServer := newGRPCServer
+	newGRPCServer = func(opts ...grpc.ServerOption) grpcServer { return fs }
+	defer func() { newGRPCServer = origNewGRPCServer }()
+
+	// Create a new xDS enabled gRPC server.  Note that we are not deferring the
+	// Stop() here since we explicitly call it after the LDS watch has been
+	// registered.
+	server, err := NewGRPCServer(BootstrapContentsForTesting(generateBootstrapContents(t, nodeID, mgmtServer.Address)))
+	if err != nil {
+		t.Fatalf("Failed to create an xDS enabled gRPC server: %v", err)
+	}
+
+	// Call Serve() in a goroutine, and push on a channel when Serve returns.
+	lis, err := testutils.LocalTCPListener()
+	if err != nil {
+		server.Stop()
+		t.Fatalf("testutils.LocalTCPListener() failed: %v", err)
+	}
+	serveDone := testutils.NewChannel()
+	go func() {
+		if err := server.Serve(lis); err != nil {
+			t.Error(err)
+		}
+		serveDone.Send(nil)
+	}()
+
+	// Ensure that the LDS request is sent out for the expected name.
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	var gotNames []string
+	select {
+	case gotNames = <-ldsRequestCh:
+	case <-ctx.Done():
+		t.Fatalf("Timeout when waiting for an LDS request to be sent out")
+	}
+	wantNames := []string{strings.Replace(e2e.ServerListenerResourceNameTemplate, "%s", lis.Addr().String(), -1)}
+	if !cmp.Equal(gotNames, wantNames) {
+		t.Fatalf("LDS watch registered for names %v, want %v", gotNames, wantNames)
+	}
+
+	// Call Stop() on the xDS enabled gRPC server before the management server
+	// can respond.
+	server.Stop()
+	if _, err := serveDone.Receive(ctx); err != nil {
+		t.Fatalf("Timeout when waiting for Serve() to exit: %v", err)
+	}
+
+	// Make sure that Serve() on the underlying grpc.Server is not called.
+	sCtx, sCancel := context.WithTimeout(context.Background(), defaultTestShortTimeout)
+	defer sCancel()
+	if _, err := fs.serveCh.Receive(sCtx); err != context.DeadlineExceeded {
+		t.Fatal("Serve() called on underlying grpc.Server")
+	}
+}
+
+// TestNewServer_ClientCreationFailure tests the case where the xDS client
+// creation fails and verifies that the call to NewGRPCServer() fails.
+func (s) TestNewServer_ClientCreationFailure(t *testing.T) {
+	origNewXDSClient := newXDSClient
+	newXDSClient = func() (xdsclient.XDSClient, func(), error) {
+		return nil, nil, errors.New("xdsClient creation failed")
+	}
+	defer func() { newXDSClient = origNewXDSClient }()
+
+	if _, err := NewGRPCServer(); err == nil {
+		t.Fatal("NewGRPCServer() succeeded when expected to fail")
+	}
+}
+
+// TestHandleListenerUpdate_NoXDSCreds tests the case where an xds-enabled gRPC
+// server is not configured with xDS credentials. Verifies that the security
+// config received as part of a Listener update is not acted upon.
+func (s) TestHandleListenerUpdate_NoXDSCreds(t *testing.T) {
+	mgmtServer, err := e2e.StartManagementServer(e2e.ManagementServerOptions{})
+	if err != nil {
+		t.Fatalf("Failed to start xDS management server: %v", err)
+	}
+	defer mgmtServer.Stop()
+
+	// Generate bootstrap configuration pointing to the above management server
+	// with certificate provider configuration pointing to fake certifcate
+	// providers.
+	nodeID := uuid.NewString()
+	bootstrapContents, err := bootstrap.Contents(bootstrap.Options{
+		NodeID:    nodeID,
+		ServerURI: mgmtServer.Address,
+		CertificateProviders: map[string]json.RawMessage{
+			e2e.ServerSideCertProviderInstance: fakeProvider1Config,
+			e2e.ClientSideCertProviderInstance: fakeProvider2Config,
+		},
+		ServerListenerResourceNameTemplate: e2e.ServerListenerResourceNameTemplate,
+	})
+	if err != nil {
+		t.Fatalf("Failed to create bootstrap configuration: %v", err)
+	}
+
+	// Create a new xDS enabled gRPC server and pass it a server option to get
+	// notified about serving mode changes. Also pass the above bootstrap
+	// configuration to be used during xDS client creation.
+	modeChangeCh := testutils.NewChannel()
+	modeChangeOption := ServingModeCallback(func(addr net.Addr, args ServingModeChangeArgs) {
+		t.Logf("Server mode change callback invoked for listener %q with mode %q and error %v", addr.String(), args.Mode, args.Err)
+		modeChangeCh.Send(args.Mode)
+	})
+	server, err := NewGRPCServer(modeChangeOption, BootstrapContentsForTesting(bootstrapContents))
+	if err != nil {
+		t.Fatalf("Failed to create an xDS enabled gRPC server: %v", err)
+	}
+	defer server.Stop()
+
+	// Call Serve() in a goroutine.
+	lis, err := testutils.LocalTCPListener()
+	if err != nil {
+		t.Fatalf("testutils.LocalTCPListener() failed: %v", err)
+	}
+	go func() {
+		if err := server.Serve(lis); err != nil {
+			t.Error(err)
+		}
+	}()
+
+	// Update the management server with a good listener resource that contains
+	// security configuration.
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	host, port := hostPortFromListener(t, lis)
+	resources := e2e.UpdateOptions{
+		NodeID:    nodeID,
+		Listeners: []*v3listenerpb.Listener{e2e.DefaultServerListener(host, port, e2e.SecurityLevelMTLS)},
+	}
+	if err := mgmtServer.Update(ctx, resources); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify the serving mode reports SERVING.
+	v, err := modeChangeCh.Receive(ctx)
+	if err != nil {
+		t.Fatalf("Timeout when waiting for serving mode to change: %v", err)
+	}
+	if mode := v.(connectivity.ServingMode); mode != connectivity.ServingModeServing {
+		t.Fatalf("Serving mode is %q, want %q", mode, connectivity.ServingModeServing)
+	}
+
+	// Make sure the security configuration is not acted upon.
+	if err := verifyCertProviderNotCreated(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestHandleListenerUpdate_ErrorUpdate tests the case where an xds-enabled gRPC
+// server is configured with xDS credentials, but receives a Listener update
+// with an error. Verifies that no certificate providers are created.
+func (s) TestHandleListenerUpdate_ErrorUpdate(t *testing.T) {
+	// Setup an xDS management server that pushes on a channel when an LDS
+	// request is received by it.
+	ldsRequestCh := make(chan []string, 1)
+	mgmtServer, nodeID, _, _, cancel := e2e.SetupManagementServer(t, e2e.ManagementServerOptions{
+		OnStreamRequest: func(id int64, req *v3discoverypb.DiscoveryRequest) error {
+			if req.GetTypeUrl() == version.V3ListenerURL {
+				select {
+				case ldsRequestCh <- req.GetResourceNames():
+				default:
+				}
+			}
+			return nil
+		},
+	})
+	defer cancel()
+
+	// Generate bootstrap configuration pointing to the above management server
+	// with certificate provider configuration pointing to fake certifcate
+	// providers.
+	bootstrapContents, err := bootstrap.Contents(bootstrap.Options{
+		NodeID:    nodeID,
+		ServerURI: mgmtServer.Address,
+		CertificateProviders: map[string]json.RawMessage{
+			e2e.ServerSideCertProviderInstance: fakeProvider1Config,
+			e2e.ClientSideCertProviderInstance: fakeProvider2Config,
+		},
+		ServerListenerResourceNameTemplate: e2e.ServerListenerResourceNameTemplate,
+	})
+	if err != nil {
+		t.Fatalf("Failed to create bootstrap configuration: %v", err)
+	}
+
+	// Create a new xDS enabled gRPC server and pass it a server option to get
+	// notified about serving mode changes. Also pass the above bootstrap
+	// configuration to be used during xDS client creation.
+	modeChangeCh := testutils.NewChannel()
+	modeChangeOption := ServingModeCallback(func(addr net.Addr, args ServingModeChangeArgs) {
+		t.Logf("Server mode change callback invoked for listener %q with mode %q and error %v", addr.String(), args.Mode, args.Err)
+		modeChangeCh.Send(args.Mode)
+	})
+	server, err := NewGRPCServer(modeChangeOption, BootstrapContentsForTesting(bootstrapContents))
+	if err != nil {
+		t.Fatalf("Failed to create an xDS enabled gRPC server: %v", err)
+	}
+	defer server.Stop()
+
+	// Call Serve() in a goroutine.
+	lis, err := testutils.LocalTCPListener()
+	if err != nil {
+		t.Fatalf("testutils.LocalTCPListener() failed: %v", err)
+	}
+	go server.Serve(lis)
+
+	// Update the listener resource on the management server in such a way that
+	// it will be NACKed by our xDS client. The listener_filters field is
+	// unsupported and will be NACKed.
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	host, port := hostPortFromListener(t, lis)
+	listener := e2e.DefaultServerListener(host, port, e2e.SecurityLevelMTLS)
+	listener.ListenerFilters = []*v3listenerpb.ListenerFilter{{Name: "foo"}}
+	resources := e2e.UpdateOptions{
+		NodeID:    nodeID,
+		Listeners: []*v3listenerpb.Listener{listener},
+	}
+	if err := mgmtServer.Update(ctx, resources); err != nil {
+		t.Fatal(err)
+	}
+
+	// Ensure that the LDS request is sent out for the expected name.
+	var gotNames []string
+	select {
+	case gotNames = <-ldsRequestCh:
+	case <-ctx.Done():
+		t.Fatalf("Timeout when waiting for an LDS request to be sent out")
+	}
+	wantNames := []string{strings.Replace(e2e.ServerListenerResourceNameTemplate, "%s", lis.Addr().String(), -1)}
+	if !cmp.Equal(gotNames, wantNames) {
+		t.Fatalf("LDS watch registered for names %v, want %v", gotNames, wantNames)
+	}
+
+	// Make sure that no certificate providers are created.
+	if err := verifyCertProviderNotCreated(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Also make sure that no serving mode updates are received. The serving
+	// mode does not change until the server comes to the conclusion that the
+	// requested resource is not present in the management server. This happens
+	// when the watch timer expires or when the resource is explicitly deleted
+	// by the management server.
+	sCtx, sCancel := context.WithTimeout(context.Background(), defaultTestShortTimeout)
+	defer sCancel()
+	if _, err := modeChangeCh.Receive(sCtx); err != context.DeadlineExceeded {
+		t.Fatal("Serving mode changed received when none expected")
+	}
+}
+
 // TestServeReturnsErrorAfterClose tests that the xds Server returns
 // grpc.ErrServerStopped if Serve is called after Close on the server.
 func (s) TestServeReturnsErrorAfterClose(t *testing.T) {
-	cancel := setupClientOverride(t)
-	defer cancel()
-	server := NewGRPCServer()
+	server, err := NewGRPCServer(BootstrapContentsForTesting(generateBootstrapContents(t, uuid.NewString(), nonExistentManagementServer)))
+	if err != nil {
+		t.Fatalf("Failed to create an xDS enabled gRPC server: %v", err)
+	}
 
 	lis, err := testutils.LocalTCPListener()
 	if err != nil {
 		t.Fatalf("testutils.LocalTCPListener() failed: %v", err)
 	}
-
 	server.Stop()
 	err = server.Serve(lis)
 	if err == nil || !strings.Contains(err.Error(), grpc.ErrServerStopped.Error()) {
@@ -932,9 +792,6 @@ func (s) TestServeReturnsErrorAfterClose(t *testing.T) {
 // TestServeAndCloseDoNotRace tests that Serve and Close on the xDS Server do
 // not race and leak the xDS Client. A leak would be found by the leak checker.
 func (s) TestServeAndCloseDoNotRace(t *testing.T) {
-	cleanup := setupClientOverride(t)
-	defer cleanup()
-
 	lis, err := testutils.LocalTCPListener()
 	if err != nil {
 		t.Fatalf("testutils.LocalTCPListener() failed: %v", err)
@@ -942,7 +799,10 @@ func (s) TestServeAndCloseDoNotRace(t *testing.T) {
 
 	wg := sync.WaitGroup{}
 	for i := 0; i < 100; i++ {
-		server := NewGRPCServer()
+		server, err := NewGRPCServer(BootstrapContentsForTesting(generateBootstrapContents(t, uuid.NewString(), nonExistentManagementServer)))
+		if err != nil {
+			t.Fatalf("Failed to create an xDS enabled gRPC server: %v", err)
+		}
 		wg.Add(1)
 		go func() {
 			server.Serve(lis)


### PR DESCRIPTION
Currently we create the xDS client when `Serve()` is called for the first time. This leads to unnecessary code complexity since we have to synchronize access to the xDS client and its close function inside the server. The following code paths touch the xDS client:
- In `Serve` to see if one has been created, and create a new one if none exists
- In `Stop` and `GracefulStop` to closed the client
- In the `ListenerWrapper` to register LDS and RDS watches using it

This PR changes the code such that the xDS client is created when the xDS enabled gRPC server is created. Certain bootstrap configuration validation is also moved to here. Therefore we can fail the server creation when appropriate.

Note that with this change, since the mutex has been eliminated, `Serve` and `Stop` can race in the sense that `Serve` might not return `grpc.ErrServerStopped` in all cases, but this does not affect any other functionality and does not lead to leaking of the xDS client.

This PR also cleans up the tests to use a real management server and gets rid of using a fake xDS client.

RELEASE NOTES: none