### PR TITLE
xds: Passthrough filter name to RBAC filters

### DIFF
--- a/authz/grpc_authz_server_interceptors.go
+++ b/authz/grpc_authz_server_interceptors.go
@@ -48,7 +48,8 @@ func NewStatic(authzPolicy string) (*StaticInterceptor, error) {
 	if err != nil {
 		return nil, err
 	}
-	chainEngine, err := rbac.NewChainEngine(rbacs, policyName)
+	chainEngine, err := rbac.NewChainEngine(rbacs)
+	chainEngine.SetName(policyName)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/xds/rbac/rbac_engine.go
+++ b/internal/xds/rbac/rbac_engine.go
@@ -112,6 +112,7 @@ func (cre *ChainEngine) IsAuthorized(ctx context.Context) error {
 	return nil
 }
 
+// SetName sets the policyName on each engine in the chain to name.
 func (cre *ChainEngine) SetName(name string) {
 	for _, e := range cre.chainedEngines {
 		e.policyName = name

--- a/internal/xds/rbac/rbac_engine.go
+++ b/internal/xds/rbac/rbac_engine.go
@@ -112,6 +112,12 @@ func (cre *ChainEngine) IsAuthorized(ctx context.Context) error {
 	return nil
 }
 
+func (cre *ChainEngine) SetName(name string) {
+	for _, e := range cre.chainedEngines {
+		e.policyName = name
+	}
+}
+
 // engine is used for matching incoming RPCs to policies.
 type engine struct {
 	// TODO(gtcooke94) - differentiate between `policyName`, `policies`, and `rules`

--- a/internal/xds/rbac/rbac_engine.go
+++ b/internal/xds/rbac/rbac_engine.go
@@ -52,10 +52,10 @@ type ChainEngine struct {
 
 // NewChainEngine returns a chain of RBAC engines, used to make authorization
 // decisions on incoming RPCs. Returns a non-nil error for invalid policies.
-func NewChainEngine(policies []*v3rbacpb.RBAC, policyName string) (*ChainEngine, error) {
+func NewChainEngine(policies []*v3rbacpb.RBAC) (*ChainEngine, error) {
 	engines := make([]*engine, 0, len(policies))
 	for _, policy := range policies {
-		engine, err := newEngine(policy, policyName)
+		engine, err := newEngine(policy)
 		if err != nil {
 			return nil, err
 		}
@@ -132,7 +132,7 @@ type engine struct {
 
 // newEngine creates an RBAC Engine based on the contents of a policy. Returns a
 // non-nil error if the policy is invalid.
-func newEngine(config *v3rbacpb.RBAC, policyName string) (*engine, error) {
+func newEngine(config *v3rbacpb.RBAC) (*engine, error) {
 	a := config.GetAction()
 	if a != v3rbacpb.RBAC_ALLOW && a != v3rbacpb.RBAC_DENY {
 		return nil, fmt.Errorf("unsupported action %s", config.Action)
@@ -152,7 +152,6 @@ func newEngine(config *v3rbacpb.RBAC, policyName string) (*engine, error) {
 		return nil, err
 	}
 	return &engine{
-		policyName:     policyName,
 		policies:       policies,
 		action:         a,
 		auditLoggers:   auditLoggers,

--- a/internal/xds/rbac/rbac_engine_test.go
+++ b/internal/xds/rbac/rbac_engine_test.go
@@ -671,7 +671,7 @@ func (s) TestNewChainEngine(t *testing.T) {
 			audit.RegisterLoggerBuilder(&b)
 			b2 := TestAuditLoggerCustomConfigBuilder{testName: test.name}
 			audit.RegisterLoggerBuilder(&b2)
-			if _, err := NewChainEngine(test.policies, test.policyName); (err != nil) != test.wantErr {
+			if _, err := NewChainEngine(test.policies); (err != nil) != test.wantErr {
 				t.Fatalf("NewChainEngine(%+v) returned err: %v, wantErr: %v", test.policies, err, test.wantErr)
 			}
 		})
@@ -1736,7 +1736,8 @@ func (s) TestChainEngine(t *testing.T) {
 
 			// Instantiate the chainedRBACEngine with different configurations that are
 			// interesting to test and to query.
-			cre, err := NewChainEngine(test.rbacConfigs, test.policyName)
+			cre, err := NewChainEngine(test.rbacConfigs)
+			cre.SetName(test.policyName)
 			if err != nil {
 				t.Fatalf("Error constructing RBAC Engine: %v", err)
 			}

--- a/xds/internal/httpfilter/httpfilter.go
+++ b/xds/internal/httpfilter/httpfilter.go
@@ -75,7 +75,7 @@ type ServerInterceptorBuilder interface {
 	// but override may be nil if no override config exists for the filter.  It
 	// is valid for Build to return a nil Interceptor and a nil error.  In this
 	// case, the RPC will not be intercepted by this filter.
-	BuildServerInterceptor(config, override FilterConfig) (iresolver.ServerInterceptor, error)
+	BuildServerInterceptor(config, override FilterConfig, name string) (iresolver.ServerInterceptor, error)
 }
 
 var (

--- a/xds/internal/httpfilter/rbac/rbac.go
+++ b/xds/internal/httpfilter/rbac/rbac.go
@@ -59,7 +59,7 @@ type builder struct {
 
 type config struct {
 	httpfilter.FilterConfig
-	ChainEngine *rbac.ChainEngine
+	chainEngine *rbac.ChainEngine
 }
 
 func (builder) TypeURLs() []string {
@@ -138,7 +138,7 @@ func parseConfig(rbacCfg *rpb.RBAC) (httpfilter.FilterConfig, error) {
 		}
 	}
 
-	return config{ChainEngine: ce}, nil
+	return config{chainEngine: ce}, nil
 }
 
 func (builder) ParseFilterConfig(cfg proto.Message) (httpfilter.FilterConfig, error) {
@@ -203,12 +203,12 @@ func (builder) BuildServerInterceptor(cfg httpfilter.FilterConfig, override http
 	// Documentation for Rules field.
 	// "At this time, if the RBAC.action is Action.LOG then the policy will be
 	// completely ignored, as if RBAC was not configurated." - A41
-	if c.ChainEngine == nil {
+	if c.chainEngine == nil {
 		return nil, nil
 	}
 
-	c.ChainEngine.SetName(name)
-	return &interceptor{chainEngine: c.ChainEngine}, nil
+	c.chainEngine.SetName(name)
+	return &interceptor{chainEngine: c.chainEngine}, nil
 }
 
 type interceptor struct {

--- a/xds/internal/httpfilter/rbac/rbac.go
+++ b/xds/internal/httpfilter/rbac/rbac.go
@@ -59,7 +59,7 @@ type builder struct {
 
 type config struct {
 	httpfilter.FilterConfig
-	chainEngine *rbac.ChainEngine
+	ChainEngine *rbac.ChainEngine
 }
 
 func (builder) TypeURLs() []string {
@@ -138,7 +138,7 @@ func parseConfig(rbacCfg *rpb.RBAC) (httpfilter.FilterConfig, error) {
 		}
 	}
 
-	return config{chainEngine: ce}, nil
+	return config{ChainEngine: ce}, nil
 }
 
 func (builder) ParseFilterConfig(cfg proto.Message) (httpfilter.FilterConfig, error) {
@@ -179,7 +179,7 @@ var _ httpfilter.ServerInterceptorBuilder = builder{}
 
 // BuildServerInterceptor is an optional interface builder implements in order
 // to signify it works server side.
-func (builder) BuildServerInterceptor(cfg httpfilter.FilterConfig, override httpfilter.FilterConfig) (resolver.ServerInterceptor, error) {
+func (builder) BuildServerInterceptor(cfg httpfilter.FilterConfig, override httpfilter.FilterConfig, name string) (resolver.ServerInterceptor, error) {
 	if cfg == nil {
 		return nil, fmt.Errorf("rbac: nil config provided")
 	}
@@ -203,10 +203,12 @@ func (builder) BuildServerInterceptor(cfg httpfilter.FilterConfig, override http
 	// Documentation for Rules field.
 	// "At this time, if the RBAC.action is Action.LOG then the policy will be
 	// completely ignored, as if RBAC was not configurated." - A41
-	if c.chainEngine == nil {
+	if c.ChainEngine == nil {
 		return nil, nil
 	}
-	return &interceptor{chainEngine: c.chainEngine}, nil
+
+	c.ChainEngine.SetName(name)
+	return &interceptor{chainEngine: c.ChainEngine}, nil
 }
 
 type interceptor struct {

--- a/xds/internal/httpfilter/rbac/rbac.go
+++ b/xds/internal/httpfilter/rbac/rbac.go
@@ -126,10 +126,7 @@ func parseConfig(rbacCfg *rpb.RBAC) (httpfilter.FilterConfig, error) {
 		return config{}, nil
 	}
 
-	// TODO(gregorycooke) - change the call chain to here so we have the filter
-	// name to input here instead of an empty string. It will come from here:
-	// https://github.com/grpc/grpc-go/blob/eff0942e95d93112921414aee758e619ec86f26f/xds/internal/xdsclient/xdsresource/unmarshal_lds.go#L199
-	ce, err := rbac.NewChainEngine([]*v3rbacpb.RBAC{rbacCfg.GetRules()}, "")
+	ce, err := rbac.NewChainEngine([]*v3rbacpb.RBAC{rbacCfg.GetRules()})
 	if err != nil {
 		// "At this time, if the RBAC.action is Action.LOG then the policy will be
 		// completely ignored, as if RBAC was not configurated." - A41
@@ -177,8 +174,8 @@ func (builder) IsTerminal() bool {
 
 var _ httpfilter.ServerInterceptorBuilder = builder{}
 
-// BuildServerInterceptor is an optional interface builder implements in order
-// to signify it works server side.
+// BuildServerInterceptor is an optional interface that builder implements in
+// order to signify it works server side.
 func (builder) BuildServerInterceptor(cfg httpfilter.FilterConfig, override httpfilter.FilterConfig, name string) (resolver.ServerInterceptor, error) {
 	if cfg == nil {
 		return nil, fmt.Errorf("rbac: nil config provided")

--- a/xds/internal/httpfilter/router/router.go
+++ b/xds/internal/httpfilter/router/router.go
@@ -95,7 +95,7 @@ func (builder) BuildClientInterceptor(cfg, override httpfilter.FilterConfig) (ir
 	return nil, nil
 }
 
-func (builder) BuildServerInterceptor(cfg, override httpfilter.FilterConfig) (iresolver.ServerInterceptor, error) {
+func (builder) BuildServerInterceptor(cfg, override httpfilter.FilterConfig, _ string) (iresolver.ServerInterceptor, error) {
 	if _, ok := cfg.(config); !ok {
 		return nil, fmt.Errorf("router: incorrect config type provided (%T): %v", cfg, cfg)
 	}

--- a/xds/internal/xdsclient/xdsresource/filter_chain.go
+++ b/xds/internal/xdsclient/xdsresource/filter_chain.go
@@ -129,7 +129,7 @@ func (f *FilterChain) convertVirtualHost(virtualHost *VirtualHost) (VirtualHostW
 				// Should not happen if it passed xdsClient validation.
 				return VirtualHostWithInterceptors{}, fmt.Errorf("filter does not support use in server")
 			}
-			si, err := sb.BuildServerInterceptor(filter.Config, override)
+			si, err := sb.BuildServerInterceptor(filter.Config, override, filter.Name)
 			if err != nil {
 				return VirtualHostWithInterceptors{}, fmt.Errorf("filter construction: %v", err)
 			}

--- a/xds/internal/xdsclient/xdsresource/filter_chain_test.go
+++ b/xds/internal/xdsclient/xdsresource/filter_chain_test.go
@@ -2596,7 +2596,7 @@ type filterBuilder struct {
 
 var _ httpfilter.ServerInterceptorBuilder = &filterBuilder{}
 
-func (fb *filterBuilder) BuildServerInterceptor(config httpfilter.FilterConfig, override httpfilter.FilterConfig) (iresolver.ServerInterceptor, error) {
+func (fb *filterBuilder) BuildServerInterceptor(config httpfilter.FilterConfig, override httpfilter.FilterConfig, _ string) (iresolver.ServerInterceptor, error) {
 	var level string
 	level = config.(filterCfg).level
 


### PR DESCRIPTION
Our filters are named in the input configs, but the overall name was not getting passed through to the rbac config.

This PR makes that name get passed through via the `ServerInterceptorBuilder`. Everything else that uses `ServerInterceptorBuilder` had to have this `name` parameter added, but it is blank for them.

Each `engine` in the constructed `ChainEngine` is expected to have the same overall policy name. I exported a new function `SetName` on `ChainEngine` so that the rbac code could set this value.

RELEASE NOTES: N/A