### PR TITLE
clusterresolver: comply with A37 for handling errors from discovery mechanisms

### DIFF
--- a/xds/internal/balancer/clusterresolver/configbuilder.go
+++ b/xds/internal/balancer/clusterresolver/configbuilder.go
@@ -191,15 +191,14 @@ func buildClusterImplConfigForEDS(g *nameGenerator, edsResp xdsresource.Endpoint
 	}
 
 	var priorities [][]xdsresource.Locality
-	// Triggered by an EDS error before update, or empty localities list in a
-	// update. In either case want to create a priority, and send down empty
-	// address list, causing TF for that priority.
+	// Triggered by an NACK or resource-not-found error before update, or a
+	// empty localities list in a update. In either case want to create a
+	// priority, and send down empty address list, causing TF for that priority.
 	if len(edsResp.Localities) == 0 {
 		// "If any discovery mechanism instance experiences an error retrieving
 		// data, and it has not previously reported any results, it should
 		// report a result that is a single priority with no endpoints." - A37
-		priorities = make([][]xdsresource.Locality, 1)
-		priorities[0] = make([]xdsresource.Locality, 0)
+		priorities = [][]xdsresource.Locality{{}}
 	} else {
 		priorities = groupLocalitiesByPriority(edsResp.Localities)
 	}

--- a/xds/internal/balancer/clusterresolver/configbuilder.go
+++ b/xds/internal/balancer/clusterresolver/configbuilder.go
@@ -190,16 +190,15 @@ func buildClusterImplConfigForEDS(g *nameGenerator, edsResp xdsresource.Endpoint
 		})
 	}
 
-	var priorities [][]xdsresource.Locality
-	// Triggered by an NACK or resource-not-found error before update, or a
-	// empty localities list in a update. In either case want to create a
-	// priority, and send down empty address list, causing TF for that priority.
-	if len(edsResp.Localities) == 0 {
-		// "If any discovery mechanism instance experiences an error retrieving
-		// data, and it has not previously reported any results, it should
-		// report a result that is a single priority with no endpoints." - A37
-		priorities = [][]xdsresource.Locality{{}}
-	} else {
+	// Localities of length 0 is triggered by an NACK or resource-not-found
+	// error before update, or a empty localities list in a update. In either
+	// case want to create a priority, and send down empty address list, causing
+	// TF for that priority. "If any discovery mechanism instance experiences an
+	// error retrieving data, and it has not previously reported any results, it
+	// should report a result that is a single priority with no endpoints." -
+	// A37
+	priorities := [][]xdsresource.Locality{{}}
+	if len(edsResp.Localities) != 0 {
 		priorities = groupLocalitiesByPriority(edsResp.Localities)
 	}
 	retNames := g.generate(priorities)

--- a/xds/internal/balancer/clusterresolver/resource_resolver.go
+++ b/xds/internal/balancer/clusterresolver/resource_resolver.go
@@ -38,7 +38,6 @@ type resourceUpdate struct {
 // from underlying concrete resolvers.
 type topLevelResolver interface {
 	onUpdate()
-	onError(error)
 }
 
 // endpointsResolver wraps the functionality to resolve a given resource name to
@@ -276,12 +275,4 @@ func (rr *resourceResolver) onUpdate() {
 	rr.mu.Lock()
 	rr.generateLocked()
 	rr.mu.Unlock()
-}
-
-func (rr *resourceResolver) onError(err error) {
-	select {
-	case <-rr.updateChannel:
-	default:
-	}
-	rr.updateChannel <- &resourceUpdate{err: err}
 }

--- a/xds/internal/balancer/clusterresolver/resource_resolver_dns.go
+++ b/xds/internal/balancer/clusterresolver/resource_resolver_dns.go
@@ -76,7 +76,7 @@ func newDNSResolver(target string, topLevelResolver topLevelResolver, logger *gr
 	u, err := url.Parse("dns:///" + target)
 	if err != nil {
 		if ret.logger.V(2) {
-			ret.logger.Infof("failed to parse dns hostname %q in clusterresolver LB policy", target)
+			ret.logger.Infof("Failed to parse dns hostname %q in clusterresolver LB policy", target)
 		}
 		ret.updateReceived = true
 		ret.topLevelResolver.onUpdate()
@@ -86,7 +86,7 @@ func newDNSResolver(target string, topLevelResolver topLevelResolver, logger *gr
 	r, err := newDNS(resolver.Target{URL: *u}, ret, resolver.BuildOptions{})
 	if err != nil {
 		if ret.logger.V(2) {
-			ret.logger.Infof("failed to build DNS resolver for target %q: %v", target, err)
+			ret.logger.Infof("Failed to build DNS resolver for target %q: %v", target, err)
 		}
 		ret.updateReceived = true
 		ret.topLevelResolver.onUpdate()


### PR DESCRIPTION
Fixes #6462. This PR fixes cluster_resolver error handing. The desired behavior as per gRFC A37 is to create a priority and send down an empty address list if an EDS Discovery Mechanism or DNS Discovery Mechanism errors before a first good update, triggering Transient Failure for that priority and causing fallback if another lower level priority. In master, we simply don't create the priority child in the EDS case and send down a resolver error in the DNS case.

RELEASE NOTES: N/A