### PR TITLE
fix: 6478: wrap pointer safety check around cc.cancel in Close()

### DIFF
--- a/clientconn.go
+++ b/clientconn.go
@@ -1209,7 +1209,11 @@ func (cc *ClientConn) ResetConnectBackoff() {
 
 // Close tears down the ClientConn and all underlying connections.
 func (cc *ClientConn) Close() error {
-	defer cc.cancel()
+	defer func() {
+		if cc.cancel != nil {
+			cc.cancel()
+		}
+	}()
 
 	cc.mu.Lock()
 	if cc.conns == nil {

--- a/clientconn_test.go
+++ b/clientconn_test.go
@@ -254,6 +254,18 @@ func (s) TestDialWaitsForServerSettingsAndFails(t *testing.T) {
 	}
 }
 
+// 1. Client creates an empty ClientConn instance
+// 2. Client calls Close() on uninitialized ClientConn instance
+// 3. Close() should return ErrClientConnClosing
+func (s) TestCloseConnectionUninitialized(t *testing.T) {
+	client := ClientConn{}
+	err := client.Close()
+
+	if err != ErrClientConnClosing {
+		t.Fatalf("error return from Close() is %v; want %v", err, ErrClientConnClosing)
+	}
+}
+
 // 1. Client connects to a server that doesn't send preface.
 // 2. After minConnectTimeout(500 ms here), client disconnects and retries.
 // 3. The new server sends its preface.


### PR DESCRIPTION
RELEASE NOTES: none

This PR addresses #6478.

Changes:
- wrap deferred call to cc.cancel() in ClientConn.Close() in a nil pointer check to ensure we don't dereference a nil pointer in the case that the ClientConn is uninitialized
- create a unit test that creates the scenario and expects the code not to panic and to instead return the proper error

All tests and vet.sh pass.

I will accept/sign the LInux Foundation CLA once the PR is open.