### PR TITLE
testutils: remove TestSubConns for future extensibility

### DIFF
--- a/xds/internal/testutils/balancer_test.go
+++ b/xds/internal/testutils/balancer_test.go
@@ -27,9 +27,9 @@ import (
 
 func TestIsRoundRobin(t *testing.T) {
 	var (
-		sc1 = testutils.TestSubConns[0]
-		sc2 = testutils.TestSubConns[1]
-		sc3 = testutils.TestSubConns[2]
+		sc1 = &testutils.TestSubConn{}
+		sc2 = &testutils.TestSubConn{}
+		sc3 = &testutils.TestSubConn{}
 	)
 
 	testCases := []struct {


### PR DESCRIPTION
When adding methods to `TestSubConn` (matching new APIs planned in #6472), I found that this global was not necessary and was making it harder to do so.  So this PR removes that global and uses more local things in the two places it is used instead.

RELEASE NOTES: n/a