### PR TITLE
grpc: perform a blocking close of the balancer in ccb

### DIFF
--- a/balancer_conn_wrappers.go
+++ b/balancer_conn_wrappers.go
@@ -226,11 +226,9 @@ func (ccb *ccBalancerWrapper) closeBalancer(m ccbMode) {
 	}
 	ccb.mu.Unlock()
 
-	// Give enqueued callbacks a chance to finish.
+	// Give enqueued callbacks a chance to finish before closing the balancer.
 	<-done
-	// Spawn a goroutine to close the balancer (since it may block trying to
-	// cleanup all allocated resources) and return early.
-	go b.Close()
+	b.Close()
 }
 
 // exitIdleMode is invoked by grpc when the channel exits idle mode either


### PR DESCRIPTION
This PR fixes the following issue:
- Channel is `READY` and things are good
- After a period of inactivity, channel moves to `IDLE`
  - As part of this the LB policy is shutdown. But currently a goroutine is spawned to shutdown the LB policy.
- At the same time, an RPC is initiated
  - This brings the channel out of `IDLE` and a new LB policy is created
- New policy moves channel to `READY`
- Still, the old policy hasn't been completely shutdown because the goroutine did not get a change to run
  - The connections belonging to the old policy and shutdown, and the old policy receives state updates on these subConns
  - The old policy updates channel with `TRANSIENT_FAILURE` 

This whole scenario can be prevented if the old policy was shutdown inline when the channel entered `IDLE`.

This PR also includes a minor fix to one of the tests to prevent a race where the test is waiting for the channel become `READY`. But it could so happen that the channel became `READY` and in fact became `IDLE` before the test started the check. Instead of relying on the connectivity state, the test now performs an RPC to ensure that the channel is in fact `READY`.

RELEASE NOTES:
- grpc: fix a bug where the channel could erroneously move to `TRANSIENT_FAILURE` when actually moving to `IDLE`