### PR TITLE
test/xds: increase default test timeout

### DIFF
--- a/test/xds/xds_client_integration_test.go
+++ b/test/xds/xds_client_integration_test.go
@@ -44,7 +44,7 @@ func Test(t *testing.T) {
 }
 
 const (
-	defaultTestTimeout      = 5 * time.Second
+	defaultTestTimeout      = 10 * time.Second
 	defaultTestShortTimeout = 10 * time.Millisecond // For events expected to *not* happen.
 )
 


### PR DESCRIPTION
As part of some other testing, I noticed that one of the custom LB policy tests which verifies RR behavior was quite flaky on google3. The reason being the `5s` default test timeout that we use. The test verifies that the RPC distribution reaches expected value within this timeout. Increasing the timeout to `10s` fixes the issue.

RELEASE NOTES: none