### PR TITLE
clusterresolver: fix a flaky test

### DIFF
--- a/xds/internal/balancer/clusterresolver/e2e_test/balancer_test.go
+++ b/xds/internal/balancer/clusterresolver/e2e_test/balancer_test.go
@@ -276,9 +276,11 @@ func (s) TestErrorFromParentLB_ResourceNotFound(t *testing.T) {
 		t.Fatalf("RPCs did not fail after removal of Cluster resource")
 	}
 
-	// Ensure that the ClientConn is in TransientFailure.
-	if state := cc.GetState(); state != connectivity.TransientFailure {
-		t.Fatalf("Unexpected connectivity state for ClientConn, got: %s, want %s", state, connectivity.TransientFailure)
+	// Ensure that the ClientConn moves to TransientFailure.
+	for state := cc.GetState(); state != connectivity.TransientFailure; state = cc.GetState() {
+		if !cc.WaitForStateChange(ctx, state) {
+			t.Fatalf("Timed out waiting for state change.  got %v; want %v", state, connectivity.TransientFailure)
+		}
 	}
 
 	// Configure cluster and endpoints resources in the management server.

--- a/xds/internal/balancer/clusterresolver/e2e_test/balancer_test.go
+++ b/xds/internal/balancer/clusterresolver/e2e_test/balancer_test.go
@@ -279,7 +279,7 @@ func (s) TestErrorFromParentLB_ResourceNotFound(t *testing.T) {
 	// Ensure that the ClientConn moves to TransientFailure.
 	for state := cc.GetState(); state != connectivity.TransientFailure; state = cc.GetState() {
 		if !cc.WaitForStateChange(ctx, state) {
-			t.Fatalf("Timed out waiting for state change.  got %v; want %v", state, connectivity.TransientFailure)
+			t.Fatalf("Timed out waiting for state change. got %v; want %v", state, connectivity.TransientFailure)
 		}
 	}
 


### PR DESCRIPTION
In one of the `clusterresolver` tests, we remove the EDS resource from the management server and expect RPCs to fail *and then* verify that the connectivity state of the channel is `TRANSIENT_FAILURE`.

When the LB policy reports a state update with a new picker and new connectivity state, the picker is first applied. This is by design. See: https://github.com/grpc/grpc-go/blob/master/balancer_conn_wrappers.go#L351-L357

This means that in the above test, when the `clusterresolver` reports a new picker and a state of `TRANSIENT_FAILURE`, the picker is first applied, thereby causing RPCs to fail. The channel state is yet to be updated though, and in this tiny time window, the test reads the current connectivity state of the channel and expects it to be `TRANSIENT_FAILURE`. Changing the test to retry this check in a loop fixes the flake.


RELEASE NOTES: none