### PR TITLE
xdsclient: make watch timer a no-op if authority is closed

### DIFF
--- a/xds/internal/xdsclient/authority.go
+++ b/xds/internal/xdsclient/authority.go
@@ -83,6 +83,7 @@ type authority struct {
 	// actual state of the resource.
 	resourcesMu sync.Mutex
 	resources   map[xdsresource.Type]map[string]*resourceState
+	closed      bool
 }
 
 // authorityArgs is a convenience struct to wrap arguments required to create a
@@ -443,6 +444,10 @@ func (a *authority) unrefLocked() int {
 
 func (a *authority) close() {
 	a.transport.Close()
+
+	a.resourcesMu.Lock()
+	a.closed = true
+	a.resourcesMu.Unlock()
 }
 
 func (a *authority) watchResource(rType xdsresource.Type, resourceName string, watcher xdsresource.ResourceWatcher) func() {
@@ -507,9 +512,13 @@ func (a *authority) watchResource(rType xdsresource.Type, resourceName string, w
 }
 
 func (a *authority) handleWatchTimerExpiry(rType xdsresource.Type, resourceName string, state *resourceState) {
-	a.logger.Warningf("Watch for resource %q of type %s timed out", resourceName, rType.TypeName())
 	a.resourcesMu.Lock()
 	defer a.resourcesMu.Unlock()
+
+	if a.closed {
+		return
+	}
+	a.logger.Warningf("Watch for resource %q of type %s timed out", resourceName, rType.TypeName())
 
 	switch state.wState {
 	case watchStateRequested:


### PR DESCRIPTION
This fixes a test flake where the timer fires after the authority is closed and the test is done, and leads to a log message being thrown after the test completes. And this races with the test logger being set on the top-level test object.

RELEASE NOTES: none