### PR TITLE
test: clean up deadlines set in tests

### DIFF
--- a/test/authority_test.go
+++ b/test/authority_test.go
@@ -29,7 +29,6 @@ import (
 	"strings"
 	"sync"
 	"testing"
-	"time"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -84,7 +83,7 @@ func runUnixTest(t *testing.T, address, target, expectedAuthority string, dialer
 		t.Fatalf("Error starting endpoint server: %v", err)
 	}
 	defer ss.Stop()
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
 	_, err := ss.Client.EmptyCall(ctx, &testpb.Empty{})
 	if err != nil {
@@ -202,7 +201,7 @@ func (s) TestColonPortAuthority(t *testing.T) {
 		t.Fatalf("grpc.Dial(%q) = %v", ss.Target, err)
 	}
 	defer cc.Close()
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
 	_, err = testgrpc.NewTestServiceClient(cc).EmptyCall(ctx, &testpb.Empty{})
 	if err != nil {

--- a/test/balancer_test.go
+++ b/test/balancer_test.go
@@ -170,7 +170,9 @@ func (s) TestCredsBundleFromBalancer(t *testing.T) {
 
 	cc := te.clientConn()
 	tc := testgrpc.NewTestServiceClient(cc)
-	if _, err := tc.EmptyCall(context.Background(), &testpb.Empty{}); err != nil {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	if _, err := tc.EmptyCall(ctx, &testpb.Empty{}); err != nil {
 		t.Fatalf("Test failed. Reason: %v", err)
 	}
 }
@@ -244,7 +246,7 @@ func testDoneInfo(t *testing.T, e env) {
 	cc := te.clientConn()
 	tc := testgrpc.NewTestServiceClient(cc)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
 	wantErr := detailedError
 	if _, err := tc.EmptyCall(ctx, &testpb.Empty{}); !testutils.StatusErrEqual(err, wantErr) {
@@ -321,7 +323,7 @@ func testDoneLoads(t *testing.T) {
 
 	tc := testgrpc.NewTestServiceClient(ss.CC)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
 	if _, err := tc.EmptyCall(ctx, &testpb.Empty{}); err != nil {
 		t.Fatalf("TestService/EmptyCall(_, _) = _, %v, want _, %v", err, nil)
@@ -438,7 +440,7 @@ func (s) TestAddressAttributesInNewSubConn(t *testing.T) {
 	t.Log("Created a ClientConn...")
 
 	// The first RPC should fail because there's no address.
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestShortTimeout)
 	defer cancel()
 	if _, err := tc.EmptyCall(ctx, &testpb.Empty{}); err == nil || status.Code(err) != codes.DeadlineExceeded {
 		t.Fatalf("EmptyCall() = _, %v, want _, DeadlineExceeded", err)
@@ -450,7 +452,7 @@ func (s) TestAddressAttributesInNewSubConn(t *testing.T) {
 	t.Logf("Pushing resolver state update: %v through the manual resolver", state)
 
 	// The second RPC should succeed.
-	ctx, cancel = context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel = context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
 	if _, err := tc.EmptyCall(ctx, &testpb.Empty{}); err != nil {
 		t.Fatalf("EmptyCall() = _, %v, want _, <nil>", err)
@@ -519,7 +521,7 @@ func (s) TestMetadataInAddressAttributes(t *testing.T) {
 	defer ss.Stop()
 
 	// The RPC should succeed with the expected md.
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
 	if _, err := ss.Client.EmptyCall(ctx, &testpb.Empty{}); err != nil {
 		t.Fatalf("EmptyCall() = _, %v, want _, <nil>", err)
@@ -536,7 +538,7 @@ func (s) TestMetadataInAddressAttributes(t *testing.T) {
 // TestServersSwap creates two servers and verifies the client switches between
 // them when the name resolver reports the first and then the second.
 func (s) TestServersSwap(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
 
 	// Initialize servers
@@ -592,7 +594,7 @@ func (s) TestServersSwap(t *testing.T) {
 }
 
 func (s) TestWaitForReady(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
 
 	// Initialize server
@@ -1035,7 +1037,7 @@ func (s) TestBalancerProducerHonorsContext(t *testing.T) {
 	// rpcErrChan is given to the LB policy to report the status of the
 	// producer's one RPC.
 	ctxChan := make(chan context.Context, 1)
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	ctxChan <- ctx
 
 	rpcErrChan := make(chan error)

--- a/test/channelz_test.go
+++ b/test/channelz_test.go
@@ -914,6 +914,9 @@ func (s) TestCZClientSocketMetricsStreamsAndMessagesCount(t *testing.T) {
 			break
 		}
 		skt := channelz.GetSocket(skID)
+		if skt == nil {
+			return false, fmt.Errorf("couldn't find socket for ID: %v", skID)
+		}
 		sktData := skt.SocketData
 		if sktData.StreamsStarted != 1 || sktData.StreamsSucceeded != 1 || sktData.MessagesSent != 1 || sktData.MessagesReceived != 1 {
 			return false, fmt.Errorf("channelz.GetSocket(%d), want (StreamsStarted, StreamsSucceeded, MessagesSent, MessagesReceived) = (1, 1, 1, 1), got (%d, %d, %d, %d)", skt.ID, sktData.StreamsStarted, sktData.StreamsSucceeded, sktData.MessagesSent, sktData.MessagesReceived)
@@ -926,6 +929,9 @@ func (s) TestCZClientSocketMetricsStreamsAndMessagesCount(t *testing.T) {
 	doServerSideFailedUnaryCall(tc, t)
 	if err := verifyResultWithDelay(func() (bool, error) {
 		skt := channelz.GetSocket(skID)
+		if skt == nil {
+			return false, fmt.Errorf("couldn't find socket for ID: %v", skID)
+		}
 		sktData := skt.SocketData
 		if sktData.StreamsStarted != 2 || sktData.StreamsSucceeded != 2 || sktData.MessagesSent != 2 || sktData.MessagesReceived != 1 {
 			return false, fmt.Errorf("channelz.GetSocket(%d), want (StreamsStarted, StreamsSucceeded, MessagesSent, MessagesReceived) = (2, 2, 2, 1), got (%d, %d, %d, %d)", skt.ID, sktData.StreamsStarted, sktData.StreamsSucceeded, sktData.MessagesSent, sktData.MessagesReceived)
@@ -938,6 +944,9 @@ func (s) TestCZClientSocketMetricsStreamsAndMessagesCount(t *testing.T) {
 	doClientSideInitiatedFailedStream(tc, t)
 	if err := verifyResultWithDelay(func() (bool, error) {
 		skt := channelz.GetSocket(skID)
+		if skt == nil {
+			return false, fmt.Errorf("couldn't find socket for ID: %v", skID)
+		}
 		sktData := skt.SocketData
 		if sktData.StreamsStarted != 3 || sktData.StreamsSucceeded != 2 || sktData.StreamsFailed != 1 || sktData.MessagesSent != 3 || sktData.MessagesReceived != 2 {
 			return false, fmt.Errorf("channelz.GetSocket(%d), want (StreamsStarted, StreamsSucceeded, StreamsFailed, MessagesSent, MessagesReceived) = (3, 2, 1, 3, 2), got (%d, %d, %d, %d, %d)", skt.ID, sktData.StreamsStarted, sktData.StreamsSucceeded, sktData.StreamsFailed, sktData.MessagesSent, sktData.MessagesReceived)
@@ -950,6 +959,9 @@ func (s) TestCZClientSocketMetricsStreamsAndMessagesCount(t *testing.T) {
 	doServerSideInitiatedFailedStreamWithRSTStream(tc, t, rcw)
 	if err := verifyResultWithDelay(func() (bool, error) {
 		skt := channelz.GetSocket(skID)
+		if skt == nil {
+			return false, fmt.Errorf("couldn't find socket for ID: %v", skID)
+		}
 		sktData := skt.SocketData
 		if sktData.StreamsStarted != 4 || sktData.StreamsSucceeded != 2 || sktData.StreamsFailed != 2 || sktData.MessagesSent != 4 || sktData.MessagesReceived != 3 {
 			return false, fmt.Errorf("channelz.GetSocket(%d), want (StreamsStarted, StreamsSucceeded, StreamsFailed, MessagesSent, MessagesReceived) = (4, 2, 2, 4, 3), got (%d, %d, %d, %d, %d)", skt.ID, sktData.StreamsStarted, sktData.StreamsSucceeded, sktData.StreamsFailed, sktData.MessagesSent, sktData.MessagesReceived)
@@ -962,6 +974,9 @@ func (s) TestCZClientSocketMetricsStreamsAndMessagesCount(t *testing.T) {
 	doServerSideInitiatedFailedStreamWithGoAway(tc, t, rcw)
 	if err := verifyResultWithDelay(func() (bool, error) {
 		skt := channelz.GetSocket(skID)
+		if skt == nil {
+			return false, fmt.Errorf("couldn't find socket for ID: %v", skID)
+		}
 		sktData := skt.SocketData
 		if sktData.StreamsStarted != 6 || sktData.StreamsSucceeded != 2 || sktData.StreamsFailed != 3 || sktData.MessagesSent != 6 || sktData.MessagesReceived != 5 {
 			return false, fmt.Errorf("channelz.GetSocket(%d), want (StreamsStarted, StreamsSucceeded, StreamsFailed, MessagesSent, MessagesReceived) = (6, 2, 3, 6, 5), got (%d, %d, %d, %d, %d)", skt.ID, sktData.StreamsStarted, sktData.StreamsSucceeded, sktData.StreamsFailed, sktData.MessagesSent, sktData.MessagesReceived)

--- a/test/channelz_test.go
+++ b/test/channelz_test.go
@@ -523,7 +523,9 @@ func (s) TestCZChannelMetrics(t *testing.T) {
 	cc := te.clientConn(grpc.WithResolvers(r))
 	defer te.tearDown()
 	tc := testgrpc.NewTestServiceClient(cc)
-	if _, err := tc.EmptyCall(context.Background(), &testpb.Empty{}); err != nil {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	if _, err := tc.EmptyCall(ctx, &testpb.Empty{}); err != nil {
 		t.Fatalf("TestService/EmptyCall(_, _) = _, %v, want _, <nil>", err)
 	}
 
@@ -540,11 +542,11 @@ func (s) TestCZChannelMetrics(t *testing.T) {
 		Payload:      largePayload,
 	}
 
-	if _, err := tc.UnaryCall(context.Background(), req); err == nil || status.Code(err) != codes.ResourceExhausted {
+	if _, err := tc.UnaryCall(ctx, req); err == nil || status.Code(err) != codes.ResourceExhausted {
 		t.Fatalf("TestService/UnaryCall(_, _) = _, %v, want _, error code: %s", err, codes.ResourceExhausted)
 	}
 
-	stream, err := tc.FullDuplexCall(context.Background())
+	stream, err := tc.FullDuplexCall(ctx)
 	if err != nil {
 		t.Fatalf("%v.FullDuplexCall(_) = _, %v, want <nil>", tc, err)
 	}
@@ -603,7 +605,9 @@ func (s) TestCZServerMetrics(t *testing.T) {
 	defer te.tearDown()
 	cc := te.clientConn()
 	tc := testgrpc.NewTestServiceClient(cc)
-	if _, err := tc.EmptyCall(context.Background(), &testpb.Empty{}); err != nil {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	if _, err := tc.EmptyCall(ctx, &testpb.Empty{}); err != nil {
 		t.Fatalf("TestService/EmptyCall(_, _) = _, %v, want _, <nil>", err)
 	}
 
@@ -619,11 +623,11 @@ func (s) TestCZServerMetrics(t *testing.T) {
 		ResponseSize: int32(smallSize),
 		Payload:      largePayload,
 	}
-	if _, err := tc.UnaryCall(context.Background(), req); err == nil || status.Code(err) != codes.ResourceExhausted {
+	if _, err := tc.UnaryCall(ctx, req); err == nil || status.Code(err) != codes.ResourceExhausted {
 		t.Fatalf("TestService/UnaryCall(_, _) = _, %v, want _, error code: %s", err, codes.ResourceExhausted)
 	}
 
-	stream, err := tc.FullDuplexCall(context.Background())
+	stream, err := tc.FullDuplexCall(ctx)
 	if err != nil {
 		t.Fatalf("%v.FullDuplexCall(_) = _, %v, want <nil>", tc, err)
 	}
@@ -746,7 +750,7 @@ func doServerSideFailedUnaryCall(tc testgrpc.TestServiceClient, t *testing.T) {
 }
 
 func doClientSideInitiatedFailedStream(tc testgrpc.TestServiceClient, t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	stream, err := tc.FullDuplexCall(ctx)
 	if err != nil {
 		t.Fatalf("TestService/FullDuplexCall(_) = _, %v, want <nil>", err)
@@ -779,7 +783,9 @@ func doClientSideInitiatedFailedStream(tc testgrpc.TestServiceClient, t *testing
 
 // This func is to be used to test client side counting of failed streams.
 func doServerSideInitiatedFailedStreamWithRSTStream(tc testgrpc.TestServiceClient, t *testing.T, l *listenerWrapper) {
-	stream, err := tc.FullDuplexCall(context.Background())
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	stream, err := tc.FullDuplexCall(ctx)
 	if err != nil {
 		t.Fatalf("TestService/FullDuplexCall(_) = _, %v, want <nil>", err)
 	}
@@ -819,7 +825,9 @@ func doServerSideInitiatedFailedStreamWithRSTStream(tc testgrpc.TestServiceClien
 func doServerSideInitiatedFailedStreamWithGoAway(tc testgrpc.TestServiceClient, t *testing.T, l *listenerWrapper) {
 	// This call is just to keep the transport from shutting down (socket will be deleted
 	// in this case, and we will not be able to get metrics).
-	s, err := tc.FullDuplexCall(context.Background())
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	s, err := tc.FullDuplexCall(ctx)
 	if err != nil {
 		t.Fatalf("TestService/FullDuplexCall(_) = _, %v, want <nil>", err)
 	}
@@ -834,7 +842,7 @@ func doServerSideInitiatedFailedStreamWithGoAway(tc testgrpc.TestServiceClient, 
 		t.Fatalf("s.Recv() failed with error: %v", err)
 	}
 
-	s, err = tc.FullDuplexCall(context.Background())
+	s, err = tc.FullDuplexCall(ctx)
 	if err != nil {
 		t.Fatalf("TestService/FullDuplexCall(_) = _, %v, want <nil>", err)
 	}
@@ -859,7 +867,7 @@ func doServerSideInitiatedFailedStreamWithGoAway(tc testgrpc.TestServiceClient, 
 }
 
 func doIdleCallToInvokeKeepAlive(tc testgrpc.TestServiceClient, t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	_, err := tc.FullDuplexCall(ctx)
 	if err != nil {
 		t.Fatalf("TestService/FullDuplexCall(_) = _, %v, want <nil>", err)
@@ -988,7 +996,7 @@ func (s) TestCZClientAndServerSocketMetricsStreamsCountFlowControlRSTStream(t *t
 	cc, dw := te.clientConnWithConnControl()
 	tc := &testServiceClientWrapper{TestServiceClient: testgrpc.NewTestServiceClient(cc)}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	stream, err := tc.FullDuplexCall(ctx)
 	if err != nil {
 		t.Fatalf("TestService/FullDuplexCall(_) = _, %v, want <nil>", err)
@@ -1534,7 +1542,7 @@ func (s) TestCZSubChannelTraceCreationDeletion(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
 	awaitState(ctx, t, te.cc, connectivity.Ready)
 	r.UpdateState(resolver.State{Addresses: []resolver.Address{{Addr: "fake address"}}})
@@ -1694,7 +1702,7 @@ func (s) TestCZSubChannelPickedNewAddress(t *testing.T) {
 	defer te.tearDown()
 	tc := testgrpc.NewTestServiceClient(cc)
 	// make sure the connection is up
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
 	if _, err := tc.EmptyCall(ctx, &testpb.Empty{}); err != nil {
 		t.Fatalf("TestService/EmptyCall(_, _) = _, %v, want _, <nil>", err)
@@ -1707,9 +1715,7 @@ func (s) TestCZSubChannelPickedNewAddress(t *testing.T) {
 	defer close(done)
 	go func() {
 		for {
-			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 			tc.EmptyCall(ctx, &testpb.Empty{})
-			cancel()
 			select {
 			case <-time.After(10 * time.Millisecond):
 			case <-done:
@@ -1763,7 +1769,7 @@ func (s) TestCZSubChannelConnectivityState(t *testing.T) {
 	defer te.tearDown()
 	tc := testgrpc.NewTestServiceClient(cc)
 	// make sure the connection is up
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
 	if _, err := tc.EmptyCall(ctx, &testpb.Empty{}); err != nil {
 		t.Fatalf("TestService/EmptyCall(_, _) = _, %v, want _, <nil>", err)
@@ -1862,7 +1868,7 @@ func (s) TestCZChannelConnectivityState(t *testing.T) {
 	defer te.tearDown()
 	tc := testgrpc.NewTestServiceClient(cc)
 	// make sure the connection is up
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
 	if _, err := tc.EmptyCall(ctx, &testpb.Empty{}); err != nil {
 		t.Fatalf("TestService/EmptyCall(_, _) = _, %v, want _, <nil>", err)
@@ -2010,7 +2016,7 @@ func (s) TestCZTraceOverwriteSubChannelDeletion(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
 	awaitState(ctx, t, te.cc, connectivity.Ready)
 	r.UpdateState(resolver.State{Addresses: []resolver.Address{{Addr: "fake address"}}})

--- a/test/config_selector_test.go
+++ b/test/config_selector_test.go
@@ -62,12 +62,14 @@ func (s) TestConfigSelector(t *testing.T) {
 	}
 	defer ss.Stop()
 
-	ctxDeadline := time.Now().Add(10 * time.Second)
-	ctx, cancel := context.WithDeadline(context.Background(), ctxDeadline)
+	const normalTimeout = 10 * time.Second
+	ctxDeadline := time.Now().Add(normalTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), normalTimeout)
 	defer cancel()
 
-	longCtxDeadline := time.Now().Add(30 * time.Second)
-	longdeadlineCtx, cancel := context.WithDeadline(context.Background(), longCtxDeadline)
+	const longTimeout = 30 * time.Second
+	longCtxDeadline := time.Now().Add(longTimeout)
+	longdeadlineCtx, cancel := context.WithTimeout(context.Background(), longTimeout)
 	defer cancel()
 	shorterTimeout := 3 * time.Second
 

--- a/test/context_canceled_test.go
+++ b/test/context_canceled_test.go
@@ -141,7 +141,7 @@ func (s) TestCancelWhileRecvingWithCompression(t *testing.T) {
 	defer ss.Stop()
 
 	for i := 0; i < 10; i++ {
-		ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+		ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 		s, err := ss.Client.FullDuplexCall(ctx, grpc.UseCompressor(gzip.Name))
 		if err != nil {
 			t.Fatalf("failed to start bidi streaming RPC: %v", err)

--- a/test/gracefulstop_test.go
+++ b/test/gracefulstop_test.go
@@ -24,7 +24,6 @@ import (
 	"net"
 	"sync"
 	"testing"
-	"time"
 
 	"golang.org/x/net/http2"
 	"google.golang.org/grpc"
@@ -148,7 +147,7 @@ func (s) TestGracefulStop(t *testing.T) {
 
 	// Now dial.  The listener's Accept method will return a valid connection,
 	// even though GracefulStop has closed the listener.
-	ctx, dialCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, dialCancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer dialCancel()
 	cc, err := grpc.DialContext(ctx, "", grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithContextDialer(d))
 	if err != nil {
@@ -160,7 +159,7 @@ func (s) TestGracefulStop(t *testing.T) {
 	// 4. Send an RPC on the new connection.
 	// The server would send a GOAWAY first, but we are delaying the server's
 	// writes for now until the client writes more than the preface.
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	if _, err = client.FullDuplexCall(ctx); err == nil || status.Code(err) != codes.Unavailable {
 		t.Fatalf("FullDuplexCall= _, %v; want _, <status code Unavailable>", err)
 	}

--- a/test/healthcheck_test.go
+++ b/test/healthcheck_test.go
@@ -890,7 +890,7 @@ func verifyHealthCheckErrCode(t *testing.T, d time.Duration, cc *grpc.ClientConn
 // RPC, and returns the stream.
 func newHealthCheckStream(t *testing.T, cc *grpc.ClientConn, service string) (healthgrpc.Health_WatchClient, context.CancelFunc) {
 	t.Helper()
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	hc := healthgrpc.NewHealthClient(cc)
 	stream, err := hc.Watch(ctx, &healthpb.HealthCheckRequest{Service: service})
 	if err != nil {

--- a/test/invoke_test.go
+++ b/test/invoke_test.go
@@ -122,7 +122,7 @@ func (s) TestInvokeCancel(t *testing.T) {
 	defer ss.Stop()
 
 	for i := 0; i < 100; i++ {
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 		cancel()
 		ss.CC.Invoke(ctx, "/grpc.testing.TestService/EmptyCall", &testpb.Empty{}, &testpb.Empty{})
 	}
@@ -144,7 +144,7 @@ func (s) TestInvokeCancelClosedNonFailFast(t *testing.T) {
 	defer ss.Stop()
 
 	ss.CC.Close()
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	cancel()
 	if err := ss.CC.Invoke(ctx, "/grpc.testing.TestService/EmptyCall", &testpb.Empty{}, &testpb.Empty{}, grpc.WaitForReady(true)); err == nil {
 		t.Fatal("ClientConn.Invoke() on closed connection succeeded when expected to fail")

--- a/test/local_creds_test.go
+++ b/test/local_creds_test.go
@@ -103,7 +103,7 @@ func testLocalCredsE2ESucceed(network, address string) error {
 	defer cc.Close()
 
 	c := testgrpc.NewTestServiceClient(cc)
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
 
 	if _, err = c.EmptyCall(ctx, &testpb.Empty{}); err != nil {
@@ -198,7 +198,7 @@ func testLocalCredsE2EFail(dopts []grpc.DialOption) error {
 	defer cc.Close()
 
 	c := testgrpc.NewTestServiceClient(cc)
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
 
 	_, err = c.EmptyCall(ctx, &testpb.Empty{})

--- a/test/metadata_test.go
+++ b/test/metadata_test.go
@@ -25,7 +25,6 @@ import (
 	"reflect"
 	"strings"
 	"testing"
-	"time"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/internal/grpctest"
@@ -125,7 +124,7 @@ func (s) TestInvalidMetadata(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run("unary "+test.name, func(t *testing.T) {
-			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 			defer cancel()
 			ctx = metadata.NewOutgoingContext(ctx, test.md)
 			ctx = metadata.AppendToOutgoingContext(ctx, test.appendMD...)
@@ -138,11 +137,11 @@ func (s) TestInvalidMetadata(t *testing.T) {
 	// call the stream server's api to drive the server-side unit testing
 	for _, test := range tests {
 		t.Run("streaming "+test.name, func(t *testing.T) {
-			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 			defer cancel()
 			stream, err := ss.Client.FullDuplexCall(ctx)
 			if err != nil {
-				t.Errorf("call ss.Client.FullDuplexCall(context.Background()) will success but got err :%v", err)
+				t.Errorf("call ss.Client.FullDuplexCall got err :%v", err)
 				return
 			}
 			if err := stream.Send(&testpb.StreamingOutputCallRequest{}); err != nil {

--- a/test/recv_buffer_pool_test.go
+++ b/test/recv_buffer_pool_test.go
@@ -23,7 +23,6 @@ import (
 	"context"
 	"io"
 	"testing"
-	"time"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/internal/stubserver"
@@ -57,7 +56,7 @@ func (s) TestRecvBufferPool(t *testing.T) {
 	}
 	defer ss.Stop()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
 
 	stream, err := ss.Client.FullDuplexCall(ctx)

--- a/test/retry_test.go
+++ b/test/retry_test.go
@@ -90,7 +90,7 @@ func (s) TestRetryUnary(t *testing.T) {
 	}
 	for num, tc := range testCases {
 		t.Log("Case", num)
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 		_, err := ss.Client.EmptyCall(ctx, &testpb.Empty{})
 		cancel()
 		if status.Code(err) != tc.code {
@@ -154,7 +154,7 @@ func (s) TestRetryThrottling(t *testing.T) {
 		{codes.Unavailable, 17}, // tokens = 4.5
 	}
 	for _, tc := range testCases {
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 		_, err := ss.Client.EmptyCall(ctx, &testpb.Empty{})
 		cancel()
 		if status.Code(err) != tc.code {
@@ -429,7 +429,8 @@ func (s) TestRetryStreaming(t *testing.T) {
 		t.Fatalf("Error starting endpoint server: %v", err)
 	}
 	defer ss.Stop()
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
 	for {
 		if ctx.Err() != nil {
 			t.Fatalf("Timed out waiting for service config update")
@@ -439,15 +440,12 @@ func (s) TestRetryStreaming(t *testing.T) {
 		}
 		time.Sleep(time.Millisecond)
 	}
-	cancel()
 
 	for _, tc := range testCases {
 		func() {
 			serverOpIter = 0
 			serverOps = tc.serverOps
 
-			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-			defer cancel()
 			stream, err := ss.Client.FullDuplexCall(ctx)
 			if err != nil {
 				t.Fatalf("%v: Error while creating stream: %v", tc.desc, err)

--- a/test/roundrobin_test.go
+++ b/test/roundrobin_test.go
@@ -225,7 +225,8 @@ func (s) TestRoundRobin_AllServersDown(t *testing.T) {
 
 	// Failfast RPCs should fail with Unavailable.
 	client := testgrpc.NewTestServiceClient(cc)
-	if _, err := client.EmptyCall(context.Background(), &testpb.Empty{}); status.Code(err) != codes.Unavailable {
+
+	if _, err := client.EmptyCall(ctx, &testpb.Empty{}); status.Code(err) != codes.Unavailable {
 		t.Fatalf("EmptyCall got err: %v; want Unavailable", err)
 	}
 }

--- a/test/service_config_deprecated_test.go
+++ b/test/service_config_deprecated_test.go
@@ -192,12 +192,12 @@ func testServiceConfigTimeoutTD(t *testing.T, e env) {
 	cc := te.clientConn()
 	tc := testgrpc.NewTestServiceClient(cc)
 	// The following RPCs are expected to become non-fail-fast ones with 1ns deadline.
-	ctx, cancel := context.WithTimeout(context.Background(), time.Nanosecond)
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestShortTimeout)
 	if _, err := tc.EmptyCall(ctx, &testpb.Empty{}, grpc.WaitForReady(true)); status.Code(err) != codes.DeadlineExceeded {
 		t.Fatalf("TestService/EmptyCall(_, _) = _, %v, want _, %s", err, codes.DeadlineExceeded)
 	}
 	cancel()
-	ctx, cancel = context.WithTimeout(context.Background(), time.Nanosecond)
+	ctx, cancel = context.WithTimeout(context.Background(), defaultTestShortTimeout)
 	if _, err := tc.FullDuplexCall(ctx, grpc.WaitForReady(true)); status.Code(err) != codes.DeadlineExceeded {
 		t.Fatalf("TestService/FullDuplexCall(_) = _, %v, want %s", err, codes.DeadlineExceeded)
 	}
@@ -227,17 +227,15 @@ func testServiceConfigTimeoutTD(t *testing.T, e env) {
 		t.Fatalf("Timeout when waiting for service config to take effect")
 	}
 
-	ctx, cancel = context.WithTimeout(context.Background(), time.Hour)
+	ctx, cancel = context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
 	if _, err := tc.EmptyCall(ctx, &testpb.Empty{}, grpc.WaitForReady(true)); status.Code(err) != codes.DeadlineExceeded {
 		t.Fatalf("TestService/EmptyCall(_, _) = _, %v, want _, %s", err, codes.DeadlineExceeded)
 	}
-	cancel()
 
-	ctx, cancel = context.WithTimeout(context.Background(), time.Hour)
 	if _, err := tc.FullDuplexCall(ctx, grpc.WaitForReady(true)); status.Code(err) != codes.DeadlineExceeded {
 		t.Fatalf("TestService/FullDuplexCall(_) = _, %v, want %s", err, codes.DeadlineExceeded)
 	}
-	cancel()
 }
 
 func (s) TestServiceConfigMaxMsgSizeTD(t *testing.T) {

--- a/test/stream_cleanup_test.go
+++ b/test/stream_cleanup_test.go
@@ -91,7 +91,7 @@ func (s) TestStreamCleanupAfterSendStatus(t *testing.T) {
 
 	// 1. Make a long living stream RPC. So server's activeStream list is not
 	// empty.
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
 	stream, err := ss.Client.FullDuplexCall(ctx)
 	if err != nil {

--- a/test/subconn_test.go
+++ b/test/subconn_test.go
@@ -23,7 +23,6 @@ import (
 	"errors"
 	"fmt"
 	"testing"
-	"time"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/balancer"
@@ -46,7 +45,7 @@ func (p *tsccPicker) Pick(info balancer.PickInfo) (balancer.PickResult, error) {
 // TestSubConnEmpty tests that removing all addresses from a SubConn and then
 // re-adding them does not cause a panic and properly reconnects.
 func (s) TestSubConnEmpty(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
 
 	// sc is the one SubConn used throughout the test.  Created on demand and


### PR DESCRIPTION
A straw finally broke the camel's back.  Many of our tests don't set timeouts and hang for minutes.  This change fixes them, and also standardizes on the use of `defaultTest[Short]Timeout` everywhere.  My goal is to eventually put something like this into `vet.sh` to make it never happen again:

```sh
# Only allow context.Background() to be used with a timeout.
$ find . -name '*_test.go' | xargs grep -n context\.Background | grep -v context.WithTimeout
# Only allow defaultTestTimeout for context.Background() timeouts.
$ find . -name '*_test.go' | xargs grep -n context\.WithTimeout\(context.Background | grep -v defaultTest.*Timeout
```

There are currently 130 left in our entire tree.  Some of these will need to be exempted somehow, or reworked a little to first create a `ctx` with a timeout and then shorten it from there.

We probably also should look out for `select`s without a context, bare reads from channels, and `any wg.Wait()` calls.


RELEASE NOTES: none