### PR TITLE
xds/cdsbalancer: stop handling subconn state updates

### DIFF
--- a/xds/internal/balancer/cdsbalancer/cdsbalancer.go
+++ b/xds/internal/balancer/cdsbalancer/cdsbalancer.go
@@ -149,13 +149,6 @@ type ccUpdate struct {
 	err         error
 }
 
-// scUpdate wraps a subConn update received from gRPC. This is directly passed
-// on to the cluster_resolver balancer.
-type scUpdate struct {
-	subConn balancer.SubConn
-	state   balancer.SubConnState
-}
-
 type exitIdle struct{}
 
 // cdsBalancer implements a CDS based LB policy. It instantiates a
@@ -415,14 +408,6 @@ func (b *cdsBalancer) run() {
 			switch update := u.(type) {
 			case *ccUpdate:
 				b.handleClientConnUpdate(update)
-			case *scUpdate:
-				// SubConn updates are passthrough and are simply handed over to
-				// the underlying cluster_resolver balancer.
-				if b.childLB == nil {
-					b.logger.Errorf("Received SubConn update with no child policy: %+v", update)
-					break
-				}
-				b.childLB.UpdateSubConnState(update.subConn, update.state)
 			case exitIdle:
 				if b.childLB == nil {
 					b.logger.Errorf("Received ExitIdle with no child policy")
@@ -540,11 +525,7 @@ func (b *cdsBalancer) ResolverError(err error) {
 
 // UpdateSubConnState handles subConn updates from gRPC.
 func (b *cdsBalancer) UpdateSubConnState(sc balancer.SubConn, state balancer.SubConnState) {
-	if b.closed.HasFired() {
-		b.logger.Warningf("Received subConn update after close: {%v, %v}", sc, state)
-		return
-	}
-	b.updateCh.Put(&scUpdate{subConn: sc, state: state})
+	b.logger.Errorf("UpdateSubConnState(%v, %+v) called unexpectedly", sc, state)
 }
 
 // Close cancels the CDS watch, closes the child policy and closes the

--- a/xds/internal/balancer/cdsbalancer/cdsbalancer_test.go
+++ b/xds/internal/balancer/cdsbalancer/cdsbalancer_test.go
@@ -174,20 +174,6 @@ func (tb *testEDSBalancer) waitForClientConnUpdate(ctx context.Context, wantCCS 
 	return nil
 }
 
-// waitForSubConnUpdate verifies if the testEDSBalancer receives the provided
-// SubConn update before the context expires.
-func (tb *testEDSBalancer) waitForSubConnUpdate(ctx context.Context, wantSCS subConnWithState) error {
-	scs, err := tb.scStateCh.Receive(ctx)
-	if err != nil {
-		return err
-	}
-	gotSCS := scs.(subConnWithState)
-	if !cmp.Equal(gotSCS, wantSCS, cmp.AllowUnexported(subConnWithState{})) {
-		return fmt.Errorf("received SubConnState: %+v, want %+v", gotSCS, wantSCS)
-	}
-	return nil
-}
-
 // waitForResolverError verifies if the testEDSBalancer receives the provided
 // resolver error before the context expires.
 func (tb *testEDSBalancer) waitForResolverError(ctx context.Context, wantErr error) error {


### PR DESCRIPTION
Because its child, `clusterresolver`, uses `StateListener` always (https://github.com/grpc/grpc-go/blob/e9a4e942b10030c6dc487b2ebf396bf6dfa9d465/xds/internal/balancer/clusterresolver/clusterresolver.go#L424-L429), this change is safe to make in isolation now.

RELEASE NOTES: none