### PR TITLE
benchmark: restore old buffer size values for published benchmarks

### DIFF
--- a/benchmark/client/main.go
+++ b/benchmark/client/main.go
@@ -136,7 +136,12 @@ func main() {
 func buildConnections(ctx context.Context) []*grpc.ClientConn {
 	ccs := make([]*grpc.ClientConn, *numConn)
 	for i := range ccs {
-		ccs[i] = benchmark.NewClientConnWithContext(ctx, "localhost:"+*port, grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithBlock())
+		ccs[i] = benchmark.NewClientConnWithContext(ctx, "localhost:"+*port,
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+			grpc.WithBlock(),
+			grpc.WithWriteBufferSize(128*1024),
+			grpc.WithReadBufferSize(128*1024),
+		)
 	}
 	return ccs
 }

--- a/benchmark/server/main.go
+++ b/benchmark/server/main.go
@@ -39,6 +39,7 @@ import (
 	"runtime/pprof"
 	"time"
 
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/benchmark"
 	"google.golang.org/grpc/grpclog"
 	"google.golang.org/grpc/internal/syscall"
@@ -70,7 +71,10 @@ func main() {
 	pprof.StartCPUProfile(cf)
 	cpuBeg := syscall.GetCPUTime()
 	// Launch server in a separate goroutine.
-	stop := benchmark.StartServer(benchmark.ServerInfo{Type: "protobuf", Listener: lis})
+	stop := benchmark.StartServer(benchmark.ServerInfo{Type: "protobuf", Listener: lis},
+		grpc.WriteBufferSize(128*1024),
+		grpc.ReadBufferSize(128*1024),
+	)
 	// Wait on OS terminate signal.
 	ch := make(chan os.Signal, 1)
 	signal.Notify(ch, os.Interrupt)


### PR DESCRIPTION
In #5762, the default values used by our benchmarks was changed to be the same as the default gRPC values.  However, I was unaware that we were publishing these benchmarks at http://grpc.io.  That led to [this regression](https://grafana-dot-grpc-testing.appspot.com/?viewPanel=21&orgId=1&from=1667333818308&to=1668946615952) :+1: 

![image](https://github.com/grpc/grpc-go/assets/26072277/73ebb3ad-cacc-4fdf-a353-c4990a77f853)

This change restores the values that were in use before the change, which should lower CPU usage by using bigger buffers.  It does this in the client and server used by the benchmark framework, but not for our local benchmarks that we occasionally run to evaluate the performance impact of changes.

RELEASE NOTES: none