### PR TITLE
tests: stop using UpdateSubConnState

### DIFF
--- a/clientconn_test.go
+++ b/clientconn_test.go
@@ -1146,7 +1146,9 @@ type stateRecordingBalancer struct {
 	balancer.Balancer
 }
 
-func (b *stateRecordingBalancer) UpdateSubConnState(sc balancer.SubConn, s balancer.SubConnState) {}
+func (b *stateRecordingBalancer) UpdateSubConnState(sc balancer.SubConn, s balancer.SubConnState) {
+	panic(fmt.Sprintf("UpdateSubConnState(%v, %+v) called unexpectedly", sc, s))
+}
 
 func (b *stateRecordingBalancer) Close() {
 	b.Balancer.Close()

--- a/test/balancer_switching_test.go
+++ b/test/balancer_switching_test.go
@@ -483,10 +483,6 @@ func (s) TestBalancerSwitch_Graceful(t *testing.T) {
 			}()
 			return nil
 		},
-		UpdateSubConnState: func(bd *stub.BalancerData, sc balancer.SubConn, state balancer.SubConnState) {
-			bal := bd.Data.(balancer.Balancer)
-			bal.UpdateSubConnState(sc, state)
-		},
 	})
 
 	// Push a resolver update with the service config specifying our stub

--- a/test/resolver_update_test.go
+++ b/test/resolver_update_test.go
@@ -177,10 +177,6 @@ func (s) TestResolverUpdate_InvalidServiceConfigAfterGoodUpdate(t *testing.T) {
 			ccs.BalancerConfig = nil
 			return bal.UpdateClientConnState(ccs)
 		},
-		UpdateSubConnState: func(bd *stub.BalancerData, sc balancer.SubConn, state balancer.SubConnState) {
-			bal := bd.Data.(balancer.Balancer)
-			bal.UpdateSubConnState(sc, state)
-		},
 	})
 
 	// Start a backend exposing the test service.


### PR DESCRIPTION
A future change will delete `stub.BalancerFuncs.UpdateSubConnState`... This prepares for that and uses `StateListener` instead.

RELEASE NOTES: none