### PR TITLE
gracefulswitch, stub: remove last UpdateSubConnState references

### DIFF
--- a/balancer/weightedtarget/weightedtarget.go
+++ b/balancer/weightedtarget/weightedtarget.go
@@ -163,7 +163,7 @@ func (b *weightedTargetBalancer) ResolverError(err error) {
 }
 
 func (b *weightedTargetBalancer) UpdateSubConnState(sc balancer.SubConn, state balancer.SubConnState) {
-	b.bg.UpdateSubConnState(sc, state)
+	b.logger.Errorf("UpdateSubConnState(%v, %+v) called unexpectedly", sc, state)
 }
 
 func (b *weightedTargetBalancer) Close() {

--- a/internal/balancer/gracefulswitch/gracefulswitch_test.go
+++ b/internal/balancer/gracefulswitch/gracefulswitch_test.go
@@ -1024,7 +1024,7 @@ func (vb *verifyBalancer) newSubConn(addrs []resolver.Address, opts balancer.New
 	if opts.StateListener == nil {
 		opts.StateListener = func(state balancer.SubConnState) {
 			if vb.closed.HasFired() {
-				vb.t.Fatalf("UpdateSubConnState(%+v) was called after Close(), which breaks the balancer API", state)
+				vb.t.Fatalf("StateListener(%+v) was called after Close(), which breaks the balancer API", state)
 			}
 		}
 	}

--- a/internal/balancer/stub/stub.go
+++ b/internal/balancer/stub/stub.go
@@ -21,6 +21,7 @@ package stub
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"google.golang.org/grpc/balancer"
 	"google.golang.org/grpc/serviceconfig"
@@ -38,7 +39,6 @@ type BalancerFuncs struct {
 
 	UpdateClientConnState func(*BalancerData, balancer.ClientConnState) error
 	ResolverError         func(*BalancerData, error)
-	UpdateSubConnState    func(*BalancerData, balancer.SubConn, balancer.SubConnState)
 	Close                 func(*BalancerData)
 	ExitIdle              func(*BalancerData)
 }
@@ -72,9 +72,7 @@ func (b *bal) ResolverError(e error) {
 }
 
 func (b *bal) UpdateSubConnState(sc balancer.SubConn, scs balancer.SubConnState) {
-	if b.bf.UpdateSubConnState != nil {
-		b.bf.UpdateSubConnState(b.bd, sc, scs)
-	}
+	panic(fmt.Sprintf("UpdateSubConnState(%v, %+v) called unexpectedly", sc, scs))
 }
 
 func (b *bal) Close() {


### PR DESCRIPTION
- gracefulswitch_test: make `UpdateSubConnState` error if called, and do that behavior directly in the `StateListener`s
- stub: delete `UpdateSubConnState` field, which requires all tests that use it to use `StateListener`s now (all migrated before this PR; requires #6525, included here as a separate commit).

RELEASE NOTES: none