### PR TITLE
rls: fix flaky test introduced by #6514 

### DIFF
--- a/balancer/rls/balancer_test.go
+++ b/balancer/rls/balancer_test.go
@@ -919,7 +919,7 @@ func (s) TestUpdateStatePauses(t *testing.T) {
 	}
 	stub.Register(childPolicyName, stub.BalancerFuncs{
 		Init: func(bd *stub.BalancerData) {
-			bd.Data = balancer.Get(grpc.PickFirstBalancerName).Build(ccWrapper, bd.BuildOptions)
+			bd.Data = balancer.Get(grpc.PickFirstBalancerName).Build(bd.ClientConn, bd.BuildOptions)
 		},
 		ParseConfig: func(sc json.RawMessage) (serviceconfig.LoadBalancingConfig, error) {
 			cfg := &childPolicyConfig{}


### PR DESCRIPTION
https://github.com/grpc/grpc-go/pull/6514 changed some tests to use the `stub` balancer package instead of defining custom test balancers, but it introduced a bug which made one of the tests flaky.

The bug was that a `testCCWrapper` was being passed as the `balancer.ClientConn` for the child policies of RLS. This meant that any state change reported by the child policy ended up changing the state of the main channel. This is not how it is supposed to work. The way it works is that the RLS LB policy intercepts state updates from the child policies, aggregates them and pushes a final state to the parent ClientConn.

The fix for this PR ensures that the `balancer.ClientConn` passed by RLS LB policy (when it creates a child policy) is the one which gets passed to the child policy in the test as well.

RELEASE NOTES: none