### PR TITLE
benchmark: update proper benchmark binary to use larger buffers

### DIFF
--- a/benchmark/worker/benchmark_client.go
+++ b/benchmark/worker/benchmark_client.go
@@ -116,7 +116,10 @@ func setupClientEnv(config *testpb.ClientConfig) {
 // It returns the connections and corresponding function to close them.
 // It returns non-nil error if there is anything wrong.
 func createConns(config *testpb.ClientConfig) ([]*grpc.ClientConn, func(), error) {
-	var opts []grpc.DialOption
+	opts := []grpc.DialOption{
+		grpc.WithWriteBufferSize(128 * 1024),
+		grpc.WithReadBufferSize(128 * 1024),
+	}
 
 	// Sanity check for client type.
 	switch config.ClientType {

--- a/benchmark/worker/benchmark_server.go
+++ b/benchmark/worker/benchmark_server.go
@@ -80,7 +80,10 @@ func startBenchmarkServer(config *testpb.ServerConfig, serverPort int) (*benchma
 	}
 	runtime.GOMAXPROCS(numOfCores)
 
-	var opts []grpc.ServerOption
+	opts := []grpc.ServerOption{
+		grpc.WriteBufferSize(128 * 1024),
+		grpc.ReadBufferSize(128 * 1024),
+	}
 
 	// Sanity check for server type.
 	switch config.ServerType {


### PR DESCRIPTION
#6516 updated the wrong binary, and had no effect on our results.  This package appears to be what is actually run in our published benchmarks ([ref](https://github.com/grpc/grpc/blob/master/tools/run_tests/performance/run_worker_go.sh)).

RELEASE NOTES: none