### PR TITLE
update CI jobs to use go 1.21

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.20'
+          go-version: '1.21'
       - name: Checkout repo
         uses: actions/checkout@v3
 
@@ -46,31 +46,31 @@ jobs:
       matrix:
         include:
           - type: vet
-            goversion: '1.20'
+            goversion: '1.21'
 
           - type: tests
-            goversion: '1.20'
+            goversion: '1.21'
 
           - type: tests
-            goversion: '1.20'
+            goversion: '1.21'
             testflags: -race
 
           - type: tests
-            goversion: '1.20'
+            goversion: '1.21'
             goarch: 386
 
           - type: tests
-            goversion: '1.20'
+            goversion: '1.21'
             goarch: arm64
+
+          - type: tests
+            goversion: '1.20'
 
           - type: tests
             goversion: '1.19'
 
-          - type: tests
-            goversion: '1.18'
-
           - type: extras
-            goversion: '1.20'
+            goversion: '1.21'
 
     steps:
       # Setup the environment.


### PR DESCRIPTION
- update the github CI jobs to test with go 1.19, 1.20 and 1.21


Normally I would also update the min. version in the go.mod files, but they haven't been updated for a while and are still set to 1.17. 
I moved that therefore to a separate PR: https://github.com/grpc/grpc-go/pull/6542


RELEASE NOTES: none