### PR TITLE
cdsbalancer: test cleanup part 1/N

### DIFF
--- a/internal/testutils/xds/e2e/clientresources.go
+++ b/internal/testutils/xds/e2e/clientresources.go
@@ -460,6 +460,9 @@ type ClusterOptions struct {
 	Policy LoadBalancingPolicy
 	// SecurityLevel determines the security configuration for the Cluster.
 	SecurityLevel SecurityLevel
+	// EnableLRS adds a load reporting configuration with a config source
+	// pointing to self.
+	EnableLRS bool
 }
 
 // ClusterResourceWithOptions returns an xDS Cluster resource configured with
@@ -518,6 +521,13 @@ func ClusterResourceWithOptions(opts ClusterOptions) *v3clusterpb.Cluster {
 			Name: "envoy.transport_sockets.tls",
 			ConfigType: &v3corepb.TransportSocket_TypedConfig{
 				TypedConfig: testutils.MarshalAny(tlsContext),
+			},
+		}
+	}
+	if opts.EnableLRS {
+		cluster.LrsServer = &v3corepb.ConfigSource{
+			ConfigSourceSpecifier: &v3corepb.ConfigSource_Self{
+				Self: &v3corepb.SelfConfigSource{},
 			},
 		}
 	}

--- a/xds/internal/balancer/cdsbalancer/cdsbalancer.go
+++ b/xds/internal/balancer/cdsbalancer/cdsbalancer.go
@@ -381,7 +381,7 @@ func (b *cdsBalancer) handleWatchUpdate(update clusterHandlerUpdate) {
 
 	var sc serviceconfig.LoadBalancingConfig
 	if sc, err = b.crParser.ParseConfig(crLBCfgJSON); err != nil {
-		b.logger.Errorf("cds_balancer: cluster_resolver config generated %v is invalid: %v", crLBCfgJSON, err)
+		b.logger.Errorf("cds_balancer: cluster_resolver config generated %v is invalid: %v", string(crLBCfgJSON), err)
 		return
 	}
 

--- a/xds/internal/balancer/cdsbalancer/cdsbalancer_test.go
+++ b/xds/internal/balancer/cdsbalancer/cdsbalancer_test.go
@@ -21,26 +21,47 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/balancer"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/connectivity"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/internal"
+	"google.golang.org/grpc/internal/balancer/stub"
 	"google.golang.org/grpc/internal/grpctest"
-	internalserviceconfig "google.golang.org/grpc/internal/serviceconfig"
+	iserviceconfig "google.golang.org/grpc/internal/serviceconfig"
+	"google.golang.org/grpc/internal/stubserver"
 	"google.golang.org/grpc/internal/testutils"
+	"google.golang.org/grpc/internal/testutils/xds/e2e"
 	"google.golang.org/grpc/resolver"
+	"google.golang.org/grpc/resolver/manual"
 	"google.golang.org/grpc/serviceconfig"
+	"google.golang.org/grpc/status"
 	"google.golang.org/grpc/xds/internal/balancer/clusterresolver"
 	"google.golang.org/grpc/xds/internal/balancer/outlierdetection"
-	"google.golang.org/grpc/xds/internal/balancer/ringhash"
 	"google.golang.org/grpc/xds/internal/balancer/wrrlocality"
 	"google.golang.org/grpc/xds/internal/testutils/fakeclient"
 	"google.golang.org/grpc/xds/internal/xdsclient"
 	"google.golang.org/grpc/xds/internal/xdsclient/bootstrap"
 	"google.golang.org/grpc/xds/internal/xdsclient/xdsresource"
+	"google.golang.org/grpc/xds/internal/xdsclient/xdsresource/version"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	v3clusterpb "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	v3corepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	v3endpointpb "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
+	v3discoverypb "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+	testgrpc "google.golang.org/grpc/interop/grpc_testing"
+	testpb "google.golang.org/grpc/interop/grpc_testing"
+
+	_ "google.golang.org/grpc/xds/internal/balancer/ringhash" // Register the ring_hash LB policy
 )
 
 const (
@@ -59,20 +80,15 @@ var (
 	}
 	noopODLBCfg         = outlierdetection.LBConfig{}
 	noopODLBCfgJSON, _  = json.Marshal(noopODLBCfg)
-	wrrLocalityLBConfig = &internalserviceconfig.BalancerConfig{
+	wrrLocalityLBConfig = &iserviceconfig.BalancerConfig{
 		Name: wrrlocality.Name,
 		Config: &wrrlocality.LBConfig{
-			ChildPolicy: &internalserviceconfig.BalancerConfig{
+			ChildPolicy: &iserviceconfig.BalancerConfig{
 				Name: "round_robin",
 			},
 		},
 	}
 	wrrLocalityLBConfigJSON, _ = json.Marshal(wrrLocalityLBConfig)
-	ringHashLBConfig           = &internalserviceconfig.BalancerConfig{
-		Name:   ringhash.Name,
-		Config: &ringhash.LBConfig{MinRingSize: 10, MaxRingSize: 100},
-	}
-	ringHashLBConfigJSON, _ = json.Marshal(ringHashLBConfig)
 )
 
 type s struct {
@@ -183,15 +199,6 @@ func (tb *testEDSBalancer) waitForResolverError(ctx context.Context, wantErr err
 	}
 	if gotErr != wantErr {
 		return fmt.Errorf("received resolver error: %v, want %v", gotErr, wantErr)
-	}
-	return nil
-}
-
-// waitForClose verifies that the edsBalancer is closed before the context
-// expires.
-func (tb *testEDSBalancer) waitForClose(ctx context.Context) error {
-	if _, err := tb.closeCh.Receive(ctx); err != nil {
-		return err
 	}
 	return nil
 }
@@ -315,507 +322,1283 @@ func setupWithWatch(t *testing.T) (*fakeclient.Client, *cdsBalancer, *testEDSBal
 	return xdsC, cdsB, edsB, tcc, cancel
 }
 
-// TestUpdateClientConnState invokes the UpdateClientConnState method on the
-// cdsBalancer with different inputs and verifies that the CDS watch API on the
-// provided xdsClient is invoked appropriately.
-func (s) TestUpdateClientConnState(t *testing.T) {
-	xdsC := fakeclient.NewClient()
-
-	tests := []struct {
-		name        string
-		ccs         balancer.ClientConnState
-		wantErr     error
-		wantCluster string
-	}{
-		{
-			name:    "bad-lbCfg-type",
-			ccs:     balancer.ClientConnState{BalancerConfig: nil},
-			wantErr: balancer.ErrBadResolverState,
-		},
-		{
-			name:    "empty-cluster-in-lbCfg",
-			ccs:     balancer.ClientConnState{BalancerConfig: &lbConfig{ClusterName: ""}},
-			wantErr: balancer.ErrBadResolverState,
-		},
-		{
-			name:        "happy-good-case",
-			ccs:         cdsCCS(clusterName, xdsC),
-			wantCluster: clusterName,
-		},
+func waitForResourceNames(ctx context.Context, resourceNamesCh chan []string, wantNames []string) error {
+	for ctx.Err() == nil {
+		select {
+		case <-ctx.Done():
+		case gotNames := <-resourceNamesCh:
+			if cmp.Equal(gotNames, wantNames) {
+				return nil
+			}
+		}
 	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			_, cdsB, _, _, cancel := setup(t)
-			defer func() {
-				cancel()
-				cdsB.Close()
-			}()
-
-			if err := cdsB.UpdateClientConnState(test.ccs); err != test.wantErr {
-				t.Fatalf("cdsBalancer.UpdateClientConnState failed with error: %v", err)
-			}
-			if test.wantErr != nil {
-				// When we wanted an error and got it, we should return early.
-				return
-			}
-			ctx, ctxCancel := context.WithTimeout(context.Background(), defaultTestTimeout)
-			defer ctxCancel()
-			gotCluster, err := xdsC.WaitForWatchCluster(ctx)
-			if err != nil {
-				t.Fatalf("xdsClient.WatchCDS failed with error: %v", err)
-			}
-			if gotCluster != test.wantCluster {
-				t.Fatalf("xdsClient.WatchCDS called for cluster: %v, want: %v", gotCluster, test.wantCluster)
-			}
-		})
+	if ctx.Err() != nil {
+		return fmt.Errorf("Timeout when waiting for appropriate Cluster resources to be requested")
 	}
+	return nil
 }
 
-// TestUpdateClientConnStateWithSameState verifies that a ClientConnState
-// update with the same cluster and xdsClient does not cause the cdsBalancer to
-// create a new watch.
-func (s) TestUpdateClientConnStateWithSameState(t *testing.T) {
-	xdsC, cdsB, _, _, cancel := setupWithWatch(t)
-	defer func() {
-		cancel()
-		cdsB.Close()
-	}()
-
-	// This is the same clientConn update sent in setupWithWatch().
-	if err := cdsB.UpdateClientConnState(cdsCCS(clusterName, xdsC)); err != nil {
-		t.Fatalf("cdsBalancer.UpdateClientConnState failed with error: %v", err)
-	}
-	// The above update should not result in a new watch being registered.
-	ctx, ctxCancel := context.WithTimeout(context.Background(), defaultTestShortTimeout)
-	defer ctxCancel()
-	if _, err := xdsC.WaitForWatchCluster(ctx); err != context.DeadlineExceeded {
-		t.Fatalf("waiting for WatchCluster() should have timed out, but returned error: %v", err)
-	}
-}
-
-// TestHandleClusterUpdate invokes the registered CDS watch callback with
-// different updates and verifies that the expect ClientConnState is propagated
-// to the edsBalancer.
-func (s) TestHandleClusterUpdate(t *testing.T) {
-	xdsC, cdsB, edsB, _, cancel := setupWithWatch(t)
-	xdsC.SetBootstrapConfig(&bootstrap.Config{
-		XDSServer: defaultTestAuthorityServerConfig,
+// Tests the functionality that handles LB policy configuration. Verifies that
+// the appropriate xDS resource is requested corresponding to the provided LB
+// policy configuration. Also verifies that when the LB policy receives the same
+// configuration again, it does not send out a new request, and when the
+// configuration changes, it stops requesting the old cluster resource and
+// starts requesting the new one.
+func (s) TestConfigurationUpdate_Success(t *testing.T) {
+	// Setup a management server that pushes the names of the requested cluster
+	// resources for the test to inspect.
+	cdsResourceRequestedCh := make(chan []string, 1)
+	_, _, bootstrapContents, _, cleanup := e2e.SetupManagementServer(t, e2e.ManagementServerOptions{
+		OnStreamRequest: func(_ int64, req *v3discoverypb.DiscoveryRequest) error {
+			if req.GetTypeUrl() == version.V3ClusterURL {
+				select {
+				case cdsResourceRequestedCh <- req.GetResourceNames():
+				default:
+				}
+			}
+			return nil
+		},
 	})
-	defer func() {
-		cancel()
-		cdsB.Close()
-	}()
+	defer cleanup()
 
+	// Create an xDS client to be sent to the CDS LB policy as part of its
+	// configuration.
+	xdsClient, xdsClose, err := xdsclient.NewWithBootstrapContentsForTesting(bootstrapContents)
+	if err != nil {
+		t.Fatalf("Failed to create xDS client: %v", err)
+	}
+	defer xdsClose()
+
+	// Create a manual resolver that configures the CDS LB policy as the
+	// top-level LB policy on the channel.
+	r := manual.NewBuilderWithScheme("whatever")
+	jsonSC := fmt.Sprintf(`{
+			"loadBalancingConfig":[{
+				"cds_experimental":{
+					"cluster": "%s"
+				}
+			}]
+		}`, clusterName)
+	scpr := internal.ParseServiceConfig.(func(string) *serviceconfig.ParseResult)(jsonSC)
+	state := xdsclient.SetClient(resolver.State{ServiceConfig: scpr}, xdsClient)
+	r.InitialState(state)
+
+	// Create a ClientConn with the above manual resolver.
+	cc, err := grpc.Dial(r.Scheme()+":///test.service", grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithResolvers(r))
+	if err != nil {
+		t.Fatalf("Failed to dial: %v", err)
+	}
+	defer cc.Close()
+
+	// Verify that the specified cluster resource is requested.
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	wantNames := []string{clusterName}
+	if err := waitForResourceNames(ctx, cdsResourceRequestedCh, wantNames); err != nil {
+		t.Fatal(err)
+	}
+
+	// Push the same configuration and verify that a new request is not sent.
+	r.UpdateState(state)
+	sCtx, sCancel := context.WithTimeout(ctx, defaultTestShortTimeout)
+	defer sCancel()
+	select {
+	case <-sCtx.Done():
+	case gotNames := <-cdsResourceRequestedCh:
+		t.Fatalf("CDS resources %v requested when none expected", gotNames)
+	}
+
+	// Push an updated configuration with a different cluster name.
+	newClusterName := clusterName + "-new"
+	jsonSC = fmt.Sprintf(`{
+			"loadBalancingConfig":[{
+				"cds_experimental":{
+					"cluster": "%s"
+				}
+			}]
+		}`, newClusterName)
+	scpr = internal.ParseServiceConfig.(func(string) *serviceconfig.ParseResult)(jsonSC)
+	state = xdsclient.SetClient(resolver.State{ServiceConfig: scpr}, xdsClient)
+	r.UpdateState(state)
+
+	// Verify that the new cluster name is requested and the old one is no
+	// longer requested.
+	wantNames = []string{newClusterName}
+	if err := waitForResourceNames(ctx, cdsResourceRequestedCh, wantNames); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Tests the case where a configuration with an empty cluster name is pushed to
+// the CDS LB policy. Verifies that an appropriate error is returned.
+func (s) TestConfigurationUpdate_EmptyCluster(t *testing.T) {
+	// Setup a management server and an xDS client to talk to it.
+	// resources for the test to inspect.
+	_, _, bootstrapContents, _, cleanup := e2e.SetupManagementServer(t, e2e.ManagementServerOptions{})
+	defer cleanup()
+	xdsClient, xdsClose, err := xdsclient.NewWithBootstrapContentsForTesting(bootstrapContents)
+	if err != nil {
+		t.Fatalf("Failed to create xDS client: %v", err)
+	}
+	defer xdsClose()
+
+	// Create a manual resolver that configures the CDS LB policy as the
+	// top-level LB policy on the channel, and pushes a configuration with an
+	// empty cluster name. Also, register a callback with the manual resolver to
+	// receive the error returned by the balancer when a configuration with an
+	// empty cluster name is pushed.
+	r := manual.NewBuilderWithScheme("whatever")
+	updateStateErrCh := make(chan error, 1)
+	r.UpdateStateCallback = func(err error) { updateStateErrCh <- err }
+	jsonSC := `{
+			"loadBalancingConfig":[{
+				"cds_experimental":{
+					"cluster": ""
+				}
+			}]
+		}`
+	scpr := internal.ParseServiceConfig.(func(string) *serviceconfig.ParseResult)(jsonSC)
+	r.InitialState(xdsclient.SetClient(resolver.State{ServiceConfig: scpr}, xdsClient))
+
+	// Create a ClientConn with the above manual resolver.
+	cc, err := grpc.Dial(r.Scheme()+":///test.service", grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithResolvers(r))
+	if err != nil {
+		t.Fatalf("Failed to dial: %v", err)
+	}
+	defer cc.Close()
+
+	select {
+	case <-time.After(defaultTestTimeout):
+		t.Fatalf("Timed out waiting for error from the LB policy")
+	case err := <-updateStateErrCh:
+		if err != balancer.ErrBadResolverState {
+			t.Fatalf("For a configuration update with an empty cluster name, got error %v from the LB policy, want %v", err, balancer.ErrBadResolverState)
+		}
+	}
+}
+
+// Tests the case where a configuration with a missing xDS client is pushed to
+// the CDS LB policy. Verifies that an appropriate error is returned.
+func (s) TestConfigurationUpdate_MissingXdsClient(t *testing.T) {
+	// Create a manual resolver that configures the CDS LB policy as the
+	// top-level LB policy on the channel, and pushes a configuration that is
+	// missing the xDS client.  Also, register a callback with the manual
+	// resolver to receive the error returned by the balancer.
+	r := manual.NewBuilderWithScheme("whatever")
+	updateStateErrCh := make(chan error, 1)
+	r.UpdateStateCallback = func(err error) { updateStateErrCh <- err }
+	jsonSC := `{
+			"loadBalancingConfig":[{
+				"cds_experimental":{
+					"cluster": "foo"
+				}
+			}]
+		}`
+	scpr := internal.ParseServiceConfig.(func(string) *serviceconfig.ParseResult)(jsonSC)
+	r.InitialState(resolver.State{ServiceConfig: scpr})
+
+	// Create a ClientConn with the above manual resolver.
+	cc, err := grpc.Dial(r.Scheme()+":///test.service", grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithResolvers(r))
+	if err != nil {
+		t.Fatalf("Failed to dial: %v", err)
+	}
+	defer cc.Close()
+
+	select {
+	case <-time.After(defaultTestTimeout):
+		t.Fatalf("Timed out waiting for error from the LB policy")
+	case err := <-updateStateErrCh:
+		if err != balancer.ErrBadResolverState {
+			t.Fatalf("For a configuration update missing the xDS client, got error %v from the LB policy, want %v", err, balancer.ErrBadResolverState)
+		}
+	}
+}
+
+// Tests success scenarios where the cds LB policy receives a cluster resource
+// from the management server. Verifies that the load balancing configuration
+// pushed to the child is on expected lines.
+func (s) TestClusterUpdate_Success(t *testing.T) {
 	tests := []struct {
-		name      string
-		cdsUpdate xdsresource.ClusterUpdate
-		updateErr error
-		wantCCS   balancer.ClientConnState
+		name            string
+		clusterResource *v3clusterpb.Cluster
+		wantChildCfg    serviceconfig.LoadBalancingConfig
 	}{
 		{
-			name: "happy-case-with-lrs",
-			cdsUpdate: xdsresource.ClusterUpdate{
-				ClusterName:     serviceName,
-				LRSServerConfig: xdsresource.ClusterLRSServerSelf,
-				LBPolicy:        wrrLocalityLBConfigJSON,
+			name: "happy-case-with-circuit-breakers",
+			clusterResource: func() *v3clusterpb.Cluster {
+				c := e2e.DefaultCluster(clusterName, serviceName, e2e.SecurityLevelNone)
+				c.CircuitBreakers = &v3clusterpb.CircuitBreakers{
+					Thresholds: []*v3clusterpb.CircuitBreakers_Thresholds{
+						{
+							Priority:    v3corepb.RoutingPriority_DEFAULT,
+							MaxRequests: wrapperspb.UInt32(512),
+						},
+						{
+							Priority:    v3corepb.RoutingPriority_HIGH,
+							MaxRequests: nil,
+						},
+					},
+				}
+				return c
+			}(),
+			wantChildCfg: &clusterresolver.LBConfig{
+				DiscoveryMechanisms: []clusterresolver.DiscoveryMechanism{{
+					Cluster:               clusterName,
+					Type:                  clusterresolver.DiscoveryMechanismTypeEDS,
+					EDSServiceName:        serviceName,
+					MaxConcurrentRequests: newUint32(512),
+					OutlierDetection:      json.RawMessage(`{}`),
+				}},
+				XDSLBPolicy: json.RawMessage(`[{"xds_wrr_locality_experimental": {"childPolicy": [{"round_robin": {}}]}}]`),
 			},
-			wantCCS: edsCCS(serviceName, nil, true, wrrLocalityLBConfigJSON, noopODLBCfgJSON),
 		},
 		{
-			name: "happy-case-without-lrs",
-			cdsUpdate: xdsresource.ClusterUpdate{
-				ClusterName: serviceName,
-				LBPolicy:    wrrLocalityLBConfigJSON,
+			name: "happy-case-with-ring-hash-default",
+			clusterResource: e2e.ClusterResourceWithOptions(e2e.ClusterOptions{
+				ClusterName:   clusterName,
+				ServiceName:   serviceName,
+				SecurityLevel: e2e.SecurityLevelNone,
+				Policy:        e2e.LoadBalancingPolicyRingHash,
+			}),
+			wantChildCfg: &clusterresolver.LBConfig{
+				DiscoveryMechanisms: []clusterresolver.DiscoveryMechanism{{
+					Cluster:          clusterName,
+					Type:             clusterresolver.DiscoveryMechanismTypeEDS,
+					EDSServiceName:   serviceName,
+					OutlierDetection: json.RawMessage(`{}`),
+				}},
+				XDSLBPolicy: json.RawMessage(`[{"ring_hash_experimental": {"minRingSize":1024, "maxRingSize":8388608}}]`),
 			},
-			wantCCS: edsCCS(serviceName, nil, false, wrrLocalityLBConfigJSON, noopODLBCfgJSON),
 		},
 		{
-			name: "happy-case-with-ring-hash-lb-policy",
-			cdsUpdate: xdsresource.ClusterUpdate{
-				ClusterName: serviceName,
-				LBPolicy:    ringHashLBConfigJSON,
+			name: "happy-case-with-ring-hash-non-default",
+			clusterResource: func() *v3clusterpb.Cluster {
+				c := e2e.ClusterResourceWithOptions(e2e.ClusterOptions{
+					ClusterName:   clusterName,
+					ServiceName:   serviceName,
+					SecurityLevel: e2e.SecurityLevelNone,
+					Policy:        e2e.LoadBalancingPolicyRingHash,
+				})
+				c.LbConfig = &v3clusterpb.Cluster_RingHashLbConfig_{
+					RingHashLbConfig: &v3clusterpb.Cluster_RingHashLbConfig{
+						MinimumRingSize: &wrapperspb.UInt64Value{Value: 100},
+						MaximumRingSize: &wrapperspb.UInt64Value{Value: 1000},
+					},
+				}
+				return c
+			}(),
+			wantChildCfg: &clusterresolver.LBConfig{
+				DiscoveryMechanisms: []clusterresolver.DiscoveryMechanism{{
+					Cluster:          clusterName,
+					Type:             clusterresolver.DiscoveryMechanismTypeEDS,
+					EDSServiceName:   serviceName,
+					OutlierDetection: json.RawMessage(`{}`),
+				}},
+				XDSLBPolicy: json.RawMessage(`[{"ring_hash_experimental": {"minRingSize":100, "maxRingSize":1000}}]`),
 			},
-			wantCCS: edsCCS(serviceName, nil, false, ringHashLBConfigJSON, noopODLBCfgJSON),
 		},
 		{
-			name: "happy-case-outlier-detection-xds-defaults",
-			// i.e. od proto set but no proto fields set
-			cdsUpdate: xdsresource.ClusterUpdate{
-				ClusterName: serviceName,
-				OutlierDetection: json.RawMessage(`{
-				"successRateEjection": {}
-			}`),
-				LBPolicy: wrrLocalityLBConfigJSON,
+			name: "happy-case-outlier-detection-xds-defaults", // OD proto set but no proto fields set
+			clusterResource: func() *v3clusterpb.Cluster {
+				c := e2e.ClusterResourceWithOptions(e2e.ClusterOptions{
+					ClusterName:   clusterName,
+					ServiceName:   serviceName,
+					SecurityLevel: e2e.SecurityLevelNone,
+					Policy:        e2e.LoadBalancingPolicyRingHash,
+				})
+				c.OutlierDetection = &v3clusterpb.OutlierDetection{}
+				return c
+			}(),
+			wantChildCfg: &clusterresolver.LBConfig{
+				DiscoveryMechanisms: []clusterresolver.DiscoveryMechanism{{
+					Cluster:          clusterName,
+					Type:             clusterresolver.DiscoveryMechanismTypeEDS,
+					EDSServiceName:   serviceName,
+					OutlierDetection: json.RawMessage(`{"successRateEjection":{}}`),
+				}},
+				XDSLBPolicy: json.RawMessage(`[{"ring_hash_experimental": {"minRingSize":1024, "maxRingSize":8388608}}]`),
 			},
-			wantCCS: edsCCS(serviceName, nil, false, wrrLocalityLBConfigJSON, json.RawMessage(`{
-				"successRateEjection": {}
-			}`)),
 		},
 		{
 			name: "happy-case-outlier-detection-all-fields-set",
-			cdsUpdate: xdsresource.ClusterUpdate{
-				ClusterName: serviceName,
-				OutlierDetection: json.RawMessage(`{
-				"interval": "10s",
-				"baseEjectionTime": "30s",
-				"maxEjectionTime": "300s",
-				"maxEjectionPercent": 10,
-				"successRateEjection": {
-					"stdevFactor": 1900,
-					"enforcementPercentage": 100,
-					"minimumHosts": 5,
-					"requestVolume": 100
-				},
-				"failurePercentageEjection": {
-					"threshold": 85,
-					"enforcementPercentage": 5,
-					"minimumHosts": 5,
-					"requestVolume": 50
+			clusterResource: func() *v3clusterpb.Cluster {
+				c := e2e.ClusterResourceWithOptions(e2e.ClusterOptions{
+					ClusterName:   clusterName,
+					ServiceName:   serviceName,
+					SecurityLevel: e2e.SecurityLevelNone,
+					Policy:        e2e.LoadBalancingPolicyRingHash,
+				})
+				c.OutlierDetection = &v3clusterpb.OutlierDetection{
+					Interval:                       durationpb.New(10 * time.Second),
+					BaseEjectionTime:               durationpb.New(30 * time.Second),
+					MaxEjectionTime:                durationpb.New(300 * time.Second),
+					MaxEjectionPercent:             wrapperspb.UInt32(10),
+					SuccessRateStdevFactor:         wrapperspb.UInt32(1900),
+					EnforcingSuccessRate:           wrapperspb.UInt32(100),
+					SuccessRateMinimumHosts:        wrapperspb.UInt32(5),
+					SuccessRateRequestVolume:       wrapperspb.UInt32(100),
+					FailurePercentageThreshold:     wrapperspb.UInt32(85),
+					EnforcingFailurePercentage:     wrapperspb.UInt32(5),
+					FailurePercentageMinimumHosts:  wrapperspb.UInt32(5),
+					FailurePercentageRequestVolume: wrapperspb.UInt32(50),
 				}
-			}`),
-				LBPolicy: wrrLocalityLBConfigJSON,
+				return c
+			}(),
+			wantChildCfg: &clusterresolver.LBConfig{
+				DiscoveryMechanisms: []clusterresolver.DiscoveryMechanism{{
+					Cluster:        clusterName,
+					Type:           clusterresolver.DiscoveryMechanismTypeEDS,
+					EDSServiceName: serviceName,
+					OutlierDetection: json.RawMessage(`{
+						"interval": "10s",
+						"baseEjectionTime": "30s",
+						"maxEjectionTime": "300s",
+						"maxEjectionPercent": 10,
+						"successRateEjection": {
+							"stdevFactor": 1900,
+							"enforcementPercentage": 100,
+							"minimumHosts": 5,
+							"requestVolume": 100
+						},
+						"failurePercentageEjection": {
+							"threshold": 85,
+							"enforcementPercentage": 5,
+							"minimumHosts": 5,
+							"requestVolume": 50
+						}
+					}`),
+				}},
+				XDSLBPolicy: json.RawMessage(`[{"ring_hash_experimental": {"minRingSize":1024, "maxRingSize":8388608}}]`),
 			},
-			wantCCS: edsCCS(serviceName, nil, false, wrrLocalityLBConfigJSON, json.RawMessage(`{
-				"interval": "10s",
-				"baseEjectionTime": "30s",
-				"maxEjectionTime": "300s",
-				"maxEjectionPercent": 10,
-				"successRateEjection": {
-					"stdevFactor": 1900,
-					"enforcementPercentage": 100,
-					"minimumHosts": 5,
-					"requestVolume": 100
-				},
-				"failurePercentageEjection": {
-					"threshold": 85,
-					"enforcementPercentage": 5,
-					"minimumHosts": 5,
-					"requestVolume": 50
-				}
-			}`)),
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			ctx, ctxCancel := context.WithTimeout(context.Background(), defaultTestTimeout)
-			defer ctxCancel()
-			if err := invokeWatchCbAndWait(ctx, xdsC, cdsWatchInfo{test.cdsUpdate, test.updateErr}, test.wantCCS, edsB); err != nil {
+			mgmtServer, nodeID, lbCfgCh := setupForTestClusterUpdateSuccess(t)
+
+			ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+			defer cancel()
+			if err := mgmtServer.Update(ctx, e2e.UpdateOptions{
+				NodeID:         nodeID,
+				Clusters:       []*v3clusterpb.Cluster{test.clusterResource},
+				SkipValidation: true,
+			}); err != nil {
+				t.Fatal(err)
+			}
+
+			if err := compareLoadBalancingConfig(ctx, lbCfgCh, test.wantChildCfg); err != nil {
 				t.Fatal(err)
 			}
 		})
 	}
 }
 
-// TestHandleClusterUpdateError covers the cases that an error is returned from
-// the watcher.
-func (s) TestHandleClusterUpdateError(t *testing.T) {
-	// This creates a CDS balancer, pushes a ClientConnState update with a fake
-	// xdsClient, and makes sure that the CDS balancer registers a watch on the
-	// provided xdsClient.
-	xdsC, cdsB, edsB, tcc, cancel := setupWithWatch(t)
-	defer func() {
-		cancel()
-		cdsB.Close()
-	}()
-
-	// A watch was registered above, but the watch callback has not been invoked
-	// yet. This means that the watch handler on the CDS balancer has not been
-	// invoked yet, and therefore no EDS balancer has been built so far. A
-	// resolver error at this point should result in the CDS balancer returning
-	// an error picker.
-	watcherErr := errors.New("cdsBalancer watcher error")
-	xdsC.InvokeWatchClusterCallback(xdsresource.ClusterUpdate{}, watcherErr)
-
-	// Since the error being pushed here is not a resource-not-found-error, the
-	// registered watch should not be cancelled.
-	sCtx, sCancel := context.WithTimeout(context.Background(), defaultTestShortTimeout)
-	defer sCancel()
-	if _, err := xdsC.WaitForCancelClusterWatch(sCtx); err != context.DeadlineExceeded {
-		t.Fatal("cluster watch cancelled for a non-resource-not-found-error")
-	}
-	// The CDS balancer has not yet created an EDS balancer. So, this resolver
-	// error should not be forwarded to our fake EDS balancer.
-	sCtx, sCancel = context.WithTimeout(context.Background(), defaultTestShortTimeout)
-	defer sCancel()
-	if err := edsB.waitForResolverError(sCtx, watcherErr); err != context.DeadlineExceeded {
-		t.Fatal("eds balancer shouldn't get error (shouldn't be built yet)")
-	}
-
-	// Make sure the CDS balancer reports an error picker.
-	ctx, ctxCancel := context.WithTimeout(context.Background(), defaultTestTimeout)
-	defer ctxCancel()
-	select {
-	case <-ctx.Done():
-		t.Fatalf("timeout when waiting for an error picker")
-	case picker := <-tcc.NewPickerCh:
-		if _, perr := picker.Pick(balancer.PickInfo{}); perr == nil {
-			t.Fatalf("CDS balancer returned a picker which is not an error picker")
-		}
-	}
-
-	// Here we invoke the watch callback registered on the fake xdsClient. This
-	// will trigger the watch handler on the CDS balancer, which will attempt to
-	// create a new EDS balancer. The fake EDS balancer created above will be
-	// returned to the CDS balancer, because we have overridden the
-	// newChildBalancer function as part of test setup.
-	cdsUpdate := xdsresource.ClusterUpdate{
-		ClusterName: serviceName,
-		LBPolicy:    wrrLocalityLBConfigJSON,
-	}
-	wantCCS := edsCCS(serviceName, nil, false, wrrLocalityLBConfigJSON, noopODLBCfgJSON)
-	if err := invokeWatchCbAndWait(ctx, xdsC, cdsWatchInfo{cdsUpdate, nil}, wantCCS, edsB); err != nil {
-		t.Fatal(err)
-	}
-
-	// Again push a non-resource-not-found-error through the watcher callback.
-	xdsC.InvokeWatchClusterCallback(xdsresource.ClusterUpdate{}, watcherErr)
-	// Make sure the registered watch is not cancelled.
-	sCtx, sCancel = context.WithTimeout(context.Background(), defaultTestShortTimeout)
-	defer sCancel()
-	if _, err := xdsC.WaitForCancelClusterWatch(sCtx); err != context.DeadlineExceeded {
-		t.Fatal("cluster watch cancelled for a non-resource-not-found-error")
-	}
-	// Make sure the error is forwarded to the EDS balancer.
-	if err := edsB.waitForResolverError(ctx, watcherErr); err != nil {
-		t.Fatalf("Watch callback error is not forwarded to EDS balancer")
-	}
-
-	// Push a resource-not-found-error this time around.
-	resourceErr := xdsresource.NewErrorf(xdsresource.ErrorTypeResourceNotFound, "cdsBalancer resource not found error")
-	xdsC.InvokeWatchClusterCallback(xdsresource.ClusterUpdate{}, resourceErr)
-	// Make sure that the watch is not cancelled. This error indicates that the
-	// request cluster resource is not found. We should continue to watch it.
-	sCtx, sCancel = context.WithTimeout(context.Background(), defaultTestShortTimeout)
-	defer sCancel()
-	if _, err := xdsC.WaitForCancelClusterWatch(sCtx); err != context.DeadlineExceeded {
-		t.Fatal("cluster watch cancelled for a resource-not-found-error")
-	}
-	// Make sure the error is forwarded to the EDS balancer.
-	if err := edsB.waitForResolverError(ctx, resourceErr); err != nil {
-		t.Fatalf("Watch callback error is not forwarded to EDS balancer")
-	}
-}
-
-// TestResolverError verifies the ResolverError() method in the CDS balancer.
-func (s) TestResolverError(t *testing.T) {
-	// This creates a CDS balancer, pushes a ClientConnState update with a fake
-	// xdsClient, and makes sure that the CDS balancer registers a watch on the
-	// provided xdsClient.
-	xdsC, cdsB, edsB, tcc, cancel := setupWithWatch(t)
-	defer func() {
-		cancel()
-		cdsB.Close()
-	}()
-
-	// A watch was registered above, but the watch callback has not been invoked
-	// yet. This means that the watch handler on the CDS balancer has not been
-	// invoked yet, and therefore no EDS balancer has been built so far. A
-	// resolver error at this point should result in the CDS balancer returning
-	// an error picker.
-	resolverErr := errors.New("cdsBalancer resolver error")
-	cdsB.ResolverError(resolverErr)
-
-	// Since the error being pushed here is not a resource-not-found-error, the
-	// registered watch should not be cancelled.
-	sCtx, sCancel := context.WithTimeout(context.Background(), defaultTestShortTimeout)
-	defer sCancel()
-	if _, err := xdsC.WaitForCancelClusterWatch(sCtx); err != context.DeadlineExceeded {
-		t.Fatal("cluster watch cancelled for a non-resource-not-found-error")
-	}
-	// The CDS balancer has not yet created an EDS balancer. So, this resolver
-	// error should not be forwarded to our fake EDS balancer.
-	sCtx, sCancel = context.WithTimeout(context.Background(), defaultTestShortTimeout)
-	defer sCancel()
-	if err := edsB.waitForResolverError(sCtx, resolverErr); err != context.DeadlineExceeded {
-		t.Fatal("eds balancer shouldn't get error (shouldn't be built yet)")
-	}
-	// Make sure the CDS balancer reports an error picker.
-	ctx, ctxCancel := context.WithTimeout(context.Background(), defaultTestTimeout)
-	defer ctxCancel()
-	select {
-	case <-ctx.Done():
-		t.Fatalf("timeout when waiting for an error picker")
-	case picker := <-tcc.NewPickerCh:
-		if _, perr := picker.Pick(balancer.PickInfo{}); perr == nil {
-			t.Fatalf("CDS balancer returned a picker which is not an error picker")
-		}
-	}
-
-	// Here we invoke the watch callback registered on the fake xdsClient. This
-	// will trigger the watch handler on the CDS balancer, which will attempt to
-	// create a new EDS balancer. The fake EDS balancer created above will be
-	// returned to the CDS balancer, because we have overridden the
-	// newChildBalancer function as part of test setup.
-	cdsUpdate := xdsresource.ClusterUpdate{
-		ClusterName: serviceName,
-		LBPolicy:    wrrLocalityLBConfigJSON,
-	}
-	wantCCS := edsCCS(serviceName, nil, false, wrrLocalityLBConfigJSON, noopODLBCfgJSON)
-	if err := invokeWatchCbAndWait(ctx, xdsC, cdsWatchInfo{cdsUpdate, nil}, wantCCS, edsB); err != nil {
-		t.Fatal(err)
-	}
-
-	// Again push a non-resource-not-found-error.
-	cdsB.ResolverError(resolverErr)
-	// Make sure the registered watch is not cancelled.
-	sCtx, sCancel = context.WithTimeout(context.Background(), defaultTestShortTimeout)
-	defer sCancel()
-	if _, err := xdsC.WaitForCancelClusterWatch(sCtx); err != context.DeadlineExceeded {
-		t.Fatal("cluster watch cancelled for a non-resource-not-found-error")
-	}
-	// Make sure the error is forwarded to the EDS balancer.
-	if err := edsB.waitForResolverError(ctx, resolverErr); err != nil {
-		t.Fatalf("ResolverError() not forwarded to EDS balancer")
-	}
-
-	// Push a resource-not-found-error this time around.
-	resourceErr := xdsresource.NewErrorf(xdsresource.ErrorTypeResourceNotFound, "cdsBalancer resource not found error")
-	cdsB.ResolverError(resourceErr)
-	// Make sure the registered watch is cancelled.
-	if _, err := xdsC.WaitForCancelClusterWatch(ctx); err != nil {
-		t.Fatalf("want watch to be canceled, watchForCancel failed: %v", err)
-	}
-	// Make sure the error is forwarded to the EDS balancer.
-	if err := edsB.waitForResolverError(ctx, resourceErr); err != nil {
-		t.Fatalf("eds balancer should get resource-not-found error, waitForError failed: %v", err)
-	}
-}
-
-// TestCircuitBreaking verifies that the CDS balancer correctly updates a
-// service's counter on watch updates.
-func (s) TestCircuitBreaking(t *testing.T) {
-	// This creates a CDS balancer, pushes a ClientConnState update with a fake
-	// xdsClient, and makes sure that the CDS balancer registers a watch on the
-	// provided xdsClient.
-	xdsC, cdsB, edsB, _, cancel := setupWithXDSCreds(t)
-	defer func() {
-		cancel()
-		cdsB.Close()
-	}()
-	// Here we invoke the watch callback registered on the fake xdsClient. This
-	// will trigger the watch handler on the CDS balancer, which will update
-	// the service's counter with the new max requests.
-	var maxRequests uint32 = 1
-	cdsUpdate := xdsresource.ClusterUpdate{
+// Tests a single success scenario where the cds LB policy receives a cluster
+// resource from the management server with LRS enabled. Verifies that the load
+// balancing configuration pushed to the child is on expected lines.
+func (s) TestClusterUpdate_SuccessWithLRS(t *testing.T) {
+	mgmtServer, nodeID, lbCfgCh := setupForTestClusterUpdateSuccess(t)
+	clusterResource := e2e.ClusterResourceWithOptions(e2e.ClusterOptions{
 		ClusterName: clusterName,
-		MaxRequests: &maxRequests,
-		LBPolicy:    wrrLocalityLBConfigJSON,
-	}
-	wantCCS := edsCCS(clusterName, &maxRequests, false, wrrLocalityLBConfigJSON, noopODLBCfgJSON)
-	ctx, ctxCancel := context.WithTimeout(context.Background(), defaultTestTimeout)
-	defer ctxCancel()
-	if err := invokeWatchCbAndWait(ctx, xdsC, cdsWatchInfo{cdsUpdate, nil}, wantCCS, edsB); err != nil {
-		t.Fatal(err)
+		ServiceName: serviceName,
+		EnableLRS:   true,
+	})
+	wantChildCfg := &clusterresolver.LBConfig{
+		DiscoveryMechanisms: []clusterresolver.DiscoveryMechanism{{
+			Cluster:        clusterName,
+			Type:           clusterresolver.DiscoveryMechanismTypeEDS,
+			EDSServiceName: serviceName,
+			LoadReportingServer: &bootstrap.ServerConfig{
+				ServerURI: mgmtServer.Address,
+				Creds:     bootstrap.ChannelCreds{Type: "insecure"},
+			},
+			OutlierDetection: json.RawMessage(`{}`),
+		}},
+		XDSLBPolicy: json.RawMessage(`[{"xds_wrr_locality_experimental": {"childPolicy": [{"round_robin": {}}]}}]`),
 	}
 
-	// Since the counter's max requests was set to 1, the first request should
-	// succeed and the second should fail.
-	counter := xdsclient.GetClusterRequestsCounter(clusterName, "")
-	if err := counter.StartRequest(maxRequests); err != nil {
-		t.Fatal(err)
-	}
-	if err := counter.StartRequest(maxRequests); err == nil {
-		t.Fatal("unexpected success on start request over max")
-	}
-	counter.EndRequest()
-}
-
-// TestClose verifies the Close() method in the CDS balancer.
-func (s) TestClose(t *testing.T) {
-	grpctest.TLogger.ExpectError("cds-lb.*Received balancer config after close")
-
-	// This creates a CDS balancer, pushes a ClientConnState update with a fake
-	// xdsClient, and makes sure that the CDS balancer registers a watch on the
-	// provided xdsClient.
-	xdsC, cdsB, edsB, _, cancel := setupWithWatch(t)
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
-	// Here we invoke the watch callback registered on the fake xdsClient. This
-	// will trigger the watch handler on the CDS balancer, which will attempt to
-	// create a new EDS balancer. The fake EDS balancer created above will be
-	// returned to the CDS balancer, because we have overridden the
-	// newChildBalancer function as part of test setup.
-	cdsUpdate := xdsresource.ClusterUpdate{
-		ClusterName: serviceName,
-		LBPolicy:    wrrLocalityLBConfigJSON,
-	}
-	wantCCS := edsCCS(serviceName, nil, false, wrrLocalityLBConfigJSON, noopODLBCfgJSON)
-	ctx, ctxCancel := context.WithTimeout(context.Background(), defaultTestTimeout)
-	defer ctxCancel()
-	if err := invokeWatchCbAndWait(ctx, xdsC, cdsWatchInfo{cdsUpdate, nil}, wantCCS, edsB); err != nil {
+	if err := mgmtServer.Update(ctx, e2e.UpdateOptions{
+		NodeID:         nodeID,
+		Clusters:       []*v3clusterpb.Cluster{clusterResource},
+		SkipValidation: true,
+	}); err != nil {
 		t.Fatal(err)
 	}
 
-	// Close the CDS balancer.
-	cdsB.Close()
-
-	// Make sure that the cluster watch registered by the CDS balancer is
-	// cancelled.
-	if _, err := xdsC.WaitForCancelClusterWatch(ctx); err != nil {
+	if err := compareLoadBalancingConfig(ctx, lbCfgCh, wantChildCfg); err != nil {
 		t.Fatal(err)
-	}
-
-	// Make sure that a cluster update is not acted upon.
-	xdsC.InvokeWatchClusterCallback(cdsUpdate, nil)
-	sCtx, sCancel := context.WithTimeout(context.Background(), defaultTestShortTimeout)
-	defer sCancel()
-	if err := edsB.waitForClientConnUpdate(sCtx, balancer.ClientConnState{}); err != context.DeadlineExceeded {
-		t.Fatalf("ClusterUpdate after close forwaded to EDS balancer")
-	}
-
-	// Make sure that the underlying EDS balancer is closed.
-	if err := edsB.waitForClose(ctx); err != nil {
-		t.Fatal(err)
-	}
-
-	// Make sure that the UpdateClientConnState() method on the CDS balancer
-	// returns error.
-	if err := cdsB.UpdateClientConnState(cdsCCS(clusterName, xdsC)); err != errBalancerClosed {
-		t.Fatalf("UpdateClientConnState() after close returned %v, want %v", err, errBalancerClosed)
-	}
-
-	// Make sure that the ResolverErr() method on the CDS balancer does not
-	// forward the update to the EDS balancer.
-	rErr := errors.New("cdsBalancer resolver error")
-	cdsB.ResolverError(rErr)
-	sCtx, sCancel = context.WithTimeout(context.Background(), defaultTestShortTimeout)
-	defer sCancel()
-	if err := edsB.waitForResolverError(sCtx, rErr); err != context.DeadlineExceeded {
-		t.Fatal("ResolverError() forwarded to EDS balancer after Close()")
 	}
 }
 
-func (s) TestExitIdle(t *testing.T) {
-	// This creates a CDS balancer, pushes a ClientConnState update with a fake
-	// xdsClient, and makes sure that the CDS balancer registers a watch on the
-	// provided xdsClient.
-	xdsC, cdsB, edsB, _, cancel := setupWithWatch(t)
-	defer func() {
-		cancel()
-		cdsB.Close()
-	}()
+// Performs setup required for cluster update success scenarios.
+//   - Spins up an xDS management server
+//   - Creates an xDS client talking to this management server
+//   - Overrides the clusterresolver LB policy and makes the load balancing
+//     configuration pushed to it available on a channel
+//   - Creates a manual resolver that configures the cds LB policy as the
+//     top-level policy
+//   - Creates a gRPC channel with the above manual resolver
+//
+// Returns the following
+//   - a reference to the management server
+//   - nodeID expected by the management server
+//   - a channel on which the load balancing configuration received by the child
+//     policy is pushed on to
+func setupForTestClusterUpdateSuccess(t *testing.T) (*e2e.ManagementServer, string, chan serviceconfig.LoadBalancingConfig) {
+	t.Helper()
 
-	// Here we invoke the watch callback registered on the fake xdsClient. This
-	// will trigger the watch handler on the CDS balancer, which will attempt to
-	// create a new EDS balancer. The fake EDS balancer created above will be
-	// returned to the CDS balancer, because we have overridden the
-	// newChildBalancer function as part of test setup.
-	cdsUpdate := xdsresource.ClusterUpdate{
-		ClusterName: serviceName,
-		LBPolicy:    wrrLocalityLBConfigJSON,
+	mgmtServer, nodeID, bootstrapContents, _, cleanup := e2e.SetupManagementServer(t, e2e.ManagementServerOptions{})
+	t.Cleanup(cleanup)
+
+	// Register a wrapped clusterresolver LB policy (child policy of the cds LB
+	// policy) for the duration of this test that makes the LB config pushed to
+	// it available to the test.
+	clusterresolverBuilder := balancer.Get(clusterresolver.Name)
+	internal.BalancerUnregister(clusterresolverBuilder.Name())
+	lbCfgCh := make(chan serviceconfig.LoadBalancingConfig, 1)
+	stub.Register(clusterresolver.Name, stub.BalancerFuncs{
+		Init: func(bd *stub.BalancerData) {
+			bd.Data = clusterresolverBuilder.Build(bd.ClientConn, bd.BuildOptions)
+		},
+		ParseConfig: func(lbCfg json.RawMessage) (serviceconfig.LoadBalancingConfig, error) {
+			return clusterresolverBuilder.(balancer.ConfigParser).ParseConfig(lbCfg)
+		},
+		UpdateClientConnState: func(bd *stub.BalancerData, ccs balancer.ClientConnState) error {
+			select {
+			case lbCfgCh <- ccs.BalancerConfig:
+			default:
+			}
+			bal := bd.Data.(balancer.Balancer)
+			return bal.UpdateClientConnState(ccs)
+		},
+		Close: func(bd *stub.BalancerData) {
+			bal := bd.Data.(balancer.Balancer)
+			bal.Close()
+		},
+	})
+	t.Cleanup(func() { balancer.Register(clusterresolverBuilder) })
+
+	// Create an xDS client for use by the cluster_resolver LB policy.
+	xdsC, xdsClose, err := xdsclient.NewWithBootstrapContentsForTesting(bootstrapContents)
+	if err != nil {
+		t.Fatalf("Failed to create xDS client: %v", err)
 	}
-	wantCCS := edsCCS(serviceName, nil, false, wrrLocalityLBConfigJSON, noopODLBCfgJSON)
-	ctx, ctxCancel := context.WithTimeout(context.Background(), defaultTestTimeout)
-	defer ctxCancel()
-	if err := invokeWatchCbAndWait(ctx, xdsC, cdsWatchInfo{cdsUpdate, nil}, wantCCS, edsB); err != nil {
+	t.Cleanup(xdsClose)
+
+	// Create a manual resolver and push a service config specifying the use of
+	// the cds LB policy as the top-level LB policy, and a corresponding config
+	// with a single cluster.
+	r := manual.NewBuilderWithScheme("whatever")
+	jsonSC := fmt.Sprintf(`{
+			"loadBalancingConfig":[{
+				"cds_experimental":{
+					"cluster": "%s"
+				}
+			}]
+		}`, clusterName)
+	scpr := internal.ParseServiceConfig.(func(string) *serviceconfig.ParseResult)(jsonSC)
+	r.InitialState(xdsclient.SetClient(resolver.State{ServiceConfig: scpr}, xdsC))
+
+	// Create a ClientConn and make a successful RPC.
+	cc, err := grpc.Dial(r.Scheme()+":///test.service", grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithResolvers(r))
+	if err != nil {
+		t.Fatalf("Failed to dial local test server: %v", err)
+	}
+	t.Cleanup(func() { cc.Close() })
+
+	return mgmtServer, nodeID, lbCfgCh
+}
+
+// Helper function to compare the load balancing configuration received on the
+// channel with the expected one. Both configs are marshalled to JSON and then
+// compared.
+func compareLoadBalancingConfig(ctx context.Context, lbCfgCh chan serviceconfig.LoadBalancingConfig, wantChildCfg serviceconfig.LoadBalancingConfig) error {
+	wantJSON, err := json.Marshal(wantChildCfg)
+	if err != nil {
+		return fmt.Errorf("failed to marshal expected child config to JSON: %v", err)
+	}
+	select {
+	case lbCfg := <-lbCfgCh:
+		gotJSON, err := json.Marshal(lbCfg)
+		if err != nil {
+			return fmt.Errorf("failed to marshal received LB config into JSON: %v", err)
+		}
+		if diff := cmp.Diff(wantJSON, gotJSON); diff != "" {
+			return fmt.Errorf("child policy received unexpected diff in config (-want +got):\n%s", diff)
+		}
+	case <-ctx.Done():
+		return fmt.Errorf("timeout when waiting for child policy to receive its configuration")
+	}
+	return nil
+}
+
+// Tests scenarios for a bad cluster update received from the management server.
+//
+//   - when a bad cluster resource update is received without any previous good
+//     update from the management server, the cds LB policy is expected to put
+//     the channel in TRANSIENT_FAILURE.
+//   - when a bad cluster resource update is received after a previous good
+//     update from the management server, the cds LB policy is expected to
+//     continue using the previous good update.
+//   - when the cluster resource is removed after a previous good
+//     update from the management server, the cds LB policy is expected to put
+//     the channel in TRANSIENT_FAILURE.
+func (s) TestClusterUpdate_Failure(t *testing.T) {
+	// Register a wrapped clusterresolver LB policy (child policy of the cds LB
+	// policy) for the duration of this test that makes the resolver error
+	// pushed to it available to the test.
+	clusterresolverBuilder := balancer.Get(clusterresolver.Name)
+	internal.BalancerUnregister(clusterresolverBuilder.Name())
+	resolverErrCh := make(chan error, 1)
+	stub.Register(clusterresolver.Name, stub.BalancerFuncs{
+		Init: func(bd *stub.BalancerData) {
+			bd.Data = clusterresolverBuilder.Build(bd.ClientConn, bd.BuildOptions)
+		},
+		ParseConfig: func(lbCfg json.RawMessage) (serviceconfig.LoadBalancingConfig, error) {
+			return clusterresolverBuilder.(balancer.ConfigParser).ParseConfig(lbCfg)
+		},
+		UpdateClientConnState: func(bd *stub.BalancerData, ccs balancer.ClientConnState) error {
+			bal := bd.Data.(balancer.Balancer)
+			return bal.UpdateClientConnState(ccs)
+		},
+		ResolverError: func(bd *stub.BalancerData, err error) {
+			select {
+			case resolverErrCh <- err:
+			default:
+			}
+			bal := bd.Data.(balancer.Balancer)
+			bal.ResolverError(err)
+		},
+		Close: func(bd *stub.BalancerData) {
+			bal := bd.Data.(balancer.Balancer)
+			bal.Close()
+		},
+	})
+	t.Cleanup(func() { balancer.Register(clusterresolverBuilder) })
+
+	// Start an xDS management server that uses a couple of channels to
+	// notify the test about the following events:
+	// - a CDS requested with the expected resource name is requested
+	// - CDS resource is unrequested, i.e, a CDS request with no resource name
+	//   is received, which indicates that we are not longer interested in that
+	//   resource.
+	cdsResourceRequestedCh := make(chan struct{}, 1)
+	cdsResourceCanceledCh := make(chan struct{}, 1)
+	mgmtServer, nodeID, bootstrapContents, _, cleanup := e2e.SetupManagementServer(t, e2e.ManagementServerOptions{
+		OnStreamRequest: func(_ int64, req *v3discoverypb.DiscoveryRequest) error {
+			if req.GetTypeUrl() == version.V3ClusterURL {
+				switch len(req.GetResourceNames()) {
+				case 0:
+					select {
+					case cdsResourceCanceledCh <- struct{}{}:
+					default:
+					}
+				case 1:
+					if req.GetResourceNames()[0] == clusterName {
+						select {
+						case cdsResourceRequestedCh <- struct{}{}:
+						default:
+						}
+					}
+				default:
+					t.Errorf("Unexpected number of resources, %d, in a CDS request", len(req.GetResourceNames()))
+				}
+			}
+			return nil
+		},
+	})
+	t.Cleanup(cleanup)
+
+	// Create an xDS client for use by the cluster_resolver LB policy.
+	xdsC, xdsClose, err := xdsclient.NewWithBootstrapContentsForTesting(bootstrapContents)
+	if err != nil {
+		t.Fatalf("Failed to create xDS client: %v", err)
+	}
+	t.Cleanup(xdsClose)
+
+	// Create a manual resolver and push a service config specifying the use of
+	// the cds LB policy as the top-level LB policy, and a corresponding config
+	// with a single cluster.
+	r := manual.NewBuilderWithScheme("whatever")
+	jsonSC := fmt.Sprintf(`{
+			"loadBalancingConfig":[{
+				"cds_experimental":{
+					"cluster": "%s"
+				}
+			}]
+		}`, clusterName)
+	scpr := internal.ParseServiceConfig.(func(string) *serviceconfig.ParseResult)(jsonSC)
+	r.InitialState(xdsclient.SetClient(resolver.State{ServiceConfig: scpr}, xdsC))
+
+	// Create a ClientConn, and this should trigger the cds LB policy.
+	cc, err := grpc.Dial(r.Scheme()+":///test.service", grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithResolvers(r))
+	if err != nil {
+		t.Fatalf("Failed to dial local test server: %v", err)
+	}
+	t.Cleanup(func() { cc.Close() })
+
+	// Verify that the specified cluster resource is requested.
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	select {
+	case <-ctx.Done():
+		t.Fatal("Timeout when waiting for cluster resource to be requested")
+	case <-cdsResourceRequestedCh:
+	}
+
+	// Configure the management server to return a cluster resource that
+	// contains a config_source_specifier for the `lrs_server` field which is not
+	// set to `self`, and hence is expected to be NACKed by the client.
+	cluster := e2e.DefaultCluster(clusterName, serviceName, e2e.SecurityLevelNone)
+	cluster.LrsServer = &v3corepb.ConfigSource{ConfigSourceSpecifier: &v3corepb.ConfigSource_Ads{}}
+	resources := e2e.UpdateOptions{
+		NodeID:         nodeID,
+		Clusters:       []*v3clusterpb.Cluster{cluster},
+		SkipValidation: true,
+	}
+	if err := mgmtServer.Update(ctx, resources); err != nil {
 		t.Fatal(err)
 	}
 
-	// Call ExitIdle on the CDS balancer.
-	cdsB.ExitIdle()
+	// Verify that the watch for the cluster resource is not cancelled.
+	sCtx, sCancel := context.WithTimeout(ctx, defaultTestShortTimeout)
+	defer sCancel()
+	select {
+	case <-sCtx.Done():
+	case <-cdsResourceCanceledCh:
+		t.Fatal("Watch for cluster resource is cancelled when not expected to")
+	}
 
-	edsB.exitIdleCh.Receive(ctx)
+	// Ensure that the ClientConn moves to TransientFailure.
+	for state := cc.GetState(); state != connectivity.TransientFailure; state = cc.GetState() {
+		if !cc.WaitForStateChange(ctx, state) {
+			t.Fatalf("Timed out waiting for state change. got %v; want %v", state, connectivity.TransientFailure)
+		}
+	}
+
+	// Ensure that the NACK error is propagated to the RPC caller.
+	const wantClusterNACKErr = "unsupported config_source_specifier"
+	client := testgrpc.NewTestServiceClient(cc)
+	_, err = client.EmptyCall(ctx, &testpb.Empty{})
+	if code := status.Code(err); code != codes.Unavailable {
+		t.Fatalf("EmptyCall() failed with code: %v, want %v", code, codes.Unavailable)
+	}
+	if err != nil && !strings.Contains(err.Error(), wantClusterNACKErr) {
+		t.Fatalf("EmptyCall() failed with err: %v, want %v", err, wantClusterNACKErr)
+	}
+
+	// Start a test service backend.
+	server := stubserver.StartTestService(t, nil)
+	defer server.Stop()
+
+	// Configure cluster and endpoints resources in the management server.
+	resources = e2e.UpdateOptions{
+		NodeID:         nodeID,
+		Clusters:       []*v3clusterpb.Cluster{e2e.DefaultCluster(clusterName, serviceName, e2e.SecurityLevelNone)},
+		Endpoints:      []*v3endpointpb.ClusterLoadAssignment{e2e.DefaultEndpoint(serviceName, "localhost", []uint32{testutils.ParsePort(t, server.Address)})},
+		SkipValidation: true,
+	}
+	if err := mgmtServer.Update(ctx, resources); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify that a successful RPC can be made.
+	if _, err = client.EmptyCall(ctx, &testpb.Empty{}, grpc.WaitForReady(true)); err != nil {
+		t.Fatalf("EmptyCall() failed: %v", err)
+	}
+
+	// Send the bad cluster resource again.
+	resources = e2e.UpdateOptions{
+		NodeID:         nodeID,
+		Clusters:       []*v3clusterpb.Cluster{cluster},
+		Endpoints:      []*v3endpointpb.ClusterLoadAssignment{e2e.DefaultEndpoint(serviceName, "localhost", []uint32{testutils.ParsePort(t, server.Address)})},
+		SkipValidation: true,
+	}
+	if err := mgmtServer.Update(ctx, resources); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify that the watch for the cluster resource is not cancelled.
+	sCtx, sCancel = context.WithTimeout(ctx, defaultTestShortTimeout)
+	defer sCancel()
+	select {
+	case <-sCtx.Done():
+	case <-cdsResourceCanceledCh:
+		t.Fatal("Watch for cluster resource is cancelled when not expected to")
+	}
+
+	// Verify that a successful RPC can be made, using the previously received
+	// good configuration.
+	if _, err = client.EmptyCall(ctx, &testpb.Empty{}, grpc.WaitForReady(true)); err != nil {
+		t.Fatalf("EmptyCall() failed: %v", err)
+	}
+
+	// Verify that the resolver error is pushed to the child policy.
+	select {
+	case err := <-resolverErrCh:
+		if !strings.Contains(err.Error(), wantClusterNACKErr) {
+			t.Fatalf("Error pushed to child policy is %v, want %v", err, wantClusterNACKErr)
+		}
+	case <-ctx.Done():
+		t.Fatal("Timeout when waiting for resolver error to be pushed to the child policy")
+	}
+
+	// Remove the cluster resource from the management server, triggering a
+	// resource-not-found error.
+	resources = e2e.UpdateOptions{
+		NodeID:         nodeID,
+		SkipValidation: true,
+	}
+	if err := mgmtServer.Update(ctx, resources); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify that the watch for the cluster resource is not cancelled.
+	sCtx, sCancel = context.WithTimeout(ctx, defaultTestShortTimeout)
+	defer sCancel()
+	select {
+	case <-sCtx.Done():
+	case <-cdsResourceCanceledCh:
+		t.Fatal("Watch for cluster resource is cancelled when not expected to")
+	}
+
+	// Ensure that the ClientConn moves to TransientFailure.
+	for state := cc.GetState(); state != connectivity.TransientFailure; state = cc.GetState() {
+		if !cc.WaitForStateChange(ctx, state) {
+			t.Fatalf("Timed out waiting for state change. got %v; want %v", state, connectivity.TransientFailure)
+		}
+	}
+}
+
+// Tests the following scenarios for resolver errors:
+//   - when a resolver error is received without any previous good update from the
+//     management server, the cds LB policy is expected to put the channel in
+//     TRANSIENT_FAILURE.
+//   - when a resolver error is received (one that is not a resource-not-found
+//     error), with a previous good update from the management server, the cds LB
+//     policy is expected to push the error down the child policy, but is expected
+//     to continue to use the previously received good configuration.
+//   - when a resolver error is received (one that is a resource-not-found error),
+//     with a previous good update from the management server, the cds LB policy
+//     is expected to push the error down the child policy and put the channel in
+//     TRANSIENT_FAILURE. It is also expected to cancel the CDS watch.
+func (s) TestResolverError(t *testing.T) {
+	// Register a wrapped clusterresolver LB policy (child policy of the cds LB
+	// policy) for the duration of this test that makes the resolver error
+	// pushed to it available to the test.
+	clusterresolverBuilder := balancer.Get(clusterresolver.Name)
+	t.Logf("easwars: clusterresolverBuilder is %p, %T", &clusterresolverBuilder, clusterresolverBuilder)
+	internal.BalancerUnregister(clusterresolverBuilder.Name())
+	resolverErrCh := make(chan error, 1)
+	stub.Register(clusterresolver.Name, stub.BalancerFuncs{
+		Init: func(bd *stub.BalancerData) {
+			t.Logf("easwars: building child policy")
+			bd.Data = clusterresolverBuilder.Build(bd.ClientConn, bd.BuildOptions)
+			t.Logf("easwars: bal is %p, %T", bd.Data, bd.Data)
+		},
+		ParseConfig: func(lbCfg json.RawMessage) (serviceconfig.LoadBalancingConfig, error) {
+			return clusterresolverBuilder.(balancer.ConfigParser).ParseConfig(lbCfg)
+		},
+		UpdateClientConnState: func(bd *stub.BalancerData, ccs balancer.ClientConnState) error {
+			bal := bd.Data.(balancer.Balancer)
+			return bal.UpdateClientConnState(ccs)
+		},
+		ResolverError: func(bd *stub.BalancerData, err error) {
+			/*
+				select {
+				case resolverErrCh <- err:
+				default:
+				}
+			*/
+			t.Logf("easwars: in wrapped child policy ResolverError")
+			bal := bd.Data.(balancer.Balancer)
+			t.Logf("easwars: bal is %p", bal)
+			bal.ResolverError(err)
+			resolverErrCh <- err
+		},
+		Close: func(bd *stub.BalancerData) {
+			bal := bd.Data.(balancer.Balancer)
+			bal.Close()
+		},
+	})
+	t.Cleanup(func() { balancer.Register(clusterresolverBuilder) })
+
+	// Start an xDS management server that uses a couple of channels to
+	// notify the test about the following events:
+	// - a CDS requested with the expected resource name is requested
+	// - CDS resource is unrequested, i.e, a CDS request with no resource name
+	//   is received, which indicates that we are not longer interested in that
+	//   resource.
+	cdsResourceRequestedCh := make(chan struct{}, 1)
+	cdsResourceCanceledCh := make(chan struct{}, 1)
+	mgmtServer, nodeID, bootstrapContents, _, cleanup := e2e.SetupManagementServer(t, e2e.ManagementServerOptions{
+		OnStreamRequest: func(_ int64, req *v3discoverypb.DiscoveryRequest) error {
+			if req.GetTypeUrl() == version.V3ClusterURL {
+				switch len(req.GetResourceNames()) {
+				case 0:
+					select {
+					case cdsResourceCanceledCh <- struct{}{}:
+					default:
+					}
+				case 1:
+					if req.GetResourceNames()[0] == clusterName {
+						select {
+						case cdsResourceRequestedCh <- struct{}{}:
+						default:
+						}
+					}
+				default:
+					t.Errorf("Unexpected number of resources, %d, in a CDS request", len(req.GetResourceNames()))
+				}
+			}
+			return nil
+		},
+	})
+	t.Cleanup(cleanup)
+
+	// Create an xDS client for use by the cluster_resolver LB policy.
+	xdsC, xdsClose, err := xdsclient.NewWithBootstrapContentsForTesting(bootstrapContents)
+	if err != nil {
+		t.Fatalf("Failed to create xDS client: %v", err)
+	}
+	t.Cleanup(xdsClose)
+
+	// Create a manual resolver and push a service config specifying the use of
+	// the cds LB policy as the top-level LB policy, and a corresponding config
+	// with a single cluster.
+	r := manual.NewBuilderWithScheme("whatever")
+	jsonSC := fmt.Sprintf(`{
+			"loadBalancingConfig":[{
+				"cds_experimental":{
+					"cluster": "%s"
+				}
+			}]
+		}`, clusterName)
+	scpr := internal.ParseServiceConfig.(func(string) *serviceconfig.ParseResult)(jsonSC)
+	r.InitialState(xdsclient.SetClient(resolver.State{ServiceConfig: scpr}, xdsC))
+
+	// Create a ClientConn, and this should trigger the cds LB policy.
+	cc, err := grpc.Dial(r.Scheme()+":///test.service", grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithResolvers(r))
+	if err != nil {
+		t.Fatalf("Failed to dial local test server: %v", err)
+	}
+	t.Cleanup(func() { cc.Close() })
+
+	// Verify that the specified cluster resource is requested.
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	select {
+	case <-ctx.Done():
+		t.Fatal("Timeout when waiting for cluster resource to be requested")
+	case <-cdsResourceRequestedCh:
+	}
+
+	// Push a resolver error that is not a resource-not-found error.
+	resolverErr := errors.New("resolver-error-not-a-resource-not-found-error")
+	r.ReportError(resolverErr)
+
+	// Ensure that the ClientConn moves to TransientFailure.
+	for state := cc.GetState(); state != connectivity.TransientFailure; state = cc.GetState() {
+		if !cc.WaitForStateChange(ctx, state) {
+			t.Fatalf("Timed out waiting for state change. got %v; want %v", state, connectivity.TransientFailure)
+		}
+	}
+
+	// Drain the resolver error channel.
+	select {
+	case <-resolverErrCh:
+	default:
+	}
+
+	// Ensure that the resolver error is propagated to the RPC caller.
+	client := testgrpc.NewTestServiceClient(cc)
+	_, err = client.EmptyCall(ctx, &testpb.Empty{})
+	if code := status.Code(err); code != codes.Unavailable {
+		t.Fatalf("EmptyCall() failed with code: %v, want %v", code, codes.Unavailable)
+	}
+	if err != nil && !strings.Contains(err.Error(), resolverErr.Error()) {
+		t.Fatalf("EmptyCall() failed with err: %v, want %v", err, resolverErr)
+	}
+
+	// Also verify that the watch for the cluster resource is not cancelled.
+	sCtx, sCancel := context.WithTimeout(ctx, defaultTestShortTimeout)
+	defer sCancel()
+	select {
+	case <-sCtx.Done():
+	case <-cdsResourceCanceledCh:
+		t.Fatal("Watch for cluster resource is cancelled when not expected to")
+	}
+
+	// Start a test service backend.
+	server := stubserver.StartTestService(t, nil)
+	defer server.Stop()
+
+	// Configure cluster and endpoints resources in the management server.
+	resources := e2e.UpdateOptions{
+		NodeID:         nodeID,
+		Clusters:       []*v3clusterpb.Cluster{e2e.DefaultCluster(clusterName, serviceName, e2e.SecurityLevelNone)},
+		Endpoints:      []*v3endpointpb.ClusterLoadAssignment{e2e.DefaultEndpoint(serviceName, "localhost", []uint32{testutils.ParsePort(t, server.Address)})},
+		SkipValidation: true,
+	}
+	if err := mgmtServer.Update(ctx, resources); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify that a successful RPC can be made.
+	if _, err = client.EmptyCall(ctx, &testpb.Empty{}, grpc.WaitForReady(true)); err != nil {
+		t.Fatalf("EmptyCall() failed: %v", err)
+	}
+
+	// Again push a resolver error that is not a resource-not-found error.
+	r.ReportError(resolverErr)
+
+	// And again verify that the watch for the cluster resource is not
+	// cancelled.
+	sCtx, sCancel = context.WithTimeout(ctx, defaultTestShortTimeout)
+	defer sCancel()
+	select {
+	case <-sCtx.Done():
+	case <-cdsResourceCanceledCh:
+		t.Fatal("Watch for cluster resource is cancelled when not expected to")
+	}
+
+	// Verify that a successful RPC can be made, using the previously received
+	// good configuration.
+	if _, err = client.EmptyCall(ctx, &testpb.Empty{}, grpc.WaitForReady(true)); err != nil {
+		t.Fatalf("EmptyCall() failed: %v", err)
+	}
+
+	// Verify that the resolver error is pushed to the child policy.
+	select {
+	case err := <-resolverErrCh:
+		if err != resolverErr {
+			t.Fatalf("Error pushed to child policy is %v, want %v", err, resolverErr)
+		}
+	case <-ctx.Done():
+		t.Fatal("Timeout when waiting for resolver error to be pushed to the child policy")
+	}
+
+	// Push a resource-not-found-error this time around.
+	resolverErr = xdsresource.NewErrorf(xdsresource.ErrorTypeResourceNotFound, "xds resource not found error")
+	r.ReportError(resolverErr)
+
+	// Wait for the CDS resource to be not requested anymore.
+	select {
+	case <-ctx.Done():
+		t.Fatal("Timeout when waiting for CDS resource to not requested")
+	case <-cdsResourceCanceledCh:
+	}
+
+	// Verify that the resolver error is pushed to the child policy.
+	select {
+	case err := <-resolverErrCh:
+		if err != resolverErr {
+			t.Fatalf("Error pushed to child policy is %v, want %v", err, resolverErr)
+		}
+	case <-ctx.Done():
+		t.Fatal("Timeout when waiting for resolver error to be pushed to the child policy")
+	}
+
+	// Ensure that the ClientConn moves to TransientFailure.
+	for state := cc.GetState(); state != connectivity.TransientFailure; state = cc.GetState() {
+		if !cc.WaitForStateChange(ctx, state) {
+			t.Fatalf("Timed out waiting for state change. got %v; want %v", state, connectivity.TransientFailure)
+		}
+	}
+}
+
+// Tests that closing the cds LB policy results in the cluster resource watch
+// being cancelled and the child policy being closed.
+func (s) TestClose(t *testing.T) {
+	// Register a wrapped cds LB policy for the duration of this test that
+	// allows explicitly closing the LB policy.
+	cdsBuilder := balancer.Get(cdsName)
+	internal.BalancerUnregister(cdsBuilder.Name())
+	cdsBalancerCh := make(chan balancer.Balancer, 1)
+	stub.Register(cdsBuilder.Name(), stub.BalancerFuncs{
+		Init: func(bd *stub.BalancerData) {
+			bal := cdsBuilder.Build(bd.ClientConn, bd.BuildOptions)
+			bd.Data = bal
+			cdsBalancerCh <- bal
+		},
+		ParseConfig: func(lbCfg json.RawMessage) (serviceconfig.LoadBalancingConfig, error) {
+			return cdsBuilder.(balancer.ConfigParser).ParseConfig(lbCfg)
+		},
+		UpdateClientConnState: func(bd *stub.BalancerData, ccs balancer.ClientConnState) error {
+			bal := bd.Data.(balancer.Balancer)
+			return bal.UpdateClientConnState(ccs)
+		},
+		Close: func(bd *stub.BalancerData) {
+			bal := bd.Data.(balancer.Balancer)
+			bal.Close()
+		},
+	})
+	t.Cleanup(func() { balancer.Register(cdsBuilder) })
+
+	// Register a wrapped clusterresolver LB policy (child policy of the cds LB
+	// policy) for the duration of this test that closes a channel when closed.
+	clusterresolverBuilder := balancer.Get(clusterresolver.Name)
+	internal.BalancerUnregister(clusterresolverBuilder.Name())
+	childPolicyCloseCh := make(chan struct{})
+	stub.Register(clusterresolver.Name, stub.BalancerFuncs{
+		Init: func(bd *stub.BalancerData) {
+			bd.Data = clusterresolverBuilder.Build(bd.ClientConn, bd.BuildOptions)
+		},
+		ParseConfig: func(lbCfg json.RawMessage) (serviceconfig.LoadBalancingConfig, error) {
+			return clusterresolverBuilder.(balancer.ConfigParser).ParseConfig(lbCfg)
+		},
+		UpdateClientConnState: func(bd *stub.BalancerData, ccs balancer.ClientConnState) error {
+			bal := bd.Data.(balancer.Balancer)
+			return bal.UpdateClientConnState(ccs)
+		},
+		Close: func(bd *stub.BalancerData) {
+			bal := bd.Data.(balancer.Balancer)
+			bal.Close()
+			close(childPolicyCloseCh)
+		},
+	})
+	t.Cleanup(func() { balancer.Register(clusterresolverBuilder) })
+
+	// Start an xDS management server that uses a couple of channels to
+	// notify the test about the following events:
+	// - a CDS requested with the expected resource name is requested
+	// - CDS resource is unrequested, i.e, a CDS request with no resource name
+	//   is received, which indicates that we are not longer interested in that
+	//   resource.
+	cdsResourceRequestedCh := make(chan struct{}, 1)
+	cdsResourceCanceledCh := make(chan struct{}, 1)
+	mgmtServer, nodeID, bootstrapContents, _, cleanup := e2e.SetupManagementServer(t, e2e.ManagementServerOptions{
+		OnStreamRequest: func(_ int64, req *v3discoverypb.DiscoveryRequest) error {
+			if req.GetTypeUrl() == version.V3ClusterURL {
+				switch len(req.GetResourceNames()) {
+				case 0:
+					select {
+					case cdsResourceCanceledCh <- struct{}{}:
+					default:
+					}
+				case 1:
+					if req.GetResourceNames()[0] == clusterName {
+						select {
+						case cdsResourceRequestedCh <- struct{}{}:
+						default:
+						}
+					}
+				default:
+					t.Errorf("Unexpected number of resources, %d, in a CDS request", len(req.GetResourceNames()))
+				}
+			}
+			return nil
+		},
+	})
+	t.Cleanup(cleanup)
+
+	// Create an xDS client for use by the cluster_resolver LB policy.
+	xdsC, xdsClose, err := xdsclient.NewWithBootstrapContentsForTesting(bootstrapContents)
+	if err != nil {
+		t.Fatalf("Failed to create xDS client: %v", err)
+	}
+	t.Cleanup(xdsClose)
+
+	// Start a test service backend.
+	server := stubserver.StartTestService(t, nil)
+	defer server.Stop()
+
+	// Configure cluster and endpoints resources in the management server.
+	resources := e2e.UpdateOptions{
+		NodeID:         nodeID,
+		Clusters:       []*v3clusterpb.Cluster{e2e.DefaultCluster(clusterName, serviceName, e2e.SecurityLevelNone)},
+		Endpoints:      []*v3endpointpb.ClusterLoadAssignment{e2e.DefaultEndpoint(serviceName, "localhost", []uint32{testutils.ParsePort(t, server.Address)})},
+		SkipValidation: true,
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	if err := mgmtServer.Update(ctx, resources); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a manual resolver and push a service config specifying the use of
+	// the cds LB policy as the top-level LB policy, and a corresponding config
+	// with a single cluster.
+	r := manual.NewBuilderWithScheme("whatever")
+	jsonSC := fmt.Sprintf(`{
+			"loadBalancingConfig":[{
+				"cds_experimental":{
+					"cluster": "%s"
+				}
+			}]
+		}`, clusterName)
+	scpr := internal.ParseServiceConfig.(func(string) *serviceconfig.ParseResult)(jsonSC)
+	r.InitialState(xdsclient.SetClient(resolver.State{ServiceConfig: scpr}, xdsC))
+
+	// Create a ClientConn, and this should trigger the cds LB policy.
+	cc, err := grpc.Dial(r.Scheme()+":///test.service", grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithResolvers(r))
+	if err != nil {
+		t.Fatalf("Failed to dial local test server: %v", err)
+	}
+	t.Cleanup(func() { cc.Close() })
+
+	// Verify that a successful RPC can be made.
+	client := testgrpc.NewTestServiceClient(cc)
+	if _, err = client.EmptyCall(ctx, &testpb.Empty{}, grpc.WaitForReady(true)); err != nil {
+		t.Fatalf("EmptyCall() failed: %v", err)
+	}
+
+	// Retrieve the cds LB policy policy and close it.
+	var cdsBal balancer.Balancer
+	select {
+	case cdsBal = <-cdsBalancerCh:
+	case <-ctx.Done():
+		t.Fatal("Timeout when waiting for cds LB policy to be created")
+	}
+	cdsBal.Close()
+
+	// Wait for the CDS resource to be not requested anymore.
+	select {
+	case <-ctx.Done():
+		t.Fatal("Timeout when waiting for CDS resource to not requested")
+	case <-cdsResourceCanceledCh:
+	}
+	// Wait for the child policy to be closed.
+	select {
+	case <-ctx.Done():
+		t.Fatal("Timeout when waiting for the child policy to be closed")
+	case <-childPolicyCloseCh:
+	}
+}
+
+// Tests the calling ExitIdle on the cds LB policy results in the call being
+// propagated to the child policy.
+func (s) TestExitIdle(t *testing.T) {
+	// Register a wrapped cds LB policy for the duration of this test that
+	// allows explicitly calling ExitIdle on the LB policy.
+	cdsBuilder := balancer.Get(cdsName)
+	internal.BalancerUnregister(cdsBuilder.Name())
+	cdsBalancerCh := make(chan balancer.Balancer, 1)
+	stub.Register(cdsBuilder.Name(), stub.BalancerFuncs{
+		Init: func(bd *stub.BalancerData) {
+			bal := cdsBuilder.Build(bd.ClientConn, bd.BuildOptions)
+			bd.Data = bal
+			cdsBalancerCh <- bal
+		},
+		ParseConfig: func(lbCfg json.RawMessage) (serviceconfig.LoadBalancingConfig, error) {
+			return cdsBuilder.(balancer.ConfigParser).ParseConfig(lbCfg)
+		},
+		UpdateClientConnState: func(bd *stub.BalancerData, ccs balancer.ClientConnState) error {
+			bal := bd.Data.(balancer.Balancer)
+			return bal.UpdateClientConnState(ccs)
+		},
+		Close: func(bd *stub.BalancerData) {
+			bal := bd.Data.(balancer.Balancer)
+			bal.Close()
+		},
+		ExitIdle: func(bd *stub.BalancerData) {
+			bal := bd.Data.(balancer.Balancer)
+			bal.(balancer.ExitIdler).ExitIdle()
+		},
+	})
+	t.Cleanup(func() { balancer.Register(cdsBuilder) })
+
+	// Register a wrapped clusterresolver LB policy (child policy of the cds LB
+	// policy) for the duration of this test that notfies the test when ExitIdle
+	// is being invoked.
+	clusterresolverBuilder := balancer.Get(clusterresolver.Name)
+	internal.BalancerUnregister(clusterresolverBuilder.Name())
+	exitIdleCh := make(chan struct{})
+	stub.Register(clusterresolver.Name, stub.BalancerFuncs{
+		Init: func(bd *stub.BalancerData) {
+			bd.Data = clusterresolverBuilder.Build(bd.ClientConn, bd.BuildOptions)
+		},
+		ParseConfig: func(lbCfg json.RawMessage) (serviceconfig.LoadBalancingConfig, error) {
+			return clusterresolverBuilder.(balancer.ConfigParser).ParseConfig(lbCfg)
+		},
+		UpdateClientConnState: func(bd *stub.BalancerData, ccs balancer.ClientConnState) error {
+			bal := bd.Data.(balancer.Balancer)
+			return bal.UpdateClientConnState(ccs)
+		},
+		Close: func(bd *stub.BalancerData) {
+			bal := bd.Data.(balancer.Balancer)
+			bal.Close()
+		},
+		ExitIdle: func(bd *stub.BalancerData) {
+			bal := bd.Data.(balancer.Balancer)
+			bal.(balancer.ExitIdler).ExitIdle()
+			close(exitIdleCh)
+		},
+	})
+	t.Cleanup(func() { balancer.Register(clusterresolverBuilder) })
+
+	mgmtServer, nodeID, bootstrapContents, _, cleanup := e2e.SetupManagementServer(t, e2e.ManagementServerOptions{})
+	t.Cleanup(cleanup)
+
+	// Create an xDS client for use by the cluster_resolver LB policy.
+	xdsC, xdsClose, err := xdsclient.NewWithBootstrapContentsForTesting(bootstrapContents)
+	if err != nil {
+		t.Fatalf("Failed to create xDS client: %v", err)
+	}
+	t.Cleanup(xdsClose)
+
+	// Start a test service backend.
+	server := stubserver.StartTestService(t, nil)
+	defer server.Stop()
+
+	// Configure cluster and endpoints resources in the management server.
+	resources := e2e.UpdateOptions{
+		NodeID:         nodeID,
+		Clusters:       []*v3clusterpb.Cluster{e2e.DefaultCluster(clusterName, serviceName, e2e.SecurityLevelNone)},
+		Endpoints:      []*v3endpointpb.ClusterLoadAssignment{e2e.DefaultEndpoint(serviceName, "localhost", []uint32{testutils.ParsePort(t, server.Address)})},
+		SkipValidation: true,
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	if err := mgmtServer.Update(ctx, resources); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a manual resolver and push a service config specifying the use of
+	// the cds LB policy as the top-level LB policy, and a corresponding config
+	// with a single cluster.
+	r := manual.NewBuilderWithScheme("whatever")
+	jsonSC := fmt.Sprintf(`{
+			"loadBalancingConfig":[{
+				"cds_experimental":{
+					"cluster": "%s"
+				}
+			}]
+		}`, clusterName)
+	scpr := internal.ParseServiceConfig.(func(string) *serviceconfig.ParseResult)(jsonSC)
+	r.InitialState(xdsclient.SetClient(resolver.State{ServiceConfig: scpr}, xdsC))
+
+	// Create a ClientConn, and this should trigger the cds LB policy.
+	cc, err := grpc.Dial(r.Scheme()+":///test.service", grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithResolvers(r))
+	if err != nil {
+		t.Fatalf("Failed to dial local test server: %v", err)
+	}
+	t.Cleanup(func() { cc.Close() })
+
+	// Verify that a successful RPC can be made.
+	client := testgrpc.NewTestServiceClient(cc)
+	if _, err = client.EmptyCall(ctx, &testpb.Empty{}, grpc.WaitForReady(true)); err != nil {
+		t.Fatalf("EmptyCall() failed: %v", err)
+	}
+
+	// Retrieve the cds LB policy policy and call ExitIdle() on it.
+	var cdsBal balancer.Balancer
+	select {
+	case cdsBal = <-cdsBalancerCh:
+	case <-ctx.Done():
+		t.Fatal("Timeout when waiting for cds LB policy to be created")
+	}
+	cdsBal.(balancer.ExitIdler).ExitIdle()
+
+	// Wait for ExitIdle to be called on the child policy.
+	select {
+	case <-ctx.Done():
+		t.Fatal("Timeout when waiting for the child policy to be closed")
+	case <-exitIdleCh:
+	}
 }
 
 // TestParseConfig verifies the ParseConfig() method in the CDS balancer.
@@ -871,4 +1654,8 @@ func (s) TestParseConfig(t *testing.T) {
 			}
 		})
 	}
+}
+
+func newUint32(i uint32) *uint32 {
+	return &i
 }

--- a/xds/internal/balancer/cdsbalancer/cdsbalancer_test.go
+++ b/xds/internal/balancer/cdsbalancer/cdsbalancer_test.go
@@ -1249,7 +1249,7 @@ func (s) TestExitIdle(t *testing.T) {
 		t.Fatalf("EmptyCall() failed: %v", err)
 	}
 
-	// Retrieve the cds LB policy policy and call ExitIdle() on it.
+	// Retrieve the cds LB policy and call ExitIdle() on it.
 	var cdsBal balancer.Balancer
 	select {
 	case cdsBal = <-cdsBalancerCh:

--- a/xds/internal/xdsclient/tests/resource_update_test.go
+++ b/xds/internal/xdsclient/tests/resource_update_test.go
@@ -588,24 +588,11 @@ func (s) TestHandleClusterResponseFromManagementServer(t *testing.T) {
 		resourceName1 = "resource-name-1"
 		resourceName2 = "resource-name-2"
 	)
-	resource1 := &v3clusterpb.Cluster{
-		Name:                 resourceName1,
-		ClusterDiscoveryType: &v3clusterpb.Cluster_Type{Type: v3clusterpb.Cluster_EDS},
-		EdsClusterConfig: &v3clusterpb.Cluster_EdsClusterConfig{
-			EdsConfig: &v3corepb.ConfigSource{
-				ConfigSourceSpecifier: &v3corepb.ConfigSource_Ads{
-					Ads: &v3corepb.AggregatedConfigSource{},
-				},
-			},
-			ServiceName: "eds-service-name",
-		},
-		LbPolicy: v3clusterpb.Cluster_ROUND_ROBIN,
-		LrsServer: &v3corepb.ConfigSource{
-			ConfigSourceSpecifier: &v3corepb.ConfigSource_Self{
-				Self: &v3corepb.SelfConfigSource{},
-			},
-		},
-	}
+	resource1 := e2e.ClusterResourceWithOptions(e2e.ClusterOptions{
+		ClusterName: resourceName1,
+		ServiceName: "eds-service-name",
+		EnableLRS:   true,
+	})
 	resource2 := proto.Clone(resource1).(*v3clusterpb.Cluster)
 	resource2.Name = resourceName2
 

--- a/xds/internal/xdsclient/xdsresource/tests/unmarshal_cds_test.go
+++ b/xds/internal/xdsclient/xdsresource/tests/unmarshal_cds_test.go
@@ -31,6 +31,7 @@ import (
 	"google.golang.org/grpc/internal/grpctest"
 	iserviceconfig "google.golang.org/grpc/internal/serviceconfig"
 	"google.golang.org/grpc/internal/testutils"
+	"google.golang.org/grpc/internal/testutils/xds/e2e"
 	"google.golang.org/grpc/serviceconfig"
 	_ "google.golang.org/grpc/xds" // Register the xDS LB Registry Converters.
 	"google.golang.org/grpc/xds/internal/balancer/ringhash"
@@ -179,19 +180,8 @@ func (s) TestValidateCluster_Success(t *testing.T) {
 			},
 		},
 		{
-			name: "happy-case-no-service-name-no-lrs",
-			cluster: &v3clusterpb.Cluster{
-				Name:                 clusterName,
-				ClusterDiscoveryType: &v3clusterpb.Cluster_Type{Type: v3clusterpb.Cluster_EDS},
-				EdsClusterConfig: &v3clusterpb.Cluster_EdsClusterConfig{
-					EdsConfig: &v3corepb.ConfigSource{
-						ConfigSourceSpecifier: &v3corepb.ConfigSource_Ads{
-							Ads: &v3corepb.AggregatedConfigSource{},
-						},
-					},
-				},
-				LbPolicy: v3clusterpb.Cluster_ROUND_ROBIN,
-			},
+			name:       "happy-case-no-service-name-no-lrs",
+			cluster:    e2e.DefaultCluster(clusterName, "", e2e.SecurityLevelNone),
 			wantUpdate: emptyUpdate,
 			wantLBConfig: &iserviceconfig.BalancerConfig{
 				Name: wrrlocality.Name,
@@ -203,21 +193,12 @@ func (s) TestValidateCluster_Success(t *testing.T) {
 			},
 		},
 		{
-			name: "happy-case-no-lrs",
-			cluster: &v3clusterpb.Cluster{
-				Name:                 clusterName,
-				ClusterDiscoveryType: &v3clusterpb.Cluster_Type{Type: v3clusterpb.Cluster_EDS},
-				EdsClusterConfig: &v3clusterpb.Cluster_EdsClusterConfig{
-					EdsConfig: &v3corepb.ConfigSource{
-						ConfigSourceSpecifier: &v3corepb.ConfigSource_Ads{
-							Ads: &v3corepb.AggregatedConfigSource{},
-						},
-					},
-					ServiceName: serviceName,
-				},
-				LbPolicy: v3clusterpb.Cluster_ROUND_ROBIN,
+			name:    "happy-case-no-lrs",
+			cluster: e2e.DefaultCluster(clusterName, serviceName, e2e.SecurityLevelNone),
+			wantUpdate: xdsresource.ClusterUpdate{
+				ClusterName:    clusterName,
+				EDSServiceName: serviceName,
 			},
-			wantUpdate: xdsresource.ClusterUpdate{ClusterName: clusterName, EDSServiceName: serviceName, LRSServerConfig: xdsresource.ClusterLRSOff},
 			wantLBConfig: &iserviceconfig.BalancerConfig{
 				Name: wrrlocality.Name,
 				Config: &wrrlocality.LBConfig{
@@ -229,25 +210,16 @@ func (s) TestValidateCluster_Success(t *testing.T) {
 		},
 		{
 			name: "happiest-case",
-			cluster: &v3clusterpb.Cluster{
-				Name:                 clusterName,
-				ClusterDiscoveryType: &v3clusterpb.Cluster_Type{Type: v3clusterpb.Cluster_EDS},
-				EdsClusterConfig: &v3clusterpb.Cluster_EdsClusterConfig{
-					EdsConfig: &v3corepb.ConfigSource{
-						ConfigSourceSpecifier: &v3corepb.ConfigSource_Ads{
-							Ads: &v3corepb.AggregatedConfigSource{},
-						},
-					},
-					ServiceName: serviceName,
-				},
-				LbPolicy: v3clusterpb.Cluster_ROUND_ROBIN,
-				LrsServer: &v3corepb.ConfigSource{
-					ConfigSourceSpecifier: &v3corepb.ConfigSource_Self{
-						Self: &v3corepb.SelfConfigSource{},
-					},
-				},
+			cluster: e2e.ClusterResourceWithOptions(e2e.ClusterOptions{
+				ClusterName: clusterName,
+				ServiceName: serviceName,
+				EnableLRS:   true,
+			}),
+			wantUpdate: xdsresource.ClusterUpdate{
+				ClusterName:     clusterName,
+				EDSServiceName:  serviceName,
+				LRSServerConfig: xdsresource.ClusterLRSServerSelf,
 			},
-			wantUpdate: xdsresource.ClusterUpdate{ClusterName: clusterName, EDSServiceName: serviceName, LRSServerConfig: xdsresource.ClusterLRSServerSelf},
 			wantLBConfig: &iserviceconfig.BalancerConfig{
 				Name: wrrlocality.Name,
 				Config: &wrrlocality.LBConfig{
@@ -259,19 +231,13 @@ func (s) TestValidateCluster_Success(t *testing.T) {
 		},
 		{
 			name: "happiest-case-with-circuitbreakers",
-			cluster: &v3clusterpb.Cluster{
-				Name:                 clusterName,
-				ClusterDiscoveryType: &v3clusterpb.Cluster_Type{Type: v3clusterpb.Cluster_EDS},
-				EdsClusterConfig: &v3clusterpb.Cluster_EdsClusterConfig{
-					EdsConfig: &v3corepb.ConfigSource{
-						ConfigSourceSpecifier: &v3corepb.ConfigSource_Ads{
-							Ads: &v3corepb.AggregatedConfigSource{},
-						},
-					},
+			cluster: func() *v3clusterpb.Cluster {
+				c := e2e.ClusterResourceWithOptions(e2e.ClusterOptions{
+					ClusterName: clusterName,
 					ServiceName: serviceName,
-				},
-				LbPolicy: v3clusterpb.Cluster_ROUND_ROBIN,
-				CircuitBreakers: &v3clusterpb.CircuitBreakers{
+					EnableLRS:   true,
+				})
+				c.CircuitBreakers = &v3clusterpb.CircuitBreakers{
 					Thresholds: []*v3clusterpb.CircuitBreakers_Thresholds{
 						{
 							Priority:    v3corepb.RoutingPriority_DEFAULT,
@@ -282,14 +248,15 @@ func (s) TestValidateCluster_Success(t *testing.T) {
 							MaxRequests: nil,
 						},
 					},
-				},
-				LrsServer: &v3corepb.ConfigSource{
-					ConfigSourceSpecifier: &v3corepb.ConfigSource_Self{
-						Self: &v3corepb.SelfConfigSource{},
-					},
-				},
+				}
+				return c
+			}(),
+			wantUpdate: xdsresource.ClusterUpdate{
+				ClusterName:     clusterName,
+				EDSServiceName:  serviceName,
+				LRSServerConfig: xdsresource.ClusterLRSServerSelf,
+				MaxRequests:     func() *uint32 { i := uint32(512); return &i }(),
 			},
-			wantUpdate: xdsresource.ClusterUpdate{ClusterName: clusterName, EDSServiceName: serviceName, LRSServerConfig: xdsresource.ClusterLRSServerSelf, MaxRequests: func() *uint32 { i := uint32(512); return &i }()},
 			wantLBConfig: &iserviceconfig.BalancerConfig{
 				Name: wrrlocality.Name,
 				Config: &wrrlocality.LBConfig{
@@ -301,26 +268,14 @@ func (s) TestValidateCluster_Success(t *testing.T) {
 		},
 		{
 			name: "happiest-case-with-ring-hash-lb-policy-with-default-config",
-			cluster: &v3clusterpb.Cluster{
-				Name:                 clusterName,
-				ClusterDiscoveryType: &v3clusterpb.Cluster_Type{Type: v3clusterpb.Cluster_EDS},
-				EdsClusterConfig: &v3clusterpb.Cluster_EdsClusterConfig{
-					EdsConfig: &v3corepb.ConfigSource{
-						ConfigSourceSpecifier: &v3corepb.ConfigSource_Ads{
-							Ads: &v3corepb.AggregatedConfigSource{},
-						},
-					},
-					ServiceName: serviceName,
-				},
-				LbPolicy: v3clusterpb.Cluster_RING_HASH,
-				LrsServer: &v3corepb.ConfigSource{
-					ConfigSourceSpecifier: &v3corepb.ConfigSource_Self{
-						Self: &v3corepb.SelfConfigSource{},
-					},
-				},
-			},
+			cluster: func() *v3clusterpb.Cluster {
+				c := e2e.DefaultCluster(clusterName, serviceName, e2e.SecurityLevelNone)
+				c.LbPolicy = v3clusterpb.Cluster_RING_HASH
+				return c
+			}(),
 			wantUpdate: xdsresource.ClusterUpdate{
-				ClusterName: clusterName, EDSServiceName: serviceName, LRSServerConfig: xdsresource.ClusterLRSServerSelf,
+				ClusterName:    clusterName,
+				EDSServiceName: serviceName,
 			},
 			wantLBConfig: &iserviceconfig.BalancerConfig{
 				Name: "ring_hash_experimental",
@@ -332,32 +287,20 @@ func (s) TestValidateCluster_Success(t *testing.T) {
 		},
 		{
 			name: "happiest-case-with-ring-hash-lb-policy-with-none-default-config",
-			cluster: &v3clusterpb.Cluster{
-				Name:                 clusterName,
-				ClusterDiscoveryType: &v3clusterpb.Cluster_Type{Type: v3clusterpb.Cluster_EDS},
-				EdsClusterConfig: &v3clusterpb.Cluster_EdsClusterConfig{
-					EdsConfig: &v3corepb.ConfigSource{
-						ConfigSourceSpecifier: &v3corepb.ConfigSource_Ads{
-							Ads: &v3corepb.AggregatedConfigSource{},
-						},
-					},
-					ServiceName: serviceName,
-				},
-				LbPolicy: v3clusterpb.Cluster_RING_HASH,
-				LbConfig: &v3clusterpb.Cluster_RingHashLbConfig_{
+			cluster: func() *v3clusterpb.Cluster {
+				c := e2e.DefaultCluster(clusterName, serviceName, e2e.SecurityLevelNone)
+				c.LbPolicy = v3clusterpb.Cluster_RING_HASH
+				c.LbConfig = &v3clusterpb.Cluster_RingHashLbConfig_{
 					RingHashLbConfig: &v3clusterpb.Cluster_RingHashLbConfig{
 						MinimumRingSize: wrapperspb.UInt64(10),
 						MaximumRingSize: wrapperspb.UInt64(100),
 					},
-				},
-				LrsServer: &v3corepb.ConfigSource{
-					ConfigSourceSpecifier: &v3corepb.ConfigSource_Self{
-						Self: &v3corepb.SelfConfigSource{},
-					},
-				},
-			},
+				}
+				return c
+			}(),
 			wantUpdate: xdsresource.ClusterUpdate{
-				ClusterName: clusterName, EDSServiceName: serviceName, LRSServerConfig: xdsresource.ClusterLRSServerSelf,
+				ClusterName:    clusterName,
+				EDSServiceName: serviceName,
 			},
 			wantLBConfig: &iserviceconfig.BalancerConfig{
 				Name: "ring_hash_experimental",
@@ -395,7 +338,8 @@ func (s) TestValidateCluster_Success(t *testing.T) {
 				},
 			},
 			wantUpdate: xdsresource.ClusterUpdate{
-				ClusterName: clusterName, EDSServiceName: serviceName,
+				ClusterName:    clusterName,
+				EDSServiceName: serviceName,
 			},
 			wantLBConfig: &iserviceconfig.BalancerConfig{
 				Name: "ring_hash_experimental",
@@ -429,7 +373,8 @@ func (s) TestValidateCluster_Success(t *testing.T) {
 				},
 			},
 			wantUpdate: xdsresource.ClusterUpdate{
-				ClusterName: clusterName, EDSServiceName: serviceName,
+				ClusterName:    clusterName,
+				EDSServiceName: serviceName,
 			},
 			wantLBConfig: &iserviceconfig.BalancerConfig{
 				Name: wrrlocality.Name,
@@ -467,7 +412,8 @@ func (s) TestValidateCluster_Success(t *testing.T) {
 				},
 			},
 			wantUpdate: xdsresource.ClusterUpdate{
-				ClusterName: clusterName, EDSServiceName: serviceName,
+				ClusterName:    clusterName,
+				EDSServiceName: serviceName,
 			},
 			wantLBConfig: &iserviceconfig.BalancerConfig{
 				Name: wrrlocality.Name,
@@ -514,7 +460,8 @@ func (s) TestValidateCluster_Success(t *testing.T) {
 				},
 			},
 			wantUpdate: xdsresource.ClusterUpdate{
-				ClusterName: clusterName, EDSServiceName: serviceName,
+				ClusterName:    clusterName,
+				EDSServiceName: serviceName,
 			},
 			wantLBConfig: &iserviceconfig.BalancerConfig{
 				Name: "ring_hash_experimental",
@@ -560,7 +507,8 @@ func (s) TestValidateCluster_Success(t *testing.T) {
 				},
 			},
 			wantUpdate: xdsresource.ClusterUpdate{
-				ClusterName: clusterName, EDSServiceName: serviceName,
+				ClusterName:    clusterName,
+				EDSServiceName: serviceName,
 			},
 			wantLBConfig: &iserviceconfig.BalancerConfig{
 				Name: "ring_hash_experimental",


### PR DESCRIPTION
This PR is the first in a set of test cleanups for the tests in the cds balancer. This is a pre-requisite for switching the cds balancer to use the generic xdsClient watch API.

Summary of changes:
- Cleanup of tests in `cdsbalancer_test.go` to use a real management server and rely on behavior instead of internal implementation details
- Add support for LRS config in the `e2e` package
  - Switch some usages of handcrafting the `Cluster` resource to use the utilities provided by the `e2e` package
-  Add an `UpdateStateCallback` to the `manual` resolver

RELEASE NOTES: none