### PR TITLE
resolver: remove outdated Target examples

### DIFF
--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -260,15 +260,6 @@ type ClientConn interface {
 // target does not contain a scheme or if the parsed scheme is not registered
 // (i.e. no corresponding resolver available to resolve the endpoint), we will
 // apply the default scheme, and will attempt to reparse it.
-//
-// Examples:
-//
-//   - "dns://some_authority/foo.bar"
-//     Target{Scheme: "dns", Authority: "some_authority", Endpoint: "foo.bar"}
-//   - "foo.bar"
-//     Target{Scheme: resolver.GetDefaultScheme(), Endpoint: "foo.bar"}
-//   - "unknown_scheme://authority/endpoint"
-//     Target{Scheme: resolver.GetDefaultScheme(), Endpoint: "unknown_scheme://authority/endpoint"}
 type Target struct {
 	// URL contains the parsed dial target with an optional default scheme added
 	// to it if the original dial target contained no scheme or contained an


### PR DESCRIPTION
This PR aims to resolve https://github.com/grpc/grpc-go/issues/6496, in which an outdated Godoc was noticed. In the past the `resolver.Target` struct contained three different fields, but nowadays it's only `URL`, but the examples in the Godoc still referenced the old fields.

As the `Target` doesn't seem to be usually created directly by a user of grpc-go, but instead through `Dial` or `DialContext`, it seems reasonable to just remove the examples instead of replacing them with an example where a target string is manually parsed with `url.Parse`.

RELEASE NOTES: none