### PR TITLE
pick_first: de-experiment pick first

### DIFF
--- a/internal/envconfig/envconfig.go
+++ b/internal/envconfig/envconfig.go
@@ -37,9 +37,8 @@ var (
 	// checking which NACKs configs specifying ring sizes > 8*1024*1024 (~8M).
 	RingHashCap = uint64FromEnv("GRPC_RING_HASH_CAP", 4096, 1, 8*1024*1024)
 	// PickFirstLBConfig is set if we should support configuration of the
-	// pick_first LB policy, which can be enabled by setting the environment
-	// variable "GRPC_EXPERIMENTAL_PICKFIRST_LB_CONFIG" to "true".
-	PickFirstLBConfig = boolFromEnv("GRPC_EXPERIMENTAL_PICKFIRST_LB_CONFIG", false)
+	// pick_first LB policy.
+	PickFirstLBConfig = boolFromEnv("GRPC_EXPERIMENTAL_PICKFIRST_LB_CONFIG", true)
 	// ALTSMaxConcurrentHandshakes is the maximum number of concurrent ALTS
 	// handshakes that can be performed.
 	ALTSMaxConcurrentHandshakes = uint64FromEnv("GRPC_ALTS_MAX_CONCURRENT_HANDSHAKES", 100, 1, 100)

--- a/xds/internal/xdsclient/xdslbregistry/xdslbregistry_test.go
+++ b/xds/internal/xdsclient/xdslbregistry/xdslbregistry_test.go
@@ -183,7 +183,7 @@ func (s) TestConvertToServiceConfigSuccess(t *testing.T) {
 			rhDisabled: true,
 		},
 		{
-			name: "pick_first_disabled_pf_rr_use_first_supported",
+			name: "pick_first_enabled_pf_rr_use_first_supported",
 			policy: &v3clusterpb.LoadBalancingPolicy{
 				Policies: []*v3clusterpb.LoadBalancingPolicy_Policy{
 					{
@@ -200,7 +200,7 @@ func (s) TestConvertToServiceConfigSuccess(t *testing.T) {
 					},
 				},
 			},
-			wantConfig: `[{"round_robin": {}}]`,
+			wantConfig: `[{"pick_first": { "shuffleAddressList": true }}]`,
 			pfDisabled: true,
 		},
 		{

--- a/xds/internal/xdsclient/xdslbregistry/xdslbregistry_test.go
+++ b/xds/internal/xdsclient/xdslbregistry/xdslbregistry_test.go
@@ -222,7 +222,6 @@ func (s) TestConvertToServiceConfigSuccess(t *testing.T) {
 				},
 			},
 			wantConfig: `[{"pick_first": { "shuffleAddressList": true }}]`,
-			pfDisabled: false,
 		},
 		{
 			name: "custom_lb_type_v3_struct",


### PR DESCRIPTION
De-experiment pick first since we have both affinity and randomness E2E test running successfully.

@apolcyn @easwars 

RELEASE NOTES: none