### PR TITLE
grpctest: use an interface instead of reflection

### DIFF
--- a/internal/grpctest/grpctest.go
+++ b/internal/grpctest/grpctest.go
@@ -62,6 +62,11 @@ func (Tester) Teardown(t *testing.T) {
 	TLogger.EndTest(t)
 }
 
+type Interface interface {
+	Setup(*testing.T)
+	Teardown(*testing.T)
+}
+
 func getTestFunc(t *testing.T, xv reflect.Value, name string) func(*testing.T) {
 	if m := xv.MethodByName(name); m.IsValid() {
 		if f, ok := m.Interface().(func(*testing.T)); ok {
@@ -74,9 +79,8 @@ func getTestFunc(t *testing.T, xv reflect.Value, name string) func(*testing.T) {
 }
 
 // RunSubTests runs all "Test___" functions that are methods of x as subtests
-// of the current test.  If x contains methods "Setup(*testing.T)" or
-// "Teardown(*testing.T)", those are run before or after each of the test
-// functions, respectively.
+// of the current test.  Setup is run before the test function and Teardown is
+// run after.
 //
 // For example usage, see example_test.go.  Run it using:
 //
@@ -85,12 +89,9 @@ func getTestFunc(t *testing.T, xv reflect.Value, name string) func(*testing.T) {
 // To run a specific test/subtest:
 //
 //	$ go test -v -run 'TestExample/^Something$' .
-func RunSubTests(t *testing.T, x any) {
+func RunSubTests(t *testing.T, x Interface) {
 	xt := reflect.TypeOf(x)
 	xv := reflect.ValueOf(x)
-
-	setup := getTestFunc(t, xv, "Setup")
-	teardown := getTestFunc(t, xv, "Teardown")
 
 	for i := 0; i < xt.NumMethod(); i++ {
 		methodName := xt.Method(i).Name
@@ -104,8 +105,8 @@ func RunSubTests(t *testing.T, x any) {
 			//
 			// Note that a defer would run before t.Cleanup, so if a goroutine
 			// is closed by a test's t.Cleanup, a deferred leakcheck would fail.
-			t.Cleanup(func() { teardown(t) })
-			setup(t)
+			t.Cleanup(func() { x.Teardown(t) })
+			x.Setup(t)
 			tfunc(t)
 		})
 	}

--- a/internal/grpctest/grpctest.go
+++ b/internal/grpctest/grpctest.go
@@ -62,6 +62,7 @@ func (Tester) Teardown(t *testing.T) {
 	TLogger.EndTest(t)
 }
 
+// Interface defines Tester's methods for use in this package.
 type Interface interface {
 	Setup(*testing.T)
 	Teardown(*testing.T)

--- a/internal/grpctest/grpctest_test.go
+++ b/internal/grpctest/grpctest_test.go
@@ -44,20 +44,3 @@ func TestRunSubTests(t *testing.T) {
 		t.Fatalf("x = %v; want all fields true", x)
 	}
 }
-
-type tNoST struct {
-	test bool
-}
-
-func (t *tNoST) TestSubTest(*testing.T) {
-	t.test = true
-}
-
-func TestNoSetupOrTeardown(t *testing.T) {
-	// Ensures nothing panics or fails if Setup/Teardown are omitted.
-	x := &tNoST{}
-	RunSubTests(t, x)
-	if want := (&tNoST{test: true}); !reflect.DeepEqual(x, want) {
-		t.Fatalf("x = %v; want %v", x, want)
-	}
-}


### PR DESCRIPTION
I was originally going to try to see if I could use generics to set a `context.Context` field in the `Tester` embedded in the struct so that every test case could automatically get our default deadline (and we could even forbid `context.Background()` from being called from tests).  But, in practice we declare test methods without receivers, e.g.:

```go
func (s) TestFoo(t *testing.T)
```

So the only way to do that would require a change to:

```go
func (s s) TestFoo(t *testing.T) {
	// access s.Ctx here
}
```

At which point, we might just be better off doing:

```go
func (s) TestFoo(ctx context.Context, t *testing.T)
```

But regardless of any of that, I found a simple cleanup to use an interface instead of reflection to find the `Setup` and `Teardown` methods, which at one point (before we started overriding the logger) were optional.


RELEASE NOTES: n/a