### PR TITLE
idle: speed up test by 5x even while running 2x more iterations

### DIFF
--- a/idle_test.go
+++ b/idle_test.go
@@ -322,7 +322,7 @@ func (ri *racyIdlenessEnforcer) enterIdleMode() error {
 // mode.
 func (s) TestIdlenessManager_IdleTimeoutRacesWithOnCallBegin(t *testing.T) {
 	// Run multiple iterations to simulate different possibilities.
-	for i := 0; i < 10; i++ {
+	for i := 0; i < 20; i++ {
 		t.Run(fmt.Sprintf("iteration=%d", i), func(t *testing.T) {
 			var idlenessState racyIdlenessState
 			enforcer := &racyIdlenessEnforcer{state: &idlenessState}
@@ -337,7 +337,7 @@ func (s) TestIdlenessManager_IdleTimeoutRacesWithOnCallBegin(t *testing.T) {
 			go func() {
 				defer wg.Done()
 				m := mgr.(interface{ handleIdleTimeout() })
-				<-time.After(defaultTestIdleTimeout)
+				<-time.After(defaultTestIdleTimeout / 10)
 				m.handleIdleTimeout()
 			}()
 			for j := 0; j < 100; j++ {
@@ -346,7 +346,7 @@ func (s) TestIdlenessManager_IdleTimeoutRacesWithOnCallBegin(t *testing.T) {
 					defer wg.Done()
 					// Wait for the configured idle timeout and simulate an RPC to
 					// race with the idle timeout timer callback.
-					<-time.After(defaultTestIdleTimeout)
+					<-time.After(defaultTestIdleTimeout / 10)
 					if err := mgr.onCallBegin(); err != nil {
 						t.Errorf("onCallBegin() failed: %v", err)
 					}


### PR DESCRIPTION
Before this change, test iterations would last 500ms (* 10 iterations = 5s total).  With this change, test iterations happen in 50ms (*20 iterations = 1s).

Not super significant in and of itself, but it was a very simple change that cuts several seconds off per run (and we run each test 6 times in GA).

RELEASE NOTES: none