### PR TITLE
client: fix ClientStream.Header() behavior

### DIFF
--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -1505,6 +1505,9 @@ func (t *http2Client) operateHeaders(frame *http2.MetaHeadersFrame) {
 		return
 	}
 
+	// For headers, set them in s.header and close headerChan.  For trailers or
+	// trailers-only, closeStream will set the trailers and close headerChan as
+	// needed.
 	if !endStream {
 		// If headerChan hasn't been closed yet (expected, given we checked it
 		// above, but something else could have potentially closed the whole

--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -1505,11 +1505,7 @@ func (t *http2Client) operateHeaders(frame *http2.MetaHeadersFrame) {
 		return
 	}
 
-	isHeader := false
-
 	if !endStream {
-		// HEADERS frame block carries a Response-Headers.
-		isHeader = true
 		// If headerChan hasn't been closed yet (expected, given we checked it
 		// above, but something else could have potentially closed the whole
 		// stream).
@@ -1527,7 +1523,7 @@ func (t *http2Client) operateHeaders(frame *http2.MetaHeadersFrame) {
 	}
 
 	for _, sh := range t.statsHandlers {
-		if isHeader {
+		if !endStream {
 			inHeader := &stats.InHeader{
 				Client:      true,
 				WireLength:  int(frame.Header().Length),

--- a/internal/transport/transport.go
+++ b/internal/transport/transport.go
@@ -43,10 +43,6 @@ import (
 	"google.golang.org/grpc/tap"
 )
 
-// ErrNoHeaders is used as a signal that a trailers only response was received,
-// and is not a real error.
-var ErrNoHeaders = errors.New("stream has no headers")
-
 const logLevel = 2
 
 type bufferPool struct {
@@ -390,12 +386,8 @@ func (s *Stream) Header() (metadata.MD, error) {
 	}
 	s.waitOnHeader()
 
-	if !s.headerValid {
+	if !s.headerValid || s.noHeaders {
 		return nil, s.status.Err()
-	}
-
-	if s.noHeaders {
-		return nil, ErrNoHeaders
 	}
 
 	return s.header.Copy(), nil

--- a/rpc_util.go
+++ b/rpc_util.go
@@ -867,15 +867,18 @@ func Errorf(c codes.Code, format string, a ...any) error {
 	return status.Errorf(c, format, a...)
 }
 
+var errContextCanceled = status.Error(codes.Canceled, context.Canceled.Error())
+var errContextDeadline = status.Error(codes.DeadlineExceeded, context.DeadlineExceeded.Error())
+
 // toRPCErr converts an error into an error from the status package.
 func toRPCErr(err error) error {
 	switch err {
 	case nil, io.EOF:
 		return err
 	case context.DeadlineExceeded:
-		return status.Error(codes.DeadlineExceeded, err.Error())
+		return errContextDeadline
 	case context.Canceled:
-		return status.Error(codes.Canceled, err.Error())
+		return errContextCanceled
 	case io.ErrUnexpectedEOF:
 		return status.Error(codes.Internal, err.Error())
 	}

--- a/stream.go
+++ b/stream.go
@@ -987,13 +987,11 @@ func (cs *clientStream) finish(err error) {
 	}
 
 	cs.mu.Unlock()
-	// For binary logging. only log cancel in finish (could be caused by RPC ctx
-	// canceled or ClientConn closed).
-	//
-	// Only one of cancel or trailer needs to be logged. In the cases where
-	// users don't call RecvMsg, users must have already canceled the RPC.
+	// Only one of cancel or trailer needs to be logged.
 	if len(cs.binlogs) != 0 {
-		if status.Code(err) == codes.Canceled {
+		if err == errContextCanceled ||
+			err == errContextDeadline ||
+			err == ErrClientConnClosing {
 			c := &binarylog.Cancel{
 				OnClientSide: true,
 			}

--- a/stream.go
+++ b/stream.go
@@ -789,23 +789,23 @@ func (cs *clientStream) withRetry(op func(a *csAttempt) error, onSuccess func())
 
 func (cs *clientStream) Header() (metadata.MD, error) {
 	var m metadata.MD
-	noHeader := false
 	err := cs.withRetry(func(a *csAttempt) error {
 		var err error
 		m, err = a.s.Header()
-		if err == transport.ErrNoHeaders {
-			noHeader = true
-			return nil
-		}
 		return toRPCErr(err)
 	}, cs.commitAttemptLocked)
+
+	if m == nil && err == nil {
+		// The stream ended with success.  Finish the clientStream.
+		err = io.EOF
+	}
 
 	if err != nil {
 		cs.finish(err)
 		return nil, err
 	}
 
-	if len(cs.binlogs) != 0 && !cs.serverHeaderBinlogged && !noHeader {
+	if len(cs.binlogs) != 0 && !cs.serverHeaderBinlogged && m != nil {
 		// Only log if binary log is on and header has not been logged, and
 		// there is actually headers to log.
 		logEntry := &binarylog.ServerHeader{
@@ -821,6 +821,7 @@ func (cs *clientStream) Header() (metadata.MD, error) {
 			binlog.Log(cs.ctx, logEntry)
 		}
 	}
+
 	return m, nil
 }
 
@@ -929,24 +930,6 @@ func (cs *clientStream) RecvMsg(m any) error {
 	if err != nil || !cs.desc.ServerStreams {
 		// err != nil or non-server-streaming indicates end of stream.
 		cs.finish(err)
-
-		if len(cs.binlogs) != 0 {
-			// finish will not log Trailer. Log Trailer here.
-			logEntry := &binarylog.ServerTrailer{
-				OnClientSide: true,
-				Trailer:      cs.Trailer(),
-				Err:          err,
-			}
-			if logEntry.Err == io.EOF {
-				logEntry.Err = nil
-			}
-			if peer, ok := peer.FromContext(cs.Context()); ok {
-				logEntry.PeerAddr = peer.Addr
-			}
-			for _, binlog := range cs.binlogs {
-				binlog.Log(cs.ctx, logEntry)
-			}
-		}
 	}
 	return err
 }
@@ -1002,18 +985,33 @@ func (cs *clientStream) finish(err error) {
 			}
 		}
 	}
+
 	cs.mu.Unlock()
 	// For binary logging. only log cancel in finish (could be caused by RPC ctx
-	// canceled or ClientConn closed). Trailer will be logged in RecvMsg.
+	// canceled or ClientConn closed).
 	//
 	// Only one of cancel or trailer needs to be logged. In the cases where
 	// users don't call RecvMsg, users must have already canceled the RPC.
-	if len(cs.binlogs) != 0 && status.Code(err) == codes.Canceled {
-		c := &binarylog.Cancel{
-			OnClientSide: true,
-		}
-		for _, binlog := range cs.binlogs {
-			binlog.Log(cs.ctx, c)
+	if len(cs.binlogs) != 0 {
+		if status.Code(err) == codes.Canceled {
+			c := &binarylog.Cancel{
+				OnClientSide: true,
+			}
+			for _, binlog := range cs.binlogs {
+				binlog.Log(cs.ctx, c)
+			}
+		} else {
+			logEntry := &binarylog.ServerTrailer{
+				OnClientSide: true,
+				Trailer:      cs.Trailer(),
+				Err:          err,
+			}
+			if peer, ok := peer.FromContext(cs.Context()); ok {
+				logEntry.PeerAddr = peer.Addr
+			}
+			for _, binlog := range cs.binlogs {
+				binlog.Log(cs.ctx, logEntry)
+			}
 		}
 	}
 	if err == nil {

--- a/stream.go
+++ b/stream.go
@@ -989,16 +989,15 @@ func (cs *clientStream) finish(err error) {
 	cs.mu.Unlock()
 	// Only one of cancel or trailer needs to be logged.
 	if len(cs.binlogs) != 0 {
-		if err == errContextCanceled ||
-			err == errContextDeadline ||
-			err == ErrClientConnClosing {
+		switch err {
+		case errContextCanceled, errContextDeadline, ErrClientConnClosing:
 			c := &binarylog.Cancel{
 				OnClientSide: true,
 			}
 			for _, binlog := range cs.binlogs {
 				binlog.Log(cs.ctx, c)
 			}
-		} else {
+		default:
 			logEntry := &binarylog.ServerTrailer{
 				OnClientSide: true,
 				Trailer:      cs.Trailer(),

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -6339,12 +6339,11 @@ func (s) TestGlobalBinaryLoggingOptions(t *testing.T) {
 			return &testpb.SimpleResponse{}, nil
 		},
 		FullDuplexCallF: func(stream testgrpc.TestService_FullDuplexCallServer) error {
-			for {
-				_, err := stream.Recv()
-				if err == io.EOF {
-					return nil
-				}
+			_, err := stream.Recv()
+			if err == io.EOF {
+				return nil
 			}
+			return status.Errorf(codes.Unknown, "expected client to CloseSend")
 		},
 	}
 

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -6343,7 +6343,7 @@ func (s) TestGlobalBinaryLoggingOptions(t *testing.T) {
 			if err == io.EOF {
 				return nil
 			}
-			return status.Errorf(codes.Unknown, "expected client to CloseSend")
+			return status.Errorf(codes.Unknown, "expected client to call CloseSend")
 		},
 	}
 


### PR DESCRIPTION
This fixes a regression introduced in #5763.  Fixes #6524

This change causes us to reliably report the stream status from `ClientStream.Header()`, including `io.EOF` in case the stream ended successfully with a trailers-only response.  To do this required moving the binary logging of trailers into `clientStream.finish()`.

By doing this, retry is also fixed in cases where an error is encountered on the stream before calling `Header()`.  Previously, if `Header()` was called first, we would report `ErrNoHeaders` from the transport which would be converted into a non-error by `clientStream.Header()`, which would then commit the RPC and prevent retries.  A test case was added to cover this scenario.

RELEASE NOTES:
* client: fix a bug that prevented `ClientStream.Header` from returning an error for trailers-only RPC responses, and as a side-effect, prevented retry of the RPC.