### PR TITLE
idle: move idleness manager to separate package and ~13s of tests into it

### DIFF
--- a/balancer/rls/balancer_test.go
+++ b/balancer/rls/balancer_test.go
@@ -1030,11 +1030,7 @@ func (s) TestUpdateStatePauses(t *testing.T) {
 	//    the test would fail. Waiting for the channel to become READY here
 	//    ensures that the test does not flake because of this rare sequence of
 	//    events.
-	for s := cc.GetState(); s != connectivity.Ready; s = cc.GetState() {
-		if !cc.WaitForStateChange(ctx, s) {
-			t.Fatal("Timeout when waiting for connectivity state to reach READY")
-		}
-	}
+	testutils.AwaitState(ctx, t, cc, connectivity.Ready)
 
 	// Cache the state changes seen up to this point.
 	states0 := ccWrapper.getStates()

--- a/call.go
+++ b/call.go
@@ -27,10 +27,10 @@ import (
 //
 // All errors returned by Invoke are compatible with the status package.
 func (cc *ClientConn) Invoke(ctx context.Context, method string, args, reply any, opts ...CallOption) error {
-	if err := cc.idlenessMgr.onCallBegin(); err != nil {
+	if err := cc.idlenessMgr.OnCallBegin(); err != nil {
 		return err
 	}
-	defer cc.idlenessMgr.onCallEnd()
+	defer cc.idlenessMgr.OnCallEnd()
 
 	// allow interceptor to see all applicable call options, which means those
 	// configured as defaults from dial option as well as per-call options

--- a/channelz/service/service_sktopt_test.go
+++ b/channelz/service/service_sktopt_test.go
@@ -128,8 +128,6 @@ func protoToSocketOption(skopts []*channelzpb.SocketOption) *channelz.SocketOpti
 }
 
 func (s) TestGetSocketOptions(t *testing.T) {
-	channelz.NewChannelzStorageForTesting()
-
 	ss := []*dummySocket{
 		{
 			socketOptions: &channelz.SocketOptionData{

--- a/channelz/service/service_sktopt_test.go
+++ b/channelz/service/service_sktopt_test.go
@@ -128,8 +128,8 @@ func protoToSocketOption(skopts []*channelzpb.SocketOption) *channelz.SocketOpti
 }
 
 func (s) TestGetSocketOptions(t *testing.T) {
-	czCleanup := channelz.NewChannelzStorageForTesting()
-	defer cleanupWrapper(czCleanup, t)
+	channelz.NewChannelzStorageForTesting()
+
 	ss := []*dummySocket{
 		{
 			socketOptions: &channelz.SocketOptionData{

--- a/channelz/service/service_test.go
+++ b/channelz/service/service_test.go
@@ -51,12 +51,6 @@ func Test(t *testing.T) {
 	grpctest.RunSubTests(t, s{})
 }
 
-func cleanupWrapper(cleanup func() error, t *testing.T) {
-	if err := cleanup(); err != nil {
-		t.Error(err)
-	}
-}
-
 type protoToSocketOptFunc func([]*channelzpb.SocketOption) *channelz.SocketOptionData
 
 // protoToSocketOpt is used in function socketProtoToStruct to extract socket option
@@ -311,8 +305,8 @@ func (s) TestGetTopChannels(t *testing.T) {
 		},
 		{},
 	}
-	czCleanup := channelz.NewChannelzStorageForTesting()
-	defer cleanupWrapper(czCleanup, t)
+	channelz.NewChannelzStorageForTesting()
+
 	for _, c := range tcs {
 		id := channelz.RegisterChannel(c, nil, "")
 		defer channelz.RemoveEntry(id)
@@ -364,8 +358,8 @@ func (s) TestGetServers(t *testing.T) {
 			lastCallStartedTimestamp: time.Now().UTC(),
 		},
 	}
-	czCleanup := channelz.NewChannelzStorageForTesting()
-	defer cleanupWrapper(czCleanup, t)
+	channelz.NewChannelzStorageForTesting()
+
 	for _, s := range ss {
 		id := channelz.RegisterServer(s, "")
 		defer channelz.RemoveEntry(id)
@@ -397,8 +391,8 @@ func (s) TestGetServers(t *testing.T) {
 }
 
 func (s) TestGetServerSockets(t *testing.T) {
-	czCleanup := channelz.NewChannelzStorageForTesting()
-	defer cleanupWrapper(czCleanup, t)
+	channelz.NewChannelzStorageForTesting()
+
 	svrID := channelz.RegisterServer(&dummyServer{}, "")
 	defer channelz.RemoveEntry(svrID)
 	refNames := []string{"listen socket 1", "normal socket 1", "normal socket 2"}
@@ -438,8 +432,8 @@ func (s) TestGetServerSockets(t *testing.T) {
 // This test makes a GetServerSockets with a non-zero start ID, and expect only
 // sockets with ID >= the given start ID.
 func (s) TestGetServerSocketsNonZeroStartID(t *testing.T) {
-	czCleanup := channelz.NewChannelzStorageForTesting()
-	defer cleanupWrapper(czCleanup, t)
+	channelz.NewChannelzStorageForTesting()
+
 	svrID := channelz.RegisterServer(&dummyServer{}, "")
 	defer channelz.RemoveEntry(svrID)
 	refNames := []string{"listen socket 1", "normal socket 1", "normal socket 2"}
@@ -470,8 +464,7 @@ func (s) TestGetServerSocketsNonZeroStartID(t *testing.T) {
 }
 
 func (s) TestGetChannel(t *testing.T) {
-	czCleanup := channelz.NewChannelzStorageForTesting()
-	defer cleanupWrapper(czCleanup, t)
+	channelz.NewChannelzStorageForTesting()
 
 	refNames := []string{"top channel 1", "nested channel 1", "sub channel 2", "nested channel 3"}
 	ids := make([]*channelz.Identifier, 4)
@@ -584,8 +577,8 @@ func (s) TestGetSubChannel(t *testing.T) {
 		subchanConnectivityChange = fmt.Sprintf("Subchannel Connectivity change to %v", connectivity.Ready)
 		subChanPickNewAddress     = fmt.Sprintf("Subchannel picks a new address %q to connect", "0.0.0.0")
 	)
-	czCleanup := channelz.NewChannelzStorageForTesting()
-	defer cleanupWrapper(czCleanup, t)
+	channelz.NewChannelzStorageForTesting()
+
 	refNames := []string{"top channel 1", "sub channel 1", "socket 1", "socket 2"}
 	ids := make([]*channelz.Identifier, 4)
 	ids[0] = channelz.RegisterChannel(&dummyChannel{}, nil, refNames[0])
@@ -662,8 +655,8 @@ func (s) TestGetSubChannel(t *testing.T) {
 }
 
 func (s) TestGetSocket(t *testing.T) {
-	czCleanup := channelz.NewChannelzStorageForTesting()
-	defer cleanupWrapper(czCleanup, t)
+	channelz.NewChannelzStorageForTesting()
+
 	ss := []*dummySocket{
 		{
 			streamsStarted:                   10,

--- a/channelz/service/service_test.go
+++ b/channelz/service/service_test.go
@@ -305,7 +305,6 @@ func (s) TestGetTopChannels(t *testing.T) {
 		},
 		{},
 	}
-	channelz.NewChannelzStorageForTesting()
 
 	for _, c := range tcs {
 		id := channelz.RegisterChannel(c, nil, "")
@@ -358,7 +357,6 @@ func (s) TestGetServers(t *testing.T) {
 			lastCallStartedTimestamp: time.Now().UTC(),
 		},
 	}
-	channelz.NewChannelzStorageForTesting()
 
 	for _, s := range ss {
 		id := channelz.RegisterServer(s, "")
@@ -391,8 +389,6 @@ func (s) TestGetServers(t *testing.T) {
 }
 
 func (s) TestGetServerSockets(t *testing.T) {
-	channelz.NewChannelzStorageForTesting()
-
 	svrID := channelz.RegisterServer(&dummyServer{}, "")
 	defer channelz.RemoveEntry(svrID)
 	refNames := []string{"listen socket 1", "normal socket 1", "normal socket 2"}
@@ -432,8 +428,6 @@ func (s) TestGetServerSockets(t *testing.T) {
 // This test makes a GetServerSockets with a non-zero start ID, and expect only
 // sockets with ID >= the given start ID.
 func (s) TestGetServerSocketsNonZeroStartID(t *testing.T) {
-	channelz.NewChannelzStorageForTesting()
-
 	svrID := channelz.RegisterServer(&dummyServer{}, "")
 	defer channelz.RemoveEntry(svrID)
 	refNames := []string{"listen socket 1", "normal socket 1", "normal socket 2"}
@@ -464,8 +458,6 @@ func (s) TestGetServerSocketsNonZeroStartID(t *testing.T) {
 }
 
 func (s) TestGetChannel(t *testing.T) {
-	channelz.NewChannelzStorageForTesting()
-
 	refNames := []string{"top channel 1", "nested channel 1", "sub channel 2", "nested channel 3"}
 	ids := make([]*channelz.Identifier, 4)
 	ids[0] = channelz.RegisterChannel(&dummyChannel{}, nil, refNames[0])
@@ -577,7 +569,6 @@ func (s) TestGetSubChannel(t *testing.T) {
 		subchanConnectivityChange = fmt.Sprintf("Subchannel Connectivity change to %v", connectivity.Ready)
 		subChanPickNewAddress     = fmt.Sprintf("Subchannel picks a new address %q to connect", "0.0.0.0")
 	)
-	channelz.NewChannelzStorageForTesting()
 
 	refNames := []string{"top channel 1", "sub channel 1", "socket 1", "socket 2"}
 	ids := make([]*channelz.Identifier, 4)
@@ -655,8 +646,6 @@ func (s) TestGetSubChannel(t *testing.T) {
 }
 
 func (s) TestGetSocket(t *testing.T) {
-	channelz.NewChannelzStorageForTesting()
-
 	ss := []*dummySocket{
 		{
 			streamsStarted:                   10,

--- a/clientconn.go
+++ b/clientconn.go
@@ -38,6 +38,7 @@ import (
 	"google.golang.org/grpc/internal/backoff"
 	"google.golang.org/grpc/internal/channelz"
 	"google.golang.org/grpc/internal/grpcsync"
+	"google.golang.org/grpc/internal/idle"
 	"google.golang.org/grpc/internal/pretty"
 	iresolver "google.golang.org/grpc/internal/resolver"
 	"google.golang.org/grpc/internal/transport"
@@ -266,7 +267,7 @@ func DialContext(ctx context.Context, target string, opts ...DialOption) (conn *
 	// Configure idleness support with configured idle timeout or default idle
 	// timeout duration. Idleness can be explicitly disabled by the user, by
 	// setting the dial option to 0.
-	cc.idlenessMgr = newIdlenessManager(cc, cc.dopts.idleTimeout)
+	cc.idlenessMgr = idle.NewIdlenessManager(idle.IdlenessManagerOptions{Enforcer: (*idler)(cc), Timeout: cc.dopts.idleTimeout, Logger: logger})
 
 	// Return early for non-blocking dials.
 	if !cc.dopts.block {
@@ -315,6 +316,16 @@ func (cc *ClientConn) addTraceEvent(msg string) {
 		}
 	}
 	channelz.AddTraceEvent(logger, cc.channelzID, 0, ted)
+}
+
+type idler ClientConn
+
+func (i *idler) EnterIdleMode() error {
+	return (*ClientConn)(i).enterIdleMode()
+}
+
+func (i *idler) ExitIdleMode() error {
+	return (*ClientConn)(i).exitIdleMode()
 }
 
 // exitIdleMode moves the channel out of idle mode by recreating the name
@@ -639,7 +650,7 @@ type ClientConn struct {
 	channelzID      *channelz.Identifier // Channelz identifier for the channel.
 	resolverBuilder resolver.Builder     // See parseTargetAndFindResolver().
 	balancerWrapper *ccBalancerWrapper   // Uses gracefulswitch.balancer underneath.
-	idlenessMgr     idlenessManager
+	idlenessMgr     idle.IdlenessManager
 
 	// The following provide their own synchronization, and therefore don't
 	// require cc.mu to be held to access them.
@@ -1268,7 +1279,7 @@ func (cc *ClientConn) Close() error {
 		rWrapper.close()
 	}
 	if idlenessMgr != nil {
-		idlenessMgr.close()
+		idlenessMgr.Close()
 	}
 
 	for ac := range conns {

--- a/clientconn.go
+++ b/clientconn.go
@@ -267,7 +267,7 @@ func DialContext(ctx context.Context, target string, opts ...DialOption) (conn *
 	// Configure idleness support with configured idle timeout or default idle
 	// timeout duration. Idleness can be explicitly disabled by the user, by
 	// setting the dial option to 0.
-	cc.idlenessMgr = idle.NewIdlenessManager(idle.IdlenessManagerOptions{Enforcer: (*idler)(cc), Timeout: cc.dopts.idleTimeout, Logger: logger})
+	cc.idlenessMgr = idle.NewManager(idle.ManagerOptions{Enforcer: (*idler)(cc), Timeout: cc.dopts.idleTimeout, Logger: logger})
 
 	// Return early for non-blocking dials.
 	if !cc.dopts.block {
@@ -650,7 +650,7 @@ type ClientConn struct {
 	channelzID      *channelz.Identifier // Channelz identifier for the channel.
 	resolverBuilder resolver.Builder     // See parseTargetAndFindResolver().
 	balancerWrapper *ccBalancerWrapper   // Uses gracefulswitch.balancer underneath.
-	idlenessMgr     idle.IdlenessManager
+	idlenessMgr     idle.Manager
 
 	// The following provide their own synchronization, and therefore don't
 	// require cc.mu to be held to access them.

--- a/internal/channelz/types.go
+++ b/internal/channelz/types.go
@@ -628,6 +628,7 @@ type tracedChannel interface {
 
 type channelTrace struct {
 	cm          *channelMap
+	clearCalled bool
 	createdTime time.Time
 	eventCount  int64
 	mu          sync.Mutex
@@ -656,6 +657,10 @@ func (c *channelTrace) append(e *TraceEvent) {
 }
 
 func (c *channelTrace) clear() {
+	if c.clearCalled {
+		return
+	}
+	c.clearCalled = true
 	c.mu.Lock()
 	for _, e := range c.events {
 		if e.RefID != 0 {

--- a/internal/idle/idle.go
+++ b/internal/idle/idle.go
@@ -184,7 +184,7 @@ func (m *manager) handleIdleTimeout() {
 //
 // Return value indicates whether or not the channel moved to idle mode.
 //
-// Holds idleMu which ensures mutual exclusion with ExitIdleMode.
+// Holds idleMu which ensures mutual exclusion with exitIdleMode.
 func (m *manager) tryEnterIdleMode() bool {
 	m.idleMu.Lock()
 	defer m.idleMu.Unlock()
@@ -227,7 +227,7 @@ func (m *manager) OnCallBegin() error {
 
 	// Channel is either in idle mode or is in the process of moving to idle
 	// mode. Attempt to exit idle mode to allow this RPC.
-	if err := m.ExitIdleMode(); err != nil {
+	if err := m.exitIdleMode(); err != nil {
 		// Undo the increment to calls count, and return an error causing the
 		// RPC to fail.
 		atomic.AddInt32(&m.activeCallsCount, -1)
@@ -238,10 +238,10 @@ func (m *manager) OnCallBegin() error {
 	return nil
 }
 
-// ExitIdleMode instructs the channel to exit idle mode.
+// exitIdleMode instructs the channel to exit idle mode.
 //
 // Holds idleMu which ensures mutual exclusion with tryEnterIdleMode.
-func (m *manager) ExitIdleMode() error {
+func (m *manager) exitIdleMode() error {
 	m.idleMu.Lock()
 	defer m.idleMu.Unlock()
 

--- a/internal/idle/idle.go
+++ b/internal/idle/idle.go
@@ -16,6 +16,8 @@
  *
  */
 
+// Package idle contains a component for managing idleness (entering and exiting)
+// based on RPC activity.
 package idle
 
 import (

--- a/internal/idle/idle_e2e_test.go
+++ b/internal/idle/idle_e2e_test.go
@@ -103,8 +103,7 @@ func channelzTraceEventNotFound(ctx context.Context, wantDesc string) error {
 // of 0. Verifies that a READY channel with no RPCs does not move to IDLE.
 func (s) TestChannelIdleness_Disabled_NoActivity(t *testing.T) {
 	// Setup channelz for testing.
-	czCleanup := channelz.NewChannelzStorageForTesting()
-	t.Cleanup(testutils.ErrCloseWrapper(t, czCleanup))
+	channelz.NewChannelzStorageForTesting()
 
 	// Create a ClientConn with idle_timeout set to 0.
 	r := manual.NewBuilderWithScheme("whatever")
@@ -148,8 +147,7 @@ func (s) TestChannelIdleness_Disabled_NoActivity(t *testing.T) {
 // idle_timeout. Verifies that a READY channel with no RPCs moves to IDLE.
 func (s) TestChannelIdleness_Enabled_NoActivity(t *testing.T) {
 	// Setup channelz for testing.
-	czCleanup := channelz.NewChannelzStorageForTesting()
-	t.Cleanup(testutils.ErrCloseWrapper(t, czCleanup))
+	channelz.NewChannelzStorageForTesting()
 
 	// Create a ClientConn with a short idle_timeout.
 	r := manual.NewBuilderWithScheme("whatever")
@@ -188,8 +186,7 @@ func (s) TestChannelIdleness_Enabled_NoActivity(t *testing.T) {
 // idle_timeout. Verifies that a READY channel with an ongoing RPC stays READY.
 func (s) TestChannelIdleness_Enabled_OngoingCall(t *testing.T) {
 	// Setup channelz for testing.
-	czCleanup := channelz.NewChannelzStorageForTesting()
-	t.Cleanup(testutils.ErrCloseWrapper(t, czCleanup))
+	channelz.NewChannelzStorageForTesting()
 
 	// Create a ClientConn with a short idle_timeout.
 	r := manual.NewBuilderWithScheme("whatever")
@@ -273,8 +270,7 @@ func (s) TestChannelIdleness_Enabled_OngoingCall(t *testing.T) {
 // RPCs) keeps it from moving to IDLE.
 func (s) TestChannelIdleness_Enabled_ActiveSinceLastCheck(t *testing.T) {
 	// Setup channelz for testing.
-	czCleanup := channelz.NewChannelzStorageForTesting()
-	t.Cleanup(testutils.ErrCloseWrapper(t, czCleanup))
+	channelz.NewChannelzStorageForTesting()
 
 	// Create a ClientConn with a short idle_timeout.
 	r := manual.NewBuilderWithScheme("whatever")
@@ -337,8 +333,7 @@ func (s) TestChannelIdleness_Enabled_ActiveSinceLastCheck(t *testing.T) {
 // verifies that a subsequent RPC on the IDLE channel kicks it out of IDLE.
 func (s) TestChannelIdleness_Enabled_ExitIdleOnRPC(t *testing.T) {
 	// Setup channelz for testing.
-	czCleanup := channelz.NewChannelzStorageForTesting()
-	t.Cleanup(testutils.ErrCloseWrapper(t, czCleanup))
+	channelz.NewChannelzStorageForTesting()
 
 	// Start a test backend and set the bootstrap state of the resolver to
 	// include this address. This will ensure that when the resolver is
@@ -399,8 +394,7 @@ func (s) TestChannelIdleness_Enabled_ExitIdleOnRPC(t *testing.T) {
 // In either of these cases, all RPCs must succeed.
 func (s) TestChannelIdleness_Enabled_IdleTimeoutRacesWithRPCs(t *testing.T) {
 	// Setup channelz for testing.
-	czCleanup := channelz.NewChannelzStorageForTesting()
-	t.Cleanup(testutils.ErrCloseWrapper(t, czCleanup))
+	channelz.NewChannelzStorageForTesting()
 
 	// Start a test backend and set the bootstrap state of the resolver to
 	// include this address. This will ensure that when the resolver is

--- a/internal/idle/idle_e2e_test.go
+++ b/internal/idle/idle_e2e_test.go
@@ -102,9 +102,6 @@ func channelzTraceEventNotFound(ctx context.Context, wantDesc string) error {
 // Tests the case where channel idleness is disabled by passing an idle_timeout
 // of 0. Verifies that a READY channel with no RPCs does not move to IDLE.
 func (s) TestChannelIdleness_Disabled_NoActivity(t *testing.T) {
-	// Setup channelz for testing.
-	channelz.NewChannelzStorageForTesting()
-
 	// Create a ClientConn with idle_timeout set to 0.
 	r := manual.NewBuilderWithScheme("whatever")
 	dopts := []grpc.DialOption{
@@ -146,9 +143,6 @@ func (s) TestChannelIdleness_Disabled_NoActivity(t *testing.T) {
 // Tests the case where channel idleness is enabled by passing a small value for
 // idle_timeout. Verifies that a READY channel with no RPCs moves to IDLE.
 func (s) TestChannelIdleness_Enabled_NoActivity(t *testing.T) {
-	// Setup channelz for testing.
-	channelz.NewChannelzStorageForTesting()
-
 	// Create a ClientConn with a short idle_timeout.
 	r := manual.NewBuilderWithScheme("whatever")
 	dopts := []grpc.DialOption{
@@ -185,9 +179,6 @@ func (s) TestChannelIdleness_Enabled_NoActivity(t *testing.T) {
 // Tests the case where channel idleness is enabled by passing a small value for
 // idle_timeout. Verifies that a READY channel with an ongoing RPC stays READY.
 func (s) TestChannelIdleness_Enabled_OngoingCall(t *testing.T) {
-	// Setup channelz for testing.
-	channelz.NewChannelzStorageForTesting()
-
 	// Create a ClientConn with a short idle_timeout.
 	r := manual.NewBuilderWithScheme("whatever")
 	dopts := []grpc.DialOption{
@@ -269,9 +260,6 @@ func (s) TestChannelIdleness_Enabled_OngoingCall(t *testing.T) {
 // idle_timeout. Verifies that activity on a READY channel (frequent and short
 // RPCs) keeps it from moving to IDLE.
 func (s) TestChannelIdleness_Enabled_ActiveSinceLastCheck(t *testing.T) {
-	// Setup channelz for testing.
-	channelz.NewChannelzStorageForTesting()
-
 	// Create a ClientConn with a short idle_timeout.
 	r := manual.NewBuilderWithScheme("whatever")
 	dopts := []grpc.DialOption{
@@ -332,9 +320,6 @@ func (s) TestChannelIdleness_Enabled_ActiveSinceLastCheck(t *testing.T) {
 // idle_timeout. Verifies that a READY channel with no RPCs moves to IDLE. Also
 // verifies that a subsequent RPC on the IDLE channel kicks it out of IDLE.
 func (s) TestChannelIdleness_Enabled_ExitIdleOnRPC(t *testing.T) {
-	// Setup channelz for testing.
-	channelz.NewChannelzStorageForTesting()
-
 	// Start a test backend and set the bootstrap state of the resolver to
 	// include this address. This will ensure that when the resolver is
 	// restarted when exiting idle, it will push the same address to grpc again.
@@ -393,9 +378,6 @@ func (s) TestChannelIdleness_Enabled_ExitIdleOnRPC(t *testing.T) {
 //
 // In either of these cases, all RPCs must succeed.
 func (s) TestChannelIdleness_Enabled_IdleTimeoutRacesWithRPCs(t *testing.T) {
-	// Setup channelz for testing.
-	channelz.NewChannelzStorageForTesting()
-
 	// Start a test backend and set the bootstrap state of the resolver to
 	// include this address. This will ensure that when the resolver is
 	// restarted when exiting idle, it will push the same address to grpc again.

--- a/internal/testutils/state.go
+++ b/internal/testutils/state.go
@@ -59,18 +59,18 @@ func AwaitState(ctx context.Context, t *testing.T, sc StateChanger, stateWant co
 	t.Helper()
 	for state := sc.GetState(); state != stateWant; state = sc.GetState() {
 		if !sc.WaitForStateChange(ctx, state) {
-			t.Fatalf("timed out waiting for state change.  got %v; want %v", state, stateWant)
+			t.Fatalf("Timed out waiting for state change.  got %v; want %v", state, stateWant)
 		}
 	}
 }
 
-// AwaitNotState waits for sc to leave stateWant or fatal errors if it doesn't
-// happen before ctx expires.
+// AwaitNotState waits for sc to leave stateDoNotWant or fatal errors if it
+// doesn't happen before ctx expires.
 func AwaitNotState(ctx context.Context, t *testing.T, sc StateChanger, stateDoNotWant connectivity.State) {
 	t.Helper()
 	for state := sc.GetState(); state == stateDoNotWant; state = sc.GetState() {
 		if !sc.WaitForStateChange(ctx, state) {
-			t.Fatalf("timed out waiting for state change.  got %v; want NOT %v", state, stateDoNotWant)
+			t.Fatalf("Timed out waiting for state change.  got %v; want NOT %v", state, stateDoNotWant)
 		}
 	}
 }

--- a/internal/testutils/state.go
+++ b/internal/testutils/state.go
@@ -1,0 +1,85 @@
+/*
+ *
+ * Copyright 2023 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package testutils
+
+import (
+	"context"
+	"testing"
+
+	"google.golang.org/grpc/connectivity"
+)
+
+// A StateChanger reports state changes, e.g. a grpc.ClientConn.
+type StateChanger interface {
+	// Connect begins connecting the StateChanger.
+	Connect()
+	// GetState returns the current state of the StateChanger.
+	GetState() connectivity.State
+	// WaitForStateChange returns true when the state becomes s, or returns
+	// false if ctx is canceled first.
+	WaitForStateChange(ctx context.Context, s connectivity.State) bool
+}
+
+// StayConnected makes sc stay connected by repeatedly calling sc.Connect()
+// until the state becomes Shutdown or until ithe context expires.
+func StayConnected(ctx context.Context, sc StateChanger) {
+	for {
+		state := sc.GetState()
+		switch state {
+		case connectivity.Idle:
+			sc.Connect()
+		case connectivity.Shutdown:
+			return
+		}
+		if !sc.WaitForStateChange(ctx, state) {
+			return
+		}
+	}
+}
+
+// AwaitState waits for sc to enter stateWant or fatal errors if it doesn't
+// happen before ctx expires.
+func AwaitState(ctx context.Context, t *testing.T, sc StateChanger, stateWant connectivity.State) {
+	t.Helper()
+	for state := sc.GetState(); state != stateWant; state = sc.GetState() {
+		if !sc.WaitForStateChange(ctx, state) {
+			t.Fatalf("timed out waiting for state change.  got %v; want %v", state, stateWant)
+		}
+	}
+}
+
+// AwaitNotState waits for sc to leave stateWant or fatal errors if it doesn't
+// happen before ctx expires.
+func AwaitNotState(ctx context.Context, t *testing.T, sc StateChanger, stateDoNotWant connectivity.State) {
+	t.Helper()
+	for state := sc.GetState(); state == stateDoNotWant; state = sc.GetState() {
+		if !sc.WaitForStateChange(ctx, state) {
+			t.Fatalf("timed out waiting for state change.  got %v; want NOT %v", state, stateDoNotWant)
+		}
+	}
+}
+
+// AwaitNoStateChange expects ctx to be canceled before sc's state leaves
+// currState, and fatal errors otherwise.
+func AwaitNoStateChange(ctx context.Context, t *testing.T, sc StateChanger, currState connectivity.State) {
+	t.Helper()
+	if sc.WaitForStateChange(ctx, currState) {
+		t.Fatalf("State changed from %q to %q when no state change was expected", currState, sc.GetState())
+	}
+}

--- a/internal/testutils/wrappers.go
+++ b/internal/testutils/wrappers.go
@@ -72,3 +72,13 @@ func NewListenerWrapper(t *testing.T, lis net.Listener) *ListenerWrapper {
 		NewConnCh: NewChannel(),
 	}
 }
+
+// ErrCloseWrapper wraps closer with a function that does not return an error,
+// but calls t.Error if it does, instead.
+func ErrCloseWrapper(t *testing.T, closer func() error) func() {
+	return func() {
+		if err := closer(); err != nil {
+			t.Error(err)
+		}
+	}
+}

--- a/internal/testutils/wrappers.go
+++ b/internal/testutils/wrappers.go
@@ -72,13 +72,3 @@ func NewListenerWrapper(t *testing.T, lis net.Listener) *ListenerWrapper {
 		NewConnCh: NewChannel(),
 	}
 }
-
-// ErrCloseWrapper wraps closer with a function that does not return an error,
-// but calls t.Error if it does, instead.
-func ErrCloseWrapper(t *testing.T, closer func() error) func() {
-	return func() {
-		if err := closer(); err != nil {
-			t.Error(err)
-		}
-	}
-}

--- a/stream.go
+++ b/stream.go
@@ -156,10 +156,10 @@ type ClientStream interface {
 // If none of the above happen, a goroutine and a context will be leaked, and grpc
 // will not call the optionally-configured stats handler with a stats.End message.
 func (cc *ClientConn) NewStream(ctx context.Context, desc *StreamDesc, method string, opts ...CallOption) (ClientStream, error) {
-	if err := cc.idlenessMgr.onCallBegin(); err != nil {
+	if err := cc.idlenessMgr.OnCallBegin(); err != nil {
 		return nil, err
 	}
-	defer cc.idlenessMgr.onCallEnd()
+	defer cc.idlenessMgr.OnCallEnd()
 
 	// allow interceptor to see all applicable call options, which means those
 	// configured as defaults from dial option as well as per-call options

--- a/test/balancer_switching_test.go
+++ b/test/balancer_switching_test.go
@@ -29,7 +29,6 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/internal"
 	"google.golang.org/grpc/internal/balancer/stub"
-	"google.golang.org/grpc/internal/channelz"
 	"google.golang.org/grpc/internal/stubserver"
 	"google.golang.org/grpc/internal/testutils/fakegrpclb"
 	"google.golang.org/grpc/internal/testutils/pickfirst"
@@ -63,7 +62,6 @@ const (
 //
 // Returns a cleanup function to be invoked by the caller.
 func setupBackendsAndFakeGRPCLB(t *testing.T) ([]*stubserver.StubServer, *fakegrpclb.Server, func()) {
-	channelz.NewChannelzStorageForTesting()
 	backends, backendsCleanup := startBackendsForBalancerSwitch(t)
 
 	lbServer, err := fakegrpclb.NewServer(fakegrpclb.ServerParams{

--- a/test/balancer_switching_test.go
+++ b/test/balancer_switching_test.go
@@ -63,7 +63,7 @@ const (
 //
 // Returns a cleanup function to be invoked by the caller.
 func setupBackendsAndFakeGRPCLB(t *testing.T) ([]*stubserver.StubServer, *fakegrpclb.Server, func()) {
-	czCleanup := channelz.NewChannelzStorageForTesting()
+	channelz.NewChannelzStorageForTesting()
 	backends, backendsCleanup := startBackendsForBalancerSwitch(t)
 
 	lbServer, err := fakegrpclb.NewServer(fakegrpclb.ServerParams{
@@ -83,7 +83,6 @@ func setupBackendsAndFakeGRPCLB(t *testing.T) ([]*stubserver.StubServer, *fakegr
 	return backends, lbServer, func() {
 		backendsCleanup()
 		lbServer.Stop()
-		czCleanupWrapper(czCleanup, t)
 	}
 }
 

--- a/test/channelz_linux_test.go
+++ b/test/channelz_linux_test.go
@@ -35,8 +35,8 @@ func (s) TestCZSocketMetricsSocketOption(t *testing.T) {
 }
 
 func testCZSocketMetricsSocketOption(t *testing.T, e env) {
-	czCleanup := channelz.NewChannelzStorageForTesting()
-	defer czCleanupWrapper(czCleanup, t)
+	channelz.NewChannelzStorageForTesting()
+
 	te := newTest(t, e)
 	te.startServer(&testServer{security: e.security})
 	defer te.tearDown()

--- a/test/channelz_linux_test.go
+++ b/test/channelz_linux_test.go
@@ -35,8 +35,6 @@ func (s) TestCZSocketMetricsSocketOption(t *testing.T) {
 }
 
 func testCZSocketMetricsSocketOption(t *testing.T, e env) {
-	channelz.NewChannelzStorageForTesting()
-
 	te := newTest(t, e)
 	te.startServer(&testServer{security: e.security})
 	defer te.tearDown()

--- a/test/channelz_test.go
+++ b/test/channelz_test.go
@@ -95,7 +95,6 @@ func (s) TestCZServerRegistrationAndDeletion(t *testing.T) {
 		te.tearDown()
 		ss, end = channelz.GetServers(c.start, c.max)
 		if len(ss) != 0 || !end {
-			panic("die")
 			t.Fatalf("%d: GetServers(0) = %+v (len of which: %d), end: %+v, want len(GetServers(0)) = 0, end: true", i, ss, len(ss), end)
 		}
 	}

--- a/test/channelz_test.go
+++ b/test/channelz_test.go
@@ -52,12 +52,6 @@ import (
 	testpb "google.golang.org/grpc/interop/grpc_testing"
 )
 
-func czCleanupWrapper(cleanup func() error, t *testing.T) {
-	if err := cleanup(); err != nil {
-		t.Error(err)
-	}
-}
-
 func verifyResultWithDelay(f func() (bool, error)) error {
 	var ok bool
 	var err error
@@ -87,8 +81,8 @@ func (s) TestCZServerRegistrationAndDeletion(t *testing.T) {
 	}
 
 	for _, c := range testcases {
-		czCleanup := channelz.NewChannelzStorageForTesting()
-		defer czCleanupWrapper(czCleanup, t)
+		channelz.NewChannelzStorageForTesting()
+
 		e := tcpClearRREnv
 		te := newTest(t, e)
 		te.startServers(&testServer{security: e.security}, c.total)
@@ -106,8 +100,8 @@ func (s) TestCZServerRegistrationAndDeletion(t *testing.T) {
 }
 
 func (s) TestCZGetServer(t *testing.T) {
-	czCleanup := channelz.NewChannelzStorageForTesting()
-	defer czCleanupWrapper(czCleanup, t)
+	channelz.NewChannelzStorageForTesting()
+
 	e := tcpClearRREnv
 	te := newTest(t, e)
 	te.startServer(&testServer{security: e.security})
@@ -158,8 +152,8 @@ func (s) TestCZTopChannelRegistrationAndDeletion(t *testing.T) {
 	}
 
 	for _, c := range testcases {
-		czCleanup := channelz.NewChannelzStorageForTesting()
-		defer czCleanupWrapper(czCleanup, t)
+		channelz.NewChannelzStorageForTesting()
+
 		e := tcpClearRREnv
 		te := newTest(t, e)
 		var ccs []*grpc.ClientConn
@@ -196,8 +190,8 @@ func (s) TestCZTopChannelRegistrationAndDeletion(t *testing.T) {
 }
 
 func (s) TestCZTopChannelRegistrationAndDeletionWhenDialFail(t *testing.T) {
-	czCleanup := channelz.NewChannelzStorageForTesting()
-	defer czCleanupWrapper(czCleanup, t)
+	channelz.NewChannelzStorageForTesting()
+
 	// Make dial fails (due to no transport security specified)
 	_, err := grpc.Dial("fake.addr")
 	if err == nil {
@@ -209,8 +203,8 @@ func (s) TestCZTopChannelRegistrationAndDeletionWhenDialFail(t *testing.T) {
 }
 
 func (s) TestCZNestedChannelRegistrationAndDeletion(t *testing.T) {
-	czCleanup := channelz.NewChannelzStorageForTesting()
-	defer czCleanupWrapper(czCleanup, t)
+	channelz.NewChannelzStorageForTesting()
+
 	e := tcpClearRREnv
 	// avoid calling API to set balancer type, which will void service config's change of balancer.
 	e.balancer = ""
@@ -257,8 +251,8 @@ func (s) TestCZNestedChannelRegistrationAndDeletion(t *testing.T) {
 }
 
 func (s) TestCZClientSubChannelSocketRegistrationAndDeletion(t *testing.T) {
-	czCleanup := channelz.NewChannelzStorageForTesting()
-	defer czCleanupWrapper(czCleanup, t)
+	channelz.NewChannelzStorageForTesting()
+
 	e := tcpClearRREnv
 	num := 3 // number of backends
 	te := newTest(t, e)
@@ -345,8 +339,8 @@ func (s) TestCZServerSocketRegistrationAndDeletion(t *testing.T) {
 	}
 
 	for _, c := range testcases {
-		czCleanup := channelz.NewChannelzStorageForTesting()
-		defer czCleanupWrapper(czCleanup, t)
+		channelz.NewChannelzStorageForTesting()
+
 		e := tcpClearRREnv
 		te := newTest(t, e)
 		te.startServer(&testServer{security: e.security})
@@ -405,8 +399,8 @@ func (s) TestCZServerSocketRegistrationAndDeletion(t *testing.T) {
 }
 
 func (s) TestCZServerListenSocketDeletion(t *testing.T) {
-	czCleanup := channelz.NewChannelzStorageForTesting()
-	defer czCleanupWrapper(czCleanup, t)
+	channelz.NewChannelzStorageForTesting()
+
 	s := grpc.NewServer()
 	lis, err := net.Listen("tcp", "localhost:0")
 	if err != nil {
@@ -462,8 +456,8 @@ func (s) TestCZRecusivelyDeletionOfEntry(t *testing.T) {
 	//    |             |
 	//    v             v
 	// Socket1       Socket2
-	czCleanup := channelz.NewChannelzStorageForTesting()
-	defer czCleanupWrapper(czCleanup, t)
+	channelz.NewChannelzStorageForTesting()
+
 	topChanID := channelz.RegisterChannel(&dummyChannel{}, nil, "")
 	subChanID1, _ := channelz.RegisterSubChannel(&dummyChannel{}, topChanID, "")
 	subChanID2, _ := channelz.RegisterSubChannel(&dummyChannel{}, topChanID, "")
@@ -507,8 +501,8 @@ func (s) TestCZRecusivelyDeletionOfEntry(t *testing.T) {
 }
 
 func (s) TestCZChannelMetrics(t *testing.T) {
-	czCleanup := channelz.NewChannelzStorageForTesting()
-	defer czCleanupWrapper(czCleanup, t)
+	channelz.NewChannelzStorageForTesting()
+
 	e := tcpClearRREnv
 	num := 3 // number of backends
 	te := newTest(t, e)
@@ -597,8 +591,8 @@ func (s) TestCZChannelMetrics(t *testing.T) {
 }
 
 func (s) TestCZServerMetrics(t *testing.T) {
-	czCleanup := channelz.NewChannelzStorageForTesting()
-	defer czCleanupWrapper(czCleanup, t)
+	channelz.NewChannelzStorageForTesting()
+
 	e := tcpClearRREnv
 	te := newTest(t, e)
 	te.maxServerReceiveMsgSize = newInt(8)
@@ -869,8 +863,8 @@ func (s) TestCZClientSocketMetricsStreamsAndMessagesCount(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
 
-	czCleanup := channelz.NewChannelzStorageForTesting()
-	defer czCleanupWrapper(czCleanup, t)
+	channelz.NewChannelzStorageForTesting()
+
 	e := tcpClearRREnv
 	te := newTest(t, e)
 	te.maxServerReceiveMsgSize = newInt(20)
@@ -969,8 +963,8 @@ func (s) TestCZClientSocketMetricsStreamsAndMessagesCount(t *testing.T) {
 // It is separated from other cases due to setup incompatibly, i.e. max receive
 // size violation will mask flow control violation.
 func (s) TestCZClientAndServerSocketMetricsStreamsCountFlowControlRSTStream(t *testing.T) {
-	czCleanup := channelz.NewChannelzStorageForTesting()
-	defer czCleanupWrapper(czCleanup, t)
+	channelz.NewChannelzStorageForTesting()
+
 	e := tcpClearRREnv
 	te := newTest(t, e)
 	te.serverInitialWindowSize = 65536
@@ -1053,8 +1047,8 @@ func (s) TestCZClientAndServerSocketMetricsStreamsCountFlowControlRSTStream(t *t
 }
 
 func (s) TestCZClientAndServerSocketMetricsFlowControl(t *testing.T) {
-	czCleanup := channelz.NewChannelzStorageForTesting()
-	defer czCleanupWrapper(czCleanup, t)
+	channelz.NewChannelzStorageForTesting()
+
 	e := tcpClearRREnv
 	te := newTest(t, e)
 	// disable BDP
@@ -1167,8 +1161,8 @@ func (s) TestCZClientAndServerSocketMetricsFlowControl(t *testing.T) {
 
 func (s) TestCZClientSocketMetricsKeepAlive(t *testing.T) {
 	const keepaliveRate = 50 * time.Millisecond
-	czCleanup := channelz.NewChannelzStorageForTesting()
-	defer czCleanupWrapper(czCleanup, t)
+	channelz.NewChannelzStorageForTesting()
+
 	defer func(t time.Duration) { internal.KeepaliveMinPingTime = t }(internal.KeepaliveMinPingTime)
 	internal.KeepaliveMinPingTime = keepaliveRate
 	e := tcpClearRREnv
@@ -1227,8 +1221,8 @@ func (s) TestCZClientSocketMetricsKeepAlive(t *testing.T) {
 }
 
 func (s) TestCZServerSocketMetricsStreamsAndMessagesCount(t *testing.T) {
-	czCleanup := channelz.NewChannelzStorageForTesting()
-	defer czCleanupWrapper(czCleanup, t)
+	channelz.NewChannelzStorageForTesting()
+
 	e := tcpClearRREnv
 	te := newTest(t, e)
 	te.maxServerReceiveMsgSize = newInt(20)
@@ -1291,8 +1285,8 @@ func (s) TestCZServerSocketMetricsKeepAlive(t *testing.T) {
 	defer func(t time.Duration) { internal.KeepaliveMinServerPingTime = t }(internal.KeepaliveMinServerPingTime)
 	internal.KeepaliveMinServerPingTime = 50 * time.Millisecond
 
-	czCleanup := channelz.NewChannelzStorageForTesting()
-	defer czCleanupWrapper(czCleanup, t)
+	channelz.NewChannelzStorageForTesting()
+
 	e := tcpClearRREnv
 	te := newTest(t, e)
 	// We setup the server keepalive parameters to send one keepalive every
@@ -1361,8 +1355,8 @@ var cipherSuites = []string{
 }
 
 func (s) TestCZSocketGetSecurityValueTLS(t *testing.T) {
-	czCleanup := channelz.NewChannelzStorageForTesting()
-	defer czCleanupWrapper(czCleanup, t)
+	channelz.NewChannelzStorageForTesting()
+
 	e := tcpTLSRREnv
 	te := newTest(t, e)
 	te.startServer(&testServer{security: e.security})
@@ -1411,8 +1405,7 @@ func (s) TestCZSocketGetSecurityValueTLS(t *testing.T) {
 }
 
 func (s) TestCZChannelTraceCreationDeletion(t *testing.T) {
-	czCleanup := channelz.NewChannelzStorageForTesting()
-	defer czCleanupWrapper(czCleanup, t)
+	channelz.NewChannelzStorageForTesting()
 
 	e := tcpClearRREnv
 	// avoid calling API to set balancer type, which will void service config's change of balancer.
@@ -1494,8 +1487,8 @@ func (s) TestCZChannelTraceCreationDeletion(t *testing.T) {
 }
 
 func (s) TestCZSubChannelTraceCreationDeletion(t *testing.T) {
-	czCleanup := channelz.NewChannelzStorageForTesting()
-	defer czCleanupWrapper(czCleanup, t)
+	channelz.NewChannelzStorageForTesting()
+
 	e := tcpClearRREnv
 	te := newTest(t, e)
 	te.startServer(&testServer{security: e.security})
@@ -1579,8 +1572,8 @@ func (s) TestCZSubChannelTraceCreationDeletion(t *testing.T) {
 }
 
 func (s) TestCZChannelAddressResolutionChange(t *testing.T) {
-	czCleanup := channelz.NewChannelzStorageForTesting()
-	defer czCleanupWrapper(czCleanup, t)
+	channelz.NewChannelzStorageForTesting()
+
 	e := tcpClearRREnv
 	e.balancer = ""
 	te := newTest(t, e)
@@ -1685,8 +1678,8 @@ func (s) TestCZChannelAddressResolutionChange(t *testing.T) {
 }
 
 func (s) TestCZSubChannelPickedNewAddress(t *testing.T) {
-	czCleanup := channelz.NewChannelzStorageForTesting()
-	defer czCleanupWrapper(czCleanup, t)
+	channelz.NewChannelzStorageForTesting()
+
 	e := tcpClearRREnv
 	e.balancer = ""
 	te := newTest(t, e)
@@ -1757,8 +1750,8 @@ func (s) TestCZSubChannelPickedNewAddress(t *testing.T) {
 }
 
 func (s) TestCZSubChannelConnectivityState(t *testing.T) {
-	czCleanup := channelz.NewChannelzStorageForTesting()
-	defer czCleanupWrapper(czCleanup, t)
+	channelz.NewChannelzStorageForTesting()
+
 	e := tcpClearRREnv
 	te := newTest(t, e)
 	te.startServer(&testServer{security: e.security})
@@ -1856,8 +1849,8 @@ func (s) TestCZSubChannelConnectivityState(t *testing.T) {
 }
 
 func (s) TestCZChannelConnectivityState(t *testing.T) {
-	czCleanup := channelz.NewChannelzStorageForTesting()
-	defer czCleanupWrapper(czCleanup, t)
+	channelz.NewChannelzStorageForTesting()
+
 	e := tcpClearRREnv
 	te := newTest(t, e)
 	te.startServer(&testServer{security: e.security})
@@ -1915,8 +1908,8 @@ func (s) TestCZChannelConnectivityState(t *testing.T) {
 }
 
 func (s) TestCZTraceOverwriteChannelDeletion(t *testing.T) {
-	czCleanup := channelz.NewChannelzStorageForTesting()
-	defer czCleanupWrapper(czCleanup, t)
+	channelz.NewChannelzStorageForTesting()
+
 	e := tcpClearRREnv
 	e.balancer = ""
 	te := newTest(t, e)
@@ -1985,8 +1978,8 @@ func (s) TestCZTraceOverwriteChannelDeletion(t *testing.T) {
 }
 
 func (s) TestCZTraceOverwriteSubChannelDeletion(t *testing.T) {
-	czCleanup := channelz.NewChannelzStorageForTesting()
-	defer czCleanupWrapper(czCleanup, t)
+	channelz.NewChannelzStorageForTesting()
+
 	e := tcpClearRREnv
 	te := newTest(t, e)
 	channelz.SetMaxTraceEntry(1)
@@ -2035,8 +2028,8 @@ func (s) TestCZTraceOverwriteSubChannelDeletion(t *testing.T) {
 }
 
 func (s) TestCZTraceTopChannelDeletionTraceClear(t *testing.T) {
-	czCleanup := channelz.NewChannelzStorageForTesting()
-	defer czCleanupWrapper(czCleanup, t)
+	channelz.NewChannelzStorageForTesting()
+
 	e := tcpClearRREnv
 	te := newTest(t, e)
 	te.startServer(&testServer{security: e.security})

--- a/test/channelz_test.go
+++ b/test/channelz_test.go
@@ -41,6 +41,7 @@ import (
 	"google.golang.org/grpc/internal"
 	"google.golang.org/grpc/internal/channelz"
 	"google.golang.org/grpc/internal/stubserver"
+	"google.golang.org/grpc/internal/testutils"
 	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/resolver"
 	"google.golang.org/grpc/resolver/manual"
@@ -1187,7 +1188,7 @@ func (s) TestCZClientSocketMetricsKeepAlive(t *testing.T) {
 	cc := te.clientConn() // Dial the server
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
-	awaitState(ctx, t, cc, connectivity.Ready)
+	testutils.AwaitState(ctx, t, cc, connectivity.Ready)
 	start := time.Now()
 	// Wait for at least two keepalives to be able to occur.
 	time.Sleep(2 * keepaliveRate)
@@ -1311,7 +1312,7 @@ func (s) TestCZServerSocketMetricsKeepAlive(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
-	awaitState(ctx, t, cc, connectivity.Ready)
+	testutils.AwaitState(ctx, t, cc, connectivity.Ready)
 
 	// Allow about 5 pings to happen (250ms/50ms).
 	time.Sleep(255 * time.Millisecond)
@@ -1543,9 +1544,9 @@ func (s) TestCZSubChannelTraceCreationDeletion(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
-	awaitState(ctx, t, te.cc, connectivity.Ready)
+	testutils.AwaitState(ctx, t, te.cc, connectivity.Ready)
 	r.UpdateState(resolver.State{Addresses: []resolver.Address{{Addr: "fake address"}}})
-	awaitNotState(ctx, t, te.cc, connectivity.Ready)
+	testutils.AwaitNotState(ctx, t, te.cc, connectivity.Ready)
 
 	if err := verifyResultWithDelay(func() (bool, error) {
 		tcs, _ := channelz.GetTopChannels(0, 0)
@@ -2017,9 +2018,9 @@ func (s) TestCZTraceOverwriteSubChannelDeletion(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
-	awaitState(ctx, t, te.cc, connectivity.Ready)
+	testutils.AwaitState(ctx, t, te.cc, connectivity.Ready)
 	r.UpdateState(resolver.State{Addresses: []resolver.Address{{Addr: "fake address"}}})
-	awaitNotState(ctx, t, te.cc, connectivity.Ready)
+	testutils.AwaitNotState(ctx, t, te.cc, connectivity.Ready)
 
 	// verify that the subchannel no longer exist due to trace referencing it got overwritten.
 	if err := verifyResultWithDelay(func() (bool, error) {

--- a/test/clientconn_test.go
+++ b/test/clientconn_test.go
@@ -40,9 +40,6 @@ import (
 // blocking. The test verifies that closing the ClientConn unblocks the RPC with
 // the expected error code.
 func (s) TestClientConnClose_WithPendingRPC(t *testing.T) {
-	// Initialize channelz. Used to determine pending RPC count.
-	channelz.NewChannelzStorageForTesting()
-
 	r := manual.NewBuilderWithScheme("whatever")
 	cc, err := grpc.Dial(r.Scheme()+":///test.server", grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithResolvers(r))
 	if err != nil {

--- a/test/clientconn_test.go
+++ b/test/clientconn_test.go
@@ -41,8 +41,7 @@ import (
 // the expected error code.
 func (s) TestClientConnClose_WithPendingRPC(t *testing.T) {
 	// Initialize channelz. Used to determine pending RPC count.
-	czCleanup := channelz.NewChannelzStorageForTesting()
-	defer czCleanupWrapper(czCleanup, t)
+	channelz.NewChannelzStorageForTesting()
 
 	r := manual.NewBuilderWithScheme("whatever")
 	cc, err := grpc.Dial(r.Scheme()+":///test.server", grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithResolvers(r))

--- a/test/creds_test.go
+++ b/test/creds_test.go
@@ -32,6 +32,7 @@ import (
 	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/internal/testutils"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/resolver"
 	"google.golang.org/grpc/resolver/manual"
@@ -445,7 +446,7 @@ func (s) TestCredsHandshakeAuthority(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
-	awaitState(ctx, t, cc, connectivity.Ready)
+	testutils.AwaitState(ctx, t, cc, connectivity.Ready)
 
 	if cred.got != testAuthority {
 		t.Fatalf("client creds got authority: %q, want: %q", cred.got, testAuthority)
@@ -477,7 +478,7 @@ func (s) TestCredsHandshakeServerNameAuthority(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
-	awaitState(ctx, t, cc, connectivity.Ready)
+	testutils.AwaitState(ctx, t, cc, connectivity.Ready)
 
 	if cred.got != testServerName {
 		t.Fatalf("client creds got authority: %q, want: %q", cred.got, testAuthority)

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -34,6 +34,7 @@ import (
 	"os"
 	"reflect"
 	"runtime"
+	"runtime/debug"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -573,6 +574,7 @@ func newTest(t *testing.T, e env) *test {
 
 func (te *test) listenAndServe(ts testgrpc.TestServiceServer, listen func(network, address string) (net.Listener, error)) net.Listener {
 	te.t.Helper()
+	debug.PrintStack()
 	te.t.Logf("Running test in %s environment...", te.e.name)
 	sopts := []grpc.ServerOption{grpc.MaxConcurrentStreams(te.maxStream)}
 	if te.maxServerMsgSize != nil {

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -34,7 +34,6 @@ import (
 	"os"
 	"reflect"
 	"runtime"
-	"runtime/debug"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -574,7 +573,6 @@ func newTest(t *testing.T, e env) *test {
 
 func (te *test) listenAndServe(ts testgrpc.TestServiceServer, listen func(network, address string) (net.Listener, error)) net.Listener {
 	te.t.Helper()
-	debug.PrintStack()
 	te.t.Logf("Running test in %s environment...", te.e.name)
 	sopts := []grpc.ServerOption{grpc.MaxConcurrentStreams(te.maxStream)}
 	if te.maxServerMsgSize != nil {

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -696,6 +696,7 @@ func (w wrapHS) GracefulStop() {
 
 func (w wrapHS) Stop() {
 	w.s.Close()
+	w.s.Handler.(*grpc.Server).Stop()
 }
 
 func (te *test) startServerWithConnControl(ts testgrpc.TestServiceServer) *listenerWrapper {
@@ -3031,7 +3032,9 @@ func (s) TestTransparentRetry(t *testing.T) {
 
 func (s) TestCancel(t *testing.T) {
 	for _, e := range listTestEnv() {
-		testCancel(t, e)
+		t.Run(e.name, func(t *testing.T) {
+			testCancel(t, e)
+		})
 	}
 }
 

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -984,9 +984,9 @@ func testTimeoutOnDeadServer(t *testing.T, e env) {
 	}
 	// Wait for the client to report READY, stop the server, then wait for the
 	// client to notice the connection is gone.
-	awaitState(ctx, t, cc, connectivity.Ready)
+	testutils.AwaitState(ctx, t, cc, connectivity.Ready)
 	te.srv.Stop()
-	awaitNotState(ctx, t, cc, connectivity.Ready)
+	testutils.AwaitNotState(ctx, t, cc, connectivity.Ready)
 	ctx, cancel = context.WithTimeout(ctx, defaultTestShortTimeout)
 	defer cancel()
 	if _, err := tc.EmptyCall(ctx, &testpb.Empty{}, grpc.WaitForReady(true)); status.Code(err) != codes.DeadlineExceeded {
@@ -4855,7 +4855,7 @@ func testWaitForReadyConnection(t *testing.T, e env) {
 	tc := testgrpc.NewTestServiceClient(cc)
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
-	awaitState(ctx, t, cc, connectivity.Ready)
+	testutils.AwaitState(ctx, t, cc, connectivity.Ready)
 	// Make a fail-fast RPC.
 	if _, err := tc.EmptyCall(ctx, &testpb.Empty{}); err != nil {
 		t.Fatalf("TestService/EmptyCall(_,_) = _, %v, want _, nil", err)

--- a/test/goaway_test.go
+++ b/test/goaway_test.go
@@ -595,7 +595,7 @@ func (s) TestGoAwayThenClose(t *testing.T) {
 	client := testgrpc.NewTestServiceClient(cc)
 
 	t.Log("Waiting for the ClientConn to enter READY state.")
-	awaitState(ctx, t, cc, connectivity.Ready)
+	testutils.AwaitState(ctx, t, cc, connectivity.Ready)
 
 	// We make a streaming RPC and do an one-message-round-trip to make sure
 	// it's created on connection 1.
@@ -618,7 +618,7 @@ func (s) TestGoAwayThenClose(t *testing.T) {
 	go s1.GracefulStop()
 
 	t.Log("Waiting for the ClientConn to enter IDLE state.")
-	awaitState(ctx, t, cc, connectivity.Idle)
+	testutils.AwaitState(ctx, t, cc, connectivity.Idle)
 
 	t.Log("Performing another RPC to create a connection to server 2.")
 	if _, err := client.UnaryCall(ctx, &testpb.SimpleRequest{}); err != nil {

--- a/test/healthcheck_test.go
+++ b/test/healthcheck_test.go
@@ -35,6 +35,7 @@ import (
 	"google.golang.org/grpc/internal"
 	"google.golang.org/grpc/internal/channelz"
 	"google.golang.org/grpc/internal/grpctest"
+	"google.golang.org/grpc/internal/testutils"
 	"google.golang.org/grpc/resolver"
 	"google.golang.org/grpc/resolver/manual"
 	"google.golang.org/grpc/status"
@@ -212,33 +213,33 @@ func (s) TestHealthCheckWatchStateChange(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
-	awaitNotState(ctx, t, cc, connectivity.Idle)
-	awaitNotState(ctx, t, cc, connectivity.Connecting)
-	awaitState(ctx, t, cc, connectivity.TransientFailure)
+	testutils.AwaitNotState(ctx, t, cc, connectivity.Idle)
+	testutils.AwaitNotState(ctx, t, cc, connectivity.Connecting)
+	testutils.AwaitState(ctx, t, cc, connectivity.TransientFailure)
 	if s := cc.GetState(); s != connectivity.TransientFailure {
 		t.Fatalf("ClientConn is in %v state, want TRANSIENT FAILURE", s)
 	}
 
 	ts.SetServingStatus("foo", healthpb.HealthCheckResponse_SERVING)
-	awaitNotState(ctx, t, cc, connectivity.TransientFailure)
+	testutils.AwaitNotState(ctx, t, cc, connectivity.TransientFailure)
 	if s := cc.GetState(); s != connectivity.Ready {
 		t.Fatalf("ClientConn is in %v state, want READY", s)
 	}
 
 	ts.SetServingStatus("foo", healthpb.HealthCheckResponse_SERVICE_UNKNOWN)
-	awaitNotState(ctx, t, cc, connectivity.Ready)
+	testutils.AwaitNotState(ctx, t, cc, connectivity.Ready)
 	if s := cc.GetState(); s != connectivity.TransientFailure {
 		t.Fatalf("ClientConn is in %v state, want TRANSIENT FAILURE", s)
 	}
 
 	ts.SetServingStatus("foo", healthpb.HealthCheckResponse_SERVING)
-	awaitNotState(ctx, t, cc, connectivity.TransientFailure)
+	testutils.AwaitNotState(ctx, t, cc, connectivity.TransientFailure)
 	if s := cc.GetState(); s != connectivity.Ready {
 		t.Fatalf("ClientConn is in %v state, want READY", s)
 	}
 
 	ts.SetServingStatus("foo", healthpb.HealthCheckResponse_UNKNOWN)
-	awaitNotState(ctx, t, cc, connectivity.Ready)
+	testutils.AwaitNotState(ctx, t, cc, connectivity.Ready)
 	if s := cc.GetState(); s != connectivity.TransientFailure {
 		t.Fatalf("ClientConn is in %v state, want TRANSIENT FAILURE", s)
 	}
@@ -267,8 +268,8 @@ func (s) TestHealthCheckHealthServerNotRegistered(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
-	awaitNotState(ctx, t, cc, connectivity.Idle)
-	awaitNotState(ctx, t, cc, connectivity.Connecting)
+	testutils.AwaitNotState(ctx, t, cc, connectivity.Idle)
+	testutils.AwaitNotState(ctx, t, cc, connectivity.Connecting)
 	if s := cc.GetState(); s != connectivity.Ready {
 		t.Fatalf("ClientConn is in %v state, want READY", s)
 	}

--- a/test/pickfirst_test.go
+++ b/test/pickfirst_test.go
@@ -56,8 +56,7 @@ func setupPickFirst(t *testing.T, backendCount int, opts ...grpc.DialOption) (*g
 	t.Helper()
 
 	// Initialize channelz. Used to determine pending RPC count.
-	czCleanup := channelz.NewChannelzStorageForTesting()
-	t.Cleanup(func() { czCleanupWrapper(czCleanup, t) })
+	channelz.NewChannelzStorageForTesting()
 
 	r := manual.NewBuilderWithScheme("whatever")
 
@@ -579,8 +578,7 @@ func setupPickFirstWithListenerWrapper(t *testing.T, backendCount int, opts ...g
 	t.Helper()
 
 	// Initialize channelz. Used to determine pending RPC count.
-	czCleanup := channelz.NewChannelzStorageForTesting()
-	t.Cleanup(func() { czCleanupWrapper(czCleanup, t) })
+	channelz.NewChannelzStorageForTesting()
 
 	backends := make([]*stubserver.StubServer, backendCount)
 	addrs := make([]resolver.Address, backendCount)

--- a/test/pickfirst_test.go
+++ b/test/pickfirst_test.go
@@ -55,9 +55,6 @@ const pickFirstServiceConfig = `{"loadBalancingConfig": [{"pick_first":{}}]}`
 func setupPickFirst(t *testing.T, backendCount int, opts ...grpc.DialOption) (*grpc.ClientConn, *manual.Resolver, []*stubserver.StubServer) {
 	t.Helper()
 
-	// Initialize channelz. Used to determine pending RPC count.
-	channelz.NewChannelzStorageForTesting()
-
 	r := manual.NewBuilderWithScheme("whatever")
 
 	backends := make([]*stubserver.StubServer, backendCount)
@@ -576,9 +573,6 @@ func (s) TestPickFirst_ParseConfig_Failure(t *testing.T) {
 // a wrapped listener that the test can use to track accepted connections.
 func setupPickFirstWithListenerWrapper(t *testing.T, backendCount int, opts ...grpc.DialOption) (*grpc.ClientConn, *manual.Resolver, []*stubserver.StubServer, []*testutils.ListenerWrapper) {
 	t.Helper()
-
-	// Initialize channelz. Used to determine pending RPC count.
-	channelz.NewChannelzStorageForTesting()
 
 	backends := make([]*stubserver.StubServer, backendCount)
 	addrs := make([]resolver.Address, backendCount)

--- a/test/pickfirst_test.go
+++ b/test/pickfirst_test.go
@@ -259,7 +259,7 @@ func (s) TestPickFirst_NewAddressWhileBlocking(t *testing.T) {
 	// Send a resolver update with no addresses. This should push the channel into
 	// TransientFailure.
 	r.UpdateState(resolver.State{})
-	awaitState(ctx, t, cc, connectivity.TransientFailure)
+	testutils.AwaitState(ctx, t, cc, connectivity.TransientFailure)
 
 	doneCh := make(chan struct{})
 	client := testgrpc.NewTestServiceClient(cc)
@@ -355,7 +355,7 @@ func (s) TestPickFirst_StickyTransientFailure(t *testing.T) {
 	}
 	t.Cleanup(func() { cc.Close() })
 
-	awaitState(ctx, t, cc, connectivity.TransientFailure)
+	testutils.AwaitState(ctx, t, cc, connectivity.TransientFailure)
 
 	// Spawn a goroutine to ensure that the channel stays in TransientFailure.
 	// The call to cc.WaitForStateChange will return false when the main
@@ -423,7 +423,7 @@ func (s) TestPickFirst_ShuffleAddressList(t *testing.T) {
 	// Send a resolver update with no addresses. This should push the channel
 	// into TransientFailure.
 	r.UpdateState(resolver.State{})
-	awaitState(ctx, t, cc, connectivity.TransientFailure)
+	testutils.AwaitState(ctx, t, cc, connectivity.TransientFailure)
 
 	// Send the same config as last time with shuffling enabled.  Since we are
 	// not connected to backend 0, we should connect to backend 1.
@@ -803,7 +803,7 @@ func (s) TestPickFirst_ResolverError_NoPreviousUpdate(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
-	awaitState(ctx, t, cc, connectivity.TransientFailure)
+	testutils.AwaitState(ctx, t, cc, connectivity.TransientFailure)
 
 	client := testgrpc.NewTestServiceClient(cc)
 	_, err := client.EmptyCall(ctx, &testpb.Empty{})
@@ -888,7 +888,7 @@ func (s) TestPickFirst_ResolverError_WithPreviousUpdate_Connecting(t *testing.T)
 
 	addrs := []resolver.Address{{Addr: lis.Addr().String()}}
 	r.UpdateState(resolver.State{Addresses: addrs})
-	awaitState(ctx, t, cc, connectivity.Connecting)
+	testutils.AwaitState(ctx, t, cc, connectivity.Connecting)
 
 	nrErr := errors.New("error from name resolver")
 	r.ReportError(nrErr)
@@ -905,7 +905,7 @@ func (s) TestPickFirst_ResolverError_WithPreviousUpdate_Connecting(t *testing.T)
 	// Closing this channel leads to closing of the connection by our listener.
 	// gRPC should see this as a connection error.
 	close(waitForConnecting)
-	awaitState(ctx, t, cc, connectivity.TransientFailure)
+	testutils.AwaitState(ctx, t, cc, connectivity.TransientFailure)
 	checkForConnectionError(ctx, t, cc)
 }
 
@@ -945,7 +945,7 @@ func (s) TestPickFirst_ResolverError_WithPreviousUpdate_TransientFailure(t *test
 	r.UpdateState(resolver.State{Addresses: addrs})
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
-	awaitState(ctx, t, cc, connectivity.TransientFailure)
+	testutils.AwaitState(ctx, t, cc, connectivity.TransientFailure)
 	checkForConnectionError(ctx, t, cc)
 
 	// An error from the name resolver should result in RPCs failing with that

--- a/test/roundrobin_test.go
+++ b/test/roundrobin_test.go
@@ -48,8 +48,7 @@ func testRoundRobinBasic(ctx context.Context, t *testing.T, opts ...grpc.DialOpt
 	t.Helper()
 
 	// Initialize channelz. Used to determine pending RPC count.
-	czCleanup := channelz.NewChannelzStorageForTesting()
-	t.Cleanup(func() { czCleanupWrapper(czCleanup, t) })
+	channelz.NewChannelzStorageForTesting()
 
 	r := manual.NewBuilderWithScheme("whatever")
 

--- a/test/roundrobin_test.go
+++ b/test/roundrobin_test.go
@@ -47,9 +47,6 @@ const rrServiceConfig = `{"loadBalancingConfig": [{"round_robin":{}}]}`
 func testRoundRobinBasic(ctx context.Context, t *testing.T, opts ...grpc.DialOption) (*grpc.ClientConn, *manual.Resolver, []*stubserver.StubServer) {
 	t.Helper()
 
-	// Initialize channelz. Used to determine pending RPC count.
-	channelz.NewChannelzStorageForTesting()
-
 	r := manual.NewBuilderWithScheme("whatever")
 
 	const backendCount = 5

--- a/test/roundrobin_test.go
+++ b/test/roundrobin_test.go
@@ -31,6 +31,7 @@ import (
 	"google.golang.org/grpc/internal/channelz"
 	imetadata "google.golang.org/grpc/internal/metadata"
 	"google.golang.org/grpc/internal/stubserver"
+	"google.golang.org/grpc/internal/testutils"
 	rrutil "google.golang.org/grpc/internal/testutils/roundrobin"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/resolver"
@@ -119,7 +120,7 @@ func (s) TestRoundRobin_AddressesRemoved(t *testing.T) {
 	// Send a resolver update with no addresses. This should push the channel into
 	// TransientFailure.
 	r.UpdateState(resolver.State{Addresses: []resolver.Address{}})
-	awaitState(ctx, t, cc, connectivity.TransientFailure)
+	testutils.AwaitState(ctx, t, cc, connectivity.TransientFailure)
 
 	const msgWant = "produced zero addresses"
 	client := testgrpc.NewTestServiceClient(cc)
@@ -141,7 +142,7 @@ func (s) TestRoundRobin_NewAddressWhileBlocking(t *testing.T) {
 	// Send a resolver update with no addresses. This should push the channel into
 	// TransientFailure.
 	r.UpdateState(resolver.State{Addresses: []resolver.Address{}})
-	awaitState(ctx, t, cc, connectivity.TransientFailure)
+	testutils.AwaitState(ctx, t, cc, connectivity.TransientFailure)
 
 	client := testgrpc.NewTestServiceClient(cc)
 	doneCh := make(chan struct{})
@@ -221,7 +222,7 @@ func (s) TestRoundRobin_AllServersDown(t *testing.T) {
 		b.Stop()
 	}
 
-	awaitState(ctx, t, cc, connectivity.TransientFailure)
+	testutils.AwaitState(ctx, t, cc, connectivity.TransientFailure)
 
 	// Failfast RPCs should fail with Unavailable.
 	client := testgrpc.NewTestServiceClient(cc)

--- a/test/subconn_test.go
+++ b/test/subconn_test.go
@@ -30,6 +30,7 @@ import (
 	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/internal/balancer/stub"
 	"google.golang.org/grpc/internal/stubserver"
+	"google.golang.org/grpc/internal/testutils"
 	testpb "google.golang.org/grpc/interop/grpc_testing"
 	"google.golang.org/grpc/resolver"
 )
@@ -115,7 +116,7 @@ func (s) TestSubConnEmpty(t *testing.T) {
 
 	t.Log("Removing addresses from resolver and SubConn")
 	ss.R.UpdateState(resolver.State{Addresses: []resolver.Address{}})
-	awaitState(ctx, t, ss.CC, connectivity.TransientFailure)
+	testutils.AwaitState(ctx, t, ss.CC, connectivity.TransientFailure)
 
 	t.Log("Re-adding addresses to resolver and SubConn")
 	ss.R.UpdateState(resolver.State{Addresses: []resolver.Address{{Addr: ss.Address}}})

--- a/xds/internal/balancer/cdsbalancer/cdsbalancer_security_test.go
+++ b/xds/internal/balancer/cdsbalancer/cdsbalancer_security_test.go
@@ -388,11 +388,7 @@ func (s) TestSecurityConfigNotFoundInBootstrap(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	for state := cc.GetState(); state != connectivity.TransientFailure; state = cc.GetState() {
-		if !cc.WaitForStateChange(ctx, state) {
-			t.Fatal("Timed out waiting for channel to enter TRANSIENT_FAILURE")
-		}
-	}
+	testutils.AwaitState(ctx, t, cc, connectivity.TransientFailure)
 }
 
 // A ceritificate provider builder that returns a nil Provider from the starter
@@ -456,11 +452,7 @@ func (s) TestCertproviderStoreError(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	for state := cc.GetState(); state != connectivity.TransientFailure; state = cc.GetState() {
-		if !cc.WaitForStateChange(ctx, state) {
-			t.Fatal("Timed out waiting for channel to enter TRANSIENT_FAILURE")
-		}
-	}
+	testutils.AwaitState(ctx, t, cc, connectivity.TransientFailure)
 }
 
 // Tests the case where the cds LB policy receives security configuration as
@@ -545,11 +537,7 @@ func (s) TestSecurityConfigUpdate_BadToGood(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	for state := cc.GetState(); state != connectivity.TransientFailure; state = cc.GetState() {
-		if !cc.WaitForStateChange(ctx, state) {
-			t.Fatal("Timed out waiting for channel to enter TRANSIENT_FAILURE")
-		}
-	}
+	testutils.AwaitState(ctx, t, cc, connectivity.TransientFailure)
 
 	// Update the management server with a Cluster resource that contains a
 	// certificate provider instance that is present in the bootstrap

--- a/xds/internal/balancer/cdsbalancer/cdsbalancer_test.go
+++ b/xds/internal/balancer/cdsbalancer/cdsbalancer_test.go
@@ -665,12 +665,7 @@ func (s) TestClusterUpdate_Failure(t *testing.T) {
 		t.Fatal("Watch for cluster resource is cancelled when not expected to")
 	}
 
-	// Ensure that the ClientConn moves to TransientFailure.
-	for state := cc.GetState(); state != connectivity.TransientFailure; state = cc.GetState() {
-		if !cc.WaitForStateChange(ctx, state) {
-			t.Fatalf("Timed out waiting for state change. got %v; want %v", state, connectivity.TransientFailure)
-		}
-	}
+	testutils.AwaitState(ctx, t, cc, connectivity.TransientFailure)
 
 	// Ensure that the NACK error is propagated to the RPC caller.
 	const wantClusterNACKErr = "unsupported config_source_specifier"
@@ -758,12 +753,8 @@ func (s) TestClusterUpdate_Failure(t *testing.T) {
 		t.Fatal("Watch for cluster resource is cancelled when not expected to")
 	}
 
-	// Ensure that the ClientConn moves to TransientFailure.
-	for state := cc.GetState(); state != connectivity.TransientFailure; state = cc.GetState() {
-		if !cc.WaitForStateChange(ctx, state) {
-			t.Fatalf("Timed out waiting for state change. got %v; want %v", state, connectivity.TransientFailure)
-		}
-	}
+	testutils.AwaitState(ctx, t, cc, connectivity.TransientFailure)
+
 	// Ensure RPC fails with Unavailable. The actual error message depends on
 	// the picker returned from the priority LB policy, and therefore not
 	// checking for it here.
@@ -801,12 +792,7 @@ func (s) TestResolverError(t *testing.T) {
 	resolverErr := errors.New("resolver-error-not-a-resource-not-found-error")
 	r.ReportError(resolverErr)
 
-	// Ensure that the ClientConn moves to TransientFailure.
-	for state := cc.GetState(); state != connectivity.TransientFailure; state = cc.GetState() {
-		if !cc.WaitForStateChange(ctx, state) {
-			t.Fatalf("Timed out waiting for state change. got %v; want %v", state, connectivity.TransientFailure)
-		}
-	}
+	testutils.AwaitState(ctx, t, cc, connectivity.TransientFailure)
 
 	// Drain the resolver error channel.
 	select {
@@ -903,12 +889,7 @@ func (s) TestResolverError(t *testing.T) {
 		t.Fatal("Timeout when waiting for resolver error to be pushed to the child policy")
 	}
 
-	// Ensure that the ClientConn moves to TransientFailure.
-	for state := cc.GetState(); state != connectivity.TransientFailure; state = cc.GetState() {
-		if !cc.WaitForStateChange(ctx, state) {
-			t.Fatalf("Timed out waiting for state change. got %v; want %v", state, connectivity.TransientFailure)
-		}
-	}
+	testutils.AwaitState(ctx, t, cc, connectivity.TransientFailure)
 
 	// Ensure RPC fails with Unavailable. The actual error message depends on
 	// the picker returned from the priority LB policy, and therefore not

--- a/xds/internal/balancer/clusterresolver/e2e_test/balancer_test.go
+++ b/xds/internal/balancer/clusterresolver/e2e_test/balancer_test.go
@@ -277,12 +277,7 @@ func (s) TestErrorFromParentLB_ResourceNotFound(t *testing.T) {
 		t.Fatalf("RPCs did not fail after removal of Cluster resource")
 	}
 
-	// Ensure that the ClientConn moves to TransientFailure.
-	for state := cc.GetState(); state != connectivity.TransientFailure; state = cc.GetState() {
-		if !cc.WaitForStateChange(ctx, state) {
-			t.Fatalf("Timed out waiting for state change. got %v; want %v", state, connectivity.TransientFailure)
-		}
-	}
+	testutils.AwaitState(ctx, t, cc, connectivity.TransientFailure)
 
 	// Configure cluster and endpoints resources in the management server.
 	resources = e2e.UpdateOptions{


### PR DESCRIPTION
Also: pull out some shared testing code to make it easier to use in other packages than `test/`.

Before:

```
$ time go test -count=1 ./...
<snip>
real	0m47.221s
user	1m31.381s
sys	0m30.061s
```

After:

```
$ time go test -count=1 ./...
<snip>
real	0m38.994s
user	1m30.279s
sys	0m29.964s
```

For reference:

```
$ go test -count=1 ./internal/idle
ok  	google.golang.org/grpc/internal/idle	12.739s
```

RELEASE NOTES: none