### PR TITLE
attributes: print typed nil values instead of panic

### DIFF
--- a/attributes/attributes.go
+++ b/attributes/attributes.go
@@ -27,6 +27,7 @@ package attributes
 
 import (
 	"fmt"
+	"reflect"
 	"strings"
 )
 
@@ -121,8 +122,26 @@ func (a *Attributes) String() string {
 	return sb.String()
 }
 
-func str(x any) string {
-	if v, ok := x.(fmt.Stringer); ok {
+func str(x any) (s string) {
+	defer func() {
+		if r := recover(); r != nil {
+			// If it panics with a nil pointer, just say "<nil>". The likeliest causes are a
+			// [fmt.Stringer] that fails to guard against nil or a nil pointer for a
+			// value receiver, and in either case, "<nil>" is a nice result.
+			//
+			// Adapted from the code in fmt/print.go.
+			if v := reflect.ValueOf(x); v.Kind() == reflect.Pointer && v.IsNil() {
+				s = "<nil>"
+				return
+			}
+
+			// The panic was likely not caused by fmt.Stringer.
+			panic(r)
+		}
+	}()
+	if x == nil { // NOTE: typed nils will not be caught by this check
+		return "<nil>"
+	} else if v, ok := x.(fmt.Stringer); ok {
 		return v.String()
 	} else if v, ok := x.(string); ok {
 		return v

--- a/attributes/attributes.go
+++ b/attributes/attributes.go
@@ -125,26 +125,10 @@ func (a *Attributes) String() string {
 const nilAngleString = "<nil>"
 
 func str(x any) (s string) {
-	defer func() {
-		if r := recover(); r != nil {
-			// If it panics with a nil pointer, just say "<nil>". The likeliest causes are a
-			// [fmt.Stringer] that fails to guard against nil or a nil pointer for a
-			// value receiver, and in either case, "<nil>" is a nice result.
-			//
-			// Adapted from the code in fmt/print.go.
-			if v := reflect.ValueOf(x); v.Kind() == reflect.Pointer && v.IsNil() {
-				s = nilAngleString
-				return
-			}
-
-			// The panic was likely not caused by fmt.Stringer.
-			panic(r)
-		}
-	}()
 	if x == nil { // NOTE: typed nils will not be caught by this check
 		return nilAngleString
 	} else if v, ok := x.(fmt.Stringer); ok {
-		return v.String()
+		return fmt.Sprint(v)
 	} else if v, ok := x.(string); ok {
 		return v
 	}

--- a/attributes/attributes.go
+++ b/attributes/attributes.go
@@ -27,7 +27,6 @@ package attributes
 
 import (
 	"fmt"
-	"reflect"
 	"strings"
 )
 
@@ -128,54 +127,7 @@ func str(x any) (s string) {
 	} else if v, ok := x.(string); ok {
 		return v
 	}
-	value := reflect.ValueOf(x)
-	switch value.Kind() {
-	case reflect.Chan, reflect.Func, reflect.Map, reflect.Pointer, reflect.Slice, reflect.UnsafePointer:
-		return fmt.Sprintf("<%p>", x)
-	default:
-		// This will call badVerb to print as "<%p>", but without leading "%!(" and tailing ")"
-		return badVerb(x, value)
-	}
-}
-
-const nilAngleString = "<nil>"
-
-// badVerb is like fmt.Sprintf("%p", arg), but with
-// leading "%!verb(" replaced by "<" and tailing ")" replaced by ">".
-// If an invalid argument is given for a '%p', such as providing
-// an int to %p, the generated string will contain a
-// description of the problem, as in these examples:
-//
-// # our style
-//
-//	Wrong type or unknown verb: <type=value>
-//		Printf("%p", 1):        <int=1>
-//
-// # fmt style as `fmt.Sprintf("%p", arg)`
-//
-//	Wrong type or unknown verb: %!verb(type=value)
-//		Printf("%p", 1):        %!d(int=1)
-//
-// Adapted from the code in fmt/print.go.
-func badVerb(arg any, value reflect.Value) string {
-	var buf strings.Builder
-	switch {
-	case arg != nil:
-		buf.WriteByte('<')
-		buf.WriteString(reflect.TypeOf(arg).String())
-		buf.WriteByte('=')
-		_, _ = fmt.Fprintf(&buf, "%v", arg)
-		buf.WriteByte('>')
-	case value.IsValid():
-		buf.WriteByte('<')
-		buf.WriteString(value.Type().String())
-		buf.WriteByte('=')
-		_, _ = fmt.Fprintf(&buf, "%v", 0)
-		buf.WriteByte('>')
-	default:
-		buf.WriteString(nilAngleString)
-	}
-	return buf.String()
+	return fmt.Sprintf("%#v", x)
 }
 
 // MarshalJSON helps implement the json.Marshaler interface, thereby rendering

--- a/attributes/attributes.go
+++ b/attributes/attributes.go
@@ -122,12 +122,8 @@ func (a *Attributes) String() string {
 	return sb.String()
 }
 
-const nilAngleString = "<nil>"
-
 func str(x any) (s string) {
-	if x == nil { // NOTE: typed nils will not be caught by this check
-		return nilAngleString
-	} else if v, ok := x.(fmt.Stringer); ok {
+	if v, ok := x.(fmt.Stringer); ok {
 		return fmt.Sprint(v)
 	} else if v, ok := x.(string); ok {
 		return v
@@ -141,6 +137,8 @@ func str(x any) (s string) {
 		return badVerb(x, value)
 	}
 }
+
+const nilAngleString = "<nil>"
 
 // badVerb is like fmt.Sprintf("%p", arg), but with
 // leading "%!verb(" replaced by "<" and tailing ")" replaced by ">".

--- a/attributes/attributes_test.go
+++ b/attributes/attributes_test.go
@@ -34,6 +34,14 @@ func (s stringVal) Equal(o any) bool {
 	return ok && s.s == os.s
 }
 
+type stringerVal struct {
+	s string
+}
+
+func (s stringerVal) String() string {
+	return s.s
+}
+
 func ExampleAttributes() {
 	type keyOne struct{}
 	type keyTwo struct{}
@@ -55,6 +63,33 @@ func ExampleAttributes_WithValue() {
 	// Output:
 	// Key one: 1
 	// Key two: {two}
+}
+
+func ExampleAttributes_String() {
+	type key struct{}
+	var typedNil *stringerVal
+	a1 := attributes.New(key{}, typedNil)            // typed nil implements [fmt.Stringer]
+	a2 := attributes.New(key{}, (*stringerVal)(nil)) // typed nil implements [fmt.Stringer]
+	a3 := attributes.New(key{}, (*stringVal)(nil))   // typed nil not implements [fmt.Stringer]
+	a4 := attributes.New(key{}, nil)                 // untyped nil
+	a5 := attributes.New(key{}, 1)
+	a6 := attributes.New(key{}, stringerVal{s: "two"})
+	a7 := attributes.New(key{}, stringVal{s: "two"})
+	fmt.Println("a1:", a1.String())
+	fmt.Println("a2:", a2.String())
+	fmt.Println("a3:", a3.String())
+	fmt.Println("a4:", a4.String())
+	fmt.Println("a5:", a5.String())
+	fmt.Println("a6:", a6.String())
+	fmt.Println("a7:", a7.String())
+	// Output:
+	// a1: {"<%!p(attributes_test.key={})>": "<nil>" }
+	// a2: {"<%!p(attributes_test.key={})>": "<nil>" }
+	// a3: {"<%!p(attributes_test.key={})>": "<0x0>" }
+	// a4: {"<%!p(attributes_test.key={})>": "<nil>" }
+	// a5: {"<%!p(attributes_test.key={})>": "<%!p(int=1)>" }
+	// a6: {"<%!p(attributes_test.key={})>": "two" }
+	// a7: {"<%!p(attributes_test.key={})>": "<%!p(attributes_test.stringVal={two})>" }
 }
 
 // Test that two attributes with the same content are Equal.

--- a/attributes/attributes_test.go
+++ b/attributes/attributes_test.go
@@ -75,6 +75,7 @@ func ExampleAttributes_String() {
 	a5 := attributes.New(key{}, 1)
 	a6 := attributes.New(key{}, stringerVal{s: "two"})
 	a7 := attributes.New(key{}, stringVal{s: "two"})
+	a8 := attributes.New(1, true)
 	fmt.Println("a1:", a1.String())
 	fmt.Println("a2:", a2.String())
 	fmt.Println("a3:", a3.String())
@@ -82,14 +83,16 @@ func ExampleAttributes_String() {
 	fmt.Println("a5:", a5.String())
 	fmt.Println("a6:", a6.String())
 	fmt.Println("a7:", a7.String())
+	fmt.Println("a8:", a8.String())
 	// Output:
-	// a1: {"<%!p(attributes_test.key={})>": "<nil>" }
-	// a2: {"<%!p(attributes_test.key={})>": "<nil>" }
-	// a3: {"<%!p(attributes_test.key={})>": "<0x0>" }
-	// a4: {"<%!p(attributes_test.key={})>": "<nil>" }
-	// a5: {"<%!p(attributes_test.key={})>": "<%!p(int=1)>" }
-	// a6: {"<%!p(attributes_test.key={})>": "two" }
-	// a7: {"<%!p(attributes_test.key={})>": "<%!p(attributes_test.stringVal={two})>" }
+	// a1: {"<attributes_test.key={}>": "<nil>" }
+	// a2: {"<attributes_test.key={}>": "<nil>" }
+	// a3: {"<attributes_test.key={}>": "<0x0>" }
+	// a4: {"<attributes_test.key={}>": "<nil>" }
+	// a5: {"<attributes_test.key={}>": "<int=1>" }
+	// a6: {"<attributes_test.key={}>": "two" }
+	// a7: {"<attributes_test.key={}>": "<attributes_test.stringVal={two}>" }
+	// a8: {"<int=1>": "<bool=true>" }
 }
 
 // Test that two attributes with the same content are Equal.

--- a/attributes/attributes_test.go
+++ b/attributes/attributes_test.go
@@ -85,14 +85,14 @@ func ExampleAttributes_String() {
 	fmt.Println("a7:", a7.String())
 	fmt.Println("a8:", a8.String())
 	// Output:
-	// a1: {"<attributes_test.key={}>": "<nil>" }
-	// a2: {"<attributes_test.key={}>": "<nil>" }
-	// a3: {"<attributes_test.key={}>": "<0x0>" }
-	// a4: {"<attributes_test.key={}>": "<nil>" }
-	// a5: {"<attributes_test.key={}>": "<int=1>" }
-	// a6: {"<attributes_test.key={}>": "two" }
-	// a7: {"<attributes_test.key={}>": "<attributes_test.stringVal={two}>" }
-	// a8: {"<int=1>": "<bool=true>" }
+	// a1: {"attributes_test.key{}": "<nil>" }
+	// a2: {"attributes_test.key{}": "<nil>" }
+	// a3: {"attributes_test.key{}": "(*attributes_test.stringVal)(nil)" }
+	// a4: {"attributes_test.key{}": "<nil>" }
+	// a5: {"attributes_test.key{}": "1" }
+	// a6: {"attributes_test.key{}": "two" }
+	// a7: {"attributes_test.key{}": "attributes_test.stringVal{s:\"two\"}" }
+	// a8: {"1": "true" }
 }
 
 // Test that two attributes with the same content are Equal.

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -142,3 +142,25 @@ func (s) TestResolverAddressesToEndpoints(t *testing.T) {
 		t.Fatalf("timed out waiting for endpoints")
 	}
 }
+
+// TestResolverAddressesWithTypedNilAttribute ensures no panic if typed-nil attributes within resolver.State.Addresses
+func (s) TestResolverAddressesWithTypedNilAttribute(t *testing.T) {
+	const scheme = "testresolveraddresseswithtypednilattribute"
+	r := manual.NewBuilderWithScheme(scheme)
+	resolver.Register(r)
+
+	addrAttr := attributes.New("typed_nil", (*stringerVal)(nil))
+	r.InitialState(resolver.State{Addresses: []resolver.Address{{Addr: "addr1", Attributes: addrAttr}}})
+
+	cc, err := Dial(r.Scheme()+":///",
+		WithTransportCredentials(insecure.NewCredentials()),
+		WithResolvers(r))
+	if err != nil {
+		t.Fatalf("Unexpected error dialing: %v", err)
+	}
+	defer cc.Close()
+}
+
+type stringerVal struct{ s string }
+
+func (s stringerVal) String() string { return s.s }

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -145,16 +145,13 @@ func (s) TestResolverAddressesToEndpoints(t *testing.T) {
 
 // TestResolverAddressesWithTypedNilAttribute ensures no panic if typed-nil attributes within resolver.State.Addresses
 func (s) TestResolverAddressesWithTypedNilAttribute(t *testing.T) {
-	const scheme = "testresolveraddresseswithtypednilattribute"
-	r := manual.NewBuilderWithScheme(scheme)
+	r := manual.NewBuilderWithScheme(t.Name())
 	resolver.Register(r)
 
 	addrAttr := attributes.New("typed_nil", (*stringerVal)(nil))
 	r.InitialState(resolver.State{Addresses: []resolver.Address{{Addr: "addr1", Attributes: addrAttr}}})
 
-	cc, err := Dial(r.Scheme()+":///",
-		WithTransportCredentials(insecure.NewCredentials()),
-		WithResolvers(r))
+	cc, err := Dial(r.Scheme()+":///", WithTransportCredentials(insecure.NewCredentials()), WithResolvers(r))
 	if err != nil {
 		t.Fatalf("Unexpected error dialing: %v", err)
 	}

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -143,7 +143,8 @@ func (s) TestResolverAddressesToEndpoints(t *testing.T) {
 	}
 }
 
-// TestResolverAddressesWithTypedNilAttribute ensures no panic if typed-nil attributes within resolver.State.Addresses
+// Test ensures that there is no panic if the attributes within
+// resolver.State.Addresses contains a typed-nil value.
 func (s) TestResolverAddressesWithTypedNilAttribute(t *testing.T) {
 	r := manual.NewBuilderWithScheme(t.Name())
 	resolver.Register(r)


### PR DESCRIPTION
This fixes a panic caused by typed nil, introduced in https://github.com/grpc/grpc-go/pull/6224. 
`String()` should catch panics when formatting by using the `fmt` package. 

RELEASE NOTES: none