### PR TITLE
grpc: re-enable channel idleness by default

### DIFF
--- a/dialoptions.go
+++ b/dialoptions.go
@@ -644,6 +644,7 @@ func defaultDialOptions() dialOptions {
 			UseProxy:        true,
 		},
 		recvBufferPool: nopBufferPool{},
+		idleTimeout:    30 * time.Minute,
 	}
 }
 
@@ -680,8 +681,8 @@ func WithResolvers(rs ...resolver.Builder) DialOption {
 // channel will exit idle mode when the Connect() method is called or when an
 // RPC is initiated.
 //
-// By default this feature is disabled, which can also be explicitly configured
-// by passing zero to this function.
+// A default timeout of 30 min will be used if this dial option is not set at
+// dial time and idleness can be disabled by passing a timeout of zero.
 //
 // # Experimental
 //

--- a/dialoptions.go
+++ b/dialoptions.go
@@ -681,8 +681,8 @@ func WithResolvers(rs ...resolver.Builder) DialOption {
 // channel will exit idle mode when the Connect() method is called or when an
 // RPC is initiated.
 //
-// A default timeout of 30 min will be used if this dial option is not set at
-// dial time and idleness can be disabled by passing a timeout of zero.
+// A default timeout of 30 minutes will be used if this dial option is not set
+// at dial time and idleness can be disabled by passing a timeout of zero.
 //
 // # Experimental
 //


### PR DESCRIPTION
The plan was always to enable this by default. But we hit a bug right after making the changes, and had to disable it. We have since fixed the underlying bug.

Fixes https://github.com/grpc/grpc-go/issues/6559

RELEASE NOTES:
- grpc: channel idleness enabled by default with an `idle_timeout` of `30m`