### PR TITLE
balancer/leastrequest: Cache atomic load and also add concurrent rpc test

### DIFF
--- a/balancer/leastrequest/balancer_test.go
+++ b/balancer/leastrequest/balancer_test.go
@@ -502,7 +502,9 @@ func (s) TestConcurrentRPCs(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			testServiceClient.EmptyCall(ctx, &testpb.Empty{})
+			for j := 0; j < 5; j++ {
+				testServiceClient.EmptyCall(ctx, &testpb.Empty{})
+			}
 		}()
 	}
 	wg.Wait()

--- a/balancer/leastrequest/leastrequest.go
+++ b/balancer/leastrequest/leastrequest.go
@@ -155,15 +155,18 @@ type picker struct {
 
 func (p *picker) Pick(balancer.PickInfo) (balancer.PickResult, error) {
 	var pickedSC *scWithRPCCount
+	var pickedSCNumRPCs int32
 	for i := 0; i < int(p.choiceCount); i++ {
 		index := grpcranduint32() % uint32(len(p.subConns))
 		sc := p.subConns[index]
 		if pickedSC == nil {
 			pickedSC = &sc
+			pickedSCNumRPCs = pickedSC.numRPCs.Load()
 			continue
 		}
-		if sc.numRPCs.Load() < pickedSC.numRPCs.Load() {
+		if sc.numRPCs.Load() < pickedSCNumRPCs {
 			pickedSC = &sc
+			pickedSCNumRPCs = pickedSC.numRPCs.Load()
 		}
 	}
 	// "The counter for a subchannel should be atomically incremented by one

--- a/balancer/leastrequest/leastrequest.go
+++ b/balancer/leastrequest/leastrequest.go
@@ -164,9 +164,10 @@ func (p *picker) Pick(balancer.PickInfo) (balancer.PickResult, error) {
 			pickedSCNumRPCs = pickedSC.numRPCs.Load()
 			continue
 		}
-		if sc.numRPCs.Load() < pickedSCNumRPCs {
+		scNumRPCs := sc.numRPCs.Load()
+		if scNumRPCs < pickedSCNumRPCs {
 			pickedSC = &sc
-			pickedSCNumRPCs = pickedSC.numRPCs.Load()
+			pickedSCNumRPCs = scNumRPCs
 		}
 	}
 	// "The counter for a subchannel should be atomically incremented by one

--- a/balancer/leastrequest/leastrequest.go
+++ b/balancer/leastrequest/leastrequest.go
@@ -159,15 +159,10 @@ func (p *picker) Pick(balancer.PickInfo) (balancer.PickResult, error) {
 	for i := 0; i < int(p.choiceCount); i++ {
 		index := grpcranduint32() % uint32(len(p.subConns))
 		sc := p.subConns[index]
-		if pickedSC == nil {
+		n := sc.numRPCs.Load()
+		if pickedSC == nil || n < pickedSCNumRPCs {
 			pickedSC = &sc
-			pickedSCNumRPCs = pickedSC.numRPCs.Load()
-			continue
-		}
-		scNumRPCs := sc.numRPCs.Load()
-		if scNumRPCs < pickedSCNumRPCs {
-			pickedSC = &sc
-			pickedSCNumRPCs = scNumRPCs
+			pickedSCNumRPCs = n
 		}
 	}
 	// "The counter for a subchannel should be atomically incremented by one


### PR DESCRIPTION
This PR caches the atomic load of the picked SubConn in the picker algorithm in least request picker for efficiency reasons, rather than doing it per iteration. It also adds an e2e test which performs concurrent RPCs to check for a race condition.

Continuation of #6587. Needs to be backported to 1.58 alongside that bug fix PR.

RELEASE NOTES: N/A