### PR TITLE
rpc_util: added a byte slice return to recvBufferPool

### DIFF
--- a/server.go
+++ b/server.go
@@ -1311,7 +1311,6 @@ func (s *Server) processUnaryRPC(ctx context.Context, t transport.ServerTranspor
 		}
 		return err
 	}
-
 	defer s.opts.recvBufferPool.Put(&d)
 
 	if channelz.IsOn() {

--- a/server.go
+++ b/server.go
@@ -1311,6 +1311,9 @@ func (s *Server) processUnaryRPC(ctx context.Context, t transport.ServerTranspor
 		}
 		return err
 	}
+
+	defer s.opts.recvBufferPool.Put(&d)
+
 	if channelz.IsOn() {
 		t.IncrMsgRecv()
 	}


### PR DESCRIPTION
this PR adds the logic of adding the allocated buffer back to the buffer pool. See more details https://github.com/grpc/grpc-go/issues/6578

RELEASE NOTES: none