### PR TITLE
Reuse server send buffers

### DIFF
--- a/codec.go
+++ b/codec.go
@@ -31,8 +31,12 @@ type baseCodec interface {
 	Unmarshal(data []byte, v any) error
 }
 
+type appendCodec interface {
+	MarshalAppend(buf []byte, v interface{}) ([]byte, error)
+}
+
 var _ baseCodec = Codec(nil)
-var _ baseCodec = encoding.Codec(nil)
+var _ baseCodec = encoding.AppendCodec(nil)
 
 // Codec defines the interface gRPC uses to encode and decode messages.
 // Note that implementations of this interface must be thread safe;

--- a/dialoptions.go
+++ b/dialoptions.go
@@ -79,6 +79,7 @@ type dialOptions struct {
 	resolvers                   []resolver.Builder
 	idleTimeout                 time.Duration
 	recvBufferPool              SharedBufferPool
+	sendBufferPool              SendBufferPool
 }
 
 // DialOption configures how we set up the connection.
@@ -644,6 +645,7 @@ func defaultDialOptions() dialOptions {
 			UseProxy:        true,
 		},
 		recvBufferPool: nopBufferPool{},
+		sendBufferPool: NewSendBufferPool(),
 		idleTimeout:    30 * time.Minute,
 	}
 }
@@ -712,5 +714,11 @@ func WithIdleTimeout(d time.Duration) DialOption {
 func WithRecvBufferPool(bufferPool SharedBufferPool) DialOption {
 	return newFuncDialOption(func(o *dialOptions) {
 		o.recvBufferPool = bufferPool
+	})
+}
+
+func WithSendBufferPool(bufferPool SendBufferPool) DialOption {
+	return newFuncDialOption(func(o *dialOptions) {
+		o.sendBufferPool = bufferPool
 	})
 }

--- a/encoding/encoding.go
+++ b/encoding/encoding.go
@@ -99,6 +99,14 @@ type Codec interface {
 	Name() string
 }
 
+// AppendCodec is an extension of the Codec interface which allows marshaling
+// to a given buffer instead of allocating a new one.
+type AppendCodec interface {
+	Codec
+	// MarshalAppend writes the wire format of v to the given buffer.
+	MarshalAppend(buf []byte, v interface{}) ([]byte, error)
+}
+
 var registeredCodecs = make(map[string]Codec)
 
 // RegisterCodec registers the provided Codec for use with all gRPC clients and

--- a/encoding/proto/proto.go
+++ b/encoding/proto/proto.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"google.golang.org/grpc/encoding"
+	protoV2 "google.golang.org/protobuf/proto"
 )
 
 // Name is the name registered for the proto compressor.
@@ -43,6 +44,19 @@ func (codec) Marshal(v any) ([]byte, error) {
 		return nil, fmt.Errorf("failed to marshal, message is %T, want proto.Message", v)
 	}
 	return proto.Marshal(vv)
+}
+
+func (c codec) MarshalAppend(buf []byte, v any) ([]byte, error) {
+	vv, ok := v.(proto.Message)
+	if !ok {
+		return nil, fmt.Errorf("failed to marshal, message is %T, want proto.Message", v)
+	}
+
+	nbuf, err := protoV2.MarshalOptions{}.MarshalAppend(buf, proto.MessageV2(vv))
+	if err != nil {
+		return buf, err
+	}
+	return nbuf, nil
 }
 
 func (codec) Unmarshal(data []byte, v any) error {

--- a/internal/transport/http2_server.go
+++ b/internal/transport/http2_server.go
@@ -1114,6 +1114,7 @@ func (t *http2Server) Write(s *Stream, hdr []byte, data []byte, opts *Options) e
 		h:           hdr,
 		d:           data,
 		onEachWrite: t.setResetPingStrikes,
+		onSent:      opts.OnSent,
 	}
 	if err := s.wq.get(int32(len(hdr) + len(data))); err != nil {
 		return t.streamContextErr(s)

--- a/internal/transport/transport.go
+++ b/internal/transport/transport.go
@@ -607,6 +607,10 @@ type Options struct {
 	// Last indicates whether this write is the last piece for
 	// this stream.
 	Last bool
+	// OnSent is invoked once the underlying message has successfully been
+	// sent. Note that this is not invoked if the message was not sent
+	// successfully.
+	OnSent func()
 }
 
 // CallHdr carries the information of a particular RPC.

--- a/preloader.go
+++ b/preloader.go
@@ -53,15 +53,22 @@ func (p *PreparedMsg) Encode(s Stream, msg any) error {
 	}
 
 	// prepare the msg
-	data, err := encode(rpcInfo.preloaderInfo.codec, msg)
+	data, err := encode(rpcInfo.preloaderInfo.codec, msg, nil)
 	if err != nil {
 		return err
 	}
 	p.encodedData = data
-	compData, err := compress(data, rpcInfo.preloaderInfo.cp, rpcInfo.preloaderInfo.comp)
-	if err != nil {
-		return err
+
+	var compData []byte
+	if shouldCompress(rpcInfo.preloaderInfo.cp, rpcInfo.preloaderInfo.comp) {
+		compData, err = compress(data, rpcInfo.preloaderInfo.cp, rpcInfo.preloaderInfo.comp, nil)
+		if err != nil {
+			return err
+		}
+	} else {
+		compData = data
 	}
+
 	p.hdr, p.payload = msgHeader(data, compData)
 	return nil
 }

--- a/rpc_util_test.go
+++ b/rpc_util_test.go
@@ -113,7 +113,7 @@ func (s) TestEncode(t *testing.T) {
 	}{
 		{nil, []byte{0, 0, 0, 0, 0}, []byte{}, nil},
 	} {
-		data, err := encode(encoding.GetCodec(protoenc.Name), test.msg)
+		data, err := encode(encoding.GetCodec(protoenc.Name), test.msg, nil)
 		if err != test.err || !bytes.Equal(data, test.data) {
 			t.Errorf("encode(_, %v) = %v, %v; want %v, %v", test.msg, data, err, test.data, test.err)
 			continue
@@ -196,12 +196,12 @@ func (s) TestToRPCErr(t *testing.T) {
 func bmEncode(b *testing.B, mSize int) {
 	cdc := encoding.GetCodec(protoenc.Name)
 	msg := &perfpb.Buffer{Body: make([]byte, mSize)}
-	encodeData, _ := encode(cdc, msg)
+	encodeData, _ := encode(cdc, msg, nil)
 	encodedSz := int64(len(encodeData))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		encode(cdc, msg)
+		encode(cdc, msg, nil)
 	}
 	b.SetBytes(encodedSz)
 }

--- a/send_buffer_pool.go
+++ b/send_buffer_pool.go
@@ -1,0 +1,44 @@
+package grpc
+
+import "sync"
+
+type SendBufferPool interface {
+	Get() []byte
+	Put([]byte)
+}
+
+type sendBufferPool struct {
+	pool sync.Pool
+}
+
+const defaultSendBufferPoolBufSize = 1 << 10 /* 1kb */
+
+func NewSendBufferPool() SendBufferPool {
+	return &sendBufferPool{
+		pool: sync.Pool{
+			New: func() interface{} {
+				return make([]byte, 0, defaultSendBufferPoolBufSize)
+			},
+		},
+	}
+}
+
+func (p *sendBufferPool) Get() []byte {
+	return p.pool.Get().([]byte)
+}
+
+func (p *sendBufferPool) Put(buf []byte) {
+	// TODO(PapaCharlie): uncomment after 1.21 migration
+	// clear(b[:cap(b)])
+	buf = buf[:0]
+	p.pool.Put(buf)
+}
+
+type nopSendBufferPool struct{}
+
+func (n nopSendBufferPool) Get() []byte {
+	return nil
+}
+
+func (n nopSendBufferPool) Put([]byte) {
+}


### PR DESCRIPTION
Under significant load, the server concurrently allocates a significant amount of buffers to serialize and compress the responses before sending them over the wire. This causes significant GC pressure and can cause large spikes in memory allocations.

Tests are benchmark results are pending.