### PR TITLE
xds: fix hash policy header to skip bin headers and use extra metadata

### DIFF
--- a/xds/internal/resolver/serviceconfig.go
+++ b/xds/internal/resolver/serviceconfig.go
@@ -247,7 +247,8 @@ func (cs *configSelector) generateHash(rpcInfo iresolver.RPCInfo, hashPolicies [
 			}
 			values := emd.Get(policy.HeaderName)
 			if len(values) == 0 {
-				// Extra metadata takes precedence over the user's metadata.
+				// Extra metadata (e.g. the "content-type" header) takes
+				// precedence over the user's metadata.
 				values = md.Get(policy.HeaderName)
 				if len(values) == 0 {
 					// If the header isn't present at all, this policy is a no-op.

--- a/xds/internal/resolver/serviceconfig.go
+++ b/xds/internal/resolver/serviceconfig.go
@@ -31,6 +31,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/internal/envconfig"
 	"google.golang.org/grpc/internal/grpcrand"
+	"google.golang.org/grpc/internal/grpcutil"
 	iresolver "google.golang.org/grpc/internal/resolver"
 	"google.golang.org/grpc/internal/serviceconfig"
 	"google.golang.org/grpc/internal/wrr"
@@ -229,19 +230,29 @@ func retryConfigToPolicy(config *xdsresource.RetryConfig) *serviceconfig.RetryPo
 func (cs *configSelector) generateHash(rpcInfo iresolver.RPCInfo, hashPolicies []*xdsresource.HashPolicy) uint64 {
 	var hash uint64
 	var generatedHash bool
+	var md, emd metadata.MD
+	var mdRead bool
 	for _, policy := range hashPolicies {
 		var policyHash uint64
 		var generatedPolicyHash bool
 		switch policy.HashPolicyType {
 		case xdsresource.HashPolicyTypeHeader:
-			md, ok := metadata.FromOutgoingContext(rpcInfo.Context)
-			if !ok {
+			if strings.HasSuffix(policy.HeaderName, "-bin") {
 				continue
 			}
-			values := md.Get(policy.HeaderName)
-			// If the header isn't present, no-op.
+			if !mdRead {
+				md, _ = metadata.FromOutgoingContext(rpcInfo.Context)
+				emd, _ = grpcutil.ExtraMetadata(rpcInfo.Context)
+				mdRead = true
+			}
+			values := emd.Get(policy.HeaderName)
 			if len(values) == 0 {
-				continue
+				// Extra metadata takes precedence over the user's metadata.
+				values = md.Get(policy.HeaderName)
+				if len(values) == 0 {
+					// If the header isn't present at all, this policy is a no-op.
+					continue
+				}
 			}
 			joinedValues := strings.Join(values, ",")
 			if policy.Regex != nil {

--- a/xds/internal/resolver/serviceconfig_test.go
+++ b/xds/internal/resolver/serviceconfig_test.go
@@ -121,7 +121,7 @@ func (s) TestGenerateRequestHash(t *testing.T) {
 				Context: metadata.NewOutgoingContext(context.Background(), metadata.Pairs("something-bin", "xyz")),
 			},
 		},
-		// Tests that extra metadata is used first.
+		// Tests that extra metadata takes precedence over the user's metadata.
 		{
 			name: "extra-metadata",
 			hashPolicies: []*xdsresource.HashPolicy{{

--- a/xds/internal/resolver/serviceconfig_test.go
+++ b/xds/internal/resolver/serviceconfig_test.go
@@ -25,6 +25,7 @@ import (
 
 	xxhash "github.com/cespare/xxhash/v2"
 	"github.com/google/go-cmp/cmp"
+	"google.golang.org/grpc/internal/grpcutil"
 	iresolver "google.golang.org/grpc/internal/resolver"
 	"google.golang.org/grpc/metadata"
 	_ "google.golang.org/grpc/xds/internal/balancer/cdsbalancer" // To parse LB config
@@ -104,6 +105,35 @@ func (s) TestGenerateRequestHash(t *testing.T) {
 			rpcInfo: iresolver.RPCInfo{
 				Context: metadata.NewOutgoingContext(context.Background(), metadata.Pairs(":path", "abc")),
 				Method:  "/some-method",
+			},
+		},
+		// Tests that bin headers are skipped.
+		{
+			name: "skip-bin",
+			hashPolicies: []*xdsresource.HashPolicy{{
+				HashPolicyType: xdsresource.HashPolicyTypeHeader,
+				HeaderName:     "something-bin",
+			}, {
+				HashPolicyType: xdsresource.HashPolicyTypeChannelID,
+			}},
+			requestHashWant: channelID,
+			rpcInfo: iresolver.RPCInfo{
+				Context: metadata.NewOutgoingContext(context.Background(), metadata.Pairs("something-bin", "xyz")),
+			},
+		},
+		// Tests that extra metadata is used first.
+		{
+			name: "extra-metadata",
+			hashPolicies: []*xdsresource.HashPolicy{{
+				HashPolicyType: xdsresource.HashPolicyTypeHeader,
+				HeaderName:     "content-type",
+			}},
+			requestHashWant: xxhash.Sum64String("grpc value"),
+			rpcInfo: iresolver.RPCInfo{
+				Context: grpcutil.WithExtraMetadata(
+					metadata.NewOutgoingContext(context.Background(), metadata.Pairs("content-type", "user value")),
+					metadata.Pairs("content-type", "grpc value"),
+				),
 			},
 		},
 	}


### PR DESCRIPTION
A42 update PR: https://github.com/grpc/proposal/pull/392

Also a minor performance optimization to not read metadata from context more than once if not required, as this operation allocates a map (https://github.com/grpc/grpc-go/blob/c2b0797a5353b29ca02869629c83151c980a6e31/metadata/metadata.go#L271).

RELEASE NOTES:
* xds: fix hash policy header to skip "-bin" headers and read content-type header as expected