### PR TITLE
idle: decrement active call count for streaming RPCs only when the call completes

### DIFF
--- a/call.go
+++ b/call.go
@@ -27,11 +27,6 @@ import (
 //
 // All errors returned by Invoke are compatible with the status package.
 func (cc *ClientConn) Invoke(ctx context.Context, method string, args, reply any, opts ...CallOption) error {
-	if err := cc.idlenessMgr.OnCallBegin(); err != nil {
-		return err
-	}
-	defer cc.idlenessMgr.OnCallEnd()
-
 	// allow interceptor to see all applicable call options, which means those
 	// configured as defaults from dial option as well as per-call options
 	opts = combine(cc.dopts.callOptions, opts)

--- a/internal/idle/idle_e2e_test.go
+++ b/internal/idle/idle_e2e_test.go
@@ -178,8 +178,90 @@ func (s) TestChannelIdleness_Enabled_NoActivity(t *testing.T) {
 }
 
 // Tests the case where channel idleness is enabled by passing a small value for
-// idle_timeout. Verifies that a READY channel with an ongoing RPC stays READY.
-func (s) TestChannelIdleness_Enabled_OngoingCall(t *testing.T) {
+// idle_timeout. Verifies that a READY channel with an ongoing unary RPC stays
+// READY.
+func (s) TestChannelIdleness_Enabled_OngoingCall_Unary(t *testing.T) {
+	// Create a ClientConn with a short idle_timeout.
+	r := manual.NewBuilderWithScheme("whatever")
+	dopts := []grpc.DialOption{
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithResolvers(r),
+		grpc.WithIdleTimeout(defaultTestShortIdleTimeout),
+		grpc.WithDefaultServiceConfig(`{"loadBalancingConfig": [{"round_robin":{}}]}`),
+	}
+	cc, err := grpc.Dial(r.Scheme()+":///test.server", dopts...)
+	if err != nil {
+		t.Fatalf("grpc.Dial() failed: %v", err)
+	}
+	t.Cleanup(func() { cc.Close() })
+
+	// Start a test backend which keeps a unary RPC call active by blocking on a
+	// channel that is closed by the test later on. Also push an address update
+	// via the resolver.
+	blockCh := make(chan struct{})
+	backend := &stubserver.StubServer{
+		EmptyCallF: func(ctx context.Context, in *testpb.Empty) (*testpb.Empty, error) {
+			<-blockCh
+			return &testpb.Empty{}, nil
+		},
+	}
+	if err := backend.StartServer(); err != nil {
+		t.Fatalf("Failed to start backend: %v", err)
+	}
+	t.Cleanup(backend.Stop)
+	r.UpdateState(resolver.State{Addresses: []resolver.Address{{Addr: backend.Address}}})
+
+	// Verify that the ClientConn moves to READY.
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	testutils.AwaitState(ctx, t, cc, connectivity.Ready)
+
+	// Spawn a goroutine which checks expected state transitions and idleness
+	// channelz trace events. It eventually closes `blockCh`, thereby unblocking
+	// the server RPC handler and the unary call below.
+	errCh := make(chan error, 1)
+	go func() {
+		defer close(blockCh)
+		// Verify that the ClientConn stays in READY.
+		sCtx, sCancel := context.WithTimeout(ctx, 3*defaultTestShortIdleTimeout)
+		defer sCancel()
+		testutils.AwaitNoStateChange(sCtx, t, cc, connectivity.Ready)
+
+		// Verify that there are no idleness related channelz events.
+		if err := channelzTraceEventNotFound(ctx, "entering idle mode"); err != nil {
+			errCh <- err
+			return
+		}
+		if err := channelzTraceEventNotFound(ctx, "exiting idle mode"); err != nil {
+			errCh <- err
+			return
+		}
+
+		// Unblock the unary RPC on the server.
+		errCh <- nil
+	}()
+
+	// Make a unary RPC that blocks on the server, thereby ensuring that the
+	// count of active RPCs on the client is non-zero.
+	client := testgrpc.NewTestServiceClient(cc)
+	if _, err := client.EmptyCall(ctx, &testpb.Empty{}); err != nil {
+		t.Errorf("EmptyCall RPC failed: %v", err)
+	}
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-ctx.Done():
+		t.Fatalf("Timeout when trying to verify that an active RPC keeps channel from moving to IDLE")
+	}
+}
+
+// Tests the case where channel idleness is enabled by passing a small value for
+// idle_timeout. Verifies that a READY channel with an ongoing streaming RPC
+// stays READY.
+func (s) TestChannelIdleness_Enabled_OngoingCall_Streaming(t *testing.T) {
 	// Create a ClientConn with a short idle_timeout.
 	r := manual.NewBuilderWithScheme("whatever")
 	dopts := []grpc.DialOption{

--- a/internal/idle/idle_e2e_test.go
+++ b/internal/idle/idle_e2e_test.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"strings"
 	"testing"
 	"time"
@@ -193,14 +194,25 @@ func (s) TestChannelIdleness_Enabled_OngoingCall(t *testing.T) {
 	}
 	t.Cleanup(func() { cc.Close() })
 
-	// Start a test backend which keeps a unary RPC call active by blocking on a
-	// channel that is closed by the test later on. Also push an address update
-	// via the resolver.
-	blockCh := make(chan struct{})
-	backend := &stubserver.StubServer{
-		EmptyCallF: func(ctx context.Context, in *testpb.Empty) (*testpb.Empty, error) {
-			<-blockCh
-			return &testpb.Empty{}, nil
+	// Start a backend that implements a streaming RPC.
+	backend := stubserver.StubServer{
+		FullDuplexCallF: func(stream testgrpc.TestService_FullDuplexCallServer) error {
+			// Streaming implementation replies with a dummy response until the
+			// client closes the stream (in which case it will see an io.EOF),
+			// or an error occurs while reading/writing messages.
+			for {
+				_, err := stream.Recv()
+				if err == io.EOF {
+					return nil
+				}
+				if err != nil {
+					return err
+				}
+				payload := &testpb.Payload{Body: make([]byte, 32)}
+				if err := stream.Send(&testpb.StreamingOutputCallResponse{Payload: payload}); err != nil {
+					return err
+				}
+			}
 		},
 	}
 	if err := backend.StartServer(); err != nil {
@@ -215,15 +227,16 @@ func (s) TestChannelIdleness_Enabled_OngoingCall(t *testing.T) {
 	testutils.AwaitState(ctx, t, cc, connectivity.Ready)
 
 	// Spawn a goroutine which checks expected state transitions and idleness
-	// channelz trace events. It eventually closes `blockCh`, thereby unblocking
-	// the server RPC handler and the unary call below.
+	// channelz trace events.
 	errCh := make(chan error, 1)
 	go func() {
-		defer close(blockCh)
 		// Verify that the ClientConn stays in READY.
 		sCtx, sCancel := context.WithTimeout(ctx, 3*defaultTestShortIdleTimeout)
 		defer sCancel()
-		testutils.AwaitNoStateChange(sCtx, t, cc, connectivity.Ready)
+		if cc.WaitForStateChange(sCtx, connectivity.Ready) {
+			errCh <- fmt.Errorf("State changed from %q to %q when no state change was expected", connectivity.Ready, cc.GetState())
+			return
+		}
 
 		// Verify that there are no idleness related channelz events.
 		if err := channelzTraceEventNotFound(ctx, "entering idle mode"); err != nil {
@@ -234,16 +247,14 @@ func (s) TestChannelIdleness_Enabled_OngoingCall(t *testing.T) {
 			errCh <- err
 			return
 		}
-
-		// Unblock the unary RPC on the server.
 		errCh <- nil
 	}()
 
-	// Make a unary RPC that blocks on the server, thereby ensuring that the
-	// count of active RPCs on the client is non-zero.
+	// Start a streaming RPC. Even though the stream is inactive (i,e no reads
+	// or writes), the stream should prevent the channel from moving to IDLE.
 	client := testgrpc.NewTestServiceClient(cc)
-	if _, err := client.EmptyCall(ctx, &testpb.Empty{}); err != nil {
-		t.Errorf("EmptyCall RPC failed: %v", err)
+	if _, err := client.FullDuplexCall(ctx); err != nil {
+		t.Fatalf("FullDuplexCall RPC failed: %v", err)
 	}
 
 	select {

--- a/internal/idle/idle_e2e_test.go
+++ b/internal/idle/idle_e2e_test.go
@@ -266,7 +266,7 @@ func (s) TestChannelIdleness_Enabled_OngoingCall(t *testing.T) {
 				// Verify that there are no idleness related channelz events.
 				//
 				// TODO: Improve the checks here. If these log strings are
-				// changed in the code , these checks will continue to pass.
+				// changed in the code, these checks will continue to pass.
 				if err := channelzTraceEventNotFound(ctx, "entering idle mode"); err != nil {
 					errCh <- err
 					return

--- a/internal/idle/idle_e2e_test.go
+++ b/internal/idle/idle_e2e_test.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"strings"
 	"testing"
 	"time"
@@ -178,174 +177,112 @@ func (s) TestChannelIdleness_Enabled_NoActivity(t *testing.T) {
 }
 
 // Tests the case where channel idleness is enabled by passing a small value for
-// idle_timeout. Verifies that a READY channel with an ongoing unary RPC stays
-// READY.
-func (s) TestChannelIdleness_Enabled_OngoingCall_Unary(t *testing.T) {
-	// Create a ClientConn with a short idle_timeout.
-	r := manual.NewBuilderWithScheme("whatever")
-	dopts := []grpc.DialOption{
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithResolvers(r),
-		grpc.WithIdleTimeout(defaultTestShortIdleTimeout),
-		grpc.WithDefaultServiceConfig(`{"loadBalancingConfig": [{"round_robin":{}}]}`),
-	}
-	cc, err := grpc.Dial(r.Scheme()+":///test.server", dopts...)
-	if err != nil {
-		t.Fatalf("grpc.Dial() failed: %v", err)
-	}
-	t.Cleanup(func() { cc.Close() })
-
-	// Start a test backend which keeps a unary RPC call active by blocking on a
-	// channel that is closed by the test later on. Also push an address update
-	// via the resolver.
-	blockCh := make(chan struct{})
-	backend := &stubserver.StubServer{
-		EmptyCallF: func(ctx context.Context, in *testpb.Empty) (*testpb.Empty, error) {
-			<-blockCh
-			return &testpb.Empty{}, nil
+// idle_timeout. Verifies that a READY channel with an ongoing RPC stays READY.
+func (s) TestChannelIdleness_Enabled_OngoingCall(t *testing.T) {
+	tests := []struct {
+		name    string
+		makeRPC func(ctx context.Context, client testgrpc.TestServiceClient) error
+	}{
+		{
+			name: "unary",
+			makeRPC: func(ctx context.Context, client testgrpc.TestServiceClient) error {
+				if _, err := client.EmptyCall(ctx, &testpb.Empty{}); err != nil {
+					return fmt.Errorf("EmptyCall RPC failed: %v", err)
+				}
+				return nil
+			},
+		},
+		{
+			name: "streaming",
+			makeRPC: func(ctx context.Context, client testgrpc.TestServiceClient) error {
+				if _, err := client.FullDuplexCall(ctx); err != nil {
+					t.Fatalf("FullDuplexCall RPC failed: %v", err)
+				}
+				return nil
+			},
 		},
 	}
-	if err := backend.StartServer(); err != nil {
-		t.Fatalf("Failed to start backend: %v", err)
-	}
-	t.Cleanup(backend.Stop)
-	r.UpdateState(resolver.State{Addresses: []resolver.Address{{Addr: backend.Address}}})
 
-	// Verify that the ClientConn moves to READY.
-	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
-	defer cancel()
-	testutils.AwaitState(ctx, t, cc, connectivity.Ready)
-
-	// Spawn a goroutine which checks expected state transitions and idleness
-	// channelz trace events. It eventually closes `blockCh`, thereby unblocking
-	// the server RPC handler and the unary call below.
-	errCh := make(chan error, 1)
-	go func() {
-		defer close(blockCh)
-		// Verify that the ClientConn stays in READY.
-		sCtx, sCancel := context.WithTimeout(ctx, 3*defaultTestShortIdleTimeout)
-		defer sCancel()
-		testutils.AwaitNoStateChange(sCtx, t, cc, connectivity.Ready)
-
-		// Verify that there are no idleness related channelz events.
-		if err := channelzTraceEventNotFound(ctx, "entering idle mode"); err != nil {
-			errCh <- err
-			return
-		}
-		if err := channelzTraceEventNotFound(ctx, "exiting idle mode"); err != nil {
-			errCh <- err
-			return
-		}
-
-		// Unblock the unary RPC on the server.
-		errCh <- nil
-	}()
-
-	// Make a unary RPC that blocks on the server, thereby ensuring that the
-	// count of active RPCs on the client is non-zero.
-	client := testgrpc.NewTestServiceClient(cc)
-	if _, err := client.EmptyCall(ctx, &testpb.Empty{}); err != nil {
-		t.Errorf("EmptyCall RPC failed: %v", err)
-	}
-
-	select {
-	case err := <-errCh:
-		if err != nil {
-			t.Fatal(err)
-		}
-	case <-ctx.Done():
-		t.Fatalf("Timeout when trying to verify that an active RPC keeps channel from moving to IDLE")
-	}
-}
-
-// Tests the case where channel idleness is enabled by passing a small value for
-// idle_timeout. Verifies that a READY channel with an ongoing streaming RPC
-// stays READY.
-func (s) TestChannelIdleness_Enabled_OngoingCall_Streaming(t *testing.T) {
-	// Create a ClientConn with a short idle_timeout.
-	r := manual.NewBuilderWithScheme("whatever")
-	dopts := []grpc.DialOption{
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithResolvers(r),
-		grpc.WithIdleTimeout(defaultTestShortIdleTimeout),
-		grpc.WithDefaultServiceConfig(`{"loadBalancingConfig": [{"round_robin":{}}]}`),
-	}
-	cc, err := grpc.Dial(r.Scheme()+":///test.server", dopts...)
-	if err != nil {
-		t.Fatalf("grpc.Dial() failed: %v", err)
-	}
-	t.Cleanup(func() { cc.Close() })
-
-	// Start a backend that implements a streaming RPC.
-	backend := stubserver.StubServer{
-		FullDuplexCallF: func(stream testgrpc.TestService_FullDuplexCallServer) error {
-			// Streaming implementation replies with a dummy response until the
-			// client closes the stream (in which case it will see an io.EOF),
-			// or an error occurs while reading/writing messages.
-			for {
-				_, err := stream.Recv()
-				if err == io.EOF {
-					return nil
-				}
-				if err != nil {
-					return err
-				}
-				payload := &testpb.Payload{Body: make([]byte, 32)}
-				if err := stream.Send(&testpb.StreamingOutputCallResponse{Payload: payload}); err != nil {
-					return err
-				}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Create a ClientConn with a short idle_timeout.
+			r := manual.NewBuilderWithScheme("whatever")
+			dopts := []grpc.DialOption{
+				grpc.WithTransportCredentials(insecure.NewCredentials()),
+				grpc.WithResolvers(r),
+				grpc.WithIdleTimeout(defaultTestShortIdleTimeout),
+				grpc.WithDefaultServiceConfig(`{"loadBalancingConfig": [{"round_robin":{}}]}`),
 			}
-		},
-	}
-	if err := backend.StartServer(); err != nil {
-		t.Fatalf("Failed to start backend: %v", err)
-	}
-	t.Cleanup(backend.Stop)
-	r.UpdateState(resolver.State{Addresses: []resolver.Address{{Addr: backend.Address}}})
+			cc, err := grpc.Dial(r.Scheme()+":///test.server", dopts...)
+			if err != nil {
+				t.Fatalf("grpc.Dial() failed: %v", err)
+			}
+			t.Cleanup(func() { cc.Close() })
 
-	// Verify that the ClientConn moves to READY.
-	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
-	defer cancel()
-	testutils.AwaitState(ctx, t, cc, connectivity.Ready)
+			// Start a test backend which keeps a unary RPC call active by blocking on a
+			// channel that is closed by the test later on. Also push an address update
+			// via the resolver.
+			blockCh := make(chan struct{})
+			backend := &stubserver.StubServer{
+				EmptyCallF: func(ctx context.Context, in *testpb.Empty) (*testpb.Empty, error) {
+					<-blockCh
+					return &testpb.Empty{}, nil
+				},
+				FullDuplexCallF: func(stream testgrpc.TestService_FullDuplexCallServer) error {
+					<-blockCh
+					return nil
+				},
+			}
+			if err := backend.StartServer(); err != nil {
+				t.Fatalf("Failed to start backend: %v", err)
+			}
+			t.Cleanup(backend.Stop)
+			r.UpdateState(resolver.State{Addresses: []resolver.Address{{Addr: backend.Address}}})
 
-	// Spawn a goroutine which checks expected state transitions and idleness
-	// channelz trace events.
-	errCh := make(chan error, 1)
-	go func() {
-		// Verify that the ClientConn stays in READY.
-		sCtx, sCancel := context.WithTimeout(ctx, 3*defaultTestShortIdleTimeout)
-		defer sCancel()
-		if cc.WaitForStateChange(sCtx, connectivity.Ready) {
-			errCh <- fmt.Errorf("State changed from %q to %q when no state change was expected", connectivity.Ready, cc.GetState())
-			return
-		}
+			// Verify that the ClientConn moves to READY.
+			ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+			defer cancel()
+			testutils.AwaitState(ctx, t, cc, connectivity.Ready)
 
-		// Verify that there are no idleness related channelz events.
-		if err := channelzTraceEventNotFound(ctx, "entering idle mode"); err != nil {
-			errCh <- err
-			return
-		}
-		if err := channelzTraceEventNotFound(ctx, "exiting idle mode"); err != nil {
-			errCh <- err
-			return
-		}
-		errCh <- nil
-	}()
+			// Spawn a goroutine which checks expected state transitions and idleness
+			// channelz trace events.
+			errCh := make(chan error, 1)
+			go func() {
+				defer close(blockCh)
 
-	// Start a streaming RPC. Even though the stream is inactive (i,e no reads
-	// or writes), the stream should prevent the channel from moving to IDLE.
-	client := testgrpc.NewTestServiceClient(cc)
-	if _, err := client.FullDuplexCall(ctx); err != nil {
-		t.Fatalf("FullDuplexCall RPC failed: %v", err)
-	}
+				// Verify that the ClientConn stays in READY.
+				sCtx, sCancel := context.WithTimeout(ctx, 3*defaultTestShortIdleTimeout)
+				defer sCancel()
+				if cc.WaitForStateChange(sCtx, connectivity.Ready) {
+					errCh <- fmt.Errorf("state changed from %q to %q when no state change was expected", connectivity.Ready, cc.GetState())
+					return
+				}
 
-	select {
-	case err := <-errCh:
-		if err != nil {
-			t.Fatal(err)
-		}
-	case <-ctx.Done():
-		t.Fatalf("Timeout when trying to verify that an active RPC keeps channel from moving to IDLE")
+				// Verify that there are no idleness related channelz events.
+				if err := channelzTraceEventNotFound(ctx, "entering idle mode"); err != nil {
+					errCh <- err
+					return
+				}
+				if err := channelzTraceEventNotFound(ctx, "exiting idle mode"); err != nil {
+					errCh <- err
+					return
+				}
+				errCh <- nil
+			}()
+
+			if err := test.makeRPC(ctx, testgrpc.NewTestServiceClient(cc)); err != nil {
+				t.Fatalf("%s rpc failed: %v", test.name, err)
+			}
+
+			select {
+			case err := <-errCh:
+				if err != nil {
+					t.Fatal(err)
+				}
+			case <-ctx.Done():
+				t.Fatalf("Timeout when trying to verify that an active RPC keeps channel from moving to IDLE")
+			}
+		})
 	}
 }
 

--- a/stream.go
+++ b/stream.go
@@ -182,7 +182,7 @@ func newClientStream(ctx context.Context, desc *StreamDesc, cc *ClientConn, meth
 	}
 	// Add a calloption, to decrement the active call count, that gets executed
 	// when the RPC completes.
-	opts = append(opts, OnFinish(func(error) { cc.idlenessMgr.OnCallEnd() }))
+	opts = append([]CallOption{OnFinish(func(error) { cc.idlenessMgr.OnCallEnd() })}, opts...)
 
 	if md, added, ok := metadata.FromOutgoingContextRaw(ctx); ok {
 		// validate md

--- a/stream.go
+++ b/stream.go
@@ -158,19 +158,9 @@ type ClientStream interface {
 // If none of the above happen, a goroutine and a context will be leaked, and grpc
 // will not call the optionally-configured stats handler with a stats.End message.
 func (cc *ClientConn) NewStream(ctx context.Context, desc *StreamDesc, method string, opts ...CallOption) (ClientStream, error) {
-	if err := cc.idlenessMgr.OnCallBegin(); err != nil {
-		return nil, err
-	}
-
 	// allow interceptor to see all applicable call options, which means those
 	// configured as defaults from dial option as well as per-call options
 	opts = combine(cc.dopts.callOptions, opts)
-
-	// Add a calloption, to decrement the count of active RPCs, that gets
-	// executed when the RPC completes.
-	opts = append(opts, OnFinish(func(error) {
-		cc.idlenessMgr.OnCallEnd()
-	}))
 
 	if cc.dopts.streamInt != nil {
 		return cc.dopts.streamInt(ctx, desc, cc, method, newClientStream, opts...)
@@ -184,6 +174,16 @@ func NewClientStream(ctx context.Context, desc *StreamDesc, cc *ClientConn, meth
 }
 
 func newClientStream(ctx context.Context, desc *StreamDesc, cc *ClientConn, method string, opts ...CallOption) (_ ClientStream, err error) {
+	// Start tracking the RPC for idleness purposes. This is where a stream is
+	// created for both streaming and unary RPCs, and hence is a good place to
+	// track active RPC count.
+	if err := cc.idlenessMgr.OnCallBegin(); err != nil {
+		return nil, err
+	}
+	// Add a calloption, to decrement the active call count, that gets executed
+	// when the RPC completes.
+	opts = append(opts, OnFinish(func(error) { cc.idlenessMgr.OnCallEnd() }))
+
 	if md, added, ok := metadata.FromOutgoingContextRaw(ctx); ok {
 		// validate md
 		if err := imetadata.Validate(md); err != nil {


### PR DESCRIPTION
RELEASE NOTES:
- idle: fix a bug that was decrementing active RPC count too early for streaming RPCs; leading to channel moving to IDLE even though it had open streams