### PR TITLE
grpc: provide a mechanism for encoded message buffer recycling

### DIFF
--- a/benchmark/stats/stats.go
+++ b/benchmark/stats/stats.go
@@ -59,6 +59,7 @@ const (
 	SleepBetweenRPCs
 	RecvBufferPool
 	SharedWriteBuffer
+	EncoderBufferPool
 
 	// MaxFeatureIndex is a place holder to indicate the total number of feature
 	// indices we have. Any new feature indices should be added above this.
@@ -132,6 +133,8 @@ type Features struct {
 	RecvBufferPool string
 	// SharedWriteBuffer configures whether both client and server share per-connection write buffer
 	SharedWriteBuffer bool
+	// SharedWriteBuffer configures whether both client and server share encoder buffers
+	EncoderBufferPool bool
 }
 
 // String returns all the feature values as a string.
@@ -151,13 +154,14 @@ func (f Features) String() string {
 		"trace_%v-latency_%v-kbps_%v-MTU_%v-maxConcurrentCalls_%v-%s-%s-"+
 		"compressor_%v-channelz_%v-preloader_%v-clientReadBufferSize_%v-"+
 		"clientWriteBufferSize_%v-serverReadBufferSize_%v-serverWriteBufferSize_%v-"+
-		"sleepBetweenRPCs_%v-connections_%v-recvBufferPool_%v-sharedWriteBuffer_%v",
+		"sleepBetweenRPCs_%v-connections_%v-recvBufferPool_%v-sharedWriteBuffer_%v-"+
+		"encoderBufferPool_%v",
 		f.NetworkMode, f.UseBufConn, f.EnableKeepalive, f.BenchTime, f.EnableTrace,
 		f.Latency, f.Kbps, f.MTU, f.MaxConcurrentCalls, reqPayloadString,
 		respPayloadString, f.ModeCompressor, f.EnableChannelz, f.EnablePreloader,
 		f.ClientReadBufferSize, f.ClientWriteBufferSize, f.ServerReadBufferSize,
 		f.ServerWriteBufferSize, f.SleepBetweenRPCs, f.Connections,
-		f.RecvBufferPool, f.SharedWriteBuffer)
+		f.RecvBufferPool, f.SharedWriteBuffer, f.EncoderBufferPool)
 }
 
 // SharedFeatures returns the shared features as a pretty printable string.
@@ -235,6 +239,8 @@ func (f Features) partialString(b *bytes.Buffer, wantFeatures []bool, sep, delim
 				b.WriteString(fmt.Sprintf("RecvBufferPool%v%v%v", sep, f.RecvBufferPool, delim))
 			case SharedWriteBuffer:
 				b.WriteString(fmt.Sprintf("SharedWriteBuffer%v%v%v", sep, f.SharedWriteBuffer, delim))
+			case EncoderBufferPool:
+				b.WriteString(fmt.Sprintf("EncoderBufferPool%v%v%v", sep, f.EncoderBufferPool, delim))
 			default:
 				log.Fatalf("Unknown feature index %v. maxFeatureIndex is %v", i, MaxFeatureIndex)
 			}

--- a/codec.go
+++ b/codec.go
@@ -31,6 +31,10 @@ type baseCodec interface {
 	Unmarshal(data []byte, v any) error
 }
 
+type baseBufferedCodec interface {
+	MarshalWithBuffer(v any, pool encoding.SharedBufferPool) ([]byte, error)
+}
+
 var _ baseCodec = Codec(nil)
 var _ baseCodec = encoding.Codec(nil)
 

--- a/encoding/encoding.go
+++ b/encoding/encoding.go
@@ -99,6 +99,43 @@ type Codec interface {
 	Name() string
 }
 
+// SharedBufferPool is a pool of buffers that can be shared, resulting in
+// decreased memory allocation.
+//
+// # Experimental
+//
+// Notice: This API is EXPERIMENTAL and may be changed or removed in a
+// later release.
+type SharedBufferPool interface {
+	// Get returns a buffer with specified length from the pool.
+	//
+	// The returned byte slice may be not zero initialized.
+	//
+	// Should be thread-safe.
+	Get(length int) []byte
+
+	// Put returns a buffer to the pool.
+	//
+	// Should be thread-safe.
+	Put(*[]byte)
+}
+
+// BufferedCodec is an optional interface Codec may implement.
+// It signals the ability of the codec to use pre-existing memory
+// when writing the wire format of messages.
+//
+// # Experimental
+//
+// Notice: This API is EXPERIMENTAL and may be changed or removed in a
+// later release.
+type BufferedCodec interface {
+	// MarshalWithBuffer returns the wire format of v.
+	//
+	// Implementation may use a buffer from the provided buffer
+	// pool when marshalling. Doing so enables memory reuse.
+	MarshalWithBuffer(v any, pool SharedBufferPool) ([]byte, error)
+}
+
 var registeredCodecs = make(map[string]Codec)
 
 // RegisterCodec registers the provided Codec for use with all gRPC clients and

--- a/encoding/proto/proto.go
+++ b/encoding/proto/proto.go
@@ -53,6 +53,21 @@ func (codec) Unmarshal(data []byte, v any) error {
 	return proto.Unmarshal(data, vv)
 }
 
+func (c codec) MarshalWithBuffer(v any, pool encoding.SharedBufferPool) ([]byte, error) {
+	vv, ok := v.(proto.Message)
+	if !ok {
+		return nil, fmt.Errorf("failed to marshal, message is %T, want proto.Message", v)
+	}
+
+	protoSize := proto.Size(vv)
+	buffer := proto.NewBuffer(pool.Get(protoSize)[:0])
+	if err := buffer.Marshal(vv); err != nil {
+		return nil, err
+	}
+
+	return buffer.Unread()[:protoSize], nil
+}
+
 func (codec) Name() string {
 	return Name
 }

--- a/internal/transport/controlbuf.go
+++ b/internal/transport/controlbuf.go
@@ -152,6 +152,8 @@ type dataFrame struct {
 	// onEachWrite is called every time
 	// a part of d is written out.
 	onEachWrite func()
+	// onCompletion is called when the frame has been written in full
+	onCompletion func()
 }
 
 func (*dataFrame) isTransportResponseFrame() bool { return false }
@@ -980,6 +982,9 @@ func (l *loopyWriter) processData() (bool, error) {
 	dataItem.d = dataItem.d[dSize:]
 
 	if len(dataItem.h) == 0 && len(dataItem.d) == 0 { // All the data from that message was written out.
+		if dataItem.onCompletion != nil {
+			dataItem.onCompletion()
+		}
 		str.itl.dequeue()
 	}
 	if str.itl.isEmpty() {

--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -1038,10 +1038,11 @@ func (t *http2Client) Write(s *Stream, hdr []byte, data []byte, opts *Options) e
 		return errStreamDone
 	}
 	df := &dataFrame{
-		streamID:  s.id,
-		endStream: opts.Last,
-		h:         hdr,
-		d:         data,
+		streamID:     s.id,
+		endStream:    opts.Last,
+		h:            hdr,
+		d:            data,
+		onCompletion: opts.OnWrittenToTransport,
 	}
 	if hdr != nil || data != nil { // If it's not an empty data frame, check quota.
 		if err := s.wq.get(int32(len(hdr) + len(data))); err != nil {

--- a/internal/transport/http2_server.go
+++ b/internal/transport/http2_server.go
@@ -1110,10 +1110,11 @@ func (t *http2Server) Write(s *Stream, hdr []byte, data []byte, opts *Options) e
 		}
 	}
 	df := &dataFrame{
-		streamID:    s.id,
-		h:           hdr,
-		d:           data,
-		onEachWrite: t.setResetPingStrikes,
+		streamID:     s.id,
+		h:            hdr,
+		d:            data,
+		onEachWrite:  t.setResetPingStrikes,
+		onCompletion: opts.OnWrittenToTransport,
 	}
 	if err := s.wq.get(int32(len(hdr) + len(data))); err != nil {
 		return t.streamContextErr(s)

--- a/internal/transport/transport.go
+++ b/internal/transport/transport.go
@@ -607,6 +607,11 @@ type Options struct {
 	// Last indicates whether this write is the last piece for
 	// this stream.
 	Last bool
+
+	// OnWrittenToTransport is called exactly once after the
+	// data has been fully written to the transport layer.
+	// It is not called if the write fails.
+	OnWrittenToTransport func()
 }
 
 // CallHdr carries the information of a particular RPC.

--- a/preloader.go
+++ b/preloader.go
@@ -53,7 +53,7 @@ func (p *PreparedMsg) Encode(s Stream, msg any) error {
 	}
 
 	// prepare the msg
-	data, err := encode(rpcInfo.preloaderInfo.codec, msg)
+	data, err := encode(rpcInfo.preloaderInfo.codec, msg, nil)
 	if err != nil {
 		return err
 	}

--- a/rpc_util.go
+++ b/rpc_util.go
@@ -663,11 +663,18 @@ func (p *parser) recvMsg(maxReceiveMessageSize int) (pf payloadFormat, msg []byt
 // encode serializes msg and returns a buffer containing the message, or an
 // error if it is too large to be transmitted by grpc.  If msg is nil, it
 // generates an empty message.
-func encode(c baseCodec, msg any) ([]byte, error) {
+func encode(c baseCodec, msg any, encoderBufferPool SharedBufferPool) (b []byte, err error) {
 	if msg == nil { // NOTE: typed nils will not be caught by this check
 		return nil, nil
 	}
-	b, err := c.Marshal(msg)
+
+	// Attempt to promote the codec to one that supports reusing buffers
+	if cBuffer, ok := c.(baseBufferedCodec); ok && encoderBufferPool != nil {
+		b, err = cBuffer.MarshalWithBuffer(msg, encoderBufferPool)
+	} else {
+		b, err = c.Marshal(msg)
+	}
+
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "grpc: error while marshaling: %v", err.Error())
 	}

--- a/server.go
+++ b/server.go
@@ -1127,7 +1127,7 @@ func (s *Server) incrCallsFailed() {
 }
 
 func (s *Server) sendResponse(ctx context.Context, t transport.ServerTransport, stream *transport.Stream, msg any, cp Compressor, opts *transport.Options, comp encoding.Compressor) error {
-	data, err := encode(s.getCodec(stream.ContentSubtype()), msg)
+	data, err := encode(s.getCodec(stream.ContentSubtype()), msg, s.opts.encoderBufferPool)
 	if err != nil {
 		channelz.Error(logger, s.channelzID, "grpc: server failed to encode response: ", err)
 		return err

--- a/stream.go
+++ b/stream.go
@@ -889,7 +889,7 @@ func (cs *clientStream) SendMsg(m any) (err error) {
 	}
 
 	// load hdr, payload, data
-	hdr, payload, data, err := prepareMsg(m, cs.codec, cs.cp, cs.comp)
+	hdr, payload, data, err := prepareMsg(m, cs.codec, cs.cp, cs.comp, cs.encoderBufferPool)
 	if err != nil {
 		return err
 	}
@@ -911,6 +911,7 @@ func (cs *clientStream) SendMsg(m any) (err error) {
 			binlog.Log(cs.ctx, cm)
 		}
 	}
+
 	return err
 }
 
@@ -1382,7 +1383,7 @@ func (as *addrConnStream) SendMsg(m any) (err error) {
 	}
 
 	// load hdr, payload, data
-	hdr, payld, data, err := prepareMsg(m, as.codec, as.cp, as.comp)
+	hdr, payld, data, err := prepareMsg(m, as.codec, as.cp, as.comp, as.encoderBufferPool)
 	if err != nil {
 		return err
 	}
@@ -1664,7 +1665,7 @@ func (ss *serverStream) SendMsg(m any) (err error) {
 	}
 
 	// load hdr, payload, data
-	hdr, payload, data, err := prepareMsg(m, ss.codec, ss.cp, ss.comp)
+	hdr, payload, data, err := prepareMsg(m, ss.codec, ss.cp, ss.comp, ss.encoderBufferPool)
 	if err != nil {
 		return err
 	}
@@ -1791,13 +1792,13 @@ func MethodFromServerStream(stream ServerStream) (string, bool) {
 // prepareMsg returns the hdr, payload and data
 // using the compressors passed or using the
 // passed preparedmsg
-func prepareMsg(m any, codec baseCodec, cp Compressor, comp encoding.Compressor) (hdr, payload, data []byte, err error) {
+func prepareMsg(m any, codec baseCodec, cp Compressor, comp encoding.Compressor, encoderBufferPool SharedBufferPool) (hdr, payload, data []byte, err error) {
 	if preparedMsg, ok := m.(*PreparedMsg); ok {
 		return preparedMsg.hdr, preparedMsg.payload, preparedMsg.encodedData, nil
 	}
 	// The input interface is not a prepared msg.
 	// Marshal and Compress the data at this point
-	data, err = encode(codec, m)
+	data, err = encode(codec, m, encoderBufferPool)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/stream.go
+++ b/stream.go
@@ -446,12 +446,13 @@ func (cs *clientStream) newAttemptLocked(isTransparent bool) (*csAttempt, error)
 	}
 
 	return &csAttempt{
-		ctx:           ctx,
-		beginTime:     beginTime,
-		cs:            cs,
-		dc:            cs.cc.dopts.dc,
-		statsHandlers: shs,
-		trInfo:        trInfo,
+		ctx:               ctx,
+		beginTime:         beginTime,
+		cs:                cs,
+		dc:                cs.cc.dopts.dc,
+		statsHandlers:     shs,
+		trInfo:            trInfo,
+		encoderBufferPool: cs.encoderBufferPool,
 	}, nil
 }
 
@@ -595,6 +596,8 @@ type csAttempt struct {
 	allowTransparentRetry bool
 	// set for pick errors that are returned as a status
 	drop bool
+
+	encoderBufferPool SharedBufferPool
 }
 
 func (cs *clientStream) commitAttemptLocked() {
@@ -1556,6 +1559,8 @@ type serverStream struct {
 	// It's only checked in send and sendHeader, doesn't need to be
 	// synchronized.
 	serverHeaderBinlogged bool
+
+	encoderBufferPool SharedBufferPool
 
 	mu sync.Mutex // protects trInfo.tr after the service handler runs.
 }

--- a/test/encoder_buffer_pool_test.go
+++ b/test/encoder_buffer_pool_test.go
@@ -1,0 +1,162 @@
+/*
+ *
+ * Copyright 2023 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package test
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"io"
+	"sync/atomic"
+	"testing"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/internal/stubserver"
+	testgrpc "google.golang.org/grpc/interop/grpc_testing"
+)
+
+type CountingBufferPool struct {
+	alloc   int32
+	dealloc int32
+}
+
+func (c *CountingBufferPool) Get(length int) []byte {
+	atomic.AddInt32(&c.alloc, 1)
+	return make([]byte, length)
+}
+
+// Put returns a buffer to the pool.
+func (c *CountingBufferPool) Put(b *[]byte) {
+	atomic.AddInt32(&c.dealloc, 1)
+}
+
+func (c *CountingBufferPool) ResetAllocs() int {
+	return int(atomic.SwapInt32(&c.alloc, 0))
+}
+
+func (c *CountingBufferPool) ResetDeallocs() int {
+	return int(atomic.SwapInt32(&c.dealloc, 0))
+}
+
+func (s) TestEncoderBufferPool(t *testing.T) {
+	body := make([]byte, 1<<10)
+	rand.Read(body)
+
+	ss := &stubserver.StubServer{
+		UnaryCallF: func(ctx context.Context, in *testgrpc.SimpleRequest) (*testgrpc.SimpleResponse, error) {
+			return &testgrpc.SimpleResponse{
+				Payload: &testgrpc.Payload{
+					Body: body,
+				},
+			}, nil
+		},
+		FullDuplexCallF: func(stream testgrpc.TestService_FullDuplexCallServer) error {
+			for i := 0; i < 10; i++ {
+				err := stream.SendMsg(&testgrpc.StreamingOutputCallResponse{
+					Payload: &testgrpc.Payload{
+						Body: body,
+					},
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+			return nil
+		},
+	}
+
+	var (
+		serverPool CountingBufferPool
+		clientPool CountingBufferPool
+	)
+
+	if err := ss.Start(
+		[]grpc.ServerOption{grpc.ServerEncoderBufferPool(&serverPool)},
+		grpc.WithDefaultCallOptions(grpc.ClientEncoderBufferPool(&clientPool)),
+	); err != nil {
+		t.Fatalf("Error starting endpoint server: %v", err)
+	}
+	defer ss.Stop()
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+
+	// Assert that we can communicate without the buffer pool
+	response, err := ss.Client.UnaryCall(ctx, &testgrpc.SimpleRequest{
+		Payload: &testgrpc.Payload{
+			Body: body,
+		},
+	}, grpc.ClientEncoderBufferPool(nil))
+	if err != nil {
+		t.Fatalf("ss.Client.UnaryCall failed: %s", err)
+	}
+
+	if !bytes.Equal(response.GetPayload().GetBody(), body) {
+		t.Fatal("received mismatching buffer")
+	}
+
+	response, err = ss.Client.UnaryCall(ctx, &testgrpc.SimpleRequest{
+		Payload: &testgrpc.Payload{
+			Body: body,
+		},
+	})
+	if err != nil {
+		t.Fatalf("ss.Client.UnaryCall failed: %f", err)
+	}
+
+	if !bytes.Equal(response.GetPayload().GetBody(), body) {
+		t.Fatal("received mismatching buffer")
+	}
+
+	stream, err := ss.Client.FullDuplexCall(ctx)
+	if err != nil {
+		t.Fatalf("ss.Client.FullDuplexCall failed: %f", err)
+	}
+
+	var ngot int
+	for {
+		reply, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(reply.GetPayload().GetBody(), body) {
+			t.Fatal("received mismatching buffer")
+		}
+		ngot++
+	}
+	if want := 10; ngot != want {
+		t.Errorf("Got %d replies, want %d", ngot, want)
+	}
+
+	if got := clientPool.ResetAllocs(); got != 1 {
+		t.Errorf("Got %d client allocation, want %d", got, 0)
+	}
+	if got := clientPool.ResetDeallocs(); got != 1 {
+		t.Errorf("Got %d client deallocation, want %d", got, 0)
+	}
+	if got := serverPool.ResetAllocs(); got != 12 {
+		t.Errorf("Got %d server allocation, want %d", got, 10)
+	}
+	if got := serverPool.ResetDeallocs(); got != 12 {
+		t.Errorf("Got %d server deallocation, want %d", got, 10)
+	}
+}


### PR DESCRIPTION
RELEASE NOTES:

This PR adds a new public API to allow users to pass a buffer pool 
(implementing the pre-existing `grpc.SharedBufferPool`). When used in 
conjunction with a compatible `encoding.Codec`, the memory used to 
marshal messages may be reused indefinitely, significantly reducing the
garbage collection overhead for clients and servers dealing with high 
number of messages or high volume of data. 

## Motivation

We are currently working on a service that uses gRPC streaming to stream
(potentially) large files, in chunks, back to gRPC clients over the 
network. We measured that the Go allocation volume per second is roughly
equal to the network throughput of the host. This creates GC cycles that
introduce latency spikes and prevent us from predictably saturating the 
network at a reasonable CPU cost.

After investigation, we have isolated the source of most of these 
allocations to protobuf slice creation during message serialization.

## Results

Using this patch-set, CPU usage was reduced by 27% and by up to 64% in 
one (quite synthetic) extreme case. Allocation volume per second dropped
almost 100%, from 805MiB/s to 5MiB/s.

This PR also commits some benchmarks to demonstrate the effect in an 
ideal scenario:

```
benchmark                    old ns/op     new ns/op     delta
BenchmarkEncode1B-10         90.7          118           +30.43%
BenchmarkEncode1KiB-10       336           134           -60.05%
BenchmarkEncode8KiB-10       1806          260           -85.61%
BenchmarkEncode64KiB-10      11749         1235          -89.49%
BenchmarkEncode512KiB-10     86471         14682         -83.02%
BenchmarkEncode1MiB-10       111630        25925         -76.78%

benchmark                    old MB/s     new MB/s     speedup
BenchmarkEncode1B-10         33.08        25.37        0.77x
BenchmarkEncode1KiB-10       3057.12      7652.03      2.50x
BenchmarkEncode8KiB-10       4538.51      31539.55     6.95x
BenchmarkEncode64KiB-10      5578.28      53078.44     9.52x
BenchmarkEncode512KiB-10     6063.21      35709.85     5.89x
BenchmarkEncode1MiB-10       9393.39      40446.71     4.31x

benchmark                    old allocs     new allocs     delta
BenchmarkEncode1B-10         1              0              -100.00%
BenchmarkEncode1KiB-10       1              0              -100.00%
BenchmarkEncode8KiB-10       1              0              -100.00%
BenchmarkEncode64KiB-10      1              0              -100.00%
BenchmarkEncode512KiB-10     1              0              -100.00%
BenchmarkEncode1MiB-10       1              0              -100.00%

benchmark                    old bytes     new bytes     delta
BenchmarkEncode1B-10         3             0             -100.00%
BenchmarkEncode1KiB-10       1152          0             -100.00%
BenchmarkEncode8KiB-10       9472          0             -100.00%
BenchmarkEncode64KiB-10      73728         1             -100.00%
BenchmarkEncode512KiB-10     532482        12            -100.00%
BenchmarkEncode1MiB-10       1056772       22            -100.00%
```

## Notes

I am unsure if this is a direction the project maintainers are 
comfortable pursuing, and this is my first time contributing. Please let
me know if you'd rather I break up the PR into smaller ones (the commit
log is clean and should let us do that easily). Or, if there is a better way
to achieve this!

Additionally, there are a few things of note I considered and would 
appreciate feedback on:
* I was unsure whether we should reuse the existing buffer pools that 
  can already be passed today, such as through the `grpc.RecvBufferPool`
  or `[With]SharedWriteBuffer` options;
* Whether this mechanism should also apply to compressors, which operate
  much the same way as encoders do (some already store a buffer pool 
  internally);
* Tiny messages may suffer from this change, as it adds some extra
  logic that only pays off when the messages are larger than around 64
  bytes.
* Whether this is even safe to do, given we pass encoded message buffers 
  to handlers, which may keep references to them. This strikes me as a bad
  practice that would lead to bugs, but I am unable to find a written 
  documentation about it.

Thank you!