### PR TITLE
grpc: ensure transports are closed when the channel enters IDLE

### DIFF
--- a/clientconn.go
+++ b/clientconn.go
@@ -1091,8 +1091,8 @@ func (ac *addrConn) updateAddrs(addrs []resolver.Address) {
 	ac.cancel()
 	ac.ctx, ac.cancel = context.WithCancel(ac.cc.ctx)
 
-	// We have to defer here because GracefulClose => Close => onClose, which
-	// requires locking ac.mu.
+	// We have to defer here because GracefulClose => onClose, which requires
+	// locking ac.mu.
 	if ac.transport != nil {
 		defer ac.transport.GracefulClose()
 		ac.transport = nil
@@ -1680,16 +1680,35 @@ func (ac *addrConn) tearDown(err error) {
 	ac.updateConnectivityState(connectivity.Shutdown, nil)
 	ac.cancel()
 	ac.curAddr = resolver.Address{}
-	if err == errConnDrain && curTr != nil {
-		// GracefulClose(...) may be executed multiple times when
-		// i) receiving multiple GoAway frames from the server; or
-		// ii) there are concurrent name resolver/Balancer triggered
-		// address removal and GoAway.
-		// We have to unlock and re-lock here because GracefulClose => Close => onClose, which requires locking ac.mu.
-		ac.mu.Unlock()
-		curTr.GracefulClose()
-		ac.mu.Lock()
+
+	if curTr != nil {
+		if err == errConnDrain {
+			// Close the transport gracefully when the subConn is being shutdown.
+			//
+			// GracefulClose() may be executed multiple times if:
+			// - multiple GoAway frames are received from the server
+			// - there are concurrent name resolver or balancer triggered
+			//   address removal and GoAway
+			//
+			// We have to unlock and re-lock here because GracefulClose calls
+			// onClose, which requires locking ac.mu.
+			ac.mu.Unlock()
+			curTr.GracefulClose()
+			ac.mu.Lock()
+		} else {
+			// Hard close the transport when the channel is entering idle or is
+			// being shutdown.  In the case where the channel is being shutdown,
+			// closing of transports is also taken care of by cancelation of cc.ctx.
+			// But in the case where the channel is entering idle, we need to
+			// explicitly close the transports here. Instead of distinguishing
+			// between these two cases, it is simpler to close the transport
+			// unconditionally here.
+			ac.mu.Unlock()
+			curTr.Close(err)
+			ac.mu.Lock()
+		}
 	}
+
 	channelz.AddTraceEvent(logger, ac.channelzID, 0, &channelz.TraceEventDesc{
 		Desc:     "Subchannel deleted",
 		Severity: channelz.CtInfo,


### PR DESCRIPTION
Prior to channel idleness, sub-channels would be closed either because:
- the LB policy shuts it down (or the LB policy is being switched)
  - in this case, the underlying transport is gracefully closed
- the channel is being shutdown
  - in this case, `cc.ctx` is canceled
  - this context is passed to the transport, and leads to the transport shutting down

In the case of the channel moving to IDLE though, we were calling `ac.tearDown`, but this was not actually closing the transport because the passed in error was not `errConnDrain`.

With this PR, we will always close the underlying transport from `ac.tearDown`, either gracefully or forcefully. 

RELEASE NOTES:
- grpc: fix a bug where transports were not being closed upon channel entering IDLE