### PR TITLE
grpc: Move some stats handler callouts from transport to gRPC layer server side

### DIFF
--- a/internal/transport/handler_server.go
+++ b/internal/transport/handler_server.go
@@ -167,6 +167,8 @@ func (ht *serverHandlerTransport) Close(err error) {
 
 func (ht *serverHandlerTransport) RemoteAddr() net.Addr { return strAddr(ht.req.RemoteAddr) }
 
+func (ht *serverHandlerTransport) LocalAddr() net.Addr { return nil }
+
 // strAddr is a net.Addr backed by either a TCP "ip:port" string, or
 // the empty string if unknown.
 type strAddr string

--- a/internal/transport/transport_test.go
+++ b/internal/transport/transport_test.go
@@ -337,7 +337,7 @@ func (s *server) start(t *testing.T, port int, serverConfig *ServerConfig, ht hT
 			return
 		}
 		rawConn := conn
-		transport, err := NewServerTransport(conn, serverConfig)
+		transport, err := NewServerTransport(context.Background(), conn, serverConfig)
 		if err != nil {
 			return
 		}


### PR DESCRIPTION
This PR moves the Conn Begin and InHeader calls from the transport layer to gRPC layer. The other three (OutHeader, OutTrailer, ConnEnd) will come in a future PR which will delete the need for the setContext() function. The OutHeader and OutTrailer will require some reworking of the ownership of logic between the layers of gRPC and Transport.

RELEASE NOTES: N/A