### PR TITLE
idle: use LB policy close event as a proxy for channel idleness

### DIFF
--- a/internal/idle/idle_e2e_test.go
+++ b/internal/idle/idle_e2e_test.go
@@ -32,7 +32,6 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/credentials/insecure"
-	"google.golang.org/grpc/internal"
 	"google.golang.org/grpc/internal/balancer/stub"
 	"google.golang.org/grpc/internal/channelz"
 	"google.golang.org/grpc/internal/grpctest"
@@ -93,8 +92,6 @@ func channelzTraceEventFound(ctx context.Context, wantDesc string) error {
 // Returns a channel that gets pinged when the balancer is closed.
 func registerWrappedRoundRobinPolicy(t *testing.T) chan struct{} {
 	rrBuilder := balancer.Get(roundrobin.Name)
-	internal.BalancerUnregister(rrBuilder.Name())
-
 	closeCh := make(chan struct{}, 1)
 	stub.Register(roundrobin.Name, stub.BalancerFuncs{
 		Init: func(bd *stub.BalancerData) {


### PR DESCRIPTION
Existing tests were using the absence of a certain log message in channelz to verify that the channel did not enter IDLE (apart from checking the channel connectivity state). But these checks aren't great because if we decided to change the string we log, then the test case will no longer be valid but will continue to pass. 

This PR uses the closing of the LB policy as a proxy for channel entering IDLE mode instead.

Fixes https://github.com/grpc/grpc-go/issues/6612

RELEASE NOTES: none