### PR TITLE
balancer/weightedroundrobin: fix ticker leak on update

### DIFF
--- a/balancer/weightedroundrobin/balancer.go
+++ b/balancer/weightedroundrobin/balancer.go
@@ -369,6 +369,7 @@ func (p *picker) start(ctx context.Context) {
 	}
 	go func() {
 		ticker := time.NewTicker(time.Duration(p.cfg.WeightUpdatePeriod))
+		defer ticker.Stop()
 		for {
 			select {
 			case <-ctx.Done():


### PR DESCRIPTION
The code that regenerate the picker, called on every conn update, does creates ticker to update weights but does not properly close it. This causes resource leaks.

Fix this by properly stopping the ticker.

RELEASE NOTES:
- balancer/weightedroundrobin: fix a memory leak caused by not stopping a `time.Ticker`