### PR TITLE
balancer: add a warning for balancer names that contain upper case letters

### DIFF
--- a/balancer/balancer.go
+++ b/balancer/balancer.go
@@ -79,6 +79,12 @@ func init() {
 // Note that the compare is done in a case-insensitive fashion.
 // If no builder is register with the name, nil will be returned.
 func Get(name string) Builder {
+	if strings.ToLower(name) != name {
+		// TODO: Skip the use of strings.ToLower() to index the map after v1.59
+		// is released to switch to case sensitive balancer registry. Also,
+		// remove this warning and update the docstrings for Register and Get.
+		logger.Warningf("Balancer retrieved for name %q. grpc-go will be switching to case sensitive balancer registries soon", name)
+	}
 	if b, ok := m[strings.ToLower(name)]; ok {
 		return b
 	}

--- a/balancer/balancer.go
+++ b/balancer/balancer.go
@@ -40,6 +40,8 @@ import (
 var (
 	// m is a map from name to balancer builder.
 	m = make(map[string]Builder)
+
+	logger = grpclog.Component("balancer")
 )
 
 // Register registers the balancer builder to the balancer map. b.Name
@@ -56,7 +58,7 @@ func Register(b Builder) {
 		// TODO: Skip the use of strings.ToLower() to index the map after v1.59
 		// is released to switch to case insensitive balancer registry. Also,
 		// remove this warning and update the docstrings for Register and Get.
-		grpclog.Warningf("Balancer registered with name %q. grpc-go will be switching to case insensitive balancer registries soon", b.Name())
+		logger.Warningf("Balancer registered with name %q. grpc-go will be switching to case insensitive balancer registries soon", b.Name())
 	}
 	m[strings.ToLower(b.Name())] = b
 }

--- a/balancer/balancer.go
+++ b/balancer/balancer.go
@@ -56,9 +56,9 @@ var (
 func Register(b Builder) {
 	if strings.ToLower(b.Name()) != b.Name() {
 		// TODO: Skip the use of strings.ToLower() to index the map after v1.59
-		// is released to switch to case insensitive balancer registry. Also,
+		// is released to switch to case sensitive balancer registry. Also,
 		// remove this warning and update the docstrings for Register and Get.
-		logger.Warningf("Balancer registered with name %q. grpc-go will be switching to case insensitive balancer registries soon", b.Name())
+		logger.Warningf("Balancer registered with name %q. grpc-go will be switching to case sensitive balancer registries soon", b.Name())
 	}
 	m[strings.ToLower(b.Name())] = b
 }

--- a/balancer/balancer.go
+++ b/balancer/balancer.go
@@ -30,6 +30,7 @@ import (
 	"google.golang.org/grpc/channelz"
 	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/grpclog"
 	"google.golang.org/grpc/internal"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/resolver"
@@ -51,6 +52,12 @@ var (
 // an init() function), and is not thread-safe. If multiple Balancers are
 // registered with the same name, the one registered last will take effect.
 func Register(b Builder) {
+	if strings.ToLower(b.Name()) != b.Name() {
+		// TODO: Skip the use of strings.ToLower() to index the map after v1.59
+		// is released to switch to case insensitive balancer registry. Also,
+		// remove this warning and update the docstrings for Register and Get.
+		grpclog.Warningf("Balancer registered with name %q. grpc-go will be switching to case insensitive balancer registries soon", b.Name())
+	}
 	m[strings.ToLower(b.Name())] = b
 }
 

--- a/xds/internal/balancer/clusterresolver/config_test.go
+++ b/xds/internal/balancer/clusterresolver/config_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"google.golang.org/grpc/balancer"
+	"google.golang.org/grpc/balancer/roundrobin"
 	iserviceconfig "google.golang.org/grpc/internal/serviceconfig"
 	"google.golang.org/grpc/xds/internal/balancer/outlierdetection"
 	"google.golang.org/grpc/xds/internal/balancer/ringhash"
@@ -107,7 +108,7 @@ const (
     "edsServiceName": "test-eds-service-name",
     "outlierDetection": {}
   }],
-  "xdsLbPolicy":[{"ROUND_ROBIN":{}}]
+  "xdsLbPolicy":[{"round_robin":{}}]
 }`
 	testJSONConfig2 = `{
   "discoveryMechanisms": [{
@@ -124,7 +125,7 @@ const (
     "type": "LOGICAL_DNS",
     "outlierDetection": {}
   }],
-  "xdsLbPolicy":[{"ROUND_ROBIN":{}}]
+  "xdsLbPolicy":[{"round_robin":{}}]
 }`
 	testJSONConfig3 = `{
   "discoveryMechanisms": [{
@@ -138,7 +139,7 @@ const (
     "edsServiceName": "test-eds-service-name",
     "outlierDetection": {}
   }],
-  "xdsLbPolicy":[{"ROUND_ROBIN":{}}]
+  "xdsLbPolicy":[{"round_robin":{}}]
 }`
 	testJSONConfig4 = `{
   "discoveryMechanisms": [{
@@ -166,7 +167,7 @@ const (
     "edsServiceName": "test-eds-service-name",
     "outlierDetection": {}
   }],
-  "xdsLbPolicy":[{"ROUND_ROBIN":{}}]
+  "xdsLbPolicy":[{"round_robin":{}}]
 }`
 )
 
@@ -211,7 +212,7 @@ func TestParseConfig(t *testing.T) {
 					},
 				},
 				xdsLBPolicy: iserviceconfig.BalancerConfig{ // do we want to make this not pointer
-					Name:   "ROUND_ROBIN",
+					Name:   roundrobin.Name,
 					Config: nil,
 				},
 			},
@@ -248,7 +249,7 @@ func TestParseConfig(t *testing.T) {
 					},
 				},
 				xdsLBPolicy: iserviceconfig.BalancerConfig{
-					Name:   "ROUND_ROBIN",
+					Name:   roundrobin.Name,
 					Config: nil,
 				},
 			},
@@ -275,7 +276,7 @@ func TestParseConfig(t *testing.T) {
 					},
 				},
 				xdsLBPolicy: iserviceconfig.BalancerConfig{
-					Name:   "ROUND_ROBIN",
+					Name:   roundrobin.Name,
 					Config: nil,
 				},
 			},
@@ -329,7 +330,7 @@ func TestParseConfig(t *testing.T) {
 					},
 				},
 				xdsLBPolicy: iserviceconfig.BalancerConfig{
-					Name:   "ROUND_ROBIN",
+					Name:   roundrobin.Name,
 					Config: nil,
 				},
 			},


### PR DESCRIPTION
After the next release (v1.59), we can switch over to having a case sensitive balancer registry.

This PR also fixes a test which would be broken once we switch to a case sensitive balancer registry.

https://github.com/grpc/grpc-go/issues/5288

RELEASE NOTES:
- balancer: grpc will switch to case sensitive balancer names soon