### PR TITLE
balancer/weightedroundrobin: fix ticker leak on update

### DIFF
--- a/balancer/weightedroundrobin/balancer.go
+++ b/balancer/weightedroundrobin/balancer.go
@@ -369,6 +369,7 @@ func (p *picker) start(ctx context.Context) {
 	}
 	go func() {
 		ticker := time.NewTicker(time.Duration(p.cfg.WeightUpdatePeriod))
+		defer ticker.Stop()
 		for {
 			select {
 			case <-ctx.Done():


### PR DESCRIPTION
cherry-pick #6643 

RELEASE NOTES:
- balancer/weightedroundrobin: fix a memory leak caused by not stopping a `time.Ticker`