### PR TITLE
grpc: add a warning for unsupported codec

### DIFF
--- a/server.go
+++ b/server.go
@@ -1915,6 +1915,7 @@ func (s *Server) getCodec(contentSubtype string) baseCodec {
 	}
 	codec := encoding.GetCodec(contentSubtype)
 	if codec == nil {
+		logger.Warningf("Unsupported codec %q. Defaulting to %q for now. This will start to fail in future releases.", contentSubtype, proto.Name)
 		return encoding.GetCodec(proto.Name)
 	}
 	return codec


### PR DESCRIPTION
RELEASE NOTES:
- grpc: add a warning message for unsupported codecs; will stop defaulting to `proto` codec in a future release