### PR TITLE
status: fix/improve status handling

### DIFF
--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -43,9 +43,45 @@ type Status struct {
 	s *spb.Status
 }
 
+// NewWithProto returns a new status including details from statusProto.  This
+// is meant to be used by the gRPC library only.
+func NewWithProto(code codes.Code, message string, statusProto []string) *Status {
+	if len(statusProto) != 1 {
+		// No grpc-status-details bin header, or multiple; just ignore.
+		return &Status{s: &spb.Status{Code: normalizeCode(code), Message: message}}
+	}
+	st := &spb.Status{}
+	if err := proto.Unmarshal([]byte(statusProto[0]), st); err != nil {
+		// Probably not a google.rpc.Status proto; do not provide details.
+		return &Status{s: &spb.Status{Code: normalizeCode(code), Message: message}}
+	}
+	if st.Code == int32(code) {
+		// The codes match between the grpc-status header and the
+		// grpc-status-details-bin header; use the full details proto.
+		st.Code = normalizeCode(codes.Code(st.Code))
+		return &Status{s: st}
+	}
+	return &Status{
+		s: &spb.Status{
+			Code: int32(codes.Internal),
+			Message: fmt.Sprintf(
+				"grpc-status-details-bin mismatch: grpc-status=%v, grpc-message=%q, grpc-status-details-bin=%+v",
+				code, message, st,
+			),
+		},
+	}
+}
+
+func normalizeCode(c codes.Code) int32 {
+	if c > 16 {
+		return int32(codes.Unknown)
+	}
+	return int32(c)
+}
+
 // New returns a Status representing c and msg.
 func New(c codes.Code, msg string) *Status {
-	return &Status{s: &spb.Status{Code: int32(c), Message: msg}}
+	return &Status{s: &spb.Status{Code: normalizeCode(c), Message: msg}}
 }
 
 // Newf returns New(c, fmt.Sprintf(format, a...)).

--- a/internal/stubserver/stubserver.go
+++ b/internal/stubserver/stubserver.go
@@ -141,7 +141,7 @@ func (ss *StubServer) setupServer(sopts ...grpc.ServerOption) (net.Listener, err
 	}
 
 	testgrpc.RegisterTestServiceServer(ss.S, ss)
-	ss.cleanups = append(ss.cleanups, ss.S.Stop, func() { lis.Close() })
+	ss.cleanups = append(ss.cleanups, ss.S.Stop)
 	return lis, nil
 }
 

--- a/internal/stubserver/stubserver.go
+++ b/internal/stubserver/stubserver.go
@@ -165,6 +165,7 @@ func (ss *StubServer) StartHandlerServer(sopts ...grpc.ServerOption) error {
 			hs.ServeConn(conn, opts)
 		}
 	}()
+	ss.cleanups = append(ss.cleanups, func() { lis.Close() })
 
 	return nil
 }

--- a/internal/transport/handler_server.go
+++ b/internal/transport/handler_server.go
@@ -220,18 +220,20 @@ func (ht *serverHandlerTransport) WriteStatus(s *Stream, st *status.Status) erro
 			h.Set("Grpc-Message", encodeGrpcMessage(m))
 		}
 
+		s.hdrMu.Lock()
 		if p := st.Proto(); p != nil && len(p.Details) > 0 {
+			delete(s.trailer, grpcStatusDetailsBinHeader)
 			stBytes, err := proto.Marshal(p)
 			if err != nil {
 				// TODO: return error instead, when callers are able to handle it.
 				panic(err)
 			}
 
-			h.Set("Grpc-Status-Details-Bin", encodeBinHeader(stBytes))
+			h.Set(grpcStatusDetailsBinHeader, encodeBinHeader(stBytes))
 		}
 
-		if md := s.Trailer(); len(md) > 0 {
-			for k, vv := range md {
+		if len(s.trailer) > 0 {
+			for k, vv := range s.trailer {
 				// Clients don't tolerate reading restricted headers after some non restricted ones were sent.
 				if isReservedHeader(k) {
 					continue
@@ -243,6 +245,7 @@ func (ht *serverHandlerTransport) WriteStatus(s *Stream, st *status.Status) erro
 				}
 			}
 		}
+		s.hdrMu.Unlock()
 	})
 
 	if err == nil { // transport has not been closed
@@ -287,7 +290,7 @@ func (ht *serverHandlerTransport) writeCommonHeaders(s *Stream) {
 }
 
 // writeCustomHeaders sets custom headers set on the stream via SetHeader
-// on the first write call (Write, WriteHeader, or WriteStatus).
+// on the first write call (Write, WriteHeader, or WriteStatus)
 func (ht *serverHandlerTransport) writeCustomHeaders(s *Stream) {
 	h := ht.rw.Header()
 

--- a/internal/transport/http_util.go
+++ b/internal/transport/http_util.go
@@ -34,12 +34,9 @@ import (
 	"time"
 	"unicode/utf8"
 
-	"github.com/golang/protobuf/proto"
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/hpack"
-	spb "google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 const (
@@ -88,6 +85,8 @@ var (
 	}
 )
 
+var grpcStatusDetailsBinHeader = "grpc-status-details-bin"
+
 // isReservedHeader checks whether hdr belongs to HTTP2 headers
 // reserved by gRPC protocol. Any other headers are classified as the
 // user-specified metadata.
@@ -103,7 +102,6 @@ func isReservedHeader(hdr string) bool {
 		"grpc-message",
 		"grpc-status",
 		"grpc-timeout",
-		"grpc-status-details-bin",
 		// Intentionally exclude grpc-previous-rpc-attempts and
 		// grpc-retry-pushback-ms, which are "reserved", but their API
 		// intentionally works via metadata.
@@ -152,18 +150,6 @@ func decodeMetadataHeader(k, v string) (string, error) {
 		return string(b), err
 	}
 	return v, nil
-}
-
-func decodeGRPCStatusDetails(rawDetails string) (*status.Status, error) {
-	v, err := decodeBinHeader(rawDetails)
-	if err != nil {
-		return nil, err
-	}
-	st := &spb.Status{}
-	if err = proto.Unmarshal(v, st); err != nil {
-		return nil, err
-	}
-	return status.FromProto(st), nil
 }
 
 type timeoutUnit uint8

--- a/status/status_ext_test.go
+++ b/status/status_ext_test.go
@@ -21,12 +21,12 @@ package status_test
 import (
 	"context"
 	"errors"
-	"reflect"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/golang/protobuf/proto"
+	"github.com/google/go-cmp/cmp"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/internal/grpctest"
@@ -188,7 +188,7 @@ func (s) TestStatusDetails(t *testing.T) {
 					trailerGot := metadata.MD{}
 					_, errGot := ss.Client.UnaryCall(ctx, &testpb.SimpleRequest{}, grpc.Trailer(&trailerGot))
 					gsdb := trailerGot["grpc-status-details-bin"]
-					if !reflect.DeepEqual(gsdb, tc.trailerWant) {
+					if !cmp.Equal(gsdb, tc.trailerWant) {
 						t.Errorf("Trailer got: %v; want: %v", gsdb, tc.trailerWant)
 					}
 					if tc.errWant != nil && !testutils.StatusErrEqual(errGot, tc.errWant) {

--- a/status/status_ext_test.go
+++ b/status/status_ext_test.go
@@ -19,16 +19,26 @@
 package status_test
 
 import (
+	"context"
 	"errors"
+	"reflect"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/golang/protobuf/proto"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/internal/grpctest"
+	"google.golang.org/grpc/internal/stubserver"
+	"google.golang.org/grpc/internal/testutils"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 
 	testpb "google.golang.org/grpc/interop/grpc_testing"
 )
+
+const defaultTestTimeout = 10 * time.Second
 
 type s struct {
 	grpctest.Tester
@@ -78,5 +88,163 @@ func (s) TestErrorIs(t *testing.T) {
 		if is != tc.want {
 			t.Errorf("(%v).Is(%v) = %t; want %t", tc.err1, tc.err2, is, tc.want)
 		}
+	}
+}
+
+// TestStatusDetails tests how gRPC handles grpc-status-details-bin, especially
+// in cases where it doesn't match the grpc-status trailer or contains arbitrary
+// data.
+func (s) TestStatusDetails(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+
+	for _, serverType := range []struct {
+		name            string
+		startServerFunc func(*stubserver.StubServer) error
+	}{{
+		name: "normal server",
+		startServerFunc: func(ss *stubserver.StubServer) error {
+			return ss.StartServer()
+		},
+	}, {
+		name: "handler server",
+		startServerFunc: func(ss *stubserver.StubServer) error {
+			return ss.StartHandlerServer()
+		},
+	}} {
+		t.Run(serverType.name, func(t *testing.T) {
+			// Start a simple server that returns the trailer and error it receives from
+			// channels.
+			trailerCh := make(chan metadata.MD, 1)
+			errCh := make(chan error, 1)
+			ss := &stubserver.StubServer{
+				UnaryCallF: func(ctx context.Context, in *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
+					grpc.SetTrailer(ctx, <-trailerCh)
+					return nil, <-errCh
+				},
+			}
+			if err := serverType.startServerFunc(ss); err != nil {
+				t.Fatalf("Error starting endpoint server: %v", err)
+			}
+			if err := ss.StartClient(); err != nil {
+				t.Fatalf("Error starting endpoint client: %v", err)
+			}
+			defer ss.Stop()
+
+			// Convenience function for making a status including details.
+			detailErr := func(c codes.Code, m string) error {
+				s, err := status.New(c, m).WithDetails(&testpb.SimpleRequest{
+					Payload: &testpb.Payload{Body: []byte("detail msg")},
+				})
+				if err != nil {
+					t.Fatalf("Error adding details: %v", err)
+				}
+				return s.Err()
+			}
+
+			serialize := func(err error) string {
+				buf, _ := proto.Marshal(status.Convert(err).Proto())
+				return string(buf)
+			}
+
+			testCases := []struct {
+				name        string
+				trailerSent metadata.MD
+				errSent     error
+				trailerWant []string
+				errWant     error
+				errContains error
+			}{{
+				name:        "basic without details",
+				trailerSent: metadata.MD{},
+				errSent:     status.Error(codes.Aborted, "test msg"),
+				errWant:     status.Error(codes.Aborted, "test msg"),
+			}, {
+				name:        "basic without details passes through trailers",
+				trailerSent: metadata.MD{"grpc-status-details-bin": []string{"random text"}},
+				errSent:     status.Error(codes.Aborted, "test msg"),
+				trailerWant: []string{"random text"},
+				errWant:     status.Error(codes.Aborted, "test msg"),
+			}, {
+				name:        "basic without details conflicts with manual details",
+				trailerSent: metadata.MD{"grpc-status-details-bin": []string{serialize(status.Error(codes.Canceled, "test msg"))}},
+				errSent:     status.Error(codes.Aborted, "test msg"),
+				trailerWant: []string{serialize(status.Error(codes.Canceled, "test msg"))},
+				errContains: status.Error(codes.Internal, "mismatch"),
+			}, {
+				name:        "basic with details",
+				trailerSent: metadata.MD{},
+				errSent:     detailErr(codes.Aborted, "test msg"),
+				trailerWant: []string{serialize(detailErr(codes.Aborted, "test msg"))},
+				errWant:     detailErr(codes.Aborted, "test msg"),
+			}, {
+				name:        "basic with details discards user's trailers",
+				trailerSent: metadata.MD{"grpc-status-details-bin": []string{"will be ignored"}},
+				errSent:     detailErr(codes.Aborted, "test msg"),
+				trailerWant: []string{serialize(detailErr(codes.Aborted, "test msg"))},
+				errWant:     detailErr(codes.Aborted, "test msg"),
+			}}
+
+			for _, tc := range testCases {
+				t.Run(tc.name, func(t *testing.T) {
+					trailerCh <- tc.trailerSent
+					errCh <- tc.errSent
+					trailerGot := metadata.MD{}
+					_, errGot := ss.Client.UnaryCall(ctx, &testpb.SimpleRequest{}, grpc.Trailer(&trailerGot))
+					gsdb := trailerGot["grpc-status-details-bin"]
+					if !reflect.DeepEqual(gsdb, tc.trailerWant) {
+						t.Errorf("Trailer got: %v; want: %v", gsdb, tc.trailerWant)
+					}
+					if tc.errWant != nil && !testutils.StatusErrEqual(errGot, tc.errWant) {
+						t.Errorf("Err got: %v; want: %v", errGot, tc.errWant)
+					}
+					if tc.errContains != nil && (status.Code(errGot) != status.Code(tc.errContains) || !strings.Contains(status.Convert(errGot).Message(), status.Convert(tc.errContains).Message())) {
+						t.Errorf("Err got: %v; want: (Contains: %v)", errGot, tc.errWant)
+					}
+				})
+			}
+		})
+	}
+}
+
+// TestStatusCodeCollapse ensures that status codes are collapsed to UNKNOWN
+// when they are out of the valid range.
+func (s) TestStatusCodeCollapse(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+
+	for _, serverType := range []struct {
+		name            string
+		startServerFunc func(*stubserver.StubServer) error
+	}{{
+		name: "normal server",
+		startServerFunc: func(ss *stubserver.StubServer) error {
+			return ss.StartServer()
+		},
+	}, {
+		name: "handler server",
+		startServerFunc: func(ss *stubserver.StubServer) error {
+			return ss.StartHandlerServer()
+		},
+	}} {
+		t.Run(serverType.name, func(t *testing.T) {
+			errWant := status.Errorf(codes.Unknown, "test msg")
+			ss := &stubserver.StubServer{
+				UnaryCallF: func(ctx context.Context, in *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
+					return nil, status.Errorf(codes.Code(23), "test msg")
+				},
+			}
+			if err := serverType.startServerFunc(ss); err != nil {
+				t.Fatalf("Error starting endpoint server: %v", err)
+			}
+			if err := ss.StartClient(); err != nil {
+				t.Fatalf("Error starting endpoint client: %v", err)
+			}
+			defer ss.Stop()
+
+			if _, err := ss.Client.UnaryCall(ctx, &testpb.SimpleRequest{}); !testutils.StatusErrEqual(err, errWant) {
+				t.Errorf("Err got: %v; want: %v", err, errWant)
+			}
+		})
 	}
 }

--- a/status/status_test.go
+++ b/status/status_test.go
@@ -268,6 +268,14 @@ func (s) TestCodeUnknownError(t *testing.T) {
 	}
 }
 
+func (s) TestCodeOutOfRangeBecomesUnknown(t *testing.T) {
+	const code, codeWant = codes.Code(20), codes.Unknown
+	err := fmt.Errorf("wrapped: %w", Error(code, "test description"))
+	if s := Code(err); s != codeWant {
+		t.Fatalf("Code(%v) = %v; want <Code()=%s>", err, s, codeWant)
+	}
+}
+
 func (s) TestCodeWrapped(t *testing.T) {
 	const code = codes.Internal
 	err := fmt.Errorf("wrapped: %w", Error(code, "test description"))

--- a/test/balancer_test.go
+++ b/test/balancer_test.go
@@ -246,7 +246,7 @@ func testDoneInfo(t *testing.T, e env) {
 	defer cancel()
 	wantErr := detailedError
 	if _, err := tc.EmptyCall(ctx, &testpb.Empty{}); !testutils.StatusErrEqual(err, wantErr) {
-		t.Fatalf("TestService/EmptyCall(_, _) = _, %v, want _, %v", err, wantErr)
+		t.Fatalf("TestService/EmptyCall(_, _) = _, %v, want _, %v", status.Convert(err).Proto(), status.Convert(wantErr).Proto())
 	}
 	if _, err := tc.UnaryCall(ctx, &testpb.SimpleRequest{}); err != nil {
 		t.Fatalf("TestService.UnaryCall(%v, _, _, _) = _, %v; want _, <nil>", ctx, err)


### PR DESCRIPTION
Fixes #5485

cc @ejona86 @markdroth FYI / to review the behavior to confirm it conforms to the grpc spec or the intentions of the spec, since there is unfortunately no written spec for `grpc-status-details-bin`.


### API-layer:

If the user sets a status code outside the bounds defined in the `codes` package 0-16 (inclusive), set the status code to `codes.Unknown`.  This impacts statuses created locally as well as statuses received in RPC response trailers.  See https://github.com/grpc/grpc-java/issues/10568 for evidence this may be happening in the wild.

_Previous behavior_: allowed any value to be used and set on the wire (server) or read from the wire (client).

### Client-side:

When receiving a `grpc-status-details-bin` trailer:

- If there is 1 value and it deserializes into a `google.rpc.Status`, ensure the code field matches the `grpc-status` header's code.  If it does not match, convert the code to `codes.Internal` and set a message indicating the mismatch.  If it does, the status will contain the full details of the `grpc-status-details-bin` proto.  (Note that `grpc-message` will not be checked against the proto's message field, and will be silently discarded if there is a mismatch.)

- Otherwise, the status returned to the application will use the `grpc-status` and `grpc-message` values only.

- In all cases, the raw `grpc-status-details-bin` trailer will be visible to the application via `trailer["grpc-status-details-bin"]` (where `trailer` is either obtained via the `grpc.Trailer()` `CallOption` or `grpc.ClientStream.Trailer()`).

_Previous behavior_: use the `grpc-status-details-bin`, if present, directly, ignoring `grpc-status` and `grpc-message`, and returning a different error to the application if it could not be parsed as a `google.rpc.Status`.

### Server-side:

If the user manually sets `grpc-status-details-bin` in the trailers:

- If the status returned by the method handler _does not_ include details (see `status.(*Status).WithDetails`), the transport will send the user's `grpc-status-details-bin` trailer(s) directly.

- If the status returned by the method handler _does_ include details, the transport will disregard the user's trailer(s) and replace them with a serialized `google.rpc.Status` proto version of the returned status.

_Previous behavior_: ignore any `grpc-status-details-bin` set by the user and set it automatically as a proto if details were present in the returned status.

### Internal

This change also adds a way to use the stub server with the handler transport.


RELEASE NOTES:
- status: enforce that all status codes must be a valid `code.Code`; other values will be converted to `codes.Unknown`  AND server: allow applications to send arbitrary data in the `grpc-status-details-bin` trailer  AND  client: validate `grpc-status-details-bin` trailer and pass through the trailer to the application directly