### PR TITLE
attributes: avoid the use of %#v formatting verb

### DIFF
--- a/attributes/attributes.go
+++ b/attributes/attributes.go
@@ -127,7 +127,7 @@ func str(x any) (s string) {
 	} else if v, ok := x.(string); ok {
 		return v
 	}
-	return fmt.Sprintf("%#v", x)
+	return fmt.Sprintf("<%p>", x)
 }
 
 // MarshalJSON helps implement the json.Marshaler interface, thereby rendering

--- a/attributes/attributes_test.go
+++ b/attributes/attributes_test.go
@@ -85,14 +85,14 @@ func ExampleAttributes_String() {
 	fmt.Println("a7:", a7.String())
 	fmt.Println("a8:", a8.String())
 	// Output:
-	// a1: {"attributes_test.key{}": "<nil>" }
-	// a2: {"attributes_test.key{}": "<nil>" }
-	// a3: {"attributes_test.key{}": "(*attributes_test.stringVal)(nil)" }
-	// a4: {"attributes_test.key{}": "<nil>" }
-	// a5: {"attributes_test.key{}": "1" }
-	// a6: {"attributes_test.key{}": "two" }
-	// a7: {"attributes_test.key{}": "attributes_test.stringVal{s:\"two\"}" }
-	// a8: {"1": "true" }
+	// a1: {"<%!p(attributes_test.key={})>": "<nil>" }
+	// a2: {"<%!p(attributes_test.key={})>": "<nil>" }
+	// a3: {"<%!p(attributes_test.key={})>": "<0x0>" }
+	// a4: {"<%!p(attributes_test.key={})>": "<%!p(<nil>)>" }
+	// a5: {"<%!p(attributes_test.key={})>": "<%!p(int=1)>" }
+	// a6: {"<%!p(attributes_test.key={})>": "two" }
+	// a7: {"<%!p(attributes_test.key={})>": "<%!p(attributes_test.stringVal={two})>" }
+	// a8: {"<%!p(int=1)>": "<%!p(bool=true)>" }
 }
 
 // Test that two attributes with the same content are Equal.


### PR DESCRIPTION
The `%#v` formatting verb looks deep into structs which are passed by pointer as well. This means that if a struct contains a `sync.Mutex` and is a key or value in the `attributes`, then printing the `attributes` with the `%#v` verb will result in the fields of this struct being accessed without holding the mutex.

While this does not introduce correctness issues in the code (we might end up with inconsistent data in the log messages where the `attributes` are printed), this causes our tests to be super flaky when run with the go race detector. And it wasn't straight-forward to figure out why the race was happening when looking at the stack traces reported by the race detector.

This PR eliminates this race by using the `%p` verb that we were using earlier. While this results in some sub-optimal logging output of the `attributes`, this is much better than having flaky tests.

RELEASE NOTES: none