### PR TITLE
grpc: disable and document overrides of OS default TCP keepalive by Go

### DIFF
--- a/benchmark/benchmain/main.go
+++ b/benchmark/benchmain/main.go
@@ -373,7 +373,7 @@ func makeClients(bf stats.Features) ([]testgrpc.BenchmarkServiceClient, func()) 
 			logger.Fatalf("Failed to listen: %v", err)
 		}
 		opts = append(opts, grpc.WithContextDialer(func(ctx context.Context, address string) (net.Conn, error) {
-			return nw.ContextDialer((&net.Dialer{}).DialContext)(ctx, "tcp", lis.Addr().String())
+			return nw.ContextDialer((&net.Dialer{KeepAlive: time.Duration(-1)}).DialContext)(ctx, "tcp", lis.Addr().String())
 		}))
 	}
 	lis = nw.Listener(lis)

--- a/dialoptions.go
+++ b/dialoptions.go
@@ -419,7 +419,7 @@ func WithTimeout(d time.Duration) DialOption {
 // To retain OS defaults, use a net.Dialer with the KeepAlive field set to a
 // negative value.
 //
-// For more information, please see [issue 23459] in the Go github repo
+// For more information, please see [issue 23459] in the Go github repo.
 //
 // [issue 23459]: https://github.com/golang/go/issues/23459
 func WithContextDialer(f func(context.Context, string) (net.Conn, error)) DialOption {

--- a/dialoptions.go
+++ b/dialoptions.go
@@ -414,7 +414,7 @@ func WithTimeout(d time.Duration) DialOption {
 // returned by f, gRPC checks the error's Temporary() method to decide if it
 // should try to reconnect to the network address.
 //
-// Note: As of Go 1.13, the standard library overrides the OS defaults for
+// Note: As of Go 1.21, the standard library overrides the OS defaults for
 // TCP keepalive time and interval to 15s.
 // To retain OS defaults, use a net.Dialer with the KeepAlive field set to a
 // negative value.

--- a/dialoptions.go
+++ b/dialoptions.go
@@ -415,7 +415,8 @@ func WithTimeout(d time.Duration) DialOption {
 // should try to reconnect to the network address.
 //
 // Note: Go overrides the OS defaults for TCP keepalive time and interval to 15s.
-// To retain OS defaults, use a net.Dialer with the KeepAlive field set to a negative value.
+// To retain OS defaults, use a net.Dialer with the KeepAlive field set to a
+// negative value.
 func WithContextDialer(f func(context.Context, string) (net.Conn, error)) DialOption {
 	return newFuncDialOption(func(o *dialOptions) {
 		o.copts.Dialer = f

--- a/dialoptions.go
+++ b/dialoptions.go
@@ -413,6 +413,9 @@ func WithTimeout(d time.Duration) DialOption {
 // connections. If FailOnNonTempDialError() is set to true, and an error is
 // returned by f, gRPC checks the error's Temporary() method to decide if it
 // should try to reconnect to the network address.
+//
+// Note: Go overrides the OS defaults for TCP keepalive interval to 15s.
+// To retain the OS defaults, pass in a custom dialer with KeepAlive set to a negative duration.
 func WithContextDialer(f func(context.Context, string) (net.Conn, error)) DialOption {
 	return newFuncDialOption(func(o *dialOptions) {
 		o.copts.Dialer = f

--- a/dialoptions.go
+++ b/dialoptions.go
@@ -414,9 +414,14 @@ func WithTimeout(d time.Duration) DialOption {
 // returned by f, gRPC checks the error's Temporary() method to decide if it
 // should try to reconnect to the network address.
 //
-// Note: Go overrides the OS defaults for TCP keepalive time and interval to 15s.
+// Note: As of Go 1.13, the standard library overrides the OS defaults for
+// TCP keepalive time and interval to 15s.
 // To retain OS defaults, use a net.Dialer with the KeepAlive field set to a
 // negative value.
+//
+// For more information, please see [issue 23459] in the Go github repo
+//
+// [issue 23459]: https://github.com/golang/go/issues/23459
 func WithContextDialer(f func(context.Context, string) (net.Conn, error)) DialOption {
 	return newFuncDialOption(func(o *dialOptions) {
 		o.copts.Dialer = f

--- a/dialoptions.go
+++ b/dialoptions.go
@@ -414,8 +414,8 @@ func WithTimeout(d time.Duration) DialOption {
 // returned by f, gRPC checks the error's Temporary() method to decide if it
 // should try to reconnect to the network address.
 //
-// Note: Go overrides the OS defaults for TCP keepalive interval to 15s.
-// To retain the OS defaults, pass in a custom dialer with KeepAlive set to a negative duration.
+// Note: Go overrides the OS defaults for TCP keepalive time and interval to 15s.
+// To retain OS defaults, use a net.Dialer with the KeepAlive field set to a negative value.
 func WithContextDialer(f func(context.Context, string) (net.Conn, error)) DialOption {
 	return newFuncDialOption(func(o *dialOptions) {
 		o.copts.Dialer = f

--- a/examples/helloworld/greeter_server/main.go
+++ b/examples/helloworld/greeter_server/main.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"log"
 	"net"
-	"time"
 
 	"google.golang.org/grpc"
 	pb "google.golang.org/grpc/examples/helloworld/helloworld"
@@ -48,9 +47,7 @@ func (s *server) SayHello(ctx context.Context, in *pb.HelloRequest) (*pb.HelloRe
 
 func main() {
 	flag.Parse()
-	// Setting KeepAlive to -1 allows the listener to retain OS default TCP keepalive time and interval.
-	lc := net.ListenConfig{KeepAlive: time.Duration(-1)}
-	lis, err := lc.Listen(context.Background(), "tcp", fmt.Sprintf(":%d", *port))
+	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", *port))
 	if err != nil {
 		log.Fatalf("failed to listen: %v", err)
 	}

--- a/examples/helloworld/greeter_server/main.go
+++ b/examples/helloworld/greeter_server/main.go
@@ -48,10 +48,8 @@ func (s *server) SayHello(ctx context.Context, in *pb.HelloRequest) (*pb.HelloRe
 
 func main() {
 	flag.Parse()
-	// ListenConfig allows options to be passed to the listener.
-	var lc net.ListenConfig
-	// Setting KeepAlive to -1 allows the listener to retain OS default TCP keep-alive interval.
-	lc.KeepAlive = time.Duration(-1)
+	// Setting KeepAlive to -1 allows the listener to retain OS default TCP keepalive time and interval.
+	lc := net.ListenConfig{KeepAlive: time.Duration(-1)}
 	lis, err := lc.Listen(context.Background(), "tcp", fmt.Sprintf(":%d", *port))
 	if err != nil {
 		log.Fatalf("failed to listen: %v", err)

--- a/examples/helloworld/greeter_server/main.go
+++ b/examples/helloworld/greeter_server/main.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"time"
 
 	"google.golang.org/grpc"
 	pb "google.golang.org/grpc/examples/helloworld/helloworld"
@@ -47,7 +48,11 @@ func (s *server) SayHello(ctx context.Context, in *pb.HelloRequest) (*pb.HelloRe
 
 func main() {
 	flag.Parse()
-	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", *port))
+	// ListenConfig allows options to be passed to the listener.
+	var lc net.ListenConfig
+	// Setting KeepAlive to -1 allows the listener to retain OS default TCP keep-alive interval.
+	lc.KeepAlive = time.Duration(-1)
+	lis, err := lc.Listen(context.Background(), "tcp", fmt.Sprintf(":%d", *port))
 	if err != nil {
 		log.Fatalf("failed to listen: %v", err)
 	}

--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -176,7 +176,8 @@ func dial(ctx context.Context, fn func(context.Context, string) (net.Conn, error
 	if networkType == "tcp" && useProxy {
 		return proxyDial(ctx, address, grpcUA)
 	}
-	// KeepAlive is set to a negative value to prevent Go's override of the TCP keepalive time and interval; retain the OS default.
+	// KeepAlive is set to a negative value to prevent Go's override of the TCP
+	// keepalive time and interval; retain the OS default.
 	return (&net.Dialer{KeepAlive: time.Duration(-1)}).DialContext(ctx, networkType, address)
 }
 

--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -176,7 +176,7 @@ func dial(ctx context.Context, fn func(context.Context, string) (net.Conn, error
 	if networkType == "tcp" && useProxy {
 		return proxyDial(ctx, address, grpcUA)
 	}
-	return (&net.Dialer{}).DialContext(ctx, networkType, address)
+	return (&net.Dialer{KeepAlive: time.Duration(-1)}).DialContext(ctx, networkType, address)
 }
 
 func isTemporary(err error) bool {

--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -176,6 +176,7 @@ func dial(ctx context.Context, fn func(context.Context, string) (net.Conn, error
 	if networkType == "tcp" && useProxy {
 		return proxyDial(ctx, address, grpcUA)
 	}
+	// KeepAlive is set to a negative value to prevent Go's override of the TCP keepalive time and interval; retain the OS default.
 	return (&net.Dialer{KeepAlive: time.Duration(-1)}).DialContext(ctx, networkType, address)
 }
 

--- a/internal/transport/proxy.go
+++ b/internal/transport/proxy.go
@@ -28,6 +28,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"time"
 )
 
 const proxyAuthHeaderKey = "Proxy-Authorization"
@@ -122,7 +123,7 @@ func proxyDial(ctx context.Context, addr string, grpcUA string) (conn net.Conn, 
 		newAddr = proxyURL.Host
 	}
 
-	conn, err = (&net.Dialer{}).DialContext(ctx, "tcp", newAddr)
+	conn, err = (&net.Dialer{KeepAlive: time.Duration(-1)}).DialContext(ctx, "tcp", newAddr)
 	if err != nil {
 		return
 	}

--- a/server.go
+++ b/server.go
@@ -814,10 +814,14 @@ func (l *listenSocket) Close() error {
 // this method returns.
 // Serve will return a non-nil error unless Stop or GracefulStop is called.
 //
-// Note: Go overrides OS defaults for TCP keepalive time and interval to 15s.
+// Note: As of Go 1.13, the standard library overrides the OS defaults for
+// TCP keepalive time and interval to 15s.
 // To retain OS defaults, pass a net.Listener created by calling the Listen method
-// on a net.ListenConfig with the `KeepAlive` field set to a negative value. See
-// helloworld/greeter_server/main.go for an example.
+// on a net.ListenConfig with the `KeepAlive` field set to a negative value.
+//
+// For more information, please see [issue 23459] in the Go github repo
+//
+// [issue 23459]: https://github.com/golang/go/issues/23459
 func (s *Server) Serve(lis net.Listener) error {
 	s.mu.Lock()
 	s.printf("serving")

--- a/server.go
+++ b/server.go
@@ -819,7 +819,7 @@ func (l *listenSocket) Close() error {
 // To retain OS defaults, pass a net.Listener created by calling the Listen method
 // on a net.ListenConfig with the `KeepAlive` field set to a negative value.
 //
-// For more information, please see [issue 23459] in the Go github repo
+// For more information, please see [issue 23459] in the Go github repo.
 //
 // [issue 23459]: https://github.com/golang/go/issues/23459
 func (s *Server) Serve(lis net.Listener) error {

--- a/server.go
+++ b/server.go
@@ -814,11 +814,10 @@ func (l *listenSocket) Close() error {
 // this method returns.
 // Serve will return a non-nil error unless Stop or GracefulStop is called.
 //
-// Note: Go overrides the OS defaults for TCP keepalive interval to 15s.
-// To retain the OS defaults, you will need to create a net.ListenConfig with the
-// KeepAlive parameter set to a negative value and use the Listen method on it to create
-// the net.Listener to pass to this function.
-// See https://github.com/grpc/grpc-go/blob/master/examples/helloworld/greeter_client/main.go#L51
+// Note: Go overrides OS defaults for TCP keepalive time and interval to 15s.
+// To retain OS defaults, pass a net.Listener created by calling the Listen method
+// on a net.ListenConfig with the `KeepAlive` field set to a negative value. See
+// helloworld/greeter_server/main.go for an example.
 func (s *Server) Serve(lis net.Listener) error {
 	s.mu.Lock()
 	s.printf("serving")

--- a/server.go
+++ b/server.go
@@ -814,7 +814,7 @@ func (l *listenSocket) Close() error {
 // this method returns.
 // Serve will return a non-nil error unless Stop or GracefulStop is called.
 //
-// Note: As of Go 1.13, the standard library overrides the OS defaults for
+// Note: As of Go 1.21, the standard library overrides the OS defaults for
 // TCP keepalive time and interval to 15s.
 // To retain OS defaults, pass a net.Listener created by calling the Listen method
 // on a net.ListenConfig with the `KeepAlive` field set to a negative value.

--- a/server.go
+++ b/server.go
@@ -813,6 +813,12 @@ func (l *listenSocket) Close() error {
 // Serve returns when lis.Accept fails with fatal errors.  lis will be closed when
 // this method returns.
 // Serve will return a non-nil error unless Stop or GracefulStop is called.
+//
+// Note: Go overrides the OS defaults for TCP keepalive interval to 15s.
+// To retain the OS defaults, you will need to create a net.ListenConfig with the
+// KeepAlive parameter set to a negative value and use the Listen method on it to create
+// the net.Listener to pass to this function.
+// See https://github.com/grpc/grpc-go/blob/master/examples/helloworld/greeter_client/main.go#L51
 func (s *Server) Serve(lis net.Listener) error {
 	s.mu.Lock()
 	s.printf("serving")


### PR DESCRIPTION
Pertaining to #6250 

Summary of Changes made (as suggested by @easwars):
- `transport/http2_client.go`: Disable Go's override of OS default TCP keepalive interval (currently 15s) on the client-side
- Add documentation to retain OS defaults on server-side and example to implement it within `helloworld/greeter_server`

I am still unable to replicate the bug mentioned originally in the issue and test whether my changes on client-side will fix it. 

grpc version: v1.58.2
go version: go1.20.4 darwin/arm64
OS: macOS Ventura 13.4

<img width="1485" alt="image" src="https://github.com/grpc/grpc-go/assets/90945854/0d8e0058-9a0e-43c1-8f6a-a42b859505a3">

at packet 3773, I applied the rule to `pftcl`:

```
block drop in on lo0 proto tcp from any to any port = 8080
```

but my server does not reset the connection after a single lost keepalive packet (I am using the default keepalive settings on both client and server side).


RELEASE NOTES: none