### PR TITLE
resolver: Add an endpoint map type

### DIFF
--- a/resolver/map.go
+++ b/resolver/map.go
@@ -230,9 +230,9 @@ func (em *EndpointMap) Values() []any {
 	return ret
 }
 
-// find returns the pointer to endpoint node in the EndpointMap endpoints map if
-// the endpoint node is already present. If not found, nil is returned. The
-// comparisons are done on the unordered set of addresses within an endpoint.
+// find returns a pointer to the endpoint node in em if the endpoint node is
+// already present. If not found, nil is returned. The comparisons are done on
+// the unordered set of addresses within an endpoint.
 func (em EndpointMap) find(e endpointNode) *endpointNode {
 	for endpoint := range em.endpoints {
 		if e.Equal(endpoint) {

--- a/resolver/map.go
+++ b/resolver/map.go
@@ -167,8 +167,8 @@ func toEndpointNode(endpoint Endpoint) endpointNode {
 
 // EndpointMap is a map of endpoints to arbitrary values keyed on only the
 // unordered set of address strings within an endpoint. This map is not thread
-// safe, cannot access multiple times concurrently. The zero value for an
-// EndpointMap is an empty EndpointMap ready to use.
+// safe, thus it is unsafe to access concurrently. Must be created via
+// NewEndpointMap; do not construct directly.
 type EndpointMap struct {
 	endpoints map[*endpointNode]any
 }
@@ -248,8 +248,7 @@ func (em EndpointMap) find(e endpointNode) *endpointNode {
 // Delete removes the specified endpoint from the map.
 func (em *EndpointMap) Delete(e Endpoint) {
 	en := toEndpointNode(e)
-	entry := em.find(en)
-	if entry != nil {
+	if entry := em.find(en); entry != nil {
 		delete(em.endpoints, entry)
 	}
 }

--- a/resolver/map.go
+++ b/resolver/map.go
@@ -139,12 +139,11 @@ func (a *AddressMap) Values() []any {
 
 type endpointNode struct {
 	addrs map[string]int
-	val   any
 }
 
 // Equal returns whether the unordered set of addrs counts are the same between
 // the endpoint nodes.
-func (en endpointNode) Equal(en2 endpointNode) bool {
+func (en *endpointNode) Equal(en2 *endpointNode) bool {
 	if len(en.addrs) != len(en2.addrs) {
 		return false
 	}
@@ -171,20 +170,21 @@ func toEndpointNode(endpoint Endpoint) endpointNode {
 // safe, cannot access multiple times concurrently. The zero value for an
 // EndpointMap is an empty EndpointMap ready to use.
 type EndpointMap struct {
-	// Use a slice instead of a map is because slices or maps cannot be used as
-	// map keys. Thus, for efficiency store as a map and compare to others so
-	// each node comparison is o(n), where n is the number of unique addresses
-	// in the endpoint rather than having to sort a list on each comparison
-	// which is n(log(n)) (cannot use slices for the latter case or maps for the
-	// former case as map keys, so needs to be a list).
-	endpoints []endpointNode // Cannot use maps as a map key. Thus, keep a list, and o(n) search. Not on RPC fast path so efficiency not as important.
+	endpoints map[*endpointNode]any
+}
+
+// NewEndpointMap creates a new EndpointMap.
+func NewEndpointMap() *EndpointMap {
+	return &EndpointMap{
+		endpoints: make(map[*endpointNode]any),
+	}
 }
 
 // Get returns the value for the address in the map, if present.
 func (em *EndpointMap) Get(e Endpoint) (value any, ok bool) {
 	en := toEndpointNode(e)
-	if i := em.find(en); i != -1 {
-		return em.endpoints[i].val, true
+	if endpoint := em.find(en); endpoint != nil {
+		return em.endpoints[endpoint], true
 	}
 	return nil, false
 }
@@ -192,12 +192,11 @@ func (em *EndpointMap) Get(e Endpoint) (value any, ok bool) {
 // Set updates or adds the value to the address in the map.
 func (em *EndpointMap) Set(e Endpoint, value any) {
 	en := toEndpointNode(e)
-	if i := em.find(en); i != -1 {
-		em.endpoints[i].val = value
+	if endpoint := em.find(en); endpoint != nil {
+		em.endpoints[endpoint] = value
 		return
 	}
-	en.val = value
-	em.endpoints = append(em.endpoints, en)
+	em.endpoints[&en] = value
 }
 
 // Len returns the number of entries in the map.
@@ -211,7 +210,7 @@ func (em *EndpointMap) Len() int {
 // the full endpoint data but can be used for EndpointMap accesses.
 func (em *EndpointMap) Keys() []Endpoint { // TODO: Persist the whole endpoint data to return in nodes? No use case now, but one could come up in future.
 	ret := make([]Endpoint, 0, len(em.endpoints))
-	for _, en := range em.endpoints {
+	for en := range em.endpoints {
 		var endpoint Endpoint
 		for addr, count := range en.addrs {
 			for i := 0; i < count; i++ {
@@ -228,34 +227,29 @@ func (em *EndpointMap) Keys() []Endpoint { // TODO: Persist the whole endpoint d
 // Values returns a slice of all current map values.
 func (em *EndpointMap) Values() []any {
 	ret := make([]any, 0, len(em.endpoints))
-	for _, en := range em.endpoints {
-		ret = append(ret, en.val)
+	for _, val := range em.endpoints {
+		ret = append(ret, val)
 	}
 	return ret
 }
 
-// find returns the index of endpoint in the EndpointMap endpoints slice, or -1
-// if not present. The comparisons are done on the unordered set of the
-// addresses within an endpoint.
-func (em EndpointMap) find(e endpointNode) int {
-	for i, endpoint := range em.endpoints {
-		if endpoint.Equal(e) {
-			return i
+// find returns the pointer to endpoint node in the EndpointMap endpoints map if
+// the endpoint node is already present. If not found, nil is returned. The
+// comparisons are done on the unordered set of addresses within an endpoint.
+func (em EndpointMap) find(e endpointNode) *endpointNode {
+	for endpoint := range em.endpoints {
+		if e.Equal(endpoint) {
+			return endpoint
 		}
 	}
-	return -1
+	return nil
 }
 
 // Delete removes the specified endpoint from the map.
 func (em *EndpointMap) Delete(e Endpoint) {
 	en := toEndpointNode(e)
 	entry := em.find(en)
-	if entry == -1 {
-		return
+	if entry != nil {
+		delete(em.endpoints, entry)
 	}
-	if len(em.endpoints) == 1 {
-		em.endpoints = nil
-	}
-	copy(em.endpoints[entry:], em.endpoints[entry+1:])
-	em.endpoints = em.endpoints[:len(em.endpoints)-1]
 }

--- a/resolver/map.go
+++ b/resolver/map.go
@@ -136,3 +136,134 @@ func (a *AddressMap) Values() []any {
 	}
 	return ret
 }
+
+type endpointNodeList []endpointNode
+
+type endpointNode struct {
+	addrs map[string]int
+	val   any
+}
+
+// Equal returns whether the unordered set of addrs counts are the same between
+// the endpoint nodes.
+func (en endpointNode) Equal(en2 endpointNode) bool {
+	if len(en.addrs) != len(en2.addrs) {
+		return false
+	}
+	for addr, count := range en.addrs {
+		if count2, ok := en2.addrs[addr]; !ok || count != count2 {
+			return false
+		}
+	}
+	return true
+}
+
+func toEndpointNode(endpoint Endpoint) endpointNode {
+	en := make(map[string]int)
+	for _, addr := range endpoint.Addresses {
+		if count, ok := en[addr.Addr]; ok {
+			en[addr.Addr] = count + 1
+		}
+		en[addr.Addr] = 1
+	}
+	return endpointNode{
+		addrs: en,
+	}
+}
+
+// EndpointMap is a map of endpoints to arbitrary values keyed on only the
+// unordered set of addresses string within an endpoint. The reason this uses a
+// slice instead of a map is because slices or maps cannot be used as map keys.
+// Thus, for efficiency store as a map and compare to others so each node
+// comparison is o(n), where n is the number of unique addresses in the endpoint
+// rather than having to sort a list on each comparison which is n(log(n))
+// (cannot use slices for the latter case or maps for the former case as map
+// keys, so needs to be a list).
+type EndpointMap struct {
+	endpoints endpointNodeList // Cannot use maps as a map key. Thus, keep a list, and o(n) search. Not on RPC fast path so efficiency not as important.
+}
+
+// NewEndpointMap returns a new EndpointMap.
+func NewEndpointMap() *EndpointMap {
+	return &EndpointMap{}
+}
+
+// Get returns the value for the address in the map, if present.
+func (em *EndpointMap) Get(e Endpoint) (value any, ok bool) {
+	en := toEndpointNode(e)
+	if i := em.endpoints.find(en); i != -1 {
+		return em.endpoints[i].val, true
+	}
+	return nil, false
+}
+
+// Set updates or adds the value to the address in the map.
+func (em *EndpointMap) Set(e Endpoint, value any) {
+	en := toEndpointNode(e)
+	if i := em.endpoints.find(en); i != -1 {
+		em.endpoints[i].val = value
+		return
+	}
+	en.val = value
+	em.endpoints = append(em.endpoints, en)
+}
+
+// Len returns the number of entries in the map.
+func (em *EndpointMap) Len() int {
+	return len(em.endpoints)
+}
+
+// Keys returns a slice of all current map keys, as endpoints specifying the
+// addresses present in the endpoint keys, in which uniqueness is determined by
+// the unordered set of addresses. Thus, endpoint information returned is not
+// the full endpoint data but can be used for EndpointMap accesses.
+func (em *EndpointMap) Keys() []Endpoint { // TODO: Persist the whole endpoint data to return in nodes? No use case now, but one could come up in future.
+	ret := make([]Endpoint, 0, len(em.endpoints))
+	for _, en := range em.endpoints {
+		var endpoint Endpoint
+		for addr, count := range en.addrs {
+			for i := 0; i < count; i++ {
+				endpoint.Addresses = append(endpoint.Addresses, Address{
+					Addr: addr,
+				})
+			}
+		}
+		ret = append(ret, endpoint)
+	}
+	return ret
+}
+
+// Values returns a slice of all current map values.
+func (em *EndpointMap) Values() []any {
+	ret := make([]any, 0, len(em.endpoints))
+	for _, en := range em.endpoints {
+		ret = append(ret, en.val)
+	}
+	return ret
+}
+
+// find returns the index of endpoint in the endpointNodeList slice, or -1 if
+// not present. The comparisons are done on the unordered set of the addresses
+// within endpoint.
+func (l endpointNodeList) find(e endpointNode) int {
+	for i, endpoint := range l {
+		if endpoint.Equal(e) {
+			return i
+		}
+	}
+	return -1
+}
+
+// Delete removes the specified endpoint from the map.
+func (em *EndpointMap) Delete(e Endpoint) {
+	en := toEndpointNode(e)
+	entry := em.endpoints.find(en)
+	if entry == -1 {
+		return
+	}
+	if len(em.endpoints) == 1 {
+		em.endpoints = nil
+	}
+	copy(em.endpoints[entry:], em.endpoints[entry+1:])
+	em.endpoints = em.endpoints[:len(em.endpoints)-1]
+}

--- a/resolver/map_test.go
+++ b/resolver/map_test.go
@@ -38,6 +38,17 @@ var (
 	addr5 = Address{Addr: "a1", Attributes: attributes.New("a1", "3"), ServerName: "s1"}
 	addr6 = Address{Addr: "a1", Attributes: attributes.New("a1", 3), ServerName: "s2"}
 	addr7 = Address{Addr: "a1", Attributes: attributes.New("a1", 3), ServerName: "s1", BalancerAttributes: attributes.New("xx", 3)}
+
+	endpoint1   = Endpoint{Addresses: []Address{{Addr: "addr1"}}}
+	endpoint2   = Endpoint{Addresses: []Address{{Addr: "addr2"}}}
+	endpoint3   = Endpoint{Addresses: []Address{{Addr: "addr3"}}}
+	endpoint4   = Endpoint{Addresses: []Address{{Addr: "addr4"}}}
+	endpoint5   = Endpoint{Addresses: []Address{{Addr: "addr5"}}}
+	endpoint6   = Endpoint{Addresses: []Address{{Addr: "addr6"}}}
+	endpoint7   = Endpoint{Addresses: []Address{{Addr: "addr7"}}}
+	endpoint12  = Endpoint{Addresses: []Address{{Addr: "addr1"}, {Addr: "addr2"}}}
+	endpoint21  = Endpoint{Addresses: []Address{{Addr: "addr2"}, {Addr: "addr1"}}}
+	endpoint123 = Endpoint{Addresses: []Address{{Addr: "addr1"}, {Addr: "addr2"}, {Addr: "addr3"}}}
 )
 
 func (s) TestAddressMap_Length(t *testing.T) {
@@ -159,5 +170,120 @@ func (s) TestAddressMap_Values(t *testing.T) {
 	sort.Ints(got)
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Fatalf("addrMap.Values returned unexpected elements (-want, +got):\n%v", diff)
+	}
+}
+
+func (s) TestEndpointMap_Length(t *testing.T) {
+	em := NewEndpointMap()
+	// Should be empty at creation time.
+	if got := em.Len(); got != 0 {
+		t.Fatalf("em.Len() = %v; want 0", got)
+	}
+	// Add two endpoints with the same unordered set of addresses. This should
+	// amount to one endpoint. It should also not take into account attributes.
+	em.Set(endpoint12, struct{}{})
+	em.Set(endpoint21, struct{}{})
+
+	if got := em.Len(); got != 1 {
+		t.Fatalf("em.Len() = %v; want 1", got)
+	}
+
+	// Add another unique endpoint. This should cause the length to be 2.
+	em.Set(endpoint123, struct{}{})
+	if got := em.Len(); got != 2 {
+		t.Fatalf("em.Len() = %v; want 2", got)
+	}
+}
+
+func (s) TestEndpointMap_Get(t *testing.T) {
+	em := NewEndpointMap()
+	em.Set(endpoint1, 1)
+	// The second endpoint endpoint21 should override.
+	em.Set(endpoint12, 1)
+	em.Set(endpoint21, 2)
+	em.Set(endpoint3, 3)
+	em.Set(endpoint4, 4)
+	em.Set(endpoint5, 5)
+	em.Set(endpoint6, 6)
+	em.Set(endpoint7, 7)
+
+	if got, ok := em.Get(endpoint1); !ok || got.(int) != 1 {
+		t.Fatalf("em.Get(endpoint1) = %v, %v; want %v, true", got, ok, 1)
+	}
+	if got, ok := em.Get(endpoint12); !ok || got.(int) != 2 {
+		t.Fatalf("em.Get(endpoint12) = %v, %v; want %v, true", got, ok, 2)
+	}
+	if got, ok := em.Get(endpoint21); !ok || got.(int) != 2 {
+		t.Fatalf("em.Get(endpoint21) = %v, %v; want %v, true", got, ok, 2)
+	}
+	if got, ok := em.Get(endpoint3); !ok || got.(int) != 3 {
+		t.Fatalf("em.Get(endpoint1) = %v, %v; want %v, true", got, ok, 3)
+	}
+	if got, ok := em.Get(endpoint4); !ok || got.(int) != 4 {
+		t.Fatalf("em.Get(endpoint1) = %v, %v; want %v, true", got, ok, 4)
+	}
+	if got, ok := em.Get(endpoint5); !ok || got.(int) != 5 {
+		t.Fatalf("em.Get(endpoint1) = %v, %v; want %v, true", got, ok, 5)
+	}
+	if got, ok := em.Get(endpoint6); !ok || got.(int) != 6 {
+		t.Fatalf("em.Get(endpoint1) = %v, %v; want %v, true", got, ok, 6)
+	}
+	if got, ok := em.Get(endpoint7); !ok || got.(int) != 7 {
+		t.Fatalf("em.Get(endpoint1) = %v, %v; want %v, true", got, ok, 7)
+	}
+	if _, ok := em.Get(endpoint123); ok {
+		t.Fatalf("em.Get(endpoint123) = _, %v; want _, false", ok)
+	}
+}
+
+func (s) TestEndpointMap_Delete(t *testing.T) {
+	em := NewEndpointMap()
+	// Initial state of system: [1, 2, 3, 12]
+	em.Set(endpoint1, struct{}{})
+	em.Set(endpoint2, struct{}{})
+	em.Set(endpoint3, struct{}{})
+	em.Set(endpoint12, struct{}{})
+	// Delete: [2, 21]
+	em.Delete(endpoint2)
+	em.Delete(endpoint21)
+
+	// [1, 3] should be present:
+	if _, ok := em.Get(endpoint1); !ok {
+		t.Fatalf("em.Get(endpoint1) = %v, want true", ok)
+	}
+	if _, ok := em.Get(endpoint3); !ok {
+		t.Fatalf("em.Get(endpoint3) = %v, want true", ok)
+	}
+	// [2, 12] should not be present:
+	if _, ok := em.Get(endpoint2); ok {
+		t.Fatalf("em.Get(endpoint2) = %v, want false", ok)
+	}
+	if _, ok := em.Get(endpoint12); ok {
+		t.Fatalf("em.Get(endpoint12) = %v, want false", ok)
+	}
+	if _, ok := em.Get(endpoint21); ok {
+		t.Fatalf("em.Get(endpoint21) = %v, want false", ok)
+	}
+}
+
+func (s) TestEndpointMap_Values(t *testing.T) {
+	em := NewEndpointMap()
+	em.Set(endpoint1, 1)
+	// The second endpoint endpoint21 should override.
+	em.Set(endpoint12, 1)
+	em.Set(endpoint21, 2)
+	em.Set(endpoint3, 3)
+	em.Set(endpoint4, 4)
+	em.Set(endpoint5, 5)
+	em.Set(endpoint6, 6)
+	em.Set(endpoint7, 7)
+	want := []int{1, 2, 3, 4, 5, 6, 7}
+	var got []int
+	for _, v := range em.Values() {
+		got = append(got, v.(int))
+	}
+	sort.Ints(got)
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("em.Values() returned unexpected elements (-want, +got):\n%v", diff)
 	}
 }

--- a/resolver/map_test.go
+++ b/resolver/map_test.go
@@ -174,7 +174,7 @@ func (s) TestAddressMap_Values(t *testing.T) {
 }
 
 func (s) TestEndpointMap_Length(t *testing.T) {
-	em := NewEndpointMap()
+	var em EndpointMap
 	// Should be empty at creation time.
 	if got := em.Len(); got != 0 {
 		t.Fatalf("em.Len() = %v; want 0", got)
@@ -196,7 +196,7 @@ func (s) TestEndpointMap_Length(t *testing.T) {
 }
 
 func (s) TestEndpointMap_Get(t *testing.T) {
-	em := NewEndpointMap()
+	var em EndpointMap
 	em.Set(endpoint1, 1)
 	// The second endpoint endpoint21 should override.
 	em.Set(endpoint12, 1)
@@ -237,7 +237,7 @@ func (s) TestEndpointMap_Get(t *testing.T) {
 }
 
 func (s) TestEndpointMap_Delete(t *testing.T) {
-	em := NewEndpointMap()
+	var em EndpointMap
 	// Initial state of system: [1, 2, 3, 12]
 	em.Set(endpoint1, struct{}{})
 	em.Set(endpoint2, struct{}{})
@@ -267,7 +267,7 @@ func (s) TestEndpointMap_Delete(t *testing.T) {
 }
 
 func (s) TestEndpointMap_Values(t *testing.T) {
-	em := NewEndpointMap()
+	var em EndpointMap
 	em.Set(endpoint1, 1)
 	// The second endpoint endpoint21 should override.
 	em.Set(endpoint12, 1)

--- a/resolver/map_test.go
+++ b/resolver/map_test.go
@@ -174,7 +174,7 @@ func (s) TestAddressMap_Values(t *testing.T) {
 }
 
 func (s) TestEndpointMap_Length(t *testing.T) {
-	var em EndpointMap
+	em := NewEndpointMap()
 	// Should be empty at creation time.
 	if got := em.Len(); got != 0 {
 		t.Fatalf("em.Len() = %v; want 0", got)
@@ -196,7 +196,7 @@ func (s) TestEndpointMap_Length(t *testing.T) {
 }
 
 func (s) TestEndpointMap_Get(t *testing.T) {
-	var em EndpointMap
+	em := NewEndpointMap()
 	em.Set(endpoint1, 1)
 	// The second endpoint endpoint21 should override.
 	em.Set(endpoint12, 1)
@@ -237,7 +237,7 @@ func (s) TestEndpointMap_Get(t *testing.T) {
 }
 
 func (s) TestEndpointMap_Delete(t *testing.T) {
-	var em EndpointMap
+	em := NewEndpointMap()
 	// Initial state of system: [1, 2, 3, 12]
 	em.Set(endpoint1, struct{}{})
 	em.Set(endpoint2, struct{}{})
@@ -267,7 +267,7 @@ func (s) TestEndpointMap_Delete(t *testing.T) {
 }
 
 func (s) TestEndpointMap_Values(t *testing.T) {
-	var em EndpointMap
+	em := NewEndpointMap()
 	em.Set(endpoint1, 1)
 	// The second endpoint endpoint21 should override.
 	em.Set(endpoint12, 1)


### PR DESCRIPTION
This PR adds an endpoint map type for use by Petiole policies for pick first children and also balancers like Outlier Detection which store state unique to individual endpoints. The endpoints are unique based off the unordered set of address string counts within an endpoint.

RELEASE NOTES:
* resolver: Add an endpoint map type