### PR TITLE
Explicitly specify the `dns` schema for the ALTS hand-shaker.

### DIFF
--- a/credentials/alts/alts.go
+++ b/credentials/alts/alts.go
@@ -43,7 +43,7 @@ import (
 const (
 	// hypervisorHandshakerServiceAddress represents the default ALTS gRPC
 	// handshaker service address in the hypervisor.
-	hypervisorHandshakerServiceAddress = "metadata.google.internal.:8080"
+	hypervisorHandshakerServiceAddress = "dns:///metadata.google.internal.:8080"
 	// defaultTimeout specifies the server handshake timeout.
 	defaultTimeout = 30.0 * time.Second
 	// The following constants specify the minimum and maximum acceptable


### PR DESCRIPTION
Before this change applications that override the default resolver may not be able to talk to the metadata server to start the ALTS Handshake, resulting in DirectPath not being used.