### PR TITLE
readme: fix badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # gRPC-Go
 
-[![Build Status](https://travis-ci.org/grpc/grpc-go.svg)](https://travis-ci.org/grpc/grpc-go)
 [![GoDoc](https://pkg.go.dev/badge/google.golang.org/grpc)][API]
 [![GoReportCard](https://goreportcard.com/badge/grpc/grpc-go)](https://goreportcard.com/report/github.com/grpc/grpc-go)
-[![codecov](https://codecov.io/gh/{{REPOSITORY}}/branch/main/graph/badge.svg)](https://codecov.io/gh/{{REPOSITORY}})
+[![codecov](https://codecov.io/gh/grpc/grpc-go/graph/badge.svg?token=2y7jc5C5Sv)](https://codecov.io/gh/grpc/grpc-go)
 
 The [Go][] implementation of [gRPC][]: A high performance, open source, general
 RPC framework that puts mobile and HTTP/2 first. For more information see the

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![GoDoc](https://pkg.go.dev/badge/google.golang.org/grpc)][API]
 [![GoReportCard](https://goreportcard.com/badge/grpc/grpc-go)](https://goreportcard.com/report/github.com/grpc/grpc-go)
-[![codecov](https://codecov.io/gh/grpc/grpc-go/graph/badge.svg?token=2y7jc5C5Sv)](https://codecov.io/gh/grpc/grpc-go)
+[![codecov](https://codecov.io/gh/grpc/grpc-go/graph/badge.svg)](https://codecov.io/gh/grpc/grpc-go)
 
 The [Go][] implementation of [gRPC][]: A high performance, open source, general
 RPC framework that puts mobile and HTTP/2 first. For more information see the


### PR DESCRIPTION
The travis CI badge was broken. Nixing that since we are not using it anymore. 
Codecov badge was also broken with the wrong URI.

RELEASE NOTES: none