### PR TITLE
Reapply "status: fix/improve status handling (#6662)" (#6673)

### DIFF
--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -43,6 +43,34 @@ type Status struct {
 	s *spb.Status
 }
 
+// NewWithProto returns a new status including details from statusProto.  This
+// is meant to be used by the gRPC library only.
+func NewWithProto(code codes.Code, message string, statusProto []string) *Status {
+	if len(statusProto) != 1 {
+		// No grpc-status-details bin header, or multiple; just ignore.
+		return &Status{s: &spb.Status{Code: int32(code), Message: message}}
+	}
+	st := &spb.Status{}
+	if err := proto.Unmarshal([]byte(statusProto[0]), st); err != nil {
+		// Probably not a google.rpc.Status proto; do not provide details.
+		return &Status{s: &spb.Status{Code: int32(code), Message: message}}
+	}
+	if st.Code == int32(code) {
+		// The codes match between the grpc-status header and the
+		// grpc-status-details-bin header; use the full details proto.
+		return &Status{s: st}
+	}
+	return &Status{
+		s: &spb.Status{
+			Code: int32(codes.Internal),
+			Message: fmt.Sprintf(
+				"grpc-status-details-bin mismatch: grpc-status=%v, grpc-message=%q, grpc-status-details-bin=%+v",
+				code, message, st,
+			),
+		},
+	}
+}
+
 // New returns a Status representing c and msg.
 func New(c codes.Code, msg string) *Status {
 	return &Status{s: &spb.Status{Code: int32(c), Message: msg}}

--- a/internal/transport/handler_server.go
+++ b/internal/transport/handler_server.go
@@ -220,18 +220,20 @@ func (ht *serverHandlerTransport) WriteStatus(s *Stream, st *status.Status) erro
 			h.Set("Grpc-Message", encodeGrpcMessage(m))
 		}
 
+		s.hdrMu.Lock()
 		if p := st.Proto(); p != nil && len(p.Details) > 0 {
+			delete(s.trailer, grpcStatusDetailsBinHeader)
 			stBytes, err := proto.Marshal(p)
 			if err != nil {
 				// TODO: return error instead, when callers are able to handle it.
 				panic(err)
 			}
 
-			h.Set("Grpc-Status-Details-Bin", encodeBinHeader(stBytes))
+			h.Set(grpcStatusDetailsBinHeader, encodeBinHeader(stBytes))
 		}
 
-		if md := s.Trailer(); len(md) > 0 {
-			for k, vv := range md {
+		if len(s.trailer) > 0 {
+			for k, vv := range s.trailer {
 				// Clients don't tolerate reading restricted headers after some non restricted ones were sent.
 				if isReservedHeader(k) {
 					continue
@@ -243,6 +245,7 @@ func (ht *serverHandlerTransport) WriteStatus(s *Stream, st *status.Status) erro
 				}
 			}
 		}
+		s.hdrMu.Unlock()
 	})
 
 	if err == nil { // transport has not been closed
@@ -287,7 +290,7 @@ func (ht *serverHandlerTransport) writeCommonHeaders(s *Stream) {
 }
 
 // writeCustomHeaders sets custom headers set on the stream via SetHeader
-// on the first write call (Write, WriteHeader, or WriteStatus).
+// on the first write call (Write, WriteHeader, or WriteStatus)
 func (ht *serverHandlerTransport) writeCustomHeaders(s *Stream) {
 	h := ht.rw.Header()
 

--- a/internal/transport/http_util.go
+++ b/internal/transport/http_util.go
@@ -34,12 +34,9 @@ import (
 	"time"
 	"unicode/utf8"
 
-	"github.com/golang/protobuf/proto"
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/hpack"
-	spb "google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 const (
@@ -88,6 +85,8 @@ var (
 	}
 )
 
+var grpcStatusDetailsBinHeader = "grpc-status-details-bin"
+
 // isReservedHeader checks whether hdr belongs to HTTP2 headers
 // reserved by gRPC protocol. Any other headers are classified as the
 // user-specified metadata.
@@ -103,7 +102,6 @@ func isReservedHeader(hdr string) bool {
 		"grpc-message",
 		"grpc-status",
 		"grpc-timeout",
-		"grpc-status-details-bin",
 		// Intentionally exclude grpc-previous-rpc-attempts and
 		// grpc-retry-pushback-ms, which are "reserved", but their API
 		// intentionally works via metadata.
@@ -152,18 +150,6 @@ func decodeMetadataHeader(k, v string) (string, error) {
 		return string(b), err
 	}
 	return v, nil
-}
-
-func decodeGRPCStatusDetails(rawDetails string) (*status.Status, error) {
-	v, err := decodeBinHeader(rawDetails)
-	if err != nil {
-		return nil, err
-	}
-	st := &spb.Status{}
-	if err = proto.Unmarshal(v, st); err != nil {
-		return nil, err
-	}
-	return status.FromProto(st), nil
 }
 
 type timeoutUnit uint8

--- a/status/status_ext_test.go
+++ b/status/status_ext_test.go
@@ -19,16 +19,26 @@
 package status_test
 
 import (
+	"context"
 	"errors"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/golang/protobuf/proto"
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/internal/grpctest"
+	"google.golang.org/grpc/internal/stubserver"
+	"google.golang.org/grpc/internal/testutils"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 
 	testpb "google.golang.org/grpc/interop/grpc_testing"
 )
+
+const defaultTestTimeout = 10 * time.Second
 
 type s struct {
 	grpctest.Tester
@@ -78,5 +88,117 @@ func (s) TestErrorIs(t *testing.T) {
 		if is != tc.want {
 			t.Errorf("(%v).Is(%v) = %t; want %t", tc.err1, tc.err2, is, tc.want)
 		}
+	}
+}
+
+// TestStatusDetails tests how gRPC handles grpc-status-details-bin, especially
+// in cases where it doesn't match the grpc-status trailer or contains arbitrary
+// data.
+func (s) TestStatusDetails(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+
+	for _, serverType := range []struct {
+		name            string
+		startServerFunc func(*stubserver.StubServer) error
+	}{{
+		name: "normal server",
+		startServerFunc: func(ss *stubserver.StubServer) error {
+			return ss.StartServer()
+		},
+	}, {
+		name: "handler server",
+		startServerFunc: func(ss *stubserver.StubServer) error {
+			return ss.StartHandlerServer()
+		},
+	}} {
+		t.Run(serverType.name, func(t *testing.T) {
+			// Convenience function for making a status including details.
+			detailErr := func(c codes.Code, m string) error {
+				s, err := status.New(c, m).WithDetails(&testpb.SimpleRequest{
+					Payload: &testpb.Payload{Body: []byte("detail msg")},
+				})
+				if err != nil {
+					t.Fatalf("Error adding details: %v", err)
+				}
+				return s.Err()
+			}
+
+			serialize := func(err error) string {
+				buf, _ := proto.Marshal(status.Convert(err).Proto())
+				return string(buf)
+			}
+
+			testCases := []struct {
+				name        string
+				trailerSent metadata.MD
+				errSent     error
+				trailerWant []string
+				errWant     error
+				errContains error
+			}{{
+				name:        "basic without details",
+				trailerSent: metadata.MD{},
+				errSent:     status.Error(codes.Aborted, "test msg"),
+				errWant:     status.Error(codes.Aborted, "test msg"),
+			}, {
+				name:        "basic without details passes through trailers",
+				trailerSent: metadata.MD{"grpc-status-details-bin": []string{"random text"}},
+				errSent:     status.Error(codes.Aborted, "test msg"),
+				trailerWant: []string{"random text"},
+				errWant:     status.Error(codes.Aborted, "test msg"),
+			}, {
+				name:        "basic without details conflicts with manual details",
+				trailerSent: metadata.MD{"grpc-status-details-bin": []string{serialize(status.Error(codes.Canceled, "test msg"))}},
+				errSent:     status.Error(codes.Aborted, "test msg"),
+				trailerWant: []string{serialize(status.Error(codes.Canceled, "test msg"))},
+				errContains: status.Error(codes.Internal, "mismatch"),
+			}, {
+				name:        "basic with details",
+				trailerSent: metadata.MD{},
+				errSent:     detailErr(codes.Aborted, "test msg"),
+				trailerWant: []string{serialize(detailErr(codes.Aborted, "test msg"))},
+				errWant:     detailErr(codes.Aborted, "test msg"),
+			}, {
+				name:        "basic with details discards user's trailers",
+				trailerSent: metadata.MD{"grpc-status-details-bin": []string{"will be ignored"}},
+				errSent:     detailErr(codes.Aborted, "test msg"),
+				trailerWant: []string{serialize(detailErr(codes.Aborted, "test msg"))},
+				errWant:     detailErr(codes.Aborted, "test msg"),
+			}}
+
+			for _, tc := range testCases {
+				t.Run(tc.name, func(t *testing.T) {
+					// Start a simple server that returns the trailer and error it receives from
+					// channels.
+					ss := &stubserver.StubServer{
+						UnaryCallF: func(ctx context.Context, in *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
+							grpc.SetTrailer(ctx, tc.trailerSent)
+							return nil, tc.errSent
+						},
+					}
+					if err := serverType.startServerFunc(ss); err != nil {
+						t.Fatalf("Error starting endpoint server: %v", err)
+					}
+					if err := ss.StartClient(); err != nil {
+						t.Fatalf("Error starting endpoint client: %v", err)
+					}
+					defer ss.Stop()
+
+					trailerGot := metadata.MD{}
+					_, errGot := ss.Client.UnaryCall(ctx, &testpb.SimpleRequest{}, grpc.Trailer(&trailerGot))
+					gsdb := trailerGot["grpc-status-details-bin"]
+					if !cmp.Equal(gsdb, tc.trailerWant) {
+						t.Errorf("Trailer got: %v; want: %v", gsdb, tc.trailerWant)
+					}
+					if tc.errWant != nil && !testutils.StatusErrEqual(errGot, tc.errWant) {
+						t.Errorf("Err got: %v; want: %v", errGot, tc.errWant)
+					}
+					if tc.errContains != nil && (status.Code(errGot) != status.Code(tc.errContains) || !strings.Contains(status.Convert(errGot).Message(), status.Convert(tc.errContains).Message())) {
+						t.Errorf("Err got: %v; want: (Contains: %v)", errGot, tc.errWant)
+					}
+				})
+			}
+		})
 	}
 }

--- a/test/balancer_test.go
+++ b/test/balancer_test.go
@@ -246,7 +246,7 @@ func testDoneInfo(t *testing.T, e env) {
 	defer cancel()
 	wantErr := detailedError
 	if _, err := tc.EmptyCall(ctx, &testpb.Empty{}); !testutils.StatusErrEqual(err, wantErr) {
-		t.Fatalf("TestService/EmptyCall(_, _) = _, %v, want _, %v", err, wantErr)
+		t.Fatalf("TestService/EmptyCall(_, _) = _, %v, want _, %v", status.Convert(err).Proto(), status.Convert(wantErr).Proto())
 	}
 	if _, err := tc.UnaryCall(ctx, &testpb.SimpleRequest{}); err != nil {
 		t.Fatalf("TestService.UnaryCall(%v, _, _, _) = _, %v; want _, <nil>", ctx, err)


### PR DESCRIPTION
This reverts commit 9e1fc3e9c088387890f5a303b805d320f11cc6dd.

It removes the part of the commit that forces status codes out of range to be converted to UNKNOWN, however.

(relnotes from previous PR)
RELEASE NOTES: none