### PR TITLE
xds/internal/server: stop using a fake xDS client in rds handler tests

### DIFF
--- a/xds/internal/server/listener_wrapper_test.go
+++ b/xds/internal/server/listener_wrapper_test.go
@@ -47,7 +47,7 @@ const (
 	fakeListenerHost         = "0.0.0.0"
 	fakeListenerPort         = 50051
 	testListenerResourceName = "lds.target.1.2.3.4:1111"
-	defaultTestTimeout       = 1 * time.Second
+	defaultTestTimeout       = 10 * time.Second
 	defaultTestShortTimeout  = 10 * time.Millisecond
 )
 

--- a/xds/internal/server/rds_handler_test.go
+++ b/xds/internal/server/rds_handler_test.go
@@ -20,325 +20,391 @@ package server
 
 import (
 	"context"
-	"errors"
 	"fmt"
+	"strings"
 	"testing"
+	"time"
 
+	wrapperspb "github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/google/go-cmp/cmp"
-	"google.golang.org/grpc/xds/internal/testutils/fakeclient"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"google.golang.org/grpc/internal/testutils/xds/e2e"
+	"google.golang.org/grpc/xds/internal/xdsclient"
 	"google.golang.org/grpc/xds/internal/xdsclient/xdsresource"
+	"google.golang.org/grpc/xds/internal/xdsclient/xdsresource/version"
+
+	v3routepb "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	v3discoverypb "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 )
 
 const (
+	listenerName = "listener"
+	clusterName  = "cluster"
+
 	route1 = "route1"
 	route2 = "route2"
 	route3 = "route3"
 )
 
-// setupTests creates a rds handler with a fake xds client for control over the
-// xds client.
-func setupTests() (*rdsHandler, *fakeclient.Client, chan rdsHandlerUpdate) {
-	xdsC := fakeclient.NewClient()
-	ch := make(chan rdsHandlerUpdate, 1)
-	rh := newRDSHandler(xdsC, ch)
-	return rh, xdsC, ch
-}
+// setupForRDSHandlerTests performs the following setup actions:
+//   - spins up an xDS management server
+//   - creates an xDS client with a bootstrap configuration pointing to the above
+//     management server
+//
+// Returns the following:
+// - a reference to the management server
+// - nodeID to use when pushing resources to the management server
+// - a channel to read resource names received by the management server
+// - an xDS client to pass to the rdsHandler under test
+func setupForRDSHandlerTests(t *testing.T) (*e2e.ManagementServer, string, chan []string, xdsclient.XDSClient) {
+	namesCh := make(chan []string, 1)
 
-// waitForFuncWithNames makes sure that a blocking function returns the correct
-// set of names, where order doesn't matter. This takes away nondeterminism from
-// ranging through a map.
-func waitForFuncWithNames(ctx context.Context, f func(context.Context) (string, error), names ...string) error {
-	wantNames := make(map[string]bool, len(names))
-	for _, name := range names {
-		wantNames[name] = true
-	}
-	gotNames := make(map[string]bool, len(names))
-	for range wantNames {
-		name, err := f(ctx)
-		if err != nil {
-			return err
-		}
-		gotNames[name] = true
-	}
-	if !cmp.Equal(gotNames, wantNames) {
-		return fmt.Errorf("got routeNames %v, want %v", gotNames, wantNames)
-	}
-	return nil
-}
+	// Setup the management server to push the requested route configuration
+	// resource names on to a channel for the test to inspect.
+	mgmtServer, nodeID, bootstrapContents, _, cleanup := e2e.SetupManagementServer(t, e2e.ManagementServerOptions{
+		OnStreamRequest: func(_ int64, req *v3discoverypb.DiscoveryRequest) error {
+			if req.GetTypeUrl() != version.V3RouteConfigURL {
+				return fmt.Errorf("unexpected resources %v of type %q requested", req.GetResourceNames(), req.GetTypeUrl())
+			}
+			select {
+			case <-namesCh:
+			default:
+			}
+			select {
+			case namesCh <- req.GetResourceNames():
+			default:
+			}
+			return nil
+		},
+		AllowResourceSubset: true,
+	})
+	t.Cleanup(cleanup)
 
-// TestSuccessCaseOneRDSWatch tests the simplest scenario: the rds handler
-// receives a single route name, starts a watch for that route name, gets a
-// successful update, and then writes an update to the update channel for
-// listener to pick up.
-func (s) TestSuccessCaseOneRDSWatch(t *testing.T) {
-	rh, fakeClient, ch := setupTests()
-	// When you first update the rds handler with a list of a single Route names
-	// that needs dynamic RDS Configuration, this Route name has not been seen
-	// before, so the RDS Handler should start a watch on that RouteName.
-	rh.updateRouteNamesToWatch(map[string]bool{route1: true})
-	// The RDS Handler should start a watch for that routeName.
-	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
-	defer cancel()
-	gotRoute, err := fakeClient.WaitForWatchRouteConfig(ctx)
+	xdsC, cancel, err := xdsclient.NewWithBootstrapContentsForTesting(bootstrapContents)
 	if err != nil {
-		t.Fatalf("xdsClient.WatchRDS failed with error: %v", err)
+		t.Fatal(err)
 	}
-	if gotRoute != route1 {
-		t.Fatalf("xdsClient.WatchRDS called for route: %v, want %v", gotRoute, route1)
+	t.Cleanup(cancel)
+
+	return mgmtServer, nodeID, namesCh, xdsC
+}
+
+// Waits for the wantNames to be pushed on to namesCh. Fails the test by calling
+// t.Fatal if the context expires before that.
+func waitForResourceNames(ctx context.Context, t *testing.T, namesCh chan []string, wantNames []string) {
+	t.Helper()
+
+	for ; ctx.Err() == nil; <-time.After(defaultTestShortTimeout) {
+		select {
+		case <-ctx.Done():
+		case gotNames := <-namesCh:
+			if cmp.Equal(gotNames, wantNames, cmpopts.EquateEmpty(), cmpopts.SortSlices(func(s1, s2 string) bool { return s1 < s2 })) {
+				return
+			}
+			t.Logf("Received resource names %v, want %v", gotNames, wantNames)
+		}
 	}
-	rdsUpdate := xdsresource.RouteConfigUpdate{}
-	// Invoke callback with the xds client with a certain route update. Due to
-	// this route update updating every route name that rds handler handles,
-	// this should write to the update channel to send to the listener.
-	fakeClient.InvokeWatchRouteConfigCallback(route1, rdsUpdate, nil)
-	rhuWant := map[string]xdsresource.RouteConfigUpdate{route1: rdsUpdate}
+	t.Fatalf("Timeout waiting for resource to be requested from the management server")
+}
+
+// Waits for an update to be pushed on updateCh and compares it to wantUpdate.
+// Fails the test by calling t.Fatal if the context expires or if the update
+// received on the channel does not match wantUpdate.
+func verifyUpdateFromChannel(ctx context.Context, t *testing.T, updateCh chan rdsHandlerUpdate, wantUpdate rdsHandlerUpdate) {
+	t.Helper()
+
+	opts := []cmp.Option{
+		cmpopts.EquateEmpty(),
+		cmpopts.SortSlices(func(s1, s2 string) bool { return s1 < s2 }),
+		cmpopts.SortMaps(func(s1, s2 string) bool { return s1 < s2 }),
+		cmpopts.IgnoreFields(xdsresource.RouteConfigUpdate{}, "Raw"),
+		cmp.AllowUnexported(rdsHandlerUpdate{}),
+	}
 	select {
-	case rhu := <-ch:
-		if diff := cmp.Diff(rhu.updates, rhuWant); diff != "" {
-			t.Fatalf("got unexpected route update, diff (-got, +want): %v", diff)
+	case gotUpdate := <-updateCh:
+		if diff := cmp.Diff(gotUpdate, wantUpdate, opts...); diff != "" {
+			t.Fatalf("Got unexpected route update, diff (-got, +want): %v", diff)
 		}
 	case <-ctx.Done():
-		t.Fatal("Timed out waiting for update from update channel.")
-	}
-	// Close the rds handler. This is meant to be called when the lis wrapper is
-	// closed, and the call should cancel all the watches present (for this
-	// test, a single watch).
-	rh.close()
-	routeNameDeleted, err := fakeClient.WaitForCancelRouteConfigWatch(ctx)
-	if err != nil {
-		t.Fatalf("xdsClient.CancelRDS failed with error: %v", err)
-	}
-	if routeNameDeleted != route1 {
-		t.Fatalf("xdsClient.CancelRDS called for route %v, want %v", routeNameDeleted, route1)
+		t.Fatal("Timed out waiting for a route config update")
 	}
 }
 
-// TestSuccessCaseTwoUpdates tests the case where the rds handler receives an
-// update with a single Route, then receives a second update with two routes.
-// The handler should start a watch for the added route, and if received a RDS
-// update for that route it should send an update with both RDS updates present.
-func (s) TestSuccessCaseTwoUpdates(t *testing.T) {
-	rh, fakeClient, ch := setupTests()
+func routeConfigResourceForName(name string) *v3routepb.RouteConfiguration {
+	return e2e.RouteConfigResourceWithOptions(e2e.RouteConfigOptions{
+		RouteConfigName:      name,
+		ListenerName:         listenerName,
+		ClusterSpecifierType: e2e.RouteConfigClusterSpecifierTypeCluster,
+		ClusterName:          clusterName,
+	})
+}
 
-	rh.updateRouteNamesToWatch(map[string]bool{route1: true})
+var defaultRouteConfigUpdate = xdsresource.RouteConfigUpdate{
+	VirtualHosts: []*xdsresource.VirtualHost{{
+		Domains: []string{listenerName},
+		Routes: []*xdsresource.Route{{
+			Prefix:           newStringP("/"),
+			ActionType:       xdsresource.RouteActionRoute,
+			WeightedClusters: map[string]xdsresource.WeightedCluster{clusterName: {Weight: 1}},
+		}},
+	}},
+}
 
+// Tests the simplest scenario: the rds handler receives a single route name.
+//
+// The test verifies the following:
+//   - the handler starts a watch for the given route name
+//   - once an update it received from the management server, it is pushed to the
+//     update channel
+//   - once the handler is closed, the watch for the route name is canceled.
+func (s) TestRDSHandler_SuccessCaseOneRDSWatch(t *testing.T) {
+	mgmtServer, nodeID, resourceNamesCh, xdsC := setupForRDSHandlerTests(t)
+
+	// Configure the management server with a route config resource.
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
-	gotRoute, err := fakeClient.WaitForWatchRouteConfig(ctx)
-	if err != nil {
-		t.Fatalf("xdsClient.WatchRDS failed with error: %v", err)
+	resources := e2e.UpdateOptions{
+		NodeID:         nodeID,
+		Routes:         []*v3routepb.RouteConfiguration{routeConfigResourceForName(route1)},
+		SkipValidation: true,
 	}
-	if gotRoute != route1 {
-		t.Fatalf("xdsClient.WatchRDS called for route: %v, want %v", gotRoute, route1)
+	if err := mgmtServer.Update(ctx, resources); err != nil {
+		t.Fatal(err)
 	}
 
-	// Update the RDSHandler with route names which adds a route name to watch.
-	// This should trigger the RDSHandler to start a watch for the added route
-	// name to watch.
+	// Create an rds handler and give it a single route to watch.
+	updateCh := make(chan rdsHandlerUpdate, 1)
+	rh := newRDSHandler(xdsC, updateCh)
+	rh.updateRouteNamesToWatch(map[string]bool{route1: true})
+
+	// Verify that the given route is requested.
+	waitForResourceNames(ctx, t, resourceNamesCh, []string{route1})
+
+	// Verify that the update is pushed to the handler's update channel.
+	wantUpdate := rdsHandlerUpdate{updates: map[string]xdsresource.RouteConfigUpdate{route1: defaultRouteConfigUpdate}}
+	verifyUpdateFromChannel(ctx, t, updateCh, wantUpdate)
+
+	// Close the rds handler and verify that the watch is canceled.
+	rh.close()
+	waitForResourceNames(ctx, t, resourceNamesCh, []string{})
+}
+
+// Tests the case where the rds handler receives two route names to watch. The
+// test verifies that when the handler receives only once of them, it does not
+// push an update on the channel. And when the handler receives the second
+// route, the test verifies that the update is pushed.
+func (s) TestRDSHandler_SuccessCaseTwoUpdates(t *testing.T) {
+	mgmtServer, nodeID, resourceNamesCh, xdsC := setupForRDSHandlerTests(t)
+
+	// Create an rds handler and give it a single route to watch.
+	updateCh := make(chan rdsHandlerUpdate, 1)
+	rh := newRDSHandler(xdsC, updateCh)
+	rh.updateRouteNamesToWatch(map[string]bool{route1: true})
+
+	// Verify that the given route is requested.
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	waitForResourceNames(ctx, t, resourceNamesCh, []string{route1})
+
+	// Update the rds handler to watch for two routes.
 	rh.updateRouteNamesToWatch(map[string]bool{route1: true, route2: true})
-	gotRoute, err = fakeClient.WaitForWatchRouteConfig(ctx)
-	if err != nil {
-		t.Fatalf("xdsClient.WatchRDS failed with error: %v", err)
+	waitForResourceNames(ctx, t, resourceNamesCh, []string{route1, route2})
+
+	// Configure the management server with a single route config resource.
+	routeResource1 := routeConfigResourceForName(route1)
+	resources := e2e.UpdateOptions{
+		NodeID:         nodeID,
+		Routes:         []*v3routepb.RouteConfiguration{routeResource1},
+		SkipValidation: true,
 	}
-	if gotRoute != route2 {
-		t.Fatalf("xdsClient.WatchRDS called for route: %v, want %v", gotRoute, route2)
+	if err := mgmtServer.Update(ctx, resources); err != nil {
+		t.Fatal(err)
 	}
 
-	// Invoke the callback with an update for route 1. This shouldn't cause the
-	// handler to write an update, as it has not received RouteConfigurations
-	// for every RouteName.
-	rdsUpdate1 := xdsresource.RouteConfigUpdate{}
-	fakeClient.InvokeWatchRouteConfigCallback(route1, rdsUpdate1, nil)
-
-	// The RDS Handler should not send an update.
-	sCtx, sCtxCancel := context.WithTimeout(context.Background(), defaultTestShortTimeout)
+	// Verify that the rds handler does not send an update.
+	sCtx, sCtxCancel := context.WithTimeout(ctx, defaultTestShortTimeout)
 	defer sCtxCancel()
 	select {
-	case <-ch:
+	case <-updateCh:
 		t.Fatal("RDS Handler wrote an update to updateChannel when it shouldn't have, as each route name has not received an update yet")
 	case <-sCtx.Done():
 	}
 
-	// Invoke the callback with an update for route 2. This should cause the
-	// handler to write an update, as it has received RouteConfigurations for
-	// every RouteName.
-	rdsUpdate2 := xdsresource.RouteConfigUpdate{}
-	fakeClient.InvokeWatchRouteConfigCallback(route2, rdsUpdate2, nil)
-	// The RDS Handler should then update the listener wrapper with an update
-	// with two route configurations, as both route names the RDS Handler handles
-	// have received an update.
-	rhuWant := map[string]xdsresource.RouteConfigUpdate{route1: rdsUpdate1, route2: rdsUpdate2}
-	select {
-	case rhu := <-ch:
-		if diff := cmp.Diff(rhu.updates, rhuWant); diff != "" {
-			t.Fatalf("got unexpected route update, diff (-got, +want): %v", diff)
-		}
-	case <-ctx.Done():
-		t.Fatal("Timed out waiting for the rds handler update to be written to the update buffer.")
+	// Configure the management server with both route config resources.
+	routeResource2 := routeConfigResourceForName(route2)
+	resources.Routes = []*v3routepb.RouteConfiguration{routeResource1, routeResource2}
+	if err := mgmtServer.Update(ctx, resources); err != nil {
+		t.Fatal(err)
 	}
 
-	// Close the rds handler. This is meant to be called when the lis wrapper is
-	// closed, and the call should cancel all the watches present (for this
-	// test, two watches on route1 and route2).
-	rh.close()
-	if err = waitForFuncWithNames(ctx, fakeClient.WaitForCancelRouteConfigWatch, route1, route2); err != nil {
-		t.Fatalf("Error while waiting for names: %v", err)
+	// Verify that the update is pushed to the handler's update channel.
+	wantUpdate := rdsHandlerUpdate{
+		updates: map[string]xdsresource.RouteConfigUpdate{
+			route1: defaultRouteConfigUpdate,
+			route2: defaultRouteConfigUpdate,
+		},
 	}
+	verifyUpdateFromChannel(ctx, t, updateCh, wantUpdate)
+
+	// Close the rds handler and verify that the watch is canceled.
+	rh.close()
+	waitForResourceNames(ctx, t, resourceNamesCh, []string{})
 }
 
-// TestSuccessCaseDeletedRoute tests the case where the rds handler receives an
-// update with two routes, then receives an update with only one route. The RDS
-// Handler is expected to cancel the watch for the route no longer present.
-func (s) TestSuccessCaseDeletedRoute(t *testing.T) {
-	rh, fakeClient, ch := setupTests()
+// Tests the case where the rds handler receives an update with two routes, then
+// receives an update with only one route. The rds handler is expected to cancel
+// the watch for the route no longer present, and push a corresponding update.
+func (s) TestRDSHandler_SuccessCaseDeletedRoute(t *testing.T) {
+	mgmtServer, nodeID, resourceNamesCh, xdsC := setupForRDSHandlerTests(t)
 
+	// Create an rds handler and give it two routes to watch.
+	updateCh := make(chan rdsHandlerUpdate, 1)
+	rh := newRDSHandler(xdsC, updateCh)
 	rh.updateRouteNamesToWatch(map[string]bool{route1: true, route2: true})
+
+	// Verify that the given routes are requested.
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
-	// Will start two watches.
-	if err := waitForFuncWithNames(ctx, fakeClient.WaitForWatchRouteConfig, route1, route2); err != nil {
-		t.Fatalf("Error while waiting for names: %v", err)
+	waitForResourceNames(ctx, t, resourceNamesCh, []string{route1, route2})
+
+	// Configure the management server with two route config resources.
+	routeResource1 := routeConfigResourceForName(route1)
+	routeResource2 := routeConfigResourceForName(route2)
+	resources := e2e.UpdateOptions{
+		NodeID:         nodeID,
+		Routes:         []*v3routepb.RouteConfiguration{routeResource1, routeResource2},
+		SkipValidation: true,
+	}
+	if err := mgmtServer.Update(ctx, resources); err != nil {
+		t.Fatal(err)
 	}
 
-	// Update the RDSHandler with route names which deletes a route name to
-	// watch. This should trigger the RDSHandler to cancel the watch for the
-	// deleted route name to watch.
+	// Verify that the update is pushed to the handler's update channel.
+	wantUpdate := rdsHandlerUpdate{
+		updates: map[string]xdsresource.RouteConfigUpdate{
+			route1: defaultRouteConfigUpdate,
+			route2: defaultRouteConfigUpdate,
+		},
+	}
+	verifyUpdateFromChannel(ctx, t, updateCh, wantUpdate)
+
+	// Update the handler to watch only one of the two previous routes.
 	rh.updateRouteNamesToWatch(map[string]bool{route1: true})
-	// This should delete the watch for route2.
-	routeNameDeleted, err := fakeClient.WaitForCancelRouteConfigWatch(ctx)
-	if err != nil {
-		t.Fatalf("xdsClient.CancelRDS failed with error %v", err)
-	}
-	if routeNameDeleted != route2 {
-		t.Fatalf("xdsClient.CancelRDS called for route %v, want %v", routeNameDeleted, route2)
-	}
 
-	rdsUpdate := xdsresource.RouteConfigUpdate{}
-	// Invoke callback with the xds client with a certain route update. Due to
-	// this route update updating every route name that rds handler handles,
-	// this should write to the update channel to send to the listener.
-	fakeClient.InvokeWatchRouteConfigCallback(route1, rdsUpdate, nil)
-	rhuWant := map[string]xdsresource.RouteConfigUpdate{route1: rdsUpdate}
-	select {
-	case rhu := <-ch:
-		if diff := cmp.Diff(rhu.updates, rhuWant); diff != "" {
-			t.Fatalf("got unexpected route update, diff (-got, +want): %v", diff)
-		}
-	case <-ctx.Done():
-		t.Fatal("Timed out waiting for update from update channel.")
-	}
+	// Verify that the other route is no longer requested.
+	waitForResourceNames(ctx, t, resourceNamesCh, []string{route1})
 
+	// Verify that an update is pushed with only one route.
+	wantUpdate = rdsHandlerUpdate{updates: map[string]xdsresource.RouteConfigUpdate{route1: defaultRouteConfigUpdate}}
+	verifyUpdateFromChannel(ctx, t, updateCh, wantUpdate)
+
+	// Close the rds handler and verify that the watch is canceled.
 	rh.close()
-	routeNameDeleted, err = fakeClient.WaitForCancelRouteConfigWatch(ctx)
-	if err != nil {
-		t.Fatalf("xdsClient.CancelRDS failed with error: %v", err)
-	}
-	if routeNameDeleted != route1 {
-		t.Fatalf("xdsClient.CancelRDS called for route %v, want %v", routeNameDeleted, route1)
-	}
+	waitForResourceNames(ctx, t, resourceNamesCh, []string{})
 }
 
-// TestSuccessCaseTwoUpdatesAddAndDeleteRoute tests the case where the rds
+// Tests the case where the rds
 // handler receives an update with two routes, and then receives an update with
 // two routes, one previously there and one added (i.e. 12 -> 23). This should
 // cause the route that is no longer there to be deleted and cancelled, and the
 // route that was added should have a watch started for it.
-func (s) TestSuccessCaseTwoUpdatesAddAndDeleteRoute(t *testing.T) {
-	rh, fakeClient, ch := setupTests()
+func (s) TestRDSHandler_SuccessCaseTwoUpdatesAddAndDeleteRoute(t *testing.T) {
+	mgmtServer, nodeID, resourceNamesCh, xdsC := setupForRDSHandlerTests(t)
 
+	// Create an rds handler and give it two routes to watch.
+	updateCh := make(chan rdsHandlerUpdate, 1)
+	rh := newRDSHandler(xdsC, updateCh)
 	rh.updateRouteNamesToWatch(map[string]bool{route1: true, route2: true})
 
+	// Verify that the given routes are requested.
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
-	if err := waitForFuncWithNames(ctx, fakeClient.WaitForWatchRouteConfig, route1, route2); err != nil {
-		t.Fatalf("Error while waiting for names: %v", err)
+	waitForResourceNames(ctx, t, resourceNamesCh, []string{route1, route2})
+
+	// Configure the management server with two route config resources.
+	routeResource1 := routeConfigResourceForName(route1)
+	routeResource2 := routeConfigResourceForName(route2)
+	resources := e2e.UpdateOptions{
+		NodeID:         nodeID,
+		Routes:         []*v3routepb.RouteConfiguration{routeResource1, routeResource2},
+		SkipValidation: true,
+	}
+	if err := mgmtServer.Update(ctx, resources); err != nil {
+		t.Fatal(err)
 	}
 
-	// Update the rds handler with two routes, one which was already there and a new route.
-	// This should cause the rds handler to delete/cancel watch for route 1 and start a watch
-	// for route 3.
+	// Verify that the update is pushed to the handler's update channel.
+	wantUpdate := rdsHandlerUpdate{
+		updates: map[string]xdsresource.RouteConfigUpdate{
+			route1: defaultRouteConfigUpdate,
+			route2: defaultRouteConfigUpdate,
+		},
+	}
+	verifyUpdateFromChannel(ctx, t, updateCh, wantUpdate)
+
+	// Update the handler with a route that was already there and a new route.
 	rh.updateRouteNamesToWatch(map[string]bool{route2: true, route3: true})
+	waitForResourceNames(ctx, t, resourceNamesCh, []string{route2, route3})
 
-	// Start watch comes first, which should be for route3 as was just added.
-	gotRoute, err := fakeClient.WaitForWatchRouteConfig(ctx)
-	if err != nil {
-		t.Fatalf("xdsClient.WatchRDS failed with error: %v", err)
-	}
-	if gotRoute != route3 {
-		t.Fatalf("xdsClient.WatchRDS called for route: %v, want %v", gotRoute, route3)
-	}
-
-	// Then route 1 should be deleted/cancelled watch for, as it is no longer present
-	// in the new RouteName to watch map.
-	routeNameDeleted, err := fakeClient.WaitForCancelRouteConfigWatch(ctx)
-	if err != nil {
-		t.Fatalf("xdsClient.CancelRDS failed with error: %v", err)
-	}
-	if routeNameDeleted != route1 {
-		t.Fatalf("xdsClient.CancelRDS called for route %v, want %v", routeNameDeleted, route1)
-	}
-
-	// Invoke the callback with an update for route 2. This shouldn't cause the
-	// handler to write an update, as it has not received RouteConfigurations
-	// for every RouteName.
-	rdsUpdate2 := xdsresource.RouteConfigUpdate{}
-	fakeClient.InvokeWatchRouteConfigCallback(route2, rdsUpdate2, nil)
-
-	// The RDS Handler should not send an update.
+	// The handler should not send an update.
 	sCtx, sCtxCancel := context.WithTimeout(context.Background(), defaultTestShortTimeout)
 	defer sCtxCancel()
 	select {
-	case <-ch:
+	case <-updateCh:
 		t.Fatalf("RDS Handler wrote an update to updateChannel when it shouldn't have, as each route name has not received an update yet")
 	case <-sCtx.Done():
 	}
 
-	// Invoke the callback with an update for route 3. This should cause the
-	// handler to write an update, as it has received RouteConfigurations for
-	// every RouteName.
-	rdsUpdate3 := xdsresource.RouteConfigUpdate{}
-	fakeClient.InvokeWatchRouteConfigCallback(route3, rdsUpdate3, nil)
-	// The RDS Handler should then update the listener wrapper with an update
-	// with two route configurations, as both route names the RDS Handler handles
-	// have received an update.
-	rhuWant := map[string]xdsresource.RouteConfigUpdate{route2: rdsUpdate2, route3: rdsUpdate3}
-	select {
-	case rhu := <-rh.updateChannel:
-		if diff := cmp.Diff(rhu.updates, rhuWant); diff != "" {
-			t.Fatalf("got unexpected route update, diff (-got, +want): %v", diff)
-		}
-	case <-ctx.Done():
-		t.Fatal("Timed out waiting for the rds handler update to be written to the update buffer.")
+	// Configure the management server with the third resource.
+	routeResource3 := routeConfigResourceForName(route3)
+	resources.Routes = append(resources.Routes, routeResource3)
+	if err := mgmtServer.Update(ctx, resources); err != nil {
+		t.Fatal(err)
 	}
-	// Close the rds handler. This is meant to be called when the lis wrapper is
-	// closed, and the call should cancel all the watches present (for this
-	// test, two watches on route2 and route3).
+
+	// Verify that the update is pushed to the handler's update channel.
+	wantUpdate = rdsHandlerUpdate{
+		updates: map[string]xdsresource.RouteConfigUpdate{
+			route2: defaultRouteConfigUpdate,
+			route3: defaultRouteConfigUpdate,
+		},
+	}
+	verifyUpdateFromChannel(ctx, t, updateCh, wantUpdate)
+
+	// Close the rds handler and verify that the watch is canceled.
 	rh.close()
-	if err = waitForFuncWithNames(ctx, fakeClient.WaitForCancelRouteConfigWatch, route2, route3); err != nil {
-		t.Fatalf("Error while waiting for names: %v", err)
-	}
+	waitForResourceNames(ctx, t, resourceNamesCh, []string{})
 }
 
-// TestSuccessCaseSecondUpdateMakesRouteFull tests the scenario where the rds handler gets
-// told to watch three rds configurations, gets two successful updates, then gets told to watch
-// only those two. The rds handler should then write an update to update buffer.
-func (s) TestSuccessCaseSecondUpdateMakesRouteFull(t *testing.T) {
-	rh, fakeClient, ch := setupTests()
+// Tests the scenario where the rds handler gets told to watch three rds
+// configurations, gets two successful updates, then gets told to watch only
+// those two. The rds handler should then write an update to update buffer.
+func (s) TestRDSHandler_SuccessCaseSecondUpdateMakesRouteFull(t *testing.T) {
+	mgmtServer, nodeID, resourceNamesCh, xdsC := setupForRDSHandlerTests(t)
 
+	// Create an rds handler and give it three routes to watch.
+	updateCh := make(chan rdsHandlerUpdate, 1)
+	rh := newRDSHandler(xdsC, updateCh)
 	rh.updateRouteNamesToWatch(map[string]bool{route1: true, route2: true, route3: true})
 
+	// Verify that the given routes are requested.
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
-	if err := waitForFuncWithNames(ctx, fakeClient.WaitForWatchRouteConfig, route1, route2, route3); err != nil {
-		t.Fatalf("Error while waiting for names: %v", err)
+	waitForResourceNames(ctx, t, resourceNamesCh, []string{route1, route2, route3})
+
+	// Configure the management server with two route config resources.
+	routeResource1 := routeConfigResourceForName(route1)
+	routeResource2 := routeConfigResourceForName(route2)
+	resources := e2e.UpdateOptions{
+		NodeID:         nodeID,
+		Routes:         []*v3routepb.RouteConfiguration{routeResource1, routeResource2},
+		SkipValidation: true,
+	}
+	if err := mgmtServer.Update(ctx, resources); err != nil {
+		t.Fatal(err)
 	}
 
-	// Invoke the callbacks for two of the three watches. Since RDS is not full,
-	// this shouldn't trigger rds handler to write an update to update buffer.
-	fakeClient.InvokeWatchRouteConfigCallback(route1, xdsresource.RouteConfigUpdate{}, nil)
-	fakeClient.InvokeWatchRouteConfigCallback(route2, xdsresource.RouteConfigUpdate{}, nil)
-
-	// The RDS Handler should not send an update.
+	// The handler should not send an update.
 	sCtx, sCtxCancel := context.WithTimeout(context.Background(), defaultTestShortTimeout)
 	defer sCtxCancel()
 	select {
@@ -351,51 +417,60 @@ func (s) TestSuccessCaseSecondUpdateMakesRouteFull(t *testing.T) {
 	// trigger the rds handler to write an update to the update buffer as it now
 	// has full rds configuration.
 	rh.updateRouteNamesToWatch(map[string]bool{route1: true, route2: true})
-	// Route 3 should be deleted/cancelled watch for, as it is no longer present
-	// in the new RouteName to watch map.
-	routeNameDeleted, err := fakeClient.WaitForCancelRouteConfigWatch(ctx)
-	if err != nil {
-		t.Fatalf("xdsClient.CancelRDS failed with error: %v", err)
+	wantUpdate := rdsHandlerUpdate{
+		updates: map[string]xdsresource.RouteConfigUpdate{
+			route1: defaultRouteConfigUpdate,
+			route2: defaultRouteConfigUpdate,
+		},
 	}
-	if routeNameDeleted != route3 {
-		t.Fatalf("xdsClient.CancelRDS called for route %v, want %v", routeNameDeleted, route1)
-	}
-	rhuWant := map[string]xdsresource.RouteConfigUpdate{route1: {}, route2: {}}
-	select {
-	case rhu := <-ch:
-		if diff := cmp.Diff(rhu.updates, rhuWant); diff != "" {
-			t.Fatalf("got unexpected route update, diff (-got, +want): %v", diff)
-		}
-	case <-ctx.Done():
-		t.Fatal("Timed out waiting for the rds handler update to be written to the update buffer.")
-	}
+	waitForResourceNames(ctx, t, resourceNamesCh, []string{route1, route2})
+	verifyUpdateFromChannel(ctx, t, updateCh, wantUpdate)
+
+	// Close the rds handler and verify that the watch is canceled.
+	rh.close()
+	waitForResourceNames(ctx, t, resourceNamesCh, []string{})
 }
 
 // TestErrorReceived tests the case where the rds handler receives a route name
 // to watch, then receives an update with an error. This error should be then
 // written to the update channel.
 func (s) TestErrorReceived(t *testing.T) {
-	rh, fakeClient, ch := setupTests()
+	mgmtServer, nodeID, resourceNamesCh, xdsC := setupForRDSHandlerTests(t)
 
+	// Create an rds handler and give it a single route to watch.
+	updateCh := make(chan rdsHandlerUpdate, 1)
+	rh := newRDSHandler(xdsC, updateCh)
 	rh.updateRouteNamesToWatch(map[string]bool{route1: true})
+
+	// Verify that the given route is requested.
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
-	gotRoute, err := fakeClient.WaitForWatchRouteConfig(ctx)
-	if err != nil {
-		t.Fatalf("xdsClient.WatchRDS failed with error %v", err)
+	waitForResourceNames(ctx, t, resourceNamesCh, []string{route1})
+
+	// Configure the management server with a single route config resource, that
+	// is expected to be NACKed.
+	routeResource := routeConfigResourceForName(route1)
+	routeResource.VirtualHosts[0].RetryPolicy = &v3routepb.RetryPolicy{NumRetries: &wrapperspb.UInt32Value{Value: 0}}
+	resources := e2e.UpdateOptions{
+		NodeID:         nodeID,
+		Routes:         []*v3routepb.RouteConfiguration{routeResource},
+		SkipValidation: true,
 	}
-	if gotRoute != route1 {
-		t.Fatalf("xdsClient.WatchRDS called for route: %v, want %v", gotRoute, route1)
+	if err := mgmtServer.Update(ctx, resources); err != nil {
+		t.Fatal(err)
 	}
 
-	rdsErr := errors.New("some error")
-	fakeClient.InvokeWatchRouteConfigCallback(route1, xdsresource.RouteConfigUpdate{}, rdsErr)
+	const wantErr = "received route is invalid: retry_policy.num_retries = 0; must be >= 1"
 	select {
-	case rhu := <-ch:
-		if rhu.err.Error() != "some error" {
-			t.Fatalf("Did not receive the expected error, instead received: %v", rhu.err.Error())
+	case update := <-updateCh:
+		if !strings.Contains(update.err.Error(), wantErr) {
+			t.Fatalf("Update received with error %v, want error containing %q", update.err, wantErr)
 		}
 	case <-ctx.Done():
 		t.Fatal("Timed out waiting for update from update channel")
 	}
+}
+
+func newStringP(s string) *string {
+	return &s
 }


### PR DESCRIPTION
This is in prep for xDS generic API changes for the server side.

RELEASE NOTES: none