### PR TITLE
codes: update docstring to indicate expected usage

### DIFF
--- a/codes/codes.go
+++ b/codes/codes.go
@@ -25,7 +25,13 @@ import (
 	"strconv"
 )
 
-// A Code is an unsigned 32-bit error code as defined in the gRPC spec.
+// A Code is a status code according to the gRPC spec:
+//
+// https://github.com/grpc/grpc/blob/master/doc/statuscodes.md
+//
+// Only the codes defined as consts in this package are valid codes. Do not use
+// other code values.  Behavior and interopability are implementation-specific
+// and not guaranteed.
 type Code uint32
 
 const (

--- a/codes/codes.go
+++ b/codes/codes.go
@@ -25,13 +25,13 @@ import (
 	"strconv"
 )
 
-// A Code is a status code according to the gRPC spec:
-//
-// https://github.com/grpc/grpc/blob/master/doc/statuscodes.md
+// A Code is a status code defined according to the [gRPC documentation].
 //
 // Only the codes defined as consts in this package are valid codes. Do not use
-// other code values.  Behavior and interopability are implementation-specific
-// and not guaranteed.
+// other code values.  Behavior of other codes is implementation-specific and
+// interoperability between implementations is not guaranteed.
+//
+// [gRPC documentation]: https://github.com/grpc/grpc/blob/master/doc/statuscodes.md
 type Code uint32
 
 const (


### PR DESCRIPTION
Related to https://github.com/grpc/grpc/pull/34588; specifically document that users should use ONLY the values defined by us.

RELEASE NOTES:
* codes: clarify that only codes defined by this package are valid and that users should not cast other values to `codes.Code`