### PR TITLE
Add LocalAddr to peer.Peer (#6577)

### DIFF
--- a/balancer/leastrequest/balancer_test.go
+++ b/balancer/leastrequest/balancer_test.go
@@ -161,14 +161,18 @@ func checkRoundRobinRPCs(ctx context.Context, client testgrpc.TestServiceClient,
 		gotAddrCount = make(map[string]int)
 		// Perform 3 iterations.
 		var iterations [][]string
+		var localIterations [][]string
 		for i := 0; i < 3; i++ {
 			iteration := make([]string, len(addrs))
+			localIteration := make([]string, len(addrs))
 			for c := 0; c < len(addrs); c++ {
 				var peer peer.Peer
 				client.EmptyCall(ctx, &testpb.Empty{}, grpc.Peer(&peer))
 				iteration[c] = peer.Addr.String()
+				localIteration[c] = peer.LocalAddr.String()
 			}
 			iterations = append(iterations, iteration)
+			localIterations = append(localIterations, localIteration)
 		}
 		// Ensure the the first iteration contains all addresses in addrs.
 		for _, addr := range iterations[0] {
@@ -179,6 +183,10 @@ func checkRoundRobinRPCs(ctx context.Context, client testgrpc.TestServiceClient,
 		}
 		// Ensure all three iterations contain the same addresses.
 		if !cmp.Equal(iterations[0], iterations[1]) || !cmp.Equal(iterations[0], iterations[2]) {
+			continue
+		}
+		// Ensure all three iterations contain the same local addresses.
+		if !cmp.Equal(localIterations[0], localIterations[1]) || !cmp.Equal(localIterations[0], localIterations[2]) {
 			continue
 		}
 		return nil

--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -493,8 +493,9 @@ func (t *http2Client) newStream(ctx context.Context, callHdr *CallHdr) *Stream {
 
 func (t *http2Client) getPeer() *peer.Peer {
 	return &peer.Peer{
-		Addr:     t.remoteAddr,
-		AuthInfo: t.authInfo, // Can be nil
+		Addr:      t.remoteAddr,
+		AuthInfo:  t.authInfo, // Can be nil
+		LocalAddr: t.localAddr,
 	}
 }
 

--- a/internal/transport/http2_server.go
+++ b/internal/transport/http2_server.go
@@ -1440,8 +1440,9 @@ func (t *http2Server) getOutFlowWindow() int64 {
 
 func (t *http2Server) getPeer() *peer.Peer {
 	return &peer.Peer{
-		Addr:     t.remoteAddr,
-		AuthInfo: t.authInfo, // Can be nil
+		Addr:      t.remoteAddr,
+		AuthInfo:  t.authInfo, // Can be nil
+		LocalAddr: t.localAddr,
 	}
 }
 

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -35,7 +35,7 @@ type Peer struct {
 	// AuthInfo is the authentication information of the transport.
 	// It is nil if there is no transport security being used.
 	AuthInfo credentials.AuthInfo
-	// LocalAddr is the peer local addrerss.
+	// LocalAddr is the peer local address.
 	LocalAddr net.Addr
 }
 

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -35,6 +35,8 @@ type Peer struct {
 	// AuthInfo is the authentication information of the transport.
 	// It is nil if there is no transport security being used.
 	AuthInfo credentials.AuthInfo
+	// LocalAddr is the peer local addrerss.
+	LocalAddr net.Addr
 }
 
 type peerKey struct{}

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -612,11 +612,13 @@ func (te *test) listenAndServe(ts testgrpc.TestServiceServer, listen func(networ
 		sopts = append(sopts, grpc.InitialConnWindowSize(te.serverInitialConnWindowSize))
 	}
 	la := "localhost:0"
+
 	switch te.e.network {
 	case "unix":
 		la = "/tmp/testsock" + fmt.Sprintf("%d", time.Now().UnixNano())
 		syscall.Unlink(la)
 	}
+
 	lis, err := listen(te.e.network, la)
 	if err != nil {
 		te.t.Fatalf("Failed to listen: %v", err)
@@ -2382,6 +2384,11 @@ func testPeerClientSide(t *testing.T, e env) {
 	if pp != sp {
 		t.Fatalf("peer.Addr = localhost:%v, want localhost:%v", pp, sp)
 	}
+
+	pla := peer.LocalAddr.String()
+	if _, _, err := net.SplitHostPort(pla); err != nil {
+		t.Fatalf("Failed to parse local address from peer.")
+	}
 }
 
 // TestPeerNegative tests that if call fails setting peer
@@ -2459,6 +2466,11 @@ func testPeerFailedRPC(t *testing.T, e env) {
 		}
 		if pp != sp {
 			t.Fatalf("peer.Addr = localhost:%v, want localhost:%v", pp, sp)
+		}
+
+		pla := peer.LocalAddr.String()
+		if _, _, err := net.SplitHostPort(pla); err != nil {
+			t.Fatalf("Failed to parse local address from peer.")
 		}
 	}
 }

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -612,13 +612,11 @@ func (te *test) listenAndServe(ts testgrpc.TestServiceServer, listen func(networ
 		sopts = append(sopts, grpc.InitialConnWindowSize(te.serverInitialConnWindowSize))
 	}
 	la := "localhost:0"
-
 	switch te.e.network {
 	case "unix":
 		la = "/tmp/testsock" + fmt.Sprintf("%d", time.Now().UnixNano())
 		syscall.Unlink(la)
 	}
-
 	lis, err := listen(te.e.network, la)
 	if err != nil {
 		te.t.Fatalf("Failed to listen: %v", err)


### PR DESCRIPTION
Resolves #6577 , requesting the ability to log the local address in addition to the remote address for server-side interceptors for debugging. 

It isn't obvious to me if we want to also include the local address in the server handler, [here](https://github.com/grpc/grpc-go/blob/master/internal/transport/handler_server.go#L386) . This would require parsing the information form the http request, likely using [X-Forward-For ](https://en.wikipedia.org/wiki/X-Forwarded-For).

There may be the necessity for a followup ticket to extend the binarylog package to include the local address in gRPC binary logging. 

Hope this helps!

