### PR TITLE
grpc: Add a pointer of server to ctx passed into stats handler

### DIFF
--- a/internal/internal.go
+++ b/internal/internal.go
@@ -73,6 +73,11 @@ var (
 	// xDS-enabled server invokes this method on a grpc.Server when a particular
 	// listener moves to "not-serving" mode.
 	DrainServerTransports any // func(*grpc.Server, string)
+	// IsRegisteredMethod returns whether the passed in method is registered as
+	// a method on the server.
+	IsRegisteredMethod any // func(*grpc.Server, string)
+	// ServerFromContext returns the server from the context.
+	ServerFromContext any // func(context.Context) *Server
 	// AddGlobalServerOptions adds an array of ServerOption that will be
 	// effective globally for newly created servers. The priority will be: 1.
 	// user-provided; 2. this method; 3. default values.

--- a/internal/stubstatshandler/stubstatshandler.go
+++ b/internal/stubstatshandler/stubstatshandler.go
@@ -1,0 +1,72 @@
+/*
+ *
+ * Copyright 2023 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// Package stubstatshandler is a stubbable implementation of
+// google.golang.org/grpc/stats.Handler for testing purposes.
+package stubstatshandler
+
+import (
+	"context"
+
+	"google.golang.org/grpc/stats"
+
+	testgrpc "google.golang.org/grpc/interop/grpc_testing"
+)
+
+// StubStatsHandler is a stats handler that is easy to customize within
+// individual test cases.
+type StubStatsHandler struct {
+	// Guarantees we satisfy this interface; panics if unimplemented methods are
+	// called.
+	testgrpc.TestServiceServer
+
+	TagRPCF     func(ctx context.Context, info *stats.RPCTagInfo) context.Context
+	HandleRPCF  func(ctx context.Context, info stats.RPCStats)
+	TagConnF    func(ctx context.Context, info *stats.ConnTagInfo) context.Context
+	HandleConnF func(ctx context.Context, info stats.ConnStats)
+}
+
+// TagRPC calls the StubStatsHandler's TagRPCF, if set.
+func (ssh *StubStatsHandler) TagRPC(ctx context.Context, info *stats.RPCTagInfo) context.Context {
+	if ssh.TagRPCF != nil {
+		return ssh.TagRPCF(ctx, info)
+	}
+	return ctx
+}
+
+// HandleRPC calls the StubStatsHandler's HandleRPCF, if set.
+func (ssh *StubStatsHandler) HandleRPC(ctx context.Context, rs stats.RPCStats) {
+	if ssh.HandleRPCF != nil {
+		ssh.HandleRPCF(ctx, rs)
+	}
+}
+
+// TagConn calls the StubStatsHandler's TagConnF, if set.
+func (ssh *StubStatsHandler) TagConn(ctx context.Context, info *stats.ConnTagInfo) context.Context {
+	if ssh.TagConnF != nil {
+		return ssh.TagConnF(ctx, info)
+	}
+	return ctx
+}
+
+// HandleConn calls the StubStatsHandler's HandleConnF, if set.
+func (ssh *StubStatsHandler) HandleConn(ctx context.Context, cs stats.ConnStats) {
+	if ssh.HandleConnF != nil {
+		ssh.HandleConnF(ctx, cs)
+	}
+}

--- a/internal/transport/handler_server_test.go
+++ b/internal/transport/handler_server_test.go
@@ -314,7 +314,7 @@ func (s) TestHandlerTransport_HandleStreams(t *testing.T) {
 		st.ht.WriteStatus(s, status.New(codes.OK, ""))
 	}
 	st.ht.HandleStreams(
-		func(s *Stream) { go handleStream(s) },
+		context.Background(), func(s *Stream) { go handleStream(s) },
 	)
 	wantHeader := http.Header{
 		"Date":          nil,
@@ -347,7 +347,7 @@ func handleStreamCloseBodyTest(t *testing.T, statusCode codes.Code, msg string) 
 		st.ht.WriteStatus(s, status.New(statusCode, msg))
 	}
 	st.ht.HandleStreams(
-		func(s *Stream) { go handleStream(s) },
+		context.Background(), func(s *Stream) { go handleStream(s) },
 	)
 	wantHeader := http.Header{
 		"Date":         nil,
@@ -396,7 +396,7 @@ func (s) TestHandlerTransport_HandleStreams_Timeout(t *testing.T) {
 		ht.WriteStatus(s, status.New(codes.DeadlineExceeded, "too slow"))
 	}
 	ht.HandleStreams(
-		func(s *Stream) { go runStream(s) },
+		context.Background(), func(s *Stream) { go runStream(s) },
 	)
 	wantHeader := http.Header{
 		"Date":         nil,
@@ -448,7 +448,7 @@ func (s) TestHandlerTransport_HandleStreams_WriteStatusWrite(t *testing.T) {
 func testHandlerTransportHandleStreams(t *testing.T, handleStream func(st *handleStreamTest, s *Stream)) {
 	st := newHandleStreamTest(t)
 	st.ht.HandleStreams(
-		func(s *Stream) { go handleStream(st, s) },
+		context.Background(), func(s *Stream) { go handleStream(st, s) },
 	)
 }
 
@@ -481,7 +481,7 @@ func (s) TestHandlerTransport_HandleStreams_ErrDetails(t *testing.T) {
 		hst.ht.WriteStatus(s, st)
 	}
 	hst.ht.HandleStreams(
-		func(s *Stream) { go handleStream(s) },
+		context.Background(), func(s *Stream) { go handleStream(s) },
 	)
 	wantHeader := http.Header{
 		"Date":         nil,

--- a/internal/transport/transport.go
+++ b/internal/transport/transport.go
@@ -37,6 +37,7 @@ import (
 	"google.golang.org/grpc/internal/channelz"
 	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/resolver"
 	"google.golang.org/grpc/stats"
 	"google.golang.org/grpc/status"
@@ -265,7 +266,8 @@ type Stream struct {
 	// headerValid indicates whether a valid header was received.  Only
 	// meaningful after headerChan is closed (always call waitOnHeader() before
 	// reading its value).  Not valid on server side.
-	headerValid bool
+	headerValid      bool
+	headerWireLength int // Only set on server side.
 
 	// hdrMu protects header and trailer metadata on the server-side.
 	hdrMu sync.Mutex
@@ -425,6 +427,12 @@ func (s *Stream) Context() context.Context {
 	return s.ctx
 }
 
+// SetContext sets the context of the stream. This will be deleted once the
+// stats handler callouts all move to gRPC layer.
+func (s *Stream) SetContext(ctx context.Context) {
+	s.ctx = ctx
+}
+
 // Method returns the method for the stream.
 func (s *Stream) Method() string {
 	return s.method
@@ -435,6 +443,12 @@ func (s *Stream) Method() string {
 // that is, after Done() is closed.
 func (s *Stream) Status() *status.Status {
 	return s.status
+}
+
+// HeaderWireLength returns the size of the headers of the stream as received
+// from the wire. Valid only on the server.
+func (s *Stream) HeaderWireLength() int {
+	return s.headerWireLength
 }
 
 // SetHeader sets the header metadata. This can be called multiple times.
@@ -698,7 +712,7 @@ type ClientTransport interface {
 // Write methods for a given Stream will be called serially.
 type ServerTransport interface {
 	// HandleStreams receives incoming streams using the given handler.
-	HandleStreams(func(*Stream))
+	HandleStreams(context.Context, func(*Stream))
 
 	// WriteHeader sends the header metadata for the given stream.
 	// WriteHeader may not be called on all streams.
@@ -717,8 +731,14 @@ type ServerTransport interface {
 	// handlers will be terminated asynchronously.
 	Close(err error)
 
+	// LocalAddr returns the local network address.
+	LocalAddr() net.Addr
+
 	// RemoteAddr returns the remote network address.
 	RemoteAddr() net.Addr
+
+	// Peer returns the peer of the server transport.
+	Peer() *peer.Peer
 
 	// Drain notifies the client this ServerTransport stops accepting new RPCs.
 	Drain(debugData string)

--- a/internal/transport/transport_test.go
+++ b/internal/transport/transport_test.go
@@ -35,8 +35,6 @@ import (
 	"testing"
 	"time"
 
-	"google.golang.org/grpc/peer"
-
 	"github.com/google/go-cmp/cmp"
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/hpack"
@@ -356,19 +354,19 @@ func (s *server) start(t *testing.T, port int, serverConfig *ServerConfig, ht hT
 		s.mu.Unlock()
 		switch ht {
 		case notifyCall:
-			go transport.HandleStreams(h.handleStreamAndNotify)
+			go transport.HandleStreams(context.Background(), h.handleStreamAndNotify)
 		case suspended:
-			go transport.HandleStreams(func(*Stream) {})
+			go transport.HandleStreams(context.Background(), func(*Stream) {})
 		case misbehaved:
-			go transport.HandleStreams(func(s *Stream) {
+			go transport.HandleStreams(context.Background(), func(s *Stream) {
 				go h.handleStreamMisbehave(t, s)
 			})
 		case encodingRequiredStatus:
-			go transport.HandleStreams(func(s *Stream) {
+			go transport.HandleStreams(context.Background(), func(s *Stream) {
 				go h.handleStreamEncodingRequiredStatus(s)
 			})
 		case invalidHeaderField:
-			go transport.HandleStreams(func(s *Stream) {
+			go transport.HandleStreams(context.Background(), func(s *Stream) {
 				go h.handleStreamInvalidHeaderField(s)
 			})
 		case delayRead:
@@ -377,15 +375,15 @@ func (s *server) start(t *testing.T, port int, serverConfig *ServerConfig, ht hT
 			s.mu.Lock()
 			close(s.ready)
 			s.mu.Unlock()
-			go transport.HandleStreams(func(s *Stream) {
+			go transport.HandleStreams(context.Background(), func(s *Stream) {
 				go h.handleStreamDelayRead(t, s)
 			})
 		case pingpong:
-			go transport.HandleStreams(func(s *Stream) {
+			go transport.HandleStreams(context.Background(), func(s *Stream) {
 				go h.handleStreamPingPong(t, s)
 			})
 		default:
-			go transport.HandleStreams(func(s *Stream) {
+			go transport.HandleStreams(context.Background(), func(s *Stream) {
 				go h.handleStream(t, s)
 			})
 		}
@@ -2593,53 +2591,4 @@ func TestConnectionError_Unwrap(t *testing.T) {
 	if !errors.Is(err, os.ErrNotExist) {
 		t.Error("ConnectionError does not unwrap")
 	}
-}
-
-func (s) TestPeerSetInServerContext(t *testing.T) {
-	// create client and server transports.
-	server, client, cancel := setUp(t, 0, normal)
-	defer cancel()
-	defer server.stop()
-	defer client.Close(fmt.Errorf("closed manually by test"))
-
-	// create a stream with client transport.
-	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
-	defer cancel()
-	stream, err := client.NewStream(ctx, &CallHdr{})
-	if err != nil {
-		t.Fatalf("failed to create a stream: %v", err)
-	}
-
-	waitWhileTrue(t, func() (bool, error) {
-		server.mu.Lock()
-		defer server.mu.Unlock()
-
-		if len(server.conns) == 0 {
-			return true, fmt.Errorf("timed-out while waiting for connection to be created on the server")
-		}
-		return false, nil
-	})
-
-	// verify peer is set in client transport context.
-	if _, ok := peer.FromContext(client.ctx); !ok {
-		t.Fatalf("Peer expected in client transport's context, but actually not found.")
-	}
-
-	// verify peer is set in stream context.
-	if _, ok := peer.FromContext(stream.ctx); !ok {
-		t.Fatalf("Peer expected in stream context, but actually not found.")
-	}
-
-	// verify peer is set in server transport context.
-	server.mu.Lock()
-	for k := range server.conns {
-		sc, ok := k.(*http2Server)
-		if !ok {
-			t.Fatalf("ServerTransport is of type %T, want %T", k, &http2Server{})
-		}
-		if _, ok = peer.FromContext(sc.ctx); !ok {
-			t.Fatalf("Peer expected in server transport's context, but actually not found.")
-		}
-	}
-	server.mu.Unlock()
 }

--- a/internal/xds/rbac/rbac_engine.go
+++ b/internal/xds/rbac/rbac_engine.go
@@ -34,7 +34,6 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/grpclog"
-	"google.golang.org/grpc/internal/transport"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
@@ -42,7 +41,7 @@ import (
 
 var logger = grpclog.Component("rbac")
 
-var getConnection = transport.GetConnection
+var getConnection = grpc.GetConnection
 
 // ChainEngine represents a chain of RBAC Engines, used to make authorization
 // decisions on incoming RPCs.

--- a/stats/stats_test.go
+++ b/stats/stats_test.go
@@ -20,6 +20,7 @@ package stats_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -31,7 +32,11 @@ import (
 	"github.com/golang/protobuf/proto"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/internal"
 	"google.golang.org/grpc/internal/grpctest"
+	"google.golang.org/grpc/internal/stubserver"
+	"google.golang.org/grpc/internal/stubstatshandler"
+	"google.golang.org/grpc/internal/testutils"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/stats"
 	"google.golang.org/grpc/status"
@@ -1455,5 +1460,79 @@ func (s) TestMultipleServerStatsHandler(t *testing.T) {
 	// Each connection generates 4 conn events on the server-side, times 2 StatsHandler
 	if len(h.gotConn) != 4 {
 		t.Fatalf("h.gotConn: unexpected amount of ConnStats: %v != %v", len(h.gotConn), 4)
+	}
+}
+
+// TestStatsHandlerCallsServerIsRegisteredMethod tests whether a stats handler
+// gets access to a Server on the server side, and thus the method that the
+// server owns which specifies whether a method is made or not. The test sets up
+// a server with a unary call and full duplex call configured, and makes an RPC.
+// Within the stats handler, asking the server whether unary or duplex method
+// names are registered should return true, and any other query should return
+// false.
+func (s) TestStatsHandlerCallsServerIsRegisteredMethod(t *testing.T) {
+	errorCh := testutils.NewChannel()
+	stubStatsHandler := &stubstatshandler.StubStatsHandler{
+		TagRPCF: func(ctx context.Context, _ *stats.RPCTagInfo) context.Context {
+			// OpenTelemetry instrumentation needs the passed in Server to determine if
+			// methods are registered in different handle calls in to record metrics.
+			// This tag RPC call context gets passed into every handle call, so can
+			// assert once here, since it maps to all the handle RPC calls that come
+			// after. These internal calls will be how the OpenTelemetry instrumentation
+			// component accesses this server and the subsequent helper on the server.
+			server := internal.ServerFromContext.(func(context.Context) *grpc.Server)(ctx)
+			if server == nil {
+				errorCh.Send("stats handler received ctx has no server present")
+			}
+			isRegisteredMethod := internal.IsRegisteredMethod.(func(*grpc.Server, string) bool)
+			// /s/m and s/m are valid.
+			if !isRegisteredMethod(server, "/grpc.testing.TestService/UnaryCall") {
+				errorCh.Send(errors.New("UnaryCall should be a registered method according to server"))
+				return ctx
+			}
+			if !isRegisteredMethod(server, "grpc.testing.TestService/FullDuplexCall") {
+				errorCh.Send(errors.New("FullDuplexCall should be a registered method according to server"))
+				return ctx
+			}
+			if isRegisteredMethod(server, "/grpc.testing.TestService/DoesNotExistCall") {
+				errorCh.Send(errors.New("DoesNotExistCall should not be a registered method according to server"))
+				return ctx
+			}
+			if isRegisteredMethod(server, "/unknownService/UnaryCall") {
+				errorCh.Send(errors.New("/unknownService/UnaryCall should not be a registered method according to server"))
+				return ctx
+			}
+			errorCh.Send(nil)
+			return ctx
+		},
+	}
+	ss := &stubserver.StubServer{
+		UnaryCallF: func(ctx context.Context, in *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
+			return &testpb.SimpleResponse{}, nil
+		},
+		FullDuplexCallF: func(stream testpb.TestService_FullDuplexCallServer) error {
+			for {
+				if _, err := stream.Recv(); err == io.EOF {
+					return nil
+				}
+			}
+		},
+	}
+	if err := ss.Start([]grpc.ServerOption{grpc.StatsHandler(stubStatsHandler)}); err != nil {
+		t.Fatalf("Error starting endpoint server: %v", err)
+	}
+	defer ss.Stop()
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	if _, err := ss.Client.UnaryCall(ctx, &testpb.SimpleRequest{Payload: &testpb.Payload{}}); err != nil {
+		t.Fatalf("Unexpected error from UnaryCall: %v", err)
+	}
+	err, errRecv := errorCh.Receive(ctx)
+	if errRecv != nil {
+		t.Fatalf("error receiving from channel: %v", errRecv)
+	}
+	if err != nil {
+		t.Fatalf("error received from error channel: %v", err)
 	}
 }

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -60,7 +60,6 @@ import (
 	"google.golang.org/grpc/internal/grpctest"
 	"google.golang.org/grpc/internal/stubserver"
 	"google.golang.org/grpc/internal/testutils"
-	"google.golang.org/grpc/internal/transport"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/resolver"
@@ -5834,7 +5833,7 @@ func (s) TestClientSettingsFloodCloseConn(t *testing.T) {
 }
 
 func unaryInterceptorVerifyConn(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
-	conn := transport.GetConnection(ctx)
+	conn := grpc.GetConnection(ctx)
 	if conn == nil {
 		return nil, status.Error(codes.NotFound, "connection was not in context")
 	}
@@ -5859,7 +5858,7 @@ func (s) TestUnaryServerInterceptorGetsConnection(t *testing.T) {
 }
 
 func streamingInterceptorVerifyConn(srv any, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
-	conn := transport.GetConnection(ss.Context())
+	conn := grpc.GetConnection(ss.Context())
 	if conn == nil {
 		return status.Error(codes.NotFound, "connection was not in context")
 	}

--- a/xds/server.go
+++ b/xds/server.go
@@ -35,7 +35,6 @@ import (
 	internalgrpclog "google.golang.org/grpc/internal/grpclog"
 	"google.golang.org/grpc/internal/grpcsync"
 	iresolver "google.golang.org/grpc/internal/resolver"
-	"google.golang.org/grpc/internal/transport"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 	"google.golang.org/grpc/xds/internal/server"
@@ -341,7 +340,7 @@ func (s *GRPCServer) GracefulStop() {
 // table and also processes the RPC by running the incoming RPC through any HTTP
 // Filters configured.
 func routeAndProcess(ctx context.Context) error {
-	conn := transport.GetConnection(ctx)
+	conn := grpc.GetConnection(ctx)
 	cw, ok := conn.(interface {
 		VirtualHosts() []xdsresource.VirtualHostWithInterceptors
 	})


### PR DESCRIPTION
This PR adds a pointer to the grpc.Server into the context passed into the stats handler. It also adds an internal only helper on the server that returns whether a given method is registered or not. This will be used in OpenTelemetry instrumentation for security purposes with respect to the cardinality of the method attribute. Contains and is based on (and technically requires) https://github.com/grpc/grpc-go/pull/6716. The next step after these two PRs is to move the rest of the stats handler callouts to the gRPC layer, get registered methods plumbed client side, canoncalize Target() without breaking it and then the OpenTelemetry instrumentation itself :).

RELEASE NOTES: N/A