### PR TITLE
status: fix issue grpc#6667 Panic on nil pointer dereference

### DIFF
--- a/status/status.go
+++ b/status/status.go
@@ -99,7 +99,7 @@ func FromError(err error) (s *Status, ok bool) {
 	}
 	type grpcstatus interface{ GRPCStatus() *Status }
 	if gs, ok := err.(grpcstatus); ok && gs != nil {
-	if grpcStatus := gs.GRPCStatus(); grpcStatus != nil {
+		if grpcStatus := gs.GRPCStatus(); grpcStatus != nil {
 			return grpcStatus, true
 		}
 	} else if errors.As(err, &gs) && gs != nil {

--- a/status/status.go
+++ b/status/status.go
@@ -97,6 +97,13 @@ func FromError(err error) (s *Status, ok bool) {
 	if err == nil {
 		return nil, true
 	}
+	defer func() {
+		if r := recover(); r != nil {
+			// type assertion passes but GRPCStatus method is still nil
+			s = New(codes.Unknown, err.Error())
+			ok = false
+		}
+	}()
 	type grpcstatus interface{ GRPCStatus() *Status }
 	if gs, ok := err.(grpcstatus); ok && gs != nil {
 		if grpcStatus := gs.GRPCStatus(); grpcStatus != nil {

--- a/status/status.go
+++ b/status/status.go
@@ -98,31 +98,21 @@ func FromError(err error) (s *Status, ok bool) {
 		return nil, true
 	}
 	type grpcstatus interface{ GRPCStatus() *Status }
-	if gs, ok := err.(grpcstatus); ok {
-		if gs == nil || gs.GRPCStatus() == nil {
-			// Error has status nil, which maps to codes.OK. There
-			// is no sensible behavior for this, so we turn it into
-			// an error with codes.Unknown and discard the existing
-			// status.
-			return New(codes.Unknown, err.Error()), false
+	if gs, ok := err.(grpcstatus); ok && gs != nil {
+	if grpcStatus := gs.GRPCStatus(); grpcStatus != nil {
+			return grpcStatus, true
 		}
-		grpcStatus := gs.GRPCStatus()
-		return grpcStatus, true
-	}
-	var gs grpcstatus
-	if errors.As(err, &gs) {
-		if gs == nil || gs.GRPCStatus() == nil {
-			// Error wraps an error that has status nil, which maps
-			// to codes.OK.  There is no sensible behavior for this,
-			// so we turn it into an error with codes.Unknown and
-			// discard the existing status.
-			return New(codes.Unknown, err.Error()), false
+	} else if errors.As(err, &gs) && gs != nil {
+		if grpcStatus := gs.GRPCStatus(); grpcStatus != nil {
+			p := grpcStatus.Proto()
+			p.Message = err.Error()
+			return status.FromProto(p), true
 		}
-		grpcStatus := gs.GRPCStatus()
-		p := grpcStatus.Proto()
-		p.Message = err.Error()
-		return status.FromProto(p), true
 	}
+	// Error is or wraps an error that has status nil, which maps
+	// to codes.OK.  There is no sensible behavior for this,
+	// so we turn it into an error with codes.Unknown and
+	// discard the existing status.
 	return New(codes.Unknown, err.Error()), false
 }
 

--- a/status/status.go
+++ b/status/status.go
@@ -99,26 +99,26 @@ func FromError(err error) (s *Status, ok bool) {
 	}
 	type grpcstatus interface{ GRPCStatus() *Status }
 	if gs, ok := err.(grpcstatus); ok {
-		grpcStatus := gs.GRPCStatus()
-		if grpcStatus == nil {
+		if gs == nil || gs.GRPCStatus() == nil {
 			// Error has status nil, which maps to codes.OK. There
 			// is no sensible behavior for this, so we turn it into
 			// an error with codes.Unknown and discard the existing
 			// status.
 			return New(codes.Unknown, err.Error()), false
 		}
+		grpcStatus := gs.GRPCStatus()
 		return grpcStatus, true
 	}
 	var gs grpcstatus
 	if errors.As(err, &gs) {
-		grpcStatus := gs.GRPCStatus()
-		if grpcStatus == nil {
+		if gs == nil || gs.GRPCStatus() == nil {
 			// Error wraps an error that has status nil, which maps
 			// to codes.OK.  There is no sensible behavior for this,
 			// so we turn it into an error with codes.Unknown and
 			// discard the existing status.
 			return New(codes.Unknown, err.Error()), false
 		}
+		grpcStatus := gs.GRPCStatus()
 		p := grpcStatus.Proto()
 		p.Message = err.Error()
 		return status.FromProto(p), true

--- a/status/status_test.go
+++ b/status/status_test.go
@@ -202,21 +202,6 @@ func (s) TestFromErrorWrapped(t *testing.T) {
 	}
 }
 
-type customErrorNotImplementsInterface struct {
-}
-
-func (c customErrorNotImplementsInterface) Error() string {
-	return "test"
-}
-
-func (s) TestFromErrorNotImplementsInterfaceReturnsOKStatus(t *testing.T) {
-	err := customErrorNotImplementsInterface{}
-	s, ok := FromError(err)
-	if ok || s.Code() != codes.Unknown || s.Message() != err.Error() {
-		t.Fatalf("FromError(%v) = %v, %v; want <Code()=%s, Message()=%q, Err()!=nil>, true", err, s, ok, codes.Unknown, err.Error())
-	}
-}
-
 type customErrorNilStatus struct {
 }
 

--- a/status/status_test.go
+++ b/status/status_test.go
@@ -202,6 +202,21 @@ func (s) TestFromErrorWrapped(t *testing.T) {
 	}
 }
 
+type customErrorNotImplementsInterface struct {
+}
+
+func (c customErrorNotImplementsInterface) Error() string {
+	return "test"
+}
+
+func (s) TestFromErrorNotImplementsInterfaceReturnsOKStatus(t *testing.T) {
+	err := customErrorNotImplementsInterface{}
+	s, ok := FromError(err)
+	if ok || s.Code() != codes.Unknown || s.Message() != err.Error() {
+		t.Fatalf("FromError(%v) = %v, %v; want <Code()=%s, Message()=%q, Err()!=nil>, true", err, s, ok, codes.Unknown, err.Error())
+	}
+}
+
 type customErrorNilStatus struct {
 }
 

--- a/status/status_test.go
+++ b/status/status_test.go
@@ -202,6 +202,26 @@ func (s) TestFromErrorWrapped(t *testing.T) {
 	}
 }
 
+type grpcStatus interface {
+	GRPCStatus() *Status
+}
+
+type customErrorNotImplementsInterface struct {
+	grpcStatus
+}
+
+func (c customErrorNotImplementsInterface) Error() string {
+	return "test"
+}
+
+func (s) TestFromErrorNotImplementsInterfaceReturnsOKStatus(t *testing.T) {
+	err := customErrorNotImplementsInterface{}
+	s, ok := FromError(err)
+	if ok || s.Code() != codes.Unknown || s.Message() != err.Error() {
+		t.Fatalf("FromError(%v) = %v, %v; want <Code()=%s, Message()=%q, Err()!=nil>, true", err, s, ok, codes.Unknown, err.Error())
+	}
+}
+
 type customErrorNilStatus struct {
 }
 


### PR DESCRIPTION
**Description:**
This pull request resolves issue grpc#6667 "Panic (nil pointer dereference) in processStreamingRPC". This change ensures that the program does not crash due to a nil pointer dereference.

**Changes Made:**
- Added nil checks in FromError function of status package.

**Testing Done:**
- To test this change, I ran the status_test.go.

RELEASE NOTES: N/A