### PR TITLE
balancer/rls: Fix RLS failure mode by treating response with no targets as an error

### DIFF
--- a/balancer/rls/picker.go
+++ b/balancer/rls/picker.go
@@ -254,19 +254,10 @@ func (p *rlsPicker) handleRouteLookupResponse(cacheKey cacheKey, targets []strin
 	now := time.Now()
 
 	// "An RLS request is considered to have failed if it returns a non-OK
-	// status or the RLS response's targets list does not contain any non-empty
-	// entries." - RLS LB Policy design.
-	allTargetsEmpty := true
-	for _, target := range targets {
-		if target != "" {
-			allTargetsEmpty = false
-			break
-		}
-	}
-	if allTargetsEmpty {
-		if err == nil {
-			err = fmt.Errorf("RLS response's target list does not contain any non-empty entries for key %+v", cacheKey)
-		}
+	// status or the RLS response's targets list is non-empty." - RLS LB Policy
+	// design.
+	if len(targets) == 0 && err == nil {
+		err = fmt.Errorf("RLS response's target list does not contain any entries for key %+v", cacheKey)
 		// If err is set, rpc error from the control plane and no control plane
 		// configuration is why no targets were passed into this helper, no need
 		// to specify and tell the user this information.

--- a/balancer/rls/picker.go
+++ b/balancer/rls/picker.go
@@ -256,21 +256,20 @@ func (p *rlsPicker) handleRouteLookupResponse(cacheKey cacheKey, targets []strin
 	// "An RLS request is considered to have failed if it returns a non-OK
 	// status or the RLS response's targets list does not contain any non-empty
 	// entries." - RLS LB Policy design.
-	var nonEmptyTarget bool
+	allTargetsEmpty := true
 	for _, target := range targets {
 		if target != "" {
-			nonEmptyTarget = true
+			allTargetsEmpty = false
 			break
 		}
 	}
-	if !nonEmptyTarget {
+	if allTargetsEmpty {
 		if err == nil {
 			err = fmt.Errorf("RLS response's target list does not contain any non-empty entries for key %+v", cacheKey)
-		} else {
-			// Can eat the status part of error since the RLS doesn't forward
-			// statuses from control plane RPCss to data plane RPCss (see Pick).
-			err = fmt.Errorf(err.Error()+"and also RLS response's target list does not contain any non-empty entries for key %+v", cacheKey)
 		}
+		// If err is set, rpc error from the control plane and no control plane
+		// configuration is why no targets were passed into this helper, no need
+		// to specify and tell the user this information.
 	}
 	if err != nil {
 		dcEntry.status = err

--- a/balancer/rls/picker_test.go
+++ b/balancer/rls/picker_test.go
@@ -20,6 +20,7 @@ package rls
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -38,6 +39,40 @@ import (
 	testgrpc "google.golang.org/grpc/interop/grpc_testing"
 	testpb "google.golang.org/grpc/interop/grpc_testing"
 )
+
+// TestNoNonEmptyTargetsReturnsError tests the case where the RLS Server returns
+// a response with no non empty targets. This should be treated as an Control
+// Plane RPC failure, and thus fail Data Plane RPC's with an error with the
+// appropriate information specfying data plane sent a response with no non
+// empty targets.
+func (s) TestNoNonEmptyTargetsReturnsError(t *testing.T) {
+	// Setup RLS Server to return a response with an empty target string.
+	rlsServer, rlsReqCh := rlstest.SetupFakeRLSServer(t, nil)
+	rlsServer.SetResponseCallback(func(_ context.Context, req *rlspb.RouteLookupRequest) *rlstest.RouteLookupResponse {
+		return &rlstest.RouteLookupResponse{Resp: &rlspb.RouteLookupResponse{Targets: []string{""}}}
+	})
+
+	// Register a manual resolver and push the RLS service config through it.
+	rlsConfig := buildBasicRLSConfigWithChildPolicy(t, t.Name(), rlsServer.Address)
+	r := startManualResolverWithConfig(t, rlsConfig)
+
+	// Dial the backend.
+	cc, err := grpc.Dial(r.Scheme()+":///", grpc.WithResolvers(r), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("grpc.Dial() failed: %v", err)
+	}
+	defer cc.Close()
+
+	// Make an RPC and expect it to fail with an error specifying RLS response's
+	// target list does not contain any non empty entries.
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	makeTestRPCAndVerifyError(ctx, t, cc, codes.Unavailable, errors.New("RLS response's target list does not contain any non-empty entries for key"))
+
+	// Make sure an RLS request is sent out. Even though the RLS Server will
+	// return no targets, the request should still hit the server.
+	verifyRLSRequest(t, rlsReqCh, true)
+}
 
 // Test verifies the scenario where there is no matching entry in the data cache
 // and no pending request either, and the ensuing RLS request is throttled.
@@ -103,7 +138,7 @@ func (s) TestPick_DataCacheMiss_NoPendingEntry_ThrottledWithoutDefaultTarget(t *
 // Test verifies the scenario where there is no matching entry in the data cache
 // and no pending request either, and the ensuing RLS request is not throttled.
 // The RLS response does not contain any backends, so the RPC fails with a
-// deadline exceeded error.
+// unavailable error.
 func (s) TestPick_DataCacheMiss_NoPendingEntry_NotThrottled(t *testing.T) {
 	// Start an RLS server and set the throttler to never throttle requests.
 	rlsServer, rlsReqCh := rlstest.SetupFakeRLSServer(t, nil)
@@ -126,7 +161,7 @@ func (s) TestPick_DataCacheMiss_NoPendingEntry_NotThrottled(t *testing.T) {
 	// smaller timeout to ensure that the test doesn't run very long.
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestShortTimeout)
 	defer cancel()
-	makeTestRPCAndVerifyError(ctx, t, cc, codes.DeadlineExceeded, context.DeadlineExceeded)
+	makeTestRPCAndVerifyError(ctx, t, cc, codes.Unavailable, errors.New("RLS response's target list does not contain any non-empty entries for key"))
 
 	// Make sure an RLS request is sent out.
 	verifyRLSRequest(t, rlsReqCh, true)

--- a/balancer/rls/picker_test.go
+++ b/balancer/rls/picker_test.go
@@ -49,7 +49,7 @@ func (s) TestNoNonEmptyTargetsReturnsError(t *testing.T) {
 	// Setup RLS Server to return a response with an empty target string.
 	rlsServer, rlsReqCh := rlstest.SetupFakeRLSServer(t, nil)
 	rlsServer.SetResponseCallback(func(_ context.Context, req *rlspb.RouteLookupRequest) *rlstest.RouteLookupResponse {
-		return &rlstest.RouteLookupResponse{Resp: &rlspb.RouteLookupResponse{Targets: []string{""}}}
+		return &rlstest.RouteLookupResponse{Resp: &rlspb.RouteLookupResponse{}}
 	})
 
 	// Register a manual resolver and push the RLS service config through it.
@@ -67,7 +67,7 @@ func (s) TestNoNonEmptyTargetsReturnsError(t *testing.T) {
 	// target list does not contain any non empty entries.
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
-	makeTestRPCAndVerifyError(ctx, t, cc, codes.Unavailable, errors.New("RLS response's target list does not contain any non-empty entries for key"))
+	makeTestRPCAndVerifyError(ctx, t, cc, codes.Unavailable, errors.New("RLS response's target list does not contain any entries for key"))
 
 	// Make sure an RLS request is sent out. Even though the RLS Server will
 	// return no targets, the request should still hit the server.
@@ -161,7 +161,7 @@ func (s) TestPick_DataCacheMiss_NoPendingEntry_NotThrottled(t *testing.T) {
 	// smaller timeout to ensure that the test doesn't run very long.
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestShortTimeout)
 	defer cancel()
-	makeTestRPCAndVerifyError(ctx, t, cc, codes.Unavailable, errors.New("RLS response's target list does not contain any non-empty entries for key"))
+	makeTestRPCAndVerifyError(ctx, t, cc, codes.Unavailable, errors.New("RLS response's target list does not contain any entries for key"))
 
 	// Make sure an RLS request is sent out.
 	verifyRLSRequest(t, rlsReqCh, true)


### PR DESCRIPTION
Fixes #6719. Previously, the RLS Balancer would not treat an RLS response with no targets as an error. This PR makes it treat an RLS response with no targets as an error.

The relevant language from the RLS LB Design document: "An RLS request is considered to have failed if it returns a non-OK status or the RLS response's targets list is non-empty."

RELEASE NOTES:
* balancer/rls: Fix RLS failure mode by treating response with no targets as an error