### PR TITLE
server: fix semaphore release

### DIFF
--- a/server.go
+++ b/server.go
@@ -2093,7 +2093,7 @@ func (q *atomicSemaphore) release() {
 	// concurrent calls to acquire, but also note that with synchronous calls to
 	// acquire, as our system does, n will never be less than -1.  There are
 	// fairness issues (queuing) to consider if this was to be generalized.
-	if atomic.AddInt64(&q.n, -1) <= 0 {
+	if atomic.AddInt64(&q.n, 1) <= 0 {
 		// An acquire was waiting on us.  Unblock it.
 		q.wait <- struct{}{}
 	}


### PR DESCRIPTION
This is to fix a bug in v1.57.1 where servers will run very sluggishly, and also take ages to shut down.

The acquire and release functions should have opposite impacts on the count.

Credit to @colega who spotted the diff.

This was introduced in #6706, a backport of #6703, where the line is correct.
https://github.com/grpc/grpc-go/pull/6703/files#diff-366e46a40f6f60b4f7614eb0976bb51820364bf5ca6ccc4787eb49d7bdbef3e6R2098

Also correct in the 1.56 backport: https://github.com/grpc/grpc-go/pull/6708/files#diff-366e46a40f6f60b4f7614eb0976bb51820364bf5ca6ccc4787eb49d7bdbef3e6R2073

RELEASE NOTES: n/a