### PR TITLE
metadata: Use strings.EqualFold for ValueFromIncomingContext

### DIFF
--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -193,9 +193,7 @@ func FromIncomingContext(ctx context.Context) (MD, bool) {
 	}
 	out := make(MD, len(md))
 	for k, v := range md {
-		// We need to manually convert all keys to lower case, because MD is a
-		// map, and there's no guarantee that the MD attached to the context is
-		// created using our helper functions.
+		// Convert keys to lower case: MD can be modified after NewIncomingContext().
 		key := strings.ToLower(k)
 		out[key] = copyOf(v)
 	}
@@ -219,17 +217,14 @@ func ValueFromIncomingContext(ctx context.Context, key string) []string {
 		return copyOf(v)
 	}
 	for k, v := range md {
-		// We need to manually convert all keys to lower case, because MD is a
-		// map, and there's no guarantee that the MD attached to the context is
-		// created using our helper functions.
-		if strings.ToLower(k) == key {
+		// Case-insensitive compare: MD can be modified after NewIncomingContext().
+		if strings.EqualFold(k, key) {
 			return copyOf(v)
 		}
 	}
 	return nil
 }
 
-// the returned slice must not be modified in place
 func copyOf(v []string) []string {
 	vals := make([]string, len(v))
 	copy(vals, v)

--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -202,10 +202,9 @@ func (s) TestFromIncomingContext(t *testing.T) {
 	md := Pairs(
 		"X-My-Header-1", "42",
 	)
-	ctx := NewIncomingContext(context.Background(), md)
-
-	// Check that we lowercase if callers modify md after NewIncomingContext
+	// Verify that we lowercase if callers directly modify md
 	md["X-INCORRECT-UPPERCASE"] = []string{"foo"}
+	ctx := NewIncomingContext(context.Background(), md)
 
 	result, found := FromIncomingContext(ctx)
 	if !found {
@@ -239,10 +238,9 @@ func (s) TestValueFromIncomingContext(t *testing.T) {
 		"X-My-Header-2", "43-2",
 		"x-my-header-3", "44",
 	)
-	ctx := NewIncomingContext(context.Background(), md)
-
-	// Check that we lowercase if callers modify md after NewIncomingContext
+	// Verify that we lowercase if callers directly modify md
 	md["X-INCORRECT-UPPERCASE"] = []string{"foo"}
+	ctx := NewIncomingContext(context.Background(), md)
 
 	for _, test := range []struct {
 		key  string


### PR DESCRIPTION
This is approximately 30% faster in a microbenchmark I added. The previous version using strings.ToLower() looks at every key byte. This version will typically evaluate "not equal" on the first byte.

The test and benchmark had no coverage for this loop, so I added it. I also revised the comments in FromIncomingContext and ValueFromIncomingContext. The problem is not that the MD is created using the helper functions. The MD must be attached to the context using NewIncomingContext, which could lower case the keys. The problem is that NewIncomingContext does not make a copy of its argument, so callers can mutate it after.

This change adds a test for FromIncomingContext that tests this case, and modifies the existing TestValueFromIncomingContext to test it.

Benchstat output from 10 runs of the benchmark on my laptop:
```
goos: darwin
goarch: arm64
pkg: google.golang.org/grpc/metadata
                                          │ before.txt  │              after.txt              │
                                          │   sec/op    │   sec/op     vs base                │
ValueFromIncomingContext/key-found-10       26.56n ± 2%   26.74n ± 2%        ~ (p=0.078 n=10)
ValueFromIncomingContext/key-not-found-10   50.48n ± 1%   36.23n ± 2%  -28.23% (p=0.000 n=10)
geomean                                     36.62n        31.13n       -15.00%
```

RELEASE NOTES: none