### PR TITLE
grpc: optional interface to provide channel authority

### DIFF
--- a/clientconn.go
+++ b/clientconn.go
@@ -1981,16 +1981,14 @@ func (cc *ClientConn) determineAuthority() error {
 	}
 
 	endpoint := cc.parsedTarget.Endpoint()
-	target := cc.target
+	auth, isAuthOverrider := any(cc.resolverBuilder).(resolver.AuthorityOverrider)
 	switch {
 	case authorityFromDialOption != "":
 		cc.authority = authorityFromDialOption
 	case authorityFromCreds != "":
 		cc.authority = authorityFromCreds
-	case strings.HasPrefix(target, "unix:") || strings.HasPrefix(target, "unix-abstract:"):
-		// TODO: remove when the unix resolver implements optional interface to
-		// return channel authority.
-		cc.authority = "localhost"
+	case isAuthOverrider:
+		cc.authority = auth.GetServiceAuthority(cc.parsedTarget)
 	case strings.HasPrefix(endpoint, ":"):
 		cc.authority = "localhost" + endpoint
 	default:

--- a/clientconn.go
+++ b/clientconn.go
@@ -1980,13 +1980,14 @@ func (cc *ClientConn) determineAuthority() error {
 		return fmt.Errorf("ClientConn's authority from transport creds %q and dial option %q don't match", authorityFromCreds, authorityFromDialOption)
 	}
 
+	endpoint := cc.parsedTarget.Endpoint()
 	if authorityFromDialOption != "" {
 		cc.authority = authorityFromDialOption
 	} else if authorityFromCreds != "" {
 		cc.authority = authorityFromCreds
 	} else if auth, ok := cc.resolverBuilder.(resolver.AuthorityOverrider); ok {
 		cc.authority = auth.OverrideAuthority(cc.parsedTarget)
-	} else if endpoint := cc.parsedTarget.Endpoint(); strings.HasPrefix(endpoint, ":") {
+	} else if strings.HasPrefix(endpoint, ":") {
 		cc.authority = "localhost" + endpoint
 	} else {
 		cc.authority = encodeAuthority(endpoint)

--- a/clientconn.go
+++ b/clientconn.go
@@ -1984,7 +1984,7 @@ func (cc *ClientConn) determineAuthority() error {
 		cc.authority = authorityFromDialOption
 	} else if authorityFromCreds != "" {
 		cc.authority = authorityFromCreds
-	} else if auth, isAuthOverrider := cc.resolverBuilder.(resolver.AuthorityOverrider); isAuthOverrider {
+	} else if auth, ok := cc.resolverBuilder.(resolver.AuthorityOverrider); ok {
 		cc.authority = auth.OverrideAuthority(cc.parsedTarget)
 	} else if endpoint := cc.parsedTarget.Endpoint(); strings.HasPrefix(endpoint, ":") {
 		cc.authority = "localhost" + endpoint

--- a/internal/resolver/unix/unix.go
+++ b/internal/resolver/unix/unix.go
@@ -61,7 +61,7 @@ func (b *builder) Scheme() string {
 	return b.scheme
 }
 
-func (b *builder) GetServiceAuthority(t resolver.Target) string {
+func (b *builder) OverrideAuthority(t resolver.Target) string {
 	return "localhost"
 }
 

--- a/internal/resolver/unix/unix.go
+++ b/internal/resolver/unix/unix.go
@@ -61,7 +61,7 @@ func (b *builder) Scheme() string {
 	return b.scheme
 }
 
-func (b *builder) OverrideAuthority(t resolver.Target) string {
+func (b *builder) OverrideAuthority(resolver.Target) string {
 	return "localhost"
 }
 

--- a/internal/resolver/unix/unix.go
+++ b/internal/resolver/unix/unix.go
@@ -61,6 +61,10 @@ func (b *builder) Scheme() string {
 	return b.scheme
 }
 
+func (b *builder) GetServiceAuthority(t resolver.Target) string {
+	return "localhost"
+}
+
 type nopResolver struct {
 }
 

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -324,7 +324,7 @@ type Resolver interface {
 // default authority for the ClientConn.
 // By default, the authority used is target.Endpoint()
 type AuthorityOverrider interface {
-	// GetServiceAuthority returns the authority to use for a ClientConn with the
+	// OverrideAuthority returns the authority to use for a ClientConn with the
 	// given target. It must not perform I/O or any other blocking operations.
-	GetServiceAuthority(t Target) string
+	OverrideAuthority(Target) string
 }

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -322,7 +322,7 @@ type Resolver interface {
 
 // AuthorityOverrider is implemented by Builders that wish to override the
 // default authority for the ClientConn.
-// By default, the authority used is target.Endpoint()
+// By default, the authority used is target.Endpoint().
 type AuthorityOverrider interface {
 	// OverrideAuthority returns the authority to use for a ClientConn with the
 	// given target. It must not perform I/O or any other blocking operations.

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -325,6 +325,7 @@ type Resolver interface {
 // By default, the authority used is target.Endpoint().
 type AuthorityOverrider interface {
 	// OverrideAuthority returns the authority to use for a ClientConn with the
-	// given target. It must not perform I/O or any other blocking operations.
+	// given target. The implementation must generate it without blocking,
+	// typically in line, and must keep it unchanged.
 	OverrideAuthority(Target) string
 }

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -324,7 +324,7 @@ type Resolver interface {
 // default authority for the ClientConn.
 // By default, the authority used is target.Endpoint()
 type AuthorityOverrider interface {
-	// OverrideAuthority returns the authority to use for a ClientConn with the
+	// GetServiceAuthority returns the authority to use for a ClientConn with the
 	// given target. It must not perform I/O or any other blocking operations.
 	GetServiceAuthority(t Target) string
 }

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -319,3 +319,12 @@ type Resolver interface {
 	// Close closes the resolver.
 	Close()
 }
+
+// AuthorityOverrider is implemented by Builders that wish to override the
+// default authority for the ClientConn.
+// By default, the authority used is target.Endpoint()
+type AuthorityOverrider interface {
+	// OverrideAuthority returns the authority to use for a ClientConn with the
+	// given target. It must not perform I/O or any other blocking operations.
+	GetServiceAuthority(t Target) string
+}


### PR DESCRIPTION
Also implements the same for unix resolver's builder

Fixes #5360 

RELEASE NOTES:
* resolver: provide method for resolver to implement to override default channel authority (EXPERIMENTAL).