### PR TITLE
xds/resolver: extend test to re-add listener

### DIFF
--- a/xds/internal/resolver/xds_resolver_test.go
+++ b/xds/internal/resolver/xds_resolver_test.go
@@ -595,6 +595,17 @@ func (s) TestResolverRemovedWithRPCs(t *testing.T) {
 			t.Fatalf("Got service config:\n%s \nWant service config:\n%s", cmp.Diff(nil, state.ServiceConfig.Config), cmp.Diff(nil, wantSCParsed.Config))
 		}
 	}
+
+	// Re-add the listener and expect everything to work again.
+	configureResourcesOnManagementServer(ctx, t, mgmtServer, nodeID, listeners, routes)
+	// Read the update pushed by the resolver to the ClientConn.
+	cs = verifyUpdateFromResolver(ctx, t, stateCh, wantDefaultServiceConfig)
+
+	res, err = cs.SelectConfig(iresolver.RPCInfo{Context: ctx, Method: "/service/method"})
+	if err != nil {
+		t.Fatalf("cs.SelectConfig(): %v", err)
+	}
+	res.OnCommitted()
 }
 
 // Tests the case where resources returned by the management server are removed.


### PR DESCRIPTION
This is just for peace of mind since a similar situation came up in interop tests, and I wanted to make sure it was handled correctly.

RELEASE NOTES: none