### PR TITLE
Set top-level read-only workflow permissions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -8,15 +8,17 @@ on:
 
 permissions:
   contents: read
-  security-events: write
-  pull-requests: read
-  actions: read
 
 jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
     timeout-minutes: 30
+
+    permissions:
+      security-events: write
+      pull-requests: read
+      actions: read
 
     strategy:
       fail-fast: false

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,5 +1,9 @@
 name: codecov
 on: [push, pull_request]
+
+permissions:
+  contents: read
+
 jobs:
   upload:
     runs-on: ubuntu-latest

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -6,12 +6,14 @@ on:
     - cron: '22 1 * * *'
 
 permissions:
-  issues: write
-  pull-requests: write
+  contents: read
 
 jobs:
   lock:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - uses: dessant/lock-threads@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   release:
     permissions:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -5,6 +5,9 @@ on:
   schedule:
   - cron: "44 */2 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   stale:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fixes #6774.

As mentioned in the issue, this PR adds top-level read-only permissions to `coverage.yml`, ensuring it can't be used for supply-chain attacks on the repo.

I've also made a few similar changes to the other workflows, mostly just setting `write` permissions at job-level instead of top-level. This serves to future-proof the workflows in case new jobs (that don't need those permissions) are added to the workflows. However, this change has no immediate impact to those workflows' security: the tokens effectively used in those jobs are unchanged.

RELEASE NOTES: None