### PR TITLE
credentials: if not set, restrict to TLS v1.2+ and CipherSuites per RFC7540

### DIFF
--- a/credentials/tls.go
+++ b/credentials/tls.go
@@ -153,10 +153,39 @@ func (c *tlsCreds) OverrideServerName(serverNameOverride string) error {
 	return nil
 }
 
+// The following cipher suites are forbidden for use with HTTP/2 by
+// https://datatracker.ietf.org/doc/html/rfc7540#appendix-A
+var tls12ForbiddenCipherSuites = map[uint16]struct{}{
+	tls.TLS_RSA_WITH_AES_128_CBC_SHA:         {},
+	tls.TLS_RSA_WITH_AES_256_CBC_SHA:         {},
+	tls.TLS_RSA_WITH_AES_128_GCM_SHA256:      {},
+	tls.TLS_RSA_WITH_AES_256_GCM_SHA384:      {},
+	tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA: {},
+	tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA: {},
+	tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA:   {},
+	tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA:   {},
+}
+
 // NewTLS uses c to construct a TransportCredentials based on TLS.
 func NewTLS(c *tls.Config) TransportCredentials {
 	tc := &tlsCreds{credinternal.CloneTLSConfig(c)}
 	tc.config.NextProtos = credinternal.AppendH2ToNextProtos(tc.config.NextProtos)
+	// If the user did not configure a MinVersion and did not configure a
+	// MaxVersion < 1.2, use MinVersion=1.2, which is required by
+	// https://datatracker.ietf.org/doc/html/rfc7540#section-9.2
+	if tc.config.MinVersion == 0 && (tc.config.MaxVersion == 0 || tc.config.MaxVersion >= tls.VersionTLS12) {
+		tc.config.MinVersion = tls.VersionTLS12
+	}
+	// If the user did not configure CipherSuites, use all "secure" cipher
+	// suites reported by the TLS package, but remove some explicitly forbidden
+	// by https://datatracker.ietf.org/doc/html/rfc7540#appendix-A
+	if tc.config.CipherSuites == nil {
+		for _, cs := range tls.CipherSuites() {
+			if _, ok := tls12ForbiddenCipherSuites[cs.ID]; !ok {
+				tc.config.CipherSuites = append(tc.config.CipherSuites, cs.ID)
+			}
+		}
+	}
 	return tc
 }
 

--- a/credentials/tls_ext_test.go
+++ b/credentials/tls_ext_test.go
@@ -203,7 +203,7 @@ func (s) TestTLS_CipherSuites(t *testing.T) {
 	}
 }
 
-// Tests that CipherSuites is not overriden when it is set.
+// Tests that CipherSuites is not overridden when it is set.
 func (s) TestTLS_CipherSuitesOverridable(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()

--- a/credentials/tls_ext_test.go
+++ b/credentials/tls_ext_test.go
@@ -1,0 +1,238 @@
+/*
+ *
+ * Copyright 2023 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package credentials_test
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/internal/grpctest"
+	"google.golang.org/grpc/internal/stubserver"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/testdata"
+
+	testgrpc "google.golang.org/grpc/interop/grpc_testing"
+	testpb "google.golang.org/grpc/interop/grpc_testing"
+)
+
+const defaultTestTimeout = 10 * time.Second
+
+type s struct {
+	grpctest.Tester
+}
+
+func Test(t *testing.T) {
+	grpctest.RunSubTests(t, s{})
+}
+
+var serverCert tls.Certificate
+var certPool *x509.CertPool
+var serverName = "x.test.example.com"
+
+func init() {
+	var err error
+	serverCert, err = tls.LoadX509KeyPair(testdata.Path("x509/server1_cert.pem"), testdata.Path("x509/server1_key.pem"))
+	if err != nil {
+		panic(fmt.Sprintf("tls.LoadX509KeyPair(server1.pem, server1.key) failed: %v", err))
+	}
+
+	b, err := os.ReadFile(testdata.Path("x509/server_ca_cert.pem"))
+	if err != nil {
+		panic(fmt.Sprintf("Error reading CA cert file: %v", err))
+	}
+	certPool = x509.NewCertPool()
+	if !certPool.AppendCertsFromPEM(b) {
+		panic("Error appending cert from PEM")
+	}
+}
+
+// Tests that the MinVersion of tls.Config is set to 1.2 if it is not already
+// set by the user.
+func (s) TestTLS_MinVersion12(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+
+	// Create server creds without a minimum version.
+	serverCreds := credentials.NewTLS(&tls.Config{
+		// MinVersion should be set to 1.2 by gRPC by default.
+		Certificates: []tls.Certificate{serverCert},
+	})
+	ss := stubserver.StubServer{
+		EmptyCallF: func(context.Context, *testpb.Empty) (*testpb.Empty, error) {
+			return &testpb.Empty{}, nil
+		},
+	}
+
+	// Create client creds that supports V1.0-V1.1.
+	clientCreds := credentials.NewTLS(&tls.Config{
+		ServerName: serverName,
+		RootCAs:    certPool,
+		MinVersion: tls.VersionTLS10,
+		MaxVersion: tls.VersionTLS11,
+	})
+
+	// Start server and client separately, because Start() blocks on a
+	// successful connection, which we will not get.
+	if err := ss.StartServer(grpc.Creds(serverCreds)); err != nil {
+		t.Fatalf("Error starting server: %v", err)
+	}
+	defer ss.Stop()
+
+	cc, err := grpc.Dial(ss.Address, grpc.WithTransportCredentials(clientCreds))
+	if err != nil {
+		t.Fatalf("grpc.Dial error: %v", err)
+	}
+	defer cc.Close()
+
+	client := testgrpc.NewTestServiceClient(cc)
+
+	const wantStr = "authentication handshake failed"
+	if _, err = client.EmptyCall(ctx, &testpb.Empty{}); status.Code(err) != codes.Unavailable || !strings.Contains(status.Convert(err).Message(), wantStr) {
+		t.Fatalf("EmptyCall err = %v; want code=%v, message contains %q", err, codes.Unavailable, wantStr)
+	}
+}
+
+// Tests that the MinVersion of tls.Config is not changed if it is set by the
+// user.
+func (s) TestTLS_MinVersionOverridable(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+
+	var allCipherSuites []uint16
+	for _, cs := range tls.CipherSuites() {
+		allCipherSuites = append(allCipherSuites, cs.ID)
+	}
+
+	// Create server creds that allow v1.0.
+	serverCreds := credentials.NewTLS(&tls.Config{
+		MinVersion:   tls.VersionTLS10,
+		Certificates: []tls.Certificate{serverCert},
+		CipherSuites: allCipherSuites,
+	})
+	ss := stubserver.StubServer{
+		EmptyCallF: func(context.Context, *testpb.Empty) (*testpb.Empty, error) {
+			return &testpb.Empty{}, nil
+		},
+	}
+
+	// Create client creds that supports V1.0-V1.1.
+	clientCreds := credentials.NewTLS(&tls.Config{
+		ServerName:   serverName,
+		RootCAs:      certPool,
+		CipherSuites: allCipherSuites,
+		MinVersion:   tls.VersionTLS10,
+		MaxVersion:   tls.VersionTLS11,
+	})
+
+	if err := ss.Start([]grpc.ServerOption{grpc.Creds(serverCreds)}, grpc.WithTransportCredentials(clientCreds)); err != nil {
+		t.Fatalf("Error starting stub server: %v", err)
+	}
+	defer ss.Stop()
+
+	if _, err := ss.Client.EmptyCall(ctx, &testpb.Empty{}); err != nil {
+		t.Fatalf("EmptyCall err = %v; want <nil>", err)
+	}
+}
+
+// Tests that CipherSuites is set to exclude HTTP/2 forbidden suites by default.
+func (s) TestTLS_CipherSuites(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+
+	// Create server creds without cipher suites.
+	serverCreds := credentials.NewTLS(&tls.Config{
+		Certificates: []tls.Certificate{serverCert},
+	})
+	ss := stubserver.StubServer{
+		EmptyCallF: func(context.Context, *testpb.Empty) (*testpb.Empty, error) {
+			return &testpb.Empty{}, nil
+		},
+	}
+
+	// Create client creds that use a forbidden suite only.
+	clientCreds := credentials.NewTLS(&tls.Config{
+		ServerName:   serverName,
+		RootCAs:      certPool,
+		CipherSuites: []uint16{tls.TLS_RSA_WITH_AES_128_CBC_SHA},
+		MaxVersion:   tls.VersionTLS12, // TLS1.3 cipher suites are not configurable, so limit to 1.2.
+	})
+
+	// Start server and client separately, because Start() blocks on a
+	// successful connection, which we will not get.
+	if err := ss.StartServer(grpc.Creds(serverCreds)); err != nil {
+		t.Fatalf("Error starting server: %v", err)
+	}
+	defer ss.Stop()
+
+	cc, err := grpc.Dial("dns:"+ss.Address, grpc.WithTransportCredentials(clientCreds))
+	if err != nil {
+		t.Fatalf("grpc.Dial error: %v", err)
+	}
+	defer cc.Close()
+
+	client := testgrpc.NewTestServiceClient(cc)
+
+	const wantStr = "authentication handshake failed"
+	if _, err = client.EmptyCall(ctx, &testpb.Empty{}); status.Code(err) != codes.Unavailable || !strings.Contains(status.Convert(err).Message(), wantStr) {
+		t.Fatalf("EmptyCall err = %v; want code=%v, message contains %q", err, codes.Unavailable, wantStr)
+	}
+}
+
+// Tests that CipherSuites is not overriden when it is set.
+func (s) TestTLS_CipherSuitesOverridable(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+
+	// Create server that allows only a forbidden cipher suite.
+	serverCreds := credentials.NewTLS(&tls.Config{
+		Certificates: []tls.Certificate{serverCert},
+		CipherSuites: []uint16{tls.TLS_RSA_WITH_AES_128_CBC_SHA},
+	})
+	ss := stubserver.StubServer{
+		EmptyCallF: func(context.Context, *testpb.Empty) (*testpb.Empty, error) {
+			return &testpb.Empty{}, nil
+		},
+	}
+
+	// Create server that allows only a forbidden cipher suite.
+	clientCreds := credentials.NewTLS(&tls.Config{
+		ServerName:   serverName,
+		RootCAs:      certPool,
+		CipherSuites: []uint16{tls.TLS_RSA_WITH_AES_128_CBC_SHA},
+		MaxVersion:   tls.VersionTLS12, // TLS1.3 cipher suites are not configurable, so limit to 1.2.
+	})
+
+	if err := ss.Start([]grpc.ServerOption{grpc.Creds(serverCreds)}, grpc.WithTransportCredentials(clientCreds)); err != nil {
+		t.Fatalf("Error starting stub server: %v", err)
+	}
+	defer ss.Stop()
+
+	if _, err := ss.Client.EmptyCall(ctx, &testpb.Empty{}); err != nil {
+		t.Fatalf("EmptyCall err = %v; want <nil>", err)
+	}
+}


### PR DESCRIPTION
Fixes #6758

cc @ejona86 FYI

RELEASE NOTES:
* credentials: if not set, set TLS `MinVersion` to 1.2 and `CipherSuites` according to supported suites not forbidden by RFC7540.  This is a behavior change to bring us into better alignment with RFC 7540.