### PR TITLE
Fix race in grpcsync.CallbackSerializer

### DIFF
--- a/internal/grpcsync/callback_serializer.go
+++ b/internal/grpcsync/callback_serializer.go
@@ -85,11 +85,10 @@ func (cs *CallbackSerializer) run(ctx context.Context) {
 			// Do nothing here. Next iteration of the for loop will not happen,
 			// since ctx.Err() would be non-nil.
 		case callback, ok := <-cs.callbacks.Get():
-			if !ok {
-				return
+			if ok {
+				cs.callbacks.Load()
+				callback.(func(ctx context.Context))(ctx)
 			}
-			cs.callbacks.Load()
-			callback.(func(ctx context.Context))(ctx)
 		}
 	}
 


### PR DESCRIPTION
Here is the race condition that we encountered on one of our servers.

```
goroutine 4809 [chan receive, 937 minutes]:
google.golang.org/grpc.(*ccResolverWrapper).UpdateState(0xc0005ef200, {{0xc001a11140, 0x3, 0x3}, {0xc0245f3380, 0x3, 0x3}, 0x0, 0x0})
	/go/pkg/mod/google.golang.org/grpc@v1.59.0/resolver_conn_wrapper.go:178 +0x1ae
github.com/DataDog/dd-source/libs/go/grpc/resolvers/healthchecked.(*ddResolver).update(0xc000b89a20, {0x38db400, 0xc0003a93f8})
	/go/pkg/mod/github.com/!data!dog/dd-source@v0.0.0-20231103202127-db6dd9a878c8/libs/go/grpc/resolvers/healthchecked/base.go:443 +0x78f
github.com/DataDog/dd-source/libs/go/grpc/resolvers/healthchecked.(*ddResolver).updater(0xc000b89a20, 0x0?)
	/go/pkg/mod/github.com/!data!dog/dd-source@v0.0.0-20231103202127-db6dd9a878c8/libs/go/grpc/resolvers/healthchecked/base.go:402 +0x14a
created by github.com/DataDog/dd-source/libs/go/grpc/resolvers/healthchecked.(*builder).buildWithStopper in goroutine 1
	/go/pkg/mod/github.com/!data!dog/dd-source@v0.0.0-20231103202127-db6dd9a878c8/libs/go/grpc/resolvers/healthchecked/base.go:134 +0x2cb

goroutine 2156775 [chan receive, 937 minutes]:
google.golang.org/grpc.(*ccResolverWrapper).close(0xc0005ef200)
	/go/pkg/mod/google.golang.org/grpc@v1.59.0/resolver_conn_wrapper.go:136 +0x13b
google.golang.org/grpc.(*ClientConn).enterIdleMode(0xc000b49400)
	/go/pkg/mod/google.golang.org/grpc@v1.59.0/clientconn.go:429 +0xf1
google.golang.org/grpc.(*idler).EnterIdleMode(0x1?)
	/go/pkg/mod/google.golang.org/grpc@v1.59.0/clientconn.go:324 +0x13
google.golang.org/grpc/internal/idle.(*manager).tryEnterIdleMode(0xc0000fbce0)
	/go/pkg/mod/google.golang.org/grpc@v1.59.0/internal/idle/idle.go:206 +0x97
google.golang.org/grpc/internal/idle.(*manager).handleIdleTimeout(0xc0000fbce0)
	/go/pkg/mod/google.golang.org/grpc@v1.59.0/internal/idle/idle.go:169 +0x54
created by time.goFunc
	/root/.gimme/versions/go1.21.3.linux.amd64/src/time/sleep.go:176 +0x2d
```
My understanding of this trace is the following:
* calls to ccResolverWrapper.close and ccResolverWrapper.UpdateState happened simultaneously.
* [the following line](https://github.com/grpc/grpc-go/blob/be1d1c10a930fa0e91fc4bcd01963035011e2466/internal/grpcsync/callback_serializer.go#L89) was executed first. cs.callbacks list was empty and CallbackSerializer.run() exited without taking closedMu lock. 
* CallbackSerializer.Schedule() was called by UpdateState() It put new callback into cs.callbacks [here](https://github.com/grpc/grpc-go/blob/be1d1c10a930fa0e91fc4bcd01963035011e2466/internal/grpcsync/callback_serializer.go#L74) It did this while holding closedMu lock, but we didn't check this lock before exiting from CallbackSerializer.run method. 
* As a result the new callback was never executed. I think [backlog](https://github.com/grpc/grpc-go/blob/be1d1c10a930fa0e91fc4bcd01963035011e2466/internal/grpcsync/callback_serializer.go#L103) was meant to fix this, but it was never called. 
* ccResolverWrapper.UpdateState remained stuck on [this line](https://github.com/grpc/grpc-go/blob/be1d1c10a930fa0e91fc4bcd01963035011e2466/resolver_conn_wrapper.go#L178) which make sense, because callback wasn't called and nobody wrote to the errCh

The fix is to always check backlog while holding closedMu lock before returning from CallbackSerializer.run()