### PR TITLE
Add LocalAddr to http2Client.getPeer()

### DIFF
--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -495,8 +495,9 @@ func (t *http2Client) newStream(ctx context.Context, callHdr *CallHdr) *Stream {
 
 func (t *http2Client) getPeer() *peer.Peer {
 	return &peer.Peer{
-		Addr:     t.remoteAddr,
-		AuthInfo: t.authInfo, // Can be nil
+		Addr:      t.remoteAddr,
+		AuthInfo:  t.authInfo, // Can be nil
+		LocalAddr: t.localAddr,
 	}
 }
 


### PR DESCRIPTION
Fixes #6577.

Followup to #6716 that exposes `LocalAddr` also to grpc clients (#6716 only exposed it to servers). Release note in #6716 encapsulates this logic as well.

RELEASE NOTES: n/a