### PR TITLE
resolver: remove ClientConn.NewServiceConfig

### DIFF
--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -240,11 +240,6 @@ type ClientConn interface {
 	//
 	// Deprecated: Use UpdateState instead.
 	NewAddress(addresses []Address)
-	// NewServiceConfig is called by resolver to notify ClientConn a new
-	// service config. The service config should be provided as a json string.
-	//
-	// Deprecated: Use UpdateState instead.
-	NewServiceConfig(serviceConfig string)
 	// ParseServiceConfig parses the provided service config and returns an
 	// object that provides the parsed config.
 	ParseServiceConfig(serviceConfigJSON string) *serviceconfig.ParseResult

--- a/resolver_conn_wrapper.go
+++ b/resolver_conn_wrapper.go
@@ -197,26 +197,6 @@ func (ccr *ccResolverWrapper) NewAddress(addrs []resolver.Address) {
 	})
 }
 
-// NewServiceConfig is called by the resolver implementation to send service
-// configs to gRPC.
-func (ccr *ccResolverWrapper) NewServiceConfig(sc string) {
-	ccr.serializerScheduleLocked(func(_ context.Context) {
-		channelz.Infof(logger, ccr.channelzID, "ccResolverWrapper: got new service config: %s", sc)
-		if ccr.ignoreServiceConfig {
-			channelz.Info(logger, ccr.channelzID, "Service config lookups disabled; ignoring config")
-			return
-		}
-		scpr := parseServiceConfig(sc)
-		if scpr.Err != nil {
-			channelz.Warningf(logger, ccr.channelzID, "ccResolverWrapper: error parsing service config: %v", scpr.Err)
-			return
-		}
-		ccr.addChannelzTraceEvent(resolver.State{Addresses: ccr.curState.Addresses, ServiceConfig: scpr})
-		ccr.curState.ServiceConfig = scpr
-		ccr.cc.updateResolverState(ccr.curState, nil)
-	})
-}
-
 // ParseServiceConfig is called by resolver implementations to parse a JSON
 // representation of the service config.
 func (ccr *ccResolverWrapper) ParseServiceConfig(scJSON string) *serviceconfig.ParseResult {

--- a/xds/internal/balancer/clusterresolver/resource_resolver_dns.go
+++ b/xds/internal/balancer/clusterresolver/resource_resolver_dns.go
@@ -183,10 +183,6 @@ func (dr *dnsDiscoveryMechanism) NewAddress(addresses []resolver.Address) {
 	dr.UpdateState(resolver.State{Addresses: addresses})
 }
 
-func (dr *dnsDiscoveryMechanism) NewServiceConfig(string) {
-	// This method is deprecated, and service config isn't supported.
-}
-
 func (dr *dnsDiscoveryMechanism) ParseServiceConfig(string) *serviceconfig.ParseResult {
 	return &serviceconfig.ParseResult{Err: fmt.Errorf("service config not supported")}
 }


### PR DESCRIPTION
cc #6472

All dependencies checked do not use this method any longer.  It has been deprecated for sufficient time.

RELEASE NOTES:
* resolver: remove deprecated and experimental `ClientConn.NewServiceConfig`