### PR TITLE
client: simplify initialization and cleanup a bit

### DIFF
--- a/balancer_conn_wrappers.go
+++ b/balancer_conn_wrappers.go
@@ -338,7 +338,7 @@ func (ccb *ccBalancerWrapper) UpdateState(s balancer.State) {
 	// case where we wait for ready and then perform an RPC.  If the picker is
 	// updated later, we could call the "connecting" picker when the state is
 	// updated, and then call the "ready" picker after the picker gets updated.
-	ccb.cc.blockingpicker.updatePicker(s.Picker)
+	ccb.cc.pickerWrapper.updatePicker(s.Picker)
 	ccb.cc.csMgr.updateState(s.ConnectivityState)
 }
 

--- a/balancer_conn_wrappers.go
+++ b/balancer_conn_wrappers.go
@@ -76,17 +76,14 @@ type ccBalancerWrapper struct {
 	mode             ccbMode                      // Tracks the current mode of the wrapper.
 }
 
-// newCCBalancerWrapper creates a new balancer wrapper. The underlying balancer
-// is not created until the switchTo() method is invoked.
+// newCCBalancerWrapper creates a new balancer wrapper in idle state. The
+// underlying balancer is not created until the switchTo() method is invoked.
 func newCCBalancerWrapper(cc *ClientConn, bopts balancer.BuildOptions) *ccBalancerWrapper {
-	ctx, cancel := context.WithCancel(context.Background())
 	ccb := &ccBalancerWrapper{
-		cc:               cc,
-		opts:             bopts,
-		serializer:       grpcsync.NewCallbackSerializer(ctx),
-		serializerCancel: cancel,
+		cc:   cc,
+		opts: bopts,
+		mode: ccbModeIdle,
 	}
-	ccb.balancer = gracefulswitch.NewBalancer(ccb, bopts)
 	return ccb
 }
 
@@ -258,7 +255,7 @@ func (ccb *ccBalancerWrapper) exitIdleMode() {
 	// exitIdleMode(), and since we just created a new serializer, we can be
 	// sure that the below function will be scheduled.
 	done := make(chan struct{})
-	ccb.serializer.Schedule(func(_ context.Context) {
+	ccb.serializer.Schedule(func(context.Context) {
 		defer close(done)
 
 		ccb.mu.Lock()
@@ -271,7 +268,11 @@ func (ccb *ccBalancerWrapper) exitIdleMode() {
 
 		// Gracefulswitch balancer does not support a switchTo operation after
 		// being closed. Hence we need to create a new one here.
-		ccb.balancer = gracefulswitch.NewBalancer(ccb, ccb.opts)
+		opts := ccb.opts
+		if c := opts.DialCreds; c != nil {
+			opts.DialCreds = c.Clone()
+		}
+		ccb.balancer = gracefulswitch.NewBalancer(ccb, opts)
 		ccb.mode = ccbModeActive
 		channelz.Info(logger, ccb.cc.channelzID, "ccBalancerWrapper: exiting idle mode")
 

--- a/clientconn.go
+++ b/clientconn.go
@@ -160,7 +160,7 @@ func DialContext(ctx context.Context, target string, opts ...DialOption) (conn *
 	cc.ctx, cc.cancel = context.WithCancel(context.Background())
 	cc.exitIdleCond = sync.NewCond(&cc.mu)
 
-	// Apply dial options
+	// Apply dial options.
 	disableGlobalOpts := false
 	for _, opt := range opts {
 		if _, ok := opt.(*disableGlobalDialOptions); ok {

--- a/clientconn.go
+++ b/clientconn.go
@@ -205,9 +205,11 @@ func DialContext(ctx context.Context, target string, opts ...DialOption) (conn *
 
 	// Determine the resolver to use.
 	if err := cc.parseTargetAndFindResolver(); err != nil {
+		channelz.RemoveEntry(cc.channelzID)
 		return nil, err
 	}
 	if err = cc.determineAuthority(); err != nil {
+		channelz.RemoveEntry(cc.channelzID)
 		return nil, err
 	}
 


### PR DESCRIPTION
- Unconditionally initialize blockingpicker (renamed to pickerWrapper) and balancerWrapper to simplify cleanup.
- Rearrange things in DialContext a bit further to facilitate the above
- Access mutex-protected fields in Close after Unlock directly, as it is safe.

RELEASE NOTES: none
