### PR TITLE
client: further streamlining of Dial

### DIFF
--- a/balancer_wrapper.go
+++ b/balancer_wrapper.go
@@ -268,11 +268,7 @@ func (ccb *ccBalancerWrapper) exitIdleMode() {
 
 		// Gracefulswitch balancer does not support a switchTo operation after
 		// being closed. Hence we need to create a new one here.
-		opts := ccb.opts
-		if c := opts.DialCreds; c != nil {
-			opts.DialCreds = c.Clone()
-		}
-		ccb.balancer = gracefulswitch.NewBalancer(ccb, opts)
+		ccb.balancer = gracefulswitch.NewBalancer(ccb, ccb.opts)
 		ccb.mode = ccbModeActive
 		channelz.Info(logger, ccb.cc.channelzID, "ccBalancerWrapper: exiting idle mode")
 

--- a/dialoptions.go
+++ b/dialoptions.go
@@ -483,7 +483,7 @@ func FailOnNonTempDialError(f bool) DialOption {
 // the RPCs.
 func WithUserAgent(s string) DialOption {
 	return newFuncDialOption(func(o *dialOptions) {
-		o.copts.UserAgent = s
+		o.copts.UserAgent = s + " " + grpcUA
 	})
 }
 
@@ -633,14 +633,16 @@ func withHealthCheckFunc(f internal.HealthChecker) DialOption {
 
 func defaultDialOptions() dialOptions {
 	return dialOptions{
-		healthCheckFunc: internal.HealthCheckFunc,
 		copts: transport.ConnectOptions{
-			WriteBufferSize: defaultWriteBufSize,
 			ReadBufferSize:  defaultReadBufSize,
+			WriteBufferSize: defaultWriteBufSize,
 			UseProxy:        true,
+			UserAgent:       grpcUA,
 		},
-		recvBufferPool: nopBufferPool{},
-		idleTimeout:    30 * time.Minute,
+		bs:              internalbackoff.DefaultExponential,
+		healthCheckFunc: internal.HealthCheckFunc,
+		idleTimeout:     30 * time.Minute,
+		recvBufferPool:  nopBufferPool{},
 	}
 }
 


### PR DESCRIPTION
* Add newClient method that starts a client in idle mode.
* Use newClient in DialContext.
* Use default dial options as appropriate.
* Stop cloning credentials unnecessarily.  We never mutate them ourselves and a single copy is insufficient if some other LB policy ever mutates them.

RELEASE NOTES: n/a