### PR TITLE
client: rework resolver and balancer wrappers to avoid deadlock

### DIFF
--- a/balancer_wrapper.go
+++ b/balancer_wrapper.go
@@ -51,11 +51,13 @@ type ccBalancerWrapper struct {
 	// read-only afterwards, and therefore can be accessed without a mutex.
 	cc               *ClientConn
 	opts             balancer.BuildOptions
-	balancer         *gracefulswitch.Balancer
 	serializer       *grpcsync.CallbackSerializer
 	serializerCancel context.CancelFunc
 
-	curBalancerName string // only accessed within the serializer
+	// The following fields are only accessed within the serializer or during
+	// initialization.
+	curBalancerName string
+	balancer        *gracefulswitch.Balancer
 
 	// The following field is protected by mu.  Caller must take cc.mu before
 	// taking mu.

--- a/balancer_wrapper.go
+++ b/balancer_wrapper.go
@@ -217,7 +217,7 @@ func (ccb *ccBalancerWrapper) NewSubConn(addrs []resolver.Address, opts balancer
 	ccb.mu.Lock()
 	if ccb.closed {
 		ccb.mu.Unlock()
-		return nil, errConnIdling
+		return nil, fmt.Errorf("balancer is being closed; no new SubConns allowed.")
 	}
 	ccb.mu.Unlock()
 

--- a/balancer_wrapper.go
+++ b/balancer_wrapper.go
@@ -168,9 +168,9 @@ func (ccb *ccBalancerWrapper) buildLoadBalancingPolicy(name string) {
 	ccb.curBalancerName = builder.Name()
 }
 
-// close initiates async shutdown of the wrapper.  To determine the wrapper has
-// finished shutting down, the channel should block on ccb.serializer.Done()
-// without cc.mu held.
+// close initiates async shutdown of the wrapper.  cc.mu must be held when
+// calling this function.  To determine the wrapper has finished shutting down,
+// the channel should block on ccb.serializer.Done() without cc.mu held.
 func (ccb *ccBalancerWrapper) close() {
 	ccb.mu.Lock()
 	ccb.closed = true

--- a/balancer_wrapper.go
+++ b/balancer_wrapper.go
@@ -182,7 +182,13 @@ func (ccb *ccBalancerWrapper) buildLoadBalancingPolicy(name string) {
 	ccb.curBalancerName = builder.Name()
 }
 
+// close initiates async shutdown of the wrapper.  To determine the wrapper has
+// finished shutting down, the channel should block on ccb.serializer.Done()
+// without cc.mu held.
 func (ccb *ccBalancerWrapper) close() {
+	ccb.mu.Lock()
+	ccb.closed = true
+	ccb.mu.Unlock()
 	channelz.Info(logger, ccb.cc.channelzID, "ccBalancerWrapper: closing")
 	ccb.serializer.Schedule(func(context.Context) {
 		if ccb.balancer == nil {

--- a/balancer_wrapper.go
+++ b/balancer_wrapper.go
@@ -203,7 +203,7 @@ func (ccb *ccBalancerWrapper) NewSubConn(addrs []resolver.Address, opts balancer
 	ccb.mu.Lock()
 	if ccb.closed {
 		ccb.mu.Unlock()
-		return nil, fmt.Errorf("balancer is being closed; no new SubConns allowed.")
+		return nil, fmt.Errorf("balancer is being closed; no new SubConns allowed")
 	}
 	ccb.mu.Unlock()
 

--- a/balancer_wrapper_test.go
+++ b/balancer_wrapper_test.go
@@ -55,7 +55,7 @@ func (s) TestBalancer_StateListenerBeforeConnect(t *testing.T) {
 							t.Error("Unexpected call to StateListener with:", scs)
 						},
 					})
-					if err != nil && !strings.Contains(err.Error(), "connection is closing") && !strings.Contains(err.Error(), "is deleted") && !strings.Contains(err.Error(), "is closed or idle") {
+					if err != nil && !strings.Contains(err.Error(), "connection is closing") && !strings.Contains(err.Error(), "is deleted") && !strings.Contains(err.Error(), "is closed or idle") && !strings.Contains(err.Error(), "balancer is being closed") {
 						t.Error("Unexpected error creating subconn:", err)
 					}
 					wg.Done()

--- a/clientconn.go
+++ b/clientconn.go
@@ -1224,7 +1224,7 @@ func (ac *addrConn) updateConnectivityState(s connectivity.State, lastErr error)
 	} else {
 		channelz.Infof(logger, ac.channelzID, "Subchannel Connectivity change to %v, last error: %s", s, lastErr)
 	}
-	ac.acbw.ccb.updateSubConnState(ac.acbw, s, lastErr)
+	ac.acbw.updateState(s, lastErr)
 }
 
 // adjustParams updates parameters used to create transports upon

--- a/clientconn.go
+++ b/clientconn.go
@@ -124,7 +124,6 @@ func newClient(target string, opts ...DialOption) (conn *ClientConn, err error) 
 		conns:  make(map[*addrConn]struct{}),
 		dopts:  defaultDialOptions(),
 		czData: new(channelzData),
-		idle:   true,
 	}
 
 	cc.retryThrottler.Store((*retryThrottler)(nil))
@@ -612,7 +611,6 @@ type ClientConn struct {
 	sc              *ServiceConfig             // Latest service config received from the resolver.
 	conns           map[*addrConn]struct{}     // Set to nil on close.
 	mkp             keepalive.ClientParameters // May be updated upon receipt of a GoAway.
-	idle            bool
 
 	lceMu               sync.Mutex // protects lastConnectionError
 	lastConnectionError error

--- a/internal/channelz/funcs.go
+++ b/internal/channelz/funcs.go
@@ -31,6 +31,7 @@ import (
 	"time"
 
 	"google.golang.org/grpc/grpclog"
+	"google.golang.org/grpc/internal"
 )
 
 const (
@@ -55,6 +56,12 @@ func TurnOn() {
 		db.set(newChannelMap())
 		IDGen.Reset()
 		atomic.StoreInt32(&curState, 1)
+	}
+}
+
+func init() {
+	internal.ChannelzTurnOffForTesting = func() {
+		atomic.StoreInt32(&curState, 0)
 	}
 }
 

--- a/internal/idle/idle.go
+++ b/internal/idle/idle.go
@@ -130,7 +130,7 @@ func (m *Manager) handleIdleTimeout() {
 		// Set the timer to fire after a duration of idle timeout, calculated
 		// from the time the most recent RPC completed.
 		atomic.StoreInt32(&m.activeSinceLastTimerCheck, 0)
-		m.resetIdleTimer(time.Duration(time.Now().UnixNano()-atomic.LoadInt64(&m.lastCallEndTime)) + m.timeout)
+		m.resetIdleTimer(time.Duration(atomic.LoadInt64(&m.lastCallEndTime)-time.Now().UnixNano()) + m.timeout)
 		return
 	}
 

--- a/internal/idle/idle.go
+++ b/internal/idle/idle.go
@@ -234,7 +234,7 @@ func (m *Manager) ExitIdleMode() error {
 	}
 
 	if err := m.enforcer.ExitIdleMode(); err != nil {
-		return fmt.Errorf("channel failed to exit idle mode: %w", err)
+		return fmt.Errorf("failed to exit idle mode: %w", err)
 	}
 
 	// Undo the idle entry process. This also respects any new RPC attempts.

--- a/internal/idle/idle.go
+++ b/internal/idle/idle.go
@@ -250,7 +250,7 @@ func (m *Manager) ExitIdleMode() error {
 		// - Channel is in idle mode, and multiple new RPCs come in at the same
 		//   time, all of them notice a negative calls count in OnCallBegin and get
 		//   here. The first one to get the lock would got the channel to exit idle.
-		// - Channel is in idle mode, and the user calls Connect which calls
+		// - Channel is not in idle mode, and the user calls Connect which calls
 		//   m.ExitIdleMode.
 		//
 		// In any case, there is nothing to do here.

--- a/internal/idle/idle.go
+++ b/internal/idle/idle.go
@@ -295,7 +295,9 @@ func (m *manager) Close() {
 	atomic.StoreInt32(&m.closed, 1)
 
 	m.idleMu.Lock()
-	m.timer.Stop()
-	m.timer = nil
+	if m.timer != nil {
+		m.timer.Stop()
+		m.timer = nil
+	}
 	m.idleMu.Unlock()
 }

--- a/internal/idle/idle_e2e_test.go
+++ b/internal/idle/idle_e2e_test.go
@@ -586,12 +586,8 @@ func (s) TestChannelIdleness_RaceBetweenEnterAndExitIdleMode(t *testing.T) {
 	}
 	defer cc.Close()
 
-	enterIdle := internal.EnterIdleModeForTesting.(func(*grpc.ClientConn) error)
-	enterIdleFunc := func() {
-		if err := enterIdle(cc); err != nil {
-			t.Errorf("Failed to enter idle mode: %v", err)
-		}
-	}
+	enterIdle := internal.EnterIdleModeForTesting.(func(*grpc.ClientConn))
+	enterIdleFunc := func() { enterIdle(cc) }
 	exitIdle := internal.ExitIdleModeForTesting.(func(*grpc.ClientConn) error)
 	exitIdleFunc := func() {
 		if err := exitIdle(cc); err != nil {

--- a/internal/idle/idle_test.go
+++ b/internal/idle/idle_test.go
@@ -319,7 +319,7 @@ type racyEnforcer struct {
 func (ri *racyEnforcer) ExitIdleMode() error {
 	// Set only on the initial ExitIdleMode
 	if ri.started == false {
-		if !atomic.CompareAndSwapInt32((*int32)(ri.state), int32(stateInitial), int32(stateExitedIdle)) {
+		if !atomic.CompareAndSwapInt32((*int32)(ri.state), int32(stateInitial), int32(stateInitial)) {
 			return fmt.Errorf("idleness enforcer's first ExitIdleMode after EnterIdleMode")
 		}
 		ri.started = true
@@ -360,16 +360,16 @@ func (s) TestManager_IdleTimeoutRacesWithOnCallBegin(t *testing.T) {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				<-time.After(defaultTestIdleTimeout / 10)
+				<-time.After(defaultTestIdleTimeout / 50)
 				mgr.handleIdleTimeout()
 			}()
-			for j := 0; j < 100; j++ {
+			for j := 0; j < 5; j++ {
 				wg.Add(1)
 				go func() {
 					defer wg.Done()
 					// Wait for the configured idle timeout and simulate an RPC to
 					// race with the idle timeout timer callback.
-					<-time.After(defaultTestIdleTimeout / 10)
+					<-time.After(defaultTestIdleTimeout / 50)
 					if err := mgr.OnCallBegin(); err != nil {
 						t.Errorf("OnCallBegin() failed: %v", err)
 					}

--- a/internal/idle/idle_test.go
+++ b/internal/idle/idle_test.go
@@ -26,7 +26,6 @@ import (
 	"testing"
 	"time"
 
-	"google.golang.org/grpc/grpclog"
 	"google.golang.org/grpc/internal/grpctest"
 )
 
@@ -55,10 +54,8 @@ func (ti *testEnforcer) ExitIdleMode() error {
 
 }
 
-func (ti *testEnforcer) EnterIdleMode() error {
+func (ti *testEnforcer) EnterIdleMode() {
 	ti.enterIdleCh <- struct{}{}
-	return nil
-
 }
 
 func newTestEnforcer() *testEnforcer {
@@ -91,7 +88,7 @@ func overrideNewTimer(t *testing.T) <-chan struct{} {
 // TestManager_Disabled tests the case where the idleness manager is
 // disabled by passing an idle_timeout of 0. Verifies the following things:
 //   - timer callback does not fire
-//   - an RPC does not trigger a call to ExitIdleMode on the ClientConn
+//   - an RPC triggers a call to ExitIdleMode on the ClientConn
 //   - more calls to RPC termination (as compared to RPC initiation) does not
 //     result in an error log
 func (s) TestManager_Disabled(t *testing.T) {
@@ -100,7 +97,7 @@ func (s) TestManager_Disabled(t *testing.T) {
 	// Create an idleness manager that is disabled because of idleTimeout being
 	// set to `0`.
 	enforcer := newTestEnforcer()
-	mgr := NewManager(ManagerOptions{Enforcer: enforcer, Timeout: time.Duration(0), Logger: grpclog.Component("test")})
+	mgr := NewManager(ManagerOptions{Enforcer: enforcer, Timeout: time.Duration(0)})
 
 	// Ensure that the timer callback does not fire within a short deadline.
 	select {
@@ -109,13 +106,13 @@ func (s) TestManager_Disabled(t *testing.T) {
 	case <-time.After(defaultTestShortTimeout):
 	}
 
-	// The first invocation of OnCallBegin() would lead to a call to
-	// ExitIdleMode() on the enforcer, unless the idleness manager is disabled.
-	mgr.OnCallBegin()
+	// The first invocation of OnCallBegin() should lead to a call to
+	// ExitIdleMode() on the enforcer.
+	go mgr.OnCallBegin()
 	select {
 	case <-enforcer.exitIdleCh:
-		t.Fatalf("ExitIdleMode() called on enforcer when manager is disabled")
 	case <-time.After(defaultTestShortTimeout):
+		t.Fatal("Timeout waiting for channel to move out of idle mode")
 	}
 
 	// If the number of calls to OnCallEnd() exceeds the number of calls to
@@ -137,8 +134,9 @@ func (s) TestManager_Enabled_TimerFires(t *testing.T) {
 	callbackCh := overrideNewTimer(t)
 
 	enforcer := newTestEnforcer()
-	mgr := NewManager(ManagerOptions{Enforcer: enforcer, Timeout: time.Duration(defaultTestIdleTimeout), Logger: grpclog.Component("test")})
+	mgr := NewManager(ManagerOptions{Enforcer: enforcer, Timeout: time.Duration(defaultTestIdleTimeout)})
 	defer mgr.Close()
+	mgr.ExitIdleMode()
 
 	// Ensure that the timer callback fires within a appropriate amount of time.
 	select {
@@ -162,8 +160,9 @@ func (s) TestManager_Enabled_OngoingCall(t *testing.T) {
 	callbackCh := overrideNewTimer(t)
 
 	enforcer := newTestEnforcer()
-	mgr := NewManager(ManagerOptions{Enforcer: enforcer, Timeout: time.Duration(defaultTestIdleTimeout), Logger: grpclog.Component("test")})
+	mgr := NewManager(ManagerOptions{Enforcer: enforcer, Timeout: time.Duration(defaultTestIdleTimeout)})
 	defer mgr.Close()
+	mgr.ExitIdleMode()
 
 	// Fire up a goroutine that simulates an ongoing RPC that is terminated
 	// after the timer callback fires for the first time.
@@ -207,8 +206,9 @@ func (s) TestManager_Enabled_ActiveSinceLastCheck(t *testing.T) {
 	callbackCh := overrideNewTimer(t)
 
 	enforcer := newTestEnforcer()
-	mgr := NewManager(ManagerOptions{Enforcer: enforcer, Timeout: time.Duration(defaultTestIdleTimeout), Logger: grpclog.Component("test")})
+	mgr := NewManager(ManagerOptions{Enforcer: enforcer, Timeout: time.Duration(defaultTestIdleTimeout)})
 	defer mgr.Close()
+	mgr.ExitIdleMode()
 
 	// Fire up a goroutine that simulates unary RPCs until the timer callback
 	// fires.
@@ -233,6 +233,7 @@ func (s) TestManager_Enabled_ActiveSinceLastCheck(t *testing.T) {
 	case <-callbackCh:
 		close(timerFired)
 	case <-time.After(2 * defaultTestIdleTimeout):
+		close(timerFired)
 		t.Fatal("Timeout waiting for idle timer callback to fire")
 	}
 	select {
@@ -257,9 +258,11 @@ func (s) TestManager_Enabled_ExitIdleOnRPC(t *testing.T) {
 	overrideNewTimer(t)
 
 	enforcer := newTestEnforcer()
-	mgr := NewManager(ManagerOptions{Enforcer: enforcer, Timeout: time.Duration(defaultTestIdleTimeout), Logger: grpclog.Component("test")})
+	mgr := NewManager(ManagerOptions{Enforcer: enforcer, Timeout: time.Duration(defaultTestIdleTimeout)})
 	defer mgr.Close()
 
+	mgr.ExitIdleMode()
+	<-enforcer.exitIdleCh
 	// Ensure that the channel moves to idle since there are no RPCs.
 	select {
 	case <-enforcer.enterIdleCh:
@@ -297,7 +300,7 @@ func (s) TestManager_Enabled_ExitIdleOnRPC(t *testing.T) {
 type racyState int32
 
 const (
-	stateInital racyState = iota
+	stateInitial racyState = iota
 	stateEnteredIdle
 	stateExitedIdle
 	stateActiveRPCs
@@ -306,12 +309,22 @@ const (
 // racyIdlnessEnforcer is a test idleness enforcer used specifically to test the
 // race between idle timeout and incoming RPCs.
 type racyEnforcer struct {
-	state *racyState // Accessed atomically.
+	t       *testing.T
+	state   *racyState // Accessed atomically.
+	started bool
 }
 
 // ExitIdleMode sets the internal state to stateExitedIdle. We should only ever
 // exit idle when we are currently in idle.
 func (ri *racyEnforcer) ExitIdleMode() error {
+	// Set only on the initial ExitIdleMode
+	if ri.started == false {
+		if *ri.state != stateInitial {
+			return fmt.Errorf("idleness enforcer's first ExitIdleMode after EnterIdleMode")
+		}
+		ri.started = true
+		return nil
+	}
 	if !atomic.CompareAndSwapInt32((*int32)(ri.state), int32(stateEnteredIdle), int32(stateExitedIdle)) {
 		return fmt.Errorf("idleness enforcer asked to exit idle when it did not enter idle earlier")
 	}
@@ -319,38 +332,36 @@ func (ri *racyEnforcer) ExitIdleMode() error {
 }
 
 // EnterIdleMode attempts to set the internal state to stateEnteredIdle. We should only ever enter idle before RPCs start.
-func (ri *racyEnforcer) EnterIdleMode() error {
-	if !atomic.CompareAndSwapInt32((*int32)(ri.state), int32(stateInital), int32(stateEnteredIdle)) {
-		return fmt.Errorf("idleness enforcer asked to enter idle after rpcs started")
+func (ri *racyEnforcer) EnterIdleMode() {
+	if !atomic.CompareAndSwapInt32((*int32)(ri.state), int32(stateInitial), int32(stateEnteredIdle)) {
+		ri.t.Errorf("idleness enforcer asked to enter idle after rpcs started")
 	}
-	return nil
 }
 
-// TestManager_IdleTimeoutRacesWithOnCallBegin tests the case where
-// firing of the idle timeout races with an incoming RPC. The test verifies that
-// if the timer callback win the race and puts the channel in idle, the RPCs can
-// kick it out of idle. And if the RPCs win the race and keep the channel
-// active, then the timer callback should not attempt to put the channel in idle
-// mode.
+// TestManager_IdleTimeoutRacesWithOnCallBegin tests the case where firing of
+// the idle timeout races with an incoming RPC. The test verifies that if the
+// timer callback wins the race and puts the channel in idle, the RPCs can kick
+// it out of idle. And if the RPCs win the race and keep the channel active,
+// then the timer callback should not attempt to put the channel in idle mode.
 func (s) TestManager_IdleTimeoutRacesWithOnCallBegin(t *testing.T) {
 	// Run multiple iterations to simulate different possibilities.
 	for i := 0; i < 20; i++ {
 		t.Run(fmt.Sprintf("iteration=%d", i), func(t *testing.T) {
 			var idlenessState racyState
-			enforcer := &racyEnforcer{state: &idlenessState}
+			enforcer := &racyEnforcer{t: t, state: &idlenessState}
 
 			// Configure a large idle timeout so that we can control the
 			// race between the timer callback and RPCs.
-			mgr := NewManager(ManagerOptions{Enforcer: enforcer, Timeout: time.Duration(10 * time.Minute), Logger: grpclog.Component("test")})
+			mgr := NewManager(ManagerOptions{Enforcer: enforcer, Timeout: time.Duration(10 * time.Minute)})
 			defer mgr.Close()
+			mgr.ExitIdleMode()
 
 			var wg sync.WaitGroup
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				m := mgr.(interface{ handleIdleTimeout() })
 				<-time.After(defaultTestIdleTimeout / 10)
-				m.handleIdleTimeout()
+				mgr.handleIdleTimeout()
 			}()
 			for j := 0; j < 100; j++ {
 				wg.Add(1)

--- a/internal/idle/idle_test.go
+++ b/internal/idle/idle_test.go
@@ -97,7 +97,7 @@ func (s) TestManager_Disabled(t *testing.T) {
 	// Create an idleness manager that is disabled because of idleTimeout being
 	// set to `0`.
 	enforcer := newTestEnforcer()
-	mgr := NewManager(ManagerOptions{Enforcer: enforcer, Timeout: time.Duration(0)})
+	mgr := NewManager(enforcer, time.Duration(0))
 
 	// Ensure that the timer callback does not fire within a short deadline.
 	select {
@@ -134,7 +134,7 @@ func (s) TestManager_Enabled_TimerFires(t *testing.T) {
 	callbackCh := overrideNewTimer(t)
 
 	enforcer := newTestEnforcer()
-	mgr := NewManager(ManagerOptions{Enforcer: enforcer, Timeout: time.Duration(defaultTestIdleTimeout)})
+	mgr := NewManager(enforcer, time.Duration(defaultTestIdleTimeout))
 	defer mgr.Close()
 	mgr.ExitIdleMode()
 
@@ -160,7 +160,7 @@ func (s) TestManager_Enabled_OngoingCall(t *testing.T) {
 	callbackCh := overrideNewTimer(t)
 
 	enforcer := newTestEnforcer()
-	mgr := NewManager(ManagerOptions{Enforcer: enforcer, Timeout: time.Duration(defaultTestIdleTimeout)})
+	mgr := NewManager(enforcer, time.Duration(defaultTestIdleTimeout))
 	defer mgr.Close()
 	mgr.ExitIdleMode()
 
@@ -206,7 +206,7 @@ func (s) TestManager_Enabled_ActiveSinceLastCheck(t *testing.T) {
 	callbackCh := overrideNewTimer(t)
 
 	enforcer := newTestEnforcer()
-	mgr := NewManager(ManagerOptions{Enforcer: enforcer, Timeout: time.Duration(defaultTestIdleTimeout)})
+	mgr := NewManager(enforcer, time.Duration(defaultTestIdleTimeout))
 	defer mgr.Close()
 	mgr.ExitIdleMode()
 
@@ -258,7 +258,7 @@ func (s) TestManager_Enabled_ExitIdleOnRPC(t *testing.T) {
 	overrideNewTimer(t)
 
 	enforcer := newTestEnforcer()
-	mgr := NewManager(ManagerOptions{Enforcer: enforcer, Timeout: time.Duration(defaultTestIdleTimeout)})
+	mgr := NewManager(enforcer, time.Duration(defaultTestIdleTimeout))
 	defer mgr.Close()
 
 	mgr.ExitIdleMode()
@@ -352,7 +352,7 @@ func (s) TestManager_IdleTimeoutRacesWithOnCallBegin(t *testing.T) {
 
 			// Configure a large idle timeout so that we can control the
 			// race between the timer callback and RPCs.
-			mgr := NewManager(ManagerOptions{Enforcer: enforcer, Timeout: time.Duration(10 * time.Minute)})
+			mgr := NewManager(enforcer, time.Duration(10*time.Minute))
 			defer mgr.Close()
 			mgr.ExitIdleMode()
 

--- a/internal/idle/idle_test.go
+++ b/internal/idle/idle_test.go
@@ -319,7 +319,7 @@ type racyEnforcer struct {
 func (ri *racyEnforcer) ExitIdleMode() error {
 	// Set only on the initial ExitIdleMode
 	if ri.started == false {
-		if *ri.state != stateInitial {
+		if !atomic.CompareAndSwapInt32((*int32)(ri.state), int32(stateInitial), int32(stateExitedIdle)) {
 			return fmt.Errorf("idleness enforcer's first ExitIdleMode after EnterIdleMode")
 		}
 		ri.started = true

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -186,6 +186,8 @@ var (
 
 	// ExitIdleModeForTesting gets the ClientConn to exit IDLE mode.
 	ExitIdleModeForTesting any // func(*grpc.ClientConn) error
+
+	ChannelzTurnOffForTesting func()
 )
 
 // HealthChecker defines the signature of the client-side LB channel health checking function.

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -182,7 +182,7 @@ var (
 	GRPCResolverSchemeExtraMetadata string = "xds"
 
 	// EnterIdleModeForTesting gets the ClientConn to enter IDLE mode.
-	EnterIdleModeForTesting any // func(*grpc.ClientConn) error
+	EnterIdleModeForTesting any // func(*grpc.ClientConn)
 
 	// ExitIdleModeForTesting gets the ClientConn to exit IDLE mode.
 	ExitIdleModeForTesting any // func(*grpc.ClientConn) error

--- a/picker_wrapper.go
+++ b/picker_wrapper.go
@@ -37,7 +37,6 @@ import (
 type pickerWrapper struct {
 	mu            sync.Mutex
 	done          bool
-	idle          bool
 	blockingCh    chan struct{}
 	picker        balancer.Picker
 	statsHandlers []stats.Handler // to record blocking picker calls
@@ -53,11 +52,7 @@ func newPickerWrapper(statsHandlers []stats.Handler) *pickerWrapper {
 // updatePicker is called by UpdateBalancerState. It unblocks all blocked pick.
 func (pw *pickerWrapper) updatePicker(p balancer.Picker) {
 	pw.mu.Lock()
-	if pw.done || pw.idle {
-		// There is a small window where a picker update from the LB policy can
-		// race with the channel going to idle mode. If the picker is idle here,
-		// it is because the channel asked it to do so, and therefore it is sage
-		// to ignore the update from the LB policy.
+	if pw.done {
 		pw.mu.Unlock()
 		return
 	}
@@ -210,23 +205,15 @@ func (pw *pickerWrapper) close() {
 	close(pw.blockingCh)
 }
 
+// enterIdleMode clears the pickerWrapper and prepares it for being used again
+// when idle mode is exited.
 func (pw *pickerWrapper) enterIdleMode() {
 	pw.mu.Lock()
 	defer pw.mu.Unlock()
 	if pw.done {
 		return
 	}
-	pw.idle = true
-}
-
-func (pw *pickerWrapper) exitIdleMode() {
-	pw.mu.Lock()
-	defer pw.mu.Unlock()
-	if pw.done {
-		return
-	}
 	pw.blockingCh = make(chan struct{})
-	pw.idle = false
 }
 
 // dropError is a wrapper error that indicates the LB policy wishes to drop the

--- a/picker_wrapper.go
+++ b/picker_wrapper.go
@@ -205,9 +205,9 @@ func (pw *pickerWrapper) close() {
 	close(pw.blockingCh)
 }
 
-// enterIdleMode clears the pickerWrapper and prepares it for being used again
-// when idle mode is exited.
-func (pw *pickerWrapper) enterIdleMode() {
+// reset clears the pickerWrapper and prepares it for being used again when idle
+// mode is exited.
+func (pw *pickerWrapper) reset() {
 	pw.mu.Lock()
 	defer pw.mu.Unlock()
 	if pw.done {

--- a/resolver_balancer_ext_test.go
+++ b/resolver_balancer_ext_test.go
@@ -35,11 +35,11 @@ import (
 )
 
 // TestResolverBalancerInteraction tests:
-// 1. resolver.Builder.Build()
-// 2. resolver.ClientConn.UpdateState()
-// 3. balancer.Balancer.UpdateClientConnState()
-// 4. balancer.ClientConn.ResolveNow()
-// 5. resolver.Resolver.ResolveNow()
+// 1. resolver.Builder.Build() ->
+// 2. resolver.ClientConn.UpdateState() ->
+// 3. balancer.Balancer.UpdateClientConnState() ->
+// 4. balancer.ClientConn.ResolveNow() ->
+// 5. resolver.Resolver.ResolveNow() ->
 func (s) TestResolverBalancerInteraction(t *testing.T) {
 	const name = "testrbi"
 	bf := stub.BalancerFuncs{

--- a/resolver_balancer_ext_test.go
+++ b/resolver_balancer_ext_test.go
@@ -1,0 +1,71 @@
+/*
+ *
+ * Copyright 2014 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package grpc_test
+
+import (
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/balancer"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/internal/balancer/stub"
+	"google.golang.org/grpc/resolver"
+	"google.golang.org/grpc/resolver/manual"
+)
+
+// TestResolverBalancerInteraction tests:
+// 1. resolver.Builder.Build()
+// 2. resolver.ClientConn.UpdateState()
+// 3. balancer.Balancer.UpdateClientConnState()
+// 4. balancer.ClientConn.ResolveNow()
+// 5. resolver.Resolver.ResolveNow()
+func (s) TestResolverBalancerInteraction(t *testing.T) {
+	const name = "testrbi"
+	bf := stub.BalancerFuncs{
+		UpdateClientConnState: func(bd *stub.BalancerData, ccs balancer.ClientConnState) error {
+			bd.ClientConn.ResolveNow(resolver.ResolveNowOptions{})
+			return nil
+		},
+	}
+	stub.Register(name, bf)
+
+	rb := manual.NewBuilderWithScheme(name)
+	rb.BuildCallback = func(_ resolver.Target, cc resolver.ClientConn, _ resolver.BuildOptions) {
+		sc := cc.ParseServiceConfig(`{"loadBalancingConfig": [{"` + name + `":{}}]}`)
+		cc.UpdateState(resolver.State{
+			Addresses:     []resolver.Address{{Addr: "test"}},
+			ServiceConfig: sc,
+		})
+	}
+	rnCh := make(chan struct{})
+	rb.ResolveNowCallback = func(resolver.ResolveNowOptions) { close(rnCh) }
+	resolver.Register(rb)
+
+	cc, err := grpc.Dial(name+":///", grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("grpc.Dial error: %v", err)
+	}
+	defer cc.Close()
+	select {
+	case <-rnCh:
+	case <-time.After(defaultTestTimeout):
+		t.Fatalf("timed out waiting for resolver.ResolveNow")
+	}
+}

--- a/resolver_balancer_ext_test.go
+++ b/resolver_balancer_ext_test.go
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2014 gRPC authors.
+ * Copyright 2023 gRPC authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,7 +45,8 @@ import (
 // 4. balancer.ClientConn.ResolveNow() ->
 // 5. resolver.Resolver.ResolveNow() ->
 func (s) TestResolverBalancerInteraction(t *testing.T) {
-	const name = "testrbi"
+	name := strings.Replace(strings.ToLower(t.Name()), "/", "", -1)
+	fmt.Println(name)
 	bf := stub.BalancerFuncs{
 		UpdateClientConnState: func(bd *stub.BalancerData, ccs balancer.ClientConnState) error {
 			bd.ClientConn.ResolveNow(resolver.ResolveNowOptions{})
@@ -104,7 +105,7 @@ func (b *resolverBuilderWithErr) Close() {}
 // 4. resolver.Builder.Build() fails.
 func (s) TestResolverBuildFailure(t *testing.T) {
 	enterIdle := internal.EnterIdleModeForTesting.(func(*grpc.ClientConn))
-	const name = "trbf"
+	name := strings.Replace(strings.ToLower(t.Name()), "/", "", -1)
 	resErrCh := make(chan error, 1)
 	resolver.Register(&resolverBuilderWithErr{errCh: resErrCh, scheme: name})
 
@@ -130,7 +131,7 @@ func (s) TestResolverBuildFailure(t *testing.T) {
 // the channel enters idle mode.
 func (s) TestEnterIdleDuringResolverUpdateState(t *testing.T) {
 	enterIdle := internal.EnterIdleModeForTesting.(func(*grpc.ClientConn))
-	const name = "testeidrus"
+	name := strings.Replace(strings.ToLower(t.Name()), "/", "", -1)
 
 	// Create a manual resolver that spams UpdateState calls until it is closed.
 	rb := manual.NewBuilderWithScheme(name)
@@ -175,7 +176,7 @@ func (s) TestEnterIdleDuringResolverUpdateState(t *testing.T) {
 // time as the balancer being closed while the channel enters idle mode.
 func (s) TestEnterIdleDuringBalancerUpdateState(t *testing.T) {
 	enterIdle := internal.EnterIdleModeForTesting.(func(*grpc.ClientConn))
-	const name = "testeidbus"
+	name := strings.Replace(strings.ToLower(t.Name()), "/", "", -1)
 
 	// Create a balancer that calls UpdateState once asynchronously, attempting
 	// to make the channel appear ready even after entering idle.
@@ -220,7 +221,7 @@ func (s) TestEnterIdleDuringBalancerNewSubConn(t *testing.T) {
 	channelz.TurnOn()
 	defer internal.ChannelzTurnOffForTesting()
 	enterIdle := internal.EnterIdleModeForTesting.(func(*grpc.ClientConn))
-	const name = "testeidbnsc"
+	name := strings.Replace(strings.ToLower(t.Name()), "/", "", -1)
 
 	// Create a balancer that calls NewSubConn once asynchronously, attempting
 	// to create a subchannel after going idle.

--- a/resolver_wrapper.go
+++ b/resolver_wrapper.go
@@ -33,14 +33,14 @@ import (
 // ccResolverWrapper is a wrapper on top of cc for resolvers.
 // It implements resolver.ClientConn interface.
 type ccResolverWrapper struct {
-	// The following fields are read-only.
+	// The following fields are initialized when the wrapper is created and are
+	// read-only afterwards, and therefore can be accessed without a mutex.
 	cc                  *ClientConn
 	ignoreServiceConfig bool
 	serializer          *grpcsync.CallbackSerializer
 	serializerCancel    context.CancelFunc
 
-	// The following fields are only accessed within the serializer.
-	resolver resolver.Resolver
+	resolver resolver.Resolver // only accessed within the serializer
 
 	// The following fields are protected by mu.  Caller must take cc.mu before
 	// taking mu.

--- a/resolver_wrapper.go
+++ b/resolver_wrapper.go
@@ -49,8 +49,8 @@ type ccResolverWrapper struct {
 	closed   bool
 }
 
-// newCCResolverWrapper uses the resolver.Builder to build a Resolver and
-// returns a ccResolverWrapper object which wraps the newly built resolver.
+// newCCResolverWrapper initializes the ccResolverWrapper.  It can only be used
+// after calling start, which builds the resolver.
 func newCCResolverWrapper(cc *ClientConn) *ccResolverWrapper {
 	ctx, cancel := context.WithCancel(cc.ctx)
 	return &ccResolverWrapper{
@@ -61,6 +61,9 @@ func newCCResolverWrapper(cc *ClientConn) *ccResolverWrapper {
 	}
 }
 
+// start builds the name resolver using the resolver.Builder in cc and returns
+// any error encountered.  It must always be the first operation performed on
+// any newly created ccResolverWrapper, except that close may be called instead.
 func (ccr *ccResolverWrapper) start() error {
 	errCh := make(chan error)
 	ccr.serializer.Schedule(func(ctx context.Context) {

--- a/resolver_wrapper.go
+++ b/resolver_wrapper.go
@@ -23,7 +23,6 @@ import (
 	"strings"
 	"sync"
 
-	"google.golang.org/grpc/balancer"
 	"google.golang.org/grpc/internal/channelz"
 	"google.golang.org/grpc/internal/grpcsync"
 	"google.golang.org/grpc/internal/pretty"
@@ -31,119 +30,89 @@ import (
 	"google.golang.org/grpc/serviceconfig"
 )
 
-// resolverStateUpdater wraps the single method used by ccResolverWrapper to
-// report a state update from the actual resolver implementation.
-type resolverStateUpdater interface {
-	updateResolverState(s resolver.State, err error) error
-}
-
 // ccResolverWrapper is a wrapper on top of cc for resolvers.
 // It implements resolver.ClientConn interface.
 type ccResolverWrapper struct {
-	// The following fields are initialized when the wrapper is created and are
-	// read-only afterwards, and therefore can be accessed without a mutex.
-	cc                  resolverStateUpdater
-	channelzID          *channelz.Identifier
+	// The following fields are read-only.
+	cc                  *ClientConn
 	ignoreServiceConfig bool
-	opts                ccResolverWrapperOpts
-	serializer          *grpcsync.CallbackSerializer // To serialize all incoming calls.
-	serializerCancel    context.CancelFunc           // To close the serializer, accessed only from close().
+	serializer          *grpcsync.CallbackSerializer
+	serializerCancel    context.CancelFunc
 
-	// All incoming (resolver --> gRPC) calls are guaranteed to execute in a
-	// mutually exclusive manner as they are scheduled on the serializer.
-	// Fields accessed *only* in these serializer callbacks, can therefore be
-	// accessed without a mutex.
-	curState resolver.State
+	// The following fields are only accessed within the serializer.
+	resolver resolver.Resolver
 
-	// mu guards access to the below fields.
+	// The following fields are protected by mu.
 	mu       sync.Mutex
+	curState resolver.State
 	closed   bool
-	resolver resolver.Resolver // Accessed only from outgoing calls.
-}
-
-// ccResolverWrapperOpts wraps the arguments to be passed when creating a new
-// ccResolverWrapper.
-type ccResolverWrapperOpts struct {
-	target     resolver.Target       // User specified dial target to resolve.
-	builder    resolver.Builder      // Resolver builder to use.
-	bOpts      resolver.BuildOptions // Resolver build options to use.
-	channelzID *channelz.Identifier  // Channelz identifier for the channel.
 }
 
 // newCCResolverWrapper uses the resolver.Builder to build a Resolver and
 // returns a ccResolverWrapper object which wraps the newly built resolver.
-func newCCResolverWrapper(cc resolverStateUpdater, opts ccResolverWrapperOpts) (*ccResolverWrapper, error) {
-	ctx, cancel := context.WithCancel(context.Background())
+func newCCResolverWrapper(cc *ClientConn) (*ccResolverWrapper, error) {
+	ctx, cancel := context.WithCancel(cc.ctx)
 	ccr := &ccResolverWrapper{
 		cc:                  cc,
-		channelzID:          opts.channelzID,
-		ignoreServiceConfig: opts.bOpts.DisableServiceConfig,
-		opts:                opts,
+		ignoreServiceConfig: cc.dopts.disableServiceConfig,
 		serializer:          grpcsync.NewCallbackSerializer(ctx),
 		serializerCancel:    cancel,
 	}
 
-	// Cannot hold the lock at build time because the resolver can send an
-	// update or error inline and these incoming calls grab the lock to schedule
-	// a callback in the serializer.
-	r, err := opts.builder.Build(opts.target, ccr, opts.bOpts)
-	if err != nil {
-		cancel()
+	errCh := make(chan error)
+	ccr.serializer.Schedule(func(ctx context.Context) {
+		if ctx.Err() != nil {
+			return
+		}
+		opts := resolver.BuildOptions{
+			DisableServiceConfig: cc.dopts.disableServiceConfig,
+			DialCreds:            cc.dopts.copts.TransportCredentials,
+			CredsBundle:          cc.dopts.copts.CredsBundle,
+			Dialer:               cc.dopts.copts.Dialer,
+		}
+		var err error
+		ccr.resolver, err = cc.resolverBuilder.Build(cc.parsedTarget, ccr, opts)
+		errCh <- err
+	})
+
+	if err := <-errCh; err != nil {
 		return nil, err
 	}
-
-	// Any error reported by the resolver at build time that leads to a
-	// re-resolution request from the balancer is dropped by grpc until we
-	// return from this function. So, we don't have to handle pending resolveNow
-	// requests here.
-	ccr.mu.Lock()
-	ccr.resolver = r
-	ccr.mu.Unlock()
-
 	return ccr, nil
 }
 
 func (ccr *ccResolverWrapper) resolveNow(o resolver.ResolveNowOptions) {
-	ccr.mu.Lock()
-	defer ccr.mu.Unlock()
-
-	// ccr.resolver field is set only after the call to Build() returns. But in
-	// the process of building, the resolver may send an error update which when
-	// propagated to the balancer may result in a re-resolution request.
-	if ccr.closed || ccr.resolver == nil {
-		return
-	}
-	ccr.resolver.ResolveNow(o)
+	ccr.serializer.Schedule(func(ctx context.Context) {
+		if ctx.Err() != nil || ccr.resolver == nil {
+			return
+		}
+		ccr.resolver.ResolveNow(o)
+	})
 }
 
 func (ccr *ccResolverWrapper) close() {
-	ccr.mu.Lock()
-	if ccr.closed {
+	channelz.Info(logger, ccr.cc.channelzID, "Closing the name resolver")
+
+	ccr.serializer.Schedule(func(context.Context) {
+		if ccr.resolver == nil {
+			return
+		}
+		ccr.mu.Lock()
+		ccr.closed = true
 		ccr.mu.Unlock()
-		return
-	}
-
-	channelz.Info(logger, ccr.channelzID, "Closing the name resolver")
-
-	// Close the serializer to ensure that no more calls from the resolver are
-	// handled, before actually closing the resolver.
+		ccr.resolver.Close()
+		ccr.resolver = nil
+	})
 	ccr.serializerCancel()
-	ccr.closed = true
-	r := ccr.resolver
-	ccr.mu.Unlock()
-
-	// Give enqueued callbacks a chance to finish.
-	<-ccr.serializer.Done()
-
-	// Spawn a goroutine to close the resolver (since it may block trying to
-	// cleanup all allocated resources) and return early.
-	go r.Close()
 }
 
 // UpdateState is called by resolver implementations to report new state to gRPC
 // which includes addresses and service config.
 func (ccr *ccResolverWrapper) UpdateState(s resolver.State) error {
-	errCh := make(chan error, 1)
+	ccr.mu.Lock()
+	if ccr.closed {
+		return nil
+	}
 	if s.Endpoints == nil {
 		s.Endpoints = make([]resolver.Endpoint, 0, len(s.Addresses))
 		for _, a := range s.Addresses {
@@ -152,41 +121,38 @@ func (ccr *ccResolverWrapper) UpdateState(s resolver.State) error {
 			s.Endpoints = append(s.Endpoints, ep)
 		}
 	}
-	ok := ccr.serializer.Schedule(func(context.Context) {
-		ccr.addChannelzTraceEvent(s)
-		ccr.curState = s
-		if err := ccr.cc.updateResolverState(ccr.curState, nil); err == balancer.ErrBadResolverState {
-			errCh <- balancer.ErrBadResolverState
-			return
-		}
-		errCh <- nil
-	})
-	if !ok {
-		// The only time when Schedule() fail to add the callback to the
-		// serializer is when the serializer is closed, and this happens only
-		// when the resolver wrapper is closed.
-		return nil
-	}
-	return <-errCh
+	ccr.addChannelzTraceEvent(s)
+	ccr.curState = s
+	ccr.mu.Unlock()
+	return ccr.cc.updateResolverState(s, nil)
 }
 
 // ReportError is called by resolver implementations to report errors
 // encountered during name resolution to gRPC.
 func (ccr *ccResolverWrapper) ReportError(err error) {
-	ccr.serializer.Schedule(func(_ context.Context) {
-		channelz.Warningf(logger, ccr.channelzID, "ccResolverWrapper: reporting error to cc: %v", err)
-		ccr.cc.updateResolverState(resolver.State{}, err)
-	})
+	ccr.mu.Lock()
+	if ccr.closed {
+		ccr.mu.Unlock()
+		return
+	}
+	ccr.mu.Unlock()
+	channelz.Warningf(logger, ccr.cc.channelzID, "ccResolverWrapper: reporting error to cc: %v", err)
+	ccr.cc.updateResolverState(resolver.State{}, err)
 }
 
 // NewAddress is called by the resolver implementation to send addresses to
 // gRPC.
 func (ccr *ccResolverWrapper) NewAddress(addrs []resolver.Address) {
-	ccr.serializer.Schedule(func(_ context.Context) {
-		ccr.addChannelzTraceEvent(resolver.State{Addresses: addrs, ServiceConfig: ccr.curState.ServiceConfig})
-		ccr.curState.Addresses = addrs
-		ccr.cc.updateResolverState(ccr.curState, nil)
-	})
+	ccr.mu.Lock()
+	if ccr.closed {
+		ccr.mu.Unlock()
+		return
+	}
+	s := resolver.State{Addresses: addrs, ServiceConfig: ccr.curState.ServiceConfig}
+	ccr.addChannelzTraceEvent(s)
+	ccr.curState = s
+	ccr.mu.Unlock()
+	ccr.cc.updateResolverState(s, nil)
 }
 
 // ParseServiceConfig is called by resolver implementations to parse a JSON
@@ -215,5 +181,5 @@ func (ccr *ccResolverWrapper) addChannelzTraceEvent(s resolver.State) {
 	} else if len(ccr.curState.Addresses) == 0 && len(s.Addresses) > 0 {
 		updates = append(updates, "resolver returned new addresses")
 	}
-	channelz.Infof(logger, ccr.channelzID, "Resolver state updated: %s (%v)", pretty.ToJSON(s), strings.Join(updates, "; "))
+	channelz.Infof(logger, ccr.cc.channelzID, "Resolver state updated: %s (%v)", pretty.ToJSON(s), strings.Join(updates, "; "))
 }

--- a/resolver_wrapper.go
+++ b/resolver_wrapper.go
@@ -92,6 +92,9 @@ func (ccr *ccResolverWrapper) resolveNow(o resolver.ResolveNowOptions) {
 	})
 }
 
+// close initiates async shutdown of the wrapper.  To determine the wrapper has
+// finished shutting down, the channel should block on ccr.serializer.Done()
+// without cc.mu held.
 func (ccr *ccResolverWrapper) close() {
 	channelz.Info(logger, ccr.cc.channelzID, "Closing the name resolver")
 	ccr.mu.Lock()


### PR DESCRIPTION
- Balancer wrapper is now recreated for each trip out of idle mode (instead of supporting its own idle mode).
- Removed mutexes or limited as much as possible.
- All calls into resolver/balancer are done in serializer, with no mutexes held.
- Calls from old resolver instances are ignored.
- ExitIdleCond is no longer needed by closing the idlenessMgr at the start of Close.
- Constructors figure out their own parameters from cc instead of being passed in.
- Handle resolver.Build->cc.updateResolverState->balancer.UpdateState->resolver.ResolveNow properly
- Idle Manager starts in idle state.
- All channel idleness management goes through idle manager -- e.g. Connect().
- Add lock and closed state to balancer_wrapper to prevent a race where the
  balancer creates a subchannel and we enter idle mode during that process.
- Split resolver wrapper into constructor and start method so the serializer is
  available during resolver.Build.
- Add EnterIdleModeForTesting to idleness manager and use idlenessMgr methods
  in the idleness test instead of methods on the ClientConn which should not be
  called directly.

Fixes #6783 

RELEASE NOTES:
* client: fix race that could cause a deadlock while entering idle mode and receiving a name resolver update