### PR TITLE
interop: Custom creds for stress test client

### DIFF
--- a/interop/stress/client/main.go
+++ b/interop/stress/client/main.go
@@ -25,7 +25,7 @@ import (
 	"fmt"
 	"math/rand"
 	"net"
-  "os"
+	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -35,15 +35,15 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
-	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/credentials/google"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/grpclog"
 	"google.golang.org/grpc/interop"
 	"google.golang.org/grpc/resolver"
 	"google.golang.org/grpc/status"
 	"google.golang.org/grpc/testdata"
 
-  _ "google.golang.org/grpc/xds/googledirectpath" // Register xDS resolver required for c2p directpath.
+	_ "google.golang.org/grpc/xds/googledirectpath" // Register xDS resolver required for c2p directpath.
 
 	testgrpc "google.golang.org/grpc/interop/grpc_testing"
 	metricspb "google.golang.org/grpc/interop/stress/grpc_testing"
@@ -87,7 +87,7 @@ func parseTestCases(testCaseString string) []testCaseWithWeight {
 			panic(fmt.Sprintf("invalid test case with weight: %s", str))
 		}
 		// Check if test case is supported.
-    testCaseName := strings.ToLower(testCaseNameAndWeight[0])
+		testCaseName := strings.ToLower(testCaseNameAndWeight[0])
 		switch testCaseName {
 		case
 			"empty_unary",
@@ -297,7 +297,7 @@ func newConn(address string, useTLS, testCA bool, tlsServerName string) (*grpc.C
 		} else {
 			logger.Fatalf("Unknown custom credentials: %v", *customCredentialsType)
 		}
-	} else if useTLS {  
+	} else if useTLS {
 		var sn string
 		if tlsServerName != "" {
 			sn = tlsServerName
@@ -324,7 +324,7 @@ func newConn(address string, useTLS, testCA bool, tlsServerName string) (*grpc.C
 
 func main() {
 	flag.Parse()
-  resolver.SetDefaultScheme("dns")
+	resolver.SetDefaultScheme("dns")
 	addresses := strings.Split(*serverAddresses, ",")
 	tests := parseTestCases(*testCases)
 	logParameterInfo(addresses, tests)
@@ -359,6 +359,6 @@ func main() {
 		close(stop)
 	}
 	wg.Wait()
-  fmt.Fprintf(os.Stdout, "Total calls made: %v\n", totalNumCalls)
+	fmt.Fprintf(os.Stdout, "Total calls made: %v\n", totalNumCalls)
 	logger.Infof(" ===== ALL DONE ===== ")
 }

--- a/interop/stress/client/main.go
+++ b/interop/stress/client/main.go
@@ -82,13 +82,13 @@ func parseTestCases(testCaseString string) []testCaseWithWeight {
 	testCaseStrings := strings.Split(testCaseString, ",")
 	testCases := make([]testCaseWithWeight, len(testCaseStrings))
 	for i, str := range testCaseStrings {
-		testCase := strings.Split(str, ":")
-		if len(testCase) != 2 {
+		testCaseNameAndWeight := strings.Split(str, ":")
+		if len(testCaseNameAndWeight) != 2 {
 			panic(fmt.Sprintf("invalid test case with weight: %s", str))
 		}
 		// Check if test case is supported.
-    testCaseName := strings.ToLower(testCase[0])
-		switch strings.ToLower(testCaseName) {
+    testCaseName := strings.ToLower(testCaseNameAndWeight[0])
+		switch testCaseName {
 		case
 			"empty_unary",
 			"large_unary",
@@ -102,10 +102,10 @@ func parseTestCases(testCaseString string) []testCaseWithWeight {
 			"status_code_and_message",
 			"custom_metadata":
 		default:
-			panic(fmt.Sprintf("unknown test type: %s", testCase[0]))
+			panic(fmt.Sprintf("unknown test type: %s", testCaseNameAndWeight[0]))
 		}
 		testCases[i].name = testCaseName
-		w, err := strconv.Atoi(testCase[1])
+		w, err := strconv.Atoi(testCaseNameAndWeight[1])
 		if err != nil {
 			panic(fmt.Sprintf("%v", err))
 		}


### PR DESCRIPTION
Allows custom, Google specific credentials to be specified from the command line.

Also adds a final printout to stdout with the total amount of calls made. Stress tests can use that to determine the average QPS of a run.

RELEASE NOTES: none