### PR TITLE
xds/internal/server: cleanup formatting directives in some logs

### DIFF
--- a/xds/internal/server/listener_wrapper.go
+++ b/xds/internal/server/listener_wrapper.go
@@ -254,7 +254,7 @@ func (l *listenerWrapper) Accept() (net.Conn, error) {
 			// error, `grpc.Serve()` method sleeps for a small duration and
 			// therefore ends up blocking all connection attempts during that
 			// time frame, which is also not ideal for an error like this.
-			l.logger.Warningf("Connection from %s to %s failed to find any matching filter chain", conn.RemoteAddr().String(), conn.LocalAddr().String())
+			l.logger.Warningf("Connection from %s to %s failed to find any matching filter chain", conn.RemoteAddr(), conn.LocalAddr())
 			conn.Close()
 			continue
 		}
@@ -425,7 +425,7 @@ func (lw *ldsWatcher) OnError(err error) {
 		return
 	}
 	if lw.logger.V(2) {
-		lw.logger.Infof("LDS watch for resource %q reported error: %#v", lw.name, err)
+		lw.logger.Infof("LDS watch for resource %q reported error: %v", lw.name, err)
 	}
 	// For errors which are anything other than "resource-not-found", we
 	// continue to use the old configuration.
@@ -433,11 +433,11 @@ func (lw *ldsWatcher) OnError(err error) {
 
 func (lw *ldsWatcher) OnResourceDoesNotExist() {
 	if lw.parent.closed.HasFired() {
-		lw.logger.Warningf("Resource %q received resource-not-found-error after listener was closed", lw.name)
+		lw.logger.Warningf("Resource %q received resource-does-not-exist error after listener was closed", lw.name)
 		return
 	}
 	if lw.logger.V(2) {
-		lw.logger.Infof("LDS watch for resource %q reported resource-does-not-exist error: %v", lw.name)
+		lw.logger.Infof("LDS watch for resource %q reported resource-does-not-exist error", lw.name)
 	}
 	err := xdsresource.NewErrorf(xdsresource.ErrorTypeResourceNotFound, "resource name %q of type Listener not found in received response", lw.name)
 	lw.parent.switchMode(nil, connectivity.ServingModeNotServing, err)


### PR DESCRIPTION
One of these came up in the review of PR 6726 after it was merged. I made a pass through the file and cleaned up all the logs that I thought deserved a cleanup.

RELEASE NOTES: none