### PR TITLE
security/advancedtls: fix test that relies on min TLS version

### DIFF
--- a/security/advancedtls/advancedtls_test.go
+++ b/security/advancedtls/advancedtls_test.go
@@ -942,7 +942,7 @@ func (s) TestGetCertificatesSNI(t *testing.T) {
 				ServerName:        test.serverName,
 				SupportedCurves:   []tls.CurveID{tls.CurveP256},
 				SupportedPoints:   []uint8{pointFormatUncompressed},
-				SupportedVersions: []uint16{tls.VersionTLS10},
+				SupportedVersions: []uint16{tls.VersionTLS12},
 			}
 			gotCertificate, err := serverConfig.GetCertificate(clientHello)
 			if err != nil {


### PR DESCRIPTION
Go 1.22 changed the default TLS minimum version. Toolchains which do not respect go.mod 'go' version directives will break when executing the Test/GetCertificatesSNI/Select_serverCert3 test, since it relies on the private tls.ClientHelloInfo.config fields minimum version matching the configured tls.ClientHelloInfo.SupportedVersions field. This change just bumps the version in tls.ClientHelloInfo.SupportedVersions to tls.VersionTLS12.

With Go 1.22, gRPC users will still be able to use TLS versions VersionTLS10, VersionTLS11 by utilizing MinVersion and MaxVersion parameters of ClientOptions struct.

b/315783527

RELEASE NOTES: N/A