### PR TITLE
client: always enable TCP keepalives with OS defaults

### DIFF
--- a/benchmark/benchmain/main.go
+++ b/benchmark/benchmain/main.go
@@ -67,6 +67,7 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/experimental"
 	"google.golang.org/grpc/grpclog"
+	"google.golang.org/grpc/internal"
 	"google.golang.org/grpc/internal/channelz"
 	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/metadata"
@@ -373,7 +374,7 @@ func makeClients(bf stats.Features) ([]testgrpc.BenchmarkServiceClient, func()) 
 			logger.Fatalf("Failed to listen: %v", err)
 		}
 		opts = append(opts, grpc.WithContextDialer(func(ctx context.Context, address string) (net.Conn, error) {
-			return nw.ContextDialer((&net.Dialer{KeepAlive: time.Duration(-1)}).DialContext)(ctx, "tcp", lis.Addr().String())
+			return nw.ContextDialer((internal.NetDialerWithTCPKeepalive().DialContext))(ctx, "tcp", lis.Addr().String())
 		}))
 	}
 	lis = nw.Listener(lis)

--- a/dialoptions.go
+++ b/dialoptions.go
@@ -401,12 +401,12 @@ func WithTimeout(d time.Duration) DialOption {
 // returned by f, gRPC checks the error's Temporary() method to decide if it
 // should try to reconnect to the network address.
 //
-// Note: As of Go 1.21, the standard library overrides the OS defaults for TCP
-// keepalive time and interval to 15s. To enable TCP keepalive with OS defaults
-// for keepalive time and interval, use a net.Dialer that sets the KeepAlive
-// field set to a negative value, and sets the SO_KEEPALIVE socket option to
-// true from the Control or ControlContext field. For a concrete example of how
-// to do this, see internal.NetDialerWithTCPKeepalive().
+// Note: All supported releases of Go (as of December 2023) override the OS
+// defaults for TCP keepalive time and interval to 15s. To enable TCP keepalive
+// with OS defaults for keepalive time and interval, use a net.Dialer that sets
+// the KeepAlive field to a negative value, and sets the SO_KEEPALIVE socket
+// option to true from the Control or ControlContext field. For a concrete
+// example of how to do this, see internal.NetDialerWithTCPKeepalive().
 //
 // For more information, please see [issue 23459] in the Go github repo.
 //

--- a/dialoptions.go
+++ b/dialoptions.go
@@ -401,10 +401,12 @@ func WithTimeout(d time.Duration) DialOption {
 // returned by f, gRPC checks the error's Temporary() method to decide if it
 // should try to reconnect to the network address.
 //
-// Note: As of Go 1.21, the standard library overrides the OS defaults for
-// TCP keepalive time and interval to 15s.
-// To retain OS defaults, use a net.Dialer with the KeepAlive field set to a
-// negative value.
+// Note: As of Go 1.21, the standard library overrides the OS defaults for TCP
+// keepalive time and interval to 15s. To enable TCP keepalive with OS defaults
+// for keepalive time and interval, use a net.Dialer that sets the KeepAlive
+// field set to a negative value, and sets the SO_KEEPALIVE socket option to
+// true from the Control or ControlContext field. For a concrete example of how
+// to do this, see internal.NetDialerWithTCPKeepalive().
 //
 // For more information, please see [issue 23459] in the Go github repo.
 //

--- a/dialoptions.go
+++ b/dialoptions.go
@@ -405,8 +405,8 @@ func WithTimeout(d time.Duration) DialOption {
 // defaults for TCP keepalive time and interval to 15s. To enable TCP keepalive
 // with OS defaults for keepalive time and interval, use a net.Dialer that sets
 // the KeepAlive field to a negative value, and sets the SO_KEEPALIVE socket
-// option to true from the Control or ControlContext field. For a concrete
-// example of how to do this, see internal.NetDialerWithTCPKeepalive().
+// option to true from the Control field. For a concrete example of how to do
+// this, see internal.NetDialerWithTCPKeepalive().
 //
 // For more information, please see [issue 23459] in the Go github repo.
 //

--- a/internal/tcp_keepalive.go
+++ b/internal/tcp_keepalive.go
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2023 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package internal
+
+import (
+	"context"
+	"net"
+	"syscall"
+	"time"
+)
+
+// NetDialerWithTCPKeepalive returns a net.Dialer that enables TCP keepalives on
+// the underlying connection with OS default values for keepalive parameters.
+//
+// TODO: Once https://github.com/golang/go/issues/62254 lands, and the
+// appropriate Go version becomes less than our least supported Go version, we
+// should look into using the new API to make things more straightforward.
+func NetDialerWithTCPKeepalive() *net.Dialer {
+	return &net.Dialer{
+		// Setting a negative value here prevents the Go stdlib from overriding
+		// the values of TCP keepalive time and interval. It also prevents the
+		// Go stdlib from enabling TCP keepalives by default.
+		KeepAlive: time.Duration(-1),
+		// This method is called after the underlying network socket is created,
+		// but before dialing the socket (or calling its connect() method). The
+		// combination of unconditionally enabling TCP keepalives here, and
+		// disabling the overriding of TCP keepalive parameters by setting the
+		// KeepAlive field to a negative value above, results in OS defaults for
+		// the TCP keealive interval and time parameters.
+		ControlContext: func(_ context.Context, _, _ string, c syscall.RawConn) error {
+			return c.Control(func(fd uintptr) {
+				syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_KEEPALIVE, 1)
+			})
+		},
+	}
+}

--- a/internal/tcp_keepalive.go
+++ b/internal/tcp_keepalive.go
@@ -18,7 +18,6 @@
 package internal
 
 import (
-	"context"
 	"net"
 	"syscall"
 	"time"
@@ -42,7 +41,7 @@ func NetDialerWithTCPKeepalive() *net.Dialer {
 		// disabling the overriding of TCP keepalive parameters by setting the
 		// KeepAlive field to a negative value above, results in OS defaults for
 		// the TCP keealive interval and time parameters.
-		ControlContext: func(_ context.Context, _, _ string, c syscall.RawConn) error {
+		Control: func(_, _ string, c syscall.RawConn) error {
 			return c.Control(func(fd uintptr) {
 				syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_KEEPALIVE, 1)
 			})

--- a/internal/transport/proxy.go
+++ b/internal/transport/proxy.go
@@ -28,7 +28,8 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
-	"time"
+
+	"google.golang.org/grpc/internal"
 )
 
 const proxyAuthHeaderKey = "Proxy-Authorization"
@@ -113,7 +114,7 @@ func doHTTPConnectHandshake(ctx context.Context, conn net.Conn, backendAddr stri
 // proxyDial dials, connecting to a proxy first if necessary. Checks if a proxy
 // is necessary, dials, does the HTTP CONNECT handshake, and returns the
 // connection.
-func proxyDial(ctx context.Context, addr string, grpcUA string) (conn net.Conn, err error) {
+func proxyDial(ctx context.Context, addr string, grpcUA string) (net.Conn, error) {
 	newAddr := addr
 	proxyURL, err := mapAddress(addr)
 	if err != nil {
@@ -123,15 +124,15 @@ func proxyDial(ctx context.Context, addr string, grpcUA string) (conn net.Conn, 
 		newAddr = proxyURL.Host
 	}
 
-	conn, err = (&net.Dialer{KeepAlive: time.Duration(-1)}).DialContext(ctx, "tcp", newAddr)
+	conn, err := internal.NetDialerWithTCPKeepalive().DialContext(ctx, "tcp", newAddr)
 	if err != nil {
-		return
+		return nil, err
 	}
-	if proxyURL != nil {
+	if proxyURL == nil {
 		// proxy is disabled if proxyURL is nil.
-		conn, err = doHTTPConnectHandshake(ctx, conn, addr, proxyURL, grpcUA)
+		return conn, err
 	}
-	return
+	return doHTTPConnectHandshake(ctx, conn, addr, proxyURL, grpcUA)
 }
 
 func sendHTTPRequest(ctx context.Context, req *http.Request, conn net.Conn) error {

--- a/server.go
+++ b/server.go
@@ -813,6 +813,18 @@ func (l *listenSocket) Close() error {
 // Serve returns when lis.Accept fails with fatal errors.  lis will be closed when
 // this method returns.
 // Serve will return a non-nil error unless Stop or GracefulStop is called.
+//
+// Note: All supported releases of Go (as of December 2023) override the OS
+// defaults for TCP keepalive time and interval to 15s. To enable TCP keepalive
+// with OS defaults for keepalive time and interval, callers need to do the
+// following two things:
+//   - pass a net.Listener created by calling the Listen method on a
+//     net.ListenConfig with the `KeepAlive` field set to a negative value. This
+//     will result in the Go standard library not overriding OS defaults for TCP
+//     keepalive interval and time. But this will also result in the Go standard
+//     library not enabling TCP keepalives by default.
+//   - override the Accept method on the passed in net.Listener and set the
+//     SO_KEEPALIVE socket option to enable TCP keepalives, with OS defaults.
 func (s *Server) Serve(lis net.Listener) error {
 	s.mu.Lock()
 	s.printf("serving")

--- a/server.go
+++ b/server.go
@@ -813,15 +813,6 @@ func (l *listenSocket) Close() error {
 // Serve returns when lis.Accept fails with fatal errors.  lis will be closed when
 // this method returns.
 // Serve will return a non-nil error unless Stop or GracefulStop is called.
-//
-// Note: As of Go 1.21, the standard library overrides the OS defaults for
-// TCP keepalive time and interval to 15s.
-// To retain OS defaults, pass a net.Listener created by calling the Listen method
-// on a net.ListenConfig with the `KeepAlive` field set to a negative value.
-//
-// For more information, please see [issue 23459] in the Go github repo.
-//
-// [issue 23459]: https://github.com/golang/go/issues/23459
 func (s *Server) Serve(lis net.Listener) error {
 	s.mu.Lock()
 	s.printf("serving")


### PR DESCRIPTION
In https://github.com/grpc/grpc-go/pull/6672, we attempted to configure OS defaults for TCP keepalive parameters (keepalive time and interval). But this had the unintended consequence of disabling TCP keepalives completely because of the way things are implemented in the Go stdlib. In this PR, we attempt to do the following:

Summary of changes:
- Always enable TCP keepalives on client connections 
  - This has been the behavior for a while because the Go stdlib enables TCP keepalives as long as the `net.Dialer.KeepAlive` field is not set to a negative value. 
  - Explicitly setting the socket option ensures the old behavior persists.
- Use OS defaults for TCP keepalive interval and time
  - We do this by setting the `net.Dialer.KeepAlive` field to a negative value, thereby disabling the Go stdlib's override of these values to `15s`.
 
There will be a follow-up PR for the server side.

Addresses https://github.com/grpc/grpc-go/issues/6250

RELEASE NOTES:
- client: always enable TCP keepalives with OS defaults