### PR TITLE
internal: use OS defaults for TCP keepalive params only on unix

### DIFF
--- a/internal/tcp_keepalive_nonunix.go
+++ b/internal/tcp_keepalive_nonunix.go
@@ -1,0 +1,29 @@
+//go:build !unix
+
+/*
+ * Copyright 2023 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package internal
+
+import (
+	"net"
+)
+
+// NetDialerWithTCPKeepalive returns a vanilla net.Dialer on non-unix platforms.
+func NetDialerWithTCPKeepalive() *net.Dialer {
+	return &net.Dialer{}
+}

--- a/internal/tcp_keepalive_unix.go
+++ b/internal/tcp_keepalive_unix.go
@@ -1,3 +1,5 @@
+//go:build unix
+
 /*
  * Copyright 2023 gRPC authors.
  *
@@ -21,6 +23,8 @@ import (
 	"net"
 	"syscall"
 	"time"
+
+	"golang.org/x/sys/unix"
 )
 
 // NetDialerWithTCPKeepalive returns a net.Dialer that enables TCP keepalives on
@@ -43,7 +47,7 @@ func NetDialerWithTCPKeepalive() *net.Dialer {
 		// the TCP keealive interval and time parameters.
 		Control: func(_, _ string, c syscall.RawConn) error {
 			return c.Control(func(fd uintptr) {
-				syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_KEEPALIVE, 1)
+				unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_KEEPALIVE, 1)
 			})
 		},
 	}


### PR DESCRIPTION
In https://github.com/grpc/grpc-go/pull/6834, we made a change to ensure that OS defaults for TCP keepalive params are used. But, that change failed to compile on windows. This fix addresses it.

RELEASE NOTES: none