### PR TITLE
grpc: skip compression of empty messages

### DIFF
--- a/rpc_util.go
+++ b/rpc_util.go
@@ -640,12 +640,16 @@ func encode(c baseCodec, msg any) ([]byte, error) {
 	return b, nil
 }
 
-// compress returns the input bytes compressed by compressor or cp.  If both
-// compressors are nil, returns nil.
+// compress returns the input bytes compressed by compressor or cp.
+// If both compressors are nil, or if the message has zero length, returns nil,
+// indicating no compression was done.
 //
 // TODO(dfawley): eliminate cp parameter by wrapping Compressor in an encoding.Compressor.
 func compress(in []byte, cp Compressor, compressor encoding.Compressor) ([]byte, error) {
 	if compressor == nil && cp == nil {
+		return nil, nil
+	}
+	if len(in) == 0 {
 		return nil, nil
 	}
 	wrapErr := func(err error) error {


### PR DESCRIPTION
Fixes #6831.

This avoids compressing messages that are empty, since you can't compress zero bytes to anything smaller than zero bytes, and most compression algorithms output headers and trailers which means the resulting message will be non-zero bytes.

RELEASE NOTES:
- grpc: skip compression of empty messages (as an optimization)
