### PR TITLE
Apply max send size to un-compressed data

### DIFF
--- a/server.go
+++ b/server.go
@@ -1141,9 +1141,8 @@ func (s *Server) sendResponse(ctx context.Context, t transport.ServerTransport, 
 		return err
 	}
 	hdr, payload := msgHeader(data, compData)
-	// TODO(dfawley): should we be checking len(data) instead?
-	if len(payload) > s.opts.maxSendMessageSize {
-		return status.Errorf(codes.ResourceExhausted, "grpc: trying to send message larger than max (%d vs. %d)", len(payload), s.opts.maxSendMessageSize)
+	if len(data) > s.opts.maxSendMessageSize || len(payload) > s.opts.maxSendMessageSize {
+		return status.Errorf(codes.ResourceExhausted, "grpc: trying to send message larger than max (%d vs. %d)", len(data), s.opts.maxSendMessageSize)
 	}
 	err = t.Write(stream, hdr, payload, opts)
 	if err == nil {

--- a/stream.go
+++ b/stream.go
@@ -894,9 +894,8 @@ func (cs *clientStream) SendMsg(m any) (err error) {
 		return err
 	}
 
-	// TODO(dfawley): should we be checking len(data) instead?
-	if len(payload) > *cs.callInfo.maxSendMessageSize {
-		return status.Errorf(codes.ResourceExhausted, "trying to send message larger than max (%d vs. %d)", len(payload), *cs.callInfo.maxSendMessageSize)
+	if len(data) > *cs.callInfo.maxSendMessageSize || len(payload) > *cs.callInfo.maxSendMessageSize {
+		return status.Errorf(codes.ResourceExhausted, "trying to send message larger than max (%d vs. %d)", len(data), *cs.callInfo.maxSendMessageSize)
 	}
 	op := func(a *csAttempt) error {
 		return a.sendMsg(m, hdr, payload, data)
@@ -1371,14 +1370,13 @@ func (as *addrConnStream) SendMsg(m any) (err error) {
 	}
 
 	// load hdr, payload, data
-	hdr, payld, _, err := prepareMsg(m, as.codec, as.cp, as.comp)
+	hdr, payld, data, err := prepareMsg(m, as.codec, as.cp, as.comp)
 	if err != nil {
 		return err
 	}
 
-	// TODO(dfawley): should we be checking len(data) instead?
-	if len(payld) > *as.callInfo.maxSendMessageSize {
-		return status.Errorf(codes.ResourceExhausted, "trying to send message larger than max (%d vs. %d)", len(payld), *as.callInfo.maxSendMessageSize)
+	if len(data) > *as.callInfo.maxSendMessageSize || len(payld) > *as.callInfo.maxSendMessageSize {
+		return status.Errorf(codes.ResourceExhausted, "trying to send message larger than max (%d vs. %d)", len(data), *as.callInfo.maxSendMessageSize)
 	}
 
 	if err := as.t.Write(as.s, hdr, payld, &transport.Options{Last: !as.desc.ClientStreams}); err != nil {
@@ -1648,9 +1646,8 @@ func (ss *serverStream) SendMsg(m any) (err error) {
 		return err
 	}
 
-	// TODO(dfawley): should we be checking len(data) instead?
-	if len(payload) > ss.maxSendMessageSize {
-		return status.Errorf(codes.ResourceExhausted, "trying to send message larger than max (%d vs. %d)", len(payload), ss.maxSendMessageSize)
+	if len(data) > ss.maxSendMessageSize || len(payload) > ss.maxSendMessageSize {
+		return status.Errorf(codes.ResourceExhausted, "trying to send message larger than max (%d vs. %d)", len(data), ss.maxSendMessageSize)
 	}
 	if err := ss.t.Write(ss.s, hdr, payload, &transport.Options{Last: false}); err != nil {
 		return toRPCErr(err)


### PR DESCRIPTION
I noticed a number of TODO comments questioning whether max send size checking should be applied to message data prior to compression, or on the payload (ie, post compression).

I went and checked both the [Java](https://github.com/grpc/grpc-java/blob/3e3ba56838ddabb57a241718b568db61e11d92cc/core/src/main/java/io/grpc/internal/MessageFramer.java#L190) and the [C++](https://github.com/grpc/grpc/blob/42b57fc632cbbe9ad10ee8d65d5e8a7d1a30e248/src/core/ext/filters/message_size/message_size_filter.cc#L161C22-L161C29) implementations, and from my reading of the code, they both apply the length check to the uncompressed message data.

I also think logically, it makes sense to apply this to the uncompressed data, since the biggest reason I can think of to apply a check here is to ensure we don't send a message that is larger than the other end wants to buffer (we've already buffered it ourselves, so no reason to check for us). Receivers always apply the max receive size to the bytes being read out of the decompressor, for one, to protect against compression blowup vulnerabilities, but also because the purpose of the limit is to limit the number of bytes they are willing to buffer, so it wouldn't be correct to not apply it to the output of decompression. This ensures a fail fast on the sender side in such cases where the sender has been configured to mirror the clients max receive size, and makes it easier to debug on the sending side.

So, I've changed it to do the length check on the message data. I've also included the length check on the payload still, so both the compressed and uncompressed byte counts are checked. This is actually consistent with the receiver - receivers first check that the length of the message is less than their max receive size, before reading the message and again applying the message length check after decompression. It is possible, if the message contains data that doesn't compress well, that the resulting message could be larger than the compressed message, causing the the receiver to fail to receive a message whose compressed bytes exceed the limit but who's decompressed bytes don't.

However, from my reading, neither the Java nor the C++ code applies the same duplicate check to the compressed payload. I think they probably should, to mirror the receive checking. But happy to remove the additional check if you think it's unnecessary.