### PR TITLE
 Forbid dependabot from performing major version bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,6 @@ updates:
       github-actions:
         patterns:
           - "*"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
As requested in https://github.com/grpc/grpc-go/pull/6835#issuecomment-1846253818, this PR configures dependabot to ignore major version bumps, reducing the risk of breaking changes.

If you wish, I can instead configure dependabot to send separate PRs with major version bumps. This way, you can easily identify and merge the "easy" minor/patch bumps, but also be notified of major version bumps that may require a bit more attention.

RELEASE NOTES: none