### PR TITLE
support HTTPS_PROXY using tls conn

### DIFF
--- a/balancer/grpclb/grpclb_test.go
+++ b/balancer/grpclb/grpclb_test.go
@@ -20,6 +20,7 @@ package grpclb
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"io"
@@ -127,6 +128,9 @@ func (c *serverNameCheckCreds) Clone() credentials.TransportCredentials {
 	return &serverNameCheckCreds{}
 }
 func (c *serverNameCheckCreds) OverrideServerName(s string) error {
+	return nil
+}
+func (c *serverNameCheckCreds) TLSConfig() *tls.Config {
 	return nil
 }
 

--- a/credentials/alts/alts.go
+++ b/credentials/alts/alts.go
@@ -25,6 +25,7 @@ package alts
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"net"
@@ -286,6 +287,10 @@ func (g *altsTC) Clone() credentials.TransportCredentials {
 
 func (g *altsTC) OverrideServerName(serverNameOverride string) error {
 	g.info.ServerName = serverNameOverride
+	return nil
+}
+
+func (g *altsTC) TLSConfig() *tls.Config {
 	return nil
 }
 

--- a/credentials/credentials.go
+++ b/credentials/credentials.go
@@ -24,6 +24,7 @@ package credentials // import "google.golang.org/grpc/credentials"
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"net"
@@ -166,6 +167,9 @@ type TransportCredentials interface {
 	// Deprecated: use grpc.WithAuthority instead. Will be supported
 	// throughout 1.x.
 	OverrideServerName(string) error
+
+	// TLSConfig provides the tls Config of this TransportCredentials.
+	TLSConfig() *tls.Config
 }
 
 // Bundle is a combination of TransportCredentials and PerRPCCredentials.

--- a/credentials/google/xds.go
+++ b/credentials/google/xds.go
@@ -20,6 +20,7 @@ package google
 
 import (
 	"context"
+	"crypto/tls"
 	"net"
 	"net/url"
 	"strings"
@@ -125,4 +126,8 @@ func (c *clusterTransportCreds) OverrideServerName(s string) error {
 		return err
 	}
 	return c.alts.OverrideServerName(s)
+}
+
+func (c *clusterTransportCreds) TLSConfig() *tls.Config {
+	return c.tls.TLSConfig()
 }

--- a/credentials/insecure/insecure.go
+++ b/credentials/insecure/insecure.go
@@ -22,6 +22,7 @@ package insecure
 
 import (
 	"context"
+	"crypto/tls"
 	"net"
 
 	"google.golang.org/grpc/credentials"
@@ -57,6 +58,10 @@ func (insecureTC) Clone() credentials.TransportCredentials {
 }
 
 func (insecureTC) OverrideServerName(string) error {
+	return nil
+}
+
+func (insecureTC) TLSConfig() *tls.Config {
 	return nil
 }
 

--- a/credentials/local/local.go
+++ b/credentials/local/local.go
@@ -31,6 +31,7 @@ package local
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"net"
 	"strings"
@@ -108,5 +109,9 @@ func (c *localTC) Clone() credentials.TransportCredentials {
 // Since this feature is specific to TLS (SNI + hostname verification check), it does not take any effet for local credentials.
 func (c *localTC) OverrideServerName(serverNameOverride string) error {
 	c.info.ServerName = serverNameOverride
+	return nil
+}
+
+func (c *localTC) TLSConfig() *tls.Config {
 	return nil
 }

--- a/credentials/tls.go
+++ b/credentials/tls.go
@@ -153,6 +153,10 @@ func (c *tlsCreds) OverrideServerName(serverNameOverride string) error {
 	return nil
 }
 
+func (c *tlsCreds) TLSConfig() *tls.Config {
+	return c.config.Clone()
+}
+
 // The following cipher suites are forbidden for use with HTTP/2 by
 // https://datatracker.ietf.org/doc/html/rfc7540#appendix-A
 var tls12ForbiddenCipherSuites = map[uint16]struct{}{

--- a/credentials/xds/xds.go
+++ b/credentials/xds/xds.go
@@ -275,6 +275,10 @@ func (c *credsImpl) OverrideServerName(_ string) error {
 	return errors.New("serverName for peer validation must be configured as a list of acceptable SANs")
 }
 
+func (c *credsImpl) TLSConfig() *tls.Config {
+	return nil
+}
+
 // UsesXDS returns true if c uses xDS to fetch security configuration
 // used at handshake time, and false otherwise.
 func (c *credsImpl) UsesXDS() bool {

--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -150,7 +150,8 @@ type http2Client struct {
 	logger       *grpclog.PrefixLogger
 }
 
-func dial(ctx context.Context, fn func(context.Context, string) (net.Conn, error), addr resolver.Address, useProxy bool, grpcUA string) (net.Conn, error) {
+func dial(ctx context.Context, fn func(context.Context, string) (net.Conn, error), addr resolver.Address, useProxy bool,
+	grpcUA string, transportCreds credentials.TransportCredentials) (net.Conn, error) {
 	address := addr.Addr
 	networkType, ok := networktype.Get(addr)
 	if fn != nil {
@@ -175,7 +176,7 @@ func dial(ctx context.Context, fn func(context.Context, string) (net.Conn, error
 		networkType, address = parseDialTarget(address)
 	}
 	if networkType == "tcp" && useProxy {
-		return proxyDial(ctx, address, grpcUA)
+		return proxyDial(ctx, address, grpcUA, transportCreds)
 	}
 	return internal.NetDialerWithTCPKeepalive().DialContext(ctx, networkType, address)
 }
@@ -208,13 +209,25 @@ func newHTTP2Client(connectCtx, ctx context.Context, addr resolver.Address, opts
 		}
 	}()
 
+	transportCreds := opts.TransportCredentials
+	perRPCCreds := opts.PerRPCCredentials
+
+	if b := opts.CredsBundle; b != nil {
+		if t := b.TransportCredentials(); t != nil {
+			transportCreds = t
+		}
+		if t := b.PerRPCCredentials(); t != nil {
+			perRPCCreds = append(perRPCCreds, t)
+		}
+	}
+
 	// gRPC, resolver, balancer etc. can specify arbitrary data in the
 	// Attributes field of resolver.Address, which is shoved into connectCtx
 	// and passed to the dialer and credential handshaker. This makes it possible for
 	// address specific arbitrary data to reach custom dialers and credential handshakers.
 	connectCtx = icredentials.NewClientHandshakeInfoContext(connectCtx, credentials.ClientHandshakeInfo{Attributes: addr.Attributes})
 
-	conn, err := dial(connectCtx, opts.Dialer, addr, opts.UseProxy, opts.UserAgent)
+	conn, err := dial(connectCtx, opts.Dialer, addr, opts.UseProxy, opts.UserAgent, transportCreds)
 	if err != nil {
 		if opts.FailOnNonTempDialError {
 			return nil, connectionErrorf(isTemporary(err), err, "transport: error while dialing: %v", err)
@@ -272,17 +285,7 @@ func newHTTP2Client(connectCtx, ctx context.Context, addr resolver.Address, opts
 		isSecure bool
 		authInfo credentials.AuthInfo
 	)
-	transportCreds := opts.TransportCredentials
-	perRPCCreds := opts.PerRPCCredentials
 
-	if b := opts.CredsBundle; b != nil {
-		if t := b.TransportCredentials(); t != nil {
-			transportCreds = t
-		}
-		if t := b.PerRPCCredentials(); t != nil {
-			perRPCCreds = append(perRPCCreds, t)
-		}
-	}
 	if transportCreds != nil {
 		conn, authInfo, err = transportCreds.ClientHandshake(connectCtx, addr.ServerName, conn)
 		if err != nil {

--- a/internal/transport/proxy_test.go
+++ b/internal/transport/proxy_test.go
@@ -141,7 +141,7 @@ func testHTTPConnect(t *testing.T, proxyURLModify func(*url.URL) *url.URL, proxy
 	// Dial to proxy server.
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	c, err := proxyDial(ctx, blis.Addr().String(), "test")
+	c, err := proxyDial(ctx, blis.Addr().String(), "test", nil)
 	if err != nil {
 		t.Fatalf("http connect Dial failed: %v", err)
 	}

--- a/internal/transport/transport_test.go
+++ b/internal/transport/transport_test.go
@@ -21,6 +21,7 @@ package transport
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -1150,7 +1151,7 @@ func (s) TestServerConnDecoupledFromApplicationRead(t *testing.T) {
 	if err := client.Write(cstream1, nil, make([]byte, defaultWindowSize), &Options{Last: true}); err != nil {
 		t.Fatalf("Client failed to write data. Err: %v", err)
 	}
-	//Client should be able to create another stream and send data on it.
+	// Client should be able to create another stream and send data on it.
 	cstream2, err := client.NewStream(ctx, &CallHdr{})
 	if err != nil {
 		t.Fatalf("Failed to create 2nd stream. Err: %v", err)
@@ -2331,6 +2332,9 @@ func (ac *attrTransportCreds) Info() credentials.ProtocolInfo {
 	return credentials.ProtocolInfo{}
 }
 func (ac *attrTransportCreds) Clone() credentials.TransportCredentials {
+	return nil
+}
+func (ac *attrTransportCreds) TLSConfig() *tls.Config {
 	return nil
 }
 

--- a/security/advancedtls/advancedtls.go
+++ b/security/advancedtls/advancedtls.go
@@ -114,7 +114,7 @@ func (o RootCertificateOptions) nonNilFieldCount() int {
 // At most one option could be set.
 type IdentityCertificateOptions struct {
 	// If Certificates is set, it will be used every time when needed to present
-	//identity certificates, without performing identity certificate reloading.
+	// identity certificates, without performing identity certificate reloading.
 	Certificates []tls.Certificate
 	// If GetIdentityCertificatesForClient is set, it will be invoked to obtain
 	// identity certs for every new connection.
@@ -470,6 +470,13 @@ func (c *advancedTLSCreds) Clone() credentials.TransportCredentials {
 
 func (c *advancedTLSCreds) OverrideServerName(serverNameOverride string) error {
 	c.config.ServerName = serverNameOverride
+	return nil
+}
+
+func (c *advancedTLSCreds) TLSConfig() *tls.Config {
+	if c.config != nil {
+		return c.config.Clone()
+	}
 	return nil
 }
 

--- a/test/balancer_test.go
+++ b/test/balancer_test.go
@@ -20,6 +20,7 @@ package test
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"net"
@@ -367,6 +368,9 @@ func (ac *attrTransportCreds) Info() credentials.ProtocolInfo {
 	return credentials.ProtocolInfo{}
 }
 func (ac *attrTransportCreds) Clone() credentials.TransportCredentials {
+	return nil
+}
+func (ac *attrTransportCreds) TLSConfig() *tls.Config {
 	return nil
 }
 

--- a/test/creds_test.go
+++ b/test/creds_test.go
@@ -20,6 +20,7 @@ package test
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"net"
@@ -227,6 +228,9 @@ func (c clientAlwaysFailCred) Info() credentials.ProtocolInfo {
 func (c clientAlwaysFailCred) Clone() credentials.TransportCredentials {
 	return nil
 }
+func (c *clientAlwaysFailCred) TLSConfig() *tls.Config {
+	return nil
+}
 
 func (s) TestFailFastRPCErrorOnBadCertificates(t *testing.T) {
 	te := newTest(t, env{name: "bad-cred", network: "tcp", security: "empty", balancer: "round_robin"})
@@ -421,6 +425,9 @@ func (c *authorityCheckCreds) Info() credentials.ProtocolInfo {
 }
 func (c *authorityCheckCreds) Clone() credentials.TransportCredentials {
 	return c
+}
+func (c *authorityCheckCreds) TLSConfig() *tls.Config {
+	return nil
 }
 
 // This test makes sure that the authority client handshake gets is the endpoint

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -4178,6 +4178,9 @@ func (c *clientFailCreds) Clone() credentials.TransportCredentials {
 func (c *clientFailCreds) OverrideServerName(s string) error {
 	return nil
 }
+func (c *clientFailCreds) TLSConfig() *tls.Config {
+	return nil
+}
 
 // This test makes sure that failfast RPCs fail if client handshake fails with
 // fatal errors.

--- a/test/transport_test.go
+++ b/test/transport_test.go
@@ -19,6 +19,7 @@ package test
 
 import (
 	"context"
+	"crypto/tls"
 	"io"
 	"net"
 	"sync"
@@ -72,6 +73,9 @@ func (c *transportRestartCheckCreds) Clone() credentials.TransportCredentials {
 	return c
 }
 func (c *transportRestartCheckCreds) OverrideServerName(s string) error {
+	return nil
+}
+func (c *transportRestartCheckCreds) TLSConfig() *tls.Config {
 	return nil
 }
 


### PR DESCRIPTION
I found grcp-go only support HTTP_PROXY proxy,  does not support HTTPS_PROXY proxy. 
See more detail in this issue https://github.com/grpc/grpc-go/issues/6846.

So create this PR and try to support HTTPS_PROXY.
