### PR TITLE
interop/xds: Increase go log verbosity to 99 so that EDS is logged (v1.56.x backport)

### DIFF
--- a/interop/xds/client/Dockerfile
+++ b/interop/xds/client/Dockerfile
@@ -31,7 +31,7 @@ RUN go build -tags osusergo,netgo interop/xds/client/client.go
 # reduces the docker image size.
 FROM alpine
 COPY --from=build /go/src/grpc-go/client .
-ENV GRPC_GO_LOG_VERBOSITY_LEVEL=2
+ENV GRPC_GO_LOG_VERBOSITY_LEVEL=99
 ENV GRPC_GO_LOG_SEVERITY_LEVEL="info"
 ENV GRPC_GO_LOG_FORMATTER="json"
 ENTRYPOINT ["./client"]

--- a/interop/xds/server/Dockerfile
+++ b/interop/xds/server/Dockerfile
@@ -31,7 +31,7 @@ RUN go build -tags osusergo,netgo interop/xds/server/server.go
 # reduces the docker image size.
 FROM alpine
 COPY --from=build /go/src/grpc-go/server .
-ENV GRPC_GO_LOG_VERBOSITY_LEVEL=2
+ENV GRPC_GO_LOG_VERBOSITY_LEVEL=99
 ENV GRPC_GO_LOG_SEVERITY_LEVEL="info"
 ENV GRPC_GO_LOG_FORMATTER="json"
 ENTRYPOINT ["./server"]


### PR DESCRIPTION
Backport of #6860 to v1.56.x.
---
gRPC-go versions v1.54.x and later don't log ADS responses anymore. This makes it hard to debug without being able to see EDS resources. Logging behavior was changed by https://github.com/grpc/grpc-go/pull/5992.

This PR updates XdsTestServer/XdsTestClient Docker images so that GRPC_GO_LOG_VERBOSITY_LEVEL is increased from `2` to `99`.

RELEASE NOTES: N/A