### PR TITLE
removing deprecated http closenotifier function

### DIFF
--- a/internal/transport/handler_server_test.go
+++ b/internal/transport/handler_server_test.go
@@ -227,7 +227,7 @@ type testHandlerResponseWriter struct {
 	*httptest.ResponseRecorder
 }
 
-func (w testHandlerResponseWriter) Flush()                   {}
+func (w testHandlerResponseWriter) Flush() {}
 
 func newTestHandlerResponseWriter() http.ResponseWriter {
 	return testHandlerResponseWriter{

--- a/internal/transport/handler_server_test.go
+++ b/internal/transport/handler_server_test.go
@@ -93,7 +93,6 @@ func (s) TestHandlerTransport_NewServerHandlerTransport(t *testing.T) {
 				// Return w without its Flush method
 				type onlyCloseNotifier interface {
 					http.ResponseWriter
-					http.CloseNotifier
 				}
 				return struct{ onlyCloseNotifier }{w.(onlyCloseNotifier)}
 			},
@@ -196,7 +195,6 @@ func (s) TestHandlerTransport_NewServerHandlerTransport(t *testing.T) {
 		rrec := httptest.NewRecorder()
 		rw := http.ResponseWriter(testHandlerResponseWriter{
 			ResponseRecorder: rrec,
-			closeNotify:      make(chan bool, 1),
 		})
 
 		if tt.modrw != nil {
@@ -227,16 +225,13 @@ func (s) TestHandlerTransport_NewServerHandlerTransport(t *testing.T) {
 
 type testHandlerResponseWriter struct {
 	*httptest.ResponseRecorder
-	closeNotify chan bool
 }
 
-func (w testHandlerResponseWriter) CloseNotify() <-chan bool { return w.closeNotify }
 func (w testHandlerResponseWriter) Flush()                   {}
 
 func newTestHandlerResponseWriter() http.ResponseWriter {
 	return testHandlerResponseWriter{
 		ResponseRecorder: httptest.NewRecorder(),
-		closeNotify:      make(chan bool, 1),
 	}
 }
 


### PR DESCRIPTION
Regarding this little issue with deprecated function http.CloseNotify, 
https://github.com/grpc/grpc-go/issues/6782

I have decided to add just small pr for http.CloseNotify deprecated 

In this pull request, I have just removed the implementation, tests are going well, 

my other approach was this: 

to add and update `onlyCloseNotifier` interface, by doing this: 

```
type onlyContext {
  http.ResponseWriter
  context.Context
}
```
then to update whole `testHandlerResponseWriter` with corresponding context.Context methods, like these: 
```
type testHandlerResponseWriter struct {
    *httptest.ResponseRecorder
    done chan struct{}
    err error
    value any
    deadline time.Time
    ok bool
}

func (w testHandlerResponseWriter) Deadline() (deadline time.Time, ok bool) {return time.Time{}, false}
func (w testHandlerResponseWriter) Done() <-chan struct{}                              { return w.Result().Request.Context().Done() }
func (w testHandlerResponseWriter) Err() error                                                    {return nil}
func (w testHandlerResponseWriter) Value(key any) any                                     { return nil}

testHandlerResponseWriter{
        ResponseRecorder: httptest.NewRecorder(),
        done: make(chan struct{}, 1),
        err: nil,
        value: nil,
        deadline: time.Time{},
        ok: true,
}
```

But I suppose non of this is required ? 

RELEASE NOTES: none