### PR TITLE
removing Roots deprecated Subjects field in tests

### DIFF
--- a/credentials/tls/certprovider/pemfile/watcher_test.go
+++ b/credentials/tls/certprovider/pemfile/watcher_test.go
@@ -61,12 +61,6 @@ func compareKeyMaterial(got, want *certprovider.KeyMaterial) error {
 		}
 	}
 
-	// x509.CertPool contains only unexported fields some of which contain other
-	// unexported fields. So usage of cmp.AllowUnexported() or
-	// cmpopts.IgnoreUnexported() does not help us much here. Also, the standard
-	// library does not provide a way to compare CertPool values. Comparing the
-	// subjects field of the certs in the CertPool seems like a reasonable
-	// approach.
 	if gotR, wantR := got.Roots, want.Roots; !gotR.Equal(wantR) {
 		return fmt.Errorf("keyMaterial roots = %v, want %v", gotR, wantR)
 	}

--- a/credentials/tls/certprovider/pemfile/watcher_test.go
+++ b/credentials/tls/certprovider/pemfile/watcher_test.go
@@ -64,7 +64,7 @@ func compareKeyMaterial(got, want *certprovider.KeyMaterial) error {
 	if gotR, wantR := got.Roots, want.Roots; !gotR.Equal(wantR) {
 		return fmt.Errorf("keyMaterial roots = %v, want %v", gotR, wantR)
 	}
-	
+
 	return nil
 }
 

--- a/credentials/tls/certprovider/pemfile/watcher_test.go
+++ b/credentials/tls/certprovider/pemfile/watcher_test.go
@@ -64,6 +64,7 @@ func compareKeyMaterial(got, want *certprovider.KeyMaterial) error {
 	if gotR, wantR := got.Roots, want.Roots; !gotR.Equal(wantR) {
 		return fmt.Errorf("keyMaterial roots = %v, want %v", gotR, wantR)
 	}
+	
 	return nil
 }
 

--- a/credentials/tls/certprovider/pemfile/watcher_test.go
+++ b/credentials/tls/certprovider/pemfile/watcher_test.go
@@ -26,8 +26,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"google.golang.org/grpc/credentials/tls/certprovider"
 	"google.golang.org/grpc/internal/grpctest"
 	"google.golang.org/grpc/internal/testutils"
@@ -69,7 +67,7 @@ func compareKeyMaterial(got, want *certprovider.KeyMaterial) error {
 	// library does not provide a way to compare CertPool values. Comparing the
 	// subjects field of the certs in the CertPool seems like a reasonable
 	// approach.
-	if gotR, wantR := got.Roots.Subjects(), want.Roots.Subjects(); !cmp.Equal(gotR, wantR, cmpopts.EquateEmpty()) {
+	if gotR, wantR := got.Roots, want.Roots; !gotR.Equal(wantR) {
 		return fmt.Errorf("keyMaterial roots = %v, want %v", gotR, wantR)
 	}
 	return nil

--- a/credentials/tls/certprovider/store_test.go
+++ b/credentials/tls/certprovider/store_test.go
@@ -163,6 +163,7 @@ func compareKeyMaterial(got, want *KeyMaterial) error {
 	if gotR, wantR := got.Roots, want.Roots; !gotR.Equal(wantR) {
 		return fmt.Errorf("keyMaterial roots = %v, want %v", gotR, wantR)
 	}
+	
 	return nil
 }
 

--- a/credentials/tls/certprovider/store_test.go
+++ b/credentials/tls/certprovider/store_test.go
@@ -160,12 +160,6 @@ func compareKeyMaterial(got, want *KeyMaterial) error {
 		}
 	}
 
-	// x509.CertPool contains only unexported fields some of which contain other
-	// unexported fields. So usage of cmp.AllowUnexported() or
-	// cmpopts.IgnoreUnexported() does not help us much here. Also, the standard
-	// library does not provide a way to compare CertPool values. Comparing the
-	// subjects field of the certs in the CertPool seems like a reasonable
-	// approach.
 	if gotR, wantR := got.Roots, want.Roots; !gotR.Equal(wantR) {
 		return fmt.Errorf("keyMaterial roots = %v, want %v", gotR, wantR)
 	}

--- a/credentials/tls/certprovider/store_test.go
+++ b/credentials/tls/certprovider/store_test.go
@@ -163,7 +163,7 @@ func compareKeyMaterial(got, want *KeyMaterial) error {
 	if gotR, wantR := got.Roots, want.Roots; !gotR.Equal(wantR) {
 		return fmt.Errorf("keyMaterial roots = %v, want %v", gotR, wantR)
 	}
-	
+
 	return nil
 }
 

--- a/credentials/tls/certprovider/store_test.go
+++ b/credentials/tls/certprovider/store_test.go
@@ -28,8 +28,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"google.golang.org/grpc/internal/grpctest"
 	"google.golang.org/grpc/internal/testutils"
 	"google.golang.org/grpc/testdata"
@@ -168,7 +166,7 @@ func compareKeyMaterial(got, want *KeyMaterial) error {
 	// library does not provide a way to compare CertPool values. Comparing the
 	// subjects field of the certs in the CertPool seems like a reasonable
 	// approach.
-	if gotR, wantR := got.Roots.Subjects(), want.Roots.Subjects(); !cmp.Equal(gotR, wantR, cmpopts.EquateEmpty()) {
+	if gotR, wantR := got.Roots, want.Roots; !gotR.Equal(wantR) {
 		return fmt.Errorf("keyMaterial roots = %v, want %v", gotR, wantR)
 	}
 	return nil

--- a/vet.sh
+++ b/vet.sh
@@ -185,8 +185,6 @@ GetSafeRegexMatch
 GetSuffixMatch
 GetTlsCertificateCertificateProviderInstance
 GetValidationContextCertificateProviderInstance
-XXXXX TODO: Remove the below deprecation usages:
-Roots.Subjects
 XXXXX PleaseIgnoreUnused'
 
 echo SUCCESS


### PR DESCRIPTION
Regarding this issue, https://github.com/grpc/grpc-go/issues/6782

one of the goals was to remove usage of deprecated field `Subjects`, which is not being returned by `SystemCertPool` anymore, more details here https://pkg.go.dev/crypto/x509#CertPool.Subjects
also I have updated these tests so we compare got and wanted CertPool structs, by using https://pkg.go.dev/crypto/x509#CertPool.Equal

RELEASE NOTES: none