### PR TITLE
vet: remove ignore of CloseNotifier

### DIFF
--- a/binarylog/grpc_binarylog_v1/binarylog.pb.go
+++ b/binarylog/grpc_binarylog_v1/binarylog.pb.go
@@ -430,7 +430,7 @@ type ClientHeader struct {
 	MethodName string `protobuf:"bytes,2,opt,name=method_name,json=methodName,proto3" json:"method_name,omitempty"`
 	// A single process may be used to run multiple virtual
 	// servers with different identities.
-	// The authority is the name of such a server identitiy.
+	// The authority is the name of such a server identity.
 	// It is typically a portion of the URI in the form of
 	// <host> or <host>:<port> .
 	Authority string `protobuf:"bytes,3,opt,name=authority,proto3" json:"authority,omitempty"`

--- a/binarylog/grpc_binarylog_v1/binarylog.pb.go
+++ b/binarylog/grpc_binarylog_v1/binarylog.pb.go
@@ -430,7 +430,7 @@ type ClientHeader struct {
 	MethodName string `protobuf:"bytes,2,opt,name=method_name,json=methodName,proto3" json:"method_name,omitempty"`
 	// A single process may be used to run multiple virtual
 	// servers with different identities.
-	// The authority is the name of such a server identity.
+	// The authority is the name of such a server identitiy.
 	// It is typically a portion of the URI in the form of
 	// <host> or <host>:<port> .
 	Authority string `protobuf:"bytes,3,opt,name=authority,proto3" json:"authority,omitempty"`

--- a/vet.sh
+++ b/vet.sh
@@ -186,7 +186,6 @@ GetSuffixMatch
 GetTlsCertificateCertificateProviderInstance
 GetValidationContextCertificateProviderInstance
 XXXXX TODO: Remove the below deprecation usages:
-CloseNotifier
 Roots.Subjects
 XXXXX PleaseIgnoreUnused'
 


### PR DESCRIPTION
## Changes: 
- #6886 removed the usage of the deprecated function. However we need to remove the ignore of the usage from vet.sh as well. 


RELEASE NOTES: none