### PR TITLE
DNS resolving with timeout

### DIFF
--- a/internal/resolver/dns/dns_resolver.go
+++ b/internal/resolver/dns/dns_resolver.go
@@ -45,6 +45,13 @@ import (
 // addresses from SRV records.  Must not be changed after init time.
 var EnableSRVLookups = false
 
+// ResolvingTimeout specifies the maximum duration for a DNS resolution request.
+// If the timeout expires before a response is received, the request will be canceled.
+//
+// It is recommended to set this value at application startup. Avoid modifying this variable
+// after initialization as it's not thread-safe for concurrent modification.
+var ResolvingTimeout = 10 * time.Second
+
 var logger = grpclog.Component("dns")
 
 func init() {
@@ -100,7 +107,9 @@ type dnsBuilder struct{}
 
 // Build creates and starts a DNS resolver that watches the name resolution of
 // the target.
-func (b *dnsBuilder) Build(target resolver.Target, cc resolver.ClientConn, opts resolver.BuildOptions) (resolver.Resolver, error) {
+func (b *dnsBuilder) Build(target resolver.Target, cc resolver.ClientConn, opts resolver.BuildOptions) (
+	resolver.Resolver, error,
+) {
 	host, port, err := parseTarget(target.Endpoint(), defaultPort)
 	if err != nil {
 		return nil, err
@@ -221,18 +230,18 @@ func (d *dnsResolver) watcher() {
 	}
 }
 
-func (d *dnsResolver) lookupSRV() ([]resolver.Address, error) {
+func (d *dnsResolver) lookupSRV(ctx context.Context) ([]resolver.Address, error) {
 	if !EnableSRVLookups {
 		return nil, nil
 	}
 	var newAddrs []resolver.Address
-	_, srvs, err := d.resolver.LookupSRV(d.ctx, "grpclb", "tcp", d.host)
+	_, srvs, err := d.resolver.LookupSRV(ctx, "grpclb", "tcp", d.host)
 	if err != nil {
 		err = handleDNSError(err, "SRV") // may become nil
 		return nil, err
 	}
 	for _, s := range srvs {
-		lbAddrs, err := d.resolver.LookupHost(d.ctx, s.Target)
+		lbAddrs, err := d.resolver.LookupHost(ctx, s.Target)
 		if err != nil {
 			err = handleDNSError(err, "A") // may become nil
 			if err == nil {
@@ -269,8 +278,8 @@ func handleDNSError(err error, lookupType string) error {
 	return err
 }
 
-func (d *dnsResolver) lookupTXT() *serviceconfig.ParseResult {
-	ss, err := d.resolver.LookupTXT(d.ctx, txtPrefix+d.host)
+func (d *dnsResolver) lookupTXT(ctx context.Context) *serviceconfig.ParseResult {
+	ss, err := d.resolver.LookupTXT(ctx, txtPrefix+d.host)
 	if err != nil {
 		if envconfig.TXTErrIgnore {
 			return nil
@@ -297,8 +306,8 @@ func (d *dnsResolver) lookupTXT() *serviceconfig.ParseResult {
 	return d.cc.ParseServiceConfig(sc)
 }
 
-func (d *dnsResolver) lookupHost() ([]resolver.Address, error) {
-	addrs, err := d.resolver.LookupHost(d.ctx, d.host)
+func (d *dnsResolver) lookupHost(ctx context.Context) ([]resolver.Address, error) {
+	addrs, err := d.resolver.LookupHost(ctx, d.host)
 	if err != nil {
 		err = handleDNSError(err, "A")
 		return nil, err
@@ -316,8 +325,12 @@ func (d *dnsResolver) lookupHost() ([]resolver.Address, error) {
 }
 
 func (d *dnsResolver) lookup() (*resolver.State, error) {
-	srv, srvErr := d.lookupSRV()
-	addrs, hostErr := d.lookupHost()
+	ctxSRV, cancelSRV := context.WithTimeout(d.ctx, ResolvingTimeout)
+	defer cancelSRV()
+	srv, srvErr := d.lookupSRV(ctxSRV)
+	ctxHost, cancelHost := context.WithTimeout(d.ctx, ResolvingTimeout)
+	defer cancelHost()
+	addrs, hostErr := d.lookupHost(ctxHost)
 	if hostErr != nil && (srvErr != nil || len(srv) == 0) {
 		return nil, hostErr
 	}
@@ -327,7 +340,9 @@ func (d *dnsResolver) lookup() (*resolver.State, error) {
 		state = grpclbstate.Set(state, &grpclbstate.State{BalancerAddresses: srv})
 	}
 	if !d.disableServiceConfig {
-		state.ServiceConfig = d.lookupTXT()
+		ctxTXT, cancelTXT := context.WithTimeout(d.ctx, ResolvingTimeout)
+		defer cancelTXT()
+		state.ServiceConfig = d.lookupTXT(ctxTXT)
 	}
 	return &state, nil
 }

--- a/internal/resolver/dns/dns_resolver.go
+++ b/internal/resolver/dns/dns_resolver.go
@@ -50,7 +50,7 @@ var EnableSRVLookups = false
 //
 // It is recommended to set this value at application startup. Avoid modifying this variable
 // after initialization as it's not thread-safe for concurrent modification.
-var ResolvingTimeout = 10 * time.Second
+var ResolvingTimeout = 30 * time.Second
 
 var logger = grpclog.Component("dns")
 

--- a/internal/resolver/dns/dns_resolver_test.go
+++ b/internal/resolver/dns/dns_resolver_test.go
@@ -1219,6 +1219,8 @@ func (s) TestReportError(t *testing.T) {
 
 // Override the default dns.ResolvingTimeout with a test duration.
 func overrideResolveTimeoutDuration(t *testing.T, dur time.Duration) {
+	t.Helper()
+
 	origDur := dns.ResolvingTimeout
 	dnspublic.SetResolvingTimeout(dur)
 
@@ -1232,7 +1234,6 @@ func (s) TestResolveTimeout(t *testing.T) {
 	timeoutDur := 7 * time.Millisecond
 	overrideResolveTimeoutDuration(t, timeoutDur)
 
-	// context with a bit larger
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
 
@@ -1253,7 +1254,7 @@ func (s) TestResolveTimeout(t *testing.T) {
 		t.Fatal("Timeout when waiting for the DNS resolver to timeout")
 	case err := <-errCh:
 		if err == nil || !strings.Contains(err.Error(), "context deadline exceeded") {
-			t.Fatalf(`We expect to see timed out error`)
+			t.Fatalf(`Expected to see Timeout error; got: %v`, err)
 		}
 	}
 }

--- a/internal/resolver/dns/dns_resolver_test.go
+++ b/internal/resolver/dns/dns_resolver_test.go
@@ -1225,7 +1225,7 @@ func overrideResolveTimeoutDuration(t *testing.T, dur time.Duration) {
 	t.Cleanup(func() { dnspublic.SetResolvingTimeout(origDur) })
 }
 
-// Test verifies that when the DNS resolver gets timeout error when net.Resolver
+// Test verifies that the DNS resolver gets timeout error when net.Resolver
 // takes too long to resolve a target.
 func (s) TestResolveTimeout(t *testing.T) {
 	// Set DNS resolving timeout duration to 7ms
@@ -1242,13 +1242,11 @@ func (s) TestResolveTimeout(t *testing.T) {
 	// Define a testNetResolver with lookupHostCh, an unbuffered channel,
 	// so we can block the resolver until reaching timeout.
 	tr := &testNetResolver{
-		lookupHostCh:    testutils.NewChannel(),
+		lookupHostCh:    testutils.NewChannelWithSize(0),
 		hostLookupTable: map[string][]string{target: {"1.2.3.4"}},
 	}
 	overrideNetResolver(t, tr)
 
-	// block testNetResolver.testNetResolver until timeout
-	_ = tr.lookupHostCh.SendContext(ctx, nil)
 	_, _, errCh := buildResolverWithTestClientConn(t, target)
 	select {
 	case <-ctx.Done():

--- a/internal/resolver/dns/fake_net_resolver_test.go
+++ b/internal/resolver/dns/fake_net_resolver_test.go
@@ -42,12 +42,7 @@ type testNetResolver struct {
 func (tr *testNetResolver) LookupHost(ctx context.Context, host string) ([]string, error) {
 	if tr.lookupHostCh != nil {
 		if err := tr.lookupHostCh.SendContext(ctx, nil); nil != err {
-			return nil, &net.DNSError{
-				Err:         "hostLookup timeout",
-				Name:        host,
-				Server:      "fake",
-				IsTemporary: true,
-			}
+			return nil, err
 		}
 	}
 

--- a/internal/resolver/dns/fake_net_resolver_test.go
+++ b/internal/resolver/dns/fake_net_resolver_test.go
@@ -41,7 +41,7 @@ type testNetResolver struct {
 
 func (tr *testNetResolver) LookupHost(ctx context.Context, host string) ([]string, error) {
 	if tr.lookupHostCh != nil {
-		if err := tr.lookupHostCh.SendContext(ctx, nil); nil != err {
+		if err := tr.lookupHostCh.SendContext(ctx, nil); err != nil {
 			return nil, err
 		}
 	}

--- a/resolver/dns/dns_resolver.go
+++ b/resolver/dns/dns_resolver.go
@@ -37,7 +37,7 @@ import (
 // It must be called only at application startup, before any gRPC calls are made.
 // Modifying this value after initialization is not thread-safe.
 //
-// The default value is 10 seconds. Setting the timeout too low may result
+// The default value is 30 seconds. Setting the timeout too low may result
 // in premature timeouts during resolution, while setting it too high may
 // lead to unnecessary delays in service discovery. Choose a value appropriate
 // for your specific needs and network environment.

--- a/resolver/dns/dns_resolver.go
+++ b/resolver/dns/dns_resolver.go
@@ -34,7 +34,7 @@ import (
 //
 // This function affects the global timeout used by all channels using the DNS name resolver scheme.
 //
-// It must be called only at application startup, before any  gRPC calls are made.
+// It must be called only at application startup, before any gRPC calls are made.
 // Modifying this value after initialization is not thread-safe.
 //
 // The default value is 10 seconds. Setting the timeout too low may result

--- a/resolver/dns/dns_resolver.go
+++ b/resolver/dns/dns_resolver.go
@@ -32,15 +32,16 @@ import (
 
 // SetResolvingTimeout sets the maximum duration for DNS resolution requests.
 //
-// This function affects the global timeout used by all channels using the DNS name resolver scheme.
+// This function affects the global timeout used by all channels using the DNS
+// name resolver scheme.
 //
-// It must be called only at application startup, before any gRPC calls are made.
-// Modifying this value after initialization is not thread-safe.
+// It must be called only at application startup, before any gRPC calls are
+// made. Modifying this value after initialization is not thread-safe.
 //
-// The default value is 30 seconds. Setting the timeout too low may result
-// in premature timeouts during resolution, while setting it too high may
-// lead to unnecessary delays in service discovery. Choose a value appropriate
-// for your specific needs and network environment.
+// The default value is 30 seconds. Setting the timeout too low may result in
+// premature timeouts during resolution, while setting it too high may lead to
+// unnecessary delays in service discovery. Choose a value appropriate for your
+// specific needs and network environment.
 func SetResolvingTimeout(timeout time.Duration) {
 	dns.ResolvingTimeout = timeout
 }

--- a/resolver/dns/dns_resolver.go
+++ b/resolver/dns/dns_resolver.go
@@ -32,12 +32,10 @@ import (
 
 // SetResolvingTimeout sets the maximum duration for DNS resolution requests.
 //
-// This function updates the global `ResolvingTimeout` variable, which specifies
-// how long a DNS resolution attempt will wait before it is canceled.
+// This function affects the global timeout used by all channels using the DNS name resolver scheme.
 //
-// It is recommended to call this function at application startup, before any
-// gRPC calls are made. Modifying this value after initialization is not
-// thread-safe.
+// It must be called only at application startup, before any  gRPC calls are made.
+// Modifying this value after initialization is not thread-safe.
 //
 // The default value is 10 seconds. Setting the timeout too low may result
 // in premature timeouts during resolution, while setting it too high may

--- a/resolver/dns/dns_resolver.go
+++ b/resolver/dns/dns_resolver.go
@@ -24,9 +24,28 @@
 package dns
 
 import (
+	"time"
+
 	"google.golang.org/grpc/internal/resolver/dns"
 	"google.golang.org/grpc/resolver"
 )
+
+// SetResolvingTimeout sets the maximum duration for DNS resolution requests.
+//
+// This function updates the global `ResolvingTimeout` variable, which specifies
+// how long a DNS resolution attempt will wait before it is canceled.
+//
+// It is recommended to call this function at application startup, before any
+// gRPC calls are made. Modifying this value after initialization is not
+// thread-safe.
+//
+// The default value is 10 seconds. Setting the timeout too low may result
+// in premature timeouts during resolution, while setting it too high may
+// lead to unnecessary delays in service discovery. Choose a value appropriate
+// for your specific needs and network environment.
+func SetResolvingTimeout(timeout time.Duration) {
+	dns.ResolvingTimeout = timeout
+}
 
 // NewBuilder creates a dnsBuilder which is used to factory DNS resolvers.
 //


### PR DESCRIPTION
Currently, the DNS resolver does not have a timeout mechanism for DNS resolution. In some edge cases, where the DNS server is slow to respond, this can lead to stale records being used, resulting in failed connections or other issues.

This pull request adds a configurable timeout for DNS resolution, which can be set by the user to a value that suits their needs. The default value is set to 5 seconds, which should be sufficient for most cases. If the DNS server does not respond within the specified time, the resolver will cancel the request and move on to the next available server.

Please review and let me know if you have any questions or concerns.

Thanks!

RELEASE NOTES:
* resolver/dns: add SetResolvingTimeout to allow configuring the DNS resolver's timeout globally.