### PR TITLE
grpc: Canonicalize string returned by ClientConn.Target() and resolver.Address.String()

### DIFF
--- a/clientconn.go
+++ b/clientconn.go
@@ -883,14 +883,14 @@ func (cc *ClientConn) channelzMetric() *channelz.ChannelInternalMetric {
 	}
 }
 
-// Target returns the target string of the ClientConn.
+// Target returns the canonicalized target string of the ClientConn.
 //
 // # Experimental
 //
 // Notice: This API is EXPERIMENTAL and may be changed or removed in a
 // later release.
 func (cc *ClientConn) Target() string {
-	return cc.target
+	return cc.parsedTarget.String()
 }
 
 func (cc *ClientConn) incrCallsStarted() {
@@ -1744,7 +1744,6 @@ func (cc *ClientConn) parseTargetAndFindResolver() error {
 	defScheme := resolver.GetDefaultScheme()
 	channelz.Infof(logger, cc.channelzID, "fallback to scheme %q", defScheme)
 	canonicalTarget := defScheme + ":///" + cc.target
-
 	parsedTarget, err = parseTarget(canonicalTarget)
 	if err != nil {
 		channelz.Infof(logger, cc.channelzID, "dial target %q parse failed: %v", canonicalTarget, err)

--- a/clientconn.go
+++ b/clientconn.go
@@ -883,7 +883,7 @@ func (cc *ClientConn) channelzMetric() *channelz.ChannelInternalMetric {
 	}
 }
 
-// Target returns the canonicalized target string of the ClientConn.
+// Target returns the canonical target string of the ClientConn.
 //
 // # Experimental
 //

--- a/clientconn_test.go
+++ b/clientconn_test.go
@@ -815,8 +815,8 @@ func (s) TestGetClientConnTarget(t *testing.T) {
 		t.Fatalf("Dial(%s, _) = _, %v, want _, <nil>", addr, err)
 	}
 	defer cc.Close()
-	if cc.Target() != addr {
-		t.Fatalf("Target() = %s, want %s", cc.Target(), addr)
+	if cc.Target() != "passthrough:///"+addr {
+		t.Fatalf("Target() = %s, want %s", cc.Target(), "passthrough:///"+addr)
 	}
 }
 

--- a/clientconn_test.go
+++ b/clientconn_test.go
@@ -808,15 +808,39 @@ func (s) TestMethodConfigDefaultService(t *testing.T) {
 	}
 }
 
-func (s) TestGetClientConnTarget(t *testing.T) {
-	addr := "nonexist:///non.existent"
-	cc, err := Dial(addr, WithTransportCredentials(insecure.NewCredentials()))
-	if err != nil {
-		t.Fatalf("Dial(%s, _) = _, %v, want _, <nil>", addr, err)
+func (s) TestClientConn_Target(t *testing.T) {
+	tests := []struct {
+		name       string
+		addr       string
+		targetWant string
+	}{
+		{
+			name:       "normal-case",
+			addr:       "dns://a.server.com/google.com",
+			targetWant: "dns://a.server.com/google.com",
+		},
+		{
+			name:       "canonicalized-target-not-specified",
+			addr:       "no.scheme",
+			targetWant: "passthrough:///no.scheme",
+		},
+		{
+			name:       "canonicalized-target-nonexistent",
+			addr:       "nonexist:///non.existent",
+			targetWant: "passthrough:///nonexist:///non.existent",
+		},
 	}
-	defer cc.Close()
-	if cc.Target() != "passthrough:///"+addr {
-		t.Fatalf("Target() = %s, want %s", cc.Target(), "passthrough:///"+addr)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cc, err := Dial(test.addr, WithTransportCredentials(insecure.NewCredentials()))
+			if err != nil {
+				t.Fatalf("Dial(%s, _) = _, %v, want _, <nil>", test.addr, err)
+			}
+			defer cc.Close()
+			if cc.Target() != test.targetWant {
+				t.Fatalf("Target() = %s, want %s", cc.Target(), test.targetWant)
+			}
+		})
 	}
 }
 

--- a/clientconn_test.go
+++ b/clientconn_test.go
@@ -820,14 +820,19 @@ func (s) TestClientConn_Target(t *testing.T) {
 			targetWant: "dns://a.server.com/google.com",
 		},
 		{
-			name:       "canonicalized-target-not-specified",
+			name:       "canonical-target-not-specified",
 			addr:       "no.scheme",
 			targetWant: "passthrough:///no.scheme",
 		},
 		{
-			name:       "canonicalized-target-nonexistent",
+			name:       "canonical-target-nonexistent",
 			addr:       "nonexist:///non.existent",
 			targetWant: "passthrough:///nonexist:///non.existent",
+		},
+		{
+			name:       "canonical-target-add-colon-slash",
+			addr:       "dns:hostname:port",
+			targetWant: "dns:///hostname:port",
 		},
 	}
 	for _, test := range tests {

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -281,7 +281,7 @@ func (t Target) Endpoint() string {
 	return strings.TrimPrefix(endpoint, "/")
 }
 
-// String returns a string representation of Target.
+// String returns a canonical string representation of Target.
 func (t Target) String() string {
 	return t.URL.Scheme + "://" + t.URL.Host + "/" + t.Endpoint()
 }

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -281,7 +281,7 @@ func (t Target) Endpoint() string {
 	return strings.TrimPrefix(endpoint, "/")
 }
 
-// String returns a canonical string representation of Target.
+// String returns the canonical string representation of Target.
 func (t Target) String() string {
 	return t.URL.Scheme + "://" + t.URL.Host + "/" + t.Endpoint()
 }

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -283,7 +283,7 @@ func (t Target) Endpoint() string {
 
 // String returns a string representation of Target.
 func (t Target) String() string {
-	return t.URL.String()
+	return t.URL.Scheme + "://" + t.URL.Host + "/" + t.Endpoint()
 }
 
 // Builder creates a resolver that will be used to watch name resolution updates.


### PR DESCRIPTION
This PR canoncializes the string returned from Target() on the ClientConn. This is a behavior change, but ok because API is marked experimental.

RELEASE NOTES:
* grpc: Canonicalize string returned by ClientConn.Target() and resolver.Address.String()