### PR TITLE
internal/grpcrand: use Go top-level random functions for go1.21+

### DIFF
--- a/internal/grpcrand/grpcrand.go
+++ b/internal/grpcrand/grpcrand.go
@@ -1,5 +1,7 @@
 //go:build !go1.21
-// +build !go1.21
+
+// TODO: when this file is deleted (after Go 1.20 support is dropped), delete
+// all of grpcrand and call the rand package directly.
 
 /*
  *

--- a/internal/grpcrand/grpcrand_go1.21.go
+++ b/internal/grpcrand/grpcrand_go1.21.go
@@ -1,5 +1,4 @@
 //go:build go1.21
-// +build go1.21
 
 /*
  *

--- a/internal/grpcrand/grpcrand_go1.21.go
+++ b/internal/grpcrand/grpcrand_go1.21.go
@@ -1,9 +1,9 @@
-//go:build !go1.21
-// +build !go1.21
+//go:build go1.21
+// +build go1.21
 
 /*
  *
- * Copyright 2018 gRPC authors.
+ * Copyright 2024 gRPC authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,76 +23,52 @@
 // with a global random source, independent of math/rand's global source.
 package grpcrand
 
-import (
-	"math/rand"
-	"sync"
-	"time"
-)
+import "math/rand"
 
-var (
-	r  = rand.New(rand.NewSource(time.Now().UnixNano()))
-	mu sync.Mutex
-)
+// This implementation will be used for Go version 1.21 or newer.
+// For older versions, the original implementation with mutex will be used.
 
 // Int implements rand.Int on the grpcrand global source.
 func Int() int {
-	mu.Lock()
-	defer mu.Unlock()
-	return r.Int()
+	return rand.Int()
 }
 
 // Int63n implements rand.Int63n on the grpcrand global source.
 func Int63n(n int64) int64 {
-	mu.Lock()
-	defer mu.Unlock()
-	return r.Int63n(n)
+	return rand.Int63n(n)
 }
 
 // Intn implements rand.Intn on the grpcrand global source.
 func Intn(n int) int {
-	mu.Lock()
-	defer mu.Unlock()
-	return r.Intn(n)
+	return rand.Intn(n)
 }
 
 // Int31n implements rand.Int31n on the grpcrand global source.
 func Int31n(n int32) int32 {
-	mu.Lock()
-	defer mu.Unlock()
-	return r.Int31n(n)
+	return rand.Int31n(n)
 }
 
 // Float64 implements rand.Float64 on the grpcrand global source.
 func Float64() float64 {
-	mu.Lock()
-	defer mu.Unlock()
-	return r.Float64()
+	return rand.Float64()
 }
 
 // Uint64 implements rand.Uint64 on the grpcrand global source.
 func Uint64() uint64 {
-	mu.Lock()
-	defer mu.Unlock()
-	return r.Uint64()
+	return rand.Uint64()
 }
 
 // Uint32 implements rand.Uint32 on the grpcrand global source.
 func Uint32() uint32 {
-	mu.Lock()
-	defer mu.Unlock()
-	return r.Uint32()
+	return rand.Uint32()
 }
 
 // ExpFloat64 implements rand.ExpFloat64 on the grpcrand global source.
 func ExpFloat64() float64 {
-	mu.Lock()
-	defer mu.Unlock()
-	return r.ExpFloat64()
+	return rand.ExpFloat64()
 }
 
 // Shuffle implements rand.Shuffle on the grpcrand global source.
 var Shuffle = func(n int, f func(int, int)) {
-	mu.Lock()
-	defer mu.Unlock()
-	r.Shuffle(n, f)
+	rand.Shuffle(n, f)
 }


### PR DESCRIPTION
This PR closes issue #6650.

**What I did**
I duplicated all functions in `grpcrand` package into another file, changing the implementation to call top-level functions of Go `math/rand` package internally, adding the `_go1.21` suffix to new file name and build comments to both files, to instruct the Go compiler to compile the new file instead of the original one for Go 1.21 or higher.

**Why**
As described in the related issue, apart from reducing complexity, it is concurrent safe as of Go 1.21, and also significantly faster. I ran a benchmark to demonstrate the difference.

```go
import (
	"math/rand"
	"sync"
	"testing"
	"time"
)

var (
	r  = rand.New(rand.NewSource(time.Now().UnixNano()))
	mu sync.Mutex
)

func BenchmarkIntMutex(b *testing.B) {
	for i := 0; i < b.N; i++ {
		IntMutex()
	}
}

func BenchmarkIntTopLevel(b *testing.B) {
	for i := 0; i < b.N; i++ {
		IntTopLevel()
	}
}

func BenchmarkInt63nMutex(b *testing.B) {
	for i := 0; i < b.N; i++ {
		IntMutex()
	}
}

func BenchmarkInt63nTopLevel(b *testing.B) {
	for i := 0; i < b.N; i++ {
		IntTopLevel()
	}
}

func BenchmarkIntnMutex(b *testing.B) {
	for i := 0; i < b.N; i++ {
		IntMutex()
	}
}

func BenchmarkIntnTopLevel(b *testing.B) {
	for i := 0; i < b.N; i++ {
		IntTopLevel()
	}
}

func BenchmarkInt31nMutex(b *testing.B) {
	for i := 0; i < b.N; i++ {
		IntMutex()
	}
}

func BenchmarkInt31nTopLevel(b *testing.B) {
	for i := 0; i < b.N; i++ {
		IntTopLevel()
	}
}

func BenchmarkFloat64Mutex(b *testing.B) {
	for i := 0; i < b.N; i++ {
		IntMutex()
	}
}

func BenchmarkFloat64TopLevel(b *testing.B) {
	for i := 0; i < b.N; i++ {
		IntTopLevel()
	}
}

func BenchmarkUint64Mutex(b *testing.B) {
	for i := 0; i < b.N; i++ {
		IntMutex()
	}
}

func BenchmarkUint64TopLevel(b *testing.B) {
	for i := 0; i < b.N; i++ {
		IntTopLevel()
	}
}

func BenchmarkUint32Mutex(b *testing.B) {
	for i := 0; i < b.N; i++ {
		IntMutex()
	}
}

func BenchmarkUint32TopLevel(b *testing.B) {
	for i := 0; i < b.N; i++ {
		IntTopLevel()
	}
}

func BenchmarkExpFloat64Mutex(b *testing.B) {
	for i := 0; i < b.N; i++ {
		IntMutex()
	}
}

func BenchmarkExpFloat64TopLevel(b *testing.B) {
	for i := 0; i < b.N; i++ {
		IntTopLevel()
	}
}

func BenchmarkShuffleMutex(b *testing.B) {
	for i := 0; i < b.N; i++ {
		IntMutex()
	}
}

func BenchmarkShuffleTopLevel(b *testing.B) {
	for i := 0; i < b.N; i++ {
		IntTopLevel()
	}
}

func IntMutex() int {
	mu.Lock()
	defer mu.Unlock()
	return r.Int()
}

func Int63nMutex(n int64) int64 {
	mu.Lock()
	defer mu.Unlock()
	return r.Int63n(n)
}

func IntnMutex(n int) int {
	mu.Lock()
	defer mu.Unlock()
	return r.Intn(n)
}

func Int31nMutex(n int32) int32 {
	mu.Lock()
	defer mu.Unlock()
	return r.Int31n(n)
}

func Float64Mutex() float64 {
	mu.Lock()
	defer mu.Unlock()
	return r.Float64()
}

func Uint64Mutex() uint64 {
	mu.Lock()
	defer mu.Unlock()
	return r.Uint64()
}

func Uint32Mutex() uint32 {
	mu.Lock()
	defer mu.Unlock()
	return r.Uint32()
}

func ExpFloat64Mutex() float64 {
	mu.Lock()
	defer mu.Unlock()
	return r.ExpFloat64()
}

func ShuffleMutex(n int, f func(int, int)) {
	mu.Lock()
	defer mu.Unlock()
	r.Shuffle(n, f)
}

func IntTopLevel() int {
	return r.Int()
}

func Int63nTopLevel(n int64) int64 {
	return rand.Int63n(n)
}

func IntnTopLevel(n int) int {
	return rand.Intn(n)
}

func Int31nTopLevel(n int32) int32 {
	return rand.Int31n(n)
}

func Float64TopLevel() float64 {
	return rand.Float64()
}

func Uint64TopLevel() uint64 {
	return rand.Uint64()
}

func Uint32TopLevel() uint32 {
	return rand.Uint32()
}

func ExpFloat64TopLevel() float64 {
	return rand.ExpFloat64()
}

func ShuffleTopLevel(n int, f func(int, int)) {
	rand.Shuffle(n, f)
}
```

results:

```
BenchmarkIntMutex-8                     86689021                13.69 ns/op
BenchmarkIntTopLevel-8                  464327850                2.581 ns/op
BenchmarkInt63nMutex-8                  87957193                13.74 ns/op
BenchmarkInt63nTopLevel-8               463219412                2.586 ns/op
BenchmarkIntnMutex-8                    87656822                13.71 ns/op
BenchmarkIntnTopLevel-8                 463425360                2.653 ns/op
BenchmarkInt31nMutex-8                  87715021                13.68 ns/op
BenchmarkInt31nTopLevel-8               464232123                2.577 ns/op
BenchmarkFloat64Mutex-8                 87786145                13.71 ns/op
BenchmarkFloat64TopLevel-8              463119002                2.583 ns/op
BenchmarkUint64Mutex-8                  87422935                13.73 ns/op
BenchmarkUint64TopLevel-8               462573543                2.605 ns/op
BenchmarkUint32Mutex-8                  87592838                13.80 ns/op
BenchmarkUint32TopLevel-8               461618060                2.607 ns/op
BenchmarkExpFloat64Mutex-8              87122502                15.18 ns/op
BenchmarkExpFloat64TopLevel-8           453928900                2.581 ns/op
BenchmarkShuffleMutex-8                 86752477                13.67 ns/op
BenchmarkShuffleTopLevel-8              465211470                2.585 ns/op
```

Making the functions ~5x faster.

RELEASE NOTES:
- rand: improve performance and simplify implementation of `grpcrand` by adopting `math/rand`'s top-level functions for go version 1.21.0 and newer.
