### PR TITLE
grpc: Add StaticMethod CallOption

### DIFF
--- a/rpc_util.go
+++ b/rpc_util.go
@@ -972,6 +972,7 @@ const (
 	SupportPackageIsVersion5 = true
 	SupportPackageIsVersion6 = true
 	SupportPackageIsVersion7 = true
+	SupportPackageIsVersion8 = true
 )
 
 const grpcUA = "grpc-go/" + Version

--- a/rpc_util.go
+++ b/rpc_util.go
@@ -190,19 +190,18 @@ func (EmptyCallOption) before(*callInfo) error      { return nil }
 func (EmptyCallOption) after(*callInfo, *csAttempt) {}
 
 // StaticMethod returns a CallOption which specifies that a call is being made
-// to a method that is static, which the method is known at compile time and
-// doesn't change at runtime. This can be used as a signal to stats plugins that
-// this method is safe to include as a key to a measurement.
+// to a method that is static, which means the method is known at compile time
+// and doesn't change at runtime. This can be used as a signal to stats plugins
+// that this method is safe to include as a key to a measurement.
 func StaticMethod() CallOption {
 	return StaticMethodCallOption{}
 }
 
 // StaticMethodCallOption is a CallOption that specifies that a call comes
 // from a static method.
-type StaticMethodCallOption struct{}
-
-func (StaticMethodCallOption) before(*callInfo) error      { return nil }
-func (StaticMethodCallOption) after(*callInfo, *csAttempt) {}
+type StaticMethodCallOption struct {
+	EmptyCallOption
+}
 
 // Header returns a CallOptions that retrieves the header metadata
 // for a unary RPC.

--- a/rpc_util.go
+++ b/rpc_util.go
@@ -189,19 +189,20 @@ type EmptyCallOption struct{}
 func (EmptyCallOption) before(*callInfo) error      { return nil }
 func (EmptyCallOption) after(*callInfo, *csAttempt) {}
 
-// RegisteredMethod returns a CallOption which specifies that a call comes from
-// a registered method. This does nothing functionally, but serves as a signal
-// to other code.
-func RegisteredMethod() CallOption {
-	return RegisteredMethodCallOption{}
+// StaticMethod returns a CallOption which specifies that a call is being made
+// to a method that is static, which the method is known at compile time and
+// doesn't change at runtime. This can be used as a signal to stats plugins that
+// this method is safe to include as a key to a measurement.
+func StaticMethod() CallOption {
+	return StaticMethodCallOption{}
 }
 
-// RegisteredMethodCallOption is a CallOption that specifies that a call comes
-// from a registered method.
-type RegisteredMethodCallOption struct{}
+// StaticMethodCallOption is a CallOption that specifies that a call comes
+// from a static method.
+type StaticMethodCallOption struct{}
 
-func (RegisteredMethodCallOption) before(*callInfo) error      { return nil }
-func (RegisteredMethodCallOption) after(*callInfo, *csAttempt) {}
+func (StaticMethodCallOption) before(*callInfo) error      { return nil }
+func (StaticMethodCallOption) after(*callInfo, *csAttempt) {}
 
 // Header returns a CallOptions that retrieves the header metadata
 // for a unary RPC.

--- a/rpc_util.go
+++ b/rpc_util.go
@@ -189,7 +189,14 @@ type EmptyCallOption struct{}
 func (EmptyCallOption) before(*callInfo) error      { return nil }
 func (EmptyCallOption) after(*callInfo, *csAttempt) {}
 
-// RegisteredMethodCallOption is a call option that specifies that a call comes
+// RegisteredMethod returns a CallOption which specifies that a call comes from
+// a registered method. This does nothing functionally, but serves as a signal
+// to other code.
+func RegisteredMethod() CallOption {
+	return RegisteredMethodCallOption{}
+}
+
+// RegisteredMethodCallOption is a CallOption that specifies that a call comes
 // from a registered method.
 type RegisteredMethodCallOption struct{}
 

--- a/rpc_util.go
+++ b/rpc_util.go
@@ -189,6 +189,13 @@ type EmptyCallOption struct{}
 func (EmptyCallOption) before(*callInfo) error      { return nil }
 func (EmptyCallOption) after(*callInfo, *csAttempt) {}
 
+// RegisteredMethodCallOption is a call option that specifies that a call comes
+// from a registered method.
+type RegisteredMethodCallOption struct{}
+
+func (RegisteredMethodCallOption) before(*callInfo) error      { return nil }
+func (RegisteredMethodCallOption) after(*callInfo, *csAttempt) {}
+
 // Header returns a CallOptions that retrieves the header metadata
 // for a unary RPC.
 func Header(md *metadata.MD) CallOption {


### PR DESCRIPTION
This PR adds a call option that specifies whether a method is static. This is intended to be used by generated code and users to get a method attribute within OpenTelemetry while protecting the cardinality of OpenTelemetry timeseries.

RELEASE NOTES:
* grpc: Add StaticMethod CallOption as a signal to stats handler that a method is safe to use as an instrument key.