### PR TITLE
Propagate resolver attributes from cdsbalancer via the addresses. 

### DIFF
--- a/attributes/attributes.go
+++ b/attributes/attributes.go
@@ -70,6 +70,33 @@ func (a *Attributes) Value(key any) any {
 	return a.m[key]
 }
 
+// Merge returns a new Attributes containing the union of keys and values 
+// associated with two Attributes. If the same key appears multiple times, the 
+// last value overwrites all previous values for that key. To remove an
+// existing key, use a nil value.  Value should not be modified later.
+func (a *Attributes) Merge(b *Attributes) *Attributes {
+	totalLen := 0
+	if a != nil {
+		totalLen += len(a.m)
+	}
+	if b != nil {
+		totalLen += len(b.m)
+	}
+	c := &Attributes{m: make(map[any]any, totalLen)}
+	if a != nil {
+		for k, v := range a.m {
+			c.m[k] = v
+		}
+	}
+	if b != nil {
+		for k, v := range b.m {
+			c.m[k] = v
+		}
+	}
+
+	return c
+}
+
 // Equal returns whether a and o are equivalent.  If 'Equal(o any) bool' is
 // implemented for a value in the attributes, it is called to determine if the
 // value matches the one stored in the other attributes.  If Equal is not

--- a/attributes/attributes.go
+++ b/attributes/attributes.go
@@ -45,7 +45,7 @@ func New(key, value any) *Attributes {
 	return &Attributes{m: map[any]any{key: value}}
 }
 
-// WithValue returns a new Attributes containing the previous keys and values
+// WithValue returns a new Attribute containing the previous keys and values
 // and the new key/value pair.  If the same key appears multiple times, the
 // last value overwrites all previous values for that key.  To remove an
 // existing key, use a nil value.  value should not be modified later.
@@ -70,8 +70,8 @@ func (a *Attributes) Value(key any) any {
 	return a.m[key]
 }
 
-// Merge returns a new Attributes containing the union of keys and values 
-// associated with two Attributes. If the same key appears multiple times, the 
+// Merge returns a new Attributes containing the union of keys and values
+// associated with two Attributes. If the same key appears multiple times, the
 // last value overwrites all previous values for that key. To remove an
 // existing key, use a nil value.  Value should not be modified later.
 func (a *Attributes) Merge(b *Attributes) *Attributes {

--- a/attributes/attributes_test.go
+++ b/attributes/attributes_test.go
@@ -126,3 +126,51 @@ func TestNotEqual(t *testing.T) {
 		t.Fatalf("%+v.Equals(%+v) = true; want false", a3, a1)
 	}
 }
+
+func TestMerge(t *testing.T) {
+	type keyOne struct{}
+	type keyTwo struct{}
+	tests := []struct {
+		name string
+		a    *attributes.Attributes
+		b    *attributes.Attributes
+		want *attributes.Attributes
+	}{
+		{
+			name: "a_nil",
+			a:    nil,
+			b:    attributes.New(keyOne{}, 1).WithValue(keyTwo{}, stringVal{s: "two"}),
+			want: attributes.New(keyOne{}, 1).WithValue(keyTwo{}, stringVal{s: "two"}),
+		},
+		{
+			name: "b_nil",
+			a:    attributes.New(keyOne{}, 1).WithValue(keyTwo{}, stringVal{s: "two"}),
+			b:    nil,
+			want: attributes.New(keyOne{}, 1).WithValue(keyTwo{}, stringVal{s: "two"}),
+		},
+		{
+			name: "overwrite_a",
+			a:    attributes.New(keyOne{}, 1),
+			b:    attributes.New(keyOne{}, 2).WithValue(keyTwo{}, stringVal{s: "two"}),
+			want: attributes.New(keyOne{}, 2).WithValue(keyTwo{}, stringVal{s: "two"}),
+		},
+		{
+			name: "retain_missing",
+			a:    attributes.New(keyOne{}, 1).WithValue(keyTwo{}, stringVal{s: "two"}),
+			b:    attributes.New(keyOne{}, 2),
+			want: attributes.New(keyOne{}, 2).WithValue(keyTwo{}, stringVal{s: "two"}),
+		},
+		{
+			name: "disjoint",
+			a:    attributes.New(keyOne{}, 1),
+			b:    attributes.New(keyTwo{}, stringVal{s: "two"}),
+			want: attributes.New(keyOne{}, 1).WithValue(keyTwo{}, stringVal{s: "two"}),
+		},
+	}
+
+	for _, test := range tests {
+		if got := test.a.Merge(test.b); !got.Equal(test.want) {
+			t.Errorf("a.Merge(b) = %v, want %v", got, test.want)
+		}
+	}
+}


### PR DESCRIPTION
To make the propagation easier add a helper method in attributes library which merges two attributes together.

This feature allows any resolver attributes to be propagated further along the xds layers. This is especially useful for resolvers that embed the xds resolvers for example and want to propagated custom attributes.

@dfawley 