### PR TITLE
internal/transport: Remove redundant if conditional in http2_server

### DIFF
--- a/internal/transport/http2_server.go
+++ b/internal/transport/http2_server.go
@@ -636,10 +636,6 @@ func (t *http2Server) HandleStreams(ctx context.Context, handle func(*Stream)) {
 				}
 				continue
 			}
-			if err == io.EOF || err == io.ErrUnexpectedEOF {
-				t.Close(err)
-				return
-			}
 			t.Close(err)
 			return
 		}


### PR DESCRIPTION
In internal/transport/http2_server.go, around line 640, the if-else branches contain the identical code, and should be combined:

```go
if err == io.EOF || err == io.ErrUnexpectedEOF {
  t.Close(err)
  return
}
t.Close(err)
return
```

RELEASE NOTES: none