### PR TITLE
xds/googlec2p: use xdstp names for LDS

### DIFF
--- a/xds/googledirectpath/googlec2p.go
+++ b/xds/googledirectpath/googlec2p.go
@@ -120,7 +120,8 @@ func (c2pResolverBuilder) Build(t resolver.Target, cc resolver.ClientConn, opts 
 		ClientDefaultListenerResourceNameTemplate: "%s",
 		Authorities: map[string]*bootstrap.Authority{
 			c2pAuthority: {
-				XDSServer: serverConfig,
+				XDSServer:                          serverConfig,
+				ClientListenerResourceNameTemplate: "xdstp://traffic-director-c2p.xds.googleapis.com/envoy.config.listener.v3.Listener/%s",
 			},
 		},
 		NodeProto: newNode(<-zoneCh, <-ipv6CapableCh),

--- a/xds/googledirectpath/googlec2p_test.go
+++ b/xds/googledirectpath/googlec2p_test.go
@@ -220,7 +220,7 @@ func TestBuildXDS(t *testing.T) {
 			}
 			wantConfig := &bootstrap.Config{
 				XDSServer: wantServerConfig,
-				ClientDefaultListenerResourceNameTemplate: "xdstp://traffic-director-c2p.xds.googleapis.com/envoy.config.listener.v3.Listener/%s",
+				ClientDefaultListenerResourceNameTemplate: "%s",
 				Authorities: map[string]*bootstrap.Authority{
 					"traffic-director-c2p.xds.googleapis.com": {
 						XDSServer: wantServerConfig,

--- a/xds/googledirectpath/googlec2p_test.go
+++ b/xds/googledirectpath/googlec2p_test.go
@@ -220,7 +220,7 @@ func TestBuildXDS(t *testing.T) {
 			}
 			wantConfig := &bootstrap.Config{
 				XDSServer: wantServerConfig,
-				ClientDefaultListenerResourceNameTemplate: "%s",
+				ClientDefaultListenerResourceNameTemplate: "xdstp://traffic-director-c2p.xds.googleapis.com/envoy.config.listener.v3.Listener/%s",
 				Authorities: map[string]*bootstrap.Authority{
 					"traffic-director-c2p.xds.googleapis.com": {
 						XDSServer: wantServerConfig,

--- a/xds/googledirectpath/googlec2p_test.go
+++ b/xds/googledirectpath/googlec2p_test.go
@@ -223,7 +223,8 @@ func TestBuildXDS(t *testing.T) {
 				ClientDefaultListenerResourceNameTemplate: "%s",
 				Authorities: map[string]*bootstrap.Authority{
 					"traffic-director-c2p.xds.googleapis.com": {
-						XDSServer: wantServerConfig,
+						XDSServer:                          wantServerConfig,
+						ClientListenerResourceNameTemplate: "xdstp://traffic-director-c2p.xds.googleapis.com/envoy.config.listener.v3.Listener/%s",
 					},
 				},
 				NodeProto: wantNode,


### PR DESCRIPTION
As title.

Integration tests passing.

RELEASE NOTES: 

*  xds/googlec2p: use xdstp names for LDS