### PR TITLE
status: modify TestStatus_ErrorDetails_Fail to replace protoimpl package

### DIFF
--- a/status/status_test.go
+++ b/status/status_test.go
@@ -424,13 +424,13 @@ func (s) TestStatus_ErrorDetails_Fail(t *testing.T) {
 			// want to do a compare the proto message for an Equal match, and
 			// for errors only check for presense.
 			if _, ok := d.(error); ok {
-				if (d != nil) != (tc.want != nil) {
-					t.Fatalf("asdasdas")
+				if (d != nil) != (tc.want[i] != nil) {
+					t.Fatalf("s.Details()[%v] was %v; want %v", i, d, tc.want[i])
 				}
 				continue
 			}
 			if !cmp.Equal(d, tc.want[i], cmp.Comparer(proto.Equal)) {
-				t.Fatalf("%v", d)
+				t.Fatalf("s.Details()[%v] was %v; want %v", i, d, tc.want[i])
 			}
 		}
 	}

--- a/status/status_test.go
+++ b/status/status_test.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	cpb "google.golang.org/genproto/googleapis/rpc/code"
 	epb "google.golang.org/genproto/googleapis/rpc/errdetails"
 	spb "google.golang.org/genproto/googleapis/rpc/status"
@@ -417,9 +418,20 @@ func (s) TestStatus_ErrorDetails_Fail(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		got := tc.s.Details()
-		if (got != nil) != (tc.want != nil) {
-			t.Fatalf("(%v).Details() = %+v, want %+v", str(tc.s), got, tc.want)
+		details := tc.s.Details()
+		for i, d := range details {
+			// s.Deatils can either contain an error or a proto message.  We
+			// want to do a compare the proto message for an Equal match, and
+			// for errors only check for presense.
+			if _, ok := d.(error); ok {
+				if (d != nil) != (tc.want != nil) {
+					t.Fatalf("asdasdas")
+				}
+				continue
+			}
+			if !cmp.Equal(d, tc.want[i], cmp.Comparer(proto.Equal)) {
+				t.Fatalf("%v", d)
+			}
 		}
 	}
 }

--- a/status/status_test.go
+++ b/status/status_test.go
@@ -419,8 +419,11 @@ func (s) TestStatus_ErrorDetails_Fail(t *testing.T) {
 	}
 	for _, tc := range tests {
 		details := tc.s.Details()
+		if len(details) != len(tc.want) {
+			t.Fatalf("len(s.Details()) = %v, want = %v.", len(details), len(tc.want))
+		}
 		for i, d := range details {
-			// s.Deatils can either contain an error or a proto message.  We
+			// s.Details can either contain an error or a proto message.  We
 			// want to do a compare the proto message for an Equal match, and
 			// for errors only check for presence.
 			if _, ok := d.(error); ok {

--- a/status/status_test.go
+++ b/status/status_test.go
@@ -422,7 +422,7 @@ func (s) TestStatus_ErrorDetails_Fail(t *testing.T) {
 		for i, d := range details {
 			// s.Deatils can either contain an error or a proto message.  We
 			// want to do a compare the proto message for an Equal match, and
-			// for errors only check for presense.
+			// for errors only check for presence.
 			if _, ok := d.(error); ok {
 				if (d != nil) != (tc.want[i] != nil) {
 					t.Fatalf("s.Details()[%v] was %v; want %v", i, d, tc.want[i])


### PR DESCRIPTION
The protoimpl package is being currently used in a test (which got introduced in #6919). But this package cannot be accessed directly in google3, hence we need a different way of testing the case. 

RELEASE NOTES: none
