### PR TITLE
Set the security level of Windows named pipes to NoSecurity

### DIFF
--- a/credentials/local/local.go
+++ b/credentials/local/local.go
@@ -65,6 +65,9 @@ func getSecurityLevel(network, addr string) (credentials.SecurityLevel, error) {
 	// Local TCP connection
 	case strings.HasPrefix(addr, "127."), strings.HasPrefix(addr, "[::1]:"):
 		return credentials.NoSecurity, nil
+	// Windows named pipe connection
+	case network == "pipe" && strings.HasPrefix(addr, `\\.\pipe\`):
+		return credentials.NoSecurity, nil
 	// UDS connection
 	case network == "unix":
 		return credentials.PrivacyAndIntegrity, nil


### PR DESCRIPTION
Communication over named pipes on Windows is local IPC.

RELEASE NOTES:
- Set the security level of Windows named pipes to NoSecurity
