### PR TITLE
Delay closing connection on the server after all streams are completed

### DIFF
--- a/server.go
+++ b/server.go
@@ -1020,6 +1020,10 @@ func (s *Server) serveStreams(ctx context.Context, st transport.ServerTransport,
 	}
 
 	defer func() {
+		// The client might not be done reading all the data, which at this point
+		// is stored in the kernel TCP buffer, yet. If we close the connection right away
+		// the client will get RST and the request will fail. Delay closing for 1 sec.
+		// See more details in https://github.com/grpc/grpc-go/pull/6957
 		time.Sleep(goAwayTimeout)
 		st.Close(errors.New("finished serving streams for the server transport"))
 		for _, sh := range s.opts.statsHandlers {

--- a/server.go
+++ b/server.go
@@ -1013,6 +1013,7 @@ func (s *Server) serveStreams(ctx context.Context, st transport.ServerTransport,
 	}
 
 	defer func() {
+		time.Sleep(time.Second)
 		st.Close(errors.New("finished serving streams for the server transport"))
 		for _, sh := range s.opts.statsHandlers {
 			sh.HandleConn(ctx, &stats.ConnEnd{})

--- a/server.go
+++ b/server.go
@@ -1013,7 +1013,7 @@ func (s *Server) serveStreams(ctx context.Context, st transport.ServerTransport,
 	}
 
 	defer func() {
-		time.Sleep(time.Second)
+		time.Sleep(2 * time.Second)
 		st.Close(errors.New("finished serving streams for the server transport"))
 		for _, sh := range s.opts.statsHandlers {
 			sh.HandleConn(ctx, &stats.ConnEnd{})


### PR DESCRIPTION
We hit exactly the same bug that was previously reported in grpc-java https://github.com/grpc/grpc-java/issues/9566

It was also fixed in http2 go standard lib https://github.com/golang/net/commit/cd69bc3fc700721b709c3a59e16e24c67b58f6ff#diff-75c1d03aa4d9dfad1fe759ba9fce0462d6e88f2e33242425c4563d4ffb454951

TL;DR is that when server sends large responses and configures MaxConnectionAge, sometimes it closes the connection too early after finishing processing all active streams (the client is not done reading all data from the connection yet, the data is still stored inside TCP kernel buffer on the server) In such cases the client receives RST and gets the following error:

```
error while calling server error="rpc error: code = Unavailable desc = closing transport due to: connection error: desc = \"error reading from server: read tcp 10.131.194.232:41856->10.132.142.4:3000: read: connection reset by peer\", received prior goaway: code: NO_ERROR, debug data: \"max_age\""
```

The fix is very simple: sleep for 1 sec after finishing processing all streams and before closing the connection.

I can reliably reproduce this error in our staging environment, and I verified that the proposed fix actually works. 

I am still working on a unit test that reproduces the error locally. My plan is to modify [this](https://github.com/grpc/grpc-go/blob/master/test/goaway_test.go#L55) test and make the server send large responses, but I'll appreciate any guidance on how we should test this.

I can also make the sleep duration configurable if you prefer.