### PR TITLE
resolver/dns: Add SetMinResolutionInterval Option

### DIFF
--- a/internal/resolver/dns/dns_resolver.go
+++ b/internal/resolver/dns/dns_resolver.go
@@ -49,16 +49,16 @@ var (
 	// MinResolutionRate is the minimum rate at which re-resolutions are
 	// allowed. This helps to prevent excessive re-resolution.
 	MinResolutionRate = 30 * time.Second
+
+	// ResolvingTimeout specifies the maximum duration for a DNS resolution request.
+	// If the timeout expires before a response is received, the request will be canceled.
+	//
+	// It is recommended to set this value at application startup. Avoid modifying this variable
+	// after initialization as it's not thread-safe for concurrent modification.
+	ResolvingTimeout = 30 * time.Second
+
+	logger = grpclog.Component("dns")
 )
-
-// ResolvingTimeout specifies the maximum duration for a DNS resolution request.
-// If the timeout expires before a response is received, the request will be canceled.
-//
-// It is recommended to set this value at application startup. Avoid modifying this variable
-// after initialization as it's not thread-safe for concurrent modification.
-var ResolvingTimeout = 30 * time.Second
-
-var logger = grpclog.Component("dns")
 
 func init() {
 	resolver.Register(NewBuilder())

--- a/internal/resolver/dns/dns_resolver.go
+++ b/internal/resolver/dns/dns_resolver.go
@@ -41,9 +41,15 @@ import (
 	"google.golang.org/grpc/serviceconfig"
 )
 
-// EnableSRVLookups controls whether the DNS resolver attempts to fetch gRPCLB
-// addresses from SRV records.  Must not be changed after init time.
-var EnableSRVLookups = false
+var (
+	// EnableSRVLookups controls whether the DNS resolver attempts to fetch gRPCLB
+	// addresses from SRV records.  Must not be changed after init time.
+	EnableSRVLookups = false
+
+	// MinResolutionRate is the minimum rate at which re-resolutions are
+	// allowed. This helps to prevent excessive re-resolution.
+	MinResolutionRate = 30 * time.Second
+)
 
 // ResolvingTimeout specifies the maximum duration for a DNS resolution request.
 // If the timeout expires before a response is received, the request will be canceled.
@@ -208,7 +214,7 @@ func (d *dnsResolver) watcher() {
 			// Success resolving, wait for the next ResolveNow. However, also wait 30
 			// seconds at the very least to prevent constantly re-resolving.
 			backoffIndex = 1
-			waitTime = internal.MinResolutionRate
+			waitTime = MinResolutionRate
 			select {
 			case <-d.ctx.Done():
 				return

--- a/internal/resolver/dns/dns_resolver.go
+++ b/internal/resolver/dns/dns_resolver.go
@@ -46,9 +46,9 @@ var (
 	// addresses from SRV records.  Must not be changed after init time.
 	EnableSRVLookups = false
 
-	// MinResolutionRate is the minimum rate at which re-resolutions are
+	// MinResolutionInterval is the minimum interval at which re-resolutions are
 	// allowed. This helps to prevent excessive re-resolution.
-	MinResolutionRate = 30 * time.Second
+	MinResolutionInterval = 30 * time.Second
 
 	// ResolvingTimeout specifies the maximum duration for a DNS resolution request.
 	// If the timeout expires before a response is received, the request will be canceled.
@@ -214,7 +214,7 @@ func (d *dnsResolver) watcher() {
 			// Success resolving, wait for the next ResolveNow. However, also wait 30
 			// seconds at the very least to prevent constantly re-resolving.
 			backoffIndex = 1
-			waitTime = MinResolutionRate
+			waitTime = MinResolutionInterval
 			select {
 			case <-d.ctx.Done():
 				return

--- a/internal/resolver/dns/dns_resolver_test.go
+++ b/internal/resolver/dns/dns_resolver_test.go
@@ -71,8 +71,8 @@ func overrideNetResolver(t *testing.T, r *testNetResolver) {
 // Override the DNS Min Res Rate used by the resolver.
 func overrideResolutionRate(t *testing.T, d time.Duration) {
 	origMinResRate := dns.MinResolutionRate
-	dns.MinResolutionRate = d
-	t.Cleanup(func() { dns.MinResolutionRate = origMinResRate })
+	dnspublic.SetMinResolutionRate(d)
+	t.Cleanup(func() { dnspublic.SetMinResolutionRate(origMinResRate) })
 }
 
 // Override the timer used by the DNS resolver to fire after a duration of d.

--- a/internal/resolver/dns/dns_resolver_test.go
+++ b/internal/resolver/dns/dns_resolver_test.go
@@ -68,11 +68,11 @@ func overrideNetResolver(t *testing.T, r *testNetResolver) {
 	t.Cleanup(func() { dnsinternal.NewNetResolver = origNetResolver })
 }
 
-// Override the DNS Min Res Rate used by the resolver.
-func overrideResolutionRate(t *testing.T, d time.Duration) {
-	origMinResRate := dns.MinResolutionRate
-	dnspublic.SetMinResolutionRate(d)
-	t.Cleanup(func() { dnspublic.SetMinResolutionRate(origMinResRate) })
+// Override the DNS minimum resolution interval used by the resolver.
+func overrideResolutionInterval(t *testing.T, d time.Duration) {
+	origMinResInterval := dns.MinResolutionInterval
+	dnspublic.SetMinResolutionInterval(d)
+	t.Cleanup(func() { dnspublic.SetMinResolutionInterval(origMinResInterval) })
 }
 
 // Override the timer used by the DNS resolver to fire after a duration of d.
@@ -636,7 +636,7 @@ func (s) TestDNSResolver_ExponentialBackoff(t *testing.T) {
 func (s) TestDNSResolver_ResolveNow(t *testing.T) {
 	const target = "foo.bar.com"
 
-	overrideResolutionRate(t, 0)
+	overrideResolutionInterval(t, 0)
 	overrideTimeAfterFunc(t, 0)
 	tr := &testNetResolver{
 		hostLookupTable: map[string][]string{
@@ -739,7 +739,7 @@ func (s) TestIPResolver(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			overrideResolutionRate(t, 0)
+			overrideResolutionInterval(t, 0)
 			overrideTimeAfterFunc(t, 2*defaultTestTimeout)
 			r, stateCh, _ := buildResolverWithTestClientConn(t, test.target)
 
@@ -1259,12 +1259,12 @@ func (s) TestResolveTimeout(t *testing.T) {
 	}
 }
 
-// Test verifies that changing [MinResolutionRate] variable correctly effects
+// Test verifies that changing [MinResolutionInterval] variable correctly effects
 // the resolution behaviour
-func (s) TestMinResolutionRate(t *testing.T) {
+func (s) TestMinResolutionInterval(t *testing.T) {
 	const target = "foo.bar.com"
 
-	overrideResolutionRate(t, 1*time.Millisecond)
+	overrideResolutionInterval(t, 1*time.Millisecond)
 	tr := &testNetResolver{
 		hostLookupTable: map[string][]string{
 			"foo.bar.com": {"1.2.3.4", "5.6.7.8"},
@@ -1281,7 +1281,7 @@ func (s) TestMinResolutionRate(t *testing.T) {
 	wantSC := scJSON
 
 	for i := 0; i < 5; i++ {
-		// set context timeout slightly higher than the resolution rate to make sure resolutions
+		// set context timeout slightly higher than the min resolution interval to make sure resolutions
 		// happen successfully
 		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 		defer cancel()

--- a/internal/resolver/dns/internal/internal.go
+++ b/internal/resolver/dns/internal/internal.go
@@ -50,10 +50,6 @@ var (
 
 // The following vars are overridden from tests.
 var (
-	// MinResolutionRate is the minimum rate at which re-resolutions are
-	// allowed. This helps to prevent excessive re-resolution.
-	MinResolutionRate = 30 * time.Second
-
 	// TimeAfterFunc is used by the DNS resolver to wait for the given duration
 	// to elapse. In non-test code, this is implemented by time.After.  In test
 	// code, this can be used to control the amount of time the resolver is

--- a/resolver/dns/dns_resolver.go
+++ b/resolver/dns/dns_resolver.go
@@ -52,3 +52,12 @@ func SetResolvingTimeout(timeout time.Duration) {
 func NewBuilder() resolver.Builder {
 	return dns.NewBuilder()
 }
+
+// SetMinResolutionRate sets the default minimum rate at which DNS re-resolutions are
+// allowed. This helps to prevent excessive re-resolution.
+//
+// Using this option overwrites the default [MinResolutionRate] specified
+// in the internal dns resolver package.
+func SetMinResolutionRate(d time.Duration) {
+	dns.MinResolutionRate = d
+}

--- a/resolver/dns/dns_resolver.go
+++ b/resolver/dns/dns_resolver.go
@@ -53,8 +53,8 @@ func NewBuilder() resolver.Builder {
 	return dns.NewBuilder()
 }
 
-// SetMinResolutionRate sets the default minimum rate at which DNS re-resolutions are
+// SetMinResolutionInterval sets the default minimum interval at which DNS re-resolutions are
 // allowed. This helps to prevent excessive re-resolution.
-func SetMinResolutionRate(d time.Duration) {
-	dns.MinResolutionRate = d
+func SetMinResolutionInterval(d time.Duration) {
+	dns.MinResolutionInterval = d
 }

--- a/resolver/dns/dns_resolver.go
+++ b/resolver/dns/dns_resolver.go
@@ -55,9 +55,6 @@ func NewBuilder() resolver.Builder {
 
 // SetMinResolutionRate sets the default minimum rate at which DNS re-resolutions are
 // allowed. This helps to prevent excessive re-resolution.
-//
-// Using this option overwrites the default [MinResolutionRate] specified
-// in the internal dns resolver package.
 func SetMinResolutionRate(d time.Duration) {
 	dns.MinResolutionRate = d
 }


### PR DESCRIPTION
In this merge request I tried to make `SetMinResolutionInterval` which is currently a constant duration variable by providing options. SetMinResolutionInterval sets the default minimum interval at which DNS re-resolutions are allowed. This helps to prevent excessive re-resolution.

RELEASE NOTES:
- resolver/dns: Add SetMinResolutionInterval sets the default minimum interval at which DNS re-resolutions are allowed.