### PR TITLE
Revert "xds/googlec2p: use xdstp names for LDS (#6949)"

### DIFF
--- a/xds/googledirectpath/googlec2p.go
+++ b/xds/googledirectpath/googlec2p.go
@@ -120,8 +120,7 @@ func (c2pResolverBuilder) Build(t resolver.Target, cc resolver.ClientConn, opts 
 		ClientDefaultListenerResourceNameTemplate: "%s",
 		Authorities: map[string]*bootstrap.Authority{
 			c2pAuthority: {
-				XDSServer:                          serverConfig,
-				ClientListenerResourceNameTemplate: "xdstp://traffic-director-c2p.xds.googleapis.com/envoy.config.listener.v3.Listener/%s",
+				XDSServer: serverConfig,
 			},
 		},
 		NodeProto: newNode(<-zoneCh, <-ipv6CapableCh),

--- a/xds/googledirectpath/googlec2p_test.go
+++ b/xds/googledirectpath/googlec2p_test.go
@@ -223,8 +223,7 @@ func TestBuildXDS(t *testing.T) {
 				ClientDefaultListenerResourceNameTemplate: "%s",
 				Authorities: map[string]*bootstrap.Authority{
 					"traffic-director-c2p.xds.googleapis.com": {
-						XDSServer:                          wantServerConfig,
-						ClientListenerResourceNameTemplate: "xdstp://traffic-director-c2p.xds.googleapis.com/envoy.config.listener.v3.Listener/%s",
+						XDSServer: wantServerConfig,
 					},
 				},
 				NodeProto: wantNode,


### PR DESCRIPTION
This reverts commit 3aafa84f176227b9ba75240cdd41918d305f066d.

As described in https://github.com/grpc/proposal/blob/master/A47-xds-federation.md#bootstrap-config-changes, `client_listener_resource_name_template` *inside the authority map* should default to `xdstp://<authority_name>/envoy.config.listener.v3.Listener/%s`, so #6949 shouldn't be necessary.

cc @arvindbr8 

RELEASE NOTES: none