### PR TITLE
server: wait to close connection until incoming socket is drained (with timeout)

### DIFF
--- a/internal/transport/controlbuf.go
+++ b/internal/transport/controlbuf.go
@@ -535,8 +535,8 @@ const minBatchSize = 1000
 // size is too low to give stream goroutines a chance to fill it up.
 //
 // Upon exiting, if the error causing the exit is not an I/O error, run()
-// flushes and closes the underlying connection.  Otherwise, the connection is
-// left open to allow the I/O error to be encountered by the reader instead.
+// flushes the underlying connection.  The connection is always left open to
+// allow different closing behavior on the client and server.
 func (l *loopyWriter) run() (err error) {
 	defer func() {
 		if l.logger.V(logLevel) {
@@ -544,7 +544,6 @@ func (l *loopyWriter) run() (err error) {
 		}
 		if !isIOError(err) {
 			l.framer.writer.Flush()
-			l.conn.Close()
 		}
 		l.cbuf.finish()
 	}()

--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -452,6 +452,10 @@ func newHTTP2Client(connectCtx, ctx context.Context, addr resolver.Address, opts
 	go func() {
 		t.loopy = newLoopyWriter(clientSide, t.framer, t.controlBuf, t.bdpEst, t.conn, t.logger)
 		t.loopy.run()
+		// Immediately close the connection, as the loopy writer returns when
+		// there are no more active streams and we were draining (the server
+		// sent a GOAWAY).
+		t.conn.Close()
 		close(t.writerDone)
 	}()
 	return t, nil

--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -451,11 +451,13 @@ func newHTTP2Client(connectCtx, ctx context.Context, addr resolver.Address, opts
 	}
 	go func() {
 		t.loopy = newLoopyWriter(clientSide, t.framer, t.controlBuf, t.bdpEst, t.conn, t.logger)
-		t.loopy.run()
-		// Immediately close the connection, as the loopy writer returns when
-		// there are no more active streams and we were draining (the server
-		// sent a GOAWAY).
-		t.conn.Close()
+		if err := t.loopy.run(); !isIOError(err) {
+			// Immediately close the connection, as the loopy writer returns
+			// when there are no more active streams and we were draining (the
+			// server sent a GOAWAY).  For I/O errors, the reader will hit it
+			// after draining any remaining incoming data.
+			t.conn.Close()
+		}
 		close(t.writerDone)
 	}()
 	return t, nil


### PR DESCRIPTION
Replaces #6957

Fixes #5358 (A modified version of the test in that issue runs for 5+ minutes without failing with these changes.  On a broken branch it fails reliably within 30s, and often much faster.)

See also https://github.com/grpc/grpc-java/issues/9566 and https://github.com/golang/net/commit/cd69bc3fc700721b709c3a59e16e24c67b58f6ff / https://github.com/golang/go/issues/18701

This change also adjusts the ping timer after sending the initial GOAWAY from 1 minute to 5 seconds at @ejona86's recommendation.

RELEASE NOTES:
* server: wait to close connection until incoming socket is drained (with timeout) to prevent data loss on client-side