### PR TITLE
transport: when using write buffer pooling, use input size instead of size*2

### DIFF
--- a/dialoptions.go
+++ b/dialoptions.go
@@ -154,9 +154,7 @@ func WithSharedWriteBuffer(val bool) DialOption {
 }
 
 // WithWriteBufferSize determines how much data can be batched before doing a
-// write on the wire. The corresponding memory allocation for this buffer will
-// be twice the size to keep syscalls low. The default value for this buffer is
-// 32KB.
+// write on the wire. The default value for this buffer is 32KB.
 //
 // Zero or negative values will disable the write buffer such that each write
 // will be on underlying connection. Note: A Send call may not directly

--- a/internal/transport/http_util.go
+++ b/internal/transport/http_util.go
@@ -418,10 +418,9 @@ func newFramer(conn net.Conn, writeBufferSize, readBufferSize int, sharedWriteBu
 	return f
 }
 
-func getWriteBufferPool(writeBufferSize int) *sync.Pool {
+func getWriteBufferPool(size int) *sync.Pool {
 	writeBufferMutex.Lock()
 	defer writeBufferMutex.Unlock()
-	size := writeBufferSize * 2
 	pool, ok := writeBufferPoolMap[size]
 	if ok {
 		return pool

--- a/internal/transport/http_util.go
+++ b/internal/transport/http_util.go
@@ -418,9 +418,10 @@ func newFramer(conn net.Conn, writeBufferSize, readBufferSize int, sharedWriteBu
 	return f
 }
 
-func getWriteBufferPool(size int) *sync.Pool {
+func getWriteBufferPool(writeBufferSize int) *sync.Pool {
 	writeBufferMutex.Lock()
 	defer writeBufferMutex.Unlock()
+	size := writeBufferSize * 2
 	pool, ok := writeBufferPoolMap[size]
 	if ok {
 		return pool

--- a/server.go
+++ b/server.go
@@ -249,8 +249,8 @@ func SharedWriteBuffer(val bool) ServerOption {
 }
 
 // WriteBufferSize determines how much data can be batched before doing a write
-// on the wire. The default value for this buffer is 32KB. Zero or negative 
-// values will disable the write buffer such that each write will be on underlying 
+// on the wire. The default value for this buffer is 32KB. Zero or negative
+// values will disable the write buffer such that each write will be on underlying
 // connection. Note: A Send call may not directly translate to a write.
 func WriteBufferSize(s int) ServerOption {
 	return newFuncServerOption(func(o *serverOptions) {

--- a/server.go
+++ b/server.go
@@ -249,11 +249,9 @@ func SharedWriteBuffer(val bool) ServerOption {
 }
 
 // WriteBufferSize determines how much data can be batched before doing a write
-// on the wire. The corresponding memory allocation for this buffer will be
-// twice the size to keep syscalls low. The default value for this buffer is
-// 32KB. Zero or negative values will disable the write buffer such that each
-// write will be on underlying connection.
-// Note: A Send call may not directly translate to a write.
+// on the wire. The default value for this buffer is 32KB. Zero or negative 
+// values will disable the write buffer such that each write will be on underlying 
+// connection. Note: A Send call may not directly translate to a write.
 func WriteBufferSize(s int) ServerOption {
 	return newFuncServerOption(func(o *serverOptions) {
 		o.writeBufferSize = s


### PR DESCRIPTION
This is a minor change to fix an inconsistency in #6309 

It seems in the past, for unknown reasons (see [comment](https://github.com/grpc/grpc-go/pull/6309/files#r1490181244)), the write buffer would be [allocated to 2x the input size](https://github.com/grpc/grpc-go/blame/d524b409462c601ef3f05a7e1fba19755a337c77/internal/transport/http_util.go#L321). It's been [fixed since](https://github.com/grpc/grpc-go/blob/408139acc3066657dbe63938447a10af64d79347/internal/transport/http_util.go#L314-L316), but is still 2x the size for the shared buffer. 

Edit: it seems like the reasons aren't really unknown, the buffer allocation was 2x the size to [keep syscalls low](https://github.com/grpc/grpc-go/blob/d524b409462c601ef3f05a7e1fba19755a337c77/server.go#L239-L240). If syscalls become a performance issue, the calling code is able to specify a `WriteBufferSize` that is larger. We shouldn't be automatcally 2x-ing the buffer size callers pass in. 

RELEASE NOTES: 
* Remove legacy behavior that allocates twice the buffer size in the shared write buffer. 

**Testing**
Ran the same command from the original PR (minus `-shareConnection=false`; it's not a recognized parameter. Added `-sharedWriteBuffer=on` and `-connections=100`). There are no significant differences. 
```
go run benchmark/benchmain/main.go -workloads all -kbps 0 -latency 0s -maxConcurrentCalls 1000 -reqSizeBytes 1 -respSizeBytes 1 -benchtime 1m -sleepBetweenRPCs=20s -sharedWriteBuffer=on -connections=100 -resultFile /tmp/master2 -memProfile /tmp/master2-mem
```
Before change (I just `git revert`):
```
➜  grpc-go go tool pprof -top -inuse_space /tmp/master2-mem
Type: inuse_space
Time: Feb 14, 2024 at 8:20pm (PST)
Showing nodes accounting for 545.04MB, 98.60% of 552.78MB total
Dropped 78 nodes (cum <= 2.76MB)
      flat  flat%   sum%        cum   cum%
  243.60MB 44.07% 44.07%   243.60MB 44.07%  runtime.malg
  132.56MB 23.98% 68.05%   186.56MB 33.75%  google.golang.org/grpc/internal/transport.(*http2Server).operateHeaders
      31MB  5.61% 73.66%    31.50MB  5.70%  google.golang.org/grpc/benchmark.(*testServer).UnconstrainedStreamingCall
   27.51MB  4.98% 78.63%    76.01MB 13.75%  google.golang.org/grpc.(*Server).processStreamingRPC
   18.50MB  3.35% 81.98%    18.50MB  3.35%  google.golang.org/grpc/internal/transport.newWriteQuota (inline)
   16.50MB  2.99% 84.96%    16.50MB  2.99%  context.WithValue
   15.50MB  2.80% 87.77%    15.50MB  2.80%  google.golang.org/grpc/internal/transport.newRecvBuffer (inline)
   10.63MB  1.92% 89.69%    10.63MB  1.92%  google.golang.org/grpc/internal/transport.(*loopyWriter).registerStreamHandler (inline)
    9.50MB  1.72% 91.41%     9.50MB  1.72%  google.golang.org/grpc/internal/status.New (inline)
       8MB  1.45% 92.86%        8MB  1.45%  time.Sleep
       8MB  1.45% 94.30%    11.50MB  2.08%  google.golang.org/grpc.newContextWithRPCInfo (inline)
    7.50MB  1.36% 95.66%     7.50MB  1.36%  context.(*cancelCtx).Done
       7MB  1.27% 96.93%        7MB  1.27%  context.newCancelCtx (inline)
    5.15MB  0.93% 97.86%     5.15MB  0.93%  runtime.allgadd
    3.09MB  0.56% 98.42%     3.09MB  0.56%  bufio.NewReaderSize (inline)
    0.50MB  0.09% 98.51%     7.50MB  1.36%  context.WithCancel
    0.50MB  0.09% 98.60%       32MB  5.79%  google.golang.org/grpc/interop/grpc_testing._BenchmarkService_StreamingCall_Handler
         0     0% 98.60%        7MB  1.27%  context.withCancel
         0     0% 98.60%     4.09MB  0.74%  google.golang.org/grpc.(*Server).Serve.func3
         0     0% 98.60%     4.09MB  0.74%  google.golang.org/grpc.(*Server).handleRawConn
         0     0% 98.60%   186.56MB 33.75%  google.golang.org/grpc.(*Server).handleRawConn.func1
         0     0% 98.60%    79.01MB 14.29%  google.golang.org/grpc.(*Server).handleStream
         0     0% 98.60%     4.09MB  0.74%  google.golang.org/grpc.(*Server).newHTTP2Transport
         0     0% 98.60%   186.56MB 33.75%  google.golang.org/grpc.(*Server).serveStreams
         0     0% 98.60%    79.01MB 14.29%  google.golang.org/grpc.(*Server).serveStreams.func2.1
         0     0% 98.60%       10MB  1.81%  google.golang.org/grpc.(*parser).recvMsg
         0     0% 98.60%    10.50MB  1.90%  google.golang.org/grpc.(*serverStream).RecvMsg
         0     0% 98.60%        5MB   0.9%  google.golang.org/grpc.NewContextWithServerTransportStream (inline)
         0     0% 98.60%        3MB  0.54%  google.golang.org/grpc.contextWithServer (inline)
         0     0% 98.60%    10.50MB  1.90%  google.golang.org/grpc.recv
         0     0% 98.60%       10MB  1.81%  google.golang.org/grpc.recvAndDecompress
         0     0% 98.60%    31.50MB  5.70%  google.golang.org/grpc/benchmark.(*testServer).StreamingCall
         0     0% 98.60%       10MB  1.81%  google.golang.org/grpc/benchmark.(*testServer).UnconstrainedStreamingCall.func1
         0     0% 98.60%     8.50MB  1.54%  google.golang.org/grpc/benchmark.(*testServer).UnconstrainedStreamingCall.func2
         0     0% 98.60%       10MB  1.81%  google.golang.org/grpc/internal/transport.(*Stream).Read
         0     0% 98.60%   186.56MB 33.75%  google.golang.org/grpc/internal/transport.(*http2Server).HandleStreams
         0     0% 98.60%    10.63MB  1.92%  google.golang.org/grpc/internal/transport.(*loopyWriter).handle
         0     0% 98.60%    12.19MB  2.21%  google.golang.org/grpc/internal/transport.(*loopyWriter).run
         0     0% 98.60%       10MB  1.81%  google.golang.org/grpc/internal/transport.(*recvBufferReader).Read
         0     0% 98.60%       10MB  1.81%  google.golang.org/grpc/internal/transport.(*recvBufferReader).read
         0     0% 98.60%       10MB  1.81%  google.golang.org/grpc/internal/transport.(*transportReader).Read
         0     0% 98.60%       10MB  1.81%  google.golang.org/grpc/internal/transport.ContextErr
         0     0% 98.60%     4.09MB  0.74%  google.golang.org/grpc/internal/transport.NewServerTransport
         0     0% 98.60%    11.66MB  2.11%  google.golang.org/grpc/internal/transport.NewServerTransport.func2
         0     0% 98.60%     3.59MB  0.65%  google.golang.org/grpc/internal/transport.newFramer
         0     0% 98.60%        5MB   0.9%  google.golang.org/grpc/metadata.NewIncomingContext (inline)
         0     0% 98.60%       10MB  1.81%  google.golang.org/grpc/status.Error (inline)
         0     0% 98.60%     9.50MB  1.72%  google.golang.org/grpc/status.New (inline)
         0     0% 98.60%       10MB  1.81%  io.ReadAtLeast
         0     0% 98.60%       10MB  1.81%  io.ReadFull (inline)
         0     0% 98.60%   248.75MB 45.00%  runtime.newproc.func1
         0     0% 98.60%   248.75MB 45.00%  runtime.newproc1
         0     0% 98.60%   248.75MB 45.00%  runtime.systemstack

```
After change:
```
➜  grpc-go go tool pprof -top -inuse_space /tmp/master3-mem
Type: inuse_space
Time: Feb 14, 2024 at 8:14pm (PST)
Showing nodes accounting for 539.80MB, 98.63% of 547.31MB total
Dropped 65 nodes (cum <= 2.74MB)
      flat  flat%   sum%        cum   cum%
  245.10MB 44.78% 44.78%   245.10MB 44.78%  runtime.malg
  110.05MB 20.11% 64.89%   164.55MB 30.07%  google.golang.org/grpc/internal/transport.(*http2Server).operateHeaders
   32.51MB  5.94% 70.83%    78.51MB 14.34%  google.golang.org/grpc.(*Server).processStreamingRPC
   27.50MB  5.03% 75.85%       28MB  5.12%  google.golang.org/grpc/benchmark.(*testServer).UnconstrainedStreamingCall
   19.50MB  3.56% 79.42%    19.50MB  3.56%  google.golang.org/grpc/internal/transport.newRecvBuffer (inline)
      18MB  3.29% 82.71%       18MB  3.29%  context.WithValue
   15.66MB  2.86% 85.57%    15.66MB  2.86%  google.golang.org/grpc/internal/transport.(*loopyWriter).registerStreamHandler (inline)
   14.50MB  2.65% 88.22%    14.50MB  2.65%  google.golang.org/grpc/internal/transport.newWriteQuota (inline)
   11.50MB  2.10% 90.32%    11.50MB  2.10%  context.(*cancelCtx).Done
       7MB  1.28% 91.60%       13MB  2.38%  google.golang.org/grpc.newContextWithRPCInfo (inline)
    6.50MB  1.19% 92.78%     6.50MB  1.19%  context.newCancelCtx (inline)
    6.50MB  1.19% 93.97%     6.50MB  1.19%  time.Sleep
    6.19MB  1.13% 95.10%     6.19MB  1.13%  google.golang.org/grpc/internal/transport.getWriteBufferPool.func1
    5.50MB  1.00% 96.11%     5.50MB  1.00%  google.golang.org/grpc/internal/status.New (inline)
    5.15MB  0.94% 97.05%     5.15MB  0.94%  runtime.allgadd
    4.13MB  0.75% 97.80%     4.13MB  0.75%  bufio.NewReaderSize (inline)
    3.52MB  0.64% 98.45%     3.52MB  0.64%  runtime.doaddtimer
       1MB  0.18% 98.63%       29MB  5.30%  google.golang.org/grpc/interop/grpc_testing._BenchmarkService_StreamingCall_Handler
         0     0% 98.63%     6.50MB  1.19%  context.WithCancel
         0     0% 98.63%     6.50MB  1.19%  context.withCancel
         0     0% 98.63%     4.13MB  0.75%  golang.org/x/net/http2.(*Framer).WriteData (inline)
         0     0% 98.63%     4.13MB  0.75%  golang.org/x/net/http2.(*Framer).WriteDataPadded
         0     0% 98.63%     6.19MB  1.13%  golang.org/x/net/http2.(*Framer).endWrite
         0     0% 98.63%     4.13MB  0.75%  google.golang.org/grpc.(*Server).Serve.func3
         0     0% 98.63%     4.13MB  0.75%  google.golang.org/grpc.(*Server).handleRawConn
         0     0% 98.63%   166.06MB 30.34%  google.golang.org/grpc.(*Server).handleRawConn.func1
         0     0% 98.63%    84.51MB 15.44%  google.golang.org/grpc.(*Server).handleStream
         0     0% 98.63%     4.13MB  0.75%  google.golang.org/grpc.(*Server).newHTTP2Transport
         0     0% 98.63%   166.06MB 30.34%  google.golang.org/grpc.(*Server).serveStreams
         0     0% 98.63%    84.51MB 15.44%  google.golang.org/grpc.(*Server).serveStreams.func2.1
         0     0% 98.63%        7MB  1.28%  google.golang.org/grpc.(*parser).recvMsg
         0     0% 98.63%        7MB  1.28%  google.golang.org/grpc.(*serverStream).RecvMsg
         0     0% 98.63%        4MB  0.73%  google.golang.org/grpc.NewContextWithServerTransportStream (inline)
         0     0% 98.63%     5.50MB  1.00%  google.golang.org/grpc.contextWithServer (inline)
         0     0% 98.63%        7MB  1.28%  google.golang.org/grpc.recv
         0     0% 98.63%        7MB  1.28%  google.golang.org/grpc.recvAndDecompress
         0     0% 98.63%       28MB  5.12%  google.golang.org/grpc/benchmark.(*testServer).StreamingCall
         0     0% 98.63%        7MB  1.28%  google.golang.org/grpc/benchmark.(*testServer).UnconstrainedStreamingCall.func1
         0     0% 98.63%     8.50MB  1.55%  google.golang.org/grpc/benchmark.(*testServer).UnconstrainedStreamingCall.func2
         0     0% 98.63%        7MB  1.28%  google.golang.org/grpc/internal/transport.(*Stream).Read
         0     0% 98.63%     6.19MB  1.13%  google.golang.org/grpc/internal/transport.(*bufWriter).Write
         0     0% 98.63%   166.06MB 30.34%  google.golang.org/grpc/internal/transport.(*http2Server).HandleStreams
         0     0% 98.63%    17.72MB  3.24%  google.golang.org/grpc/internal/transport.(*loopyWriter).handle
         0     0% 98.63%     4.13MB  0.75%  google.golang.org/grpc/internal/transport.(*loopyWriter).processData
         0     0% 98.63%    21.85MB  3.99%  google.golang.org/grpc/internal/transport.(*loopyWriter).run
         0     0% 98.63%        7MB  1.28%  google.golang.org/grpc/internal/transport.(*recvBufferReader).Read
         0     0% 98.63%        7MB  1.28%  google.golang.org/grpc/internal/transport.(*recvBufferReader).read
         0     0% 98.63%        7MB  1.28%  google.golang.org/grpc/internal/transport.(*transportReader).Read
         0     0% 98.63%        7MB  1.28%  google.golang.org/grpc/internal/transport.ContextErr
         0     0% 98.63%     4.13MB  0.75%  google.golang.org/grpc/internal/transport.NewServerTransport
         0     0% 98.63%    19.25MB  3.52%  google.golang.org/grpc/internal/transport.NewServerTransport.func2
         0     0% 98.63%     4.13MB  0.75%  google.golang.org/grpc/internal/transport.newFramer
         0     0% 98.63%     3.09MB  0.57%  google.golang.org/grpc/internal/transport.newHTTP2Client.func6
         0     0% 98.63%        7MB  1.28%  google.golang.org/grpc/status.Error (inline)
         0     0% 98.63%     5.50MB  1.00%  google.golang.org/grpc/status.New (inline)
         0     0% 98.63%     8.01MB  1.46%  io.ReadAtLeast
         0     0% 98.63%     8.01MB  1.46%  io.ReadFull (inline)
         0     0% 98.63%     3.52MB  0.64%  runtime.mcall
         0     0% 98.63%     3.52MB  0.64%  runtime.modtimer
         0     0% 98.63%   250.25MB 45.72%  runtime.newproc.func1
         0     0% 98.63%   250.25MB 45.72%  runtime.newproc1
         0     0% 98.63%     3.52MB  0.64%  runtime.park_m
         0     0% 98.63%     3.52MB  0.64%  runtime.resetForSleep
         0     0% 98.63%     3.52MB  0.64%  runtime.resettimer (inline)
         0     0% 98.63%   250.25MB 45.72%  runtime.systemstack
         0     0% 98.63%     6.19MB  1.13%  sync.(*Pool).Get
```

RELEASE NOTES:
* transport: when using write buffer pooling, use input size instead of size*2