### PR TITLE
*: forbid the use of time.After

### DIFF
--- a/internal/transport/http2_server.go
+++ b/internal/transport/http2_server.go
@@ -334,9 +334,11 @@ func NewServerTransport(conn net.Conn, config *ServerConfig) (_ ServerTransport,
 			// closed, would lead to a TCP RST instead of FIN, and the client
 			// encountering errors.  For more info:
 			// https://github.com/grpc/grpc-go/issues/5358
+			timer := time.NewTimer(time.Second)
+			defer timer.Stop()
 			select {
 			case <-t.readerDone:
-			case <-time.After(time.Second):
+			case <-timer.C:
 			}
 			t.conn.Close()
 		}

--- a/vet.sh
+++ b/vet.sh
@@ -83,6 +83,10 @@ git grep 'func [A-Z]' -- "*_test.go" | not grep -v 'func Test\|Benchmark\|Exampl
 # - Do not import x/net/context.
 not git grep -l 'x/net/context' -- "*.go"
 
+# - Do not use time.After except in tests.  It has the potential to leak the
+#   timer since there is no way to stop it early.
+git grep -l 'time.After(' -- "*.go" | not grep -v '_test.go\|test_utils\|testutils'
+
 # - Do not import math/rand for real library code.  Use internal/grpcrand for
 #   thread safety.
 git grep -l '"math/rand"' -- "*.go" 2>&1 | not grep -v '^examples\|^interop/stress\|grpcrand\|^benchmark\|wrr_test'


### PR DESCRIPTION
This particular use seems pretty harmless, but I think we might as well forbid this problematic function that can leak timers as a rule.

RELEASE NOTES: none