### PR TITLE
transport: Make error-handling for bad HTTP method consistent between HTTP/2 server transport and handler server transport

### DIFF
--- a/internal/transport/handler_server.go
+++ b/internal/transport/handler_server.go
@@ -51,14 +51,10 @@ import (
 // inside an http.Handler, or writes an HTTP error to w and returns an error.
 // It requires that the http Server supports HTTP/2.
 func NewServerHandlerTransport(w http.ResponseWriter, r *http.Request, stats []stats.Handler) (ServerTransport, error) {
-	if r.ProtoMajor != 2 {
-		msg := "gRPC requires HTTP/2"
-		http.Error(w, msg, http.StatusBadRequest)
-		return nil, errors.New(msg)
-	}
-	if r.Method != "POST" {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
 		msg := fmt.Sprintf("invalid gRPC request method %q", r.Method)
-		http.Error(w, msg, http.StatusBadRequest)
+		http.Error(w, msg, http.StatusMethodNotAllowed)
 		return nil, errors.New(msg)
 	}
 	contentType := r.Header.Get("Content-Type")
@@ -67,6 +63,11 @@ func NewServerHandlerTransport(w http.ResponseWriter, r *http.Request, stats []s
 	if !validContentType {
 		msg := fmt.Sprintf("invalid gRPC request content-type %q", contentType)
 		http.Error(w, msg, http.StatusUnsupportedMediaType)
+		return nil, errors.New(msg)
+	}
+	if r.ProtoMajor != 2 {
+		msg := "gRPC requires HTTP/2"
+		http.Error(w, msg, http.StatusHTTPVersionNotSupported)
 		return nil, errors.New(msg)
 	}
 	if _, ok := w.(http.Flusher); !ok {

--- a/internal/transport/handler_server_test.go
+++ b/internal/transport/handler_server_test.go
@@ -51,15 +51,6 @@ func (s) TestHandlerTransport_NewServerHandlerTransport(t *testing.T) {
 	}
 	tests := []testCase{
 		{
-			name: "http/1.1",
-			req: &http.Request{
-				ProtoMajor: 1,
-				ProtoMinor: 1,
-			},
-			wantErr:     "gRPC requires HTTP/2",
-			wantErrCode: http.StatusBadRequest,
-		},
-		{
 			name: "bad method",
 			req: &http.Request{
 				ProtoMajor: 2,
@@ -67,7 +58,7 @@ func (s) TestHandlerTransport_NewServerHandlerTransport(t *testing.T) {
 				Header:     http.Header{},
 			},
 			wantErr:     `invalid gRPC request method "GET"`,
-			wantErrCode: http.StatusBadRequest,
+			wantErrCode: http.StatusMethodNotAllowed,
 		},
 		{
 			name: "bad content type",
@@ -80,6 +71,17 @@ func (s) TestHandlerTransport_NewServerHandlerTransport(t *testing.T) {
 			},
 			wantErr:     `invalid gRPC request content-type "application/foo"`,
 			wantErrCode: http.StatusUnsupportedMediaType,
+		},
+		{
+			name: "http/1.1",
+			req: &http.Request{
+				ProtoMajor: 1,
+				ProtoMinor: 1,
+				Method:     "POST",
+				Header:     http.Header{"Content-Type": []string{"application/grpc"}},
+			},
+			wantErr:     "gRPC requires HTTP/2",
+			wantErrCode: http.StatusHTTPVersionNotSupported,
 		},
 		{
 			name: "not flusher",


### PR DESCRIPTION
This tweaks `transport.NewServerHandlerTransport` so that it behaves more like the normal HTTP/2 transport returned by `transport.NewServerTransport` with regard to requests with the wrong HTTP method. In particular, it now sends back a _405 Method Not Allowed_ status code and correctly sets an `Allow` response header.

I've also moved the HTTP version check to after we've confirmed that this is a gRPC request (via content-type check) and changed that to also use a more appropriate HTTP status code: _505 HTTP Version Not Supported_. (This is not really related to consistency since the other transport never has to worry about HTTP 1.1 requests. But it makes the checks a little more coherent since IMO it seems more appropriate to reject the HTTP version only once we've confirmed that it's a gRPC request.)

RELEASE NOTES:
* server: Fix some error cases when using a `grpc.Server` as an `http.Handler` with the Go stdlib HTTP server.