### PR TITLE
xdsclient: use dataplane authority for virtualhost lookup

### DIFF
--- a/clientconn.go
+++ b/clientconn.go
@@ -1772,9 +1772,7 @@ func parseTarget(target string) (resolver.Target, error) {
 }
 
 // encodeAuthority escapes the authority string based on valid chars defined in
-// [Section 3.2 of RFC3986].
-//
-// [Section 3.2 of RFC3986]: https://datatracker.ietf.org/doc/html/rfc3986#section-3.2
+// https://datatracker.ietf.org/doc/html/rfc3986#section-3.2.
 func encodeAuthority(authority string) string {
 	const upperhex = "0123456789ABCDEF"
 

--- a/clientconn.go
+++ b/clientconn.go
@@ -1771,6 +1771,10 @@ func parseTarget(target string) (resolver.Target, error) {
 	return resolver.Target{URL: *u}, nil
 }
 
+// encodeAuthority escapes the authority string based on valid chars defined in
+// [Section 3.2 of RFC3986].
+//
+// [Section 3.2 of RFC3986]: https://datatracker.ietf.org/doc/html/rfc3986#section-3.2
 func encodeAuthority(authority string) string {
 	const upperhex = "0123456789ABCDEF"
 

--- a/internal/testutils/xds/e2e/clientresources.go
+++ b/internal/testutils/xds/e2e/clientresources.go
@@ -365,11 +365,11 @@ func HTTPFilter(name string, config proto.Message) *v3httppb.HttpFilter {
 }
 
 // DefaultRouteConfig returns a basic xds RouteConfig resource.
-func DefaultRouteConfig(routeName, ldsTarget, clusterName string) *v3routepb.RouteConfiguration {
+func DefaultRouteConfig(routeName, vhDomain, clusterName string) *v3routepb.RouteConfiguration {
 	return &v3routepb.RouteConfiguration{
 		Name: routeName,
 		VirtualHosts: []*v3routepb.VirtualHost{{
-			Domains: []string{ldsTarget},
+			Domains: []string{vhDomain},
 			Routes: []*v3routepb.Route{{
 				Match: &v3routepb.RouteMatch{PathSpecifier: &v3routepb.RouteMatch_Prefix{Prefix: "/"}},
 				Action: &v3routepb.Route_Route{Route: &v3routepb.RouteAction{

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -168,8 +168,8 @@ type BuildOptions struct {
 	// field. In most cases though, it is not appropriate, and this field may
 	// be ignored.
 	Dialer func(context.Context, string) (net.Conn, error)
-	// Authority is the effective authority of the connection for which the
-	// resolver is built for.
+	// Authority is the effective authority of the clientconn for which the
+	// resolver is built.
 	Authority string
 }
 

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -168,6 +168,9 @@ type BuildOptions struct {
 	// field. In most cases though, it is not appropriate, and this field may
 	// be ignored.
 	Dialer func(context.Context, string) (net.Conn, error)
+	// Authority is the effective authority of the connection for which the
+	// resolver is built for.
+	Authority string
 }
 
 // An Endpoint is one network endpoint, or server, which may have multiple

--- a/resolver_wrapper.go
+++ b/resolver_wrapper.go
@@ -75,6 +75,7 @@ func (ccr *ccResolverWrapper) start() error {
 			DialCreds:            ccr.cc.dopts.copts.TransportCredentials,
 			CredsBundle:          ccr.cc.dopts.copts.CredsBundle,
 			Dialer:               ccr.cc.dopts.copts.Dialer,
+			Authority:            ccr.cc.authority,
 		}
 		var err error
 		ccr.resolver, err = ccr.cc.resolverBuilder.Build(ccr.cc.parsedTarget, ccr, opts)

--- a/test/xds/xds_client_federation_test.go
+++ b/test/xds/xds_client_federation_test.go
@@ -182,8 +182,7 @@ func (s) TestClientSideFederationWithTDOM(t *testing.T) {
 	edsName := "endpoints-" + serviceName
 
 	resourceUpdate := e2e.UpdateOptions{
-		NodeID: nodeID,
-		// This has only RDS and EDS.
+		NodeID:         nodeID,
 		Listeners:      []*v3listenerpb.Listener{e2e.DefaultClientListener(ldsName, rdsName)},
 		Routes:         []*v3routepb.RouteConfiguration{e2e.DefaultRouteConfig(rdsName, serviceName, cdsName)},
 		Clusters:       []*v3clusterpb.Cluster{e2e.DefaultCluster(cdsName, edsName, e2e.SecurityLevelNone)},

--- a/test/xds/xds_client_federation_test.go
+++ b/test/xds/xds_client_federation_test.go
@@ -302,7 +302,7 @@ func (s) TestFederation_UnknownAuthorityInReceivedResponse(t *testing.T) {
 	resources := e2e.UpdateOptions{
 		NodeID:         nodeID,
 		Listeners:      []*v3listenerpb.Listener{e2e.DefaultClientListener(ldsName, rdsName)},
-		Routes:         []*v3routepb.RouteConfiguration{e2e.DefaultRouteConfig(rdsName, serviceName, "cluster-"+serviceName)},
+		Routes:         []*v3routepb.RouteConfiguration{e2e.DefaultRouteConfig(rdsName, ldsName, "cluster-"+serviceName)},
 		SkipValidation: true, // This update has only LDS and RDS resources.
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)

--- a/test/xds/xds_client_federation_test.go
+++ b/test/xds/xds_client_federation_test.go
@@ -178,9 +178,9 @@ func (s) TestClientSideFederationWithOnlyXDSTPStyleLDS(t *testing.T) {
 	const serviceName = "my-service-client-side-xds/2nd component"
 
 	// All other resources are with old style name.
-	rdsName := "route-" + serviceName
-	cdsName := "cluster-" + serviceName
-	edsName := "endpoints-" + serviceName
+	const rdsName = "route-" + serviceName
+	const cdsName = "cluster-" + serviceName
+	const edsName = "endpoints-" + serviceName
 
 	// Resource update sent to go-control-plane mgmt server.
 	resourceUpdate := e2e.UpdateOptions{

--- a/test/xds/xds_client_federation_test.go
+++ b/test/xds/xds_client_federation_test.go
@@ -140,10 +140,10 @@ func (s) TestClientSideFederation(t *testing.T) {
 	}
 }
 
-// TestClientSideFederationWithOnlyXDSTPStyleLDS tests that federation is supported
-// with new xdstp style names for LDS only while using the old style for other
-// resources. This test in addition also checks that when service name contains
-// escapable characters (in this case a `/`), we encode it for looking up
+// TestClientSideFederationWithOnlyXDSTPStyleLDS tests that federation is
+// supported with new xdstp style names for LDS only while using the old style
+// for other resources. This test in addition also checks that when service name
+// contains escapable characters, we "fully" encode it for looking up
 // VirtualHosts in xDS RouteConfigurtion.
 func (s) TestClientSideFederationWithOnlyXDSTPStyleLDS(t *testing.T) {
 	// Start a management server as a sophisticated authority.

--- a/xds/internal/resolver/helpers_test.go
+++ b/xds/internal/resolver/helpers_test.go
@@ -21,6 +21,7 @@ package resolver_test
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -104,7 +105,9 @@ func buildResolverForTarget(t *testing.T, target resolver.Target) (chan resolver
 		}
 	}
 	tcc := &testutils.ResolverClientConn{Logger: t, UpdateStateF: updateStateF, ReportErrorF: reportErrorF}
-	r, err := builder.Build(target, tcc, resolver.BuildOptions{})
+	r, err := builder.Build(target, tcc, resolver.BuildOptions{
+		Authority: url.PathEscape(target.Endpoint()),
+	})
 	if err != nil {
 		t.Fatalf("Failed to build xDS resolver for target %q: %v", target, err)
 	}

--- a/xds/internal/resolver/xds_resolver.go
+++ b/xds/internal/resolver/xds_resolver.go
@@ -120,9 +120,9 @@ func (b *xdsResolverBuilder) Build(target resolver.Target, cc resolver.ClientCon
 		endpoint = target.URL.Opaque
 	}
 	endpoint = strings.TrimPrefix(endpoint, "/")
+	r.dataplaneAuthority = url.PathEscape(endpoint)
 	r.ldsResourceName = bootstrap.PopulateResourceTemplate(template, endpoint)
 	r.listenerWatcher = newListenerWatcher(r.ldsResourceName, r)
-	r.dataplaneAuthority = url.PathEscape(endpoint)
 	return r, nil
 }
 

--- a/xds/internal/resolver/xds_resolver.go
+++ b/xds/internal/resolver/xds_resolver.go
@@ -418,7 +418,7 @@ func (r *xdsResolver) onResolutionComplete() {
 func (r *xdsResolver) applyRouteConfigUpdate(update xdsresource.RouteConfigUpdate) {
 	matchVh := xdsresource.FindBestMatchingVirtualHost(r.dataplaneAuthority, update.VirtualHosts)
 	if matchVh == nil {
-		r.onError(fmt.Errorf("no matching virtual host found for %q", r.ldsResourceName))
+		r.onError(fmt.Errorf("no matching virtual host found for %q", r.dataplaneAuthority))
 		return
 	}
 	r.currentRouteConfig = update

--- a/xds/internal/resolver/xds_resolver.go
+++ b/xds/internal/resolver/xds_resolver.go
@@ -191,11 +191,12 @@ type xdsResolver struct {
 	serializer       *grpcsync.CallbackSerializer
 	serializerCancel context.CancelFunc
 
-	// Per [A47] the authority used for the data plane connections (which is
+	// Per [A47], the authority used for the data plane connections (which is
 	// also used to select the VirtualHost within the xDS RouteConfiguration)
-	// will continue to be the last path component of the xds URI used to create
-	// the gRPC channel (i.e., the part following the last / character, or the
-	// entire path if the path contains no / character).
+	// will continue to be the path component of the `xds` URI used to create
+	// the gRPC channel, stripping off the leading `/` if any.  (Any remaining
+	// `/` characters will be percent-encoded, as is normal when determining the
+	// data plane authority from the gRPC target URI.).
 	//
 	// [A47]: https://github.com/grpc/proposal/blob/master/A47-xds-federation.md
 	dataplaneAuthority string

--- a/xds/internal/resolver/xds_resolver.go
+++ b/xds/internal/resolver/xds_resolver.go
@@ -22,6 +22,7 @@ package resolver
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"strings"
 	"sync/atomic"
 
@@ -119,11 +120,9 @@ func (b *xdsResolverBuilder) Build(target resolver.Target, cc resolver.ClientCon
 		endpoint = target.URL.Opaque
 	}
 	endpoint = strings.TrimPrefix(endpoint, "/")
-	// TODO(https://github.com/grpc/grpc-go/issues/7002): Check if
-	// dataplaneAuthority is URL encoded (including /'s). If not, encode it.
-	r.dataplaneAuthority = endpoint
 	r.ldsResourceName = bootstrap.PopulateResourceTemplate(template, endpoint)
 	r.listenerWatcher = newListenerWatcher(r.ldsResourceName, r)
+	r.dataplaneAuthority = url.PathEscape(endpoint)
 	return r, nil
 }
 
@@ -195,7 +194,8 @@ type xdsResolver struct {
 
 	// dataplaneAuthority is the authority used for the data plane connections,
 	// which is also used to select the VirtualHost within the xDS
-	// RouteConfiguration.
+	// RouteConfiguration.  This string is %-encoded to match with VirtualHost
+	// Domain in xDS RouteConfiguration.
 	dataplaneAuthority string
 
 	ldsResourceName     string

--- a/xds/internal/resolver/xds_resolver.go
+++ b/xds/internal/resolver/xds_resolver.go
@@ -22,7 +22,6 @@ package resolver
 import (
 	"context"
 	"fmt"
-	"net/url"
 	"strings"
 	"sync/atomic"
 
@@ -120,7 +119,7 @@ func (b *xdsResolverBuilder) Build(target resolver.Target, cc resolver.ClientCon
 		endpoint = target.URL.Opaque
 	}
 	endpoint = strings.TrimPrefix(endpoint, "/")
-	r.dataplaneAuthority = url.PathEscape(endpoint)
+	r.dataplaneAuthority = opts.Authority
 	r.ldsResourceName = bootstrap.PopulateResourceTemplate(template, endpoint)
 	r.listenerWatcher = newListenerWatcher(r.ldsResourceName, r)
 	return r, nil

--- a/xds/internal/resolver/xds_resolver.go
+++ b/xds/internal/resolver/xds_resolver.go
@@ -191,6 +191,13 @@ type xdsResolver struct {
 	serializer       *grpcsync.CallbackSerializer
 	serializerCancel context.CancelFunc
 
+	// Per [A47] the authority used for the data plane connections (which is
+	// also used to select the VirtualHost within the xDS RouteConfiguration)
+	// will continue to be the last path component of the xds URI used to create
+	// the gRPC channel (i.e., the part following the last / character, or the
+	// entire path if the path contains no / character).
+	//
+	// [A47]: https://github.com/grpc/proposal/blob/master/A47-xds-federation.md
 	dataplaneAuthority string
 
 	ldsResourceName     string

--- a/xds/internal/resolver/xds_resolver.go
+++ b/xds/internal/resolver/xds_resolver.go
@@ -119,6 +119,7 @@ func (b *xdsResolverBuilder) Build(target resolver.Target, cc resolver.ClientCon
 		endpoint = target.URL.Opaque
 	}
 	endpoint = strings.TrimPrefix(endpoint, "/")
+	// TODO(https://github.com/grpc/grpc-go/issues/7002): Check if dataplaneAuthority is URL encoded (including /'s). If not, encode it.
 	r.dataplaneAuthority = endpoint
 	r.ldsResourceName = bootstrap.PopulateResourceTemplate(template, endpoint)
 	r.listenerWatcher = newListenerWatcher(r.ldsResourceName, r)
@@ -191,14 +192,9 @@ type xdsResolver struct {
 	serializer       *grpcsync.CallbackSerializer
 	serializerCancel context.CancelFunc
 
-	// Per [A47], the authority used for the data plane connections (which is
-	// also used to select the VirtualHost within the xDS RouteConfiguration)
-	// will continue to be the path component of the `xds` URI used to create
-	// the gRPC channel, stripping off the leading `/` if any.  (Any remaining
-	// `/` characters will be percent-encoded, as is normal when determining the
-	// data plane authority from the gRPC target URI.).
-	//
-	// [A47]: https://github.com/grpc/proposal/blob/master/A47-xds-federation.md
+	// dataplaneAuthority is the authority used for the data plane connections,
+	// which is also used to select the VirtualHost within the xDS
+	// RouteConfiguration.
 	dataplaneAuthority string
 
 	ldsResourceName     string

--- a/xds/internal/resolver/xds_resolver.go
+++ b/xds/internal/resolver/xds_resolver.go
@@ -194,8 +194,8 @@ type xdsResolver struct {
 
 	// dataplaneAuthority is the authority used for the data plane connections,
 	// which is also used to select the VirtualHost within the xDS
-	// RouteConfiguration.  This string is %-encoded to match with VirtualHost
-	// Domain in xDS RouteConfiguration.
+	// RouteConfiguration.  This is %-encoded to match with VirtualHost Domain
+	// in xDS RouteConfiguration.
 	dataplaneAuthority string
 
 	ldsResourceName     string

--- a/xds/internal/resolver/xds_resolver.go
+++ b/xds/internal/resolver/xds_resolver.go
@@ -119,7 +119,8 @@ func (b *xdsResolverBuilder) Build(target resolver.Target, cc resolver.ClientCon
 		endpoint = target.URL.Opaque
 	}
 	endpoint = strings.TrimPrefix(endpoint, "/")
-	// TODO(https://github.com/grpc/grpc-go/issues/7002): Check if dataplaneAuthority is URL encoded (including /'s). If not, encode it.
+	// TODO(https://github.com/grpc/grpc-go/issues/7002): Check if
+	// dataplaneAuthority is URL encoded (including /'s). If not, encode it.
 	r.dataplaneAuthority = endpoint
 	r.ldsResourceName = bootstrap.PopulateResourceTemplate(template, endpoint)
 	r.listenerWatcher = newListenerWatcher(r.ldsResourceName, r)

--- a/xds/internal/resolver/xds_resolver.go
+++ b/xds/internal/resolver/xds_resolver.go
@@ -22,7 +22,6 @@ package resolver
 import (
 	"context"
 	"fmt"
-	"strings"
 	"sync/atomic"
 
 	"google.golang.org/grpc/internal"
@@ -114,13 +113,8 @@ func (b *xdsResolverBuilder) Build(target resolver.Target, cc resolver.ClientCon
 	if err != nil {
 		return nil, err
 	}
-	endpoint := target.URL.Path
-	if endpoint == "" {
-		endpoint = target.URL.Opaque
-	}
-	endpoint = strings.TrimPrefix(endpoint, "/")
 	r.dataplaneAuthority = opts.Authority
-	r.ldsResourceName = bootstrap.PopulateResourceTemplate(template, endpoint)
+	r.ldsResourceName = bootstrap.PopulateResourceTemplate(template, target.Endpoint())
 	r.listenerWatcher = newListenerWatcher(r.ldsResourceName, r)
 	return r, nil
 }

--- a/xds/internal/resolver/xds_resolver_test.go
+++ b/xds/internal/resolver/xds_resolver_test.go
@@ -116,6 +116,59 @@ func (s) TestResolverBuilder_AuthorityNotDefinedInBootstrap(t *testing.T) {
 	}
 }
 
+// // Tests the case where the specified dial target contains an authority that is
+// // not specified in the bootstrap file. Verifies that the resolver.Build method
+// // fails with the expected error string.
+// func (s) TestResolverBuilder_ParsesDataplaneAuthorityCorrectly(t *testing.T) {
+// 	bootstrapCleanup, err := xdsbootstrap.CreateFile(xdsbootstrap.Options{
+// 		NodeID:    "node-id",
+// 		ServerURI: "dummy-management-server",
+// 		Authorities: map[string]string{
+// 			"something-authority": "dummy-management-server-address",
+// 		},
+// 	})
+// 	if err != nil {
+// 		t.Fatal(err)
+// 	}
+// 	defer bootstrapCleanup()
+
+// 	builder := resolver.Get(xdsresolver.Scheme)
+// 	if builder == nil {
+// 		t.Fatalf("Scheme %q is not registered", xdsresolver.Scheme)
+// 	}
+
+// 	tests := []struct {
+// 		targetURL              string
+// 		wantDataPlaneAuthority string
+// 	}{
+// 		{
+// 			targetURL:              "xds:///target",
+// 			wantDataPlaneAuthority: "target",
+// 		},
+// 		{
+// 			targetURL:              "xds://something-authority/target",
+// 			wantDataPlaneAuthority: "target",
+// 		},
+// 	}
+
+// 	for i, tt := range tests {
+// 		t.Run(fmt.Sprintf("case-%d", i), func(t *testing.T) {
+// 			target := resolver.Target{URL: *testutils.MustParseURL(tt.targetURL)}
+
+// 			r, err := builder.Build(target, &testutils.ResolverClientConn{Logger: t}, resolver.BuildOptions{})
+// 			if err != nil {
+// 				t.Fatalf("xds Resolver Build(%v): %v", target, err)
+// 			}
+// 			r.Close()
+
+// 			if r.(*iresolver.xdsResolver).dataplaneAuthority != tt.wantDataPlaneAuthority {
+// 				t.Fatalf("xds Resolver Build(%v) returned DataPlaneAuthority: %v, want: %v", target, r.(*iresolver.Resolver).DataPlaneAuthority(), tt.wantDataPlaneAuthority)
+// 			}
+// 		})
+// 	}
+
+// }
+
 // Test builds an xDS resolver and verifies that the resource name specified in
 // the discovery request matches expectations.
 func (s) TestResolverResourceName(t *testing.T) {

--- a/xds/internal/resolver/xds_resolver_test.go
+++ b/xds/internal/resolver/xds_resolver_test.go
@@ -116,59 +116,6 @@ func (s) TestResolverBuilder_AuthorityNotDefinedInBootstrap(t *testing.T) {
 	}
 }
 
-// // Tests the case where the specified dial target contains an authority that is
-// // not specified in the bootstrap file. Verifies that the resolver.Build method
-// // fails with the expected error string.
-// func (s) TestResolverBuilder_ParsesDataplaneAuthorityCorrectly(t *testing.T) {
-// 	bootstrapCleanup, err := xdsbootstrap.CreateFile(xdsbootstrap.Options{
-// 		NodeID:    "node-id",
-// 		ServerURI: "dummy-management-server",
-// 		Authorities: map[string]string{
-// 			"something-authority": "dummy-management-server-address",
-// 		},
-// 	})
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	defer bootstrapCleanup()
-
-// 	builder := resolver.Get(xdsresolver.Scheme)
-// 	if builder == nil {
-// 		t.Fatalf("Scheme %q is not registered", xdsresolver.Scheme)
-// 	}
-
-// 	tests := []struct {
-// 		targetURL              string
-// 		wantDataPlaneAuthority string
-// 	}{
-// 		{
-// 			targetURL:              "xds:///target",
-// 			wantDataPlaneAuthority: "target",
-// 		},
-// 		{
-// 			targetURL:              "xds://something-authority/target",
-// 			wantDataPlaneAuthority: "target",
-// 		},
-// 	}
-
-// 	for i, tt := range tests {
-// 		t.Run(fmt.Sprintf("case-%d", i), func(t *testing.T) {
-// 			target := resolver.Target{URL: *testutils.MustParseURL(tt.targetURL)}
-
-// 			r, err := builder.Build(target, &testutils.ResolverClientConn{Logger: t}, resolver.BuildOptions{})
-// 			if err != nil {
-// 				t.Fatalf("xds Resolver Build(%v): %v", target, err)
-// 			}
-// 			r.Close()
-
-// 			if r.(*iresolver.xdsResolver).dataplaneAuthority != tt.wantDataPlaneAuthority {
-// 				t.Fatalf("xds Resolver Build(%v) returned DataPlaneAuthority: %v, want: %v", target, r.(*iresolver.Resolver).DataPlaneAuthority(), tt.wantDataPlaneAuthority)
-// 			}
-// 		})
-// 	}
-
-// }
-
 // Test builds an xDS resolver and verifies that the resource name specified in
 // the discovery request matches expectations.
 func (s) TestResolverResourceName(t *testing.T) {


### PR DESCRIPTION
Fixes #6996 

A new field `Authority` is added to `resolver.BuildOptions` to pass the effective authority of clientconn for which the resolver was built. 

Testing:

I have verified that this diff works with the bootstrap generator @ https://github.com/GoogleCloudPlatform/traffic-director-grpc-bootstrap/pull/57. 

<details>
<summary>Test logs</summary>

```
2024/02/22 00:39:20 INFO: [core] [Channel #1] Channel created
2024/02/22 00:39:20 INFO: [core] [Channel #1] original dial target is: "xds:///helloworld-gke:8000"
2024/02/22 00:39:20 INFO: [core] [Channel #1] parsed dial target is: resolver.Target{URL:url.URL{Scheme:"xds", Opaque:"", User:(*url.Userinfo)(nil), Host:"", Path:"/helloworld-gke:8000", RawPath:"", OmitHost:false, ForceQuery:false, RawQuery:"", Fragment:"", RawFragment:""}}
2024/02/22 00:39:20 INFO: [core] [Channel #1] Channel authority set to "helloworld-gke:8000"
2024/02/22 00:39:20 INFO: [xds] [xds-resolver 0xc0002fc5a0] Creating resolver for target: xds:///helloworld-gke:8000
2024/02/22 00:39:20 INFO: [xds] [xds-bootstrap] Using bootstrap file with name "/tmp/grpc-xds/td-grpc-bootstrap.json"
2024/02/22 00:39:20 INFO: [xds] [xds-bootstrap] Bootstrap config for creating xds-client: {
  "XDSServer": {
    "server_uri": "trafficdirector.googleapis.com:443",
    "channel_creds": [
      {
        "type": "google_default"
      }
    ],
    "server_features": [
      "xds_v3"
    ]
  },
  "CertProviderConfigs": {
    "google_cloud_private_spiffe": {}
  },
  "ServerListenerResourceNameTemplate": "grpc/server?xds.resource.listening_address=%s",
  "ClientDefaultListenerResourceNameTemplate": "xdstp://traffic-director-global.xds.googleapis.com/envoy.config.listener.v3.Listener/439293274322/default/%s",
  "Authorities": {
    "traffic-director-c2p.xds.googleapis.com": {
      "ClientListenerResourceNameTemplate": "xdstp://traffic-director-c2p.xds.googleapis.com/envoy.config.listener.v3.Listener/%s",
      "XDSServer": {
        "server_uri": "dns:///directpath-pa.googleapis.com",
        "channel_creds": [
          {
            "type": "google_default"
          }
        ],
        "server_features": [
          "xds_v3",
          "ignore_resource_deletion"
        ]
      }
    },
    "traffic-director-global.xds.googleapis.com": {
      "ClientListenerResourceNameTemplate": "xdstp://traffic-director-global.xds.googleapis.com/envoy.config.listener.v3.Listener/439293274322/default/%s",
      "XDSServer": null
    }
  },
  "NodeProto": {
    "id": "projects/439293274322/networks/default/nodes/c51c7df5-68d2-40c2-bc7b-513817204bad",
    "cluster": "cluster",
    "metadata": {
      "INSTANCE_IP": "10.116.2.7",
      "TRAFFICDIRECTOR_GRPC_BOOTSTRAP_GENERATOR_SHA": "3149e0342ac92c92d89feaacc96d9d2f511f5b97"
    },
    "locality": {
      "zone": "us-west2-a"
    },
    "user_agent_name": "gRPC Go",
    "UserAgentVersionType": {
      "UserAgentVersion": "1.63.0-dev"
    },
    "client_features": [
      "envoy.lb.does_not_support_overprovisioning",
      "xds.config.resource-in-sotw"
    ]
  }
}
2024/02/22 00:39:20 INFO: [xds] [xds-client 0xc00034adc0] Created client to xDS management server: trafficdirector.googleapis.com:443-google_default-xds_v3
2024/02/22 00:39:20 INFO: [xds] xDS node ID: projects/439293274322/networks/default/nodes/c51c7df5-68d2-40c2-bc7b-513817204bad
2024/02/22 00:39:20 INFO: [core] [Channel #2] Channel created
2024/02/22 00:39:20 INFO: [core] [Channel #2] original dial target is: "trafficdirector.googleapis.com:443"
2024/02/22 00:39:20 INFO: [core] [Channel #2] parsed dial target is: resolver.Target{URL:url.URL{Scheme:"trafficdirector.googleapis.com", Opaque:"443", User:(*url.Userinfo)(nil), Host:"", Path:"", RawPath:"", OmitHost:false, ForceQuery:false, RawQuery:"", Fragment:"", RawFragment:""}}
2024/02/22 00:39:20 INFO: [core] [Channel #2] fallback to scheme "passthrough"
2024/02/22 00:39:20 INFO: [core] [Channel #2] parsed dial target is: passthrough:///trafficdirector.googleapis.com:443
2024/02/22 00:39:20 INFO: [core] [Channel #2] Channel authority set to "trafficdirector.googleapis.com:443"
2024/02/22 00:39:20 INFO: [core] [Channel #2] Resolver state updated: {
  "Addresses": [
    {
      "Addr": "trafficdirector.googleapis.com:443",
      "ServerName": "",
      "Attributes": null,
      "BalancerAttributes": null,
      "Metadata": null
    }
  ],
  "Endpoints": [
    {
      "Addresses": [
        {
          "Addr": "trafficdirector.googleapis.com:443",
          "ServerName": "",
          "Attributes": null,
          "BalancerAttributes": null,
          "Metadata": null
        }
      ],
      "Attributes": null
    }
  ],
  "ServiceConfig": null,
  "Attributes": null
} (resolver returned new addresses)
2024/02/22 00:39:20 INFO: [core] [Channel #2] Channel switches to new LB policy "pick_first"
2024/02/22 00:39:20 INFO: [core] [pick-first-lb 0xc00039ccc0] Received new config {
  "shuffleAddressList": false
}, resolver state {
  "Addresses": [
    {
      "Addr": "trafficdirector.googleapis.com:443",
      "ServerName": "",
      "Attributes": null,
      "BalancerAttributes": null,
      "Metadata": null
    }
  ],
  "Endpoints": [
    {
      "Addresses": [
        {
          "Addr": "trafficdirector.googleapis.com:443",
          "ServerName": "",
          "Attributes": null,
          "BalancerAttributes": null,
          "Metadata": null
        }
      ],
      "Attributes": null
    }
  ],
  "ServiceConfig": null,
  "Attributes": null
}
2024/02/22 00:39:20 INFO: [core] [Channel #2 SubChannel #3] Subchannel created
2024/02/22 00:39:20 INFO: [core] [Channel #2] Channel Connectivity change to CONNECTING
2024/02/22 00:39:20 INFO: [core] [Channel #2] Channel exiting idle mode
2024/02/22 00:39:20 INFO: [xds] [xds-client 0xc00034adc0] [trafficdirector.googleapis.com:443] Created transport to server "trafficdirector.googleapis.com:443"
2024/02/22 00:39:20 INFO: [xds] [xds-client 0xc00034adc0] [trafficdirector.googleapis.com:443] New watch for type "ListenerResource", resource name "xdstp://traffic-director-global.xds.googleapis.com/envoy.config.listener.v3.Listener/439293274322/default/helloworld-gke:8000"
2024/02/22 00:39:20 INFO: [xds] [xds-client 0xc00034adc0] [trafficdirector.googleapis.com:443] First watch for type "ListenerResource", resource name "xdstp://traffic-director-global.xds.googleapis.com/envoy.config.listener.v3.Listener/439293274322/default/helloworld-gke:8000"
2024/02/22 00:39:20 INFO: [core] [Channel #1] Channel exiting idle mode
2024/02/22 00:39:20 INFO: [core] [Channel #2 SubChannel #3] Subchannel Connectivity change to CONNECTING
2024/02/22 00:39:20 INFO: [core] [Channel #2 SubChannel #3] Subchannel picks a new address "trafficdirector.googleapis.com:443" to connect
2024/02/22 00:39:20 INFO: [core] [pick-first-lb 0xc00039ccc0] Received SubConn state update: 0xc00039ce40, {ConnectivityState:CONNECTING ConnectionError:<nil>}
2024/02/22 00:39:20 INFO: [core] [Channel #2 SubChannel #3] Subchannel Connectivity change to READY
2024/02/22 00:39:20 INFO: [core] [pick-first-lb 0xc00039ccc0] Received SubConn state update: 0xc00039ce40, {ConnectivityState:READY ConnectionError:<nil>}
2024/02/22 00:39:20 INFO: [core] [Channel #2] Channel Connectivity change to READY
2024/02/22 00:39:20 INFO: [xds] [xds-client 0xc00034adc0] [trafficdirector.googleapis.com:443] ADS stream created
2024/02/22 00:39:20 INFO: [xds] [xds-client 0xc00034adc0] [trafficdirector.googleapis.com:443] ADS request sent: {
  "node":  {
    "id":  "projects/439293274322/networks/default/nodes/c51c7df5-68d2-40c2-bc7b-513817204bad",
    "cluster":  "cluster",
    "metadata":  {
      "INSTANCE_IP":  "10.116.2.7",
      "TRAFFICDIRECTOR_GRPC_BOOTSTRAP_GENERATOR_SHA":  "3149e0342ac92c92d89feaacc96d9d2f511f5b97"
    },
    "locality":  {
      "zone":  "us-west2-a"
    },
    "userAgentName":  "gRPC Go",
    "userAgentVersion":  "1.63.0-dev",
    "clientFeatures":  [
      "envoy.lb.does_not_support_overprovisioning",
      "xds.config.resource-in-sotw"
    ]
  },
  "resourceNames":  [
    "xdstp://traffic-director-global.xds.googleapis.com/envoy.config.listener.v3.Listener/439293274322/default/helloworld-gke:8000"
  ],
  "typeUrl":  "type.googleapis.com/envoy.config.listener.v3.Listener"
}
2024/02/22 00:39:20 INFO: [xds] [xds-client 0xc00034adc0] [trafficdirector.googleapis.com:443] ADS response received: {
  "versionInfo":  "1708544016622413917",
  "resources":  [
    {
      "@type":  "type.googleapis.com/envoy.config.listener.v3.Listener",
      "name":  "xdstp://traffic-director-global.xds.googleapis.com/envoy.config.listener.v3.Listener/439293274322/default/helloworld-gke:8000",
      "apiListener":  {
        "apiListener":  {
          "@type":  "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
          "statPrefix":  "trafficdirector",
          "rds":  {
            "configSource":  {
              "ads":  {},
              "resourceApiVersion":  "V3"
            },
            "routeConfigName":  "URL_MAP/439293274322_grpc-gke-url-map_0_helloworld-gke:8000"
          },
          "httpFilters":  [
            {
              "name":  "envoy.filters.http.fault",
              "typedConfig":  {
                "@type":  "type.googleapis.com/envoy.extensions.filters.http.fault.v3.HTTPFault"
              }
            },
            {
              "name":  "envoy.filters.http.router",
              "typedConfig":  {
                "@type":  "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router",
                "suppressEnvoyHeaders":  true
              }
            }
          ],
          "normalizePath":  true,
          "mergeSlashes":  true
        }
      }
    }
  ],
  "typeUrl":  "type.googleapis.com/envoy.config.listener.v3.Listener",
  "nonce":  "1"
}
2024/02/22 00:39:20 INFO: [xds] [xds-client 0xc00034adc0] [trafficdirector.googleapis.com:443] Resource type "ListenerResource" with name "xdstp://traffic-director-global.xds.googleapis.com/envoy.config.listener.v3.Listener/439293274322/default/helloworld-gke:8000" added to cache
2024/02/22 00:39:20 INFO: [xds] [xds-client 0xc00034adc0] [trafficdirector.googleapis.com:443] Sending ACK for resource type: "type.googleapis.com/envoy.config.listener.v3.Listener", version: "1708544016622413917", nonce: "1"
2024/02/22 00:39:20 INFO: [xds] [xds-client 0xc00034adc0] [trafficdirector.googleapis.com:443] ADS request sent: {
  "versionInfo":  "1708544016622413917",
  "resourceNames":  [
    "xdstp://traffic-director-global.xds.googleapis.com/envoy.config.listener.v3.Listener/439293274322/default/helloworld-gke:8000"
  ],
  "typeUrl":  "type.googleapis.com/envoy.config.listener.v3.Listener",
  "responseNonce":  "1"
}
2024/02/22 00:39:20 INFO: [xds] [xds-resolver 0xc0002fc5a0] Received update for Listener resource "xdstp://traffic-director-global.xds.googleapis.com/envoy.config.listener.v3.Listener/439293274322/default/helloworld-gke:8000": {
  "RouteConfigName": "URL_MAP/439293274322_grpc-gke-url-map_0_helloworld-gke:8000",
  "InlineRouteConfig": null,
  "MaxStreamDuration": 0,
  "HTTPFilters": [
    {
      "Name": "envoy.filters.http.fault",
      "Filter": {},
      "Config": {
        "FilterConfig": null
      }
    },
    {
      "Name": "envoy.filters.http.router",
      "Filter": {},
      "Config": {
        "FilterConfig": null
      }
    }
  ],
  "InboundListenerCfg": null,
  "Raw": {
    "type_url": "type.googleapis.com/envoy.config.listener.v3.Listener",
    "value": "Cn14ZHN0cDovL3RyYWZmaWMtZGlyZWN0b3ItZ2xvYmFsLnhkcy5nb29nbGVhcGlzLmNvbS9lbnZveS5jb25maWcubGlzdGVuZXIudjMuTGlzdGVuZXIvNDM5MjkzMjc0MzIyL2RlZmF1bHQvaGVsbG93b3JsZC1na2U6ODAwMJoBlgMKkwMKZXR5cGUuZ29vZ2xlYXBpcy5jb20vZW52b3kuZXh0ZW5zaW9ucy5maWx0ZXJzLm5ldHdvcmsuaHR0cF9jb25uZWN0aW9uX21hbmFnZXIudjMuSHR0cENvbm5lY3Rpb25NYW5hZ2VyEqkCEg90cmFmZmljZGlyZWN0b3IaQwoEGgAwAhI7VVJMX01BUC80MzkyOTMyNzQzMjJfZ3JwYy1na2UtdXJsLW1hcF8wX2hlbGxvd29ybGQtZ2tlOjgwMDAqYgoYZW52b3kuZmlsdGVycy5odHRwLmZhdWx0IkYKRHR5cGUuZ29vZ2xlYXBpcy5jb20vZW52b3kuZXh0ZW5zaW9ucy5maWx0ZXJzLmh0dHAuZmF1bHQudjMuSFRUUEZhdWx0KmUKGWVudm95LmZpbHRlcnMuaHR0cC5yb3V0ZXIiSApCdHlwZS5nb29nbGVhcGlzLmNvbS9lbnZveS5leHRlbnNpb25zLmZpbHRlcnMuaHR0cC5yb3V0ZXIudjMuUm91dGVyEgIgAfIBAggBiAIB"
  }
}
2024/02/22 00:39:20 INFO: [xds] [xds-client 0xc00034adc0] [trafficdirector.googleapis.com:443] New watch for type "RouteConfigResource", resource name "URL_MAP/439293274322_grpc-gke-url-map_0_helloworld-gke:8000"
2024/02/22 00:39:20 INFO: [xds] [xds-client 0xc00034adc0] [trafficdirector.googleapis.com:443] First watch for type "RouteConfigResource", resource name "URL_MAP/439293274322_grpc-gke-url-map_0_helloworld-gke:8000"
2024/02/22 00:39:20 INFO: [xds] [xds-client 0xc00034adc0] [trafficdirector.googleapis.com:443] ADS request sent: {
  "resourceNames":  [
    "URL_MAP/439293274322_grpc-gke-url-map_0_helloworld-gke:8000"
  ],
  "typeUrl":  "type.googleapis.com/envoy.config.route.v3.RouteConfiguration"
}
2024/02/22 00:39:20 INFO: [xds] [xds-client 0xc00034adc0] [trafficdirector.googleapis.com:443] ADS response received: {
  "versionInfo":  "1708544016622413917",
  "resources":  [
    {
      "@type":  "type.googleapis.com/envoy.config.route.v3.RouteConfiguration",
      "name":  "URL_MAP/439293274322_grpc-gke-url-map_0_helloworld-gke:8000",
      "virtualHosts":  [
        {
          "domains":  [
            "helloworld-gke:8000"
          ],
          "routes":  [
            {
              "name":  "URL_MAP/439293274322_grpc-gke-url-map_0_helloworld-gke:8000-route-0",
              "match":  {
                "prefix":  ""
              },
              "route":  {
                "cluster":  "cloud-internal-istio:cloud_mp_439293274322_77023378241484717",
                "timeout":  "30s",
                "retryPolicy":  {
                  "retryOn":  "gateway-error",
                  "numRetries":  1,
                  "perTryTimeout":  "30s"
                }
              }
            }
          ]
        }
      ]
    }
  ],
  "typeUrl":  "type.googleapis.com/envoy.config.route.v3.RouteConfiguration",
  "nonce":  "1"
}
2024/02/22 00:39:20 INFO: [xds] [xds-client 0xc00034adc0] [trafficdirector.googleapis.com:443] Resource type "RouteConfigResource" with name "URL_MAP/439293274322_grpc-gke-url-map_0_helloworld-gke:8000" added to cache
2024/02/22 00:39:20 INFO: [xds] [xds-client 0xc00034adc0] [trafficdirector.googleapis.com:443] Sending ACK for resource type: "type.googleapis.com/envoy.config.route.v3.RouteConfiguration", version: "1708544016622413917", nonce: "1"
2024/02/22 00:39:20 INFO: [xds] [xds-resolver 0xc0002fc5a0] Received update for RouteConfiguration resource "URL_MAP/439293274322_grpc-gke-url-map_0_helloworld-gke:8000": {
  "VirtualHosts": [
    {
      "Domains": [
        "helloworld-gke:8000"
      ],
      "Routes": [
        {
          "Path": null,
          "Prefix": "",
          "Regex": null,
          "CaseInsensitive": false,
          "Headers": null,
          "Fraction": null,
          "HashPolicies": null,
          "MaxStreamDuration": null,
          "HTTPFilterConfigOverride": null,
          "RetryConfig": {
            "RetryOn": null,
            "NumRetries": 0,
            "RetryBackoff": {
              "BaseInterval": 0,
              "MaxInterval": 0
            }
          },
          "ActionType": 1,
          "WeightedClusters": {
            "cloud-internal-istio:cloud_mp_439293274322_77023378241484717": {
              "Weight": 1,
              "HTTPFilterConfigOverride": null
            }
          },
          "ClusterSpecifierPlugin": ""
        }
      ],
      "HTTPFilterConfigOverride": null,
      "RetryConfig": null
    }
  ],
  "ClusterSpecifierPlugins": {},
  "Raw": {
    "type_url": "type.googleapis.com/envoy.config.route.v3.RouteConfiguration",
    "value": "CjtVUkxfTUFQLzQzOTI5MzI3NDMyMl9ncnBjLWdrZS11cmwtbWFwXzBfaGVsbG93b3JsZC1na2U6ODAwMBK+ARITaGVsbG93b3JsZC1na2U6ODAwMBqmAQoCCgASWwo8Y2xvdWQtaW50ZXJuYWwtaXN0aW86Y2xvdWRfbXBfNDM5MjkzMjc0MzIyXzc3MDIzMzc4MjQxNDg0NzE3QgIIHkoXCg1nYXRld2F5LWVycm9yEgIIARoCCB5yQ1VSTF9NQVAvNDM5MjkzMjc0MzIyX2dycGMtZ2tlLXVybC1tYXBfMF9oZWxsb3dvcmxkLWdrZTo4MDAwLXJvdXRlLTA="
  }
}
2024/02/22 00:39:20 INFO: [xds] [xds-resolver 0xc0002fc5a0] For Listener resource "xdstp://traffic-director-global.xds.googleapis.com/envoy.config.listener.v3.Listener/439293274322/default/helloworld-gke:8000" and RouteConfiguration resource "URL_MAP/439293274322_grpc-gke-url-map_0_helloworld-gke:8000", generated service config: {
  "loadBalancingConfig": [
    {
      "xds_cluster_manager_experimental": {
        "children": {
          "cluster:cloud-internal-istio:cloud_mp_439293274322_77023378241484717": {
            "childPolicy": [
              {
                "cds_experimental": {
                  "cluster": "cloud-internal-istio:cloud_mp_439293274322_77023378241484717"
                }
              }
            ]
          }
        }
      }
    }
  ]
}
2024/02/22 00:39:20 INFO: [core] [Channel #1] Resolver state updated: {
  "Addresses": null,
  "Endpoints": [],
  "ServiceConfig": {
    "Config": {
      "Config": null,
      "LB": null,
      "Methods": {}
    },
    "Err": null
  },
  "Attributes": {
    "\u003c%!p(resolver.csKeyType=grpc.internal.resolver.configSelector)\u003e": "\u003c0xc0000aa4b0\u003e",
    "\u003c%!p(xdsclient.clientKeyType=grpc.xds.internal.client.Client)\u003e": "\u003c0xc0003598a0\u003e"
  }
} (service config updated)
2024/02/22 00:39:20 INFO: [core] [Channel #1] Channel switches to new LB policy "xds_cluster_manager_experimental"
2024/02/22 00:39:20 INFO: [xds] [xds-client 0xc00034adc0] [trafficdirector.googleapis.com:443] ADS request sent: {
  "versionInfo":  "1708544016622413917",
  "resourceNames":  [
    "URL_MAP/439293274322_grpc-gke-url-map_0_helloworld-gke:8000"
  ],
  "typeUrl":  "type.googleapis.com/envoy.config.route.v3.RouteConfiguration",
  "responseNonce":  "1"
}
2024/02/22 00:39:20 INFO: [xds] [xds-cluster-manager-lb 0xc00007b2e0] Created
2024/02/22 00:39:20 INFO: [xds] [xds-cluster-manager-lb 0xc00007b2e0] update with config {
  "LoadBalancingConfig": null,
  "Children": {
    "cluster:cloud-internal-istio:cloud_mp_439293274322_77023378241484717": {
      "ChildPolicy": [
        {
          "cds_experimental": {
            "LoadBalancingConfig": null,
            "Cluster": "cloud-internal-istio:cloud_mp_439293274322_77023378241484717"
          }
        }
      ]
    }
  }
}, resolver state {Addresses:[] Endpoints:[] ServiceConfig:0xc00007b240 Attributes:{"<%!p(resolver.csKeyType=grpc.internal.resolver.configSelector)>": "<0xc0000aa4b0>" , "<%!p(xdsclient.clientKeyType=grpc.xds.internal.client.Client)>": "<0xc0003598a0>" }}
2024/02/22 00:39:20 INFO: [xds] [xds-cluster-manager-lb 0xc00007b2e0] Adding child policy of type "cds_experimental" for locality "cluster:cloud-internal-istio:cloud_mp_439293274322_77023378241484717"
2024/02/22 00:39:20 INFO: [xds] [xds-cluster-manager-lb 0xc00007b2e0] Creating child policy of type "cds_experimental" for locality "cluster:cloud-internal-istio:cloud_mp_439293274322_77023378241484717"
2024/02/22 00:39:20 INFO: [xds] [cds-lb 0xc0004aa180] Created
2024/02/22 00:39:20 INFO: [xds] [cds-lb 0xc0004aa180] xDS credentials in use: false
2024/02/22 00:39:20 INFO: [xds] [cds-lb 0xc0004aa180] Received balancer config update: {
  "LoadBalancingConfig": null,
  "Cluster": "cloud-internal-istio:cloud_mp_439293274322_77023378241484717"
}
2024/02/22 00:39:20 INFO: [xds] [xds-client 0xc00034adc0] [trafficdirector.googleapis.com:443] New watch for type "ClusterResource", resource name "cloud-internal-istio:cloud_mp_439293274322_77023378241484717"
2024/02/22 00:39:20 INFO: [xds] [xds-client 0xc00034adc0] [trafficdirector.googleapis.com:443] First watch for type "ClusterResource", resource name "cloud-internal-istio:cloud_mp_439293274322_77023378241484717"
2024/02/22 00:39:20 INFO: [xds] [xds-client 0xc00034adc0] [trafficdirector.googleapis.com:443] ADS request sent: {
  "resourceNames":  [
    "cloud-internal-istio:cloud_mp_439293274322_77023378241484717"
  ],
  "typeUrl":  "type.googleapis.com/envoy.config.cluster.v3.Cluster"
}
2024/02/22 00:39:20 INFO: [xds] [xds-client 0xc00034adc0] [trafficdirector.googleapis.com:443] ADS response received: {
  "versionInfo":  "1708544016622413917",
  "resources":  [
    {
      "@type":  "type.googleapis.com/envoy.config.cluster.v3.Cluster",
      "name":  "cloud-internal-istio:cloud_mp_439293274322_77023378241484717",
      "altStatName":  "/projects/439293274322/global/backendServices/grpc-gke-helloworld-service",
      "type":  "EDS",
      "edsClusterConfig":  {
        "edsConfig":  {
          "ads":  {},
          "initialFetchTimeout":  "15s",
          "resourceApiVersion":  "V3"
        }
      },
      "connectTimeout":  "30s",
      "circuitBreakers":  {
        "thresholds":  [
          {
            "maxConnections":  2147483647,
            "maxPendingRequests":  2147483647,
            "maxRequests":  2147483647,
            "maxRetries":  2147483647
          }
        ]
      },
      "http2ProtocolOptions":  {
        "maxConcurrentStreams":  100
      },
      "commonLbConfig":  {
        "healthyPanicThreshold":  {
          "value":  1
        },
        "localityWeightedLbConfig":  {}
      },
      "metadata":  {
        "filterMetadata":  {
          "com.google.trafficdirector":  {
            "backend_service_name":  "grpc-gke-helloworld-service",
            "backend_service_project_number":  439293274322
          }
        }
      },
      "lrsServer":  {
        "self":  {}
      }
    }
  ],
  "typeUrl":  "type.googleapis.com/envoy.config.cluster.v3.Cluster",
  "nonce":  "1"
}
2024/02/22 00:39:20 INFO: [xds] [xds-client 0xc00034adc0] [trafficdirector.googleapis.com:443] Resource type "ClusterResource" with name "cloud-internal-istio:cloud_mp_439293274322_77023378241484717" added to cache
2024/02/22 00:39:20 INFO: [xds] [xds-client 0xc00034adc0] [trafficdirector.googleapis.com:443] Sending ACK for resource type: "type.googleapis.com/envoy.config.cluster.v3.Cluster", version: "1708544016622413917", nonce: "1"
2024/02/22 00:39:20 INFO: [xds] [xds-client 0xc00034adc0] [trafficdirector.googleapis.com:443] ADS request sent: {
  "versionInfo":  "1708544016622413917",
  "resourceNames":  [
    "cloud-internal-istio:cloud_mp_439293274322_77023378241484717"
  ],
  "typeUrl":  "type.googleapis.com/envoy.config.cluster.v3.Cluster",
  "responseNonce":  "1"
}
2024/02/22 00:39:20 INFO: [xds] [cds-lb 0xc0004aa180] Received Cluster resource: {
  "ClusterType": 0,
  "ClusterName": "cloud-internal-istio:cloud_mp_439293274322_77023378241484717",
  "EDSServiceName": "",
  "LRSServerConfig": 1,
  "SecurityCfg": null,
  "MaxRequests": 2147483647,
  "DNSHostName": "",
  "PrioritizedClusterNames": null,
  "LBPolicy": [
    {
      "xds_wrr_locality_experimental": {
        "childPolicy": [
          {
            "round_robin": {}
          }
        ]
      }
    }
  ],
  "OutlierDetection": null,
  "Raw": {
    "type_url": "type.googleapis.com/envoy.config.cluster.v3.Cluster",
    "value": "CjxjbG91ZC1pbnRlcm5hbC1pc3RpbzpjbG91ZF9tcF80MzkyOTMyNzQzMjJfNzcwMjMzNzgyNDE0ODQ3MTcQAxoKCggaACICCA8wAiICCB5SIgogEgYI/////wcaBgj/////ByIGCP////8HKgYI/////wdyBBICCGTKAYUBCoIBChpjb20uZ29vZ2xlLnRyYWZmaWNkaXJlY3RvchJkCisKHmJhY2tlbmRfc2VydmljZV9wcm9qZWN0X251bWJlchIJEQCANNr6kVlCCjUKFGJhY2tlbmRfc2VydmljZV9uYW1lEh0aG2dycGMtZ2tlLWhlbGxvd29ybGQtc2VydmljZdoBDQoJCQAAAAAAAPA/GgDiAUkvcHJvamVjdHMvNDM5MjkzMjc0MzIyL2dsb2JhbC9iYWNrZW5kU2VydmljZXMvZ3JwYy1na2UtaGVsbG93b3JsZC1zZXJ2aWNl0gICKgA="
  }
}
2024/02/22 00:39:20 INFO: [xds] [xds-cluster-resolver-lb 0xc00039b380] Created
2024/02/22 00:39:20 INFO: [xds] [cds-lb 0xc0004aa180] Created child policy 0xc00039b380 of type cluster_resolver_experimental
2024/02/22 00:39:20 INFO: [xds] [xds-cluster-resolver-lb 0xc00039b380] Received new balancer config: {
  "discoveryMechanisms": [
    {
      "cluster": "cloud-internal-istio:cloud_mp_439293274322_77023378241484717",
      "lrsLoadReportingServer": {
        "server_uri": "trafficdirector.googleapis.com:443",
        "channel_creds": [
          {
            "type": "google_default"
          }
        ],
        "server_features": [
          "xds_v3"
        ]
      },
      "maxConcurrentRequests": 2147483647,
      "outlierDetection": {}
    }
  ],
  "xdsLbPolicy": [
    {
      "xds_wrr_locality_experimental": {
        "childPolicy": [
          {
            "round_robin": {}
          }
        ]
      }
    }
  ]
}
2024/02/22 00:39:20 INFO: [xds] [xds-client 0xc00034adc0] [trafficdirector.googleapis.com:443] New watch for type "EndpointsResource", resource name "cloud-internal-istio:cloud_mp_439293274322_77023378241484717"
2024/02/22 00:39:20 INFO: [xds] [xds-client 0xc00034adc0] [trafficdirector.googleapis.com:443] First watch for type "EndpointsResource", resource name "cloud-internal-istio:cloud_mp_439293274322_77023378241484717"
2024/02/22 00:39:20 INFO: [xds] [xds-client 0xc00034adc0] [trafficdirector.googleapis.com:443] ADS request sent: {
  "resourceNames":  [
    "cloud-internal-istio:cloud_mp_439293274322_77023378241484717"
  ],
  "typeUrl":  "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment"
}
2024/02/22 00:39:20 INFO: [xds] [xds-client 0xc00034adc0] [trafficdirector.googleapis.com:443] ADS response received: {
  "versionInfo":  "1",
  "resources":  [
    {
      "@type":  "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment",
      "clusterName":  "cloud-internal-istio:cloud_mp_439293274322_77023378241484717",
      "endpoints":  [
        {
          "locality":  {
            "subZone":  "hg:us-west2-a_5349090172098836088_neg"
          },
          "lbEndpoints":  [
            {
              "endpoint":  {
                "address":  {
                  "socketAddress":  {
                    "address":  "10.116.1.8",
                    "portValue":  50051
                  }
                }
              },
              "healthStatus":  "HEALTHY"
            },
            {
              "endpoint":  {
                "address":  {
                  "socketAddress":  {
                    "address":  "10.116.2.6",
                    "portValue":  50051
                  }
                }
              },
              "healthStatus":  "HEALTHY"
            }
          ],
          "loadBalancingWeight":  1000000
        }
      ]
    }
  ],
  "typeUrl":  "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment",
  "nonce":  "1"
}
2024/02/22 00:39:20 INFO: [xds] [xds-client 0xc00034adc0] [trafficdirector.googleapis.com:443] Resource type "EndpointsResource" with name "cloud-internal-istio:cloud_mp_439293274322_77023378241484717" added to cache
2024/02/22 00:39:20 INFO: [xds] [xds-client 0xc00034adc0] [trafficdirector.googleapis.com:443] Sending ACK for resource type: "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment", version: "1", nonce: "1"
2024/02/22 00:39:20 INFO: [xds] [xds-client 0xc00034adc0] [trafficdirector.googleapis.com:443] ADS request sent: {
  "versionInfo":  "1",
  "resourceNames":  [
    "cloud-internal-istio:cloud_mp_439293274322_77023378241484717"
  ],
  "typeUrl":  "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment",
  "responseNonce":  "1"
}

                    ],
                    "server_features": [
                      "xds_v3"
                    ]
                  },
                  "maxConcurrentRequests": 2147483647,
                  "childPolicy": [
                    {
                      "xds_wrr_locality_experimental": {
                        "childPolicy": [
                          {
                            "round_robin": {}
                          }
                        ]
                      }
                    }
                  ]
                }
              }
            ]
          }
        }
      ],
      "ignoreReresolutionRequests": true
    }
  },
  "priorities": [
    "priority-0-0"
  ]
}
2024/02/22 00:39:20 INFO: [xds] [priority-lb 0xc000294770] Received an update with balancer config: {
  "children": {
    "priority-0-0": {
      "config": [
        {
          "outlier_detection_experimental": {
            "interval": "10s",
            "baseEjectionTime": "30s",
            "maxEjectionTime": "300s",
            "maxEjectionPercent": 10,
            "childPolicy": [
              {
                "xds_cluster_impl_experimental": {
                  "cluster": "cloud-internal-istio:cloud_mp_439293274322_77023378241484717",
                  "lrsLoadReportingServer": {
                    "server_uri": "trafficdirector.googleapis.com:443",
                    "channel_creds": [
                      {
                        "type": "google_default"
                      }
                    ],
                    "server_features": [
                      "xds_v3"
                    ]
                  },
                  "maxConcurrentRequests": 2147483647,
                  "childPolicy": [
                    {
                      "xds_wrr_locality_experimental": {
                        "childPolicy": [
                          {
                            "round_robin": {}
                          }
                        ]
                      }
                    }
                  ]
                }
              }
            ]
          }
        }
      ],
      "ignoreReresolutionRequests": true
    }
  },
  "priorities": [
    "priority-0-0"
  ]
}
2024/02/22 00:39:20 INFO: [xds] [priority-lb 0xc000294770] childInUse, childUpdating: "", "priority-0-0"
2024/02/22 00:39:20 INFO: [xds] [xds-cluster-manager-lb 0xc00007b2e0] Balancer state update from locality cluster:cloud-internal-istio:cloud_mp_439293274322_77023378241484717, new state: {ConnectivityState:CONNECTING Picker:0xc0003c0ce0}
2024/02/22 00:39:20 INFO: [xds] [xds-cluster-manager-lb 0xc00007b2e0] Child pickers: map[cluster:cloud-internal-istio:cloud_mp_439293274322_77023378241484717:picker:0xc0003c0ce0,state:CONNECTING,stateToAggregate:CONNECTING]
2024/02/22 00:39:20 INFO: [core] [Channel #1] Channel Connectivity change to CONNECTING
2024/02/22 00:39:20 INFO: [xds] [priority-lb 0xc000294770] Switching to ("priority-0-0", 0) in syncPriority
2024/02/22 00:39:20 INFO: [xds] [priority-lb 0xc000294770] Adding child policy of type "outlier_detection_experimental" for locality "priority-0-0"
2024/02/22 00:39:20 INFO: [xds] [priority-lb 0xc000294770] Creating child policy of type "outlier_detection_experimental" for locality "priority-0-0"
2024/02/22 00:39:20 INFO: [xds] [outlier-detection-lb 0xc00052a180] Created
2024/02/22 00:39:20 INFO: [xds] [xds-cluster-impl-lb 0xc00033b200] Created
2024/02/22 00:39:20 INFO: [xds] [xds-cluster-impl-lb 0xc00033b200] Received update from resolver, balancer config: {
  "cluster": "cloud-internal-istio:cloud_mp_439293274322_77023378241484717",
  "lrsLoadReportingServer": {
    "server_uri": "trafficdirector.googleapis.com:443",
    "channel_creds": [
      {
        "type": "google_default"
      }
    ],
    "server_features": [
      "xds_v3"
    ]
  },
  "maxConcurrentRequests": 2147483647,
  "childPolicy": [
    {
      "xds_wrr_locality_experimental": {
        "childPolicy": [
          {
            "round_robin": {}
          }
        ]
      }
    }
  ]
}
2024/02/22 00:39:20 INFO: [xds] [weighted-target-lb 0xc0002da4e0] Created
2024/02/22 00:39:20 INFO: [xds] [wrrlocality-lb 0xc000475f20] Created
2024/02/22 00:39:20 INFO: [xds] [xds-client 0xc00034adc0] [trafficdirector.googleapis.com:443] Created LRS stream to server "trafficdirector.googleapis.com:443"
2024/02/22 00:39:20 INFO: [xds] [weighted-target-lb 0xc0002da4e0] Received update from resolver, balancer config: {
  "targets": {
    "{\"subZone\":\"hg:us-west2-a_5349090172098836088_neg\"}": {
      "weight": 1000000,
      "childPolicy": [
        {
          "round_robin": {}
        }
      ]
    }
  }
}
2024/02/22 00:39:20 INFO: [xds] [weighted-target-lb 0xc0002da4e0] Adding child policy of type "round_robin" for locality "{\"subZone\":\"hg:us-west2-a_5349090172098836088_neg\"}"
2024/02/22 00:39:20 INFO: [xds] [weighted-target-lb 0xc0002da4e0] Creating child policy of type "round_robin" for locality "{\"subZone\":\"hg:us-west2-a_5349090172098836088_neg\"}"
2024/02/22 00:39:20 INFO: [balancer] base.baseBalancer: got new ClientConn state:  {{[{Addr: "10.116.1.8:50051", ServerName: "", BalancerAttributes: {"<%!p(wrrlocality.attributeKey={})>": "Locality Weight: 1000000" , "<%!p(hierarchy.pathKeyType=grpc.internal.address.hierarchical_path)>": "<0xc00007be70>" , "<%!p(internal.localityKeyType=grpc.xds.internal.address.locality)>": "<%!p(internal.LocalityID={  hg:us-west2-a_5349090172098836088_neg})>" , "<%!p(weightedroundrobin.attributeKey={})>": "Weight: 1000000" }} {Addr: "10.116.2.6:50051", ServerName: "", BalancerAttributes: {"<%!p(wrrlocality.attributeKey={})>": "Locality Weight: 1000000" , "<%!p(weightedroundrobin.attributeKey={})>": "Weight: 1000000" , "<%!p(hierarchy.pathKeyType=grpc.internal.address.hierarchical_path)>": "<0xc00007beb0>" , "<%!p(internal.localityKeyType=grpc.xds.internal.address.locality)>": "<%!p(internal.LocalityID={  hg:us-west2-a_5349090172098836088_neg})>" }}] [] <nil> {"<%!p(xdsclient.clientKeyType=grpc.xds.internal.client.Client)>": "<0xc0003598a0>" }} <nil>}
2024/02/22 00:39:20 INFO: [core] [Channel #1 SubChannel #5] Subchannel created
2024/02/22 00:39:20 INFO: [core] [Channel #1 SubChannel #6] Subchannel created
2024/02/22 00:39:20 INFO: [roundrobin] roundrobinPicker: Build called with info: {map[]}
2024/02/22 00:39:20 INFO: [xds] [weighted-target-lb 0xc0002da4e0] Balancer state update from locality {"subZone":"hg:us-west2-a_5349090172098836088_neg"}, new state: {ConnectivityState:CONNECTING Picker:0xc0003a4980}
2024/02/22 00:39:20 INFO: [xds] [weighted-target-lb 0xc0002da4e0] Child pickers with config: map[{"subZone":"hg:us-west2-a_5349090172098836088_neg"}:weight:1000000,picker:0xc0003a4980,state:CONNECTING,stateToAggregate:CONNECTING]
2024/02/22 00:39:20 INFO: [core] [Channel #1 SubChannel #5] Subchannel Connectivity change to CONNECTING
2024/02/22 00:39:20 INFO: [core] [Channel #1 SubChannel #5] Subchannel picks a new address "10.116.1.8:50051" to connect
2024/02/22 00:39:20 INFO: [core] [Channel #1 SubChannel #6] Subchannel Connectivity change to CONNECTING
2024/02/22 00:39:20 INFO: [core] [Channel #1 SubChannel #6] Subchannel picks a new address "10.116.2.6:50051" to connect
2024/02/22 00:39:20 INFO: [xds] [xds-client 0xc00034adc0] [trafficdirector.googleapis.com:443] Sending initial LoadStatsRequest: {
  "node":  {
    "id":  "projects/439293274322/networks/default/nodes/c51c7df5-68d2-40c2-bc7b-513817204bad",
    "cluster":  "cluster",
    "metadata":  {
      "INSTANCE_IP":  "10.116.2.7",
      "TRAFFICDIRECTOR_GRPC_BOOTSTRAP_GENERATOR_SHA":  "3149e0342ac92c92d89feaacc96d9d2f511f5b97"
    },
    "locality":  {
      "zone":  "us-west2-a"
    },
    "userAgentName":  "gRPC Go",
    "userAgentVersion":  "1.63.0-dev",
    "clientFeatures":  [
      "envoy.lb.does_not_support_overprovisioning",
      "xds.config.resource-in-sotw",
      "envoy.lrs.supports_send_all_clusters"
    ]
  }
}
2024/02/22 00:39:20 INFO: [xds] [priority-lb 0xc000294770] Balancer state update from locality priority-0-0, new state: {ConnectivityState:CONNECTING Picker:0xc0000c5818}
2024/02/22 00:39:20 INFO: [balancer] base.baseBalancer: handle SubConn state change: 0xc0002dab00, CONNECTING
2024/02/22 00:39:20 INFO: [xds] [weighted-target-lb 0xc0002da4e0] Balancer state update from locality {"subZone":"hg:us-west2-a_5349090172098836088_neg"}, new state: {ConnectivityState:CONNECTING Picker:0xc0003a4980}
2024/02/22 00:39:20 INFO: [xds] [weighted-target-lb 0xc0002da4e0] Child pickers with config: map[{"subZone":"hg:us-west2-a_5349090172098836088_neg"}:weight:1000000,picker:0xc0003a4980,state:CONNECTING,stateToAggregate:CONNECTING]
2024/02/22 00:39:20 INFO: [balancer] base.baseBalancer: handle SubConn state change: 0xc0002dad20, CONNECTING
2024/02/22 00:39:20 INFO: [xds] [priority-lb 0xc000294770] childInUse, childUpdating: "priority-0-0", "priority-0-0"
2024/02/22 00:39:20 INFO: [xds] [xds-cluster-manager-lb 0xc00007b2e0] Balancer state update from locality cluster:cloud-internal-istio:cloud_mp_439293274322_77023378241484717, new state: {ConnectivityState:CONNECTING Picker:0xc0000c5818}
2024/02/22 00:39:20 INFO: [xds] [xds-cluster-manager-lb 0xc00007b2e0] Child pickers: map[cluster:cloud-internal-istio:cloud_mp_439293274322_77023378241484717:picker:0xc0000c5818,state:CONNECTING,stateToAggregate:CONNECTING]
2024/02/22 00:39:20 INFO: [xds] [priority-lb 0xc000294770] Switching to ("priority-0-0", 0) in syncPriority
2024/02/22 00:39:20 INFO: [xds] [weighted-target-lb 0xc0002da4e0] Balancer state update from locality {"subZone":"hg:us-west2-a_5349090172098836088_neg"}, new state: {ConnectivityState:CONNECTING Picker:0xc0003a4980}
2024/02/22 00:39:20 INFO: [xds] [weighted-target-lb 0xc0002da4e0] Child pickers with config: map[{"subZone":"hg:us-west2-a_5349090172098836088_neg"}:weight:1000000,picker:0xc0003a4980,state:CONNECTING,stateToAggregate:CONNECTING]
2024/02/22 00:39:20 INFO: [xds] [priority-lb 0xc000294770] Balancer state update from locality priority-0-0, new state: {ConnectivityState:CONNECTING Picker:0xc0005ed668}
2024/02/22 00:39:20 INFO: [xds] [priority-lb 0xc000294770] Balancer state update from locality priority-0-0, new state: {ConnectivityState:CONNECTING Picker:0xc0005ed698}
2024/02/22 00:39:20 INFO: [xds] [priority-lb 0xc000294770] childInUse, childUpdating: "priority-0-0", "priority-0-0"
2024/02/22 00:39:20 INFO: [core] [Channel #1 SubChannel #5] Subchannel Connectivity change to READY
2024/02/22 00:39:20 INFO: [xds] [xds-cluster-manager-lb 0xc00007b2e0] Balancer state update from locality cluster:cloud-internal-istio:cloud_mp_439293274322_77023378241484717, new state: {ConnectivityState:CONNECTING Picker:0xc0005ed668}
2024/02/22 00:39:20 INFO: [xds] [xds-cluster-manager-lb 0xc00007b2e0] Child pickers: map[cluster:cloud-internal-istio:cloud_mp_439293274322_77023378241484717:picker:0xc0005ed668,state:CONNECTING,stateToAggregate:CONNECTING]
2024/02/22 00:39:20 INFO: [xds] [priority-lb 0xc000294770] Switching to ("priority-0-0", 0) in syncPriority
2024/02/22 00:39:20 INFO: [xds] [priority-lb 0xc000294770] childInUse, childUpdating: "priority-0-0", "priority-0-0"
2024/02/22 00:39:20 INFO: [xds] [xds-cluster-manager-lb 0xc00007b2e0] Balancer state update from locality cluster:cloud-internal-istio:cloud_mp_439293274322_77023378241484717, new state: {ConnectivityState:CONNECTING Picker:0xc0005ed698}
2024/02/22 00:39:20 INFO: [xds] [xds-cluster-manager-lb 0xc00007b2e0] Child pickers: map[cluster:cloud-internal-istio:cloud_mp_439293274322_77023378241484717:picker:0xc0005ed698,state:CONNECTING,stateToAggregate:CONNECTING]
2024/02/22 00:39:20 INFO: [xds] [priority-lb 0xc000294770] Switching to ("priority-0-0", 0) in syncPriority
2024/02/22 00:39:20 INFO: [balancer] base.baseBalancer: handle SubConn state change: 0xc0002dab00, READY
2024/02/22 00:39:20 INFO: [roundrobin] roundrobinPicker: Build called with info: {map[0xc0002dab00:{{Addr: "10.116.1.8:50051", ServerName: "", BalancerAttributes: {"<%!p(wrrlocality.attributeKey={})>": "Locality Weight: 1000000" , "<%!p(hierarchy.pathKeyType=grpc.internal.address.hierarchical_path)>": "<0xc00007be70>" , "<%!p(internal.localityKeyType=grpc.xds.internal.address.locality)>": "<%!p(internal.LocalityID={  hg:us-west2-a_5349090172098836088_neg})>" , "<%!p(weightedroundrobin.attributeKey={})>": "Weight: 1000000" }}}]}
2024/02/22 00:39:20 INFO: [xds] [weighted-target-lb 0xc0002da4e0] Balancer state update from locality {"subZone":"hg:us-west2-a_5349090172098836088_neg"}, new state: {ConnectivityState:READY Picker:0xc0002db0c0}
2024/02/22 00:39:20 INFO: [xds] [weighted-target-lb 0xc0002da4e0] Child pickers with config: map[{"subZone":"hg:us-west2-a_5349090172098836088_neg"}:weight:1000000,picker:0xc0002db0c0,state:READY,stateToAggregate:READY]
2024/02/22 00:39:20 INFO: [xds] [priority-lb 0xc000294770] Balancer state update from locality priority-0-0, new state: {ConnectivityState:READY Picker:0xc000516000}
2024/02/22 00:39:20 INFO: [xds] [priority-lb 0xc000294770] childInUse, childUpdating: "priority-0-0", "priority-0-0"
2024/02/22 00:39:20 INFO: [xds] [xds-cluster-manager-lb 0xc00007b2e0] Balancer state update from locality cluster:cloud-internal-istio:cloud_mp_439293274322_77023378241484717, new state: {ConnectivityState:READY Picker:0xc000516000}
2024/02/22 00:39:20 INFO: [xds] [xds-cluster-manager-lb 0xc00007b2e0] Child pickers: map[cluster:cloud-internal-istio:cloud_mp_439293274322_77023378241484717:picker:0xc000516000,state:READY,stateToAggregate:READY]
2024/02/22 00:39:20 INFO: [core] [Channel #1] Channel Connectivity change to READY
2024/02/22 00:39:20 INFO: [xds] [priority-lb 0xc000294770] Switching to ("priority-0-0", 0) in syncPriority
2024/02/22 00:39:20 Greeting: Hello world, from app1-75956dfb7c-z7brj
2024/02/22 00:39:20 INFO: [core] [Channel #1 SubChannel #6] Subchannel Connectivity change to READY
2024/02/22 00:39:20 INFO: [core] [Channel #1] Channel Connectivity change to SHUTDOWN
2024/02/22 00:39:20 INFO: [core] [Channel #1] Closing the name resolver
2024/02/22 00:39:20 INFO: [core] [Channel #1] ccBalancerWrapper: closing
2024/02/22 00:39:20 INFO: [xds] [xds-client 0xc00034adc0] [trafficdirector.googleapis.com:443] Removing last watch for type "ClusterResource", resource name "cloud-internal-istio:cloud_mp_439293274322_77023378241484717"
2024/02/22 00:39:20 INFO: [xds] [xds-client 0xc00034adc0] [trafficdirector.googleapis.com:443] Removing last watch for type "EndpointsResource", resource name "cloud-internal-istio:cloud_mp_439293274322_77023378241484717"
2024/02/22 00:39:20 INFO: [xds] [xds-client 0xc00034adc0] [trafficdirector.googleapis.com:443] Removing last watch for type "ListenerResource", resource name "xdstp://traffic-director-global.xds.googleapis.com/envoy.config.listener.v3.Listener/439293274322/default/helloworld-gke:8000"
2024/02/22 00:39:20 INFO: [xds] [xds-resolver 0xc0002fc5a0] Canceling watch on Listener resource "xdstp://traffic-director-global.xds.googleapis.com/envoy.config.listener.v3.Listener/439293274322/default/helloworld-gke:8000"
2024/02/22 00:39:20 INFO: [xds] [xds-client 0xc00034adc0] [trafficdirector.googleapis.com:443] Removing last watch for type "RouteConfigResource", resource name "URL_MAP/439293274322_grpc-gke-url-map_0_helloworld-gke:8000"
2024/02/22 00:39:20 INFO: [xds] [xds-resolver 0xc0002fc5a0] Canceling watch on RouteConfiguration resource "URL_MAP/439293274322_grpc-gke-url-map_0_helloworld-gke:8000"
2024/02/22 00:39:20 INFO: [balancer] base.baseBalancer: handle SubConn state change: 0xc0002dad20, READY
2024/02/22 00:39:20 INFO: [roundrobin] roundrobinPicker: Build called with info: {map[0xc0002dab00:{{Addr: "10.116.1.8:50051", ServerName: "", BalancerAttributes: {"<%!p(internal.localityKeyType=grpc.xds.internal.address.locality)>": "<%!p(internal.LocalityID={  hg:us-west2-a_5349090172098836088_neg})>" , "<%!p(weightedroundrobin.attributeKey={})>": "Weight: 1000000" , "<%!p(wrrlocality.attributeKey={})>": "Locality Weight: 1000000" , "<%!p(hierarchy.pathKeyType=grpc.internal.address.hierarchical_path)>": "<0xc00007be70>" }}} 0xc0002dad20:{{Addr: "10.116.2.6:50051", ServerName: "", BalancerAttributes: {"<%!p(wrrlocality.attributeKey={})>": "Locality Weight: 1000000" , "<%!p(weightedroundrobin.attributeKey={})>": "Weight: 1000000" , "<%!p(hierarchy.pathKeyType=grpc.internal.address.hierarchical_path)>": "<0xc00007beb0>" , "<%!p(internal.localityKeyType=grpc.xds.internal.address.locality)>": "<%!p(internal.LocalityID={  hg:us-west2-a_5349090172098836088_neg})>" }}}]}
2024/02/22 00:39:20 INFO: [xds] [weighted-target-lb 0xc0002da4e0] Balancer state update from locality {"subZone":"hg:us-west2-a_5349090172098836088_neg"}, new state: {ConnectivityState:READY Picker:0xc00051dae0}
2024/02/22 00:39:20 INFO: [xds] [xds-client 0xc00034adc0] [trafficdirector.googleapis.com:443] ADS request sent: {
  "versionInfo":  "1708544016622413917",
  "typeUrl":  "type.googleapis.com/envoy.config.cluster.v3.Cluster",
  "responseNonce":  "1"
}
2024/02/22 00:39:20 INFO: [xds] [weighted-target-lb 0xc0002da4e0] Child pickers with config: map[{"subZone":"hg:us-west2-a_5349090172098836088_neg"}:weight:1000000,picker:0xc00051dae0,state:READY,stateToAggregate:READY]
2024/02/22 00:39:20 WARNING: [xds] [xds-client 0xc00034adc0] [trafficdirector.googleapis.com:443] Watchers not notified since ADS stream failed after having received at least one response: rpc error: code = Canceled desc = context canceled
2024/02/22 00:39:20 WARNING: [xds] [xds-client 0xc00034adc0] [trafficdirector.googleapis.com:443] ADS stream closed: rpc error: code = Canceled desc = context canceled
2024/02/22 00:39:20 INFO: [xds] [xds-cluster-impl-lb 0xc00033b200] Shutdown
2024/02/22 00:39:20 INFO: [xds] [priority-lb 0xc000294770] Removing child policy for locality "priority-0-0"
2024/02/22 00:39:20 INFO: [xds] [xds-cluster-resolver-lb 0xc00039b380] Shutdown
2024/02/22 00:39:20 INFO: [xds] [cds-lb 0xc0004aa180] Shutdown
2024/02/22 00:39:20 INFO: [xds] [xds-cluster-manager-lb 0xc00007b2e0] Shutdown
2024/02/22 00:39:20 INFO: [core] [Channel #2] Channel Connectivity change to SHUTDOWN
2024/02/22 00:39:20 INFO: [core] [Channel #2] Closing the name resolver
2024/02/22 00:39:20 INFO: [core] [Channel #2] ccBalancerWrapper: closing
2024/02/22 00:39:20 INFO: [core] [Channel #2 SubChannel #3] Subchannel Connectivity change to SHUTDOWN
2024/02/22 00:39:20 INFO: [core] [Channel #2 SubChannel #3] Subchannel deleted
2024/02/22 00:39:20 INFO: [transport] [client-transport 0xc0000e0248] Closing: rpc error: code = Canceled desc = grpc: the client connection is closing
2024/02/22 00:39:20 INFO: [transport] [client-transport 0xc0000e0248] loopyWriter exiting with error: transport closed by client
2024/02/22 00:39:20 INFO: [core] [Channel #2] Channel deleted
2024/02/22 00:39:20 INFO: [xds] [xds-client 0xc00034adc0] Shutdown
2024/02/22 00:39:20 INFO: [xds] [xds-resolver 0xc0002fc5a0] Shutdown
2024/02/22 00:39:20 INFO: [core] [Channel #1 SubChannel #5] Subchannel Connectivity change to SHUTDOWN
2024/02/22 00:39:20 INFO: [core] [Channel #1 SubChannel #5] Subchannel deleted
2024/02/22 00:39:20 INFO: [transport] [client-transport 0xc000140b48] Closing: rpc error: code = Canceled desc = grpc: the client connection is closing
2024/02/22 00:39:20 WARNING: [xds] [xds-client 0xc00034adc0] [trafficdirector.googleapis.com:443] Reading from LRS stream failed: failed to receive first LoadStatsResponse: rpc error: code = Canceled desc = grpc: the client connection is closing
2024/02/22 00:39:20 INFO: [transport] [client-transport 0xc000140b48] loopyWriter exiting with error: transport closed by client
2024/02/22 00:39:20 INFO: [core] [Channel #1 SubChannel #6] Subchannel Connectivity change to SHUTDOWN
2024/02/22 00:39:20 INFO: [core] [Channel #1 SubChannel #6] Subchannel deleted
2024/02/22 00:39:20 INFO: [transport] [client-transport 0xc000140d88] Closing: rpc error: code = Canceled desc = grpc: the client connection is closing
2024/02/22 00:39:20 INFO: [transport] [client-transport 0xc000140d88] loopyWriter exiting with error: transport closed by client
2024/02/22 00:39:20 INFO: [core] [Channel #1] Channel deleted
```

</details>



RELEASE NOTES: 

* resolver: Add `Authority` to `resolver.BuildOptions` pass the effective authority of clientconn for which the resolver was built.