### PR TITLE
rpc_util: Throws error if message is larger than MaxRecvMsgSize

### DIFF
--- a/rpc_util.go
+++ b/rpc_util.go
@@ -782,8 +782,20 @@ func decompress(compressor encoding.Compressor, d []byte, maxReceiveMessageSize 
 			// size is used as an estimate to size the buffer, but we
 			// will read more data if available.
 			// +MinRead so ReadFrom will not reallocate if size is correct.
-			buf := bytes.NewBuffer(make([]byte, 0, size+bytes.MinRead))
-			bytesRead, err := buf.ReadFrom(io.LimitReader(dcReader, int64(maxReceiveMessageSize)+1))
+			bufferSize := uint64(size) + bytes.MinRead
+			if bufferSize > math.MaxInt {
+				bufferSize = math.MaxInt
+			}
+			buf := bytes.NewBuffer(make([]byte, 0, int(bufferSize)))
+
+			bytesRead, err := buf.ReadFrom(io.LimitReader(dcReader, int64(maxReceiveMessageSize)))
+			if bytesRead == int64(maxReceiveMessageSize) {
+				b := make([]byte, 1)
+				if n, err := dcReader.Read(b); n > 0 || err != io.EOF {
+					return nil, size + n, fmt.Errorf("overflow: message larger than max size receivable by client (%v bytes)", maxReceiveMessageSize)
+				}
+			}
+
 			return buf.Bytes(), int(bytesRead), err
 		}
 	}


### PR DESCRIPTION
Also prevents int overflow in bufferSize

Fixes #4552 

RELEASE NOTES: none