### PR TITLE
Revert "grpc: Canonicalize string returned by ClientConn.Target() and resolver.Address.String() (#6923)"

### DIFF
--- a/clientconn.go
+++ b/clientconn.go
@@ -883,14 +883,14 @@ func (cc *ClientConn) channelzMetric() *channelz.ChannelInternalMetric {
 	}
 }
 
-// Target returns the canonical target string of the ClientConn.
+// Target returns the target string of the ClientConn.
 //
 // # Experimental
 //
 // Notice: This API is EXPERIMENTAL and may be changed or removed in a
 // later release.
 func (cc *ClientConn) Target() string {
-	return cc.parsedTarget.String()
+	return cc.target
 }
 
 func (cc *ClientConn) incrCallsStarted() {
@@ -1744,6 +1744,7 @@ func (cc *ClientConn) parseTargetAndFindResolver() error {
 	defScheme := resolver.GetDefaultScheme()
 	channelz.Infof(logger, cc.channelzID, "fallback to scheme %q", defScheme)
 	canonicalTarget := defScheme + ":///" + cc.target
+
 	parsedTarget, err = parseTarget(canonicalTarget)
 	if err != nil {
 		channelz.Infof(logger, cc.channelzID, "dial target %q parse failed: %v", canonicalTarget, err)

--- a/clientconn_test.go
+++ b/clientconn_test.go
@@ -808,44 +808,15 @@ func (s) TestMethodConfigDefaultService(t *testing.T) {
 	}
 }
 
-func (s) TestClientConn_Target(t *testing.T) {
-	tests := []struct {
-		name       string
-		addr       string
-		targetWant string
-	}{
-		{
-			name:       "normal-case",
-			addr:       "dns://a.server.com/google.com",
-			targetWant: "dns://a.server.com/google.com",
-		},
-		{
-			name:       "canonical-target-not-specified",
-			addr:       "no.scheme",
-			targetWant: "passthrough:///no.scheme",
-		},
-		{
-			name:       "canonical-target-nonexistent",
-			addr:       "nonexist:///non.existent",
-			targetWant: "passthrough:///nonexist:///non.existent",
-		},
-		{
-			name:       "canonical-target-add-colon-slash",
-			addr:       "dns:hostname:port",
-			targetWant: "dns:///hostname:port",
-		},
+func (s) TestGetClientConnTarget(t *testing.T) {
+	addr := "nonexist:///non.existent"
+	cc, err := Dial(addr, WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("Dial(%s, _) = _, %v, want _, <nil>", addr, err)
 	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			cc, err := Dial(test.addr, WithTransportCredentials(insecure.NewCredentials()))
-			if err != nil {
-				t.Fatalf("Dial(%s, _) = _, %v, want _, <nil>", test.addr, err)
-			}
-			defer cc.Close()
-			if cc.Target() != test.targetWant {
-				t.Fatalf("Target() = %s, want %s", cc.Target(), test.targetWant)
-			}
-		})
+	defer cc.Close()
+	if cc.Target() != addr {
+		t.Fatalf("Target() = %s, want %s", cc.Target(), addr)
 	}
 }
 

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -281,9 +281,9 @@ func (t Target) Endpoint() string {
 	return strings.TrimPrefix(endpoint, "/")
 }
 
-// String returns the canonical string representation of Target.
+// String returns a string representation of Target.
 func (t Target) String() string {
-	return t.URL.Scheme + "://" + t.URL.Host + "/" + t.Endpoint()
+	return t.URL.String()
 }
 
 // Builder creates a resolver that will be used to watch name resolution updates.


### PR DESCRIPTION
This reverts commit 3ae77e65289012f05699aef3567e68eed8ca9293.