### PR TITLE
Send GOAWAY to server on Client Transport Shutdown

### DIFF
--- a/internal/transport/controlbuf.go
+++ b/internal/transport/controlbuf.go
@@ -193,7 +193,7 @@ type goAway struct {
 	code         http2.ErrCode
 	debugData    []byte
 	headsUp      bool
-	closeConnErr error // if set, loopyWriter will exit, resulting in conn closure
+	closeConnErr error // if set, loopyWriter will exit with this error
 }
 
 func (*goAway) isTransportResponseFrame() bool { return false }

--- a/internal/transport/controlbuf.go
+++ b/internal/transport/controlbuf.go
@@ -340,11 +340,9 @@ func (c *controlBuffer) executeAndPut(f func(it any) bool, it cbItem) (bool, err
 	var wakeUp bool
 	c.mu.Lock()
 	if c.err != nil {
-		fmt.Printf("ControlBUf already have error %v: ", c.err)
 		c.mu.Unlock()
 		return false, c.err
 	}
-	fmt.Println("Success putting the goaway")
 	if f != nil {
 		if !f(it) { // f wasn't successful
 			c.mu.Unlock()
@@ -544,7 +542,6 @@ func (l *loopyWriter) run() (err error) {
 		if l.logger.V(logLevel) {
 			l.logger.Infof("loopyWriter exiting with error: %v", err)
 		}
-		l.logger.Infof("loopyWriter exiting with error: %v", err)
 		if !isIOError(err) {
 			l.framer.writer.Flush()
 		}

--- a/internal/transport/controlbuf.go
+++ b/internal/transport/controlbuf.go
@@ -190,10 +190,10 @@ type incomingGoAway struct {
 func (*incomingGoAway) isTransportResponseFrame() bool { return false }
 
 type goAway struct {
-	code      http2.ErrCode
-	debugData []byte
-	headsUp   bool
-	closeConn error // if set, loopyWriter will exit, resulting in conn closure
+	code         http2.ErrCode
+	debugData    []byte
+	headsUp      bool
+	closeConnErr error // if set, loopyWriter will exit, resulting in conn closure
 }
 
 func (*goAway) isTransportResponseFrame() bool { return false }
@@ -340,9 +340,11 @@ func (c *controlBuffer) executeAndPut(f func(it any) bool, it cbItem) (bool, err
 	var wakeUp bool
 	c.mu.Lock()
 	if c.err != nil {
+		fmt.Printf("ControlBUf already have error %v: ", c.err)
 		c.mu.Unlock()
 		return false, c.err
 	}
+	fmt.Println("Success putting the goaway")
 	if f != nil {
 		if !f(it) { // f wasn't successful
 			c.mu.Unlock()
@@ -542,6 +544,7 @@ func (l *loopyWriter) run() (err error) {
 		if l.logger.V(logLevel) {
 			l.logger.Infof("loopyWriter exiting with error: %v", err)
 		}
+		l.logger.Infof("loopyWriter exiting with error: %v", err)
 		if !isIOError(err) {
 			l.framer.writer.Flush()
 		}

--- a/internal/transport/controlbuf.go
+++ b/internal/transport/controlbuf.go
@@ -190,10 +190,10 @@ type incomingGoAway struct {
 func (*incomingGoAway) isTransportResponseFrame() bool { return false }
 
 type goAway struct {
-	code         http2.ErrCode
-	debugData    []byte
-	headsUp      bool
-	closeConnErr error // if set, loopyWriter will exit with this error
+	code      http2.ErrCode
+	debugData []byte
+	headsUp   bool
+	closeConn error // if set, loopyWriter will exit with this error
 }
 
 func (*goAway) isTransportResponseFrame() bool { return false }
@@ -495,21 +495,22 @@ type loopyWriter struct {
 	ssGoAwayHandler func(*goAway) (bool, error)
 }
 
-func newLoopyWriter(s side, fr *framer, cbuf *controlBuffer, bdpEst *bdpEstimator, conn net.Conn, logger *grpclog.PrefixLogger) *loopyWriter {
+func newLoopyWriter(s side, fr *framer, cbuf *controlBuffer, bdpEst *bdpEstimator, conn net.Conn, logger *grpclog.PrefixLogger, goAwayHandler func(*goAway) (bool, error)) *loopyWriter {
 	var buf bytes.Buffer
 	l := &loopyWriter{
-		side:          s,
-		cbuf:          cbuf,
-		sendQuota:     defaultWindowSize,
-		oiws:          defaultWindowSize,
-		estdStreams:   make(map[uint32]*outStream),
-		activeStreams: newOutStreamList(),
-		framer:        fr,
-		hBuf:          &buf,
-		hEnc:          hpack.NewEncoder(&buf),
-		bdpEst:        bdpEst,
-		conn:          conn,
-		logger:        logger,
+		side:            s,
+		cbuf:            cbuf,
+		sendQuota:       defaultWindowSize,
+		oiws:            defaultWindowSize,
+		estdStreams:     make(map[uint32]*outStream),
+		activeStreams:   newOutStreamList(),
+		framer:          fr,
+		hBuf:            &buf,
+		hEnc:            hpack.NewEncoder(&buf),
+		bdpEst:          bdpEst,
+		conn:            conn,
+		logger:          logger,
+		ssGoAwayHandler: goAwayHandler,
 	}
 	return l
 }

--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -1006,7 +1006,7 @@ func (t *http2Client) Close(err error) {
 	t.mu.Unlock()
 	// Per HTTP/2 spec, a GOAWAY frame must be sent before closing the
 	// connection. See https://httpwg.org/specs/rfc7540.html#GOAWAY.
-	t.controlBuf.put(&goAway{code: http2.ErrCodeNo, debugData: []byte(err.Error()), closeConn: err})
+	t.controlBuf.put(&goAway{code: http2.ErrCodeNo, debugData: []byte("client transport shutdown"), closeConn: err})
 	<-t.writerDone
 	t.cancel()
 	t.conn.Close()

--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -409,7 +409,7 @@ func newHTTP2Client(connectCtx, ctx context.Context, addr resolver.Address, opts
 	go t.reader(readerErrCh)
 	defer func() {
 		if err != nil {
-			// Close writerDone in case of error occurs
+			// writerDone should be closed since the loopy goroutine wouldn't have started in the case this function returns an error.
 			close(t.writerDone)
 			t.Close(err)
 		}

--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -524,7 +524,9 @@ func (t *http2Client) getPeer() *peer.Peer {
 // OutgoingGoAwayHandler writes a GOAWAY to the connection.  Always returns (false, err) as we want the GoAway
 // to be the last frame loopy writes to the transport.
 func (t *http2Client) outgoingGoAwayHandler(g *goAway) (bool, error) {
-	if err := t.framer.fr.WriteGoAway(math.MaxInt32*3/4, http2.ErrCodeNo, g.debugData); err != nil {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if err := t.framer.fr.WriteGoAway(t.nextID-2, http2.ErrCodeNo, g.debugData); err != nil {
 		return false, err
 	}
 	return false, g.closeConn

--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -471,7 +471,6 @@ func newHTTP2Client(connectCtx, ctx context.Context, addr resolver.Address, opts
 		}
 		close(t.writerDone)
 	}()
-
 	return t, nil
 }
 

--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -1002,9 +1002,8 @@ func (t *http2Client) Close(err error) {
 		t.kpDormancyCond.Signal()
 	}
 	t.mu.Unlock()
-	// The HTTP/2 spec mentions that a GOAWAY frame should be sent before a connection close. If this close() function
-	// ever starts to take in an HTTP/2 error code the peer will be able to get more information about the reason
-	// behind the connection close.
+	// Per HTTP/2 spec, a GOAWAY frame must be sent before closing the
+	// connection. See https://httpwg.org/specs/rfc7540.html#GOAWAY.
 	t.controlBuf.put(&goAway{code: http2.ErrCodeNo, debugData: []byte(fmt.Sprintf("client shutdown with: %v", err)), closeConnErr: err})
 	if t.writerDone != nil {
 		<-t.writerDone

--- a/internal/transport/transport_test.go
+++ b/internal/transport/transport_test.go
@@ -2671,7 +2671,9 @@ func (s) TestClientSendsAGoAwayFrame(t *testing.T) {
 	defer lis.Close()
 	// The success channel verifies that the server's reader goroutine received
 	// a GOAWAY frame from the client.
-	success := testutils.NewChannel()
+	greetDone := make(chan struct{})
+	successCh := make(chan struct{})
+	errorCh := make(chan struct{})
 	connectCtx, cancel := context.WithDeadline(context.Background(), time.Now().Add(10*time.Second))
 	defer cancel()
 	// Launch the server.
@@ -2695,69 +2697,53 @@ func (s) TestClientSendsAGoAwayFrame(t *testing.T) {
 			t.Errorf("Error while writing settings %v", err)
 			return
 		}
-		if err := sfr.WriteSettingsAck(); err != nil {
-			t.Errorf("Error while writing settings ack %v", err)
+
+		sfr.ReadFrame()
+		sfr.ReadFrame()
+		sfr.ReadFrame()
+		close(greetDone)
+
+		frame, err := sfr.ReadFrame()
+		if err != nil {
 			return
 		}
-
-		// Read frames off the wire. Should expect to see a GOAWAY frame after
-		// the client closes.
-		for {
-			frame, err := sfr.ReadFrame()
-			if err != nil {
-				return
+		switch fr := frame.(type) {
+		case *http2.GoAwayFrame:
+			// Records that the server successfully received a GOAWAY frame.
+			goAwayFrame := fr
+			if goAwayFrame.ErrCode == http2.ErrCodeNo && string(goAwayFrame.DebugData()) == "graceful_shutdown" {
+				t.Logf("Received goAway frame from client")
+				close(successCh)
+			} else {
+				close(errorCh)
 			}
-			t.Logf("Received frame: %v", frame)
-			switch fr := frame.(type) {
-			case *http2.SettingsFrame:
-				// Do nothing. A settings frame is expected from client preface.
-			case *http2.GoAwayFrame:
-				// Records that the server successfully received a GOAWAY frame.
-				goAwayFrame := fr
-				if goAwayFrame.ErrCode == http2.ErrCodeNo && string(goAwayFrame.DebugData()) == "graceful_stop" {
-					t.Logf("Received goAway frame from client")
-					success.Send(nil)
-				} else {
-					success.Send(errors.New("the server received a frame other than settings or GOAWAY"))
-				}
-				return
-			default:
-				// The client should have sent any frame other than GOAWAY or settings.
-				t.Logf("the server received a frame other than settings or GOAWAY")
-				success.Send(errors.New("the server received a frame other than settings or GOAWAY"))
-				return
-			}
+			return
+		default:
+			// The client should have sent any frame other than GOAWAY
+			t.Logf("The server received a frame other than GOAWAY")
+			return
 		}
 	}()
 
-	dialer := func(ctx context.Context, addr string) (net.Conn, error) {
-		return (&net.Dialer{}).DialContext(ctx, "tcp", addr)
-	}
-	copts := ConnectOptions{
-		Dialer:         dialer,
-		ChannelzParent: channelz.RegisterSubChannel(-1, "test subchannel"),
-	}
-	ct, err := NewClientTransport(connectCtx, context.Background(), resolver.Address{Addr: lis.Addr().String()}, copts, func(GoAwayReason) {})
+	ct, err := NewClientTransport(connectCtx, context.Background(), resolver.Address{Addr: lis.Addr().String()}, ConnectOptions{}, func(GoAwayReason) {})
 	if err != nil {
 		t.Fatalf("Error while creating client transport: %v", err)
 	}
-	callHdr := &CallHdr{
-		Host:   "localhost",
-		Method: "foo.Small",
-	}
-	s1, err1 := ct.NewStream(connectCtx, callHdr)
+	s1, err1 := ct.NewStream(connectCtx, &CallHdr{})
 	if err1 != nil {
 		t.Fatalf("failed to open stream: %v", err1)
 	}
 	if s1.id != 1 {
 		t.Fatalf("wrong stream id: %d", s1.id)
 	}
+	<-greetDone
 	ct.Close(errors.New("manually closed by client"))
 	t.Logf("Closed the client connection")
-	e, err := success.Receive(connectCtx)
-	if e != nil || err != nil {
-		t.Fatalf("Error in frame received: %v. Error receiving from channel: %v", e, err)
-	} else {
-		t.Logf("Server received the GOAWAY from client")
+	select {
+	case <-successCh:
+	case <-errorCh:
+		t.Errorf("Received an unexpected frame")
+	case <-connectCtx.Done():
+		t.Errorf("Timed out")
 	}
 }

--- a/internal/transport/transport_test.go
+++ b/internal/transport/transport_test.go
@@ -2718,14 +2718,12 @@ func (s) TestClientSendsAGoAwayFrame(t *testing.T) {
 				t.Logf("Received goAway frame from client")
 				close(errorCh)
 			} else {
-				t.Logf("Received unexpected goAway frame from client")
-				errorCh <- errors.New("received unexpected goAway frame from client")
+				errorCh <- fmt.Errorf("received unexpected goAway frame: %v", err)
 				close(errorCh)
 			}
 			return
 		default:
-			t.Logf("The server received a frame other than GOAWAY")
-			errorCh <- errors.New("server received a frame other than GOAWAY")
+			errorCh <- fmt.Errorf("server received a frame other than GOAWAY: %v", err)
 			close(errorCh)
 			return
 		}
@@ -2744,13 +2742,11 @@ func (s) TestClientSendsAGoAwayFrame(t *testing.T) {
 	ct.Close(errors.New("manually closed by client"))
 	t.Logf("Closed the client connection")
 	select {
-	case err = <-errorCh:
+	case err := <-errorCh:
+		if err != nil {
+			t.Errorf("Error receiving the GOAWAY frame: %v", err)
+		}
 	case <-ctx.Done():
-		t.Errorf("Timed out")
-	}
-	if err != nil {
-		t.Errorf("Error receiving the GOAWAY frame: %v", err)
-	} else {
-		t.Logf("Received a GOAWAY frame from client")
+		t.Errorf("Context timed out")
 	}
 }

--- a/internal/transport/transport_test.go
+++ b/internal/transport/transport_test.go
@@ -2659,3 +2659,105 @@ func TestConnectionError_Unwrap(t *testing.T) {
 		t.Error("ConnectionError does not unwrap")
 	}
 }
+
+// Test that a transport level client shutdown successfully sends a GOAWAY frame
+// to underlying connection.
+func (s) TestClientSendsAGoAwayFrame(t *testing.T) {
+	// Create a server.
+	lis, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("Error while listening: %v", err)
+	}
+	defer lis.Close()
+	// The success channel verifies that the server's reader goroutine received
+	// a GOAWAY frame from the client.
+	success := testutils.NewChannel()
+	connectCtx, cancel := context.WithDeadline(context.Background(), time.Now().Add(10*time.Second))
+	defer cancel()
+	// Launch the server.
+	go func() {
+		sconn, err := lis.Accept()
+		if err != nil {
+			t.Errorf("Error while accepting: %v", err)
+		}
+		defer func(sconn net.Conn) {
+			err := sconn.Close()
+			if err != nil {
+				return
+			}
+		}(sconn)
+		if _, err := io.ReadFull(sconn, make([]byte, len(clientPreface))); err != nil {
+			t.Errorf("Error while writing settings ack: %v", err)
+			return
+		}
+		sfr := http2.NewFramer(sconn, sconn)
+		if err := sfr.WriteSettings(); err != nil {
+			t.Errorf("Error while writing settings %v", err)
+			return
+		}
+		if err := sfr.WriteSettingsAck(); err != nil {
+			t.Errorf("Error while writing settings ack %v", err)
+			return
+		}
+
+		// Read frames off the wire. Should expect to see a GOAWAY frame after
+		// the client closes.
+		for {
+			frame, err := sfr.ReadFrame()
+			if err != nil {
+				return
+			}
+			t.Logf("Received frame: %v", frame)
+			switch fr := frame.(type) {
+			case *http2.SettingsFrame:
+				// Do nothing. A settings frame is expected from client preface.
+			case *http2.GoAwayFrame:
+				// Records that the server successfully received a GOAWAY frame.
+				goAwayFrame := fr
+				if goAwayFrame.ErrCode == http2.ErrCodeNo && string(goAwayFrame.DebugData()) == "graceful_stop" {
+					t.Logf("Received goAway frame from client")
+					success.Send(nil)
+				} else {
+					success.Send(errors.New("the server received a frame other than settings or GOAWAY"))
+				}
+				return
+			default:
+				// The client should have sent any frame other than GOAWAY or settings.
+				t.Logf("the server received a frame other than settings or GOAWAY")
+				success.Send(errors.New("the server received a frame other than settings or GOAWAY"))
+				return
+			}
+		}
+	}()
+
+	dialer := func(ctx context.Context, addr string) (net.Conn, error) {
+		return (&net.Dialer{}).DialContext(ctx, "tcp", addr)
+	}
+	copts := ConnectOptions{
+		Dialer:         dialer,
+		ChannelzParent: channelz.RegisterSubChannel(-1, "test subchannel"),
+	}
+	ct, err := NewClientTransport(connectCtx, context.Background(), resolver.Address{Addr: lis.Addr().String()}, copts, func(GoAwayReason) {})
+	if err != nil {
+		t.Fatalf("Error while creating client transport: %v", err)
+	}
+	callHdr := &CallHdr{
+		Host:   "localhost",
+		Method: "foo.Small",
+	}
+	s1, err1 := ct.NewStream(connectCtx, callHdr)
+	if err1 != nil {
+		t.Fatalf("failed to open stream: %v", err1)
+	}
+	if s1.id != 1 {
+		t.Fatalf("wrong stream id: %d", s1.id)
+	}
+	ct.Close(errors.New("manually closed by client"))
+	t.Logf("Closed the client connection")
+	e, err := success.Receive(connectCtx)
+	if e != nil || err != nil {
+		t.Fatalf("Error in frame received: %v. Error receiving from channel: %v", e, err)
+	} else {
+		t.Logf("Server received the GOAWAY from client")
+	}
+}

--- a/internal/transport/transport_test.go
+++ b/internal/transport/transport_test.go
@@ -2660,8 +2660,9 @@ func TestConnectionError_Unwrap(t *testing.T) {
 	}
 }
 
-// Test that a transport level client shutdown successfully sends a GOAWAY frame
-// to underlying connection.
+// Test that in the event of a graceful client transport shutdown, i.e.,
+// clientTransport.Close(), client sends a goaway to the server with the correct
+// error code and debug data.
 func (s) TestClientSendsAGoAwayFrame(t *testing.T) {
 	// Create a server.
 	lis, err := net.Listen("tcp", "localhost:0")
@@ -2669,12 +2670,13 @@ func (s) TestClientSendsAGoAwayFrame(t *testing.T) {
 		t.Fatalf("Error while listening: %v", err)
 	}
 	defer lis.Close()
-	// The success channel verifies that the server's reader goroutine received
-	// a GOAWAY frame from the client.
+	// greetDone channel verifies that greet is done with the connection
 	greetDone := make(chan struct{})
+	// successCh verifies that GOAWAY is received at server side
 	successCh := make(chan struct{})
+	// errorCh verifies that desired GOAWAY not received by server
 	errorCh := make(chan struct{})
-	connectCtx, cancel := context.WithDeadline(context.Background(), time.Now().Add(10*time.Second))
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
 	// Launch the server.
 	go func() {
@@ -2682,12 +2684,7 @@ func (s) TestClientSendsAGoAwayFrame(t *testing.T) {
 		if err != nil {
 			t.Errorf("Error while accepting: %v", err)
 		}
-		defer func(sconn net.Conn) {
-			err := sconn.Close()
-			if err != nil {
-				return
-			}
-		}(sconn)
+		defer sconn.Close()
 		if _, err := io.ReadFull(sconn, make([]byte, len(clientPreface))); err != nil {
 			t.Errorf("Error while writing settings ack: %v", err)
 			return
@@ -2711,7 +2708,7 @@ func (s) TestClientSendsAGoAwayFrame(t *testing.T) {
 		case *http2.GoAwayFrame:
 			// Records that the server successfully received a GOAWAY frame.
 			goAwayFrame := fr
-			if goAwayFrame.ErrCode == http2.ErrCodeNo && string(goAwayFrame.DebugData()) == "graceful_shutdown" {
+			if goAwayFrame.ErrCode == http2.ErrCodeNo {
 				t.Logf("Received goAway frame from client")
 				close(successCh)
 			} else {
@@ -2721,21 +2718,20 @@ func (s) TestClientSendsAGoAwayFrame(t *testing.T) {
 		default:
 			// The client should have sent any frame other than GOAWAY
 			t.Logf("The server received a frame other than GOAWAY")
+			close(errorCh)
 			return
 		}
 	}()
 
-	ct, err := NewClientTransport(connectCtx, context.Background(), resolver.Address{Addr: lis.Addr().String()}, ConnectOptions{}, func(GoAwayReason) {})
+	ct, err := NewClientTransport(ctx, context.Background(), resolver.Address{Addr: lis.Addr().String()}, ConnectOptions{}, func(GoAwayReason) {})
 	if err != nil {
 		t.Fatalf("Error while creating client transport: %v", err)
 	}
-	s1, err1 := ct.NewStream(connectCtx, &CallHdr{})
-	if err1 != nil {
-		t.Fatalf("failed to open stream: %v", err1)
+	_, err = ct.NewStream(ctx, &CallHdr{})
+	if err != nil {
+		t.Fatalf("failed to open stream: %v", err)
 	}
-	if s1.id != 1 {
-		t.Fatalf("wrong stream id: %d", s1.id)
-	}
+	// Wait until server receives the headers and settings frame as part of greet
 	<-greetDone
 	ct.Close(errors.New("manually closed by client"))
 	t.Logf("Closed the client connection")
@@ -2743,7 +2739,7 @@ func (s) TestClientSendsAGoAwayFrame(t *testing.T) {
 	case <-successCh:
 	case <-errorCh:
 		t.Errorf("Received an unexpected frame")
-	case <-connectCtx.Done():
+	case <-ctx.Done():
 		t.Errorf("Timed out")
 	}
 }

--- a/test/goaway_test.go
+++ b/test/goaway_test.go
@@ -761,3 +761,66 @@ func (s) TestTwoGoAwayPingFrames(t *testing.T) {
 		t.Fatalf("Error waiting for graceful shutdown of the server: %v", err)
 	}
 }
+
+// TestClientSendsAGoAway tests the scenario where you get a go away ping
+// frames from the client during graceful shutdown.
+func (s) TestClientSendsAGoAway(t *testing.T) {
+	lis, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("error listening: %v", err)
+	}
+	ctCh := testutils.NewChannel()
+	go func() {
+		conn, err := lis.Accept()
+		if err != nil {
+			t.Errorf("error in lis.Accept(): %v", err)
+		}
+		ct := newClientTester(t, conn)
+		ctCh.Send(ct)
+	}()
+	defer lis.Close()
+
+	cc, err := grpc.Dial(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("error dialing: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+
+	val, err := ctCh.Receive(ctx)
+	if err != nil {
+		t.Fatalf("timeout waiting for client transport (should be given after http2 creation)")
+	}
+	ct := val.(*clientTester)
+	goAwayReceived := make(chan struct{})
+	errCh := make(chan struct{})
+	go func() {
+		for {
+			f, err := ct.fr.ReadFrame()
+			if err != nil {
+				return
+			}
+			switch fr := f.(type) {
+			case *http2.GoAwayFrame:
+				fr = f.(*http2.GoAwayFrame)
+				if fr.ErrCode == http2.ErrCodeNo {
+					t.Logf("GoAway received from client")
+					close(goAwayReceived)
+				}
+			default:
+				t.Errorf("server tester received unexpected frame type %T", f)
+				close(errCh)
+			}
+		}
+	}()
+	cc.Close()
+	defer ct.conn.Close()
+	select {
+	case <-goAwayReceived:
+	case <-errCh:
+		t.Errorf("Error receiving the goAway: %v", err)
+	case <-ctx.Done():
+		t.Errorf("Context timed out")
+	}
+}


### PR DESCRIPTION
Fixes #460 

RELEASE NOTES:

* client: client sends GOAWAY to server on graceful shutdown 