### PR TITLE
xds: add LRS named metrics support

### DIFF
--- a/xds/internal/balancer/clusterimpl/picker.go
+++ b/xds/internal/balancer/clusterimpl/picker.go
@@ -68,11 +68,6 @@ func (d *dropper) drop() (ret bool) {
 	return d.w.Next().(bool)
 }
 
-const (
-	serverLoadCPUName    = "cpu_utilization"
-	serverLoadMemoryName = "mem_utilization"
-)
-
 // loadReporter wraps the methods from the loadStore that are used here.
 type loadReporter interface {
 	CallStarted(locality string)
@@ -163,12 +158,7 @@ func (d *picker) Pick(info balancer.PickInfo) (balancer.PickResult, error) {
 			if !ok || load == nil {
 				return
 			}
-			d.loadStore.CallServerLoad(lIDStr, serverLoadCPUName, load.CpuUtilization)
-			d.loadStore.CallServerLoad(lIDStr, serverLoadMemoryName, load.MemUtilization)
-			for n, c := range load.RequestCost {
-				d.loadStore.CallServerLoad(lIDStr, n, c)
-			}
-			for n, c := range load.Utilization {
+			for n, c := range load.NamedMetrics {
 				d.loadStore.CallServerLoad(lIDStr, n, c)
 			}
 		}


### PR DESCRIPTION
Design:
* go/grpc-xds-lrs-named-metrics
* go/lrs-named-metrics-design-review-slides
* Implements gRFC A64 https://github.com/grpc/proposal/blob/master/A64-lrs-custom-metrics.md
* Only include named metrics from `OrcaLoadReport` and remove all previous fields (e.g. CPU utilization, memory utilization, etc.) as they are unused
* Added  xDS clusterImpl balancer tests to verify named metrics aggregation logic
* Added completely missing tests for `UpstreamLocalityStats` to verify aggregation logic

Tested:
* `VET_SKIP_PROTO=1 ./vet.sh`
* `go test -cpu 1,4 -timeout 7m ./...`
* `go test -race -cpu 1,4 -timeout 7m ./...`
* Tested end-to-end by spinning up test client/server  and verified named metrics from the `OrcaLoadReport` are aggregated and send in LRS load reports

RELEASE NOTES:
* xds: implement LRS named metrics support ([gRFC A64](https://github.com/grpc/proposal/blob/master/A64-lrs-custom-metrics.md))