### PR TITLE
grpc: clean up doc strings and some code around Dial vs NewClient

### DIFF
--- a/clientconn_parsed_target_test.go
+++ b/clientconn_parsed_target_test.go
@@ -33,91 +33,116 @@ import (
 	"google.golang.org/grpc/resolver"
 )
 
-func generateTarget(scheme string, target string) resolver.Target {
-	return resolver.Target{URL: *testutils.MustParseURL(fmt.Sprintf("%s:///%s", scheme, target))}
+func generateTarget(target string) resolver.Target {
+	return resolver.Target{URL: *testutils.MustParseURL(target)}
 }
 
-// This is here just in case another test calls the SetDefaultScheme method.
+// Resets the default scheme as though it was never set by the user.
 func resetInitialResolverState() {
 	resolver.SetDefaultScheme("passthrough")
 	internal.UserSetDefaultScheme = false
 }
 
+type testResolverForParser struct {
+	resolver.Resolver
+}
+
+func (testResolverForParser) Build(resolver.Target, resolver.ClientConn, resolver.BuildOptions) (resolver.Resolver, error) {
+	return testResolverForParser{}, nil
+}
+
+func (testResolverForParser) Close() {}
+
+func (testResolverForParser) Scheme() string {
+	return "testresolverforparser"
+}
+
+func init() { resolver.Register(testResolverForParser{}) }
+
 func (s) TestParsedTarget_Success_WithoutCustomDialer(t *testing.T) {
-	resetInitialResolverState()
-	dialScheme := resolver.GetDefaultScheme()
-	newClientScheme := "dns"
 	tests := []struct {
 		target             string
 		wantDialParse      resolver.Target
 		wantNewClientParse resolver.Target
+		wantCustomParse    resolver.Target
 	}{
 		// No scheme is specified.
 		{
 			target:             "://a/b",
-			wantDialParse:      generateTarget(dialScheme, "://a/b"),
-			wantNewClientParse: generateTarget(newClientScheme, "://a/b"),
+			wantDialParse:      generateTarget("passthrough:///://a/b"),
+			wantNewClientParse: generateTarget("dns:///://a/b"),
+			wantCustomParse:    generateTarget("testresolverforparser:///://a/b"),
 		},
 		{
 			target:             "a//b",
-			wantDialParse:      generateTarget(dialScheme, "a//b"),
-			wantNewClientParse: generateTarget(newClientScheme, "a//b"),
+			wantDialParse:      generateTarget("passthrough:///a//b"),
+			wantNewClientParse: generateTarget("dns:///a//b"),
+			wantCustomParse:    generateTarget("testresolverforparser:///a//b"),
 		},
 
 		// An unregistered scheme is specified.
 		{
 			target:             "a:///",
-			wantDialParse:      generateTarget(dialScheme, "a:///"),
-			wantNewClientParse: generateTarget(newClientScheme, "a:///"),
+			wantDialParse:      generateTarget("passthrough:///a:///"),
+			wantNewClientParse: generateTarget("dns:///a:///"),
+			wantCustomParse:    generateTarget("testresolverforparser:///a:///"),
 		},
 		{
 			target:             "a:b",
-			wantDialParse:      generateTarget(dialScheme, "a:b"),
-			wantNewClientParse: generateTarget(newClientScheme, "a:b"),
+			wantDialParse:      generateTarget("passthrough:///a:b"),
+			wantNewClientParse: generateTarget("dns:///a:b"),
+			wantCustomParse:    generateTarget("testresolverforparser:///a:b"),
 		},
 
 		// A registered scheme is specified.
 		{
 			target:             "dns://a.server.com/google.com",
-			wantDialParse:      resolver.Target{URL: *testutils.MustParseURL("dns://a.server.com/google.com")},
-			wantNewClientParse: resolver.Target{URL: *testutils.MustParseURL("dns://a.server.com/google.com")},
+			wantDialParse:      generateTarget("dns://a.server.com/google.com"),
+			wantNewClientParse: generateTarget("dns://a.server.com/google.com"),
+			wantCustomParse:    generateTarget("dns://a.server.com/google.com"),
 		},
 		{
 			target:             "unix-abstract:/ a///://::!@#$%25^&*()b",
-			wantDialParse:      resolver.Target{URL: *testutils.MustParseURL("unix-abstract:/ a///://::!@#$%25^&*()b")},
-			wantNewClientParse: resolver.Target{URL: *testutils.MustParseURL("unix-abstract:/ a///://::!@#$%25^&*()b")},
+			wantDialParse:      generateTarget("unix-abstract:/ a///://::!@#$%25^&*()b"),
+			wantNewClientParse: generateTarget("unix-abstract:/ a///://::!@#$%25^&*()b"),
+			wantCustomParse:    generateTarget("unix-abstract:/ a///://::!@#$%25^&*()b"),
 		},
 		{
 			target:             "unix-abstract:passthrough:abc",
-			wantDialParse:      resolver.Target{URL: *testutils.MustParseURL("unix-abstract:passthrough:abc")},
-			wantNewClientParse: resolver.Target{URL: *testutils.MustParseURL("unix-abstract:passthrough:abc")},
+			wantDialParse:      generateTarget("unix-abstract:passthrough:abc"),
+			wantNewClientParse: generateTarget("unix-abstract:passthrough:abc"),
+			wantCustomParse:    generateTarget("unix-abstract:passthrough:abc"),
 		},
 		{
 			target:             "passthrough:///unix:///a/b/c",
-			wantDialParse:      resolver.Target{URL: *testutils.MustParseURL("passthrough:///unix:///a/b/c")},
-			wantNewClientParse: resolver.Target{URL: *testutils.MustParseURL("passthrough:///unix:///a/b/c")},
+			wantDialParse:      generateTarget("passthrough:///unix:///a/b/c"),
+			wantNewClientParse: generateTarget("passthrough:///unix:///a/b/c"),
+			wantCustomParse:    generateTarget("passthrough:///unix:///a/b/c"),
 		},
 
 		// Cases for `scheme:absolute-path`.
 		{
 			target:             "dns:/a/b/c",
-			wantDialParse:      resolver.Target{URL: *testutils.MustParseURL("dns:/a/b/c")},
-			wantNewClientParse: resolver.Target{URL: *testutils.MustParseURL("dns:/a/b/c")},
+			wantDialParse:      generateTarget("dns:/a/b/c"),
+			wantNewClientParse: generateTarget("dns:/a/b/c"),
+			wantCustomParse:    generateTarget("dns:/a/b/c"),
 		},
 		{
 			target:             "unregistered:/a/b/c",
-			wantDialParse:      generateTarget(dialScheme, "unregistered:/a/b/c"),
-			wantNewClientParse: generateTarget(newClientScheme, "unregistered:/a/b/c"),
+			wantDialParse:      generateTarget("passthrough:///unregistered:/a/b/c"),
+			wantNewClientParse: generateTarget("dns:///unregistered:/a/b/c"),
+			wantCustomParse:    generateTarget("testresolverforparser:///unregistered:/a/b/c"),
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.target, func(t *testing.T) {
+			resetInitialResolverState()
 			cc, err := Dial(test.target, WithTransportCredentials(insecure.NewCredentials()))
 			if err != nil {
 				t.Fatalf("Dial(%q) failed: %v", test.target, err)
 			}
-			defer cc.Close()
+			cc.Close()
 
 			if !cmp.Equal(cc.parsedTarget, test.wantDialParse) {
 				t.Errorf("cc.parsedTarget for dial target %q = %+v, want %+v", test.target, cc.parsedTarget, test.wantDialParse)
@@ -127,13 +152,36 @@ func (s) TestParsedTarget_Success_WithoutCustomDialer(t *testing.T) {
 			if err != nil {
 				t.Fatalf("NewClient(%q) failed: %v", test.target, err)
 			}
-			defer cc.Close()
+			cc.Close()
 
 			if !cmp.Equal(cc.parsedTarget, test.wantNewClientParse) {
 				t.Errorf("cc.parsedTarget for newClient target %q = %+v, want %+v", test.target, cc.parsedTarget, test.wantNewClientParse)
 			}
+
+			resolver.SetDefaultScheme("testresolverforparser")
+			cc, err = Dial(test.target, WithTransportCredentials(insecure.NewCredentials()))
+			if err != nil {
+				t.Fatalf("Dial(%q) failed: %v", test.target, err)
+			}
+			cc.Close()
+
+			if !cmp.Equal(cc.parsedTarget, test.wantCustomParse) {
+				t.Errorf("cc.parsedTarget for dial target %q = %+v, want %+v", test.target, cc.parsedTarget, test.wantDialParse)
+			}
+
+			cc, err = NewClient(test.target, WithTransportCredentials(insecure.NewCredentials()))
+			if err != nil {
+				t.Fatalf("NewClient(%q) failed: %v", test.target, err)
+			}
+			cc.Close()
+
+			if !cmp.Equal(cc.parsedTarget, test.wantCustomParse) {
+				t.Errorf("cc.parsedTarget for newClient target %q = %+v, want %+v", test.target, cc.parsedTarget, test.wantNewClientParse)
+			}
+
 		})
 	}
+	resetInitialResolverState()
 }
 
 func (s) TestParsedTarget_Failure_WithoutCustomDialer(t *testing.T) {

--- a/dialoptions.go
+++ b/dialoptions.go
@@ -79,7 +79,7 @@ type dialOptions struct {
 	resolvers                   []resolver.Builder
 	idleTimeout                 time.Duration
 	recvBufferPool              SharedBufferPool
-	defScheme                   string
+	defaultScheme               string
 }
 
 // DialOption configures how we set up the connection.
@@ -632,7 +632,7 @@ func withHealthCheckFunc(f internal.HealthChecker) DialOption {
 	})
 }
 
-func defaultDialOptions(defScheme string) dialOptions {
+func defaultDialOptions() dialOptions {
 	return dialOptions{
 		copts: transport.ConnectOptions{
 			ReadBufferSize:  defaultReadBufSize,
@@ -644,7 +644,7 @@ func defaultDialOptions(defScheme string) dialOptions {
 		healthCheckFunc: internal.HealthCheckFunc,
 		idleTimeout:     30 * time.Minute,
 		recvBufferPool:  nopBufferPool{},
-		defScheme:       defScheme,
+		defaultScheme:   "dns",
 	}
 }
 
@@ -656,6 +656,14 @@ func defaultDialOptions(defScheme string) dialOptions {
 func withMinConnectDeadline(f func() time.Duration) DialOption {
 	return newFuncDialOption(func(o *dialOptions) {
 		o.minConnectTimeout = f
+	})
+}
+
+// withDefaultScheme is used to allow Dial to use "passthrough" as the default
+// name resolver, while NewClient uses "dns" otherwise.
+func withDefaultScheme(s string) DialOption {
+	return newFuncDialOption(func(o *dialOptions) {
+		o.defaultScheme = s
 	})
 }
 


### PR DESCRIPTION
Also added a test and removed an unused parameter from a function and call sites.  (The reason it was needed in the past is to auto-detect the gRPCLB LB policy, which is functionality we no longer support.)

RELEASE NOTES: none