### PR TITLE
grpc: Export header list sizes in DialOption and ServerOption

### DIFF
--- a/default_dial_option_server_option_test.go
+++ b/default_dial_option_server_option_test.go
@@ -141,7 +141,7 @@ func (s) TestHeaderListSizeDialOptionServerOption(t *testing.T) {
 		t.Fatalf("Unexpected s.opts.MaxHeaderListSizeDialOption.MaxHeaderListSize: %d != %d", clientHeaderListSize, maxHeaderListSize)
 	}
 	serverHeaderListSize := MaxHeaderListSize(maxHeaderListSize)
-	if serverHeaderListSize.(*MaxHeaderListSizeServerOption).MaxHeaderListSize != maxHeaderListSize {
+	if serverHeaderListSize.(MaxHeaderListSizeServerOption).MaxHeaderListSize != maxHeaderListSize {
 		t.Fatalf("Unexpected s.opts.MaxHeaderListSizeDialOption.MaxHeaderListSize: %d != %d", serverHeaderListSize, maxHeaderListSize)
 	}
 }

--- a/default_dial_option_server_option_test.go
+++ b/default_dial_option_server_option_test.go
@@ -132,3 +132,16 @@ func (s) TestJoinServerOption(t *testing.T) {
 		t.Fatalf("Unexpected s.opts.initialWindowSize: %d != %d", s.opts.initialWindowSize, initialWindowSize)
 	}
 }
+
+// funcTestHeaderListSizeDialOptionServerOption tests
+func (s) TestHeaderListSizeDialOptionServerOption(t *testing.T) {
+	const maxHeaderListSize uint32 = 998765
+	clientHeaderListSize := WithMaxHeaderListSize(maxHeaderListSize)
+	if clientHeaderListSize.(MaxHeaderListSizeDialOption).MaxHeaderListSize != maxHeaderListSize {
+		t.Fatalf("Unexpected s.opts.MaxHeaderListSizeDialOption.MaxHeaderListSize: %d != %d", clientHeaderListSize, maxHeaderListSize)
+	}
+	serverHeaderListSize := MaxHeaderListSize(maxHeaderListSize)
+	if serverHeaderListSize.(*MaxHeaderListSizeServerOption).MaxHeaderListSize != maxHeaderListSize {
+		t.Fatalf("Unexpected s.opts.MaxHeaderListSizeDialOption.MaxHeaderListSize: %d != %d", serverHeaderListSize, maxHeaderListSize)
+	}
+}

--- a/dialoptions.go
+++ b/dialoptions.go
@@ -601,12 +601,22 @@ func WithDisableRetry() DialOption {
 	})
 }
 
+// MaxHeaderListSizeDialOption is a DialOption that specifies the maximum
+// (uncompressed) size of header list that the client is prepared to accept.
+type MaxHeaderListSizeDialOption struct {
+	MaxHeaderListSize uint32
+}
+
+func (o MaxHeaderListSizeDialOption) apply(do *dialOptions) {
+	do.copts.MaxHeaderListSize = &o.MaxHeaderListSize
+}
+
 // WithMaxHeaderListSize returns a DialOption that specifies the maximum
 // (uncompressed) size of header list that the client is prepared to accept.
 func WithMaxHeaderListSize(s uint32) DialOption {
-	return newFuncDialOption(func(o *dialOptions) {
-		o.copts.MaxHeaderListSize = &s
-	})
+	return MaxHeaderListSizeDialOption{
+		MaxHeaderListSize: s,
+	}
 }
 
 // WithDisableHealthCheck disables the LB channel health checking for all

--- a/server.go
+++ b/server.go
@@ -528,12 +528,22 @@ func ConnectionTimeout(d time.Duration) ServerOption {
 	})
 }
 
+// MaxHeaderListSizeServerOption is a ServerOption that sets the max
+// (uncompressed) size of header list that the server is prepared to accept.
+type MaxHeaderListSizeServerOption struct {
+	MaxHeaderListSize uint32
+}
+
+func (o MaxHeaderListSizeServerOption) apply(so *serverOptions) {
+	so.maxHeaderListSize = &o.MaxHeaderListSize
+}
+
 // MaxHeaderListSize returns a ServerOption that sets the max (uncompressed) size
 // of header list that the server is prepared to accept.
 func MaxHeaderListSize(s uint32) ServerOption {
-	return newFuncServerOption(func(o *serverOptions) {
-		o.maxHeaderListSize = &s
-	})
+	return &MaxHeaderListSizeServerOption{
+		MaxHeaderListSize: s,
+	}
 }
 
 // HeaderTableSize returns a ServerOption that sets the size of dynamic

--- a/server.go
+++ b/server.go
@@ -541,7 +541,7 @@ func (o MaxHeaderListSizeServerOption) apply(so *serverOptions) {
 // MaxHeaderListSize returns a ServerOption that sets the max (uncompressed) size
 // of header list that the server is prepared to accept.
 func MaxHeaderListSize(s uint32) ServerOption {
-	return &MaxHeaderListSizeServerOption{
+	return MaxHeaderListSizeServerOption{
 		MaxHeaderListSize: s,
 	}
 }


### PR DESCRIPTION
Similar to https://github.com/grpc/grpc-go/pull/1902, it is good to export the header list sizes for users to know what is the existing metadata size limit.

RELEASE NOTES: none