### PR TITLE
Fix: error message using correct keepalive config value

### DIFF
--- a/internal/transport/http2_server.go
+++ b/internal/transport/http2_server.go
@@ -1198,7 +1198,7 @@ func (t *http2Server) keepalive() {
 				continue
 			}
 			if outstandingPing && kpTimeoutLeft <= 0 {
-				t.Close(fmt.Errorf("keepalive ping not acked within timeout %s", t.kp.Time))
+				t.Close(fmt.Errorf("keepalive ping not acked within timeout %s", t.kp.Timeout))
 				return
 			}
 			if !outstandingPing {


### PR DESCRIPTION
`kpTimeoutLeft` is calculated from `kp.Timeout`, but the error message implies it's based on `kp.Time`.

RELEASE NOTES:
- transport/server: use the proper timeout value when keepalive pings are not ack'd in time