### PR TITLE
googlec2p: use xdstp style template for client LDS resource name

### DIFF
--- a/xds/googledirectpath/googlec2p.go
+++ b/xds/googledirectpath/googlec2p.go
@@ -110,7 +110,7 @@ func (c2pResolverBuilder) Build(t resolver.Target, cc resolver.ClientConn, opts 
 	{
 		"server_uri": "%s",
 		"channel_creds": [{"type": "google_default"}],
-		"server_features": ["xds_v3", "ignore_resource_deletion"]
+		"server_features": ["xds_v3", "ignore_resource_deletion", "xds.config.resource-in-sotw"]
 	}`, balancerName)))
 	if err != nil {
 		return nil, fmt.Errorf("failed to build bootstrap configuration: %v", err)

--- a/xds/googledirectpath/googlec2p.go
+++ b/xds/googledirectpath/googlec2p.go
@@ -120,7 +120,8 @@ func (c2pResolverBuilder) Build(t resolver.Target, cc resolver.ClientConn, opts 
 		ClientDefaultListenerResourceNameTemplate: "%s",
 		Authorities: map[string]*bootstrap.Authority{
 			c2pAuthority: {
-				XDSServer: serverConfig,
+				XDSServer:                          serverConfig,
+				ClientListenerResourceNameTemplate: fmt.Sprintf("xdstp://%s/envoy.config.listener.v3.Listener/%%s", c2pAuthority),
 			},
 		},
 		NodeProto: newNode(<-zoneCh, <-ipv6CapableCh),

--- a/xds/googledirectpath/googlec2p_test.go
+++ b/xds/googledirectpath/googlec2p_test.go
@@ -213,7 +213,7 @@ func TestBuildXDS(t *testing.T) {
 			wantServerConfig, err := bootstrap.ServerConfigFromJSON([]byte(fmt.Sprintf(`{
 				"server_uri": "%s",
 				"channel_creds": [{"type": "google_default"}],
-				"server_features": ["xds_v3", "ignore_resource_deletion"]
+				"server_features": ["xds_v3", "ignore_resource_deletion", "xds.config.resource-in-sotw"]
 			}`, tdURL)))
 			if err != nil {
 				t.Fatalf("Failed to build server bootstrap config: %v", err)

--- a/xds/googledirectpath/googlec2p_test.go
+++ b/xds/googledirectpath/googlec2p_test.go
@@ -223,7 +223,8 @@ func TestBuildXDS(t *testing.T) {
 				ClientDefaultListenerResourceNameTemplate: "%s",
 				Authorities: map[string]*bootstrap.Authority{
 					"traffic-director-c2p.xds.googleapis.com": {
-						XDSServer: wantServerConfig,
+						XDSServer:                          wantServerConfig,
+						ClientListenerResourceNameTemplate: "xdstp://traffic-director-c2p.xds.googleapis.com/envoy.config.listener.v3.Listener/%s",
 					},
 				},
 				NodeProto: wantNode,


### PR DESCRIPTION
The google c2p resolver should be using the new xdstp style names for LDS resource names. Also adds "xds.config.resource-in-sotw" to `server_features` which is also required by the google c2p resolver. 

RELEASE NOTES: none