### PR TITLE
cmd/protoc-gen-go-grpc: don't emit const blocks for services with no methods

### DIFF
--- a/cmd/protoc-gen-go-grpc/grpc.go
+++ b/cmd/protoc-gen-go-grpc/grpc.go
@@ -52,6 +52,10 @@ func (serviceGenerateHelper) formatFullMethodSymbol(service *protogen.Service, m
 }
 
 func (serviceGenerateHelper) genFullMethods(g *protogen.GeneratedFile, service *protogen.Service) {
+	if len(service.Methods) == 0 {
+		return
+	}
+
 	g.P("const (")
 	for _, method := range service.Methods {
 		fmSymbol := helper.formatFullMethodSymbol(service, method)


### PR DESCRIPTION
Closes #7054

With proto of

```proto
syntax = "proto3";
package foobar;
option go_package = "github.com/foobar";

service Foobar {}
```

you get

```go
// Code generated by protoc-gen-go-grpc. DO NOT EDIT.
// versions:
// - protoc-gen-go-grpc v1.3.0
// - protoc             v4.25.3
// source: service-foobar.proto

package popsa

import (
	grpc "google.golang.org/grpc"
)

// This is a compile-time assertion to ensure that this generated file
// is compatible with the grpc package it is being compiled against.
// Requires gRPC-Go v1.32.0 or later.
const _ = grpc.SupportPackageIsVersion7

const ()

// FoobarClient is the client API for Foobar service.
//
// For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
type FoobarClient interface {
}
```

which causes a `gofmt` failure due to empty const block

RELEASE NOTES: none
(protoc-gen-go-grpc does not use these relnotes)