### PR TITLE
Update docs and examples and tests to use NewClient instead of Dial

### DIFF
--- a/Documentation/anti-patterns.md
+++ b/Documentation/anti-patterns.md
@@ -38,6 +38,7 @@ connection until an RPC is executed. Instead of using the WithBlock option, whic
 may not be recommended in some cases, you can call the
 [`ClientConn.Connect`](https://pkg.go.dev/google.golang.org/grpc#ClientConn.Connect)
 method to explicitly initiate a connection.
+[`WithBlock`](https://pkg.go.dev/google.golang.org/grpc#WithBlock) in an instance where WithBlock(true) is used, `Connect` and `WaitForStateChange` is invoked until either the context created via `context.WithTimeout` expires or the `ClientConn` is ready.
 
 ### Using `FailOnNonTempDialError`, `WithBlock`, and `WithReturnConnectionError`
 
@@ -55,6 +56,17 @@ whether a connection was never established in the first place, or if it was
 created and then immediately lost.  Implementing proper error handling for RPCs
 is crucial for maintaining the reliability and stability of your gRPC
 communication.
+
+### Difference between Dial and NewClient
+[`grpc.NewClient`](https://pkg.go.dev/google.golang.org/grpc#NewClient) is a function in the grpc libaray that creates a new gRPC `channel` for the target URI that is passed in as an argument, together with a list of `DialOption`, and returns [`ClientConn`](https://pkg.go.dev/google.golang.org/grpc#ClientConn) an object representing a server connection.
+
+Unlike `grpc.NewClient`, whereby using the ClientConn for RPCs will automatically cause it to connect or `Connect` may be used to manually create a connection, by default `Dial` does not always establish a connection to servers. Connection behavior is determined by the load balancing policy used.
+
+`grpc.NewClient` automatically ignores `DialOptions` returned by `WithBlock`, `WithTimeout`, `WithReturnConnectionError`, and `FailOnNonTempDialError. 
+
+`grpc.NewClient` uses passthrough as the default name resolver for backward compatibility while  `Dial` uses dns as its default name resolver. This subtle diffrence is crucial in legacy systems that specify a custom dialer and expect it to receive the target string directly.
+
+Timeouts are not supported by `grpc.NewClient`. 
 
 ###  Why we discourage using `FailOnNonTempDialError`, `WithBlock`, and `WithReturnConnectionError`
 

--- a/authz/audit/audit_logging_test.go
+++ b/authz/audit/audit_logging_test.go
@@ -279,9 +279,9 @@ func (s) TestAuditLogger(t *testing.T) {
 			go s.Serve(lis)
 
 			// Setup gRPC test client with certificates containing a SPIFFE Id.
-			clientConn, err := grpc.Dial(lis.Addr().String(), grpc.WithTransportCredentials(clientCreds))
+			clientConn, err := grpc.NewClient(lis.Addr().String(), grpc.WithTransportCredentials(clientCreds))
 			if err != nil {
-				t.Fatalf("grpc.Dial(%v) failed: %v", lis.Addr().String(), err)
+				t.Fatalf("grpc.NewClient(%v) failed: %v", lis.Addr().String(), err)
 			}
 			defer clientConn.Close()
 			client := testgrpc.NewTestServiceClient(clientConn)

--- a/authz/grpc_authz_end2end_test.go
+++ b/authz/grpc_authz_end2end_test.go
@@ -326,9 +326,9 @@ func (s) TestStaticPolicyEnd2End(t *testing.T) {
 			go s.Serve(lis)
 
 			// Establish a connection to the server.
-			clientConn, err := grpc.Dial(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+			clientConn, err := grpc.NewClient(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 			if err != nil {
-				t.Fatalf("grpc.Dial(%v) failed: %v", lis.Addr().String(), err)
+				t.Fatalf("grpc.NewClient(%v) failed: %v", lis.Addr().String(), err)
 			}
 			defer clientConn.Close()
 			client := testgrpc.NewTestServiceClient(clientConn)
@@ -400,9 +400,9 @@ func (s) TestAllowsRPCRequestWithPrincipalsFieldOnTLSAuthenticatedConnection(t *
 	if err != nil {
 		t.Fatalf("failed to load credentials: %v", err)
 	}
-	clientConn, err := grpc.Dial(lis.Addr().String(), grpc.WithTransportCredentials(creds))
+	clientConn, err := grpc.NewClient(lis.Addr().String(), grpc.WithTransportCredentials(creds))
 	if err != nil {
-		t.Fatalf("grpc.Dial(%v) failed: %v", lis.Addr().String(), err)
+		t.Fatalf("grpc.NewClient(%v) failed: %v", lis.Addr().String(), err)
 	}
 	defer clientConn.Close()
 	client := testgrpc.NewTestServiceClient(clientConn)
@@ -478,9 +478,9 @@ func (s) TestAllowsRPCRequestWithPrincipalsFieldOnMTLSAuthenticatedConnection(t 
 		RootCAs:      roots,
 		ServerName:   "x.test.example.com",
 	})
-	clientConn, err := grpc.Dial(lis.Addr().String(), grpc.WithTransportCredentials(creds))
+	clientConn, err := grpc.NewClient(lis.Addr().String(), grpc.WithTransportCredentials(creds))
 	if err != nil {
-		t.Fatalf("grpc.Dial(%v) failed: %v", lis.Addr().String(), err)
+		t.Fatalf("grpc.NewClient(%v) failed: %v", lis.Addr().String(), err)
 	}
 	defer clientConn.Close()
 	client := testgrpc.NewTestServiceClient(clientConn)
@@ -516,9 +516,9 @@ func (s) TestFileWatcherEnd2End(t *testing.T) {
 			go s.Serve(lis)
 
 			// Establish a connection to the server.
-			clientConn, err := grpc.Dial(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+			clientConn, err := grpc.NewClient(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 			if err != nil {
-				t.Fatalf("grpc.Dial(%v) failed: %v", lis.Addr().String(), err)
+				t.Fatalf("grpc.NewClient(%v) failed: %v", lis.Addr().String(), err)
 			}
 			defer clientConn.Close()
 			client := testgrpc.NewTestServiceClient(clientConn)
@@ -585,9 +585,9 @@ func (s) TestFileWatcher_ValidPolicyRefresh(t *testing.T) {
 	go s.Serve(lis)
 
 	// Establish a connection to the server.
-	clientConn, err := grpc.Dial(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	clientConn, err := grpc.NewClient(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
-		t.Fatalf("grpc.Dial(%v) failed: %v", lis.Addr().String(), err)
+		t.Fatalf("grpc.NewClient(%v) failed: %v", lis.Addr().String(), err)
 	}
 	defer clientConn.Close()
 	client := testgrpc.NewTestServiceClient(clientConn)
@@ -633,9 +633,9 @@ func (s) TestFileWatcher_InvalidPolicySkipReload(t *testing.T) {
 	go s.Serve(lis)
 
 	// Establish a connection to the server.
-	clientConn, err := grpc.Dial(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	clientConn, err := grpc.NewClient(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
-		t.Fatalf("grpc.Dial(%v) failed: %v", lis.Addr().String(), err)
+		t.Fatalf("grpc.NewClient(%v) failed: %v", lis.Addr().String(), err)
 	}
 	defer clientConn.Close()
 	client := testgrpc.NewTestServiceClient(clientConn)
@@ -684,9 +684,9 @@ func (s) TestFileWatcher_RecoversFromReloadFailure(t *testing.T) {
 	go s.Serve(lis)
 
 	// Establish a connection to the server.
-	clientConn, err := grpc.Dial(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	clientConn, err := grpc.NewClient(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
-		t.Fatalf("grpc.Dial(%v) failed: %v", lis.Addr().String(), err)
+		t.Fatalf("grpc.NewClient(%v) failed: %v", lis.Addr().String(), err)
 	}
 	defer clientConn.Close()
 	client := testgrpc.NewTestServiceClient(clientConn)

--- a/balancer/grpclb/grpclb_test.go
+++ b/balancer/grpclb/grpclb_test.go
@@ -458,7 +458,7 @@ func (s) TestGRPCLB_Basic(t *testing.T) {
 		grpc.WithContextDialer(fakeNameDialer),
 		grpc.WithUserAgent(testUserAgent),
 	}
-	cc, err := grpc.Dial(r.Scheme()+":///"+beServerName, dopts...)
+	cc, err := grpc.NewClient(r.Scheme()+":///"+beServerName, dopts...)
 	if err != nil {
 		t.Fatalf("Failed to dial to the backend %v", err)
 	}
@@ -515,7 +515,7 @@ func (s) TestGRPCLB_Weighted(t *testing.T) {
 		grpc.WithTransportCredentials(&serverNameCheckCreds{}),
 		grpc.WithContextDialer(fakeNameDialer),
 	}
-	cc, err := grpc.Dial(r.Scheme()+":///"+beServerName, dopts...)
+	cc, err := grpc.NewClient(r.Scheme()+":///"+beServerName, dopts...)
 	if err != nil {
 		t.Fatalf("Failed to dial to the backend %v", err)
 	}
@@ -595,7 +595,7 @@ func (s) TestGRPCLB_DropRequest(t *testing.T) {
 		grpc.WithTransportCredentials(&serverNameCheckCreds{}),
 		grpc.WithContextDialer(fakeNameDialer),
 	}
-	cc, err := grpc.Dial(r.Scheme()+":///"+beServerName, dopts...)
+	cc, err := grpc.NewClient(r.Scheme()+":///"+beServerName, dopts...)
 	if err != nil {
 		t.Fatalf("Failed to dial to the backend %v", err)
 	}
@@ -767,7 +767,7 @@ func (s) TestGRPCLB_BalancerDisconnects(t *testing.T) {
 		grpc.WithTransportCredentials(&serverNameCheckCreds{}),
 		grpc.WithContextDialer(fakeNameDialer),
 	}
-	cc, err := grpc.Dial(r.Scheme()+":///"+beServerName, dopts...)
+	cc, err := grpc.NewClient(r.Scheme()+":///"+beServerName, dopts...)
 	if err != nil {
 		t.Fatalf("Failed to dial to the backend %v", err)
 	}
@@ -938,7 +938,7 @@ func (s) TestGRPCLB_ExplicitFallback(t *testing.T) {
 		grpc.WithTransportCredentials(&serverNameCheckCreds{}),
 		grpc.WithContextDialer(fakeNameDialer),
 	}
-	cc, err := grpc.Dial(r.Scheme()+":///"+beServerName, dopts...)
+	cc, err := grpc.NewClient(r.Scheme()+":///"+beServerName, dopts...)
 	if err != nil {
 		t.Fatalf("Failed to dial to the backend %v", err)
 	}

--- a/balancer/leastrequest/balancer_test.go
+++ b/balancer/leastrequest/balancer_test.go
@@ -232,9 +232,9 @@ func (s) TestLeastRequestE2E(t *testing.T) {
 		ServiceConfig: sc,
 	})
 
-	cc, err := grpc.Dial(mr.Scheme()+":///", grpc.WithResolvers(mr), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	cc, err := grpc.NewClient(mr.Scheme()+":///", grpc.WithResolvers(mr), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
-		t.Fatalf("grpc.Dial() failed: %v", err)
+		t.Fatalf("grpc.NewClient() failed: %v", err)
 	}
 	defer cc.Close()
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
@@ -347,9 +347,9 @@ func (s) TestLeastRequestPersistsCounts(t *testing.T) {
 		ServiceConfig: sc,
 	})
 
-	cc, err := grpc.Dial(mr.Scheme()+":///", grpc.WithResolvers(mr), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	cc, err := grpc.NewClient(mr.Scheme()+":///", grpc.WithResolvers(mr), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
-		t.Fatalf("grpc.Dial() failed: %v", err)
+		t.Fatalf("grpc.NewClient() failed: %v", err)
 	}
 	defer cc.Close()
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
@@ -488,9 +488,9 @@ func (s) TestConcurrentRPCs(t *testing.T) {
 		ServiceConfig: sc,
 	})
 
-	cc, err := grpc.Dial(mr.Scheme()+":///", grpc.WithResolvers(mr), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	cc, err := grpc.NewClient(mr.Scheme()+":///", grpc.WithResolvers(mr), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
-		t.Fatalf("grpc.Dial() failed: %v", err)
+		t.Fatalf("grpc.NewClient() failed: %v", err)
 	}
 	defer cc.Close()
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)

--- a/binarylog/binarylog_end2end_test.go
+++ b/binarylog/binarylog_end2end_test.go
@@ -316,7 +316,7 @@ func (te *test) clientConn() *grpc.ClientConn {
 	opts := []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithBlock()}
 
 	var err error
-	te.cc, err = grpc.Dial(te.srvAddr, opts...)
+	te.cc, err = grpc.NewClient(te.srvAddr, opts...)
 	if err != nil {
 		te.t.Fatalf("Dial(%q) = %v", te.srvAddr, err)
 	}

--- a/clientconn_authority_test.go
+++ b/clientconn_authority_test.go
@@ -128,8 +128,8 @@ func (s) TestClientConnAuthority_CredsAndDialOptionMismatch(t *testing.T) {
 		t.Fatalf("credentials.NewClientTLSFromFile(_, %q) failed: %v", err, serverNameOverride)
 	}
 	opts := []DialOption{WithTransportCredentials(creds), WithAuthority("authority-override")}
-	if cc, err := Dial("Non-Existent.Server:8000", opts...); err == nil {
+	if cc, err := NewClient("Non-Existent.Server:8000", opts...); err == nil {
 		cc.Close()
-		t.Fatal("grpc.Dial() succeeded when expected to fail")
+		t.Fatal("grpc.NewClient() succeeded when expected to fail")
 	}
 }

--- a/credentials/alts/alts_test.go
+++ b/credentials/alts/alts_test.go
@@ -385,9 +385,9 @@ func versions(minMajor, minMinor, maxMajor, maxMinor uint32) *altspb.RpcProtocol
 
 func establishAltsConnection(t *testing.T, handshakerAddress, serverAddress string) {
 	clientCreds := NewClientCreds(&ClientOptions{HandshakerServiceAddress: handshakerAddress})
-	conn, err := grpc.Dial(serverAddress, grpc.WithTransportCredentials(clientCreds))
+	conn, err := grpc.NewClient(serverAddress, grpc.WithTransportCredentials(clientCreds))
 	if err != nil {
-		t.Fatalf("grpc.Dial(%v) failed: %v", serverAddress, err)
+		t.Fatalf("grpc.NewClient(%v) failed: %v", serverAddress, err)
 	}
 	defer conn.Close()
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestLongTimeout)

--- a/credentials/tls_ext_test.go
+++ b/credentials/tls_ext_test.go
@@ -103,9 +103,9 @@ func (s) TestTLS_MinVersion12(t *testing.T) {
 	}
 	defer ss.Stop()
 
-	cc, err := grpc.Dial(ss.Address, grpc.WithTransportCredentials(clientCreds))
+	cc, err := grpc.NewClient(ss.Address, grpc.WithTransportCredentials(clientCreds))
 	if err != nil {
-		t.Fatalf("grpc.Dial error: %v", err)
+		t.Fatalf("grpc.NewClient error: %v", err)
 	}
 	defer cc.Close()
 
@@ -189,9 +189,9 @@ func (s) TestTLS_CipherSuites(t *testing.T) {
 	}
 	defer ss.Stop()
 
-	cc, err := grpc.Dial("dns:"+ss.Address, grpc.WithTransportCredentials(clientCreds))
+	cc, err := grpc.NewClient("dns:"+ss.Address, grpc.WithTransportCredentials(clientCreds))
 	if err != nil {
-		t.Fatalf("grpc.Dial error: %v", err)
+		t.Fatalf("grpc.NewClient error: %v", err)
 	}
 	defer cc.Close()
 

--- a/encoding/encoding_test.go
+++ b/encoding/encoding_test.go
@@ -122,7 +122,7 @@ func (s) TestEncodeDoesntPanicOnServer(t *testing.T) {
 	defer backend.Stop()
 
 	// Create a channel to the above server.
-	cc, err := grpc.Dial(backend.Address, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	cc, err := grpc.NewClient(backend.Address, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		t.Fatalf("Failed to dial test backend at %q: %v", backend.Address, err)
 	}
@@ -159,7 +159,7 @@ func (s) TestDecodeDoesntPanicOnServer(t *testing.T) {
 
 	// Create a channel to the above server. Since we do not specify any codec
 	// here, the proto codec will get automatically used.
-	cc, err := grpc.Dial(backend.Address, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	cc, err := grpc.NewClient(backend.Address, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		t.Fatalf("Failed to dial test backend at %q: %v", backend.Address, err)
 	}
@@ -196,7 +196,7 @@ func (s) TestEncodeDoesntPanicOnClient(t *testing.T) {
 	ec := &errProtoCodec{name: t.Name(), encodingErr: encodingErr}
 
 	// Create a channel to the above server.
-	cc, err := grpc.Dial(backend.Address, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	cc, err := grpc.NewClient(backend.Address, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		t.Fatalf("Failed to dial test backend at %q: %v", backend.Address, err)
 	}
@@ -232,7 +232,7 @@ func (s) TestDecodeDoesntPanicOnClient(t *testing.T) {
 	ec := &errProtoCodec{name: t.Name(), decodingErr: decodingErr}
 
 	// Create a channel to the above server.
-	cc, err := grpc.Dial(backend.Address, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	cc, err := grpc.NewClient(backend.Address, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		t.Fatalf("Failed to dial test backend at %q: %v", backend.Address, err)
 	}
@@ -288,7 +288,7 @@ func (s) TestForceServerCodec(t *testing.T) {
 	defer backend.Stop()
 
 	// Create a channel to the above server.
-	cc, err := grpc.Dial(backend.Address, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	cc, err := grpc.NewClient(backend.Address, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		t.Fatalf("Failed to dial test backend at %q: %v", backend.Address, err)
 	}

--- a/examples/features/authentication/client/main.go
+++ b/examples/features/authentication/client/main.go
@@ -66,7 +66,7 @@ func main() {
 		grpc.WithTransportCredentials(creds),
 	}
 
-	conn, err := grpc.Dial(*addr, opts...)
+	conn, err := grpc.NewClient(*addr, opts...)
 	if err != nil {
 		log.Fatalf("did not connect: %v", err)
 	}

--- a/examples/features/authz/client/main.go
+++ b/examples/features/authz/client/main.go
@@ -99,9 +99,9 @@ func main() {
 		log.Fatalf("failed to load credentials: %v", err)
 	}
 	// Set up a connection to the server.
-	conn, err := grpc.Dial(*addr, grpc.WithTransportCredentials(creds))
+	conn, err := grpc.NewClient(*addr, grpc.WithTransportCredentials(creds))
 	if err != nil {
-		log.Fatalf("grpc.Dial(%q): %v", *addr, err)
+		log.Fatalf("grpc.NewClient(%q): %v", *addr, err)
 	}
 	defer conn.Close()
 

--- a/examples/features/cancellation/client/main.go
+++ b/examples/features/cancellation/client/main.go
@@ -56,7 +56,7 @@ func main() {
 	flag.Parse()
 
 	// Set up a connection to the server.
-	conn, err := grpc.Dial(*addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.NewClient(*addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		log.Fatalf("did not connect: %v", err)
 	}

--- a/examples/features/compression/client/main.go
+++ b/examples/features/compression/client/main.go
@@ -38,7 +38,7 @@ func main() {
 	flag.Parse()
 
 	// Set up a connection to the server.
-	conn, err := grpc.Dial(*addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.NewClient(*addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		log.Fatalf("did not connect: %v", err)
 	}

--- a/examples/features/deadline/client/main.go
+++ b/examples/features/deadline/client/main.go
@@ -73,7 +73,7 @@ func streamingCall(c pb.EchoClient, requestID int, message string, want codes.Co
 func main() {
 	flag.Parse()
 
-	conn, err := grpc.Dial(*addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.NewClient(*addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		log.Fatalf("did not connect: %v", err)
 	}

--- a/examples/features/deadline/server/main.go
+++ b/examples/features/deadline/server/main.go
@@ -95,7 +95,7 @@ func (s *server) Close() {
 
 func newEchoServer() *server {
 	target := fmt.Sprintf("localhost:%v", *port)
-	cc, err := grpc.Dial(target, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	cc, err := grpc.NewClient(target, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		log.Fatalf("did not connect: %v", err)
 	}

--- a/examples/features/debugging/client/main.go
+++ b/examples/features/debugging/client/main.go
@@ -60,7 +60,7 @@ func main() {
 	/***** Initialize manual resolver and Dial *****/
 	r := manual.NewBuilderWithScheme("whatever")
 	// Set up a connection to the server.
-	conn, err := grpc.Dial(r.Scheme()+":///test.server", grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithResolvers(r), grpc.WithDefaultServiceConfig(`{"loadBalancingPolicy":"round_robin"}`))
+	conn, err := grpc.NewClient(r.Scheme()+":///test.server", grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithResolvers(r), grpc.WithDefaultServiceConfig(`{"loadBalancingPolicy":"round_robin"}`))
 	if err != nil {
 		log.Fatalf("did not connect: %v", err)
 	}

--- a/examples/features/encryption/ALTS/client/main.go
+++ b/examples/features/encryption/ALTS/client/main.go
@@ -50,7 +50,7 @@ func main() {
 	altsTC := alts.NewClientCreds(alts.DefaultClientOptions())
 
 	// Set up a connection to the server.
-	conn, err := grpc.Dial(*addr, grpc.WithTransportCredentials(altsTC))
+	conn, err := grpc.NewClient(*addr, grpc.WithTransportCredentials(altsTC))
 	if err != nil {
 		log.Fatalf("did not connect: %v", err)
 	}

--- a/examples/features/encryption/TLS/client/main.go
+++ b/examples/features/encryption/TLS/client/main.go
@@ -54,7 +54,7 @@ func main() {
 	}
 
 	// Set up a connection to the server.
-	conn, err := grpc.Dial(*addr, grpc.WithTransportCredentials(creds))
+	conn, err := grpc.NewClient(*addr, grpc.WithTransportCredentials(creds))
 	if err != nil {
 		log.Fatalf("did not connect: %v", err)
 	}

--- a/examples/features/encryption/mTLS/client/main.go
+++ b/examples/features/encryption/mTLS/client/main.go
@@ -71,7 +71,7 @@ func main() {
 		RootCAs:      ca,
 	}
 
-	conn, err := grpc.Dial(*addr, grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)))
+	conn, err := grpc.NewClient(*addr, grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)))
 	if err != nil {
 		log.Fatalf("did not connect: %v", err)
 	}

--- a/examples/features/error_details/client/main.go
+++ b/examples/features/error_details/client/main.go
@@ -39,7 +39,7 @@ func main() {
 	flag.Parse()
 
 	// Set up a connection to the server.
-	conn, err := grpc.Dial(*addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.NewClient(*addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		log.Fatalf("did not connect: %v", err)
 	}

--- a/examples/features/error_handling/client/main.go
+++ b/examples/features/error_handling/client/main.go
@@ -44,7 +44,7 @@ func main() {
 	}
 
 	// Set up a connection to the server.
-	conn, err := grpc.Dial(*addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.NewClient(*addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		log.Fatalf("Failed to connect: %v", err)
 	}

--- a/examples/features/flow_control/client/main.go
+++ b/examples/features/flow_control/client/main.go
@@ -41,7 +41,7 @@ func main() {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	conn, err := grpc.Dial(*addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.NewClient(*addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		log.Fatalf("did not connect: %v", err)
 	}

--- a/examples/features/health/client/main.go
+++ b/examples/features/health/client/main.go
@@ -72,9 +72,9 @@ func main() {
 		grpc.WithDefaultServiceConfig(serviceConfig),
 	}
 
-	conn, err := grpc.Dial(address, options...)
+	conn, err := grpc.NewClient(address, options...)
 	if err != nil {
-		log.Fatalf("grpc.Dial(%q): %v", address, err)
+		log.Fatalf("grpc.NewClient(%q): %v", address, err)
 	}
 	defer conn.Close()
 

--- a/examples/features/interceptor/client/main.go
+++ b/examples/features/interceptor/client/main.go
@@ -153,7 +153,7 @@ func main() {
 	}
 
 	// Set up a connection to the server.
-	conn, err := grpc.Dial(*addr, grpc.WithTransportCredentials(creds), grpc.WithUnaryInterceptor(unaryInterceptor), grpc.WithStreamInterceptor(streamInterceptor))
+	conn, err := grpc.NewClient(*addr, grpc.WithTransportCredentials(creds), grpc.WithUnaryInterceptor(unaryInterceptor), grpc.WithStreamInterceptor(streamInterceptor))
 	if err != nil {
 		log.Fatalf("did not connect: %v", err)
 	}

--- a/examples/features/keepalive/client/main.go
+++ b/examples/features/keepalive/client/main.go
@@ -43,7 +43,7 @@ var kacp = keepalive.ClientParameters{
 func main() {
 	flag.Parse()
 
-	conn, err := grpc.Dial(*addr, grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithKeepaliveParams(kacp))
+	conn, err := grpc.NewClient(*addr, grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithKeepaliveParams(kacp))
 	if err != nil {
 		log.Fatalf("did not connect: %v", err)
 	}

--- a/examples/features/load_balancing/client/main.go
+++ b/examples/features/load_balancing/client/main.go
@@ -57,7 +57,7 @@ func makeRPCs(cc *grpc.ClientConn, n int) {
 
 func main() {
 	// "pick_first" is the default, so there's no need to set the load balancing policy.
-	pickfirstConn, err := grpc.Dial(
+	pickfirstConn, err := grpc.NewClient(
 		fmt.Sprintf("%s:///%s", exampleScheme, exampleServiceName),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 	)
@@ -72,7 +72,7 @@ func main() {
 	fmt.Println()
 
 	// Make another ClientConn with round_robin policy.
-	roundrobinConn, err := grpc.Dial(
+	roundrobinConn, err := grpc.NewClient(
 		fmt.Sprintf("%s:///%s", exampleScheme, exampleServiceName),
 		grpc.WithDefaultServiceConfig(`{"loadBalancingConfig": [{"round_robin":{}}]}`), // This sets the initial balancing policy.
 		grpc.WithTransportCredentials(insecure.NewCredentials()),

--- a/examples/features/metadata/client/main.go
+++ b/examples/features/metadata/client/main.go
@@ -287,7 +287,7 @@ const message = "this is examples/metadata"
 func main() {
 	flag.Parse()
 	// Set up a connection to the server.
-	conn, err := grpc.Dial(*addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.NewClient(*addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		log.Fatalf("did not connect: %v", err)
 	}

--- a/examples/features/metadata_interceptor/client/main.go
+++ b/examples/features/metadata_interceptor/client/main.go
@@ -69,9 +69,9 @@ func callBidiStreamingEcho(ctx context.Context, client pb.EchoClient) {
 func main() {
 	flag.Parse()
 
-	conn, err := grpc.Dial(*addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.NewClient(*addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
-		log.Fatalf("grpc.Dial(%q): %v", *addr, err)
+		log.Fatalf("grpc.NewClient(%q): %v", *addr, err)
 	}
 	defer conn.Close()
 

--- a/examples/features/multiplex/client/main.go
+++ b/examples/features/multiplex/client/main.go
@@ -59,7 +59,7 @@ func callUnaryEcho(client ecpb.EchoClient, message string) {
 func main() {
 	flag.Parse()
 	// Set up a connection to the server.
-	conn, err := grpc.Dial(*addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.NewClient(*addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		log.Fatalf("did not connect: %v", err)
 	}

--- a/examples/features/name_resolving/client/main.go
+++ b/examples/features/name_resolving/client/main.go
@@ -56,7 +56,7 @@ func makeRPCs(cc *grpc.ClientConn, n int) {
 }
 
 func main() {
-	passthroughConn, err := grpc.Dial(
+	passthroughConn, err := grpc.NewClient(
 		fmt.Sprintf("passthrough:///%s", backendAddr), // Dial to "passthrough:///localhost:50051"
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 	)
@@ -70,7 +70,7 @@ func main() {
 
 	fmt.Println()
 
-	exampleConn, err := grpc.Dial(
+	exampleConn, err := grpc.NewClient(
 		fmt.Sprintf("%s:///%s", exampleScheme, exampleServiceName), // Dial to "example:///resolver.example.grpc.io"
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 	)

--- a/examples/features/orca/client/main.go
+++ b/examples/features/orca/client/main.go
@@ -44,7 +44,7 @@ func main() {
 
 	// Set up a connection to the server.  Configure to use our custom LB
 	// policy which will receive all the ORCA load reports.
-	conn, err := grpc.Dial(*addr,
+	conn, err := grpc.NewClient(*addr,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithDefaultServiceConfig(`{"loadBalancingConfig": [{"orca_example":{}}]}`),
 	)
@@ -101,9 +101,9 @@ func (o *orcaLB) UpdateClientConnState(ccs balancer.ClientConnState) error {
 	// the use of the "passthrough" (default) name resolver.
 
 	addrs := ccs.ResolverState.Addresses
-	if len(addrs) != 1 {
-		return fmt.Errorf("orcaLB: expected 1 address; received: %v", addrs)
-	}
+	// if len(addrs) != 1 {
+	// 	return fmt.Errorf("orcaLB: expected 1 address; received: %v", addrs)
+	// }
 
 	// Create one SubConn for the address and connect it.
 	var sc balancer.SubConn

--- a/examples/features/orca/client/main.go
+++ b/examples/features/orca/client/main.go
@@ -97,14 +97,7 @@ type orcaLB struct {
 }
 
 func (o *orcaLB) UpdateClientConnState(ccs balancer.ClientConnState) error {
-	// We assume only one update, ever, containing exactly one address, given
-	// the use of the "passthrough" (default) name resolver.
-
 	addrs := ccs.ResolverState.Addresses
-	// if len(addrs) != 1 {
-	// 	return fmt.Errorf("orcaLB: expected 1 address; received: %v", addrs)
-	// }
-
 	// Create one SubConn for the address and connect it.
 	var sc balancer.SubConn
 	sc, err := o.cc.NewSubConn(addrs, balancer.NewSubConnOptions{

--- a/examples/features/retry/client/main.go
+++ b/examples/features/retry/client/main.go
@@ -49,7 +49,7 @@ var (
 
 // use grpc.WithDefaultServiceConfig() to set service config
 func retryDial() (*grpc.ClientConn, error) {
-	return grpc.Dial(*addr, grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithDefaultServiceConfig(retryPolicy))
+	return grpc.NewClient(*addr, grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithDefaultServiceConfig(retryPolicy))
 }
 
 func main() {

--- a/examples/features/stats_monitoring/client/main.go
+++ b/examples/features/stats_monitoring/client/main.go
@@ -41,7 +41,7 @@ func main() {
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithStatsHandler(statshandler.New()),
 	}
-	conn, err := grpc.Dial(*addr, opts...)
+	conn, err := grpc.NewClient(*addr, opts...)
 	if err != nil {
 		log.Fatalf("failed to connect to server %q: %v", *addr, err)
 	}

--- a/examples/features/unix_abstract/client/main.go
+++ b/examples/features/unix_abstract/client/main.go
@@ -63,9 +63,9 @@ func makeRPCs(cc *grpc.ClientConn, n int) {
 func main() {
 	flag.Parse()
 	sockAddr := fmt.Sprintf("unix-abstract:%v", *addr)
-	cc, err := grpc.Dial(sockAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	cc, err := grpc.NewClient(sockAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
-		log.Fatalf("grpc.Dial(%q) failed: %v", sockAddr, err)
+		log.Fatalf("grpc.NewClient(%q) failed: %v", sockAddr, err)
 	}
 	defer cc.Close()
 

--- a/examples/features/wait_for_ready/main.go
+++ b/examples/features/wait_for_ready/main.go
@@ -59,7 +59,7 @@ func serve() {
 }
 
 func main() {
-	conn, err := grpc.Dial("localhost:50053", grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.NewClient("localhost:50053", grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		log.Fatalf("did not connect: %v", err)
 	}

--- a/examples/features/xds/client/main.go
+++ b/examples/features/xds/client/main.go
@@ -56,9 +56,9 @@ func main() {
 			log.Fatalf("failed to create client-side xDS credentials: %v", err)
 		}
 	}
-	conn, err := grpc.Dial(*target, grpc.WithTransportCredentials(creds))
+	conn, err := grpc.NewClient(*target, grpc.WithTransportCredentials(creds))
 	if err != nil {
-		log.Fatalf("grpc.Dial(%s) failed: %v", *target, err)
+		log.Fatalf("grpc.NewClient(%s) failed: %v", *target, err)
 	}
 	defer conn.Close()
 

--- a/internal/idle/idle_e2e_test.go
+++ b/internal/idle/idle_e2e_test.go
@@ -488,9 +488,9 @@ func (s) TestChannelIdleness_Enabled_IdleTimeoutRacesWithRPCs(t *testing.T) {
 		grpc.WithIdleTimeout(defaultTestShortTimeout),
 		grpc.WithDefaultServiceConfig(`{"loadBalancingConfig": [{"round_robin":{}}]}`),
 	}
-	cc, err := grpc.Dial(r.Scheme()+":///test.server", dopts...)
+	cc, err := grpc.NewClient(r.Scheme()+":///test.server", dopts...)
 	if err != nil {
-		t.Fatalf("grpc.Dial() failed: %v", err)
+		t.Fatalf("grpc.NewClient() failed: %v", err)
 	}
 	defer cc.Close()
 
@@ -531,9 +531,9 @@ func (s) TestChannelIdleness_Connect(t *testing.T) {
 		grpc.WithIdleTimeout(defaultTestShortIdleTimeout),
 		grpc.WithDefaultServiceConfig(`{"loadBalancingConfig": [{"round_robin":{}}]}`),
 	}
-	cc, err := grpc.Dial(r.Scheme()+":///test.server", dopts...)
+	cc, err := grpc.NewClient(r.Scheme()+":///test.server", dopts...)
 	if err != nil {
-		t.Fatalf("grpc.Dial() failed: %v", err)
+		t.Fatalf("grpc.NewClient() failed: %v", err)
 	}
 	defer cc.Close()
 
@@ -581,9 +581,9 @@ func (s) TestChannelIdleness_RaceBetweenEnterAndExitIdleMode(t *testing.T) {
 		grpc.WithIdleTimeout(30 * time.Minute),
 		grpc.WithDefaultServiceConfig(`{"loadBalancingConfig": [{"pick_first":{}}]}`),
 	}
-	cc, err := grpc.Dial(r.Scheme()+":///test.server", dopts...)
+	cc, err := grpc.NewClient(r.Scheme()+":///test.server", dopts...)
 	if err != nil {
-		t.Fatalf("grpc.Dial() failed: %v", err)
+		t.Fatalf("grpc.NewClient() failed: %v", err)
 	}
 	defer cc.Close()
 

--- a/interop/xds/custom_lb_test.go
+++ b/interop/xds/custom_lb_test.go
@@ -105,9 +105,9 @@ func (s) TestCustomLB(t *testing.T) {
 		ServiceConfig: sc,
 	})
 
-	cc, err := grpc.Dial(mr.Scheme()+":///", grpc.WithResolvers(mr), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	cc, err := grpc.NewClient(mr.Scheme()+":///", grpc.WithResolvers(mr), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
-		t.Fatalf("grpc.Dial() failed: %v", err)
+		t.Fatalf("grpc.NewClient() failed: %v", err)
 	}
 	defer cc.Close()
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)

--- a/orca/call_metrics_test.go
+++ b/orca/call_metrics_test.go
@@ -118,9 +118,9 @@ func (s) TestE2ECallMetricsUnary(t *testing.T) {
 			defer srv.Stop()
 
 			// Dial the stub server.
-			cc, err := grpc.Dial(srv.Address, grpc.WithTransportCredentials(insecure.NewCredentials()))
+			cc, err := grpc.NewClient(srv.Address, grpc.WithTransportCredentials(insecure.NewCredentials()))
 			if err != nil {
-				t.Fatalf("grpc.Dial(%s) failed: %v", srv.Address, err)
+				t.Fatalf("grpc.NewClient(%s) failed: %v", srv.Address, err)
 			}
 			defer cc.Close()
 
@@ -239,9 +239,9 @@ func (s) TestE2ECallMetricsStreaming(t *testing.T) {
 			defer srv.Stop()
 
 			// Dial the stub server.
-			cc, err := grpc.Dial(srv.Address, grpc.WithTransportCredentials(insecure.NewCredentials()))
+			cc, err := grpc.NewClient(srv.Address, grpc.WithTransportCredentials(insecure.NewCredentials()))
 			if err != nil {
-				t.Fatalf("grpc.Dial(%s) failed: %v", srv.Address, err)
+				t.Fatalf("grpc.NewClient(%s) failed: %v", srv.Address, err)
 			}
 			defer cc.Close()
 

--- a/orca/service_test.go
+++ b/orca/service_test.go
@@ -106,9 +106,9 @@ func (s) TestE2E_CustomBackendMetrics_OutOfBand(t *testing.T) {
 	t.Logf("Started gRPC server at %s...", lis.Addr().String())
 
 	// Dial the test server.
-	cc, err := grpc.Dial(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	cc, err := grpc.NewClient(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
-		t.Fatalf("grpc.Dial(%s) failed: %v", lis.Addr().String(), err)
+		t.Fatalf("grpc.NewClient(%s) failed: %v", lis.Addr().String(), err)
 	}
 	defer cc.Close()
 

--- a/reflection/test/serverreflection_test.go
+++ b/reflection/test/serverreflection_test.go
@@ -413,7 +413,7 @@ func (x) TestReflectionEnd2end(t *testing.T) {
 	t.Cleanup(s.Stop)
 
 	// Create client.
-	conn, err := grpc.Dial(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.NewClient(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		t.Fatalf("cannot connect to server: %v", err)
 	}

--- a/resolver_balancer_ext_test.go
+++ b/resolver_balancer_ext_test.go
@@ -150,9 +150,9 @@ func (s) TestEnterIdleDuringResolverUpdateState(t *testing.T) {
 	}
 	resolver.Register(rb)
 
-	cc, err := grpc.Dial(name+":///", grpc.WithTransportCredentials(insecure.NewCredentials()))
+	cc, err := grpc.NewClient(name+":///", grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
-		t.Fatalf("grpc.Dial error: %v", err)
+		t.Fatalf("grpc.NewClient error: %v", err)
 	}
 	defer cc.Close()
 
@@ -196,12 +196,12 @@ func (s) TestEnterIdleDuringBalancerUpdateState(t *testing.T) {
 	}
 	resolver.Register(rb)
 
-	cc, err := grpc.Dial(
+	cc, err := grpc.NewClient(
 		name+":///",
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithDefaultServiceConfig(`{"loadBalancingConfig": [{"`+name+`":{}}]}`))
 	if err != nil {
-		t.Fatalf("grpc.Dial error: %v", err)
+		t.Fatalf("grpc.NewClient error: %v", err)
 	}
 	defer cc.Close()
 
@@ -241,12 +241,12 @@ func (s) TestEnterIdleDuringBalancerNewSubConn(t *testing.T) {
 	}
 	resolver.Register(rb)
 
-	cc, err := grpc.Dial(
+	cc, err := grpc.NewClient(
 		name+":///",
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithDefaultServiceConfig(`{"loadBalancingConfig": [{"`+name+`":{}}]}`))
 	if err != nil {
-		t.Fatalf("grpc.Dial error: %v", err)
+		t.Fatalf("grpc.NewClient error: %v", err)
 	}
 	defer cc.Close()
 

--- a/security/advancedtls/examples/credential_reloading_from_files/client/main.go
+++ b/security/advancedtls/examples/credential_reloading_from_files/client/main.go
@@ -90,9 +90,9 @@ func main() {
 	}
 
 	// Make a connection using the credentials.
-	conn, err := grpc.Dial(address, grpc.WithTransportCredentials(clientTLSCreds))
+	conn, err := grpc.NewClient(address, grpc.WithTransportCredentials(clientTLSCreds))
 	if err != nil {
-		log.Fatalf("grpc.DialContext to %s failed: %v", address, err)
+		log.Fatalf("grpc.NewClient to %s failed: %v", address, err)
 	}
 	client := pb.NewGreeterClient(conn)
 

--- a/server_ext_test.go
+++ b/server_ext_test.go
@@ -124,9 +124,9 @@ func (s) TestStreamWorkers_RPCsAndStop(t *testing.T) {
 	ccs := make([]*grpc.ClientConn, numChannels)
 	for i := 0; i < numChannels; i++ {
 		var err error
-		ccs[i], err = grpc.Dial(ss.Address, grpc.WithTransportCredentials(insecure.NewCredentials()))
+		ccs[i], err = grpc.NewClient(ss.Address, grpc.WithTransportCredentials(insecure.NewCredentials()))
 		if err != nil {
-			t.Fatalf("[iteration: %d] grpc.Dial(%s) failed: %v", i, ss.Address, err)
+			t.Fatalf("[iteration: %d] grpc.NewClient(%s) failed: %v", i, ss.Address, err)
 		}
 		defer ccs[i].Close()
 		client := testgrpc.NewTestServiceClient(ccs[i])

--- a/test/authority_test.go
+++ b/test/authority_test.go
@@ -228,9 +228,9 @@ func (s) TestAuthorityReplacedWithResolverAddress(t *testing.T) {
 
 	r := manual.NewBuilderWithScheme("whatever")
 	r.InitialState(resolver.State{Addresses: []resolver.Address{{Addr: ss.Address, ServerName: expectedAuthority}}})
-	cc, err := grpc.Dial(r.Scheme()+":///whatever", grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithResolvers(r))
+	cc, err := grpc.NewClient(r.Scheme()+":///whatever", grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithResolvers(r))
 	if err != nil {
-		t.Fatalf("grpc.Dial(%q) = %v", ss.Address, err)
+		t.Fatalf("grpc.NewClient(%q) = %v", ss.Address, err)
 	}
 	defer cc.Close()
 

--- a/test/balancer_test.go
+++ b/test/balancer_test.go
@@ -429,7 +429,7 @@ func (s) TestAddressAttributesInNewSubConn(t *testing.T) {
 		grpc.WithResolvers(r),
 		grpc.WithDefaultServiceConfig(fmt.Sprintf(`{ "loadBalancingConfig": [{"%v": {}}] }`, attrBalancerName)),
 	}
-	cc, err := grpc.Dial(r.Scheme()+":///test.server", dopts...)
+	cc, err := grpc.NewClient(r.Scheme()+":///test.server", dopts...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -753,7 +753,7 @@ func (s) TestAuthorityInBuildOptions(t *testing.T) {
 				grpc.WithResolvers(r),
 				grpc.WithDefaultServiceConfig(fmt.Sprintf(`{ "loadBalancingConfig": [{"%v": {}}] }`, balancerName)),
 			}, test.dopts...)
-			cc, err := grpc.Dial(r.Scheme()+":///"+dialTarget, dopts...)
+			cc, err := grpc.NewClient(r.Scheme()+":///"+dialTarget, dopts...)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -863,9 +863,9 @@ func (s) TestMetadataInPickResult(t *testing.T) {
 		grpc.WithResolvers(r),
 		grpc.WithDefaultServiceConfig(fmt.Sprintf(`{"loadBalancingConfig": [{"%s":{}}]}`, t.Name())),
 	}
-	cc, err := grpc.Dial(r.Scheme()+":///test.server", dopts...)
+	cc, err := grpc.NewClient(r.Scheme()+":///test.server", dopts...)
 	if err != nil {
-		t.Fatalf("grpc.Dial(): %v", err)
+		t.Fatalf("grpc.NewClient(): %v", err)
 	}
 	defer cc.Close()
 	tc := testgrpc.NewTestServiceClient(cc)

--- a/test/channelz_test.go
+++ b/test/channelz_test.go
@@ -302,7 +302,7 @@ func (s) TestCZTopChannelRegistrationAndDeletion(t *testing.T) {
 
 func (s) TestCZTopChannelRegistrationAndDeletionWhenDialFail(t *testing.T) {
 	// Make dial fails (due to no transport security specified)
-	_, err := grpc.Dial("fake.addr")
+	_, err := grpc.NewClient("fake.addr")
 	if err == nil {
 		t.Fatal("expecting dial to fail")
 	}

--- a/test/clientconn_test.go
+++ b/test/clientconn_test.go
@@ -41,9 +41,9 @@ import (
 // the expected error code.
 func (s) TestClientConnClose_WithPendingRPC(t *testing.T) {
 	r := manual.NewBuilderWithScheme("whatever")
-	cc, err := grpc.Dial(r.Scheme()+":///test.server", grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithResolvers(r))
+	cc, err := grpc.NewClient(r.Scheme()+":///test.server", grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithResolvers(r))
 	if err != nil {
-		t.Fatalf("grpc.Dial() failed: %v", err)
+		t.Fatalf("grpc.NewClient() failed: %v", err)
 	}
 	client := testgrpc.NewTestServiceClient(cc)
 

--- a/test/goaway_test.go
+++ b/test/goaway_test.go
@@ -72,7 +72,7 @@ func (s) TestGracefulClientOnGoAway(t *testing.T) {
 	}
 	go s.Serve(lis)
 
-	cc, err := grpc.Dial(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	cc, err := grpc.NewClient(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		t.Fatalf("Failed to dial server: %v", err)
 	}

--- a/test/http_header_end2end_test.go
+++ b/test/http_header_end2end_test.go
@@ -242,9 +242,9 @@ func startServer(t *testing.T, headerFields ...[]string) (serverAddr string, cle
 }
 
 func doHTTPHeaderTest(lisAddr string, errCode codes.Code) error {
-	cc, err := grpc.Dial(lisAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	cc, err := grpc.NewClient(lisAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
-		return fmt.Errorf("dial(%q): %v", lisAddr, err)
+		return fmt.Errorf("NewClient(%q): %v", lisAddr, err)
 	}
 	defer cc.Close()
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)

--- a/test/insecure_creds_test.go
+++ b/test/insecure_creds_test.go
@@ -126,9 +126,9 @@ func (s) TestInsecureCreds(t *testing.T) {
 			if test.clientInsecureCreds {
 				opts = []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}
 			}
-			cc, err := grpc.Dial(addr, opts...)
+			cc, err := grpc.NewClient(addr, opts...)
 			if err != nil {
-				t.Fatalf("grpc.Dial(%q) failed: %v", addr, err)
+				t.Fatalf("grpc.NewClient(%q) failed: %v", addr, err)
 			}
 			defer cc.Close()
 
@@ -165,9 +165,9 @@ func (s) TestInsecureCreds_WithPerRPCCredentials_AsCallOption(t *testing.T) {
 
 	dopts := []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}
 	copts := []grpc.CallOption{grpc.PerRPCCredentials(testLegacyPerRPCCredentials{})}
-	cc, err := grpc.Dial(addr, dopts...)
+	cc, err := grpc.NewClient(addr, dopts...)
 	if err != nil {
-		t.Fatalf("grpc.Dial(%q) failed: %v", addr, err)
+		t.Fatalf("grpc.NewClient(%q) failed: %v", addr, err)
 	}
 	defer cc.Close()
 
@@ -201,7 +201,7 @@ func (s) TestInsecureCreds_WithPerRPCCredentials_AsDialOption(t *testing.T) {
 		grpc.WithPerRPCCredentials(testLegacyPerRPCCredentials{}),
 	}
 	const wantErr = "the credentials require transport level security"
-	if _, err := grpc.Dial(addr, dopts...); err == nil || !strings.Contains(err.Error(), wantErr) {
-		t.Fatalf("grpc.Dial(%q) returned err %v, want: %v", addr, err, wantErr)
+	if _, err := grpc.NewClient(addr, dopts...); err == nil || !strings.Contains(err.Error(), wantErr) {
+		t.Fatalf("grpc.NewClient(%q) returned err %v, want: %v", addr, err, wantErr)
 	}
 }

--- a/test/local_creds_test.go
+++ b/test/local_creds_test.go
@@ -93,7 +93,7 @@ func testLocalCredsE2ESucceed(network, address string) error {
 				return net.Dial("unix", addr)
 			}))
 	case "tcp":
-		cc, err = grpc.Dial(lisAddr, grpc.WithTransportCredentials(local.NewCredentials()))
+		cc, err = grpc.NewClient(lisAddr, grpc.WithTransportCredentials(local.NewCredentials()))
 	default:
 		return fmt.Errorf("unsupported network %q", network)
 	}
@@ -191,7 +191,7 @@ func testLocalCredsE2EFail(dopts []grpc.DialOption) error {
 
 	go s.Serve(spoofListener(lis, fakeClientAddr))
 
-	cc, err := grpc.Dial(lis.Addr().String(), append(dopts, grpc.WithDialer(spoofDialer(fakeServerAddr)))...)
+	cc, err := grpc.NewClient(lis.Addr().String(), append(dopts, grpc.WithDialer(spoofDialer(fakeServerAddr)))...)
 	if err != nil {
 		return fmt.Errorf("Failed to dial server: %v, %v", err, lis.Addr().String())
 	}

--- a/test/pickfirst_test.go
+++ b/test/pickfirst_test.go
@@ -80,9 +80,9 @@ func setupPickFirst(t *testing.T, backendCount int, opts ...grpc.DialOption) (*g
 		grpc.WithDefaultServiceConfig(pickFirstServiceConfig),
 	}
 	dopts = append(dopts, opts...)
-	cc, err := grpc.Dial(r.Scheme()+":///test.server", dopts...)
+	cc, err := grpc.NewClient(r.Scheme()+":///test.server", dopts...)
 	if err != nil {
-		t.Fatalf("grpc.Dial() failed: %v", err)
+		t.Fatalf("grpc.NewClient() failed: %v", err)
 	}
 	t.Cleanup(func() { cc.Close() })
 
@@ -531,9 +531,9 @@ func setupPickFirstWithListenerWrapper(t *testing.T, backendCount int, opts ...g
 		grpc.WithDefaultServiceConfig(pickFirstServiceConfig),
 	}
 	dopts = append(dopts, opts...)
-	cc, err := grpc.Dial(r.Scheme()+":///test.server", dopts...)
+	cc, err := grpc.NewClient(r.Scheme()+":///test.server", dopts...)
 	if err != nil {
-		t.Fatalf("grpc.Dial() failed: %v", err)
+		t.Fatalf("grpc.NewClient() failed: %v", err)
 	}
 	t.Cleanup(func() { cc.Close() })
 

--- a/test/resolver_update_test.go
+++ b/test/resolver_update_test.go
@@ -56,9 +56,9 @@ func (s) TestResolverUpdateDuringBuild_ServiceConfigParseError(t *testing.T) {
 	r := manual.NewBuilderWithScheme("whatever")
 	r.InitialState(resolver.State{ServiceConfig: &serviceconfig.ParseResult{Err: errors.New("resolver build err")}})
 
-	cc, err := grpc.Dial(r.Scheme()+":///test.server", grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithResolvers(r))
+	cc, err := grpc.NewClient(r.Scheme()+":///test.server", grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithResolvers(r))
 	if err != nil {
-		t.Fatalf("Dial(_, _) = _, %v; want _, nil", err)
+		t.Fatalf("NewClient(_, _) = _, %v; want _, nil", err)
 	}
 	defer cc.Close()
 
@@ -88,9 +88,9 @@ func (s) TestResolverUpdateDuringBuild_ServiceConfigInvalidTypeError(t *testing.
 	r := manual.NewBuilderWithScheme("whatever")
 	r.InitialState(resolver.State{ServiceConfig: &serviceconfig.ParseResult{Config: fakeConfig{}}})
 
-	cc, err := grpc.Dial(r.Scheme()+":///test.server", grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithResolvers(r))
+	cc, err := grpc.NewClient(r.Scheme()+":///test.server", grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithResolvers(r))
 	if err != nil {
-		t.Fatalf("Dial(_, _) = _, %v; want _, nil", err)
+		t.Fatalf("NewClient(_, _) = _, %v; want _, nil", err)
 	}
 	defer cc.Close()
 

--- a/test/retry_test.go
+++ b/test/retry_test.go
@@ -531,7 +531,7 @@ func (s) TestRetryStats(t *testing.T) {
 	}
 	server.start(t, lis)
 	handler := &retryStatsHandler{}
-	cc, err := grpc.Dial(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithStatsHandler(handler),
+	cc, err := grpc.NewClient(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithStatsHandler(handler),
 		grpc.WithDefaultServiceConfig((`{
     "methodConfig": [{
       "name": [{"service": "grpc.testing.TestService"}],

--- a/test/roundrobin_test.go
+++ b/test/roundrobin_test.go
@@ -72,9 +72,9 @@ func testRoundRobinBasic(ctx context.Context, t *testing.T, opts ...grpc.DialOpt
 		grpc.WithDefaultServiceConfig(rrServiceConfig),
 	}
 	dopts = append(dopts, opts...)
-	cc, err := grpc.Dial(r.Scheme()+":///test.server", dopts...)
+	cc, err := grpc.NewClient(r.Scheme()+":///test.server", dopts...)
 	if err != nil {
-		t.Fatalf("grpc.Dial() failed: %v", err)
+		t.Fatalf("grpc.NewClient() failed: %v", err)
 	}
 	t.Cleanup(func() { cc.Close() })
 	client := testgrpc.NewTestServiceClient(cc)

--- a/test/xds/xds_client_ack_nack_test.go
+++ b/test/xds/xds_client_ack_nack_test.go
@@ -142,7 +142,7 @@ func (s) TestClientResourceVersionAfterStreamRestart(t *testing.T) {
 	}
 
 	// Create a ClientConn and make a successful RPC.
-	cc, err := grpc.Dial(fmt.Sprintf("xds:///%s", serviceName), grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithResolvers(resolver))
+	cc, err := grpc.NewClient(fmt.Sprintf("xds:///%s", serviceName), grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithResolvers(resolver))
 	if err != nil {
 		t.Fatalf("failed to dial local test server: %v", err)
 	}

--- a/test/xds/xds_client_affinity_test.go
+++ b/test/xds/xds_client_affinity_test.go
@@ -115,7 +115,7 @@ func (s) TestClientSideAffinitySanityCheck(t *testing.T) {
 	}
 
 	// Create a ClientConn and make a successful RPC.
-	cc, err := grpc.Dial(fmt.Sprintf("xds:///%s", serviceName), grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithResolvers(resolver))
+	cc, err := grpc.NewClient(fmt.Sprintf("xds:///%s", serviceName), grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithResolvers(resolver))
 	if err != nil {
 		t.Fatalf("failed to dial local test server: %v", err)
 	}

--- a/test/xds/xds_client_certificate_providers_test.go
+++ b/test/xds/xds_client_certificate_providers_test.go
@@ -112,7 +112,7 @@ func (s) TestClientSideXDS_WithNoCertificateProvidersInBootstrap_Success(t *test
 	}
 
 	// Create a ClientConn and make a successful RPC.
-	cc, err := grpc.Dial(fmt.Sprintf("xds:///%s", serviceName), grpc.WithTransportCredentials(creds), grpc.WithResolvers(resolverBuilder))
+	cc, err := grpc.NewClient(fmt.Sprintf("xds:///%s", serviceName), grpc.WithTransportCredentials(creds), grpc.WithResolvers(resolverBuilder))
 	if err != nil {
 		t.Fatalf("failed to dial local test server: %v", err)
 	}
@@ -330,7 +330,7 @@ func (s) TestClientSideXDS_WithValidAndInvalidSecurityConfiguration(t *testing.T
 	}
 
 	// Create a ClientConn.
-	cc, err := grpc.Dial(fmt.Sprintf("xds:///%s", serviceName), grpc.WithTransportCredentials(creds), grpc.WithResolvers(resolver))
+	cc, err := grpc.NewClient(fmt.Sprintf("xds:///%s", serviceName), grpc.WithTransportCredentials(creds), grpc.WithResolvers(resolver))
 	if err != nil {
 		t.Fatalf("failed to dial local test server: %v", err)
 	}

--- a/test/xds/xds_client_custom_lb_test.go
+++ b/test/xds/xds_client_custom_lb_test.go
@@ -253,7 +253,7 @@ func (s) TestWrrLocality(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			cc, err := grpc.Dial(fmt.Sprintf("xds:///%s", serviceName), grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithResolvers(r))
+			cc, err := grpc.NewClient(fmt.Sprintf("xds:///%s", serviceName), grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithResolvers(r))
 			if err != nil {
 				t.Fatalf("Failed to dial local test server: %v", err)
 			}

--- a/test/xds/xds_client_federation_test.go
+++ b/test/xds/xds_client_federation_test.go
@@ -128,7 +128,7 @@ func (s) TestClientSideFederation(t *testing.T) {
 	}
 
 	// Create a ClientConn and make a successful RPC.
-	cc, err := grpc.Dial(fmt.Sprintf("xds:///%s", serviceName), grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithResolvers(resolver))
+	cc, err := grpc.NewClient(fmt.Sprintf("xds:///%s", serviceName), grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithResolvers(resolver))
 	if err != nil {
 		t.Fatalf("failed to dial local test server: %v", err)
 	}
@@ -213,7 +213,7 @@ func (s) TestClientSideFederationWithOnlyXDSTPStyleLDS(t *testing.T) {
 	}
 
 	// Create a ClientConn and make a successful RPC.
-	cc, err := grpc.Dial(fmt.Sprintf("xds:///%s", serviceName), grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithResolvers(resolver))
+	cc, err := grpc.NewClient(fmt.Sprintf("xds:///%s", serviceName), grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithResolvers(resolver))
 	if err != nil {
 		t.Fatalf("failed to dial local test server: %v", err)
 	}
@@ -258,7 +258,7 @@ func (s) TestFederation_UnknownAuthorityInDialTarget(t *testing.T) {
 
 	// Create a ClientConn and make a successful RPC.
 	target := fmt.Sprintf("xds:///%s", serviceName)
-	cc, err := grpc.Dial(target, grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithResolvers(resolver))
+	cc, err := grpc.NewClient(target, grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithResolvers(resolver))
 	if err != nil {
 		t.Fatalf("Dialing target %q: %v", target, err)
 	}
@@ -327,7 +327,7 @@ func (s) TestFederation_UnknownAuthorityInReceivedResponse(t *testing.T) {
 	}
 
 	target := fmt.Sprintf("xds:///%s", serviceName)
-	cc, err := grpc.Dial(target, grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithResolvers(resolver))
+	cc, err := grpc.NewClient(target, grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithResolvers(resolver))
 	if err != nil {
 		t.Fatalf("Dialing target %q: %v", target, err)
 	}

--- a/test/xds/xds_client_ignore_resource_deletion_test.go
+++ b/test/xds/xds_client_ignore_resource_deletion_test.go
@@ -158,7 +158,7 @@ func testResourceDeletionIgnored(t *testing.T, initialResource func(string) e2e.
 		t.Fatal(err)
 	}
 
-	cc, err := grpc.Dial(fmt.Sprintf("xds:///%s", serviceName), grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithResolvers(xdsR))
+	cc, err := grpc.NewClient(fmt.Sprintf("xds:///%s", serviceName), grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithResolvers(xdsR))
 	if err != nil {
 		t.Fatalf("Failed to dial local test server: %v.", err)
 	}
@@ -213,7 +213,7 @@ func testResourceDeletionNotIgnored(t *testing.T, initialResource func(string) e
 		t.Fatal(err)
 	}
 
-	cc, err := grpc.Dial(fmt.Sprintf("xds:///%s", serviceName), grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithResolvers(xdsR))
+	cc, err := grpc.NewClient(fmt.Sprintf("xds:///%s", serviceName), grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithResolvers(xdsR))
 	if err != nil {
 		t.Fatalf("failed to dial local test server: %v", err)
 	}
@@ -375,7 +375,7 @@ func (s) TestListenerResourceDeletionOnServerIgnored(t *testing.T) {
 	}
 
 	// Create a ClientConn and make a successful RPCs.
-	cc, err := grpc.Dial(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithResolvers(xdsR))
+	cc, err := grpc.NewClient(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithResolvers(xdsR))
 	if err != nil {
 		t.Fatalf("failed to dial local test server: %v", err)
 	}
@@ -442,7 +442,7 @@ func (s) TestListenerResourceDeletionOnServerNotIgnored(t *testing.T) {
 	}
 
 	// Create a ClientConn and make a successful RPCs.
-	cc, err := grpc.Dial(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithResolvers(xdsR))
+	cc, err := grpc.NewClient(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithResolvers(xdsR))
 	if err != nil {
 		t.Fatalf("failed to dial local test server: %v", err)
 	}

--- a/test/xds/xds_client_integration_test.go
+++ b/test/xds/xds_client_integration_test.go
@@ -70,7 +70,7 @@ func (s) TestClientSideXDS(t *testing.T) {
 	}
 
 	// Create a ClientConn and make a successful RPC.
-	cc, err := grpc.Dial(fmt.Sprintf("xds:///%s", serviceName), grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithResolvers(resolver))
+	cc, err := grpc.NewClient(fmt.Sprintf("xds:///%s", serviceName), grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithResolvers(resolver))
 	if err != nil {
 		t.Fatalf("failed to dial local test server: %v", err)
 	}

--- a/test/xds/xds_client_outlier_detection_test.go
+++ b/test/xds/xds_client_outlier_detection_test.go
@@ -75,7 +75,7 @@ func (s) TestOutlierDetection_NoopConfig(t *testing.T) {
 	}
 
 	// Create a ClientConn and make a successful RPC.
-	cc, err := grpc.Dial(fmt.Sprintf("xds:///%s", serviceName), grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithResolvers(resolver))
+	cc, err := grpc.NewClient(fmt.Sprintf("xds:///%s", serviceName), grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithResolvers(resolver))
 	if err != nil {
 		t.Fatalf("failed to dial local test server: %v", err)
 	}
@@ -204,7 +204,7 @@ func (s) TestOutlierDetectionWithOutlier(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cc, err := grpc.Dial(fmt.Sprintf("xds:///%s", serviceName), grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithResolvers(r))
+	cc, err := grpc.NewClient(fmt.Sprintf("xds:///%s", serviceName), grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithResolvers(r))
 	if err != nil {
 		t.Fatalf("failed to dial local test server: %v", err)
 	}
@@ -291,7 +291,7 @@ func (s) TestOutlierDetectionXDSDefaultOn(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cc, err := grpc.Dial(fmt.Sprintf("xds:///%s", serviceName), grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithResolvers(r))
+	cc, err := grpc.NewClient(fmt.Sprintf("xds:///%s", serviceName), grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithResolvers(r))
 	if err != nil {
 		t.Fatalf("failed to dial local test server: %v", err)
 	}

--- a/test/xds/xds_client_retry_test.go
+++ b/test/xds/xds_client_retry_test.go
@@ -69,7 +69,7 @@ func (s) TestClientSideRetry(t *testing.T) {
 	}
 
 	// Create a ClientConn and make a successful RPC.
-	cc, err := grpc.Dial(fmt.Sprintf("xds:///%s", serviceName), grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithResolvers(resolver))
+	cc, err := grpc.NewClient(fmt.Sprintf("xds:///%s", serviceName), grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithResolvers(resolver))
 	if err != nil {
 		t.Fatalf("failed to dial local test server: %v", err)
 	}

--- a/test/xds/xds_rls_clusterspecifier_plugin_test.go
+++ b/test/xds/xds_rls_clusterspecifier_plugin_test.go
@@ -142,7 +142,7 @@ func testRLSinxDS(t *testing.T, lbPolicy e2e.LoadBalancingPolicy) {
 	})
 
 	// Create a ClientConn and make a successful RPC.
-	cc, err := grpc.Dial(fmt.Sprintf("xds:///%s", serviceName), grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithResolvers(resolver))
+	cc, err := grpc.NewClient(fmt.Sprintf("xds:///%s", serviceName), grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithResolvers(resolver))
 	if err != nil {
 		t.Fatalf("failed to dial local test server: %v", err)
 	}

--- a/test/xds/xds_security_config_nack_test.go
+++ b/test/xds/xds_security_config_nack_test.go
@@ -344,7 +344,7 @@ func (s) TestUnmarshalCluster_WithUpdateValidatorFunc(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			cc, err := grpc.Dial(fmt.Sprintf("xds:///%s", serviceName), grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithResolvers(resolver))
+			cc, err := grpc.NewClient(fmt.Sprintf("xds:///%s", serviceName), grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithResolvers(resolver))
 			if err != nil {
 				t.Fatalf("failed to dial local test server: %v", err)
 			}

--- a/test/xds/xds_server_certificate_providers_test.go
+++ b/test/xds/xds_server_certificate_providers_test.go
@@ -97,7 +97,7 @@ func (s) TestServerSideXDS_WithNoCertificateProvidersInBootstrap_Success(t *test
 	}
 
 	// Create a client that uses insecure creds and verify RPCs.
-	cc, err := grpc.Dial(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	cc, err := grpc.NewClient(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		t.Fatalf("Failed to dial local test server: %v", err)
 	}
@@ -225,7 +225,7 @@ func (s) TestServerSideXDS_WithNoCertificateProvidersInBootstrap_Failure(t *test
 
 	// Create a client that uses insecure creds and verify that RPCs don't
 	// succeed.
-	cc, err := grpc.Dial(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	cc, err := grpc.NewClient(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		t.Fatalf("Failed to dial local test server: %v", err)
 	}
@@ -443,7 +443,7 @@ func (s) TestServerSideXDS_WithValidAndInvalidSecurityConfiguration(t *testing.T
 
 	// Create a client that uses TLS creds and verify RPCs to listener1.
 	clientCreds := e2e.CreateClientTLSCredentials(t)
-	cc1, err := grpc.Dial(lis1.Addr().String(), grpc.WithTransportCredentials(clientCreds))
+	cc1, err := grpc.NewClient(lis1.Addr().String(), grpc.WithTransportCredentials(clientCreds))
 	if err != nil {
 		t.Fatalf("Failed to dial local test server: %v", err)
 	}
@@ -471,7 +471,7 @@ func (s) TestServerSideXDS_WithValidAndInvalidSecurityConfiguration(t *testing.T
 
 	// Create a client that uses insecure creds and verify that RPCs don't
 	// succeed to listener2.
-	cc2, err := grpc.Dial(lis2.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	cc2, err := grpc.NewClient(lis2.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		t.Fatalf("Failed to dial local test server: %v", err)
 	}

--- a/test/xds/xds_server_serving_mode_test.go
+++ b/test/xds/xds_server_serving_mode_test.go
@@ -103,7 +103,7 @@ func (s) TestServerSideXDS_RedundantUpdateSuppression(t *testing.T) {
 	}
 
 	// Create a ClientConn and make a successful RPCs.
-	cc, err := grpc.Dial(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	cc, err := grpc.NewClient(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		t.Fatalf("failed to dial local test server: %v", err)
 	}
@@ -265,7 +265,7 @@ func (s) TestServerSideXDS_ServingModeChanges(t *testing.T) {
 	}
 
 	// Create a ClientConn to the first listener and make a successful RPCs.
-	cc1, err := grpc.Dial(lis1.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	cc1, err := grpc.NewClient(lis1.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		t.Fatalf("failed to dial local test server: %v", err)
 	}
@@ -273,7 +273,7 @@ func (s) TestServerSideXDS_ServingModeChanges(t *testing.T) {
 	waitForSuccessfulRPC(ctx, t, cc1)
 
 	// Create a ClientConn to the second listener and make a successful RPCs.
-	cc2, err := grpc.Dial(lis2.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	cc2, err := grpc.NewClient(lis2.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		t.Fatalf("failed to dial local test server: %v", err)
 	}

--- a/test/xds/xds_server_test.go
+++ b/test/xds/xds_server_test.go
@@ -110,7 +110,7 @@ func (s) TestServeLDSRDS(t *testing.T) {
 	case <-serving.Done():
 	}
 
-	cc, err := grpc.Dial(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	cc, err := grpc.NewClient(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		t.Fatalf("failed to dial local test server: %v", err)
 	}
@@ -214,7 +214,7 @@ func (s) TestRDSNack(t *testing.T) {
 		}
 	}()
 
-	cc, err := grpc.Dial(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	cc, err := grpc.NewClient(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		t.Fatalf("failed to dial local test server: %v", err)
 	}
@@ -277,7 +277,7 @@ func (s) TestResourceNotFoundRDS(t *testing.T) {
 		}
 	}()
 
-	cc, err := grpc.Dial(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	cc, err := grpc.NewClient(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		t.Fatalf("failed to dial local test server: %v", err)
 	}
@@ -358,7 +358,7 @@ func (s) TestServingModeChanges(t *testing.T) {
 			t.Errorf("Serve() failed: %v", err)
 		}
 	}()
-	cc, err := grpc.Dial(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	cc, err := grpc.NewClient(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		t.Fatalf("failed to dial local test server: %v", err)
 	}
@@ -471,7 +471,7 @@ func (s) TestMultipleUpdatesImmediatelySwitch(t *testing.T) {
 		}
 	}()
 
-	cc, err := grpc.Dial(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	cc, err := grpc.NewClient(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		t.Fatalf("failed to dial local test server: %v", err)
 	}

--- a/xds/csds/csds_e2e_test.go
+++ b/xds/csds/csds_e2e_test.go
@@ -165,7 +165,7 @@ func (s) TestCSDS(t *testing.T) {
 	}()
 
 	// Create a client to the CSDS server.
-	conn, err := grpc.Dial(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.NewClient(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		t.Fatalf("Failed to dial CSDS server %q: %v", lis.Addr().String(), err)
 	}
@@ -434,7 +434,7 @@ func (s) TestCSDSNoXDSClient(t *testing.T) {
 	defer server.Stop()
 
 	// Create a client to the CSDS server.
-	conn, err := grpc.Dial(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.NewClient(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		t.Fatalf("Failed to dial CSDS server %q: %v", lis.Addr().String(), err)
 	}

--- a/xds/internal/balancer/clusterimpl/tests/balancer_test.go
+++ b/xds/internal/balancer/clusterimpl/tests/balancer_test.go
@@ -92,7 +92,7 @@ func (s) TestConfigUpdateWithSameLoadReportingServerConfig(t *testing.T) {
 	}
 
 	// Create a ClientConn and make a successful RPC.
-	cc, err := grpc.Dial(fmt.Sprintf("xds:///%s", serviceName), grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithResolvers(resolver))
+	cc, err := grpc.NewClient(fmt.Sprintf("xds:///%s", serviceName), grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithResolvers(resolver))
 	if err != nil {
 		t.Fatalf("failed to dial local test server: %v", err)
 	}

--- a/xds/internal/balancer/outlierdetection/e2e_test/outlierdetection_test.go
+++ b/xds/internal/balancer/outlierdetection/e2e_test/outlierdetection_test.go
@@ -221,9 +221,9 @@ func (s) TestOutlierDetectionAlgorithmsE2E(t *testing.T) {
 				ServiceConfig: sc,
 			})
 
-			cc, err := grpc.Dial(mr.Scheme()+":///", grpc.WithResolvers(mr), grpc.WithTransportCredentials(insecure.NewCredentials()))
+			cc, err := grpc.NewClient(mr.Scheme()+":///", grpc.WithResolvers(mr), grpc.WithTransportCredentials(insecure.NewCredentials()))
 			if err != nil {
-				t.Fatalf("grpc.Dial() failed: %v", err)
+				t.Fatalf("grpc.NewClient() failed: %v", err)
 			}
 			defer cc.Close()
 			ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
@@ -298,9 +298,9 @@ func (s) TestNoopConfiguration(t *testing.T) {
 		Addresses:     fullAddresses,
 		ServiceConfig: sc,
 	})
-	cc, err := grpc.Dial(mr.Scheme()+":///", grpc.WithResolvers(mr), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	cc, err := grpc.NewClient(mr.Scheme()+":///", grpc.WithResolvers(mr), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
-		t.Fatalf("grpc.Dial() failed: %v", err)
+		t.Fatalf("grpc.NewClient() failed: %v", err)
 	}
 	defer cc.Close()
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)

--- a/xds/internal/httpfilter/fault/fault_test.go
+++ b/xds/internal/httpfilter/fault/fault_test.go
@@ -529,7 +529,7 @@ func (s) TestFaultInjection_Unary(t *testing.T) {
 			}
 
 			// Create a ClientConn and run the test case.
-			cc, err := grpc.Dial("xds:///"+serviceName, grpc.WithTransportCredentials(insecure.NewCredentials()))
+			cc, err := grpc.NewClient("xds:///"+serviceName, grpc.WithTransportCredentials(insecure.NewCredentials()))
 			if err != nil {
 				t.Fatalf("failed to dial local test server: %v", err)
 			}
@@ -605,7 +605,7 @@ func (s) TestFaultInjection_MaxActiveFaults(t *testing.T) {
 	}
 
 	// Create a ClientConn
-	cc, err := grpc.Dial("xds:///myservice", grpc.WithTransportCredentials(insecure.NewCredentials()))
+	cc, err := grpc.NewClient("xds:///myservice", grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		t.Fatalf("failed to dial local test server: %v", err)
 	}

--- a/xds/internal/xdsclient/tlscreds/bundle_ext_test.go
+++ b/xds/internal/xdsclient/tlscreds/bundle_ext_test.go
@@ -168,7 +168,7 @@ func (s) TestCaReloading(t *testing.T) {
 	serverCredentials := grpc.Creds(e2e.CreateServerTLSCredentials(t, tls.NoClientCert))
 	server := stubserver.StartTestService(t, nil, serverCredentials)
 
-	conn, err := grpc.Dial(
+	conn, err := grpc.NewClient(
 		server.Address,
 		grpc.WithCredentialsBundle(tlsBundle),
 		grpc.WithAuthority("x.test.example.com"),
@@ -241,7 +241,7 @@ func (s) TestMTLS(t *testing.T) {
 		t.Fatalf("Failed to create TLS bundle: %v", err)
 	}
 	defer stop()
-	conn, err := grpc.Dial(s.Address, grpc.WithCredentialsBundle(tlsBundle), grpc.WithAuthority("x.test.example.com"))
+	conn, err := grpc.NewClient(s.Address, grpc.WithCredentialsBundle(tlsBundle), grpc.WithAuthority("x.test.example.com"))
 	if err != nil {
 		t.Fatalf("Error dialing: %v", err)
 	}

--- a/xds/internal/xdsclient/tlscreds/bundle_test.go
+++ b/xds/internal/xdsclient/tlscreds/bundle_test.go
@@ -78,7 +78,7 @@ func (s) TestFailingProvider(t *testing.T) {
 	}
 	creds.provider = &failingProvider{}
 
-	conn, err := grpc.Dial(s.Address, grpc.WithCredentialsBundle(tlsBundle), grpc.WithAuthority("x.test.example.com"))
+	conn, err := grpc.NewClient(s.Address, grpc.WithCredentialsBundle(tlsBundle), grpc.WithAuthority("x.test.example.com"))
 	if err != nil {
 		t.Fatalf("Error dialing: %v", err)
 	}

--- a/xds/internal/xdsclient/transport/transport_test.go
+++ b/xds/internal/xdsclient/transport/transport_test.go
@@ -39,7 +39,7 @@ func (s) TestNewWithGRPCDial(t *testing.T) {
 	customDialerCalled := false
 	customDialer := func(target string, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
 		customDialerCalled = true
-		return grpc.Dial(target, opts...)
+		return grpc.NewClient(target, opts...)
 	}
 	oldDial := grpcDial
 	grpcDial = customDialer
@@ -66,7 +66,7 @@ func (s) TestNewWithGRPCDial(t *testing.T) {
 
 	// Reset the dialer, create a new transport and ensure that our custom
 	// dialer is no longer called.
-	grpcDial = grpc.Dial
+	grpcDial = grpc.NewClient
 	c, err = New(opts)
 	defer func() {
 		if c != nil {


### PR DESCRIPTION
- [x] refactored tests and examples that utilized `grpc.Dial` to `grpc.NewClient` while some tests were left to use the deprecated `grpc.Dial`


RELEASE NOTES: none