### PR TITLE
xds/internal/xdsclient: Process string metadata in CDS for com.google.csm.telemetry_labels

### DIFF
--- a/xds/internal/xdsclient/xdsresource/type_cds.go
+++ b/xds/internal/xdsclient/xdsresource/type_cds.go
@@ -85,7 +85,8 @@ type ClusterUpdate struct {
 
 	// Raw is the resource from the xds response.
 	Raw *anypb.Any
-	// All the string valued metadata of filter_metadata type
-	// "com.google.csm.telemetry_labels".
-	StringMD map[string]string
+	// TelemetryLabels are the string valued metadata of filter_metadata type
+	// "com.google.csm.telemetry_labels" with keys "service_name" or
+	// "service_namespace".
+	TelemetryLabels map[string]string
 }

--- a/xds/internal/xdsclient/xdsresource/type_cds.go
+++ b/xds/internal/xdsclient/xdsresource/type_cds.go
@@ -85,4 +85,7 @@ type ClusterUpdate struct {
 
 	// Raw is the resource from the xds response.
 	Raw *anypb.Any
+	// All the string valued metadata of filter_metadata type
+	// "com.google.csm.telemetry_labels".
+	StringMD map[string]string
 }

--- a/xds/internal/xdsclient/xdsresource/unmarshal_cds.go
+++ b/xds/internal/xdsclient/xdsresource/unmarshal_cds.go
@@ -85,9 +85,20 @@ func validateClusterAndConstructClusterUpdate(cluster *v3clusterpb.Cluster) (Clu
 	stringMD := make(map[string]string)
 	if fmd := cluster.GetMetadata().GetFilterMetadata(); fmd != nil {
 		if val, ok := fmd["com.google.csm.telemetry_labels"]; ok {
-			for key, val := range val.GetFields() {
-				if _, ok := val.GetKind().(*structpb.Value_StringValue); ok {
-					stringMD[key] = val.GetStringValue()
+			/*
+				"service_name" = "",
+				"service_namespace" = ""
+			*/
+			if fields := val.GetFields(); fields != nil {
+				if val, ok := fields["service_name"]; ok {
+					if _, isStringVal := val.GetKind().(*structpb.Value_StringValue); isStringVal {
+						stringMD["service_name"] = val.GetStringValue()
+					}
+				}
+				if val, ok := fields["service_namespace"]; ok {
+					if _, isStringVal := val.GetKind().(*structpb.Value_StringValue); isStringVal {
+						stringMD["service_namespace"] = val.GetStringValue()
+					}
 				}
 			}
 		}

--- a/xds/internal/xdsclient/xdsresource/unmarshal_cds.go
+++ b/xds/internal/xdsclient/xdsresource/unmarshal_cds.go
@@ -82,22 +82,18 @@ const (
 )
 
 func validateClusterAndConstructClusterUpdate(cluster *v3clusterpb.Cluster) (ClusterUpdate, error) {
-	stringMD := make(map[string]string)
+	telemetryLabels := make(map[string]string)
 	if fmd := cluster.GetMetadata().GetFilterMetadata(); fmd != nil {
 		if val, ok := fmd["com.google.csm.telemetry_labels"]; ok {
-			/*
-				"service_name" = "",
-				"service_namespace" = ""
-			*/
 			if fields := val.GetFields(); fields != nil {
 				if val, ok := fields["service_name"]; ok {
-					if _, isStringVal := val.GetKind().(*structpb.Value_StringValue); isStringVal {
-						stringMD["service_name"] = val.GetStringValue()
+					if _, ok := val.GetKind().(*structpb.Value_StringValue); ok {
+						telemetryLabels["service_name"] = val.GetStringValue()
 					}
 				}
 				if val, ok := fields["service_namespace"]; ok {
-					if _, isStringVal := val.GetKind().(*structpb.Value_StringValue); isStringVal {
-						stringMD["service_namespace"] = val.GetStringValue()
+					if _, ok := val.GetKind().(*structpb.Value_StringValue); ok {
+						telemetryLabels["service_namespace"] = val.GetStringValue()
 					}
 				}
 			}
@@ -183,7 +179,7 @@ func validateClusterAndConstructClusterUpdate(cluster *v3clusterpb.Cluster) (Clu
 		MaxRequests:      circuitBreakersFromCluster(cluster),
 		LBPolicy:         lbPolicy,
 		OutlierDetection: od,
-		StringMD:         stringMD,
+		TelemetryLabels:  telemetryLabels,
 	}
 
 	// Note that this is different from the gRFC (gRFC A47 says to include the

--- a/xds/internal/xdsclient/xdsresource/unmarshal_cds_test.go
+++ b/xds/internal/xdsclient/xdsresource/unmarshal_cds_test.go
@@ -1375,7 +1375,7 @@ func (s) TestUnmarshalCluster(t *testing.T) {
 				EDSServiceName:  v3Service,
 				LRSServerConfig: ClusterLRSServerSelf,
 				Raw:             v3ClusterAnyWithTelemetryLabels,
-				StringMD: map[string]string{
+				TelemetryLabels: map[string]string{
 					"service_name":      "grpc-service",
 					"service_namespace": "grpc-service-namespace",
 				},
@@ -1390,7 +1390,7 @@ func (s) TestUnmarshalCluster(t *testing.T) {
 				EDSServiceName:  v3Service,
 				LRSServerConfig: ClusterLRSServerSelf,
 				Raw:             v3ClusterAnyWithTelemetryLabelsIgnoreSome,
-				StringMD: map[string]string{
+				TelemetryLabels: map[string]string{
 					"service_name": "grpc-service",
 				},
 			},

--- a/xds/internal/xdsclient/xdsresource/unmarshal_cds_test.go
+++ b/xds/internal/xdsclient/xdsresource/unmarshal_cds_test.go
@@ -1267,14 +1267,16 @@ func (s) TestUnmarshalCluster(t *testing.T) {
 				FilterMetadata: map[string]*structpb.Struct{
 					"com.google.csm.telemetry_labels": {
 						Fields: map[string]*structpb.Value{
-							"string-value-dont-ignore": structpb.NewStringValue("string-val"),
-							"float-value-ignore":       structpb.NewNumberValue(3),
-							"bool-value-ignore":        structpb.NewBoolValue(false),
+							"string-value-should-ignore": structpb.NewStringValue("string-val"),
+							"float-value-ignore":         structpb.NewNumberValue(3),
+							"bool-value-ignore":          structpb.NewBoolValue(false),
+							"service_name":               structpb.NewStringValue("grpc-service"), // shouldn't ignore
+							"service_namespace":          structpb.NewNullValue(),                 // should ignore - wrong type
 						},
 					},
-					"ignore-this-metadata": {
+					"ignore-this-metadata": { // should ignore this filter_metadata
 						Fields: map[string]*structpb.Value{
-							"string-value-should-ignore": structpb.NewStringValue("string-val-should-ignore"),
+							"service_namespace": structpb.NewStringValue("string-val-should-ignore"),
 						},
 					},
 				},
@@ -1389,7 +1391,7 @@ func (s) TestUnmarshalCluster(t *testing.T) {
 				LRSServerConfig: ClusterLRSServerSelf,
 				Raw:             v3ClusterAnyWithTelemetryLabelsIgnoreSome,
 				StringMD: map[string]string{
-					"string-value-dont-ignore": "string-val",
+					"service_name": "grpc-service",
 				},
 			},
 		},


### PR DESCRIPTION
This PR adds processing in CDS for string telemetry labels with filter_metadata string "com.google.csm.telemetry_labels". Other value types and filter_metadata identifiers are ignored. This also does not introduce NACK's. This is based off the C-Core implementation, which I disagree with technically but understand there were good reasons for the decisions made. See discussion in xDS Chat room for context as to why C-Core did it this way and why I followed it.

The relevant language in the CSM Observability Design is "The above key_value pairs from `com.google.csm.telemetry_labels` are going to be parsed by xDS Client from the CDS Resource and propagated to the watcher on this resource in the “cds” load balancing policy."

RELEASE NOTES: N/A