### PR TITLE
channelz: ensure `SubChannel` is always registered with parent

### DIFF
--- a/channelz/service/service_test.go
+++ b/channelz/service/service_test.go
@@ -327,7 +327,10 @@ func (s) TestGetChannel(t *testing.T) {
 		},
 	})
 
-	subChan := channelz.RegisterSubChannel(cids[0].ID, refNames[2])
+	subChan, err := channelz.RegisterSubChannel(cids[0], refNames[2])
+	if err != nil {
+		t.Fatal(err)
+	}
 	channelz.AddTraceEvent(logger, subChan, 0, &channelz.TraceEvent{
 		Desc:     "SubChannel Created",
 		Severity: channelz.CtInfo,
@@ -425,7 +428,10 @@ func (s) TestGetSubChannel(t *testing.T) {
 		Desc:     "Channel Created",
 		Severity: channelz.CtInfo,
 	})
-	subChan := channelz.RegisterSubChannel(chann.ID, refNames[1])
+	subChan, err := channelz.RegisterSubChannel(chann, refNames[1])
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer channelz.RemoveEntry(subChan.ID)
 	channelz.AddTraceEvent(logger, subChan, 0, &channelz.TraceEvent{
 		Desc:     subchanCreated,

--- a/clientconn.go
+++ b/clientconn.go
@@ -838,12 +838,16 @@ func (cc *ClientConn) newAddrConnLocked(addrs []resolver.Address, opts balancer.
 		addrs:        copyAddressesWithoutBalancerAttributes(addrs),
 		scopts:       opts,
 		dopts:        cc.dopts,
-		channelz:     channelz.RegisterSubChannel(cc.channelz.ID, ""),
 		resetBackoff: make(chan struct{}),
 		stateChan:    make(chan struct{}),
 	}
 	ac.ctx, ac.cancel = context.WithCancel(cc.ctx)
 
+	var err error
+	ac.channelz, err = channelz.RegisterSubChannel(cc.channelz, "")
+	if err != nil {
+		return nil, err
+	}
 	channelz.AddTraceEvent(logger, ac.channelz, 0, &channelz.TraceEvent{
 		Desc:     "Subchannel created",
 		Severity: channelz.CtInfo,

--- a/test/channelz_test.go
+++ b/test/channelz_test.go
@@ -554,8 +554,14 @@ func (s) TestCZRecusivelyDeletionOfEntry(t *testing.T) {
 	// Socket1       Socket2
 
 	topChan := channelz.RegisterChannel(nil, "")
-	subChan1 := channelz.RegisterSubChannel(topChan.ID, "")
-	subChan2 := channelz.RegisterSubChannel(topChan.ID, "")
+	subChan1, err := channelz.RegisterSubChannel(topChan, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	subChan2, err := channelz.RegisterSubChannel(topChan, "")
+	if err != nil {
+		t.Fatal(err)
+	}
 	skt1 := channelz.RegisterSocket(&channelz.Socket{SocketType: channelz.SocketTypeNormal, Parent: subChan1})
 	skt2 := channelz.RegisterSocket(&channelz.Socket{SocketType: channelz.SocketTypeNormal, Parent: subChan1})
 


### PR DESCRIPTION
`channelz.SubChannel` may be missing parent information if created using `channelz.RegisterSubChannel`.
This is because `channelz.RegisterSubChannel` does not take a `channelz.Channel` as argument, but just the ID of this channel.
The function itself then tries to load the Channel from a package scoped `channelMap`.
This map does not contain any entries if channelz data collection is turned off, resulting in the SubChannel being created without a parent.
Which in turn results in the SubChannel's string representation being logged as `<nil> SubChannel #1234` (1234 being some ID of the SubChannel).

This PR fixes this by restoring the behavior of `v1.62.2`, which instead of passing just the ID of a SubChannel's parent, passed a reference to the parent Channel, returning an error if it is `nil`: https://github.com/grpc/grpc-go/blob/10baa6bd42af1c0fc4d65e58bddf1b3f3c6a5aa8/internal/channelz/funcs.go#L199-L206

RELEASE NOTES: none