### PR TITLE
grpc: Deprecate WithBlock, WithReturnConnectionError, FailOnNonTempDialError

### DIFF
--- a/clientconn.go
+++ b/clientconn.go
@@ -121,8 +121,9 @@ func (dcs *defaultConfigSelector) SelectConfig(rpcInfo iresolver.RPCInfo) (*ires
 // https://github.com/grpc/grpc/blob/master/doc/naming.md.  e.g. to use dns
 // resolver, a "dns:///" prefix should be applied to the target.
 //
-// The DialOptions returned by WithBlock, WithTimeout, and
-// WithReturnConnectionError are ignored by this function.
+// The DialOptions returned by WithBlock, WithTimeout,
+// WithReturnConnectionError, and FailOnNonTempDialError are ignored by this
+// function.
 func NewClient(target string, opts ...DialOption) (conn *ClientConn, err error) {
 	cc := &ClientConn{
 		target: target,

--- a/dialoptions.go
+++ b/dialoptions.go
@@ -317,12 +317,8 @@ func WithBlock() DialOption {
 // Use of this feature is not recommended.  For more information, please see:
 // https://github.com/grpc/grpc-go/blob/master/Documentation/anti-patterns.md
 //
-// # Experimental
-//
-// Notice: This API is EXPERIMENTAL and may be changed or removed in a
-// later release.
-//
 // Deprecated: this DialOption is not supported by NewClient.
+// Will be supported throughout 1.x.
 func WithReturnConnectionError() DialOption {
 	return newFuncDialOption(func(o *dialOptions) {
 		o.block = true

--- a/dialoptions.go
+++ b/dialoptions.go
@@ -471,12 +471,9 @@ func withBinaryLogger(bl binarylog.Logger) DialOption {
 // Use of this feature is not recommended.  For more information, please see:
 // https://github.com/grpc/grpc-go/blob/master/Documentation/anti-patterns.md
 //
-// # Experimental
-//
-// Notice: This API is EXPERIMENTAL and may be changed or removed in a
-// later release.
-//
 // Deprecated: this DialOption is not supported by NewClient.
+// This API may be changed or removed in a
+// later release.
 func FailOnNonTempDialError(f bool) DialOption {
 	return newFuncDialOption(func(o *dialOptions) {
 		o.copts.FailOnNonTempDialError = f

--- a/dialoptions.go
+++ b/dialoptions.go
@@ -300,6 +300,9 @@ func withBackoff(bs internalbackoff.Strategy) DialOption {
 //
 // Use of this feature is not recommended.  For more information, please see:
 // https://github.com/grpc/grpc-go/blob/master/Documentation/anti-patterns.md
+//
+// Deprecated: this DialOption is not supported by NewClient.
+// Will be supported throughout 1.x.
 func WithBlock() DialOption {
 	return newFuncDialOption(func(o *dialOptions) {
 		o.block = true
@@ -318,6 +321,8 @@ func WithBlock() DialOption {
 //
 // Notice: This API is EXPERIMENTAL and may be changed or removed in a
 // later release.
+//
+// Deprecated: this DialOption is not supported by NewClient.
 func WithReturnConnectionError() DialOption {
 	return newFuncDialOption(func(o *dialOptions) {
 		o.block = true
@@ -387,8 +392,8 @@ func WithCredentialsBundle(b credentials.Bundle) DialOption {
 // WithTimeout returns a DialOption that configures a timeout for dialing a
 // ClientConn initially. This is valid if and only if WithBlock() is present.
 //
-// Deprecated: use DialContext instead of Dial and context.WithTimeout
-// instead.  Will be supported throughout 1.x.
+// Deprecated: this DialOption is not supported by NewClient.
+// Will be supported throughout 1.x.
 func WithTimeout(d time.Duration) DialOption {
 	return newFuncDialOption(func(o *dialOptions) {
 		o.timeout = d
@@ -474,6 +479,8 @@ func withBinaryLogger(bl binarylog.Logger) DialOption {
 //
 // Notice: This API is EXPERIMENTAL and may be changed or removed in a
 // later release.
+//
+// Deprecated: this DialOption is not supported by NewClient.
 func FailOnNonTempDialError(f bool) DialOption {
 	return newFuncDialOption(func(o *dialOptions) {
 		o.copts.FailOnNonTempDialError = f


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc-go/issues/7095

Notice in `NewClient` GoDoc comment that `FailOnNonTempDialError` dial option is ignored.

Deprecate options that are ignored by `NewClient` function.
These options are only supported by deprecated `Dial` and `DialContext` functions.

RELEASE NOTES:
- grpc: Deprecate WithBlock, WithReturnConnectionError, FailOnNonTempDialError which are ignored by NewClient