### PR TITLE
channelz: pass parent pointer instead of parent ID to RegisterSubChannel

### DIFF
--- a/channelz/service/service_test.go
+++ b/channelz/service/service_test.go
@@ -327,7 +327,7 @@ func (s) TestGetChannel(t *testing.T) {
 		},
 	})
 
-	subChan := channelz.RegisterSubChannel(cids[0].ID, refNames[2])
+	subChan := channelz.RegisterSubChannel(cids[0], refNames[2])
 	channelz.AddTraceEvent(logger, subChan, 0, &channelz.TraceEvent{
 		Desc:     "SubChannel Created",
 		Severity: channelz.CtInfo,
@@ -425,7 +425,7 @@ func (s) TestGetSubChannel(t *testing.T) {
 		Desc:     "Channel Created",
 		Severity: channelz.CtInfo,
 	})
-	subChan := channelz.RegisterSubChannel(chann.ID, refNames[1])
+	subChan := channelz.RegisterSubChannel(chann, refNames[1])
 	defer channelz.RemoveEntry(subChan.ID)
 	channelz.AddTraceEvent(logger, subChan, 0, &channelz.TraceEvent{
 		Desc:     subchanCreated,

--- a/clientconn.go
+++ b/clientconn.go
@@ -838,7 +838,7 @@ func (cc *ClientConn) newAddrConnLocked(addrs []resolver.Address, opts balancer.
 		addrs:        copyAddressesWithoutBalancerAttributes(addrs),
 		scopts:       opts,
 		dopts:        cc.dopts,
-		channelz:     channelz.RegisterSubChannel(cc.channelz.ID, ""),
+		channelz:     channelz.RegisterSubChannel(cc.channelz, ""),
 		resetBackoff: make(chan struct{}),
 		stateChan:    make(chan struct{}),
 	}

--- a/internal/channelz/funcs.go
+++ b/internal/channelz/funcs.go
@@ -143,20 +143,21 @@ func RegisterChannel(parent *Channel, target string) *Channel {
 // Returns a unique channelz identifier assigned to this subChannel.
 //
 // If channelz is not turned ON, the channelz database is not mutated.
-func RegisterSubChannel(pid int64, ref string) *SubChannel {
+func RegisterSubChannel(parent *Channel, ref string) *SubChannel {
 	id := IDGen.genID()
-	if !IsOn() {
-		return &SubChannel{ID: id}
+	sc := &SubChannel{
+		ID:      id,
+		RefName: ref,
+		parent:  parent,
 	}
 
-	sc := &SubChannel{
-		RefName: ref,
-		ID:      id,
-		sockets: make(map[int64]string),
-		parent:  db.getChannel(pid),
-		trace:   &ChannelTrace{CreationTime: time.Now(), Events: make([]*traceEvent, 0, getMaxTraceEntry())},
+	if !IsOn() {
+		return sc
 	}
-	db.addSubChannel(id, sc, pid)
+
+	sc.sockets = make(map[int64]string)
+	sc.trace = &ChannelTrace{CreationTime: time.Now(), Events: make([]*traceEvent, 0, getMaxTraceEntry())}
+	db.addSubChannel(id, sc, parent.ID)
 	return sc
 }
 

--- a/test/channelz_test.go
+++ b/test/channelz_test.go
@@ -554,8 +554,8 @@ func (s) TestCZRecusivelyDeletionOfEntry(t *testing.T) {
 	// Socket1       Socket2
 
 	topChan := channelz.RegisterChannel(nil, "")
-	subChan1 := channelz.RegisterSubChannel(topChan.ID, "")
-	subChan2 := channelz.RegisterSubChannel(topChan.ID, "")
+	subChan1 := channelz.RegisterSubChannel(topChan, "")
+	subChan2 := channelz.RegisterSubChannel(topChan, "")
 	skt1 := channelz.RegisterSocket(&channelz.Socket{SocketType: channelz.SocketTypeNormal, Parent: subChan1})
 	skt2 := channelz.RegisterSocket(&channelz.Socket{SocketType: channelz.SocketTypeNormal, Parent: subChan1})
 


### PR DESCRIPTION
This fixes logging that, with channelz off, would omit the channel ID in subchannel logs.

RELEASE NOTES: none