### PR TITLE
test/kokoro: Migrate PSM Interop to Artifact Registry (v1.55.x backport)

### DIFF
--- a/test/kokoro/psm-security.sh
+++ b/test/kokoro/psm-security.sh
@@ -19,8 +19,9 @@ set -eo pipefail
 readonly GITHUB_REPOSITORY_NAME="grpc-go"
 readonly TEST_DRIVER_INSTALL_SCRIPT_URL="https://raw.githubusercontent.com/${TEST_DRIVER_REPO_OWNER:-grpc}/psm-interop/${TEST_DRIVER_BRANCH:-main}/.kokoro/psm_interop_kokoro_lib.sh"
 ## xDS test server/client Docker images
-readonly SERVER_IMAGE_NAME="gcr.io/grpc-testing/xds-interop/go-server"
-readonly CLIENT_IMAGE_NAME="gcr.io/grpc-testing/xds-interop/go-client"
+readonly DOCKER_REGISTRY="us-docker.pkg.dev"
+readonly SERVER_IMAGE_NAME="us-docker.pkg.dev/grpc-testing/psm-interop/go-server"
+readonly CLIENT_IMAGE_NAME="us-docker.pkg.dev/grpc-testing/psm-interop/go-client"
 readonly FORCE_IMAGE_BUILD="${FORCE_IMAGE_BUILD:-0}"
 
 #######################################
@@ -39,7 +40,7 @@ build_test_app_docker_images() {
   echo "Building Go xDS interop test app Docker images"
   docker build -f "${SRC_DIR}/interop/xds/client/Dockerfile" -t "${CLIENT_IMAGE_NAME}:${GIT_COMMIT}" "${SRC_DIR}"
   docker build -f "${SRC_DIR}/interop/xds/server/Dockerfile" -t "${SERVER_IMAGE_NAME}:${GIT_COMMIT}" "${SRC_DIR}"
-  gcloud -q auth configure-docker
+  gcloud -q auth configure-docker "${DOCKER_REGISTRY}"
   docker push "${CLIENT_IMAGE_NAME}:${GIT_COMMIT}"
   docker push "${SERVER_IMAGE_NAME}:${GIT_COMMIT}"
   if is_version_branch "${TESTING_VERSION}"; then

--- a/test/kokoro/xds_k8s_lb.sh
+++ b/test/kokoro/xds_k8s_lb.sh
@@ -19,8 +19,9 @@ set -eo pipefail
 readonly GITHUB_REPOSITORY_NAME="grpc-go"
 readonly TEST_DRIVER_INSTALL_SCRIPT_URL="https://raw.githubusercontent.com/${TEST_DRIVER_REPO_OWNER:-grpc}/psm-interop/${TEST_DRIVER_BRANCH:-main}/.kokoro/psm_interop_kokoro_lib.sh"
 ## xDS test server/client Docker images
-readonly SERVER_IMAGE_NAME="gcr.io/grpc-testing/xds-interop/go-server"
-readonly CLIENT_IMAGE_NAME="gcr.io/grpc-testing/xds-interop/go-client"
+readonly DOCKER_REGISTRY="us-docker.pkg.dev"
+readonly SERVER_IMAGE_NAME="us-docker.pkg.dev/grpc-testing/psm-interop/go-server"
+readonly CLIENT_IMAGE_NAME="us-docker.pkg.dev/grpc-testing/psm-interop/go-client"
 readonly FORCE_IMAGE_BUILD="${FORCE_IMAGE_BUILD:-0}"
 
 #######################################
@@ -39,7 +40,7 @@ build_test_app_docker_images() {
   echo "Building Go xDS interop test app Docker images"
   docker build -f "${SRC_DIR}/interop/xds/client/Dockerfile" -t "${CLIENT_IMAGE_NAME}:${GIT_COMMIT}" "${SRC_DIR}"
   docker build -f "${SRC_DIR}/interop/xds/server/Dockerfile" -t "${SERVER_IMAGE_NAME}:${GIT_COMMIT}" "${SRC_DIR}"
-  gcloud -q auth configure-docker
+  gcloud -q auth configure-docker "${DOCKER_REGISTRY}"
   docker push "${CLIENT_IMAGE_NAME}:${GIT_COMMIT}"
   docker push "${SERVER_IMAGE_NAME}:${GIT_COMMIT}"
   if is_version_branch "${TESTING_VERSION}"; then

--- a/test/kokoro/xds_url_map.sh
+++ b/test/kokoro/xds_url_map.sh
@@ -19,7 +19,8 @@ set -eo pipefail
 readonly GITHUB_REPOSITORY_NAME="grpc-go"
 readonly TEST_DRIVER_INSTALL_SCRIPT_URL="https://raw.githubusercontent.com/${TEST_DRIVER_REPO_OWNER:-grpc}/psm-interop/${TEST_DRIVER_BRANCH:-main}/.kokoro/psm_interop_kokoro_lib.sh"
 ## xDS test client Docker images
-readonly CLIENT_IMAGE_NAME="gcr.io/grpc-testing/xds-interop/go-client"
+readonly DOCKER_REGISTRY="us-docker.pkg.dev"
+readonly CLIENT_IMAGE_NAME="us-docker.pkg.dev/grpc-testing/psm-interop/go-client"
 readonly FORCE_IMAGE_BUILD="${FORCE_IMAGE_BUILD:-0}"
 
 #######################################
@@ -35,7 +36,7 @@ readonly FORCE_IMAGE_BUILD="${FORCE_IMAGE_BUILD:-0}"
 build_test_app_docker_images() {
   echo "Building Go xDS interop test app Docker images"
   docker build -f "${SRC_DIR}/interop/xds/client/Dockerfile" -t "${CLIENT_IMAGE_NAME}:${GIT_COMMIT}" "${SRC_DIR}"
-  gcloud -q auth configure-docker
+  gcloud -q auth configure-docker "${DOCKER_REGISTRY}"
   docker push "${CLIENT_IMAGE_NAME}:${GIT_COMMIT}"
   if is_version_branch "${TESTING_VERSION}"; then
     tag_and_push_docker_image "${CLIENT_IMAGE_NAME}" "${GIT_COMMIT}" "${TESTING_VERSION}"


### PR DESCRIPTION
Backport of #7102 to v1.55.x.
---
Migrate PSM Interop images from Container Registry (gcr.io) to Artifact Registry (pkg.dev).

RELEASE NOTES: n/a