### PR TITLE
Update golang.org/x/net for CVE-2023-45288

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,10 +10,10 @@ require (
 	github.com/golang/protobuf v1.5.4
 	github.com/google/go-cmp v0.6.0
 	github.com/google/uuid v1.6.0
-	golang.org/x/net v0.22.0
+	golang.org/x/net v0.24.0
 	golang.org/x/oauth2 v0.18.0
 	golang.org/x/sync v0.6.0
-	golang.org/x/sys v0.18.0
+	golang.org/x/sys v0.19.0
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240318140521-94a12d6c2237
 	google.golang.org/protobuf v1.33.0
 )


### PR DESCRIPTION
Update golang.org/x/net for fix for CVE-2023-45288, fixed in https://github.com/golang/net/commit/ba872109ef2dc8f1da778651bd1fd3792d0e4587