### PR TITLE
stats: mark InPayload.Data and OutPayload.Data for deletion (experimental)

### DIFF
--- a/stats/stats.go
+++ b/stats/stats.go
@@ -73,7 +73,9 @@ func (*PickerUpdated) isRPCStats() {}
 type InPayload struct {
 	// Client is true if this InPayload is from client side.
 	Client bool
-	// Payload is the payload with original type.
+	// Payload is the payload with original type.  This may be modified after
+	// the call to HandleRPC which provides the InPayload returns and must be
+	// copied if needed later.
 	Payload any
 	// Data is the serialized message payload.
 	// Deprecated: Data will be removed in the next release.
@@ -144,7 +146,9 @@ func (s *InTrailer) isRPCStats() {}
 type OutPayload struct {
 	// Client is true if this OutPayload is from client side.
 	Client bool
-	// Payload is the payload with original type.
+	// Payload is the payload with original type.  This may be modified after
+	// the call to HandleRPC which provides the OutPayload returns and must be
+	// copied if needed later.
 	Payload any
 	// Data is the serialized message payload.
 	// Deprecated: Data will be removed in the next release.

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -76,6 +76,7 @@ type InPayload struct {
 	// Payload is the payload with original type.
 	Payload any
 	// Data is the serialized message payload.
+	// Deprecated: Data will be removed in the next release.
 	Data []byte
 
 	// Length is the size of the uncompressed payload data. Does not include any
@@ -146,6 +147,7 @@ type OutPayload struct {
 	// Payload is the payload with original type.
 	Payload any
 	// Data is the serialized message payload.
+	// Deprecated: Data will be removed in the next release.
 	Data []byte
 	// Length is the size of the uncompressed payload data. Does not include any
 	// framing (gRPC or HTTP/2).


### PR DESCRIPTION
cc @papacharlie

RELEASE NOTES:
* stats: deprecate `InPayload.Data` and `OutPayload.Data`; they were experimental and will be deleted in the next release