### PR TITLE
Fix close in use certificate providers after double `Close()` method call on wrapper object

### DIFF
--- a/credentials/tls/certprovider/store.go
+++ b/credentials/tls/certprovider/store.go
@@ -64,8 +64,8 @@ func (c closedProvider) KeyMaterial(ctx context.Context) (*KeyMaterial, error) {
 func (c closedProvider) Close() {
 }
 
-// singleCloseWrappedProvider wraps a provider instance with a reference count to avoid double
-// close still in use provider.
+// singleCloseWrappedProvider wraps a provider instance with a reference count
+// to properly handle multiple calls to Close.
 type singleCloseWrappedProvider struct {
 	mu       sync.RWMutex
 	provider Provider


### PR DESCRIPTION
`wrappedProvider` add refcounter to `certprovider.Provider`, but there no guards to prevent multiple `Close()` call after single `Build()` call.

The situation is complicated by:
 - the error does not appear where there was a double closure;
 - before the rotation of certificates, the problem may not manifest itself (that is, the effect is greatly delayed in time);
 - `certprovider.Provider` implementation don't panic/error on multiple `Close()` calls.


Fix errors like:
```
[core][Channel #39 SubChannel #941] grpc: addrConn.createTransport failed to connect to ...
Err: connection error: desc = "transport: authentication handshake failed:
xds: fetching trusted roots from CertificateProvider failed: provider instance is closed"
```

RELEASE NOTES:
- Fix `xds: fetching trusted roots from CertificateProvider failed: provider instance is closed` error