### PR TITLE
xds/internal/xdsclient/xdslbregistry: remove unused call to type url

### DIFF
--- a/xds/internal/xdsclient/xdslbregistry/xdslbregistry.go
+++ b/xds/internal/xdsclient/xdslbregistry/xdslbregistry.go
@@ -66,7 +66,6 @@ func ConvertToServiceConfig(lbPolicy *v3clusterpb.LoadBalancingPolicy, depth int
 	// LoadBalancingPolicy, attempting to convert each one to gRPC form,
 	// stopping at the first supported policy." - A52
 	for _, policy := range lbPolicy.GetPolicies() {
-		policy.GetTypedExtensionConfig().GetTypedConfig().GetTypeUrl()
 		converter := m[policy.GetTypedExtensionConfig().GetTypedConfig().GetTypeUrl()]
 		// "Any entry not in the above list is unsupported and will be skipped."
 		// - A52


### PR DESCRIPTION
I was reading through the implementation for custom lb polices and noticed a call to the policy type URL wasn't being used

RELEASE NOTES: n/a