### PR TITLE
peer and metadata: Implement the Stringer interface for Peer and Metadata

### DIFF
--- a/balancer_wrapper.go
+++ b/balancer_wrapper.go
@@ -261,7 +261,9 @@ func (acbw *acBalancerWrapper) updateState(s connectivity.State, err error) {
 }
 
 func (acbw *acBalancerWrapper) String() string {
-	return fmt.Sprintf("SubConn(id:%d)", acbw.ac.channelz.ID)
+	acbw.ac.mu.Lock()
+	defer acbw.ac.mu.Unlock()
+	return fmt.Sprintf("SubConn(id:%d;addr:%s)", acbw.ac.channelz.ID, acbw.ac.curAddr.Addr)
 }
 
 func (acbw *acBalancerWrapper) UpdateAddresses(addrs []resolver.Address) {

--- a/balancer_wrapper.go
+++ b/balancer_wrapper.go
@@ -261,9 +261,7 @@ func (acbw *acBalancerWrapper) updateState(s connectivity.State, err error) {
 }
 
 func (acbw *acBalancerWrapper) String() string {
-	acbw.ac.mu.Lock()
-	defer acbw.ac.mu.Unlock()
-	return fmt.Sprintf("SubConn(id:%d;addr:%s)", acbw.ac.channelz.ID, acbw.ac.curAddr.Addr)
+	return fmt.Sprintf("SubConn(id:%d)", acbw.ac.channelz.ID)
 }
 
 func (acbw *acBalancerWrapper) UpdateAddresses(addrs []resolver.Address) {

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -90,7 +90,8 @@ func Pairs(kv ...string) MD {
 	return md
 }
 
-// String implements the Stringer interface for pretty-printing a MD. Ordering of the values is non-deterministic as it ranges over a map.
+// String implements the Stringer interface for pretty-printing a MD.
+// Ordering of the values is non-deterministic as it ranges over a map.
 func (md MD) String() string {
 	var sb strings.Builder
 	fmt.Fprintf(&sb, "MD{")

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -90,6 +90,22 @@ func Pairs(kv ...string) MD {
 	return md
 }
 
+// String implements the Stringer interface for pretty-printing a MD. Ordering of the values is non-deterministic as it ranges over a map.
+func (md MD) String() string {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "MD{")
+	needSep := false
+	for k, v := range md {
+		if needSep {
+			fmt.Fprintf(&sb, ", ")
+		}
+		fmt.Fprintf(&sb, "%s=[%s]", k, strings.Join(v, ", "))
+		needSep = true
+	}
+	fmt.Fprintf(&sb, "}")
+	return sb.String()
+}
+
 // Len returns the number of items in md.
 func (md MD) Len() int {
 	return len(md)

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -94,13 +94,11 @@ func Pairs(kv ...string) MD {
 func (md MD) String() string {
 	var sb strings.Builder
 	fmt.Fprintf(&sb, "MD{")
-	needSep := false
 	for k, v := range md {
-		if needSep {
+		if sb.Len() > 3 {
 			fmt.Fprintf(&sb, ", ")
 		}
 		fmt.Fprintf(&sb, "%s=[%s]", k, strings.Join(v, ", "))
-		needSep = true
 	}
 	fmt.Fprintf(&sb, "}")
 	return sb.String()

--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -350,10 +350,10 @@ func TestStringerMD(t *testing.T) {
 		{MD{"k1": []string{"v1"}}, []string{"MD{k1=[v1]}"}},
 		{MD{"k1": []string{"v1", "v2"}, "k2": []string{}, "k3": []string{"1", "2", "3"}}, []string{"MD{", "k1=[v1, v2]", "k2=[]", "k3=[1, 2, 3]", "}"}},
 	} {
-		strMd := test.md.String()
+		got := test.md.String()
 		for _, want := range test.want {
-			if !strings.Contains(strMd, want) {
-				t.Fatalf("Metadata string '%s' is missing '%s'", strMd, want)
+			if !strings.Contains(got, want) {
+				t.Fatalf("Metadata string %q is missing %q", got, want)
 			}
 		}
 	}

--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"reflect"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -335,6 +336,26 @@ func (s) TestAppendToOutgoingContext_FromKVSlice(t *testing.T) {
 	md, _ = FromOutgoingContext(ctx)
 	if md[k][0] != v {
 		t.Fatalf("md[%q] = %q; want %q", k, md[k], v)
+	}
+}
+
+func TestStringerMD(t *testing.T) {
+	for _, test := range []struct {
+		md   MD
+		want []string
+	}{
+		{MD{}, []string{"MD{}"}},
+		{MD{"k1": []string{}}, []string{"MD{k1=[]}"}},
+		{MD{"k1": []string{"v1", "v2"}}, []string{"MD{k1=[v1, v2]}"}},
+		{MD{"k1": []string{"v1"}}, []string{"MD{k1=[v1]}"}},
+		{MD{"k1": []string{"v1", "v2"}, "k2": []string{}, "k3": []string{"1", "2", "3"}}, []string{"MD{", "k1=[v1, v2]", "k2=[]", "k3=[1, 2, 3]", "}"}},
+	} {
+		strMd := test.md.String()
+		for _, want := range test.want {
+			if !strings.Contains(strMd, want) {
+				t.Fatalf("Metadata string '%s' is missing '%s'", strMd, want)
+			}
+		}
 	}
 }
 

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -22,6 +22,7 @@ package peer
 
 import (
 	"context"
+	"fmt"
 	"net"
 
 	"google.golang.org/grpc/credentials"
@@ -37,6 +38,26 @@ type Peer struct {
 	// AuthInfo is the authentication information of the transport.
 	// It is nil if there is no transport security being used.
 	AuthInfo credentials.AuthInfo
+}
+
+// String ensures the Peer types implements the Stringer interface in order to
+// allow to print a context with a peerKey value effectively.
+func (p *Peer) String() string {
+	if p == nil {
+		return "Peer<nil>"
+	}
+	ret := "Peer{"
+	if p.Addr != nil {
+		ret += fmt.Sprintf("Addr: '%s'", p.Addr.String())
+	}
+	if p.AuthInfo != nil {
+		if len(ret) > 5 {
+			ret += ", "
+		}
+		ret += fmt.Sprintf("AuthInfo: '%s'", p.AuthInfo.AuthType())
+	}
+	ret += "}"
+	return ret
 }
 
 type peerKey struct{}

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -24,6 +24,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"strings"
 
 	"google.golang.org/grpc/credentials"
 )
@@ -46,18 +47,21 @@ func (p *Peer) String() string {
 	if p == nil {
 		return "Peer<nil>"
 	}
-	ret := "Peer{"
+	sb := &strings.Builder{}
+	sb.WriteString("Peer{")
 	if p.Addr != nil {
-		ret += fmt.Sprintf("Addr: '%s'", p.Addr.String())
+		fmt.Fprintf(sb, "Addr: '%s', ", p.Addr.String())
+	} else {
+		fmt.Fprintf(sb, "Addr: <nil>, ")
 	}
 	if p.AuthInfo != nil {
-		if len(ret) > 5 {
-			ret += ", "
-		}
-		ret += fmt.Sprintf("AuthInfo: '%s'", p.AuthInfo.AuthType())
+		fmt.Fprintf(sb, "AuthInfo: '%s'", p.AuthInfo.AuthType())
+	} else {
+		fmt.Fprintf(sb, "AuthInfo: <nil>")
 	}
-	ret += "}"
-	return ret
+	sb.WriteString("}")
+
+	return sb.String()
 }
 
 type peerKey struct{}

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -54,6 +54,11 @@ func (p *Peer) String() string {
 	} else {
 		fmt.Fprintf(sb, "Addr: <nil>, ")
 	}
+	if p.LocalAddr != nil {
+		fmt.Fprintf(sb, "LocalAddr: '%s', ", p.LocalAddr.String())
+	} else {
+		fmt.Fprintf(sb, "LocalAddr: <nil>, ")
+	}
 	if p.AuthInfo != nil {
 		fmt.Fprintf(sb, "AuthInfo: '%s'", p.AuthInfo.AuthType())
 	} else {

--- a/peer/peer_test.go
+++ b/peer/peer_test.go
@@ -36,60 +36,12 @@ func (ta testAuthInfo) AuthType() string {
 	return fmt.Sprintf("testAuthInfo-%d", ta.SecurityLevel)
 }
 
-func TestPeerSecurityLevel(t *testing.T) {
-	testCases := []struct {
-		authLevel credentials.SecurityLevel
-		testLevel credentials.SecurityLevel
-		want      bool
-	}{
-		{
-			authLevel: credentials.PrivacyAndIntegrity,
-			testLevel: credentials.PrivacyAndIntegrity,
-			want:      true,
-		},
-		{
-			authLevel: credentials.IntegrityOnly,
-			testLevel: credentials.PrivacyAndIntegrity,
-			want:      false,
-		},
-		{
-			authLevel: credentials.IntegrityOnly,
-			testLevel: credentials.NoSecurity,
-			want:      true,
-		},
-		{
-			authLevel: credentials.InvalidSecurityLevel,
-			testLevel: credentials.IntegrityOnly,
-			want:      true,
-		},
-		{
-			authLevel: credentials.InvalidSecurityLevel,
-			testLevel: credentials.PrivacyAndIntegrity,
-			want:      true,
-		},
-	}
-	for _, tc := range testCases {
-		t.Run(tc.authLevel.String()+"-"+tc.testLevel.String(), func(t *testing.T) {
-			ctx := NewContext(context.Background(), &Peer{AuthInfo: testAuthInfo{credentials.CommonAuthInfo{SecurityLevel: tc.authLevel}}})
-			p, ok := FromContext(ctx)
-			if !ok {
-				t.Fatalf("Unable to get peer from context")
-			}
-			err := credentials.CheckSecurityLevel(p.AuthInfo, tc.testLevel)
-			if tc.want && (err != nil) {
-				t.Fatalf("CheckSeurityLevel(%s, %s) returned failure but want success", tc.authLevel.String(), tc.testLevel.String())
-			} else if !tc.want && (err == nil) {
-				t.Fatalf("CheckSeurityLevel(%s, %s) returned success but want failure", tc.authLevel.String(), tc.testLevel.String())
-			}
-		})
-	}
-}
-
 type addr struct {
 	ipAddress string
 }
 
-func (addr) Network() string   { return "" }
+func (addr) Network() string { return "" }
+
 func (a *addr) String() string { return a.ipAddress }
 
 func TestPeerStringer(t *testing.T) {

--- a/peer/peer_test.go
+++ b/peer/peer_test.go
@@ -103,15 +103,15 @@ func TestPeerStringer(t *testing.T) {
 		{
 			addr:      &addr{"1.2.3.4:1234"},
 			authLevel: -1,
-			want:      "Peer{Addr: '1.2.3.4:1234'}",
+			want:      "Peer{Addr: '1.2.3.4:1234', AuthInfo: <nil>}",
 		},
 		{
 			authLevel: credentials.InvalidSecurityLevel,
-			want:      "Peer{AuthInfo: 'testAuthInfo'}",
+			want:      "Peer{Addr: <nil>, AuthInfo: 'testAuthInfo'}",
 		},
 		{
 			authLevel: -1,
-			want:      "Peer{}",
+			want:      "Peer{Addr: <nil>, AuthInfo: <nil>}",
 		},
 	}
 	for _, tc := range testCases {

--- a/peer/peer_test.go
+++ b/peer/peer_test.go
@@ -1,0 +1,145 @@
+/*
+ *
+ * Copyright 2024 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package peer
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"google.golang.org/grpc/credentials"
+)
+
+// A struct that implements AuthInfo interface and implements CommonAuthInfo() method.
+type testAuthInfo struct {
+	credentials.CommonAuthInfo
+}
+
+func (ta testAuthInfo) AuthType() string {
+	return "testAuthInfo"
+}
+
+func TestPeerSecurityLevel(t *testing.T) {
+	testCases := []struct {
+		authLevel credentials.SecurityLevel
+		testLevel credentials.SecurityLevel
+		want      bool
+	}{
+		{
+			authLevel: credentials.PrivacyAndIntegrity,
+			testLevel: credentials.PrivacyAndIntegrity,
+			want:      true,
+		},
+		{
+			authLevel: credentials.IntegrityOnly,
+			testLevel: credentials.PrivacyAndIntegrity,
+			want:      false,
+		},
+		{
+			authLevel: credentials.IntegrityOnly,
+			testLevel: credentials.NoSecurity,
+			want:      true,
+		},
+		{
+			authLevel: credentials.InvalidSecurityLevel,
+			testLevel: credentials.IntegrityOnly,
+			want:      true,
+		},
+		{
+			authLevel: credentials.InvalidSecurityLevel,
+			testLevel: credentials.PrivacyAndIntegrity,
+			want:      true,
+		},
+	}
+	for _, tc := range testCases {
+		ctx := NewContext(context.Background(), &Peer{AuthInfo: testAuthInfo{credentials.CommonAuthInfo{SecurityLevel: tc.authLevel}}})
+		p, ok := FromContext(ctx)
+		if !ok {
+			t.Fatalf("Unable to get peer from context")
+		}
+		err := credentials.CheckSecurityLevel(p.AuthInfo, tc.testLevel)
+		if tc.want && (err != nil) {
+			t.Fatalf("CheckSeurityLevel(%s, %s) returned failure but want success", tc.authLevel.String(), tc.testLevel.String())
+		} else if !tc.want && (err == nil) {
+			t.Fatalf("CheckSeurityLevel(%s, %s) returned success but want failure", tc.authLevel.String(), tc.testLevel.String())
+		}
+	}
+}
+
+type addr struct {
+	ipAddress string
+}
+
+func (addr) Network() string   { return "" }
+func (a *addr) String() string { return a.ipAddress }
+
+func TestPeerStringer(t *testing.T) {
+	testCases := []struct {
+		addr      *addr
+		authLevel credentials.SecurityLevel
+		want      string
+	}{
+		{
+			addr:      &addr{"example.com:1234"},
+			authLevel: credentials.PrivacyAndIntegrity,
+			want:      "Peer{Addr: 'example.com:1234', AuthInfo: 'testAuthInfo'}",
+		},
+		{
+			addr:      &addr{"1.2.3.4:1234"},
+			authLevel: -1,
+			want:      "Peer{Addr: '1.2.3.4:1234'}",
+		},
+		{
+			authLevel: credentials.InvalidSecurityLevel,
+			want:      "Peer{AuthInfo: 'testAuthInfo'}",
+		},
+		{
+			authLevel: -1,
+			want:      "Peer{}",
+		},
+	}
+	for _, tc := range testCases {
+		ctx := NewContext(context.Background(), &Peer{Addr: tc.addr, AuthInfo: testAuthInfo{credentials.CommonAuthInfo{SecurityLevel: tc.authLevel}}})
+		p, ok := FromContext(ctx)
+		if tc.authLevel == -1 {
+			p.AuthInfo = nil
+		}
+		if tc.addr == nil {
+			p.Addr = nil
+		}
+		if !ok {
+			t.Fatalf("Unable to get peer from context")
+		}
+		if p.String() != tc.want {
+			t.Fatalf("Error using peer String(): expected %q, got %q", tc.want, p.String())
+		}
+	}
+	t.Run("test String on nil Peer", func(st *testing.T) {
+		var test *Peer
+		if test.String() != "Peer<nil>" {
+			st.Fatalf("Error using String on nil Peer. Expected 'Peer<nil>', got: '%s'", test.String())
+		}
+	})
+	t.Run("test Stringer on context", func(st *testing.T) {
+		ctx := NewContext(context.Background(), &Peer{Addr: &addr{"1.2.3.4:1234"}, AuthInfo: testAuthInfo{credentials.CommonAuthInfo{SecurityLevel: credentials.PrivacyAndIntegrity}}})
+		if fmt.Sprintf("%v", ctx) != "context.Background.WithValue(type peer.peerKey, val Peer{Addr: '1.2.3.4:1234', AuthInfo: 'testAuthInfo'})" {
+			st.Fatalf("Error printing context with embedded Peer. Got: %v", ctx)
+		}
+	})
+}


### PR DESCRIPTION
Effectively allowing to print contextes containing a `Peer` properly.
Instead of printing with `%v` as:
```
context.Background.WithValue(type peer.peerKey, val <not Stringer>)
```
contexts containing a peer will now print as:
```
context.Background.WithValue(type peer.peerKey, val Peer{Addr: '1.2.3.4:1234', AuthInfo: 'testAuthInfo'})
```

This is also satisfying Stringer interface for `Metadata`, allowing to print them easily too. Since `Metadata` are basically a map, notice that `String` output is not stable. I could change it to print it in alphabetical order if you prefer.

RELEASE NOTES:
- peer/peer: implement the Stringer interface for pretty printing Peer
- metadata/metadata: implement the Stringer interface for pretty printing MD