### PR TITLE
*: fix regenerate.sh

### DIFF
--- a/channelz/internal/protoconv/sockopt_linux.go
+++ b/channelz/internal/protoconv/sockopt_linux.go
@@ -22,10 +22,13 @@ import (
 	"time"
 
 	channelzpb "google.golang.org/grpc/channelz/grpc_channelz_v1"
+	"google.golang.org/grpc/grpclog"
 	"google.golang.org/grpc/internal/channelz"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/durationpb"
 )
+
+var logger = grpclog.Component("channelz")
 
 func convertToPbDuration(sec int64, usec int64) *durationpb.Duration {
 	return durationpb.New(time.Duration(sec*1e9 + usec*1e3))

--- a/channelz/internal/protoconv/sockopt_nonlinux.go
+++ b/channelz/internal/protoconv/sockopt_nonlinux.go
@@ -26,6 +26,7 @@ import (
 	"google.golang.org/grpc/internal/channelz"
 )
 
-func sockoptToProto(skopts *channelz.SocketOptionData) []*channelzpb.SocketOption {
+func sockoptToProto(_ *channelz.SocketOptionData) []*channelzpb.SocketOption {
+	logger.Info("sockoptToProto is not implemented on non-linux platforms")
 	return nil
 }

--- a/channelz/internal/protoconv/sockopt_nonlinux.go
+++ b/channelz/internal/protoconv/sockopt_nonlinux.go
@@ -27,6 +27,5 @@ import (
 )
 
 func sockoptToProto(_ *channelz.SocketOptionData) []*channelzpb.SocketOption {
-	logger.Info("sockoptToProto is not implemented on non-linux platforms")
 	return nil
 }

--- a/channelz/internal/protoconv/util.go
+++ b/channelz/internal/protoconv/util.go
@@ -20,12 +20,6 @@
 // implementation and the protobuf representation of all the entities.
 package protoconv
 
-import (
-	"google.golang.org/grpc/grpclog"
-)
-
-var logger = grpclog.Component("channelz")
-
 func strFromPointer(s *string) string {
 	if s == nil {
 		return ""

--- a/reflection/test/grpc_testing_not_regenerate/dynamic.proto
+++ b/reflection/test/grpc_testing_not_regenerate/dynamic.proto
@@ -17,7 +17,7 @@
 
 syntax = "proto3";
 
-option go_package = "google.golang.org/grpc/reflection/grpc_testing_not_regenerate";
+option go_package = "google.golang.org/grpc/reflection/test/grpc_testing_not_regenerate";
 
 package grpc.testing;
 

--- a/reflection/test/grpc_testing_not_regenerate/testv3.proto
+++ b/reflection/test/grpc_testing_not_regenerate/testv3.proto
@@ -17,7 +17,7 @@
 
 syntax = "proto3";
 
-option go_package = "google.golang.org/grpc/reflection/grpc_testing_not_regenerate";
+option go_package = "google.golang.org/grpc/reflection/test/grpc_testing_not_regenerate";
 
 package grpc.testingv3;
 

--- a/regenerate.sh
+++ b/regenerate.sh
@@ -20,7 +20,7 @@ WORKDIR=$(mktemp -d)
 function finish {
   rm -rf "$WORKDIR"
 }
-trap finish EXIT
+# trap finish EXIT
 
 export GOBIN=${WORKDIR}/bin
 export PATH=${GOBIN}:${PATH}

--- a/regenerate.sh
+++ b/regenerate.sh
@@ -118,6 +118,6 @@ mv ${WORKDIR}/out/google.golang.org/grpc/lookup/grpc_lookup_v1/* ${WORKDIR}/out/
 
 # grpc_testing_not_regenerate/*.pb.go are not re-generated,
 # see grpc_testing_not_regenerate/README.md for details.
-rm ${WORKDIR}/out/google.golang.org/grpc/reflection/grpc_testing_not_regenerate/*.pb.go
+rm ${WORKDIR}/out/google.golang.org/grpc/reflection/test/grpc_testing_not_regenerate/*.pb.go
 
 cp -R ${WORKDIR}/out/google.golang.org/grpc/* .

--- a/regenerate.sh
+++ b/regenerate.sh
@@ -20,7 +20,7 @@ WORKDIR=$(mktemp -d)
 function finish {
   rm -rf "$WORKDIR"
 }
-# trap finish EXIT
+trap finish EXIT
 
 export GOBIN=${WORKDIR}/bin
 export PATH=${GOBIN}:${PATH}

--- a/scripts/vet.sh
+++ b/scripts/vet.sh
@@ -3,7 +3,7 @@
 set -ex  # Exit on error; debugging enabled.
 set -o pipefail  # Fail a pipe if any sub-command fails.
 
-source "../vet-common.sh"
+source "$(dirname $0)/vet-common.sh"
 
 # Check to make sure it's safe to modify the user's git repo.
 git status --porcelain | fail_on_output

--- a/scripts/vet.sh
+++ b/scripts/vet.sh
@@ -119,7 +119,6 @@ grep "(SA1019)" "${SC_OUT}" | not grep -Fv 'XXXXX PleaseIgnoreUnused
 XXXXX Protobuf related deprecation errors:
 "github.com/golang/protobuf
 .pb.go:
-grpc_testing_not_regenerate
 : ptypes.
 proto.RegisterType
 XXXXX gRPC internal usage deprecation errors:

--- a/scripts/vet.sh
+++ b/scripts/vet.sh
@@ -3,7 +3,7 @@
 set -ex  # Exit on error; debugging enabled.
 set -o pipefail  # Fail a pipe if any sub-command fails.
 
-source "$(dirname $0)/vet-common.sh"
+source "../vet-common.sh"
 
 # Check to make sure it's safe to modify the user's git repo.
 git status --porcelain | fail_on_output
@@ -119,6 +119,7 @@ grep "(SA1019)" "${SC_OUT}" | not grep -Fv 'XXXXX PleaseIgnoreUnused
 XXXXX Protobuf related deprecation errors:
 "github.com/golang/protobuf
 .pb.go:
+grpc_testing_not_regenerate
 : ptypes.
 proto.RegisterType
 XXXXX gRPC internal usage deprecation errors:


### PR DESCRIPTION
`vet.sh` was failing in macOS. The logger defined in channelz/internal/protoconv package was not used when build on non_linux machines, which caused staticcheck to output this: 

```
channelz/internal/protoconv/util.go:27:5: var logger is unused (U1000)
```

also fixes the go_package for grpc_testing_not_regenerate proto

RELEASE NOTES: none
