### PR TITLE
fix: race detected on accessing http2Client.nextID

### DIFF
--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -526,7 +526,7 @@ func (t *http2Client) getPeer() *peer.Peer {
 func (t *http2Client) outgoingGoAwayHandler(g *goAway) (bool, error) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	if err := t.framer.fr.WriteGoAway(t.nextID-2, http2.ErrCodeNo, g.debugData); err != nil {
+	if err := t.framer.fr.WriteGoAway(math.MaxInt32*3/4, http2.ErrCodeNo, g.debugData); err != nil {
 		return false, err
 	}
 	return false, g.closeConn


### PR DESCRIPTION
RELEASE NOTES: 

- fixes race condition detected on accessing t.nextID while sending GOAWAY frame from client.