### PR TITLE
advancedtls: Rename VType

### DIFF
--- a/security/advancedtls/advancedtls.go
+++ b/security/advancedtls/advancedtls.go
@@ -179,8 +179,9 @@ type ClientOptions struct {
 	// the `VerificationType` enum for the different options.
 	// Default: CertAndHostVerification
 	VerificationType VerificationType
-	// DEPRECATED: Renamed to `VerificationType`
 	// VType is the verification type on the client side.
+	//
+	// Deprecated: use VerificationType instead.
 	VType VerificationType
 	// RevocationConfig is the configurations for certificate revocation checks.
 	// It could be nil if such checks are not needed.
@@ -219,8 +220,9 @@ type ServerOptions struct {
 	// the `VerificationType` enum for the different options.
 	// Default: CertAndHostVerification
 	VerificationType VerificationType
-	// DEPRECATED: Renamed to `VerificationType`
 	// VType is the verification type on the server side.
+	//
+	// Deprecated: use VerificationType instead.
 	VType VerificationType
 	// RevocationConfig is the configurations for certificate revocation checks.
 	// It could be nil if such checks are not needed.

--- a/security/advancedtls/advancedtls.go
+++ b/security/advancedtls/advancedtls.go
@@ -175,8 +175,9 @@ type ClientOptions struct {
 	// RootOptions is OPTIONAL on client side. If not set, we will try to use the
 	// default trust certificates in users' OS system.
 	RootOptions RootCertificateOptions
-	// VerificationType defines at what type of server verification is done. See
+	// VerificationType defines what type of server verification is done. See
 	// the `VerificationType` enum for the different options.
+	// Default: CertAndHostVerification
 	VerificationType VerificationType
 	// DEPRECATED: Renamed to `VerificationType`
 	// VType is the verification type on the client side.
@@ -214,6 +215,11 @@ type ServerOptions struct {
 	RootOptions RootCertificateOptions
 	// If the server want the client to send certificates.
 	RequireClientCert bool
+	// VerificationType defines what type of client verification is done. See
+	// the `VerificationType` enum for the different options.
+	// Default: CertAndHostVerification
+	VerificationType VerificationType
+	// DEPRECATED: Renamed to `VerificationType`
 	// VType is the verification type on the server side.
 	VType VerificationType
 	// RevocationConfig is the configurations for certificate revocation checks.
@@ -233,7 +239,7 @@ type ServerOptions struct {
 func (o *ClientOptions) config() (*tls.Config, error) {
 	// TODO(gtcooke94). VType is deprecated, eventually remove this block. This
 	// will ensure that users still explicitly setting `VType` will get the
-	// setting to the right place
+	// setting to the right place.
 	if o.VType != CertAndHostVerification {
 		o.VerificationType = o.VType
 	}
@@ -313,7 +319,13 @@ func (o *ClientOptions) config() (*tls.Config, error) {
 }
 
 func (o *ServerOptions) config() (*tls.Config, error) {
-	if o.RequireClientCert && o.VType == SkipVerification && o.VerifyPeer == nil {
+	// TODO(gtcooke94). VType is deprecated, eventually remove this block. This
+	// will ensure that users still explicitly setting `VType` will get the
+	// setting to the right place.
+	if o.VType != CertAndHostVerification {
+		o.VerificationType = o.VType
+	}
+	if o.RequireClientCert && o.VerificationType == SkipVerification && o.VerifyPeer == nil {
 		return nil, fmt.Errorf("server needs to provide custom verification mechanism if choose to skip default verification, but require client certificate(s)")
 	}
 	// Make sure users didn't specify more than one fields in
@@ -361,7 +373,7 @@ func (o *ServerOptions) config() (*tls.Config, error) {
 	default:
 		// No root certificate options specified by user. Use the certificates
 		// stored in system default path as the last resort.
-		if o.VType != SkipVerification && o.RequireClientCert {
+		if o.VerificationType != SkipVerification && o.RequireClientCert {
 			systemRootCAs, err := x509.SystemCertPool()
 			if err != nil {
 				return nil, err
@@ -405,7 +417,7 @@ type advancedTLSCreds struct {
 	verifyFunc       CustomVerificationFunc
 	getRootCAs       func(params *GetRootCAsParams) (*GetRootCAsResults, error)
 	isClient         bool
-	vType            VerificationType
+	verificationType VerificationType
 	revocationConfig *RevocationConfig
 }
 
@@ -505,7 +517,7 @@ func buildVerifyFunc(c *advancedTLSCreds,
 			}
 			rawCertList[i] = cert
 		}
-		if c.vType == CertAndHostVerification || c.vType == CertVerification {
+		if c.verificationType == CertAndHostVerification || c.verificationType == CertVerification {
 			// perform possible trust credential reloading and certificate check
 			rootCAs := c.config.RootCAs
 			if !c.isClient {
@@ -537,7 +549,7 @@ func buildVerifyFunc(c *advancedTLSCreds,
 				opts.Intermediates.AddCert(cert)
 			}
 			// Perform default hostname check if specified.
-			if c.isClient && c.vType == CertAndHostVerification && serverName != "" {
+			if c.isClient && c.verificationType == CertAndHostVerification && serverName != "" {
 				parsedName, _, err := net.SplitHostPort(serverName)
 				if err != nil {
 					// If the serverName had no host port or if the serverName cannot be
@@ -589,7 +601,7 @@ func NewClientCreds(o *ClientOptions) (credentials.TransportCredentials, error) 
 		isClient:         true,
 		getRootCAs:       o.RootOptions.GetRootCertificates,
 		verifyFunc:       o.VerifyPeer,
-		vType:            o.VerificationType,
+		verificationType: o.VerificationType,
 		revocationConfig: o.RevocationConfig,
 	}
 	tc.config.NextProtos = credinternal.AppendH2ToNextProtos(tc.config.NextProtos)
@@ -608,7 +620,7 @@ func NewServerCreds(o *ServerOptions) (credentials.TransportCredentials, error) 
 		isClient:         false,
 		getRootCAs:       o.RootOptions.GetRootCertificates,
 		verifyFunc:       o.VerifyPeer,
-		vType:            o.VType,
+		verificationType: o.VerificationType,
 		revocationConfig: o.RevocationConfig,
 	}
 	tc.config.NextProtos = credinternal.AppendH2ToNextProtos(tc.config.NextProtos)

--- a/security/advancedtls/advancedtls_integration_test.go
+++ b/security/advancedtls/advancedtls_integration_test.go
@@ -373,7 +373,7 @@ func (s) TestEnd2End(t *testing.T) {
 					RootCACerts:         test.clientRoot,
 					GetRootCertificates: test.clientGetRoot,
 				},
-				VType: test.clientVType,
+				VerificationType: test.clientVType,
 			}
 			clientTLSCreds, err := NewClientCreds(clientOptions)
 			if err != nil {
@@ -664,7 +664,7 @@ func (s) TestPEMFileProviderEnd2End(t *testing.T) {
 				RootOptions: RootCertificateOptions{
 					RootProvider: clientRootProvider,
 				},
-				VType: CertVerification,
+				VerificationType: CertVerification,
 			}
 			clientTLSCreds, err := NewClientCreds(clientOptions)
 			if err != nil {
@@ -789,7 +789,7 @@ func (s) TestDefaultHostNameCheck(t *testing.T) {
 				RootOptions: RootCertificateOptions{
 					RootCACerts: test.clientRoot,
 				},
-				VType: test.clientVType,
+				VerificationType: test.clientVType,
 			}
 			clientTLSCreds, err := NewClientCreds(clientOptions)
 			if err != nil {
@@ -929,9 +929,9 @@ func (s) TestTLSVersions(t *testing.T) {
 				RootOptions: RootCertificateOptions{
 					RootCACerts: cs.ClientTrust1,
 				},
-				VType:      CertAndHostVerification,
-				MinVersion: test.clientMinVersion,
-				MaxVersion: test.clientMaxVersion,
+				VerificationType: CertAndHostVerification,
+				MinVersion:       test.clientMinVersion,
+				MaxVersion:       test.clientMaxVersion,
 			}
 			clientTLSCreds, err := NewClientCreds(clientOptions)
 			if err != nil {

--- a/security/advancedtls/advancedtls_integration_test.go
+++ b/security/advancedtls/advancedtls_integration_test.go
@@ -138,19 +138,19 @@ func (s) TestEnd2End(t *testing.T) {
 	}
 	stage := &stageInfo{}
 	for _, test := range []struct {
-		desc             string
-		clientCert       []tls.Certificate
-		clientGetCert    func(*tls.CertificateRequestInfo) (*tls.Certificate, error)
-		clientRoot       *x509.CertPool
-		clientGetRoot    func(params *GetRootCAsParams) (*GetRootCAsResults, error)
-		clientVerifyFunc CustomVerificationFunc
-		clientVType      VerificationType
-		serverCert       []tls.Certificate
-		serverGetCert    func(*tls.ClientHelloInfo) ([]*tls.Certificate, error)
-		serverRoot       *x509.CertPool
-		serverGetRoot    func(params *GetRootCAsParams) (*GetRootCAsResults, error)
-		serverVerifyFunc CustomVerificationFunc
-		serverVType      VerificationType
+		desc                   string
+		clientCert             []tls.Certificate
+		clientGetCert          func(*tls.CertificateRequestInfo) (*tls.Certificate, error)
+		clientRoot             *x509.CertPool
+		clientGetRoot          func(params *GetRootCAsParams) (*GetRootCAsResults, error)
+		clientVerifyFunc       CustomVerificationFunc
+		clientVerificationType VerificationType
+		serverCert             []tls.Certificate
+		serverGetCert          func(*tls.ClientHelloInfo) ([]*tls.Certificate, error)
+		serverRoot             *x509.CertPool
+		serverGetRoot          func(params *GetRootCAsParams) (*GetRootCAsResults, error)
+		serverVerifyFunc       CustomVerificationFunc
+		serverVerificationType VerificationType
 	}{
 		// Test Scenarios:
 		// At initialization(stage = 0), client will be initialized with cert
@@ -178,8 +178,8 @@ func (s) TestEnd2End(t *testing.T) {
 			clientVerifyFunc: func(params *VerificationFuncParams) (*VerificationResults, error) {
 				return &VerificationResults{}, nil
 			},
-			clientVType: CertVerification,
-			serverCert:  []tls.Certificate{cs.ServerCert1},
+			clientVerificationType: CertVerification,
+			serverCert:             []tls.Certificate{cs.ServerCert1},
 			serverGetRoot: func(params *GetRootCAsParams) (*GetRootCAsResults, error) {
 				switch stage.read() {
 				case 0, 1:
@@ -191,7 +191,7 @@ func (s) TestEnd2End(t *testing.T) {
 			serverVerifyFunc: func(params *VerificationFuncParams) (*VerificationResults, error) {
 				return &VerificationResults{}, nil
 			},
-			serverVType: CertVerification,
+			serverVerificationType: CertVerification,
 		},
 		// Test Scenarios:
 		// At initialization(stage = 0), client will be initialized with cert
@@ -219,7 +219,7 @@ func (s) TestEnd2End(t *testing.T) {
 			clientVerifyFunc: func(params *VerificationFuncParams) (*VerificationResults, error) {
 				return &VerificationResults{}, nil
 			},
-			clientVType: CertVerification,
+			clientVerificationType: CertVerification,
 			serverGetCert: func(*tls.ClientHelloInfo) ([]*tls.Certificate, error) {
 				switch stage.read() {
 				case 0:
@@ -232,7 +232,7 @@ func (s) TestEnd2End(t *testing.T) {
 			serverVerifyFunc: func(params *VerificationFuncParams) (*VerificationResults, error) {
 				return &VerificationResults{}, nil
 			},
-			serverVType: CertVerification,
+			serverVerificationType: CertVerification,
 		},
 		// Test Scenarios:
 		// At initialization(stage = 0), client will be initialized with cert
@@ -284,7 +284,7 @@ func (s) TestEnd2End(t *testing.T) {
 				}
 				return nil, fmt.Errorf("custom authz check fails")
 			},
-			clientVType: CertVerification,
+			clientVerificationType: CertVerification,
 			serverGetCert: func(*tls.ClientHelloInfo) ([]*tls.Certificate, error) {
 				switch stage.read() {
 				case 0:
@@ -297,7 +297,7 @@ func (s) TestEnd2End(t *testing.T) {
 			serverVerifyFunc: func(params *VerificationFuncParams) (*VerificationResults, error) {
 				return &VerificationResults{}, nil
 			},
-			serverVType: CertVerification,
+			serverVerificationType: CertVerification,
 		},
 		// Test Scenarios:
 		// At initialization(stage = 0), client will be initialized with cert
@@ -317,9 +317,9 @@ func (s) TestEnd2End(t *testing.T) {
 			clientVerifyFunc: func(params *VerificationFuncParams) (*VerificationResults, error) {
 				return &VerificationResults{}, nil
 			},
-			clientVType: CertVerification,
-			serverCert:  []tls.Certificate{cs.ServerCert1},
-			serverRoot:  cs.ServerTrust1,
+			clientVerificationType: CertVerification,
+			serverCert:             []tls.Certificate{cs.ServerCert1},
+			serverRoot:             cs.ServerTrust1,
 			serverVerifyFunc: func(params *VerificationFuncParams) (*VerificationResults, error) {
 				switch stage.read() {
 				case 0, 2:
@@ -330,7 +330,7 @@ func (s) TestEnd2End(t *testing.T) {
 					return nil, fmt.Errorf("custom authz check fails")
 				}
 			},
-			serverVType: CertVerification,
+			serverVerificationType: CertVerification,
 		},
 	} {
 		test := test
@@ -347,7 +347,7 @@ func (s) TestEnd2End(t *testing.T) {
 				},
 				RequireClientCert: true,
 				VerifyPeer:        test.serverVerifyFunc,
-				VType:             test.serverVType,
+				VerificationType:  test.serverVerificationType,
 			}
 			serverTLSCreds, err := NewServerCreds(serverOptions)
 			if err != nil {
@@ -373,7 +373,7 @@ func (s) TestEnd2End(t *testing.T) {
 					RootCACerts:         test.clientRoot,
 					GetRootCertificates: test.clientGetRoot,
 				},
-				VerificationType: test.clientVType,
+				VerificationType: test.clientVerificationType,
 			}
 			clientTLSCreds, err := NewClientCreds(clientOptions)
 			if err != nil {
@@ -638,7 +638,7 @@ func (s) TestPEMFileProviderEnd2End(t *testing.T) {
 				VerifyPeer: func(params *VerificationFuncParams) (*VerificationResults, error) {
 					return &VerificationResults{}, nil
 				},
-				VType: CertVerification,
+				VerificationType: CertVerification,
 			}
 			serverTLSCreds, err := NewServerCreds(serverOptions)
 			if err != nil {
@@ -731,34 +731,34 @@ func (s) TestDefaultHostNameCheck(t *testing.T) {
 		t.Fatalf("cs.LoadCerts() failed, err: %v", err)
 	}
 	for _, test := range []struct {
-		desc        string
-		clientRoot  *x509.CertPool
-		clientVType VerificationType
-		serverCert  []tls.Certificate
-		serverVType VerificationType
-		expectError bool
+		desc                   string
+		clientRoot             *x509.CertPool
+		clientVerificationType VerificationType
+		serverCert             []tls.Certificate
+		serverVerificationType VerificationType
+		expectError            bool
 	}{
 		// Client side sets vType to CertAndHostVerification, and will do
 		// default hostname check. Server uses a cert without "localhost" or
 		// "127.0.0.1" as common name or SAN names, and will hence fail.
 		{
-			desc:        "Bad default hostname check",
-			clientRoot:  cs.ClientTrust1,
-			clientVType: CertAndHostVerification,
-			serverCert:  []tls.Certificate{cs.ServerCert1},
-			serverVType: CertAndHostVerification,
-			expectError: true,
+			desc:                   "Bad default hostname check",
+			clientRoot:             cs.ClientTrust1,
+			clientVerificationType: CertAndHostVerification,
+			serverCert:             []tls.Certificate{cs.ServerCert1},
+			serverVerificationType: CertAndHostVerification,
+			expectError:            true,
 		},
 		// Client side sets vType to CertAndHostVerification, and will do
 		// default hostname check. Server uses a certificate with "localhost" as
 		// common name, and will hence pass the default hostname check.
 		{
-			desc:        "Good default hostname check",
-			clientRoot:  cs.ClientTrust1,
-			clientVType: CertAndHostVerification,
-			serverCert:  []tls.Certificate{cs.ServerPeerLocalhost1},
-			serverVType: CertAndHostVerification,
-			expectError: false,
+			desc:                   "Good default hostname check",
+			clientRoot:             cs.ClientTrust1,
+			clientVerificationType: CertAndHostVerification,
+			serverCert:             []tls.Certificate{cs.ServerPeerLocalhost1},
+			serverVerificationType: CertAndHostVerification,
+			expectError:            false,
 		},
 	} {
 		test := test
@@ -769,7 +769,7 @@ func (s) TestDefaultHostNameCheck(t *testing.T) {
 					Certificates: test.serverCert,
 				},
 				RequireClientCert: false,
-				VType:             test.serverVType,
+				VerificationType:  test.serverVerificationType,
 			}
 			serverTLSCreds, err := NewServerCreds(serverOptions)
 			if err != nil {
@@ -789,7 +789,7 @@ func (s) TestDefaultHostNameCheck(t *testing.T) {
 				RootOptions: RootCertificateOptions{
 					RootCACerts: test.clientRoot,
 				},
-				VerificationType: test.clientVType,
+				VerificationType: test.clientVerificationType,
 			}
 			clientTLSCreds, err := NewClientCreds(clientOptions)
 			if err != nil {
@@ -907,7 +907,7 @@ func (s) TestTLSVersions(t *testing.T) {
 					Certificates: []tls.Certificate{cs.ServerPeerLocalhost1},
 				},
 				RequireClientCert: false,
-				VType:             CertAndHostVerification,
+				VerificationType:  CertAndHostVerification,
 				MinVersion:        test.serverMinVersion,
 				MaxVersion:        test.serverMaxVersion,
 			}

--- a/security/advancedtls/advancedtls_test.go
+++ b/security/advancedtls/advancedtls_test.go
@@ -88,28 +88,28 @@ func (f fakeProvider) Close() {}
 
 func (s) TestClientOptionsConfigErrorCases(t *testing.T) {
 	tests := []struct {
-		desc            string
-		clientVType     VerificationType
-		IdentityOptions IdentityCertificateOptions
-		RootOptions     RootCertificateOptions
-		MinVersion      uint16
-		MaxVersion      uint16
+		desc                   string
+		clientVerificationType VerificationType
+		IdentityOptions        IdentityCertificateOptions
+		RootOptions            RootCertificateOptions
+		MinVersion             uint16
+		MaxVersion             uint16
 	}{
 		{
-			desc:        "Skip default verification and provide no root credentials",
-			clientVType: SkipVerification,
+			desc:                   "Skip default verification and provide no root credentials",
+			clientVerificationType: SkipVerification,
 		},
 		{
-			desc:        "More than one fields in RootCertificateOptions is specified",
-			clientVType: CertVerification,
+			desc:                   "More than one fields in RootCertificateOptions is specified",
+			clientVerificationType: CertVerification,
 			RootOptions: RootCertificateOptions{
 				RootCACerts:  x509.NewCertPool(),
 				RootProvider: fakeProvider{},
 			},
 		},
 		{
-			desc:        "More than one fields in IdentityCertificateOptions is specified",
-			clientVType: CertVerification,
+			desc:                   "More than one fields in IdentityCertificateOptions is specified",
+			clientVerificationType: CertVerification,
 			IdentityOptions: IdentityCertificateOptions{
 				GetIdentityCertificatesForClient: func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
 					return nil, nil
@@ -135,7 +135,7 @@ func (s) TestClientOptionsConfigErrorCases(t *testing.T) {
 		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			clientOptions := &ClientOptions{
-				VerificationType: test.clientVType,
+				VerificationType: test.clientVerificationType,
 				IdentityOptions:  test.IdentityOptions,
 				RootOptions:      test.RootOptions,
 				MinVersion:       test.MinVersion,
@@ -151,20 +151,20 @@ func (s) TestClientOptionsConfigErrorCases(t *testing.T) {
 
 func (s) TestClientOptionsConfigSuccessCases(t *testing.T) {
 	tests := []struct {
-		desc            string
-		clientVType     VerificationType
-		IdentityOptions IdentityCertificateOptions
-		RootOptions     RootCertificateOptions
-		MinVersion      uint16
-		MaxVersion      uint16
+		desc                   string
+		clientVerificationType VerificationType
+		IdentityOptions        IdentityCertificateOptions
+		RootOptions            RootCertificateOptions
+		MinVersion             uint16
+		MaxVersion             uint16
 	}{
 		{
-			desc:        "Use system default if no fields in RootCertificateOptions is specified",
-			clientVType: CertVerification,
+			desc:                   "Use system default if no fields in RootCertificateOptions is specified",
+			clientVerificationType: CertVerification,
 		},
 		{
-			desc:        "Good case with mutual TLS",
-			clientVType: CertVerification,
+			desc:                   "Good case with mutual TLS",
+			clientVerificationType: CertVerification,
 			RootOptions: RootCertificateOptions{
 				RootProvider: fakeProvider{},
 			},
@@ -179,7 +179,7 @@ func (s) TestClientOptionsConfigSuccessCases(t *testing.T) {
 		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			clientOptions := &ClientOptions{
-				VerificationType: test.clientVType,
+				VerificationType: test.clientVerificationType,
 				IdentityOptions:  test.IdentityOptions,
 				RootOptions:      test.RootOptions,
 				MinVersion:       test.MinVersion,
@@ -203,23 +203,23 @@ func (s) TestClientOptionsConfigSuccessCases(t *testing.T) {
 
 func (s) TestServerOptionsConfigErrorCases(t *testing.T) {
 	tests := []struct {
-		desc              string
-		requireClientCert bool
-		serverVType       VerificationType
-		IdentityOptions   IdentityCertificateOptions
-		RootOptions       RootCertificateOptions
-		MinVersion        uint16
-		MaxVersion        uint16
+		desc                   string
+		requireClientCert      bool
+		serverVerificationType VerificationType
+		IdentityOptions        IdentityCertificateOptions
+		RootOptions            RootCertificateOptions
+		MinVersion             uint16
+		MaxVersion             uint16
 	}{
 		{
-			desc:              "Skip default verification and provide no root credentials",
-			requireClientCert: true,
-			serverVType:       SkipVerification,
+			desc:                   "Skip default verification and provide no root credentials",
+			requireClientCert:      true,
+			serverVerificationType: SkipVerification,
 		},
 		{
-			desc:              "More than one fields in RootCertificateOptions is specified",
-			requireClientCert: true,
-			serverVType:       CertVerification,
+			desc:                   "More than one fields in RootCertificateOptions is specified",
+			requireClientCert:      true,
+			serverVerificationType: CertVerification,
 			RootOptions: RootCertificateOptions{
 				RootCACerts: x509.NewCertPool(),
 				GetRootCertificates: func(*GetRootCAsParams) (*GetRootCAsResults, error) {
@@ -228,16 +228,16 @@ func (s) TestServerOptionsConfigErrorCases(t *testing.T) {
 			},
 		},
 		{
-			desc:        "More than one fields in IdentityCertificateOptions is specified",
-			serverVType: CertVerification,
+			desc:                   "More than one fields in IdentityCertificateOptions is specified",
+			serverVerificationType: CertVerification,
 			IdentityOptions: IdentityCertificateOptions{
 				Certificates:     []tls.Certificate{},
 				IdentityProvider: fakeProvider{pt: provTypeIdentity},
 			},
 		},
 		{
-			desc:        "no field in IdentityCertificateOptions is specified",
-			serverVType: CertVerification,
+			desc:                   "no field in IdentityCertificateOptions is specified",
+			serverVerificationType: CertVerification,
 		},
 		{
 			desc: "Specify GetIdentityCertificatesForClient",
@@ -257,7 +257,7 @@ func (s) TestServerOptionsConfigErrorCases(t *testing.T) {
 		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			serverOptions := &ServerOptions{
-				VType:             test.serverVType,
+				VerificationType:  test.serverVerificationType,
 				RequireClientCert: test.requireClientCert,
 				IdentityOptions:   test.IdentityOptions,
 				RootOptions:       test.RootOptions,
@@ -274,26 +274,26 @@ func (s) TestServerOptionsConfigErrorCases(t *testing.T) {
 
 func (s) TestServerOptionsConfigSuccessCases(t *testing.T) {
 	tests := []struct {
-		desc              string
-		requireClientCert bool
-		serverVType       VerificationType
-		IdentityOptions   IdentityCertificateOptions
-		RootOptions       RootCertificateOptions
-		MinVersion        uint16
-		MaxVersion        uint16
+		desc                   string
+		requireClientCert      bool
+		serverVerificationType VerificationType
+		IdentityOptions        IdentityCertificateOptions
+		RootOptions            RootCertificateOptions
+		MinVersion             uint16
+		MaxVersion             uint16
 	}{
 		{
-			desc:              "Use system default if no fields in RootCertificateOptions is specified",
-			requireClientCert: true,
-			serverVType:       CertVerification,
+			desc:                   "Use system default if no fields in RootCertificateOptions is specified",
+			requireClientCert:      true,
+			serverVerificationType: CertVerification,
 			IdentityOptions: IdentityCertificateOptions{
 				Certificates: []tls.Certificate{},
 			},
 		},
 		{
-			desc:              "Good case with mutual TLS",
-			requireClientCert: true,
-			serverVType:       CertVerification,
+			desc:                   "Good case with mutual TLS",
+			requireClientCert:      true,
+			serverVerificationType: CertVerification,
 			RootOptions: RootCertificateOptions{
 				RootProvider: fakeProvider{},
 			},
@@ -310,7 +310,7 @@ func (s) TestServerOptionsConfigSuccessCases(t *testing.T) {
 		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			serverOptions := &ServerOptions{
-				VType:             test.serverVType,
+				VerificationType:  test.serverVerificationType,
 				RequireClientCert: test.requireClientCert,
 				IdentityOptions:   test.IdentityOptions,
 				RootOptions:       test.RootOptions,
@@ -404,7 +404,7 @@ func (s) TestClientServerHandshake(t *testing.T) {
 		clientRoot                 *x509.CertPool
 		clientGetRoot              func(params *GetRootCAsParams) (*GetRootCAsResults, error)
 		clientVerifyFunc           CustomVerificationFunc
-		clientVType                VerificationType
+		clientVerificationType     VerificationType
 		clientRootProvider         certprovider.Provider
 		clientIdentityProvider     certprovider.Provider
 		clientRevocationConfig     *RevocationConfig
@@ -415,7 +415,7 @@ func (s) TestClientServerHandshake(t *testing.T) {
 		serverRoot                 *x509.CertPool
 		serverGetRoot              func(params *GetRootCAsParams) (*GetRootCAsResults, error)
 		serverVerifyFunc           CustomVerificationFunc
-		serverVType                VerificationType
+		serverVerificationType     VerificationType
 		serverRootProvider         certprovider.Provider
 		serverIdentityProvider     certprovider.Provider
 		serverRevocationConfig     *RevocationConfig
@@ -427,22 +427,22 @@ func (s) TestClientServerHandshake(t *testing.T) {
 		// Reason: we will use verifyFuncGood to verify the server,
 		// if either clientCert or clientGetCert is not set
 		{
-			desc:             "Client has no trust cert with verifyFuncGood; server sends peer cert",
-			clientVerifyFunc: clientVerifyFuncGood,
-			clientVType:      SkipVerification,
-			serverCert:       []tls.Certificate{cs.ServerCert1},
-			serverVType:      CertAndHostVerification,
+			desc:                   "Client has no trust cert with verifyFuncGood; server sends peer cert",
+			clientVerifyFunc:       clientVerifyFuncGood,
+			clientVerificationType: SkipVerification,
+			serverCert:             []tls.Certificate{cs.ServerCert1},
+			serverVerificationType: CertAndHostVerification,
 		},
 		// Client: set clientGetRoot and clientVerifyFunc
 		// Server: only set serverCert with mutual TLS off
 		// Expected Behavior: success
 		{
-			desc:             "Client sets reload root function with verifyFuncGood; server sends peer cert",
-			clientGetRoot:    getRootCAsForClient,
-			clientVerifyFunc: clientVerifyFuncGood,
-			clientVType:      CertVerification,
-			serverCert:       []tls.Certificate{cs.ServerCert1},
-			serverVType:      CertAndHostVerification,
+			desc:                   "Client sets reload root function with verifyFuncGood; server sends peer cert",
+			clientGetRoot:          getRootCAsForClient,
+			clientVerifyFunc:       clientVerifyFuncGood,
+			clientVerificationType: CertVerification,
+			serverCert:             []tls.Certificate{cs.ServerCert1},
+			serverVerificationType: CertAndHostVerification,
 		},
 		// Client: set clientGetRoot and bad clientVerifyFunc function
 		// Server: only set serverCert with mutual TLS off
@@ -452,39 +452,39 @@ func (s) TestClientServerHandshake(t *testing.T) {
 			desc:                       "Client sets reload root function with verifyFuncBad; server sends peer cert",
 			clientGetRoot:              getRootCAsForClient,
 			clientVerifyFunc:           verifyFuncBad,
-			clientVType:                CertVerification,
+			clientVerificationType:     CertVerification,
 			clientExpectHandshakeError: true,
 			serverCert:                 []tls.Certificate{cs.ServerCert1},
-			serverVType:                CertVerification,
+			serverVerificationType:     CertVerification,
 			serverExpectError:          true,
 		},
 		// Client: set clientGetRoot, clientVerifyFunc and clientCert
 		// Server: set serverRoot and serverCert with mutual TLS on
 		// Expected Behavior: success
 		{
-			desc:             "Client sets peer cert, reload root function with verifyFuncGood; server sets peer cert and root cert; mutualTLS",
-			clientCert:       []tls.Certificate{cs.ClientCert1},
-			clientGetRoot:    getRootCAsForClient,
-			clientVerifyFunc: clientVerifyFuncGood,
-			clientVType:      CertVerification,
-			serverMutualTLS:  true,
-			serverCert:       []tls.Certificate{cs.ServerCert1},
-			serverRoot:       cs.ServerTrust1,
-			serverVType:      CertVerification,
+			desc:                   "Client sets peer cert, reload root function with verifyFuncGood; server sets peer cert and root cert; mutualTLS",
+			clientCert:             []tls.Certificate{cs.ClientCert1},
+			clientGetRoot:          getRootCAsForClient,
+			clientVerifyFunc:       clientVerifyFuncGood,
+			clientVerificationType: CertVerification,
+			serverMutualTLS:        true,
+			serverCert:             []tls.Certificate{cs.ServerCert1},
+			serverRoot:             cs.ServerTrust1,
+			serverVerificationType: CertVerification,
 		},
 		// Client: set clientGetRoot, clientVerifyFunc and clientCert
 		// Server: set serverGetRoot and serverCert with mutual TLS on
 		// Expected Behavior: success
 		{
-			desc:             "Client sets peer cert, reload root function with verifyFuncGood; Server sets peer cert, reload root function; mutualTLS",
-			clientCert:       []tls.Certificate{cs.ClientCert1},
-			clientGetRoot:    getRootCAsForClient,
-			clientVerifyFunc: clientVerifyFuncGood,
-			clientVType:      CertVerification,
-			serverMutualTLS:  true,
-			serverCert:       []tls.Certificate{cs.ServerCert1},
-			serverGetRoot:    getRootCAsForServer,
-			serverVType:      CertVerification,
+			desc:                   "Client sets peer cert, reload root function with verifyFuncGood; Server sets peer cert, reload root function; mutualTLS",
+			clientCert:             []tls.Certificate{cs.ClientCert1},
+			clientGetRoot:          getRootCAsForClient,
+			clientVerifyFunc:       clientVerifyFuncGood,
+			clientVerificationType: CertVerification,
+			serverMutualTLS:        true,
+			serverCert:             []tls.Certificate{cs.ServerCert1},
+			serverGetRoot:          getRootCAsForServer,
+			serverVerificationType: CertVerification,
 		},
 		// Client: set clientGetRoot, clientVerifyFunc and clientCert
 		// Server: set serverGetRoot returning error and serverCert with mutual
@@ -492,16 +492,16 @@ func (s) TestClientServerHandshake(t *testing.T) {
 		// Expected Behavior: server side failure
 		// Reason: server side reloading returns failure
 		{
-			desc:              "Client sets peer cert, reload root function with verifyFuncGood; Server sets peer cert, bad reload root function; mutualTLS",
-			clientCert:        []tls.Certificate{cs.ClientCert1},
-			clientGetRoot:     getRootCAsForClient,
-			clientVerifyFunc:  clientVerifyFuncGood,
-			clientVType:       CertVerification,
-			serverMutualTLS:   true,
-			serverCert:        []tls.Certificate{cs.ServerCert1},
-			serverGetRoot:     getRootCAsForServerBad,
-			serverVType:       CertVerification,
-			serverExpectError: true,
+			desc:                   "Client sets peer cert, reload root function with verifyFuncGood; Server sets peer cert, bad reload root function; mutualTLS",
+			clientCert:             []tls.Certificate{cs.ClientCert1},
+			clientGetRoot:          getRootCAsForClient,
+			clientVerifyFunc:       clientVerifyFuncGood,
+			clientVerificationType: CertVerification,
+			serverMutualTLS:        true,
+			serverCert:             []tls.Certificate{cs.ServerCert1},
+			serverGetRoot:          getRootCAsForServerBad,
+			serverVerificationType: CertVerification,
+			serverExpectError:      true,
 		},
 		// Client: set clientGetRoot, clientVerifyFunc and clientGetCert
 		// Server: set serverGetRoot and serverGetCert with mutual TLS on
@@ -511,16 +511,16 @@ func (s) TestClientServerHandshake(t *testing.T) {
 			clientGetCert: func(info *tls.CertificateRequestInfo) (*tls.Certificate, error) {
 				return &cs.ClientCert1, nil
 			},
-			clientGetRoot:    getRootCAsForClient,
-			clientVerifyFunc: clientVerifyFuncGood,
-			clientVType:      CertVerification,
-			serverMutualTLS:  true,
+			clientGetRoot:          getRootCAsForClient,
+			clientVerifyFunc:       clientVerifyFuncGood,
+			clientVerificationType: CertVerification,
+			serverMutualTLS:        true,
 			serverGetCert: func(info *tls.ClientHelloInfo) ([]*tls.Certificate, error) {
 				return []*tls.Certificate{&cs.ServerCert1}, nil
 			},
-			serverGetRoot:    getRootCAsForServer,
-			serverVerifyFunc: serverVerifyFunc,
-			serverVType:      CertVerification,
+			serverGetRoot:          getRootCAsForServer,
+			serverVerifyFunc:       serverVerifyFunc,
+			serverVerificationType: CertVerification,
 		},
 		// Client: set everything but with the wrong peer cert not trusted by
 		// server
@@ -532,17 +532,17 @@ func (s) TestClientServerHandshake(t *testing.T) {
 			clientGetCert: func(info *tls.CertificateRequestInfo) (*tls.Certificate, error) {
 				return &cs.ServerCert1, nil
 			},
-			clientGetRoot:    getRootCAsForClient,
-			clientVerifyFunc: clientVerifyFuncGood,
-			clientVType:      CertVerification,
-			serverMutualTLS:  true,
+			clientGetRoot:          getRootCAsForClient,
+			clientVerifyFunc:       clientVerifyFuncGood,
+			clientVerificationType: CertVerification,
+			serverMutualTLS:        true,
 			serverGetCert: func(info *tls.ClientHelloInfo) ([]*tls.Certificate, error) {
 				return []*tls.Certificate{&cs.ServerCert1}, nil
 			},
-			serverGetRoot:     getRootCAsForServer,
-			serverVerifyFunc:  serverVerifyFunc,
-			serverVType:       CertVerification,
-			serverExpectError: true,
+			serverGetRoot:          getRootCAsForServer,
+			serverVerifyFunc:       serverVerifyFunc,
+			serverVerificationType: CertVerification,
+			serverExpectError:      true,
 		},
 		// Client: set everything but with the wrong trust cert not trusting server
 		// Server: set serverGetRoot and serverGetCert with mutual TLS on
@@ -555,16 +555,16 @@ func (s) TestClientServerHandshake(t *testing.T) {
 			},
 			clientGetRoot:              getRootCAsForServer,
 			clientVerifyFunc:           clientVerifyFuncGood,
-			clientVType:                CertVerification,
+			clientVerificationType:     CertVerification,
 			clientExpectHandshakeError: true,
 			serverMutualTLS:            true,
 			serverGetCert: func(info *tls.ClientHelloInfo) ([]*tls.Certificate, error) {
 				return []*tls.Certificate{&cs.ServerCert1}, nil
 			},
-			serverGetRoot:     getRootCAsForServer,
-			serverVerifyFunc:  serverVerifyFunc,
-			serverVType:       CertVerification,
-			serverExpectError: true,
+			serverGetRoot:          getRootCAsForServer,
+			serverVerifyFunc:       serverVerifyFunc,
+			serverVerificationType: CertVerification,
+			serverExpectError:      true,
 		},
 		// Client: set clientGetRoot, clientVerifyFunc and clientCert
 		// Server: set everything but with the wrong peer cert not trusted by
@@ -576,17 +576,17 @@ func (s) TestClientServerHandshake(t *testing.T) {
 			clientGetCert: func(info *tls.CertificateRequestInfo) (*tls.Certificate, error) {
 				return &cs.ClientCert1, nil
 			},
-			clientGetRoot:    getRootCAsForClient,
-			clientVerifyFunc: clientVerifyFuncGood,
-			clientVType:      CertVerification,
-			serverMutualTLS:  true,
+			clientGetRoot:          getRootCAsForClient,
+			clientVerifyFunc:       clientVerifyFuncGood,
+			clientVerificationType: CertVerification,
+			serverMutualTLS:        true,
 			serverGetCert: func(info *tls.ClientHelloInfo) ([]*tls.Certificate, error) {
 				return []*tls.Certificate{&cs.ClientCert1}, nil
 			},
-			serverGetRoot:     getRootCAsForServer,
-			serverVerifyFunc:  serverVerifyFunc,
-			serverVType:       CertVerification,
-			serverExpectError: true,
+			serverGetRoot:          getRootCAsForServer,
+			serverVerifyFunc:       serverVerifyFunc,
+			serverVerificationType: CertVerification,
+			serverExpectError:      true,
 		},
 		// Client: set clientGetRoot, clientVerifyFunc and clientCert
 		// Server: set everything but with the wrong trust cert not trusting client
@@ -599,16 +599,16 @@ func (s) TestClientServerHandshake(t *testing.T) {
 			},
 			clientGetRoot:              getRootCAsForClient,
 			clientVerifyFunc:           clientVerifyFuncGood,
-			clientVType:                CertVerification,
+			clientVerificationType:     CertVerification,
 			clientExpectHandshakeError: true,
 			serverMutualTLS:            true,
 			serverGetCert: func(info *tls.ClientHelloInfo) ([]*tls.Certificate, error) {
 				return []*tls.Certificate{&cs.ServerCert1}, nil
 			},
-			serverGetRoot:     getRootCAsForClient,
-			serverVerifyFunc:  serverVerifyFunc,
-			serverVType:       CertVerification,
-			serverExpectError: true,
+			serverGetRoot:          getRootCAsForClient,
+			serverVerifyFunc:       serverVerifyFunc,
+			serverVerificationType: CertVerification,
+			serverExpectError:      true,
 		},
 		// Client: set clientGetRoot, clientVerifyFunc and clientCert
 		// Server: set serverGetRoot and serverCert, but with bad verifyFunc
@@ -619,13 +619,13 @@ func (s) TestClientServerHandshake(t *testing.T) {
 			clientCert:                 []tls.Certificate{cs.ClientCert1},
 			clientGetRoot:              getRootCAsForClient,
 			clientVerifyFunc:           clientVerifyFuncGood,
-			clientVType:                CertVerification,
+			clientVerificationType:     CertVerification,
 			clientExpectHandshakeError: true,
 			serverMutualTLS:            true,
 			serverCert:                 []tls.Certificate{cs.ServerCert1},
 			serverGetRoot:              getRootCAsForServer,
 			serverVerifyFunc:           verifyFuncBad,
-			serverVType:                CertVerification,
+			serverVerificationType:     CertVerification,
 			serverExpectError:          true,
 		},
 		// Client: set a clientIdentityProvider which will get multiple cert chains
@@ -637,11 +637,11 @@ func (s) TestClientServerHandshake(t *testing.T) {
 			clientIdentityProvider: fakeProvider{pt: provTypeIdentity, isClient: true, wantMultiCert: true},
 			clientRootProvider:     fakeProvider{isClient: true},
 			clientVerifyFunc:       clientVerifyFuncGood,
-			clientVType:            CertVerification,
+			clientVerificationType: CertVerification,
 			serverMutualTLS:        true,
 			serverIdentityProvider: fakeProvider{pt: provTypeIdentity, isClient: false},
 			serverRootProvider:     fakeProvider{isClient: false},
-			serverVType:            CertVerification,
+			serverVerificationType: CertVerification,
 			serverExpectError:      true,
 		},
 		// Client: set a bad clientIdentityProvider
@@ -652,11 +652,11 @@ func (s) TestClientServerHandshake(t *testing.T) {
 			clientIdentityProvider: fakeProvider{pt: provTypeIdentity, isClient: true, wantError: true},
 			clientRootProvider:     fakeProvider{isClient: true},
 			clientVerifyFunc:       clientVerifyFuncGood,
-			clientVType:            CertVerification,
+			clientVerificationType: CertVerification,
 			serverMutualTLS:        true,
 			serverIdentityProvider: fakeProvider{pt: provTypeIdentity, isClient: false},
 			serverRootProvider:     fakeProvider{isClient: false},
-			serverVType:            CertVerification,
+			serverVerificationType: CertVerification,
 			serverExpectError:      true,
 		},
 		// Client: set clientIdentityProvider and clientRootProvider
@@ -667,11 +667,11 @@ func (s) TestClientServerHandshake(t *testing.T) {
 			clientIdentityProvider: fakeProvider{pt: provTypeIdentity, isClient: true},
 			clientRootProvider:     fakeProvider{isClient: true},
 			clientVerifyFunc:       clientVerifyFuncGood,
-			clientVType:            CertVerification,
+			clientVerificationType: CertVerification,
 			serverMutualTLS:        true,
 			serverIdentityProvider: fakeProvider{pt: provTypeIdentity, isClient: false},
 			serverRootProvider:     fakeProvider{isClient: false, wantError: true},
-			serverVType:            CertVerification,
+			serverVerificationType: CertVerification,
 			serverExpectError:      true,
 		},
 		// Client: set clientIdentityProvider and clientRootProvider
@@ -682,11 +682,11 @@ func (s) TestClientServerHandshake(t *testing.T) {
 			clientIdentityProvider: fakeProvider{pt: provTypeIdentity, isClient: true},
 			clientRootProvider:     fakeProvider{isClient: true},
 			clientVerifyFunc:       clientVerifyFuncGood,
-			clientVType:            CertVerification,
+			clientVerificationType: CertVerification,
 			serverMutualTLS:        true,
 			serverIdentityProvider: fakeProvider{pt: provTypeIdentity, isClient: false},
 			serverRootProvider:     fakeProvider{isClient: false},
-			serverVType:            CertVerification,
+			serverVerificationType: CertVerification,
 		},
 		// Client: set clientIdentityProvider and clientRootProvider
 		// Server: set serverIdentityProvider getting multiple cert chains and serverRootProvider with mutual TLS on
@@ -696,30 +696,30 @@ func (s) TestClientServerHandshake(t *testing.T) {
 			clientIdentityProvider: fakeProvider{pt: provTypeIdentity, isClient: true},
 			clientRootProvider:     fakeProvider{isClient: true},
 			clientVerifyFunc:       clientVerifyFuncGood,
-			clientVType:            CertVerification,
+			clientVerificationType: CertVerification,
 			serverMutualTLS:        true,
 			serverIdentityProvider: fakeProvider{pt: provTypeIdentity, isClient: false, wantMultiCert: true},
 			serverRootProvider:     fakeProvider{isClient: false},
-			serverVType:            CertVerification,
+			serverVerificationType: CertVerification,
 		},
 		// Client: set valid credentials with the revocation config
 		// Server: set valid credentials with the revocation config
 		// Expected Behavior: success, because none of the certificate chains sent in the connection are revoked
 		{
-			desc:             "Client sets peer cert, reload root function with verifyFuncGood; Server sets peer cert, reload root function; mutualTLS",
-			clientCert:       []tls.Certificate{cs.ClientCert1},
-			clientGetRoot:    getRootCAsForClient,
-			clientVerifyFunc: clientVerifyFuncGood,
-			clientVType:      CertVerification,
+			desc:                   "Client sets peer cert, reload root function with verifyFuncGood; Server sets peer cert, reload root function; mutualTLS",
+			clientCert:             []tls.Certificate{cs.ClientCert1},
+			clientGetRoot:          getRootCAsForClient,
+			clientVerifyFunc:       clientVerifyFuncGood,
+			clientVerificationType: CertVerification,
 			clientRevocationConfig: &RevocationConfig{
 				RootDir:           testdata.Path("crl"),
 				AllowUndetermined: true,
 				Cache:             cache,
 			},
-			serverMutualTLS: true,
-			serverCert:      []tls.Certificate{cs.ServerCert1},
-			serverGetRoot:   getRootCAsForServer,
-			serverVType:     CertVerification,
+			serverMutualTLS:        true,
+			serverCert:             []tls.Certificate{cs.ServerCert1},
+			serverGetRoot:          getRootCAsForServer,
+			serverVerificationType: CertVerification,
 			serverRevocationConfig: &RevocationConfig{
 				RootDir:           testdata.Path("crl"),
 				AllowUndetermined: true,
@@ -734,12 +734,12 @@ func (s) TestClientServerHandshake(t *testing.T) {
 			clientCert:             []tls.Certificate{cs.ClientCertForCRL},
 			clientGetRoot:          getRootCAsForClientCRL,
 			clientVerifyFunc:       clientVerifyFuncGood,
-			clientVType:            CertVerification,
+			clientVerificationType: CertVerification,
 			clientRevocationConfig: makeStaticCRLRevocationConfig(testdata.Path("crl/provider_crl_empty.pem"), true),
 			serverMutualTLS:        true,
 			serverCert:             []tls.Certificate{cs.ServerCertForCRL},
 			serverGetRoot:          getRootCAsForServerCRL,
-			serverVType:            CertVerification,
+			serverVerificationType: CertVerification,
 		},
 		// Client: set valid credentials with the revocation config
 		// Server: set revoked credentials with the revocation config
@@ -749,12 +749,12 @@ func (s) TestClientServerHandshake(t *testing.T) {
 			clientCert:             []tls.Certificate{cs.ClientCertForCRL},
 			clientGetRoot:          getRootCAsForClientCRL,
 			clientVerifyFunc:       clientVerifyFuncGood,
-			clientVType:            CertVerification,
+			clientVerificationType: CertVerification,
 			clientRevocationConfig: makeStaticCRLRevocationConfig(testdata.Path("crl/provider_crl_server_revoked.pem"), true),
 			serverMutualTLS:        true,
 			serverCert:             []tls.Certificate{cs.ServerCertForCRL},
 			serverGetRoot:          getRootCAsForServerCRL,
-			serverVType:            CertVerification,
+			serverVerificationType: CertVerification,
 			serverExpectError:      true,
 		},
 		// Client: set valid credentials with the revocation config
@@ -766,12 +766,12 @@ func (s) TestClientServerHandshake(t *testing.T) {
 			clientCert:             []tls.Certificate{cs.ClientCertForCRL},
 			clientGetRoot:          getRootCAsForClientCRL,
 			clientVerifyFunc:       clientVerifyFuncGood,
-			clientVType:            CertVerification,
+			clientVerificationType: CertVerification,
 			clientRevocationConfig: makeStaticCRLRevocationConfig(testdata.Path("crl/provider_malicious_crl_empty.pem"), false),
 			serverMutualTLS:        true,
 			serverCert:             []tls.Certificate{cs.ServerCertForCRL},
 			serverGetRoot:          getRootCAsForServerCRL,
-			serverVType:            CertVerification,
+			serverVerificationType: CertVerification,
 			serverExpectError:      true,
 		},
 	} {
@@ -796,7 +796,7 @@ func (s) TestClientServerHandshake(t *testing.T) {
 				},
 				RequireClientCert: test.serverMutualTLS,
 				VerifyPeer:        test.serverVerifyFunc,
-				VType:             test.serverVType,
+				VerificationType:  test.serverVerificationType,
 				RevocationConfig:  test.serverRevocationConfig,
 			}
 			go func(done chan credentials.AuthInfo, lis net.Listener, serverOptions *ServerOptions) {
@@ -839,7 +839,7 @@ func (s) TestClientServerHandshake(t *testing.T) {
 					GetRootCertificates: test.clientGetRoot,
 					RootProvider:        test.clientRootProvider,
 				},
-				VerificationType: test.clientVType,
+				VerificationType: test.clientVerificationType,
 				RevocationConfig: test.clientRevocationConfig,
 			}
 			clientTLS, err := NewClientCreds(clientOptions)

--- a/security/advancedtls/advancedtls_test.go
+++ b/security/advancedtls/advancedtls_test.go
@@ -135,11 +135,11 @@ func (s) TestClientOptionsConfigErrorCases(t *testing.T) {
 		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			clientOptions := &ClientOptions{
-				VType:           test.clientVType,
-				IdentityOptions: test.IdentityOptions,
-				RootOptions:     test.RootOptions,
-				MinVersion:      test.MinVersion,
-				MaxVersion:      test.MaxVersion,
+				VerificationType: test.clientVType,
+				IdentityOptions:  test.IdentityOptions,
+				RootOptions:      test.RootOptions,
+				MinVersion:       test.MinVersion,
+				MaxVersion:       test.MaxVersion,
 			}
 			_, err := clientOptions.config()
 			if err == nil {
@@ -179,11 +179,11 @@ func (s) TestClientOptionsConfigSuccessCases(t *testing.T) {
 		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			clientOptions := &ClientOptions{
-				VType:           test.clientVType,
-				IdentityOptions: test.IdentityOptions,
-				RootOptions:     test.RootOptions,
-				MinVersion:      test.MinVersion,
-				MaxVersion:      test.MaxVersion,
+				VerificationType: test.clientVType,
+				IdentityOptions:  test.IdentityOptions,
+				RootOptions:      test.RootOptions,
+				MinVersion:       test.MinVersion,
+				MaxVersion:       test.MaxVersion,
 			}
 			clientConfig, err := clientOptions.config()
 			if err != nil {
@@ -839,7 +839,7 @@ func (s) TestClientServerHandshake(t *testing.T) {
 					GetRootCertificates: test.clientGetRoot,
 					RootProvider:        test.clientRootProvider,
 				},
-				VType:            test.clientVType,
+				VerificationType: test.clientVType,
 				RevocationConfig: test.clientRevocationConfig,
 			}
 			clientTLS, err := NewClientCreds(clientOptions)

--- a/security/advancedtls/advancedtls_test.go
+++ b/security/advancedtls/advancedtls_test.go
@@ -149,6 +149,20 @@ func (s) TestClientOptionsConfigErrorCases(t *testing.T) {
 	}
 }
 
+// TODO(gtcooke94) Remove when deprecated `VType` is removed. This doesn't fit nicely into other table tests since it is setting a deprecated option.
+// Set VerificationType via the deprecated VType. Make sure it cascades to
+// VerificationType. This should error because one cannot skip default
+// verification and provide no root credentials",
+func (s) TestClientOptionsWithDeprecatedVType(t *testing.T) {
+	clientOptions := &ClientOptions{
+		VType: SkipVerification,
+	}
+	_, err := clientOptions.config()
+	if err == nil {
+		t.Fatalf("ClientOptions{%v}.config() returns no err, wantErr != nil", clientOptions)
+	}
+}
+
 func (s) TestClientOptionsConfigSuccessCases(t *testing.T) {
 	tests := []struct {
 		desc                   string
@@ -269,6 +283,20 @@ func (s) TestServerOptionsConfigErrorCases(t *testing.T) {
 				t.Fatalf("ServerOptions{%v}.config() returns no err, wantErr != nil", serverOptions)
 			}
 		})
+	}
+}
+
+// TODO(gtcooke94) Remove when deprecated `VType` is removed. This doesn't fit nicely into other table tests since it is setting a deprecated option.
+// Set VerificationType via the deprecated VType. Make sure it cascades to
+// VerificationType. This should error because one cannot skip default
+// verification and provide no root credentials",
+func (s) TestServerOptionsWithDeprecatedVType(t *testing.T) {
+	serverOptions := &ServerOptions{
+		VType: SkipVerification,
+	}
+	_, err := serverOptions.config()
+	if err == nil {
+		t.Fatalf("ClientOptions{%v}.config() returns no err, wantErr != nil", serverOptions)
 	}
 }
 

--- a/security/advancedtls/examples/credential_reloading_from_files/client/main.go
+++ b/security/advancedtls/examples/credential_reloading_from_files/client/main.go
@@ -82,7 +82,7 @@ func main() {
 		RootOptions: advancedtls.RootCertificateOptions{
 			RootProvider: rootProvider,
 		},
-		VType: advancedtls.CertVerification,
+		VerificationType: advancedtls.CertVerification,
 	}
 	clientTLSCreds, err := advancedtls.NewClientCreds(options)
 	if err != nil {

--- a/security/advancedtls/examples/credential_reloading_from_files/server/main.go
+++ b/security/advancedtls/examples/credential_reloading_from_files/server/main.go
@@ -89,7 +89,7 @@ func main() {
 			fmt.Printf("Client common name: %s.\n", params.Leaf.Subject.CommonName)
 			return &advancedtls.VerificationResults{}, nil
 		},
-		VType: advancedtls.CertVerification,
+		VerificationType: advancedtls.CertVerification,
 	}
 	serverTLSCreds, err := advancedtls.NewServerCreds(options)
 	if err != nil {


### PR DESCRIPTION
This PR renames `VType` to `VerificationType` for clarity.
It marks `VType` as deprecated. For now, if `VType` is explicitly set (does not have the default value) then we set `VerificationType` to `VType` so that user behavior doesn't break.

RELEASE NOTES: none