### PR TITLE
add: information about endpoint connection when auth handshake fails

### DIFF
--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -286,7 +286,7 @@ func newHTTP2Client(connectCtx, ctx context.Context, addr resolver.Address, opts
 	if transportCreds != nil {
 		conn, authInfo, err = transportCreds.ClientHandshake(connectCtx, addr.ServerName, conn)
 		if err != nil {
-			return nil, connectionErrorf(isTemporary(err), err, "transport: authentication handshake failed: %v", err)
+			return nil, connectionErrorf(isTemporary(err), err, "transport: authentication handshake failed for %s: %v", addr.ServerName, err)
 		}
 		for _, cd := range perRPCCreds {
 			if cd.RequireTransportSecurity() {


### PR DESCRIPTION
Wanted in Kubernetes: https://github.com/kubernetes/kubernetes/issues/122639

It adds more information to the log when the authentication handshake fails in gRPC connections.