### PR TITLE
xds/internal/xdsclient/xdsresource: Preallocate VirtualHost slice correctly

### DIFF
--- a/xds/internal/xdsclient/xdsresource/filter_chain.go
+++ b/xds/internal/xdsclient/xdsresource/filter_chain.go
@@ -106,7 +106,7 @@ type UsableRouteConfiguration struct {
 // ConstructUsableRouteConfiguration takes Route Configuration and converts it
 // into matchable route configuration, with instantiated HTTP Filters per route.
 func (fc *FilterChain) ConstructUsableRouteConfiguration(config RouteConfigUpdate) *UsableRouteConfiguration {
-	vhs := make([]VirtualHostWithInterceptors, len(config.VirtualHosts))
+	vhs := make([]VirtualHostWithInterceptors, 0, len(config.VirtualHosts))
 	for _, vh := range config.VirtualHosts {
 		vhwi, err := fc.convertVirtualHost(vh)
 		if err != nil {


### PR DESCRIPTION
when I want to add feature for linter [makezero](https://github.com/ashanbrown/makezero) in PR https://github.com/ashanbrown/makezero/pull/15 , I run a github action for real world repos, and the action result report this bug.

RELEASE NOTES: N/A