### PR TITLE
examples: fix the quickstart link in the routeguide example

### DIFF
--- a/examples/gotutorial.md
+++ b/examples/gotutorial.md
@@ -28,7 +28,7 @@ Then change your current directory to `grpc-go/examples/route_guide`:
 $ cd $GOPATH/src/google.golang.org/grpc/examples/route_guide
 ```
 
-You also should have the relevant tools installed to generate the server and client interface code - if you don't already, follow the setup instructions in [the Go quick start guide](https://github.com/grpc/grpc-go/tree/master/examples/).
+You also should have the relevant tools installed to generate the server and client interface code - if you don't already, follow the setup instructions in [the Go quick start guide](https://grpc.io/docs/languages/go/quickstart).
 
 
 ## Defining the service

--- a/examples/gotutorial.md
+++ b/examples/gotutorial.md
@@ -28,7 +28,7 @@ Then change your current directory to `grpc-go/examples/route_guide`:
 $ cd $GOPATH/src/google.golang.org/grpc/examples/route_guide
 ```
 
-You also should have the relevant tools installed to generate the server and client interface code - if you don't already, follow the setup instructions in [the Go quick start guide](https://grpc.io/docs/languages/go/quickstart).
+Ensure you have the relevant tools installed to generate the server and client interface code. If you don't, follow the setup instructions in [the Go quick start guide](https://grpc.io/docs/languages/go/quickstart).
 
 
 ## Defining the service


### PR DESCRIPTION
Point to the Go quickstart link which has the instructions for installing protoc and the required plugins.

RELEASE NOTES: none