### PR TITLE
advancedTLS: Rename {Min/Max}Version to {Min/Max}TLSVersion

### DIFF
--- a/security/advancedtls/advancedtls.go
+++ b/security/advancedtls/advancedtls.go
@@ -221,7 +221,7 @@ type ClientOptions struct {
 	MinVersion uint16
 	// MaxVersion contains the maximum TLS version that is acceptable.
 	//
-	// Deprecated: use MinTLSVersion instead.
+	// Deprecated: use MaxTLSVersion instead.
 	MaxVersion uint16
 	// MinTLSVersion contains the minimum TLS version that is acceptable.
 	// By default, TLS 1.2 is currently used as the minimum when acting as a
@@ -279,7 +279,7 @@ type ServerOptions struct {
 	MinVersion uint16
 	// MaxVersion contains the maximum TLS version that is acceptable.
 	//
-	// Deprecated: use MinTLSVersion instead.
+	// Deprecated: use MaxTLSVersion instead.
 	MaxVersion uint16
 	// MinTLSVersion contains the minimum TLS version that is acceptable.
 	// By default, TLS 1.2 is currently used as the minimum when acting as a

--- a/security/advancedtls/advancedtls.go
+++ b/security/advancedtls/advancedtls.go
@@ -224,12 +224,14 @@ type ClientOptions struct {
 	// Deprecated: use MaxTLSVersion instead.
 	MaxVersion uint16
 	// MinTLSVersion contains the minimum TLS version that is acceptable.
+	// The value should be set using tls.VersionTLSxx from https://pkg.go.dev/crypto/tls
 	// By default, TLS 1.2 is currently used as the minimum when acting as a
 	// client, and TLS 1.0 when acting as a server. TLS 1.0 is the minimum
 	// supported by this package, both as a client and as a server.  This
 	// default may be changed over time affecting backwards compatibility.
 	MinTLSVersion uint16
 	// MaxTLSVersion contains the maximum TLS version that is acceptable.
+	// The value should be set using tls.VersionTLSxx from https://pkg.go.dev/crypto/tls
 	// By default, the maximum version supported by this package is used,
 	// which is currently TLS 1.3.  This default may be changed over time
 	// affecting backwards compatibility.
@@ -282,12 +284,14 @@ type ServerOptions struct {
 	// Deprecated: use MaxTLSVersion instead.
 	MaxVersion uint16
 	// MinTLSVersion contains the minimum TLS version that is acceptable.
+	// The value should be set using tls.VersionTLSxx from https://pkg.go.dev/crypto/tls
 	// By default, TLS 1.2 is currently used as the minimum when acting as a
 	// client, and TLS 1.0 when acting as a server. TLS 1.0 is the minimum
 	// supported by this package, both as a client and as a server.  This
 	// default may be changed over time affecting backwards compatibility.
 	MinTLSVersion uint16
 	// MaxTLSVersion contains the maximum TLS version that is acceptable.
+	// The value should be set using tls.VersionTLSxx from https://pkg.go.dev/crypto/tls
 	// By default, the maximum version supported by this package is used,
 	// which is currently TLS 1.3.  This default may be changed over time
 	// affecting backwards compatibility.

--- a/security/advancedtls/advancedtls.go
+++ b/security/advancedtls/advancedtls.go
@@ -306,6 +306,15 @@ func (o *ClientOptions) config() (*tls.Config, error) {
 	if o.VType != CertAndHostVerification {
 		o.VerificationType = o.VType
 	}
+	// TODO(gtcooke94) MinVersion and MaxVersion are deprected, eventually
+	// remove this block. This is a temporary fallback to ensure that if the
+	// refactored names aren't set we use the old names.
+	if o.MinTLSVersion == 0 {
+		o.MinTLSVersion = o.MinVersion
+	}
+	if o.MaxTLSVersion == 0 {
+		o.MaxTLSVersion = o.MaxVersion
+	}
 	if o.VerificationType == SkipVerification && o.AdditionalPeerVerification == nil {
 		return nil, fmt.Errorf("client needs to provide custom verification mechanism if choose to skip default verification")
 	}
@@ -322,6 +331,14 @@ func (o *ClientOptions) config() (*tls.Config, error) {
 	}
 	if o.MinTLSVersion > o.MaxTLSVersion {
 		return nil, fmt.Errorf("the minimum TLS version is larger than the maximum TLS version")
+	}
+	// If the MinTLSVersion isn't set, default to 1.2
+	if o.MinTLSVersion == 0 {
+		o.MinTLSVersion = tls.VersionTLS12
+	}
+	// If the MaxTLSVersion isn't set, default to 1.3
+	if o.MaxTLSVersion == 0 {
+		o.MaxTLSVersion = tls.VersionTLS13
 	}
 	config := &tls.Config{
 		ServerName: o.serverNameOverride,

--- a/security/advancedtls/advancedtls.go
+++ b/security/advancedtls/advancedtls.go
@@ -410,6 +410,15 @@ func (o *ServerOptions) config() (*tls.Config, error) {
 	if o.VType != CertAndHostVerification {
 		o.VerificationType = o.VType
 	}
+	// TODO(gtcooke94) MinVersion and MaxVersion are deprected, eventually
+	// remove this block. This is a temporary fallback to ensure that if the
+	// refactored names aren't set we use the old names.
+	if o.MinTLSVersion == 0 {
+		o.MinTLSVersion = o.MinVersion
+	}
+	if o.MaxTLSVersion == 0 {
+		o.MaxTLSVersion = o.MaxVersion
+	}
 	if o.RequireClientCert && o.VerificationType == SkipVerification && o.AdditionalPeerVerification == nil {
 		return nil, fmt.Errorf("server needs to provide custom verification mechanism if choose to skip default verification, but require client certificate(s)")
 	}
@@ -433,6 +442,14 @@ func (o *ServerOptions) config() (*tls.Config, error) {
 		// TLS package to use the verification function we built from
 		// buildVerifyFunc.
 		clientAuth = tls.RequireAnyClientCert
+	}
+	// If the MinTLSVersion isn't set, default to 1.2
+	if o.MinTLSVersion == 0 {
+		o.MinTLSVersion = tls.VersionTLS12
+	}
+	// If the MaxTLSVersion isn't set, default to 1.3
+	if o.MaxTLSVersion == 0 {
+		o.MaxTLSVersion = tls.VersionTLS13
 	}
 	config := &tls.Config{
 		ClientAuth: clientAuth,

--- a/security/advancedtls/advancedtls.go
+++ b/security/advancedtls/advancedtls.go
@@ -216,14 +216,24 @@ type ClientOptions struct {
 	// It could be nil if such checks are not needed.
 	RevocationConfig *RevocationConfig
 	// MinVersion contains the minimum TLS version that is acceptable.
-	// By default, TLS 1.2 is currently used as the minimum when acting as a
-	// client, and TLS 1.0 when acting as a server. TLS 1.0 is the minimum
-	// supported by this package, both as a client and as a server.
+	//
+	// Deprecated: use MinTLSVersion instead.
 	MinVersion uint16
 	// MaxVersion contains the maximum TLS version that is acceptable.
-	// By default, the maximum version supported by this package is used,
-	// which is currently TLS 1.3.
+	//
+	// Deprecated: use MinTLSVersion instead.
 	MaxVersion uint16
+	// MinTLSVersion contains the minimum TLS version that is acceptable.
+	// By default, TLS 1.2 is currently used as the minimum when acting as a
+	// client, and TLS 1.0 when acting as a server. TLS 1.0 is the minimum
+	// supported by this package, both as a client and as a server.  This
+	// default may be changed over time affecting backwards compatibility.
+	MinTLSVersion uint16
+	// MaxTLSVersion contains the maximum TLS version that is acceptable.
+	// By default, the maximum version supported by this package is used,
+	// which is currently TLS 1.3.  This default may be changed over time
+	// affecting backwards compatibility.
+	MaxTLSVersion uint16
 	// serverNameOverride is for testing only. If set to a non-empty string, it
 	// will override the virtual host name of authority (e.g. :authority header
 	// field) in requests and the target hostname used during server cert
@@ -264,14 +274,24 @@ type ServerOptions struct {
 	// It could be nil if such checks are not needed.
 	RevocationConfig *RevocationConfig
 	// MinVersion contains the minimum TLS version that is acceptable.
-	// By default, TLS 1.2 is currently used as the minimum when acting as a
-	// client, and TLS 1.0 when acting as a server. TLS 1.0 is the minimum
-	// supported by this package, both as a client and as a server.
+	//
+	// Deprecated: use MinTLSVersion instead.
 	MinVersion uint16
 	// MaxVersion contains the maximum TLS version that is acceptable.
-	// By default, the maximum version supported by this package is used,
-	// which is currently TLS 1.3.
+	//
+	// Deprecated: use MinTLSVersion instead.
 	MaxVersion uint16
+	// MinTLSVersion contains the minimum TLS version that is acceptable.
+	// By default, TLS 1.2 is currently used as the minimum when acting as a
+	// client, and TLS 1.0 when acting as a server. TLS 1.0 is the minimum
+	// supported by this package, both as a client and as a server.  This
+	// default may be changed over time affecting backwards compatibility.
+	MinTLSVersion uint16
+	// MaxTLSVersion contains the maximum TLS version that is acceptable.
+	// By default, the maximum version supported by this package is used,
+	// which is currently TLS 1.3.  This default may be changed over time
+	// affecting backwards compatibility.
+	MaxTLSVersion uint16
 }
 
 func (o *ClientOptions) config() (*tls.Config, error) {
@@ -300,7 +320,7 @@ func (o *ClientOptions) config() (*tls.Config, error) {
 	if o.IdentityOptions.GetIdentityCertificatesForServer != nil {
 		return nil, fmt.Errorf("GetIdentityCertificatesForServer cannot be specified on the client side")
 	}
-	if o.MinVersion > o.MaxVersion {
+	if o.MinTLSVersion > o.MaxTLSVersion {
 		return nil, fmt.Errorf("the minimum TLS version is larger than the maximum TLS version")
 	}
 	config := &tls.Config{
@@ -308,8 +328,8 @@ func (o *ClientOptions) config() (*tls.Config, error) {
 		// We have to set InsecureSkipVerify to true to skip the default checks and
 		// use the verification function we built from buildVerifyFunc.
 		InsecureSkipVerify: true,
-		MinVersion:         o.MinVersion,
-		MaxVersion:         o.MaxVersion,
+		MinVersion:         o.MinTLSVersion,
+		MaxVersion:         o.MaxTLSVersion,
 	}
 	// Propagate root-certificate-related fields in tls.Config.
 	switch {
@@ -387,7 +407,7 @@ func (o *ServerOptions) config() (*tls.Config, error) {
 	if o.IdentityOptions.GetIdentityCertificatesForClient != nil {
 		return nil, fmt.Errorf("GetIdentityCertificatesForClient cannot be specified on the server side")
 	}
-	if o.MinVersion > o.MaxVersion {
+	if o.MinTLSVersion > o.MaxTLSVersion {
 		return nil, fmt.Errorf("the minimum TLS version is larger than the maximum TLS version")
 	}
 	clientAuth := tls.NoClientCert
@@ -399,8 +419,8 @@ func (o *ServerOptions) config() (*tls.Config, error) {
 	}
 	config := &tls.Config{
 		ClientAuth: clientAuth,
-		MinVersion: o.MinVersion,
-		MaxVersion: o.MaxVersion,
+		MinVersion: o.MinTLSVersion,
+		MaxVersion: o.MaxTLSVersion,
 	}
 	// Propagate root-certificate-related fields in tls.Config.
 	switch {

--- a/security/advancedtls/advancedtls_integration_test.go
+++ b/security/advancedtls/advancedtls_integration_test.go
@@ -908,8 +908,8 @@ func (s) TestTLSVersions(t *testing.T) {
 				},
 				RequireClientCert: false,
 				VerificationType:  CertAndHostVerification,
-				MinVersion:        test.serverMinVersion,
-				MaxVersion:        test.serverMaxVersion,
+				MinTLSVersion:     test.serverMinVersion,
+				MaxTLSVersion:     test.serverMaxVersion,
 			}
 			serverTLSCreds, err := NewServerCreds(serverOptions)
 			if err != nil {
@@ -930,8 +930,8 @@ func (s) TestTLSVersions(t *testing.T) {
 					RootCACerts: cs.ClientTrust1,
 				},
 				VerificationType: CertAndHostVerification,
-				MinVersion:       test.clientMinVersion,
-				MaxVersion:       test.clientMaxVersion,
+				MinTLSVersion:    test.clientMinVersion,
+				MaxTLSVersion:    test.clientMaxVersion,
 			}
 			clientTLSCreds, err := NewClientCreds(clientOptions)
 			if err != nil {

--- a/security/advancedtls/advancedtls_test.go
+++ b/security/advancedtls/advancedtls_test.go
@@ -211,6 +211,24 @@ func (s) TestClientOptionsConfigSuccessCases(t *testing.T) {
 					t.Fatalf("Failed to assign system-provided certificates on the client side.")
 				}
 			}
+			if test.MinVersion != 0 {
+				if clientConfig.MinVersion != test.MinVersion {
+					t.Fatalf("Failed to assign min tls version.")
+				}
+			} else {
+				if clientConfig.MinVersion != tls.VersionTLS12 {
+					t.Fatalf("Default min tls version not set correctly")
+				}
+			}
+			if test.MaxVersion != 0 {
+				if clientConfig.MaxVersion != test.MaxVersion {
+					t.Fatalf("Failed to assign max tls version.")
+				}
+			} else {
+				if clientConfig.MaxVersion != tls.VersionTLS13 {
+					t.Fatalf("Default max tls version not set correctly")
+				}
+			}
 		})
 	}
 }

--- a/security/advancedtls/advancedtls_test.go
+++ b/security/advancedtls/advancedtls_test.go
@@ -138,8 +138,8 @@ func (s) TestClientOptionsConfigErrorCases(t *testing.T) {
 				VerificationType: test.clientVerificationType,
 				IdentityOptions:  test.IdentityOptions,
 				RootOptions:      test.RootOptions,
-				MinVersion:       test.MinVersion,
-				MaxVersion:       test.MaxVersion,
+				MinTLSVersion:    test.MinVersion,
+				MaxTLSVersion:    test.MaxVersion,
 			}
 			_, err := clientOptions.config()
 			if err == nil {
@@ -196,8 +196,8 @@ func (s) TestClientOptionsConfigSuccessCases(t *testing.T) {
 				VerificationType: test.clientVerificationType,
 				IdentityOptions:  test.IdentityOptions,
 				RootOptions:      test.RootOptions,
-				MinVersion:       test.MinVersion,
-				MaxVersion:       test.MaxVersion,
+				MinTLSVersion:    test.MinVersion,
+				MaxTLSVersion:    test.MaxVersion,
 			}
 			clientConfig, err := clientOptions.config()
 			if err != nil {
@@ -275,8 +275,8 @@ func (s) TestServerOptionsConfigErrorCases(t *testing.T) {
 				RequireClientCert: test.requireClientCert,
 				IdentityOptions:   test.IdentityOptions,
 				RootOptions:       test.RootOptions,
-				MinVersion:        test.MinVersion,
-				MaxVersion:        test.MaxVersion,
+				MinTLSVersion:     test.MinVersion,
+				MaxTLSVersion:     test.MaxVersion,
 			}
 			_, err := serverOptions.config()
 			if err == nil {
@@ -342,8 +342,8 @@ func (s) TestServerOptionsConfigSuccessCases(t *testing.T) {
 				RequireClientCert: test.requireClientCert,
 				IdentityOptions:   test.IdentityOptions,
 				RootOptions:       test.RootOptions,
-				MinVersion:        test.MinVersion,
-				MaxVersion:        test.MaxVersion,
+				MinTLSVersion:     test.MinVersion,
+				MaxTLSVersion:     test.MaxVersion,
 			}
 			serverConfig, err := serverOptions.config()
 			if err != nil {


### PR DESCRIPTION
This PR renames the `MinVersion` and `MaxVersion` on `ClientOptions` and `ServerOptions` to `MinTLSVersion` and `MaxTLSVersion` to make it clear that this field represents the TLS version.

It also adds logic to set the default min and max to TLS12 and TLS13 respectively, and a tests for that logic.
Previously our code comments indicated this was the default, but we really just delegated to the defaults of the crypto/tls package (which are currently the same). Now we explicitly set to the defaults that we say we do, rather than depending on a dependency's defaults to match ours.

RELEASE NOTES: none