### PR TITLE
xds/internal: Replace calls to `Debugf` with `V(2)` checks and `Infof`

### DIFF
--- a/xds/internal/balancer/priority/balancer.go
+++ b/xds/internal/balancer/priority/balancer.go
@@ -115,7 +115,9 @@ type priorityBalancer struct {
 }
 
 func (b *priorityBalancer) UpdateClientConnState(s balancer.ClientConnState) error {
-	b.logger.Debugf("Received an update with balancer config: %+v", pretty.ToJSON(s.BalancerConfig))
+	if b.logger.V(2) {
+		b.logger.Infof("Received an update with balancer config: %+v", pretty.ToJSON(s.BalancerConfig))
+	}
 	newConfig, ok := s.BalancerConfig.(*LBConfig)
 	if !ok {
 		return fmt.Errorf("unexpected balancer config with type: %T", s.BalancerConfig)

--- a/xds/internal/xdsclient/authority.go
+++ b/xds/internal/xdsclient/authority.go
@@ -482,7 +482,9 @@ func (a *authority) watchResource(rType xdsresource.Type, resourceName string, w
 
 	// If we have a cached copy of the resource, notify the new watcher.
 	if state.cache != nil {
-		a.logger.Debugf("Resource type %q with resource name %q found in cache: %s", rType.TypeName(), resourceName, state.cache.ToJSON())
+		if a.logger.V(2) {
+			a.logger.Infof("Resource type %q with resource name %q found in cache: %s", rType.TypeName(), resourceName, state.cache.ToJSON())
+		}
 		resource := state.cache
 		a.serializer.Schedule(func(context.Context) { watcher.OnUpdate(resource) })
 	}

--- a/xds/internal/xdsclient/bootstrap/bootstrap.go
+++ b/xds/internal/xdsclient/bootstrap/bootstrap.go
@@ -568,6 +568,8 @@ func newConfigFromContents(data []byte) (*Config, error) {
 	node.ClientFeatures = append(node.ClientFeatures, clientFeatureNoOverprovisioning, clientFeatureResourceWrapper)
 	config.NodeProto = node
 
-	logger.Debugf("Bootstrap config for creating xds-client: %v", pretty.ToJSON(config))
+	if logger.V(2) {
+		logger.Infof("Bootstrap config for creating xds-client: %v", pretty.ToJSON(config))
+	}
 	return config, nil
 }


### PR DESCRIPTION
… to limit calls to `pretty.ToJSON`

RELEASE NOTES: None
