### PR TITLE
advancedtls: populate verified chains when using custom buildVerifyFunc

### DIFF
--- a/security/advancedtls/advancedtls.go
+++ b/security/advancedtls/advancedtls.go
@@ -35,7 +35,7 @@ import (
 	credinternal "google.golang.org/grpc/internal/credentials"
 )
 
-type CertChains [][]*x509.Certificate
+type CertificateChains [][]*x509.Certificate
 
 // HandshakeVerificationInfo contains information about a handshake needed for
 // verification for use when implementing the `PostHandshakeVerificationFunc`
@@ -49,7 +49,7 @@ type HandshakeVerificationInfo struct {
 	RawCerts [][]byte
 	// The verification chain obtained by checking peer RawCerts against the
 	// trust certificate bundle(s), if applicable.
-	VerifiedChains CertChains
+	VerifiedChains CertificateChains
 	// The leaf certificate sent from peer, if choosing to verify the peer
 	// certificate(s) and that verification passed. This field would be nil if
 	// either user chose not to verify or the verification failed.
@@ -486,7 +486,7 @@ func (c *advancedTLSCreds) ClientHandshake(ctx context.Context, authority string
 	if cfg.ServerName == "" {
 		cfg.ServerName = authority
 	}
-	peerVerifiedChains := CertChains{}
+	peerVerifiedChains := CertificateChains{}
 	cfg.VerifyPeerCertificate = buildVerifyFunc(c, cfg.ServerName, rawConn, &peerVerifiedChains)
 	conn := tls.Client(rawConn, cfg)
 	errChannel := make(chan error, 1)
@@ -517,7 +517,7 @@ func (c *advancedTLSCreds) ClientHandshake(ctx context.Context, authority string
 
 func (c *advancedTLSCreds) ServerHandshake(rawConn net.Conn) (net.Conn, credentials.AuthInfo, error) {
 	cfg := credinternal.CloneTLSConfig(c.config)
-	peerVerifiedChains := CertChains{}
+	peerVerifiedChains := CertificateChains{}
 	cfg.VerifyPeerCertificate = buildVerifyFunc(c, "", rawConn, &peerVerifiedChains)
 	conn := tls.Server(rawConn, cfg)
 	if err := conn.Handshake(); err != nil {
@@ -564,7 +564,7 @@ func (c *advancedTLSCreds) OverrideServerName(serverNameOverride string) error {
 func buildVerifyFunc(c *advancedTLSCreds,
 	serverName string,
 	rawConn net.Conn,
-	peerVerifiedChains *CertChains) func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
+	peerVerifiedChains *CertificateChains) func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
 	return func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
 		chains := verifiedChains
 		var leafCert *x509.Certificate
@@ -628,7 +628,7 @@ func buildVerifyFunc(c *advancedTLSCreds,
 		if c.revocationOptions != nil {
 			verifiedChains := chains
 			if verifiedChains == nil {
-				verifiedChains = CertChains{rawCertList}
+				verifiedChains = CertificateChains{rawCertList}
 			}
 			if err := checkChainRevocation(verifiedChains, *c.revocationOptions); err != nil {
 				return err

--- a/security/advancedtls/advancedtls.go
+++ b/security/advancedtls/advancedtls.go
@@ -618,7 +618,6 @@ func buildVerifyFunc(c *advancedTLSCreds,
 				return err
 			}
 			leafCert = rawCertList[0]
-			*peerVerifiedChains = chains
 		}
 		// Perform certificate revocation check if specified.
 		if c.revocationOptions != nil {
@@ -640,6 +639,7 @@ func buildVerifyFunc(c *advancedTLSCreds,
 			})
 			return err
 		}
+		*peerVerifiedChains = chains
 		return nil
 	}
 }

--- a/security/advancedtls/advancedtls.go
+++ b/security/advancedtls/advancedtls.go
@@ -509,6 +509,7 @@ func (c *advancedTLSCreds) ClientHandshake(ctx context.Context, authority string
 		},
 	}
 	info.SPIFFEID = credinternal.SPIFFEIDFromState(conn.ConnectionState())
+	// set the VerifiedChains
 	info.State.VerifiedChains = peerVerifiedChains
 	return credinternal.WrapSyscallConn(rawConn, conn), info, nil
 }
@@ -529,6 +530,7 @@ func (c *advancedTLSCreds) ServerHandshake(rawConn net.Conn) (net.Conn, credenti
 		},
 	}
 	info.SPIFFEID = credinternal.SPIFFEIDFromState(conn.ConnectionState())
+	// set the VerifiedChains
 	info.State.VerifiedChains = peerVerifiedChains
 	return credinternal.WrapSyscallConn(rawConn, conn), info, nil
 }

--- a/security/advancedtls/advancedtls.go
+++ b/security/advancedtls/advancedtls.go
@@ -556,6 +556,11 @@ func (c *advancedTLSCreds) OverrideServerName(serverNameOverride string) error {
 //  1. does not have a good support on root cert reloading.
 //  2. will ignore basic certificate check when setting InsecureSkipVerify
 //     to true.
+//
+// peerVerifiedChains(output param): verified chain of certs from leaf to the
+// trust cert that the peer trusts.
+//  1. For server it is, client certs + Root ca that the server trusts
+//  2. For client it is, server certs + Root ca that the client trusts
 func buildVerifyFunc(c *advancedTLSCreds,
 	serverName string,
 	rawConn net.Conn,
@@ -637,7 +642,9 @@ func buildVerifyFunc(c *advancedTLSCreds,
 				VerifiedChains: chains,
 				Leaf:           leafCert,
 			})
-			return err
+			if err != nil {
+				return err
+			}
 		}
 		*peerVerifiedChains = chains
 		return nil

--- a/security/advancedtls/advancedtls.go
+++ b/security/advancedtls/advancedtls.go
@@ -509,7 +509,6 @@ func (c *advancedTLSCreds) ClientHandshake(ctx context.Context, authority string
 		},
 	}
 	info.SPIFFEID = credinternal.SPIFFEIDFromState(conn.ConnectionState())
-	// set the VerifiedChains
 	info.State.VerifiedChains = peerVerifiedChains
 	return credinternal.WrapSyscallConn(rawConn, conn), info, nil
 }
@@ -530,7 +529,6 @@ func (c *advancedTLSCreds) ServerHandshake(rawConn net.Conn) (net.Conn, credenti
 		},
 	}
 	info.SPIFFEID = credinternal.SPIFFEIDFromState(conn.ConnectionState())
-	// set the VerifiedChains
 	info.State.VerifiedChains = peerVerifiedChains
 	return credinternal.WrapSyscallConn(rawConn, conn), info, nil
 }

--- a/security/advancedtls/advancedtls_test.go
+++ b/security/advancedtls/advancedtls_test.go
@@ -909,7 +909,7 @@ func (s) TestClientServerHandshake(t *testing.T) {
 					cert, _ := test.clientGetCert(&tls.CertificateRequestInfo{})
 					clientCert = cert
 				} else if test.clientIdentityProvider != nil {
-					km, _ := test.clientIdentityProvider.KeyMaterial(nil)
+					km, _ := test.clientIdentityProvider.KeyMaterial(context.TODO())
 					clientCert = &km.Certs[0]
 				}
 				if !bytes.Equal((*serverVerifiedChains[0][0]).Raw, clientCert.Certificate[0]) {
@@ -923,7 +923,7 @@ func (s) TestClientServerHandshake(t *testing.T) {
 					result, _ := test.serverGetRoot(&GetRootCAsParams{})
 					serverRoot = result.TrustCerts
 				} else if test.serverRootProvider != nil {
-					km, _ := test.serverRootProvider.KeyMaterial(nil)
+					km, _ := test.serverRootProvider.KeyMaterial(context.TODO())
 					serverRoot = km.Roots
 				}
 				serverVerifiedChainsCp := x509.NewCertPool()
@@ -944,7 +944,7 @@ func (s) TestClientServerHandshake(t *testing.T) {
 					cert, _ := test.serverGetCert(&tls.ClientHelloInfo{})
 					serverCert = cert[0]
 				} else if test.serverIdentityProvider != nil {
-					km, _ := test.serverIdentityProvider.KeyMaterial(nil)
+					km, _ := test.serverIdentityProvider.KeyMaterial(context.TODO())
 					serverCert = &km.Certs[0]
 				}
 				if !bytes.Equal((*clientVerifiedChains[0][0]).Raw, serverCert.Certificate[0]) {
@@ -958,7 +958,7 @@ func (s) TestClientServerHandshake(t *testing.T) {
 					result, _ := test.clientGetRoot(&GetRootCAsParams{})
 					clientRoot = result.TrustCerts
 				} else if test.clientRootProvider != nil {
-					km, _ := test.clientRootProvider.KeyMaterial(nil)
+					km, _ := test.clientRootProvider.KeyMaterial(context.TODO())
 					clientRoot = km.Roots
 				}
 				clientVerifiedChainsCp := x509.NewCertPool()

--- a/security/advancedtls/advancedtls_test.go
+++ b/security/advancedtls/advancedtls_test.go
@@ -19,6 +19,7 @@
 package advancedtls
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
 	"crypto/x509"
@@ -895,6 +896,76 @@ func (s) TestClientServerHandshake(t *testing.T) {
 			if !compare(clientAuthInfo, serverAuthInfo) {
 				t.Fatalf("c.ClientHandshake(_, %v, _) = %v, want %v.", lisAddr,
 					clientAuthInfo, serverAuthInfo)
+			}
+			serverVerifiedChains := serverAuthInfo.(credentials.TLSInfo).State.VerifiedChains
+			if test.serverMutualTLS && !test.serverExpectError {
+				if len(serverVerifiedChains) == 0 {
+					t.Fatalf("server verified chains is empty")
+				}
+				var clientCert *tls.Certificate
+				if len(test.clientCert) > 0 {
+					clientCert = &test.clientCert[0]
+				} else if test.clientGetCert != nil {
+					cert, _ := test.clientGetCert(&tls.CertificateRequestInfo{})
+					clientCert = cert
+				} else if test.clientIdentityProvider != nil {
+					km, _ := test.clientIdentityProvider.KeyMaterial(nil)
+					clientCert = &km.Certs[0]
+				}
+				if !bytes.Equal((*serverVerifiedChains[0][0]).Raw, clientCert.Certificate[0]) {
+					t.Fatal("server verifiedChains leaf cert doesn't match client cert")
+				}
+
+				var serverRoot *x509.CertPool
+				if test.serverRoot != nil {
+					serverRoot = test.serverRoot
+				} else if test.serverGetRoot != nil {
+					result, _ := test.serverGetRoot(&GetRootCAsParams{})
+					serverRoot = result.TrustCerts
+				} else if test.serverRootProvider != nil {
+					km, _ := test.serverRootProvider.KeyMaterial(nil)
+					serverRoot = km.Roots
+				}
+				serverVerifiedChainsCp := x509.NewCertPool()
+				serverVerifiedChainsCp.AddCert(serverVerifiedChains[0][len(serverVerifiedChains[0])-1])
+				if !serverVerifiedChainsCp.Equal(serverRoot) {
+					t.Fatalf("server verified chain hierarchy doesn't match")
+				}
+			}
+			clientVerifiedChains := clientAuthInfo.(credentials.TLSInfo).State.VerifiedChains
+			if test.serverMutualTLS && !test.clientExpectHandshakeError {
+				if len(clientVerifiedChains) == 0 {
+					t.Fatalf("client verified chains is empty")
+				}
+				var serverCert *tls.Certificate
+				if len(test.serverCert) > 0 {
+					serverCert = &test.serverCert[0]
+				} else if test.serverGetCert != nil {
+					cert, _ := test.serverGetCert(&tls.ClientHelloInfo{})
+					serverCert = cert[0]
+				} else if test.serverIdentityProvider != nil {
+					km, _ := test.serverIdentityProvider.KeyMaterial(nil)
+					serverCert = &km.Certs[0]
+				}
+				if !bytes.Equal((*clientVerifiedChains[0][0]).Raw, serverCert.Certificate[0]) {
+					t.Fatal("client verifiedChains leaf cert doesn't match server cert")
+				}
+
+				var clientRoot *x509.CertPool
+				if test.clientRoot != nil {
+					clientRoot = test.clientRoot
+				} else if test.clientGetRoot != nil {
+					result, _ := test.clientGetRoot(&GetRootCAsParams{})
+					clientRoot = result.TrustCerts
+				} else if test.clientRootProvider != nil {
+					km, _ := test.clientRootProvider.KeyMaterial(nil)
+					clientRoot = km.Roots
+				}
+				clientVerifiedChainsCp := x509.NewCertPool()
+				clientVerifiedChainsCp.AddCert(clientVerifiedChains[0][len(clientVerifiedChains[0])-1])
+				if !clientVerifiedChainsCp.Equal(clientRoot) {
+					t.Fatalf("client verified chain hierarchy doesn't match")
+				}
 			}
 		})
 	}


### PR DESCRIPTION
This request is to address the issue opened https://github.com/grpc/grpc-go/issues/7176

Basically this patch will set the verifiedChains correctly when advancedtls package is used with buildVerifyFunc() and applications need to access TLSInfo.State.VerifiedChains in their logic.

RELEASE NOTES: none