### PR TITLE
credentials/tls: reject connections with ALPN disabled

### DIFF
--- a/credentials/tls.go
+++ b/credentials/tls.go
@@ -151,8 +151,20 @@ func (c *tlsCreds) ServerHandshake(rawConn net.Conn) (net.Conn, AuthInfo, error)
 		conn.Close()
 		return nil, nil, err
 	}
+	cs := conn.ConnectionState()
+    // The negotiated application protocol can be empty only if the client doesn't 
+    // support ALPN. In such cases, we can close the connection since ALPN is required
+    // for using HTTP/2 over TLS.
+	if cs.NegotiatedProtocol == "" {
+		if envconfig.EnforceALPNEnabled {
+			conn.Close()
+			return nil, nil, fmt.Errorf("credentials: cannot check peer: missing selected ALPN property")
+		} else if logger.V(2) {
+			logger.Info("Allowing TLS connection from client with ALPN disabled. TLS connections with ALPN disabled will be disallowed in future grpc-go releases")
+		}
+	}
 	tlsInfo := TLSInfo{
-		State: conn.ConnectionState(),
+		State: cs,
 		CommonAuthInfo: CommonAuthInfo{
 			SecurityLevel: PrivacyAndIntegrity,
 		},

--- a/credentials/tls.go
+++ b/credentials/tls.go
@@ -152,9 +152,9 @@ func (c *tlsCreds) ServerHandshake(rawConn net.Conn) (net.Conn, AuthInfo, error)
 		return nil, nil, err
 	}
 	cs := conn.ConnectionState()
-    // The negotiated application protocol can be empty only if the client doesn't 
-    // support ALPN. In such cases, we can close the connection since ALPN is required
-    // for using HTTP/2 over TLS.
+	// The negotiated application protocol can be empty only if the client doesn't
+	// support ALPN. In such cases, we can close the connection since ALPN is required
+	// for using HTTP/2 over TLS.
 	if cs.NegotiatedProtocol == "" {
 		if envconfig.EnforceALPNEnabled {
 			conn.Close()

--- a/credentials/tls.go
+++ b/credentials/tls.go
@@ -27,8 +27,12 @@ import (
 	"net/url"
 	"os"
 
+	"google.golang.org/grpc/grpclog"
 	credinternal "google.golang.org/grpc/internal/credentials"
+	"google.golang.org/grpc/internal/envconfig"
 )
+
+var logger = grpclog.Component("credentials")
 
 // TLSInfo contains the auth information for a TLS authenticated connection.
 // It implements the AuthInfo interface.
@@ -113,17 +117,20 @@ func (c *tlsCreds) ClientHandshake(ctx context.Context, authority string, rawCon
 		return nil, nil, ctx.Err()
 	}
 
-    // The negotiated protocol can be either of the following:
-    // 1. h2: When the server supports ALPN. Only HTTP/2 can be negotiated since
-    //    it is the only protocol advertised by the client during the handshake.
-    //    The tls library ensures that the server chooses a protocol advertised
-    //    by the client.
-    // 2. "" (empty string): If the server doesn't support ALPN. ALPN is a requirement
-    //    for using HTTP/2 over TLS. We can terminate the connection immediately.
-    np := conn.ConnectionState().NegotiatedProtocol
-    if np == "" {
-		_ = conn.Close()
-		return nil, nil, fmt.Errorf("cannot check peer: missing selected ALPN property")
+	// The negotiated protocol can be either of the following:
+	// 1. h2: When the server supports ALPN. Only HTTP/2 can be negotiated since
+	//    it is the only protocol advertised by the client during the handshake.
+	//    The tls library ensures that the server chooses a protocol advertised
+	//    by the client.
+	// 2. "" (empty string): If the server doesn't support ALPN. ALPN is a requirement
+	//    for using HTTP/2 over TLS. We can terminate the connection immediately.
+	np := conn.ConnectionState().NegotiatedProtocol
+	if np == "" {
+		if envconfig.EnforceALPNEnabled {
+			_ = conn.Close()
+			return nil, nil, fmt.Errorf("cannot check peer: missing selected ALPN property")
+		}
+		logger.Warning("Allowing TLS connection to server %q with ALPN disabled")
 	}
 	tlsInfo := TLSInfo{
 		State: conn.ConnectionState(),

--- a/credentials/tls.go
+++ b/credentials/tls.go
@@ -112,6 +112,19 @@ func (c *tlsCreds) ClientHandshake(ctx context.Context, authority string, rawCon
 		conn.Close()
 		return nil, nil, ctx.Err()
 	}
+
+    // The negotiated protocol can be either of the following:
+    // 1. h2: When the server supports ALPN. Only HTTP/2 can be negotiated since
+    //    it is the only protocol advertised by the client during the handshake.
+    //    The tls library ensures that the server chooses a protocol advertised
+    //    by the client.
+    // 2. "" (empty string): If the server doesn't support ALPN. ALPN is a requirement
+    //    for using HTTP/2 over TLS. We can terminate the connection immediately.
+    np := conn.ConnectionState().NegotiatedProtocol
+    if np == "" {
+		_ = conn.Close()
+		return nil, nil, fmt.Errorf("cannot check peer: missing selected ALPN property")
+	}
 	tlsInfo := TLSInfo{
 		State: conn.ConnectionState(),
 		CommonAuthInfo: CommonAuthInfo{

--- a/credentials/tls.go
+++ b/credentials/tls.go
@@ -127,10 +127,10 @@ func (c *tlsCreds) ClientHandshake(ctx context.Context, authority string, rawCon
 	np := conn.ConnectionState().NegotiatedProtocol
 	if np == "" {
 		if envconfig.EnforceALPNEnabled {
-			_ = conn.Close()
-			return nil, nil, fmt.Errorf("cannot check peer: missing selected ALPN property")
+			conn.Close()
+			return nil, nil, fmt.Errorf("credentials: cannot check peer: missing selected ALPN property")
 		}
-		logger.Warning("Allowing TLS connection to server %q with ALPN disabled")
+		logger.Warningf("Allowing TLS connection to server %q with ALPN disabled. TLS connections to servers with ALPN disabled will be disallowed in future grpc-go releases", cfg.ServerName)
 	}
 	tlsInfo := TLSInfo{
 		State: conn.ConnectionState(),

--- a/credentials/tls_ext_test.go
+++ b/credentials/tls_ext_test.go
@@ -385,11 +385,8 @@ func (s) TestTLS_DisabledALPNServer(t *testing.T) {
 			}
 			defer conn.Close()
 
-			select {
-			case err := <-errCh:
-				if err != nil {
-					t.Fatalf("Unexpected server error: %v", err)
-				}
+			if err := <-errCh; err != nil {
+				t.Fatalf("Unexpected server error: %v", err)
 			}
 		})
 	}

--- a/credentials/tls_ext_test.go
+++ b/credentials/tls_ext_test.go
@@ -352,12 +352,11 @@ func (s) TestTLS_DisabledALPNServer(t *testing.T) {
 				t.Fatalf("Error starting server: %v", err)
 			}
 
-			errCh := make(chan error)
+			errCh := make(chan error, 1)
 			go func() {
 				conn, err := listener.Accept()
 				if err != nil {
 					errCh <- fmt.Errorf("listener.Accept returned error: %v", err)
-					close(errCh)
 					return
 				}
 				defer conn.Close()

--- a/credentials/tls_ext_test.go
+++ b/credentials/tls_ext_test.go
@@ -262,29 +262,29 @@ func (s) TestTLS_DisabledALPN(t *testing.T) {
 	defer listner.Close()
 
 	tests := []struct {
-		description            string
+		name                   string
 		alpnEnforced           bool
 		wantErrMatchPattern    string
 		wantErrNonMatchPattern string
 	}{
 		{
-			description:         "enforced",
+			name:                "enforced",
 			alpnEnforced:        true,
 			wantErrMatchPattern: "transport: .*missing selected ALPN property",
 		},
 		{
-			description:            "not_enforced",
+			name:                   "not_enforced",
 			wantErrNonMatchPattern: "transport:",
 		},
 		{
-			description:            "default_value",
+			name:                   "default_value",
 			wantErrNonMatchPattern: "transport:",
 			alpnEnforced:           initialVal,
 		},
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.description, func(t *testing.T) {
+		t.Run(tc.name, func(t *testing.T) {
 			envconfig.EnforceALPNEnabled = tc.alpnEnforced
 			// Listen to one TCP connection request.
 			go func() {

--- a/credentials/tls_ext_test.go
+++ b/credentials/tls_ext_test.go
@@ -242,14 +242,12 @@ func (s) TestTLS_CipherSuitesOverridable(t *testing.T) {
 // TestTLS_DisabledALPN tests the behaviour of a gRPC client when connecting to
 // a server that doesn't support ALPN.
 func (s) TestTLS_DisabledALPN(t *testing.T) {
-
 	initialVal := envconfig.EnforceALPNEnabled
 	defer func() {
 		envconfig.EnforceALPNEnabled = initialVal
 	}()
 
-	// Start a non gRPC TLS server.
-	config := &tls.Config{
+	serverCfg := &tls.Config{
 		Certificates: []tls.Certificate{serverCert},
 		NextProtos:   []string{}, // Empty list indicates ALPN is disabled.
 	}
@@ -271,11 +269,12 @@ func (s) TestTLS_DisabledALPN(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			listner, err := tls.Listen("tcp", "localhost:0", config)
+			envconfig.EnforceALPNEnabled = tc.alpnEnforced
+
+			listner, err := tls.Listen("tcp", "localhost:0", serverCfg)
 			if err != nil {
 				t.Fatalf("Error starting TLS server: %v", err)
 			}
-			envconfig.EnforceALPNEnabled = tc.alpnEnforced
 
 			go func() {
 				conn, err := listner.Accept()

--- a/credentials/tls_ext_test.go
+++ b/credentials/tls_ext_test.go
@@ -385,8 +385,13 @@ func (s) TestTLS_DisabledALPNServer(t *testing.T) {
 			}
 			defer conn.Close()
 
-			if err := <-errCh; err != nil {
-				t.Fatalf("Unexpected server error: %v", err)
+			select {
+			case <-time.After(defaultTestTimeout):
+				t.Fatal("Timed out waiting for completion")
+			case err := <-errCh:
+				if err != nil {
+					t.Fatalf("Unexpected server error: %v", err)
+				}
 			}
 		})
 	}

--- a/internal/envconfig/envconfig.go
+++ b/internal/envconfig/envconfig.go
@@ -43,6 +43,12 @@ var (
 	// ALTSMaxConcurrentHandshakes is the maximum number of concurrent ALTS
 	// handshakes that can be performed.
 	ALTSMaxConcurrentHandshakes = uint64FromEnv("GRPC_ALTS_MAX_CONCURRENT_HANDSHAKES", 100, 1, 100)
+	// EnforceALPNEnabled is set if TLS connections to servers with ALPN disabled
+	// should be rejected. The HTTP/2 protocol requires ALPN to be enabled, this
+	// option is present for backward compatibility. This option may be overridden
+	// by setting the environment variable "GRPC_ENFORCE_ALPN_ENABLED" to "true"
+	// or "false".
+	EnforceALPNEnabled = boolFromEnv("GRPC_ENFORCE_ALPN_ENABLED", false)
 )
 
 func boolFromEnv(envVar string, def bool) bool {


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc-go/issues/434

Since HTTP/2 mandates the use of ALPN during the TLS handshake to establish connections, gRPC clients will reject connections to servers that don't have ALPN enabled. gRPC servers will also reject TLS connections from clients with ALPN disabled.
As this change can break existing clients, this behaviour is guarded by an environment variable flag. The error message returned is similar to the [message returned by the C++ implementation](https://github.com/grpc/grpc/blob/master/src/core/lib/security/security_connector/ssl_utils.cc#L138).

RELEASE NOTES: 
- credentials/tls: clients and servers will reject connections that don't support ALPN when environment variable "GRPC_ENFORCE_ALPN_ENABLED" is set to "true" (case insensitive).  This behavior will become the default in a future release.