### PR TITLE
channelz: fix missing Target on SubChannel type

### DIFF
--- a/clientconn.go
+++ b/clientconn.go
@@ -842,6 +842,9 @@ func (cc *ClientConn) newAddrConnLocked(addrs []resolver.Address, opts balancer.
 		stateChan:    make(chan struct{}),
 	}
 	ac.ctx, ac.cancel = context.WithCancel(cc.ctx)
+	// Start with our address set to the first address; this may be updated if
+	// we connect to different addresses.
+	ac.channelz.ChannelMetrics.Target.Store(&addrs[0].Addr)
 
 	channelz.AddTraceEvent(logger, ac.channelz, 0, &channelz.TraceEvent{
 		Desc:     "Subchannel created",
@@ -1304,6 +1307,7 @@ func (ac *addrConn) resetTransport() {
 func (ac *addrConn) tryAllAddrs(ctx context.Context, addrs []resolver.Address, connectDeadline time.Time) error {
 	var firstConnErr error
 	for _, addr := range addrs {
+		ac.channelz.ChannelMetrics.Target.Store(&addr.Addr)
 		if ctx.Err() != nil {
 			return errConnClosing
 		}

--- a/test/channelz_test.go
+++ b/test/channelz_test.go
@@ -158,6 +158,10 @@ func (s) TestCZGetSubChannel(t *testing.T) {
 		if sc == nil {
 			return false, fmt.Errorf("subchannel with id %v is nil", scid)
 		}
+		target := sc.ChannelMetrics.Target.Load()
+		if target == nil || !strings.HasPrefix(*target, "localhost") {
+			t.Fatalf("subchannel target must never be set incorrectly; got: %v, want <HasPrefix('localhost')>", target)
+		}
 		state := sc.ChannelMetrics.State.Load()
 		if state == nil || *state != connectivity.Ready {
 			return false, fmt.Errorf("Got subchannel state=%v; want %q", state, connectivity.Ready)


### PR DESCRIPTION
Fixes #7187 

RELEASE NOTES:
- channelz: fix bug that was causing the subchannel's target to be unset