### PR TITLE
codec: remove option to suppress setting supported compressors in headers

### DIFF
--- a/internal/envconfig/envconfig.go
+++ b/internal/envconfig/envconfig.go
@@ -28,9 +28,6 @@ import (
 var (
 	// TXTErrIgnore is set if TXT errors should be ignored ("GRPC_GO_IGNORE_TXT_ERRORS" is not "false").
 	TXTErrIgnore = boolFromEnv("GRPC_GO_IGNORE_TXT_ERRORS", true)
-	// AdvertiseCompressors is set if registered compressor should be advertised
-	// ("GRPC_GO_ADVERTISE_COMPRESSORS" is not "false").
-	AdvertiseCompressors = boolFromEnv("GRPC_GO_ADVERTISE_COMPRESSORS", true)
 	// RingHashCap indicates the maximum ring size which defaults to 4096
 	// entries but may be overridden by setting the environment variable
 	// "GRPC_RING_HASH_CAP".  This does not override the default bounds

--- a/internal/grpcutil/compressor.go
+++ b/internal/grpcutil/compressor.go
@@ -20,8 +20,6 @@ package grpcutil
 
 import (
 	"strings"
-
-	"google.golang.org/grpc/internal/envconfig"
 )
 
 // RegisteredCompressorNames holds names of the registered compressors.
@@ -40,8 +38,5 @@ func IsCompressorNameRegistered(name string) bool {
 // RegisteredCompressors returns a string of registered compressor names
 // separated by comma.
 func RegisteredCompressors() string {
-	if !envconfig.AdvertiseCompressors {
-		return ""
-	}
 	return strings.Join(RegisteredCompressorNames, ",")
 }


### PR DESCRIPTION
RELEASE NOTES:
- codec: remove handling of environment variable `GRPC_GO_ADVERTISE_COMPRESSORS` to suppress setting supported compressors in `grpc-accept-encoding` header.  Compressors will always be advertised, as they have been by default for some time.