### PR TITLE
peer: remove change detector test

### DIFF
--- a/peer/peer_test.go
+++ b/peer/peer_test.go
@@ -93,11 +93,3 @@ func TestPeerStringer(t *testing.T) {
 		})
 	}
 }
-
-func TestPeerStringerOnContext(t *testing.T) {
-	ctx := NewContext(context.Background(), &Peer{Addr: &addr{"1.2.3.4:1234"}, AuthInfo: testAuthInfo{credentials.CommonAuthInfo{SecurityLevel: credentials.PrivacyAndIntegrity}}})
-	want := "context.Background.WithValue(type peer.peerKey, val Peer{Addr: '1.2.3.4:1234', LocalAddr: <nil>, AuthInfo: 'testAuthInfo-3'})"
-	if got := fmt.Sprintf("%v", ctx); got != want {
-		t.Fatalf("Unexpected stringer output, got: %q; want: %q", got, want)
-	}
-}


### PR DESCRIPTION
This change detector test seems asserts for an exact match and relies on the go std library print statements which can be subjected to change. 

RELEASE NOTES: none