### PR TITLE
client: add user-friendly error message of LB policy update timed out

### DIFF
--- a/picker_wrapper.go
+++ b/picker_wrapper.go
@@ -20,6 +20,7 @@ package grpc
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"sync"
 
@@ -117,7 +118,7 @@ func (pw *pickerWrapper) pick(ctx context.Context, failfast bool, info balancer.
 				if lastPickErr != nil {
 					errStr = "latest balancer error: " + lastPickErr.Error()
 				} else {
-					errStr = ctx.Err().Error()
+					errStr = fmt.Sprintf("received context error while waiting for new LB policy update: %s", ctx.Err().Error())
 				}
 				switch ctx.Err() {
 				case context.DeadlineExceeded:
@@ -151,7 +152,6 @@ func (pw *pickerWrapper) pick(ctx context.Context, failfast bool, info balancer.
 		pickResult, err := p.Pick(info)
 		if err != nil {
 			if err == balancer.ErrNoSubConnAvailable {
-				lastPickErr = err
 				continue
 			}
 			if st, ok := status.FromError(err); ok {

--- a/picker_wrapper.go
+++ b/picker_wrapper.go
@@ -151,6 +151,7 @@ func (pw *pickerWrapper) pick(ctx context.Context, failfast bool, info balancer.
 		pickResult, err := p.Pick(info)
 		if err != nil {
 			if err == balancer.ErrNoSubConnAvailable {
+				lastPickErr = err
 				continue
 			}
 			if st, ok := status.FromError(err); ok {

--- a/picker_wrapper_test.go
+++ b/picker_wrapper_test.go
@@ -26,7 +26,6 @@ import (
 	"time"
 
 	"google.golang.org/grpc/balancer"
-	"google.golang.org/grpc/balancer/base"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/internal/transport"
@@ -72,23 +71,6 @@ func (s) TestBlockingPickTimeout(t *testing.T) {
 	defer cancel()
 	if _, _, err := bp.pick(ctx, true, balancer.PickInfo{}); status.Code(err) != codes.DeadlineExceeded {
 		t.Errorf("bp.pick returned error %v, want DeadlineExceeded", err)
-	}
-}
-
-func (s) TestBlockingPickErrNoSubConnAvailableTimeout(t *testing.T) {
-	bp := newPickerWrapper(nil)
-	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
-	defer cancel()
-
-	bp.updatePicker(base.NewErrPicker(balancer.ErrNoSubConnAvailable))
-	var err error
-	if _, _, err = bp.pick(ctx, true, balancer.PickInfo{}); status.Code(err) != codes.DeadlineExceeded {
-		t.Errorf("bp.pick returned error %v, want DeadlineExceeded", err)
-	}
-
-	serr, _ := status.FromError(err)
-	if serr.Message() != "latest balancer error: "+balancer.ErrNoSubConnAvailable.Error() {
-		t.Errorf("bp.pick returned error %v, want balancer.ErrNoSubConnAvailable", err)
 	}
 }
 

--- a/picker_wrapper_test.go
+++ b/picker_wrapper_test.go
@@ -70,8 +70,7 @@ func (s) TestBlockingPickTimeout(t *testing.T) {
 	bp := newPickerWrapper(nil)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
 	defer cancel()
-	var err error
-	if _, _, err = bp.pick(ctx, true, balancer.PickInfo{}); status.Code(err) != codes.DeadlineExceeded {
+	if _, _, err := bp.pick(ctx, true, balancer.PickInfo{}); status.Code(err) != codes.DeadlineExceeded {
 		t.Errorf("bp.pick returned error %v, want DeadlineExceeded", err)
 	}
 }


### PR DESCRIPTION
Fixes #7135

add user-friendly error message of LB policy update timed out.

refer to PR https://github.com/grpc/grpc-go/pull/7143