### PR TITLE
resolver/dns: Add docstring to SetMinResolutionInterval

### DIFF
--- a/resolver/dns/dns_resolver.go
+++ b/resolver/dns/dns_resolver.go
@@ -18,9 +18,6 @@
 
 // Package dns implements a dns resolver to be installed as the default resolver
 // in grpc.
-//
-// Deprecated: this package is imported by grpc and should not need to be
-// imported directly by users.
 package dns
 
 import (
@@ -53,8 +50,11 @@ func NewBuilder() resolver.Builder {
 	return dns.NewBuilder()
 }
 
-// SetMinResolutionInterval sets the default minimum interval at which DNS re-resolutions are
-// allowed. This helps to prevent excessive re-resolution.
+// SetMinResolutionInterval sets the default minimum interval at which DNS
+// re-resolutions are allowed. This helps to prevent excessive re-resolution.
+//
+// It must be called only at application startup, before any gRPC calls are
+// made. Modifying this value after initialization is not thread-safe.
 func SetMinResolutionInterval(d time.Duration) {
 	dns.MinResolutionInterval = d
 }


### PR DESCRIPTION
SetMinResolutionInterval was added as part of https://github.com/grpc/grpc-go/pull/6962. We need talk about calling the method only during init time, since modifying this value afterwards is not thread-safe. 

Also marking resolver/dns package as not deprecated. The reason for marking this deprecated is to limit the usage to gRPC and discourage users from using this.

RELEASE NOTES: none