### PR TITLE
test: fix flaky test ClientSendsAGoAway

### DIFF
--- a/test/goaway_test.go
+++ b/test/goaway_test.go
@@ -800,6 +800,7 @@ func (s) TestClientSendsAGoAway(t *testing.T) {
 		for {
 			f, err := ct.fr.ReadFrame()
 			if err != nil {
+				t.Logf("error reading frame: %v", err)
 				return
 			}
 			switch fr := f.(type) {
@@ -808,6 +809,7 @@ func (s) TestClientSendsAGoAway(t *testing.T) {
 				if fr.ErrCode == http2.ErrCodeNo {
 					t.Logf("GoAway received from client")
 					close(goAwayReceived)
+					return
 				}
 			default:
 				t.Errorf("server tester received unexpected frame type %T", f)
@@ -816,6 +818,7 @@ func (s) TestClientSendsAGoAway(t *testing.T) {
 			}
 		}
 	}()
+	cc.WaitForStateChange(ctx, connectivity.Connecting)
 	cc.Close()
 	defer ct.conn.Close()
 	select {

--- a/test/goaway_test.go
+++ b/test/goaway_test.go
@@ -800,7 +800,7 @@ func (s) TestClientSendsAGoAway(t *testing.T) {
 		for {
 			f, err := ct.fr.ReadFrame()
 			if err != nil {
-				t.Logf("error reading frame: %v", err)
+				errCh <- fmt.Errorf("error reading frame: %v", err)
 				return
 			}
 			switch fr := f.(type) {


### PR DESCRIPTION
Fixes #7160 
fix: `goaway_test/TestClientSendsAGoAway` didn't use to wait for channels to be ready and which is why sometimes it was not able to read the frame and eventually result in test failure. This PR change make sure we read the frame only when the channel's state becomes READY.

RELEASE NOTES: n/a