### PR TITLE
fix panic, when service Handler returns (nil, nil)

### DIFF
--- a/rpc_util.go
+++ b/rpc_util.go
@@ -26,6 +26,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"reflect"
 	"strings"
 	"sync"
 	"time"
@@ -641,7 +642,8 @@ func (p *parser) recvMsg(maxReceiveMessageSize int) (pf payloadFormat, msg []byt
 // error if it is too large to be transmitted by grpc.  If msg is nil, it
 // generates an empty message.
 func encode(c baseCodec, msg any) ([]byte, error) {
-	if msg == nil { // NOTE: typed nils will not be caught by this check
+	if msg == nil ||
+		reflect.ValueOf(msg).IsNil() { // in gRPC, msg must be a ptr(or nil ptr)
 		return nil, nil
 	}
 	b, err := c.Marshal(msg)

--- a/rpc_util_test.go
+++ b/rpc_util_test.go
@@ -192,7 +192,9 @@ func (s) TestToRPCErr(t *testing.T) {
 }
 
 func (s) TestNilReply(t *testing.T) {
-	type XxxReply struct{}
+	type XxxReply struct {
+		proto.Message
+	}
 
 	handler := func() (any, error) {
 		return func() (*XxxReply, error) {

--- a/rpc_util_test.go
+++ b/rpc_util_test.go
@@ -191,6 +191,22 @@ func (s) TestToRPCErr(t *testing.T) {
 	}
 }
 
+func (s) TestNilReply(t *testing.T) {
+	type XxxReply struct{}
+
+	handler := func() (any, error) {
+		return func() (*XxxReply, error) {
+			return nil, nil
+		}()
+	}
+
+	reply, _ := handler()
+	raw, err := encode(encoding.GetCodec(protoenc.Name), reply)
+	if err != nil || raw != nil {
+		t.Fatal(err)
+	}
+}
+
 // bmEncode benchmarks encoding a Protocol Buffer message containing mSize
 // bytes.
 func bmEncode(b *testing.B, mSize int) {


### PR DESCRIPTION
Fix panic, when service Handler returns (nil, nil)

Why wasn't this done before? Is it because it introduced reflection?