### PR TITLE
grpc: Add perTargetDialOption type and global list

### DIFF
--- a/clientconn.go
+++ b/clientconn.go
@@ -153,22 +153,13 @@ func NewClient(target string, opts ...DialOption) (conn *ClientConn, err error) 
 		opt.apply(&cc.dopts)
 	}
 
-	// Register ClientConn with channelz.
-	cc.channelzRegistration(target)
-	// TODO: Ideally it should be impossible to error from this function after
-	// channelz registration.  This will require removing some channelz logs
-	// from the following functions that can error.  Errors can be returned to
-	// the user, and successful logs can be emitted here, after the checks have
-	// passed and channelz is subsequently registered.
-
 	// Determine the resolver to use.
 	if err := cc.parseTargetAndFindResolver(); err != nil {
-		channelz.RemoveEntry(cc.channelz.ID)
 		return nil, err
 	}
 
-	for _, lateApplyOpt := range globalLateApplyDialOptions {
-		lateApplyOpt.DialOption(cc.parsedTarget.URL).apply(&cc.dopts)
+	for _, opt := range globalPerTargetDialOptions {
+		opt.DialOption(cc.parsedTarget.URL).apply(&cc.dopts)
 	}
 
 	chainUnaryClientInterceptors(cc)
@@ -188,9 +179,12 @@ func NewClient(target string, opts ...DialOption) (conn *ClientConn, err error) 
 	cc.mkp = cc.dopts.copts.KeepaliveParams
 
 	if err = cc.determineAuthority(); err != nil {
-		channelz.RemoveEntry(cc.channelz.ID)
 		return nil, err
 	}
+
+	// Register ClientConn with channelz.
+	cc.channelzRegistration(target)
+	channelz.Infof(logger, cc.channelz, "Channel authority set to %q", cc.authority)
 
 	cc.csMgr = newConnectivityStateManager(cc.ctx, cc.channelz)
 	cc.pickerWrapper = newPickerWrapper(cc.dopts.copts.StatsHandlers)
@@ -1686,14 +1680,14 @@ func (cc *ClientConn) connectionError() error {
 //
 // Doesn't grab cc.mu as this method is expected to be called only at Dial time.
 func (cc *ClientConn) parseTargetAndFindResolver() error {
-	channelz.Infof(logger, cc.channelz, "original dial target is: %q", cc.target)
+	logger.Infof("original dial target is: %q", cc.target)
 
 	var rb resolver.Builder
 	parsedTarget, err := parseTarget(cc.target)
 	if err != nil {
-		channelz.Infof(logger, cc.channelz, "dial target %q parse failed: %v", cc.target, err)
+		logger.Infof("dial target %q parse failed: %v", cc.target, err)
 	} else {
-		channelz.Infof(logger, cc.channelz, "parsed dial target is: %#v", parsedTarget)
+		logger.Infof("parsed dial target is: %#v", parsedTarget)
 		rb = cc.getResolver(parsedTarget.URL.Scheme)
 		if rb != nil {
 			cc.parsedTarget = parsedTarget
@@ -1712,15 +1706,15 @@ func (cc *ClientConn) parseTargetAndFindResolver() error {
 		defScheme = resolver.GetDefaultScheme()
 	}
 
-	channelz.Infof(logger, cc.channelz, "fallback to scheme %q", defScheme)
+	logger.Infof("fallback to scheme %q", defScheme)
 	canonicalTarget := defScheme + ":///" + cc.target
 
 	parsedTarget, err = parseTarget(canonicalTarget)
 	if err != nil {
-		channelz.Infof(logger, cc.channelz, "dial target %q parse failed: %v", canonicalTarget, err)
+		logger.Infof("dial target %q parse failed: %v", canonicalTarget, err)
 		return err
 	}
-	channelz.Infof(logger, cc.channelz, "parsed dial target is: %+v", parsedTarget)
+	logger.Infof("parsed dial target is: %+v", parsedTarget)
 	rb = cc.getResolver(parsedTarget.URL.Scheme)
 	if rb == nil {
 		return fmt.Errorf("could not get resolver for default scheme: %q", parsedTarget.URL.Scheme)
@@ -1843,6 +1837,5 @@ func (cc *ClientConn) determineAuthority() error {
 	} else {
 		cc.authority = encodeAuthority(endpoint)
 	}
-	channelz.Infof(logger, cc.channelz, "Channel authority set to %q", cc.authority)
 	return nil
 }

--- a/default_dial_option_server_option_test.go
+++ b/default_dial_option_server_option_test.go
@@ -122,6 +122,7 @@ func (s) TestAddGlobalServerOptions(t *testing.T) {
 		t.Fatalf("Unexpected s.opts.maxReceiveMessageSize: %d != %d", s.opts.maxReceiveMessageSize, maxRecvSize)
 	}
 
+	internal.ClearGlobalServerOptions()
 	if len(globalServerOptions) != 0 {
 		t.Fatalf("Unexpected len of globalServerOptions: %d != 0", len(globalServerOptions))
 	}

--- a/dialoptions.go
+++ b/dialoptions.go
@@ -44,11 +44,13 @@ func init() {
 	internal.ClearGlobalDialOptions = func() {
 		globalDialOptions = nil
 	}
-	internal.AddGlobalLateApplyDialOptions = func(opt ...LateApplyDialOption) {
-		globalLateApplyDialOptions = append(globalLateApplyDialOptions, opt...)
+	internal.AddGlobalPerTargetDialOptions = func(opt any) {
+		if ptdo, ok := opt.(perTargetDialOption); ok {
+			globalPerTargetDialOptions = append(globalPerTargetDialOptions, ptdo)
+		}
 	}
-	internal.ClearGlobalLateApplyDialOptions = func() {
-		globalLateApplyDialOptions = nil
+	internal.ClearGlobalPerTargetDialOptions = func() {
+		globalPerTargetDialOptions = nil
 	}
 	internal.WithBinaryLogger = withBinaryLogger
 	internal.JoinDialOptions = newJoinDialOption
@@ -96,13 +98,16 @@ type DialOption interface {
 
 var globalDialOptions []DialOption
 
-// LateApplyDialOption takes a parsed target and returns a dial option to apply.
-type LateApplyDialOption interface {
+// perTargetDialOption takes a parsed target and returns a dial option to apply.
+//
+// This gets called after NewClient() parses the target, and allows per target
+// configuration set through a returned DialOption.
+type perTargetDialOption interface {
 	// DialOption returns a Dial Option to apply.
 	DialOption(parsedTarget url.URL) DialOption
 }
 
-var globalLateApplyDialOptions []LateApplyDialOption
+var globalPerTargetDialOptions []perTargetDialOption
 
 // EmptyDialOption does not alter the dial configuration. It can be embedded in
 // another structure to build custom dial options.

--- a/dialoptions.go
+++ b/dialoptions.go
@@ -104,7 +104,7 @@ var globalDialOptions []DialOption
 // configuration set through a returned DialOption.
 type perTargetDialOption interface {
 	// DialOption returns a Dial Option to apply.
-	DialOption(parsedTarget url.URL) DialOption
+	DialOptionForTarget(parsedTarget url.URL) DialOption
 }
 
 var globalPerTargetDialOptions []perTargetDialOption

--- a/dialoptions.go
+++ b/dialoptions.go
@@ -101,7 +101,9 @@ var globalDialOptions []DialOption
 // perTargetDialOption takes a parsed target and returns a dial option to apply.
 //
 // This gets called after NewClient() parses the target, and allows per target
-// configuration set through a returned DialOption.
+// configuration set through a returned DialOption. The DialOption will not take
+// effect if specifies a resolver builder, as that Dial Option is factored in
+// while parsing target.
 type perTargetDialOption interface {
 	// DialOption returns a Dial Option to apply.
 	DialOptionForTarget(parsedTarget url.URL) DialOption

--- a/dialoptions.go
+++ b/dialoptions.go
@@ -21,6 +21,7 @@ package grpc
 import (
 	"context"
 	"net"
+	"net/url"
 	"time"
 
 	"google.golang.org/grpc/backoff"
@@ -42,6 +43,12 @@ func init() {
 	}
 	internal.ClearGlobalDialOptions = func() {
 		globalDialOptions = nil
+	}
+	internal.AddGlobalLateApplyDialOptions = func(opt ...LateApplyDialOption) {
+		globalLateApplyDialOptions = append(globalLateApplyDialOptions, opt...)
+	}
+	internal.ClearGlobalLateApplyDialOptions = func() {
+		globalLateApplyDialOptions = nil
 	}
 	internal.WithBinaryLogger = withBinaryLogger
 	internal.JoinDialOptions = newJoinDialOption
@@ -88,6 +95,14 @@ type DialOption interface {
 }
 
 var globalDialOptions []DialOption
+
+// LateApplyDialOption takes a parsed target and returns a dial option to apply.
+type LateApplyDialOption interface {
+	// DialOption returns a Dial Option to apply.
+	DialOption(parsedTarget url.URL) DialOption
+}
+
+var globalLateApplyDialOptions []LateApplyDialOption
 
 // EmptyDialOption does not alter the dial configuration. It can be embedded in
 // another structure to build custom dial options.

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -106,6 +106,14 @@ var (
 	// This is used in the 1.0 release of gcp/observability, and thus must not be
 	// deleted or changed.
 	ClearGlobalDialOptions func()
+
+	// AddGlobalLateApplyDialOptions adds a slice of lateApplyDialOptions that
+	// will be configured for newly created ClientConns.
+	AddGlobalLateApplyDialOptions any // func (opt ...lateApplyDialOption)
+	// ClearGlobalLateApplyDialOptions clears the slice of global late apply
+	// dial options.
+	ClearGlobalLateApplyDialOptions func()
+
 	// JoinDialOptions combines the dial options passed as arguments into a
 	// single dial option.
 	JoinDialOptions any // func(...grpc.DialOption) grpc.DialOption

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -107,12 +107,12 @@ var (
 	// deleted or changed.
 	ClearGlobalDialOptions func()
 
-	// AddGlobalLateApplyDialOptions adds a slice of lateApplyDialOptions that
-	// will be configured for newly created ClientConns.
-	AddGlobalLateApplyDialOptions any // func (opt ...lateApplyDialOption)
-	// ClearGlobalLateApplyDialOptions clears the slice of global late apply
+	// AddGlobalPerTargetDialOptions adds a PerTargetDialOption that will be
+	// configured for newly created ClientConns.
+	AddGlobalPerTargetDialOptions any // func (opt any)
+	// ClearGlobalPerTargetDialOptions clears the slice of global late apply
 	// dial options.
-	ClearGlobalLateApplyDialOptions func()
+	ClearGlobalPerTargetDialOptions func()
 
 	// JoinDialOptions combines the dial options passed as arguments into a
 	// single dial option.
@@ -134,7 +134,8 @@ var (
 	// deleted or changed.
 	BinaryLogger any // func(binarylog.Logger) grpc.ServerOption
 
-	// SubscribeToConnectivityStateChanges adds a grpcsync.Subscriber to a provided grpc.ClientConn
+	// SubscribeToConnectivityStateChanges adds a grpcsync.Subscriber to a
+	// provided grpc.ClientConn.
 	SubscribeToConnectivityStateChanges any // func(*grpc.ClientConn, grpcsync.Subscriber)
 
 	// NewXDSResolverWithConfigForTesting creates a new xds resolver builder using
@@ -203,14 +204,17 @@ var (
 	// resource name.
 	TriggerXDSResourceNameNotFoundClient any // func(string, string) error
 
-	// FromOutgoingContextRaw returns the un-merged, intermediary contents of metadata.rawMD.
+	// FromOutgoingContextRaw returns the un-merged, intermediary contents of
+	// metadata.rawMD.
 	FromOutgoingContextRaw any // func(context.Context) (metadata.MD, [][]string, bool)
 
-	// UserSetDefaultScheme is set to true if the user has overridden the default resolver scheme.
+	// UserSetDefaultScheme is set to true if the user has overridden the
+	// default resolver scheme.
 	UserSetDefaultScheme bool = false
 )
 
-// HealthChecker defines the signature of the client-side LB channel health checking function.
+// HealthChecker defines the signature of the client-side LB channel health
+// checking function.
 //
 // The implementation is expected to create a health checking RPC stream by
 // calling newStream(), watch for the health status of serviceName, and report


### PR DESCRIPTION
This PR adds an internal only (exported, but can only set through internal/) LateApplyDialOption type. This will be used in CSM Observability.

RELEASE NOTES: N/A