### PR TITLE
documentation: on server, use FromIncomingContext  for retrieving context and `SetHeader`, `SetTrailer` to send metadata to client

### DIFF
--- a/Documentation/grpc-metadata.md
+++ b/Documentation/grpc-metadata.md
@@ -12,11 +12,11 @@ Four kinds of service method:
 - [Client streaming RPC](https://grpc.io/docs/guides/concepts.html#client-streaming-rpc)
 - [Bidirectional streaming RPC](https://grpc.io/docs/guides/concepts.html#bidirectional-streaming-rpc)
 
-And concept of [metadata](https://grpc.io/docs/guides/concepts.html#metadata).
+And concept of [metadata].
 
 ## Constructing metadata
 
-A metadata can be created using package [metadata][11].
+A metadata can be created using package [metadata].
 The type MD is actually a map from string to a list of strings:
 
 ```go
@@ -62,17 +62,6 @@ md := metadata.Pairs(
     "key-bin", string([]byte{96, 102}), // this binary data will be encoded (base64) before sending
                                         // and will be decoded after being transferred.
 )
-```
-
-## Retrieving metadata from context
-
-Metadata can be retrieved from context using `FromIncomingContext`:
-
-```go
-func (s *server) SomeRPC(ctx context.Context, in *pb.SomeRequest) (*pb.SomeResponse, err) {
-    md, ok := metadata.FromIncomingContext(ctx)
-    // do something with metadata
-}
 ```
 
 ## Sending and receiving metadata - client side
@@ -129,7 +118,7 @@ Metadata that a client can receive includes header and trailer.
 #### Unary call
 
 Header and trailer sent along with a unary call can be retrieved using function
-[Header][8] and [Trailer][9] in [CallOption][10]:
+[Header] and [Trailer] in [CallOption]:
 
 ```go
 var header, trailer metadata.MD // variable to store header and trailer
@@ -152,7 +141,7 @@ For streaming calls including:
 - Bidirectional streaming RPC
 
 Header and trailer can be retrieved from the returned stream using function
-`Header` and `Trailer` in interface [ClientStream][7]:
+`Header` and `Trailer` in interface [ClientStream]:
 
 ```go
 stream, err := client.SomeStreamingRPC(ctx)
@@ -173,7 +162,7 @@ Server side metadata sending and receiving examples are available
 ### Receiving metadata
 
 To read metadata sent by the client, the server needs to retrieve it from RPC
-context using [FromIncomingContext][1].
+context using [FromIncomingContext].
 If it is a unary call, the RPC handler's context can be used.
 For streaming calls, the server needs to get context from the stream.
 
@@ -200,15 +189,15 @@ func (s *server) SomeStreamingRPC(stream pb.Service_SomeStreamingRPCServer) erro
 #### Unary call
 
 To send header and trailer to client in unary call, the server can call
-[SendHeader][2] and [SetTrailer][3] functions in module [grpc][6].
+[SetHeader] and [SetTrailer] functions in module [grpc].
 These two functions take a context as the first parameter.
 It should be the RPC handler's context or one derived from it:
 
 ```go
 func (s *server) SomeRPC(ctx context.Context, in *pb.someRequest) (*pb.someResponse, error) {
-    // create and send header
+    // create and set header
     header := metadata.Pairs("header-key", "val")
-    grpc.SendHeader(ctx, header)
+    grpc.SetHeader(ctx, header)
     // create and set trailer
     trailer := metadata.Pairs("trailer-key", "val")
     grpc.SetTrailer(ctx, trailer)
@@ -218,36 +207,38 @@ func (s *server) SomeRPC(ctx context.Context, in *pb.someRequest) (*pb.someRespo
 #### Streaming call
 
 For streaming calls, header and trailer can be sent using function
-[SendHeader][2] and [SetTrailer][3] in interface [ServerStream][5]:
+[SetHeader] and [SetTrailer] in interface [ServerStream]:
 
 ```go
 func (s *server) SomeStreamingRPC(stream pb.Service_SomeStreamingRPCServer) error {
-    // create and send header
+    // create and set header
     header := metadata.Pairs("header-key", "val")
-    stream.SendHeader(header)
+    stream.SetHeader(header)
     // create and set trailer
     trailer := metadata.Pairs("trailer-key", "val")
     stream.SetTrailer(trailer)
 }
 ```
 
+**Important**
+
 Do not use
-[FromOutgoingContext][4] on the server to write metadata to be sent to the client.
-[FromOutgoingContext][4] is for client-side use only.
+[FromOutgoingContext] on the server to write metadata to be sent to the client.
+[FromOutgoingContext] is for client-side use only.
 
 ## Updating metadata from a server interceptor
 
 An example for updating metadata from a server interceptor is
 available [here](../examples/features/metadata_interceptor/server/main.go).
 
-[1]: <https://pkg.go.dev/google.golang.org/grpc/metadata#FromIncomingContext> "FromIncomingContext"
-[2]: <https://godoc.org/google.golang.org/grpc#SendHeader> "SendHeader"
-[3]: https://godoc.org/google.golang.org/grpc#SetTrailer "SetTrailer"
-[4]: https://pkg.go.dev/google.golang.org/grpc/metadata#FromOutgoingContext "FromOutgoingContext"
-[5]: https://godoc.org/google.golang.org/grpc#ServerStream "ServerStream"
-[6]: https://godoc.org/google.golang.org/grpc "grpc"
-[7]: https://godoc.org/google.golang.org/grpc#ClientStream "ClientStream"
-[8]: https://godoc.org/google.golang.org/grpc#Header "Header"
-[9]: https://godoc.org/google.golang.org/grpc#Trailer "Trailer"
-[10]: https://godoc.org/google.golang.org/grpc#CallOption, "CallOption"
-[11]: https://godoc.org/google.golang.org/grpc/metadata "Metadata"
+[FromIncomingContext]: <https://pkg.go.dev/google.golang.org/grpc/metadata#FromIncomingContext>
+[SetHeader]: <https://godoc.org/google.golang.org/grpc#SetHeader>
+[SetTrailer]: https://godoc.org/google.golang.org/grpc#SetTrailer
+[FromOutgoingContext]: https://pkg.go.dev/google.golang.org/grpc/metadata#FromOutgoingContext
+[ServerStream]: https://godoc.org/google.golang.org/grpc#ServerStream
+[grpc]: https://godoc.org/google.golang.org/grpc
+[ClientStream]: https://godoc.org/google.golang.org/grpc#ClientStream
+[Header]: https://godoc.org/google.golang.org/grpc#Header
+[Trailer]: https://godoc.org/google.golang.org/grpc#Trailer
+[CallOption]: https://godoc.org/google.golang.org/grpc#CallOption
+[metadata]: https://godoc.org/google.golang.org/grpc/metadata

--- a/Documentation/grpc-metadata.md
+++ b/Documentation/grpc-metadata.md
@@ -168,7 +168,8 @@ Server side metadata sending and receiving examples are available [here](../exam
 
 ### Receiving metadata
 
-To read metadata sent by the client, the server needs to retrieve it from RPC context using `FromIncomingContext`. Do not use `FromOutgoingContext` on server as it is for client-side only.
+To read metadata sent by the client, the server needs to retrieve it from RPC
+context using [FromIncomingContext](https://pkg.go.dev/google.golang.org/grpc/metadata#FromIncomingContext).
 If it is a unary call, the RPC handler's context can be used.
 For streaming calls, the server needs to get context from the stream.
 
@@ -194,7 +195,9 @@ func (s *server) SomeStreamingRPC(stream pb.Service_SomeStreamingRPCServer) erro
 
 #### Unary call
 
-To send header and trailer to client in unary call, the server can call [SendHeader](https://godoc.org/google.golang.org/grpc#SendHeader) and [SetTrailer](https://godoc.org/google.golang.org/grpc#SetTrailer) functions in module [grpc](https://godoc.org/google.golang.org/grpc).
+To send header and trailer to client in unary call, the server can call
+[SendHeader](https://godoc.org/google.golang.org/grpc#SendHeader) and [SetTrailer](https://godoc.org/google.golang.org/grpc#SetTrailer)
+functions in module [grpc](https://godoc.org/google.golang.org/grpc).
 These two functions take a context as the first parameter.
 It should be the RPC handler's context or one derived from it:
 
@@ -211,7 +214,7 @@ func (s *server) SomeRPC(ctx context.Context, in *pb.someRequest) (*pb.someRespo
 
 #### Streaming call
 
-For streaming calls, header and trailer can be sent using function `SendHeader` and `SetTrailer` in interface [ServerStream](https://godoc.org/google.golang.org/grpc#ServerStream):
+For streaming calls, header and trailer can be sent using function [SendHeader](https://godoc.org/google.golang.org/grpc#SendHeader) and [SetTrailer](https://godoc.org/google.golang.org/grpc#SetTrailer) in interface [ServerStream](https://godoc.org/google.golang.org/grpc#ServerStream):
 
 ```go
 func (s *server) SomeStreamingRPC(stream pb.Service_SomeStreamingRPCServer) error {
@@ -223,6 +226,10 @@ func (s *server) SomeStreamingRPC(stream pb.Service_SomeStreamingRPCServer) erro
     stream.SetTrailer(trailer)
 }
 ```
+
+Do not use
+[FromOutgoingContext](https://pkg.go.dev/google.golang.org/grpc/metadata#FromOutgoingContext) on the server to write metadata to be sent to the client.
+[FromOutgoingContext](https://pkg.go.dev/google.golang.org/grpc/metadata#FromOutgoingContext) is for client-side use only.
 
 ## Updating metadata from a server interceptor
 

--- a/Documentation/grpc-metadata.md
+++ b/Documentation/grpc-metadata.md
@@ -16,7 +16,7 @@ And concept of [metadata](https://grpc.io/docs/guides/concepts.html#metadata).
 
 ## Constructing metadata
 
-A metadata can be created using package [metadata](https://godoc.org/google.golang.org/grpc/metadata).
+A metadata can be created using package [metadata][11].
 The type MD is actually a map from string to a list of strings:
 
 ```go
@@ -77,7 +77,8 @@ func (s *server) SomeRPC(ctx context.Context, in *pb.SomeRequest) (*pb.SomeRespo
 
 ## Sending and receiving metadata - client side
 
-Client side metadata sending and receiving examples are available [here](../examples/features/metadata/client/main.go).
+Client side metadata sending and receiving examples are available
+[here](../examples/features/metadata/client/main.go).
 
 ### Sending metadata
 
@@ -127,7 +128,8 @@ Metadata that a client can receive includes header and trailer.
 
 #### Unary call
 
-Header and trailer sent along with a unary call can be retrieved using function [Header](https://godoc.org/google.golang.org/grpc#Header) and [Trailer](https://godoc.org/google.golang.org/grpc#Trailer) in [CallOption](https://godoc.org/google.golang.org/grpc#CallOption):
+Header and trailer sent along with a unary call can be retrieved using function
+[Header][8] and [Trailer][9] in [CallOption][10]:
 
 ```go
 var header, trailer metadata.MD // variable to store header and trailer
@@ -149,7 +151,8 @@ For streaming calls including:
 - Client streaming RPC
 - Bidirectional streaming RPC
 
-Header and trailer can be retrieved from the returned stream using function `Header` and `Trailer` in interface [ClientStream](https://godoc.org/google.golang.org/grpc#ClientStream):
+Header and trailer can be retrieved from the returned stream using function
+`Header` and `Trailer` in interface [ClientStream][7]:
 
 ```go
 stream, err := client.SomeStreamingRPC(ctx)
@@ -164,12 +167,13 @@ trailer := stream.Trailer()
 
 ## Sending and receiving metadata - server side
 
-Server side metadata sending and receiving examples are available [here](../examples/features/metadata/server/main.go).
+Server side metadata sending and receiving examples are available
+[here](../examples/features/metadata/server/main.go).
 
 ### Receiving metadata
 
 To read metadata sent by the client, the server needs to retrieve it from RPC
-context using [FromIncomingContext](https://pkg.go.dev/google.golang.org/grpc/metadata#FromIncomingContext).
+context using [FromIncomingContext][1].
 If it is a unary call, the RPC handler's context can be used.
 For streaming calls, the server needs to get context from the stream.
 
@@ -196,8 +200,7 @@ func (s *server) SomeStreamingRPC(stream pb.Service_SomeStreamingRPCServer) erro
 #### Unary call
 
 To send header and trailer to client in unary call, the server can call
-[SendHeader](https://godoc.org/google.golang.org/grpc#SendHeader) and [SetTrailer](https://godoc.org/google.golang.org/grpc#SetTrailer)
-functions in module [grpc](https://godoc.org/google.golang.org/grpc).
+[SendHeader][2] and [SetTrailer][3] functions in module [grpc][6].
 These two functions take a context as the first parameter.
 It should be the RPC handler's context or one derived from it:
 
@@ -214,7 +217,8 @@ func (s *server) SomeRPC(ctx context.Context, in *pb.someRequest) (*pb.someRespo
 
 #### Streaming call
 
-For streaming calls, header and trailer can be sent using function [SendHeader](https://godoc.org/google.golang.org/grpc#SendHeader) and [SetTrailer](https://godoc.org/google.golang.org/grpc#SetTrailer) in interface [ServerStream](https://godoc.org/google.golang.org/grpc#ServerStream):
+For streaming calls, header and trailer can be sent using function
+[SendHeader][2] and [SetTrailer][3] in interface [ServerStream][5]:
 
 ```go
 func (s *server) SomeStreamingRPC(stream pb.Service_SomeStreamingRPCServer) error {
@@ -228,10 +232,22 @@ func (s *server) SomeStreamingRPC(stream pb.Service_SomeStreamingRPCServer) erro
 ```
 
 Do not use
-[FromOutgoingContext](https://pkg.go.dev/google.golang.org/grpc/metadata#FromOutgoingContext) on the server to write metadata to be sent to the client.
-[FromOutgoingContext](https://pkg.go.dev/google.golang.org/grpc/metadata#FromOutgoingContext) is for client-side use only.
+[FromOutgoingContext][4] on the server to write metadata to be sent to the client.
+[FromOutgoingContext][4] is for client-side use only.
 
 ## Updating metadata from a server interceptor
 
 An example for updating metadata from a server interceptor is
 available [here](../examples/features/metadata_interceptor/server/main.go).
+
+[1]: <https://pkg.go.dev/google.golang.org/grpc/metadata#FromIncomingContext> "FromIncomingContext"
+[2]: <https://godoc.org/google.golang.org/grpc#SendHeader> "SendHeader"
+[3]: https://godoc.org/google.golang.org/grpc#SetTrailer "SetTrailer"
+[4]: https://pkg.go.dev/google.golang.org/grpc/metadata#FromOutgoingContext "FromOutgoingContext"
+[5]: https://godoc.org/google.golang.org/grpc#ServerStream "ServerStream"
+[6]: https://godoc.org/google.golang.org/grpc "grpc"
+[7]: https://godoc.org/google.golang.org/grpc#ClientStream "ClientStream"
+[8]: https://godoc.org/google.golang.org/grpc#Header "Header"
+[9]: https://godoc.org/google.golang.org/grpc#Trailer "Trailer"
+[10]: https://godoc.org/google.golang.org/grpc#CallOption, "CallOption"
+[11]: https://godoc.org/google.golang.org/grpc/metadata "Metadata"

--- a/Documentation/grpc-metadata.md
+++ b/Documentation/grpc-metadata.md
@@ -168,7 +168,7 @@ Server side metadata sending and receiving examples are available [here](../exam
 
 ### Receiving metadata
 
-To read metadata sent by the client, the server needs to retrieve it from RPC context.
+To read metadata sent by the client, the server needs to retrieve it from RPC context using `FromIncomingContext`. Do not use `FromOutgoingContext` on server as it is for client-side only.
 If it is a unary call, the RPC handler's context can be used.
 For streaming calls, the server needs to get context from the stream.
 

--- a/examples/features/metadata_interceptor/client/main.go
+++ b/examples/features/metadata_interceptor/client/main.go
@@ -38,12 +38,7 @@ var addr = flag.String("addr", "localhost:50051", "the address to connect to")
 
 func callUnaryEcho(ctx context.Context, client pb.EchoClient) {
 	var header, trailer metadata.MD
-	resp, err := client.UnaryEcho(
-		ctx,
-		&pb.EchoRequest{Message: "hello world"},
-		grpc.Header(&header),
-		grpc.Trailer(&trailer))
-
+	resp, err := client.UnaryEcho(ctx, &pb.EchoRequest{Message: "hello world"}, grpc.Header(&header), grpc.Trailer(&trailer))
 	if err != nil {
 		log.Fatalf("UnaryEcho: %v", err)
 	}
@@ -85,11 +80,10 @@ func callBidiStreamingEcho(ctx context.Context, client pb.EchoClient) {
 	header, err := c.Header()
 	if err != nil {
 		log.Fatalf("Receiving headers: %v", err)
-	} else {
-		fmt.Println("Received headers:")
-		for k, v := range header {
-			fmt.Printf("%s: %v\n", k, v)
-		}
+	}
+	fmt.Println("Received headers:")
+	for k, v := range header {
+		fmt.Printf("%s: %v\n", k, v)
 	}
 
 	trailer := c.Trailer()

--- a/examples/features/metadata_interceptor/client/main.go
+++ b/examples/features/metadata_interceptor/client/main.go
@@ -29,6 +29,7 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
 
 	pb "google.golang.org/grpc/examples/features/proto/echo"
 )
@@ -36,11 +37,27 @@ import (
 var addr = flag.String("addr", "localhost:50051", "the address to connect to")
 
 func callUnaryEcho(ctx context.Context, client pb.EchoClient) {
-	resp, err := client.UnaryEcho(ctx, &pb.EchoRequest{Message: "hello world"})
+	var header, trailer metadata.MD
+	resp, err := client.UnaryEcho(
+		ctx,
+		&pb.EchoRequest{Message: "hello world"},
+		grpc.Header(&header),
+		grpc.Trailer(&trailer))
+
 	if err != nil {
 		log.Fatalf("UnaryEcho: %v", err)
 	}
 	fmt.Println("UnaryEcho: ", resp.Message)
+
+	fmt.Println("Received headers:")
+	for k, v := range header {
+		fmt.Printf("%s: %v\n", k, v)
+	}
+
+	fmt.Println("Received trailers:")
+	for k, v := range trailer {
+		fmt.Printf("%s: %v\n", k, v)
+	}
 }
 
 func callBidiStreamingEcho(ctx context.Context, client pb.EchoClient) {
@@ -63,6 +80,22 @@ func callBidiStreamingEcho(ctx context.Context, client pb.EchoClient) {
 			log.Fatalf("Receiving echo response: %v", err)
 		}
 		fmt.Println("BidiStreaming Echo: ", resp.Message)
+	}
+
+	header, err := c.Header()
+	if err != nil {
+		log.Fatalf("Receiving headers: %v", err)
+	} else {
+		fmt.Println("Received headers:")
+		for k, v := range header {
+			fmt.Printf("%s: %v\n", k, v)
+		}
+	}
+
+	trailer := c.Trailer()
+	fmt.Println("Received tailers:")
+	for k, v := range trailer {
+		fmt.Printf("%s: %v\n", k, v)
 	}
 }
 

--- a/examples/features/metadata_interceptor/server/main.go
+++ b/examples/features/metadata_interceptor/server/main.go
@@ -49,10 +49,22 @@ func unaryInterceptor(ctx context.Context, req any, info *grpc.UnaryServerInfo, 
 		return nil, errMissingMetadata
 	}
 
+	// create and set metadata from interceptor to server
 	md.Append("key1", "value1")
 	ctx = metadata.NewIncomingContext(ctx, md)
 
-	return handler(ctx, req)
+	// call the handler to complete the normal execution of the RPC
+	resp, err := handler(ctx, req)
+
+	// create and set header metadata from interceptor to client
+	header := metadata.Pairs("header-key", "val")
+	grpc.SetHeader(ctx, header)
+
+	// create and set trailer metadata from interceptor to client
+	trailer := metadata.Pairs("trailer-key", "val")
+	grpc.SetTrailer(ctx, trailer)
+
+	return resp, err
 }
 
 func (s *server) UnaryEcho(ctx context.Context, in *pb.EchoRequest) (*pb.EchoResponse, error) {
@@ -89,10 +101,22 @@ func streamInterceptor(srv any, ss grpc.ServerStream, info *grpc.StreamServerInf
 		return errMissingMetadata
 	}
 
+	// create and set metadata from interceptor to server
 	md.Append("key1", "value1")
 	ctx := metadata.NewIncomingContext(ss.Context(), md)
 
-	return handler(srv, &wrappedStream{ss, ctx})
+	// call the handler to complete the normal execution of the RPC
+	err := handler(srv, &wrappedStream{ss, ctx})
+
+	// create and set header metadata from interceptor to client
+	header := metadata.Pairs("header-key", "val")
+	ss.SetHeader(header)
+
+	// create and set trailer metadata from interceptor to client
+	trailer := metadata.Pairs("trailer-key", "val")
+	ss.SetTrailer(trailer)
+
+	return err
 }
 
 func (s *server) BidirectionalStreamingEcho(stream pb.Echo_BidirectionalStreamingEchoServer) error {

--- a/examples/features/metadata_interceptor/server/main.go
+++ b/examples/features/metadata_interceptor/server/main.go
@@ -49,18 +49,18 @@ func unaryInterceptor(ctx context.Context, req any, info *grpc.UnaryServerInfo, 
 		return nil, errMissingMetadata
 	}
 
-	// create and set metadata from interceptor to server
+	// Create and set metadata from interceptor to server.
 	md.Append("key1", "value1")
 	ctx = metadata.NewIncomingContext(ctx, md)
 
-	// call the handler to complete the normal execution of the RPC
+	// Call the handler to complete the normal execution of the RPC.
 	resp, err := handler(ctx, req)
 
-	// create and set header metadata from interceptor to client
+	// Create and set header metadata from interceptor to client.
 	header := metadata.Pairs("header-key", "val")
 	grpc.SetHeader(ctx, header)
 
-	// create and set trailer metadata from interceptor to client
+	// Create and set trailer metadata from interceptor to client.
 	trailer := metadata.Pairs("trailer-key", "val")
 	grpc.SetTrailer(ctx, trailer)
 
@@ -101,18 +101,18 @@ func streamInterceptor(srv any, ss grpc.ServerStream, info *grpc.StreamServerInf
 		return errMissingMetadata
 	}
 
-	// create and set metadata from interceptor to server
+	// Create and set metadata from interceptor to server.
 	md.Append("key1", "value1")
 	ctx := metadata.NewIncomingContext(ss.Context(), md)
 
-	// call the handler to complete the normal execution of the RPC
+	// Call the handler to complete the normal execution of the RPC.
 	err := handler(srv, &wrappedStream{ss, ctx})
 
-	// create and set header metadata from interceptor to client
+	// Create and set header metadata from interceptor to client.
 	header := metadata.Pairs("header-key", "val")
 	ss.SetHeader(header)
 
-	// create and set trailer metadata from interceptor to client
+	// Create and set trailer metadata from interceptor to client.
 	trailer := metadata.Pairs("trailer-key", "val")
 	ss.SetTrailer(trailer)
 


### PR DESCRIPTION
Fixes: #7215. It was opened while addressing the question #7125 in order to make it more clear for sending metadata from server to client. The [sending metadata documentation section](https://github.com/grpc/grpc-go/blob/master/Documentation/grpc-metadata.md#sending-metadata-1) specifies it clearly in grpc-metadata.md to use `grpc.SetTrailer`

However, we should make it more explicit to use `FromIncomingContext` on server as original issue was using `OutgoingContext` in server interceptor. Moreover, we should replace `SendHeader` to `SetHeader` in documentation as `SendHeader` is used to send the headers immediately to the client where as `SetHeader` is used to set headers that will be sent with the gRPC response, which is a more common use case.

RELEASE NOTES: None