### PR TITLE
advancedTLS: unset a deprecated field after copying it

### DIFF
--- a/security/advancedtls/advancedtls.go
+++ b/security/advancedtls/advancedtls.go
@@ -315,6 +315,9 @@ func (o *Options) clientConfig() (*tls.Config, error) {
 	// the setting int the right place.
 	if o.RootOptions.RootCACerts != nil {
 		o.RootOptions.RootCertificates = o.RootOptions.RootCACerts
+		// There are additional checks that only 1 field of `RootOptions` is
+		// non-nil, so set the deprecated field to nil
+		o.RootOptions.RootCACerts = nil
 	}
 	if o.VerificationType == SkipVerification && o.AdditionalPeerVerification == nil {
 		return nil, fmt.Errorf("client needs to provide custom verification mechanism if choose to skip default verification")
@@ -425,6 +428,9 @@ func (o *Options) serverConfig() (*tls.Config, error) {
 	// the setting int the right place.
 	if o.RootOptions.RootCACerts != nil {
 		o.RootOptions.RootCertificates = o.RootOptions.RootCACerts
+		// There are additional checks that only 1 field of `RootOptions` is
+		// non-nil, so set the deprecated field to nil
+		o.RootOptions.RootCACerts = nil
 	}
 	if o.RequireClientCert && o.VerificationType == SkipVerification && o.AdditionalPeerVerification == nil {
 		return nil, fmt.Errorf("server needs to provide custom verification mechanism if choose to skip default verification, but require client certificate(s)")

--- a/security/advancedtls/advancedtls_test.go
+++ b/security/advancedtls/advancedtls_test.go
@@ -188,6 +188,13 @@ func (s) TestClientOptionsConfigSuccessCases(t *testing.T) {
 			MinVersion: tls.VersionTLS12,
 			MaxVersion: tls.VersionTLS13,
 		},
+		{
+			desc:                   "Deprecated option is set and forwarded",
+			clientVerificationType: CertVerification,
+			RootOptions: RootCertificateOptions{
+				RootCACerts: x509.NewCertPool(),
+			},
+		},
 	}
 	for _, test := range tests {
 		test := test
@@ -350,6 +357,15 @@ func (s) TestServerOptionsConfigSuccessCases(t *testing.T) {
 			},
 			MinVersion: tls.VersionTLS12,
 			MaxVersion: tls.VersionTLS13,
+		},
+		{
+			desc: "Deprecated option is set and forwarded",
+			IdentityOptions: IdentityCertificateOptions{
+				Certificates: []tls.Certificate{},
+			},
+			RootOptions: RootCertificateOptions{
+				RootCACerts: x509.NewCertPool(),
+			},
 		},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
There is a check to make sure that only one field of `RootOptions` is set. In copying the value of a deprecated field, there was a potential for multiple to be set. This PR sets the old field to nil after copying it.

RELEASE NOTES: none