### PR TITLE
xds: change the DumpResources API to return proto message containing the resource dump

### DIFF
--- a/xds/internal/xdsclient/client.go
+++ b/xds/internal/xdsclient/client.go
@@ -24,6 +24,8 @@ import (
 	"google.golang.org/grpc/internal/xds/bootstrap"
 	"google.golang.org/grpc/xds/internal/xdsclient/load"
 	"google.golang.org/grpc/xds/internal/xdsclient/xdsresource"
+
+	v3statuspb "github.com/envoyproxy/go-control-plane/envoy/service/status/v3"
 )
 
 // XDSClient is a full fledged gRPC client which queries a set of discovery APIs
@@ -48,7 +50,7 @@ type XDSClient interface {
 
 	// DumpResources returns the status of the xDS resources. Returns a map of
 	// resource type URLs to a map of resource names to resource state.
-	DumpResources() map[string]map[string]xdsresource.UpdateWithMD
+	DumpResources() (*v3statuspb.ClientStatusResponse, error)
 
 	ReportLoad(*bootstrap.ServerConfig) (*load.Store, func())
 

--- a/xds/internal/xdsclient/clientimpl_dump.go
+++ b/xds/internal/xdsclient/clientimpl_dump.go
@@ -19,35 +19,30 @@
 package xdsclient
 
 import (
-	"google.golang.org/grpc/xds/internal/xdsclient/xdsresource"
+	v3statuspb "github.com/envoyproxy/go-control-plane/envoy/service/status/v3"
 )
 
-func appendMaps(dst, src map[string]map[string]xdsresource.UpdateWithMD) {
-	// Iterate through the resource types.
-	for rType, srcResources := range src {
-		// Lookup/create the resource type specific map in the destination.
-		dstResources := dst[rType]
-		if dstResources == nil {
-			dstResources = make(map[string]xdsresource.UpdateWithMD)
-			dst[rType] = dstResources
-		}
-
-		// Iterate through the resources within the resource type in the source,
-		// and copy them over to the destination.
-		for name, update := range srcResources {
-			dstResources[name] = update
-		}
-	}
-}
-
 // DumpResources returns the status and contents of all xDS resources.
-func (c *clientImpl) DumpResources() map[string]map[string]xdsresource.UpdateWithMD {
+func (c *clientImpl) DumpResources() (*v3statuspb.ClientStatusResponse, error) {
 	c.authorityMu.Lock()
 	defer c.authorityMu.Unlock()
-	dumps := make(map[string]map[string]xdsresource.UpdateWithMD)
+
+	var retCfg []*v3statuspb.ClientConfig_GenericXdsConfig
 	for _, a := range c.authorities {
-		dump := a.dumpResources()
-		appendMaps(dumps, dump)
+		cfg, err := a.dumpResources()
+		if err != nil {
+			return nil, err
+		}
+		retCfg = append(retCfg, cfg...)
 	}
-	return dumps
+
+	return &v3statuspb.ClientStatusResponse{
+		Config: []*v3statuspb.ClientConfig{
+			{
+				// TODO: Populate ClientScope. Need to update go-control-plane dependency.
+				Node:              c.config.NodeProto,
+				GenericXdsConfigs: retCfg,
+			},
+		},
+	}, nil
 }

--- a/xds/internal/xdsclient/tests/resource_update_test.go
+++ b/xds/internal/xdsclient/tests/resource_update_test.go
@@ -88,9 +88,6 @@ func compareUpdateMetadata(ctx context.Context, dumpFunc func() (*v3statuspb.Cli
 		protocmp.Transform(),
 		protocmp.IgnoreFields((*v3statuspb.ClientConfig_GenericXdsConfig)(nil), "last_updated"),
 		protocmp.IgnoreFields((*v3adminpb.UpdateFailureState)(nil), "last_update_attempt", "details"),
-		// cmpopts.EquateEmpty(),
-		cmp.Comparer(func(a, b time.Time) bool { return true }),
-		// cmpopts.EquateErrors(),
 	}
 
 	var lastErr error


### PR DESCRIPTION
Addresses https://github.com/grpc/grpc-go/issues/6898

This PR does not cover all changes required to support A71 in CSDS. It changes the `DumpResources` API on the `XDSclient` interface to return the actual proto message for the CSDS response. The eventual goal is as follows:
- remove the `DumpResources` method from the `XDSClient` interface
- unexport the `DumpResources` method on the `clientImpl` type which is the implementation of the `XDSClient` interface
- have a package level function `xdsclient.DumpResources()` with returns the CSDS response proto
  - this function would go through the list of available xDS clients, and invoke their `dumpResources()` method and collate all the responses and return one
- CSDS service implementation would call the above package level function

I'm currently blocked on the last two steps because our current state of things with the global singleton and global xDS clients for testing seems to be mess. I need to clean that up quite a bit before I can get to the last two steps here.

#a71-xds-fallback

RELEASE NOTES: none
