### PR TITLE
.github: Skip OpenTelemetry module in go 1.20 tests

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -105,7 +105,10 @@ jobs:
           cd "${GITHUB_WORKSPACE}"
           for MOD_FILE in $(find . -name 'go.mod' | grep -Ev '^\./go\.mod'); do
             pushd "$(dirname ${MOD_FILE})"
-            go test ${{ matrix.testflags }} -cpu 1,4 -timeout 2m ./...
+            # Skip OpenTelemetry module if go 1.20, Go OpenTelemetry does not support 1.20.
+            if [[ matrix.goversion != 1.20 ]] || [[ dirname != ./stats/opentelemetry* ]]; then
+               go test ${{ matrix.testflags }} -cpu 1,4 -timeout 2m ./...
+            fi
             popd
           done
 


### PR DESCRIPTION
RELEASE NOTES: N/A