### PR TITLE
*: end support for Go v1.20

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -64,8 +64,6 @@ jobs:
           - type: tests
             goversion: '1.21'
 
-          - type: tests
-            goversion: '1.20'
     steps:
       # Setup the environment.
       - name: Setup GOARCH

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ RPC framework that puts mobile and HTTP/2 first. For more information see the
 
 ## Prerequisites
 
-- **[Go][]**: any one of the **three latest major** [releases][go-releases].
+- **[Go][]**: any one of the **two latest major** [releases][go-releases].
 
 ## Installation
 


### PR DESCRIPTION
Fixes #7249

We should leave this PR open for at least a few days to solicit feedback on the change.

RELEASE NOTES:
* ALL: Change support policy to only cover the latest two releases of Go.  See #7249 for more information.