### PR TITLE
stats/opentelemetry: CSM Observability server side component changes

### DIFF
--- a/stats/opentelemetry/client_metrics.go
+++ b/stats/opentelemetry/client_metrics.go
@@ -27,8 +27,8 @@ import (
 	"google.golang.org/grpc/stats"
 	"google.golang.org/grpc/status"
 
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/metric"
+	otelattribute "go.opentelemetry.io/otel/attribute"
+	otelmetric "go.opentelemetry.io/otel/metric"
 )
 
 type clientStatsHandler struct {
@@ -51,11 +51,11 @@ func (csh *clientStatsHandler) initializeMetrics() {
 
 	setOfMetrics := csh.o.MetricsOptions.Metrics.metrics
 
-	csh.clientMetrics.attemptStarted = createInt64Counter(setOfMetrics, "grpc.client.attempt.started", meter, metric.WithUnit("attempt"), metric.WithDescription("Number of client call attempts started."))
-	csh.clientMetrics.attemptDuration = createFloat64Histogram(setOfMetrics, "grpc.client.attempt.duration", meter, metric.WithUnit("s"), metric.WithDescription("End-to-end time taken to complete a client call attempt."), metric.WithExplicitBucketBoundaries(DefaultLatencyBounds...))
-	csh.clientMetrics.attemptSentTotalCompressedMessageSize = createInt64Histogram(setOfMetrics, "grpc.client.attempt.sent_total_compressed_message_size", meter, metric.WithUnit("By"), metric.WithDescription("Compressed message bytes sent per client call attempt."), metric.WithExplicitBucketBoundaries(DefaultSizeBounds...))
-	csh.clientMetrics.attemptRcvdTotalCompressedMessageSize = createInt64Histogram(setOfMetrics, "grpc.client.attempt.rcvd_total_compressed_message_size", meter, metric.WithUnit("By"), metric.WithDescription("Compressed message bytes received per call attempt."), metric.WithExplicitBucketBoundaries(DefaultSizeBounds...))
-	csh.clientMetrics.callDuration = createFloat64Histogram(setOfMetrics, "grpc.client.call.duration", meter, metric.WithUnit("s"), metric.WithDescription("Time taken by gRPC to complete an RPC from application's perspective."), metric.WithExplicitBucketBoundaries(DefaultLatencyBounds...))
+	csh.clientMetrics.attemptStarted = createInt64Counter(setOfMetrics, "grpc.client.attempt.started", meter, otelmetric.WithUnit("attempt"), otelmetric.WithDescription("Number of client call attempts started."))
+	csh.clientMetrics.attemptDuration = createFloat64Histogram(setOfMetrics, "grpc.client.attempt.duration", meter, otelmetric.WithUnit("s"), otelmetric.WithDescription("End-to-end time taken to complete a client call attempt."), otelmetric.WithExplicitBucketBoundaries(DefaultLatencyBounds...))
+	csh.clientMetrics.attemptSentTotalCompressedMessageSize = createInt64Histogram(setOfMetrics, "grpc.client.attempt.sent_total_compressed_message_size", meter, otelmetric.WithUnit("By"), otelmetric.WithDescription("Compressed message bytes sent per client call attempt."), otelmetric.WithExplicitBucketBoundaries(DefaultSizeBounds...))
+	csh.clientMetrics.attemptRcvdTotalCompressedMessageSize = createInt64Histogram(setOfMetrics, "grpc.client.attempt.rcvd_total_compressed_message_size", meter, otelmetric.WithUnit("By"), otelmetric.WithDescription("Compressed message bytes received per call attempt."), otelmetric.WithExplicitBucketBoundaries(DefaultSizeBounds...))
+	csh.clientMetrics.callDuration = createFloat64Histogram(setOfMetrics, "grpc.client.call.duration", meter, otelmetric.WithUnit("s"), otelmetric.WithDescription("Time taken by gRPC to complete an RPC from application's perspective."), otelmetric.WithExplicitBucketBoundaries(DefaultLatencyBounds...))
 }
 
 func (csh *clientStatsHandler) unaryInterceptor(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
@@ -67,9 +67,10 @@ func (csh *clientStatsHandler) unaryInterceptor(ctx context.Context, method stri
 
 	if csh.o.MetricsOptions.pluginOption != nil {
 		md := csh.o.MetricsOptions.pluginOption.GetMetadata()
-		val := md.Get("x-envoy-peer-metadata")
-		if len(val) == 1 {
-			ctx = metadata.AppendToOutgoingContext(ctx, metadataExchangeKey, val[0])
+		for k, v := range md {
+			if len(v) == 1 {
+				ctx = metadata.AppendToOutgoingContext(ctx, k, v[0])
+			}
 		}
 	}
 
@@ -108,6 +109,16 @@ func (csh *clientStatsHandler) streamInterceptor(ctx context.Context, desc *grpc
 		method: csh.determineMethod(method, opts...),
 	}
 	ctx = setCallInfo(ctx, ci)
+
+	if csh.o.MetricsOptions.pluginOption != nil {
+		md := csh.o.MetricsOptions.pluginOption.GetMetadata()
+		for k, v := range md {
+			if len(v) == 1 {
+				ctx = metadata.AppendToOutgoingContext(ctx, k, v[0])
+			}
+		}
+	}
+
 	startTime := time.Now()
 
 	callback := func(err error) {
@@ -120,7 +131,7 @@ func (csh *clientStatsHandler) streamInterceptor(ctx context.Context, desc *grpc
 func (csh *clientStatsHandler) perCallMetrics(ctx context.Context, err error, startTime time.Time, ci *callInfo) {
 	s := status.Convert(err)
 	callLatency := float64(time.Since(startTime)) / float64(time.Second)
-	csh.clientMetrics.callDuration.Record(ctx, callLatency, metric.WithAttributes(attribute.String("grpc.method", ci.method), attribute.String("grpc.target", ci.target), attribute.String("grpc.status", canonicalString(s.Code()))))
+	csh.clientMetrics.callDuration.Record(ctx, callLatency, otelmetric.WithAttributes(otelattribute.String("grpc.method", ci.method), otelattribute.String("grpc.target", ci.target), otelattribute.String("grpc.status", canonicalString(s.Code()))))
 }
 
 // TagConn exists to satisfy stats.Handler.
@@ -141,12 +152,12 @@ func (csh *clientStatsHandler) TagRPC(ctx context.Context, info *stats.RPCTagInf
 	if labels = istats.GetLabels(ctx); labels == nil {
 		labels = &istats.Labels{
 			TelemetryLabels: make(map[string]string),
-		} // Create optional labels map only if first stats handler in possible chain for a channel.
+		}
+		ctx = istats.SetLabels(ctx, labels)
 	}
-	ctx = istats.SetLabels(ctx, labels)
 	mi := &metricsInfo{ // populates information about RPC start.
 		startTime: time.Now(),
-		xDSLabels: labels.TelemetryLabels,
+		xdsLabels: labels.TelemetryLabels,
 		method:    info.FullMethodName,
 	}
 	ri := &rpcInfo{
@@ -173,25 +184,24 @@ func (csh *clientStatsHandler) processRPCEvent(ctx context.Context, s stats.RPCS
 			return
 		}
 
-		csh.clientMetrics.attemptStarted.Add(ctx, 1, metric.WithAttributes(attribute.String("grpc.method", ci.method), attribute.String("grpc.target", ci.target)))
+		csh.clientMetrics.attemptStarted.Add(ctx, 1, otelmetric.WithAttributes(otelattribute.String("grpc.method", ci.method), otelattribute.String("grpc.target", ci.target)))
 	case *stats.OutPayload:
 		atomic.AddInt64(&mi.sentCompressedBytes, int64(st.CompressedLength))
 	case *stats.InPayload:
 		atomic.AddInt64(&mi.recvCompressedBytes, int64(st.CompressedLength))
 	case *stats.InHeader:
-		csh.getLabelsFromPluginOption(mi, st.Header)
+		csh.setLabelsFromPluginOption(mi, st.Header)
 	case *stats.InTrailer:
-		csh.getLabelsFromPluginOption(mi, st.Trailer)
+		csh.setLabelsFromPluginOption(mi, st.Trailer)
 	case *stats.End:
 		csh.processRPCEnd(ctx, mi, st)
 	default:
 	}
 }
 
-func (csh *clientStatsHandler) getLabelsFromPluginOption(mi *metricsInfo, incomingMetadata metadata.MD) {
-	if !mi.labelsReceived && csh.o.MetricsOptions.pluginOption != nil {
-		mi.labels = csh.o.MetricsOptions.pluginOption.GetLabels(incomingMetadata)
-		mi.labelsReceived = true
+func (csh *clientStatsHandler) setLabelsFromPluginOption(mi *metricsInfo, incomingMetadata metadata.MD) {
+	if mi.pluginOptionLabels != nil && csh.o.MetricsOptions.pluginOption != nil {
+		mi.pluginOptionLabels = csh.o.MetricsOptions.pluginOption.GetLabels(incomingMetadata)
 	}
 }
 
@@ -208,23 +218,23 @@ func (csh *clientStatsHandler) processRPCEnd(ctx context.Context, mi *metricsInf
 		st = canonicalString(s.Code())
 	}
 
-	attributes := []attribute.KeyValue{
-		attribute.String("grpc.method", ci.method),
-		attribute.String("grpc.target", ci.target),
-		attribute.String("grpc.status", st),
+	attributes := []otelattribute.KeyValue{
+		otelattribute.String("grpc.method", ci.method),
+		otelattribute.String("grpc.target", ci.target),
+		otelattribute.String("grpc.status", st),
 	}
 
-	for k, v := range mi.labels {
-		attributes = append(attributes, attribute.String(k, v))
+	for k, v := range mi.pluginOptionLabels {
+		attributes = append(attributes, otelattribute.String(k, v))
 	}
 
 	for _, o := range csh.o.MetricsOptions.OptionalLabels {
-		if val, ok := mi.xDSLabels[o]; ok {
-			attributes = append(attributes, attribute.String(o, val))
+		if val, ok := mi.xdsLabels[o]; ok {
+			attributes = append(attributes, otelattribute.String(o, val))
 		}
 	}
 
-	clientAttributeOption := metric.WithAttributes(attributes...)
+	clientAttributeOption := otelmetric.WithAttributes(attributes...)
 	csh.clientMetrics.attemptDuration.Record(ctx, latency, clientAttributeOption)
 	csh.clientMetrics.attemptSentTotalCompressedMessageSize.Record(ctx, atomic.LoadInt64(&mi.sentCompressedBytes), clientAttributeOption)
 	csh.clientMetrics.attemptRcvdTotalCompressedMessageSize.Record(ctx, atomic.LoadInt64(&mi.recvCompressedBytes), clientAttributeOption)

--- a/stats/opentelemetry/client_metrics.go
+++ b/stats/opentelemetry/client_metrics.go
@@ -67,9 +67,9 @@ func (csh *clientStatsHandler) unaryInterceptor(ctx context.Context, method stri
 
 	if csh.o.MetricsOptions.pluginOption != nil {
 		md := csh.o.MetricsOptions.pluginOption.GetMetadata()
-		for k, v := range md {
-			if len(v) == 1 {
-				ctx = metadata.AppendToOutgoingContext(ctx, k, v[0])
+		for k, vs := range md {
+			for _, v := range vs {
+				ctx = metadata.AppendToOutgoingContext(ctx, k, v)
 			}
 		}
 	}
@@ -112,9 +112,9 @@ func (csh *clientStatsHandler) streamInterceptor(ctx context.Context, desc *grpc
 
 	if csh.o.MetricsOptions.pluginOption != nil {
 		md := csh.o.MetricsOptions.pluginOption.GetMetadata()
-		for k, v := range md {
-			if len(v) == 1 {
-				ctx = metadata.AppendToOutgoingContext(ctx, k, v[0])
+		for k, vs := range md {
+			for _, v := range vs {
+				ctx = metadata.AppendToOutgoingContext(ctx, k, v)
 			}
 		}
 	}

--- a/stats/opentelemetry/opentelemetry.go
+++ b/stats/opentelemetry/opentelemetry.go
@@ -154,6 +154,8 @@ func DialOption(o Options) grpc.DialOption {
 	return joinDialOptions(grpc.WithChainUnaryInterceptor(csh.unaryInterceptor), grpc.WithChainStreamInterceptor(csh.streamInterceptor), grpc.WithStatsHandler(csh))
 }
 
+var joinServerOptions = internal.JoinServerOptions.(func(...grpc.ServerOption) grpc.ServerOption)
+
 // ServerOption returns a server option which enables OpenTelemetry
 // instrumentation code for a grpc.Server.
 //
@@ -169,7 +171,7 @@ func DialOption(o Options) grpc.DialOption {
 func ServerOption(o Options) grpc.ServerOption {
 	ssh := &serverStatsHandler{o: o}
 	ssh.initializeMetrics()
-	return grpc.StatsHandler(ssh)
+	return joinServerOptions(grpc.ChainUnaryInterceptor(ssh.unaryInterceptor), grpc.ChainStreamInterceptor(ssh.streamInterceptor), grpc.StatsHandler(ssh))
 }
 
 // callInfo is information pertaining to the lifespan of the RPC client side.

--- a/stats/opentelemetry/opentelemetry.go
+++ b/stats/opentelemetry/opentelemetry.go
@@ -33,9 +33,6 @@ import (
 	"go.opentelemetry.io/otel/metric/noop"
 )
 
-// metadataExchangeKey is the key for HTTP metadata exchange.
-const metadataExchangeKey = "x-envoy-peer-metadata"
-
 var logger = grpclog.Component("otel-plugin")
 
 var canonicalString = internal.CanonicalString.(func(codes.Code) string)
@@ -131,8 +128,8 @@ type MetricsOptions struct {
 	// This only applies for server side metrics.
 	MethodAttributeFilter func(string) bool
 
-	// OptionalLabels are labels received from xDS that this component should
-	// add to metrics that record after receiving incoming metadata.
+	// OptionalLabels are labels received from LB Policies that this component
+	// should add to metrics that record after receiving incoming metadata.
 	OptionalLabels []string
 
 	// pluginOption is used to get labels to attach to certain metrics, if set.
@@ -232,9 +229,8 @@ type metricsInfo struct {
 	startTime time.Time
 	method    string
 
-	labelsReceived bool
-	labels         map[string]string // labels to attach to metrics emitted
-	xDSLabels      map[string]string
+	pluginOptionLabels map[string]string // pluginOptionLabels to attach to metrics emitted
+	xdsLabels          map[string]string
 }
 
 type clientMetrics struct {

--- a/stats/opentelemetry/opentelemetry.go
+++ b/stats/opentelemetry/opentelemetry.go
@@ -195,7 +195,7 @@ func getCallInfo(ctx context.Context) *callInfo {
 // rpcInfo is RPC information scoped to the RPC attempt life span client side,
 // and the RPC life span server side.
 type rpcInfo struct {
-	mi *metricsInfo
+	ai *attemptInfo
 }
 
 type rpcInfoKey struct{}
@@ -215,9 +215,9 @@ func removeLeadingSlash(mn string) string {
 	return strings.TrimLeft(mn, "/")
 }
 
-// metricsInfo is RPC information scoped to the RPC attempt life span client
+// attemptInfo is RPC information scoped to the RPC attempt life span client
 // side, and the RPC life span server side.
-type metricsInfo struct {
+type attemptInfo struct {
 	// access these counts atomically for hedging in the future:
 	// number of bytes after compression (within each message) from side (client
 	// || server).

--- a/stats/opentelemetry/server_metrics.go
+++ b/stats/opentelemetry/server_metrics.go
@@ -23,11 +23,12 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/internal"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/stats"
 	"google.golang.org/grpc/status"
 
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/metric"
+	otelattribute "go.opentelemetry.io/otel/attribute"
+	otelmetric "go.opentelemetry.io/otel/metric"
 )
 
 type serverStatsHandler struct {
@@ -49,10 +50,122 @@ func (ssh *serverStatsHandler) initializeMetrics() {
 	}
 	setOfMetrics := ssh.o.MetricsOptions.Metrics.metrics
 
-	ssh.serverMetrics.callStarted = createInt64Counter(setOfMetrics, "grpc.server.call.started", meter, metric.WithUnit("call"), metric.WithDescription("Number of server calls started."))
-	ssh.serverMetrics.callSentTotalCompressedMessageSize = createInt64Histogram(setOfMetrics, "grpc.server.call.sent_total_compressed_message_size", meter, metric.WithUnit("By"), metric.WithDescription("Compressed message bytes sent per server call."), metric.WithExplicitBucketBoundaries(DefaultSizeBounds...))
-	ssh.serverMetrics.callRcvdTotalCompressedMessageSize = createInt64Histogram(setOfMetrics, "grpc.server.call.rcvd_total_compressed_message_size", meter, metric.WithUnit("By"), metric.WithDescription("Compressed message bytes received per server call."), metric.WithExplicitBucketBoundaries(DefaultSizeBounds...))
-	ssh.serverMetrics.callDuration = createFloat64Histogram(setOfMetrics, "grpc.server.call.duration", meter, metric.WithUnit("s"), metric.WithDescription("End-to-end time taken to complete a call from server transport's perspective."), metric.WithExplicitBucketBoundaries(DefaultLatencyBounds...))
+	ssh.serverMetrics.callStarted = createInt64Counter(setOfMetrics, "grpc.server.call.started", meter, otelmetric.WithUnit("call"), otelmetric.WithDescription("Number of server calls started."))
+	ssh.serverMetrics.callSentTotalCompressedMessageSize = createInt64Histogram(setOfMetrics, "grpc.server.call.sent_total_compressed_message_size", meter, otelmetric.WithUnit("By"), otelmetric.WithDescription("Compressed message bytes sent per server call."), otelmetric.WithExplicitBucketBoundaries(DefaultSizeBounds...))
+	ssh.serverMetrics.callRcvdTotalCompressedMessageSize = createInt64Histogram(setOfMetrics, "grpc.server.call.rcvd_total_compressed_message_size", meter, otelmetric.WithUnit("By"), otelmetric.WithDescription("Compressed message bytes received per server call."), otelmetric.WithExplicitBucketBoundaries(DefaultSizeBounds...))
+	ssh.serverMetrics.callDuration = createFloat64Histogram(setOfMetrics, "grpc.server.call.duration", meter, otelmetric.WithUnit("s"), otelmetric.WithDescription("End-to-end time taken to complete a call from server transport's perspective."), otelmetric.WithExplicitBucketBoundaries(DefaultLatencyBounds...))
+}
+
+// attachLabelsTransport stream intercepts SetHeader and SendHeader calls of the
+// underlying ServerTransportStream to attach metadataExchangeLabels.
+type attachLabelsTransportStream struct {
+	grpc.ServerTransportStream
+
+	attachedLabels         atomic.Bool
+	metadataExchangeLabels metadata.MD
+}
+
+func (alts *attachLabelsTransportStream) SetHeader(md metadata.MD) error {
+	if !alts.attachedLabels.Swap(true) {
+		val := alts.metadataExchangeLabels.Get("x-envoy-peer-metadata")
+		md.Append("x-envoy-peer-metadata", val...)
+	}
+	return alts.ServerTransportStream.SetHeader(md)
+}
+
+func (alts *attachLabelsTransportStream) SendHeader(md metadata.MD) error {
+	if !alts.attachedLabels.Swap(true) {
+		val := alts.metadataExchangeLabels.Get("x-envoy-peer-metadata")
+		md.Append("x-envoy-peer-metadata", val...)
+	}
+
+	return alts.ServerTransportStream.SendHeader(md)
+}
+
+func (ssh *serverStatsHandler) unaryInterceptor(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+	var metadataExchangeLabels metadata.MD
+	if ssh.o.MetricsOptions.pluginOption != nil {
+		metadataExchangeLabels = ssh.o.MetricsOptions.pluginOption.GetMetadata()
+	}
+
+	sts := grpc.ServerTransportStreamFromContext(ctx)
+
+	alts := &attachLabelsTransportStream{
+		ServerTransportStream:  sts,
+		metadataExchangeLabels: metadataExchangeLabels,
+	}
+	ctx = grpc.NewContextWithServerTransportStream(ctx, alts)
+
+	any, err := handler(ctx, req)
+	if err != nil { // error returned, so trailers only
+		if !alts.attachedLabels.Swap(true) {
+			alts.SetTrailer(alts.metadataExchangeLabels)
+		}
+		logger.Infof("RPC failed with error: %v", err)
+	} else { // headers will be written; a message was sent
+		if !alts.attachedLabels.Swap(true) {
+			alts.SetHeader(alts.metadataExchangeLabels)
+		}
+	}
+
+	return any, err
+}
+
+// attachLabelsStream embeds a grpc.ServerStream, and intercepts the
+// SetHeader/SendHeader/SendMsg/SendTrailer call to attach metadata exchange
+// labels.
+type attachLabelsStream struct {
+	grpc.ServerStream
+
+	attachedLabels         atomic.Bool
+	metadataExchangeLabels metadata.MD
+}
+
+func (als *attachLabelsStream) SetHeader(md metadata.MD) error {
+	if !als.attachedLabels.Swap(true) {
+		val := als.metadataExchangeLabels.Get("x-envoy-peer-metadata")
+		md.Append("x-envoy-peer-metadata", val...)
+	}
+
+	return als.ServerStream.SetHeader(md)
+}
+
+func (als *attachLabelsStream) SendHeader(md metadata.MD) error {
+	if !als.attachedLabels.Swap(true) {
+		val := als.metadataExchangeLabels.Get("x-envoy-peer-metadata")
+		md.Append("x-envoy-peer-metadata", val...)
+	}
+
+	return als.ServerStream.SendHeader(md)
+}
+
+func (als *attachLabelsStream) SendMsg(m any) error {
+	if !als.attachedLabels.Swap(true) {
+		als.ServerStream.SetHeader(als.metadataExchangeLabels)
+	}
+	return als.ServerStream.SendMsg(m)
+}
+
+func (ssh *serverStatsHandler) streamInterceptor(srv any, ss grpc.ServerStream, ssi *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+	var metadataExchangeLabels metadata.MD
+	if ssh.o.MetricsOptions.pluginOption != nil {
+		metadataExchangeLabels = ssh.o.MetricsOptions.pluginOption.GetMetadata()
+	}
+	als := &attachLabelsStream{
+		ServerStream:           ss,
+		metadataExchangeLabels: metadataExchangeLabels,
+	}
+	err := handler(srv, als)
+	if err != nil {
+		logger.Infof("RPC failed with error: %v", err)
+	}
+
+	// Add metadata exchange labels to trailers if never sent in headers,
+	// irrespective of whether or not RPC failed.
+	if !als.attachedLabels.Load() {
+		als.SetTrailer(als.metadataExchangeLabels)
+	}
+	return err
 }
 
 // TagConn exists to satisfy stats.Handler.
@@ -105,7 +218,10 @@ func (ssh *serverStatsHandler) HandleRPC(ctx context.Context, rs stats.RPCStats)
 func (ssh *serverStatsHandler) processRPCData(ctx context.Context, s stats.RPCStats, ai *attemptInfo) {
 	switch st := s.(type) {
 	case *stats.InHeader:
-		ssh.serverMetrics.callStarted.Add(ctx, 1, metric.WithAttributes(attribute.String("grpc.method", ai.method)))
+		if ai.pluginOptionLabels != nil && ssh.o.MetricsOptions.pluginOption != nil {
+			ai.pluginOptionLabels = ssh.o.MetricsOptions.pluginOption.GetLabels(st.Header)
+		}
+		ssh.serverMetrics.callStarted.Add(ctx, 1, otelmetric.WithAttributes(otelattribute.String("grpc.method", ai.method)))
 	case *stats.OutPayload:
 		atomic.AddInt64(&ai.sentCompressedBytes, int64(st.CompressedLength))
 	case *stats.InPayload:
@@ -123,8 +239,15 @@ func (ssh *serverStatsHandler) processRPCEnd(ctx context.Context, ai *attemptInf
 		s, _ := status.FromError(e.Error)
 		st = canonicalString(s.Code())
 	}
-	serverAttributeOption := metric.WithAttributes(attribute.String("grpc.method", ai.method), attribute.String("grpc.status", st))
+	attributes := []otelattribute.KeyValue{
+		otelattribute.String("grpc.method", ai.method),
+		otelattribute.String("grpc.status", st),
+	}
+	for k, v := range ai.pluginOptionLabels {
+		attributes = append(attributes, otelattribute.String(k, v))
+	}
 
+	serverAttributeOption := otelmetric.WithAttributes(attributes...)
 	ssh.serverMetrics.callDuration.Record(ctx, latency, serverAttributeOption)
 	ssh.serverMetrics.callSentTotalCompressedMessageSize.Record(ctx, atomic.LoadInt64(&ai.sentCompressedBytes), serverAttributeOption)
 	ssh.serverMetrics.callRcvdTotalCompressedMessageSize.Record(ctx, atomic.LoadInt64(&ai.recvCompressedBytes), serverAttributeOption)

--- a/stats/opentelemetry/server_metrics.go
+++ b/stats/opentelemetry/server_metrics.go
@@ -82,12 +82,12 @@ func (ssh *serverStatsHandler) TagRPC(ctx context.Context, info *stats.RPCTagInf
 		}
 	}
 
-	mi := &metricsInfo{
+	ai := &attemptInfo{
 		startTime: time.Now(),
 		method:    removeLeadingSlash(method),
 	}
 	ri := &rpcInfo{
-		mi: mi,
+		ai: ai,
 	}
 	return setRPCInfo(ctx, ri)
 }
@@ -99,35 +99,35 @@ func (ssh *serverStatsHandler) HandleRPC(ctx context.Context, rs stats.RPCStats)
 		logger.Error("ctx passed into server side stats handler metrics event handling has no server call data present")
 		return
 	}
-	ssh.processRPCData(ctx, rs, ri.mi)
+	ssh.processRPCData(ctx, rs, ri.ai)
 }
 
-func (ssh *serverStatsHandler) processRPCData(ctx context.Context, s stats.RPCStats, mi *metricsInfo) {
+func (ssh *serverStatsHandler) processRPCData(ctx context.Context, s stats.RPCStats, ai *attemptInfo) {
 	switch st := s.(type) {
 	case *stats.InHeader:
-		ssh.serverMetrics.callStarted.Add(ctx, 1, metric.WithAttributes(attribute.String("grpc.method", mi.method)))
+		ssh.serverMetrics.callStarted.Add(ctx, 1, metric.WithAttributes(attribute.String("grpc.method", ai.method)))
 	case *stats.OutPayload:
-		atomic.AddInt64(&mi.sentCompressedBytes, int64(st.CompressedLength))
+		atomic.AddInt64(&ai.sentCompressedBytes, int64(st.CompressedLength))
 	case *stats.InPayload:
-		atomic.AddInt64(&mi.recvCompressedBytes, int64(st.CompressedLength))
+		atomic.AddInt64(&ai.recvCompressedBytes, int64(st.CompressedLength))
 	case *stats.End:
-		ssh.processRPCEnd(ctx, mi, st)
+		ssh.processRPCEnd(ctx, ai, st)
 	default:
 	}
 }
 
-func (ssh *serverStatsHandler) processRPCEnd(ctx context.Context, mi *metricsInfo, e *stats.End) {
-	latency := float64(time.Since(mi.startTime)) / float64(time.Second)
+func (ssh *serverStatsHandler) processRPCEnd(ctx context.Context, ai *attemptInfo, e *stats.End) {
+	latency := float64(time.Since(ai.startTime)) / float64(time.Second)
 	st := "OK"
 	if e.Error != nil {
 		s, _ := status.FromError(e.Error)
 		st = canonicalString(s.Code())
 	}
-	serverAttributeOption := metric.WithAttributes(attribute.String("grpc.method", mi.method), attribute.String("grpc.status", st))
+	serverAttributeOption := metric.WithAttributes(attribute.String("grpc.method", ai.method), attribute.String("grpc.status", st))
 
 	ssh.serverMetrics.callDuration.Record(ctx, latency, serverAttributeOption)
-	ssh.serverMetrics.callSentTotalCompressedMessageSize.Record(ctx, atomic.LoadInt64(&mi.sentCompressedBytes), serverAttributeOption)
-	ssh.serverMetrics.callRcvdTotalCompressedMessageSize.Record(ctx, atomic.LoadInt64(&mi.recvCompressedBytes), serverAttributeOption)
+	ssh.serverMetrics.callSentTotalCompressedMessageSize.Record(ctx, atomic.LoadInt64(&ai.sentCompressedBytes), serverAttributeOption)
+	ssh.serverMetrics.callRcvdTotalCompressedMessageSize.Record(ctx, atomic.LoadInt64(&ai.recvCompressedBytes), serverAttributeOption)
 }
 
 const (


### PR DESCRIPTION
This PR adds the CSM Observability logic for the client side of the OpenTelemetry component.

Also contains #7256. The second commit is the scope of this PR.

RELEASE NOTES: N/A