### PR TITLE
stats/opentelemetry: Add CSM Observability Layer

### DIFF
--- a/stats/opentelemetry/client_metrics.go
+++ b/stats/opentelemetry/client_metrics.go
@@ -27,8 +27,8 @@ import (
 	"google.golang.org/grpc/stats"
 	"google.golang.org/grpc/status"
 
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/metric"
+	otelattribute "go.opentelemetry.io/otel/attribute"
+	otelmetric "go.opentelemetry.io/otel/metric"
 )
 
 type clientStatsHandler struct {
@@ -51,11 +51,11 @@ func (csh *clientStatsHandler) initializeMetrics() {
 
 	setOfMetrics := csh.o.MetricsOptions.Metrics.metrics
 
-	csh.clientMetrics.attemptStarted = createInt64Counter(setOfMetrics, "grpc.client.attempt.started", meter, metric.WithUnit("attempt"), metric.WithDescription("Number of client call attempts started."))
-	csh.clientMetrics.attemptDuration = createFloat64Histogram(setOfMetrics, "grpc.client.attempt.duration", meter, metric.WithUnit("s"), metric.WithDescription("End-to-end time taken to complete a client call attempt."), metric.WithExplicitBucketBoundaries(DefaultLatencyBounds...))
-	csh.clientMetrics.attemptSentTotalCompressedMessageSize = createInt64Histogram(setOfMetrics, "grpc.client.attempt.sent_total_compressed_message_size", meter, metric.WithUnit("By"), metric.WithDescription("Compressed message bytes sent per client call attempt."), metric.WithExplicitBucketBoundaries(DefaultSizeBounds...))
-	csh.clientMetrics.attemptRcvdTotalCompressedMessageSize = createInt64Histogram(setOfMetrics, "grpc.client.attempt.rcvd_total_compressed_message_size", meter, metric.WithUnit("By"), metric.WithDescription("Compressed message bytes received per call attempt."), metric.WithExplicitBucketBoundaries(DefaultSizeBounds...))
-	csh.clientMetrics.callDuration = createFloat64Histogram(setOfMetrics, "grpc.client.call.duration", meter, metric.WithUnit("s"), metric.WithDescription("Time taken by gRPC to complete an RPC from application's perspective."), metric.WithExplicitBucketBoundaries(DefaultLatencyBounds...))
+	csh.clientMetrics.attemptStarted = createInt64Counter(setOfMetrics, "grpc.client.attempt.started", meter, otelmetric.WithUnit("attempt"), otelmetric.WithDescription("Number of client call attempts started."))
+	csh.clientMetrics.attemptDuration = createFloat64Histogram(setOfMetrics, "grpc.client.attempt.duration", meter, otelmetric.WithUnit("s"), otelmetric.WithDescription("End-to-end time taken to complete a client call attempt."), otelmetric.WithExplicitBucketBoundaries(DefaultLatencyBounds...))
+	csh.clientMetrics.attemptSentTotalCompressedMessageSize = createInt64Histogram(setOfMetrics, "grpc.client.attempt.sent_total_compressed_message_size", meter, otelmetric.WithUnit("By"), otelmetric.WithDescription("Compressed message bytes sent per client call attempt."), otelmetric.WithExplicitBucketBoundaries(DefaultSizeBounds...))
+	csh.clientMetrics.attemptRcvdTotalCompressedMessageSize = createInt64Histogram(setOfMetrics, "grpc.client.attempt.rcvd_total_compressed_message_size", meter, otelmetric.WithUnit("By"), otelmetric.WithDescription("Compressed message bytes received per call attempt."), otelmetric.WithExplicitBucketBoundaries(DefaultSizeBounds...))
+	csh.clientMetrics.callDuration = createFloat64Histogram(setOfMetrics, "grpc.client.call.duration", meter, otelmetric.WithUnit("s"), otelmetric.WithDescription("Time taken by gRPC to complete an RPC from application's perspective."), otelmetric.WithExplicitBucketBoundaries(DefaultLatencyBounds...))
 }
 
 func (csh *clientStatsHandler) unaryInterceptor(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
@@ -67,9 +67,10 @@ func (csh *clientStatsHandler) unaryInterceptor(ctx context.Context, method stri
 
 	if csh.o.MetricsOptions.pluginOption != nil {
 		md := csh.o.MetricsOptions.pluginOption.GetMetadata()
-		val := md.Get("x-envoy-peer-metadata")
-		if len(val) == 1 {
-			ctx = metadata.AppendToOutgoingContext(ctx, metadataExchangeKey, val[0])
+		for k, v := range md {
+			if len(v) == 1 {
+				ctx = metadata.AppendToOutgoingContext(ctx, k, v[0])
+			}
 		}
 	}
 
@@ -108,6 +109,16 @@ func (csh *clientStatsHandler) streamInterceptor(ctx context.Context, desc *grpc
 		method: csh.determineMethod(method, opts...),
 	}
 	ctx = setCallInfo(ctx, ci)
+
+	if csh.o.MetricsOptions.pluginOption != nil {
+		md := csh.o.MetricsOptions.pluginOption.GetMetadata()
+		for k, v := range md {
+			if len(v) == 1 {
+				ctx = metadata.AppendToOutgoingContext(ctx, k, v[0])
+			}
+		}
+	}
+
 	startTime := time.Now()
 
 	callback := func(err error) {
@@ -120,7 +131,7 @@ func (csh *clientStatsHandler) streamInterceptor(ctx context.Context, desc *grpc
 func (csh *clientStatsHandler) perCallMetrics(ctx context.Context, err error, startTime time.Time, ci *callInfo) {
 	s := status.Convert(err)
 	callLatency := float64(time.Since(startTime)) / float64(time.Second)
-	csh.clientMetrics.callDuration.Record(ctx, callLatency, metric.WithAttributes(attribute.String("grpc.method", ci.method), attribute.String("grpc.target", ci.target), attribute.String("grpc.status", canonicalString(s.Code()))))
+	csh.clientMetrics.callDuration.Record(ctx, callLatency, otelmetric.WithAttributes(otelattribute.String("grpc.method", ci.method), otelattribute.String("grpc.target", ci.target), otelattribute.String("grpc.status", canonicalString(s.Code()))))
 }
 
 // TagConn exists to satisfy stats.Handler.
@@ -141,12 +152,12 @@ func (csh *clientStatsHandler) TagRPC(ctx context.Context, info *stats.RPCTagInf
 	if labels = istats.GetLabels(ctx); labels == nil {
 		labels = &istats.Labels{
 			TelemetryLabels: make(map[string]string),
-		} // Create optional labels map only if first stats handler in possible chain for a channel.
+		}
+		ctx = istats.SetLabels(ctx, labels)
 	}
-	ctx = istats.SetLabels(ctx, labels)
 	mi := &metricsInfo{ // populates information about RPC start.
 		startTime: time.Now(),
-		xDSLabels: labels.TelemetryLabels,
+		xdsLabels: labels.TelemetryLabels,
 		method:    info.FullMethodName,
 	}
 	ri := &rpcInfo{
@@ -173,25 +184,24 @@ func (csh *clientStatsHandler) processRPCEvent(ctx context.Context, s stats.RPCS
 			return
 		}
 
-		csh.clientMetrics.attemptStarted.Add(ctx, 1, metric.WithAttributes(attribute.String("grpc.method", ci.method), attribute.String("grpc.target", ci.target)))
+		csh.clientMetrics.attemptStarted.Add(ctx, 1, otelmetric.WithAttributes(otelattribute.String("grpc.method", ci.method), otelattribute.String("grpc.target", ci.target)))
 	case *stats.OutPayload:
 		atomic.AddInt64(&mi.sentCompressedBytes, int64(st.CompressedLength))
 	case *stats.InPayload:
 		atomic.AddInt64(&mi.recvCompressedBytes, int64(st.CompressedLength))
 	case *stats.InHeader:
-		csh.getLabelsFromPluginOption(mi, st.Header)
+		csh.setLabelsFromPluginOption(mi, st.Header)
 	case *stats.InTrailer:
-		csh.getLabelsFromPluginOption(mi, st.Trailer)
+		csh.setLabelsFromPluginOption(mi, st.Trailer)
 	case *stats.End:
 		csh.processRPCEnd(ctx, mi, st)
 	default:
 	}
 }
 
-func (csh *clientStatsHandler) getLabelsFromPluginOption(mi *metricsInfo, incomingMetadata metadata.MD) {
-	if !mi.labelsReceived && csh.o.MetricsOptions.pluginOption != nil {
-		mi.labels = csh.o.MetricsOptions.pluginOption.GetLabels(incomingMetadata)
-		mi.labelsReceived = true
+func (csh *clientStatsHandler) setLabelsFromPluginOption(mi *metricsInfo, incomingMetadata metadata.MD) {
+	if mi.pluginOptionLabels != nil && csh.o.MetricsOptions.pluginOption != nil {
+		mi.pluginOptionLabels = csh.o.MetricsOptions.pluginOption.GetLabels(incomingMetadata)
 	}
 }
 
@@ -208,23 +218,23 @@ func (csh *clientStatsHandler) processRPCEnd(ctx context.Context, mi *metricsInf
 		st = canonicalString(s.Code())
 	}
 
-	attributes := []attribute.KeyValue{
-		attribute.String("grpc.method", ci.method),
-		attribute.String("grpc.target", ci.target),
-		attribute.String("grpc.status", st),
+	attributes := []otelattribute.KeyValue{
+		otelattribute.String("grpc.method", ci.method),
+		otelattribute.String("grpc.target", ci.target),
+		otelattribute.String("grpc.status", st),
 	}
 
-	for k, v := range mi.labels {
-		attributes = append(attributes, attribute.String(k, v))
+	for k, v := range mi.pluginOptionLabels {
+		attributes = append(attributes, otelattribute.String(k, v))
 	}
 
 	for _, o := range csh.o.MetricsOptions.OptionalLabels {
-		if val, ok := mi.xDSLabels[o]; ok {
-			attributes = append(attributes, attribute.String(o, val))
+		if val, ok := mi.xdsLabels[o]; ok {
+			attributes = append(attributes, otelattribute.String(o, val))
 		}
 	}
 
-	clientAttributeOption := metric.WithAttributes(attributes...)
+	clientAttributeOption := otelmetric.WithAttributes(attributes...)
 	csh.clientMetrics.attemptDuration.Record(ctx, latency, clientAttributeOption)
 	csh.clientMetrics.attemptSentTotalCompressedMessageSize.Record(ctx, atomic.LoadInt64(&mi.sentCompressedBytes), clientAttributeOption)
 	csh.clientMetrics.attemptRcvdTotalCompressedMessageSize.Record(ctx, atomic.LoadInt64(&mi.recvCompressedBytes), clientAttributeOption)

--- a/stats/opentelemetry/csm/observability.go
+++ b/stats/opentelemetry/csm/observability.go
@@ -1,0 +1,86 @@
+/*
+ *
+ * Copyright 2024 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package csm
+
+import (
+	"context"
+	"net/url"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/internal"
+	"google.golang.org/grpc/stats/opentelemetry"
+	otelinternal "google.golang.org/grpc/stats/opentelemetry/internal"
+)
+
+var clientSideOTelWithCSM grpc.DialOption
+var clientSideOTel grpc.DialOption
+
+// Observability sets up CSM Observability for the binary globally. It sets up
+// two client side OpenTelemetry instrumentation components configured with the
+// provided options, one with a CSM Plugin Option configured, one without.
+// Created channels will pick up one of these dependent on whether channels are
+// CSM Channels or not, which is derived from the Channel's parsed target after
+// dialing.
+//
+// It sets up a server side OpenTelemetry instrumentation component configured
+// with options provided alongside a CSM Plugin Option to be registered globally
+// and picked up for every server.
+//
+// The CSM Plugin Option is instantiated with local labels and metadata exchange
+// labels pulled from the environment, and emits metadata exchange labels from
+// the peer and local labels. Context timeouts do not trigger an error, but set
+// certain labels to "unknown".
+//
+// This function is not thread safe, and should only be invoked once in main
+// before any channels or servers are created. Returns a cleanup function to be
+// deferred in main.
+func Observability(ctx context.Context, options opentelemetry.Options) func() {
+	csmPluginOption := newPluginOption(ctx)
+	clientSideOTelWithCSM = dialOptionWithCSMPluginOption(options, csmPluginOption)
+	clientSideOTel = opentelemetry.DialOption(options)
+
+	serverSideOTelWithCSM := serverOptionWithCSMPluginOption(options, csmPluginOption)
+
+	internal.AddGlobalPerTargetDialOptions.(func(opt any))(perTargetDialOption)
+
+	internal.AddGlobalServerOptions.(func(opt ...grpc.ServerOption))(serverSideOTelWithCSM)
+
+	return func() {
+		internal.ClearGlobalServerOptions()
+		internal.ClearGlobalPerTargetDialOptions()
+	}
+}
+
+func perTargetDialOption(parsedTarget url.URL) grpc.DialOption {
+	if determineTargetCSM(&parsedTarget) {
+		return clientSideOTelWithCSM
+	}
+	return clientSideOTel
+}
+
+func dialOptionWithCSMPluginOption(options opentelemetry.Options, po otelinternal.PluginOption) grpc.DialOption {
+	options.MetricsOptions.OptionalLabels = []string{"csm.service_name", "csm.service_namespace"} // Attach the two xDS Optional Labels for this component to not filter out.
+	otelinternal.SetPluginOption.(func(options *opentelemetry.Options, po otelinternal.PluginOption))(&options, po)
+	return opentelemetry.DialOption(options)
+}
+
+func serverOptionWithCSMPluginOption(options opentelemetry.Options, po otelinternal.PluginOption) grpc.ServerOption {
+	otelinternal.SetPluginOption.(func(options *opentelemetry.Options, po otelinternal.PluginOption))(&options, po)
+	return opentelemetry.ServerOption(options)
+}

--- a/stats/opentelemetry/internal/pluginoption.go
+++ b/stats/opentelemetry/internal/pluginoption.go
@@ -21,6 +21,9 @@ import (
 	"google.golang.org/grpc/metadata"
 )
 
+// SetPluginOption sets the plugin option on Options.
+var SetPluginOption any // func(*Options, PluginOption)
+
 // PluginOption is the interface which represents a plugin option for the
 // OpenTelemetry instrumentation component. This plugin option emits labels from
 // metadata and also creates metadata containing labels. These labels are

--- a/stats/opentelemetry/opentelemetry.go
+++ b/stats/opentelemetry/opentelemetry.go
@@ -154,6 +154,8 @@ func DialOption(o Options) grpc.DialOption {
 	return joinDialOptions(grpc.WithChainUnaryInterceptor(csh.unaryInterceptor), grpc.WithChainStreamInterceptor(csh.streamInterceptor), grpc.WithStatsHandler(csh))
 }
 
+var joinServerOptions = internal.JoinServerOptions.(func(...grpc.ServerOption) grpc.ServerOption)
+
 // ServerOption returns a server option which enables OpenTelemetry
 // instrumentation code for a grpc.Server.
 //
@@ -169,7 +171,7 @@ func DialOption(o Options) grpc.DialOption {
 func ServerOption(o Options) grpc.ServerOption {
 	ssh := &serverStatsHandler{o: o}
 	ssh.initializeMetrics()
-	return grpc.StatsHandler(ssh)
+	return joinServerOptions(grpc.ChainUnaryInterceptor(ssh.unaryInterceptor), grpc.ChainStreamInterceptor(ssh.streamInterceptor), grpc.StatsHandler(ssh))
 }
 
 // callInfo is information pertaining to the lifespan of the RPC client side.

--- a/stats/opentelemetry/opentelemetry.go
+++ b/stats/opentelemetry/opentelemetry.go
@@ -33,9 +33,6 @@ import (
 	"go.opentelemetry.io/otel/metric/noop"
 )
 
-// metadataExchangeKey is the key for HTTP metadata exchange.
-const metadataExchangeKey = "x-envoy-peer-metadata"
-
 var logger = grpclog.Component("otel-plugin")
 
 var canonicalString = internal.CanonicalString.(func(codes.Code) string)
@@ -131,8 +128,8 @@ type MetricsOptions struct {
 	// This only applies for server side metrics.
 	MethodAttributeFilter func(string) bool
 
-	// OptionalLabels are labels received from xDS that this component should
-	// add to metrics that record after receiving incoming metadata.
+	// OptionalLabels are labels received from LB Policies that this component
+	// should add to metrics that record after receiving incoming metadata.
 	OptionalLabels []string
 
 	// pluginOption is used to get labels to attach to certain metrics, if set.
@@ -232,9 +229,8 @@ type metricsInfo struct {
 	startTime time.Time
 	method    string
 
-	labelsReceived bool
-	labels         map[string]string // labels to attach to metrics emitted
-	xDSLabels      map[string]string
+	pluginOptionLabels map[string]string // pluginOptionLabels to attach to metrics emitted
+	xdsLabels          map[string]string
 }
 
 type clientMetrics struct {

--- a/stats/opentelemetry/opentelemetry.go
+++ b/stats/opentelemetry/opentelemetry.go
@@ -33,6 +33,12 @@ import (
 	"go.opentelemetry.io/otel/metric/noop"
 )
 
+func init() {
+	otelinternal.SetPluginOption = func(o *Options, po otelinternal.PluginOption) {
+		o.MetricsOptions.pluginOption = po
+	}
+}
+
 var logger = grpclog.Component("otel-plugin")
 
 var canonicalString = internal.CanonicalString.(func(codes.Code) string)


### PR DESCRIPTION
This PR adds the CSM Observability Layer, externally exposed to users to call from main().

Contains #7257, third commit is the scope of this PR.

RELEASE NOTES: N/A