### PR TITLE
dns: fix constant 30s backoff for re-resolution

### DIFF
--- a/internal/resolver/dns/dns_resolver.go
+++ b/internal/resolver/dns/dns_resolver.go
@@ -63,6 +63,7 @@ var (
 func init() {
 	resolver.Register(NewBuilder())
 	internal.TimeAfterFunc = time.After
+	internal.TimeUntilFunc = time.Until
 	internal.NewNetResolver = newNetResolver
 	internal.AddressDialer = addressDialer
 }
@@ -229,7 +230,7 @@ func (d *dnsResolver) watcher() {
 		select {
 		case <-d.ctx.Done():
 			return
-		case <-internal.TimeAfterFunc(time.Until(nextResolutionTime)):
+		case <-internal.TimeAfterFunc(internal.TimeUntilFunc(nextResolutionTime)):
 		}
 	}
 }

--- a/internal/resolver/dns/dns_resolver.go
+++ b/internal/resolver/dns/dns_resolver.go
@@ -63,6 +63,7 @@ var (
 func init() {
 	resolver.Register(NewBuilder())
 	internal.TimeAfterFunc = time.After
+	internal.TimeNowFunc = time.Now
 	internal.TimeUntilFunc = time.Until
 	internal.NewNetResolver = newNetResolver
 	internal.AddressDialer = addressDialer
@@ -215,7 +216,7 @@ func (d *dnsResolver) watcher() {
 			// Success resolving, wait for the next ResolveNow. However, also wait 30
 			// seconds at the very least to prevent constantly re-resolving.
 			backoffIndex = 1
-			nextResolutionTime = time.Now().Add(MinResolutionInterval)
+			nextResolutionTime = internal.TimeNowFunc().Add(MinResolutionInterval)
 			select {
 			case <-d.ctx.Done():
 				return
@@ -224,7 +225,7 @@ func (d *dnsResolver) watcher() {
 		} else {
 			// Poll on an error found in DNS Resolver or an error received from
 			// ClientConn.
-			nextResolutionTime = time.Now().Add(backoff.DefaultExponential.Backoff(backoffIndex))
+			nextResolutionTime = internal.TimeNowFunc().Add(backoff.DefaultExponential.Backoff(backoffIndex))
 			backoffIndex++
 		}
 		select {

--- a/internal/resolver/dns/dns_resolver_test.go
+++ b/internal/resolver/dns/dns_resolver_test.go
@@ -194,190 +194,190 @@ func verifyUpdateFromResolver(ctx context.Context, t *testing.T, stateCh chan re
 //   - the fourth and fifth entries will match the canarying rules, and therefore
 //     the fourth entry will be used as it will be  the first matching entry.
 const txtRecordGood = `
-[
-	{
-		"clientLanguage": [
-			"CPP",
-			"JAVA"
-		],
-		"serviceConfig": {
-			"loadBalancingPolicy": "grpclb",
-			"methodConfig": [
-				{
-					"name": [
-						{
-							"service": "all"
-						}
-					],
-					"timeout": "1s"
-				}
-			]
-		}
-	},
-	{
-		"percentage": 0,
-		"serviceConfig": {
-			"loadBalancingPolicy": "grpclb",
-			"methodConfig": [
-				{
-					"name": [
-						{
-							"service": "all"
-						}
-					],
-					"timeout": "1s"
-				}
-			]
-		}
-	},
-	{
-		"clientHostName": [
-			"localhost"
-		],
-		"serviceConfig": {
-			"loadBalancingPolicy": "grpclb",
-			"methodConfig": [
-				{
-					"name": [
-						{
-							"service": "all"
-						}
-					],
-					"timeout": "1s"
-				}
-			]
-		}
-	},
-	{
-		"clientLanguage": [
-			"GO"
-		],
-		"percentage": 100,
-		"serviceConfig": {
-			"loadBalancingPolicy": "round_robin",
-			"methodConfig": [
-				{
-					"name": [
-						{
-							"service": "foo"
-						}
-					],
-					"waitForReady": true,
-					"timeout": "1s"
-				},
-				{
-					"name": [
-						{
-							"service": "bar"
-						}
-					],
-					"waitForReady": false
-				}
-			]
-		}
-	},
-	{
-		"serviceConfig": {
-			"loadBalancingPolicy": "round_robin",
-			"methodConfig": [
-				{
-					"name": [
-						{
-							"service": "foo",
-							"method": "bar"
-						}
-					],
-					"waitForReady": true
-				}
-			]
-		}
-	}
-]`
+ [
+	 {
+		 "clientLanguage": [
+			 "CPP",
+			 "JAVA"
+		 ],
+		 "serviceConfig": {
+			 "loadBalancingPolicy": "grpclb",
+			 "methodConfig": [
+				 {
+					 "name": [
+						 {
+							 "service": "all"
+						 }
+					 ],
+					 "timeout": "1s"
+				 }
+			 ]
+		 }
+	 },
+	 {
+		 "percentage": 0,
+		 "serviceConfig": {
+			 "loadBalancingPolicy": "grpclb",
+			 "methodConfig": [
+				 {
+					 "name": [
+						 {
+							 "service": "all"
+						 }
+					 ],
+					 "timeout": "1s"
+				 }
+			 ]
+		 }
+	 },
+	 {
+		 "clientHostName": [
+			 "localhost"
+		 ],
+		 "serviceConfig": {
+			 "loadBalancingPolicy": "grpclb",
+			 "methodConfig": [
+				 {
+					 "name": [
+						 {
+							 "service": "all"
+						 }
+					 ],
+					 "timeout": "1s"
+				 }
+			 ]
+		 }
+	 },
+	 {
+		 "clientLanguage": [
+			 "GO"
+		 ],
+		 "percentage": 100,
+		 "serviceConfig": {
+			 "loadBalancingPolicy": "round_robin",
+			 "methodConfig": [
+				 {
+					 "name": [
+						 {
+							 "service": "foo"
+						 }
+					 ],
+					 "waitForReady": true,
+					 "timeout": "1s"
+				 },
+				 {
+					 "name": [
+						 {
+							 "service": "bar"
+						 }
+					 ],
+					 "waitForReady": false
+				 }
+			 ]
+		 }
+	 },
+	 {
+		 "serviceConfig": {
+			 "loadBalancingPolicy": "round_robin",
+			 "methodConfig": [
+				 {
+					 "name": [
+						 {
+							 "service": "foo",
+							 "method": "bar"
+						 }
+					 ],
+					 "waitForReady": true
+				 }
+			 ]
+		 }
+	 }
+ ]`
 
 // This is the matched portion of the above TXT record entry.
 const scJSON = `
-{
-	"loadBalancingPolicy": "round_robin",
-	"methodConfig": [
-		{
-			"name": [
-				{
-					"service": "foo"
-				}
-			],
-			"waitForReady": true,
-			"timeout": "1s"
-		},
-		{
-			"name": [
-				{
-					"service": "bar"
-				}
-			],
-			"waitForReady": false
-		}
-	]
-}`
+ {
+	 "loadBalancingPolicy": "round_robin",
+	 "methodConfig": [
+		 {
+			 "name": [
+				 {
+					 "service": "foo"
+				 }
+			 ],
+			 "waitForReady": true,
+			 "timeout": "1s"
+		 },
+		 {
+			 "name": [
+				 {
+					 "service": "bar"
+				 }
+			 ],
+			 "waitForReady": false
+		 }
+	 ]
+ }`
 
 // This service config contains three entries, but none of the match the DNS
 // resolver's canarying rules and hence the resulting service config pushed by
 // the DNS resolver will be an empty one.
 const txtRecordNonMatching = `
-[
-	{
-		"clientLanguage": [
-			"CPP",
-			"JAVA"
-		],
-		"serviceConfig": {
-			"loadBalancingPolicy": "grpclb",
-			"methodConfig": [
-				{
-					"name": [
-						{
-							"service": "all"
-						}
-					],
-					"timeout": "1s"
-				}
-			]
-		}
-	},
-	{
-		"percentage": 0,
-		"serviceConfig": {
-			"loadBalancingPolicy": "grpclb",
-			"methodConfig": [
-				{
-					"name": [
-						{
-							"service": "all"
-						}
-					],
-					"timeout": "1s"
-				}
-			]
-		}
-	},
-	{
-		"clientHostName": [
-			"localhost"
-		],
-		"serviceConfig": {
-			"loadBalancingPolicy": "grpclb",
-			"methodConfig": [
-				{
-					"name": [
-						{
-							"service": "all"
-						}
-					],
-					"timeout": "1s"
-				}
-			]
-		}
-	}
-]`
+ [
+	 {
+		 "clientLanguage": [
+			 "CPP",
+			 "JAVA"
+		 ],
+		 "serviceConfig": {
+			 "loadBalancingPolicy": "grpclb",
+			 "methodConfig": [
+				 {
+					 "name": [
+						 {
+							 "service": "all"
+						 }
+					 ],
+					 "timeout": "1s"
+				 }
+			 ]
+		 }
+	 },
+	 {
+		 "percentage": 0,
+		 "serviceConfig": {
+			 "loadBalancingPolicy": "grpclb",
+			 "methodConfig": [
+				 {
+					 "name": [
+						 {
+							 "service": "all"
+						 }
+					 ],
+					 "timeout": "1s"
+				 }
+			 ]
+		 }
+	 },
+	 {
+		 "clientHostName": [
+			 "localhost"
+		 ],
+		 "serviceConfig": {
+			 "loadBalancingPolicy": "grpclb",
+			 "methodConfig": [
+				 {
+					 "name": [
+						 {
+							 "service": "all"
+						 }
+					 ],
+					 "timeout": "1s"
+				 }
+			 ]
+		 }
+	 }
+ ]`
 
 // Tests the scenario where a name resolves to a list of addresses, possibly
 // some grpclb addresses as well, and a service config. The test verifies that
@@ -636,8 +636,8 @@ func (s) TestDNSResolver_ExponentialBackoff(t *testing.T) {
 func (s) TestDNSResolver_ResolveNow(t *testing.T) {
 	const target = "foo.bar.com"
 
-	overrideResolutionInterval(t, 0)
-	overrideTimeAfterFunc(t, 0)
+	overrideResolutionInterval(t, 5*time.Second)
+	//overrideTimeAfterFunc(t, 0)
 	tr := &testNetResolver{
 		hostLookupTable: map[string][]string{
 			"foo.bar.com": {"1.2.3.4", "5.6.7.8"},
@@ -653,7 +653,7 @@ func (s) TestDNSResolver_ResolveNow(t *testing.T) {
 	// Verify that the first update pushed by the resolver matches expectations.
 	wantAddrs := []resolver.Address{{Addr: "1.2.3.4" + colonDefaultPort}, {Addr: "5.6.7.8" + colonDefaultPort}}
 	wantSC := scJSON
-	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 	verifyUpdateFromResolver(ctx, t, stateCh, wantAddrs, nil, wantSC)
 
@@ -666,10 +666,13 @@ func (s) TestDNSResolver_ResolveNow(t *testing.T) {
 
 	// Ask the resolver to re-resolve and verify that the new update matches
 	// expectations.
+	fmt.Printf("1st resolve sent %v\n", time.Now())
 	r.ResolveNow(resolver.ResolveNowOptions{})
 	wantAddrs = []resolver.Address{{Addr: "1.2.3.4" + colonDefaultPort}}
 	wantSC = `{"loadBalancingPolicy": "grpclb"}`
 	verifyUpdateFromResolver(ctx, t, stateCh, wantAddrs, nil, wantSC)
+	fmt.Printf("1st resolve completed %v\n", time.Now())
+	time.Sleep(5 * time.Second)
 
 	// Update state in the fake resolver to return no addresses and the same
 	// service config as before.
@@ -677,8 +680,10 @@ func (s) TestDNSResolver_ResolveNow(t *testing.T) {
 
 	// Ask the resolver to re-resolve and verify that the new update matches
 	// expectations.
+	fmt.Printf("2nd resolve sent %v\n", time.Now())
 	r.ResolveNow(resolver.ResolveNowOptions{})
 	verifyUpdateFromResolver(ctx, t, stateCh, nil, nil, wantSC)
+	fmt.Printf("2nd resolve completed %v\n", time.Now())
 }
 
 // Tests the case where the given name is an IP address and verifies that the

--- a/internal/resolver/dns/dns_resolver_test.go
+++ b/internal/resolver/dns/dns_resolver_test.go
@@ -102,13 +102,25 @@ func overrideTimeAfterFuncWithChannel(t *testing.T) (durChan chan time.Duration,
 	return durChan, timeChan
 }
 
-// Override the remaining time used by the DNS resolver to allow resolution
-func overrideTimeUntilFunc(t *testing.T, now time.Time) {
+// Override the current time used by the DNS resolver.
+func overrideTimeNowFunc(t *testing.T, now time.Time) {
+	origTimeNowFunc := dnsinternal.TimeNowFunc
+	dnsinternal.TimeNowFunc = func() time.Time { return now }
+	t.Cleanup(func() { dnsinternal.TimeNowFunc = origTimeNowFunc })
+}
+
+// Override the remaining wait time to allow re-resolution by DNS resolver.
+// Use the timeChan to read the time until resolver needs to wait for
+// and return 0 wait time.
+func overrideTimeUntilFuncWithChannel(t *testing.T) (timeChan chan time.Time) {
+	timeCh := make(chan time.Time, 1)
 	origTimeUntil := dnsinternal.TimeUntilFunc
-	dnsinternal.TimeUntilFunc = func(tm time.Time) time.Duration {
-		return now.Sub(tm)
+	dnsinternal.TimeUntilFunc = func(t time.Time) time.Duration {
+		timeCh <- t
+		return 0
 	}
 	t.Cleanup(func() { dnsinternal.TimeUntilFunc = origTimeUntil })
+	return timeCh
 }
 
 func enableSRVLookups(t *testing.T) {
@@ -1301,12 +1313,8 @@ func (s) TestMinResolutionInterval(t *testing.T) {
 }
 
 // TestMinResolutionInterval_NoExtraDelay verifies that there is no extra delay
-// between two resolution requests apart from [minResolutionInterval].
-// It sets the minResolutionInterval 1s and overrides timeUntilFunc to
-// calculate remaining time to allow resolution after 1s and verifies that
-// remaining time to allow resolution is very small
+// between two resolution requests apart from [MinResolutionInterval].
 func (s) TestMinResolutionInterval_NoExtraDelay(t *testing.T) {
-	durChan, timeChan := overrideTimeAfterFuncWithChannel(t)
 	tr := &testNetResolver{
 		hostLookupTable: map[string][]string{
 			"foo.bar.com": {"1.2.3.4", "5.6.7.8"},
@@ -1316,13 +1324,20 @@ func (s) TestMinResolutionInterval_NoExtraDelay(t *testing.T) {
 		},
 	}
 	overrideNetResolver(t, tr)
-	var minResolutionInterval = 1 * time.Second
-	overrideResolutionInterval(t, minResolutionInterval)
+	// Override time.Now() to return a zero value for time. This will allow us
+	// to verify that the call to time.Until is made with the exact
+	// [MinResolutionInterval] that we expect.
+	overrideTimeNowFunc(t, time.Time{})
+	// Override time.Until() to read the time passed to it
+	// and return immediately without any delay
+	timeCh := overrideTimeUntilFuncWithChannel(t)
 
 	r, stateCh, errorCh := buildResolverWithTestClientConn(t, "foo.bar.com")
 
-	ctx, ctxCancel := context.WithTimeout(context.Background(), defaultTestTimeout)
-	defer ctxCancel()
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+
+	// Ensure that the first resolution happens.
 	select {
 	case <-ctx.Done():
 		t.Fatal("Timeout when waiting for DNS resolver")
@@ -1331,25 +1346,20 @@ func (s) TestMinResolutionInterval_NoExtraDelay(t *testing.T) {
 	case <-stateCh:
 	}
 
-	// Make next resolution request after 1s.
-	var now = time.Now().Add(minResolutionInterval)
-	overrideTimeUntilFunc(t, now)
+	// Request re-resolution and verify that the resolver waits for
+	// [MinResolutionInterval].
 	r.ResolveNow(resolver.ResolveNowOptions{})
-
-	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
-	defer cancel()
 	select {
 	case <-ctx.Done():
 		t.Fatal("Timeout when waiting for DNS resolver")
-	case dur := <-durChan:
-		if dur > 1*time.Millisecond {
-			t.Fatalf("Remaining time duration to allow next resolution is higher than expected")
+	case gotTime := <-timeCh:
+		wantTime := time.Time{}.Add(dns.MinResolutionInterval)
+		if !gotTime.Equal(wantTime) {
+			t.Fatalf("DNS resolver waits for %v time before re-resolution, want %v", gotTime, wantTime)
 		}
 	}
 
-	// Unblock the DNS resolver's backoff by pushing the current time.
-	timeChan <- time.Now()
-
+	// Ensure that the re-resolution request actually happens.
 	select {
 	case <-ctx.Done():
 		t.Fatal("Timeout when waiting for an error from the resolver")

--- a/internal/resolver/dns/dns_resolver_test.go
+++ b/internal/resolver/dns/dns_resolver_test.go
@@ -194,190 +194,190 @@ func verifyUpdateFromResolver(ctx context.Context, t *testing.T, stateCh chan re
 //   - the fourth and fifth entries will match the canarying rules, and therefore
 //     the fourth entry will be used as it will be  the first matching entry.
 const txtRecordGood = `
- [
-	 {
-		 "clientLanguage": [
-			 "CPP",
-			 "JAVA"
-		 ],
-		 "serviceConfig": {
-			 "loadBalancingPolicy": "grpclb",
-			 "methodConfig": [
-				 {
-					 "name": [
-						 {
-							 "service": "all"
-						 }
-					 ],
-					 "timeout": "1s"
-				 }
-			 ]
-		 }
-	 },
-	 {
-		 "percentage": 0,
-		 "serviceConfig": {
-			 "loadBalancingPolicy": "grpclb",
-			 "methodConfig": [
-				 {
-					 "name": [
-						 {
-							 "service": "all"
-						 }
-					 ],
-					 "timeout": "1s"
-				 }
-			 ]
-		 }
-	 },
-	 {
-		 "clientHostName": [
-			 "localhost"
-		 ],
-		 "serviceConfig": {
-			 "loadBalancingPolicy": "grpclb",
-			 "methodConfig": [
-				 {
-					 "name": [
-						 {
-							 "service": "all"
-						 }
-					 ],
-					 "timeout": "1s"
-				 }
-			 ]
-		 }
-	 },
-	 {
-		 "clientLanguage": [
-			 "GO"
-		 ],
-		 "percentage": 100,
-		 "serviceConfig": {
-			 "loadBalancingPolicy": "round_robin",
-			 "methodConfig": [
-				 {
-					 "name": [
-						 {
-							 "service": "foo"
-						 }
-					 ],
-					 "waitForReady": true,
-					 "timeout": "1s"
-				 },
-				 {
-					 "name": [
-						 {
-							 "service": "bar"
-						 }
-					 ],
-					 "waitForReady": false
-				 }
-			 ]
-		 }
-	 },
-	 {
-		 "serviceConfig": {
-			 "loadBalancingPolicy": "round_robin",
-			 "methodConfig": [
-				 {
-					 "name": [
-						 {
-							 "service": "foo",
-							 "method": "bar"
-						 }
-					 ],
-					 "waitForReady": true
-				 }
-			 ]
-		 }
-	 }
- ]`
+[
+	{
+		"clientLanguage": [
+			"CPP",
+			"JAVA"
+		],
+		"serviceConfig": {
+			"loadBalancingPolicy": "grpclb",
+			"methodConfig": [
+				{
+					"name": [
+						{
+							"service": "all"
+						}
+					],
+					"timeout": "1s"
+				}
+			]
+		}
+	},
+	{
+		"percentage": 0,
+		"serviceConfig": {
+			"loadBalancingPolicy": "grpclb",
+			"methodConfig": [
+				{
+					"name": [
+						{
+							"service": "all"
+						}
+					],
+					"timeout": "1s"
+				}
+			]
+		}
+	},
+	{
+		"clientHostName": [
+			"localhost"
+		],
+		"serviceConfig": {
+			"loadBalancingPolicy": "grpclb",
+			"methodConfig": [
+				{
+					"name": [
+						{
+							"service": "all"
+						}
+					],
+					"timeout": "1s"
+				}
+			]
+		}
+	},
+	{
+		"clientLanguage": [
+			"GO"
+		],
+		"percentage": 100,
+		"serviceConfig": {
+			"loadBalancingPolicy": "round_robin",
+			"methodConfig": [
+				{
+					"name": [
+						{
+							"service": "foo"
+						}
+					],
+					"waitForReady": true,
+					"timeout": "1s"
+				},
+				{
+					"name": [
+						{
+							"service": "bar"
+						}
+					],
+					"waitForReady": false
+				}
+			]
+		}
+	},
+	{
+		"serviceConfig": {
+			"loadBalancingPolicy": "round_robin",
+			"methodConfig": [
+				{
+					"name": [
+						{
+							"service": "foo",
+							"method": "bar"
+						}
+					],
+					"waitForReady": true
+				}
+			]
+		}
+	}
+]`
 
 // This is the matched portion of the above TXT record entry.
 const scJSON = `
- {
-	 "loadBalancingPolicy": "round_robin",
-	 "methodConfig": [
-		 {
-			 "name": [
-				 {
-					 "service": "foo"
-				 }
-			 ],
-			 "waitForReady": true,
-			 "timeout": "1s"
-		 },
-		 {
-			 "name": [
-				 {
-					 "service": "bar"
-				 }
-			 ],
-			 "waitForReady": false
-		 }
-	 ]
- }`
+{
+	"loadBalancingPolicy": "round_robin",
+	"methodConfig": [
+		{
+			"name": [
+				{
+					"service": "foo"
+				}
+			],
+			"waitForReady": true,
+			"timeout": "1s"
+		},
+		{
+			"name": [
+				{
+					"service": "bar"
+				}
+			],
+			"waitForReady": false
+		}
+	]
+}`
 
 // This service config contains three entries, but none of the match the DNS
 // resolver's canarying rules and hence the resulting service config pushed by
 // the DNS resolver will be an empty one.
 const txtRecordNonMatching = `
- [
-	 {
-		 "clientLanguage": [
-			 "CPP",
-			 "JAVA"
-		 ],
-		 "serviceConfig": {
-			 "loadBalancingPolicy": "grpclb",
-			 "methodConfig": [
-				 {
-					 "name": [
-						 {
-							 "service": "all"
-						 }
-					 ],
-					 "timeout": "1s"
-				 }
-			 ]
-		 }
-	 },
-	 {
-		 "percentage": 0,
-		 "serviceConfig": {
-			 "loadBalancingPolicy": "grpclb",
-			 "methodConfig": [
-				 {
-					 "name": [
-						 {
-							 "service": "all"
-						 }
-					 ],
-					 "timeout": "1s"
-				 }
-			 ]
-		 }
-	 },
-	 {
-		 "clientHostName": [
-			 "localhost"
-		 ],
-		 "serviceConfig": {
-			 "loadBalancingPolicy": "grpclb",
-			 "methodConfig": [
-				 {
-					 "name": [
-						 {
-							 "service": "all"
-						 }
-					 ],
-					 "timeout": "1s"
-				 }
-			 ]
-		 }
-	 }
- ]`
+[
+	{
+		"clientLanguage": [
+			"CPP",
+			"JAVA"
+		],
+		"serviceConfig": {
+			"loadBalancingPolicy": "grpclb",
+			"methodConfig": [
+				{
+					"name": [
+						{
+							"service": "all"
+						}
+					],
+					"timeout": "1s"
+				}
+			]
+		}
+	},
+	{
+		"percentage": 0,
+		"serviceConfig": {
+			"loadBalancingPolicy": "grpclb",
+			"methodConfig": [
+				{
+					"name": [
+						{
+							"service": "all"
+						}
+					],
+					"timeout": "1s"
+				}
+			]
+		}
+	},
+	{
+		"clientHostName": [
+			"localhost"
+		],
+		"serviceConfig": {
+			"loadBalancingPolicy": "grpclb",
+			"methodConfig": [
+				{
+					"name": [
+						{
+							"service": "all"
+						}
+					],
+					"timeout": "1s"
+				}
+			]
+		}
+	}
+]`
 
 // Tests the scenario where a name resolves to a list of addresses, possibly
 // some grpclb addresses as well, and a service config. The test verifies that
@@ -636,8 +636,8 @@ func (s) TestDNSResolver_ExponentialBackoff(t *testing.T) {
 func (s) TestDNSResolver_ResolveNow(t *testing.T) {
 	const target = "foo.bar.com"
 
-	overrideResolutionInterval(t, 5*time.Second)
-	//overrideTimeAfterFunc(t, 0)
+	overrideResolutionInterval(t, 0)
+	overrideTimeAfterFunc(t, 0)
 	tr := &testNetResolver{
 		hostLookupTable: map[string][]string{
 			"foo.bar.com": {"1.2.3.4", "5.6.7.8"},
@@ -653,7 +653,7 @@ func (s) TestDNSResolver_ResolveNow(t *testing.T) {
 	// Verify that the first update pushed by the resolver matches expectations.
 	wantAddrs := []resolver.Address{{Addr: "1.2.3.4" + colonDefaultPort}, {Addr: "5.6.7.8" + colonDefaultPort}}
 	wantSC := scJSON
-	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
 	verifyUpdateFromResolver(ctx, t, stateCh, wantAddrs, nil, wantSC)
 
@@ -666,13 +666,10 @@ func (s) TestDNSResolver_ResolveNow(t *testing.T) {
 
 	// Ask the resolver to re-resolve and verify that the new update matches
 	// expectations.
-	fmt.Printf("1st resolve sent %v\n", time.Now())
 	r.ResolveNow(resolver.ResolveNowOptions{})
 	wantAddrs = []resolver.Address{{Addr: "1.2.3.4" + colonDefaultPort}}
 	wantSC = `{"loadBalancingPolicy": "grpclb"}`
 	verifyUpdateFromResolver(ctx, t, stateCh, wantAddrs, nil, wantSC)
-	fmt.Printf("1st resolve completed %v\n", time.Now())
-	time.Sleep(5 * time.Second)
 
 	// Update state in the fake resolver to return no addresses and the same
 	// service config as before.
@@ -680,10 +677,8 @@ func (s) TestDNSResolver_ResolveNow(t *testing.T) {
 
 	// Ask the resolver to re-resolve and verify that the new update matches
 	// expectations.
-	fmt.Printf("2nd resolve sent %v\n", time.Now())
 	r.ResolveNow(resolver.ResolveNowOptions{})
 	verifyUpdateFromResolver(ctx, t, stateCh, nil, nil, wantSC)
-	fmt.Printf("2nd resolve completed %v\n", time.Now())
 }
 
 // Tests the case where the given name is an IP address and verifies that the

--- a/internal/resolver/dns/internal/internal.go
+++ b/internal/resolver/dns/internal/internal.go
@@ -51,10 +51,16 @@ var (
 // The following vars are overridden from tests.
 var (
 	// TimeAfterFunc is used by the DNS resolver to wait for the given duration
-	// to elapse. In non-test code, this is implemented by time.After.  In test
+	// to elapse. In non-test code, this is implemented by time.After. In test
 	// code, this can be used to control the amount of time the resolver is
 	// blocked waiting for the duration to elapse.
 	TimeAfterFunc func(time.Duration) <-chan time.Time
+
+	// TimeUntilFunc is used by the DNS resolver to get the time remaining
+	// to allow next resolution. In non-test code, this is implemented by
+	// time.Until. In test code, this can be used to control the remaining
+	// time for resolver to allow next resolution.
+	TimeUntilFunc func(time.Time) time.Duration
 
 	// NewNetResolver returns the net.Resolver instance for the given target.
 	NewNetResolver func(string) (NetResolver, error)

--- a/internal/resolver/dns/internal/internal.go
+++ b/internal/resolver/dns/internal/internal.go
@@ -56,10 +56,15 @@ var (
 	// blocked waiting for the duration to elapse.
 	TimeAfterFunc func(time.Duration) <-chan time.Time
 
-	// TimeUntilFunc is used by the DNS resolver to get the time remaining
-	// to allow next resolution. In non-test code, this is implemented by
+	// TimeNowFunc is used by the DNS resolver to get the current time.
+	// In non-test code, this is implemented by time.Now. In test code,
+	// this can be used to control the current time for the resolver.
+	TimeNowFunc func() time.Time
+
+	// TimeUntilFunc is used by the DNS resolver to calculate the remaining
+	// wait time for re-resolution. In non-test code, this is implemented by
 	// time.Until. In test code, this can be used to control the remaining
-	// time for resolver to allow next resolution.
+	// time for resolver to wait for re-resolution.
 	TimeUntilFunc func(time.Time) time.Duration
 
 	// NewNetResolver returns the net.Resolver instance for the given target.


### PR DESCRIPTION
Fixes #7186 with a test

RELEASE NOTES:

- dns: fix bug that was causing constant 30s backoff between every resolution request