### PR TITLE
alts: fix defer in test

### DIFF
--- a/credentials/alts/internal/handshaker/service/service_test.go
+++ b/credentials/alts/internal/handshaker/service/service_test.go
@@ -38,7 +38,7 @@ func TestDial(t *testing.T) {
 		return func() {
 			hsDialer = temp
 		}
-	}()
+	}()()
 
 	// First call to Dial, it should create a connection to the server running
 	// at the given address.


### PR DESCRIPTION
The first () calls the function immediately, and the second calls the returned function at the end.

Doesn't really matter here because there's just one test, but happened to find this while writing a linter for this and figured I might as well send a PR.