### PR TITLE
advancedtls: use realistic ciphersuite in test

### DIFF
--- a/security/advancedtls/advancedtls_test.go
+++ b/security/advancedtls/advancedtls_test.go
@@ -1107,7 +1107,7 @@ func (s) TestGetCertificatesSNI(t *testing.T) {
 			}
 			pointFormatUncompressed := uint8(0)
 			clientHello := &tls.ClientHelloInfo{
-				CipherSuites:      []uint16{tls.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA},
+				CipherSuites:      []uint16{tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA},
 				ServerName:        test.serverName,
 				SupportedCurves:   []tls.CurveID{tls.CurveP256},
 				SupportedPoints:   []uint8{pointFormatUncompressed},


### PR DESCRIPTION
Instead of 3DES, something which should basically never be used in production. Go is removing default support for 3DES is Go 1.24, requiring new modules to opt into support for this cipher.

This fixes an internal Google test failure, see b/343028077.

RELEASE NOTES: none