### PR TITLE
MAINTAINERS.md: add new members and move ex-members to emeritus

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -9,7 +9,6 @@ for general contribution guidelines.
 
 ## Maintainers (in alphabetical order)
 
-- [erm-g](https://github.com/erm-g), Google LLC
 - [aranjans](https://github.com/aranjans), Google LLC
 - [arjan-bal](https://github.com/arjan-bal), Google LLC
 - [arvindbr8](https://github.com/arvindbr8), Google LLC
@@ -17,6 +16,7 @@ for general contribution guidelines.
 - [cesarghali](https://github.com/cesarghali), Google LLC
 - [dfawley](https://github.com/dfawley), Google LLC
 - [easwars](https://github.com/easwars), Google LLC
+- [erm-g](https://github.com/erm-g), Google LLC
 - [gtcooke94](https://github.com/gtcooke94), Google LLC
 - [menghanl](https://github.com/menghanl), Google LLC
 - [purnesh42h](https://github.com/purnesh42h), Google LLC

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -21,16 +21,16 @@ for general contribution guidelines.
 - [zasweq](https://github.com/zasweq), Google LLC
 
 ## Emeritus Maintainers (in alphabetical order)
-- [adelez](https://github.com/adelez),
-- [canguler](https://github.com/canguler),
-- [cesarghali](https://github.com/cesarghali),
-- [iamqizhao](https://github.com/iamqizhao),
-- [jadekler](https://github.com/jadekler),
-- [jtattermusch](https://github.com/jtattermusch),
-- [lyuxuan](https://github.com/lyuxuan),
-- [makmukhi](https://github.com/makmukhi),
-- [matt-kwong](https://github.com/matt-kwong),
-- [menghanl](https://github.com/menghanl),
-- [nicolasnoble](https://github.com/nicolasnoble),
-- [yongni](https://github.com/yongni),
-- [srini100](https://github.com/srini100),
+- [adelez](https://github.com/adelez)
+- [canguler](https://github.com/canguler)
+- [cesarghali](https://github.com/cesarghali)
+- [iamqizhao](https://github.com/iamqizhao)
+- [jeanbza](https://github.com/jeanbza)
+- [jtattermusch](https://github.com/jtattermusch)
+- [lyuxuan](https://github.com/lyuxuan)
+- [makmukhi](https://github.com/makmukhi)
+- [matt-kwong](https://github.com/matt-kwong)
+- [menghanl](https://github.com/menghanl)
+- [nicolasnoble](https://github.com/nicolasnoble)
+- [srini100](https://github.com/srini100)
+- [yongni](https://github.com/yongni)

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -9,12 +9,19 @@ for general contribution guidelines.
 
 ## Maintainers (in alphabetical order)
 
+- [erm-g](https://github.com/erm-g), Google LLC
+- [aranjans](https://github.com/aranjans), Google LLC
+- [arjan-bal](https://github.com/arjan-bal), Google LLC
+- [arvindbr8](https://github.com/arvindbr8), Google LLC
 - [atollena](https://github.com/atollena), Datadog, Inc.
 - [cesarghali](https://github.com/cesarghali), Google LLC
 - [dfawley](https://github.com/dfawley), Google LLC
 - [easwars](https://github.com/easwars), Google LLC
+- [gtcooke94](https://github.com/gtcooke94), Google LLC
 - [menghanl](https://github.com/menghanl), Google LLC
+- [purnesh42h](https://github.com/purnesh42h), Google LLC
 - [srini100](https://github.com/srini100), Google LLC
+- [zasweq](https://github.com/zasweq), Google LLC
 
 ## Emeritus Maintainers (in alphabetical order)
 - [adelez](https://github.com/adelez), Google LLC

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -13,24 +13,24 @@ for general contribution guidelines.
 - [arjan-bal](https://github.com/arjan-bal), Google LLC
 - [arvindbr8](https://github.com/arvindbr8), Google LLC
 - [atollena](https://github.com/atollena), Datadog, Inc.
-- [cesarghali](https://github.com/cesarghali), Google LLC
 - [dfawley](https://github.com/dfawley), Google LLC
 - [easwars](https://github.com/easwars), Google LLC
 - [erm-g](https://github.com/erm-g), Google LLC
 - [gtcooke94](https://github.com/gtcooke94), Google LLC
-- [menghanl](https://github.com/menghanl), Google LLC
 - [purnesh42h](https://github.com/purnesh42h), Google LLC
-- [srini100](https://github.com/srini100), Google LLC
 - [zasweq](https://github.com/zasweq), Google LLC
 
 ## Emeritus Maintainers (in alphabetical order)
-- [adelez](https://github.com/adelez), Google LLC
-- [canguler](https://github.com/canguler), Google LLC
-- [iamqizhao](https://github.com/iamqizhao), Google LLC
-- [jadekler](https://github.com/jadekler), Google LLC
-- [jtattermusch](https://github.com/jtattermusch), Google LLC
-- [lyuxuan](https://github.com/lyuxuan), Google LLC
-- [makmukhi](https://github.com/makmukhi), Google LLC
-- [matt-kwong](https://github.com/matt-kwong), Google LLC
-- [nicolasnoble](https://github.com/nicolasnoble), Google LLC
-- [yongni](https://github.com/yongni), Google LLC
+- [adelez](https://github.com/adelez),
+- [canguler](https://github.com/canguler),
+- [cesarghali](https://github.com/cesarghali),
+- [iamqizhao](https://github.com/iamqizhao),
+- [jadekler](https://github.com/jadekler),
+- [jtattermusch](https://github.com/jtattermusch),
+- [lyuxuan](https://github.com/lyuxuan),
+- [makmukhi](https://github.com/makmukhi),
+- [matt-kwong](https://github.com/matt-kwong),
+- [menghanl](https://github.com/menghanl),
+- [nicolasnoble](https://github.com/nicolasnoble),
+- [yongni](https://github.com/yongni),
+- [srini100](https://github.com/srini100),


### PR DESCRIPTION
[vote] Added Arvind, Arjan, Abhishek, Purnesh, Gregory Cooke, Andrey Ermolov, Zach Reyes into grpc-go active maintainers list.
Removed @cesarghali, @menghanl, @srini100 from active maintainers list and moved them to emeritus. Updated GitHub handle of @jeanbza . Removed org for emeritus list.
Please comment as "Agree" if you agree to the change, if not please comment as "Disagree". Your comment will be counted as a vote.
The PR needs to stay open for 14 days, I.e. till 14th June 2024 as per governance guidelines

RELEASE NOTES: none