### PR TITLE
xds: cleanup bootstrap processing functionality

### DIFF
--- a/internal/testutils/xds/bootstrap/bootstrap.go
+++ b/internal/testutils/xds/bootstrap/bootstrap.go
@@ -111,7 +111,6 @@ func Contents(opts Options) ([]byte, error) {
 		ClientDefaultListenerResourceNameTemplate: opts.ClientDefaultListenerResourceNameTemplate,
 		ServerListenerResourceNameTemplate:        opts.ServerListenerResourceNameTemplate,
 	}
-	cfg.XdsServers[0].ServerFeatures = append(cfg.XdsServers[0].ServerFeatures, "xds_v3")
 	if opts.IgnoreResourceDeletion {
 		cfg.XdsServers[0].ServerFeatures = append(cfg.XdsServers[0].ServerFeatures, "ignore_resource_deletion")
 	}

--- a/internal/testutils/xds/e2e/setup_management_server.go
+++ b/internal/testutils/xds/e2e/setup_management_server.go
@@ -57,7 +57,7 @@ func SetupManagementServer(t *testing.T, opts ManagementServerOptions) (*Managem
 	}()
 
 	nodeID := uuid.New().String()
-	bootstrapContents, err := DefaultBootstrapContents(nodeID, server.Address)
+	bootstrapContents, err := DefaultBootstrapContents(nodeID, fmt.Sprintf("passthrough:///%s", server.Address))
 	if err != nil {
 		server.Stop()
 		t.Fatal(err)

--- a/internal/xds/bootstrap/bootstrap.go
+++ b/internal/xds/bootstrap/bootstrap.go
@@ -36,10 +36,10 @@ import (
 	"google.golang.org/grpc/internal/envconfig"
 	"google.golang.org/grpc/internal/pretty"
 	"google.golang.org/grpc/xds/bootstrap"
-
-	v3corepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/structpb"
+
+	v3corepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 )
 
 const (
@@ -154,15 +154,15 @@ func (sc *ServerConfig) ServerFeatures() []string {
 	return sc.serverFeatures
 }
 
-// IgnoreResourceDeletion returns true if this server supports a feature where
-// the xDS client can ignore resource deletions from this server, as described
-// in gRFC A53.
+// ServerFeaturesIgnoreResourceDeletion returns true if this server supports a
+// feature where the xDS client can ignore resource deletions from this server,
+// as described in gRFC A53.
 //
 // This feature controls the behavior of the xDS client when the server deletes
 // a previously sent Listener or Cluster resource. If set, the xDS client will
 // not invoke the watchers' OnResourceDoesNotExist() method when a resource is
 // deleted, nor will it remove the existing resource value from its cache.
-func (sc *ServerConfig) IgnoreResourceDeletion() bool {
+func (sc *ServerConfig) ServerFeaturesIgnoreResourceDeletion() bool {
 	for _, sf := range sc.serverFeatures {
 		if sf == serverFeaturesIgnoreResourceDeletion {
 			return true
@@ -238,7 +238,7 @@ func (sc *ServerConfig) MarshalJSON() ([]byte, error) {
 func (sc *ServerConfig) UnmarshalJSON(data []byte) error {
 	server := serverConfigJSON{}
 	if err := json.Unmarshal(data, &server); err != nil {
-		return fmt.Errorf("xds: json.Unmarshal(%s) for server configuration failed during bootstrap: %v", string(data), err)
+		return fmt.Errorf("xds: failed to JSON unmarshal server configuration during bootstrap: %v, config:\n%s", err, string(data))
 	}
 
 	sc.serverURI = server.ServerURI

--- a/internal/xds/bootstrap/bootstrap.go
+++ b/internal/xds/bootstrap/bootstrap.go
@@ -418,6 +418,14 @@ func NewConfigFromContents(data []byte) (*Config, error) {
 }
 
 func newConfigFromContents(data []byte) (*Config, error) {
+	// Normalize the input configuration.
+	buf := bytes.Buffer{}
+	err := json.Indent(&buf, data, "", "")
+	if err != nil {
+		return nil, fmt.Errorf("xds: error normalizing JSON bootstrap configuration: %v", err)
+	}
+	data = bytes.TrimSpace(buf.Bytes())
+
 	config := &Config{}
 
 	var jsonData map[string]json.RawMessage

--- a/internal/xds/bootstrap/bootstrap.go
+++ b/internal/xds/bootstrap/bootstrap.go
@@ -24,8 +24,10 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"net/url"
 	"os"
+	"slices"
 	"strings"
 
 	"google.golang.org/grpc"
@@ -34,25 +36,17 @@ import (
 	"google.golang.org/grpc/internal/envconfig"
 	"google.golang.org/grpc/internal/pretty"
 	"google.golang.org/grpc/xds/bootstrap"
-	"google.golang.org/protobuf/encoding/protojson"
 
 	v3corepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 const (
-	// The "server_features" field in the bootstrap file contains a list of
-	// features supported by the server:
-	// - A value of "xds_v3" indicates that the server supports the v3 version of
-	//   the xDS transport protocol.
-	// - A value of "ignore_resource_deletion" indicates that the client should
-	//   ignore deletion of Listener and Cluster resources in updates from the
-	//   server.
-	serverFeaturesV3                     = "xds_v3"
 	serverFeaturesIgnoreResourceDeletion = "ignore_resource_deletion"
-
-	gRPCUserAgentName               = "gRPC Go"
-	clientFeatureNoOverprovisioning = "envoy.lb.does_not_support_overprovisioning"
-	clientFeatureResourceWrapper    = "xds.config.resource-in-sotw"
+	gRPCUserAgentName                    = "gRPC Go"
+	clientFeatureNoOverprovisioning      = "envoy.lb.does_not_support_overprovisioning"
+	clientFeatureResourceWrapper         = "xds.config.resource-in-sotw"
 )
 
 // For overriding in unit tests.
@@ -60,12 +54,15 @@ var bootstrapFileReadFunc = os.ReadFile
 
 // ChannelCreds contains the credentials to be used while communicating with an
 // xDS server. It is also used to dedup servers with the same server URI.
+//
+// This type does not implement custom JSON marshal/unmarshal logic because it
+// is straightforward to accomplish the same with json struct tags.
 type ChannelCreds struct {
 	// Type contains a unique name identifying the credentials type. The only
 	// supported types currently are "google_default" and "insecure".
-	Type string
+	Type string `json:"type,omitempty"`
 	// Config contains the JSON configuration associated with the credentials.
-	Config json.RawMessage
+	Config json.RawMessage `json:"config,omitempty"`
 }
 
 // Equal reports whether cc and other are considered equal.
@@ -87,164 +84,10 @@ func (cc ChannelCreds) String() string {
 	return cc.Type + "-" + string(b)
 }
 
-// ServerConfig contains the configuration to connect to a server, including
-// URI, creds, and transport API version (e.g. v2 or v3).
+// Authority contains configuration for an xDS control plane authority.
 //
-// It contains unexported fields that are initialized when unmarshaled from JSON
-// using either the UnmarshalJSON() method or the ServerConfigFromJSON()
-// function. Hence users are strongly encouraged not to use a literal struct
-// initialization to create an instance of this type, but instead unmarshal from
-// JSON using one of the two available options.
-type ServerConfig struct {
-	// ServerURI is the management server to connect to.
-	//
-	// The bootstrap file contains an ordered list of xDS servers to contact for
-	// this authority. The first one is picked.
-	ServerURI string
-	// Creds contains the credentials to be used while communicationg with this
-	// xDS server. It is also used to dedup servers with the same server URI.
-	Creds ChannelCreds
-	// ServerFeatures contains a list of features supported by this xDS server.
-	// It is also used to dedup servers with the same server URI and creds.
-	ServerFeatures []string
-
-	// As part of unmarshalling the JSON config into this struct, we ensure that
-	// the credentials config is valid by building an instance of the specified
-	// credentials and store it here as a grpc.DialOption for easy access when
-	// dialing this xDS server.
-	credsDialOption grpc.DialOption
-
-	// IgnoreResourceDeletion controls the behavior of the xDS client when the
-	// server deletes a previously sent Listener or Cluster resource. If set, the
-	// xDS client will not invoke the watchers' OnResourceDoesNotExist() method
-	// when a resource is deleted, nor will it remove the existing resource value
-	// from its cache.
-	IgnoreResourceDeletion bool
-
-	// Cleanups are called when the xDS client for this server is closed. Allows
-	// cleaning up resources created specifically for this ServerConfig.
-	Cleanups []func()
-}
-
-// CredsDialOption returns the configured credentials as a grpc dial option.
-func (sc *ServerConfig) CredsDialOption() grpc.DialOption {
-	return sc.credsDialOption
-}
-
-// String returns the string representation of the ServerConfig.
-//
-// This string representation will be used as map keys in federation
-// (`map[ServerConfig]authority`), so that the xDS ClientConn and stream will be
-// shared by authorities with different names but the same server config.
-//
-// It covers (almost) all the fields so the string can represent the config
-// content. It doesn't cover NodeProto because NodeProto isn't used by
-// federation.
-func (sc *ServerConfig) String() string {
-	features := strings.Join(sc.ServerFeatures, "-")
-	return strings.Join([]string{sc.ServerURI, sc.Creds.String(), features}, "-")
-}
-
-// MarshalJSON marshals the ServerConfig to json.
-func (sc ServerConfig) MarshalJSON() ([]byte, error) {
-	server := xdsServer{
-		ServerURI:      sc.ServerURI,
-		ChannelCreds:   []channelCreds{{Type: sc.Creds.Type, Config: sc.Creds.Config}},
-		ServerFeatures: sc.ServerFeatures,
-	}
-	server.ServerFeatures = []string{serverFeaturesV3}
-	if sc.IgnoreResourceDeletion {
-		server.ServerFeatures = append(server.ServerFeatures, serverFeaturesIgnoreResourceDeletion)
-	}
-	return json.Marshal(server)
-}
-
-// UnmarshalJSON takes the json data (a server) and unmarshals it to the struct.
-func (sc *ServerConfig) UnmarshalJSON(data []byte) error {
-	var server xdsServer
-	if err := json.Unmarshal(data, &server); err != nil {
-		return fmt.Errorf("xds: json.Unmarshal(data) for field ServerConfig failed during bootstrap: %v", err)
-	}
-
-	sc.ServerURI = server.ServerURI
-	sc.ServerFeatures = server.ServerFeatures
-	for _, f := range server.ServerFeatures {
-		if f == serverFeaturesIgnoreResourceDeletion {
-			sc.IgnoreResourceDeletion = true
-		}
-	}
-	for _, cc := range server.ChannelCreds {
-		// We stop at the first credential type that we support.
-		c := bootstrap.GetCredentials(cc.Type)
-		if c == nil {
-			continue
-		}
-		bundle, cancel, err := c.Build(cc.Config)
-		if err != nil {
-			return fmt.Errorf("failed to build credentials bundle from bootstrap for %q: %v", cc.Type, err)
-		}
-		sc.Creds = ChannelCreds(cc)
-		sc.credsDialOption = grpc.WithCredentialsBundle(bundle)
-		sc.Cleanups = append(sc.Cleanups, cancel)
-		break
-	}
-	return nil
-}
-
-// ServerConfigFromJSON creates a new ServerConfig from the given JSON
-// configuration. This is the preferred way of creating a ServerConfig when
-// hand-crafting the JSON configuration.
-func ServerConfigFromJSON(data []byte) (*ServerConfig, error) {
-	sc := new(ServerConfig)
-	if err := sc.UnmarshalJSON(data); err != nil {
-		return nil, err
-	}
-	return sc, nil
-}
-
-// Equal reports whether sc and other are considered equal.
-func (sc *ServerConfig) Equal(other *ServerConfig) bool {
-	switch {
-	case sc == nil && other == nil:
-		return true
-	case (sc != nil) != (other != nil):
-		return false
-	case sc.ServerURI != other.ServerURI:
-		return false
-	case !sc.Creds.Equal(other.Creds):
-		return false
-	case !equalStringSlice(sc.ServerFeatures, other.ServerFeatures):
-		return false
-	}
-	return true
-}
-
-func equalStringSlice(a, b []string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
-}
-
-// unmarshalJSONServerConfigSlice unmarshals JSON to a slice.
-func unmarshalJSONServerConfigSlice(data []byte) ([]*ServerConfig, error) {
-	var servers []*ServerConfig
-	if err := json.Unmarshal(data, &servers); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal JSON to []*ServerConfig: %v", err)
-	}
-	if len(servers) < 1 {
-		return nil, fmt.Errorf("no management server found in JSON")
-	}
-	return servers, nil
-}
-
-// Authority contains configuration for an Authority for an xDS control plane
-// server. See the Authorities field in the Config struct for how it's used.
+// This type does not implement custom JSON marshal/unmarshal logic because it
+// is straightforward to accomplish the same with json struct tags.
 type Authority struct {
 	// ClientListenerResourceNameTemplate is template for the name of the
 	// Listener resource to subscribe to for a gRPC client channel.  Used only
@@ -259,123 +102,413 @@ type Authority struct {
 	//
 	// If not present in the bootstrap file, defaults to
 	// "xdstp://<authority_name>/envoy.config.listener.v3.Listener/%s".
-	ClientListenerResourceNameTemplate string
-	// XDSServer contains the management server and config to connect to for
-	// this authority.
-	XDSServer *ServerConfig
+	ClientListenerResourceNameTemplate string `json:"client_listener_resource_name_template,omitempty"`
+	// XDSServers contains the list of server configurations for this authority.
+	XDSServers []*ServerConfig `json:"xds_servers,omitempty"`
 }
 
-// UnmarshalJSON implement json unmarshaller.
-func (a *Authority) UnmarshalJSON(data []byte) error {
-	var jsonData map[string]json.RawMessage
-	if err := json.Unmarshal(data, &jsonData); err != nil {
-		return fmt.Errorf("xds: failed to parse authority: %v", err)
+// Equal returns true if a equals other.
+func (a *Authority) Equal(other *Authority) bool {
+	switch {
+	case a == nil && other == nil:
+		return true
+	case (a != nil) != (other != nil):
+		return false
+	case a.ClientListenerResourceNameTemplate != other.ClientListenerResourceNameTemplate:
+		return false
+	case !slices.EqualFunc(a.XDSServers, other.XDSServers, func(a, b *ServerConfig) bool { return a.Equal(b) }):
+		return false
+	}
+	return true
+}
+
+// ServerConfig contains the configuration to connect to a server.
+type ServerConfig struct {
+	serverURI      string
+	channelCreds   []ChannelCreds
+	serverFeatures []string
+
+	// As part of unmarshalling the JSON config into this struct, we ensure that
+	// the credentials config is valid by building an instance of the specified
+	// credentials and store it here for easy access.
+	selectedCreds   ChannelCreds
+	credsDialOption grpc.DialOption
+
+	cleanups []func()
+}
+
+// ServerURI returns the URI of the management server to connect to.
+func (sc *ServerConfig) ServerURI() string {
+	return sc.serverURI
+}
+
+// ChannelCreds returns the credentials configuration to use when communicating
+// with this server. Also used to dedup servers with the same server URI.
+func (sc *ServerConfig) ChannelCreds() []ChannelCreds {
+	return sc.channelCreds
+}
+
+// ServerFeatures returns the list of features supported by this server. Also
+// used to dedup servers with the same server URI and channel creds.
+func (sc *ServerConfig) ServerFeatures() []string {
+	return sc.serverFeatures
+}
+
+// IgnoreResourceDeletion returns true if this server supports a feature where
+// the xDS client can ignore resource deletions from this server, as described
+// in gRFC A53.
+//
+// This feature controls the behavior of the xDS client when the server deletes
+// a previously sent Listener or Cluster resource. If set, the xDS client will
+// not invoke the watchers' OnResourceDoesNotExist() method when a resource is
+// deleted, nor will it remove the existing resource value from its cache.
+func (sc *ServerConfig) IgnoreResourceDeletion() bool {
+	for _, sf := range sc.serverFeatures {
+		if sf == serverFeaturesIgnoreResourceDeletion {
+			return true
+		}
+	}
+	return false
+}
+
+// CredsDialOption returns the first supported transport credentials from the
+// configuration, as a dial option.
+func (sc *ServerConfig) CredsDialOption() grpc.DialOption {
+	return sc.credsDialOption
+}
+
+// Cleanups returns a collection of functions to be called when the xDS client
+// for this server is closed. Allows cleaning up resources created specifically
+// for this server.
+func (sc *ServerConfig) Cleanups() []func() {
+	return sc.cleanups
+}
+
+// Equal reports whether sc and other are considered equal.
+func (sc *ServerConfig) Equal(other *ServerConfig) bool {
+	switch {
+	case sc == nil && other == nil:
+		return true
+	case (sc != nil) != (other != nil):
+		return false
+	case sc.serverURI != other.serverURI:
+		return false
+	case !slices.EqualFunc(sc.channelCreds, other.channelCreds, func(a, b ChannelCreds) bool { return a.Equal(b) }):
+		return false
+	case !slices.Equal(sc.serverFeatures, other.serverFeatures):
+		return false
+	case !sc.selectedCreds.Equal(other.selectedCreds):
+		return false
+	}
+	return true
+}
+
+// String returns the string representation of the ServerConfig.
+//
+// This string representation will be used as map keys in federation
+// (`map[ServerConfig]authority`), so that the xDS ClientConn and stream will be
+// shared by authorities with different names but the same server config.
+//
+// It covers (almost) all the fields so the string can represent the config
+// content. It doesn't cover NodeProto because NodeProto isn't used by
+// federation.
+func (sc *ServerConfig) String() string {
+	features := strings.Join(sc.serverFeatures, "-")
+	return strings.Join([]string{sc.serverURI, sc.selectedCreds.String(), features}, "-")
+}
+
+// The following fields correspond 1:1 with the JSON schema for ServerConfig.
+type serverConfigJSON struct {
+	ServerURI      string         `json:"server_uri"`
+	ChannelCreds   []ChannelCreds `json:"channel_creds"`
+	ServerFeatures []string       `json:"server_features"`
+}
+
+// MarshalJSON returns marshaled JSON bytes corresponding to this server config.
+func (sc *ServerConfig) MarshalJSON() ([]byte, error) {
+	server := &serverConfigJSON{
+		ServerURI:      sc.serverURI,
+		ChannelCreds:   sc.channelCreds,
+		ServerFeatures: sc.serverFeatures,
+	}
+	return json.Marshal(server)
+}
+
+// UnmarshalJSON takes the json data (a server) and unmarshals it to the struct.
+func (sc *ServerConfig) UnmarshalJSON(data []byte) error {
+	server := serverConfigJSON{}
+	if err := json.Unmarshal(data, &server); err != nil {
+		return fmt.Errorf("xds: json.Unmarshal(%s) for server configuration failed during bootstrap: %v", string(data), err)
 	}
 
-	for k, v := range jsonData {
-		switch k {
-		case "xds_servers":
-			servers, err := unmarshalJSONServerConfigSlice(v)
-			if err != nil {
-				return fmt.Errorf("xds: json.Unmarshal(data) for field %q failed during bootstrap: %v", k, err)
-			}
-			a.XDSServer = servers[0]
-		case "client_listener_resource_name_template":
-			if err := json.Unmarshal(v, &a.ClientListenerResourceNameTemplate); err != nil {
-				return fmt.Errorf("xds: json.Unmarshal(%v) for field %q failed during bootstrap: %v", string(v), k, err)
-			}
+	sc.serverURI = server.ServerURI
+	sc.channelCreds = server.ChannelCreds
+	sc.serverFeatures = server.ServerFeatures
+
+	for _, cc := range server.ChannelCreds {
+		// We stop at the first credential type that we support.
+		c := bootstrap.GetCredentials(cc.Type)
+		if c == nil {
+			continue
+		}
+		bundle, cancel, err := c.Build(cc.Config)
+		if err != nil {
+			return fmt.Errorf("failed to build credentials bundle from bootstrap for %q: %v", cc.Type, err)
+		}
+		sc.selectedCreds = cc
+		sc.credsDialOption = grpc.WithCredentialsBundle(bundle)
+		sc.cleanups = append(sc.cleanups, cancel)
+		break
+	}
+	if sc.serverURI == "" {
+		return fmt.Errorf("xds: `server_uri` field in server config cannot be empty: %s", string(data))
+	}
+	if sc.credsDialOption == nil {
+		return fmt.Errorf("xds: `channel_creds` field in server config cannot be empty: %s", string(data))
+	}
+	return nil
+}
+
+// ServerConfigTestingOptions specifies options for creating a new ServerConfig
+// for testing purposes.
+//
+// # Testing-Only
+type ServerConfigTestingOptions struct {
+	// URI is the name of the server corresponding to this server config.
+	URI string
+	// ChannelCreds contains a list of channel credentials to use when talking
+	// to this server. If unspecified, `insecure` credentials will be used.
+	ChannelCreds []ChannelCreds
+	// ServerFeatures represents the list of features supported by this server.
+	ServerFeatures []string
+}
+
+// ServerConfigForTesting creates a new ServerConfig from the passed in options,
+// for testing purposes.
+//
+// # Testing-Only
+func ServerConfigForTesting(opts ServerConfigTestingOptions) (*ServerConfig, error) {
+	cc := opts.ChannelCreds
+	if cc == nil {
+		cc = []ChannelCreds{{Type: "insecure"}}
+	}
+	scInternal := &serverConfigJSON{
+		ServerURI:      opts.URI,
+		ChannelCreds:   cc,
+		ServerFeatures: opts.ServerFeatures,
+	}
+	scJSON, err := json.Marshal(scInternal)
+	if err != nil {
+		return nil, err
+	}
+
+	sc := new(ServerConfig)
+	if err := sc.UnmarshalJSON(scJSON); err != nil {
+		return nil, err
+	}
+	return sc, nil
+}
+
+// Config is the internal representation of the bootstrap configuration provided
+// to the xDS client.
+type Config struct {
+	xDSServers                                []*ServerConfig
+	cpcs                                      map[string]certproviderNameAndConfig
+	serverListenerResourceNameTemplate        string
+	clientDefaultListenerResourceNameTemplate string
+	authorities                               map[string]*Authority
+	node                                      node
+
+	// A map from certprovider instance names to parsed buildable configs.
+	certProviderConfigs map[string]*certprovider.BuildableConfig
+}
+
+// XDSServers returns the top-level list of management servers to connect to,
+// ordered by priority.
+func (c *Config) XDSServers() []*ServerConfig {
+	return c.xDSServers
+}
+
+// CertProviderConfigs returns a map from certificate provider plugin instance
+// name to their configuration. Callers must not modify the returned map.
+func (c *Config) CertProviderConfigs() map[string]*certprovider.BuildableConfig {
+	return c.certProviderConfigs
+}
+
+// ServerListenerResourceNameTemplate returns template for the name of the
+// Listener resource to subscribe to for a gRPC server.
+//
+// If starts with "xdstp:", will be interpreted as a new-style name,
+// in which case the authority of the URI will be used to select the
+// relevant configuration in the "authorities" map.
+//
+// The token "%s", if present in this string, will be replaced with the IP
+// and port on which the server is listening.  (e.g., "0.0.0.0:8080",
+// "[::]:8080"). For example, a value of "example/resource/%s" could become
+// "example/resource/0.0.0.0:8080". If the template starts with "xdstp:",
+// the replaced string will be %-encoded.
+//
+// There is no default; if unset, xDS-based server creation fails.
+func (c *Config) ServerListenerResourceNameTemplate() string {
+	return c.serverListenerResourceNameTemplate
+}
+
+// ClientDefaultListenerResourceNameTemplate returns a template for the name of
+// the Listener resource to subscribe to for a gRPC client channel.  Used only
+// when the channel is created with an "xds:" URI with no authority.
+//
+// If starts with "xdstp:", will be interpreted as a new-style name,
+// in which case the authority of the URI will be used to select the
+// relevant configuration in the "authorities" map.
+//
+// The token "%s", if present in this string, will be replaced with
+// the service authority (i.e., the path part of the target URI
+// used to create the gRPC channel).  If the template starts with
+// "xdstp:", the replaced string will be %-encoded.
+//
+// Defaults to "%s".
+func (c *Config) ClientDefaultListenerResourceNameTemplate() string {
+	return c.clientDefaultListenerResourceNameTemplate
+}
+
+// Authorities returns a map of authority name to corresponding configuration.
+// Callers must not modify the returned map.
+//
+// This is used in the following cases:
+//   - A gRPC client channel is created using an "xds:" URI that includes
+//     an authority.
+//   - A gRPC client channel is created using an "xds:" URI with no
+//     authority, but the "client_default_listener_resource_name_template"
+//     field above turns it into an "xdstp:" URI.
+//   - A gRPC server is created and the
+//     "server_listener_resource_name_template" field is an "xdstp:" URI.
+//
+// In any of those cases, it is an error if the specified authority is
+// not present in this map.
+func (c *Config) Authorities() map[string]*Authority {
+	return c.authorities
+}
+
+// Node returns xDS a v3 Node proto corresponding to the node field in the
+// bootstrap configuration, which identifies a specific gRPC instance.
+func (c *Config) Node() *v3corepb.Node {
+	return c.node.toProto()
+}
+
+// Equal returns true if c equals other.
+func (c *Config) Equal(other *Config) bool {
+	switch {
+	case c == nil && other == nil:
+		return true
+	case (c != nil) != (other != nil):
+		return false
+	case !slices.EqualFunc(c.xDSServers, other.xDSServers, func(a, b *ServerConfig) bool { return a.Equal(b) }):
+		return false
+	case !maps.EqualFunc(c.certProviderConfigs, other.certProviderConfigs, func(a, b *certprovider.BuildableConfig) bool { return a.String() == b.String() }):
+		return false
+	case c.serverListenerResourceNameTemplate != other.serverListenerResourceNameTemplate:
+		return false
+	case c.clientDefaultListenerResourceNameTemplate != other.clientDefaultListenerResourceNameTemplate:
+		return false
+	case !maps.EqualFunc(c.authorities, other.authorities, func(a, b *Authority) bool { return a.Equal(b) }):
+		return false
+	case !c.node.Equal(other.node):
+		return false
+	}
+	return true
+}
+
+// The following fields correspond 1:1 with the JSON schema for Config.
+type configJSON struct {
+	XDSServers                                []*ServerConfig                      `json:"xds_servers,omitempty"`
+	CertificateProviders                      map[string]certproviderNameAndConfig `json:"certificate_providers,omitempty"`
+	ServerListenerResourceNameTemplate        string                               `json:"server_listener_resource_name_template,omitempty"`
+	ClientDefaultListenerResourceNameTemplate string                               `json:"client_default_listener_resource_name_template,omitempty"`
+	Authorities                               map[string]*Authority                `json:"authorities,omitempty"`
+	Node                                      node                                 `json:"node,omitempty"`
+}
+
+// MarshalJSON returns marshaled JSON bytes corresponding to this config.
+func (c *Config) MarshalJSON() ([]byte, error) {
+	config := &configJSON{
+		XDSServers:                                c.xDSServers,
+		CertificateProviders:                      c.cpcs,
+		ServerListenerResourceNameTemplate:        c.serverListenerResourceNameTemplate,
+		ClientDefaultListenerResourceNameTemplate: c.clientDefaultListenerResourceNameTemplate,
+		Authorities:                               c.authorities,
+		Node:                                      c.node,
+	}
+	return json.Marshal(config)
+}
+
+// UnmarshalJSON takes the json data (the complete bootstrap configuration) and
+// unmarshals it to the struct.
+func (c *Config) UnmarshalJSON(data []byte) error {
+	// Initialize the node field with client controlled values. This ensures
+	// even if the bootstrap configuration did not contain the node field, we
+	// will have a node field with client controlled fields alone.
+	config := configJSON{Node: newNode()}
+	if err := json.Unmarshal(data, &config); err != nil {
+		return fmt.Errorf("xds: json.Unmarshal(%s) failed during bootstrap: %v", string(data), err)
+	}
+
+	c.xDSServers = config.XDSServers
+	c.cpcs = config.CertificateProviders
+	c.serverListenerResourceNameTemplate = config.ServerListenerResourceNameTemplate
+	c.clientDefaultListenerResourceNameTemplate = config.ClientDefaultListenerResourceNameTemplate
+	c.authorities = config.Authorities
+	c.node = config.Node
+
+	// Build the certificate providers configuration to ensure that it is valid.
+	cpcCfgs := make(map[string]*certprovider.BuildableConfig)
+	getBuilder := internal.GetCertificateProviderBuilder.(func(string) certprovider.Builder)
+	for instance, nameAndConfig := range c.cpcs {
+		name := nameAndConfig.PluginName
+		parser := getBuilder(nameAndConfig.PluginName)
+		if parser == nil {
+			// We ignore plugins that we do not know about.
+			continue
+		}
+		bc, err := parser.ParseConfig(nameAndConfig.Config)
+		if err != nil {
+			return fmt.Errorf("xds: config parsing for certifcate provider plugin %q failed during bootstrap: %v", name, err)
+		}
+		cpcCfgs[instance] = bc
+	}
+	c.certProviderConfigs = cpcCfgs
+
+	// Default value of the default client listener name template is "%s".
+	if c.clientDefaultListenerResourceNameTemplate == "" {
+		c.clientDefaultListenerResourceNameTemplate = "%s"
+	}
+	if len(c.xDSServers) == 0 {
+		return fmt.Errorf("xds: required field `xds_servers` not found in bootstrap configuration: %s", string(data))
+	}
+
+	// Post-process the authorities' client listener resource template field:
+	// - if set, it must start with "xdstp://<authority_name>/"
+	// - if not set, it defaults to "xdstp://<authority_name>/envoy.config.listener.v3.Listener/%s"
+	for name, authority := range c.authorities {
+		prefix := fmt.Sprintf("xdstp://%s", url.PathEscape(name))
+		if authority.ClientListenerResourceNameTemplate == "" {
+			authority.ClientListenerResourceNameTemplate = prefix + "/envoy.config.listener.v3.Listener/%s"
+			continue
+		}
+		if !strings.HasPrefix(authority.ClientListenerResourceNameTemplate, prefix) {
+			return fmt.Errorf("xds: field clientListenerResourceNameTemplate %q of authority %q doesn't start with prefix %q", authority.ClientListenerResourceNameTemplate, name, prefix)
 		}
 	}
 	return nil
 }
 
-// Config provides the xDS client with several key bits of information that it
-// requires in its interaction with the management server. The Config is
-// initialized from the bootstrap file.
-//
-// Users must use one of the NewConfigXxx() functions to create a Config
-// instance, and not initialize it manually.
-type Config struct {
-	// XDSServer is the management server to connect to.
-	//
-	// The bootstrap file contains a list of servers (with name+creds), but we
-	// pick the first one.
-	XDSServer *ServerConfig
-	// CertProviderConfigs contains a mapping from certificate provider plugin
-	// instance names to parsed buildable configs.
-	CertProviderConfigs map[string]*certprovider.BuildableConfig
-	// ServerListenerResourceNameTemplate is a template for the name of the
-	// Listener resource to subscribe to for a gRPC server.
-	//
-	// If starts with "xdstp:", will be interpreted as a new-style name,
-	// in which case the authority of the URI will be used to select the
-	// relevant configuration in the "authorities" map.
-	//
-	// The token "%s", if present in this string, will be replaced with the IP
-	// and port on which the server is listening.  (e.g., "0.0.0.0:8080",
-	// "[::]:8080"). For example, a value of "example/resource/%s" could become
-	// "example/resource/0.0.0.0:8080". If the template starts with "xdstp:",
-	// the replaced string will be %-encoded.
-	//
-	// There is no default; if unset, xDS-based server creation fails.
-	ServerListenerResourceNameTemplate string
-	// A template for the name of the Listener resource to subscribe to
-	// for a gRPC client channel.  Used only when the channel is created
-	// with an "xds:" URI with no authority.
-	//
-	// If starts with "xdstp:", will be interpreted as a new-style name,
-	// in which case the authority of the URI will be used to select the
-	// relevant configuration in the "authorities" map.
-	//
-	// The token "%s", if present in this string, will be replaced with
-	// the service authority (i.e., the path part of the target URI
-	// used to create the gRPC channel).  If the template starts with
-	// "xdstp:", the replaced string will be %-encoded.
-	//
-	// Defaults to "%s".
-	ClientDefaultListenerResourceNameTemplate string
-	// Authorities is a map of authority name to corresponding configuration.
-	//
-	// This is used in the following cases:
-	// - A gRPC client channel is created using an "xds:" URI that includes
-	//   an authority.
-	// - A gRPC client channel is created using an "xds:" URI with no
-	//   authority, but the "client_default_listener_resource_name_template"
-	//   field above turns it into an "xdstp:" URI.
-	// - A gRPC server is created and the
-	//   "server_listener_resource_name_template" field is an "xdstp:" URI.
-	//
-	// In any of those cases, it is an error if the specified authority is
-	// not present in this map.
-	Authorities map[string]*Authority
-	// NodeProto contains the Node proto to be used in xDS requests. This will be
-	// of type *v3corepb.Node.
-	NodeProto *v3corepb.Node
-}
-
-type channelCreds struct {
-	Type   string          `json:"type"`
-	Config json.RawMessage `json:"config,omitempty"`
-}
-
-type xdsServer struct {
-	ServerURI      string         `json:"server_uri"`
-	ChannelCreds   []channelCreds `json:"channel_creds"`
-	ServerFeatures []string       `json:"server_features"`
-}
-
+// Returns the bootstrap configuration from env vars ${GRPC_XDS_BOOTSTRAP} or
+// ${GRPC_XDS_BOOTSTRAP_CONFIG}. If both env vars are set, the former is
+// preferred. And if none of the env vars are set, an error is returned.
 func bootstrapConfigFromEnvVariable() ([]byte, error) {
 	fName := envconfig.XDSBootstrapFileName
 	fContent := envconfig.XDSBootstrapFileContent
 
-	// Bootstrap file name has higher priority than bootstrap content.
 	if fName != "" {
-		// If file name is set
-		// - If file not found (or other errors), fail
-		// - Otherwise, use the content.
-		//
-		// Note that even if the content is invalid, we don't failover to the
-		// file content env variable.
 		logger.Debugf("Using bootstrap file with name %q", fName)
 		return bootstrapFileReadFunc(fName)
 	}
@@ -384,8 +517,7 @@ func bootstrapConfigFromEnvVariable() ([]byte, error) {
 		return []byte(fContent), nil
 	}
 
-	return nil, fmt.Errorf("none of the bootstrap environment variables (%q or %q) defined",
-		envconfig.XDSBootstrapFileNameEnv, envconfig.XDSBootstrapFileContentEnv)
+	return nil, fmt.Errorf("none of the bootstrap environment variables (%q or %q) defined", envconfig.XDSBootstrapFileNameEnv, envconfig.XDSBootstrapFileContentEnv)
 }
 
 // NewConfig returns a new instance of Config initialized by reading the
@@ -427,115 +559,117 @@ func newConfigFromContents(data []byte) (*Config, error) {
 	data = bytes.TrimSpace(buf.Bytes())
 
 	config := &Config{}
-
-	var jsonData map[string]json.RawMessage
-	if err := json.Unmarshal(data, &jsonData); err != nil {
-		return nil, fmt.Errorf("xds: failed to parse bootstrap config: %v", err)
+	if err := config.UnmarshalJSON(data); err != nil {
+		return nil, err
 	}
-
-	var node *v3corepb.Node
-	opts := protojson.UnmarshalOptions{DiscardUnknown: true}
-	for k, v := range jsonData {
-		switch k {
-		case "node":
-			node = &v3corepb.Node{}
-			if err := opts.Unmarshal(v, node); err != nil {
-				return nil, fmt.Errorf("xds: protojson.Unmarshal(%v) for field %q failed during bootstrap: %v", string(v), k, err)
-			}
-		case "xds_servers":
-			servers, err := unmarshalJSONServerConfigSlice(v)
-			if err != nil {
-				return nil, fmt.Errorf("xds: json.Unmarshal(data) for field %q failed during bootstrap: %v", k, err)
-			}
-			config.XDSServer = servers[0]
-		case "certificate_providers":
-			var providerInstances map[string]json.RawMessage
-			if err := json.Unmarshal(v, &providerInstances); err != nil {
-				return nil, fmt.Errorf("xds: json.Unmarshal(%v) for field %q failed during bootstrap: %v", string(v), k, err)
-			}
-			configs := make(map[string]*certprovider.BuildableConfig)
-			getBuilder := internal.GetCertificateProviderBuilder.(func(string) certprovider.Builder)
-			for instance, data := range providerInstances {
-				var nameAndConfig struct {
-					PluginName string          `json:"plugin_name"`
-					Config     json.RawMessage `json:"config"`
-				}
-				if err := json.Unmarshal(data, &nameAndConfig); err != nil {
-					return nil, fmt.Errorf("xds: json.Unmarshal(%v) for field %q failed during bootstrap: %v", string(v), instance, err)
-				}
-
-				name := nameAndConfig.PluginName
-				parser := getBuilder(nameAndConfig.PluginName)
-				if parser == nil {
-					// We ignore plugins that we do not know about.
-					continue
-				}
-				bc, err := parser.ParseConfig(nameAndConfig.Config)
-				if err != nil {
-					return nil, fmt.Errorf("xds: config parsing for plugin %q failed: %v", name, err)
-				}
-				configs[instance] = bc
-			}
-			config.CertProviderConfigs = configs
-		case "server_listener_resource_name_template":
-			if err := json.Unmarshal(v, &config.ServerListenerResourceNameTemplate); err != nil {
-				return nil, fmt.Errorf("xds: json.Unmarshal(%v) for field %q failed during bootstrap: %v", string(v), k, err)
-			}
-		case "client_default_listener_resource_name_template":
-			if err := json.Unmarshal(v, &config.ClientDefaultListenerResourceNameTemplate); err != nil {
-				return nil, fmt.Errorf("xds: json.Unmarshal(%v) for field %q failed during bootstrap: %v", string(v), k, err)
-			}
-		case "authorities":
-			if err := json.Unmarshal(v, &config.Authorities); err != nil {
-				return nil, fmt.Errorf("xds: json.Unmarshal(%v) for field %q failed during bootstrap: %v", string(v), k, err)
-			}
-		default:
-			logger.Warningf("Bootstrap content has unknown field: %s", k)
-		}
-		// Do not fail the xDS bootstrap when an unknown field is seen. This can
-		// happen when an older version client reads a newer version bootstrap
-		// file with new fields.
-	}
-
-	if config.ClientDefaultListenerResourceNameTemplate == "" {
-		// Default value of the default client listener name template is "%s".
-		config.ClientDefaultListenerResourceNameTemplate = "%s"
-	}
-	if config.XDSServer == nil {
-		return nil, fmt.Errorf("xds: required field %q not found in bootstrap %s", "xds_servers", jsonData["xds_servers"])
-	}
-	if config.XDSServer.ServerURI == "" {
-		return nil, fmt.Errorf("xds: required field %q not found in bootstrap %s", "xds_servers.server_uri", jsonData["xds_servers"])
-	}
-	if config.XDSServer.CredsDialOption() == nil {
-		return nil, fmt.Errorf("xds: required field %q doesn't contain valid value in bootstrap %s", "xds_servers.channel_creds", jsonData["xds_servers"])
-	}
-	// Post-process the authorities' client listener resource template field:
-	// - if set, it must start with "xdstp://<authority_name>/"
-	// - if not set, it defaults to "xdstp://<authority_name>/envoy.config.listener.v3.Listener/%s"
-	for name, authority := range config.Authorities {
-		prefix := fmt.Sprintf("xdstp://%s", url.PathEscape(name))
-		if authority.ClientListenerResourceNameTemplate == "" {
-			authority.ClientListenerResourceNameTemplate = prefix + "/envoy.config.listener.v3.Listener/%s"
-			continue
-		}
-		if !strings.HasPrefix(authority.ClientListenerResourceNameTemplate, prefix) {
-			return nil, fmt.Errorf("xds: field ClientListenerResourceNameTemplate %q of authority %q doesn't start with prefix %q", authority.ClientListenerResourceNameTemplate, name, prefix)
-		}
-	}
-
-	// Performing post-production on the node information. Some additional fields
-	// which are not expected to be set in the bootstrap file are populated here.
-	if node == nil {
-		node = &v3corepb.Node{}
-	}
-	node.UserAgentName = gRPCUserAgentName
-	node.UserAgentVersionType = &v3corepb.Node_UserAgentVersion{UserAgentVersion: grpc.Version}
-	node.ClientFeatures = append(node.ClientFeatures, clientFeatureNoOverprovisioning, clientFeatureResourceWrapper)
-	config.NodeProto = node
 
 	if logger.V(2) {
 		logger.Infof("Bootstrap config for creating xds-client: %v", pretty.ToJSON(config))
+	} else {
+		logger.Infof("Bootstrap config for creating xds-client: %+v", config)
 	}
 	return config, nil
+}
+
+// certproviderNameAndConfig is the internal representation of
+// the`certificate_providers` field in the bootstrap configuration.
+type certproviderNameAndConfig struct {
+	PluginName string          `json:"plugin_name"`
+	Config     json.RawMessage `json:"config"`
+}
+
+// locality is the internal representation of the locality field within node.
+type locality struct {
+	Region  string `json:"region,omitempty"`
+	Zone    string `json:"zone,omitempty"`
+	SubZone string `json:"sub_zone,omitempty"`
+}
+
+func (l locality) Equal(other locality) bool {
+	return l.Region == other.Region && l.Zone == other.Zone && l.SubZone == other.SubZone
+}
+
+func (l locality) isEmpty() bool {
+	return l.Equal(locality{})
+}
+
+type userAgentVersion struct {
+	UserAgentVersion string `json:"user_agent_version,omitempty"`
+}
+
+// node is the internal representation of the node field in the bootstrap
+// configuration.
+type node struct {
+	ID       string           `json:"id,omitempty"`
+	Cluster  string           `json:"cluster,omitempty"`
+	Locality locality         `json:"locality,omitempty"`
+	Metadata *structpb.Struct `json:"metadata,omitempty"`
+
+	// The following fields are controlled by the client implementation and
+	// should not unmarshaled from JSON.
+	userAgentName        string
+	userAgentVersionType userAgentVersion
+	clientFeatures       []string
+}
+
+// newNode is a convenience function to create a new node instance with fields
+// controlled by the client implementation set to the desired values.
+func newNode() node {
+	return node{
+		userAgentName:        gRPCUserAgentName,
+		userAgentVersionType: userAgentVersion{UserAgentVersion: grpc.Version},
+		clientFeatures:       []string{clientFeatureNoOverprovisioning, clientFeatureResourceWrapper},
+	}
+}
+
+func (n node) Equal(other node) bool {
+	switch {
+	case n.ID != other.ID:
+		return false
+	case n.Cluster != other.Cluster:
+		return false
+	case !n.Locality.Equal(other.Locality):
+		return false
+	case n.userAgentName != other.userAgentName:
+		return false
+	case n.userAgentVersionType != other.userAgentVersionType:
+		return false
+	}
+
+	// Consider failures in JSON marshaling as being unable to perform the
+	// comparison, and hence return false.
+	nMetadata, err := n.Metadata.MarshalJSON()
+	if err != nil {
+		return false
+	}
+	otherMetadata, err := other.Metadata.MarshalJSON()
+	if err != nil {
+		return false
+	}
+	if !bytes.Equal(nMetadata, otherMetadata) {
+		return false
+	}
+
+	return slices.Equal(n.clientFeatures, other.clientFeatures)
+}
+
+func (n node) toProto() *v3corepb.Node {
+	return &v3corepb.Node{
+		Id:      n.ID,
+		Cluster: n.Cluster,
+		Locality: func() *v3corepb.Locality {
+			if n.Locality.isEmpty() {
+				return nil
+			}
+			return &v3corepb.Locality{
+				Region:  n.Locality.Region,
+				Zone:    n.Locality.Zone,
+				SubZone: n.Locality.SubZone,
+			}
+		}(),
+		Metadata:             proto.Clone(n.Metadata).(*structpb.Struct),
+		UserAgentName:        n.userAgentName,
+		UserAgentVersionType: &v3corepb.Node_UserAgentVersion{UserAgentVersion: n.userAgentVersionType.UserAgentVersion},
+		ClientFeatures:       slices.Clone(n.clientFeatures),
+	}
 }

--- a/internal/xds/bootstrap/bootstrap_test.go
+++ b/internal/xds/bootstrap/bootstrap_test.go
@@ -1029,7 +1029,7 @@ func Test(t *testing.T) {
 	grpctest.RunSubTests(t, s{})
 }
 
-func newStructProtoFromMap(t *testing.T, input map[string]interface{}) *structpb.Struct {
+func newStructProtoFromMap(t *testing.T, input map[string]any) *structpb.Struct {
 	t.Helper()
 
 	ret, err := structpb.NewStruct(input)
@@ -1069,7 +1069,7 @@ func (s) TestNode_MarshalAndUnmarshal(t *testing.T) {
 					Zone:    "zone",
 					SubZone: "sub_zone",
 				},
-				Metadata: newStructProtoFromMap(t, map[string]interface{}{
+				Metadata: newStructProtoFromMap(t, map[string]any{
 					"k1": "v1",
 					"k2": 101,
 					"k3": 280.0,
@@ -1147,7 +1147,7 @@ func (s) TestNode_ToProto(t *testing.T) {
 					Zone:    "zone",
 					SubZone: "sub_zone",
 				}
-				n.Metadata = newStructProtoFromMap(t, map[string]interface{}{
+				n.Metadata = newStructProtoFromMap(t, map[string]any{
 					"k1": "v1",
 					"k2": 101,
 					"k3": 280.0,
@@ -1162,7 +1162,7 @@ func (s) TestNode_ToProto(t *testing.T) {
 					Zone:    "zone",
 					SubZone: "sub_zone",
 				},
-				Metadata: newStructProtoFromMap(t, map[string]interface{}{
+				Metadata: newStructProtoFromMap(t, map[string]any{
 					"k1": "v1",
 					"k2": 101,
 					"k3": 280.0,

--- a/stats/opentelemetry/csm/pluginoption.go
+++ b/stats/opentelemetry/csm/pluginoption.go
@@ -294,10 +294,10 @@ func getNodeID() string {
 	if err != nil {
 		return "" // will become "unknown"
 	}
-	if cfg.NodeProto == nil {
+	if cfg.Node() == nil {
 		return ""
 	}
-	return cfg.NodeProto.GetId()
+	return cfg.Node().GetId()
 }
 
 // metadataExchangeKey is the key for HTTP metadata exchange.

--- a/xds/googledirectpath/googlec2p.go
+++ b/xds/googledirectpath/googlec2p.go
@@ -65,6 +65,8 @@ const (
 var (
 	onGCE = googlecloud.OnGCE
 
+	randInt = rand.Int
+
 	newClientWithConfig = func(config *bootstrap.Config) (xdsclient.XDSClient, func(), error) {
 		return xdsclient.NewWithConfig(config)
 	}
@@ -159,8 +161,6 @@ func (r *c2pResolver) Close() {
 	r.clientCloseFunc()
 }
 
-var id = fmt.Sprintf("C2P-%d", rand.Int())
-
 func newNodeConfig(zone string, ipv6Capable bool) string {
 	metadata := ""
 	if ipv6Capable {
@@ -174,7 +174,7 @@ func newNodeConfig(zone string, ipv6Capable bool) string {
 			"zone": "%s"
 		}
 		%s
-	}`, id, zone, metadata)
+	}`, fmt.Sprintf("C2P-%d", randInt()), zone, metadata)
 }
 
 func newAuthoritiesConfig(xdsServer string) string {
@@ -192,7 +192,7 @@ func newXdsServerConfig(xdsServerURI string) string {
 	{
 		"server_uri": "%s",
 		"channel_creds": [{"type": "google_default"}],
-		"server_features": ["xds_v3", "ignore_resource_deletion", "xds.config.resource-in-sotw"]
+		"server_features": ["ignore_resource_deletion"]
 	}`, xdsServerURI)
 }
 

--- a/xds/googledirectpath/googlec2p.go
+++ b/xds/googledirectpath/googlec2p.go
@@ -46,18 +46,13 @@ const (
 	c2pScheme    = "google-c2p"
 	c2pAuthority = "traffic-director-c2p.xds.googleapis.com"
 
-	tdURL          = "dns:///directpath-pa.googleapis.com"
-	httpReqTimeout = 10 * time.Second
-	zoneURL        = "http://metadata.google.internal/computeMetadata/v1/instance/zone"
-	ipv6URL        = "http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/ipv6s"
+	tdURL                   = "dns:///directpath-pa.googleapis.com"
+	zoneURL                 = "http://metadata.google.internal/computeMetadata/v1/instance/zone"
+	ipv6URL                 = "http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/ipv6s"
+	ipv6CapableMetadataName = "TRAFFICDIRECTOR_DIRECTPATH_C2P_IPV6_CAPABLE"
+	httpReqTimeout          = 10 * time.Second
 
-	gRPCUserAgentName               = "gRPC Go"
-	clientFeatureNoOverprovisioning = "envoy.lb.does_not_support_overprovisioning"
-	clientFeatureResourceWrapper    = "xds.config.resource-in-sotw"
-	ipv6CapableMetadataName         = "TRAFFICDIRECTOR_DIRECTPATH_C2P_IPV6_CAPABLE"
-
-	logPrefix = "[google-c2p-resolver]"
-
+	logPrefix        = "[google-c2p-resolver]"
 	dnsName, xdsName = "dns", "xds"
 )
 

--- a/xds/internal/balancer/cdsbalancer/cdsbalancer.go
+++ b/xds/internal/balancer/cdsbalancer/cdsbalancer.go
@@ -207,7 +207,7 @@ func (b *cdsBalancer) handleSecurityConfig(config *xdsresource.SecurityConfig) e
 	}
 
 	// A root provider is required whether we are using TLS or mTLS.
-	cpc := b.xdsClient.BootstrapConfig().CertProviderConfigs
+	cpc := b.xdsClient.BootstrapConfig().CertProviderConfigs()
 	rootProvider, err := buildProvider(cpc, config.RootInstanceName, config.RootCertName, false, true)
 	if err != nil {
 		return err

--- a/xds/internal/balancer/cdsbalancer/cdsbalancer_test.go
+++ b/xds/internal/balancer/cdsbalancer/cdsbalancer_test.go
@@ -597,16 +597,18 @@ func (s) TestClusterUpdate_SuccessWithLRS(t *testing.T) {
 		ServiceName: serviceName,
 		EnableLRS:   true,
 	})
+	lrsServerCfg, err := bootstrap.ServerConfigForTesting(bootstrap.ServerConfigTestingOptions{URI: fmt.Sprintf("passthrough:///%s", mgmtServer.Address)})
+	if err != nil {
+		t.Fatalf("Failed to create LRS server config for testing: %v", err)
+	}
+
 	wantChildCfg := &clusterresolver.LBConfig{
 		DiscoveryMechanisms: []clusterresolver.DiscoveryMechanism{{
-			Cluster:        clusterName,
-			Type:           clusterresolver.DiscoveryMechanismTypeEDS,
-			EDSServiceName: serviceName,
-			LoadReportingServer: &bootstrap.ServerConfig{
-				ServerURI: mgmtServer.Address,
-				Creds:     bootstrap.ChannelCreds{Type: "insecure"},
-			},
-			OutlierDetection: json.RawMessage(`{}`),
+			Cluster:             clusterName,
+			Type:                clusterresolver.DiscoveryMechanismTypeEDS,
+			EDSServiceName:      serviceName,
+			LoadReportingServer: lrsServerCfg,
+			OutlierDetection:    json.RawMessage(`{}`),
 		}},
 		XDSLBPolicy: json.RawMessage(`[{"xds_wrr_locality_experimental": {"childPolicy": [{"round_robin": {}}]}}]`),
 	}

--- a/xds/internal/balancer/clusterimpl/balancer_test.go
+++ b/xds/internal/balancer/clusterimpl/balancer_test.go
@@ -59,17 +59,8 @@ const (
 )
 
 var (
-	testBackendAddrs = []resolver.Address{
-		{Addr: "1.1.1.1:1"},
-	}
-	testLRSServerConfig = &bootstrap.ServerConfig{
-		ServerURI: "trafficdirector.googleapis.com:443",
-		Creds: bootstrap.ChannelCreds{
-			Type: "google_default",
-		},
-	}
-
-	cmpOpts = cmp.Options{
+	testBackendAddrs = []resolver.Address{{Addr: "1.1.1.1:1"}}
+	cmpOpts          = cmp.Options{
 		cmpopts.EquateEmpty(),
 		cmpopts.IgnoreFields(load.Data{}, "ReportInterval"),
 	}
@@ -107,6 +98,13 @@ func (s) TestDropByCategory(t *testing.T) {
 		dropNumerator   = 1
 		dropDenominator = 2
 	)
+	testLRSServerConfig, err := bootstrap.ServerConfigForTesting(bootstrap.ServerConfigTestingOptions{
+		URI:          "trafficdirector.googleapis.com:443",
+		ChannelCreds: []bootstrap.ChannelCreds{{Type: "google_default"}},
+	})
+	if err != nil {
+		t.Fatalf("Failed to create LRS server config for testing: %v", err)
+	}
 	if err := b.UpdateClientConnState(balancer.ClientConnState{
 		ResolverState: xdsclient.SetClient(resolver.State{Addresses: testBackendAddrs}, xdsC),
 		BalancerConfig: &LBConfig{
@@ -262,6 +260,13 @@ func (s) TestDropCircuitBreaking(t *testing.T) {
 	defer b.Close()
 
 	var maxRequest uint32 = 50
+	testLRSServerConfig, err := bootstrap.ServerConfigForTesting(bootstrap.ServerConfigTestingOptions{
+		URI:          "trafficdirector.googleapis.com:443",
+		ChannelCreds: []bootstrap.ChannelCreds{{Type: "google_default"}},
+	})
+	if err != nil {
+		t.Fatalf("Failed to create LRS server config for testing: %v", err)
+	}
 	if err := b.UpdateClientConnState(balancer.ClientConnState{
 		ResolverState: xdsclient.SetClient(resolver.State{Addresses: testBackendAddrs}, xdsC),
 		BalancerConfig: &LBConfig{
@@ -592,6 +597,13 @@ func (s) TestLoadReporting(t *testing.T) {
 	for i, a := range testBackendAddrs {
 		addrs[i] = xdsinternal.SetLocalityID(a, testLocality)
 	}
+	testLRSServerConfig, err := bootstrap.ServerConfigForTesting(bootstrap.ServerConfigTestingOptions{
+		URI:          "trafficdirector.googleapis.com:443",
+		ChannelCreds: []bootstrap.ChannelCreds{{Type: "google_default"}},
+	})
+	if err != nil {
+		t.Fatalf("Failed to create LRS server config for testing: %v", err)
+	}
 	if err := b.UpdateClientConnState(balancer.ClientConnState{
 		ResolverState: xdsclient.SetClient(resolver.State{Addresses: addrs}, xdsC),
 		BalancerConfig: &LBConfig{
@@ -715,6 +727,13 @@ func (s) TestUpdateLRSServer(t *testing.T) {
 	for i, a := range testBackendAddrs {
 		addrs[i] = xdsinternal.SetLocalityID(a, testLocality)
 	}
+	testLRSServerConfig, err := bootstrap.ServerConfigForTesting(bootstrap.ServerConfigTestingOptions{
+		URI:          "trafficdirector.googleapis.com:443",
+		ChannelCreds: []bootstrap.ChannelCreds{{Type: "google_default"}},
+	})
+	if err != nil {
+		t.Fatalf("Failed to create LRS server config for testing: %v", err)
+	}
 	if err := b.UpdateClientConnState(balancer.ClientConnState{
 		ResolverState: xdsclient.SetClient(resolver.State{Addresses: addrs}, xdsC),
 		BalancerConfig: &LBConfig{
@@ -740,12 +759,14 @@ func (s) TestUpdateLRSServer(t *testing.T) {
 		t.Fatalf("xdsClient.ReportLoad called with {%q}: want {%q}", got.Server, testLRSServerConfig)
 	}
 
-	testLRSServerConfig2 := &bootstrap.ServerConfig{
-		ServerURI: "trafficdirector-another.googleapis.com:443",
-		Creds: bootstrap.ChannelCreds{
-			Type: "google_default",
-		},
+	testLRSServerConfig2, err := bootstrap.ServerConfigForTesting(bootstrap.ServerConfigTestingOptions{
+		URI:          "trafficdirector-another.googleapis.com:443",
+		ChannelCreds: []bootstrap.ChannelCreds{{Type: "google_default"}},
+	})
+	if err != nil {
+		t.Fatalf("Failed to create LRS server config for testing: %v", err)
 	}
+
 	// Update LRS server to a different name.
 	if err := b.UpdateClientConnState(balancer.ClientConnState{
 		ResolverState: xdsclient.SetClient(resolver.State{Addresses: addrs}, xdsC),

--- a/xds/internal/balancer/clusterimpl/config_test.go
+++ b/xds/internal/balancer/clusterimpl/config_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"google.golang.org/grpc/balancer"
 	_ "google.golang.org/grpc/balancer/roundrobin"
 	_ "google.golang.org/grpc/balancer/weightedtarget"
@@ -89,6 +88,14 @@ var (
 )
 
 func TestParseConfig(t *testing.T) {
+	testLRSServerConfig, err := bootstrap.ServerConfigForTesting(bootstrap.ServerConfigTestingOptions{
+		URI:          "trafficdirector.googleapis.com:443",
+		ChannelCreds: []bootstrap.ChannelCreds{{Type: "google_default"}},
+	})
+	if err != nil {
+		t.Fatalf("Failed to create LRS server config for testing: %v", err)
+	}
+
 	tests := []struct {
 		name    string
 		js      string
@@ -133,8 +140,8 @@ func TestParseConfig(t *testing.T) {
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("parseConfig() error = %v, wantErr %v", err, tt.wantErr)
 			}
-			if !cmp.Equal(got, tt.want, cmpopts.IgnoreFields(bootstrap.ServerConfig{}, "Creds")) {
-				t.Errorf("parseConfig() got unexpected result, diff: %v", cmp.Diff(got, tt.want))
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("parseConfig() got unexpected diff (-want, +got): %v", diff)
 			}
 		})
 	}

--- a/xds/internal/balancer/clusterresolver/config_test.go
+++ b/xds/internal/balancer/clusterresolver/config_test.go
@@ -171,14 +171,14 @@ const (
 }`
 )
 
-var testLRSServerConfig = &bootstrap.ServerConfig{
-	ServerURI: "trafficdirector.googleapis.com:443",
-	Creds: bootstrap.ChannelCreds{
-		Type: "google_default",
-	},
-}
-
 func TestParseConfig(t *testing.T) {
+	testLRSServerConfig, err := bootstrap.ServerConfigForTesting(bootstrap.ServerConfigTestingOptions{
+		URI:          "trafficdirector.googleapis.com:443",
+		ChannelCreds: []bootstrap.ChannelCreds{{Type: "google_default"}},
+	})
+	if err != nil {
+		t.Fatalf("Failed to create LRS server config for testing: %v", err)
+	}
 	tests := []struct {
 		name    string
 		js      string

--- a/xds/internal/balancer/clusterresolver/configbuilder_test.go
+++ b/xds/internal/balancer/clusterresolver/configbuilder_test.go
@@ -33,6 +33,7 @@ import (
 	"google.golang.org/grpc/balancer/weightedroundrobin"
 	"google.golang.org/grpc/internal/hierarchy"
 	iserviceconfig "google.golang.org/grpc/internal/serviceconfig"
+	"google.golang.org/grpc/internal/xds/bootstrap"
 	"google.golang.org/grpc/resolver"
 	"google.golang.org/grpc/xds/internal"
 	"google.golang.org/grpc/xds/internal/balancer/clusterimpl"
@@ -132,6 +133,14 @@ func init() {
 // TestBuildPriorityConfigJSON is a sanity check that the built balancer config
 // can be parsed. The behavior test is covered by TestBuildPriorityConfig.
 func TestBuildPriorityConfigJSON(t *testing.T) {
+	testLRSServerConfig, err := bootstrap.ServerConfigForTesting(bootstrap.ServerConfigTestingOptions{
+		URI:          "trafficdirector.googleapis.com:443",
+		ChannelCreds: []bootstrap.ChannelCreds{{Type: "google_default"}},
+	})
+	if err != nil {
+		t.Fatalf("Failed to create LRS server config for testing: %v", err)
+	}
+
 	gotConfig, _, err := buildPriorityConfigJSON([]priorityConfig{
 		{
 			mechanism: DiscoveryMechanism{
@@ -317,6 +326,14 @@ func TestBuildClusterImplConfigForDNS(t *testing.T) {
 }
 
 func TestBuildClusterImplConfigForEDS(t *testing.T) {
+	testLRSServerConfig, err := bootstrap.ServerConfigForTesting(bootstrap.ServerConfigTestingOptions{
+		URI:          "trafficdirector.googleapis.com:443",
+		ChannelCreds: []bootstrap.ChannelCreds{{Type: "google_default"}},
+	})
+	if err != nil {
+		t.Fatalf("Failed to create LRS server config for testing: %v", err)
+	}
+
 	gotNames, gotConfigs, gotAddrs, _ := buildClusterImplConfigForEDS(
 		newNameGenerator(2),
 		xdsresource.EndpointsUpdate{

--- a/xds/internal/balancer/clusterresolver/e2e_test/aggregate_cluster_test.go
+++ b/xds/internal/balancer/clusterresolver/e2e_test/aggregate_cluster_test.go
@@ -89,7 +89,9 @@ func setupDNS() (chan resolver.Target, chan struct{}, chan resolver.ResolveNowOp
 	resolveNowCh := make(chan resolver.ResolveNowOptions, 1)
 
 	mr := manual.NewBuilderWithScheme("dns")
-	mr.BuildCallback = func(target resolver.Target, _ resolver.ClientConn, _ resolver.BuildOptions) { targetCh <- target }
+	mr.BuildCallback = func(target resolver.Target, _ resolver.ClientConn, _ resolver.BuildOptions) {
+		targetCh <- target
+	}
 	mr.CloseCallback = func() { closeCh <- struct{}{} }
 	mr.ResolveNowCallback = func(opts resolver.ResolveNowOptions) { resolveNowCh <- opts }
 

--- a/xds/internal/resolver/xds_resolver.go
+++ b/xds/internal/resolver/xds_resolver.go
@@ -139,9 +139,13 @@ func (r *xdsResolver) sanityChecksOnBootstrapConfig(target resolver.Target, opts
 	// Find the client listener template to use from the bootstrap config:
 	// - If authority is not set in the target, use the top level template
 	// - If authority is set, use the template from the authority map.
-	template := bootstrapConfig.ClientDefaultListenerResourceNameTemplate
+	template := bootstrapConfig.ClientDefaultListenerResourceNameTemplate()
 	if authority := target.URL.Host; authority != "" {
-		a := bootstrapConfig.Authorities[authority]
+		authorities := bootstrapConfig.Authorities()
+		if authorities == nil {
+			return "", fmt.Errorf("xds: authority %q specified in dial target %q is not found in the bootstrap file", authority, target)
+		}
+		a := authorities[authority]
 		if a == nil {
 			return "", fmt.Errorf("xds: authority %q specified in dial target %q is not found in the bootstrap file", authority, target)
 		}

--- a/xds/internal/server/conn_wrapper.go
+++ b/xds/internal/server/conn_wrapper.go
@@ -107,7 +107,7 @@ func (c *connWrapper) XDSHandshakeInfo() (*xdsinternal.HandshakeInfo, error) {
 		return xdsinternal.NewHandshakeInfo(nil, nil, nil, false), nil
 	}
 
-	cpc := c.parent.xdsC.BootstrapConfig().CertProviderConfigs
+	cpc := c.parent.xdsC.BootstrapConfig().CertProviderConfigs()
 	// Identity provider name is mandatory on the server-side, and this is
 	// enforced when the resource is received at the XDSClient layer.
 	secCfg := c.filterChain.SecurityCfg

--- a/xds/internal/testutils/fakeclient/client.go
+++ b/xds/internal/testutils/fakeclient/client.go
@@ -108,6 +108,6 @@ func NewClientWithName(name string) *Client {
 		loadReportCh: testutils.NewChannel(),
 		lrsCancelCh:  testutils.NewChannel(),
 		loadStore:    load.NewStore(),
-		bootstrapCfg: &bootstrap.Config{ClientDefaultListenerResourceNameTemplate: "%s"},
+		bootstrapCfg: &bootstrap.Config{},
 	}
 }

--- a/xds/internal/testutils/testutils.go
+++ b/xds/internal/testutils/testutils.go
@@ -19,10 +19,6 @@
 package testutils
 
 import (
-	"fmt"
-	"testing"
-
-	"google.golang.org/grpc/internal/xds/bootstrap"
 	"google.golang.org/grpc/xds/internal/xdsclient/xdsresource"
 	"google.golang.org/grpc/xds/internal/xdsclient/xdsresource/version"
 )
@@ -52,21 +48,4 @@ func BuildResourceName(typeName, auth, id string, ctxParams map[string]string) s
 		ID:            id,
 		ContextParams: ctxParams,
 	}).String()
-}
-
-// ServerConfigForAddress returns a bootstrap.ServerConfig for the given address
-// with default values of insecure channel_creds and v3 server_features.
-func ServerConfigForAddress(t *testing.T, addr string) *bootstrap.ServerConfig {
-	t.Helper()
-
-	jsonCfg := fmt.Sprintf(`{
-		"server_uri": "%s",
-		"channel_creds": [{"type": "insecure"}],
-		"server_features": ["xds_v3"]
-	}`, addr)
-	sc, err := bootstrap.ServerConfigFromJSON([]byte(jsonCfg))
-	if err != nil {
-		t.Fatalf("Failed to create server config from JSON %s: %v", jsonCfg, err)
-	}
-	return sc
 }

--- a/xds/internal/xdsclient/authority.go
+++ b/xds/internal/xdsclient/authority.go
@@ -283,7 +283,7 @@ func (a *authority) updateResourceStateAndScheduleCallbacks(rType xdsresource.Ty
 			// resource deletion is to be ignored, the resource is not removed from
 			// the cache and the corresponding OnResourceDoesNotExist() callback is
 			// not invoked on the watchers.
-			if a.serverCfg.IgnoreResourceDeletion() {
+			if a.serverCfg.ServerFeaturesIgnoreResourceDeletion() {
 				if !state.deletionIgnored {
 					state.deletionIgnored = true
 					a.logger.Warningf("Ignoring resource deletion for resource %q of type %q", name, rType.TypeName())

--- a/xds/internal/xdsclient/authority.go
+++ b/xds/internal/xdsclient/authority.go
@@ -118,12 +118,12 @@ func newAuthority(args authorityArgs) (*authority, error) {
 	}
 
 	tr, err := transport.New(transport.Options{
-		ServerCfg:      *args.serverCfg,
+		ServerCfg:      args.serverCfg,
 		OnRecvHandler:  ret.handleResourceUpdate,
 		OnErrorHandler: ret.newConnectionError,
 		OnSendHandler:  ret.transportOnSendHandler,
 		Logger:         args.logger,
-		NodeProto:      args.bootstrapCfg.NodeProto,
+		NodeProto:      args.bootstrapCfg.Node(),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("creating new transport to %q: %v", args.serverCfg, err)
@@ -283,7 +283,7 @@ func (a *authority) updateResourceStateAndScheduleCallbacks(rType xdsresource.Ty
 			// resource deletion is to be ignored, the resource is not removed from
 			// the cache and the corresponding OnResourceDoesNotExist() callback is
 			// not invoked on the watchers.
-			if a.serverCfg.IgnoreResourceDeletion {
+			if a.serverCfg.IgnoreResourceDeletion() {
 				if !state.deletionIgnored {
 					state.deletionIgnored = true
 					a.logger.Warningf("Ignoring resource deletion for resource %q of type %q", name, rType.TypeName())

--- a/xds/internal/xdsclient/client_new.go
+++ b/xds/internal/xdsclient/client_new.go
@@ -84,7 +84,7 @@ func newWithConfig(config *bootstrap.Config, watchExpiryTimeout time.Duration, i
 	}
 
 	c.logger = prefixLogger(c)
-	c.logger.Infof("Created client to xDS management server: %s", config.XDSServer)
+	c.logger.Infof("Created client to xDS management server: %s", config.XDSServers()[0])
 	return c, nil
 }
 

--- a/xds/internal/xdsclient/clientimpl.go
+++ b/xds/internal/xdsclient/clientimpl.go
@@ -85,16 +85,16 @@ func (c *clientImpl) close() {
 	c.authorityMu.Unlock()
 	c.serializerClose()
 
-	for _, f := range c.config.XDSServer.Cleanups {
-		f()
-	}
-	for _, a := range c.config.Authorities {
-		if a.XDSServer == nil {
-			// The server for this authority is the top-level one, cleaned up above.
-			continue
-		}
-		for _, f := range a.XDSServer.Cleanups {
+	for _, s := range c.config.XDSServers() {
+		for _, f := range s.Cleanups() {
 			f()
+		}
+	}
+	for _, a := range c.config.Authorities() {
+		for _, s := range a.XDSServers {
+			for _, f := range s.Cleanups() {
+				f()
+			}
 		}
 	}
 	c.logger.Infof("Shutdown")

--- a/xds/internal/xdsclient/clientimpl_authority.go
+++ b/xds/internal/xdsclient/clientimpl_authority.go
@@ -45,14 +45,18 @@ func (c *clientImpl) findAuthority(n *xdsresource.Name) (*authority, func(), err
 		return nil, nil, errors.New("the xds-client is closed")
 	}
 
-	config := c.config.XDSServer
+	config := c.config.XDSServers()[0]
 	if scheme == xdsresource.FederationScheme {
-		cfg, ok := c.config.Authorities[authority]
+		authorities := c.config.Authorities()
+		if authorities == nil {
+			return nil, nil, fmt.Errorf("xds: failed to find authority %q", authority)
+		}
+		cfg, ok := authorities[authority]
 		if !ok {
 			return nil, nil, fmt.Errorf("xds: failed to find authority %q", authority)
 		}
-		if cfg.XDSServer != nil {
-			config = cfg.XDSServer
+		if len(cfg.XDSServers) >= 1 {
+			config = cfg.XDSServers[0]
 		}
 	}
 
@@ -110,7 +114,7 @@ func (c *clientImpl) newAuthorityLocked(config *bootstrap.ServerConfig) (_ *auth
 		serializer:         c.serializer,
 		resourceTypeGetter: c.resourceTypes.get,
 		watchExpiryTimeout: c.watchExpiryTimeout,
-		logger:             grpclog.NewPrefixLogger(logger, authorityPrefix(c, config.ServerURI)),
+		logger:             grpclog.NewPrefixLogger(logger, authorityPrefix(c, config.ServerURI())),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("creating new authority for config %q: %v", config.String(), err)

--- a/xds/internal/xdsclient/clientimpl_dump.go
+++ b/xds/internal/xdsclient/clientimpl_dump.go
@@ -40,7 +40,7 @@ func (c *clientImpl) DumpResources() (*v3statuspb.ClientStatusResponse, error) {
 		Config: []*v3statuspb.ClientConfig{
 			{
 				// TODO: Populate ClientScope. Need to update go-control-plane dependency.
-				Node:              c.config.NodeProto,
+				Node:              c.config.Node(),
 				GenericXdsConfigs: retCfg,
 			},
 		},

--- a/xds/internal/xdsclient/singleton.go
+++ b/xds/internal/xdsclient/singleton.go
@@ -94,7 +94,7 @@ func newRefCountedWithConfig(fallbackConfig *bootstrap.Config) (XDSClient, func(
 	singletonClient = &clientRefCounted{clientImpl: c, refCount: 1}
 	singletonClientImplCreateHook()
 
-	logger.Infof("xDS node ID: %s", config.NodeProto.GetId())
+	logger.Infof("xDS node ID: %s", config.Node().GetId())
 	return singletonClient, grpcsync.OnceFunc(clientRefCountedClose), nil
 }
 

--- a/xds/internal/xdsclient/tests/resource_update_test.go
+++ b/xds/internal/xdsclient/tests/resource_update_test.go
@@ -32,8 +32,8 @@ import (
 	"google.golang.org/grpc/internal/testutils"
 	"google.golang.org/grpc/internal/testutils/xds/e2e"
 	"google.golang.org/grpc/internal/testutils/xds/fakeserver"
+	"google.golang.org/grpc/internal/xds/bootstrap"
 	"google.golang.org/grpc/xds/internal"
-	xdstestutils "google.golang.org/grpc/xds/internal/testutils"
 	"google.golang.org/grpc/xds/internal/xdsclient"
 	"google.golang.org/grpc/xds/internal/xdsclient/xdsresource"
 	"google.golang.org/protobuf/proto"
@@ -867,7 +867,11 @@ func (s) TestHandleClusterResponseFromManagementServer(t *testing.T) {
 			// server at that point, hence we do it here before verifying the
 			// received update.
 			if test.wantErr == "" {
-				test.wantUpdate.LRSServerConfig = xdstestutils.ServerConfigForAddress(t, mgmtServer.Address)
+				serverCfg, err := bootstrap.ServerConfigForTesting(bootstrap.ServerConfigTestingOptions{URI: mgmtServer.Address})
+				if err != nil {
+					t.Fatalf("Failed to create server config for testing: %v", err)
+				}
+				test.wantUpdate.LRSServerConfig = serverCfg
 			}
 			cmpOpts := []cmp.Option{
 				cmpopts.EquateEmpty(),

--- a/xds/internal/xdsclient/transport/internal/internal.go
+++ b/xds/internal/xdsclient/transport/internal/internal.go
@@ -1,0 +1,25 @@
+/*
+ *
+ * Copyright 2024 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package internal contains functionality internal to the transport package.
+package internal
+
+// The following vars can be overridden by tests.
+var (
+	// GRPCNewClient creates a new gRPC Client.
+	GRPCNewClient any // func(string, ...grpc.DialOption) (*grpc.ClientConn, error)
+)

--- a/xds/internal/xdsclient/transport/transport_ack_nack_test.go
+++ b/xds/internal/xdsclient/transport/transport_ack_nack_test.go
@@ -29,7 +29,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/internal/testutils"
 	"google.golang.org/grpc/internal/testutils/xds/e2e"
-	xdstestutils "google.golang.org/grpc/xds/internal/testutils"
+	"google.golang.org/grpc/internal/xds/bootstrap"
 	"google.golang.org/grpc/xds/internal/xdsclient/transport"
 	"google.golang.org/grpc/xds/internal/xdsclient/xdsresource/version"
 	"google.golang.org/protobuf/proto"
@@ -133,9 +133,14 @@ func (s) TestSimpleAckAndNack(t *testing.T) {
 		SkipValidation: true,
 	})
 
+	serverCfg, err := bootstrap.ServerConfigForTesting(bootstrap.ServerConfigTestingOptions{URI: mgmtServer.Address})
+	if err != nil {
+		t.Fatalf("Failed to create server config for testing: %v", err)
+	}
+
 	// Create a new transport.
 	tr, err := transport.New(transport.Options{
-		ServerCfg:      *xdstestutils.ServerConfigForAddress(t, mgmtServer.Address),
+		ServerCfg:      serverCfg,
 		OnRecvHandler:  dataModelValidator,
 		OnErrorHandler: func(err error) {},
 		OnSendHandler:  func(*transport.ResourceSendInfo) {},
@@ -313,9 +318,14 @@ func (s) TestInvalidFirstResponse(t *testing.T) {
 		SkipValidation: true,
 	})
 
+	serverCfg, err := bootstrap.ServerConfigForTesting(bootstrap.ServerConfigTestingOptions{URI: mgmtServer.Address})
+	if err != nil {
+		t.Fatalf("Failed to create server config for testing: %v", err)
+	}
+
 	// Create a new transport.
 	tr, err := transport.New(transport.Options{
-		ServerCfg:      *xdstestutils.ServerConfigForAddress(t, mgmtServer.Address),
+		ServerCfg:      serverCfg,
 		NodeProto:      &v3corepb.Node{Id: nodeID},
 		OnRecvHandler:  dataModelValidator,
 		OnErrorHandler: func(err error) {},
@@ -435,9 +445,14 @@ func (s) TestResourceIsNotRequestedAnymore(t *testing.T) {
 		SkipValidation: true,
 	})
 
+	serverCfg, err := bootstrap.ServerConfigForTesting(bootstrap.ServerConfigTestingOptions{URI: mgmtServer.Address})
+	if err != nil {
+		t.Fatalf("Failed to create server config for testing: %v", err)
+	}
+
 	// Create a new transport.
 	tr, err := transport.New(transport.Options{
-		ServerCfg:      *xdstestutils.ServerConfigForAddress(t, mgmtServer.Address),
+		ServerCfg:      serverCfg,
 		NodeProto:      &v3corepb.Node{Id: nodeID},
 		OnRecvHandler:  dataModelValidator,
 		OnErrorHandler: func(err error) {},

--- a/xds/internal/xdsclient/transport/transport_new_test.go
+++ b/xds/internal/xdsclient/transport/transport_new_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 
 	"google.golang.org/grpc/internal/xds/bootstrap"
-	"google.golang.org/grpc/xds/internal/testutils"
 	"google.golang.org/grpc/xds/internal/xdsclient/transport"
 
 	v3corepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -31,25 +30,20 @@ import (
 // TestNew covers that New() returns an error if the input *ServerConfig
 // contains invalid content.
 func (s) TestNew(t *testing.T) {
+	serverCfg, err := bootstrap.ServerConfigForTesting(bootstrap.ServerConfigTestingOptions{URI: "server-address"})
+	if err != nil {
+		t.Fatalf("Failed to create server config for testing: %v", err)
+	}
+
 	tests := []struct {
 		name       string
 		opts       transport.Options
 		wantErrStr string
 	}{
 		{
-			name:       "missing server URI",
-			opts:       transport.Options{ServerCfg: bootstrap.ServerConfig{}},
-			wantErrStr: "missing server URI when creating a new transport",
-		},
-		{
-			name:       "missing credentials",
-			opts:       transport.Options{ServerCfg: bootstrap.ServerConfig{ServerURI: "server-address"}},
-			wantErrStr: "missing credentials when creating a new transport",
-		},
-		{
 			name: "missing onRecv handler",
 			opts: transport.Options{
-				ServerCfg: *testutils.ServerConfigForAddress(t, "server-address"),
+				ServerCfg: serverCfg,
 				NodeProto: &v3corepb.Node{},
 			},
 			wantErrStr: "missing OnRecv callback handler when creating a new transport",
@@ -57,7 +51,7 @@ func (s) TestNew(t *testing.T) {
 		{
 			name: "missing onError handler",
 			opts: transport.Options{
-				ServerCfg:     *testutils.ServerConfigForAddress(t, "server-address"),
+				ServerCfg:     serverCfg,
 				NodeProto:     &v3corepb.Node{},
 				OnRecvHandler: func(transport.ResourceUpdate) error { return nil },
 				OnSendHandler: func(*transport.ResourceSendInfo) {},
@@ -68,7 +62,7 @@ func (s) TestNew(t *testing.T) {
 		{
 			name: "missing onSend handler",
 			opts: transport.Options{
-				ServerCfg:      *testutils.ServerConfigForAddress(t, "server-address"),
+				ServerCfg:      serverCfg,
 				NodeProto:      &v3corepb.Node{},
 				OnRecvHandler:  func(transport.ResourceUpdate) error { return nil },
 				OnErrorHandler: func(error) {},
@@ -78,7 +72,7 @@ func (s) TestNew(t *testing.T) {
 		{
 			name: "happy case",
 			opts: transport.Options{
-				ServerCfg:      *testutils.ServerConfigForAddress(t, "server-address"),
+				ServerCfg:      serverCfg,
 				NodeProto:      &v3corepb.Node{},
 				OnRecvHandler:  func(transport.ResourceUpdate) error { return nil },
 				OnErrorHandler: func(error) {},

--- a/xds/internal/xdsclient/xdsresource/listener_resource_type.go
+++ b/xds/internal/xdsclient/xdsresource/listener_resource_type.go
@@ -60,12 +60,12 @@ func securityConfigValidator(bc *bootstrap.Config, sc *SecurityConfig) error {
 		return nil
 	}
 	if sc.IdentityInstanceName != "" {
-		if _, ok := bc.CertProviderConfigs[sc.IdentityInstanceName]; !ok {
+		if _, ok := bc.CertProviderConfigs()[sc.IdentityInstanceName]; !ok {
 			return fmt.Errorf("identity certificate provider instance name %q missing in bootstrap configuration", sc.IdentityInstanceName)
 		}
 	}
 	if sc.RootInstanceName != "" {
-		if _, ok := bc.CertProviderConfigs[sc.RootInstanceName]; !ok {
+		if _, ok := bc.CertProviderConfigs()[sc.RootInstanceName]; !ok {
 			return fmt.Errorf("root certificate provider instance name %q missing in bootstrap configuration", sc.RootInstanceName)
 		}
 	}

--- a/xds/internal/xdsclient/xdsresource/tests/unmarshal_cds_test.go
+++ b/xds/internal/xdsclient/xdsresource/tests/unmarshal_cds_test.go
@@ -99,6 +99,10 @@ func (s) TestValidateCluster_Success(t *testing.T) {
 			return customLBConfig{}, nil
 		},
 	})
+	serverCfg, err := bootstrap.ServerConfigForTesting(bootstrap.ServerConfigTestingOptions{URI: "test-server"})
+	if err != nil {
+		t.Fatalf("Failed to create server config for testing: %v", err)
+	}
 
 	defer func(old bool) { envconfig.LeastRequestLB = old }(envconfig.LeastRequestLB)
 	envconfig.LeastRequestLB = true
@@ -214,11 +218,11 @@ func (s) TestValidateCluster_Success(t *testing.T) {
 				ServiceName: serviceName,
 				EnableLRS:   true,
 			}),
-			serverCfg: &bootstrap.ServerConfig{ServerURI: "test-server-uri"},
+			serverCfg: serverCfg,
 			wantUpdate: xdsresource.ClusterUpdate{
 				ClusterName:     clusterName,
 				EDSServiceName:  serviceName,
-				LRSServerConfig: &bootstrap.ServerConfig{ServerURI: "test-server-uri"},
+				LRSServerConfig: serverCfg,
 			},
 			wantLBConfig: &iserviceconfig.BalancerConfig{
 				Name: wrrlocality.Name,
@@ -251,11 +255,11 @@ func (s) TestValidateCluster_Success(t *testing.T) {
 				}
 				return c
 			}(),
-			serverCfg: &bootstrap.ServerConfig{ServerURI: "test-server-uri"},
+			serverCfg: serverCfg,
 			wantUpdate: xdsresource.ClusterUpdate{
 				ClusterName:     clusterName,
 				EDSServiceName:  serviceName,
-				LRSServerConfig: &bootstrap.ServerConfig{ServerURI: "test-server-uri"},
+				LRSServerConfig: serverCfg,
 				MaxRequests:     func() *uint32 { i := uint32(512); return &i }(),
 			},
 			wantLBConfig: &iserviceconfig.BalancerConfig{

--- a/xds/internal/xdsclient/xdsresource/unmarshal_cds_test.go
+++ b/xds/internal/xdsclient/xdsresource/unmarshal_cds_test.go
@@ -1263,6 +1263,11 @@ func (s) TestUnmarshalCluster(t *testing.T) {
 		})
 	)
 
+	serverCfg, err := bootstrap.ServerConfigForTesting(bootstrap.ServerConfigTestingOptions{URI: "test-server"})
+	if err != nil {
+		t.Fatalf("Failed to create server config for testing: %v", err)
+	}
+
 	tests := []struct {
 		name       string
 		resource   *anypb.Any
@@ -1319,48 +1324,48 @@ func (s) TestUnmarshalCluster(t *testing.T) {
 		{
 			name:      "v3 cluster",
 			resource:  v3ClusterAny,
-			serverCfg: &bootstrap.ServerConfig{ServerURI: "test-server-uri"},
+			serverCfg: serverCfg,
 			wantName:  v3ClusterName,
 			wantUpdate: ClusterUpdate{
 				ClusterName:     v3ClusterName,
 				EDSServiceName:  v3Service,
-				LRSServerConfig: &bootstrap.ServerConfig{ServerURI: "test-server-uri"},
+				LRSServerConfig: serverCfg,
 				Raw:             v3ClusterAny,
 			},
 		},
 		{
 			name:      "v3 cluster wrapped",
 			resource:  testutils.MarshalAny(t, &v3discoverypb.Resource{Resource: v3ClusterAny}),
-			serverCfg: &bootstrap.ServerConfig{ServerURI: "test-server-uri"},
+			serverCfg: serverCfg,
 			wantName:  v3ClusterName,
 			wantUpdate: ClusterUpdate{
 				ClusterName:     v3ClusterName,
 				EDSServiceName:  v3Service,
-				LRSServerConfig: &bootstrap.ServerConfig{ServerURI: "test-server-uri"},
+				LRSServerConfig: serverCfg,
 				Raw:             v3ClusterAny,
 			},
 		},
 		{
 			name:      "v3 cluster with EDS config source self",
 			resource:  v3ClusterAnyWithEDSConfigSourceSelf,
-			serverCfg: &bootstrap.ServerConfig{ServerURI: "test-server-uri"},
+			serverCfg: serverCfg,
 			wantName:  v3ClusterName,
 			wantUpdate: ClusterUpdate{
 				ClusterName:     v3ClusterName,
 				EDSServiceName:  v3Service,
-				LRSServerConfig: &bootstrap.ServerConfig{ServerURI: "test-server-uri"},
+				LRSServerConfig: serverCfg,
 				Raw:             v3ClusterAnyWithEDSConfigSourceSelf,
 			},
 		},
 		{
 			name:      "v3 cluster with telemetry case",
 			resource:  v3ClusterAnyWithTelemetryLabels,
-			serverCfg: &bootstrap.ServerConfig{ServerURI: "test-server-uri"},
+			serverCfg: serverCfg,
 			wantName:  v3ClusterName,
 			wantUpdate: ClusterUpdate{
 				ClusterName:     v3ClusterName,
 				EDSServiceName:  v3Service,
-				LRSServerConfig: &bootstrap.ServerConfig{ServerURI: "test-server-uri"},
+				LRSServerConfig: serverCfg,
 				Raw:             v3ClusterAnyWithTelemetryLabels,
 				TelemetryLabels: map[string]string{
 					"csm.service_name":           "grpc-service",
@@ -1371,12 +1376,12 @@ func (s) TestUnmarshalCluster(t *testing.T) {
 		{
 			name:      "v3 metadata ignore other types not string and not com.google.csm.telemetry_labels",
 			resource:  v3ClusterAnyWithTelemetryLabelsIgnoreSome,
-			serverCfg: &bootstrap.ServerConfig{ServerURI: "test-server-uri"},
+			serverCfg: serverCfg,
 			wantName:  v3ClusterName,
 			wantUpdate: ClusterUpdate{
 				ClusterName:     v3ClusterName,
 				EDSServiceName:  v3Service,
-				LRSServerConfig: &bootstrap.ServerConfig{ServerURI: "test-server-uri"},
+				LRSServerConfig: serverCfg,
 				Raw:             v3ClusterAnyWithTelemetryLabelsIgnoreSome,
 				TelemetryLabels: map[string]string{
 					"csm.service_name": "grpc-service",

--- a/xds/server.go
+++ b/xds/server.go
@@ -108,7 +108,7 @@ func NewGRPCServer(opts ...grpc.ServerOption) (*GRPCServer, error) {
 
 	// Listener resource name template is mandatory on the server side.
 	cfg := xdsClient.BootstrapConfig()
-	if cfg.ServerListenerResourceNameTemplate == "" {
+	if cfg.ServerListenerResourceNameTemplate() == "" {
 		xdsClientClose()
 		return nil, errors.New("missing server_listener_resource_name_template in the bootstrap configuration")
 	}
@@ -191,7 +191,7 @@ func (s *GRPCServer) Serve(lis net.Listener) error {
 	// string, it will be replaced with the server's listening "IP:port" (e.g.,
 	// "0.0.0.0:8080", "[::]:8080").
 	cfg := s.xdsC.BootstrapConfig()
-	name := bootstrap.PopulateResourceTemplate(cfg.ServerListenerResourceNameTemplate, lis.Addr().String())
+	name := bootstrap.PopulateResourceTemplate(cfg.ServerListenerResourceNameTemplate(), lis.Addr().String())
 
 	// Create a listenerWrapper which handles all functionality required by
 	// this particular instance of Serve().


### PR DESCRIPTION
This PR cleans up how to process the bootstrap configuration. This also brings up in line with other languages in the following ways:
- Do not use a `Node` proto to unmarshal bootstrap config's `node` field. Instead only read the supported fields. This is done by defining a struct with only the supported fields, and appropriate json struct tags.
  - This also ensures that we don't read the `client_features` field from the bootstrap configuration. This is a field which should be completely controlled by the client implementation.
 
Summary of changes:
- `internal/xds/bootstrap` package now exports the following types:
  - `ChannelCreds`: corresponds to the `channel_credentials` field in the bootstrap config
  - `Authority`: corresponds to the `authority` field in the bootstrap config
    - The above types are very simple, and do not contain custom JSON marshal/unmarshal logic;
    - Therefore, these contain fields that are exported with json struct tags in them. This makes it possible to marshal and unmarshal using `json.Marshal` and `json.Unmarshal`;
    - These types do implement an `Equal` method to ensure that tests can use `cmp.Diff` or `cmp.Equal` without any custom cmp opts.
  - `ServerConfig`: corresponds to the message type within the `xds_servers` field in the bootstrap config
  - `Config`: the complete bootstrap configuration
    - The above types contain custom marshal/unmarshal logic. So, they implement `MarshalJSON` and `UnmarshalJSON` methods;
    - These types are opaque, i.e fields are not exported, but they do come with getters;
    - They also implement an `Equal` method for use with `cmp.Diff` and `cmp.Equal`.
    - A corresponding unexported type (`serverConfigJSON` and `configJSON`) is also defined with exported fields and json struct tags to make it easy to marshal and unamrshal to JSON, instead of the old way, where we marshal to `map[string]json.RawMessage` and traverse the map, and individually marshal each of the fields.
- Remove mentions of the `xds_v3` server feature. We do not support it any more. See [here](https://github.com/grpc/grpc/blob/master/doc/grpc_xds_features.md) for when support was removed.
- Use the `passthrough` scheme to dial the xDS management server from tests.
  - This is a subtlety arising out of the interaction between `grpc.NewClient` which defaults to scheme `dns`, and how some tests override the actual `dns` resolver with a mock one.

With this change, tests cannot create a `ServerConfig` or `Config` struct using literal struct initializations. We have helpers to construct `ServerConfig` for tests, and we can create `Config` from JSON for tests. In a follow-up PR, I will move code out of `internal/testutils/xds/bootstrap` which contains code to create `Config` for tests using options, and move it into the main `bootstrap` package. This change will simplify dependencies for tests, and will also help with eventually moving everything out of `xds/internal` to `internal/xds`.

#a71-xds-fallback

RELEASE NOTES: none