### PR TITLE
credentials/alts: fix defer in TestDial

### DIFF
--- a/credentials/alts/internal/handshaker/service/service.go
+++ b/credentials/alts/internal/handshaker/service/service.go
@@ -34,8 +34,6 @@ var (
 	// to a corresponding connection to a hypervisor handshaker service
 	// instance.
 	hsConnMap = make(map[string]*grpc.ClientConn)
-	// hsDialer will be reassigned in tests.
-	hsDialer = grpc.Dial
 )
 
 // Dial dials the handshake service in the hypervisor. If a connection has
@@ -50,7 +48,7 @@ func Dial(hsAddress string) (*grpc.ClientConn, error) {
 		// Create a new connection to the handshaker service. Note that
 		// this connection stays open until the application is closed.
 		var err error
-		hsConn, err = hsDialer(hsAddress, grpc.WithTransportCredentials(insecure.NewCredentials()))
+		hsConn, err = grpc.Dial(hsAddress, grpc.WithTransportCredentials(insecure.NewCredentials()))
 		if err != nil {
 			return nil, err
 		}

--- a/credentials/alts/internal/handshaker/service/service_test.go
+++ b/credentials/alts/internal/handshaker/service/service_test.go
@@ -30,14 +30,12 @@ const (
 )
 
 func TestDial(t *testing.T) {
-	defer func() func() {
-		temp := hsDialer
-		hsDialer = func(target string, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
-			return &grpc.ClientConn{}, nil
-		}
-		return func() {
-			hsDialer = temp
-		}
+	temp := hsDialer
+	hsDialer = func(target string, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
+		return &grpc.ClientConn{}, nil
+	}
+	defer func() {
+		hsDialer = temp
 	}()
 
 	// First call to Dial, it should create a connection to the server running

--- a/credentials/alts/internal/handshaker/service/service_test.go
+++ b/credentials/alts/internal/handshaker/service/service_test.go
@@ -20,8 +20,6 @@ package service
 
 import (
 	"testing"
-
-	grpc "google.golang.org/grpc"
 )
 
 const (
@@ -37,14 +35,6 @@ const (
 //   - Third call to Dial with a different address creates a separate new connection
 //     and expects a different connection from connnection1 and connection2.
 func TestDial(t *testing.T) {
-	temp := hsDialer
-	hsDialer = func(target string, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
-		return &grpc.ClientConn{}, nil
-	}
-	defer func() {
-		hsDialer = temp
-	}()
-
 	// First call to Dial, it should create a connection to the server running
 	// at the given address.
 	conn1, err := Dial(testAddress1)

--- a/credentials/alts/internal/handshaker/service/service_test.go
+++ b/credentials/alts/internal/handshaker/service/service_test.go
@@ -20,30 +20,34 @@ package service
 
 import (
 	"testing"
+
+	"google.golang.org/grpc/internal/grpctest"
 )
+
+type s struct {
+	grpctest.Tester
+}
+
+func Test(t *testing.T) {
+	grpctest.RunSubTests(t, s{})
+}
 
 const (
 	testAddress1 = "some_address_1"
 	testAddress2 = "some_address_2"
 )
 
-// TestDial verifies the behavior of the Dial function in managing gRPC connections
-// and checks the below scenarios:
-//   - First call to Dial with an address creates a new connection and stores it.
-//   - Second call to Dial with the same address returns the existing connection
-//     and expects the returned connection matching with ƒirst connection.
-//   - Third call to Dial with a different address creates a separate new connection
-//     and expects a different connection from connnection1 and connection2.
-func TestDial(t *testing.T) {
+// TestDial verifies the behaviour of alts handshake when there are multiple Dials.
+// If a connection has already been established, this function returns it.
+// Otherwise, a new connection is created.
+func (s) TestDial(t *testing.T) {
 	// First call to Dial, it should create a connection to the server running
 	// at the given address.
 	conn1, err := Dial(testAddress1)
 	if err != nil {
 		t.Fatalf("first call to Dial(%v) failed: %v", testAddress1, err)
 	}
-	if conn1 == nil {
-		t.Fatalf("first call to Dial(%v)=(nil, _), want not nil", testAddress1)
-	}
+	defer conn1.Close()
 	if got, want := hsConnMap[testAddress1], conn1; got != want {
 		t.Fatalf("hsConnMap[%v]=%v, want %v", testAddress1, got, want)
 	}
@@ -53,6 +57,7 @@ func TestDial(t *testing.T) {
 	if err != nil {
 		t.Fatalf("second call to Dial(%v) failed: %v", testAddress1, err)
 	}
+	defer conn2.Close()
 	if got, want := conn2, conn1; got != want {
 		t.Fatalf("second call to Dial(%v)=(%v, _), want (%v,. _)", testAddress1, got, want)
 	}
@@ -60,15 +65,12 @@ func TestDial(t *testing.T) {
 		t.Fatalf("hsConnMap[%v]=%v, want %v", testAddress1, got, want)
 	}
 
-	// Third call to Dial using a different address should create a new
-	// connection.
+	// Third call to Dial using a different address should create a new connection.
 	conn3, err := Dial(testAddress2)
 	if err != nil {
 		t.Fatalf("third call to Dial(%v) failed: %v", testAddress2, err)
 	}
-	if conn3 == nil {
-		t.Fatalf("third call to Dial(%v)=(nil, _), want not nil", testAddress2)
-	}
+	defer conn3.Close()
 	if got, want := hsConnMap[testAddress2], conn3; got != want {
 		t.Fatalf("hsConnMap[%v]=%v, want %v", testAddress2, got, want)
 	}

--- a/credentials/alts/internal/handshaker/service/service_test.go
+++ b/credentials/alts/internal/handshaker/service/service_test.go
@@ -29,6 +29,13 @@ const (
 	testAddress2 = "some_address_2"
 )
 
+// TestDial verifies the behavior of the Dial function in managing gRPC connections
+// and checks the below scenarios:
+//   - First call to Dial with an address creates a new connection and stores it.
+//   - Second call to Dial with the same address returns the existing connection
+//     and expects the returned connection matching with ƒirst connection.
+//   - Third call to Dial with a different address creates a separate new connection
+//     and expects a different connection from connnection1 and connection2.
 func TestDial(t *testing.T) {
 	temp := hsDialer
 	hsDialer = func(target string, opts ...grpc.DialOption) (*grpc.ClientConn, error) {


### PR DESCRIPTION
fix: second call in the defer isn't executing, which prevents the hsDialer restore and hence it was never getting updated. This PR fixes the ```TestDial```.

RELEASE NOTES: n/a