### PR TITLE
github: add cache-dependency-path to setup-go

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -85,7 +85,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.goversion }}
-          cache-dependency-path: "**/go.sum"
+          cache-dependency-path: "**/*go.sum"
 
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -85,9 +85,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.goversion }}
-          cache-dependency-path: |
-              **/go.sum
-              **/go.mod
+          cache-dependency-path: "**/go.sum"
 
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -25,6 +25,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '1.22'
+          cache-dependency-path: "**/go.sum"
       - name: Checkout repo
         uses: actions/checkout@v4
 
@@ -84,6 +85,9 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.goversion }}
+          cache-dependency-path: |
+              **/go.sum
+              **/go.mod
 
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -20,14 +20,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
       # Setup the environment.
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
           go-version: '1.22'
           cache-dependency-path: "**/go.sum"
-      - name: Checkout repo
-        uses: actions/checkout@v4
 
       # Run the vet-proto checks.
       - name: vet-proto
@@ -80,15 +81,15 @@ jobs:
       - name: Setup GRPC environment
         if: matrix.grpcenv != ''
         run: echo "${{ matrix.grpcenv }}" >> $GITHUB_ENV
+        
+      - name: Checkout repo
+        uses: actions/checkout@v4
 
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.goversion }}
           cache-dependency-path: "**/*go.sum"
-
-      - name: Checkout repo
-        uses: actions/checkout@v4
 
       # Only run vet for 'vet' runs.
       - name: Run vet.sh


### PR DESCRIPTION
Fixes: https://github.com/grpc/grpc-go/issues/7287

Also, checkout of the codebase needs to happen before setup-go so that the action can find the dep refs


RELEASE NOTES: none