### PR TITLE
examples/features/retry: Improve docstring

### DIFF
--- a/examples/features/retry/client/main.go
+++ b/examples/features/retry/client/main.go
@@ -47,19 +47,14 @@ var (
 		}]}`
 )
 
-// newClientWithRetries uses grpc.WithDefaultServiceConfig() to set
-// service config, and creates the channel. However, the recommended
-// approach is to fetch the retry configuration from the name resolver
-// rather than defining it on the client side.
-func newClientWithRetries() (*grpc.ClientConn, error) {
-	return grpc.NewClient(*addr, grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithDefaultServiceConfig(retryPolicy))
-}
-
 func main() {
 	flag.Parse()
 
-	// Set up a connection to the server.
-	conn, err := newClientWithRetries()
+	// Set up a connection to the server with service config and create the channel.
+	// However, the recommended approach is to fetch the retry configuration
+	// (which is part of the service config) from the name resolver rather than
+	// defining it on the client side.
+	conn, err := grpc.NewClient(*addr, grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithDefaultServiceConfig(retryPolicy))
 	if err != nil {
 		log.Fatalf("did not connect: %v", err)
 	}

--- a/examples/features/retry/client/main.go
+++ b/examples/features/retry/client/main.go
@@ -47,10 +47,11 @@ var (
 		}]}`
 )
 
-// use grpc.WithDefaultServiceConfig() to set service config. However,
-// better way to manage retry configuration is to retrieve it directly
-// from the name resolver instead of setting it up on the client side.
-func retryDial() (*grpc.ClientConn, error) {
+// newClientWithRetries uses grpc.WithDefaultServiceConfig() to set
+// service config, and creates the channel. However, the recommended
+// approach is to fetch the retry configuration from the name resolver
+// rather than defining it on the client side.
+func newClientWithRetries() (*grpc.ClientConn, error) {
 	return grpc.NewClient(*addr, grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithDefaultServiceConfig(retryPolicy))
 }
 
@@ -58,7 +59,7 @@ func main() {
 	flag.Parse()
 
 	// Set up a connection to the server.
-	conn, err := retryDial()
+	conn, err := newClientWithRetries()
 	if err != nil {
 		log.Fatalf("did not connect: %v", err)
 	}

--- a/examples/features/retry/client/main.go
+++ b/examples/features/retry/client/main.go
@@ -47,7 +47,9 @@ var (
 		}]}`
 )
 
-// use grpc.WithDefaultServiceConfig() to set service config
+// use grpc.WithDefaultServiceConfig() to set service config. However,
+// better way to manage retry configuration is to retrieve it directly
+// from the name resolver instead of setting it up on the client side.
 func retryDial() (*grpc.ClientConn, error) {
 	return grpc.NewClient(*addr, grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithDefaultServiceConfig(retryPolicy))
 }


### PR DESCRIPTION
This issue #7275 talks about the example where the service config is being passed to the NewClient, but ideally the retry config should be accessed via the name resolver instead of defining it from client side. This PR adds the recommended approach.

RELEASE NOTES: n/a