### PR TITLE
doc: fix link to error_details example

### DIFF
--- a/Documentation/rpc-errors.md
+++ b/Documentation/rpc-errors.md
@@ -65,4 +65,4 @@ exit status 1
 [details]:      https://godoc.org/google.golang.org/grpc/internal/status#Status.Details
 [status-err]:   https://godoc.org/google.golang.org/grpc/internal/status#Status.Err
 [status-error]: https://godoc.org/google.golang.org/grpc/status#Error
-[example]:      https://github.com/grpc/grpc-go/tree/master/examples/features/errors
+[example]:      https://github.com/grpc/grpc-go/tree/master/examples/features/error_details


### PR DESCRIPTION
The previously linked example was called errors, but got renamed after the addition of the error_handling example. (see #6293)

RELEASE NOTES: none