### PR TITLE
metadata: make Stringer implementation consistent

### DIFF
--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -90,19 +90,10 @@ func Pairs(kv ...string) MD {
 	return md
 }
 
-// String implements the Stringer interface for pretty-printing a MD.
-// Ordering of the values is non-deterministic as it ranges over a map.
+// String implements fmt.Stringer to allow metadata to be printed when stored
+// in a context.  It returns the metadata map as formatted by Go's fmt package.
 func (md MD) String() string {
-	var sb strings.Builder
-	fmt.Fprintf(&sb, "MD{")
-	for k, v := range md {
-		if sb.Len() > 3 {
-			fmt.Fprintf(&sb, ", ")
-		}
-		fmt.Fprintf(&sb, "%s=[%s]", k, strings.Join(v, ", "))
-	}
-	fmt.Fprintf(&sb, "}")
-	return sb.String()
+	return fmt.Sprint(map[string][]string(md))
 }
 
 // Len returns the number of items in md.

--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"reflect"
 	"strconv"
-	"strings"
 	"testing"
 	"time"
 
@@ -342,19 +341,19 @@ func (s) TestAppendToOutgoingContext_FromKVSlice(t *testing.T) {
 func TestStringerMD(t *testing.T) {
 	for _, test := range []struct {
 		md   MD
-		want []string
+		want string
 	}{
-		{MD{}, []string{"MD{}"}},
-		{MD{"k1": []string{}}, []string{"MD{k1=[]}"}},
-		{MD{"k1": []string{"v1", "v2"}}, []string{"MD{k1=[v1, v2]}"}},
-		{MD{"k1": []string{"v1"}}, []string{"MD{k1=[v1]}"}},
-		{MD{"k1": []string{"v1", "v2"}, "k2": []string{}, "k3": []string{"1", "2", "3"}}, []string{"MD{", "k1=[v1, v2]", "k2=[]", "k3=[1, 2, 3]", "}"}},
+		{MD{}, "map[]"},
+		{MD{"k1": []string{}}, "map[k1:[]]"},
+		{MD{"k1": []string{"v1", "v2"}}, "map[k1:[v1 v2]]"},
+		{MD{"k1": []string{"v1"}}, "map[k1:[v1]]"},
+		{MD{"k1": []string{"v1", "v2"}, "k2": []string{}, "k3": []string{"1", "2", "3"}}, "map[k1:[v1 v2] k2:[] k3:[1 2 3]]"},
+		{MD{"k2": []string{}, "k3": []string{"1", "2", "3"}, "k1": []string{"v1", "v2"}}, "map[k1:[v1 v2] k2:[] k3:[1 2 3]]"},
+		{MD{"k3": []string{"1", "2", "3"}, "k2": []string{}, "k1": []string{"v1", "v2"}}, "map[k1:[v1 v2] k2:[] k3:[1 2 3]]"},
 	} {
 		got := test.md.String()
-		for _, want := range test.want {
-			if !strings.Contains(got, want) {
-				t.Fatalf("Metadata string %q is missing %q", got, want)
-			}
+		if got != test.want {
+			t.Fatalf("Metadata string %q should be %q", got, test.want)
 		}
 	}
 }


### PR DESCRIPTION
Please see the following kubernetes/etcd test scenario failure:
https://github.com/kubernetes/kubernetes/issues/125688

and notes from @serathius here on why this is important for etcd watches to work:
https://github.com/grpc/grpc-go/pull/7137#issuecomment-2192423620

RELEASE NOTES:
- metadata/metadata: ensure the String interface for pretty printing MD is deterministic

