### PR TITLE
xds: Add a test for incorrect load reporting when using pickfirst with servers in multiple localities

### DIFF
--- a/internal/stubserver/stubserver.go
+++ b/internal/stubserver/stubserver.go
@@ -238,7 +238,7 @@ func (ss *StubServer) Stop() {
 	for i := len(ss.cleanups) - 1; i >= 0; i-- {
 		ss.cleanups[i]()
 	}
-    ss.cleanups = nil
+	ss.cleanups = nil
 }
 
 func parseCfg(r *manual.Resolver, s string) *serviceconfig.ParseResult {

--- a/internal/stubserver/stubserver.go
+++ b/internal/stubserver/stubserver.go
@@ -238,6 +238,7 @@ func (ss *StubServer) Stop() {
 	for i := len(ss.cleanups) - 1; i >= 0; i-- {
 		ss.cleanups[i]()
 	}
+    ss.cleanups = nil
 }
 
 func parseCfg(r *manual.Resolver, s string) *serviceconfig.ParseResult {

--- a/xds/internal/balancer/clusterimpl/tests/balancer_test.go
+++ b/xds/internal/balancer/clusterimpl/tests/balancer_test.go
@@ -232,7 +232,7 @@ func (s) TestLoadReportingPickFirstMultiLocality(t *testing.T) {
 		Listeners: []*v3listenerpb.Listener{e2e.DefaultClientListener(serviceName, routeConfigName)},
 		Routes:    []*v3routepb.RouteConfiguration{e2e.DefaultRouteConfig(routeConfigName, serviceName, clusterName)},
 		Clusters: []*v3clusterpb.Cluster{
-			&v3clusterpb.Cluster{
+			{
 				Name:                 clusterName,
 				ClusterDiscoveryType: &v3clusterpb.Cluster_Type{Type: v3clusterpb.Cluster_EDS},
 				EdsClusterConfig: &v3clusterpb.Cluster_EdsClusterConfig{

--- a/xds/internal/balancer/clusterimpl/tests/balancer_test.go
+++ b/xds/internal/balancer/clusterimpl/tests/balancer_test.go
@@ -306,14 +306,14 @@ func (s) TestLoadReportingPickFirstMultiLocality(t *testing.T) {
 	}
 	mgmtServer.LRSServer.LRSResponseChan <- &resp
 
-	// Wait for load to be reported for locality of server 1.
-	if err := waitForSuccessfulLoadReport(ctx, mgmtServer.LRSServer, "region-1"); err != nil {
-		// TODO(#7339): Enable this test once pickfirst has one address per subconn.
-		// This assertion fails because pickfirst always reports load for the locality
-		// of the last address in the subconn. This will be fixed by ensuring
-		// there is only one address per subconn.
-		t.Skip("Skipping due to issue #7339.")
-		t.Fatalf("server 1 did not receive load due to error: %v", err)
+	// Wait for load to be reported for locality of server 2.
+	// We (incorrectly) wait for load report for region-2 because presently
+	// pickfirst always reports load for the locality of the last address in the
+	// subconn. This will be fixed by ensuring there is only one address per
+	// subconn.
+	// TODO(#7339): Change region to region-1 once fixed.
+	if err := waitForSuccessfulLoadReport(ctx, mgmtServer.LRSServer, "region-2"); err != nil {
+		t.Fatalf("region-2 did not receive load due to error: %v", err)
 	}
 
 	// Stop server 1 and send one more rpc. Now the request should go to server 2.

--- a/xds/internal/balancer/clusterimpl/tests/balancer_test.go
+++ b/xds/internal/balancer/clusterimpl/tests/balancer_test.go
@@ -216,7 +216,7 @@ func (s) TestLoadReportingPickFirstMultiLocality(t *testing.T) {
 	clusterName := "cluster-" + serviceName
 	endpointsName := "endpoints-" + serviceName
 	routePolicy := e2e.DefaultRouteConfig(routeConfigName, serviceName, clusterName)
-    // Configure retries as we will shut down server 1 and switch to server 2 later.
+	// Configure retries as we will shut down server 1 and switch to server 2 later.
 	routePolicy.VirtualHosts[0].RetryPolicy = &v3routepb.RetryPolicy{
 		RetryOn:    "unavailable",
 		NumRetries: &wrapperspb.UInt32Value{Value: 1},

--- a/xds/internal/balancer/clusterimpl/tests/balancer_test.go
+++ b/xds/internal/balancer/clusterimpl/tests/balancer_test.go
@@ -182,6 +182,8 @@ func (s) TestConfigUpdateWithSameLoadReportingServerConfig(t *testing.T) {
 // TestLoadReportingPickFirstMultiLocality tests whether load is reported correctly
 // when using pickfirst with endpoints in multiple localities.
 func (s) TestLoadReportingPickFirstMultiLocality(t *testing.T) {
+	// TODO(#7339): Enable this test once pickfirst has one address per subconn.
+	t.Skip("Skipping due to issue #7339.")
 	originalTickerFactory := transport.TickerFactory
 	tickChan := make(chan time.Time)
 	transport.TickerFactory = func(freq time.Duration) (<-chan time.Time, func()) {

--- a/xds/internal/balancer/clusterimpl/tests/balancer_test.go
+++ b/xds/internal/balancer/clusterimpl/tests/balancer_test.go
@@ -321,7 +321,6 @@ func (s) TestLoadReportingPickFirstMultiLocality(t *testing.T) {
 	}
 
 	// Stop server 1 and send one more rpc. Now the request should go to server 2.
-
 	server1.Stop()
 
 	// Wait for the balancer to pick up the server state change.

--- a/xds/internal/balancer/clusterimpl/tests/balancer_test.go
+++ b/xds/internal/balancer/clusterimpl/tests/balancer_test.go
@@ -182,8 +182,6 @@ func (s) TestConfigUpdateWithSameLoadReportingServerConfig(t *testing.T) {
 // TestLoadReportingPickFirstMultiLocality tests whether load is reported correctly
 // when using pickfirst with endpoints in multiple localities.
 func (s) TestLoadReportingPickFirstMultiLocality(t *testing.T) {
-	// TODO(#7339): Enable this test once pickfirst has one address per subconn.
-	t.Skip("Skipping due to issue #7339.")
 	originalTickerFactory := transport.TickerFactory
 	tickChan := make(chan time.Time)
 	transport.TickerFactory = func(freq time.Duration) (<-chan time.Time, func()) {
@@ -379,6 +377,8 @@ func (s) TestLoadReportingPickFirstMultiLocality(t *testing.T) {
 	}
 
 	if finalRegion == initialRegion {
+		// TODO(#7339): Enable this test once pickfirst has one address per subconn.
+		t.Skip("Skipping due to issue #7339.")
 		t.Errorf("Unexpected region received traffic: %q", finalRegion)
 	}
 }

--- a/xds/internal/xdsclient/transport/loadreport.go
+++ b/xds/internal/xdsclient/transport/loadreport.go
@@ -195,6 +195,7 @@ func (t *Transport) recvFirstLoadStatsResponse(stream lrsStream) ([]string, time
 
 	return clusters, interval, nil
 }
+
 func (t *Transport) sendLoadStatsRequest(stream lrsStream, loads []*load.Data) error {
 	clusterStats := make([]*v3endpointpb.ClusterStats, 0, len(loads))
 	for _, sd := range loads {

--- a/xds/internal/xdsclient/transport/loadreport.go
+++ b/xds/internal/xdsclient/transport/loadreport.go
@@ -40,12 +40,6 @@ import (
 
 type lrsStream = v3lrsgrpc.LoadReportingService_StreamLoadStatsClient
 
-// TickerFactory returns tickers. It is used to mock time based events for testing.
-var TickerFactory = func(freq time.Duration) (<-chan time.Time, func()) {
-	tick := time.NewTicker(freq)
-	return tick.C, tick.Stop
-}
-
 // ReportLoad starts reporting loads to the management server the transport is
 // configured to use.
 //
@@ -140,11 +134,11 @@ func (t *Transport) lrsRunner(ctx context.Context) {
 }
 
 func (t *Transport) sendLoads(ctx context.Context, stream lrsStream, clusterNames []string, interval time.Duration) {
-	tc, cancel := TickerFactory(interval)
-	defer cancel()
+	tick := time.NewTicker(interval)
+	defer tick.Stop()
 	for {
 		select {
-		case <-tc:
+		case <-tick.C:
 		case <-ctx.Done():
 			return
 		}


### PR DESCRIPTION
This PR addressed the first task for https://github.com/grpc/grpc-go/issues/7339, adding a unit test that fails. The test presently asserts that the incorrect region received the load until the bug has been fixed:

The test asserts the following after sending 1 rpc:

1. Server 1 received the rpc
1. region-2 receives the load (wrong, but represents the current behaviour)

Then we stop server 1, send another rpc and assert the following:

1. Server 2 received the rpc
1. region-2 receives the load


Issue: https://github.com/grpc/grpc-go/issues/7339

RELEASE NOTES: None