### PR TITLE
metadata: stabilize ValueFromIncomingContext

### DIFF
--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -219,11 +219,6 @@ func FromIncomingContext(ctx context.Context) (MD, bool) {
 // ValueFromIncomingContext returns the metadata value corresponding to the metadata
 // key from the incoming metadata if it exists. Keys are matched in a case insensitive
 // manner.
-//
-// # Experimental
-//
-// Notice: This API is EXPERIMENTAL and may be changed or removed in a
-// later release.
 func ValueFromIncomingContext(ctx context.Context, key string) []string {
 	md, ok := ctx.Value(mdIncomingKey{}).(MD)
 	if !ok {


### PR DESCRIPTION
ValueFromIncomingContext is an API available in metadata package which can be used to fetch single key from grpc metadata with lower memory footprint and cpu time. This PR stabilises the API after which this can be used safely

Fixes: https://github.com/grpc/grpc-go/issues/7298

RELEASE NOTES:
* metadata: stabilize ValueFromIncomingContext