### PR TITLE
transport: add timeout for writing GOAWAY on http2Client.Close()

### DIFF
--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -1009,7 +1009,12 @@ func (t *http2Client) Close(err error) {
 	// Per HTTP/2 spec, a GOAWAY frame must be sent before closing the
 	// connection. See https://httpwg.org/specs/rfc7540.html#GOAWAY.
 	t.controlBuf.put(&goAway{code: http2.ErrCodeNo, debugData: []byte("client transport shutdown"), closeConn: err})
-	<-t.writerDone
+	timer := time.NewTimer(5 * time.Second)
+	select {
+	case <-t.writerDone:
+	case <-timer.C:
+		t.logger.Warningf("timeout waiting for the loopy writer to be closed.")
+	}
 	t.cancel()
 	t.conn.Close()
 	channelz.RemoveEntry(t.channelz.ID)
@@ -1035,6 +1040,7 @@ func (t *http2Client) Close(err error) {
 		}
 		sh.HandleConn(t.ctx, connEnd)
 	}
+	t.logger.Infof("Closed the client connection")
 }
 
 // GracefulClose sets the state to draining, which prevents new streams from

--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -985,6 +985,7 @@ func (t *http2Client) closeStream(s *Stream, err error, rst bool, rstCode http2.
 // only once on a transport. Once it is called, the transport should not be
 // accessed anymore.
 func (t *http2Client) Close(err error) {
+	t.conn.SetWriteDeadline(time.Now().Add(time.Second * 10))
 	t.mu.Lock()
 	// Make sure we only close once.
 	if t.state == closing {

--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -982,7 +982,7 @@ func (t *http2Client) closeStream(s *Stream, err error, rst bool, rstCode http2.
 }
 
 // Close kicks off the shutdown process of the transport. This should be called
-// only once on transport. Once it is called, the transport should not be
+// only once on a transport. Once it is called, the transport should not be
 // accessed anymore.
 func (t *http2Client) Close(err error) {
 	t.mu.Lock()
@@ -1027,7 +1027,8 @@ func (t *http2Client) Close(err error) {
 			st = status.New(codes.Unavailable, err.Error())
 		}
 	case <-time.After(goAwayLoopyWriterTimeout):
-		t.logger.Warningf("Failed to write a GOAWAY frame as part of connection close after %v. Giving up and closing the transport.", goAwayLoopyWriterTimeout)
+		st = status.New(codes.Unavailable, err.Error())
+		t.logger.Warningf("Failed to write a GOAWAY frame as part of connection close after %s. Giving up and closing the transport.", goAwayLoopyWriterTimeout)
 	}
 	t.cancel()
 	t.conn.Close()

--- a/internal/transport/transport_test.go
+++ b/internal/transport/transport_test.go
@@ -90,8 +90,9 @@ const (
 	invalidHeaderField
 	delayRead
 	pingpong
-	goAwayFrameSize = 42
 )
+
+const goAwayFrameSize = 42
 
 func (h *testStreamHandler) handleStreamAndNotify(s *Stream) {
 	if h.notify == nil {
@@ -2661,94 +2662,15 @@ func TestConnectionError_Unwrap(t *testing.T) {
 // clientTransport.Close(), client sends a goaway to the server with the correct
 // error code and debug data.
 func (s) TestClientSendsAGoAwayFrame(t *testing.T) {
-	// Create a server.
-	lis, err := net.Listen("tcp", "localhost:0")
-	if err != nil {
-		t.Fatalf("Error while listening: %v", err)
-	}
-	defer lis.Close()
-	// greetDone is used to notify when server is done greeting the client.
-	greetDone := make(chan struct{})
-	// errorCh verifies that desired GOAWAY not received by server
-	errorCh := make(chan error)
-	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
-	defer cancel()
-	// Launch the server.
-	go func() {
-		sconn, err := lis.Accept()
-		if err != nil {
-			t.Errorf("Error while accepting: %v", err)
-		}
-		defer sconn.Close()
-		if _, err := io.ReadFull(sconn, make([]byte, len(clientPreface))); err != nil {
-			t.Errorf("Error while writing settings ack: %v", err)
-			return
-		}
-		sfr := http2.NewFramer(sconn, sconn)
-		if err := sfr.WriteSettings(); err != nil {
-			t.Errorf("Error while writing settings %v", err)
-			return
-		}
-		fr, _ := sfr.ReadFrame()
-		if _, ok := fr.(*http2.SettingsFrame); !ok {
-			t.Errorf("Expected settings frame, got %v", fr)
-		}
-		fr, _ = sfr.ReadFrame()
-		if fr, ok := fr.(*http2.SettingsFrame); !ok || !fr.IsAck() {
-			t.Errorf("Expected settings ACK frame, got %v", fr)
-		}
-		fr, _ = sfr.ReadFrame()
-		if fr, ok := fr.(*http2.HeadersFrame); !ok || !fr.Flags.Has(http2.FlagHeadersEndHeaders) {
-			t.Errorf("Expected Headers frame with END_HEADERS frame, got %v", fr)
-		}
-		close(greetDone)
-
-		frame, err := sfr.ReadFrame()
-		if err != nil {
-			return
-		}
-		switch fr := frame.(type) {
-		case *http2.GoAwayFrame:
-			// Records that the server successfully received a GOAWAY frame.
-			goAwayFrame := fr
-			if goAwayFrame.ErrCode == http2.ErrCodeNo {
-				t.Logf("Received goAway frame from client")
-				close(errorCh)
-			} else {
-				errorCh <- fmt.Errorf("received unexpected goAway frame: %v", err)
-				close(errorCh)
-			}
-			return
-		default:
-			errorCh <- fmt.Errorf("server received a frame other than GOAWAY: %v", err)
-			close(errorCh)
-			return
-		}
-	}()
-
-	ct, err := NewClientTransport(ctx, context.Background(), resolver.Address{Addr: lis.Addr().String()}, ConnectOptions{}, func(GoAwayReason) {})
-	if err != nil {
-		t.Fatalf("Error while creating client transport: %v", err)
-	}
-	_, err = ct.NewStream(ctx, &CallHdr{})
-	if err != nil {
-		t.Fatalf("failed to open stream: %v", err)
-	}
-	// Wait until server receives the headers and settings frame as part of greet.
-	<-greetDone
-	ct.Close(errors.New("manually closed by client"))
-	select {
-	case err := <-errorCh:
-		if err != nil {
-			t.Errorf("Error receiving the GOAWAY frame: %v", err)
-		}
-	case <-ctx.Done():
-		t.Errorf("Context timed out")
-	}
+	createClientServerConn(t, ConnectOptions{})
 }
 
+// writeHangSignal is used to hang the net.Conn Write for complete test duration.
 var writeHangSignal chan struct{}
 
+// hangingConn is a net.Conn wrapper for testing, simulating hanging connections
+// after a GOAWAY frame is sent, of which Write operations pause until explicitly signaled
+// or a timeout occurs.
 type hangingConn struct {
 	net.Conn
 }
@@ -2761,8 +2683,7 @@ func (hc *hangingConn) Read(b []byte) (n int, err error) {
 func (hc *hangingConn) Write(b []byte) (n int, err error) {
 	n, err = hc.Conn.Write(b)
 	if n == goAwayFrameSize { // GOAWAY frame
-		writeHangSignal = make(chan struct{})
-		time.Sleep(15 * time.Second)
+		<-writeHangSignal
 	}
 	return n, err
 }
@@ -2801,8 +2722,25 @@ func hangingDialer(_ context.Context, addr string) (net.Conn, error) {
 
 // TestClientCloseTimeoutOnHang verifies that in the event of a graceful
 // client transport shutdown, i.e., clientTransport.Close(), if the conn hung
-// forever, client should still be close itself and do not wait for long.
+// for LoopyWriterTimeout, client should still be close itself and should
+// not wait for long.
 func (s) TestClientCloseTimeoutOnHang(t *testing.T) {
+	origGoAwayLoopyTimeout := GoAwayLoopyWriterTimeout
+	GoAwayLoopyWriterTimeout = 0
+	defer func() {
+		GoAwayLoopyWriterTimeout = origGoAwayLoopyTimeout
+	}()
+	writeHangSignal = make(chan struct{})
+	ctx, _, _ := createClientServerConn(t, ConnectOptions{Dialer: hangingDialer})
+	defer close(writeHangSignal)
+	select {
+	case <-writeHangSignal:
+		t.Errorf("error: channel closed too early.")
+	case <-ctx.Done():
+	}
+}
+
+func createClientServerConn(t *testing.T, connectOptions ConnectOptions) (context.Context, chan error, ClientTransport) {
 	// Create a server.
 	lis, err := net.Listen("tcp", "localhost:0")
 	if err != nil {
@@ -2868,7 +2806,7 @@ func (s) TestClientCloseTimeoutOnHang(t *testing.T) {
 		}
 	}()
 
-	ct, err := NewClientTransport(ctx, context.Background(), resolver.Address{Addr: lis.Addr().String()}, ConnectOptions{Dialer: hangingDialer}, func(GoAwayReason) {})
+	ct, err := NewClientTransport(ctx, context.Background(), resolver.Address{Addr: lis.Addr().String()}, connectOptions, func(GoAwayReason) {})
 	if err != nil {
 		t.Fatalf("Error while creating client transport: %v", err)
 	}
@@ -2879,11 +2817,13 @@ func (s) TestClientCloseTimeoutOnHang(t *testing.T) {
 	// Wait until server receives the headers and settings frame as part of greet.
 	<-greetDone
 	ct.Close(errors.New("manually closed by client"))
-	defer close(writeHangSignal)
 	select {
-	case <-writeHangSignal:
-		t.Errorf("error: channel closed too early.")
+	case err := <-errorCh:
+		if err != nil {
+			t.Errorf("Error receiving the GOAWAY frame: %v", err)
+		}
 	case <-ctx.Done():
+		t.Errorf("Context timed out")
 	}
-
+	return ctx, errorCh, ct
 }

--- a/internal/transport/transport_test.go
+++ b/internal/transport/transport_test.go
@@ -2771,19 +2771,5 @@ func (s) TestClientCloseReturnsEarlyWhenGoAwayWriteHangs(t *testing.T) {
 		t.Fatalf("Failed to open stream: %v", err)
 	}
 
-	ctClosed := make(chan struct{})
-	go func() {
-		// ct.Close will try to send a GOAWAY frame to the server but conn.Write
-		// will time out due to goAwayLoopyWriterTimeout being 0. It is
-		// equivalent of a network hang when GOAWAY doesn't finish within
-		// specified deadline.
-		ct.Close(errors.New("manually closed by client"))
-		close(ctClosed)
-	}()
-
-	select {
-	case <-ctClosed:
-	case <-ctx.Done():
-		t.Errorf("Timeout waiting for Close() to complete")
-	}
+	ct.Close(errors.New("manually closed by client"))
 }

--- a/internal/transport/transport_test.go
+++ b/internal/transport/transport_test.go
@@ -2748,14 +2748,13 @@ func (s) TestClientSendsAGoAwayFrame(t *testing.T) {
 }
 
 // Test that in the event of a graceful client transport shutdown
-// , i.e., clientTransport.Close(), if the conn hung for
-// LoopyWriterTimeout, client should still be close itself and should
-// not wait for long.
+// ,  i.e., clientTransport.Close(), if the GOAWAY write is not
+// finished within specified time due to network hang, client
+// should still close without waiting for too long.
 func (s) TestClientCloseReturnsEarlyWhenGoAwayWriteHangs(t *testing.T) {
-	// Override goAwayLoopyWriterTimeout to 0 so that we always
-	// time out while writing GOAWAY on client.Close(). This is
-	// equivalent to network hang scenario when client is
-	// failing to write GOAWAY frame.
+	// Override timer for writing GOAWAY to 0 so that the connection write
+	// always times out. It is equivalent of real network hang when conn
+	// write for goaway doesn't finish in specified deadline
 	origGoAwayLoopyTimeout := goAwayLoopyWriterTimeout
 	goAwayLoopyWriterTimeout = 0
 	defer func() {
@@ -2768,13 +2767,13 @@ func (s) TestClientCloseReturnsEarlyWhenGoAwayWriteHangs(t *testing.T) {
 		t.Fatalf("Error while listening: %v", err)
 	}
 	defer lis.Close()
-	// serverGreetingDone is used to notify when server is done greeting the client.
-	serverGreetingDone := make(chan struct{})
 	// errorCh verifies that desired GOAWAY not received by server
 	errorCh := make(chan error, 1)
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
-	// Launch the server.
+	// Launch the server and handle HTTP/2 connections, specifically
+	// focusing on the reception and interpretation of GOAWAY frames
+	// sent from client.
 	go func() {
 		defer close(errorCh)
 		conn, err := lis.Accept()
@@ -2782,28 +2781,11 @@ func (s) TestClientCloseReturnsEarlyWhenGoAwayWriteHangs(t *testing.T) {
 			t.Errorf("Error while accepting: %v", err)
 		}
 		defer conn.Close()
-		if _, err := io.ReadFull(conn, make([]byte, len(clientPreface))); err != nil {
-			t.Errorf("Error while reading client preface: %v", err)
-			return
-		}
 		framer := http2.NewFramer(conn, conn)
 		if err := framer.WriteSettings(); err != nil {
 			t.Errorf("Error while writing settings %v", err)
 			return
 		}
-		fr, _ := framer.ReadFrame()
-		if _, ok := fr.(*http2.SettingsFrame); !ok {
-			t.Errorf("Expected settings frame, got %T", fr)
-		}
-		fr, _ = framer.ReadFrame()
-		if fr, ok := fr.(*http2.SettingsFrame); !ok || !fr.IsAck() {
-			t.Errorf("Expected settings ACK frame, got %T", fr)
-		}
-		fr, _ = framer.ReadFrame()
-		if fr, ok := fr.(*http2.HeadersFrame); !ok || !fr.Flags.Has(http2.FlagHeadersEndHeaders) {
-			t.Errorf("Expected Headers frame with END_HEADERS frame, got %T", fr)
-		}
-		close(serverGreetingDone)
 
 		frame, err := framer.ReadFrame()
 		if err != nil {
@@ -2830,16 +2812,14 @@ func (s) TestClientCloseReturnsEarlyWhenGoAwayWriteHangs(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to open stream: %v", err)
 	}
-	// Wait until server receives the headers and settings frame as part of greet.
-	<-serverGreetingDone
-	// ct.Close will try to send the GOAWAY to server and will fail writing
-	// GOAWAY and will eventually close the loopyWriter as
-	// goAwayLoopyWriterTimeout (time out for writing GOAWAY) is set to zero, which is
-	// equivalent to network hang scenario.
+	// ct.Close will try to send the GOAWAY to server but conn.
+	// Write will time out due to goAwayLoopyWriterTimeout being
+	// 0. It is equivalent of a network hang when GOAWAY doesn't
+	// finish within specified deadline.
 	ct.Close(errors.New("manually closed by client"))
 	select {
 	case <-errorCh:
 	case <-ctx.Done():
-		t.Errorf("Context timed out")
+		t.Errorf("timeout waiting for client Close(): Context timed out")
 	}
 }

--- a/internal/transport/transport_test.go
+++ b/internal/transport/transport_test.go
@@ -2778,30 +2778,6 @@ func (hc *hangingConn) Write(b []byte) (n int, err error) {
 	return n, err
 }
 
-func (hc *hangingConn) Close() error {
-	return hc.Conn.Close()
-}
-
-func (hc *hangingConn) LocalAddr() net.Addr {
-	return hc.Conn.LocalAddr()
-}
-
-func (hc *hangingConn) RemoteAddr() net.Addr {
-	return hc.Conn.RemoteAddr()
-}
-
-func (hc *hangingConn) SetDeadline(t time.Time) error {
-	return hc.Conn.SetDeadline(t)
-}
-
-func (hc *hangingConn) SetReadDeadline(t time.Time) error {
-	return hc.Conn.SetReadDeadline(t)
-}
-
-func (hc *hangingConn) SetWriteDeadline(t time.Time) error {
-	return hc.Conn.SetWriteDeadline(t)
-}
-
 func hangingDialer(_ context.Context, addr string) (net.Conn, error) {
 	conn, err := net.Dial("tcp", addr)
 	if err != nil {

--- a/internal/transport/transport_test.go
+++ b/internal/transport/transport_test.go
@@ -32,6 +32,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -57,8 +58,6 @@ type s struct {
 func Test(t *testing.T) {
 	grpctest.RunSubTests(t, s{})
 }
-
-const goAwayFrameSize = 42
 
 var (
 	expectedRequest            = []byte("ping")
@@ -2754,23 +2753,16 @@ func (s) TestClientSendsAGoAwayFrame(t *testing.T) {
 // signaled or a timeout occurs.
 type hangingConn struct {
 	net.Conn
-	hangConn chan struct{}
+	hangConn     chan struct{}
+	startHanging *atomic.Bool
 }
 
 func (hc *hangingConn) Write(b []byte) (n int, err error) {
 	n, err = hc.Conn.Write(b)
-	if n == goAwayFrameSize { // hang the conn after the goAway is received
+	if hc.startHanging.Load() {
 		<-hc.hangConn
 	}
 	return n, err
-}
-
-func hangingDialer(_ context.Context, addr string) (net.Conn, error) {
-	conn, err := net.Dial("tcp", addr)
-	if err != nil {
-		return nil, err
-	}
-	return &hangingConn{Conn: conn, hangConn: make(chan struct{})}, nil
 }
 
 // Tests the scenario where a client transport is closed and writing of the
@@ -2788,14 +2780,35 @@ func (s) TestClientCloseReturnsEarlyWhenGoAwayWriteHangs(t *testing.T) {
 	}()
 
 	// Create the server set up.
-	server, ct, cancel := setUpWithOptions(t, 0, &ServerConfig{}, normal, ConnectOptions{Dialer: hangingDialer})
+	connectCtx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
+	server := setUpServerOnly(t, 0, &ServerConfig{}, normal)
 	defer server.stop()
+	addr := resolver.Address{Addr: "localhost:" + server.port}
+	isGreetingDone := &atomic.Bool{}
+	hangConn := make(chan struct{})
+	defer close(hangConn)
+	dialer := func(_ context.Context, addr string) (net.Conn, error) {
+		conn, err := net.Dial("tcp", addr)
+		if err != nil {
+			return nil, err
+		}
+		return &hangingConn{Conn: conn, hangConn: hangConn, startHanging: isGreetingDone}, nil
+	}
+	copts := ConnectOptions{Dialer: dialer}
+	copts.ChannelzParent = channelzSubChannel(t)
+	// Create client transport with custom dialer
+	ct, connErr := NewClientTransport(connectCtx, context.Background(), addr, copts, func(GoAwayReason) {})
+	if connErr != nil {
+		t.Fatalf("failed to create transport: %v", connErr)
+	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
 	if _, err := ct.NewStream(ctx, &CallHdr{}); err != nil {
 		t.Fatalf("Failed to open stream: %v", err)
 	}
+
+	isGreetingDone.Store(true)
 	ct.Close(errors.New("manually closed by client"))
 }

--- a/internal/transport/transport_test.go
+++ b/internal/transport/transport_test.go
@@ -2753,13 +2753,13 @@ func (s) TestClientSendsAGoAwayFrame(t *testing.T) {
 // signaled or a timeout occurs.
 type hangingConn struct {
 	net.Conn
-	hangConn       chan struct{}
-	isGreetingDone *atomic.Bool
+	hangConn     chan struct{}
+	startHanging *atomic.Bool
 }
 
 func (hc *hangingConn) Write(b []byte) (n int, err error) {
 	n, err = hc.Conn.Write(b)
-	if hc.isGreetingDone.Load() == true {
+	if hc.startHanging.Load() == true {
 		// Hang the Write for more than goAwayLoopyWriterTimeout
 		timer := time.NewTimer(time.Millisecond * 5)
 		defer timer.Stop()
@@ -2795,8 +2795,7 @@ func (s) TestClientCloseReturnsEarlyWhenGoAwayWriteHangs(t *testing.T) {
 		if err != nil {
 			return nil, err
 		}
-		isGreetingDone.Store(false)
-		return &hangingConn{Conn: conn, hangConn: make(chan struct{}), isGreetingDone: isGreetingDone}, nil
+		return &hangingConn{Conn: conn, hangConn: make(chan struct{}), startHanging: isGreetingDone}, nil
 	}
 	copts := ConnectOptions{Dialer: dialer}
 	copts.ChannelzParent = channelzSubChannel(t)


### PR DESCRIPTION
fixes [#7314](https://github.com/grpc/grpc-go/issues/7314)
### Problem
In gRPC 1.64, we released a [feature](https://github.com/grpc/grpc-go/pull/7015) "Send GOAWAY to server on Client Transport Shutdown", post which in case of network hang when we are not able to write GOAWAY frame from client, closing connections will take a very long time.

### What does this PR fix
This PR fixes this issue by having a timeout for loopyWriter to write GOAWAY so that http2Client.Close() doesn't wait for too long.

RELEASE NOTES: 

- transport/http2_client: fix waiting on http2Client.Close() in case of network hang for writing GOAWAY.