### PR TITLE
xds: use locality from the connected address for load reporting

### DIFF
--- a/balancer/balancer.go
+++ b/balancer/balancer.go
@@ -72,11 +72,10 @@ func unregisterForTesting(name string) {
 	delete(m, name)
 }
 
-// connectedAddress returns the connected address for a SubConnState.
-// The second return value is set to to false if the state is not READY, and the
-// first return value is meaningless in this case.
-func connectedAddress(scs SubConnState) (resolver.Address, bool) {
-	return scs.connectedAddress, scs.ConnectivityState == connectivity.Ready
+// connectedAddress returns the connected address for a SubConnState. The
+// address is only valid if the state is READY.
+func connectedAddress(scs SubConnState) resolver.Address {
+	return scs.connectedAddress
 }
 
 // setConnectedAddress sets the connected address for a SubConnState.
@@ -427,12 +426,6 @@ type SubConnState struct {
 	// connectedAddr contains the connected address when ConnectivityState is
 	// Ready. Otherwise, it is indeterminate.
 	connectedAddress resolver.Address
-}
-
-func (lhs SubConnState) Equal(rhs SubConnState) bool {
-	return lhs.ConnectivityState == rhs.ConnectivityState &&
-		lhs.ConnectionError == rhs.ConnectionError &&
-		lhs.connectedAddress.Equal(rhs.connectedAddress)
 }
 
 // ClientConnState describes the state of a ClientConn relevant to the

--- a/balancer/balancer.go
+++ b/balancer/balancer.go
@@ -72,8 +72,20 @@ func unregisterForTesting(name string) {
 	delete(m, name)
 }
 
+// getConnectedAddress returns the connected address for a SubConnState.
+func getConnectedAddress(scs SubConnState) (resolver.Address, bool) {
+	return scs.connectedAddress, scs.ConnectivityState == connectivity.Ready
+}
+
+// setConnectedAddress sets the connected address for a SubConnState.
+func setConnectedAddress(scs *SubConnState, addr resolver.Address) {
+	scs.connectedAddress = addr
+}
+
 func init() {
 	internal.BalancerUnregister = unregisterForTesting
+	internal.GetConnectedAddress = getConnectedAddress
+	internal.SetConnectedAddress = setConnectedAddress
 }
 
 // Get returns the resolver builder registered with the given name.
@@ -410,6 +422,9 @@ type SubConnState struct {
 	// ConnectionError is set if the ConnectivityState is TransientFailure,
 	// describing the reason the SubConn failed.  Otherwise, it is nil.
 	ConnectionError error
+	// connectedAddr contains the connected address when ConnectivityState is Ready. Otherwise, it is
+	// indeterminate.
+	connectedAddress resolver.Address
 }
 
 // ClientConnState describes the state of a ClientConn relevant to the

--- a/balancer/balancer.go
+++ b/balancer/balancer.go
@@ -72,7 +72,8 @@ func unregisterForTesting(name string) {
 	delete(m, name)
 }
 
-// getConnectedAddress returns the connected address for a SubConnState.
+// getConnectedAddress returns the connected address for a SubConnState and
+// whether or not it is valid.
 func getConnectedAddress(scs SubConnState) (resolver.Address, bool) {
 	return scs.connectedAddress, scs.ConnectivityState == connectivity.Ready
 }
@@ -422,9 +423,15 @@ type SubConnState struct {
 	// ConnectionError is set if the ConnectivityState is TransientFailure,
 	// describing the reason the SubConn failed.  Otherwise, it is nil.
 	ConnectionError error
-	// connectedAddr contains the connected address when ConnectivityState is Ready. Otherwise, it is
-	// indeterminate.
+	// connectedAddr contains the connected address when ConnectivityState is
+	// Ready. Otherwise, it is indeterminate.
 	connectedAddress resolver.Address
+}
+
+func (lhs SubConnState) Equal(rhs SubConnState) bool {
+	return lhs.ConnectivityState == rhs.ConnectivityState &&
+		lhs.ConnectionError == rhs.ConnectionError &&
+		lhs.connectedAddress.Addr == rhs.connectedAddress.Addr
 }
 
 // ClientConnState describes the state of a ClientConn relevant to the

--- a/balancer/balancer.go
+++ b/balancer/balancer.go
@@ -432,7 +432,7 @@ type SubConnState struct {
 func (lhs SubConnState) Equal(rhs SubConnState) bool {
 	return lhs.ConnectivityState == rhs.ConnectivityState &&
 		lhs.ConnectionError == rhs.ConnectionError &&
-		lhs.connectedAddress.Addr == rhs.connectedAddress.Addr
+		lhs.connectedAddress.Equal(rhs.connectedAddress)
 }
 
 // ClientConnState describes the state of a ClientConn relevant to the

--- a/balancer/balancer.go
+++ b/balancer/balancer.go
@@ -72,9 +72,10 @@ func unregisterForTesting(name string) {
 	delete(m, name)
 }
 
-// getConnectedAddress returns the connected address for a SubConnState and
-// whether or not it is valid.
-func getConnectedAddress(scs SubConnState) (resolver.Address, bool) {
+// connectedAddress returns the connected address for a SubConnState.
+// The second return value is set to to false if the state is not READY, and the
+// first return value is meaningless in this case.
+func connectedAddress(scs SubConnState) (resolver.Address, bool) {
 	return scs.connectedAddress, scs.ConnectivityState == connectivity.Ready
 }
 
@@ -85,7 +86,7 @@ func setConnectedAddress(scs *SubConnState, addr resolver.Address) {
 
 func init() {
 	internal.BalancerUnregister = unregisterForTesting
-	internal.GetConnectedAddress = getConnectedAddress
+	internal.ConnectedAddress = connectedAddress
 	internal.SetConnectedAddress = setConnectedAddress
 }
 

--- a/balancer_wrapper.go
+++ b/balancer_wrapper.go
@@ -25,7 +25,7 @@ import (
 
 	"google.golang.org/grpc/balancer"
 	"google.golang.org/grpc/connectivity"
-	grpcinternal "google.golang.org/grpc/internal"
+	"google.golang.org/grpc/internal"
 	"google.golang.org/grpc/internal/balancer/gracefulswitch"
 	"google.golang.org/grpc/internal/channelz"
 	"google.golang.org/grpc/internal/grpcsync"
@@ -263,8 +263,8 @@ func (acbw *acBalancerWrapper) updateState(s connectivity.State, curAddr resolve
 		// TODO: delete this comment when UpdateSubConnState is removed.
 		scs := balancer.SubConnState{ConnectivityState: s, ConnectionError: err}
 		if s == connectivity.Ready {
-			if SetConnectedAddress, ok := grpcinternal.SetConnectedAddress.(func(state *balancer.SubConnState, addr resolver.Address)); ok {
-				SetConnectedAddress(&scs, curAddr)
+			if sca, ok := internal.SetConnectedAddress.(func(*balancer.SubConnState, resolver.Address)); ok {
+				sca(&scs, curAddr)
 			}
 		}
 		acbw.stateListener(scs)

--- a/balancer_wrapper.go
+++ b/balancer_wrapper.go
@@ -32,6 +32,8 @@ import (
 	"google.golang.org/grpc/resolver"
 )
 
+var setConnectedAddress = internal.SetConnectedAddress.(func(*balancer.SubConnState, resolver.Address))
+
 // ccBalancerWrapper sits between the ClientConn and the Balancer.
 //
 // ccBalancerWrapper implements methods corresponding to the ones on the
@@ -263,9 +265,7 @@ func (acbw *acBalancerWrapper) updateState(s connectivity.State, curAddr resolve
 		// TODO: delete this comment when UpdateSubConnState is removed.
 		scs := balancer.SubConnState{ConnectivityState: s, ConnectionError: err}
 		if s == connectivity.Ready {
-			if sca, ok := internal.SetConnectedAddress.(func(*balancer.SubConnState, resolver.Address)); ok {
-				sca(&scs, curAddr)
-			}
+			setConnectedAddress(&scs, curAddr)
 		}
 		acbw.stateListener(scs)
 	})

--- a/clientconn.go
+++ b/clientconn.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"math"
 	"net/url"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -918,6 +919,10 @@ func (ac *addrConn) connect() error {
 	return nil
 }
 
+// equalAddress returns true is a and b are considered equal.
+// This is different from the Equal method on the resolver.Address type which
+// considers all fields to determine equality. Here, we only consider fields
+// that are meaningful to the subConn.
 func equalAddress(a, b resolver.Address) bool {
 	return a.Addr == b.Addr && a.ServerName == b.ServerName &&
 		a.Attributes.Equal(b.Attributes) &&
@@ -925,15 +930,7 @@ func equalAddress(a, b resolver.Address) bool {
 }
 
 func equalAddresses(a, b []resolver.Address) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i, v := range a {
-		if !equalAddress(v, b[i]) {
-			return false
-		}
-	}
-	return true
+	return slices.EqualFunc(a, b, func(a, b resolver.Address) bool { return equalAddress(a, b) })
 }
 
 // updateAddrs updates ac.addrs with the new addresses list and handles active

--- a/clientconn.go
+++ b/clientconn.go
@@ -812,13 +812,6 @@ func (cc *ClientConn) applyFailingLBLocked(sc *serviceconfig.ParseResult) {
 	cc.csMgr.updateState(connectivity.TransientFailure)
 }
 
-// addressWithoutBalancerAttributes returns a copy of the input address with
-// the BalancerAttributes field cleared.
-func addressWithoutBalancerAttributes(a resolver.Address) resolver.Address {
-	a.BalancerAttributes = nil
-	return a
-}
-
 // Makes a copy of the input addresses slice. Addresses are passed during
 // subconn creation and address update operations.
 func copyAddresses(in []resolver.Address) []resolver.Address {

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -209,9 +209,9 @@ var (
 	// is the number of elements.  swap swaps the elements with indexes i and j.
 	ShuffleAddressListForTesting any // func(n int, swap func(i, j int))
 
-	// ConnectedAddress returns the connected address for a SubConnState.
-// The second return value is set to to false if the state is not READY, and the
-// first return value is meaningless in this case.
+	// ConnectedAddress returns the connected address for a SubConnState. The
+	// second return value is set to to false if the state is not READY, and the
+	// first return value is meaningless in this case.
 	ConnectedAddress any // func (scs SubConnState) (resolver.Address, bool)
 
 	// SetConnectedAddress sets the connected address for a SubConnState.

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -210,9 +210,8 @@ var (
 	ShuffleAddressListForTesting any // func(n int, swap func(i, j int))
 
 	// ConnectedAddress returns the connected address for a SubConnState. The
-	// second return value is set to to false if the state is not READY, and the
-	// first return value is meaningless in this case.
-	ConnectedAddress any // func (scs SubConnState) (resolver.Address, bool)
+	// address is only valid if the state is READY.
+	ConnectedAddress any // func (scs SubConnState) resolver.Address
 
 	// SetConnectedAddress sets the connected address for a SubConnState.
 	SetConnectedAddress any // func(scs *SubConnState, addr resolver.Address)

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -208,6 +208,13 @@ var (
 	// ShuffleAddressListForTesting pseudo-randomizes the order of addresses.  n
 	// is the number of elements.  swap swaps the elements with indexes i and j.
 	ShuffleAddressListForTesting any // func(n int, swap func(i, j int))
+
+	// GetConnectedAddress returns the connected address for a SubConnState and
+	// whether the address is valid based on the state.
+	GetConnectedAddress any // func (scs SubConnState) (resolver.Address, bool)
+
+	// SetConnectedAddress sets the connected address for a SubConnState.
+	SetConnectedAddress any // func(scs *SubConnState, addr resolver.Address)
 )
 
 // HealthChecker defines the signature of the client-side LB channel health

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -209,9 +209,10 @@ var (
 	// is the number of elements.  swap swaps the elements with indexes i and j.
 	ShuffleAddressListForTesting any // func(n int, swap func(i, j int))
 
-	// GetConnectedAddress returns the connected address for a SubConnState and
-	// whether the address is valid based on the state.
-	GetConnectedAddress any // func (scs SubConnState) (resolver.Address, bool)
+	// ConnectedAddress returns the connected address for a SubConnState.
+// The second return value is set to to false if the state is not READY, and the
+// first return value is meaningless in this case.
+	ConnectedAddress any // func (scs SubConnState) (resolver.Address, bool)
 
 	// SetConnectedAddress sets the connected address for a SubConnState.
 	SetConnectedAddress any // func(scs *SubConnState, addr resolver.Address)

--- a/internal/testutils/balancer.go
+++ b/internal/testutils/balancer.go
@@ -26,7 +26,6 @@ import (
 
 	"google.golang.org/grpc/balancer"
 	"google.golang.org/grpc/connectivity"
-	"google.golang.org/grpc/internal"
 	"google.golang.org/grpc/internal/grpcsync"
 	"google.golang.org/grpc/resolver"
 )
@@ -71,21 +70,6 @@ func (tsc *TestSubConn) GetOrBuildProducer(balancer.ProducerBuilder) (balancer.P
 // UpdateState pushes the state to the listener, if one is registered.
 func (tsc *TestSubConn) UpdateState(state balancer.SubConnState) {
 	<-tsc.connectCalled.Done()
-	if tsc.stateListener != nil {
-		tsc.stateListener(state)
-		return
-	}
-}
-
-// UpdateStateAndConnectedAddress saves the connected address to state if the
-// connectivity state is Ready and pushes the state to the listener if one is
-// registered.
-func (tsc *TestSubConn) UpdateStateAndConnectedAddress(state balancer.SubConnState, addr resolver.Address) {
-	<-tsc.connectCalled.Done()
-	if state.ConnectivityState == connectivity.Ready {
-		sca := internal.SetConnectedAddress.(func(*balancer.SubConnState, resolver.Address))
-		sca(&state, addr)
-	}
 	if tsc.stateListener != nil {
 		tsc.stateListener(state)
 		return

--- a/xds/internal/balancer/clusterimpl/balancer_test.go
+++ b/xds/internal/balancer/clusterimpl/balancer_test.go
@@ -637,7 +637,7 @@ func (s) TestLoadReporting(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 
-	sc1.UpdateState(balancer.SubConnState{ConnectivityState: connectivity.Ready})
+	sc1.UpdateStateAndConnectedAddress(balancer.SubConnState{ConnectivityState: connectivity.Ready}, addrs[0])
 	// Test pick with one backend.
 	const successCount = 5
 	const errorCount = 5

--- a/xds/internal/balancer/clusterimpl/balancer_test.go
+++ b/xds/internal/balancer/clusterimpl/balancer_test.go
@@ -32,6 +32,7 @@ import (
 	"google.golang.org/grpc/balancer/base"
 	"google.golang.org/grpc/balancer/roundrobin"
 	"google.golang.org/grpc/connectivity"
+	"google.golang.org/grpc/internal"
 	"google.golang.org/grpc/internal/balancer/stub"
 	"google.golang.org/grpc/internal/grpctest"
 	internalserviceconfig "google.golang.org/grpc/internal/serviceconfig"
@@ -637,7 +638,10 @@ func (s) TestLoadReporting(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 
-	sc1.UpdateStateAndConnectedAddress(balancer.SubConnState{ConnectivityState: connectivity.Ready}, addrs[0])
+	scs := balancer.SubConnState{ConnectivityState: connectivity.Ready}
+	sca := internal.SetConnectedAddress.(func(*balancer.SubConnState, resolver.Address))
+	sca(&scs, addrs[0])
+	sc1.UpdateState(scs)
 	// Test pick with one backend.
 	const successCount = 5
 	const errorCount = 5

--- a/xds/internal/balancer/clusterimpl/clusterimpl.go
+++ b/xds/internal/balancer/clusterimpl/clusterimpl.go
@@ -361,11 +361,8 @@ func (scw *scWrapper) localityID() xdsinternal.LocalityID {
 func (b *clusterImplBalancer) NewSubConn(addrs []resolver.Address, opts balancer.NewSubConnOptions) (balancer.SubConn, error) {
 	clusterName := b.getClusterName()
 	newAddrs := make([]resolver.Address, len(addrs))
-	// TODO: Don't set the locality here. Let the StateListener handle it all.
-	var lID xdsinternal.LocalityID
 	for i, addr := range addrs {
 		newAddrs[i] = xds.SetXDSHandshakeClusterName(addr, clusterName)
-		lID = xdsinternal.GetLocalityID(newAddrs[i])
 	}
 	var sc balancer.SubConn
 	scw := &scWrapper{}
@@ -390,7 +387,6 @@ func (b *clusterImplBalancer) NewSubConn(addrs []resolver.Address, opts balancer
 		return nil, err
 	}
 	scw.SubConn = sc
-	scw.updateLocalityID(lID)
 	return scw, nil
 }
 

--- a/xds/internal/balancer/clusterimpl/clusterimpl.go
+++ b/xds/internal/balancer/clusterimpl/clusterimpl.go
@@ -372,8 +372,8 @@ func (b *clusterImplBalancer) NewSubConn(addrs []resolver.Address, opts balancer
 	oldListener := opts.StateListener
 	opts.StateListener = func(state balancer.SubConnState) {
 		b.updateSubConnState(sc, state, oldListener)
-		// Read connected address and call updateLocalityID() based on the connected address's locality.
-		// https://github.com/grpc/grpc-go/issues/7339
+		// Read connected address and call updateLocalityID() based on the connected
+		// address's locality. https://github.com/grpc/grpc-go/issues/7339
 		if gca, ok := internal.GetConnectedAddress.(func(balancer.SubConnState) (resolver.Address, bool)); ok {
 			if addr, ok := gca(state); ok {
 				lID := xdsinternal.GetLocalityID(addr)

--- a/xds/internal/balancer/clusterimpl/clusterimpl.go
+++ b/xds/internal/balancer/clusterimpl/clusterimpl.go
@@ -371,13 +371,13 @@ func (b *clusterImplBalancer) NewSubConn(addrs []resolver.Address, opts balancer
 		b.updateSubConnState(sc, state, oldListener)
 		// Read connected address and call updateLocalityID() based on the connected
 		// address's locality. https://github.com/grpc/grpc-go/issues/7339
-		if gca, ok := internal.GetConnectedAddress.(func(balancer.SubConnState) (resolver.Address, bool)); ok {
+		if gca, ok := internal.ConnectedAddress.(func(balancer.SubConnState) (resolver.Address, bool)); ok {
 			if addr, ok := gca(state); ok {
 				lID := xdsinternal.GetLocalityID(addr)
 				if !lID.Empty() {
 					scw.updateLocalityID(lID)
 				} else if b.logger.V(2) {
-					b.logger.Infof("Locality ID for %v unexpectedly empty", addr)
+					b.logger.Infof("Locality ID for %s unexpectedly empty", addr)
 				}
 			}
 		}

--- a/xds/internal/balancer/clusterimpl/tests/balancer_test.go
+++ b/xds/internal/balancer/clusterimpl/tests/balancer_test.go
@@ -310,14 +310,9 @@ func (s) TestLoadReportingPickFirstMultiLocality(t *testing.T) {
 	}
 	mgmtServer.LRSServer.LRSResponseChan <- &resp
 
-	// Wait for load to be reported for locality of server 2.
-	// We (incorrectly) wait for load report for region-2 because presently
-	// pickfirst always reports load for the locality of the last address in the
-	// subconn. This will be fixed by ensuring there is only one address per
-	// subconn.
-	// TODO(#7339): Change region to region-1 once fixed.
-	if err := waitForSuccessfulLoadReport(ctx, mgmtServer.LRSServer, "region-2"); err != nil {
-		t.Fatalf("region-2 did not receive load due to error: %v", err)
+	// Wait for load to be reported for locality of server 1.
+	if err := waitForSuccessfulLoadReport(ctx, mgmtServer.LRSServer, "region-1"); err != nil {
+		t.Fatalf("Server 1 did not receive load due to error: %v", err)
 	}
 
 	// Stop server 1 and send one more rpc. Now the request should go to server 2.

--- a/xds/internal/balancer/outlierdetection/balancer_test.go
+++ b/xds/internal/balancer/outlierdetection/balancer_test.go
@@ -852,7 +852,7 @@ func (s) TestUpdateAddresses(t *testing.T) {
 }
 
 func scwsEqual(gotSCWS subConnWithState, wantSCWS subConnWithState) error {
-	if gotSCWS.sc != wantSCWS.sc || !cmp.Equal(gotSCWS.state, wantSCWS.state, cmp.AllowUnexported(subConnWrapper{}, addressInfo{}), cmpopts.IgnoreFields(subConnWrapper{}, "scUpdateCh")) {
+	if gotSCWS.sc != wantSCWS.sc || !cmp.Equal(gotSCWS.state, wantSCWS.state, cmp.AllowUnexported(subConnWrapper{}, addressInfo{}, balancer.SubConnState{}), cmpopts.IgnoreFields(subConnWrapper{}, "scUpdateCh")) {
 		return fmt.Errorf("received SubConnState: %+v, want %+v", gotSCWS, wantSCWS)
 	}
 	return nil

--- a/xds/internal/internal.go
+++ b/xds/internal/internal.go
@@ -57,7 +57,7 @@ func (l LocalityID) Equal(o any) bool {
 
 // Empty returns whether or not the locality ID is empty.
 func (l LocalityID) Empty() bool {
-	return len(l.Region) == 0 && len(l.Zone) == 0 && len(l.SubZone) == 0
+	return l.Region == "" && l.Zone == "" && l.SubZone == ""
 }
 
 // LocalityIDFromString converts a json representation of locality, into a

--- a/xds/internal/internal.go
+++ b/xds/internal/internal.go
@@ -55,6 +55,11 @@ func (l LocalityID) Equal(o any) bool {
 	return l.Region == ol.Region && l.Zone == ol.Zone && l.SubZone == ol.SubZone
 }
 
+// Empty returns whether or not the locality ID is empty.
+func (l LocalityID) Empty() bool {
+	return len(l.Region) == 0 && len(l.Zone) == 0 && len(l.SubZone) == 0
+}
+
 // LocalityIDFromString converts a json representation of locality, into a
 // LocalityID struct.
 func LocalityIDFromString(s string) (ret LocalityID, _ error) {


### PR DESCRIPTION
* Add `SubConnState.connectedAddress` field.
* Add `internal.GetConnectedAddress` and `internal.SetConnectedAddress` accessor function `var`s to get and set `SubConnState.connectedAddress`.
* Set the connected address in `acBalancerWrapper.updateState` when connectivity state is `Ready`.
* Read the connected address in the subconn `StateListener` and call `updateLocalityID()` based on that address's locality.
* Modify `addrConn` to store the full `resolver.Address` rather than one with `BalancerAttributes` removed.
* Modify a test to check for the new correct behavior.

Fixes #7339

RELEASE NOTES:
- TBD
