### PR TITLE
fix: Add a package-level mutex protecting SetLoggerV2 to avoid DATA RACE errors

### DIFF
--- a/grpclog/loggerv2.go
+++ b/grpclog/loggerv2.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 
 	"google.golang.org/grpc/internal/grpclog"
 )

--- a/grpclog/loggerv2.go
+++ b/grpclog/loggerv2.go
@@ -66,9 +66,15 @@ type LoggerV2 interface {
 	V(l int) bool
 }
 
+// Package-level mutex to protect SetLoggerV2
+var loggerMutex sync.Mutex
+
 // SetLoggerV2 sets logger that is used in grpc to a V2 logger.
-// Not mutex-protected, should be called before any gRPC functions.
+// Now mutex-protected. Should be called before any gRPC functions.
 func SetLoggerV2(l LoggerV2) {
+	loggerMutex.Lock()
+	defer loggerMutex.Unlock()
+
 	if _, ok := l.(*componentData); ok {
 		panic("cannot use component logger as grpclog logger")
 	}


### PR DESCRIPTION
Hi there! 👋 

I have an application running e2e tests for a gRPC server (AKA my service). That service also uses other gRPC clients to call other services. That eventually leads to `grpc_logrus.ReplaceGrpcLogger` being called concurrently due to the server and the clients constructors trying to replace and use the logger at the same time.

It's failing my test suite due to DATA ERRORS and I was wondering if protecting SetLoggerV2 with a Mutex was such a bad idea to avoid this 🤔 

Thanks!