### PR TITLE
cmd/protoc-gen-go-grpc: default use_generic_streams_experimental to true

### DIFF
--- a/cmd/protoc-gen-go-grpc/main.go
+++ b/cmd/protoc-gen-go-grpc/main.go
@@ -57,7 +57,7 @@ func main() {
 
 	var flags flag.FlagSet
 	requireUnimplemented = flags.Bool("require_unimplemented_servers", true, "set to false to match legacy behavior")
-	useGenericStreams = flags.Bool("use_generic_streams_experimental", false, "set to true to use generic types for streaming client and server objects; this flag is EXPERIMENTAL and may be changed or removed in a future release")
+	useGenericStreams = flags.Bool("use_generic_streams_experimental", true, "set to true to use generic types for streaming client and server objects; this flag is EXPERIMENTAL and may be changed or removed in a future release")
 
 	protogen.Options{
 		ParamFunc: flags.Set,


### PR DESCRIPTION
relnotes for cmd/protoc-gen-go-grpc:
* Generated code for services will produce streaming method definitions using one of six different generic types (e.g. `BidiStreamingServer` or `ClientStreamingClient`) instead of producing complete interfaces and implementations for the streaming methods.  This can be disabled by setting `use_generic_streams_experimental=false`.  Please file a bug if you encounter any issues with this behavior.  This will become the default behavior in an upcoming release.
 
RELEASE NOTES: NONE
