### PR TITLE
grpc: hold ac.mu while calling resetTransport to prevent concurrent connection attempts

### DIFF
--- a/clientconn.go
+++ b/clientconn.go
@@ -1228,6 +1228,9 @@ func (ac *addrConn) adjustParams(r transport.GoAwayReason) {
 	}
 }
 
+// resetTransportAndUnlock unconditionally connects the addrConn.
+//
+// ac.mu must be held by the caller, and this function will guarantee it is released.
 func (ac *addrConn) resetTransportAndUnlock() {
 	acCtx := ac.ctx
 	if acCtx.Err() != nil {

--- a/clientconn.go
+++ b/clientconn.go
@@ -918,6 +918,9 @@ func (ac *addrConn) connect() error {
 		ac.mu.Unlock()
 		return nil
 	}
+	// Update the state to ensure no concurrent requests start once the lock
+	// is released.
+	ac.updateConnectivityState(connectivity.Connecting, nil)
 	ac.mu.Unlock()
 
 	ac.resetTransport()

--- a/clientconn.go
+++ b/clientconn.go
@@ -918,12 +918,8 @@ func (ac *addrConn) connect() error {
 		ac.mu.Unlock()
 		return nil
 	}
-	// Update the state to ensure no concurrent requests start once the lock
-	// is released.
-	ac.updateConnectivityState(connectivity.Connecting, nil)
-	ac.mu.Unlock()
 
-	ac.resetTransport()
+	ac.resetTransportAndUnlock()
 	return nil
 }
 
@@ -995,11 +991,9 @@ func (ac *addrConn) updateAddrs(addrs []resolver.Address) {
 		ac.updateConnectivityState(connectivity.Idle, nil)
 	}
 
-	ac.mu.Unlock()
-
 	// Since we were connecting/connected, we should start a new connection
 	// attempt.
-	go ac.resetTransport()
+	go ac.resetTransportAndUnlock()
 }
 
 // getServerName determines the serverName to be used in the connection
@@ -1234,8 +1228,7 @@ func (ac *addrConn) adjustParams(r transport.GoAwayReason) {
 	}
 }
 
-func (ac *addrConn) resetTransport() {
-	ac.mu.Lock()
+func (ac *addrConn) resetTransportAndUnlock() {
 	acCtx := ac.ctx
 	if acCtx.Err() != nil {
 		ac.mu.Unlock()


### PR DESCRIPTION
This change ensures that caller of `resetTransport()` keep holding the mutex instead of releasing it and having `resetTransport()` re-acquire it. This ensures that no concurrent requests are able to start once caller of `resetTransport` does some validation and calls `resetTransport`.

See https://github.com/grpc/grpc-go/issues/7365#issuecomment-2208258873 for more details.

## Tested
Verified that Test/AuthorityRevive no longer flakes for 100000 attempts with the change.

Fixes: https://github.com/grpc/grpc-go/issues/7365

RELEASE NOTES:
- client: fix race that could lead to orphaned connections and associated resources.