### PR TITLE
refactor:rename clientside dialoption field 'maxAttempts'

### DIFF
--- a/clientconn.go
+++ b/clientconn.go
@@ -173,7 +173,7 @@ func NewClient(target string, opts ...DialOption) (conn *ClientConn, err error) 
 	}
 
 	if cc.dopts.defaultServiceConfigRawJSON != nil {
-		scpr := parseServiceConfig(*cc.dopts.defaultServiceConfigRawJSON, cc.dopts.maxCallAttempts)
+		scpr := parseServiceConfig(*cc.dopts.defaultServiceConfigRawJSON, cc.dopts.maxRetryAttempts)
 		if scpr.Err != nil {
 			return nil, fmt.Errorf("%s: %v", invalidDefaultServiceConfigErrPrefix, scpr.Err)
 		}
@@ -696,7 +696,7 @@ func (cc *ClientConn) waitForResolvedAddrs(ctx context.Context) error {
 var emptyServiceConfig *ServiceConfig
 
 func init() {
-	cfg := parseServiceConfig("{}", defaultMaxCallAttempts)
+	cfg := parseServiceConfig("{}", defaultMaxRetryAttempts)
 	if cfg.Err != nil {
 		panic(fmt.Sprintf("impossible error parsing empty service config: %v", cfg.Err))
 	}

--- a/dialoptions.go
+++ b/dialoptions.go
@@ -39,7 +39,7 @@ import (
 
 const (
 	// https://github.com/grpc/proposal/blob/master/A6-client-retries.md#limits-on-retries-and-hedges
-	defaultMaxCallAttempts = 5
+	defaultMaxRetryAttempts = 5
 )
 
 func init() {
@@ -94,7 +94,7 @@ type dialOptions struct {
 	idleTimeout                 time.Duration
 	recvBufferPool              SharedBufferPool
 	defaultScheme               string
-	maxCallAttempts             int
+	maxRetryAttempts            int
 }
 
 // DialOption configures how we set up the connection.
@@ -678,12 +678,12 @@ func defaultDialOptions() dialOptions {
 			UseProxy:        true,
 			UserAgent:       grpcUA,
 		},
-		bs:              internalbackoff.DefaultExponential,
-		healthCheckFunc: internal.HealthCheckFunc,
-		idleTimeout:     30 * time.Minute,
-		recvBufferPool:  nopBufferPool{},
-		defaultScheme:   "dns",
-		maxCallAttempts: defaultMaxCallAttempts,
+		bs:               internalbackoff.DefaultExponential,
+		healthCheckFunc:  internal.HealthCheckFunc,
+		idleTimeout:      30 * time.Minute,
+		recvBufferPool:   nopBufferPool{},
+		defaultScheme:    "dns",
+		maxRetryAttempts: defaultMaxRetryAttempts,
 	}
 }
 
@@ -752,9 +752,9 @@ func WithIdleTimeout(d time.Duration) DialOption {
 func WithMaxCallAttempts(n int) DialOption {
 	return newFuncDialOption(func(o *dialOptions) {
 		if n < 2 {
-			n = defaultMaxCallAttempts
+			n = defaultMaxRetryAttempts
 		}
-		o.maxCallAttempts = n
+		o.maxRetryAttempts = n
 	})
 }
 

--- a/resolver_wrapper.go
+++ b/resolver_wrapper.go
@@ -171,7 +171,7 @@ func (ccr *ccResolverWrapper) NewAddress(addrs []resolver.Address) {
 // ParseServiceConfig is called by resolver implementations to parse a JSON
 // representation of the service config.
 func (ccr *ccResolverWrapper) ParseServiceConfig(scJSON string) *serviceconfig.ParseResult {
-	return parseServiceConfig(scJSON, ccr.cc.dopts.maxCallAttempts)
+	return parseServiceConfig(scJSON, ccr.cc.dopts.maxRetryAttempts)
 }
 
 // addChannelzTraceEvent adds a channelz trace event containing the new

--- a/service_config.go
+++ b/service_config.go
@@ -165,7 +165,7 @@ type jsonSC struct {
 
 func init() {
 	internal.ParseServiceConfig = func(js string) *serviceconfig.ParseResult {
-		return parseServiceConfig(js, defaultMaxCallAttempts)
+		return parseServiceConfig(js, defaultMaxRetryAttempts)
 	}
 }
 func parseServiceConfig(js string, maxAttempts int) *serviceconfig.ParseResult {

--- a/service_config_test.go
+++ b/service_config_test.go
@@ -60,7 +60,7 @@ func runParseTests(t *testing.T, testCases []parseTestCase) {
 	t.Helper()
 	for i, c := range testCases {
 		t.Run(fmt.Sprint(i), func(t *testing.T) {
-			scpr := parseServiceConfig(c.scjs, defaultMaxCallAttempts)
+			scpr := parseServiceConfig(c.scjs, defaultMaxRetryAttempts)
 			var sc *ServiceConfig
 			sc, _ = scpr.Config.(*ServiceConfig)
 			if !c.wantErr {


### PR DESCRIPTION
RELEASE NOTES:
- Renamed the variable `maxCallAttempts` to `maxRetryAttempts` to improve clarity and better represent its purpose.

Recently, I noticed a bug with the RPC client's setting of the maximum number of reconnections. I was very surprised to find that it has been solved in this PR [client: implement maxAttempts for retryPolicy](https://github.com/grpc/grpc-go/pull/7229) .  However, I think the meaning of this variable 'maxCallAttempts' are not clear enough, so I submitted this PR to rename this variable.