### PR TITLE
transport/bufWriter: fast-fail on error returned from flushKeepBuffer()

### DIFF
--- a/internal/transport/http_util.go
+++ b/internal/transport/http_util.go
@@ -340,7 +340,7 @@ func (w *bufWriter) Write(b []byte) (n int, err error) {
 			}
 		}
 	}
-	return n, err
+	return n, nil
 }
 
 func (w *bufWriter) Flush() error {

--- a/internal/transport/http_util.go
+++ b/internal/transport/http_util.go
@@ -36,7 +36,6 @@ import (
 
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/hpack"
-
 	"google.golang.org/grpc/codes"
 )
 

--- a/internal/transport/http_util.go
+++ b/internal/transport/http_util.go
@@ -36,7 +36,6 @@ import (
 
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/hpack"
-
 	"google.golang.org/grpc/codes"
 )
 
@@ -341,7 +340,7 @@ func (w *bufWriter) Write(b []byte) (n int, err error) {
 			}
 		}
 	}
-	return n, nil
+	return n, err
 }
 
 func (w *bufWriter) Flush() error {

--- a/internal/transport/http_util.go
+++ b/internal/transport/http_util.go
@@ -36,6 +36,7 @@ import (
 
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/hpack"
+
 	"google.golang.org/grpc/codes"
 )
 
@@ -335,10 +336,12 @@ func (w *bufWriter) Write(b []byte) (n int, err error) {
 		w.offset += nn
 		n += nn
 		if w.offset >= w.batchSize {
-			err = w.flushKeepBuffer()
+			if err = w.flushKeepBuffer(); err != nil {
+				return n, err
+			}
 		}
 	}
-	return n, err
+	return n, nil
 }
 
 func (w *bufWriter) Flush() error {

--- a/internal/transport/http_util.go
+++ b/internal/transport/http_util.go
@@ -363,8 +363,8 @@ func (w *bufWriter) flushKeepBuffer() error {
 	if w.offset == 0 {
 		return nil
 	}
-	_, err := w.conn.Write(w.buf[:w.offset])
-	w.err = toIOError(err)
+	_, w.err = w.conn.Write(w.buf[:w.offset])
+	w.err = toIOError(w.err)
 	w.offset = 0
 	return w.err
 }

--- a/internal/transport/http_util.go
+++ b/internal/transport/http_util.go
@@ -366,9 +366,8 @@ func (w *bufWriter) flushKeepBuffer() (int, error) {
 	if w.offset == 0 {
 		return 0, nil
 	}
-	var n int
-	n, w.err = w.conn.Write(w.buf[:w.offset])
-	w.err = toIOError(w.err)
+	n, err := w.conn.Write(w.buf[:w.offset])
+	w.err = toIOError(err)
 	w.offset = 0
 	return n, w.err
 }


### PR DESCRIPTION
fixes https://github.com/grpc/grpc-go/issues/7389

RELEASE NOTES:
- fast-fail Write() on error returned from underlying network connection