### PR TITLE
test/channelz: change channelz_test to use write data

### DIFF
--- a/test/channelz_test.go
+++ b/test/channelz_test.go
@@ -1086,7 +1086,7 @@ func (s) TestCZClientAndServerSocketMetricsStreamsCountFlowControlRSTStream(t *t
 	go func() {
 		payload := make([]byte, 16384)
 		for i := 0; i < 6; i++ {
-			dw.getRawConnWrapper().writeRawFrame(http2.FrameData, 0, tc.getCurrentStreamID(), payload)
+			dw.getRawConnWrapper().writeDataFrame(tc.getCurrentStreamID(), payload)
 		}
 	}()
 	if _, err := stream.Recv(); status.Code(err) != codes.ResourceExhausted {

--- a/test/rawConnWrapper.go
+++ b/test/rawConnWrapper.go
@@ -239,8 +239,8 @@ func (rcw *rawConnWrapper) writeGoAway(maxStreamID uint32, code http2.ErrCode, d
 	return nil
 }
 
-func (rcw *rawConnWrapper) writeRawFrame(t http2.FrameType, flags http2.Flags, streamID uint32, payload []byte) error {
-	if err := rcw.fr.WriteRawFrame(t, flags, streamID, payload); err != nil {
+func (rcw *rawConnWrapper) writeDataFrame(streamID uint32, payload []byte) error {
+	if err := rcw.fr.WriteData(streamID, false, payload); err != nil {
 		return fmt.Errorf("error writing Raw Frame: %v", err)
 	}
 	return nil


### PR DESCRIPTION
Remove the call to `WriteRawFrame` in order to remove that method from the new Framer API.

This particular test was calling `WriteRawFrame` to write a Data Frame, which could be replaced by `WriteData` method provided by the x/net/http2 framer.

RELEASE NOTES: none