### PR TITLE
xds: make fallback bootstrap configuration per-process

### DIFF
--- a/internal/testutils/xds/e2e/bootstrap.go
+++ b/internal/testutils/xds/e2e/bootstrap.go
@@ -76,7 +76,7 @@ func DefaultBootstrapContents(t *testing.T, nodeID, serverURI string) []byte {
 			"server_uri": "passthrough:///%s",
 			"channel_creds": [{"type": "insecure"}]
 		}`, serverURI))},
-		NodeID:                             nodeID,
+		Node:                               []byte(fmt.Sprintf(`{"id": "%s"}`, nodeID)),
 		CertificateProviders:               cpc,
 		ServerListenerResourceNameTemplate: ServerListenerResourceNameTemplate,
 	})

--- a/internal/xds/bootstrap/bootstrap.go
+++ b/internal/xds/bootstrap/bootstrap.go
@@ -29,6 +29,7 @@ import (
 	"os"
 	"slices"
 	"strings"
+	"sync"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/tls/certprovider"
@@ -509,54 +510,48 @@ func (c *Config) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// Returns the bootstrap configuration from env vars ${GRPC_XDS_BOOTSTRAP} or
-// ${GRPC_XDS_BOOTSTRAP_CONFIG}. If both env vars are set, the former is
-// preferred. And if none of the env vars are set, an error is returned.
-func bootstrapConfigFromEnvVariable() ([]byte, error) {
-	fName := envconfig.XDSBootstrapFileName
-	fContent := envconfig.XDSBootstrapFileContent
-
-	if fName != "" {
-		if logger.V(2) {
-			logger.Infof("Using bootstrap file with name %q", fName)
-		}
-		return bootstrapFileReadFunc(fName)
-	}
-
-	if fContent != "" {
-		return []byte(fContent), nil
-	}
-
-	return nil, fmt.Errorf("none of the bootstrap environment variables (%q or %q) defined", envconfig.XDSBootstrapFileNameEnv, envconfig.XDSBootstrapFileContentEnv)
-}
-
-// NewConfig returns a new instance of Config initialized by reading the
-// bootstrap file found at ${GRPC_XDS_BOOTSTRAP} or bootstrap contents specified
-// at ${GRPC_XDS_BOOTSTRAP_CONFIG}. If both env vars are set, the former is
-// preferred.
+// GetConfiguration returns the bootstrap configuration initialized by reading
+// the bootstrap file found at ${GRPC_XDS_BOOTSTRAP} or bootstrap contents
+// specified at ${GRPC_XDS_BOOTSTRAP_CONFIG}. If both env vars are set, the
+// former is preferred.
 //
-// We support a credential registration mechanism and only credentials
-// registered through that mechanism will be accepted here. See package
-// `xds/bootstrap` for details.
+// If none of the env vars are set, this function returns the fallback
+// configuration if it is not nil. Else, it returns an error.
 //
 // This function tries to process as much of the bootstrap file as possible (in
 // the presence of the errors) and may return a Config object with certain
 // fields left unspecified, in which case the caller should use some sane
 // defaults.
-func NewConfig() (*Config, error) {
-	// Examples of the bootstrap json can be found in the generator tests
-	// https://github.com/GoogleCloudPlatform/traffic-director-grpc-bootstrap/blob/master/main_test.go.
-	data, err := bootstrapConfigFromEnvVariable()
-	if err != nil {
-		return nil, fmt.Errorf("xds: Failed to read bootstrap config: %v", err)
-	}
-	return newConfigFromContents(data)
-}
+func GetConfiguration() (*Config, error) {
+	fName := envconfig.XDSBootstrapFileName
+	fContent := envconfig.XDSBootstrapFileContent
 
-// NewConfigFromContents returns a new Config using the specified
-// bootstrap file contents instead of reading the environment variable.
-func NewConfigFromContents(data []byte) (*Config, error) {
-	return newConfigFromContents(data)
+	if fName != "" {
+		if logger.V(2) {
+			logger.Infof("Using bootstrap file with name %q from GRPC_XDS_BOOTSTRAP environment variable", fName)
+		}
+		cfg, err := bootstrapFileReadFunc(fName)
+		if err != nil {
+			return nil, fmt.Errorf("xds: failed to read bootstrap config from file %q: %v", fName, err)
+		}
+		return newConfigFromContents(cfg)
+	}
+
+	if fContent != "" {
+		if logger.V(2) {
+			logger.Infof("Using bootstrap contents from GRPC_XDS_BOOTSTRAP_CONFIG environment variable")
+		}
+		return newConfigFromContents([]byte(fContent))
+	}
+
+	if cfg := getFallbackBootstrapConfig(); cfg != nil {
+		if logger.V(2) {
+			logger.Infof("Using bootstrap contents from fallback config")
+		}
+		return cfg, nil
+	}
+
+	return nil, fmt.Errorf("bootstrap environment variables (%q or %q) not defined, and no fallback config set", envconfig.XDSBootstrapFileNameEnv, envconfig.XDSBootstrapFileContentEnv)
 }
 
 func newConfigFromContents(data []byte) (*Config, error) {
@@ -596,9 +591,9 @@ type ConfigOptionsForTesting struct {
 	ClientDefaultListenerResourceNameTemplate string
 	// Authorities is a list of non-default authorities.
 	Authorities map[string]json.RawMessage
-	// NodeID is the node identifier of the gRPC client/server node in the
+	// Node identifies the gRPC client/server node in the
 	// proxyless service mesh.
-	NodeID string
+	Node json.RawMessage
 }
 
 // NewContentsForTesting creates a new bootstrap configuration from the passed in
@@ -630,19 +625,31 @@ func NewContentsForTesting(opts ConfigOptionsForTesting) ([]byte, error) {
 		}
 		authorities[k] = a
 	}
+	node := newNode()
+	if err := json.Unmarshal(opts.Node, &node); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal node configuration %s: %v", string(opts.Node), err)
+	}
 	cfgJSON := configJSON{
 		XDSServers:                                servers,
 		CertificateProviders:                      certProviders,
 		ServerListenerResourceNameTemplate:        opts.ServerListenerResourceNameTemplate,
 		ClientDefaultListenerResourceNameTemplate: opts.ClientDefaultListenerResourceNameTemplate,
 		Authorities:                               authorities,
-		Node:                                      node{ID: opts.NodeID},
+		Node:                                      node,
 	}
 	contents, err := json.MarshalIndent(cfgJSON, " ", " ")
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal bootstrap configuration for provided options %+v: %v", opts, err)
 	}
 	return contents, nil
+}
+
+// NewConfigForTesting creates a new bootstrap configuration from the provided
+// contents, for testing purposes.
+//
+// # Testing-Only
+func NewConfigForTesting(contents []byte) (*Config, error) {
+	return newConfigFromContents(contents)
 }
 
 // certproviderNameAndConfig is the internal representation of
@@ -747,3 +754,44 @@ func (n node) toProto() *v3corepb.Node {
 		ClientFeatures:       slices.Clone(n.clientFeatures),
 	}
 }
+
+// SetFallbackBootstrapConfig sets the fallback bootstrap configuration to be
+// used when the bootstrap environment variables are unset.
+//
+// The provided configuration must be valid JSON. Returns a non-nil error if
+// parsing the provided configuration fails.
+func SetFallbackBootstrapConfig(cfgJSON []byte) error {
+	config, err := newConfigFromContents(cfgJSON)
+	if err != nil {
+		return err
+	}
+
+	configMu.Lock()
+	defer configMu.Unlock()
+	fallbackBootstrapConfig = config
+	return nil
+}
+
+// UnSetFallbackBootstrapConfigForTesting unsets the fallback bootstrap
+// configuration to be used when the bootstrap environment variables are unset.
+//
+// # Testing-Only
+func UnSetFallbackBootstrapConfigForTesting() {
+	configMu.Lock()
+	defer configMu.Unlock()
+	fallbackBootstrapConfig = nil
+}
+
+// getFallbackBootstrapConfig returns the fallback bootstrap configuration
+// that will be used by the xDS client when the bootstrap environment
+// variables are unset.
+func getFallbackBootstrapConfig() *Config {
+	configMu.Lock()
+	defer configMu.Unlock()
+	return fallbackBootstrapConfig
+}
+
+var (
+	configMu                sync.Mutex
+	fallbackBootstrapConfig *Config
+)

--- a/internal/xds/bootstrap/bootstrap.go
+++ b/internal/xds/bootstrap/bootstrap.go
@@ -544,7 +544,7 @@ func GetConfiguration() (*Config, error) {
 		return newConfigFromContents([]byte(fContent))
 	}
 
-	if cfg := getFallbackBootstrapConfig(); cfg != nil {
+	if cfg := fallbackBootstrapConfig(); cfg != nil {
 		if logger.V(2) {
 			logger.Infof("Using bootstrap contents from fallback config")
 		}
@@ -768,30 +768,30 @@ func SetFallbackBootstrapConfig(cfgJSON []byte) error {
 
 	configMu.Lock()
 	defer configMu.Unlock()
-	fallbackBootstrapConfig = config
+	fallbackBootstrapCfg = config
 	return nil
 }
 
-// UnSetFallbackBootstrapConfigForTesting unsets the fallback bootstrap
+// UnsetFallbackBootstrapConfigForTesting unsets the fallback bootstrap
 // configuration to be used when the bootstrap environment variables are unset.
 //
 // # Testing-Only
-func UnSetFallbackBootstrapConfigForTesting() {
+func UnsetFallbackBootstrapConfigForTesting() {
 	configMu.Lock()
 	defer configMu.Unlock()
-	fallbackBootstrapConfig = nil
+	fallbackBootstrapCfg = nil
 }
 
-// getFallbackBootstrapConfig returns the fallback bootstrap configuration
+// fallbackBootstrapConfig returns the fallback bootstrap configuration
 // that will be used by the xDS client when the bootstrap environment
 // variables are unset.
-func getFallbackBootstrapConfig() *Config {
+func fallbackBootstrapConfig() *Config {
 	configMu.Lock()
 	defer configMu.Unlock()
-	return fallbackBootstrapConfig
+	return fallbackBootstrapCfg
 }
 
 var (
-	configMu                sync.Mutex
-	fallbackBootstrapConfig *Config
+	configMu             sync.Mutex
+	fallbackBootstrapCfg *Config
 )

--- a/stats/opentelemetry/csm/pluginoption.go
+++ b/stats/opentelemetry/csm/pluginoption.go
@@ -290,7 +290,7 @@ func initializeLocalAndMetadataLabels(labels map[string]string) (map[string]stri
 
 // getNodeID gets the Node ID from the bootstrap data.
 func getNodeID() string {
-	cfg, err := bootstrap.NewConfig()
+	cfg, err := bootstrap.GetConfiguration()
 	if err != nil {
 		return "" // will become "unknown"
 	}

--- a/test/xds/xds_client_certificate_providers_test.go
+++ b/test/xds/xds_client_certificate_providers_test.go
@@ -122,7 +122,7 @@ func (s) TestClientSideXDS_WithNoCertificateProvidersInBootstrap_Failure(t *test
 					"server_uri": %q,
 					"channel_creds": [{"type": "insecure"}]
 				}`, mgmtServer.Address))},
-		NodeID: nodeID,
+		Node: []byte(fmt.Sprintf(`{"id": "%s"}`, nodeID)),
 	})
 	if err != nil {
 		t.Fatalf("Failed to create bootstrap configuration: %v", err)

--- a/test/xds/xds_client_federation_test.go
+++ b/test/xds/xds_client_federation_test.go
@@ -68,7 +68,7 @@ func (s) TestClientSideFederation(t *testing.T) {
 			"server_uri": %q,
 			"channel_creds": [{"type": "insecure"}]
 		}`, serverDefaultAuth.Address))},
-		NodeID:                             nodeID,
+		Node:                               []byte(fmt.Sprintf(`{"id": "%s"}`, nodeID)),
 		ServerListenerResourceNameTemplate: e2e.ServerListenerResourceNameTemplate,
 		// Specify the address of the non-default authority.
 		Authorities: map[string]json.RawMessage{
@@ -162,7 +162,7 @@ func (s) TestClientSideFederationWithOnlyXDSTPStyleLDS(t *testing.T) {
 			"server_uri": %q,
 			"channel_creds": [{"type": "insecure"}]
 		}`, mgmtServer.Address))},
-		NodeID: nodeID,
+		Node: []byte(fmt.Sprintf(`{"id": "%s"}`, nodeID)),
 		ClientDefaultListenerResourceNameTemplate: fmt.Sprintf("xdstp://%s/envoy.config.listener.v3.Listener/%%s", authority),
 		// Specify the address of the non-default authority.
 		Authorities: map[string]json.RawMessage{

--- a/test/xds/xds_client_ignore_resource_deletion_test.go
+++ b/test/xds/xds_client_ignore_resource_deletion_test.go
@@ -276,7 +276,7 @@ func generateBootstrapContents(t *testing.T, serverURI string, ignoreResourceDel
 	}
 	bootstrapContents, err := bootstrap.NewContentsForTesting(bootstrap.ConfigOptionsForTesting{
 		Servers:                            []json.RawMessage{serverCfg},
-		NodeID:                             nodeID,
+		Node:                               []byte(fmt.Sprintf(`{"id": "%s"}`, nodeID)),
 		ServerListenerResourceNameTemplate: e2e.ServerListenerResourceNameTemplate,
 	})
 	if err != nil {

--- a/test/xds/xds_server_certificate_providers_test.go
+++ b/test/xds/xds_server_certificate_providers_test.go
@@ -134,7 +134,7 @@ func (s) TestServerSideXDS_WithNoCertificateProvidersInBootstrap_Failure(t *test
 			"server_uri": %q,
 			"channel_creds": [{"type": "insecure"}]
 		}`, mgmtServer.Address))},
-		NodeID:                             nodeID,
+		Node:                               []byte(fmt.Sprintf(`{"id": "%s"}`, nodeID)),
 		ServerListenerResourceNameTemplate: e2e.ServerListenerResourceNameTemplate,
 	})
 	if err != nil {

--- a/xds/googledirectpath/googlec2p.go
+++ b/xds/googledirectpath/googlec2p.go
@@ -26,6 +26,7 @@
 package googledirectpath
 
 import (
+	"encoding/json"
 	"fmt"
 	"math/rand"
 	"net/url"
@@ -37,7 +38,6 @@ import (
 	internalgrpclog "google.golang.org/grpc/internal/grpclog"
 	"google.golang.org/grpc/internal/xds/bootstrap"
 	"google.golang.org/grpc/resolver"
-	"google.golang.org/grpc/xds/internal/xdsclient"
 
 	_ "google.golang.org/grpc/xds" // To register xds resolvers and balancers.
 )
@@ -58,15 +58,9 @@ const (
 
 // For overriding in unittests.
 var (
-	onGCE = googlecloud.OnGCE
-
+	onGCE   = googlecloud.OnGCE
 	randInt = rand.Int
-
-	newClientWithConfig = func(name string, config *bootstrap.Config) (xdsclient.XDSClient, func(), error) {
-		return xdsclient.NewWithConfig(name, config)
-	}
-
-	logger = internalgrpclog.NewPrefixLogger(grpclog.Component("directpath"), logPrefix)
+	logger  = internalgrpclog.NewPrefixLogger(grpclog.Component("directpath"), logPrefix)
 )
 
 func init() {
@@ -105,23 +99,18 @@ func (c2pResolverBuilder) Build(t resolver.Target, cc resolver.ClientConn, opts 
 	xdsServerCfg := newXdsServerConfig(xdsServerURI)
 	authoritiesCfg := newAuthoritiesConfig(xdsServerCfg)
 
-	config, err := bootstrap.NewConfigFromContents([]byte(fmt.Sprintf(`
-	{
-		"xds_servers": [%s],
-		"client_default_listener_resource_name_template": "%%s",
-		"authorities": %s,
-		"node": %s
-	}`, xdsServerCfg, authoritiesCfg, nodeCfg)))
-
-	if err != nil {
-		return nil, fmt.Errorf("failed to build bootstrap configuration: %v", err)
+	cfg := map[string]any{
+		"xds_servers": []any{xdsServerCfg},
+		"client_default_listener_resource_name_template": "%s",
+		"authorities": authoritiesCfg,
+		"node":        nodeCfg,
 	}
-
-	// Create singleton xds client with this config. The xds client will be
-	// used by the xds resolver later.
-	_, close, err := newClientWithConfig(t.String(), config)
+	cfgJSON, err := json.Marshal(cfg)
 	if err != nil {
-		return nil, fmt.Errorf("failed to start xDS client: %v", err)
+		return nil, fmt.Errorf("failed to marshal bootstrap configuration: %v", err)
+	}
+	if err := bootstrap.SetFallbackBootstrapConfig(cfgJSON); err != nil {
+		return nil, fmt.Errorf("failed to set fallback bootstrap configuration: %v", err)
 	}
 
 	t = resolver.Target{
@@ -131,64 +120,36 @@ func (c2pResolverBuilder) Build(t resolver.Target, cc resolver.ClientConn, opts 
 			Path:   t.URL.Path,
 		},
 	}
-	xdsR, err := resolver.Get(xdsName).Build(t, cc, opts)
-	if err != nil {
-		close()
-		return nil, err
-	}
-	return &c2pResolver{
-		Resolver:        xdsR,
-		clientCloseFunc: close,
-	}, nil
+	return resolver.Get(xdsName).Build(t, cc, opts)
 }
 
 func (b c2pResolverBuilder) Scheme() string {
 	return c2pScheme
 }
 
-type c2pResolver struct {
-	resolver.Resolver
-	clientCloseFunc func()
-}
-
-func (r *c2pResolver) Close() {
-	r.Resolver.Close()
-	r.clientCloseFunc()
-}
-
-func newNodeConfig(zone string, ipv6Capable bool) string {
-	metadata := ""
+func newNodeConfig(zone string, ipv6Capable bool) map[string]any {
+	node := map[string]any{
+		"id":       fmt.Sprintf("C2P-%d", randInt()),
+		"locality": map[string]any{"zone": zone},
+	}
 	if ipv6Capable {
-		metadata = fmt.Sprintf(`, "metadata":  { "%s": true }`, ipv6CapableMetadataName)
+		node["metadata"] = map[string]any{ipv6CapableMetadataName: true}
 	}
-
-	return fmt.Sprintf(`
-	{
-		"id": "%s",
-		"locality": {
-			"zone": "%s"
-		}
-		%s
-	}`, fmt.Sprintf("C2P-%d", randInt()), zone, metadata)
+	return node
 }
 
-func newAuthoritiesConfig(xdsServer string) string {
-	return fmt.Sprintf(`
-	{
-		"%s": {
-			"xds_servers": [%s]
-		}
+func newAuthoritiesConfig(serverCfg map[string]any) map[string]any {
+	return map[string]any{
+		c2pAuthority: map[string]any{"xds_servers": []any{serverCfg}},
 	}
-	`, c2pAuthority, xdsServer)
 }
 
-func newXdsServerConfig(xdsServerURI string) string {
-	return fmt.Sprintf(`
-	{
-		"server_uri": "%s",
-		"channel_creds": [{"type": "google_default"}],
-		"server_features": ["ignore_resource_deletion"]
-	}`, xdsServerURI)
+func newXdsServerConfig(uri string) map[string]any {
+	return map[string]any{
+		"server_uri":      uri,
+		"channel_creds":   []map[string]any{{"type": "google_default"}},
+		"server_features": []any{"ignore_resource_deletion"},
+	}
 }
 
 // runDirectPath returns whether this resolver should use direct path.

--- a/xds/googledirectpath/googlec2p_test.go
+++ b/xds/googledirectpath/googlec2p_test.go
@@ -34,8 +34,6 @@ import (
 	"google.golang.org/grpc/resolver"
 )
 
-const defaultTestTimeout = 10 * time.Second
-
 type s struct {
 	grpctest.Tester
 }

--- a/xds/googledirectpath/googlec2p_test.go
+++ b/xds/googledirectpath/googlec2p_test.go
@@ -19,7 +19,7 @@
 package googledirectpath
 
 import (
-	"context"
+	"encoding/json"
 	"strconv"
 	"strings"
 	"testing"
@@ -32,7 +32,6 @@ import (
 	"google.golang.org/grpc/internal/grpctest"
 	"google.golang.org/grpc/internal/xds/bootstrap"
 	"google.golang.org/grpc/resolver"
-	"google.golang.org/grpc/xds/internal/xdsclient"
 )
 
 const defaultTestTimeout = 10 * time.Second
@@ -85,28 +84,6 @@ func simulateRunningOnGCE(t *testing.T, gce bool) {
 	t.Cleanup(func() { onGCE = oldOnGCE })
 }
 
-type testXDSClient struct {
-	xdsclient.XDSClient
-	closed chan struct{}
-}
-
-func (c *testXDSClient) Close() {
-	c.closed <- struct{}{}
-}
-
-// Overrides the creation of a real xDS client with a test one.
-func overrideWithTestXDSClient(t *testing.T) (*testXDSClient, chan *bootstrap.Config) {
-	xdsC := &testXDSClient{closed: make(chan struct{}, 1)}
-	configCh := make(chan *bootstrap.Config, 1)
-	oldNewClient := newClientWithConfig
-	newClientWithConfig = func(name string, config *bootstrap.Config) (xdsclient.XDSClient, func(), error) {
-		configCh <- config
-		return xdsC, func() { xdsC.Close() }, nil
-	}
-	t.Cleanup(func() { newClientWithConfig = oldNewClient })
-	return xdsC, configCh
-}
-
 // Tests the scenario where the bootstrap env vars are set and we're running on
 // GCE. The test builds a google-c2p resolver and verifies that an xDS resolver
 // is built and that we don't fallback to DNS (because federation is enabled by
@@ -123,8 +100,6 @@ func (s) TestBuildWithBootstrapEnvSet(t *testing.T) {
 			*envP = "does not matter"
 			defer func() { *envP = oldEnv }()
 
-			overrideWithTestXDSClient(t)
-
 			// Build the google-c2p resolver.
 			r, err := builder.Build(resolver.Target{}, nil, resolver.BuildOptions{})
 			if err != nil {
@@ -133,9 +108,8 @@ func (s) TestBuildWithBootstrapEnvSet(t *testing.T) {
 			defer r.Close()
 
 			// Build should return xDS, not DNS.
-			rr := r.(*c2pResolver)
-			if rrr := rr.Resolver; rrr != testXDSResolver {
-				t.Fatalf("want xds resolver, got %#v", rrr)
+			if r != testXDSResolver {
+				t.Fatalf("Build() returned %#v, want xds resolver", r)
 			}
 		})
 	}
@@ -157,8 +131,22 @@ func (s) TestBuildNotOnGCE(t *testing.T) {
 
 	// Build should return DNS, not xDS.
 	if r != testDNSResolver {
-		t.Fatalf("want dns resolver, got %#v", r)
+		t.Fatalf("Build() returned %#v, want dns resolver", r)
 	}
+}
+
+func bootstrapConfig(t *testing.T, opts bootstrap.ConfigOptionsForTesting) *bootstrap.Config {
+	t.Helper()
+
+	contents, err := bootstrap.NewContentsForTesting(opts)
+	if err != nil {
+		t.Fatalf("Failed to create bootstrap contents: %v", err)
+	}
+	cfg, err := bootstrap.NewConfigForTesting(contents)
+	if err != nil {
+		t.Fatalf("Failed to create bootstrap config: %v", err)
+	}
+	return cfg
 }
 
 // Test that when a google-c2p resolver is built, the xDS client is built with
@@ -186,120 +174,87 @@ func (s) TestBuildXDS(t *testing.T) {
 	}{
 		{
 			desc: "ipv6 false",
-			wantBootstrapConfig: func() *bootstrap.Config {
-				cfg, err := bootstrap.NewConfigFromContents([]byte(`{
-"xds_servers": [
-  {
-    "server_uri": "dns:///directpath-pa.googleapis.com",
-    "channel_creds": [{"type": "google_default"}],
-    "server_features": ["ignore_resource_deletion"]
-  }
-],
-"client_default_listener_resource_name_template": "%s",
-"authorities": {
-  "traffic-director-c2p.xds.googleapis.com": {
-    "xds_servers": [
-      {
-        "server_uri": "dns:///directpath-pa.googleapis.com",
-        "channel_creds": [{"type": "google_default"}],
-        "server_features": ["ignore_resource_deletion"]
-      }
-	]
-  }
-},
-"node": {
-  "id": "C2P-666",
-  "locality": {
-  "zone": "test-zone"
-  }
-}
-}`))
-				if err != nil {
-					t.Fatalf("Bootstrap parsing failure: %v", err)
-				}
-				return cfg
-			}(),
+			wantBootstrapConfig: bootstrapConfig(t, bootstrap.ConfigOptionsForTesting{
+				Servers: []json.RawMessage{[]byte(`{
+						"server_uri": "dns:///directpath-pa.googleapis.com",
+					    "channel_creds": [{"type": "google_default"}],
+					    "server_features": ["ignore_resource_deletion"]
+  					}`)},
+				Authorities: map[string]json.RawMessage{
+					"traffic-director-c2p.xds.googleapis.com": []byte(`{
+							"xds_servers": [
+  								{
+								    "server_uri": "dns:///directpath-pa.googleapis.com",
+								    "channel_creds": [{"type": "google_default"}],
+								    "server_features": ["ignore_resource_deletion"]
+  								}
+							]
+						}`),
+				},
+				Node: []byte(`{
+					  "id": "C2P-666",
+					  "locality": {"zone": "test-zone"}
+					}`),
+			}),
 		},
 		{
 			desc:        "ipv6 true",
 			ipv6Capable: true,
-			wantBootstrapConfig: func() *bootstrap.Config {
-				cfg, err := bootstrap.NewConfigFromContents([]byte(`{
-"xds_servers": [
-  {
-    "server_uri": "dns:///directpath-pa.googleapis.com",
-    "channel_creds": [{"type": "google_default"}],
-    "server_features": ["ignore_resource_deletion"]
-  }
-],
-"client_default_listener_resource_name_template": "%s",
-"authorities": {
-  "traffic-director-c2p.xds.googleapis.com": {
-    "xds_servers": [
-      {
-        "server_uri": "dns:///directpath-pa.googleapis.com",
-        "channel_creds": [{"type": "google_default"}],
-        "server_features": ["ignore_resource_deletion"]
-      }
-	]
-  }
-},
-"node": {
-  "id": "C2P-666",
-  "locality": {
-  "zone": "test-zone"
-  },
-  "metadata": {
-	"TRAFFICDIRECTOR_DIRECTPATH_C2P_IPV6_CAPABLE": true
-  }
-}
-}`))
-				if err != nil {
-					t.Fatalf("Bootstrap parsing failure: %v", err)
-				}
-				return cfg
-			}(),
+			wantBootstrapConfig: bootstrapConfig(t, bootstrap.ConfigOptionsForTesting{
+				Servers: []json.RawMessage{[]byte(`{
+						"server_uri": "dns:///directpath-pa.googleapis.com",
+					    "channel_creds": [{"type": "google_default"}],
+					    "server_features": ["ignore_resource_deletion"]
+  					}`)},
+				Authorities: map[string]json.RawMessage{
+					"traffic-director-c2p.xds.googleapis.com": []byte(`{
+							"xds_servers": [
+  								{
+								    "server_uri": "dns:///directpath-pa.googleapis.com",
+								    "channel_creds": [{"type": "google_default"}],
+								    "server_features": ["ignore_resource_deletion"]
+  								}
+							]
+						}`),
+				},
+				Node: []byte(`{
+					  "id": "C2P-666",
+					  "locality": {"zone": "test-zone"},
+			  			"metadata": {
+							"TRAFFICDIRECTOR_DIRECTPATH_C2P_IPV6_CAPABLE": true
+			  			}
+					}`),
+			}),
 		},
 		{
 			desc:          "override TD URI",
 			ipv6Capable:   true,
 			tdURIOverride: "test-uri",
-			wantBootstrapConfig: func() *bootstrap.Config {
-				cfg, err := bootstrap.NewConfigFromContents([]byte(`{
-"xds_servers": [
-  {
-    "server_uri": "test-uri",
-    "channel_creds": [{"type": "google_default"}],
-    "server_features": ["ignore_resource_deletion"]
-  }
-],
-"client_default_listener_resource_name_template": "%s",
-"authorities": {
-  "traffic-director-c2p.xds.googleapis.com": {
-    "xds_servers": [
-      {
-        "server_uri": "test-uri",
-        "channel_creds": [{"type": "google_default"}],
-        "server_features": ["ignore_resource_deletion"]
-      }
-	]
-  }
-},
-"node": {
-  "id": "C2P-666",
-  "locality": {
-  "zone": "test-zone"
-  },
-  "metadata": {
-	"TRAFFICDIRECTOR_DIRECTPATH_C2P_IPV6_CAPABLE": true
-  }
-}
-}`))
-				if err != nil {
-					t.Fatalf("Bootstrap parsing failure: %v", err)
-				}
-				return cfg
-			}(),
+			wantBootstrapConfig: bootstrapConfig(t, bootstrap.ConfigOptionsForTesting{
+				Servers: []json.RawMessage{[]byte(`{
+						"server_uri": "test-uri",
+					    "channel_creds": [{"type": "google_default"}],
+					    "server_features": ["ignore_resource_deletion"]
+  					}`)},
+				Authorities: map[string]json.RawMessage{
+					"traffic-director-c2p.xds.googleapis.com": []byte(`{
+							"xds_servers": [
+  								{
+								    "server_uri": "test-uri",
+								    "channel_creds": [{"type": "google_default"}],
+								    "server_features": ["ignore_resource_deletion"]
+  								}
+							]
+						}`),
+				},
+				Node: []byte(`{
+					  "id": "C2P-666",
+					  "locality": {"zone": "test-zone"},
+			  			"metadata": {
+							"TRAFFICDIRECTOR_DIRECTPATH_C2P_IPV6_CAPABLE": true
+			  			}
+					}`),
+			}),
 		},
 	} {
 		t.Run(tt.desc, func(t *testing.T) {
@@ -315,38 +270,24 @@ func (s) TestBuildXDS(t *testing.T) {
 				defer func() { envconfig.C2PResolverTestOnlyTrafficDirectorURI = oldURI }()
 			}
 
-			tXDSClient, configCh := overrideWithTestXDSClient(t)
-
-			ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
-			defer cancel()
-
 			// Build the google-c2p resolver.
 			r, err := builder.Build(resolver.Target{}, nil, resolver.BuildOptions{})
 			if err != nil {
 				t.Fatalf("failed to build resolver: %v", err)
 			}
+			defer r.Close()
 
 			// Build should return xDS, not DNS.
-			rr := r.(*c2pResolver)
-			if rrr := rr.Resolver; rrr != testXDSResolver {
-				t.Fatalf("want xds resolver, got %#v, ", rrr)
+			if r != testXDSResolver {
+				t.Fatalf("Build() returned %#v, want xds resolver", r)
 			}
 
-			var gotConfig *bootstrap.Config
-			select {
-			case gotConfig = <-configCh:
-				if diff := cmp.Diff(tt.wantBootstrapConfig, gotConfig); diff != "" {
-					t.Fatalf("Unexpected diff in bootstrap config (-want +got):\n%s", diff)
-				}
-			case <-ctx.Done():
-				t.Fatalf("Timeout waiting for new xDS client to be built")
+			gotConfig, err := bootstrap.GetConfiguration()
+			if err != nil {
+				t.Fatalf("Failed to get boostrap config: %v", err)
 			}
-
-			r.Close()
-			select {
-			case <-tXDSClient.closed:
-			case <-ctx.Done():
-				t.Fatalf("Timeout waiting for xDS client to be closed")
+			if diff := cmp.Diff(tt.wantBootstrapConfig, gotConfig); diff != "" {
+				t.Fatalf("Unexpected diff in bootstrap config (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/xds/internal/balancer/cdsbalancer/cdsbalancer_security_test.go
+++ b/xds/internal/balancer/cdsbalancer/cdsbalancer_security_test.go
@@ -379,7 +379,7 @@ func (s) TestSecurityConfigNotFoundInBootstrap(t *testing.T) {
 			"server_uri": %q,
 			"channel_creds": [{"type": "insecure"}]
 		}`, mgmtServer.Address))},
-		NodeID:                             nodeID,
+		Node:                               []byte(fmt.Sprintf(`{"id": "%s"}`, nodeID)),
 		ServerListenerResourceNameTemplate: e2e.ServerListenerResourceNameTemplate,
 	})
 	if err != nil {
@@ -445,7 +445,7 @@ func (s) TestCertproviderStoreError(t *testing.T) {
 			"server_uri": %q,
 			"channel_creds": [{"type": "insecure"}]
 		}`, mgmtServer.Address))},
-		NodeID:                             nodeID,
+		Node:                               []byte(fmt.Sprintf(`{"id": "%s"}`, nodeID)),
 		ServerListenerResourceNameTemplate: e2e.ServerListenerResourceNameTemplate,
 		CertificateProviders:               map[string]json.RawMessage{e2e.ClientSideCertProviderInstance: providerCfg},
 	})

--- a/xds/internal/resolver/xds_resolver_test.go
+++ b/xds/internal/resolver/xds_resolver_test.go
@@ -166,7 +166,7 @@ func (s) TestResolverResourceName(t *testing.T) {
 					"channel_creds": [{"type": "insecure"}]
 				}`, mgmtServer.Address))},
 				ClientDefaultListenerResourceNameTemplate: tt.listenerResourceNameTemplate,
-				NodeID: nodeID,
+				Node: []byte(fmt.Sprintf(`{"id": "%s"}`, nodeID)),
 			}
 			if tt.extraAuthority != "" {
 				// In this test, we really don't care about having multiple

--- a/xds/internal/xdsclient/client_new.go
+++ b/xds/internal/xdsclient/client_new.go
@@ -116,7 +116,7 @@ func NewForTesting(opts OptionsForTesting) (XDSClient, func(), error) {
 		return nil, nil, err
 	}
 	client, cancel, err := newRefCounted(opts.Name, opts.WatchExpiryTimeout, opts.AuthorityIdleTimeout)
-	return client, func() { bootstrap.UnSetFallbackBootstrapConfigForTesting(); cancel() }, err
+	return client, func() { bootstrap.UnsetFallbackBootstrapConfigForTesting(); cancel() }, err
 }
 
 // GetForTesting returns an xDS client created earlier using the given name.

--- a/xds/internal/xdsclient/tests/authority_test.go
+++ b/xds/internal/xdsclient/tests/authority_test.go
@@ -87,7 +87,7 @@ func setupForAuthorityTests(ctx context.Context, t *testing.T, idleTimeout time.
 			"server_uri": %q,
 			"channel_creds": [{"type": "insecure"}]
 		}`, defaultAuthorityServer.Address))},
-		NodeID: nodeID,
+		Node: []byte(fmt.Sprintf(`{"id": "%s"}`, nodeID)),
 		Authorities: map[string]json.RawMessage{
 			testAuthority1: []byte(`{}`),
 			testAuthority2: []byte(`{}`),

--- a/xds/internal/xdsclient/tests/cds_watchers_test.go
+++ b/xds/internal/xdsclient/tests/cds_watchers_test.go
@@ -184,7 +184,7 @@ func (s) TestCDSWatch(t *testing.T) {
 					"server_uri": %q,
 					"channel_creds": [{"type": "insecure"}]
 				}`, mgmtServer.Address))},
-				NodeID: nodeID,
+				Node: []byte(fmt.Sprintf(`{"id": "%s"}`, nodeID)),
 				Authorities: map[string]json.RawMessage{
 					// Xdstp resource names used in this test do not specify an
 					// authority. These will end up looking up an entry with the
@@ -334,7 +334,7 @@ func (s) TestCDSWatch_TwoWatchesForSameResourceName(t *testing.T) {
 					"server_uri": %q,
 					"channel_creds": [{"type": "insecure"}]
 				}`, mgmtServer.Address))},
-				NodeID: nodeID,
+				Node: []byte(fmt.Sprintf(`{"id": "%s"}`, nodeID)),
 				Authorities: map[string]json.RawMessage{
 					// Xdstp resource names used in this test do not specify an
 					// authority. These will end up looking up an entry with the
@@ -438,7 +438,7 @@ func (s) TestCDSWatch_ThreeWatchesForDifferentResourceNames(t *testing.T) {
 					"server_uri": %q,
 					"channel_creds": [{"type": "insecure"}]
 				}`, mgmtServer.Address))},
-		NodeID: nodeID,
+		Node: []byte(fmt.Sprintf(`{"id": "%s"}`, nodeID)),
 		Authorities: map[string]json.RawMessage{
 			// Xdstp style resource names used in this test use a slash removed
 			// version of t.Name as their authority, and the empty config
@@ -731,7 +731,7 @@ func (s) TestCDSWatch_ResourceRemoved(t *testing.T) {
 					"server_uri": %q,
 					"channel_creds": [{"type": "insecure"}]
 				}`, mgmtServer.Address))},
-		NodeID: nodeID,
+		Node: []byte(fmt.Sprintf(`{"id": "%s"}`, nodeID)),
 		Authorities: map[string]json.RawMessage{
 			// Xdstp style resource names used in this test use a slash removed
 			// version of t.Name as their authority, and the empty config
@@ -912,7 +912,7 @@ func (s) TestCDSWatch_PartialValid(t *testing.T) {
 					"server_uri": %q,
 					"channel_creds": [{"type": "insecure"}]
 				}`, mgmtServer.Address))},
-		NodeID: nodeID,
+		Node: []byte(fmt.Sprintf(`{"id": "%s"}`, nodeID)),
 		Authorities: map[string]json.RawMessage{
 			// Xdstp style resource names used in this test use a slash removed
 			// version of t.Name as their authority, and the empty config
@@ -1004,7 +1004,7 @@ func (s) TestCDSWatch_PartialResponse(t *testing.T) {
 					"server_uri": %q,
 					"channel_creds": [{"type": "insecure"}]
 				}`, mgmtServer.Address))},
-		NodeID: nodeID,
+		Node: []byte(fmt.Sprintf(`{"id": "%s"}`, nodeID)),
 		Authorities: map[string]json.RawMessage{
 			// Xdstp style resource names used in this test use a slash removed
 			// version of t.Name as their authority, and the empty config

--- a/xds/internal/xdsclient/tests/dump_test.go
+++ b/xds/internal/xdsclient/tests/dump_test.go
@@ -393,7 +393,7 @@ func (s) TestDumpResources_ManyToMany(t *testing.T) {
 					"server_uri": %q,
 					"channel_creds": [{"type": "insecure"}]
 				}`, mgmtServer1.Address))},
-		NodeID: nodeID,
+		Node: []byte(fmt.Sprintf(`{"id": "%s"}`, nodeID)),
 		Authorities: map[string]json.RawMessage{
 			authority: []byte(fmt.Sprintf(`{
 				"xds_servers": [{

--- a/xds/internal/xdsclient/tests/eds_watchers_test.go
+++ b/xds/internal/xdsclient/tests/eds_watchers_test.go
@@ -215,7 +215,7 @@ func (s) TestEDSWatch(t *testing.T) {
 					"server_uri": %q,
 					"channel_creds": [{"type": "insecure"}]
 				}`, mgmtServer.Address))},
-				NodeID: nodeID,
+				Node: []byte(fmt.Sprintf(`{"id": "%s"}`, nodeID)),
 				Authorities: map[string]json.RawMessage{
 					// Xdstp resource names used in this test do not specify an
 					// authority. These will end up looking up an entry with the
@@ -405,7 +405,7 @@ func (s) TestEDSWatch_TwoWatchesForSameResourceName(t *testing.T) {
 					"server_uri": %q,
 					"channel_creds": [{"type": "insecure"}]
 				}`, mgmtServer.Address))},
-				NodeID: nodeID,
+				Node: []byte(fmt.Sprintf(`{"id": "%s"}`, nodeID)),
 				Authorities: map[string]json.RawMessage{
 					// Xdstp resource names used in this test do not specify an
 					// authority. These will end up looking up an entry with the
@@ -510,7 +510,7 @@ func (s) TestEDSWatch_ThreeWatchesForDifferentResourceNames(t *testing.T) {
 					"server_uri": %q,
 					"channel_creds": [{"type": "insecure"}]
 				}`, mgmtServer.Address))},
-		NodeID: nodeID,
+		Node: []byte(fmt.Sprintf(`{"id": "%s"}`, nodeID)),
 		Authorities: map[string]json.RawMessage{
 			// Xdstp style resource names used in this test use a slash removed
 			// version of t.Name as their authority, and the empty config
@@ -875,7 +875,7 @@ func (s) TestEDSWatch_PartialValid(t *testing.T) {
 					"server_uri": %q,
 					"channel_creds": [{"type": "insecure"}]
 				}`, mgmtServer.Address))},
-		NodeID: nodeID,
+		Node: []byte(fmt.Sprintf(`{"id": "%s"}`, nodeID)),
 		Authorities: map[string]json.RawMessage{
 			// Xdstp style resource names used in this test use a slash removed
 			// version of t.Name as their authority, and the empty config

--- a/xds/internal/xdsclient/tests/federation_watchers_test.go
+++ b/xds/internal/xdsclient/tests/federation_watchers_test.go
@@ -56,7 +56,7 @@ func setupForFederationWatchersTest(t *testing.T) (*e2e.ManagementServer, string
 			"server_uri": %q,
 			"channel_creds": [{"type": "insecure"}]
 		}`, serverDefaultAuthority.Address))},
-		NodeID: nodeID,
+		Node: []byte(fmt.Sprintf(`{"id": "%s"}`, nodeID)),
 		Authorities: map[string]json.RawMessage{
 			testNonDefaultAuthority: []byte(fmt.Sprintf(`{
 				"xds_servers": [{

--- a/xds/internal/xdsclient/tests/lds_watchers_test.go
+++ b/xds/internal/xdsclient/tests/lds_watchers_test.go
@@ -204,7 +204,7 @@ func (s) TestLDSWatch(t *testing.T) {
 					"server_uri": %q,
 					"channel_creds": [{"type": "insecure"}]
 				}`, mgmtServer.Address))},
-				NodeID: nodeID,
+				Node: []byte(fmt.Sprintf(`{"id": "%s"}`, nodeID)),
 				Authorities: map[string]json.RawMessage{
 					// Xdstp resource names used in this test do not specify an
 					// authority. These will end up looking up an entry with the
@@ -354,7 +354,7 @@ func (s) TestLDSWatch_TwoWatchesForSameResourceName(t *testing.T) {
 					"server_uri": %q,
 					"channel_creds": [{"type": "insecure"}]
 				}`, mgmtServer.Address))},
-				NodeID: nodeID,
+				Node: []byte(fmt.Sprintf(`{"id": "%s"}`, nodeID)),
 				Authorities: map[string]json.RawMessage{
 					// Xdstp resource names used in this test do not specify an
 					// authority. These will end up looking up an entry with the
@@ -459,7 +459,7 @@ func (s) TestLDSWatch_ThreeWatchesForDifferentResourceNames(t *testing.T) {
 					"server_uri": %q,
 					"channel_creds": [{"type": "insecure"}]
 				}`, mgmtServer.Address))},
-		NodeID: nodeID,
+		Node: []byte(fmt.Sprintf(`{"id": "%s"}`, nodeID)),
 		Authorities: map[string]json.RawMessage{
 			// Xdstp style resource names used in this test use a slash removed
 			// version of t.Name as their authority, and the empty config
@@ -749,7 +749,7 @@ func (s) TestLDSWatch_ResourceRemoved(t *testing.T) {
 					"server_uri": %q,
 					"channel_creds": [{"type": "insecure"}]
 				}`, mgmtServer.Address))},
-		NodeID: nodeID,
+		Node: []byte(fmt.Sprintf(`{"id": "%s"}`, nodeID)),
 		Authorities: map[string]json.RawMessage{
 			// Xdstp style resource names used in this test use a slash removed
 			// version of t.Name as their authority, and the empty config
@@ -927,7 +927,7 @@ func (s) TestLDSWatch_PartialValid(t *testing.T) {
 					"server_uri": %q,
 					"channel_creds": [{"type": "insecure"}]
 				}`, mgmtServer.Address))},
-		NodeID: nodeID,
+		Node: []byte(fmt.Sprintf(`{"id": "%s"}`, nodeID)),
 		Authorities: map[string]json.RawMessage{
 			// Xdstp style resource names used in this test use a slash removed
 			// version of t.Name as their authority, and the empty config
@@ -1020,7 +1020,7 @@ func (s) TestLDSWatch_PartialResponse(t *testing.T) {
 					"server_uri": %q,
 					"channel_creds": [{"type": "insecure"}]
 				}`, mgmtServer.Address))},
-		NodeID: nodeID,
+		Node: []byte(fmt.Sprintf(`{"id": "%s"}`, nodeID)),
 		Authorities: map[string]json.RawMessage{
 			// Xdstp style resource names used in this test use a slash removed
 			// version of t.Name as their authority, and the empty config

--- a/xds/internal/xdsclient/tests/misc_watchers_test.go
+++ b/xds/internal/xdsclient/tests/misc_watchers_test.go
@@ -108,7 +108,7 @@ func (s) TestWatchCallAnotherWatch(t *testing.T) {
 					"server_uri": %q,
 					"channel_creds": [{"type": "insecure"}]
 				}`, mgmtServer.Address))},
-		NodeID: nodeID,
+		Node: []byte(fmt.Sprintf(`{"id": "%s"}`, nodeID)),
 		Authorities: map[string]json.RawMessage{
 			// Xdstp style resource names used in this test use a slash removed
 			// version of t.Name as their authority, and the empty config

--- a/xds/internal/xdsclient/tests/rds_watchers_test.go
+++ b/xds/internal/xdsclient/tests/rds_watchers_test.go
@@ -217,7 +217,7 @@ func (s) TestRDSWatch(t *testing.T) {
 					"server_uri": %q,
 					"channel_creds": [{"type": "insecure"}]
 				}`, mgmtServer.Address))},
-				NodeID: nodeID,
+				Node: []byte(fmt.Sprintf(`{"id": "%s"}`, nodeID)),
 				Authorities: map[string]json.RawMessage{
 					// Xdstp resource names used in this test do not specify an
 					// authority. These will end up looking up an entry with the
@@ -407,7 +407,7 @@ func (s) TestRDSWatch_TwoWatchesForSameResourceName(t *testing.T) {
 					"server_uri": %q,
 					"channel_creds": [{"type": "insecure"}]
 				}`, mgmtServer.Address))},
-				NodeID: nodeID,
+				Node: []byte(fmt.Sprintf(`{"id": "%s"}`, nodeID)),
 				Authorities: map[string]json.RawMessage{
 					// Xdstp resource names used in this test do not specify an
 					// authority. These will end up looking up an entry with the
@@ -512,7 +512,7 @@ func (s) TestRDSWatch_ThreeWatchesForDifferentResourceNames(t *testing.T) {
 					"server_uri": %q,
 					"channel_creds": [{"type": "insecure"}]
 				}`, mgmtServer.Address))},
-		NodeID: nodeID,
+		Node: []byte(fmt.Sprintf(`{"id": "%s"}`, nodeID)),
 		Authorities: map[string]json.RawMessage{
 			// Xdstp style resource names used in this test use a slash removed
 			// version of t.Name as their authority, and the empty config
@@ -876,7 +876,7 @@ func (s) TestRDSWatch_PartialValid(t *testing.T) {
 					"server_uri": %q,
 					"channel_creds": [{"type": "insecure"}]
 				}`, mgmtServer.Address))},
-		NodeID: nodeID,
+		Node: []byte(fmt.Sprintf(`{"id": "%s"}`, nodeID)),
 		Authorities: map[string]json.RawMessage{
 			// Xdstp style resource names used in this test use a slash removed
 			// version of t.Name as their authority, and the empty config

--- a/xds/server_test.go
+++ b/xds/server_test.go
@@ -178,7 +178,7 @@ func (s) TestNewServer_Failure(t *testing.T) {
 		{
 			desc:       "bootstrap env var not set",
 			serverOpts: []grpc.ServerOption{grpc.Creds(xdsCreds)},
-			wantErr:    "bootstrap env vars are unspecified",
+			wantErr:    "failed to get xDS bootstrap config",
 		},
 		{
 			desc: "empty bootstrap config",
@@ -198,7 +198,7 @@ func (s) TestNewServer_Failure(t *testing.T) {
 							"server_uri": %q,
 							"channel_creds": [{"type": "insecure"}]
 						}`, nonExistentManagementServer))},
-						NodeID: uuid.New().String(),
+						Node: []byte(fmt.Sprintf(`{"id": "%s"}`, uuid.New().String())),
 						CertificateProviders: map[string]json.RawMessage{
 							"cert-provider-instance": json.RawMessage("{}"),
 						},
@@ -500,7 +500,7 @@ func (s) TestHandleListenerUpdate_NoXDSCreds(t *testing.T) {
 			"server_uri": %q,
 			"channel_creds": [{"type": "insecure"}]
 		}`, mgmtServer.Address))},
-		NodeID: nodeID,
+		Node: []byte(fmt.Sprintf(`{"id": "%s"}`, nodeID)),
 		CertificateProviders: map[string]json.RawMessage{
 			e2e.ServerSideCertProviderInstance: fakeProvider1Config,
 			e2e.ClientSideCertProviderInstance: fakeProvider2Config,
@@ -592,7 +592,7 @@ func (s) TestHandleListenerUpdate_ErrorUpdate(t *testing.T) {
 			"server_uri": %q,
 			"channel_creds": [{"type": "insecure"}]
 		}`, mgmtServer.Address))},
-		NodeID: nodeID,
+		Node: []byte(fmt.Sprintf(`{"id": "%s"}`, nodeID)),
 		CertificateProviders: map[string]json.RawMessage{
 			e2e.ServerSideCertProviderInstance: fakeProvider1Config,
 			e2e.ClientSideCertProviderInstance: fakeProvider2Config,


### PR DESCRIPTION
This PR makes fallback bootstrap configuration to be a per-process configuration. This means that it applies to all xDS clients created by the process when the bootstrap environment variables are unset. This switches us to the model used in C-core.

Summary of changes:
- `internal/xds/bootstrap`
  - Added a package global variable to store the fallback bootstrap configuration. 
  - Added methods to set and get fallback bootstrap configuration.
  - Replaced `NewConfig` with `GetConfiguration`. The latter retrieves bootstrap configuration from the ordered list of sources.
  - Added `NewConfigForTesting` to create bootstrap configuration for testing purposes.
  - In the `ConfigOptionsForTesting` struct, replaced the `NodeID` field with a `Node` field that supports node information specified as JSON. This fixes an earlier shortsightedness.
- `xds/googledirectpath`
  - Switched to creating the bootstrap JSON as a `map[string]json.RawMessage` followed by a call to `json.Marshal` instead of creating it as a `[]byte`.
  - Sets the global fallback bootstrap configuration.
  - No longer creates an xDS client.
- `xds/internal/xdsclient`
  - The only APIs to create an xDS client now are `xdsclient.New` and `xdsclient.NewForTesting`

Fixes https://github.com/grpc/grpc-go/issues/7346

RELEASE NOTES: none