### PR TITLE
security/advancedtls: remove Go1.19 build constraints

### DIFF
--- a/security/advancedtls/crl.go
+++ b/security/advancedtls/crl.go
@@ -1,6 +1,3 @@
-// TODO(@gregorycooke) - Remove when only golang 1.19+ is supported
-//go:build go1.19
-
 /*
  *
  * Copyright 2021 gRPC authors.

--- a/security/advancedtls/crl_test.go
+++ b/security/advancedtls/crl_test.go
@@ -1,6 +1,3 @@
-// TODO(@gregorycooke) - Remove when only golang 1.19+ is supported
-//go:build go1.19
-
 /*
  *
  * Copyright 2021 gRPC authors.


### PR DESCRIPTION
This helps get rid of a `vet` failure.

RELEASE NOTES: none