### PR TITLE
scripts: regenerate pbs with caching deps to a fixed tmp folder

### DIFF
--- a/scripts/install-protoc.sh
+++ b/scripts/install-protoc.sh
@@ -65,9 +65,19 @@ download_binary() {
   fi
 
   DOWNLOAD_URL="https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-${OS}-${ARCH}.zip"
-  # For cURL, -L follows redirects. 
-  # For tar, --exclude excludes files, and -C specifies the directory. 
-  curl -L "${DOWNLOAD_URL}" | tar -xz --exclude="readme.txt" -C "${INSTALL_PATH}"
+  # -L follows redirects.
+  # -O writes output to a file.
+  curl -LO "${DOWNLOAD_URL}"
+  # Unzip the downloaded file and except readme.txt.
+  # The file structure should look like:
+  # INSTALL_PATH
+  # ├── bin
+  # │   └── protoc
+  # └── include
+  #     └── other files...
+  unzip "protoc-${PROTOC_VERSION}-$2-$1.zip" -d "${INSTALL_PATH}" -x "readme.txt"
+  rm "protoc-${PROTOC_VERSION}-$2-$1.zip"
+  # Make the protoc binary executable. ¯\_(ツ)_/¯  crazy, right?
   chmod +x "${INSTALL_PATH}/bin/protoc"
 }
 

--- a/scripts/install-protoc.sh
+++ b/scripts/install-protoc.sh
@@ -39,13 +39,13 @@ main() {
   if [[ "$#" -ne 1 ]]; then
     die "Usage: $0 INSTALL_PATH"
   fi
-  
+
   INSTALL_PATH="${1}"
 
   if [[ ! -d "${INSTALL_PATH}" ]]; then
     die "INSTALL_PATH (${INSTALL_PATH}) does not exist."
   fi
-  
+
   echo "Installing protoc version $PROTOC_VERSION to ${INSTALL_PATH}..."
 
   # Detect the hardware platform.
@@ -55,7 +55,7 @@ main() {
     "arm64")    ARCH="aarch_64";;
     *)          die "Install unsuccessful. Hardware platform not supported by installer: $1";;
   esac
-  
+
   # Detect the Operating System.
   case "$(uname -s)" in
     "Darwin") OS="osx";;
@@ -72,11 +72,11 @@ main() {
   fi
 
   DOWNLOAD_URL="https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-${OS}-${ARCH}.zip"
-  
+
   # -L follows redirects.
   # -O writes output to a file.
   curl -LO "${DOWNLOAD_URL}"
-  
+
   # Unzip the downloaded file and except readme.txt.
   # The file structure should look like:
   # INSTALL_PATH
@@ -86,7 +86,7 @@ main() {
   #     └── other files...
   unzip "protoc-${PROTOC_VERSION}-${OS}-${ARCH}.zip" -d "${INSTALL_PATH}" -x "readme.txt"
   rm "protoc-${PROTOC_VERSION}-${OS}-${ARCH}.zip"
-  
+
   # Make the protoc binary executable. ¯\_(ツ)_/¯  crazy, right?
   chmod +x "${INSTALL_PATH}/bin/protoc"
 }

--- a/scripts/install-protoc.sh
+++ b/scripts/install-protoc.sh
@@ -67,7 +67,7 @@ download_binary() {
   DOWNLOAD_URL="https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-${OS}-${ARCH}.zip"
   # For cURL, -L follows redirects. 
   # For tar, --exclude excludes files, and -C specifies the directory. 
-  curl -L "${DOWNLOAD_URL}" | tar -x --exclude="readme.txt" -C "${INSTALL_PATH}"
+  curl -L "${DOWNLOAD_URL}" | tar -xz --exclude="readme.txt" -C "${INSTALL_PATH}"
   chmod +x "${INSTALL_PATH}/bin/protoc"
 }
 

--- a/scripts/install-protoc.sh
+++ b/scripts/install-protoc.sh
@@ -75,8 +75,8 @@ download_binary() {
   # │   └── protoc
   # └── include
   #     └── other files...
-  unzip "protoc-${PROTOC_VERSION}-$2-$1.zip" -d "${INSTALL_PATH}" -x "readme.txt"
-  rm "protoc-${PROTOC_VERSION}-$2-$1.zip"
+  unzip "protoc-${PROTOC_VERSION}-${OS}-${ARCH}.zip" -d "${INSTALL_PATH}" -x "readme.txt"
+  rm "protoc-${PROTOC_VERSION}-${OS}-${ARCH}.zip"
   # Make the protoc binary executable. ¯\_(ツ)_/¯  crazy, right?
   chmod +x "${INSTALL_PATH}/bin/protoc"
 }

--- a/scripts/install-protoc.sh
+++ b/scripts/install-protoc.sh
@@ -35,22 +35,29 @@ source "$(dirname $0)/common.sh"
 # The version of protoc that will be installed.
 PROTOC_VERSION="27.1"
 
-INSTALL_PATH="${1}"
+main() {
+  if [[ "$#" -ne 1 ]]; then
+    die "Usage: $0 INSTALL_PATH"
+  fi
+  
+  INSTALL_PATH="${1}"
 
-# downloads the pre-built binaries for Linux to $INSTALL_PATH.
-# Usage:
-#   download_binary ARCH OS
-# Arguments:
-#   ARCH:  The hardware platform of the system.  Accepted values: [x86_64, aarch_64]
-#   OS:    The operating system of the system.   Accepted values: [osx, linux]
-download_binary() {
-  case "${1}" in
+  if [[ ! -d "${INSTALL_PATH}" ]]; then
+    die "INSTALL_PATH (${INSTALL_PATH}) does not exist."
+  fi
+  
+  echo "Installing protoc version $PROTOC_VERSION to ${INSTALL_PATH}."
+
+  # Detect the hardware platform.
+  case "$(uname -m)" in
     "x86_64")   ARCH="x86_64";;
     "aarch64")  ARCH="aarch_64";;
     "arm64")    ARCH="aarch_64";;
     *)          die "Install unsuccessful. Hardware platform not supported by installer: $1";;
   esac
-  case "${2}" in
+  
+  # Detect the Operating System.
+  case "$(uname -s)" in
     "Darwin") OS="osx";;
     "Linux")  OS="linux";;
     *)        die "Install unsuccessful. OS not supported by installer: $2";;
@@ -65,9 +72,11 @@ download_binary() {
   fi
 
   DOWNLOAD_URL="https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-${OS}-${ARCH}.zip"
+  
   # -L follows redirects.
   # -O writes output to a file.
   curl -LO "${DOWNLOAD_URL}"
+  
   # Unzip the downloaded file and except readme.txt.
   # The file structure should look like:
   # INSTALL_PATH
@@ -77,24 +86,9 @@ download_binary() {
   #     └── other files...
   unzip "protoc-${PROTOC_VERSION}-${OS}-${ARCH}.zip" -d "${INSTALL_PATH}" -x "readme.txt"
   rm "protoc-${PROTOC_VERSION}-${OS}-${ARCH}.zip"
+  
   # Make the protoc binary executable. ¯\_(ツ)_/¯  crazy, right?
   chmod +x "${INSTALL_PATH}/bin/protoc"
-}
-
-main() {
-  if [[ "$#" -ne 1 ]]; then
-    die "Usage: $0 INSTALL_PATH"
-  fi
-
-  if [[ ! -d "${INSTALL_PATH}" ]]; then
-    die "INSTALL_PATH (${INSTALL_PATH}) does not exist."
-  fi
-  echo "Installing protoc version $PROTOC_VERSION to ${INSTALL_PATH}."
-  # Detect the hardware platform.
-  ARCH="$(uname -m)"
-  # Detect the Operating System.
-  OS="$(uname -s)"
-  download_binary "${ARCH}" "${OS}"
 }
 
 main "$@"

--- a/scripts/install-protoc.sh
+++ b/scripts/install-protoc.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# 
+#
 # Copyright 2024 gRPC authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,21 +14,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# install-protoc.sh 
-# 
-# This script installs the Protocol Buffers compiler (protoc) on the local
-# machine. It is used to generate code from .proto files for gRPC communication.
-# The script downloads the protoc binary from the official GitHub repository and
-# installs it in the system. 
-# 
-# Usage: ./install-protoc.sh [INSTALL_PATH]
+# install-protoc.sh
 #
-# Arguments: 
-#   INSTALL_PATH: The path where the protoc binary will be installed (optional).
-#                 If not provided, the script will install the binary in the the
-#                 directory named by the GOBIN environment variable, which
-#                 defaults to $GOPATH/bin or $HOME/go/bin if the GOPATH
-#                 environment variable is not set. 
+# This script installs the Protocol Buffers compiler (protoc) to the specified
+# directory.  It is used to generate code from .proto files for gRPC
+# communication. The script downloads the protoc binary from the official GitHub
+# repository and installs it in the system.
+#
+# Usage: ./install-protoc.sh INSTALL_PATH
+#
+# Arguments:
+#   INSTALL_PATH: The path where the protoc binary will be installed.
 #
 # Note: This script requires internet connectivity to download the protoc binary.
 
@@ -39,53 +35,56 @@ source "$(dirname $0)/common.sh"
 # The version of protoc that will be installed.
 PROTOC_VERSION="27.1"
 
-INSTALL_PATH="${1:-${GOBIN:-${GOPATH:-$HOME/go}}}"
+INSTALL_PATH="${1}"
 
 # downloads the pre-built binaries for Linux to $INSTALL_PATH.
 # Usage:
 #   download_binary ARCH OS
 # Arguments:
-#   ARCH:  The architecture of the system.  Accepted values: [x86_64, aarch_64]
-#   OS:    The operating system of the system.  Accepted values: [osx, linux]
-download_binary() {  
-  DOWNLOAD_URL="https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-$2-$1.zip"
-  # -L follows redirects.
-  # -O writes output to a file.
-  curl -LO "${DOWNLOAD_URL}"
-  unzip "protoc-${PROTOC_VERSION}-$2-$1.zip" -d "${INSTALL_PATH}"
-  rm "protoc-${PROTOC_VERSION}-$2-$1.zip"
-  rm "${INSTALL_PATH}/readme.txt"
-}
+#   ARCH:  The hardware platform of the system.  Accepted values: [x86_64, aarch_64]
+#   OS:    The operating system of the system.   Accepted values: [osx, linux]
+download_binary() {
+  case "${1}" in
+    "x86_64")   ARCH="x86_64";;
+    "aarch64")  ARCH="aarch_64";;
+    "arm64")    ARCH="aarch_64";;
+    *)          die "Install unsuccessful. Hardware platform not supported by installer: $1";;
+  esac
+  case "${2}" in
+    "Darwin") OS="osx";;
+    "Linux")  OS="linux";;
+    *)        die "Install unsuccessful. OS not supported by installer: $2";;
+  esac
 
-main() {
-  # Check if protoc is already available.
-  if command -v protoc &> /dev/null; then
-    if INSTALL_VERSION=$(protoc --version | cut -d' ' -f2 2>/dev/null); then
-      if [ "$INSTALL_VERSION" = "$PROTOC_VERSION" ]; then
-        echo "protoc version $PROTOC_VERSION is already installed."
-        return
-      else
-        die "Existing protoc version ($INSTALL_VERSION) differs. Kindly make sure you have $PROTOC_VERSION installed."
-      fi
+  # Check if the protoc binary with the right version is already installed.
+  if [[ -f "${INSTALL_PATH}/bin/protoc" ]]; then
+    if [[ "$("${INSTALL_PATH}/bin/protoc" --version)" == "libprotoc ${PROTOC_VERSION}" ]]; then
+      echo "protoc version ${PROTOC_VERSION} is already installed in ${INSTALL_PATH}."
+      return
     fi
   fi
 
-  # Detect the architecture
-  case "$(uname -m)" in
-    "x86_64") ARCH="x86_64";;
-    "aarch64") ARCH="aarch_64";;
-    "arm64") ARCH="aarch_64";;
-  *) die "Unsupported architecture. Please consider manual installation from "\
-          "https://github.com/protocolbuffers/protobuf/releases/ and add to PATH."
-  esac
+  DOWNLOAD_URL="https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-${OS}-${ARCH}.zip"
+  # For cURL, -L follows redirects. 
+  # For tar, --exclude excludes files, and -C specifies the directory. 
+  curl -L "${DOWNLOAD_URL}" | tar -x --exclude="readme.txt" -C "${INSTALL_PATH}"
+  chmod +x "${INSTALL_PATH}/bin/protoc"
+}
 
-  # Detect the Operating System
-  case "$(uname -s)" in
-    "Darwin") download_binary $ARCH "osx";;
-    "Linux") download_binary $ARCH "linux";;
-  *) die "Unsupported OS. Please consider manual installation from "\
-          "https://github.com/protocolbuffers/protobuf/releases/ and add to PATH" ;;
-  esac
+main() {
+  if [[ "$#" -ne 1 ]]; then
+    die "Usage: $0 INSTALL_PATH"
+  fi
+
+  if [[ ! -d "${INSTALL_PATH}" ]]; then
+    die "INSTALL_PATH (${INSTALL_PATH}) does not exist."
+  fi
+  echo "Installing protoc version $PROTOC_VERSION to ${INSTALL_PATH}."
+  # Detect the hardware platform.
+  ARCH="$(uname -m)"
+  # Detect the Operating System.
+  OS="$(uname -s)"
+  download_binary "${ARCH}" "${OS}"
 }
 
 main "$@"

--- a/scripts/install-protoc.sh
+++ b/scripts/install-protoc.sh
@@ -46,7 +46,7 @@ main() {
     die "INSTALL_PATH (${INSTALL_PATH}) does not exist."
   fi
   
-  echo "Installing protoc version $PROTOC_VERSION to ${INSTALL_PATH}."
+  echo "Installing protoc version $PROTOC_VERSION to ${INSTALL_PATH}..."
 
   # Detect the hardware platform.
   case "$(uname -m)" in
@@ -66,7 +66,7 @@ main() {
   # Check if the protoc binary with the right version is already installed.
   if [[ -f "${INSTALL_PATH}/bin/protoc" ]]; then
     if [[ "$("${INSTALL_PATH}/bin/protoc" --version)" == "libprotoc ${PROTOC_VERSION}" ]]; then
-      echo "protoc version ${PROTOC_VERSION} is already installed in ${INSTALL_PATH}."
+      echo "protoc version ${PROTOC_VERSION} is already installed in ${INSTALL_PATH}"
       return
     fi
   fi

--- a/scripts/regenerate.sh
+++ b/scripts/regenerate.sh
@@ -19,31 +19,31 @@ set -eu -o pipefail
 WORKDIR="/tmp/grpc-go-tools"
 mkdir -p "${WORKDIR}"
 
-"./$(dirname "${0}")/install-protoc.sh" ${WORKDIR}
+$(dirname "${0}")/install-protoc.sh ${WORKDIR}
 
 export GOBIN="${WORKDIR}"/bin
 export PATH="${GOBIN}:${PATH}"
 mkdir -p "${GOBIN}"
 
-echo "remove existing generated files"
+echo "removing existing generated files..."
 # grpc_testing_not_regenerate/*.pb.go is not re-generated,
 # see grpc_testing_not_regenerate/README.md for details.
 find . -name '*.pb.go' | grep -v 'grpc_testing_not_regenerate' | xargs rm -f || true
 
-echo "go install google.golang.org/protobuf/cmd/protoc-gen-go"
+echo "Executing: go install google.golang.org/protobuf/cmd/protoc-gen-go..."
 (cd test/tools && go install google.golang.org/protobuf/cmd/protoc-gen-go)
 
-echo "go install cmd/protoc-gen-go-grpc"
+echo "Executing: go install cmd/protoc-gen-go-grpc..."
 (cd cmd/protoc-gen-go-grpc && go install .)
 
-echo "git clone https://github.com/grpc/grpc-proto"
+echo "Pulling protos from https://github.com/grpc/grpc-proto..."
 if [ -d "${WORKDIR}/grpc-proto" ]; then
   (cd "${WORKDIR}/grpc-proto" && git pull)
 else
   git clone --quiet https://github.com/grpc/grpc-proto "${WORKDIR}/grpc-proto"
 fi
 
-echo "git clone https://github.com/protocolbuffers/protobuf"
+echo "Pulling protos from https://github.com/protocolbuffers/protobuf..."
 if [ -d "${WORKDIR}/protobuf" ]; then
   (cd "${WORKDIR}/protobuf" && git pull)
 else
@@ -52,7 +52,7 @@ fi
 
 # Pull in code.proto as a proto dependency
 mkdir -p "${WORKDIR}/googleapis/google/rpc"
-echo "curl https://raw.githubusercontent.com/googleapis/googleapis/master/google/rpc/code.proto"
+echo "Pulling code.proto from https://raw.githubusercontent.com/googleapis/googleapis/master/google/rpc/code.proto..."
 curl --silent https://raw.githubusercontent.com/googleapis/googleapis/master/google/rpc/code.proto > "${WORKDIR}/googleapis/google/rpc/code.proto"
 
 

--- a/scripts/regenerate.sh
+++ b/scripts/regenerate.sh
@@ -19,7 +19,7 @@ set -eu -o pipefail
 WORKDIR="/tmp/grpc-go-tools"
 mkdir -p "${WORKDIR}"
 
-$(dirname "${0}")/install-protoc.sh ${WORKDIR}
+"$(dirname "${0}")"/install-protoc.sh ${WORKDIR}
 
 export GOBIN="${WORKDIR}"/bin
 export PATH="${GOBIN}:${PATH}"


### PR DESCRIPTION
Fixes #7400 

@dfawley I went with something that's more along the lines of option no.3 in the issue.  Now the deps are installed in a 
"well-known" directory which is `/tmp/grpc-go-tools`.  This will ensure not requiring to re-download all deps when running regenerate.

Changes: 

install-protoc.sh
1. Now requires an INSTALL_PATH to be specified
	- This is a behavior change.  Previously INSTALL_PATH was optional and would put it in your GOBIN/GOPATH.  We dont want to be polluting the users GO dir with non-golang binaries.
2. Now checks if `protoc` in the required version is present in INSTALL_PATH and not $PATH

regenerate.sh
1. Installs everything to `/tmp/grpc-go-tools` instead of mktmp
2. Only download deps if not present
3. Other shell linter changes


cc: @aranjans 

RELEASE NOTES: none