### PR TITLE
xds: Fix flaky test Test/ServerSideXDS_WithValidAndInvalidSecurityConfiguration

### DIFF
--- a/test/xds/xds_server_certificate_providers_test.go
+++ b/test/xds/xds_server_certificate_providers_test.go
@@ -120,7 +120,7 @@ func (s) TestServerSideXDS_WithNoCertificateProvidersInBootstrap_Failure(t *test
 			}
 			select {
 			case nackCh <- struct{}{}:
-			case <-ctx.Done():
+			default:
 			}
 			return nil
 		},
@@ -247,7 +247,7 @@ func (s) TestServerSideXDS_WithValidAndInvalidSecurityConfiguration(t *testing.T
 			}
 			select {
 			case nackCh <- struct{}{}:
-			case <-ctx.Done():
+			default:
 			}
 			return nil
 		},


### PR DESCRIPTION
In the logs of failing runs for `TestServerSideXDS_WithValidAndInvalidSecurityConfiguration`, we see that the resource snapshot update request is sent to the xds management server before the xds client is able to connect to it. Every time a gRPC server receives the updated snapshot resource from the xds server, it sends a NACK as the configuration is invalid. When the server receives more than one NACK, it gets stuck while writing to a buffered channel here:
https://github.com/grpc/grpc-go/blob/d27ddb5eb5940c949f88bc2cb21eed9254f8be75/test/xds/xds_server_certificate_providers_test.go#L249

This results in the gRPC server timing out while getting the new configuration.

This change ensures that the server writes to the buffered channel at most once and doesn't get stuck.

Example failure: https://github.com/grpc/grpc-go/actions/runs/9790522733/job/27032314481?pr=7390

## Tested
Verified that the test no longer fails in 100000 runs

Updates: https://github.com/grpc/grpc-go/issues/6914

RELEASE NOTES: None