### PR TITLE
docs: point RecvBufferPool server option to correct deprecation replacement

### DIFF
--- a/server.go
+++ b/server.go
@@ -603,7 +603,7 @@ func WaitForHandlers(w bool) ServerOption {
 // options are used: StatsHandler, EnableTracing, or binary logging. In such
 // cases, the shared buffer pool will be ignored.
 //
-// Deprecated: use experimental.WithRecvBufferPool instead.  Will be deleted in
+// Deprecated: use experimental.RecvBufferPool instead.  Will be deleted in
 // v1.60.0 or later.
 func RecvBufferPool(bufferPool SharedBufferPool) ServerOption {
 	return recvBufferPool(bufferPool)


### PR DESCRIPTION
Hi,

The current deprecation notice for the function `grpc.RecvBufferPool` points to `experimental.WithRecvBufferPool` which is a `grpc.DialOption`, while `grpc.NewServer` actually expects `grpc.ServerOption`.

The proper replacement function is `experimental.RecvBufferPool`, not `experimental.WithRecvBufferPool`.

This PR / commit simply refer to the proper experimental package function.

RELEASE NOTES: point RecvBufferPool server option to correct deprecation replacement