### PR TITLE
outlierdetection: Disable outlier detection for pickfirst balancer

### DIFF
--- a/clientconn_test.go
+++ b/clientconn_test.go
@@ -1072,7 +1072,7 @@ func (s) TestUpdateAddresses_NoopIfCalledWithSameAddresses(t *testing.T) {
 
 	// Call UpdateAddresses with the same list of addresses, it should be a noop
 	// (even when the SubConn is Connecting, and doesn't have a curAddr).
-	ac.acbw.UpdateAddresses(addrsList)
+	ac.acbw.UpdateAddresses(ac.addrs)
 
 	// We've called tryUpdateAddrs - now let's make server2 close the
 	// connection and check that it continues to server3.


### PR DESCRIPTION
As part of the dual stack changes, the pick first LB policy will start creating 1 subConn for each address. As a result, outlier detection (OD) will start working on subConns created by pickfirst (https://github.com/grpc/grpc-go/pull/7384).

Based on the comment in c-core we don't want to support outlier detection for pick first: https://github.com/grpc/grpc/issues/32967#issuecomment-1574427837
>We are planning to make some significant structural changes as part of the forthcoming design for supporting dualstack IPv4/IPv6 backends, and as part of that work, we are going to be modeling outlier detection as a health signal instead of a connectivity signal. This will make it similar to what we support for client-side health checking (see [gRFC A17](https://github.com/grpc/proposal/blob/master/A17-client-side-health-checking.md)), which we [explicitly do not support with pick_first](https://github.com/grpc/proposal/blob/master/A17-client-side-health-checking.md#pick_first). If we start supporting outlier detection with pick_first now, it will cause complications for this dualstack design.

Similar change from c-core: https://github.com/grpc/grpc/pull/33336

Before this change, OD worked for pick first when there was only one address. This isn't very useful since there would be no addresses left after ejection.

RELEASE NOTES:
* Outlier detection is disabled when using pick first child policy. Earlier it would work only when there was only one address provided to pick first.