### PR TITLE
xds/balancer/priority: Unlock mutex before returning

### DIFF
--- a/xds/internal/balancer/priority/balancer.go
+++ b/xds/internal/balancer/priority/balancer.go
@@ -270,6 +270,7 @@ func (b *priorityBalancer) run() {
 			// deadlock.
 			b.mu.Lock()
 			if b.done.HasFired() {
+				b.mu.Unlock()
 				return
 			}
 			switch s := u.(type) {


### PR DESCRIPTION
Release the mutex that is locked a couple of lines above.

https://github.com/grpc/grpc-go/blob/d27ddb5eb5940c949f88bc2cb21eed9254f8be75/xds/internal/balancer/priority/balancer.go#L271-L274

This could subsequent calls to `UpdateClientConnState` to get stuck.

RELEASE NOTES: None