### PR TITLE
vet: fix option order when invoking grep

### DIFF
--- a/scripts/vet.sh
+++ b/scripts/vet.sh
@@ -121,7 +121,7 @@ XXXXX PleaseIgnoreUnused'
 
   # Ignore a false positive when operands have side affectes.
   # TODO(https://github.com/dominikh/go-tools/issues/54): Remove this once the issue is fixed in staticcheck.
-  noret_grep "(SA4000)" "${SC_OUT}" | not grep -v -e "crl.go:\d*:\d*: identical expressions on the left and right side of the '||' operator (SA4000)"
+  noret_grep "(SA4000)" "${SC_OUT}" | not grep -v -e "crl.go:[0-9]\+:[0-9]\+: identical expressions on the left and right side of the '||' operator (SA4000)"
 
   # Only ignore the following deprecated types/fields/functions and exclude
   # generated code.

--- a/scripts/vet.sh
+++ b/scripts/vet.sh
@@ -121,7 +121,7 @@ XXXXX PleaseIgnoreUnused'
 
   # Ignore a false positive when operands have side affectes.
   # TODO(https://github.com/dominikh/go-tools/issues/54): Remove this once the issue is fixed in staticcheck.
-  noret_grep "(SA4000)" "${SC_OUT}" | not grep -ev "crl.go:\d*:\d*: identical expressions on the left and right side of the '||' operator (SA4000)"
+  noret_grep "(SA4000)" "${SC_OUT}" | not grep -v -e "crl.go:\d*:\d*: identical expressions on the left and right side of the '||' operator (SA4000)"
 
   # Only ignore the following deprecated types/fields/functions and exclude
   # generated code.


### PR DESCRIPTION
vet.sh is currently calling `grep -ev expr`. This is being interpreted as "grep pattern 'v' in file 'expr'", instead of the intended "invert grep for pattern 'expr' in standard input". As a result:

- Most of the time we see a line as follows on standard output:

```
+ noret_grep '(SA4000)' /tmp/tmp.xKUnikWsnw
+ grep '(SA4000)' /tmp/tmp.xKUnikWsnw
+ not grep -ev 'crl.go:\d*:\d*: identical expressions on the left and right side of the '\''||'\'' operator (SA4000)'
+ grep -ev 'crl.go:\d*:\d*: identical expressions on the left and right side of the '\''||'\'' operator (SA4000)'
+ [[ 1 == 1 ]]
grep: crl.go:\d*:\d*: identical expressions on the left and right side of the '||' operator (SA4000): No such file or directory
```

and the process continues without error, but doesn't do what we want it to do.

- Occasionally, this causes a broken pipe on the first grep which results in an error:

```
+ noret_grep '(SA4000)' /tmp/tmp.BmSCFYnqgE
+ grep '(SA4000)' /tmp/tmp.BmSCFYnqgE
+ not grep -ev 'crl.go:\d*:\d*: identical expressions on the left and right side of the '\''||'\'' operator (SA4000)'
+ grep -ev 'crl.go:\d*:\d*: identical expressions on the left and right side of the '\''||'\'' operator (SA4000)'
grep: crl.go:\d*:\d*: identical expressions on the left and right side of the '||' operator (SA4000): No such file or directory
grep: write error: Broken pipe
+ [[ 2 == 1 ]]
```

RELEASE NOTES: none