### PR TITLE
transport: Discard the buffer when empty after http connect handshake

### DIFF
--- a/internal/transport/proxy.go
+++ b/internal/transport/proxy.go
@@ -107,8 +107,14 @@ func doHTTPConnectHandshake(ctx context.Context, conn net.Conn, backendAddr stri
 		}
 		return nil, fmt.Errorf("failed to do connect handshake, response: %q", dump)
 	}
-
-	return &bufConn{Conn: conn, r: r}, nil
+	// The buffer could contain extra bytes from the target server, so we can't
+	// discard it. However, in many cases where the server waits for the client
+	// to send the first message (e.g. when TLS is being used), the buffer will
+	// be empty, so we can avoid the overhead of reading through this buffer.
+	if r.Buffered() != 0 {
+		return &bufConn{Conn: conn, r: r}, nil
+	}
+	return conn, nil
 }
 
 // proxyDial dials, connecting to a proxy first if necessary. Checks if a proxy


### PR DESCRIPTION
Fixes: https://github.com/grpc/grpc-go/issues/7327

The buffer used to read the http connect response could contain extra bytes from the target server, so we can't discard it. However, in many cases where the server waits for the client to send the first message (e.g. when TLS is being used), the buffer will be empty, so we can avoid the overhead of reading through this buffer.

This PR also adds a unit test to ensure the buffer is not discarded when it has unread data.

RELEASE NOTES:
* Double buffering is avoided when using an http connect proxy and the target server waits for client to send the first message.