### PR TITLE
grpc: Add metrics recorder list and usage in ClientConn

### DIFF
--- a/balancer/balancer.go
+++ b/balancer/balancer.go
@@ -30,6 +30,7 @@ import (
 	"google.golang.org/grpc/channelz"
 	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/credentials"
+	estats "google.golang.org/grpc/experimental/stats"
 	"google.golang.org/grpc/grpclog"
 	"google.golang.org/grpc/internal"
 	"google.golang.org/grpc/metadata"
@@ -256,6 +257,10 @@ type BuildOptions struct {
 	// same resolver.Target as passed to the resolver. See the documentation for
 	// the resolver.Target type for details about what it contains.
 	Target resolver.Target
+	// MetricsRecorder is the metrics recorder that balancers can use to record
+	// metrics. Balancer implementations which do not register metrics on
+	// metrics registry and record on them can ignore this field.
+	MetricsRecorder estats.MetricsRecorder
 }
 
 // Builder creates a balancer.

--- a/balancer_wrapper.go
+++ b/balancer_wrapper.go
@@ -82,6 +82,7 @@ func newCCBalancerWrapper(cc *ClientConn) *ccBalancerWrapper {
 			CustomUserAgent: cc.dopts.copts.UserAgent,
 			ChannelzParent:  cc.channelz,
 			Target:          cc.parsedTarget,
+			MetricsRecorder: cc.metricsRecorderList,
 		},
 		serializer:       grpcsync.NewCallbackSerializer(ctx),
 		serializerCancel: cancel,

--- a/clientconn.go
+++ b/clientconn.go
@@ -40,6 +40,7 @@ import (
 	"google.golang.org/grpc/internal/grpcsync"
 	"google.golang.org/grpc/internal/idle"
 	iresolver "google.golang.org/grpc/internal/resolver"
+	"google.golang.org/grpc/internal/stats"
 	"google.golang.org/grpc/internal/transport"
 	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/resolver"
@@ -195,8 +196,11 @@ func NewClient(target string, opts ...DialOption) (conn *ClientConn, err error) 
 	cc.csMgr = newConnectivityStateManager(cc.ctx, cc.channelz)
 	cc.pickerWrapper = newPickerWrapper(cc.dopts.copts.StatsHandlers)
 
+	cc.metricsRecorderList = stats.NewMetricsRecorderList(cc.dopts.copts.StatsHandlers)
+
 	cc.initIdleStateLocked() // Safe to call without the lock, since nothing else has a reference to cc.
 	cc.idlenessMgr = idle.NewManager((*idler)(cc), cc.dopts.idleTimeout)
+
 	return cc, nil
 }
 
@@ -591,13 +595,14 @@ type ClientConn struct {
 	cancel context.CancelFunc // Cancelled on close.
 
 	// The following are initialized at dial time, and are read-only after that.
-	target          string            // User's dial target.
-	parsedTarget    resolver.Target   // See initParsedTargetAndResolverBuilder().
-	authority       string            // See initAuthority().
-	dopts           dialOptions       // Default and user specified dial options.
-	channelz        *channelz.Channel // Channelz object.
-	resolverBuilder resolver.Builder  // See initParsedTargetAndResolverBuilder().
-	idlenessMgr     *idle.Manager
+	target              string            // User's dial target.
+	parsedTarget        resolver.Target   // See initParsedTargetAndResolverBuilder().
+	authority           string            // See initAuthority().
+	dopts               dialOptions       // Default and user specified dial options.
+	channelz            *channelz.Channel // Channelz object.
+	resolverBuilder     resolver.Builder  // See initParsedTargetAndResolverBuilder().
+	idlenessMgr         *idle.Manager
+	metricsRecorderList *stats.MetricsRecorderList
 
 	// The following provide their own synchronization, and therefore don't
 	// require cc.mu to be held to access them.

--- a/experimental/stats/metricregistry.go
+++ b/experimental/stats/metricregistry.go
@@ -23,7 +23,12 @@ import (
 	"testing"
 
 	"google.golang.org/grpc/grpclog"
+	"google.golang.org/grpc/internal"
 )
+
+func init() {
+	internal.SnapshotMetricRegistryForTesting = snapshotMetricsRegistryForTesting
+}
 
 var logger = grpclog.Component("metrics-registry")
 
@@ -54,6 +59,10 @@ type MetricDescriptor struct {
 	// The type of metric. This is set by the metric registry, and not intended
 	// to be set by a component registering a metric.
 	Type MetricType
+	// Bounds are the bounds of this metric. This only applies to histogram
+	// metrics. If unset or set with length 0, stats handlers will fall back to
+	// default bounds.
+	Bounds []float64
 }
 
 // MetricType is the type of metric.

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -215,6 +215,12 @@ var (
 
 	// SetConnectedAddress sets the connected address for a SubConnState.
 	SetConnectedAddress any // func(scs *SubConnState, addr resolver.Address)
+
+	// SnapshotMetricsRegistryForTesting snapshots the global data of the
+	// metrics registry. Registers a cleanup function on the provided testing.T
+	// that sets the metrics registry to its original state. Only called in
+	// testing functions.
+	SnapshotMetricRegistryForTesting any // func(t *testing.T)
 )
 
 // HealthChecker defines the signature of the client-side LB channel health

--- a/internal/stats/metrics_recorder_list.go
+++ b/internal/stats/metrics_recorder_list.go
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2024 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package stats
+
+import (
+	estats "google.golang.org/grpc/experimental/stats"
+	"google.golang.org/grpc/grpclog"
+	"google.golang.org/grpc/stats"
+)
+
+var logger = grpclog.Component("metrics-recorder-list")
+
+// MetricRecorderList forwards Record calls to all of it's metricsRecorders.
+//
+// It eats any record calls where the label values provided do not match the
+// number of label keys.
+type MetricsRecorderList struct {
+	// metricsRecorders are the metrics recorders this list will forward to.
+	metricsRecorders []estats.MetricsRecorder
+}
+
+// NewMetricsRecorderList creates a new metric recorder list with all the stats
+// handlers provided which implement the MetricsRecorder interface.
+// If no stats handlers provided implement the MetricsRecorder interface,
+// the MetricsRecorder list returned is a no-op.
+func NewMetricsRecorderList(shs []stats.Handler) *MetricsRecorderList {
+	var mrs []estats.MetricsRecorder
+	for _, sh := range shs {
+		if mr, ok := sh.(estats.MetricsRecorder); ok {
+			mrs = append(mrs, mr)
+		}
+	}
+	return &MetricsRecorderList{
+		metricsRecorders: mrs,
+	}
+}
+
+func (l *MetricsRecorderList) RecordInt64Count(handle *estats.Int64CountHandle, incr int64, labels ...string) {
+	if got, want := len(handle.Labels)+len(handle.OptionalLabels), len(labels); got != want {
+		logger.Infof("length of labels passed to RecordInt64Count incorrect got: %v, want: %v", got, want)
+	}
+
+	for _, metricRecorder := range l.metricsRecorders {
+		metricRecorder.RecordInt64Count(handle, incr, labels...)
+	}
+}
+
+func (l *MetricsRecorderList) RecordFloat64Count(handle *estats.Float64CountHandle, incr float64, labels ...string) {
+	if got, want := len(handle.Labels)+len(handle.OptionalLabels), len(labels); got != want {
+		logger.Infof("length of labels passed to RecordFloat64Count incorrect got: %v, want: %v", got, want)
+	}
+
+	for _, metricRecorder := range l.metricsRecorders {
+		metricRecorder.RecordFloat64Count(handle, incr, labels...)
+	}
+}
+
+func (l *MetricsRecorderList) RecordInt64Histo(handle *estats.Int64HistoHandle, incr int64, labels ...string) {
+	if got, want := len(handle.Labels)+len(handle.OptionalLabels), len(labels); got != want {
+		logger.Infof("length of labels passed to RecordInt64Histo incorrect got: %v, want: %v", got, want)
+	}
+
+	for _, metricRecorder := range l.metricsRecorders {
+		metricRecorder.RecordInt64Histo(handle, incr, labels...)
+	}
+}
+
+func (l *MetricsRecorderList) RecordFloat64Histo(handle *estats.Float64HistoHandle, incr float64, labels ...string) {
+	if got, want := len(handle.Labels)+len(handle.OptionalLabels), len(labels); got != want {
+		logger.Infof("length of labels passed to RecordFloat64Histo incorrect got: %v, want: %v", got, want)
+	}
+
+	for _, metricRecorder := range l.metricsRecorders {
+		metricRecorder.RecordFloat64Histo(handle, incr, labels...)
+	}
+}
+
+func (l *MetricsRecorderList) RecordInt64Gauge(handle *estats.Int64GaugeHandle, incr int64, labels ...string) {
+	if got, want := len(handle.Labels)+len(handle.OptionalLabels), len(labels); got != want {
+		logger.Infof("length of labels passed to RecordInt64Gauge incorrect got: %v, want: %v", got, want)
+	}
+
+	for _, metricRecorder := range l.metricsRecorders {
+		metricRecorder.RecordInt64Gauge(handle, incr, labels...)
+	}
+}

--- a/internal/stats/test/metrics_recorder_list_test.go
+++ b/internal/stats/test/metrics_recorder_list_test.go
@@ -1,0 +1,131 @@
+/*
+ *
+ * Copyright 2024 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package test
+
+import (
+	"context"
+	"log"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	estats "google.golang.org/grpc/experimental/stats"
+	"google.golang.org/grpc/internal"
+	"google.golang.org/grpc/internal/grpctest"
+	testgrpc "google.golang.org/grpc/interop/grpc_testing"
+	testpb "google.golang.org/grpc/interop/grpc_testing"
+	"google.golang.org/grpc/resolver"
+	"google.golang.org/grpc/resolver/manual"
+	"google.golang.org/grpc/serviceconfig"
+)
+
+var defaultTestTimeout = 5 * time.Second
+
+type s struct {
+	grpctest.Tester
+}
+
+func Test(t *testing.T) {
+	grpctest.RunSubTests(t, s{})
+}
+
+// TestMetricsRecorderList tests the metrics recorder list functionality of the
+// ClientConn. It configures a global and local stats handler Dial Option. These
+// stats handlers implement the MetricsRecorder interface. It also configures a
+// balancer which registers metrics and records on metrics at build time. This
+// test then asserts that the recorded metrics show up on both configured stats
+// handlers, and that metrics calls with the incorrect number of labels do not
+// make their way to stats handlers.
+func (s) TestMetricsRecorderList(t *testing.T) {
+	mr := manual.NewBuilderWithScheme("test-metrics-recorder-list")
+	defer mr.Close()
+
+	json := `{"loadBalancingConfig": [{"recording_load_balancer":{}}]}`
+	sc := internal.ParseServiceConfig.(func(string) *serviceconfig.ParseResult)(json)
+	mr.InitialState(resolver.State{
+		ServiceConfig: sc,
+	})
+
+	// Create two stats.Handlers which also implement MetricsRecorder, configure
+	// one as a global dial option and one as a local dial option.
+	mr1 := NewTestMetricsRecorder(t, []string{})
+	mr2 := NewTestMetricsRecorder(t, []string{})
+
+	defer internal.ClearGlobalDialOptions()
+	internal.AddGlobalDialOptions.(func(opt ...grpc.DialOption))(grpc.WithStatsHandler(mr1))
+
+	cc, err := grpc.NewClient(mr.Scheme()+":///", grpc.WithResolvers(mr), grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithStatsHandler(mr2))
+	if err != nil {
+		log.Fatalf("Failed to dial: %v", err)
+	}
+	defer cc.Close()
+
+	tsc := testgrpc.NewTestServiceClient(cc)
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+
+	// Trigger the recording_load_balancer to build, which will trigger metrics
+	// to record.
+	tsc.UnaryCall(ctx, &testpb.SimpleRequest{})
+
+	mdWant := MetricsData{
+		Handle:    (*estats.MetricDescriptor)(intCountHandle),
+		IntIncr:   1,
+		LabelKeys: []string{"int counter label", "int counter optional label"},
+		LabelVals: []string{"int counter label val", "int counter optional label val"},
+	}
+	mr1.WaitForInt64Count(ctx, mdWant)
+	mr2.WaitForInt64Count(ctx, mdWant)
+
+	mdWant = MetricsData{
+		Handle:    (*estats.MetricDescriptor)(floatCountHandle),
+		FloatIncr: 2,
+		LabelKeys: []string{"float counter label", "float counter optional label"},
+		LabelVals: []string{"float counter label val", "float counter optional label val"},
+	}
+	mr1.WaitForFloat64Count(ctx, mdWant)
+	mr2.WaitForFloat64Count(ctx, mdWant)
+
+	mdWant = MetricsData{
+		Handle:    (*estats.MetricDescriptor)(intHistoHandle),
+		IntIncr:   3,
+		LabelKeys: []string{"int histo label", "int histo optional label"},
+		LabelVals: []string{"int histo label val", "int histo optional label val"},
+	}
+	mr1.WaitForInt64Histo(ctx, mdWant)
+	mr2.WaitForInt64Histo(ctx, mdWant)
+
+	mdWant = MetricsData{
+		Handle:    (*estats.MetricDescriptor)(floatHistoHandle),
+		FloatIncr: 4,
+		LabelKeys: []string{"float histo label", "float histo optional label"},
+		LabelVals: []string{"float histo label val", "float histo optional label val"},
+	}
+	mr1.WaitForFloat64Histo(ctx, mdWant)
+	mr2.WaitForFloat64Histo(ctx, mdWant)
+	mdWant = MetricsData{
+		Handle:    (*estats.MetricDescriptor)(intGaugeHandle),
+		IntIncr:   5, // Should ignore the 7 metrics recording point because emits wrong number of labels.
+		LabelKeys: []string{"int gauge label", "int gauge optional label"},
+		LabelVals: []string{"int gauge label val", "int gauge optional label val"},
+	}
+	mr1.WaitForInt64Gauge(ctx, mdWant)
+	mr2.WaitForInt64Gauge(ctx, mdWant)
+}

--- a/internal/stats/test/recording_load_balancer.go
+++ b/internal/stats/test/recording_load_balancer.go
@@ -1,0 +1,100 @@
+/*
+ *
+ * Copyright 2024 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package test
+
+import (
+	"google.golang.org/grpc/balancer"
+	"google.golang.org/grpc/balancer/pickfirst"
+	"google.golang.org/grpc/experimental/stats"
+)
+
+var (
+	intCountHandle = stats.RegisterInt64Count(stats.MetricDescriptor{
+		Name:           "simple counter",
+		Description:    "sum of all emissions from tests",
+		Unit:           "int",
+		Labels:         []string{"int counter label"},
+		OptionalLabels: []string{"int counter optional label"},
+		Default:        false,
+	})
+	floatCountHandle = stats.RegisterFloat64Count(stats.MetricDescriptor{
+		Name:           "float counter",
+		Description:    "sum of all emissions from tests",
+		Unit:           "float",
+		Labels:         []string{"float counter label"},
+		OptionalLabels: []string{"float counter optional label"},
+		Default:        false,
+	})
+	intHistoHandle = stats.RegisterInt64Histo(stats.MetricDescriptor{
+		Name:           "int histo",
+		Description:    "sum of all emissions from tests",
+		Unit:           "int",
+		Labels:         []string{"int histo label"},
+		OptionalLabels: []string{"int histo optional label"},
+		Default:        false,
+	})
+	floatHistoHandle = stats.RegisterFloat64Histo(stats.MetricDescriptor{
+		Name:           "float histo",
+		Description:    "sum of all emissions from tests",
+		Unit:           "float",
+		Labels:         []string{"float histo label"},
+		OptionalLabels: []string{"float histo optional label"},
+		Default:        false,
+	})
+	intGaugeHandle = stats.RegisterInt64Gauge(stats.MetricDescriptor{
+		Name:           "simple gauge",
+		Description:    "the most recent int emitted by test",
+		Unit:           "int",
+		Labels:         []string{"int gauge label"},
+		OptionalLabels: []string{"int gauge optional label"},
+		Default:        false,
+	})
+)
+
+func init() {
+	balancer.Register(recordingLoadBalancerBuilder{})
+}
+
+const recordingLoadBalancerName = "recording_load_balancer"
+
+type recordingLoadBalancerBuilder struct{}
+
+func (recordingLoadBalancerBuilder) Name() string {
+	return recordingLoadBalancerName
+}
+
+func (recordingLoadBalancerBuilder) Build(cc balancer.ClientConn, bOpts balancer.BuildOptions) balancer.Balancer {
+	intCountHandle.Record(bOpts.MetricsRecorder, 1, "int counter label val", "int counter optional label val")
+	floatCountHandle.Record(bOpts.MetricsRecorder, 2, "float counter label val", "float counter optional label val")
+	intHistoHandle.Record(bOpts.MetricsRecorder, 3, "int histo label val", "int histo optional label val")
+	floatHistoHandle.Record(bOpts.MetricsRecorder, 4, "float histo label val", "float histo optional label val")
+	intGaugeHandle.Record(bOpts.MetricsRecorder, 5, "int gauge label val", "int gauge optional label val")
+	// This Record call should get eaten by metrics recorder list and not end up
+	// in the stats handler data. This is because this emits the wrong number of
+	// labels.
+	intGaugeHandle.Record(bOpts.MetricsRecorder, 7, "non-existent-label")
+
+	return &recordingLoadBalancer{
+		Balancer: balancer.Get(pickfirst.Name).Build(cc, bOpts),
+	}
+}
+
+type recordingLoadBalancer struct {
+	balancer.Balancer
+}

--- a/internal/stats/test/test_metrics_recorder.go
+++ b/internal/stats/test/test_metrics_recorder.go
@@ -1,0 +1,209 @@
+/*
+ *
+ * Copyright 2024 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	estats "google.golang.org/grpc/experimental/stats"
+	"google.golang.org/grpc/internal/testutils"
+	"google.golang.org/grpc/stats"
+)
+
+// TestMetricsRecorder is a MetricsRecorder to be used in tests. It sends
+// recording events on channels and provides helpers to check if certain events
+// have taken place. It also persists metrics data keyed on the metrics
+// descriptor.
+type TestMetricsRecorder struct {
+	t *testing.T
+
+	// TODO: scale this persisted storage up with label key values.
+	intValues   map[*estats.MetricDescriptor]int64
+	floatValues map[*estats.MetricDescriptor]float64
+
+	intCountCh   *testutils.Channel
+	floatCountCh *testutils.Channel
+	intHistoCh   *testutils.Channel
+	floatHistoCh *testutils.Channel
+	intGaugeCh   *testutils.Channel
+}
+
+func NewTestMetricsRecorder(t *testing.T, metrics []string) *TestMetricsRecorder {
+	tmr := &TestMetricsRecorder{
+		t:           t,
+		intValues:   make(map[*estats.MetricDescriptor]int64),
+		floatValues: make(map[*estats.MetricDescriptor]float64),
+
+		intCountCh:   testutils.NewChannelWithSize(10),
+		floatCountCh: testutils.NewChannelWithSize(10),
+		intHistoCh:   testutils.NewChannelWithSize(10),
+		floatHistoCh: testutils.NewChannelWithSize(10),
+		intGaugeCh:   testutils.NewChannelWithSize(10),
+	}
+
+	for _, metric := range metrics {
+		desc := estats.DescriptorForMetric(estats.Metric(metric))
+		switch desc.Type {
+		case estats.MetricTypeIntCount:
+		case estats.MetricTypeIntHisto:
+		case estats.MetricTypeIntGauge:
+			tmr.intValues[desc] = 0
+		case estats.MetricTypeFloatCount:
+		case estats.MetricTypeFloatHisto:
+			tmr.floatValues[desc] = 0
+		}
+	}
+	return tmr
+}
+
+type MetricsData struct {
+	Handle *estats.MetricDescriptor
+
+	// Only set based on the type of metric. So only one of IntIncr or FloatIncr
+	// is set.
+	IntIncr   int64
+	FloatIncr float64
+
+	LabelKeys []string
+	LabelVals []string
+}
+
+func (r *TestMetricsRecorder) WaitForInt64Count(ctx context.Context, metricsDataWant MetricsData) {
+	got, err := r.intCountCh.Receive(ctx)
+	if err != nil {
+		r.t.Fatalf("timeout waiting for int64Count")
+	}
+	metricsDataGot := got.(MetricsData)
+	if diff := cmp.Diff(metricsDataGot, metricsDataWant); diff != "" {
+		r.t.Fatalf("int64count metricsData received unexpected value (-got, +want): %v", diff)
+	}
+}
+
+func (r *TestMetricsRecorder) RecordInt64Count(handle *estats.Int64CountHandle, incr int64, labels ...string) {
+	r.intCountCh.Send(MetricsData{
+		Handle:    (*estats.MetricDescriptor)(handle),
+		IntIncr:   incr,
+		LabelKeys: append(handle.Labels, handle.OptionalLabels...),
+		LabelVals: labels,
+	})
+
+	r.intValues[(*estats.MetricDescriptor)(handle)] += incr
+}
+
+func (r *TestMetricsRecorder) WaitForFloat64Count(ctx context.Context, metricsDataWant MetricsData) {
+	got, err := r.floatCountCh.Receive(ctx)
+	if err != nil {
+		r.t.Fatalf("timeout waiting for float64Count")
+	}
+	metricsDataGot := got.(MetricsData)
+	if diff := cmp.Diff(metricsDataGot, metricsDataWant); diff != "" {
+		r.t.Fatalf("float64count metricsData received unexpected value (-got, +want): %v", diff)
+	}
+}
+
+func (r *TestMetricsRecorder) RecordFloat64Count(handle *estats.Float64CountHandle, incr float64, labels ...string) {
+	r.floatCountCh.Send(MetricsData{
+		Handle:    (*estats.MetricDescriptor)(handle),
+		FloatIncr: incr,
+		LabelKeys: append(handle.Labels, handle.OptionalLabels...),
+		LabelVals: labels,
+	})
+
+	r.floatValues[(*estats.MetricDescriptor)(handle)] += incr
+}
+
+func (r *TestMetricsRecorder) WaitForInt64Histo(ctx context.Context, metricsDataWant MetricsData) {
+	got, err := r.intHistoCh.Receive(ctx)
+	if err != nil {
+		r.t.Fatalf("timeout waiting for int64Histo")
+	}
+	metricsDataGot := got.(MetricsData)
+	if diff := cmp.Diff(metricsDataGot, metricsDataWant); diff != "" {
+		r.t.Fatalf("int64Histo metricsData received unexpected value (-got, +want): %v", diff)
+	}
+}
+
+func (r *TestMetricsRecorder) RecordInt64Histo(handle *estats.Int64HistoHandle, incr int64, labels ...string) {
+	r.intHistoCh.Send(MetricsData{
+		Handle:    (*estats.MetricDescriptor)(handle),
+		IntIncr:   incr,
+		LabelKeys: append(handle.Labels, handle.OptionalLabels...),
+		LabelVals: labels,
+	})
+
+	r.intValues[(*estats.MetricDescriptor)(handle)] += incr
+}
+
+func (r *TestMetricsRecorder) WaitForFloat64Histo(ctx context.Context, metricsDataWant MetricsData) {
+	got, err := r.floatHistoCh.Receive(ctx)
+	if err != nil {
+		r.t.Fatalf("timeout waiting for float64Histo")
+	}
+	metricsDataGot := got.(MetricsData)
+	if diff := cmp.Diff(metricsDataGot, metricsDataWant); diff != "" {
+		r.t.Fatalf("float64Histo metricsData received unexpected value (-got, +want): %v", diff)
+	}
+}
+
+func (r *TestMetricsRecorder) RecordFloat64Histo(handle *estats.Float64HistoHandle, incr float64, labels ...string) {
+	r.floatHistoCh.Send(MetricsData{
+		Handle:    (*estats.MetricDescriptor)(handle),
+		FloatIncr: incr,
+		LabelKeys: append(handle.Labels, handle.OptionalLabels...),
+		LabelVals: labels,
+	})
+	r.floatValues[(*estats.MetricDescriptor)(handle)] += incr
+}
+
+func (r *TestMetricsRecorder) WaitForInt64Gauge(ctx context.Context, metricsDataWant MetricsData) {
+	got, err := r.intGaugeCh.Receive(ctx)
+	if err != nil {
+		r.t.Fatalf("timeout waiting for int64Gauge")
+	}
+	metricsDataGot := got.(MetricsData)
+	if diff := cmp.Diff(metricsDataGot, metricsDataWant); diff != "" {
+		r.t.Fatalf("int64Gauge metricsData received unexpected value (-got, +want): %v", diff)
+	}
+}
+
+func (r *TestMetricsRecorder) RecordInt64Gauge(handle *estats.Int64GaugeHandle, incr int64, labels ...string) {
+	r.intGaugeCh.Send(MetricsData{
+		Handle:    (*estats.MetricDescriptor)(handle),
+		IntIncr:   incr,
+		LabelKeys: append(handle.Labels, handle.OptionalLabels...),
+		LabelVals: labels,
+	})
+
+	r.intValues[(*estats.MetricDescriptor)(handle)] = incr
+}
+
+// To implement a stats.Handler, which allows it to be set as a dial option:
+func (r *TestMetricsRecorder) TagRPC(ctx context.Context, _ *stats.RPCTagInfo) context.Context {
+	return ctx
+}
+
+func (r *TestMetricsRecorder) HandleRPC(context.Context, stats.RPCStats) {}
+
+func (r *TestMetricsRecorder) TagConn(ctx context.Context, _ *stats.ConnTagInfo) context.Context {
+	return ctx
+}
+
+func (r *TestMetricsRecorder) HandleConn(context.Context, stats.ConnStats) {}

--- a/stats/opentelemetry/client_metrics.go
+++ b/stats/opentelemetry/client_metrics.go
@@ -30,10 +30,10 @@ import (
 
 	otelattribute "go.opentelemetry.io/otel/attribute"
 	otelmetric "go.opentelemetry.io/otel/metric"
-	"go.opentelemetry.io/otel/metric/noop"
 )
 
 type clientStatsHandler struct {
+	registryMetrics
 	options Options
 
 	clientMetrics clientMetrics
@@ -62,110 +62,37 @@ func (h *clientStatsHandler) initializeMetrics() {
 	h.clientMetrics.attemptRcvdTotalCompressedMessageSize = createInt64Histogram(metrics.Metrics(), "grpc.client.attempt.rcvd_total_compressed_message_size", meter, otelmetric.WithUnit("By"), otelmetric.WithDescription("Compressed message bytes received per call attempt."), otelmetric.WithExplicitBucketBoundaries(DefaultSizeBounds...))
 	h.clientMetrics.callDuration = createFloat64Histogram(metrics.Metrics(), "grpc.client.call.duration", meter, otelmetric.WithUnit("s"), otelmetric.WithDescription("Time taken by gRPC to complete an RPC from application's perspective."), otelmetric.WithExplicitBucketBoundaries(DefaultLatencyBounds...))
 
-	h.clientMetrics.intCounts = make(map[*estats.MetricDescriptor]otelmetric.Int64Counter)
-	h.clientMetrics.floatCounts = make(map[*estats.MetricDescriptor]otelmetric.Float64Counter)
-	h.clientMetrics.intHistos = make(map[*estats.MetricDescriptor]otelmetric.Int64Histogram)
-	h.clientMetrics.floatHistos = make(map[*estats.MetricDescriptor]otelmetric.Float64Histogram)
-	h.clientMetrics.intGauges = make(map[*estats.MetricDescriptor]otelmetric.Int64Gauge)
+	h.registryMetrics = registryMetrics{
+		intCounts:   make(map[*estats.MetricDescriptor]otelmetric.Int64Counter),
+		floatCounts: make(map[*estats.MetricDescriptor]otelmetric.Float64Counter),
+		intHistos:   make(map[*estats.MetricDescriptor]otelmetric.Int64Histogram),
+		floatHistos: make(map[*estats.MetricDescriptor]otelmetric.Float64Histogram),
+		intGauges:   make(map[*estats.MetricDescriptor]otelmetric.Int64Gauge),
+
+		optionalLabels: h.options.MetricsOptions.OptionalLabels,
+	}
 
 	for metric := range metrics.Metrics() {
 		desc := estats.DescriptorForMetric(metric)
-		// Per call or metrics not registered, when gets a handle corresponding
-		// it will be a no-op record.
 		if desc == nil {
+			// Either the metric was per call or the metric is not registered.
+			// Thus, if this component ever receives the desc as a handle in
+			// record it will be a no-op.
 			continue
 		}
 		switch desc.Type {
 		case estats.MetricTypeIntCount:
-			ic := createInt64Counter(metrics.Metrics(), estats.Metric(desc.Name), meter, otelmetric.WithUnit(desc.Unit), otelmetric.WithDescription(desc.Description))
-			h.clientMetrics.intCounts[desc] = ic
+			h.registryMetrics.intCounts[desc] = createInt64Counter(metrics.Metrics(), desc.Name, meter, otelmetric.WithUnit(desc.Unit), otelmetric.WithDescription(desc.Description))
 		case estats.MetricTypeFloatCount:
-			fc := createFloat64Counter(metrics.Metrics(), estats.Metric(desc.Name), meter, otelmetric.WithUnit(desc.Unit), otelmetric.WithDescription(desc.Description))
-			h.clientMetrics.floatCounts[desc] = fc
+			h.registryMetrics.floatCounts[desc] = createFloat64Counter(metrics.Metrics(), desc.Name, meter, otelmetric.WithUnit(desc.Unit), otelmetric.WithDescription(desc.Description))
 		case estats.MetricTypeIntHisto:
-			opts := []otelmetric.Int64HistogramOption{otelmetric.WithUnit(desc.Unit), otelmetric.WithDescription(desc.Description)}
-			if len(desc.Bounds) != 0 {
-				opts = append(opts, otelmetric.WithExplicitBucketBoundaries(desc.Bounds...))
-			}
-			ih := createInt64Histogram(metrics.Metrics(), estats.Metric(desc.Name), meter, opts...)
-			h.clientMetrics.intHistos[desc] = ih
+			h.registryMetrics.intHistos[desc] = createInt64Histogram(metrics.Metrics(), desc.Name, meter, otelmetric.WithUnit(desc.Unit), otelmetric.WithDescription(desc.Description), otelmetric.WithExplicitBucketBoundaries(desc.Bounds...))
 		case estats.MetricTypeFloatHisto:
-			opts := []otelmetric.Float64HistogramOption{otelmetric.WithUnit(desc.Unit), otelmetric.WithDescription(desc.Description)}
-			if len(desc.Bounds) != 0 {
-				opts = append(opts, otelmetric.WithExplicitBucketBoundaries(desc.Bounds...))
-			}
-			fh := createFloat64Histogram(metrics.Metrics(), estats.Metric(desc.Name), meter, opts...)
-			h.clientMetrics.floatHistos[desc] = fh
+			h.registryMetrics.floatHistos[desc] = createFloat64Histogram(metrics.Metrics(), desc.Name, meter, otelmetric.WithUnit(desc.Unit), otelmetric.WithDescription(desc.Description), otelmetric.WithExplicitBucketBoundaries(desc.Bounds...))
 		case estats.MetricTypeIntGauge:
-			ig := createInt64Gauge(metrics.Metrics(), estats.Metric(desc.Name), meter, otelmetric.WithUnit(desc.Unit), otelmetric.WithDescription(desc.Description))
-			h.clientMetrics.intGauges[desc] = ig
+			h.registryMetrics.intGauges[desc] = createInt64Gauge(metrics.Metrics(), desc.Name, meter, otelmetric.WithUnit(desc.Unit), otelmetric.WithDescription(desc.Description))
 		}
 	}
-}
-
-func (h *clientStatsHandler) RecordInt64Count(handle *estats.Int64CountHandle, incr int64, labels ...string) {
-	desc := (*estats.MetricDescriptor)(handle)
-	ao := createAttributeOptionFromLabels(desc.Labels, desc.OptionalLabels, h.options.MetricsOptions.OptionalLabels, labels...)
-	h.getInt64Counter(desc).Add(h.options.MetricsOptions.Context, incr, ao)
-}
-
-func (h *clientStatsHandler) getInt64Counter(desc *estats.MetricDescriptor) otelmetric.Int64Counter {
-	if ic, ok := h.clientMetrics.intCounts[desc]; ok {
-		return ic
-	}
-	return noop.Int64Counter{}
-}
-
-func (h *clientStatsHandler) RecordFloat64Count(handle *estats.Float64CountHandle, incr float64, labels ...string) {
-	desc := (*estats.MetricDescriptor)(handle)
-	ao := createAttributeOptionFromLabels(desc.Labels, desc.OptionalLabels, h.options.MetricsOptions.OptionalLabels, labels...)
-	h.getFloat64Counter(desc).Add(h.options.MetricsOptions.Context, incr, ao)
-}
-
-func (h *clientStatsHandler) getFloat64Counter(desc *estats.MetricDescriptor) otelmetric.Float64Counter {
-	if fc, ok := h.clientMetrics.floatCounts[desc]; ok {
-		return fc
-	}
-	return noop.Float64Counter{}
-}
-
-func (h *clientStatsHandler) RecordInt64Histo(handle *estats.Int64HistoHandle, incr int64, labels ...string) {
-	desc := (*estats.MetricDescriptor)(handle)
-	ao := createAttributeOptionFromLabels(desc.Labels, desc.OptionalLabels, h.options.MetricsOptions.OptionalLabels, labels...)
-	h.getInt64Histo(desc).Record(h.options.MetricsOptions.Context, incr, ao)
-}
-
-func (h *clientStatsHandler) getInt64Histo(desc *estats.MetricDescriptor) otelmetric.Int64Histogram {
-	if ih, ok := h.clientMetrics.intHistos[desc]; ok {
-		return ih
-	}
-	return noop.Int64Histogram{}
-}
-
-func (h *clientStatsHandler) RecordFloat64Histo(handle *estats.Float64HistoHandle, incr float64, labels ...string) {
-	desc := (*estats.MetricDescriptor)(handle)
-	ao := createAttributeOptionFromLabels(desc.Labels, desc.OptionalLabels, h.options.MetricsOptions.OptionalLabels, labels...)
-	h.getFloat64Histo(desc).Record(h.options.MetricsOptions.Context, incr, ao)
-}
-
-func (h *clientStatsHandler) getFloat64Histo(desc *estats.MetricDescriptor) otelmetric.Float64Histogram {
-	if fh, ok := h.clientMetrics.floatHistos[desc]; ok {
-		return fh
-	}
-	return noop.Float64Histogram{}
-}
-
-func (h *clientStatsHandler) RecordInt64Gauge(handle *estats.Int64GaugeHandle, incr int64, labels ...string) {
-	desc := (*estats.MetricDescriptor)(handle)
-	ao := createAttributeOptionFromLabels(desc.Labels, desc.OptionalLabels, h.options.MetricsOptions.OptionalLabels, labels...)
-	h.getInt64Gauge(desc).Record(h.options.MetricsOptions.Context, incr, ao)
-}
-
-func (h *clientStatsHandler) getInt64Gauge(desc *estats.MetricDescriptor) otelmetric.Int64Gauge {
-	if ig, ok := h.clientMetrics.intGauges[desc]; ok {
-		return ig
-	}
-	return noop.Int64Gauge{}
 }
 
 func (h *clientStatsHandler) unaryInterceptor(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {

--- a/stats/opentelemetry/csm/observability_test.go
+++ b/stats/opentelemetry/csm/observability_test.go
@@ -206,13 +206,13 @@ func (s) TestCSMPluginOptionUnary(t *testing.T) {
 				serverOptionWithCSMPluginOption(opentelemetry.Options{
 					MetricsOptions: opentelemetry.MetricsOptions{
 						MeterProvider: provider,
-						Metrics:       opentelemetry.DefaultMetrics,
+						Metrics:       opentelemetry.DefaultMetrics(),
 					}}, po),
 			}
 			dopts := []grpc.DialOption{dialOptionWithCSMPluginOption(opentelemetry.Options{
 				MetricsOptions: opentelemetry.MetricsOptions{
 					MeterProvider:  provider,
-					Metrics:        opentelemetry.DefaultMetrics,
+					Metrics:        opentelemetry.DefaultMetrics(),
 					OptionalLabels: []string{"csm.service_name", "csm.service_namespace_name"},
 				},
 			}, po)}
@@ -368,13 +368,13 @@ func (s) TestCSMPluginOptionStreaming(t *testing.T) {
 				serverOptionWithCSMPluginOption(opentelemetry.Options{
 					MetricsOptions: opentelemetry.MetricsOptions{
 						MeterProvider: provider,
-						Metrics:       opentelemetry.DefaultMetrics,
+						Metrics:       opentelemetry.DefaultMetrics(),
 					}}, po),
 			}
 			dopts := []grpc.DialOption{dialOptionWithCSMPluginOption(opentelemetry.Options{
 				MetricsOptions: opentelemetry.MetricsOptions{
 					MeterProvider:  provider,
-					Metrics:        opentelemetry.DefaultMetrics,
+					Metrics:        opentelemetry.DefaultMetrics(),
 					OptionalLabels: []string{"csm.service_name", "csm.service_namespace_name"},
 				},
 			}, po)}
@@ -460,7 +460,7 @@ func (s) TestXDSLabels(t *testing.T) {
 	dopts := []grpc.DialOption{dialOptionWithCSMPluginOption(opentelemetry.Options{
 		MetricsOptions: opentelemetry.MetricsOptions{
 			MeterProvider:  provider,
-			Metrics:        opentelemetry.DefaultMetrics,
+			Metrics:        opentelemetry.DefaultMetrics(),
 			OptionalLabels: []string{"csm.service_name", "csm.service_namespace_name"},
 		},
 	}, po), grpc.WithUnaryInterceptor(unaryInterceptorAttachXDSLabels)}

--- a/stats/opentelemetry/e2e_test.go
+++ b/stats/opentelemetry/e2e_test.go
@@ -52,9 +52,7 @@ func Test(t *testing.T) {
 // component and the server.
 func setup(t *testing.T, methodAttributeFilter func(string) bool) (*metric.ManualReader, *stubserver.StubServer) {
 	reader := metric.NewManualReader()
-	provider := metric.NewMeterProvider(
-		metric.WithReader(reader),
-	)
+	provider := metric.NewMeterProvider(metric.WithReader(reader))
 	ss := &stubserver.StubServer{
 		UnaryCallF: func(ctx context.Context, in *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
 			return &testpb.SimpleResponse{Payload: &testpb.Payload{
@@ -74,12 +72,12 @@ func setup(t *testing.T, methodAttributeFilter func(string) bool) (*metric.Manua
 	if err := ss.Start([]grpc.ServerOption{opentelemetry.ServerOption(opentelemetry.Options{
 		MetricsOptions: opentelemetry.MetricsOptions{
 			MeterProvider:         provider,
-			Metrics:               opentelemetry.DefaultMetrics,
+			Metrics:               opentelemetry.DefaultMetrics(),
 			MethodAttributeFilter: methodAttributeFilter,
 		}})}, opentelemetry.DialOption(opentelemetry.Options{
 		MetricsOptions: opentelemetry.MetricsOptions{
 			MeterProvider: provider,
-			Metrics:       opentelemetry.DefaultMetrics,
+			Metrics:       opentelemetry.DefaultMetrics(),
 		},
 	})); err != nil {
 		t.Fatalf("Error starting endpoint server: %v", err)

--- a/stats/opentelemetry/example_test.go
+++ b/stats/opentelemetry/example_test.go
@@ -19,7 +19,7 @@ package opentelemetry_test
 import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
-	stats2 "google.golang.org/grpc/experimental/stats"
+	estats "google.golang.org/grpc/experimental/stats"
 	"google.golang.org/grpc/stats/opentelemetry"
 
 	"go.opentelemetry.io/otel/sdk/metric"
@@ -53,7 +53,7 @@ func Example_dialOption() {
 	opts := opentelemetry.Options{
 		MetricsOptions: opentelemetry.MetricsOptions{
 			MeterProvider: provider,
-			Metrics:       opentelemetry.DefaultMetrics, // equivalent to unset - distinct from empty
+			Metrics:       opentelemetry.DefaultMetrics(), // equivalent to unset - distinct from empty
 		},
 	}
 	do := opentelemetry.DialOption(opts)
@@ -88,7 +88,7 @@ func ExampleMetrics_excludeSome() {
 	// To exclude specific metrics, initialize Options as follows:
 	opts := opentelemetry.Options{
 		MetricsOptions: opentelemetry.MetricsOptions{
-			Metrics: opentelemetry.DefaultMetrics.Remove(opentelemetry.ClientAttemptDuration, opentelemetry.ClientAttemptRcvdCompressedTotalMessageSize),
+			Metrics: opentelemetry.DefaultMetrics().Remove(opentelemetry.ClientAttemptDuration, opentelemetry.ClientAttemptRcvdCompressedTotalMessageSize),
 		},
 	}
 	do := opentelemetry.DialOption(opts)
@@ -103,7 +103,7 @@ func ExampleMetrics_disableAll() {
 	// To disable all metrics, initialize Options as follows:
 	opts := opentelemetry.Options{
 		MetricsOptions: opentelemetry.MetricsOptions{
-			Metrics: stats2.NewMetrics(), // Distinct to nil, which creates default metrics. This empty set creates no metrics.
+			Metrics: estats.NewMetrics(), // Distinct to nil, which creates default metrics. This empty set creates no metrics.
 		},
 	}
 	do := opentelemetry.DialOption(opts)
@@ -118,7 +118,7 @@ func ExampleMetrics_enableSome() {
 	// To only create specific metrics, initialize Options as follows:
 	opts := opentelemetry.Options{
 		MetricsOptions: opentelemetry.MetricsOptions{
-			Metrics: stats2.NewMetrics(opentelemetry.ClientAttemptDuration, opentelemetry.ClientAttemptRcvdCompressedTotalMessageSize), // only create these metrics
+			Metrics: estats.NewMetrics(opentelemetry.ClientAttemptDuration, opentelemetry.ClientAttemptRcvdCompressedTotalMessageSize), // only create these metrics
 		},
 	}
 	do := opentelemetry.DialOption(opts)

--- a/stats/opentelemetry/metricsregistry_test.go
+++ b/stats/opentelemetry/metricsregistry_test.go
@@ -1,0 +1,284 @@
+/*
+ * Copyright 2024 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package opentelemetry
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	estats "google.golang.org/grpc/experimental/stats"
+	"google.golang.org/grpc/internal"
+	"google.golang.org/grpc/internal/grpctest"
+
+	"go.opentelemetry.io/otel/attribute"
+	otelmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata/metricdatatest"
+)
+
+var defaultTestTimeout = 5 * time.Second
+
+type s struct {
+	grpctest.Tester
+}
+
+func Test(t *testing.T) {
+	grpctest.RunSubTests(t, s{})
+}
+
+// TestMetricsRegistryMetrics tests the OpenTelemetry behavior with respect to
+// registered metrics. It registers metrics in the instrument registry. It then
+// creates an OpenTelemetry server stats handler This test then makes
+// measurements on those instruments using this stats handler, then tests the
+// expected metrics emissions, which includes default metrics and optional label
+// assertions.
+func (s) TestMetricsRegistryMetrics(t *testing.T) {
+	internal.SnapshotMetricRegistryForTesting.(func(t *testing.T))(t)
+	intCountHandle1 := estats.RegisterInt64Count(estats.MetricDescriptor{
+		Name:           "int-counter-1",
+		Description:    "Sum of calls from test",
+		Unit:           "int",
+		Labels:         []string{"int counter 1 label key"},
+		OptionalLabels: []string{"int counter 1 optional label key"},
+		Default:        true,
+	})
+	// A non default metric. If not specified in OpenTelemetry constructor, this
+	// will become a no-op, so measurements recorded on it won't show up in
+	// emitted metrics.
+	intCountHandle2 := estats.RegisterInt64Count(estats.MetricDescriptor{
+		Name:           "int-counter-2",
+		Description:    "Sum of calls from test",
+		Unit:           "int",
+		Labels:         []string{"int counter 2 label key"},
+		OptionalLabels: []string{"int counter 2 optional label key"},
+		Default:        false,
+	})
+	// Register another non default metric. This will get added to the default
+	// metrics set in the OpenTelemetry constructor options, so metrics recorded
+	// on this should show up in metrics emissions.
+	intCountHandle3 := estats.RegisterInt64Count(estats.MetricDescriptor{
+		Name:           "int-counter-3",
+		Description:    "sum of calls from test",
+		Unit:           "int",
+		Labels:         []string{"int counter 3 label key"},
+		OptionalLabels: []string{"int counter 3 optional label key"},
+		Default:        false,
+	})
+	floatCountHandle := estats.RegisterFloat64Count(estats.MetricDescriptor{
+		Name:           "float-counter",
+		Description:    "sum of calls from test",
+		Unit:           "float",
+		Labels:         []string{"float counter label key"},
+		OptionalLabels: []string{"float counter optional label key"},
+		Default:        true,
+	})
+	bounds := []float64{0, 5, 10}
+	intHistoHandle := estats.RegisterInt64Histo(estats.MetricDescriptor{
+		Name:           "int-histo",
+		Description:    "histogram of call values from tests",
+		Unit:           "int",
+		Labels:         []string{"int histo label key"},
+		OptionalLabels: []string{"int histo optional label key"},
+		Default:        true,
+		Bounds:         bounds,
+	})
+	floatHistoHandle := estats.RegisterFloat64Histo(estats.MetricDescriptor{
+		Name:           "float-histo",
+		Description:    "histogram of call values from tests",
+		Unit:           "float",
+		Labels:         []string{"float histo label key"},
+		OptionalLabels: []string{"float histo optional label key"},
+		Default:        true,
+		Bounds:         bounds,
+	})
+	intGaugeHandle := estats.RegisterInt64Gauge(estats.MetricDescriptor{
+		Name:           "simple-gauge",
+		Description:    "the most recent int emitted by test",
+		Unit:           "int",
+		Labels:         []string{"int gauge label key"},
+		OptionalLabels: []string{"int gauge optional label key"},
+		Default:        true,
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+
+	reader := otelmetric.NewManualReader()
+	provider := otelmetric.NewMeterProvider(otelmetric.WithReader(reader))
+
+	// This configures the defaults alongside int counter 3. All the instruments
+	// registered except int counter 2 and 3 are default, so all measurements
+	// recorded should show up in reader collected metrics except those for int
+	// counter 2.
+	// This also only toggles the float count and float histo optional labels,
+	// so only those should show up in metrics emissions. All the required
+	// labels should show up in metrics emissions.
+	mo := MetricsOptions{
+		Context:        ctx, // Tests the context logic on metrics recording calls - OTel is a separate component than grpc.ClientConn/grpc.Server and is independent so gets own context.
+		Metrics:        DefaultMetrics().Add("int-counter-3"),
+		OptionalLabels: []string{"float counter optional label key", "float histo optional label key"},
+		MeterProvider:  provider,
+	}
+
+	// Don't have access to serverStatsHandler in ServerOption, so just create
+	// one directly.
+	ssh := &serverStatsHandler{options: Options{MetricsOptions: mo}} // TODO: Cleanly test clientStatsHandler as well (manually tested and it worked)
+	ssh.initializeMetrics()
+	// These Record calls are guaranteed at a layer underneath OpenTelemetry for
+	// labels emitted to match the length of labels + optional labels.
+	intCountHandle1.Record(ssh, 1, []string{"int counter 1 label value", "int counter 1 optional label value"}...)
+	// int-counter-2 is not part of metrics specified (not default), so this
+	// record call shouldn't show up in the reader.
+	intCountHandle2.Record(ssh, 2, []string{"int counter 2 label value", "int counter 2 optional label value"}...)
+	// int-counter-3 is part of metrics specified, so this call should show up
+	// in the reader.
+	intCountHandle3.Record(ssh, 4, []string{"int counter 3 label value", "int counter 3 optional label value"}...) // record the same values...
+
+	// All future recording points should show up in emissions as all of these are defaults.
+	floatCountHandle.Record(ssh, 1.2, []string{"float counter label value", "float counter optional label value"}...)
+	intHistoHandle.Record(ssh, 3, []string{"int histo label value", "int histo optional label value"}...)
+	floatHistoHandle.Record(ssh, 4.3, []string{"float histo label value", "float histo optional label value"}...)
+	intGaugeHandle.Record(ssh, 7, []string{"int gauge label value", "int gauge optional label value"}...) // size should match, below does this for us no need to verify...
+	// This second gauge call should take the place of the previous gauge call.
+	intGaugeHandle.Record(ssh, 8, []string{"int gauge label value", "int gauge optional label value"}...)
+	rm := &metricdata.ResourceMetrics{}
+	reader.Collect(ctx, rm)
+	gotMetrics := map[string]metricdata.Metrics{}
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			gotMetrics[m.Name] = m
+		}
+	}
+
+	// Only float optional labels are configured, so only float optional labels should show up.
+	// All required labels should show up.
+	wantMetrics := []metricdata.Metrics{
+		{
+			Name:        "int-counter-1",
+			Description: "Sum of calls from test",
+			Unit:        "int",
+			Data: metricdata.Sum[int64]{
+				DataPoints: []metricdata.DataPoint[int64]{
+					{
+						Attributes: attribute.NewSet(attribute.String("int counter 1 label key", "int counter 1 label value")), // No optional label, not float.
+						Value:      1,
+					},
+				},
+				Temporality: metricdata.CumulativeTemporality,
+				IsMonotonic: true,
+			},
+		},
+		{
+			Name:        "int-counter-3",
+			Description: "sum of calls from test",
+			Unit:        "int",
+			Data: metricdata.Sum[int64]{
+				DataPoints: []metricdata.DataPoint[int64]{
+					{
+						Attributes: attribute.NewSet(attribute.String("int counter 3 label key", "int counter 3 label value")), // No optional label, not float.
+						Value:      4,
+					},
+				},
+				Temporality: metricdata.CumulativeTemporality,
+				IsMonotonic: true,
+			},
+		},
+		{
+			Name:        "float-counter",
+			Description: "sum of calls from test",
+			Unit:        "float",
+			Data: metricdata.Sum[float64]{
+				DataPoints: []metricdata.DataPoint[float64]{
+					{
+						Attributes: attribute.NewSet(attribute.String("float counter label key", "float counter label value"), attribute.String("float counter optional label key", "float counter optional label value")),
+						Value:      1.2,
+					},
+				},
+				Temporality: metricdata.CumulativeTemporality,
+				IsMonotonic: true,
+			},
+		},
+		{
+			Name:        "int-histo",
+			Description: "histogram of call values from tests",
+			Unit:        "int",
+			Data: metricdata.Histogram[int64]{
+				DataPoints: []metricdata.HistogramDataPoint[int64]{
+					{
+						Attributes:   attribute.NewSet(attribute.String("int histo label key", "int histo label value")), // No optional label, not float.
+						Count:        1,
+						Bounds:       bounds,
+						BucketCounts: []uint64{0, 1, 0, 0},
+						Min:          metricdata.NewExtrema(int64(3)),
+						Max:          metricdata.NewExtrema(int64(3)),
+						Sum:          3,
+					},
+				},
+				Temporality: metricdata.CumulativeTemporality,
+			},
+		},
+		{
+			Name:        "float-histo",
+			Description: "histogram of call values from tests",
+			Unit:        "float",
+			Data: metricdata.Histogram[float64]{
+				DataPoints: []metricdata.HistogramDataPoint[float64]{
+					{
+						Attributes:   attribute.NewSet(attribute.String("float histo label key", "float histo label value"), attribute.String("float histo optional label key", "float histo optional label value")),
+						Count:        1,
+						Bounds:       bounds,
+						BucketCounts: []uint64{0, 1, 0, 0},
+						Min:          metricdata.NewExtrema(float64(4.3)),
+						Max:          metricdata.NewExtrema(float64(4.3)),
+						Sum:          4.3,
+					},
+				},
+				Temporality: metricdata.CumulativeTemporality,
+			},
+		},
+		{
+			Name:        "simple-gauge",
+			Description: "the most recent int emitted by test",
+			Unit:        "int",
+			Data: metricdata.Gauge[int64]{
+				DataPoints: []metricdata.DataPoint[int64]{
+					{
+						Attributes: attribute.NewSet(attribute.String("int gauge label key", "int gauge label value")), // No optional label, not float.
+						Value:      8,
+					},
+				},
+			},
+		},
+	}
+
+	for _, metric := range wantMetrics {
+		val, ok := gotMetrics[metric.Name]
+		if !ok {
+			t.Fatalf("Metric %v not present in recorded metrics", metric.Name)
+		}
+		if !metricdatatest.AssertEqual(t, metric, val, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreExemplars()) {
+			t.Fatalf("Metrics data type not equal for metric: %v", metric.Name)
+		}
+	}
+
+	// int-counter-2 is not a default metric and wasn't specified in
+	// constructor, so emissions should not show up.
+	if _, ok := gotMetrics["int-counter-2"]; ok {
+		t.Fatalf("Metric int-counter-2 present in recorded metrics, was not configured")
+	}
+}

--- a/stats/opentelemetry/metricsregistry_test.go
+++ b/stats/opentelemetry/metricsregistry_test.go
@@ -129,7 +129,6 @@ func (s) TestMetricsRegistryMetrics(t *testing.T) {
 	// so only those should show up in metrics emissions. All the required
 	// labels should show up in metrics emissions.
 	mo := MetricsOptions{
-		Context:        ctx, // Tests the context logic on metrics recording calls - OTel is a separate component than grpc.ClientConn/grpc.Server and is independent so gets own context.
 		Metrics:        DefaultMetrics().Add("int-counter-3"),
 		OptionalLabels: []string{"float counter optional label key", "float histo optional label key"},
 		MeterProvider:  provider,

--- a/stats/opentelemetry/opentelemetry.go
+++ b/stats/opentelemetry/opentelemetry.go
@@ -30,7 +30,8 @@ import (
 	"google.golang.org/grpc/internal"
 	otelinternal "google.golang.org/grpc/stats/opentelemetry/internal"
 
-	"go.opentelemetry.io/otel/metric"
+	otelattribute "go.opentelemetry.io/otel/attribute"
+	otelmetric "go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/metric/noop"
 )
 
@@ -59,7 +60,7 @@ type MetricsOptions struct {
 	// unset, no metrics will be recorded. Any implementation knobs (i.e. views,
 	// bounds) set in the MeterProvider take precedence over the API calls from
 	// this interface. (i.e. it will create default views for unset views).
-	MeterProvider metric.MeterProvider
+	MeterProvider otelmetric.MeterProvider
 
 	// Metrics are the metrics to instrument. Will create instrument and record telemetry
 	// for corresponding metric supported by the client and server
@@ -81,6 +82,9 @@ type MetricsOptions struct {
 
 	// pluginOption is used to get labels to attach to certain metrics, if set.
 	pluginOption otelinternal.PluginOption
+	// Context is the context of the OpenTelemetry plugin. If unset, will
+	// default to a context.Background.
+	Context context.Context
 }
 
 // DialOption returns a dial option which enables OpenTelemetry instrumentation
@@ -96,6 +100,9 @@ type MetricsOptions struct {
 // configured for an individual metric turned on, the API call in this component
 // will create a default view for that metric.
 func DialOption(o Options) grpc.DialOption {
+	if o.MetricsOptions.Context == nil {
+		o.MetricsOptions.Context = context.Background()
+	}
 	csh := &clientStatsHandler{options: o}
 	csh.initializeMetrics()
 	return joinDialOptions(grpc.WithChainUnaryInterceptor(csh.unaryInterceptor), grpc.WithChainStreamInterceptor(csh.streamInterceptor), grpc.WithStatsHandler(csh))
@@ -116,6 +123,9 @@ var joinServerOptions = internal.JoinServerOptions.(func(...grpc.ServerOption) g
 // configured for an individual metric turned on, the API call in this component
 // will create a default view for that metric.
 func ServerOption(o Options) grpc.ServerOption {
+	if o.MetricsOptions.Context == nil {
+		o.MetricsOptions.Context = context.Background()
+	}
 	ssh := &serverStatsHandler{options: o}
 	ssh.initializeMetrics()
 	return joinServerOptions(grpc.ChainUnaryInterceptor(ssh.unaryInterceptor), grpc.ChainStreamInterceptor(ssh.streamInterceptor), grpc.StatsHandler(ssh))
@@ -184,63 +194,121 @@ type attemptInfo struct {
 
 type clientMetrics struct {
 	// "grpc.client.attempt.started"
-	attemptStarted metric.Int64Counter
+	attemptStarted otelmetric.Int64Counter
 	// "grpc.client.attempt.duration"
-	attemptDuration metric.Float64Histogram
+	attemptDuration otelmetric.Float64Histogram
 	// "grpc.client.attempt.sent_total_compressed_message_size"
-	attemptSentTotalCompressedMessageSize metric.Int64Histogram
+	attemptSentTotalCompressedMessageSize otelmetric.Int64Histogram
 	// "grpc.client.attempt.rcvd_total_compressed_message_size"
-	attemptRcvdTotalCompressedMessageSize metric.Int64Histogram
+	attemptRcvdTotalCompressedMessageSize otelmetric.Int64Histogram
 
 	// "grpc.client.call.duration"
-	callDuration metric.Float64Histogram
+	callDuration otelmetric.Float64Histogram
+
+	// Metrics from metrics registry:
+	intCounts   map[*estats.MetricDescriptor]otelmetric.Int64Counter
+	floatCounts map[*estats.MetricDescriptor]otelmetric.Float64Counter
+	intHistos   map[*estats.MetricDescriptor]otelmetric.Int64Histogram
+	floatHistos map[*estats.MetricDescriptor]otelmetric.Float64Histogram
+	intGauges   map[*estats.MetricDescriptor]otelmetric.Int64Gauge
 }
 
 type serverMetrics struct {
 	// "grpc.server.call.started"
-	callStarted metric.Int64Counter
+	callStarted otelmetric.Int64Counter
 	// "grpc.server.call.sent_total_compressed_message_size"
-	callSentTotalCompressedMessageSize metric.Int64Histogram
+	callSentTotalCompressedMessageSize otelmetric.Int64Histogram
 	// "grpc.server.call.rcvd_total_compressed_message_size"
-	callRcvdTotalCompressedMessageSize metric.Int64Histogram
+	callRcvdTotalCompressedMessageSize otelmetric.Int64Histogram
 	// "grpc.server.call.duration"
-	callDuration metric.Float64Histogram
+	callDuration otelmetric.Float64Histogram
+
+	// Metrics from metrics registry:
+	intCounts   map[*estats.MetricDescriptor]otelmetric.Int64Counter
+	floatCounts map[*estats.MetricDescriptor]otelmetric.Float64Counter
+	intHistos   map[*estats.MetricDescriptor]otelmetric.Int64Histogram
+	floatHistos map[*estats.MetricDescriptor]otelmetric.Float64Histogram
+	intGauges   map[*estats.MetricDescriptor]otelmetric.Int64Gauge
 }
 
-func createInt64Counter(setOfMetrics map[estats.Metric]bool, metricName estats.Metric, meter metric.Meter, options ...metric.Int64CounterOption) metric.Int64Counter {
+func createInt64Counter(setOfMetrics map[estats.Metric]bool, metricName estats.Metric, meter otelmetric.Meter, options ...otelmetric.Int64CounterOption) otelmetric.Int64Counter {
 	if _, ok := setOfMetrics[metricName]; !ok {
 		return noop.Int64Counter{}
 	}
 	ret, err := meter.Int64Counter(string(metricName), options...)
 	if err != nil {
-		logger.Errorf("failed to register metric \"%v\", will not record", metricName)
+		logger.Errorf("failed to register metric \"%v\", will not record: %v", metricName, err)
 		return noop.Int64Counter{}
 	}
 	return ret
 }
 
-func createInt64Histogram(setOfMetrics map[estats.Metric]bool, metricName estats.Metric, meter metric.Meter, options ...metric.Int64HistogramOption) metric.Int64Histogram {
+func createFloat64Counter(setOfMetrics map[estats.Metric]bool, metricName estats.Metric, meter otelmetric.Meter, options ...otelmetric.Float64CounterOption) otelmetric.Float64Counter {
+	if _, ok := setOfMetrics[metricName]; !ok {
+		return noop.Float64Counter{}
+	}
+	ret, err := meter.Float64Counter(string(metricName), options...)
+	if err != nil {
+		logger.Errorf("failed to register metric \"%v\", will not record: %v", metricName, err)
+		return noop.Float64Counter{}
+	}
+	return ret
+}
+
+func createInt64Histogram(setOfMetrics map[estats.Metric]bool, metricName estats.Metric, meter otelmetric.Meter, options ...otelmetric.Int64HistogramOption) otelmetric.Int64Histogram {
+
 	if _, ok := setOfMetrics[metricName]; !ok {
 		return noop.Int64Histogram{}
 	}
 	ret, err := meter.Int64Histogram(string(metricName), options...)
 	if err != nil {
-		logger.Errorf("failed to register metric \"%v\", will not record", metricName)
+		logger.Errorf("failed to register metric \"%v\", will not record: %v", metricName, err)
 		return noop.Int64Histogram{}
 	}
 	return ret
 }
 
-func createFloat64Histogram(setOfMetrics map[estats.Metric]bool, metricName estats.Metric, meter metric.Meter, options ...metric.Float64HistogramOption) metric.Float64Histogram {
+func createFloat64Histogram(setOfMetrics map[estats.Metric]bool, metricName estats.Metric, meter otelmetric.Meter, options ...otelmetric.Float64HistogramOption) otelmetric.Float64Histogram {
 	if _, ok := setOfMetrics[metricName]; !ok {
 		return noop.Float64Histogram{}
 	}
 	ret, err := meter.Float64Histogram(string(metricName), options...)
 	if err != nil {
-		logger.Errorf("failed to register metric \"%v\", will not record", metricName)
+		logger.Errorf("failed to register metric \"%v\", will not record: %v", metricName, err)
 		return noop.Float64Histogram{}
 	}
 	return ret
+}
+
+func createInt64Gauge(setOfMetrics map[estats.Metric]bool, metricName estats.Metric, meter otelmetric.Meter, options ...otelmetric.Int64GaugeOption) otelmetric.Int64Gauge {
+	if _, ok := setOfMetrics[metricName]; !ok {
+		return noop.Int64Gauge{}
+	}
+	ret, err := meter.Int64Gauge(string(metricName), options...)
+	if err != nil {
+		logger.Errorf("failed to register metric \"%v\", will not record: %v", metricName, err)
+		return noop.Int64Gauge{}
+	}
+	return ret
+}
+
+func createAttributeOptionFromLabels(labelKeys []string, optionalLabelKeys []string, optionalLabels []string, labelVals ...string) otelmetric.MeasurementOption {
+	var attributes []otelattribute.KeyValue
+
+	// Once it hits here lower level has guaranteed length of labelVals matches
+	// labelKeys + optionalLabelKeys.
+	for i, label := range labelKeys {
+		attributes = append(attributes, otelattribute.String(label, labelVals[i]))
+	}
+
+	for i, label := range optionalLabelKeys {
+		for _, optLabel := range optionalLabels { // o(n) could build out a set but n is currently capped at < 5
+			if label == optLabel {
+				attributes = append(attributes, otelattribute.String(label, labelVals[i+len(labelKeys)]))
+			}
+		}
+	}
+	return otelmetric.WithAttributes(attributes...)
 }
 
 // Users of this component should use these bucket boundaries as part of their
@@ -253,6 +321,14 @@ var (
 	DefaultLatencyBounds = []float64{0, 0.00001, 0.00005, 0.0001, 0.0003, 0.0006, 0.0008, 0.001, 0.002, 0.003, 0.004, 0.005, 0.006, 0.008, 0.01, 0.013, 0.016, 0.02, 0.025, 0.03, 0.04, 0.05, 0.065, 0.08, 0.1, 0.13, 0.16, 0.2, 0.25, 0.3, 0.4, 0.5, 0.65, 0.8, 1, 2, 5, 10, 20, 50, 100} // provide "advice" through API, SDK should set this too
 	// DefaultSizeBounds are the default bounds for metrics which record size.
 	DefaultSizeBounds = []float64{0, 1024, 2048, 4096, 16384, 65536, 262144, 1048576, 4194304, 16777216, 67108864, 268435456, 1073741824, 4294967296}
-	// DefaultMetrics are the default metrics provided by this module.
-	DefaultMetrics = estats.NewMetrics(ClientAttemptStarted, ClientAttemptDuration, ClientAttemptSentCompressedTotalMessageSize, ClientAttemptRcvdCompressedTotalMessageSize, ClientCallDuration, ServerCallStarted, ServerCallSentCompressedTotalMessageSize, ServerCallRcvdCompressedTotalMessageSize, ServerCallDuration)
+	// defaultPerCallMetrics are the default metrics provided by this module.
+	defaultPerCallMetrics = estats.NewMetrics(ClientAttemptStarted, ClientAttemptDuration, ClientAttemptSentCompressedTotalMessageSize, ClientAttemptRcvdCompressedTotalMessageSize, ClientCallDuration, ServerCallStarted, ServerCallSentCompressedTotalMessageSize, ServerCallRcvdCompressedTotalMessageSize, ServerCallDuration)
 )
+
+// DefaultMetrics returns a set of default metrics for per call joined with any
+// default metrics registered through metrics registry.
+//
+// This should only be invoked after init time.
+func DefaultMetrics() *estats.Metrics {
+	return defaultPerCallMetrics.Join(estats.DefaultMetrics)
+}

--- a/stats/opentelemetry/server_metrics.go
+++ b/stats/opentelemetry/server_metrics.go
@@ -30,10 +30,11 @@ import (
 
 	otelattribute "go.opentelemetry.io/otel/attribute"
 	otelmetric "go.opentelemetry.io/otel/metric"
-	"go.opentelemetry.io/otel/metric/noop"
 )
 
 type serverStatsHandler struct {
+	registryMetrics
+
 	options Options
 
 	serverMetrics serverMetrics
@@ -60,111 +61,38 @@ func (h *serverStatsHandler) initializeMetrics() {
 	h.serverMetrics.callRcvdTotalCompressedMessageSize = createInt64Histogram(metrics.Metrics(), "grpc.server.call.rcvd_total_compressed_message_size", meter, otelmetric.WithUnit("By"), otelmetric.WithDescription("Compressed message bytes received per server call."), otelmetric.WithExplicitBucketBoundaries(DefaultSizeBounds...))
 	h.serverMetrics.callDuration = createFloat64Histogram(metrics.Metrics(), "grpc.server.call.duration", meter, otelmetric.WithUnit("s"), otelmetric.WithDescription("End-to-end time taken to complete a call from server transport's perspective."), otelmetric.WithExplicitBucketBoundaries(DefaultLatencyBounds...))
 
-	h.serverMetrics.intCounts = make(map[*estats.MetricDescriptor]otelmetric.Int64Counter)
-	h.serverMetrics.floatCounts = make(map[*estats.MetricDescriptor]otelmetric.Float64Counter)
-	h.serverMetrics.intHistos = make(map[*estats.MetricDescriptor]otelmetric.Int64Histogram)
-	h.serverMetrics.floatHistos = make(map[*estats.MetricDescriptor]otelmetric.Float64Histogram)
-	h.serverMetrics.intGauges = make(map[*estats.MetricDescriptor]otelmetric.Int64Gauge)
+	h.registryMetrics = registryMetrics{
+		intCounts:   make(map[*estats.MetricDescriptor]otelmetric.Int64Counter),
+		floatCounts: make(map[*estats.MetricDescriptor]otelmetric.Float64Counter),
+		intHistos:   make(map[*estats.MetricDescriptor]otelmetric.Int64Histogram),
+		floatHistos: make(map[*estats.MetricDescriptor]otelmetric.Float64Histogram),
+		intGauges:   make(map[*estats.MetricDescriptor]otelmetric.Int64Gauge),
+
+		optionalLabels: h.options.MetricsOptions.OptionalLabels,
+	}
 
 	// Metric registry metrics:
 	for metric := range metrics.Metrics() {
 		desc := estats.DescriptorForMetric(metric)
-		// Per call or metrics not registered, when gets a handle corresponding
-		// it will be a no-op record.
 		if desc == nil {
+			// Either the metric was per call or the metric is not registered.
+			// Thus, if this component ever receives the desc as a handle in
+			// record it will be a no-op.
 			continue
 		}
 		switch desc.Type {
 		case estats.MetricTypeIntCount:
-			ic := createInt64Counter(metrics.Metrics(), desc.Name, meter, otelmetric.WithUnit(desc.Unit), otelmetric.WithDescription(desc.Description))
-			h.serverMetrics.intCounts[desc] = ic
+			h.registryMetrics.intCounts[desc] = createInt64Counter(metrics.Metrics(), desc.Name, meter, otelmetric.WithUnit(desc.Unit), otelmetric.WithDescription(desc.Description))
 		case estats.MetricTypeFloatCount:
-			fc := createFloat64Counter(metrics.Metrics(), desc.Name, meter, otelmetric.WithUnit(desc.Unit), otelmetric.WithDescription(desc.Description))
-			h.serverMetrics.floatCounts[desc] = fc
+			h.registryMetrics.floatCounts[desc] = createFloat64Counter(metrics.Metrics(), desc.Name, meter, otelmetric.WithUnit(desc.Unit), otelmetric.WithDescription(desc.Description))
 		case estats.MetricTypeIntHisto:
-			opts := []otelmetric.Int64HistogramOption{otelmetric.WithUnit(desc.Unit), otelmetric.WithDescription(desc.Description)}
-			if len(desc.Bounds) != 0 {
-				opts = append(opts, otelmetric.WithExplicitBucketBoundaries(desc.Bounds...))
-			}
-			ih := createInt64Histogram(metrics.Metrics(), desc.Name, meter, opts...)
-			h.serverMetrics.intHistos[desc] = ih
+			h.registryMetrics.intHistos[desc] = createInt64Histogram(metrics.Metrics(), desc.Name, meter, otelmetric.WithUnit(desc.Unit), otelmetric.WithDescription(desc.Description), otelmetric.WithExplicitBucketBoundaries(desc.Bounds...))
 		case estats.MetricTypeFloatHisto:
-			opts := []otelmetric.Float64HistogramOption{otelmetric.WithUnit(desc.Unit), otelmetric.WithDescription(desc.Description)}
-			if len(desc.Bounds) != 0 {
-				opts = append(opts, otelmetric.WithExplicitBucketBoundaries(desc.Bounds...))
-			}
-			fh := createFloat64Histogram(metrics.Metrics(), desc.Name, meter, opts...)
-			h.serverMetrics.floatHistos[desc] = fh
+			h.registryMetrics.floatHistos[desc] = createFloat64Histogram(metrics.Metrics(), desc.Name, meter, otelmetric.WithUnit(desc.Unit), otelmetric.WithDescription(desc.Description), otelmetric.WithExplicitBucketBoundaries(desc.Bounds...))
 		case estats.MetricTypeIntGauge:
-			ig := createInt64Gauge(metrics.Metrics(), estats.Metric(desc.Name), meter, otelmetric.WithUnit(desc.Unit), otelmetric.WithDescription(desc.Description))
-			h.serverMetrics.intGauges[desc] = ig
+			h.registryMetrics.intGauges[desc] = createInt64Gauge(metrics.Metrics(), desc.Name, meter, otelmetric.WithUnit(desc.Unit), otelmetric.WithDescription(desc.Description))
 		}
 	}
-}
-
-func (h *serverStatsHandler) RecordInt64Count(handle *estats.Int64CountHandle, incr int64, labels ...string) {
-	desc := (*estats.MetricDescriptor)(handle)
-	ao := createAttributeOptionFromLabels(desc.Labels, desc.OptionalLabels, h.options.MetricsOptions.OptionalLabels, labels...)
-	h.getInt64Counter(desc).Add(h.options.MetricsOptions.Context, incr, ao)
-}
-
-func (h *serverStatsHandler) getInt64Counter(desc *estats.MetricDescriptor) otelmetric.Int64Counter {
-	if ic, ok := h.serverMetrics.intCounts[desc]; ok {
-		return ic
-	}
-	return noop.Int64Counter{}
-}
-
-func (h *serverStatsHandler) RecordFloat64Count(handle *estats.Float64CountHandle, incr float64, labels ...string) {
-	desc := (*estats.MetricDescriptor)(handle)
-	ao := createAttributeOptionFromLabels(desc.Labels, desc.OptionalLabels, h.options.MetricsOptions.OptionalLabels, labels...)
-	h.getFloat64Counter(desc).Add(h.options.MetricsOptions.Context, incr, ao)
-}
-
-func (h *serverStatsHandler) getFloat64Counter(desc *estats.MetricDescriptor) otelmetric.Float64Counter {
-	if fc, ok := h.serverMetrics.floatCounts[desc]; ok {
-		return fc
-	}
-	return noop.Float64Counter{}
-}
-
-func (h *serverStatsHandler) RecordInt64Histo(handle *estats.Int64HistoHandle, incr int64, labels ...string) {
-	desc := (*estats.MetricDescriptor)(handle)
-	ao := createAttributeOptionFromLabels(desc.Labels, desc.OptionalLabels, h.options.MetricsOptions.OptionalLabels, labels...)
-	h.getInt64Histo(desc).Record(h.options.MetricsOptions.Context, incr, ao)
-}
-
-func (h *serverStatsHandler) getInt64Histo(desc *estats.MetricDescriptor) otelmetric.Int64Histogram {
-	if ih, ok := h.serverMetrics.intHistos[desc]; ok {
-		return ih
-	}
-	return noop.Int64Histogram{}
-}
-
-func (h *serverStatsHandler) RecordFloat64Histo(handle *estats.Float64HistoHandle, incr float64, labels ...string) {
-	desc := (*estats.MetricDescriptor)(handle)
-	ao := createAttributeOptionFromLabels(desc.Labels, desc.OptionalLabels, h.options.MetricsOptions.OptionalLabels, labels...)
-	h.getFloat64Histo(desc).Record(h.options.MetricsOptions.Context, incr, ao)
-}
-
-func (h *serverStatsHandler) getFloat64Histo(desc *estats.MetricDescriptor) otelmetric.Float64Histogram {
-	if fh, ok := h.serverMetrics.floatHistos[desc]; ok {
-		return fh
-	}
-	return noop.Float64Histogram{}
-}
-
-func (h *serverStatsHandler) RecordInt64Gauge(handle *estats.Int64GaugeHandle, incr int64, labels ...string) {
-	desc := (*estats.MetricDescriptor)(handle)
-	ao := createAttributeOptionFromLabels(desc.Labels, desc.OptionalLabels, h.options.MetricsOptions.OptionalLabels, labels...)
-	h.getInt64Gauge(desc).Record(h.options.MetricsOptions.Context, incr, ao)
-}
-
-func (h *serverStatsHandler) getInt64Gauge(desc *estats.MetricDescriptor) otelmetric.Int64Gauge {
-	if ig, ok := h.serverMetrics.intGauges[desc]; ok {
-		return ig
-	}
-	return noop.Int64Gauge{}
 }
 
 // attachLabelsTransportStream intercepts SetHeader and SendHeader calls of the

--- a/stats/opentelemetry/server_metrics.go
+++ b/stats/opentelemetry/server_metrics.go
@@ -30,6 +30,7 @@ import (
 
 	otelattribute "go.opentelemetry.io/otel/attribute"
 	otelmetric "go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/noop"
 )
 
 type serverStatsHandler struct {
@@ -51,13 +52,119 @@ func (h *serverStatsHandler) initializeMetrics() {
 	}
 	metrics := h.options.MetricsOptions.Metrics
 	if metrics == nil {
-		metrics = DefaultMetrics
+		metrics = DefaultMetrics()
 	}
 
 	h.serverMetrics.callStarted = createInt64Counter(metrics.Metrics(), "grpc.server.call.started", meter, otelmetric.WithUnit("call"), otelmetric.WithDescription("Number of server calls started."))
 	h.serverMetrics.callSentTotalCompressedMessageSize = createInt64Histogram(metrics.Metrics(), "grpc.server.call.sent_total_compressed_message_size", meter, otelmetric.WithUnit("By"), otelmetric.WithDescription("Compressed message bytes sent per server call."), otelmetric.WithExplicitBucketBoundaries(DefaultSizeBounds...))
 	h.serverMetrics.callRcvdTotalCompressedMessageSize = createInt64Histogram(metrics.Metrics(), "grpc.server.call.rcvd_total_compressed_message_size", meter, otelmetric.WithUnit("By"), otelmetric.WithDescription("Compressed message bytes received per server call."), otelmetric.WithExplicitBucketBoundaries(DefaultSizeBounds...))
 	h.serverMetrics.callDuration = createFloat64Histogram(metrics.Metrics(), "grpc.server.call.duration", meter, otelmetric.WithUnit("s"), otelmetric.WithDescription("End-to-end time taken to complete a call from server transport's perspective."), otelmetric.WithExplicitBucketBoundaries(DefaultLatencyBounds...))
+
+	h.serverMetrics.intCounts = make(map[*estats.MetricDescriptor]otelmetric.Int64Counter)
+	h.serverMetrics.floatCounts = make(map[*estats.MetricDescriptor]otelmetric.Float64Counter)
+	h.serverMetrics.intHistos = make(map[*estats.MetricDescriptor]otelmetric.Int64Histogram)
+	h.serverMetrics.floatHistos = make(map[*estats.MetricDescriptor]otelmetric.Float64Histogram)
+	h.serverMetrics.intGauges = make(map[*estats.MetricDescriptor]otelmetric.Int64Gauge)
+
+	// Metric registry metrics:
+	for metric := range metrics.Metrics() {
+		desc := estats.DescriptorForMetric(metric)
+		// Per call or metrics not registered, when gets a handle corresponding
+		// it will be a no-op record.
+		if desc == nil {
+			continue
+		}
+		switch desc.Type {
+		case estats.MetricTypeIntCount:
+			ic := createInt64Counter(metrics.Metrics(), desc.Name, meter, otelmetric.WithUnit(desc.Unit), otelmetric.WithDescription(desc.Description))
+			h.serverMetrics.intCounts[desc] = ic
+		case estats.MetricTypeFloatCount:
+			fc := createFloat64Counter(metrics.Metrics(), desc.Name, meter, otelmetric.WithUnit(desc.Unit), otelmetric.WithDescription(desc.Description))
+			h.serverMetrics.floatCounts[desc] = fc
+		case estats.MetricTypeIntHisto:
+			opts := []otelmetric.Int64HistogramOption{otelmetric.WithUnit(desc.Unit), otelmetric.WithDescription(desc.Description)}
+			if len(desc.Bounds) != 0 {
+				opts = append(opts, otelmetric.WithExplicitBucketBoundaries(desc.Bounds...))
+			}
+			ih := createInt64Histogram(metrics.Metrics(), desc.Name, meter, opts...)
+			h.serverMetrics.intHistos[desc] = ih
+		case estats.MetricTypeFloatHisto:
+			opts := []otelmetric.Float64HistogramOption{otelmetric.WithUnit(desc.Unit), otelmetric.WithDescription(desc.Description)}
+			if len(desc.Bounds) != 0 {
+				opts = append(opts, otelmetric.WithExplicitBucketBoundaries(desc.Bounds...))
+			}
+			fh := createFloat64Histogram(metrics.Metrics(), desc.Name, meter, opts...)
+			h.serverMetrics.floatHistos[desc] = fh
+		case estats.MetricTypeIntGauge:
+			ig := createInt64Gauge(metrics.Metrics(), estats.Metric(desc.Name), meter, otelmetric.WithUnit(desc.Unit), otelmetric.WithDescription(desc.Description))
+			h.serverMetrics.intGauges[desc] = ig
+		}
+	}
+}
+
+func (h *serverStatsHandler) RecordInt64Count(handle *estats.Int64CountHandle, incr int64, labels ...string) {
+	desc := (*estats.MetricDescriptor)(handle)
+	ao := createAttributeOptionFromLabels(desc.Labels, desc.OptionalLabels, h.options.MetricsOptions.OptionalLabels, labels...)
+	h.getInt64Counter(desc).Add(h.options.MetricsOptions.Context, incr, ao)
+}
+
+func (h *serverStatsHandler) getInt64Counter(desc *estats.MetricDescriptor) otelmetric.Int64Counter {
+	if ic, ok := h.serverMetrics.intCounts[desc]; ok {
+		return ic
+	}
+	return noop.Int64Counter{}
+}
+
+func (h *serverStatsHandler) RecordFloat64Count(handle *estats.Float64CountHandle, incr float64, labels ...string) {
+	desc := (*estats.MetricDescriptor)(handle)
+	ao := createAttributeOptionFromLabels(desc.Labels, desc.OptionalLabels, h.options.MetricsOptions.OptionalLabels, labels...)
+	h.getFloat64Counter(desc).Add(h.options.MetricsOptions.Context, incr, ao)
+}
+
+func (h *serverStatsHandler) getFloat64Counter(desc *estats.MetricDescriptor) otelmetric.Float64Counter {
+	if fc, ok := h.serverMetrics.floatCounts[desc]; ok {
+		return fc
+	}
+	return noop.Float64Counter{}
+}
+
+func (h *serverStatsHandler) RecordInt64Histo(handle *estats.Int64HistoHandle, incr int64, labels ...string) {
+	desc := (*estats.MetricDescriptor)(handle)
+	ao := createAttributeOptionFromLabels(desc.Labels, desc.OptionalLabels, h.options.MetricsOptions.OptionalLabels, labels...)
+	h.getInt64Histo(desc).Record(h.options.MetricsOptions.Context, incr, ao)
+}
+
+func (h *serverStatsHandler) getInt64Histo(desc *estats.MetricDescriptor) otelmetric.Int64Histogram {
+	if ih, ok := h.serverMetrics.intHistos[desc]; ok {
+		return ih
+	}
+	return noop.Int64Histogram{}
+}
+
+func (h *serverStatsHandler) RecordFloat64Histo(handle *estats.Float64HistoHandle, incr float64, labels ...string) {
+	desc := (*estats.MetricDescriptor)(handle)
+	ao := createAttributeOptionFromLabels(desc.Labels, desc.OptionalLabels, h.options.MetricsOptions.OptionalLabels, labels...)
+	h.getFloat64Histo(desc).Record(h.options.MetricsOptions.Context, incr, ao)
+}
+
+func (h *serverStatsHandler) getFloat64Histo(desc *estats.MetricDescriptor) otelmetric.Float64Histogram {
+	if fh, ok := h.serverMetrics.floatHistos[desc]; ok {
+		return fh
+	}
+	return noop.Float64Histogram{}
+}
+
+func (h *serverStatsHandler) RecordInt64Gauge(handle *estats.Int64GaugeHandle, incr int64, labels ...string) {
+	desc := (*estats.MetricDescriptor)(handle)
+	ao := createAttributeOptionFromLabels(desc.Labels, desc.OptionalLabels, h.options.MetricsOptions.OptionalLabels, labels...)
+	h.getInt64Gauge(desc).Record(h.options.MetricsOptions.Context, incr, ao)
+}
+
+func (h *serverStatsHandler) getInt64Gauge(desc *estats.MetricDescriptor) otelmetric.Int64Gauge {
+	if ig, ok := h.serverMetrics.intGauges[desc]; ok {
+		return ig
+	}
+	return noop.Int64Gauge{}
 }
 
 // attachLabelsTransportStream intercepts SetHeader and SendHeader calls of the


### PR DESCRIPTION
Contains #7410. This is orthogonal, but decided to keep both in one commit thread since my upcoming PR WRR Metrics requires both.

The latest commit is the addition of metrics recorder list.

RELEASE NOTES: N/A