### PR TITLE
grpclog: refactor existing logger interfaces for better interoparability

### DIFF
--- a/internal/grpclog/grpclog.go
+++ b/internal/grpclog/grpclog.go
@@ -66,6 +66,15 @@ func FatalDepth(depth int, args ...any) {
 	os.Exit(1)
 }
 
+// V reports whether verbosity level l is at least the requested verbose level.
+func V(l int) bool {
+	if DepthLogger != nil {
+		return DepthLogger.V(l)
+	} else {
+		return Logger.V(l)
+	}
+}
+
 // LoggerV2 does underlying logging work for grpclog.
 // This is a copy of the LoggerV2 defined in the external grpclog package. It
 // is defined here to avoid a circular dependency.
@@ -123,4 +132,6 @@ type DepthLoggerV2 interface {
 	ErrorDepth(depth int, args ...any)
 	// FatalDepth logs to FATAL log at the specified depth. Arguments are handled in the manner of fmt.Println.
 	FatalDepth(depth int, args ...any)
+	// V reports whether verbosity level l is at least the requested verbose level.
+	V(l int) bool
 }

--- a/internal/grpclog/prefixLogger.go
+++ b/internal/grpclog/prefixLogger.go
@@ -63,10 +63,10 @@ func (pl *PrefixLogger) Errorf(format string, args ...any) {
 
 // V reports whether verbosity level l is at least the requested verbose level.
 func (pl *PrefixLogger) V(l int) bool {
-	// TODO(6044): Refactor interfaces LoggerV2 and DepthLogger, and maybe
-	// rewrite PrefixLogger a little to ensure that we don't use the global
-	// `Logger` here, and instead use the `logger` field.
-	return Logger.V(l)
+	if pl != nil {
+		return pl.logger.V(l)
+	}
+	return V(l)
 }
 
 // NewPrefixLogger creates a prefix logger with the given prefix.


### PR DESCRIPTION
Fixes: https://github.com/grpc/grpc-go/issues/6044

What's changed: 
* Implement `fun V(l int) bool` for `PrefixLogger`, and delegate calls to its `logger` field.

@easwars  Just let me know if I misunderstood anything or if there’s more to do.

RELEASE NOTES: none