### PR TITLE
resolver_wrapper: add early return in addChannelzTraceEvent

### DIFF
--- a/resolver_wrapper.go
+++ b/resolver_wrapper.go
@@ -177,6 +177,9 @@ func (ccr *ccResolverWrapper) ParseServiceConfig(scJSON string) *serviceconfig.P
 // addChannelzTraceEvent adds a channelz trace event containing the new
 // state received from resolver implementations.
 func (ccr *ccResolverWrapper) addChannelzTraceEvent(s resolver.State) {
+	if !logger.V(0) && !channelz.IsOn() {
+		return
+	}
 	var updates []string
 	var oldSC, newSC *ServiceConfig
 	var oldOK, newOK bool


### PR DESCRIPTION
Note: this is a degradation introduced in this PR: https://github.com/grpc/grpc-go/pull/5192

Which [used to wrap calls](https://github.com/grpc/grpc-go/commit/a73725f42db97964eb538a5cf4d302f760357dbe#diff-f328282147b29224bf45cfe72630d84fa5d9b43b3b976ebb82077b3a322daa53L101) to `addChannelzTraceEvent` in a `if channelz.IsOn() {`

# Problem

Large and frequent calls to this method in UpdateState can cause an extremely high usage of CPU time and Memory due to underlying json.Marshal calls that are not used or needed if were not Info level logging as it is.

Alternative approach to: https://github.com/grpc/grpc-go/pull/7436

# Pprofs

![image](https://github.com/user-attachments/assets/69076fd2-aa0c-49bd-b8ee-25e643f0432c)

![image](https://github.com/user-attachments/assets/a5f4bdf4-3713-4d50-b66b-5e92631848f9)

RELEASE NOTES: none