### PR TITLE
Fix compression case5

### DIFF
--- a/server.go
+++ b/server.go
@@ -1336,7 +1336,7 @@ func (s *Server) processUnaryRPC(ctx context.Context, t transport.ServerTranspor
 		payInfo = &payloadInfo{}
 	}
 
-	d, cancel, err := recvAndDecompress(&parser{r: stream, recvBufferPool: s.opts.recvBufferPool}, stream, dc, s.opts.maxReceiveMessageSize, payInfo, decomp)
+	d, cancel, err := recvAndDecompress(&parser{r: stream, recvBufferPool: s.opts.recvBufferPool}, stream, dc, s.opts.maxReceiveMessageSize, payInfo, decomp, true)
 	if err != nil {
 		if e := t.WriteStatus(stream, status.Convert(err)); e != nil {
 			channelz.Warningf(logger, s.channelz, "grpc: Server.processUnaryRPC failed to write status: %v", e)

--- a/stream.go
+++ b/stream.go
@@ -1083,7 +1083,7 @@ func (a *csAttempt) recvMsg(m any, payInfo *payloadInfo) (err error) {
 		// Only initialize this state once per stream.
 		a.decompSet = true
 	}
-	err = recv(a.p, cs.codec, a.s, a.dc, m, *cs.callInfo.maxReceiveMessageSize, payInfo, a.decomp)
+	err = recv(a.p, cs.codec, a.s, a.dc, m, *cs.callInfo.maxReceiveMessageSize, payInfo, a.decomp, false)
 	if err != nil {
 		if err == io.EOF {
 			if statusErr := a.s.Status().Err(); statusErr != nil {
@@ -1122,7 +1122,7 @@ func (a *csAttempt) recvMsg(m any, payInfo *payloadInfo) (err error) {
 	}
 	// Special handling for non-server-stream rpcs.
 	// This recv expects EOF or errors, so we don't collect inPayload.
-	err = recv(a.p, cs.codec, a.s, a.dc, m, *cs.callInfo.maxReceiveMessageSize, nil, a.decomp)
+	err = recv(a.p, cs.codec, a.s, a.dc, m, *cs.callInfo.maxReceiveMessageSize, nil, a.decomp, false)
 	if err == nil {
 		return toRPCErr(errors.New("grpc: client streaming protocol violation: get <nil>, want <EOF>"))
 	}
@@ -1423,7 +1423,7 @@ func (as *addrConnStream) RecvMsg(m any) (err error) {
 		// Only initialize this state once per stream.
 		as.decompSet = true
 	}
-	err = recv(as.p, as.codec, as.s, as.dc, m, *as.callInfo.maxReceiveMessageSize, nil, as.decomp)
+	err = recv(as.p, as.codec, as.s, as.dc, m, *as.callInfo.maxReceiveMessageSize, nil, as.decomp, false)
 	if err != nil {
 		if err == io.EOF {
 			if statusErr := as.s.Status().Err(); statusErr != nil {
@@ -1444,7 +1444,7 @@ func (as *addrConnStream) RecvMsg(m any) (err error) {
 
 	// Special handling for non-server-stream rpcs.
 	// This recv expects EOF or errors, so we don't collect inPayload.
-	err = recv(as.p, as.codec, as.s, as.dc, m, *as.callInfo.maxReceiveMessageSize, nil, as.decomp)
+	err = recv(as.p, as.codec, as.s, as.dc, m, *as.callInfo.maxReceiveMessageSize, nil, as.decomp, false)
 	if err == nil {
 		return toRPCErr(errors.New("grpc: client streaming protocol violation: get <nil>, want <EOF>"))
 	}
@@ -1715,7 +1715,7 @@ func (ss *serverStream) RecvMsg(m any) (err error) {
 	if len(ss.statsHandler) != 0 || len(ss.binlogs) != 0 {
 		payInfo = &payloadInfo{}
 	}
-	if err := recv(ss.p, ss.codec, ss.s, ss.dc, m, ss.maxReceiveMessageSize, payInfo, ss.decomp); err != nil {
+	if err := recv(ss.p, ss.codec, ss.s, ss.dc, m, ss.maxReceiveMessageSize, payInfo, ss.decomp, true); err != nil {
 		if err == io.EOF {
 			if len(ss.binlogs) != 0 {
 				chc := &binarylog.ClientHalfClose{}

--- a/test/compression_cases_test.go
+++ b/test/compression_cases_test.go
@@ -1,0 +1,77 @@
+package test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/internal/stubserver"
+
+	testpb "google.golang.org/grpc/interop/grpc_testing"
+	"google.golang.org/grpc/status"
+)
+
+func TestCompressionCases(t *testing.T) {
+	cases := []struct {
+		desc                 string
+		clientUseCompression bool
+		serverUseCompression bool
+		expectedStatus       codes.Code
+	}{
+		{
+			desc:                 "Client usecompression true, server usecompression true",
+			clientUseCompression: true,
+			serverUseCompression: true,
+			expectedStatus:       codes.OK,
+		},
+		{
+			desc:                 "Client usecompression true, server usecompression false",
+			clientUseCompression: true,
+			serverUseCompression: false,
+			expectedStatus:       codes.Unimplemented,
+		},
+		{
+			desc:                 "Client usecompression false, server usecompression true",
+			clientUseCompression: false,
+			serverUseCompression: true,
+			expectedStatus:       codes.Internal,
+		},
+	}
+	for i, tc := range cases {
+		fmt.Println("TESTCASE: ", i)
+
+		ss := &stubserver.StubServer{
+			UnaryCallF: func(ctx context.Context, in *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
+				return &testpb.SimpleResponse{
+					Payload: in.Payload,
+				}, nil
+			},
+		}
+		sopts := []grpc.ServerOption{}
+		if tc.serverUseCompression {
+			sopts = append(sopts, grpc.RPCCompressor(grpc.NewGZIPCompressor()), grpc.RPCDecompressor(grpc.NewGZIPDecompressor()))
+		}
+		if err := ss.Start(sopts); err != nil {
+			t.Fatalf("Error starting server: %v", err)
+		}
+		defer ss.Stop()
+		payload := &testpb.SimpleRequest{
+			Payload: &testpb.Payload{
+				Body: []byte("test message"),
+			},
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+		defer cancel()
+		opts := []grpc.CallOption{}
+		if tc.clientUseCompression {
+			opts = append(opts, grpc.UseCompressor("gzip"))
+		}
+		_, err := ss.Client.UnaryCall(ctx, payload, opts...)
+		if st, _ := status.FromError(err); st.Code() != tc.expectedStatus {
+			t.Fatalf("got %v want %v", st.Code(), tc.expectedStatus)
+		}
+	}
+
+}


### PR DESCRIPTION
Client should report  Internal error status when server response contains unsupported encoding. 

Fixes: #6987