### PR TITLE
examples/retry: remove waitForReady from service config

### DIFF
--- a/examples/features/retry/README.md
+++ b/examples/features/retry/README.md
@@ -41,7 +41,6 @@ RetryableStatusCodes: Retry only when receiving these status codes.
             "methodConfig": [{
                 // config per method or all methods under service
                 "name": [{"service": "grpc.examples.echo.Echo"}],
-                "waitForReady": true,
 
                 "retryPolicy": {
                     "MaxAttempts": 4,

--- a/examples/features/retry/client/main.go
+++ b/examples/features/retry/client/main.go
@@ -36,7 +36,6 @@ var (
 	retryPolicy = `{
 		"methodConfig": [{
 		  "name": [{"service": "grpc.examples.echo.Echo"}],
-		  "waitForReady": true,
 		  "retryPolicy": {
 			  "MaxAttempts": 4,
 			  "InitialBackoff": ".01s",

--- a/rpc_util.go
+++ b/rpc_util.go
@@ -271,17 +271,13 @@ func (o PeerCallOption) after(c *callInfo, attempt *csAttempt) {
 	}
 }
 
-// WaitForReady configures the action to take when an RPC is attempted on broken
-// connections or unreachable servers. If waitForReady is false and the
-// connection is in the TRANSIENT_FAILURE state, the RPC will fail
-// immediately. Otherwise, the RPC client will block the call until a
-// connection is available (or the call is canceled or times out) and will
-// retry the call if it fails due to a transient error.  gRPC will not retry if
-// data was written to the wire unless the server indicates it did not process
-// the data.  Please refer to
-// https://github.com/grpc/grpc/blob/master/doc/wait-for-ready.md.
+// WaitForReady configures the RPC's behavior when the client is in
+// TRANSIENT_FAILURE, which occurs when all addresses fail to connect.  If
+// waitForReady is false, the RPC will fail immediately.  Otherwise, the client
+// will wait until a connection becomes available or the RPC's deadline is
+// reached.
 //
-// By default, RPCs don't "wait for ready".
+// By default, RPCs do not "wait for ready".
 func WaitForReady(waitForReady bool) CallOption {
 	return FailFastCallOption{FailFast: !waitForReady}
 }


### PR DESCRIPTION
This setting is irrelevant, so remove it to avoid any confusion.

Fixes #7440 

RELEASE NOTES: none