### PR TITLE
cmd/protoc-gen-go-grpc: remove replace and skip test that requires it for now

### DIFF
--- a/cmd/protoc-gen-go-grpc/go.mod
+++ b/cmd/protoc-gen-go-grpc/go.mod
@@ -13,5 +13,3 @@ require (
 	golang.org/x/text v0.16.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240604185151-ef581f913117 // indirect
 )
-
-replace google.golang.org/grpc => ../..

--- a/cmd/protoc-gen-go-grpc/go.sum
+++ b/cmd/protoc-gen-go-grpc/go.sum
@@ -8,5 +8,7 @@ golang.org/x/text v0.16.0 h1:a94ExnEXNtEwYLGJSIUxnWoxoRz/ZcCsV63ROupILh4=
 golang.org/x/text v0.16.0/go.mod h1:GhwF1Be+LQoKShO3cGOHzqOgRrGaYc9AvblQOmPVHnI=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20240604185151-ef581f913117 h1:1GBuWVLM/KMVUv1t1En5Gs+gFZCNd360GGb4sSxtrhU=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20240604185151-ef581f913117/go.mod h1:EfXuqaE1J41VCDicxHzUDm+8rk+7ZdXzHV0IhO/I6s0=
+google.golang.org/grpc v1.65.0 h1:bs/cUb4lp1G5iImFFd3u5ixQzweKizoZJAwBNLR42lc=
+google.golang.org/grpc v1.65.0/go.mod h1:WgYC2ypjlB0EiQi6wdKixMqukr6lBc0Vo+oOgjrM5ZQ=
 google.golang.org/protobuf v1.34.1 h1:9ddQBjfCyZPOHPUiPxpYESBLc+T8P3E+Vo4IbKZgFWg=
 google.golang.org/protobuf v1.34.1/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=

--- a/cmd/protoc-gen-go-grpc/unimpl_test.go
+++ b/cmd/protoc-gen-go-grpc/unimpl_test.go
@@ -34,6 +34,8 @@ type unimplEmbeddedByValue struct {
 }
 
 func TestUnimplementedEmbedding(t *testing.T) {
+	t.Skip("Skip until next grpc release includes panic during registration.")
+
 	// Embedded by value, this should succeed.
 	testgrpc.RegisterTestServiceServer(grpc.NewServer(), &unimplEmbeddedByValue{})
 	defer func() {
@@ -41,6 +43,7 @@ func TestUnimplementedEmbedding(t *testing.T) {
 			t.Fatalf("Expected panic; received none")
 		}
 	}()
+
 	// Embedded by pointer, this should panic.
 	testgrpc.RegisterTestServiceServer(grpc.NewServer(), &unimplEmbeddedByPointer{})
 }


### PR DESCRIPTION
RELEASE NOTES: none