### PR TITLE
experimental/stats/metricregistry: Add comments on enum consts for Metrics Type

### DIFF
--- a/experimental/stats/metricregistry.go
+++ b/experimental/stats/metricregistry.go
@@ -68,6 +68,7 @@ type MetricDescriptor struct {
 // MetricType is the type of metric.
 type MetricType int
 
+// Type of metric supported by this instrument registry.
 const (
 	MetricTypeIntCount MetricType = iota
 	MetricTypeFloatCount


### PR DESCRIPTION
The PR fixes a linter in Google 3.

RELEASE NOTES: N/A