### PR TITLE
grpclog: refactor to move implementation to grpclog/internal

### DIFF
--- a/grpclog/component.go
+++ b/grpclog/component.go
@@ -20,8 +20,6 @@ package grpclog
 
 import (
 	"fmt"
-
-	"google.golang.org/grpc/internal/grpclog"
 )
 
 // componentData records the settings for a component.
@@ -33,22 +31,22 @@ var cache = map[string]*componentData{}
 
 func (c *componentData) InfoDepth(depth int, args ...any) {
 	args = append([]any{"[" + string(c.name) + "]"}, args...)
-	grpclog.InfoDepth(depth+1, args...)
+	InfoDepth(depth+1, args...)
 }
 
 func (c *componentData) WarningDepth(depth int, args ...any) {
 	args = append([]any{"[" + string(c.name) + "]"}, args...)
-	grpclog.WarningDepth(depth+1, args...)
+	WarningDepth(depth+1, args...)
 }
 
 func (c *componentData) ErrorDepth(depth int, args ...any) {
 	args = append([]any{"[" + string(c.name) + "]"}, args...)
-	grpclog.ErrorDepth(depth+1, args...)
+	ErrorDepth(depth+1, args...)
 }
 
 func (c *componentData) FatalDepth(depth int, args ...any) {
 	args = append([]any{"[" + string(c.name) + "]"}, args...)
-	grpclog.FatalDepth(depth+1, args...)
+	FatalDepth(depth+1, args...)
 }
 
 func (c *componentData) Info(args ...any) {

--- a/grpclog/grpclog.go
+++ b/grpclog/grpclog.go
@@ -129,6 +129,11 @@ func Println(args ...any) {
 }
 
 // InfoDepth logs to the INFO log at the specified depth.
+//
+// # Experimental
+//
+// Notice: This API is EXPERIMENTAL and may be changed or removed in a
+// later release.
 func InfoDepth(depth int, args ...any) {
 	if internal.DepthLoggerV2Impl != nil {
 		internal.DepthLoggerV2Impl.InfoDepth(depth, args...)
@@ -138,6 +143,11 @@ func InfoDepth(depth int, args ...any) {
 }
 
 // WarningDepth logs to the WARNING log at the specified depth.
+//
+// # Experimental
+//
+// Notice: This API is EXPERIMENTAL and may be changed or removed in a
+// later release.
 func WarningDepth(depth int, args ...any) {
 	if internal.DepthLoggerV2Impl != nil {
 		internal.DepthLoggerV2Impl.WarningDepth(depth, args...)
@@ -147,6 +157,11 @@ func WarningDepth(depth int, args ...any) {
 }
 
 // ErrorDepth logs to the ERROR log at the specified depth.
+//
+// # Experimental
+//
+// Notice: This API is EXPERIMENTAL and may be changed or removed in a
+// later release.
 func ErrorDepth(depth int, args ...any) {
 	if internal.DepthLoggerV2Impl != nil {
 		internal.DepthLoggerV2Impl.ErrorDepth(depth, args...)
@@ -156,6 +171,11 @@ func ErrorDepth(depth int, args ...any) {
 }
 
 // FatalDepth logs to the FATAL log at the specified depth.
+//
+// # Experimental
+//
+// Notice: This API is EXPERIMENTAL and may be changed or removed in a
+// later release.
 func FatalDepth(depth int, args ...any) {
 	if internal.DepthLoggerV2Impl != nil {
 		internal.DepthLoggerV2Impl.FatalDepth(depth, args...)

--- a/grpclog/grpclog.go
+++ b/grpclog/grpclog.go
@@ -18,18 +18,15 @@
 
 // Package grpclog defines logging for grpc.
 //
-// All logs in transport and grpclb packages only go to verbose level 2.
-// All logs in other packages in grpc are logged in spite of the verbosity level.
-//
-// In the default logger,
-// severity level can be set by environment variable GRPC_GO_LOG_SEVERITY_LEVEL,
-// verbosity level can be set by GRPC_GO_LOG_VERBOSITY_LEVEL.
-package grpclog // import "google.golang.org/grpc/grpclog"
+// In the default logger, severity level can be set by environment variable
+// GRPC_GO_LOG_SEVERITY_LEVEL, verbosity level can be set by
+// GRPC_GO_LOG_VERBOSITY_LEVEL.
+package grpclog
 
 import (
 	"os"
 
-	"google.golang.org/grpc/internal/grpclog"
+	"google.golang.org/grpc/grpclog/internal"
 )
 
 func init() {
@@ -38,58 +35,58 @@ func init() {
 
 // V reports whether verbosity level l is at least the requested verbose level.
 func V(l int) bool {
-	return grpclog.Logger.V(l)
+	return internal.LoggerV2Impl.V(l)
 }
 
 // Info logs to the INFO log.
 func Info(args ...any) {
-	grpclog.Logger.Info(args...)
+	internal.LoggerV2Impl.Info(args...)
 }
 
 // Infof logs to the INFO log. Arguments are handled in the manner of fmt.Printf.
 func Infof(format string, args ...any) {
-	grpclog.Logger.Infof(format, args...)
+	internal.LoggerV2Impl.Infof(format, args...)
 }
 
 // Infoln logs to the INFO log. Arguments are handled in the manner of fmt.Println.
 func Infoln(args ...any) {
-	grpclog.Logger.Infoln(args...)
+	internal.LoggerV2Impl.Infoln(args...)
 }
 
 // Warning logs to the WARNING log.
 func Warning(args ...any) {
-	grpclog.Logger.Warning(args...)
+	internal.LoggerV2Impl.Warning(args...)
 }
 
 // Warningf logs to the WARNING log. Arguments are handled in the manner of fmt.Printf.
 func Warningf(format string, args ...any) {
-	grpclog.Logger.Warningf(format, args...)
+	internal.LoggerV2Impl.Warningf(format, args...)
 }
 
 // Warningln logs to the WARNING log. Arguments are handled in the manner of fmt.Println.
 func Warningln(args ...any) {
-	grpclog.Logger.Warningln(args...)
+	internal.LoggerV2Impl.Warningln(args...)
 }
 
 // Error logs to the ERROR log.
 func Error(args ...any) {
-	grpclog.Logger.Error(args...)
+	internal.LoggerV2Impl.Error(args...)
 }
 
 // Errorf logs to the ERROR log. Arguments are handled in the manner of fmt.Printf.
 func Errorf(format string, args ...any) {
-	grpclog.Logger.Errorf(format, args...)
+	internal.LoggerV2Impl.Errorf(format, args...)
 }
 
 // Errorln logs to the ERROR log. Arguments are handled in the manner of fmt.Println.
 func Errorln(args ...any) {
-	grpclog.Logger.Errorln(args...)
+	internal.LoggerV2Impl.Errorln(args...)
 }
 
 // Fatal logs to the FATAL log. Arguments are handled in the manner of fmt.Print.
 // It calls os.Exit() with exit code 1.
 func Fatal(args ...any) {
-	grpclog.Logger.Fatal(args...)
+	internal.LoggerV2Impl.Fatal(args...)
 	// Make sure fatal logs will exit.
 	os.Exit(1)
 }
@@ -97,7 +94,7 @@ func Fatal(args ...any) {
 // Fatalf logs to the FATAL log. Arguments are handled in the manner of fmt.Printf.
 // It calls os.Exit() with exit code 1.
 func Fatalf(format string, args ...any) {
-	grpclog.Logger.Fatalf(format, args...)
+	internal.LoggerV2Impl.Fatalf(format, args...)
 	// Make sure fatal logs will exit.
 	os.Exit(1)
 }
@@ -105,7 +102,7 @@ func Fatalf(format string, args ...any) {
 // Fatalln logs to the FATAL log. Arguments are handled in the manner of fmt.Println.
 // It calls os.Exit() with exit code 1.
 func Fatalln(args ...any) {
-	grpclog.Logger.Fatalln(args...)
+	internal.LoggerV2Impl.Fatalln(args...)
 	// Make sure fatal logs will exit.
 	os.Exit(1)
 }
@@ -114,19 +111,56 @@ func Fatalln(args ...any) {
 //
 // Deprecated: use Info.
 func Print(args ...any) {
-	grpclog.Logger.Info(args...)
+	internal.LoggerV2Impl.Info(args...)
 }
 
 // Printf prints to the logger. Arguments are handled in the manner of fmt.Printf.
 //
 // Deprecated: use Infof.
 func Printf(format string, args ...any) {
-	grpclog.Logger.Infof(format, args...)
+	internal.LoggerV2Impl.Infof(format, args...)
 }
 
 // Println prints to the logger. Arguments are handled in the manner of fmt.Println.
 //
 // Deprecated: use Infoln.
 func Println(args ...any) {
-	grpclog.Logger.Infoln(args...)
+	internal.LoggerV2Impl.Infoln(args...)
+}
+
+// InfoDepth logs to the INFO log at the specified depth.
+func InfoDepth(depth int, args ...any) {
+	if internal.DepthLoggerV2Impl != nil {
+		internal.DepthLoggerV2Impl.InfoDepth(depth, args...)
+	} else {
+		internal.LoggerV2Impl.Infoln(args...)
+	}
+}
+
+// WarningDepth logs to the WARNING log at the specified depth.
+func WarningDepth(depth int, args ...any) {
+	if internal.DepthLoggerV2Impl != nil {
+		internal.DepthLoggerV2Impl.WarningDepth(depth, args...)
+	} else {
+		internal.LoggerV2Impl.Warningln(args...)
+	}
+}
+
+// ErrorDepth logs to the ERROR log at the specified depth.
+func ErrorDepth(depth int, args ...any) {
+	if internal.DepthLoggerV2Impl != nil {
+		internal.DepthLoggerV2Impl.ErrorDepth(depth, args...)
+	} else {
+		internal.LoggerV2Impl.Errorln(args...)
+	}
+}
+
+// FatalDepth logs to the FATAL log at the specified depth.
+func FatalDepth(depth int, args ...any) {
+	if internal.DepthLoggerV2Impl != nil {
+		internal.DepthLoggerV2Impl.FatalDepth(depth, args...)
+	} else {
+		internal.LoggerV2Impl.Fatalln(args...)
+	}
+	os.Exit(1)
 }

--- a/grpclog/internal/grpclog.go
+++ b/grpclog/internal/grpclog.go
@@ -16,6 +16,7 @@
  *
  */
 
+// Package internal contains functionality internal to the grpclog package.
 package internal
 
 // LoggerV2Impl is the logger used for the non-depth log functions.

--- a/grpclog/internal/grpclog.go
+++ b/grpclog/internal/grpclog.go
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2015 gRPC authors.
+ * Copyright 2024 gRPC authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,21 +16,10 @@
  *
  */
 
-package grpclog
+package internal
 
-import (
-	"google.golang.org/grpc/grpclog/internal"
-)
+// LoggerV2Impl is the logger used for the non-depth log functions.
+var LoggerV2Impl LoggerV2
 
-// Logger mimics golang's standard Logger as an interface.
-//
-// Deprecated: use LoggerV2.
-type Logger internal.Logger
-
-// SetLogger sets the logger that is used in grpc. Call only from
-// init() functions.
-//
-// Deprecated: use SetLoggerV2.
-func SetLogger(l Logger) {
-	internal.LoggerV2Impl = &internal.LoggerWrapper{Logger: l}
-}
+// DepthLoggerV2Impl is the logger used for the depth log functions.
+var DepthLoggerV2Impl DepthLoggerV2

--- a/grpclog/internal/logger.go
+++ b/grpclog/internal/logger.go
@@ -1,0 +1,87 @@
+/*
+ *
+ * Copyright 2024 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package internal
+
+// Logger mimics golang's standard Logger as an interface.
+//
+// Deprecated: use LoggerV2.
+type Logger interface {
+	Fatal(args ...any)
+	Fatalf(format string, args ...any)
+	Fatalln(args ...any)
+	Print(args ...any)
+	Printf(format string, args ...any)
+	Println(args ...any)
+}
+
+// LoggerWrapper wraps Logger into a LoggerV2.
+type LoggerWrapper struct {
+	Logger
+}
+
+// Info logs to INFO log. Arguments are handled in the manner of fmt.Print.
+func (l *LoggerWrapper) Info(args ...any) {
+	l.Logger.Print(args...)
+}
+
+// Infoln logs to INFO log. Arguments are handled in the manner of fmt.Println.
+func (l *LoggerWrapper) Infoln(args ...any) {
+	l.Logger.Println(args...)
+}
+
+// Infof logs to INFO log. Arguments are handled in the manner of fmt.Printf.
+func (l *LoggerWrapper) Infof(format string, args ...any) {
+	l.Logger.Printf(format, args...)
+}
+
+// Warning logs to WARNING log. Arguments are handled in the manner of fmt.Print.
+func (l *LoggerWrapper) Warning(args ...any) {
+	l.Logger.Print(args...)
+}
+
+// Warningln logs to WARNING log. Arguments are handled in the manner of fmt.Println.
+func (l *LoggerWrapper) Warningln(args ...any) {
+	l.Logger.Println(args...)
+}
+
+// Warningf logs to WARNING log. Arguments are handled in the manner of fmt.Printf.
+func (l *LoggerWrapper) Warningf(format string, args ...any) {
+	l.Logger.Printf(format, args...)
+}
+
+// Error logs to ERROR log. Arguments are handled in the manner of fmt.Print.
+func (l *LoggerWrapper) Error(args ...any) {
+	l.Logger.Print(args...)
+}
+
+// Errorln logs to ERROR log. Arguments are handled in the manner of fmt.Println.
+func (l *LoggerWrapper) Errorln(args ...any) {
+	l.Logger.Println(args...)
+}
+
+// Errorf logs to ERROR log. Arguments are handled in the manner of fmt.Printf.
+func (l *LoggerWrapper) Errorf(format string, args ...any) {
+	l.Logger.Printf(format, args...)
+}
+
+// V reports whether verbosity level l is at least the requested verbose level.
+func (*LoggerWrapper) V(l int) bool {
+	// Returns true for all verbose level.
+	return true
+}

--- a/grpclog/internal/loggerv2.go
+++ b/grpclog/internal/loggerv2.go
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2020 gRPC authors.
+ * Copyright 2024 gRPC authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,59 +16,17 @@
  *
  */
 
-// Package grpclog (internal) defines depth logging for grpc.
-package grpclog
+package internal
 
 import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
 	"os"
 )
 
-// Logger is the logger used for the non-depth log functions.
-var Logger LoggerV2
-
-// DepthLogger is the logger used for the depth log functions.
-var DepthLogger DepthLoggerV2
-
-// InfoDepth logs to the INFO log at the specified depth.
-func InfoDepth(depth int, args ...any) {
-	if DepthLogger != nil {
-		DepthLogger.InfoDepth(depth, args...)
-	} else {
-		Logger.Infoln(args...)
-	}
-}
-
-// WarningDepth logs to the WARNING log at the specified depth.
-func WarningDepth(depth int, args ...any) {
-	if DepthLogger != nil {
-		DepthLogger.WarningDepth(depth, args...)
-	} else {
-		Logger.Warningln(args...)
-	}
-}
-
-// ErrorDepth logs to the ERROR log at the specified depth.
-func ErrorDepth(depth int, args ...any) {
-	if DepthLogger != nil {
-		DepthLogger.ErrorDepth(depth, args...)
-	} else {
-		Logger.Errorln(args...)
-	}
-}
-
-// FatalDepth logs to the FATAL log at the specified depth.
-func FatalDepth(depth int, args ...any) {
-	if DepthLogger != nil {
-		DepthLogger.FatalDepth(depth, args...)
-	} else {
-		Logger.Fatalln(args...)
-	}
-	os.Exit(1)
-}
-
 // LoggerV2 does underlying logging work for grpclog.
-// This is a copy of the LoggerV2 defined in the external grpclog package. It
-// is defined here to avoid a circular dependency.
 type LoggerV2 interface {
 	// Info logs to INFO log. Arguments are handled in the manner of fmt.Print.
 	Info(args ...any)
@@ -107,14 +65,13 @@ type LoggerV2 interface {
 // DepthLoggerV2 logs at a specified call frame. If a LoggerV2 also implements
 // DepthLoggerV2, the below functions will be called with the appropriate stack
 // depth set for trivial functions the logger may ignore.
-// This is a copy of the DepthLoggerV2 defined in the external grpclog package.
-// It is defined here to avoid a circular dependency.
 //
 // # Experimental
 //
 // Notice: This type is EXPERIMENTAL and may be changed or removed in a
 // later release.
 type DepthLoggerV2 interface {
+	LoggerV2
 	// InfoDepth logs to INFO log at the specified depth. Arguments are handled in the manner of fmt.Println.
 	InfoDepth(depth int, args ...any)
 	// WarningDepth logs to WARNING log at the specified depth. Arguments are handled in the manner of fmt.Println.
@@ -123,4 +80,125 @@ type DepthLoggerV2 interface {
 	ErrorDepth(depth int, args ...any)
 	// FatalDepth logs to FATAL log at the specified depth. Arguments are handled in the manner of fmt.Println.
 	FatalDepth(depth int, args ...any)
+}
+
+const (
+	// infoLog indicates Info severity.
+	infoLog int = iota
+	// warningLog indicates Warning severity.
+	warningLog
+	// errorLog indicates Error severity.
+	errorLog
+	// fatalLog indicates Fatal severity.
+	fatalLog
+)
+
+// severityName contains the string representation of each severity.
+var severityName = []string{
+	infoLog:    "INFO",
+	warningLog: "WARNING",
+	errorLog:   "ERROR",
+	fatalLog:   "FATAL",
+}
+
+// loggerT is the default logger used by grpclog.
+type loggerT struct {
+	m          []*log.Logger
+	v          int
+	jsonFormat bool
+}
+
+func (g *loggerT) output(severity int, s string) {
+	sevStr := severityName[severity]
+	if !g.jsonFormat {
+		g.m[severity].Output(2, fmt.Sprintf("%v: %v", sevStr, s))
+		return
+	}
+	// TODO: we can also include the logging component, but that needs more
+	// (API) changes.
+	b, _ := json.Marshal(map[string]string{
+		"severity": sevStr,
+		"message":  s,
+	})
+	g.m[severity].Output(2, string(b))
+}
+
+func (g *loggerT) Info(args ...any) {
+	g.output(infoLog, fmt.Sprint(args...))
+}
+
+func (g *loggerT) Infoln(args ...any) {
+	g.output(infoLog, fmt.Sprintln(args...))
+}
+
+func (g *loggerT) Infof(format string, args ...any) {
+	g.output(infoLog, fmt.Sprintf(format, args...))
+}
+
+func (g *loggerT) Warning(args ...any) {
+	g.output(warningLog, fmt.Sprint(args...))
+}
+
+func (g *loggerT) Warningln(args ...any) {
+	g.output(warningLog, fmt.Sprintln(args...))
+}
+
+func (g *loggerT) Warningf(format string, args ...any) {
+	g.output(warningLog, fmt.Sprintf(format, args...))
+}
+
+func (g *loggerT) Error(args ...any) {
+	g.output(errorLog, fmt.Sprint(args...))
+}
+
+func (g *loggerT) Errorln(args ...any) {
+	g.output(errorLog, fmt.Sprintln(args...))
+}
+
+func (g *loggerT) Errorf(format string, args ...any) {
+	g.output(errorLog, fmt.Sprintf(format, args...))
+}
+
+func (g *loggerT) Fatal(args ...any) {
+	g.output(fatalLog, fmt.Sprint(args...))
+	os.Exit(1)
+}
+
+func (g *loggerT) Fatalln(args ...any) {
+	g.output(fatalLog, fmt.Sprintln(args...))
+	os.Exit(1)
+}
+
+func (g *loggerT) Fatalf(format string, args ...any) {
+	g.output(fatalLog, fmt.Sprintf(format, args...))
+	os.Exit(1)
+}
+
+func (g *loggerT) V(l int) bool {
+	return l <= g.v
+}
+
+// LoggerV2Config configures the LoggerV2 implementation.
+type LoggerV2Config struct {
+	// Verbosity sets the verbosity level of the logger.
+	Verbosity int
+	// FormatJSON controls whether the logger should output logs in JSON format.
+	FormatJSON bool
+}
+
+// NewLoggerV2 creates a new LoggerV2 instance with the provided configuration.
+// The infoW, warningW, and errorW writers are used to write log messages of
+// different severity levels.
+func NewLoggerV2(infoW, warningW, errorW io.Writer, c LoggerV2Config) LoggerV2 {
+	var m []*log.Logger
+	flag := log.LstdFlags
+	if c.FormatJSON {
+		flag = 0
+	}
+	m = append(m, log.New(infoW, "", flag))
+	m = append(m, log.New(io.MultiWriter(infoW, warningW), "", flag))
+	ew := io.MultiWriter(infoW, warningW, errorW) // ew will be used for error and fatal.
+	m = append(m, log.New(ew, "", flag))
+	m = append(m, log.New(ew, "", flag))
+	return &loggerT{m: m, v: c.Verbosity, jsonFormat: c.FormatJSON}
 }

--- a/grpclog/internal/loggerv2_test.go
+++ b/grpclog/internal/loggerv2_test.go
@@ -16,7 +16,7 @@
  *
  */
 
-package grpclog
+package internal
 
 import (
 	"bytes"
@@ -27,11 +27,11 @@ import (
 
 func TestLoggerV2Severity(t *testing.T) {
 	buffers := []*bytes.Buffer{new(bytes.Buffer), new(bytes.Buffer), new(bytes.Buffer)}
-	SetLoggerV2(NewLoggerV2(buffers[infoLog], buffers[warningLog], buffers[errorLog]))
+	l := NewLoggerV2(buffers[infoLog], buffers[warningLog], buffers[errorLog], LoggerV2Config{})
 
-	Info(severityName[infoLog])
-	Warning(severityName[warningLog])
-	Error(severityName[errorLog])
+	l.Info(severityName[infoLog])
+	l.Warning(severityName[warningLog])
+	l.Error(severityName[errorLog])
 
 	for i := 0; i < fatalLog; i++ {
 		buf := buffers[i]

--- a/grpclog/logger.go
+++ b/grpclog/logger.go
@@ -18,9 +18,7 @@
 
 package grpclog
 
-import (
-	"google.golang.org/grpc/grpclog/internal"
-)
+import "google.golang.org/grpc/grpclog/internal"
 
 // Logger mimics golang's standard Logger as an interface.
 //

--- a/grpclog/loggerv2.go
+++ b/grpclog/loggerv2.go
@@ -19,52 +19,16 @@
 package grpclog
 
 import (
-	"encoding/json"
-	"fmt"
 	"io"
-	"log"
 	"os"
 	"strconv"
 	"strings"
 
-	"google.golang.org/grpc/internal/grpclog"
+	"google.golang.org/grpc/grpclog/internal"
 )
 
 // LoggerV2 does underlying logging work for grpclog.
-type LoggerV2 interface {
-	// Info logs to INFO log. Arguments are handled in the manner of fmt.Print.
-	Info(args ...any)
-	// Infoln logs to INFO log. Arguments are handled in the manner of fmt.Println.
-	Infoln(args ...any)
-	// Infof logs to INFO log. Arguments are handled in the manner of fmt.Printf.
-	Infof(format string, args ...any)
-	// Warning logs to WARNING log. Arguments are handled in the manner of fmt.Print.
-	Warning(args ...any)
-	// Warningln logs to WARNING log. Arguments are handled in the manner of fmt.Println.
-	Warningln(args ...any)
-	// Warningf logs to WARNING log. Arguments are handled in the manner of fmt.Printf.
-	Warningf(format string, args ...any)
-	// Error logs to ERROR log. Arguments are handled in the manner of fmt.Print.
-	Error(args ...any)
-	// Errorln logs to ERROR log. Arguments are handled in the manner of fmt.Println.
-	Errorln(args ...any)
-	// Errorf logs to ERROR log. Arguments are handled in the manner of fmt.Printf.
-	Errorf(format string, args ...any)
-	// Fatal logs to ERROR log. Arguments are handled in the manner of fmt.Print.
-	// gRPC ensures that all Fatal logs will exit with os.Exit(1).
-	// Implementations may also call os.Exit() with a non-zero exit code.
-	Fatal(args ...any)
-	// Fatalln logs to ERROR log. Arguments are handled in the manner of fmt.Println.
-	// gRPC ensures that all Fatal logs will exit with os.Exit(1).
-	// Implementations may also call os.Exit() with a non-zero exit code.
-	Fatalln(args ...any)
-	// Fatalf logs to ERROR log. Arguments are handled in the manner of fmt.Printf.
-	// gRPC ensures that all Fatal logs will exit with os.Exit(1).
-	// Implementations may also call os.Exit() with a non-zero exit code.
-	Fatalf(format string, args ...any)
-	// V reports whether verbosity level l is at least the requested verbose level.
-	V(l int) bool
-}
+type LoggerV2 internal.LoggerV2
 
 // SetLoggerV2 sets logger that is used in grpc to a V2 logger.
 // Not mutex-protected, should be called before any gRPC functions.
@@ -72,34 +36,8 @@ func SetLoggerV2(l LoggerV2) {
 	if _, ok := l.(*componentData); ok {
 		panic("cannot use component logger as grpclog logger")
 	}
-	grpclog.Logger = l
-	grpclog.DepthLogger, _ = l.(grpclog.DepthLoggerV2)
-}
-
-const (
-	// infoLog indicates Info severity.
-	infoLog int = iota
-	// warningLog indicates Warning severity.
-	warningLog
-	// errorLog indicates Error severity.
-	errorLog
-	// fatalLog indicates Fatal severity.
-	fatalLog
-)
-
-// severityName contains the string representation of each severity.
-var severityName = []string{
-	infoLog:    "INFO",
-	warningLog: "WARNING",
-	errorLog:   "ERROR",
-	fatalLog:   "FATAL",
-}
-
-// loggerT is the default logger used by grpclog.
-type loggerT struct {
-	m          []*log.Logger
-	v          int
-	jsonFormat bool
+	internal.LoggerV2Impl = l
+	internal.DepthLoggerV2Impl, _ = l.(internal.DepthLoggerV2)
 }
 
 // NewLoggerV2 creates a loggerV2 with the provided writers.
@@ -108,32 +46,13 @@ type loggerT struct {
 // Warning logs will be written to warningW and infoW.
 // Info logs will be written to infoW.
 func NewLoggerV2(infoW, warningW, errorW io.Writer) LoggerV2 {
-	return newLoggerV2WithConfig(infoW, warningW, errorW, loggerV2Config{})
+	return internal.NewLoggerV2(infoW, warningW, errorW, internal.LoggerV2Config{})
 }
 
 // NewLoggerV2WithVerbosity creates a loggerV2 with the provided writers and
 // verbosity level.
 func NewLoggerV2WithVerbosity(infoW, warningW, errorW io.Writer, v int) LoggerV2 {
-	return newLoggerV2WithConfig(infoW, warningW, errorW, loggerV2Config{verbose: v})
-}
-
-type loggerV2Config struct {
-	verbose    int
-	jsonFormat bool
-}
-
-func newLoggerV2WithConfig(infoW, warningW, errorW io.Writer, c loggerV2Config) LoggerV2 {
-	var m []*log.Logger
-	flag := log.LstdFlags
-	if c.jsonFormat {
-		flag = 0
-	}
-	m = append(m, log.New(infoW, "", flag))
-	m = append(m, log.New(io.MultiWriter(infoW, warningW), "", flag))
-	ew := io.MultiWriter(infoW, warningW, errorW) // ew will be used for error and fatal.
-	m = append(m, log.New(ew, "", flag))
-	m = append(m, log.New(ew, "", flag))
-	return &loggerT{m: m, v: c.verbose, jsonFormat: c.jsonFormat}
+	return internal.NewLoggerV2(infoW, warningW, errorW, internal.LoggerV2Config{Verbosity: v})
 }
 
 // newLoggerV2 creates a loggerV2 to be used as default logger.
@@ -161,80 +80,10 @@ func newLoggerV2() LoggerV2 {
 
 	jsonFormat := strings.EqualFold(os.Getenv("GRPC_GO_LOG_FORMATTER"), "json")
 
-	return newLoggerV2WithConfig(infoW, warningW, errorW, loggerV2Config{
-		verbose:    v,
-		jsonFormat: jsonFormat,
+	return internal.NewLoggerV2(infoW, warningW, errorW, internal.LoggerV2Config{
+		Verbosity:  v,
+		FormatJSON: jsonFormat,
 	})
-}
-
-func (g *loggerT) output(severity int, s string) {
-	sevStr := severityName[severity]
-	if !g.jsonFormat {
-		g.m[severity].Output(2, fmt.Sprintf("%v: %v", sevStr, s))
-		return
-	}
-	// TODO: we can also include the logging component, but that needs more
-	// (API) changes.
-	b, _ := json.Marshal(map[string]string{
-		"severity": sevStr,
-		"message":  s,
-	})
-	g.m[severity].Output(2, string(b))
-}
-
-func (g *loggerT) Info(args ...any) {
-	g.output(infoLog, fmt.Sprint(args...))
-}
-
-func (g *loggerT) Infoln(args ...any) {
-	g.output(infoLog, fmt.Sprintln(args...))
-}
-
-func (g *loggerT) Infof(format string, args ...any) {
-	g.output(infoLog, fmt.Sprintf(format, args...))
-}
-
-func (g *loggerT) Warning(args ...any) {
-	g.output(warningLog, fmt.Sprint(args...))
-}
-
-func (g *loggerT) Warningln(args ...any) {
-	g.output(warningLog, fmt.Sprintln(args...))
-}
-
-func (g *loggerT) Warningf(format string, args ...any) {
-	g.output(warningLog, fmt.Sprintf(format, args...))
-}
-
-func (g *loggerT) Error(args ...any) {
-	g.output(errorLog, fmt.Sprint(args...))
-}
-
-func (g *loggerT) Errorln(args ...any) {
-	g.output(errorLog, fmt.Sprintln(args...))
-}
-
-func (g *loggerT) Errorf(format string, args ...any) {
-	g.output(errorLog, fmt.Sprintf(format, args...))
-}
-
-func (g *loggerT) Fatal(args ...any) {
-	g.output(fatalLog, fmt.Sprint(args...))
-	os.Exit(1)
-}
-
-func (g *loggerT) Fatalln(args ...any) {
-	g.output(fatalLog, fmt.Sprintln(args...))
-	os.Exit(1)
-}
-
-func (g *loggerT) Fatalf(format string, args ...any) {
-	g.output(fatalLog, fmt.Sprintf(format, args...))
-	os.Exit(1)
-}
-
-func (g *loggerT) V(l int) bool {
-	return l <= g.v
 }
 
 // DepthLoggerV2 logs at a specified call frame. If a LoggerV2 also implements
@@ -245,14 +94,4 @@ func (g *loggerT) V(l int) bool {
 //
 // Notice: This type is EXPERIMENTAL and may be changed or removed in a
 // later release.
-type DepthLoggerV2 interface {
-	LoggerV2
-	// InfoDepth logs to INFO log at the specified depth. Arguments are handled in the manner of fmt.Println.
-	InfoDepth(depth int, args ...any)
-	// WarningDepth logs to WARNING log at the specified depth. Arguments are handled in the manner of fmt.Println.
-	WarningDepth(depth int, args ...any)
-	// ErrorDepth logs to ERROR log at the specified depth. Arguments are handled in the manner of fmt.Println.
-	ErrorDepth(depth int, args ...any)
-	// FatalDepth logs to FATAL log at the specified depth. Arguments are handled in the manner of fmt.Println.
-	FatalDepth(depth int, args ...any)
-}
+type DepthLoggerV2 internal.DepthLoggerV2

--- a/internal/grpclog/prefix_logger.go
+++ b/internal/grpclog/prefix_logger.go
@@ -16,6 +16,8 @@
  *
  */
 
+// Package grpclog provides logging functionality for internal gRPC packages,
+// outside of the functionality provided by the external `grpclog` package.
 package grpclog
 
 import (

--- a/internal/grpclog/prefix_logger.go
+++ b/internal/grpclog/prefix_logger.go
@@ -20,13 +20,15 @@ package grpclog
 
 import (
 	"fmt"
+
+	"google.golang.org/grpc/grpclog"
 )
 
 // PrefixLogger does logging with a prefix.
 //
 // Logging method on a nil logs without any prefix.
 type PrefixLogger struct {
-	logger DepthLoggerV2
+	logger grpclog.DepthLoggerV2
 	prefix string
 }
 
@@ -38,7 +40,7 @@ func (pl *PrefixLogger) Infof(format string, args ...any) {
 		pl.logger.InfoDepth(1, fmt.Sprintf(format, args...))
 		return
 	}
-	InfoDepth(1, fmt.Sprintf(format, args...))
+	grpclog.InfoDepth(1, fmt.Sprintf(format, args...))
 }
 
 // Warningf does warning logging.
@@ -48,7 +50,7 @@ func (pl *PrefixLogger) Warningf(format string, args ...any) {
 		pl.logger.WarningDepth(1, fmt.Sprintf(format, args...))
 		return
 	}
-	WarningDepth(1, fmt.Sprintf(format, args...))
+	grpclog.WarningDepth(1, fmt.Sprintf(format, args...))
 }
 
 // Errorf does error logging.
@@ -58,18 +60,18 @@ func (pl *PrefixLogger) Errorf(format string, args ...any) {
 		pl.logger.ErrorDepth(1, fmt.Sprintf(format, args...))
 		return
 	}
-	ErrorDepth(1, fmt.Sprintf(format, args...))
+	grpclog.ErrorDepth(1, fmt.Sprintf(format, args...))
 }
 
 // V reports whether verbosity level l is at least the requested verbose level.
 func (pl *PrefixLogger) V(l int) bool {
-	// TODO(6044): Refactor interfaces LoggerV2 and DepthLogger, and maybe
-	// rewrite PrefixLogger a little to ensure that we don't use the global
-	// `Logger` here, and instead use the `logger` field.
-	return Logger.V(l)
+	if pl == nil {
+		return true
+	}
+	return pl.logger.V(l)
 }
 
 // NewPrefixLogger creates a prefix logger with the given prefix.
-func NewPrefixLogger(logger DepthLoggerV2, prefix string) *PrefixLogger {
+func NewPrefixLogger(logger grpclog.DepthLoggerV2, prefix string) *PrefixLogger {
 	return &PrefixLogger{logger: logger, prefix: prefix}
 }

--- a/internal/grpclog/prefix_logger.go
+++ b/internal/grpclog/prefix_logger.go
@@ -67,10 +67,10 @@ func (pl *PrefixLogger) Errorf(format string, args ...any) {
 
 // V reports whether verbosity level l is at least the requested verbose level.
 func (pl *PrefixLogger) V(l int) bool {
-	if pl == nil {
-		return true
+	if pl != nil {
+		return pl.logger.V(l)
 	}
-	return pl.logger.V(l)
+	return true
 }
 
 // NewPrefixLogger creates a prefix logger with the given prefix.

--- a/internal/grpctest/tlogger_test.go
+++ b/internal/grpctest/tlogger_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 
 	"google.golang.org/grpc/grpclog"
-	grpclogi "google.golang.org/grpc/internal/grpclog"
 )
 
 type s struct {
@@ -46,7 +45,7 @@ func (s) TestInfof(t *testing.T) {
 }
 
 func (s) TestInfoDepth(t *testing.T) {
-	grpclogi.InfoDepth(0, "Info", "depth", "message.")
+	grpclog.InfoDepth(0, "Info", "depth", "message.")
 }
 
 func (s) TestWarning(t *testing.T) {
@@ -62,7 +61,7 @@ func (s) TestWarningf(t *testing.T) {
 }
 
 func (s) TestWarningDepth(t *testing.T) {
-	grpclogi.WarningDepth(0, "Warning", "depth", "message.")
+	grpclog.WarningDepth(0, "Warning", "depth", "message.")
 }
 
 func (s) TestError(t *testing.T) {

--- a/scripts/vet.sh
+++ b/scripts/vet.sh
@@ -124,6 +124,13 @@ XXXXX PleaseIgnoreUnused'
   # TODO(https://github.com/dominikh/go-tools/issues/54): Remove this once the issue is fixed in staticcheck.
   noret_grep "(SA4000)" "${SC_OUT}" | not grep -v -e "crl.go:[0-9]\+:[0-9]\+: identical expressions on the left and right side of the '||' operator (SA4000)"
 
+  # Usage of the deprecated Logger interface from prefix_logger.go is the only
+  # allowed one. If any other files use the deprecated interface, this check
+  # will fails. Also, note that this same deprecation notice is also added to
+  # the list of ignored notices down below to allow for the usage in
+  # prefix_logger.go to not case vet failure.
+  noret_grep "(SA1019)" "${SC_OUT}" | noret_grep "internal.Logger is deprecated:" | not grep -v -e "grpclog/logger.go"
+
   # Only ignore the following deprecated types/fields/functions and exclude
   # generated code.
   noret_grep "(SA1019)" "${SC_OUT}" | not grep -Fv 'XXXXX PleaseIgnoreUnused
@@ -140,6 +147,7 @@ XXXXX gRPC internal usage deprecation errors:
 : v1alphareflectionpb.
 BalancerAttributes is deprecated:
 CredsBundle is deprecated:
+internal.Logger is deprecated:
 Metadata is deprecated: use Attributes instead.
 NewSubConn is deprecated:
 OverrideServerName is deprecated:
@@ -149,7 +157,6 @@ Target is deprecated: Use the Target field in the BuildOptions instead.
 UpdateAddresses is deprecated:
 UpdateSubConnState is deprecated:
 balancer.ErrTransientFailure is deprecated:
-internal.Logger is deprecated:
 grpc/reflection/v1alpha/reflection.proto
 SwitchTo is deprecated:
 XXXXX xDS deprecated fields we support

--- a/scripts/vet.sh
+++ b/scripts/vet.sh
@@ -59,7 +59,7 @@ git grep -l 'time.After(' -- "*.go" | not grep -v '_test.go\|test_utils\|testuti
 git grep -l 'interface{}' -- "*.go" 2>&1 | not grep -v '\.pb\.go\|protoc-gen-go-grpc\|grpc_testing_not_regenerate'
 
 # - Do not call grpclog directly. Use grpclog.Component instead.
-git grep -l -e 'grpclog.I' --or -e 'grpclog.W' --or -e 'grpclog.E' --or -e 'grpclog.F' --or -e 'grpclog.V' -- "*.go" | not grep -v '^grpclog/component.go\|^internal/grpctest/tlogger_test.go'
+git grep -l -e 'grpclog.I' --or -e 'grpclog.W' --or -e 'grpclog.E' --or -e 'grpclog.F' --or -e 'grpclog.V' -- "*.go" | not grep -v '^grpclog/component.go\|^internal/grpctest/tlogger_test.go\|^internal/grpclog/prefix_logger.go'
 
 # - Ensure that the deprecated protobuf dependency is not used.
 not git grep "\"github.com/golang/protobuf/*" -- "*.go" ':(exclude)reflection/test/grpc_testing_not_regenerate/*'

--- a/scripts/vet.sh
+++ b/scripts/vet.sh
@@ -149,6 +149,7 @@ Target is deprecated: Use the Target field in the BuildOptions instead.
 UpdateAddresses is deprecated:
 UpdateSubConnState is deprecated:
 balancer.ErrTransientFailure is deprecated:
+internal.Logger is deprecated:
 grpc/reflection/v1alpha/reflection.proto
 SwitchTo is deprecated:
 XXXXX xDS deprecated fields we support


### PR DESCRIPTION
Idea behind the refactor:
- Public API for logging should be provided by the `grpclog` package
- Implementation should mostly reside in `grpclog/internal` package
- Any functionality that is not exposed externally, but is available to grpc packages should be in `internal/grpclog`
- Package `grpclog` will take a dependency on `grpclog/internal`
- Package `internal/grpclog` will take a dependency on `grpclog`

Also introduces a few methods for depth logging to the external `grpclog` package.

RELEASE NOTES: none