### PR TITLE
doc: update keepalive ClientParameters doc about doubling the interval upon GOAWAY

### DIFF
--- a/dialoptions.go
+++ b/dialoptions.go
@@ -518,6 +518,8 @@ func WithUserAgent(s string) DialOption {
 
 // WithKeepaliveParams returns a DialOption that specifies keepalive parameters
 // for the client transport.
+//
+// Keepalive is disabled by default.
 func WithKeepaliveParams(kp keepalive.ClientParameters) DialOption {
 	if kp.Time < internal.KeepaliveMinPingTime {
 		logger.Warningf("Adjusting keepalive ping interval to minimum period of %v", internal.KeepaliveMinPingTime)

--- a/keepalive/keepalive.go
+++ b/keepalive/keepalive.go
@@ -34,6 +34,16 @@ type ClientParameters struct {
 	// After a duration of this time if the client doesn't see any activity it
 	// pings the server to see if the transport is still alive.
 	// If set below 10s, a minimum value of 10s will be used instead.
+	//
+	// Note that server has a default EnforcementPolicy.MinTime of 5 minutes
+	// (which means the client shouldn't ping more frequently than every 5 minutes).
+	//
+	// But it's not a strong requirement to set this less than
+	// EnforcementPolicy.MinTime, because the server sends a GOAWAY with error code
+	// ENHANCE_YOUR_CALM and debug data equal to ASCII "too_many_pings", and the
+	// client will double this interval upon receiving that.
+	//
+	// For more details, see https://github.com/grpc/proposal/blob/master/A8-client-side-keepalive.md
 	Time time.Duration // The current default value is infinity.
 	// After having pinged for keepalive check, the client waits for a duration
 	// of Timeout and if no activity is seen even after that the connection is

--- a/keepalive/keepalive.go
+++ b/keepalive/keepalive.go
@@ -45,15 +45,18 @@ type ClientParameters struct {
 	//
 	// For more details, see
 	// https://github.com/grpc/proposal/blob/master/A8-client-side-keepalive.md
-	Time time.Duration // The current default value is infinity.
+	Time time.Duration
 	// After having pinged for keepalive check, the client waits for a duration
 	// of Timeout and if no activity is seen even after that the connection is
 	// closed.
-	Timeout time.Duration // The current default value is 20 seconds.
+	//
+	// If keepalive is enabled, and this value is not explicitly set, the default
+	// is 20 seconds.
+	Timeout time.Duration
 	// If true, client sends keepalive pings even with no active RPCs. If false,
 	// when there are no active RPCs, Time and Timeout will be ignored and no
 	// keepalive pings will be sent.
-	PermitWithoutStream bool // false by default.
+	PermitWithoutStream bool
 }
 
 // ServerParameters is used to set keepalive and max-age parameters on the

--- a/keepalive/keepalive.go
+++ b/keepalive/keepalive.go
@@ -33,8 +33,7 @@ import (
 type ClientParameters struct {
 	// After a duration of this time if the client doesn't see any activity it
 	// pings the server to see if the transport is still alive.
-	// If set below 10s (including 0), a minimum value of 10s will be used
-	// instead.
+	// If set below 10s, a minimum value of 10s will be used instead.
 	//
 	// Note that gRPC servers have a default EnforcementPolicy.MinTime of 5
 	// minutes (which means the client shouldn't ping more frequently than every

--- a/keepalive/keepalive.go
+++ b/keepalive/keepalive.go
@@ -35,15 +35,16 @@ type ClientParameters struct {
 	// pings the server to see if the transport is still alive.
 	// If set below 10s, a minimum value of 10s will be used instead.
 	//
-	// Note that server has a default EnforcementPolicy.MinTime of 5 minutes
-	// (which means the client shouldn't ping more frequently than every 5 minutes).
+	// Note that gRPC servers have a default EnforcementPolicy.MinTime of 5
+	// minutes (which means the client shouldn't ping more frequently than every
+	// 5 minutes).
 	//
-	// But it's not a strong requirement to set this less than
-	// EnforcementPolicy.MinTime, because the server sends a GOAWAY with error code
-	// ENHANCE_YOUR_CALM and debug data equal to ASCII "too_many_pings", and the
-	// client will double this interval upon receiving that.
+	// Though not ideal, it's not a strong requirement for Time to be less than
+	// EnforcementPolicy.MinTime.  Time will automatically double if the server
+	// disconnects due to its enforcement policy.
 	//
-	// For more details, see https://github.com/grpc/proposal/blob/master/A8-client-side-keepalive.md
+	// For more details, see
+	// https://github.com/grpc/proposal/blob/master/A8-client-side-keepalive.md
 	Time time.Duration // The current default value is infinity.
 	// After having pinged for keepalive check, the client waits for a duration
 	// of Timeout and if no activity is seen even after that the connection is

--- a/keepalive/keepalive.go
+++ b/keepalive/keepalive.go
@@ -33,7 +33,8 @@ import (
 type ClientParameters struct {
 	// After a duration of this time if the client doesn't see any activity it
 	// pings the server to see if the transport is still alive.
-	// If set below 10s, a minimum value of 10s will be used instead.
+	// If set below 10s (including 0), a minimum value of 10s will be used
+	// instead.
 	//
 	// Note that gRPC servers have a default EnforcementPolicy.MinTime of 5
 	// minutes (which means the client shouldn't ping more frequently than every


### PR DESCRIPTION
Add to the godoc the behavior that the client doubles the keepalive ping interval when GOAWAY is received due to too-many-pings.

And link to the design doc.

RELEASE NOTES: N/A