### PR TITLE
Use builtin min and max functions

### DIFF
--- a/balancer/rls/internal/adaptive/lookback.go
+++ b/balancer/rls/internal/adaptive/lookback.go
@@ -82,10 +82,3 @@ func (l *lookback) advance(t time.Time) int64 {
 	l.head = nh
 	return nh
 }
-
-func min(x int64, y int64) int64 {
-	if x < y {
-		return x
-	}
-	return y
-}

--- a/benchmark/stats/stats.go
+++ b/benchmark/stats/stats.go
@@ -494,10 +494,3 @@ func (s *Stats) dump(result *BenchResults) {
 	b.WriteString(fmt.Sprintf("Number of responses: %v\tResponse throughput: %v bit/s\n", resp, result.Data.RespT))
 	fmt.Println(b.String())
 }
-
-func max(a, b int64) int64 {
-	if a > b {
-		return a
-	}
-	return b
-}

--- a/credentials/alts/internal/conn/record.go
+++ b/credentials/alts/internal/conn/record.go
@@ -266,10 +266,3 @@ func (p *conn) Write(b []byte) (n int, err error) {
 	}
 	return n, nil
 }
-
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}

--- a/internal/channelz/channelmap.go
+++ b/internal/channelz/channelmap.go
@@ -234,13 +234,6 @@ func copyMap(m map[int64]string) map[int64]string {
 	return n
 }
 
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}
-
 func (c *channelMap) getTopChannels(id int64, maxResults int) ([]*Channel, bool) {
 	if maxResults <= 0 {
 		maxResults = EntriesPerPage

--- a/internal/transport/controlbuf.go
+++ b/internal/transport/controlbuf.go
@@ -30,7 +30,6 @@ import (
 
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/hpack"
-
 	"google.golang.org/grpc/internal/grpclog"
 	"google.golang.org/grpc/internal/grpcutil"
 	"google.golang.org/grpc/status"

--- a/internal/transport/controlbuf.go
+++ b/internal/transport/controlbuf.go
@@ -30,6 +30,7 @@ import (
 
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/hpack"
+
 	"google.golang.org/grpc/internal/grpclog"
 	"google.golang.org/grpc/internal/grpcutil"
 	"google.golang.org/grpc/status"
@@ -1016,11 +1017,4 @@ func (l *loopyWriter) processData() (bool, error) {
 		l.activeStreams.enqueue(str)
 	}
 	return false, nil
-}
-
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
 }

--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -34,7 +34,6 @@ import (
 
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/hpack"
-
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/internal"

--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -34,6 +34,7 @@ import (
 
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/hpack"
+
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/internal"
@@ -1671,13 +1672,6 @@ func (t *http2Client) reader(errCh chan<- error) {
 	}
 }
 
-func minTime(a, b time.Duration) time.Duration {
-	if a < b {
-		return a
-	}
-	return b
-}
-
 // keepalive running in a separate goroutine makes sure the connection is alive by sending pings.
 func (t *http2Client) keepalive() {
 	p := &ping{data: [8]byte{}}
@@ -1745,7 +1739,7 @@ func (t *http2Client) keepalive() {
 			// timeoutLeft. This will ensure that we wait only for kp.Time
 			// before sending out the next ping (for cases where the ping is
 			// acked).
-			sleepDuration := minTime(t.kp.Time, timeoutLeft)
+			sleepDuration := min(t.kp.Time, timeoutLeft)
 			timeoutLeft -= sleepDuration
 			timer.Reset(sleepDuration)
 		case <-t.ctx.Done():

--- a/internal/transport/http2_server.go
+++ b/internal/transport/http2_server.go
@@ -35,12 +35,11 @@ import (
 
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/hpack"
-	"google.golang.org/protobuf/proto"
-
 	"google.golang.org/grpc/internal/grpclog"
 	"google.golang.org/grpc/internal/grpcutil"
 	"google.golang.org/grpc/internal/pretty"
 	"google.golang.org/grpc/internal/syscall"
+	"google.golang.org/protobuf/proto"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"

--- a/internal/transport/http2_server.go
+++ b/internal/transport/http2_server.go
@@ -35,11 +35,12 @@ import (
 
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/hpack"
+	"google.golang.org/protobuf/proto"
+
 	"google.golang.org/grpc/internal/grpclog"
 	"google.golang.org/grpc/internal/grpcutil"
 	"google.golang.org/grpc/internal/pretty"
 	"google.golang.org/grpc/internal/syscall"
-	"google.golang.org/protobuf/proto"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
@@ -1225,7 +1226,7 @@ func (t *http2Server) keepalive() {
 			// timeoutLeft. This will ensure that we wait only for kp.Time
 			// before sending out the next ping (for cases where the ping is
 			// acked).
-			sleepDuration := minTime(t.kp.Time, kpTimeoutLeft)
+			sleepDuration := min(t.kp.Time, kpTimeoutLeft)
 			kpTimeoutLeft -= sleepDuration
 			kpTimer.Reset(sleepDuration)
 		case <-t.done:

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -43,7 +43,6 @@ import (
 
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/hpack"
-
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/balancer"
 	"google.golang.org/grpc/balancer/roundrobin"
@@ -72,13 +71,12 @@ import (
 	"google.golang.org/grpc/testdata"
 
 	spb "google.golang.org/genproto/googleapis/rpc/status"
-	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/types/known/anypb"
-
 	healthgrpc "google.golang.org/grpc/health/grpc_health_v1"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 	testgrpc "google.golang.org/grpc/interop/grpc_testing"
 	testpb "google.golang.org/grpc/interop/grpc_testing"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
 
 	_ "google.golang.org/grpc/encoding/gzip"
 )

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -43,6 +43,7 @@ import (
 
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/hpack"
+
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/balancer"
 	"google.golang.org/grpc/balancer/roundrobin"
@@ -71,12 +72,13 @@ import (
 	"google.golang.org/grpc/testdata"
 
 	spb "google.golang.org/genproto/googleapis/rpc/status"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
+
 	healthgrpc "google.golang.org/grpc/health/grpc_health_v1"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 	testgrpc "google.golang.org/grpc/interop/grpc_testing"
 	testpb "google.golang.org/grpc/interop/grpc_testing"
-	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/types/known/anypb"
 
 	_ "google.golang.org/grpc/encoding/gzip"
 )
@@ -4741,13 +4743,6 @@ type windowSizeConfig struct {
 	serverConn   int32
 	clientStream int32
 	clientConn   int32
-}
-
-func max(a, b int32) int32 {
-	if a > b {
-		return a
-	}
-	return b
 }
 
 func (s) TestConfigurableWindowSizeWithLargeWindow(t *testing.T) {

--- a/xds/internal/balancer/outlierdetection/balancer.go
+++ b/xds/internal/balancer/outlierdetection/balancer.go
@@ -592,20 +592,6 @@ func (b *outlierDetectionBalancer) Target() string {
 	return b.cc.Target()
 }
 
-func max(x, y time.Duration) time.Duration {
-	if x < y {
-		return y
-	}
-	return x
-}
-
-func min(x, y time.Duration) time.Duration {
-	if x < y {
-		return x
-	}
-	return y
-}
-
 // handleSubConnUpdate stores the recent state and forward the update
 // if the SubConn is not ejected.
 func (b *outlierDetectionBalancer) handleSubConnUpdate(u *scUpdate) {


### PR DESCRIPTION
With the upgrade to Go 1.21 (#7282), grpc-go can use the new builtin [min](https://pkg.go.dev/builtin#min) and [max](https://pkg.go.dev/builtin#max) functions. This commit removes existing functions and uses the built-ins instead.

RELEASE NOTES: none