### PR TITLE
internal/transport: Unlock mutex before panic

### DIFF
--- a/internal/transport/handler_server.go
+++ b/internal/transport/handler_server.go
@@ -244,6 +244,7 @@ func (ht *serverHandlerTransport) WriteStatus(s *Stream, st *status.Status) erro
 		}
 
 		s.hdrMu.Lock()
+		defer s.hdrMu.Unlock()
 		if p := st.Proto(); p != nil && len(p.Details) > 0 {
 			delete(s.trailer, grpcStatusDetailsBinHeader)
 			stBytes, err := proto.Marshal(p)
@@ -268,7 +269,6 @@ func (ht *serverHandlerTransport) WriteStatus(s *Stream, st *status.Status) erro
 				}
 			}
 		}
-		s.hdrMu.Unlock()
 	})
 
 	if err == nil { // transport has not been closed


### PR DESCRIPTION
1. Panic will not actively release the lock.
2. This function is called by a goroutine, if panic occurs, the lock will be held until the entire program exits.

```
s.hdrMu.Lock()
if p := st.Proto(); p != nil && len(p.Details) > 0 {
	delete(s.trailer, grpcStatusDetailsBinHeader)
	stBytes, err := proto.Marshal(p)
	if err != nil {
		// TODO: return error instead, when callers are able to handle it.
		panic(err)
	}

	h.Set(grpcStatusDetailsBinHeader, encodeBinHeader(stBytes))
}
```

RELEASE NOTES: None