### PR TITLE
cluster_resolver: wait for child policy configuration update inline

### DIFF
--- a/xds/internal/balancer/clusterresolver/clusterresolver.go
+++ b/xds/internal/balancer/clusterresolver/clusterresolver.go
@@ -77,10 +77,11 @@ func (bb) Build(cc balancer.ClientConn, opts balancer.BuildOptions) balancer.Bal
 	}
 
 	b := &clusterResolverBalancer{
-		bOpts:                opts,
-		updateCh:             buffer.NewUnbounded(),
-		closed:               grpcsync.NewEvent(),
-		done:                 grpcsync.NewEvent(),
+		bOpts:    opts,
+		updateCh: buffer.NewUnbounded(),
+		closed:   grpcsync.NewEvent(),
+		done:     grpcsync.NewEvent(),
+
 		priorityBuilder:      priorityBuilder,
 		priorityConfigParser: priorityConfigParser,
 	}
@@ -311,6 +312,8 @@ func (b *clusterResolverBalancer) run() {
 			case *ccUpdate:
 				b.handleClientConnUpdate(update)
 				if update.done != nil {
+					// Close the channel to convey to the consumers of updateCh
+					// that child policies config are updated inline.
 					close(update.done)
 				}
 			case exitIdle:

--- a/xds/internal/balancer/clusterresolver/e2e_test/balancer_test.go
+++ b/xds/internal/balancer/clusterresolver/e2e_test/balancer_test.go
@@ -449,7 +449,7 @@ func (s) TestOutlierDetectionConfigPropagationToChildPolicy(t *testing.T) {
 
 // Test verifies that LB waits for child policy configuration update
 // inline on receipt of configuration update.
-func (s) TestPickerUpdatedSynchronouslyOnConfigUpdate(t *testing.T) {
+func (s) TestChildPoliciesConfigUpdatedInline(t *testing.T) {
 	// Override the newConfigHook to ensure picker was updated.
 	configUpdated := make(chan struct{})
 	origNewConfigHook := clusterresolver.NewConfigHook
@@ -464,7 +464,6 @@ func (s) TestPickerUpdatedSynchronouslyOnConfigUpdate(t *testing.T) {
 
 	// Start an xDS management server with the above restartable listener, and
 	// push a channel when the stream is closed.
-	//streamClosedCh := make(chan struct{}, 1)
 	managementServer := e2e.StartManagementServer(t, e2e.ManagementServerOptions{
 		Listener: lis,
 	})

--- a/xds/internal/balancer/clusterresolver/e2e_test/balancer_test.go
+++ b/xds/internal/balancer/clusterresolver/e2e_test/balancer_test.go
@@ -44,6 +44,7 @@ import (
 	"google.golang.org/grpc/status"
 	xdsinternal "google.golang.org/grpc/xds/internal"
 	"google.golang.org/grpc/xds/internal/balancer/clusterimpl"
+	"google.golang.org/grpc/xds/internal/balancer/clusterresolver"
 	"google.golang.org/grpc/xds/internal/balancer/outlierdetection"
 	"google.golang.org/grpc/xds/internal/balancer/priority"
 	"google.golang.org/grpc/xds/internal/balancer/wrrlocality"
@@ -443,5 +444,66 @@ func (s) TestOutlierDetectionConfigPropagationToChildPolicy(t *testing.T) {
 		}
 	case <-ctx.Done():
 		t.Fatalf("Timeout when waiting for child policy to receive its configuration")
+	}
+}
+
+// Test verifies that LB waits for child policy configuration update
+// inline on receipt of configuration update.
+func (s) TestPickerUpdatedSynchronouslyOnConfigUpdate(t *testing.T) {
+	// Override the newConfigHook to ensure picker was updated.
+	configUpdated := make(chan struct{})
+	origNewConfigHook := clusterresolver.NewConfigHook
+	clusterresolver.NewConfigHook = func() { configUpdated <- struct{}{} }
+	defer func() { clusterresolver.NewConfigHook = origNewConfigHook }()
+	// Create a listener to be used by the management server. The test will
+	// close this listener to simulate ADS stream breakage.
+	lis, err := testutils.LocalTCPListener()
+	if err != nil {
+		t.Fatalf("testutils.LocalTCPListener() failed: %v", err)
+	}
+
+	// Start an xDS management server with the above restartable listener, and
+	// push a channel when the stream is closed.
+	//streamClosedCh := make(chan struct{}, 1)
+	managementServer := e2e.StartManagementServer(t, e2e.ManagementServerOptions{
+		Listener: lis,
+	})
+
+	// Create bootstrap configuration pointing to the above management server.
+	nodeID := uuid.New().String()
+	bootstrapContents := e2e.DefaultBootstrapContents(t, nodeID, managementServer.Address)
+
+	server := stubserver.StartTestService(t, nil)
+	defer server.Stop()
+
+	// Configure cluster and endpoints resources in the management server.
+	resources := e2e.UpdateOptions{
+		NodeID:         nodeID,
+		Clusters:       []*v3clusterpb.Cluster{e2e.DefaultCluster(clusterName, edsServiceName, e2e.SecurityLevelNone)},
+		Endpoints:      []*v3endpointpb.ClusterLoadAssignment{e2e.DefaultEndpoint(edsServiceName, "localhost", []uint32{testutils.ParsePort(t, server.Address)})},
+		SkipValidation: true,
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	if err := managementServer.Update(ctx, resources); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create xDS client, configure cds_experimental LB policy with a manual
+	// resolver, and dial the test backends.
+	cc, cleanup := setupAndDial(t, bootstrapContents)
+	defer cleanup()
+
+	client := testgrpc.NewTestServiceClient(cc)
+	if _, err := client.EmptyCall(ctx, &testpb.Empty{}); err != nil {
+		t.Fatalf("EmptyCall() failed: %v", err)
+	}
+
+	// Close the listener and ensure that the config is updated.
+	lis.Close()
+	select {
+	case <-configUpdated:
+	case <-ctx.Done():
+		t.Fatal("Timed out waiting for LB configuration update.")
 	}
 }


### PR DESCRIPTION
### Problem
[#5469](https://github.com/grpc/grpc-go/issues/5469) recommends an audit of existing LB policies to ensure that they update their pickers synchronously upon receipt of a configuration update. `cluster_resolver` neither does update its picker synchronously nor wait for the child policy configuration update inline.

### What does this PR do?
This PR ensures that every time configuration update is triggered, it waits for child policy configuration update inline.

RELEASE NOTES: 

- cluster_resolver: wait for child policy configuration update inline