### PR TITLE
transport: change `*http2Client` to interface `ClientTransport`

### DIFF
--- a/internal/transport/transport.go
+++ b/internal/transport/transport.go
@@ -241,7 +241,7 @@ const (
 type Stream struct {
 	id           uint32
 	st           ServerTransport    // nil for client side Stream
-	ct           *http2Client       // nil for server side Stream
+	ct           ClientTransport    // nil for server side Stream
 	ctx          context.Context    // the associated context of the stream
 	cancel       context.CancelFunc // always nil for client side Stream
 	done         chan struct{}      // closed at the end of stream to unblock writers. On the client side.


### PR DESCRIPTION
Change `transport.Stream` to reference the generic interface `ClientTransport` instead of the specific `*http2Client`.

RELEASE NOTES: none