### PR TITLE
rbac: fix usage of AuthInfo

### DIFF
--- a/internal/xds/rbac/rbac_engine.go
+++ b/internal/xds/rbac/rbac_engine.go
@@ -237,12 +237,9 @@ func newRPCData(ctx context.Context) (*rpcData, error) {
 
 	var authType string
 	var peerCertificates []*x509.Certificate
-	if pi.AuthInfo != nil {
-		tlsInfo, ok := pi.AuthInfo.(credentials.TLSInfo)
-		if ok {
-			authType = pi.AuthInfo.AuthType()
-			peerCertificates = tlsInfo.State.PeerCertificates
-		}
+	if tlsInfo, ok := pi.AuthInfo.(credentials.TLSInfo); ok {
+		authType = pi.AuthInfo.AuthType()
+		peerCertificates = tlsInfo.State.PeerCertificates
 	}
 
 	return &rpcData{
@@ -281,11 +278,12 @@ func (e *engine) doAuditLogging(rpcData *rpcData, rule string, authorized bool) 
 	// In the RBAC world, we need to have a SPIFFE ID as the principal for this
 	// to be meaningful
 	principal := ""
-	if rpcData.peerInfo != nil && rpcData.peerInfo.AuthInfo != nil && rpcData.peerInfo.AuthInfo.AuthType() == "tls" {
+	if rpcData.peerInfo != nil {
 		// If AuthType = tls, then we can cast AuthInfo to TLSInfo.
-		tlsInfo := rpcData.peerInfo.AuthInfo.(credentials.TLSInfo)
-		if tlsInfo.SPIFFEID != nil {
-			principal = tlsInfo.SPIFFEID.String()
+		if tlsInfo, ok := rpcData.peerInfo.AuthInfo.(credentials.TLSInfo); ok {
+			if tlsInfo.SPIFFEID != nil {
+				principal = tlsInfo.SPIFFEID.String()
+			}
 		}
 	}
 


### PR DESCRIPTION
This could actually lead to a panic if the auth type reports "tls" but the `AuthInfo` is not a `credentials.TLSInfo`.  There is no evidence this is happening and has been this way for a long time.

RELEASE NOTES: none