### PR TITLE
stats/opentelemetry: Optimize slice allocations

### DIFF
--- a/stats/opentelemetry/opentelemetry.go
+++ b/stats/opentelemetry/opentelemetry.go
@@ -330,41 +330,40 @@ func (rm *registryMetrics) registerMetrics(metrics *estats.Metrics, meter otelme
 
 func (rm *registryMetrics) RecordInt64Count(handle *estats.Int64CountHandle, incr int64, labels ...string) {
 	desc := handle.Descriptor()
-	ao := optionFromLabels(desc.Labels, desc.OptionalLabels, rm.optionalLabels, labels...)
-
 	if ic, ok := rm.intCounts[desc]; ok {
+		ao := optionFromLabels(desc.Labels, desc.OptionalLabels, rm.optionalLabels, labels...)
 		ic.Add(context.TODO(), incr, ao)
 	}
 }
 
 func (rm *registryMetrics) RecordFloat64Count(handle *estats.Float64CountHandle, incr float64, labels ...string) {
 	desc := handle.Descriptor()
-	ao := optionFromLabels(desc.Labels, desc.OptionalLabels, rm.optionalLabels, labels...)
 	if fc, ok := rm.floatCounts[desc]; ok {
+		ao := optionFromLabels(desc.Labels, desc.OptionalLabels, rm.optionalLabels, labels...)
 		fc.Add(context.TODO(), incr, ao)
 	}
 }
 
 func (rm *registryMetrics) RecordInt64Histo(handle *estats.Int64HistoHandle, incr int64, labels ...string) {
 	desc := handle.Descriptor()
-	ao := optionFromLabels(desc.Labels, desc.OptionalLabels, rm.optionalLabels, labels...)
 	if ih, ok := rm.intHistos[desc]; ok {
+		ao := optionFromLabels(desc.Labels, desc.OptionalLabels, rm.optionalLabels, labels...)
 		ih.Record(context.TODO(), incr, ao)
 	}
 }
 
 func (rm *registryMetrics) RecordFloat64Histo(handle *estats.Float64HistoHandle, incr float64, labels ...string) {
 	desc := handle.Descriptor()
-	ao := optionFromLabels(desc.Labels, desc.OptionalLabels, rm.optionalLabels, labels...)
 	if fh, ok := rm.floatHistos[desc]; ok {
+		ao := optionFromLabels(desc.Labels, desc.OptionalLabels, rm.optionalLabels, labels...)
 		fh.Record(context.TODO(), incr, ao)
 	}
 }
 
 func (rm *registryMetrics) RecordInt64Gauge(handle *estats.Int64GaugeHandle, incr int64, labels ...string) {
 	desc := handle.Descriptor()
-	ao := optionFromLabels(desc.Labels, desc.OptionalLabels, rm.optionalLabels, labels...)
 	if ig, ok := rm.intGauges[desc]; ok {
+		ao := optionFromLabels(desc.Labels, desc.OptionalLabels, rm.optionalLabels, labels...)
 		ig.Record(context.TODO(), incr, ao)
 	}
 }

--- a/stats/opentelemetry/opentelemetry.go
+++ b/stats/opentelemetry/opentelemetry.go
@@ -283,7 +283,7 @@ func optionFromLabels(labelKeys []string, optionalLabelKeys []string, optionalLa
 			}
 		}
 	}
-	return otelmetric.WithAttributes(attributes...)
+	return otelmetric.WithAttributeSet(otelattribute.NewSet(attributes...))
 }
 
 // registryMetrics implements MetricsRecorder for the client and server stats


### PR DESCRIPTION
First commit moves attribute construction under `if` to only construct them when they are used.

Second commit uses `WithAttributeSet()` instead of `WithAttributes()`. This avoids copying the slice, which is not necessary for this code. See https://github.com/open-telemetry/opentelemetry-go/blob/metric/v1.28.0/metric/instrument.go#L349-L368.

Also, a bit of allocations can be removed by constructing the vararg slice one time vs when calling `Record()` each time.

```go
var sink []string

func abc(vals ...string) {
	sink = vals
}

func BenchmarkFuncCall(b *testing.B) {
	b.ReportAllocs()
	b.ResetTimer()
	arg := []string{"a", "b", "c"}
	for i := 0; i < b.N; i++ {
		abc(arg...)
	}
}
```

The above benchmark gives me these results:

```
// Pass "a", "b", "c"
BenchmarkFuncCall-10    	43171615	        27.14 ns/op	      48 B/op	       1 allocs/op

// Pass arg...
BenchmarkFuncCall-10    	1000000000	         0.9530 ns/op	       0 B/op	       0 allocs/op
```

See https://go.dev/ref/spec#Passing_arguments_to_..._parameters.

RELEASE NOTES: None