### PR TITLE
xds/clusterimpl: update UpdateClientConnState to handle updates synchronously  

### DIFF
--- a/xds/internal/balancer/clusterimpl/clusterimpl.go
+++ b/xds/internal/balancer/clusterimpl/clusterimpl.go
@@ -261,8 +261,8 @@ func (b *clusterImplBalancer) UpdateClientConnState(s balancer.ClientConnState) 
 		errCh <- b.updateClientConnState(s)
 	}
 	onFailure := func() {
-		// The call to Schedule returns false *only* if the serializer has been
-		// closed, which happens only when we receive an update after close.
+		// An attempt to schedule callback fails only when an update is received
+		// after Close().
 		errCh <- errBalancerClosed
 	}
 	b.serializer.ScheduleOr(callback, onFailure)


### PR DESCRIPTION
Part of #7210.

`UpdateClientConnState` now handles updates in a blocking fashion. 

To simplify the code, this PR replaces the existing `run` goroutine inside `clusterimpl` lb policy and instead handles calls from gRPC and from the child policy (to update state) in a `grpcsync.CallbackSerializer`. This approach simplifies things by removing the need for synchronization using locks and other grpcsync.Event fields. 

RELEASE NOTES: none