### PR TITLE
credentials/tls: default GRPC_ENFORCE_ALPN_ENABLED to true

### DIFF
--- a/credentials/credentials_test.go
+++ b/credentials/credentials_test.go
@@ -311,7 +311,7 @@ func tlsServerHandshake(conn net.Conn) (AuthInfo, error) {
 
 func tlsClientHandshake(conn net.Conn, _ string) (AuthInfo, error) {
 	clientTLSConfig := &tls.Config{
-		InsecureSkipVerify: true,
+		InsecureSkipVerify: true, // NOLINT
 		NextProtos:         []string{"h2"},
 	}
 	clientConn := tls.Client(conn, clientTLSConfig)

--- a/credentials/credentials_test.go
+++ b/credentials/credentials_test.go
@@ -297,7 +297,10 @@ func tlsServerHandshake(conn net.Conn) (AuthInfo, error) {
 	if err != nil {
 		return nil, err
 	}
-	serverTLSConfig := &tls.Config{Certificates: []tls.Certificate{cert}}
+	serverTLSConfig := &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		NextProtos:   []string{"h2"},
+	}
 	serverConn := tls.Server(conn, serverTLSConfig)
 	err = serverConn.Handshake()
 	if err != nil {
@@ -307,7 +310,10 @@ func tlsServerHandshake(conn net.Conn) (AuthInfo, error) {
 }
 
 func tlsClientHandshake(conn net.Conn, _ string) (AuthInfo, error) {
-	clientTLSConfig := &tls.Config{InsecureSkipVerify: true}
+	clientTLSConfig := &tls.Config{
+		InsecureSkipVerify: true,
+		NextProtos:         []string{"h2"},
+	}
 	clientConn := tls.Client(conn, clientTLSConfig)
 	if err := clientConn.Handshake(); err != nil {
 		return nil, err

--- a/credentials/xds/xds_client_test.go
+++ b/credentials/xds/xds_client_test.go
@@ -146,7 +146,10 @@ func testServerTLSHandshake(rawConn net.Conn) handshakeResult {
 	if err != nil {
 		return handshakeResult{err: err}
 	}
-	cfg := &tls.Config{Certificates: []tls.Certificate{cert}}
+	cfg := &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		NextProtos:   []string{"h2"},
+	}
 	conn := tls.Server(rawConn, cfg)
 	if err := conn.Handshake(); err != nil {
 		return handshakeResult{err: err}

--- a/credentials/xds/xds_server_test.go
+++ b/credentials/xds/xds_server_test.go
@@ -66,6 +66,7 @@ func makeClientTLSConfig(t *testing.T, mTLS bool) *tls.Config {
 		// verification function. So, the server credentials tests will rely
 		// solely on the success/failure of the server-side handshake.
 		InsecureSkipVerify: true,
+		NextProtos:         []string{"h2"},
 	}
 }
 

--- a/internal/envconfig/envconfig.go
+++ b/internal/envconfig/envconfig.go
@@ -45,7 +45,7 @@ var (
 	// option is present for backward compatibility. This option may be overridden
 	// by setting the environment variable "GRPC_ENFORCE_ALPN_ENABLED" to "true"
 	// or "false".
-	EnforceALPNEnabled = boolFromEnv("GRPC_ENFORCE_ALPN_ENABLED", false)
+	EnforceALPNEnabled = boolFromEnv("GRPC_ENFORCE_ALPN_ENABLED", true)
 	// XDSFallbackSupport is the env variable that controls whether support for
 	// xDS fallback is turned on. If this is unset or is false, only the first
 	// xDS server in the list of server configs will be used.


### PR DESCRIPTION
Related issue: https://github.com/grpc/grpc-go/issues/434

RELEASE NOTES:
* Clients and servers will reject TLS connections that don't support ALPN. This can be disabled by setting environment variable `GRPC_ENFORCE_ALPN_ENABLED` to `false` (case insensitive). Please file a bug if you encounter any issues with this behaviour. This will become the default behaviour in an upcoming release.