### PR TITLE
vet: dont revive from revive

### DIFF
--- a/scripts/revive.toml
+++ b/scripts/revive.toml
@@ -1,0 +1,21 @@
+# TODO(#7444): Enable these rules once the linter issues are fixed.
+[rule.context-as-argument]
+    Disabled = true
+[rule.empty-block]
+    Disabled = true
+[rule.exported]
+    Disabled = true
+[rule.increment-decrement]
+    Disabled = true
+[rule.indent-error-flow]
+    Disabled = true
+[rule.package-comments]
+    Disabled = true
+[rule.redefines-builtin-id]
+    Disabled = true
+[rule.superfluous-else]
+    Disabled = true
+[rule.var-declaration]
+    Disabled = true
+[rule.var-naming]
+    Disabled = true

--- a/scripts/vet.sh
+++ b/scripts/vet.sh
@@ -176,12 +176,6 @@ XXXXX PleaseIgnoreUnused'
   popd
 done
 
-# Collection of revive linter analysis checks
-REV_OUT="$(mktemp)"
-revive -formatter plain ./... >"${REV_OUT}" || true
-
-# Error for anything other than unused-parameter linter check and in generated code.
-# TODO: Remove `|| true` to unskip linter failures once existing issues are fixed.
-(noret_grep -v "unused-parameter" "${REV_OUT}" | not grep -v "\.pb\.go:") || true
+revive -config "$(dirname "$0")/revive.toml" ./... | fail_on_output
 
 echo SUCCESS


### PR DESCRIPTION
I would prefer if we took this approach with revive + #7444.  This way we can re-enable each of the check as in when we fix them. This gives us a better way of testing changes like #7528 

Let me know how you think about this

RELEASE NOTES: none