### PR TITLE
stats/otel: upgrade grpc version that contains the experimental/stats package

### DIFF
--- a/examples/go.mod
+++ b/examples/go.mod
@@ -9,7 +9,7 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.28.0
 	golang.org/x/oauth2 v0.22.0
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240814211410-ddb44dafa142
-	google.golang.org/grpc v1.65.0
+	google.golang.org/grpc v1.67.0-dev
 	google.golang.org/grpc/gcp/observability v1.0.1
 	google.golang.org/grpc/stats/opentelemetry v0.0.0-20240816220358-f8d98a477c22
 	google.golang.org/protobuf v1.34.2

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -9,7 +9,7 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.28.0
 	golang.org/x/oauth2 v0.22.0
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240814211410-ddb44dafa142
-	google.golang.org/grpc v1.67.0-dev
+	google.golang.org/grpc v1.66.0
 	google.golang.org/grpc/gcp/observability v1.0.1
 	google.golang.org/grpc/stats/opentelemetry v0.0.0-20240816220358-f8d98a477c22
 	google.golang.org/protobuf v1.34.2

--- a/interop/xds/go.mod
+++ b/interop/xds/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/prometheus/client_golang v1.20.0
 	go.opentelemetry.io/otel/exporters/prometheus v0.50.0
 	go.opentelemetry.io/otel/sdk/metric v1.28.0
-	google.golang.org/grpc v1.67.0-dev
+	google.golang.org/grpc v1.66.0
 	google.golang.org/grpc/stats/opentelemetry v0.0.0-20240816220358-f8d98a477c22
 )
 

--- a/interop/xds/go.mod
+++ b/interop/xds/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/prometheus/client_golang v1.20.0
 	go.opentelemetry.io/otel/exporters/prometheus v0.50.0
 	go.opentelemetry.io/otel/sdk/metric v1.28.0
-	google.golang.org/grpc v1.65.0
+	google.golang.org/grpc v1.67.0-dev
 	google.golang.org/grpc/stats/opentelemetry v0.0.0-20240816220358-f8d98a477c22
 )
 

--- a/security/advancedtls/examples/go.mod
+++ b/security/advancedtls/examples/go.mod
@@ -3,7 +3,7 @@ module google.golang.org/grpc/security/advancedtls/examples
 go 1.21
 
 require (
-	google.golang.org/grpc v1.65.0
+	google.golang.org/grpc v1.67.0-dev
 	google.golang.org/grpc/examples v0.0.0-20240816220358-f8d98a477c22
 	google.golang.org/grpc/security/advancedtls v1.0.0
 )

--- a/security/advancedtls/examples/go.mod
+++ b/security/advancedtls/examples/go.mod
@@ -3,7 +3,7 @@ module google.golang.org/grpc/security/advancedtls/examples
 go 1.21
 
 require (
-	google.golang.org/grpc v1.67.0-dev
+	google.golang.org/grpc v1.66.0
 	google.golang.org/grpc/examples v0.0.0-20240816220358-f8d98a477c22
 	google.golang.org/grpc/security/advancedtls v1.0.0
 )

--- a/security/advancedtls/go.mod
+++ b/security/advancedtls/go.mod
@@ -5,7 +5,7 @@ go 1.21
 require (
 	github.com/google/go-cmp v0.6.0
 	golang.org/x/crypto v0.26.0
-	google.golang.org/grpc v1.65.0
+	google.golang.org/grpc v1.67.0-dev
 	google.golang.org/grpc/examples v0.0.0-20201112215255-90f1b3ee835b
 )
 

--- a/security/advancedtls/go.mod
+++ b/security/advancedtls/go.mod
@@ -5,7 +5,7 @@ go 1.21
 require (
 	github.com/google/go-cmp v0.6.0
 	golang.org/x/crypto v0.26.0
-	google.golang.org/grpc v1.67.0-dev
+	google.golang.org/grpc v1.66.0
 	google.golang.org/grpc/examples v0.0.0-20201112215255-90f1b3ee835b
 )
 

--- a/stats/opentelemetry/go.mod
+++ b/stats/opentelemetry/go.mod
@@ -12,7 +12,7 @@ require (
 	go.opentelemetry.io/otel/metric v1.28.0
 	go.opentelemetry.io/otel/sdk v1.28.0
 	go.opentelemetry.io/otel/sdk/metric v1.28.0
-	google.golang.org/grpc v1.65.0
+	google.golang.org/grpc v1.67.0-dev
 	google.golang.org/protobuf v1.34.2
 )
 

--- a/stats/opentelemetry/go.mod
+++ b/stats/opentelemetry/go.mod
@@ -12,7 +12,7 @@ require (
 	go.opentelemetry.io/otel/metric v1.28.0
 	go.opentelemetry.io/otel/sdk v1.28.0
 	go.opentelemetry.io/otel/sdk/metric v1.28.0
-	google.golang.org/grpc v1.67.0-dev
+	google.golang.org/grpc v1.66.0
 	google.golang.org/protobuf v1.34.2
 )
 


### PR DESCRIPTION
Building stats/otel was broken on its own because this package depends on `grpc/experimental/stats` which is not released yet. Our tests passed because of the replace directive magic.

RELEASE NOTES: none