### PR TITLE
clusterresolver/e2e_test: Avoid making DNS requests

### DIFF
--- a/resolver/manual/manual.go
+++ b/resolver/manual/manual.go
@@ -76,9 +76,11 @@ func (r *Resolver) InitialState(s resolver.State) {
 
 // Build returns itself for Resolver, because it's both a builder and a resolver.
 func (r *Resolver) Build(target resolver.Target, cc resolver.ClientConn, opts resolver.BuildOptions) (resolver.Resolver, error) {
-	r.BuildCallback(target, cc, opts)
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	// Call BuildCallback after locking to avoid a race when UpdateState
+	// or ReportError is called before Build returns.
+	r.BuildCallback(target, cc, opts)
 	r.CC = cc
 	if r.lastSeenState != nil {
 		err := r.CC.UpdateState(*r.lastSeenState)

--- a/xds/internal/balancer/clusterresolver/e2e_test/aggregate_cluster_test.go
+++ b/xds/internal/balancer/clusterresolver/e2e_test/aggregate_cluster_test.go
@@ -840,6 +840,7 @@ func (s) TestAggregateCluster_BadEDSFromError_GoodToBadDNS(t *testing.T) {
 // good update, this test verifies the cluster_resolver balancer correctly falls
 // back from the LOGICAL_DNS cluster to the EDS cluster.
 func (s) TestAggregateCluster_BadDNS_GoodEDS(t *testing.T) {
+	dnsTargetCh, dnsR := setupDNS(t)
 	// Start an xDS management server.
 	managementServer := e2e.StartManagementServer(t, e2e.ManagementServerOptions{AllowResourceSubset: true})
 
@@ -857,12 +858,14 @@ func (s) TestAggregateCluster_BadDNS_GoodEDS(t *testing.T) {
 	const (
 		edsClusterName = clusterName + "-eds"
 		dnsClusterName = clusterName + "-dns"
+		dnsHostName    = "bad.ip.v4.address"
+		dnsPort        = 8080
 	)
 	resources := e2e.UpdateOptions{
 		NodeID: nodeID,
 		Clusters: []*v3clusterpb.Cluster{
 			makeAggregateClusterResource(clusterName, []string{dnsClusterName, edsClusterName}),
-			makeLogicalDNSClusterResource(dnsClusterName, "bad%ipv4%address", 8080), // Invalid URL to avoid making a DNS request.
+			makeLogicalDNSClusterResource(dnsClusterName, dnsHostName, dnsPort),
 			e2e.DefaultCluster(edsClusterName, edsServiceName, e2e.SecurityLevelNone),
 		},
 		Endpoints:      []*v3endpointpb.ClusterLoadAssignment{e2e.DefaultEndpoint(edsServiceName, "localhost", []uint32{uint32(edsPort)})},
@@ -878,6 +881,21 @@ func (s) TestAggregateCluster_BadDNS_GoodEDS(t *testing.T) {
 	// resolver, and dial the test backends.
 	cc, cleanup := setupAndDial(t, bootstrapContents)
 	defer cleanup()
+
+	// Ensure that the DNS resolver is started for the expected target.
+	select {
+	case <-ctx.Done():
+		t.Fatal("Timeout when waiting for DNS resolver to be started")
+	case target := <-dnsTargetCh:
+		got, want := target.Endpoint(), fmt.Sprintf("%s:%d", dnsHostName, dnsPort)
+		if got != want {
+			t.Fatalf("DNS resolution started for target %q, want %q", got, want)
+		}
+	}
+
+	// Produce a bad resolver update from the DNS resolver.
+	dnsErr := fmt.Errorf("DNS error")
+	dnsR.ReportError(dnsErr)
 
 	// RPCs should work, higher level DNS cluster errors so should fallback to
 	// EDS cluster.

--- a/xds/internal/balancer/clusterresolver/e2e_test/aggregate_cluster_test.go
+++ b/xds/internal/balancer/clusterresolver/e2e_test/aggregate_cluster_test.go
@@ -862,7 +862,7 @@ func (s) TestAggregateCluster_BadDNS_GoodEDS(t *testing.T) {
 		NodeID: nodeID,
 		Clusters: []*v3clusterpb.Cluster{
 			makeAggregateClusterResource(clusterName, []string{dnsClusterName, edsClusterName}),
-			makeLogicalDNSClusterResource(dnsClusterName, "bad.ip.v4.address", 8080),
+			makeLogicalDNSClusterResource(dnsClusterName, "bad%ipv4%address", 8080), // Invalid URL to avoid making a DNS request.
 			e2e.DefaultCluster(edsClusterName, edsServiceName, e2e.SecurityLevelNone),
 		},
 		Endpoints:      []*v3endpointpb.ClusterLoadAssignment{e2e.DefaultEndpoint(edsServiceName, "localhost", []uint32{uint32(edsPort)})},


### PR DESCRIPTION
The test is presently making a real DNS request for a non existing domain `bad.ip.v4.address`. This makes the test non-hermitic and could potentially be the cause of the test flaking. This change makes the test use a fake resolver to avoid making DNS requests.

Related issue: https://github.com/grpc/grpc-go/issues/7354

RELEASE NOTES: None