### PR TITLE
cluster_resolver: wait until the configs have been propagated to all the children

### DIFF
--- a/xds/internal/balancer/clusterresolver/clusterresolver.go
+++ b/xds/internal/balancer/clusterresolver/clusterresolver.go
@@ -51,6 +51,9 @@ var (
 	newChildBalancer  = func(bb balancer.Builder, cc balancer.ClientConn, o balancer.BuildOptions) balancer.Balancer {
 		return bb.Build(cc, o)
 	}
+	// Below function is no-op in actual code, but can be overridden in
+	// tests to give tests visibility into exactly when certain events happen.
+	ClientConnUpdateHook = func() {}
 )
 
 func init() {
@@ -145,6 +148,7 @@ func (bb) ParseConfig(j json.RawMessage) (serviceconfig.LoadBalancingConfig, err
 type ccUpdate struct {
 	state balancer.ClientConnState
 	err   error
+	done  chan struct{}
 }
 
 type exitIdle struct{}
@@ -306,6 +310,11 @@ func (b *clusterResolverBalancer) run() {
 			switch update := u.(type) {
 			case *ccUpdate:
 				b.handleClientConnUpdate(update)
+				if update.done != nil {
+					// Close the channel to convey to the consumers of updateCh
+					// that child policies config are updated inline.
+					close(update.done)
+				}
 			case exitIdle:
 				if b.child == nil {
 					b.logger.Errorf("xds: received ExitIdle with no child balancer")
@@ -357,7 +366,10 @@ func (b *clusterResolverBalancer) UpdateClientConnState(state balancer.ClientCon
 		b.attrsWithClient = state.ResolverState.Attributes
 	}
 
-	b.updateCh.Put(&ccUpdate{state: state})
+	done := make(chan struct{})
+	b.updateCh.Put(&ccUpdate{state: state, done: done})
+	<-done
+	ClientConnUpdateHook()
 	return nil
 }
 

--- a/xds/internal/balancer/clusterresolver/clusterresolver.go
+++ b/xds/internal/balancer/clusterresolver/clusterresolver.go
@@ -51,8 +51,8 @@ var (
 	newChildBalancer  = func(bb balancer.Builder, cc balancer.ClientConn, o balancer.BuildOptions) balancer.Balancer {
 		return bb.Build(cc, o)
 	}
-	// Below function is no-op in actual code, but can be overridden in
-	// tests to give tests visibility into exactly when certain events happen.
+	// This function is a no-op in production code but can be overridden
+	// in tests to track the timing of specific events for test visibility.
 	ClientConnUpdateHook = func() {}
 )
 
@@ -311,8 +311,8 @@ func (b *clusterResolverBalancer) run() {
 			case *ccUpdate:
 				b.handleClientConnUpdate(update)
 				if update.done != nil {
-					// Close the channel to convey to the consumers of updateCh
-					// that child policies config are updated inline.
+					// Close the channel to signal to consumers of updateCh
+					// that the child policies' configuration has been updated.
 					close(update.done)
 				}
 			case exitIdle:


### PR DESCRIPTION
### What does this PR do?
This PR ensures that every time configuration update is triggered, it waits for child policy configuration update inline.

### Approach:
Added a channel to `ccUpdate` of which that channel will be closed after child policies are updated. Same is verified in the test by having a `ClientConnUpdateHook()` which is called after the above mentioned channel is closed, which ensures child policy was updated synchronously.

RELEASE NOTES:

- cluster_resolver: wait for child policy configuration to be updated inline