### PR TITLE
.*: revive from unused_parameters

### DIFF
--- a/balancer/base/balancer.go
+++ b/balancer/base/balancer.go
@@ -36,7 +36,7 @@ type baseBuilder struct {
 	config        Config
 }
 
-func (bb *baseBuilder) Build(cc balancer.ClientConn, opt balancer.BuildOptions) balancer.Balancer {
+func (bb *baseBuilder) Build(cc balancer.ClientConn, _ balancer.BuildOptions) balancer.Balancer {
 	bal := &baseBalancer{
 		cc:            cc,
 		pickerBuilder: bb.pickerBuilder,
@@ -259,6 +259,6 @@ type errPicker struct {
 	err error // Pick() always returns this err.
 }
 
-func (p *errPicker) Pick(info balancer.PickInfo) (balancer.PickResult, error) {
+func (p *errPicker) Pick(balancer.PickInfo) (balancer.PickResult, error) {
 	return balancer.PickResult{}, p.err
 }

--- a/balancer/base/balancer_test.go
+++ b/balancer/base/balancer_test.go
@@ -44,7 +44,7 @@ type testSubConn struct {
 	updateState func(balancer.SubConnState)
 }
 
-func (sc *testSubConn) UpdateAddresses(addresses []resolver.Address) {}
+func (sc *testSubConn) UpdateAddresses([]resolver.Address) {}
 
 func (sc *testSubConn) Connect() {}
 
@@ -88,7 +88,7 @@ func TestBaseBalancerReserveAttributes(t *testing.T) {
 	}
 	pickBuilder := &testPickBuilder{validate: v}
 	b := (&baseBuilder{pickerBuilder: pickBuilder}).Build(&testClientConn{
-		newSubConn: func(addrs []resolver.Address, opts balancer.NewSubConnOptions) (balancer.SubConn, error) {
+		newSubConn: func(_ []resolver.Address, opts balancer.NewSubConnOptions) (balancer.SubConn, error) {
 			return &testSubConn{updateState: opts.StateListener}, nil
 		},
 	}, balancer.BuildOptions{}).(*baseBalancer)

--- a/balancer/endpointsharding/endpointsharding.go
+++ b/balancer/endpointsharding/endpointsharding.go
@@ -165,7 +165,7 @@ func (es *endpointSharding) ResolverError(err error) {
 	}
 }
 
-func (es *endpointSharding) UpdateSubConnState(sc balancer.SubConn, state balancer.SubConnState) {
+func (es *endpointSharding) UpdateSubConnState(balancer.SubConn, balancer.SubConnState) {
 	// UpdateSubConnState is deprecated.
 }
 

--- a/balancer/endpointsharding/endpointsharding_test.go
+++ b/balancer/endpointsharding/endpointsharding_test.go
@@ -79,7 +79,7 @@ func (fakePetioleBuilder) Build(cc balancer.ClientConn, opts balancer.BuildOptio
 	return fp
 }
 
-func (fakePetioleBuilder) ParseConfig(s json.RawMessage) (serviceconfig.LoadBalancingConfig, error) {
+func (fakePetioleBuilder) ParseConfig(json.RawMessage) (serviceconfig.LoadBalancingConfig, error) {
 	return nil, nil
 }
 

--- a/balancer/grpclb/grpclb_test.go
+++ b/balancer/grpclb/grpclb_test.go
@@ -126,7 +126,7 @@ func (c *serverNameCheckCreds) Info() credentials.ProtocolInfo {
 func (c *serverNameCheckCreds) Clone() credentials.TransportCredentials {
 	return &serverNameCheckCreds{}
 }
-func (c *serverNameCheckCreds) OverrideServerName(s string) error {
+func (c *serverNameCheckCreds) OverrideServerName(string) error {
 	return nil
 }
 
@@ -307,7 +307,7 @@ type testServer struct {
 
 const testmdkey = "testmd"
 
-func (s *testServer) EmptyCall(ctx context.Context, in *testpb.Empty) (*testpb.Empty, error) {
+func (s *testServer) EmptyCall(ctx context.Context, _ *testpb.Empty) (*testpb.Empty, error) {
 	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
 		return nil, status.Error(codes.Internal, "failed to receive metadata")
@@ -319,7 +319,7 @@ func (s *testServer) EmptyCall(ctx context.Context, in *testpb.Empty) (*testpb.E
 	return &testpb.Empty{}, nil
 }
 
-func (s *testServer) FullDuplexCall(stream testgrpc.TestService_FullDuplexCallServer) error {
+func (s *testServer) FullDuplexCall(testgrpc.TestService_FullDuplexCallServer) error {
 	return nil
 }
 
@@ -1378,7 +1378,7 @@ func (s) TestGRPCLBWithTargetNameFieldInConfig(t *testing.T) {
 
 type failPreRPCCred struct{}
 
-func (failPreRPCCred) GetRequestMetadata(ctx context.Context, uri ...string) (map[string]string, error) {
+func (failPreRPCCred) GetRequestMetadata(_ context.Context, uri ...string) (map[string]string, error) {
 	if strings.Contains(uri[0], failtosendURI) {
 		return nil, fmt.Errorf("rpc should fail to send")
 	}
@@ -1619,7 +1619,7 @@ func (s) TestGRPCLBStatsStreamingFailedToSend(t *testing.T) {
 func (s) TestGRPCLBStatsQuashEmpty(t *testing.T) {
 	ch := make(chan *lbpb.ClientStats)
 	defer close(ch)
-	if err := runAndCheckStats(t, false, ch, func(cc *grpc.ClientConn) {
+	if err := runAndCheckStats(t, false, ch, func(*grpc.ClientConn) {
 		// Perform no RPCs; wait for load reports to start, which should be
 		// zero, then expect no other load report within 5x the update
 		// interval.

--- a/balancer/grpclb/grpclb_util_test.go
+++ b/balancer/grpclb/grpclb_util_test.go
@@ -52,7 +52,7 @@ func newMockClientConn() *mockClientConn {
 	}
 }
 
-func (mcc *mockClientConn) NewSubConn(addrs []resolver.Address, opts balancer.NewSubConnOptions) (balancer.SubConn, error) {
+func (mcc *mockClientConn) NewSubConn(addrs []resolver.Address, _ balancer.NewSubConnOptions) (balancer.SubConn, error) {
 	sc := &mockSubConn{mcc: mcc}
 	mcc.mu.Lock()
 	defer mcc.mu.Unlock()

--- a/balancer/leastrequest/balancer_test.go
+++ b/balancer/leastrequest/balancer_test.go
@@ -127,7 +127,7 @@ func setupBackends(t *testing.T) []string {
 	// Construct and start three working backends.
 	for i := 0; i < numBackends; i++ {
 		backend := &stubserver.StubServer{
-			EmptyCallF: func(ctx context.Context, in *testpb.Empty) (*testpb.Empty, error) {
+			EmptyCallF: func(context.Context, *testpb.Empty) (*testpb.Empty, error) {
 				return &testpb.Empty{}, nil
 			},
 			FullDuplexCallF: func(stream testgrpc.TestService_FullDuplexCallServer) error {

--- a/balancer/pickfirst/pickfirst.go
+++ b/balancer/pickfirst/pickfirst.go
@@ -50,7 +50,7 @@ const (
 
 type pickfirstBuilder struct{}
 
-func (pickfirstBuilder) Build(cc balancer.ClientConn, opt balancer.BuildOptions) balancer.Balancer {
+func (pickfirstBuilder) Build(cc balancer.ClientConn, _ balancer.BuildOptions) balancer.Balancer {
 	b := &pickfirstBalancer{cc: cc}
 	b.logger = internalgrpclog.NewPrefixLogger(logger, fmt.Sprintf(logPrefix, b))
 	return b

--- a/balancer/rls/balancer_test.go
+++ b/balancer/rls/balancer_test.go
@@ -69,11 +69,11 @@ func (s) TestConfigUpdate_ControlChannel(t *testing.T) {
 	// Start a couple of test backends, and set up the fake RLS servers to return
 	// these as a target in the RLS response.
 	backendCh1, backendAddress1 := startBackend(t)
-	rlsServer1.SetResponseCallback(func(_ context.Context, req *rlspb.RouteLookupRequest) *rlstest.RouteLookupResponse {
+	rlsServer1.SetResponseCallback(func(_ context.Context, _ *rlspb.RouteLookupRequest) *rlstest.RouteLookupResponse {
 		return &rlstest.RouteLookupResponse{Resp: &rlspb.RouteLookupResponse{Targets: []string{backendAddress1}}}
 	})
 	backendCh2, backendAddress2 := startBackend(t)
-	rlsServer2.SetResponseCallback(func(_ context.Context, req *rlspb.RouteLookupRequest) *rlstest.RouteLookupResponse {
+	rlsServer2.SetResponseCallback(func(context.Context, *rlspb.RouteLookupRequest) *rlstest.RouteLookupResponse {
 		return &rlstest.RouteLookupResponse{Resp: &rlspb.RouteLookupResponse{Targets: []string{backendAddress2}}}
 	})
 
@@ -155,7 +155,7 @@ func (s) TestConfigUpdate_ControlChannelWithCreds(t *testing.T) {
 	// and set up the fake RLS server to return this as the target in the RLS
 	// response.
 	backendCh, backendAddress := startBackend(t, grpc.Creds(serverCreds))
-	rlsServer.SetResponseCallback(func(_ context.Context, req *rlspb.RouteLookupRequest) *rlstest.RouteLookupResponse {
+	rlsServer.SetResponseCallback(func(_ context.Context, _ *rlspb.RouteLookupRequest) *rlstest.RouteLookupResponse {
 		return &rlstest.RouteLookupResponse{Resp: &rlspb.RouteLookupResponse{Targets: []string{backendAddress}}}
 	})
 
@@ -219,7 +219,7 @@ func (s) TestConfigUpdate_ControlChannelServiceConfig(t *testing.T) {
 	// Start a test backend, and set up the fake RLS server to return this as a
 	// target in the RLS response.
 	backendCh, backendAddress := startBackend(t)
-	rlsServer.SetResponseCallback(func(_ context.Context, req *rlspb.RouteLookupRequest) *rlstest.RouteLookupResponse {
+	rlsServer.SetResponseCallback(func(_ context.Context, _ *rlspb.RouteLookupRequest) *rlstest.RouteLookupResponse {
 		return &rlstest.RouteLookupResponse{Resp: &rlspb.RouteLookupResponse{Targets: []string{backendAddress}}}
 	})
 
@@ -300,7 +300,7 @@ func (s) TestConfigUpdate_ChildPolicyConfigs(t *testing.T) {
 	testBackendCh, testBackendAddress := startBackend(t)
 
 	// Set up the RLS server to respond with the test backend.
-	rlsServer.SetResponseCallback(func(_ context.Context, req *rlspb.RouteLookupRequest) *rlstest.RouteLookupResponse {
+	rlsServer.SetResponseCallback(func(_ context.Context, _ *rlspb.RouteLookupRequest) *rlstest.RouteLookupResponse {
 		return &rlstest.RouteLookupResponse{Resp: &rlspb.RouteLookupResponse{Targets: []string{testBackendAddress}}}
 	})
 
@@ -521,7 +521,7 @@ func (s) TestConfigUpdate_BadChildPolicyConfigs(t *testing.T) {
 	// Set up the RLS server to respond with a bad target field which is expected
 	// to cause the child policy's ParseTarget to fail and should result in the LB
 	// policy creating a lame child policy wrapper.
-	rlsServer.SetResponseCallback(func(_ context.Context, req *rlspb.RouteLookupRequest) *rlstest.RouteLookupResponse {
+	rlsServer.SetResponseCallback(func(_ context.Context, _ *rlspb.RouteLookupRequest) *rlstest.RouteLookupResponse {
 		return &rlstest.RouteLookupResponse{Resp: &rlspb.RouteLookupResponse{Targets: []string{e2e.RLSChildPolicyBadTarget}}}
 	})
 
@@ -590,7 +590,7 @@ func (s) TestConfigUpdate_DataCacheSizeDecrease(t *testing.T) {
 	// these as targets in the RLS response, based on request keys.
 	backendCh1, backendAddress1 := startBackend(t)
 	backendCh2, backendAddress2 := startBackend(t)
-	rlsServer.SetResponseCallback(func(ctx context.Context, req *rlspb.RouteLookupRequest) *rlstest.RouteLookupResponse {
+	rlsServer.SetResponseCallback(func(_ context.Context, req *rlspb.RouteLookupRequest) *rlstest.RouteLookupResponse {
 		if req.KeyMap["k1"] == "v1" {
 			return &rlstest.RouteLookupResponse{Resp: &rlspb.RouteLookupResponse{Targets: []string{backendAddress1}}}
 		}
@@ -717,7 +717,7 @@ func (s) TestPickerUpdateOnDataCacheSizeDecrease(t *testing.T) {
 	// these as targets in the RLS response, based on request keys.
 	backendCh1, backendAddress1 := startBackend(t)
 	backendCh2, backendAddress2 := startBackend(t)
-	rlsServer.SetResponseCallback(func(ctx context.Context, req *rlspb.RouteLookupRequest) *rlstest.RouteLookupResponse {
+	rlsServer.SetResponseCallback(func(_ context.Context, req *rlspb.RouteLookupRequest) *rlstest.RouteLookupResponse {
 		if req.KeyMap["k1"] == "v1" {
 			return &rlstest.RouteLookupResponse{Resp: &rlspb.RouteLookupResponse{Targets: []string{backendAddress1}}}
 		}
@@ -859,7 +859,7 @@ func (s) TestDataCachePurging(t *testing.T) {
 	// Start a test backend, and set up the fake RLS server to return this as a
 	// target in the RLS response.
 	backendCh, backendAddress := startBackend(t)
-	rlsServer.SetResponseCallback(func(_ context.Context, req *rlspb.RouteLookupRequest) *rlstest.RouteLookupResponse {
+	rlsServer.SetResponseCallback(func(_ context.Context, _ *rlspb.RouteLookupRequest) *rlstest.RouteLookupResponse {
 		return &rlstest.RouteLookupResponse{Resp: &rlspb.RouteLookupResponse{Targets: []string{backendAddress}}}
 	})
 
@@ -950,7 +950,7 @@ func (s) TestControlChannelConnectivityStateMonitoring(t *testing.T) {
 	// Start a test backend, and set up the fake RLS server to return this as a
 	// target in the RLS response.
 	backendCh, backendAddress := startBackend(t)
-	rlsServer.SetResponseCallback(func(_ context.Context, req *rlspb.RouteLookupRequest) *rlstest.RouteLookupResponse {
+	rlsServer.SetResponseCallback(func(_ context.Context, _ *rlspb.RouteLookupRequest) *rlstest.RouteLookupResponse {
 		return &rlstest.RouteLookupResponse{Resp: &rlspb.RouteLookupResponse{Targets: []string{backendAddress}}}
 	})
 
@@ -1121,7 +1121,7 @@ func (s) TestUpdateStatePauses(t *testing.T) {
 
 	// Start a test backend and set the RLS server to respond with it.
 	testBackendCh, testBackendAddress := startBackend(t)
-	rlsServer.SetResponseCallback(func(_ context.Context, req *rlspb.RouteLookupRequest) *rlstest.RouteLookupResponse {
+	rlsServer.SetResponseCallback(func(_ context.Context, _ *rlspb.RouteLookupRequest) *rlstest.RouteLookupResponse {
 		return &rlstest.RouteLookupResponse{Resp: &rlspb.RouteLookupResponse{Targets: []string{testBackendAddress}}}
 	})
 

--- a/balancer/rls/control_channel_test.go
+++ b/balancer/rls/control_channel_test.go
@@ -74,7 +74,7 @@ func (s) TestLookupFailure(t *testing.T) {
 	overrideAdaptiveThrottler(t, neverThrottlingThrottler())
 
 	// Setup the RLS server to respond with errors.
-	rlsServer.SetResponseCallback(func(_ context.Context, req *rlspb.RouteLookupRequest) *rlstest.RouteLookupResponse {
+	rlsServer.SetResponseCallback(func(context.Context, *rlspb.RouteLookupRequest) *rlstest.RouteLookupResponse {
 		return &rlstest.RouteLookupResponse{Err: errors.New("rls failure")}
 	})
 
@@ -109,7 +109,7 @@ func (s) TestLookupFailure(t *testing.T) {
 // respond within the configured rpc timeout.
 func (s) TestLookupDeadlineExceeded(t *testing.T) {
 	// A unary interceptor which returns a status error with DeadlineExceeded.
-	interceptor := func(ctx context.Context, req any, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp any, err error) {
+	interceptor := func(context.Context, any, *grpc.UnaryServerInfo, grpc.UnaryHandler) (resp any, err error) {
 		return nil, status.Error(codes.DeadlineExceeded, "deadline exceeded")
 	}
 
@@ -260,7 +260,7 @@ func testControlChannelCredsSuccess(t *testing.T, sopts []grpc.ServerOption, bop
 	overrideAdaptiveThrottler(t, neverThrottlingThrottler())
 
 	// Setup the RLS server to respond with a valid response.
-	rlsServer.SetResponseCallback(func(_ context.Context, req *rlspb.RouteLookupRequest) *rlstest.RouteLookupResponse {
+	rlsServer.SetResponseCallback(func(context.Context, *rlspb.RouteLookupRequest) *rlstest.RouteLookupResponse {
 		return lookupResponse
 	})
 

--- a/balancer/rls/helpers_test.go
+++ b/balancer/rls/helpers_test.go
@@ -61,7 +61,7 @@ type fakeBackoffStrategy struct {
 	backoff time.Duration
 }
 
-func (f *fakeBackoffStrategy) Backoff(retries int) time.Duration {
+func (f *fakeBackoffStrategy) Backoff(int) time.Duration {
 	return f.backoff
 }
 
@@ -171,7 +171,7 @@ func startBackend(t *testing.T, sopts ...grpc.ServerOption) (rpcCh chan struct{}
 
 	rpcCh = make(chan struct{}, 1)
 	backend := &stubserver.StubServer{
-		EmptyCallF: func(ctx context.Context, in *testpb.Empty) (*testpb.Empty, error) {
+		EmptyCallF: func(context.Context, *testpb.Empty) (*testpb.Empty, error) {
 			select {
 			case rpcCh <- struct{}{}:
 			default:

--- a/balancer/weightedroundrobin/balancer.go
+++ b/balancer/weightedroundrobin/balancer.go
@@ -440,7 +440,7 @@ func (p *picker) start(ctx context.Context) {
 	}()
 }
 
-func (p *picker) Pick(info balancer.PickInfo) (balancer.PickResult, error) {
+func (p *picker) Pick(balancer.PickInfo) (balancer.PickResult, error) {
 	// Read the scheduler atomically.  All scheduler operations are threadsafe,
 	// and if the scheduler is replaced during this usage, we want to use the
 	// scheduler that was live when the pick started.

--- a/balancer/weightedtarget/weightedtarget_test.go
+++ b/balancer/weightedtarget/weightedtarget_test.go
@@ -1327,7 +1327,7 @@ func (s) TestUpdateStatePauses(t *testing.T) {
 	cc := &tcc{BalancerClientConn: testutils.NewBalancerClientConn(t)}
 
 	balFuncs := stub.BalancerFuncs{
-		UpdateClientConnState: func(bd *stub.BalancerData, s balancer.ClientConnState) error {
+		UpdateClientConnState: func(bd *stub.BalancerData, _ balancer.ClientConnState) error {
 			bd.ClientConn.UpdateState(balancer.State{ConnectivityState: connectivity.TransientFailure, Picker: nil})
 			bd.ClientConn.UpdateState(balancer.State{ConnectivityState: connectivity.Ready, Picker: nil})
 			return nil

--- a/balancer_wrapper.go
+++ b/balancer_wrapper.go
@@ -192,7 +192,7 @@ func (ccb *ccBalancerWrapper) NewSubConn(addrs []resolver.Address, opts balancer
 	return acbw, nil
 }
 
-func (ccb *ccBalancerWrapper) RemoveSubConn(sc balancer.SubConn) {
+func (ccb *ccBalancerWrapper) RemoveSubConn(balancer.SubConn) {
 	// The graceful switch balancer will never call this.
 	logger.Errorf("ccb RemoveSubConn(%v) called unexpectedly, sc")
 }

--- a/benchmark/benchmain/main.go
+++ b/benchmark/benchmain/main.go
@@ -384,7 +384,7 @@ func makeClients(bf stats.Features) ([]testgrpc.BenchmarkServiceClient, func()) 
 	if bf.UseBufConn {
 		bcLis := bufconn.Listen(256 * 1024)
 		lis = bcLis
-		opts = append(opts, grpc.WithContextDialer(func(ctx context.Context, address string) (net.Conn, error) {
+		opts = append(opts, grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
 			return nw.ContextDialer(func(context.Context, string, string) (net.Conn, error) {
 				return bcLis.Dial()
 			})(ctx, "", "")
@@ -395,7 +395,7 @@ func makeClients(bf stats.Features) ([]testgrpc.BenchmarkServiceClient, func()) 
 		if err != nil {
 			logger.Fatalf("Failed to listen: %v", err)
 		}
-		opts = append(opts, grpc.WithContextDialer(func(ctx context.Context, address string) (net.Conn, error) {
+		opts = append(opts, grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
 			return nw.ContextDialer((internal.NetDialerWithTCPKeepalive().DialContext))(ctx, "tcp", lis.Addr().String())
 		}))
 	}
@@ -418,7 +418,7 @@ func makeClients(bf stats.Features) ([]testgrpc.BenchmarkServiceClient, func()) 
 
 func makeFuncUnary(bf stats.Features) (rpcCallFunc, rpcCleanupFunc) {
 	clients, cleanup := makeClients(bf)
-	return func(cn, pos int) {
+	return func(cn, _ int) {
 		reqSizeBytes := bf.ReqSizeBytes
 		respSizeBytes := bf.RespSizeBytes
 		if bf.ReqPayloadCurve != nil {

--- a/benchmark/benchmark.go
+++ b/benchmark/benchmark.go
@@ -69,7 +69,7 @@ type testServer struct {
 	testgrpc.UnimplementedBenchmarkServiceServer
 }
 
-func (s *testServer) UnaryCall(ctx context.Context, in *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
+func (s *testServer) UnaryCall(_ context.Context, in *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
 	return &testpb.SimpleResponse{
 		Payload: NewPayload(in.ResponseType, int(in.ResponseSize)),
 	}, nil
@@ -218,7 +218,7 @@ type byteBufServer struct {
 
 // UnaryCall is an empty function and is not used for benchmark.
 // If bytebuf UnaryCall benchmark is needed later, the function body needs to be updated.
-func (s *byteBufServer) UnaryCall(ctx context.Context, in *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
+func (s *byteBufServer) UnaryCall(context.Context, *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
 	return &testpb.SimpleResponse{}, nil
 }
 
@@ -318,7 +318,7 @@ func DoStreamingRoundTripPreloaded(stream testgrpc.BenchmarkService_StreamingCal
 }
 
 // DoByteBufStreamingRoundTrip performs a round trip for a single streaming rpc, using a custom codec for byte buffer.
-func DoByteBufStreamingRoundTrip(stream testgrpc.BenchmarkService_StreamingCallClient, reqSize, respSize int) error {
+func DoByteBufStreamingRoundTrip(stream testgrpc.BenchmarkService_StreamingCallClient, reqSize, _ int) error {
 	out := make([]byte, reqSize)
 	if err := stream.(grpc.ClientStream).SendMsg(&out); err != nil {
 		return fmt.Errorf("/BenchmarkService/StreamingCall.(ClientStream).SendMsg(_) = %v, want <nil>", err)

--- a/benchmark/latency/latency_test.go
+++ b/benchmark/latency/latency_test.go
@@ -43,12 +43,12 @@ type bufConn struct {
 	*bytes.Buffer
 }
 
-func (bufConn) Close() error                       { panic("unimplemented") }
-func (bufConn) LocalAddr() net.Addr                { panic("unimplemented") }
-func (bufConn) RemoteAddr() net.Addr               { panic("unimplemented") }
-func (bufConn) SetDeadline(t time.Time) error      { panic("unimplemented") }
-func (bufConn) SetReadDeadline(t time.Time) error  { panic("unimplemented") }
-func (bufConn) SetWriteDeadline(t time.Time) error { panic("unimplemented") }
+func (bufConn) Close() error                     { panic("unimplemented") }
+func (bufConn) LocalAddr() net.Addr              { panic("unimplemented") }
+func (bufConn) RemoteAddr() net.Addr             { panic("unimplemented") }
+func (bufConn) SetDeadline(time.Time) error      { panic("unimplemented") }
+func (bufConn) SetReadDeadline(time.Time) error  { panic("unimplemented") }
+func (bufConn) SetWriteDeadline(time.Time) error { panic("unimplemented") }
 
 func restoreHooks() func() {
 	s := sleep

--- a/benchmark/worker/main.go
+++ b/benchmark/worker/main.go
@@ -188,12 +188,12 @@ func (s *workerServer) RunClient(stream testgrpc.WorkerService_RunClientServer) 
 	}
 }
 
-func (s *workerServer) CoreCount(ctx context.Context, in *testpb.CoreRequest) (*testpb.CoreResponse, error) {
+func (s *workerServer) CoreCount(context.Context, *testpb.CoreRequest) (*testpb.CoreResponse, error) {
 	logger.Infof("core count: %v", runtime.NumCPU())
 	return &testpb.CoreResponse{Cores: int32(runtime.NumCPU())}, nil
 }
 
-func (s *workerServer) QuitWorker(ctx context.Context, in *testpb.Void) (*testpb.Void, error) {
+func (s *workerServer) QuitWorker(context.Context, *testpb.Void) (*testpb.Void, error) {
 	logger.Infof("quitting worker")
 	s.stop <- true
 	return &testpb.Void{}, nil

--- a/channelz/service/service.go
+++ b/channelz/service/service.go
@@ -51,7 +51,7 @@ type serverImpl struct {
 	channelzgrpc.UnimplementedChannelzServer
 }
 
-func (s *serverImpl) GetChannel(ctx context.Context, req *channelzpb.GetChannelRequest) (*channelzpb.GetChannelResponse, error) {
+func (s *serverImpl) GetChannel(_ context.Context, req *channelzpb.GetChannelRequest) (*channelzpb.GetChannelResponse, error) {
 	ch, err := protoconv.GetChannel(req.GetChannelId())
 	if err != nil {
 		return nil, err
@@ -59,13 +59,13 @@ func (s *serverImpl) GetChannel(ctx context.Context, req *channelzpb.GetChannelR
 	return &channelzpb.GetChannelResponse{Channel: ch}, nil
 }
 
-func (s *serverImpl) GetTopChannels(ctx context.Context, req *channelzpb.GetTopChannelsRequest) (*channelzpb.GetTopChannelsResponse, error) {
+func (s *serverImpl) GetTopChannels(_ context.Context, req *channelzpb.GetTopChannelsRequest) (*channelzpb.GetTopChannelsResponse, error) {
 	resp := &channelzpb.GetTopChannelsResponse{}
 	resp.Channel, resp.End = protoconv.GetTopChannels(req.GetStartChannelId(), int(req.GetMaxResults()))
 	return resp, nil
 }
 
-func (s *serverImpl) GetServer(ctx context.Context, req *channelzpb.GetServerRequest) (*channelzpb.GetServerResponse, error) {
+func (s *serverImpl) GetServer(_ context.Context, req *channelzpb.GetServerRequest) (*channelzpb.GetServerResponse, error) {
 	srv, err := protoconv.GetServer(req.GetServerId())
 	if err != nil {
 		return nil, err
@@ -73,13 +73,13 @@ func (s *serverImpl) GetServer(ctx context.Context, req *channelzpb.GetServerReq
 	return &channelzpb.GetServerResponse{Server: srv}, nil
 }
 
-func (s *serverImpl) GetServers(ctx context.Context, req *channelzpb.GetServersRequest) (*channelzpb.GetServersResponse, error) {
+func (s *serverImpl) GetServers(_ context.Context, req *channelzpb.GetServersRequest) (*channelzpb.GetServersResponse, error) {
 	resp := &channelzpb.GetServersResponse{}
 	resp.Server, resp.End = protoconv.GetServers(req.GetStartServerId(), int(req.GetMaxResults()))
 	return resp, nil
 }
 
-func (s *serverImpl) GetSubchannel(ctx context.Context, req *channelzpb.GetSubchannelRequest) (*channelzpb.GetSubchannelResponse, error) {
+func (s *serverImpl) GetSubchannel(_ context.Context, req *channelzpb.GetSubchannelRequest) (*channelzpb.GetSubchannelResponse, error) {
 	subChan, err := protoconv.GetSubChannel(req.GetSubchannelId())
 	if err != nil {
 		return nil, err
@@ -87,13 +87,13 @@ func (s *serverImpl) GetSubchannel(ctx context.Context, req *channelzpb.GetSubch
 	return &channelzpb.GetSubchannelResponse{Subchannel: subChan}, nil
 }
 
-func (s *serverImpl) GetServerSockets(ctx context.Context, req *channelzpb.GetServerSocketsRequest) (*channelzpb.GetServerSocketsResponse, error) {
+func (s *serverImpl) GetServerSockets(_ context.Context, req *channelzpb.GetServerSocketsRequest) (*channelzpb.GetServerSocketsResponse, error) {
 	resp := &channelzpb.GetServerSocketsResponse{}
 	resp.SocketRef, resp.End = protoconv.GetServerSockets(req.GetServerId(), req.GetStartSocketId(), int(req.GetMaxResults()))
 	return resp, nil
 }
 
-func (s *serverImpl) GetSocket(ctx context.Context, req *channelzpb.GetSocketRequest) (*channelzpb.GetSocketResponse, error) {
+func (s *serverImpl) GetSocket(_ context.Context, req *channelzpb.GetSocketRequest) (*channelzpb.GetSocketResponse, error) {
 	socket, err := protoconv.GetSocket(req.GetSocketId())
 	if err != nil {
 		return nil, err

--- a/clientconn_parsed_target_test.go
+++ b/clientconn_parsed_target_test.go
@@ -268,7 +268,7 @@ func (s) TestParsedTarget_WithCustomDialer(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.target, func(t *testing.T) {
 			addrCh := make(chan string, 1)
-			dialer := func(ctx context.Context, address string) (net.Conn, error) {
+			dialer := func(_ context.Context, address string) (net.Conn, error) {
 				addrCh <- address
 				return nil, errors.New("dialer error")
 			}

--- a/cmd/protoc-gen-go-grpc/grpc.go
+++ b/cmd/protoc-gen-go-grpc/grpc.go
@@ -73,11 +73,11 @@ func (serviceGenerateHelper) generateClientStruct(g *protogen.GeneratedFile, cli
 	g.P()
 }
 
-func (serviceGenerateHelper) generateNewClientDefinitions(g *protogen.GeneratedFile, service *protogen.Service, clientName string) {
+func (serviceGenerateHelper) generateNewClientDefinitions(g *protogen.GeneratedFile, _ *protogen.Service, clientName string) {
 	g.P("return &", unexport(clientName), "{cc}")
 }
 
-func (serviceGenerateHelper) generateUnimplementedServerType(gen *protogen.Plugin, file *protogen.File, g *protogen.GeneratedFile, service *protogen.Service) {
+func (serviceGenerateHelper) generateUnimplementedServerType(_ *protogen.Plugin, _ *protogen.File, g *protogen.GeneratedFile, service *protogen.Service) {
 	serverType := service.GoName + "Server"
 	mustOrShould := "must"
 	if !*requireUnimplemented {
@@ -119,7 +119,7 @@ func (serviceGenerateHelper) generateServerFunctions(gen *protogen.Plugin, file 
 	genServiceDesc(file, g, serviceDescVar, serverType, service, handlerNames)
 }
 
-func (serviceGenerateHelper) formatHandlerFuncName(service *protogen.Service, hname string) string {
+func (serviceGenerateHelper) formatHandlerFuncName(_ *protogen.Service, hname string) string {
 	return hname
 }
 
@@ -354,7 +354,7 @@ func clientStreamInterface(g *protogen.GeneratedFile, method *protogen.Method) s
 	return g.QualifiedGoIdent(grpcPackage.Ident("ServerStreamingClient")) + "[" + g.QualifiedGoIdent(method.Output.GoIdent) + "]"
 }
 
-func genClientMethod(gen *protogen.Plugin, file *protogen.File, g *protogen.GeneratedFile, method *protogen.Method, index int) {
+func genClientMethod(_ *protogen.Plugin, _ *protogen.File, g *protogen.GeneratedFile, method *protogen.Method, index int) {
 	service := method.Parent
 	fmSymbol := helper.formatFullMethodSymbol(service, method)
 
@@ -522,7 +522,7 @@ func serverStreamInterface(g *protogen.GeneratedFile, method *protogen.Method) s
 	return g.QualifiedGoIdent(grpcPackage.Ident("ServerStreamingServer")) + "[" + g.QualifiedGoIdent(method.Output.GoIdent) + "]"
 }
 
-func genServerMethod(gen *protogen.Plugin, file *protogen.File, g *protogen.GeneratedFile, method *protogen.Method, hnameFuncNameFormatter func(string) string) string {
+func genServerMethod(_ *protogen.Plugin, _ *protogen.File, g *protogen.GeneratedFile, method *protogen.Method, hnameFuncNameFormatter func(string) string) string {
 	service := method.Parent
 	hname := fmt.Sprintf("_%s_%s_Handler", service.GoName, method.GoName)
 

--- a/credentials/alts/internal/handshaker/handshaker.go
+++ b/credentials/alts/internal/handshaker/handshaker.go
@@ -128,7 +128,7 @@ type altsHandshaker struct {
 // NewClientHandshaker creates a core.Handshaker that performs a client-side
 // ALTS handshake by acting as a proxy between the peer and the ALTS handshaker
 // service in the metadata server.
-func NewClientHandshaker(ctx context.Context, conn *grpc.ClientConn, c net.Conn, opts *ClientHandshakerOptions) (core.Handshaker, error) {
+func NewClientHandshaker(_ context.Context, conn *grpc.ClientConn, c net.Conn, opts *ClientHandshakerOptions) (core.Handshaker, error) {
 	return &altsHandshaker{
 		stream:     nil,
 		conn:       c,
@@ -141,7 +141,7 @@ func NewClientHandshaker(ctx context.Context, conn *grpc.ClientConn, c net.Conn,
 // NewServerHandshaker creates a core.Handshaker that performs a server-side
 // ALTS handshake by acting as a proxy between the peer and the ALTS handshaker
 // service in the metadata server.
-func NewServerHandshaker(ctx context.Context, conn *grpc.ClientConn, c net.Conn, opts *ServerHandshakerOptions) (core.Handshaker, error) {
+func NewServerHandshaker(_ context.Context, conn *grpc.ClientConn, c net.Conn, opts *ServerHandshakerOptions) (core.Handshaker, error) {
 	return &altsHandshaker{
 		stream:     nil,
 		conn:       c,

--- a/credentials/alts/internal/handshaker/handshaker_test.go
+++ b/credentials/alts/internal/handshaker/handshaker_test.go
@@ -273,7 +273,7 @@ func (t *testUnresponsiveRPCStream) Recv() (*altspb.HandshakerResp, error) {
 	return &altspb.HandshakerResp{}, nil
 }
 
-func (t *testUnresponsiveRPCStream) Send(req *altspb.HandshakerReq) error {
+func (t *testUnresponsiveRPCStream) Send(*altspb.HandshakerReq) error {
 	return nil
 }
 

--- a/credentials/alts/internal/testutil/testutil.go
+++ b/credentials/alts/internal/testutil/testutil.go
@@ -120,12 +120,12 @@ func NewUnresponsiveTestConn() net.Conn {
 }
 
 // Read reads from the in buffer.
-func (c *unresponsiveTestConn) Read(b []byte) (n int, err error) {
+func (c *unresponsiveTestConn) Read([]byte) (n int, err error) {
 	return 0, io.EOF
 }
 
 // Write writes to the out buffer.
-func (c *unresponsiveTestConn) Write(b []byte) (n int, err error) {
+func (c *unresponsiveTestConn) Write([]byte) (n int, err error) {
 	return 0, nil
 }
 

--- a/credentials/google/google_test.go
+++ b/credentials/google/google_test.go
@@ -43,11 +43,11 @@ type testCreds struct {
 	typ string
 }
 
-func (c *testCreds) ClientHandshake(ctx context.Context, authority string, rawConn net.Conn) (net.Conn, credentials.AuthInfo, error) {
+func (c *testCreds) ClientHandshake(context.Context, string, net.Conn) (net.Conn, credentials.AuthInfo, error) {
 	return nil, &testAuthInfo{typ: c.typ}, nil
 }
 
-func (c *testCreds) ServerHandshake(conn net.Conn) (net.Conn, credentials.AuthInfo, error) {
+func (c *testCreds) ServerHandshake(net.Conn) (net.Conn, credentials.AuthInfo, error) {
 	return nil, &testAuthInfo{typ: c.typ}, nil
 }
 

--- a/credentials/insecure/insecure.go
+++ b/credentials/insecure/insecure.go
@@ -40,7 +40,7 @@ func NewCredentials() credentials.TransportCredentials {
 // NoSecurity.
 type insecureTC struct{}
 
-func (insecureTC) ClientHandshake(ctx context.Context, _ string, conn net.Conn) (net.Conn, credentials.AuthInfo, error) {
+func (insecureTC) ClientHandshake(_ context.Context, _ string, conn net.Conn) (net.Conn, credentials.AuthInfo, error) {
 	return conn, info{credentials.CommonAuthInfo{SecurityLevel: credentials.NoSecurity}}, nil
 }
 

--- a/credentials/local/local.go
+++ b/credentials/local/local.go
@@ -77,7 +77,7 @@ func getSecurityLevel(network, addr string) (credentials.SecurityLevel, error) {
 	}
 }
 
-func (*localTC) ClientHandshake(ctx context.Context, authority string, conn net.Conn) (net.Conn, credentials.AuthInfo, error) {
+func (*localTC) ClientHandshake(_ context.Context, _ string, conn net.Conn) (net.Conn, credentials.AuthInfo, error) {
 	secLevel, err := getSecurityLevel(conn.RemoteAddr().Network(), conn.RemoteAddr().String())
 	if err != nil {
 		return nil, nil, err

--- a/credentials/oauth/oauth.go
+++ b/credentials/oauth/oauth.go
@@ -38,7 +38,7 @@ type TokenSource struct {
 }
 
 // GetRequestMetadata gets the request metadata as a map from a TokenSource.
-func (ts TokenSource) GetRequestMetadata(ctx context.Context, uri ...string) (map[string]string, error) {
+func (ts TokenSource) GetRequestMetadata(ctx context.Context, _ ...string) (map[string]string, error) {
 	token, err := ts.Token()
 	if err != nil {
 		return nil, err
@@ -127,7 +127,7 @@ func NewOauthAccess(token *oauth2.Token) credentials.PerRPCCredentials {
 	return oauthAccess{token: *token}
 }
 
-func (oa oauthAccess) GetRequestMetadata(ctx context.Context, uri ...string) (map[string]string, error) {
+func (oa oauthAccess) GetRequestMetadata(ctx context.Context, _ ...string) (map[string]string, error) {
 	ri, _ := credentials.RequestInfoFromContext(ctx)
 	if err := credentials.CheckSecurityLevel(ri.AuthInfo, credentials.PrivacyAndIntegrity); err != nil {
 		return nil, fmt.Errorf("unable to transfer oauthAccess PerRPCCredentials: %v", err)
@@ -156,7 +156,7 @@ type serviceAccount struct {
 	t      *oauth2.Token
 }
 
-func (s *serviceAccount) GetRequestMetadata(ctx context.Context, uri ...string) (map[string]string, error) {
+func (s *serviceAccount) GetRequestMetadata(ctx context.Context, _ ...string) (map[string]string, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if !s.t.Valid() {

--- a/credentials/sts/sts_test.go
+++ b/credentials/sts/sts_test.go
@@ -109,7 +109,7 @@ func createTestContext(ctx context.Context, s credentials.SecurityLevel) context
 // Read method.
 type errReader struct{}
 
-func (r errReader) Read(b []byte) (n int, err error) {
+func (r errReader) Read([]byte) (n int, err error) {
 	return 0, errors.New("read error")
 }
 
@@ -155,7 +155,7 @@ func overrideHTTPClient(fc *testutils.FakeHTTPClient) func() {
 // our tests.
 func overrideSubjectTokenGood() func() {
 	origReadSubjectTokenFrom := readSubjectTokenFrom
-	readSubjectTokenFrom = func(path string) ([]byte, error) {
+	readSubjectTokenFrom = func(string) ([]byte, error) {
 		return []byte(subjectTokenContents), nil
 	}
 	return func() { readSubjectTokenFrom = origReadSubjectTokenFrom }
@@ -164,7 +164,7 @@ func overrideSubjectTokenGood() func() {
 // Overrides the subject token read to always return an error.
 func overrideSubjectTokenError() func() {
 	origReadSubjectTokenFrom := readSubjectTokenFrom
-	readSubjectTokenFrom = func(path string) ([]byte, error) {
+	readSubjectTokenFrom = func(string) ([]byte, error) {
 		return nil, errors.New("error reading subject token")
 	}
 	return func() { readSubjectTokenFrom = origReadSubjectTokenFrom }
@@ -174,7 +174,7 @@ func overrideSubjectTokenError() func() {
 // our tests.
 func overrideActorTokenGood() func() {
 	origReadActorTokenFrom := readActorTokenFrom
-	readActorTokenFrom = func(path string) ([]byte, error) {
+	readActorTokenFrom = func(string) ([]byte, error) {
 		return []byte(actorTokenContents), nil
 	}
 	return func() { readActorTokenFrom = origReadActorTokenFrom }
@@ -183,7 +183,7 @@ func overrideActorTokenGood() func() {
 // Overrides the actor token read to always return an error.
 func overrideActorTokenError() func() {
 	origReadActorTokenFrom := readActorTokenFrom
-	readActorTokenFrom = func(path string) ([]byte, error) {
+	readActorTokenFrom = func(string) ([]byte, error) {
 		return nil, errors.New("error reading actor token")
 	}
 	return func() { readActorTokenFrom = origReadActorTokenFrom }

--- a/credentials/tls/certprovider/store.go
+++ b/credentials/tls/certprovider/store.go
@@ -58,7 +58,7 @@ type wrappedProvider struct {
 // closedProvider always returns errProviderClosed error.
 type closedProvider struct{}
 
-func (c closedProvider) KeyMaterial(ctx context.Context) (*KeyMaterial, error) {
+func (c closedProvider) KeyMaterial(context.Context) (*KeyMaterial, error) {
 	return nil, errProviderClosed
 }
 

--- a/credentials/xds/xds.go
+++ b/credentials/xds/xds.go
@@ -138,7 +138,7 @@ func (c *credsImpl) ClientHandshake(ctx context.Context, authority string, rawCo
 	if err != nil {
 		return nil, nil, err
 	}
-	cfg.VerifyPeerCertificate = func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
+	cfg.VerifyPeerCertificate = func(rawCerts [][]byte, _ [][]*x509.Certificate) error {
 		// Parse all raw certificates presented by the peer.
 		var certs []*x509.Certificate
 		for _, rc := range rawCerts {

--- a/credentials/xds/xds_client_test.go
+++ b/credentials/xds/xds_client_test.go
@@ -186,7 +186,7 @@ type fakeProvider struct {
 	err error
 }
 
-func (f *fakeProvider) KeyMaterial(ctx context.Context) (*certprovider.KeyMaterial, error) {
+func (f *fakeProvider) KeyMaterial(context.Context) (*certprovider.KeyMaterial, error) {
 	return f.km, f.err
 }
 
@@ -419,7 +419,7 @@ func (s) TestClientCredsHandshakeTimeout(t *testing.T) {
 	// server-side by simply blocking on the client-side handshake to timeout
 	// and not writing any handshake data.
 	hErr := errors.New("server handshake error")
-	ts := newTestServerWithHandshakeFunc(func(rawConn net.Conn) handshakeResult {
+	ts := newTestServerWithHandshakeFunc(func(net.Conn) handshakeResult {
 		<-clientDone
 		return handshakeResult{err: hErr}
 	})

--- a/examples/features/advancedtls/server/main.go
+++ b/examples/features/advancedtls/server/main.go
@@ -46,7 +46,7 @@ const goodServerWithCRLPort int = 50051
 const revokedServerWithCRLPort int = 50053
 const insecurePort int = 50054
 
-func (s *server) UnaryEcho(ctx context.Context, req *pb.EchoRequest) (*pb.EchoResponse, error) {
+func (s *server) UnaryEcho(_ context.Context, req *pb.EchoRequest) (*pb.EchoResponse, error) {
 	return &pb.EchoResponse{Message: req.Message}, nil
 }
 

--- a/examples/features/authentication/server/main.go
+++ b/examples/features/authentication/server/main.go
@@ -77,7 +77,7 @@ type ecServer struct {
 	pb.UnimplementedEchoServer
 }
 
-func (s *ecServer) UnaryEcho(ctx context.Context, req *pb.EchoRequest) (*pb.EchoResponse, error) {
+func (s *ecServer) UnaryEcho(_ context.Context, req *pb.EchoRequest) (*pb.EchoResponse, error) {
 	return &pb.EchoResponse{Message: req.Message}, nil
 }
 
@@ -97,7 +97,7 @@ func valid(authorization []string) bool {
 // the token is missing or invalid, the interceptor blocks execution of the
 // handler and returns an error. Otherwise, the interceptor invokes the unary
 // handler.
-func ensureValidToken(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+func ensureValidToken(ctx context.Context, req any, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
 	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
 		return nil, errMissingMetadata

--- a/examples/features/authz/server/main.go
+++ b/examples/features/authz/server/main.go
@@ -101,7 +101,7 @@ type server struct {
 	pb.UnimplementedEchoServer
 }
 
-func (s *server) UnaryEcho(ctx context.Context, in *pb.EchoRequest) (*pb.EchoResponse, error) {
+func (s *server) UnaryEcho(_ context.Context, in *pb.EchoRequest) (*pb.EchoResponse, error) {
 	fmt.Printf("unary echoing message %q\n", in.Message)
 	return &pb.EchoResponse{Message: in.Message}, nil
 }
@@ -144,7 +144,7 @@ func isAuthenticated(authorization []string) (username string, err error) {
 // authUnaryInterceptor looks up the authorization header from the incoming RPC context,
 // retrieves the username from it and creates a new context with the username before invoking
 // the provided handler.
-func authUnaryInterceptor(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+func authUnaryInterceptor(ctx context.Context, req any, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
 	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
 		return nil, errMissingMetadata
@@ -175,7 +175,7 @@ func newWrappedStream(ctx context.Context, s grpc.ServerStream) grpc.ServerStrea
 // authStreamInterceptor looks up the authorization header from the incoming RPC context,
 // retrieves the username from it and creates a new context with the username before invoking
 // the provided handler.
-func authStreamInterceptor(srv any, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+func authStreamInterceptor(srv any, ss grpc.ServerStream, _ *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 	md, ok := metadata.FromIncomingContext(ss.Context())
 	if !ok {
 		return errMissingMetadata

--- a/examples/features/compression/server/main.go
+++ b/examples/features/compression/server/main.go
@@ -38,7 +38,7 @@ type server struct {
 	pb.UnimplementedEchoServer
 }
 
-func (s *server) UnaryEcho(ctx context.Context, in *pb.EchoRequest) (*pb.EchoResponse, error) {
+func (s *server) UnaryEcho(_ context.Context, in *pb.EchoRequest) (*pb.EchoResponse, error) {
 	fmt.Printf("UnaryEcho called with message %q\n", in.GetMessage())
 	return &pb.EchoResponse{Message: in.Message}, nil
 }

--- a/examples/features/csm_observability/server/main.go
+++ b/examples/features/csm_observability/server/main.go
@@ -46,7 +46,7 @@ type echoServer struct {
 	addr string
 }
 
-func (s *echoServer) UnaryEcho(ctx context.Context, req *pb.EchoRequest) (*pb.EchoResponse, error) {
+func (s *echoServer) UnaryEcho(_ context.Context, req *pb.EchoRequest) (*pb.EchoResponse, error) {
 	return &pb.EchoResponse{Message: fmt.Sprintf("%s (from %s)", req.Message, s.addr)}, nil
 }
 

--- a/examples/features/customloadbalancer/server/main.go
+++ b/examples/features/customloadbalancer/server/main.go
@@ -38,7 +38,7 @@ type echoServer struct {
 	addr string
 }
 
-func (s *echoServer) UnaryEcho(ctx context.Context, req *pb.EchoRequest) (*pb.EchoResponse, error) {
+func (s *echoServer) UnaryEcho(_ context.Context, req *pb.EchoRequest) (*pb.EchoResponse, error) {
 	return &pb.EchoResponse{Message: fmt.Sprintf("%s (from %s)", req.Message, s.addr)}, nil
 }
 

--- a/examples/features/debugging/server/main.go
+++ b/examples/features/debugging/server/main.go
@@ -42,7 +42,7 @@ type server struct {
 }
 
 // SayHello implements helloworld.GreeterServer
-func (s *server) SayHello(ctx context.Context, in *pb.HelloRequest) (*pb.HelloReply, error) {
+func (s *server) SayHello(_ context.Context, in *pb.HelloRequest) (*pb.HelloReply, error) {
 	return &pb.HelloReply{Message: "Hello " + in.Name}, nil
 }
 
@@ -52,7 +52,7 @@ type slowServer struct {
 }
 
 // SayHello implements helloworld.GreeterServer
-func (s *slowServer) SayHello(ctx context.Context, in *pb.HelloRequest) (*pb.HelloReply, error) {
+func (s *slowServer) SayHello(_ context.Context, in *pb.HelloRequest) (*pb.HelloReply, error) {
 	// Delay 100ms ~ 200ms before replying
 	time.Sleep(time.Duration(100+rand.Intn(100)) * time.Millisecond)
 	return &pb.HelloReply{Message: "Hello " + in.Name}, nil

--- a/examples/features/encryption/ALTS/server/main.go
+++ b/examples/features/encryption/ALTS/server/main.go
@@ -38,7 +38,7 @@ type ecServer struct {
 	pb.UnimplementedEchoServer
 }
 
-func (s *ecServer) UnaryEcho(ctx context.Context, req *pb.EchoRequest) (*pb.EchoResponse, error) {
+func (s *ecServer) UnaryEcho(_ context.Context, req *pb.EchoRequest) (*pb.EchoResponse, error) {
 	return &pb.EchoResponse{Message: req.Message}, nil
 }
 

--- a/examples/features/encryption/TLS/server/main.go
+++ b/examples/features/encryption/TLS/server/main.go
@@ -39,7 +39,7 @@ type ecServer struct {
 	pb.UnimplementedEchoServer
 }
 
-func (s *ecServer) UnaryEcho(ctx context.Context, req *pb.EchoRequest) (*pb.EchoResponse, error) {
+func (s *ecServer) UnaryEcho(_ context.Context, req *pb.EchoRequest) (*pb.EchoResponse, error) {
 	return &pb.EchoResponse{Message: req.Message}, nil
 }
 

--- a/examples/features/encryption/mTLS/server/main.go
+++ b/examples/features/encryption/mTLS/server/main.go
@@ -41,7 +41,7 @@ type ecServer struct {
 	pb.UnimplementedEchoServer
 }
 
-func (s *ecServer) UnaryEcho(ctx context.Context, req *pb.EchoRequest) (*pb.EchoResponse, error) {
+func (s *ecServer) UnaryEcho(_ context.Context, req *pb.EchoRequest) (*pb.EchoResponse, error) {
 	return &pb.EchoResponse{Message: req.Message}, nil
 }
 

--- a/examples/features/error_details/server/main.go
+++ b/examples/features/error_details/server/main.go
@@ -45,7 +45,7 @@ type server struct {
 }
 
 // SayHello implements helloworld.GreeterServer
-func (s *server) SayHello(ctx context.Context, in *pb.HelloRequest) (*pb.HelloReply, error) {
+func (s *server) SayHello(_ context.Context, in *pb.HelloRequest) (*pb.HelloReply, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	// Track the number of times the user has been greeted.

--- a/examples/features/error_handling/server/main.go
+++ b/examples/features/error_handling/server/main.go
@@ -41,7 +41,7 @@ type server struct {
 }
 
 // SayHello implements helloworld.GreeterServer.
-func (s *server) SayHello(ctx context.Context, in *pb.HelloRequest) (*pb.HelloReply, error) {
+func (s *server) SayHello(_ context.Context, in *pb.HelloRequest) (*pb.HelloReply, error) {
 	if in.Name == "" {
 		return nil, status.Errorf(codes.InvalidArgument, "request missing required field: Name")
 	}

--- a/examples/features/health/server/main.go
+++ b/examples/features/health/server/main.go
@@ -45,7 +45,7 @@ type echoServer struct {
 	pb.UnimplementedEchoServer
 }
 
-func (e *echoServer) UnaryEcho(ctx context.Context, req *pb.EchoRequest) (*pb.EchoResponse, error) {
+func (e *echoServer) UnaryEcho(context.Context, *pb.EchoRequest) (*pb.EchoResponse, error) {
 	return &pb.EchoResponse{
 		Message: fmt.Sprintf("hello from localhost:%d", *port),
 	}, nil

--- a/examples/features/interceptor/server/main.go
+++ b/examples/features/interceptor/server/main.go
@@ -55,7 +55,7 @@ type server struct {
 	pb.UnimplementedEchoServer
 }
 
-func (s *server) UnaryEcho(ctx context.Context, in *pb.EchoRequest) (*pb.EchoResponse, error) {
+func (s *server) UnaryEcho(_ context.Context, in *pb.EchoRequest) (*pb.EchoResponse, error) {
 	fmt.Printf("unary echoing message %q\n", in.Message)
 	return &pb.EchoResponse{Message: in.Message}, nil
 }
@@ -87,7 +87,7 @@ func valid(authorization []string) bool {
 	return token == "some-secret-token"
 }
 
-func unaryInterceptor(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+func unaryInterceptor(ctx context.Context, req any, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
 	// authentication (token verification)
 	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
@@ -123,7 +123,7 @@ func newWrappedStream(s grpc.ServerStream) grpc.ServerStream {
 	return &wrappedStream{s}
 }
 
-func streamInterceptor(srv any, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+func streamInterceptor(srv any, ss grpc.ServerStream, _ *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 	// authentication (token verification)
 	md, ok := metadata.FromIncomingContext(ss.Context())
 	if !ok {

--- a/examples/features/keepalive/server/main.go
+++ b/examples/features/keepalive/server/main.go
@@ -53,7 +53,7 @@ type server struct {
 	pb.UnimplementedEchoServer
 }
 
-func (s *server) UnaryEcho(ctx context.Context, req *pb.EchoRequest) (*pb.EchoResponse, error) {
+func (s *server) UnaryEcho(_ context.Context, req *pb.EchoRequest) (*pb.EchoResponse, error) {
 	return &pb.EchoResponse{Message: req.Message}, nil
 }
 

--- a/examples/features/load_balancing/client/main.go
+++ b/examples/features/load_balancing/client/main.go
@@ -91,7 +91,7 @@ func main() {
 
 type exampleResolverBuilder struct{}
 
-func (*exampleResolverBuilder) Build(target resolver.Target, cc resolver.ClientConn, opts resolver.BuildOptions) (resolver.Resolver, error) {
+func (*exampleResolverBuilder) Build(target resolver.Target, cc resolver.ClientConn, _ resolver.BuildOptions) (resolver.Resolver, error) {
 	r := &exampleResolver{
 		target: target,
 		cc:     cc,
@@ -118,8 +118,8 @@ func (r *exampleResolver) start() {
 	}
 	r.cc.UpdateState(resolver.State{Addresses: addrs})
 }
-func (*exampleResolver) ResolveNow(o resolver.ResolveNowOptions) {}
-func (*exampleResolver) Close()                                  {}
+func (*exampleResolver) ResolveNow(resolver.ResolveNowOptions) {}
+func (*exampleResolver) Close()                                {}
 
 func init() {
 	resolver.Register(&exampleResolverBuilder{})

--- a/examples/features/load_balancing/server/main.go
+++ b/examples/features/load_balancing/server/main.go
@@ -40,7 +40,7 @@ type ecServer struct {
 	addr string
 }
 
-func (s *ecServer) UnaryEcho(ctx context.Context, req *pb.EchoRequest) (*pb.EchoResponse, error) {
+func (s *ecServer) UnaryEcho(_ context.Context, req *pb.EchoRequest) (*pb.EchoResponse, error) {
 	return &pb.EchoResponse{Message: fmt.Sprintf("%s (from %s)", req.Message, s.addr)}, nil
 }
 

--- a/examples/features/metadata_interceptor/server/main.go
+++ b/examples/features/metadata_interceptor/server/main.go
@@ -43,7 +43,7 @@ type server struct {
 	pb.UnimplementedEchoServer
 }
 
-func unaryInterceptor(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+func unaryInterceptor(ctx context.Context, req any, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
 	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
 		return nil, errMissingMetadata
@@ -95,7 +95,7 @@ func (s *wrappedStream) Context() context.Context {
 	return s.ctx
 }
 
-func streamInterceptor(srv any, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+func streamInterceptor(srv any, ss grpc.ServerStream, _ *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 	md, ok := metadata.FromIncomingContext(ss.Context())
 	if !ok {
 		return errMissingMetadata

--- a/examples/features/multiplex/server/main.go
+++ b/examples/features/multiplex/server/main.go
@@ -40,7 +40,7 @@ type hwServer struct {
 }
 
 // SayHello implements helloworld.GreeterServer
-func (s *hwServer) SayHello(ctx context.Context, in *hwpb.HelloRequest) (*hwpb.HelloReply, error) {
+func (s *hwServer) SayHello(_ context.Context, in *hwpb.HelloRequest) (*hwpb.HelloReply, error) {
 	return &hwpb.HelloReply{Message: "Hello " + in.Name}, nil
 }
 
@@ -48,7 +48,7 @@ type ecServer struct {
 	ecpb.UnimplementedEchoServer
 }
 
-func (s *ecServer) UnaryEcho(ctx context.Context, req *ecpb.EchoRequest) (*ecpb.EchoResponse, error) {
+func (s *ecServer) UnaryEcho(_ context.Context, req *ecpb.EchoRequest) (*ecpb.EchoResponse, error) {
 	return &ecpb.EchoResponse{Message: req.Message}, nil
 }
 

--- a/examples/features/name_resolving/client/main.go
+++ b/examples/features/name_resolving/client/main.go
@@ -97,7 +97,7 @@ func main() {
 // ResolverBuilder(https://godoc.org/google.golang.org/grpc/resolver#Builder).
 type exampleResolverBuilder struct{}
 
-func (*exampleResolverBuilder) Build(target resolver.Target, cc resolver.ClientConn, opts resolver.BuildOptions) (resolver.Resolver, error) {
+func (*exampleResolverBuilder) Build(target resolver.Target, cc resolver.ClientConn, _ resolver.BuildOptions) (resolver.Resolver, error) {
 	r := &exampleResolver{
 		target: target,
 		cc:     cc,
@@ -126,8 +126,8 @@ func (r *exampleResolver) start() {
 	}
 	r.cc.UpdateState(resolver.State{Addresses: addrs})
 }
-func (*exampleResolver) ResolveNow(o resolver.ResolveNowOptions) {}
-func (*exampleResolver) Close()                                  {}
+func (*exampleResolver) ResolveNow(resolver.ResolveNowOptions) {}
+func (*exampleResolver) Close()                                {}
 
 func init() {
 	// Register the example ResolverBuilder. This is usually done in a package's

--- a/examples/features/name_resolving/server/main.go
+++ b/examples/features/name_resolving/server/main.go
@@ -37,7 +37,7 @@ type ecServer struct {
 	addr string
 }
 
-func (s *ecServer) UnaryEcho(ctx context.Context, req *pb.EchoRequest) (*pb.EchoResponse, error) {
+func (s *ecServer) UnaryEcho(_ context.Context, req *pb.EchoRequest) (*pb.EchoResponse, error) {
 	return &pb.EchoResponse{Message: fmt.Sprintf("%s (from %s)", req.Message, s.addr)}, nil
 }
 

--- a/examples/features/observability/server/main.go
+++ b/examples/features/observability/server/main.go
@@ -45,7 +45,7 @@ type server struct {
 }
 
 // SayHello implements helloworld.GreeterServer
-func (s *server) SayHello(ctx context.Context, in *pb.HelloRequest) (*pb.HelloReply, error) {
+func (s *server) SayHello(_ context.Context, in *pb.HelloRequest) (*pb.HelloReply, error) {
 	log.Printf("Received: %v", in.GetName())
 	return &pb.HelloReply{Message: "Hello " + in.GetName()}, nil
 }

--- a/examples/features/opentelemetry/server/main.go
+++ b/examples/features/opentelemetry/server/main.go
@@ -45,7 +45,7 @@ type echoServer struct {
 	addr string
 }
 
-func (s *echoServer) UnaryEcho(ctx context.Context, req *pb.EchoRequest) (*pb.EchoResponse, error) {
+func (s *echoServer) UnaryEcho(_ context.Context, req *pb.EchoRequest) (*pb.EchoResponse, error) {
 	return &pb.EchoResponse{Message: fmt.Sprintf("%s (from %s)", req.Message, s.addr)}, nil
 }
 

--- a/examples/features/orca/client/main.go
+++ b/examples/features/orca/client/main.go
@@ -82,7 +82,7 @@ func init() {
 type orcaLBBuilder struct{}
 
 func (orcaLBBuilder) Name() string { return "orca_example" }
-func (orcaLBBuilder) Build(cc balancer.ClientConn, opts balancer.BuildOptions) balancer.Balancer {
+func (orcaLBBuilder) Build(cc balancer.ClientConn, _ balancer.BuildOptions) balancer.Balancer {
 	return &orcaLB{cc: cc}
 }
 
@@ -124,7 +124,7 @@ func (o *orcaLB) UpdateClientConnState(ccs balancer.ClientConnState) error {
 func (o *orcaLB) ResolverError(error) {}
 
 // TODO: unused; remove when no longer required.
-func (o *orcaLB) UpdateSubConnState(sc balancer.SubConn, scs balancer.SubConnState) {}
+func (o *orcaLB) UpdateSubConnState(balancer.SubConn, balancer.SubConnState) {}
 
 func (o *orcaLB) Close() {}
 
@@ -132,7 +132,7 @@ type picker struct {
 	sc balancer.SubConn
 }
 
-func (p *picker) Pick(info balancer.PickInfo) (balancer.PickResult, error) {
+func (p *picker) Pick(balancer.PickInfo) (balancer.PickResult, error) {
 	return balancer.PickResult{
 		SubConn: p.sc,
 		Done: func(di balancer.DoneInfo) {

--- a/examples/features/reflection/server/main.go
+++ b/examples/features/reflection/server/main.go
@@ -41,7 +41,7 @@ type hwServer struct {
 }
 
 // SayHello implements helloworld.GreeterServer
-func (s *hwServer) SayHello(ctx context.Context, in *hwpb.HelloRequest) (*hwpb.HelloReply, error) {
+func (s *hwServer) SayHello(_ context.Context, in *hwpb.HelloRequest) (*hwpb.HelloReply, error) {
 	return &hwpb.HelloReply{Message: "Hello " + in.Name}, nil
 }
 
@@ -49,7 +49,7 @@ type ecServer struct {
 	ecpb.UnimplementedEchoServer
 }
 
-func (s *ecServer) UnaryEcho(ctx context.Context, req *ecpb.EchoRequest) (*ecpb.EchoResponse, error) {
+func (s *ecServer) UnaryEcho(_ context.Context, req *ecpb.EchoRequest) (*ecpb.EchoResponse, error) {
 	return &ecpb.EchoResponse{Message: req.Message}, nil
 }
 

--- a/examples/features/retry/server/main.go
+++ b/examples/features/retry/server/main.go
@@ -57,7 +57,7 @@ func (s *failingServer) maybeFailRequest() error {
 	return status.Errorf(codes.Unavailable, "maybeFailRequest: failing it")
 }
 
-func (s *failingServer) UnaryEcho(ctx context.Context, req *pb.EchoRequest) (*pb.EchoResponse, error) {
+func (s *failingServer) UnaryEcho(_ context.Context, req *pb.EchoRequest) (*pb.EchoResponse, error) {
 	if err := s.maybeFailRequest(); err != nil {
 		log.Println("request failed count:", s.reqCounter)
 		return nil, err

--- a/examples/features/stats_monitoring/server/main.go
+++ b/examples/features/stats_monitoring/server/main.go
@@ -40,7 +40,7 @@ type server struct {
 	echogrpc.UnimplementedEchoServer
 }
 
-func (s *server) UnaryEcho(ctx context.Context, req *echopb.EchoRequest) (*echopb.EchoResponse, error) {
+func (s *server) UnaryEcho(_ context.Context, req *echopb.EchoRequest) (*echopb.EchoResponse, error) {
 	time.Sleep(2 * time.Second)
 	return &echopb.EchoResponse{Message: req.Message}, nil
 }

--- a/examples/features/wait_for_ready/main.go
+++ b/examples/features/wait_for_ready/main.go
@@ -40,7 +40,7 @@ type server struct {
 	pb.UnimplementedEchoServer
 }
 
-func (s *server) UnaryEcho(ctx context.Context, req *pb.EchoRequest) (*pb.EchoResponse, error) {
+func (s *server) UnaryEcho(_ context.Context, req *pb.EchoRequest) (*pb.EchoResponse, error) {
 	return &pb.EchoResponse{Message: req.Message}, nil
 }
 

--- a/examples/features/xds/server/main.go
+++ b/examples/features/xds/server/main.go
@@ -51,7 +51,7 @@ type server struct {
 }
 
 // SayHello implements helloworld.GreeterServer interface.
-func (s *server) SayHello(ctx context.Context, in *pb.HelloRequest) (*pb.HelloReply, error) {
+func (s *server) SayHello(_ context.Context, in *pb.HelloRequest) (*pb.HelloReply, error) {
 	log.Printf("Received: %v", in.GetName())
 	return &pb.HelloReply{Message: "Hello " + in.GetName() + ", from " + s.serverName}, nil
 }

--- a/examples/helloworld/greeter_server/main.go
+++ b/examples/helloworld/greeter_server/main.go
@@ -40,7 +40,7 @@ type server struct {
 }
 
 // SayHello implements helloworld.GreeterServer
-func (s *server) SayHello(ctx context.Context, in *pb.HelloRequest) (*pb.HelloReply, error) {
+func (s *server) SayHello(_ context.Context, in *pb.HelloRequest) (*pb.HelloReply, error) {
 	log.Printf("Received: %v", in.GetName())
 	return &pb.HelloReply{Message: "Hello " + in.GetName()}, nil
 }

--- a/examples/route_guide/server/server.go
+++ b/examples/route_guide/server/server.go
@@ -60,7 +60,7 @@ type routeGuideServer struct {
 }
 
 // GetFeature returns the feature at the given point.
-func (s *routeGuideServer) GetFeature(ctx context.Context, point *pb.Point) (*pb.Feature, error) {
+func (s *routeGuideServer) GetFeature(_ context.Context, point *pb.Point) (*pb.Feature, error) {
 	for _, feature := range s.savedFeatures {
 		if proto.Equal(feature.Location, point) {
 			return feature, nil

--- a/gcp/observability/logging_test.go
+++ b/gcp/observability/logging_test.go
@@ -134,7 +134,7 @@ func (s) TestClientRPCEventsLogAll(t *testing.T) {
 		newLoggingExporter = ne
 	}(newLoggingExporter)
 
-	newLoggingExporter = func(ctx context.Context, config *config) (loggingExporter, error) {
+	newLoggingExporter = func(context.Context, *config) (loggingExporter, error) {
 		return fle, nil
 	}
 
@@ -157,7 +157,7 @@ func (s) TestClientRPCEventsLogAll(t *testing.T) {
 	defer cleanup()
 
 	ss := &stubserver.StubServer{
-		UnaryCallF: func(ctx context.Context, in *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
+		UnaryCallF: func(context.Context, *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
 			return &testpb.SimpleResponse{}, nil
 		},
 		FullDuplexCallF: func(stream testgrpc.TestService_FullDuplexCallServer) error {
@@ -344,7 +344,7 @@ func (s) TestServerRPCEventsLogAll(t *testing.T) {
 		newLoggingExporter = ne
 	}(newLoggingExporter)
 
-	newLoggingExporter = func(ctx context.Context, config *config) (loggingExporter, error) {
+	newLoggingExporter = func(context.Context, *config) (loggingExporter, error) {
 		return fle, nil
 	}
 
@@ -367,7 +367,7 @@ func (s) TestServerRPCEventsLogAll(t *testing.T) {
 	defer cleanup()
 
 	ss := &stubserver.StubServer{
-		UnaryCallF: func(ctx context.Context, in *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
+		UnaryCallF: func(context.Context, *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
 			return &testpb.SimpleResponse{}, nil
 		},
 		FullDuplexCallF: func(stream testgrpc.TestService_FullDuplexCallServer) error {
@@ -558,7 +558,7 @@ func (s) TestBothClientAndServerRPCEvents(t *testing.T) {
 		newLoggingExporter = ne
 	}(newLoggingExporter)
 
-	newLoggingExporter = func(ctx context.Context, config *config) (loggingExporter, error) {
+	newLoggingExporter = func(context.Context, *config) (loggingExporter, error) {
 		return fle, nil
 	}
 

--- a/gcp/observability/observability_test.go
+++ b/gcp/observability/observability_test.go
@@ -369,7 +369,7 @@ func (s) TestOpenCensusIntegration(t *testing.T) {
 		newExporter = ne
 	}(newExporter)
 
-	newExporter = func(config *config) (tracingMetricsExporter, error) {
+	newExporter = func(*config) (tracingMetricsExporter, error) {
 		return fe, nil
 	}
 
@@ -387,7 +387,7 @@ func (s) TestOpenCensusIntegration(t *testing.T) {
 	defer cleanup()
 
 	ss := &stubserver.StubServer{
-		UnaryCallF: func(ctx context.Context, in *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
+		UnaryCallF: func(context.Context, *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
 			return &testpb.SimpleResponse{}, nil
 		},
 		FullDuplexCallF: func(stream testgrpc.TestService_FullDuplexCallServer) error {
@@ -569,7 +569,7 @@ func (s) TestLoggingLinkedWithTraceClientSide(t *testing.T) {
 		newLoggingExporter = oldNewLoggingExporter
 	}()
 
-	newLoggingExporter = func(ctx context.Context, config *config) (loggingExporter, error) {
+	newLoggingExporter = func(context.Context, *config) (loggingExporter, error) {
 		return fle, nil
 	}
 
@@ -584,7 +584,7 @@ func (s) TestLoggingLinkedWithTraceClientSide(t *testing.T) {
 		newExporter = oldNewExporter
 	}()
 
-	newExporter = func(config *config) (tracingMetricsExporter, error) {
+	newExporter = func(*config) (tracingMetricsExporter, error) {
 		return fe, nil
 	}
 
@@ -610,7 +610,7 @@ func (s) TestLoggingLinkedWithTraceClientSide(t *testing.T) {
 	}
 	defer cleanup()
 	ss := &stubserver.StubServer{
-		UnaryCallF: func(ctx context.Context, in *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
+		UnaryCallF: func(context.Context, *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
 			return &testpb.SimpleResponse{}, nil
 		},
 		FullDuplexCallF: func(stream testgrpc.TestService_FullDuplexCallServer) error {
@@ -711,7 +711,7 @@ func (s) TestLoggingLinkedWithTraceServerSide(t *testing.T) {
 		newLoggingExporter = oldNewLoggingExporter
 	}()
 
-	newLoggingExporter = func(ctx context.Context, config *config) (loggingExporter, error) {
+	newLoggingExporter = func(context.Context, *config) (loggingExporter, error) {
 		return fle, nil
 	}
 
@@ -726,7 +726,7 @@ func (s) TestLoggingLinkedWithTraceServerSide(t *testing.T) {
 		newExporter = oldNewExporter
 	}()
 
-	newExporter = func(config *config) (tracingMetricsExporter, error) {
+	newExporter = func(*config) (tracingMetricsExporter, error) {
 		return fe, nil
 	}
 
@@ -752,7 +752,7 @@ func (s) TestLoggingLinkedWithTraceServerSide(t *testing.T) {
 	}
 	defer cleanup()
 	ss := &stubserver.StubServer{
-		UnaryCallF: func(ctx context.Context, in *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
+		UnaryCallF: func(context.Context, *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
 			return &testpb.SimpleResponse{}, nil
 		},
 		FullDuplexCallF: func(stream testgrpc.TestService_FullDuplexCallServer) error {
@@ -855,7 +855,7 @@ func (s) TestLoggingLinkedWithTrace(t *testing.T) {
 		newLoggingExporter = oldNewLoggingExporter
 	}()
 
-	newLoggingExporter = func(ctx context.Context, config *config) (loggingExporter, error) {
+	newLoggingExporter = func(context.Context, *config) (loggingExporter, error) {
 		return fle, nil
 	}
 
@@ -870,7 +870,7 @@ func (s) TestLoggingLinkedWithTrace(t *testing.T) {
 		newExporter = oldNewExporter
 	}()
 
-	newExporter = func(config *config) (tracingMetricsExporter, error) {
+	newExporter = func(*config) (tracingMetricsExporter, error) {
 		return fe, nil
 	}
 
@@ -903,7 +903,7 @@ func (s) TestLoggingLinkedWithTrace(t *testing.T) {
 	}
 	defer cleanup()
 	ss := &stubserver.StubServer{
-		UnaryCallF: func(ctx context.Context, in *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
+		UnaryCallF: func(context.Context, *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
 			return &testpb.SimpleResponse{}, nil
 		},
 		FullDuplexCallF: func(stream testgrpc.TestService_FullDuplexCallServer) error {

--- a/grpclog/internal/logger.go
+++ b/grpclog/internal/logger.go
@@ -81,7 +81,7 @@ func (l *LoggerWrapper) Errorf(format string, args ...any) {
 }
 
 // V reports whether verbosity level l is at least the requested verbose level.
-func (*LoggerWrapper) V(l int) bool {
+func (*LoggerWrapper) V(int) bool {
 	// Returns true for all verbose level.
 	return true
 }

--- a/health/client_test.go
+++ b/health/client_test.go
@@ -47,7 +47,7 @@ func (s) TestClientHealthCheckBackoff(t *testing.T) {
 	}
 
 	oldBackoffFunc := backoffFunc
-	backoffFunc = func(ctx context.Context, retries int) bool {
+	backoffFunc = func(_ context.Context, retries int) bool {
 		got = append(got, time.Duration(retries+1)*time.Second)
 		return true
 	}

--- a/health/server.go
+++ b/health/server.go
@@ -51,7 +51,7 @@ func NewServer() *Server {
 }
 
 // Check implements `service Health`.
-func (s *Server) Check(ctx context.Context, in *healthpb.HealthCheckRequest) (*healthpb.HealthCheckResponse, error) {
+func (s *Server) Check(_ context.Context, in *healthpb.HealthCheckRequest) (*healthpb.HealthCheckResponse, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	if servingStatus, ok := s.statusMap[in.Service]; ok {

--- a/internal/balancer/gracefulswitch/gracefulswitch_test.go
+++ b/internal/balancer/gracefulswitch/gracefulswitch_test.go
@@ -666,7 +666,7 @@ func (s) TestPendingReplacedByAnotherPending(t *testing.T) {
 // Picker which never errors here for test purposes (can fill up tests further up with this)
 type neverErrPicker struct{}
 
-func (p *neverErrPicker) Pick(info balancer.PickInfo) (balancer.PickResult, error) {
+func (p *neverErrPicker) Pick(balancer.PickInfo) (balancer.PickResult, error) {
 	return balancer.PickResult{}, nil
 }
 
@@ -836,7 +836,7 @@ const buildCallbackBalName = "callbackInBuildBalancer"
 
 type mockBalancerBuilder1 struct{}
 
-func (mockBalancerBuilder1) Build(cc balancer.ClientConn, opts balancer.BuildOptions) balancer.Balancer {
+func (mockBalancerBuilder1) Build(cc balancer.ClientConn, _ balancer.BuildOptions) balancer.Balancer {
 	return &mockBalancer{
 		ccsCh:         testutils.NewChannel(),
 		scStateCh:     testutils.NewChannel(),
@@ -969,7 +969,7 @@ func (mb1 *mockBalancer) updateAddresses(sc balancer.SubConn, addrs []resolver.A
 
 type mockBalancerBuilder2 struct{}
 
-func (mockBalancerBuilder2) Build(cc balancer.ClientConn, opts balancer.BuildOptions) balancer.Balancer {
+func (mockBalancerBuilder2) Build(cc balancer.ClientConn, _ balancer.BuildOptions) balancer.Balancer {
 	return &mockBalancer{
 		ccsCh:         testutils.NewChannel(),
 		scStateCh:     testutils.NewChannel(),
@@ -985,7 +985,7 @@ func (mockBalancerBuilder2) Name() string {
 
 type verifyBalancerBuilder struct{}
 
-func (verifyBalancerBuilder) Build(cc balancer.ClientConn, opts balancer.BuildOptions) balancer.Balancer {
+func (verifyBalancerBuilder) Build(cc balancer.ClientConn, _ balancer.BuildOptions) balancer.Balancer {
 	return &verifyBalancer{
 		closed: grpcsync.NewEvent(),
 		cc:     cc,
@@ -1006,11 +1006,11 @@ type verifyBalancer struct {
 	t *testing.T
 }
 
-func (vb *verifyBalancer) UpdateClientConnState(ccs balancer.ClientConnState) error {
+func (vb *verifyBalancer) UpdateClientConnState(balancer.ClientConnState) error {
 	return nil
 }
 
-func (vb *verifyBalancer) ResolverError(err error) {}
+func (vb *verifyBalancer) ResolverError(error) {}
 
 func (vb *verifyBalancer) UpdateSubConnState(sc balancer.SubConn, state balancer.SubConnState) {
 	panic(fmt.Sprintf("UpdateSubConnState(%v, %+v) called unexpectedly", sc, state))
@@ -1034,7 +1034,7 @@ func (vb *verifyBalancer) newSubConn(addrs []resolver.Address, opts balancer.New
 
 type buildCallbackBalancerBuilder struct{}
 
-func (buildCallbackBalancerBuilder) Build(cc balancer.ClientConn, opts balancer.BuildOptions) balancer.Balancer {
+func (buildCallbackBalancerBuilder) Build(cc balancer.ClientConn, _ balancer.BuildOptions) balancer.Balancer {
 	b := &buildCallbackBal{
 		cc:      cc,
 		closeCh: testutils.NewChannel(),
@@ -1062,11 +1062,11 @@ type buildCallbackBal struct {
 	closeCh *testutils.Channel
 }
 
-func (bcb *buildCallbackBal) UpdateClientConnState(ccs balancer.ClientConnState) error {
+func (bcb *buildCallbackBal) UpdateClientConnState(balancer.ClientConnState) error {
 	return nil
 }
 
-func (bcb *buildCallbackBal) ResolverError(err error) {}
+func (bcb *buildCallbackBal) ResolverError(error) {}
 
 func (bcb *buildCallbackBal) UpdateSubConnState(sc balancer.SubConn, state balancer.SubConnState) {
 	panic(fmt.Sprintf("UpdateSubConnState(%v, %+v) called unexpectedly", sc, state))

--- a/internal/binarylog/method_logger.go
+++ b/internal/binarylog/method_logger.go
@@ -106,7 +106,7 @@ func (ml *TruncatingMethodLogger) Build(c LogEntryConfig) *binlogpb.GrpcLogEntry
 }
 
 // Log creates a proto binary log entry, and logs it to the sink.
-func (ml *TruncatingMethodLogger) Log(ctx context.Context, c LogEntryConfig) {
+func (ml *TruncatingMethodLogger) Log(_ context.Context, c LogEntryConfig) {
 	ml.sink.Write(ml.Build(c))
 }
 

--- a/internal/channelz/syscall_nonlinux.go
+++ b/internal/channelz/syscall_nonlinux.go
@@ -35,13 +35,13 @@ type SocketOptionData struct {
 // Getsockopt defines the function to get socket options requested by channelz.
 // It is to be passed to syscall.RawConn.Control().
 // Windows OS doesn't support Socket Option
-func (s *SocketOptionData) Getsockopt(fd uintptr) {
+func (s *SocketOptionData) Getsockopt(uintptr) {
 	once.Do(func() {
 		logger.Warning("Channelz: socket options are not supported on non-linux environments")
 	})
 }
 
 // GetSocketOption gets the socket option info of the conn.
-func GetSocketOption(c any) *SocketOptionData {
+func GetSocketOption(any) *SocketOptionData {
 	return nil
 }

--- a/internal/grpctest/tlogger_test.go
+++ b/internal/grpctest/tlogger_test.go
@@ -32,39 +32,39 @@ func Test(t *testing.T) {
 	RunSubTests(t, s{})
 }
 
-func (s) TestInfo(t *testing.T) {
+func (s) TestInfo(*testing.T) {
 	grpclog.Info("Info", "message.")
 }
 
-func (s) TestInfoln(t *testing.T) {
+func (s) TestInfoln(*testing.T) {
 	grpclog.Infoln("Info", "message.")
 }
 
-func (s) TestInfof(t *testing.T) {
+func (s) TestInfof(*testing.T) {
 	grpclog.Infof("%v %v.", "Info", "message")
 }
 
-func (s) TestInfoDepth(t *testing.T) {
+func (s) TestInfoDepth(*testing.T) {
 	grpclog.InfoDepth(0, "Info", "depth", "message.")
 }
 
-func (s) TestWarning(t *testing.T) {
+func (s) TestWarning(*testing.T) {
 	grpclog.Warning("Warning", "message.")
 }
 
-func (s) TestWarningln(t *testing.T) {
+func (s) TestWarningln(*testing.T) {
 	grpclog.Warningln("Warning", "message.")
 }
 
-func (s) TestWarningf(t *testing.T) {
+func (s) TestWarningf(*testing.T) {
 	grpclog.Warningf("%v %v.", "Warning", "message")
 }
 
-func (s) TestWarningDepth(t *testing.T) {
+func (s) TestWarningDepth(*testing.T) {
 	grpclog.WarningDepth(0, "Warning", "depth", "message.")
 }
 
-func (s) TestError(t *testing.T) {
+func (s) TestError(*testing.T) {
 	const numErrors = 10
 	TLogger.ExpectError("Expected error")
 	TLogger.ExpectError("Expected ln error")

--- a/internal/leakcheck/leakcheck_test.go
+++ b/internal/leakcheck/leakcheck_test.go
@@ -30,7 +30,7 @@ type testLogger struct {
 	errors     []string
 }
 
-func (e *testLogger) Logf(format string, args ...any) {
+func (e *testLogger) Logf(string, ...any) {
 }
 
 func (e *testLogger) Errorf(format string, args ...any) {

--- a/internal/resolver/passthrough/passthrough.go
+++ b/internal/resolver/passthrough/passthrough.go
@@ -55,7 +55,7 @@ func (r *passthroughResolver) start() {
 	r.cc.UpdateState(resolver.State{Addresses: []resolver.Address{{Addr: r.target.Endpoint()}}})
 }
 
-func (*passthroughResolver) ResolveNow(o resolver.ResolveNowOptions) {}
+func (*passthroughResolver) ResolveNow(resolver.ResolveNowOptions) {}
 
 func (*passthroughResolver) Close() {}
 

--- a/internal/syscall/syscall_nonlinux.go
+++ b/internal/syscall/syscall_nonlinux.go
@@ -58,20 +58,20 @@ func GetRusage() *Rusage {
 
 // CPUTimeDiff returns the differences of user CPU time and system CPU time used
 // between two Rusage structs. It a no-op function for non-linux environments.
-func CPUTimeDiff(first *Rusage, latest *Rusage) (float64, float64) {
+func CPUTimeDiff(*Rusage, *Rusage) (float64, float64) {
 	log()
 	return 0, 0
 }
 
 // SetTCPUserTimeout is a no-op function under non-linux environments.
-func SetTCPUserTimeout(conn net.Conn, timeout time.Duration) error {
+func SetTCPUserTimeout(net.Conn, time.Duration) error {
 	log()
 	return nil
 }
 
 // GetTCPUserTimeout is a no-op function under non-linux environments.
 // A negative return value indicates the operation is not supported
-func GetTCPUserTimeout(conn net.Conn) (int, error) {
+func GetTCPUserTimeout(net.Conn) (int, error) {
 	log()
 	return -1, nil
 }

--- a/internal/testutils/balancer.go
+++ b/internal/testutils/balancer.go
@@ -379,7 +379,7 @@ type TestConstPicker struct {
 }
 
 // Pick returns the const SubConn or the error.
-func (tcp *TestConstPicker) Pick(info balancer.PickInfo) (balancer.PickResult, error) {
+func (tcp *TestConstPicker) Pick(balancer.PickInfo) (balancer.PickResult, error) {
 	if tcp.Err != nil {
 		return balancer.PickResult{}, tcp.Err
 	}

--- a/internal/testutils/rls/fake_rls_server.go
+++ b/internal/testutils/rls/fake_rls_server.go
@@ -53,7 +53,7 @@ func SetupFakeRLSServer(t *testing.T, lis net.Listener, opts ...grpc.ServerOptio
 	t.Logf("Started fake RLS server at %q", s.Address)
 
 	ch := make(chan struct{}, 1)
-	s.SetRequestCallback(func(request *rlspb.RouteLookupRequest) {
+	s.SetRequestCallback(func(*rlspb.RouteLookupRequest) {
 		select {
 		case ch <- struct{}{}:
 		default:

--- a/internal/transport/handler_server.go
+++ b/internal/transport/handler_server.go
@@ -333,7 +333,7 @@ func (ht *serverHandlerTransport) writeCustomHeaders(s *Stream) {
 	s.hdrMu.Unlock()
 }
 
-func (ht *serverHandlerTransport) Write(s *Stream, hdr []byte, data mem.BufferSlice, opts *Options) error {
+func (ht *serverHandlerTransport) Write(s *Stream, hdr []byte, data mem.BufferSlice, _ *Options) error {
 	// Always take a reference because otherwise there is no guarantee the data will
 	// be available after this function returns. This is what callers to Write
 	// expect.
@@ -475,7 +475,7 @@ func (ht *serverHandlerTransport) IncrMsgSent() {}
 
 func (ht *serverHandlerTransport) IncrMsgRecv() {}
 
-func (ht *serverHandlerTransport) Drain(debugData string) {
+func (ht *serverHandlerTransport) Drain(string) {
 	panic("Drain() is not implemented")
 }
 

--- a/internal/transport/handler_server_test.go
+++ b/internal/transport/handler_server_test.go
@@ -138,7 +138,7 @@ func (s) TestHandlerTransport_NewServerHandlerTransport(t *testing.T) {
 					Path: "/service/foo.bar",
 				},
 			},
-			check: func(t *serverHandlerTransport, tt *testCase) error {
+			check: func(t *serverHandlerTransport, _ *testCase) error {
 				if !t.timeoutSet {
 					return errors.New("timeout not set")
 				}
@@ -179,7 +179,7 @@ func (s) TestHandlerTransport_NewServerHandlerTransport(t *testing.T) {
 					Path: "/service/foo.bar",
 				},
 			},
-			check: func(ht *serverHandlerTransport, tt *testCase) error {
+			check: func(ht *serverHandlerTransport, _ *testCase) error {
 				want := metadata.MD{
 					"meta-bar":     {"bar-val1", "bar-val2"},
 					"user-agent":   {"x/y a/b"},

--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -772,7 +772,7 @@ func (t *http2Client) NewStream(ctx context.Context, callHdr *CallHdr) (*Stream,
 	hdr := &headerFrame{
 		hf:        headerFields,
 		endStream: false,
-		initStream: func(id uint32) error {
+		initStream: func(uint32) error {
 			t.mu.Lock()
 			// TODO: handle transport closure in loopy instead and remove this
 			// initStream is never called when transport is draining.

--- a/internal/transport/http2_server.go
+++ b/internal/transport/http2_server.go
@@ -1117,7 +1117,7 @@ func (t *http2Server) WriteStatus(s *Stream, st *status.Status) error {
 
 // Write converts the data into HTTP2 data frame and sends it out. Non-nil error
 // is returns if it fails (e.g., framing error, transport error).
-func (t *http2Server) Write(s *Stream, hdr []byte, data mem.BufferSlice, opts *Options) error {
+func (t *http2Server) Write(s *Stream, hdr []byte, data mem.BufferSlice, _ *Options) error {
 	reader := data.Reader()
 
 	if !s.isHeaderSent() { // Headers haven't been written yet.

--- a/internal/transport/proxy_test.go
+++ b/internal/transport/proxy_test.go
@@ -159,7 +159,7 @@ func testHTTPConnect(t *testing.T, args testArgs) {
 	}()
 
 	// Overwrite the function in the test and restore them in defer.
-	hpfe := func(req *http.Request) (*url.URL, error) {
+	hpfe := func(*http.Request) (*url.URL, error) {
 		return args.proxyURLModify(&url.URL{Host: plis.Addr().String()}), nil
 	}
 	defer overwrite(hpfe)()

--- a/internal/transport/transport_test.go
+++ b/internal/transport/transport_test.go
@@ -117,7 +117,7 @@ const (
 	pingpong
 )
 
-func (h *testStreamHandler) handleStreamAndNotify(s *Stream) {
+func (h *testStreamHandler) handleStreamAndNotify(*Stream) {
 	if h.notify == nil {
 		return
 	}
@@ -2423,7 +2423,7 @@ type attrTransportCreds struct {
 	attr *attributes.Attributes
 }
 
-func (ac *attrTransportCreds) ClientHandshake(ctx context.Context, addr string, rawConn net.Conn) (net.Conn, credentials.AuthInfo, error) {
+func (ac *attrTransportCreds) ClientHandshake(ctx context.Context, _ string, rawConn net.Conn) (net.Conn, credentials.AuthInfo, error) {
 	ai := credentials.ClientHandshakeInfoFromContext(ctx)
 	ac.attr = ai.Attributes
 	return rawConn, nil, nil

--- a/internal/xds/rbac/matchers.go
+++ b/internal/xds/rbac/matchers.go
@@ -244,7 +244,7 @@ func (am *andMatcher) match(data *rpcData) bool {
 type alwaysMatcher struct {
 }
 
-func (am *alwaysMatcher) match(data *rpcData) bool {
+func (am *alwaysMatcher) match(*rpcData) bool {
 	return true
 }
 

--- a/internal/xds/rbac/rbac_engine_test.go
+++ b/internal/xds/rbac/rbac_engine_test.go
@@ -1812,15 +1812,15 @@ func (sts *ServerTransportStreamWithMethod) Method() string {
 	return sts.method
 }
 
-func (sts *ServerTransportStreamWithMethod) SetHeader(md metadata.MD) error {
+func (sts *ServerTransportStreamWithMethod) SetHeader(metadata.MD) error {
 	return nil
 }
 
-func (sts *ServerTransportStreamWithMethod) SendHeader(md metadata.MD) error {
+func (sts *ServerTransportStreamWithMethod) SendHeader(metadata.MD) error {
 	return nil
 }
 
-func (sts *ServerTransportStreamWithMethod) SetTrailer(md metadata.MD) error {
+func (sts *ServerTransportStreamWithMethod) SetTrailer(metadata.MD) error {
 	return nil
 }
 
@@ -1844,11 +1844,11 @@ type TestAuditLoggerBufferConfig struct {
 	audit.LoggerConfig
 }
 
-func (b *TestAuditLoggerBufferBuilder) ParseLoggerConfig(configJSON json.RawMessage) (config audit.LoggerConfig, err error) {
+func (b *TestAuditLoggerBufferBuilder) ParseLoggerConfig(json.RawMessage) (config audit.LoggerConfig, err error) {
 	return TestAuditLoggerBufferConfig{}, nil
 }
 
-func (b *TestAuditLoggerBufferBuilder) Build(config audit.LoggerConfig) audit.Logger {
+func (b *TestAuditLoggerBufferBuilder) Build(audit.LoggerConfig) audit.Logger {
 	return &TestAuditLoggerBuffer{auditEvents: &b.auditEvents}
 }
 
@@ -1885,7 +1885,7 @@ func (b TestAuditLoggerCustomConfigBuilder) ParseLoggerConfig(configJSON json.Ra
 	return c, nil
 }
 
-func (b *TestAuditLoggerCustomConfigBuilder) Build(config audit.LoggerConfig) audit.Logger {
+func (b *TestAuditLoggerCustomConfigBuilder) Build(audit.LoggerConfig) audit.Logger {
 	return &TestAuditLoggerCustomConfig{}
 }
 

--- a/interop/orcalb.go
+++ b/interop/orcalb.go
@@ -37,7 +37,7 @@ func init() {
 
 type orcabb struct{}
 
-func (orcabb) Build(cc balancer.ClientConn, opts balancer.BuildOptions) balancer.Balancer {
+func (orcabb) Build(cc balancer.ClientConn, _ balancer.BuildOptions) balancer.Balancer {
 	return &orcab{cc: cc}
 }
 

--- a/interop/stress/client/main.go
+++ b/interop/stress/client/main.go
@@ -173,7 +173,7 @@ func newMetricsServer() *server {
 }
 
 // GetAllGauges returns all gauges.
-func (s *server) GetAllGauges(in *metricspb.EmptyMessage, stream metricspb.MetricsService_GetAllGaugesServer) error {
+func (s *server) GetAllGauges(_ *metricspb.EmptyMessage, stream metricspb.MetricsService_GetAllGaugesServer) error {
 	s.mutex.RLock()
 	defer s.mutex.RUnlock()
 
@@ -186,7 +186,7 @@ func (s *server) GetAllGauges(in *metricspb.EmptyMessage, stream metricspb.Metri
 }
 
 // GetGauge returns the gauge for the given name.
-func (s *server) GetGauge(ctx context.Context, in *metricspb.GaugeRequest) (*metricspb.GaugeResponse, error) {
+func (s *server) GetGauge(_ context.Context, in *metricspb.GaugeRequest) (*metricspb.GaugeResponse, error) {
 	s.mutex.RLock()
 	defer s.mutex.RUnlock()
 

--- a/interop/test_utils.go
+++ b/interop/test_utils.go
@@ -801,7 +801,7 @@ func NewTestServer(opts ...NewTestServerOptions) testgrpc.TestServiceServer {
 	return &testServer{}
 }
 
-func (s *testServer) EmptyCall(ctx context.Context, in *testpb.Empty) (*testpb.Empty, error) {
+func (s *testServer) EmptyCall(context.Context, *testpb.Empty) (*testpb.Empty, error) {
 	return new(testpb.Empty), nil
 }
 

--- a/interop/xds/client/client.go
+++ b/interop/xds/client/client.go
@@ -279,7 +279,7 @@ func (s *statsService) GetClientStats(ctx context.Context, in *testpb.LoadBalanc
 	}
 }
 
-func (s *statsService) GetClientAccumulatedStats(ctx context.Context, in *testpb.LoadBalancerAccumulatedStatsRequest) (*testpb.LoadBalancerAccumulatedStatsResponse, error) {
+func (s *statsService) GetClientAccumulatedStats(context.Context, *testpb.LoadBalancerAccumulatedStatsRequest) (*testpb.LoadBalancerAccumulatedStatsResponse, error) {
 	return accStats.buildResp(), nil
 }
 
@@ -287,7 +287,7 @@ type configureService struct {
 	testgrpc.UnimplementedXdsUpdateClientConfigureServiceServer
 }
 
-func (s *configureService) Configure(ctx context.Context, in *testpb.ClientConfigureRequest) (*testpb.ClientConfigureResponse, error) {
+func (s *configureService) Configure(_ context.Context, in *testpb.ClientConfigureRequest) (*testpb.ClientConfigureResponse, error) {
 	rpcsToMD := make(map[testpb.ClientConfigureRequest_RpcType][]string)
 	for _, typ := range in.GetTypes() {
 		rpcsToMD[typ] = nil

--- a/interop/xds/custom_lb_test.go
+++ b/interop/xds/custom_lb_test.go
@@ -58,7 +58,7 @@ func (s) TestCustomLB(t *testing.T) {
 	// Setup a backend which verifies the expected rpc-behavior metadata is
 	// present in the request.
 	backend := &stubserver.StubServer{
-		UnaryCallF: func(ctx context.Context, in *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
+		UnaryCallF: func(ctx context.Context, _ *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
 			md, ok := metadata.FromIncomingContext(ctx)
 			if !ok {
 				errCh.Send(errors.New("failed to receive metadata"))

--- a/mem/buffers.go
+++ b/mem/buffers.go
@@ -224,11 +224,11 @@ func (e emptyBuffer) Len() int {
 	return 0
 }
 
-func (e emptyBuffer) split(n int) (left, right Buffer) {
+func (e emptyBuffer) split(int) (left, right Buffer) {
 	return e, e
 }
 
-func (e emptyBuffer) read(buf []byte) (int, Buffer) {
+func (e emptyBuffer) read([]byte) (int, Buffer) {
 	return 0, e
 }
 

--- a/orca/call_metrics.go
+++ b/orca/call_metrics.go
@@ -156,7 +156,7 @@ func unaryInt(smp ServerMetricsProvider) func(ctx context.Context, req any, _ *g
 }
 
 func streamInt(smp ServerMetricsProvider) func(srv any, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
-	return func(srv any, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+	return func(srv any, ss grpc.ServerStream, _ *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 		// We don't allocate the metric recorder here. It will be allocated the
 		// first time the user calls CallMetricsRecorderFromContext().
 		rw := &recorderWrapper{smp: smp}

--- a/picker_wrapper_test.go
+++ b/picker_wrapper_test.go
@@ -56,7 +56,7 @@ type testingPicker struct {
 	maxCalled int64
 }
 
-func (p *testingPicker) Pick(info balancer.PickInfo) (balancer.PickResult, error) {
+func (p *testingPicker) Pick(balancer.PickInfo) (balancer.PickResult, error) {
 	if atomic.AddInt64(&p.maxCalled, -1) < 0 {
 		return balancer.PickResult{}, fmt.Errorf("pick called to many times (> goroutineCount)")
 	}

--- a/profiling/service/service.go
+++ b/profiling/service/service.go
@@ -99,7 +99,7 @@ func getProfilingServerInstance() *profilingServer {
 	return profilingServerInstance
 }
 
-func (s *profilingServer) Enable(ctx context.Context, req *ppb.EnableRequest) (*ppb.EnableResponse, error) {
+func (s *profilingServer) Enable(_ context.Context, req *ppb.EnableRequest) (*ppb.EnableResponse, error) {
 	if req.Enabled {
 		logger.Infof("profilingServer: Enable: enabling profiling")
 	} else {
@@ -133,7 +133,7 @@ func statToProtoStat(stat *profiling.Stat) *ppb.Stat {
 	return protoStat
 }
 
-func (s *profilingServer) GetStreamStats(ctx context.Context, req *ppb.GetStreamStatsRequest) (*ppb.GetStreamStatsResponse, error) {
+func (s *profilingServer) GetStreamStats(context.Context, *ppb.GetStreamStatsRequest) (*ppb.GetStreamStatsResponse, error) {
 	// Since the drain operation is destructive, only one client request should
 	// be served at a time.
 	logger.Infof("profilingServer: GetStreamStats: processing request")

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -55,7 +55,7 @@ func (s) TestResolverCaseSensitivity(t *testing.T) {
 	// into a loopback IP (v4 or v6) address.
 	target := "caseTest:///localhost:1234"
 	addrCh := make(chan string, 1)
-	customDialer := func(ctx context.Context, addr string) (net.Conn, error) {
+	customDialer := func(_ context.Context, addr string) (net.Conn, error) {
 		select {
 		case addrCh <- addr:
 		default:

--- a/rpc_util.go
+++ b/rpc_util.go
@@ -220,8 +220,8 @@ type HeaderCallOption struct {
 	HeaderAddr *metadata.MD
 }
 
-func (o HeaderCallOption) before(c *callInfo) error { return nil }
-func (o HeaderCallOption) after(c *callInfo, attempt *csAttempt) {
+func (o HeaderCallOption) before(*callInfo) error { return nil }
+func (o HeaderCallOption) after(_ *callInfo, attempt *csAttempt) {
 	*o.HeaderAddr, _ = attempt.s.Header()
 }
 
@@ -242,8 +242,8 @@ type TrailerCallOption struct {
 	TrailerAddr *metadata.MD
 }
 
-func (o TrailerCallOption) before(c *callInfo) error { return nil }
-func (o TrailerCallOption) after(c *callInfo, attempt *csAttempt) {
+func (o TrailerCallOption) before(*callInfo) error { return nil }
+func (o TrailerCallOption) after(_ *callInfo, attempt *csAttempt) {
 	*o.TrailerAddr = attempt.s.Trailer()
 }
 
@@ -264,8 +264,8 @@ type PeerCallOption struct {
 	PeerAddr *peer.Peer
 }
 
-func (o PeerCallOption) before(c *callInfo) error { return nil }
-func (o PeerCallOption) after(c *callInfo, attempt *csAttempt) {
+func (o PeerCallOption) before(*callInfo) error { return nil }
+func (o PeerCallOption) after(_ *callInfo, attempt *csAttempt) {
 	if x, ok := peer.FromContext(attempt.s.Context()); ok {
 		*o.PeerAddr = *x
 	}
@@ -304,7 +304,7 @@ func (o FailFastCallOption) before(c *callInfo) error {
 	c.failFast = o.FailFast
 	return nil
 }
-func (o FailFastCallOption) after(c *callInfo, attempt *csAttempt) {}
+func (o FailFastCallOption) after(*callInfo, *csAttempt) {}
 
 // OnFinish returns a CallOption that configures a callback to be called when
 // the call completes. The error passed to the callback is the status of the
@@ -339,7 +339,7 @@ func (o OnFinishCallOption) before(c *callInfo) error {
 	return nil
 }
 
-func (o OnFinishCallOption) after(c *callInfo, attempt *csAttempt) {}
+func (o OnFinishCallOption) after(*callInfo, *csAttempt) {}
 
 // MaxCallRecvMsgSize returns a CallOption which sets the maximum message size
 // in bytes the client can receive. If this is not set, gRPC uses the default
@@ -363,7 +363,7 @@ func (o MaxRecvMsgSizeCallOption) before(c *callInfo) error {
 	c.maxReceiveMessageSize = &o.MaxRecvMsgSize
 	return nil
 }
-func (o MaxRecvMsgSizeCallOption) after(c *callInfo, attempt *csAttempt) {}
+func (o MaxRecvMsgSizeCallOption) after(*callInfo, *csAttempt) {}
 
 // MaxCallSendMsgSize returns a CallOption which sets the maximum message size
 // in bytes the client can send. If this is not set, gRPC uses the default
@@ -387,7 +387,7 @@ func (o MaxSendMsgSizeCallOption) before(c *callInfo) error {
 	c.maxSendMessageSize = &o.MaxSendMsgSize
 	return nil
 }
-func (o MaxSendMsgSizeCallOption) after(c *callInfo, attempt *csAttempt) {}
+func (o MaxSendMsgSizeCallOption) after(*callInfo, *csAttempt) {}
 
 // PerRPCCredentials returns a CallOption that sets credentials.PerRPCCredentials
 // for a call.
@@ -410,7 +410,7 @@ func (o PerRPCCredsCallOption) before(c *callInfo) error {
 	c.creds = o.Creds
 	return nil
 }
-func (o PerRPCCredsCallOption) after(c *callInfo, attempt *csAttempt) {}
+func (o PerRPCCredsCallOption) after(*callInfo, *csAttempt) {}
 
 // UseCompressor returns a CallOption which sets the compressor used when
 // sending the request.  If WithCompressor is also set, UseCompressor has
@@ -438,7 +438,7 @@ func (o CompressorCallOption) before(c *callInfo) error {
 	c.compressorType = o.CompressorType
 	return nil
 }
-func (o CompressorCallOption) after(c *callInfo, attempt *csAttempt) {}
+func (o CompressorCallOption) after(*callInfo, *csAttempt) {}
 
 // CallContentSubtype returns a CallOption that will set the content-subtype
 // for a call. For example, if content-subtype is "json", the Content-Type over
@@ -475,7 +475,7 @@ func (o ContentSubtypeCallOption) before(c *callInfo) error {
 	c.contentSubtype = o.ContentSubtype
 	return nil
 }
-func (o ContentSubtypeCallOption) after(c *callInfo, attempt *csAttempt) {}
+func (o ContentSubtypeCallOption) after(*callInfo, *csAttempt) {}
 
 // ForceCodec returns a CallOption that will set codec to be used for all
 // request and response messages for a call. The result of calling Name() will
@@ -514,7 +514,7 @@ func (o ForceCodecCallOption) before(c *callInfo) error {
 	c.codec = newCodecV1Bridge(o.Codec)
 	return nil
 }
-func (o ForceCodecCallOption) after(c *callInfo, attempt *csAttempt) {}
+func (o ForceCodecCallOption) after(*callInfo, *csAttempt) {}
 
 // ForceCodecV2 returns a CallOption that will set codec to be used for all
 // request and response messages for a call. The result of calling Name() will
@@ -554,7 +554,7 @@ func (o ForceCodecV2CallOption) before(c *callInfo) error {
 	return nil
 }
 
-func (o ForceCodecV2CallOption) after(c *callInfo, attempt *csAttempt) {}
+func (o ForceCodecV2CallOption) after(*callInfo, *csAttempt) {}
 
 // CallCustomCodec behaves like ForceCodec, but accepts a grpc.Codec instead of
 // an encoding.Codec.
@@ -579,7 +579,7 @@ func (o CustomCodecCallOption) before(c *callInfo) error {
 	c.codec = newCodecV0Bridge(o.Codec)
 	return nil
 }
-func (o CustomCodecCallOption) after(c *callInfo, attempt *csAttempt) {}
+func (o CustomCodecCallOption) after(*callInfo, *csAttempt) {}
 
 // MaxRetryRPCBufferSize returns a CallOption that limits the amount of memory
 // used for buffering this RPC's requests for retry purposes.
@@ -607,7 +607,7 @@ func (o MaxRetryRPCBufferSizeCallOption) before(c *callInfo) error {
 	c.maxRetryRPCBufferSize = o.MaxRetryRPCBufferSize
 	return nil
 }
-func (o MaxRetryRPCBufferSizeCallOption) after(c *callInfo, attempt *csAttempt) {}
+func (o MaxRetryRPCBufferSizeCallOption) after(*callInfo, *csAttempt) {}
 
 // The format of the payload: compressed or not?
 type payloadFormat uint8

--- a/scripts/vet.sh
+++ b/scripts/vet.sh
@@ -178,10 +178,9 @@ done
 
 # Collection of revive linter analysis checks
 REV_OUT="$(mktemp)"
-revive -formatter plain ./... >"${REV_OUT}" || true
+revive -set_exit_status=1 -exclude "reflection/test/grpc_testing_not_regenerate/" -formatter plain ./... >"${REV_OUT}" || true
 
-# Error for anything other than unused-parameter linter check and in generated code.
 # TODO: Remove `|| true` to unskip linter failures once existing issues are fixed.
-(noret_grep -v "unused-parameter" "${REV_OUT}" | not grep -v "\.pb\.go:") || true
+(not grep -v "\.pb\.go:" "${REV_OUT}") || true
 
 echo SUCCESS

--- a/security/advancedtls/advancedtls_integration_test.go
+++ b/security/advancedtls/advancedtls_integration_test.go
@@ -80,7 +80,7 @@ type greeterServer struct {
 }
 
 // sayHello is a simple implementation of the pb.GreeterServer SayHello method.
-func (greeterServer) SayHello(ctx context.Context, in *pb.HelloRequest) (*pb.HelloReply, error) {
+func (greeterServer) SayHello(_ context.Context, in *pb.HelloRequest) (*pb.HelloReply, error) {
 	return &pb.HelloReply{Message: "Hello " + in.Name}, nil
 }
 
@@ -175,12 +175,12 @@ func (s) TestEnd2End(t *testing.T) {
 				}
 			},
 			clientRoot: cs.ClientTrust1,
-			clientVerifyFunc: func(params *HandshakeVerificationInfo) (*PostHandshakeVerificationResults, error) {
+			clientVerifyFunc: func(*HandshakeVerificationInfo) (*PostHandshakeVerificationResults, error) {
 				return &PostHandshakeVerificationResults{}, nil
 			},
 			clientVerificationType: CertVerification,
 			serverCert:             []tls.Certificate{cs.ServerCert1},
-			serverGetRoot: func(params *ConnectionInfo) (*RootCertificates, error) {
+			serverGetRoot: func(*ConnectionInfo) (*RootCertificates, error) {
 				switch stage.read() {
 				case 0, 1:
 					return &RootCertificates{TrustCerts: cs.ServerTrust1}, nil
@@ -188,7 +188,7 @@ func (s) TestEnd2End(t *testing.T) {
 					return &RootCertificates{TrustCerts: cs.ServerTrust2}, nil
 				}
 			},
-			serverVerifyFunc: func(params *HandshakeVerificationInfo) (*PostHandshakeVerificationResults, error) {
+			serverVerifyFunc: func(*HandshakeVerificationInfo) (*PostHandshakeVerificationResults, error) {
 				return &PostHandshakeVerificationResults{}, nil
 			},
 			serverVerificationType: CertVerification,
@@ -208,7 +208,7 @@ func (s) TestEnd2End(t *testing.T) {
 		{
 			desc:       "test the reloading feature for server identity callback and client trust callback",
 			clientCert: []tls.Certificate{cs.ClientCert1},
-			clientGetRoot: func(params *ConnectionInfo) (*RootCertificates, error) {
+			clientGetRoot: func(*ConnectionInfo) (*RootCertificates, error) {
 				switch stage.read() {
 				case 0, 1:
 					return &RootCertificates{TrustCerts: cs.ClientTrust1}, nil
@@ -216,7 +216,7 @@ func (s) TestEnd2End(t *testing.T) {
 					return &RootCertificates{TrustCerts: cs.ClientTrust2}, nil
 				}
 			},
-			clientVerifyFunc: func(params *HandshakeVerificationInfo) (*PostHandshakeVerificationResults, error) {
+			clientVerifyFunc: func(*HandshakeVerificationInfo) (*PostHandshakeVerificationResults, error) {
 				return &PostHandshakeVerificationResults{}, nil
 			},
 			clientVerificationType: CertVerification,
@@ -229,7 +229,7 @@ func (s) TestEnd2End(t *testing.T) {
 				}
 			},
 			serverRoot: cs.ServerTrust1,
-			serverVerifyFunc: func(params *HandshakeVerificationInfo) (*PostHandshakeVerificationResults, error) {
+			serverVerifyFunc: func(*HandshakeVerificationInfo) (*PostHandshakeVerificationResults, error) {
 				return &PostHandshakeVerificationResults{}, nil
 			},
 			serverVerificationType: CertVerification,
@@ -250,7 +250,7 @@ func (s) TestEnd2End(t *testing.T) {
 		{
 			desc:       "test client custom verification",
 			clientCert: []tls.Certificate{cs.ClientCert1},
-			clientGetRoot: func(params *ConnectionInfo) (*RootCertificates, error) {
+			clientGetRoot: func(*ConnectionInfo) (*RootCertificates, error) {
 				switch stage.read() {
 				case 0:
 					return &RootCertificates{TrustCerts: cs.ClientTrust1}, nil
@@ -294,7 +294,7 @@ func (s) TestEnd2End(t *testing.T) {
 				}
 			},
 			serverRoot: cs.ServerTrust1,
-			serverVerifyFunc: func(params *HandshakeVerificationInfo) (*PostHandshakeVerificationResults, error) {
+			serverVerifyFunc: func(*HandshakeVerificationInfo) (*PostHandshakeVerificationResults, error) {
 				return &PostHandshakeVerificationResults{}, nil
 			},
 			serverVerificationType: CertVerification,
@@ -314,13 +314,13 @@ func (s) TestEnd2End(t *testing.T) {
 			desc:       "TestServerCustomVerification",
 			clientCert: []tls.Certificate{cs.ClientCert1},
 			clientRoot: cs.ClientTrust1,
-			clientVerifyFunc: func(params *HandshakeVerificationInfo) (*PostHandshakeVerificationResults, error) {
+			clientVerifyFunc: func(*HandshakeVerificationInfo) (*PostHandshakeVerificationResults, error) {
 				return &PostHandshakeVerificationResults{}, nil
 			},
 			clientVerificationType: CertVerification,
 			serverCert:             []tls.Certificate{cs.ServerCert1},
 			serverRoot:             cs.ServerTrust1,
-			serverVerifyFunc: func(params *HandshakeVerificationInfo) (*PostHandshakeVerificationResults, error) {
+			serverVerifyFunc: func(*HandshakeVerificationInfo) (*PostHandshakeVerificationResults, error) {
 				switch stage.read() {
 				case 0, 2:
 					return &PostHandshakeVerificationResults{}, nil
@@ -635,7 +635,7 @@ func (s) TestPEMFileProviderEnd2End(t *testing.T) {
 					RootProvider: serverRootProvider,
 				},
 				RequireClientCert: true,
-				AdditionalPeerVerification: func(params *HandshakeVerificationInfo) (*PostHandshakeVerificationResults, error) {
+				AdditionalPeerVerification: func(*HandshakeVerificationInfo) (*PostHandshakeVerificationResults, error) {
 					return &PostHandshakeVerificationResults{}, nil
 				},
 				VerificationType: CertVerification,
@@ -658,7 +658,7 @@ func (s) TestPEMFileProviderEnd2End(t *testing.T) {
 				IdentityOptions: IdentityCertificateOptions{
 					IdentityProvider: clientIdentityProvider,
 				},
-				AdditionalPeerVerification: func(params *HandshakeVerificationInfo) (*PostHandshakeVerificationResults, error) {
+				AdditionalPeerVerification: func(*HandshakeVerificationInfo) (*PostHandshakeVerificationResults, error) {
 					return &PostHandshakeVerificationResults{}, nil
 				},
 				RootOptions: RootCertificateOptions{

--- a/security/advancedtls/advancedtls_test.go
+++ b/security/advancedtls/advancedtls_test.go
@@ -59,7 +59,7 @@ type fakeProvider struct {
 	wantError     bool
 }
 
-func (f fakeProvider) KeyMaterial(ctx context.Context) (*certprovider.KeyMaterial, error) {
+func (f fakeProvider) KeyMaterial(context.Context) (*certprovider.KeyMaterial, error) {
 	if f.wantError {
 		return nil, fmt.Errorf("bad fakeProvider")
 	}
@@ -391,7 +391,7 @@ func (s) TestClientServerHandshake(t *testing.T) {
 	if err := cs.LoadCerts(); err != nil {
 		t.Fatalf("cs.LoadCerts() failed, err: %v", err)
 	}
-	getRootCertificatesForClient := func(params *ConnectionInfo) (*RootCertificates, error) {
+	getRootCertificatesForClient := func(*ConnectionInfo) (*RootCertificates, error) {
 		return &RootCertificates{TrustCerts: cs.ClientTrust1}, nil
 	}
 
@@ -406,10 +406,10 @@ func (s) TestClientServerHandshake(t *testing.T) {
 
 		return &PostHandshakeVerificationResults{}, nil
 	}
-	verifyFuncBad := func(params *HandshakeVerificationInfo) (*PostHandshakeVerificationResults, error) {
+	verifyFuncBad := func(*HandshakeVerificationInfo) (*PostHandshakeVerificationResults, error) {
 		return nil, fmt.Errorf("custom verification function failed")
 	}
-	getRootCertificatesForServer := func(params *ConnectionInfo) (*RootCertificates, error) {
+	getRootCertificatesForServer := func(*ConnectionInfo) (*RootCertificates, error) {
 		return &RootCertificates{TrustCerts: cs.ServerTrust1}, nil
 	}
 	serverVerifyFunc := func(params *HandshakeVerificationInfo) (*PostHandshakeVerificationResults, error) {
@@ -423,15 +423,15 @@ func (s) TestClientServerHandshake(t *testing.T) {
 
 		return &PostHandshakeVerificationResults{}, nil
 	}
-	getRootCertificatesForServerBad := func(params *ConnectionInfo) (*RootCertificates, error) {
+	getRootCertificatesForServerBad := func(*ConnectionInfo) (*RootCertificates, error) {
 		return nil, fmt.Errorf("bad root certificate reloading")
 	}
 
-	getRootCertificatesForClientCRL := func(params *ConnectionInfo) (*RootCertificates, error) {
+	getRootCertificatesForClientCRL := func(*ConnectionInfo) (*RootCertificates, error) {
 		return &RootCertificates{TrustCerts: cs.ClientTrust3}, nil
 	}
 
-	getRootCertificatesForServerCRL := func(params *ConnectionInfo) (*RootCertificates, error) {
+	getRootCertificatesForServerCRL := func(*ConnectionInfo) (*RootCertificates, error) {
 		return &RootCertificates{TrustCerts: cs.ServerTrust3}, nil
 	}
 
@@ -558,14 +558,14 @@ func (s) TestClientServerHandshake(t *testing.T) {
 		// Expected Behavior: success
 		{
 			desc: "Client sets reload peer/root function with verifyFuncGood; Server sets reload peer/root function with verifyFuncGood; mutualTLS",
-			clientGetCert: func(info *tls.CertificateRequestInfo) (*tls.Certificate, error) {
+			clientGetCert: func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
 				return &cs.ClientCert1, nil
 			},
 			clientGetRoot:          getRootCertificatesForClient,
 			clientVerifyFunc:       clientVerifyFuncGood,
 			clientVerificationType: CertVerification,
 			serverMutualTLS:        true,
-			serverGetCert: func(info *tls.ClientHelloInfo) ([]*tls.Certificate, error) {
+			serverGetCert: func(*tls.ClientHelloInfo) ([]*tls.Certificate, error) {
 				return []*tls.Certificate{&cs.ServerCert1}, nil
 			},
 			serverGetRoot:          getRootCertificatesForServer,
@@ -579,14 +579,14 @@ func (s) TestClientServerHandshake(t *testing.T) {
 		// certificate mismatch
 		{
 			desc: "Client sends wrong peer cert; Server sets reload peer/root function with verifyFuncGood; mutualTLS",
-			clientGetCert: func(info *tls.CertificateRequestInfo) (*tls.Certificate, error) {
+			clientGetCert: func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
 				return &cs.ServerCert1, nil
 			},
 			clientGetRoot:          getRootCertificatesForClient,
 			clientVerifyFunc:       clientVerifyFuncGood,
 			clientVerificationType: CertVerification,
 			serverMutualTLS:        true,
-			serverGetCert: func(info *tls.ClientHelloInfo) ([]*tls.Certificate, error) {
+			serverGetCert: func(*tls.ClientHelloInfo) ([]*tls.Certificate, error) {
 				return []*tls.Certificate{&cs.ServerCert1}, nil
 			},
 			serverGetRoot:          getRootCertificatesForServer,
@@ -600,7 +600,7 @@ func (s) TestClientServerHandshake(t *testing.T) {
 		// certificate mismatch and handshake failure
 		{
 			desc: "Client has wrong trust cert; Server sets reload peer/root function with verifyFuncGood; mutualTLS",
-			clientGetCert: func(info *tls.CertificateRequestInfo) (*tls.Certificate, error) {
+			clientGetCert: func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
 				return &cs.ClientCert1, nil
 			},
 			clientGetRoot:              getRootCertificatesForServer,
@@ -608,7 +608,7 @@ func (s) TestClientServerHandshake(t *testing.T) {
 			clientVerificationType:     CertVerification,
 			clientExpectHandshakeError: true,
 			serverMutualTLS:            true,
-			serverGetCert: func(info *tls.ClientHelloInfo) ([]*tls.Certificate, error) {
+			serverGetCert: func(*tls.ClientHelloInfo) ([]*tls.Certificate, error) {
 				return []*tls.Certificate{&cs.ServerCert1}, nil
 			},
 			serverGetRoot:          getRootCertificatesForServer,
@@ -623,14 +623,14 @@ func (s) TestClientServerHandshake(t *testing.T) {
 		// certificate mismatch and handshake failure
 		{
 			desc: "Client sets reload peer/root function with verifyFuncGood; Server sends wrong peer cert; mutualTLS",
-			clientGetCert: func(info *tls.CertificateRequestInfo) (*tls.Certificate, error) {
+			clientGetCert: func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
 				return &cs.ClientCert1, nil
 			},
 			clientGetRoot:          getRootCertificatesForClient,
 			clientVerifyFunc:       clientVerifyFuncGood,
 			clientVerificationType: CertVerification,
 			serverMutualTLS:        true,
-			serverGetCert: func(info *tls.ClientHelloInfo) ([]*tls.Certificate, error) {
+			serverGetCert: func(*tls.ClientHelloInfo) ([]*tls.Certificate, error) {
 				return []*tls.Certificate{&cs.ClientCert1}, nil
 			},
 			serverGetRoot:          getRootCertificatesForServer,
@@ -644,7 +644,7 @@ func (s) TestClientServerHandshake(t *testing.T) {
 		// certificate mismatch and handshake failure
 		{
 			desc: "Client sets reload peer/root function with verifyFuncGood; Server has wrong trust cert; mutualTLS",
-			clientGetCert: func(info *tls.CertificateRequestInfo) (*tls.Certificate, error) {
+			clientGetCert: func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
 				return &cs.ClientCert1, nil
 			},
 			clientGetRoot:              getRootCertificatesForClient,
@@ -652,7 +652,7 @@ func (s) TestClientServerHandshake(t *testing.T) {
 			clientVerificationType:     CertVerification,
 			clientExpectHandshakeError: true,
 			serverMutualTLS:            true,
-			serverGetCert: func(info *tls.ClientHelloInfo) ([]*tls.Certificate, error) {
+			serverGetCert: func(*tls.ClientHelloInfo) ([]*tls.Certificate, error) {
 				return []*tls.Certificate{&cs.ServerCert1}, nil
 			},
 			serverGetRoot:          getRootCertificatesForClient,
@@ -1040,7 +1040,7 @@ func (s) TestGetCertificatesSNI(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			serverOptions := &Options{
 				IdentityOptions: IdentityCertificateOptions{
-					GetIdentityCertificatesForServer: func(info *tls.ClientHelloInfo) ([]*tls.Certificate, error) {
+					GetIdentityCertificatesForServer: func(*tls.ClientHelloInfo) ([]*tls.Certificate, error) {
 						return []*tls.Certificate{&cs.ServerCert1, &cs.ServerCert2, &cs.ServerPeer3}, nil
 					},
 				},

--- a/security/advancedtls/examples/credential_reloading_from_files/client/main.go
+++ b/security/advancedtls/examples/credential_reloading_from_files/client/main.go
@@ -76,7 +76,7 @@ func main() {
 		IdentityOptions: advancedtls.IdentityCertificateOptions{
 			IdentityProvider: identityProvider,
 		},
-		AdditionalPeerVerification: func(params *advancedtls.HandshakeVerificationInfo) (*advancedtls.PostHandshakeVerificationResults, error) {
+		AdditionalPeerVerification: func(*advancedtls.HandshakeVerificationInfo) (*advancedtls.PostHandshakeVerificationResults, error) {
 			return &advancedtls.PostHandshakeVerificationResults{}, nil
 		},
 		RootOptions: advancedtls.RootCertificateOptions{

--- a/security/advancedtls/examples/credential_reloading_from_files/server/main.go
+++ b/security/advancedtls/examples/credential_reloading_from_files/server/main.go
@@ -47,7 +47,7 @@ type greeterServer struct {
 }
 
 // sayHello is a simple implementation of the pb.GreeterServer SayHello method.
-func (greeterServer) SayHello(ctx context.Context, in *pb.HelloRequest) (*pb.HelloReply, error) {
+func (greeterServer) SayHello(_ context.Context, in *pb.HelloRequest) (*pb.HelloReply, error) {
 	return &pb.HelloReply{Message: "Hello " + in.Name}, nil
 }
 

--- a/server_test.go
+++ b/server_test.go
@@ -133,24 +133,24 @@ func (s) TestGetServiceInfo(t *testing.T) {
 
 func (s) TestRetryChainedInterceptor(t *testing.T) {
 	var records []int
-	i1 := func(ctx context.Context, req any, info *UnaryServerInfo, handler UnaryHandler) (resp any, err error) {
+	i1 := func(ctx context.Context, req any, _ *UnaryServerInfo, handler UnaryHandler) (resp any, err error) {
 		records = append(records, 1)
 		// call handler twice to simulate a retry here.
 		handler(ctx, req)
 		return handler(ctx, req)
 	}
-	i2 := func(ctx context.Context, req any, info *UnaryServerInfo, handler UnaryHandler) (resp any, err error) {
+	i2 := func(ctx context.Context, req any, _ *UnaryServerInfo, handler UnaryHandler) (resp any, err error) {
 		records = append(records, 2)
 		return handler(ctx, req)
 	}
-	i3 := func(ctx context.Context, req any, info *UnaryServerInfo, handler UnaryHandler) (resp any, err error) {
+	i3 := func(ctx context.Context, req any, _ *UnaryServerInfo, handler UnaryHandler) (resp any, err error) {
 		records = append(records, 3)
 		return handler(ctx, req)
 	}
 
 	ii := chainUnaryInterceptors([]UnaryServerInterceptor{i1, i2, i3})
 
-	handler := func(ctx context.Context, req any) (any, error) {
+	handler := func(context.Context, any) (any, error) {
 		return nil, nil
 	}
 
@@ -185,7 +185,7 @@ func BenchmarkChainUnaryInterceptor(b *testing.B) {
 			interceptors := make([]UnaryServerInterceptor, 0, n)
 			for i := 0; i < n; i++ {
 				interceptors = append(interceptors, func(
-					ctx context.Context, req any, info *UnaryServerInfo, handler UnaryHandler,
+					ctx context.Context, req any, _ *UnaryServerInfo, handler UnaryHandler,
 				) (any, error) {
 					return handler(ctx, req)
 				})
@@ -196,7 +196,7 @@ func BenchmarkChainUnaryInterceptor(b *testing.B) {
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				if _, err := s.opts.unaryInt(ctx, nil, nil,
-					func(ctx context.Context, req any) (any, error) {
+					func(context.Context, any) (any, error) {
 						return nil, nil
 					},
 				); err != nil {
@@ -214,7 +214,7 @@ func BenchmarkChainStreamInterceptor(b *testing.B) {
 			interceptors := make([]StreamServerInterceptor, 0, n)
 			for i := 0; i < n; i++ {
 				interceptors = append(interceptors, func(
-					srv any, ss ServerStream, info *StreamServerInfo, handler StreamHandler,
+					srv any, ss ServerStream, _ *StreamServerInfo, handler StreamHandler,
 				) error {
 					return handler(srv, ss)
 				})
@@ -224,7 +224,7 @@ func BenchmarkChainStreamInterceptor(b *testing.B) {
 			b.ReportAllocs()
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				if err := s.opts.streamInt(nil, nil, nil, func(srv any, stream ServerStream) error {
+				if err := s.opts.streamInt(nil, nil, nil, func(any, ServerStream) error {
 					return nil
 				}); err != nil {
 					b.Fatal(err)

--- a/service_config_test.go
+++ b/service_config_test.go
@@ -93,7 +93,7 @@ func (parseBalancerBuilder) ParseConfig(c json.RawMessage) (serviceconfig.LoadBa
 	return d, nil
 }
 
-func (parseBalancerBuilder) Build(cc balancer.ClientConn, opts balancer.BuildOptions) balancer.Balancer {
+func (parseBalancerBuilder) Build(balancer.ClientConn, balancer.BuildOptions) balancer.Balancer {
 	panic("unimplemented")
 }
 

--- a/stats/opencensus/e2e_test.go
+++ b/stats/opencensus/e2e_test.go
@@ -307,7 +307,7 @@ func (s) TestAllMetricsOneFunction(t *testing.T) {
 	defer view.UnregisterExporter(fe)
 
 	ss := &stubserver.StubServer{
-		UnaryCallF: func(ctx context.Context, in *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
+		UnaryCallF: func(context.Context, *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
 			return &testpb.SimpleResponse{Payload: &testpb.Payload{
 				Body: make([]byte, 10000),
 			}}, nil
@@ -1072,7 +1072,7 @@ func (s) TestOpenCensusTags(t *testing.T) {
 	// populated at the client side application layer if populated.
 	tmCh := testutils.NewChannel()
 	ss := &stubserver.StubServer{
-		UnaryCallF: func(ctx context.Context, in *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
+		UnaryCallF: func(ctx context.Context, _ *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
 			// Do the sends of the tag maps for assertions in this main testing
 			// goroutine. Do the receives and assertions in a forked goroutine.
 			if tm := tag.FromContext(ctx); tm != nil {
@@ -1404,7 +1404,7 @@ func (s) TestSpan(t *testing.T) {
 		DisableTrace: false,
 	}
 	ss := &stubserver.StubServer{
-		UnaryCallF: func(ctx context.Context, in *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
+		UnaryCallF: func(context.Context, *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
 			return &testpb.SimpleResponse{}, nil
 		},
 		FullDuplexCallF: func(stream testgrpc.TestService_FullDuplexCallServer) error {

--- a/stats/opencensus/trace.go
+++ b/stats/opencensus/trace.go
@@ -81,7 +81,7 @@ func (ssh *serverStatsHandler) traceTagRPC(ctx context.Context, rti *stats.RPCTa
 // populateSpan populates span information based on stats passed in (invariants
 // of the RPC lifecycle), and also ends span which triggers the span to be
 // exported.
-func populateSpan(ctx context.Context, rs stats.RPCStats, ti *traceInfo) {
+func populateSpan(_ context.Context, rs stats.RPCStats, ti *traceInfo) {
 	if ti == nil || ti.span == nil {
 		// Shouldn't happen, tagRPC call comes before this function gets called
 		// which populates this information.

--- a/stats/opentelemetry/csm/observability_test.go
+++ b/stats/opentelemetry/csm/observability_test.go
@@ -134,7 +134,7 @@ func (s) TestCSMPluginOptionUnary(t *testing.T) {
 	}{
 		{
 			name: "normal-flow",
-			unaryCallFunc: func(ctx context.Context, in *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
+			unaryCallFunc: func(_ context.Context, in *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
 				return &testpb.SimpleResponse{Payload: &testpb.Payload{
 					Body: make([]byte, len(in.GetPayload().GetBody())),
 				}}, nil
@@ -146,7 +146,7 @@ func (s) TestCSMPluginOptionUnary(t *testing.T) {
 		},
 		{
 			name: "trailers-only",
-			unaryCallFunc: func(ctx context.Context, in *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
+			unaryCallFunc: func(context.Context, *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
 				return nil, errors.New("some error") // return an error and no message - this triggers trailers only - no messages or headers sent
 			},
 			opts: itestutils.MetricDataOptions{
@@ -184,7 +184,7 @@ func (s) TestCSMPluginOptionUnary(t *testing.T) {
 		},
 		{
 			name: "send-msg",
-			unaryCallFunc: func(ctx context.Context, in *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
+			unaryCallFunc: func(_ context.Context, in *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
 				return &testpb.SimpleResponse{Payload: &testpb.Payload{
 					Body: make([]byte, len(in.GetPayload().GetBody())),
 				}}, nil
@@ -453,7 +453,7 @@ func (s) TestXDSLabels(t *testing.T) {
 	reader := metric.NewManualReader()
 	provider := metric.NewMeterProvider(metric.WithReader(reader))
 	ss := &stubserver.StubServer{
-		UnaryCallF: func(ctx context.Context, in *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
+		UnaryCallF: func(_ context.Context, in *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
 			return &testpb.SimpleResponse{Payload: &testpb.Payload{
 				Body: make([]byte, len(in.GetPayload().GetBody())),
 			}}, nil
@@ -607,7 +607,7 @@ func (s) TestXDSLabels(t *testing.T) {
 // TestObservability tests that Observability global function compiles and runs
 // without error. The actual functionality of this function will be verified in
 // interop tests.
-func (s) TestObservability(t *testing.T) {
+func (s) TestObservability(*testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
 

--- a/stats/opentelemetry/server_metrics.go
+++ b/stats/opentelemetry/server_metrics.go
@@ -90,7 +90,7 @@ func (s *attachLabelsTransportStream) SendHeader(md metadata.MD) error {
 	return s.ServerTransportStream.SendHeader(md)
 }
 
-func (h *serverStatsHandler) unaryInterceptor(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+func (h *serverStatsHandler) unaryInterceptor(ctx context.Context, req any, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
 	var metadataExchangeLabels metadata.MD
 	if h.options.MetricsOptions.pluginOption != nil {
 		metadataExchangeLabels = h.options.MetricsOptions.pluginOption.GetMetadata()
@@ -151,7 +151,7 @@ func (s *attachLabelsStream) SendMsg(m any) error {
 	return s.ServerStream.SendMsg(m)
 }
 
-func (h *serverStatsHandler) streamInterceptor(srv any, ss grpc.ServerStream, ssi *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+func (h *serverStatsHandler) streamInterceptor(srv any, ss grpc.ServerStream, _ *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 	var metadataExchangeLabels metadata.MD
 	if h.options.MetricsOptions.pluginOption != nil {
 		metadataExchangeLabels = h.options.MetricsOptions.pluginOption.GetMetadata()

--- a/test/balancer_switching_test.go
+++ b/test/balancer_switching_test.go
@@ -94,7 +94,7 @@ func startBackendsForBalancerSwitch(t *testing.T) ([]*stubserver.StubServer, fun
 	backends := make([]*stubserver.StubServer, backendCount)
 	for i := 0; i < backendCount; i++ {
 		backend := &stubserver.StubServer{
-			EmptyCallF: func(ctx context.Context, in *testpb.Empty) (*testpb.Empty, error) { return &testpb.Empty{}, nil },
+			EmptyCallF: func(context.Context, *testpb.Empty) (*testpb.Empty, error) { return &testpb.Empty{}, nil },
 		}
 		if err := backend.StartServer(); err != nil {
 			t.Fatalf("Failed to start backend: %v", err)
@@ -375,7 +375,7 @@ func (s) TestBalancerSwitch_OldBalancerCallsShutdownInClose(t *testing.T) {
 			close(uccsCalled)
 			return nil
 		},
-		Close: func(data *stub.BalancerData) {
+		Close: func(*stub.BalancerData) {
 			(<-scChan).Shutdown()
 		},
 	})

--- a/test/balancer_test.go
+++ b/test/balancer_test.go
@@ -71,7 +71,7 @@ type testBalancer struct {
 	doneInfo          []balancer.DoneInfo
 }
 
-func (b *testBalancer) Build(cc balancer.ClientConn, opt balancer.BuildOptions) balancer.Balancer {
+func (b *testBalancer) Build(cc balancer.ClientConn, _ balancer.BuildOptions) balancer.Balancer {
 	b.cc = cc
 	return b
 }
@@ -80,7 +80,7 @@ func (*testBalancer) Name() string {
 	return testBalancerName
 }
 
-func (*testBalancer) ResolverError(err error) {
+func (*testBalancer) ResolverError(error) {
 	panic("not implemented")
 }
 
@@ -308,7 +308,7 @@ func testDoneLoads(t *testing.T) {
 	const testLoad = "test-load-,-should-be-orca"
 
 	ss := &stubserver.StubServer{
-		EmptyCallF: func(ctx context.Context, in *testpb.Empty) (*testpb.Empty, error) {
+		EmptyCallF: func(ctx context.Context, _ *testpb.Empty) (*testpb.Empty, error) {
 			grpc.SetTrailer(ctx, metadata.Pairs(loadMDKey, testLoad))
 			return &testpb.Empty{}, nil
 		},
@@ -359,7 +359,7 @@ type attrTransportCreds struct {
 	attr *attributes.Attributes
 }
 
-func (ac *attrTransportCreds) ClientHandshake(ctx context.Context, addr string, rawConn net.Conn) (net.Conn, credentials.AuthInfo, error) {
+func (ac *attrTransportCreds) ClientHandshake(ctx context.Context, _ string, rawConn net.Conn) (net.Conn, credentials.AuthInfo, error) {
 	ai := credentials.ClientHandshakeInfoFromContext(ctx)
 	ac.attr = ai.Attributes
 	return rawConn, nil, nil
@@ -550,7 +550,7 @@ func (s) TestServersSwap(t *testing.T) {
 		}
 		s := grpc.NewServer()
 		ts := &funcServer{
-			unaryCall: func(ctx context.Context, in *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
+			unaryCall: func(context.Context, *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
 				return &testpb.SimpleResponse{Username: username}, nil
 			},
 		}
@@ -607,7 +607,7 @@ func (s) TestWaitForReady(t *testing.T) {
 	defer s.Stop()
 	const one = "1"
 	ts := &funcServer{
-		unaryCall: func(ctx context.Context, in *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
+		unaryCall: func(context.Context, *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
 			return &testpb.SimpleResponse{Username: one}, nil
 		},
 	}
@@ -662,7 +662,7 @@ type authorityOverrideTransportCreds struct {
 	authorityOverride string
 }
 
-func (ao *authorityOverrideTransportCreds) ClientHandshake(ctx context.Context, addr string, rawConn net.Conn) (net.Conn, credentials.AuthInfo, error) {
+func (ao *authorityOverrideTransportCreds) ClientHandshake(_ context.Context, _ string, rawConn net.Conn) (net.Conn, credentials.AuthInfo, error) {
 	return rawConn, nil, nil
 }
 func (ao *authorityOverrideTransportCreds) Info() credentials.ProtocolInfo {
@@ -913,7 +913,7 @@ type producerTestBalancerBuilder struct {
 	connect    bool
 }
 
-func (bb *producerTestBalancerBuilder) Build(cc balancer.ClientConn, opts balancer.BuildOptions) balancer.Balancer {
+func (bb *producerTestBalancerBuilder) Build(cc balancer.ClientConn, _ balancer.BuildOptions) balancer.Balancer {
 	return &producerTestBalancer{cc: cc, rpcErrChan: bb.rpcErrChan, ctxChan: bb.ctxChan, connect: bb.connect}
 }
 
@@ -1003,7 +1003,7 @@ func (s) TestBalancerProducerBlockUntilReady(t *testing.T) {
 	balancer.Register(&producerTestBalancerBuilder{rpcErrChan: rpcErrChan, ctxChan: ctxChan, connect: true})
 
 	ss := &stubserver.StubServer{
-		EmptyCallF: func(ctx context.Context, in *testpb.Empty) (*testpb.Empty, error) {
+		EmptyCallF: func(context.Context, *testpb.Empty) (*testpb.Empty, error) {
 			return &testpb.Empty{}, nil
 		},
 	}
@@ -1034,7 +1034,7 @@ func (s) TestBalancerProducerHonorsContext(t *testing.T) {
 	balancer.Register(&producerTestBalancerBuilder{rpcErrChan: rpcErrChan, ctxChan: ctxChan, connect: false})
 
 	ss := &stubserver.StubServer{
-		EmptyCallF: func(ctx context.Context, in *testpb.Empty) (*testpb.Empty, error) {
+		EmptyCallF: func(context.Context, *testpb.Empty) (*testpb.Empty, error) {
 			return &testpb.Empty{}, nil
 		},
 	}

--- a/test/compressor_test.go
+++ b/test/compressor_test.go
@@ -73,7 +73,7 @@ func (s) TestUnsupportedEncodingResponse(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			ss := &stubserver.StubServer{
-				UnaryCallF: func(ctx context.Context, in *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
+				UnaryCallF: func(_ context.Context, in *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
 					return &testpb.SimpleResponse{Payload: in.Payload}, nil
 				},
 			}
@@ -301,7 +301,7 @@ func (s) TestClientForwardsGrpcAcceptEncodingHeader(t *testing.T) {
 	decompressor := renameDecompressor{Decompressor: grpc.NewGZIPDecompressor(), name: "testgzip"}
 
 	ss := &stubserver.StubServer{
-		EmptyCallF: func(ctx context.Context, in *testpb.Empty) (*testpb.Empty, error) {
+		EmptyCallF: func(ctx context.Context, _ *testpb.Empty) (*testpb.Empty, error) {
 			md, ok := metadata.FromIncomingContext(ctx)
 			if !ok {
 				return nil, status.Errorf(codes.Internal, "no metadata in context")
@@ -414,7 +414,7 @@ func (s) TestSetSendCompressorSuccess(t *testing.T) {
 func testUnarySetSendCompressorSuccess(t *testing.T, payload *testpb.Payload, resCompressor string, wantCompressInvokes int32, dialOpts []grpc.DialOption) {
 	wc := setupGzipWrapCompressor(t)
 	ss := &stubserver.StubServer{
-		UnaryCallF: func(ctx context.Context, in *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
+		UnaryCallF: func(ctx context.Context, _ *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
 			if err := grpc.SetSendCompressor(ctx, resCompressor); err != nil {
 				return nil, err
 			}
@@ -500,7 +500,7 @@ func (s) TestUnregisteredSetSendCompressorFailure(t *testing.T) {
 
 func testUnarySetSendCompressorFailure(t *testing.T, resCompressor string, wantErr error) {
 	ss := &stubserver.StubServer{
-		EmptyCallF: func(ctx context.Context, in *testpb.Empty) (*testpb.Empty, error) {
+		EmptyCallF: func(ctx context.Context, _ *testpb.Empty) (*testpb.Empty, error) {
 			if err := grpc.SetSendCompressor(ctx, resCompressor); err != nil {
 				return nil, err
 			}
@@ -558,7 +558,7 @@ func testStreamSetSendCompressorFailure(t *testing.T, resCompressor string, want
 
 func (s) TestUnarySetSendCompressorAfterHeaderSendFailure(t *testing.T) {
 	ss := &stubserver.StubServer{
-		EmptyCallF: func(ctx context.Context, in *testpb.Empty) (*testpb.Empty, error) {
+		EmptyCallF: func(ctx context.Context, _ *testpb.Empty) (*testpb.Empty, error) {
 			// Send headers early and then set send compressor.
 			grpc.SendHeader(ctx, metadata.MD{})
 			err := grpc.SetSendCompressor(ctx, "gzip")
@@ -653,7 +653,7 @@ func (s) TestClientSupportedCompressors(t *testing.T) {
 	} {
 		t.Run(tt.desc, func(t *testing.T) {
 			ss := &stubserver.StubServer{
-				EmptyCallF: func(ctx context.Context, in *testpb.Empty) (*testpb.Empty, error) {
+				EmptyCallF: func(ctx context.Context, _ *testpb.Empty) (*testpb.Empty, error) {
 					got, err := grpc.ClientSupportedCompressors(ctx)
 					if err != nil {
 						return nil, err
@@ -763,7 +763,7 @@ func (badGzipCompressor) Type() string {
 
 func (s) TestGzipBadChecksum(t *testing.T) {
 	ss := &stubserver.StubServer{
-		UnaryCallF: func(ctx context.Context, _ *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
+		UnaryCallF: func(context.Context, *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
 			return &testpb.SimpleResponse{}, nil
 		},
 	}

--- a/test/config_selector_test.go
+++ b/test/config_selector_test.go
@@ -50,7 +50,7 @@ func (s) TestConfigSelector(t *testing.T) {
 	gotContextChan := testutils.NewChannelWithSize(1)
 
 	ss := &stubserver.StubServer{
-		EmptyCallF: func(ctx context.Context, in *testpb.Empty) (*testpb.Empty, error) {
+		EmptyCallF: func(ctx context.Context, _ *testpb.Empty) (*testpb.Empty, error) {
 			gotContextChan.SendContext(ctx, ctx)
 			return &testpb.Empty{}, nil
 		},

--- a/test/control_plane_status_test.go
+++ b/test/control_plane_status_test.go
@@ -56,7 +56,7 @@ func (s) TestConfigSelectorStatusCodes(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			ss := &stubserver.StubServer{
-				EmptyCallF: func(ctx context.Context, in *testpb.Empty) (*testpb.Empty, error) {
+				EmptyCallF: func(context.Context, *testpb.Empty) (*testpb.Empty, error) {
 					return &testpb.Empty{}, nil
 				},
 			}
@@ -71,7 +71,7 @@ func (s) TestConfigSelectorStatusCodes(t *testing.T) {
 				Addresses:     []resolver.Address{{Addr: ss.Address}},
 				ServiceConfig: parseServiceConfig(t, ss.R, "{}"),
 			}, funcConfigSelector{
-				f: func(i iresolver.RPCInfo) (*iresolver.RPCConfig, error) {
+				f: func(iresolver.RPCInfo) (*iresolver.RPCConfig, error) {
 					return nil, tc.csErr
 				},
 			})
@@ -104,7 +104,7 @@ func (s) TestPickerStatusCodes(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			ss := &stubserver.StubServer{
-				EmptyCallF: func(ctx context.Context, in *testpb.Empty) (*testpb.Empty, error) {
+				EmptyCallF: func(context.Context, *testpb.Empty) (*testpb.Empty, error) {
 					return &testpb.Empty{}, nil
 				},
 			}
@@ -165,7 +165,7 @@ func (s) TestCallCredsFromDialOptionsStatusCodes(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			ss := &stubserver.StubServer{
-				EmptyCallF: func(ctx context.Context, in *testpb.Empty) (*testpb.Empty, error) {
+				EmptyCallF: func(context.Context, *testpb.Empty) (*testpb.Empty, error) {
 					return &testpb.Empty{}, nil
 				},
 			}
@@ -208,7 +208,7 @@ func (s) TestCallCredsFromCallOptionsStatusCodes(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			ss := &stubserver.StubServer{
-				EmptyCallF: func(ctx context.Context, in *testpb.Empty) (*testpb.Empty, error) {
+				EmptyCallF: func(context.Context, *testpb.Empty) (*testpb.Empty, error) {
 					return &testpb.Empty{}, nil
 				},
 			}

--- a/test/creds_test.go
+++ b/test/creds_test.go
@@ -150,7 +150,7 @@ type clientTimeoutCreds struct {
 	timeoutReturned bool
 }
 
-func (c *clientTimeoutCreds) ClientHandshake(ctx context.Context, addr string, rawConn net.Conn) (net.Conn, credentials.AuthInfo, error) {
+func (c *clientTimeoutCreds) ClientHandshake(_ context.Context, _ string, rawConn net.Conn) (net.Conn, credentials.AuthInfo, error) {
 	if !c.timeoutReturned {
 		c.timeoutReturned = true
 		return nil, nil, context.DeadlineExceeded
@@ -184,7 +184,7 @@ func (s) TestNonFailFastRPCSucceedOnTimeoutCreds(t *testing.T) {
 
 type methodTestCreds struct{}
 
-func (m *methodTestCreds) GetRequestMetadata(ctx context.Context, uri ...string) (map[string]string, error) {
+func (m *methodTestCreds) GetRequestMetadata(ctx context.Context, _ ...string) (map[string]string, error) {
 	ri, _ := credentials.RequestInfoFromContext(ctx)
 	return nil, status.Errorf(codes.Unknown, ri.Method)
 }
@@ -218,7 +218,7 @@ type clientAlwaysFailCred struct {
 	credentials.TransportCredentials
 }
 
-func (c clientAlwaysFailCred) ClientHandshake(ctx context.Context, addr string, rawConn net.Conn) (net.Conn, credentials.AuthInfo, error) {
+func (c clientAlwaysFailCred) ClientHandshake(context.Context, string, net.Conn) (net.Conn, credentials.AuthInfo, error) {
 	return nil, nil, errors.New(clientAlwaysFailCredErrorMsg)
 }
 func (c clientAlwaysFailCred) Info() credentials.ProtocolInfo {
@@ -291,7 +291,7 @@ type testPerRPCCredentials struct {
 	errChan  chan error
 }
 
-func (cr testPerRPCCredentials) GetRequestMetadata(ctx context.Context, uri ...string) (map[string]string, error) {
+func (cr testPerRPCCredentials) GetRequestMetadata(context.Context, ...string) (map[string]string, error) {
 	var err error
 	if cr.errChan != nil {
 		err = <-cr.errChan
@@ -303,7 +303,7 @@ func (cr testPerRPCCredentials) RequireTransportSecurity() bool {
 	return false
 }
 
-func authHandle(ctx context.Context, info *tap.Info) (context.Context, error) {
+func authHandle(ctx context.Context, _ *tap.Info) (context.Context, error) {
 	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
 		return ctx, fmt.Errorf("didn't find metadata in context")
@@ -412,7 +412,7 @@ type authorityCheckCreds struct {
 	got string
 }
 
-func (c *authorityCheckCreds) ClientHandshake(ctx context.Context, authority string, rawConn net.Conn) (net.Conn, credentials.AuthInfo, error) {
+func (c *authorityCheckCreds) ClientHandshake(_ context.Context, authority string, rawConn net.Conn) (net.Conn, credentials.AuthInfo, error) {
 	c.got = authority
 	return rawConn, nil, nil
 }
@@ -489,7 +489,7 @@ type serverDispatchCred struct {
 	rawConnCh chan net.Conn
 }
 
-func (c *serverDispatchCred) ClientHandshake(ctx context.Context, addr string, rawConn net.Conn) (net.Conn, credentials.AuthInfo, error) {
+func (c *serverDispatchCred) ClientHandshake(_ context.Context, _ string, rawConn net.Conn) (net.Conn, credentials.AuthInfo, error) {
 	return rawConn, nil, nil
 }
 func (c *serverDispatchCred) ServerHandshake(rawConn net.Conn) (net.Conn, credentials.AuthInfo, error) {
@@ -505,7 +505,7 @@ func (c *serverDispatchCred) Info() credentials.ProtocolInfo {
 func (c *serverDispatchCred) Clone() credentials.TransportCredentials {
 	return nil
 }
-func (c *serverDispatchCred) OverrideServerName(s string) error {
+func (c *serverDispatchCred) OverrideServerName(string) error {
 	return nil
 }
 func (c *serverDispatchCred) getRawConn() net.Conn {

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -146,7 +146,7 @@ type testServer struct {
 	unaryCallSleepTime time.Duration
 }
 
-func (s *testServer) EmptyCall(ctx context.Context, in *testpb.Empty) (*testpb.Empty, error) {
+func (s *testServer) EmptyCall(ctx context.Context, _ *testpb.Empty) (*testpb.Empty, error) {
 	if md, ok := metadata.FromIncomingContext(ctx); ok {
 		// For testing purpose, returns an error if user-agent is failAppUA.
 		// To test that client gets the correct error.
@@ -1011,7 +1011,7 @@ func (s) TestDetailedConnectionCloseErrorPropagatesToRPCError(t *testing.T) {
 	rpcDoneOnClient := make(chan struct{})
 	defer close(rpcDoneOnClient)
 	ss := &stubserver.StubServer{
-		FullDuplexCallF: func(stream testgrpc.TestService_FullDuplexCallServer) error {
+		FullDuplexCallF: func(testgrpc.TestService_FullDuplexCallServer) error {
 			close(rpcStartedOnServer)
 			<-rpcDoneOnClient
 			return status.Error(codes.Internal, "arbitrary status")
@@ -3404,7 +3404,7 @@ type concurrentSendServer struct {
 	testgrpc.TestServiceServer
 }
 
-func (s concurrentSendServer) StreamingOutputCall(args *testpb.StreamingOutputCallRequest, stream testgrpc.TestService_StreamingOutputCallServer) error {
+func (s concurrentSendServer) StreamingOutputCall(_ *testpb.StreamingOutputCallRequest, stream testgrpc.TestService_StreamingOutputCallServer) error {
 	for i := 0; i < 10; i++ {
 		stream.Send(&testpb.StreamingOutputCallResponse{
 			Payload: &testpb.Payload{
@@ -3774,7 +3774,7 @@ func (s) TestUnaryServerInterceptor(t *testing.T) {
 	}
 }
 
-func errInjector(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+func errInjector(context.Context, any, *grpc.UnaryServerInfo, grpc.UnaryHandler) (any, error) {
 	return nil, status.Error(codes.PermissionDenied, "")
 }
 
@@ -3883,7 +3883,7 @@ func (s) TestClientRequestBodyErrorUnexpectedEOF(t *testing.T) {
 
 func testClientRequestBodyErrorUnexpectedEOF(t *testing.T, e env) {
 	te := newTest(t, e)
-	ts := &funcServer{unaryCall: func(ctx context.Context, in *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
+	ts := &funcServer{unaryCall: func(context.Context, *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
 		errUnexpectedCall := errors.New("unexpected call func server method")
 		t.Error(errUnexpectedCall)
 		return nil, errUnexpectedCall
@@ -3967,7 +3967,7 @@ func (s) TestInvalidStreamIDSmallerThanPrevious(t *testing.T) {
 func testClientRequestBodyErrorCloseAfterLength(t *testing.T, e env) {
 	te := newTest(t, e)
 	te.declareLogNoise("Server.processUnaryRPC failed to write status")
-	ts := &funcServer{unaryCall: func(ctx context.Context, in *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
+	ts := &funcServer{unaryCall: func(context.Context, *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
 		errUnexpectedCall := errors.New("unexpected call func server method")
 		t.Error(errUnexpectedCall)
 		return nil, errUnexpectedCall
@@ -3991,7 +3991,7 @@ func (s) TestClientRequestBodyErrorCancel(t *testing.T) {
 func testClientRequestBodyErrorCancel(t *testing.T, e env) {
 	te := newTest(t, e)
 	gotCall := make(chan bool, 1)
-	ts := &funcServer{unaryCall: func(ctx context.Context, in *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
+	ts := &funcServer{unaryCall: func(context.Context, *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
 		gotCall <- true
 		return new(testpb.SimpleResponse), nil
 	}}
@@ -4229,7 +4229,7 @@ type clientFailCreds struct{}
 func (c *clientFailCreds) ServerHandshake(rawConn net.Conn) (net.Conn, credentials.AuthInfo, error) {
 	return rawConn, nil, nil
 }
-func (c *clientFailCreds) ClientHandshake(ctx context.Context, authority string, rawConn net.Conn) (net.Conn, credentials.AuthInfo, error) {
+func (c *clientFailCreds) ClientHandshake(context.Context, string, net.Conn) (net.Conn, credentials.AuthInfo, error) {
 	return nil, nil, fmt.Errorf("client handshake fails with fatal error")
 }
 func (c *clientFailCreds) Info() credentials.ProtocolInfo {
@@ -4238,7 +4238,7 @@ func (c *clientFailCreds) Info() credentials.ProtocolInfo {
 func (c *clientFailCreds) Clone() credentials.TransportCredentials {
 	return c
 }
-func (c *clientFailCreds) OverrideServerName(s string) error {
+func (c *clientFailCreds) OverrideServerName(string) error {
 	return nil
 }
 
@@ -4339,7 +4339,7 @@ type flowControlLogicalRaceServer struct {
 	itemCount int
 }
 
-func (s *flowControlLogicalRaceServer) StreamingOutputCall(req *testpb.StreamingOutputCallRequest, srv testgrpc.TestService_StreamingOutputCallServer) error {
+func (s *flowControlLogicalRaceServer) StreamingOutputCall(_ *testpb.StreamingOutputCallRequest, srv testgrpc.TestService_StreamingOutputCallServer) error {
 	for i := 0; i < s.itemCount; i++ {
 		err := srv.Send(&testpb.StreamingOutputCallResponse{
 			Payload: &testpb.Payload{
@@ -4483,7 +4483,7 @@ func (s) TestGRPCMethod(t *testing.T) {
 	var ok bool
 
 	ss := &stubserver.StubServer{
-		EmptyCallF: func(ctx context.Context, in *testpb.Empty) (*testpb.Empty, error) {
+		EmptyCallF: func(ctx context.Context, _ *testpb.Empty) (*testpb.Empty, error) {
 			method, ok = grpc.Method(ctx)
 			return &testpb.Empty{}, nil
 		},
@@ -4510,7 +4510,7 @@ func (s) TestUnaryProxyDoesNotForwardMetadata(t *testing.T) {
 
 	// endpoint ensures mdkey is NOT in metadata and returns an error if it is.
 	endpoint := &stubserver.StubServer{
-		EmptyCallF: func(ctx context.Context, in *testpb.Empty) (*testpb.Empty, error) {
+		EmptyCallF: func(ctx context.Context, _ *testpb.Empty) (*testpb.Empty, error) {
 			if md, ok := metadata.FromIncomingContext(ctx); !ok || md[mdkey] != nil {
 				return nil, status.Errorf(codes.Internal, "endpoint: md=%v; want !contains(%q)", md, mdkey)
 			}
@@ -4625,7 +4625,7 @@ func (s) TestStatsTagsAndTrace(t *testing.T) {
 	// endpoint ensures Tags() and Trace() in context match those that were added
 	// by the client and returns an error if not.
 	endpoint := &stubserver.StubServer{
-		EmptyCallF: func(ctx context.Context, in *testpb.Empty) (*testpb.Empty, error) {
+		EmptyCallF: func(ctx context.Context, _ *testpb.Empty) (*testpb.Empty, error) {
 			md, _ := metadata.FromIncomingContext(ctx)
 			if tg := stats.Tags(ctx); !reflect.DeepEqual(tg, tags) {
 				return nil, status.Errorf(codes.Internal, "stats.Tags(%v)=%v; want %v", ctx, tg, tags)
@@ -4685,7 +4685,7 @@ func (s) TestTapTimeout(t *testing.T) {
 	}
 
 	ss := &stubserver.StubServer{
-		EmptyCallF: func(ctx context.Context, in *testpb.Empty) (*testpb.Empty, error) {
+		EmptyCallF: func(ctx context.Context, _ *testpb.Empty) (*testpb.Empty, error) {
 			<-ctx.Done()
 			return nil, status.Errorf(codes.Canceled, ctx.Err().Error())
 		},
@@ -4710,7 +4710,7 @@ func (s) TestTapTimeout(t *testing.T) {
 
 func (s) TestClientWriteFailsAfterServerClosesStream(t *testing.T) {
 	ss := &stubserver.StubServer{
-		FullDuplexCallF: func(stream testgrpc.TestService_FullDuplexCallServer) error {
+		FullDuplexCallF: func(testgrpc.TestService_FullDuplexCallServer) error {
 			return status.Errorf(codes.Internal, "")
 		},
 	}
@@ -4924,7 +4924,7 @@ func (s) TestMethodFromServerStream(t *testing.T) {
 	te := newTest(t, e)
 	var method string
 	var ok bool
-	te.unknownHandler = func(srv any, stream grpc.ServerStream) error {
+	te.unknownHandler = func(_ any, stream grpc.ServerStream) error {
 		method, ok = grpc.MethodFromServerStream(stream)
 		return nil
 	}
@@ -4982,11 +4982,11 @@ func (s) TestInterceptorCanAccessCallOptions(t *testing.T) {
 		}
 	}
 
-	te.unaryClientInt = func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+	te.unaryClientInt = func(_ context.Context, _ string, _, _ any, _ *grpc.ClientConn, _ grpc.UnaryInvoker, opts ...grpc.CallOption) error {
 		populateOpts(opts)
 		return nil
 	}
-	te.streamClientInt = func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+	te.streamClientInt = func(_ context.Context, _ *grpc.StreamDesc, _ *grpc.ClientConn, _ string, _ grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
 		populateOpts(opts)
 		return nil, nil
 	}
@@ -5098,7 +5098,7 @@ func (s) TestStatusInvalidUTF8Message(t *testing.T) {
 	)
 
 	ss := &stubserver.StubServer{
-		EmptyCallF: func(ctx context.Context, in *testpb.Empty) (*testpb.Empty, error) {
+		EmptyCallF: func(context.Context, *testpb.Empty) (*testpb.Empty, error) {
 			return nil, status.Errorf(codes.Internal, origMsg)
 		},
 	}
@@ -5127,7 +5127,7 @@ func (s) TestStatusInvalidUTF8Details(t *testing.T) {
 	)
 
 	ss := &stubserver.StubServer{
-		EmptyCallF: func(ctx context.Context, in *testpb.Empty) (*testpb.Empty, error) {
+		EmptyCallF: func(context.Context, *testpb.Empty) (*testpb.Empty, error) {
 			st := status.New(codes.Internal, origMsg)
 			st, err := st.WithDetails(&testpb.Empty{})
 			if err != nil {
@@ -5436,7 +5436,7 @@ func (s) TestNetPipeConn(t *testing.T) {
 	pl := testutils.NewPipeListener()
 	s := grpc.NewServer()
 	defer s.Stop()
-	ts := &funcServer{unaryCall: func(ctx context.Context, in *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
+	ts := &funcServer{unaryCall: func(context.Context, *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
 		return &testpb.SimpleResponse{}, nil
 	}}
 	testgrpc.RegisterTestServiceServer(s, ts)
@@ -5476,7 +5476,7 @@ func testLargeTimeout(t *testing.T, e env) {
 	}
 
 	for i, maxTimeout := range timeouts {
-		ts.unaryCall = func(ctx context.Context, in *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
+		ts.unaryCall = func(ctx context.Context, _ *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
 			deadline, ok := ctx.Deadline()
 			timeout := time.Until(deadline)
 			minTimeout := maxTimeout - 5*time.Second
@@ -5869,7 +5869,7 @@ func (s) TestClientSettingsFloodCloseConn(t *testing.T) {
 	timer.Stop()
 }
 
-func unaryInterceptorVerifyConn(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+func unaryInterceptorVerifyConn(ctx context.Context, _ any, _ *grpc.UnaryServerInfo, _ grpc.UnaryHandler) (any, error) {
 	conn := transport.GetConnection(ctx)
 	if conn == nil {
 		return nil, status.Error(codes.NotFound, "connection was not in context")
@@ -5894,7 +5894,7 @@ func (s) TestUnaryServerInterceptorGetsConnection(t *testing.T) {
 	}
 }
 
-func streamingInterceptorVerifyConn(srv any, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+func streamingInterceptorVerifyConn(_ any, ss grpc.ServerStream, _ *grpc.StreamServerInfo, _ grpc.StreamHandler) error {
 	conn := transport.GetConnection(ss.Context())
 	if conn == nil {
 		return status.Error(codes.NotFound, "connection was not in context")
@@ -5926,7 +5926,7 @@ func (s) TestStreamingServerInterceptorGetsConnection(t *testing.T) {
 // unaryInterceptorVerifyAuthority verifies there is an unambiguous :authority
 // once the request gets to an interceptor. An unambiguous :authority is defined
 // as at most a single :authority header, and no host header according to A41.
-func unaryInterceptorVerifyAuthority(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+func unaryInterceptorVerifyAuthority(ctx context.Context, _ any, _ *grpc.UnaryServerInfo, _ grpc.UnaryHandler) (any, error) {
 	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
 		return nil, status.Error(codes.NotFound, "metadata was not in context")
@@ -6002,7 +6002,7 @@ func (s) TestAuthorityHeader(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			te := newTest(t, tcpClearRREnv)
-			ts := &funcServer{unaryCall: func(ctx context.Context, in *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
+			ts := &funcServer{unaryCall: func(context.Context, *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
 				return &testpb.SimpleResponse{}, nil
 			}}
 			te.unaryServerInt = unaryInterceptorVerifyAuthority
@@ -6109,7 +6109,7 @@ func (s) TestServerClosesConn(t *testing.T) {
 func (s) TestNilStatsHandler(t *testing.T) {
 	grpctest.TLogger.ExpectErrorN("ignoring nil parameter", 2)
 	ss := &stubserver.StubServer{
-		UnaryCallF: func(ctx context.Context, in *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
+		UnaryCallF: func(context.Context, *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
 			return &testpb.SimpleResponse{}, nil
 		},
 	}
@@ -6131,7 +6131,7 @@ func (s) TestNilStatsHandler(t *testing.T) {
 // not fail with unexpected.EOF.
 func (s) TestUnexpectedEOF(t *testing.T) {
 	ss := &stubserver.StubServer{
-		UnaryCallF: func(ctx context.Context, in *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
+		UnaryCallF: func(_ context.Context, in *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
 			return &testpb.SimpleResponse{
 				Payload: &testpb.Payload{
 					Body: bytes.Repeat([]byte("a"), int(in.ResponseSize)),
@@ -6231,7 +6231,7 @@ func (s) TestGlobalBinaryLoggingOptions(t *testing.T) {
 		internal.ClearGlobalServerOptions()
 	}()
 	ss := &stubserver.StubServer{
-		UnaryCallF: func(ctx context.Context, in *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
+		UnaryCallF: func(context.Context, *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
 			return &testpb.SimpleResponse{}, nil
 		},
 		FullDuplexCallF: func(stream testgrpc.TestService_FullDuplexCallServer) error {
@@ -6304,7 +6304,7 @@ type triggerRPCBlockPicker struct {
 	pickDone func()
 }
 
-func (bp *triggerRPCBlockPicker) Pick(pi balancer.PickInfo) (balancer.PickResult, error) {
+func (bp *triggerRPCBlockPicker) Pick(balancer.PickInfo) (balancer.PickResult, error) {
 	bp.pickDone()
 	return balancer.PickResult{}, balancer.ErrNoSubConnAvailable
 }
@@ -6393,7 +6393,7 @@ func (bpb *triggerRPCBlockBalancer) UpdateState(state balancer.State) {
 func (s) TestRPCBlockingOnPickerStatsCall(t *testing.T) {
 	sh := &statsHandlerRecordEvents{}
 	ss := &stubserver.StubServer{
-		UnaryCallF: func(ctx context.Context, in *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
+		UnaryCallF: func(context.Context, *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
 			return &testpb.SimpleResponse{}, nil
 		},
 	}

--- a/test/goaway_test.go
+++ b/test/goaway_test.go
@@ -94,7 +94,7 @@ func (s) TestGracefulClientOnGoAway(t *testing.T) {
 func (s) TestDetailedGoAwayErrorOnGracefulClosePropagatesToRPCError(t *testing.T) {
 	rpcDoneOnClient := make(chan struct{})
 	ss := &stubserver.StubServer{
-		FullDuplexCallF: func(stream testgrpc.TestService_FullDuplexCallServer) error {
+		FullDuplexCallF: func(testgrpc.TestService_FullDuplexCallServer) error {
 			<-rpcDoneOnClient
 			return status.Error(codes.Internal, "arbitrary status")
 		},
@@ -134,7 +134,7 @@ func (s) TestDetailedGoAwayErrorOnAbruptClosePropagatesToRPCError(t *testing.T) 
 
 	rpcDoneOnClient := make(chan struct{})
 	ss := &stubserver.StubServer{
-		FullDuplexCallF: func(stream testgrpc.TestService_FullDuplexCallServer) error {
+		FullDuplexCallF: func(testgrpc.TestService_FullDuplexCallServer) error {
 			<-rpcDoneOnClient
 			return status.Error(codes.Internal, "arbitrary status")
 		},
@@ -554,7 +554,7 @@ func (s) TestGoAwayThenClose(t *testing.T) {
 	s1 := grpc.NewServer()
 	defer s1.Stop()
 	ts := &funcServer{
-		unaryCall: func(ctx context.Context, in *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
+		unaryCall: func(context.Context, *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
 			return &testpb.SimpleResponse{}, nil
 		},
 		fullDuplexCall: func(stream testgrpc.TestService_FullDuplexCallServer) error {

--- a/test/gracefulstop_test.go
+++ b/test/gracefulstop_test.go
@@ -176,7 +176,7 @@ func (s) TestGracefulStopClosesConnAfterLastStream(t *testing.T) {
 	handlerCalled := make(chan struct{})
 	gracefulStopCalled := make(chan struct{})
 
-	ts := &funcServer{streamingInputCall: func(stream testgrpc.TestService_StreamingInputCallServer) error {
+	ts := &funcServer{streamingInputCall: func(testgrpc.TestService_StreamingInputCallServer) error {
 		close(handlerCalled) // Initiate call to GracefulStop.
 		<-gracefulStopCalled // Wait for GOAWAYs to be received by the client.
 		return nil
@@ -225,7 +225,7 @@ func (s) TestGracefulStopBlocksUntilGRPCConnectionsTerminate(t *testing.T) {
 	unblockGRPCCall := make(chan struct{})
 	grpcCallExecuting := make(chan struct{})
 	ss := &stubserver.StubServer{
-		UnaryCallF: func(ctx context.Context, in *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
+		UnaryCallF: func(context.Context, *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
 			close(grpcCallExecuting)
 			<-unblockGRPCCall
 			return &testpb.SimpleResponse{}, nil
@@ -276,7 +276,7 @@ func (s) TestStopAbortsBlockingGRPCCall(t *testing.T) {
 	unblockGRPCCall := make(chan struct{})
 	grpcCallExecuting := make(chan struct{})
 	ss := &stubserver.StubServer{
-		UnaryCallF: func(ctx context.Context, in *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
+		UnaryCallF: func(context.Context, *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
 			close(grpcCallExecuting)
 			<-unblockGRPCCall
 			return &testpb.SimpleResponse{}, nil

--- a/test/healthcheck_test.go
+++ b/test/healthcheck_test.go
@@ -86,7 +86,7 @@ func defaultWatchFunc(s *testHealthServer, in *healthpb.HealthCheckRequest, stre
 	return nil
 }
 
-type healthWatchFunc func(s *testHealthServer, in *healthpb.HealthCheckRequest, stream healthgrpc.Health_WatchServer) error
+type healthWatchFunc func(*testHealthServer, *healthpb.HealthCheckRequest, healthgrpc.Health_WatchServer) error
 
 type testHealthServer struct {
 	healthgrpc.UnimplementedHealthServer
@@ -96,7 +96,7 @@ type testHealthServer struct {
 	update    chan struct{}
 }
 
-func (s *testHealthServer) Check(ctx context.Context, in *healthpb.HealthCheckRequest) (*healthpb.HealthCheckResponse, error) {
+func (s *testHealthServer) Check(context.Context, *healthpb.HealthCheckRequest) (*healthpb.HealthCheckResponse, error) {
 	return &healthpb.HealthCheckResponse{
 		Status: healthpb.HealthCheckResponse_SERVING,
 	}, nil
@@ -538,7 +538,7 @@ func (s) TestHealthCheckWithClientConnClose(t *testing.T) {
 // closes the skipReset channel(since it has not been closed inside health check func) to unblock
 // onGoAway/onClose goroutine.
 func (s) TestHealthCheckWithoutSetConnectivityStateCalledAddrConnShutDown(t *testing.T) {
-	watchFunc := func(s *testHealthServer, in *healthpb.HealthCheckRequest, stream healthgrpc.Health_WatchServer) error {
+	watchFunc := func(_ *testHealthServer, in *healthpb.HealthCheckRequest, stream healthgrpc.Health_WatchServer) error {
 		if in.Service != "delay" {
 			return status.Error(codes.FailedPrecondition,
 				"this special Watch function only handles request with service name to be \"delay\"")
@@ -601,7 +601,7 @@ func (s) TestHealthCheckWithoutSetConnectivityStateCalledAddrConnShutDown(t *tes
 // closes the allowedToReset channel(since it has not been closed inside health check func) to unblock
 // onGoAway/onClose goroutine.
 func (s) TestHealthCheckWithoutSetConnectivityStateCalled(t *testing.T) {
-	watchFunc := func(s *testHealthServer, in *healthpb.HealthCheckRequest, stream healthgrpc.Health_WatchServer) error {
+	watchFunc := func(_ *testHealthServer, in *healthpb.HealthCheckRequest, stream healthgrpc.Health_WatchServer) error {
 		if in.Service != "delay" {
 			return status.Error(codes.FailedPrecondition,
 				"this special Watch function only handles request with service name to be \"delay\"")
@@ -763,7 +763,7 @@ func (s) TestHealthCheckDisable(t *testing.T) {
 }
 
 func (s) TestHealthCheckChannelzCountingCallSuccess(t *testing.T) {
-	watchFunc := func(s *testHealthServer, in *healthpb.HealthCheckRequest, stream healthgrpc.Health_WatchServer) error {
+	watchFunc := func(_ *testHealthServer, in *healthpb.HealthCheckRequest, _ healthgrpc.Health_WatchServer) error {
 		if in.Service != "channelzSuccess" {
 			return status.Error(codes.FailedPrecondition,
 				"this special Watch function only handles request with service name to be \"channelzSuccess\"")
@@ -812,7 +812,7 @@ func (s) TestHealthCheckChannelzCountingCallSuccess(t *testing.T) {
 }
 
 func (s) TestHealthCheckChannelzCountingCallFailure(t *testing.T) {
-	watchFunc := func(s *testHealthServer, in *healthpb.HealthCheckRequest, stream healthgrpc.Health_WatchServer) error {
+	watchFunc := func(_ *testHealthServer, in *healthpb.HealthCheckRequest, _ healthgrpc.Health_WatchServer) error {
 		if in.Service != "channelzFailure" {
 			return status.Error(codes.FailedPrecondition,
 				"this special Watch function only handles request with service name to be \"channelzFailure\"")
@@ -1127,7 +1127,7 @@ func (s) TestUnknownHandler(t *testing.T) {
 	// An example unknownHandler that returns a different code and a different
 	// method, making sure that we do not expose what methods are implemented to
 	// a client that is not authenticated.
-	unknownHandler := func(srv any, stream grpc.ServerStream) error {
+	unknownHandler := func(any, grpc.ServerStream) error {
 		return status.Error(codes.Unauthenticated, "user unauthenticated")
 	}
 	for _, e := range listTestEnv() {

--- a/test/insecure_creds_test.go
+++ b/test/insecure_creds_test.go
@@ -39,7 +39,7 @@ import (
 // testLegacyPerRPCCredentials is a PerRPCCredentials that has yet incorporated security level.
 type testLegacyPerRPCCredentials struct{}
 
-func (cr testLegacyPerRPCCredentials) GetRequestMetadata(ctx context.Context, uri ...string) (map[string]string, error) {
+func (cr testLegacyPerRPCCredentials) GetRequestMetadata(context.Context, ...string) (map[string]string, error) {
 	return nil, nil
 }
 
@@ -84,7 +84,7 @@ func (s) TestInsecureCreds(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
 			ss := &stubserver.StubServer{
-				EmptyCallF: func(ctx context.Context, in *testpb.Empty) (*testpb.Empty, error) {
+				EmptyCallF: func(ctx context.Context, _ *testpb.Empty) (*testpb.Empty, error) {
 					if !test.serverInsecureCreds {
 						return &testpb.Empty{}, nil
 					}
@@ -144,7 +144,7 @@ func (s) TestInsecureCreds(t *testing.T) {
 
 func (s) TestInsecureCreds_WithPerRPCCredentials_AsCallOption(t *testing.T) {
 	ss := &stubserver.StubServer{
-		EmptyCallF: func(ctx context.Context, in *testpb.Empty) (*testpb.Empty, error) {
+		EmptyCallF: func(context.Context, *testpb.Empty) (*testpb.Empty, error) {
 			return &testpb.Empty{}, nil
 		},
 	}

--- a/test/local_creds_test.go
+++ b/test/local_creds_test.go
@@ -41,7 +41,7 @@ import (
 
 func testLocalCredsE2ESucceed(network, address string) error {
 	ss := &stubserver.StubServer{
-		EmptyCallF: func(ctx context.Context, in *testpb.Empty) (*testpb.Empty, error) {
+		EmptyCallF: func(ctx context.Context, _ *testpb.Empty) (*testpb.Empty, error) {
 			pr, ok := peer.FromContext(ctx)
 			if !ok {
 				return nil, status.Error(codes.DataLoss, "Failed to get peer from ctx")
@@ -89,7 +89,7 @@ func testLocalCredsE2ESucceed(network, address string) error {
 	switch network {
 	case "unix":
 		cc, err = grpc.Dial(lisAddr, grpc.WithTransportCredentials(local.NewCredentials()), grpc.WithContextDialer(
-			func(ctx context.Context, addr string) (net.Conn, error) {
+			func(_ context.Context, addr string) (net.Conn, error) {
 				return net.Dial("unix", addr)
 			}))
 	case "tcp":

--- a/test/metadata_test.go
+++ b/test/metadata_test.go
@@ -94,7 +94,7 @@ func (s) TestInvalidMetadata(t *testing.T) {
 
 	testNum := 0
 	ss := &stubserver.StubServer{
-		EmptyCallF: func(ctx context.Context, in *testpb.Empty) (*testpb.Empty, error) {
+		EmptyCallF: func(context.Context, *testpb.Empty) (*testpb.Empty, error) {
 			return &testpb.Empty{}, nil
 		},
 		FullDuplexCallF: func(stream testgrpc.TestService_FullDuplexCallServer) error {

--- a/test/pickfirst_test.go
+++ b/test/pickfirst_test.go
@@ -59,7 +59,7 @@ func setupPickFirst(t *testing.T, backendCount int, opts ...grpc.DialOption) (*g
 	addrs := make([]resolver.Address, backendCount)
 	for i := 0; i < backendCount; i++ {
 		backend := &stubserver.StubServer{
-			EmptyCallF: func(ctx context.Context, in *testpb.Empty) (*testpb.Empty, error) {
+			EmptyCallF: func(context.Context, *testpb.Empty) (*testpb.Empty, error) {
 				return &testpb.Empty{}, nil
 			},
 		}
@@ -514,7 +514,7 @@ func setupPickFirstWithListenerWrapper(t *testing.T, backendCount int, opts ...g
 		lis := testutils.NewListenerWrapper(t, nil)
 		backend := &stubserver.StubServer{
 			Listener: lis,
-			EmptyCallF: func(ctx context.Context, in *testpb.Empty) (*testpb.Empty, error) {
+			EmptyCallF: func(context.Context, *testpb.Empty) (*testpb.Empty, error) {
 				return &testpb.Empty{}, nil
 			},
 		}

--- a/test/resolver_update_test.go
+++ b/test/resolver_update_test.go
@@ -182,7 +182,7 @@ func (s) TestResolverUpdate_InvalidServiceConfigAfterGoodUpdate(t *testing.T) {
 
 	// Start a backend exposing the test service.
 	backend := &stubserver.StubServer{
-		EmptyCallF: func(ctx context.Context, in *testpb.Empty) (*testpb.Empty, error) { return &testpb.Empty{}, nil },
+		EmptyCallF: func(context.Context, *testpb.Empty) (*testpb.Empty, error) { return &testpb.Empty{}, nil },
 	}
 	if err := backend.StartServer(); err != nil {
 		t.Fatalf("Failed to start backend: %v", err)

--- a/test/retry_test.go
+++ b/test/retry_test.go
@@ -226,7 +226,7 @@ func (s) TestRetryStreaming(t *testing.T) {
 		}
 	}
 	sErr := func(c codes.Code) serverOp {
-		return func(stream testgrpc.TestService_FullDuplexCallServer) error {
+		return func(testgrpc.TestService_FullDuplexCallServer) error {
 			return status.New(c, "this is a test error").Err()
 		}
 	}
@@ -512,7 +512,7 @@ func (s) TestMaxCallAttempts(t *testing.T) {
 		unaryCallCount := 0
 
 		ss := &stubserver.StubServer{
-			FullDuplexCallF: func(stream testgrpc.TestService_FullDuplexCallServer) error {
+			FullDuplexCallF: func(testgrpc.TestService_FullDuplexCallServer) error {
 				streamCallCount++
 				return status.New(codes.Unavailable, "this is a test error").Err()
 			},

--- a/test/roundrobin_test.go
+++ b/test/roundrobin_test.go
@@ -54,7 +54,7 @@ func testRoundRobinBasic(ctx context.Context, t *testing.T, opts ...grpc.DialOpt
 	addrs := make([]resolver.Address, backendCount)
 	for i := 0; i < backendCount; i++ {
 		backend := &stubserver.StubServer{
-			EmptyCallF: func(ctx context.Context, in *testpb.Empty) (*testpb.Empty, error) { return &testpb.Empty{}, nil },
+			EmptyCallF: func(context.Context, *testpb.Empty) (*testpb.Empty, error) { return &testpb.Empty{}, nil },
 		}
 		if err := backend.StartServer(); err != nil {
 			t.Fatalf("Failed to start backend: %v", err)

--- a/test/server_test.go
+++ b/test/server_test.go
@@ -39,10 +39,10 @@ type ctxKey string
 // Unknown.
 func (s) TestServerReturningContextError(t *testing.T) {
 	ss := &stubserver.StubServer{
-		EmptyCallF: func(ctx context.Context, in *testpb.Empty) (*testpb.Empty, error) {
+		EmptyCallF: func(context.Context, *testpb.Empty) (*testpb.Empty, error) {
 			return nil, context.DeadlineExceeded
 		},
-		FullDuplexCallF: func(stream testgrpc.TestService_FullDuplexCallServer) error {
+		FullDuplexCallF: func(testgrpc.TestService_FullDuplexCallServer) error {
 			return context.DeadlineExceeded
 		},
 	}
@@ -75,7 +75,7 @@ func (s) TestChainUnaryServerInterceptor(t *testing.T) {
 		secondIntKey = ctxKey("secondIntKey")
 	)
 
-	firstInt := func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+	firstInt := func(ctx context.Context, req any, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
 		if ctx.Value(firstIntKey) != nil {
 			return nil, status.Errorf(codes.Internal, "first interceptor should not have %v in context", firstIntKey)
 		}
@@ -101,7 +101,7 @@ func (s) TestChainUnaryServerInterceptor(t *testing.T) {
 		}, nil
 	}
 
-	secondInt := func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+	secondInt := func(ctx context.Context, req any, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
 		if ctx.Value(firstIntKey) == nil {
 			return nil, status.Errorf(codes.Internal, "second interceptor should have %v in context", firstIntKey)
 		}
@@ -127,7 +127,7 @@ func (s) TestChainUnaryServerInterceptor(t *testing.T) {
 		}, nil
 	}
 
-	lastInt := func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+	lastInt := func(ctx context.Context, req any, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
 		if ctx.Value(firstIntKey) == nil {
 			return nil, status.Errorf(codes.Internal, "last interceptor should have %v in context", firstIntKey)
 		}
@@ -157,7 +157,7 @@ func (s) TestChainUnaryServerInterceptor(t *testing.T) {
 	}
 
 	ss := &stubserver.StubServer{
-		UnaryCallF: func(ctx context.Context, in *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
+		UnaryCallF: func(context.Context, *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
 			payload, err := newPayload(testpb.PayloadType_COMPRESSABLE, 0)
 			if err != nil {
 				return nil, status.Errorf(codes.Aborted, "failed to make payload: %v", err)
@@ -189,7 +189,7 @@ func (s) TestChainUnaryServerInterceptor(t *testing.T) {
 func (s) TestChainOnBaseUnaryServerInterceptor(t *testing.T) {
 	baseIntKey := ctxKey("baseIntKey")
 
-	baseInt := func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+	baseInt := func(ctx context.Context, req any, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
 		if ctx.Value(baseIntKey) != nil {
 			return nil, status.Errorf(codes.Internal, "base interceptor should not have %v in context", baseIntKey)
 		}
@@ -198,7 +198,7 @@ func (s) TestChainOnBaseUnaryServerInterceptor(t *testing.T) {
 		return handler(baseCtx, req)
 	}
 
-	chainInt := func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+	chainInt := func(ctx context.Context, req any, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
 		if ctx.Value(baseIntKey) == nil {
 			return nil, status.Errorf(codes.Internal, "chain interceptor should have %v in context", baseIntKey)
 		}
@@ -212,7 +212,7 @@ func (s) TestChainOnBaseUnaryServerInterceptor(t *testing.T) {
 	}
 
 	ss := &stubserver.StubServer{
-		EmptyCallF: func(ctx context.Context, in *testpb.Empty) (*testpb.Empty, error) {
+		EmptyCallF: func(context.Context, *testpb.Empty) (*testpb.Empty, error) {
 			return &testpb.Empty{}, nil
 		},
 	}
@@ -232,7 +232,7 @@ func (s) TestChainOnBaseUnaryServerInterceptor(t *testing.T) {
 func (s) TestChainStreamServerInterceptor(t *testing.T) {
 	callCounts := make([]int, 4)
 
-	firstInt := func(srv any, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+	firstInt := func(srv any, stream grpc.ServerStream, _ *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 		if callCounts[0] != 0 {
 			return status.Errorf(codes.Internal, "callCounts[0] should be 0, but got=%d", callCounts[0])
 		}
@@ -249,7 +249,7 @@ func (s) TestChainStreamServerInterceptor(t *testing.T) {
 		return handler(srv, stream)
 	}
 
-	secondInt := func(srv any, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+	secondInt := func(srv any, stream grpc.ServerStream, _ *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 		if callCounts[0] != 1 {
 			return status.Errorf(codes.Internal, "callCounts[0] should be 1, but got=%d", callCounts[0])
 		}
@@ -266,7 +266,7 @@ func (s) TestChainStreamServerInterceptor(t *testing.T) {
 		return handler(srv, stream)
 	}
 
-	lastInt := func(srv any, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+	lastInt := func(srv any, stream grpc.ServerStream, _ *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 		if callCounts[0] != 1 {
 			return status.Errorf(codes.Internal, "callCounts[0] should be 1, but got=%d", callCounts[0])
 		}
@@ -288,7 +288,7 @@ func (s) TestChainStreamServerInterceptor(t *testing.T) {
 	}
 
 	ss := &stubserver.StubServer{
-		FullDuplexCallF: func(stream testgrpc.TestService_FullDuplexCallServer) error {
+		FullDuplexCallF: func(testgrpc.TestService_FullDuplexCallServer) error {
 			if callCounts[0] != 1 {
 				return status.Errorf(codes.Internal, "callCounts[0] should be 1, but got=%d", callCounts[0])
 			}

--- a/test/stats_test.go
+++ b/test/stats_test.go
@@ -125,7 +125,7 @@ type peerStatsHandler struct {
 	mu   sync.Mutex
 }
 
-func (h *peerStatsHandler) TagRPC(ctx context.Context, info *stats.RPCTagInfo) context.Context {
+func (h *peerStatsHandler) TagRPC(ctx context.Context, _ *stats.RPCTagInfo) context.Context {
 	return ctx
 }
 
@@ -136,7 +136,7 @@ func (h *peerStatsHandler) HandleRPC(ctx context.Context, rs stats.RPCStats) {
 	h.args = append(h.args, peerStats{rs, p})
 }
 
-func (h *peerStatsHandler) TagConn(ctx context.Context, info *stats.ConnTagInfo) context.Context {
+func (h *peerStatsHandler) TagConn(ctx context.Context, _ *stats.ConnTagInfo) context.Context {
 	return ctx
 }
 

--- a/test/stream_cleanup_test.go
+++ b/test/stream_cleanup_test.go
@@ -39,7 +39,7 @@ func (s) TestStreamCleanup(t *testing.T) {
 	const callRecvMsgSize uint = 1           // The maximum message size the client can receive
 
 	ss := &stubserver.StubServer{
-		UnaryCallF: func(ctx context.Context, in *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
+		UnaryCallF: func(context.Context, *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
 			return &testpb.SimpleResponse{Payload: &testpb.Payload{
 				Body: make([]byte, bodySize),
 			}}, nil

--- a/test/subconn_test.go
+++ b/test/subconn_test.go
@@ -39,7 +39,7 @@ type tsccPicker struct {
 	sc balancer.SubConn
 }
 
-func (p *tsccPicker) Pick(info balancer.PickInfo) (balancer.PickResult, error) {
+func (p *tsccPicker) Pick(balancer.PickInfo) (balancer.PickResult, error) {
 	return balancer.PickResult{SubConn: p.sc}, nil
 }
 
@@ -102,7 +102,7 @@ func (s) TestSubConnEmpty(t *testing.T) {
 
 	// Start the stub server with our stub balancer.
 	ss := &stubserver.StubServer{
-		EmptyCallF: func(ctx context.Context, in *testpb.Empty) (*testpb.Empty, error) {
+		EmptyCallF: func(context.Context, *testpb.Empty) (*testpb.Empty, error) {
 			return &testpb.Empty{}, nil
 		},
 	}

--- a/test/transport_test.go
+++ b/test/transport_test.go
@@ -58,7 +58,7 @@ type transportRestartCheckCreds struct {
 func (c *transportRestartCheckCreds) ServerHandshake(rawConn net.Conn) (net.Conn, credentials.AuthInfo, error) {
 	return rawConn, nil, nil
 }
-func (c *transportRestartCheckCreds) ClientHandshake(ctx context.Context, authority string, rawConn net.Conn) (net.Conn, credentials.AuthInfo, error) {
+func (c *transportRestartCheckCreds) ClientHandshake(_ context.Context, _ string, rawConn net.Conn) (net.Conn, credentials.AuthInfo, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	conn := &connWrapperWithCloseCh{Conn: rawConn, close: grpcsync.NewEvent()}
@@ -71,7 +71,7 @@ func (c *transportRestartCheckCreds) Info() credentials.ProtocolInfo {
 func (c *transportRestartCheckCreds) Clone() credentials.TransportCredentials {
 	return c
 }
-func (c *transportRestartCheckCreds) OverrideServerName(s string) error {
+func (c *transportRestartCheckCreds) OverrideServerName(string) error {
 	return nil
 }
 

--- a/xds/internal/balancer/cdsbalancer/cdsbalancer.go
+++ b/xds/internal/balancer/cdsbalancer/cdsbalancer.go
@@ -364,7 +364,7 @@ func (b *cdsBalancer) closeAllWatchers() {
 // Close cancels the CDS watch, closes the child policy and closes the
 // cdsBalancer.
 func (b *cdsBalancer) Close() {
-	b.serializer.TrySchedule(func(ctx context.Context) {
+	b.serializer.TrySchedule(func(context.Context) {
 		b.closeAllWatchers()
 
 		if b.childLB != nil {

--- a/xds/internal/balancer/clustermanager/clustermanager_test.go
+++ b/xds/internal/balancer/clustermanager/clustermanager_test.go
@@ -719,7 +719,7 @@ func (s) TestUpdateStatePauses(t *testing.T) {
 	cc := &tcc{BalancerClientConn: testutils.NewBalancerClientConn(t)}
 
 	balFuncs := stub.BalancerFuncs{
-		UpdateClientConnState: func(bd *stub.BalancerData, s balancer.ClientConnState) error {
+		UpdateClientConnState: func(bd *stub.BalancerData, _ balancer.ClientConnState) error {
 			bd.ClientConn.UpdateState(balancer.State{ConnectivityState: connectivity.TransientFailure, Picker: nil})
 			bd.ClientConn.UpdateState(balancer.State{ConnectivityState: connectivity.Ready, Picker: nil})
 			return nil

--- a/xds/internal/balancer/outlierdetection/balancer_test.go
+++ b/xds/internal/balancer/outlierdetection/balancer_test.go
@@ -578,11 +578,11 @@ func (s) TestChildBasicOperations(t *testing.T) {
 	closeCh := testutils.NewChannel()
 
 	stub.Register(t.Name()+"child1", stub.BalancerFuncs{
-		UpdateClientConnState: func(bd *stub.BalancerData, ccs balancer.ClientConnState) error {
+		UpdateClientConnState: func(_ *stub.BalancerData, ccs balancer.ClientConnState) error {
 			ccsCh.Send(ccs.BalancerConfig)
 			return nil
 		},
-		Close: func(bd *stub.BalancerData) {
+		Close: func(*stub.BalancerData) {
 			closeCh.Send(nil)
 		},
 	})
@@ -598,7 +598,7 @@ func (s) TestChildBasicOperations(t *testing.T) {
 			ccsCh.Send(nil)
 			return nil
 		},
-		Close: func(bd *stub.BalancerData) {
+		Close: func(*stub.BalancerData) {
 			closeCh.Send(nil)
 		},
 	})

--- a/xds/internal/balancer/priority/balancer_test.go
+++ b/xds/internal/balancer/priority/balancer_test.go
@@ -1491,7 +1491,7 @@ var errTestInlineStateUpdate = fmt.Errorf("don't like addresses, empty or not")
 
 func init() {
 	stub.Register(inlineUpdateBalancerName, stub.BalancerFuncs{
-		UpdateClientConnState: func(bd *stub.BalancerData, opts balancer.ClientConnState) error {
+		UpdateClientConnState: func(bd *stub.BalancerData, _ balancer.ClientConnState) error {
 			bd.ClientConn.UpdateState(balancer.State{
 				ConnectivityState: connectivity.Ready,
 				Picker:            &testutils.TestConstPicker{Err: errTestInlineStateUpdate},

--- a/xds/internal/balancer/ringhash/ringhash.go
+++ b/xds/internal/balancer/ringhash/ringhash.go
@@ -44,7 +44,7 @@ func init() {
 
 type bb struct{}
 
-func (bb) Build(cc balancer.ClientConn, bOpts balancer.BuildOptions) balancer.Balancer {
+func (bb) Build(cc balancer.ClientConn, _ balancer.BuildOptions) balancer.Balancer {
 	b := &ringhashBalancer{
 		cc:              cc,
 		subConns:        resolver.NewAddressMap(),

--- a/xds/internal/balancer/wrrlocality/balancer_test.go
+++ b/xds/internal/balancer/wrrlocality/balancer_test.go
@@ -153,7 +153,7 @@ func (s) TestUpdateClientConnState(t *testing.T) {
 			}
 			return &cfg, nil
 		},
-		UpdateClientConnState: func(bd *stub.BalancerData, ccs balancer.ClientConnState) error {
+		UpdateClientConnState: func(_ *stub.BalancerData, ccs balancer.ClientConnState) error {
 			wtCfg, ok := ccs.BalancerConfig.(*weightedtarget.LBConfig)
 			if !ok {
 				return errors.New("child received config that was not a weighted target config")

--- a/xds/internal/httpfilter/fault/fault.go
+++ b/xds/internal/httpfilter/fault/fault.go
@@ -139,7 +139,7 @@ type interceptor struct {
 
 var activeFaults uint32 // global active faults; accessed atomically
 
-func (i *interceptor) NewStream(ctx context.Context, ri iresolver.RPCInfo, done func(), newStream func(ctx context.Context, done func()) (iresolver.ClientStream, error)) (iresolver.ClientStream, error) {
+func (i *interceptor) NewStream(ctx context.Context, _ iresolver.RPCInfo, done func(), newStream func(ctx context.Context, done func()) (iresolver.ClientStream, error)) (iresolver.ClientStream, error) {
 	if maxAF := i.config.GetMaxActiveFaults(); maxAF != nil {
 		defer atomic.AddUint32(&activeFaults, ^uint32(0)) // decrement counter
 		if af := atomic.AddUint32(&activeFaults, 1); af > maxAF.GetValue() {
@@ -296,5 +296,5 @@ func (*okStream) Header() (metadata.MD, error) { return nil, nil }
 func (*okStream) Trailer() metadata.MD         { return nil }
 func (*okStream) CloseSend() error             { return nil }
 func (o *okStream) Context() context.Context   { return o.ctx }
-func (*okStream) SendMsg(m any) error          { return io.EOF }
-func (*okStream) RecvMsg(m any) error          { return io.EOF }
+func (*okStream) SendMsg(any) error            { return io.EOF }
+func (*okStream) RecvMsg(any) error            { return io.EOF }

--- a/xds/internal/httpfilter/fault/fault_test.go
+++ b/xds/internal/httpfilter/fault/fault_test.go
@@ -567,7 +567,7 @@ func (s) TestFaultInjection_MaxActiveFaults(t *testing.T) {
 
 	defer func() { newTimer = time.NewTimer }()
 	timers := make(chan *time.Timer, 2)
-	newTimer = func(d time.Duration) *time.Timer {
+	newTimer = func(time.Duration) *time.Timer {
 		t := time.NewTimer(24 * time.Hour) // Will reset to fire.
 		timers <- t
 		return t

--- a/xds/internal/resolver/serviceconfig.go
+++ b/xds/internal/resolver/serviceconfig.go
@@ -336,7 +336,7 @@ type interceptorList struct {
 	interceptors []iresolver.ClientInterceptor
 }
 
-func (il *interceptorList) NewStream(ctx context.Context, ri iresolver.RPCInfo, done func(), newStream func(ctx context.Context, done func()) (iresolver.ClientStream, error)) (iresolver.ClientStream, error) {
+func (il *interceptorList) NewStream(ctx context.Context, ri iresolver.RPCInfo, _ func(), newStream func(ctx context.Context, _ func()) (iresolver.ClientStream, error)) (iresolver.ClientStream, error) {
 	for i := len(il.interceptors) - 1; i >= 0; i-- {
 		ns := newStream
 		interceptor := il.interceptors[i]

--- a/xds/internal/resolver/xds_resolver.go
+++ b/xds/internal/resolver/xds_resolver.go
@@ -128,7 +128,7 @@ func (b *xdsResolverBuilder) Build(target resolver.Target, cc resolver.ClientCon
 //
 // Returns the listener resource name template to use. If any of the above
 // validations fail, a non-nil error is returned.
-func (r *xdsResolver) sanityChecksOnBootstrapConfig(target resolver.Target, opts resolver.BuildOptions, client xdsclient.XDSClient) (string, error) {
+func (r *xdsResolver) sanityChecksOnBootstrapConfig(target resolver.Target, _ resolver.BuildOptions, client xdsclient.XDSClient) (string, error) {
 	bootstrapConfig := client.BootstrapConfig()
 	if bootstrapConfig == nil {
 		// This is never expected to happen after a successful xDS client
@@ -214,7 +214,7 @@ type xdsResolver struct {
 }
 
 // ResolveNow is a no-op at this point.
-func (*xdsResolver) ResolveNow(o resolver.ResolveNowOptions) {}
+func (*xdsResolver) ResolveNow(resolver.ResolveNowOptions) {}
 
 func (r *xdsResolver) Close() {
 	// Cancel the context passed to the serializer and wait for any scheduled

--- a/xds/internal/xdsclient/client_refcounted.go
+++ b/xds/internal/xdsclient/client_refcounted.go
@@ -35,8 +35,8 @@ const (
 var (
 	// The following functions are no-ops in the actual code, but can be
 	// overridden in tests to give them visibility into certain events.
-	xdsClientImplCreateHook = func(name string) {}
-	xdsClientImplCloseHook  = func(name string) {}
+	xdsClientImplCreateHook = func(string) {}
+	xdsClientImplCloseHook  = func(string) {}
 )
 
 func clientRefCountedClose(name string) {

--- a/xds/internal/xdsclient/xdsresource/endpoints_resource_type.go
+++ b/xds/internal/xdsclient/xdsresource/endpoints_resource_type.go
@@ -54,7 +54,7 @@ type endpointsResourceType struct {
 
 // Decode deserializes and validates an xDS resource serialized inside the
 // provided `Any` proto, as received from the xDS management server.
-func (endpointsResourceType) Decode(opts *DecodeOptions, resource *anypb.Any) (*DecodeResult, error) {
+func (endpointsResourceType) Decode(_ *DecodeOptions, resource *anypb.Any) (*DecodeResult, error) {
 	name, rc, err := unmarshalEndpointsResource(resource)
 	switch {
 	case name == "":

--- a/xds/internal/xdsclient/xdsresource/matcher_test.go
+++ b/xds/internal/xdsclient/xdsresource/matcher_test.go
@@ -123,7 +123,7 @@ func (s) TestFractionMatcherMatch(t *testing.T) {
 	}()
 
 	// rand > fraction, should return false.
-	RandInt63n = func(n int64) int64 {
+	RandInt63n = func(int64) int64 {
 		return fraction + 1
 	}
 	if matched := fm.match(); matched {
@@ -131,7 +131,7 @@ func (s) TestFractionMatcherMatch(t *testing.T) {
 	}
 
 	// rand == fraction, should return true.
-	RandInt63n = func(n int64) int64 {
+	RandInt63n = func(int64) int64 {
 		return fraction
 	}
 	if matched := fm.match(); !matched {
@@ -139,7 +139,7 @@ func (s) TestFractionMatcherMatch(t *testing.T) {
 	}
 
 	// rand < fraction, should return true.
-	RandInt63n = func(n int64) int64 {
+	RandInt63n = func(int64) int64 {
 		return fraction - 1
 	}
 	if matched := fm.match(); !matched {

--- a/xds/internal/xdsclient/xdsresource/route_config_resource_type.go
+++ b/xds/internal/xdsclient/xdsresource/route_config_resource_type.go
@@ -54,7 +54,7 @@ type routeConfigResourceType struct {
 
 // Decode deserializes and validates an xDS resource serialized inside the
 // provided `Any` proto, as received from the xDS management server.
-func (routeConfigResourceType) Decode(opts *DecodeOptions, resource *anypb.Any) (*DecodeResult, error) {
+func (routeConfigResourceType) Decode(_ *DecodeOptions, resource *anypb.Any) (*DecodeResult, error) {
 	name, rc, err := unmarshalRouteConfigResource(resource)
 	switch {
 	case name == "":

--- a/xds/internal/xdsclient/xdsresource/test_utils_test.go
+++ b/xds/internal/xdsclient/xdsresource/test_utils_test.go
@@ -38,8 +38,8 @@ func Test(t *testing.T) {
 var (
 	cmpOpts = cmp.Options{
 		cmpopts.EquateEmpty(),
-		cmp.FilterValues(func(x, y error) bool { return true }, cmpopts.EquateErrors()),
-		cmp.Comparer(func(a, b time.Time) bool { return true }),
+		cmp.FilterValues(func(_, _ error) bool { return true }, cmpopts.EquateErrors()),
+		cmp.Comparer(func(_, _ time.Time) bool { return true }),
 		protocmp.Transform(),
 	}
 )

--- a/xds/internal/xdsclient/xdsresource/unmarshal_lds_test.go
+++ b/xds/internal/xdsclient/xdsresource/unmarshal_lds_test.go
@@ -1746,11 +1746,11 @@ type errHTTPFilter struct {
 
 func (errHTTPFilter) TypeURLs() []string { return []string{"err.custom.filter"} }
 
-func (errHTTPFilter) ParseFilterConfig(cfg proto.Message) (httpfilter.FilterConfig, error) {
+func (errHTTPFilter) ParseFilterConfig(proto.Message) (httpfilter.FilterConfig, error) {
 	return nil, fmt.Errorf("error from ParseFilterConfig")
 }
 
-func (errHTTPFilter) ParseFilterConfigOverride(override proto.Message) (httpfilter.FilterConfig, error) {
+func (errHTTPFilter) ParseFilterConfigOverride(proto.Message) (httpfilter.FilterConfig, error) {
 	return nil, fmt.Errorf("error from ParseFilterConfigOverride")
 }
 

--- a/xds/server_test.go
+++ b/xds/server_test.go
@@ -231,7 +231,7 @@ func (s) TestRegisterService(t *testing.T) {
 	fs := newFakeGRPCServer()
 
 	origNewGRPCServer := newGRPCServer
-	newGRPCServer = func(opts ...grpc.ServerOption) grpcServer { return fs }
+	newGRPCServer = func(...grpc.ServerOption) grpcServer { return fs }
 	defer func() { newGRPCServer = origNewGRPCServer }()
 
 	s, err := NewGRPCServer(BootstrapContentsForTesting(generateBootstrapContents(t, uuid.NewString(), "non-existent-management-server")))
@@ -355,7 +355,7 @@ func (s) TestServeSuccess(t *testing.T) {
 	// request is received by it.
 	ldsRequestCh := make(chan []string, 1)
 	mgmtServer := e2e.StartManagementServer(t, e2e.ManagementServerOptions{
-		OnStreamRequest: func(id int64, req *v3discoverypb.DiscoveryRequest) error {
+		OnStreamRequest: func(_ int64, req *v3discoverypb.DiscoveryRequest) error {
 			if req.GetTypeUrl() == version.V3ListenerURL {
 				select {
 				case ldsRequestCh <- req.GetResourceNames():
@@ -374,7 +374,7 @@ func (s) TestServeSuccess(t *testing.T) {
 	// test to verify that Serve() is called on the underlying server.
 	fs := newFakeGRPCServer()
 	origNewGRPCServer := newGRPCServer
-	newGRPCServer = func(opts ...grpc.ServerOption) grpcServer { return fs }
+	newGRPCServer = func(...grpc.ServerOption) grpcServer { return fs }
 	defer func() { newGRPCServer = origNewGRPCServer }()
 
 	// Create a new xDS enabled gRPC server and pass it a server option to get
@@ -572,7 +572,7 @@ func (s) TestHandleListenerUpdate_ErrorUpdate(t *testing.T) {
 	// request is received by it.
 	ldsRequestCh := make(chan []string, 1)
 	mgmtServer := e2e.StartManagementServer(t, e2e.ManagementServerOptions{
-		OnStreamRequest: func(id int64, req *v3discoverypb.DiscoveryRequest) error {
+		OnStreamRequest: func(_ int64, req *v3discoverypb.DiscoveryRequest) error {
 			if req.GetTypeUrl() == version.V3ListenerURL {
 				select {
 				case ldsRequestCh <- req.GetResourceNames():


### PR DESCRIPTION
part of #7500 

unused_parameters linters issue from revive were bypassed earlier. This is an attempt to fix that. 

This PR also modifies vet:
- revive earlier did not error when there was output. I added `-set_exit_status=1` to do that
- we should exclude `reflection/test/grpc_testing_not_regenerate/`
- remove the bypass for unused-parameters

RELEASE NOTES: none
