### PR TITLE
xds: keep ads flow control local to xdsclient/transport package

### DIFF
--- a/xds/internal/balancer/cdsbalancer/cluster_watcher.go
+++ b/xds/internal/balancer/cdsbalancer/cluster_watcher.go
@@ -32,19 +32,19 @@ type clusterWatcher struct {
 	parent *cdsBalancer
 }
 
-func (cw *clusterWatcher) OnUpdate(u *xdsresource.ClusterResourceData, onDone xdsresource.DoneNotifier) {
-	handleUpdate := func(context.Context) { cw.parent.onClusterUpdate(cw.name, u.Resource); onDone.OnDone() }
-	cw.parent.serializer.ScheduleOr(handleUpdate, onDone.OnDone)
+func (cw *clusterWatcher) OnUpdate(u *xdsresource.ClusterResourceData, onDone xdsresource.OnDoneFunc) {
+	handleUpdate := func(context.Context) { cw.parent.onClusterUpdate(cw.name, u.Resource); onDone() }
+	cw.parent.serializer.ScheduleOr(handleUpdate, onDone)
 }
 
-func (cw *clusterWatcher) OnError(err error, onDone xdsresource.DoneNotifier) {
-	handleError := func(context.Context) { cw.parent.onClusterError(cw.name, err); onDone.OnDone() }
-	cw.parent.serializer.ScheduleOr(handleError, onDone.OnDone)
+func (cw *clusterWatcher) OnError(err error, onDone xdsresource.OnDoneFunc) {
+	handleError := func(context.Context) { cw.parent.onClusterError(cw.name, err); onDone() }
+	cw.parent.serializer.ScheduleOr(handleError, onDone)
 }
 
-func (cw *clusterWatcher) OnResourceDoesNotExist(onDone xdsresource.DoneNotifier) {
-	handleNotFound := func(context.Context) { cw.parent.onClusterResourceNotFound(cw.name); onDone.OnDone() }
-	cw.parent.serializer.ScheduleOr(handleNotFound, onDone.OnDone)
+func (cw *clusterWatcher) OnResourceDoesNotExist(onDone xdsresource.OnDoneFunc) {
+	handleNotFound := func(context.Context) { cw.parent.onClusterResourceNotFound(cw.name); onDone() }
+	cw.parent.serializer.ScheduleOr(handleNotFound, onDone)
 }
 
 // watcherState groups the state associated with a clusterWatcher.

--- a/xds/internal/balancer/clusterresolver/clusterresolver.go
+++ b/xds/internal/balancer/clusterresolver/clusterresolver.go
@@ -216,7 +216,7 @@ func (b *clusterResolverBalancer) handleResourceUpdate(update *resourceUpdate) {
 	b.updateChildConfig()
 
 	if update.onDone != nil {
-		update.onDone.OnDone()
+		update.onDone()
 	}
 }
 

--- a/xds/internal/balancer/clusterresolver/resource_resolver_dns.go
+++ b/xds/internal/balancer/clusterresolver/resource_resolver_dns.go
@@ -27,7 +27,6 @@ import (
 	"google.golang.org/grpc/internal/pretty"
 	"google.golang.org/grpc/resolver"
 	"google.golang.org/grpc/serviceconfig"
-	"google.golang.org/grpc/xds/internal/xdsclient/xdsresource"
 )
 
 var (
@@ -80,7 +79,7 @@ func newDNSResolver(target string, topLevelResolver topLevelResolver, logger *gr
 			ret.logger.Infof("Failed to parse dns hostname %q in clusterresolver LB policy", target)
 		}
 		ret.updateReceived = true
-		ret.topLevelResolver.onUpdate(xdsresource.NopDoneNotifier{})
+		ret.topLevelResolver.onUpdate(func() {})
 		return ret
 	}
 
@@ -90,7 +89,7 @@ func newDNSResolver(target string, topLevelResolver topLevelResolver, logger *gr
 			ret.logger.Infof("Failed to build DNS resolver for target %q: %v", target, err)
 		}
 		ret.updateReceived = true
-		ret.topLevelResolver.onUpdate(xdsresource.NopDoneNotifier{})
+		ret.topLevelResolver.onUpdate(func() {})
 		return ret
 	}
 	ret.dnsR = r
@@ -154,7 +153,7 @@ func (dr *dnsDiscoveryMechanism) UpdateState(state resolver.State) error {
 	dr.updateReceived = true
 	dr.mu.Unlock()
 
-	dr.topLevelResolver.onUpdate(xdsresource.NopDoneNotifier{})
+	dr.topLevelResolver.onUpdate(func() {})
 	return nil
 }
 
@@ -177,7 +176,7 @@ func (dr *dnsDiscoveryMechanism) ReportError(err error) {
 	dr.updateReceived = true
 	dr.mu.Unlock()
 
-	dr.topLevelResolver.onUpdate(xdsresource.NopDoneNotifier{})
+	dr.topLevelResolver.onUpdate(func() {})
 }
 
 func (dr *dnsDiscoveryMechanism) NewAddress(addresses []resolver.Address) {

--- a/xds/internal/balancer/clusterresolver/resource_resolver_eds.go
+++ b/xds/internal/balancer/clusterresolver/resource_resolver_eds.go
@@ -76,9 +76,9 @@ func newEDSResolver(nameToWatch string, producer xdsresource.Producer, topLevelR
 }
 
 // OnUpdate is invoked to report an update for the resource being watched.
-func (er *edsDiscoveryMechanism) OnUpdate(update *xdsresource.EndpointsResourceData, onDone xdsresource.DoneNotifier) {
+func (er *edsDiscoveryMechanism) OnUpdate(update *xdsresource.EndpointsResourceData, onDone xdsresource.OnDoneFunc) {
 	if er.stopped.HasFired() {
-		onDone.OnDone()
+		onDone()
 		return
 	}
 
@@ -89,9 +89,9 @@ func (er *edsDiscoveryMechanism) OnUpdate(update *xdsresource.EndpointsResourceD
 	er.topLevelResolver.onUpdate(onDone)
 }
 
-func (er *edsDiscoveryMechanism) OnError(err error, onDone xdsresource.DoneNotifier) {
+func (er *edsDiscoveryMechanism) OnError(err error, onDone xdsresource.OnDoneFunc) {
 	if er.stopped.HasFired() {
-		onDone.OnDone()
+		onDone()
 		return
 	}
 
@@ -104,7 +104,7 @@ func (er *edsDiscoveryMechanism) OnError(err error, onDone xdsresource.DoneNotif
 		// Continue using a previously received good configuration if one
 		// exists.
 		er.mu.Unlock()
-		onDone.OnDone()
+		onDone()
 		return
 	}
 
@@ -120,9 +120,9 @@ func (er *edsDiscoveryMechanism) OnError(err error, onDone xdsresource.DoneNotif
 	er.topLevelResolver.onUpdate(onDone)
 }
 
-func (er *edsDiscoveryMechanism) OnResourceDoesNotExist(onDone xdsresource.DoneNotifier) {
+func (er *edsDiscoveryMechanism) OnResourceDoesNotExist(onDone xdsresource.OnDoneFunc) {
 	if er.stopped.HasFired() {
-		onDone.OnDone()
+		onDone()
 		return
 	}
 

--- a/xds/internal/resolver/watch_service.go
+++ b/xds/internal/resolver/watch_service.go
@@ -36,19 +36,19 @@ func newListenerWatcher(resourceName string, parent *xdsResolver) *listenerWatch
 	return lw
 }
 
-func (l *listenerWatcher) OnUpdate(update *xdsresource.ListenerResourceData, onDone xdsresource.DoneNotifier) {
-	handleUpdate := func(context.Context) { l.parent.onListenerResourceUpdate(update.Resource); onDone.OnDone() }
-	l.parent.serializer.ScheduleOr(handleUpdate, onDone.OnDone)
+func (l *listenerWatcher) OnUpdate(update *xdsresource.ListenerResourceData, onDone xdsresource.OnDoneFunc) {
+	handleUpdate := func(context.Context) { l.parent.onListenerResourceUpdate(update.Resource); onDone() }
+	l.parent.serializer.ScheduleOr(handleUpdate, onDone)
 }
 
-func (l *listenerWatcher) OnError(err error, onDone xdsresource.DoneNotifier) {
-	handleError := func(context.Context) { l.parent.onListenerResourceError(err); onDone.OnDone() }
-	l.parent.serializer.ScheduleOr(handleError, onDone.OnDone)
+func (l *listenerWatcher) OnError(err error, onDone xdsresource.OnDoneFunc) {
+	handleError := func(context.Context) { l.parent.onListenerResourceError(err); onDone() }
+	l.parent.serializer.ScheduleOr(handleError, onDone)
 }
 
-func (l *listenerWatcher) OnResourceDoesNotExist(onDone xdsresource.DoneNotifier) {
-	handleNotFound := func(context.Context) { l.parent.onListenerResourceNotFound(); onDone.OnDone() }
-	l.parent.serializer.ScheduleOr(handleNotFound, onDone.OnDone)
+func (l *listenerWatcher) OnResourceDoesNotExist(onDone xdsresource.OnDoneFunc) {
+	handleNotFound := func(context.Context) { l.parent.onListenerResourceNotFound(); onDone() }
+	l.parent.serializer.ScheduleOr(handleNotFound, onDone)
 }
 
 func (l *listenerWatcher) stop() {
@@ -68,22 +68,22 @@ func newRouteConfigWatcher(resourceName string, parent *xdsResolver) *routeConfi
 	return rw
 }
 
-func (r *routeConfigWatcher) OnUpdate(u *xdsresource.RouteConfigResourceData, onDone xdsresource.DoneNotifier) {
+func (r *routeConfigWatcher) OnUpdate(u *xdsresource.RouteConfigResourceData, onDone xdsresource.OnDoneFunc) {
 	handleUpdate := func(context.Context) {
 		r.parent.onRouteConfigResourceUpdate(r.resourceName, u.Resource)
-		onDone.OnDone()
+		onDone()
 	}
-	r.parent.serializer.ScheduleOr(handleUpdate, onDone.OnDone)
+	r.parent.serializer.ScheduleOr(handleUpdate, onDone)
 }
 
-func (r *routeConfigWatcher) OnError(err error, onDone xdsresource.DoneNotifier) {
-	handleError := func(context.Context) { r.parent.onRouteConfigResourceError(r.resourceName, err); onDone.OnDone() }
-	r.parent.serializer.ScheduleOr(handleError, onDone.OnDone)
+func (r *routeConfigWatcher) OnError(err error, onDone xdsresource.OnDoneFunc) {
+	handleError := func(context.Context) { r.parent.onRouteConfigResourceError(r.resourceName, err); onDone() }
+	r.parent.serializer.ScheduleOr(handleError, onDone)
 }
 
-func (r *routeConfigWatcher) OnResourceDoesNotExist(onDone xdsresource.DoneNotifier) {
-	handleNotFound := func(context.Context) { r.parent.onRouteConfigResourceNotFound(r.resourceName); onDone.OnDone() }
-	r.parent.serializer.ScheduleOr(handleNotFound, onDone.OnDone)
+func (r *routeConfigWatcher) OnResourceDoesNotExist(onDone xdsresource.OnDoneFunc) {
+	handleNotFound := func(context.Context) { r.parent.onRouteConfigResourceNotFound(r.resourceName); onDone() }
+	r.parent.serializer.ScheduleOr(handleNotFound, onDone)
 }
 
 func (r *routeConfigWatcher) stop() {

--- a/xds/internal/server/listener_wrapper.go
+++ b/xds/internal/server/listener_wrapper.go
@@ -410,8 +410,8 @@ type ldsWatcher struct {
 	name   string
 }
 
-func (lw *ldsWatcher) OnUpdate(update *xdsresource.ListenerResourceData, onDone xdsresource.DoneNotifier) {
-	defer onDone.OnDone()
+func (lw *ldsWatcher) OnUpdate(update *xdsresource.ListenerResourceData, onDone xdsresource.OnDoneFunc) {
+	defer onDone()
 	if lw.parent.closed.HasFired() {
 		lw.logger.Warningf("Resource %q received update: %#v after listener was closed", lw.name, update)
 		return
@@ -422,8 +422,8 @@ func (lw *ldsWatcher) OnUpdate(update *xdsresource.ListenerResourceData, onDone 
 	lw.parent.handleLDSUpdate(update.Resource)
 }
 
-func (lw *ldsWatcher) OnError(err error, onDone xdsresource.DoneNotifier) {
-	defer onDone.OnDone()
+func (lw *ldsWatcher) OnError(err error, onDone xdsresource.OnDoneFunc) {
+	defer onDone()
 	if lw.parent.closed.HasFired() {
 		lw.logger.Warningf("Resource %q received error: %v after listener was closed", lw.name, err)
 		return
@@ -435,8 +435,8 @@ func (lw *ldsWatcher) OnError(err error, onDone xdsresource.DoneNotifier) {
 	// continue to use the old configuration.
 }
 
-func (lw *ldsWatcher) OnResourceDoesNotExist(onDone xdsresource.DoneNotifier) {
-	defer onDone.OnDone()
+func (lw *ldsWatcher) OnResourceDoesNotExist(onDone xdsresource.OnDoneFunc) {
+	defer onDone()
 	if lw.parent.closed.HasFired() {
 		lw.logger.Warningf("Resource %q received resource-does-not-exist error after listener was closed", lw.name)
 		return

--- a/xds/internal/server/rds_handler.go
+++ b/xds/internal/server/rds_handler.go
@@ -147,8 +147,8 @@ type rdsWatcher struct {
 	canceled bool // eats callbacks if true
 }
 
-func (rw *rdsWatcher) OnUpdate(update *xdsresource.RouteConfigResourceData, onDone xdsresource.DoneNotifier) {
-	defer onDone.OnDone()
+func (rw *rdsWatcher) OnUpdate(update *xdsresource.RouteConfigResourceData, onDone xdsresource.OnDoneFunc) {
+	defer onDone()
 	rw.mu.Lock()
 	if rw.canceled {
 		rw.mu.Unlock()
@@ -161,8 +161,8 @@ func (rw *rdsWatcher) OnUpdate(update *xdsresource.RouteConfigResourceData, onDo
 	rw.parent.handleRouteUpdate(rw.routeName, rdsWatcherUpdate{data: &update.Resource})
 }
 
-func (rw *rdsWatcher) OnError(err error, onDone xdsresource.DoneNotifier) {
-	defer onDone.OnDone()
+func (rw *rdsWatcher) OnError(err error, onDone xdsresource.OnDoneFunc) {
+	defer onDone()
 	rw.mu.Lock()
 	if rw.canceled {
 		rw.mu.Unlock()
@@ -175,8 +175,8 @@ func (rw *rdsWatcher) OnError(err error, onDone xdsresource.DoneNotifier) {
 	rw.parent.handleRouteUpdate(rw.routeName, rdsWatcherUpdate{err: err})
 }
 
-func (rw *rdsWatcher) OnResourceDoesNotExist(onDone xdsresource.DoneNotifier) {
-	defer onDone.OnDone()
+func (rw *rdsWatcher) OnResourceDoesNotExist(onDone xdsresource.OnDoneFunc) {
+	defer onDone()
 	rw.mu.Lock()
 	if rw.canceled {
 		rw.mu.Unlock()

--- a/xds/internal/testutils/resource_watcher.go
+++ b/xds/internal/testutils/resource_watcher.go
@@ -37,8 +37,8 @@ type TestResourceWatcher struct {
 
 // OnUpdate is invoked by the xDS client to report the latest update on the resource
 // being watched.
-func (w *TestResourceWatcher) OnUpdate(data xdsresource.ResourceData, onDone xdsresource.DoneNotifier) {
-	defer onDone.OnDone()
+func (w *TestResourceWatcher) OnUpdate(data xdsresource.ResourceData, onDone xdsresource.OnDoneFunc) {
+	defer onDone()
 	select {
 	case <-w.UpdateCh:
 	default:
@@ -47,8 +47,8 @@ func (w *TestResourceWatcher) OnUpdate(data xdsresource.ResourceData, onDone xds
 }
 
 // OnError is invoked by the xDS client to report the latest error.
-func (w *TestResourceWatcher) OnError(err error, onDone xdsresource.DoneNotifier) {
-	defer onDone.OnDone()
+func (w *TestResourceWatcher) OnError(err error, onDone xdsresource.OnDoneFunc) {
+	defer onDone()
 	select {
 	case <-w.ErrorCh:
 	default:
@@ -58,8 +58,8 @@ func (w *TestResourceWatcher) OnError(err error, onDone xdsresource.DoneNotifier
 
 // OnResourceDoesNotExist is used by the xDS client to report that the resource
 // being watched no longer exists.
-func (w *TestResourceWatcher) OnResourceDoesNotExist(onDone xdsresource.DoneNotifier) {
-	defer onDone.OnDone()
+func (w *TestResourceWatcher) OnResourceDoesNotExist(onDone xdsresource.OnDoneFunc) {
+	defer onDone()
 	select {
 	case <-w.ResourceDoesNotExistCh:
 	default:

--- a/xds/internal/xdsclient/authority.go
+++ b/xds/internal/xdsclient/authority.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"google.golang.org/grpc/internal/grpclog"
@@ -148,7 +149,7 @@ func (a *authority) transportOnSendHandler(u *transport.ResourceSendInfo) {
 	a.startWatchTimersLocked(rType, u.ResourceNames)
 }
 
-func (a *authority) handleResourceUpdate(resourceUpdate transport.ResourceUpdate, fc *transport.ADSFlowControl) error {
+func (a *authority) handleResourceUpdate(resourceUpdate transport.ResourceUpdate, onDone func()) error {
 	rType := a.resourceTypeGetter(resourceUpdate.URL)
 	if rType == nil {
 		return xdsresource.NewErrorf(xdsresource.ErrorTypeResourceTypeUnsupported, "Resource URL %v unknown in response from server", resourceUpdate.URL)
@@ -159,24 +160,37 @@ func (a *authority) handleResourceUpdate(resourceUpdate transport.ResourceUpdate
 		ServerConfig:    a.serverCfg,
 	}
 	updates, md, err := decodeAllResources(opts, rType, resourceUpdate)
-	a.updateResourceStateAndScheduleCallbacks(rType, updates, md, fc)
+	a.updateResourceStateAndScheduleCallbacks(rType, updates, md, onDone)
 	return err
 }
 
-func (a *authority) updateResourceStateAndScheduleCallbacks(rType xdsresource.Type, updates map[string]resourceDataErrTuple, md xdsresource.UpdateMetadata, fc *transport.ADSFlowControl) {
+func (a *authority) updateResourceStateAndScheduleCallbacks(rType xdsresource.Type, updates map[string]resourceDataErrTuple, md xdsresource.UpdateMetadata, onDone func()) {
 	a.resourcesMu.Lock()
 	defer a.resourcesMu.Unlock()
 
 	// We build a list of callback funcs to invoke, and invoke them at the end
 	// of this method instead of inline (when handling the update for a
 	// particular resource), because we want to make sure that all calls to
-	// `fc.Add` happen before any callbacks are invoked. This will ensure that
-	// the next read is never attempted before all callbacks are invoked, and
-	// the watchers have processed the update.
+	// increment watcherCnt happen before any callbacks are invoked. This will
+	// ensure that the onDone callback is never invoked before all watcher
+	// callbacks are invoked, and the watchers have processed the update.
+	watcherCnt := new(atomic.Int64)
+	done := func() {
+		watcherCnt.Add(-1)
+		if watcherCnt.Load() == 0 {
+			onDone()
+		}
+	}
 	funcsToSchedule := []func(context.Context){}
 	defer func() {
+		if len(funcsToSchedule) == 0 {
+			// When there are no watchers for the resources received as part of
+			// this update, invoke onDone explicitly to unblock the next read on
+			// the ADS stream.
+			onDone()
+		}
 		for _, f := range funcsToSchedule {
-			a.serializer.ScheduleOr(f, fc.OnDone)
+			a.serializer.ScheduleOr(f, onDone)
 		}
 	}()
 
@@ -223,8 +237,8 @@ func (a *authority) updateResourceStateAndScheduleCallbacks(rType xdsresource.Ty
 				for watcher := range state.watchers {
 					watcher := watcher
 					err := uErr.err
-					fc.Add()
-					funcsToSchedule = append(funcsToSchedule, func(context.Context) { watcher.OnError(err, fc) })
+					watcherCnt.Add(1)
+					funcsToSchedule = append(funcsToSchedule, func(context.Context) { watcher.OnError(err, done) })
 				}
 				continue
 			}
@@ -239,8 +253,8 @@ func (a *authority) updateResourceStateAndScheduleCallbacks(rType xdsresource.Ty
 				for watcher := range state.watchers {
 					watcher := watcher
 					resource := uErr.resource
-					fc.Add()
-					funcsToSchedule = append(funcsToSchedule, func(context.Context) { watcher.OnUpdate(resource, fc) })
+					watcherCnt.Add(1)
+					funcsToSchedule = append(funcsToSchedule, func(context.Context) { watcher.OnUpdate(resource, done) })
 				}
 			}
 			// Sync cache.
@@ -315,8 +329,8 @@ func (a *authority) updateResourceStateAndScheduleCallbacks(rType xdsresource.Ty
 			state.md = xdsresource.UpdateMetadata{Status: xdsresource.ServiceStatusNotExist}
 			for watcher := range state.watchers {
 				watcher := watcher
-				fc.Add()
-				funcsToSchedule = append(funcsToSchedule, func(context.Context) { watcher.OnResourceDoesNotExist(fc) })
+				watcherCnt.Add(1)
+				funcsToSchedule = append(funcsToSchedule, func(context.Context) { watcher.OnResourceDoesNotExist(done) })
 			}
 		}
 	}
@@ -445,7 +459,7 @@ func (a *authority) newConnectionError(err error) {
 			for watcher := range state.watchers {
 				watcher := watcher
 				a.serializer.TrySchedule(func(context.Context) {
-					watcher.OnError(xdsresource.NewErrorf(xdsresource.ErrorTypeConnection, "xds: error received from xDS stream: %v", err), xdsresource.NopDoneNotifier{})
+					watcher.OnError(xdsresource.NewErrorf(xdsresource.ErrorTypeConnection, "xds: error received from xDS stream: %v", err), func() {})
 				})
 			}
 		}
@@ -511,7 +525,7 @@ func (a *authority) watchResource(rType xdsresource.Type, resourceName string, w
 			a.logger.Infof("Resource type %q with resource name %q found in cache: %s", rType.TypeName(), resourceName, state.cache.ToJSON())
 		}
 		resource := state.cache
-		a.serializer.TrySchedule(func(context.Context) { watcher.OnUpdate(resource, xdsresource.NopDoneNotifier{}) })
+		a.serializer.TrySchedule(func(context.Context) { watcher.OnUpdate(resource, func() {}) })
 	}
 
 	return func() {
@@ -564,7 +578,7 @@ func (a *authority) handleWatchTimerExpiryLocked(rType xdsresource.Type, resourc
 	state.md = xdsresource.UpdateMetadata{Status: xdsresource.ServiceStatusNotExist}
 	for watcher := range state.watchers {
 		watcher := watcher
-		a.serializer.TrySchedule(func(context.Context) { watcher.OnResourceDoesNotExist(xdsresource.NopDoneNotifier{}) })
+		a.serializer.TrySchedule(func(context.Context) { watcher.OnResourceDoesNotExist(func() {}) })
 	}
 }
 
@@ -590,7 +604,7 @@ func (a *authority) triggerResourceNotFoundForTesting(rType xdsresource.Type, re
 	state.md = xdsresource.UpdateMetadata{Status: xdsresource.ServiceStatusNotExist}
 	for watcher := range state.watchers {
 		watcher := watcher
-		a.serializer.TrySchedule(func(context.Context) { watcher.OnResourceDoesNotExist(xdsresource.NopDoneNotifier{}) })
+		a.serializer.TrySchedule(func(context.Context) { watcher.OnResourceDoesNotExist(func() {}) })
 	}
 }
 

--- a/xds/internal/xdsclient/clientimpl_watchers.go
+++ b/xds/internal/xdsclient/clientimpl_watchers.go
@@ -44,7 +44,7 @@ func (c *clientImpl) WatchResource(rType xdsresource.Type, resourceName string, 
 
 	if err := c.resourceTypes.maybeRegister(rType); err != nil {
 		logger.Warningf("Watch registered for name %q of type %q which is already registered", rType.TypeName(), resourceName)
-		c.serializer.TrySchedule(func(context.Context) { watcher.OnError(err, xdsresource.NopDoneNotifier{}) })
+		c.serializer.TrySchedule(func(context.Context) { watcher.OnError(err, func() {}) })
 		return func() {}
 	}
 
@@ -54,7 +54,7 @@ func (c *clientImpl) WatchResource(rType xdsresource.Type, resourceName string, 
 	a, unref, err := c.findAuthority(n)
 	if err != nil {
 		logger.Warningf("Watch registered for name %q of type %q, authority %q is not found", rType.TypeName(), resourceName, n.Authority)
-		c.serializer.TrySchedule(func(context.Context) { watcher.OnError(err, xdsresource.NopDoneNotifier{}) })
+		c.serializer.TrySchedule(func(context.Context) { watcher.OnError(err, func() {}) })
 		return func() {}
 	}
 	cancelF := a.watchResource(rType, n.String(), watcher)

--- a/xds/internal/xdsclient/tests/misc_watchers_test.go
+++ b/xds/internal/xdsclient/tests/misc_watchers_test.go
@@ -69,26 +69,26 @@ func newTestRouteConfigWatcher(client xdsclient.XDSClient, name1, name2 string) 
 	}
 }
 
-func (rw *testRouteConfigWatcher) OnUpdate(update *xdsresource.RouteConfigResourceData, done xdsresource.DoneNotifier) {
+func (rw *testRouteConfigWatcher) OnUpdate(update *xdsresource.RouteConfigResourceData, onDone xdsresource.OnDoneFunc) {
 	rw.updateCh.Send(routeConfigUpdateErrTuple{update: update.Resource})
 
 	rw.cancel1 = xdsresource.WatchRouteConfig(rw.client, rw.name1, rw.rcw1)
 	rw.cancel2 = xdsresource.WatchRouteConfig(rw.client, rw.name2, rw.rcw2)
-	done.OnDone()
+	onDone()
 }
 
-func (rw *testRouteConfigWatcher) OnError(err error, done xdsresource.DoneNotifier) {
+func (rw *testRouteConfigWatcher) OnError(err error, onDone xdsresource.OnDoneFunc) {
 	// When used with a go-control-plane management server that continuously
 	// resends resources which are NACKed by the xDS client, using a `Replace()`
 	// here and in OnResourceDoesNotExist() simplifies tests which will have
 	// access to the most recently received error.
 	rw.updateCh.Replace(routeConfigUpdateErrTuple{err: err})
-	done.OnDone()
+	onDone()
 }
 
-func (rw *testRouteConfigWatcher) OnResourceDoesNotExist(done xdsresource.DoneNotifier) {
+func (rw *testRouteConfigWatcher) OnResourceDoesNotExist(onDone xdsresource.OnDoneFunc) {
 	rw.updateCh.Replace(routeConfigUpdateErrTuple{err: xdsresource.NewErrorf(xdsresource.ErrorTypeResourceNotFound, "RouteConfiguration not found in received response")})
-	done.OnDone()
+	onDone()
 }
 
 func (rw *testRouteConfigWatcher) cancel() {

--- a/xds/internal/xdsclient/tests/rds_watchers_test.go
+++ b/xds/internal/xdsclient/tests/rds_watchers_test.go
@@ -43,14 +43,14 @@ import (
 
 type noopRouteConfigWatcher struct{}
 
-func (noopRouteConfigWatcher) OnUpdate(update *xdsresource.RouteConfigResourceData, done xdsresource.DoneNotifier) {
-	done.OnDone()
+func (noopRouteConfigWatcher) OnUpdate(update *xdsresource.RouteConfigResourceData, onDone xdsresource.OnDoneFunc) {
+	onDone()
 }
-func (noopRouteConfigWatcher) OnError(err error, done xdsresource.DoneNotifier) {
-	done.OnDone()
+func (noopRouteConfigWatcher) OnError(err error, onDone xdsresource.OnDoneFunc) {
+	onDone()
 }
-func (noopRouteConfigWatcher) OnResourceDoesNotExist(done xdsresource.DoneNotifier) {
-	done.OnDone()
+func (noopRouteConfigWatcher) OnResourceDoesNotExist(onDone xdsresource.OnDoneFunc) {
+	onDone()
 }
 
 type routeConfigUpdateErrTuple struct {
@@ -66,23 +66,23 @@ func newRouteConfigWatcher() *routeConfigWatcher {
 	return &routeConfigWatcher{updateCh: testutils.NewChannel()}
 }
 
-func (rw *routeConfigWatcher) OnUpdate(update *xdsresource.RouteConfigResourceData, done xdsresource.DoneNotifier) {
+func (rw *routeConfigWatcher) OnUpdate(update *xdsresource.RouteConfigResourceData, onDone xdsresource.OnDoneFunc) {
 	rw.updateCh.Send(routeConfigUpdateErrTuple{update: update.Resource})
-	done.OnDone()
+	onDone()
 }
 
-func (rw *routeConfigWatcher) OnError(err error, done xdsresource.DoneNotifier) {
+func (rw *routeConfigWatcher) OnError(err error, onDone xdsresource.OnDoneFunc) {
 	// When used with a go-control-plane management server that continuously
 	// resends resources which are NACKed by the xDS client, using a `Replace()`
 	// here and in OnResourceDoesNotExist() simplifies tests which will have
 	// access to the most recently received error.
 	rw.updateCh.Replace(routeConfigUpdateErrTuple{err: err})
-	done.OnDone()
+	onDone()
 }
 
-func (rw *routeConfigWatcher) OnResourceDoesNotExist(done xdsresource.DoneNotifier) {
+func (rw *routeConfigWatcher) OnResourceDoesNotExist(onDone xdsresource.OnDoneFunc) {
 	rw.updateCh.Replace(routeConfigUpdateErrTuple{err: xdsresource.NewErrorf(xdsresource.ErrorTypeResourceNotFound, "RouteConfiguration not found in received response")})
-	done.OnDone()
+	onDone()
 }
 
 // badRouteConfigResource returns a RouteConfiguration resource for the given

--- a/xds/internal/xdsclient/transport/loadreport_test.go
+++ b/xds/internal/xdsclient/transport/loadreport_test.go
@@ -68,10 +68,10 @@ func (s) TestReportLoad(t *testing.T) {
 	tr, err := transport.New(transport.Options{
 		ServerCfg:      serverCfg,
 		NodeProto:      nodeProto,
-		OnRecvHandler:  func(transport.ResourceUpdate, *transport.ADSFlowControl) error { return nil }, // No ADS validation.
-		OnErrorHandler: func(error) {},                                                                 // No ADS stream error handling.
-		OnSendHandler:  func(*transport.ResourceSendInfo) {},                                           // No ADS stream update handling.
-		Backoff:        func(int) time.Duration { return time.Duration(0) },                            // No backoff.
+		OnRecvHandler:  noopRecvHandler,                                     // No ADS validation.
+		OnErrorHandler: func(error) {},                                      // No ADS stream error handling.
+		OnSendHandler:  func(*transport.ResourceSendInfo) {},                // No ADS stream update handling.
+		Backoff:        func(int) time.Duration { return time.Duration(0) }, // No backoff.
 	})
 	if err != nil {
 		t.Fatalf("Failed to create xDS transport: %v", err)

--- a/xds/internal/xdsclient/transport/transport_ack_nack_test.go
+++ b/xds/internal/xdsclient/transport/transport_ack_nack_test.go
@@ -49,7 +49,8 @@ var (
 
 	// A simple update handler for listener resources which validates only the
 	// `use_original_dst` field.
-	dataModelValidator = func(update transport.ResourceUpdate, _ *transport.ADSFlowControl) error {
+	dataModelValidator = func(update transport.ResourceUpdate, onDone func()) error {
+		defer onDone()
 		for _, r := range update.Resources {
 			inner := &v3discoverypb.Resource{}
 			if err := proto.Unmarshal(r.GetValue(), inner); err != nil {

--- a/xds/internal/xdsclient/transport/transport_backoff_test.go
+++ b/xds/internal/xdsclient/transport/transport_backoff_test.go
@@ -44,6 +44,11 @@ import (
 
 var strSort = func(s1, s2 string) bool { return s1 < s2 }
 
+var noopRecvHandler = func(_ transport.ResourceUpdate, onDone func()) error {
+	onDone()
+	return nil
+}
+
 // TestTransport_BackoffAfterStreamFailure tests the case where the management
 // server returns an error in the ADS streaming RPC. The test verifies the
 // following:
@@ -101,7 +106,7 @@ func (s) TestTransport_BackoffAfterStreamFailure(t *testing.T) {
 	nodeID := uuid.New().String()
 	tr, err := transport.New(transport.Options{
 		ServerCfg:     serverCfg,
-		OnRecvHandler: func(transport.ResourceUpdate, *transport.ADSFlowControl) error { return nil }, // No data model layer validation.
+		OnRecvHandler: noopRecvHandler, // No data model layer validation.
 		OnErrorHandler: func(err error) {
 			select {
 			case streamErrCh <- err:
@@ -262,7 +267,7 @@ func (s) TestTransport_RetriesAfterBrokenStream(t *testing.T) {
 	// we can pass a no-op data model layer implementation.
 	tr, err := transport.New(transport.Options{
 		ServerCfg:     serverCfg,
-		OnRecvHandler: func(transport.ResourceUpdate, *transport.ADSFlowControl) error { return nil }, // No data model layer validation.
+		OnRecvHandler: noopRecvHandler, // No data model layer validation.
 		OnErrorHandler: func(err error) {
 			select {
 			case streamErrCh <- err:
@@ -394,10 +399,10 @@ func (s) TestTransport_ResourceRequestedBeforeStreamCreation(t *testing.T) {
 	nodeID := uuid.New().String()
 	tr, err := transport.New(transport.Options{
 		ServerCfg:      serverCfg,
-		OnRecvHandler:  func(transport.ResourceUpdate, *transport.ADSFlowControl) error { return nil }, // No data model layer validation.
-		OnErrorHandler: func(error) {},                                                                 // No stream error handling.
-		OnSendHandler:  func(*transport.ResourceSendInfo) {},                                           // No on send handler
-		Backoff:        func(int) time.Duration { return time.Duration(0) },                            // No backoff.
+		OnRecvHandler:  noopRecvHandler,                                     // No data model layer validation.
+		OnErrorHandler: func(error) {},                                      // No stream error handling.
+		OnSendHandler:  func(*transport.ResourceSendInfo) {},                // No on send handler
+		Backoff:        func(int) time.Duration { return time.Duration(0) }, // No backoff.
 		NodeProto:      &v3corepb.Node{Id: nodeID},
 	})
 	if err != nil {

--- a/xds/internal/xdsclient/transport/transport_new_test.go
+++ b/xds/internal/xdsclient/transport/transport_new_test.go
@@ -53,7 +53,7 @@ func (s) TestNew(t *testing.T) {
 			opts: transport.Options{
 				ServerCfg:     serverCfg,
 				NodeProto:     &v3corepb.Node{},
-				OnRecvHandler: func(transport.ResourceUpdate, *transport.ADSFlowControl) error { return nil },
+				OnRecvHandler: noopRecvHandler, // No data model layer validation.
 				OnSendHandler: func(*transport.ResourceSendInfo) {},
 			},
 			wantErrStr: "missing OnError callback handler when creating a new transport",
@@ -64,7 +64,7 @@ func (s) TestNew(t *testing.T) {
 			opts: transport.Options{
 				ServerCfg:      serverCfg,
 				NodeProto:      &v3corepb.Node{},
-				OnRecvHandler:  func(transport.ResourceUpdate, *transport.ADSFlowControl) error { return nil },
+				OnRecvHandler:  noopRecvHandler, // No data model layer validation.
 				OnErrorHandler: func(error) {},
 			},
 			wantErrStr: "missing OnSend callback handler when creating a new transport",
@@ -74,7 +74,7 @@ func (s) TestNew(t *testing.T) {
 			opts: transport.Options{
 				ServerCfg:      serverCfg,
 				NodeProto:      &v3corepb.Node{},
-				OnRecvHandler:  func(transport.ResourceUpdate, *transport.ADSFlowControl) error { return nil },
+				OnRecvHandler:  noopRecvHandler, // No data model layer validation.
 				OnErrorHandler: func(error) {},
 				OnSendHandler:  func(*transport.ResourceSendInfo) {},
 			},

--- a/xds/internal/xdsclient/transport/transport_resource_test.go
+++ b/xds/internal/xdsclient/transport/transport_resource_test.go
@@ -185,12 +185,13 @@ func (s) TestHandleResponseFromManagementServer(t *testing.T) {
 			tr, err := transport.New(transport.Options{
 				ServerCfg: serverCfg,
 				// No validation. Simply push received resources on a channel.
-				OnRecvHandler: func(update transport.ResourceUpdate, _ *transport.ADSFlowControl) error {
+				OnRecvHandler: func(update transport.ResourceUpdate, onDone func()) error {
 					resourcesCh.Send(&resourcesWithTypeURL{
 						resources: update.Resources,
 						url:       update.URL,
 						// Ignore resource version here.
 					})
+					onDone()
 					return nil
 				},
 				OnSendHandler:  func(*transport.ResourceSendInfo) {},                // No onSend handling.
@@ -239,7 +240,7 @@ func (s) TestEmptyListenerResourceOnStreamRestart(t *testing.T) {
 	nodeProto := &v3corepb.Node{Id: uuid.New().String()}
 	tr, err := transport.New(transport.Options{
 		ServerCfg:      serverCfg,
-		OnRecvHandler:  func(transport.ResourceUpdate, *transport.ADSFlowControl) error { return nil },
+		OnRecvHandler:  noopRecvHandler,                                     // No data model layer validation.
 		OnSendHandler:  func(*transport.ResourceSendInfo) {},                // No onSend handling.
 		OnErrorHandler: func(error) {},                                      // No stream error handling.
 		Backoff:        func(int) time.Duration { return time.Duration(0) }, // No backoff.
@@ -330,7 +331,7 @@ func (s) TestEmptyClusterResourceOnStreamRestartWithListener(t *testing.T) {
 	nodeProto := &v3corepb.Node{Id: uuid.New().String()}
 	tr, err := transport.New(transport.Options{
 		ServerCfg:      serverCfg,
-		OnRecvHandler:  func(transport.ResourceUpdate, *transport.ADSFlowControl) error { return nil },
+		OnRecvHandler:  noopRecvHandler,                                     // No data model layer validation.
 		OnSendHandler:  func(*transport.ResourceSendInfo) {},                // No onSend handling.
 		OnErrorHandler: func(error) {},                                      // No stream error handling.
 		Backoff:        func(int) time.Duration { return time.Duration(0) }, // No backoff.

--- a/xds/internal/xdsclient/transport/transport_test.go
+++ b/xds/internal/xdsclient/transport/transport_test.go
@@ -47,8 +47,8 @@ func (s) TestNewWithGRPCDial(t *testing.T) {
 	opts := transport.Options{
 		ServerCfg: serverCfg,
 		NodeProto: &v3corepb.Node{},
-		OnRecvHandler: func(update transport.ResourceUpdate, fc *transport.ADSFlowControl) error {
-			fc.OnDone()
+		OnRecvHandler: func(update transport.ResourceUpdate, onDone func()) error {
+			onDone()
 			return nil
 		},
 		OnErrorHandler: func(error) {},

--- a/xds/internal/xdsclient/xdsresource/cluster_resource_type.go
+++ b/xds/internal/xdsclient/xdsresource/cluster_resource_type.go
@@ -111,10 +111,7 @@ func (c *ClusterResourceData) Raw() *anypb.Any {
 // corresponding to the cluster resource being watched.
 type ClusterWatcher interface {
 	// OnUpdate is invoked to report an update for the resource being watched.
-	//
-	// The watcher is expected to call Done() on the DoneNotifier once it has
-	// processed the update.
-	OnUpdate(*ClusterResourceData, DoneNotifier)
+	OnUpdate(*ClusterResourceData, OnDoneFunc)
 
 	// OnError is invoked under different error conditions including but not
 	// limited to the following:
@@ -124,34 +121,28 @@ type ClusterWatcher interface {
 	//	- resource validation error
 	//	- ADS stream failure
 	//	- connection failure
-	//
-	// The watcher is expected to call Done() on the DoneNotifier once it has
-	// processed the update.
-	OnError(error, DoneNotifier)
+	OnError(error, OnDoneFunc)
 
 	// OnResourceDoesNotExist is invoked for a specific error condition where
 	// the requested resource is not found on the xDS management server.
-	//
-	// The watcher is expected to call Done() on the DoneNotifier once it has
-	// processed the update.
-	OnResourceDoesNotExist(DoneNotifier)
+	OnResourceDoesNotExist(OnDoneFunc)
 }
 
 type delegatingClusterWatcher struct {
 	watcher ClusterWatcher
 }
 
-func (d *delegatingClusterWatcher) OnUpdate(data ResourceData, done DoneNotifier) {
+func (d *delegatingClusterWatcher) OnUpdate(data ResourceData, onDone OnDoneFunc) {
 	c := data.(*ClusterResourceData)
-	d.watcher.OnUpdate(c, done)
+	d.watcher.OnUpdate(c, onDone)
 }
 
-func (d *delegatingClusterWatcher) OnError(err error, done DoneNotifier) {
-	d.watcher.OnError(err, done)
+func (d *delegatingClusterWatcher) OnError(err error, onDone OnDoneFunc) {
+	d.watcher.OnError(err, onDone)
 }
 
-func (d *delegatingClusterWatcher) OnResourceDoesNotExist(done DoneNotifier) {
-	d.watcher.OnResourceDoesNotExist(done)
+func (d *delegatingClusterWatcher) OnResourceDoesNotExist(onDone OnDoneFunc) {
+	d.watcher.OnResourceDoesNotExist(onDone)
 }
 
 // WatchCluster uses xDS to discover the configuration associated with the

--- a/xds/internal/xdsclient/xdsresource/endpoints_resource_type.go
+++ b/xds/internal/xdsclient/xdsresource/endpoints_resource_type.go
@@ -107,10 +107,7 @@ func (e *EndpointsResourceData) Raw() *anypb.Any {
 // events corresponding to the endpoints resource being watched.
 type EndpointsWatcher interface {
 	// OnUpdate is invoked to report an update for the resource being watched.
-	//
-	// The watcher is expected to call Done() on the DoneNotifier once it has
-	// processed the update.
-	OnUpdate(*EndpointsResourceData, DoneNotifier)
+	OnUpdate(*EndpointsResourceData, OnDoneFunc)
 
 	// OnError is invoked under different error conditions including but not
 	// limited to the following:
@@ -120,34 +117,28 @@ type EndpointsWatcher interface {
 	//	- resource validation error
 	//	- ADS stream failure
 	//	- connection failure
-	//
-	// The watcher is expected to call Done() on the DoneNotifier once it has
-	// processed the update.
-	OnError(error, DoneNotifier)
+	OnError(error, OnDoneFunc)
 
 	// OnResourceDoesNotExist is invoked for a specific error condition where
 	// the requested resource is not found on the xDS management server.
-	//
-	// The watcher is expected to call Done() on the DoneNotifier once it has
-	// processed the update.
-	OnResourceDoesNotExist(DoneNotifier)
+	OnResourceDoesNotExist(OnDoneFunc)
 }
 
 type delegatingEndpointsWatcher struct {
 	watcher EndpointsWatcher
 }
 
-func (d *delegatingEndpointsWatcher) OnUpdate(data ResourceData, done DoneNotifier) {
+func (d *delegatingEndpointsWatcher) OnUpdate(data ResourceData, onDone OnDoneFunc) {
 	e := data.(*EndpointsResourceData)
-	d.watcher.OnUpdate(e, done)
+	d.watcher.OnUpdate(e, onDone)
 }
 
-func (d *delegatingEndpointsWatcher) OnError(err error, done DoneNotifier) {
-	d.watcher.OnError(err, done)
+func (d *delegatingEndpointsWatcher) OnError(err error, onDone OnDoneFunc) {
+	d.watcher.OnError(err, onDone)
 }
 
-func (d *delegatingEndpointsWatcher) OnResourceDoesNotExist(done DoneNotifier) {
-	d.watcher.OnResourceDoesNotExist(done)
+func (d *delegatingEndpointsWatcher) OnResourceDoesNotExist(onDone OnDoneFunc) {
+	d.watcher.OnResourceDoesNotExist(onDone)
 }
 
 // WatchEndpoints uses xDS to discover the configuration associated with the

--- a/xds/internal/xdsclient/xdsresource/listener_resource_type.go
+++ b/xds/internal/xdsclient/xdsresource/listener_resource_type.go
@@ -144,10 +144,7 @@ func (l *ListenerResourceData) Raw() *anypb.Any {
 // events corresponding to the listener resource being watched.
 type ListenerWatcher interface {
 	// OnUpdate is invoked to report an update for the resource being watched.
-	//
-	// The watcher is expected to call Done() on the DoneNotifier once it has
-	// processed the update.
-	OnUpdate(*ListenerResourceData, DoneNotifier)
+	OnUpdate(*ListenerResourceData, OnDoneFunc)
 
 	// OnError is invoked under different error conditions including but not
 	// limited to the following:
@@ -157,34 +154,28 @@ type ListenerWatcher interface {
 	//	- resource validation error
 	//	- ADS stream failure
 	//	- connection failure
-	//
-	// The watcher is expected to call Done() on the DoneNotifier once it has
-	// processed the update.
-	OnError(error, DoneNotifier)
+	OnError(error, OnDoneFunc)
 
 	// OnResourceDoesNotExist is invoked for a specific error condition where
 	// the requested resource is not found on the xDS management server.
-	//
-	// The watcher is expected to call Done() on the DoneNotifier once it has
-	// processed the update.
-	OnResourceDoesNotExist(DoneNotifier)
+	OnResourceDoesNotExist(OnDoneFunc)
 }
 
 type delegatingListenerWatcher struct {
 	watcher ListenerWatcher
 }
 
-func (d *delegatingListenerWatcher) OnUpdate(data ResourceData, done DoneNotifier) {
+func (d *delegatingListenerWatcher) OnUpdate(data ResourceData, onDone OnDoneFunc) {
 	l := data.(*ListenerResourceData)
-	d.watcher.OnUpdate(l, done)
+	d.watcher.OnUpdate(l, onDone)
 }
 
-func (d *delegatingListenerWatcher) OnError(err error, done DoneNotifier) {
-	d.watcher.OnError(err, done)
+func (d *delegatingListenerWatcher) OnError(err error, onDone OnDoneFunc) {
+	d.watcher.OnError(err, onDone)
 }
 
-func (d *delegatingListenerWatcher) OnResourceDoesNotExist(done DoneNotifier) {
-	d.watcher.OnResourceDoesNotExist(done)
+func (d *delegatingListenerWatcher) OnResourceDoesNotExist(onDone OnDoneFunc) {
+	d.watcher.OnResourceDoesNotExist(onDone)
 }
 
 // WatchListener uses xDS to discover the configuration associated with the

--- a/xds/internal/xdsclient/xdsresource/route_config_resource_type.go
+++ b/xds/internal/xdsclient/xdsresource/route_config_resource_type.go
@@ -108,10 +108,7 @@ func (r *RouteConfigResourceData) Raw() *anypb.Any {
 // events corresponding to the route configuration resource being watched.
 type RouteConfigWatcher interface {
 	// OnUpdate is invoked to report an update for the resource being watched.
-	//
-	// The watcher is expected to call Done() on the DoneNotifier once it has
-	// processed the update.
-	OnUpdate(*RouteConfigResourceData, DoneNotifier)
+	OnUpdate(*RouteConfigResourceData, OnDoneFunc)
 
 	// OnError is invoked under different error conditions including but not
 	// limited to the following:
@@ -121,34 +118,28 @@ type RouteConfigWatcher interface {
 	//	- resource validation error
 	//	- ADS stream failure
 	//	- connection failure
-	//
-	// The watcher is expected to call Done() on the DoneNotifier once it has
-	// processed the update.
-	OnError(error, DoneNotifier)
+	OnError(error, OnDoneFunc)
 
 	// OnResourceDoesNotExist is invoked for a specific error condition where
 	// the requested resource is not found on the xDS management server.
-	//
-	// The watcher is expected to call Done() on the DoneNotifier once it has
-	// processed the update.
-	OnResourceDoesNotExist(DoneNotifier)
+	OnResourceDoesNotExist(OnDoneFunc)
 }
 
 type delegatingRouteConfigWatcher struct {
 	watcher RouteConfigWatcher
 }
 
-func (d *delegatingRouteConfigWatcher) OnUpdate(data ResourceData, done DoneNotifier) {
+func (d *delegatingRouteConfigWatcher) OnUpdate(data ResourceData, onDone OnDoneFunc) {
 	rc := data.(*RouteConfigResourceData)
-	d.watcher.OnUpdate(rc, done)
+	d.watcher.OnUpdate(rc, onDone)
 }
 
-func (d *delegatingRouteConfigWatcher) OnError(err error, done DoneNotifier) {
-	d.watcher.OnError(err, done)
+func (d *delegatingRouteConfigWatcher) OnError(err error, onDone OnDoneFunc) {
+	d.watcher.OnError(err, onDone)
 }
 
-func (d *delegatingRouteConfigWatcher) OnResourceDoesNotExist(done DoneNotifier) {
-	d.watcher.OnResourceDoesNotExist(done)
+func (d *delegatingRouteConfigWatcher) OnResourceDoesNotExist(onDone OnDoneFunc) {
+	d.watcher.OnResourceDoesNotExist(onDone)
 }
 
 // WatchRouteConfig uses xDS to discover the configuration associated with the


### PR DESCRIPTION
This PR ensures that the ADS stream level flow control functionality added recently is kept local to the `xdsclient/transport` package. It also simplifies the implementation in a number of ways.

Summary of changes:
- Simplify the public watch API by having a `func` parameter instead of an `interface` to notify that local processing of the update is complete
- Simplify the flow control implementation by not having to worry about the actual number of watchers that are yet to process the most recent update, and instead having a boolean that indicates whether or not the update has been processed by all watchers.
  - The actual work of tracking how many watchers are yet to process the most recent update is moved to the `authority`, which is the one that is actually invoking the watcher callbacks.
- The reason for defining `xdsresource.OnDoneFunc` and making the watcher callbacks use that instead of a plan `func()` is to ease documenting the interface. 
  - Willing to change this if deemed to cause more harm than good.

One of the main motivations for this change is the ongoing refactor to move ADS and LRS functionality out of the xDS transport type into separate types. With the flow control functionality becoming local to the `transport` package, it can easily be moved into the eventual type that will provide the ADS functionality.

RELEASE NOTES: none