### PR TITLE
Add full method names list to generated code for enhanced gRPC interceptor control

### DIFF
--- a/balancer/grpclb/grpc_lb_v1/load_balancer_grpc.pb.go
+++ b/balancer/grpclb/grpc_lb_v1/load_balancer_grpc.pb.go
@@ -41,6 +41,12 @@ const (
 	LoadBalancer_BalanceLoad_FullMethodName = "/grpc.lb.v1.LoadBalancer/BalanceLoad"
 )
 
+var (
+	LoadBalancer_FullMethodNames = []string{
+		"/grpc.lb.v1.LoadBalancer/BalanceLoad",
+	}
+)
+
 // LoadBalancerClient is the client API for LoadBalancer service.
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.

--- a/channelz/grpc_channelz_v1/channelz_grpc.pb.go
+++ b/channelz/grpc_channelz_v1/channelz_grpc.pb.go
@@ -49,6 +49,18 @@ const (
 	Channelz_GetSocket_FullMethodName        = "/grpc.channelz.v1.Channelz/GetSocket"
 )
 
+var (
+	Channelz_FullMethodNames = []string{
+		"/grpc.channelz.v1.Channelz/GetTopChannels",
+		"/grpc.channelz.v1.Channelz/GetServers",
+		"/grpc.channelz.v1.Channelz/GetServer",
+		"/grpc.channelz.v1.Channelz/GetServerSockets",
+		"/grpc.channelz.v1.Channelz/GetChannel",
+		"/grpc.channelz.v1.Channelz/GetSubchannel",
+		"/grpc.channelz.v1.Channelz/GetSocket",
+	}
+)
+
 // ChannelzClient is the client API for Channelz service.
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.

--- a/cmd/protoc-gen-go-grpc/grpc.go
+++ b/cmd/protoc-gen-go-grpc/grpc.go
@@ -56,12 +56,24 @@ func (serviceGenerateHelper) genFullMethods(g *protogen.GeneratedFile, service *
 		return
 	}
 
+	serviceFullMethodNames := make([]string, 0, len(service.Methods))
+
 	g.P("const (")
 	for _, method := range service.Methods {
 		fmSymbol := helper.formatFullMethodSymbol(service, method)
 		fmName := fmt.Sprintf("/%s/%s", service.Desc.FullName(), method.Desc.Name())
+		serviceFullMethodNames = append(serviceFullMethodNames, fmName)
 		g.P(fmSymbol, ` = "`, fmName, `"`)
 	}
+	g.P(")")
+	g.P()
+
+	g.P("var (")
+	g.P(fmt.Sprintf("%s_FullMethodNames = []string{", service.GoName))
+	for _, fullMethodName := range serviceFullMethodNames {
+		g.P(fmt.Sprintf(`"%s",`, fullMethodName))
+	}
+	g.P("}")
 	g.P(")")
 	g.P()
 }

--- a/credentials/alts/internal/proto/grpc_gcp/handshaker_grpc.pb.go
+++ b/credentials/alts/internal/proto/grpc_gcp/handshaker_grpc.pb.go
@@ -39,6 +39,12 @@ const (
 	HandshakerService_DoHandshake_FullMethodName = "/grpc.gcp.HandshakerService/DoHandshake"
 )
 
+var (
+	HandshakerService_FullMethodNames = []string{
+		"/grpc.gcp.HandshakerService/DoHandshake",
+	}
+)
+
 // HandshakerServiceClient is the client API for HandshakerService service.
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.

--- a/examples/features/proto/echo/echo_grpc.pb.go
+++ b/examples/features/proto/echo/echo_grpc.pb.go
@@ -42,6 +42,15 @@ const (
 	Echo_BidirectionalStreamingEcho_FullMethodName = "/grpc.examples.echo.Echo/BidirectionalStreamingEcho"
 )
 
+var (
+	Echo_FullMethodNames = []string{
+		"/grpc.examples.echo.Echo/UnaryEcho",
+		"/grpc.examples.echo.Echo/ServerStreamingEcho",
+		"/grpc.examples.echo.Echo/ClientStreamingEcho",
+		"/grpc.examples.echo.Echo/BidirectionalStreamingEcho",
+	}
+)
+
 // EchoClient is the client API for Echo service.
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.

--- a/examples/helloworld/helloworld/helloworld_grpc.pb.go
+++ b/examples/helloworld/helloworld/helloworld_grpc.pb.go
@@ -36,6 +36,12 @@ const (
 	Greeter_SayHello_FullMethodName = "/helloworld.Greeter/SayHello"
 )
 
+var (
+	Greeter_FullMethodNames = []string{
+		"/helloworld.Greeter/SayHello",
+	}
+)
+
 // GreeterClient is the client API for Greeter service.
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.

--- a/examples/route_guide/routeguide/route_guide_grpc.pb.go
+++ b/examples/route_guide/routeguide/route_guide_grpc.pb.go
@@ -39,6 +39,15 @@ const (
 	RouteGuide_RouteChat_FullMethodName    = "/routeguide.RouteGuide/RouteChat"
 )
 
+var (
+	RouteGuide_FullMethodNames = []string{
+		"/routeguide.RouteGuide/GetFeature",
+		"/routeguide.RouteGuide/ListFeatures",
+		"/routeguide.RouteGuide/RecordRoute",
+		"/routeguide.RouteGuide/RouteChat",
+	}
+)
+
 // RouteGuideClient is the client API for RouteGuide service.
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.

--- a/health/grpc_health_v1/health_grpc.pb.go
+++ b/health/grpc_health_v1/health_grpc.pb.go
@@ -40,6 +40,13 @@ const (
 	Health_Watch_FullMethodName = "/grpc.health.v1.Health/Watch"
 )
 
+var (
+	Health_FullMethodNames = []string{
+		"/grpc.health.v1.Health/Check",
+		"/grpc.health.v1.Health/Watch",
+	}
+)
+
 // HealthClient is the client API for Health service.
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.

--- a/internal/proto/grpc_lookup_v1/rls_grpc.pb.go
+++ b/internal/proto/grpc_lookup_v1/rls_grpc.pb.go
@@ -36,6 +36,12 @@ const (
 	RouteLookupService_RouteLookup_FullMethodName = "/grpc.lookup.v1.RouteLookupService/RouteLookup"
 )
 
+var (
+	RouteLookupService_FullMethodNames = []string{
+		"/grpc.lookup.v1.RouteLookupService/RouteLookup",
+	}
+)
+
 // RouteLookupServiceClient is the client API for RouteLookupService service.
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.

--- a/interop/grpc_testing/benchmark_service_grpc.pb.go
+++ b/interop/grpc_testing/benchmark_service_grpc.pb.go
@@ -43,6 +43,16 @@ const (
 	BenchmarkService_StreamingBothWays_FullMethodName   = "/grpc.testing.BenchmarkService/StreamingBothWays"
 )
 
+var (
+	BenchmarkService_FullMethodNames = []string{
+		"/grpc.testing.BenchmarkService/UnaryCall",
+		"/grpc.testing.BenchmarkService/StreamingCall",
+		"/grpc.testing.BenchmarkService/StreamingFromClient",
+		"/grpc.testing.BenchmarkService/StreamingFromServer",
+		"/grpc.testing.BenchmarkService/StreamingBothWays",
+	}
+)
+
 // BenchmarkServiceClient is the client API for BenchmarkService service.
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.

--- a/interop/grpc_testing/report_qps_scenario_service_grpc.pb.go
+++ b/interop/grpc_testing/report_qps_scenario_service_grpc.pb.go
@@ -39,6 +39,12 @@ const (
 	ReportQpsScenarioService_ReportScenario_FullMethodName = "/grpc.testing.ReportQpsScenarioService/ReportScenario"
 )
 
+var (
+	ReportQpsScenarioService_FullMethodNames = []string{
+		"/grpc.testing.ReportQpsScenarioService/ReportScenario",
+	}
+)
+
 // ReportQpsScenarioServiceClient is the client API for ReportQpsScenarioService service.
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.

--- a/interop/grpc_testing/test_grpc.pb.go
+++ b/interop/grpc_testing/test_grpc.pb.go
@@ -46,6 +46,19 @@ const (
 	TestService_UnimplementedCall_FullMethodName   = "/grpc.testing.TestService/UnimplementedCall"
 )
 
+var (
+	TestService_FullMethodNames = []string{
+		"/grpc.testing.TestService/EmptyCall",
+		"/grpc.testing.TestService/UnaryCall",
+		"/grpc.testing.TestService/CacheableUnaryCall",
+		"/grpc.testing.TestService/StreamingOutputCall",
+		"/grpc.testing.TestService/StreamingInputCall",
+		"/grpc.testing.TestService/FullDuplexCall",
+		"/grpc.testing.TestService/HalfDuplexCall",
+		"/grpc.testing.TestService/UnimplementedCall",
+	}
+)
+
 // TestServiceClient is the client API for TestService service.
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
@@ -434,6 +447,12 @@ const (
 	UnimplementedService_UnimplementedCall_FullMethodName = "/grpc.testing.UnimplementedService/UnimplementedCall"
 )
 
+var (
+	UnimplementedService_FullMethodNames = []string{
+		"/grpc.testing.UnimplementedService/UnimplementedCall",
+	}
+)
+
 // UnimplementedServiceClient is the client API for UnimplementedService service.
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
@@ -543,6 +562,13 @@ var UnimplementedService_ServiceDesc = grpc.ServiceDesc{
 const (
 	ReconnectService_Start_FullMethodName = "/grpc.testing.ReconnectService/Start"
 	ReconnectService_Stop_FullMethodName  = "/grpc.testing.ReconnectService/Stop"
+)
+
+var (
+	ReconnectService_FullMethodNames = []string{
+		"/grpc.testing.ReconnectService/Start",
+		"/grpc.testing.ReconnectService/Stop",
+	}
 )
 
 // ReconnectServiceClient is the client API for ReconnectService service.
@@ -687,6 +713,13 @@ var ReconnectService_ServiceDesc = grpc.ServiceDesc{
 const (
 	LoadBalancerStatsService_GetClientStats_FullMethodName            = "/grpc.testing.LoadBalancerStatsService/GetClientStats"
 	LoadBalancerStatsService_GetClientAccumulatedStats_FullMethodName = "/grpc.testing.LoadBalancerStatsService/GetClientAccumulatedStats"
+)
+
+var (
+	LoadBalancerStatsService_FullMethodNames = []string{
+		"/grpc.testing.LoadBalancerStatsService/GetClientStats",
+		"/grpc.testing.LoadBalancerStatsService/GetClientAccumulatedStats",
+	}
 )
 
 // LoadBalancerStatsServiceClient is the client API for LoadBalancerStatsService service.
@@ -837,6 +870,14 @@ const (
 	HookService_Hook_FullMethodName              = "/grpc.testing.HookService/Hook"
 	HookService_SetReturnStatus_FullMethodName   = "/grpc.testing.HookService/SetReturnStatus"
 	HookService_ClearReturnStatus_FullMethodName = "/grpc.testing.HookService/ClearReturnStatus"
+)
+
+var (
+	HookService_FullMethodNames = []string{
+		"/grpc.testing.HookService/Hook",
+		"/grpc.testing.HookService/SetReturnStatus",
+		"/grpc.testing.HookService/ClearReturnStatus",
+	}
 )
 
 // HookServiceClient is the client API for HookService service.
@@ -1029,6 +1070,14 @@ const (
 	XdsUpdateHealthService_SendHookRequest_FullMethodName = "/grpc.testing.XdsUpdateHealthService/SendHookRequest"
 )
 
+var (
+	XdsUpdateHealthService_FullMethodNames = []string{
+		"/grpc.testing.XdsUpdateHealthService/SetServing",
+		"/grpc.testing.XdsUpdateHealthService/SetNotServing",
+		"/grpc.testing.XdsUpdateHealthService/SendHookRequest",
+	}
+)
+
 // XdsUpdateHealthServiceClient is the client API for XdsUpdateHealthService service.
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
@@ -1208,6 +1257,12 @@ var XdsUpdateHealthService_ServiceDesc = grpc.ServiceDesc{
 
 const (
 	XdsUpdateClientConfigureService_Configure_FullMethodName = "/grpc.testing.XdsUpdateClientConfigureService/Configure"
+)
+
+var (
+	XdsUpdateClientConfigureService_FullMethodNames = []string{
+		"/grpc.testing.XdsUpdateClientConfigureService/Configure",
+	}
 )
 
 // XdsUpdateClientConfigureServiceClient is the client API for XdsUpdateClientConfigureService service.

--- a/interop/grpc_testing/worker_service_grpc.pb.go
+++ b/interop/grpc_testing/worker_service_grpc.pb.go
@@ -42,6 +42,15 @@ const (
 	WorkerService_QuitWorker_FullMethodName = "/grpc.testing.WorkerService/QuitWorker"
 )
 
+var (
+	WorkerService_FullMethodNames = []string{
+		"/grpc.testing.WorkerService/RunServer",
+		"/grpc.testing.WorkerService/RunClient",
+		"/grpc.testing.WorkerService/CoreCount",
+		"/grpc.testing.WorkerService/QuitWorker",
+	}
+)
+
 // WorkerServiceClient is the client API for WorkerService service.
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.

--- a/interop/stress/grpc_testing/metrics_grpc.pb.go
+++ b/interop/stress/grpc_testing/metrics_grpc.pb.go
@@ -44,6 +44,13 @@ const (
 	MetricsService_GetGauge_FullMethodName     = "/grpc.testing.MetricsService/GetGauge"
 )
 
+var (
+	MetricsService_FullMethodNames = []string{
+		"/grpc.testing.MetricsService/GetAllGauges",
+		"/grpc.testing.MetricsService/GetGauge",
+	}
+)
+
 // MetricsServiceClient is the client API for MetricsService service.
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.

--- a/profiling/proto/service_grpc.pb.go
+++ b/profiling/proto/service_grpc.pb.go
@@ -37,6 +37,13 @@ const (
 	Profiling_GetStreamStats_FullMethodName = "/grpc.go.profiling.v1alpha.Profiling/GetStreamStats"
 )
 
+var (
+	Profiling_FullMethodNames = []string{
+		"/grpc.go.profiling.v1alpha.Profiling/Enable",
+		"/grpc.go.profiling.v1alpha.Profiling/GetStreamStats",
+	}
+)
+
 // ProfilingClient is the client API for Profiling service.
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.

--- a/reflection/grpc_reflection_v1/reflection_grpc.pb.go
+++ b/reflection/grpc_reflection_v1/reflection_grpc.pb.go
@@ -43,6 +43,12 @@ const (
 	ServerReflection_ServerReflectionInfo_FullMethodName = "/grpc.reflection.v1.ServerReflection/ServerReflectionInfo"
 )
 
+var (
+	ServerReflection_FullMethodNames = []string{
+		"/grpc.reflection.v1.ServerReflection/ServerReflectionInfo",
+	}
+)
+
 // ServerReflectionClient is the client API for ServerReflection service.
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.

--- a/reflection/grpc_reflection_v1alpha/reflection_grpc.pb.go
+++ b/reflection/grpc_reflection_v1alpha/reflection_grpc.pb.go
@@ -40,6 +40,12 @@ const (
 	ServerReflection_ServerReflectionInfo_FullMethodName = "/grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo"
 )
 
+var (
+	ServerReflection_FullMethodNames = []string{
+		"/grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo",
+	}
+)
+
 // ServerReflectionClient is the client API for ServerReflection service.
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.

--- a/reflection/grpc_testing/test_grpc.pb.go
+++ b/reflection/grpc_testing/test_grpc.pb.go
@@ -37,6 +37,13 @@ const (
 	SearchService_StreamingSearch_FullMethodName = "/grpc.testing.SearchService/StreamingSearch"
 )
 
+var (
+	SearchService_FullMethodNames = []string{
+		"/grpc.testing.SearchService/Search",
+		"/grpc.testing.SearchService/StreamingSearch",
+	}
+)
+
 // SearchServiceClient is the client API for SearchService service.
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.


### PR DESCRIPTION
Add full method names list for each service to enhance custom gRPC interceptor control

- Implemented a feature that generates a list of full method names for each gRPC service in the generated code.
- This list is integrated into the code to facilitate service-wide control mechanisms in custom gRPC interceptors.
- By providing access to all method names, this feature allows developers to apply consistent logic, such as authentication, logging, or rate-limiting, across an entire service in a more streamlined and efficient manner.
- Updated code generation logic to include the method names list, ensuring better introspection and control over gRPC services.