### PR TITLE
endpointsharding: Skip nil child pickers while updating ClientConn state

### DIFF
--- a/balancer/endpointsharding/endpointsharding.go
+++ b/balancer/endpointsharding/endpointsharding.go
@@ -116,7 +116,13 @@ func (es *endpointSharding) UpdateClientConnState(state balancer.ClientConnState
 			bal = child.(*balancerWrapper)
 		} else {
 			bal = &balancerWrapper{
-				childState: ChildState{Endpoint: endpoint},
+				childState: ChildState{
+					Endpoint: endpoint,
+					State: balancer.State{
+						ConnectivityState: connectivity.Connecting,
+						Picker:            base.NewErrPicker(balancer.ErrNoSubConnAvailable),
+					},
+				},
 				ClientConn: es.cc,
 				es:         es,
 			}


### PR DESCRIPTION
The child pickers are initialized to `nil` when child LB policies are created
https://github.com/grpc/grpc-go/blob/ca4865d6dd6f3d8b77f1943ccfd6c9e78223912d/balancer/endpointsharding/endpointsharding.go#L118-L122

When pick is called on endpointsharding's picker, it tries to call `Pick()` on a nil picker here and panics
https://github.com/grpc/grpc-go/blob/ca4865d6dd6f3d8b77f1943ccfd6c9e78223912d/balancer/endpointsharding/endpointsharding.go#L254-L258

This change ignores nil child pickers during aggregation. If all pickers are nil, the channel state is set to CONNECTING with error `balancer.ErrNoSubConnAvailable`.

Test logs demonstrating the panic: [panic_logs.txt](https://github.com/user-attachments/files/17193245/panic_logs.txt)

RELEASE NOTES:
* endpointsharding: Skip `nil` child pickers while updating ClientConn state. This avoid panics when an RPC is made before the child policy generates a picker.