### PR TITLE
xds: add xDS transport custom Dialer support

### DIFF
--- a/internal/xds/bootstrap/bootstrap.go
+++ b/internal/xds/bootstrap/bootstrap.go
@@ -313,8 +313,7 @@ func (sc *ServerConfig) UnmarshalJSON(data []byte) error {
 		}
 		sc.selectedCreds = cc
 		sc.credsDialOption = grpc.WithCredentialsBundle(bundle)
-		d, ok := bundle.(dialer)
-		if ok {
+		if d, ok := bundle.(dialer); ok {
 			sc.dialerOption = grpc.WithContextDialer(d.Dialer)
 		}
 		sc.cleanups = append(sc.cleanups, cancel)

--- a/internal/xds/bootstrap/bootstrap.go
+++ b/internal/xds/bootstrap/bootstrap.go
@@ -226,8 +226,9 @@ func (sc *ServerConfig) CredsDialOption() grpc.DialOption {
 	return sc.credsDialOption
 }
 
-// DialerOption returns the first supported Dialer function that specifies how
-// to dial the xDS server from the configuration, as a dial option.
+// DialerOption returns the Dialer function that specifies how to dial the xDS
+// server determined by the first supported credentials from the configuration,
+// as a dial option.
 func (sc *ServerConfig) DialerOption() grpc.DialOption {
 	return sc.dialerOption
 }

--- a/internal/xds/bootstrap/bootstrap.go
+++ b/internal/xds/bootstrap/bootstrap.go
@@ -229,6 +229,9 @@ func (sc *ServerConfig) CredsDialOption() grpc.DialOption {
 // DialerOption returns the Dialer function that specifies how to dial the xDS
 // server determined by the first supported credentials from the configuration,
 // as a dial option.
+//
+// TODO(https://github.com/grpc/grpc-go/issues/7661): change ServerConfig type
+// to have a single method that returns all configured dial options.
 func (sc *ServerConfig) DialerOption() grpc.DialOption {
 	return sc.dialerOption
 }

--- a/test/xds/xds_client_custom_dialer_test.go
+++ b/test/xds/xds_client_custom_dialer_test.go
@@ -57,7 +57,7 @@ func (t *testDialerCredsBuilder) Build(config json.RawMessage) (credentials.Bund
 	if err := json.Unmarshal(config, &cfg); err != nil {
 		return nil, func() {}, fmt.Errorf("failed to unmarshal config: %v", err)
 	}
-	return &testDialerCredsBundle{t.dialerCalled, cfg.MgmtServerAddress}, func() {}, nil
+	return &testDialerCredsBundle{insecure.NewBundle(), t.dialerCalled, cfg.MgmtServerAddress}, func() {}, nil
 }
 
 func (t *testDialerCredsBuilder) Name() string {
@@ -68,20 +68,9 @@ func (t *testDialerCredsBuilder) Name() string {
 // `credentials` and encapsulates an insecure credential with a custom Dialer
 // that specifies how to dial the xDS server.
 type testDialerCredsBundle struct {
+	credentials.Bundle
 	dialerCalled      chan struct{}
 	mgmtServerAddress string
-}
-
-func (t *testDialerCredsBundle) TransportCredentials() credentials.TransportCredentials {
-	return insecure.NewCredentials()
-}
-
-func (t *testDialerCredsBundle) PerRPCCredentials() credentials.PerRPCCredentials {
-	return nil
-}
-
-func (t *testDialerCredsBundle) NewWithMode(string) (credentials.Bundle, error) {
-	return &testDialerCredsBundle{}, nil
 }
 
 // Dialer specifies how to dial the xDS management server.

--- a/test/xds/xds_client_custom_dialer_test.go
+++ b/test/xds/xds_client_custom_dialer_test.go
@@ -52,7 +52,7 @@ type testDialerCredsBuilder struct {
 
 func (t *testDialerCredsBuilder) Build(config json.RawMessage) (credentials.Bundle, func(), error) {
 	cfg := &struct {
-		MgmtServerAddress string `json:"mgmtServerAddress"`
+		MgmtServerAddress string `json:"mgmt_server_address"`
 	}{}
 	if err := json.Unmarshal(config, &cfg); err != nil {
 		return nil, func() {}, fmt.Errorf("failed to unmarshal config: %v", err)
@@ -95,7 +95,7 @@ func (s) TestClientCustomDialerFromCredentialsBundle(t *testing.T) {
 			"server_uri": %q,
 			"channel_creds": [{
 				"type": %q,
-				"config": {"mgmtServerAddress": %q}
+				"config": {"mgmt_server_address": %q}
 			}]
 		}]`, mgmtServer.Address, testDialerCredsBuilderName, mgmtServer.Address)),
 		Node: []byte(fmt.Sprintf(`{"id": "%s"}`, nodeID)),

--- a/test/xds/xds_client_custom_dialer_test.go
+++ b/test/xds/xds_client_custom_dialer_test.go
@@ -1,0 +1,158 @@
+/*
+ *
+ * Copyright 2024 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package xds_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"testing"
+
+	"github.com/google/uuid"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/internal"
+	"google.golang.org/grpc/internal/stubserver"
+	"google.golang.org/grpc/internal/testutils"
+	"google.golang.org/grpc/internal/testutils/xds/e2e"
+	internalbootstrap "google.golang.org/grpc/internal/xds/bootstrap"
+	"google.golang.org/grpc/resolver"
+	"google.golang.org/grpc/xds/bootstrap"
+
+	testgrpc "google.golang.org/grpc/interop/grpc_testing"
+	testpb "google.golang.org/grpc/interop/grpc_testing"
+)
+
+const testDialerCredsBuilderName = "test_dialer_creds"
+
+var (
+	mgmtServerAddress  string
+	customDialerCalled bool
+)
+
+func init() {
+	bootstrap.RegisterCredentials(&testDialerCredsBuilder{})
+}
+
+// testDialerCredsBuilder implements the `Credentials` interface defined in
+// package `xds/bootstrap` and encapsulates an insecure credential with a
+// custom Dialer that specifies how to dial the xDS server.
+type testDialerCredsBuilder struct{}
+
+func (t *testDialerCredsBuilder) Build(json.RawMessage) (credentials.Bundle, func(), error) {
+	return &testDialerCredsBundle{}, func() {}, nil
+}
+
+func (t *testDialerCredsBuilder) Name() string {
+	return testDialerCredsBuilderName
+}
+
+// testDialerCredsBundle implements the `Bundle` interface defined in package
+// `credentials` and encapsulates an insecure credential with a custom Dialer
+// that specifies how to dial the xDS server.
+type testDialerCredsBundle struct{}
+
+func (t *testDialerCredsBundle) TransportCredentials() credentials.TransportCredentials {
+	return insecure.NewCredentials()
+}
+
+func (t *testDialerCredsBundle) PerRPCCredentials() credentials.PerRPCCredentials {
+	return nil
+}
+
+func (t *testDialerCredsBundle) NewWithMode(string) (credentials.Bundle, error) {
+	return &testDialerCredsBundle{}, nil
+}
+
+// Dialer specifies how to dial the xDS management server.
+func (t *testDialerCredsBundle) Dialer(context.Context, string) (net.Conn, error) {
+	customDialerCalled = true
+	// Create a pass-through connection (no-op) to the xDS management server.
+	return net.Dial("tcp", mgmtServerAddress)
+}
+
+func (s) TestClientCustomDialerFromCredentialsBundle(t *testing.T) {
+	customDialerCalled = false
+
+	// Start an xDS management server.
+	mgmtServer := e2e.StartManagementServer(t, e2e.ManagementServerOptions{})
+
+	// Create bootstrap configuration pointing to the above management server.
+	nodeID := uuid.New().String()
+	bc, err := internalbootstrap.NewContentsForTesting(internalbootstrap.ConfigOptionsForTesting{
+		Servers: []byte(fmt.Sprintf(`[{
+			"server_uri": %q,
+			"channel_creds": [{"type": %q}]
+		}]`, mgmtServer.Address, testDialerCredsBuilderName)),
+		Node: []byte(fmt.Sprintf(`{"id": "%s"}`, nodeID)),
+	})
+	if err != nil {
+		t.Fatalf("Failed to create bootstrap configuration: %v", err)
+	}
+
+	// Set the management server address to be used by the custom dialer.
+	mgmtServerAddress = mgmtServer.Address
+
+	// Create an xDS resolver with the above bootstrap configuration.
+	var resolverBuilder resolver.Builder
+	if newResolver := internal.NewXDSResolverWithConfigForTesting; newResolver != nil {
+		resolverBuilder, err = newResolver.(func([]byte) (resolver.Builder, error))(bc)
+		if err != nil {
+			t.Fatalf("Failed to create xDS resolver for testing: %v", err)
+		}
+	}
+
+	// Spin up a test backend.
+	server := stubserver.StartTestService(t, nil)
+	defer server.Stop()
+
+	// Configure client side xDS resources on the management server.
+	const serviceName = "my-service-client-side-xds"
+	resources := e2e.DefaultClientResources(e2e.ResourceParams{
+		DialTarget: serviceName,
+		NodeID:     nodeID,
+		Host:       "localhost",
+		Port:       testutils.ParsePort(t, server.Address),
+		SecLevel:   e2e.SecurityLevelNone,
+	})
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	if err := mgmtServer.Update(ctx, resources); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a ClientConn and make a successful RPC. The insecure transport credentials passed into
+	// the gRPC.NewClient is the credentials for the data plane communication with the test backend.
+	cc, err := grpc.NewClient(fmt.Sprintf("xds:///%s", serviceName), grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithResolvers(resolverBuilder))
+	if err != nil {
+		t.Fatalf("failed to dial local test server: %v", err)
+	}
+	defer cc.Close()
+
+	client := testgrpc.NewTestServiceClient(cc)
+	if _, err := client.EmptyCall(ctx, &testpb.Empty{}, grpc.WaitForReady(true)); err != nil {
+		t.Fatalf("EmptyCall() failed: %v", err)
+	}
+
+	if !customDialerCalled {
+		t.Fatalf("xDS client transport custom dialer called = false, want true")
+	}
+}

--- a/xds/internal/xdsclient/transport/transport.go
+++ b/xds/internal/xdsclient/transport/transport.go
@@ -202,8 +202,7 @@ func New(opts Options) (*Transport, error) {
 			Timeout: 20 * time.Second,
 		}),
 	}
-	dialerOpts := opts.ServerCfg.DialerOption()
-	if dialerOpts != nil {
+	if dialerOpts := opts.ServerCfg.DialerOption(); dialerOpts != nil {
 		dopts = append(dopts, dialerOpts)
 	}
 	grpcNewClient := transportinternal.GRPCNewClient.(func(string, ...grpc.DialOption) (*grpc.ClientConn, error))

--- a/xds/internal/xdsclient/transport/transport.go
+++ b/xds/internal/xdsclient/transport/transport.go
@@ -202,6 +202,10 @@ func New(opts Options) (*Transport, error) {
 			Timeout: 20 * time.Second,
 		}),
 	}
+	dialerOpts := opts.ServerCfg.DialerOption()
+	if dialerOpts != nil {
+		dopts = append(dopts, dialerOpts)
+	}
 	grpcNewClient := transportinternal.GRPCNewClient.(func(string, ...grpc.DialOption) (*grpc.ClientConn, error))
 	cc, err := grpcNewClient(opts.ServerCfg.ServerURI(), dopts...)
 	if err != nil {

--- a/xds/internal/xdsclient/transport/transport_test.go
+++ b/xds/internal/xdsclient/transport/transport_test.go
@@ -34,46 +34,6 @@ import (
 	v3corepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 )
 
-const testDialerCredsBuilderName = "test_dialer_creds"
-
-func init() {
-	bootstrap.RegisterCredentials(&testDialerCredsBuilder{})
-}
-
-// testDialerCredsBuilder implements the `Credentials` interface defined in
-// package `xds/bootstrap` and encapsulates an insecure credential with a
-// custom Dialer that specifies how to dial the xDS server.
-type testDialerCredsBuilder struct{}
-
-func (t *testDialerCredsBuilder) Build(json.RawMessage) (credentials.Bundle, func(), error) {
-	return &testDialerCredsBundle{}, func() {}, nil
-}
-
-func (t *testDialerCredsBuilder) Name() string {
-	return testDialerCredsBuilderName
-}
-
-// testDialerCredsBundle implements the `Bundle` interface defined in package
-// `credentials` and encapsulates an insecure credential with a custom Dialer
-// that specifies how to dial the xDS server.
-type testDialerCredsBundle struct{}
-
-func (t *testDialerCredsBundle) TransportCredentials() credentials.TransportCredentials {
-	return insecure.NewCredentials()
-}
-
-func (t *testDialerCredsBundle) PerRPCCredentials() credentials.PerRPCCredentials {
-	return nil
-}
-
-func (t *testDialerCredsBundle) NewWithMode(string) (credentials.Bundle, error) {
-	return &testDialerCredsBundle{}, nil
-}
-
-func (t *testDialerCredsBundle) Dialer(context.Context, string) (net.Conn, error) {
-	return nil, nil
-}
-
 func (s) TestNewWithGRPCDial(t *testing.T) {
 	// Override the dialer with a custom one.
 	customDialerCalled := false
@@ -127,6 +87,46 @@ func (s) TestNewWithGRPCDial(t *testing.T) {
 	if customDialerCalled {
 		t.Fatalf("transport.New(%+v) custom dialer called = true, want false", opts)
 	}
+}
+
+const testDialerCredsBuilderName = "test_dialer_creds"
+
+func init() {
+	bootstrap.RegisterCredentials(&testDialerCredsBuilder{})
+}
+
+// testDialerCredsBuilder implements the `Credentials` interface defined in
+// package `xds/bootstrap` and encapsulates an insecure credential with a
+// custom Dialer that specifies how to dial the xDS server.
+type testDialerCredsBuilder struct{}
+
+func (t *testDialerCredsBuilder) Build(json.RawMessage) (credentials.Bundle, func(), error) {
+	return &testDialerCredsBundle{}, func() {}, nil
+}
+
+func (t *testDialerCredsBuilder) Name() string {
+	return testDialerCredsBuilderName
+}
+
+// testDialerCredsBundle implements the `Bundle` interface defined in package
+// `credentials` and encapsulates an insecure credential with a custom Dialer
+// that specifies how to dial the xDS server.
+type testDialerCredsBundle struct{}
+
+func (t *testDialerCredsBundle) TransportCredentials() credentials.TransportCredentials {
+	return insecure.NewCredentials()
+}
+
+func (t *testDialerCredsBundle) PerRPCCredentials() credentials.PerRPCCredentials {
+	return nil
+}
+
+func (t *testDialerCredsBundle) NewWithMode(string) (credentials.Bundle, error) {
+	return &testDialerCredsBundle{}, nil
+}
+
+func (t *testDialerCredsBundle) Dialer(context.Context, string) (net.Conn, error) {
+	return nil, nil
 }
 
 func (s) TestNewWithDialerFromCredentialsBundle(t *testing.T) {

--- a/xds/internal/xdsclient/transport/transport_test.go
+++ b/xds/internal/xdsclient/transport/transport_test.go
@@ -23,9 +23,9 @@ import (
 	"net"
 	"testing"
 
-  "google.golang.org/grpc/credentials"
-  "google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
 	internalbootstrap "google.golang.org/grpc/internal/xds/bootstrap"
 	"google.golang.org/grpc/xds/bootstrap"
 	"google.golang.org/grpc/xds/internal/xdsclient/transport"


### PR DESCRIPTION
Design:
* go/grpc-go-corp-to-prod-td-doc
* Add a custom `Dialer` method that specifies how to dial the xDS server via the credentials bundle without introducing new public APIs.
* No code change for existing users that do not need a custom Dialer for the xDS transport.

Tested:
* `./scripts/vet.sh`
* `go test -cpu 1,4 -timeout 7m ./...`
* `go test -race -cpu 1,4 -timeout 7m ./...`
* Verified end-to-end by running a test gRPC client with a xDS client that used the custom Dialer for the xDS transport to successfully communicate with the xDS server and fetch configs.

RELEASE NOTES:
* xds: add experimental feature to customize the Dialer used by the xDS transport