### PR TITLE
mem: replace flate.Reader reference

### DIFF
--- a/mem/buffer_slice.go
+++ b/mem/buffer_slice.go
@@ -19,7 +19,6 @@
 package mem
 
 import (
-	"compress/flate"
 	"io"
 )
 
@@ -126,7 +125,8 @@ func (s BufferSlice) Reader() Reader {
 // Remaining(), which returns the number of unread bytes remaining in the slice.
 // Buffers will be freed as they are read.
 type Reader interface {
-	flate.Reader
+	io.Reader
+	io.ByteReader
 	// Close frees the underlying BufferSlice and never returns an error. Subsequent
 	// calls to Read will return (0, io.EOF).
 	Close() error


### PR DESCRIPTION
This interface has nothing to do with compression and there are no other references to that package in the codebase. If we remove the reference we same compiler and linker some work - no need to parse, compile, link that package just to use one interface from it (assuming no other references from the codebase).

RELEASE NOTES:
- mem: remove dependency on `compress/flate` package