### PR TITLE
clusterimpl: update picker synchronously on config update

### DIFF
--- a/xds/internal/balancer/clusterimpl/balancer_test.go
+++ b/xds/internal/balancer/clusterimpl/balancer_test.go
@@ -965,7 +965,7 @@ func (s) TestPickerUpdatedSynchronouslyOnConfigUpdate(t *testing.T) {
 	// change).
 	const childPolicyName = "stubBalancer-PickerUpdatedSynchronouslyOnConfigUpdate"
 	stub.Register(childPolicyName, stub.BalancerFuncs{
-		UpdateClientConnState: func(bd *stub.BalancerData, ccs balancer.ClientConnState) error {
+		UpdateClientConnState: func(bd *stub.BalancerData, _ balancer.ClientConnState) error {
 			bd.ClientConn.UpdateState(balancer.State{
 				Picker: base.NewErrPicker(errors.New("dummy error picker")),
 			})

--- a/xds/internal/balancer/clusterimpl/balancer_test.go
+++ b/xds/internal/balancer/clusterimpl/balancer_test.go
@@ -851,10 +851,10 @@ func (s) TestChildPolicyUpdatedOnConfigUpdate(t *testing.T) {
 	b := builder.Build(cc, balancer.BuildOptions{})
 	defer b.Close()
 
-	// Keep track of which child policy was updated
+	// Keep track of which child policy was updated.
 	updatedChildPolicy := ""
 
-	// Create stub balancers to track config updates
+	// Create stub balancers to track config updates.
 	const (
 		childPolicyName1 = "stubBalancer1"
 		childPolicyName2 = "stubBalancer2"
@@ -874,7 +874,7 @@ func (s) TestChildPolicyUpdatedOnConfigUpdate(t *testing.T) {
 		},
 	})
 
-	// Initial config update with childPolicyName1
+	// Initial config update with childPolicyName1.
 	if err := b.UpdateClientConnState(balancer.ClientConnState{
 		ResolverState: xdsclient.SetClient(resolver.State{Addresses: testBackendAddrs}, xdsC),
 		BalancerConfig: &LBConfig{
@@ -891,7 +891,7 @@ func (s) TestChildPolicyUpdatedOnConfigUpdate(t *testing.T) {
 		t.Fatal("Child policy 1 was not updated on initial configuration update.")
 	}
 
-	// Second config update with childPolicyName2
+	// Second config update with childPolicyName2.
 	if err := b.UpdateClientConnState(balancer.ClientConnState{
 		ResolverState: xdsclient.SetClient(resolver.State{Addresses: testBackendAddrs}, xdsC),
 		BalancerConfig: &LBConfig{

--- a/xds/internal/balancer/clusterimpl/balancer_test.go
+++ b/xds/internal/balancer/clusterimpl/balancer_test.go
@@ -861,14 +861,14 @@ func (s) TestChildPolicyUpdatedOnConfigUpdate(t *testing.T) {
 	)
 
 	stub.Register(childPolicyName1, stub.BalancerFuncs{
-		UpdateClientConnState: func(bd *stub.BalancerData, ccs balancer.ClientConnState) error {
+		UpdateClientConnState: func(_ *stub.BalancerData, _ balancer.ClientConnState) error {
 			updatedChildPolicy = childPolicyName1
 			return nil
 		},
 	})
 
 	stub.Register(childPolicyName2, stub.BalancerFuncs{
-		UpdateClientConnState: func(bd *stub.BalancerData, ccs balancer.ClientConnState) error {
+		UpdateClientConnState: func(_ *stub.BalancerData, _ balancer.ClientConnState) error {
 			updatedChildPolicy = childPolicyName2
 			return nil
 		},
@@ -923,7 +923,7 @@ func (s) TestFailedToParseChildPolicyConfig(t *testing.T) {
 	const parseConfigError = "failed to parse config"
 	const childPolicyName = "stubBalancer-FailedToParseChildPolicyConfig"
 	stub.Register(childPolicyName, stub.BalancerFuncs{
-		ParseConfig: func(lbCfg json.RawMessage) (serviceconfig.LoadBalancingConfig, error) {
+		ParseConfig: func(_ json.RawMessage) (serviceconfig.LoadBalancingConfig, error) {
 			return nil, errors.New(parseConfigError)
 		},
 	})


### PR DESCRIPTION
#5469 recommends an audit of existing LB policies to ensure that they update their pickers synchronously upon receipt of a configuration update. clusterimpl does not update picker synchronously before because of multiple reasons, one is on reciept of configuration update, process of switching the child policies was aysnchronous, and second is it was not waiting for the child policy config to be update first, before returning from `UpdateClientConnState`.

What does this PR do?
This PR ensures that every time configuration update is triggered, picker is updated synchronously.

RELEASE NOTES:

- clusterimpl: update picker synchronously on receipt of configuration update.