### PR TITLE
Deps: Bump Go version in Dockerfiles and test/kokoro/xds.sh

### DIFF
--- a/examples/features/csm_observability/client/Dockerfile
+++ b/examples/features/csm_observability/client/Dockerfile
@@ -15,7 +15,7 @@
 # Dockerfile for building the example client. To build the image, run the
 # following command from grpc-go directory:
 # docker build -t <TAG> -f examples/features/csm_observability/client/Dockerfile .
-FROM golang:1.21-alpine as build
+FROM golang:1.23-alpine as build
 
 RUN apk --no-cache add curl
 

--- a/examples/features/csm_observability/server/Dockerfile
+++ b/examples/features/csm_observability/server/Dockerfile
@@ -16,7 +16,7 @@
 # following command from grpc-go directory:
 # docker build -t <TAG> -f examples/features/csm_observability/server/Dockerfile .
 
-FROM golang:1.21-alpine as build
+FROM golang:1.23-alpine as build
 RUN apk --no-cache add curl
 # Make a grpc-go directory and copy the repo into it.
 WORKDIR /go/src/grpc-go

--- a/interop/observability/Dockerfile
+++ b/interop/observability/Dockerfile
@@ -17,7 +17,7 @@
 # Stage 1: Build the interop test client and server
 #
 
-FROM golang:1.21-bullseye as build
+FROM golang:1.23-bullseye as build
 
 WORKDIR /grpc-go
 COPY . .
@@ -36,7 +36,7 @@ RUN go build -o server/ server/server.go && \
 #   with the given parameters.
 #
 
-FROM golang:1.21-bullseye
+FROM golang:1.23-bullseye
 
 ENV GRPC_GO_LOG_SEVERITY_LEVEL info
 ENV GRPC_GO_LOG_VERBOSITY_LEVEL 2

--- a/interop/xds/client/Dockerfile
+++ b/interop/xds/client/Dockerfile
@@ -16,7 +16,7 @@
 # following command from grpc-go directory:
 # docker build -t <TAG> -f interop/xds/client/Dockerfile .
 
-FROM golang:1.21-alpine as build
+FROM golang:1.22-alpine as build
 
 # Make a grpc-go directory and copy the repo into it.
 WORKDIR /go/src/grpc-go

--- a/interop/xds/client/Dockerfile
+++ b/interop/xds/client/Dockerfile
@@ -16,7 +16,7 @@
 # following command from grpc-go directory:
 # docker build -t <TAG> -f interop/xds/client/Dockerfile .
 
-FROM golang:1.22-alpine as build
+FROM golang:1.23-alpine as build
 
 # Make a grpc-go directory and copy the repo into it.
 WORKDIR /go/src/grpc-go

--- a/interop/xds/server/Dockerfile
+++ b/interop/xds/server/Dockerfile
@@ -16,7 +16,7 @@
 # following command from grpc-go directory:
 # docker build -t <TAG> -f interop/xds/server/Dockerfile .
 
-FROM golang:1.21-alpine as build
+FROM golang:1.22-alpine as build
 
 # Make a grpc-go directory and copy the repo into it.
 WORKDIR /go/src/grpc-go

--- a/interop/xds/server/Dockerfile
+++ b/interop/xds/server/Dockerfile
@@ -16,7 +16,7 @@
 # following command from grpc-go directory:
 # docker build -t <TAG> -f interop/xds/server/Dockerfile .
 
-FROM golang:1.22-alpine as build
+FROM golang:1.23-alpine as build
 
 # Make a grpc-go directory and copy the repo into it.
 WORKDIR /go/src/grpc-go

--- a/test/kokoro/xds.sh
+++ b/test/kokoro/xds.sh
@@ -9,7 +9,7 @@ export GOPATH="${HOME}/gopath"
 pushd grpc-go/interop/xds/client
 # Install a version of Go supported by gRPC for the new features, e.g.
 # errors.Is()
-gofilename=go1.21.0.linux-amd64.tar.gz
+gofilename=go1.23.0.linux-amd64.tar.gz
 curl --retry 3 -O -L "https://go.dev/dl/${gofilename}"
 sudo tar -C /usr/local -xf "${gofilename}"
 sudo ln -s /usr/local/go/bin/go /usr/bin/go


### PR DESCRIPTION
Since the minimum supported Go version was bumped in https://github.com/grpc/grpc-go/pull/7624, the Docker build for the psm interop client and server has been failing with the following error:
```
#10 [build 4/4] RUN cd interop/xds/client && go build -tags osusergo,netgo .
#10 0.248 go: ../go.mod requires go >= 1.22.7 (running go 1.21.13; GOTOOLCHAIN=local)
#10 ERROR: process "/bin/sh -c cd interop/xds/client && go build -tags osusergo,netgo ." did not complete successfully: exit code: 1
------
 > [build 4/4] RUN cd interop/xds/client && go build -tags osusergo,netgo .:
0.248 go: ../go.mod requires go >= 1.22.7 (running go 1.21.13; GOTOOLCHAIN=local)
------
```

Verified that the docker build succeeds with the change in base image version to 1.22.
```sh
 docker build -f examples/features/csm_observability/client/Dockerfile . && \
 docker build -f examples/features/csm_observability/server/Dockerfile . && \
 docker build -f  interop/observability/Dockerfile . && \
 docker build -f  interop/xds/client/Dockerfile . && \
 docker build -f  interop/xds/server/Dockerfile . 
```
Verified that the download URL still works in `xds.sh`.
```sh
gofilename=go1.23.0.linux-amd64.tar.gz
curl --retry 3 -O -L "https://go.dev/dl/${gofilename}"
```

RELEASE NOTES: N/A