### PR TITLE
balancer: fix logic to prevent producer streams before READY is reported

### DIFF
--- a/balancer_wrapper.go
+++ b/balancer_wrapper.go
@@ -283,7 +283,6 @@ func (acbw *acBalancerWrapper) updateState(s connectivity.State, curAddr resolve
 			// ac.getTransport() from unblocking before the LB policy starts
 			// tracking the subchannel as READY.
 			close(acbw.ac.stateReadyChan)
-			acbw.ac.stateReadyChan = make(chan struct{})
 		}
 	})
 }


### PR DESCRIPTION
Fixes #7648 and #7507

The problem here was that the producer stream could attempt to start immediately after the channel went ready, but before ready was reported.  The fix is to simply wait on the `stateReadyChan` even if the state is `Ready` at the start, which will proceed immediately if it's already closed.  However, doing this requires some minor changes to managing the channel (only re-create when entering `Ready` and close when shutting down) and some test tweaks.

RELEASE NOTES: none