### PR TITLE
clusterimpl: update picker synchronously on config update

### DIFF
--- a/xds/internal/balancer/clusterimpl/balancer_test.go
+++ b/xds/internal/balancer/clusterimpl/balancer_test.go
@@ -980,10 +980,9 @@ func (s) TestPickerUpdatedSynchronouslyOnConfigUpdate(t *testing.T) {
 	defer b.Close()
 
 	// Create a stub balancer which waits for the cluster_impl policy to be
-	// closed before sending a picker update (upon receipt of a subConn state
-	// change).
-	const childPolicyName = "stubBalancer-PickerUpdatedSynchronouslyOnConfigUpdate"
-	stub.Register(childPolicyName, stub.BalancerFuncs{
+	// closed before sending a picker update (upon receipt of a resolver
+	// update).
+	stub.Register(t.Name(), stub.BalancerFuncs{
 		UpdateClientConnState: func(bd *stub.BalancerData, _ balancer.ClientConnState) error {
 			bd.ClientConn.UpdateState(balancer.State{
 				Picker: base.NewErrPicker(errors.New("dummy error picker")),
@@ -998,11 +997,11 @@ func (s) TestPickerUpdatedSynchronouslyOnConfigUpdate(t *testing.T) {
 			Cluster:        testClusterName,
 			EDSServiceName: testServiceName,
 			ChildPolicy: &internalserviceconfig.BalancerConfig{
-				Name: childPolicyName,
+				Name: t.Name(),
 			},
 		},
 	}); err != nil {
-		t.Fatalf("unexpected error from UpdateClientConnState: %v", err)
+		t.Fatalf("Unexpected error from UpdateClientConnState: %v", err)
 	}
 
 	select {

--- a/xds/internal/balancer/clusterimpl/balancer_test.go
+++ b/xds/internal/balancer/clusterimpl/balancer_test.go
@@ -943,6 +943,81 @@ func (s) TestFailedToParseChildPolicyConfig(t *testing.T) {
 	}
 }
 
+// TestPickerUpdatedSynchronouslyOnConfigUpdate covers the case picker is updated
+// synchronous on receipt of configuration update.
+func (s) TestPickerUpdatedSynchronouslyOnConfigUpdate(t *testing.T) {
+	// Override the newConfigHook to ensure picker was updated.
+	clientConnUpdateDone := make(chan struct{}, 1)
+	origClientConnUpdateHook := clientConnUpdateHook
+	clientConnUpdateHook = func() { clientConnUpdateDone <- struct{}{} }
+	defer func() { clientConnUpdateHook = origClientConnUpdateHook }()
+
+	defer xdsclient.ClearCounterForTesting(testClusterName, testServiceName)
+	xdsC := fakeclient.NewClient()
+
+	builder := balancer.Get(Name)
+	cc := testutils.NewBalancerClientConn(t)
+	b := builder.Build(cc, balancer.BuildOptions{})
+	defer b.Close()
+
+	// Create a stub balancer which waits for the cluster_impl policy to be
+	// closed before sending a picker update (upon receipt of a subConn state
+	// change).
+	const childPolicyName = "stubBalancer-PickerUpdatedSynchronouslyOnConfigUpdate"
+	stub.Register(childPolicyName, stub.BalancerFuncs{
+		UpdateClientConnState: func(bd *stub.BalancerData, _ balancer.ClientConnState) error {
+			bd.ClientConn.UpdateState(balancer.State{
+				Picker: base.NewErrPicker(errors.New("dummy error picker")),
+			})
+			return nil
+		},
+	})
+
+	const (
+		dropReason      = "test-dropping-category"
+		dropNumerator   = 1
+		dropDenominator = 2
+	)
+	testLRSServerConfig, err := bootstrap.ServerConfigForTesting(bootstrap.ServerConfigTestingOptions{
+		URI:          "trafficdirector.googleapis.com:443",
+		ChannelCreds: []bootstrap.ChannelCreds{{Type: "google_default"}},
+	})
+	if err != nil {
+		t.Fatalf("Failed to create LRS server config for testing: %v", err)
+	}
+	if err := b.UpdateClientConnState(balancer.ClientConnState{
+		ResolverState: xdsclient.SetClient(resolver.State{Addresses: testBackendAddrs}, xdsC),
+		BalancerConfig: &LBConfig{
+			Cluster:             testClusterName,
+			EDSServiceName:      testServiceName,
+			LoadReportingServer: testLRSServerConfig,
+			DropCategories: []DropConfig{{
+				Category:           dropReason,
+				RequestsPerMillion: million * dropNumerator / dropDenominator,
+			}},
+			ChildPolicy: &internalserviceconfig.BalancerConfig{
+				Name: childPolicyName,
+			},
+		},
+	}); err != nil {
+		t.Fatalf("unexpected error from UpdateClientConnState: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultShortTestTimeout)
+	defer cancel()
+	select {
+	case <-cc.NewPickerCh:
+	case <-ctx.Done():
+		t.Fatalf("Timed out waiting for the picker update on receipt of configuration update.")
+	}
+
+	select {
+	case <-clientConnUpdateDone:
+	case <-ctx.Done():
+		t.Fatal("Timed out waiting for client conn update to be completed.")
+	}
+}
+
 func assertString(f func() (string, error)) string {
 	s, err := f()
 	if err != nil {

--- a/xds/internal/balancer/clusterimpl/balancer_test.go
+++ b/xds/internal/balancer/clusterimpl/balancer_test.go
@@ -946,13 +946,13 @@ func (s) TestFailedToParseChildPolicyConfig(t *testing.T) {
 // Test verify that the case picker is updated synchronously on receipt of
 // configuration update.
 func (s) TestPickerUpdatedSynchronouslyOnConfigUpdate(t *testing.T) {
-	// Override the newPickerUpdated to be notified that picker was updated.
+	// Override the pickerUpdateHook to be notified that picker was updated.
 	pickerUpdated := make(chan struct{}, 1)
-	origNewPickerUpdated := newPickerUpdated
-	newPickerUpdated = func() {
+	origNewPickerUpdated := pickerUpdateHook
+	pickerUpdateHook = func() {
 		pickerUpdated <- struct{}{}
 	}
-	defer func() { newPickerUpdated = origNewPickerUpdated }()
+	defer func() { pickerUpdateHook = origNewPickerUpdated }()
 
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()

--- a/xds/internal/balancer/clusterimpl/balancer_test.go
+++ b/xds/internal/balancer/clusterimpl/balancer_test.go
@@ -943,8 +943,8 @@ func (s) TestFailedToParseChildPolicyConfig(t *testing.T) {
 	}
 }
 
-// TestPickerUpdatedSynchronouslyOnConfigUpdate covers the case picker is updated
-// synchronous on receipt of configuration update.
+// Test verify that the case picker is updated synchronously on receipt of
+// configuration update.
 func (s) TestPickerUpdatedSynchronouslyOnConfigUpdate(t *testing.T) {
 	// Override the newConfigHook to ensure picker was updated.
 	clientConnUpdateDone := make(chan struct{}, 1)

--- a/xds/internal/balancer/clusterimpl/clusterimpl.go
+++ b/xds/internal/balancer/clusterimpl/clusterimpl.go
@@ -56,6 +56,9 @@ const (
 var (
 	connectedAddress  = internal.ConnectedAddress.(func(balancer.SubConnState) resolver.Address)
 	errBalancerClosed = fmt.Errorf("%s LB policy is closed", Name)
+	// Below function is no-op in actual code, but can be overridden in
+	// tests to give tests visibility into exactly when certain events happen.
+	clientConnUpdateHook = func() {}
 )
 
 func init() {
@@ -101,6 +104,12 @@ type clusterImplBalancer struct {
 	edsServiceName   string
 	lrsServer        *bootstrap.ServerConfig
 	loadWrapper      *loadstore.Wrapper
+
+	// Set during UpdateClientConnState when pushing updates to child policies.
+	// Prevents state updates from child policies causing new pickers to be sent
+	// up the channel. Cleared after all child policies have processed the
+	// updates sent to them, after which a new picker is sent up the channel.
+	inhibitPickerUpdates bool
 
 	clusterNameMu sync.Mutex
 	clusterName   string
@@ -199,6 +208,8 @@ func (b *clusterImplBalancer) updateLoadStore(newConfig *LBConfig) error {
 }
 
 func (b *clusterImplBalancer) updateClientConnState(s balancer.ClientConnState) error {
+	defer clientConnUpdateHook()
+
 	if b.logger.V(2) {
 		b.logger.Infof("Received configuration: %s", pretty.ToJSON(s.BalancerConfig))
 	}
@@ -242,6 +253,9 @@ func (b *clusterImplBalancer) updateClientConnState(s balancer.ClientConnState) 
 	}
 
 	b.config = newConfig
+
+	b.inhibitPickerUpdates = true
+	defer func() { b.inhibitPickerUpdates = false }()
 
 	b.telemetryLabels = newConfig.TelemetryLabels
 	dc := b.handleDropAndRequestCount(newConfig)
@@ -327,14 +341,16 @@ func (b *clusterImplBalancer) ExitIdle() {
 func (b *clusterImplBalancer) UpdateState(state balancer.State) {
 	b.serializer.TrySchedule(func(context.Context) {
 		b.childState = state
-		b.ClientConn.UpdateState(balancer.State{
-			ConnectivityState: b.childState.ConnectivityState,
-			Picker: b.newPicker(&dropConfigs{
-				drops:           b.drops,
-				requestCounter:  b.requestCounter,
-				requestCountMax: b.requestCountMax,
-			}),
-		})
+		if !b.inhibitPickerUpdates {
+			b.ClientConn.UpdateState(balancer.State{
+				ConnectivityState: b.childState.ConnectivityState,
+				Picker: b.newPicker(&dropConfigs{
+					drops:           b.drops,
+					requestCounter:  b.requestCounter,
+					requestCountMax: b.requestCountMax,
+				}),
+			})
+		}
 	})
 }
 

--- a/xds/internal/balancer/clusterimpl/clusterimpl.go
+++ b/xds/internal/balancer/clusterimpl/clusterimpl.go
@@ -56,7 +56,7 @@ var (
 	// Below function is no-op in actual code, but can be overridden in
 	// tests to give tests visibility into exactly when certain events happen.
 	clientConnUpdateHook = func() {}
-	newPickerUpdated     = func() {}
+	pickerUpdateHook     = func() {}
 )
 
 func init() {
@@ -301,7 +301,7 @@ func (b *clusterImplBalancer) UpdateClientConnState(s balancer.ClientConnState) 
 	}
 	b.inhibitPickerUpdates = false
 	b.mu.Unlock()
-	newPickerUpdated()
+	pickerUpdateHook()
 	return err
 }
 
@@ -363,6 +363,7 @@ func (b *clusterImplBalancer) UpdateState(state balancer.State) {
 		ConnectivityState: state.ConnectivityState,
 		Picker:            b.newPickerLocked(),
 	})
+	pickerUpdateHook()
 }
 
 func (b *clusterImplBalancer) setClusterName(n string) {

--- a/xds/internal/balancer/clusterimpl/picker.go
+++ b/xds/internal/balancer/clusterimpl/picker.go
@@ -88,6 +88,11 @@ type picker struct {
 }
 
 func (b *clusterImplBalancer) newPicker(config *dropConfigs) *picker {
+	b.childStateMu.Lock()
+	defer b.childStateMu.Unlock()
+	b.configMu.Lock()
+	defer b.configMu.Unlock()
+
 	return &picker{
 		drops:           config.drops,
 		s:               b.childState,

--- a/xds/internal/balancer/clusterimpl/picker.go
+++ b/xds/internal/balancer/clusterimpl/picker.go
@@ -87,22 +87,6 @@ type picker struct {
 	telemetryLabels map[string]string
 }
 
-func (b *clusterImplBalancer) newPicker(config *dropConfigs) *picker {
-	b.childStateMu.Lock()
-	defer b.childStateMu.Unlock()
-	b.configMu.Lock()
-	defer b.configMu.Unlock()
-
-	return &picker{
-		drops:           config.drops,
-		s:               b.childState,
-		loadStore:       b.loadWrapper,
-		counter:         config.requestCounter,
-		countMax:        config.requestCountMax,
-		telemetryLabels: b.telemetryLabels,
-	}
-}
-
 func telemetryLabels(ctx context.Context) map[string]string {
 	if ctx == nil {
 		return nil


### PR DESCRIPTION
#5469 recommends an audit of existing LB policies to ensure that they update their pickers synchronously upon receipt of a configuration update. clusterimpl does not update picker synchronously before because of multiple reasons, one is on reciept of configuration update, process of switching the child policies was aysnchronous, and second is it was not waiting for the child policy config to be update first, before returning from `UpdateClientConnState`.

What does this PR do?
This PR ensures that every time configuration update is triggered, picker is updated synchronously.

RELEASE NOTES:

- clusterimpl: update picker synchronously on receipt of configuration update.