### PR TITLE
mem: implement `ReadAll()` for more efficient `io.Reader` consumption

### DIFF
--- a/mem/buffer_slice.go
+++ b/mem/buffer_slice.go
@@ -234,8 +234,10 @@ func NewWriter(buffers *BufferSlice, pool BufferPool) io.Writer {
 // A successful call returns err == nil, not err == EOF. Because ReadAll is
 // defined to read from src until EOF, it does not treat an EOF from Read
 // as an error to be reported.
-// A failed call returns a non-nil error and could return partially read
-// buffers. It is the responsibility of the caller to free this buffer.
+//
+// Important: A failed call returns a non-nil error and may also return
+// partially read buffers. It is the responsibility of the caller to free the
+// BufferSlice returned, or its memory will not be reused.
 func ReadAll(r io.Reader, pool BufferPool) (BufferSlice, error) {
 	var result BufferSlice
 	if wt, ok := r.(io.WriterTo); ok {

--- a/mem/buffer_slice.go
+++ b/mem/buffer_slice.go
@@ -234,8 +234,8 @@ func NewWriter(buffers *BufferSlice, pool BufferPool) io.Writer {
 // A successful call returns err == nil, not err == EOF. Because ReadAll is
 // defined to read from src until EOF, it does not treat an EOF from Read
 // as an error to be reported.
-// A failed call returns a non-nil error and could return partially read buffers.
-// It is the responsibility of the caller to free this buffer.
+// A failed call returns a non-nil error and could return partially read
+// buffers. It is the responsibility of the caller to free this buffer.
 func ReadAll(r io.Reader, pool BufferPool) (BufferSlice, error) {
 	var result BufferSlice
 	wt, ok := r.(io.WriterTo)

--- a/mem/buffer_slice.go
+++ b/mem/buffer_slice.go
@@ -22,6 +22,10 @@ import (
 	"io"
 )
 
+const (
+	readAllBufSize = 32 * 1024 // 32 KiB
+)
+
 // BufferSlice offers a means to represent data that spans one or more Buffer
 // instances. A BufferSlice is meant to be immutable after creation, and methods
 // like Ref create and return copies of the slice. This is why all methods have
@@ -223,4 +227,48 @@ func (w *writer) Write(p []byte) (n int, err error) {
 // the given BufferSlice.
 func NewWriter(buffers *BufferSlice, pool BufferPool) io.Writer {
 	return &writer{buffers: buffers, pool: pool}
+}
+
+// ReadAll reads from r until an error or EOF and returns the data it read.
+// A successful call returns err == nil, not err == EOF. Because ReadAll is
+// defined to read from src until EOF, it does not treat an EOF from Read
+// as an error to be reported.
+// Make sure to free the returned buffers even if you get an error from this function.
+func ReadAll(r io.Reader, pool BufferPool) (BufferSlice, error) {
+	var result BufferSlice
+	wt, ok := r.(io.WriterTo)
+	if ok {
+		// This is more optimal since wt knows the size of chunks it wants to write and, hence, we can allocate
+		// buffers of an optimal size to fit them. E.g. might be a single big chunk, and we wouldn't chop it into pieces.
+		w := NewWriter(&result, pool)
+		_, err := wt.WriteTo(w)
+		return result, err
+	}
+	for {
+		buf := pool.Get(readAllBufSize)
+		// We asked for 32KiB but may have been given a bigger buffer. Use all of it if that's the case.
+		*buf = (*buf)[:cap(*buf)]
+		usedCap := 0
+		for {
+			n, err := r.Read((*buf)[usedCap:])
+			usedCap += n
+			if err != nil {
+				if usedCap == 0 {
+					// Nothing in this buf, put it back
+					pool.Put(buf)
+				} else {
+					*buf = (*buf)[:usedCap]
+					result = append(result, NewBuffer(buf, pool))
+				}
+				if err == io.EOF {
+					err = nil
+				}
+				return result, err
+			}
+			if len(*buf) == usedCap {
+				result = append(result, NewBuffer(buf, pool))
+				break // grab a new buf from pool
+			}
+		}
+	}
 }

--- a/mem/buffer_slice_test.go
+++ b/mem/buffer_slice_test.go
@@ -30,9 +30,7 @@ import (
 )
 
 const (
-	// 1025 is a value above 1024 that is not mem.IsBelowBufferPoolingThreshold().
-	// See https://github.com/grpc/grpc-go/issues/7631.
-	minReadSize = 1025
+	minReadSize = 1
 	// Should match the constant in buffer_slice.go (another package)
 	readAllBufSize = 32 * 1024 // 32 KiB
 )

--- a/mem/buffer_slice_test.go
+++ b/mem/buffer_slice_test.go
@@ -164,7 +164,8 @@ func (s) TestBufferSlice_Reader(t *testing.T) {
 	}
 }
 
-// TestBufferSlice_ReadAll_Reads exercises ReadAll by allowing it to read various combinations of data, empty data, EOF.
+// TestBufferSlice_ReadAll_Reads exercises ReadAll by allowing it to read
+// various combinations of data, empty data, EOF.
 func (s) TestBufferSlice_ReadAll_Reads(t *testing.T) {
 	testcases := []struct {
 		name     string
@@ -349,7 +350,8 @@ func (s) TestBufferSlice_ReadAll_Reads(t *testing.T) {
 			if len(data) != tc.wantBufs {
 				t.Fatalf("ReadAll() returned %d bufs, wanted %d bufs", len(data), tc.wantBufs)
 			}
-			for i := 0; i < len(data)-1; i++ { // all but last should be full buffers
+			// all but last should be full buffers
+			for i := 0; i < len(data)-1; i++ {
 				if data[i].Len() != readAllBufSize {
 					t.Fatalf("ReadAll() returned data length %d, wanted %d", data[i].Len(), readAllBufSize)
 				}
@@ -434,7 +436,8 @@ var (
 	_ mem.BufferPool = (*testPool)(nil)
 )
 
-// readStep describes what a single stepReader.Read should do - how much data to return and what error to return.
+// readStep describes what a single stepReader.Read should do - how much data
+// to return and what error to return.
 type readStep struct {
 	n   int
 	err error

--- a/rpc_util.go
+++ b/rpc_util.go
@@ -899,8 +899,7 @@ func decompress(compressor encoding.Compressor, d mem.BufferSlice, maxReceiveMes
 	//	}
 	//}
 
-	var out mem.BufferSlice
-	_, err = io.Copy(mem.NewWriter(&out, pool), io.LimitReader(dcReader, int64(maxReceiveMessageSize)+1))
+	out, err := mem.ReadAll(io.LimitReader(dcReader, int64(maxReceiveMessageSize)+1), pool)
 	if err != nil {
 		out.Free()
 		return nil, 0, err


### PR DESCRIPTION
I moved my project to gRPC 1.66.2 and saw a good reduction in RAM consumption. Now the hot spot is `decompress()`, where `io.Copy()` allocates a temporary buffer, reads from the reader into it, copies the read data into another buffer it got from the pool. This is an unnecessary allocation, an unnecessary copy, and underutilized buffers from the pool.

This PR adds `mem.ReadAll()` (like `io.ReadAll()`) to efficiently consume a reader into buffers from the pool.

<img width="331" alt="Screenshot 2024-09-19 at 8 11 15 AM" src="https://github.com/user-attachments/assets/a38c0ba7-a3b4-4f89-90a6-b0ec367fddae">

I found https://github.com/grpc/grpc-go/issues/7631 while working on this code (I have similar code in my project, but decided to contribute it upstream and replace this `io.Copy` with it).

RELEASE NOTES:
- mem: implement a `ReadAll()` method for more efficient `io.Reader` consumption