### PR TITLE
protoc-gen-go-grpc: remove `use_generic_streams_experimental` flag (defaults to true)

### DIFF
--- a/cmd/protoc-gen-go-grpc/grpc.go
+++ b/cmd/protoc-gen-go-grpc/grpc.go
@@ -489,7 +489,6 @@ func genServerMethod(_ *protogen.Plugin, _ *protogen.File, g *protogen.Generated
 		g.P("return srv.(", service.GoName, "Server).", method.GoName, "(&", streamImpl, "{ServerStream: stream})")
 	}
 	g.P("}")
-
 	g.P()
 
 	// Auxiliary types aliases, for backwards compatibility.

--- a/cmd/protoc-gen-go-grpc/grpc.go
+++ b/cmd/protoc-gen-go-grpc/grpc.go
@@ -178,13 +178,9 @@ func generateFileContent(gen *protogen.Plugin, file *protogen.File, g *protogen.
 
 	g.P("// This is a compile-time assertion to ensure that this generated file")
 	g.P("// is compatible with the grpc package it is being compiled against.")
-	if *useGenericStreams {
-		g.P("// Requires gRPC-Go v1.64.0 or later.")
-		g.P("const _ = ", grpcPackage.Ident("SupportPackageIsVersion9"))
-	} else {
-		g.P("// Requires gRPC-Go v1.62.0 or later.")
-		g.P("const _ = ", grpcPackage.Ident("SupportPackageIsVersion8")) // When changing, update version number above.
-	}
+	g.P("// Requires gRPC-Go v1.64.0 or later.")
+	g.P("const _ = ", grpcPackage.Ident("SupportPackageIsVersion9"))
+
 	g.P()
 	for _, service := range file.Services {
 		genService(gen, file, g, service)
@@ -333,11 +329,9 @@ func clientSignature(g *protogen.GeneratedFile, method *protogen.Method) string 
 	if !method.Desc.IsStreamingClient() && !method.Desc.IsStreamingServer() {
 		s += "*" + g.QualifiedGoIdent(method.Output.GoIdent)
 	} else {
-		if *useGenericStreams {
-			s += clientStreamInterface(g, method)
-		} else {
-			s += method.Parent.GoName + "_" + method.GoName + "Client"
-		}
+
+		s += clientStreamInterface(g, method)
+
 	}
 	s += ", error)"
 	return s
@@ -373,11 +367,8 @@ func genClientMethod(_ *protogen.Plugin, _ *protogen.File, g *protogen.Generated
 		return
 	}
 
-	streamImpl := unexport(service.GoName) + method.GoName + "Client"
-	if *useGenericStreams {
-		typeParam := g.QualifiedGoIdent(method.Input.GoIdent) + ", " + g.QualifiedGoIdent(method.Output.GoIdent)
-		streamImpl = g.QualifiedGoIdent(grpcPackage.Ident("GenericClientStream")) + "[" + typeParam + "]"
-	}
+	typeParam := g.QualifiedGoIdent(method.Input.GoIdent) + ", " + g.QualifiedGoIdent(method.Output.GoIdent)
+	streamImpl := g.QualifiedGoIdent(grpcPackage.Ident("GenericClientStream")) + "[" + typeParam + "]"
 
 	serviceDescVar := service.GoName + "_ServiceDesc"
 	g.P("stream, err := c.cc.NewStream(ctx, &", serviceDescVar, ".Streams[", index, `], `, fmSymbol, `, cOpts...)`)
@@ -392,61 +383,9 @@ func genClientMethod(_ *protogen.Plugin, _ *protogen.File, g *protogen.Generated
 	g.P()
 
 	// Auxiliary types aliases, for backwards compatibility.
-	if *useGenericStreams {
-		g.P("// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.")
-		g.P("type ", service.GoName, "_", method.GoName, "Client = ", clientStreamInterface(g, method))
-		g.P()
-		return
-	}
-
-	// Stream auxiliary types and methods, if we're not taking advantage of the
-	// pre-implemented generic types and their methods.
-	genSend := method.Desc.IsStreamingClient()
-	genRecv := method.Desc.IsStreamingServer()
-	genCloseAndRecv := !method.Desc.IsStreamingServer()
-
-	g.P("type ", service.GoName, "_", method.GoName, "Client interface {")
-	if genSend {
-		g.P("Send(*", method.Input.GoIdent, ") error")
-	}
-	if genRecv {
-		g.P("Recv() (*", method.Output.GoIdent, ", error)")
-	}
-	if genCloseAndRecv {
-		g.P("CloseAndRecv() (*", method.Output.GoIdent, ", error)")
-	}
-	g.P(grpcPackage.Ident("ClientStream"))
-	g.P("}")
+	g.P("// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.")
+	g.P("type ", service.GoName, "_", method.GoName, "Client = ", clientStreamInterface(g, method))
 	g.P()
-
-	g.P("type ", streamImpl, " struct {")
-	g.P(grpcPackage.Ident("ClientStream"))
-	g.P("}")
-	g.P()
-
-	if genSend {
-		g.P("func (x *", streamImpl, ") Send(m *", method.Input.GoIdent, ") error {")
-		g.P("return x.ClientStream.SendMsg(m)")
-		g.P("}")
-		g.P()
-	}
-	if genRecv {
-		g.P("func (x *", streamImpl, ") Recv() (*", method.Output.GoIdent, ", error) {")
-		g.P("m := new(", method.Output.GoIdent, ")")
-		g.P("if err := x.ClientStream.RecvMsg(m); err != nil { return nil, err }")
-		g.P("return m, nil")
-		g.P("}")
-		g.P()
-	}
-	if genCloseAndRecv {
-		g.P("func (x *", streamImpl, ") CloseAndRecv() (*", method.Output.GoIdent, ", error) {")
-		g.P("if err := x.ClientStream.CloseSend(); err != nil { return nil, err }")
-		g.P("m := new(", method.Output.GoIdent, ")")
-		g.P("if err := x.ClientStream.RecvMsg(m); err != nil { return nil, err }")
-		g.P("return m, nil")
-		g.P("}")
-		g.P()
-	}
 }
 
 func serverSignature(g *protogen.GeneratedFile, method *protogen.Method) string {
@@ -460,11 +399,8 @@ func serverSignature(g *protogen.GeneratedFile, method *protogen.Method) string 
 		reqArgs = append(reqArgs, "*"+g.QualifiedGoIdent(method.Input.GoIdent))
 	}
 	if method.Desc.IsStreamingClient() || method.Desc.IsStreamingServer() {
-		if *useGenericStreams {
-			reqArgs = append(reqArgs, serverStreamInterface(g, method))
-		} else {
-			reqArgs = append(reqArgs, method.Parent.GoName+"_"+method.GoName+"Server")
-		}
+		reqArgs = append(reqArgs, serverStreamInterface(g, method))
+
 	}
 	return method.GoName + "(" + strings.Join(reqArgs, ", ") + ") " + ret
 }
@@ -545,11 +481,8 @@ func genServerMethod(_ *protogen.Plugin, _ *protogen.File, g *protogen.Generated
 		return hname
 	}
 
-	streamImpl := unexport(service.GoName) + method.GoName + "Server"
-	if *useGenericStreams {
-		typeParam := g.QualifiedGoIdent(method.Input.GoIdent) + ", " + g.QualifiedGoIdent(method.Output.GoIdent)
-		streamImpl = g.QualifiedGoIdent(grpcPackage.Ident("GenericServerStream")) + "[" + typeParam + "]"
-	}
+	typeParam := g.QualifiedGoIdent(method.Input.GoIdent) + ", " + g.QualifiedGoIdent(method.Output.GoIdent)
+	streamImpl := g.QualifiedGoIdent(grpcPackage.Ident("GenericServerStream")) + "[" + typeParam + "]"
 
 	g.P("func ", hnameFuncNameFormatter(hname), "(srv interface{}, stream ", grpcPackage.Ident("ServerStream"), ") error {")
 	if !method.Desc.IsStreamingClient() {
@@ -563,59 +496,9 @@ func genServerMethod(_ *protogen.Plugin, _ *protogen.File, g *protogen.Generated
 	g.P()
 
 	// Auxiliary types aliases, for backwards compatibility.
-	if *useGenericStreams {
-		g.P("// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.")
-		g.P("type ", service.GoName, "_", method.GoName, "Server = ", serverStreamInterface(g, method))
-		g.P()
-		return hname
-	}
-
-	// Stream auxiliary types and methods, if we're not taking advantage of the
-	// pre-implemented generic types and their methods.
-	genSend := method.Desc.IsStreamingServer()
-	genSendAndClose := !method.Desc.IsStreamingServer()
-	genRecv := method.Desc.IsStreamingClient()
-
-	g.P("type ", service.GoName, "_", method.GoName, "Server interface {")
-	if genSend {
-		g.P("Send(*", method.Output.GoIdent, ") error")
-	}
-	if genSendAndClose {
-		g.P("SendAndClose(*", method.Output.GoIdent, ") error")
-	}
-	if genRecv {
-		g.P("Recv() (*", method.Input.GoIdent, ", error)")
-	}
-	g.P(grpcPackage.Ident("ServerStream"))
-	g.P("}")
+	g.P("// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.")
+	g.P("type ", service.GoName, "_", method.GoName, "Server = ", serverStreamInterface(g, method))
 	g.P()
-
-	g.P("type ", streamImpl, " struct {")
-	g.P(grpcPackage.Ident("ServerStream"))
-	g.P("}")
-	g.P()
-
-	if genSend {
-		g.P("func (x *", streamImpl, ") Send(m *", method.Output.GoIdent, ") error {")
-		g.P("return x.ServerStream.SendMsg(m)")
-		g.P("}")
-		g.P()
-	}
-	if genSendAndClose {
-		g.P("func (x *", streamImpl, ") SendAndClose(m *", method.Output.GoIdent, ") error {")
-		g.P("return x.ServerStream.SendMsg(m)")
-		g.P("}")
-		g.P()
-	}
-	if genRecv {
-		g.P("func (x *", streamImpl, ") Recv() (*", method.Input.GoIdent, ", error) {")
-		g.P("m := new(", method.Input.GoIdent, ")")
-		g.P("if err := x.ServerStream.RecvMsg(m); err != nil { return nil, err }")
-		g.P("return m, nil")
-		g.P("}")
-		g.P()
-	}
-
 	return hname
 }
 

--- a/cmd/protoc-gen-go-grpc/grpc.go
+++ b/cmd/protoc-gen-go-grpc/grpc.go
@@ -489,6 +489,7 @@ func genServerMethod(_ *protogen.Plugin, _ *protogen.File, g *protogen.Generated
 		g.P("return srv.(", service.GoName, "Server).", method.GoName, "(&", streamImpl, "{ServerStream: stream})")
 	}
 	g.P("}")
+
 	g.P()
 
 	// Auxiliary types aliases, for backwards compatibility.

--- a/cmd/protoc-gen-go-grpc/grpc.go
+++ b/cmd/protoc-gen-go-grpc/grpc.go
@@ -180,7 +180,6 @@ func generateFileContent(gen *protogen.Plugin, file *protogen.File, g *protogen.
 	g.P("// is compatible with the grpc package it is being compiled against.")
 	g.P("// Requires gRPC-Go v1.64.0 or later.")
 	g.P("const _ = ", grpcPackage.Ident("SupportPackageIsVersion9"))
-
 	g.P()
 	for _, service := range file.Services {
 		genService(gen, file, g, service)
@@ -329,9 +328,7 @@ func clientSignature(g *protogen.GeneratedFile, method *protogen.Method) string 
 	if !method.Desc.IsStreamingClient() && !method.Desc.IsStreamingServer() {
 		s += "*" + g.QualifiedGoIdent(method.Output.GoIdent)
 	} else {
-
 		s += clientStreamInterface(g, method)
-
 	}
 	s += ", error)"
 	return s
@@ -400,7 +397,6 @@ func serverSignature(g *protogen.GeneratedFile, method *protogen.Method) string 
 	}
 	if method.Desc.IsStreamingClient() || method.Desc.IsStreamingServer() {
 		reqArgs = append(reqArgs, serverStreamInterface(g, method))
-
 	}
 	return method.GoName + "(" + strings.Join(reqArgs, ", ") + ") " + ret
 }

--- a/cmd/protoc-gen-go-grpc/main.go
+++ b/cmd/protoc-gen-go-grpc/main.go
@@ -45,7 +45,6 @@ import (
 const version = "1.5.1"
 
 var requireUnimplemented *bool
-var useGenericStreams *bool
 
 func main() {
 	showVersion := flag.Bool("version", false, "print the version and exit")
@@ -57,7 +56,6 @@ func main() {
 
 	var flags flag.FlagSet
 	requireUnimplemented = flags.Bool("require_unimplemented_servers", true, "set to false to match legacy behavior")
-	useGenericStreams = flags.Bool("use_generic_streams_experimental", true, "set to true to use generic types for streaming client and server objects; this flag is EXPERIMENTAL and may be changed or removed in a future release")
 
 	protogen.Options{
 		ParamFunc: flags.Set,

--- a/cmd/protoc-gen-go-grpc/protoc-gen-go-grpc_test.sh
+++ b/cmd/protoc-gen-go-grpc/protoc-gen-go-grpc_test.sh
@@ -30,7 +30,7 @@ popd
 
 protoc \
     --go-grpc_out="${TEMPDIR}" \
-    --go-grpc_opt=paths=source_relative, \
+    --go-grpc_opt=paths=source_relative \
     "examples/route_guide/routeguide/route_guide.proto"
 
 GOLDENFILE="examples/route_guide/routeguide/route_guide_grpc.pb.go"

--- a/cmd/protoc-gen-go-grpc/protoc-gen-go-grpc_test.sh
+++ b/cmd/protoc-gen-go-grpc/protoc-gen-go-grpc_test.sh
@@ -30,7 +30,7 @@ popd
 
 protoc \
     --go-grpc_out="${TEMPDIR}" \
-    --go-grpc_opt=paths=source_relative,use_generic_streams_experimental=true \
+    --go-grpc_opt=paths=source_relative, \
     "examples/route_guide/routeguide/route_guide.proto"
 
 GOLDENFILE="examples/route_guide/routeguide/route_guide_grpc.pb.go"


### PR DESCRIPTION
Fixes task 2 : #1894 - Delete the code to generate stream interfaces for client and server.

Deletes the unused code to make stream generics default.

RELEASE NOTES: None