### PR TITLE
transport: Fix reporting of bytes read while reading headers

### DIFF
--- a/internal/transport/transport.go
+++ b/internal/transport/transport.go
@@ -625,7 +625,7 @@ func (t *transportReader) ReadHeader(header []byte) (int, error) {
 		t.er = err
 		return 0, err
 	}
-	t.windowHandler(len(header))
+	t.windowHandler(n)
 	return n, nil
 }
 


### PR DESCRIPTION
Fixes: https://github.com/grpc/grpc-go/issues/7641

## Background
The headers are being read incrementally here:
https://github.com/grpc/grpc-go/blob/8ea3460acace12cd1f2f0502784d42c21eeadf42/internal/transport/transport.go#L559-L579

We keep filling the underlying `header` slice until its full, but we do so by moving the start of the slice forward. In the following function that is called by the function above to perform reads and update the flow control window, we do `t.windowHandler(len(header))`.
https://github.com/grpc/grpc-go/blob/8ea3460acace12cd1f2f0502784d42c21eeadf42/internal/transport/transport.go#L622-L630

The code has read `n` bytes, but it says it read `len(header)` bytes. `len(header)` is the total number of bytes that remain to be read, which is not always equal the the bytes there were read. I was able to get [the repro test ](https://github.com/grpc/grpc-go/pull/7642) to pass after changing the line to `t.windowHandler(n)`.

RELEASE NOTES:
* transport: Fix bug causing stream failures due incorrect calculation of the flow control window in both clients and servers.