### PR TITLE
transport: prevent deadlock in transport Close when GoAway write hangs

### DIFF
--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -1009,19 +1009,10 @@ func (t *http2Client) Close(err error) {
 		// should unblock it so that the goroutine eventually exits.
 		t.kpDormancyCond.Signal()
 	}
-	t.mu.Unlock()
-
 	// Append info about previous goaways if there were any, since this may be important
 	// for understanding the root cause for this connection to be closed.
 	goAwayDebugMessage := t.goAwayDebugMessage
-
-	var st *status.Status
-	if len(goAwayDebugMessage) > 0 {
-		st = status.Newf(codes.Unavailable, "closing transport due to: %v, received prior goaway: %v", err, goAwayDebugMessage)
-		err = st.Err()
-	} else {
-		st = status.New(codes.Unavailable, err.Error())
-	}
+	t.mu.Unlock()
 
 	// Per HTTP/2 spec, a GOAWAY frame must be sent before closing the
 	// connection. See https://httpwg.org/specs/rfc7540.html#GOAWAY. It
@@ -1039,6 +1030,13 @@ func (t *http2Client) Close(err error) {
 	t.cancel()
 	t.conn.Close()
 	channelz.RemoveEntry(t.channelz.ID)
+	var st *status.Status
+	if len(goAwayDebugMessage) > 0 {
+		st = status.Newf(codes.Unavailable, "closing transport due to: %v, received prior goaway: %v", err, goAwayDebugMessage)
+		err = st.Err()
+	} else {
+		st = status.New(codes.Unavailable, err.Error())
+	}
 
 	// Notify all active streams.
 	for _, s := range streams {


### PR DESCRIPTION
Fixes #7606.

Couple of recent changes worth noting here:
- https://github.com/grpc/grpc-go/pull/7015 added logic to send a GOAWAY frame on client transport shutdown. Unfortunately the handler responsible for writing the GOAWAY frame was holding on to the client transport mutex when attempting to write the GOAWAY frame.
- https://github.com/grpc/grpc-go/pull/7371  introduced a timeout in the client transport shutdown handler to wait for `loopyWriter` to exit (after enqueueing the above GOAWAY frame on the `controlbuf`). This was done to ensure that the client transport shutdown can complete in the face of a hanging network connection that blocks forever when attempting to write the above GOAWAY frame

Description of the deadlock:
- During client transport shutdown, after enqueueing the GOAWAY frame on the `controlbuf`, `http2Client.Close` calls `http2Client.GetGoAwayReason` to fetch the last GOAWAY's debug message, and the latter attempts to grab `http2Client.mu`.
- `http2Client.outgoingGoAwayHandler` holds `http2Client.mu` when it is attempting to write the GOAWAY frame. So, if the underlying network connection is hanging, this method will not release the mutex, and therefore `http2Client.GetGoAwayReason` will not be able to grab the same mutex, and thereby `http2Client.Close` will deadlock.

RELEASE NOTES: 
- transport: prevent deadlock in client transport shutdown when writing the GOAWAY frame hangs.