### PR TITLE
Transport: Prevent DNS lookup if host not provided

### DIFF
--- a/internal/resolver/dns/dns_resolver.go
+++ b/internal/resolver/dns/dns_resolver.go
@@ -372,7 +372,7 @@ func formatIP(addr string) (addrIP string, ok bool) {
 // target: "www.google.com" defaultPort: "443" returns host: "www.google.com", port: "443"
 // target: "ipv4-host:80" defaultPort: "443" returns host: "ipv4-host", port: "80"
 // target: "[ipv6-host]" defaultPort: "443" returns host: "ipv6-host", port: "443"
-// target: ":80" defaultPort: "443" returns host: "localhost", port: "80"
+// target: ":80" defaultPort: "443" returns host: "127.0.0.1", port: "80"
 func parseTarget(target, defaultPort string) (host, port string, err error) {
 	if target == "" {
 		return "", "", internal.ErrMissingAddr
@@ -391,7 +391,7 @@ func parseTarget(target, defaultPort string) (host, port string, err error) {
 		if host == "" {
 			// Keep consistent with net.Dial(): If the host is empty, as in ":80",
 			// the local system is assumed.
-			host = "localhost"
+			host = "127.0.0.1"
 		}
 		return host, port, nil
 	}

--- a/internal/resolver/dns/dns_resolver.go
+++ b/internal/resolver/dns/dns_resolver.go
@@ -372,7 +372,7 @@ func formatIP(addr string) (addrIP string, ok bool) {
 // target: "www.google.com" defaultPort: "443" returns host: "www.google.com", port: "443"
 // target: "ipv4-host:80" defaultPort: "443" returns host: "ipv4-host", port: "80"
 // target: "[ipv6-host]" defaultPort: "443" returns host: "ipv6-host", port: "443"
-// target: ":80" defaultPort: "443" returns host: "127.0.0.1", port: "80"
+// target: ":80" defaultPort: "443" returns host: "localhost", port: "80"
 func parseTarget(target, defaultPort string) (host, port string, err error) {
 	if target == "" {
 		return "", "", internal.ErrMissingAddr

--- a/internal/resolver/dns/dns_resolver.go
+++ b/internal/resolver/dns/dns_resolver.go
@@ -388,7 +388,7 @@ func parseTarget(target, defaultPort string) (host, port string, err error) {
 			return "", "", internal.ErrEndsWithColon
 		}
 		// target has port, i.e ipv4-host:port, [ipv6-host]:port, host-name:port
-		if host == "" || host == "localhost" {
+		if host == "" {
 			// Keep consistent with net.Dial(): If the host is empty, as in ":80",
 			// the local system is assumed.
 			host = "127.0.0.1"

--- a/internal/resolver/dns/dns_resolver.go
+++ b/internal/resolver/dns/dns_resolver.go
@@ -388,7 +388,7 @@ func parseTarget(target, defaultPort string) (host, port string, err error) {
 			return "", "", internal.ErrEndsWithColon
 		}
 		// target has port, i.e ipv4-host:port, [ipv6-host]:port, host-name:port
-		if host == "" {
+		if host == "" || host == "localhost" {
 			// Keep consistent with net.Dial(): If the host is empty, as in ":80",
 			// the local system is assumed.
 			host = "127.0.0.1"

--- a/internal/resolver/dns/dns_resolver_test.go
+++ b/internal/resolver/dns/dns_resolver_test.go
@@ -1036,7 +1036,7 @@ func (s) TestCustomAuthority(t *testing.T) {
 		{
 			name:          "no host port and non-default port",
 			authority:     ":123",
-			wantAuthority: "localhost:123",
+			wantAuthority: "127.0.0.1:123",
 		},
 		{
 			name:          "only colon",

--- a/test/xds/xds_client_custom_lb_test.go
+++ b/test/xds/xds_client_custom_lb_test.go
@@ -235,7 +235,7 @@ func (s) TestWrrLocality(t *testing.T) {
 				Clusters:  []*v3clusterpb.Cluster{clusterWithLBConfiguration(t, clusterName, endpointsName, e2e.SecurityLevelNone, test.wrrLocalityConfiguration)},
 				Endpoints: []*v3endpointpb.ClusterLoadAssignment{e2e.EndpointResourceWithOptions(e2e.EndpointOptions{
 					ClusterName: endpointsName,
-					Host:        "127.0.0.1",
+					Host:        "localhost",
 					Localities: []e2e.LocalityOptions{
 						{
 							Backends: []e2e.BackendOptions{{Port: port1}, {Port: port2}},
@@ -268,6 +268,7 @@ func (s) TestWrrLocality(t *testing.T) {
 					addrDistWant = append(addrDistWant, resolver.Address{Addr: addrAndCount.addr})
 				}
 			}
+			fmt.Printf("addrDistWant %v\n", addrDistWant)
 			if err := roundrobin.CheckWeightedRoundRobinRPCs(ctx, client, addrDistWant); err != nil {
 				t.Fatalf("Error in expected round robin: %v", err)
 			}

--- a/test/xds/xds_client_custom_lb_test.go
+++ b/test/xds/xds_client_custom_lb_test.go
@@ -268,7 +268,6 @@ func (s) TestWrrLocality(t *testing.T) {
 					addrDistWant = append(addrDistWant, resolver.Address{Addr: addrAndCount.addr})
 				}
 			}
-			fmt.Printf("addrDistWant %v\n", addrDistWant)
 			if err := roundrobin.CheckWeightedRoundRobinRPCs(ctx, client, addrDistWant); err != nil {
 				t.Fatalf("Error in expected round robin: %v", err)
 			}

--- a/test/xds/xds_client_custom_lb_test.go
+++ b/test/xds/xds_client_custom_lb_test.go
@@ -235,7 +235,7 @@ func (s) TestWrrLocality(t *testing.T) {
 				Clusters:  []*v3clusterpb.Cluster{clusterWithLBConfiguration(t, clusterName, endpointsName, e2e.SecurityLevelNone, test.wrrLocalityConfiguration)},
 				Endpoints: []*v3endpointpb.ClusterLoadAssignment{e2e.EndpointResourceWithOptions(e2e.EndpointOptions{
 					ClusterName: endpointsName,
-					Host:        "localhost",
+					Host:        "127.0.0.1",
 					Localities: []e2e.LocalityOptions{
 						{
 							Backends: []e2e.BackendOptions{{Port: port1}, {Port: port2}},


### PR DESCRIPTION
Currently, if the host is not specified, it defaults to localhost. This can lead to issues if the DNS server does not resolve localhost correctly, potentially resulting in errors such as `{"code":14,"message":"dns: A record lookup error: lookup localhost: i/o timeout"}`.

I believe that if the host is not provided, the system should skip DNS resolution entirely and directly use the host, which would help prevent these unintended behaviors.

RELEASE NOTES: 

-  Skip DNS resolution when host not specified