### PR TITLE
github/workflows: Fix the tag used to enable buffer leak checks

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -57,7 +57,7 @@ jobs:
 
           - type: tests
             goversion: '1.22'
-            testflags: '-race -tags=buffer_pooling'
+            testflags: '-race -tags=checkbuffers'
 
           - type: tests
             goversion: '1.22'


### PR DESCRIPTION
The build tag used to enable buffer leaks is defined here:
https://github.com/grpc/grpc-go/blob/e7a8097342e07dbfa093589eed67a8e0d6558423/internal/leakcheck/leakcheck_enabled.go#L1

The Github workflow seems to be using the wrong tag name.

RELEASE NOTES: N/A