### PR TITLE
xds: Fix flaky test TestUnmarshalListener_WithUpdateValidatorFunc

### DIFF
--- a/test/xds/xds_server_integration_test.go
+++ b/test/xds/xds_server_integration_test.go
@@ -140,7 +140,7 @@ func setupGRPCServer(t *testing.T, bootstrapContents []byte) (net.Listener, func
 	select {
 	case <-readyLis.serverReady.Done():
 	case <-time.After(defaultTestTimeout):
-		t.Fatalf("Timed out while waiting for the back end server to start")
+		t.Fatalf("Timed out while waiting for the backend server to start serving")
 	}
 
 	return lis, func() {


### PR DESCRIPTION
Fixes: https://github.com/grpc/grpc-go/issues/7599

This change ensures that the server has started listening for requests by wrapping the listener passed to `server.Serve()`
Verified that the test no longer flakes in 100000 runs on forge.

RELEASE NOTES: N/A