### PR TITLE
xds: misc test cleanup (4/N)

### DIFF
--- a/internal/testutils/channel.go
+++ b/internal/testutils/channel.go
@@ -26,8 +26,9 @@ const DefaultChanBufferSize = 1
 
 // Channel wraps a generic channel and provides a timed receive operation.
 type Channel struct {
-	// C is the underlying channel on which values sent using the SendXxx() methods are delivered.
-	// Tests which cannot use ReceiveXxx() for whatever reasons can use C to read the values.
+	// C is the underlying channel on which values sent using the SendXxx()
+	// methods are delivered. Tests which cannot use ReceiveXxx() for whatever
+	// reasons can use C to read the values.
 	C chan any
 }
 

--- a/test/xds/xds_client_federation_test.go
+++ b/test/xds/xds_client_federation_test.go
@@ -336,7 +336,4 @@ func (s) TestFederation_UnknownAuthorityInReceivedResponse(t *testing.T) {
 	if got, want := status.Code(err), codes.Unavailable; got != want {
 		t.Fatalf("EmptyCall RPC returned status code: %v, want %v", got, want)
 	}
-	if wantErr := `failed to find authority "unknown-authority"`; !strings.Contains(err.Error(), wantErr) {
-		t.Fatalf("EmptyCall RPC returned error: %v, want %v", err, wantErr)
-	}
 }

--- a/xds/internal/xdsclient/tests/cds_watchers_test.go
+++ b/xds/internal/xdsclient/tests/cds_watchers_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
 	"google.golang.org/grpc/internal/grpcsync"
+	"google.golang.org/grpc/internal/pretty"
 	"google.golang.org/grpc/internal/testutils"
 	"google.golang.org/grpc/internal/testutils/xds/e2e"
 	"google.golang.org/grpc/internal/xds/bootstrap"
@@ -130,7 +131,7 @@ func verifyNoClusterUpdate(ctx context.Context, updateCh *testutils.Channel) err
 	sCtx, sCancel := context.WithTimeout(ctx, defaultTestShortTimeout)
 	defer sCancel()
 	if u, err := updateCh.Receive(sCtx); err != context.DeadlineExceeded {
-		return fmt.Errorf("received unexpected ClusterUpdate when expecting none: %v", u)
+		return fmt.Errorf("received unexpected ClusterUpdate when expecting none: %s", pretty.ToJSON(u))
 	}
 	return nil
 }

--- a/xds/server_test.go
+++ b/xds/server_test.go
@@ -697,17 +697,16 @@ func (s) TestServeAndCloseDoNotRace(t *testing.T) {
 	}
 
 	wg := sync.WaitGroup{}
+	wg.Add(200)
 	for i := 0; i < 100; i++ {
 		server, err := NewGRPCServer(BootstrapContentsForTesting(generateBootstrapContents(t, uuid.NewString(), nonExistentManagementServer)))
 		if err != nil {
 			t.Fatalf("Failed to create an xDS enabled gRPC server: %v", err)
 		}
-		wg.Add(1)
 		go func() {
 			server.Serve(lis)
 			wg.Done()
 		}()
-		wg.Add(1)
 		go func() {
 			server.Stop()
 			wg.Done()


### PR DESCRIPTION
#a71-xds-fallback
#xdsclient-refactor

Addresses https://github.com/grpc/grpc-go/issues/6902

RELEASE NOTES: none