### PR TITLE
mem: use slice capacity instead of length, to determine whether to pool buffers or directly allocate them

### DIFF
--- a/mem/buffers.go
+++ b/mem/buffers.go
@@ -92,7 +92,10 @@ func newBuffer() *buffer {
 //
 // Note that the backing array of the given data is not copied.
 func NewBuffer(data *[]byte, pool BufferPool) Buffer {
-	if pool == nil || IsBelowBufferPoolingThreshold(len(*data)) {
+	// Use the buffer's capacity instead of the length, otherwise buffers may not be reused under certain
+	// conditions. For example, if a large buffer is acquired from the pool, but fewer bytes than the
+	// buffering threshold are written to it, the buffer will not be returned to the pool.
+	if pool == nil || IsBelowBufferPoolingThreshold(cap(*data)) {
 		return (SliceBuffer)(*data)
 	}
 	b := newBuffer()

--- a/mem/buffers.go
+++ b/mem/buffers.go
@@ -92,9 +92,10 @@ func newBuffer() *buffer {
 //
 // Note that the backing array of the given data is not copied.
 func NewBuffer(data *[]byte, pool BufferPool) Buffer {
-	// Use the buffer's capacity instead of the length, otherwise buffers may not be reused under certain
-	// conditions. For example, if a large buffer is acquired from the pool, but fewer bytes than the
-	// buffering threshold are written to it, the buffer will not be returned to the pool.
+	// Use the buffer's capacity instead of the length, otherwise buffers may
+	// not be reused under certain conditions. For example, if a large buffer
+	// is acquired from the pool, but fewer bytes than the buffering threshold
+	// are written to it, the buffer will not be returned to the pool.
 	if pool == nil || IsBelowBufferPoolingThreshold(cap(*data)) {
 		return (SliceBuffer)(*data)
 	}

--- a/mem/buffers_test.go
+++ b/mem/buffers_test.go
@@ -98,6 +98,32 @@ func (s) TestBuffer_NewBufferRefAndFree(t *testing.T) {
 	}
 }
 
+func (s) TestBuffer_NewBufferHandlesShortBuffers(t *testing.T) {
+	const threshold = 100
+
+	// Update the pooling threshold, since that's what's being tested.
+	internal.SetBufferPoolingThresholdForTesting.(func(int))(threshold)
+	t.Cleanup(func() {
+		internal.SetBufferPoolingThresholdForTesting.(func(int))(0)
+	})
+
+	// Make a buffer whose capacity is larger than the pooling threshold, but whose length is less than
+	// the threshold.
+	b := make([]byte, threshold/2, threshold*2)
+	pool := &singleBufferPool{
+		t:    t,
+		data: &b,
+	}
+
+	// Get a buffer, then free it. If NewBuffer decided that the buffer shouldn't get pooled, Free will
+	// be a noop and singleBufferPool will not have been updated.
+	mem.NewBuffer(&b, pool).Free()
+
+	if pool.data != nil {
+		t.Fatalf("buffer not returned to pool")
+	}
+}
+
 func (s) TestBuffer_FreeAfterFree(t *testing.T) {
 	buf := newBuffer([]byte("abcd"), mem.NopBufferPool{})
 	if buf.Len() != 4 {

--- a/mem/buffers_test.go
+++ b/mem/buffers_test.go
@@ -107,16 +107,17 @@ func (s) TestBuffer_NewBufferHandlesShortBuffers(t *testing.T) {
 		internal.SetBufferPoolingThresholdForTesting.(func(int))(0)
 	})
 
-	// Make a Buffer whose capacity is larger than the pooling threshold, but whose length is less than
-	// the threshold.
+	// Make a pool with a buffer whose capacity is larger than the pooling
+	// threshold, but whose length is less than the threshold.
 	b := make([]byte, threshold/2, threshold*2)
 	pool := &singleBufferPool{
 		t:    t,
 		data: &b,
 	}
 
-	// Get a Buffer, then free it. If NewBuffer decided that the Buffer shouldn't get pooled, Free will
-	// be a noop and singleBufferPool will not have been updated.
+	// Get a Buffer, then free it. If NewBuffer decided that the Buffer
+	// shouldn't get pooled, Free will be a noop and singleBufferPool will not
+	// have been updated.
 	mem.NewBuffer(&b, pool).Free()
 
 	if pool.data != nil {

--- a/mem/buffers_test.go
+++ b/mem/buffers_test.go
@@ -107,7 +107,7 @@ func (s) TestBuffer_NewBufferHandlesShortBuffers(t *testing.T) {
 		internal.SetBufferPoolingThresholdForTesting.(func(int))(0)
 	})
 
-	// Make a buffer whose capacity is larger than the pooling threshold, but whose length is less than
+	// Make a Buffer whose capacity is larger than the pooling threshold, but whose length is less than
 	// the threshold.
 	b := make([]byte, threshold/2, threshold*2)
 	pool := &singleBufferPool{
@@ -115,12 +115,12 @@ func (s) TestBuffer_NewBufferHandlesShortBuffers(t *testing.T) {
 		data: &b,
 	}
 
-	// Get a buffer, then free it. If NewBuffer decided that the buffer shouldn't get pooled, Free will
+	// Get a Buffer, then free it. If NewBuffer decided that the Buffer shouldn't get pooled, Free will
 	// be a noop and singleBufferPool will not have been updated.
 	mem.NewBuffer(&b, pool).Free()
 
 	if pool.data != nil {
-		t.Fatalf("buffer not returned to pool")
+		t.Fatalf("Buffer not returned to pool")
 	}
 }
 


### PR DESCRIPTION
Fixes #7631 

As the issue states, `mem.NewBuffer` would not pool buffers with a length below the pooling threshold but whose capacity is actually larger than the pooling threshold. This can lead to buffers being leaked.

RELEASE NOTES:
- mem: use slice capacity instead of length, to determine whether to pool buffers or directly allocate them