### PR TITLE
Revert "protoc-gen-go-grpc: remove `use_generic_streams_experimental`  flag (defaults to true) (#7654)

### DIFF
--- a/cmd/protoc-gen-go-grpc/main.go
+++ b/cmd/protoc-gen-go-grpc/main.go
@@ -45,6 +45,7 @@ import (
 const version = "1.5.1"
 
 var requireUnimplemented *bool
+var useGenericStreams *bool
 
 func main() {
 	showVersion := flag.Bool("version", false, "print the version and exit")
@@ -56,6 +57,7 @@ func main() {
 
 	var flags flag.FlagSet
 	requireUnimplemented = flags.Bool("require_unimplemented_servers", true, "set to false to match legacy behavior")
+	useGenericStreams = flags.Bool("use_generic_streams_experimental", true, "set to true to use generic types for streaming client and server objects; this flag is EXPERIMENTAL and may be changed or removed in a future release")
 
 	protogen.Options{
 		ParamFunc: flags.Set,

--- a/cmd/protoc-gen-go-grpc/protoc-gen-go-grpc_test.sh
+++ b/cmd/protoc-gen-go-grpc/protoc-gen-go-grpc_test.sh
@@ -30,7 +30,7 @@ popd
 
 protoc \
     --go-grpc_out="${TEMPDIR}" \
-    --go-grpc_opt=paths=source_relative \
+    --go-grpc_opt=paths=source_relative,use_generic_streams_experimental=true \
     "examples/route_guide/routeguide/route_guide.proto"
 
 GOLDENFILE="examples/route_guide/routeguide/route_guide_grpc.pb.go"


### PR DESCRIPTION
This PR reverts #7654  which attempted to:

- Remove the use_generic_streams_experimental flag.
- Make the use of generics mandatory for stream methods.

This revert is necessary because the previous changes caused compatibility issues with existing usages of client and server stream methods within internal google3.

We will revisit this change once the affected usages in google3 have been migrated.

RELEASE NOTES: None