### PR TITLE
revert xds: return all ServerConfig dial options together

### DIFF
--- a/internal/xds/bootstrap/bootstrap.go
+++ b/internal/xds/bootstrap/bootstrap.go
@@ -220,14 +220,20 @@ func (sc *ServerConfig) ServerFeaturesIgnoreResourceDeletion() bool {
 	return false
 }
 
-// DialOptions returns a slice of all the configured dial options for this
-// server.
-func (sc *ServerConfig) DialOptions() []grpc.DialOption {
-	dopts := []grpc.DialOption{sc.credsDialOption}
-	if sc.dialerOption != nil {
-		dopts = append(dopts, sc.dialerOption)
-	}
-	return dopts
+// CredsDialOption returns the first supported transport credentials from the
+// configuration, as a dial option.
+func (sc *ServerConfig) CredsDialOption() grpc.DialOption {
+	return sc.credsDialOption
+}
+
+// DialerOption returns the Dialer function that specifies how to dial the xDS
+// server determined by the first supported credentials from the configuration,
+// as a dial option.
+//
+// TODO(https://github.com/grpc/grpc-go/issues/7661): change ServerConfig type
+// to have a single method that returns all configured dial options.
+func (sc *ServerConfig) DialerOption() grpc.DialOption {
+	return sc.dialerOption
 }
 
 // Cleanups returns a collection of functions to be called when the xDS client

--- a/xds/internal/xdsclient/transport/transport.go
+++ b/xds/internal/xdsclient/transport/transport.go
@@ -192,14 +192,19 @@ func New(opts Options) (*Transport, error) {
 		return nil, errors.New("missing OnSend callback handler when creating a new transport")
 	}
 
-	// Dial the xDS management server with dial options specified by the server
-	// configuration and a static keepalive configuration that is common across
-	// gRPC language implementations.
-	kpCfg := grpc.WithKeepaliveParams(keepalive.ClientParameters{
-		Time:    5 * time.Minute,
-		Timeout: 20 * time.Second,
-	})
-	dopts := append([]grpc.DialOption{kpCfg}, opts.ServerCfg.DialOptions()...)
+	// Dial the xDS management with the passed in credentials.
+	dopts := []grpc.DialOption{
+		opts.ServerCfg.CredsDialOption(),
+		grpc.WithKeepaliveParams(keepalive.ClientParameters{
+			// We decided to use these sane defaults in all languages, and
+			// kicked the can down the road as far making these configurable.
+			Time:    5 * time.Minute,
+			Timeout: 20 * time.Second,
+		}),
+	}
+	if dialerOpts := opts.ServerCfg.DialerOption(); dialerOpts != nil {
+		dopts = append(dopts, dialerOpts)
+	}
 	grpcNewClient := transportinternal.GRPCNewClient.(func(string, ...grpc.DialOption) (*grpc.ClientConn, error))
 	cc, err := grpcNewClient(opts.ServerCfg.ServerURI(), dopts...)
 	if err != nil {

--- a/xds/internal/xdsclient/transport/transport_test.go
+++ b/xds/internal/xdsclient/transport/transport_test.go
@@ -43,8 +43,6 @@ func Test(t *testing.T) {
 	grpctest.RunSubTests(t, s{})
 }
 
-const defaultTestTimeout = 10 * time.Second
-
 var noopRecvHandler = func(_ transport.ResourceUpdate, onDone func()) error {
 	onDone()
 	return nil


### PR DESCRIPTION
This revert #7680 which : 
- Added a single DialOptions() method that returns a slice of all dial options for the type ServerConfig instead of individual methods to get all dial options.
- Changed the test to wait for the custom dialer to be called.

Also reverts #7710 which :
- Added `defaultTestTimeout` variable which is now unused.

Reverting this is necessary because the wait for dialer is failing in google3.

RELEASE NOTES: none
