### PR TITLE
testutils: add couple of log statements to the restartable listener type

### DIFF
--- a/internal/testutils/restartable_listener.go
+++ b/internal/testutils/restartable_listener.go
@@ -81,6 +81,8 @@ func (l *RestartableListener) Addr() net.Addr {
 // Stop closes existing connections on the listener and prevents new connections
 // from being accepted.
 func (l *RestartableListener) Stop() {
+	logger.Infof("Stopping restartable listener %q", l.Addr())
+
 	l.mu.Lock()
 	l.stopped = true
 	for _, conn := range l.conns {
@@ -92,6 +94,8 @@ func (l *RestartableListener) Stop() {
 
 // Restart gets a previously stopped listener to start accepting connections.
 func (l *RestartableListener) Restart() {
+	logger.Infof("Restarting listener %q", l.Addr())
+
 	l.mu.Lock()
 	l.stopped = false
 	l.mu.Unlock()


### PR DESCRIPTION
#a71-xds-fallback
#xdsclient-refactor

Addresses https://github.com/grpc/grpc-go/issues/6902

RELEASE NOTES: none