### PR TITLE
xdsclient: new Transport interface and LRS stream implementation

### DIFF
--- a/xds/internal/xdsclient/internal/internal.go
+++ b/xds/internal/xdsclient/internal/internal.go
@@ -20,6 +20,9 @@ package internal
 
 // The following vars can be overridden by tests.
 var (
-	// NewADSStream is a function that returns a new ADS stream.
+	// GRPCNewClient returns a new gRPC Client.
+	GRPCNewClient any // func(string, ...grpc.DialOption) (*grpc.ClientConn, error)
+
+	// NewADSStream returns a new ADS stream.
 	NewADSStream any // func(context.Context, *grpc.ClientConn) (v3adsgrpc.AggregatedDiscoveryService_StreamAggregatedResourcesClient, error)
 )

--- a/xds/internal/xdsclient/transport/grpctransport/grpctransport.go
+++ b/xds/internal/xdsclient/transport/grpctransport/grpctransport.go
@@ -25,7 +25,6 @@ import (
 	"time"
 
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/grpclog"
 	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/xds/internal/xdsclient/internal"
 	"google.golang.org/grpc/xds/internal/xdsclient/transport"
@@ -49,7 +48,7 @@ type Builder struct{}
 // Build creates a new gRPC-based transport to an XDS server using the provided
 // options. It establishes a gRPC client connection using the server URI and
 // credentials specified in the provided options.
-func (b *Builder) Build(opts transport.BuildOptions) (transport.TransportInterface, error) {
+func (b *Builder) Build(opts transport.BuildOptions) (transport.Interface, error) {
 	if opts.ServerConfig == nil {
 		return nil, fmt.Errorf("ServerConfig field in opts cannot be nil")
 	}
@@ -115,7 +114,6 @@ func (g *grpcTransport) newLRSStreamingCall(ctx context.Context) (transport.Stre
 }
 
 func (g *grpcTransport) Close() error {
-	grpclog.Infof("Shutdown")
 	return g.cc.Close()
 }
 

--- a/xds/internal/xdsclient/transport/grpctransport/grpctransport.go
+++ b/xds/internal/xdsclient/transport/grpctransport/grpctransport.go
@@ -42,12 +42,12 @@ func init() {
 	}
 }
 
-// Builder provides a way to build a gRPC-based transport to an XDS server.
+// Builder provides a way to build a gRPC-based transport to an xDS server.
 type Builder struct{}
 
-// Build creates a new gRPC-based transport to an XDS server using the provided
-// options. It establishes a gRPC client connection using the server URI and
-// credentials specified in the provided options.
+// Build creates a new gRPC-based transport to an xDS server using the provided
+// options. This involves creating a grpc.ClientConn to the server identified by
+// the server URI in the provided options.
 func (b *Builder) Build(opts transport.BuildOptions) (transport.Interface, error) {
 	if opts.ServerConfig == nil {
 		return nil, fmt.Errorf("ServerConfig field in opts cannot be nil")

--- a/xds/internal/xdsclient/transport/grpctransport/grpctransport.go
+++ b/xds/internal/xdsclient/transport/grpctransport/grpctransport.go
@@ -65,11 +65,7 @@ func (b *Builder) Build(opts transport.BuildOptions) (transport.Interface, error
 		Time:    5 * time.Minute,
 		Timeout: 20 * time.Second,
 	})
-	dopts := append([]grpc.DialOption{kpCfg}, opts.ServerConfig.CredsDialOption())
-	if opt := opts.ServerConfig.DialerOption(); opt != nil {
-		dopts = append(dopts, opt)
-	}
-
+	dopts := append(opts.ServerConfig.DialOptions(), kpCfg)
 	dialer := internal.GRPCNewClient.(func(string, ...grpc.DialOption) (*grpc.ClientConn, error))
 	cc, err := dialer(opts.ServerConfig.ServerURI(), dopts...)
 	if err != nil {

--- a/xds/internal/xdsclient/transport/grpctransport/grpctransport.go
+++ b/xds/internal/xdsclient/transport/grpctransport/grpctransport.go
@@ -1,0 +1,144 @@
+/*
+ *
+ * Copyright 2024 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package grpctransport provides an implementation of the transport interface
+// using gRPC.
+package grpctransport
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/grpclog"
+	"google.golang.org/grpc/keepalive"
+	"google.golang.org/grpc/xds/internal/xdsclient/internal"
+	"google.golang.org/grpc/xds/internal/xdsclient/transport"
+
+	v3adsgrpc "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+	v3adspb "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+	v3lrsgrpc "github.com/envoyproxy/go-control-plane/envoy/service/load_stats/v3"
+	v3lrspb "github.com/envoyproxy/go-control-plane/envoy/service/load_stats/v3"
+)
+
+func init() {
+	internal.GRPCNewClient = grpc.NewClient
+	internal.NewADSStream = func(ctx context.Context, cc *grpc.ClientConn) (v3adsgrpc.AggregatedDiscoveryService_StreamAggregatedResourcesClient, error) {
+		return v3adsgrpc.NewAggregatedDiscoveryServiceClient(cc).StreamAggregatedResources(ctx)
+	}
+}
+
+// Builder provides a way to build a gRPC-based transport to an XDS server.
+type Builder struct{}
+
+// Build creates a new gRPC-based transport to an XDS server using the provided
+// options. It establishes a gRPC client connection using the server URI and
+// credentials specified in the provided options.
+func (b *Builder) Build(opts transport.BuildOptions) (transport.TransportInterface, error) {
+	if opts.ServerConfig == nil {
+		return nil, fmt.Errorf("ServerConfig field in opts cannot be nil")
+	}
+
+	// NOTE: The bootstrap package ensures that the server_uri and credentials
+	// inside the server config are always populated. If we end up using a
+	// different type in BuildOptions to specify the server configuration, we
+	// must ensure that those fields are not empty before proceeding.
+
+	// Dial the xDS management server with dial options specified by the server
+	// configuration and a static keepalive configuration that is common across
+	// gRPC language implementations.
+	kpCfg := grpc.WithKeepaliveParams(keepalive.ClientParameters{
+		Time:    5 * time.Minute,
+		Timeout: 20 * time.Second,
+	})
+	dopts := append([]grpc.DialOption{kpCfg}, opts.ServerConfig.CredsDialOption())
+	if opt := opts.ServerConfig.DialerOption(); opt != nil {
+		dopts = append(dopts, opt)
+	}
+
+	dialer := internal.GRPCNewClient.(func(string, ...grpc.DialOption) (*grpc.ClientConn, error))
+	cc, err := dialer(opts.ServerConfig.ServerURI(), dopts...)
+	if err != nil {
+		// An error from a non-blocking dial indicates something serious.
+		return nil, fmt.Errorf("failed to create a grpc transport to the management server %q: %v", opts.ServerConfig.ServerURI(), err)
+	}
+	cc.Connect()
+
+	return &grpcTransport{cc: cc}, nil
+}
+
+type grpcTransport struct {
+	cc *grpc.ClientConn
+}
+
+func (g *grpcTransport) CreateStreamingCall(ctx context.Context, method string) (transport.StreamingCall, error) {
+	switch method {
+	case v3adsgrpc.AggregatedDiscoveryService_StreamAggregatedResources_FullMethodName:
+		return g.newADSStreamingCall(ctx)
+	case v3lrsgrpc.LoadReportingService_StreamLoadStats_FullMethodName:
+		return g.newLRSStreamingCall(ctx)
+	default:
+		return nil, fmt.Errorf("unsupported method: %v", method)
+	}
+}
+
+func (g *grpcTransport) newADSStreamingCall(ctx context.Context) (transport.StreamingCall, error) {
+	newStream := internal.NewADSStream.(func(context.Context, *grpc.ClientConn) (v3adsgrpc.AggregatedDiscoveryService_StreamAggregatedResourcesClient, error))
+	stream, err := newStream(ctx, g.cc)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create an ADS stream: %v", err)
+	}
+	return &adsStream{stream: stream}, nil
+}
+
+func (g *grpcTransport) newLRSStreamingCall(ctx context.Context) (transport.StreamingCall, error) {
+	stream, err := v3lrsgrpc.NewLoadReportingServiceClient(g.cc).StreamLoadStats(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create an LRS stream: %v", err)
+	}
+	return &lrsStream{stream: stream}, nil
+}
+
+func (g *grpcTransport) Close() error {
+	grpclog.Infof("Shutdown")
+	return g.cc.Close()
+}
+
+type adsStream struct {
+	stream v3adsgrpc.AggregatedDiscoveryService_StreamAggregatedResourcesClient
+}
+
+func (a *adsStream) Send(msg any) error {
+	return a.stream.Send(msg.(*v3adspb.DiscoveryRequest))
+}
+
+func (a *adsStream) Recv() (any, error) {
+	return a.stream.Recv()
+}
+
+type lrsStream struct {
+	stream v3lrsgrpc.LoadReportingService_StreamLoadStatsClient
+}
+
+func (l *lrsStream) Send(msg any) error {
+	return l.stream.Send(msg.(*v3lrspb.LoadStatsRequest))
+}
+
+func (l *lrsStream) Recv() (any, error) {
+	return l.stream.Recv()
+}

--- a/xds/internal/xdsclient/transport/grpctransport/grpctransport_ext_test.go
+++ b/xds/internal/xdsclient/transport/grpctransport/grpctransport_ext_test.go
@@ -19,7 +19,6 @@ package grpctransport_test
 
 import (
 	"testing"
-	"time"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/internal/grpctest"
@@ -36,8 +35,6 @@ type s struct {
 func Test(t *testing.T) {
 	grpctest.RunSubTests(t, s{})
 }
-
-const defaultTestTimeout = 10 * time.Second
 
 // Tests that the grpctransport.Builder creates a new grpc.ClientConn every time
 // Build() is called.

--- a/xds/internal/xdsclient/transport/grpctransport/grpctransport_ext_test.go
+++ b/xds/internal/xdsclient/transport/grpctransport/grpctransport_ext_test.go
@@ -67,17 +67,15 @@ func (s) TestBuild_CustomDialer(t *testing.T) {
 	}
 	customDialerCalled = false
 
-	// Reset the dialer, create a new transport and ensure that our custom
-	// dialer is no longer called.
-	internal.GRPCNewClient = origDialer
+	// Create another transport and ensure that the custom dialer was called.
 	tr, err = builder.Build(opts)
 	if err != nil {
 		t.Fatalf("Builder.Build(%+v) failed: %v", opts, err)
 	}
 	defer tr.Close()
 
-	if customDialerCalled {
-		t.Fatalf("Builder.Build(%+v): custom dialer called = true, want false", opts)
+	if !customDialerCalled {
+		t.Fatalf("Builder.Build(%+v): custom dialer called = false, want true", opts)
 	}
 }
 
@@ -85,9 +83,9 @@ func (s) TestBuild_CustomDialer(t *testing.T) {
 // provided BuildOptions do not contain a ServerConfig.
 func (s) TestBuild_EmptyServerConfig(t *testing.T) {
 	builder := &grpctransport.Builder{}
-	tr, err := builder.Build(transport.BuildOptions{})
-	if err == nil {
+	opts := transport.BuildOptions{}
+	if tr, err := builder.Build(opts); err == nil {
 		tr.Close()
-		t.Fatalf("Builder.Build(%+v) succeeded when expected to fail", transport.BuildOptions{})
+		t.Fatalf("Builder.Build(%+v) succeeded when expected to fail", opts)
 	}
 }

--- a/xds/internal/xdsclient/transport/grpctransport/grpctransport_ext_test.go
+++ b/xds/internal/xdsclient/transport/grpctransport/grpctransport_ext_test.go
@@ -1,0 +1,96 @@
+/*
+ *
+ * Copyright 2022 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package grpctransport_test
+
+import (
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/internal/grpctest"
+	internalbootstrap "google.golang.org/grpc/internal/xds/bootstrap"
+	"google.golang.org/grpc/xds/internal/xdsclient/internal"
+	"google.golang.org/grpc/xds/internal/xdsclient/transport"
+	"google.golang.org/grpc/xds/internal/xdsclient/transport/grpctransport"
+)
+
+type s struct {
+	grpctest.Tester
+}
+
+func Test(t *testing.T) {
+	grpctest.RunSubTests(t, s{})
+}
+
+const defaultTestTimeout = 10 * time.Second
+
+// Tests that the grpctransport.Builder creates a new grpc.ClientConn every time
+// Build() is called.
+func (s) TestBuild_CustomDialer(t *testing.T) {
+	// Override the dialer with a custom one.
+	customDialerCalled := false
+	origDialer := internal.GRPCNewClient
+	internal.GRPCNewClient = func(target string, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
+		customDialerCalled = true
+		return grpc.NewClient(target, opts...)
+	}
+	defer func() { internal.GRPCNewClient = origDialer }()
+
+	serverCfg, err := internalbootstrap.ServerConfigForTesting(internalbootstrap.ServerConfigTestingOptions{URI: "server-address"})
+	if err != nil {
+		t.Fatalf("Failed to create server config for testing: %v", err)
+	}
+
+	// Create a new transport and ensure that the custom dialer was called.
+	opts := transport.BuildOptions{ServerConfig: serverCfg}
+	builder := &grpctransport.Builder{}
+	tr, err := builder.Build(opts)
+	if err != nil {
+		t.Fatalf("Builder.Build(%+v) failed: %v", opts, err)
+	}
+	defer tr.Close()
+
+	if !customDialerCalled {
+		t.Fatalf("Builder.Build(%+v): custom dialer called = false, want true", opts)
+	}
+	customDialerCalled = false
+
+	// Reset the dialer, create a new transport and ensure that our custom
+	// dialer is no longer called.
+	internal.GRPCNewClient = origDialer
+	tr, err = builder.Build(opts)
+	if err != nil {
+		t.Fatalf("Builder.Build(%+v) failed: %v", opts, err)
+	}
+	defer tr.Close()
+
+	if customDialerCalled {
+		t.Fatalf("Builder.Build(%+v): custom dialer called = true, want false", opts)
+	}
+}
+
+// Tests that the grpctransport.Builder fails to build a transport when the
+// provided BuildOptions do not contain a ServerConfig.
+func (s) TestBuild_EmptyServerConfig(t *testing.T) {
+	builder := &grpctransport.Builder{}
+	tr, err := builder.Build(transport.BuildOptions{})
+	if err == nil {
+		tr.Close()
+		t.Fatalf("Builder.Build(%+v) succeeded when expected to fail", transport.BuildOptions{})
+	}
+}

--- a/xds/internal/xdsclient/transport/lrs/lrs_stream.go
+++ b/xds/internal/xdsclient/transport/lrs/lrs_stream.go
@@ -1,0 +1,326 @@
+/*
+ *
+ * Copyright 2024 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package lrs provides the implementation of an LRS (Load Reporting Service)
+// stream for the xDS client.
+package lrs
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"sync"
+	"time"
+
+	"google.golang.org/grpc/grpclog"
+	"google.golang.org/grpc/internal/backoff"
+	igrpclog "google.golang.org/grpc/internal/grpclog"
+	"google.golang.org/grpc/internal/grpcsync"
+	"google.golang.org/grpc/internal/pretty"
+	"google.golang.org/grpc/xds/internal"
+	"google.golang.org/grpc/xds/internal/xdsclient/load"
+	"google.golang.org/grpc/xds/internal/xdsclient/transport"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/durationpb"
+
+	v3corepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	v3endpointpb "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
+	v3lrspb "github.com/envoyproxy/go-control-plane/envoy/service/load_stats/v3"
+)
+
+// Any per-RPC level logs which print complete request or response messages
+// should be gated at this verbosity level. Other per-RPC level logs which print
+// terse output should be at `INFO` and verbosity 2.
+const perRPCVerbosityLevel = 9
+
+// Stream provides all the functionality associated with an LRS (Load Reporting
+// Service) stream on the client-side.
+type Stream struct {
+	// The following fields are initialized from arguments passed to the
+	// constructor and are read-only afterwards, and hence can be accessed
+	// without a mutex.
+	transport transport.TransportInterface // Transport to use for LRS stream.
+	backoff   func(int) time.Duration      // Backoff after stream failures.
+	nodeProto *v3corepb.Node               // Identifies the gRPC application.
+	doneCh    chan struct{}                // To notify exit of LRS goroutine.
+	logger    *igrpclog.PrefixLogger
+
+	// Guards access to the below fields.
+	mu           sync.Mutex
+	cancelStream context.CancelFunc // Cancel the stream. If nil, the stream is not active.
+	refCount     int                // Number of interested parties.
+	lrsStore     *load.Store        // Store returned to user for pushing loads.
+}
+
+// StreamOpts holds the options for creating an lrsStream.
+type StreamOpts struct {
+	Transport transport.TransportInterface // xDS transport to create the stream on.
+	Backoff   func(int) time.Duration      // Backoff after stream failures.
+	NodeProto *v3corepb.Node               // Node proto to identify the gRPC application.
+	LogPrefix string                       // Prefix to be used for log messages.
+}
+
+// NewStream creates a new LRS Stream with the provided options.
+//
+// The actual streaming RPC call is initiated when the first call to ReportLoad
+// is made, and is terminated when the last call to ReportLoad is canceled.
+func NewStream(opts StreamOpts) *Stream {
+	lrs := &Stream{
+		transport: opts.Transport,
+		backoff:   opts.Backoff,
+		nodeProto: opts.NodeProto,
+		lrsStore:  load.NewStore(),
+	}
+
+	l := grpclog.Component("xds")
+	lrs.logger = igrpclog.NewPrefixLogger(l, opts.LogPrefix+fmt.Sprintf("[lrs-stream %p] ", lrs))
+	return lrs
+}
+
+// ReportLoad returns a load.Store that can be used to report load, and a
+// cleanup function that should be called when the load reporting is no longer
+// needed.
+//
+// The first call to ReportLoad will start the LRS streaming call. Subsequent
+// calls will increment the reference count and return the same load.Store. The
+// cleanup function will stop the LRS stream when the last reference is removed.
+func (lrs *Stream) ReportLoad() (*load.Store, func()) {
+	lrs.mu.Lock()
+	defer lrs.mu.Unlock()
+
+	cleanup := grpcsync.OnceFunc(func() {
+		lrs.mu.Lock()
+		defer lrs.mu.Unlock()
+
+		if lrs.refCount == 0 {
+			lrs.logger.Errorf("Attempting to stop an LRS stream that has already been stopped.")
+			return
+		}
+		lrs.refCount--
+		if lrs.refCount != 0 {
+			return
+		}
+		lrs.cancelStream()
+		lrs.cancelStream = nil
+		lrs.logger.Infof("Stopping LRS stream")
+	})
+
+	if lrs.refCount != 0 {
+		lrs.refCount++
+		return lrs.lrsStore, cleanup
+	}
+
+	lrs.refCount++
+	ctx, cancel := context.WithCancel(context.Background())
+	lrs.cancelStream = cancel
+	lrs.doneCh = make(chan struct{})
+	go lrs.runner(ctx)
+	return lrs.lrsStore, cleanup
+}
+
+// runner is responsible for managing the lifetime of an LRS streaming call. It
+// creates the stream, sends the initial LoadStatsRequest, receives the first
+// LoadStatsResponse, and then starts a goroutine to periodically send
+// LoadStatsRequests. The runner will restart the stream if it encounters any
+// errors.
+func (lrs *Stream) runner(ctx context.Context) {
+	defer close(lrs.doneCh)
+
+	// This feature indicates that the client supports the
+	// LoadStatsResponse.send_all_clusters field in the LRS response.
+	node := proto.Clone(lrs.nodeProto).(*v3corepb.Node)
+	node.ClientFeatures = append(node.ClientFeatures, "envoy.lrs.supports_send_all_clusters")
+
+	runLoadReportStream := func() error {
+		// streamCtx is created and canceled in case we terminate the stream
+		// early for any reason, to avoid gRPC-Go leaking the RPC's monitoring
+		// goroutine.
+		streamCtx, cancel := context.WithCancel(ctx)
+		defer cancel()
+
+		stream, err := lrs.transport.CreateStreamingCall(ctx, "/envoy.service.load_stats.v3.LoadReportingService/StreamLoadStats")
+		if err != nil {
+			lrs.logger.Warningf("Creating new LRS stream failed: %v", err)
+			return nil
+		}
+		if lrs.logger.V(2) {
+			lrs.logger.Infof("LRS stream created")
+		}
+
+		if err := lrs.sendFirstLoadStatsRequest(stream, node); err != nil {
+			lrs.logger.Warningf("Sending first LRS request failed: %v", err)
+			return nil
+		}
+
+		clusters, interval, err := lrs.recvFirstLoadStatsResponse(stream)
+		if err != nil {
+			lrs.logger.Warningf("Reading from LRS stream failed: %v", err)
+			return nil
+		}
+
+		// We reset backoff state when we successfully receive at least one
+		// message from the server.
+		lrs.sendLoads(streamCtx, stream, clusters, interval)
+		return backoff.ErrResetBackoff
+	}
+	backoff.RunF(ctx, runLoadReportStream, lrs.backoff)
+}
+
+func (lrs *Stream) sendLoads(ctx context.Context, stream transport.StreamingCall, clusterNames []string, interval time.Duration) {
+	tick := time.NewTicker(interval)
+	defer tick.Stop()
+	for {
+		select {
+		case <-tick.C:
+		case <-ctx.Done():
+			return
+		}
+		if err := lrs.sendLoadStatsRequest(stream, lrs.lrsStore.Stats(clusterNames)); err != nil {
+			lrs.logger.Warningf("Writing to LRS stream failed: %v", err)
+			return
+		}
+	}
+}
+
+func (lrs *Stream) sendFirstLoadStatsRequest(stream transport.StreamingCall, node *v3corepb.Node) error {
+	req := &v3lrspb.LoadStatsRequest{Node: node}
+	if lrs.logger.V(perRPCVerbosityLevel) {
+		lrs.logger.Infof("Sending initial LoadStatsRequest: %s", pretty.ToJSON(req))
+	}
+	err := stream.Send(req)
+	if err == io.EOF {
+		return getStreamError(stream)
+	}
+	return err
+}
+
+func (lrs *Stream) recvFirstLoadStatsResponse(stream transport.StreamingCall) ([]string, time.Duration, error) {
+	r, err := stream.Recv()
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to receive first LoadStatsResponse: %v", err)
+	}
+	resp, ok := r.(*v3lrspb.LoadStatsResponse)
+	if !ok {
+		lrs.logger.Infof("Message received on ADS stream of unexpected type: %T", r)
+		return nil, time.Duration(0), fmt.Errorf("unexpected message type %T", r)
+	}
+	if lrs.logger.V(perRPCVerbosityLevel) {
+		lrs.logger.Infof("Received first LoadStatsResponse: %s", pretty.ToJSON(resp))
+	}
+
+	rInterval := resp.GetLoadReportingInterval()
+	if rInterval.CheckValid() != nil {
+		return nil, 0, fmt.Errorf("invalid load_reporting_interval: %v", err)
+	}
+	interval := rInterval.AsDuration()
+
+	if resp.ReportEndpointGranularity {
+		// TODO(easwars): Support per endpoint loads.
+		return nil, 0, errors.New("lrs: endpoint loads requested, but not supported by current implementation")
+	}
+
+	clusters := resp.Clusters
+	if resp.SendAllClusters {
+		// Return nil to send stats for all clusters.
+		clusters = nil
+	}
+
+	return clusters, interval, nil
+}
+
+func (lrs *Stream) sendLoadStatsRequest(stream transport.StreamingCall, loads []*load.Data) error {
+	clusterStats := make([]*v3endpointpb.ClusterStats, 0, len(loads))
+	for _, sd := range loads {
+		droppedReqs := make([]*v3endpointpb.ClusterStats_DroppedRequests, 0, len(sd.Drops))
+		for category, count := range sd.Drops {
+			droppedReqs = append(droppedReqs, &v3endpointpb.ClusterStats_DroppedRequests{
+				Category:     category,
+				DroppedCount: count,
+			})
+		}
+		localityStats := make([]*v3endpointpb.UpstreamLocalityStats, 0, len(sd.LocalityStats))
+		for l, localityData := range sd.LocalityStats {
+			lid, err := internal.LocalityIDFromString(l)
+			if err != nil {
+				return err
+			}
+			loadMetricStats := make([]*v3endpointpb.EndpointLoadMetricStats, 0, len(localityData.LoadStats))
+			for name, loadData := range localityData.LoadStats {
+				loadMetricStats = append(loadMetricStats, &v3endpointpb.EndpointLoadMetricStats{
+					MetricName:                    name,
+					NumRequestsFinishedWithMetric: loadData.Count,
+					TotalMetricValue:              loadData.Sum,
+				})
+			}
+			localityStats = append(localityStats, &v3endpointpb.UpstreamLocalityStats{
+				Locality: &v3corepb.Locality{
+					Region:  lid.Region,
+					Zone:    lid.Zone,
+					SubZone: lid.SubZone,
+				},
+				TotalSuccessfulRequests: localityData.RequestStats.Succeeded,
+				TotalRequestsInProgress: localityData.RequestStats.InProgress,
+				TotalErrorRequests:      localityData.RequestStats.Errored,
+				TotalIssuedRequests:     localityData.RequestStats.Issued,
+				LoadMetricStats:         loadMetricStats,
+				UpstreamEndpointStats:   nil, // TODO: populate for per endpoint loads.
+			})
+		}
+
+		clusterStats = append(clusterStats, &v3endpointpb.ClusterStats{
+			ClusterName:           sd.Cluster,
+			ClusterServiceName:    sd.Service,
+			UpstreamLocalityStats: localityStats,
+			TotalDroppedRequests:  sd.TotalDrops,
+			DroppedRequests:       droppedReqs,
+			LoadReportInterval:    durationpb.New(sd.ReportInterval),
+		})
+	}
+
+	req := &v3lrspb.LoadStatsRequest{ClusterStats: clusterStats}
+	if lrs.logger.V(perRPCVerbosityLevel) {
+		lrs.logger.Infof("Sending LRS loads: %s", pretty.ToJSON(req))
+	}
+	err := stream.Send(req)
+	if err == io.EOF {
+		return getStreamError(stream)
+	}
+	return err
+}
+
+func getStreamError(stream transport.StreamingCall) error {
+	for {
+		if _, err := stream.Recv(); err != nil {
+			return err
+		}
+	}
+}
+
+// Stop blocks until the stream is closed and all spawned goroutines exit.
+func (lrs *Stream) Stop() {
+	lrs.mu.Lock()
+	defer lrs.mu.Unlock()
+
+	if lrs.cancelStream == nil {
+		return
+	}
+	lrs.cancelStream()
+	lrs.cancelStream = nil
+	lrs.logger.Infof("Stopping LRS stream")
+	<-lrs.doneCh
+}

--- a/xds/internal/xdsclient/transport/lrs/lrs_stream.go
+++ b/xds/internal/xdsclient/transport/lrs/lrs_stream.go
@@ -21,7 +21,6 @@ package lrs
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"sync"
@@ -223,9 +222,6 @@ func (lrs *StreamImpl) sendFirstLoadStatsRequest(stream transport.StreamingCall,
 //     server requested for load from all clusters
 //   - the load reporting interval, and
 //   - any error encountered
-//
-// If the server requests for endpoint-level load reporting, an error is
-// returned, since this is not yet supported.
 func (lrs *StreamImpl) recvFirstLoadStatsResponse(stream transport.StreamingCall) ([]string, time.Duration, error) {
 	r, err := stream.Recv()
 	if err != nil {
@@ -244,11 +240,6 @@ func (lrs *StreamImpl) recvFirstLoadStatsResponse(stream transport.StreamingCall
 		return nil, 0, fmt.Errorf("lrs: invalid load_reporting_interval: %v", err)
 	}
 	loadReportingInterval := internal.AsDuration()
-
-	if resp.ReportEndpointGranularity {
-		// TODO(easwars): Support per endpoint loads.
-		return nil, 0, errors.New("lrs: endpoint loads requested, but not supported by current implementation")
-	}
 
 	clusters := resp.Clusters
 	if resp.SendAllClusters {

--- a/xds/internal/xdsclient/transport/lrs/lrs_stream.go
+++ b/xds/internal/xdsclient/transport/lrs/lrs_stream.go
@@ -54,10 +54,10 @@ type Stream struct {
 	// The following fields are initialized from arguments passed to the
 	// constructor and are read-only afterwards, and hence can be accessed
 	// without a mutex.
-	transport transport.TransportInterface // Transport to use for LRS stream.
-	backoff   func(int) time.Duration      // Backoff after stream failures.
-	nodeProto *v3corepb.Node               // Identifies the gRPC application.
-	doneCh    chan struct{}                // To notify exit of LRS goroutine.
+	transport transport.Interface     // Transport to use for LRS stream.
+	backoff   func(int) time.Duration // Backoff after stream failures.
+	nodeProto *v3corepb.Node          // Identifies the gRPC application.
+	doneCh    chan struct{}           // To notify exit of LRS goroutine.
 	logger    *igrpclog.PrefixLogger
 
 	// Guards access to the below fields.
@@ -69,10 +69,10 @@ type Stream struct {
 
 // StreamOpts holds the options for creating an lrsStream.
 type StreamOpts struct {
-	Transport transport.TransportInterface // xDS transport to create the stream on.
-	Backoff   func(int) time.Duration      // Backoff after stream failures.
-	NodeProto *v3corepb.Node               // Node proto to identify the gRPC application.
-	LogPrefix string                       // Prefix to be used for log messages.
+	Transport transport.Interface     // xDS transport to create the stream on.
+	Backoff   func(int) time.Duration // Backoff after stream failures.
+	NodeProto *v3corepb.Node          // Node proto to identify the gRPC application.
+	LogPrefix string                  // Prefix to be used for log messages.
 }
 
 // NewStream creates a new LRS Stream with the provided options.

--- a/xds/internal/xdsclient/transport/transport_interface.go
+++ b/xds/internal/xdsclient/transport/transport_interface.go
@@ -1,0 +1,67 @@
+/*
+ *
+ * Copyright 2024 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package transport defines the interface that describe the functionality
+// required to communicate with an xDS server using streaming calls.
+package transport
+
+import (
+	"context"
+
+	"google.golang.org/grpc/internal/xds/bootstrap"
+)
+
+// Builder is an interface for building a new xDS transport.
+type Builder interface {
+	// Build creates a new xDS transport with the provided options.
+	Build(opts BuildOptions) (Transport, error)
+}
+
+// BuildOptions contains the options for building a new xDS transport.
+type BuildOptions struct {
+	// ServerConfig contains the configuration that controls how the transport
+	// interacts with the XDS server. This includes the server URI and the
+	// credentials to use to connect to the server, among other things.
+	ServerConfig *bootstrap.ServerConfig
+}
+
+// TransportInterface provides the functionality to communicate with an XDS
+// server using streaming calls.
+//
+// TODO(easwars): Rename this to Transport once the existing Transport type is
+// removed.
+type TransportInterface interface {
+	// CreateStreamingCall creates a new streaming call to the XDS server for the
+	// specified method name. The returned StreamingCall interface can be used to
+	// send and receive messages on the stream.
+	CreateStreamingCall(context.Context, string) (StreamingCall, error)
+
+	// Close closes the underlying connection and cleans up any resources used by the
+	// Transport.
+	Close() error
+}
+
+// StreamingCall is an interface that provides a way to send and receive
+// messages on a stream. The methods accept or return any.Any messages instead
+// of concrete types to allow this interface to be used for both ADS and LRS.
+type StreamingCall interface {
+	// Send sends the provided message on the stream.
+	Send(any) error
+
+	// Recv block until the next message is received on the stream.
+	Recv() (any, error)
+}

--- a/xds/internal/xdsclient/transport/transport_interface.go
+++ b/xds/internal/xdsclient/transport/transport_interface.go
@@ -39,12 +39,12 @@ type BuildOptions struct {
 	ServerConfig *bootstrap.ServerConfig
 }
 
-// TransportInterface provides the functionality to communicate with an XDS
-// server using streaming calls.
+// Interface provides the functionality to communicate with an XDS server using
+// streaming calls.
 //
 // TODO(easwars): Rename this to Transport once the existing Transport type is
 // removed.
-type TransportInterface interface {
+type Interface interface {
 	// CreateStreamingCall creates a new streaming call to the XDS server for the
 	// specified method name. The returned StreamingCall interface can be used to
 	// send and receive messages on the stream.


### PR DESCRIPTION
#a71-xds-fallback
#xdsclient-refactor

The existing structure of the xDS client is as follows:
- the xDS client has an `authority` type for each authority configuration in the bootstrap (ignoring authority sharing)
- each `authority` has a `Transport` which contains a `grpc.ClientConn` to the xDS management server
- the `Transport` type provides the following functionality
  - runs an ADS stream, and allows the authority to trigger a `DiscoveryRequest` to be sent
  - runs an LRS stream, and allows the authority to start the load reporting

The new structure for the xDS client will be as follows:
- the xDS client will have one `authority` type for each authority configuration in the bootstrap (even if the authority configuration are the same or have the same server configuration)
- the xDS client will own a bunch of `xdsChannel`s, one each for each server configuration specified in the bootstrap
- each `authority` will acquire references to one of more `xdsChannel` instances
- each `xdsChannel` will contain the following
  - a `Transport` to the xDS management server. This will be an interface allowing for non-grpc transports to be used.
  - an ADS stream instance that runs an ADS stream and supports resource subscription/unsubscription.
  - an LRS stream instance that runs an LRS stream and support starting and stopping the stream.

This PR introduces the following functionality:
- Defines the `Transport` interface and provides a gRPC transport implementation.
- An LRS stream implementation.

The current LRS implementation can be found in https://github.com/grpc/grpc-go/blob/master/xds/internal/xdsclient/transport/loadreport.go, and this PR's implementation is heavily based off of it.

Subsequent PRs will add more functionatlity.

Addresses https://github.com/grpc/grpc-go/issues/6902

RELEASE NOTES: none