### PR TITLE
xdsclient: deflake TestADS_ResourcesAreRequestedAfterStreamRestart

### DIFF
--- a/xds/internal/xdsclient/tests/ads_stream_backoff_test.go
+++ b/xds/internal/xdsclient/tests/ads_stream_backoff_test.go
@@ -434,15 +434,16 @@ func (s) TestADS_ResourceRequestedBeforeStreamCreation(t *testing.T) {
 func waitForResourceNames(ctx context.Context, t *testing.T, namesCh chan []string, wantNames []string) error {
 	t.Helper()
 
-	for ; ctx.Err() == nil; <-time.After(defaultTestShortTimeout) {
+	var lastRequestedNames []string
+	for ; ; <-time.After(defaultTestShortTimeout) {
 		select {
 		case <-ctx.Done():
+			return fmt.Errorf("timeout waiting for resources %v to be requested from the management server. Last requested resources: %v", wantNames, lastRequestedNames)
 		case gotNames := <-namesCh:
 			if cmp.Equal(gotNames, wantNames, cmpopts.EquateEmpty(), cmpopts.SortSlices(func(s1, s2 string) bool { return s1 < s2 })) {
 				return nil
 			}
-			t.Logf("Received resource names %v, want %v", gotNames, wantNames)
+			lastRequestedNames = gotNames
 		}
 	}
-	return fmt.Errorf("timeout waiting for resource to be requested from the management server")
 }


### PR DESCRIPTION
Reasons for the flake:
- The resource names requested from the management server were written on to a channel in a non-blocking fashion. This meant that the most recently requested names were not always available.
- A goroutine leak was also happening in some cases because the test was not reading the updates delivered to the resource watcher.

The fix addresses both of the above issues. It also improves the error message when the test times out waiting for a response that matches expectation.

Fixes https://github.com/grpc/grpc-go/issues/7714

#a71-xds-fallback
#xdsclient-refactor

RELEASE NOTES: none