### PR TITLE
xds: switching to stubserver in tests instead of testservice implementation

### DIFF
--- a/xds/internal/httpfilter/fault/fault_test.go
+++ b/xds/internal/httpfilter/fault/fault_test.go
@@ -37,6 +37,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/internal/grpctest"
+	"google.golang.org/grpc/internal/stubserver"
 	"google.golang.org/grpc/internal/testutils"
 	"google.golang.org/grpc/internal/testutils/xds/e2e"
 	"google.golang.org/grpc/metadata"
@@ -67,25 +68,6 @@ func Test(t *testing.T) {
 	grpctest.RunSubTests(t, s{})
 }
 
-type testService struct {
-	testgrpc.TestServiceServer
-}
-
-func (*testService) EmptyCall(context.Context, *testpb.Empty) (*testpb.Empty, error) {
-	return &testpb.Empty{}, nil
-}
-
-func (*testService) FullDuplexCall(stream testgrpc.TestService_FullDuplexCallServer) error {
-	// End RPC after client does a CloseSend.
-	for {
-		if _, err := stream.Recv(); err == io.EOF {
-			return nil
-		} else if err != nil {
-			return err
-		}
-	}
-}
-
 // clientSetup performs a bunch of steps common to all xDS server tests here:
 // - spin up an xDS management server on a local port
 // - spin up a gRPC server and register the test service on it
@@ -106,9 +88,26 @@ func clientSetup(t *testing.T) (*e2e.ManagementServer, string, uint32, func()) {
 	bootstrapContents := e2e.DefaultBootstrapContents(t, nodeID, managementServer.Address)
 	testutils.CreateBootstrapFileForTesting(t, bootstrapContents)
 
+	stub := &stubserver.StubServer{
+		EmptyCallF: func(context.Context, *testpb.Empty) (*testpb.Empty, error) {
+			return &testpb.Empty{}, nil
+		},
+		FullDuplexCallF: func(stream testgrpc.TestService_FullDuplexCallServer) error {
+			for {
+				if _, err := stream.Recv(); err == io.EOF {
+					return nil
+				} else if err != nil {
+					return err
+				}
+			}
+		},
+	}
 	// Initialize a gRPC server and register the stubServer on it.
 	server := grpc.NewServer()
-	testgrpc.RegisterTestServiceServer(server, &testService{})
+
+	// Set the server in the stub and start the test service.
+	stub.S = server
+	stubserver.StartTestService(t, stub)
 
 	// Create a local listener and pass it to Serve().
 	lis, err := testutils.LocalTCPListener()

--- a/xds/internal/httpfilter/fault/fault_test.go
+++ b/xds/internal/httpfilter/fault/fault_test.go
@@ -88,6 +88,7 @@ func clientSetup(t *testing.T) (*e2e.ManagementServer, string, uint32, func()) {
 	bootstrapContents := e2e.DefaultBootstrapContents(t, nodeID, managementServer.Address)
 	testutils.CreateBootstrapFileForTesting(t, bootstrapContents)
 
+	// Initialize an xDS-enabled gRPC server and use the helper to start the test service.
 	stub := &stubserver.StubServer{
 		EmptyCallF: func(context.Context, *testpb.Empty) (*testpb.Empty, error) {
 			return &testpb.Empty{}, nil
@@ -104,7 +105,6 @@ func clientSetup(t *testing.T) (*e2e.ManagementServer, string, uint32, func()) {
 	}
 	server := grpc.NewServer()
 
-	// Set the server in the stub and start the test service.
 	stub.S = server
 	stubserver.StartTestService(t, stub)
 

--- a/xds/internal/httpfilter/fault/fault_test.go
+++ b/xds/internal/httpfilter/fault/fault_test.go
@@ -113,10 +113,9 @@ func clientSetup(t *testing.T) (*e2e.ManagementServer, string, uint32, func()) {
 	}
 	stub.Listener = lis
 	stubserver.StartTestService(t, stub)
-	cleanup := func() {
+	return managementServer, nodeID, uint32(lis.Addr().(*net.TCPAddr).Port), func() {
 		stub.S.Stop()
 	}
-	return managementServer, nodeID, uint32(lis.Addr().(*net.TCPAddr).Port), cleanup
 }
 
 func (s) TestFaultInjection_Unary(t *testing.T) {

--- a/xds/internal/httpfilter/fault/fault_test.go
+++ b/xds/internal/httpfilter/fault/fault_test.go
@@ -88,7 +88,7 @@ func clientSetup(t *testing.T) (*e2e.ManagementServer, string, uint32, func()) {
 	bootstrapContents := e2e.DefaultBootstrapContents(t, nodeID, managementServer.Address)
 	testutils.CreateBootstrapFileForTesting(t, bootstrapContents)
 
-	// Initialize an xDS-enabled gRPC server and use the helper to start the test service.
+	// Initialize a test gRPC server, assign it to the stub server, and start the test service.
 	stub := &stubserver.StubServer{
 		EmptyCallF: func(context.Context, *testpb.Empty) (*testpb.Empty, error) {
 			return &testpb.Empty{}, nil

--- a/xds/internal/httpfilter/fault/fault_test.go
+++ b/xds/internal/httpfilter/fault/fault_test.go
@@ -106,23 +106,17 @@ func clientSetup(t *testing.T) (*e2e.ManagementServer, string, uint32, func()) {
 		},
 	}
 
-	stubserver.StartTestService(t, stub)
-
-	// Create a local listener and pass it to Serve().
+	// Create a local listener and assign it to the stub server.
 	lis, err := testutils.LocalTCPListener()
 	if err != nil {
 		t.Fatalf("testutils.LocalTCPListener() failed: %v", err)
 	}
-
-	go func() {
-		if err := stub.S.Serve(lis); err != nil {
-			t.Errorf("Serve() failed: %v", err)
-		}
-	}()
-
-	return managementServer, nodeID, uint32(lis.Addr().(*net.TCPAddr).Port), func() {
+	stub.Listener = lis
+	stubserver.StartTestService(t, stub)
+	cleanup := func() {
 		stub.S.Stop()
 	}
+	return managementServer, nodeID, uint32(lis.Addr().(*net.TCPAddr).Port), cleanup
 }
 
 func (s) TestFaultInjection_Unary(t *testing.T) {

--- a/xds/internal/httpfilter/fault/fault_test.go
+++ b/xds/internal/httpfilter/fault/fault_test.go
@@ -103,7 +103,6 @@ func clientSetup(t *testing.T) (*e2e.ManagementServer, string, uint32, func()) {
 			}
 		},
 	}
-
 	server := grpc.NewServer()
 
 	stub.S = server

--- a/xds/internal/httpfilter/fault/fault_test.go
+++ b/xds/internal/httpfilter/fault/fault_test.go
@@ -103,6 +103,7 @@ func clientSetup(t *testing.T) (*e2e.ManagementServer, string, uint32, func()) {
 			}
 		},
 	}
+
 	server := grpc.NewServer()
 
 	stub.S = server

--- a/xds/internal/httpfilter/fault/fault_test.go
+++ b/xds/internal/httpfilter/fault/fault_test.go
@@ -102,7 +102,6 @@ func clientSetup(t *testing.T) (*e2e.ManagementServer, string, uint32, func()) {
 			}
 		},
 	}
-	// Initialize a gRPC server and register the stubServer on it.
 	server := grpc.NewServer()
 
 	// Set the server in the stub and start the test service.

--- a/xds/internal/httpfilter/fault/fault_test.go
+++ b/xds/internal/httpfilter/fault/fault_test.go
@@ -113,9 +113,7 @@ func clientSetup(t *testing.T) (*e2e.ManagementServer, string, uint32) {
 	}
 
 	stubserver.StartTestService(t, stub)
-	t.Cleanup(func() {
-		stub.S.Stop()
-	})
+	t.Cleanup(stub.S.Stop)
 	return managementServer, nodeID, uint32(lis.Addr().(*net.TCPAddr).Port)
 }
 
@@ -541,7 +539,6 @@ func (s) TestFaultInjection_Unary(t *testing.T) {
 
 func (s) TestFaultInjection_MaxActiveFaults(t *testing.T) {
 	fs, nodeID, port := clientSetup(t)
-
 	resources := e2e.DefaultClientResources(e2e.ResourceParams{
 		DialTarget: "myservice",
 		NodeID:     nodeID,

--- a/xds/server_ext_test.go
+++ b/xds/server_ext_test.go
@@ -125,6 +125,8 @@ func (s) TestServingModeChanges(t *testing.T) {
 		}
 	})
 
+	sopts := []grpc.ServerOption{grpc.Creds(insecure.NewCredentials()), modeChangeOpt, xds.BootstrapContentsForTesting(bootstrapContents)}
+
 	stub := &stubserver.StubServer{
 		EmptyCallF: func(context.Context, *testpb.Empty) (*testpb.Empty, error) {
 			return &testpb.Empty{}, nil
@@ -141,14 +143,11 @@ func (s) TestServingModeChanges(t *testing.T) {
 			}
 		},
 	}
-	server, err := xds.NewGRPCServer(grpc.Creds(insecure.NewCredentials()), modeChangeOpt, xds.BootstrapContentsForTesting(bootstrapContents))
-	if err != nil {
+	if stub.S, err = xds.NewGRPCServer(sopts...); err != nil {
 		t.Fatalf("Failed to create an xDS enabled gRPC server: %v", err)
 	}
-	defer server.Stop()
-
-	stub.S = server
-	stubserver.StartTestService(t, stub)
+	stubserver.StartTestService(t, stub, sopts...)
+	defer stub.S.Stop()
 
 	go func() {
 		if err := stub.S.Serve(lis); err != nil {
@@ -270,6 +269,8 @@ func (s) TestResourceNotFoundRDS(t *testing.T) {
 		}
 	})
 
+	sopts := []grpc.ServerOption{grpc.Creds(insecure.NewCredentials()), modeChangeOpt, xds.BootstrapContentsForTesting(bootstrapContents)}
+
 	stub := &stubserver.StubServer{
 		EmptyCallF: func(context.Context, *testpb.Empty) (*testpb.Empty, error) {
 			return &testpb.Empty{}, nil
@@ -286,14 +287,11 @@ func (s) TestResourceNotFoundRDS(t *testing.T) {
 			}
 		},
 	}
-	server, err := xds.NewGRPCServer(grpc.Creds(insecure.NewCredentials()), modeChangeOpt, xds.BootstrapContentsForTesting(bootstrapContents))
-	if err != nil {
+	if stub.S, err = xds.NewGRPCServer(sopts...); err != nil {
 		t.Fatalf("Failed to create an xDS enabled gRPC server: %v", err)
 	}
-	defer server.Stop()
-
-	stub.S = server
-	stubserver.StartTestService(t, stub)
+	stubserver.StartTestService(t, stub, sopts...)
+	defer stub.S.Stop()
 
 	go func() {
 		if err := stub.S.Serve(lis); err != nil {

--- a/xds/server_ext_test.go
+++ b/xds/server_ext_test.go
@@ -286,7 +286,6 @@ func (s) TestResourceNotFoundRDS(t *testing.T) {
 			}
 		},
 	}
-
 	server, err := xds.NewGRPCServer(grpc.Creds(insecure.NewCredentials()), modeChangeOpt, xds.BootstrapContentsForTesting(bootstrapContents))
 	if err != nil {
 		t.Fatalf("Failed to create an xDS enabled gRPC server: %v", err)

--- a/xds/server_ext_test.go
+++ b/xds/server_ext_test.go
@@ -151,7 +151,7 @@ func (s) TestServingModeChanges(t *testing.T) {
 	stubserver.StartTestService(t, stub)
 
 	go func() {
-		if err := server.Serve(lis); err != nil {
+		if err := stub.S.Serve(lis); err != nil {
 			t.Errorf("Serve() failed: %v", err)
 		}
 	}()
@@ -296,7 +296,7 @@ func (s) TestResourceNotFoundRDS(t *testing.T) {
 	stubserver.StartTestService(t, stub)
 
 	go func() {
-		if err := server.Serve(lis); err != nil {
+		if err := stub.S.Serve(lis); err != nil {
 			t.Errorf("Serve() failed: %v", err)
 		}
 	}()

--- a/xds/server_ext_test.go
+++ b/xds/server_ext_test.go
@@ -145,11 +145,11 @@ func (s) TestServingModeChanges(t *testing.T) {
 		t.Fatalf("Failed to create an xDS enabled gRPC server: %v", err)
 	}
 
+	defer server.Stop()
+
 	// Set the server in the stub and start the test service.
 	stub.S = server
 	stubserver.StartTestService(t, stub)
-
-	defer server.Stop()
 
 	go func() {
 		if err := server.Serve(lis); err != nil {
@@ -293,11 +293,11 @@ func (s) TestResourceNotFoundRDS(t *testing.T) {
 		t.Fatalf("Failed to create an xDS enabled gRPC server: %v", err)
 	}
 
+	defer server.Stop()
+
 	// Set the server in the stub and start the test service.
 	stub.S = server
 	stubserver.StartTestService(t, stub)
-
-	defer server.Stop()
 
 	go func() {
 		if err := server.Serve(lis); err != nil {

--- a/xds/server_ext_test.go
+++ b/xds/server_ext_test.go
@@ -146,14 +146,10 @@ func (s) TestServingModeChanges(t *testing.T) {
 	if stub.S, err = xds.NewGRPCServer(sopts...); err != nil {
 		t.Fatalf("Failed to create an xDS enabled gRPC server: %v", err)
 	}
+	stub.Listener = lis
 	stubserver.StartTestService(t, stub, sopts...)
 	defer stub.S.Stop()
 
-	go func() {
-		if err := stub.S.Serve(lis); err != nil {
-			t.Errorf("Serve() failed: %v", err)
-		}
-	}()
 	cc, err := grpc.NewClient(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		t.Fatalf("failed to dial local test server: %v", err)
@@ -290,14 +286,9 @@ func (s) TestResourceNotFoundRDS(t *testing.T) {
 	if stub.S, err = xds.NewGRPCServer(sopts...); err != nil {
 		t.Fatalf("Failed to create an xDS enabled gRPC server: %v", err)
 	}
+	stub.Listener = lis
 	stubserver.StartTestService(t, stub, sopts...)
 	defer stub.S.Stop()
-
-	go func() {
-		if err := stub.S.Serve(lis); err != nil {
-			t.Errorf("Serve() failed: %v", err)
-		}
-	}()
 
 	cc, err := grpc.NewClient(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {

--- a/xds/server_ext_test.go
+++ b/xds/server_ext_test.go
@@ -144,7 +144,6 @@ func (s) TestServingModeChanges(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create an xDS enabled gRPC server: %v", err)
 	}
-
 	defer server.Stop()
 
 	// Set the server in the stub and start the test service.

--- a/xds/server_ext_test.go
+++ b/xds/server_ext_test.go
@@ -125,8 +125,6 @@ func (s) TestServingModeChanges(t *testing.T) {
 		}
 	})
 
-	sopts := []grpc.ServerOption{grpc.Creds(insecure.NewCredentials()), modeChangeOpt, xds.BootstrapContentsForTesting(bootstrapContents)}
-
 	stub := &stubserver.StubServer{
 		EmptyCallF: func(context.Context, *testpb.Empty) (*testpb.Empty, error) {
 			return &testpb.Empty{}, nil
@@ -143,6 +141,7 @@ func (s) TestServingModeChanges(t *testing.T) {
 			}
 		},
 	}
+	sopts := []grpc.ServerOption{grpc.Creds(insecure.NewCredentials()), modeChangeOpt, xds.BootstrapContentsForTesting(bootstrapContents)}
 	if stub.S, err = xds.NewGRPCServer(sopts...); err != nil {
 		t.Fatalf("Failed to create an xDS enabled gRPC server: %v", err)
 	}
@@ -265,8 +264,6 @@ func (s) TestResourceNotFoundRDS(t *testing.T) {
 		}
 	})
 
-	sopts := []grpc.ServerOption{grpc.Creds(insecure.NewCredentials()), modeChangeOpt, xds.BootstrapContentsForTesting(bootstrapContents)}
-
 	stub := &stubserver.StubServer{
 		EmptyCallF: func(context.Context, *testpb.Empty) (*testpb.Empty, error) {
 			return &testpb.Empty{}, nil
@@ -283,6 +280,7 @@ func (s) TestResourceNotFoundRDS(t *testing.T) {
 			}
 		},
 	}
+	sopts := []grpc.ServerOption{grpc.Creds(insecure.NewCredentials()), modeChangeOpt, xds.BootstrapContentsForTesting(bootstrapContents)}
 	if stub.S, err = xds.NewGRPCServer(sopts...); err != nil {
 		t.Fatalf("Failed to create an xDS enabled gRPC server: %v", err)
 	}

--- a/xds/server_ext_test.go
+++ b/xds/server_ext_test.go
@@ -126,6 +126,7 @@ func (s) TestServingModeChanges(t *testing.T) {
 	})
 
 	stub := &stubserver.StubServer{
+		Listener: lis,
 		EmptyCallF: func(context.Context, *testpb.Empty) (*testpb.Empty, error) {
 			return &testpb.Empty{}, nil
 		},
@@ -145,8 +146,7 @@ func (s) TestServingModeChanges(t *testing.T) {
 	if stub.S, err = xds.NewGRPCServer(sopts...); err != nil {
 		t.Fatalf("Failed to create an xDS enabled gRPC server: %v", err)
 	}
-	stub.Listener = lis
-	stubserver.StartTestService(t, stub, sopts...)
+	stubserver.StartTestService(t, stub)
 	defer stub.S.Stop()
 	cc, err := grpc.NewClient(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
@@ -264,6 +264,7 @@ func (s) TestResourceNotFoundRDS(t *testing.T) {
 	})
 
 	stub := &stubserver.StubServer{
+		Listener: lis,
 		EmptyCallF: func(context.Context, *testpb.Empty) (*testpb.Empty, error) {
 			return &testpb.Empty{}, nil
 		},
@@ -283,8 +284,7 @@ func (s) TestResourceNotFoundRDS(t *testing.T) {
 	if stub.S, err = xds.NewGRPCServer(sopts...); err != nil {
 		t.Fatalf("Failed to create an xDS enabled gRPC server: %v", err)
 	}
-	stub.Listener = lis
-	stubserver.StartTestService(t, stub, sopts...)
+	stubserver.StartTestService(t, stub)
 	defer stub.S.Stop()
 
 	cc, err := grpc.NewClient(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))

--- a/xds/server_ext_test.go
+++ b/xds/server_ext_test.go
@@ -124,6 +124,7 @@ func (s) TestServingModeChanges(t *testing.T) {
 			serving.Fire()
 		}
 	})
+
 	stub := &stubserver.StubServer{
 		EmptyCallF: func(context.Context, *testpb.Empty) (*testpb.Empty, error) {
 			return &testpb.Empty{}, nil
@@ -146,7 +147,6 @@ func (s) TestServingModeChanges(t *testing.T) {
 	}
 	defer server.Stop()
 
-	// Set the server in the stub and start the test service.
 	stub.S = server
 	stubserver.StartTestService(t, stub)
 
@@ -291,10 +291,8 @@ func (s) TestResourceNotFoundRDS(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create an xDS enabled gRPC server: %v", err)
 	}
-
 	defer server.Stop()
 
-	// Set the server in the stub and start the test service.
 	stub.S = server
 	stubserver.StartTestService(t, stub)
 

--- a/xds/server_ext_test.go
+++ b/xds/server_ext_test.go
@@ -148,7 +148,6 @@ func (s) TestServingModeChanges(t *testing.T) {
 	stub.Listener = lis
 	stubserver.StartTestService(t, stub, sopts...)
 	defer stub.S.Stop()
-
 	cc, err := grpc.NewClient(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		t.Fatalf("failed to dial local test server: %v", err)

--- a/xds/server_ext_test.go
+++ b/xds/server_ext_test.go
@@ -35,6 +35,7 @@ import (
 	"google.golang.org/grpc/internal"
 	"google.golang.org/grpc/internal/grpcsync"
 	"google.golang.org/grpc/internal/grpctest"
+	"google.golang.org/grpc/internal/stubserver"
 	"google.golang.org/grpc/internal/testutils"
 	"google.golang.org/grpc/internal/testutils/xds/e2e"
 	"google.golang.org/grpc/status"
@@ -65,27 +66,6 @@ const (
 	defaultTestTimeout      = 10 * time.Second
 	defaultTestShortTimeout = 10 * time.Millisecond // For events expected to *not* happen.
 )
-
-type testService struct {
-	testgrpc.UnimplementedTestServiceServer
-}
-
-func (*testService) EmptyCall(context.Context, *testpb.Empty) (*testpb.Empty, error) {
-	return &testpb.Empty{}, nil
-}
-
-func (*testService) UnaryCall(context.Context, *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
-	return &testpb.SimpleResponse{}, nil
-}
-
-func (*testService) FullDuplexCall(stream testgrpc.TestService_FullDuplexCallServer) error {
-	for {
-		_, err := stream.Recv() // hangs here forever if stream doesn't shut down...doesn't receive EOF without any errors
-		if err == io.EOF {
-			return nil
-		}
-	}
-}
 
 func hostPortFromListener(lis net.Listener) (string, uint32, error) {
 	host, p, err := net.SplitHostPort(lis.Addr().String())
@@ -144,13 +124,33 @@ func (s) TestServingModeChanges(t *testing.T) {
 			serving.Fire()
 		}
 	})
-
+	stub := &stubserver.StubServer{
+		EmptyCallF: func(context.Context, *testpb.Empty) (*testpb.Empty, error) {
+			return &testpb.Empty{}, nil
+		},
+		UnaryCallF: func(context.Context, *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
+			return &testpb.SimpleResponse{}, nil
+		},
+		FullDuplexCallF: func(stream testgrpc.TestService_FullDuplexCallServer) error {
+			for {
+				_, err := stream.Recv() // hangs here forever if stream doesn't shut down...doesn't receive EOF without any errors
+				if err == io.EOF {
+					return nil
+				}
+			}
+		},
+	}
 	server, err := xds.NewGRPCServer(grpc.Creds(insecure.NewCredentials()), modeChangeOpt, xds.BootstrapContentsForTesting(bootstrapContents))
 	if err != nil {
 		t.Fatalf("Failed to create an xDS enabled gRPC server: %v", err)
 	}
+
+	// Set the server in the stub and start the test service.
+	stub.S = server
+	stubserver.StartTestService(t, stub)
+
 	defer server.Stop()
-	testgrpc.RegisterTestServiceServer(server, &testService{})
+
 	go func() {
 		if err := server.Serve(lis); err != nil {
 			t.Errorf("Serve() failed: %v", err)
@@ -271,12 +271,34 @@ func (s) TestResourceNotFoundRDS(t *testing.T) {
 		}
 	})
 
+	stub := &stubserver.StubServer{
+		EmptyCallF: func(context.Context, *testpb.Empty) (*testpb.Empty, error) {
+			return &testpb.Empty{}, nil
+		},
+		UnaryCallF: func(context.Context, *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
+			return &testpb.SimpleResponse{}, nil
+		},
+		FullDuplexCallF: func(stream testgrpc.TestService_FullDuplexCallServer) error {
+			for {
+				_, err := stream.Recv() // hangs here forever if stream doesn't shut down...doesn't receive EOF without any errors
+				if err == io.EOF {
+					return nil
+				}
+			}
+		},
+	}
+
 	server, err := xds.NewGRPCServer(grpc.Creds(insecure.NewCredentials()), modeChangeOpt, xds.BootstrapContentsForTesting(bootstrapContents))
 	if err != nil {
 		t.Fatalf("Failed to create an xDS enabled gRPC server: %v", err)
 	}
+
+	// Set the server in the stub and start the test service.
+	stub.S = server
+	stubserver.StartTestService(t, stub)
+
 	defer server.Stop()
-	testgrpc.RegisterTestServiceServer(server, &testService{})
+
 	go func() {
 		if err := server.Serve(lis); err != nil {
 			t.Errorf("Serve() failed: %v", err)


### PR DESCRIPTION
Partially Addresses: https://github.com/grpc/grpc-go/issues/7291

RELEASE NOTES: None