### PR TITLE
orca: switching to stubserver in tests instead of testservice implementation

### DIFF
--- a/orca/service_test.go
+++ b/orca/service_test.go
@@ -153,10 +153,6 @@ func (s) TestE2E_CustomBackendMetrics_OutOfBand(t *testing.T) {
 		currentRequests := requests
 		mu.Unlock()
 
-		if currentRequests == numRequests {
-			break
-		}
-
 		wantProto := &v3orcapb.OrcaLoadReport{
 			CpuUtilization:         50.0,
 			MemUtilization:         0.9,
@@ -179,6 +175,10 @@ func (s) TestE2E_CustomBackendMetrics_OutOfBand(t *testing.T) {
 	if _, err := testStub.EmptyCall(ctx, &testpb.Empty{}); err != nil {
 		t.Fatalf("EmptyCall failed: %v", err)
 	}
+
+	// A short delay to ensure the metrics deletion is processed.
+	time.Sleep(shortReportingInterval * 2)
+
 	// Wait for the server to push empty metrics which indicate the processing
 	// of the above EmptyCall RPC.
 	for {

--- a/orca/service_test.go
+++ b/orca/service_test.go
@@ -172,9 +172,6 @@ func (s) TestE2E_CustomBackendMetrics_OutOfBand(t *testing.T) {
 		t.Fatalf("EmptyCall failed: %v", err)
 	}
 
-	// A short delay to ensure the metrics deletion is processed.
-	time.Sleep(shortReportingInterval * 2)
-
 	// Wait for the server to push empty metrics which indicate the processing
 	// of the above EmptyCall RPC.
 	for {

--- a/orca/service_test.go
+++ b/orca/service_test.go
@@ -90,17 +90,15 @@ func (s) TestE2E_CustomBackendMetrics_OutOfBand(t *testing.T) {
 		},
 	}
 
+	// Assign the gRPC server to the stub server and start serving.
+	stub.Listener = lis
+	stub.S = grpc.NewServer()
 	// Register the OpenRCAService with a very short metrics reporting interval.
-	s := grpc.NewServer()
-	if err := orca.Register(s, opts); err != nil {
+	if err := orca.Register(stub.S, opts); err != nil {
 		t.Fatalf("orca.EnableOutOfBandMetricsReportingForTesting() failed: %v", err)
 	}
-
-	// Assign the gRPC server to the stub server and start serving.
-	stub.S = s
 	stubserver.StartTestService(t, stub)
-	go s.Serve(lis)
-	defer s.Stop()
+	defer stub.S.Stop()
 	t.Logf("Started gRPC server at %s...", lis.Addr().String())
 
 	// Dial the test server.

--- a/orca/service_test.go
+++ b/orca/service_test.go
@@ -72,6 +72,7 @@ func (s) TestE2E_CustomBackendMetrics_OutOfBand(t *testing.T) {
 		UnaryCallF: func(ctx context.Context, req *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
 			mu.Lock()
 			requests++
+
 			smr.SetNamedUtilization(requestsMetricKey, float64(requests)*0.01)
 			mu.Unlock()
 

--- a/orca/service_test.go
+++ b/orca/service_test.go
@@ -29,6 +29,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/internal/pretty"
+	"google.golang.org/grpc/internal/stubserver"
 	"google.golang.org/grpc/internal/testutils"
 	"google.golang.org/grpc/orca"
 	"google.golang.org/grpc/orca/internal"
@@ -47,33 +48,6 @@ const requestsMetricKey = "test-service-requests"
 // An implementation of grpc_testing.TestService for the purpose of this test.
 // We cannot use the StubServer approach here because we need to register the
 // OpenRCAService as well on the same gRPC server.
-type testServiceImpl struct {
-	mu       sync.Mutex
-	requests int64
-
-	testgrpc.TestServiceServer
-	smr orca.ServerMetricsRecorder
-}
-
-func (t *testServiceImpl) UnaryCall(context.Context, *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
-	t.mu.Lock()
-	t.requests++
-	t.mu.Unlock()
-
-	t.smr.SetNamedUtilization(requestsMetricKey, float64(t.requests)*0.01)
-	t.smr.SetCPUUtilization(50.0)
-	t.smr.SetMemoryUtilization(0.9)
-	t.smr.SetApplicationUtilization(1.2)
-	return &testpb.SimpleResponse{}, nil
-}
-
-func (t *testServiceImpl) EmptyCall(context.Context, *testpb.Empty) (*testpb.Empty, error) {
-	t.smr.DeleteNamedUtilization(requestsMetricKey)
-	t.smr.SetCPUUtilization(0)
-	t.smr.SetMemoryUtilization(0)
-	t.smr.DeleteApplicationUtilization()
-	return &testpb.Empty{}, nil
-}
 
 // TestE2E_CustomBackendMetrics_OutOfBand tests the injection of out-of-band
 // custom backend metrics from the server application, and verifies that
@@ -93,6 +67,29 @@ func (s) TestE2E_CustomBackendMetrics_OutOfBand(t *testing.T) {
 	opts := orca.ServiceOptions{MinReportingInterval: shortReportingInterval, ServerMetricsProvider: smr}
 	internal.AllowAnyMinReportingInterval.(func(*orca.ServiceOptions))(&opts)
 
+	var requests int
+	var mu sync.Mutex
+	stub := &stubserver.StubServer{
+		UnaryCallF: func(ctx context.Context, req *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
+			mu.Lock()
+			requests++
+			mu.Unlock()
+
+			smr.SetNamedUtilization(requestsMetricKey, float64(requests)*0.01)
+			smr.SetCPUUtilization(50.0)
+			smr.SetMemoryUtilization(0.9)
+			smr.SetApplicationUtilization(1.2)
+			return &testpb.SimpleResponse{}, nil
+		},
+		EmptyCallF: func(ctx context.Context, req *testpb.Empty) (*testpb.Empty, error) {
+			smr.DeleteNamedUtilization(requestsMetricKey)
+			smr.SetCPUUtilization(0)
+			smr.SetMemoryUtilization(0)
+			smr.DeleteApplicationUtilization()
+			return &testpb.Empty{}, nil
+		},
+	}
+
 	// Register the OpenRCAService with a very short metrics reporting interval.
 	s := grpc.NewServer()
 	if err := orca.Register(s, opts); err != nil {
@@ -100,7 +97,8 @@ func (s) TestE2E_CustomBackendMetrics_OutOfBand(t *testing.T) {
 	}
 
 	// Register the test service implementation on the same grpc server, and start serving.
-	testgrpc.RegisterTestServiceServer(s, &testServiceImpl{smr: smr})
+	stub.S = s
+	stubserver.StartTestService(t, stub)
 	go s.Serve(lis)
 	defer s.Stop()
 	t.Logf("Started gRPC server at %s...", lis.Addr().String())
@@ -112,11 +110,11 @@ func (s) TestE2E_CustomBackendMetrics_OutOfBand(t *testing.T) {
 	}
 	defer cc.Close()
 
-	// Spawn a goroutine which sends 20 unary RPCs to the test server. This
+	// Spawn a goroutine which sends 20 unary RPCs to the stub server. This
 	// will trigger the injection of custom backend metrics from the
-	// testServiceImpl.
+	// stubServer.
 	const numRequests = 20
-	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	testStub := testgrpc.NewTestServiceClient(cc)
 	errCh := make(chan error, 1)
@@ -138,16 +136,17 @@ func (s) TestE2E_CustomBackendMetrics_OutOfBand(t *testing.T) {
 		t.Fatalf("Failed to create a stream for out-of-band metrics")
 	}
 
+	// Wait for the goroutine to finish before processing metrics.
+	if err := <-errCh; err != nil {
+		t.Fatal(err)
+	}
+
 	// Wait for the server to push metrics which indicate the completion of all
 	// the unary RPCs made from the above goroutine.
 	for {
 		select {
 		case <-ctx.Done():
 			t.Fatal("Timeout when waiting for out-of-band custom backend metrics to match expected values")
-		case err := <-errCh:
-			if err != nil {
-				t.Fatal(err)
-			}
 		default:
 		}
 

--- a/orca/service_test.go
+++ b/orca/service_test.go
@@ -68,7 +68,6 @@ func (s) TestE2E_CustomBackendMetrics_OutOfBand(t *testing.T) {
 	stub := &stubserver.StubServer{
 		Listener: lis,
 		UnaryCallF: func(ctx context.Context, req *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
-
 			newRequests := requests.Add(1)
 
 			smr.SetNamedUtilization(requestsMetricKey, float64(newRequests)*0.01)

--- a/orca/service_test.go
+++ b/orca/service_test.go
@@ -138,11 +138,11 @@ func (s) TestE2E_CustomBackendMetrics_OutOfBand(t *testing.T) {
 		select {
 		case <-ctx.Done():
 			t.Fatal("Timeout when waiting for out-of-band custom backend metrics to match expected values")
-		default:
 		case err := <-errCh:
 			if err != nil {
 				t.Fatal(err)
 			}
+		default:
 		}
 
 		mu.Lock()

--- a/orca/service_test.go
+++ b/orca/service_test.go
@@ -63,16 +63,20 @@ func (s) TestE2E_CustomBackendMetrics_OutOfBand(t *testing.T) {
 	opts := orca.ServiceOptions{MinReportingInterval: shortReportingInterval, ServerMetricsProvider: smr}
 	internal.AllowAnyMinReportingInterval.(func(*orca.ServiceOptions))(&opts)
 
-	var requests int
-	var mu sync.Mutex
+	var (
+		requests int64
+		mu       sync.Mutex
+	)
 
 	stub := &stubserver.StubServer{
 		UnaryCallF: func(ctx context.Context, req *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
 			mu.Lock()
-			requests++
+			currentRequests := requests + 1
+			requests = currentRequests
 			mu.Unlock()
 
-			smr.SetNamedUtilization(requestsMetricKey, float64(requests)*0.01)
+			utilizationValue := float64(currentRequests) * 0.01
+			smr.SetNamedUtilization(requestsMetricKey, utilizationValue)
 			smr.SetCPUUtilization(50.0)
 			smr.SetMemoryUtilization(0.9)
 			smr.SetApplicationUtilization(1.2)
@@ -146,17 +150,18 @@ func (s) TestE2E_CustomBackendMetrics_OutOfBand(t *testing.T) {
 		}
 
 		mu.Lock()
-		if requests == numRequests {
-			mu.Unlock()
+		currentRequests := requests
+		mu.Unlock()
+
+		if currentRequests == numRequests {
 			break
 		}
-		mu.Unlock()
 
 		wantProto := &v3orcapb.OrcaLoadReport{
 			CpuUtilization:         50.0,
 			MemUtilization:         0.9,
 			ApplicationUtilization: 1.2,
-			Utilization:            map[string]float64{requestsMetricKey: float64(requests) * 0.01},
+			Utilization:            map[string]float64{requestsMetricKey: float64(currentRequests) * 0.01},
 		}
 		gotProto, err := stream.Recv()
 		if err != nil {

--- a/orca/service_test.go
+++ b/orca/service_test.go
@@ -63,7 +63,7 @@ func (s) TestE2E_CustomBackendMetrics_OutOfBand(t *testing.T) {
 	opts := orca.ServiceOptions{MinReportingInterval: shortReportingInterval, ServerMetricsProvider: smr}
 	internal.AllowAnyMinReportingInterval.(func(*orca.ServiceOptions))(&opts)
 
-	var requests int
+	var requests int64
 	var mu sync.Mutex
 
 	const numRequests = 20

--- a/orca/service_test.go
+++ b/orca/service_test.go
@@ -95,6 +95,7 @@ func (s) TestE2E_CustomBackendMetrics_OutOfBand(t *testing.T) {
 		t.Fatalf("orca.EnableOutOfBandMetricsReportingForTesting() failed: %v", err)
 	}
 
+	// Assign the gRPC server to the stub server and start serving.
 	stub.S = s
 	stubserver.StartTestService(t, stub)
 	go s.Serve(lis)

--- a/orca/service_test.go
+++ b/orca/service_test.go
@@ -174,7 +174,6 @@ func (s) TestE2E_CustomBackendMetrics_OutOfBand(t *testing.T) {
 	if _, err := testStub.EmptyCall(ctx, &testpb.Empty{}); err != nil {
 		t.Fatalf("EmptyCall failed: %v", err)
 	}
-
 	// Wait for the server to push empty metrics which indicate the processing
 	// of the above EmptyCall RPC.
 	for {

--- a/orca/service_test.go
+++ b/orca/service_test.go
@@ -149,15 +149,11 @@ func (s) TestE2E_CustomBackendMetrics_OutOfBand(t *testing.T) {
 		default:
 		}
 
-		mu.Lock()
-		currentRequests := requests
-		mu.Unlock()
-
 		wantProto := &v3orcapb.OrcaLoadReport{
 			CpuUtilization:         50.0,
 			MemUtilization:         0.9,
 			ApplicationUtilization: 1.2,
-			Utilization:            map[string]float64{requestsMetricKey: float64(currentRequests) * 0.01},
+			Utilization:            map[string]float64{requestsMetricKey: float64(requests) * 0.01},
 		}
 		gotProto, err := stream.Recv()
 		if err != nil {

--- a/orca/service_test.go
+++ b/orca/service_test.go
@@ -114,7 +114,7 @@ func (s) TestE2E_CustomBackendMetrics_OutOfBand(t *testing.T) {
 	// will trigger the injection of custom backend metrics from the
 	// stubServer.
 	const numRequests = 20
-	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*defaultTestTimeout)
 	defer cancel()
 	testStub := testgrpc.NewTestServiceClient(cc)
 	errCh := make(chan error, 1)


### PR DESCRIPTION
Partially Addresses: https://github.com/grpc/grpc-go/issues/7291

RELEASE NOTES: None