### PR TITLE
loopyWriter: fix dataItem.h

### DIFF
--- a/internal/transport/controlbuf.go
+++ b/internal/transport/controlbuf.go
@@ -1011,7 +1011,7 @@ func (l *loopyWriter) processData() (bool, error) {
 	}
 	str.bytesOutStanding += size
 	l.sendQuota -= uint32(size)
-	dataItem.h = dataItem.h[hSize:]
+	dataItem.h = nil
 
 	if remainingBytes == 0 { // All the data from that message was written out.
 		_ = dataItem.reader.Close()


### PR DESCRIPTION
```go
	hSize := min(maxSize, len(dataItem.h))
        ...
	if hSize != 0 && dSize == 0 {
		buf = &dataItem.h
        }
```

If `hSize` is less than `len(dataItem.h)`, we still send the whole header.
So afterward, we need to set it nil, instead of using the wrong `hSize`