### PR TITLE
Enhance parseDialTarget Function to Support Named Pipes

### DIFF
--- a/internal/transport/http_util.go
+++ b/internal/transport/http_util.go
@@ -457,7 +457,7 @@ func parseDialTarget(target string) (string, string) {
 		}
 		scheme := t.Scheme
 		addr := t.Path
-		if scheme == "unix" {
+		if scheme == "unix" || scheme == "npipe" {
 			if addr == "" {
 				addr = t.Host
 			}

--- a/internal/transport/http_util_test.go
+++ b/internal/transport/http_util_test.go
@@ -210,6 +210,7 @@ func (s) TestParseDialTarget(t *testing.T) {
 		{"https://google.com:443", "tcp", "https://google.com:443"},
 		{"dns:///google.com", "tcp", "dns:///google.com"},
 		{"/unix/socket/address", "tcp", "/unix/socket/address"},
+		{"npipe:////./pipe/pipe-name", "npipe", "//./pipe/pipe-name"},
 	} {
 		gotNet, gotAddr := parseDialTarget(test.target)
 		if gotNet != test.wantNet || gotAddr != test.wantAddr {


### PR DESCRIPTION
This update modifies the `parseDialTarget` function to support named pipes in addition to existing protocols. The function now checks for the `npipe` scheme, returning the appropriate network and address when a named pipe is specified. 
The corresponding test case for TestParseDialTarget has been updated to include scenarios for named pipe targets, ensuring correct parsing and validation of input.


**Changes made:**

- Updated the parseDialTarget function to handle the "npipe" scheme alongside the existing "unix" scheme.

- Added new test cases in TestParseDialTarget to validate the functionality for named pipes, enhancing test coverage for different address formats.

RELEASE NOTES: None