### PR TITLE
vet: Use go1.22 instead of go1.21 for tidy and staticcheck

### DIFF
--- a/scripts/vet.sh
+++ b/scripts/vet.sh
@@ -97,13 +97,13 @@ for MOD_FILE in $(find . -name 'go.mod'); do
   gofmt -s -d -l . 2>&1 | fail_on_output
   goimports -l . 2>&1 | not grep -vE "\.pb\.go"
 
-  go mod tidy -compat=1.21
+  go mod tidy -compat=1.22
   git status --porcelain 2>&1 | fail_on_output || \
     (git status; git --no-pager diff; exit 1)
 
   # - Collection of static analysis checks
   SC_OUT="$(mktemp)"
-  staticcheck -go 1.21 -checks 'all' ./... >"${SC_OUT}" || true
+  staticcheck -go 1.22 -checks 'all' ./... >"${SC_OUT}" || true
 
   # Error for anything other than checks that need exclusions.
   noret_grep -v "(ST1000)" "${SC_OUT}" | noret_grep -v "(SA1019)" | noret_grep -v "(ST1003)" | noret_grep -v "(ST1019)\|\(other import of\)" | not grep -v "(SA4000)"


### PR DESCRIPTION
grpc-go requires go version >= 1.22. This change bumps the Go version used in vet.sh to 1.22. This fixes error similar to the following:
```
Error: -: /opt/hostedtoolcache/go/1.23.2/x64/src/runtime/time.go:204:17: cannot range over 3 (untyped int constant): requires go1.22 or later (compile)
```

RELEASE NOTES: None