### PR TITLE
4552 empty response on enable decompression

### DIFF
--- a/rpc_util.go
+++ b/rpc_util.go
@@ -876,34 +876,36 @@ func decompress(compressor encoding.Compressor, d mem.BufferSlice, maxReceiveMes
 	if err != nil {
 		return nil, 0, err
 	}
+
 	// TODO: Can/should this still be preserved with the new BufferSlice API? Are
+	//  there any actual benefits to allocating a single large buffer instead of
+	//  multiple smaller ones?
+	//if sizer, ok := compressor.(interface {
+	//	DecompressedSize(compressedBytes []byte) int
+	//}); ok {
+	//	if size := sizer.DecompressedSize(d); size >= 0 {
+	//		if size > maxReceiveMessageSize {
+	//			return nil, size, nil
+	//		}
+	//		// size is used as an estimate to size the buffer, but we
+	//		// will read more data if available.
+	//		// +MinRead so ReadFrom will not reallocate if size is correct.
+	//		//
+	//		// TODO: If we ensure that the buffer size is the same as the DecompressedSize,
+	//		// we can also utilize the recv buffer pool here.
+	//		buf := bytes.NewBuffer(make([]byte, 0, size+bytes.MinRead))
+	//		bytesRead, err := buf.ReadFrom(io.LimitReader(dcReader, int64(maxReceiveMessageSize)+1))
+	//		return buf.Bytes(), int(bytesRead), err
+	//	}
+	//}
+
 	var out mem.BufferSlice
-	_, err = io.Copy(mem.NewWriter(&out, pool), io.LimitReader(dcReader, int64(maxReceiveMessageSize)))
+	_, err = io.Copy(mem.NewWriter(&out, pool), io.LimitReader(dcReader, int64(maxReceiveMessageSize)+1))
 	if err != nil {
 		out.Free()
 		return nil, 0, err
 	}
-	if err = checkReceiveMessageOverflow(int64(out.Len()), int64(maxReceiveMessageSize), dcReader); err != nil {
-		return nil, out.Len() + 1, err
-	}
-	return out, len(out), err
-}
-
-// checkReceiveMessageOverflow checks if the number of bytes read from the stream exceeds
-// the maximum receive message size allowed by the client. If the `readBytes` equals
-// `maxReceiveMessageSize`, the function attempts to read one more byte from the `dcReader`
-// to detect if there's an overflow.
-//
-// If additional data is read, or an error other than `io.EOF` is encountered, the function
-// returns an error indicating that the message size has exceeded the permissible limit.
-func checkReceiveMessageOverflow(readBytes, maxReceiveMessageSize int64, dcReader io.Reader) error {
-	if readBytes == maxReceiveMessageSize {
-		b := make([]byte, 1)
-		if n, err := dcReader.Read(b); n > 0 || err != io.EOF {
-			return fmt.Errorf("overflow: message larger than max size receivable by client (%d bytes)", maxReceiveMessageSize)
-		}
-	}
-	return nil
+	return out, out.Len(), nil
 }
 
 // For the two compressor parameters, both should not be set, but if they are,

--- a/rpc_util_test.go
+++ b/rpc_util_test.go
@@ -21,12 +21,14 @@ package grpc
 import (
 	"bytes"
 	"compress/gzip"
+	"errors"
 	"io"
 	"math"
 	"reflect"
 	"testing"
 
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/encoding"
 	protoenc "google.golang.org/grpc/encoding/proto"
 	"google.golang.org/grpc/internal/testutils"
 	"google.golang.org/grpc/internal/transport"
@@ -289,4 +291,131 @@ func BenchmarkGZIPCompressor512KiB(b *testing.B) {
 
 func BenchmarkGZIPCompressor1MiB(b *testing.B) {
 	bmCompressor(b, 1024*1024, NewGZIPCompressor())
+}
+
+type mockCompressor struct {
+	DecompressedData []byte
+	ErrDecompress    error
+	Size             int
+	CustomReader     io.Reader
+}
+
+func (m *mockCompressor) Compress(w io.Writer) (io.WriteCloser, error) {
+	return nil, nil
+}
+
+func (m *mockCompressor) Decompress(r io.Reader) (io.Reader, error) {
+	if m.ErrDecompress != nil {
+		return nil, m.ErrDecompress
+	}
+	if m.CustomReader != nil {
+		return m.CustomReader, nil
+	}
+	return bytes.NewReader(m.DecompressedData), nil
+}
+
+func (m *mockCompressor) DecompressedSize(compressedBytes mem.BufferSlice) int {
+	return m.Size
+}
+
+func (m *mockCompressor) Name() string {
+	return "mockCompressor"
+}
+
+type ErrorReader struct{}
+
+func (e *ErrorReader) Read(p []byte) (n int, err error) {
+	return 0, errors.New("simulated io.Copy read error")
+}
+
+func TestDecompress(t *testing.T) {
+	tests := []struct {
+		name                  string
+		compressor            encoding.Compressor
+		input                 mem.BufferSlice
+		maxReceiveMessageSize int
+		want                  mem.BufferSlice
+		size                  int
+		error                 error
+	}{
+		{
+			name: "Successful decompression",
+			compressor: &mockCompressor{
+				DecompressedData: []byte("decompressed data"),
+				Size:             17,
+			},
+			input:                 mem.BufferSlice{},
+			maxReceiveMessageSize: 100,
+			want: func() mem.BufferSlice {
+				decompressed := []byte("decompressed data")
+				return mem.BufferSlice{mem.NewBuffer(&decompressed, nil)}
+			}(),
+			size:  1,
+			error: nil,
+		},
+		{
+			name: "Error during decompression",
+			compressor: &mockCompressor{
+				ErrDecompress: errors.New("decompression error"),
+			},
+			input:                 mem.BufferSlice{},
+			maxReceiveMessageSize: 100,
+			want:                  nil,
+			size:                  0,
+			error:                 errors.New("decompression error"),
+		},
+		{
+			name: "Buffer overflow",
+			compressor: &mockCompressor{
+				DecompressedData: []byte("overflow data"),
+				Size:             100,
+			},
+			input:                 mem.BufferSlice{},
+			maxReceiveMessageSize: 5,
+			want:                  nil,
+			size:                  6,
+			error:                 errors.New("overflow: message larger than max size receivable by client (5 bytes)"),
+		},
+		{
+			name: "MaxInt64 receive size with small data",
+			compressor: &mockCompressor{
+				DecompressedData: []byte("small data"),
+				Size:             10,
+			},
+			input:                 mem.BufferSlice{},
+			maxReceiveMessageSize: math.MaxInt64,
+			want: func() mem.BufferSlice {
+				smallDecompressed := []byte("small data, small data ")
+				return mem.BufferSlice{mem.NewBuffer(&smallDecompressed, nil)}
+			}(),
+			size:  1,
+			error: nil,
+		}, {
+			name: "Error during io.Copy",
+			compressor: &mockCompressor{
+				CustomReader: &ErrorReader{},
+			},
+			input:                 mem.BufferSlice{},
+			maxReceiveMessageSize: 100,
+			want:                  nil,
+			size:                  0,
+			error:                 errors.New("simulated io.Copy read error"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			output, size, err := decompress(tt.compressor, tt.input, tt.maxReceiveMessageSize, nil)
+			// check both err and tt.error are either nil or non-nil, the condition will be false
+			if (err != nil) != (tt.error != nil) {
+				t.Errorf("unexpected error state: got err=%v, want err=%v", err, tt.error)
+			}
+			if size != tt.size {
+				t.Errorf("decompress() size = %d, want %d", size, tt.size)
+			}
+			if len(tt.want) != len(output) {
+				t.Errorf("decompress() output length = %d, want %d", output, tt.want)
+			}
+		})
+	}
 }

--- a/rpc_util_test.go
+++ b/rpc_util_test.go
@@ -21,14 +21,12 @@ package grpc
 import (
 	"bytes"
 	"compress/gzip"
-	"errors"
 	"io"
 	"math"
 	"reflect"
 	"testing"
 
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/encoding"
 	protoenc "google.golang.org/grpc/encoding/proto"
 	"google.golang.org/grpc/internal/testutils"
 	"google.golang.org/grpc/internal/transport"
@@ -291,131 +289,4 @@ func BenchmarkGZIPCompressor512KiB(b *testing.B) {
 
 func BenchmarkGZIPCompressor1MiB(b *testing.B) {
 	bmCompressor(b, 1024*1024, NewGZIPCompressor())
-}
-
-type mockCompressor struct {
-	DecompressedData []byte
-	ErrDecompress    error
-	Size             int
-	CustomReader     io.Reader
-}
-
-func (m *mockCompressor) Compress(w io.Writer) (io.WriteCloser, error) {
-	return nil, nil
-}
-
-func (m *mockCompressor) Decompress(r io.Reader) (io.Reader, error) {
-	if m.ErrDecompress != nil {
-		return nil, m.ErrDecompress
-	}
-	if m.CustomReader != nil {
-		return m.CustomReader, nil
-	}
-	return bytes.NewReader(m.DecompressedData), nil
-}
-
-func (m *mockCompressor) DecompressedSize(compressedBytes mem.BufferSlice) int {
-	return m.Size
-}
-
-func (m *mockCompressor) Name() string {
-	return "mockCompressor"
-}
-
-type ErrorReader struct{}
-
-func (e *ErrorReader) Read(p []byte) (n int, err error) {
-	return 0, errors.New("simulated io.Copy read error")
-}
-
-func TestDecompress(t *testing.T) {
-	tests := []struct {
-		name                  string
-		compressor            encoding.Compressor
-		input                 mem.BufferSlice
-		maxReceiveMessageSize int
-		want                  mem.BufferSlice
-		size                  int
-		error                 error
-	}{
-		{
-			name: "Successful decompression",
-			compressor: &mockCompressor{
-				DecompressedData: []byte("decompressed data"),
-				Size:             17,
-			},
-			input:                 mem.BufferSlice{},
-			maxReceiveMessageSize: 100,
-			want: func() mem.BufferSlice {
-				decompressed := []byte("decompressed data")
-				return mem.BufferSlice{mem.NewBuffer(&decompressed, nil)}
-			}(),
-			size:  1,
-			error: nil,
-		},
-		{
-			name: "Error during decompression",
-			compressor: &mockCompressor{
-				ErrDecompress: errors.New("decompression error"),
-			},
-			input:                 mem.BufferSlice{},
-			maxReceiveMessageSize: 100,
-			want:                  nil,
-			size:                  0,
-			error:                 errors.New("decompression error"),
-		},
-		{
-			name: "Buffer overflow",
-			compressor: &mockCompressor{
-				DecompressedData: []byte("overflow data"),
-				Size:             100,
-			},
-			input:                 mem.BufferSlice{},
-			maxReceiveMessageSize: 5,
-			want:                  nil,
-			size:                  6,
-			error:                 errors.New("overflow: message larger than max size receivable by client (5 bytes)"),
-		},
-		{
-			name: "MaxInt64 receive size with small data",
-			compressor: &mockCompressor{
-				DecompressedData: []byte("small data"),
-				Size:             10,
-			},
-			input:                 mem.BufferSlice{},
-			maxReceiveMessageSize: math.MaxInt64,
-			want: func() mem.BufferSlice {
-				smallDecompressed := []byte("small data, small data ")
-				return mem.BufferSlice{mem.NewBuffer(&smallDecompressed, nil)}
-			}(),
-			size:  1,
-			error: nil,
-		}, {
-			name: "Error during io.Copy",
-			compressor: &mockCompressor{
-				CustomReader: &ErrorReader{},
-			},
-			input:                 mem.BufferSlice{},
-			maxReceiveMessageSize: 100,
-			want:                  nil,
-			size:                  0,
-			error:                 errors.New("simulated io.Copy read error"),
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			output, size, err := decompress(tt.compressor, tt.input, tt.maxReceiveMessageSize, nil)
-			// check both err and tt.error are either nil or non-nil, the condition will be false
-			if (err != nil) != (tt.error != nil) {
-				t.Errorf("unexpected error state: got err=%v, want err=%v", err, tt.error)
-			}
-			if size != tt.size {
-				t.Errorf("decompress() size = %d, want %d", size, tt.size)
-			}
-			if len(tt.want) != len(output) {
-				t.Errorf("decompress() output length = %d, want %d", output, tt.want)
-			}
-		})
-	}
 }


### PR DESCRIPTION
Problem:

#issue no: [#4552](https://github.com/grpc/grpc-go/issues/4552)
Get empty response when compress enabled and maxReceiveMessageSize be maxInt64
Action:

UT Successful decompression
UT Decompressed size exceeds maxReceiveMessageSize
UT Error during decompression
UT Buffer overflow
make the decompress function compatible with calling function

Release note:

NA