### PR TITLE
Make balancer registration threadsafe

### DIFF
--- a/balancer/balancer.go
+++ b/balancer/balancer.go
@@ -52,9 +52,9 @@ var (
 // configs are received by the resolver, and the result will be provided to the
 // Balancer in UpdateClientConnState.
 //
-// NOTE: this function must only be called during initialization time (i.e. in
-// an init() function), and is not thread-safe. If multiple Balancers are
-// registered with the same name, the one registered last will take effect.
+// NOTE: this function is intended to be called during initialization time (i.e.
+// in an init() function). If multiple Balancers are registered with the same
+// name, the one registered last will take effect.
 func Register(b Builder) {
 	name := strings.ToLower(b.Name())
 	if name != b.Name() {


### PR DESCRIPTION
Although it's not a well-supported pattern, I have use-cases where I can't easily register all of my balancer implementations in `init` functions.

Today, any call to `balancer.Register` can trigger a fatal error via an unsynchronized concurrent map access:
```
fatal error: concurrent map read and map write
goroutine 452 [running]:
google.golang.org/grpc/balancer.Get({0x2407e87, 0xa})
	external/org_golang_google_grpc/balancer/balancer.go:88 +0xea
```

This PR is intended to be a very lightweight change that makes it a bit less dangerous to do just-in-time balancer registration. Any existing use-cases should be unaffected, and the performance difference should be negligible.

RELEASE NOTES:
- Made `balancer.Register` threadsafe