### PR TITLE
vet: Don't use GOROOT to set PATH if GOROOT is unset

### DIFF
--- a/scripts/vet.sh
+++ b/scripts/vet.sh
@@ -21,7 +21,10 @@ cleanup() {
 }
 trap cleanup EXIT
 
-PATH="${HOME}/go/bin:${GOROOT}/bin:${PATH}"
+if [ -n "${GOROOT}" ]; then
+  PATH="${GOROOT}/bin:${PATH}"
+fi
+PATH="${HOME}/go/bin:${PATH}"
 go version
 
 if [[ "$1" = "-install" ]]; then


### PR DESCRIPTION
The runner is installing go1.22, but starts using go1.23 when running vet:
```
PATH=/home/runner/go/bin:/bin:/home/runner/go/bin:/opt/hostedtoolcache/go/1.22.8/x64/bin:/snap/bin:/home/runner/.local/bin:/opt/pipx_bin:/home/runner/.cargo/bin:/home/runner/.config/composer/vendor/bin:/usr/local/.ghcup/bin:/home/runner/.dotnet/tools:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin
+ go version
go version go1.23.2 linux/amd64
```
I added logs to debug the go version before vet.sh updates the PATH
```
+ go version
go version go1.22.8 linux/amd64
+ which go
/opt/hostedtoolcache/go/1.22.8/x64/bin/go
+ trap cleanup EXIT
+ PATH=/home/runner/go/bin:/bin:/home/runner/go/bin:/opt/hostedtoolcache/go/1.22.8/x64/bin:/snap/bin:/home/runner/.local/bin:/opt/pipx_bin:/home/runner/.cargo/bin:/home/runner/.config/composer/vendor/bin:/usr/local/.ghcup/bin:/home/runner/.dotnet/tools:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin
+ go version
go version go1.23.2 linux/amd64
+ which go
/bin/go
```
The problem is that `GOROOT` is not set and we're using it to set PATH. 

Example failure: https://github.com/grpc/grpc-go/actions/runs/11409299053/job/31749221269?pr=7759

RELEASE NOTES: None