### PR TITLE
vet: add dependency checks

### DIFF
--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -1,0 +1,45 @@
+name: Dependency Changes
+
+# Trigger on PRs.
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  # Compare dependencies before and after this PR.
+  dependencies:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: true
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: stable
+          cache-dependency-path: "**/*go.sum"
+
+      # Run the commands to generate dependencies before and after and compare.
+      - name: Compare dependencies
+        run: |
+          BEFORE="$(mktemp -d)"
+          AFTER="$(mktemp -d)"
+
+          cp scripts/gen-deps.sh /tmp/  # TODO: delete
+          scripts/gen-deps.sh "${AFTER}"
+          git checkout origin/master
+          cp /tmp/gen-deps.sh scripts/  # TODO: delete
+          scripts/gen-deps.sh "${BEFORE}"
+
+          echo "Comparing dependencies..."
+          # Run grep in a sub-shell since bash does not support ! in the middle of a pipe
+          diff -u0 -r "${BEFORE}" "${AFTER}" | bash -c '! grep -v "@@"'
+          echo "No changes detected."

--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -33,10 +33,8 @@ jobs:
           BEFORE="$(mktemp -d)"
           AFTER="$(mktemp -d)"
 
-          cp scripts/gen-deps.sh /tmp/  # TODO: delete
           scripts/gen-deps.sh "${AFTER}"
           git checkout origin/master
-          cp /tmp/gen-deps.sh scripts/  # TODO: delete
           scripts/gen-deps.sh "${BEFORE}"
 
           echo "Comparing dependencies..."

--- a/scripts/gen-deps.sh
+++ b/scripts/gen-deps.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -e          # Exit on error
+set -o pipefail # Fail a pipe if any sub-command fails.
+
+if [[ "$#" -ne 1 || ! -d "$1" ]]; then
+    echo "Specify a valid output directory as the first parameter."
+    exit 1
+fi
+
+SCRIPTS_DIR="$(dirname "$0")"
+OUTPUT_DIR="$1"
+
+cd "${SCRIPTS_DIR}/.."
+
+git ls-files -- '*.go' | grep -v '\(^\|/\)\(internal\|examples\|benchmark\|interop\|test\|testdata\)\(/\|$\)' | xargs dirname | sort -u | while read d; do
+  pushd "$d" > /dev/null
+  pkg="$(echo "$d" | sed 's;\.;grpc;' | sed 's;/;_;g')"
+  go list -deps . | sort >| "${OUTPUT_DIR}/$pkg"
+  popd > /dev/null
+done


### PR DESCRIPTION
Fixes #7690

This change adds a new GA workflow to compare dependencies before and after a PR.  If they change, it will report a red X.  We will not require this check to pass for merging, but it should be inspected to see if the change in dependencies is reasonable and expected.

RELEASE NOTES: none