### PR TITLE
test: Add unit test for channel state waiting for first resolver update

### DIFF
--- a/test/clientconn_state_transition_test.go
+++ b/test/clientconn_state_transition_test.go
@@ -622,7 +622,7 @@ func (s) TestConnectivityStateSubscriber(t *testing.T) {
 // TestChannelStateWaitingForFirstResolverUpdate verifies the initial
 // state of the channel when a manual name resolver doesn't provide any updates.
 func (s) TestChannelStateWaitingForFirstResolverUpdate(t *testing.T) {
-	t.Skip("The channel remains in IDLE until the LB policy updates the state to CONNECTING. This is a bug and the channel should transition to CONNECTING as soon as Connect() is called soon as Connect() is called. See issue #7686.")
+	t.Skip("The channel remains in IDLE until the LB policy updates the state to CONNECTING. This is a bug and the channel should transition to CONNECTING as soon as Connect() is called. See issue #7686.")
 
 	backend := stubserver.StartTestService(t, nil)
 	defer backend.Stop()
@@ -636,10 +636,12 @@ func (s) TestChannelStateWaitingForFirstResolverUpdate(t *testing.T) {
 	}
 	defer cc.Close()
 
+	if state := cc.GetState(); state != connectivity.Idle {
+		t.Fatalf("Expected initial state to be IDLE, got %v", state)
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
-
-	testutils.AwaitState(ctx, t, cc, connectivity.Idle)
 
 	// The channel should transition to CONNECTING automatically when Connect()
 	// is called.
@@ -653,7 +655,7 @@ func (s) TestChannelStateWaitingForFirstResolverUpdate(t *testing.T) {
 }
 
 func (s) TestChannelStateTransitionWithRPC(t *testing.T) {
-	t.Skip("The channel remains in IDLE until the LB policy updates the state to CONNECTING. This is a bug and the channel should transition to CONNECTING as soon as an RPC call is made soon as Connect() is called. See issue #7686.")
+	t.Skip("The channel remains in IDLE until the LB policy updates the state to CONNECTING. This is a bug and the channel should transition to CONNECTING as soon as an RPC call is made. See issue #7686.")
 
 	backend := stubserver.StartTestService(t, nil)
 	defer backend.Stop()
@@ -667,10 +669,12 @@ func (s) TestChannelStateTransitionWithRPC(t *testing.T) {
 	}
 	defer cc.Close()
 
+	if state := cc.GetState(); state != connectivity.Idle {
+		t.Fatalf("Expected initial state to be IDLE, got %v", state)
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
-
-	testutils.AwaitState(ctx, t, cc, connectivity.Idle)
 
 	// Make an RPC call to transition the channel to CONNECTING.
 	go func() {

--- a/test/clientconn_state_transition_test.go
+++ b/test/clientconn_state_transition_test.go
@@ -640,15 +640,15 @@ func (s) TestChannelStateWaitingForFirstResolverUpdate(t *testing.T) {
 	shortCtx, shortCancel := context.WithTimeout(ctx, defaultTestShortTimeout)
 	defer shortCancel()
 
-	// TODO: Change this assertion to testutils.AwaitState(shortCtx, t, cc,
-	// connectivity.Connecting) when the channel correctly transitions to
-	// CONNECTING while waiting for the first resolver update.
 	testutils.AwaitNoStateChange(shortCtx, t, cc, connectivity.Idle)
 
 	internal.EnterIdleModeForTesting.(func(*grpc.ClientConn))(cc)
 
 	cc.Connect()
 
+	// TODO: Change this assertion to testutils.AwaitState(shortCtx, t, cc,
+	// connectivity.Connecting) when the channel correctly transitions to
+	// CONNECTING while waiting for the first resolver update.
 	testutils.AwaitNoStateChange(shortCtx, t, cc, connectivity.Idle)
 
 	shortCancel()

--- a/test/clientconn_state_transition_test.go
+++ b/test/clientconn_state_transition_test.go
@@ -644,7 +644,7 @@ func (s) TestChannelStateWaitingForFirstResolverUpdate(t *testing.T) {
 	testutils.AwaitState(shortCtx, t, cc, connectivity.Idle)
 
 	mr.UpdateState(resolver.State{
-		Addresses: []resolver.Address{{Addr: backend.Address}}, // Delivering the address
+		Addresses: []resolver.Address{{Addr: backend.Address}},
 	})
 
 	// Check that the channel transitions to CONNECTING then READY

--- a/test/clientconn_state_transition_test.go
+++ b/test/clientconn_state_transition_test.go
@@ -621,9 +621,8 @@ func (s) TestConnectivityStateSubscriber(t *testing.T) {
 // TestChannelStateWaitingForFirstResolverUpdate verifies the initial
 // state of the channel when a manual name resolver doesn't provide any updates.
 func (s) TestChannelStateWaitingForFirstResolverUpdate(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping test.")
-	}
+
+	t.Skip("The channel remains in IDLE until the LB policy updates the state to CONNECTING. This is a bug and the channel should transition to CONNECTING as soon as Connect() is called.")
 
 	backend := stubserver.StartTestService(t, nil)
 	defer backend.Stop()
@@ -644,13 +643,6 @@ func (s) TestChannelStateWaitingForFirstResolverUpdate(t *testing.T) {
 
 	cc.Connect()
 
-	time.Sleep(100 * time.Millisecond)
-
 	testutils.AwaitState(ctx, t, cc, connectivity.Connecting)
 
-	mr.UpdateState(resolver.State{
-		Addresses: []resolver.Address{{Addr: backend.Address}},
-	})
-
-	testutils.AwaitState(ctx, t, cc, connectivity.Ready)
 }

--- a/test/clientconn_state_transition_test.go
+++ b/test/clientconn_state_transition_test.go
@@ -622,7 +622,7 @@ func (s) TestConnectivityStateSubscriber(t *testing.T) {
 // state of the channel when a manual name resolver doesn't provide any updates.
 func (s) TestChannelStateWaitingForFirstResolverUpdate(t *testing.T) {
 	if testing.Short() {
-		t.Skip("Skipping test in short mode.")
+		t.Skip("Skipping test.")
 	}
 
 	backend := stubserver.StartTestService(t, nil)
@@ -640,15 +640,15 @@ func (s) TestChannelStateWaitingForFirstResolverUpdate(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
 
+	testutils.AwaitState(ctx, t, cc, connectivity.Idle)
+
 	cc.Connect()
 
-	testutils.AwaitState(ctx, t, cc, connectivity.Idle)
+	testutils.AwaitState(ctx, t, cc, connectivity.Connecting)
 
 	mr.UpdateState(resolver.State{
 		Addresses: []resolver.Address{{Addr: backend.Address}},
 	})
-
-	testutils.AwaitState(ctx, t, cc, connectivity.Connecting)
 
 	testutils.AwaitState(ctx, t, cc, connectivity.Ready)
 }

--- a/test/clientconn_state_transition_test.go
+++ b/test/clientconn_state_transition_test.go
@@ -680,8 +680,8 @@ func (s) TestChannelStateTransitionWithRPC(t *testing.T) {
 		}
 	}()
 
-	// The channel should transition to CONNECTING automatically when Connect()
-	// is called.
+	// The channel should transition to CONNECTING automatically when an RPC
+	// is made.
 	testutils.AwaitState(ctx, t, cc, connectivity.Connecting)
 
 	// The channel remains in CONNECTING state for a short time.

--- a/test/clientconn_state_transition_test.go
+++ b/test/clientconn_state_transition_test.go
@@ -622,7 +622,7 @@ func (s) TestConnectivityStateSubscriber(t *testing.T) {
 // TestChannelStateWaitingForFirstResolverUpdate verifies the initial
 // state of the channel when a manual name resolver doesn't provide any updates.
 func (s) TestChannelStateWaitingForFirstResolverUpdate(t *testing.T) {
-	t.Skip("The channel remains in IDLE until the LB policy updates the state to CONNECTING. This is a bug and the channel should transition to CONNECTING as soon as Connect() is called.")
+	t.Skip("The channel remains in IDLE until the LB policy updates the state to CONNECTING. This is a bug and the channel should transition to CONNECTING as soon as Connect() is called soon as Connect() is called. See issue #7686.")
 
 	backend := stubserver.StartTestService(t, nil)
 	defer backend.Stop()
@@ -653,7 +653,7 @@ func (s) TestChannelStateWaitingForFirstResolverUpdate(t *testing.T) {
 }
 
 func (s) TestChannelStateTransitionWithRPC(t *testing.T) {
-	t.Skip("The channel remains in IDLE until the LB policy updates the state to CONNECTING. This is a bug and the channel should transition to CONNECTING as soon as an RPC call is made.")
+	t.Skip("The channel remains in IDLE until the LB policy updates the state to CONNECTING. This is a bug and the channel should transition to CONNECTING as soon as an RPC call is made soon as Connect() is called. See issue #7686.")
 
 	backend := stubserver.StartTestService(t, nil)
 	defer backend.Stop()

--- a/test/clientconn_state_transition_test.go
+++ b/test/clientconn_state_transition_test.go
@@ -644,6 +644,8 @@ func (s) TestChannelStateWaitingForFirstResolverUpdate(t *testing.T) {
 
 	cc.Connect()
 
+	time.Sleep(100 * time.Millisecond)
+
 	testutils.AwaitState(ctx, t, cc, connectivity.Connecting)
 
 	mr.UpdateState(resolver.State{

--- a/test/clientconn_state_transition_test.go
+++ b/test/clientconn_state_transition_test.go
@@ -103,7 +103,7 @@ func (s) TestStateTransitions_SingleAddress(t *testing.T) {
 		},
 		{
 			desc: `When the server sends its connection preface, but the connection dies before the client can write its
- connection preface, the client enters TRANSIENT FAILURE.`,
+connection preface, the client enters TRANSIENT FAILURE.`,
 			want: []connectivity.State{
 				connectivity.Connecting,
 				connectivity.TransientFailure,
@@ -127,7 +127,7 @@ func (s) TestStateTransitions_SingleAddress(t *testing.T) {
 		},
 		{
 			desc: `When the server reads the client connection preface but does not send its connection preface, the
- client enters TRANSIENT FAILURE.`,
+client enters TRANSIENT FAILURE.`,
 			want: []connectivity.State{
 				connectivity.Connecting,
 				connectivity.TransientFailure,


### PR DESCRIPTION
Addresses:  #7686 

RELEASE NOTES: None


