### PR TITLE
testutils: change ListenerWrapper to push the most recently accepted connection

### DIFF
--- a/internal/testutils/wrappers.go
+++ b/internal/testutils/wrappers.go
@@ -53,7 +53,7 @@ func (l *ListenerWrapper) Accept() (net.Conn, error) {
 	}
 	closeCh := NewChannel()
 	conn := &ConnWrapper{Conn: c, CloseCh: closeCh}
-	l.NewConnCh.Send(conn)
+	l.NewConnCh.Replace(conn)
 	return conn, nil
 }
 


### PR DESCRIPTION
#a71-xds-fallback
#xdsclient-refactor
Addresses https://github.com/grpc/grpc-go/issues/6902

Some e2e style tests cannot control the backoff behavior for reconnecting after a failed connection. So, making the `ListenerWrapper` push the most recently accepted connection on the channel, makes it easier for these tests.

RELEASE NOTES: none