### PR TITLE
xdsclient: make sending requests more deterministic

### DIFF
--- a/xds/internal/xdsclient/transport/ads/ads_stream.go
+++ b/xds/internal/xdsclient/transport/ads/ads_stream.go
@@ -102,6 +102,7 @@ type resourceTypeState struct {
 	nonce               string                         // Last received nonce. Should be reset when the stream breaks.
 	bufferedRequests    chan struct{}                  // Channel to buffer requests when writing is blocked.
 	subscribedResources map[string]*ResourceWatchState // Map of subscribed resource names to their state.
+	pendingWrite        bool                           // True if there is a pending write for this resource type.
 }
 
 // StreamImpl provides the functionality associated with an ADS (Aggregated
@@ -203,6 +204,7 @@ func (s *StreamImpl) Subscribe(typ xdsresource.Type, name string) {
 	// Create state for the newly subscribed resource. The watch timer will
 	// be started when a request for this resource is actually sent out.
 	state.subscribedResources[name] = &ResourceWatchState{State: ResourceWatchStateStarted}
+	state.pendingWrite = true
 
 	// Send a request for the resource type with updated subscriptions.
 	s.requestCh.Put(typ)
@@ -233,6 +235,7 @@ func (s *StreamImpl) Unsubscribe(typ xdsresource.Type, name string) {
 		rs.ExpiryTimer.Stop()
 	}
 	delete(state.subscribedResources, name)
+	state.pendingWrite = true
 
 	// Send a request for the resource type with updated subscriptions.
 	s.requestCh.Put(typ)
@@ -346,17 +349,7 @@ func (s *StreamImpl) sendNew(stream transport.StreamingCall, typ xdsresource.Typ
 		return nil
 	}
 
-	names := resourceNames(state.subscribedResources)
-	if err := s.sendMessageLocked(stream, names, typ.TypeURL(), state.version, state.nonce, nil); err != nil {
-		return err
-
-	}
-	select {
-	case <-state.bufferedRequests:
-	default:
-	}
-	s.startWatchTimersLocked(typ, names)
-	return nil
+	return s.sendMessageIfWritePending(stream, typ, state)
 }
 
 // sendExisting sends out discovery requests for existing resources when
@@ -385,18 +378,10 @@ func (s *StreamImpl) sendExisting(stream transport.StreamingCall) error {
 			continue
 		}
 
-		names := resourceNames(state.subscribedResources)
-		if s.logger.V(2) {
-			s.logger.Infof("Re-requesting resources %v of type %q, as the stream has been recreated", names, typ.TypeURL())
-		}
-		if err := s.sendMessageLocked(stream, names, typ.TypeURL(), state.version, state.nonce, nil); err != nil {
+		state.pendingWrite = true
+		if err := s.sendMessageIfWritePending(stream, typ, state); err != nil {
 			return err
 		}
-		select {
-		case <-state.bufferedRequests:
-		default:
-		}
-		s.startWatchTimersLocked(typ, names)
 	}
 	return nil
 }
@@ -413,16 +398,46 @@ func (s *StreamImpl) sendBuffered(stream transport.StreamingCall) error {
 	for typ, state := range s.resourceTypeState {
 		select {
 		case <-state.bufferedRequests:
-			names := resourceNames(state.subscribedResources)
-			if err := s.sendMessageLocked(stream, names, typ.TypeURL(), state.version, state.nonce, nil); err != nil {
+			if err := s.sendMessageIfWritePending(stream, typ, state); err != nil {
 				return err
 			}
-			s.startWatchTimersLocked(typ, names)
 		default:
 			// No buffered request.
 			continue
 		}
 	}
+	return nil
+}
+
+// sendMessageIfWritePending attempts to sends a discovery request to the
+// server, if there is a pending write for the given resource type.
+//
+// If the request is successfully sent, the pending write field is cleared and
+// watch timers are started for the resources in the request.
+//
+// Caller needs to hold c.mu.
+func (s *StreamImpl) sendMessageIfWritePending(stream transport.StreamingCall, typ xdsresource.Type, state *resourceTypeState) error {
+	if !state.pendingWrite {
+		if s.logger.V(2) {
+			s.logger.Infof("Skipping sending request for type %q, because all subscribed resources were already sent", typ.TypeURL())
+		}
+		return nil
+	}
+
+	names := resourceNames(state.subscribedResources)
+	if err := s.sendMessageLocked(stream, names, typ.TypeURL(), state.version, state.nonce, nil); err != nil {
+		return err
+	}
+	state.pendingWrite = false
+
+	// Drain the buffered requests channel because we just sent a request for this
+	// resource type.
+	select {
+	case <-state.bufferedRequests:
+	default:
+	}
+
+	s.startWatchTimersLocked(typ, names)
 	return nil
 }
 


### PR DESCRIPTION
This PR fixes a flaky test https://github.com/grpc/grpc-go/actions/runs/11499180098/job/32006581739?pr=7773, where the following happens:
- CDS LB policy requests for a cluster resource which turns out to be an aggregate cluster.
- CDS LB policy then requests for the child clusters, which turn out to leaf clusters of type EDS.
- CDS LB policy generates child policy config for cluster_resolver with discovery mechanisms for the above EDS clusters.
- cluster_resolver does not handle its config update inline. Instead it pushes the config update on to a channel which is then read by a goroutine.
- When the config update is eventually picked up the goroutine, the cluster_resolver LB policy ends up requesting for EDS resources corresponding to the discovery mechanisms in its config.

But the asynchronous behavior of cluster_resolver means that CDS LB policy considers the local processing of the response containing the child clusters to be complete, and therefore invokes the done callback on the xds client to unblock the receive side flow control on the ADS stream. This requires a fix in the cluster_resolver LB policy.

But the above failure also uncovered an issue with the new ADS stream implementation. Consider the following sequence of events:
- A subscription request for resource A, reaches the ADS stream implementation. It pushes this onto a channel and returns.
- A subscription request for resource B, reaches the ADS stream implementation. It pushes this onto a channel and returns.
- A runner goroutine reads the first message off the channel, but it sees a subscription for both resources A and B, and it ends up sending them both.
- The same runner goroutine reads the second message off the channel, and again sees a subscription for both resources A and B, and it ends up sending them both.
- While this is not a correctness issue, it causes flakes in tests.

What this PR does:
- It adds a `pending_write` bit to the resource-type specific state maintained by the ADS stream implementation
- The bit it set to true every time a resource is being subscribed or unsubscribed
- And whenever resources of a particular type are sent out, the bit is set back to false
- This guarantees that in the above described scenario, only one request message is sent out for both resources

#a71-xds-fallback
#xdsclient-refactor
Addresses https://github.com/grpc/grpc-go/issues/6902


RELEASE NOTES: none