### PR TITLE
proposal: add cause to canceled context when Client sending a RST_STREAM due to an error on their end

### DIFF
--- a/examples/features/context/README.md
+++ b/examples/features/context/README.md
@@ -1,0 +1,12 @@
+# Context
+
+This example shows how servers can process requests in separate goroutines and
+handle context cancellation.
+
+```
+go run server/main.go
+```
+
+```
+go run client/main.go
+```

--- a/examples/features/context/client/main.go
+++ b/examples/features/context/client/main.go
@@ -1,0 +1,161 @@
+/*
+ *
+ * Copyright 2024 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// Binary client demonstrates how to cancel in-flight RPCs by canceling the
+// context passed to the RPC.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	pb "google.golang.org/grpc/examples/features/proto/echo"
+	"google.golang.org/grpc/status"
+)
+
+var addr = flag.String("addr", "localhost:50051", "the address to connect to")
+
+func sendMessage(stream pb.Echo_BidirectionalStreamingEchoClient, msg string) error {
+	fmt.Printf("sending message %q\n", msg)
+	return stream.Send(&pb.EchoRequest{Message: msg})
+}
+
+func recvMessage(stream pb.Echo_BidirectionalStreamingEchoClient, wantErrCode codes.Code) {
+	res, err := stream.Recv()
+	if status.Code(err) != wantErrCode {
+		log.Fatalf("stream.Recv() = %v, %v; want _, status.Code(err)=%v", res, err, wantErrCode)
+	}
+	if err != nil {
+		fmt.Printf("stream.Recv() returned expected error %v\n", err)
+		return
+	}
+	fmt.Printf("received message %q\n", res.GetMessage())
+}
+
+func cancelStream() {
+	fmt.Println("sending two messages and then canceling")
+	conn, err := grpc.NewClient(*addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		log.Fatalf("did not connect: %v", err)
+	}
+	defer conn.Close()
+
+	c := pb.NewEchoClient(conn)
+
+	// Initiate the stream with a context that supports cancellation.
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	stream, err := c.BidirectionalStreamingEcho(ctx)
+	if err != nil {
+		log.Fatalf("error creating stream: %v", err)
+	}
+
+	// Send some test messages.
+	if err := sendMessage(stream, "hello"); err != nil {
+		log.Fatalf("error sending on stream: %v", err)
+	}
+	if err := sendMessage(stream, "world"); err != nil {
+		log.Fatalf("error sending on stream: %v", err)
+	}
+
+	// Ensure the RPC is working.
+	recvMessage(stream, codes.OK)
+	recvMessage(stream, codes.OK)
+
+	fmt.Println("canceling context")
+	cancel()
+}
+
+func closeConnection() {
+	fmt.Println("sending two messages and then closing connection")
+	conn, err := grpc.NewClient(*addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		log.Fatalf("did not connect: %v", err)
+	}
+	defer func() {
+		fmt.Println("closing connection")
+		conn.Close()
+	}()
+
+	c := pb.NewEchoClient(conn)
+
+	stream, err := c.BidirectionalStreamingEcho(context.Background())
+	if err != nil {
+		log.Fatalf("error creating stream: %v", err)
+	}
+
+	// Send some test messages.
+	if err := sendMessage(stream, "hello"); err != nil {
+		log.Fatalf("error sending on stream: %v", err)
+	}
+	if err := sendMessage(stream, "world"); err != nil {
+		log.Fatalf("error sending on stream: %v", err)
+	}
+
+	// Ensure the RPC is working.
+	recvMessage(stream, codes.OK)
+	recvMessage(stream, codes.OK)
+}
+
+func timout() {
+	fmt.Println("sending two messages and then waiting for timeout")
+	conn, err := grpc.NewClient(*addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		log.Fatalf("did not connect: %v", err)
+	}
+	defer conn.Close()
+
+	c := pb.NewEchoClient(conn)
+
+	// Initiate the stream with a context that supports cancellation.
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	stream, err := c.BidirectionalStreamingEcho(ctx)
+	if err != nil {
+		log.Fatalf("error creating stream: %v", err)
+	}
+
+	// Send some test messages.
+	if err := sendMessage(stream, "hello"); err != nil {
+		log.Fatalf("error sending on stream: %v", err)
+	}
+	if err := sendMessage(stream, "world"); err != nil {
+		log.Fatalf("error sending on stream: %v", err)
+	}
+
+	recvMessage(stream, codes.OK)
+	recvMessage(stream, codes.OK)
+
+	fmt.Println("waiting for timeout")
+	<-ctx.Done()
+}
+
+func main() {
+	flag.Parse()
+
+	// simulate some client behaviors which terminate with different reasons
+	cancelStream()
+	closeConnection()
+	timout()
+}

--- a/examples/features/context/server/main.go
+++ b/examples/features/context/server/main.go
@@ -1,0 +1,96 @@
+/*
+ *
+ * Copyright 2024 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// Binary server demonstrates how to handle canceled contexts when a client
+// cancels an in-flight RPC.
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"net"
+
+	"golang.org/x/net/http2"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/internal/transport"
+
+	pb "google.golang.org/grpc/examples/features/proto/echo"
+)
+
+var port = flag.Int("port", 50051, "the port to serve on")
+
+type server struct {
+	pb.UnimplementedEchoServer
+}
+
+func workOnMessage(ctx context.Context, msg string) {
+	fmt.Printf("starting work on message: %q\n", msg)
+	i := 0
+	for {
+		if err := ctx.Err(); err != nil {
+			cause := context.Cause(ctx)
+			fmt.Printf("'%v' with cause '%v', message worker for message %q stopping.\n", err, cause, msg)
+			var httpErr *transport.HTTP2CodeError
+			if errors.As(cause, &httpErr) {
+				switch httpErr.Code {
+				case http2.ErrCodeNo:
+					return
+				default:
+					fmt.Printf("unexpected HTTP/2 error: %v", httpErr)
+				}
+			}
+			return
+		}
+		// simulate work on message but don't flood the logs
+		i++
+	}
+}
+
+func (s *server) BidirectionalStreamingEcho(stream pb.Echo_BidirectionalStreamingEchoServer) error {
+	ctx := stream.Context()
+	for {
+		recv, err := stream.Recv()
+		if err != nil {
+			fmt.Printf("server: error receiving from stream: %v\n", err)
+			if err == io.EOF {
+				return nil
+			}
+			return err
+		}
+		msg := recv.Message
+		go workOnMessage(ctx, msg)
+		stream.Send(&pb.EchoResponse{Message: msg})
+	}
+}
+
+func main() {
+	flag.Parse()
+
+	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", *port))
+	if err != nil {
+		log.Fatalf("failed to listen: %v", err)
+	}
+	fmt.Printf("server listening at port %v\n", lis.Addr())
+	s := grpc.NewServer()
+	pb.RegisterEchoServer(s, &server{})
+	s.Serve(lis)
+}

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/prometheus/client_golang v1.20.5
 	go.opentelemetry.io/otel/exporters/prometheus v0.53.0
 	go.opentelemetry.io/otel/sdk/metric v1.31.0
+	golang.org/x/net v0.30.0
 	golang.org/x/oauth2 v0.23.0
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20241015192408-796eee8c2d53
 	google.golang.org/grpc v1.67.1
@@ -69,7 +70,6 @@ require (
 	go.opentelemetry.io/otel/sdk v1.31.0 // indirect
 	go.opentelemetry.io/otel/trace v1.31.0 // indirect
 	golang.org/x/crypto v0.28.0 // indirect
-	golang.org/x/net v0.30.0 // indirect
 	golang.org/x/sync v0.8.0 // indirect
 	golang.org/x/sys v0.26.0 // indirect
 	golang.org/x/text v0.19.0 // indirect

--- a/internal/transport/context.go
+++ b/internal/transport/context.go
@@ -1,0 +1,61 @@
+/*
+ *
+ * Copyright 2024 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package transport
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"golang.org/x/net/http2"
+	"google.golang.org/grpc/status"
+)
+
+var ErrGrpcTimeout = errors.New("grpc-timeout")
+var ErrRequestDone = errors.New("request is done processing")
+var ErrServerTransportClosed = errors.New("server transport closed")
+var ErrUnreachable = errors.New("unreachable")
+
+type RstCodeError struct {
+	RstCode http2.ErrCode
+}
+
+func (e RstCodeError) Error() string {
+	return e.RstCode.String()
+}
+
+type StatusError struct {
+	Status *status.Status
+}
+
+func (e StatusError) Error() string {
+	return e.Status.String()
+}
+
+func createContext(ctx context.Context, timeoutSet bool, timeout time.Duration) (context.Context, context.CancelCauseFunc) {
+	var timoutCancel context.CancelFunc = nil
+	if timeoutSet {
+		ctx, timoutCancel = context.WithTimeoutCause(ctx, timeout, ErrGrpcTimeout)
+	}
+	ctx, cancel := context.WithCancelCause(ctx)
+	if timoutCancel != nil {
+		context.AfterFunc(ctx, timoutCancel)
+	}
+	return ctx, cancel
+}

--- a/internal/transport/context.go
+++ b/internal/transport/context.go
@@ -20,38 +20,13 @@ package transport
 
 import (
 	"context"
-	"errors"
 	"time"
-
-	"golang.org/x/net/http2"
-	"google.golang.org/grpc/status"
 )
 
-var ErrGrpcTimeout = errors.New("grpc-timeout")
-var ErrRequestDone = errors.New("request is done processing")
-var ErrServerTransportClosed = errors.New("server transport closed")
-var ErrUnreachable = errors.New("unreachable")
-
-type RstCodeError struct {
-	RstCode http2.ErrCode
-}
-
-func (e RstCodeError) Error() string {
-	return e.RstCode.String()
-}
-
-type StatusError struct {
-	Status *status.Status
-}
-
-func (e StatusError) Error() string {
-	return e.Status.String()
-}
-
-func createContext(ctx context.Context, timeoutSet bool, timeout time.Duration) (context.Context, context.CancelCauseFunc) {
-	var timoutCancel context.CancelFunc = nil
+func createContextWithTimeout(ctx context.Context, timeoutSet bool, timeout time.Duration) (context.Context, context.CancelCauseFunc) {
+	var timoutCancel context.CancelFunc
 	if timeoutSet {
-		ctx, timoutCancel = context.WithTimeoutCause(ctx, timeout, ErrGrpcTimeout)
+		ctx, timoutCancel = context.WithTimeout(ctx, timeout)
 	}
 	ctx, cancel := context.WithCancelCause(ctx)
 	if timoutCancel != nil {

--- a/internal/transport/context_test.go
+++ b/internal/transport/context_test.go
@@ -1,0 +1,76 @@
+/*
+ *
+ * Copyright 2024 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package transport
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func Test_createContext(t *testing.T) {
+	tests := []struct {
+		name  string
+		f     func() context.Context
+		err   error
+		cause error
+	}{
+		{"cause when cancelled",
+			func() context.Context {
+				ctx, cancel := createContext(context.Background(), false, 0)
+				cancel(ErrRequestDone)
+				return ctx
+			},
+			context.Canceled,
+			ErrRequestDone,
+		},
+		{"cause when cancelled after deadline exceeded",
+			func() context.Context {
+				ctx, cancel := createContext(context.Background(), true, 0)
+				cancel(ErrRequestDone)
+				return ctx
+			},
+			context.DeadlineExceeded,
+			ErrGrpcTimeout,
+		},
+		{"cause when cancelled before deadline exceeded",
+			func() context.Context {
+				ctx, cancel := createContext(context.Background(), true, 1*time.Second)
+				cancel(ErrRequestDone)
+				return ctx
+			},
+			context.Canceled,
+			ErrRequestDone,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := tt.f()
+			err := ctx.Err()
+			if !reflect.DeepEqual(err, tt.err) {
+				t.Errorf("ctx.Err() got %v, want %v", err, tt.cause)
+			}
+			cause := context.Cause(ctx)
+			if !reflect.DeepEqual(cause, tt.cause) {
+				t.Errorf("context.Cause(ctx) got = %v, want %v", cause, tt.cause)
+			}
+		})
+	}
+}

--- a/internal/transport/context_test.go
+++ b/internal/transport/context_test.go
@@ -20,12 +20,15 @@ package transport
 
 import (
 	"context"
+	"errors"
 	"reflect"
 	"testing"
 	"time"
 )
 
-func Test_createContext(t *testing.T) {
+var errRequestDone = errors.New("request is done processing")
+
+func Test_createContextWithTimeout(t *testing.T) {
 	tests := []struct {
 		name  string
 		f     func() context.Context
@@ -34,30 +37,30 @@ func Test_createContext(t *testing.T) {
 	}{
 		{"cause when cancelled",
 			func() context.Context {
-				ctx, cancel := createContext(context.Background(), false, 0)
-				cancel(ErrRequestDone)
+				ctx, cancel := createContextWithTimeout(context.Background(), false, 0)
+				cancel(errRequestDone)
 				return ctx
 			},
 			context.Canceled,
-			ErrRequestDone,
+			errRequestDone,
 		},
 		{"cause when cancelled after deadline exceeded",
 			func() context.Context {
-				ctx, cancel := createContext(context.Background(), true, 0)
-				cancel(ErrRequestDone)
+				ctx, cancel := createContextWithTimeout(context.Background(), true, 0)
+				cancel(errRequestDone)
 				return ctx
 			},
 			context.DeadlineExceeded,
-			ErrGrpcTimeout,
+			context.DeadlineExceeded,
 		},
 		{"cause when cancelled before deadline exceeded",
 			func() context.Context {
-				ctx, cancel := createContext(context.Background(), true, 1*time.Second)
-				cancel(ErrRequestDone)
+				ctx, cancel := createContextWithTimeout(context.Background(), true, 1*time.Second)
+				cancel(errRequestDone)
 				return ctx
 			},
 			context.Canceled,
-			ErrRequestDone,
+			errRequestDone,
 		},
 	}
 	for _, tt := range tests {

--- a/internal/transport/handler_server.go
+++ b/internal/transport/handler_server.go
@@ -387,7 +387,7 @@ func (ht *serverHandlerTransport) WriteHeader(s *ServerStream, md metadata.MD) e
 
 func (ht *serverHandlerTransport) HandleStreams(ctx context.Context, startStream func(*ServerStream)) {
 	// With this transport type there will be exactly 1 stream: this HTTP request.
-	ctx, cancel := createContext(ctx, ht.timeoutSet, ht.timeout)
+	ctx, cancel := createContextWithTimeout(ctx, ht.timeoutSet, ht.timeout)
 
 	// requestOver is closed when the status has been written via WriteStatus.
 	requestOver := make(chan struct{})
@@ -397,8 +397,8 @@ func (ht *serverHandlerTransport) HandleStreams(ctx context.Context, startStream
 		case <-ht.closedCh:
 		case <-ht.req.Context().Done():
 		}
-		cancel(ErrRequestDone)
-		ht.Close(ErrRequestDone)
+		cancel(nil)
+		ht.Close(errors.New("request is done processing"))
 	}()
 
 	ctx = metadata.NewIncomingContext(ctx, ht.headerMD)

--- a/internal/transport/handler_server.go
+++ b/internal/transport/handler_server.go
@@ -387,12 +387,7 @@ func (ht *serverHandlerTransport) WriteHeader(s *ServerStream, md metadata.MD) e
 
 func (ht *serverHandlerTransport) HandleStreams(ctx context.Context, startStream func(*ServerStream)) {
 	// With this transport type there will be exactly 1 stream: this HTTP request.
-	var cancel context.CancelFunc
-	if ht.timeoutSet {
-		ctx, cancel = context.WithTimeout(ctx, ht.timeout)
-	} else {
-		ctx, cancel = context.WithCancel(ctx)
-	}
+	ctx, cancel := createContext(ctx, ht.timeoutSet, ht.timeout)
 
 	// requestOver is closed when the status has been written via WriteStatus.
 	requestOver := make(chan struct{})
@@ -402,8 +397,8 @@ func (ht *serverHandlerTransport) HandleStreams(ctx context.Context, startStream
 		case <-ht.closedCh:
 		case <-ht.req.Context().Done():
 		}
-		cancel()
-		ht.Close(errors.New("request is done processing"))
+		cancel(ErrRequestDone)
+		ht.Close(ErrRequestDone)
 	}()
 
 	ctx = metadata.NewIncomingContext(ctx, ht.headerMD)

--- a/internal/transport/server_stream.go
+++ b/internal/transport/server_stream.go
@@ -33,8 +33,8 @@ type ServerStream struct {
 	*Stream // Embed for common stream functionality.
 
 	st      ServerTransport
-	ctxDone <-chan struct{}    // closed at the end of stream.  Cache of ctx.Done() (for performance)
-	cancel  context.CancelFunc // invoked at the end of stream to cancel ctx.
+	ctxDone <-chan struct{}         // closed at the end of stream.  Cache of ctx.Done() (for performance)
+	cancel  context.CancelCauseFunc // invoked at the end of stream to cancel ctx.
 
 	// Holds compressor names passed in grpc-accept-encoding metadata from the
 	// client.


### PR DESCRIPTION
**Related Issue:** [#7541](https://github.com/grpc/grpc-go/issues/7541)

**Summary:**
This PR introduces a feature to add a cause to the context cancellation, for example when a client sends an RST_STREAM frame. This enhancement aims to provide more transparency and ease debugging by distinguishing between different reasons for context cancellation.

**Use Case:**
When a client resets a connection, the `http2_server` cancels the current context to interrupt all server internal processing. However, it is challenging to determine the exact reason for the context cancellation, whether it was due to an internal error, a timeout, or a client sending an RST frame. This feature will help in identifying the cause of the context cancellation, making it easier to debug and handle errors appropriately.

**Proposed Solution:**
- Replace `context.CancelFunc` with `context.CancelCauseFunc`.
- Adjust all context cancellations to report the cause.
- For example, when handling an RST_STREAM frame, the context will be canceled with a specific error indicating the receipt of the RST_STREAM frame.

**Additional Context:**
This change is backward-compatible and does not affect existing application code that checks for `ctx.Err()`. The new `context.Cause(ctx)` method will provide additional information when available.

**Example:**

The PR adds an example which shows how to implement a server with asynchronous processing using goroutines. 
The example illustrates some client behaviors (RST frame, close connection, timeout) which are propagated to the worker goroutine through the context. 

Here are the logs of the example server (with comments):

```
starting work on message: "world"
starting work on message: "hello"
'context canceled' with cause 'NO_ERROR', message worker for message "world" stopping. 👈🏻 NO_ERROR indicates the context was caused by HTTP status 0
server: error receiving from stream: rpc error: code = Canceled desc = context canceled 
'context canceled' with cause 'NO_ERROR', message worker for message "hello" stopping. 👈🏻 see above
starting work on message: "world"
starting work on message: "hello"
'context canceled' with cause 'context canceled', message worker for message "hello" stopping. 👈🏻 this case could be made more transparent when setting a cancel cause for a closed connection as well. 
'context canceled' with cause 'context canceled', message worker for message "world" stopping. 👈🏻 see above
server: error receiving from stream: rpc error: code = Canceled desc = context canceled
starting work on message: "world"
starting work on message: "hello"
'context deadline exceeded' with cause 'context deadline exceeded', message worker for message "world" stopping. 👈🏻 this case could be made more transparent by setting a custom cause for the context deadline in `ctx, timoutCancel = context.WithTimeout(ctx, timeout)`
server: error receiving from stream: rpc error: code = DeadlineExceeded desc = context deadline exceeded
'context deadline exceeded' with cause 'context deadline exceeded', message worker for message "hello" stopping. 👈🏻 see above
```

**Open Issues**

 * This PR is still a draft and almost no unit tests have been added to production code. This can be done when the reviewers agree that the feature of this PR will be considered to be added to the library. 
 * Some uses cases (client closes connection, timeout) do not receive a proper cause in this PR, as it was explicitly requested to set the cause only for the RST frame case yet. 
 * So far one error type (`Http2CodeError`) has been added to illustrate how server implementations could do error matching. The design for error types could be discussed in more detail. I'd see more error cases in the future that could be propagated through the context (e.g. `ConnectionClosed` by client, `GrpcTimeout` to distinguish from other timeouts). 


