### PR TITLE
grpc: export MethodHandler #7794

### DIFF
--- a/server.go
+++ b/server.go
@@ -87,6 +87,7 @@ func init() {
 var statusOK = status.New(codes.OK, "")
 var logger = grpclog.Component("core")
 
+// MethodHandler is a function type that processes a unary RPC method call.
 type MethodHandler func(srv any, ctx context.Context, dec func(any) error, interceptor UnaryServerInterceptor) (any, error)
 
 // MethodDesc represents an RPC service's method specification.


### PR DESCRIPTION
**Made MethodHandler type exportable**

- Updated MethodHandler to be exportable for external use.
- Modified MethodDesc struct to reference the exportable MethodHandler type.


[Issue #7794](https://github.com/grpc/grpc-go/issues/7794)

RELEASE NOTES:
* grpc: export `MethodHandler`, which is the type of an already-exported field in `MethodDesc`