### PR TITLE
xds/resolver: fix flaky test TestResolverRemovedWithRPCs with a workaround

### DIFF
--- a/xds/internal/resolver/xds_resolver_test.go
+++ b/xds/internal/resolver/xds_resolver_test.go
@@ -554,6 +554,9 @@ func (s) TestResolverRemovedWithRPCs(t *testing.T) {
 	// between resource removal and re-addition. To avoid this, continuously
 	// push new versions of the resources to the server, ensuring the client
 	// eventually receives the configuration.
+	//
+	// TODO(https://github.com/grpc/grpc-go/issues/7807): Remove this workaround
+	// once the issue is fixed.
 waitForStateUpdate:
 	for {
 		sCtx, sCancel := context.WithTimeout(ctx, defaultTestShortTimeout)

--- a/xds/internal/resolver/xds_resolver_test.go
+++ b/xds/internal/resolver/xds_resolver_test.go
@@ -548,10 +548,36 @@ func (s) TestResolverRemovedWithRPCs(t *testing.T) {
 		}
 	}
 
-	// Re-add the listener and expect everything to work again.
-	configureResourcesOnManagementServer(ctx, t, mgmtServer, nodeID, listeners, routes)
-	// Read the update pushed by the resolver to the ClientConn.
-	cs = verifyUpdateFromResolver(ctx, t, stateCh, wantDefaultServiceConfig)
+	// Workaround for https://github.com/envoyproxy/go-control-plane/issues/431.
+	//
+	// The xDS client can miss route configurations due to a race condition
+	// between resource removal and re-addition. To avoid this, continuously
+	// push new versions of the resources to the server, ensuring the client
+	// eventually receives the configuration.
+waitForStateUpdate:
+	for {
+		sCtx, sCancel := context.WithTimeout(ctx, defaultTestShortTimeout)
+		defer sCancel()
+
+		configureResourcesOnManagementServer(ctx, t, mgmtServer, nodeID, listeners, routes)
+
+		select {
+		case state = <-stateCh:
+			if err := state.ServiceConfig.Err; err != nil {
+				t.Fatalf("Received error in service config: %v", state.ServiceConfig.Err)
+			}
+			wantSCParsed := internal.ParseServiceConfig.(func(string) *serviceconfig.ParseResult)(wantDefaultServiceConfig)
+			if !internal.EqualServiceConfigForTesting(state.ServiceConfig.Config, wantSCParsed.Config) {
+				t.Fatalf("Got service config:\n%s \nWant service config:\n%s", cmp.Diff(nil, state.ServiceConfig.Config), cmp.Diff(nil, wantSCParsed.Config))
+			}
+			break waitForStateUpdate
+		case <-sCtx.Done():
+		}
+	}
+	cs = iresolver.GetConfigSelector(state)
+	if cs == nil {
+		t.Fatal("Received nil config selector in update from resolver")
+	}
 
 	res, err = cs.SelectConfig(iresolver.RPCInfo{Context: ctx, Method: "/service/method"})
 	if err != nil {


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc-go/issues/7799

Once resources are removed from the management server (as part of this test), the xDS client used by the resolver will see discovery responses from the server with no resources. This will trigger a resource-not-found error on the resolver when the listener resource is missing in the response from the server. This will cause the resolver to stop watching the route configuration resource.

The test then re-adds these resources to the management server, and these two events can race and can lead to the management server sending the route configuration too early to the client (which at that point thinks that it has not requested for that resource, and hence drops it on the floor).

And later when the client requests for the same route configuration, the server does not send it because it thinks that it has already sent it to the client. See https://github.com/grpc/grpc-go/issues/7799#issuecomment-2455454005 for a sequence of events where this leads to a problem. 

The workaround is to continuously push a new version to the server with the same resources so that eventually, the route configuration is pushed to the client when it is in a state where it can accept it.

RELEASE NOTES: none