### PR TITLE
transport: add send operations to ClientStream and ServerStream

### DIFF
--- a/internal/transport/client_stream.go
+++ b/internal/transport/client_stream.go
@@ -50,6 +50,7 @@ type ClientStream struct {
 	status *status.Status // the status error received from the server
 }
 
+// Read reads an n byte message from the input stream.
 func (s *ClientStream) Read(n int) (mem.BufferSlice, error) {
 	b, err := s.Stream.read(n)
 	if err == nil {
@@ -58,6 +59,7 @@ func (s *ClientStream) Read(n int) (mem.BufferSlice, error) {
 	return b, err
 }
 
+// Close closes the stream and popagates err to any readers.
 func (s *ClientStream) Close(err error) {
 	var (
 		rst     bool
@@ -70,6 +72,7 @@ func (s *ClientStream) Close(err error) {
 	s.ct.closeStream(s, err, rst, rstCode, status.Convert(err), nil, false)
 }
 
+// Write writes the hdr and data bytes to the output stream.
 func (s *ClientStream) Write(hdr []byte, data mem.BufferSlice, opts *WriteOptions) error {
 	return s.ct.write(s, hdr, data, opts)
 }

--- a/internal/transport/client_stream.go
+++ b/internal/transport/client_stream.go
@@ -44,8 +44,8 @@ type ClientStream struct {
 	header      metadata.MD // the received header metadata
 	noHeaders   bool        // set if the client never received headers (set only after the stream is done).
 
-	bytesReceived uint32 // indicates whether any bytes have been received on this stream
-	unprocessed   uint32 // set if the server sends a refused stream or GOAWAY including this stream
+	bytesReceived atomic.Bool // indicates whether any bytes have been received on this stream
+	unprocessed   atomic.Bool // set if the server sends a refused stream or GOAWAY including this stream
 
 	status *status.Status // the status error received from the server
 }
@@ -79,13 +79,13 @@ func (s *ClientStream) Write(hdr []byte, data mem.BufferSlice, opts *WriteOption
 
 // BytesReceived indicates whether any bytes have been received on this stream.
 func (s *ClientStream) BytesReceived() bool {
-	return atomic.LoadUint32(&s.bytesReceived) == 1
+	return s.bytesReceived.Load()
 }
 
 // Unprocessed indicates whether the server did not process this stream --
 // i.e. it sent a refused stream or GOAWAY including this stream ID.
 func (s *ClientStream) Unprocessed() bool {
-	return atomic.LoadUint32(&s.unprocessed) == 1
+	return s.unprocessed.Load()
 }
 
 func (s *ClientStream) waitOnHeader() {

--- a/internal/transport/client_stream.go
+++ b/internal/transport/client_stream.go
@@ -50,6 +50,14 @@ type ClientStream struct {
 	status *status.Status // the status error received from the server
 }
 
+func (s *ClientStream) Read(n int) (mem.BufferSlice, error) {
+	b, err := s.Stream.read(n)
+	if err == nil {
+		s.ct.incrMsgRecv()
+	}
+	return b, err
+}
+
 func (s *ClientStream) Close(err error) {
 	var (
 		rst     bool

--- a/internal/transport/handler_server.go
+++ b/internal/transport/handler_server.go
@@ -473,9 +473,9 @@ func (ht *serverHandlerTransport) runStream() {
 	}
 }
 
-func (ht *serverHandlerTransport) IncrMsgSent() {}
+func (ht *serverHandlerTransport) incrMsgSent() {}
 
-func (ht *serverHandlerTransport) IncrMsgRecv() {}
+func (ht *serverHandlerTransport) incrMsgRecv() {}
 
 func (ht *serverHandlerTransport) Drain(string) {
 	panic("Drain() is not implemented")

--- a/internal/transport/handler_server.go
+++ b/internal/transport/handler_server.go
@@ -225,7 +225,7 @@ func (ht *serverHandlerTransport) do(fn func()) error {
 	}
 }
 
-func (ht *serverHandlerTransport) WriteStatus(s *ServerStream, st *status.Status) error {
+func (ht *serverHandlerTransport) writeStatus(s *ServerStream, st *status.Status) error {
 	ht.writeStatusMu.Lock()
 	defer ht.writeStatusMu.Unlock()
 
@@ -333,7 +333,7 @@ func (ht *serverHandlerTransport) writeCustomHeaders(s *ServerStream) {
 	s.hdrMu.Unlock()
 }
 
-func (ht *serverHandlerTransport) Write(s *ServerStream, hdr []byte, data mem.BufferSlice, _ *Options) error {
+func (ht *serverHandlerTransport) write(s *ServerStream, hdr []byte, data mem.BufferSlice, _ *WriteOptions) error {
 	// Always take a reference because otherwise there is no guarantee the data will
 	// be available after this function returns. This is what callers to Write
 	// expect.
@@ -357,7 +357,7 @@ func (ht *serverHandlerTransport) Write(s *ServerStream, hdr []byte, data mem.Bu
 	return nil
 }
 
-func (ht *serverHandlerTransport) WriteHeader(s *ServerStream, md metadata.MD) error {
+func (ht *serverHandlerTransport) writeHeader(s *ServerStream, md metadata.MD) error {
 	if err := s.SetHeader(md); err != nil {
 		return err
 	}

--- a/internal/transport/handler_server.go
+++ b/internal/transport/handler_server.go
@@ -473,8 +473,6 @@ func (ht *serverHandlerTransport) runStream() {
 	}
 }
 
-func (ht *serverHandlerTransport) incrMsgSent() {}
-
 func (ht *serverHandlerTransport) incrMsgRecv() {}
 
 func (ht *serverHandlerTransport) Drain(string) {

--- a/internal/transport/handler_server_test.go
+++ b/internal/transport/handler_server_test.go
@@ -310,7 +310,7 @@ func (s) TestHandlerTransport_HandleStreams(t *testing.T) {
 		}
 
 		st.bodyw.Close() // no body
-		st.ht.WriteStatus(s, status.New(codes.OK, ""))
+		s.WriteStatus(status.New(codes.OK, ""))
 	}
 	st.ht.HandleStreams(
 		context.Background(), func(s *ServerStream) { go handleStream(s) },
@@ -343,7 +343,7 @@ func handleStreamCloseBodyTest(t *testing.T, statusCode codes.Code, msg string) 
 	st := newHandleStreamTest(t)
 
 	handleStream := func(s *ServerStream) {
-		st.ht.WriteStatus(s, status.New(statusCode, msg))
+		s.WriteStatus(status.New(statusCode, msg))
 	}
 	st.ht.HandleStreams(
 		context.Background(), func(s *ServerStream) { go handleStream(s) },
@@ -392,7 +392,7 @@ func (s) TestHandlerTransport_HandleStreams_Timeout(t *testing.T) {
 			t.Errorf("ctx.Err = %v; want %v", err, context.DeadlineExceeded)
 			return
 		}
-		ht.WriteStatus(s, status.New(codes.DeadlineExceeded, "too slow"))
+		s.WriteStatus(status.New(codes.DeadlineExceeded, "too slow"))
 	}
 	ht.HandleStreams(
 		context.Background(), func(s *ServerStream) { go runStream(s) },
@@ -423,7 +423,7 @@ func (s) TestHandlerTransport_HandleStreams_MultiWriteStatus(t *testing.T) {
 		for i := 0; i < 5; i++ {
 			go func() {
 				defer wg.Done()
-				st.ht.WriteStatus(s, status.New(codes.OK, ""))
+				s.WriteStatus(status.New(codes.OK, ""))
 			}()
 		}
 		wg.Wait()
@@ -439,8 +439,8 @@ func (s) TestHandlerTransport_HandleStreams_WriteStatusWrite(t *testing.T) {
 		}
 		st.bodyw.Close() // no body
 
-		st.ht.WriteStatus(s, status.New(codes.OK, ""))
-		st.ht.Write(s, []byte("hdr"), newBufferSlice([]byte("data")), &Options{})
+		s.WriteStatus(status.New(codes.OK, ""))
+		s.Write([]byte("hdr"), newBufferSlice([]byte("data")), &WriteOptions{})
 	})
 }
 
@@ -477,7 +477,7 @@ func (s) TestHandlerTransport_HandleStreams_ErrDetails(t *testing.T) {
 
 	hst := newHandleStreamTest(t)
 	handleStream := func(s *ServerStream) {
-		hst.ht.WriteStatus(s, st)
+		s.WriteStatus(st)
 	}
 	hst.ht.HandleStreams(
 		context.Background(), func(s *ServerStream) { go handleStream(s) },

--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -1102,6 +1102,7 @@ func (t *http2Client) write(s *ClientStream, hdr []byte, data mem.BufferSlice, o
 		_ = reader.Close()
 		return err
 	}
+	t.incrMsgSent()
 	return nil
 }
 
@@ -1797,14 +1798,18 @@ func (t *http2Client) socketMetrics() *channelz.EphemeralSocketMetrics {
 
 func (t *http2Client) RemoteAddr() net.Addr { return t.remoteAddr }
 
-func (t *http2Client) IncrMsgSent() {
-	t.channelz.SocketMetrics.MessagesSent.Add(1)
-	t.channelz.SocketMetrics.LastMessageSentTimestamp.Store(time.Now().UnixNano())
+func (t *http2Client) incrMsgSent() {
+	if channelz.IsOn() {
+		t.channelz.SocketMetrics.MessagesSent.Add(1)
+		t.channelz.SocketMetrics.LastMessageSentTimestamp.Store(time.Now().UnixNano())
+	}
 }
 
-func (t *http2Client) IncrMsgRecv() {
-	t.channelz.SocketMetrics.MessagesReceived.Add(1)
-	t.channelz.SocketMetrics.LastMessageReceivedTimestamp.Store(time.Now().UnixNano())
+func (t *http2Client) incrMsgRecv() {
+	if channelz.IsOn() {
+		t.channelz.SocketMetrics.MessagesReceived.Add(1)
+		t.channelz.SocketMetrics.LastMessageReceivedTimestamp.Store(time.Now().UnixNano())
+	}
 }
 
 func (t *http2Client) getOutFlowWindow() int64 {

--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -765,7 +765,7 @@ func (t *http2Client) NewStream(ctx context.Context, callHdr *CallHdr) (*ClientS
 			return
 		}
 		// The stream was unprocessed by the server.
-		atomic.StoreUint32(&s.unprocessed, 1)
+		s.unprocessed.Store(true)
 		s.write(recvMsg{err: err})
 		close(s.done)
 		// If headerChan isn't closed, then close it.
@@ -1231,7 +1231,7 @@ func (t *http2Client) handleRSTStream(f *http2.RSTStreamFrame) {
 	}
 	if f.ErrCode == http2.ErrCodeRefusedStream {
 		// The stream was unprocessed by the server.
-		atomic.StoreUint32(&s.unprocessed, 1)
+		s.unprocessed.Store(true)
 	}
 	statusCode, ok := http2ErrConvTab[f.ErrCode]
 	if !ok {
@@ -1376,7 +1376,7 @@ func (t *http2Client) handleGoAway(f *http2.GoAwayFrame) error {
 	for streamID, stream := range t.activeStreams {
 		if streamID > id && streamID <= upperLimit {
 			// The stream was unprocessed by the server.
-			atomic.StoreUint32(&stream.unprocessed, 1)
+			stream.unprocessed.Store(true)
 			streamsToClose = append(streamsToClose, stream)
 		}
 	}
@@ -1428,7 +1428,7 @@ func (t *http2Client) operateHeaders(frame *http2.MetaHeadersFrame) {
 		return
 	}
 	endStream := frame.StreamEnded()
-	atomic.StoreUint32(&s.bytesReceived, 1)
+	s.bytesReceived.Store(true)
 	initialHeader := atomic.LoadUint32(&s.headerChanClosed) == 0
 
 	if !initialHeader && !endStream {

--- a/internal/transport/http2_server.go
+++ b/internal/transport/http2_server.go
@@ -1149,6 +1149,7 @@ func (t *http2Server) write(s *ServerStream, hdr []byte, data mem.BufferSlice, _
 		_ = reader.Close()
 		return err
 	}
+	t.incrMsgSent()
 	return nil
 }
 
@@ -1417,14 +1418,18 @@ func (t *http2Server) socketMetrics() *channelz.EphemeralSocketMetrics {
 	}
 }
 
-func (t *http2Server) IncrMsgSent() {
-	t.channelz.SocketMetrics.MessagesSent.Add(1)
-	t.channelz.SocketMetrics.LastMessageSentTimestamp.Add(1)
+func (t *http2Server) incrMsgSent() {
+	if channelz.IsOn() {
+		t.channelz.SocketMetrics.MessagesSent.Add(1)
+		t.channelz.SocketMetrics.LastMessageSentTimestamp.Add(1)
+	}
 }
 
-func (t *http2Server) IncrMsgRecv() {
-	t.channelz.SocketMetrics.MessagesReceived.Add(1)
-	t.channelz.SocketMetrics.LastMessageReceivedTimestamp.Add(1)
+func (t *http2Server) incrMsgRecv() {
+	if channelz.IsOn() {
+		t.channelz.SocketMetrics.MessagesReceived.Add(1)
+		t.channelz.SocketMetrics.LastMessageReceivedTimestamp.Add(1)
+	}
 }
 
 func (t *http2Server) getOutFlowWindow() int64 {

--- a/internal/transport/http2_server.go
+++ b/internal/transport/http2_server.go
@@ -975,7 +975,7 @@ func (t *http2Server) streamContextErr(s *ServerStream) error {
 }
 
 // WriteHeader sends the header metadata md back to the client.
-func (t *http2Server) WriteHeader(s *ServerStream, md metadata.MD) error {
+func (t *http2Server) writeHeader(s *ServerStream, md metadata.MD) error {
 	s.hdrMu.Lock()
 	defer s.hdrMu.Unlock()
 	if s.getState() == streamDone {
@@ -1048,7 +1048,7 @@ func (t *http2Server) writeHeaderLocked(s *ServerStream) error {
 // There is no further I/O operations being able to perform on this stream.
 // TODO(zhaoq): Now it indicates the end of entire stream. Revisit if early
 // OK is adopted.
-func (t *http2Server) WriteStatus(s *ServerStream, st *status.Status) error {
+func (t *http2Server) writeStatus(s *ServerStream, st *status.Status) error {
 	s.hdrMu.Lock()
 	defer s.hdrMu.Unlock()
 
@@ -1119,11 +1119,11 @@ func (t *http2Server) WriteStatus(s *ServerStream, st *status.Status) error {
 
 // Write converts the data into HTTP2 data frame and sends it out. Non-nil error
 // is returns if it fails (e.g., framing error, transport error).
-func (t *http2Server) Write(s *ServerStream, hdr []byte, data mem.BufferSlice, _ *Options) error {
+func (t *http2Server) write(s *ServerStream, hdr []byte, data mem.BufferSlice, _ *WriteOptions) error {
 	reader := data.Reader()
 
 	if !s.isHeaderSent() { // Headers haven't been written yet.
-		if err := t.WriteHeader(s, nil); err != nil {
+		if err := t.writeHeader(s, nil); err != nil {
 			_ = reader.Close()
 			return err
 		}

--- a/internal/transport/keepalive_test.go
+++ b/internal/transport/keepalive_test.go
@@ -68,7 +68,7 @@ func (s) TestMaxConnectionIdle(t *testing.T) {
 	if err != nil {
 		t.Fatalf("client.NewStream() failed: %v", err)
 	}
-	client.CloseStream(stream, io.EOF)
+	stream.Close(io.EOF)
 
 	// Verify the server sends a GoAway to client after MaxConnectionIdle timeout
 	// kicks in.
@@ -708,7 +708,7 @@ func (s) TestTCPUserTimeout(t *testing.T) {
 		if err != nil {
 			t.Fatalf("client.NewStream() failed: %v", err)
 		}
-		client.CloseStream(stream, io.EOF)
+		stream.Close(io.EOF)
 
 		// check client TCP user timeout only when non TLS
 		// TODO : find a way to get the underlying conn for client when TLS
@@ -772,7 +772,7 @@ func checkForHealthyStream(client *http2Client) error {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
 	stream, err := client.NewStream(ctx, &CallHdr{})
-	client.CloseStream(stream, err)
+	stream.Close(err)
 	return err
 }
 

--- a/internal/transport/server_stream.go
+++ b/internal/transport/server_stream.go
@@ -58,8 +58,7 @@ func (s *ServerStream) Read(n int) (mem.BufferSlice, error) {
 	return b, err
 }
 
-// WriteHeader sends the header metadata for the given stream.
-// WriteHeader may not be called on all streams.
+// SendHeader sends the header metadata for the given stream.
 func (s *ServerStream) SendHeader(md metadata.MD) error {
 	return s.st.writeHeader(s, md)
 }

--- a/internal/transport/server_stream.go
+++ b/internal/transport/server_stream.go
@@ -49,6 +49,14 @@ type ServerStream struct {
 	headerSent uint32      // atomically set to 1 when the headers are sent out.
 }
 
+func (s *ServerStream) Read(n int) (mem.BufferSlice, error) {
+	b, err := s.Stream.read(n)
+	if err == nil {
+		s.st.incrMsgRecv()
+	}
+	return b, err
+}
+
 // WriteHeader sends the header metadata for the given stream.
 // WriteHeader may not be called on all streams.
 func (s *ServerStream) SendHeader(md metadata.MD) error {

--- a/internal/transport/transport.go
+++ b/internal/transport/transport.go
@@ -342,15 +342,14 @@ func (s *Stream) write(m recvMsg) {
 	s.buf.put(m)
 }
 
-// ReadHeader reads data into the provided header slice from the stream. It
-// first checks if there was an error during a previous read operation and
+// ReadMessageHeader reads data into the provided header slice from the stream.
+// It first checks if there was an error during a previous read operation and
 // returns it if present. It then requests a read operation for the length of
 // the header. It continues to read from the stream until the entire header
-// slice is filled or an error occurs. If an `io.EOF` error is encountered
-// with partially read data, it is converted to `io.ErrUnexpectedEOF` to
-// indicate an unexpected end of the stream. The method returns any error
-// encountered during the read process or nil if the header was successfully
-// read.
+// slice is filled or an error occurs. If an `io.EOF` error is encountered with
+// partially read data, it is converted to `io.ErrUnexpectedEOF` to indicate an
+// unexpected end of the stream. The method returns any error encountered during
+// the read process or nil if the header was successfully read.
 func (s *Stream) ReadMessageHeader(header []byte) (err error) {
 	// Don't request a read if there was an error earlier
 	if er := s.trReader.er; er != nil {

--- a/internal/transport/transport_test.go
+++ b/internal/transport/transport_test.go
@@ -144,13 +144,13 @@ func (h *testStreamHandler) handleStream(t *testing.T, s *ServerStream) {
 	}
 	if !bytes.Equal(p, req) {
 		t.Errorf("handleStream got %v, want %v", p, req)
-		h.t.WriteStatus(s, status.New(codes.Internal, "panic"))
+		s.WriteStatus(status.New(codes.Internal, "panic"))
 		return
 	}
 	// send a response back to the client.
-	h.t.Write(s, nil, newBufferSlice(resp), &Options{})
+	s.Write(nil, newBufferSlice(resp), &WriteOptions{})
 	// send the trailer to end the stream.
-	h.t.WriteStatus(s, status.New(codes.OK, ""))
+	s.WriteStatus(status.New(codes.OK, ""))
 }
 
 func (h *testStreamHandler) handleStreamPingPong(t *testing.T, s *ServerStream) {
@@ -158,25 +158,25 @@ func (h *testStreamHandler) handleStreamPingPong(t *testing.T, s *ServerStream) 
 	for {
 		if _, err := s.readTo(header); err != nil {
 			if err == io.EOF {
-				h.t.WriteStatus(s, status.New(codes.OK, ""))
+				s.WriteStatus(status.New(codes.OK, ""))
 				return
 			}
 			t.Errorf("Error on server while reading data header: %v", err)
-			h.t.WriteStatus(s, status.New(codes.Internal, "panic"))
+			s.WriteStatus(status.New(codes.Internal, "panic"))
 			return
 		}
 		sz := binary.BigEndian.Uint32(header[1:])
 		msg := make([]byte, int(sz))
 		if _, err := s.readTo(msg); err != nil {
 			t.Errorf("Error on server while reading message: %v", err)
-			h.t.WriteStatus(s, status.New(codes.Internal, "panic"))
+			s.WriteStatus(status.New(codes.Internal, "panic"))
 			return
 		}
 		buf := make([]byte, sz+5)
 		buf[0] = byte(0)
 		binary.BigEndian.PutUint32(buf[1:], uint32(sz))
 		copy(buf[5:], msg)
-		h.t.Write(s, nil, newBufferSlice(buf), &Options{})
+		s.Write(nil, newBufferSlice(buf), &WriteOptions{})
 	}
 }
 
@@ -184,7 +184,7 @@ func (h *testStreamHandler) handleStreamMisbehave(t *testing.T, s *ServerStream)
 	conn, ok := s.st.(*http2Server)
 	if !ok {
 		t.Errorf("Failed to convert %v to *http2Server", s.st)
-		h.t.WriteStatus(s, status.New(codes.Internal, ""))
+		s.WriteStatus(status.New(codes.Internal, ""))
 		return
 	}
 	var sent int
@@ -215,7 +215,7 @@ func (h *testStreamHandler) handleStreamMisbehave(t *testing.T, s *ServerStream)
 
 func (h *testStreamHandler) handleStreamEncodingRequiredStatus(s *ServerStream) {
 	// raw newline is not accepted by http2 framer so it must be encoded.
-	h.t.WriteStatus(s, encodingTestStatus)
+	s.WriteStatus(encodingTestStatus)
 	// Drain any remaining buffers from the stream since it was closed early.
 	s.Read(math.MaxInt)
 }
@@ -300,7 +300,7 @@ func (h *testStreamHandler) handleStreamDelayRead(t *testing.T, s *ServerStream)
 	// This write will cause server to run out of stream level,
 	// flow control and the other side won't send a window update
 	// until that happens.
-	if err := h.t.Write(s, nil, newBufferSlice(resp), &Options{}); err != nil {
+	if err := s.Write(nil, newBufferSlice(resp), &WriteOptions{}); err != nil {
 		t.Errorf("server Write got %v, want <nil>", err)
 		return
 	}
@@ -313,7 +313,7 @@ func (h *testStreamHandler) handleStreamDelayRead(t *testing.T, s *ServerStream)
 		return
 	}
 	// send the trailer to end the stream.
-	if err := h.t.WriteStatus(s, status.New(codes.OK, "")); err != nil {
+	if err := s.WriteStatus(status.New(codes.OK, "")); err != nil {
 		t.Errorf("server WriteStatus got %v, want <nil>", err)
 		return
 	}
@@ -535,7 +535,7 @@ func (s) TestInflightStreamClosing(t *testing.T) {
 	}()
 
 	// should unblock concurrent stream.Read
-	client.CloseStream(stream, serr)
+	stream.Close(serr)
 
 	// wait for stream.Read error
 	timeout := time.NewTimer(5 * time.Second)
@@ -618,8 +618,8 @@ func (s) TestClientSendAndReceive(t *testing.T) {
 	if s2.id != 3 {
 		t.Fatalf("wrong stream id: %d", s2.id)
 	}
-	opts := Options{Last: true}
-	if err := ct.Write(s1, nil, newBufferSlice(expectedRequest), &opts); err != nil && err != io.EOF {
+	opts := WriteOptions{Last: true}
+	if err := s1.Write(nil, newBufferSlice(expectedRequest), &opts); err != nil && err != io.EOF {
 		t.Fatalf("failed to send data: %v", err)
 	}
 	p := make([]byte, len(expectedResponse))
@@ -655,8 +655,8 @@ func performOneRPC(ct ClientTransport) {
 	if err != nil {
 		return
 	}
-	opts := Options{Last: true}
-	if err := ct.Write(s, []byte{}, newBufferSlice(expectedRequest), &opts); err == nil || err == io.EOF {
+	opts := WriteOptions{Last: true}
+	if err := s.Write([]byte{}, newBufferSlice(expectedRequest), &opts); err == nil || err == io.EOF {
 		time.Sleep(5 * time.Millisecond)
 		// The following s.Recv()'s could error out because the
 		// underlying transport is gone.
@@ -701,7 +701,7 @@ func (s) TestLargeMessage(t *testing.T) {
 			if err != nil {
 				t.Errorf("%v.NewStream(_, _) = _, %v, want _, <nil>", ct, err)
 			}
-			if err := ct.Write(s, []byte{}, newBufferSlice(expectedRequestLarge), &Options{Last: true}); err != nil && err != io.EOF {
+			if err := s.Write([]byte{}, newBufferSlice(expectedRequestLarge), &WriteOptions{Last: true}); err != nil && err != io.EOF {
 				t.Errorf("%v.Write(_, _, _) = %v, want  <nil>", ct, err)
 			}
 			p := make([]byte, len(expectedResponseLarge))
@@ -792,7 +792,7 @@ func (s) TestLargeMessageWithDelayRead(t *testing.T) {
 	// This write will cause client to run out of stream level,
 	// flow control and the other side won't send a window update
 	// until that happens.
-	if err := ct.Write(s, []byte{}, newBufferSlice(expectedRequestLarge), &Options{}); err != nil {
+	if err := s.Write([]byte{}, newBufferSlice(expectedRequestLarge), &WriteOptions{}); err != nil {
 		t.Fatalf("write(_, _, _) = %v, want  <nil>", err)
 	}
 	p := make([]byte, len(expectedResponseLarge))
@@ -807,7 +807,7 @@ func (s) TestLargeMessageWithDelayRead(t *testing.T) {
 	if _, err := s.readTo(p); err != nil || !bytes.Equal(p, expectedResponseLarge) {
 		t.Fatalf("s.Read(_) = _, %v, want _, <nil>", err)
 	}
-	if err := ct.Write(s, []byte{}, newBufferSlice(expectedRequestLarge), &Options{Last: true}); err != nil {
+	if err := s.Write([]byte{}, newBufferSlice(expectedRequestLarge), &WriteOptions{Last: true}); err != nil {
 		t.Fatalf("Write(_, _, _) = %v, want <nil>", err)
 	}
 	if _, err = s.readTo(p); err != io.EOF {
@@ -847,7 +847,7 @@ func (s) TestGracefulClose(t *testing.T) {
 	outgoingHeader[0] = byte(0)
 	binary.BigEndian.PutUint32(outgoingHeader[1:], uint32(len(msg)))
 	incomingHeader := make([]byte, 5)
-	if err := ct.Write(s, outgoingHeader, newBufferSlice(msg), &Options{}); err != nil {
+	if err := s.Write(outgoingHeader, newBufferSlice(msg), &WriteOptions{}); err != nil {
 		t.Fatalf("Error while writing: %v", err)
 	}
 	if _, err := s.readTo(incomingHeader); err != nil {
@@ -879,7 +879,7 @@ func (s) TestGracefulClose(t *testing.T) {
 	}
 
 	// Confirm the existing stream still functions as expected.
-	ct.Write(s, nil, nil, &Options{Last: true})
+	s.Write(nil, nil, &WriteOptions{Last: true})
 	if _, err := s.readTo(incomingHeader); err != io.EOF {
 		t.Fatalf("Client expected EOF from the server. Got: %v", err)
 	}
@@ -904,12 +904,12 @@ func (s) TestLargeMessageSuspension(t *testing.T) {
 	// stream.go to keep track of context timeout and call CloseStream.
 	go func() {
 		<-ctx.Done()
-		ct.CloseStream(s, ContextErr(ctx.Err()))
+		s.Close(ContextErr(ctx.Err()))
 	}()
 	// Write should not be done successfully due to flow control.
 	msg := make([]byte, initialWindowSize*8)
-	ct.Write(s, nil, newBufferSlice(msg), &Options{})
-	err = ct.Write(s, nil, newBufferSlice(msg), &Options{Last: true})
+	s.Write(nil, newBufferSlice(msg), &WriteOptions{})
+	err = s.Write(nil, newBufferSlice(msg), &WriteOptions{Last: true})
 	if err != errStreamDone {
 		t.Fatalf("Write got %v, want io.EOF", err)
 	}
@@ -977,7 +977,7 @@ func (s) TestMaxStreams(t *testing.T) {
 	}()
 	// Close all the extra streams created and make sure the new stream is not created.
 	for _, str := range slist {
-		ct.CloseStream(str, nil)
+		str.Close(nil)
 	}
 	select {
 	case <-done:
@@ -985,7 +985,7 @@ func (s) TestMaxStreams(t *testing.T) {
 	default:
 	}
 	// Close the first stream created so that the new stream can finally be created.
-	ct.CloseStream(s, nil)
+	s.Close(nil)
 	<-done
 	ct.Close(fmt.Errorf("closed manually by test"))
 	<-ct.writerDone
@@ -1108,7 +1108,7 @@ func (s) TestClientConnDecoupledFromApplicationRead(t *testing.T) {
 		t.Fatalf("Didn't find stream corresponding to client cstream.id: %v on the server", cstream1.id)
 	}
 	// Exhaust client's connection window.
-	if err := st.Write(sstream1, []byte{}, newBufferSlice(make([]byte, defaultWindowSize)), &Options{}); err != nil {
+	if err := sstream1.Write([]byte{}, newBufferSlice(make([]byte, defaultWindowSize)), &WriteOptions{}); err != nil {
 		t.Fatalf("Server failed to write data. Err: %v", err)
 	}
 	notifyChan = make(chan struct{})
@@ -1133,7 +1133,7 @@ func (s) TestClientConnDecoupledFromApplicationRead(t *testing.T) {
 		t.Fatalf("Didn't find stream corresponding to client cstream.id: %v on the server", cstream2.id)
 	}
 	// Server should be able to send data on the new stream, even though the client hasn't read anything on the first stream.
-	if err := st.Write(sstream2, []byte{}, newBufferSlice(make([]byte, defaultWindowSize)), &Options{}); err != nil {
+	if err := sstream2.Write([]byte{}, newBufferSlice(make([]byte, defaultWindowSize)), &WriteOptions{}); err != nil {
 		t.Fatalf("Server failed to write data. Err: %v", err)
 	}
 
@@ -1179,7 +1179,7 @@ func (s) TestServerConnDecoupledFromApplicationRead(t *testing.T) {
 		t.Fatalf("Failed to create 1st stream. Err: %v", err)
 	}
 	// Exhaust server's connection window.
-	if err := client.Write(cstream1, nil, newBufferSlice(make([]byte, defaultWindowSize)), &Options{Last: true}); err != nil {
+	if err := cstream1.Write(nil, newBufferSlice(make([]byte, defaultWindowSize)), &WriteOptions{Last: true}); err != nil {
 		t.Fatalf("Client failed to write data. Err: %v", err)
 	}
 	//Client should be able to create another stream and send data on it.
@@ -1187,7 +1187,7 @@ func (s) TestServerConnDecoupledFromApplicationRead(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create 2nd stream. Err: %v", err)
 	}
-	if err := client.Write(cstream2, nil, newBufferSlice(make([]byte, defaultWindowSize)), &Options{}); err != nil {
+	if err := cstream2.Write(nil, newBufferSlice(make([]byte, defaultWindowSize)), &WriteOptions{}); err != nil {
 		t.Fatalf("Client failed to write data. Err: %v", err)
 	}
 	// Get the streams on server.
@@ -1458,7 +1458,7 @@ func (s) TestClientWithMisbehavedServer(t *testing.T) {
 	timer := time.NewTimer(time.Second * 5)
 	go func() { // This go routine mimics the one in stream.go to call CloseStream.
 		<-str.Done()
-		ct.CloseStream(str, nil)
+		str.Close(nil)
 	}()
 	select {
 	case <-timer.C:
@@ -1485,8 +1485,8 @@ func (s) TestEncodingRequiredStatus(t *testing.T) {
 	if err != nil {
 		return
 	}
-	opts := Options{Last: true}
-	if err := ct.Write(s, nil, newBufferSlice(expectedRequest), &opts); err != nil && err != errStreamDone {
+	opts := WriteOptions{Last: true}
+	if err := s.Write(nil, newBufferSlice(expectedRequest), &opts); err != nil && err != errStreamDone {
 		t.Fatalf("Failed to write the request: %v", err)
 	}
 	p := make([]byte, http2MaxFrameLen)
@@ -1671,10 +1671,10 @@ func testFlowControlAccountCheck(t *testing.T, msgSize int, wc windowSizeConfig)
 			buf := make([]byte, msgSize+5)
 			buf[0] = byte(0)
 			binary.BigEndian.PutUint32(buf[1:], uint32(msgSize))
-			opts := Options{}
+			opts := WriteOptions{}
 			header := make([]byte, 5)
 			for i := 1; i <= 5; i++ {
-				if err := client.Write(stream, nil, newBufferSlice(buf), &opts); err != nil {
+				if err := stream.Write(nil, newBufferSlice(buf), &opts); err != nil {
 					t.Errorf("Error on client while writing message %v on stream %v: %v", i, stream.id, err)
 					return
 				}
@@ -1714,7 +1714,7 @@ func testFlowControlAccountCheck(t *testing.T, msgSize int, wc windowSizeConfig)
 	st.mu.Unlock()
 	// Close all streams
 	for _, stream := range clientStreams {
-		client.Write(stream, nil, nil, &Options{Last: true})
+		stream.Write(nil, nil, &WriteOptions{Last: true})
 		if _, err := stream.readTo(make([]byte, 5)); err != io.EOF {
 			t.Fatalf("Client expected an EOF from the server. Got: %v", err)
 		}
@@ -2230,7 +2230,7 @@ func (s) TestWriteHeaderConnectionError(t *testing.T) {
 	<-serverTransport.done
 
 	// Write header on a closed server transport.
-	err = serverTransport.WriteHeader(sstream, metadata.MD{})
+	err = sstream.SendHeader(metadata.MD{})
 	st := status.Convert(err)
 	if st.Code() != codes.Unavailable {
 		t.Fatalf("WriteHeader() failed with status code %s, want %s", st.Code(), codes.Unavailable)
@@ -2277,13 +2277,13 @@ func runPingPongTest(t *testing.T, msgSize int) {
 	outgoingHeader := make([]byte, 5)
 	outgoingHeader[0] = byte(0)
 	binary.BigEndian.PutUint32(outgoingHeader[1:], uint32(msgSize))
-	opts := &Options{}
+	opts := &WriteOptions{}
 	incomingHeader := make([]byte, 5)
 
 	ctx, cancel = context.WithTimeout(ctx, 10*time.Millisecond)
 	defer cancel()
 	for ctx.Err() == nil {
-		if err := client.Write(stream, outgoingHeader, newBufferSlice(msg), opts); err != nil {
+		if err := stream.Write(outgoingHeader, newBufferSlice(msg), opts); err != nil {
 			t.Fatalf("Error on client while writing message. Err: %v", err)
 		}
 		if _, err := stream.readTo(incomingHeader); err != nil {
@@ -2296,7 +2296,7 @@ func runPingPongTest(t *testing.T, msgSize int) {
 		}
 	}
 
-	client.Write(stream, nil, nil, &Options{Last: true})
+	stream.Write(nil, nil, &WriteOptions{Last: true})
 	if _, err := stream.readTo(incomingHeader); err != io.EOF {
 		t.Fatalf("Client expected EOF from the server. Got: %v", err)
 	}

--- a/internal/transport/transport_test.go
+++ b/internal/transport/transport_test.go
@@ -80,7 +80,7 @@ func newBufferSlice(b []byte) mem.BufferSlice {
 }
 
 func (s *Stream) readTo(p []byte) (int, error) {
-	data, err := s.Read(len(p))
+	data, err := s.read(len(p))
 	defer data.Free()
 
 	if err != nil {
@@ -2934,7 +2934,7 @@ func (s) TestClientCloseReturnsEarlyWhenGoAwayWriteHangs(t *testing.T) {
 // TestReadHeaderMultipleBuffers tests the stream when the gRPC headers are
 // split across multiple buffers. It verifies that the reporting of the
 // number of bytes read for flow control is correct.
-func (s) TestReadHeaderMultipleBuffers(t *testing.T) {
+func (s) TestReadMessageHeaderMultipleBuffers(t *testing.T) {
 	headerLen := 5
 	recvBuffer := newRecvBuffer()
 	recvBuffer.put(recvMsg{buffer: make(mem.SliceBuffer, 3)})
@@ -2953,7 +2953,7 @@ func (s) TestReadHeaderMultipleBuffers(t *testing.T) {
 	}
 
 	header := make([]byte, headerLen)
-	err := s.ReadHeader(header)
+	err := s.ReadMessageHeader(header)
 	if err != nil {
 		t.Fatalf("ReadHeader(%v) = %v", header, err)
 	}

--- a/rpc_util.go
+++ b/rpc_util.go
@@ -622,7 +622,7 @@ func (pf payloadFormat) isCompressed() bool {
 }
 
 type streamReader interface {
-	ReadHeader(header []byte) error
+	ReadMessageHeader(header []byte) error
 	Read(n int) (mem.BufferSlice, error)
 }
 
@@ -656,7 +656,7 @@ type parser struct {
 // that the underlying streamReader must not return an incompatible
 // error.
 func (p *parser) recvMsg(maxReceiveMessageSize int) (payloadFormat, mem.BufferSlice, error) {
-	err := p.r.ReadHeader(p.header[:])
+	err := p.r.ReadMessageHeader(p.header[:])
 	if err != nil {
 		return 0, nil, err
 	}
@@ -664,9 +664,6 @@ func (p *parser) recvMsg(maxReceiveMessageSize int) (payloadFormat, mem.BufferSl
 	pf := payloadFormat(p.header[0])
 	length := binary.BigEndian.Uint32(p.header[1:])
 
-	if length == 0 {
-		return pf, nil, nil
-	}
 	if int64(length) > int64(maxInt) {
 		return 0, nil, status.Errorf(codes.ResourceExhausted, "grpc: received message larger than max length allowed on current machine (%d vs. %d)", length, maxInt)
 	}

--- a/rpc_util_test.go
+++ b/rpc_util_test.go
@@ -40,7 +40,7 @@ type fullReader struct {
 	data []byte
 }
 
-func (f *fullReader) ReadHeader(header []byte) error {
+func (f *fullReader) ReadMessageHeader(header []byte) error {
 	buf, err := f.Read(len(header))
 	defer buf.Free()
 	if err != nil {
@@ -52,6 +52,10 @@ func (f *fullReader) ReadHeader(header []byte) error {
 }
 
 func (f *fullReader) Read(n int) (mem.BufferSlice, error) {
+	if n == 0 {
+		return nil, nil
+	}
+
 	if len(f.data) == 0 {
 		return nil, io.EOF
 	}

--- a/server.go
+++ b/server.go
@@ -1360,9 +1360,6 @@ func (s *Server) processUnaryRPC(ctx context.Context, t transport.ServerTranspor
 		return err
 	}
 	defer d.Free()
-	if channelz.IsOn() {
-		t.IncrMsgRecv()
-	}
 	df := func(v any) error {
 		if err := s.getCodec(stream.ContentSubtype()).Unmarshal(d, v); err != nil {
 			return status.Errorf(codes.Internal, "grpc: error unmarshalling request: %v", err)
@@ -1483,9 +1480,6 @@ func (s *Server) processUnaryRPC(ctx context.Context, t transport.ServerTranspor
 			binlog.Log(ctx, sh)
 			binlog.Log(ctx, sm)
 		}
-	}
-	if channelz.IsOn() {
-		t.IncrMsgSent()
 	}
 	if trInfo != nil {
 		trInfo.tr.LazyLog(&payload{sent: true, msg: reply}, true)

--- a/stream.go
+++ b/stream.go
@@ -1565,7 +1565,6 @@ type ServerStream interface {
 // serverStream implements a server side Stream.
 type serverStream struct {
 	ctx   context.Context
-	t     transport.ServerTransport
 	s     *transport.ServerStream
 	p     *parser
 	codec baseCodec

--- a/stream.go
+++ b/stream.go
@@ -1097,9 +1097,6 @@ func (a *csAttempt) sendMsg(m any, hdr []byte, payld mem.BufferSlice, dataLength
 			sh.HandleRPC(a.ctx, outPayload(true, m, dataLength, payloadLength, time.Now()))
 		}
 	}
-	if channelz.IsOn() {
-		a.t.IncrMsgSent()
-	}
 	return nil
 }
 
@@ -1152,9 +1149,6 @@ func (a *csAttempt) recvMsg(m any, payInfo *payloadInfo) (err error) {
 			CompressedLength: payInfo.compressedLength,
 			Length:           payInfo.uncompressedBytes.Len(),
 		})
-	}
-	if channelz.IsOn() {
-		a.t.IncrMsgRecv()
 	}
 	if cs.desc.ServerStreams {
 		// Subsequent messages should be received by subsequent RecvMsg calls.
@@ -1440,9 +1434,6 @@ func (as *addrConnStream) SendMsg(m any) (err error) {
 		return io.EOF
 	}
 
-	if channelz.IsOn() {
-		as.t.IncrMsgSent()
-	}
 	return nil
 }
 
@@ -1480,9 +1471,6 @@ func (as *addrConnStream) RecvMsg(m any) (err error) {
 		return toRPCErr(err)
 	}
 
-	if channelz.IsOn() {
-		as.t.IncrMsgRecv()
-	}
 	if as.desc.ServerStreams {
 		// Subsequent messages should be received by subsequent RecvMsg calls.
 		return nil
@@ -1676,9 +1664,6 @@ func (ss *serverStream) SendMsg(m any) (err error) {
 			// status from the service handler, we will log that error instead.
 			// This behavior is similar to an interceptor.
 		}
-		if channelz.IsOn() && err == nil {
-			ss.t.IncrMsgSent()
-		}
 	}()
 
 	// Server handler could have set new compressor by calling SetSendCompressor.
@@ -1763,9 +1748,6 @@ func (ss *serverStream) RecvMsg(m any) (err error) {
 			// This is not handled specifically now. User will return a final
 			// status from the service handler, we will log that error instead.
 			// This behavior is similar to an interceptor.
-		}
-		if channelz.IsOn() && err == nil {
-			ss.t.IncrMsgRecv()
 		}
 	}()
 	var payInfo *payloadInfo


### PR DESCRIPTION
More background refactoring work to potentially allow us to create an interceptor that can read raw bytes, and a couple very minor cleanups, too.

Next up I'm thinking of changing `ReadMessageHeader(buf)` (I found `ReadHeader` ambiguous and confusing) and `Read(n)` into a single `Read() (isCompressed bool, msgBytes mem.BufferSlice, err error)`.  This means the transport needs to understand the grpc header and max message size configuration instead of the grpc layer, but that actually seems pretty straightforward and also appropriate.

RELEASE NOTES: none