### PR TITLE
xdsclient: fix flaky test TestServeAndCloseDoNotRace

### DIFF
--- a/xds/internal/resolver/xds_resolver_test.go
+++ b/xds/internal/resolver/xds_resolver_test.go
@@ -71,6 +71,7 @@ import (
 // build fails as well.
 func (s) TestResolverBuilder_ClientCreationFails_NoBootstrap(t *testing.T) {
 	// Build an xDS resolver without specifying bootstrap env vars.
+	bootstrap.UnsetFallbackBootstrapConfigForTesting()
 	builder := resolver.Get(xdsresolver.Scheme)
 	if builder == nil {
 		t.Fatalf("Scheme %q is not registered", xdsresolver.Scheme)

--- a/xds/internal/xdsclient/authority.go
+++ b/xds/internal/xdsclient/authority.go
@@ -481,7 +481,7 @@ func (a *authority) watchResource(rType xdsresource.Type, resourceName string, w
 		cleanup = a.unwatchResource(rType, resourceName, watcher)
 	}, func() {
 		if a.logger.V(2) {
-			a.logger.Infof("Failed to schedule a watch for type %q, resource name %q", rType.TypeName(), resourceName)
+			a.logger.Infof("Failed to schedule a watch for type %q, resource name %q, because the xDS client is closed", rType.TypeName(), resourceName)
 		}
 		close(done)
 	})

--- a/xds/internal/xdsclient/client_new.go
+++ b/xds/internal/xdsclient/client_new.go
@@ -128,6 +128,11 @@ type OptionsForTesting struct {
 
 // NewForTesting returns an xDS client configured with the provided options.
 //
+// Sets the fallback bootstrap configuration to the contents in the
+// opts.Contents field. This value persists for the life of the test binary. So,
+// tests that want this value to be empty should call
+// bootstrap.UnsetFallbackBootstrapConfigForTesting to ensure the same.
+//
 // The second return value represents a close function which the caller is
 // expected to invoke once they are done using the client.  It is safe for the
 // caller to invoke this close function multiple times.
@@ -152,8 +157,7 @@ func NewForTesting(opts OptionsForTesting) (XDSClient, func(), error) {
 	if err := bootstrap.SetFallbackBootstrapConfig(opts.Contents); err != nil {
 		return nil, nil, err
 	}
-	client, cancel, err := newRefCounted(opts.Name, opts.WatchExpiryTimeout, opts.IdleChannelExpiryTimeout, opts.StreamBackoffAfterFailure)
-	return client, func() { bootstrap.UnsetFallbackBootstrapConfigForTesting(); cancel() }, err
+	return newRefCounted(opts.Name, opts.WatchExpiryTimeout, opts.IdleChannelExpiryTimeout, opts.StreamBackoffAfterFailure)
 }
 
 // GetForTesting returns an xDS client created earlier using the given name.


### PR DESCRIPTION
This PR addresses two issues:
- A bug in the code: 
  - In `authority.watchResource`, the watch is handled by scheduling a callback on the serializer and waiting for the callback to be executed by blocking on a `done` channel that is closed when the callback has completed its work.
  - In the event where we fail to schedule the callback on the serializer, we were not closing the `done` channel. This meant that the `authority.watchResource` call would block forever.
  - The same bug existed in `autority.dumpResources` as well.
- A bug in the test:
  - `xdsclient.NewForTesting` accepts a bootstrap configuration as one of its options and sets the fallback bootstrap configuration (i.e. the configuration that gets used when the bootstrap env vars are not set). As part of the cleanup function that is returned, the fallback bootstrap configuration is unset.
  - In `TestServeAndCloseDoNotRace`, the following happens in a loop:
    - A new xDS-enabled gRPC server is created with the `BootstrapContentsForTesting` server option. This results in an xDS client being created (or refcount on an existing one being incremented) using `xdsclient.NewForTesting` with the provided bootstrap configuration.
    - A goroutine is invoked to call `Serve`.
    - A goroutine is invoked to call `Stop`. This results in the xDS client cleanup function being invoked.
    - This means that there could be a race between one iteration of the loop calling the cleanup function (and therefore erasing the fallback boostrap configuration) and one iteration of the loop creating the server (and therefore writing the fallback bootstrap configuration).
  - The fix involves not resetting the fallback bootstrap configuration from the cleanup function returned by `xdsclient.NewForTesting`, but instead leaving that up to the tests.

Ran on forge for 100K times without a flake.

Fixes https://github.com/grpc/grpc-go/issues/7627

RELEASE NOTES: none