### PR TITLE
xdsclient: don't change any global state in NewForTesting

### DIFF
--- a/xds/internal/resolver/xds_resolver_test.go
+++ b/xds/internal/resolver/xds_resolver_test.go
@@ -71,7 +71,6 @@ import (
 // build fails as well.
 func (s) TestResolverBuilder_ClientCreationFails_NoBootstrap(t *testing.T) {
 	// Build an xDS resolver without specifying bootstrap env vars.
-	bootstrap.UnsetFallbackBootstrapConfigForTesting()
 	builder := resolver.Get(xdsresolver.Scheme)
 	if builder == nil {
 		t.Fatalf("Scheme %q is not registered", xdsresolver.Scheme)

--- a/xds/internal/xdsclient/client_new.go
+++ b/xds/internal/xdsclient/client_new.go
@@ -133,11 +133,6 @@ type OptionsForTesting struct {
 
 // NewForTesting returns an xDS client configured with the provided options.
 //
-// Sets the fallback bootstrap configuration to the contents in the
-// opts.Contents field. This value persists for the life of the test binary. So,
-// tests that want this value to be empty should call
-// bootstrap.UnsetFallbackBootstrapConfigForTesting to ensure the same.
-//
 // The second return value represents a close function which the caller is
 // expected to invoke once they are done using the client.  It is safe for the
 // caller to invoke this close function multiple times.

--- a/xds/internal/xdsclient/client_refcounted.go
+++ b/xds/internal/xdsclient/client_refcounted.go
@@ -19,7 +19,6 @@
 package xdsclient
 
 import (
-	"fmt"
 	"sync/atomic"
 	"time"
 
@@ -63,7 +62,7 @@ func clientRefCountedClose(name string) {
 // newRefCounted creates a new reference counted xDS client implementation for
 // name, if one does not exist already. If an xDS client for the given name
 // exists, it gets a reference to it and returns it.
-func newRefCounted(name string, watchExpiryTimeout, idleChannelExpiryTimeout time.Duration, streamBackoff func(int) time.Duration) (XDSClient, func(), error) {
+func newRefCounted(name string, config *bootstrap.Config, watchExpiryTimeout, idleChannelExpiryTimeout time.Duration, streamBackoff func(int) time.Duration) (XDSClient, func(), error) {
 	clientsMu.Lock()
 	defer clientsMu.Unlock()
 
@@ -73,10 +72,6 @@ func newRefCounted(name string, watchExpiryTimeout, idleChannelExpiryTimeout tim
 	}
 
 	// Create the new client implementation.
-	config, err := bootstrap.GetConfiguration()
-	if err != nil {
-		return nil, nil, fmt.Errorf("xds: failed to get xDS bootstrap config: %v", err)
-	}
 	c, err := newClientImpl(config, watchExpiryTimeout, idleChannelExpiryTimeout, streamBackoff)
 	if err != nil {
 		return nil, nil, err

--- a/xds/server_test.go
+++ b/xds/server_test.go
@@ -176,14 +176,9 @@ func (s) TestNewServer_Failure(t *testing.T) {
 		wantErr    string
 	}{
 		{
-			desc: "bootstrap env var not set",
-			serverOpts: func() []grpc.ServerOption {
-				// Ensure that any fallback bootstrap configuration setup by
-				// previous tests is cleared.
-				bootstrap.UnsetFallbackBootstrapConfigForTesting()
-				return []grpc.ServerOption{grpc.Creds(xdsCreds)}
-			}(),
-			wantErr: "failed to get xDS bootstrap config",
+			desc:       "bootstrap env var not set",
+			serverOpts: []grpc.ServerOption{grpc.Creds(xdsCreds)},
+			wantErr:    "failed to get xDS bootstrap config",
 		},
 		{
 			desc: "empty bootstrap config",
@@ -701,11 +696,8 @@ func (s) TestServeAndCloseDoNotRace(t *testing.T) {
 		t.Fatalf("testutils.LocalTCPListener() failed: %v", err)
 	}
 
-	// Generate bootstrap contents up front for all servers, and clear the
-	// fallback bootstrap configuration that gets set when a server is created
-	// with the BootstrapContentsForTesting() server option.
+	// Generate bootstrap contents up front for all servers.
 	bootstrapContents := generateBootstrapContents(t, uuid.NewString(), nonExistentManagementServer)
-	defer bootstrap.UnsetFallbackBootstrapConfigForTesting()
 
 	wg := sync.WaitGroup{}
 	wg.Add(200)


### PR DESCRIPTION
#### Current state of affairs:

Two ways of creating an xDS client:
- `xdsclient.New`
- `xdsclient.NewForTesting`

Both of these end up calling `newRefCounted` which reads the bootstrap configuration from one of the three supported places (in the given order)
- env var `GRPC_XDS_BOOTSTRAP`
- env var `GRPC_XDS_BOOTSTRAP_CONFIG`
- fallback bootstrap configuration set using `bootstrap.SetFallbackBootstrapConfig`

`xdsclient.NewForTesting` calls `bootstrap.SetFallbackBootstrapConfig` before calling `newRefCounted`, which meant that it was changing global state and thereby making the outcome of the tests dependent on the order in which they are executed.

#### What this PR does:

- Changes `newRefCounted` to accept bootstrap configuration as a parameter instead of reading the configuration from one of the above mentioned places.
- Makes `xdsclient.New` read the bootstrap configuration from one of the above mentioned places, and pass it to `newRefCounted`.
- Makes `xdsclient.NewForTesting` no longer set the fallback configuration, but instead pass the config provided by the test directly to `newRefCounted. This makes it not change any global state.

Fixes https://github.com/grpc/grpc-go/issues/7821

RELEASE NOTES: none