### PR TITLE
protoc-gen-go-grpc: update README to clarify `--go-grpc_opt`

### DIFF
--- a/cmd/protoc-gen-go-grpc/README.md
+++ b/cmd/protoc-gen-go-grpc/README.md
@@ -14,8 +14,8 @@ To restore this behavior, set the option `require_unimplemented_servers=false`.
 E.g.:
 
 ```sh
-   protoc --go-grpc_out=. --go-grpc_opt=require_unimplemented_servers=false \
-          --go-grpc_opt=[other options...]
+  protoc --go-grpc_out=. --go-grpc_opt=require_unimplemented_servers=false \
+  --go-grpc_opt=[other options...]
 ```
 
 Note that this is not recommended, and the option is only provided to restore

--- a/cmd/protoc-gen-go-grpc/README.md
+++ b/cmd/protoc-gen-go-grpc/README.md
@@ -17,6 +17,10 @@ E.g.:
   protoc --go-grpc_out=. --go-grpc_opt=require_unimplemented_servers=false[,other options...] \
 ```
 
+**Using of --go-grpc_out and --go-grpc_opt**
+- `--go-grpc_out=<output-directory>`: This option specifies the output directory for the generated Go gRPC code. The value should be the directory where you want the generated files to be placed (e.g., `.` for the current directory).
+- `--go-grpc_opt=<options>`: This option is used to pass additional settings for code generation, such as configuring compatibility behavior or specifying file path rules. Multiple options can be passed by separating them with commas.
+
 Note that this is not recommended, and the option is only provided to restore
 backward compatibility with previously-generated code.
 

--- a/cmd/protoc-gen-go-grpc/README.md
+++ b/cmd/protoc-gen-go-grpc/README.md
@@ -14,12 +14,9 @@ To restore this behavior, set the option `require_unimplemented_servers=false`.
 E.g.:
 
 ```sh
-  protoc --go-grpc_out=. --go-grpc_opt=require_unimplemented_servers=false[,other options...] \
+   protoc --go-grpc_out=. --go-grpc_opt=require_unimplemented_servers=false \
+          --go-grpc_opt=[other options...]
 ```
-
-**Using of --go-grpc_out and --go-grpc_opt**
-- `--go-grpc_out=<output-directory>`: This option specifies the output directory for the generated Go gRPC code. The value should be the directory where you want the generated files to be placed (e.g., `.` for the current directory).
-- `--go-grpc_opt=<options>`: This option is used to pass additional settings for code generation, such as configuring compatibility behavior or specifying file path rules. Multiple options can be passed by separating them with commas.
 
 Note that this is not recommended, and the option is only provided to restore
 backward compatibility with previously-generated code.


### PR DESCRIPTION
Address: #5651 
RELEASE NOTES: None