### PR TITLE
cleanup: use SliceBuffer directly where no pool is available

### DIFF
--- a/codec.go
+++ b/codec.go
@@ -71,7 +71,7 @@ func (c codecV0Bridge) Marshal(v any) (mem.BufferSlice, error) {
 	if err != nil {
 		return nil, err
 	}
-	return mem.BufferSlice{mem.NewBuffer(&data, nil)}, nil
+	return mem.BufferSlice{mem.SliceBuffer(data)}, nil
 }
 
 func (c codecV0Bridge) Unmarshal(data mem.BufferSlice, v any) (err error) {

--- a/internal/transport/transport_test.go
+++ b/internal/transport/transport_test.go
@@ -76,7 +76,7 @@ func init() {
 }
 
 func newBufferSlice(b []byte) mem.BufferSlice {
-	return mem.BufferSlice{mem.NewBuffer(&b, nil)}
+	return mem.BufferSlice{mem.SliceBuffer(b)}
 }
 
 func (s *Stream) readTo(p []byte) (int, error) {
@@ -1796,7 +1796,7 @@ func (s) TestReadGivesSameErrorAfterAnyErrorOccurs(t *testing.T) {
 	testData := make([]byte, 1)
 	testData[0] = 5
 	testErr := errors.New("test error")
-	s.write(recvMsg{buffer: mem.NewBuffer(&testData, nil), err: testErr})
+	s.write(recvMsg{buffer: mem.SliceBuffer(testData), err: testErr})
 
 	inBuf := make([]byte, 1)
 	actualCount, actualErr := s.readTo(inBuf)
@@ -1807,8 +1807,8 @@ func (s) TestReadGivesSameErrorAfterAnyErrorOccurs(t *testing.T) {
 		t.Errorf("_ , actualErr := s.Read(_) differs; want actualErr.Error() to be %v; got %v", testErr.Error(), actualErr.Error())
 	}
 
-	s.write(recvMsg{buffer: mem.NewBuffer(&testData, nil), err: nil})
-	s.write(recvMsg{buffer: mem.NewBuffer(&testData, nil), err: errors.New("different error from first")})
+	s.write(recvMsg{buffer: mem.SliceBuffer(testData), err: nil})
+	s.write(recvMsg{buffer: mem.SliceBuffer(testData), err: errors.New("different error from first")})
 
 	for i := 0; i < 2; i++ {
 		inBuf := make([]byte, 1)

--- a/preloader.go
+++ b/preloader.go
@@ -62,7 +62,7 @@ func (p *PreparedMsg) Encode(s Stream, msg any) error {
 
 	materializedData := data.Materialize()
 	data.Free()
-	p.encodedData = mem.BufferSlice{mem.NewBuffer(&materializedData, nil)}
+	p.encodedData = mem.BufferSlice{mem.SliceBuffer(materializedData)}
 
 	// TODO: it should be possible to grab the bufferPool from the underlying
 	//  stream implementation with a type cast to its actual type (such as
@@ -76,7 +76,7 @@ func (p *PreparedMsg) Encode(s Stream, msg any) error {
 	if p.pf.isCompressed() {
 		materializedCompData := compData.Materialize()
 		compData.Free()
-		compData = mem.BufferSlice{mem.NewBuffer(&materializedCompData, nil)}
+		compData = mem.BufferSlice{mem.SliceBuffer(materializedCompData)}
 	}
 
 	p.hdr, p.payload = msgHeader(p.encodedData, compData, p.pf)

--- a/rpc_util.go
+++ b/rpc_util.go
@@ -841,7 +841,7 @@ func recvAndDecompress(p *parser, s recvCompressor, dc Decompressor, maxReceiveM
 			var uncompressedBuf []byte
 			uncompressedBuf, err = dc.Do(compressed.Reader())
 			if err == nil {
-				out = mem.BufferSlice{mem.NewBuffer(&uncompressedBuf, nil)}
+				out = mem.BufferSlice{mem.SliceBuffer(uncompressedBuf)}
 			}
 			size = len(uncompressedBuf)
 		} else {

--- a/rpc_util_test.go
+++ b/rpc_util_test.go
@@ -59,13 +59,13 @@ func (f *fullReader) Read(n int) (mem.BufferSlice, error) {
 	if len(f.data) < n {
 		data := f.data
 		f.data = nil
-		return mem.BufferSlice{mem.NewBuffer(&data, nil)}, io.ErrUnexpectedEOF
+		return mem.BufferSlice{mem.SliceBuffer(data)}, io.ErrUnexpectedEOF
 	}
 
 	buf := f.data[:n]
 	f.data = f.data[n:]
 
-	return mem.BufferSlice{mem.NewBuffer(&buf, nil)}, nil
+	return mem.BufferSlice{mem.SliceBuffer(buf)}, nil
 }
 
 var _ CallOption = EmptyCallOption{} // ensure EmptyCallOption implements the interface


### PR DESCRIPTION
As discussed in https://github.com/grpc/grpc-go/pull/7653#issuecomment-2445484589, this is a minor code simplification.

RELEASE NOTES: none