### PR TITLE
grpc: prevent nil-dereference in clientStream.Trailer

### DIFF
--- a/stream.go
+++ b/stream.go
@@ -857,7 +857,7 @@ func (cs *clientStream) Trailer() metadata.MD {
 	// directions -- it will prevent races and should not meaningfully impact
 	// performance.
 	cs.commitAttempt()
-	if cs.attempt.s == nil {
+	if cs.attempt != nil || cs.attempt.s == nil {
 		return nil
 	}
 	return cs.attempt.s.Trailer()


### PR DESCRIPTION
While calling this method from clientStream.finish cs.attempt may be nil. Check it before dereference.

Found by Linux Verification Center (linuxtesting.org) with SVACE.