### PR TITLE
examples: fix debugging example after Dial->NewClient migration

### DIFF
--- a/examples/features/debugging/client/main.go
+++ b/examples/features/debugging/client/main.go
@@ -60,6 +60,7 @@ func main() {
 
 	/***** Initialize manual resolver and Dial *****/
 	r := manual.NewBuilderWithScheme("whatever")
+	r.InitialState(resolver.State{Addresses: []resolver.Address{{Addr: ":10001"}, {Addr: ":10002"}, {Addr: ":10003"}}})
 	// Set up a connection to the server.
 	conn, err := grpc.NewClient(r.Scheme()+":///test.server", grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithResolvers(r), grpc.WithDefaultServiceConfig(`{"loadBalancingPolicy":"round_robin"}`))
 	if err != nil {
@@ -67,7 +68,6 @@ func main() {
 	}
 	defer conn.Close()
 	// Manually provide resolved addresses for the target.
-	r.UpdateState(resolver.State{Addresses: []resolver.Address{{Addr: ":10001"}, {Addr: ":10002"}, {Addr: ":10003"}}})
 
 	c := pb.NewGreeterClient(conn)
 

--- a/examples/features/debugging/server/main.go
+++ b/examples/features/debugging/server/main.go
@@ -61,7 +61,7 @@ func (s *slowServer) SayHello(_ context.Context, in *pb.HelloRequest) (*pb.Hello
 
 func main() {
 	/***** Set up the server serving channelz service. *****/
-	lis, err := net.Listen("tcp", ":50051")
+	lis, err := net.Listen("tcp", ":50052")
 	if err != nil {
 		log.Fatalf("failed to listen: %v", err)
 	}


### PR DESCRIPTION
This addresses a comment in #7049.

The `manual` package's `UpdateState` method cannot be used until after a client attempts to connect.  Maybe that behavior should be change, but this example really wants to use `InitialState` anyway.  Also, make the client and server listen on different ports for channelz, so they can both run at the same time.

RELEASE NOTES:
* examples: fix the debugging example