### PR TITLE
xdsclient: fix resource type documentation to only mention handling xds responses

### DIFF
--- a/xds/internal/xdsclient/client.go
+++ b/xds/internal/xdsclient/client.go
@@ -32,9 +32,9 @@ import (
 type XDSClient interface {
 	// WatchResource uses xDS to discover the resource associated with the
 	// provided resource name. The resource type implementation determines how
-	// xDS requests are sent out and how responses are deserialized and
-	// validated. Upon receipt of a response from the management server, an
-	// appropriate callback on the watcher is invoked.
+	// xDS responses are are deserialized and validated, as received from the
+	// xDS management server. Upon receipt of a response from the management
+	// server, an appropriate callback on the watcher is invoked.
 	//
 	// Most callers will not have a need to use this API directly. They will
 	// instead use a resource-type-specific wrapper API provided by the relevant

--- a/xds/internal/xdsclient/clientimpl_watchers.go
+++ b/xds/internal/xdsclient/clientimpl_watchers.go
@@ -27,10 +27,10 @@ import (
 )
 
 // WatchResource uses xDS to discover the resource associated with the provided
-// resource name. The resource type implementation determines how xDS requests
-// are sent out and how responses are deserialized and validated. Upon receipt
-// of a response from the management server, an appropriate callback on the
-// watcher is invoked.
+// resource name. The resource type implementation determines how xDS responses
+// are are deserialized and validated, as received from the xDS management
+// server. Upon receipt of a response from the management server, an
+// appropriate callback on the watcher is invoked.
 func (c *clientImpl) WatchResource(rType xdsresource.Type, resourceName string, watcher xdsresource.ResourceWatcher) (cancel func()) {
 	// Return early if the client is already closed.
 	//

--- a/xds/internal/xdsclient/xdsresource/resource_type.go
+++ b/xds/internal/xdsclient/xdsresource/resource_type.go
@@ -46,9 +46,9 @@ func init() {
 type Producer interface {
 	// WatchResource uses xDS to discover the resource associated with the
 	// provided resource name. The resource type implementation determines how
-	// xDS requests are sent out and how responses are deserialized and
-	// validated. Upon receipt of a response from the management server, an
-	// appropriate callback on the watcher is invoked.
+	// xDS responses are are deserialized and validated, as received from the
+	// xDS management server. Upon receipt of a response from the management
+	// server, an appropriate callback on the watcher is invoked.
 	WatchResource(rType Type, resourceName string, watcher ResourceWatcher) (cancel func())
 }
 


### PR DESCRIPTION
The resource type implementation does not determine how the xDS requests are sent out. It only controls how responses are deserialized and validated.

RELEASE NOTES: None