### PR TITLE
xdsclient: remove unexported method from ResourceData interface

### DIFF
--- a/xds/internal/xdsclient/xdsresource/resource_type.go
+++ b/xds/internal/xdsclient/xdsresource/resource_type.go
@@ -119,8 +119,6 @@ type Type interface {
 // provide an implementation of this interface to represent the configuration
 // received from the xDS management server.
 type ResourceData interface {
-	isResourceData()
-
 	// RawEqual returns true if the passed in resource data is equal to that of
 	// the receiver, based on the underlying raw protobuf message.
 	RawEqual(ResourceData) bool


### PR DESCRIPTION
Having an unexported method in the `ResourceData` interface is not very useful since it has other exported methods. Implementations are currently forced to embed this interface to satisfy it. But if a breaking change is made to the interface, implementations will panic at runtime if the newly added method is called (since they embed the interface and therefore satisfy the interface, but don't have an implementation for the newly added method).

Removing the unexported interface results in implementations no longer having to embed this interface. Instead, they can rely on compile time type assertions to ensure that their implementation satisfies the interface, and therefore their build will fail at compile time if a breaking change is made to the interface (instead of a runtime panic).

RELEASE NOTES: none