### PR TITLE
stats: deprecate trace and tags methods and remove all usages from internal code

### DIFF
--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -599,12 +599,6 @@ func (t *http2Client) createHeaderFields(ctx context.Context, callHdr *CallHdr) 
 	for k, v := range callAuthData {
 		headerFields = append(headerFields, hpack.HeaderField{Name: k, Value: encodeMetadataHeader(k, v)})
 	}
-	if b := outgoingTags(ctx); b != nil {
-		headerFields = append(headerFields, hpack.HeaderField{Name: "grpc-tags-bin", Value: encodeBinHeader(b)})
-	}
-	if b := outgoingTrace(ctx); b != nil {
-		headerFields = append(headerFields, hpack.HeaderField{Name: "grpc-trace-bin", Value: encodeBinHeader(b)})
-	}
 
 	if md, added, ok := metadataFromOutgoingContextRaw(ctx); ok {
 		var k string
@@ -1840,28 +1834,4 @@ func (t *http2Client) stateForTesting() transportState {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	return t.state
-}
-
-func outgoingTrace(ctx context.Context) []byte {
-	md, ok := metadata.FromOutgoingContext(ctx)
-	if !ok {
-		return nil
-	}
-	traceValues := md.Get("grpc-trace-bin")
-	if len(traceValues) == 0 {
-		return nil
-	}
-	return []byte(traceValues[len(traceValues)-1])
-}
-
-func outgoingTags(ctx context.Context) []byte {
-	md, ok := metadata.FromOutgoingContext(ctx)
-	if !ok {
-		return nil
-	}
-	tagValues := md.Get("grpc-tags-bin")
-	if len(tagValues) == 0 {
-		return nil
-	}
-	return []byte(tagValues[len(tagValues)-1])
 }

--- a/internal/transport/http2_server.go
+++ b/internal/transport/http2_server.go
@@ -539,14 +539,6 @@ func (t *http2Server) operateHeaders(ctx context.Context, frame *http2.MetaHeade
 	// Attach the received metadata to the context.
 	if len(mdata) > 0 {
 		s.ctx = metadata.NewIncomingContext(s.ctx, mdata)
-		if statsTags := mdata["grpc-tags-bin"]; len(statsTags) > 0 {
-			mdata.Set("grpc-tags-bin", string([]byte(statsTags[len(statsTags)-1])))
-			s.ctx = metadata.NewIncomingContext(s.ctx, mdata)
-		}
-		if statsTrace := mdata["grpc-trace-bin"]; len(statsTrace) > 0 {
-			mdata.Set("grpc-trace-bin", string([]byte(statsTrace[len(statsTrace)-1])))
-			s.ctx = metadata.NewIncomingContext(s.ctx, mdata)
-		}
 	}
 	t.mu.Lock()
 	if t.state != reachable {

--- a/internal/transport/http2_server.go
+++ b/internal/transport/http2_server.go
@@ -542,9 +542,6 @@ func (t *http2Server) operateHeaders(ctx context.Context, frame *http2.MetaHeade
 		if statsTags := mdata["grpc-tags-bin"]; len(statsTags) > 0 {
 			s.ctx = stats.SetIncomingTags(s.ctx, []byte(statsTags[len(statsTags)-1]))
 		}
-		if statsTrace := mdata["grpc-trace-bin"]; len(statsTrace) > 0 {
-			s.ctx = stats.SetIncomingTrace(s.ctx, []byte(statsTrace[len(statsTrace)-1]))
-		}
 	}
 	t.mu.Lock()
 	if t.state != reachable {

--- a/internal/transport/http2_server.go
+++ b/internal/transport/http2_server.go
@@ -540,7 +540,12 @@ func (t *http2Server) operateHeaders(ctx context.Context, frame *http2.MetaHeade
 	if len(mdata) > 0 {
 		s.ctx = metadata.NewIncomingContext(s.ctx, mdata)
 		if statsTags := mdata["grpc-tags-bin"]; len(statsTags) > 0 {
-			s.ctx = stats.SetIncomingTags(s.ctx, []byte(statsTags[len(statsTags)-1]))
+			mdata.Set("grpc-tags-bin", string([]byte(statsTags[len(statsTags)-1])))
+			s.ctx = metadata.NewIncomingContext(s.ctx, mdata)
+		}
+		if statsTrace := mdata["grpc-trace-bin"]; len(statsTrace) > 0 {
+			mdata.Set("grpc-trace-bin", string([]byte(statsTrace[len(statsTrace)-1])))
+			s.ctx = metadata.NewIncomingContext(s.ctx, mdata)
 		}
 	}
 	t.mu.Lock()

--- a/stats/opencensus/stats.go
+++ b/stats/opencensus/stats.go
@@ -29,6 +29,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/grpclog"
 	"google.golang.org/grpc/internal"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/stats"
 	"google.golang.org/grpc/status"
 )
@@ -86,7 +87,12 @@ func (csh *clientStatsHandler) statsTagRPC(ctx context.Context, info *stats.RPCT
 
 	// Populate gRPC Metadata with OpenCensus tag map if set by application.
 	if tm := tag.FromContext(ctx); tm != nil {
-		ctx = stats.SetTags(ctx, tag.Encode(tm))
+		md, ok := metadata.FromOutgoingContext(ctx)
+		if !ok {
+			md = metadata.MD{}
+		}
+		md["grpc-tags-bin"] = []string{string(tag.Encode(tm))}
+		ctx = metadata.NewOutgoingContext(ctx, md)
 	}
 	return ctx, mi
 }
@@ -94,18 +100,23 @@ func (csh *clientStatsHandler) statsTagRPC(ctx context.Context, info *stats.RPCT
 // statsTagRPC creates a recording object to derive measurements from in the
 // context, scoping the recordings to per RPC server side (scope of the
 // context). It also deserializes the opencensus tags set in the context's gRPC
-// Metadata, and adds a server method tag to the opencensus tags.
+// Metadata, and adds a server method tag to the opencensus tags. If multiple
+// tags exist, it adds the last one.
 func (ssh *serverStatsHandler) statsTagRPC(ctx context.Context, info *stats.RPCTagInfo) (context.Context, *metricsInfo) {
 	mi := &metricsInfo{
 		startTime: time.Now(),
 		method:    info.FullMethodName,
 	}
 
-	if tagsBin := stats.Tags(ctx); tagsBin != nil {
-		if tags, err := tag.Decode(tagsBin); err == nil {
-			ctx = tag.NewContext(ctx, tags)
+	if md, ok := metadata.FromIncomingContext(ctx); ok {
+		if tgValues := md.Get("grpc-tags-bin"); len(tgValues) > 0 {
+			tagsBin := []byte(tgValues[len(tgValues)-1])
+			if tags, err := tag.Decode(tagsBin); err == nil {
+				ctx = tag.NewContext(ctx, tags)
+			}
 		}
 	}
+
 	// We can ignore the error here because in the error case, the context
 	// passed in is returned. If the call errors, the server side application
 	// layer won't get this key server method information in the tag map, but

--- a/stats/opencensus/trace.go
+++ b/stats/opencensus/trace.go
@@ -24,6 +24,7 @@ import (
 	"go.opencensus.io/trace"
 	"go.opencensus.io/trace/propagation"
 
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/stats"
 	"google.golang.org/grpc/status"
 )
@@ -46,7 +47,12 @@ func (csh *clientStatsHandler) traceTagRPC(ctx context.Context, rti *stats.RPCTa
 	_, span := trace.StartSpan(ctx, mn, trace.WithSampler(csh.to.TS))
 
 	tcBin := propagation.Binary(span.SpanContext())
-	return stats.SetTrace(ctx, tcBin), &traceInfo{
+	md, ok := metadata.FromOutgoingContext(ctx)
+	if !ok {
+		md = metadata.MD{}
+	}
+	md["grpc-trace-bin"] = []string{string(tcBin)}
+	return metadata.NewOutgoingContext(ctx, md), &traceInfo{
 		span:         span,
 		countSentMsg: 0, // msg events scoped to scope of context, per attempt client side
 		countRecvMsg: 0,
@@ -55,12 +61,19 @@ func (csh *clientStatsHandler) traceTagRPC(ctx context.Context, rti *stats.RPCTa
 
 // traceTagRPC populates context with new span data, with a parent based on the
 // spanContext deserialized from context passed in (wire data in gRPC metadata)
-// if present.
+// if present. If multiple spanContexts exist, it takes the last one.
 func (ssh *serverStatsHandler) traceTagRPC(ctx context.Context, rti *stats.RPCTagInfo) (context.Context, *traceInfo) {
 	mn := strings.ReplaceAll(removeLeadingSlash(rti.FullMethodName), "/", ".")
 
+	var tcBin []byte
+	if md, ok := metadata.FromIncomingContext(ctx); ok {
+		if tcValues := md.Get("grpc-trace-bin"); len(tcValues) > 0 {
+			tcBin = []byte(tcValues[len(tcValues)-1])
+		}
+	}
+
 	var span *trace.Span
-	if sc, ok := propagation.FromBinary(stats.Trace(ctx)); ok {
+	if sc, ok := propagation.FromBinary(tcBin); ok {
 		// Returned context is ignored because will populate context with data
 		// that wraps the span instead.
 		_, span = trace.StartSpanWithRemoteParent(ctx, mn, sc, trace.WithSpanKind(trace.SpanKindServer), trace.WithSampler(ssh.to.TS))

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -280,38 +280,6 @@ func Tags(ctx context.Context) []byte {
 	return []byte(traceValues[len(traceValues)-1])
 }
 
-// SetIncomingTags attaches stats tagging data to the context, to be read by
-// the application (not sent in outgoing RPCs).
-//
-// This is intended for gRPC-internal use ONLY.
-//
-// Deprecated: set the `grpc-tags-bin` header in the metadata instead.
-func SetIncomingTags(ctx context.Context, b []byte) context.Context {
-	md, ok := metadata.FromIncomingContext(ctx)
-	if !ok {
-		md = metadata.MD{}
-	}
-	md.Set("grpc-tags-bin", string(b))
-	return metadata.NewIncomingContext(ctx, md)
-}
-
-// OutgoingTags returns the tags from the context for the outbound RPC.
-//
-// This is intended for gRPC-internal use ONLY.
-//
-// Deprecated: obtain the `grpc-tags-bin` header from metadata instead.
-func OutgoingTags(ctx context.Context) []byte {
-	md, ok := metadata.FromOutgoingContext(ctx)
-	if !ok {
-		return nil
-	}
-	tagValues := md.Get("grpc-tags-bin")
-	if len(tagValues) == 0 {
-		return nil
-	}
-	return []byte(tagValues[len(tagValues)-1])
-}
-
 // SetTrace attaches stats tagging data to the context, which will be sent in
 // the outgoing RPC with the header grpc-trace-bin.  Subsequent calls to
 // SetTrace will overwrite the values from earlier calls.
@@ -326,37 +294,6 @@ func SetTrace(ctx context.Context, b []byte) context.Context {
 // Deprecated: obtain the `grpc-trace-bin` header from metadata instead.
 func Trace(ctx context.Context) []byte {
 	traceValues := metadata.ValueFromIncomingContext(ctx, "grpc-trace-bin")
-	if len(traceValues) == 0 {
-		return nil
-	}
-	return []byte(traceValues[len(traceValues)-1])
-}
-
-// SetIncomingTrace attaches stats tagging data to the context's metadata
-// as `grpc-trace-bin` header, to be read by the application (not sent in
-// outgoing RPCs).  It is intended for gRPC-internal use.
-//
-// Deprecated: set the `grpc-trace-bin` header in the metadata instead.
-func SetIncomingTrace(ctx context.Context, b []byte) context.Context {
-	md, ok := metadata.FromIncomingContext(ctx)
-	if !ok {
-		md = metadata.MD{}
-	}
-	md.Set("grpc-trace-bin", string(b))
-	return metadata.NewIncomingContext(ctx, md)
-}
-
-// OutgoingTrace returns the trace from the `grpc-trace-bin` header of the
-// context's metadata for the outbound RPC.  It is intended for gRPC-internal
-// use.
-//
-// Deprecated: obtain the `grpc-trace-bin` header from metadata instead.
-func OutgoingTrace(ctx context.Context) []byte {
-	md, ok := metadata.FromOutgoingContext(ctx)
-	if !ok {
-		return nil
-	}
-	traceValues := md.Get("grpc-trace-bin")
 	if len(traceValues) == 0 {
 		return nil
 	}

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -266,23 +266,14 @@ func (s *ConnEnd) isConnStats() {}
 //
 // Deprecated: set the `grpc-tags-bin` header in the metadata instead.
 func SetTags(ctx context.Context, b []byte) context.Context {
-	md, ok := metadata.FromOutgoingContext(ctx)
-	if !ok {
-		md = metadata.MD{}
-	}
-	md.Set("grpc-tags-bin", string(b))
-	return metadata.NewOutgoingContext(ctx, md)
+	return metadata.AppendToOutgoingContext(ctx, "grpc-tags-bin", string(b))
 }
 
 // Tags returns the tags from the context for the inbound RPC.
 //
 // Deprecated: obtain the `grpc-tags-bin` header from metadata instead.
 func Tags(ctx context.Context) []byte {
-	md, ok := metadata.FromIncomingContext(ctx)
-	if !ok {
-		return nil
-	}
-	traceValues := md.Get("grpc-tags-bin")
+	traceValues := metadata.ValueFromIncomingContext(ctx, "grpc-tags-bin")
 	if len(traceValues) == 0 {
 		return nil
 	}
@@ -327,23 +318,14 @@ func OutgoingTags(ctx context.Context) []byte {
 //
 // Deprecated: set the `grpc-trace-bin` header in the metadata instead.
 func SetTrace(ctx context.Context, b []byte) context.Context {
-	md, ok := metadata.FromOutgoingContext(ctx)
-	if !ok {
-		md = metadata.MD{}
-	}
-	md.Set("grpc-trace-bin", string(b))
-	return metadata.NewOutgoingContext(ctx, md)
+	return metadata.AppendToOutgoingContext(ctx, "grpc-trace-bin", string(b))
 }
 
 // Trace returns the trace from the context for the inbound RPC.
 //
 // Deprecated: obtain the `grpc-trace-bin` header from metadata instead.
 func Trace(ctx context.Context) []byte {
-	md, ok := metadata.FromIncomingContext(ctx)
-	if !ok {
-		return nil
-	}
-	traceValues := md.Get("grpc-trace-bin")
+	traceValues := metadata.ValueFromIncomingContext(ctx, "grpc-trace-bin")
 	if len(traceValues) == 0 {
 		return nil
 	}

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -4618,6 +4618,26 @@ func (s) TestStreamingProxyDoesNotForwardMetadata(t *testing.T) {
 }
 
 func (s) TestStatsTagsAndTrace(t *testing.T) {
+	const mdTraceKey = "grpc-trace-bin"
+	const mdTagsKey = "grpc-tags-bin"
+
+	setTrace := func(ctx context.Context, b []byte) context.Context {
+		md, ok := metadata.FromOutgoingContext(ctx)
+		if !ok {
+			md = metadata.MD{}
+		}
+		md.Set(mdTraceKey, string(b))
+		return metadata.NewOutgoingContext(ctx, md)
+	}
+	setTags := func(ctx context.Context, b []byte) context.Context {
+		md, ok := metadata.FromOutgoingContext(ctx)
+		if !ok {
+			md = metadata.MD{}
+		}
+		md.Set(mdTagsKey, string(b))
+		return metadata.NewOutgoingContext(ctx, md)
+	}
+
 	// Data added to context by client (typically in a stats handler).
 	tags := []byte{1, 5, 2, 4, 3}
 	trace := []byte{5, 2, 1, 3, 4}
@@ -4627,17 +4647,11 @@ func (s) TestStatsTagsAndTrace(t *testing.T) {
 	endpoint := &stubserver.StubServer{
 		EmptyCallF: func(ctx context.Context, _ *testpb.Empty) (*testpb.Empty, error) {
 			md, _ := metadata.FromIncomingContext(ctx)
-			if tg := stats.Tags(ctx); !reflect.DeepEqual(tg, tags) {
-				return nil, status.Errorf(codes.Internal, "stats.Tags(%v)=%v; want %v", ctx, tg, tags)
+			if !reflect.DeepEqual(md[mdTagsKey], []string{string(tags)}) {
+				return nil, status.Errorf(codes.Internal, "md['grpc-tags-bin']=%v; want %v", md[mdTagsKey], tags)
 			}
-			if !reflect.DeepEqual(md["grpc-tags-bin"], []string{string(tags)}) {
-				return nil, status.Errorf(codes.Internal, "md['grpc-tags-bin']=%v; want %v", md["grpc-tags-bin"], tags)
-			}
-			if tr := stats.Trace(ctx); !reflect.DeepEqual(tr, trace) {
-				return nil, status.Errorf(codes.Internal, "stats.Trace(%v)=%v; want %v", ctx, tr, trace)
-			}
-			if !reflect.DeepEqual(md["grpc-trace-bin"], []string{string(trace)}) {
-				return nil, status.Errorf(codes.Internal, "md['grpc-trace-bin']=%v; want %v", md["grpc-trace-bin"], trace)
+			if !reflect.DeepEqual(md[mdTraceKey], []string{string(trace)}) {
+				return nil, status.Errorf(codes.Internal, "md['grpc-trace-bin']=%v; want %v", md[mdTraceKey], trace)
 			}
 			return &testpb.Empty{}, nil
 		},
@@ -4655,10 +4669,10 @@ func (s) TestStatsTagsAndTrace(t *testing.T) {
 		want codes.Code
 	}{
 		{ctx: ctx, want: codes.Internal},
-		{ctx: stats.SetTags(ctx, tags), want: codes.Internal},
-		{ctx: stats.SetTrace(ctx, trace), want: codes.Internal},
-		{ctx: stats.SetTags(stats.SetTrace(ctx, tags), tags), want: codes.Internal},
-		{ctx: stats.SetTags(stats.SetTrace(ctx, trace), tags), want: codes.OK},
+		{ctx: setTags(ctx, tags), want: codes.Internal},
+		{ctx: setTrace(ctx, trace), want: codes.Internal},
+		{ctx: setTags(setTrace(ctx, tags), tags), want: codes.Internal},
+		{ctx: setTags(setTrace(ctx, trace), tags), want: codes.OK},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Addresses: #7836

RELEASE NOTES:

- stats: deprecated trace and tags methods and remove all usages from internal code