### PR TITLE
xdsclient: rename the interface for the transport

### DIFF
--- a/xds/internal/xdsclient/channel.go
+++ b/xds/internal/xdsclient/channel.go
@@ -60,7 +60,7 @@ type xdsChannelEventHandler interface {
 
 // xdsChannelOpts holds the options for creating a new xdsChannel.
 type xdsChannelOpts struct {
-	transport          transport.Interface           // Takes ownership of this transport.
+	transport          transport.Transport           // Takes ownership of this transport.
 	serverConfig       *bootstrap.ServerConfig       // Configuration of the server to connect to.
 	bootstrapConfig    *bootstrap.Config             // Complete bootstrap configuration, used to decode resources.
 	resourceTypeGetter func(string) xdsresource.Type // Function to retrieve resource parsing functionality, based on resource type.
@@ -126,7 +126,7 @@ func newXDSChannel(opts xdsChannelOpts) (*xdsChannel, error) {
 type xdsChannel struct {
 	// The following fields are initialized at creation time and are read-only
 	// after that, and hence need not be guarded by a mutex.
-	transport          transport.Interface           // Takes ownership of this transport (used to make streaming calls).
+	transport          transport.Transport           // Takes ownership of this transport (used to make streaming calls).
 	ads                *ads.StreamImpl               // An ADS stream to the management server.
 	lrs                *lrs.StreamImpl               // An LRS stream to the management server.
 	serverConfig       *bootstrap.ServerConfig       // Configuration of the server to connect to.

--- a/xds/internal/xdsclient/channel_test.go
+++ b/xds/internal/xdsclient/channel_test.go
@@ -148,7 +148,7 @@ func verifyUpdateAndMetadata(ctx context.Context, t *testing.T, eh *testEventHan
 // serverConfig, bootstrapConfig, or resourceTypeGetter) are missing or nil.
 func (s) TestChannel_New_FailureCases(t *testing.T) {
 	type fakeTransport struct {
-		transport.Interface
+		transport.Transport
 	}
 
 	tests := []struct {

--- a/xds/internal/xdsclient/transport/ads/ads_stream.go
+++ b/xds/internal/xdsclient/transport/ads/ads_stream.go
@@ -113,7 +113,7 @@ type StreamImpl struct {
 	// The following fields are initialized from arguments passed to the
 	// constructor and are read-only afterwards, and hence can be accessed
 	// without a mutex.
-	transport          transport.Interface     // Transport to use for ADS stream.
+	transport          transport.Transport     // Transport to use for ADS stream.
 	eventHandler       StreamEventHandler      // Callbacks into the xdsChannel.
 	backoff            func(int) time.Duration // Backoff for retries, after stream failures.
 	nodeProto          *v3corepb.Node          // Identifies the gRPC application.
@@ -136,7 +136,7 @@ type StreamImpl struct {
 
 // StreamOpts contains the options for creating a new ADS Stream.
 type StreamOpts struct {
-	Transport          transport.Interface     // xDS transport to create the stream on.
+	Transport          transport.Transport     // xDS transport to create the stream on.
 	EventHandler       StreamEventHandler      // Callbacks for stream events.
 	Backoff            func(int) time.Duration // Backoff for retries, after stream failures.
 	NodeProto          *v3corepb.Node          // Node proto to identify the gRPC application.

--- a/xds/internal/xdsclient/transport/grpctransport/grpctransport.go
+++ b/xds/internal/xdsclient/transport/grpctransport/grpctransport.go
@@ -48,7 +48,7 @@ type Builder struct{}
 // Build creates a new gRPC-based transport to an xDS server using the provided
 // options. This involves creating a grpc.ClientConn to the server identified by
 // the server URI in the provided options.
-func (b *Builder) Build(opts transport.BuildOptions) (transport.Interface, error) {
+func (b *Builder) Build(opts transport.BuildOptions) (transport.Transport, error) {
 	if opts.ServerConfig == nil {
 		return nil, fmt.Errorf("ServerConfig field in opts cannot be nil")
 	}

--- a/xds/internal/xdsclient/transport/lrs/lrs_stream.go
+++ b/xds/internal/xdsclient/transport/lrs/lrs_stream.go
@@ -55,7 +55,7 @@ const perRPCVerbosityLevel = 9
 type StreamImpl struct {
 	// The following fields are initialized when a Stream instance is created
 	// and are read-only afterwards, and hence can be accessed without a mutex.
-	transport transport.Interface     // Transport to use for LRS stream.
+	transport transport.Transport     // Transport to use for LRS stream.
 	backoff   func(int) time.Duration // Backoff for retries, after stream failures.
 	nodeProto *v3corepb.Node          // Identifies the gRPC application.
 	doneCh    chan struct{}           // To notify exit of LRS goroutine.
@@ -70,7 +70,7 @@ type StreamImpl struct {
 
 // StreamOpts holds the options for creating an lrsStream.
 type StreamOpts struct {
-	Transport transport.Interface     // xDS transport to create the stream on.
+	Transport transport.Transport     // xDS transport to create the stream on.
 	Backoff   func(int) time.Duration // Backoff for retries, after stream failures.
 	NodeProto *v3corepb.Node          // Node proto to identify the gRPC application.
 	LogPrefix string                  // Prefix to be used for log messages.

--- a/xds/internal/xdsclient/transport/transport_interface.go
+++ b/xds/internal/xdsclient/transport/transport_interface.go
@@ -28,7 +28,7 @@ import (
 // Builder is an interface for building a new xDS transport.
 type Builder interface {
 	// Build creates a new xDS transport with the provided options.
-	Build(opts BuildOptions) (Interface, error)
+	Build(opts BuildOptions) (Transport, error)
 }
 
 // BuildOptions contains the options for building a new xDS transport.
@@ -39,12 +39,9 @@ type BuildOptions struct {
 	ServerConfig *bootstrap.ServerConfig
 }
 
-// Interface provides the functionality to communicate with an xDS server using
+// Transport provides the functionality to communicate with an xDS server using
 // streaming calls.
-//
-// TODO(easwars): Rename this to Transport once the existing Transport type is
-// removed.
-type Interface interface {
+type Transport interface {
 	// CreateStreamingCall creates a new streaming call to the xDS server for the
 	// specified method name. The returned StreamingCall interface can be used to
 	// send and receive messages on the stream.


### PR DESCRIPTION
This PR addresses a TODO that was missed at the end of the recent refactors.

RELEASE NOTES: none