### PR TITLE
credentials: remove the context timeout to fix token request failure with non-GCE ADC

### DIFF
--- a/credentials/google/google.go
+++ b/credentials/google/google.go
@@ -22,7 +22,6 @@ package google
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/alts"
@@ -30,8 +29,6 @@ import (
 	"google.golang.org/grpc/grpclog"
 	"google.golang.org/grpc/internal"
 )
-
-const tokenRequestTimeout = 30 * time.Second
 
 var logger = grpclog.Component("credentials")
 
@@ -50,10 +47,8 @@ type DefaultCredentialsOptions struct {
 // This API is experimental.
 func NewDefaultCredentialsWithOptions(opts DefaultCredentialsOptions) credentials.Bundle {
 	if opts.PerRPCCreds == nil {
-		ctx, cancel := context.WithTimeout(context.Background(), tokenRequestTimeout)
-		defer cancel()
 		var err error
-		opts.PerRPCCreds, err = newADC(ctx)
+		opts.PerRPCCreds, err = newADC()
 		if err != nil {
 			logger.Warningf("NewDefaultCredentialsWithOptions: failed to create application oauth: %v", err)
 		}
@@ -121,8 +116,11 @@ var (
 	newALTS = func() credentials.TransportCredentials {
 		return alts.NewClientCreds(alts.DefaultClientOptions())
 	}
-	newADC = func(ctx context.Context) (credentials.PerRPCCredentials, error) {
-		return oauth.NewApplicationDefault(ctx)
+	newADC = func() (credentials.PerRPCCredentials, error) {
+		// If the ADC ends up being Compute Engine Credentials, this context
+		// won't be used. Otherwise, the context dictates all the subsequent
+		// token requests via HTTP. So we cannot have any deadline or timeout.
+		return oauth.NewApplicationDefault(context.Background())
 	}
 )
 

--- a/credentials/google/google_test.go
+++ b/credentials/google/google_test.go
@@ -87,7 +87,7 @@ func overrideNewCredsFuncs() func() {
 		return testALTS
 	}
 	origNewADC := newADC
-	newADC = func(ctx context.Context) (credentials.PerRPCCredentials, error) {
+	newADC = func(context.Context) (credentials.PerRPCCredentials, error) {
 		// We do not use perRPC creds in this test. It is safe to return nil here.
 		return nil, nil
 	}

--- a/credentials/google/google_test.go
+++ b/credentials/google/google_test.go
@@ -87,7 +87,7 @@ func overrideNewCredsFuncs() func() {
 		return testALTS
 	}
 	origNewADC := newADC
-	newADC = func(context.Context) (credentials.PerRPCCredentials, error) {
+	newADC = func() (credentials.PerRPCCredentials, error) {
 		// We do not use perRPC creds in this test. It is safe to return nil here.
 		return nil, nil
 	}

--- a/credentials/google/google_test.go
+++ b/credentials/google/google_test.go
@@ -87,7 +87,7 @@ func overrideNewCredsFuncs() func() {
 		return testALTS
 	}
 	origNewADC := newADC
-	newADC = func() (credentials.PerRPCCredentials, error) {
+	newADC = func(ctx context.Context) (credentials.PerRPCCredentials, error) {
 		// We do not use perRPC creds in this test. It is safe to return nil here.
 		return nil, nil
 	}


### PR DESCRIPTION
The `defer cancel()` is called when `NewDefaultCredentialsWithOptions` returns and this is definitely a problem. It means the context is done, but all non-GCE token sources will rely on it to make HTTP requests to the token endpoint.

Alternatively (or maybe preferably), `NewDefaultCredentialsWithOptions` should take a top-level context. Despite this being an experimental API, I don't think such a breaking change is easy.

RELEASE NOTES: NONE