### PR TITLE
test/xds: remove redundant server when using stubserver in tests

### DIFF
--- a/test/xds/xds_client_ignore_resource_deletion_test.go
+++ b/test/xds/xds_client_ignore_resource_deletion_test.go
@@ -319,8 +319,7 @@ func setupGRPCServerWithModeChangeChannelAndServe(t *testing.T, bootstrapContent
 		},
 	}
 	var err error
-	stub.S, err = xds.NewGRPCServer(grpc.Creds(insecure.NewCredentials()), modeChangeOpt, xds.BootstrapContentsForTesting(bootstrapContents))
-	if err != nil {
+	if stub.S, err = xds.NewGRPCServer(grpc.Creds(insecure.NewCredentials()), modeChangeOpt, xds.BootstrapContentsForTesting(bootstrapContents)); err != nil {
 		t.Fatalf("Failed to create an xDS enabled gRPC server: %v", err)
 	}
 	t.Cleanup(stub.S.Stop)

--- a/test/xds/xds_client_ignore_resource_deletion_test.go
+++ b/test/xds/xds_client_ignore_resource_deletion_test.go
@@ -319,8 +319,8 @@ func setupGRPCServerWithModeChangeChannelAndServe(t *testing.T, bootstrapContent
 		},
 	}
 	var err error
-	sopts := []grpc.ServerOption{grpc.Creds(insecure.NewCredentials()), modeChangeOpt, xds.BootstrapContentsForTesting(bootstrapContents)}
-	if stub.S, err = xds.NewGRPCServer(sopts...); err != nil {
+	stub.S, err = xds.NewGRPCServer(grpc.Creds(insecure.NewCredentials()), modeChangeOpt, xds.BootstrapContentsForTesting(bootstrapContents))
+	if err != nil {
 		t.Fatalf("Failed to create an xDS enabled gRPC server: %v", err)
 	}
 	t.Cleanup(stub.S.Stop)

--- a/test/xds/xds_client_ignore_resource_deletion_test.go
+++ b/test/xds/xds_client_ignore_resource_deletion_test.go
@@ -263,15 +263,15 @@ func generateBootstrapContents(t *testing.T, serverURI string, ignoreResourceDel
 	var serverCfgs json.RawMessage
 	if ignoreResourceDeletion {
 		serverCfgs = []byte(fmt.Sprintf(`[{
-			 "server_uri": %q,
-			 "channel_creds": [{"type": "insecure"}],
-			 "server_features": ["ignore_resource_deletion"]
-		 }]`, serverURI))
+			"server_uri": %q,
+			"channel_creds": [{"type": "insecure"}],
+			"server_features": ["ignore_resource_deletion"]
+		}]`, serverURI))
 	} else {
 		serverCfgs = []byte(fmt.Sprintf(`[{
-			 "server_uri": %q,
-			 "channel_creds": [{"type": "insecure"}]
-		 }]`, serverURI))
+			"server_uri": %q,
+			"channel_creds": [{"type": "insecure"}]
+		}]`, serverURI))
 
 	}
 	bootstrapContents, err := bootstrap.NewContentsForTesting(bootstrap.ConfigOptionsForTesting{

--- a/test/xds/xds_client_ignore_resource_deletion_test.go
+++ b/test/xds/xds_client_ignore_resource_deletion_test.go
@@ -318,10 +318,11 @@ func setupGRPCServerWithModeChangeChannelAndServe(t *testing.T, bootstrapContent
 			return &testpb.SimpleResponse{}, nil
 		},
 	}
-	var err error
-	if stub.S, err = xds.NewGRPCServer(grpc.Creds(insecure.NewCredentials()), modeChangeOpt, xds.BootstrapContentsForTesting(bootstrapContents)); err != nil {
+	server, err := xds.NewGRPCServer(grpc.Creds(insecure.NewCredentials()), modeChangeOpt, xds.BootstrapContentsForTesting(bootstrapContents))
+	if err != nil {
 		t.Fatalf("Failed to create an xDS enabled gRPC server: %v", err)
 	}
+	stub.S = server
 	t.Cleanup(stub.S.Stop)
 
 	stubserver.StartTestService(t, stub)

--- a/test/xds/xds_server_certificate_providers_test.go
+++ b/test/xds/xds_server_certificate_providers_test.go
@@ -104,7 +104,7 @@ func (s) TestServerSideXDS_WithNoCertificateProvidersInBootstrap_Success(t *test
 // instance name specified in the Listener resource will not be present in the
 // bootstrap file. The test verifies that server creation does not fail and that
 // the xDS-enabled gRPC server does not enter "serving" mode.
-func (s) TestServerSideXDS_WithNoCertificateProvidersInBootstrap_Failure(t *testing.T) {
+func TestServerSideXDS_WithNoCertificateProvidersInBootstrap_Failure(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
 
@@ -164,6 +164,7 @@ func (s) TestServerSideXDS_WithNoCertificateProvidersInBootstrap_Failure(t *test
 	if err != nil {
 		t.Fatalf("testutils.LocalTCPListener() failed: %v", err)
 	}
+
 	stub := &stubserver.StubServer{
 		Listener: lis,
 	}

--- a/test/xds/xds_server_certificate_providers_test.go
+++ b/test/xds/xds_server_certificate_providers_test.go
@@ -168,8 +168,7 @@ func (s) TestServerSideXDS_WithNoCertificateProvidersInBootstrap_Failure(t *test
 	stub := &stubserver.StubServer{
 		Listener: lis,
 	}
-	stub.S, err = xds.NewGRPCServer(grpc.Creds(creds), modeChangeOpt, xds.BootstrapContentsForTesting(bs))
-	if err != nil {
+	if stub.S, err = xds.NewGRPCServer(grpc.Creds(creds), modeChangeOpt, xds.BootstrapContentsForTesting(bs)); err != nil {
 		t.Fatalf("Failed to create an xDS enabled gRPC server: %v", err)
 	}
 	defer stub.S.Stop()

--- a/test/xds/xds_server_certificate_providers_test.go
+++ b/test/xds/xds_server_certificate_providers_test.go
@@ -104,7 +104,7 @@ func (s) TestServerSideXDS_WithNoCertificateProvidersInBootstrap_Success(t *test
 // instance name specified in the Listener resource will not be present in the
 // bootstrap file. The test verifies that server creation does not fail and that
 // the xDS-enabled gRPC server does not enter "serving" mode.
-func TestServerSideXDS_WithNoCertificateProvidersInBootstrap_Failure(t *testing.T) {
+func (s) TestServerSideXDS_WithNoCertificateProvidersInBootstrap_Failure(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
 

--- a/test/xds/xds_server_certificate_providers_test.go
+++ b/test/xds/xds_server_certificate_providers_test.go
@@ -227,7 +227,7 @@ func (s) TestServerSideXDS_WithNoCertificateProvidersInBootstrap_Failure(t *test
 //
 // The test verifies that an RPC to the first listener succeeds, while the
 // second listener never moves to "serving" mode and RPCs to it fail.
-func TestServerSideXDS_WithValidAndInvalidSecurityConfiguration(t *testing.T) {
+func (s) TestServerSideXDS_WithValidAndInvalidSecurityConfiguration(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
 

--- a/test/xds/xds_server_certificate_providers_test.go
+++ b/test/xds/xds_server_certificate_providers_test.go
@@ -168,9 +168,9 @@ func (s) TestServerSideXDS_WithNoCertificateProvidersInBootstrap_Failure(t *test
 	stub := &stubserver.StubServer{
 		Listener: lis,
 	}
-	sopts := []grpc.ServerOption{grpc.Creds(creds), modeChangeOpt, xds.BootstrapContentsForTesting(bs)}
-	if stub.S, err = xds.NewGRPCServer(sopts...); err != nil {
-		t.Fatalf("Failed to create an xDS enabled gRPC server:%v", err)
+	stub.S, err = xds.NewGRPCServer(grpc.Creds(creds), modeChangeOpt, xds.BootstrapContentsForTesting(bs))
+	if err != nil {
+		t.Fatalf("Failed to create an xDS enabled gRPC server: %v", err)
 	}
 	defer stub.S.Stop()
 	stubserver.StartTestService(t, stub)

--- a/test/xds/xds_server_certificate_providers_test.go
+++ b/test/xds/xds_server_certificate_providers_test.go
@@ -172,6 +172,7 @@ func (s) TestServerSideXDS_WithNoCertificateProvidersInBootstrap_Failure(t *test
 	if stub.S, err = xds.NewGRPCServer(sopts...); err != nil {
 		t.Fatalf("Failed to create an xDS enabled gRPC server:%v", err)
 	}
+	defer stub.S.Stop()
 	stubserver.StartTestService(t, stub)
 
 	// Create an inbound xDS listener resource for the server side that contains

--- a/test/xds/xds_server_integration_test.go
+++ b/test/xds/xds_server_integration_test.go
@@ -111,8 +111,8 @@ func setupGRPCServer(t *testing.T, bootstrapContents []byte) (net.Listener, func
 		},
 	}
 
-	sopts := []grpc.ServerOption{grpc.Creds(creds), testModeChangeServerOption(t), xds.BootstrapContentsForTesting(bootstrapContents)}
-	if stub.S, err = xds.NewGRPCServer(sopts...); err != nil {
+	stub.S, err = xds.NewGRPCServer(grpc.Creds(creds), testModeChangeServerOption(t), xds.BootstrapContentsForTesting(bootstrapContents))
+	if err != nil {
 		t.Fatalf("Failed to create an xDS enabled gRPC server: %v", err)
 	}
 

--- a/test/xds/xds_server_integration_test.go
+++ b/test/xds/xds_server_integration_test.go
@@ -111,8 +111,7 @@ func setupGRPCServer(t *testing.T, bootstrapContents []byte) (net.Listener, func
 		},
 	}
 
-	stub.S, err = xds.NewGRPCServer(grpc.Creds(creds), testModeChangeServerOption(t), xds.BootstrapContentsForTesting(bootstrapContents))
-	if err != nil {
+	if stub.S, err = xds.NewGRPCServer(grpc.Creds(creds), testModeChangeServerOption(t), xds.BootstrapContentsForTesting(bootstrapContents)); err != nil {
 		t.Fatalf("Failed to create an xDS enabled gRPC server: %v", err)
 	}
 

--- a/test/xds/xds_server_serving_mode_test.go
+++ b/test/xds/xds_server_serving_mode_test.go
@@ -356,8 +356,7 @@ func createStubServer(t *testing.T, lis net.Listener, creds credentials.Transpor
 		},
 	}
 	var err error
-	sopts := []grpc.ServerOption{grpc.Creds(creds), modeChangeOpt, xds.BootstrapContentsForTesting(bootstrapContents)}
-	if stub.S, err = xds.NewGRPCServer(sopts...); err != nil {
+	if stub.S, err = xds.NewGRPCServer(grpc.Creds(creds), modeChangeOpt, xds.BootstrapContentsForTesting(bootstrapContents)); err != nil {
 		t.Fatalf("Failed to create an xDS enabled gRPC server: %v", err)
 	}
 	stubserver.StartTestService(t, stub)

--- a/test/xds/xds_server_serving_mode_test.go
+++ b/test/xds/xds_server_serving_mode_test.go
@@ -366,8 +366,8 @@ func createStubServer(t *testing.T, lis net.Listener, creds credentials.Transpor
 			return &testpb.Empty{}, nil
 		},
 	}
-	sopts := []grpc.ServerOption{grpc.Creds(creds), modeChangeOpt, xds.BootstrapContentsForTesting(bootstrapContents)}
 	var err error
+	sopts := []grpc.ServerOption{grpc.Creds(creds), modeChangeOpt, xds.BootstrapContentsForTesting(bootstrapContents)}
 	if stub.S, err = xds.NewGRPCServer(sopts...); err != nil {
 		t.Fatalf("Failed to create an xDS enabled gRPC server: %v", err)
 	}

--- a/test/xds/xds_server_serving_mode_test.go
+++ b/test/xds/xds_server_serving_mode_test.go
@@ -355,10 +355,11 @@ func createStubServer(t *testing.T, lis net.Listener, creds credentials.Transpor
 			return &testpb.Empty{}, nil
 		},
 	}
-	var err error
-	if stub.S, err = xds.NewGRPCServer(grpc.Creds(creds), modeChangeOpt, xds.BootstrapContentsForTesting(bootstrapContents)); err != nil {
+	server, err := xds.NewGRPCServer(grpc.Creds(creds), modeChangeOpt, xds.BootstrapContentsForTesting(bootstrapContents))
+	if err != nil {
 		t.Fatalf("Failed to create an xDS enabled gRPC server: %v", err)
 	}
+	stub.S = server
 	stubserver.StartTestService(t, stub)
 	return stub
 }

--- a/test/xds/xds_server_serving_mode_test.go
+++ b/test/xds/xds_server_serving_mode_test.go
@@ -169,7 +169,7 @@ func (s) TestServerSideXDS_RedundantUpdateSuppression(t *testing.T) {
 // TestServerSideXDS_ServingModeChanges tests the serving mode functionality in
 // xDS enabled gRPC servers. It verifies that appropriate mode changes happen in
 // the server, and also verifies behavior of clientConns under these modes.
-func TestServerSideXDS_ServingModeChanges(t *testing.T) {
+func (s) TestServerSideXDS_ServingModeChanges(t *testing.T) {
 	managementServer, nodeID, bootstrapContents, _ := setup.ManagementServerAndResolver(t)
 
 	// Configure xDS credentials to be used on the server-side.

--- a/test/xds/xds_server_serving_mode_test.go
+++ b/test/xds/xds_server_serving_mode_test.go
@@ -66,19 +66,8 @@ func (s) TestServerSideXDS_RedundantUpdateSuppression(t *testing.T) {
 
 	// Initialize a test gRPC server, assign it to the stub server, and start
 	// the test service.
-	stub := &stubserver.StubServer{
-		Listener: lis,
-		EmptyCallF: func(ctx context.Context, in *testpb.Empty) (*testpb.Empty, error) {
-			return &testpb.Empty{}, nil
-		},
-	}
-	sopts := []grpc.ServerOption{grpc.Creds(creds), modeChangeOpt, xds.BootstrapContentsForTesting(bootstrapContents)}
-	if stub.S, err = xds.NewGRPCServer(sopts...); err != nil {
-		t.Fatalf("Failed to create an xDS enabled gRPC server: %v", err)
-	}
+	stub := createStubServer(t, lis, creds, modeChangeOpt, bootstrapContents)
 	defer stub.S.Stop()
-
-	stubserver.StartTestService(t, stub)
 
 	// Setup the management server to respond with the listener resources.
 	host, port, err := hostPortFromListener(lis)

--- a/test/xds/xds_server_test.go
+++ b/test/xds/xds_server_test.go
@@ -98,7 +98,7 @@ func (s) TestServeLDSRDS(t *testing.T) {
 	// server-side.
 	creds, err := xdscreds.NewServerCredentials(xdscreds.ServerOptions{FallbackCreds: insecure.NewCredentials()})
 	if err != nil {
-		t.Fatal(err)
+		t.Fatal("failed to create server credentials", err)
 	}
 	stub := createStubServer(t, lis, creds, modeChangeOpt, bootstrapContents)
 	defer stub.S.Stop()
@@ -204,7 +204,7 @@ func (s) TestRDSNack(t *testing.T) {
 	// server-side.
 	creds, err := xdscreds.NewServerCredentials(xdscreds.ServerOptions{FallbackCreds: insecure.NewCredentials()})
 	if err != nil {
-		t.Fatal(err)
+		t.Fatal("failed to create server credentials", err)
 	}
 
 	stub := createStubServer(t, lis, creds, modeChangeOpt, bootstrapContents)
@@ -272,8 +272,7 @@ func (s) TestMultipleUpdatesImmediatelySwitch(t *testing.T) {
 		},
 	}
 
-	sopts := []grpc.ServerOption{grpc.Creds(insecure.NewCredentials()), testModeChangeServerOption(t), xds.BootstrapContentsForTesting(bootstrapContents)}
-	if stub.S, err = xds.NewGRPCServer(sopts...); err != nil {
+	if stub.S, err = xds.NewGRPCServer(grpc.Creds(insecure.NewCredentials()), testModeChangeServerOption(t), xds.BootstrapContentsForTesting(bootstrapContents)); err != nil {
 		t.Fatalf("Failed to create an xDS enabled gRPC server: %v", err)
 	}
 	defer stub.S.Stop()

--- a/test/xds/xds_server_test.go
+++ b/test/xds/xds_server_test.go
@@ -98,7 +98,7 @@ func (s) TestServeLDSRDS(t *testing.T) {
 	// server-side.
 	creds, err := xdscreds.NewServerCredentials(xdscreds.ServerOptions{FallbackCreds: insecure.NewCredentials()})
 	if err != nil {
-		t.Fatal("failed to create server credentials", err)
+		t.Fatalf("failed to create server credentials: %v", err)
 	}
 	stub := createStubServer(t, lis, creds, modeChangeOpt, bootstrapContents)
 	defer stub.S.Stop()
@@ -204,7 +204,7 @@ func (s) TestRDSNack(t *testing.T) {
 	// server-side.
 	creds, err := xdscreds.NewServerCredentials(xdscreds.ServerOptions{FallbackCreds: insecure.NewCredentials()})
 	if err != nil {
-		t.Fatal("failed to create server credentials", err)
+		t.Fatalf("failed to create server credentials: %v", err)
 	}
 
 	stub := createStubServer(t, lis, creds, modeChangeOpt, bootstrapContents)

--- a/test/xds/xds_server_test.go
+++ b/test/xds/xds_server_test.go
@@ -286,7 +286,6 @@ func (s) TestMultipleUpdatesImmediatelySwitch(t *testing.T) {
 		t.Fatalf("Failed to create an xDS enabled gRPC server: %v", err)
 	}
 	defer stub.S.Stop()
-
 	stubserver.StartTestService(t, stub)
 
 	cc, err := grpc.NewClient(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))


### PR DESCRIPTION
Partially Addresses: https://github.com/grpc/grpc-go/issues/7291

RELEASE NOTES: None