### PR TITLE
xdsclient: fix new watcher to get both old good update and nack error (if exist) from the cache 

### DIFF
--- a/xds/internal/xdsclient/authority.go
+++ b/xds/internal/xdsclient/authority.go
@@ -644,7 +644,10 @@ func (a *authority) watchResource(rType xdsresource.Type, resourceName string, w
 		}
 		// If last update was NACK'd, notify the new watcher of error
 		// immediately as well.
-		if state.md.Status == xdsresource.ServiceStatusNACKed && state.md.ErrState != nil {
+		if state.md.Status == xdsresource.ServiceStatusNACKed {
+			if a.logger.V(2) {
+				a.logger.Infof("Resource type %q with resource name %q was NACKed: %s", rType.TypeName(), resourceName, state.cache.ToJSON())
+			}
 			a.watcherCallbackSerializer.TrySchedule(func(context.Context) { watcher.OnError(state.md.ErrState.Err, func() {}) })
 		}
 		// If the metadata field is updated to indicate that the management

--- a/xds/internal/xdsclient/authority.go
+++ b/xds/internal/xdsclient/authority.go
@@ -641,11 +641,11 @@ func (a *authority) watchResource(rType xdsresource.Type, resourceName string, w
 			}
 			resource := state.cache
 			a.watcherCallbackSerializer.TrySchedule(func(context.Context) { watcher.OnUpdate(resource, func() {}) })
-			// If last update was NACK'd, notify the new watcher of error
-			// immediately as well.
-			if state.md.Status == xdsresource.ServiceStatusNACKed && state.md.ErrState != nil {
-				a.watcherCallbackSerializer.TrySchedule(func(context.Context) { watcher.OnError(state.md.ErrState.Err, func() {}) })
-			}
+		}
+		// If last update was NACK'd, notify the new watcher of error
+		// immediately as well.
+		if state.md.Status == xdsresource.ServiceStatusNACKed && state.md.ErrState != nil {
+			a.watcherCallbackSerializer.TrySchedule(func(context.Context) { watcher.OnError(state.md.ErrState.Err, func() {}) })
 		}
 		// If the metadata field is updated to indicate that the management
 		// server does not have this resource, notify the new watcher.

--- a/xds/internal/xdsclient/authority.go
+++ b/xds/internal/xdsclient/authority.go
@@ -633,13 +633,19 @@ func (a *authority) watchResource(rType xdsresource.Type, resourceName string, w
 		// Always add the new watcher to the set of watchers.
 		state.watchers[watcher] = true
 
-		// If we have a cached copy of the resource, notify the new watcher.
+		// If we have a cached copy of the resource, notify the new watcher
+		// immediately.
 		if state.cache != nil {
 			if a.logger.V(2) {
 				a.logger.Infof("Resource type %q with resource name %q found in cache: %s", rType.TypeName(), resourceName, state.cache.ToJSON())
 			}
 			resource := state.cache
 			a.watcherCallbackSerializer.TrySchedule(func(context.Context) { watcher.OnUpdate(resource, func() {}) })
+			// If last update was NACK'd, notify the new watcher of error
+			// immediately as well.
+			if state.md.Status == xdsresource.ServiceStatusNACKed && state.md.ErrState != nil {
+				a.watcherCallbackSerializer.TrySchedule(func(context.Context) { watcher.OnError(state.md.ErrState.Err, func() {}) })
+			}
 		}
 		// If the metadata field is updated to indicate that the management
 		// server does not have this resource, notify the new watcher.

--- a/xds/internal/xdsclient/tests/lds_watchers_test.go
+++ b/xds/internal/xdsclient/tests/lds_watchers_test.go
@@ -95,7 +95,7 @@ type listenerWatcherMultiple struct {
 }
 
 // TODO: delete this once `newListenerWatcher` is modified to handle multiple
-// updates.
+// updates (https://github.com/grpc/grpc-go/issues/7864).
 func newListenerWatcherMultiple(size int) *listenerWatcherMultiple {
 	return &listenerWatcherMultiple{updateCh: testutils.NewChannelWithSize(size)}
 }

--- a/xds/internal/xdsclient/tests/lds_watchers_test.go
+++ b/xds/internal/xdsclient/tests/lds_watchers_test.go
@@ -1127,15 +1127,6 @@ func (s) TestLDSWatch_ResourceCaching_NACKError(t *testing.T) {
 	if gotErr == nil || !strings.Contains(gotErr.Error(), wantListenerNACKErr) {
 		t.Fatalf("update received with error: %v, want %q", gotErr, wantListenerNACKErr)
 	}
-	// No request should get sent out as part of this watch.
-	sCtx, sCancel := context.WithTimeout(ctx, defaultTestShortTimeout)
-	defer sCancel()
-	select {
-	case <-sCtx.Done():
-	case <-secondRequestReceived.Done():
-		t.Fatal("xdsClient sent out request instead of using update from cache")
-	default:
-	}
 }
 
 // TestLDSWatch_PartialValid covers the case where a response from the


### PR DESCRIPTION
Addresses: #7819

If a watch is registered for a listener resource which is already present in the cache with an old good update as well latest NACK error, the new watcher should receive both good update and error, without a new resource request being sent to the management server.

RELEASE NOTES: 

- xds: fixed an edge-case issue where some clients or servers would not receive errors if another channel or server with the same target was already in use.