### PR TITLE
xdsclient: fix new watcher hang when registering for removed resource

### DIFF
--- a/xds/internal/xdsclient/authority.go
+++ b/xds/internal/xdsclient/authority.go
@@ -641,6 +641,11 @@ func (a *authority) watchResource(rType xdsresource.Type, resourceName string, w
 			resource := state.cache
 			a.watcherCallbackSerializer.TrySchedule(func(context.Context) { watcher.OnUpdate(resource, func() {}) })
 		}
+		// If the metadata field is updated to indicate that the management
+		// server does not have this resource, notify the new watcher.
+		if state.md.Status == xdsresource.ServiceStatusNotExist {
+			a.watcherCallbackSerializer.TrySchedule(func(context.Context) { watcher.OnResourceDoesNotExist(func() {}) })
+		}
 		cleanup = a.unwatchResource(rType, resourceName, watcher)
 	}, func() {
 		if a.logger.V(2) {


### PR DESCRIPTION
Addresses: #7819

Right now if any new watcher try to register watcher for removed resource, it hangs as there is no update to be received. This fix adds a condition in xDS Client to trigger watch callback `OnResourceDoesNotExist()` to new watcher if its registering for a removed resource.

RELEASE NOTES:

- xds: fixed an edge-case issue where some clients or servers would not initialize correctly if another channel or server with the same target was already in use.