### PR TITLE
pickfirst: Ensure pickfirst_test.go runs against both new and old policies

### DIFF
--- a/balancer/pickfirst/pickfirst_test.go
+++ b/balancer/pickfirst/pickfirst_test.go
@@ -48,14 +48,14 @@ func Test(t *testing.T) {
 	grpctest.RunSubTests(t, s{})
 }
 
-// TestPickFirstLeaf_InitialResolverError sends a resolver error to the balancer
+// TestPickFirst_InitialResolverError sends a resolver error to the balancer
 // before a valid resolver update. It verifies that the clientconn state is
 // updated to TRANSIENT_FAILURE.
-func (s) TestPickFirstLeaf_InitialResolverError(t *testing.T) {
+func (s) TestPickFirst_InitialResolverError(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
 	cc := testutils.NewBalancerClientConn(t)
-	bal := pickfirstBuilder{}.Build(cc, balancer.BuildOptions{})
+	bal := balancer.Get(Name).Build(cc, balancer.BuildOptions{})
 	defer bal.Close()
 	bal.ResolverError(errors.New("resolution failed: test error"))
 
@@ -81,14 +81,14 @@ func (s) TestPickFirstLeaf_InitialResolverError(t *testing.T) {
 	}
 }
 
-// TestPickFirstLeaf_ResolverErrorinTF sends a resolver error to the balancer
+// TestPickFirst_ResolverErrorinTF sends a resolver error to the balancer
 // before when it's attempting to connect to a SubConn TRANSIENT_FAILURE. It
 // verifies that the picker is updated and the SubConn is not closed.
-func (s) TestPickFirstLeaf_ResolverErrorinTF(t *testing.T) {
+func (s) TestPickFirst_ResolverErrorinTF(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
 	cc := testutils.NewBalancerClientConn(t)
-	bal := pickfirstBuilder{}.Build(cc, balancer.BuildOptions{})
+	bal := balancer.Get(Name).Build(cc, balancer.BuildOptions{})
 	defer bal.Close()
 
 	// After sending a valid update, the LB policy should report CONNECTING.


### PR DESCRIPTION
The tests in `pickfirst_test.go` are meant to test common behaviours of both the new and old pickfirst policies depending on which LB policy is registered under the `pick_first` name. The tests were only using the old policy due to the usage of the   `pickfirstBuilder{}`. This change uses the balancer registry to get the builder.

This change also removed the `Leaf` part in the test names, since these tests are not only for the the new pickfirst.

RELEASE NOTES: N/A