### PR TITLE
credentials/alts/internal/handshaker: avoid looking up SRV and TXT records for handshaker service

### DIFF
--- a/credentials/alts/internal/handshaker/service/service.go
+++ b/credentials/alts/internal/handshaker/service/service.go
@@ -48,7 +48,7 @@ func Dial(hsAddress string) (*grpc.ClientConn, error) {
 		// Create a new connection to the handshaker service. Note that
 		// this connection stays open until the application is closed.
 		var err error
-		hsConn, err = grpc.Dial(hsAddress, grpc.WithTransportCredentials(insecure.NewCredentials()))
+		hsConn, err = grpc.Dial(hsAddress, grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithDisableServiceConfig())
 		if err != nil {
 			return nil, err
 		}

--- a/internal/resolver/dns/dns_resolver.go
+++ b/internal/resolver/dns/dns_resolver.go
@@ -333,7 +333,11 @@ func (d *dnsResolver) lookupHost(ctx context.Context) ([]resolver.Address, error
 func (d *dnsResolver) lookup() (*resolver.State, error) {
 	ctx, cancel := context.WithTimeout(d.ctx, ResolvingTimeout)
 	defer cancel()
-	srv, srvErr := d.lookupSRV(ctx)
+	var srv []resolver.Address
+	var srvErr error
+	if !d.disableServiceConfig {
+		srv, srvErr = d.lookupSRV(ctx)
+	}
 	addrs, hostErr := d.lookupHost(ctx)
 	if hostErr != nil && (srvErr != nil || len(srv) == 0) {
 		return nil, hostErr


### PR DESCRIPTION
When dialing the handshake service, disable the service config to ignore any provided by the resolver.

When doing a DNS resolver lookup, if we've disabled the service config, don't do an SRV record lookup.

RELEASE NOTES: none
