### PR TITLE
stream: add jitter to retry backoff in accordance with gRFC A6

### DIFF
--- a/service_config.go
+++ b/service_config.go
@@ -168,6 +168,7 @@ func init() {
 		return parseServiceConfig(js, defaultMaxCallAttempts)
 	}
 }
+
 func parseServiceConfig(js string, maxAttempts int) *serviceconfig.ParseResult {
 	if len(js) == 0 {
 		return &serviceconfig.ParseResult{Err: fmt.Errorf("no JSON service config provided")}
@@ -297,7 +298,7 @@ func convertRetryPolicy(jrp *jsonRetryPolicy, maxAttempts int) (p *internalservi
 	return rp, nil
 }
 
-func min(a, b *int) *int {
+func minPointers(a, b *int) *int {
 	if *a < *b {
 		return a
 	}
@@ -309,7 +310,7 @@ func getMaxSize(mcMax, doptMax *int, defaultVal int) *int {
 		return &defaultVal
 	}
 	if mcMax != nil && doptMax != nil {
-		return min(mcMax, doptMax)
+		return minPointers(mcMax, doptMax)
 	}
 	if mcMax != nil {
 		return mcMax

--- a/stream.go
+++ b/stream.go
@@ -709,7 +709,7 @@ func (a *csAttempt) shouldRetry(err error) (bool, error) {
 	} else {
 		fact := math.Pow(rp.BackoffMultiplier, float64(cs.numRetriesSincePushback))
 		cur := min(float64(rp.InitialBackoff)*fact, float64(rp.MaxBackoff))
-		// apply a jitter of plus or minus 0.2
+		// Apply jitter by multiplying with a random factor between 0.8 and 1.2
 		cur *= 0.8 + 0.4*rand.Float64()
 		dur = time.Duration(int64(cur))
 		cs.numRetriesSincePushback++


### PR DESCRIPTION
Update the delay calculation to reflect the updated gRFC

Address #7514 

RELEASE NOTES:

* client: update Retry backoff to apply jitter per updates to [gRFC A6](https://github.com/grpc/proposal/blob/master/A6-client-retries.md).