### PR TITLE
cherry-pick #7861 to 1.68.x

### DIFF
--- a/credentials/alts/internal/handshaker/service/service.go
+++ b/credentials/alts/internal/handshaker/service/service.go
@@ -47,8 +47,10 @@ func Dial(hsAddress string) (*grpc.ClientConn, error) {
 	if !ok {
 		// Create a new connection to the handshaker service. Note that
 		// this connection stays open until the application is closed.
+		// Disable the service config to avoid unnecessary TXT record lookups that
+		// cause timeouts with some versions of systemd-resolved.
 		var err error
-		hsConn, err = grpc.Dial(hsAddress, grpc.WithTransportCredentials(insecure.NewCredentials()))
+		hsConn, err = grpc.Dial(hsAddress, grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithDisableServiceConfig())
 		if err != nil {
 			return nil, err
 		}

--- a/internal/resolver/dns/dns_resolver.go
+++ b/internal/resolver/dns/dns_resolver.go
@@ -237,7 +237,9 @@ func (d *dnsResolver) watcher() {
 }
 
 func (d *dnsResolver) lookupSRV(ctx context.Context) ([]resolver.Address, error) {
-	if !EnableSRVLookups {
+	// Skip this particular host to avoid timeouts with some versions of
+	// systemd-resolved.
+	if !EnableSRVLookups || d.host == "metadata.google.internal." {
 		return nil, nil
 	}
 	var newAddrs []resolver.Address


### PR DESCRIPTION
We will need a patch release for this.  Can you take care of that please @purnesh42H?

RELEASE NOTES:

* credentials/alts: disable SRV and TXT lookups for handshaker service to prevent timeouts when retrieving credentials on systems containing a known bug in `systemd-resolved`.