### PR TITLE
scripts/gen-deps: filter out grpc modules

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -11,6 +11,13 @@ not() {
   ! "$@"
 }
 
+# noret_grep will return 0 if zero or more lines were selected, and >1 if an
+# error occurred. Suppresses grep's return code of 1 when there are no matches
+# (for eg, empty file).
+noret_grep() {
+  grep "$@" || [[ $? == 1 ]]
+}
+
 die() {
   echo "$@" >&2
   exit 1

--- a/scripts/gen-deps.sh
+++ b/scripts/gen-deps.sh
@@ -3,6 +3,8 @@
 set -e          # Exit on error
 set -o pipefail # Fail a pipe if any sub-command fails.
 
+source "$(dirname $0)/common.sh"
+
 if [[ "$#" -ne 1 || ! -d "$1" ]]; then
     echo "Specify a valid output directory as the first parameter."
     exit 1
@@ -16,6 +18,6 @@ cd "${SCRIPTS_DIR}/.."
 git ls-files -- '*.go' | grep -v '\(^\|/\)\(internal\|examples\|benchmark\|interop\|test\|testdata\)\(/\|$\)' | xargs dirname | sort -u | while read d; do
   pushd "$d" > /dev/null
   pkg="$(echo "$d" | sed 's;\.;grpc;' | sed 's;/;_;g')"
-  go list -deps . | sort >| "${OUTPUT_DIR}/$pkg"
+  go list -deps . | sort | noret_grep -v 'google.golang.org/grpc' >| "${OUTPUT_DIR}/$pkg"
   popd > /dev/null
 done

--- a/scripts/vet.sh
+++ b/scripts/vet.sh
@@ -8,13 +8,6 @@ source "$(dirname $0)/common.sh"
 # Check to make sure it's safe to modify the user's git repo.
 git status --porcelain | fail_on_output
 
-# noret_grep will return 0 if zero or more lines were selected, and >1 if an
-# error occurred. Suppresses grep's return code of 1 when there are no matches
-# (for eg, empty file).
-noret_grep() {
-  grep "$@" || [[ $? == 1 ]]
-}
-
 # Undo any edits made by this script.
 cleanup() {
   git reset --hard HEAD


### PR DESCRIPTION
Any of grpc's modules should be fine to use anywhere, unless they pull in unwanted dependencies from outside grpc.  Since the deps are generated with all transitive dependencies, simply filtering out all packages under `google.golang.org/grpc` should tell us what we want and not have red Xs on the presubmit statuses when nothing external changes.

RELEASE NOTES: none