### PR TITLE
health, grpc: Deliver health service updates through the health listener

### DIFF
--- a/balancer/pickfirst/pickfirstleaf/pickfirstleaf_ext_test.go
+++ b/balancer/pickfirst/pickfirstleaf/pickfirstleaf_ext_test.go
@@ -1495,7 +1495,7 @@ func subConnAddresses(ctx context.Context, cc *testutils.BalancerClientConn, sub
 	return addresses, nil
 }
 
-// stateStoringBalancer stores the state of the SubConns being created.
+// stateStoringBalancer stores the state of the subconns being created.
 type stateStoringBalancer struct {
 	balancer.Balancer
 	mu       sync.Mutex

--- a/balancer/pickfirst/pickfirstleaf/pickfirstleaf_ext_test.go
+++ b/balancer/pickfirst/pickfirstleaf/pickfirstleaf_ext_test.go
@@ -1495,7 +1495,7 @@ func subConnAddresses(ctx context.Context, cc *testutils.BalancerClientConn, sub
 	return addresses, nil
 }
 
-// stateStoringBalancer stores the state of the subconns being created.
+// stateStoringBalancer stores the state of the SubConns being created.
 type stateStoringBalancer struct {
 	balancer.Balancer
 	mu       sync.Mutex

--- a/balancer_wrapper.go
+++ b/balancer_wrapper.go
@@ -424,9 +424,9 @@ func (acbw *acBalancerWrapper) closeProducers() {
 // for registering listeners.
 type healthProducerRegisterFn = func(context.Context, balancer.SubConn, string, func(balancer.SubConnState)) func()
 
-// healthServiceOpts returns the options for client side health checking.
-// It returns a nil registerHealthListenerFn if client side health checks are
-// disabled.
+// healthServiceOpts returns the service name and a function to register
+// listener for client side health checking. It returns a nil
+// registerHealthListenerFn if client side health checks are disabled.
 // Client side health checking is enabled when all the following
 // conditions are satisfied:
 // 1. Health checking is not disabled using the dial option.
@@ -483,6 +483,8 @@ func (acbw *acBalancerWrapper) RegisterHealthListener(listener func(balancer.Sub
 		if acbw.healthData != hd {
 			return
 		}
+		// If client side health checks are disabled, send the raw connectivity
+		// state and return.
 		if registerFn == nil {
 			listener(balancer.SubConnState{ConnectivityState: connectivity.Ready})
 			return

--- a/health/producer.go
+++ b/health/producer.go
@@ -1,0 +1,121 @@
+/*
+ *
+ * Copyright 2024 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package health
+
+import (
+	"context"
+	"sync"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/balancer"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/connectivity"
+	"google.golang.org/grpc/internal"
+	"google.golang.org/grpc/internal/grpcsync"
+	"google.golang.org/grpc/status"
+)
+
+func init() {
+	producerBuilderSingleton = &producerBuilder{}
+	internal.RegisterClientHealthCheckListener = RegisterClientSideHealthCheckListener
+}
+
+type producerBuilder struct{}
+
+var producerBuilderSingleton *producerBuilder
+
+// Build constructs and returns a producer and its cleanup function.
+func (*producerBuilder) Build(cci any) (balancer.Producer, func()) {
+	doneCh := make(chan struct{})
+	p := &healthServiceProducer{
+		cc:         cci.(grpc.ClientConnInterface),
+		cancelDone: doneCh,
+		cancel: grpcsync.OnceFunc(func() {
+			close(doneCh)
+		}),
+	}
+	return p, func() {
+		p.mu.Lock()
+		defer p.mu.Unlock()
+		p.cancel()
+		<-p.cancelDone
+	}
+}
+
+type healthServiceProducer struct {
+	// The following fields are initialized at build time and read-only after
+	// that and therefore do not need to be guarded by a mutex.
+	cc grpc.ClientConnInterface
+
+	mu         sync.Mutex
+	cancel     func()
+	cancelDone chan (struct{})
+}
+
+// RegisterClientSideHealthCheckListener accepts a listener to provide server
+// health state via the health service.
+//
+// # Experimental
+//
+// Notice: This type is EXPERIMENTAL and may be changed or removed in a
+// later release.
+func RegisterClientSideHealthCheckListener(ctx context.Context, sc balancer.SubConn, opts grpc.HealthCheckOptions) {
+	pr, _ := sc.GetOrBuildProducer(producerBuilderSingleton)
+	p := pr.(*healthServiceProducer)
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.cancel()
+	<-p.cancelDone
+	if opts.Listener == nil {
+		return
+	}
+
+	p.cancelDone = make(chan struct{})
+	ctx, cancel := context.WithCancel(ctx)
+	p.cancel = cancel
+
+	go p.startHealthCheck(ctx, sc, opts, p.cancelDone)
+}
+
+func (p *healthServiceProducer) startHealthCheck(ctx context.Context, sc balancer.SubConn, opts grpc.HealthCheckOptions, closeCh chan struct{}) {
+	defer close(closeCh)
+	serviceName := opts.HealthServiceName
+	newStream := func(method string) (any, error) {
+		return p.cc.NewStream(ctx, &grpc.StreamDesc{ServerStreams: true}, method)
+	}
+
+	setConnectivityState := func(state connectivity.State, err error) {
+		opts.Listener(balancer.SubConnState{
+			ConnectivityState: state,
+			ConnectionError:   err,
+		})
+	}
+
+	// Call the function through the internal variable as tests use it for
+	// mocking.
+	err := internal.HealthCheckFunc(ctx, newStream, setConnectivityState, serviceName)
+	if err == nil {
+		return
+	}
+	if status.Code(err) == codes.Unimplemented {
+		logger.Errorf("Subchannel health check is unimplemented at server side, thus health check is disabled for SubConn %p", sc)
+	} else {
+		logger.Errorf("Health checking failed for SubConn %p: %v", sc, err)
+	}
+}

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -32,8 +32,9 @@ var (
 	// HealthCheckFunc is used to provide client-side LB channel health checking
 	HealthCheckFunc HealthChecker
 	// RegisterClientHealthCheckListener is used to provide a listener for
-	// updates from the client-side health checking service.
-	RegisterClientHealthCheckListener any // func(context.Context, balancer.SubConn, grpc.HealthCheckOptions)
+	// updates from the client-side health checking service. It returns a
+	// function that can be called to stop the health producer.
+	RegisterClientHealthCheckListener any // func(context.Context, balancer.SubConn, grpc.HealthCheckOptions) func()
 	// BalancerUnregister is exported by package balancer to unregister a balancer.
 	BalancerUnregister func(name string)
 	// KeepaliveMinPingTime is the minimum ping interval.  This must be 10s by

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -31,6 +31,9 @@ import (
 var (
 	// HealthCheckFunc is used to provide client-side LB channel health checking
 	HealthCheckFunc HealthChecker
+	// RegisterClientHealthCheckListener is used to provide a listener for
+	// updates from the client-side health checking service.
+	RegisterClientHealthCheckListener any // func(context.Context, balancer.SubConn, grpc.HealthCheckOptions)
 	// BalancerUnregister is exported by package balancer to unregister a balancer.
 	BalancerUnregister func(name string)
 	// KeepaliveMinPingTime is the minimum ping interval.  This must be 10s by

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -34,7 +34,7 @@ var (
 	// RegisterClientHealthCheckListener is used to provide a listener for
 	// updates from the client-side health checking service. It returns a
 	// function that can be called to stop the health producer.
-	RegisterClientHealthCheckListener any // func(context.Context, balancer.SubConn, grpc.HealthCheckOptions) func()
+	RegisterClientHealthCheckListener any // func(ctx context.Context, sc balancer.SubConn, serviceName string, listener func(balancer.SubConnState)) func()
 	// BalancerUnregister is exported by package balancer to unregister a balancer.
 	BalancerUnregister func(name string)
 	// KeepaliveMinPingTime is the minimum ping interval.  This must be 10s by

--- a/test/healthcheck_test.go
+++ b/test/healthcheck_test.go
@@ -64,6 +64,8 @@ func init() {
 	// Till dualstack changes are not implemented and round_robin doesn't
 	// delegate to pickfirst, test a fake petiole policy that delegates to
 	// the new pickfirst balancer.
+	// TODO: https://github.com/grpc/grpc-go/issues/7906 - Remove the fake
+	// petiole policy one round robin starts delegating to pickfirst.
 	if envconfig.NewPickFirstEnabled {
 		healthCheckTestPolicyName = healthCheckingPetiolePolicyName
 	}
@@ -72,10 +74,9 @@ func init() {
 type healthCheckingPetiolePolicyBuilder struct{}
 
 func (bb *healthCheckingPetiolePolicyBuilder) Build(cc balancer.ClientConn, opts balancer.BuildOptions) balancer.Balancer {
-	b := &healthCheckingPetiolePolicy{
+	return &healthCheckingPetiolePolicy{
 		Balancer: balancer.Get(pickfirstleaf.Name).Build(cc, opts),
 	}
-	return b
 }
 
 func (bb *healthCheckingPetiolePolicyBuilder) Name() string {
@@ -307,11 +308,11 @@ func (s) TestHealthCheckHealthServerNotRegistered(t *testing.T) {
 	r.UpdateState(resolver.State{
 		Addresses: []resolver.Address{{Addr: lis.Addr().String()}},
 		ServiceConfig: parseServiceConfig(t, r, fmt.Sprintf(`{
-	"healthCheckConfig": {
-		"serviceName": "foo"
-	},
-	"loadBalancingConfig": [{"%s":{}}]
-}`, healthCheckTestPolicyName))})
+			"healthCheckConfig": {
+				"serviceName": "foo"
+			},
+			"loadBalancingConfig": [{"%s":{}}]
+		}`, healthCheckTestPolicyName))})
 
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
@@ -334,11 +335,11 @@ func (s) TestHealthCheckWithGoAway(t *testing.T) {
 	r.UpdateState(resolver.State{
 		Addresses: []resolver.Address{{Addr: lis.Addr().String()}},
 		ServiceConfig: parseServiceConfig(t, r, fmt.Sprintf(`{
-	"healthCheckConfig": {
-		"serviceName": "foo"
-	},
-	"loadBalancingConfig": [{"%s":{}}]
-}`, healthCheckTestPolicyName))})
+			"healthCheckConfig": {
+				"serviceName": "foo"
+			},
+			"loadBalancingConfig": [{"%s":{}}]
+		}`, healthCheckTestPolicyName))})
 
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
@@ -412,11 +413,11 @@ func (s) TestHealthCheckWithConnClose(t *testing.T) {
 	r.UpdateState(resolver.State{
 		Addresses: []resolver.Address{{Addr: lis.Addr().String()}},
 		ServiceConfig: parseServiceConfig(t, r, fmt.Sprintf(`{
-	"healthCheckConfig": {
-		"serviceName": "foo"
-	},
-	"loadBalancingConfig": [{"%s":{}}]
-}`, healthCheckTestPolicyName))})
+			"healthCheckConfig": {
+				"serviceName": "foo"
+			},
+			"loadBalancingConfig": [{"%s":{}}]
+		}`, healthCheckTestPolicyName))})
 
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
@@ -460,11 +461,11 @@ func (s) TestHealthCheckWithAddrConnDrain(t *testing.T) {
 	cc, r := setupClient(t, &clientConfig{})
 	tc := testgrpc.NewTestServiceClient(cc)
 	sc := parseServiceConfig(t, r, fmt.Sprintf(`{
-	"healthCheckConfig": {
-		"serviceName": "foo"
-	},
-	"loadBalancingConfig": [{"%s":{}}]
-}`, healthCheckTestPolicyName))
+		"healthCheckConfig": {
+			"serviceName": "foo"
+		},
+		"loadBalancingConfig": [{"%s":{}}]
+	}`, healthCheckTestPolicyName))
 	r.UpdateState(resolver.State{
 		Addresses:     []resolver.Address{{Addr: lis.Addr().String()}},
 		ServiceConfig: sc,
@@ -542,11 +543,11 @@ func (s) TestHealthCheckWithClientConnClose(t *testing.T) {
 	r.UpdateState(resolver.State{
 		Addresses: []resolver.Address{{Addr: lis.Addr().String()}},
 		ServiceConfig: parseServiceConfig(t, r, (fmt.Sprintf(`{
-	"healthCheckConfig": {
-		"serviceName": "foo"
-	},
-	"loadBalancingConfig": [{"%s":{}}]
-}`, healthCheckTestPolicyName)))})
+			"healthCheckConfig": {
+				"serviceName": "foo"
+			},
+			"loadBalancingConfig": [{"%s":{}}]
+		}`, healthCheckTestPolicyName)))})
 
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
@@ -609,11 +610,11 @@ func (s) TestHealthCheckWithoutSetConnectivityStateCalledAddrConnShutDown(t *tes
 	// back to client immediately upon receiving the request (client should receive no response until
 	// test ends).
 	sc := parseServiceConfig(t, r, fmt.Sprintf(`{
-	"healthCheckConfig": {
-		"serviceName": "delay"
-	},
-	"loadBalancingConfig": [{"%s":{}}]
-}`, healthCheckTestPolicyName))
+		"healthCheckConfig": {
+			"serviceName": "delay"
+		},
+		"loadBalancingConfig": [{"%s":{}}]
+	}`, healthCheckTestPolicyName))
 	r.UpdateState(resolver.State{
 		Addresses:     []resolver.Address{{Addr: lis.Addr().String()}},
 		ServiceConfig: sc,
@@ -674,11 +675,11 @@ func (s) TestHealthCheckWithoutSetConnectivityStateCalled(t *testing.T) {
 	r.UpdateState(resolver.State{
 		Addresses: []resolver.Address{{Addr: lis.Addr().String()}},
 		ServiceConfig: parseServiceConfig(t, r, fmt.Sprintf(`{
-	"healthCheckConfig": {
-		"serviceName": "delay"
-	},
-	"loadBalancingConfig": [{"%s":{}}]
-}`, healthCheckTestPolicyName))})
+			"healthCheckConfig": {
+				"serviceName": "delay"
+			},
+			"loadBalancingConfig": [{"%s":{}}]
+		}`, healthCheckTestPolicyName))})
 
 	select {
 	case <-hcExitChan:
@@ -712,11 +713,11 @@ func testHealthCheckDisableWithDialOption(t *testing.T, addr string) {
 	r.UpdateState(resolver.State{
 		Addresses: []resolver.Address{{Addr: addr}},
 		ServiceConfig: parseServiceConfig(t, r, fmt.Sprintf(`{
-	"healthCheckConfig": {
-		"serviceName": "foo"
-	},
-	"loadBalancingConfig": [{"%s":{}}]
-}`, healthCheckTestPolicyName))})
+			"healthCheckConfig": {
+				"serviceName": "foo"
+			},
+			"loadBalancingConfig": [{"%s":{}}]
+		}`, healthCheckTestPolicyName))})
 
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
@@ -818,11 +819,11 @@ func (s) TestHealthCheckChannelzCountingCallSuccess(t *testing.T) {
 	r.UpdateState(resolver.State{
 		Addresses: []resolver.Address{{Addr: lis.Addr().String()}},
 		ServiceConfig: parseServiceConfig(t, r, fmt.Sprintf(`{
-	"healthCheckConfig": {
-		"serviceName": "channelzSuccess"
-	},
-	"loadBalancingConfig": [{"%s":{}}]
-}`, healthCheckTestPolicyName))})
+			"healthCheckConfig": {
+				"serviceName": "channelzSuccess"
+			},
+			"loadBalancingConfig": [{"%s":{}}]
+		}`, healthCheckTestPolicyName))})
 
 	if err := verifyResultWithDelay(func() (bool, error) {
 		cm, _ := channelz.GetTopChannels(0, 0)
@@ -867,11 +868,11 @@ func (s) TestHealthCheckChannelzCountingCallFailure(t *testing.T) {
 	r.UpdateState(resolver.State{
 		Addresses: []resolver.Address{{Addr: lis.Addr().String()}},
 		ServiceConfig: parseServiceConfig(t, r, fmt.Sprintf(`{
-	"healthCheckConfig": {
-		"serviceName": "channelzFailure"
-	},
-	"loadBalancingConfig": [{"%s":{}}]
-}`, healthCheckTestPolicyName))})
+			"healthCheckConfig": {
+				"serviceName": "channelzFailure"
+			},
+			"loadBalancingConfig": [{"%s":{}}]
+		}`, healthCheckTestPolicyName))})
 
 	if err := verifyResultWithDelay(func() (bool, error) {
 		cm, _ := channelz.GetTopChannels(0, 0)
@@ -980,20 +981,12 @@ func testHealthCheckSuccess(t *testing.T, e env) {
 // TestHealthCheckFailure invokes the unary Check() RPC on the health server
 // with an expired context and expects the RPC to fail.
 func (s) TestHealthCheckFailure(t *testing.T) {
-	envs := listTestEnv()
-	if envconfig.NewPickFirstEnabled {
-		envs = append([]env{
-			{name: "tcp-clear", network: "tcp", balancer: healthCheckTestPolicyName},
-			{name: "tcp-tls", network: "tcp", security: "tls", balancer: healthCheckTestPolicyName},
-		}, envs...)
-
+	e := env{
+		name:     "tcp-tls",
+		network:  "tcp",
+		security: "tls",
+		balancer: healthCheckTestPolicyName,
 	}
-	for _, e := range envs {
-		testHealthCheckFailure(t, e)
-	}
-}
-
-func testHealthCheckFailure(t *testing.T, e env) {
 	te := newTest(t, e)
 	te.declareLogNoise(
 		"Failed to dial ",
@@ -1280,13 +1273,14 @@ func (s) TestHealthCheckUnregisterHealthListener(t *testing.T) {
 		t.Fatalf("Context timed out waiting for SubConn to enter READY")
 	}
 
-	// Register a health listener and verify it receives updates.
+	// Health check should start only after a health listener is registered.
 	select {
 	case <-hcEnterChan:
 		t.Fatalf("Health service client created prematurely.")
 	case <-time.After(defaultTestShortTimeout):
 	}
 
+	// Register a health listener and verify it receives updates.
 	healthChan := make(chan balancer.SubConnState, 1)
 	sc.RegisterHealthListener(func(scs balancer.SubConnState) {
 		healthChan <- scs
@@ -1301,6 +1295,7 @@ func (s) TestHealthCheckUnregisterHealthListener(t *testing.T) {
 	for readyReceived := false; !readyReceived; {
 		select {
 		case scs := <-healthChan:
+			t.Logf("Received health update: %v", scs)
 			readyReceived = scs.ConnectivityState == connectivity.Ready
 		case <-ctx.Done():
 			t.Fatalf("Context timed out waiting for healthy backend.")

--- a/test/healthcheck_test.go
+++ b/test/healthcheck_test.go
@@ -28,12 +28,17 @@ import (
 	"time"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/balancer"
+	"google.golang.org/grpc/balancer/pickfirst"
+	"google.golang.org/grpc/balancer/pickfirst/pickfirstleaf"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/health"
 	"google.golang.org/grpc/internal"
+	"google.golang.org/grpc/internal/balancer/stub"
 	"google.golang.org/grpc/internal/channelz"
+	"google.golang.org/grpc/internal/envconfig"
 	"google.golang.org/grpc/internal/grpctest"
 	"google.golang.org/grpc/internal/testutils"
 	"google.golang.org/grpc/resolver"
@@ -45,6 +50,46 @@ import (
 	testgrpc "google.golang.org/grpc/interop/grpc_testing"
 	testpb "google.golang.org/grpc/interop/grpc_testing"
 )
+
+const healthCheckingPetiolePolicyName = "health_checking_petiole_policy"
+
+var (
+	// healthCheckTestPolicyName is the LB policy used for testing the health check
+	// service.
+	healthCheckTestPolicyName = "round_robin"
+)
+
+func init() {
+	balancer.Register(&healthCheckingPetiolePolicyBuilder{})
+	// Till dualstack changes are not implemented and round_robin doesn't
+	// delegate to pickfirst, test a fake petiole policy that delegates to
+	// the new pickfirst balancer.
+	if envconfig.NewPickFirstEnabled {
+		healthCheckTestPolicyName = healthCheckingPetiolePolicyName
+	}
+}
+
+type healthCheckingPetiolePolicyBuilder struct{}
+
+func (bb *healthCheckingPetiolePolicyBuilder) Build(cc balancer.ClientConn, opts balancer.BuildOptions) balancer.Balancer {
+	b := &healthCheckingPetiolePolicy{
+		Balancer: balancer.Get(pickfirstleaf.Name).Build(cc, opts),
+	}
+	return b
+}
+
+func (bb *healthCheckingPetiolePolicyBuilder) Name() string {
+	return healthCheckingPetiolePolicyName
+}
+
+func (b *healthCheckingPetiolePolicy) UpdateClientConnState(state balancer.ClientConnState) error {
+	state.ResolverState = pickfirstleaf.EnableHealthListener(state.ResolverState)
+	return b.Balancer.UpdateClientConnState(state)
+}
+
+type healthCheckingPetiolePolicy struct {
+	balancer.Balancer
+}
 
 func newTestHealthServer() *testHealthServer {
 	return newTestHealthServerWithWatchFunc(defaultWatchFunc)
@@ -261,12 +306,12 @@ func (s) TestHealthCheckHealthServerNotRegistered(t *testing.T) {
 	cc, r := setupClient(t, nil)
 	r.UpdateState(resolver.State{
 		Addresses: []resolver.Address{{Addr: lis.Addr().String()}},
-		ServiceConfig: parseServiceConfig(t, r, `{
+		ServiceConfig: parseServiceConfig(t, r, fmt.Sprintf(`{
 	"healthCheckConfig": {
 		"serviceName": "foo"
 	},
-	"loadBalancingConfig": [{"round_robin":{}}]
-}`)})
+	"loadBalancingConfig": [{"%s":{}}]
+}`, healthCheckTestPolicyName))})
 
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
@@ -288,12 +333,12 @@ func (s) TestHealthCheckWithGoAway(t *testing.T) {
 	tc := testgrpc.NewTestServiceClient(cc)
 	r.UpdateState(resolver.State{
 		Addresses: []resolver.Address{{Addr: lis.Addr().String()}},
-		ServiceConfig: parseServiceConfig(t, r, `{
+		ServiceConfig: parseServiceConfig(t, r, fmt.Sprintf(`{
 	"healthCheckConfig": {
 		"serviceName": "foo"
 	},
-	"loadBalancingConfig": [{"round_robin":{}}]
-}`)})
+	"loadBalancingConfig": [{"%s":{}}]
+}`, healthCheckTestPolicyName))})
 
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
@@ -366,12 +411,12 @@ func (s) TestHealthCheckWithConnClose(t *testing.T) {
 	tc := testgrpc.NewTestServiceClient(cc)
 	r.UpdateState(resolver.State{
 		Addresses: []resolver.Address{{Addr: lis.Addr().String()}},
-		ServiceConfig: parseServiceConfig(t, r, `{
+		ServiceConfig: parseServiceConfig(t, r, fmt.Sprintf(`{
 	"healthCheckConfig": {
 		"serviceName": "foo"
 	},
-	"loadBalancingConfig": [{"round_robin":{}}]
-}`)})
+	"loadBalancingConfig": [{"%s":{}}]
+}`, healthCheckTestPolicyName))})
 
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
@@ -414,12 +459,12 @@ func (s) TestHealthCheckWithAddrConnDrain(t *testing.T) {
 	hcEnterChan, hcExitChan := setupHealthCheckWrapper(t)
 	cc, r := setupClient(t, &clientConfig{})
 	tc := testgrpc.NewTestServiceClient(cc)
-	sc := parseServiceConfig(t, r, `{
+	sc := parseServiceConfig(t, r, fmt.Sprintf(`{
 	"healthCheckConfig": {
 		"serviceName": "foo"
 	},
-	"loadBalancingConfig": [{"round_robin":{}}]
-}`)
+	"loadBalancingConfig": [{"%s":{}}]
+}`, healthCheckTestPolicyName))
 	r.UpdateState(resolver.State{
 		Addresses:     []resolver.Address{{Addr: lis.Addr().String()}},
 		ServiceConfig: sc,
@@ -496,12 +541,12 @@ func (s) TestHealthCheckWithClientConnClose(t *testing.T) {
 	tc := testgrpc.NewTestServiceClient(cc)
 	r.UpdateState(resolver.State{
 		Addresses: []resolver.Address{{Addr: lis.Addr().String()}},
-		ServiceConfig: parseServiceConfig(t, r, `{
+		ServiceConfig: parseServiceConfig(t, r, (fmt.Sprintf(`{
 	"healthCheckConfig": {
 		"serviceName": "foo"
 	},
-	"loadBalancingConfig": [{"round_robin":{}}]
-}`)})
+	"loadBalancingConfig": [{"%s":{}}]
+}`, healthCheckTestPolicyName)))})
 
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
@@ -563,12 +608,12 @@ func (s) TestHealthCheckWithoutSetConnectivityStateCalledAddrConnShutDown(t *tes
 	// The serviceName "delay" is specially handled at server side, where response will not be sent
 	// back to client immediately upon receiving the request (client should receive no response until
 	// test ends).
-	sc := parseServiceConfig(t, r, `{
+	sc := parseServiceConfig(t, r, fmt.Sprintf(`{
 	"healthCheckConfig": {
 		"serviceName": "delay"
 	},
-	"loadBalancingConfig": [{"round_robin":{}}]
-}`)
+	"loadBalancingConfig": [{"%s":{}}]
+}`, healthCheckTestPolicyName))
 	r.UpdateState(resolver.State{
 		Addresses:     []resolver.Address{{Addr: lis.Addr().String()}},
 		ServiceConfig: sc,
@@ -628,12 +673,12 @@ func (s) TestHealthCheckWithoutSetConnectivityStateCalled(t *testing.T) {
 	// test ends).
 	r.UpdateState(resolver.State{
 		Addresses: []resolver.Address{{Addr: lis.Addr().String()}},
-		ServiceConfig: parseServiceConfig(t, r, `{
+		ServiceConfig: parseServiceConfig(t, r, fmt.Sprintf(`{
 	"healthCheckConfig": {
 		"serviceName": "delay"
 	},
-	"loadBalancingConfig": [{"round_robin":{}}]
-}`)})
+	"loadBalancingConfig": [{"%s":{}}]
+}`, healthCheckTestPolicyName))})
 
 	select {
 	case <-hcExitChan:
@@ -666,12 +711,12 @@ func testHealthCheckDisableWithDialOption(t *testing.T, addr string) {
 	tc := testgrpc.NewTestServiceClient(cc)
 	r.UpdateState(resolver.State{
 		Addresses: []resolver.Address{{Addr: addr}},
-		ServiceConfig: parseServiceConfig(t, r, `{
+		ServiceConfig: parseServiceConfig(t, r, fmt.Sprintf(`{
 	"healthCheckConfig": {
 		"serviceName": "foo"
 	},
-	"loadBalancingConfig": [{"round_robin":{}}]
-}`)})
+	"loadBalancingConfig": [{"%s":{}}]
+}`, healthCheckTestPolicyName))})
 
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
@@ -772,12 +817,12 @@ func (s) TestHealthCheckChannelzCountingCallSuccess(t *testing.T) {
 	_, r := setupClient(t, nil)
 	r.UpdateState(resolver.State{
 		Addresses: []resolver.Address{{Addr: lis.Addr().String()}},
-		ServiceConfig: parseServiceConfig(t, r, `{
+		ServiceConfig: parseServiceConfig(t, r, fmt.Sprintf(`{
 	"healthCheckConfig": {
 		"serviceName": "channelzSuccess"
 	},
-	"loadBalancingConfig": [{"round_robin":{}}]
-}`)})
+	"loadBalancingConfig": [{"%s":{}}]
+}`, healthCheckTestPolicyName))})
 
 	if err := verifyResultWithDelay(func() (bool, error) {
 		cm, _ := channelz.GetTopChannels(0, 0)
@@ -821,12 +866,12 @@ func (s) TestHealthCheckChannelzCountingCallFailure(t *testing.T) {
 	_, r := setupClient(t, nil)
 	r.UpdateState(resolver.State{
 		Addresses: []resolver.Address{{Addr: lis.Addr().String()}},
-		ServiceConfig: parseServiceConfig(t, r, `{
+		ServiceConfig: parseServiceConfig(t, r, fmt.Sprintf(`{
 	"healthCheckConfig": {
 		"serviceName": "channelzFailure"
 	},
-	"loadBalancingConfig": [{"round_robin":{}}]
-}`)})
+	"loadBalancingConfig": [{"%s":{}}]
+}`, healthCheckTestPolicyName))})
 
 	if err := verifyResultWithDelay(func() (bool, error) {
 		cm, _ := channelz.GetTopChannels(0, 0)
@@ -935,7 +980,15 @@ func testHealthCheckSuccess(t *testing.T, e env) {
 // TestHealthCheckFailure invokes the unary Check() RPC on the health server
 // with an expired context and expects the RPC to fail.
 func (s) TestHealthCheckFailure(t *testing.T) {
-	for _, e := range listTestEnv() {
+	envs := listTestEnv()
+	if envconfig.NewPickFirstEnabled {
+		envs = append([]env{
+			{name: "tcp-clear", network: "tcp", balancer: healthCheckTestPolicyName},
+			{name: "tcp-tls", network: "tcp", security: "tls", balancer: healthCheckTestPolicyName},
+		}, envs...)
+
+	}
+	for _, e := range envs {
 		testHealthCheckFailure(t, e)
 	}
 }
@@ -1165,4 +1218,110 @@ func testHealthCheckServingStatus(t *testing.T, e env) {
 	verifyHealthCheckStatus(t, 1*time.Second, cc, defaultHealthService, healthpb.HealthCheckResponse_SERVING)
 	te.setHealthServingStatus(defaultHealthService, healthpb.HealthCheckResponse_NOT_SERVING)
 	verifyHealthCheckStatus(t, 1*time.Second, cc, defaultHealthService, healthpb.HealthCheckResponse_NOT_SERVING)
+}
+
+// Test verifies that registering a nil health listener closes the health
+// client.
+func (s) TestHealthCheckUnregisterHealthListener(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	hcEnterChan, hcExitChan := setupHealthCheckWrapper(t)
+	scChan := make(chan balancer.SubConn, 1)
+	readyUpdateReceivedCh := make(chan struct{})
+	bf := stub.BalancerFuncs{
+		Init: func(bd *stub.BalancerData) {
+			cc := bd.ClientConn
+			ccw := &subConnStoringCCWrapper{
+				ClientConn: cc,
+				scChan:     scChan,
+				stateListener: func(scs balancer.SubConnState) {
+					if scs.ConnectivityState != connectivity.Ready {
+						return
+					}
+					close(readyUpdateReceivedCh)
+				},
+			}
+			bd.Data = balancer.Get(pickfirst.Name).Build(ccw, bd.BuildOptions)
+		},
+		Close: func(bd *stub.BalancerData) {
+			bd.Data.(balancer.Balancer).Close()
+		},
+		UpdateClientConnState: func(bd *stub.BalancerData, ccs balancer.ClientConnState) error {
+			return bd.Data.(balancer.Balancer).UpdateClientConnState(ccs)
+		},
+	}
+
+	stub.Register(t.Name(), bf)
+	_, lis, ts := setupServer(t, nil)
+	ts.SetServingStatus("foo", healthpb.HealthCheckResponse_SERVING)
+
+	_, r := setupClient(t, nil)
+	svcCfg := fmt.Sprintf(`{
+	    "healthCheckConfig": {
+		    "serviceName": "foo"
+	    },
+	    "loadBalancingConfig": [{"%s":{}}]
+    }`, t.Name())
+	r.UpdateState(resolver.State{
+		Addresses:     []resolver.Address{{Addr: lis.Addr().String()}},
+		ServiceConfig: parseServiceConfig(t, r, svcCfg)})
+
+	var sc balancer.SubConn
+	select {
+	case sc = <-scChan:
+	case <-ctx.Done():
+		t.Fatal("Context timed out waiting for SubConn creation")
+	}
+
+	// Wait for the SubConn to enter READY.
+	select {
+	case <-readyUpdateReceivedCh:
+	case <-ctx.Done():
+		t.Fatalf("Context timed out waiting for SubConn to enter READY")
+	}
+
+	// Register a health listener and verify it receives updates.
+	select {
+	case <-hcEnterChan:
+		t.Fatalf("Health service client created prematurely.")
+	case <-time.After(defaultTestShortTimeout):
+	}
+
+	healthChan := make(chan balancer.SubConnState, 1)
+	sc.RegisterHealthListener(func(scs balancer.SubConnState) {
+		healthChan <- scs
+	})
+
+	select {
+	case <-hcEnterChan:
+	case <-ctx.Done():
+		t.Fatalf("Context timed out waiting for health check to begin.")
+	}
+
+	for readyReceived := false; !readyReceived; {
+		select {
+		case scs := <-healthChan:
+			readyReceived = scs.ConnectivityState == connectivity.Ready
+		case <-ctx.Done():
+			t.Fatalf("Context timed out waiting for healthy backend.")
+		}
+	}
+
+	// Registering a nil listener should invalidate the previously registered
+	// listener and close the health service client.
+	sc.RegisterHealthListener(nil)
+	select {
+	case <-hcExitChan:
+	case <-ctx.Done():
+		t.Fatalf("Context timed out waiting for the health client to close.")
+	}
+
+	ts.SetServingStatus("foo", healthpb.HealthCheckResponse_NOT_SERVING)
+
+	// No updates should be received on the listener.
+	select {
+	case scs := <-healthChan:
+		t.Fatalf("Received unexpected health update on the listener: %v", scs)
+	case <-time.After(defaultTestShortTimeout):
+	}
 }

--- a/test/healthcheck_test.go
+++ b/test/healthcheck_test.go
@@ -1250,11 +1250,11 @@ func (s) TestHealthCheckUnregisterHealthListener(t *testing.T) {
 
 	_, r := setupClient(t, nil)
 	svcCfg := fmt.Sprintf(`{
-	    "healthCheckConfig": {
-		    "serviceName": "foo"
-	    },
-	    "loadBalancingConfig": [{"%s":{}}]
-    }`, t.Name())
+		"healthCheckConfig": {
+			"serviceName": "foo"
+		},
+		"loadBalancingConfig": [{"%s":{}}]
+	}`, t.Name())
 	r.UpdateState(resolver.State{
 		Addresses:     []resolver.Address{{Addr: lis.Addr().String()}},
 		ServiceConfig: parseServiceConfig(t, r, svcCfg)})


### PR DESCRIPTION
As part of the [dualstack changes described in A61](https://github.com/grpc/proposal/blob/master/A61-IPv4-IPv6-dualstack-backends.md#generic-health-reporting-mechanism), client side health check updates need to be delivered through the health listener instead of the raw connectivity listener. This PR creates a `health producer` that manages the health service client and allows registration of a listener for receiving updates. The `RegisterHealthListener` method in `acBalancerWrapper` decides whether client side health checking is enabled, if it is, it registers the health listener with the health producer. `acBalancerWrapper` wraps the LB policy's listener to synchronize updates from the health producer.

Existing health check tests are run against the health producer when the `GRPC_EXPERIMENTAL_ENABLE_NEW_PICK_FIRST` is set to `true`.

RELEASE NOTES: N/A