### PR TITLE
#5888 cleanup old env vars

### DIFF
--- a/credentials/tls_ext_test.go
+++ b/credentials/tls_ext_test.go
@@ -445,136 +445,104 @@ func (s) TestTLS_ServerConfiguresALPNByDefault(t *testing.T) {
 // TestTLS_DisabledALPNClient tests the behaviour of TransportCredentials when
 // connecting to a server that doesn't support ALPN.
 func (s) TestTLS_DisabledALPNClient(t *testing.T) {
-	tests := []struct {
-		name         string
-		alpnEnforced bool
-		wantErr      bool
-	}{
-		{
-			name:         "enforced",
-			alpnEnforced: true,
-			wantErr:      true,
-		},
+	listener, err := tls.Listen("tcp", "localhost:0", &tls.Config{
+		Certificates: []tls.Certificate{serverCert},
+		NextProtos:   []string{}, // Empty list indicates ALPN is disabled.
+	})
+	if err != nil {
+		t.Fatalf("Error starting TLS server: %v", err)
 	}
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			listener, err := tls.Listen("tcp", "localhost:0", &tls.Config{
-				Certificates: []tls.Certificate{serverCert},
-				NextProtos:   []string{}, // Empty list indicates ALPN is disabled.
-			})
-			if err != nil {
-				t.Fatalf("Error starting TLS server: %v", err)
-			}
+	errCh := make(chan error, 1)
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			errCh <- fmt.Errorf("listener.Accept returned error: %v", err)
+		} else {
+			// The first write to the TLS listener initiates the TLS handshake.
+			conn.Write([]byte("Hello, World!"))
+			conn.Close()
+		}
+		close(errCh)
+	}()
 
-			errCh := make(chan error, 1)
-			go func() {
-				conn, err := listener.Accept()
-				if err != nil {
-					errCh <- fmt.Errorf("listener.Accept returned error: %v", err)
-				} else {
-					// The first write to the TLS listener initiates the TLS handshake.
-					conn.Write([]byte("Hello, World!"))
-					conn.Close()
-				}
-				close(errCh)
-			}()
+	serverAddr := listener.Addr().String()
+	conn, err := net.Dial("tcp", serverAddr)
+	if err != nil {
+		t.Fatalf("net.Dial(%s) failed: %v", serverAddr, err)
+	}
+	defer conn.Close()
 
-			serverAddr := listener.Addr().String()
-			conn, err := net.Dial("tcp", serverAddr)
-			if err != nil {
-				t.Fatalf("net.Dial(%s) failed: %v", serverAddr, err)
-			}
-			defer conn.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
 
-			ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
-			defer cancel()
+	clientCfg := tls.Config{
+		ServerName: serverName,
+		RootCAs:    certPool,
+		NextProtos: []string{"h2"},
+	}
+	_, _, err = credentials.NewTLS(&clientCfg).ClientHandshake(ctx, serverName, conn)
 
-			clientCfg := tls.Config{
-				ServerName: serverName,
-				RootCAs:    certPool,
-				NextProtos: []string{"h2"},
-			}
-			_, _, err = credentials.NewTLS(&clientCfg).ClientHandshake(ctx, serverName, conn)
+	if err == nil {
+		t.Errorf("expected ClientHandshake to return an error but did not")
+	}
 
-			if gotErr := (err != nil); gotErr != tc.wantErr {
-				t.Errorf("ClientHandshake returned unexpected error: got=%v, want=%t", err, tc.wantErr)
-			}
-
-			select {
-			case err := <-errCh:
-				if err != nil {
-					t.Fatalf("Unexpected error received from server: %v", err)
-				}
-			case <-ctx.Done():
-				t.Fatalf("Timeout waiting for error from server")
-			}
-		})
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("Unexpected error received from server: %v", err)
+		}
+	case <-ctx.Done():
+		t.Fatalf("Timeout waiting for error from server")
 	}
 }
 
 // TestTLS_DisabledALPNServer tests the behaviour of TransportCredentials when
 // accepting a request from a client that doesn't support ALPN.
 func (s) TestTLS_DisabledALPNServer(t *testing.T) {
-	tests := []struct {
-		name         string
-		alpnEnforced bool
-		wantErr      bool
-	}{
-		{
-			name:         "enforced",
-			alpnEnforced: true,
-			wantErr:      true,
-		},
+	listener, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("Error starting server: %v", err)
 	}
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			listener, err := net.Listen("tcp", "localhost:0")
-			if err != nil {
-				t.Fatalf("Error starting server: %v", err)
-			}
+	errCh := make(chan error, 1)
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			errCh <- fmt.Errorf("listener.Accept returned error: %v", err)
+			return
+		}
+		defer conn.Close()
+		serverCfg := tls.Config{
+			Certificates: []tls.Certificate{serverCert},
+			NextProtos:   []string{"h2"},
+		}
+		_, _, err = credentials.NewTLS(&serverCfg).ServerHandshake(conn)
+		if err == nil {
+			t.Errorf("expected ServerHandshake to return an error but")
+		}
+		close(errCh)
+	}()
 
-			errCh := make(chan error, 1)
-			go func() {
-				conn, err := listener.Accept()
-				if err != nil {
-					errCh <- fmt.Errorf("listener.Accept returned error: %v", err)
-					return
-				}
-				defer conn.Close()
-				serverCfg := tls.Config{
-					Certificates: []tls.Certificate{serverCert},
-					NextProtos:   []string{"h2"},
-				}
-				_, _, err = credentials.NewTLS(&serverCfg).ServerHandshake(conn)
-				if gotErr := (err != nil); gotErr != tc.wantErr {
-					t.Errorf("ServerHandshake returned unexpected error: got=%v, want=%t", err, tc.wantErr)
-				}
-				close(errCh)
-			}()
+	serverAddr := listener.Addr().String()
+	clientCfg := &tls.Config{
+		Certificates: []tls.Certificate{serverCert},
+		NextProtos:   []string{}, // Empty list indicates ALPN is disabled.
+		RootCAs:      certPool,
+		ServerName:   serverName,
+	}
+	conn, err := tls.Dial("tcp", serverAddr, clientCfg)
+	if err != nil {
+		t.Fatalf("tls.Dial(%s) failed: %v", serverAddr, err)
+	}
+	defer conn.Close()
 
-			serverAddr := listener.Addr().String()
-			clientCfg := &tls.Config{
-				Certificates: []tls.Certificate{serverCert},
-				NextProtos:   []string{}, // Empty list indicates ALPN is disabled.
-				RootCAs:      certPool,
-				ServerName:   serverName,
-			}
-			conn, err := tls.Dial("tcp", serverAddr, clientCfg)
-			if err != nil {
-				t.Fatalf("tls.Dial(%s) failed: %v", serverAddr, err)
-			}
-			defer conn.Close()
-
-			select {
-			case <-time.After(defaultTestTimeout):
-				t.Fatal("Timed out waiting for completion")
-			case err := <-errCh:
-				if err != nil {
-					t.Fatalf("Unexpected server error: %v", err)
-				}
-			}
-		})
+	select {
+	case <-time.After(defaultTestTimeout):
+		t.Fatal("Timed out waiting for completion")
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("Unexpected server error: %v", err)
+		}
 	}
 }

--- a/credentials/tls_ext_test.go
+++ b/credentials/tls_ext_test.go
@@ -32,7 +32,6 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
-	"google.golang.org/grpc/internal/envconfig"
 	"google.golang.org/grpc/internal/grpctest"
 	"google.golang.org/grpc/internal/stubserver"
 	"google.golang.org/grpc/status"
@@ -410,12 +409,6 @@ func (s) TestTLS_CipherSuitesOverridable(t *testing.T) {
 // correctly for a server that doesn't specify the NextProtos field and uses
 // GetConfigForClient to provide the TLS config during the handshake.
 func (s) TestTLS_ServerConfiguresALPNByDefault(t *testing.T) {
-	initialVal := envconfig.EnforceALPNEnabled
-	defer func() {
-		envconfig.EnforceALPNEnabled = initialVal
-	}()
-	envconfig.EnforceALPNEnabled = true
-
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
 
@@ -452,11 +445,6 @@ func (s) TestTLS_ServerConfiguresALPNByDefault(t *testing.T) {
 // TestTLS_DisabledALPNClient tests the behaviour of TransportCredentials when
 // connecting to a server that doesn't support ALPN.
 func (s) TestTLS_DisabledALPNClient(t *testing.T) {
-	initialVal := envconfig.EnforceALPNEnabled
-	defer func() {
-		envconfig.EnforceALPNEnabled = initialVal
-	}()
-
 	tests := []struct {
 		name         string
 		alpnEnforced bool
@@ -467,15 +455,10 @@ func (s) TestTLS_DisabledALPNClient(t *testing.T) {
 			alpnEnforced: true,
 			wantErr:      true,
 		},
-		{
-			name: "not_enforced",
-		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			envconfig.EnforceALPNEnabled = tc.alpnEnforced
-
 			listener, err := tls.Listen("tcp", "localhost:0", &tls.Config{
 				Certificates: []tls.Certificate{serverCert},
 				NextProtos:   []string{}, // Empty list indicates ALPN is disabled.
@@ -533,11 +516,6 @@ func (s) TestTLS_DisabledALPNClient(t *testing.T) {
 // TestTLS_DisabledALPNServer tests the behaviour of TransportCredentials when
 // accepting a request from a client that doesn't support ALPN.
 func (s) TestTLS_DisabledALPNServer(t *testing.T) {
-	initialVal := envconfig.EnforceALPNEnabled
-	defer func() {
-		envconfig.EnforceALPNEnabled = initialVal
-	}()
-
 	tests := []struct {
 		name         string
 		alpnEnforced bool
@@ -548,15 +526,10 @@ func (s) TestTLS_DisabledALPNServer(t *testing.T) {
 			alpnEnforced: true,
 			wantErr:      true,
 		},
-		{
-			name: "not_enforced",
-		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			envconfig.EnforceALPNEnabled = tc.alpnEnforced
-
 			listener, err := net.Listen("tcp", "localhost:0")
 			if err != nil {
 				t.Fatalf("Error starting server: %v", err)

--- a/internal/envconfig/envconfig.go
+++ b/internal/envconfig/envconfig.go
@@ -40,12 +40,6 @@ var (
 	// ALTSMaxConcurrentHandshakes is the maximum number of concurrent ALTS
 	// handshakes that can be performed.
 	ALTSMaxConcurrentHandshakes = uint64FromEnv("GRPC_ALTS_MAX_CONCURRENT_HANDSHAKES", 100, 1, 100)
-	// EnforceALPNEnabled is set if TLS connections to servers with ALPN disabled
-	// should be rejected. The HTTP/2 protocol requires ALPN to be enabled, this
-	// option is present for backward compatibility. This option may be overridden
-	// by setting the environment variable "GRPC_ENFORCE_ALPN_ENABLED" to "true"
-	// or "false".
-	EnforceALPNEnabled = boolFromEnv("GRPC_ENFORCE_ALPN_ENABLED", true)
 	// XDSFallbackSupport is the env variable that controls whether support for
 	// xDS fallback is turned on. If this is unset or is false, only the first
 	// xDS server in the list of server configs will be used.


### PR DESCRIPTION
cleans up the ALPN enabled env var via 2 commits:

1. the actual change
2. a refactoring to support the change. this has many white space changes and would be easiest to review via ignoring white space

this does not address all of #5888  and therefore should remain open 