### PR TITLE
 grpc: fix receiving empty messages when compression is enabled and maxReceiveMessageSize is maxInt64 #7753

### DIFF
--- a/rpc_util.go
+++ b/rpc_util.go
@@ -874,7 +874,7 @@ func decompress(compressor encoding.Compressor, d mem.BufferSlice, maxReceiveMes
 		return nil, 0, err
 	}
 
-	out, err := mem.ReadAll(io.LimitReader(dcReader, int64(maxReceiveMessageSize)+1), pool)
+	out, err := mem.ReadAll(io.LimitReader(dcReader, int64(maxReceiveMessageSize)), pool)
 	if err != nil {
 		out.Free()
 		return nil, 0, err

--- a/rpc_util.go
+++ b/rpc_util.go
@@ -882,7 +882,7 @@ func decompress(compressor encoding.Compressor, d mem.BufferSlice, maxReceiveMes
 	if err = checkReceiveMessageOverflow(int64(out.Len()), int64(maxReceiveMessageSize), dcReader); err != nil {
 		return nil, out.Len() + 1, err
 	}
-	return out, len(out), err
+	return out, out.Len(), err
 }
 
 // checkReceiveMessageOverflow checks if the number of bytes read from the stream exceeds
@@ -896,7 +896,8 @@ func checkReceiveMessageOverflow(readBytes, maxReceiveMessageSize int64, dcReade
 	if readBytes == maxReceiveMessageSize {
 		b := make([]byte, 1)
 		if n, err := dcReader.Read(b); n > 0 || err != io.EOF {
-			return fmt.Errorf("overflow: message larger than max size receivable by client (%d bytes)", maxReceiveMessageSize)
+			return fmt.Errorf("overflow: received message size is larger than the allowed maxReceiveMessageSize (%d bytes)",
+				maxReceiveMessageSize)
 		}
 	}
 	return nil

--- a/rpc_util.go
+++ b/rpc_util.go
@@ -873,8 +873,8 @@ func decompress(compressor encoding.Compressor, d mem.BufferSlice, maxReceiveMes
 	if err != nil {
 		return nil, 0, err
 	}
-
-	out, err := mem.ReadAll(io.LimitReader(dcReader, int64(maxReceiveMessageSize)+1), pool)
+	var out mem.BufferSlice
+	_, err = io.Copy(mem.NewWriter(&out, pool), io.LimitReader(dcReader, int64(maxReceiveMessageSize)))
 	if err != nil {
 		out.Free()
 		return nil, 0, err
@@ -882,7 +882,7 @@ func decompress(compressor encoding.Compressor, d mem.BufferSlice, maxReceiveMes
 	if err = checkReceiveMessageOverflow(int64(out.Len()), int64(maxReceiveMessageSize), dcReader); err != nil {
 		return nil, out.Len() + 1, err
 	}
-	return out, out.Len(), err
+	return out, len(out), err
 }
 
 // checkReceiveMessageOverflow checks if the number of bytes read from the stream exceeds

--- a/rpc_util.go
+++ b/rpc_util.go
@@ -873,8 +873,8 @@ func decompress(compressor encoding.Compressor, d mem.BufferSlice, maxReceiveMes
 	if err != nil {
 		return nil, 0, err
 	}
-	var out mem.BufferSlice
-	_, err = io.Copy(mem.NewWriter(&out, pool), io.LimitReader(dcReader, int64(maxReceiveMessageSize)))
+
+	out, err := mem.ReadAll(io.LimitReader(dcReader, int64(maxReceiveMessageSize)+1), pool)
 	if err != nil {
 		out.Free()
 		return nil, 0, err
@@ -882,7 +882,7 @@ func decompress(compressor encoding.Compressor, d mem.BufferSlice, maxReceiveMes
 	if err = checkReceiveMessageOverflow(int64(out.Len()), int64(maxReceiveMessageSize), dcReader); err != nil {
 		return nil, out.Len() + 1, err
 	}
-	return out, len(out), err
+	return out, out.Len(), nil
 }
 
 // checkReceiveMessageOverflow checks if the number of bytes read from the stream exceeds

--- a/rpc_util_test.go
+++ b/rpc_util_test.go
@@ -359,6 +359,7 @@ func TestDecompress(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			compressedMsg := compressInput(tt.input)
 			output, numSliceInBuf, err := decompress(tt.compressor, compressedMsg, tt.maxReceiveMessageSize, mem.DefaultBufferPool())
+
 			var wantMsg mem.BufferSlice
 			if tt.want != nil {
 				wantMsg = mem.BufferSlice{mem.NewBuffer(&tt.want, nil)}

--- a/rpc_util_test.go
+++ b/rpc_util_test.go
@@ -335,9 +335,9 @@ func TestDecompress(t *testing.T) {
 		{
 			name:                  "failure, empty receive message",
 			compressor:            c,
-			input:                 []byte(""),
+			input:                 []byte{},
 			maxReceiveMessageSize: 10,
-			want:                  nil,
+			want:                  []byte{},
 			error:                 nil,
 		},
 		{
@@ -345,7 +345,7 @@ func TestDecompress(t *testing.T) {
 			compressor:            c,
 			input:                 []byte("small message"),
 			maxReceiveMessageSize: 5,
-			want:                  nil,
+			want:                  []byte{},
 			error:                 errors.New("overflow: received message size is larger than the allowed maxReceiveMessageSize (5 bytes)"),
 		},
 	}

--- a/rpc_util_test.go
+++ b/rpc_util_test.go
@@ -351,27 +351,21 @@ func TestDecompress(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			message := mem.BufferSlice{mem.NewBuffer(&tt.input, nil)}
-			output, size, err := decompress(tt.compressor, message, tt.maxReceiveMessageSize, nil)
+			compressedMsg := func() mem.BufferSlice {
+				compressedData := compressData(tt.input)
+				return mem.BufferSlice{mem.NewBuffer(&compressedData, nil)}
+			}()
+			output, _, err := decompress(tt.compressor, compressedMsg, tt.maxReceiveMessageSize, nil)
 			wantMsg := mem.BufferSlice{mem.NewBuffer(&tt.want, nil)}
-			if tt.error != nil && err == nil {
-				t.Fatalf("decompress() error, got err=%v, want err=%v", err, tt.error)
-			}
 			if tt.error != nil && err == nil {
 				t.Fatalf("decompress() error, got err=%v, want err=%v", err, tt.error)
 			}
 			if wantMsg != nil && output == nil {
 				t.Fatalf("decompress() got = nil, want = non nil")
 			}
-			if wantMsg != nil && output != nil {
-				if diff := cmp.Diff(wantMsg, output); diff != "" {
-					t.Fatalf("decompress() mismatch (-want +got):\n%s", diff)
-				}
+			if diff := cmp.Diff(wantMsg, output); diff != "" {
+				t.Fatalf("decompress() mismatch in bytes (-want +got):\n%s", diff)
 			}
-			if size != wantMsg.Len() {
-				t.Fatalf("decompress() buffer len, got = %d, want = %d", size, wantMsg.Len())
-			}
-
 		})
 	}
 }

--- a/rpc_util_test.go
+++ b/rpc_util_test.go
@@ -337,7 +337,7 @@ func TestDecompress(t *testing.T) {
 			compressor:            c,
 			input:                 []byte(""),
 			maxReceiveMessageSize: 10,
-			want:                  []byte(""),
+			want:                  nil,
 			error:                 nil,
 		},
 		{
@@ -345,7 +345,7 @@ func TestDecompress(t *testing.T) {
 			compressor:            c,
 			input:                 []byte("small message"),
 			maxReceiveMessageSize: 5,
-			want:                  []byte("smalll"),
+			want:                  nil,
 			error:                 errors.New("overflow: received message size is larger than the allowed maxReceiveMessageSize (5 bytes)"),
 		},
 	}
@@ -356,7 +356,10 @@ func TestDecompress(t *testing.T) {
 				return mem.BufferSlice{mem.NewBuffer(&compressedData, nil)}
 			}()
 			output, _, err := decompress(tt.compressor, compressedMsg, tt.maxReceiveMessageSize, nil)
-			wantMsg := mem.BufferSlice{mem.NewBuffer(&tt.want, nil)}
+			var wantMsg mem.BufferSlice
+			if tt.want != nil {
+				wantMsg = mem.BufferSlice{mem.NewBuffer(&tt.want, nil)}
+			}
 			if tt.error != nil && err == nil {
 				t.Fatalf("decompress() error, got err=%v, want err=%v", err, tt.error)
 			}
@@ -364,8 +367,9 @@ func TestDecompress(t *testing.T) {
 				t.Fatalf("decompress() got = nil, want = non nil")
 			}
 			if diff := cmp.Diff(wantMsg, output); diff != "" {
-				t.Fatalf("decompress() mismatch in bytes (-want +got):\n%s", diff)
+				t.Fatalf("Mismatch in output:\n%s", diff)
 			}
+
 		})
 	}
 }

--- a/rpc_util_test.go
+++ b/rpc_util_test.go
@@ -355,13 +355,17 @@ func TestDecompress(t *testing.T) {
 				compressedData := compressData(tt.input)
 				return mem.BufferSlice{mem.NewBuffer(&compressedData, nil)}
 			}()
-			output, _, err := decompress(tt.compressor, compressedMsg, tt.maxReceiveMessageSize, nil)
+
+			output, numSliceInBuf, err := decompress(tt.compressor, compressedMsg, tt.maxReceiveMessageSize, mem.DefaultBufferPool())
 			var wantMsg mem.BufferSlice
 			if tt.want != nil {
 				wantMsg = mem.BufferSlice{mem.NewBuffer(&tt.want, nil)}
 			}
 			if tt.error != nil && err == nil {
 				t.Fatalf("decompress() error, got err=%v, want err=%v", err, tt.error)
+			}
+			if numSliceInBuf != wantMsg.Len() {
+				t.Fatalf("decompress() number of slice of Buffer, got err=%v, want err=%v", numSliceInBuf, tt.want)
 			}
 			if wantMsg != nil && output == nil {
 				t.Fatalf("decompress() got = nil, want = non nil")

--- a/rpc_util_test.go
+++ b/rpc_util_test.go
@@ -21,12 +21,14 @@ package grpc
 import (
 	"bytes"
 	"compress/gzip"
+	"errors"
 	"io"
 	"math"
 	"reflect"
 	"testing"
 
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/encoding"
 	protoenc "google.golang.org/grpc/encoding/proto"
 	"google.golang.org/grpc/internal/testutils"
 	"google.golang.org/grpc/internal/transport"
@@ -289,4 +291,131 @@ func BenchmarkGZIPCompressor512KiB(b *testing.B) {
 
 func BenchmarkGZIPCompressor1MiB(b *testing.B) {
 	bmCompressor(b, 1024*1024, NewGZIPCompressor())
+}
+
+type mockCompressor struct {
+	DecompressedData []byte
+	ErrDecompress    error
+	Size             int
+	CustomReader     io.Reader
+}
+
+func (m *mockCompressor) Compress(w io.Writer) (io.WriteCloser, error) {
+	return nil, nil
+}
+
+func (m *mockCompressor) Decompress(r io.Reader) (io.Reader, error) {
+	if m.ErrDecompress != nil {
+		return nil, m.ErrDecompress
+	}
+	if m.CustomReader != nil {
+		return m.CustomReader, nil
+	}
+	return bytes.NewReader(m.DecompressedData), nil
+}
+
+func (m *mockCompressor) DecompressedSize(compressedBytes mem.BufferSlice) int {
+	return m.Size
+}
+
+func (m *mockCompressor) Name() string {
+	return "mockCompressor"
+}
+
+type ErrorReader struct{}
+
+func (e *ErrorReader) Read(p []byte) (n int, err error) {
+	return 0, errors.New("simulated io.Copy read error")
+}
+
+func TestDecompress(t *testing.T) {
+	tests := []struct {
+		name                  string
+		compressor            encoding.Compressor
+		input                 mem.BufferSlice
+		maxReceiveMessageSize int
+		want                  mem.BufferSlice
+		size                  int
+		error                 error
+	}{
+		{
+			name: "Successful decompression",
+			compressor: &mockCompressor{
+				DecompressedData: []byte("decompressed data"),
+				Size:             17,
+			},
+			input:                 mem.BufferSlice{},
+			maxReceiveMessageSize: 100,
+			want: func() mem.BufferSlice {
+				decompressed := []byte("decompressed data")
+				return mem.BufferSlice{mem.NewBuffer(&decompressed, nil)}
+			}(),
+			size:  1,
+			error: nil,
+		},
+		{
+			name: "Error during decompression",
+			compressor: &mockCompressor{
+				ErrDecompress: errors.New("decompression error"),
+			},
+			input:                 mem.BufferSlice{},
+			maxReceiveMessageSize: 100,
+			want:                  nil,
+			size:                  0,
+			error:                 errors.New("decompression error"),
+		},
+		{
+			name: "Buffer overflow",
+			compressor: &mockCompressor{
+				DecompressedData: []byte("overflow data"),
+				Size:             100,
+			},
+			input:                 mem.BufferSlice{},
+			maxReceiveMessageSize: 5,
+			want:                  nil,
+			size:                  6,
+			error:                 errors.New("overflow: message larger than max size receivable by client (5 bytes)"),
+		},
+		{
+			name: "MaxInt64 receive size with small data",
+			compressor: &mockCompressor{
+				DecompressedData: []byte("small data"),
+				Size:             10,
+			},
+			input:                 mem.BufferSlice{},
+			maxReceiveMessageSize: math.MaxInt64,
+			want: func() mem.BufferSlice {
+				smallDecompressed := []byte("small data, small data ")
+				return mem.BufferSlice{mem.NewBuffer(&smallDecompressed, nil)}
+			}(),
+			size:  1,
+			error: nil,
+		}, {
+			name: "Error during io.Copy",
+			compressor: &mockCompressor{
+				CustomReader: &ErrorReader{},
+			},
+			input:                 mem.BufferSlice{},
+			maxReceiveMessageSize: 100,
+			want:                  nil,
+			size:                  0,
+			error:                 errors.New("simulated io.Copy read error"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			output, size, err := decompress(tt.compressor, tt.input, tt.maxReceiveMessageSize, nil)
+			// check both err and tt.error are either nil or non-nil, the condition will be false
+			if (err != nil) != (tt.error != nil) {
+				t.Errorf("unexpected error state: got err=%v, want err=%v", err, tt.error)
+			}
+			if size != tt.size {
+				t.Errorf("decompress() size = %d, want %d", size, tt.size)
+			}
+			if len(tt.want) != len(output) {
+				t.Errorf("decompress() output length = %d, want %d", output, tt.want)
+			}
+		})
+	}
 }

--- a/rpc_util_test.go
+++ b/rpc_util_test.go
@@ -21,15 +21,12 @@ package grpc
 import (
 	"bytes"
 	"compress/gzip"
-	"errors"
 	"io"
 	"math"
 	"reflect"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/encoding"
 	_ "google.golang.org/grpc/encoding/gzip"
 	protoenc "google.golang.org/grpc/encoding/proto"
 	"google.golang.org/grpc/internal/testutils"
@@ -314,65 +311,4 @@ func compressData(data []byte) []byte {
 // inputs, buffer sizes, and error conditions, using the "gzip" compressor for testing.
 
 func TestDecompress(t *testing.T) {
-	c := encoding.GetCompressor("gzip")
-
-	compressInput := func(input []byte) mem.BufferSlice {
-		compressedData := compressData(input)
-		return mem.BufferSlice{mem.NewBuffer(&compressedData, nil)}
-	}
-
-	tests := []struct {
-		name                  string
-		compressor            encoding.Compressor
-		input                 []byte
-		maxReceiveMessageSize int
-		want                  []byte
-		error                 error
-	}{
-		{
-			name:                  "Decompresses successfully with sufficient buffer size",
-			compressor:            c,
-			input:                 []byte("decompressed data"),
-			maxReceiveMessageSize: 50,
-			want:                  []byte("decompressed data"),
-			error:                 nil,
-		},
-		{
-			name:                  "failure, empty receive message",
-			compressor:            c,
-			input:                 []byte{},
-			maxReceiveMessageSize: 10,
-			want:                  nil,
-			error:                 nil,
-		},
-		{
-			name:                  "overflow failure, receive message exceeds maxReceiveMessageSize",
-			compressor:            c,
-			input:                 []byte("small message"),
-			maxReceiveMessageSize: 5,
-			want:                  nil,
-			error:                 errors.New("overflow: received message size is larger than the allowed maxReceiveMessageSize (5 bytes)"),
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			compressedMsg := compressInput(tt.input)
-			output, numSliceInBuf, err := decompress(tt.compressor, compressedMsg, tt.maxReceiveMessageSize, mem.DefaultBufferPool())
-			var wantMsg mem.BufferSlice
-			if tt.want != nil {
-				wantMsg = mem.BufferSlice{mem.NewBuffer(&tt.want, nil)}
-			}
-			if tt.error != nil && err == nil {
-				t.Fatalf("decompress() error, got err=%v, want err=%v", err, tt.error)
-			}
-			if tt.error == nil && numSliceInBuf != wantMsg.Len() {
-				t.Fatalf("decompress() number of slices mismatch, got = %d, want = %d", numSliceInBuf, wantMsg.Len())
-			}
-			if diff := cmp.Diff(wantMsg.Materialize(), output.Materialize()); diff != "" {
-				t.Fatalf("Mismatch in output:\n%s", diff)
-			}
-
-		})
-	}
 }


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc-go/issues/4552

RELEASE NOTES:

grpc: fix receiving empty messages when compression is enabled and maxReceiveMessageSize is maxInt64