### PR TITLE
grpcs: update `WithContextDialer` documentation to include using passthrough resolver

### DIFF
--- a/dialoptions.go
+++ b/dialoptions.go
@@ -428,10 +428,10 @@ func WithTimeout(d time.Duration) DialOption {
 // returned by f, gRPC checks the error's Temporary() method to decide if it
 // should try to reconnect to the network address.
 //
-// If you want to bypass DNS resolution and connect directly to a specified
-// address, prefix your target address with passthrough:/// when using
-// WithContextDialer. This will cause the passthrough resolver to be used,
-// which avoids any DNS lookups. For example: passthrough:///localhost:50051.
+// Note that gRPC by default performs name resolution on the target passed to NewClient.
+// To bypass name resolution and cause the target string to be passed directly to the dialer
+// here instead, use the "passthrough" resolver by specifying it in the target string,
+// e.g. "passthrough:target".
 //
 // Note: All supported releases of Go (as of December 2023) override the OS
 // defaults for TCP keepalive time and interval to 15s. To enable TCP keepalive

--- a/dialoptions.go
+++ b/dialoptions.go
@@ -428,6 +428,11 @@ func WithTimeout(d time.Duration) DialOption {
 // returned by f, gRPC checks the error's Temporary() method to decide if it
 // should try to reconnect to the network address.
 //
+// If you want to bypass DNS resolution and connect directly to a specified
+// address, prefix your target address with passthrough:/// when using
+// WithContextDialer. This will cause the passthrough resolver to be used,
+// which avoids any DNS lookups. For example: passthrough:///localhost:50051.
+//
 // Note: All supported releases of Go (as of December 2023) override the OS
 // defaults for TCP keepalive time and interval to 15s. To enable TCP keepalive
 // with OS defaults for keepalive time and interval, use a net.Dialer that sets

--- a/dialoptions.go
+++ b/dialoptions.go
@@ -428,10 +428,10 @@ func WithTimeout(d time.Duration) DialOption {
 // returned by f, gRPC checks the error's Temporary() method to decide if it
 // should try to reconnect to the network address.
 //
-// Note that gRPC by default performs name resolution on the target passed to NewClient.
-// To bypass name resolution and cause the target string to be passed directly to the dialer
-// here instead, use the "passthrough" resolver by specifying it in the target string,
-// e.g. "passthrough:target".
+// Note that gRPC by default performs name resolution on the target passed to
+// NewClient. To bypass name resolution and cause the target string to be
+// passed directly to the dialer here instead, use the "passthrough" resolver
+// by specifying it in the target string, e.g. "passthrough:target".
 //
 // Note: All supported releases of Go (as of December 2023) override the OS
 // defaults for TCP keepalive time and interval to 15s. To enable TCP keepalive


### PR DESCRIPTION
Fixes: #7856

RELEASE NOTES: None