### PR TITLE
examples/xds: Fix typo in README.md

### DIFF
--- a/examples/features/xds/README.md
+++ b/examples/features/xds/README.md
@@ -1,7 +1,7 @@
 # gRPC xDS example
 
 xDS is the protocol initially used by Envoy, that is evolving into a universal
-data plan API for service mesh.
+data plane API for service mesh.
 
 The xDS example is a Hello World client/server capable of being configured with
 the XDS management protocol. Out-of-the-box it behaves the same as [our other


### PR DESCRIPTION
typo in xds readme, changed `data plan` to `data plane`

RELEASE NOTES: None