### PR TITLE
xdsclient: stop caching xdsChannels for potential reuse, after all references are released

### DIFF
--- a/internal/testutils/channel.go
+++ b/internal/testutils/channel.go
@@ -70,6 +70,17 @@ func (c *Channel) ReceiveOrFail() (any, bool) {
 	}
 }
 
+// Drain drains the channel by repeatedly reading from it until it is empty.
+func (c *Channel) Drain() {
+	for {
+		select {
+		case <-c.C:
+		default:
+			return
+		}
+	}
+}
+
 // Receive returns the value received on the underlying channel, or the error
 // returned by ctx if it is closed or cancelled.
 func (c *Channel) Receive(ctx context.Context) (any, error) {

--- a/xds/internal/balancer/cdsbalancer/cdsbalancer_test.go
+++ b/xds/internal/balancer/cdsbalancer/cdsbalancer_test.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
 	"strings"
 	"testing"
 	"time"
@@ -202,11 +203,18 @@ func registerWrappedCDSPolicy(t *testing.T) chan balancer.Balancer {
 //   - a channel used to signal that previously requested cluster resources are
 //     no longer requested
 func setupWithManagementServer(t *testing.T) (*e2e.ManagementServer, string, *grpc.ClientConn, *manual.Resolver, xdsclient.XDSClient, chan []string, chan struct{}) {
+	return setupWithManagementServerAndListener(t, nil)
+}
+
+// Same as setupWithManagementServer, but also allows the caller to specify
+// a listener to be used by the management server.
+func setupWithManagementServerAndListener(t *testing.T, lis net.Listener) (*e2e.ManagementServer, string, *grpc.ClientConn, *manual.Resolver, xdsclient.XDSClient, chan []string, chan struct{}) {
 	t.Helper()
 
 	cdsResourceRequestedCh := make(chan []string, 1)
 	cdsResourceCanceledCh := make(chan struct{}, 1)
 	mgmtServer := e2e.StartManagementServer(t, e2e.ManagementServerOptions{
+		Listener: lis,
 		OnStreamRequest: func(_ int64, req *v3discoverypb.DiscoveryRequest) error {
 			if req.GetTypeUrl() == version.V3ClusterURL {
 				switch len(req.GetResourceNames()) {
@@ -807,11 +815,20 @@ func (s) TestClusterUpdate_Failure(t *testing.T) {
 //     TRANSIENT_FAILURE. It is also expected to cancel the CDS watch.
 func (s) TestResolverError(t *testing.T) {
 	_, resolverErrCh, _, _ := registerWrappedClusterResolverPolicy(t)
-	mgmtServer, nodeID, cc, r, _, cdsResourceRequestedCh, cdsResourceCanceledCh := setupWithManagementServer(t)
+	lis := testutils.NewListenerWrapper(t, nil)
+	mgmtServer, nodeID, cc, r, _, cdsResourceRequestedCh, cdsResourceCanceledCh := setupWithManagementServerAndListener(t, lis)
 
-	// Verify that the specified cluster resource is requested.
+	// Grab the wrapped connection from the listener wrapper. This will be used
+	// to verify the connection is closed.
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
+	val, err := lis.NewConnCh.Receive(ctx)
+	if err != nil {
+		t.Fatalf("Failed to receive new connection from wrapped listener: %v", err)
+	}
+	conn := val.(*testutils.ConnWrapper)
+
+	// Verify that the specified cluster resource is requested.
 	wantNames := []string{clusterName}
 	if err := waitForResourceNames(ctx, cdsResourceRequestedCh, wantNames); err != nil {
 		t.Fatal(err)
@@ -831,7 +848,7 @@ func (s) TestResolverError(t *testing.T) {
 
 	// Ensure that the resolver error is propagated to the RPC caller.
 	client := testgrpc.NewTestServiceClient(cc)
-	_, err := client.EmptyCall(ctx, &testpb.Empty{})
+	_, err = client.EmptyCall(ctx, &testpb.Empty{})
 	if code := status.Code(err); code != codes.Unavailable {
 		t.Fatalf("EmptyCall() failed with code: %v, want %v", code, codes.Unavailable)
 	}
@@ -901,11 +918,14 @@ func (s) TestResolverError(t *testing.T) {
 	resolverErr = xdsresource.NewErrorf(xdsresource.ErrorTypeResourceNotFound, "xds resource not found error")
 	r.ReportError(resolverErr)
 
-	// Wait for the CDS resource to be not requested anymore.
+	// Wait for the CDS resource to be not requested anymore, or the connection
+	// to the management server to be closed (which happens as part of the last
+	// resource watch being canceled).
 	select {
 	case <-ctx.Done():
 		t.Fatal("Timeout when waiting for CDS resource to be not requested")
 	case <-cdsResourceCanceledCh:
+	case <-conn.CloseCh.C:
 	}
 
 	// Verify that the resolver error is pushed to the child policy.

--- a/xds/internal/balancer/cdsbalancer/cdsbalancer_test.go
+++ b/xds/internal/balancer/cdsbalancer/cdsbalancer_test.go
@@ -928,12 +928,12 @@ func (s) TestResolverError(t *testing.T) {
 	}
 }
 
-// Tests that closing the cds LB policy results in the cluster resource watch
-// being cancelled and the child policy being closed.
+// Tests that closing the cds LB policy results in the the child policy being
+// closed.
 func (s) TestClose(t *testing.T) {
 	cdsBalancerCh := registerWrappedCDSPolicy(t)
 	_, _, _, childPolicyCloseCh := registerWrappedClusterResolverPolicy(t)
-	mgmtServer, nodeID, cc, _, _, _, cdsResourceCanceledCh := setupWithManagementServer(t)
+	mgmtServer, nodeID, cc, _, _, _, _ := setupWithManagementServer(t)
 
 	// Start a test service backend.
 	server := stubserver.StartTestService(t, nil)
@@ -967,12 +967,6 @@ func (s) TestClose(t *testing.T) {
 	}
 	cdsBal.Close()
 
-	// Wait for the CDS resource to be not requested anymore.
-	select {
-	case <-ctx.Done():
-		t.Fatal("Timeout when waiting for CDS resource to be not requested")
-	case <-cdsResourceCanceledCh:
-	}
 	// Wait for the child policy to be closed.
 	select {
 	case <-ctx.Done():

--- a/xds/internal/xdsclient/authority.go
+++ b/xds/internal/xdsclient/authority.go
@@ -694,7 +694,7 @@ func (a *authority) unwatchResource(rType xdsresource.Type, resourceName string,
 			delete(state.watchers, watcher)
 			if len(state.watchers) > 0 {
 				if a.logger.V(2) {
-					a.logger.Infof("More watchers exist for type %q, resource name %q", rType.TypeName(), resourceName)
+					a.logger.Infof("Other watchers exist for type %q, resource name %q", rType.TypeName(), resourceName)
 				}
 				return
 			}

--- a/xds/internal/xdsclient/authority.go
+++ b/xds/internal/xdsclient/authority.go
@@ -646,7 +646,7 @@ func (a *authority) watchResource(rType xdsresource.Type, resourceName string, w
 		// immediately as well.
 		if state.md.Status == xdsresource.ServiceStatusNACKed {
 			if a.logger.V(2) {
-				a.logger.Infof("Resource type %q with resource name %q was NACKed: %s", rType.TypeName(), resourceName, state.cache.ToJSON())
+				a.logger.Infof("Resource type %q with resource name %q was NACKed", rType.TypeName(), resourceName)
 			}
 			a.watcherCallbackSerializer.TrySchedule(func(context.Context) { watcher.OnError(state.md.ErrState.Err, func() {}) })
 		}
@@ -687,7 +687,7 @@ func (a *authority) unwatchResource(rType xdsresource.Type, resourceName string,
 			delete(state.watchers, watcher)
 			if len(state.watchers) > 0 {
 				if a.logger.V(2) {
-					a.logger.Infof("%d more watchers exist for type %q, resource name %q", rType.TypeName(), resourceName)
+					a.logger.Infof("More watchers exist for type %q, resource name %q", rType.TypeName(), resourceName)
 				}
 				return
 			}

--- a/xds/internal/xdsclient/client_refcounted.go
+++ b/xds/internal/xdsclient/client_refcounted.go
@@ -27,10 +27,7 @@ import (
 	"google.golang.org/grpc/internal/xds/bootstrap"
 )
 
-const (
-	defaultWatchExpiryTimeout       = 15 * time.Second
-	defaultIdleChannelExpiryTimeout = 5 * time.Minute
-)
+const defaultWatchExpiryTimeout = 15 * time.Second
 
 var (
 	// The following functions are no-ops in the actual code, but can be
@@ -62,7 +59,7 @@ func clientRefCountedClose(name string) {
 // newRefCounted creates a new reference counted xDS client implementation for
 // name, if one does not exist already. If an xDS client for the given name
 // exists, it gets a reference to it and returns it.
-func newRefCounted(name string, config *bootstrap.Config, watchExpiryTimeout, idleChannelExpiryTimeout time.Duration, streamBackoff func(int) time.Duration) (XDSClient, func(), error) {
+func newRefCounted(name string, config *bootstrap.Config, watchExpiryTimeout time.Duration, streamBackoff func(int) time.Duration) (XDSClient, func(), error) {
 	clientsMu.Lock()
 	defer clientsMu.Unlock()
 
@@ -72,7 +69,7 @@ func newRefCounted(name string, config *bootstrap.Config, watchExpiryTimeout, id
 	}
 
 	// Create the new client implementation.
-	c, err := newClientImpl(config, watchExpiryTimeout, idleChannelExpiryTimeout, streamBackoff)
+	c, err := newClientImpl(config, watchExpiryTimeout, streamBackoff)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/xds/internal/xdsclient/clientimpl.go
+++ b/xds/internal/xdsclient/clientimpl.go
@@ -344,7 +344,9 @@ func (c *clientImpl) releaseChannel(serverConfig *bootstrap.ServerConfig, state 
 		if c.logger.V(2) {
 			c.logger.Infof("Closing xdsChannel [%p] for server config %s", state.channel, serverConfig)
 		}
+		channelToClose := state.channel
 		c.channelsMu.Unlock()
-		state.channel.close()
+
+		channelToClose.close()
 	})
 }

--- a/xds/internal/xdsclient/clientimpl.go
+++ b/xds/internal/xdsclient/clientimpl.go
@@ -25,7 +25,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"google.golang.org/grpc/internal/cache"
 	"google.golang.org/grpc/internal/grpclog"
 	"google.golang.org/grpc/internal/grpcsync"
 	"google.golang.org/grpc/internal/xds/bootstrap"
@@ -63,14 +62,9 @@ type clientImpl struct {
 	// these channels, and forwards updates from the channels to each of these
 	// authorities.
 	//
-	// Once all references to a channel are dropped, the channel is moved to the
-	// idle cache where it lives for a configured duration before being closed.
-	// If the channel is required before the idle timeout fires, it is revived
-	// from the idle cache and used.
+	// Once all references to a channel are dropped, the channel is closed.
 	channelsMu        sync.Mutex
 	xdsActiveChannels map[string]*channelState // Map from server config to in-use xdsChannels.
-	xdsIdleChannels   *cache.TimeoutCache      // Map from server config to idle xdsChannels.
-	closeCond         *sync.Cond
 }
 
 // channelState represents the state of an xDS channel. It tracks the number of
@@ -173,21 +167,6 @@ func (c *clientImpl) close() {
 		c.close()
 	}
 
-	// Similarly, closing idle channels cannot be done with the lock held, for
-	// the same reason as described above.  So, we clear the idle cache in a
-	// goroutine and use a condition variable to wait on the condition that the
-	// idle cache has zero entries. The Wait() method on the condition variable
-	// releases the lock and blocks the goroutine until signaled (which happens
-	// when an idle channel is removed from the cache and closed), and grabs the
-	// lock before returning.
-	c.channelsMu.Lock()
-	c.closeCond = sync.NewCond(&c.channelsMu)
-	go c.xdsIdleChannels.Clear(true)
-	for c.xdsIdleChannels.Len() > 0 {
-		c.closeCond.Wait()
-	}
-	c.channelsMu.Unlock()
-
 	c.serializerClose()
 	<-c.serializer.Done()
 
@@ -289,23 +268,11 @@ func (c *clientImpl) getOrCreateChannel(serverConfig *bootstrap.ServerConfig, in
 		c.logger.Infof("Received request for a reference to an xdsChannel for server config %q", serverConfig)
 	}
 
-	// Use an active channel, if one exists for this server config.
+	// Use an existing channel, if one exists for this server config.
 	if state, ok := c.xdsActiveChannels[serverConfig.String()]; ok {
 		if c.logger.V(2) {
-			c.logger.Infof("Reusing an active xdsChannel for server config %q", serverConfig)
+			c.logger.Infof("Reusing an existing xdsChannel for server config %q", serverConfig)
 		}
-		initLocked(state)
-		return state.channel, c.releaseChannel(serverConfig, state, deInitLocked), nil
-	}
-
-	// If an idle channel exists for this server config, remove it from the
-	// idle cache and add it to the map of active channels, and return it.
-	if s, ok := c.xdsIdleChannels.Remove(serverConfig.String()); ok {
-		if c.logger.V(2) {
-			c.logger.Infof("Reviving an xdsChannel from the idle cache for server config %q", serverConfig)
-		}
-		state := s.(*channelState)
-		c.xdsActiveChannels[serverConfig.String()] = state
 		initLocked(state)
 		return state.channel, c.releaseChannel(serverConfig, state, deInitLocked), nil
 	}
@@ -345,9 +312,7 @@ func (c *clientImpl) getOrCreateChannel(serverConfig *bootstrap.ServerConfig, in
 }
 
 // releaseChannel is a function that is called when a reference to an xdsChannel
-// needs to be released. It handles the logic of moving the channel to an idle
-// cache if there are no other active references, and closing the channel if it
-// remains in the idle cache for the configured duration.
+// needs to be released. It handles closing channels with no active references.
 //
 // The function takes the following parameters:
 // - serverConfig: the server configuration for the xdsChannel
@@ -360,7 +325,6 @@ func (c *clientImpl) getOrCreateChannel(serverConfig *bootstrap.ServerConfig, in
 func (c *clientImpl) releaseChannel(serverConfig *bootstrap.ServerConfig, state *channelState, deInitLocked func(*channelState)) func() {
 	return grpcsync.OnceFunc(func() {
 		c.channelsMu.Lock()
-		defer c.channelsMu.Unlock()
 
 		if c.logger.V(2) {
 			c.logger.Infof("Received request to release a reference to an xdsChannel for server config %q", serverConfig)
@@ -372,40 +336,15 @@ func (c *clientImpl) releaseChannel(serverConfig *bootstrap.ServerConfig, state 
 			if c.logger.V(2) {
 				c.logger.Infof("xdsChannel %p has other active references", state.channel)
 			}
+			c.channelsMu.Unlock()
 			return
 		}
 
-		// Move the channel to the idle cache instead of closing
-		// immediately. If the channel remains in the idle cache for
-		// the configured duration, it will get closed.
 		delete(c.xdsActiveChannels, serverConfig.String())
 		if c.logger.V(2) {
-			c.logger.Infof("Moving xdsChannel [%p] for server config %s to the idle cache", state.channel, serverConfig)
+			c.logger.Infof("Closing xdsChannel [%p] for server config %s", state.channel, serverConfig)
 		}
-
-		// The idle cache expiry timeout results in the channel getting
-		// closed in another serializer callback.
-		c.xdsIdleChannels.Add(serverConfig.String(), state, grpcsync.OnceFunc(func() {
-			c.channelsMu.Lock()
-			channelToClose := state.channel
-			c.channelsMu.Unlock()
-
-			if c.logger.V(2) {
-				c.logger.Infof("Idle cache expiry timeout fired for xdsChannel [%p] for server config %s", state.channel, serverConfig)
-			}
-			channelToClose.close()
-
-			// If the channel is being closed as a result of the xDS client
-			// being closed, closeCond is non-nil and we need to signal from
-			// here to unblock Close().  Holding the lock is not necessary
-			// to call Signal() on a condition variable. But the field
-			// `c.closeCond` needs to guarded by the lock, which is why we
-			// acquire it here.
-			c.channelsMu.Lock()
-			if c.closeCond != nil {
-				c.closeCond.Signal()
-			}
-			c.channelsMu.Unlock()
-		}))
+		c.channelsMu.Unlock()
+		state.channel.close()
 	})
 }

--- a/xds/internal/xdsclient/tests/ads_stream_ack_nack_test.go
+++ b/xds/internal/xdsclient/tests/ads_stream_ack_nack_test.go
@@ -338,8 +338,9 @@ func (s) TestADS_NACK_InvalidFirstResponse(t *testing.T) {
 //     that an ACK is sent for this resource.
 //  2. The previously requested resource is no longer requested. The test
 //     verifies that the connection to the management server is closed.
-//  3. The same resource is requested again. The test verifies that the request
-//     is sent with an empty version string.
+//  3. The same resource is requested again. The test verifies that a new
+//     request is sent with an empty version string, which corresponds to the
+//     first request on a new connection.
 func (s) TestADS_ACK_NACK_ResourceIsNotRequestedAnymore(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
@@ -349,15 +350,17 @@ func (s) TestADS_ACK_NACK_ResourceIsNotRequestedAnymore(t *testing.T) {
 	// the test goroutine to verify ACK version and nonce.
 	streamRequestCh := testutils.NewChannel()
 	streamResponseCh := testutils.NewChannel()
-	lis := testutils.NewListenerWrapper(t, nil)
+	streamCloseCh := testutils.NewChannel()
 	mgmtServer := e2e.StartManagementServer(t, e2e.ManagementServerOptions{
-		Listener: lis,
 		OnStreamRequest: func(_ int64, req *v3discoverypb.DiscoveryRequest) error {
 			streamRequestCh.SendContext(ctx, req)
 			return nil
 		},
 		OnStreamResponse: func(_ context.Context, _ int64, _ *v3discoverypb.DiscoveryRequest, resp *v3discoverypb.DiscoveryResponse) {
 			streamResponseCh.SendContext(ctx, resp)
+		},
+		OnStreamClosed: func(int64, *v3corepb.Node) {
+			streamCloseCh.SendContext(ctx, struct{}{})
 		},
 	})
 
@@ -391,14 +394,6 @@ func (s) TestADS_ACK_NACK_ResourceIsNotRequestedAnymore(t *testing.T) {
 	lw := newListenerWatcher()
 	ldsCancel := xdsresource.WatchListener(client, listenerName, lw)
 	defer ldsCancel()
-
-	// Grab the wrapped connection from the listener wrapper. This will be used
-	// to verify the connection is closed.
-	val, err := lis.NewConnCh.Receive(ctx)
-	if err != nil {
-		t.Fatalf("Failed to receive new connection from wrapped listener: %v", err)
-	}
-	conn := val.(*testutils.ConnWrapper)
 
 	// Verify that the initial discovery request matches expectation.
 	r, err := streamRequestCh.Receive(ctx)
@@ -456,9 +451,18 @@ func (s) TestADS_ACK_NACK_ResourceIsNotRequestedAnymore(t *testing.T) {
 	// Cancel the watch on the listener resource. This should result in the
 	// existing connection to be management server getting closed.
 	ldsCancel()
-	if _, err := conn.CloseCh.Receive(ctx); err != nil {
+	if _, err := streamCloseCh.Receive(ctx); err != nil {
 		t.Fatalf("Timeout when expecting existing connection to be closed: %v", err)
 	}
+
+	// There is a race between two events when the last watch on an xdsChannel
+	// is canceled:
+	// - an empty discovery request being sent out
+	// - the ADS stream being closed
+	// To handle this race, we drain the request channel here so that if an
+	// empty discovery request was received, it is pulled out of the request
+	// channel and thereby guaranteeing a clean slate for the next watch
+	// registered below.
 	streamRequestCh.Drain()
 
 	// Register a watch for the same listener resource.

--- a/xds/internal/xdsclient/tests/ads_stream_ack_nack_test.go
+++ b/xds/internal/xdsclient/tests/ads_stream_ack_nack_test.go
@@ -459,6 +459,7 @@ func (s) TestADS_ACK_NACK_ResourceIsNotRequestedAnymore(t *testing.T) {
 	if _, err := conn.CloseCh.Receive(ctx); err != nil {
 		t.Fatalf("Timeout when expecting existing connection to be closed: %v", err)
 	}
+	streamRequestCh.Drain()
 
 	// Register a watch for the same listener resource.
 	lw = newListenerWatcher()

--- a/xds/internal/xdsclient/tests/fallback_test.go
+++ b/xds/internal/xdsclient/tests/fallback_test.go
@@ -160,13 +160,10 @@ func (s) TestFallback_OnStartup(t *testing.T) {
 		t.Fatalf("Failed to create bootstrap file: %v", err)
 	}
 
-	// Create an xDS client with the above bootstrap configuration and a short
-	// idle channel expiry timeout. This ensures that connections to lower
-	// priority servers get closed quickly, for the test to verify.
+	// Create an xDS client with the above bootstrap configuration.
 	xdsC, close, err := xdsclient.NewForTesting(xdsclient.OptionsForTesting{
-		Name:                     t.Name(),
-		Contents:                 bootstrapContents,
-		IdleChannelExpiryTimeout: defaultTestIdleChannelExpiryTimeout,
+		Name:     t.Name(),
+		Contents: bootstrapContents,
 	})
 	if err != nil {
 		t.Fatalf("Failed to create xDS client: %v", err)
@@ -363,13 +360,10 @@ func (s) TestFallback_MidUpdate(t *testing.T) {
 		t.Fatalf("Failed to create bootstrap file: %v", err)
 	}
 
-	// Create an xDS client with the above bootstrap configuration and a short
-	// idle channel expiry timeout. This ensures that connections to lower
-	// priority servers get closed quickly, for the test to verify.
+	// Create an xDS client with the above bootstrap configuration.
 	xdsC, close, err := xdsclient.NewForTesting(xdsclient.OptionsForTesting{
-		Name:                     t.Name(),
-		Contents:                 bootstrapContents,
-		IdleChannelExpiryTimeout: defaultTestIdleChannelExpiryTimeout,
+		Name:     t.Name(),
+		Contents: bootstrapContents,
 	})
 	if err != nil {
 		t.Fatalf("Failed to create xDS client: %v", err)
@@ -556,13 +550,10 @@ func (s) TestFallback_MidStartup(t *testing.T) {
 		t.Fatalf("Failed to create bootstrap file: %v", err)
 	}
 
-	// Create an xDS client with the above bootstrap configuration and a short
-	// idle channel expiry timeout. This ensures that connections to lower
-	// priority servers get closed quickly, for the test to verify.
+	// Create an xDS client with the above bootstrap configuration.
 	xdsC, close, err := xdsclient.NewForTesting(xdsclient.OptionsForTesting{
-		Name:                     t.Name(),
-		Contents:                 bootstrapContents,
-		IdleChannelExpiryTimeout: defaultTestIdleChannelExpiryTimeout,
+		Name:     t.Name(),
+		Contents: bootstrapContents,
 	})
 	if err != nil {
 		t.Fatalf("Failed to create xDS client: %v", err)

--- a/xds/internal/xdsclient/tests/helpers_test.go
+++ b/xds/internal/xdsclient/tests/helpers_test.go
@@ -36,10 +36,9 @@ func Test(t *testing.T) {
 }
 
 const (
-	defaultTestWatchExpiryTimeout       = 500 * time.Millisecond
-	defaultTestIdleChannelExpiryTimeout = 50 * time.Millisecond
-	defaultTestTimeout                  = 10 * time.Second
-	defaultTestShortTimeout             = 10 * time.Millisecond // For events expected to *not* happen.
+	defaultTestWatchExpiryTimeout = 500 * time.Millisecond
+	defaultTestTimeout            = 10 * time.Second
+	defaultTestShortTimeout       = 10 * time.Millisecond // For events expected to *not* happen.
 
 	ldsName         = "xdsclient-test-lds-resource"
 	rdsName         = "xdsclient-test-rds-resource"

--- a/xds/internal/xdsclient/tests/lds_watchers_test.go
+++ b/xds/internal/xdsclient/tests/lds_watchers_test.go
@@ -1029,7 +1029,6 @@ func (s) TestLDSWatch_NACKError(t *testing.T) {
 		t.Fatalf("Failed to update management server with resources: %v, err: %v", resources, err)
 	}
 
-	// Verify that the expected error is propagated to the watcher.
 	// Verify that the expected error is propagated to the existing watcher.
 	if err := verifyUnknownListenerError(ctx, lw.updateCh, wantListenerNACKErr); err != nil {
 		t.Fatal(err)
@@ -1039,45 +1038,18 @@ func (s) TestLDSWatch_NACKError(t *testing.T) {
 	lw2 := newListenerWatcher()
 	ldsCancel2 := xdsresource.WatchListener(client, ldsName, lw2)
 	defer ldsCancel2()
-	// Verify that the expected error is propagated to the existing watcher.
 	if err := verifyUnknownListenerError(ctx, lw2.updateCh, wantListenerNACKErr); err != nil {
 		t.Fatal(err)
 	}
 }
 
-// TestLDSWatch_ResourceCaching_WithNACKError covers the case where a watch is
-// registered for a resource which is already present in the cache with an old
-// good update as well as latest NACK error. The test verifies that new watcher
-// receives both good update and error without a new resource request being
-// sent to the management server.
+// Tests the scenario where a watch registered for a resource results in a good
+// update followed by a bad update. This results in the resource cache
+// containing both the old good update and the latest NACK error. The test
+// verifies that a when a new watch is registered for the same resource, the new
+// watcher receives the good update followed by the NACK error.
 func TestLDSWatch_ResourceCaching_NACKError(t *testing.T) {
-	firstRequestReceived := false
-	firstAckReceived := grpcsync.NewEvent()
-	secondAckReceived := grpcsync.NewEvent()
-	secondRequestReceived := grpcsync.NewEvent()
-
-	mgmtServer := e2e.StartManagementServer(t, e2e.ManagementServerOptions{
-		OnStreamRequest: func(id int64, req *v3discoverypb.DiscoveryRequest) error {
-			// The first request has an empty version string.
-			if !firstRequestReceived && req.GetVersionInfo() == "" {
-				firstRequestReceived = true
-				return nil
-			}
-			// The first ack has a non-empty version string.
-			if !firstAckReceived.HasFired() && req.GetVersionInfo() != "" {
-				firstAckReceived.Fire()
-				return nil
-			}
-			// The second ack has a non-empty version string.
-			if !secondAckReceived.HasFired() && req.GetVersionInfo() != "" {
-				secondAckReceived.Fire()
-				return nil
-			}
-			// Any requests after the first request and two acks, are not expected.
-			secondRequestReceived.Fire()
-			return nil
-		},
-	})
+	mgmtServer := e2e.StartManagementServer(t, e2e.ManagementServerOptions{})
 
 	nodeID := uuid.New().String()
 	bc := e2e.DefaultBootstrapContents(t, nodeID, mgmtServer.Address)
@@ -1149,16 +1121,6 @@ func TestLDSWatch_ResourceCaching_NACKError(t *testing.T) {
 	// Verify that the expected error is propagated to the existing watcher.
 	if err := verifyUnknownListenerError(ctx, lw2.updateCh, wantListenerNACKErr); err != nil {
 		t.Fatal(err)
-	}
-
-	// No request should get sent out as part of this watch.
-	sCtx, sCancel := context.WithTimeout(ctx, defaultTestShortTimeout)
-	defer sCancel()
-	select {
-	case <-sCtx.Done():
-	case <-secondRequestReceived.Done():
-		t.Fatal("xdsClient sent out request instead of using update from cache")
-	default:
 	}
 }
 

--- a/xds/internal/xdsclient/tests/lds_watchers_test.go
+++ b/xds/internal/xdsclient/tests/lds_watchers_test.go
@@ -1048,7 +1048,7 @@ func (s) TestLDSWatch_NACKError(t *testing.T) {
 // containing both the old good update and the latest NACK error. The test
 // verifies that a when a new watch is registered for the same resource, the new
 // watcher receives the good update followed by the NACK error.
-func TestLDSWatch_ResourceCaching_NACKError(t *testing.T) {
+func (s) TestLDSWatch_ResourceCaching_NACKError(t *testing.T) {
 	mgmtServer := e2e.StartManagementServer(t, e2e.ManagementServerOptions{})
 
 	nodeID := uuid.New().String()


### PR DESCRIPTION
Prior to this PR, xdsChannels were cached for a configurable amount of time after all references to them were released. This was in the hope that an xdsChannel might get used again very soon.

But with fallback support, we want channels to lower priority servers to be closed as soon as a higher priority server comes up. If at all we want to bring back support to cache unused channels, this can be implemented in the transport builder when someone asks for it.

Link to internal discussion: https://chat.google.com/room/AAAAbkw9L3c/oa6GgM1MPlk

This change does lead to a minor behavior change. Earlier when the last watch on an xdsChannel was being canceled, we would see a discovery request with no resources specified in it. But with the current change, when the last watch on an xdsChannel is being canceled, the channel itself would get closed. Hence we **might** not see the empty discovery request on the wire.

Summary of test changes:
- `TestClose` in `cdsbalancer_test.go` was verifying that an empty discovery request was being sent out when the LB policy was closed. This does not happen anymore. So, the test is changed to only verify that the child policy is closed when the parent is closed.
- `TestADS_ACK_NACK_ResourceIsNotRequestedAnymore` in `ads_stream_ack_nack_test.go`:
  - The test was checking that an empty discovery request was being sent when a previously requested resource was no longer being requested. This is being changed to verify that the underlying connection to the management server is closed instead. 
  -  Similarly when a watch for the same resource is re-registered, earlier, the test was expecting a request with the previously cached version number. But now, since the channel is being deleted, the new watch will result in a request with an empty version string.
- `TestADS_ResourcesAreRequestedAfterStreamRestart` in `ads_stream_restart_test.go`:
  - Remove that check that looks for an empty discovery request
- `xds/internal/xdsclient/tests/authority_test.go`
  - One of the tests was specifically verifying that an xdsChannel was not being closed when the last watch was canceled. That test is changed to verify that the xdsChannel is being closed when the last watch is canceled.
  - Couple of tests are deleted because they no longer make sense
- `TestLDSWatch_ResourceCaching_NACKError` in `lds_watchers_test.go` was being flaky because it was validating that exactly two discovery requests were being sent. But since the resource in that test was being NACKed, the management server will keep resending the same resource and therefore the client will keep NACKing it. 

RELEASE NOTES:
- TBD