### PR TITLE
test: switching to stubserver in tests instead of testservice 

### DIFF
--- a/test/balancer_test.go
+++ b/test/balancer_test.go
@@ -610,7 +610,6 @@ func (s) TestWaitForReady(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error while listening. Err: %v", err)
 	}
-
 	const one = "1"
 	stub := &stubserver.StubServer{
 		Listener: lis,

--- a/test/balancer_test.go
+++ b/test/balancer_test.go
@@ -419,7 +419,7 @@ func (s) TestAddressAttributesInNewSubConn(t *testing.T) {
 	}
 	stub := &stubserver.StubServer{
 		Listener: lis,
-		EmptyCallF: func(ctx context.Context, in *testpb.Empty) (*testpb.Empty, error) {
+		EmptyCallF: func(_ context.Context, _ *testpb.Empty) (*testpb.Empty, error) {
 			return &testpb.Empty{}, nil
 		},
 	}
@@ -557,7 +557,7 @@ func (s) TestServersSwap(t *testing.T) {
 
 		stub := &stubserver.StubServer{
 			Listener: lis,
-			UnaryCallF: func(ctx context.Context, in *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
+			UnaryCallF: func(_ context.Context, _ *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
 				return &testpb.SimpleResponse{Username: username}, nil
 			},
 		}
@@ -614,7 +614,7 @@ func (s) TestWaitForReady(t *testing.T) {
 	const one = "1"
 	stub := &stubserver.StubServer{
 		Listener: lis,
-		UnaryCallF: func(ctx context.Context, in *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
+		UnaryCallF: func(_ context.Context, _ *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
 			return &testpb.SimpleResponse{Username: one}, nil
 		},
 	}
@@ -750,7 +750,7 @@ func (s) TestAuthorityInBuildOptions(t *testing.T) {
 
 			stub := &stubserver.StubServer{
 				Listener: lis,
-				EmptyCallF: func(ctx context.Context, in *testpb.Empty) (*testpb.Empty, error) {
+				EmptyCallF: func(_ context.Context, _ *testpb.Empty) (*testpb.Empty, error) {
 					return &testpb.Empty{}, nil
 				},
 			}

--- a/test/balancer_test.go
+++ b/test/balancer_test.go
@@ -426,7 +426,6 @@ func (s) TestAddressAttributesInNewSubConn(t *testing.T) {
 	}
 	stubserver.StartTestService(t, stub)
 	defer stub.S.Stop()
-
 	t.Logf("Started gRPC server at %s...", lis.Addr().String())
 
 	creds := &attrTransportCreds{}
@@ -755,7 +754,6 @@ func (s) TestAuthorityInBuildOptions(t *testing.T) {
 			}
 			stubserver.StartTestService(t, stub)
 			defer stub.S.Stop()
-
 			t.Logf("Started gRPC server at %s...", lis.Addr().String())
 
 			r := manual.NewBuilderWithScheme("whatever")

--- a/test/balancer_test.go
+++ b/test/balancer_test.go
@@ -422,9 +422,8 @@ func (s) TestAddressAttributesInNewSubConn(t *testing.T) {
 		EmptyCallF: func(_ context.Context, _ *testpb.Empty) (*testpb.Empty, error) {
 			return &testpb.Empty{}, nil
 		},
+		S: grpc.NewServer(),
 	}
-
-	stub.S = grpc.NewServer()
 	stubserver.StartTestService(t, stub)
 	defer stub.S.Stop()
 
@@ -560,8 +559,8 @@ func (s) TestServersSwap(t *testing.T) {
 			UnaryCallF: func(_ context.Context, _ *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
 				return &testpb.SimpleResponse{Username: username}, nil
 			},
+			S: grpc.NewServer(),
 		}
-		stub.S = grpc.NewServer()
 		stubserver.StartTestService(t, stub)
 		return lis.Addr().String(), stub.S.Stop
 	}
@@ -616,8 +615,8 @@ func (s) TestWaitForReady(t *testing.T) {
 		UnaryCallF: func(_ context.Context, _ *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
 			return &testpb.SimpleResponse{Username: one}, nil
 		},
+		S: grpc.NewServer(),
 	}
-	stub.S = grpc.NewServer()
 	stubserver.StartTestService(t, stub)
 	defer stub.S.Stop()
 
@@ -752,8 +751,8 @@ func (s) TestAuthorityInBuildOptions(t *testing.T) {
 				EmptyCallF: func(_ context.Context, _ *testpb.Empty) (*testpb.Empty, error) {
 					return &testpb.Empty{}, nil
 				},
+				S: grpc.NewServer(),
 			}
-			stub.S = grpc.NewServer()
 			stubserver.StartTestService(t, stub)
 			defer stub.S.Stop()
 


### PR DESCRIPTION
Partially Addresses: #7291

RELEASE NOTES: None