### PR TITLE
experimental/stats: re-add type aliases for migration

### DIFF
--- a/experimental/stats/metrics.go
+++ b/experimental/stats/metrics.go
@@ -19,6 +19,8 @@
 // Package stats contains experimental metrics/stats API's.
 package stats
 
+import "google.golang.org/grpc/stats"
+
 // MetricsRecorder records on metrics derived from metric registry.
 type MetricsRecorder interface {
 	// RecordInt64Count records the measurement alongside labels on the int
@@ -36,4 +38,12 @@ type MetricsRecorder interface {
 	// RecordInt64Gauge records the measurement alongside labels on the int
 	// gauge associated with the provided handle.
 	RecordInt64Gauge(handle *Int64GaugeHandle, incr int64, labels ...string)
+}
+
+type Metrics = stats.MetricSet
+
+type Metric = string
+
+func NewMetrics(metrics ...Metric) *Metrics {
+	return stats.NewMetricSet(metrics...)
 }

--- a/experimental/stats/metrics.go
+++ b/experimental/stats/metrics.go
@@ -40,10 +40,15 @@ type MetricsRecorder interface {
 	RecordInt64Gauge(handle *Int64GaugeHandle, incr int64, labels ...string)
 }
 
+// Metrics is an experimental legacy alias of the now-stable stats.MetricSet.
+// Metrics will be deleted in a future release.
 type Metrics = stats.MetricSet
 
+// Metric was replaced by direct usage of strings.
 type Metric = string
 
+// NewMetrics is an experimental legacy alias of the now-stable
+// stats.NewMetricSet.  NewMetrics will be deleted in a future release.
 func NewMetrics(metrics ...Metric) *Metrics {
 	return stats.NewMetricSet(metrics...)
 }


### PR DESCRIPTION
#7874 removed symbols without leaving behind type aliases, which we should not do.  This change re-adds the things removed and should be kept for several releases.

(No release notes since it will be in a patch release.)

RELEASE NOTES: none