### PR TITLE
examples/features/csm_observability: Make CSM Observability example server listen on an IPV4 address

### DIFF
--- a/examples/features/csm_observability/server/main.go
+++ b/examples/features/csm_observability/server/main.go
@@ -66,7 +66,7 @@ func main() {
 	cleanup := csm.EnableObservability(context.Background(), opentelemetry.Options{MetricsOptions: opentelemetry.MetricsOptions{MeterProvider: provider}})
 	defer cleanup()
 
-	lis, err := net.Listen("tcp", ":"+*port)
+	lis, err := net.Listen("tcp4", "0.0.0.0:"+*port)
 	if err != nil {
 		log.Fatalf("Failed to listen: %v", err)
 	}


### PR DESCRIPTION
This PR makes the example server listen explicitly on IPV4. This was causing issues as sometimes the system would listen on IPV6 in previous state which would not align with the LDS Resource.

RELEASE NOTES: N/A