### PR TITLE
clusterresolver: Avoid blocking for subsequent resolver updates in test

### DIFF
--- a/xds/internal/balancer/clusterresolver/e2e_test/eds_impl_test.go
+++ b/xds/internal/balancer/clusterresolver/e2e_test/eds_impl_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"strings"
 	"testing"
 	"time"
@@ -1159,17 +1160,17 @@ func (s) TestEDS_EndpointWithMultipleAddresses(t *testing.T) {
 			return &testpb.SimpleResponse{}, nil
 		},
 	}
-	lis1, err := testutils.LocalTCPListener()
+	lis1, err := net.Listen("tcp", "localhost:0")
 	if err != nil {
 		t.Fatalf("Failed to create listener: %v", err)
 	}
 	defer lis1.Close()
-	lis2, err := testutils.LocalTCPListener()
+	lis2, err := net.Listen("tcp", "localhost:0")
 	if err != nil {
 		t.Fatalf("Failed to create listener: %v", err)
 	}
 	defer lis2.Close()
-	lis3, err := testutils.LocalTCPListener()
+	lis3, err := net.Listen("tcp", "localhost:0")
 	if err != nil {
 		t.Fatalf("Failed to create listener: %v", err)
 	}
@@ -1240,24 +1241,25 @@ func (s) TestEDS_EndpointWithMultipleAddresses(t *testing.T) {
 				},
 			})
 
-			edsWatchCreated := make(chan struct{})
 			// Spin up a management server to receive xDS resources from.
-			mgmtServer := e2e.StartManagementServer(t, e2e.ManagementServerOptions{
-				OnStreamRequest: func(_ int64, req *v3discoverypb.DiscoveryRequest) error {
-					if req.GetTypeUrl() != "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment" {
-						return nil
-					}
-					if req.ResponseNonce == "" {
-						t.Logf("Got initial ClusterLoadAssignment request: %+v", req)
-						close(edsWatchCreated)
-					}
-					return nil
-				},
-			})
+			mgmtServer := e2e.StartManagementServer(t, e2e.ManagementServerOptions{})
 
 			// Create bootstrap configuration pointing to the above management server.
 			nodeID := uuid.New().String()
 			bootstrapContents := e2e.DefaultBootstrapContents(t, nodeID, mgmtServer.Address)
+
+			// Create xDS resources for consumption by the test. We start off with a
+			// single backend in a single EDS locality.
+			resources := clientEndpointsResource(nodeID, edsServiceName, []e2e.LocalityOptions{{
+				Name:   localityName1,
+				Weight: 1,
+				Backends: []e2e.BackendOptions{{
+					Ports: ports,
+				}},
+			}})
+			if err := mgmtServer.Update(ctx, resources); err != nil {
+				t.Fatal(err)
+			}
 
 			// Create an xDS client talking to the above management server, configured
 			// with a short watch expiry timeout.
@@ -1294,25 +1296,6 @@ func (s) TestEDS_EndpointWithMultipleAddresses(t *testing.T) {
 				t.Fatalf("failed to create new client for local test server: %v", err)
 			}
 			defer cc.Close()
-			cc.Connect()
-
-			select {
-			case <-ctx.Done():
-				t.Fatal("Timed out waiting for EDS watch to be created.")
-			case <-edsWatchCreated:
-			}
-			// Create xDS resources for consumption by the test.
-			resources := clientEndpointsResource(nodeID, edsServiceName, []e2e.LocalityOptions{{
-				Name:   localityName1,
-				Weight: 1,
-				Backends: []e2e.BackendOptions{{
-					Ports: ports,
-				}},
-			}})
-			if err := mgmtServer.Update(ctx, resources); err != nil {
-				t.Fatal(err)
-			}
-
 			client := testgrpc.NewTestServiceClient(cc)
 			if err := rrutil.CheckRoundRobinRPCs(ctx, client, []resolver.Address{{Addr: lis1.Addr().String()}}); err != nil {
 				t.Fatal(err)

--- a/xds/internal/balancer/clusterresolver/e2e_test/eds_impl_test.go
+++ b/xds/internal/balancer/clusterresolver/e2e_test/eds_impl_test.go
@@ -1232,11 +1232,7 @@ func (s) TestEDS_EndpointWithMultipleAddresses(t *testing.T) {
 					bd.Data.(balancer.Balancer).Close()
 				},
 				UpdateClientConnState: func(bd *stub.BalancerData, ccs balancer.ClientConnState) error {
-					select {
-					case resolverUpdateCh <- ccs.ResolverState:
-					default:
-						// Don't block forever in case of multiple updates.
-					}
+					resolverUpdateCh <- ccs.ResolverState
 					return bd.Data.(balancer.Balancer).UpdateClientConnState(ccs)
 				},
 			})

--- a/xds/internal/balancer/clusterresolver/e2e_test/eds_impl_test.go
+++ b/xds/internal/balancer/clusterresolver/e2e_test/eds_impl_test.go
@@ -1232,7 +1232,11 @@ func (s) TestEDS_EndpointWithMultipleAddresses(t *testing.T) {
 					bd.Data.(balancer.Balancer).Close()
 				},
 				UpdateClientConnState: func(bd *stub.BalancerData, ccs balancer.ClientConnState) error {
-					resolverUpdateCh <- ccs.ResolverState
+					select {
+					case resolverUpdateCh <- ccs.ResolverState:
+					default:
+						// Don't block forever in case of multiple updates.
+					}
 					return bd.Data.(balancer.Balancer).UpdateClientConnState(ccs)
 				},
 			})


### PR DESCRIPTION
Fixes: https://github.com/grpc/grpc-go/issues/7961

This test was added recent in #7858. In [this test failure](https://github.com/grpc/grpc-go/actions/runs/12370599541/job/34524912126?pr=7908), the stack trace indicates that a goroutine was blocked forever. There were no failure logs though. This change avoids writing to the resolver update channel if its buffer is full.

RELEASE NOTES: N/A