### PR TITLE
test: Add a test for decompression exceeding max receive message size

### DIFF
--- a/test/compressor_test.go
+++ b/test/compressor_test.go
@@ -801,7 +801,9 @@ func (f *fakeCompressor) Decompress(io.Reader) (io.Reader, error) {
 }
 
 func (f *fakeCompressor) Name() string {
-	return "fake-gzip"
+	// Use the name of an existing compressor to avoid interactions with other
+	// tests since compressors can't be un-registered.
+	return "gzip"
 }
 
 type nopWriteCloser struct {
@@ -817,6 +819,10 @@ func (nopWriteCloser) Close() error {
 // max receive message size restricted to 99 bytes. The test verifies that the
 // client receives a ResourceExhausted response from the server.
 func (s) TestDecompressionExceedsMaxMessageSize(t *testing.T) {
+	oldC := encoding.GetCompressor("gzip")
+	defer func() {
+		encoding.RegisterCompressor(oldC)
+	}()
 	const messageLen = 100
 	encoding.RegisterCompressor(&fakeCompressor{decompressedMessageSize: messageLen})
 	ss := &stubserver.StubServer{
@@ -833,7 +839,7 @@ func (s) TestDecompressionExceedsMaxMessageSize(t *testing.T) {
 	defer cancel()
 
 	req := &testpb.SimpleRequest{Payload: &testpb.Payload{}}
-	_, err := ss.Client.UnaryCall(ctx, req, grpc.UseCompressor("fake-gzip"))
+	_, err := ss.Client.UnaryCall(ctx, req, grpc.UseCompressor("gzip"))
 	if got, want := status.Code(err), codes.ResourceExhausted; got != want {
 		t.Errorf("Client.UnaryCall(%+v) returned status %v, want %v", req, got, want)
 	}


### PR DESCRIPTION
During the review of https://github.com/grpc/grpc-go/pull/7918, it was seen that even if the sender/receiver returns a `status.Internal` error code instead of `status.ResourceExhausted` when decompression results in a message exceeding the configured max receive message size, no tests fail. This PR adds a test to catch such regressions in the future.

RELEASE NOTES: N/A