### PR TITLE
envconfig: enable xDS client fallback by default

### DIFF
--- a/internal/envconfig/envconfig.go
+++ b/internal/envconfig/envconfig.go
@@ -49,7 +49,7 @@ var (
 	// XDSFallbackSupport is the env variable that controls whether support for
 	// xDS fallback is turned on. If this is unset or is false, only the first
 	// xDS server in the list of server configs will be used.
-	XDSFallbackSupport = boolFromEnv("GRPC_EXPERIMENTAL_XDS_FALLBACK", false)
+	XDSFallbackSupport = boolFromEnv("GRPC_EXPERIMENTAL_XDS_FALLBACK", true)
 	// NewPickFirstEnabled is set if the new pickfirst leaf policy is to be used
 	// instead of the exiting pickfirst implementation. This can be enabled by
 	// setting the environment variable "GRPC_EXPERIMENTAL_ENABLE_NEW_PICK_FIRST"

--- a/internal/xds/bootstrap/bootstrap_test.go
+++ b/internal/xds/bootstrap/bootstrap_test.go
@@ -429,10 +429,6 @@ func (s) TestGetConfiguration_Success(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			origFallbackEnv := envconfig.XDSFallbackSupport
-			envconfig.XDSFallbackSupport = true
-			defer func() { envconfig.XDSFallbackSupport = origFallbackEnv }()
-
 			testGetConfigurationWithFileNameEnv(t, test.name, false, test.wantConfig)
 			testGetConfigurationWithFileContentEnv(t, test.name, false, test.wantConfig)
 		})
@@ -1202,9 +1198,9 @@ func (s) TestNode_ToProto(t *testing.T) {
 // Tests the case where the xDS fallback env var is set to false, and verifies
 // that only the first server from the list of server configurations is used.
 func (s) TestGetConfiguration_FallbackDisabled(t *testing.T) {
-	// TODO(easwars): Default value of "GRPC_EXPERIMENTAL_XDS_FALLBACK"
-	// env var is currently false. When the default is changed to true,
-	// explicitly set it to false here.
+	origFallbackEnv := envconfig.XDSFallbackSupport
+	envconfig.XDSFallbackSupport = false
+	defer func() { envconfig.XDSFallbackSupport = origFallbackEnv }()
 
 	cancel := setupBootstrapOverride(map[string]string{
 		"multipleXDSServers": `

--- a/xds/internal/xdsclient/tests/fallback_test.go
+++ b/xds/internal/xdsclient/tests/fallback_test.go
@@ -30,7 +30,6 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/internal"
-	"google.golang.org/grpc/internal/envconfig"
 	"google.golang.org/grpc/internal/stubserver"
 	"google.golang.org/grpc/internal/testutils"
 	"google.golang.org/grpc/internal/testutils/xds/e2e"
@@ -79,11 +78,6 @@ func waitForRPCsToReachBackend(ctx context.Context, client testgrpc.TestServiceC
 // to it. The test also verifies that when all requested resources are cached
 // from the primary, fallback is not triggered when the connection goes down.
 func (s) TestFallback_OnStartup(t *testing.T) {
-	// Enable fallback env var.
-	origFallbackEnv := envconfig.XDSFallbackSupport
-	envconfig.XDSFallbackSupport = true
-	defer func() { envconfig.XDSFallbackSupport = origFallbackEnv }()
-
 	ctx, cancel := context.WithTimeout(context.Background(), defaultFallbackTestTimeout)
 	defer cancel()
 
@@ -248,11 +242,6 @@ func (s) TestFallback_OnStartup(t *testing.T) {
 
 // Tests fallback when the primary management server fails during an update.
 func (s) TestFallback_MidUpdate(t *testing.T) {
-	// Enable fallback env var.
-	origFallbackEnv := envconfig.XDSFallbackSupport
-	envconfig.XDSFallbackSupport = true
-	defer func() { envconfig.XDSFallbackSupport = origFallbackEnv }()
-
 	ctx, cancel := context.WithTimeout(context.Background(), defaultFallbackTestTimeout)
 	defer cancel()
 
@@ -454,11 +443,6 @@ func (s) TestFallback_MidUpdate(t *testing.T) {
 
 // Tests fallback when the primary management server fails during startup.
 func (s) TestFallback_MidStartup(t *testing.T) {
-	// Enable fallback env var.
-	origFallbackEnv := envconfig.XDSFallbackSupport
-	envconfig.XDSFallbackSupport = true
-	defer func() { envconfig.XDSFallbackSupport = origFallbackEnv }()
-
 	ctx, cancel := context.WithTimeout(context.Background(), defaultFallbackTestTimeout)
 	defer cancel()
 


### PR DESCRIPTION
Interop tests are passing. Setting this to `true` now will ensure that xDS fallback is ON by default starting `v1.70.0`.

RELEASE NOTES:
- xdsclient: fallback to a secondary management server (if specified in the bootstrap configuration) when the primary is down is enabled by default. Can be disabled by setting the environment variable `GRPC_EXPERIMENTAL_XDS_FALLBACK` to `false`.