### PR TITLE
test: Workaround slow SRV lookups in flaking test

### DIFF
--- a/test/creds_test.go
+++ b/test/creds_test.go
@@ -270,6 +270,8 @@ func (s) TestWaitForReadyRPCErrorOnBadCertificates(t *testing.T) {
 	testutils.AwaitState(ctx, t, cc, connectivity.TransientFailure)
 
 	tc := testgrpc.NewTestServiceClient(cc)
+	// Use a short context as WaitForReady waits for context expiration before
+	// failing the RPC.
 	ctx, cancel = context.WithTimeout(context.Background(), defaultTestShortTimeout)
 	defer cancel()
 	if _, err = tc.EmptyCall(ctx, &testpb.Empty{}, grpc.WaitForReady(true)); !strings.Contains(err.Error(), clientAlwaysFailCredErrorMsg) {

--- a/test/creds_test.go
+++ b/test/creds_test.go
@@ -32,7 +32,6 @@ import (
 	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
-	"google.golang.org/grpc/internal/resolver/dns"
 	"google.golang.org/grpc/internal/testutils"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/resolver"
@@ -244,28 +243,13 @@ func (s) TestFailFastRPCErrorOnBadCertificates(t *testing.T) {
 	defer cc.Close()
 
 	tc := testgrpc.NewTestServiceClient(cc)
-	for i := 0; i < 1000; i++ {
-		// This loop runs for at most 1 second. The first several RPCs will fail
-		// with Unavailable because the connection hasn't started. When the
-		// first connection failed with creds error, the next RPC should also
-		// fail with the expected error.
-		if _, err = tc.EmptyCall(ctx, &testpb.Empty{}); strings.Contains(err.Error(), clientAlwaysFailCredErrorMsg) {
-			return
-		}
-		time.Sleep(time.Millisecond)
+	if _, err = tc.EmptyCall(ctx, &testpb.Empty{}); strings.Contains(err.Error(), clientAlwaysFailCredErrorMsg) {
+		return
 	}
 	te.t.Fatalf("TestService/EmptyCall(_, _) = _, %v, want err.Error() contains %q", err, clientAlwaysFailCredErrorMsg)
 }
 
 func (s) TestWaitForReadyRPCErrorOnBadCertificates(t *testing.T) {
-	// SRV lookup is enabled because of the grpclb import in other test files.
-	// It is disabled since it can take more than 10 millis causing test
-	// flakiness.
-	originalEnableSRV := dns.EnableSRVLookups
-	defer func() {
-		dns.EnableSRVLookups = originalEnableSRV
-	}()
-	dns.EnableSRVLookups = false
 	te := newTest(t, env{name: "bad-cred", network: "tcp", security: "empty", balancer: "round_robin"})
 	te.startServer(&testServer{security: te.e.security})
 	defer te.tearDown()
@@ -277,8 +261,16 @@ func (s) TestWaitForReadyRPCErrorOnBadCertificates(t *testing.T) {
 	}
 	defer cc.Close()
 
+	// The DNS resolver may take more than defaultTestShortTimeout, we let the
+	// channel enter TransientFailure signalling that the first resolver state
+	// has been produced.
+	cc.Connect()
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	testutils.AwaitState(ctx, t, cc, connectivity.TransientFailure)
+
 	tc := testgrpc.NewTestServiceClient(cc)
-	ctx, cancel := context.WithTimeout(context.Background(), defaultTestShortTimeout)
+	ctx, cancel = context.WithTimeout(context.Background(), defaultTestShortTimeout)
 	defer cancel()
 	if _, err = tc.EmptyCall(ctx, &testpb.Empty{}, grpc.WaitForReady(true)); !strings.Contains(err.Error(), clientAlwaysFailCredErrorMsg) {
 		t.Fatalf("TestService/EmptyCall(_, _) = _, %v, want err.Error() contains %q", err, clientAlwaysFailCredErrorMsg)

--- a/test/creds_test.go
+++ b/test/creds_test.go
@@ -32,6 +32,7 @@ import (
 	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/internal/resolver/dns"
 	"google.golang.org/grpc/internal/testutils"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/resolver"
@@ -257,6 +258,14 @@ func (s) TestFailFastRPCErrorOnBadCertificates(t *testing.T) {
 }
 
 func (s) TestWaitForReadyRPCErrorOnBadCertificates(t *testing.T) {
+	// SRV lookup is enabled because of the grpclb import in other test files.
+	// It is disabled since it can take more than 10 millis causing test
+	// flakiness.
+	originalEnableSRV := dns.EnableSRVLookups
+	defer func() {
+		dns.EnableSRVLookups = originalEnableSRV
+	}()
+	dns.EnableSRVLookups = false
 	te := newTest(t, env{name: "bad-cred", network: "tcp", security: "empty", balancer: "round_robin"})
 	te.startServer(&testServer{security: te.e.security})
 	defer te.tearDown()


### PR DESCRIPTION
This test was migrated from `grpc.DialContext` to `grpc.NewClient` in https://github.com/grpc/grpc-go/pull/7920. This caused the resolver to change from passthrough to dns. The test started failing on Mac and flaking on debian systems (more than 1/100 runs fail). The test uses a short timeout and expects an RPC to fail due to a bad TLS certificate. When the test fails, the RPC failure cause is `DeadlineExceeded`. The SRV lookups for localhost and service `grpclb` are causing the timeouts. SRV lookup are disabled by default.
https://github.com/grpc/grpc-go/blob/e5a4eb091f41fa414c32c4a6c8f2ba8042cb5cb0/internal/resolver/dns/dns_resolver.go#L48

SRV lookups are enabled when grpclb is imported.
https://github.com/grpc/grpc-go/blob/e5a4eb091f41fa414c32c4a6c8f2ba8042cb5cb0/balancer/grpclb/grpclb.go#L105-L108

There is another file in the `test` package that imports grpclb, causing SRV lookups to be enabled for this test.
https://github.com/grpc/grpc-go/blob/e5a4eb091f41fa414c32c4a6c8f2ba8042cb5cb0/test/channelz_test.go#L35


RELEASE NOTES: None