### PR TITLE
cleanup: Fix usages of non-constant format strings

### DIFF
--- a/internal/testutils/blocking_context_dialer_test.go
+++ b/internal/testutils/blocking_context_dialer_test.go
@@ -125,7 +125,7 @@ func (s) TestBlockingDialer_HoldWaitFail(t *testing.T) {
 	}()
 
 	if !h.Wait(ctx) {
-		t.Fatalf("Timeout while waiting for a connection attempt to " + h.addr)
+		t.Fatal("Timeout while waiting for a connection attempt to " + h.addr)
 	}
 	select {
 	case err = <-dialError:

--- a/internal/transport/handler_server.go
+++ b/internal/transport/handler_server.go
@@ -498,5 +498,5 @@ func mapRecvMsgError(err error) error {
 	if strings.Contains(err.Error(), "body closed by handler") {
 		return status.Error(codes.Canceled, err.Error())
 	}
-	return connectionErrorf(true, err, err.Error())
+	return connectionErrorf(true, err, "%s", err.Error())
 }

--- a/stream.go
+++ b/stream.go
@@ -1766,7 +1766,7 @@ func (ss *serverStream) RecvMsg(m any) (err error) {
 			return err
 		}
 		if err == io.ErrUnexpectedEOF {
-			err = status.Errorf(codes.Internal, io.ErrUnexpectedEOF.Error())
+			err = status.Error(codes.Internal, io.ErrUnexpectedEOF.Error())
 		}
 		return toRPCErr(err)
 	}

--- a/test/creds_test.go
+++ b/test/creds_test.go
@@ -186,7 +186,7 @@ type methodTestCreds struct{}
 
 func (m *methodTestCreds) GetRequestMetadata(ctx context.Context, _ ...string) (map[string]string, error) {
 	ri, _ := credentials.RequestInfoFromContext(ctx)
-	return nil, status.Errorf(codes.Unknown, ri.Method)
+	return nil, status.Error(codes.Unknown, ri.Method)
 }
 
 func (m *methodTestCreds) RequireTransportSecurity() bool { return false }

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -4692,7 +4692,7 @@ func (s) TestTapTimeout(t *testing.T) {
 	ss := &stubserver.StubServer{
 		EmptyCallF: func(ctx context.Context, _ *testpb.Empty) (*testpb.Empty, error) {
 			<-ctx.Done()
-			return nil, status.Errorf(codes.Canceled, ctx.Err().Error())
+			return nil, status.Error(codes.Canceled, ctx.Err().Error())
 		},
 	}
 	if err := ss.Start(sopts); err != nil {
@@ -5104,7 +5104,7 @@ func (s) TestStatusInvalidUTF8Message(t *testing.T) {
 
 	ss := &stubserver.StubServer{
 		EmptyCallF: func(context.Context, *testpb.Empty) (*testpb.Empty, error) {
-			return nil, status.Errorf(codes.Internal, origMsg)
+			return nil, status.Error(codes.Internal, origMsg)
 		},
 	}
 	if err := ss.Start(nil); err != nil {

--- a/xds/internal/balancer/clusterimpl/picker.go
+++ b/xds/internal/balancer/clusterimpl/picker.go
@@ -129,7 +129,7 @@ func (d *picker) Pick(info balancer.PickInfo) (balancer.PickResult, error) {
 			if d.loadStore != nil {
 				d.loadStore.CallDropped("")
 			}
-			return balancer.PickResult{}, status.Errorf(codes.Unavailable, err.Error())
+			return balancer.PickResult{}, status.Error(codes.Unavailable, err.Error())
 		}
 	}
 

--- a/xds/internal/xdsclient/transport/ads/ads_stream.go
+++ b/xds/internal/xdsclient/transport/ads/ads_stream.go
@@ -664,7 +664,7 @@ func (s *StreamImpl) onError(err error, msgReceived bool) {
 	// connection hitting its max connection age limit.
 	// (see [gRFC A9](https://github.com/grpc/proposal/blob/master/A9-server-side-conn-mgt.md)).
 	if msgReceived {
-		err = xdsresource.NewErrorf(xdsresource.ErrTypeStreamFailedAfterRecv, err.Error())
+		err = xdsresource.NewErrorf(xdsresource.ErrTypeStreamFailedAfterRecv, "%s", err.Error())
 	}
 
 	s.eventHandler.OnADSStreamError(err)


### PR DESCRIPTION
go 1.24 includes a vet rule that catches non-constant format strings: https://github.com/golang/go/issues/60529. This causes `go test` to fail unless vet is disabled when using go1.24.


RELEASE NOTES: None