### PR TITLE
grpc: add new Dial/ServerOptions to set the size like the existing ones, but which do not also disable BDP esimation

### DIFF
--- a/dialoptions.go
+++ b/dialoptions.go
@@ -94,6 +94,8 @@ type dialOptions struct {
 	idleTimeout                 time.Duration
 	defaultScheme               string
 	maxCallAttempts             int
+	staticConnWindowSize        int32
+	staticStreamWindowSize      int32
 }
 
 // DialOption configures how we set up the connection.
@@ -659,6 +661,32 @@ func WithMaxHeaderListSize(s uint32) DialOption {
 func WithDisableHealthCheck() DialOption {
 	return newFuncDialOption(func(o *dialOptions) {
 		o.disableHealthCheck = true
+	})
+}
+
+// WithStaticConnWindowSize returns a DialOption which sets a static value for
+// the connection window size. This disables BDP estimation and keeps the
+// window size fixed at the provided value. The lower bound for window size is
+// 64K, and any value smaller than that will be ignored.
+func WithStaticConnWindowSize(s int32) DialOption {
+	return newFuncDialOption(func(o *dialOptions) {
+		if s < 64*1024 {
+			return
+		}
+		o.staticConnWindowSize = s
+	})
+}
+
+// WithStaticStreamWindowSize returns a DialOption which sets a static value for
+// the stream window size. This disables BDP estimation and keeps the
+// window size fixed at the provided value. The lower bound for window size is
+// 64K, and any value smaller than that will be ignored.
+func WithStaticStreamWindowSize(s int32) DialOption {
+	return newFuncDialOption(func(o *dialOptions) {
+		if s < 64*1024 {
+			return
+		}
+		o.staticStreamWindowSize = s
 	})
 }
 

--- a/dialoptions.go
+++ b/dialoptions.go
@@ -664,29 +664,19 @@ func WithDisableHealthCheck() DialOption {
 	})
 }
 
-// WithStaticConnWindowSize returns a DialOption which sets a static value for
-// the connection window size. This disables BDP estimation and keeps the
-// window size fixed at the provided value. The lower bound for window size is
-// 64K, and any value smaller than that will be ignored.
-func WithStaticConnWindowSize(s int32) DialOption {
+// WithStaticConnWindowSize returns a DialOption to set the static initial
+// connection window size. This does not disable BDP estimation.
+func WithStaticConnWindowSize(size int32) DialOption {
 	return newFuncDialOption(func(o *dialOptions) {
-		if s < 64*1024 {
-			return
-		}
-		o.staticConnWindowSize = s
+		o.staticConnWindowSize = size
 	})
 }
 
-// WithStaticStreamWindowSize returns a DialOption which sets a static value for
-// the stream window size. This disables BDP estimation and keeps the
-// window size fixed at the provided value. The lower bound for window size is
-// 64K, and any value smaller than that will be ignored.
-func WithStaticStreamWindowSize(s int32) DialOption {
+// WithStaticStreamWindowSize returns a DialOption to set the static initial
+// stream window size. This does not disable BDP estimation.
+func WithStaticStreamWindowSize(size int32) DialOption {
 	return newFuncDialOption(func(o *dialOptions) {
-		if s < 64*1024 {
-			return
-		}
-		o.staticStreamWindowSize = s
+		o.staticStreamWindowSize = size
 	})
 }
 

--- a/server.go
+++ b/server.go
@@ -146,34 +146,36 @@ type Server struct {
 }
 
 type serverOptions struct {
-	creds                 credentials.TransportCredentials
-	codec                 baseCodec
-	cp                    Compressor
-	dc                    Decompressor
-	unaryInt              UnaryServerInterceptor
-	streamInt             StreamServerInterceptor
-	chainUnaryInts        []UnaryServerInterceptor
-	chainStreamInts       []StreamServerInterceptor
-	binaryLogger          binarylog.Logger
-	inTapHandle           tap.ServerInHandle
-	statsHandlers         []stats.Handler
-	maxConcurrentStreams  uint32
-	maxReceiveMessageSize int
-	maxSendMessageSize    int
-	unknownStreamDesc     *StreamDesc
-	keepaliveParams       keepalive.ServerParameters
-	keepalivePolicy       keepalive.EnforcementPolicy
-	initialWindowSize     int32
-	initialConnWindowSize int32
-	writeBufferSize       int
-	readBufferSize        int
-	sharedWriteBuffer     bool
-	connectionTimeout     time.Duration
-	maxHeaderListSize     *uint32
-	headerTableSize       *uint32
-	numServerWorkers      uint32
-	bufferPool            mem.BufferPool
-	waitForHandlers       bool
+	creds                  credentials.TransportCredentials
+	codec                  baseCodec
+	cp                     Compressor
+	dc                     Decompressor
+	unaryInt               UnaryServerInterceptor
+	streamInt              StreamServerInterceptor
+	chainUnaryInts         []UnaryServerInterceptor
+	chainStreamInts        []StreamServerInterceptor
+	binaryLogger           binarylog.Logger
+	inTapHandle            tap.ServerInHandle
+	statsHandlers          []stats.Handler
+	maxConcurrentStreams   uint32
+	maxReceiveMessageSize  int
+	maxSendMessageSize     int
+	unknownStreamDesc      *StreamDesc
+	keepaliveParams        keepalive.ServerParameters
+	keepalivePolicy        keepalive.EnforcementPolicy
+	initialWindowSize      int32
+	initialConnWindowSize  int32
+	writeBufferSize        int
+	readBufferSize         int
+	sharedWriteBuffer      bool
+	connectionTimeout      time.Duration
+	maxHeaderListSize      *uint32
+	headerTableSize        *uint32
+	numServerWorkers       uint32
+	bufferPool             mem.BufferPool
+	waitForHandlers        bool
+	staticStreamWindowSize int32
+	staticConnWindowSize   int32
 }
 
 var defaultServerOptions = serverOptions{
@@ -606,6 +608,22 @@ func NumStreamWorkers(numServerWorkers uint32) ServerOption {
 func WaitForHandlers(w bool) ServerOption {
 	return newFuncServerOption(func(o *serverOptions) {
 		o.waitForHandlers = w
+	})
+}
+
+// StaticStreamWindowSize returns a ServerOption to set the static initial
+// stream window size. This does not disable BDP estimation.
+func StaticStreamWindowSize(size int32) ServerOption {
+	return newFuncServerOption(func(o *serverOptions) {
+		o.staticStreamWindowSize = size
+	})
+}
+
+// StaticConnWindowSize returns a ServerOption to set the static initial
+// connection window size. This does not disable BDP estimation.
+func StaticConnWindowSize(size int32) ServerOption {
+	return newFuncServerOption(func(o *serverOptions) {
+		o.staticConnWindowSize = size
 	})
 }
 


### PR DESCRIPTION
Partially addresses: https://github.com/grpc/grpc-go/issues/7923

RELEASE NOTES:
- grpc: add new Dial/ServerOptions to set the size like the existing ones, but which do not also disable BDP esimation