### PR TITLE
clustetresolver: Copy endpoints.Addresses slice from DNS updates to avoid data races

### DIFF
--- a/xds/internal/balancer/clusterresolver/clusterresolver.go
+++ b/xds/internal/balancer/clusterresolver/clusterresolver.go
@@ -248,37 +248,32 @@ func (b *clusterResolverBalancer) updateChildConfig() {
 		b.logger.Infof("Built child policy config: %s", pretty.ToJSON(childCfg))
 	}
 
-	flattenedAddrs := make([]resolver.Address, 0, len(endpoints))
-	// Send a copy of the endpoints slice to the children as balancer may use
-	// the same endpoints slice in subsequent updates.
-	endpointsCopy := make([]resolver.Endpoint, 0, len(endpoints))
-	for _, endpoint := range endpoints {
-		addrs := make([]resolver.Address, 0, len(endpoint.Addresses))
-		for _, addr := range endpoint.Addresses {
-			addr.BalancerAttributes = endpoint.Attributes
-			addrs = append(addrs, addr)
+	flattenedAddrs := make([]resolver.Address, len(endpoints))
+	for i := range endpoints {
+		for j := range endpoints[i].Addresses {
+			addr := endpoints[i].Addresses[j]
+			addr.BalancerAttributes = endpoints[i].Attributes
 			// If the endpoint has multiple addresses, only the first is added
 			// to the flattened address list. This ensures that LB policies
 			// that don't support endpoints create only one subchannel to a
 			// backend.
-			if len(addrs) == 1 {
-				flattenedAddrs = append(flattenedAddrs, addr)
+			if j == 0 {
+				flattenedAddrs[i] = addr
 			}
+			// BalancerAttributes need to be present in endpoint addresses. This
+			// temporary workaround is required to make load reporting work
+			// with the old pickfirst policy which creates SubConns with multiple
+			// addresses. Since the addresses can be from different localities,
+			// an Address.BalancerAttribute is used to identify the locality of the
+			// address used by the transport. This workaround can be removed once
+			// the old pickfirst is removed.
+			// See https://github.com/grpc/grpc-go/issues/7339
+			endpoints[i].Addresses[j] = addr
 		}
-		// BalancerAttributes need to be present in endpoint addresses. This
-		// temporary workaround is required to make load reporting work
-		// with the old pickfirst policy which creates SubConns with multiple
-		// addresses. Since the addresses can be from different localities,
-		// an Address.BalancerAttribute is used to identify the locality of the
-		// address used by the transport. This workaround can be removed once
-		// the old pickfirst is removed.
-		// See https://github.com/grpc/grpc-go/issues/7339
-		endpoint.Addresses = addrs
-		endpointsCopy = append(endpointsCopy, endpoint)
 	}
 	if err := b.child.UpdateClientConnState(balancer.ClientConnState{
 		ResolverState: resolver.State{
-			Endpoints:     endpointsCopy,
+			Endpoints:     endpoints,
 			Addresses:     flattenedAddrs,
 			ServiceConfig: b.configRaw,
 			Attributes:    b.attrsWithClient,

--- a/xds/internal/balancer/clusterresolver/configbuilder.go
+++ b/xds/internal/balancer/clusterresolver/configbuilder.go
@@ -144,6 +144,9 @@ func buildClusterImplConfigForDNS(g *nameGenerator, endpoints []resolver.Endpoin
 	pName := fmt.Sprintf("priority-%v", g.prefix)
 	for i, e := range endpoints {
 		retEndpoints[i] = hierarchy.SetInEndpoint(e, []string{pName})
+		// Copy the nested address field as slice fields are shared by the
+		// iteration variable and the original slice.
+		retEndpoints[i].Addresses = append([]resolver.Address{}, e.Addresses...)
 	}
 	return pName, &clusterimpl.LBConfig{
 		Cluster:         mechanism.Cluster,


### PR DESCRIPTION
Fixes: https://github.com/grpc/grpc-go/issues/7982

## Background
`clusterresolver` uses the `lastUpate()` method in the resourceResolver interface that has implementations for both EDS and DNS.
https://github.com/grpc/grpc-go/blob/2d4daf3475905868585a914ab39fdc09618869dc/xds/internal/balancer/clusterresolver/resource_resolver.go#L60-L68

When the child balancer's state needs to be updated, `clusterresolver` calls `lastUpdate` on DNS and EDS. If there were no changes since the last time `lastUpdate` was called, the child resolver will return the same update object. In case of EDS, the update contains a list of xDS endpoints, while for DNS, since https://github.com/grpc/grpc-go/pull/7858 the update contains a list of `resolver.Endpoint` grouped by locality. 

In case of EDS, when the xDS endpoints are converted to resolver.Endpoints, new Endpoint objects are allocated that don't share any memory with the previous update sent to the child balancer.
https://github.com/grpc/grpc-go/blob/2d4daf3475905868585a914ab39fdc09618869dc/xds/internal/balancer/clusterresolver/configbuilder.go#L189

However, in case of DNS, the endpoint objects are copied by iterating on the original slice returned by DNS. As `Endpoint.Addresses` is a slice field, both the original and the copy share the same slice. This is the cause of the race.
https://github.com/grpc/grpc-go/blob/2d4daf3475905868585a914ab39fdc09618869dc/xds/internal/balancer/clusterresolver/configbuilder.go#L140-L153
If the child tries to access endpoints.Addresses while clusterresolver is creating the endpoints list for the next update, a race occurs.

## Tested
Reproduced the failure on forge, it failed within 1000 runs. Verified the test no longer races in 10000 runs with the fix.

RELEASE NOTES: N/A