### PR TITLE
Cherry pick #7965 #7945 to v1.69.x

### DIFF
--- a/examples/features/csm_observability/server/main.go
+++ b/examples/features/csm_observability/server/main.go
@@ -22,7 +22,6 @@ package main
 import (
 	"context"
 	"flag"
-	"fmt"
 	"log"
 	"net"
 	"net/http"
@@ -30,7 +29,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	xdscreds "google.golang.org/grpc/credentials/xds"
-	pb "google.golang.org/grpc/examples/features/proto/echo"
+	pb "google.golang.org/grpc/examples/helloworld/helloworld"
 	"google.golang.org/grpc/stats/opentelemetry"
 	"google.golang.org/grpc/stats/opentelemetry/csm"
 	"google.golang.org/grpc/xds"
@@ -45,13 +44,15 @@ var (
 	prometheusEndpoint = flag.String("prometheus_endpoint", ":9464", "the Prometheus exporter endpoint")
 )
 
-type echoServer struct {
-	pb.UnimplementedEchoServer
+// server is used to implement helloworld.GreeterServer.
+type server struct {
+	pb.UnimplementedGreeterServer
 	addr string
 }
 
-func (s *echoServer) UnaryEcho(_ context.Context, req *pb.EchoRequest) (*pb.EchoResponse, error) {
-	return &pb.EchoResponse{Message: fmt.Sprintf("%s (from %s)", req.Message, s.addr)}, nil
+// SayHello implements helloworld.GreeterServer
+func (s *server) SayHello(_ context.Context, in *pb.HelloRequest) (*pb.HelloReply, error) {
+	return &pb.HelloReply{Message: "Hello " + in.GetName()}, nil
 }
 
 func main() {
@@ -80,7 +81,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("Failed to start xDS Server: %v", err)
 	}
-	pb.RegisterEchoServer(s, &echoServer{addr: ":" + *port})
+	pb.RegisterGreeterServer(s, &server{addr: ":" + *port})
 
 	log.Printf("Serving on %s\n", *port)
 

--- a/internal/xds/rbac/rbac_engine.go
+++ b/internal/xds/rbac/rbac_engine.go
@@ -219,6 +219,9 @@ func newRPCData(ctx context.Context) (*rpcData, error) {
 	if !ok {
 		return nil, errors.New("missing method in incoming context")
 	}
+	// gRPC-Go strips :path from the headers given to the application, but RBAC should be
+	// able to match against it.
+	md[":path"] = []string{mn}
 
 	// The connection is needed in order to find the destination address and
 	// port of the incoming RPC Call.


### PR DESCRIPTION
Original PRs
- #7965
- #7945

RELEASE NOTES:
- rbac: fix support for :path header matchers, which would previously never successfully match.
- examples/features/csm_observability: update example client and server to use the helloworld service instead of echo service.