### PR TITLE
server: fix buffer release timing in processUnaryRPC

### DIFF
--- a/server.go
+++ b/server.go
@@ -1360,8 +1360,10 @@ func (s *Server) processUnaryRPC(ctx context.Context, stream *transport.ServerSt
 		}
 		return err
 	}
+	dataFree := grpcsync.OnceFunc(d.Free)
+	defer dataFree()
 	df := func(v any) error {
-		defer d.Free()
+		defer dataFree()
 		if err := s.getCodec(stream.ContentSubtype()).Unmarshal(d, v); err != nil {
 			return status.Errorf(codes.Internal, "grpc: error unmarshalling request: %v", err)
 		}

--- a/server.go
+++ b/server.go
@@ -1360,8 +1360,8 @@ func (s *Server) processUnaryRPC(ctx context.Context, stream *transport.ServerSt
 		}
 		return err
 	}
-	defer d.Free()
 	df := func(v any) error {
+		defer d.Free()
 		if err := s.getCodec(stream.ContentSubtype()).Unmarshal(d, v); err != nil {
 			return status.Errorf(codes.Internal, "grpc: error unmarshalling request: %v", err)
 		}

--- a/server.go
+++ b/server.go
@@ -1360,7 +1360,13 @@ func (s *Server) processUnaryRPC(ctx context.Context, stream *transport.ServerSt
 		}
 		return err
 	}
-	dataFree := grpcsync.OnceFunc(d.Free)
+	freed := false
+	dataFree := func() {
+		if !freed {
+			d.Free()
+			freed = true
+		}
+	}
 	defer dataFree()
 	df := func(v any) error {
 		defer dataFree()


### PR DESCRIPTION
Previously, the buffer `d` was held for the entire duration of the handler execution in `processUnaryRPC`, leading to unnecessary memory retention. This PR adjusts the code to release the buffer immediately after the decoding function `df` completes, ensuring memory is freed as soon as it is no longer needed.

As a result, the workaround in #7972 to adjust the buffer size is no longer required, as this fix resolves the underlying issue.

RELEASE NOTES:
* grpc: The buffer used for decoding messages in unary RPCs is released after decoding. Earlier it was held till RPC completion.