### PR TITLE
endpointsharding: Export parsed pickfirst config instead of json string

### DIFF
--- a/balancer/endpointsharding/endpointsharding.go
+++ b/balancer/endpointsharding/endpointsharding.go
@@ -37,16 +37,24 @@ import (
 	"google.golang.org/grpc/balancer/base"
 	"google.golang.org/grpc/balancer/pickfirst/pickfirstleaf"
 	"google.golang.org/grpc/connectivity"
+	"google.golang.org/grpc/grpclog"
 	"google.golang.org/grpc/internal/balancer/gracefulswitch"
 	"google.golang.org/grpc/resolver"
 	"google.golang.org/grpc/serviceconfig"
 )
 
-// PickFirstConfig is a pick first config without shuffling enabled.
-var PickFirstConfig string
+var (
+	// PickFirstConfig is a pick first config without shuffling enabled.
+	PickFirstConfig serviceconfig.LoadBalancingConfig
+	logger          = grpclog.Component("endpoint-sharding")
+)
 
 func init() {
-	PickFirstConfig = fmt.Sprintf("[{%q: {}}]", pickfirstleaf.Name)
+	var err error
+	PickFirstConfig, err = ParseConfig(json.RawMessage(fmt.Sprintf("[{%q: {}}]", pickfirstleaf.Name)))
+	if err != nil {
+		logger.Fatal(err)
+	}
 }
 
 // ChildState is the balancer state of a child along with the endpoint which

--- a/balancer/endpointsharding/endpointsharding_test.go
+++ b/balancer/endpointsharding/endpointsharding_test.go
@@ -16,7 +16,7 @@
  *
  */
 
-package endpointsharding
+package endpointsharding_test
 
 import (
 	"context"
@@ -28,6 +28,7 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/balancer"
+	"google.golang.org/grpc/balancer/endpointsharding"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/grpclog"
 	"google.golang.org/grpc/internal"
@@ -49,16 +50,11 @@ func Test(t *testing.T) {
 	grpctest.RunSubTests(t, s{})
 }
 
-var gracefulSwitchPickFirst serviceconfig.LoadBalancingConfig
+var gracefulSwitchPickFirst = endpointsharding.PickFirstConfig
 
 var logger = grpclog.Component("endpoint-sharding-test")
 
 func init() {
-	var err error
-	gracefulSwitchPickFirst, err = ParseConfig(json.RawMessage(PickFirstConfig))
-	if err != nil {
-		logger.Fatal(err)
-	}
 	balancer.Register(fakePetioleBuilder{})
 }
 
@@ -75,7 +71,7 @@ func (fakePetioleBuilder) Build(cc balancer.ClientConn, opts balancer.BuildOptio
 		ClientConn: cc,
 		bOpts:      opts,
 	}
-	fp.Balancer = NewBalancer(fp, opts)
+	fp.Balancer = endpointsharding.NewBalancer(fp, opts)
 	return fp
 }
 
@@ -105,7 +101,7 @@ func (fp *fakePetiole) UpdateClientConnState(state balancer.ClientConnState) err
 }
 
 func (fp *fakePetiole) UpdateState(state balancer.State) {
-	childStates := ChildStatesFromPicker(state.Picker)
+	childStates := endpointsharding.ChildStatesFromPicker(state.Picker)
 	// Both child states should be present in the child picker. States and
 	// picker change over the lifecycle of test, but there should always be two.
 	if len(childStates) != 2 {

--- a/balancer/weightedroundrobin/balancer.go
+++ b/balancer/weightedroundrobin/balancer.go
@@ -85,15 +85,10 @@ var (
 )
 
 // endpointSharding which specifies pick first children.
-var endpointShardingLBConfig serviceconfig.LoadBalancingConfig
+var endpointShardingLBConfig = endpointsharding.PickFirstConfig
 
 func init() {
 	balancer.Register(bb{})
-	var err error
-	endpointShardingLBConfig, err = endpointsharding.ParseConfig(json.RawMessage(endpointsharding.PickFirstConfig))
-	if err != nil {
-		logger.Fatal(err)
-	}
 }
 
 type bb struct{}

--- a/examples/features/customloadbalancer/client/customroundrobin/customroundrobin.go
+++ b/examples/features/customloadbalancer/client/customroundrobin/customroundrobin.go
@@ -28,19 +28,13 @@ import (
 	"google.golang.org/grpc/balancer"
 	"google.golang.org/grpc/balancer/endpointsharding"
 	"google.golang.org/grpc/connectivity"
-	"google.golang.org/grpc/grpclog"
 	"google.golang.org/grpc/serviceconfig"
 )
 
-var gracefulSwitchPickFirst serviceconfig.LoadBalancingConfig
+var gracefulSwitchPickFirst = endpointsharding.PickFirstConfig
 
 func init() {
 	balancer.Register(customRoundRobinBuilder{})
-	var err error
-	gracefulSwitchPickFirst, err = endpointsharding.ParseConfig(json.RawMessage(endpointsharding.PickFirstConfig))
-	if err != nil {
-		logger.Fatal(err)
-	}
 }
 
 const customRRName = "custom_round_robin"
@@ -78,8 +72,6 @@ func (customRoundRobinBuilder) Build(cc balancer.ClientConn, bOpts balancer.Buil
 	crr.Balancer = endpointsharding.NewBalancer(crr, bOpts)
 	return crr
 }
-
-var logger = grpclog.Component("example")
 
 type customRoundRobin struct {
 	// All state and operations on this balancer are either initialized at build


### PR DESCRIPTION
All the users of `PickFirstConfig` needed to handle parsing errors while using the exported config. This PR exports the parsed config making the usage simpler for users.

RELEASE NOTES:
* balancer/endpointsharding: The parsed pickfirst load balancer config is exported instead of the load balancer config json.