### PR TITLE
expose the WithDefaultScheme DialOption

### DIFF
--- a/clientconn.go
+++ b/clientconn.go
@@ -225,7 +225,7 @@ func Dial(target string, opts ...DialOption) (*ClientConn, error) {
 func DialContext(ctx context.Context, target string, opts ...DialOption) (conn *ClientConn, err error) {
 	// At the end of this method, we kick the channel out of idle, rather than
 	// waiting for the first rpc.
-	opts = append([]DialOption{withDefaultScheme("passthrough")}, opts...)
+	opts = append([]DialOption{WithDefaultScheme("passthrough")}, opts...)
 	cc, err := NewClient(target, opts...)
 	if err != nil {
 		return nil, err

--- a/dialoptions.go
+++ b/dialoptions.go
@@ -689,9 +689,9 @@ func withMinConnectDeadline(f func() time.Duration) DialOption {
 	})
 }
 
-// withDefaultScheme is used to allow Dial to use "passthrough" as the default
+// WithDefaultScheme is used to allow Dial to use "passthrough" as the default
 // name resolver, while NewClient uses "dns" otherwise.
-func withDefaultScheme(s string) DialOption {
+func WithDefaultScheme(s string) DialOption {
 	return newFuncDialOption(func(o *dialOptions) {
 		o.defaultScheme = s
 	})


### PR DESCRIPTION
This exposes the DialOption `WithDefaultScheme` 

Note: I was hoping to expose this so I could set `passthrough` scheme on the client without manipulating URLs or setting it globally. Let me know if you think it makes sense to add an option like `WithDefaultPassthroughScheme()` or something.

I also didn't see a `passthrough` scheme constant in the code base - should we add one?



RELEASE NOTES: `WithDefaultScheme` DialOption allows you to configure the scheme for a client