### PR TITLE
github: Run deps workflow against base branch and add branch name suffixes for easier debuggability

### DIFF
--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -34,7 +34,8 @@ jobs:
           AFTER="$(mktemp -d)"
 
           scripts/gen-deps.sh "${AFTER}"
-          git checkout origin/master
+          # GITHUB_BASE_REF is set when the job is triggered by a PR.
+          git checkout origin/"${GITHUB_BASE_REF:-master}"
           scripts/gen-deps.sh "${BEFORE}"
 
           echo "Comparing dependencies..."

--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -34,23 +34,16 @@ jobs:
           TEMP_DIR="$(mktemp -d)"
           # GITHUB_BASE_REF is set when the job is triggered by a PR.
           TARGET_REF="${GITHUB_BASE_REF:-master}"
-          # GITHUB_HEAD_REF is set when the job is triggered by a PR.
-          SOURCE_REF="${GITHUB_HEAD_REF:-source}"
 
-          # Replace special characters in the branch names.
-          BEFORE_DIR_NAME="$(echo "${SOURCE_REF}" | sed 's/[^a-zA-Z0-9._-]/_/g')"
-          AFTER_DIR_NAME="$(echo "${TARGET_REF}" | sed 's/[^a-zA-Z0-9._-]/_/g')"
-
-
-          mkdir "${TEMP_DIR}/${AFTER_DIR_NAME}"
-          scripts/gen-deps.sh "${TEMP_DIR}/${AFTER_DIR_NAME}"
+          mkdir "${TEMP_DIR}/after"
+          scripts/gen-deps.sh "${TEMP_DIR}/after"
 
           git checkout "origin/${TARGET_REF}"
-          mkdir "${TEMP_DIR}/${BEFORE_DIR_NAME}"
-          scripts/gen-deps.sh "${TEMP_DIR}/${BEFORE_DIR_NAME}"
+          mkdir "${TEMP_DIR}/before"
+          scripts/gen-deps.sh "${TEMP_DIR}/before"
 
           echo "Comparing dependencies..."
           cd "${TEMP_DIR}"
           # Run grep in a sub-shell since bash does not support ! in the middle of a pipe
-          diff -u0 -r "./${BEFORE_DIR_NAME}" "./${AFTER_DIR_NAME}" | bash -c '! grep -v "@@"'
+          diff -u0 -r "./before" "./after" | bash -c '! grep -v "@@"'
           echo "No changes detected."

--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -30,7 +30,7 @@ jobs:
       # Run the commands to generate dependencies before and after and compare.
       - name: Compare dependencies
         run: |
-          set -eux
+          set -eu
           TEMP_DIR="$(mktemp -d)"
           # GITHUB_BASE_REF is set when the job is triggered by a PR.
           TARGET_REF="${GITHUB_BASE_REF:-master}"
@@ -45,5 +45,5 @@ jobs:
           echo "Comparing dependencies..."
           cd "${TEMP_DIR}"
           # Run grep in a sub-shell since bash does not support ! in the middle of a pipe
-          diff -u0 -r "./before" "./after" | bash -c '! grep -v "@@"'
+          diff -u0 -r "before" "after" | bash -c '! grep -v "@@"'
           echo "No changes detected."

--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -30,12 +30,18 @@ jobs:
       # Run the commands to generate dependencies before and after and compare.
       - name: Compare dependencies
         run: |
-          BEFORE="$(mktemp -d)"
-          AFTER="$(mktemp -d)"
+          set -eux
+          BASE_REF="${GITHUB_BASE_REF:-master}"
+          # Suffixes passed to mktemp must not contain "/".
+          BEFORE_SUFFIX="${BASE_REF//\//_}"
+          AFTER_SUFFIX="${GITHUB_HEAD_REF//\//_}"
+
+          BEFORE="$(mktemp -d --suffix="-${BEFORE_SUFFIX}")"
+          AFTER="$(mktemp -d --suffix="-${AFTER_SUFFIX}")"
 
           scripts/gen-deps.sh "${AFTER}"
           # GITHUB_BASE_REF is set when the job is triggered by a PR.
-          git checkout origin/"${GITHUB_BASE_REF:-master}"
+          git checkout origin/"${BASE_REF}"
           scripts/gen-deps.sh "${BEFORE}"
 
           echo "Comparing dependencies..."

--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -31,20 +31,26 @@ jobs:
       - name: Compare dependencies
         run: |
           set -eux
-          BASE_REF="${GITHUB_BASE_REF:-master}"
-          # Suffixes passed to mktemp must not contain "/".
-          BEFORE_SUFFIX="${BASE_REF//\//_}"
-          AFTER_SUFFIX="${GITHUB_HEAD_REF//\//_}"
-
-          BEFORE="$(mktemp -d --suffix="-${BEFORE_SUFFIX}")"
-          AFTER="$(mktemp -d --suffix="-${AFTER_SUFFIX}")"
-
-          scripts/gen-deps.sh "${AFTER}"
+          TEMP_DIR="$(mktemp -d)"
           # GITHUB_BASE_REF is set when the job is triggered by a PR.
-          git checkout origin/"${BASE_REF}"
-          scripts/gen-deps.sh "${BEFORE}"
+          TARGET_REF="${GITHUB_BASE_REF:-master}"
+          # GITHUB_HEAD_REF is set when the job is triggered by a PR.
+          SOURCE_REF="${GITHUB_HEAD_REF:-source}"
+
+          # Replace special characters in the branch names.
+          BEFORE_DIR_NAME="$(echo "${SOURCE_REF}" | sed 's/[^a-zA-Z0-9._-]/_/g')"
+          AFTER_DIR_NAME="$(echo "${TARGET_REF}" | sed 's/[^a-zA-Z0-9._-]/_/g')"
+
+
+          mkdir "${TEMP_DIR}/${AFTER_DIR_NAME}"
+          scripts/gen-deps.sh "${TEMP_DIR}/${AFTER_DIR_NAME}"
+
+          git checkout "origin/${TARGET_REF}"
+          mkdir "${TEMP_DIR}/${BEFORE_DIR_NAME}"
+          scripts/gen-deps.sh "${TEMP_DIR}/${BEFORE_DIR_NAME}"
 
           echo "Comparing dependencies..."
+          cd "${TEMP_DIR}"
           # Run grep in a sub-shell since bash does not support ! in the middle of a pipe
-          diff -u0 -r "${BEFORE}" "${AFTER}" | bash -c '! grep -v "@@"'
+          diff -u0 -r "./${BEFORE_DIR_NAME}" "./${AFTER_DIR_NAME}" | bash -c '! grep -v "@@"'
           echo "No changes detected."


### PR DESCRIPTION
Running the test against the base branch (instead of master) ensures the tests don't fail unnecessarily for PRs raised against release branches. 

Env vars available in Github actions: [docs](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#default-environment-variables)

RELEASE NOTES: N/A