### PR TITLE
xdsclient: release lock before attempting to close underlying transport

### DIFF
--- a/xds/internal/xdsclient/client_refcounted.go
+++ b/xds/internal/xdsclient/client_refcounted.go
@@ -54,7 +54,8 @@ func clientRefCountedClose(name string) {
 	clientsMu.Unlock()
 
 	// This attempts to close the transport to the management server and could
-	// take a while to complete. So, call it without holding the lock.
+	// theoretically call back into the xdsclient package again and deadlock.
+	// Hence, this needs to be called without holding the lock.
 	client.clientImpl.close()
 	xdsClientImplCloseHook(name)
 


### PR DESCRIPTION
This PR fixes a rare deadlock where multiple channels are created and closed to the same target URI (with an xds scheme) at the same time. This deadlock leads to xDS client creation being stalled and therefore everything on the gRPC channel is stalled.

RELEASE NOTES:
- TBD