### PR TITLE
xds: Implement system root certs support

### DIFF
--- a/internal/envconfig/xds.go
+++ b/internal/envconfig/xds.go
@@ -59,4 +59,9 @@ var (
 	// TODO: https://github.com/grpc/grpc-go/issues/7866 - Control this using
 	// an env variable when all LB policies handle endpoints.
 	XDSDualstackEndpointsEnabled = false
+
+	// XDSSystemRootCertsEnabled when xDs clients can use use the system's
+	// default root certificates for TLS certificate validation. Form more
+	// details, see gRFC A82.
+	XDSSystemRootCertsEnabled = boolFromEnv("GRPC_EXPERIMENTAL_XDS_SYSTEM_ROOT_CERTS", false)
 )

--- a/internal/envconfig/xds.go
+++ b/internal/envconfig/xds.go
@@ -60,8 +60,9 @@ var (
 	// an env variable when all LB policies handle endpoints.
 	XDSDualstackEndpointsEnabled = false
 
-	// XDSSystemRootCertsEnabled when xDs clients can use use the system's
-	// default root certificates for TLS certificate validation. Form more
-	// details, see gRFC A82.
+	// XDSSystemRootCertsEnabled is true when xDS enabled gRPC clients can use
+	// the system's default root certificates for TLS certificate validation.
+	// For more details, see:
+	// https://github.com/grpc/proposal/blob/master/A82-xds-system-root-certs.md.
 	XDSSystemRootCertsEnabled = boolFromEnv("GRPC_EXPERIMENTAL_XDS_SYSTEM_ROOT_CERTS", false)
 )

--- a/internal/testutils/xds/e2e/clientresources.go
+++ b/internal/testutils/xds/e2e/clientresources.go
@@ -67,11 +67,11 @@ const (
 	// mTLS is required. Both client and server present identity certificates in
 	// this configuration.
 	SecurityLevelMTLS
-	// SecurityLevelMTLSWithSystemRootCerts is used when security configuration
-	// corresponding to mTLS is required and the client needs to use system root
-	// certs to validate the server certificate. Both client and server present
-	// identity certificates in this configuration.
-	SecurityLevelMTLSWithSystemRootCerts
+	// SecurityLevelTLSWithSystemRootCerts is used when security configuration
+	// corresponding to TLS is required. Only the server presents an identity
+	// certificate in this configuration and the client uses system root certs
+	// to validate the server certificate.
+	SecurityLevelTLSWithSystemRootCerts
 )
 
 // ResourceParams wraps the arguments to be passed to DefaultClientResources.
@@ -598,16 +598,13 @@ func ClusterResourceWithOptions(opts ClusterOptions) *v3clusterpb.Cluster {
 				},
 			},
 		}
-	case SecurityLevelMTLSWithSystemRootCerts:
+	case SecurityLevelTLSWithSystemRootCerts:
 		tlsContext = &v3tlspb.UpstreamTlsContext{
 			CommonTlsContext: &v3tlspb.CommonTlsContext{
 				ValidationContextType: &v3tlspb.CommonTlsContext_ValidationContext{
 					ValidationContext: &v3tlspb.CertificateValidationContext{
 						SystemRootCerts: &v3tlspb.CertificateValidationContext_SystemRootCerts{},
 					},
-				},
-				TlsCertificateCertificateProviderInstance: &v3tlspb.CommonTlsContext_CertificateProviderInstance{
-					InstanceName: ClientSideCertProviderInstance,
 				},
 			},
 		}

--- a/internal/testutils/xds/e2e/clientresources.go
+++ b/internal/testutils/xds/e2e/clientresources.go
@@ -67,6 +67,11 @@ const (
 	// mTLS is required. Both client and server present identity certificates in
 	// this configuration.
 	SecurityLevelMTLS
+	// SecurityLevelMTLSWithSystemRootCerts is used when security configuration
+	// corresponding to mTLS is required and the client needs to use system root
+	// certs to validate the server certificate. Both client and server present
+	// identity certificates in this configuration.
+	SecurityLevelMTLSWithSystemRootCerts
 )
 
 // ResourceParams wraps the arguments to be passed to DefaultClientResources.
@@ -586,6 +591,19 @@ func ClusterResourceWithOptions(opts ClusterOptions) *v3clusterpb.Cluster {
 				ValidationContextType: &v3tlspb.CommonTlsContext_ValidationContextCertificateProviderInstance{
 					ValidationContextCertificateProviderInstance: &v3tlspb.CommonTlsContext_CertificateProviderInstance{
 						InstanceName: ClientSideCertProviderInstance,
+					},
+				},
+				TlsCertificateCertificateProviderInstance: &v3tlspb.CommonTlsContext_CertificateProviderInstance{
+					InstanceName: ClientSideCertProviderInstance,
+				},
+			},
+		}
+	case SecurityLevelMTLSWithSystemRootCerts:
+		tlsContext = &v3tlspb.UpstreamTlsContext{
+			CommonTlsContext: &v3tlspb.CommonTlsContext{
+				ValidationContextType: &v3tlspb.CommonTlsContext_ValidationContext{
+					ValidationContext: &v3tlspb.CertificateValidationContext{
+						SystemRootCerts: &v3tlspb.CertificateValidationContext_SystemRootCerts{},
 					},
 				},
 				TlsCertificateCertificateProviderInstance: &v3tlspb.CommonTlsContext_CertificateProviderInstance{

--- a/xds/internal/balancer/cdsbalancer/cdsbalancer.go
+++ b/xds/internal/balancer/cdsbalancer/cdsbalancer.go
@@ -687,7 +687,7 @@ type systemRootCertsProvider struct{}
 
 func (systemRootCertsProvider) Close() {}
 
-func (systemRootCertsProvider) KeyMaterial(_ context.Context) (*certprovider.KeyMaterial, error) {
+func (systemRootCertsProvider) KeyMaterial(context.Context) (*certprovider.KeyMaterial, error) {
 	rootCAs, err := x509SystemCertPoolFunc()
 	if err != nil {
 		return nil, err

--- a/xds/internal/balancer/cdsbalancer/cdsbalancer.go
+++ b/xds/internal/balancer/cdsbalancer/cdsbalancer.go
@@ -65,8 +65,9 @@ var (
 	}
 	buildProvider = buildProviderFunc
 
-	// systemRootCertsFunc is used for mocking the system cert pool for tests.
-	systemRootCertsFunc = x509.SystemCertPool
+	// x509SystemCertPoolFunc is used for mocking the system cert pool for
+	// tests.
+	x509SystemCertPoolFunc = x509.SystemCertPool
 )
 
 func init() {
@@ -680,12 +681,14 @@ func (ccw *ccWrapper) UpdateAddresses(sc balancer.SubConn, addrs []resolver.Addr
 	ccw.ClientConn.UpdateAddresses(sc, newAddrs)
 }
 
+// systemRootCertsProvider implements a certprovider.Provider that returns the
+// system default root certificates for validation.
 type systemRootCertsProvider struct{}
 
 func (systemRootCertsProvider) Close() {}
 
 func (systemRootCertsProvider) KeyMaterial(_ context.Context) (*certprovider.KeyMaterial, error) {
-	rootCAs, err := systemRootCertsFunc()
+	rootCAs, err := x509SystemCertPoolFunc()
 	if err != nil {
 		return nil, err
 	}

--- a/xds/internal/balancer/cdsbalancer/cdsbalancer.go
+++ b/xds/internal/balancer/cdsbalancer/cdsbalancer.go
@@ -19,6 +19,7 @@ package cdsbalancer
 
 import (
 	"context"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"sync/atomic"
@@ -63,6 +64,9 @@ var (
 		return builder.Build(cc, opts), nil
 	}
 	buildProvider = buildProviderFunc
+
+	// systemRootCertsFunc is used for mocking the system cert pool for tests.
+	systemRootCertsFunc = x509.SystemCertPool
 )
 
 func init() {
@@ -208,9 +212,15 @@ func (b *cdsBalancer) handleSecurityConfig(config *xdsresource.SecurityConfig) e
 
 	// A root provider is required whether we are using TLS or mTLS.
 	cpc := b.xdsClient.BootstrapConfig().CertProviderConfigs()
-	rootProvider, err := buildProvider(cpc, config.RootInstanceName, config.RootCertName, false, true)
-	if err != nil {
-		return err
+	var rootProvider certprovider.Provider
+	if config.UseSystemRootCerts {
+		rootProvider = systemRootCertsProvider{}
+	} else {
+		rp, err := buildProvider(cpc, config.RootInstanceName, config.RootCertName, false, true)
+		if err != nil {
+			return err
+		}
+		rootProvider = rp
 	}
 
 	// The identity provider is only present when using mTLS.
@@ -668,4 +678,18 @@ func (ccw *ccWrapper) UpdateAddresses(sc balancer.SubConn, addrs []resolver.Addr
 		newAddrs[i] = xdsinternal.SetHandshakeInfo(addr, ccw.xdsHIPtr)
 	}
 	ccw.ClientConn.UpdateAddresses(sc, newAddrs)
+}
+
+type systemRootCertsProvider struct{}
+
+func (systemRootCertsProvider) Close() {}
+
+func (systemRootCertsProvider) KeyMaterial(_ context.Context) (*certprovider.KeyMaterial, error) {
+	rootCAs, err := systemRootCertsFunc()
+	if err != nil {
+		return nil, err
+	}
+	return &certprovider.KeyMaterial{
+		Roots: rootCAs,
+	}, nil
 }

--- a/xds/internal/balancer/cdsbalancer/cdsbalancer_security_test.go
+++ b/xds/internal/balancer/cdsbalancer/cdsbalancer_security_test.go
@@ -40,6 +40,7 @@ import (
 	"google.golang.org/grpc/internal"
 	"google.golang.org/grpc/internal/balancer/stub"
 	xdscredsinternal "google.golang.org/grpc/internal/credentials/xds"
+	"google.golang.org/grpc/internal/envconfig"
 	"google.golang.org/grpc/internal/stubserver"
 	"google.golang.org/grpc/internal/testutils"
 	"google.golang.org/grpc/internal/testutils/xds/e2e"
@@ -747,4 +748,70 @@ func (s) TestSecurityConfigUpdate_GoodToBad(t *testing.T) {
 		t.Fatalf("EmptyCall() failed: %v", err)
 	}
 	verifySecurityInformationFromPeer(t, peer, e2e.SecurityLevelMTLS)
+}
+
+// Tests the case where the cds LB policy receives security configuration as
+// part of the Cluster resource that specifies the use system root certs.
+// Verifies that the connection between the client and the server is secure.
+func (s) TestSystemRootCertsSecurityConfig(t *testing.T) {
+	origFlag := envconfig.XDSSystemRootCertsEnabled
+	origSRCF := systemRootCertsFunc
+	defer func() {
+		envconfig.XDSSystemRootCertsEnabled = origFlag
+		systemRootCertsFunc = origSRCF
+	}()
+	envconfig.XDSSystemRootCertsEnabled = true
+	systemRootCertsFunc = origSRCF
+
+	systemRootCertsFuncCalled := false
+	systemRootCertsFunc = func() (*x509.CertPool, error) {
+		certData, err := os.ReadFile(testdata.Path("x509/server_ca_cert.pem"))
+		if err != nil {
+			return nil, fmt.Errorf("failed to read certificate file: %w", err)
+		}
+		certPool := x509.NewCertPool()
+
+		if ok := certPool.AppendCertsFromPEM(certData); !ok {
+			return nil, fmt.Errorf("failed to append certificate to cert pool")
+		}
+		systemRootCertsFuncCalled = true
+		return certPool, nil
+	}
+	// Spin up an xDS management server.
+	mgmtServer := e2e.StartManagementServer(t, e2e.ManagementServerOptions{})
+
+	// Create bootstrap configuration pointing to the above management server
+	// and one that includes certificate providers configuration.
+	nodeID := uuid.New().String()
+	bc := e2e.DefaultBootstrapContents(t, nodeID, mgmtServer.Address)
+
+	// Create a grpc channel with xDS creds talking to a test server with TLS
+	// credentials.
+	cc, serverAddress := setupForSecurityTests(t, bc, xdsClientCredsWithInsecureFallback(t), tlsServerCreds(t))
+
+	// Configure cluster and endpoints resources in the management server. The
+	// cluster resource is configured to return security configuration.
+	resources := e2e.UpdateOptions{
+		NodeID:         nodeID,
+		Clusters:       []*v3clusterpb.Cluster{e2e.DefaultCluster(clusterName, serviceName, e2e.SecurityLevelMTLSWithSystemRootCerts)},
+		Endpoints:      []*v3endpointpb.ClusterLoadAssignment{e2e.DefaultEndpoint(serviceName, "localhost", []uint32{testutils.ParsePort(t, serverAddress)})},
+		SkipValidation: true,
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	if err := mgmtServer.Update(ctx, resources); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify that a successful RPC can be made over a secure connection.
+	client := testgrpc.NewTestServiceClient(cc)
+	peer := &peer.Peer{}
+	if _, err := client.EmptyCall(ctx, &testpb.Empty{}, grpc.WaitForReady(true), grpc.Peer(peer)); err != nil {
+		t.Fatalf("EmptyCall() failed: %v", err)
+	}
+	verifySecurityInformationFromPeer(t, peer, e2e.SecurityLevelMTLS)
+
+	if systemRootCertsFuncCalled != true {
+		t.Errorf("systemRootCertsFuncCalled = %t, want = true", systemRootCertsFuncCalled)
+	}
 }

--- a/xds/internal/xdsclient/xdsresource/filter_chain_test.go
+++ b/xds/internal/xdsclient/xdsresource/filter_chain_test.go
@@ -545,7 +545,7 @@ func (s) TestNewFilterChainImpl_Failure_BadSecurityConfig(t *testing.T) {
 					},
 				},
 			},
-			wantErr: "expected field ca_certificate_provider_instance is missing and unexpected field ca_certificate_provider_instance is set",
+			wantErr: "expected field ca_certificate_provider_instance is missing and unexpected field system_root_certs is set",
 		},
 		{
 			desc: "system root certificate field set on server, env var disabled",

--- a/xds/internal/xdsclient/xdsresource/filter_chain_test.go
+++ b/xds/internal/xdsclient/xdsresource/filter_chain_test.go
@@ -38,6 +38,7 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
+	"google.golang.org/grpc/internal/envconfig"
 	iresolver "google.golang.org/grpc/internal/resolver"
 	"google.golang.org/grpc/internal/testutils"
 	"google.golang.org/grpc/internal/testutils/xds/e2e"
@@ -307,9 +308,10 @@ func (s) TestNewFilterChainImpl_Failure_OverlappingMatchingRules(t *testing.T) {
 // security configuration in the filter chain is invalid.
 func (s) TestNewFilterChainImpl_Failure_BadSecurityConfig(t *testing.T) {
 	tests := []struct {
-		desc    string
-		lis     *v3listenerpb.Listener
-		wantErr string
+		desc                      string
+		lis                       *v3listenerpb.Listener
+		wantErr                   string
+		enableSystemRootCertsFlag bool
 	}{
 		{
 			desc:    "no filter chains",
@@ -514,10 +516,76 @@ func (s) TestNewFilterChainImpl_Failure_BadSecurityConfig(t *testing.T) {
 			},
 			wantErr: "security configuration on the server-side does not contain identity certificate provider instance name",
 		},
+		{
+			desc:                      "system root certificate field set on server",
+			enableSystemRootCertsFlag: true,
+			lis: &v3listenerpb.Listener{
+				FilterChains: []*v3listenerpb.FilterChain{
+					{
+						TransportSocket: &v3corepb.TransportSocket{
+							Name: "envoy.transport_sockets.tls",
+							ConfigType: &v3corepb.TransportSocket_TypedConfig{
+								TypedConfig: testutils.MarshalAny(t, &v3tlspb.DownstreamTlsContext{
+									RequireClientCertificate: &wrapperspb.BoolValue{Value: true},
+									CommonTlsContext: &v3tlspb.CommonTlsContext{
+										TlsCertificateCertificateProviderInstance: &v3tlspb.CommonTlsContext_CertificateProviderInstance{
+											InstanceName:    "identityPluginInstance",
+											CertificateName: "identityCertName",
+										},
+										ValidationContextType: &v3tlspb.CommonTlsContext_ValidationContext{
+											ValidationContext: &v3tlspb.CertificateValidationContext{
+												SystemRootCerts: &v3tlspb.CertificateValidationContext_SystemRootCerts{},
+											},
+										},
+									},
+								}),
+							},
+						},
+						Filters: emptyValidNetworkFilters(t),
+					},
+				},
+			},
+			wantErr: "expected field ca_certificate_provider_instance is missing and unexpected field ca_certificate_provider_instance is set",
+		},
+		{
+			desc: "system root certificate field set on server, env var disabled",
+			lis: &v3listenerpb.Listener{
+				FilterChains: []*v3listenerpb.FilterChain{
+					{
+						TransportSocket: &v3corepb.TransportSocket{
+							Name: "envoy.transport_sockets.tls",
+							ConfigType: &v3corepb.TransportSocket_TypedConfig{
+								TypedConfig: testutils.MarshalAny(t, &v3tlspb.DownstreamTlsContext{
+									RequireClientCertificate: &wrapperspb.BoolValue{Value: true},
+									CommonTlsContext: &v3tlspb.CommonTlsContext{
+										TlsCertificateCertificateProviderInstance: &v3tlspb.CommonTlsContext_CertificateProviderInstance{
+											InstanceName:    "identityPluginInstance",
+											CertificateName: "identityCertName",
+										},
+										ValidationContextType: &v3tlspb.CommonTlsContext_ValidationContext{
+											ValidationContext: &v3tlspb.CertificateValidationContext{
+												SystemRootCerts: &v3tlspb.CertificateValidationContext_SystemRootCerts{},
+											},
+										},
+									},
+								}),
+							},
+						},
+						Filters: emptyValidNetworkFilters(t),
+					},
+				},
+			},
+			wantErr: "expected field ca_certificate_provider_instance is missing",
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
+			origFlag := envconfig.XDSSystemRootCertsEnabled
+			defer func() {
+				envconfig.XDSSystemRootCertsEnabled = origFlag
+			}()
+			envconfig.XDSSystemRootCertsEnabled = test.enableSystemRootCertsFlag
 			_, err := NewFilterChainManager(test.lis)
 			if err == nil || !strings.Contains(err.Error(), test.wantErr) {
 				t.Fatalf("NewFilterChainManager() returned err: %v, wantErr: %s", err, test.wantErr)
@@ -1290,9 +1358,10 @@ func (s) TestNewFilterChainImpl_Success_HTTPFilters(t *testing.T) {
 // security configuration in the filter chain contains valid data.
 func (s) TestNewFilterChainImpl_Success_SecurityConfig(t *testing.T) {
 	tests := []struct {
-		desc   string
-		lis    *v3listenerpb.Listener
-		wantFC *FilterChainManager
+		desc                      string
+		lis                       *v3listenerpb.Listener
+		wantFC                    *FilterChainManager
+		enableSystemRootCertsFlag bool
 	}{
 		{
 			desc: "empty transport socket",
@@ -1495,10 +1564,122 @@ func (s) TestNewFilterChainImpl_Success_SecurityConfig(t *testing.T) {
 				},
 			},
 		},
+		{
+			desc:                      "validation context with certificate provider and system root certs",
+			enableSystemRootCertsFlag: true,
+			lis: &v3listenerpb.Listener{
+				FilterChains: []*v3listenerpb.FilterChain{
+					{
+						TransportSocket: &v3corepb.TransportSocket{
+							Name: "envoy.transport_sockets.tls",
+							ConfigType: &v3corepb.TransportSocket_TypedConfig{
+								TypedConfig: testutils.MarshalAny(t, &v3tlspb.DownstreamTlsContext{
+									RequireClientCertificate: &wrapperspb.BoolValue{Value: true},
+									CommonTlsContext: &v3tlspb.CommonTlsContext{
+										TlsCertificateProviderInstance: &v3tlspb.CertificateProviderPluginInstance{
+											InstanceName:    "identityPluginInstance",
+											CertificateName: "identityCertName",
+										},
+										ValidationContextType: &v3tlspb.CommonTlsContext_ValidationContext{
+											ValidationContext: &v3tlspb.CertificateValidationContext{
+												CaCertificateProviderInstance: &v3tlspb.CertificateProviderPluginInstance{
+													InstanceName:    "rootPluginInstance",
+													CertificateName: "rootCertName",
+												},
+												// SystemRootCerts will be ignored
+												// when
+												// CaCertificateProviderInstance is
+												// set.
+												SystemRootCerts: &v3tlspb.CertificateValidationContext_SystemRootCerts{},
+											},
+										},
+									},
+								}),
+							},
+						},
+						Filters: emptyValidNetworkFilters(t),
+					},
+				},
+				DefaultFilterChain: &v3listenerpb.FilterChain{
+					Name: "default-filter-chain-1",
+					TransportSocket: &v3corepb.TransportSocket{
+						Name: "envoy.transport_sockets.tls",
+						ConfigType: &v3corepb.TransportSocket_TypedConfig{
+							TypedConfig: testutils.MarshalAny(t, &v3tlspb.DownstreamTlsContext{
+								RequireClientCertificate: &wrapperspb.BoolValue{Value: true},
+								CommonTlsContext: &v3tlspb.CommonTlsContext{
+									TlsCertificateProviderInstance: &v3tlspb.CertificateProviderPluginInstance{
+										InstanceName:    "defaultIdentityPluginInstance",
+										CertificateName: "defaultIdentityCertName",
+									},
+									ValidationContextType: &v3tlspb.CommonTlsContext_ValidationContext{
+										ValidationContext: &v3tlspb.CertificateValidationContext{
+											CaCertificateProviderInstance: &v3tlspb.CertificateProviderPluginInstance{
+												InstanceName:    "defaultRootPluginInstance",
+												CertificateName: "defaultRootCertName",
+											},
+											// SystemRootCerts will be ignored
+											// when
+											// CaCertificateProviderInstance is
+											// set.
+											SystemRootCerts: &v3tlspb.CertificateValidationContext_SystemRootCerts{},
+										},
+									},
+								},
+							}),
+						},
+					},
+					Filters: emptyValidNetworkFilters(t),
+				},
+			},
+			wantFC: &FilterChainManager{
+				dstPrefixMap: map[string]*destPrefixEntry{
+					unspecifiedPrefixMapKey: {
+						srcTypeArr: [3]*sourcePrefixes{
+							{
+								srcPrefixMap: map[string]*sourcePrefixEntry{
+									unspecifiedPrefixMapKey: {
+										srcPortMap: map[int]*FilterChain{
+											0: {
+												SecurityCfg: &SecurityConfig{
+													RootInstanceName:     "rootPluginInstance",
+													RootCertName:         "rootCertName",
+													IdentityInstanceName: "identityPluginInstance",
+													IdentityCertName:     "identityCertName",
+													RequireClientCert:    true,
+												},
+												InlineRouteConfig: inlineRouteConfig,
+												HTTPFilters:       makeRouterFilterList(t),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				def: &FilterChain{
+					SecurityCfg: &SecurityConfig{
+						RootInstanceName:     "defaultRootPluginInstance",
+						RootCertName:         "defaultRootCertName",
+						IdentityInstanceName: "defaultIdentityPluginInstance",
+						IdentityCertName:     "defaultIdentityCertName",
+						RequireClientCert:    true,
+					},
+					InlineRouteConfig: inlineRouteConfig,
+					HTTPFilters:       makeRouterFilterList(t),
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
+			origFlag := envconfig.XDSSystemRootCertsEnabled
+			defer func() {
+				envconfig.XDSSystemRootCertsEnabled = origFlag
+			}()
+			envconfig.XDSSystemRootCertsEnabled = test.enableSystemRootCertsFlag
 			gotFC, err := NewFilterChainManager(test.lis)
 			if err != nil {
 				t.Fatalf("NewFilterChainManager() returned err: %v, wantErr: nil", err)

--- a/xds/internal/xdsclient/xdsresource/type_cds.go
+++ b/xds/internal/xdsclient/xdsresource/type_cds.go
@@ -121,3 +121,37 @@ type SecurityConfig struct {
 	// when both RootCertName and RootInstanceName are empty.
 	UseSystemRootCerts bool
 }
+
+// Equal returns true if sc is equal to other.
+func (sc *SecurityConfig) Equal(other *SecurityConfig) bool {
+	switch {
+	case sc == nil && other == nil:
+		return true
+	case (sc != nil) != (other != nil):
+		return false
+	}
+	switch {
+	case sc.RootInstanceName != other.RootInstanceName:
+		return false
+	case sc.RootCertName != other.RootCertName:
+		return false
+	case sc.IdentityInstanceName != other.IdentityInstanceName:
+		return false
+	case sc.IdentityCertName != other.IdentityCertName:
+		return false
+	case sc.RequireClientCert != other.RequireClientCert:
+		return false
+	case sc.UseSystemRootCerts != other.UseSystemRootCerts:
+		return false
+	default:
+		if len(sc.SubjectAltNameMatchers) != len(other.SubjectAltNameMatchers) {
+			return false
+		}
+		for i := 0; i < len(sc.SubjectAltNameMatchers); i++ {
+			if !sc.SubjectAltNameMatchers[i].Equal(other.SubjectAltNameMatchers[i]) {
+				return false
+			}
+		}
+	}
+	return true
+}

--- a/xds/internal/xdsclient/xdsresource/type_cds.go
+++ b/xds/internal/xdsclient/xdsresource/type_cds.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 
 	"google.golang.org/grpc/internal/xds/bootstrap"
+	"google.golang.org/grpc/internal/xds/matcher"
 	"google.golang.org/protobuf/types/known/anypb"
 )
 
@@ -78,4 +79,45 @@ type ClusterUpdate struct {
 	// "com.google.csm.telemetry_labels" with keys "service_name" or
 	// "service_namespace".
 	TelemetryLabels map[string]string
+}
+
+// SecurityConfig contains the security configuration received as part of the
+// Cluster resource on the client-side, and as part of the Listener resource on
+// the server-side.
+type SecurityConfig struct {
+	// RootInstanceName identifies the certProvider plugin to be used to fetch
+	// root certificates. This instance name will be resolved to the plugin name
+	// and its associated configuration from the certificate_providers field of
+	// the bootstrap file.
+	RootInstanceName string
+	// RootCertName is the certificate name to be passed to the plugin (looked
+	// up from the bootstrap file) while fetching root certificates.
+	RootCertName string
+	// IdentityInstanceName identifies the certProvider plugin to be used to
+	// fetch identity certificates. This instance name will be resolved to the
+	// plugin name and its associated configuration from the
+	// certificate_providers field of the bootstrap file.
+	IdentityInstanceName string
+	// IdentityCertName is the certificate name to be passed to the plugin
+	// (looked up from the bootstrap file) while fetching identity certificates.
+	IdentityCertName string
+	// SubjectAltNameMatchers is an optional list of match criteria for SANs
+	// specified on the peer certificate. Used only on the client-side.
+	//
+	// Some intricacies:
+	// - If this field is empty, then any peer certificate is accepted.
+	// - If the peer certificate contains a wildcard DNS SAN, and an `exact`
+	//   matcher is configured, a wildcard DNS match is performed instead of a
+	//   regular string comparison.
+	SubjectAltNameMatchers []matcher.StringMatcher
+	// RequireClientCert indicates if the server handshake process expects the
+	// client to present a certificate. Set to true when performing mTLS. Used
+	// only on the server-side.
+	RequireClientCert bool
+	// UseSystemRootCerts indicates that the client should use system root
+	// certificates to validate the server certificate. This field is mutually
+	// exclusive with RootCertName and RootInstanceName. Validation performed
+	// after unmarshalling xDS resources ensures that this field is set only
+	// when both RootCertName and RootInstanceName are empty.
+	UseSystemRootCerts bool
 }

--- a/xds/internal/xdsclient/xdsresource/type_rds.go
+++ b/xds/internal/xdsclient/xdsresource/type_rds.go
@@ -213,6 +213,9 @@ type SecurityConfig struct {
 	// client to present a certificate. Set to true when performing mTLS. Used
 	// only on the server-side.
 	RequireClientCert bool
+	// UseSystemRootCerts indicates the use of system root certificates by the
+	// client to validate the server certificate.
+	UseSystemRootCerts bool
 }
 
 // Equal returns true if sc is equal to other.
@@ -233,6 +236,8 @@ func (sc *SecurityConfig) Equal(other *SecurityConfig) bool {
 	case sc.IdentityCertName != other.IdentityCertName:
 		return false
 	case sc.RequireClientCert != other.RequireClientCert:
+		return false
+	case sc.UseSystemRootCerts != other.UseSystemRootCerts:
 		return false
 	default:
 		if len(sc.SubjectAltNameMatchers) != len(other.SubjectAltNameMatchers) {

--- a/xds/internal/xdsclient/xdsresource/type_rds.go
+++ b/xds/internal/xdsclient/xdsresource/type_rds.go
@@ -213,8 +213,11 @@ type SecurityConfig struct {
 	// client to present a certificate. Set to true when performing mTLS. Used
 	// only on the server-side.
 	RequireClientCert bool
-	// UseSystemRootCerts indicates the use of system root certificates by the
-	// client to validate the server certificate.
+	// UseSystemRootCerts indicates that the client should use system root
+	// certificates to validate the server certificate. This field is mutually
+	// exclusive with RootCertName and RootInstanceName. Validation performed
+	// after unmarshalling xDS resources ensures that this field is set only
+	// when both RootCertName and RootInstanceName are empty.
 	UseSystemRootCerts bool
 }
 

--- a/xds/internal/xdsclient/xdsresource/type_rds.go
+++ b/xds/internal/xdsclient/xdsresource/type_rds.go
@@ -179,37 +179,3 @@ type Int64Range struct {
 	Start int64
 	End   int64
 }
-
-// Equal returns true if sc is equal to other.
-func (sc *SecurityConfig) Equal(other *SecurityConfig) bool {
-	switch {
-	case sc == nil && other == nil:
-		return true
-	case (sc != nil) != (other != nil):
-		return false
-	}
-	switch {
-	case sc.RootInstanceName != other.RootInstanceName:
-		return false
-	case sc.RootCertName != other.RootCertName:
-		return false
-	case sc.IdentityInstanceName != other.IdentityInstanceName:
-		return false
-	case sc.IdentityCertName != other.IdentityCertName:
-		return false
-	case sc.RequireClientCert != other.RequireClientCert:
-		return false
-	case sc.UseSystemRootCerts != other.UseSystemRootCerts:
-		return false
-	default:
-		if len(sc.SubjectAltNameMatchers) != len(other.SubjectAltNameMatchers) {
-			return false
-		}
-		for i := 0; i < len(sc.SubjectAltNameMatchers); i++ {
-			if !sc.SubjectAltNameMatchers[i].Equal(other.SubjectAltNameMatchers[i]) {
-				return false
-			}
-		}
-	}
-	return true
-}

--- a/xds/internal/xdsclient/xdsresource/type_rds.go
+++ b/xds/internal/xdsclient/xdsresource/type_rds.go
@@ -180,47 +180,6 @@ type Int64Range struct {
 	End   int64
 }
 
-// SecurityConfig contains the security configuration received as part of the
-// Cluster resource on the client-side, and as part of the Listener resource on
-// the server-side.
-type SecurityConfig struct {
-	// RootInstanceName identifies the certProvider plugin to be used to fetch
-	// root certificates. This instance name will be resolved to the plugin name
-	// and its associated configuration from the certificate_providers field of
-	// the bootstrap file.
-	RootInstanceName string
-	// RootCertName is the certificate name to be passed to the plugin (looked
-	// up from the bootstrap file) while fetching root certificates.
-	RootCertName string
-	// IdentityInstanceName identifies the certProvider plugin to be used to
-	// fetch identity certificates. This instance name will be resolved to the
-	// plugin name and its associated configuration from the
-	// certificate_providers field of the bootstrap file.
-	IdentityInstanceName string
-	// IdentityCertName is the certificate name to be passed to the plugin
-	// (looked up from the bootstrap file) while fetching identity certificates.
-	IdentityCertName string
-	// SubjectAltNameMatchers is an optional list of match criteria for SANs
-	// specified on the peer certificate. Used only on the client-side.
-	//
-	// Some intricacies:
-	// - If this field is empty, then any peer certificate is accepted.
-	// - If the peer certificate contains a wildcard DNS SAN, and an `exact`
-	//   matcher is configured, a wildcard DNS match is performed instead of a
-	//   regular string comparison.
-	SubjectAltNameMatchers []matcher.StringMatcher
-	// RequireClientCert indicates if the server handshake process expects the
-	// client to present a certificate. Set to true when performing mTLS. Used
-	// only on the server-side.
-	RequireClientCert bool
-	// UseSystemRootCerts indicates that the client should use system root
-	// certificates to validate the server certificate. This field is mutually
-	// exclusive with RootCertName and RootInstanceName. Validation performed
-	// after unmarshalling xDS resources ensures that this field is set only
-	// when both RootCertName and RootInstanceName are empty.
-	UseSystemRootCerts bool
-}
-
 // Equal returns true if sc is equal to other.
 func (sc *SecurityConfig) Equal(other *SecurityConfig) bool {
 	switch {

--- a/xds/internal/xdsclient/xdsresource/unmarshal_cds.go
+++ b/xds/internal/xdsclient/xdsresource/unmarshal_cds.go
@@ -322,12 +322,13 @@ func securityConfigFromCommonTLSContext(common *v3tlspb.CommonTlsContext, server
 	// For now, if we can't get a valid security config from the new fields, we
 	// fallback to the old deprecated fields.
 	// TODO: Drop support for deprecated fields. NACK if err != nil here.
-	sc, _ := securityConfigFromCommonTLSContextUsingNewFields(common, server)
+	sc, err1 := securityConfigFromCommonTLSContextUsingNewFields(common, server)
 	if sc == nil || sc.Equal(&SecurityConfig{}) {
 		var err error
 		sc, err = securityConfigFromCommonTLSContextWithDeprecatedFields(common, server)
 		if err != nil {
-			return nil, err
+			// Retain the validation error from using the new fields.
+			return nil, errors.Join(err1, fmt.Errorf("failed to parse config using deprecated fields: %v", err))
 		}
 	}
 	if sc != nil {
@@ -338,7 +339,7 @@ func securityConfigFromCommonTLSContext(common *v3tlspb.CommonTlsContext, server
 				return nil, errors.New("security configuration on the server-side does not contain identity certificate provider instance name")
 			}
 		} else {
-			if sc.RootInstanceName == "" {
+			if !sc.UseSystemRootCerts && sc.RootInstanceName == "" {
 				return nil, errors.New("security configuration on the client-side does not contain root certificate provider instance name")
 			}
 		}
@@ -364,6 +365,8 @@ func securityConfigFromCommonTLSContextWithDeprecatedFields(common *v3tlspb.Comm
 	//    - contains a default validation context which holds the list of
 	//      matchers for accepted SANs.
 	//    - contains certificate provider instance configuration
+	//    - contains a `system_root_certs` field indicating the use of system
+	//      root certs.
 	//  - certificate provider instance configuration
 	//    - in this case, we do not get a list of accepted SANs.
 	switch t := common.GetValidationContextType().(type) {
@@ -437,6 +440,8 @@ func securityConfigFromCommonTLSContextUsingNewFields(common *v3tlspb.CommonTlsC
 	// we are interested in:
 	//  - `ca_certificate_provider_instance`
 	//    - this is of type `CertificateProviderPluginInstance`
+	//  - `system_root_certs`:
+	//    - This indicates the usage of system root certs for validation.
 	//  - `match_subject_alt_names`
 	//    - this is a list of string matchers
 	//
@@ -460,11 +465,30 @@ func securityConfigFromCommonTLSContextUsingNewFields(common *v3tlspb.CommonTlsC
 	}
 	// If we get here, it means that the `CertificateValidationContext` message
 	// was found through one of the supported ways. It is an error if the
-	// validation context is specified, but it does not contain the
-	// ca_certificate_provider_instance field which contains information about
-	// the certificate provider to be used for the root certificates.
+	// validation context is specified, but it does not specify a way to
+	// validate TLS certificates. Peer TLS certs can be verified in the
+	// following ways:
+	// 1. If the ca_certificate_provider_instance field is set, it contains
+	//    information about the certificate provider to be used for the root
+	//    certificates, else
+	// 2. If the system_root_certs field is set, and the config is for a client,
+	//    use the system default root certs.
 	if validationCtx.GetCaCertificateProviderInstance() == nil {
-		return nil, fmt.Errorf("expected field ca_certificate_provider_instance is missing in CommonTlsContext message: %+v", common)
+		systemRootCertsEnabled := envconfig.XDSSystemRootCertsEnabled && validationCtx.GetSystemRootCerts() != nil
+		// The `system_root_certs` field will not be supported on the gRPC
+		// server side. If `ca_certificate_provider_instance` is unset and
+		// `system_root_certs` is set, the LDS resource will be NACKed.
+		// - A82
+		if server && systemRootCertsEnabled {
+			return nil, fmt.Errorf("expected field ca_certificate_provider_instance is missing and unexpected field ca_certificate_provider_instance is set for server in CommonTlsContext message: %+v", common)
+		}
+		if server || !envconfig.XDSSystemRootCertsEnabled {
+			return nil, fmt.Errorf("expected field ca_certificate_provider_instance is missing in CommonTlsContext message: %+v", common)
+		}
+		// Clients can use system root certs for validation.
+		if !systemRootCertsEnabled {
+			return nil, fmt.Errorf("expected fields ca_certificate_provider_instance and system_root_certs are missing in CommonTlsContext message: %+v", common)
+		}
 	}
 	// The following fields are ignored:
 	// - trusted_ca
@@ -487,6 +511,8 @@ func securityConfigFromCommonTLSContextUsingNewFields(common *v3tlspb.CommonTlsC
 	if rootProvider := validationCtx.GetCaCertificateProviderInstance(); rootProvider != nil {
 		sc.RootInstanceName = rootProvider.GetInstanceName()
 		sc.RootCertName = rootProvider.GetCertificateName()
+	} else if !server && envconfig.XDSSystemRootCertsEnabled && validationCtx.SystemRootCerts != nil {
+		sc.UseSystemRootCerts = true
 	}
 	var matchers []matcher.StringMatcher
 	for _, m := range validationCtx.GetMatchSubjectAltNames() {

--- a/xds/internal/xdsclient/xdsresource/unmarshal_cds_test.go
+++ b/xds/internal/xdsclient/xdsresource/unmarshal_cds_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"google.golang.org/grpc/internal/envconfig"
 	"google.golang.org/grpc/internal/pretty"
 	"google.golang.org/grpc/internal/testutils"
 	"google.golang.org/grpc/internal/xds/bootstrap"
@@ -269,10 +270,11 @@ func (s) TestValidateCluster_Failure(t *testing.T) {
 
 func (s) TestSecurityConfigFromCommonTLSContextUsingNewFields_ErrorCases(t *testing.T) {
 	tests := []struct {
-		name    string
-		common  *v3tlspb.CommonTlsContext
-		server  bool
-		wantErr string
+		name                      string
+		common                    *v3tlspb.CommonTlsContext
+		server                    bool
+		wantErr                   string
+		enableSystemRootCertsFlag bool
 	}{
 		{
 			name: "unsupported-tls_certificates-field-for-identity-certs",
@@ -422,10 +424,68 @@ func (s) TestSecurityConfigFromCommonTLSContextUsingNewFields_ErrorCases(t *test
 			server:  true,
 			wantErr: "match_subject_alt_names field in validation context is not supported on the server",
 		},
+		{
+			name:                      "client-missing-root-cert-provider-and-use-system-certs-fields",
+			enableSystemRootCertsFlag: true,
+			common: &v3tlspb.CommonTlsContext{
+				ValidationContextType: &v3tlspb.CommonTlsContext_ValidationContext{
+					ValidationContext: &v3tlspb.CertificateValidationContext{},
+				},
+			},
+			wantErr: "expected fields ca_certificate_provider_instance and system_root_certs are missing",
+		},
+		{
+			name:                      "server-missing-root-cert-provider-and-use-system-certs-fields",
+			enableSystemRootCertsFlag: true,
+			common: &v3tlspb.CommonTlsContext{
+				ValidationContextType: &v3tlspb.CommonTlsContext_ValidationContext{
+					ValidationContext: &v3tlspb.CertificateValidationContext{},
+				},
+			},
+			server:  true,
+			wantErr: "expected field ca_certificate_provider_instance is missing",
+		},
+		{
+			name: "client-missing-root-cert-provider-and-use-system-certs-fields-env-var-unset",
+			common: &v3tlspb.CommonTlsContext{
+				ValidationContextType: &v3tlspb.CommonTlsContext_ValidationContext{
+					ValidationContext: &v3tlspb.CertificateValidationContext{},
+				},
+			},
+			wantErr: "expected field ca_certificate_provider_instance is missing",
+		},
+		{
+			name: "server-missing-root-cert-provider-and-use-system-certs-fields-env-var-unset",
+			common: &v3tlspb.CommonTlsContext{
+				ValidationContextType: &v3tlspb.CommonTlsContext_ValidationContext{
+					ValidationContext: &v3tlspb.CertificateValidationContext{},
+				},
+			},
+			server:  true,
+			wantErr: "expected field ca_certificate_provider_instance is missing",
+		},
+		{
+			name:                      "server-missing-root-cert-provider-and-set-use-system-certs-fields",
+			enableSystemRootCertsFlag: true,
+			common: &v3tlspb.CommonTlsContext{
+				ValidationContextType: &v3tlspb.CommonTlsContext_ValidationContext{
+					ValidationContext: &v3tlspb.CertificateValidationContext{
+						SystemRootCerts: &v3tlspb.CertificateValidationContext_SystemRootCerts{},
+					},
+				},
+			},
+			server:  true,
+			wantErr: "expected field ca_certificate_provider_instance is missing and unexpected field ca_certificate_provider_instance is set",
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			origFlag := envconfig.XDSSystemRootCertsEnabled
+			defer func() {
+				envconfig.XDSSystemRootCertsEnabled = origFlag
+			}()
+			envconfig.XDSSystemRootCertsEnabled = test.enableSystemRootCertsFlag
 			_, err := securityConfigFromCommonTLSContextUsingNewFields(test.common, test.server)
 			if err == nil {
 				t.Fatal("securityConfigFromCommonTLSContextUsingNewFields() succeeded when expected to fail")
@@ -455,10 +515,11 @@ func (s) TestValidateClusterWithSecurityConfig(t *testing.T) {
 	var sanRE = regexp.MustCompile(sanRegexGood)
 
 	tests := []struct {
-		name       string
-		cluster    *v3clusterpb.Cluster
-		wantUpdate ClusterUpdate
-		wantErr    bool
+		name                      string
+		cluster                   *v3clusterpb.Cluster
+		wantUpdate                ClusterUpdate
+		wantErr                   bool
+		enableSystemRootCertsFlag bool
 	}{
 		{
 			name: "transport-socket-matches",
@@ -966,7 +1027,8 @@ func (s) TestValidateClusterWithSecurityConfig(t *testing.T) {
 			},
 		},
 		{
-			name: "happy-case-with-validation-context-provider-instance-using-new-fields",
+			name:                      "happy-case-with-validation-context-provider-instance-using-new-fields",
+			enableSystemRootCertsFlag: true,
 			cluster: &v3clusterpb.Cluster{
 				Name:                 clusterName,
 				ClusterDiscoveryType: &v3clusterpb.Cluster_Type{Type: v3clusterpb.Cluster_EDS},
@@ -994,6 +1056,10 @@ func (s) TestValidateClusterWithSecurityConfig(t *testing.T) {
 											InstanceName:    rootPluginInstance,
 											CertificateName: rootCertName,
 										},
+										// SystemRootCerts will be ignored dur
+										// to the presence of
+										// CaCertificateProviderInstance.
+										SystemRootCerts: &v3tlspb.CertificateValidationContext_SystemRootCerts{},
 									},
 								},
 							},
@@ -1012,6 +1078,86 @@ func (s) TestValidateClusterWithSecurityConfig(t *testing.T) {
 				},
 				TelemetryLabels: internal.UnknownCSMLabels,
 			},
+		},
+		{
+			name:                      "happy-case-with-validation-context-provider-instance-using-new-fields-and-system-root-certs",
+			enableSystemRootCertsFlag: true,
+			cluster: &v3clusterpb.Cluster{
+				Name:                 clusterName,
+				ClusterDiscoveryType: &v3clusterpb.Cluster_Type{Type: v3clusterpb.Cluster_EDS},
+				EdsClusterConfig: &v3clusterpb.Cluster_EdsClusterConfig{
+					EdsConfig: &v3corepb.ConfigSource{
+						ConfigSourceSpecifier: &v3corepb.ConfigSource_Ads{
+							Ads: &v3corepb.AggregatedConfigSource{},
+						},
+					},
+					ServiceName: serviceName,
+				},
+				LbPolicy: v3clusterpb.Cluster_ROUND_ROBIN,
+				TransportSocket: &v3corepb.TransportSocket{
+					Name: "envoy.transport_sockets.tls",
+					ConfigType: &v3corepb.TransportSocket_TypedConfig{
+						TypedConfig: testutils.MarshalAny(t, &v3tlspb.UpstreamTlsContext{
+							CommonTlsContext: &v3tlspb.CommonTlsContext{
+								TlsCertificateProviderInstance: &v3tlspb.CertificateProviderPluginInstance{
+									InstanceName:    identityPluginInstance,
+									CertificateName: identityCertName,
+								},
+								ValidationContextType: &v3tlspb.CommonTlsContext_ValidationContext{
+									ValidationContext: &v3tlspb.CertificateValidationContext{
+										SystemRootCerts: &v3tlspb.CertificateValidationContext_SystemRootCerts{},
+									},
+								},
+							},
+						}),
+					},
+				},
+			},
+			wantUpdate: ClusterUpdate{
+				ClusterName:    clusterName,
+				EDSServiceName: serviceName,
+				SecurityCfg: &SecurityConfig{
+					UseSystemRootCerts:   true,
+					IdentityInstanceName: identityPluginInstance,
+					IdentityCertName:     identityCertName,
+				},
+				TelemetryLabels: internal.UnknownCSMLabels,
+			},
+		},
+		{
+			name: "failure-case-with-validation-context-provider-instance-using-new-fields-and-system-root-certs-env-flag-disabled",
+			cluster: &v3clusterpb.Cluster{
+				Name:                 clusterName,
+				ClusterDiscoveryType: &v3clusterpb.Cluster_Type{Type: v3clusterpb.Cluster_EDS},
+				EdsClusterConfig: &v3clusterpb.Cluster_EdsClusterConfig{
+					EdsConfig: &v3corepb.ConfigSource{
+						ConfigSourceSpecifier: &v3corepb.ConfigSource_Ads{
+							Ads: &v3corepb.AggregatedConfigSource{},
+						},
+					},
+					ServiceName: serviceName,
+				},
+				LbPolicy: v3clusterpb.Cluster_ROUND_ROBIN,
+				TransportSocket: &v3corepb.TransportSocket{
+					Name: "envoy.transport_sockets.tls",
+					ConfigType: &v3corepb.TransportSocket_TypedConfig{
+						TypedConfig: testutils.MarshalAny(t, &v3tlspb.UpstreamTlsContext{
+							CommonTlsContext: &v3tlspb.CommonTlsContext{
+								TlsCertificateProviderInstance: &v3tlspb.CertificateProviderPluginInstance{
+									InstanceName:    identityPluginInstance,
+									CertificateName: identityCertName,
+								},
+								ValidationContextType: &v3tlspb.CommonTlsContext_ValidationContext{
+									ValidationContext: &v3tlspb.CertificateValidationContext{
+										SystemRootCerts: &v3tlspb.CertificateValidationContext_SystemRootCerts{},
+									},
+								},
+							},
+						}),
+					},
+				},
+			},
+			wantErr: true,
 		},
 		{
 			name: "happy-case-with-combined-validation-context-using-deprecated-fields",
@@ -1147,10 +1293,79 @@ func (s) TestValidateClusterWithSecurityConfig(t *testing.T) {
 				TelemetryLabels: internal.UnknownCSMLabels,
 			},
 		},
+		{
+			name:                      "happy-case-with-combined-validation-context-using-new-fields-and-system-root-certs",
+			enableSystemRootCertsFlag: true,
+			cluster: &v3clusterpb.Cluster{
+				Name:                 clusterName,
+				ClusterDiscoveryType: &v3clusterpb.Cluster_Type{Type: v3clusterpb.Cluster_EDS},
+				EdsClusterConfig: &v3clusterpb.Cluster_EdsClusterConfig{
+					EdsConfig: &v3corepb.ConfigSource{
+						ConfigSourceSpecifier: &v3corepb.ConfigSource_Ads{
+							Ads: &v3corepb.AggregatedConfigSource{},
+						},
+					},
+					ServiceName: serviceName,
+				},
+				LbPolicy: v3clusterpb.Cluster_ROUND_ROBIN,
+				TransportSocket: &v3corepb.TransportSocket{
+					Name: "envoy.transport_sockets.tls",
+					ConfigType: &v3corepb.TransportSocket_TypedConfig{
+						TypedConfig: testutils.MarshalAny(t, &v3tlspb.UpstreamTlsContext{
+							CommonTlsContext: &v3tlspb.CommonTlsContext{
+								TlsCertificateProviderInstance: &v3tlspb.CertificateProviderPluginInstance{
+									InstanceName:    identityPluginInstance,
+									CertificateName: identityCertName,
+								},
+								ValidationContextType: &v3tlspb.CommonTlsContext_CombinedValidationContext{
+									CombinedValidationContext: &v3tlspb.CommonTlsContext_CombinedCertificateValidationContext{
+										DefaultValidationContext: &v3tlspb.CertificateValidationContext{
+											MatchSubjectAltNames: []*v3matcherpb.StringMatcher{
+												{
+													MatchPattern: &v3matcherpb.StringMatcher_Exact{Exact: sanExact},
+													IgnoreCase:   true,
+												},
+												{MatchPattern: &v3matcherpb.StringMatcher_Prefix{Prefix: sanPrefix}},
+												{MatchPattern: &v3matcherpb.StringMatcher_Suffix{Suffix: sanSuffix}},
+												{MatchPattern: &v3matcherpb.StringMatcher_SafeRegex{SafeRegex: &v3matcherpb.RegexMatcher{Regex: sanRegexGood}}},
+												{MatchPattern: &v3matcherpb.StringMatcher_Contains{Contains: sanContains}},
+											},
+											SystemRootCerts: &v3tlspb.CertificateValidationContext_SystemRootCerts{},
+										},
+									},
+								},
+							},
+						}),
+					},
+				},
+			},
+			wantUpdate: ClusterUpdate{
+				ClusterName:    clusterName,
+				EDSServiceName: serviceName,
+				SecurityCfg: &SecurityConfig{
+					UseSystemRootCerts:   true,
+					IdentityInstanceName: identityPluginInstance,
+					IdentityCertName:     identityCertName,
+					SubjectAltNameMatchers: []matcher.StringMatcher{
+						matcher.StringMatcherForTesting(newStringP(sanExact), nil, nil, nil, nil, true),
+						matcher.StringMatcherForTesting(nil, newStringP(sanPrefix), nil, nil, nil, false),
+						matcher.StringMatcherForTesting(nil, nil, newStringP(sanSuffix), nil, nil, false),
+						matcher.StringMatcherForTesting(nil, nil, nil, nil, sanRE, false),
+						matcher.StringMatcherForTesting(nil, nil, nil, newStringP(sanContains), nil, false),
+					},
+				},
+				TelemetryLabels: internal.UnknownCSMLabels,
+			},
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			origFlag := envconfig.XDSSystemRootCertsEnabled
+			defer func() {
+				envconfig.XDSSystemRootCertsEnabled = origFlag
+			}()
+			envconfig.XDSSystemRootCertsEnabled = test.enableSystemRootCertsFlag
 			update, err := validateClusterAndConstructClusterUpdate(test.cluster, nil)
 			if (err != nil) != test.wantErr {
 				t.Errorf("validateClusterAndConstructClusterUpdate() returned err %v wantErr %v)", err, test.wantErr)

--- a/xds/internal/xdsclient/xdsresource/unmarshal_cds_test.go
+++ b/xds/internal/xdsclient/xdsresource/unmarshal_cds_test.go
@@ -475,7 +475,7 @@ func (s) TestSecurityConfigFromCommonTLSContextUsingNewFields_ErrorCases(t *test
 				},
 			},
 			server:  true,
-			wantErr: "expected field ca_certificate_provider_instance is missing and unexpected field ca_certificate_provider_instance is set",
+			wantErr: "expected field ca_certificate_provider_instance is missing and unexpected field system_root_certs is set",
 		},
 	}
 
@@ -1056,7 +1056,7 @@ func (s) TestValidateClusterWithSecurityConfig(t *testing.T) {
 											InstanceName:    rootPluginInstance,
 											CertificateName: rootCertName,
 										},
-										// SystemRootCerts will be ignored dur
+										// SystemRootCerts will be ignored due
 										// to the presence of
 										// CaCertificateProviderInstance.
 										SystemRootCerts: &v3tlspb.CertificateValidationContext_SystemRootCerts{},

--- a/xds/internal/xdsclient/xdsresource/unmarshal_lds_test.go
+++ b/xds/internal/xdsclient/xdsresource/unmarshal_lds_test.go
@@ -806,6 +806,10 @@ func (s) TestUnmarshalListener_ServerSide(t *testing.T) {
 												InstanceName:    "rootPluginInstance",
 												CertificateName: "rootCertName",
 											},
+											// SystemRootCerts is ignored when
+											// CaCertificateProviderInstance is
+											// present.
+											SystemRootCerts: &v3tlspb.CertificateValidationContext_SystemRootCerts{},
 										},
 									},
 								},


### PR DESCRIPTION
As per [gRFC A82](https://github.com/grpc/proposal/blob/master/A82-xds-system-root-certs.md), xDS client should be able to use system root certificates to validate server identity if the use of system root certs is configured by the xDS management server. This is useful when the gRPC server is behind a reverse proxy. As per the gRFC, the feature is behind a feature flag till it is proven stable.

RELEASE NOTES:
* xds: Client can use system root certificates to validate server identity when configures by the xDS management server. To enabled this feature, set the environment variable `GRPC_EXPERIMENTAL_XDS_SYSTEM_ROOT_CERTS` to `true` (case insensitive). See gRFC A82 (https://github.com/grpc/proposal/pull/436) for details.