### PR TITLE
Add "Server Started" log to route_guides/server.go

### DIFF
--- a/examples/route_guide/server/server.go
+++ b/examples/route_guide/server/server.go
@@ -237,6 +237,7 @@ func main() {
 	}
 	grpcServer := grpc.NewServer(opts...)
 	pb.RegisterRouteGuideServer(grpcServer, newServer())
+	log.Printf("Server is running on localhost:%d", *port)
 	grpcServer.Serve(lis)
 }
 


### PR DESCRIPTION
While exploring this repository, I discovered the examples folder and decided to run one of the examples locally, specifically `route_guide`. I executed the following command:

```bash
$ go run server/server.go
```

I noticed that Go was attempting to download the necessary dependencies. However, it got stuck on one of them for so long that I decided to try running the `client.go` file to see if it would work. When I found that it did, I realized that the server had started, but there was no notification to confirm this.

I believe this behavior could confuse users, so I added simple logging to indicate when the server has successfully started, ensuring users are informed that everything is ready.