### PR TITLE
endpointsharding: Allow children to remain idle if configured

### DIFF
--- a/balancer/endpointsharding/endpointsharding.go
+++ b/balancer/endpointsharding/endpointsharding.go
@@ -62,14 +62,31 @@ func init() {
 type ChildState struct {
 	Endpoint resolver.Endpoint
 	State    balancer.State
+
+	// Balancer exposes only the ExitIdler interface of the child LB policy.
+	// Other methods on the child policy are called only by endpointsharding.
+	Balancer balancer.ExitIdler
 }
 
 // NewBalancer returns a load balancing policy that manages homogeneous child
 // policies each owning a single endpoint.
 func NewBalancer(cc balancer.ClientConn, opts balancer.BuildOptions) balancer.Balancer {
+	return newBlanacer(cc, opts, true)
+}
+
+// NewBalancerWithoutAutoReconnect returns a load balancing policy that manages
+// homogeneous child policies each owning a single endpoint. The balancer will
+// allow children to remain in IDLE state until triggered to exit idle state
+// using the ChildState obtained using the endpointsharding picker.
+func NewBalancerWithoutAutoReconnect(cc balancer.ClientConn, opts balancer.BuildOptions) balancer.Balancer {
+	return newBlanacer(cc, opts, false)
+}
+
+func newBlanacer(cc balancer.ClientConn, opts balancer.BuildOptions, autoReconnect bool) balancer.Balancer {
 	es := &endpointSharding{
-		cc:    cc,
-		bOpts: opts,
+		cc:                  cc,
+		bOpts:               opts,
+		enableAutoReconnect: autoReconnect,
 	}
 	es.children.Store(resolver.NewEndpointMap())
 	return es
@@ -79,12 +96,12 @@ func NewBalancer(cc balancer.ClientConn, opts balancer.BuildOptions) balancer.Ba
 // balancer with child config for every unique Endpoint received. It updates the
 // child states on any update from parent or child.
 type endpointSharding struct {
-	cc    balancer.ClientConn
-	bOpts balancer.BuildOptions
+	cc                  balancer.ClientConn
+	bOpts               balancer.BuildOptions
+	enableAutoReconnect bool
 
 	childMu  sync.Mutex // syncs balancer.Balancer calls into children
 	children atomic.Pointer[resolver.EndpointMap]
-	closed   bool
 
 	// inhibitChildUpdates is set during UpdateClientConnState/ResolverError
 	// calls (calls to children will each produce an update, only want one
@@ -124,12 +141,17 @@ func (es *endpointSharding) UpdateClientConnState(state balancer.ClientConnState
 		var bal *balancerWrapper
 		if child, ok := children.Get(endpoint); ok {
 			bal = child.(*balancerWrapper)
+			// Endpoint attributes may have changes, update the stored endpoint.
+			es.mu.Lock()
+			bal.childState.Endpoint = endpoint
+			es.mu.Unlock()
 		} else {
 			bal = &balancerWrapper{
 				childState: ChildState{Endpoint: endpoint},
 				ClientConn: es.cc,
 				es:         es,
 			}
+			bal.childState.Balancer = bal
 			bal.Balancer = gracefulswitch.NewBalancer(bal, es.bOpts)
 		}
 		newChildren.Set(endpoint, bal)
@@ -150,9 +172,10 @@ func (es *endpointSharding) UpdateClientConnState(state balancer.ClientConnState
 	// Delete old children that are no longer present.
 	for _, e := range children.Keys() {
 		child, _ := children.Get(e)
-		bal := child.(balancer.Balancer)
+		bal := child.(*balancerWrapper)
 		if _, ok := newChildren.Get(e); !ok {
 			bal.Close()
+			bal.isClosed = true
 		}
 	}
 	es.children.Store(newChildren)
@@ -189,10 +212,10 @@ func (es *endpointSharding) Close() {
 	defer es.childMu.Unlock()
 	children := es.children.Load()
 	for _, child := range children.Values() {
-		bal := child.(balancer.Balancer)
+		bal := child.(*balancerWrapper)
 		bal.Close()
+		bal.isClosed = true
 	}
-	es.closed = true
 }
 
 // updateState updates this component's state. It sends the aggregated state,
@@ -294,24 +317,33 @@ type balancerWrapper struct {
 	es *endpointSharding
 
 	childState ChildState
+
+	// Users must hold `es.childMu`.
+	isClosed bool
 }
 
 func (bw *balancerWrapper) UpdateState(state balancer.State) {
 	bw.es.mu.Lock()
 	bw.childState.State = state
 	bw.es.mu.Unlock()
-	// When a child balancer says it's IDLE, ping it to exit idle and reconnect.
-	// TODO: In the future, perhaps make this a knob in configuration.
-	if ei, ok := bw.Balancer.(balancer.ExitIdler); state.ConnectivityState == connectivity.Idle && ok {
+	if state.ConnectivityState == connectivity.Idle && bw.es.enableAutoReconnect {
+		bw.ExitIdle()
+	}
+	bw.es.updateState()
+}
+
+// ExitIdle pings an IDLE child balancer to exit idle in a new goroutine to
+// avoid deadlocks due to synchronous balancer state updates.
+func (bw *balancerWrapper) ExitIdle() {
+	if ei, ok := bw.Balancer.(balancer.ExitIdler); ok {
 		go func() {
 			bw.es.childMu.Lock()
-			if !bw.es.closed {
+			if !bw.isClosed {
 				ei.ExitIdle()
 			}
 			bw.es.childMu.Unlock()
 		}()
 	}
-	bw.es.updateState()
 }
 
 // ParseConfig parses a child config list and returns an LB config to use with


### PR DESCRIPTION
This change allows the children of endpointsharding to remain in IDLE state. This allows lazy initialization of children and therefore lazy creation of subchannels for endpoints. This enables the usage of endpointsharding in the ringhash balancer for managing pickfirst children.

RELEASE NOTES:
* balancer/endpointsharding: Balancers created using the new `NewBalancerWithoutAutoReconnect` function will not attempt to call `ExitIdle` automatically on their children when the children report idle.