### PR TITLE
grpc: Fix encoded message size reported in error message

### DIFF
--- a/rpc_util.go
+++ b/rpc_util.go
@@ -692,9 +692,9 @@ func encode(c baseCodec, msg any) (mem.BufferSlice, error) {
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "grpc: error while marshaling: %v", err.Error())
 	}
-	if uint(b.Len()) > math.MaxUint32 {
+	if bufSize := uint(b.Len()); bufSize > math.MaxUint32 {
 		b.Free()
-		return nil, status.Errorf(codes.ResourceExhausted, "grpc: message too large (%d bytes)", len(b))
+		return nil, status.Errorf(codes.ResourceExhausted, "grpc: message too large (%d bytes)", bufSize)
 	}
 	return b, nil
 }


### PR DESCRIPTION
This PR fixes two bugs in the encoded message size error message:
1. Using len(b) returns the number of buffers in a BufferSlice and not the number of bytes in the BufferSlice.
2. Finding the size after calling b.Free() would return 0 if there are no remaining references to the buffers within the slice.

RELEASE NOTES:
* grpc: Fix the number of bytes reported in the error message when encoded messages are larger than `math.MaxUint32`.