### PR TITLE
xds/internal/xdsclient: Add counter metrics for valid and invalid resource updates

### DIFF
--- a/internal/internal.go
+++ b/internal/internal.go
@@ -60,6 +60,9 @@ var (
 	// gRPC server. An xDS-enabled server needs to know what type of credentials
 	// is configured on the underlying gRPC server. This is set by server.go.
 	GetServerCredentials any // func (*grpc.Server) credentials.TransportCredentials
+	// MetricsRecorderForServer returns the MetricsRecorderList derived from a
+	// servers stats handlers.
+	MetricsRecorderForServer any // func (*grpc.Server) estats.MetricsRecorder
 	// CanonicalString returns the canonical string of the code defined here:
 	// https://github.com/grpc/grpc/blob/master/doc/statuscodes.md.
 	//

--- a/internal/stats/metrics_recorder_list.go
+++ b/internal/stats/metrics_recorder_list.go
@@ -103,3 +103,22 @@ func (l *MetricsRecorderList) RecordInt64Gauge(handle *estats.Int64GaugeHandle, 
 		metricRecorder.RecordInt64Gauge(handle, incr, labels...)
 	}
 }
+
+// NoopMetricsRecorder is a noop MetricsRecorder to be used to prevent nil
+// panics.
+type NoopMetricsRecorder struct{}
+
+// RecordInt64Count is a noop implementation of RecordInt64Count.
+func (r *NoopMetricsRecorder) RecordInt64Count(*estats.Int64CountHandle, int64, ...string) {}
+
+// RecordFloat64Count is a noop implementation of RecordFloat64Count.
+func (r *NoopMetricsRecorder) RecordFloat64Count(*estats.Float64CountHandle, float64, ...string) {}
+
+// RecordInt64Histo is a noop implementation of RecordInt64Histo.
+func (r *NoopMetricsRecorder) RecordInt64Histo(*estats.Int64HistoHandle, int64, ...string) {}
+
+// RecordFloat64Histo is a noop implementation of RecordFloat64Histo.
+func (r *NoopMetricsRecorder) RecordFloat64Histo(*estats.Float64HistoHandle, float64, ...string) {}
+
+// RecordInt64Gauge is a noop implementation of RecordInt64Gauge.
+func (r *NoopMetricsRecorder) RecordInt64Gauge(*estats.Int64GaugeHandle, int64, ...string) {}

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -30,6 +30,7 @@ import (
 
 	"google.golang.org/grpc/attributes"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/experimental/stats"
 	"google.golang.org/grpc/internal"
 	"google.golang.org/grpc/serviceconfig"
 )
@@ -175,6 +176,8 @@ type BuildOptions struct {
 	// Authority is the effective authority of the clientconn for which the
 	// resolver is built.
 	Authority string
+	// MetricsRecorder is the metrics recorder to do recording.
+	MetricsRecorder stats.MetricsRecorder
 }
 
 // An Endpoint is one network endpoint, or server, which may have multiple

--- a/resolver_wrapper.go
+++ b/resolver_wrapper.go
@@ -76,6 +76,7 @@ func (ccr *ccResolverWrapper) start() error {
 			CredsBundle:          ccr.cc.dopts.copts.CredsBundle,
 			Dialer:               ccr.cc.dopts.copts.Dialer,
 			Authority:            ccr.cc.authority,
+			MetricsRecorder:      ccr.cc.metricsRecorderList,
 		}
 		var err error
 		ccr.resolver, err = ccr.cc.resolverBuilder.Build(ccr.cc.parsedTarget, ccr, opts)

--- a/xds/internal/balancer/clustermanager/clustermanager_test.go
+++ b/xds/internal/balancer/clustermanager/clustermanager_test.go
@@ -34,6 +34,7 @@ import (
 	"google.golang.org/grpc/internal/grpctest"
 	"google.golang.org/grpc/internal/hierarchy"
 	"google.golang.org/grpc/internal/testutils"
+	"google.golang.org/grpc/internal/testutils/stats"
 	"google.golang.org/grpc/resolver"
 	"google.golang.org/grpc/status"
 )
@@ -606,7 +607,7 @@ func TestClusterGracefulSwitch(t *testing.T) {
 	cc := testutils.NewBalancerClientConn(t)
 	builder := balancer.Get(balancerName)
 	parser := builder.(balancer.ConfigParser)
-	bal := builder.Build(cc, balancer.BuildOptions{})
+	bal := builder.Build(cc, balancer.BuildOptions{MetricsRecorder: &stats.NoopMetricsRecorder{}})
 	defer bal.Close()
 
 	configJSON1 := `{

--- a/xds/internal/resolver/helpers_test.go
+++ b/xds/internal/resolver/helpers_test.go
@@ -32,6 +32,7 @@ import (
 	"google.golang.org/grpc/internal/grpctest"
 	iresolver "google.golang.org/grpc/internal/resolver"
 	"google.golang.org/grpc/internal/testutils"
+	istats "google.golang.org/grpc/internal/testutils/stats"
 	"google.golang.org/grpc/internal/testutils/xds/e2e"
 	"google.golang.org/grpc/resolver"
 	"google.golang.org/grpc/serviceconfig"
@@ -105,7 +106,8 @@ func buildResolverForTarget(t *testing.T, target resolver.Target) (chan resolver
 	}
 	tcc := &testutils.ResolverClientConn{Logger: t, UpdateStateF: updateStateF, ReportErrorF: reportErrorF}
 	r, err := builder.Build(target, tcc, resolver.BuildOptions{
-		Authority: url.PathEscape(target.Endpoint()),
+		Authority:       url.PathEscape(target.Endpoint()),
+		MetricsRecorder: &istats.NoopMetricsRecorder{},
 	})
 	if err != nil {
 		t.Fatalf("Failed to build xDS resolver for target %q: %v", target, err)

--- a/xds/internal/resolver/internal/internal.go
+++ b/xds/internal/resolver/internal/internal.go
@@ -26,5 +26,5 @@ var (
 	NewWRR any // func() wrr.WRR
 
 	// NewXDSClient is the function used to create a new xDS client.
-	NewXDSClient any // func(string) (xdsclient.XDSClient, func(), error)
+	NewXDSClient any // func(string, estats.MetricsRecorder) (xdsclient.XDSClient, func(), error)
 )

--- a/xds/internal/xdsclient/authority.go
+++ b/xds/internal/xdsclient/authority.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"sync/atomic"
 
+	"google.golang.org/grpc/experimental/stats"
 	"google.golang.org/grpc/grpclog"
 	igrpclog "google.golang.org/grpc/internal/grpclog"
 	"google.golang.org/grpc/internal/grpcsync"
@@ -86,6 +87,8 @@ type authority struct {
 	xdsClientSerializer       *grpcsync.CallbackSerializer // Serializer to run call ins from the xDS client, owned by this authority.
 	xdsClientSerializerClose  func()                       // Function to close the above serializer.
 	logger                    *igrpclog.PrefixLogger       // Logger for this authority.
+	target                    string                       // The gRPC Channel target.
+	metricsRecorder           stats.MetricsRecorder        // The metrics recorder used for emitting metrics.
 
 	// The below defined fields must only be accessed in the context of the
 	// serializer callback, owned by this authority.
@@ -119,6 +122,8 @@ type authorityBuildOptions struct {
 	serializer       *grpcsync.CallbackSerializer // Callback serializer for invoking watch callbacks
 	getChannelForADS xdsChannelForADS             // Function to acquire a reference to an xdsChannel
 	logPrefix        string                       // Prefix for logging
+	target           string                       // Target for the gRPC Channel that owns xDS Client/Authority
+	metricsRecorder  stats.MetricsRecorder        // metricsRecorder to emit metrics
 }
 
 // newAuthority creates a new authority instance with the provided
@@ -142,6 +147,8 @@ func newAuthority(args authorityBuildOptions) *authority {
 		xdsClientSerializerClose:  cancel,
 		logger:                    igrpclog.NewPrefixLogger(l, logPrefix),
 		resources:                 make(map[xdsresource.Type]map[string]*resourceState),
+		target:                    args.target,
+		metricsRecorder:           args.metricsRecorder,
 	}
 
 	// Create an ordered list of xdsChannels with their server configs. The
@@ -357,6 +364,7 @@ func (a *authority) handleADSResourceUpdate(serverConfig *bootstrap.ServerConfig
 		// On error, keep previous version of the resource. But update status
 		// and error.
 		if uErr.Err != nil {
+			xdsClientResourceUpdatesInvalidMetric.Record(a.metricsRecorder, 1, a.target, serverConfig.ServerURI(), rType.TypeName())
 			state.md.ErrState = md.ErrState
 			state.md.Status = md.Status
 			for watcher := range state.watchers {
@@ -367,6 +375,8 @@ func (a *authority) handleADSResourceUpdate(serverConfig *bootstrap.ServerConfig
 			}
 			continue
 		}
+
+		xdsClientResourceUpdatesValidMetric.Record(a.metricsRecorder, 1, a.target, serverConfig.ServerURI(), rType.TypeName())
 
 		if state.deletionIgnored {
 			state.deletionIgnored = false

--- a/xds/internal/xdsclient/client_refcounted_test.go
+++ b/xds/internal/xdsclient/client_refcounted_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/google/uuid"
 	"google.golang.org/grpc/internal/testutils"
+	"google.golang.org/grpc/internal/testutils/stats"
 	"google.golang.org/grpc/internal/testutils/xds/e2e"
 )
 
@@ -55,7 +56,7 @@ func (s) TestClientNew_Single(t *testing.T) {
 	defer func() { xdsClientImplCloseHook = origClientImplCloseHook }()
 
 	// The first call to New() should create a new client.
-	_, closeFunc, err := New(t.Name())
+	_, closeFunc, err := New(t.Name(), &stats.NoopMetricsRecorder{})
 	if err != nil {
 		t.Fatalf("Failed to create xDS client: %v", err)
 	}
@@ -71,7 +72,7 @@ func (s) TestClientNew_Single(t *testing.T) {
 	closeFuncs := make([]func(), count)
 	for i := 0; i < count; i++ {
 		func() {
-			_, closeFuncs[i], err = New(t.Name())
+			_, closeFuncs[i], err = New(t.Name(), &stats.NoopMetricsRecorder{})
 			if err != nil {
 				t.Fatalf("%d-th call to New() failed with error: %v", i, err)
 			}
@@ -109,7 +110,7 @@ func (s) TestClientNew_Single(t *testing.T) {
 
 	// Calling New() again, after the previous Client was actually closed,
 	// should create a new one.
-	_, closeFunc, err = New(t.Name())
+	_, closeFunc, err = New(t.Name(), &stats.NoopMetricsRecorder{})
 	if err != nil {
 		t.Fatalf("Failed to create xDS client: %v", err)
 	}
@@ -147,7 +148,7 @@ func (s) TestClientNew_Multiple(t *testing.T) {
 
 	// Create two xDS clients.
 	client1Name := t.Name() + "-1"
-	_, closeFunc1, err := New(client1Name)
+	_, closeFunc1, err := New(client1Name, &stats.NoopMetricsRecorder{})
 	if err != nil {
 		t.Fatalf("Failed to create xDS client: %v", err)
 	}
@@ -162,7 +163,7 @@ func (s) TestClientNew_Multiple(t *testing.T) {
 	}
 
 	client2Name := t.Name() + "-2"
-	_, closeFunc2, err := New(client2Name)
+	_, closeFunc2, err := New(client2Name, &stats.NoopMetricsRecorder{})
 	if err != nil {
 		t.Fatalf("Failed to create xDS client: %v", err)
 	}
@@ -184,7 +185,7 @@ func (s) TestClientNew_Multiple(t *testing.T) {
 		defer wg.Done()
 		for i := 0; i < count; i++ {
 			var err error
-			_, closeFuncs1[i], err = New(client1Name)
+			_, closeFuncs1[i], err = New(client1Name, &stats.NoopMetricsRecorder{})
 			if err != nil {
 				t.Errorf("%d-th call to New() failed with error: %v", i, err)
 			}
@@ -194,7 +195,7 @@ func (s) TestClientNew_Multiple(t *testing.T) {
 		defer wg.Done()
 		for i := 0; i < count; i++ {
 			var err error
-			_, closeFuncs2[i], err = New(client2Name)
+			_, closeFuncs2[i], err = New(client2Name, &stats.NoopMetricsRecorder{})
 			if err != nil {
 				t.Errorf("%d-th call to New() failed with error: %v", i, err)
 			}

--- a/xds/internal/xdsclient/clientimpl.go
+++ b/xds/internal/xdsclient/clientimpl.go
@@ -25,6 +25,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"google.golang.org/grpc/experimental/stats"
 	"google.golang.org/grpc/internal/cache"
 	"google.golang.org/grpc/internal/grpclog"
 	"google.golang.org/grpc/internal/grpcsync"
@@ -55,6 +56,8 @@ type clientImpl struct {
 	serializer         *grpcsync.CallbackSerializer // Serializer for invoking resource watcher callbacks.
 	serializerClose    func()                       // Function to close the serializer.
 	logger             *grpclog.PrefixLogger        // Logger for this client.
+	metricsRecorder    stats.MetricsRecorder        // Metrics recorder for metrics.
+	target             string                       // The gRPC target for this client.
 
 	// The clientImpl owns a bunch of channels to individual xDS servers
 	// specified in the bootstrap configuration. Authorities acquire references

--- a/xds/internal/xdsclient/metrics_test.go
+++ b/xds/internal/xdsclient/metrics_test.go
@@ -1,0 +1,145 @@
+/*
+ *
+ * Copyright 2024 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package xdsclient
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/google/uuid"
+	"google.golang.org/grpc/internal/testutils"
+	"google.golang.org/grpc/internal/testutils/stats"
+	"google.golang.org/grpc/internal/testutils/xds/e2e"
+	"google.golang.org/grpc/internal/xds/bootstrap"
+	"google.golang.org/grpc/xds/internal/xdsclient/xdsresource"
+
+	v3listenerpb "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+)
+
+type noopListenerWatcher struct{}
+
+func (noopListenerWatcher) OnUpdate(_ *xdsresource.ListenerResourceData, onDone xdsresource.OnDoneFunc) {
+	onDone()
+}
+
+func (noopListenerWatcher) OnError(_ error, onDone xdsresource.OnDoneFunc) {
+	onDone()
+}
+
+func (noopListenerWatcher) OnResourceDoesNotExist(onDone xdsresource.OnDoneFunc) {
+	onDone()
+}
+
+// TestResourceUpdateMetrics tests resource update metrics. It configures an xDS
+// Client and provides a valid and invalid LDS update, and verifies the valid
+// and invalid metrics emitted from them.
+func (s) TestResourceUpdateMetrics(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+
+	tmr := stats.NewTestMetricsRecorder()
+	l, err := testutils.LocalTCPListener()
+	if err != nil {
+		t.Fatalf("net.Listen() failed: %v", err)
+	}
+
+	mgmtServer := e2e.StartManagementServer(t, e2e.ManagementServerOptions{Listener: l})
+	const listenerResourceName = "test-listener-resource"
+	const routeConfigurationName = "test-route-configuration-resource"
+	nodeID := uuid.New().String()
+	resources := e2e.UpdateOptions{
+		NodeID:         nodeID,
+		Listeners:      []*v3listenerpb.Listener{e2e.DefaultClientListener(listenerResourceName, routeConfigurationName)},
+		SkipValidation: true,
+	}
+	if err := mgmtServer.Update(ctx, resources); err != nil {
+		t.Fatalf("Failed to update management server with resources: %v, err: %v", resources, err)
+	}
+
+	bootstrapContents, err := bootstrap.NewContentsForTesting(bootstrap.ConfigOptionsForTesting{
+		Servers: []byte(fmt.Sprintf(`[{
+			"server_uri": %q,
+			"channel_creds": [{"type": "insecure"}]
+		}]`, mgmtServer.Address)),
+		Node: []byte(fmt.Sprintf(`{"id": "%s"}`, nodeID)),
+		Authorities: map[string]json.RawMessage{
+			"authority": []byte("{}"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("Failed to create bootstrap configuration: %v", err)
+	}
+
+	client, close, err := NewForTesting(OptionsForTesting{
+		Name:               t.Name(),
+		Contents:           bootstrapContents,
+		WatchExpiryTimeout: defaultTestWatchExpiryTimeout,
+		MetricsRecorder:    tmr,
+	})
+	if err != nil {
+		t.Fatalf("Failed to create an xDS client: %v", err)
+	}
+	defer close()
+
+	// Watch the valid listener configured on the management server. This should
+	// cause a resource updates valid count to emit eventually.
+	xdsresource.WatchListener(client, listenerResourceName, noopListenerWatcher{})
+	mdWant := stats.MetricsData{
+		Handle:    xdsClientResourceUpdatesValidMetric.Descriptor(),
+		IntIncr:   1,
+		LabelKeys: []string{"grpc.target", "grpc.xds.server", "grpc.xds.resource_type"},
+		LabelVals: []string{"Test/ResourceUpdateMetrics", mgmtServer.Address, "ListenerResource"},
+	}
+	if err := tmr.WaitForInt64Count(ctx, mdWant); err != nil {
+		t.Fatal(err.Error())
+	}
+	// Invalid should have no recording point.
+	if got, _ := tmr.Metric("grpc.xds_client.resource_updates_invalid"); got != 0 {
+		t.Fatalf("Unexpected data for metric \"grpc.xds_client.resource_updates_invalid\", got: %v, want: %v", got, 0)
+	}
+
+	// Update management server with a bad update. Eventually, tmr should
+	// receive an invalid count received metric. The successful metric should
+	// stay the same.
+	resources = e2e.UpdateOptions{
+		NodeID:         nodeID,
+		Listeners:      []*v3listenerpb.Listener{e2e.DefaultClientListener(listenerResourceName, routeConfigurationName)},
+		SkipValidation: true,
+	}
+	resources.Listeners[0].ApiListener = nil
+	if err := mgmtServer.Update(ctx, resources); err != nil {
+		t.Fatalf("Failed to update management server with resources: %v, err: %v", resources, err)
+	}
+
+	mdWant = stats.MetricsData{
+		Handle:    xdsClientResourceUpdatesInvalidMetric.Descriptor(),
+		IntIncr:   1,
+		LabelKeys: []string{"grpc.target", "grpc.xds.server", "grpc.xds.resource_type"},
+		LabelVals: []string{"Test/ResourceUpdateMetrics", mgmtServer.Address, "ListenerResource"},
+	}
+	if err := tmr.WaitForInt64Count(ctx, mdWant); err != nil {
+		t.Fatal(err.Error())
+	}
+	// Valid should stay the same at 1.
+	if got, _ := tmr.Metric("grpc.xds_client.resource_updates_valid"); got != 1 {
+		t.Fatalf("Unexpected data for metric \"grpc.xds_client.resource_updates_invalid\", got: %v, want: %v", got, 1)
+	}
+}

--- a/xds/server_test.go
+++ b/xds/server_test.go
@@ -38,6 +38,7 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/credentials/tls/certprovider"
 	"google.golang.org/grpc/credentials/xds"
+	"google.golang.org/grpc/experimental/stats"
 	"google.golang.org/grpc/internal/grpctest"
 	"google.golang.org/grpc/internal/testutils"
 	"google.golang.org/grpc/internal/testutils/xds/e2e"
@@ -475,7 +476,7 @@ func (s) TestServeSuccess(t *testing.T) {
 // creation fails and verifies that the call to NewGRPCServer() fails.
 func (s) TestNewServer_ClientCreationFailure(t *testing.T) {
 	origNewXDSClient := newXDSClient
-	newXDSClient = func(string) (xdsclient.XDSClient, func(), error) {
+	newXDSClient = func(string, stats.MetricsRecorder) (xdsclient.XDSClient, func(), error) {
 		return nil, nil, errors.New("xdsClient creation failed")
 	}
 	defer func() { newXDSClient = origNewXDSClient }()


### PR DESCRIPTION
This PR adds counter metrics for the xDS Client, and unit tests. E2E tests still need to be written.

The gauge metrics are blocked on adding support for asynchronous gauges, and we also should move our synchronous gauges in RLS to asynchronous.

RELEASE NOTES:
* xds/internal/xdsclient: Add counter metrics for valid and invalid resource updates