### PR TITLE
xds/internal/xdsclient: Add counter metrics for valid and invalid resource updates

### DIFF
--- a/internal/internal.go
+++ b/internal/internal.go
@@ -65,7 +65,7 @@ var (
 	// is configured on the underlying gRPC server. This is set by server.go.
 	GetServerCredentials any // func (*grpc.Server) credentials.TransportCredentials
 	// MetricsRecorderForServer returns the MetricsRecorderList derived from a
-	// servers stats handlers.
+	// server's stats handlers.
 	MetricsRecorderForServer any // func (*grpc.Server) estats.MetricsRecorder
 	// CanonicalString returns the canonical string of the code defined here:
 	// https://github.com/grpc/grpc/blob/master/doc/statuscodes.md.

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -64,6 +64,9 @@ var (
 	// gRPC server. An xDS-enabled server needs to know what type of credentials
 	// is configured on the underlying gRPC server. This is set by server.go.
 	GetServerCredentials any // func (*grpc.Server) credentials.TransportCredentials
+	// MetricsRecorderForServer returns the MetricsRecorderList derived from a
+	// servers stats handlers.
+	MetricsRecorderForServer any // func (*grpc.Server) estats.MetricsRecorder
 	// CanonicalString returns the canonical string of the code defined here:
 	// https://github.com/grpc/grpc/blob/master/doc/statuscodes.md.
 	//

--- a/internal/stats/metrics_recorder_list.go
+++ b/internal/stats/metrics_recorder_list.go
@@ -103,22 +103,3 @@ func (l *MetricsRecorderList) RecordInt64Gauge(handle *estats.Int64GaugeHandle, 
 		metricRecorder.RecordInt64Gauge(handle, incr, labels...)
 	}
 }
-
-// NoopMetricsRecorder is a noop MetricsRecorder to be used to prevent nil
-// panics.
-type NoopMetricsRecorder struct{}
-
-// RecordInt64Count is a noop implementation of RecordInt64Count.
-func (r *NoopMetricsRecorder) RecordInt64Count(*estats.Int64CountHandle, int64, ...string) {}
-
-// RecordFloat64Count is a noop implementation of RecordFloat64Count.
-func (r *NoopMetricsRecorder) RecordFloat64Count(*estats.Float64CountHandle, float64, ...string) {}
-
-// RecordInt64Histo is a noop implementation of RecordInt64Histo.
-func (r *NoopMetricsRecorder) RecordInt64Histo(*estats.Int64HistoHandle, int64, ...string) {}
-
-// RecordFloat64Histo is a noop implementation of RecordFloat64Histo.
-func (r *NoopMetricsRecorder) RecordFloat64Histo(*estats.Float64HistoHandle, float64, ...string) {}
-
-// RecordInt64Gauge is a noop implementation of RecordInt64Gauge.
-func (r *NoopMetricsRecorder) RecordInt64Gauge(*estats.Int64GaugeHandle, int64, ...string) {}

--- a/internal/stats/metrics_recorder_list.go
+++ b/internal/stats/metrics_recorder_list.go
@@ -103,3 +103,22 @@ func (l *MetricsRecorderList) RecordInt64Gauge(handle *estats.Int64GaugeHandle, 
 		metricRecorder.RecordInt64Gauge(handle, incr, labels...)
 	}
 }
+
+// NoopMetricsRecorder is a noop MetricsRecorder to be used to prevent nil
+// panics.
+type NoopMetricsRecorder struct{}
+
+// RecordInt64Count is a noop implementation of RecordInt64Count.
+func (r *NoopMetricsRecorder) RecordInt64Count(*estats.Int64CountHandle, int64, ...string) {}
+
+// RecordFloat64Count is a noop implementation of RecordFloat64Count.
+func (r *NoopMetricsRecorder) RecordFloat64Count(*estats.Float64CountHandle, float64, ...string) {}
+
+// RecordInt64Histo is a noop implementation of RecordInt64Histo.
+func (r *NoopMetricsRecorder) RecordInt64Histo(*estats.Int64HistoHandle, int64, ...string) {}
+
+// RecordFloat64Histo is a noop implementation of RecordFloat64Histo.
+func (r *NoopMetricsRecorder) RecordFloat64Histo(*estats.Float64HistoHandle, float64, ...string) {}
+
+// RecordInt64Gauge is a noop implementation of RecordInt64Gauge.
+func (r *NoopMetricsRecorder) RecordInt64Gauge(*estats.Int64GaugeHandle, int64, ...string) {}

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -30,6 +30,7 @@ import (
 
 	"google.golang.org/grpc/attributes"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/experimental/stats"
 	"google.golang.org/grpc/internal"
 	"google.golang.org/grpc/serviceconfig"
 )
@@ -175,6 +176,8 @@ type BuildOptions struct {
 	// Authority is the effective authority of the clientconn for which the
 	// resolver is built.
 	Authority string
+	// MetricsRecorder is the metrics recorder to do recording.
+	MetricsRecorder stats.MetricsRecorder
 }
 
 // An Endpoint is one network endpoint, or server, which may have multiple

--- a/resolver_wrapper.go
+++ b/resolver_wrapper.go
@@ -77,6 +77,7 @@ func (ccr *ccResolverWrapper) start() error {
 			CredsBundle:          ccr.cc.dopts.copts.CredsBundle,
 			Dialer:               ccr.cc.dopts.copts.Dialer,
 			Authority:            ccr.cc.authority,
+			MetricsRecorder:      ccr.cc.metricsRecorderList,
 		}
 		var err error
 		// The delegating resolver is used unless:

--- a/server.go
+++ b/server.go
@@ -37,12 +37,14 @@ import (
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/encoding"
 	"google.golang.org/grpc/encoding/proto"
+	estats "google.golang.org/grpc/experimental/stats"
 	"google.golang.org/grpc/grpclog"
 	"google.golang.org/grpc/internal"
 	"google.golang.org/grpc/internal/binarylog"
 	"google.golang.org/grpc/internal/channelz"
 	"google.golang.org/grpc/internal/grpcsync"
 	"google.golang.org/grpc/internal/grpcutil"
+	istats "google.golang.org/grpc/internal/stats"
 	"google.golang.org/grpc/internal/transport"
 	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/mem"
@@ -82,6 +84,9 @@ func init() {
 	internal.BinaryLogger = binaryLogger
 	internal.JoinServerOptions = newJoinServerOption
 	internal.BufferPool = bufferPool
+	internal.MetricsRecorderForServer = func(srv *Server) estats.MetricsRecorder {
+		return istats.NewMetricsRecorderList(srv.opts.statsHandlers)
+	}
 }
 
 var statusOK = status.New(codes.OK, "")

--- a/xds/internal/resolver/internal/internal.go
+++ b/xds/internal/resolver/internal/internal.go
@@ -26,5 +26,5 @@ var (
 	NewWRR any // func() wrr.WRR
 
 	// NewXDSClient is the function used to create a new xDS client.
-	NewXDSClient any // func(string) (xdsclient.XDSClient, func(), error)
+	NewXDSClient any // func(string, estats.MetricsRecorder) (xdsclient.XDSClient, func(), error)
 )

--- a/xds/internal/resolver/xds_resolver.go
+++ b/xds/internal/resolver/xds_resolver.go
@@ -25,6 +25,7 @@ import (
 	rand "math/rand/v2"
 	"sync/atomic"
 
+	estats "google.golang.org/grpc/experimental/stats"
 	"google.golang.org/grpc/internal"
 	"google.golang.org/grpc/internal/grpclog"
 	"google.golang.org/grpc/internal/grpcsync"
@@ -50,13 +51,16 @@ const Scheme = "xds"
 // the provided config and a new xDS client in that pool.
 func newBuilderWithConfigForTesting(config []byte) (resolver.Builder, error) {
 	return &xdsResolverBuilder{
-		newXDSClient: func(name string) (xdsclient.XDSClient, func(), error) {
+		newXDSClient: func(name string, mr estats.MetricsRecorder) (xdsclient.XDSClient, func(), error) {
 			config, err := bootstrap.NewConfigFromContents(config)
 			if err != nil {
 				return nil, nil, err
 			}
 			pool := xdsclient.NewPool(config)
-			return pool.NewClientForTesting(xdsclient.OptionsForTesting{Name: name})
+			return pool.NewClientForTesting(xdsclient.OptionsForTesting{
+				Name:            name,
+				MetricsRecorder: mr,
+			})
 		},
 	}, nil
 }
@@ -66,8 +70,11 @@ func newBuilderWithConfigForTesting(config []byte) (resolver.Builder, error) {
 // specific xds client pool being used.
 func newBuilderWithPoolForTesting(pool *xdsclient.Pool) (resolver.Builder, error) {
 	return &xdsResolverBuilder{
-		newXDSClient: func(name string) (xdsclient.XDSClient, func(), error) {
-			return pool.NewClientForTesting(xdsclient.OptionsForTesting{Name: name})
+		newXDSClient: func(name string, mr estats.MetricsRecorder) (xdsclient.XDSClient, func(), error) {
+			return pool.NewClientForTesting(xdsclient.OptionsForTesting{
+				Name:            name,
+				MetricsRecorder: mr,
+			})
 		},
 	}, nil
 }
@@ -82,7 +89,7 @@ func init() {
 }
 
 type xdsResolverBuilder struct {
-	newXDSClient func(string) (xdsclient.XDSClient, func(), error)
+	newXDSClient func(string, estats.MetricsRecorder) (xdsclient.XDSClient, func(), error)
 }
 
 // Build helps implement the resolver.Builder interface.
@@ -115,11 +122,11 @@ func (b *xdsResolverBuilder) Build(target resolver.Target, cc resolver.ClientCon
 	r.serializerCancel = cancel
 
 	// Initialize the xDS client.
-	newXDSClient := rinternal.NewXDSClient.(func(string) (xdsclient.XDSClient, func(), error))
+	newXDSClient := rinternal.NewXDSClient.(func(string, estats.MetricsRecorder) (xdsclient.XDSClient, func(), error))
 	if b.newXDSClient != nil {
 		newXDSClient = b.newXDSClient
 	}
-	client, closeFn, err := newXDSClient(target.String())
+	client, closeFn, err := newXDSClient(target.String(), opts.MetricsRecorder)
 	if err != nil {
 		return nil, fmt.Errorf("xds: failed to create xds-client: %v", err)
 	}

--- a/xds/internal/resolver/xds_resolver_test.go
+++ b/xds/internal/resolver/xds_resolver_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
 	"google.golang.org/grpc/codes"
+	estats "google.golang.org/grpc/experimental/stats"
 	"google.golang.org/grpc/internal"
 	iresolver "google.golang.org/grpc/internal/resolver"
 	"google.golang.org/grpc/internal/testutils"
@@ -257,7 +258,7 @@ func (s) TestResolverCloseClosesXDSClient(t *testing.T) {
 	// client is closed.
 	origNewClient := rinternal.NewXDSClient
 	closeCh := make(chan struct{})
-	rinternal.NewXDSClient = func(string) (xdsclient.XDSClient, func(), error) {
+	rinternal.NewXDSClient = func(string, estats.MetricsRecorder) (xdsclient.XDSClient, func(), error) {
 		bc := e2e.DefaultBootstrapContents(t, uuid.New().String(), "dummy-management-server-address")
 		config, err := bootstrap.NewConfigFromContents(bc)
 		if err != nil {

--- a/xds/internal/xdsclient/client_refcounted_test.go
+++ b/xds/internal/xdsclient/client_refcounted_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/google/uuid"
 	"google.golang.org/grpc/internal/testutils"
+	"google.golang.org/grpc/internal/testutils/stats"
 	"google.golang.org/grpc/internal/testutils/xds/e2e"
 	"google.golang.org/grpc/internal/xds/bootstrap"
 )
@@ -60,7 +61,7 @@ func (s) TestClientNew_Single(t *testing.T) {
 	defer func() { xdsClientImplCloseHook = origClientImplCloseHook }()
 
 	// The first call to New() should create a new client.
-	_, closeFunc, err := pool.NewClient(t.Name())
+	_, closeFunc, err := pool.NewClient(t.Name(), &stats.NoopMetricsRecorder{})
 	if err != nil {
 		t.Fatalf("Failed to create xDS client: %v", err)
 	}
@@ -76,7 +77,7 @@ func (s) TestClientNew_Single(t *testing.T) {
 	closeFuncs := make([]func(), count)
 	for i := 0; i < count; i++ {
 		func() {
-			_, closeFuncs[i], err = pool.NewClient(t.Name())
+			_, closeFuncs[i], err = pool.NewClient(t.Name(), &stats.NoopMetricsRecorder{})
 			if err != nil {
 				t.Fatalf("%d-th call to New() failed with error: %v", i, err)
 			}
@@ -114,7 +115,7 @@ func (s) TestClientNew_Single(t *testing.T) {
 
 	// Calling New() again, after the previous Client was actually closed,
 	// should create a new one.
-	_, closeFunc, err = pool.NewClient(t.Name())
+	_, closeFunc, err = pool.NewClient(t.Name(), &stats.NoopMetricsRecorder{})
 	if err != nil {
 		t.Fatalf("Failed to create xDS client: %v", err)
 	}
@@ -156,7 +157,7 @@ func (s) TestClientNew_Multiple(t *testing.T) {
 
 	// Create two xDS clients.
 	client1Name := t.Name() + "-1"
-	_, closeFunc1, err := pool.NewClient(client1Name)
+	_, closeFunc1, err := pool.NewClient(client1Name, &stats.NoopMetricsRecorder{})
 	if err != nil {
 		t.Fatalf("Failed to create xDS client: %v", err)
 	}
@@ -171,7 +172,7 @@ func (s) TestClientNew_Multiple(t *testing.T) {
 	}
 
 	client2Name := t.Name() + "-2"
-	_, closeFunc2, err := pool.NewClient(client2Name)
+	_, closeFunc2, err := pool.NewClient(client2Name, &stats.NoopMetricsRecorder{})
 	if err != nil {
 		t.Fatalf("Failed to create xDS client: %v", err)
 	}
@@ -193,7 +194,7 @@ func (s) TestClientNew_Multiple(t *testing.T) {
 		defer wg.Done()
 		for i := 0; i < count; i++ {
 			var err error
-			_, closeFuncs1[i], err = pool.NewClient(client1Name)
+			_, closeFuncs1[i], err = pool.NewClient(client1Name, &stats.NoopMetricsRecorder{})
 			if err != nil {
 				t.Errorf("%d-th call to New() failed with error: %v", i, err)
 			}
@@ -203,7 +204,7 @@ func (s) TestClientNew_Multiple(t *testing.T) {
 		defer wg.Done()
 		for i := 0; i < count; i++ {
 			var err error
-			_, closeFuncs2[i], err = pool.NewClient(client2Name)
+			_, closeFuncs2[i], err = pool.NewClient(client2Name, &stats.NoopMetricsRecorder{})
 			if err != nil {
 				t.Errorf("%d-th call to New() failed with error: %v", i, err)
 			}

--- a/xds/internal/xdsclient/clientimpl.go
+++ b/xds/internal/xdsclient/clientimpl.go
@@ -61,6 +61,21 @@ var (
 	xdsClientImplCloseHook  = func(string) {}
 
 	defaultExponentialBackoff = backoff.DefaultExponential.Backoff
+
+	xdsClientResourceUpdatesValidMetric = estats.RegisterInt64Count(estats.MetricDescriptor{
+		Name:        "grpc.xds_client.resource_updates_valid",
+		Description: "A counter of resources received that were considered valid. The counter will be incremented even for resources that have not changed.",
+		Unit:        "resource",
+		Labels:      []string{"grpc.target", "grpc.xds.server", "grpc.xds.resource_type"},
+		Default:     false,
+	})
+	xdsClientResourceUpdatesInvalidMetric = estats.RegisterInt64Count(estats.MetricDescriptor{
+		Name:        "grpc.xds_client.resource_updates_invalid",
+		Description: "A counter of resources received that were considered invalid.",
+		Unit:        "resource",
+		Labels:      []string{"grpc.target", "grpc.xds.server", "grpc.xds.resource_type"},
+		Default:     false,
+	})
 )
 
 // clientImpl is the real implementation of the xDS client. The exported Client

--- a/xds/internal/xdsclient/metrics_test.go
+++ b/xds/internal/xdsclient/metrics_test.go
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2024 gRPC authors.
+ * Copyright 2025 gRPC authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,9 +48,9 @@ func (noopListenerWatcher) OnResourceDoesNotExist(onDone xdsresource.OnDoneFunc)
 	onDone()
 }
 
-// TestResourceUpdateMetrics tests resource update metrics. It configures an xDS
-// Client and provides a valid and invalid LDS update, and verifies the valid
-// and invalid metrics emitted from them.
+// TestResourceUpdateMetrics configures an xDS Client and provides a valid and
+// invalid LDS update, and verifies the valid and invalid metrics emitted from
+// them.
 func (s) TestResourceUpdateMetrics(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()

--- a/xds/internal/xdsclient/metrics_test.go
+++ b/xds/internal/xdsclient/metrics_test.go
@@ -1,0 +1,149 @@
+/*
+ *
+ * Copyright 2024 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package xdsclient
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/google/uuid"
+	"google.golang.org/grpc/internal/testutils"
+	"google.golang.org/grpc/internal/testutils/stats"
+	"google.golang.org/grpc/internal/testutils/xds/e2e"
+	"google.golang.org/grpc/internal/xds/bootstrap"
+	"google.golang.org/grpc/xds/internal/xdsclient/xdsresource"
+
+	v3listenerpb "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+)
+
+type noopListenerWatcher struct{}
+
+func (noopListenerWatcher) OnUpdate(_ *xdsresource.ListenerResourceData, onDone xdsresource.OnDoneFunc) {
+	onDone()
+}
+
+func (noopListenerWatcher) OnError(_ error, onDone xdsresource.OnDoneFunc) {
+	onDone()
+}
+
+func (noopListenerWatcher) OnResourceDoesNotExist(onDone xdsresource.OnDoneFunc) {
+	onDone()
+}
+
+// TestResourceUpdateMetrics tests resource update metrics. It configures an xDS
+// Client and provides a valid and invalid LDS update, and verifies the valid
+// and invalid metrics emitted from them.
+func (s) TestResourceUpdateMetrics(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+
+	tmr := stats.NewTestMetricsRecorder()
+	l, err := testutils.LocalTCPListener()
+	if err != nil {
+		t.Fatalf("net.Listen() failed: %v", err)
+	}
+
+	mgmtServer := e2e.StartManagementServer(t, e2e.ManagementServerOptions{Listener: l})
+	const listenerResourceName = "test-listener-resource"
+	const routeConfigurationName = "test-route-configuration-resource"
+	nodeID := uuid.New().String()
+	resources := e2e.UpdateOptions{
+		NodeID:         nodeID,
+		Listeners:      []*v3listenerpb.Listener{e2e.DefaultClientListener(listenerResourceName, routeConfigurationName)},
+		SkipValidation: true,
+	}
+	if err := mgmtServer.Update(ctx, resources); err != nil {
+		t.Fatalf("Failed to update management server with resources: %v, err: %v", resources, err)
+	}
+
+	bootstrapContents, err := bootstrap.NewContentsForTesting(bootstrap.ConfigOptionsForTesting{
+		Servers: []byte(fmt.Sprintf(`[{
+			"server_uri": %q,
+			"channel_creds": [{"type": "insecure"}]
+		}]`, mgmtServer.Address)),
+		Node: []byte(fmt.Sprintf(`{"id": "%s"}`, nodeID)),
+		Authorities: map[string]json.RawMessage{
+			"authority": []byte("{}"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("Failed to create bootstrap configuration: %v", err)
+	}
+	// Create an xDS client for use by the cluster_resolver LB policy.
+	config, err := bootstrap.NewConfigFromContents(bootstrapContents)
+	if err != nil {
+		t.Fatalf("Failed to parse bootstrap contents: %s, %v", string(bootstrapContents), err)
+	}
+	pool := NewPool(config)
+	client, close, err := pool.NewClientForTesting(OptionsForTesting{
+		Name:               t.Name(),
+		WatchExpiryTimeout: defaultTestWatchExpiryTimeout,
+		MetricsRecorder:    tmr,
+	})
+	if err != nil {
+		t.Fatalf("Failed to create an xDS client: %v", err)
+	}
+	defer close()
+
+	// Watch the valid listener configured on the management server. This should
+	// cause a resource updates valid count to emit eventually.
+	xdsresource.WatchListener(client, listenerResourceName, noopListenerWatcher{})
+	mdWant := stats.MetricsData{
+		Handle:    xdsClientResourceUpdatesValidMetric.Descriptor(),
+		IntIncr:   1,
+		LabelKeys: []string{"grpc.target", "grpc.xds.server", "grpc.xds.resource_type"},
+		LabelVals: []string{"Test/ResourceUpdateMetrics", mgmtServer.Address, "ListenerResource"},
+	}
+	if err := tmr.WaitForInt64Count(ctx, mdWant); err != nil {
+		t.Fatal(err.Error())
+	}
+	// Invalid should have no recording point.
+	if got, _ := tmr.Metric("grpc.xds_client.resource_updates_invalid"); got != 0 {
+		t.Fatalf("Unexpected data for metric \"grpc.xds_client.resource_updates_invalid\", got: %v, want: %v", got, 0)
+	}
+
+	// Update management server with a bad update. Eventually, tmr should
+	// receive an invalid count received metric. The successful metric should
+	// stay the same.
+	resources = e2e.UpdateOptions{
+		NodeID:         nodeID,
+		Listeners:      []*v3listenerpb.Listener{e2e.DefaultClientListener(listenerResourceName, routeConfigurationName)},
+		SkipValidation: true,
+	}
+	resources.Listeners[0].ApiListener = nil
+	if err := mgmtServer.Update(ctx, resources); err != nil {
+		t.Fatalf("Failed to update management server with resources: %v, err: %v", resources, err)
+	}
+
+	mdWant = stats.MetricsData{
+		Handle:    xdsClientResourceUpdatesInvalidMetric.Descriptor(),
+		IntIncr:   1,
+		LabelKeys: []string{"grpc.target", "grpc.xds.server", "grpc.xds.resource_type"},
+		LabelVals: []string{"Test/ResourceUpdateMetrics", mgmtServer.Address, "ListenerResource"},
+	}
+	if err := tmr.WaitForInt64Count(ctx, mdWant); err != nil {
+		t.Fatal(err.Error())
+	}
+	// Valid should stay the same at 1.
+	if got, _ := tmr.Metric("grpc.xds_client.resource_updates_valid"); got != 1 {
+		t.Fatalf("Unexpected data for metric \"grpc.xds_client.resource_updates_invalid\", got: %v, want: %v", got, 1)
+	}
+}

--- a/xds/internal/xdsclient/metrics_test.go
+++ b/xds/internal/xdsclient/metrics_test.go
@@ -48,9 +48,9 @@ func (noopListenerWatcher) OnResourceDoesNotExist(onDone xdsresource.OnDoneFunc)
 	onDone()
 }
 
-// TestResourceUpdateMetrics configures an xDS Client and provides a valid and
-// invalid LDS update, and verifies the valid and invalid metrics emitted from
-// them.
+// TestResourceUpdateMetrics configures an xDS client, and a management server
+// to send valid and invalid LDS updates, and verifies that the expected metrics
+// for both good and bad updates are emitted.
 func (s) TestResourceUpdateMetrics(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
@@ -87,7 +87,7 @@ func (s) TestResourceUpdateMetrics(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create bootstrap configuration: %v", err)
 	}
-	// Create an xDS client for use by the cluster_resolver LB policy.
+
 	config, err := bootstrap.NewConfigFromContents(bootstrapContents)
 	if err != nil {
 		t.Fatalf("Failed to parse bootstrap contents: %s, %v", string(bootstrapContents), err)

--- a/xds/internal/xdsclient/pool.go
+++ b/xds/internal/xdsclient/pool.go
@@ -128,7 +128,7 @@ func (p *Pool) NewClientForTesting(opts OptionsForTesting) (XDSClient, func(), e
 		opts.StreamBackoffAfterFailure = defaultExponentialBackoff
 	}
 	if opts.MetricsRecorder == nil {
-		opts.MetricsRecorder = &istats.NoopMetricsRecorder{}
+		opts.MetricsRecorder = istats.NewMetricsRecorderList(nil)
 	}
 	return p.newRefCounted(opts.Name, opts.WatchExpiryTimeout, opts.StreamBackoffAfterFailure, opts.MetricsRecorder)
 }

--- a/xds/internal/xdsclient/pool.go
+++ b/xds/internal/xdsclient/pool.go
@@ -33,21 +33,7 @@ import (
 var (
 	// DefaultPool is the default pool for xDS clients. It is created at init
 	// time by reading bootstrap configuration from env vars.
-	DefaultPool                         *Pool
-	xdsClientResourceUpdatesValidMetric = estats.RegisterInt64Count(estats.MetricDescriptor{
-		Name:        "grpc.xds_client.resource_updates_valid",
-		Description: "A counter of resources received that were considered valid. The counter will be incremented even for resources that have not changed.",
-		Unit:        "resource",
-		Labels:      []string{"grpc.target", "grpc.xds.server", "grpc.xds.resource_type"},
-		Default:     false,
-	})
-	xdsClientResourceUpdatesInvalidMetric = estats.RegisterInt64Count(estats.MetricDescriptor{
-		Name:        "grpc.xds_client.resource_updates_invalid",
-		Description: "A counter of resources received that were considered invalid.",
-		Unit:        "resource",
-		Labels:      []string{"grpc.target", "grpc.xds.server", "grpc.xds.resource_type"},
-		Default:     false,
-	})
+	DefaultPool *Pool
 )
 
 // Pool represents a pool of xDS clients that share the same bootstrap


### PR DESCRIPTION
This PR adds counter metrics for the xDS Client, and unit tests. E2E tests still need to be written.

The gauge metrics are blocked on adding support for asynchronous gauges, and we also should move our synchronous gauges in RLS to asynchronous.

RELEASE NOTES:
* xds/internal/xdsclient: Add counter metrics for valid and invalid resource updates