### PR TITLE
xds: log bootstrap config missing warning from env var only when debugging

### DIFF
--- a/xds/internal/xdsclient/clientimpl.go
+++ b/xds/internal/xdsclient/clientimpl.go
@@ -101,7 +101,9 @@ func init() {
 	// attempting to create an xDS client, else xDS client creation will fail.
 	config, err := bootstrap.GetConfiguration()
 	if err != nil {
-		logger.Warningf("Failed to read xDS bootstrap config from env vars:  %v", err)
+		if logger.V(2) {
+			logger.Warningf("Failed to read xDS bootstrap config from env vars:  %v", err)
+		}
 		DefaultPool = &Pool{clients: make(map[string]*clientRefCounted)}
 		return
 	}

--- a/xds/internal/xdsclient/clientimpl.go
+++ b/xds/internal/xdsclient/clientimpl.go
@@ -102,7 +102,7 @@ func init() {
 	config, err := bootstrap.GetConfiguration()
 	if err != nil {
 		if logger.V(2) {
-			logger.Warningf("Failed to read xDS bootstrap config from env vars:  %v", err)
+			logger.Infof("Failed to read xDS bootstrap config from env vars:  %v", err)
 		}
 		DefaultPool = &Pool{clients: make(map[string]*clientRefCounted)}
 		return


### PR DESCRIPTION
One of the test in google3 doesn't expect any error/warning logs. So, adding this workaround to log bootstrap config missing warning from env error only when debugging. At the time of creating the xds client, the error will anyway be returned if config wasn't provided to the xDS client pool.

RELEASE NOTES: None