### PR TITLE
cleanup: fix new vet errors

### DIFF
--- a/security/advancedtls/advancedtls_integration_test.go
+++ b/security/advancedtls/advancedtls_integration_test.go
@@ -264,7 +264,7 @@ func (s) TestEnd2End(t *testing.T) {
 				}
 				cert, err := x509.ParseCertificate(params.RawCerts[0])
 				if err != nil || cert == nil {
-					return nil, fmt.Errorf("failed to parse certificate: " + err.Error())
+					return nil, fmt.Errorf("failed to parse certificate: %v", err)
 				}
 				authzCheck := false
 				switch stage.read() {


### PR DESCRIPTION
A pre-release version of `vet -all` on my system is running into this, so I thought I'd fix it before the actual release occurs.  This is the only instance.

RELEASE NOTES: none