### PR TITLE
outlierdetection: Support ejection of endpoints 

### DIFF
--- a/xds/internal/balancer/outlierdetection/balancer.go
+++ b/xds/internal/balancer/outlierdetection/balancer.go
@@ -65,10 +65,11 @@ func (bb) Build(cc balancer.ClientConn, bOpts balancer.BuildOptions) balancer.Ba
 		cc:             cc,
 		closed:         grpcsync.NewEvent(),
 		done:           grpcsync.NewEvent(),
-		addrs:          make(map[string]*addressInfo),
+		addrs:          make(map[string]*endpointInfo),
 		scUpdateCh:     buffer.NewUnbounded(),
 		pickerUpdateCh: buffer.NewUnbounded(),
 		channelzParent: bOpts.ChannelzParent,
+		endpoints:      resolver.NewEndpointMap(),
 	}
 	b.logger = prefixLogger(b)
 	b.logger.Infof("Created")
@@ -187,21 +188,25 @@ type outlierDetectionBalancer struct {
 	// balancer will wait for the interval timer algorithm to finish before
 	// persisting the new configuration.
 	//
-	// Another example would be the updating of the addrs map, such as from a
-	// SubConn address update in the middle of the interval timer algorithm
-	// which uses addrs. This balancer waits for the interval timer algorithm to
-	// finish before making the update to the addrs map.
+	// Another example would be the updating of the endpoints or addrs map, such
+	// as from a SubConn address update in the middle of the interval timer
+	// algorithm which uses endpoints. This balancer waits for the interval
+	// timer algorithm to finish before making the update to the endpoints map.
 	//
 	// This mutex is never held when calling methods on the child policy
 	// (within the context of a single goroutine).
-	mu                    sync.Mutex
-	addrs                 map[string]*addressInfo
+	mu sync.Mutex
+	// endpoints stores pointers to endpointInfo objects for each endpoint.
+	endpoints *resolver.EndpointMap // endpoint -> endpointInfo
+	// addrs stores pointers to endpointInfo objects for each address. Addresses
+	// belonging to the same endpoint point to the same object.
+	addrs                 map[string]*endpointInfo
 	cfg                   *LBConfig
 	timerStartTime        time.Time
 	intervalTimer         *time.Timer
 	inhibitPickerUpdates  bool
 	updateUnconditionally bool
-	numAddrsEjected       int // For fast calculations of percentage of addrs ejected
+	numEndpointsEjected   int // For fast calculations of percentage of endpoints ejected
 
 	scUpdateCh     *buffer.Unbounded
 	pickerUpdateCh *buffer.Unbounded
@@ -225,8 +230,9 @@ func (b *outlierDetectionBalancer) onIntervalConfig() {
 	var interval time.Duration
 	if b.timerStartTime.IsZero() {
 		b.timerStartTime = time.Now()
-		for _, addrInfo := range b.addrs {
-			addrInfo.callCounter.clear()
+		for _, val := range b.endpoints.Values() {
+			epInfo := val.(*endpointInfo)
+			epInfo.callCounter.clear()
 		}
 		interval = time.Duration(b.cfg.Interval)
 	} else {
@@ -248,13 +254,14 @@ func (b *outlierDetectionBalancer) onNoopConfig() {
 	// do the following:"
 	// "Unset the timer start timestamp."
 	b.timerStartTime = time.Time{}
-	for _, addrInfo := range b.addrs {
-		// "Uneject all currently ejected addresses."
-		if !addrInfo.latestEjectionTimestamp.IsZero() {
-			b.unejectAddress(addrInfo)
+	for _, val := range b.endpoints.Values() {
+		epInfo := val.(*endpointInfo)
+		// "Uneject all currently ejected endpoints."
+		if !epInfo.latestEjectionTimestamp.IsZero() {
+			b.unejectEndpoint(epInfo)
 		}
-		// "Reset each address's ejection time multiplier to 0."
-		addrInfo.ejectionTimeMultiplier = 0
+		// "Reset each endpoint's ejection time multiplier to 0."
+		epInfo.ejectionTimeMultiplier = 0
 	}
 }
 
@@ -292,16 +299,31 @@ func (b *outlierDetectionBalancer) UpdateClientConnState(s balancer.ClientConnSt
 	b.updateUnconditionally = false
 	b.cfg = lbCfg
 
-	addrs := make(map[string]bool, len(s.ResolverState.Addresses))
-	for _, addr := range s.ResolverState.Addresses {
-		addrs[addr.Addr] = true
-		if _, ok := b.addrs[addr.Addr]; !ok {
-			b.addrs[addr.Addr] = newAddressInfo()
+	newEndpoints := resolver.NewEndpointMap()
+	for _, ep := range s.ResolverState.Endpoints {
+		newEndpoints.Set(ep, true)
+		if _, ok := b.endpoints.Get(ep); !ok {
+			b.endpoints.Set(ep, newEndpointInfo())
 		}
 	}
-	for addr := range b.addrs {
-		if !addrs[addr] {
-			delete(b.addrs, addr)
+
+	for _, ep := range b.endpoints.Keys() {
+		if _, ok := newEndpoints.Get(ep); !ok {
+			b.endpoints.Delete(ep)
+		}
+	}
+
+	// populate the addrs map.
+	b.addrs = map[string]*endpointInfo{}
+	for _, ep := range s.ResolverState.Endpoints {
+		val, _ := b.endpoints.Get(ep)
+		epInfo := val.(*endpointInfo)
+		for _, addr := range ep.Addresses {
+			if _, ok := b.addrs[addr.Addr]; ok {
+				b.logger.Errorf("Endpoints contain duplicate endpoint %q", addr.Addr)
+				continue
+			}
+			b.addrs[addr.Addr] = epInfo
 		}
 	}
 
@@ -417,23 +439,23 @@ func incrementCounter(sc balancer.SubConn, info balancer.DoneInfo) {
 		return
 	}
 
-	// scw.addressInfo and callCounter.activeBucket can be written to
+	// scw.endpointInfo and callCounter.activeBucket can be written to
 	// concurrently (the pointers themselves). Thus, protect the reads here with
 	// atomics to prevent data corruption. There exists a race in which you read
-	// the addressInfo or active bucket pointer and then that pointer points to
+	// the endpointInfo or active bucket pointer and then that pointer points to
 	// deprecated memory. If this goroutine yields the processor, in between
-	// reading the addressInfo pointer and writing to the active bucket,
-	// UpdateAddresses can switch the addressInfo the scw points to. Writing to
-	// an outdated addresses is a very small race and tolerable. After reading
+	// reading the endpointInfo pointer and writing to the active bucket,
+	// UpdateAddresses can switch the endpointInfo the scw points to. Writing to
+	// an outdated endpoint is a very small race and tolerable. After reading
 	// callCounter.activeBucket in this picker a swap call can concurrently
 	// change what activeBucket points to. A50 says to swap the pointer, which
 	// will cause this race to write to deprecated memory the interval timer
 	// algorithm will never read, which makes this race alright.
-	addrInfo := (*addressInfo)(atomic.LoadPointer(&scw.addressInfo))
-	if addrInfo == nil {
+	epInfo := (*endpointInfo)(atomic.LoadPointer(&scw.endpointInfo))
+	if epInfo == nil {
 		return
 	}
-	ab := (*bucket)(atomic.LoadPointer(&addrInfo.callCounter.activeBucket))
+	ab := (*bucket)(atomic.LoadPointer(&epInfo.callCounter.activeBucket))
 
 	if info.Err == nil {
 		atomic.AddUint32(&ab.numSuccesses, 1)
@@ -467,13 +489,13 @@ func (b *outlierDetectionBalancer) NewSubConn(addrs []resolver.Address, opts bal
 	if len(addrs) != 1 {
 		return scw, nil
 	}
-	addrInfo, ok := b.addrs[addrs[0].Addr]
+	epInfo, ok := b.addrs[addrs[0].Addr]
 	if !ok {
 		return scw, nil
 	}
-	addrInfo.sws = append(addrInfo.sws, scw)
-	atomic.StorePointer(&scw.addressInfo, unsafe.Pointer(addrInfo))
-	if !addrInfo.latestEjectionTimestamp.IsZero() {
+	epInfo.sws = append(epInfo.sws, scw)
+	atomic.StorePointer(&scw.endpointInfo, unsafe.Pointer(epInfo))
+	if !epInfo.latestEjectionTimestamp.IsZero() {
 		scw.eject()
 	}
 	return scw, nil
@@ -483,34 +505,34 @@ func (b *outlierDetectionBalancer) RemoveSubConn(sc balancer.SubConn) {
 	b.logger.Errorf("RemoveSubConn(%v) called unexpectedly", sc)
 }
 
-// appendIfPresent appends the scw to the address, if the address is present in
+// appendIfPresent appends the scw to the endpoint, if the address is present in
 // the Outlier Detection balancers address map. Returns nil if not present, and
 // the map entry if present.
 //
 // Caller must hold b.mu.
-func (b *outlierDetectionBalancer) appendIfPresent(addr string, scw *subConnWrapper) *addressInfo {
-	addrInfo, ok := b.addrs[addr]
+func (b *outlierDetectionBalancer) appendIfPresent(addr string, scw *subConnWrapper) *endpointInfo {
+	epInfo, ok := b.addrs[addr]
 	if !ok {
 		return nil
 	}
 
-	addrInfo.sws = append(addrInfo.sws, scw)
-	atomic.StorePointer(&scw.addressInfo, unsafe.Pointer(addrInfo))
-	return addrInfo
+	epInfo.sws = append(epInfo.sws, scw)
+	atomic.StorePointer(&scw.endpointInfo, unsafe.Pointer(epInfo))
+	return epInfo
 }
 
-// removeSubConnFromAddressesMapEntry removes the scw from its map entry if
+// removeSubConnFromEndpointMapEntry removes the scw from its map entry if
 // present.
 //
 // Caller must hold b.mu.
-func (b *outlierDetectionBalancer) removeSubConnFromAddressesMapEntry(scw *subConnWrapper) {
-	addrInfo := (*addressInfo)(atomic.LoadPointer(&scw.addressInfo))
-	if addrInfo == nil {
+func (b *outlierDetectionBalancer) removeSubConnFromEndpointMapEntry(scw *subConnWrapper) {
+	epInfo := (*endpointInfo)(atomic.LoadPointer(&scw.endpointInfo))
+	if epInfo == nil {
 		return
 	}
-	for i, sw := range addrInfo.sws {
+	for i, sw := range epInfo.sws {
 		if scw == sw {
-			addrInfo.sws = append(addrInfo.sws[:i], addrInfo.sws[i+1:]...)
+			epInfo.sws = append(epInfo.sws[:i], epInfo.sws[i+1:]...)
 			return
 		}
 	}
@@ -537,27 +559,27 @@ func (b *outlierDetectionBalancer) UpdateAddresses(sc balancer.SubConn, addrs []
 		if scw.addresses[0].Addr == addrs[0].Addr {
 			return
 		}
-		b.removeSubConnFromAddressesMapEntry(scw)
-		addrInfo := b.appendIfPresent(addrs[0].Addr, scw)
-		if addrInfo == nil { // uneject unconditionally because could have come from an ejected address
+		b.removeSubConnFromEndpointMapEntry(scw)
+		endpointInfo := b.appendIfPresent(addrs[0].Addr, scw)
+		if endpointInfo == nil { // uneject unconditionally because could have come from an ejected endpoint
 			scw.uneject()
 			break
 		}
-		if addrInfo.latestEjectionTimestamp.IsZero() { // relay new updated subconn state
+		if endpointInfo.latestEjectionTimestamp.IsZero() { // relay new updated subconn state
 			scw.uneject()
 		} else {
 			scw.eject()
 		}
 	case len(scw.addresses) == 1: // single address to multiple/no addresses
-		b.removeSubConnFromAddressesMapEntry(scw)
-		addrInfo := (*addressInfo)(atomic.LoadPointer(&scw.addressInfo))
+		b.removeSubConnFromEndpointMapEntry(scw)
+		addrInfo := (*endpointInfo)(atomic.LoadPointer(&scw.endpointInfo))
 		if addrInfo != nil {
 			addrInfo.callCounter.clear()
 		}
 		scw.uneject()
 	case len(addrs) == 1: // multiple/no addresses to single address
-		addrInfo := b.appendIfPresent(addrs[0].Addr, scw)
-		if addrInfo != nil && !addrInfo.latestEjectionTimestamp.IsZero() {
+		endpointInfo := b.appendIfPresent(addrs[0].Addr, scw)
+		if endpointInfo != nil && !endpointInfo.latestEjectionTimestamp.IsZero() {
 			scw.eject()
 		}
 	} // otherwise multiple/no addresses to multiple/no addresses; ignore
@@ -684,16 +706,17 @@ func (b *outlierDetectionBalancer) run() {
 	}
 }
 
-// intervalTimerAlgorithm ejects and unejects addresses based on the Outlier
-// Detection configuration and data about each address from the previous
+// intervalTimerAlgorithm ejects and unejects endpoints based on the Outlier
+// Detection configuration and data about each endpoint from the previous
 // interval.
 func (b *outlierDetectionBalancer) intervalTimerAlgorithm() {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	b.timerStartTime = time.Now()
 
-	for _, addrInfo := range b.addrs {
-		addrInfo.callCounter.swap()
+	for _, val := range b.endpoints.Values() {
+		epInfo := val.(*endpointInfo)
+		epInfo.callCounter.swap()
 	}
 
 	if b.cfg.SuccessRateEjection != nil {
@@ -704,21 +727,22 @@ func (b *outlierDetectionBalancer) intervalTimerAlgorithm() {
 		b.failurePercentageAlgorithm()
 	}
 
-	for _, addrInfo := range b.addrs {
-		if addrInfo.latestEjectionTimestamp.IsZero() && addrInfo.ejectionTimeMultiplier > 0 {
-			addrInfo.ejectionTimeMultiplier--
+	for _, val := range b.endpoints.Values() {
+		epInfo := val.(*endpointInfo)
+		if epInfo.latestEjectionTimestamp.IsZero() && epInfo.ejectionTimeMultiplier > 0 {
+			epInfo.ejectionTimeMultiplier--
 			continue
 		}
-		if addrInfo.latestEjectionTimestamp.IsZero() {
-			// Address is already not ejected, so no need to check for whether
-			// to uneject the address below.
+		if epInfo.latestEjectionTimestamp.IsZero() {
+			// Endpoint is already not ejected, so no need to check for whether
+			// to uneject the endpoint below.
 			continue
 		}
-		et := time.Duration(b.cfg.BaseEjectionTime) * time.Duration(addrInfo.ejectionTimeMultiplier)
+		et := time.Duration(b.cfg.BaseEjectionTime) * time.Duration(epInfo.ejectionTimeMultiplier)
 		met := max(time.Duration(b.cfg.BaseEjectionTime), time.Duration(b.cfg.MaxEjectionTime))
-		uet := addrInfo.latestEjectionTimestamp.Add(min(et, met))
+		uet := epInfo.latestEjectionTimestamp.Add(min(et, met))
 		if now().After(uet) {
-			b.unejectAddress(addrInfo)
+			b.unejectEndpoint(epInfo)
 		}
 	}
 
@@ -730,107 +754,108 @@ func (b *outlierDetectionBalancer) intervalTimerAlgorithm() {
 	b.intervalTimer = afterFunc(time.Duration(b.cfg.Interval), b.intervalTimerAlgorithm)
 }
 
-// addrsWithAtLeastRequestVolume returns a slice of address information of all
-// addresses with at least request volume passed in.
+// endpointsWithAtLeastRequestVolume returns a slice of endpoin information of all
+// endpoints with at least request volume passed in.
 //
 // Caller must hold b.mu.
-func (b *outlierDetectionBalancer) addrsWithAtLeastRequestVolume(requestVolume uint32) []*addressInfo {
-	var addrs []*addressInfo
-	for _, addrInfo := range b.addrs {
-		bucket := addrInfo.callCounter.inactiveBucket
-		rv := bucket.numSuccesses + bucket.numFailures
+func (b *outlierDetectionBalancer) endpointsWithAtLeastRequestVolume(requestVolume uint32) []*endpointInfo {
+	var endpoints []*endpointInfo
+	for _, val := range b.endpoints.Values() {
+		epInfo := val.(*endpointInfo)
+		bucket1 := epInfo.callCounter.inactiveBucket
+		rv := bucket1.numSuccesses + bucket1.numFailures
 		if rv >= requestVolume {
-			addrs = append(addrs, addrInfo)
+			endpoints = append(endpoints, epInfo)
 		}
 	}
-	return addrs
+	return endpoints
 }
 
 // meanAndStdDev returns the mean and std dev of the fractions of successful
-// requests of the addresses passed in.
+// requests of the endpoints passed in.
 //
 // Caller must hold b.mu.
-func (b *outlierDetectionBalancer) meanAndStdDev(addrs []*addressInfo) (float64, float64) {
+func (b *outlierDetectionBalancer) meanAndStdDev(endpoints []*endpointInfo) (float64, float64) {
 	var totalFractionOfSuccessfulRequests float64
 	var mean float64
-	for _, addrInfo := range addrs {
-		bucket := addrInfo.callCounter.inactiveBucket
+	for _, epInfo := range endpoints {
+		bucket := epInfo.callCounter.inactiveBucket
 		rv := bucket.numSuccesses + bucket.numFailures
 		totalFractionOfSuccessfulRequests += float64(bucket.numSuccesses) / float64(rv)
 	}
-	mean = totalFractionOfSuccessfulRequests / float64(len(addrs))
+	mean = totalFractionOfSuccessfulRequests / float64(len(endpoints))
 	var sumOfSquares float64
-	for _, addrInfo := range addrs {
-		bucket := addrInfo.callCounter.inactiveBucket
+	for _, epInfo := range endpoints {
+		bucket := epInfo.callCounter.inactiveBucket
 		rv := bucket.numSuccesses + bucket.numFailures
 		devFromMean := (float64(bucket.numSuccesses) / float64(rv)) - mean
 		sumOfSquares += devFromMean * devFromMean
 	}
-	variance := sumOfSquares / float64(len(addrs))
+	variance := sumOfSquares / float64(len(endpoints))
 	return mean, math.Sqrt(variance)
 }
 
-// successRateAlgorithm ejects any addresses where the success rate falls below
-// the other addresses according to mean and standard deviation, and if overall
+// successRateAlgorithm ejects any endpoints where the success rate falls below
+// the other endpoints according to mean and standard deviation, and if overall
 // applicable from other set heuristics.
 //
 // Caller must hold b.mu.
 func (b *outlierDetectionBalancer) successRateAlgorithm() {
-	addrsToConsider := b.addrsWithAtLeastRequestVolume(b.cfg.SuccessRateEjection.RequestVolume)
-	if len(addrsToConsider) < int(b.cfg.SuccessRateEjection.MinimumHosts) {
+	endpointsToConsider := b.endpointsWithAtLeastRequestVolume(b.cfg.SuccessRateEjection.RequestVolume)
+	if len(endpointsToConsider) < int(b.cfg.SuccessRateEjection.MinimumHosts) {
 		return
 	}
-	mean, stddev := b.meanAndStdDev(addrsToConsider)
-	for _, addrInfo := range addrsToConsider {
-		bucket := addrInfo.callCounter.inactiveBucket
+	mean, stddev := b.meanAndStdDev(endpointsToConsider)
+	for _, epInfo := range endpointsToConsider {
+		bucket := epInfo.callCounter.inactiveBucket
 		ejectionCfg := b.cfg.SuccessRateEjection
-		if float64(b.numAddrsEjected)/float64(len(b.addrs))*100 >= float64(b.cfg.MaxEjectionPercent) {
+		if float64(b.numEndpointsEjected)/float64(b.endpoints.Len())*100 >= float64(b.cfg.MaxEjectionPercent) {
 			return
 		}
 		successRate := float64(bucket.numSuccesses) / float64(bucket.numSuccesses+bucket.numFailures)
 		requiredSuccessRate := mean - stddev*(float64(ejectionCfg.StdevFactor)/1000)
 		if successRate < requiredSuccessRate {
-			channelz.Infof(logger, b.channelzParent, "SuccessRate algorithm detected outlier: %s. Parameters: successRate=%f, mean=%f, stddev=%f, requiredSuccessRate=%f", addrInfo, successRate, mean, stddev, requiredSuccessRate)
+			channelz.Infof(logger, b.channelzParent, "SuccessRate algorithm detected outlier: %s. Parameters: successRate=%f, mean=%f, stddev=%f, requiredSuccessRate=%f", epInfo, successRate, mean, stddev, requiredSuccessRate)
 			if uint32(rand.Int32N(100)) < ejectionCfg.EnforcementPercentage {
-				b.ejectAddress(addrInfo)
+				b.ejectEndpoint(epInfo)
 			}
 		}
 	}
 }
 
-// failurePercentageAlgorithm ejects any addresses where the failure percentage
+// failurePercentageAlgorithm ejects any endpoints where the failure percentage
 // rate exceeds a set enforcement percentage, if overall applicable from other
 // set heuristics.
 //
 // Caller must hold b.mu.
 func (b *outlierDetectionBalancer) failurePercentageAlgorithm() {
-	addrsToConsider := b.addrsWithAtLeastRequestVolume(b.cfg.FailurePercentageEjection.RequestVolume)
-	if len(addrsToConsider) < int(b.cfg.FailurePercentageEjection.MinimumHosts) {
+	endpointsToConsider := b.endpointsWithAtLeastRequestVolume(b.cfg.FailurePercentageEjection.RequestVolume)
+	if len(endpointsToConsider) < int(b.cfg.FailurePercentageEjection.MinimumHosts) {
 		return
 	}
 
-	for _, addrInfo := range addrsToConsider {
-		bucket := addrInfo.callCounter.inactiveBucket
+	for _, epInfo := range endpointsToConsider {
+		bucket := epInfo.callCounter.inactiveBucket
 		ejectionCfg := b.cfg.FailurePercentageEjection
-		if float64(b.numAddrsEjected)/float64(len(b.addrs))*100 >= float64(b.cfg.MaxEjectionPercent) {
+		if float64(b.numEndpointsEjected)/float64(b.endpoints.Len())*100 >= float64(b.cfg.MaxEjectionPercent) {
 			return
 		}
 		failurePercentage := (float64(bucket.numFailures) / float64(bucket.numSuccesses+bucket.numFailures)) * 100
 		if failurePercentage > float64(b.cfg.FailurePercentageEjection.Threshold) {
-			channelz.Infof(logger, b.channelzParent, "FailurePercentage algorithm detected outlier: %s, failurePercentage=%f", addrInfo, failurePercentage)
+			channelz.Infof(logger, b.channelzParent, "FailurePercentage algorithm detected outlier: %s, failurePercentage=%f", epInfo, failurePercentage)
 			if uint32(rand.Int32N(100)) < ejectionCfg.EnforcementPercentage {
-				b.ejectAddress(addrInfo)
+				b.ejectEndpoint(epInfo)
 			}
 		}
 	}
 }
 
 // Caller must hold b.mu.
-func (b *outlierDetectionBalancer) ejectAddress(addrInfo *addressInfo) {
-	b.numAddrsEjected++
-	addrInfo.latestEjectionTimestamp = b.timerStartTime
-	addrInfo.ejectionTimeMultiplier++
-	for _, sbw := range addrInfo.sws {
+func (b *outlierDetectionBalancer) ejectEndpoint(epInfo *endpointInfo) {
+	b.numEndpointsEjected++
+	epInfo.latestEjectionTimestamp = b.timerStartTime
+	epInfo.ejectionTimeMultiplier++
+	for _, sbw := range epInfo.sws {
 		sbw.eject()
 		channelz.Infof(logger, b.channelzParent, "Subchannel ejected: %s", sbw)
 	}
@@ -838,10 +863,10 @@ func (b *outlierDetectionBalancer) ejectAddress(addrInfo *addressInfo) {
 }
 
 // Caller must hold b.mu.
-func (b *outlierDetectionBalancer) unejectAddress(addrInfo *addressInfo) {
-	b.numAddrsEjected--
-	addrInfo.latestEjectionTimestamp = time.Time{}
-	for _, sbw := range addrInfo.sws {
+func (b *outlierDetectionBalancer) unejectEndpoint(epInfo *endpointInfo) {
+	b.numEndpointsEjected--
+	epInfo.latestEjectionTimestamp = time.Time{}
+	for _, sbw := range epInfo.sws {
 		sbw.uneject()
 		channelz.Infof(logger, b.channelzParent, "Subchannel unejected: %s", sbw)
 	}
@@ -910,28 +935,28 @@ func (sbw *synchronizingBalancerWrapper) handleEjectionUpdate(u *ejectionUpdate)
 	}
 }
 
-// addressInfo contains the runtime information about an address that pertains
+// endpointInfo contains the runtime information about an endpoint that pertains
 // to Outlier Detection. This struct and all of its fields is protected by
 // outlierDetectionBalancer.mu in the case where it is accessed through the
-// address map. In the case of Picker callbacks, the writes to the activeBucket
-// of callCounter are protected by atomically loading and storing
+// address or endpoint map. In the case of Picker callbacks, the writes to the
+// activeBucket of callCounter are protected by atomically loading and storing
 // unsafe.Pointers (see further explanation in incrementCounter()).
-type addressInfo struct {
+type endpointInfo struct {
 	// The call result counter object.
 	callCounter *callCounter
 
-	// The latest ejection timestamp, or zero if the address is currently not
+	// The latest ejection timestamp, or zero if the endpoint is currently not
 	// ejected.
 	latestEjectionTimestamp time.Time
 
 	// The current ejection time multiplier, starting at 0.
 	ejectionTimeMultiplier int64
 
-	// A list of subchannel wrapper objects that correspond to this address.
+	// A list of subchannel wrapper objects that correspond to this endpoint.
 	sws []*subConnWrapper
 }
 
-func (a *addressInfo) String() string {
+func (a *endpointInfo) String() string {
 	var res strings.Builder
 	res.WriteString("[")
 	for _, sw := range a.sws {
@@ -941,8 +966,8 @@ func (a *addressInfo) String() string {
 	return res.String()
 }
 
-func newAddressInfo() *addressInfo {
-	return &addressInfo{
+func newEndpointInfo() *endpointInfo {
+	return &endpointInfo{
 		callCounter: newCallCounter(),
 	}
 }

--- a/xds/internal/balancer/outlierdetection/balancer.go
+++ b/xds/internal/balancer/outlierdetection/balancer.go
@@ -754,8 +754,8 @@ func (b *outlierDetectionBalancer) intervalTimerAlgorithm() {
 	b.intervalTimer = afterFunc(time.Duration(b.cfg.Interval), b.intervalTimerAlgorithm)
 }
 
-// endpointsWithAtLeastRequestVolume returns a slice of endpoin information of all
-// endpoints with at least request volume passed in.
+// endpointsWithAtLeastRequestVolume returns a slice of endpoint information of
+// all endpoints with at least request volume passed in.
 //
 // Caller must hold b.mu.
 func (b *outlierDetectionBalancer) endpointsWithAtLeastRequestVolume(requestVolume uint32) []*endpointInfo {

--- a/xds/internal/balancer/outlierdetection/balancer.go
+++ b/xds/internal/balancer/outlierdetection/balancer.go
@@ -319,7 +319,7 @@ func (b *outlierDetectionBalancer) UpdateClientConnState(s balancer.ClientConnSt
 		epInfo := val.(*endpointInfo)
 		for _, addr := range ep.Addresses {
 			if _, ok := b.addrs[addr.Addr]; ok {
-				b.logger.Errorf("Endpoints contain duplicate endpoint %q", addr.Addr)
+				b.logger.Errorf("Endpoints contain duplicate address %q", addr.Addr)
 				continue
 			}
 			b.addrs[addr.Addr] = epInfo

--- a/xds/internal/balancer/outlierdetection/balancer_test.go
+++ b/xds/internal/balancer/outlierdetection/balancer_test.go
@@ -1092,7 +1092,7 @@ func (s) TestEjectUnejectSuccessRate(t *testing.T) {
 
 		// Since no addresses are ejected, a SubConn update should forward down
 		// to the child.
-		od.updateSubConnState(scw1.(*subConnWrapper).SubConn, balancer.SubConnState{
+		od.updateSubConnState(scw1.(*subConnWrapper), balancer.SubConnState{
 			ConnectivityState: connectivity.Connecting,
 		})
 
@@ -1124,6 +1124,9 @@ func (s) TestEjectUnejectSuccessRate(t *testing.T) {
 		if err != nil {
 			t.Fatalf("picker.Pick failed with error: %v", err)
 		}
+		if got, want := pi.SubConn, scw3.(*subConnWrapper).SubConn; got != want {
+			t.Fatalf("Unexpected SubConn chosen by picker: got %v, want %v", got, want)
+		}
 		for c := 0; c < 5; c++ {
 			pi.Done(balancer.DoneInfo{Err: errors.New("some error")})
 		}
@@ -1154,7 +1157,7 @@ func (s) TestEjectUnejectSuccessRate(t *testing.T) {
 		// that address should not be forwarded downward. These SubConn updates
 		// will be cached to update the child sometime in the future when the
 		// address gets unejected.
-		od.updateSubConnState(pi.SubConn, balancer.SubConnState{
+		od.updateSubConnState(scw3.(*subConnWrapper), balancer.SubConnState{
 			ConnectivityState: connectivity.Connecting,
 		})
 		sCtx, cancel = context.WithTimeout(context.Background(), defaultTestShortTimeout)
@@ -1566,7 +1569,7 @@ func (s) TestConcurrentOperations(t *testing.T) {
 
 	// Call balancer.Balancers synchronously in this goroutine, upholding the
 	// balancer.Balancer API guarantee.
-	od.updateSubConnState(scw1.(*subConnWrapper).SubConn, balancer.SubConnState{
+	od.updateSubConnState(scw1.(*subConnWrapper), balancer.SubConnState{
 		ConnectivityState: connectivity.Connecting,
 	})
 	od.ResolverError(errors.New("some error"))

--- a/xds/internal/balancer/outlierdetection/balancer_test.go
+++ b/xds/internal/balancer/outlierdetection/balancer_test.go
@@ -1842,7 +1842,7 @@ func (s) TestMultipleAddressesPerEndpoint(t *testing.T) {
 		t.Fatalf("RPCs didn't go to second address in the second endpoint: %v", err)
 	}
 
-	// Reduce the ejection interval and run the internal algorithm again, it
+	// Reduce the ejection interval and run the interval algorithm again, it
 	// should uneject endpoints[0].
 	odCfg.MaxEjectionTime = 0
 	odCfg.BaseEjectionTime = 0

--- a/xds/internal/balancer/outlierdetection/balancer_test.go
+++ b/xds/internal/balancer/outlierdetection/balancer_test.go
@@ -1680,7 +1680,7 @@ func (s) TestPickFirstHealthListenerDisabled(t *testing.T) {
 // after running the intervalTimerAlgorithm. The test stops the unhealthy
 // backend and verifies that the second backend in the first endpoint is dialed
 // but it doesn't receive requests due to its ejection status. The test stops
-// stops the connected backend in the second endpoint and verifies that requests
+// the connected backend in the second endpoint and verifies that requests
 // start going to the second address in the second endpoint. The test reduces
 // the ejection interval and runs the intervalTimerAlgorithm again. The test
 // verifies that the first endpoint is unejected and requests reach both

--- a/xds/internal/balancer/outlierdetection/callcounter.go
+++ b/xds/internal/balancer/outlierdetection/callcounter.go
@@ -19,7 +19,6 @@ package outlierdetection
 
 import (
 	"sync/atomic"
-	"unsafe"
 )
 
 type bucket struct {
@@ -28,10 +27,11 @@ type bucket struct {
 }
 
 func newCallCounter() *callCounter {
-	return &callCounter{
-		activeBucket:   unsafe.Pointer(&bucket{}),
+	cc := &callCounter{
 		inactiveBucket: &bucket{},
 	}
+	cc.activeBucket.Store(&bucket{})
+	return cc
 }
 
 // callCounter has two buckets, which each count successful and failing RPC's.
@@ -40,14 +40,14 @@ func newCallCounter() *callCounter {
 // use by the Outlier Detection algorithm.
 type callCounter struct {
 	// activeBucket updates every time a call finishes (from picker passed to
-	// Client Conn), so protect pointer read with atomic load of unsafe.Pointer
+	// Client Conn), so protect pointer read with atomic load of the pointer
 	// so picker does not have to grab a mutex per RPC, the critical path.
-	activeBucket   unsafe.Pointer // bucket
+	activeBucket   atomic.Pointer[bucket]
 	inactiveBucket *bucket
 }
 
 func (cc *callCounter) clear() {
-	atomic.StorePointer(&cc.activeBucket, unsafe.Pointer(&bucket{}))
+	cc.activeBucket.Store(&bucket{})
 	cc.inactiveBucket = &bucket{}
 }
 
@@ -58,7 +58,7 @@ func (cc *callCounter) clear() {
 func (cc *callCounter) swap() {
 	ib := cc.inactiveBucket
 	*ib = bucket{}
-	ab := (*bucket)(atomic.SwapPointer(&cc.activeBucket, unsafe.Pointer(ib)))
+	ab := cc.activeBucket.Swap(ib)
 	cc.inactiveBucket = &bucket{
 		numSuccesses: atomic.LoadUint32(&ab.numSuccesses),
 		numFailures:  atomic.LoadUint32(&ab.numFailures),

--- a/xds/internal/balancer/outlierdetection/config.go
+++ b/xds/internal/balancer/outlierdetection/config.go
@@ -171,7 +171,7 @@ type LBConfig struct {
 	// time is equal to the base time multiplied by the number of times the host
 	// has been ejected and is capped by MaxEjectionTime. Defaults to 30s.
 	BaseEjectionTime iserviceconfig.Duration `json:"baseEjectionTime,omitempty"`
-	// MaxEjectionTime is the maximum time that an address is ejected for. If
+	// MaxEjectionTime is the maximum time that an endpoint is ejected for. If
 	// not specified, the default value (300s) or the BaseEjectionTime value is
 	// applied, whichever is larger.
 	MaxEjectionTime iserviceconfig.Duration `json:"maxEjectionTime,omitempty"`

--- a/xds/internal/balancer/outlierdetection/subconn_wrapper.go
+++ b/xds/internal/balancer/outlierdetection/subconn_wrapper.go
@@ -20,7 +20,7 @@ package outlierdetection
 import (
 	"fmt"
 	"sync"
-	"unsafe"
+	"sync/atomic"
 
 	"google.golang.org/grpc/balancer"
 	"google.golang.org/grpc/connectivity"
@@ -35,7 +35,7 @@ type subConnWrapper struct {
 	balancer.SubConn
 	// endpointInfo is a pointer to the subConnWrapper's corresponding endpoint
 	// map entry, if the map entry exists. It is accessed atomically.
-	endpointInfo unsafe.Pointer // *endpointInfo
+	endpointInfo atomic.Pointer[endpointInfo]
 	// The following fields are set during object creation and read-only after
 	// that.
 

--- a/xds/internal/balancer/outlierdetection/subconn_wrapper.go
+++ b/xds/internal/balancer/outlierdetection/subconn_wrapper.go
@@ -33,9 +33,9 @@ import (
 // whether or not this SubConn is ejected.
 type subConnWrapper struct {
 	balancer.SubConn
-	// addressInfo is a pointer to the subConnWrapper's corresponding address
+	// endpointInfo is a pointer to the subConnWrapper's corresponding endpoint
 	// map entry, if the map entry exists. It is accessed atomically.
-	addressInfo unsafe.Pointer // *addressInfo
+	endpointInfo unsafe.Pointer // *endpointInfo
 	// The following fields are set during object creation and read-only after
 	// that.
 


### PR DESCRIPTION
This PR implements changes to the `outlierdetection` balancer mentioned in [A61](https://github.com/grpc/proposal/blob/master/A61-IPv4-IPv6-dualstack-backends.md#outlier-detection). `outlierdetection` is now able to eject endpoints with multiple addresses. 

Additionally this PR also removed the `scWrappers` map stored in the balancer to map `*scWrapper`->`balancer.SubConn` objects. `scWrappers` are passed to the `updateSubConnState` method directly, avoid the need to lookup the map.

RELEASE NOTES:
* outlierdetection: Add support for ejecting endpoints with multiple addresses.