### PR TITLE
interop: Add empty_unary_error, rpc_soak_error test cases

### DIFF
--- a/interop/test_utils.go
+++ b/interop/test_utils.go
@@ -681,6 +681,19 @@ func DoPickFirstUnary(ctx context.Context, tc testgrpc.TestServiceClient) {
 	}
 }
 
+// DoEmptyUnaryError performs a unary RPC with empty request and expects an error with a specific error code
+// and that contains a specific error message.
+func DoEmptyUnaryError(ctx context.Context, tc testgrpc.TestServiceClient, errorCode codes.Code, errorMessage string, args ...grpc.CallOption) {
+	_, err := tc.EmptyCall(ctx, &testpb.Empty{}, args...)
+
+	if status.Code(err) != errorCode {
+		logger.Fatalf("EmptyCall compleled with error code %d, want %d", status.Code(err), errorCode)
+	}
+	if !strings.Contains(err.Error(), errorMessage) {
+		logger.Fatalf("EmptyCall completed with error message %s, want to include %s", err.Error(), errorMessage)
+	}
+}
+
 type testServer struct {
 	testgrpc.UnimplementedTestServiceServer
 


### PR DESCRIPTION
This PR adds two new test cases (`empty_unary_error` and `rpc_soak_error`) to the interop client.
The test cases verify that RPCs end up with status code equal to the `expected_error` provided via flag and the error message contains what is provided via `expecter_error_message_contains` flag.

We need these these cases to verify that the client reacts as expected to the configured failure injection in our test environment. I.e., we configure a failure injection so that RPCs are expected to fail with a specific code and message.

RELEASE NOTES: None