### PR TITLE
endpointsharding, lazy: Remove intermediary gracefulswitch balancers

### DIFF
--- a/balancer/endpointsharding/endpointsharding.go
+++ b/balancer/endpointsharding/endpointsharding.go
@@ -59,14 +59,14 @@ type Options struct {
 	DisableAutoReconnect bool
 }
 
-// childBuilderFunc creates a new balancer with the ClientConn. It has the same
+// ChildBuilderFunc creates a new balancer with the ClientConn. It has the same
 // type as the balancer.Builder.Build method.
-type childBuilderFunc = func(cc balancer.ClientConn, opts balancer.BuildOptions) balancer.Balancer
+type ChildBuilderFunc func(cc balancer.ClientConn, opts balancer.BuildOptions) balancer.Balancer
 
 // NewBalancer returns a load balancing policy that manages homogeneous child
 // policies each owning a single endpoint. The endpointsharding balancer
 // forwards the LoadBalancingConfig in ClientConn state updates to its children.
-func NewBalancer(cc balancer.ClientConn, opts balancer.BuildOptions, childBuilder childBuilderFunc, esOpts Options) balancer.Balancer {
+func NewBalancer(cc balancer.ClientConn, opts balancer.BuildOptions, childBuilder ChildBuilderFunc, esOpts Options) balancer.Balancer {
 	es := &endpointSharding{
 		cc:           cc,
 		bOpts:        opts,
@@ -84,7 +84,7 @@ type endpointSharding struct {
 	cc           balancer.ClientConn
 	bOpts        balancer.BuildOptions
 	esOpts       Options
-	childBuilder childBuilderFunc
+	childBuilder ChildBuilderFunc
 
 	// childMu synchronizes calls to any single child. It must be held for all
 	// calls into a child. To avoid deadlocks, do not acquire childMu while

--- a/balancer/endpointsharding/endpointsharding.go
+++ b/balancer/endpointsharding/endpointsharding.go
@@ -59,10 +59,14 @@ type Options struct {
 	DisableAutoReconnect bool
 }
 
+// childBuilderFunc creates a new balancer with the ClientConn. It has the same
+// type as the balancer.Builder.Build method.
+type childBuilderFunc = func(cc balancer.ClientConn, opts balancer.BuildOptions) balancer.Balancer
+
 // NewBalancer returns a load balancing policy that manages homogeneous child
 // policies each owning a single endpoint. The endpointsharding balancer
 // forwards the LoadBalancingConfig in ClientConn state updates to its children.
-func NewBalancer(cc balancer.ClientConn, opts balancer.BuildOptions, childBuilder balancer.Builder, esOpts Options) balancer.Balancer {
+func NewBalancer(cc balancer.ClientConn, opts balancer.BuildOptions, childBuilder childBuilderFunc, esOpts Options) balancer.Balancer {
 	es := &endpointSharding{
 		cc:           cc,
 		bOpts:        opts,
@@ -80,7 +84,7 @@ type endpointSharding struct {
 	cc           balancer.ClientConn
 	bOpts        balancer.BuildOptions
 	esOpts       Options
-	childBuilder balancer.Builder
+	childBuilder childBuilderFunc
 
 	// childMu synchronizes calls to any single child. It must be held for all
 	// calls into a child. To avoid deadlocks, do not acquire childMu while
@@ -141,7 +145,7 @@ func (es *endpointSharding) UpdateClientConnState(state balancer.ClientConnState
 				es:         es,
 			}
 			childBalancer.childState.Balancer = childBalancer
-			childBalancer.child = es.childBuilder.Build(childBalancer, es.bOpts)
+			childBalancer.child = es.childBuilder(childBalancer, es.bOpts)
 		}
 		newChildren.Set(endpoint, childBalancer)
 		if err := childBalancer.updateClientConnStateLocked(balancer.ClientConnState{

--- a/balancer/endpointsharding/endpointsharding_test.go
+++ b/balancer/endpointsharding/endpointsharding_test.go
@@ -81,7 +81,7 @@ func (fakePetioleBuilder) Build(cc balancer.ClientConn, opts balancer.BuildOptio
 		ClientConn: cc,
 		bOpts:      opts,
 	}
-	fp.Balancer = endpointsharding.NewBalancer(fp, opts, balancer.Get(pickfirstleaf.Name), endpointsharding.Options{})
+	fp.Balancer = endpointsharding.NewBalancer(fp, opts, balancer.Get(pickfirstleaf.Name).Build, endpointsharding.Options{})
 	return fp
 }
 
@@ -181,7 +181,7 @@ func (s) TestEndpointShardingReconnectDisabled(t *testing.T) {
 	bf := stub.BalancerFuncs{
 		Init: func(bd *stub.BalancerData) {
 			epOpts := endpointsharding.Options{DisableAutoReconnect: true}
-			bd.Data = endpointsharding.NewBalancer(bd.ClientConn, bd.BuildOptions, balancer.Get(pickfirstleaf.Name), epOpts)
+			bd.Data = endpointsharding.NewBalancer(bd.ClientConn, bd.BuildOptions, balancer.Get(pickfirstleaf.Name).Build, epOpts)
 		},
 		UpdateClientConnState: func(bd *stub.BalancerData, ccs balancer.ClientConnState) error {
 			return bd.Data.(balancer.Balancer).UpdateClientConnState(ccs)

--- a/balancer/endpointsharding/endpointsharding_test.go
+++ b/balancer/endpointsharding/endpointsharding_test.go
@@ -182,7 +182,8 @@ func (s) TestEndpointShardingReconnectDisabled(t *testing.T) {
 	name := strings.ReplaceAll(strings.ToLower(t.Name()), "/", "")
 	bf := stub.BalancerFuncs{
 		Init: func(bd *stub.BalancerData) {
-			bd.Data = endpointsharding.NewBalancerWithoutAutoReconnect(bd.ClientConn, bd.BuildOptions)
+			epOpts := endpointsharding.BuildOptions{DisableAutoReconnect: true}
+			bd.Data = endpointsharding.NewBalancerWithOpts(bd.ClientConn, bd.BuildOptions, epOpts)
 		},
 		UpdateClientConnState: func(bd *stub.BalancerData, ccs balancer.ClientConnState) error {
 			return bd.Data.(balancer.Balancer).UpdateClientConnState(balancer.ClientConnState{

--- a/balancer/lazy/lazy.go
+++ b/balancer/lazy/lazy.go
@@ -45,12 +45,12 @@ const (
 	logPrefix = "[lazy-lb %p] "
 )
 
-// childBuilderFunc creates a new balancer with the ClientConn. It has the same
+// ChildBuilderFunc creates a new balancer with the ClientConn. It has the same
 // type as the balancer.Builder.Build method.
-type childBuilderFunc = func(cc balancer.ClientConn, opts balancer.BuildOptions) balancer.Balancer
+type ChildBuilderFunc func(cc balancer.ClientConn, opts balancer.BuildOptions) balancer.Balancer
 
 // NewBalancer is the constructor for the lazy balancer.
-func NewBalancer(cc balancer.ClientConn, bOpts balancer.BuildOptions, childBuilder childBuilderFunc) balancer.Balancer {
+func NewBalancer(cc balancer.ClientConn, bOpts balancer.BuildOptions, childBuilder ChildBuilderFunc) balancer.Balancer {
 	b := &lazyBalancer{
 		cc:           cc,
 		buildOptions: bOpts,
@@ -74,7 +74,7 @@ type lazyBalancer struct {
 	cc           balancer.ClientConn
 	buildOptions balancer.BuildOptions
 	logger       *internalgrpclog.PrefixLogger
-	childBuilder childBuilderFunc
+	childBuilder ChildBuilderFunc
 
 	// The following fields are accessed while handling calls to the idlePicker
 	// and when handling ClientConn state updates. They are guarded by a mutex.

--- a/balancer/lazy/lazy_ext_test.go
+++ b/balancer/lazy/lazy_ext_test.go
@@ -78,7 +78,7 @@ func (s) TestExitIdle(t *testing.T) {
 
 	bf := stub.BalancerFuncs{
 		Init: func(bd *stub.BalancerData) {
-			bd.Data = lazy.NewBalancer(bd.ClientConn, bd.BuildOptions, balancer.Get(pickfirstleaf.Name))
+			bd.Data = lazy.NewBalancer(bd.ClientConn, bd.BuildOptions, balancer.Get(pickfirstleaf.Name).Build)
 		},
 		ExitIdle: func(bd *stub.BalancerData) {
 			bd.Data.(balancer.ExitIdler).ExitIdle()
@@ -143,7 +143,7 @@ func (s) TestPicker(t *testing.T) {
 
 	bf := stub.BalancerFuncs{
 		Init: func(bd *stub.BalancerData) {
-			bd.Data = lazy.NewBalancer(bd.ClientConn, bd.BuildOptions, balancer.Get(pickfirstleaf.Name))
+			bd.Data = lazy.NewBalancer(bd.ClientConn, bd.BuildOptions, balancer.Get(pickfirstleaf.Name).Build)
 		},
 		ExitIdle: func(bd *stub.BalancerData) {
 			t.Log("Ignoring call to ExitIdle, calling the picker should make the lazy balancer exit IDLE state.")
@@ -226,7 +226,7 @@ func (s) TestGoodUpdateThenResolverError(t *testing.T) {
 
 	topLevelBF := stub.BalancerFuncs{
 		Init: func(bd *stub.BalancerData) {
-			bd.Data = lazy.NewBalancer(bd.ClientConn, bd.BuildOptions, balancer.Get(childBalName))
+			bd.Data = lazy.NewBalancer(bd.ClientConn, bd.BuildOptions, balancer.Get(childBalName).Build)
 		},
 		ExitIdle: func(bd *stub.BalancerData) {
 			t.Log("Ignoring call to ExitIdle to delay lazy child creation until RPC time.")
@@ -322,7 +322,7 @@ func (s) TestResolverErrorThenGoodUpdate(t *testing.T) {
 
 	topLevelBF := stub.BalancerFuncs{
 		Init: func(bd *stub.BalancerData) {
-			bd.Data = lazy.NewBalancer(bd.ClientConn, bd.BuildOptions, balancer.Get(childBalName))
+			bd.Data = lazy.NewBalancer(bd.ClientConn, bd.BuildOptions, balancer.Get(childBalName).Build)
 		},
 		ExitIdle: func(bd *stub.BalancerData) {
 			t.Log("Ignoring call to ExitIdle to delay lazy child creation until RPC time.")
@@ -404,7 +404,7 @@ func (s) TestExitIdlePassthrough(t *testing.T) {
 
 	bf := stub.BalancerFuncs{
 		Init: func(bd *stub.BalancerData) {
-			bd.Data = lazy.NewBalancer(bd.ClientConn, bd.BuildOptions, balancer.Get(pickfirstleaf.Name))
+			bd.Data = lazy.NewBalancer(bd.ClientConn, bd.BuildOptions, balancer.Get(pickfirstleaf.Name).Build)
 		},
 		ExitIdle: func(bd *stub.BalancerData) {
 			bd.Data.(balancer.ExitIdler).ExitIdle()

--- a/balancer/weightedroundrobin/balancer.go
+++ b/balancer/weightedroundrobin/balancer.go
@@ -84,9 +84,6 @@ var (
 	})
 )
 
-// endpointSharding which specifies pick first children.
-var endpointShardingLBConfig = endpointsharding.PickFirstConfig
-
 func init() {
 	balancer.Register(bb{})
 }
@@ -103,7 +100,7 @@ func (bb) Build(cc balancer.ClientConn, bOpts balancer.BuildOptions) balancer.Ba
 		scToWeight:       make(map[balancer.SubConn]*endpointWeight),
 	}
 
-	b.child = endpointsharding.NewBalancer(b, bOpts)
+	b.child = endpointsharding.NewBalancer(b, bOpts, balancer.Get(pickfirstleaf.Name), endpointsharding.Options{})
 	b.logger = prefixLogger(b)
 	b.logger.Infof("Created")
 	return b
@@ -236,7 +233,7 @@ func (b *wrrBalancer) UpdateClientConnState(ccs balancer.ClientConnState) error 
 	// This causes child to update picker inline and will thus cause inline
 	// picker update.
 	return b.child.UpdateClientConnState(balancer.ClientConnState{
-		BalancerConfig: endpointShardingLBConfig,
+		BalancerConfig: nil, // pickfirst can handle nil configs.
 		ResolverState:  ccs.ResolverState,
 	})
 }

--- a/balancer/weightedroundrobin/balancer.go
+++ b/balancer/weightedroundrobin/balancer.go
@@ -100,7 +100,7 @@ func (bb) Build(cc balancer.ClientConn, bOpts balancer.BuildOptions) balancer.Ba
 		scToWeight:       make(map[balancer.SubConn]*endpointWeight),
 	}
 
-	b.child = endpointsharding.NewBalancer(b, bOpts, balancer.Get(pickfirstleaf.Name), endpointsharding.Options{})
+	b.child = endpointsharding.NewBalancer(b, bOpts, balancer.Get(pickfirstleaf.Name).Build, endpointsharding.Options{})
 	b.logger = prefixLogger(b)
 	b.logger.Infof("Created")
 	return b
@@ -227,14 +227,12 @@ func (b *wrrBalancer) UpdateClientConnState(ccs balancer.ClientConnState) error 
 	b.updateEndpointsLocked(ccs.ResolverState.Endpoints)
 	b.mu.Unlock()
 
-	// Make pickfirst children use health listeners for outlier detection to
-	// work.
-	ccs.ResolverState = pickfirstleaf.EnableHealthListener(ccs.ResolverState)
 	// This causes child to update picker inline and will thus cause inline
 	// picker update.
 	return b.child.UpdateClientConnState(balancer.ClientConnState{
-		BalancerConfig: nil, // pickfirst can handle nil configs.
-		ResolverState:  ccs.ResolverState,
+		// Make pickfirst children use health listeners for outlier detection to
+		// work.
+		ResolverState: pickfirstleaf.EnableHealthListener(ccs.ResolverState),
 	})
 }
 

--- a/examples/features/customloadbalancer/client/customroundrobin/customroundrobin.go
+++ b/examples/features/customloadbalancer/client/customroundrobin/customroundrobin.go
@@ -27,11 +27,10 @@ import (
 	_ "google.golang.org/grpc" // to register pick_first
 	"google.golang.org/grpc/balancer"
 	"google.golang.org/grpc/balancer/endpointsharding"
+	"google.golang.org/grpc/balancer/pickfirst/pickfirstleaf"
 	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/serviceconfig"
 )
-
-var gracefulSwitchPickFirst = endpointsharding.PickFirstConfig
 
 func init() {
 	balancer.Register(customRoundRobinBuilder{})
@@ -69,7 +68,7 @@ func (customRoundRobinBuilder) Build(cc balancer.ClientConn, bOpts balancer.Buil
 		ClientConn: cc,
 		bOpts:      bOpts,
 	}
-	crr.Balancer = endpointsharding.NewBalancer(crr, bOpts)
+	crr.Balancer = endpointsharding.NewBalancer(crr, bOpts, balancer.Get(pickfirstleaf.Name), endpointsharding.Options{})
 	return crr
 }
 
@@ -100,7 +99,7 @@ func (crr *customRoundRobin) UpdateClientConnState(state balancer.ClientConnStat
 	// is guaranteed to happen since the aggregator will always call
 	// UpdateChildState in its UpdateClientConnState.
 	return crr.Balancer.UpdateClientConnState(balancer.ClientConnState{
-		BalancerConfig: gracefulSwitchPickFirst,
+		BalancerConfig: nil, // pickfirst can handle nil configs.
 		ResolverState:  state.ResolverState,
 	})
 }

--- a/examples/features/customloadbalancer/client/customroundrobin/customroundrobin.go
+++ b/examples/features/customloadbalancer/client/customroundrobin/customroundrobin.go
@@ -68,7 +68,7 @@ func (customRoundRobinBuilder) Build(cc balancer.ClientConn, bOpts balancer.Buil
 		ClientConn: cc,
 		bOpts:      bOpts,
 	}
-	crr.Balancer = endpointsharding.NewBalancer(crr, bOpts, balancer.Get(pickfirstleaf.Name), endpointsharding.Options{})
+	crr.Balancer = endpointsharding.NewBalancer(crr, bOpts, balancer.Get(pickfirstleaf.Name).Build, endpointsharding.Options{})
 	return crr
 }
 
@@ -99,8 +99,7 @@ func (crr *customRoundRobin) UpdateClientConnState(state balancer.ClientConnStat
 	// is guaranteed to happen since the aggregator will always call
 	// UpdateChildState in its UpdateClientConnState.
 	return crr.Balancer.UpdateClientConnState(balancer.ClientConnState{
-		BalancerConfig: nil, // pickfirst can handle nil configs.
-		ResolverState:  state.ResolverState,
+		ResolverState: state.ResolverState,
 	})
 }
 


### PR DESCRIPTION
Presently both `lazy` and `endpointsharding` create `gracefulswtich` balancers to manage their children. The `gracefulswitch` balancer is unnecessary as the type of the child balancer in not expected to change in existing use cases.  Having the `gracefulswitch` child requires the child balancer's builder to be registered in the global LB registry. The `lazy` LB is not a complete LB policy and should not be registered globally.

This PR makes the constructors of `endpointpointsharding` and `lazy` accept the child balancer's builder to avoid using the global registry. This PR also removes the `ParseConfig` functions/methods in `lazy` and `endpointsharding` as they will simply forward the `LoadBalancingConfig`s to their children. The children are responsible to parse the `LoadBalancingConfig` JSON. Since `pickfirst` can use a `nil` `LoadBalancingConfig`, the existing users of `endpointsharding` don't need to provide a `LoadBalancingConfig`.

RELEASE NOTES:
* balancer/endpointsharding: The constructor accepts the child balancer's builder and a struct with optional configuration.
* balancer/endpointsharding: Balancers created with the new `DisableAutoReconnect` option will not attempt to call `ExitIdle` automatically on their children when the children report idle.