### PR TITLE
interop: Fix logging and totalIterations issues in soak_tests.go

### DIFF
--- a/interop/soak_tests.go
+++ b/interop/soak_tests.go
@@ -190,7 +190,7 @@ func DoSoakTest(ctx context.Context, soakConfig SoakTestConfig) {
 		soakConfig.ServerAddr, totalSuccesses, soakConfig.Iterations, totalFailures, b.String())
 
 	if totalIterations != soakConfig.Iterations {
-		fmt.Fprintf(os.Stderr, "Soak test consumed all %v of time and quit early, ran %d out of %d iterations.\n", soakConfig.OverallTimeout, totalSuccesses, soakConfig.Iterations)
+		logger.Fatalf("Soak test consumed all %v of time and quit early, ran %d out of %d iterations.\n", soakConfig.OverallTimeout, totalSuccesses, soakConfig.Iterations)
 	}
 
 	if totalFailures > soakConfig.MaxFailures {

--- a/interop/soak_tests.go
+++ b/interop/soak_tests.go
@@ -183,12 +183,13 @@ func DoSoakTest(ctx context.Context, soakConfig SoakTestConfig) {
 		}
 	}
 	var b bytes.Buffer
+	totalIterations := totalSuccesses + totalFailures
 	latencies.Print(&b)
 	fmt.Fprintf(os.Stderr,
 		"(server_uri: %s) soak test ran: %d / %d iterations. Total failures: %d. Latencies in milliseconds: %s\n",
 		soakConfig.ServerAddr, totalSuccesses, soakConfig.Iterations, totalFailures, b.String())
 
-	if totalSuccesses+totalFailures != soakConfig.Iterations {
+	if totalIterations != soakConfig.Iterations {
 		fmt.Fprintf(os.Stderr, "Soak test consumed all %v of time and quit early, ran %d out of %d iterations.\n", soakConfig.OverallTimeout, totalSuccesses, soakConfig.Iterations)
 	}
 

--- a/interop/soak_tests.go
+++ b/interop/soak_tests.go
@@ -190,7 +190,7 @@ func DoSoakTest(ctx context.Context, soakConfig SoakTestConfig) {
 		soakConfig.ServerAddr, totalSuccesses, soakConfig.Iterations, totalFailures, b.String())
 
 	if totalIterations != soakConfig.Iterations {
-		logger.Fatalf("Soak test consumed all %v of time and quit early, ran %d out of %d iterations.\n", soakConfig.OverallTimeout, totalSuccesses, soakConfig.Iterations)
+		logger.Fatalf("Soak test consumed all %v of time and quit early, ran %d out of %d iterations.\n", soakConfig.OverallTimeout, totalIterations, soakConfig.Iterations)
 	}
 
 	if totalFailures > soakConfig.MaxFailures {

--- a/interop/soak_tests.go
+++ b/interop/soak_tests.go
@@ -131,7 +131,7 @@ func executeSoakTestInWorker(ctx context.Context, config SoakTestConfig, startTi
 			continue
 		}
 		if latency > config.PerIterationMaxAcceptableLatency {
-			fmt.Fprintf(os.Stderr, "Worker %d: soak iteration: %d elapsed_ms: %d peer: %v server_uri: %s exceeds max acceptable latency: %d\n", workerID, i, latency, p.Addr, config.ServerAddr, config.PerIterationMaxAcceptableLatency.Milliseconds())
+			fmt.Fprintf(os.Stderr, "Worker %d: soak iteration: %d elapsed_ms: %d peer: %v server_uri: %s exceeds max acceptable latency: %d\n", workerID, i, latency.Milliseconds(), p.Addr, config.ServerAddr, config.PerIterationMaxAcceptableLatency.Milliseconds())
 			soakWorkerResults.Failures++
 			<-earliestNextStart
 			continue
@@ -139,7 +139,7 @@ func executeSoakTestInWorker(ctx context.Context, config SoakTestConfig, startTi
 		// Success: log the details of the iteration.
 		soakWorkerResults.Latencies.Add(latency.Milliseconds())
 		soakWorkerResults.iterationsSucceeded++
-		fmt.Fprintf(os.Stderr, "Worker %d: soak iteration: %d elapsed_ms: %d peer: %v server_uri: %s succeeded\n", workerID, i, latency, p.Addr, config.ServerAddr)
+		fmt.Fprintf(os.Stderr, "Worker %d: soak iteration: %d elapsed_ms: %d peer: %v server_uri: %s succeeded\n", workerID, i, latency.Milliseconds(), p.Addr, config.ServerAddr)
 		<-earliestNextStart
 	}
 }
@@ -165,7 +165,7 @@ func DoSoakTest(ctx context.Context, soakConfig SoakTestConfig) {
 	// Wait for all goroutines to complete.
 	wg.Wait()
 
-	//Handle results.
+	// Handle results.
 	totalSuccesses := 0
 	totalFailures := 0
 	latencies := stats.NewHistogram(stats.HistogramOptions{


### PR DESCRIPTION
Two issues handled here:
- Updated the logging print approach to fail the test rather than only print the information when soak test total failures exceed max failures threshold.
- Renamed the successfully run soak iterations and updated the total soak iteration calculations.

@dfawley 

RELEASE NOTES: n/a