### PR TITLE
internal/dns: update TestDNSResolver_ExponentialBackoff to not return error before last resolution attempt

### DIFF
--- a/internal/resolver/dns/dns_resolver_test.go
+++ b/internal/resolver/dns/dns_resolver_test.go
@@ -626,18 +626,15 @@ func (s) TestDNSResolver_ExponentialBackoff(t *testing.T) {
 					}
 				}
 
+				if i == retries-1 {
+					// Update resolver.ClientConn to not return an error
+					// anymore before last resolution retry to ensure that
+					// last resolution attempt doesn't back off.
+					returnNilErr.Store(true)
+				}
+
 				// Unblock the DNS resolver's backoff by pushing the current time.
 				timeChan <- time.Now()
-			}
-
-			// Update resolver.ClientConn to not return an error anymore.
-			returnNilErr.Store(true)
-
-			// Unblock the DNS resolver's backoff, if ongoing, while we set the
-			// test clientConn to not return an error anymore.
-			select {
-			case timeChan <- time.Now():
-			default:
 			}
 
 			// Verify that the DNS resolver does not backoff anymore.


### PR DESCRIPTION
Fixes: #7760 

The `TestDNSResolver_ExponentialBackoff` test verifies that the DNS resolver correctly implements exponential backoff when encountering errors. It simulates a failing resolver and forces it to retry 10 times. The test overrides the standard `time.After` function, used for backoff delays, with a custom implementation `overrideTimeAfterFuncWithChannel` which uses two channels: `durChan` to receive the intended backoff duration from the resolver, and `timeChan` to signal the resolver that the waiting period is over. In each iteration of the test loop (representing a retry attempt), the test first reads from `durChan` to verify if the back off happened. Because of the test setup, this read usually gets the backoff duration from the previous resolution attempt (including the first attempt from resolver build). The test then immediately unblocks the resolver by sending a signal to `timeChan`. 

The problem arose in the last iteration. The loop would exit without reading the last backoff duration from `durChan`, and right after, the test would set an atomic bool flag `returnNilErr` to true to make the resolver's update function succeed. However, a race condition existed: if the resolver happened to start its 10th and final resolution attempt before this flag was set to true, that attempt would fail, trigger a backoff and consequently put a value into `durChan`.  The test expected this final attempt to always succeed because of the flag being set right after exiting the loop. The test then checked if `durChan` was empty, and if it wasn't (meaning an unexpected backoff occurred), the test would flake. The fix resolves this by ensuring that the flag to force a successful update is set before the last resolution attempt begins. This guarantees that the last attempt will always succeed, eliminating the possibility of an unwanted backoff and ensuring that `durChan` remains empty, thus preventing the test from flaking.

Forge run without fix: https://fusion2.corp.google.com/invocations/4f183c2c-f5cf-4fee-a18d-d5c4da2479bc/targets/%2F%2Fthird_party%2Fgolang%2Fgrpc%2Finternal%2Fresolver%2Fdns:dns_test/tests

Forge run with fix: https://fusion2.corp.google.com/invocations/3bab8892-5a85-4758-bc3f-8437191bffbe/targets/%2F%2Fthird_party%2Fgolang%2Fgrpc%2Finternal%2Fresolver%2Fdns:dns_test/log

RELEASE NOTES: None