### PR TITLE
xds: introduce simple grpc transport for generic xds clients

### DIFF
--- a/xds/internal/clients/grpctransport/grpc_transport.go
+++ b/xds/internal/clients/grpctransport/grpc_transport.go
@@ -77,7 +77,6 @@ func (b *Builder) Build(sc clients.ServerConfig) (clients.Transport, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error creating grpc client for server uri %s, %v", sc.ServerURI, err)
 	}
-	cc.Connect()
 
 	return &grpcTransport{cc: cc}, nil
 }

--- a/xds/internal/clients/grpctransport/grpc_transport.go
+++ b/xds/internal/clients/grpctransport/grpc_transport.go
@@ -1,0 +1,142 @@
+/*
+ *
+ * Copyright 2025 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// Package grpctransport provides an implementation of the
+// clients.TransportBuilder interface using gRPC.
+package grpctransport
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/keepalive"
+	"google.golang.org/grpc/xds/internal/clients"
+)
+
+// ServerConfigExtension allows extending the clients.ServerConfig for the
+// gRPC-based transport builder. Any implementation of this must implement
+// the ServerConfig() method.
+//
+// This interface must be implemented by the grpc transport builder provided
+// in the Extensions field of the clients.ServerConfig.
+type ServerConfigExtension interface {
+	ServerConfig() *ServerConfig
+}
+
+// ServerConfig holds the settings for connecting to an xDS management server
+// using gRPC.
+type ServerConfig struct {
+	// Credentials is the credential bundle containing the gRPC credentials for
+	// connecting to the xDS management server.
+	Credentials credentials.Bundle
+}
+
+// ServerConfig returns the ServerConfig itself. This method is designed
+// to satisfy [ServerConfigExtension] interface requirement.
+func (s *ServerConfig) ServerConfig() *ServerConfig {
+	return s
+}
+
+// Builder provides a way to build a gRPC-based transport to an xDS management
+// server.
+type Builder struct{}
+
+// Build creates a new gRPC-based transport to an xDS management server using
+// the provided clients.ServerConfig. This involves creating a
+// grpc.ClientConn to the server using the provided credentials and server URI.
+//
+// If any of ServerURI or Extensions of `sc` are not present, Build() will return
+// an error.
+func (b *Builder) Build(sc clients.ServerConfig) (clients.Transport, error) {
+	if sc.ServerURI == "" {
+		return nil, fmt.Errorf("xds: ServerConfig's ServerURI field cannot be empty")
+	}
+	if sc.Extensions == nil {
+		return nil, fmt.Errorf("xds: ServerConfig's Extensions field cannot be nil for gRPC transport")
+	}
+	gtsce, ok := sc.Extensions.(ServerConfigExtension)
+	if !ok {
+		return nil, fmt.Errorf("xds: ServerConfig's Extensions field cannot be anything other than grpctransport.ServerConfigExtension for gRPC transport")
+	}
+	gtsc := gtsce.ServerConfig()
+	if gtsc.Credentials == nil {
+		return nil, fmt.Errorf("xsd: ServerConfigExtensions's Credentials field cannot be nil for gRPC transport")
+	}
+
+	// TODO: Incorporate reference count map for existing transports and
+	// deduplicate transports based on server URI and credentials so that
+	// transport channel to same server can be shared between xDS and LRS
+	// client.
+
+	// Dial the xDS management server with the provided credentials, server URI,
+	// and a static keepalive configuration that is common across gRPC language
+	// implementations.
+	kpCfg := grpc.WithKeepaliveParams(keepalive.ClientParameters{
+		Time:    5 * time.Minute,
+		Timeout: 20 * time.Second,
+	})
+	cc, err := grpc.NewClient(sc.ServerURI, kpCfg, grpc.WithCredentialsBundle(gtsc.Credentials))
+	if err != nil {
+		return nil, fmt.Errorf("error creating grpc client for server uri %s, %v", sc.ServerURI, err)
+	}
+	cc.Connect()
+
+	return &grpcTransport{cc: cc}, nil
+}
+
+type grpcTransport struct {
+	cc *grpc.ClientConn
+}
+
+// NewStream creates a new gRPC stream to the xDS management server for the
+// specified method.  The returned Stream interface can be used to send and
+// receive messages on the stream.
+func (g *grpcTransport) NewStream(ctx context.Context, method string) (clients.Stream, error) {
+	s, err := g.cc.NewStream(ctx, &grpc.StreamDesc{StreamName: method, ClientStreams: true, ServerStreams: true}, method)
+	if err != nil {
+		return nil, err
+	}
+	return &stream{stream: s}, nil
+}
+
+type stream struct {
+	stream grpc.ClientStream
+}
+
+// Send sends a message to the xDS management server.
+func (s *stream) Send(msg []byte) error {
+	return s.stream.SendMsg(msg)
+}
+
+// Recv receives a message from the xDS management server.
+func (s *stream) Recv() ([]byte, error) {
+	var typedRes []byte
+	err := s.stream.RecvMsg(&typedRes)
+	if err != nil {
+		return typedRes, err
+	}
+	return typedRes, nil
+}
+
+// Close closes the gRPC stream to the xDS management server.
+func (g *grpcTransport) Close() error {
+	return g.cc.Close()
+}

--- a/xds/internal/clients/grpctransport/grpc_transport.go
+++ b/xds/internal/clients/grpctransport/grpc_transport.go
@@ -32,10 +32,10 @@ import (
 )
 
 // ServerConfigExtension holds settings for connecting to a gRPC server,
-// such as an xDS or LRS server.
+// such as an xDS management or an LRS server.
 type ServerConfigExtension struct {
-	// Credentials will be used for all gRPC transports. If is unset, transport
-	// creation will fail.
+	// Credentials will be used for all gRPC transports. If it is unset,
+	// transport creation will fail.
 	Credentials credentials.Bundle
 }
 
@@ -62,13 +62,14 @@ func (b *Builder) Build(sc clients.ServerConfig) (clients.Transport, error) {
 	}
 
 	// TODO: Incorporate reference count map for existing transports and
-	// deduplicate transports based on server URI and credentials so that
+	// deduplicate transports based on the provided ServerConfig so that
 	// transport channel to same server can be shared between xDS and LRS
 	// client.
 
-	// Dial the xDS management server with the provided credentials, server URI,
-	// and a static keepalive configuration that is common across gRPC language
-	// implementations.
+	// Create a new gRPC client/channel for the xDS management server with the
+	// provided credentials, server URI, and a byte codec to send and receive
+	// messages. Aso set a static keepalive configuration that is common across
+	// gRPC language implementations.
 	kpCfg := grpc.WithKeepaliveParams(keepalive.ClientParameters{
 		Time:    5 * time.Minute,
 		Timeout: 20 * time.Second,

--- a/xds/internal/clients/grpctransport/grpc_transport.go
+++ b/xds/internal/clients/grpctransport/grpc_transport.go
@@ -31,28 +31,12 @@ import (
 	"google.golang.org/grpc/xds/internal/clients"
 )
 
-// ServerConfigExtension allows extending the clients.ServerConfig for the
-// gRPC-based transport builder. Any implementation of this must implement
-// the ServerConfig() method.
-//
-// This interface must be implemented by the grpc transport builder provided
-// in the Extensions field of the clients.ServerConfig.
-type ServerConfigExtension interface {
-	ServerConfig() *ServerConfig
-}
-
-// ServerConfig holds the settings for connecting to an xDS management server
+// ServerConfigExtension holds the settings for connecting to an xDS management server
 // using gRPC.
-type ServerConfig struct {
+type ServerConfigExtension struct {
 	// Credentials is the credential bundle containing the gRPC credentials for
 	// connecting to the xDS management server.
 	Credentials credentials.Bundle
-}
-
-// ServerConfig returns the ServerConfig itself. This method is designed
-// to satisfy [ServerConfigExtension] interface requirement.
-func (s *ServerConfig) ServerConfig() *ServerConfig {
-	return s
 }
 
 // Builder provides a way to build a gRPC-based transport to an xDS management
@@ -76,8 +60,7 @@ func (b *Builder) Build(sc clients.ServerConfig) (clients.Transport, error) {
 	if !ok {
 		return nil, fmt.Errorf("xds: ServerConfig's Extensions field cannot be anything other than grpctransport.ServerConfigExtension for gRPC transport")
 	}
-	gtsc := gtsce.ServerConfig()
-	if gtsc.Credentials == nil {
+	if gtsce.Credentials == nil {
 		return nil, fmt.Errorf("xsd: ServerConfigExtensions's Credentials field cannot be nil for gRPC transport")
 	}
 
@@ -93,7 +76,7 @@ func (b *Builder) Build(sc clients.ServerConfig) (clients.Transport, error) {
 		Time:    5 * time.Minute,
 		Timeout: 20 * time.Second,
 	})
-	cc, err := grpc.NewClient(sc.ServerURI, kpCfg, grpc.WithCredentialsBundle(gtsc.Credentials))
+	cc, err := grpc.NewClient(sc.ServerURI, kpCfg, grpc.WithCredentialsBundle(gtsce.Credentials))
 	if err != nil {
 		return nil, fmt.Errorf("error creating grpc client for server uri %s, %v", sc.ServerURI, err)
 	}

--- a/xds/internal/clients/grpctransport/grpc_transport.go
+++ b/xds/internal/clients/grpctransport/grpc_transport.go
@@ -125,7 +125,7 @@ func (c *byteCodec) Marshal(v any) ([]byte, error) {
 	if b, ok := v.([]byte); ok {
 		return b, nil
 	}
-	return nil, fmt.Errorf("message is %T, but must be a []byte", v)
+	return nil, fmt.Errorf("grpctransport: message is %T, but must be a []byte", v)
 }
 
 func (c *byteCodec) Unmarshal(data []byte, v any) error {
@@ -133,7 +133,7 @@ func (c *byteCodec) Unmarshal(data []byte, v any) error {
 		*b = data
 		return nil
 	}
-	return fmt.Errorf("target is %T, but must be *[]byte", v)
+	return fmt.Errorf("grpctransport: target is %T, but must be *[]byte", v)
 }
 
 func (c *byteCodec) Name() string {

--- a/xds/internal/clients/grpctransport/grpc_transport_test.go
+++ b/xds/internal/clients/grpctransport/grpc_transport_test.go
@@ -1,0 +1,157 @@
+/*
+ *
+ * Copyright 2025 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package grpctransport
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/internal/grpctest"
+	"google.golang.org/grpc/internal/testutils/xds/e2e"
+	"google.golang.org/grpc/xds/internal/clients"
+)
+
+const (
+	defaultTestWatchExpiryTimeout = 500 * time.Millisecond
+	defaultTestTimeout            = 10 * time.Second
+)
+
+type s struct {
+	grpctest.Tester
+}
+
+func Test(t *testing.T) {
+	grpctest.RunSubTests(t, s{})
+}
+
+// TestBuild verifies that the grpctransport.Builder creates a new
+// grpc.ClientConn every time Build() is called.
+//
+// It covers the following scenarios:
+// - ServerURI is empty.
+// - Extensions is nil.
+// - Extensions is not ServerConfigExtension.
+// - Credentials are nil.
+// - Success cases.
+func (s) TestBuild(t *testing.T) {
+	tests := []struct {
+		name      string
+		serverCfg clients.ServerConfig
+		wantErr   bool
+	}{
+		{
+			name: "ServerURI_empty",
+			serverCfg: clients.ServerConfig{
+				ServerURI:  "",
+				Extensions: &ServerConfig{Credentials: insecure.NewBundle()},
+			},
+			wantErr: true,
+		},
+		{
+			name:      "Extensions_nil",
+			serverCfg: clients.ServerConfig{ServerURI: "server-address"},
+			wantErr:   true,
+		},
+		{
+			name: "Extensions_not_ServerConfigExtension",
+			serverCfg: clients.ServerConfig{
+				ServerURI:  "server-address",
+				Extensions: 1,
+			},
+			wantErr: true,
+		},
+		{
+			name: "ServerConfigExtension_Credentials_nil",
+			serverCfg: clients.ServerConfig{
+				ServerURI:  "server-address",
+				Extensions: &ServerConfig{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "success",
+			serverCfg: clients.ServerConfig{
+				ServerURI:  "server-address",
+				Extensions: &ServerConfig{Credentials: insecure.NewBundle()},
+			},
+			wantErr: false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			b := &Builder{}
+			tr, err := b.Build(test.serverCfg)
+			if (err != nil) != test.wantErr {
+				t.Fatalf("Build() error = %v, wantErr %v", err, test.wantErr)
+			}
+			if tr != nil {
+				defer tr.Close()
+			}
+			if !test.wantErr && tr == nil {
+				t.Fatalf("got non-nil transport from Build(), want nil")
+			}
+		})
+	}
+}
+
+// TestNewStream verifies that grpcTransport.NewStream() successfully creates a
+// new client stream for the xDS management server.
+func (s) TestNewStream(t *testing.T) {
+	mgmtServer := e2e.StartManagementServer(t, e2e.ManagementServerOptions{})
+
+	tests := []struct {
+		name      string
+		serverURI string
+		wantErr   bool
+	}{
+		{
+			name:      "success",
+			serverURI: mgmtServer.Address,
+			wantErr:   false,
+		},
+		{
+			name:      "error",
+			serverURI: "invalid-server-uri",
+			wantErr:   true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			serverCfg := clients.ServerConfig{
+				ServerURI:  test.serverURI,
+				Extensions: &ServerConfig{Credentials: insecure.NewBundle()},
+			}
+			builder := Builder{}
+			transport, err := builder.Build(serverCfg)
+			if err != nil {
+				t.Fatalf("failed to build transport: %v", err)
+			}
+			defer transport.Close()
+
+			ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+			defer cancel()
+			_, err = transport.NewStream(ctx, "test-method")
+			if (err != nil) != test.wantErr {
+				t.Fatalf("transport.NewStream() error = %v, wantErr %v", err, test.wantErr)
+			}
+		})
+	}
+}

--- a/xds/internal/clients/grpctransport/grpc_transport_test.go
+++ b/xds/internal/clients/grpctransport/grpc_transport_test.go
@@ -61,7 +61,7 @@ func (s) TestBuild(t *testing.T) {
 		wantErr   bool
 	}{
 		{
-			name: "ServerURI_empty",
+			name: "ServerURI_is_empty",
 			serverCfg: clients.ServerConfig{
 				ServerURI:  "",
 				Extensions: ServerConfigExtension{Credentials: insecure.NewBundle()},
@@ -69,12 +69,12 @@ func (s) TestBuild(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:      "Extensions_nil",
+			name:      "Extensions is nil",
 			serverCfg: clients.ServerConfig{ServerURI: "server-address"},
 			wantErr:   true,
 		},
 		{
-			name: "Extensions_not_ServerConfigExtension",
+			name: "Extensions is not a ServerConfigExtension",
 			serverCfg: clients.ServerConfig{
 				ServerURI:  "server-address",
 				Extensions: 1,
@@ -82,7 +82,7 @@ func (s) TestBuild(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "ServerConfigExtension_Credentials_nil",
+			name: "ServerConfigExtension Credentials is nil",
 			serverCfg: clients.ServerConfig{
 				ServerURI:  "server-address",
 				Extensions: ServerConfigExtension{},

--- a/xds/internal/clients/grpctransport/grpc_transport_test.go
+++ b/xds/internal/clients/grpctransport/grpc_transport_test.go
@@ -61,7 +61,7 @@ func (s) TestBuild(t *testing.T) {
 			name: "ServerURI_empty",
 			serverCfg: clients.ServerConfig{
 				ServerURI:  "",
-				Extensions: &ServerConfig{Credentials: insecure.NewBundle()},
+				Extensions: ServerConfigExtension{Credentials: insecure.NewBundle()},
 			},
 			wantErr: true,
 		},
@@ -82,7 +82,7 @@ func (s) TestBuild(t *testing.T) {
 			name: "ServerConfigExtension_Credentials_nil",
 			serverCfg: clients.ServerConfig{
 				ServerURI:  "server-address",
-				Extensions: &ServerConfig{},
+				Extensions: ServerConfigExtension{},
 			},
 			wantErr: true,
 		},
@@ -90,7 +90,7 @@ func (s) TestBuild(t *testing.T) {
 			name: "success",
 			serverCfg: clients.ServerConfig{
 				ServerURI:  "server-address",
-				Extensions: &ServerConfig{Credentials: insecure.NewBundle()},
+				Extensions: ServerConfigExtension{Credentials: insecure.NewBundle()},
 			},
 			wantErr: false,
 		},
@@ -137,7 +137,7 @@ func (s) TestNewStream(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			serverCfg := clients.ServerConfig{
 				ServerURI:  test.serverURI,
-				Extensions: &ServerConfig{Credentials: insecure.NewBundle()},
+				Extensions: ServerConfigExtension{Credentials: insecure.NewBundle()},
 			}
 			builder := Builder{}
 			transport, err := builder.Build(serverCfg)


### PR DESCRIPTION
This PR is adding a simple grpc-based transport implementation of generic xds clients transport builder which can be provided as transport builder in xDS and LRS client. 

The `build()` method currently creates a new grpc channel every time. However, in future we will incorporate reference count map for existing transports and deduplicate transports based on provided ServerConfig so that transport channel to same server can be shared among xDS and LRS client.

[POC](https://github.com/purnesh42H/grpc-go/pull/8)
[Internal Design](https://docs.google.com/document/d/11RtR8CDgBzhSHImgJda1AJxw6uUUW-2LA8HX0UPQmyE)

RELEASE NOTES: None