### PR TITLE
endpointsharding: cast EndpointMap values to *balancerWrapper instead of Balancer

### DIFF
--- a/balancer/endpointsharding/endpointsharding.go
+++ b/balancer/endpointsharding/endpointsharding.go
@@ -189,7 +189,7 @@ func (es *endpointSharding) ResolverError(err error) {
 	}()
 	children := es.children.Load()
 	for _, child := range children.Values() {
-		child.(balancer.Balancer).ResolverError(err)
+		child.(*balancerWrapper).resolverErrorLocked(err)
 	}
 }
 
@@ -354,4 +354,11 @@ func (bw *balancerWrapper) closeLocked() {
 	}
 	bw.child.Close()
 	bw.isClosed = true
+}
+
+func (bw *balancerWrapper) resolverErrorLocked(err error) {
+	if bw.isClosed {
+		return
+	}
+	bw.child.ResolverError(err)
 }

--- a/balancer/endpointsharding/endpointsharding.go
+++ b/balancer/endpointsharding/endpointsharding.go
@@ -349,16 +349,10 @@ func (bw *balancerWrapper) updateClientConnStateLocked(ccs balancer.ClientConnSt
 // closeLocked closes the child balancer. Callers must hold the child mutext of
 // the parent endpointsharding balancer.
 func (bw *balancerWrapper) closeLocked() {
-	if bw.isClosed {
-		return
-	}
 	bw.child.Close()
 	bw.isClosed = true
 }
 
 func (bw *balancerWrapper) resolverErrorLocked(err error) {
-	if bw.isClosed {
-		return
-	}
 	bw.child.ResolverError(err)
 }

--- a/balancer/endpointsharding/endpointsharding_test.go
+++ b/balancer/endpointsharding/endpointsharding_test.go
@@ -153,14 +153,14 @@ func (s) TestEndpointShardingBasic(t *testing.T) {
 
 	dOpts := []grpc.DialOption{
 		grpc.WithResolvers(mr), grpc.WithTransportCredentials(insecure.NewCredentials()),
-		// Use a large backoff dealy to avoid the error picker being updated
+		// Use a large backoff delay to avoid the error picker being updated
 		// too quickly.
 		grpc.WithConnectParams(grpc.ConnectParams{
 			Backoff: backoff.Config{
-				BaseDelay:  100 * time.Second,
+				BaseDelay:  2 * defaultTestTimeout,
 				Multiplier: float64(0),
 				Jitter:     float64(0),
-				MaxDelay:   100 * time.Second,
+				MaxDelay:   2 * defaultTestTimeout,
 			},
 		}),
 	}
@@ -192,7 +192,7 @@ func (s) TestEndpointShardingBasic(t *testing.T) {
 	for ; ctx.Err() == nil; <-time.After(time.Millisecond) {
 		_, err := client.EmptyCall(ctx, &testpb.Empty{})
 		if err == nil {
-			t.Fatalf("EmptyCall returned unexpected error: <nil>, want %q", "test error")
+			t.Fatalf("EmptyCall succeeded when expected to fail with %q", "test error")
 		}
 		if strings.Contains(err.Error(), "test error") {
 			break


### PR DESCRIPTION
In https://github.com/grpc/grpc-go/pull/8031, the `balancer.Balancer` embedding in `balancerWrapper` was removed. This causes `endpointsharding` to panic when casting the `EndpointMap` value to a `balancer.Balancer`. This PR fixes the bug and adds a test.

RELEASE NOTES: None