### PR TITLE
interop: Introduce env var for xDS dualstack and add xDS interop config

### DIFF
--- a/internal/envconfig/xds.go
+++ b/internal/envconfig/xds.go
@@ -56,9 +56,7 @@ var (
 
 	// XDSDualstackEndpointsEnabled is true if gRPC should read the
 	// "additional addresses" in the xDS endpoint resource.
-	// TODO: https://github.com/grpc/grpc-go/issues/7866 - Control this using
-	// an env variable when all LB policies handle endpoints.
-	XDSDualstackEndpointsEnabled = false
+	XDSDualstackEndpointsEnabled = boolFromEnv("GRPC_EXPERIMENTAL_XDS_DUALSTACK_ENDPOINTS", false)
 
 	// XDSSystemRootCertsEnabled is true when xDS enabled gRPC clients can use
 	// the system's default root certificates for TLS certificate validation.

--- a/test/kokoro/psm-dualstack.cfg
+++ b/test/kokoro/psm-dualstack.cfg
@@ -1,0 +1,17 @@
+# Config file for internal CI
+
+# Location of the continuous shell script in repository.
+build_file: "grpc-go/test/kokoro/psm-interop-test-go.sh"
+timeout_mins: 360
+
+action {
+  define_artifacts {
+    regex: "artifacts/**/*sponge_log.xml"
+    regex: "artifacts/**/*.log"
+    strip_prefix: "artifacts"
+  }
+}
+env_vars {
+  key: "PSM_TEST_SUITE"
+  value: "dualstack"
+}


### PR DESCRIPTION
Fixes: https://github.com/grpc/grpc-go/issues/7866

## Why
This PR is required to start PSM interop testing for dualstack integration in Go. The interop test only tests the `roundrobin` LB policy which is already updated to handle endpoints in https://github.com/grpc/grpc-go/pull/7966.

## Testing
Verified that the dualstack PSM interop tests pass when run using a client image built from this branch.

RELEASE NOTES:
* xds: LB policies will receive additional addresses for endpoints which are specified in the [`additional_addresses`](https://github.com/envoyproxy/envoy/blob/df394a41c8587d1da4e97e156554e93ceee3c720/api/envoy/config/endpoint/v3/endpoint_components.proto#L91-L96) field in the `Endpoint` message. The additional addresses will be present in the `ResolverState.Endpoints` passed to `UpdateClientConnState` method of the balancers. To enable this feature, set the environment variable `GRPC_EXPERIMENTAL_XDS_DUALSTACK_ENDPOINTS` to true (case insensitive).