### PR TITLE
Add xds host_rewrite_literal support

### DIFF
--- a/internal/serviceconfig/serviceconfig.go
+++ b/internal/serviceconfig/serviceconfig.go
@@ -149,6 +149,8 @@ type MethodConfig struct {
 	MaxRespSize *int
 	// RetryPolicy configures retry options for the method.
 	RetryPolicy *RetryPolicy
+
+	Host string
 }
 
 // RetryPolicy defines the go-native version of the retry policy defined by the

--- a/stream.go
+++ b/stream.go
@@ -291,8 +291,14 @@ func newClientStreamWithParams(ctx context.Context, desc *StreamDesc, cc *Client
 		return nil, err
 	}
 
+	host := cc.authority
+	if mc.Host != "" {
+		host = mc.Host
+		ctx = context.WithValue(ctx, transport.CtxValAllowHostOverride{}, true)
+	}
+
 	callHdr := &transport.CallHdr{
-		Host:           cc.authority,
+		Host:           host,
 		Method:         method,
 		ContentSubtype: callInfo.contentSubtype,
 		DoneFunc:       doneFunc,

--- a/xds/internal/resolver/serviceconfig.go
+++ b/xds/internal/resolver/serviceconfig.go
@@ -117,6 +117,8 @@ type route struct {
 	httpFilterConfigOverride map[string]httpfilter.FilterConfig
 	retryConfig              *xdsresource.RetryConfig
 	hashPolicies             []*xdsresource.HashPolicy
+
+	hostRewriteLiteral string
 }
 
 func (r route) String() string {
@@ -198,6 +200,8 @@ func (cs *configSelector) SelectConfig(rpcInfo iresolver.RPCInfo) (*iresolver.RP
 	} else if cs.virtualHost.retryConfig != nil {
 		config.MethodConfig.RetryPolicy = retryConfigToPolicy(cs.virtualHost.retryConfig)
 	}
+
+	config.MethodConfig.Host = rt.hostRewriteLiteral
 
 	return config, nil
 }

--- a/xds/internal/resolver/xds_resolver.go
+++ b/xds/internal/resolver/xds_resolver.go
@@ -358,6 +358,7 @@ func (r *xdsResolver) newConfigSelector() (*configSelector, error) {
 		cs.routes[i].httpFilterConfigOverride = rt.HTTPFilterConfigOverride
 		cs.routes[i].retryConfig = rt.RetryConfig
 		cs.routes[i].hashPolicies = rt.HashPolicies
+		cs.routes[i].hostRewriteLiteral = rt.HostRewriteLiteral
 	}
 
 	// Account for this config selector's clusters.  Do this after no further

--- a/xds/internal/xdsclient/xdsresource/type_rds.go
+++ b/xds/internal/xdsclient/xdsresource/type_rds.go
@@ -150,6 +150,8 @@ type Route struct {
 	// ClusterSpecifierPlugin is the name of the Cluster Specifier Plugin that
 	// this Route is linked to, if specified by xDS.
 	ClusterSpecifierPlugin string
+
+	HostRewriteLiteral string
 }
 
 // WeightedCluster contains settings for an xds ActionType.WeightedCluster.

--- a/xds/internal/xdsclient/xdsresource/unmarshal_rds.go
+++ b/xds/internal/xdsclient/xdsresource/unmarshal_rds.go
@@ -302,6 +302,7 @@ func routesProtoToSlice(routes []*v3routepb.Route, csps map[string]clusterspecif
 		case *v3routepb.Route_Route:
 			route.WeightedClusters = make(map[string]WeightedCluster)
 			action := r.GetRoute()
+			route.HostRewriteLiteral = action.GetHostRewriteLiteral()
 
 			// Hash Policies are only applicable for a Ring Hash LB.
 			hp, err := hashPoliciesProtoToSlice(action.HashPolicy)


### PR DESCRIPTION
Adds support to `grpc-go` for xDS [host_rewrite_literal](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto.html#config-route-v3-routeaction).

This PR is intended to inform a forthcoming RFC.

This doesn't affect the public interface. All symbols added are internal, and to avoid changing any existing behaviour the stream host is not overridden in any other scenario, via an internal context type only set when host_rewrite_literal is received from RDS.

We've tested this internally. The xDS control plane sends the `host_rewrite_literal` in RDS (which we incidentally use for Envoy xDS in a very similar fashion as our grpc-go clients), and with this changeset the clients make a request to the upstream cluster with the correct host, and everything works as-expected.

See https://github.com/grpc/grpc/issues/38062 for the motivation. TLDR we have an Envoy instance acting as a Reverse Proxy, for which clients need to receive and set the host from xDS in their request (via host_rewrite_literal). This host differs from the reverse proxy's own host in the Cluster, and there are numerous upstream hosts it forwards to, without this the Reverse Proxy doesn't know where to send the request (relatively normal/common Reverse Proxy behaviour).

