### PR TITLE
fix: Improve idle connection handling and active endpoint detection

### DIFF
--- a/xds/internal/balancer/ringhash/ringhash.go
+++ b/xds/internal/balancer/ringhash/ringhash.go
@@ -257,18 +257,25 @@ func (b *ringhashBalancer) updatePickerLocked() {
 		sort.Slice(endpointStates, func(i, j int) bool {
 			return endpointStates[i].firstAddr < endpointStates[j].firstAddr
 		})
+
+		var foundActive bool
 		var idleBalancer balancer.ExitIdler
 		for _, es := range endpointStates {
 			connState := es.state.ConnectivityState
-			if connState == connectivity.Connecting {
-				idleBalancer = nil
+			if connState == connectivity.Ready || connState == connectivity.Connecting {
+				foundActive = true
 				break
 			}
+			// connState := es.state.ConnectivityState
+			// if connState == connectivity.Connecting {
+			// 	idleBalancer = nil
+			// 	break
+			// }
 			if idleBalancer == nil && connState == connectivity.Idle {
 				idleBalancer = es.balancer
 			}
 		}
-		if idleBalancer != nil {
+		if !foundActive && idleBalancer != nil {
 			idleBalancer.ExitIdle()
 		}
 	}


### PR DESCRIPTION
as https://github.com/grpc/grpc-go/issues/8085 said, I've updated the judgment condition of the updatePickerLocked() method to make sure that it ensures that if it encounters an edge case such as “TF, TF, IDLE, IDLE” or “TF, TF, CONNECTING (after removal), IDLE “ edge cases, endpoints in the Idle state are woken up as soon as possible so that the LB can be brought into an active state as soon as possible.

Close https://github.com/grpc/grpc-go/issues/8085