### PR TITLE
ringhash: Replace DNS resolver before sending xDS Update in test

### DIFF
--- a/xds/internal/balancer/ringhash/e2e/ringhash_balancer_test.go
+++ b/xds/internal/balancer/ringhash/e2e/ringhash_balancer_test.go
@@ -467,12 +467,13 @@ func (s) TestRingHash_AggregateClusterFallBackFromRingHashToLogicalDnsAtStartup(
 		Routes:    []*v3routepb.RouteConfiguration{route},
 		Listeners: []*v3listenerpb.Listener{listener},
 	}
-	if err := xdsServer.Update(ctx, updateOpts); err != nil {
-		t.Fatalf("Failed to update xDS resources: %v", err)
-	}
 
 	dnsR := replaceDNSResolver(t)
 	dnsR.InitialState(resolver.State{Addresses: []resolver.Address{{Addr: backends[0]}}})
+
+	if err := xdsServer.Update(ctx, updateOpts); err != nil {
+		t.Fatalf("Failed to update xDS resources: %v", err)
+	}
 
 	conn, err := grpc.NewClient("xds:///test.server", grpc.WithResolvers(xdsResolver), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
@@ -544,12 +545,13 @@ func (s) TestRingHash_AggregateClusterFallBackFromRingHashToLogicalDnsAtStartupN
 		Routes:    []*v3routepb.RouteConfiguration{route},
 		Listeners: []*v3listenerpb.Listener{listener},
 	}
-	if err := xdsServer.Update(ctx, updateOpts); err != nil {
-		t.Fatalf("Failed to update xDS resources: %v", err)
-	}
 
 	dnsR := replaceDNSResolver(t)
 	dnsR.InitialState(resolver.State{Addresses: []resolver.Address{{Addr: backends[0]}}})
+
+	if err := xdsServer.Update(ctx, updateOpts); err != nil {
+		t.Fatalf("Failed to update xDS resources: %v", err)
+	}
 
 	dialer := testutils.NewBlockingDialer()
 	cp := grpc.ConnectParams{


### PR DESCRIPTION
Fixes: https://github.com/grpc/grpc-go/issues/7993

Updating the DNS resolver after sending the xDS update could result in clusterresolver using the real DNS resolver and timing out. This PR ensures the real DNS resolver is replaced before the xDS update with the logical DNS cluster is sent.

## Tested
Verified the test no longer fails in 10^5 runs on forge.

RELEASE NOTES: N/A