### PR TITLE
xdsclient: include xds node ID in errors from the WatchResource API

### DIFF
--- a/xds/internal/xdsclient/clientimpl.go
+++ b/xds/internal/xdsclient/clientimpl.go
@@ -87,7 +87,6 @@ type clientImpl struct {
 	topLevelAuthority  *authority                   // The top-level authority, used only for old-style names without an authority.
 	authorities        map[string]*authority        // Map from authority names in bootstrap to authority struct.
 	config             *bootstrap.Config            // Complete bootstrap configuration.
-	nodeID             string                       // Node ID from bootstrap config.
 	watchExpiryTimeout time.Duration                // Expiry timeout for ADS watch.
 	backoff            func(int) time.Duration      // Backoff for ADS and LRS stream failures.
 	transportBuilder   transport.Builder            // Builder to create transports to xDS server.
@@ -138,7 +137,6 @@ func newClientImpl(config *bootstrap.Config, watchExpiryTimeout time.Duration, s
 		done:               grpcsync.NewEvent(),
 		authorities:        make(map[string]*authority),
 		config:             config,
-		nodeID:             config.Node().GetId(),
 		watchExpiryTimeout: watchExpiryTimeout,
 		backoff:            streamBackoff,
 		serializer:         grpcsync.NewCallbackSerializer(ctx),
@@ -156,7 +154,6 @@ func newClientImpl(config *bootstrap.Config, watchExpiryTimeout time.Duration, s
 			serverCfg = cfg.XDSServers
 		}
 		c.authorities[name] = newAuthority(authorityBuildOptions{
-			nodeID:           c.nodeID,
 			serverConfigs:    serverCfg,
 			name:             name,
 			serializer:       c.serializer,
@@ -167,7 +164,6 @@ func newClientImpl(config *bootstrap.Config, watchExpiryTimeout time.Duration, s
 		})
 	}
 	c.topLevelAuthority = newAuthority(authorityBuildOptions{
-		nodeID:           c.nodeID,
 		serverConfigs:    config.XDSServers(),
 		name:             "",
 		serializer:       c.serializer,

--- a/xds/internal/xdsclient/clientimpl.go
+++ b/xds/internal/xdsclient/clientimpl.go
@@ -87,6 +87,7 @@ type clientImpl struct {
 	topLevelAuthority  *authority                   // The top-level authority, used only for old-style names without an authority.
 	authorities        map[string]*authority        // Map from authority names in bootstrap to authority struct.
 	config             *bootstrap.Config            // Complete bootstrap configuration.
+	nodeID             string                       // Node ID from bootstrap config.
 	watchExpiryTimeout time.Duration                // Expiry timeout for ADS watch.
 	backoff            func(int) time.Duration      // Backoff for ADS and LRS stream failures.
 	transportBuilder   transport.Builder            // Builder to create transports to xDS server.
@@ -137,6 +138,7 @@ func newClientImpl(config *bootstrap.Config, watchExpiryTimeout time.Duration, s
 		done:               grpcsync.NewEvent(),
 		authorities:        make(map[string]*authority),
 		config:             config,
+		nodeID:             config.Node().GetId(),
 		watchExpiryTimeout: watchExpiryTimeout,
 		backoff:            streamBackoff,
 		serializer:         grpcsync.NewCallbackSerializer(ctx),
@@ -154,6 +156,7 @@ func newClientImpl(config *bootstrap.Config, watchExpiryTimeout time.Duration, s
 			serverCfg = cfg.XDSServers
 		}
 		c.authorities[name] = newAuthority(authorityBuildOptions{
+			nodeID:           c.nodeID,
 			serverConfigs:    serverCfg,
 			name:             name,
 			serializer:       c.serializer,
@@ -164,6 +167,7 @@ func newClientImpl(config *bootstrap.Config, watchExpiryTimeout time.Duration, s
 		})
 	}
 	c.topLevelAuthority = newAuthority(authorityBuildOptions{
+		nodeID:           c.nodeID,
 		serverConfigs:    config.XDSServers(),
 		name:             "",
 		serializer:       c.serializer,

--- a/xds/internal/xdsclient/clientimpl_watchers.go
+++ b/xds/internal/xdsclient/clientimpl_watchers.go
@@ -45,7 +45,9 @@ func (c *clientImpl) WatchResource(rType xdsresource.Type, resourceName string, 
 
 	if err := c.resourceTypes.maybeRegister(rType); err != nil {
 		logger.Warningf("Watch registered for name %q of type %q which is already registered", rType.TypeName(), resourceName)
-		c.serializer.TrySchedule(func(context.Context) { watcher.OnError(err, func() {}) })
+		c.serializer.TrySchedule(func(context.Context) {
+			watcher.OnError(fmt.Errorf("[xDS node id: %v]: %v", c.nodeID, err), func() {})
+		})
 		return func() {}
 	}
 
@@ -54,7 +56,7 @@ func (c *clientImpl) WatchResource(rType xdsresource.Type, resourceName string, 
 	if a == nil {
 		logger.Warningf("Watch registered for name %q of type %q, authority %q is not found", rType.TypeName(), resourceName, n.Authority)
 		c.serializer.TrySchedule(func(context.Context) {
-			watcher.OnError(fmt.Errorf("authority %q not found in bootstrap config for resource %q", n.Authority, resourceName), func() {})
+			watcher.OnError(fmt.Errorf("[xDS node id: %v]: authority %q not found in bootstrap config for resource %q", c.nodeID, n.Authority, resourceName), func() {})
 		})
 		return func() {}
 	}

--- a/xds/internal/xdsclient/clientimpl_watchers.go
+++ b/xds/internal/xdsclient/clientimpl_watchers.go
@@ -26,6 +26,24 @@ import (
 	"google.golang.org/grpc/xds/internal/xdsclient/xdsresource"
 )
 
+// wrappingWatcher is a wrapper around an xdsresource.ResourceWatcher that adds
+// the node ID to the error messages reported to the watcher.
+type wrappingWatcher struct {
+	nodeID  string
+	watcher xdsresource.ResourceWatcher
+}
+
+func (w *wrappingWatcher) OnUpdate(update xdsresource.ResourceData, done xdsresource.OnDoneFunc) {
+	w.watcher.OnUpdate(update, done)
+}
+
+func (w *wrappingWatcher) OnError(err error, done xdsresource.OnDoneFunc) {
+	w.watcher.OnError(fmt.Errorf("[xDS node id: %v]: %v", w.nodeID, err), done)
+}
+func (w *wrappingWatcher) OnResourceDoesNotExist(done xdsresource.OnDoneFunc) {
+	w.watcher.OnResourceDoesNotExist(done)
+}
+
 // WatchResource uses xDS to discover the resource associated with the provided
 // resource name. The resource type implementation determines how xDS responses
 // are are deserialized and validated, as received from the xDS management
@@ -43,11 +61,14 @@ func (c *clientImpl) WatchResource(rType xdsresource.Type, resourceName string, 
 		return func() {}
 	}
 
+	watcher = &wrappingWatcher{
+		nodeID:  c.config.Node().GetId(),
+		watcher: watcher,
+	}
+
 	if err := c.resourceTypes.maybeRegister(rType); err != nil {
 		logger.Warningf("Watch registered for name %q of type %q which is already registered", rType.TypeName(), resourceName)
-		c.serializer.TrySchedule(func(context.Context) {
-			watcher.OnError(fmt.Errorf("[xDS node id: %v]: %v", c.nodeID, err), func() {})
-		})
+		c.serializer.TrySchedule(func(context.Context) { watcher.OnError(err, func() {}) })
 		return func() {}
 	}
 
@@ -55,9 +76,7 @@ func (c *clientImpl) WatchResource(rType xdsresource.Type, resourceName string, 
 	a := c.getAuthorityForResource(n)
 	if a == nil {
 		logger.Warningf("Watch registered for name %q of type %q, authority %q is not found", rType.TypeName(), resourceName, n.Authority)
-		c.serializer.TrySchedule(func(context.Context) {
-			watcher.OnError(fmt.Errorf("[xDS node id: %v]: authority %q not found in bootstrap config for resource %q", c.nodeID, n.Authority, resourceName), func() {})
-		})
+		watcher.OnError(fmt.Errorf("authority %q not found in bootstrap config for resource %q", n.Authority, resourceName), func() {})
 		return func() {}
 	}
 	// The watchResource method on the authority is invoked with n.String()

--- a/xds/internal/xdsclient/clientimpl_watchers.go
+++ b/xds/internal/xdsclient/clientimpl_watchers.go
@@ -29,19 +29,12 @@ import (
 // wrappingWatcher is a wrapper around an xdsresource.ResourceWatcher that adds
 // the node ID to the error messages reported to the watcher.
 type wrappingWatcher struct {
-	nodeID  string
-	watcher xdsresource.ResourceWatcher
-}
-
-func (w *wrappingWatcher) OnUpdate(update xdsresource.ResourceData, done xdsresource.OnDoneFunc) {
-	w.watcher.OnUpdate(update, done)
+	xdsresource.ResourceWatcher
+	nodeID string
 }
 
 func (w *wrappingWatcher) OnError(err error, done xdsresource.OnDoneFunc) {
-	w.watcher.OnError(fmt.Errorf("[xDS node id: %v]: %v", w.nodeID, err), done)
-}
-func (w *wrappingWatcher) OnResourceDoesNotExist(done xdsresource.OnDoneFunc) {
-	w.watcher.OnResourceDoesNotExist(done)
+	w.ResourceWatcher.OnError(fmt.Errorf("[xDS node id: %v]: %v", w.nodeID, err), done)
 }
 
 // WatchResource uses xDS to discover the resource associated with the provided
@@ -62,8 +55,8 @@ func (c *clientImpl) WatchResource(rType xdsresource.Type, resourceName string, 
 	}
 
 	watcher = &wrappingWatcher{
-		nodeID:  c.config.Node().GetId(),
-		watcher: watcher,
+		ResourceWatcher: watcher,
+		nodeID:          c.config.Node().GetId(),
 	}
 
 	if err := c.resourceTypes.maybeRegister(rType); err != nil {


### PR DESCRIPTION
Addresses first bullet point in https://github.com/grpc/grpc-go/issues/7931

RELEASE NOTES: none