### PR TITLE
deps: update go version from 1.22.0 to 1.23.0

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -43,7 +43,7 @@ jobs:
       matrix:
         include:
           - type: vet
-            goversion: '1.22'
+            goversion: '1.23'
 
           - type: extras
             goversion: '1.23'
@@ -64,7 +64,7 @@ jobs:
             goarch: arm64
 
           - type: tests
-            goversion: '1.22'
+            goversion: '1.23'
 
           - type: tests
             goversion: '1.23'

--- a/cmd/protoc-gen-go-grpc/go.mod
+++ b/cmd/protoc-gen-go-grpc/go.mod
@@ -1,6 +1,6 @@
 module google.golang.org/grpc/cmd/protoc-gen-go-grpc
 
-go 1.22.0
+go 1.23.0
 
 require (
 	google.golang.org/grpc v1.70.0

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -1,6 +1,6 @@
 module google.golang.org/grpc/examples
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/cncf/xds/go v0.0.0-20241223141626-cff3c89139a3

--- a/gcp/observability/go.mod
+++ b/gcp/observability/go.mod
@@ -1,6 +1,6 @@
 module google.golang.org/grpc/gcp/observability
 
-go 1.22.0
+go 1.23.0
 
 require (
 	cloud.google.com/go/logging v1.13.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module google.golang.org/grpc
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0

--- a/interop/observability/go.mod
+++ b/interop/observability/go.mod
@@ -1,6 +1,6 @@
 module google.golang.org/grpc/interop/observability
 
-go 1.22.0
+go 1.23.0
 
 require (
 	google.golang.org/grpc v1.70.0

--- a/interop/xds/go.mod
+++ b/interop/xds/go.mod
@@ -1,6 +1,6 @@
 module google.golang.org/grpc/interop/xds
 
-go 1.22.0
+go 1.23.0
 
 replace google.golang.org/grpc => ../..
 

--- a/security/advancedtls/examples/go.mod
+++ b/security/advancedtls/examples/go.mod
@@ -1,6 +1,6 @@
 module google.golang.org/grpc/security/advancedtls/examples
 
-go 1.22.0
+go 1.23.0
 
 require (
 	google.golang.org/grpc v1.70.0

--- a/security/advancedtls/go.mod
+++ b/security/advancedtls/go.mod
@@ -1,6 +1,6 @@
 module google.golang.org/grpc/security/advancedtls
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/google/go-cmp v0.6.0

--- a/stats/opencensus/go.mod
+++ b/stats/opencensus/go.mod
@@ -1,6 +1,6 @@
 module google.golang.org/grpc/stats/opencensus
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/google/go-cmp v0.6.0

--- a/test/tools/go.mod
+++ b/test/tools/go.mod
@@ -1,6 +1,8 @@
 module google.golang.org/grpc/test/tools
 
-go 1.22.1
+go 1.23.0
+
+toolchain go1.23.1
 
 require (
 	github.com/client9/misspell v0.3.4


### PR DESCRIPTION
#### Description

[Go 1.24.0](https://go.dev/blog/go1.24) has been released on since 11 February 2025

This update Go version from 1.22.0 to 1.23.0

RELEASE NOTES: None