### PR TITLE
ringhash: Remove TODO comment

### DIFF
--- a/xds/internal/balancer/ringhash/ringhash.go
+++ b/xds/internal/balancer/ringhash/ringhash.go
@@ -231,17 +231,6 @@ func (b *ringhashBalancer) updatePickerLocked() {
 		// TF. Since there must be at least one endpoint attempting to connect,
 		// we need to trigger one.
 		//
-		// TODO: https://github.com/grpc/grpc-go/issues/8085 - Restrict the
-		// condition under which an endpoint is connected. The pseudocode
-		// mentioned in A61 doesn't handle the following edge cases where the
-		// aggregated state is TF, but no endpoint actually enters TF:
-		// 1. There are four endpoints in the following states: TF, TF, READY,
-		//    and IDLE. If the READY endpoint fails, it transitions to IDLE,
-		//    resulting in the new states: TF, TF, IDLE, IDLE.
-		// 2. There are four endpoints in the following states: TF, TF,
-		//    CONNECTING, and IDLE. If the CONNECTING endpoint is removed, the
-		//    new states become: TF, TF, IDLE.
-
 		// After calling `ExitIdle` on a child balancer, the child will send a
 		// picker update asynchronously. A race condition may occur if another
 		// picker update from endpointsharding arrives before the child's


### PR DESCRIPTION
Fixes: https://github.com/grpc/grpc-go/issues/8085

A61 was updated in https://github.com/grpc/proposal/pull/475. Go already follows the latest proposal, so no changes are required. Tests for the two scenarios mentioned in the PR are present.
https://github.com/grpc/grpc-go/blob/59c84a951d9d180347cd8c6052e50e81b4a55168/xds/internal/balancer/ringhash/e2e/ringhash_balancer_test.go#L2216-L2542

RELEASE NOTES: N/A