### PR TITLE
chore: enable early-return and unnecessary-stmt and useless-break from revive

### DIFF
--- a/clientconn.go
+++ b/clientconn.go
@@ -1231,8 +1231,7 @@ func (ac *addrConn) updateConnectivityState(s connectivity.State, lastErr error)
 // adjustParams updates parameters used to create transports upon
 // receiving a GoAway.
 func (ac *addrConn) adjustParams(r transport.GoAwayReason) {
-	switch r {
-	case transport.GoAwayTooManyPings:
+	if r == transport.GoAwayTooManyPings {
 		v := 2 * ac.dopts.copts.KeepaliveParams.Time
 		ac.cc.mu.Lock()
 		if v > ac.cc.keepaliveParams.Time {

--- a/internal/stubserver/stubserver.go
+++ b/internal/stubserver/stubserver.go
@@ -163,8 +163,7 @@ func (ss *StubServer) setupServer(sopts ...grpc.ServerOption) (net.Listener, err
 		ss.S = grpc.NewServer(sopts...)
 	}
 	for _, so := range sopts {
-		switch x := so.(type) {
-		case *registerServiceServerOption:
+		if x, ok := so.(*registerServiceServerOption); ok {
 			x.f(ss.S)
 		}
 	}

--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -1390,8 +1390,7 @@ func (t *http2Client) handleGoAway(f *http2.GoAwayFrame) error {
 // the caller.
 func (t *http2Client) setGoAwayReason(f *http2.GoAwayFrame) {
 	t.goAwayReason = GoAwayNoReason
-	switch f.ErrCode {
-	case http2.ErrCodeEnhanceYourCalm:
+	if f.ErrCode == http2.ErrCodeEnhanceYourCalm {
 		if string(f.DebugData()) == "too_many_pings" {
 			t.goAwayReason = GoAwayTooManyPings
 		}

--- a/profiling/cmd/flags.go
+++ b/profiling/cmd/flags.go
@@ -42,11 +42,10 @@ func exactlyOneOf(opts ...bool) bool {
 			continue
 		}
 
-		if first {
-			first = false
-		} else {
+		if !first {
 			return false
 		}
+		first = false
 	}
 
 	return !first

--- a/scripts/revive.toml
+++ b/scripts/revive.toml
@@ -1,33 +1,60 @@
 # Enabled rules
 [rule.blank-imports]
+
 [rule.context-as-argument]
+
 [rule.context-keys-type]
+
 [rule.dot-imports]
+
 [rule.errorf]
+
 [rule.error-return]
+
 [rule.error-strings]
+
 [rule.error-naming]
+
 [rule.exported]
+
 [rule.increment-decrement]
+
 [rule.indent-error-flow]
+    arguments = ["preserveScope"]
+
 [rule.package-comments]
+
 [rule.range]
+
 [rule.receiver-naming]
+
 [rule.superfluous-else]
+    arguments = ["preserveScope"]
+
 [rule.time-naming]
-[rule.var-naming]
+
 [rule.unexported-return]
-[rule.unused-parameter]
+
+[rule.unnecessary-stmt]
+
 [rule.unreachable-code]
-[rule.var-declaration]
+
+[rule.unused-parameter]
+
 [rule.use-any]
+
+[rule.useless-break]
+
+[rule.var-declaration]
+
+[rule.var-naming]
 
 # Disabled rules
 [rule.empty-block] # Disabled to allow intentional no-op blocks (e.g., channel draining).
     Disabled = true
+
 [rule.import-shadowing] # Disabled to allow intentional reuse of variable names that are the same as package imports.
     Disabled = true
+
 [rule.redefines-builtin-id] # Disabled to allow intentional reuse of variable names that are the same as built-in functions.
     Disabled = true
-
-

--- a/test/bufconn/bufconn.go
+++ b/test/bufconn/bufconn.go
@@ -73,7 +73,6 @@ func (l *Listener) Close() error {
 	select {
 	case <-l.done:
 		// Already closed.
-		break
 	default:
 		close(l.done)
 	}

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -610,8 +610,7 @@ func (te *test) listenAndServe(ts testgrpc.TestServiceServer, listen func(networ
 		sopts = append(sopts, grpc.InitialConnWindowSize(te.serverInitialConnWindowSize))
 	}
 	la := ":0"
-	switch te.e.network {
-	case "unix":
+	if te.e.network == "unix" {
 		la = "/tmp/testsock" + fmt.Sprintf("%d", time.Now().UnixNano())
 		syscall.Unlink(la)
 	}


### PR DESCRIPTION
#### Description

This add early-return and unnecessary-stmt and useless-break rules and fix them as they were mostly applied.
It also provide "preserveScope" argument for indent-error-flow and superfluous-else rules to avoid suggestions of refactorings that would increase variable scope.

RELEASE NOTES: None