### PR TITLE
grpc_test: add tests for cardinality violation

### DIFF
--- a/stream_test.go
+++ b/stream_test.go
@@ -20,19 +20,15 @@ package grpc_test
 
 import (
 	"context"
-	"io"
 	"testing"
 	"time"
 
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/internal/grpctest"
 	"google.golang.org/grpc/internal/stubserver"
 	"google.golang.org/grpc/status"
 
 	testgrpc "google.golang.org/grpc/interop/grpc_testing"
-	testpb "google.golang.org/grpc/interop/grpc_testing"
 )
 
 const defaultTestTimeout = 10 * time.Second
@@ -69,97 +65,4 @@ func (s) TestStream_Header_TrailersOnly(t *testing.T) {
 	if _, err := s.Recv(); status.Code(err) != codes.NotFound {
 		t.Fatalf("s.Recv() = _, %v; want _, err.Code()=codes.NotFound", err)
 	}
-}
-
-func TestCardinalityViolation(t *testing.T) {
-	ss := stubserver.StubServer{
-		StreamingInputCallF: func(stream testgrpc.TestService_StreamingInputCallServer) error {
-			stream.Recv()
-			// if err != nil {
-			// 	return err
-			// }
-			return nil
-		},
-	}
-	if err := ss.Start(nil); err != nil {
-		t.Fatal("Error starting server:", err)
-	}
-	defer ss.Stop()
-	// Establish a connection to the server.
-	cc, err := grpc.NewClient(ss.Address, grpc.WithTransportCredentials(insecure.NewCredentials()))
-	if err != nil {
-		t.Fatalf("grpc.NewClient(%v) failed: %v", ss.Address, err)
-	}
-	defer cc.Close()
-	client := testgrpc.NewTestServiceClient(cc)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	// ctx = metadata.NewOutgoingContext(ctx, test.md)
-
-	// Verifying authorization decision for Streaming RPC.
-	stream, err := client.StreamingInputCall(ctx)
-	if err != nil {
-		t.Fatalf("failed StreamingInputCall err: %v", err)
-	}
-	req := &testpb.StreamingInputCallRequest{
-		Payload: &testpb.Payload{
-			Body: []byte("hi"),
-		},
-	}
-	err = stream.Send(req)
-	if err != nil {
-		t.Fatalf("failed stream.Send err: %v", err)
-	}
-	_, err = stream.CloseAndRecv()
-	t.Fatalf("error should have been received , %v", err)
-	if err == nil {
-		t.Fatalf("error should have been received , %v", err)
-	}
-}
-
-func TestCardinalityViolation2(t *testing.T) {
-	ss := stubserver.StubServer{
-		StreamingInputCallF: func(stream testgrpc.TestService_StreamingInputCallServer) error {
-			stream.SendAndClose(&testgrpc.StreamingInputCallResponse{})
-			_, err := stream.Recv()
-			return err
-		},
-	}
-	if err := ss.Start(nil); err != nil {
-		t.Fatal("Error starting server:", err)
-	}
-	defer ss.Stop()
-	// Establish a connection to the server.
-	cc, err := grpc.NewClient(ss.Address, grpc.WithTransportCredentials(insecure.NewCredentials()))
-	if err != nil {
-		t.Fatalf("grpc.NewClient(%v) failed: %v", ss.Address, err)
-	}
-	defer cc.Close()
-	client := testgrpc.NewTestServiceClient(cc)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	// ctx = metadata.NewOutgoingContext(ctx, test.md)
-
-	// Verifying authorization decision for Streaming RPC.
-	stream, err := client.StreamingInputCall(ctx)
-	if err != nil {
-		t.Fatalf("failed StreamingInputCall err: %v", err)
-	}
-	req := &testpb.StreamingInputCallRequest{
-		Payload: &testpb.Payload{
-			Body: []byte("hi"),
-		},
-	}
-	for {
-		if err := stream.Send(req); err != nil && err != io.EOF {
-			t.Fatalf("failed stream.Send err: %v", err)
-		}
-	}
-	// _, err = stream.CloseAndRecv()
-	// t.Fatalf("error should have been received , %v", err)
-	// if err == nil {
-	// 	t.Fatalf("error should have been received , %v", err)
-	// }
 }

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -3658,7 +3658,6 @@ func (s) TestClientStreamingCardinalityViolation_ServerHandlerRecvAfterSendAndCl
 	}
 
 	req := &testpb.StreamingInputCallRequest{Payload: payload}
-	//eshita break on eof , any other error t.Fatal
 	for {
 		if err = stream.Send(req); err == io.EOF {
 			break

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -3660,9 +3660,10 @@ func testClientStreamingRecvAfterCloseError(t *testing.T, e env) {
 		if err = stream.Send(req); err == nil {
 			continue
 		}
-		if status.Code(err) != codes.Internal {
+		if _, err := stream.CloseAndRecv(); status.Code(err) != codes.Internal {
 			t.Fatalf("%v.CloseAndRecv() = %v, want error %s", stream, err, codes.Internal)
 		}
+		break
 	}
 }
 

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -3729,7 +3729,7 @@ func (s) TestClientStreaming_ReturnErrorAfterSendAndClose(t *testing.T) {
 	if err != nil {
 		t.Fatalf(".StreamingInputCall(_) = _, %v, want <nil>", err)
 	}
-	if resp, err := stream.CloseAndRecv(); err != wantError || resp != nil {
+	if resp, err := stream.CloseAndRecv(); status.Code(err) != codes.Internal || resp != nil {
 		t.Fatalf("stream.CloseSend() = %v , %v, want <nil>, %s", resp, err, wantError)
 	}
 }

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -3607,7 +3607,7 @@ func (s) TestClientStreamingMissingSendAndCloseError(t *testing.T) {
 
 func testClientStreamingMissingSendAndCloseError(t *testing.T) {
 	ss := &stubserver.StubServer{
-		StreamingInputCallF: func(stream testgrpc.TestService_StreamingInputCallServer) error {
+		StreamingInputCallF: func(_ testgrpc.TestService_StreamingInputCallServer) error {
 			return nil
 		},
 	}

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -146,8 +146,6 @@ type testServer struct {
 	setHeaderOnly      bool   // whether to only call setHeader, not sendHeader.
 	multipleSetTrailer bool   // whether to call setTrailer multiple times.
 	unaryCallSleepTime time.Duration
-	earlyNil           bool // whether to return nil without calling SendAndClose().
-	recvAfterClose     bool // whether to call Recv() after calling SendAndClose().
 }
 
 func (s *testServer) EmptyCall(ctx context.Context, _ *testpb.Empty) (*testpb.Empty, error) {
@@ -286,16 +284,6 @@ func (s *testServer) StreamingOutputCall(args *testpb.StreamingOutputCallRequest
 
 func (s *testServer) StreamingInputCall(stream testgrpc.TestService_StreamingInputCallServer) error {
 	var sum int
-	if s.earlyNil {
-		return nil
-	}
-	if s.recvAfterClose {
-		stream.SendAndClose(&testpb.StreamingInputCallResponse{
-			AggregatedPayloadSize: int32(sum),
-		})
-		_, err := stream.Recv()
-		return err
-	}
 	for {
 		in, err := stream.Recv()
 		if err == io.EOF {


### PR DESCRIPTION
Fixes: #7570

Added the following tests for client streaming RPC : 
1. Client should ensure a status `internal` error is returned for client-streaming RPCs if the server doesn't send a message before returning status OK. This is a cardinality violation. Skipping this test for now till the issues are fixed: #8119 
2.   Server can continue to receive messages after calling SendAndClose.
3. Recv() on client streaming client blocks till the server handler returns even after calling SendAndClose from the server handler
4. Client receives nil message and non-nil error when server handler returns an error after calling SendAndClose.


RELEASE NOTES: N/A