### PR TITLE
github/test: Run tests using the old pickfirst

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -69,7 +69,7 @@ jobs:
           - type: tests
             goversion: '1.24'
             testflags: -race
-            grpcenv: 'GRPC_EXPERIMENTAL_ENABLE_NEW_PICK_FIRST=true'
+            grpcenv: 'GRPC_EXPERIMENTAL_ENABLE_NEW_PICK_FIRST=false'
 
     steps:
       # Setup the environment.


### PR DESCRIPTION
https://github.com/grpc/grpc-go/pull/8126 toggled the default pickfirst to the new one. This PR ensures we still have coverage for the old pickfirst till it exists.

RELEASE NOTES: N/A