### PR TITLE
xds: ensure xDS node ID is populated in errors from xds resolver and cds lb policy

### DIFF
--- a/xds/internal/balancer/cdsbalancer/cdsbalancer.go
+++ b/xds/internal/balancer/cdsbalancer/cdsbalancer.go
@@ -430,6 +430,20 @@ func (b *cdsBalancer) ExitIdle() {
 	})
 }
 
+// Node ID needs to be manually added to errors generated in the following
+// scenarios:
+//   - resource-does-not-exist: since the xDS watch API uses a separate callback
+//     instead of returning an error value,
+//   - received a good update from the xDS client, but the update either contains
+//     an invalid security configuration or contains invalid aggragate cluster
+//     config.
+//
+// Only executed in the context of a serializer callback.
+func (b *cdsBalancer) annotateErrorWithNodeID(err error) error {
+	nodeID := b.xdsClient.BootstrapConfig().Node().GetId()
+	return fmt.Errorf("[xDS node id: %v]: %w", nodeID, err)
+}
+
 // Handles a good Cluster update from the xDS client. Kicks off the discovery
 // mechanism generation process from the top-level cluster and if the cluster
 // graph is resolved, generates child policy config and pushes it down.
@@ -459,7 +473,7 @@ func (b *cdsBalancer) onClusterUpdate(name string, update xdsresource.ClusterUpd
 			// If the security config is invalid, for example, if the provider
 			// instance is not found in the bootstrap config, we need to put the
 			// channel in transient failure.
-			b.onClusterError(name, fmt.Errorf("received Cluster resource contains invalid security config: %v", err))
+			b.onClusterError(name, b.annotateErrorWithNodeID(fmt.Errorf("received Cluster resource contains invalid security config: %v", err)))
 			return
 		}
 	}
@@ -467,12 +481,12 @@ func (b *cdsBalancer) onClusterUpdate(name string, update xdsresource.ClusterUpd
 	clustersSeen := make(map[string]bool)
 	dms, ok, err := b.generateDMsForCluster(b.lbCfg.ClusterName, 0, nil, clustersSeen)
 	if err != nil {
-		b.onClusterError(b.lbCfg.ClusterName, fmt.Errorf("failed to generate discovery mechanisms: %v", err))
+		b.onClusterError(b.lbCfg.ClusterName, b.annotateErrorWithNodeID(fmt.Errorf("failed to generate discovery mechanisms: %v", err)))
 		return
 	}
 	if ok {
 		if len(dms) == 0 {
-			b.onClusterError(b.lbCfg.ClusterName, fmt.Errorf("aggregate cluster graph has no leaf clusters"))
+			b.onClusterError(b.lbCfg.ClusterName, b.annotateErrorWithNodeID(fmt.Errorf("aggregate cluster graph has no leaf clusters")))
 			return
 		}
 		// Child policy is built the first time we resolve the cluster graph.
@@ -557,7 +571,7 @@ func (b *cdsBalancer) onClusterError(name string, err error) {
 //
 // Only executed in the context of a serializer callback.
 func (b *cdsBalancer) onClusterResourceNotFound(name string) {
-	err := xdsresource.NewErrorf(xdsresource.ErrorTypeResourceNotFound, "cluster %q not found", name)
+	err := b.annotateErrorWithNodeID(xdsresource.NewErrorf(xdsresource.ErrorTypeResourceNotFound, "cluster %q not found", name))
 	b.closeChildPolicyAndReportTF(err)
 }
 

--- a/xds/internal/balancer/cdsbalancer/cdsbalancer.go
+++ b/xds/internal/balancer/cdsbalancer/cdsbalancer.go
@@ -433,12 +433,13 @@ func (b *cdsBalancer) ExitIdle() {
 // Node ID needs to be manually added to errors generated in the following
 // scenarios:
 //   - resource-does-not-exist: since the xDS watch API uses a separate callback
-//     instead of returning an error value,
+//     instead of returning an error value. TODO(gRFC A88): Once A88 is
+//     implemented, the xDS client will be able to add the node ID to
+//     resource-does-not-exist errors as well, and we can get rid of this
+//     special handling.
 //   - received a good update from the xDS client, but the update either contains
 //     an invalid security configuration or contains invalid aggragate cluster
 //     config.
-//
-// Only executed in the context of a serializer callback.
 func (b *cdsBalancer) annotateErrorWithNodeID(err error) error {
 	nodeID := b.xdsClient.BootstrapConfig().Node().GetId()
 	return fmt.Errorf("[xDS node id: %v]: %w", nodeID, err)

--- a/xds/internal/balancer/cdsbalancer/cdsbalancer_test.go
+++ b/xds/internal/balancer/cdsbalancer/cdsbalancer_test.go
@@ -999,7 +999,7 @@ func (s) TestClusterUpdate_ResourceNotFound(t *testing.T) {
 	testutils.AwaitState(ctx, t, cc, connectivity.TransientFailure)
 
 	// Ensure RPC fails with Unavailable status code and the error message is
-	// meaningul and contains the xDS node ID.
+	// meaningful and contains the xDS node ID.
 	wantErr := fmt.Sprintf("cluster %q not found", clusterName)
 	_, err := client.EmptyCall(ctx, &testpb.Empty{})
 	if err := verifyRPCError(err, codes.Unavailable, wantErr, nodeID); err != nil {

--- a/xds/internal/balancer/cdsbalancer/cdsbalancer_test.go
+++ b/xds/internal/balancer/cdsbalancer/cdsbalancer_test.go
@@ -729,7 +729,7 @@ func (s) TestClusterUpdate_Failure(t *testing.T) {
 	const wantClusterNACKErr = "unsupported config_source_specifier"
 	client := testgrpc.NewTestServiceClient(cc)
 	_, err := client.EmptyCall(ctx, &testpb.Empty{})
-	if err := verifyRPCError(err, codes.Unavailable, wantClusterNACKErr, nodeID); err != nil{
+	if err := verifyRPCError(err, codes.Unavailable, wantClusterNACKErr, nodeID); err != nil {
 		t.Fatal(err)
 	}
 

--- a/xds/internal/balancer/cdsbalancer/cdsbalancer_test.go
+++ b/xds/internal/balancer/cdsbalancer/cdsbalancer_test.go
@@ -19,7 +19,6 @@ package cdsbalancer
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net"
 	"strings"
@@ -297,6 +296,22 @@ func compareLoadBalancingConfig(ctx context.Context, lbCfgCh chan serviceconfig.
 		}
 	case <-ctx.Done():
 		return fmt.Errorf("timeout when waiting for child policy to receive its configuration")
+	}
+	return nil
+}
+
+func verifyRPCError(gotErr error, wantCode codes.Code, wantErr, wantNodeID string) error {
+	if gotErr == nil {
+		return fmt.Errorf("RPC succeeded when expecting an error with code %v, message %q and nodeID %q", wantCode, wantErr, wantNodeID)
+	}
+	if gotCode := status.Code(gotErr); gotCode != wantCode {
+		return fmt.Errorf("RPC failed with code: %v, want code %v", gotCode, wantCode)
+	}
+	if !strings.Contains(gotErr.Error(), wantErr) {
+		return fmt.Errorf("RPC failed with error: %v, want %q", gotErr, wantErr)
+	}
+	if !strings.Contains(gotErr.Error(), wantNodeID) {
+		return fmt.Errorf("RPC failed with error: %v, want nodeID %q", gotErr, wantNodeID)
 	}
 	return nil
 }
@@ -709,15 +724,13 @@ func (s) TestClusterUpdate_Failure(t *testing.T) {
 
 	testutils.AwaitState(ctx, t, cc, connectivity.TransientFailure)
 
-	// Ensure that the NACK error is propagated to the RPC caller.
+	// Ensure that the NACK error and the xDS node ID are propagated to the RPC
+	// caller.
 	const wantClusterNACKErr = "unsupported config_source_specifier"
 	client := testgrpc.NewTestServiceClient(cc)
 	_, err := client.EmptyCall(ctx, &testpb.Empty{})
-	if code := status.Code(err); code != codes.Unavailable {
-		t.Fatalf("EmptyCall() failed with code: %v, want %v", code, codes.Unavailable)
-	}
-	if err != nil && !strings.Contains(err.Error(), wantClusterNACKErr) {
-		t.Fatalf("EmptyCall() failed with err: %v, want err containing: %v", err, wantClusterNACKErr)
+	if err := verifyRPCError(err, codes.Unavailable, wantClusterNACKErr, nodeID); err != nil{
+		t.Fatal(err)
 	}
 
 	// Start a test service backend.
@@ -811,8 +824,10 @@ func (s) TestResolverError(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Push a resolver error that is not a resource-not-found error.
-	resolverErr := errors.New("resolver-error-not-a-resource-not-found-error")
+	// Push a resolver error that is not a resource-not-found error. Here, we
+	// assume that errors from the xDS client or from the xDS resolver contain
+	// the xDS node ID.
+	resolverErr := fmt.Errorf("[xds node id: %s]: resolver-error-not-a-resource-not-found-error", nodeID)
 	r.ReportError(resolverErr)
 
 	testutils.AwaitState(ctx, t, cc, connectivity.TransientFailure)
@@ -826,11 +841,8 @@ func (s) TestResolverError(t *testing.T) {
 	// Ensure that the resolver error is propagated to the RPC caller.
 	client := testgrpc.NewTestServiceClient(cc)
 	_, err = client.EmptyCall(ctx, &testpb.Empty{})
-	if code := status.Code(err); code != codes.Unavailable {
-		t.Fatalf("EmptyCall() failed with code: %v, want %v", code, codes.Unavailable)
-	}
-	if err != nil && !strings.Contains(err.Error(), resolverErr.Error()) {
-		t.Fatalf("EmptyCall() failed with err: %v, want %v", err, resolverErr)
+	if err := verifyRPCError(err, codes.Unavailable, resolverErr.Error(), nodeID); err != nil {
+		t.Fatal(err)
 	}
 
 	// Also verify that the watch for the cluster resource is not cancelled.
@@ -891,8 +903,15 @@ func (s) TestResolverError(t *testing.T) {
 		t.Fatal("Timeout when waiting for resolver error to be pushed to the child policy")
 	}
 
-	// Push a resource-not-found-error this time around.
-	resolverErr = xdsresource.NewError(xdsresource.ErrorTypeResourceNotFound, "xds resource not found error")
+	// Push a resource-not-found-error this time around. Our xDS resolver does
+	// not send this error though. When an LDS or RDS resource is missing, the
+	// xDS resolver instead sends an erroring config selector which returns an
+	// error at RPC time with the xDS node ID, for new RPCs. Once ongoing RPCs
+	// complete, the xDS resolver will send an empty service config with no
+	// addresses, which will result in pick_first being configured on the
+	// channel. And pick_first will put the channel in TRANSIENT_FAILURE since
+	// it would have received an update with no addresses.
+	resolverErr = fmt.Errorf("[xds node id: %s]: %w", nodeID, xdsresource.NewError(xdsresource.ErrorTypeResourceNotFound, "xds resource not found error"))
 	r.ReportError(resolverErr)
 
 	// Wait for the CDS resource to be not requested anymore, or the connection
@@ -914,11 +933,10 @@ func (s) TestResolverError(t *testing.T) {
 
 	testutils.AwaitState(ctx, t, cc, connectivity.TransientFailure)
 
-	// Ensure RPC fails with Unavailable. The actual error message depends on
-	// the picker returned from the priority LB policy, and therefore not
-	// checking for it here.
-	if _, err := client.EmptyCall(ctx, &testpb.Empty{}); status.Code(err) != codes.Unavailable {
-		t.Fatalf("EmptyCall() failed with code: %v, want %v", status.Code(err), codes.Unavailable)
+	// Ensure that the resolver error is propagated to the RPC caller.
+	_, err = client.EmptyCall(ctx, &testpb.Empty{})
+	if err := verifyRPCError(err, codes.Unavailable, resolverErr.Error(), nodeID); err != nil {
+		t.Fatal(err)
 	}
 }
 
@@ -980,14 +998,12 @@ func (s) TestClusterUpdate_ResourceNotFound(t *testing.T) {
 
 	testutils.AwaitState(ctx, t, cc, connectivity.TransientFailure)
 
-	// Ensure RPC fails with Unavailable.
+	// Ensure RPC fails with Unavailable status code and the error message is
+	// meaningul and contains the xDS node ID.
 	wantErr := fmt.Sprintf("cluster %q not found", clusterName)
 	_, err := client.EmptyCall(ctx, &testpb.Empty{})
-	if status.Code(err) != codes.Unavailable {
-		t.Fatalf("EmptyCall() failed with code: %v, want %v", status.Code(err), codes.Unavailable)
-	}
-	if !strings.Contains(err.Error(), wantErr) {
-		t.Fatalf("EmptyCall() failed with error: %v, want %v", err, wantErr)
+	if err := verifyRPCError(err, codes.Unavailable, wantErr, nodeID); err != nil {
+		t.Fatal(err)
 	}
 
 	// Re-add the cluster resource to the management server.

--- a/xds/internal/balancer/priority/balancer.go
+++ b/xds/internal/balancer/priority/balancer.go
@@ -210,6 +210,9 @@ func (b *priorityBalancer) UpdateClientConnState(s balancer.ClientConnState) err
 }
 
 func (b *priorityBalancer) ResolverError(err error) {
+	if b.logger.V(2) {
+		b.logger.Infof("Received error from the resolver: %v", err)
+	}
 	b.bg.ResolverError(err)
 }
 

--- a/xds/internal/resolver/cluster_specifier_plugin_test.go
+++ b/xds/internal/resolver/cluster_specifier_plugin_test.go
@@ -115,7 +115,7 @@ func (s) TestResolverClusterSpecifierPlugin(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
 	nodeID := uuid.New().String()
-	mgmtServer, _, _, bc := setupManagementServerForTest(ctx, t, nodeID)
+	mgmtServer, _, _, bc := setupManagementServerForTest(t, nodeID)
 
 	// Configure resources on the management server.
 	listeners := []*v3listenerpb.Listener{e2e.DefaultClientListener(defaultTestServiceName, defaultTestRouteConfigName)}
@@ -205,7 +205,7 @@ func (s) TestXDSResolverDelayedOnCommittedCSP(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
 	nodeID := uuid.New().String()
-	mgmtServer, _, _, bc := setupManagementServerForTest(ctx, t, nodeID)
+	mgmtServer, _, _, bc := setupManagementServerForTest(t, nodeID)
 
 	// Configure resources on the management server.
 	listeners := []*v3listenerpb.Listener{e2e.DefaultClientListener(defaultTestServiceName, defaultTestRouteConfigName)}

--- a/xds/internal/resolver/serviceconfig.go
+++ b/xds/internal/resolver/serviceconfig.go
@@ -145,7 +145,7 @@ func newErroringConfigSelector(xdsNodeID string) *erroringConfigSelector {
 	return &erroringConfigSelector{err: annotateErrorWithNodeID(status.Errorf(codes.Unavailable, "no valid clusters"), xdsNodeID)}
 }
 
-func (cs *erroringConfigSelector) SelectConfig(rpcInfo iresolver.RPCInfo) (*iresolver.RPCConfig, error) {
+func (cs *erroringConfigSelector) SelectConfig(iresolver.RPCInfo) (*iresolver.RPCConfig, error) {
 	return nil, cs.err
 }
 func (cs *erroringConfigSelector) stop() {}

--- a/xds/internal/resolver/watch_service_test.go
+++ b/xds/internal/resolver/watch_service_test.go
@@ -46,7 +46,7 @@ func (s) TestServiceWatch_ListenerPointsToNewRouteConfiguration(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
 	nodeID := uuid.New().String()
-	mgmtServer, lisCh, routeCfgCh, bc := setupManagementServerForTest(ctx, t, nodeID)
+	mgmtServer, lisCh, routeCfgCh, bc := setupManagementServerForTest(t, nodeID)
 
 	// Configure resources on the management server.
 	listeners := []*v3listenerpb.Listener{e2e.DefaultClientListener(defaultTestServiceName, defaultTestRouteConfigName)}
@@ -103,7 +103,7 @@ func (s) TestServiceWatch_ListenerPointsToInlineRouteConfiguration(t *testing.T)
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
 	nodeID := uuid.New().String()
-	mgmtServer, lisCh, routeCfgCh, bc := setupManagementServerForTest(ctx, t, nodeID)
+	mgmtServer, lisCh, routeCfgCh, bc := setupManagementServerForTest(t, nodeID)
 
 	// Configure resources on the management server.
 	listeners := []*v3listenerpb.Listener{e2e.DefaultClientListener(defaultTestServiceName, defaultTestRouteConfigName)}

--- a/xds/internal/resolver/xds_resolver.go
+++ b/xds/internal/resolver/xds_resolver.go
@@ -249,7 +249,7 @@ type xdsResolver struct {
 	// cluster that includes a ref count and load balancing configuration.
 	activeClusters map[string]*clusterInfo
 
-	curConfigSelector *configSelector
+	curConfigSelector stoppableConfigSelector
 }
 
 // ResolveNow is a no-op at this point.
@@ -284,13 +284,13 @@ func (r *xdsResolver) Close() {
 // false if an error occurs while sending an update to the channel.
 //
 // Only executed in the context of a serializer callback.
-func (r *xdsResolver) sendNewServiceConfig(cs *configSelector) bool {
+func (r *xdsResolver) sendNewServiceConfig(cs stoppableConfigSelector) bool {
 	// Delete entries from r.activeClusters with zero references;
 	// otherwise serviceConfigJSON will generate a config including
 	// them.
 	r.pruneActiveClusters()
 
-	if cs == nil && len(r.activeClusters) == 0 {
+	if isErroringConfigSelector(cs) && len(r.activeClusters) == 0 {
 		// There are no clusters and we are sending a failing configSelector.
 		// Send an empty config, which picks pick-first, with no address, and
 		// puts the ClientConn into transient failure.
@@ -326,7 +326,8 @@ func (r *xdsResolver) sendNewServiceConfig(cs *configSelector) bool {
 // Only executed in the context of a serializer callback.
 func (r *xdsResolver) newConfigSelector() *configSelector {
 	cs := &configSelector{
-		r: r,
+		r:         r,
+		xdsNodeID: r.xdsClient.BootstrapConfig().Node().GetId(),
 		virtualHost: virtualHost{
 			httpFilterConfigOverride: r.currentVirtualHost.HTTPFilterConfigOverride,
 			retryConfig:              r.currentVirtualHost.RetryConfig,
@@ -438,14 +439,16 @@ func (r *xdsResolver) onResolutionComplete() {
 
 	cs := r.newConfigSelector()
 	if !r.sendNewServiceConfig(cs) {
-		// JSON error creating the service config (unexpected); erase
+		// Channel didn't like the update we provided (unexpected); erase
 		// this config selector and ignore this update, continuing with
 		// the previous config selector.
 		cs.stop()
 		return
 	}
 
-	r.curConfigSelector.stop()
+	if r.curConfigSelector != nil {
+		r.curConfigSelector.stop()
+	}
 	r.curConfigSelector = cs
 }
 
@@ -477,18 +480,21 @@ func (r *xdsResolver) onError(err error) {
 // Only executed in the context of a serializer callback.
 func (r *xdsResolver) onResourceNotFound() {
 	// We cannot remove clusters from the service config that have ongoing RPCs.
-	// Instead, what we can do is to send an erroring (nil) config selector
+	// Instead, what we can do is to send an erroring config selector
 	// along with normal service config. This will ensure that new RPCs will
 	// fail, and once the active RPCs complete, the reference counts on the
 	// clusters will come down to zero. At that point, we will send an empty
 	// service config with no addresses. This results in the pick-first
 	// LB policy being configured on the channel, and since there are no
 	// address, pick-first will put the channel in TRANSIENT_FAILURE.
-	r.sendNewServiceConfig(nil)
+	cs := &erroringConfigSelector{xdsNodeID: r.xdsClient.BootstrapConfig().Node().GetId()}
+	r.sendNewServiceConfig(cs)
 
 	// Stop and dereference the active config selector, if one exists.
-	r.curConfigSelector.stop()
-	r.curConfigSelector = nil
+	if r.curConfigSelector != nil {
+		r.curConfigSelector.stop()
+	}
+	r.curConfigSelector = cs
 }
 
 // Only executed in the context of a serializer callback.

--- a/xds/internal/resolver/xds_resolver_test.go
+++ b/xds/internal/resolver/xds_resolver_test.go
@@ -41,7 +41,6 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/resolver"
 	"google.golang.org/grpc/serviceconfig"
-	"google.golang.org/grpc/status"
 	"google.golang.org/grpc/xds/internal/balancer/clustermanager"
 	"google.golang.org/grpc/xds/internal/balancer/ringhash"
 	"google.golang.org/grpc/xds/internal/httpfilter"
@@ -165,7 +164,7 @@ func (s) TestResolverResourceName(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 			defer cancel()
 			nodeID := uuid.New().String()
-			mgmtServer, lisCh, _, _ := setupManagementServerForTest(ctx, t, nodeID)
+			mgmtServer, lisCh, _, _ := setupManagementServerForTest(t, nodeID)
 
 			// Create a bootstrap configuration with test options.
 			opts := bootstrap.ConfigOptionsForTesting{
@@ -300,7 +299,7 @@ func (s) TestResolverBadServiceUpdate(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
 	nodeID := uuid.New().String()
-	mgmtServer, _, _, bc := setupManagementServerForTest(ctx, t, nodeID)
+	mgmtServer, _, _, bc := setupManagementServerForTest(t, nodeID)
 
 	// Configure a listener resource that is expected to be NACKed because it
 	// does not contain the `RouteSpecifier` field in the HTTPConnectionManager.
@@ -323,7 +322,9 @@ func (s) TestResolverBadServiceUpdate(t *testing.T) {
 	// Build the resolver and expect an error update from it.
 	stateCh, errCh, _ := buildResolverForTarget(t, resolver.Target{URL: *testutils.MustParseURL("xds:///" + defaultTestServiceName)}, bc)
 	wantErr := "no RouteSpecifier"
-	verifyErrorFromResolver(ctx, t, errCh, wantErr)
+	if err := waitForErrorFromResolver(ctx, errCh, wantErr, nodeID); err != nil {
+		t.Fatal(err)
+	}
 
 	// Configure good listener and route configuration resources on the
 	// management server.
@@ -337,7 +338,9 @@ func (s) TestResolverBadServiceUpdate(t *testing.T) {
 	// Configure another bad resource on the management server and expect an
 	// error update from the resolver.
 	configureResourcesOnManagementServer(ctx, t, mgmtServer, nodeID, []*v3listenerpb.Listener{lis}, nil)
-	verifyErrorFromResolver(ctx, t, errCh, wantErr)
+	if err := waitForErrorFromResolver(ctx, errCh, wantErr, nodeID); err != nil {
+		t.Fatal(err)
+	}
 }
 
 // TestResolverGoodServiceUpdate tests the case where the resource returned by
@@ -404,7 +407,7 @@ func (s) TestResolverGoodServiceUpdate(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 			defer cancel()
 			nodeID := uuid.New().String()
-			mgmtServer, _, _, bc := setupManagementServerForTest(ctx, t, nodeID)
+			mgmtServer, _, _, bc := setupManagementServerForTest(t, nodeID)
 
 			// Configure the management server with a good listener resource and a
 			// route configuration resource, as specified by the test case.
@@ -445,7 +448,7 @@ func (s) TestResolverRequestHash(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
 	nodeID := uuid.New().String()
-	mgmtServer, _, _, bc := setupManagementServerForTest(ctx, t, nodeID)
+	mgmtServer, _, _, bc := setupManagementServerForTest(t, nodeID)
 
 	// Configure the management server with a good listener resource and a
 	// route configuration resource that specifies a hash policy.
@@ -508,7 +511,7 @@ func (s) TestResolverRemovedWithRPCs(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
 	nodeID := uuid.New().String()
-	mgmtServer, _, _, bc := setupManagementServerForTest(ctx, t, nodeID)
+	mgmtServer, _, _, bc := setupManagementServerForTest(t, nodeID)
 
 	// Configure resources on the management server.
 	listeners := []*v3listenerpb.Listener{e2e.DefaultClientListener(defaultTestServiceName, defaultTestRouteConfigName)}
@@ -537,8 +540,8 @@ func (s) TestResolverRemovedWithRPCs(t *testing.T) {
 	// return an erroring config selector which will fail new RPCs.
 	cs = verifyUpdateFromResolver(ctx, t, stateCh, wantDefaultServiceConfig)
 	_, err = cs.SelectConfig(iresolver.RPCInfo{Context: ctx, Method: "/service/method"})
-	if err == nil || status.Code(err) != codes.Unavailable {
-		t.Fatalf("cs.SelectConfig() returned: %v, want: %v", err, codes.Unavailable)
+	if err := verifyResolverError(err, codes.Unavailable, "no valid clusters", nodeID); err != nil {
+		t.Fatal(err)
 	}
 
 	// "Finish the RPC"; this could cause a panic if the resolver doesn't
@@ -610,14 +613,14 @@ func (s) TestResolverRemovedResource(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
 	nodeID := uuid.New().String()
-	mgmtServer, _, _, bc := setupManagementServerForTest(ctx, t, nodeID)
+	mgmtServer, _, _, bc := setupManagementServerForTest(t, nodeID)
 
 	// Configure resources on the management server.
 	listeners := []*v3listenerpb.Listener{e2e.DefaultClientListener(defaultTestServiceName, defaultTestRouteConfigName)}
 	routes := []*v3routepb.RouteConfiguration{e2e.DefaultRouteConfig(defaultTestRouteConfigName, defaultTestServiceName, defaultTestClusterName)}
 	configureResourcesOnManagementServer(ctx, t, mgmtServer, nodeID, listeners, routes)
 
-	stateCh, _, _ := buildResolverForTarget(t, resolver.Target{URL: *testutils.MustParseURL("xds:///" + defaultTestServiceName)}, bc)
+	stateCh, errCh, _ := buildResolverForTarget(t, resolver.Target{URL: *testutils.MustParseURL("xds:///" + defaultTestServiceName)}, bc)
 
 	// Read the update pushed by the resolver to the ClientConn.
 	cs := verifyUpdateFromResolver(ctx, t, stateCh, wantDefaultServiceConfig)
@@ -644,8 +647,8 @@ func (s) TestResolverRemovedResource(t *testing.T) {
 
 	// "Make another RPC" by invoking the config selector.
 	res, err = cs.SelectConfig(iresolver.RPCInfo{Context: ctx, Method: "/service/method"})
-	if err == nil || status.Code(err) != codes.Unavailable {
-		t.Fatalf("cs.SelectConfig() got %v, %v, expected UNAVAILABLE error", res, err)
+	if err := verifyResolverError(err, codes.Unavailable, "no valid clusters", nodeID); err != nil {
+		t.Fatal(err)
 	}
 
 	// In the meantime, an empty ServiceConfig update should have been sent.
@@ -662,6 +665,16 @@ func (s) TestResolverRemovedResource(t *testing.T) {
 			t.Fatalf("Got service config:\n%s \nWant service config:\n%s", cmp.Diff(nil, state.ServiceConfig.Config), cmp.Diff(nil, wantSCParsed.Config))
 		}
 	}
+
+	// The xDS resolver is expected to report an error to the channel.
+	select {
+	case <-ctx.Done():
+		t.Fatalf("Timeout waiting for an error from the resolver: %v", ctx.Err())
+	case err := <-errCh:
+		if err := verifyResolverError(err, codes.Unavailable, "no valid clusters", nodeID); err != nil {
+			t.Fatal(err)
+		}
+	}
 }
 
 // Tests the case where the resolver receives max stream duration as part of the
@@ -674,7 +687,7 @@ func (s) TestResolverMaxStreamDuration(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
 	nodeID := uuid.New().String()
-	mgmtServer, _, _, bc := setupManagementServerForTest(ctx, t, nodeID)
+	mgmtServer, _, _, bc := setupManagementServerForTest(t, nodeID)
 
 	stateCh, _, _ := buildResolverForTarget(t, resolver.Target{URL: *testutils.MustParseURL("xds:///" + defaultTestServiceName)}, bc)
 
@@ -807,7 +820,7 @@ func (s) TestResolverDelayedOnCommitted(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
 	nodeID := uuid.New().String()
-	mgmtServer, _, _, bc := setupManagementServerForTest(ctx, t, nodeID)
+	mgmtServer, _, _, bc := setupManagementServerForTest(t, nodeID)
 
 	// Configure resources on the management server.
 	listeners := []*v3listenerpb.Listener{e2e.DefaultClientListener(defaultTestServiceName, defaultTestRouteConfigName)}
@@ -917,7 +930,7 @@ func (s) TestResolverMultipleLDSUpdates(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
 	nodeID := uuid.New().String()
-	mgmtServer, _, _, bc := setupManagementServerForTest(ctx, t, nodeID)
+	mgmtServer, _, _, bc := setupManagementServerForTest(t, nodeID)
 
 	// Configure the management server with a listener resource, but no route
 	// configuration resource.
@@ -975,7 +988,7 @@ func (s) TestResolverWRR(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
 	nodeID := uuid.New().String()
-	mgmtServer, _, _, bc := setupManagementServerForTest(ctx, t, nodeID)
+	mgmtServer, _, _, bc := setupManagementServerForTest(t, nodeID)
 
 	stateCh, _, _ := buildResolverForTarget(t, resolver.Target{URL: *testutils.MustParseURL("xds:///" + defaultTestServiceName)}, bc)
 
@@ -1174,7 +1187,7 @@ func (s) TestConfigSelector_FailureCases(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 			defer cancel()
 			nodeID := uuid.New().String()
-			mgmtServer, _, _, bc := setupManagementServerForTest(ctx, t, nodeID)
+			mgmtServer, _, _, bc := setupManagementServerForTest(t, nodeID)
 
 			// Build an xDS resolver.
 			stateCh, _, _ := buildResolverForTarget(t, resolver.Target{URL: *testutils.MustParseURL("xds:///" + defaultTestServiceName)}, bc)
@@ -1188,8 +1201,8 @@ func (s) TestConfigSelector_FailureCases(t *testing.T) {
 
 			// Ensure that it returns the expected error.
 			_, err := cs.SelectConfig(iresolver.RPCInfo{Method: methodName, Context: ctx})
-			if err == nil || !strings.Contains(err.Error(), test.wantErr) {
-				t.Errorf("SelectConfig(_) = _, %v; want _, Contains(%v)", err, test.wantErr)
+			if err := verifyResolverError(err, codes.Unavailable, test.wantErr, nodeID); err != nil {
+				t.Fatal(err)
 			}
 		})
 	}
@@ -1413,7 +1426,7 @@ func (s) TestXDSResolverHTTPFilters(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 			defer cancel()
 			nodeID := uuid.New().String()
-			mgmtServer, _, _, bc := setupManagementServerForTest(ctx, t, nodeID)
+			mgmtServer, _, _, bc := setupManagementServerForTest(t, nodeID)
 
 			// Build an xDS resolver.
 			stateCh, _, _ := buildResolverForTarget(t, resolver.Target{URL: *testutils.MustParseURL("xds:///" + defaultTestServiceName)}, bc)

--- a/xds/internal/resolver/xds_resolver_test.go
+++ b/xds/internal/resolver/xds_resolver_test.go
@@ -646,7 +646,7 @@ func (s) TestResolverRemovedResource(t *testing.T) {
 	cs = verifyUpdateFromResolver(ctx, t, stateCh, wantDefaultServiceConfig)
 
 	// "Make another RPC" by invoking the config selector.
-	res, err = cs.SelectConfig(iresolver.RPCInfo{Context: ctx, Method: "/service/method"})
+	_, err = cs.SelectConfig(iresolver.RPCInfo{Context: ctx, Method: "/service/method"})
 	if err := verifyResolverError(err, codes.Unavailable, "no valid clusters", nodeID); err != nil {
 		t.Fatal(err)
 	}

--- a/xds/internal/xdsclient/xdsresource/errors.go
+++ b/xds/internal/xdsclient/xdsresource/errors.go
@@ -70,9 +70,9 @@ func NewError(t ErrorType, message string) error {
 }
 
 // ErrType returns the error's type.
-func ErrType(e error) ErrorType {
+func ErrType(err error) ErrorType {
 	var xe *xdsClientError
-	if ok := errors.As(e, &xe); ok {
+	if errors.As(err, &xe) {
 		return xe.t
 	}
 	return ErrorTypeUnknown


### PR DESCRIPTION
Addresses https://github.com/grpc/grpc-go/issues/7931.

Previous PRs in #7931 ensure that errors from the xDS client contains the node ID. But only applies to connectivity and NACK errors. The current watch API does not allow the xDS client to report an error value when the watched resource is not found. This PR adds that functionality to errors reported by the xDS resolver and CDS lb policy.

Summary of changes:
- CDS lb policy
  - returns an error picker when the watched cluster is not found *and* when a received cluster resource fails validation checks. Under both these circumstances, we ensure that the returned error contains the xDS node id.
- xDS resolver
  - When a watched resource is not found, the xDS resolver used to push a `nil` config selector which would fail RPCs. This PR instead switches to use an explicit erroring config selector that returns an error with the xDS node id.
  - Errors returned by the normal config selector also include the xDS node id.
  - xDS resolver pushes an empty service config to trigger the usage of `pick_first` LB policy when the watched resource is not found. This PR follows that up with a resolver error on the channel, so that `pick_first` can fail RPCs with an error that includes the xDS node id.
- Some test cleanups.

RELEASE NOTES: none
