### PR TITLE
clusterresolver: Lower log level when ExitIdle is called with no child

### DIFF
--- a/xds/internal/balancer/clusterresolver/clusterresolver.go
+++ b/xds/internal/balancer/clusterresolver/clusterresolver.go
@@ -327,7 +327,10 @@ func (b *clusterResolverBalancer) run() {
 				b.handleClientConnUpdate(update)
 			case exitIdle:
 				if b.child == nil {
-					b.logger.Errorf("xds: received ExitIdle with no child balancer")
+					// This is not necessarily an error. The EDS/DNS watch may
+					// not have  returned a list of endpoints yet, so the child
+					// may not be built.
+					b.logger.Infof("xds: received ExitIdle with no child balancer")
 					break
 				}
 				// This implementation assumes the child balancer supports

--- a/xds/internal/balancer/clusterresolver/clusterresolver.go
+++ b/xds/internal/balancer/clusterresolver/clusterresolver.go
@@ -330,7 +330,9 @@ func (b *clusterResolverBalancer) run() {
 					// This is not necessarily an error. The EDS/DNS watch may
 					// not have  returned a list of endpoints yet, so the child
 					// may not be built.
-					b.logger.Infof("xds: received ExitIdle with no child balancer")
+					if b.logger.V(2) {
+						b.logger.Infof("xds: received ExitIdle with no child balancer")
+					}
 					break
 				}
 				// This implementation assumes the child balancer supports


### PR DESCRIPTION
Fixes: https://github.com/grpc/grpc-go/issues/8132

`ExitIdle` may be called on `clusterresolver` before it's child is built. `clusterresolver`'s child is built when a list of endpoints is produced by the resource resolver. Logging the message at the ERROR level incorrectly fails tests.

RELEASE NOTES: N/A