### PR TITLE
xds: Enable dualstack flag

### DIFF
--- a/internal/envconfig/xds.go
+++ b/internal/envconfig/xds.go
@@ -56,7 +56,7 @@ var (
 
 	// XDSDualstackEndpointsEnabled is true if gRPC should read the
 	// "additional addresses" in the xDS endpoint resource.
-	XDSDualstackEndpointsEnabled = boolFromEnv("GRPC_EXPERIMENTAL_XDS_DUALSTACK_ENDPOINTS", false)
+	XDSDualstackEndpointsEnabled = boolFromEnv("GRPC_EXPERIMENTAL_XDS_DUALSTACK_ENDPOINTS", true)
 
 	// XDSSystemRootCertsEnabled is true when xDS enabled gRPC clients can use
 	// the system's default root certificates for TLS certificate validation.


### PR DESCRIPTION
The flag was enabled in master as part of https://github.com/grpc/grpc-go/pull/8126. This PR enabled only the xDS endpoints support, leaving the new pickfirst policy flag disabled.

RELEASE NOTES:
* xds: LB policies will receive additional addresses for endpoints which are specified in the [additional_addresses](https://github.com/envoyproxy/envoy/blob/df394a41c8587d1da4e97e156554e93ceee3c720/api/envoy/config/endpoint/v3/endpoint_components.proto#L91-L96) field in the Endpoint message. The additional addresses will be present in the ResolverState.Endpoints passed to UpdateClientConnState method of the balancers. To disable this feature, set the environment variable GRPC_EXPERIMENTAL_XDS_DUALSTACK_ENDPOINTS to false (case insensitive).