### PR TITLE
balancer/rls: allow maxAge to exceed 5m if staleAge is set

### DIFF
--- a/balancer/rls/config.go
+++ b/balancer/rls/config.go
@@ -219,7 +219,8 @@ func parseRLSProto(rlsProto *rlspb.RouteLookupConfig) (*lbConfig, error) {
 	}
 
 	// Validations performed here:
-	// - if `max_age` > 5m, it should be set to 5 minutes only if stale age is not set
+	// - if `max_age` > 5m, it should be set to 5 minutes
+	//   only if stale age is not set
 	// - if `stale_age` > `max_age`, ignore it
 	// - if `stale_age` is set, then `max_age` must also be set
 	maxAgeSet := false

--- a/balancer/rls/config_test.go
+++ b/balancer/rls/config_test.go
@@ -87,9 +87,83 @@ func (s) TestParseConfig(t *testing.T) {
 			}`),
 			wantCfg: &lbConfig{
 				lookupService:          ":///target",
-				lookupServiceTimeout:   10 * time.Second, // This is the default value.
-				maxAge:                 5 * time.Minute,  // This is max maxAge.
-				staleAge:               time.Duration(0), // StaleAge is ignore because it was higher than maxAge.
+				lookupServiceTimeout:   10 * time.Second,  // This is the default value.
+				maxAge:                 500 * time.Second, // Max age is not clamped when stale age is set.
+				staleAge:               300 * time.Second, // StaleAge is clamped because it was higher than maxMaxAge.
+				cacheSizeBytes:         maxCacheSize,
+				defaultTarget:          "passthrough:///default",
+				childPolicyName:        "grpclb",
+				childPolicyTargetField: "serviceName",
+				childPolicyConfig: map[string]json.RawMessage{
+					"childPolicy": json.RawMessage(`[{"pickfirst": {}}]`),
+					"serviceName": json.RawMessage(childPolicyTargetFieldVal),
+				},
+			},
+		},
+		{
+			desc: "with transformations 1",
+			input: []byte(`{
+				"top-level-unknown-field": "unknown-value",
+				"routeLookupConfig": {
+					"unknown-field": "unknown-value",
+					"grpcKeybuilders": [{
+						"names": [{"service": "service", "method": "method"}],
+						"headers": [{"key": "k1", "names": ["v1"]}]
+					}],
+					"lookupService": ":///target",
+					"maxAge" : "500s",
+					"staleAge": "200s",
+					"cacheSizeBytes": 100000000,
+					"defaultTarget": "passthrough:///default"
+				},
+				"childPolicy": [
+					{"cds_experimental": {"Cluster": "my-fav-cluster"}},
+					{"unknown-policy": {"unknown-field": "unknown-value"}},
+					{"grpclb": {"childPolicy": [{"pickfirst": {}}]}}
+				],
+				"childPolicyConfigTargetFieldName": "serviceName"
+			}`),
+			wantCfg: &lbConfig{
+				lookupService:          ":///target",
+				lookupServiceTimeout:   10 * time.Second,  // This is the default value.
+				maxAge:                 500 * time.Second, // Max age is not clamped when stale age is set.
+				staleAge:               200 * time.Second, // This is stale age within maxMaxAge.
+				cacheSizeBytes:         maxCacheSize,
+				defaultTarget:          "passthrough:///default",
+				childPolicyName:        "grpclb",
+				childPolicyTargetField: "serviceName",
+				childPolicyConfig: map[string]json.RawMessage{
+					"childPolicy": json.RawMessage(`[{"pickfirst": {}}]`),
+					"serviceName": json.RawMessage(childPolicyTargetFieldVal),
+				},
+			},
+		},
+		{
+			desc: "with transformations 1",
+			input: []byte(`{
+				"top-level-unknown-field": "unknown-value",
+				"routeLookupConfig": {
+					"unknown-field": "unknown-value",
+					"grpcKeybuilders": [{
+						"names": [{"service": "service", "method": "method"}],
+						"headers": [{"key": "k1", "names": ["v1"]}]
+					}],
+					"lookupService": ":///target",
+					"maxAge" : "500s",
+					"cacheSizeBytes": 100000000,
+					"defaultTarget": "passthrough:///default"
+				},
+				"childPolicy": [
+					{"cds_experimental": {"Cluster": "my-fav-cluster"}},
+					{"unknown-policy": {"unknown-field": "unknown-value"}},
+					{"grpclb": {"childPolicy": [{"pickfirst": {}}]}}
+				],
+				"childPolicyConfigTargetFieldName": "serviceName"
+			}`),
+			wantCfg: &lbConfig{
+				lookupService:          ":///target",
+				lookupServiceTimeout:   10 * time.Second,  // This is the default value.
+				maxAge:                 300 * time.Second, // Max age is clamped when stale age is not set.
 				cacheSizeBytes:         maxCacheSize,
 				defaultTarget:          "passthrough:///default",
 				childPolicyName:        "grpclb",

--- a/balancer/rls/config_test.go
+++ b/balancer/rls/config_test.go
@@ -60,8 +60,8 @@ func (s) TestParseConfig(t *testing.T) {
 			// - A top-level unknown field should not fail.
 			// - An unknown field in routeLookupConfig proto should not fail.
 			// - lookupServiceTimeout is set to its default value, since it is not specified in the input.
-			// - maxAge is set to maxMaxAge since the value is too large in the input.
-			// - staleAge is ignore because it is higher than maxAge in the input.
+			// - maxAge is clamped to maxMaxAge if staleAge is not set.
+			// - staleAge is ignored because it is higher than maxAge in the input.
 			// - cacheSizeBytes is greater than the hard upper limit of 5MB
 			desc: "with transformations 1",
 			input: []byte(`{
@@ -101,11 +101,9 @@ func (s) TestParseConfig(t *testing.T) {
 			},
 		},
 		{
-			desc: "with transformations 1",
+			desc: "maxAge not clamped when staleAge is set",
 			input: []byte(`{
-				"top-level-unknown-field": "unknown-value",
 				"routeLookupConfig": {
-					"unknown-field": "unknown-value",
 					"grpcKeybuilders": [{
 						"names": [{"service": "service", "method": "method"}],
 						"headers": [{"key": "k1", "names": ["v1"]}]
@@ -113,12 +111,9 @@ func (s) TestParseConfig(t *testing.T) {
 					"lookupService": ":///target",
 					"maxAge" : "500s",
 					"staleAge": "200s",
-					"cacheSizeBytes": 100000000,
-					"defaultTarget": "passthrough:///default"
+					"cacheSizeBytes": 100000000
 				},
 				"childPolicy": [
-					{"cds_experimental": {"Cluster": "my-fav-cluster"}},
-					{"unknown-policy": {"unknown-field": "unknown-value"}},
 					{"grpclb": {"childPolicy": [{"pickfirst": {}}]}}
 				],
 				"childPolicyConfigTargetFieldName": "serviceName"
@@ -129,7 +124,6 @@ func (s) TestParseConfig(t *testing.T) {
 				maxAge:                 500 * time.Second, // Max age is not clamped when stale age is set.
 				staleAge:               200 * time.Second, // This is stale age within maxMaxAge.
 				cacheSizeBytes:         maxCacheSize,
-				defaultTarget:          "passthrough:///default",
 				childPolicyName:        "grpclb",
 				childPolicyTargetField: "serviceName",
 				childPolicyConfig: map[string]json.RawMessage{
@@ -139,23 +133,18 @@ func (s) TestParseConfig(t *testing.T) {
 			},
 		},
 		{
-			desc: "with transformations 1",
+			desc: "maxAge clamped when staleAge is not set",
 			input: []byte(`{
-				"top-level-unknown-field": "unknown-value",
 				"routeLookupConfig": {
-					"unknown-field": "unknown-value",
 					"grpcKeybuilders": [{
 						"names": [{"service": "service", "method": "method"}],
 						"headers": [{"key": "k1", "names": ["v1"]}]
 					}],
 					"lookupService": ":///target",
 					"maxAge" : "500s",
-					"cacheSizeBytes": 100000000,
-					"defaultTarget": "passthrough:///default"
+					"cacheSizeBytes": 100000000
 				},
 				"childPolicy": [
-					{"cds_experimental": {"Cluster": "my-fav-cluster"}},
-					{"unknown-policy": {"unknown-field": "unknown-value"}},
 					{"grpclb": {"childPolicy": [{"pickfirst": {}}]}}
 				],
 				"childPolicyConfigTargetFieldName": "serviceName"
@@ -164,8 +153,8 @@ func (s) TestParseConfig(t *testing.T) {
 				lookupService:          ":///target",
 				lookupServiceTimeout:   10 * time.Second,  // This is the default value.
 				maxAge:                 300 * time.Second, // Max age is clamped when stale age is not set.
+				staleAge:               300 * time.Second,
 				cacheSizeBytes:         maxCacheSize,
-				defaultTarget:          "passthrough:///default",
 				childPolicyName:        "grpclb",
 				childPolicyTargetField: "serviceName",
 				childPolicyConfig: map[string]json.RawMessage{


### PR DESCRIPTION
Internal feature request: b/371591767

RELEASE NOTES:
- balancer/rls: allow `maxAge` to exceed `5m` if `staleAge` is set in the LB policy configuration