### PR TITLE
interop: Wait for server to become ready in alts tests

### DIFF
--- a/interop/alts/client/client.go
+++ b/interop/alts/client/client.go
@@ -47,7 +47,6 @@ func main() {
 		opts.HandshakerServiceAddress = *hsAddr
 	}
 	altsTC := alts.NewClientCreds(opts)
-	// Block until the server is ready.
 	conn, err := grpc.NewClient(*serverAddr, grpc.WithTransportCredentials(altsTC))
 	if err != nil {
 		logger.Fatalf("grpc.NewClient(%q) = %v", *serverAddr, err)
@@ -58,7 +57,8 @@ func main() {
 	// Call the EmptyCall API.
 	ctx := context.Background()
 	request := &testpb.Empty{}
-	if _, err := grpcClient.EmptyCall(ctx, request); err != nil {
+	// Block until the server is ready.
+	if _, err := grpcClient.EmptyCall(ctx, request, grpc.WaitForReady(true)); err != nil {
 		logger.Fatalf("grpc Client: EmptyCall(_, %v) failed: %v", request, err)
 	}
 	logger.Info("grpc Client: empty call succeeded")


### PR DESCRIPTION
In #7970, the [alts client was changed](https://github.com/grpc/grpc-go/pull/7970/files#diff-7f71e4c7ed0cdd9defd79e0b7424066d90939c53063b5d413ed5aecb3e65e9b1) from using `grpc.Dial` with `grpc.WithBlock` to `grpc.NewClient` without `WithBlock`.  The tests that run in g3 don't wait for the server to start before starting the client. If WithBlock is not used, the client enters TRANSIENT_FAILURE after getting a `connection refused` error in the first connection attempt. This PR adds `grpc.WaitForReady` while making the RPC to restore the previous behaviour.

RELEASE NOTES: N/A