### PR TITLE
grpc: Add endpoints in resolverWrapper.NewAddresses

### DIFF
--- a/scripts/vet.sh
+++ b/scripts/vet.sh
@@ -197,7 +197,8 @@ GetSafeRegexMatch
 GetSuffixMatch
 GetTlsCertificateCertificateProviderInstance
 GetValidationContextCertificateProviderInstance
-XXXXX PleaseIgnoreUnused'
+XXXXX PleaseIgnoreUnused
+NewAddress is deprecated:'
   popd
 done
 

--- a/scripts/vet.sh
+++ b/scripts/vet.sh
@@ -174,6 +174,7 @@ CredsBundle is deprecated:
 GetMetadata is deprecated:
 internal.Logger is deprecated:
 Metadata is deprecated: use Attributes instead.
+NewAddress is deprecated:
 NewSubConn is deprecated:
 OverrideServerName is deprecated:
 RemoveSubConn is deprecated:
@@ -197,8 +198,7 @@ GetSafeRegexMatch
 GetSuffixMatch
 GetTlsCertificateCertificateProviderInstance
 GetValidationContextCertificateProviderInstance
-XXXXX PleaseIgnoreUnused
-NewAddress is deprecated:'
+XXXXX PleaseIgnoreUnused'
   popd
 done
 


### PR DESCRIPTION
Fixes: https://github.com/grpc/grpc-go/issues/8146

The resolver wrapper has code in the UpdateState method to convert Addresses to Endpoints, but this handling was missing in the NewAddresses API. This PR adds it.

RELEASE NOTES: 
* grpc: Fix bug causing failures with message "no children to pick from" with custom resolvers that use the deprecated [NewAddresses API](https://pkg.go.dev/google.golang.org/grpc@v1.71.0/resolver#ClientConn).