### PR TITLE
Cherry pick #8149 to v1.71.x

### DIFF
--- a/resolver_test.go
+++ b/resolver_test.go
@@ -143,6 +143,58 @@ func (s) TestResolverAddressesToEndpoints(t *testing.T) {
 	}
 }
 
+// Test ensures one Endpoint is created for each entry in
+// resolver.State.Addresses automatically. The test calls the deprecated
+// NewAddresses API to send a list of addresses to the channel.
+func (s) TestResolverAddressesToEndpointsUsingNewAddresses(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+
+	const scheme = "testresolveraddressestoendpoints"
+	r := manual.NewBuilderWithScheme(scheme)
+
+	stateCh := make(chan balancer.ClientConnState, 1)
+	bf := stub.BalancerFuncs{
+		UpdateClientConnState: func(_ *stub.BalancerData, ccs balancer.ClientConnState) error {
+			stateCh <- ccs
+			return nil
+		},
+	}
+	balancerName := "stub-balancer-" + scheme
+	stub.Register(balancerName, bf)
+
+	a1 := attributes.New("x", "y")
+	a2 := attributes.New("a", "b")
+	addrs := []resolver.Address{
+		{Addr: "addr1", BalancerAttributes: a1},
+		{Addr: "addr2", BalancerAttributes: a2},
+	}
+
+	cc, err := NewClient(r.Scheme()+":///",
+		WithTransportCredentials(insecure.NewCredentials()),
+		WithResolvers(r),
+		WithDefaultServiceConfig(fmt.Sprintf(`{"loadBalancingConfig": [{"%s":{}}]}`, balancerName)))
+	if err != nil {
+		t.Fatalf("grpc.NewClient() failed: %v", err)
+	}
+	cc.Connect()
+	defer cc.Close()
+	r.CC.NewAddress(addrs)
+
+	select {
+	case got := <-stateCh:
+		want := []resolver.Endpoint{
+			{Addresses: []resolver.Address{{Addr: "addr1"}}, Attributes: a1},
+			{Addresses: []resolver.Address{{Addr: "addr2"}}, Attributes: a2},
+		}
+		if diff := cmp.Diff(got.ResolverState.Endpoints, want); diff != "" {
+			t.Errorf("Did not receive expected endpoints.  Diff (-got +want):\n%v", diff)
+		}
+	case <-ctx.Done():
+		t.Fatalf("timed out waiting for endpoints")
+	}
+}
+
 // Test ensures that there is no panic if the attributes within
 // resolver.State.Addresses contains a typed-nil value.
 func (s) TestResolverAddressesWithTypedNilAttribute(t *testing.T) {

--- a/scripts/vet.sh
+++ b/scripts/vet.sh
@@ -174,6 +174,7 @@ CredsBundle is deprecated:
 GetMetadata is deprecated:
 internal.Logger is deprecated:
 Metadata is deprecated: use Attributes instead.
+NewAddress is deprecated:
 NewSubConn is deprecated:
 OverrideServerName is deprecated:
 RemoveSubConn is deprecated:


### PR DESCRIPTION
Original PR: #8149 
Related issues: #8146

RELEASE NOTES: 
* grpc: Fix bug causing RPC failures with message "no children to pick from" when using a custom resolver that calls the deprecated [NewAddress API](https://pkg.go.dev/google.golang.org/grpc@v1.71.0/resolver#ClientConn).