### PR TITLE
grpc: fix bug causing an extra Read if a compressed message is the same size as the limit

### DIFF
--- a/clientconn_test.go
+++ b/clientconn_test.go
@@ -50,6 +50,7 @@ import (
 
 const (
 	defaultTestTimeout         = 10 * time.Second
+	defaultTestShortTimeout    = 10 * time.Millisecond
 	stateRecordingBalancerName = "state_recording_balancer"
 	grpclbServiceConfig        = `{"loadBalancingConfig": [{"grpclb": {}}]}`
 	rrServiceConfig            = `{"loadBalancingPolicy": [{"round_robin": {}}]}`

--- a/rpc_util_test.go
+++ b/rpc_util_test.go
@@ -28,7 +28,6 @@ import (
 	"reflect"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -438,7 +437,7 @@ func (m *mockCompressor) Decompress(io.Reader) (io.Reader, error) {
 	return m, nil
 }
 
-func (m *mockCompressor) Read(p []byte) (int, error) {
+func (m *mockCompressor) Read([]byte) (int, error) {
 	m.ch <- struct{}{}
 	return 1, io.EOF
 }
@@ -469,7 +468,7 @@ func (s) TestDecompress_NoReadAfterEOF(t *testing.T) {
 	case <-ctx.Done():
 		t.Fatalf("Timed out waiting for call to compressor")
 	}
-	ctx, cancel = context.WithTimeout(ctx, 10*time.Millisecond)
+	ctx, cancel = context.WithTimeout(ctx, defaultTestShortTimeout)
 	defer cancel()
 	select {
 	case <-ch:

--- a/rpc_util_test.go
+++ b/rpc_util_test.go
@@ -21,11 +21,14 @@ package grpc
 import (
 	"bytes"
 	"compress/gzip"
+	"context"
 	"errors"
 	"io"
 	"math"
 	"reflect"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -420,4 +423,58 @@ func (s) TestDecompress(t *testing.T) {
 			}
 		})
 	}
+}
+
+type mockCompressor struct {
+	// Written to by the io.Reader on every call to Read.
+	ch chan<- struct{}
+}
+
+func (m *mockCompressor) Compress(io.Writer) (io.WriteCloser, error) {
+	panic("unimplemented")
+}
+
+func (m *mockCompressor) Decompress(io.Reader) (io.Reader, error) {
+	return m, nil
+}
+
+func (m *mockCompressor) Read(p []byte) (int, error) {
+	m.ch <- struct{}{}
+	return 1, io.EOF
+}
+
+func (m *mockCompressor) Name() string { return "" }
+
+// Tests that the decompressor's Read method is not called after it returns EOF.
+func (s) TestDecompress_NoReadAfterEOF(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+
+	ch := make(chan struct{}, 10)
+	mc := &mockCompressor{ch: ch}
+	in := mem.BufferSlice{mem.NewBuffer(&[]byte{1, 2, 3}, nil)}
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		out, err := decompress(mc, in, nil, 1, mem.DefaultBufferPool())
+		if err != nil {
+			t.Errorf("Unexpected error from decompress: %v", err)
+			return
+		}
+		out.Free()
+	}()
+	select {
+	case <-ch:
+	case <-ctx.Done():
+		t.Fatalf("Timed out waiting for call to compressor")
+	}
+	ctx, cancel = context.WithTimeout(ctx, 10*time.Millisecond)
+	defer cancel()
+	select {
+	case <-ch:
+		t.Fatalf("Unexpected second compressor.Read call detected")
+	case <-ctx.Done():
+	}
+	wg.Wait()
 }


### PR DESCRIPTION
Fixes #8171

This is an alternate fix to the above issue as mentioned in #8172.

I'll add a test case that ensures Read is not called beyond io.EOF.  But it looks like there might be some other problems with the tests in `rpc_util_test.go`, as several test cases are not setting the decompressor field `dc`, and I want to look at that more closely, too.

cc @jhump

RELEASE NOTES:
* grpc: fix bug causing an extra Read if a compressed message is the same size as the limit