### PR TITLE
Cherry-pick #8164 #8166 to v1.71.x

### DIFF
--- a/stats/opentelemetry/client_tracing.go
+++ b/stats/opentelemetry/client_tracing.go
@@ -20,10 +20,12 @@ import (
 	"context"
 	"strings"
 
-	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
+	"google.golang.org/grpc"
 	otelinternaltracing "google.golang.org/grpc/stats/opentelemetry/internal/tracing"
 )
+
+const tracerName = "grpc-go"
 
 // traceTagRPC populates provided context with a new span using the
 // TextMapPropagator supplied in trace options and internal itracing.carrier.
@@ -32,10 +34,10 @@ import (
 // options. if TextMapPropagator is not provided, it returns the context as is.
 func (h *clientStatsHandler) traceTagRPC(ctx context.Context, ai *attemptInfo) (context.Context, *attemptInfo) {
 	mn := "Attempt." + strings.Replace(ai.method, "/", ".", -1)
-	tracer := otel.Tracer("grpc-open-telemetry")
+	tracer := h.options.TraceOptions.TracerProvider.Tracer(tracerName, trace.WithInstrumentationVersion(grpc.Version))
 	ctx, span := tracer.Start(ctx, mn)
 	carrier := otelinternaltracing.NewOutgoingCarrier(ctx)
-	otel.GetTextMapPropagator().Inject(ctx, carrier)
+	h.options.TraceOptions.TextMapPropagator.Inject(ctx, carrier)
 	ai.traceSpan = span
 	return carrier.Context(), ai
 }
@@ -48,7 +50,7 @@ func (h *clientStatsHandler) createCallTraceSpan(ctx context.Context, method str
 		return ctx, nil
 	}
 	mn := strings.Replace(removeLeadingSlash(method), "/", ".", -1)
-	tracer := otel.Tracer("grpc-open-telemetry")
+	tracer := h.options.TraceOptions.TracerProvider.Tracer(tracerName, trace.WithInstrumentationVersion(grpc.Version))
 	ctx, span := tracer.Start(ctx, mn, trace.WithSpanKind(trace.SpanKindClient))
 	return ctx, span
 }

--- a/stats/opentelemetry/e2e_test.go
+++ b/stats/opentelemetry/e2e_test.go
@@ -23,7 +23,6 @@ import (
 	"testing"
 	"time"
 
-	"go.opentelemetry.io/otel"
 	otelcodes "go.opentelemetry.io/otel/codes"
 	oteltrace "go.opentelemetry.io/otel/trace"
 
@@ -100,8 +99,6 @@ func defaultTraceOptions(_ *testing.T) (*experimental.TraceOptions, *tracetest.I
 	spanProcessor := trace.NewSimpleSpanProcessor(spanExporter)
 	tracerProvider := trace.NewTracerProvider(trace.WithSpanProcessor(spanProcessor))
 	textMapPropagator := propagation.NewCompositeTextMapPropagator(opentelemetry.GRPCTraceBinPropagator{})
-	otel.SetTextMapPropagator(textMapPropagator)
-	otel.SetTracerProvider(tracerProvider)
 	traceOptions := &experimental.TraceOptions{
 		TracerProvider:    tracerProvider,
 		TextMapPropagator: textMapPropagator,

--- a/stats/opentelemetry/server_metrics.go
+++ b/stats/opentelemetry/server_metrics.go
@@ -96,6 +96,7 @@ func (h *serverStatsHandler) unaryInterceptor(ctx context.Context, req any, _ *g
 		metadataExchangeLabels = h.options.MetricsOptions.pluginOption.GetMetadata()
 	}
 
+	// - Server-side: The first stats event after the RPC request is received.
 	sts := grpc.ServerTransportStreamFromContext(ctx)
 
 	alts := &attachLabelsTransportStream{

--- a/stats/opentelemetry/server_tracing.go
+++ b/stats/opentelemetry/server_tracing.go
@@ -20,8 +20,8 @@ import (
 	"context"
 	"strings"
 
-	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
+	"google.golang.org/grpc"
 	otelinternaltracing "google.golang.org/grpc/stats/opentelemetry/internal/tracing"
 )
 
@@ -35,8 +35,8 @@ import (
 func (h *serverStatsHandler) traceTagRPC(ctx context.Context, ai *attemptInfo) (context.Context, *attemptInfo) {
 	mn := strings.Replace(ai.method, "/", ".", -1)
 	var span trace.Span
-	tracer := otel.Tracer("grpc-open-telemetry")
-	ctx = otel.GetTextMapPropagator().Extract(ctx, otelinternaltracing.NewIncomingCarrier(ctx))
+	tracer := h.options.TraceOptions.TracerProvider.Tracer(tracerName, trace.WithInstrumentationVersion(grpc.Version))
+	ctx = h.options.TraceOptions.TextMapPropagator.Extract(ctx, otelinternaltracing.NewIncomingCarrier(ctx))
 	// If the context.Context provided in `ctx` to tracer.Start(), contains a
 	// span then the newly-created Span will be a child of that span,
 	// otherwise it will be a root span.

--- a/xds/internal/xdsclient/clientimpl.go
+++ b/xds/internal/xdsclient/clientimpl.go
@@ -113,19 +113,7 @@ func init() {
 	internal.TriggerXDSResourceNotFoundForTesting = triggerXDSResourceNotFoundForTesting
 	xdsclientinternal.ResourceWatchStateForTesting = resourceWatchStateForTesting
 
-	// DefaultPool is initialized with bootstrap configuration from one of the
-	// supported environment variables. If the environment variables are not
-	// set, then fallback bootstrap configuration should be set before
-	// attempting to create an xDS client, else xDS client creation will fail.
-	config, err := bootstrap.GetConfiguration()
-	if err != nil {
-		if logger.V(2) {
-			logger.Infof("Failed to read xDS bootstrap config from env vars:  %v", err)
-		}
-		DefaultPool = &Pool{clients: make(map[string]*clientRefCounted)}
-		return
-	}
-	DefaultPool = &Pool{clients: make(map[string]*clientRefCounted), config: config}
+	DefaultPool = &Pool{clients: make(map[string]*clientRefCounted)}
 }
 
 // newClientImpl returns a new xdsClient with the given config.

--- a/xds/internal/xdsclient/pool/pool_test.go
+++ b/xds/internal/xdsclient/pool/pool_test.go
@@ -1,0 +1,88 @@
+/*
+ *
+ * Copyright 2025 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package pool_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/google/uuid"
+	"google.golang.org/grpc/internal/grpctest"
+	"google.golang.org/grpc/internal/testutils"
+	"google.golang.org/grpc/internal/testutils/stats"
+	"google.golang.org/grpc/internal/xds/bootstrap"
+	"google.golang.org/grpc/xds/internal/xdsclient"
+)
+
+type s struct {
+	grpctest.Tester
+}
+
+func Test(t *testing.T) {
+	grpctest.RunSubTests(t, s{})
+}
+
+// TestDefaultPool_LazyLoadBootstrapConfig verifies that the DefaultPool
+// lazily loads the bootstrap configuration from environment variables when
+// an xDS client is created for the first time.
+//
+// If tries to create the new client in DefaultPool at the start of test when
+// none of the env vars are set. This should fail.
+//
+// Then it sets the env var XDSBootstrapFileName and retry creating a client
+// in DefaultPool. This should succeed.
+func (s) TestDefaultPool_LazyLoadBootstrapConfig(t *testing.T) {
+	_, closeFunc, err := xdsclient.DefaultPool.NewClient(t.Name(), &stats.NoopMetricsRecorder{})
+	if err == nil {
+		t.Fatalf("xdsclient.DefaultPool.NewClient() succeeded without setting bootstrap config env vars, want failure")
+	}
+
+	bs, err := bootstrap.NewContentsForTesting(bootstrap.ConfigOptionsForTesting{
+		Servers: []byte(fmt.Sprintf(`[{
+			 "server_uri": %q,
+			 "channel_creds": [{"type": "insecure"}]
+		 }]`, "non-existent-management-server")),
+		Node: []byte(fmt.Sprintf(`{"id": "%s"}`, uuid.New().String())),
+		CertificateProviders: map[string]json.RawMessage{
+			"cert-provider-instance": json.RawMessage("{}"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("Failed to create bootstrap configuration: %v", err)
+	}
+
+	testutils.CreateBootstrapFileForTesting(t, bs)
+	if cfg := xdsclient.DefaultPool.BootstrapConfigForTesting(); cfg != nil {
+		t.Fatalf("DefaultPool.BootstrapConfigForTesting() = %v, want nil", cfg)
+	}
+
+	_, closeFunc, err = xdsclient.DefaultPool.NewClient(t.Name(), &stats.NoopMetricsRecorder{})
+	if err != nil {
+		t.Fatalf("Failed to create xDS client: %v", err)
+	}
+	defer func() {
+		closeFunc()
+		xdsclient.DefaultPool.UnsetBootstrapConfigForTesting()
+	}()
+
+	if xdsclient.DefaultPool.BootstrapConfigForTesting() == nil {
+		t.Fatalf("DefaultPool.BootstrapConfigForTesting() = nil, want non-nil")
+	}
+}

--- a/xds/server_test.go
+++ b/xds/server_test.go
@@ -178,7 +178,7 @@ func (s) TestNewServer_Failure(t *testing.T) {
 		{
 			desc:       "bootstrap env var not set",
 			serverOpts: []grpc.ServerOption{grpc.Creds(xdsCreds), BootstrapContentsForTesting(nil)},
-			wantErr:    "bootstrap configuration not set in the pool",
+			wantErr:    "failed to read xDS bootstrap config from env vars",
 		},
 		{
 			desc: "empty bootstrap config",


### PR DESCRIPTION
Original PRs: https://github.com/grpc/grpc-go/pull/8164 https://github.com/grpc/grpc-go/pull/8166

RELEASE NOTES:

- xds: restore the behavior of reading bootstrap config before creating the first xDS client instead of package init time.
- stats/opentelemetry: fix tracing to use TextMapPropagator and TracerProvider from TraceOptions instead of OpenTelemetry globals.