### PR TITLE
resolver: convert EndpointMap to use generics

### DIFF
--- a/balancer/weightedroundrobin/balancer.go
+++ b/balancer/weightedroundrobin/balancer.go
@@ -105,7 +105,7 @@ func (bb) Build(cc balancer.ClientConn, bOpts balancer.BuildOptions) balancer.Ba
 		target:           bOpts.Target.String(),
 		metricsRecorder:  cc.MetricsRecorder(),
 		addressWeights:   resolver.NewAddressMapV2[*endpointWeight](),
-		endpointToWeight: resolver.NewEndpointMap(),
+		endpointToWeight: resolver.NewEndpointMap[*endpointWeight](),
 		scToWeight:       make(map[balancer.SubConn]*endpointWeight),
 	}
 
@@ -155,17 +155,15 @@ func (bb) Name() string {
 //
 // Caller must hold b.mu.
 func (b *wrrBalancer) updateEndpointsLocked(endpoints []resolver.Endpoint) {
-	endpointSet := resolver.NewEndpointMap()
+	endpointSet := resolver.NewEndpointMap[*endpointWeight]()
 	addressSet := resolver.NewAddressMapV2[*endpointWeight]()
 	for _, endpoint := range endpoints {
 		endpointSet.Set(endpoint, nil)
 		for _, addr := range endpoint.Addresses {
 			addressSet.Set(addr, nil)
 		}
-		var ew *endpointWeight
-		if ewi, ok := b.endpointToWeight.Get(endpoint); ok {
-			ew = ewi.(*endpointWeight)
-		} else {
+		ew, ok := b.endpointToWeight.Get(endpoint)
+		if !ok {
 			ew = &endpointWeight{
 				logger:            b.logger,
 				connectivityState: connectivity.Connecting,
@@ -215,7 +213,7 @@ type wrrBalancer struct {
 	locality         string
 	stopPicker       *grpcsync.Event
 	addressWeights   *resolver.AddressMapV2[*endpointWeight]
-	endpointToWeight *resolver.EndpointMap // endpoint -> endpointWeight
+	endpointToWeight *resolver.EndpointMap[*endpointWeight]
 	scToWeight       map[balancer.SubConn]*endpointWeight
 }
 
@@ -260,13 +258,12 @@ func (b *wrrBalancer) UpdateState(state balancer.State) {
 
 	for _, childState := range childStates {
 		if childState.State.ConnectivityState == connectivity.Ready {
-			ewv, ok := b.endpointToWeight.Get(childState.Endpoint)
+			ew, ok := b.endpointToWeight.Get(childState.Endpoint)
 			if !ok {
 				// Should never happen, simply continue and ignore this endpoint
 				// for READY pickers.
 				continue
 			}
-			ew := ewv.(*endpointWeight)
 			readyPickersWeight = append(readyPickersWeight, pickerWeightedEndpoint{
 				picker:           childState.State.Picker,
 				weightedEndpoint: ew,
@@ -398,8 +395,7 @@ func (b *wrrBalancer) Close() {
 	b.mu.Unlock()
 
 	// Ensure any lingering OOB watchers are stopped.
-	for _, ewv := range b.endpointToWeight.Values() {
-		ew := ewv.(*endpointWeight)
+	for _, ew := range b.endpointToWeight.Values() {
 		if ew.stopORCAListener != nil {
 			ew.stopORCAListener()
 		}

--- a/resolver/map.go
+++ b/resolver/map.go
@@ -162,21 +162,21 @@ type endpointMapKey string
 // unordered set of address strings within an endpoint. This map is not thread
 // safe, thus it is unsafe to access concurrently. Must be created via
 // NewEndpointMap; do not construct directly.
-type EndpointMap struct {
-	endpoints map[endpointMapKey]endpointData
+type EndpointMap[T any] struct {
+	endpoints map[endpointMapKey]endpointData[T]
 }
 
-type endpointData struct {
+type endpointData[T any] struct {
 	// decodedKey stores the original key to avoid decoding when iterating on
 	// EndpointMap keys.
 	decodedKey Endpoint
-	value      any
+	value      T
 }
 
 // NewEndpointMap creates a new EndpointMap.
-func NewEndpointMap() *EndpointMap {
-	return &EndpointMap{
-		endpoints: make(map[endpointMapKey]endpointData),
+func NewEndpointMap[T any]() *EndpointMap[T] {
+	return &EndpointMap[T]{
+		endpoints: make(map[endpointMapKey]endpointData[T]),
 	}
 }
 
@@ -196,25 +196,25 @@ func encodeEndpoint(e Endpoint) endpointMapKey {
 }
 
 // Get returns the value for the address in the map, if present.
-func (em *EndpointMap) Get(e Endpoint) (value any, ok bool) {
+func (em *EndpointMap[T]) Get(e Endpoint) (value T, ok bool) {
 	val, found := em.endpoints[encodeEndpoint(e)]
 	if found {
 		return val.value, true
 	}
-	return nil, false
+	return value, false
 }
 
 // Set updates or adds the value to the address in the map.
-func (em *EndpointMap) Set(e Endpoint, value any) {
+func (em *EndpointMap[T]) Set(e Endpoint, value T) {
 	en := encodeEndpoint(e)
-	em.endpoints[en] = endpointData{
+	em.endpoints[en] = endpointData[T]{
 		decodedKey: Endpoint{Addresses: e.Addresses},
 		value:      value,
 	}
 }
 
 // Len returns the number of entries in the map.
-func (em *EndpointMap) Len() int {
+func (em *EndpointMap[T]) Len() int {
 	return len(em.endpoints)
 }
 
@@ -223,7 +223,7 @@ func (em *EndpointMap) Len() int {
 // the unordered set of addresses. Thus, endpoint information returned is not
 // the full endpoint data (drops duplicated addresses and attributes) but can be
 // used for EndpointMap accesses.
-func (em *EndpointMap) Keys() []Endpoint {
+func (em *EndpointMap[T]) Keys() []Endpoint {
 	ret := make([]Endpoint, 0, len(em.endpoints))
 	for _, en := range em.endpoints {
 		ret = append(ret, en.decodedKey)
@@ -232,8 +232,8 @@ func (em *EndpointMap) Keys() []Endpoint {
 }
 
 // Values returns a slice of all current map values.
-func (em *EndpointMap) Values() []any {
-	ret := make([]any, 0, len(em.endpoints))
+func (em *EndpointMap[T]) Values() []T {
+	ret := make([]T, 0, len(em.endpoints))
 	for _, val := range em.endpoints {
 		ret = append(ret, val.value)
 	}
@@ -241,7 +241,7 @@ func (em *EndpointMap) Values() []any {
 }
 
 // Delete removes the specified endpoint from the map.
-func (em *EndpointMap) Delete(e Endpoint) {
+func (em *EndpointMap[T]) Delete(e Endpoint) {
 	en := encodeEndpoint(e)
 	delete(em.endpoints, en)
 }

--- a/resolver/map_test.go
+++ b/resolver/map_test.go
@@ -72,11 +72,11 @@ func (s) TestAddressMap_Length(t *testing.T) {
 }
 
 func (s) TestAddressMap_Get(t *testing.T) {
-	addrMap := NewAddressMapV2[any]()
+	addrMap := NewAddressMapV2[int]()
 	addrMap.Set(addr1, 1)
 
-	if got, ok := addrMap.Get(addr2); ok || got != nil {
-		t.Fatalf("addrMap.Get(addr1) = %v, %v; want nil, false", got, ok)
+	if got, ok := addrMap.Get(addr2); ok || got != 0 {
+		t.Fatalf("addrMap.Get(addr1) = %v, %v; want 0, false", got, ok)
 	}
 
 	addrMap.Set(addr2, 2)
@@ -85,25 +85,25 @@ func (s) TestAddressMap_Get(t *testing.T) {
 	addrMap.Set(addr5, 5)
 	addrMap.Set(addr6, 6)
 	addrMap.Set(addr7, 7) // aliases addr1
-	if got, ok := addrMap.Get(addr1); !ok || got.(int) != 7 {
+	if got, ok := addrMap.Get(addr1); !ok || got != 7 {
 		t.Fatalf("addrMap.Get(addr1) = %v, %v; want %v, true", got, ok, 7)
 	}
-	if got, ok := addrMap.Get(addr2); !ok || got.(int) != 2 {
+	if got, ok := addrMap.Get(addr2); !ok || got != 2 {
 		t.Fatalf("addrMap.Get(addr2) = %v, %v; want %v, true", got, ok, 2)
 	}
-	if got, ok := addrMap.Get(addr3); !ok || got.(int) != 3 {
+	if got, ok := addrMap.Get(addr3); !ok || got != 3 {
 		t.Fatalf("addrMap.Get(addr3) = %v, %v; want %v, true", got, ok, 3)
 	}
-	if got, ok := addrMap.Get(addr4); !ok || got.(int) != 4 {
+	if got, ok := addrMap.Get(addr4); !ok || got != 4 {
 		t.Fatalf("addrMap.Get(addr4) = %v, %v; want %v, true", got, ok, 4)
 	}
-	if got, ok := addrMap.Get(addr5); !ok || got.(int) != 5 {
+	if got, ok := addrMap.Get(addr5); !ok || got != 5 {
 		t.Fatalf("addrMap.Get(addr5) = %v, %v; want %v, true", got, ok, 5)
 	}
-	if got, ok := addrMap.Get(addr6); !ok || got.(int) != 6 {
+	if got, ok := addrMap.Get(addr6); !ok || got != 6 {
 		t.Fatalf("addrMap.Get(addr6) = %v, %v; want %v, true", got, ok, 6)
 	}
-	if got, ok := addrMap.Get(addr7); !ok || got.(int) != 7 {
+	if got, ok := addrMap.Get(addr7); !ok || got != 7 {
 		t.Fatalf("addrMap.Get(addr7) = %v, %v; want %v, true", got, ok, 7)
 	}
 }
@@ -132,7 +132,7 @@ func (s) TestAddressMap_Delete(t *testing.T) {
 }
 
 func (s) TestAddressMap_Keys(t *testing.T) {
-	addrMap := NewAddressMapV2[any]()
+	addrMap := NewAddressMapV2[int]()
 	addrMap.Set(addr1, 1)
 	addrMap.Set(addr2, 2)
 	addrMap.Set(addr3, 3)
@@ -153,7 +153,7 @@ func (s) TestAddressMap_Keys(t *testing.T) {
 }
 
 func (s) TestAddressMap_Values(t *testing.T) {
-	addrMap := NewAddressMapV2[any]()
+	addrMap := NewAddressMapV2[int]()
 	addrMap.Set(addr1, 1)
 	addrMap.Set(addr2, 2)
 	addrMap.Set(addr3, 3)
@@ -163,10 +163,7 @@ func (s) TestAddressMap_Values(t *testing.T) {
 	addrMap.Set(addr7, 7) // aliases addr1
 
 	want := []int{2, 3, 4, 5, 6, 7}
-	var got []int
-	for _, v := range addrMap.Values() {
-		got = append(got, v.(int))
-	}
+	got := addrMap.Values()
 	sort.Ints(got)
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Fatalf("addrMap.Values returned unexpected elements (-want, +got):\n%v", diff)
@@ -174,7 +171,7 @@ func (s) TestAddressMap_Values(t *testing.T) {
 }
 
 func (s) TestEndpointMap_Length(t *testing.T) {
-	em := NewEndpointMap[any]()
+	em := NewEndpointMap[struct{}]()
 	// Should be empty at creation time.
 	if got := em.Len(); got != 0 {
 		t.Fatalf("em.Len() = %v; want 0", got)
@@ -196,7 +193,7 @@ func (s) TestEndpointMap_Length(t *testing.T) {
 }
 
 func (s) TestEndpointMap_Get(t *testing.T) {
-	em := NewEndpointMap[any]()
+	em := NewEndpointMap[int]()
 	em.Set(endpoint1, 1)
 	// The second endpoint endpoint21 should override.
 	em.Set(endpoint12, 1)
@@ -207,28 +204,28 @@ func (s) TestEndpointMap_Get(t *testing.T) {
 	em.Set(endpoint6, 6)
 	em.Set(endpoint7, 7)
 
-	if got, ok := em.Get(endpoint1); !ok || got.(int) != 1 {
+	if got, ok := em.Get(endpoint1); !ok || got != 1 {
 		t.Fatalf("em.Get(endpoint1) = %v, %v; want %v, true", got, ok, 1)
 	}
-	if got, ok := em.Get(endpoint12); !ok || got.(int) != 2 {
+	if got, ok := em.Get(endpoint12); !ok || got != 2 {
 		t.Fatalf("em.Get(endpoint12) = %v, %v; want %v, true", got, ok, 2)
 	}
-	if got, ok := em.Get(endpoint21); !ok || got.(int) != 2 {
+	if got, ok := em.Get(endpoint21); !ok || got != 2 {
 		t.Fatalf("em.Get(endpoint21) = %v, %v; want %v, true", got, ok, 2)
 	}
-	if got, ok := em.Get(endpoint3); !ok || got.(int) != 3 {
+	if got, ok := em.Get(endpoint3); !ok || got != 3 {
 		t.Fatalf("em.Get(endpoint1) = %v, %v; want %v, true", got, ok, 3)
 	}
-	if got, ok := em.Get(endpoint4); !ok || got.(int) != 4 {
+	if got, ok := em.Get(endpoint4); !ok || got != 4 {
 		t.Fatalf("em.Get(endpoint1) = %v, %v; want %v, true", got, ok, 4)
 	}
-	if got, ok := em.Get(endpoint5); !ok || got.(int) != 5 {
+	if got, ok := em.Get(endpoint5); !ok || got != 5 {
 		t.Fatalf("em.Get(endpoint1) = %v, %v; want %v, true", got, ok, 5)
 	}
-	if got, ok := em.Get(endpoint6); !ok || got.(int) != 6 {
+	if got, ok := em.Get(endpoint6); !ok || got != 6 {
 		t.Fatalf("em.Get(endpoint1) = %v, %v; want %v, true", got, ok, 6)
 	}
-	if got, ok := em.Get(endpoint7); !ok || got.(int) != 7 {
+	if got, ok := em.Get(endpoint7); !ok || got != 7 {
 		t.Fatalf("em.Get(endpoint1) = %v, %v; want %v, true", got, ok, 7)
 	}
 	if _, ok := em.Get(endpoint123); ok {
@@ -237,7 +234,7 @@ func (s) TestEndpointMap_Get(t *testing.T) {
 }
 
 func (s) TestEndpointMap_Delete(t *testing.T) {
-	em := NewEndpointMap[any]()
+	em := NewEndpointMap[struct{}]()
 	// Initial state of system: [1, 2, 3, 12]
 	em.Set(endpoint1, struct{}{})
 	em.Set(endpoint2, struct{}{})
@@ -267,7 +264,7 @@ func (s) TestEndpointMap_Delete(t *testing.T) {
 }
 
 func (s) TestEndpointMap_Values(t *testing.T) {
-	em := NewEndpointMap[any]()
+	em := NewEndpointMap[int]()
 	em.Set(endpoint1, 1)
 	// The second endpoint endpoint21 should override.
 	em.Set(endpoint12, 1)
@@ -278,10 +275,7 @@ func (s) TestEndpointMap_Values(t *testing.T) {
 	em.Set(endpoint6, 6)
 	em.Set(endpoint7, 7)
 	want := []int{1, 2, 3, 4, 5, 6, 7}
-	var got []int
-	for _, v := range em.Values() {
-		got = append(got, v.(int))
-	}
+	got := em.Values()
 	sort.Ints(got)
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Fatalf("em.Values() returned unexpected elements (-want, +got):\n%v", diff)

--- a/resolver/map_test.go
+++ b/resolver/map_test.go
@@ -174,7 +174,7 @@ func (s) TestAddressMap_Values(t *testing.T) {
 }
 
 func (s) TestEndpointMap_Length(t *testing.T) {
-	em := NewEndpointMap()
+	em := NewEndpointMap[any]()
 	// Should be empty at creation time.
 	if got := em.Len(); got != 0 {
 		t.Fatalf("em.Len() = %v; want 0", got)
@@ -196,7 +196,7 @@ func (s) TestEndpointMap_Length(t *testing.T) {
 }
 
 func (s) TestEndpointMap_Get(t *testing.T) {
-	em := NewEndpointMap()
+	em := NewEndpointMap[any]()
 	em.Set(endpoint1, 1)
 	// The second endpoint endpoint21 should override.
 	em.Set(endpoint12, 1)
@@ -237,7 +237,7 @@ func (s) TestEndpointMap_Get(t *testing.T) {
 }
 
 func (s) TestEndpointMap_Delete(t *testing.T) {
-	em := NewEndpointMap()
+	em := NewEndpointMap[any]()
 	// Initial state of system: [1, 2, 3, 12]
 	em.Set(endpoint1, struct{}{})
 	em.Set(endpoint2, struct{}{})
@@ -267,7 +267,7 @@ func (s) TestEndpointMap_Delete(t *testing.T) {
 }
 
 func (s) TestEndpointMap_Values(t *testing.T) {
-	em := NewEndpointMap()
+	em := NewEndpointMap[any]()
 	em.Set(endpoint1, 1)
 	// The second endpoint endpoint21 should override.
 	em.Set(endpoint12, 1)
@@ -292,7 +292,7 @@ func (s) TestEndpointMap_Values(t *testing.T) {
 // faster than O(n). This test doesn't run O(n) operations including listing
 // keys and values.
 func BenchmarkEndpointMap(b *testing.B) {
-	em := NewEndpointMap()
+	em := NewEndpointMap[any]()
 	for i := range b.N {
 		em.Set(Endpoint{
 			Addresses: []Address{{Addr: fmt.Sprintf("%d.%d.%d.%d", i, i, i, i)}},

--- a/xds/internal/balancer/outlierdetection/balancer.go
+++ b/xds/internal/balancer/outlierdetection/balancer.go
@@ -68,7 +68,7 @@ func (bb) Build(cc balancer.ClientConn, bOpts balancer.BuildOptions) balancer.Ba
 		scUpdateCh:     buffer.NewUnbounded(),
 		pickerUpdateCh: buffer.NewUnbounded(),
 		channelzParent: bOpts.ChannelzParent,
-		endpoints:      resolver.NewEndpointMap(),
+		endpoints:      resolver.NewEndpointMap[*endpointInfo](),
 	}
 	b.logger = prefixLogger(b)
 	b.logger.Infof("Created")
@@ -196,7 +196,7 @@ type outlierDetectionBalancer struct {
 	// (within the context of a single goroutine).
 	mu sync.Mutex
 	// endpoints stores pointers to endpointInfo objects for each endpoint.
-	endpoints *resolver.EndpointMap // endpoint -> endpointInfo
+	endpoints *resolver.EndpointMap[*endpointInfo]
 	// addrs stores pointers to endpointInfo objects for each address. Addresses
 	// belonging to the same endpoint point to the same object.
 	addrs                 map[string]*endpointInfo
@@ -229,8 +229,7 @@ func (b *outlierDetectionBalancer) onIntervalConfig() {
 	var interval time.Duration
 	if b.timerStartTime.IsZero() {
 		b.timerStartTime = time.Now()
-		for _, val := range b.endpoints.Values() {
-			epInfo := val.(*endpointInfo)
+		for _, epInfo := range b.endpoints.Values() {
 			epInfo.callCounter.clear()
 		}
 		interval = time.Duration(b.cfg.Interval)
@@ -253,8 +252,7 @@ func (b *outlierDetectionBalancer) onNoopConfig() {
 	// do the following:"
 	// "Unset the timer start timestamp."
 	b.timerStartTime = time.Time{}
-	for _, val := range b.endpoints.Values() {
-		epInfo := val.(*endpointInfo)
+	for _, epInfo := range b.endpoints.Values() {
 		// "Uneject all currently ejected endpoints."
 		if !epInfo.latestEjectionTimestamp.IsZero() {
 			b.unejectEndpoint(epInfo)
@@ -298,7 +296,7 @@ func (b *outlierDetectionBalancer) UpdateClientConnState(s balancer.ClientConnSt
 	b.updateUnconditionally = false
 	b.cfg = lbCfg
 
-	newEndpoints := resolver.NewEndpointMap()
+	newEndpoints := resolver.NewEndpointMap[bool]()
 	for _, ep := range s.ResolverState.Endpoints {
 		newEndpoints.Set(ep, true)
 		if _, ok := b.endpoints.Get(ep); !ok {
@@ -315,8 +313,7 @@ func (b *outlierDetectionBalancer) UpdateClientConnState(s balancer.ClientConnSt
 	// populate the addrs map.
 	b.addrs = map[string]*endpointInfo{}
 	for _, ep := range s.ResolverState.Endpoints {
-		val, _ := b.endpoints.Get(ep)
-		epInfo := val.(*endpointInfo)
+		epInfo, _ := b.endpoints.Get(ep)
 		for _, addr := range ep.Addresses {
 			if _, ok := b.addrs[addr.Addr]; ok {
 				b.logger.Errorf("Endpoints contain duplicate address %q", addr.Addr)
@@ -705,8 +702,7 @@ func (b *outlierDetectionBalancer) intervalTimerAlgorithm() {
 	defer b.mu.Unlock()
 	b.timerStartTime = time.Now()
 
-	for _, val := range b.endpoints.Values() {
-		epInfo := val.(*endpointInfo)
+	for _, epInfo := range b.endpoints.Values() {
 		epInfo.callCounter.swap()
 	}
 
@@ -718,8 +714,7 @@ func (b *outlierDetectionBalancer) intervalTimerAlgorithm() {
 		b.failurePercentageAlgorithm()
 	}
 
-	for _, val := range b.endpoints.Values() {
-		epInfo := val.(*endpointInfo)
+	for _, epInfo := range b.endpoints.Values() {
 		if epInfo.latestEjectionTimestamp.IsZero() && epInfo.ejectionTimeMultiplier > 0 {
 			epInfo.ejectionTimeMultiplier--
 			continue
@@ -751,8 +746,7 @@ func (b *outlierDetectionBalancer) intervalTimerAlgorithm() {
 // Caller must hold b.mu.
 func (b *outlierDetectionBalancer) endpointsWithAtLeastRequestVolume(requestVolume uint32) []*endpointInfo {
 	var endpoints []*endpointInfo
-	for _, val := range b.endpoints.Values() {
-		epInfo := val.(*endpointInfo)
+	for _, epInfo := range b.endpoints.Values() {
 		bucket1 := epInfo.callCounter.inactiveBucket
 		rv := bucket1.numSuccesses + bucket1.numFailures
 		if rv >= requestVolume {

--- a/xds/internal/balancer/ringhash/ring_test.go
+++ b/xds/internal/balancer/ringhash/ring_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 var testEndpoints []resolver.Endpoint
-var testEndpointStateMap *resolver.EndpointMap
+var testEndpointStateMap *resolver.EndpointMap[*endpointState]
 
 func init() {
 	testEndpoints = []resolver.Endpoint{
@@ -38,7 +38,7 @@ func init() {
 		testEndpoint("b", 3),
 		testEndpoint("c", 4),
 	}
-	testEndpointStateMap = resolver.NewEndpointMap()
+	testEndpointStateMap = resolver.NewEndpointMap[*endpointState]()
 	testEndpointStateMap.Set(testEndpoints[0], &endpointState{firstAddr: "a", weight: 3})
 	testEndpointStateMap.Set(testEndpoints[1], &endpointState{firstAddr: "b", weight: 3})
 	testEndpointStateMap.Set(testEndpoints[2], &endpointState{firstAddr: "c", weight: 4})

--- a/xds/internal/balancer/ringhash/ringhash_test.go
+++ b/xds/internal/balancer/ringhash/ringhash_test.go
@@ -656,7 +656,7 @@ func (s) TestAggregatedConnectivityState(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			bal := &ringhashBalancer{endpointStates: resolver.NewEndpointMap()}
+			bal := &ringhashBalancer{endpointStates: resolver.NewEndpointMap[*endpointState]()}
 			for i, cs := range tt.endpointStates {
 				es := &endpointState{
 					state: balancer.State{ConnectivityState: cs},


### PR DESCRIPTION
This is #8187 but for EndpointMap.  In this case, I could find zero external usages of this type, since it is so new, so I thought it would be OK to just convert it in place.

RELEASE NOTES:
- resolver: convert EndpointMap to use generics