### PR TITLE
credentials/alts: Optimize reads

### DIFF
--- a/credentials/alts/internal/conn/common.go
+++ b/credentials/alts/internal/conn/common.go
@@ -54,11 +54,10 @@ func SliceForAppend(in []byte, n int) (head, tail []byte) {
 func ParseFramedMsg(b []byte, maxLen uint32) ([]byte, []byte, error) {
 	// If the size field is not complete, return the provided buffer as
 	// remaining buffer.
-	if len(b) < MsgLenFieldSize {
+	length, sufficientBytes := ParseMessageLength(b)
+	if !sufficientBytes {
 		return nil, b, nil
 	}
-	msgLenField := b[:MsgLenFieldSize]
-	length := binary.LittleEndian.Uint32(msgLenField)
 	if length > maxLen {
 		return nil, nil, fmt.Errorf("received the frame length %d larger than the limit %d", length, maxLen)
 	}
@@ -67,4 +66,16 @@ func ParseFramedMsg(b []byte, maxLen uint32) ([]byte, []byte, error) {
 		return nil, b, nil
 	}
 	return b[:MsgLenFieldSize+length], b[MsgLenFieldSize+length:], nil
+}
+
+// ParseMessageLength returns the message length based on frame header. It also
+// returns a boolean that indicates if the buffer contains sufficient bytes to
+// parse the length header. If there are insufficient bytes, (0, false) is
+// returned.
+func ParseMessageLength(b []byte) (uint32, bool) {
+	if len(b) < MsgLenFieldSize {
+		return 0, false
+	}
+	msgLenField := b[:MsgLenFieldSize]
+	return binary.LittleEndian.Uint32(msgLenField), true
 }

--- a/credentials/alts/internal/conn/common.go
+++ b/credentials/alts/internal/conn/common.go
@@ -54,7 +54,7 @@ func SliceForAppend(in []byte, n int) (head, tail []byte) {
 func ParseFramedMsg(b []byte, maxLen uint32) ([]byte, []byte, error) {
 	// If the size field is not complete, return the provided buffer as
 	// remaining buffer.
-	length, sufficientBytes := ParseMessageLength(b)
+	length, sufficientBytes := parseMessageLength(b)
 	if !sufficientBytes {
 		return nil, b, nil
 	}
@@ -68,11 +68,10 @@ func ParseFramedMsg(b []byte, maxLen uint32) ([]byte, []byte, error) {
 	return b[:MsgLenFieldSize+length], b[MsgLenFieldSize+length:], nil
 }
 
-// ParseMessageLength returns the message length based on frame header. It also
-// returns a boolean that indicates if the buffer contains sufficient bytes to
-// parse the length header. If there are insufficient bytes, (0, false) is
-// returned.
-func ParseMessageLength(b []byte) (uint32, bool) {
+// parseMessageLength returns the message length based on frame header. It also
+// returns a boolean indicating if the buffer contains sufficient bytes to parse
+// the length header. If there are insufficient bytes, (0, false) is returned.
+func parseMessageLength(b []byte) (uint32, bool) {
 	if len(b) < MsgLenFieldSize {
 		return 0, false
 	}

--- a/credentials/alts/internal/conn/record.go
+++ b/credentials/alts/internal/conn/record.go
@@ -191,7 +191,7 @@ func (p *conn) Read(b []byte) (n int, err error) {
 
 		// Decrypt directly into the buffer, avoiding a copy from p.buf if
 		// possible.
-		if cap(b) >= len(ciphertext) {
+		if len(b) >= len(ciphertext) {
 			dec, err := p.crypto.Decrypt(b[:0], ciphertext)
 			if err != nil {
 				return 0, err

--- a/credentials/alts/internal/conn/record.go
+++ b/credentials/alts/internal/conn/record.go
@@ -184,7 +184,7 @@ func (p *conn) Read(b []byte) (n int, err error) {
 					// header.
 					panic(fmt.Sprintf("protected buffer length shorter than expected: %d vs %d", len(p.protected), MsgLenFieldSize))
 				}
-				newProtectedBuf := mem.DefaultBufferPool().Get(int(length))
+				newProtectedBuf := mem.DefaultBufferPool().Get(int(length) + MsgLenFieldSize)
 				copy(*newProtectedBuf, p.protected)
 				p.protected = (*newProtectedBuf)[:len(p.protected)]
 				mem.DefaultBufferPool().Put(p.protectedPointer)

--- a/credentials/alts/internal/conn/record.go
+++ b/credentials/alts/internal/conn/record.go
@@ -120,8 +120,8 @@ func NewConn(c net.Conn, side core.Side, recordProtocol string, key []byte, prot
 	overhead := MsgLenFieldSize + msgTypeFieldSize + crypto.EncryptionOverhead()
 	payloadLengthLimit := altsRecordDefaultLength - overhead
 	// We pre-allocate protected to be of size 32KB during initialization.
-	// We increase the size of the buffer by the required amount if can't hold a
-	// complete encrypted record.
+	// We increase the size of the buffer by the required amount if it can't
+	// hold a complete encrypted record.
 	protectedPointer := mem.DefaultBufferPool().Get(max(altsReadBufferInitialSize, len(protected)))
 	// Copy additional data from hanshaker service.
 	copy(*protectedPointer, protected)


### PR DESCRIPTION
## Background

Internal issue: b/400312873

While benchmarking Google Cloud Storage read performance, the flame graphs showed significant time being spent in `google.golang.org/grpc/credentials/alts/internal/conn.(*conn).Read`.  These changes are done to reduce the time spent in this function. The following optimizations are done:

1. In the handshaker, allocate a buffer only once, outside the `for` loop.
2. Use 32KB (previously 4KB) buffers to read from the network.
3. When a complete ALTS frame doesn't fit into the buffer, directly expand the buffer to the required capacity instead of incrementing in steps of 4KB.
4. If the buffer passed to `Read()` is large enough, use it to store the decrypted message, avoiding an extra copy to `buf`. The default buffer size used by gRPC is 16KB, which also happens to be the size of ALTS records from GCS. This means we usually avoid the extra copy.

## Benchmarks

branch: master
```
go test ./credentials/alts/internal/conn -timeout=2s -bench="Bench"
goos: linux
goarch: amd64
pkg: google.golang.org/grpc/credentials/alts/internal/conn
cpu: Intel(R) Xeon(R) CPU @ 2.60GHz
BenchmarkLargeMessage-48              13          90139719 ns/op
PASS
ok      google.golang.org/grpc/credentials/alts/internal/conn   2.316s
```

branch: perfromance (this PR)
```
goos: linux
goarch: amd64
pkg: google.golang.org/grpc/credentials/alts/internal/conn
cpu: Intel(R) Xeon(R) CPU @ 2.60GHz
BenchmarkLargeMessage-48              14          80422425 ns/op
PASS
ok      google.golang.org/grpc/credentials/alts/internal/conn   2.139s
```

RELEASE NOTES:
* credentials/alts: Improve read performance by optimizing buffer copies and allocations.