### PR TITLE
Add doc about `mem.*Unsafe` consuming the input buffer

### DIFF
--- a/mem/buffers.go
+++ b/mem/buffers.go
@@ -207,6 +207,9 @@ func (b *buffer) String() string {
 
 // ReadUnsafe reads bytes from the given Buffer into the provided slice.
 // It does not perform safety checks.
+//
+// The returned Buffer MUST be used in place of the one passed in, as it may
+// have been modified or freed.
 func ReadUnsafe(dst []byte, buf Buffer) (int, Buffer) {
 	return buf.read(dst)
 }
@@ -214,6 +217,9 @@ func ReadUnsafe(dst []byte, buf Buffer) (int, Buffer) {
 // SplitUnsafe modifies the receiver to point to the first n bytes while it
 // returns a new reference to the remaining bytes. The returned Buffer
 // functions just like a normal reference acquired using Ref().
+//
+// The returned Buffer values MUST be used in place of the one passed in, as it
+// may have been modified or freed.
 func SplitUnsafe(buf Buffer, n int) (left, right Buffer) {
 	return buf.split(n)
 }


### PR DESCRIPTION
I've been reading the new buffer-pool-related code due to recent OOM problems with other libraries misusing `sync.Pool`, and the varying behavior between `Buffer` and `SliceBuffer` had me confused for quite a while.

Buffer mutates itself when `read`, and implicitly calls `Free` when fully consumed:
https://github.com/grpc/grpc-go/blob/5edab9e55414068e74320716117a2659c5d2174e/mem/buffers.go#L194-L200

While SliceBuffer returns a sub-slice but does not modify itself: https://github.com/grpc/grpc-go/blob/5edab9e55414068e74320716117a2659c5d2174e/mem/buffers.go#L263-L267

The only way these `*Unsafe` funcs can be used correctly is by replacing the input-buffer with the result-buffer(s), as the current code does: https://github.com/grpc/grpc-go/blob/5edab9e55414068e74320716117a2659c5d2174e/internal/transport/transport.go#L139

... which seems worth documenting since it feels like a _huge_ footgun otherwise: you only trigger the self-mutating-and-freeing behavior for relatively large data, which is less common in tests.

Granted, this isn't a technical barrier at all, but the behavior differences between implementations mislead me for a while and this "must not use input Buffer" requirement doesn't seem obviously-necessary to me when reading the code.  Might as well save future-people that effort.

---

On a related note, `Buffer` feels... a bit concerningly strange in regards to concurrency, and I didn't see it called out in the PR that introduced it so I think it might not have been noticed.

E.g. `Buffer`s are not concurrency-safe: https://github.com/grpc/grpc-go/blob/5edab9e55414068e74320716117a2659c5d2174e/mem/buffers.go#L39-L41
But it uses an atomic refcount: https://github.com/grpc/grpc-go/blob/5edab9e55414068e74320716117a2659c5d2174e/mem/buffers.go#L75-L80
... but it doesn't use it in an atomically-safe way, as it sets the value to nil when freeing: https://github.com/grpc/grpc-go/blob/5edab9e55414068e74320716117a2659c5d2174e/mem/buffers.go#L160

And if you include the fact that the ref came from a pool: https://github.com/grpc/grpc-go/blob/5edab9e55414068e74320716117a2659c5d2174e/mem/buffers.go#L157
it seems like this code cannot possibly be correct:
- non-racing code is paying for atomics it does not need
- racing code can avoid some checks by using a type that *is* race-safe
  - this might not be reachable in practice though
- racing code can double-`Put` refcounts and buffers (with a racing `Ref`, `Free`, `Ref`, `Free` sequence)
- racing code can leak refcount changes _across Buffer instances_ due to pooled reuse

So this is introducing difficult-to-investigate failure modes that non-atomic or non-pooled instances would not have.  It seems like it'd be better to either just use an `int` field or not-reuse atomics (if the goal is to detect races).

Also I would be quite surprised if pooled `*int` values perform better than non-pooled, given the cheap initialization and `sync.Pool`'s overhead, but I don't have any evidence either way.

Is there some benefit to this I'm missing?  Maybe something about it can catch tricky races or misuse that would otherwise be missed?  It seems misleading and dangerous to me otherwise.

RELEASE NOTES: none