### PR TITLE
xdsclient: fix TestServerFailureMetrics_BeforeResponseRecv test to wait for watch to start before stopping the listener

### DIFF
--- a/xds/internal/xdsclient/metrics_test.go
+++ b/xds/internal/xdsclient/metrics_test.go
@@ -160,7 +160,19 @@ func (s) TestServerFailureMetrics_BeforeResponseRecv(t *testing.T) {
 	if err != nil {
 		t.Fatalf("net.Listen() failed: %v", err)
 	}
-	mgmtServer := e2e.StartManagementServer(t, e2e.ManagementServerOptions{Listener: l})
+	lis := testutils.NewRestartableListener(l)
+	streamOpened := make(chan struct{}, 1)
+	mgmtServer := e2e.StartManagementServer(t, e2e.ManagementServerOptions{
+		Listener: lis,
+		OnStreamOpen: func(context.Context, int64, string) error {
+			select {
+			case streamOpened <- struct{}{}:
+			default:
+			}
+			return nil
+		},
+	})
+
 	nodeID := uuid.New().String()
 
 	bootstrapContents, err := bootstrap.NewContentsForTesting(bootstrap.ConfigOptionsForTesting{
@@ -196,15 +208,24 @@ func (s) TestServerFailureMetrics_BeforeResponseRecv(t *testing.T) {
 
 	// Watch for the listener on the above management server.
 	xdsresource.WatchListener(client, listenerResourceName, noopListenerWatcher{})
+	// Verify that an ADS stream is opened and an LDS request with the above
+	// resource name is sent.
+	select {
+	case <-streamOpened:
+	case <-ctx.Done():
+		t.Fatal("Timeout when waiting for ADS stream to open")
+	}
 
 	// Close the listener and ensure that the ADS stream breaks. This should
 	// cause a server failure count to emit eventually.
-	l.Close()
+	lis.Stop()
 	select {
 	case <-ctx.Done():
 		t.Fatal("Timeout when waiting for ADS stream to close")
 	default:
 	}
+	// Restart to prevent the attempt to create a new ADS stream after back off.
+	lis.Restart()
 
 	mdWant := stats.MetricsData{
 		Handle:    xdsClientServerFailureMetric.Descriptor(),

--- a/xds/internal/xdsclient/metrics_test.go
+++ b/xds/internal/xdsclient/metrics_test.go
@@ -219,11 +219,7 @@ func (s) TestServerFailureMetrics_BeforeResponseRecv(t *testing.T) {
 	// Close the listener and ensure that the ADS stream breaks. This should
 	// cause a server failure count to emit eventually.
 	lis.Stop()
-	select {
-	case <-ctx.Done():
-		t.Fatal("Timeout when waiting for ADS stream to close")
-	default:
-	}
+
 	// Restart to prevent the attempt to create a new ADS stream after back off.
 	lis.Restart()
 
@@ -315,10 +311,8 @@ func (s) TestServerFailureMetrics_AfterResponseRecv(t *testing.T) {
 	// Close the listener and ensure that the ADS stream breaks. This should
 	// cause a server failure count to emit eventually.
 	lis.Stop()
-	select {
-	case <-ctx.Done():
-		t.Fatal("Timeout when waiting for ADS stream to close")
-	default:
+	if ctx.Err() != nil {
+		t.Fatalf("Timeout when waiting for ADS stream to close")
 	}
 	// Restart to prevent the attempt to create a new ADS stream after back off.
 	lis.Restart()


### PR DESCRIPTION
Fixes: #8211

`TestServerFailureMetrics_BeforeResponseRecv` was flaking because of race between listener watch to start and closing the listener and if watch hasn't started the stream errors won't be received and server failure metric won't be emitted. Adding the hook to wait for stream to open before stopping the listener have fixed the race.

RELEASE NOTES: None

[Successful forge run](https://fusion2.corp.google.com/invocations/ab09a308-5ffe-414c-ba71-ee7fa07b5a1b/targets/%2F%2Fthird_party%2Fgolang%2Fgrpc%2Fxds%2Finternal%2Fxdsclient:xdsclient_test/log) 