### PR TITLE
Update lrs_stream.go fix use of wrong err

### DIFF
--- a/xds/internal/xdsclient/transport/lrs/lrs_stream.go
+++ b/xds/internal/xdsclient/transport/lrs/lrs_stream.go
@@ -242,7 +242,7 @@ func (lrs *StreamImpl) recvFirstLoadStatsResponse(stream transport.StreamingCall
 	}
 
 	internal := resp.GetLoadReportingInterval()
-	if internal.CheckValid() != nil {
+	if err:= internal.CheckValid(); err != nil {
 		return nil, 0, fmt.Errorf("lrs: invalid load_reporting_interval: %v", err)
 	}
 	loadReportingInterval := internal.AsDuration()

--- a/xds/internal/xdsclient/transport/lrs/lrs_stream.go
+++ b/xds/internal/xdsclient/transport/lrs/lrs_stream.go
@@ -241,11 +241,11 @@ func (lrs *StreamImpl) recvFirstLoadStatsResponse(stream transport.StreamingCall
 		lrs.logger.Infof("Received first LoadStatsResponse: %s", pretty.ToJSON(resp))
 	}
 
-	internal := resp.GetLoadReportingInterval()
-	if err:= internal.CheckValid(); err != nil {
+	interval := resp.GetLoadReportingInterval()
+	if err := interval.CheckValid(); err != nil {
 		return nil, 0, fmt.Errorf("lrs: invalid load_reporting_interval: %v", err)
 	}
-	loadReportingInterval := internal.AsDuration()
+	loadReportingInterval := interval.AsDuration()
 
 	clusters := resp.Clusters
 	if resp.SendAllClusters {


### PR DESCRIPTION
the origin `err` has been checked in line 233.

it is nil now, and after check `CheckInvalid() != nil`,

here should use the check err

RELEASE NOTES:
* xds: Fix reported error string when LRS load reporting interval is invalid.