### PR TITLE
resolver/dns: add RefreshInterval parameter to enable periodic DNS record refresh

### DIFF
--- a/resolver/dns/dns_resolver.go
+++ b/resolver/dns/dns_resolver.go
@@ -58,3 +58,8 @@ func NewBuilder() resolver.Builder {
 func SetMinResolutionInterval(d time.Duration) {
 	dns.MinResolutionInterval = d
 }
+
+// SetRefreshInterval sets the default dns refresh interval. Interval must be greater MinResolutionInterval
+func SetRefreshInterval(d time.Duration) {
+	dns.RefreshInterval = max(d, dns.MinResolutionInterval)
+}


### PR DESCRIPTION
This pull request introduces a new feature to the DNS resolver by adding a `RefreshInterval` variable, which defines the rate at which the resolver refreshes its DNS records. The default value is set to `0`, disabling the refresh unless configured otherwise. 

Key changes include:

- **New `RefreshInterval` Variable**: Allows for periodic DNS record refreshes, with a requirement that the value must be at least `MinResolutionInterval`.
- **Updated `watcher` Function**: Incorporates a new channel (`refreshCh`) to handle refresh signals, enabling automatic updates of DNS records alongside resolution requests.
- **Setter Function**: A new `SetRefreshInterval` function is added to allow users to configure the refresh interval while ensuring it meets the minimum requirement.

These enhancements improve the DNS resolver's responsiveness and accuracy in dynamic environments. Notably, similar functionality is available in the gRPC implementation for ASP.NET Core, which also features DNS address caching and refresh mechanisms (see [ASP.NET Core gRPC Load Balancing Documentation](https://learn.microsoft.com/en-us/aspnet/core/grpc/loadbalancing?view=aspnetcore-8.0#dns-address-caching)). This alignment with existing practices enhances consistency across platforms.

RELEASE NOTES:
- resolver/dns: add RefreshInterval parameter to enable periodic DNS record
