### PR TITLE
benchmark: Specify passthrough resolver to avoid resolution failures

### DIFF
--- a/benchmark/benchmain/main.go
+++ b/benchmark/benchmain/main.go
@@ -404,7 +404,7 @@ func makeClients(bf stats.Features) ([]testgrpc.BenchmarkServiceClient, func()) 
 	conns := make([]*grpc.ClientConn, bf.Connections)
 	clients := make([]testgrpc.BenchmarkServiceClient, bf.Connections)
 	for cn := 0; cn < bf.Connections; cn++ {
-		conns[cn] = benchmark.NewClientConn("" /* target not used */, opts...)
+		conns[cn] = benchmark.NewClientConn("passthrough://" /* target not used */, opts...)
 		clients[cn] = testgrpc.NewBenchmarkServiceClient(conns[cn])
 	}
 


### PR DESCRIPTION
In https://github.com/grpc/grpc-go/pull/7970, the benchmarking code was changed to use `NewClient` instead of `Dial` to create channels. This changed the default resolver from `passthrough` to `dns`. The usage fixed in this PR depended on the custom dialer dialing a fixed address irrespective of the resolver. Since the target was empty, the DNS resolver produces an error and causing RPCs to fail.

RELEASE NOTES: N/A