### PR TITLE
stats/opentelemetry: fix trace attributes message sequence numbers to start from 0

### DIFF
--- a/stats/opentelemetry/e2e_test.go
+++ b/stats/opentelemetry/e2e_test.go
@@ -876,7 +876,7 @@ func (s) TestMetricsAndTracesOptionEnabled(t *testing.T) {
 					Attributes: []attribute.KeyValue{
 						{
 							Key:   "sequence-number",
-							Value: attribute.IntValue(1),
+							Value: attribute.IntValue(0),
 						},
 						{
 							Key:   "message-size",
@@ -893,7 +893,7 @@ func (s) TestMetricsAndTracesOptionEnabled(t *testing.T) {
 					Attributes: []attribute.KeyValue{
 						{
 							Key:   "sequence-number",
-							Value: attribute.IntValue(1),
+							Value: attribute.IntValue(0),
 						},
 						{
 							Key:   "message-size",
@@ -934,7 +934,7 @@ func (s) TestMetricsAndTracesOptionEnabled(t *testing.T) {
 					Attributes: []attribute.KeyValue{
 						{
 							Key:   "sequence-number",
-							Value: attribute.IntValue(1),
+							Value: attribute.IntValue(0),
 						},
 						{
 							Key:   "message-size",
@@ -951,7 +951,7 @@ func (s) TestMetricsAndTracesOptionEnabled(t *testing.T) {
 					Attributes: []attribute.KeyValue{
 						{
 							Key:   "sequence-number",
-							Value: attribute.IntValue(1),
+							Value: attribute.IntValue(0),
 						},
 						{
 							Key:   "message-size",
@@ -1100,7 +1100,7 @@ func (s) TestSpan(t *testing.T) {
 					Attributes: []attribute.KeyValue{
 						{
 							Key:   "sequence-number",
-							Value: attribute.IntValue(1),
+							Value: attribute.IntValue(0),
 						},
 						{
 							Key:   "message-size",
@@ -1117,7 +1117,7 @@ func (s) TestSpan(t *testing.T) {
 					Attributes: []attribute.KeyValue{
 						{
 							Key:   "sequence-number",
-							Value: attribute.IntValue(1),
+							Value: attribute.IntValue(0),
 						},
 						{
 							Key:   "message-size",
@@ -1158,7 +1158,7 @@ func (s) TestSpan(t *testing.T) {
 					Attributes: []attribute.KeyValue{
 						{
 							Key:   "sequence-number",
-							Value: attribute.IntValue(1),
+							Value: attribute.IntValue(0),
 						},
 						{
 							Key:   "message-size",
@@ -1175,7 +1175,7 @@ func (s) TestSpan(t *testing.T) {
 					Attributes: []attribute.KeyValue{
 						{
 							Key:   "sequence-number",
-							Value: attribute.IntValue(1),
+							Value: attribute.IntValue(0),
 						},
 						{
 							Key:   "message-size",
@@ -1326,7 +1326,7 @@ func (s) TestSpan_WithW3CContextPropagator(t *testing.T) {
 					Attributes: []attribute.KeyValue{
 						{
 							Key:   "sequence-number",
-							Value: attribute.IntValue(1),
+							Value: attribute.IntValue(0),
 						},
 						{
 							Key:   "message-size",
@@ -1343,7 +1343,7 @@ func (s) TestSpan_WithW3CContextPropagator(t *testing.T) {
 					Attributes: []attribute.KeyValue{
 						{
 							Key:   "sequence-number",
-							Value: attribute.IntValue(1),
+							Value: attribute.IntValue(0),
 						},
 						{
 							Key:   "message-size",
@@ -1384,7 +1384,7 @@ func (s) TestSpan_WithW3CContextPropagator(t *testing.T) {
 					Attributes: []attribute.KeyValue{
 						{
 							Key:   "sequence-number",
-							Value: attribute.IntValue(1),
+							Value: attribute.IntValue(0),
 						},
 						{
 							Key:   "message-size",
@@ -1401,7 +1401,7 @@ func (s) TestSpan_WithW3CContextPropagator(t *testing.T) {
 					Attributes: []attribute.KeyValue{
 						{
 							Key:   "sequence-number",
-							Value: attribute.IntValue(1),
+							Value: attribute.IntValue(0),
 						},
 						{
 							Key:   "message-size",

--- a/stats/opentelemetry/trace.go
+++ b/stats/opentelemetry/trace.go
@@ -57,19 +57,19 @@ func populateSpan(rs stats.RPCStats, ai *attemptInfo) {
 	case *stats.InPayload:
 		// message id - "must be calculated as two different counters starting
 		// from one for sent messages and one for received messages."
-		ai.countRecvMsg++
 		span.AddEvent("Inbound compressed message", trace.WithAttributes(
 			attribute.Int64("sequence-number", int64(ai.countRecvMsg)),
 			attribute.Int64("message-size", int64(rs.Length)),
 			attribute.Int64("message-size-compressed", int64(rs.CompressedLength)),
 		))
+		ai.countRecvMsg++
 	case *stats.OutPayload:
-		ai.countSentMsg++
 		span.AddEvent("Outbound compressed message", trace.WithAttributes(
 			attribute.Int64("sequence-number", int64(ai.countSentMsg)),
 			attribute.Int64("message-size", int64(rs.Length)),
 			attribute.Int64("message-size-compressed", int64(rs.CompressedLength)),
 		))
+		ai.countSentMsg++
 	case *stats.End:
 		if rs.Error != nil {
 			s := status.Convert(rs.Error)


### PR DESCRIPTION
As per https://github.com/grpc/proposal/blob/master/A72-open-telemetry-tracing.md `sequence-number` starts at 0.

RELEASE NOTES:

- stats/opentelemetry: fix trace attributes message sequence numbers to start from 0.