### PR TITLE
ringhash: normalize uppercase in requestHashHeader from service config

### DIFF
--- a/xds/internal/balancer/ringhash/config.go
+++ b/xds/internal/balancer/ringhash/config.go
@@ -73,6 +73,7 @@ func parseConfig(c json.RawMessage) (*LBConfig, error) {
 		cfg.RequestHashHeader = ""
 	}
 	if cfg.RequestHashHeader != "" {
+		cfg.RequestHashHeader = strings.ToLower(cfg.RequestHashHeader)
 		// See rules in https://github.com/grpc/proposal/blob/master/A76-ring-hash-improvements.md#explicitly-setting-the-request-hash-key
 		if err := metadata.ValidateKey(cfg.RequestHashHeader); err != nil {
 			return nil, fmt.Errorf("invalid requestHashHeader %q: %v", cfg.RequestHashHeader, err)

--- a/xds/internal/balancer/ringhash/config_test.go
+++ b/xds/internal/balancer/ringhash/config_test.go
@@ -119,6 +119,16 @@ func (s) TestParseConfig(t *testing.T) {
 			},
 		},
 		{
+			name:                "request metadata key set with uppercase letters",
+			js:                  `{"requestHashHeader": "x-FOO"}`,
+			requestHeaderEnvVar: true,
+			want: &LBConfig{
+				MinRingSize:       defaultMinSize,
+				MaxRingSize:       defaultMaxSize,
+				RequestHashHeader: "x-foo",
+			},
+		},
+		{
 			name:                "invalid request hash header",
 			js:                  `{"requestHashHeader": "!invalid"}`,
 			requestHeaderEnvVar: true,


### PR DESCRIPTION
With gRFC A76 (#8159), when requestHashHeader is specified from the service config it fails the validation since MD keys with uppercase letters are normalized to lowercase. We should normalize the parsed value before validation.

RELEASE NOTES: N/A