### PR TITLE
Cherry-pick #8237

### DIFF
--- a/stats/opentelemetry/e2e_test.go
+++ b/stats/opentelemetry/e2e_test.go
@@ -869,7 +869,7 @@ func (s) TestMetricsAndTracesOptionEnabled(t *testing.T) {
 					Attributes: []attribute.KeyValue{
 						{
 							Key:   "sequence-number",
-							Value: attribute.IntValue(1),
+							Value: attribute.IntValue(0),
 						},
 						{
 							Key:   "message-size",
@@ -886,7 +886,7 @@ func (s) TestMetricsAndTracesOptionEnabled(t *testing.T) {
 					Attributes: []attribute.KeyValue{
 						{
 							Key:   "sequence-number",
-							Value: attribute.IntValue(1),
+							Value: attribute.IntValue(0),
 						},
 						{
 							Key:   "message-size",
@@ -927,7 +927,7 @@ func (s) TestMetricsAndTracesOptionEnabled(t *testing.T) {
 					Attributes: []attribute.KeyValue{
 						{
 							Key:   "sequence-number",
-							Value: attribute.IntValue(1),
+							Value: attribute.IntValue(0),
 						},
 						{
 							Key:   "message-size",
@@ -944,7 +944,7 @@ func (s) TestMetricsAndTracesOptionEnabled(t *testing.T) {
 					Attributes: []attribute.KeyValue{
 						{
 							Key:   "sequence-number",
-							Value: attribute.IntValue(1),
+							Value: attribute.IntValue(0),
 						},
 						{
 							Key:   "message-size",
@@ -1093,7 +1093,7 @@ func (s) TestSpan(t *testing.T) {
 					Attributes: []attribute.KeyValue{
 						{
 							Key:   "sequence-number",
-							Value: attribute.IntValue(1),
+							Value: attribute.IntValue(0),
 						},
 						{
 							Key:   "message-size",
@@ -1110,7 +1110,7 @@ func (s) TestSpan(t *testing.T) {
 					Attributes: []attribute.KeyValue{
 						{
 							Key:   "sequence-number",
-							Value: attribute.IntValue(1),
+							Value: attribute.IntValue(0),
 						},
 						{
 							Key:   "message-size",
@@ -1151,7 +1151,7 @@ func (s) TestSpan(t *testing.T) {
 					Attributes: []attribute.KeyValue{
 						{
 							Key:   "sequence-number",
-							Value: attribute.IntValue(1),
+							Value: attribute.IntValue(0),
 						},
 						{
 							Key:   "message-size",
@@ -1168,7 +1168,7 @@ func (s) TestSpan(t *testing.T) {
 					Attributes: []attribute.KeyValue{
 						{
 							Key:   "sequence-number",
-							Value: attribute.IntValue(1),
+							Value: attribute.IntValue(0),
 						},
 						{
 							Key:   "message-size",
@@ -1319,7 +1319,7 @@ func (s) TestSpan_WithW3CContextPropagator(t *testing.T) {
 					Attributes: []attribute.KeyValue{
 						{
 							Key:   "sequence-number",
-							Value: attribute.IntValue(1),
+							Value: attribute.IntValue(0),
 						},
 						{
 							Key:   "message-size",
@@ -1336,7 +1336,7 @@ func (s) TestSpan_WithW3CContextPropagator(t *testing.T) {
 					Attributes: []attribute.KeyValue{
 						{
 							Key:   "sequence-number",
-							Value: attribute.IntValue(1),
+							Value: attribute.IntValue(0),
 						},
 						{
 							Key:   "message-size",
@@ -1377,7 +1377,7 @@ func (s) TestSpan_WithW3CContextPropagator(t *testing.T) {
 					Attributes: []attribute.KeyValue{
 						{
 							Key:   "sequence-number",
-							Value: attribute.IntValue(1),
+							Value: attribute.IntValue(0),
 						},
 						{
 							Key:   "message-size",
@@ -1394,7 +1394,7 @@ func (s) TestSpan_WithW3CContextPropagator(t *testing.T) {
 					Attributes: []attribute.KeyValue{
 						{
 							Key:   "sequence-number",
-							Value: attribute.IntValue(1),
+							Value: attribute.IntValue(0),
 						},
 						{
 							Key:   "message-size",

--- a/stats/opentelemetry/trace.go
+++ b/stats/opentelemetry/trace.go
@@ -57,19 +57,19 @@ func populateSpan(rs stats.RPCStats, ai *attemptInfo) {
 	case *stats.InPayload:
 		// message id - "must be calculated as two different counters starting
 		// from one for sent messages and one for received messages."
-		ai.countRecvMsg++
 		span.AddEvent("Inbound compressed message", trace.WithAttributes(
 			attribute.Int64("sequence-number", int64(ai.countRecvMsg)),
 			attribute.Int64("message-size", int64(rs.Length)),
 			attribute.Int64("message-size-compressed", int64(rs.CompressedLength)),
 		))
+		ai.countRecvMsg++
 	case *stats.OutPayload:
-		ai.countSentMsg++
 		span.AddEvent("Outbound compressed message", trace.WithAttributes(
 			attribute.Int64("sequence-number", int64(ai.countSentMsg)),
 			attribute.Int64("message-size", int64(rs.Length)),
 			attribute.Int64("message-size-compressed", int64(rs.CompressedLength)),
 		))
+		ai.countSentMsg++
 	case *stats.End:
 		if rs.Error != nil {
 			s := status.Convert(rs.Error)


### PR DESCRIPTION
Original PR: #8237 

RELEASE NOTES:

- stats/opentelemetry: fix trace attributes message sequence numbers to… start from 0 (#8237)