### PR TITLE
xds: fix test data file name

### DIFF
--- a/internal/xds/bootstrap/tlscreds/bundle_ext_test.go
+++ b/internal/xds/bootstrap/tlscreds/bundle_ext_test.go
@@ -58,7 +58,7 @@ func (s) TestValidTlsBuilder(t *testing.T) {
 	caCert := testdata.Path("x509/server_ca_cert.pem")
 	clientCert := testdata.Path("x509/client1_cert.pem")
 	clientKey := testdata.Path("x509/client1_key.pem")
-	clientSpiffeBundle := testdata.Path("spiffe_end2end/client_spiffe.json")
+	clientSpiffeBundle := testdata.Path("spiffe_end2end/client_spiffebundle.json")
 	tests := []struct {
 		name string
 		jd   string


### PR DESCRIPTION
We were checking a file that didn't exist and it was causing a rare race - https://github.com/grpc/grpc-go/issues/8246

This brings up another question that I've added to the bug, but this fix is needed regardless.

RELEASE NOTES: N/A
