### PR TITLE
ringhash: fix flaky e2e tests

### DIFF
--- a/xds/internal/balancer/ringhash/e2e/ringhash_balancer_test.go
+++ b/xds/internal/balancer/ringhash/e2e/ringhash_balancer_test.go
@@ -2859,7 +2859,6 @@ func (s) TestRingHash_RequestHashKeyConnecting(t *testing.T) {
 		}
 		wg.Done()
 	}()
-	testutils.AwaitState(ctx, t, cc, connectivity.Connecting)
 
 	// Wait for at least one connection attempt.
 	nConn := 0
@@ -2867,6 +2866,7 @@ func (s) TestRingHash_RequestHashKeyConnecting(t *testing.T) {
 		if ctx.Err() != nil {
 			t.Fatal("Test timed out waiting for a connection attempt")
 		}
+		time.Sleep(1 * time.Millisecond)
 		for _, hold := range holds {
 			if hold.IsStarted() {
 				nConn++


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc-go/issues/8247.

1. Fix Test/RingHash_RequestHashKeyRandom by setting minRingSize to a higher value as we were doing in other tests. It lowers the skew that may occur from an imbalanced ring.

2. Fix Test/RingHash_RequestHashKeyConnecting by waiting for at least one connection attempt before proceeding to check for other connection attempts. That accounts for the unlikely case where the connection attempt has not been made by the time the channel transitions to CONNECTING state.

Testing done:
```
go test -run='Test/RingHash_RequestHashKey(Connecting|Random)' ./xds/internal/balancer/ringhash/e2e -count 10000
```

RELEASE NOTES: N/A