### PR TITLE
github: replace actions/upload-release-asset@v1 with gh cli

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,11 +57,7 @@ jobs:
           echo "name=${PACKAGE_NAME}" >> $GITHUB_OUTPUT
 
       - name: Upload asset
-        uses: actions/upload-release-asset@v1
+        run: | 
+          gh release upload ${{ github.event.release.tag_name }} ${{ steps.package.outputs.name }} 
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ./${{ steps.package.outputs.name }}
-          asset_name: ${{ steps.package.outputs.name }}
-          asset_content_type: application/gzip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
           echo "name=${PACKAGE_NAME}" >> $GITHUB_OUTPUT
 
       - name: Upload asset
-        run: | 
-          gh release upload ${{ github.event.release.tag_name }} ${{ steps.package.outputs.name }} 
+        run: |
+          gh release upload ${{ github.event.release.tag_name }} ./${{ steps.package.outputs.name }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixes: [#6416](https://github.com/grpc/grpc-go/issues/6416#issuecomment-1634700290) 

This PR replaces the usage of `actions/upload-release-asset@v1` with gh 

An example of the release can be found [here](https://github.com/Sebas03446/grpc-go/releases/tag/cmd%2Fprotoc-gen-go-grpc%2Fv1.5.3)

RELEASE NOTES: none