### PR TITLE
xds: fix TestServer_Security_WithValidAndInvalidSecurityConfiguration data race

### DIFF
--- a/xds/server_ext_test.go
+++ b/xds/server_ext_test.go
@@ -121,13 +121,6 @@ func (m *servingModeChangeHandler) modeChangeCallback(addr net.Addr, args xds.Se
 	m.currentErr = args.Err
 }
 
-// getCurrentMode safely returns the current serving mode.
-func (m *servingModeChangeHandler) getCurrentMode() connectivity.ServingMode {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	return m.currentMode
-}
-
 // createStubServer creates a new xDS-enabled gRPC server and returns a
 // stubserver.StubServer that can be used for testing. The server is configured
 // with the provided modeChangeOpt and xdsclient.Pool.

--- a/xds/server_security_ext_test.go
+++ b/xds/server_security_ext_test.go
@@ -457,8 +457,8 @@ func (s) TestServer_Security_WithValidAndInvalidSecurityConfiguration(t *testing
 	// it does not enter "serving" mode.
 	select {
 	case <-time.After(2 * defaultTestShortTimeout):
-	case <-modeChangeHandler2.modeCh:
-		if modeChangeHandler2.getCurrentMode() == connectivity.ServingModeServing {
+	case mode := <-modeChangeHandler2.modeCh:
+		if mode == connectivity.ServingModeServing {
 			t.Fatal("Server changed to serving mode when not expected to")
 		}
 	}

--- a/xds/server_security_ext_test.go
+++ b/xds/server_security_ext_test.go
@@ -458,7 +458,7 @@ func (s) TestServer_Security_WithValidAndInvalidSecurityConfiguration(t *testing
 	select {
 	case <-time.After(2 * defaultTestShortTimeout):
 	case <-modeChangeHandler2.modeCh:
-		if modeChangeHandler2.currentMode == connectivity.ServingModeServing {
+		if modeChangeHandler2.getCurrentMode() == connectivity.ServingModeServing {
 			t.Fatal("Server changed to serving mode when not expected to")
 		}
 	}


### PR DESCRIPTION
Fixes: #8268

[Successful Forge Run](https://fusion2.corp.google.com/invocations/5729c9d3-8b43-44ca-8ea7-aa65b2b75e6d)

RELEASE NOTES: None