### PR TITLE
xds: Remove redundant proto checks

### DIFF
--- a/xds/internal/clients/xdsclient/helpers_test.go
+++ b/xds/internal/clients/xdsclient/helpers_test.go
@@ -129,7 +129,7 @@ func processServerSideListener(lis *v3listenerpb.Listener) (*listenerUpdate, err
 	if n := len(lis.ListenerFilters); n != 0 {
 		return nil, fmt.Errorf("unsupported field 'listener_filters' contains %d entries", n)
 	}
-	if useOrigDst := lis.GetUseOriginalDst(); useOrigDst != nil && useOrigDst.GetValue() {
+	if lis.GetUseOriginalDst().GetValue() {
 		return nil, errors.New("unsupported field 'use_original_dst' is present and set to true")
 	}
 	addr := lis.GetAddress()

--- a/xds/internal/clients/xdsclient/test/helpers_test.go
+++ b/xds/internal/clients/xdsclient/test/helpers_test.go
@@ -137,7 +137,7 @@ func processServerSideListener(lis *v3listenerpb.Listener) (*listenerUpdate, err
 	if n := len(lis.ListenerFilters); n != 0 {
 		return nil, fmt.Errorf("unsupported field 'listener_filters' contains %d entries", n)
 	}
-	if useOrigDst := lis.GetUseOriginalDst(); useOrigDst != nil && useOrigDst.GetValue() {
+	if lis.GetUseOriginalDst().GetValue() {
 		return nil, errors.New("unsupported field 'use_original_dst' is present and set to true")
 	}
 	addr := lis.GetAddress()

--- a/xds/internal/xdsclient/xdsresource/unmarshal_lds.go
+++ b/xds/internal/xdsclient/xdsresource/unmarshal_lds.go
@@ -250,7 +250,7 @@ func processServerSideListener(lis *v3listenerpb.Listener) (*ListenerUpdate, err
 	if n := len(lis.ListenerFilters); n != 0 {
 		return nil, fmt.Errorf("unsupported field 'listener_filters' contains %d entries", n)
 	}
-	if useOrigDst := lis.GetUseOriginalDst(); useOrigDst != nil && useOrigDst.GetValue() {
+	if lis.GetUseOriginalDst().GetValue() {
 		return nil, errors.New("unsupported field 'use_original_dst' is present and set to true")
 	}
 	addr := lis.GetAddress()


### PR DESCRIPTION
Fixing findings from internal analyzer: [go/gobugs-findings#protonil](http://go/gobugs-findings#protonil)
> The Go Proto API is nil safe: it is safe to call Has/Get-methods on nil messages. If a Has-method is called on a nil proto, it returns false. If a Get-method is called on a nil proto, it returns the field's default value. This nil safety makes it possible to chain Get-methods calls without intermediate nil checks.

RELEASE NOTES: N/A