### PR TITLE
alts: Add plumbing for the bound access token field in the ALTS StartClient request.

### DIFF
--- a/credentials/alts/alts.go
+++ b/credentials/alts/alts.go
@@ -133,10 +133,11 @@ func DefaultServerOptions() *ServerOptions {
 // altsTC is the credentials required for authenticating a connection using ALTS.
 // It implements credentials.TransportCredentials interface.
 type altsTC struct {
-	info      *credentials.ProtocolInfo
-	side      core.Side
-	accounts  []string
-	hsAddress string
+	info             *credentials.ProtocolInfo
+	side             core.Side
+	accounts         []string
+	hsAddress        string
+	boundAccessToken string
 }
 
 // NewClientCreds constructs a client-side ALTS TransportCredentials object.
@@ -198,6 +199,7 @@ func (g *altsTC) ClientHandshake(ctx context.Context, addr string, rawConn net.C
 		MaxRpcVersion: maxRPCVersion,
 		MinRpcVersion: minRPCVersion,
 	}
+	opts.BoundAccessToken = g.boundAccessToken
 	chs, err := handshaker.NewClientHandshaker(ctx, hsConn, rawConn, opts)
 	if err != nil {
 		return nil, nil, err

--- a/credentials/alts/internal/handshaker/handshaker.go
+++ b/credentials/alts/internal/handshaker/handshaker.go
@@ -88,6 +88,8 @@ type ClientHandshakerOptions struct {
 	TargetServiceAccounts []string
 	// RPCVersions specifies the gRPC versions accepted by the client.
 	RPCVersions *altspb.RpcProtocolVersions
+	// BoundAccessToken is a bound access token to be sent to the server for authentication.
+	BoundAccessToken string
 }
 
 // ServerHandshakerOptions contains the server handshaker options that can
@@ -195,7 +197,9 @@ func (h *altsHandshaker) ClientHandshake(ctx context.Context) (net.Conn, credent
 			},
 		},
 	}
-
+	if h.clientOpts.BoundAccessToken != "" {
+		req.GetClientStart().AccessToken = h.clientOpts.BoundAccessToken
+	}
 	conn, result, err := h.doHandshake(req)
 	if err != nil {
 		return nil, nil, err

--- a/credentials/alts/internal/testutil/testutil.go
+++ b/credentials/alts/internal/testutil/testutil.go
@@ -145,6 +145,8 @@ func MakeFrame(pl string) []byte {
 // FakeHandshaker is a fake implementation of the ALTS handshaker service.
 type FakeHandshaker struct {
 	altsgrpc.HandshakerServiceServer
+	// ExpectedBoundAccessToken is the expected bound access token in the ClientStart request.
+	ExpectedBoundAccessToken string
 }
 
 // DoHandshake performs a fake ALTS handshake.
@@ -220,6 +222,9 @@ func (h *FakeHandshaker) processStartClient(req *altspb.StartClientHandshakeReq)
 	}
 	if len(req.RecordProtocols) != 1 || req.RecordProtocols[0] != "ALTSRP_GCM_AES128_REKEY" {
 		return nil, fmt.Errorf("unexpected record protocols: %v", req.RecordProtocols)
+	}
+	if h.ExpectedBoundAccessToken != req.GetAccessToken() {
+		return nil, fmt.Errorf("unexpected access token: %v", req.GetAccessToken())
 	}
 	return &altspb.HandshakerResp{
 		OutFrames:     []byte("ClientInit"),


### PR DESCRIPTION
At present, this field will only be exposed internally, it is not currently planned for wide usage.

RELEASE NOTES: None