### PR TITLE
xds_test: Wait for server to start serving in RBAC test

### DIFF
--- a/test/xds/xds_server_integration_test.go
+++ b/test/xds/xds_server_integration_test.go
@@ -83,7 +83,7 @@ func (l *acceptNotifyingListener) Accept() (net.Conn, error) {
 // Returns the following:
 // - local listener on which the xDS-enabled gRPC server is serving on
 // - cleanup function to be invoked by the tests when done
-func setupGRPCServer(t *testing.T, bootstrapContents []byte) (net.Listener, func()) {
+func setupGRPCServer(t *testing.T, bootstrapContents []byte, opts ...grpc.ServerOption) (net.Listener, func()) {
 	t.Helper()
 
 	// Configure xDS credentials to be used on the server-side.
@@ -113,7 +113,12 @@ func setupGRPCServer(t *testing.T, bootstrapContents []byte) (net.Listener, func
 		},
 	}
 
-	if stub.S, err = xds.NewGRPCServer(grpc.Creds(creds), testModeChangeServerOption(t), xds.BootstrapContentsForTesting(bootstrapContents)); err != nil {
+	opts = append([]grpc.ServerOption{
+		grpc.Creds(creds),
+		testModeChangeServerOption(t),
+		xds.BootstrapContentsForTesting(bootstrapContents),
+	}, opts...)
+	if stub.S, err = xds.NewGRPCServer(opts...); err != nil {
 		t.Fatalf("Failed to create an xDS enabled gRPC server: %v", err)
 	}
 

--- a/test/xds/xds_server_integration_test.go
+++ b/test/xds/xds_server_integration_test.go
@@ -122,8 +122,6 @@ func setupGRPCServer(t *testing.T, bootstrapContents []byte, opts ...grpc.Server
 		t.Fatalf("Failed to create an xDS enabled gRPC server: %v", err)
 	}
 
-	stubserver.StartTestService(t, stub)
-
 	// Create a local listener and pass it to Serve().
 	lis, err := testutils.LocalTCPListener()
 	if err != nil {
@@ -135,11 +133,8 @@ func setupGRPCServer(t *testing.T, bootstrapContents []byte, opts ...grpc.Server
 		serverReady: *grpcsync.NewEvent(),
 	}
 
-	go func() {
-		if err := stub.S.Serve(readyLis); err != nil {
-			t.Errorf("Serve() failed: %v", err)
-		}
-	}()
+	stub.Listener = readyLis
+	stubserver.StartTestService(t, stub)
 
 	// Wait for the server to start running.
 	select {


### PR DESCRIPTION
Fixes: https://github.com/grpc/grpc-go/issues/8286

This PR makes the test wait for the xds server to enter SERVING mode, otherwise it closes the net.Conn without returning any error.
https://github.com/grpc/grpc-go/blob/763d093ac8109661f4b7a118ce740eccbd100fb4/xds/internal/server/listener_wrapper.go#L287-L297

Analysis: https://github.com/grpc/grpc-go/issues/8286#issuecomment-2850859357

## Testing
Verified the test passes 10^5 runs on forge. 

RELEASE NOTES: N/A