### PR TITLE
transport: Propagate status code on receiving RST_STREAM during message read

### DIFF
--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -1242,7 +1242,8 @@ func (t *http2Client) handleRSTStream(f *http2.RSTStreamFrame) {
 			statusCode = codes.DeadlineExceeded
 		}
 	}
-	t.closeStream(s, io.EOF, false, http2.ErrCodeNo, status.Newf(statusCode, "stream terminated by RST_STREAM with error code: %v", f.ErrCode), nil, false)
+	st := status.Newf(statusCode, "stream terminated by RST_STREAM with error code: %v", f.ErrCode)
+	t.closeStream(s, st.Err(), false, http2.ErrCodeNo, st, nil, false)
 }
 
 func (t *http2Client) handleSettings(f *http2.SettingsFrame, isFirst bool) {

--- a/internal/transport/transport_test.go
+++ b/internal/transport/transport_test.go
@@ -919,8 +919,9 @@ func (s) TestLargeMessageSuspension(t *testing.T) {
 	}
 	// The server will send an RST stream frame on observing the deadline
 	// expiration making the client stream fail with a DeadlineExceeded status.
-	if _, err := s.readTo(make([]byte, 8)); err != io.EOF {
-		t.Fatalf("Read got unexpected error: %v, want %v", err, io.EOF)
+	_, err = s.readTo(make([]byte, 8))
+	if st, ok := status.FromError(err); !ok || st.Code() != codes.DeadlineExceeded {
+		t.Fatalf("Read got unexpected error: %v, want status with code %v", err, codes.DeadlineExceeded)
 	}
 	if got, want := s.Status().Code(), codes.DeadlineExceeded; got != want {
 		t.Fatalf("Read got status %v with code %v, want %v", s.Status(), got, want)

--- a/stream.go
+++ b/stream.go
@@ -1136,12 +1136,6 @@ func (a *csAttempt) recvMsg(m any, payInfo *payloadInfo) (err error) {
 			}
 			return io.EOF // indicates successful end of stream.
 		}
-		// The RPC status may be obtained from the RST_STREAM error code.
-		if err == io.ErrUnexpectedEOF {
-			if status := a.transportStream.Status(); status != nil {
-				return status.Err()
-			}
-		}
 
 		return toRPCErr(err)
 	}
@@ -1481,12 +1475,6 @@ func (as *addrConnStream) RecvMsg(m any) (err error) {
 				return statusErr
 			}
 			return io.EOF // indicates successful end of stream.
-		}
-		// The RPC status may be obtained from the RST_STREAM error code.
-		if err == io.ErrUnexpectedEOF {
-			if status := as.transportStream.Status(); status != nil {
-				return status.Err()
-			}
 		}
 		return toRPCErr(err)
 	}

--- a/stream.go
+++ b/stream.go
@@ -1136,6 +1136,12 @@ func (a *csAttempt) recvMsg(m any, payInfo *payloadInfo) (err error) {
 			}
 			return io.EOF // indicates successful end of stream.
 		}
+		// The RPC status may be obtained from the RST_STREAM error code.
+		if err == io.ErrUnexpectedEOF {
+			if status := a.transportStream.Status(); status != nil {
+				return status.Err()
+			}
+		}
 
 		return toRPCErr(err)
 	}
@@ -1475,6 +1481,12 @@ func (as *addrConnStream) RecvMsg(m any) (err error) {
 				return statusErr
 			}
 			return io.EOF // indicates successful end of stream.
+		}
+		// The RPC status may be obtained from the RST_STREAM error code.
+		if err == io.ErrUnexpectedEOF {
+			if status := as.transportStream.Status(); status != nil {
+				return status.Err()
+			}
 		}
 		return toRPCErr(err)
 	}

--- a/test/transport_test.go
+++ b/test/transport_test.go
@@ -19,16 +19,20 @@ package test
 
 import (
 	"context"
+	"encoding/binary"
 	"io"
 	"net"
 	"sync"
 	"testing"
 
+	"golang.org/x/net/http2"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/internal/grpcsync"
 	"google.golang.org/grpc/internal/stubserver"
+	"google.golang.org/grpc/internal/testutils"
 	"google.golang.org/grpc/internal/transport"
 	"google.golang.org/grpc/status"
 
@@ -151,5 +155,97 @@ func (s) TestClientTransportRestartsAfterStreamIDExhausted(t *testing.T) {
 	case <-creds.connections[0].close.Done():
 	case <-ctx.Done():
 		t.Fatal("Timeout expired when waiting for first client transport to close")
+	}
+}
+
+// Tests that an RST_STREAM frame that causes an io.ErrUnexpectedEOF while
+// reading a gRPC message is correctly converted to a gRPC status with code
+// CANCELLED. The test sends a data frame with a partial gRPC message, followed
+// by an RST_STREAM frame with HTTP/2 code CANCELLED. The test asserts the
+// client receives the correct status.
+func (s) TestRSTDuringMessageRead(t *testing.T) {
+	lis, err := testutils.LocalTCPListener()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer lis.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	cc, err := grpc.NewClient(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("grpc.NewClient(%s) = %v", lis.Addr().String(), err)
+	}
+	defer cc.Close()
+
+	go func() {
+		conn, err := lis.Accept()
+		if err != nil {
+			t.Errorf("lis.Accept() = %v", err)
+			return
+		}
+		defer conn.Close()
+		framer := http2.NewFramer(conn, conn)
+
+		if _, err := io.ReadFull(conn, make([]byte, len(clientPreface))); err != nil {
+			t.Errorf("Error while reading client preface: %v", err)
+			return
+		}
+		if err := framer.WriteSettings(); err != nil {
+			t.Errorf("Error while writing settings: %v", err)
+			return
+		}
+		if err := framer.WriteSettingsAck(); err != nil {
+			t.Errorf("Error while writing settings: %v", err)
+			return
+		}
+		var mu sync.Mutex
+		for {
+			frame, err := framer.ReadFrame()
+			if err != nil {
+				return
+			}
+			switch frame := frame.(type) {
+			case *http2.HeadersFrame:
+				// When the client creates a stream, write a partial gRPC
+				// message followed by an RST_STREAM.
+				go func() {
+					buf := make([]byte, 1024)
+					// Write the gRPC message length header.
+					binary.BigEndian.PutUint32(buf[1:5], 2048)
+					mu.Lock()
+					if err := framer.WriteData(1, false, buf); err != nil {
+						mu.Unlock()
+						return
+					}
+					framer.WriteRSTStream(1, http2.ErrCodeCancel)
+					mu.Unlock()
+				}()
+			case *http2.RSTStreamFrame:
+				if frame.Header().StreamID != 1 || http2.ErrCode(frame.ErrCode) != http2.ErrCodeFlowControl {
+					t.Errorf("RST stream received with streamID: %d and code: %v, want streamID: 1 and code: http2.ErrCodeFlowControl", frame.Header().StreamID, http2.ErrCode(frame.ErrCode))
+				}
+				return
+			case *http2.PingFrame:
+				mu.Lock()
+				framer.WritePing(true, frame.Data)
+				mu.Unlock()
+			default:
+				t.Logf("Server received frame: %v", frame)
+			}
+		}
+	}()
+
+	// The server will send a partial gRPC message before cancelling the stream.
+	// The client should get a gRPC status with code CANCELLED.
+	client := testgrpc.NewTestServiceClient(cc)
+	_, err = client.EmptyCall(ctx, &testpb.Empty{})
+
+	s, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("client.EmptyCall() returned non-status error: %v", err)
+	}
+	if s.Code() != codes.Canceled {
+		t.Fatalf("client.EmptyCall() returned status %v with code %v, want %v", s, s.Code(), codes.Canceled)
 	}
 }

--- a/test/transport_test.go
+++ b/test/transport_test.go
@@ -208,7 +208,7 @@ func (s) TestRSTDuringMessageRead(t *testing.T) {
 			case *http2.HeadersFrame:
 				// When the client creates a stream, write a partial gRPC
 				// message followed by an RST_STREAM.
-				messageLen := 2048
+				const messageLen = 2048
 				buf := make([]byte, messageLen/2)
 				// Write the gRPC message length header.
 				binary.BigEndian.PutUint32(buf[1:5], uint32(messageLen))

--- a/test/transport_test.go
+++ b/test/transport_test.go
@@ -239,13 +239,7 @@ func (s) TestRSTDuringMessageRead(t *testing.T) {
 	// The server will send a partial gRPC message before cancelling the stream.
 	// The client should get a gRPC status with code CANCELLED.
 	client := testgrpc.NewTestServiceClient(cc)
-	_, err = client.EmptyCall(ctx, &testpb.Empty{})
-
-	s, ok := status.FromError(err)
-	if !ok {
-		t.Fatalf("client.EmptyCall() returned non-status error: %v", err)
-	}
-	if s.Code() != codes.Canceled {
-		t.Fatalf("client.EmptyCall() returned status %v with code %v, want %v", s, s.Code(), codes.Canceled)
+	if _, err := client.EmptyCall(ctx, &testpb.Empty{}); status.Code(err) != codes.Canceled {
+		t.Fatalf("client.EmptyCall() returned %v; want status with code %v", err, codes.Canceled)
 	}
 }


### PR DESCRIPTION
Fixes: https://github.com/grpc/grpc-go/issues/8281

RCA: https://github.com/grpc/grpc-go/issues/8281#issuecomment-2848692246

This PR  uses a status error instead of an `io.UnexpectedEOF` to fail RPCs that have partially read a gRPC message.

RELEASE NOTES:
* grpc: Fix bug that causes RPCs to fail with status `INTERNAL` instead of `CANCELLED` or `DEADLINE_EXCEEDED` when the client receives an RST_STREAM frame while reading a gRPC message.