### PR TITLE
credentials/local: implement ValidateAuthority

### DIFF
--- a/credentials/credentials_ext_test.go
+++ b/credentials/credentials_ext_test.go
@@ -59,16 +59,17 @@ func authorityChecker(ctx context.Context, wantAuthority string) error {
 }
 
 func loadTLSCreds(t *testing.T) (grpc.ServerOption, grpc.DialOption) {
+	t.Helper()
 	cert, err := tls.LoadX509KeyPair(testdata.Path("x509/server1_cert.pem"), testdata.Path("x509/server1_key.pem"))
 	if err != nil {
-		t.Fatalf("Failed to load key pair: %s", err)
+		t.Fatalf("Failed to load key pair: %v", err)
 		return nil, nil
 	}
 	serverCreds := grpc.Creds(credentials.NewServerTLSFromCert(&cert))
 
 	clientCreds, err := credentials.NewClientTLSFromFile(testdata.Path("x509/server_ca_cert.pem"), "x.test.example.com")
 	if err != nil {
-		t.Fatalf("Failed to create client credentials: %s", err)
+		t.Fatalf("Failed to create client credentials: %v", err)
 	}
 	return serverCreds, grpc.WithTransportCredentials(clientCreds)
 }
@@ -121,9 +122,7 @@ func (s) TestCorrectAuthorityWithCreds(t *testing.T) {
 				},
 			}
 			serverOpt, dialOpt := tt.creds(t)
-			err := ss.StartServer(serverOpt)
-
-			if err != nil {
+			if err := ss.StartServer(serverOpt); err != nil {
 				t.Fatalf("Error starting endpoint server: %v", err)
 			}
 			defer ss.Stop()

--- a/credentials/credentials_ext_test.go
+++ b/credentials/credentials_ext_test.go
@@ -58,45 +58,91 @@ func authorityChecker(ctx context.Context, wantAuthority string) error {
 	return nil
 }
 
-// Tests the `grpc.CallAuthority` option with TLS credentials. This test verifies
-// that the provided authority is correctly propagated to the server when a
-// correct authority is used.
-func (s) TestCorrectAuthorityWithTLSCreds(t *testing.T) {
+func loadTLSCreds() (serverCreds credentials.TransportCredentials, clientCreds credentials.TransportCredentials, err error) {
 	cert, err := tls.LoadX509KeyPair(testdata.Path("x509/server1_cert.pem"), testdata.Path("x509/server1_key.pem"))
 	if err != nil {
-		t.Fatalf("Failed to load key pair: %s", err)
+		return nil, nil, fmt.Errorf("LoadX509KeyPair: %w", err)
 	}
-	creds, err := credentials.NewClientTLSFromFile(testdata.Path("x509/server_ca_cert.pem"), "x.test.example.com")
+	serverCreds = credentials.NewServerTLSFromCert(&cert)
+
+	clientCreds, err = credentials.NewClientTLSFromFile(testdata.Path("x509/server_ca_cert.pem"), "x.test.example.com")
 	if err != nil {
-		t.Fatalf("Failed to create credentials %v", err)
+		return nil, nil, fmt.Errorf("NewClientTLSFromFile: %w", err)
 	}
+	return serverCreds, clientCreds, nil
+}
+
+// Tests the scenario where the `grpc.CallAuthority` call option is used with
+// different transport credentials. The test verifies that the specified
+// authority is correctly propagated to the serve when a correct authority is
+// used.
+func (s) TestCorrectAuthorityWithCreds(t *testing.T) {
 	const authority = "auth.test.example.com"
-	ss := &stubserver.StubServer{
-		EmptyCallF: func(ctx context.Context, _ *testpb.Empty) (*testpb.Empty, error) {
-			if err := authorityChecker(ctx, authority); err != nil {
-				return nil, err
-			}
-			return &testpb.Empty{}, nil
+
+	serverTLS, clientTLS, err := loadTLSCreds()
+	if err != nil {
+		t.Fatalf("Failed to load TLS credentials: %v", err)
+	}
+
+	tests := []struct {
+		name         string
+		serverCreds  grpc.ServerOption
+		clientCreds  grpc.DialOption
+		expectedAuth string
+	}{
+		{
+			name:         "Insecure",
+			clientCreds:  grpc.WithTransportCredentials(insecure.NewCredentials()),
+			expectedAuth: authority,
+		},
+		{
+			name:         "Local",
+			clientCreds:  grpc.WithTransportCredentials(local.NewCredentials()),
+			expectedAuth: authority,
+		},
+		{
+			name:         "TLS",
+			serverCreds:  grpc.Creds(serverTLS),
+			clientCreds:  grpc.WithTransportCredentials(clientTLS),
+			expectedAuth: authority,
 		},
 	}
-	if err := ss.StartServer(grpc.Creds(credentials.NewServerTLSFromCert(&cert))); err != nil {
-		t.Fatalf("Error starting endpoint server: %v", err)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ss := &stubserver.StubServer{
+				EmptyCallF: func(ctx context.Context, _ *testpb.Empty) (*testpb.Empty, error) {
+					if err := authorityChecker(ctx, tt.expectedAuth); err != nil {
+						return nil, err
+					}
+					return &testpb.Empty{}, nil
+				},
+			}
+
+			if tt.serverCreds != nil {
+				err = ss.StartServer(tt.serverCreds)
+			} else {
+				err = ss.StartServer()
+			}
+
+			if err != nil {
+				t.Fatalf("Error starting endpoint server: %v", err)
+			}
+			defer ss.Stop()
+
+			cc, err := grpc.NewClient(ss.Address, tt.clientCreds)
+			if err != nil {
+				t.Fatalf("grpc.NewClient(%q) = %v", ss.Address, err)
+			}
+			defer cc.Close()
+
+			ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+			defer cancel()
+			if _, err = testgrpc.NewTestServiceClient(cc).EmptyCall(ctx, &testpb.Empty{}, grpc.CallAuthority(tt.expectedAuth)); err != nil {
+				t.Fatalf("EmptyCall() rpc failed: %v", err)
+			}
+		})
 	}
-	defer ss.Stop()
-
-	cc, err := grpc.NewClient(ss.Address, grpc.WithTransportCredentials(creds))
-	if err != nil {
-		t.Fatalf("grpc.NewClient(%q) = %v", ss.Address, err)
-	}
-	defer cc.Close()
-
-	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
-	defer cancel()
-
-	if _, err = testgrpc.NewTestServiceClient(cc).EmptyCall(ctx, &testpb.Empty{}, grpc.CallAuthority(authority)); status.Code(err) != codes.OK {
-		t.Fatalf("EmptyCall() returned status %v, want %v", status.Code(err), codes.OK)
-	}
-
 }
 
 // Tests the `grpc.CallAuthority` option with TLS credentials. This test verifies
@@ -141,70 +187,6 @@ func (s) TestIncorrectAuthorityWithTLS(t *testing.T) {
 	case <-serverCalled:
 		t.Fatalf("Server handler should not have been called")
 	case <-time.After(defaultTestShortTimeout):
-	}
-}
-
-// Tests the scenario where the `grpc.CallAuthority` call option is used with
-// insecure transport credentials. The test verifies that the specified
-// authority is correctly propagated to the server.
-func (s) TestAuthorityCallOptionWithInsecureCreds(t *testing.T) {
-	const authority = "test.server.name"
-
-	ss := &stubserver.StubServer{
-		EmptyCallF: func(ctx context.Context, _ *testpb.Empty) (*testpb.Empty, error) {
-			if err := authorityChecker(ctx, authority); err != nil {
-				return nil, err
-			}
-			return &testpb.Empty{}, nil
-		},
-	}
-	if err := ss.Start(nil); err != nil {
-		t.Fatalf("Error starting endpoint server: %v", err)
-	}
-	defer ss.Stop()
-
-	cc, err := grpc.NewClient(ss.Address, grpc.WithTransportCredentials(insecure.NewCredentials()))
-	if err != nil {
-		t.Fatalf("grpc.NewClient(%q) = %v", ss.Address, err)
-	}
-	defer cc.Close()
-
-	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
-	defer cancel()
-	if _, err = testgrpc.NewTestServiceClient(cc).EmptyCall(ctx, &testpb.Empty{}, grpc.CallAuthority(authority)); err != nil {
-		t.Fatalf("EmptyCall() rpc failed: %v", err)
-	}
-}
-
-// Tests the scenario where the `grpc.CallAuthority` call option is used with
-// local transport credentials. The test verifies that the specified
-// authority is correctly propagated to the server.
-func (s) TestAuthorityCallOptionWithLocalCreds(t *testing.T) {
-	const authority = "test.server.name"
-
-	ss := &stubserver.StubServer{
-		EmptyCallF: func(ctx context.Context, _ *testpb.Empty) (*testpb.Empty, error) {
-			if err := authorityChecker(ctx, authority); err != nil {
-				return nil, err
-			}
-			return &testpb.Empty{}, nil
-		},
-	}
-	if err := ss.Start(nil); err != nil {
-		t.Fatalf("Error starting endpoint server: %v", err)
-	}
-	defer ss.Stop()
-
-	cc, err := grpc.NewClient(ss.Address, grpc.WithTransportCredentials(local.NewCredentials()))
-	if err != nil {
-		t.Fatalf("grpc.NewClient(%q) = %v", ss.Address, err)
-	}
-	defer cc.Close()
-
-	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
-	defer cancel()
-	if _, err = testgrpc.NewTestServiceClient(cc).EmptyCall(ctx, &testpb.Empty{}, grpc.CallAuthority(authority)); err != nil {
-		t.Fatalf("EmptyCall() rpc failed: %v", err)
 	}
 }
 

--- a/credentials/local/local.go
+++ b/credentials/local/local.go
@@ -49,6 +49,12 @@ func (info) AuthType() string {
 	return "local"
 }
 
+// ValidateAuthority allows any value to be overridden for the :authority
+// header.
+func (info) ValidateAuthority(string) error {
+	return nil
+}
+
 // localTC is the credentials required to establish a local connection.
 type localTC struct {
 	info credentials.ProtocolInfo


### PR DESCRIPTION
Add ValidateAuthority implementation to local credentials to allow authority override. It permits any authority override when using local credentials.

Addresses: #5361 

RELEASE NOTES: N/A