### PR TITLE
[alts] add keepalive params to the alts handshaker client dial option

### DIFF
--- a/credentials/alts/internal/handshaker/service/service.go
+++ b/credentials/alts/internal/handshaker/service/service.go
@@ -56,8 +56,8 @@ func Dial(hsAddress string) (*grpc.ClientConn, error) {
 			grpc.WithTransportCredentials(insecure.NewCredentials()),
 			grpc.WithDisableServiceConfig(),
 			grpc.WithKeepaliveParams(keepalive.ClientParameters{
-				Timeout: 5 * time.Second,
-				Time:    time.Hour,
+				Timeout: 10 * time.Second,
+				Time:    10 * time.Minute,
 			}),
 		}
 		hsConn, err = grpc.NewClient(hsAddress, opts...)

--- a/credentials/alts/internal/handshaker/service/service.go
+++ b/credentials/alts/internal/handshaker/service/service.go
@@ -26,6 +26,7 @@ import (
 
 	grpc "google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/internal/envconfig"
 	"google.golang.org/grpc/keepalive"
 )
 
@@ -55,10 +56,12 @@ func Dial(hsAddress string) (*grpc.ClientConn, error) {
 		opts := []grpc.DialOption{
 			grpc.WithTransportCredentials(insecure.NewCredentials()),
 			grpc.WithDisableServiceConfig(),
-			grpc.WithKeepaliveParams(keepalive.ClientParameters{
+		}
+		if envconfig.ALTSHandshakerKeepaliveParams {
+			opts = append(opts, grpc.WithKeepaliveParams(keepalive.ClientParameters{
 				Timeout: 10 * time.Second,
 				Time:    10 * time.Minute,
-			}),
+			}))
 		}
 		hsConn, err = grpc.NewClient(hsAddress, opts...)
 		if err != nil {

--- a/credentials/alts/internal/handshaker/service/service.go
+++ b/credentials/alts/internal/handshaker/service/service.go
@@ -56,9 +56,8 @@ func Dial(hsAddress string) (*grpc.ClientConn, error) {
 			grpc.WithTransportCredentials(insecure.NewCredentials()),
 			grpc.WithDisableServiceConfig(),
 			grpc.WithKeepaliveParams(keepalive.ClientParameters{
-				Timeout:             5 * time.Second,
-				Time:                time.Hour,
-				PermitWithoutStream: true,
+				Timeout: 5 * time.Second,
+				Time:    time.Hour,
 			}),
 		}
 		hsConn, err = grpc.NewClient(hsAddress, opts...)

--- a/internal/envconfig/envconfig.go
+++ b/internal/envconfig/envconfig.go
@@ -69,6 +69,10 @@ var (
 	// to gRFC A76. It can be enabled by setting the environment variable
 	// "GRPC_EXPERIMENTAL_RING_HASH_SET_REQUEST_HASH_KEY" to "true".
 	RingHashSetRequestHashKey = boolFromEnv("GRPC_EXPERIMENTAL_RING_HASH_SET_REQUEST_HASH_KEY", false)
+
+	// ALTSHandshakerKeepAliveParams is set if we should add the
+	// KeepaliveParams when dial the ALTS handshaker service.
+	ALTSHandshakerKeepaliveParams = boolFromEnv("GRPC_EXPERIMENTAL_ALTS_HANDSHAKER_KEEPALIVE_PARAMS", false)
 )
 
 func boolFromEnv(envVar string, def bool) bool {

--- a/internal/envconfig/envconfig.go
+++ b/internal/envconfig/envconfig.go
@@ -70,7 +70,7 @@ var (
 	// "GRPC_EXPERIMENTAL_RING_HASH_SET_REQUEST_HASH_KEY" to "true".
 	RingHashSetRequestHashKey = boolFromEnv("GRPC_EXPERIMENTAL_RING_HASH_SET_REQUEST_HASH_KEY", false)
 
-	// ALTSHandshakerKeepAliveParams is set if we should add the
+	// ALTSHandshakerKeepaliveParams is set if we should add the
 	// KeepaliveParams when dial the ALTS handshaker service.
 	ALTSHandshakerKeepaliveParams = boolFromEnv("GRPC_EXPERIMENTAL_ALTS_HANDSHAKER_KEEPALIVE_PARAMS", false)
 )


### PR DESCRIPTION
The most important number here is the 5 seconds timeout. It means the client will close the connection if there is no activity for 5 seconds. It helps with the situation when the connection is somehow broken.

RELEASE NOTES: None