### PR TITLE
internal/transport: Wait for server goroutines to exit during shutdown in test

### DIFF
--- a/internal/transport/transport_test.go
+++ b/internal/transport/transport_test.go
@@ -406,21 +406,33 @@ func (s *server) start(t *testing.T, port int, serverConfig *ServerConfig, ht hT
 		case misbehaved:
 			go func() {
 				transport.HandleStreams(ctx, func(s *ServerStream) {
-					go h.handleStreamMisbehave(t, s)
+					wg.Add(1)
+					go func() {
+						h.handleStreamMisbehave(t, s)
+						wg.Done()
+					}()
 				})
 				wg.Done()
 			}()
 		case encodingRequiredStatus:
 			go func() {
 				transport.HandleStreams(ctx, func(s *ServerStream) {
-					go h.handleStreamEncodingRequiredStatus(s)
+					wg.Add(1)
+					go func() {
+						h.handleStreamEncodingRequiredStatus(s)
+						wg.Done()
+					}()
 				})
 				wg.Done()
 			}()
 		case invalidHeaderField:
 			go func() {
 				transport.HandleStreams(ctx, func(s *ServerStream) {
-					go h.handleStreamInvalidHeaderField(s)
+					wg.Add(1)
+					go func() {
+						h.handleStreamInvalidHeaderField(s)
+						wg.Done()
+					}()
 				})
 				wg.Done()
 			}()
@@ -432,21 +444,33 @@ func (s *server) start(t *testing.T, port int, serverConfig *ServerConfig, ht hT
 			s.mu.Unlock()
 			go func() {
 				transport.HandleStreams(ctx, func(s *ServerStream) {
-					go h.handleStreamDelayRead(t, s)
+					wg.Add(1)
+					go func() {
+						h.handleStreamDelayRead(t, s)
+						wg.Done()
+					}()
 				})
 				wg.Done()
 			}()
 		case pingpong:
 			go func() {
 				transport.HandleStreams(ctx, func(s *ServerStream) {
-					go h.handleStreamPingPong(t, s)
+					wg.Add(1)
+					go func() {
+						h.handleStreamPingPong(t, s)
+						wg.Done()
+					}()
 				})
 				wg.Done()
 			}()
 		default:
 			go func() {
 				transport.HandleStreams(ctx, func(s *ServerStream) {
-					go h.handleStream(t, s)
+					wg.Add(1)
+					go func() {
+						h.handleStream(t, s)
+						wg.Done()
+					}()
 				})
 				wg.Done()
 			}()


### PR DESCRIPTION
Internal bug: b/416700146

Presently the PingPong tests don't wait for server goroutines to finish work before the return. This causes data races when the next test tries to update the GRPCLogger. Closing the server isn't sufficient.
https://github.com/grpc/grpc-go/blob/950a7cfdfd571b75f6b869ae0f625f9d65b19842/internal/transport/http2_server.go#L1265-L1268

RELEASE NOTES: N/A