### PR TITLE
leakcheck: Fix flaky test TestCheck

### DIFF
--- a/internal/leakcheck/leakcheck_test.go
+++ b/internal/leakcheck/leakcheck_test.go
@@ -49,13 +49,14 @@ func TestCheck(t *testing.T) {
 		go func() { <-ch }()
 	}
 	if leaked := interestingGoroutines(); len(leaked) != leakCount {
-		t.Errorf("interestingGoroutines found %v leaks, want %v leaks", len(leaked), leakCount)
+		t.Errorf("interestingGoroutines() = %v, want length %v", len(leaked), leakCount)
 	}
 	e := &testLogger{}
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	if CheckGoroutines(ctx, e); e.errorCount < 3 {
-		t.Errorf("CheckGoroutines found %v leaks, want %v leaks", e.errorCount, leakCount)
+	if CheckGoroutines(ctx, e); e.errorCount < leakCount {
+		t.Errorf("CheckGoroutines() = %v, want count %v", e.errorCount, leakCount)
+		t.Logf("leaked goroutines:\n%v", strings.Join(e.errors, "\n"))
 	}
 	close(ch)
 	ctx, cancel = context.WithTimeout(context.Background(), 3*time.Second)
@@ -75,14 +76,15 @@ func TestCheckRegisterIgnore(t *testing.T) {
 		go func() { <-ch }()
 	}
 	if leaked := interestingGoroutines(); len(leaked) != leakCount {
-		t.Errorf("interestingGoroutines found %v leaks, want %v leaks", len(leaked), leakCount)
+		t.Errorf("interestingGoroutines() = %v, want length %v", len(leaked), leakCount)
 	}
 	go func() { ignoredTestingLeak(3 * time.Second) }()
 	e := &testLogger{}
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	if CheckGoroutines(ctx, e); e.errorCount < 3 {
-		t.Errorf("CheckGoroutines found %v leaks, want %v leaks", e.errorCount, leakCount)
+	if CheckGoroutines(ctx, e); e.errorCount < leakCount {
+		t.Errorf("CheckGoroutines() = %v, want count %v", e.errorCount, leakCount)
+		t.Logf("leaked goroutines:\n%v", strings.Join(e.errors, "\n"))
 	}
 	close(ch)
 	ctx, cancel = context.WithTimeout(context.Background(), 3*time.Second)

--- a/internal/leakcheck/leakcheck_test.go
+++ b/internal/leakcheck/leakcheck_test.go
@@ -23,14 +23,10 @@ import (
 	"fmt"
 	"strings"
 	"sync"
-
-	// "sync"
-
 	"testing"
 	"time"
 
 	"google.golang.org/grpc/internal"
-	// "google.golang.osrg/grpc/internal"
 )
 
 type testLogger struct {

--- a/internal/leakcheck/leakcheck_test.go
+++ b/internal/leakcheck/leakcheck_test.go
@@ -49,13 +49,13 @@ func TestCheck(t *testing.T) {
 		go func() { <-ch }()
 	}
 	if leaked := interestingGoroutines(); len(leaked) != leakCount {
-		t.Errorf("interestingGoroutines() = %v, want length %v", len(leaked), leakCount)
+		t.Errorf("interestingGoroutines() = %d, want length %d", len(leaked), leakCount)
 	}
 	e := &testLogger{}
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 	if CheckGoroutines(ctx, e); e.errorCount < leakCount {
-		t.Errorf("CheckGoroutines() = %v, want count %v", e.errorCount, leakCount)
+		t.Errorf("CheckGoroutines() = %d, want count %d", e.errorCount, leakCount)
 		t.Logf("leaked goroutines:\n%v", strings.Join(e.errors, "\n"))
 	}
 	close(ch)
@@ -70,20 +70,20 @@ func ignoredTestingLeak(d time.Duration) {
 
 func TestCheckRegisterIgnore(t *testing.T) {
 	RegisterIgnoreGoroutine("ignoredTestingLeak")
+	go ignoredTestingLeak(3 * time.Second)
 	const leakCount = 3
 	ch := make(chan struct{})
 	for i := 0; i < leakCount; i++ {
 		go func() { <-ch }()
 	}
 	if leaked := interestingGoroutines(); len(leaked) != leakCount {
-		t.Errorf("interestingGoroutines() = %v, want length %v", len(leaked), leakCount)
+		t.Errorf("interestingGoroutines() = %d, want length %d", len(leaked), leakCount)
 	}
-	go func() { ignoredTestingLeak(3 * time.Second) }()
 	e := &testLogger{}
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 	if CheckGoroutines(ctx, e); e.errorCount < leakCount {
-		t.Errorf("CheckGoroutines() = %v, want count %v", e.errorCount, leakCount)
+		t.Errorf("CheckGoroutines() = %d, want count %d", e.errorCount, leakCount)
 		t.Logf("leaked goroutines:\n%v", strings.Join(e.errors, "\n"))
 	}
 	close(ch)


### PR DESCRIPTION
Fixes #8276 

leakcheck.TestCheck and leakcheck.TestCheckRegisterIgnore is flaky due to a gouroutine leak caused by [context.WithTimeout()](https://github.com/grpc/grpc-go/blob/950a7cfdfd571b75f6b869ae0f625f9d65b19842/internal/leakcheck/leakcheck_test.go#L54C2-L55C16).
Flakiness was filed in  #8276.

RELEASE NOTES: N/A

