### PR TITLE
transport: Prevent sending negative timeouts

### DIFF
--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -592,6 +592,9 @@ func (t *http2Client) createHeaderFields(ctx context.Context, callHdr *CallHdr) 
 		// Send out timeout regardless its value. The server can detect timeout context by itself.
 		// TODO(mmukhi): Perhaps this field should be updated when actually writing out to the wire.
 		timeout := time.Until(dl)
+		if timeout <= 0 {
+			return nil, status.Error(codes.DeadlineExceeded, context.DeadlineExceeded.Error())
+		}
 		headerFields = append(headerFields, hpack.HeaderField{Name: "grpc-timeout", Value: grpcutil.EncodeDuration(timeout)})
 	}
 	for k, v := range authData {

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -5342,7 +5342,7 @@ func testRPCTimeout(t *testing.T, e env) {
 		ResponseSize: respSize,
 		Payload:      payload,
 	}
-	for i := -1; i <= 10; i++ {
+	for i := 1; i <= 10; i++ {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Duration(i)*time.Millisecond)
 		if _, err := tc.UnaryCall(ctx, req); status.Code(err) != codes.DeadlineExceeded {
 			t.Fatalf("TestService/UnaryCallv(_, _) = _, %v; want <nil>, error code: %s", err, codes.DeadlineExceeded)

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -5360,7 +5360,7 @@ func (s) TestNegativeRPCTimeout(t *testing.T) {
 	defer server.Stop()
 
 	if err := server.StartClient(); err != nil {
-		t.Fatal(err)
+		t.Fatalf("Failed to create client: %v", err)
 	}
 
 	// Try increasingly larger timeout values to trigger the condition when the


### PR DESCRIPTION
After https://github.com/grpc/grpc-go/pull/8290 is merged, negative timeout values fail the request with an internal status instead of a deadline exceeded. This test uses negative deadlines and can fail if the server sends an internal error before the client sees the deadline expire.

Sample failure: https://github.com/grpc/grpc-go/actions/runs/14979137997/job/42078795928?pr=8308

The client checks the deadline expiry before creating a stream.
https://github.com/grpc/grpc-go/blob/709023de87a25ae63b000139295af10589edffee/stream.go#L410-L413

However, the deadline may expire after this check, but before the `grpc-timeout` header is created.

RELEASE NOTES:
* transport: Fail RPCs on the client when using extremely short contexts that expire before the `grpc-timeout` header is created.