### PR TITLE
delegatingresolver: avoid proxy for resolved addresses in NO_PROXY env

### DIFF
--- a/internal/resolver/delegatingresolver/delegatingresolver.go
+++ b/internal/resolver/delegatingresolver/delegatingresolver.go
@@ -354,8 +354,9 @@ func (r *delegatingResolver) updateTargetResolverState(state resolver.State) err
 		logger.Infof("Addresses received from target resolver: %v", state.Addresses)
 	}
 	r.targetResolverState = &state
-	// If no addresses returned by resolver have network type as tcp , do not
-	// wait for proxy update.
+	// If all addresses returned by the target resolver have a non-TCP network
+	// type, or are listed in the `NO_PROXY` environment variable, do not wait
+	// for proxy update.
 	if !needsProxyResolver(r.targetResolverState) {
 		return r.cc.UpdateState(*r.targetResolverState)
 	}

--- a/internal/resolver/delegatingresolver/delegatingresolver.go
+++ b/internal/resolver/delegatingresolver/delegatingresolver.go
@@ -109,7 +109,6 @@ func New(target resolver.Target, cc resolver.ClientConn, opts resolver.BuildOpti
 
 	var err error
 	r.proxyURL, err = proxyURLForTarget(target.Endpoint())
-	logger.Info("Eshita proxy url %s", r.proxyURL)
 	if err != nil {
 		return nil, fmt.Errorf("delegating_resolver: failed to determine proxy URL for target %s: %v", target, err)
 	}

--- a/internal/resolver/delegatingresolver/delegatingresolver_ext_test.go
+++ b/internal/resolver/delegatingresolver/delegatingresolver_ext_test.go
@@ -164,6 +164,19 @@ func proxyAddressWithTargetAttribute(proxyAddr string, targetAddr string) resolv
 	return addr
 }
 
+func overrideTestHTTPSProxy(t *testing.T, proxyAddr string) {
+	t.Helper()
+	hpfe := func(req *http.Request) (*url.URL, error) {
+		return &url.URL{
+			Scheme: "https",
+			Host:   proxyAddr,
+		}, nil
+	}
+	originalhpfe := delegatingresolver.HTTPSProxyFromEnvironment
+	delegatingresolver.HTTPSProxyFromEnvironment = hpfe
+	t.Cleanup(func() { delegatingresolver.HTTPSProxyFromEnvironment = originalhpfe })
+}
+
 // Tests the scenario where proxy is configured and the target URI contains the
 // "dns" scheme and target resolution is enabled. The test verifies that the
 // addresses returned by the delegating resolver combines the addresses
@@ -176,17 +189,8 @@ func (s) TestDelegatingResolverwithDNSAndProxyWithTargetResolution(t *testing.T)
 		envProxyAddr            = "proxytest.com"
 		resolvedProxyTestAddr1  = "11.11.11.11:7687"
 	)
-	hpfe := func(req *http.Request) (*url.URL, error) {
-		return &url.URL{
-			Scheme: "https",
-			Host:   envProxyAddr,
-		}, nil
-	}
-	originalhpfe := delegatingresolver.HTTPSProxyFromEnvironment
-	delegatingresolver.HTTPSProxyFromEnvironment = hpfe
-	defer func() {
-		delegatingresolver.HTTPSProxyFromEnvironment = originalhpfe
-	}()
+	overrideTestHTTPSProxy(t, envProxyAddr)
+
 	// Manual resolver to control the target resolution.
 	targetResolver := manual.NewBuilderWithScheme("dns")
 	target := targetResolver.Scheme() + ":///" + targetTestAddr
@@ -253,17 +257,7 @@ func (s) TestDelegatingResolverwithDNSAndProxyWithNoTargetResolution(t *testing.
 		envProxyAddr           = "proxytest.com"
 		resolvedProxyTestAddr1 = "11.11.11.11:7687"
 	)
-	hpfe := func(req *http.Request) (*url.URL, error) {
-		return &url.URL{
-			Scheme: "https",
-			Host:   envProxyAddr,
-		}, nil
-	}
-	originalhpfe := delegatingresolver.HTTPSProxyFromEnvironment
-	delegatingresolver.HTTPSProxyFromEnvironment = hpfe
-	defer func() {
-		delegatingresolver.HTTPSProxyFromEnvironment = originalhpfe
-	}()
+	overrideTestHTTPSProxy(t, envProxyAddr)
 
 	targetResolver := manual.NewBuilderWithScheme("dns")
 	target := targetResolver.Scheme() + ":///" + targetTestAddr
@@ -315,17 +309,7 @@ func (s) TestDelegatingResolverwithCustomResolverAndProxy(t *testing.T) {
 		envProxyAddr            = "proxytest.com"
 		resolvedProxyTestAddr1  = "11.11.11.11:7687"
 	)
-	hpfe := func(req *http.Request) (*url.URL, error) {
-		return &url.URL{
-			Scheme: "https",
-			Host:   envProxyAddr,
-		}, nil
-	}
-	originalhpfe := delegatingresolver.HTTPSProxyFromEnvironment
-	delegatingresolver.HTTPSProxyFromEnvironment = hpfe
-	defer func() {
-		delegatingresolver.HTTPSProxyFromEnvironment = originalhpfe
-	}()
+	overrideTestHTTPSProxy(t, envProxyAddr)
 
 	// Manual resolver to control the target resolution.
 	targetResolver := manual.NewBuilderWithScheme("test")
@@ -398,17 +382,7 @@ func (s) TestDelegatingResolverForEndpointsWithProxy(t *testing.T) {
 		resolvedProxyTestAddr1  = "11.11.11.11:7687"
 		resolvedProxyTestAddr2  = "22.22.22.22:7687"
 	)
-	hpfe := func(req *http.Request) (*url.URL, error) {
-		return &url.URL{
-			Scheme: "https",
-			Host:   envProxyAddr,
-		}, nil
-	}
-	originalhpfe := delegatingresolver.HTTPSProxyFromEnvironment
-	delegatingresolver.HTTPSProxyFromEnvironment = hpfe
-	defer func() {
-		delegatingresolver.HTTPSProxyFromEnvironment = originalhpfe
-	}()
+	overrideTestHTTPSProxy(t, envProxyAddr)
 
 	// Manual resolver to control the target resolution.
 	targetResolver := manual.NewBuilderWithScheme("test")
@@ -501,17 +475,7 @@ func (s) TestDelegatingResolverForMultipleProxyAddress(t *testing.T) {
 		resolvedProxyTestAddr1  = "11.11.11.11:7687"
 		resolvedProxyTestAddr2  = "22.22.22.22:7687"
 	)
-	hpfe := func(req *http.Request) (*url.URL, error) {
-		return &url.URL{
-			Scheme: "https",
-			Host:   envProxyAddr,
-		}, nil
-	}
-	originalhpfe := delegatingresolver.HTTPSProxyFromEnvironment
-	delegatingresolver.HTTPSProxyFromEnvironment = hpfe
-	defer func() {
-		delegatingresolver.HTTPSProxyFromEnvironment = originalhpfe
-	}()
+	overrideTestHTTPSProxy(t, envProxyAddr)
 
 	// Manual resolver to control the target resolution.
 	targetResolver := manual.NewBuilderWithScheme("test")
@@ -578,17 +542,7 @@ func (s) TestDelegatingResolverForMultipleProxyAddress(t *testing.T) {
 func (s) TestDelegatingResolverUpdateStateDuringClose(t *testing.T) {
 	const envProxyAddr = "proxytest.com"
 
-	hpfe := func(req *http.Request) (*url.URL, error) {
-		return &url.URL{
-			Scheme: "https",
-			Host:   envProxyAddr,
-		}, nil
-	}
-	originalhpfe := delegatingresolver.HTTPSProxyFromEnvironment
-	delegatingresolver.HTTPSProxyFromEnvironment = hpfe
-	defer func() {
-		delegatingresolver.HTTPSProxyFromEnvironment = originalhpfe
-	}()
+	overrideTestHTTPSProxy(t, envProxyAddr)
 
 	// Manual resolver to control the target resolution.
 	targetResolver := manual.NewBuilderWithScheme("test")
@@ -675,17 +629,7 @@ func (s) TestDelegatingResolverUpdateStateDuringClose(t *testing.T) {
 func (s) TestDelegatingResolverUpdateStateFromResolveNow(t *testing.T) {
 	const envProxyAddr = "proxytest.com"
 
-	hpfe := func(req *http.Request) (*url.URL, error) {
-		return &url.URL{
-			Scheme: "https",
-			Host:   envProxyAddr,
-		}, nil
-	}
-	originalhpfe := delegatingresolver.HTTPSProxyFromEnvironment
-	delegatingresolver.HTTPSProxyFromEnvironment = hpfe
-	defer func() {
-		delegatingresolver.HTTPSProxyFromEnvironment = originalhpfe
-	}()
+	overrideTestHTTPSProxy(t, envProxyAddr)
 
 	// Manual resolver to control the target resolution.
 	targetResolver := manual.NewBuilderWithScheme("test")
@@ -739,17 +683,7 @@ func (s) TestDelegatingResolverUpdateStateFromResolveNow(t *testing.T) {
 func (s) TestDelegatingResolverResolveNow(t *testing.T) {
 	const envProxyAddr = "proxytest.com"
 
-	hpfe := func(req *http.Request) (*url.URL, error) {
-		return &url.URL{
-			Scheme: "https",
-			Host:   envProxyAddr,
-		}, nil
-	}
-	originalhpfe := delegatingresolver.HTTPSProxyFromEnvironment
-	delegatingresolver.HTTPSProxyFromEnvironment = hpfe
-	defer func() {
-		delegatingresolver.HTTPSProxyFromEnvironment = originalhpfe
-	}()
+	overrideTestHTTPSProxy(t, envProxyAddr)
 
 	// Manual resolver to control the target resolution.
 	targetResolver := manual.NewBuilderWithScheme("test")
@@ -820,17 +754,7 @@ func (s) TestDelegatingResolverForNonTCPTarget(t *testing.T) {
 		resolvedTargetTestAddr1 = "1.1.1.1:8080"
 		envProxyAddr            = "proxytest.com"
 	)
-	hpfe := func(req *http.Request) (*url.URL, error) {
-		return &url.URL{
-			Scheme: "https",
-			Host:   envProxyAddr,
-		}, nil
-	}
-	originalhpfe := delegatingresolver.HTTPSProxyFromEnvironment
-	delegatingresolver.HTTPSProxyFromEnvironment = hpfe
-	defer func() {
-		delegatingresolver.HTTPSProxyFromEnvironment = originalhpfe
-	}()
+	overrideTestHTTPSProxy(t, envProxyAddr)
 
 	// Manual resolver to control the target resolution.
 	targetResolver := manual.NewBuilderWithScheme("test")
@@ -882,7 +806,7 @@ func (s) TestDelegatingResolverForNonTCPTarget(t *testing.T) {
 
 // Tests the scenario where a proxy is configured, and the resolver returns tcp
 // and non-tcp addresses. The test verifies that the delegating resolver doesn't
-// add proxyatrribute to adresses with network type other than tcp , but adds
+// add proxyatrribute to adresses with network type other than tcp, but adds
 // the proxyattribute to addresses with network type tcp.
 func (s) TestDelegatingResolverForMixNetworkType(t *testing.T) {
 	const (
@@ -891,17 +815,7 @@ func (s) TestDelegatingResolverForMixNetworkType(t *testing.T) {
 		resolvedTargetTestAddr2 = "2.2.2.2:8080"
 		envProxyAddr            = "proxytest.com"
 	)
-	hpfe := func(req *http.Request) (*url.URL, error) {
-		return &url.URL{
-			Scheme: "https",
-			Host:   envProxyAddr,
-		}, nil
-	}
-	originalhpfe := delegatingresolver.HTTPSProxyFromEnvironment
-	delegatingresolver.HTTPSProxyFromEnvironment = hpfe
-	defer func() {
-		delegatingresolver.HTTPSProxyFromEnvironment = originalhpfe
-	}()
+	overrideTestHTTPSProxy(t, envProxyAddr)
 
 	// Manual resolver to control the target resolution.
 	targetResolver := manual.NewBuilderWithScheme("test")
@@ -956,7 +870,7 @@ func (s) TestDelegatingResolverForMixNetworkType(t *testing.T) {
 
 // Tests the scenario where a proxy is configured but some addresses are
 // excluded (by using the NO_PROXY environment variable). The test verifies that
-// the delegating resolver doesn't add proxyatrribute to adresses excluded , but
+// the delegating resolver doesn't add proxyatrribute to adresses excluded, but
 // adds the proxyattribute to all other addresses.
 func (s) TestDelegatingResolverWithNoProxyEnvUsed(t *testing.T) {
 	const (

--- a/internal/resolver/delegatingresolver/delegatingresolver_ext_test.go
+++ b/internal/resolver/delegatingresolver/delegatingresolver_ext_test.go
@@ -947,10 +947,10 @@ func (s) TestDelegatingResolverForMixNetworkType(t *testing.T) {
 // adds the proxyattribute to all other addresses.
 func (s) TestDelegatingResolverWithNoProxyEnvUsed(t *testing.T) {
 	const (
-		targetTestAddr                 = "test.target"
+		targetTestAddr             = "test.target"
 		noproxyresolvedTargetAddr1 = "1.1.1.1:8080"
-		resolvedTargetTestAddr2        = "2.2.2.2:8080"
-		envProxyAddr                   = "proxytest.com"
+		resolvedTargetTestAddr2    = "2.2.2.2:8080"
+		envProxyAddr               = "proxytest.com"
 	)
 	hpfe := func(req *http.Request) (*url.URL, error) {
 		// return nil to mimick the scenario where the address is excluded using

--- a/internal/resolver/delegatingresolver/delegatingresolver_ext_test.go
+++ b/internal/resolver/delegatingresolver/delegatingresolver_ext_test.go
@@ -163,14 +163,10 @@ func (s) TestDelegatingResolverwithDNSAndProxyWithTargetResolution(t *testing.T)
 		resolvedProxyTestAddr1  = "11.11.11.11:7687"
 	)
 	hpfe := func(req *http.Request) (*url.URL, error) {
-		if req.URL.Host == targetTestAddr {
-			return &url.URL{
-				Scheme: "https",
-				Host:   envProxyAddr,
-			}, nil
-		}
-		t.Errorf("Unexpected request host to proxy: %s want %s", req.URL.Host, targetTestAddr)
-		return nil, nil
+		return &url.URL{
+			Scheme: "https",
+			Host:   envProxyAddr,
+		}, nil
 	}
 	originalhpfe := delegatingresolver.HTTPSProxyFromEnvironment
 	delegatingresolver.HTTPSProxyFromEnvironment = hpfe
@@ -239,14 +235,10 @@ func (s) TestDelegatingResolverwithDNSAndProxyWithNoTargetResolution(t *testing.
 		resolvedProxyTestAddr1 = "11.11.11.11:7687"
 	)
 	hpfe := func(req *http.Request) (*url.URL, error) {
-		if req.URL.Host == targetTestAddr {
-			return &url.URL{
-				Scheme: "https",
-				Host:   envProxyAddr,
-			}, nil
-		}
-		t.Errorf("Unexpected request host to proxy: %s want %s", req.URL.Host, targetTestAddr)
-		return nil, nil
+		return &url.URL{
+			Scheme: "https",
+			Host:   envProxyAddr,
+		}, nil
 	}
 	originalhpfe := delegatingresolver.HTTPSProxyFromEnvironment
 	delegatingresolver.HTTPSProxyFromEnvironment = hpfe
@@ -300,14 +292,10 @@ func (s) TestDelegatingResolverwithCustomResolverAndProxy(t *testing.T) {
 		resolvedProxyTestAddr1  = "11.11.11.11:7687"
 	)
 	hpfe := func(req *http.Request) (*url.URL, error) {
-		if req.URL.Host == targetTestAddr {
-			return &url.URL{
-				Scheme: "https",
-				Host:   envProxyAddr,
-			}, nil
-		}
-		t.Errorf("Unexpected request host to proxy: %s want %s", req.URL.Host, targetTestAddr)
-		return nil, nil
+		return &url.URL{
+			Scheme: "https",
+			Host:   envProxyAddr,
+		}, nil
 	}
 	originalhpfe := delegatingresolver.HTTPSProxyFromEnvironment
 	delegatingresolver.HTTPSProxyFromEnvironment = hpfe
@@ -382,14 +370,10 @@ func (s) TestDelegatingResolverForEndpointsWithProxy(t *testing.T) {
 		resolvedProxyTestAddr2  = "22.22.22.22:7687"
 	)
 	hpfe := func(req *http.Request) (*url.URL, error) {
-		if req.URL.Host == targetTestAddr {
-			return &url.URL{
-				Scheme: "https",
-				Host:   envProxyAddr,
-			}, nil
-		}
-		t.Errorf("Unexpected request host to proxy: %s want %s", req.URL.Host, targetTestAddr)
-		return nil, nil
+		return &url.URL{
+			Scheme: "https",
+			Host:   envProxyAddr,
+		}, nil
 	}
 	originalhpfe := delegatingresolver.HTTPSProxyFromEnvironment
 	delegatingresolver.HTTPSProxyFromEnvironment = hpfe
@@ -484,14 +468,10 @@ func (s) TestDelegatingResolverForMultipleProxyAddress(t *testing.T) {
 		resolvedProxyTestAddr2  = "22.22.22.22:7687"
 	)
 	hpfe := func(req *http.Request) (*url.URL, error) {
-		if req.URL.Host == targetTestAddr {
-			return &url.URL{
-				Scheme: "https",
-				Host:   envProxyAddr,
-			}, nil
-		}
-		t.Errorf("Unexpected request host to proxy: %s want %s", req.URL.Host, targetTestAddr)
-		return nil, nil
+		return &url.URL{
+			Scheme: "https",
+			Host:   envProxyAddr,
+		}, nil
 	}
 	originalhpfe := delegatingresolver.HTTPSProxyFromEnvironment
 	delegatingresolver.HTTPSProxyFromEnvironment = hpfe
@@ -802,14 +782,10 @@ func (s) TestDelegatingResolverForNonTCPTarget(t *testing.T) {
 		envProxyAddr            = "proxytest.com"
 	)
 	hpfe := func(req *http.Request) (*url.URL, error) {
-		if req.URL.Host == targetTestAddr {
-			return &url.URL{
-				Scheme: "https",
-				Host:   envProxyAddr,
-			}, nil
-		}
-		t.Errorf("Unexpected request host to proxy: %s want %s", req.URL.Host, targetTestAddr)
-		return nil, nil
+		return &url.URL{
+			Scheme: "https",
+			Host:   envProxyAddr,
+		}, nil
 	}
 	originalhpfe := delegatingresolver.HTTPSProxyFromEnvironment
 	delegatingresolver.HTTPSProxyFromEnvironment = hpfe
@@ -881,14 +857,10 @@ func (s) TestDelegatingResolverForMixNetworkType(t *testing.T) {
 		envProxyAddr            = "proxytest.com"
 	)
 	hpfe := func(req *http.Request) (*url.URL, error) {
-		if req.URL.Host == targetTestAddr {
-			return &url.URL{
-				Scheme: "https",
-				Host:   envProxyAddr,
-			}, nil
-		}
-		t.Errorf("Unexpected request host to proxy: %s want %s", req.URL.Host, targetTestAddr)
-		return nil, nil
+		return &url.URL{
+			Scheme: "https",
+			Host:   envProxyAddr,
+		}, nil
 	}
 	originalhpfe := delegatingresolver.HTTPSProxyFromEnvironment
 	delegatingresolver.HTTPSProxyFromEnvironment = hpfe
@@ -934,6 +906,79 @@ func (s) TestDelegatingResolverForMixNetworkType(t *testing.T) {
 	wantState := resolver.State{
 		Addresses:     []resolver.Address{nonTCPAddr, proxyAddressWithTargetAttribute(envProxyAddr, resolvedTargetTestAddr2)},
 		Endpoints:     []resolver.Endpoint{{Addresses: []resolver.Address{nonTCPAddr, proxyAddressWithTargetAttribute(envProxyAddr, resolvedTargetTestAddr2)}}},
+		ServiceConfig: &serviceconfig.ParseResult{},
+	}
+
+	if diff := cmp.Diff(gotState, wantState); diff != "" {
+		t.Fatalf("Unexpected state from delegating resolver. Diff (-got +want):\n%v", diff)
+	}
+}
+
+// Tests the scenario where a proxy is configured but some addresses are
+// excluded (by using the NO_PROXY environment variable). The test verifies that
+// the delegating resolver doesn't add proxyatrribute to adresses excluded , but
+// adds the proxyattribute to all other addresses.
+func (s) TestDelegatingResolverWithNoProxyEnvUsed(t *testing.T) {
+	const (
+		targetTestAddr                 = "test.target"
+		noproxyresolvedTargetTestAddr1 = "1.1.1.1:8080"
+		resolvedTargetTestAddr2        = "2.2.2.2:8080"
+		envProxyAddr                   = "proxytest.com"
+	)
+	hpfe := func(req *http.Request) (*url.URL, error) {
+		// return nil to mimick the scenario where the address is excluded using
+		// `NO_PROXY` env variable.
+		if req.URL.Host == noproxyresolvedTargetTestAddr1 {
+			return nil, nil
+		}
+		return &url.URL{
+			Scheme: "https",
+			Host:   envProxyAddr,
+		}, nil
+	}
+	originalhpfe := delegatingresolver.HTTPSProxyFromEnvironment
+	delegatingresolver.HTTPSProxyFromEnvironment = hpfe
+	defer func() {
+		delegatingresolver.HTTPSProxyFromEnvironment = originalhpfe
+	}()
+
+	// Manual resolver to control the target resolution.
+	targetResolver := manual.NewBuilderWithScheme("test")
+	target := targetResolver.Scheme() + ":///" + targetTestAddr
+	// Set up a manual DNS resolver to control the proxy address resolution.
+	proxyResolver := setupDNS(t)
+
+	tcc, stateCh, _ := createTestResolverClientConn(t)
+	if _, err := delegatingresolver.New(resolver.Target{URL: *testutils.MustParseURL(target)}, tcc, resolver.BuildOptions{}, targetResolver, false); err != nil {
+		t.Fatalf("Failed to create delegating resolver: %v", err)
+	}
+
+	targetResolver.UpdateState(resolver.State{
+		Addresses:     []resolver.Address{{Addr: noproxyresolvedTargetTestAddr1}, {Addr: resolvedTargetTestAddr2}},
+		Endpoints:     []resolver.Endpoint{{Addresses: []resolver.Address{{Addr: noproxyresolvedTargetTestAddr1}, {Addr: resolvedTargetTestAddr2}}}},
+		ServiceConfig: &serviceconfig.ParseResult{},
+	})
+
+	select {
+	case <-stateCh:
+		t.Fatalf("Delegating resolver invoked UpdateState before both the proxy and target resolvers had updated their states.")
+	case <-time.After(defaultTestShortTimeout):
+	}
+
+	proxyResolver.UpdateState(resolver.State{
+		Addresses:     []resolver.Address{{Addr: envProxyAddr}},
+		ServiceConfig: &serviceconfig.ParseResult{},
+	})
+
+	var gotState resolver.State
+	select {
+	case gotState = <-stateCh:
+	case <-time.After(defaultTestTimeout):
+		t.Fatal("Timeout when waiting for a state update from the delegating resolver")
+	}
+	wantState := resolver.State{
+		Addresses:     []resolver.Address{{Addr: noproxyresolvedTargetTestAddr1}, proxyAddressWithTargetAttribute(envProxyAddr, resolvedTargetTestAddr2)},
+		Endpoints:     []resolver.Endpoint{{Addresses: []resolver.Address{{Addr: noproxyresolvedTargetTestAddr1}, proxyAddressWithTargetAttribute(envProxyAddr, resolvedTargetTestAddr2)}}},
 		ServiceConfig: &serviceconfig.ParseResult{},
 	}
 

--- a/internal/resolver/delegatingresolver/delegatingresolver_ext_test.go
+++ b/internal/resolver/delegatingresolver/delegatingresolver_ext_test.go
@@ -960,15 +960,15 @@ func (s) TestDelegatingResolverForMixNetworkType(t *testing.T) {
 // adds the proxyattribute to all other addresses.
 func (s) TestDelegatingResolverWithNoProxyEnvUsed(t *testing.T) {
 	const (
-		targetTestAddr             = "test.target"
-		noproxyresolvedTargetAddr1 = "1.1.1.1:8080"
-		resolvedTargetTestAddr2    = "2.2.2.2:8080"
-		envProxyAddr               = "proxytest.com"
+		targetTestAddr            = "test.target"
+		noproxyresolvedTargetAddr = "1.1.1.1:8080"
+		resolvedTargetTestAddr    = "2.2.2.2:8080"
+		envProxyAddr              = "proxytest.com"
 	)
 	hpfe := func(req *http.Request) (*url.URL, error) {
 		// return nil to mimick the scenario where the address is excluded using
 		// `NO_PROXY` env variable.
-		if req.URL.Host == noproxyresolvedTargetAddr1 {
+		if req.URL.Host == noproxyresolvedTargetAddr {
 			return nil, nil
 		}
 		return &url.URL{
@@ -994,8 +994,8 @@ func (s) TestDelegatingResolverWithNoProxyEnvUsed(t *testing.T) {
 	}
 
 	targetResolver.UpdateState(resolver.State{
-		Addresses:     []resolver.Address{{Addr: noproxyresolvedTargetAddr1}, {Addr: resolvedTargetTestAddr2}},
-		Endpoints:     []resolver.Endpoint{{Addresses: []resolver.Address{{Addr: noproxyresolvedTargetAddr1}, {Addr: resolvedTargetTestAddr2}}}},
+		Addresses:     []resolver.Address{{Addr: noproxyresolvedTargetAddr}, {Addr: resolvedTargetTestAddr}},
+		Endpoints:     []resolver.Endpoint{{Addresses: []resolver.Address{{Addr: noproxyresolvedTargetAddr}, {Addr: resolvedTargetTestAddr}}}},
 		ServiceConfig: &serviceconfig.ParseResult{},
 	})
 
@@ -1022,8 +1022,8 @@ func (s) TestDelegatingResolverWithNoProxyEnvUsed(t *testing.T) {
 		t.Fatal("Context timed out when waiting for a state update from the delegating resolver")
 	}
 	wantState := resolver.State{
-		Addresses:     []resolver.Address{{Addr: noproxyresolvedTargetAddr1}, proxyAddressWithTargetAttribute(envProxyAddr, resolvedTargetTestAddr2)},
-		Endpoints:     []resolver.Endpoint{{Addresses: []resolver.Address{{Addr: noproxyresolvedTargetAddr1}, proxyAddressWithTargetAttribute(envProxyAddr, resolvedTargetTestAddr2)}}},
+		Addresses:     []resolver.Address{{Addr: noproxyresolvedTargetAddr}, proxyAddressWithTargetAttribute(envProxyAddr, resolvedTargetTestAddr)},
+		Endpoints:     []resolver.Endpoint{{Addresses: []resolver.Address{{Addr: noproxyresolvedTargetAddr}, proxyAddressWithTargetAttribute(envProxyAddr, resolvedTargetTestAddr)}}},
 		ServiceConfig: &serviceconfig.ParseResult{},
 	}
 

--- a/internal/transport/proxy_ext_test.go
+++ b/internal/transport/proxy_ext_test.go
@@ -97,14 +97,10 @@ func (s) TestGRPCDialWithProxy(t *testing.T) {
 
 	// Overwrite the function in the test and restore them in defer.
 	hpfe := func(req *http.Request) (*url.URL, error) {
-		if req.URL.Host == unresolvedTargetURI {
-			return &url.URL{
-				Scheme: "https",
-				Host:   pAddr,
-			}, nil
-		}
-		t.Errorf("Unexpected request host to proxy: %s want %s", req.URL.Host, unresolvedTargetURI)
-		return nil, nil
+		return &url.URL{
+			Scheme: "https",
+			Host:   pAddr,
+		}, nil
 	}
 	orighpfe := delegatingresolver.HTTPSProxyFromEnvironment
 	delegatingresolver.HTTPSProxyFromEnvironment = hpfe
@@ -154,14 +150,10 @@ func (s) TestGRPCDialWithDNSAndProxy(t *testing.T) {
 
 	// Overwrite the function in the test and restore them in defer.
 	hpfe := func(req *http.Request) (*url.URL, error) {
-		if req.URL.Host == unresolvedTargetURI {
-			return &url.URL{
-				Scheme: "https",
-				Host:   pServer.Addr,
-			}, nil
-		}
-		t.Errorf("Unexpected request host to proxy: %s want %s", req.URL.Host, unresolvedTargetURI)
-		return nil, nil
+		return &url.URL{
+			Scheme: "https",
+			Host:   pServer.Addr,
+		}, nil
 	}
 	orighpfe := delegatingresolver.HTTPSProxyFromEnvironment
 	delegatingresolver.HTTPSProxyFromEnvironment = hpfe
@@ -213,14 +205,10 @@ func (s) TestNewClientWithProxy(t *testing.T) {
 
 	// Overwrite the function in the test and restore them in defer.
 	hpfe := func(req *http.Request) (*url.URL, error) {
-		if req.URL.Host == unresolvedTargetURI {
-			return &url.URL{
-				Scheme: "https",
-				Host:   pAddr,
-			}, nil
-		}
-		t.Errorf("Unexpected request host to proxy: %s want %s", req.URL.Host, unresolvedTargetURI)
-		return nil, nil
+		return &url.URL{
+			Scheme: "https",
+			Host:   pAddr,
+		}, nil
 	}
 	orighpfe := delegatingresolver.HTTPSProxyFromEnvironment
 	delegatingresolver.HTTPSProxyFromEnvironment = hpfe
@@ -267,14 +255,10 @@ func (s) TestNewClientWithProxyAndCustomResolver(t *testing.T) {
 
 	// Overwrite the function in the test and restore them in defer.
 	hpfe := func(req *http.Request) (*url.URL, error) {
-		if req.URL.Host == unresolvedTargetURI {
-			return &url.URL{
-				Scheme: "https",
-				Host:   pServer.Addr,
-			}, nil
-		}
-		t.Errorf("Unexpected request host to proxy: %s want %s", req.URL.Host, unresolvedTargetURI)
-		return nil, nil
+		return &url.URL{
+			Scheme: "https",
+			Host:   pServer.Addr,
+		}, nil
 	}
 	orighpfe := delegatingresolver.HTTPSProxyFromEnvironment
 	delegatingresolver.HTTPSProxyFromEnvironment = hpfe
@@ -329,14 +313,10 @@ func (s) TestNewClientWithProxyAndTargetResolutionEnabled(t *testing.T) {
 
 	// Overwrite the function in the test and restore them in defer.
 	hpfe := func(req *http.Request) (*url.URL, error) {
-		if req.URL.Host == unresolvedTargetURI {
-			return &url.URL{
-				Scheme: "https",
-				Host:   pServer.Addr,
-			}, nil
-		}
-		t.Errorf("Unexpected request host to proxy: %s want %s", req.URL.Host, unresolvedTargetURI)
-		return nil, nil
+		return &url.URL{
+			Scheme: "https",
+			Host:   pServer.Addr,
+		}, nil
 	}
 	orighpfe := delegatingresolver.HTTPSProxyFromEnvironment
 	delegatingresolver.HTTPSProxyFromEnvironment = hpfe
@@ -374,14 +354,10 @@ func (s) TestNewClientWithNoProxy(t *testing.T) {
 
 	// Overwrite the function in the test and restore them in defer.
 	hpfe := func(req *http.Request) (*url.URL, error) {
-		if req.URL.Host == unresolvedTargetURI {
-			return &url.URL{
-				Scheme: "https",
-				Host:   pServer.Addr,
-			}, nil
-		}
-		t.Errorf("Unexpected request host to proxy: %s want %s", req.URL.Host, unresolvedTargetURI)
-		return nil, nil
+		return &url.URL{
+			Scheme: "https",
+			Host:   pServer.Addr,
+		}, nil
 	}
 	orighpfe := delegatingresolver.HTTPSProxyFromEnvironment
 	delegatingresolver.HTTPSProxyFromEnvironment = hpfe
@@ -419,14 +395,10 @@ func (s) TestNewClientWithContextDialer(t *testing.T) {
 
 	// Overwrite the function in the test and restore them in defer.
 	hpfe := func(req *http.Request) (*url.URL, error) {
-		if req.URL.Host == unresolvedTargetURI {
-			return &url.URL{
-				Scheme: "https",
-				Host:   pServer.Addr,
-			}, nil
-		}
-		t.Errorf("Unexpected request host to proxy: %s want %s", req.URL.Host, unresolvedTargetURI)
-		return nil, nil
+		return &url.URL{
+			Scheme: "https",
+			Host:   pServer.Addr,
+		}, nil
 	}
 	orighpfe := delegatingresolver.HTTPSProxyFromEnvironment
 	delegatingresolver.HTTPSProxyFromEnvironment = hpfe


### PR DESCRIPTION
Fixes: #8327

Add a check for resolved addresses to avoid proxy for addresses mentioned in NO_PROXY environment variable. We only had a check for unresolved addresses.

RELEASE NOTES: 
- client: fixed a bug that was attempting to use a proxy for addresses matching NO_PROXY environment variable