### PR TITLE
balancer/least_request : Fix panic while handling resolver errors

### DIFF
--- a/balancer/leastrequest/leastrequest.go
+++ b/balancer/leastrequest/leastrequest.go
@@ -97,11 +97,8 @@ func (bb) Build(cc balancer.ClientConn, bOpts balancer.BuildOptions) balancer.Ba
 }
 
 type leastRequestBalancer struct {
-	// Embeds balancer.Balancer because needs to intercept UpdateClientConnState
-	// to learn about choiceCount.
-	balancer.Balancer
-	// Embeds balancer.ClientConn because needs to intercept UpdateState calls
-	// from the child balancer.
+	// Embeds balancer.ClientConn because we need to intercept UpdateState
+	// calls from the child balancer.
 	balancer.ClientConn
 	child  balancer.Balancer
 	logger *internalgrpclog.PrefixLogger
@@ -116,6 +113,15 @@ type leastRequestBalancer struct {
 func (lrb *leastRequestBalancer) Close() {
 	lrb.child.Close()
 	lrb.endpointRPCCounts = nil
+}
+
+func (lrb *leastRequestBalancer) UpdateSubConnState(sc balancer.SubConn, state balancer.SubConnState) {
+	lrb.logger.Errorf("UpdateSubConnState(%v, %+v) called unexpectedly", sc, state)
+}
+
+func (lrb *leastRequestBalancer) ResolverError(err error) {
+	// Will cause inline picker update from endpoint sharding.
+	lrb.child.ResolverError(err)
 }
 
 func (lrb *leastRequestBalancer) UpdateClientConnState(ccs balancer.ClientConnState) error {

--- a/balancer/leastrequest/leastrequest.go
+++ b/balancer/leastrequest/leastrequest.go
@@ -124,6 +124,12 @@ func (lrb *leastRequestBalancer) ResolverError(err error) {
 	lrb.child.ResolverError(err)
 }
 
+func (lrb *leastRequestBalancer) ExitIdle() {
+	if ei, ok := lrb.child.(balancer.ExitIdler); ok { // Should always be ok, as child is endpoint sharding.
+		ei.ExitIdle()
+	}
+}
+
 func (lrb *leastRequestBalancer) UpdateClientConnState(ccs balancer.ClientConnState) error {
 	lrCfg, ok := ccs.BalancerConfig.(*LBConfig)
 	if !ok {

--- a/balancer/leastrequest/leastrequest_test.go
+++ b/balancer/leastrequest/leastrequest_test.go
@@ -27,13 +27,13 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"google.golang.org/grpc/status"
-
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/internal"
 	"google.golang.org/grpc/internal/grpctest"
 	"google.golang.org/grpc/internal/stubserver"
+	"google.golang.org/grpc/internal/testutils"
 	testgrpc "google.golang.org/grpc/interop/grpc_testing"
 	testpb "google.golang.org/grpc/interop/grpc_testing"
 	"google.golang.org/grpc/peer"
@@ -43,7 +43,8 @@ import (
 )
 
 const (
-	defaultTestTimeout = 5 * time.Second
+	defaultTestTimeout      = 5 * time.Second
+	defaultTestShortTimeout = 10 * time.Millisecond
 )
 
 type s struct {
@@ -708,30 +709,62 @@ func (s) TestLeastRequestEndpoints_MultipleAddresses(t *testing.T) {
 	}
 }
 
+// Test tests that the least request balancer properly surfaces resolver
+// errors.
 func (s) TestLeastRequestEndpoints_ResolverError(t *testing.T) {
+	const sc = `{"loadBalancingConfig": [{"least_request_experimental": {}}]}`
 	mr := manual.NewBuilderWithScheme("lr-e2e")
 	defer mr.Close()
 
-	cc, err := grpc.NewClient(mr.Scheme()+":///", grpc.WithResolvers(mr), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	cc, err := grpc.NewClient(
+		mr.Scheme()+":///",
+		grpc.WithResolvers(mr),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithDefaultServiceConfig(sc),
+	)
 	if err != nil {
 		t.Fatalf("grpc.NewClient() failed: %v", err)
 	}
 	defer cc.Close()
 
+	// We need to pass an endpoint with a valid address to the resolver before
+	// reporting an error - otherwise endpointsharding does not report the
+	// error through.
+	lis, err := testutils.LocalTCPListener()
+	if err != nil {
+		t.Fatalf("net.Listen() failed: %v", err)
+	}
+	// Act like a server that closes the connection without sending a server
+	// preface.
+	go func() {
+		conn, err := lis.Accept()
+		if err != nil {
+			t.Errorf("Unexpected error when accepting a connection: %v", err)
+		}
+		conn.Close()
+	}()
+	mr.UpdateState(resolver.State{
+		Endpoints: []resolver.Endpoint{{Addresses: []resolver.Address{{Addr: lis.Addr().String()}}}},
+	})
 	cc.Connect()
-	resolverErr := fmt.Errorf("simulated resolver error")
-	mr.CC().ReportError(resolverErr)
 
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
+	testutils.AwaitState(ctx, t, cc, connectivity.TransientFailure)
 
-	// Ensure the client handles the resolver error gracefully.
+	// Report an error through the resolver
+	resolverErr := fmt.Errorf("simulated resolver error")
+	mr.CC().ReportError(resolverErr)
+
+	// Ensure the client returns the expected resolver error.
 	testServiceClient := testgrpc.NewTestServiceClient(cc)
-	_, err = testServiceClient.EmptyCall(ctx, &testpb.Empty{})
-	if err == nil {
-		t.Fatal("Got successful call, want error")
+	for ; ctx.Err() == nil; <-time.After(defaultTestShortTimeout) {
+		_, err = testServiceClient.EmptyCall(ctx, &testpb.Empty{})
+		if strings.Contains(err.Error(), resolverErr.Error()) {
+			break
+		}
 	}
-	if st, _ := status.FromError(err); st.Message() != resolverErr.Error() {
-		t.Fatalf("Got error %v, want: %v", st.Message(), resolverErr)
+	if ctx.Err() != nil {
+		t.Fatalf("Timeout when waiting for RPCs to fail with error containing %s. Last error: %v", resolverErr, err)
 	}
 }


### PR DESCRIPTION
There was a leftover embedded balancer in least request that was never set in the code when it got refactored to pick first as leaf. As a result, method calls forwarded to the embedded balancer would panic.

Remove the embedded balance and properly forward the missing methods.

Fixes https://github.com/grpc/grpc-go/issues/8332

RELEASE NOTES:
- balancer/least_request: fix panic on resolver errors when using least_request.