### PR TITLE
endpointsharding: Implement ExitIdler

### DIFF
--- a/balancer/endpointsharding/endpointsharding.go
+++ b/balancer/endpointsharding/endpointsharding.go
@@ -205,6 +205,17 @@ func (es *endpointSharding) Close() {
 	}
 }
 
+func (es *endpointSharding) ExitIdle() {
+	es.childMu.Lock()
+	defer es.childMu.Unlock()
+	for _, bw := range es.children.Load().Values() {
+		ei, ok := bw.child.(balancer.ExitIdler)
+		if ok && !bw.isClosed {
+			ei.ExitIdle()
+		}
+	}
+}
+
 // updateState updates this component's state. It sends the aggregated state,
 // and a picker with round robin behavior with all the child states present if
 // needed.

--- a/balancer/endpointsharding/endpointsharding_test.go
+++ b/balancer/endpointsharding/endpointsharding_test.go
@@ -285,3 +285,69 @@ func (s) TestEndpointShardingReconnectDisabled(t *testing.T) {
 		}
 	}
 }
+
+// Tests that endpointsharding doesn't automatically re-connect IDLE children
+// until cc.Connect() is called. The test creates an endpoint with a single
+// address. The client is connected and the active server is closed to make the
+// child pickfirst enter IDLE state. The test verifies that the child pickfirst
+// doesn't re-connect automatically. The test calls cc.Connect() and verified
+// that the balancer connects causing the channel to enter TransientFailure.
+func (s) TestEndpointShardingExitIdle(t *testing.T) {
+	backend := stubserver.StartTestService(t, nil)
+	defer backend.Stop()
+
+	mr := manual.NewBuilderWithScheme("e2e-test")
+	defer mr.Close()
+
+	name := strings.ReplaceAll(strings.ToLower(t.Name()), "/", "")
+	bf := stub.BalancerFuncs{
+		Init: func(bd *stub.BalancerData) {
+			epOpts := endpointsharding.Options{DisableAutoReconnect: true}
+			bd.Data = endpointsharding.NewBalancer(bd.ClientConn, bd.BuildOptions, balancer.Get(pickfirstleaf.Name).Build, epOpts)
+		},
+		UpdateClientConnState: func(bd *stub.BalancerData, ccs balancer.ClientConnState) error {
+			return bd.Data.(balancer.Balancer).UpdateClientConnState(ccs)
+		},
+		Close: func(bd *stub.BalancerData) {
+			bd.Data.(balancer.Balancer).Close()
+		},
+		ExitIdle: func(bd *stub.BalancerData) {
+			bd.Data.(balancer.ExitIdler).ExitIdle()
+		},
+	}
+	stub.Register(name, bf)
+
+	json := fmt.Sprintf(`{"loadBalancingConfig": [{"%s":{}}]}`, name)
+	sc := internal.ParseServiceConfig.(func(string) *serviceconfig.ParseResult)(json)
+	mr.InitialState(resolver.State{
+		Endpoints: []resolver.Endpoint{
+			{Addresses: []resolver.Address{{Addr: backend.Address}}},
+		},
+		ServiceConfig: sc,
+	})
+
+	cc, err := grpc.NewClient(mr.Scheme()+":///", grpc.WithResolvers(mr), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("Failed to create new client: %v", err)
+	}
+	defer cc.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	client := testgrpc.NewTestServiceClient(cc)
+	if _, err := client.EmptyCall(ctx, &testpb.Empty{}); err != nil {
+		t.Errorf("client.EmptyCall() returned unexpected error: %v", err)
+	}
+
+	// On closing the first server, the first child balancer should enter
+	// IDLE. Since endpointsharding is configured not to auto-reconnect, it will
+	// remain IDLE and will not try to re-connect
+	backend.Stop()
+	testutils.AwaitState(ctx, t, cc, connectivity.Idle)
+	shortCtx, shortCancel := context.WithTimeout(ctx, defaultTestShortTimeout)
+	defer shortCancel()
+	testutils.AwaitNoStateChange(shortCtx, t, cc, connectivity.Idle)
+
+	// The balancer should try to re-connect and fail.
+	cc.Connect()
+	testutils.AwaitState(ctx, t, cc, connectivity.TransientFailure)
+}

--- a/balancer/endpointsharding/endpointsharding_test.go
+++ b/balancer/endpointsharding/endpointsharding_test.go
@@ -102,6 +102,10 @@ type fakePetiole struct {
 	bOpts balancer.BuildOptions
 }
 
+func (fp *fakePetiole) ExitIdle() {
+	fp.Balancer.(balancer.ExitIdler).ExitIdle()
+}
+
 func (fp *fakePetiole) UpdateClientConnState(state balancer.ClientConnState) error {
 	if el := state.ResolverState.Endpoints; len(el) != 2 {
 		return fmt.Errorf("UpdateClientConnState wants two endpoints, got: %v", el)

--- a/balancer/leastrequest/leastrequest.go
+++ b/balancer/leastrequest/leastrequest.go
@@ -127,6 +127,8 @@ func (lrb *leastRequestBalancer) ResolverError(err error) {
 func (lrb *leastRequestBalancer) ExitIdle() {
 	if ei, ok := lrb.child.(balancer.ExitIdler); ok { // Should always be ok, as child is endpoint sharding.
 		ei.ExitIdle()
+	} else {
+		lrb.logger.Errorf("Child balancer doesn't implement ExitIdler.")
 	}
 }
 

--- a/balancer/pickfirst/pickfirstleaf/pickfirstleaf_ext_test.go
+++ b/balancer/pickfirst/pickfirstleaf/pickfirstleaf_ext_test.go
@@ -1593,9 +1593,7 @@ func (b *stateStoringBalancer) Close() {
 }
 
 func (b *stateStoringBalancer) ExitIdle() {
-	if ib, ok := b.Balancer.(balancer.ExitIdler); ok {
-		ib.ExitIdle()
-	}
+	b.Balancer.(balancer.ExitIdler).ExitIdle()
 }
 
 type stateStoringBalancerBuilder struct {

--- a/balancer/rls/internal/test/e2e/rls_child_policy.go
+++ b/balancer/rls/internal/test/e2e/rls_child_policy.go
@@ -102,6 +102,10 @@ type RLSChildPolicyConfig struct {
 	Random  string // A random field to test child policy config changes.
 }
 
+func (b *bal) ExitIdle() {
+	b.Balancer.(balancer.ExitIdler).ExitIdle()
+}
+
 func (b *bal) UpdateClientConnState(c balancer.ClientConnState) error {
 	cfg, ok := c.BalancerConfig.(*RLSChildPolicyConfig)
 	if !ok {

--- a/balancer/roundrobin/roundrobin.go
+++ b/balancer/roundrobin/roundrobin.go
@@ -75,5 +75,7 @@ func (b *rrBalancer) ExitIdle() {
 	// Should always be ok, as child is endpoint sharding.
 	if ei, ok := b.Balancer.(balancer.ExitIdler); ok {
 		ei.ExitIdle()
+	} else {
+		b.logger.Errorf("Child balancer doesn't implement ExitIdler.")
 	}
 }

--- a/balancer/weightedroundrobin/balancer.go
+++ b/balancer/weightedroundrobin/balancer.go
@@ -406,6 +406,8 @@ func (b *wrrBalancer) Close() {
 func (b *wrrBalancer) ExitIdle() {
 	if ei, ok := b.child.(balancer.ExitIdler); ok { // Should always be ok, as child is endpoint sharding.
 		ei.ExitIdle()
+	} else {
+		b.logger.Errorf("Child balancer doesn't implement ExitIdler.")
 	}
 }
 

--- a/balancer/weightedtarget/weightedtarget_test.go
+++ b/balancer/weightedtarget/weightedtarget_test.go
@@ -130,6 +130,10 @@ func getConfigKey(attr *attributes.Attributes) (string, bool) {
 	return name, ok
 }
 
+func (b *testConfigBalancer) ExitIdle() {
+	b.Balancer.(balancer.ExitIdler).ExitIdle()
+}
+
 func (b *testConfigBalancer) UpdateClientConnState(s balancer.ClientConnState) error {
 	c, ok := s.BalancerConfig.(stringBalancerConfig)
 	if !ok {

--- a/clientconn_test.go
+++ b/clientconn_test.go
@@ -1220,6 +1220,10 @@ type stateRecordingBalancer struct {
 	balancer.Balancer
 }
 
+func (b *stateRecordingBalancer) ExitIdle() {
+	b.Balancer.(balancer.ExitIdler).ExitIdle()
+}
+
 func (b *stateRecordingBalancer) UpdateSubConnState(sc balancer.SubConn, s balancer.SubConnState) {
 	panic(fmt.Sprintf("UpdateSubConnState(%v, %+v) called unexpectedly", sc, s))
 }

--- a/internal/balancer/gracefulswitch/gracefulswitch_test.go
+++ b/internal/balancer/gracefulswitch/gracefulswitch_test.go
@@ -1010,6 +1010,8 @@ func (vb *verifyBalancer) UpdateClientConnState(balancer.ClientConnState) error 
 	return nil
 }
 
+func (vb *verifyBalancer) ExitIdle() {}
+
 func (vb *verifyBalancer) ResolverError(error) {}
 
 func (vb *verifyBalancer) UpdateSubConnState(sc balancer.SubConn, state balancer.SubConnState) {

--- a/internal/balancer/nop/nop.go
+++ b/internal/balancer/nop/nop.go
@@ -60,3 +60,6 @@ func (b *bal) UpdateSubConnState(_ balancer.SubConn, _ balancer.SubConnState) {}
 
 // Close is a no-op.
 func (b *bal) Close() {}
+
+// ExitIdle is a no-op.
+func (b *bal) ExitIdle() {}

--- a/internal/stats/metrics_recorder_list_test.go
+++ b/internal/stats/metrics_recorder_list_test.go
@@ -124,6 +124,10 @@ type recordingLoadBalancer struct {
 	balancer.Balancer
 }
 
+func (b *recordingLoadBalancer) ExitIdle() {
+	b.Balancer.(balancer.ExitIdler).ExitIdle()
+}
+
 // TestMetricsRecorderList tests the metrics recorder list functionality of the
 // ClientConn. It configures a global and local stats handler Dial Option. These
 // stats handlers implement the MetricsRecorder interface. It also configures a

--- a/interop/orcalb.go
+++ b/interop/orcalb.go
@@ -53,6 +53,12 @@ type orcab struct {
 	report   *v3orcapb.OrcaLoadReport
 }
 
+func (o *orcab) ExitIdle() {
+	if o.sc != nil {
+		o.sc.Connect()
+	}
+}
+
 func (o *orcab) UpdateClientConnState(s balancer.ClientConnState) error {
 	if o.sc != nil {
 		o.sc.UpdateAddresses(s.ResolverState.Addresses)

--- a/test/clientconn_state_transition_test.go
+++ b/test/clientconn_state_transition_test.go
@@ -474,6 +474,10 @@ type stateRecordingBalancer struct {
 	balancer.Balancer
 }
 
+func (b *stateRecordingBalancer) ExitIdle() {
+	b.Balancer.(balancer.ExitIdler).ExitIdle()
+}
+
 func (b *stateRecordingBalancer) Close() {
 	b.Balancer.Close()
 }

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -6541,6 +6541,10 @@ type triggerRPCBlockBalancer struct {
 	balancer.Balancer
 }
 
+func (bpb *triggerRPCBlockBalancer) ExitIdle() {
+	bpb.Balancer.(balancer.ExitIdler).ExitIdle()
+}
+
 func (bpb *triggerRPCBlockBalancer) UpdateClientConnState(s balancer.ClientConnState) error {
 	err := bpb.Balancer.UpdateClientConnState(s)
 	bpb.ClientConn.UpdateState(balancer.State{

--- a/xds/internal/balancer/cdsbalancer/cdsbalancer.go
+++ b/xds/internal/balancer/cdsbalancer/cdsbalancer.go
@@ -426,6 +426,8 @@ func (b *cdsBalancer) ExitIdle() {
 		// will be connected.
 		if ei, ok := b.childLB.(balancer.ExitIdler); ok {
 			ei.ExitIdle()
+		} else {
+			b.logger.Errorf("Child balancer doesn't implement ExitIdler.")
 		}
 	})
 }

--- a/xds/internal/balancer/clusterresolver/clusterresolver.go
+++ b/xds/internal/balancer/clusterresolver/clusterresolver.go
@@ -341,6 +341,8 @@ func (b *clusterResolverBalancer) run() {
 				// will be connected.
 				if ei, ok := b.child.(balancer.ExitIdler); ok {
 					ei.ExitIdle()
+				} else {
+					b.logger.Errorf("Child balancer doesn't implement ExitIdler.")
 				}
 			}
 		case u := <-b.resourceWatcher.updateChannel:

--- a/xds/internal/balancer/wrrlocality/balancer.go
+++ b/xds/internal/balancer/wrrlocality/balancer.go
@@ -154,6 +154,15 @@ type wrrLocalityBalancer struct {
 	logger *grpclog.PrefixLogger
 }
 
+func (b *wrrLocalityBalancer) ExitIdle() {
+	ei, ok := b.child.(balancer.ExitIdler)
+	if ok {
+		ei.ExitIdle()
+	} else if !ok {
+		b.logger.Errorf("Child balancer doesn't implement ExitIdler.")
+	}
+}
+
 func (b *wrrLocalityBalancer) UpdateClientConnState(s balancer.ClientConnState) error {
 	lbCfg, ok := s.BalancerConfig.(*LBConfig)
 	if !ok {


### PR DESCRIPTION
@atollena pointed out that the endpointsharding LB policy doesn't implement `ExitIdler` but it's parent policies expect it to. If a balancer that delegates to endpointsharding implements ExitIdle, it won't be able to make the children of endpointsharding exit idle without making an RPC (triggering the idle picker). We haven't seen this issue cause problems because endpointsharding [will never stay in Idle ](https://github.com/grpc/grpc-go/blob/f2d3e11f3057cc8b4935fc342446ae8372de33d3/balancer/endpointsharding/endpointsharding.go#L320-L323) unless the `DisableAutoReconnect` option is used. Only ringhash sets the `DisableAutoReconnect` option, but [it doesn't need to call ExitIdle on its child balancer](https://github.com/grpc/grpc-go/blob/edf643f50334001e8a434087c480cd5d70e9fe91/xds/internal/balancer/ringhash/ringhash.go#L304-L307).

This PR also adds error logs in other places where the code type asserts `ExitIdler` to catch such issues in tests.

RELEASE NOTES:
- balancer/endpointsharding: Implement `balancer.ExitIdler` to allow channel to exit idle without making RPCs.
