### PR TITLE
Add flag guarding SPIFFE Bundle provider

### DIFF
--- a/credentials/tls/certprovider/pemfile/watcher.go
+++ b/credentials/tls/certprovider/pemfile/watcher.go
@@ -42,6 +42,7 @@ import (
 )
 
 const defaultCertRefreshDuration = 1 * time.Hour
+const spiffeEnabledEnvVar = "GRPC_EXPERIMENTAL_XDS_MTLS_SPIFFE"
 
 var (
 	// For overriding from unit tests.
@@ -78,6 +79,11 @@ func (o Options) canonical() []byte {
 }
 
 func (o Options) validate() error {
+	// Guard against SPIFFE bundle map usage
+	if os.Getenv(spiffeEnabledEnvVar) != "true" {
+		logger.Warningf("pemfile: a SPIFFE Bundle Map %q was configured but the environment variable to enabled SPIFFE verification %q is not true", o.SPIFFEBundleMapFile, spiffeEnabledEnvVar)
+		o.SPIFFEBundleMapFile = ""
+	}
 	if o.CertFile == "" && o.KeyFile == "" && o.RootFile == "" && o.SPIFFEBundleMapFile == "" {
 		return fmt.Errorf("pemfile: at least one credential file needs to be specified")
 	}

--- a/credentials/tls/certprovider/pemfile/watcher_test.go
+++ b/credentials/tls/certprovider/pemfile/watcher_test.go
@@ -76,6 +76,8 @@ func compareKeyMaterial(got, want *certprovider.KeyMaterial) error {
 
 // TestNewProvider tests the NewProvider() function with different inputs.
 func (s) TestNewProvider(t *testing.T) {
+	os.Setenv("GRPC_EXPERIMENTAL_XDS_MTLS_SPIFFE", "true")
+	t.Cleanup(func() { os.Unsetenv("GRPC_EXPERIMENTAL_XDS_MTLS_SPIFFE")})
 	tests := []struct {
 		desc      string
 		options   Options

--- a/internal/xds/bootstrap/tlscreds/bundle.go
+++ b/internal/xds/bootstrap/tlscreds/bundle.go
@@ -28,6 +28,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"os"
 	"sync"
 	"time"
 
@@ -37,6 +38,8 @@ import (
 	"google.golang.org/grpc/credentials/tls/certprovider/pemfile"
 	"google.golang.org/grpc/internal/credentials/spiffe"
 )
+
+const spiffeEnabledEnvVar = "GRPC_EXPERIMENTAL_XDS_MTLS_SPIFFE"
 
 // bundle is an implementation of credentials.Bundle which implements mTLS
 // Credentials in xDS Bootstrap File.
@@ -64,6 +67,9 @@ func NewBundle(jd json.RawMessage) (credentials.Bundle, func(), error) {
 		}
 	} // Else the config field is absent. Treat it as an empty config.
 
+	if os.Getenv(spiffeEnabledEnvVar) != "true" {
+		cfg.SPIFFETrustBundleMapFile = ""
+	}
 	if cfg.CACertificateFile == "" && cfg.CertificateFile == "" && cfg.PrivateKeyFile == "" && cfg.SPIFFETrustBundleMapFile == "" {
 		// We cannot use (and do not need) a file_watcher provider in this case,
 		// and can simply directly use the TLS transport credentials.

--- a/internal/xds/bootstrap/tlscreds/bundle_ext_test.go
+++ b/internal/xds/bootstrap/tlscreds/bundle_ext_test.go
@@ -237,6 +237,8 @@ func (s) TestCaReloading(t *testing.T) {
 // is performed and checked for failure, ensuring that gRPC is correctly using
 // the changed-on-disk bundle map.
 func (s) Test_SPIFFE_Reloading(t *testing.T) {
+	os.Setenv("GRPC_EXPERIMENTAL_XDS_MTLS_SPIFFE", "true")
+	t.Cleanup(func() { os.Unsetenv("GRPC_EXPERIMENTAL_XDS_MTLS_SPIFFE")})
 	clientSPIFFEBundle, err := os.ReadFile(testdata.Path("spiffe_end2end/client_spiffebundle.json"))
 	if err != nil {
 		t.Fatalf("Failed to read test SPIFFE bundle: %v", err)


### PR DESCRIPTION
Per https://github.com/grpc/proposal/blob/master/A87-mtls-spiffe-support.md this feature should be guarded by an environment variable, `GRPC_EXPERIMENTAL_XDS_MTLS_SPIFFE`