### PR TITLE
balacergroup: cleanup exitIdle()

### DIFF
--- a/internal/balancergroup/balancergroup.go
+++ b/internal/balancergroup/balancergroup.go
@@ -106,13 +106,13 @@ func (sbc *subBalancerWrapper) startBalancer() {
 	}
 }
 
-// exitIdle invokes the sub-balancer's ExitIdle method. Returns a true
-// indicating whether or not the operation was completed.
-func (sbc *subBalancerWrapper) exitIdle() (complete bool) {
-	if b := sbc.balancer; b != nil {
-		b.ExitIdle()
+// exitIdle invokes the sub-balancer's ExitIdle method.
+func (sbc *subBalancerWrapper) exitIdle() {
+	b := sbc.balancer
+	if b == nil {
+		return
 	}
-	return true
+	b.ExitIdle()
 }
 
 func (sbc *subBalancerWrapper) updateClientConnState(s balancer.ClientConnState) error {
@@ -573,9 +573,7 @@ func (bg *BalancerGroup) ExitIdle() {
 		return
 	}
 	for _, config := range bg.idToBalancerConfig {
-		if !config.exitIdle() {
-			bg.connect(config)
-		}
+		config.exitIdle()
 	}
 }
 
@@ -588,9 +586,7 @@ func (bg *BalancerGroup) ExitIdleOne(id string) {
 		return
 	}
 	if config := bg.idToBalancerConfig[id]; config != nil {
-		if !config.exitIdle() {
-			bg.connect(config)
-		}
+		config.exitIdle()
 	}
 }
 

--- a/internal/balancergroup/balancergroup.go
+++ b/internal/balancergroup/balancergroup.go
@@ -106,7 +106,7 @@ func (sbc *subBalancerWrapper) startBalancer() {
 	}
 }
 
-// exitIdle invokes the sub-balancer's ExitIdle method. Returns a boolean
+// exitIdle invokes the sub-balancer's ExitIdle method. Returns a true
 // indicating whether or not the operation was completed.
 func (sbc *subBalancerWrapper) exitIdle() (complete bool) {
 	if b := sbc.balancer; b != nil {

--- a/internal/balancergroup/balancergroup.go
+++ b/internal/balancergroup/balancergroup.go
@@ -106,8 +106,8 @@ func (sbc *subBalancerWrapper) startBalancer() {
 	}
 }
 
-// exitIdle invokes the sub-balancer's ExitIdle method
-// which is a graceful switch balancer.
+// exitIdle invokes the ExitIdle method on the sub-balancer, a gracefulswitch
+// balancer.
 func (sbc *subBalancerWrapper) exitIdle() {
 	b := sbc.balancer
 	if b == nil {

--- a/internal/balancergroup/balancergroup.go
+++ b/internal/balancergroup/balancergroup.go
@@ -106,7 +106,8 @@ func (sbc *subBalancerWrapper) startBalancer() {
 	}
 }
 
-// exitIdle invokes the sub-balancer's ExitIdle method.
+// exitIdle invokes the sub-balancer's ExitIdle method
+// which is a graceful switch balancer.
 func (sbc *subBalancerWrapper) exitIdle() {
 	b := sbc.balancer
 	if b == nil {

--- a/internal/balancergroup/balancergroup.go
+++ b/internal/balancergroup/balancergroup.go
@@ -109,11 +109,9 @@ func (sbc *subBalancerWrapper) startBalancer() {
 // exitIdle invokes the sub-balancer's ExitIdle method. Returns a boolean
 // indicating whether or not the operation was completed.
 func (sbc *subBalancerWrapper) exitIdle() (complete bool) {
-	b := sbc.balancer
-	if b == nil {
-		return true
+	if b := sbc.balancer; b != nil {
+		b.ExitIdle()
 	}
-	b.ExitIdle()
 	return true
 }
 

--- a/internal/balancergroup/balancergroup.go
+++ b/internal/balancergroup/balancergroup.go
@@ -409,20 +409,6 @@ func (bg *BalancerGroup) cleanupSubConns(config *subBalancerWrapper) {
 	}
 }
 
-// connect attempts to connect to all subConns belonging to sb.
-func (bg *BalancerGroup) connect(sb *subBalancerWrapper) {
-	bg.incomingMu.Lock()
-	defer bg.incomingMu.Unlock()
-	if bg.incomingClosed {
-		return
-	}
-	for sc, b := range bg.scToSubBalancer {
-		if b == sb {
-			sc.Connect()
-		}
-	}
-}
-
 // Following are actions from the parent grpc.ClientConn, forward to sub-balancers.
 
 // updateSubConnState forwards the update to cb and updates scToSubBalancer if


### PR DESCRIPTION
### context
`exitIdle()` is called in both ExitIdle() and ExitIdleOne()

```go
func (bg *BalancerGroup) ExitIdle() {
	bg.outgoingMu.Lock()
	defer bg.outgoingMu.Unlock()
	if bg.outgoingClosed {
		return
	}
	for _, config := range bg.idToBalancerConfig {
		if !config.exitIdle() { // here
			bg.connect(config)
		}
	}
}

func (bg *BalancerGroup) ExitIdleOne(id string) {
	bg.outgoingMu.Lock()
	defer bg.outgoingMu.Unlock()
	if bg.outgoingClosed {
		return
	}
	if config := bg.idToBalancerConfig[id]; config != nil {
		if !config.exitIdle() { // here
			bg.connect(config)
		}
	}
}
```
it returns boolean value. if it returns false if-statement works.
But the current implementation of `exitIdle()` is returning only true.

### As-Is
`exitIdle` method returns boolean type but implementation returns only true. 
``` go
func (sbc *subBalancerWrapper) exitIdle() (complete bool) {
	b := sbc.balancer
	if b == nil {
		return true
	}
	b.ExitIdle()
	return true
}
```

### To-be
so i simplified implementation as method only returns true.
And fixed comment too as `Returns a true`
``` go
// exitIdle invokes the sub-balancer's ExitIdle method. Returns a true
// indicating whether or not the operation was completed.
func (sbc *subBalancerWrapper) exitIdle() (complete bool) {
	if b := sbc.balancer; b != nil {
		b.ExitIdle()
	}
	return true
}
```

I'm not sure this refactoring is necessary but at least the comment on exitIdle seems to be updated.


RELEASE NOTES: N/A