### PR TITLE
Support passing contextual options to Compressor via `compressorOptions`

### DIFF
--- a/encoding/encoding.go
+++ b/encoding/encoding.go
@@ -46,7 +46,7 @@ type Compressor interface {
 	// Compress writes the data written to wc to w after compressing it.  If an
 	// error occurs while initializing the compressor, that error is returned
 	// instead.
-	Compress(w io.Writer) (io.WriteCloser, error)
+	Compress(w io.Writer, compressorOptions ...any) (io.WriteCloser, error)
 	// Decompress reads data from r, decompresses it, and provides the
 	// uncompressed data via the returned io.Reader.  If an error occurs while
 	// initializing the decompressor, that error is returned instead.

--- a/encoding/gzip/gzip.go
+++ b/encoding/gzip/gzip.go
@@ -71,7 +71,7 @@ func SetLevel(level int) error {
 	return nil
 }
 
-func (c *compressor) Compress(w io.Writer) (io.WriteCloser, error) {
+func (c *compressor) Compress(w io.Writer, compressorOptions ...any) (io.WriteCloser, error) {
 	z := c.poolCompressor.Get().(*writer)
 	z.Writer.Reset(w)
 	return z, nil

--- a/rpc_util.go
+++ b/rpc_util.go
@@ -451,7 +451,7 @@ func (o PerRPCCredsCallOption) after(*callInfo, *csAttempt) {}
 //
 // Notice: This API is EXPERIMENTAL and may be changed or removed in a
 // later release.
-func UseCompressor(name string) CallOption {
+func UseCompressor(name string, compressorOptions ...any) CallOption {
 	return CompressorCallOption{CompressorType: name}
 }
 

--- a/rpc_util_test.go
+++ b/rpc_util_test.go
@@ -429,7 +429,7 @@ type mockCompressor struct {
 	ch chan<- struct{}
 }
 
-func (m *mockCompressor) Compress(io.Writer) (io.WriteCloser, error) {
+func (m *mockCompressor) Compress(io.Writer, ...any) (io.WriteCloser, error) {
 	panic("unimplemented")
 }
 

--- a/server.go
+++ b/server.go
@@ -2109,7 +2109,7 @@ func SendHeader(ctx context.Context, md metadata.MD) error {
 //
 // Notice: This function is EXPERIMENTAL and may be changed or removed in a
 // later release.
-func SetSendCompressor(ctx context.Context, name string) error {
+func SetSendCompressor(ctx context.Context, name string, compressorOptions ...any) error {
 	stream, ok := ServerTransportStreamFromContext(ctx).(*transport.ServerStream)
 	if !ok || stream == nil {
 		return fmt.Errorf("failed to fetch the stream from the given context")

--- a/stream.go
+++ b/stream.go
@@ -910,7 +910,7 @@ func (cs *clientStream) SendMsg(m any) (err error) {
 	}
 
 	// load hdr, payload, data
-	hdr, data, payload, pf, err := prepareMsg(m, cs.codec, cs.compressorV0, cs.compressorV1, cs.cc.dopts.copts.BufferPool)
+	hdr, data, payload, pf, err := prepareMsg(m, cs.codec, cs.compressorV0, cs.compressorV1, cs.cc.dopts.copts.BufferPool, cs.callInfo.compressorOptions)
 	if err != nil {
 		return err
 	}
@@ -1417,7 +1417,7 @@ func (as *addrConnStream) SendMsg(m any) (err error) {
 	}
 
 	// load hdr, payload, data
-	hdr, data, payload, pf, err := prepareMsg(m, as.codec, as.sendCompressorV0, as.sendCompressorV1, as.ac.dopts.copts.BufferPool)
+	hdr, data, payload, pf, err := prepareMsg(m, as.codec, as.sendCompressorV0, as.sendCompressorV1, as.ac.dopts.copts.BufferPool, as.callInfo.compressorOptions)
 	if err != nil {
 		return err
 	}
@@ -1814,7 +1814,7 @@ func MethodFromServerStream(stream ServerStream) (string, bool) {
 // compression was made and therefore whether the payload needs to be freed in
 // addition to the returned data. Freeing the payload if the returned boolean is
 // false can lead to undefined behavior.
-func prepareMsg(m any, codec baseCodec, cp Compressor, comp encoding.Compressor, pool mem.BufferPool) (hdr []byte, data, payload mem.BufferSlice, pf payloadFormat, err error) {
+func prepareMsg(m any, codec baseCodec, cp Compressor, comp encoding.Compressor, pool mem.BufferPool, compressorOptions ...any) (hdr []byte, data, payload mem.BufferSlice, pf payloadFormat, err error) {
 	if preparedMsg, ok := m.(*PreparedMsg); ok {
 		return preparedMsg.hdr, preparedMsg.encodedData, preparedMsg.payload, preparedMsg.pf, nil
 	}
@@ -1824,7 +1824,7 @@ func prepareMsg(m any, codec baseCodec, cp Compressor, comp encoding.Compressor,
 	if err != nil {
 		return nil, nil, nil, 0, err
 	}
-	compData, pf, err := compress(data, cp, comp, pool)
+	compData, pf, err := compress(data, cp, comp, pool, compressorOptions...)
 	if err != nil {
 		data.Free()
 		return nil, nil, nil, 0, err

--- a/test/compressor_test.go
+++ b/test/compressor_test.go
@@ -348,7 +348,7 @@ type wrapCompressor struct {
 	compressInvokes int32
 }
 
-func (wc *wrapCompressor) Compress(w io.Writer) (io.WriteCloser, error) {
+func (wc *wrapCompressor) Compress(w io.Writer, compressorOptions ...any) (io.WriteCloser, error) {
 	atomic.AddInt32(&wc.compressInvokes, 1)
 	return wc.Compressor.Compress(w)
 }
@@ -792,7 +792,7 @@ type fakeCompressor struct {
 	decompressedMessageSize int
 }
 
-func (f *fakeCompressor) Compress(w io.Writer) (io.WriteCloser, error) {
+func (f *fakeCompressor) Compress(w io.Writer, compressorOptions ...any) (io.WriteCloser, error) {
 	return nopWriteCloser{w}, nil
 }
 


### PR DESCRIPTION
Fixes: #7017 

Some compression formats (e.g., `zstd`) support dictionary compression, which requires passing additional context to the compressor. This PR adds `compressorOptions` to enable these use cases.

RELEASE NOTES: none