### PR TITLE
transport: Re-use slice buffer reader for a stream

### DIFF
--- a/internal/transport/controlbuf.go
+++ b/internal/transport/controlbuf.go
@@ -146,10 +146,11 @@ type earlyAbortStream struct {
 func (*earlyAbortStream) isTransportResponseFrame() bool { return false }
 
 type dataFrame struct {
-	streamID  uint32
-	endStream bool
-	h         []byte
-	reader    mem.Reader
+	streamID   uint32
+	endStream  bool
+	h          []byte
+	data       mem.BufferSlice
+	processing bool
 	// onEachWrite is called every time
 	// a part of data is written out.
 	onEachWrite func()
@@ -234,6 +235,7 @@ type outStream struct {
 	itl              *itemList
 	bytesOutStanding int
 	wq               *writeQuota
+	reader           mem.Reader
 
 	next *outStream
 	prev *outStream
@@ -461,7 +463,9 @@ func (c *controlBuffer) finish() {
 				v.onOrphaned(ErrConnClosing)
 			}
 		case *dataFrame:
-			_ = v.reader.Close()
+			if !v.processing {
+				v.data.Free()
+			}
 		}
 	}
 
@@ -650,10 +654,11 @@ func (l *loopyWriter) incomingSettingsHandler(s *incomingSettings) error {
 
 func (l *loopyWriter) registerStreamHandler(h *registerStream) {
 	str := &outStream{
-		id:    h.streamID,
-		state: empty,
-		itl:   &itemList{},
-		wq:    h.wq,
+		id:     h.streamID,
+		state:  empty,
+		itl:    &itemList{},
+		wq:     h.wq,
+		reader: mem.BufferSlice{}.Reader(),
 	}
 	l.estdStreams[h.streamID] = str
 }
@@ -685,10 +690,11 @@ func (l *loopyWriter) headerHandler(h *headerFrame) error {
 	}
 	// Case 2: Client wants to originate stream.
 	str := &outStream{
-		id:    h.streamID,
-		state: empty,
-		itl:   &itemList{},
-		wq:    h.wq,
+		id:     h.streamID,
+		state:  empty,
+		itl:    &itemList{},
+		wq:     h.wq,
+		reader: mem.BufferSlice{}.Reader(),
 	}
 	return l.originateStream(str, h)
 }
@@ -790,10 +796,13 @@ func (l *loopyWriter) cleanupStreamHandler(c *cleanupStream) error {
 		// a RST_STREAM before stream initialization thus the stream might
 		// not be established yet.
 		delete(l.estdStreams, c.streamID)
+		str.reader.Close()
 		str.deleteSelf()
 		for head := str.itl.dequeueAll(); head != nil; head = head.next {
 			if df, ok := head.it.(*dataFrame); ok {
-				_ = df.reader.Close()
+				if !df.processing {
+					df.data.Free()
+				}
 			}
 		}
 	}
@@ -928,7 +937,13 @@ func (l *loopyWriter) processData() (bool, error) {
 	if str == nil {
 		return true, nil
 	}
+	reader := str.reader
 	dataItem := str.itl.peek().(*dataFrame) // Peek at the first data item this stream.
+	if !dataItem.processing {
+		dataItem.processing = true
+		str.reader.Reset(dataItem.data)
+		dataItem.data.Free()
+	}
 	// A data item is represented by a dataFrame, since it later translates into
 	// multiple HTTP2 data frames.
 	// Every dataFrame has two buffers; h that keeps grpc-message header and data
@@ -936,13 +951,13 @@ func (l *loopyWriter) processData() (bool, error) {
 	// from data is copied to h to make as big as the maximum possible HTTP2 frame
 	// size.
 
-	if len(dataItem.h) == 0 && dataItem.reader.Remaining() == 0 { // Empty data frame
+	if len(dataItem.h) == 0 && reader.Remaining() == 0 { // Empty data frame
 		// Client sends out empty data frame with endStream = true
 		if err := l.framer.fr.WriteData(dataItem.streamID, dataItem.endStream, nil); err != nil {
 			return false, err
 		}
 		str.itl.dequeue() // remove the empty data item from stream
-		_ = dataItem.reader.Close()
+		_ = reader.Close()
 		if str.itl.isEmpty() {
 			str.state = empty
 		} else if trailer, ok := str.itl.peek().(*headerFrame); ok { // the next item is trailers.
@@ -971,8 +986,8 @@ func (l *loopyWriter) processData() (bool, error) {
 	}
 	// Compute how much of the header and data we can send within quota and max frame length
 	hSize := min(maxSize, len(dataItem.h))
-	dSize := min(maxSize-hSize, dataItem.reader.Remaining())
-	remainingBytes := len(dataItem.h) + dataItem.reader.Remaining() - hSize - dSize
+	dSize := min(maxSize-hSize, reader.Remaining())
+	remainingBytes := len(dataItem.h) + reader.Remaining() - hSize - dSize
 	size := hSize + dSize
 
 	var buf *[]byte
@@ -993,7 +1008,7 @@ func (l *loopyWriter) processData() (bool, error) {
 		defer pool.Put(buf)
 
 		copy((*buf)[:hSize], dataItem.h)
-		_, _ = dataItem.reader.Read((*buf)[hSize:])
+		_, _ = reader.Read((*buf)[hSize:])
 	}
 
 	// Now that outgoing flow controls are checked we can replenish str's write quota
@@ -1014,7 +1029,7 @@ func (l *loopyWriter) processData() (bool, error) {
 	dataItem.h = dataItem.h[hSize:]
 
 	if remainingBytes == 0 { // All the data from that message was written out.
-		_ = dataItem.reader.Close()
+		_ = reader.Close()
 		str.itl.dequeue()
 	}
 	if str.itl.isEmpty() {

--- a/internal/transport/transport_test.go
+++ b/internal/transport/transport_test.go
@@ -203,10 +203,11 @@ func (h *testStreamHandler) handleStreamMisbehave(t *testing.T, s *ServerStream)
 			}
 		}
 		data := newBufferSlice(p)
+		data.Ref()
 		conn.controlBuf.put(&dataFrame{
 			streamID:    s.id,
 			h:           nil,
-			reader:      data.Reader(),
+			data:        data,
 			onEachWrite: func() {},
 		})
 		sent += len(p)
@@ -1092,11 +1093,12 @@ func (s) TestServerContextCanceledOnClosedConnection(t *testing.T) {
 		t.Fatalf("Failed to open stream: %v", err)
 	}
 	d := newBufferSlice(make([]byte, http2MaxFrameLen))
+	d.Ref()
 	ct.controlBuf.put(&dataFrame{
 		streamID:    s.id,
 		endStream:   false,
 		h:           nil,
-		reader:      d.Reader(),
+		data:        d,
 		onEachWrite: func() {},
 	})
 	// Loop until the server side stream is created.

--- a/mem/buffer_slice.go
+++ b/mem/buffer_slice.go
@@ -137,6 +137,9 @@ type Reader interface {
 	Close() error
 	// Remaining returns the number of unread bytes remaining in the slice.
 	Remaining() int
+	// Reset frees the currently held buffer slice and starts reading from the
+	// provided slice. This allows reusing the reader object.
+	Reset(s BufferSlice)
 }
 
 type sliceReader struct {
@@ -148,6 +151,14 @@ type sliceReader struct {
 
 func (r *sliceReader) Remaining() int {
 	return r.len
+}
+
+func (r *sliceReader) Reset(s BufferSlice) {
+	r.Close()
+	s.Ref()
+	r.data = s
+	r.len = s.Len()
+	r.bufferIdx = 0
 }
 
 func (r *sliceReader) Close() error {

--- a/mem/buffer_slice.go
+++ b/mem/buffer_slice.go
@@ -154,7 +154,7 @@ func (r *sliceReader) Remaining() int {
 }
 
 func (r *sliceReader) Reset(s BufferSlice) {
-	r.Close()
+	r.data.Free()
 	s.Ref()
 	r.data = s
 	r.len = s.Len()


### PR DESCRIPTION
This introduces a new method to reset the BufferSlice being used by a `mem.Reader`. The enables using a single `Reader` for an HTTP/2 stream instead of allocating one object per gRPC message. This reduces allocs/op, but doesn't have a noticable impact on qps or latency.


## Benchmarks
```
 go run benchmark/benchresult/main.go before after
streaming-networkMode_Local-bufConn_false-keepalive_false-benchTime_30s-trace_false-latency_0s-kbps_0-MTU_0-maxConcurrentCalls_60-reqSi
ze_32384B-respSize_32384B-compressor_off-channelz_false-preloader_false-clientReadBufferSize_-1-clientWriteBufferSize_-1-serverReadBuff
erSize_-1-serverWriteBufferSize_-1-sleepBetweenRPCs_0s-connections_1-recvBufferPool_simple-sharedWriteBuffer_false
               Title       Before        After Percentage
            TotalOps      1089062      1096640     0.70%
             SendOps            0            0      NaN%
             RecvOps            0            0      NaN%
            Bytes/op    135783.55    135744.35    -0.03%
           Allocs/op        32.20        30.05    -6.21%
             ReqT/op 9404849015.47 9470290602.67     0.70%
            RespT/op 9404849015.47 9470290602.67     0.70%
            50th-Lat   1.646019ms    1.62842ms    -1.07%
            90th-Lat   2.280214ms   2.264523ms    -0.69%
            99th-Lat   2.692703ms    2.68211ms    -0.39%
             Avg-Lat   1.651539ms   1.640149ms    -0.69%
           GoVersion     go1.24.2     go1.24.2
         GrpcVersion   1.74.0-dev   1.74.0-dev
```

RELEASE NOTES:
* transport: Reduce heap allocs by re-using `mem.Reader` objects.