### PR TITLE
xdsclient: Fix flakyness in `TestResourceUpdateMetrics` in the case of repeated NACKs

### DIFF
--- a/xds/internal/clients/xdsclient/test/helpers_test.go
+++ b/xds/internal/clients/xdsclient/test/helpers_test.go
@@ -296,5 +296,5 @@ func (r *testMetricsReporter) waitForMetric(ctx context.Context, metricsDataWant
 
 // ReportMetric sends the metrics data to the metricsCh channel.
 func (r *testMetricsReporter) ReportMetric(m any) {
-	r.metricsCh.Send(m)
+	r.metricsCh.Replace(m)
 }

--- a/xds/internal/clients/xdsclient/test/metrics_test.go
+++ b/xds/internal/clients/xdsclient/test/metrics_test.go
@@ -40,7 +40,7 @@ import (
 // to send valid and invalid LDS updates, and verifies that the expected metrics
 // for both good and bad updates are emitted.
 func (s) TestResourceUpdateMetrics(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout*1000)
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
 
 	tmr := newTestMetricsReporter()


### PR DESCRIPTION
Fixes: https://github.com/grpc/grpc-go/issues/8344

[Successful forge test](https://fusion2.corp.google.com/invocations/129660cb-0099-4802-b916-4d8db4f4a365/targets/%2F%2Fthird_party%2Fgolang%2Fgrpc%2Fxds%2Finternal%2Fclients%2Fxdsclient%2Ftest:xdsclient_test/tests)

In a rare case scenario of NACK, the xDS client can emit metrics in quick succession due to the interaction sequence between the xDS client (in grpc-go) and the test management server (using go-control-plane) after the initial invalid update. The test uses `testMetricsReporter ` for xdsclient to report metrics which calls `metricsReporter.ReportMetric()` to report invalid and valid xds resource updates. The flakiness is due to timeout in `r.metricsCh.Send(m)` in the case burst of redundant updates because the `metricsCh` in `testMetricsReporter` is a `testutils.Channel` initialized with a size of 1. A Send operation on this channel will block if the channel is full. See https://github.com/grpc/grpc-go/issues/8344#issuecomment-2913072335

We can mitigate the race by making the metric sends non-block by dropping redundant update and replacing with the new one. Similar to what is being done in internal grpc metrics recorder https://github.com/grpc/grpc-go/blob/master/internal/testutils/stats/test_metrics_recorder.go#L125-L126

RELEASE NOTES: None