### PR TITLE
grpctest: add test coverages of `ExitIdle`

### DIFF
--- a/internal/balancergroup/balancergroup_test.go
+++ b/internal/balancergroup/balancergroup_test.go
@@ -820,7 +820,7 @@ func (s) TestBalancerExitIdle_All(t *testing.T) {
 
 func (s) TestBalancerGroup_ExitIdle_AfterClose(t *testing.T) {
 	balancerName := t.Name()
-	exitIdleCh := make(chan struct{})
+	exitIdleCh := make(chan struct{}, 1)
 
 	stub.Register(balancerName, stub.BalancerFuncs{
 		ExitIdle: func(_ *stub.BalancerData) {


### PR DESCRIPTION
Fixes: https://github.com/grpc/grpc-go/issues/8118

- Add test cases for
  - [X] ExitIdle()
  - [X] ExitIdleOne()
  - [X] UpdateClientConnState
  - [x] ResolverError

RELEASE NOTES: N/A