### PR TITLE
grpc: Fix cardinality violations in server streaming RPC.

### DIFF
--- a/server.go
+++ b/server.go
@@ -1572,6 +1572,7 @@ func (s *Server) processStreamingRPC(ctx context.Context, stream *transport.Serv
 		s:                     stream,
 		p:                     &parser{r: stream, bufferPool: s.opts.bufferPool},
 		codec:                 s.getCodec(stream.ContentSubtype()),
+		desc:                  sd,
 		maxReceiveMessageSize: s.opts.maxReceiveMessageSize,
 		maxSendMessageSize:    s.opts.maxSendMessageSize,
 		trInfo:                trInfo,

--- a/stream.go
+++ b/stream.go
@@ -1580,6 +1580,7 @@ type serverStream struct {
 	s     *transport.ServerStream
 	p     *parser
 	codec baseCodec
+	desc  *StreamDesc
 
 	compressorV0   Compressor
 	compressorV1   encoding.Compressor
@@ -1773,6 +1774,9 @@ func (ss *serverStream) RecvMsg(m any) (err error) {
 				for _, binlog := range ss.binlogs {
 					binlog.Log(ss.ctx, chc)
 				}
+			}
+			if !ss.desc.ClientStreams {
+				return status.Errorf(codes.Internal, "RecvMsg is called twice")
 			}
 			return err
 		}


### PR DESCRIPTION
Fixes #8362 
Partially addresses: #7286 

In non-client streaming RPCs, the client's SendMsg() method is designed to automatically close the send operation after its initial call. If someone attempts to call Client.SendMsg() twice for non-client streaming RPCs, if will return with error `Internal desc = SendMsg called after CloseSend`.
To mirror this behavior, the server-side logic has been updated so that calling RecvMsg() more than once for non-client streaming RPCs will now similarly return an `Internal` error.

RELEASE NOTES:
* grpc: return status code INTERNAL when client send more than one request in unary and server streaming RPC.