### PR TITLE
examples/opentelemetry: demonstrate enabling experimental metrics

### DIFF
--- a/examples/features/opentelemetry/README.md
+++ b/examples/features/opentelemetry/README.md
@@ -3,6 +3,10 @@
 This example shows how to configure OpenTelemetry on a client and server, and
 shows what type of telemetry data it can produce for certain RPCs.
 
+## Experimental Metrics
+
+This example now includes **experimental gRPC metrics** such as Weighted Round Robin (WRR), Pick First, and XDSClient metrics. These metrics are not enabled by default and must be explicitly added to both the client and server configurations.
+
 ## Try it
 
 ```

--- a/examples/features/opentelemetry/client/main.go
+++ b/examples/features/opentelemetry/client/main.go
@@ -63,8 +63,24 @@ func main() {
 	// Configure W3C Trace Context Propagator for traces
 	textMapPropagator := otelpropagation.TraceContext{}
 	do := opentelemetry.DialOption(opentelemetry.Options{
-		MetricsOptions: opentelemetry.MetricsOptions{MeterProvider: meterProvider},
-		TraceOptions:   oteltracing.TraceOptions{TracerProvider: traceProvider, TextMapPropagator: textMapPropagator},
+		MetricsOptions: opentelemetry.MetricsOptions{
+			MeterProvider: meterProvider,
+			Metrics: opentelemetry.DefaultMetrics().Add(
+				"grpc.lb.wrr.rr_fallback",
+				"grpc.lb.wrr.endpoint_weight_not_yet_usable",
+				"grpc.lb.wrr.endpoint_weight_stale",
+				"grpc.lb.wrr.endpoint_weights",
+				"grpc.lb.pick_first.disconnections",
+				"grpc.lb.pick_first.connection_attempts_succeeded",
+				"grpc.lb.pick_first.connection_attempts_failed",
+				"grpc.xds_client.connected",
+				"grpc.xds_client.server_failure",
+				"grpc.xds_client.resource_updates_valid",
+				"grpc.xds_client.resource_updates_invalid",
+				"grpc.xds_client.resources",
+			),
+		},
+		TraceOptions: oteltracing.TraceOptions{TracerProvider: traceProvider, TextMapPropagator: textMapPropagator},
 	})
 
 	go http.ListenAndServe(*prometheusEndpoint, promhttp.Handler())

--- a/examples/features/opentelemetry/server/main.go
+++ b/examples/features/opentelemetry/server/main.go
@@ -71,8 +71,24 @@ func main() {
 	// Configure W3C Trace Context Propagator for traces
 	textMapPropagator := otelpropagation.TraceContext{}
 	so := opentelemetry.ServerOption(opentelemetry.Options{
-		MetricsOptions: opentelemetry.MetricsOptions{MeterProvider: meterProvider},
-		TraceOptions:   oteltracing.TraceOptions{TracerProvider: traceProvider, TextMapPropagator: textMapPropagator}})
+		MetricsOptions: opentelemetry.MetricsOptions{
+			MeterProvider: meterProvider,
+			Metrics: opentelemetry.DefaultMetrics().Add(
+				"grpc.lb.wrr.rr_fallback",
+				"grpc.lb.wrr.endpoint_weight_not_yet_usable",
+				"grpc.lb.wrr.endpoint_weight_stale",
+				"grpc.lb.wrr.endpoint_weights",
+				"grpc.lb.pick_first.disconnections",
+				"grpc.lb.pick_first.connection_attempts_succeeded",
+				"grpc.lb.pick_first.connection_attempts_failed",
+				"grpc.xds_client.connected",
+				"grpc.xds_client.server_failure",
+				"grpc.xds_client.resource_updates_valid",
+				"grpc.xds_client.resource_updates_invalid",
+				"grpc.xds_client.resources",
+			),
+		},
+		TraceOptions: oteltracing.TraceOptions{TracerProvider: traceProvider, TextMapPropagator: textMapPropagator}})
 
 	go http.ListenAndServe(*prometheusEndpoint, promhttp.Handler())
 

--- a/stats/opentelemetry/example_test.go
+++ b/stats/opentelemetry/example_test.go
@@ -25,7 +25,7 @@ import (
 	"go.opentelemetry.io/otel/sdk/metric"
 )
 
-func Example_dialOption() {
+func ExampleDialOption_basic() {
 	// This is setting default bounds for a view. Setting these bounds through
 	// meter provider from SDK is recommended, as API calls in this module
 	// provide default bounds, but these calls are not guaranteed to be stable
@@ -64,7 +64,7 @@ func Example_dialOption() {
 	defer cc.Close()
 }
 
-func Example_serverOption() {
+func ExampleServerOption_filterMethod() {
 	reader := metric.NewManualReader()
 	provider := metric.NewMeterProvider(metric.WithReader(reader))
 	opts := opentelemetry.Options{
@@ -84,7 +84,7 @@ func Example_serverOption() {
 	defer cc.Close()
 }
 
-func ExampleMetrics_excludeSome() {
+func ExampleOptions_excludeSomeMetrics() {
 	// To exclude specific metrics, initialize Options as follows:
 	opts := opentelemetry.Options{
 		MetricsOptions: opentelemetry.MetricsOptions{
@@ -99,7 +99,7 @@ func ExampleMetrics_excludeSome() {
 	defer cc.Close()
 }
 
-func ExampleMetrics_disableAll() {
+func ExampleOptions_disableAllMetrics() {
 	// To disable all metrics, initialize Options as follows:
 	opts := opentelemetry.Options{
 		MetricsOptions: opentelemetry.MetricsOptions{
@@ -114,7 +114,7 @@ func ExampleMetrics_disableAll() {
 	defer cc.Close()
 }
 
-func ExampleMetrics_enableSome() {
+func ExampleOptions_enableSomeMetrics() {
 	// To only create specific metrics, initialize Options as follows:
 	opts := opentelemetry.Options{
 		MetricsOptions: opentelemetry.MetricsOptions{
@@ -125,6 +125,30 @@ func ExampleMetrics_enableSome() {
 	cc, err := grpc.NewClient("<target string>", do, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil { // might fail vet
 		// Handle err.
+	}
+	defer cc.Close()
+}
+
+func ExampleOptions_addMetrics() {
+	opts := opentelemetry.Options{
+		MetricsOptions: opentelemetry.MetricsOptions{
+			Metrics: opentelemetry.DefaultMetrics().Add(
+				"grpc.lb.wrr.rr_fallback",
+				"grpc.lb.wrr.endpoint_weight_not_yet_usable",
+				"grpc.lb.wrr.endpoint_weight_stale",
+				"grpc.lb.wrr.endpoint_weights",
+				"grpc.xds_client.connected",
+				"grpc.xds_client.server_failure",
+				"grpc.xds_client.resource_updates_valid",
+				"grpc.xds_client.resource_updates_invalid",
+				"grpc.xds_client.resources",
+			),
+		},
+	}
+	do := opentelemetry.DialOption(opts)
+	cc, err := grpc.NewClient("<target string>", do, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		// Handle error.
 	}
 	defer cc.Close()
 }


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc-go/issues/8311

RELEASE NOTES:
* examples: Add examples to demonstrate enabling experimental metrics using the opentelemetry plugin.