### PR TITLE
roundrobin: Remove unnecessary ExitIdle override

### DIFF
--- a/balancer/roundrobin/roundrobin.go
+++ b/balancer/roundrobin/roundrobin.go
@@ -70,7 +70,3 @@ func (b *rrBalancer) UpdateClientConnState(ccs balancer.ClientConnState) error {
 		ResolverState: pickfirstleaf.EnableHealthListener(ccs.ResolverState),
 	})
 }
-
-func (b *rrBalancer) ExitIdle() {
-	b.Balancer.ExitIdle()
-}


### PR DESCRIPTION
This override was introduced recently in https://github.com/grpc/grpc-go/pull/8367. It's not necessary.

RELEASE NOTES: N/A