### PR TITLE
xdsclient: export genericResourceTypeDecoder

### DIFF
--- a/xds/internal/xdsclient/xdsresource/cluster_resource_type.go
+++ b/xds/internal/xdsclient/xdsresource/cluster_resource_type.go
@@ -156,5 +156,5 @@ func WatchCluster(p Producer, name string, w ClusterWatcher) (cancel func()) {
 // NewGenericClusterResourceTypeDecoder returns a xdsclient.Decoder that
 // wraps the xdsresource.clusterType.
 func NewGenericClusterResourceTypeDecoder(bc *bootstrap.Config, gServerCfgMap map[xdsclient.ServerConfig]*bootstrap.ServerConfig) xdsclient.Decoder {
-	return &genericResourceTypeDecoder{resourceType: clusterType, bootstrapConfig: bc, gServerConfigMap: gServerCfgMap}
+	return &GenericResourceTypeDecoder{ResourceType: clusterType, BootstrapConfig: bc, ServerConfigMap: gServerCfgMap}
 }

--- a/xds/internal/xdsclient/xdsresource/endpoints_resource_type.go
+++ b/xds/internal/xdsclient/xdsresource/endpoints_resource_type.go
@@ -151,5 +151,5 @@ func WatchEndpoints(p Producer, name string, w EndpointsWatcher) (cancel func())
 // NewGenericEndpointsResourceTypeDecoder returns a xdsclient.Decoder that
 // wraps the xdsresource.endpointsType.
 func NewGenericEndpointsResourceTypeDecoder() xdsclient.Decoder {
-	return &genericResourceTypeDecoder{resourceType: endpointsType}
+	return &GenericResourceTypeDecoder{ResourceType: endpointsType}
 }

--- a/xds/internal/xdsclient/xdsresource/listener_resource_type.go
+++ b/xds/internal/xdsclient/xdsresource/listener_resource_type.go
@@ -185,5 +185,5 @@ func WatchListener(p Producer, name string, w ListenerWatcher) (cancel func()) {
 // NewGenericListenerResourceTypeDecoder returns a xdsclient.Decoder that wraps
 // the xdsresource.listenerType.
 func NewGenericListenerResourceTypeDecoder(bc *bootstrap.Config) xdsclient.Decoder {
-	return &genericResourceTypeDecoder{resourceType: listenerType, bootstrapConfig: bc}
+	return &GenericResourceTypeDecoder{ResourceType: listenerType, BootstrapConfig: bc}
 }

--- a/xds/internal/xdsclient/xdsresource/resource_type.go
+++ b/xds/internal/xdsclient/xdsresource/resource_type.go
@@ -171,27 +171,27 @@ func (r resourceTypeState) AllResourcesRequiredInSotW() bool {
 	return r.allResourcesRequiredInSotW
 }
 
-// genericResourceTypeDecoder wraps an xdsresource.Type and implements
+// GenericResourceTypeDecoder wraps an xdsresource.Type and implements
 // xdsclient.Decoder.
 //
 // TODO: #8313 - Delete this once the internal xdsclient usages are updated
 // to use the generic xdsclient.ResourceType interface directly.
-type genericResourceTypeDecoder struct {
-	resourceType     Type
-	bootstrapConfig  *bootstrap.Config
-	gServerConfigMap map[xdsclient.ServerConfig]*bootstrap.ServerConfig
+type GenericResourceTypeDecoder struct {
+	ResourceType    Type
+	BootstrapConfig *bootstrap.Config
+	ServerConfigMap map[xdsclient.ServerConfig]*bootstrap.ServerConfig
 }
 
 // Decode deserialize and validate resource bytes of an xDS resource received
 // from the xDS management server.
-func (gd *genericResourceTypeDecoder) Decode(resourceBytes []byte, gOpts xdsclient.DecodeOptions) (*xdsclient.DecodeResult, error) {
-	raw := &anypb.Any{TypeUrl: gd.resourceType.TypeURL(), Value: resourceBytes}
-	opts := &DecodeOptions{BootstrapConfig: gd.bootstrapConfig}
+func (gd *GenericResourceTypeDecoder) Decode(resourceBytes []byte, gOpts xdsclient.DecodeOptions) (*xdsclient.DecodeResult, error) {
+	raw := &anypb.Any{TypeUrl: gd.ResourceType.TypeURL(), Value: resourceBytes}
+	opts := &DecodeOptions{BootstrapConfig: gd.BootstrapConfig}
 	if gOpts.ServerConfig != nil {
-		opts.ServerConfig = gd.gServerConfigMap[*gOpts.ServerConfig]
+		opts.ServerConfig = gd.ServerConfigMap[*gOpts.ServerConfig]
 	}
 
-	result, err := gd.resourceType.Decode(opts, raw)
+	result, err := gd.ResourceType.Decode(opts, raw)
 	if result == nil {
 		return nil, err
 	}

--- a/xds/internal/xdsclient/xdsresource/route_config_resource_type.go
+++ b/xds/internal/xdsclient/xdsresource/route_config_resource_type.go
@@ -153,5 +153,5 @@ func WatchRouteConfig(p Producer, name string, w RouteConfigWatcher) (cancel fun
 // NewGenericRouteConfigResourceTypeDecoder returns a xdsclient.Decoder that
 // wraps the xdsresource.routeConfigType.
 func NewGenericRouteConfigResourceTypeDecoder() xdsclient.Decoder {
-	return &genericResourceTypeDecoder{resourceType: routeConfigType}
+	return &GenericResourceTypeDecoder{ResourceType: routeConfigType}
 }


### PR DESCRIPTION
This is a follow-up from https://github.com/grpc/grpc-go/pull/8405.

Exporting this type will allow the registration of other resource type implementations. Currently this is in an internal package, and we will anyway get rid of this code once we migrate all our resource type implementations to use the new generic client API directly. This is *only* a temporary hack.

RELEASE NOTES: none