### PR TITLE
xdsclient: preserve original bytes for decoding when the resource is wrapped

### DIFF
--- a/xds/internal/clients/xdsclient/channel.go
+++ b/xds/internal/clients/xdsclient/channel.go
@@ -253,13 +253,17 @@ func decodeResponse(opts *DecodeOptions, rType *ResourceType, resp response) (ma
 	perResourceErrors := make(map[string]error) // Tracks resource validation errors, where we have a resource name.
 	ret := make(map[string]dataAndErrTuple)     // Return result, a map from resource name to either resource data or error.
 	for _, r := range resp.resources {
-		r, err := xdsresource.UnwrapResource(r)
+		// Unwrap and validate the resource, but preserve the original bytes for
+		// decoding. This is required for resource types that don't have a name
+		// field in the resource itself, but only have one in the wrapped
+		// resource.
+		inner, err := xdsresource.UnwrapResource(r)
 		if err != nil {
 			topLevelErrors = append(topLevelErrors, err)
 			continue
 		}
-		if _, ok := opts.Config.ResourceTypes[r.TypeUrl]; !ok || r.TypeUrl != resp.typeURL {
-			topLevelErrors = append(topLevelErrors, xdsresource.NewErrorf(xdsresource.ErrorTypeResourceTypeUnsupported, "unexpected resource type: %q ", r.GetTypeUrl()))
+		if _, ok := opts.Config.ResourceTypes[inner.GetTypeUrl()]; !ok || inner.GetTypeUrl() != resp.typeURL {
+			topLevelErrors = append(topLevelErrors, xdsresource.NewErrorf(xdsresource.ErrorTypeResourceTypeUnsupported, "unexpected resource type: %q ", inner.GetTypeUrl()))
 			continue
 		}
 		result, err := rType.Decoder.Decode(r.GetValue(), *opts)


### PR DESCRIPTION
Some resource types do not have a `name` field in them. They rely on being wrapped in a `discovery.Resource` proto to give them a name. So when the xdsClient unwraps such a resource for validation purposes, it still needs to send the wrapped message bytes to the decoder.

RELEASE NOTES: none