### PR TITLE
xdsclient: typed config nil better nil checks

### DIFF
--- a/xds/internal/xdsclient/xdsresource/filter_chain.go
+++ b/xds/internal/xdsclient/xdsresource/filter_chain.go
@@ -542,7 +542,10 @@ func (fcm *FilterChainManager) filterChainFromProto(fc *v3listenerpb.FilterChain
 		return nil, fmt.Errorf("transport_socket field has unexpected name: %s", name)
 	}
 	tc := ts.GetTypedConfig()
-	if tc == nil || tc.TypeUrl != version.V3DownstreamTLSContextURL {
+	if tc == nil {
+		return nil, fmt.Errorf("missing required field: TypedConfig")
+	}
+	if tc.TypeUrl != version.V3UpstreamTLSContextURL {
 		return nil, fmt.Errorf("transport_socket field has unexpected typeURL: %s", tc.TypeUrl)
 	}
 	downstreamCtx := &v3tlspb.DownstreamTlsContext{}

--- a/xds/internal/xdsclient/xdsresource/unmarshal_cds.go
+++ b/xds/internal/xdsclient/xdsresource/unmarshal_cds.go
@@ -287,7 +287,10 @@ func securityConfigFromCluster(cluster *v3clusterpb.Cluster) (*SecurityConfig, e
 		return nil, fmt.Errorf("transport_socket field has unexpected name: %s", name)
 	}
 	tc := ts.GetTypedConfig()
-	if tc == nil || tc.TypeUrl != version.V3UpstreamTLSContextURL {
+	if tc == nil {
+		return nil, fmt.Errorf("missing required field: TypedConfig")
+	}
+	if tc.TypeUrl != version.V3UpstreamTLSContextURL {
 		return nil, fmt.Errorf("transport_socket field has unexpected typeURL: %s", tc.TypeUrl)
 	}
 	upstreamCtx := &v3tlspb.UpstreamTlsContext{}


### PR DESCRIPTION
We check for nil and in next line deference it `tc.TypeUrl`?
I found two places, which takes part in it