### PR TITLE
github: Restrict repo contents permissions to read-only in pr-validation

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -3,6 +3,9 @@ on:
   pull_request:
     types: [opened, edited, synchronize, labeled, unlabeled, milestoned, demilestoned]
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     name: Validate PR


### PR DESCRIPTION
RELEASE NOTES: none