### PR TITLE
xds/cdsbalancer: correctly remove the unwanted cds watchers

### DIFF
--- a/xds/internal/balancer/cdsbalancer/aggregate_cluster_test.go
+++ b/xds/internal/balancer/cdsbalancer/aggregate_cluster_test.go
@@ -902,11 +902,12 @@ func (s) TestWatchers(t *testing.T) {
 	if err := waitForResourceNames(ctx, cdsResourceRequestedCh, wantNames); err != nil {
 		t.Fatal(err)
 	}
+
+	// Update the CDS resources to remove cluster C and add cluster D.
 	updatedResources := e2e.UpdateOptions{
 		NodeID: nodeID,
 		Clusters: []*v3clusterpb.Cluster{
 			makeAggregateClusterResource(clusterA, []string{clusterB, clusterD}),
-			// e2e.DefaultCluster(clusterC, serviceName, e2e.SecurityLevelNone),
 		},
 		SkipValidation: true,
 	}

--- a/xds/internal/balancer/cdsbalancer/aggregate_cluster_test.go
+++ b/xds/internal/balancer/cdsbalancer/aggregate_cluster_test.go
@@ -876,9 +876,6 @@ func (s) TestWatchers(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
-	// Start a test service backend.
-	server := stubserver.StartTestService(t, nil)
-	t.Cleanup(server.Stop)
 
 	const (
 		clusterA = clusterName

--- a/xds/internal/balancer/cdsbalancer/cdsbalancer.go
+++ b/xds/internal/balancer/cdsbalancer/cdsbalancer.go
@@ -541,7 +541,6 @@ func (b *cdsBalancer) onClusterUpdate(name string, update xdsresource.ClusterUpd
 			delete(b.watchers, cluster)
 		}
 	}
-	onwatcherUpdated()
 }
 
 // Handles an ambient error Cluster update from the xDS client to not stop

--- a/xds/internal/balancer/cdsbalancer/cdsbalancer.go
+++ b/xds/internal/balancer/cdsbalancer/cdsbalancer.go
@@ -443,11 +443,6 @@ func (b *cdsBalancer) annotateErrorWithNodeID(err error) error {
 	return fmt.Errorf("[xDS node id: %v]: %w", nodeID, err)
 }
 
-var onwatcherUpdated = func() {
-	// This function is a no-op, but can be overridden in tests to signal that
-	// the watchers map has been updated.
-}
-
 // Handles a good Cluster update from the xDS client. Kicks off the discovery
 // mechanism generation process from the top-level cluster and if the cluster
 // graph is resolved, generates child policy config and pushes it down.

--- a/xds/internal/balancer/cdsbalancer/cdsbalancer_test.go
+++ b/xds/internal/balancer/cdsbalancer/cdsbalancer_test.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/balancer"
@@ -85,7 +86,9 @@ func waitForResourceNames(ctx context.Context, resourceNamesCh chan []string, wa
 		select {
 		case <-ctx.Done():
 		case gotNames := <-resourceNamesCh:
-			if cmp.Equal(gotNames, wantNames) {
+			// Sort both slices before comparing them, as the order of clusters
+			// does not matter.
+			if cmp.Equal(gotNames, wantNames, cmpopts.SortSlices(func(a, b string) bool { return a < b })) {
 				return nil
 			}
 		}

--- a/xds/internal/balancer/cdsbalancer/cdsbalancer_test.go
+++ b/xds/internal/balancer/cdsbalancer/cdsbalancer_test.go
@@ -154,15 +154,15 @@ func registerWrappedClusterResolverPolicy(t *testing.T) (chan serviceconfig.Load
 // built policy available to the test to directly invoke any balancer methods.
 //
 // Returns a channel on which the newly built cds LB policy is written to.
-func registerWrappedCDSPolicy(t *testing.T) chan balancer.Balancer {
+func registerWrappedCDSPolicy(t *testing.T) chan *cdsBalancer {
 	cdsBuilder := balancer.Get(cdsName)
 	internal.BalancerUnregister(cdsBuilder.Name())
-	cdsBalancerCh := make(chan balancer.Balancer, 1)
+	cdsBalancerCh := make(chan *cdsBalancer, 1)
 	stub.Register(cdsBuilder.Name(), stub.BalancerFuncs{
 		Init: func(bd *stub.BalancerData) {
 			bal := cdsBuilder.Build(bd.ClientConn, bd.BuildOptions)
 			bd.ChildBalancer = bal
-			cdsBalancerCh <- bal
+			cdsBalancerCh <- bal.(*cdsBalancer)
 		},
 		ParseConfig: func(lbCfg json.RawMessage) (serviceconfig.LoadBalancingConfig, error) {
 			return cdsBuilder.(balancer.ConfigParser).ParseConfig(lbCfg)
@@ -1070,7 +1070,8 @@ func (s) TestClose(t *testing.T) {
 // Tests that calling ExitIdle on the cds LB policy results in the call being
 // propagated to the child policy.
 func (s) TestExitIdle(t *testing.T) {
-	cdsBalancerCh := registerWrappedCDSPolicy(t)
+	cdsBalancerCh :=
+		registerWrappedCDSPolicy(t)
 	_, _, exitIdleCh, _ := registerWrappedClusterResolverPolicy(t)
 	mgmtServer, nodeID, cc, _, _, _, _ := setupWithManagementServer(t)
 


### PR DESCRIPTION
RELEASE NOTES: 
- xds/cdsbalancer: Fixes panic in cdsBalancer by correctly removing cds watchers for clusters no longer in the cluster tree.

In the code for `onClusterUpdate` after the cluster tree has been updated, we want to remove the watchers for clusters that are not currently in the tree. The existing [code](https://github.com/grpc/grpc-go/blob/aa57e6af6cbc8e1285315b338b092420f014c732/xds/internal/balancer/cdsbalancer/cdsbalancer.go#L533C2-L540C3) will always panic because of the error in condition. This change fixes the removal of unwanted watchers.