### PR TITLE
xds: client outlier detection metrics [A91]

### DIFF
--- a/xds/internal/balancer/outlierdetection/balancer.go
+++ b/xds/internal/balancer/outlierdetection/balancer.go
@@ -65,7 +65,7 @@ var (
 
 	ejectionsUnenforcedMetric = estats.RegisterInt64Count(estats.MetricDescriptor{
 		Name:           "grpc.lb.outlier_detection.ejections_unenforced",
-		Description:    "EXPERIMENTAL. Unenforced outlier ejections due to either max ejection percentage or enforcement_percentage",
+		Description:    "EXPERIMENTAL. Number of unenforced outlier ejections due to either max ejection percentage or enforcement_percentage",
 		Unit:           "ejection",
 		Labels:         []string{"grpc.target", "grpc.lb.outlier_detection.detection_method", "grpc.lb.outlier_detection.unenforced_reason"},
 		OptionalLabels: []string{"grpc.lb.backend_service"},

--- a/xds/internal/balancer/outlierdetection/balancer.go
+++ b/xds/internal/balancer/outlierdetection/balancer.go
@@ -161,7 +161,7 @@ func (bb) Name() string {
 // extractBackendService extracts the backend service from resolver state attributes.
 // This is a placeholder implementation - the actual extraction logic should be
 // implemented based on the specific resolver attributes available.
-func extractBackendService(state resolver.State) string {
+func extractBackendService(resolver.State) string {
 	// TODO: Implement backend service extraction from resolver attributes per A89 and A75
 	// For now, return empty string as this is optional
 	return ""

--- a/xds/internal/balancer/outlierdetection/balancer.go
+++ b/xds/internal/balancer/outlierdetection/balancer.go
@@ -91,7 +91,6 @@ func (bb) Build(cc balancer.ClientConn, bOpts balancer.BuildOptions) balancer.Ba
 		endpoints:       resolver.NewEndpointMap[*endpointInfo](),
 		metricsRecorder: cc.MetricsRecorder(),
 		target:          bOpts.Target.String(),
-		backendService:  "", // Will be set in UpdateClientConnState
 	}
 	b.logger = prefixLogger(b)
 	b.logger.Infof("Created")

--- a/xds/internal/balancer/outlierdetection/balancer.go
+++ b/xds/internal/balancer/outlierdetection/balancer.go
@@ -56,7 +56,7 @@ const Name = "outlier_detection_experimental"
 var (
 	ejectionsEnforcedMetric = estats.RegisterInt64Count(estats.MetricDescriptor{
 		Name:           "grpc.lb.outlier_detection.ejections_enforced",
-		Description:    "EXPERIMENTAL. Enforced outlier ejections by detection method",
+		Description:    "EXPERIMENTAL. Number of outlier ejections enforced by detection method",
 		Unit:           "ejection",
 		Labels:         []string{"grpc.target", "grpc.lb.outlier_detection.detection_method"},
 		OptionalLabels: []string{"grpc.lb.backend_service"},

--- a/xds/internal/balancer/outlierdetection/balancer_test.go
+++ b/xds/internal/balancer/outlierdetection/balancer_test.go
@@ -762,7 +762,7 @@ func (s) TestUpdateAddresses(t *testing.T) {
 	defer cancel()
 
 	// Transition SubConns to READY so that they can register a health listener.
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		select {
 		case <-ctx.Done():
 			t.Fatalf("Timed out waiting for creation of new SubConn.")
@@ -1114,7 +1114,7 @@ func (s) TestEjectUnejectSuccessRate(t *testing.T) {
 
 	// Transition the SubConns to READY so that they can register health
 	// listeners.
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		select {
 		case <-ctx.Done():
 			t.Fatalf("Timed out waiting for creation of new SubConn.")
@@ -1380,7 +1380,7 @@ func (s) TestEjectFailureRate(t *testing.T) {
 
 	// Transition the SubConns to READY so that they can register health
 	// listeners.
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		select {
 		case <-ctx.Done():
 			t.Fatal("Timed out waiting for creation of new SubConn.")

--- a/xds/internal/balancer/outlierdetection/balancer_test.go
+++ b/xds/internal/balancer/outlierdetection/balancer_test.go
@@ -46,6 +46,7 @@ import (
 	"google.golang.org/grpc/internal/stubserver"
 	"google.golang.org/grpc/internal/testutils"
 	"google.golang.org/grpc/internal/testutils/roundrobin"
+	"google.golang.org/grpc/internal/testutils/stats"
 	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/resolver"
 	"google.golang.org/grpc/resolver/manual"
@@ -761,7 +762,7 @@ func (s) TestUpdateAddresses(t *testing.T) {
 	defer cancel()
 
 	// Transition SubConns to READY so that they can register a health listener.
-	for range 2 {
+	for i := 0; i < 2; i++ {
 		select {
 		case <-ctx.Done():
 			t.Fatalf("Timed out waiting for creation of new SubConn.")
@@ -1113,7 +1114,7 @@ func (s) TestEjectUnejectSuccessRate(t *testing.T) {
 
 	// Transition the SubConns to READY so that they can register health
 	// listeners.
-	for range 3 {
+	for i := 0; i < 3; i++ {
 		select {
 		case <-ctx.Done():
 			t.Fatalf("Timed out waiting for creation of new SubConn.")
@@ -1159,6 +1160,9 @@ func (s) TestEjectUnejectSuccessRate(t *testing.T) {
 			}
 		}
 
+		// Create test metrics recorder
+		tmr := stats.NewTestMetricsRecorder()
+		od.metricsRecorder = tmr
 		od.intervalTimerAlgorithm()
 
 		// verify no StateListener() call on the child, as no addresses got
@@ -1167,6 +1171,9 @@ func (s) TestEjectUnejectSuccessRate(t *testing.T) {
 		defer cancel()
 		if _, err := scsCh.Receive(sCtx); err == nil {
 			t.Fatalf("no SubConn update should have been sent (no SubConn got ejected)")
+		}
+		if got, _ := tmr.Metric("grpc.lb.outlier_detection.ejections_enforced"); got != 0 {
+			t.Errorf("Metric grpc.lb.outlier_detection.ejections_enforced: got %v, want 0", got)
 		}
 
 		// Since no addresses are ejected, a SubConn update should forward down
@@ -1233,6 +1240,9 @@ func (s) TestEjectUnejectSuccessRate(t *testing.T) {
 		defer cancel()
 		if _, err := scsCh.Receive(sCtx); err == nil {
 			t.Fatalf("Only one SubConn update should have been sent (only one SubConn got ejected)")
+		}
+		if got, _ := tmr.Metric("grpc.lb.outlier_detection.ejections_enforced"); got != 1 {
+			t.Errorf("Metric grpc.lb.outlier_detection.ejections_enforced: got %v, want 1", got)
 		}
 
 		// Now that an address is ejected, SubConn updates for SubConns using
@@ -1370,7 +1380,7 @@ func (s) TestEjectFailureRate(t *testing.T) {
 
 	// Transition the SubConns to READY so that they can register health
 	// listeners.
-	for range 3 {
+	for i := 0; i < 3; i++ {
 		select {
 		case <-ctx.Done():
 			t.Fatal("Timed out waiting for creation of new SubConn.")
@@ -1414,12 +1424,20 @@ func (s) TestEjectFailureRate(t *testing.T) {
 				pi.Done(balancer.DoneInfo{})
 			}
 		}
+		tmr := stats.NewTestMetricsRecorder()
+		od.metricsRecorder = tmr
 
 		od.intervalTimerAlgorithm()
 		sCtx, cancel := context.WithTimeout(context.Background(), defaultTestShortTimeout)
 		defer cancel()
 		if _, err := scsCh.Receive(sCtx); err == nil {
 			t.Fatalf("no SubConn update should have been sent (no SubConn got ejected)")
+		}
+		if got, _ := tmr.Metric("grpc.lb.outlier_detection.ejections_enforced"); got != 0 {
+			t.Errorf("Metric grpc.lb.outlier_detection.ejections_enforced: got %v, want 0", got)
+		}
+		if got, _ := tmr.Metric("grpc.lb.outlier_detection.ejections_unenforced"); got != 0 {
+			t.Errorf("Metric grpc.lb.outlier_detection.ejections_unenforced: got %v, want 0", got)
 		}
 
 		// Set two upstream addresses to have five successes each, and one
@@ -1464,6 +1482,12 @@ func (s) TestEjectFailureRate(t *testing.T) {
 		defer cancel()
 		if _, err := scsCh.Receive(sCtx); err == nil {
 			t.Fatalf("Only one SubConn update should have been sent (only one SubConn got ejected)")
+		}
+		if got, _ := tmr.Metric("grpc.lb.outlier_detection.ejections_enforced"); got != 1 {
+			t.Errorf("Metric grpc.lb.outlier_detection.ejections_enforced: got %v, want 1", got)
+		}
+		if got, _ := tmr.Metric("grpc.lb.outlier_detection.ejections_unenforced"); got != 0 {
+			t.Errorf("Metric grpc.lb.outlier_detection.ejections_unenforced: got %v, want 0", got)
 		}
 
 		// upon the Outlier Detection balancer being reconfigured with a noop

--- a/xds/internal/balancer/outlierdetection/balancer_test.go
+++ b/xds/internal/balancer/outlierdetection/balancer_test.go
@@ -1175,6 +1175,9 @@ func (s) TestEjectUnejectSuccessRate(t *testing.T) {
 		if got, _ := tmr.Metric("grpc.lb.outlier_detection.ejections_enforced"); got != 0 {
 			t.Errorf("Metric grpc.lb.outlier_detection.ejections_enforced: got %v, want 0", got)
 		}
+		if got, _ := tmr.Metric("grpc.lb.outlier_detection.ejections_unenforced"); got != 0 {
+			t.Errorf("Metric grpc.lb.outlier_detection.ejections_unenforced: got %v, want 0", got)
+		}
 
 		// Since no addresses are ejected, a SubConn update should forward down
 		// to the child.
@@ -1243,6 +1246,9 @@ func (s) TestEjectUnejectSuccessRate(t *testing.T) {
 		}
 		if got, _ := tmr.Metric("grpc.lb.outlier_detection.ejections_enforced"); got != 1 {
 			t.Errorf("Metric grpc.lb.outlier_detection.ejections_enforced: got %v, want 1", got)
+		}
+		if got, _ := tmr.Metric("grpc.lb.outlier_detection.ejections_unenforced"); got != 0 {
+			t.Errorf("Metric grpc.lb.outlier_detection.ejections_unenforced: got %v, want 0", got)
 		}
 
 		// Now that an address is ejected, SubConn updates for SubConns using


### PR DESCRIPTION
Implements [A91](https://github.com/grpc/proposal/pull/478) in grpc-go

Two counters have been added according to the gRFC within the outlier detection algorithm on either ejections or unenforced ejection.

Currently, `grpc.lb.backend_service` is an optional label with an empty string as per the design until A89 and A75 are both implemented in grpc-go, after which the string can be updated for these metrics.

RELEASE NOTES:

- outlierdetection: add metrics for enforced (`grpc.lb.outlier_detection.ejections_enforced`) and unenforced (`grpc.lb.outlier_detection.ejections_unenforced`) outlier ejections.

## Tests

Updating existing outlier detection balancer tests to check if ejection stats are measured