### PR TITLE
server: allow 0s grpc-timeout header values, as java is known to be able to send them

### DIFF
--- a/internal/transport/http_util.go
+++ b/internal/transport/http_util.go
@@ -200,9 +200,6 @@ func decodeTimeout(s string) (time.Duration, error) {
 	if err != nil {
 		return 0, err
 	}
-	if t == 0 {
-		return 0, fmt.Errorf("transport: timeout must be positive: %q", s)
-	}
 	const maxHours = math.MaxInt64 / uint64(time.Hour)
 	if d == time.Hour && t > maxHours {
 		// This timeout would overflow math.MaxInt64; clamp it.

--- a/internal/transport/http_util_test.go
+++ b/internal/transport/http_util_test.go
@@ -56,9 +56,9 @@ func (s) TestDecodeTimeout(t *testing.T) {
 		{"1", 0, true},
 		{"", 0, true},
 		{"9a1S", 0, true},
-		{"0S", 0, true}, // PROTOCOL-HTTP2.md requires positive integers
-		{"00000000S", 0, true},
-		{"000000000S", 0, true},
+		{"0S", 0, false}, // PROTOCOL-HTTP2.md requires positive integers, but we allow it to timeout instead
+		{"00000000S", 0, false},
+		{"000000000S", 0, true}, // PROTOCOL-HTTP2.md allows at most 8 digits
 	} {
 		d, err := decodeTimeout(test.s)
 		gotErr := err != nil


### PR DESCRIPTION
https://github.com/grpc/grpc-java/pull/12201 was recently created to prevent this, but older versions will still do it.  This reverts our old behavior of allowing 0 second timeouts (pre- #8290).

I would propose that we do not revert the change in http_util and allow the RPC to instantly timeout instead of throw an internal error.

cc @ejona86 

RELEASE NOTES:
* server: allow 0s grpc-timeout header values, which older gRPC-Java versions could send