### PR TITLE
xds: give up pool lock before closing xdsclient channel

### DIFF
--- a/xds/internal/xdsclient/pool.go
+++ b/xds/internal/xdsclient/pool.go
@@ -241,6 +241,9 @@ func (p *Pool) clientRefCountedClose(name string) {
 	}
 	p.mu.Unlock()
 
+	// This attempts to close the transport to the management server and could
+	// theoretically call back into the xdsclient package again and deadlock.
+	// Hence, this needs to be called without holding the lock.
 	client.Close()
 
 	xdsClientImplCloseHook(name)

--- a/xds/internal/xdsclient/pool.go
+++ b/xds/internal/xdsclient/pool.go
@@ -227,7 +227,6 @@ func (p *Pool) clientRefCountedClose(name string) {
 	}
 	delete(p.clients, name)
 
-	client.Close()
 	for _, s := range client.bootstrapConfig.XDSServers() {
 		for _, f := range s.Cleanups() {
 			f()
@@ -241,6 +240,8 @@ func (p *Pool) clientRefCountedClose(name string) {
 		}
 	}
 	p.mu.Unlock()
+
+	client.Close()
 
 	xdsClientImplCloseHook(name)
 }


### PR DESCRIPTION
This prevents deadlocks with nested xds channels.

I believe this must be cherry-picked into the 1.74 release branch, too.

RELEASE NOTES: none