### PR TITLE
transport: release mutex before returning on expired deadlines in server streams

### DIFF
--- a/internal/transport/http2_server.go
+++ b/internal/transport/http2_server.go
@@ -602,6 +602,7 @@ func (t *http2Server) operateHeaders(ctx context.Context, frame *http2.MetaHeade
 	}
 
 	if s.ctx.Err() != nil {
+		t.mu.Unlock()
 		// Early abort in case the timeout was zero or so low it already fired.
 		t.controlBuf.put(&earlyAbortStream{
 			httpStatus:     http.StatusOK,


### PR DESCRIPTION
https://github.com/grpc/grpc-go/pull/8439 introduced the change to return early when the deadline has already expired. This causes the server mutex to be held forever. 

Example failure in CI: https://github.com/grpc/grpc-go/actions/runs/16282058322/job/45973508273?pr=8437

RELEASE NOTES: N/A