### PR TITLE
stats: add DelayedPickComplete which will ultimately replace PickerUpdated

### DIFF
--- a/stats/stats.go
+++ b/stats/stats.go
@@ -64,6 +64,15 @@ func (s *Begin) IsClient() bool { return s.Client }
 
 func (s *Begin) isRPCStats() {}
 
+// DelayedPickComplete indicates that the RPC is unblocked following a delay in
+// selecting a connection for the call.
+type DelayedPickComplete struct{}
+
+// IsClient indicates DelayedPickComplete is available on the client.
+func (*DelayedPickComplete) IsClient() bool { return true }
+
+func (*DelayedPickComplete) isRPCStats() {}
+
 // PickerUpdated indicates that the LB policy provided a new picker while the
 // RPC was waiting for one.
 type PickerUpdated struct{}


### PR DESCRIPTION
This is part of a multi-step change with the goal of eliminating the potentially-multiple calls for PickerUpdated as we do today.  Other languages only have a maximum of one event for this, which is that the pick finally completed, but in Go we implemented it as a call every time the picker was updated. The plan is to implement the full change as follows:

1. Add DelayedPickComplete (v1.x)
2. Start using DelayedPickComplete to emit events (v1.x+1)
3. Delete PickerUpdated (v1.x+2)

See https://github.com/grpc/grpc-go/compare/master...dfawley:picker_updated_no?expand=1 for the final planned state.

RELEASE NOTES:
* stats: introduce `DelayedPickComplete` event, to ultimately replace `PickerUpdated`.  It is never emitted yet, but when it is, it will be done at the same time as the _final_ `PickerUpdated` call.  A subsequent release will delete `PickerUpdated` events.  OpenTelemetry metrics at that time will no longer have multiple "Delayed LB pick complete" events in Go, matching other gRPC languages.