### PR TITLE
stats/opentelemetry: remove client retry attributes from server spans

### DIFF
--- a/stats/opentelemetry/e2e_test.go
+++ b/stats/opentelemetry/e2e_test.go
@@ -868,14 +868,6 @@ func (s) TestMetricsAndTracesOptionEnabled(t *testing.T) {
 					Key:   "FailFast",
 					Value: attribute.BoolValue(false),
 				},
-				{
-					Key:   "previous-rpc-attempts",
-					Value: attribute.IntValue(0),
-				},
-				{
-					Key:   "transparent-retry",
-					Value: attribute.BoolValue(false),
-				},
 			},
 			events: []trace.Event{
 				{
@@ -988,14 +980,6 @@ func (s) TestMetricsAndTracesOptionEnabled(t *testing.T) {
 				},
 				{
 					Key:   "FailFast",
-					Value: attribute.BoolValue(false),
-				},
-				{
-					Key:   "previous-rpc-attempts",
-					Value: attribute.IntValue(0),
-				},
-				{
-					Key:   "transparent-retry",
 					Value: attribute.BoolValue(false),
 				},
 			},
@@ -1092,14 +1076,6 @@ func (s) TestSpan(t *testing.T) {
 					Key:   "FailFast",
 					Value: attribute.BoolValue(false),
 				},
-				{
-					Key:   "previous-rpc-attempts",
-					Value: attribute.IntValue(0),
-				},
-				{
-					Key:   "transparent-retry",
-					Value: attribute.BoolValue(false),
-				},
 			},
 			events: []trace.Event{
 				{
@@ -1196,14 +1172,6 @@ func (s) TestSpan(t *testing.T) {
 				},
 				{
 					Key:   "FailFast",
-					Value: attribute.BoolValue(false),
-				},
-				{
-					Key:   "previous-rpc-attempts",
-					Value: attribute.IntValue(0),
-				},
-				{
-					Key:   "transparent-retry",
 					Value: attribute.BoolValue(false),
 				},
 			},
@@ -1302,14 +1270,6 @@ func (s) TestSpan_WithW3CContextPropagator(t *testing.T) {
 					Key:   "FailFast",
 					Value: attribute.BoolValue(false),
 				},
-				{
-					Key:   "previous-rpc-attempts",
-					Value: attribute.IntValue(0),
-				},
-				{
-					Key:   "transparent-retry",
-					Value: attribute.BoolValue(false),
-				},
 			},
 			events: []trace.Event{
 				{
@@ -1406,14 +1366,6 @@ func (s) TestSpan_WithW3CContextPropagator(t *testing.T) {
 				},
 				{
 					Key:   "FailFast",
-					Value: attribute.BoolValue(false),
-				},
-				{
-					Key:   "previous-rpc-attempts",
-					Value: attribute.IntValue(0),
-				},
-				{
-					Key:   "transparent-retry",
 					Value: attribute.BoolValue(false),
 				},
 			},
@@ -1766,8 +1718,6 @@ func (s) TestStreamingRPC_TraceSequenceNumbers(t *testing.T) {
 			attributes: []attribute.KeyValue{
 				attribute.Bool("Client", false),
 				attribute.Bool("FailFast", false),
-				attribute.Int("previous-rpc-attempts", 0),
-				attribute.Bool("transparent-retry", false),
 			},
 		},
 		{

--- a/stats/opentelemetry/trace.go
+++ b/stats/opentelemetry/trace.go
@@ -44,12 +44,17 @@ func populateSpan(rs stats.RPCStats, ai *attemptInfo) {
 		// Note: Go always added Client and FailFast attributes even though they are not
 		// defined by the OpenCensus gRPC spec. Thus, they are unimportant for
 		// correctness.
-		span.SetAttributes(
+		attrs := []attribute.KeyValue{
 			attribute.Bool("Client", rs.Client),
 			attribute.Bool("FailFast", rs.FailFast),
-			attribute.Int64("previous-rpc-attempts", int64(ai.previousRPCAttempts)),
-			attribute.Bool("transparent-retry", rs.IsTransparentRetryAttempt),
-		)
+		}
+		if rs.Client {
+			attrs = append(attrs,
+				attribute.Int64("previous-rpc-attempts", int64(ai.previousRPCAttempts)),
+				attribute.Bool("transparent-retry", rs.IsTransparentRetryAttempt),
+			)
+		}
+		span.SetAttributes(attrs...)
 		// increment previous rpc attempts applicable for next attempt
 		atomic.AddUint32(&ai.previousRPCAttempts, 1)
 	case *stats.PickerUpdated:


### PR DESCRIPTION
Fixes: https://github.com/grpc/grpc-go/issues/8430

RELEASE NOTES:

stats/opentelemetry: Removed client-specific retry attributes from server spans to align with tracing proposal A72.