### PR TITLE
advancedtls: avoid txt lookups in test and use test logger instead of Printf

### DIFF
--- a/security/advancedtls/crl_provider_test.go
+++ b/security/advancedtls/crl_provider_test.go
@@ -119,7 +119,7 @@ func (s) TestFileWatcherCRLProviderConfig(t *testing.T) {
 	tooFastRefreshProvider.Close()
 
 	customCallback := func(err error) {
-		fmt.Printf("Custom error message: %v", err)
+		t.Logf("Custom error message: %v", err)
 	}
 	regularProvider, err := NewFileWatcherCRLProvider(FileWatcherOptions{
 		CRLDirectory:               testdata.Path("crl"),


### PR DESCRIPTION
Fixes: #8468

This PR disables service configs in a flaking test. Using service configs results in a DNS lookup which may be the reason the test occasionally times out in CI. The test uses the target "localhost" to verify the server's TLS certificate. This change also avoids using deprecated `grpc.WithBlock` which is a no-op with `grpc.NewClient` and `fmt.Println` for debug logs in tests.

RELEASE NOTES: N/A