### PR TITLE
xdsClient: fix race in ReportLoad

### DIFF
--- a/xds/internal/xdsclient/clientimpl.go
+++ b/xds/internal/xdsclient/clientimpl.go
@@ -20,6 +20,7 @@ package xdsclient
 
 import (
 	"fmt"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -89,7 +90,9 @@ type clientImpl struct {
 	bootstrapConfig *bootstrap.Config
 	logger          *grpclog.PrefixLogger
 	target          string
-	lrsClient       *lrsclient.LRSClient
+
+	lrsClientMu sync.Mutex
+	lrsClient   *lrsclient.LRSClient
 
 	// Accessed atomically
 	refCount int32

--- a/xds/internal/xdsclient/clientimpl_loadreport.go
+++ b/xds/internal/xdsclient/clientimpl_loadreport.go
@@ -32,6 +32,8 @@ import (
 //
 // It returns a lrsclient.LoadStore for the user to report loads.
 func (c *clientImpl) ReportLoad(server *bootstrap.ServerConfig) (*lrsclient.LoadStore, func(context.Context)) {
+	c.lrsClientMu.Lock()
+	defer c.lrsClientMu.Unlock()
 	if c.lrsClient == nil {
 		lrsC, err := lrsclient.New(lrsclient.Config{
 			Node:             c.xdsClientConfig.Node,


### PR DESCRIPTION
During the recent migration to generic xdsClient , the ReportLoad() function was changed to use LRSClient instead of xdsChannel and it was not protected under a lock. This PR adds the lock for the LRSClient.

RELEASE NOTES: N/A