### PR TITLE
xds: allow empty nodeID in bootstrap configuration

### DIFF
--- a/xds/internal/clients/xdsclient/xdsclient.go
+++ b/xds/internal/clients/xdsclient/xdsclient.go
@@ -101,8 +101,6 @@ type XDSClient struct {
 // New returns a new xDS Client configured with the provided config.
 func New(config Config) (*XDSClient, error) {
 	switch {
-	case config.Node.ID == "":
-		return nil, errors.New("xdsclient: node ID is empty")
 	case config.ResourceTypes == nil:
 		return nil, errors.New("xdsclient: resource types map is nil")
 	case config.TransportBuilder == nil:

--- a/xds/internal/clients/xdsclient/xdsclient_test.go
+++ b/xds/internal/clients/xdsclient/xdsclient_test.go
@@ -37,11 +37,6 @@ func (s) TestXDSClient_New(t *testing.T) {
 		wantErr string
 	}{
 		{
-			name:    "empty node ID",
-			config:  Config{},
-			wantErr: "node ID is empty",
-		},
-		{
 			name: "nil resource types",
 			config: Config{
 				Node: clients.Node{ID: "node-id"},
@@ -69,6 +64,16 @@ func (s) TestXDSClient_New(t *testing.T) {
 			name: "success with servers",
 			config: Config{
 				Node:             clients.Node{ID: "node-id"},
+				ResourceTypes:    map[string]ResourceType{xdsresource.V3ListenerURL: listenerType},
+				TransportBuilder: grpctransport.NewBuilder(configs),
+				Servers:          []ServerConfig{{ServerIdentifier: clients.ServerIdentifier{ServerURI: "dummy-server"}}},
+			},
+			wantErr: "",
+		},
+		{
+			name: "success with servers and empty nodeID",
+			config: Config{
+				Node:             clients.Node{ID: ""},
 				ResourceTypes:    map[string]ResourceType{xdsresource.V3ListenerURL: listenerType},
 				TransportBuilder: grpctransport.NewBuilder(configs),
 				Servers:          []ServerConfig{{ServerIdentifier: clients.ServerIdentifier{ServerURI: "dummy-server"}}},


### PR DESCRIPTION
Fixes #8473

Matches the implementation of [grpc C++](https://github.com/grpc/grpc/blob/2ca9ac63ced7b77cf0eb885276fbedec1ab0bd10/src/core/xds/grpc/xds_bootstrap_grpc.cc#L67) and Envoy that makes the node ID optional.

RELEASE NOTES:
- xds: Revert to allowing empty node ID in xDS bootstrap configuration