### PR TITLE
interop/xds: Avoid setting unit suffixes

### DIFF
--- a/examples/features/csm_observability/client/main.go
+++ b/examples/features/csm_observability/client/main.go
@@ -50,7 +50,7 @@ var (
 
 func main() {
 	flag.Parse()
-	exporter, err := prometheus.New()
+	exporter, err := prometheus.New(prometheus.WithoutUnits())
 	if err != nil {
 		log.Fatalf("Failed to start prometheus exporter: %v", err)
 	}

--- a/examples/features/csm_observability/server/main.go
+++ b/examples/features/csm_observability/server/main.go
@@ -57,7 +57,7 @@ func (s *server) SayHello(_ context.Context, in *pb.HelloRequest) (*pb.HelloRepl
 
 func main() {
 	flag.Parse()
-	exporter, err := prometheus.New()
+	exporter, err := prometheus.New(prometheus.WithoutUnits())
 	if err != nil {
 		log.Fatalf("Failed to start prometheus exporter: %v", err)
 	}

--- a/examples/features/opentelemetry/client/main.go
+++ b/examples/features/opentelemetry/client/main.go
@@ -48,7 +48,7 @@ var (
 )
 
 func main() {
-	exporter, err := prometheus.New()
+	exporter, err := prometheus.New(prometheus.WithoutUnits())
 	if err != nil {
 		log.Fatalf("Failed to start prometheus exporter: %v", err)
 	}

--- a/examples/features/opentelemetry/server/main.go
+++ b/examples/features/opentelemetry/server/main.go
@@ -56,7 +56,7 @@ func (s *echoServer) UnaryEcho(_ context.Context, req *pb.EchoRequest) (*pb.Echo
 }
 
 func main() {
-	exporter, err := prometheus.New()
+	exporter, err := prometheus.New(prometheus.WithoutUnits())
 	if err != nil {
 		log.Fatalf("Failed to start prometheus exporter: %v", err)
 	}

--- a/interop/xds/client/client.go
+++ b/interop/xds/client/client.go
@@ -380,7 +380,7 @@ func parseRPCMetadata(rpcMetadataStr string, rpcs []string) []*rpcConfig {
 func main() {
 	flag.Parse()
 	if *enableCSMObservability {
-		exporter, err := prometheus.New()
+		exporter, err := prometheus.New(prometheus.WithoutUnits())
 		if err != nil {
 			logger.Fatalf("Failed to start prometheus exporter: %v", err)
 		}

--- a/interop/xds/server/server.go
+++ b/interop/xds/server/server.go
@@ -228,7 +228,7 @@ func xdsServingModeCallback(addr net.Addr, args xds.ServingModeChangeArgs) {
 func main() {
 	flag.Parse()
 	if *enableCSMObservability {
-		exporter, err := prometheus.New()
+		exporter, err := prometheus.New(prometheus.WithoutUnits())
 		if err != nil {
 			logger.Fatalf("Failed to start prometheus exporter: %v", err)
 		}


### PR DESCRIPTION
The prometheus exporter changed it's behaviour to add not standard unit suffixes to metrics: https://github.com/open-telemetry/opentelemetry-go/pull/6839. As a result `grpc_server_call_started_total` becomes `grpc_server_call_started_call_total`.

From the [release notes](https://github.com/open-telemetry/opentelemetry-go/releases/tag/v1.37.0):
> Changed handling of go.opentelemetry.io/otel/exporters/prometheus metric renaming to add unit suffixes when it doesn't match one of the pre-defined values in the unit suffix map. 

Similar fix in another project: https://github.com/pomerium/pomerium/pull/5749/files

## Tested
Verified by running the otel examples that the units are no longer part of the metric names.

RELEASE NOTES: N/A