### PR TITLE
stats: change non-standard units to annotations

### DIFF
--- a/balancer/pickfirst/pickfirstleaf/metrics_test.go
+++ b/balancer/pickfirst/pickfirstleaf/metrics_test.go
@@ -204,7 +204,7 @@ func (s) TestPickFirstMetricsE2E(t *testing.T) {
 		{
 			Name:        "grpc.lb.pick_first.connection_attempts_succeeded",
 			Description: "EXPERIMENTAL. Number of successful connection attempts.",
-			Unit:        "attempt",
+			Unit:        "{attempt}",
 			Data: metricdata.Sum[int64]{
 				DataPoints: []metricdata.DataPoint[int64]{
 					{
@@ -219,7 +219,7 @@ func (s) TestPickFirstMetricsE2E(t *testing.T) {
 		{
 			Name:        "grpc.lb.pick_first.connection_attempts_failed",
 			Description: "EXPERIMENTAL. Number of failed connection attempts.",
-			Unit:        "attempt",
+			Unit:        "{attempt}",
 			Data: metricdata.Sum[int64]{
 				DataPoints: []metricdata.DataPoint[int64]{
 					{
@@ -234,7 +234,7 @@ func (s) TestPickFirstMetricsE2E(t *testing.T) {
 		{
 			Name:        "grpc.lb.pick_first.disconnections",
 			Description: "EXPERIMENTAL. Number of times the selected subchannel becomes disconnected.",
-			Unit:        "disconnection",
+			Unit:        "{disconnection}",
 			Data: metricdata.Sum[int64]{
 				DataPoints: []metricdata.DataPoint[int64]{
 					{

--- a/balancer/pickfirst/pickfirstleaf/pickfirstleaf.go
+++ b/balancer/pickfirst/pickfirstleaf/pickfirstleaf.go
@@ -67,21 +67,21 @@ var (
 	disconnectionsMetric = expstats.RegisterInt64Count(expstats.MetricDescriptor{
 		Name:        "grpc.lb.pick_first.disconnections",
 		Description: "EXPERIMENTAL. Number of times the selected subchannel becomes disconnected.",
-		Unit:        "disconnection",
+		Unit:        "{disconnection}",
 		Labels:      []string{"grpc.target"},
 		Default:     false,
 	})
 	connectionAttemptsSucceededMetric = expstats.RegisterInt64Count(expstats.MetricDescriptor{
 		Name:        "grpc.lb.pick_first.connection_attempts_succeeded",
 		Description: "EXPERIMENTAL. Number of successful connection attempts.",
-		Unit:        "attempt",
+		Unit:        "{attempt}",
 		Labels:      []string{"grpc.target"},
 		Default:     false,
 	})
 	connectionAttemptsFailedMetric = expstats.RegisterInt64Count(expstats.MetricDescriptor{
 		Name:        "grpc.lb.pick_first.connection_attempts_failed",
 		Description: "EXPERIMENTAL. Number of failed connection attempts.",
-		Unit:        "attempt",
+		Unit:        "{attempt}",
 		Labels:      []string{"grpc.target"},
 		Default:     false,
 	})

--- a/balancer/rls/balancer.go
+++ b/balancer/rls/balancer.go
@@ -82,7 +82,7 @@ var (
 	cacheEntriesMetric = estats.RegisterInt64Gauge(estats.MetricDescriptor{
 		Name:        "grpc.lb.rls.cache_entries",
 		Description: "EXPERIMENTAL. Number of entries in the RLS cache.",
-		Unit:        "entry",
+		Unit:        "{entry}",
 		Labels:      []string{"grpc.target", "grpc.lb.rls.server_target", "grpc.lb.rls.instance_uuid"},
 		Default:     false,
 	})
@@ -96,21 +96,21 @@ var (
 	defaultTargetPicksMetric = estats.RegisterInt64Count(estats.MetricDescriptor{
 		Name:        "grpc.lb.rls.default_target_picks",
 		Description: "EXPERIMENTAL. Number of LB picks sent to the default target.",
-		Unit:        "pick",
+		Unit:        "{pick}",
 		Labels:      []string{"grpc.target", "grpc.lb.rls.server_target", "grpc.lb.rls.data_plane_target", "grpc.lb.pick_result"},
 		Default:     false,
 	})
 	targetPicksMetric = estats.RegisterInt64Count(estats.MetricDescriptor{
 		Name:        "grpc.lb.rls.target_picks",
 		Description: "EXPERIMENTAL. Number of LB picks sent to each RLS target. Note that if the default target is also returned by the RLS server, RPCs sent to that target from the cache will be counted in this metric, not in grpc.rls.default_target_picks.",
-		Unit:        "pick",
+		Unit:        "{pick}",
 		Labels:      []string{"grpc.target", "grpc.lb.rls.server_target", "grpc.lb.rls.data_plane_target", "grpc.lb.pick_result"},
 		Default:     false,
 	})
 	failedPicksMetric = estats.RegisterInt64Count(estats.MetricDescriptor{
 		Name:        "grpc.lb.rls.failed_picks",
 		Description: "EXPERIMENTAL. Number of LB picks failed due to either a failed RLS request or the RLS channel being throttled.",
-		Unit:        "pick",
+		Unit:        "{pick}",
 		Labels:      []string{"grpc.target", "grpc.lb.rls.server_target"},
 		Default:     false,
 	})

--- a/balancer/rls/metrics_test.go
+++ b/balancer/rls/metrics_test.go
@@ -90,7 +90,7 @@ func (s) TestRLSTargetPickMetric(t *testing.T) {
 		{
 			Name:        "grpc.lb.rls.target_picks",
 			Description: "EXPERIMENTAL. Number of LB picks sent to each RLS target. Note that if the default target is also returned by the RLS server, RPCs sent to that target from the cache will be counted in this metric, not in grpc.rls.default_target_picks.",
-			Unit:        "pick",
+			Unit:        "{pick}",
 			Data: metricdata.Sum[int64]{
 				DataPoints: []metricdata.DataPoint[int64]{
 					{
@@ -107,7 +107,7 @@ func (s) TestRLSTargetPickMetric(t *testing.T) {
 		{
 			Name:        "grpc.lb.rls.cache_entries",
 			Description: "EXPERIMENTAL. Number of entries in the RLS cache.",
-			Unit:        "entry",
+			Unit:        "{entry}",
 			Data: metricdata.Gauge[int64]{
 				DataPoints: []metricdata.DataPoint[int64]{
 					{
@@ -201,7 +201,7 @@ func (s) TestRLSDefaultTargetPickMetric(t *testing.T) {
 		{
 			Name:        "grpc.lb.rls.default_target_picks",
 			Description: "EXPERIMENTAL. Number of LB picks sent to the default target.",
-			Unit:        "pick",
+			Unit:        "{pick}",
 			Data: metricdata.Sum[int64]{
 				DataPoints: []metricdata.DataPoint[int64]{
 					{
@@ -218,7 +218,7 @@ func (s) TestRLSDefaultTargetPickMetric(t *testing.T) {
 		{
 			Name:        "grpc.lb.rls.cache_entries",
 			Description: "EXPERIMENTAL. Number of entries in the RLS cache.",
-			Unit:        "entry",
+			Unit:        "{entry}",
 			Data: metricdata.Gauge[int64]{
 				DataPoints: []metricdata.DataPoint[int64]{
 					{
@@ -299,7 +299,7 @@ func (s) TestRLSFailedRPCMetric(t *testing.T) {
 		{
 			Name:        "grpc.lb.rls.failed_picks",
 			Description: "EXPERIMENTAL. Number of LB picks failed due to either a failed RLS request or the RLS channel being throttled.",
-			Unit:        "pick",
+			Unit:        "{pick}",
 			Data: metricdata.Sum[int64]{
 				DataPoints: []metricdata.DataPoint[int64]{
 					{
@@ -315,7 +315,7 @@ func (s) TestRLSFailedRPCMetric(t *testing.T) {
 		{
 			Name:        "grpc.lb.rls.cache_entries",
 			Description: "EXPERIMENTAL. Number of entries in the RLS cache.",
-			Unit:        "entry",
+			Unit:        "{entry}",
 			Data: metricdata.Gauge[int64]{
 				DataPoints: []metricdata.DataPoint[int64]{
 					{

--- a/balancer/weightedroundrobin/balancer.go
+++ b/balancer/weightedroundrobin/balancer.go
@@ -60,7 +60,7 @@ var (
 	rrFallbackMetric = estats.RegisterInt64Count(estats.MetricDescriptor{
 		Name:           "grpc.lb.wrr.rr_fallback",
 		Description:    "EXPERIMENTAL. Number of scheduler updates in which there were not enough endpoints with valid weight, which caused the WRR policy to fall back to RR behavior.",
-		Unit:           "update",
+		Unit:           "{update}",
 		Labels:         []string{"grpc.target"},
 		OptionalLabels: []string{"grpc.lb.locality"},
 		Default:        false,
@@ -69,7 +69,7 @@ var (
 	endpointWeightNotYetUsableMetric = estats.RegisterInt64Count(estats.MetricDescriptor{
 		Name:           "grpc.lb.wrr.endpoint_weight_not_yet_usable",
 		Description:    "EXPERIMENTAL. Number of endpoints from each scheduler update that don't yet have usable weight information (i.e., either the load report has not yet been received, or it is within the blackout period).",
-		Unit:           "endpoint",
+		Unit:           "{endpoint}",
 		Labels:         []string{"grpc.target"},
 		OptionalLabels: []string{"grpc.lb.locality"},
 		Default:        false,
@@ -78,7 +78,7 @@ var (
 	endpointWeightStaleMetric = estats.RegisterInt64Count(estats.MetricDescriptor{
 		Name:           "grpc.lb.wrr.endpoint_weight_stale",
 		Description:    "EXPERIMENTAL. Number of endpoints from each scheduler update whose latest weight is older than the expiration period.",
-		Unit:           "endpoint",
+		Unit:           "{endpoint}",
 		Labels:         []string{"grpc.target"},
 		OptionalLabels: []string{"grpc.lb.locality"},
 		Default:        false,
@@ -86,7 +86,7 @@ var (
 	endpointWeightsMetric = estats.RegisterFloat64Histo(estats.MetricDescriptor{
 		Name:           "grpc.lb.wrr.endpoint_weights",
 		Description:    "EXPERIMENTAL. Weight of each endpoint, recorded on every scheduler update. Endpoints without usable weights will be recorded as weight 0.",
-		Unit:           "endpoint",
+		Unit:           "{endpoint}",
 		Labels:         []string{"grpc.target"},
 		OptionalLabels: []string{"grpc.lb.locality"},
 		Default:        false,

--- a/experimental/stats/metricregistry_test.go
+++ b/experimental/stats/metricregistry_test.go
@@ -52,7 +52,7 @@ func (s) TestPanic(t *testing.T) {
 		// set by the metric registry.
 		Name:        "simple counter",
 		Description: "number of times recorded on tests",
-		Unit:        "calls",
+		Unit:        "{call}",
 	}
 	RegisterInt64Count(desc)
 	RegisterInt64Gauge(desc)

--- a/stats/opentelemetry/client_metrics.go
+++ b/stats/opentelemetry/client_metrics.go
@@ -54,7 +54,7 @@ func (h *clientMetricsHandler) initializeMetrics() {
 		metrics = DefaultMetrics()
 	}
 
-	h.clientMetrics.attemptStarted = createInt64Counter(metrics.Metrics(), "grpc.client.attempt.started", meter, otelmetric.WithUnit("attempt"), otelmetric.WithDescription("Number of client call attempts started."))
+	h.clientMetrics.attemptStarted = createInt64Counter(metrics.Metrics(), "grpc.client.attempt.started", meter, otelmetric.WithUnit("{attempt}"), otelmetric.WithDescription("Number of client call attempts started."))
 	h.clientMetrics.attemptDuration = createFloat64Histogram(metrics.Metrics(), "grpc.client.attempt.duration", meter, otelmetric.WithUnit("s"), otelmetric.WithDescription("End-to-end time taken to complete a client call attempt."), otelmetric.WithExplicitBucketBoundaries(DefaultLatencyBounds...))
 	h.clientMetrics.attemptSentTotalCompressedMessageSize = createInt64Histogram(metrics.Metrics(), "grpc.client.attempt.sent_total_compressed_message_size", meter, otelmetric.WithUnit("By"), otelmetric.WithDescription("Compressed message bytes sent per client call attempt."), otelmetric.WithExplicitBucketBoundaries(DefaultSizeBounds...))
 	h.clientMetrics.attemptRcvdTotalCompressedMessageSize = createInt64Histogram(metrics.Metrics(), "grpc.client.attempt.rcvd_total_compressed_message_size", meter, otelmetric.WithUnit("By"), otelmetric.WithDescription("Compressed message bytes received per call attempt."), otelmetric.WithExplicitBucketBoundaries(DefaultSizeBounds...))

--- a/stats/opentelemetry/csm/observability_test.go
+++ b/stats/opentelemetry/csm/observability_test.go
@@ -523,7 +523,7 @@ func (s) TestXDSLabels(t *testing.T) {
 		{
 			Name:        "grpc.client.attempt.started",
 			Description: "Number of client call attempts started.",
-			Unit:        "attempt",
+			Unit:        "{attempt}",
 			Data: metricdata.Sum[int64]{
 				DataPoints: []metricdata.DataPoint[int64]{
 					{

--- a/stats/opentelemetry/e2e_test.go
+++ b/stats/opentelemetry/e2e_test.go
@@ -361,7 +361,7 @@ func (s) TestMethodAttributeFilter(t *testing.T) {
 		{
 			Name:        "grpc.client.attempt.started",
 			Description: "Number of client call attempts started.",
-			Unit:        "attempt",
+			Unit:        "{attempt}",
 			Data: metricdata.Sum[int64]{
 				DataPoints: []metricdata.DataPoint[int64]{
 					{
@@ -487,7 +487,7 @@ func (s) TestAllMetricsOneFunction(t *testing.T) {
 		{
 			Name:        "grpc.client.attempt.started",
 			Description: "Number of client call attempts started.",
-			Unit:        "attempt",
+			Unit:        "{attempt}",
 			Data: metricdata.Sum[int64]{
 				DataPoints: []metricdata.DataPoint[int64]{
 					{
@@ -510,7 +510,7 @@ func (s) TestAllMetricsOneFunction(t *testing.T) {
 		{
 			Name:        "grpc.server.call.started",
 			Description: "Number of server calls started.",
-			Unit:        "call",
+			Unit:        "{call}",
 			Data: metricdata.Sum[int64]{
 				DataPoints: []metricdata.DataPoint[int64]{
 					{
@@ -704,7 +704,7 @@ func (s) TestWRRMetrics(t *testing.T) {
 		{
 			Name:        "grpc.lb.wrr.rr_fallback",
 			Description: "EXPERIMENTAL. Number of scheduler updates in which there were not enough endpoints with valid weight, which caused the WRR policy to fall back to RR behavior.",
-			Unit:        "update",
+			Unit:        "{update}",
 			Data: metricdata.Sum[int64]{
 				DataPoints: []metricdata.DataPoint[int64]{
 					{
@@ -720,7 +720,7 @@ func (s) TestWRRMetrics(t *testing.T) {
 		{
 			Name:        "grpc.lb.wrr.endpoint_weight_not_yet_usable",
 			Description: "EXPERIMENTAL. Number of endpoints from each scheduler update that don't yet have usable weight information (i.e., either the load report has not yet been received, or it is within the blackout period).",
-			Unit:        "endpoint",
+			Unit:        "{endpoint}",
 			Data: metricdata.Sum[int64]{
 				DataPoints: []metricdata.DataPoint[int64]{
 					{
@@ -735,7 +735,7 @@ func (s) TestWRRMetrics(t *testing.T) {
 		{
 			Name:        "grpc.lb.wrr.endpoint_weights",
 			Description: "EXPERIMENTAL. Weight of each endpoint, recorded on every scheduler update. Endpoints without usable weights will be recorded as weight 0.",
-			Unit:        "endpoint",
+			Unit:        "{endpoint}",
 			Data: metricdata.Histogram[float64]{
 				DataPoints: []metricdata.HistogramDataPoint[float64]{
 					{
@@ -757,7 +757,7 @@ func (s) TestWRRMetrics(t *testing.T) {
 	eventuallyWantMetric := metricdata.Metrics{
 		Name:        "grpc.lb.wrr.endpoint_weight_stale",
 		Description: "EXPERIMENTAL. Number of endpoints from each scheduler update whose latest weight is older than the expiration period.",
-		Unit:        "endpoint",
+		Unit:        "{endpoint}",
 		Data: metricdata.Sum[int64]{
 			DataPoints: []metricdata.DataPoint[int64]{
 				{

--- a/stats/opentelemetry/internal/testutils/testutils.go
+++ b/stats/opentelemetry/internal/testutils/testutils.go
@@ -181,7 +181,7 @@ func MetricDataUnary(options MetricDataOptions) []metricdata.Metrics {
 		{
 			Name:        "grpc.client.attempt.started",
 			Description: "Number of client call attempts started.",
-			Unit:        "attempt",
+			Unit:        "{attempt}",
 			Data: metricdata.Sum[int64]{
 				DataPoints: []metricdata.DataPoint[int64]{
 					{
@@ -264,7 +264,7 @@ func MetricDataUnary(options MetricDataOptions) []metricdata.Metrics {
 		{
 			Name:        "grpc.server.call.started",
 			Description: "Number of server calls started.",
-			Unit:        "call",
+			Unit:        "{call}",
 			Data: metricdata.Sum[int64]{
 				DataPoints: []metricdata.DataPoint[int64]{
 					{
@@ -356,7 +356,7 @@ func MetricDataStreaming(options MetricDataOptions) []metricdata.Metrics {
 		{
 			Name:        "grpc.client.attempt.started",
 			Description: "Number of client call attempts started.",
-			Unit:        "attempt",
+			Unit:        "{attempt}",
 			Data: metricdata.Sum[int64]{
 				DataPoints: []metricdata.DataPoint[int64]{
 					{
@@ -439,7 +439,7 @@ func MetricDataStreaming(options MetricDataOptions) []metricdata.Metrics {
 		{
 			Name:        "grpc.server.call.started",
 			Description: "Number of server calls started.",
-			Unit:        "call",
+			Unit:        "{call}",
 			Data: metricdata.Sum[int64]{
 				DataPoints: []metricdata.DataPoint[int64]{
 					{
@@ -555,7 +555,7 @@ func MetricData(options MetricDataOptions) []metricdata.Metrics {
 		{
 			Name:        "grpc.client.attempt.started",
 			Description: "Number of client call attempts started.",
-			Unit:        "attempt",
+			Unit:        "{attempt}",
 			Data: metricdata.Sum[int64]{
 				DataPoints: []metricdata.DataPoint[int64]{
 					{
@@ -670,7 +670,7 @@ func MetricData(options MetricDataOptions) []metricdata.Metrics {
 		{
 			Name:        "grpc.server.call.started",
 			Description: "Number of server calls started.",
-			Unit:        "call",
+			Unit:        "{call}",
 			Data: metricdata.Sum[int64]{
 				DataPoints: []metricdata.DataPoint[int64]{
 					{

--- a/stats/opentelemetry/server_metrics.go
+++ b/stats/opentelemetry/server_metrics.go
@@ -54,7 +54,7 @@ func (h *serverMetricsHandler) initializeMetrics() {
 		metrics = DefaultMetrics()
 	}
 
-	h.serverMetrics.callStarted = createInt64Counter(metrics.Metrics(), "grpc.server.call.started", meter, otelmetric.WithUnit("call"), otelmetric.WithDescription("Number of server calls started."))
+	h.serverMetrics.callStarted = createInt64Counter(metrics.Metrics(), "grpc.server.call.started", meter, otelmetric.WithUnit("{call}"), otelmetric.WithDescription("Number of server calls started."))
 	h.serverMetrics.callSentTotalCompressedMessageSize = createInt64Histogram(metrics.Metrics(), "grpc.server.call.sent_total_compressed_message_size", meter, otelmetric.WithUnit("By"), otelmetric.WithDescription("Compressed message bytes sent per server call."), otelmetric.WithExplicitBucketBoundaries(DefaultSizeBounds...))
 	h.serverMetrics.callRcvdTotalCompressedMessageSize = createInt64Histogram(metrics.Metrics(), "grpc.server.call.rcvd_total_compressed_message_size", meter, otelmetric.WithUnit("By"), otelmetric.WithDescription("Compressed message bytes received per server call."), otelmetric.WithExplicitBucketBoundaries(DefaultSizeBounds...))
 	h.serverMetrics.callDuration = createFloat64Histogram(metrics.Metrics(), "grpc.server.call.duration", meter, otelmetric.WithUnit("s"), otelmetric.WithDescription("End-to-end time taken to complete a call from server transport's perspective."), otelmetric.WithExplicitBucketBoundaries(DefaultLatencyBounds...))

--- a/xds/internal/xdsclient/clientimpl.go
+++ b/xds/internal/xdsclient/clientimpl.go
@@ -57,21 +57,21 @@ var (
 	xdsClientResourceUpdatesValidMetric = estats.RegisterInt64Count(estats.MetricDescriptor{
 		Name:        "grpc.xds_client.resource_updates_valid",
 		Description: "A counter of resources received that were considered valid. The counter will be incremented even for resources that have not changed.",
-		Unit:        "resource",
+		Unit:        "{resource}",
 		Labels:      []string{"grpc.target", "grpc.xds.server", "grpc.xds.resource_type"},
 		Default:     false,
 	})
 	xdsClientResourceUpdatesInvalidMetric = estats.RegisterInt64Count(estats.MetricDescriptor{
 		Name:        "grpc.xds_client.resource_updates_invalid",
 		Description: "A counter of resources received that were considered invalid.",
-		Unit:        "resource",
+		Unit:        "{resource}",
 		Labels:      []string{"grpc.target", "grpc.xds.server", "grpc.xds.resource_type"},
 		Default:     false,
 	})
 	xdsClientServerFailureMetric = estats.RegisterInt64Count(estats.MetricDescriptor{
 		Name:        "grpc.xds_client.server_failure",
 		Description: "A counter of xDS servers going from healthy to unhealthy. A server goes unhealthy when we have a connectivity failure or when the ADS stream fails without seeing a response message, as per gRFC A57.",
-		Unit:        "failure",
+		Unit:        "{failure}",
 		Labels:      []string{"grpc.target", "grpc.xds.server"},
 		Default:     false,
 	})


### PR DESCRIPTION
gRPC Go has been specifying units as non-standard values such as `call` and `endpoint` instead of using annotations like `{call}`. Based on the [metric naming conventions](https://ucum.org/ucum#section-Grammar-of-Units-and-Unit-Terms:~:text=%C2%A76-,curly%20braces,-%E2%96%A01%20The%20full) anything enclosed in curly braces is an annotation and in the absence of a prefix, the unit is `1`. The gRPC docs also mention that non-standard units need to be enclosed in curly braces: https://grpc.io/docs/guides/opentelemetry-metrics/#per-call-metrics.

This bug was caught due to a regression in the otel prometheus exporter: https://github.com/grpc/grpc-go/pull/8479

RELEASE NOTES:
* stats: fixed metric unit formatting by enclosing non-standard units like `call` and `endpoint` in curly braces to comply with UCUM and gRPC OpenTelemetry guidelines.
