### PR TITLE
xds/internal:Removed Generic resource Decoder and added concrete functions.#8381

### DIFF
--- a/xds/internal/xdsclient/clientimpl.go
+++ b/xds/internal/xdsclient/clientimpl.go
@@ -29,7 +29,7 @@ import (
 	"google.golang.org/grpc/internal/grpclog"
 	"google.golang.org/grpc/internal/xds/bootstrap"
 	"google.golang.org/grpc/internal/xds/bootstrap/xdsbootstrap"
-	"google.golang.org/grpc/internal/xdsclient" 
+	"google.golang.org/grpc/internal/xdsclient"
 	"google.golang.org/grpc/internal/xdsclient/lrsclient"
 	"google.golang.org/grpc/internal/xdsclient/metrics"
 	"google.golang.org/grpc/internal/xdsclient/xdsresource"

--- a/xds/internal/xdsclient/clientimpl.go
+++ b/xds/internal/xdsclient/clientimpl.go
@@ -1,5 +1,4 @@
-// xdsresource/clientimpl.go
-/*
+*
 
  * Copyright 2022 gRPC authors.
  *
@@ -27,15 +26,17 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/backoff"
 	"google.golang.org/grpc/grpclog"
+	"google.golang.org/grpc/internal/grpclog"
 	"google.golang.org/grpc/internal/xds/bootstrap"
-	"google.golang.org/grpc/xds/internal/clients"
-	"google.golang.org/grpc/xds/internal/clients/lrsclient"
-	"google.golang.org/grpc/xds/internal/clients/xdsclient"
-	"google.golang.org/grpc/xds/internal/clients/xdsclient/metrics"
-	"google.golang.org/grpc/xds/internal/clients/xdsclient/xdsresource"
-	"google.golang.org/grpc/xds/internal/transport/grpctransport"
-	"google.golang.org/grpc/xds/internal/util/estats"
+	"google.golang.org/grpc/internal/xds/bootstrap/xdsbootstrap"
+	"google.golang.org/grpc/internal/xdsclient" 
+	"google.golang.org/grpc/internal/xdsclient/lrsclient"
+	"google.golang.org/grpc/internal/xdsclient/metrics"
+	"google.golang.org/grpc/internal/xdsclient/xdsresource"
+	"google.golang.org/grpc/internal/xds/transport/grpctransport"
+	"google.golang.org/grpc/internal/xds/util/estats"
 )
+
 
 const (
 	// NameForServer is the key for the XDS server in the map of configs.

--- a/xds/internal/xdsclient/xdsresource/cluster_resource_type.go
+++ b/xds/internal/xdsclient/xdsresource/cluster_resource_type.go
@@ -21,7 +21,6 @@ import (
 	"google.golang.org/grpc/internal/pretty"
 	"google.golang.org/grpc/internal/xds/bootstrap"
 	xdsclient "google.golang.org/grpc/xds/internal/clients/xdsclient"
-	"google.golang.org/grpc/xds/internal/xdsclient/xdsresource/version"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 )
@@ -30,20 +29,6 @@ const (
 	// ClusterResourceTypeName represents the transport agnostic name for the
 	// cluster resource.
 	ClusterResourceTypeName = "ClusterResource"
-)
-
-var (
-	// Compile time interface checks.
-	_ Type = clusterResourceType{}
-
-	// Singleton instantiation of the resource type implementation.
-	clusterType = clusterResourceType{
-		resourceTypeState: resourceTypeState{
-			typeURL:                    version.V3ClusterURL,
-			typeName:                   ClusterResourceTypeName,
-			allResourcesRequiredInSotW: true,
-		},
-	}
 )
 
 // clusterResourceType provides the resource-type specific functionality for a

--- a/xds/internal/xdsclient/xdsresource/endpoints_resource_type.go
+++ b/xds/internal/xdsclient/xdsresource/endpoints_resource_type.go
@@ -20,7 +20,6 @@ package xdsresource
 import (
 	"google.golang.org/grpc/internal/pretty"
 	xdsclient "google.golang.org/grpc/xds/internal/clients/xdsclient"
-	"google.golang.org/grpc/xds/internal/xdsclient/xdsresource/version"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 )
@@ -29,20 +28,6 @@ const (
 	// EndpointsResourceTypeName represents the transport agnostic name for the
 	// endpoint resource.
 	EndpointsResourceTypeName = "EndpointsResource"
-)
-
-var (
-	// Compile time interface checks.
-	_ Type = endpointsResourceType{}
-
-	// Singleton instantiation of the resource type implementation.
-	endpointsType = endpointsResourceType{
-		resourceTypeState: resourceTypeState{
-			typeURL:                    version.V3EndpointsURL,
-			typeName:                   "EndpointsResource",
-			allResourcesRequiredInSotW: false,
-		},
-	}
 )
 
 // endpointsResourceType provides the resource-type specific functionality for a

--- a/xds/internal/xdsclient/xdsresource/listener_resource_type.go
+++ b/xds/internal/xdsclient/xdsresource/listener_resource_type.go
@@ -23,7 +23,6 @@ import (
 	"google.golang.org/grpc/internal/pretty"
 	"google.golang.org/grpc/internal/xds/bootstrap"
 	xdsclient "google.golang.org/grpc/xds/internal/clients/xdsclient"
-	"google.golang.org/grpc/xds/internal/xdsclient/xdsresource/version"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 )
@@ -32,20 +31,6 @@ const (
 	// ListenerResourceTypeName represents the transport agnostic name for the
 	// listener resource.
 	ListenerResourceTypeName = "ListenerResource"
-)
-
-var (
-	// Compile time interface checks.
-	_ Type = listenerResourceType{}
-
-	// Singleton instantiation of the resource type implementation.
-	listenerType = listenerResourceType{
-		resourceTypeState: resourceTypeState{
-			typeURL:                    version.V3ListenerURL,
-			typeName:                   ListenerResourceTypeName,
-			allResourcesRequiredInSotW: true,
-		},
-	}
 )
 
 // listenerResourceType provides the resource-type specific functionality for a

--- a/xds/internal/xdsclient/xdsresource/resource_type.go
+++ b/xds/internal/xdsclient/xdsresource/resource_type.go
@@ -69,12 +69,10 @@ type Producer interface {
 type ResourceWatcher interface {
 	// ResourceChanged indicates a new version of the resource is available.
 	ResourceChanged(resourceData ResourceData, done func())
-
 	// ResourceError indicates an error occurred while trying to fetch or
 	// decode the associated resource. The previous version of the resource
 	// should be considered invalid.
 	ResourceError(err error, done func())
-
 	// AmbientError indicates an error occurred after a resource has been
 	// received that should not modify the use of that resource but may provide
 	// useful information about the state of the XDSClient for debugging
@@ -88,23 +86,18 @@ type ResourceWatcher interface {
 type Type interface {
 	// TypeURL is the xDS type URL of this resource type for v3 transport.
 	TypeURL() string
-
 	// TypeName identifies resources in a transport protocol agnostic way. This
 	// can be used for logging/debugging purposes, as well in cases where the
 	// resource type name is to be uniquely identified but the actual
 	// functionality provided by the resource type is not required.
-
 	TypeName() string
-
 	// AllResourcesRequiredInSotW indicates whether this resource type requires
 	// that all resources be present in every SotW response from the server. If
 	// true, a response that does not include a previously seen resource will be
 	// interpreted as a deletion of that resource.
 	AllResourcesRequiredInSotW() bool
-
 	// Decode deserializes and validates an xDS resource serialized inside the
 	// provided `Any` proto, as received from the xDS management server.
-	//
 	// If protobuf deserialization fails or resource validation fails,
 	// returns a non-nil error. Otherwise, returns a fully populated
 	// DecodeResult.
@@ -119,10 +112,8 @@ type ResourceData interface {
 	// RawEqual returns true if the passed in resource data is equal to that of
 	// the receiver, based on the underlying raw protobuf message.
 	RawEqual(ResourceData) bool
-
 	// ToJSON returns a JSON string representation of the resource data.
 	ToJSON() string
-
 	Raw() *anypb.Any
 	Bytes() []byte
 	Equal(xdsclient.ResourceData) bool
@@ -150,8 +141,7 @@ type DecodeResult struct {
 }
 
 // resourceTypeState wraps the static state associated with concrete resource
-// type implementations, which can then embed this struct and get the methods
-// implemented here for free.
+// type implementations, which can then embed this struct
 type resourceTypeState struct {
 	typeURL                    string
 	typeName                   string
@@ -176,7 +166,7 @@ func (r resourceTypeState) AllResourcesRequiredInSotW() bool {
 // Listener represents the internal data structure for a Listener resource.
 // Listener
 type Listener struct {
-	*v3listenerpb.Listener // Embedding the proto for simplicity in this example
+	*v3listenerpb.Listener
 }
 
 // RawEqual implements xdsresource.ResourceData.
@@ -190,12 +180,12 @@ func (l *Listener) RawEqual(other ResourceData) bool {
 
 // ToJSON implements xdsresource.ResourceData.
 func (l *Listener) ToJSON() string {
-	return l.Listener.String() // Or your actual JSON serialization logic
+	return l.Listener.String()
 }
 
 // Raw implements xdsresource.ResourceData.
 func (l *Listener) Raw() *anypb.Any {
-	any, _ := anypb.New(l.Listener) // Error ignored for brevity, handle in real code
+	any, _ := anypb.New(l.Listener)
 	return any
 }
 func (l *Listener) Bytes() []byte {

--- a/xds/internal/xdsclient/xdsresource/route_config_resource_type.go
+++ b/xds/internal/xdsclient/xdsresource/route_config_resource_type.go
@@ -20,7 +20,6 @@ package xdsresource
 import (
 	"google.golang.org/grpc/internal/pretty"
 	xdsclient "google.golang.org/grpc/xds/internal/clients/xdsclient"
-	"google.golang.org/grpc/xds/internal/xdsclient/xdsresource/version"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 )
@@ -29,20 +28,6 @@ const (
 	// RouteConfigTypeName represents the transport agnostic name for the
 	// route config resource.
 	RouteConfigTypeName = "RouteConfigResource"
-)
-
-var (
-	// Compile time interface checks.
-	_ Type = routeConfigResourceType{}
-
-	// Singleton instantiation of the resource type implementation.
-	routeConfigType = routeConfigResourceType{
-		resourceTypeState: resourceTypeState{
-			typeURL:                    version.V3RouteConfigURL,
-			typeName:                   "RouteConfigResource",
-			allResourcesRequiredInSotW: false,
-		},
-	}
 )
 
 // routeConfigResourceType provides the resource-type specific functionality for


### PR DESCRIPTION
[Fixes:8381](https://github.com/grpc/grpc-go/issues/8381) 

Release Notes: Removed the Generic Resource Decoder file and added four concrete functions(Listener,Cluster,Route config,End Points).
