### PR TITLE
deps: bump go version to 1.24

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: '1.25'
           cache-dependency-path: "**/go.sum"
 
       # Run the vet-proto checks.
@@ -45,32 +45,32 @@ jobs:
       matrix:
         include:
           - type: vet
-            goversion: '1.23'
+            goversion: '1.24'
 
           - type: extras
-            goversion: '1.24'
+            goversion: '1.25'
 
           - type: tests
-            goversion: '1.24'
+            goversion: '1.25'
 
           - type: tests
-            goversion: '1.24'
+            goversion: '1.25'
             testflags: -race
 
           - type: tests
-            goversion: '1.24'
+            goversion: '1.25'
             goarch: 386
 
           - type: tests
-            goversion: '1.24'
+            goversion: '1.25'
             goarch: arm64
             runner: ubuntu-24.04-arm
 
           - type: tests
-            goversion: '1.23'
+            goversion: '1.24'
 
           - type: tests
-            goversion: '1.24'
+            goversion: '1.25'
             testflags: -race
             grpcenv: 'GRPC_EXPERIMENTAL_ENABLE_NEW_PICK_FIRST=false'
 

--- a/cmd/protoc-gen-go-grpc/go.mod
+++ b/cmd/protoc-gen-go-grpc/go.mod
@@ -1,6 +1,6 @@
 module google.golang.org/grpc/cmd/protoc-gen-go-grpc
 
-go 1.23.0
+go 1.24.0
 
 require (
 	google.golang.org/grpc v1.70.0

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -1,6 +1,6 @@
 module google.golang.org/grpc/examples
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/cncf/xds/go v0.0.0-20250501225837-2ac532fd4443

--- a/gcp/observability/go.mod
+++ b/gcp/observability/go.mod
@@ -1,6 +1,6 @@
 module google.golang.org/grpc/gcp/observability
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go/logging v1.13.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module google.golang.org/grpc
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0

--- a/interop/observability/go.mod
+++ b/interop/observability/go.mod
@@ -1,6 +1,6 @@
 module google.golang.org/grpc/interop/observability
 
-go 1.23.0
+go 1.24.0
 
 require (
 	google.golang.org/grpc v1.73.0

--- a/interop/xds/go.mod
+++ b/interop/xds/go.mod
@@ -1,6 +1,6 @@
 module google.golang.org/grpc/interop/xds
 
-go 1.23.0
+go 1.24.0
 
 replace google.golang.org/grpc => ../..
 

--- a/scripts/vet.sh
+++ b/scripts/vet.sh
@@ -97,7 +97,7 @@ for MOD_FILE in $(find . -name 'go.mod'); do
   gofmt -s -d -l . 2>&1 | fail_on_output
   goimports -l . 2>&1 | not grep -vE "\.pb\.go"
 
-  go mod tidy -compat=1.23
+  go mod tidy -compat=1.24
   git status --porcelain 2>&1 | fail_on_output || \
     (git status; git --no-pager diff; exit 1)
 

--- a/security/advancedtls/examples/go.mod
+++ b/security/advancedtls/examples/go.mod
@@ -1,6 +1,6 @@
 module google.golang.org/grpc/security/advancedtls/examples
 
-go 1.23.0
+go 1.24.0
 
 require (
 	google.golang.org/grpc v1.73.0

--- a/security/advancedtls/go.mod
+++ b/security/advancedtls/go.mod
@@ -1,6 +1,6 @@
 module google.golang.org/grpc/security/advancedtls
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/stats/opencensus/go.mod
+++ b/stats/opencensus/go.mod
@@ -1,6 +1,6 @@
 module google.golang.org/grpc/stats/opencensus
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/test/tools/go.mod
+++ b/test/tools/go.mod
@@ -1,6 +1,6 @@
 module google.golang.org/grpc/test/tools
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/client9/misspell v0.3.4


### PR DESCRIPTION
It's generally useful to have new-and-improved Go. One specific useful feature is `b.Loop()`, which makes benchmarking easier.

Encountered while working on #8510, as I was using `b.Loop()` in my benchmarks.

RELEASE NOTES:
* Minimum supported Go version is now 1.24