### PR TITLE
alts: increase write record size max to 1MB

### DIFF
--- a/cmd/protoc-gen-go-grpc/go.mod
+++ b/cmd/protoc-gen-go-grpc/go.mod
@@ -1,6 +1,6 @@
 module google.golang.org/grpc/cmd/protoc-gen-go-grpc
 
-go 1.23.0
+go 1.24.0
 
 require (
 	google.golang.org/grpc v1.70.0

--- a/credentials/alts/internal/conn/common.go
+++ b/credentials/alts/internal/conn/common.go
@@ -19,9 +19,7 @@
 package conn
 
 import (
-	"encoding/binary"
 	"errors"
-	"fmt"
 )
 
 const (
@@ -47,34 +45,4 @@ func SliceForAppend(in []byte, n int) (head, tail []byte) {
 	}
 	tail = head[len(in):]
 	return head, tail
-}
-
-// ParseFramedMsg parse the provided buffer and returns a frame of the format
-// msgLength+msg and any remaining bytes in that buffer.
-func ParseFramedMsg(b []byte, maxLen uint32) ([]byte, []byte, error) {
-	// If the size field is not complete, return the provided buffer as
-	// remaining buffer.
-	length, sufficientBytes := parseMessageLength(b)
-	if !sufficientBytes {
-		return nil, b, nil
-	}
-	if length > maxLen {
-		return nil, nil, fmt.Errorf("received the frame length %d larger than the limit %d", length, maxLen)
-	}
-	if len(b) < int(length)+4 { // account for the first 4 msg length bytes.
-		// Frame is not complete yet.
-		return nil, b, nil
-	}
-	return b[:MsgLenFieldSize+length], b[MsgLenFieldSize+length:], nil
-}
-
-// parseMessageLength returns the message length based on frame header. It also
-// returns a boolean indicating if the buffer contains sufficient bytes to parse
-// the length header. If there are insufficient bytes, (0, false) is returned.
-func parseMessageLength(b []byte) (uint32, bool) {
-	if len(b) < MsgLenFieldSize {
-		return 0, false
-	}
-	msgLenField := b[:MsgLenFieldSize]
-	return binary.LittleEndian.Uint32(msgLenField), true
 }

--- a/credentials/alts/internal/conn/record_test.go
+++ b/credentials/alts/internal/conn/record_test.go
@@ -168,8 +168,8 @@ func (s) TestSmallReadBuffer(t *testing.T) {
 func testLargeMsg(t *testing.T, rp string) {
 	clientConn, serverConn := newConnPair(rp, nil, nil)
 	// msgLen is such that the length in the framing is larger than the
-	// default size of one frame.
-	msgLen := altsRecordDefaultLength - msgTypeFieldSize - clientConn.crypto.EncryptionOverhead() + 1
+	// max size of one frame.
+	msgLen := altsRecordLengthLimit - msgTypeFieldSize - clientConn.crypto.EncryptionOverhead() + 1
 	msg := make([]byte, msgLen)
 	if n, err := clientConn.Write(msg); n != len(msg) || err != nil {
 		t.Fatalf("Write() = %v, %v; want %v, <nil>", n, err, len(msg))
@@ -292,7 +292,7 @@ func testWriteLargeData(t *testing.T, rp string) {
 	clientConn, serverConn := newConnPair(rp, nil, nil)
 	// Message size is intentionally chosen to not be multiple of
 	// payloadLengthLimit.
-	msgSize := altsWriteBufferMaxSize + (100 * 1024)
+	msgSize := altsRecordLengthLimit + (100 * 1024)
 	clientMsg := make([]byte, msgSize)
 	for i := 0; i < msgSize; i++ {
 		clientMsg[i] = 0xAA

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -1,6 +1,6 @@
 module google.golang.org/grpc/examples
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/cncf/xds/go v0.0.0-20250501225837-2ac532fd4443

--- a/gcp/observability/go.mod
+++ b/gcp/observability/go.mod
@@ -1,6 +1,6 @@
 module google.golang.org/grpc/gcp/observability
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go/logging v1.13.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module google.golang.org/grpc
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0

--- a/interop/observability/go.mod
+++ b/interop/observability/go.mod
@@ -1,6 +1,6 @@
 module google.golang.org/grpc/interop/observability
 
-go 1.23.0
+go 1.24.0
 
 require (
 	google.golang.org/grpc v1.73.0

--- a/interop/xds/go.mod
+++ b/interop/xds/go.mod
@@ -1,6 +1,6 @@
 module google.golang.org/grpc/interop/xds
 
-go 1.23.0
+go 1.24.0
 
 replace google.golang.org/grpc => ../..
 

--- a/scripts/vet.sh
+++ b/scripts/vet.sh
@@ -97,7 +97,7 @@ for MOD_FILE in $(find . -name 'go.mod'); do
   gofmt -s -d -l . 2>&1 | fail_on_output
   goimports -l . 2>&1 | not grep -vE "\.pb\.go"
 
-  go mod tidy -compat=1.23
+  go mod tidy -compat=1.24
   git status --porcelain 2>&1 | fail_on_output || \
     (git status; git --no-pager diff; exit 1)
 

--- a/security/advancedtls/examples/go.mod
+++ b/security/advancedtls/examples/go.mod
@@ -1,6 +1,6 @@
 module google.golang.org/grpc/security/advancedtls/examples
 
-go 1.23.0
+go 1.24.0
 
 require (
 	google.golang.org/grpc v1.73.0

--- a/security/advancedtls/go.mod
+++ b/security/advancedtls/go.mod
@@ -1,6 +1,6 @@
 module google.golang.org/grpc/security/advancedtls
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/stats/opencensus/go.mod
+++ b/stats/opencensus/go.mod
@@ -1,6 +1,6 @@
 module google.golang.org/grpc/stats/opencensus
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/test/tools/go.mod
+++ b/test/tools/go.mod
@@ -1,6 +1,6 @@
 module google.golang.org/grpc/test/tools
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/client9/misspell v0.3.4


### PR DESCRIPTION
Increases large write speed by 9.62% per BenchmarkLargeMessage. Detailed
benchmarking numbers below.

Rather than use different sizes for the maximum read record, write
record, and write buffer, just use 1MB for all of them.

Using larger records reduces the amount of payload splitting and the
number of syscalls made by ALTS.

Part of https://github.com/grpc/grpc-go/issues/8510. SO_RCVLOWAT and TCP receive zerocopy are only effective
with larger payloads, and so ALTS can't be limiting payload sizes to 4
KiB. SO_RCVLOWAT and zerocopy are on the receive side, but for
benchmarking purposes we need ALTS to send large messages.

Note that this PR includes #8511. GitHub doesn't support proper commit chains / stacked PRs, so I'm doing this in several PRs with some (annoyingly) redundant commits. Let me know if this isn't a good workflow for you and I'll change things up.

Benchmarks:
```
$ benchstat large_msg_old.txt large_msg.txt
goos: linux
goarch: amd64
pkg: google.golang.org/grpc/credentials/alts/internal/conn
cpu: AMD Ryzen Threadripper PRO 3945WX 12-Cores
                │ large_msg_old.txt │           large_msg.txt           │
                │      sec/op       │   sec/op     vs base              │
LargeMessage-12         68.88m ± 1%   62.25m ± 0%  -9.62% (p=0.002 n=6)
```