### PR TITLE
alts: receive low watermark support

### DIFF
--- a/cmd/protoc-gen-go-grpc/go.mod
+++ b/cmd/protoc-gen-go-grpc/go.mod
@@ -1,6 +1,6 @@
 module google.golang.org/grpc/cmd/protoc-gen-go-grpc
 
-go 1.23.0
+go 1.24.0
 
 require (
 	google.golang.org/grpc v1.70.0

--- a/credentials/alts/internal/conn/common.go
+++ b/credentials/alts/internal/conn/common.go
@@ -19,9 +19,7 @@
 package conn
 
 import (
-	"encoding/binary"
 	"errors"
-	"fmt"
 )
 
 const (
@@ -47,34 +45,4 @@ func SliceForAppend(in []byte, n int) (head, tail []byte) {
 	}
 	tail = head[len(in):]
 	return head, tail
-}
-
-// ParseFramedMsg parse the provided buffer and returns a frame of the format
-// msgLength+msg and any remaining bytes in that buffer.
-func ParseFramedMsg(b []byte, maxLen uint32) ([]byte, []byte, error) {
-	// If the size field is not complete, return the provided buffer as
-	// remaining buffer.
-	length, sufficientBytes := parseMessageLength(b)
-	if !sufficientBytes {
-		return nil, b, nil
-	}
-	if length > maxLen {
-		return nil, nil, fmt.Errorf("received the frame length %d larger than the limit %d", length, maxLen)
-	}
-	if len(b) < int(length)+4 { // account for the first 4 msg length bytes.
-		// Frame is not complete yet.
-		return nil, b, nil
-	}
-	return b[:MsgLenFieldSize+length], b[MsgLenFieldSize+length:], nil
-}
-
-// parseMessageLength returns the message length based on frame header. It also
-// returns a boolean indicating if the buffer contains sufficient bytes to parse
-// the length header. If there are insufficient bytes, (0, false) is returned.
-func parseMessageLength(b []byte) (uint32, bool) {
-	if len(b) < MsgLenFieldSize {
-		return 0, false
-	}
-	msgLenField := b[:MsgLenFieldSize]
-	return binary.LittleEndian.Uint32(msgLenField), true
 }

--- a/credentials/alts/internal/conn/conn.go
+++ b/credentials/alts/internal/conn/conn.go
@@ -1,0 +1,26 @@
+//go:build !linux
+
+/*
+ *
+ * Copyright 2025 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package conn
+
+// SO_RCVLOWAT exists on non-Linux OSes, but we have't tested them.
+func (p *conn) setRcvlowat(length int) error {
+	return nil
+}

--- a/credentials/alts/internal/conn/conn_linux.go
+++ b/credentials/alts/internal/conn/conn_linux.go
@@ -1,0 +1,79 @@
+/*
+ *
+ * Copyright 2025 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package conn
+
+import (
+	"errors"
+
+	"golang.org/x/sys/unix"
+)
+
+// setRcvlowat updates SO_RCVLOWAT to reduce CPU usage.
+func (p *conn) setRcvlowat(length int) error {
+	if p.rawConn == nil {
+		return nil
+	}
+
+	const (
+		rcvlowatMax = 16 * 1024 * 1024
+		rcvlowatMin = 32 * 1024
+		rcvlowatGap = 16 * 1024
+	)
+
+	remaining := min(cap(p.protected), length, rcvlowatMax)
+
+	// Small SO_RCVLOWAT values don't actually save CPU.
+	if remaining < rcvlowatMin {
+		remaining = 0
+	}
+
+	// Allow for a small gap, which can wake us up a tiny bit early. This
+	// helps with latency, as bytes can arrive between wakeup and the
+	// ensuing read.
+	if remaining > 0 {
+		remaining -= rcvlowatGap
+	}
+
+	// Don't hold up the socket once we've hit our threshold.
+	if len(p.protected) > remaining {
+		remaining = 0
+	}
+
+	// Don't enable SO_RCVLOWAT if it's not useful.
+	if p.rcvlowat <= 1 && remaining <= 1 {
+		return nil
+	}
+
+	// Don't make a syscall if nothing changed.
+	if p.rcvlowat == remaining {
+		return nil
+	}
+
+	// Make the actual setsockopt call.
+	var sockoptErr error
+	err := p.rawConn.Control(func(fd uintptr) {
+		sockoptErr = unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_RCVLOWAT, p.rcvlowat)
+	})
+	if err != nil || sockoptErr != nil {
+		return errors.Join(err, sockoptErr)
+	}
+
+	p.rcvlowat = remaining
+	return nil
+}

--- a/credentials/alts/internal/conn/record.go
+++ b/credentials/alts/internal/conn/record.go
@@ -101,7 +101,7 @@ type conn struct {
 
 // NewConn creates a new secure channel instance given the other party role and
 // handshaking result.
-func NewConn(c net.Conn, side core.Side, recordProtocol string, key []byte, protected []byte) (net.Conn, error) {
+func NewConn(c net.Conn, side core.Side, recordProtocol string, key []byte, protected []byte, rcvlowat bool) (net.Conn, error) {
 	newCrypto := protocols[recordProtocol]
 	if newCrypto == nil {
 		return nil, fmt.Errorf("negotiated unknown next_protocol %q", recordProtocol)

--- a/credentials/alts/internal/conn/record_test.go
+++ b/credentials/alts/internal/conn/record_test.go
@@ -90,7 +90,7 @@ func newTestALTSRecordConn(in, out *bytes.Buffer, side core.Side, rp string, pro
 		in:  in,
 		out: out,
 	}
-	c, err := NewConn(&tc, side, rp, key, protected)
+	c, err := NewConn(&tc, side, rp, key, protected, false /* rcvlowat */)
 	if err != nil {
 		panic(fmt.Sprintf("Unexpected error creating test ALTS record connection: %v", err))
 	}

--- a/credentials/alts/internal/conn/record_test.go
+++ b/credentials/alts/internal/conn/record_test.go
@@ -168,8 +168,8 @@ func (s) TestSmallReadBuffer(t *testing.T) {
 func testLargeMsg(t *testing.T, rp string) {
 	clientConn, serverConn := newConnPair(rp, nil, nil)
 	// msgLen is such that the length in the framing is larger than the
-	// default size of one frame.
-	msgLen := altsRecordDefaultLength - msgTypeFieldSize - clientConn.crypto.EncryptionOverhead() + 1
+	// max size of one frame.
+	msgLen := altsRecordLengthLimit - msgTypeFieldSize - clientConn.crypto.EncryptionOverhead() + 1
 	msg := make([]byte, msgLen)
 	if n, err := clientConn.Write(msg); n != len(msg) || err != nil {
 		t.Fatalf("Write() = %v, %v; want %v, <nil>", n, err, len(msg))
@@ -292,7 +292,7 @@ func testWriteLargeData(t *testing.T, rp string) {
 	clientConn, serverConn := newConnPair(rp, nil, nil)
 	// Message size is intentionally chosen to not be multiple of
 	// payloadLengthLimit.
-	msgSize := altsWriteBufferMaxSize + (100 * 1024)
+	msgSize := altsRecordLengthLimit + (100 * 1024)
 	clientMsg := make([]byte, msgSize)
 	for i := 0; i < msgSize; i++ {
 		clientMsg[i] = 0xAA

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -1,6 +1,6 @@
 module google.golang.org/grpc/examples
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/cncf/xds/go v0.0.0-20250501225837-2ac532fd4443

--- a/gcp/observability/go.mod
+++ b/gcp/observability/go.mod
@@ -1,6 +1,6 @@
 module google.golang.org/grpc/gcp/observability
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go/logging v1.13.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module google.golang.org/grpc
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0

--- a/interop/alts/client/client.go
+++ b/interop/alts/client/client.go
@@ -35,6 +35,7 @@ import (
 var (
 	hsAddr     = flag.String("alts_handshaker_service_address", "", "ALTS handshaker gRPC service address")
 	serverAddr = flag.String("server_address", ":8080", "The port on which the server is listening")
+	rcvlowat   = flag.Bool("rcvlowat", false, "Enable use of SO_RCVLOWAT to reduce CPU usage")
 
 	logger = grpclog.Component("interop")
 )
@@ -46,6 +47,7 @@ func main() {
 	if *hsAddr != "" {
 		opts.HandshakerServiceAddress = *hsAddr
 	}
+	opts.EnableRcvlowat = *rcvlowat
 	altsTC := alts.NewClientCreds(opts)
 	conn, err := grpc.NewClient(*serverAddr, grpc.WithTransportCredentials(altsTC))
 	if err != nil {

--- a/interop/alts/server/server.go
+++ b/interop/alts/server/server.go
@@ -41,6 +41,7 @@ const (
 var (
 	hsAddr     = flag.String("alts_handshaker_service_address", "", "ALTS handshaker gRPC service address")
 	serverAddr = flag.String("server_address", ":8080", "The address on which the server is listening. Only two types of addresses are supported, 'host:port' and 'unix:/path'.")
+	rcvlowat   = flag.Bool("rcvlowat", false, "Enable use of SO_RCVLOWAT to reduce CPU usage")
 
 	logger = grpclog.Component("interop")
 )
@@ -63,6 +64,7 @@ func main() {
 	if *hsAddr != "" {
 		opts.HandshakerServiceAddress = *hsAddr
 	}
+	opts.EnableRcvlowat = *rcvlowat
 	altsTC := alts.NewServerCreds(opts)
 	grpcServer := grpc.NewServer(grpc.Creds(altsTC), grpc.InTapHandle(authz))
 	testgrpc.RegisterTestServiceServer(grpcServer, interop.NewTestServer())

--- a/interop/observability/go.mod
+++ b/interop/observability/go.mod
@@ -1,6 +1,6 @@
 module google.golang.org/grpc/interop/observability
 
-go 1.23.0
+go 1.24.0
 
 require (
 	google.golang.org/grpc v1.73.0

--- a/interop/xds/go.mod
+++ b/interop/xds/go.mod
@@ -1,6 +1,6 @@
 module google.golang.org/grpc/interop/xds
 
-go 1.23.0
+go 1.24.0
 
 replace google.golang.org/grpc => ../..
 

--- a/scripts/vet.sh
+++ b/scripts/vet.sh
@@ -97,7 +97,7 @@ for MOD_FILE in $(find . -name 'go.mod'); do
   gofmt -s -d -l . 2>&1 | fail_on_output
   goimports -l . 2>&1 | not grep -vE "\.pb\.go"
 
-  go mod tidy -compat=1.23
+  go mod tidy -compat=1.24
   git status --porcelain 2>&1 | fail_on_output || \
     (git status; git --no-pager diff; exit 1)
 

--- a/security/advancedtls/examples/go.mod
+++ b/security/advancedtls/examples/go.mod
@@ -1,6 +1,6 @@
 module google.golang.org/grpc/security/advancedtls/examples
 
-go 1.23.0
+go 1.24.0
 
 require (
 	google.golang.org/grpc v1.73.0

--- a/security/advancedtls/go.mod
+++ b/security/advancedtls/go.mod
@@ -1,6 +1,6 @@
 module google.golang.org/grpc/security/advancedtls
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/stats/opencensus/go.mod
+++ b/stats/opencensus/go.mod
@@ -1,6 +1,6 @@
 module google.golang.org/grpc/stats/opencensus
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/test/tools/go.mod
+++ b/test/tools/go.mod
@@ -1,6 +1,6 @@
 module google.golang.org/grpc/test/tools
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/client9/misspell v0.3.4


### PR DESCRIPTION
Reduce CPU usage significantly via `SO_RCVLOWAT`. There is a small
throughput penalty, so `SO_RCVLOWAT` is *not* enabled by default.
Users must turn it on via an option, as not everyone will want the
CPU/throughput tradeoff.

Part of #8510.

For large payloads, we see about a 36% reduction in CPU usage and a 2.5%
reduction in throughput. This is expected, and has been observed in the
C++ gRPC library as well. The expectation is that with TCP receive
zerocopy also enabled, we'll see both a reduction in CPU usage and an
increase in throughput. For users not using zerocopy, they can choose
whether the CPU/throughput tradeoff is worthwhile.

SO_RCVLOWAT is unused for small payloads, where its impact would be
insignificant (but would cost cycles to make syscalls). Enabling it in
grpc-go has no effect on CPU usage or throughput of small payloads, and
so is omitted from the below benchmarks so as not to water down the
impact on both CPU usage and throughput.

Benchmarks are of the ALTS layer alone.

Note that this PR includes #8512. GitHub doesn't support proper commit chains / stacked PRs, so I'm doing this in several PRs with some (annoyingly) redundant commits. Let me know if this isn't a good workflow for you and I'll change things up.

Benchmark numbers:
```
$ benchstat -col "/rcvlowat" -filter "/size:(64_KiB OR 512_KiB OR 1_MiB OR 4_MiB) .unit:(Mbps OR cpu-usec/op)" ~/lowat_numbers.txt
goos: linux
goarch: amd64
pkg: google.golang.org/grpc/credentials/alts/internal/conn
cpu: AMD Ryzen Threadripper PRO 3945WX 12-Cores
                         │   false    │               true               │
                         │    Mbps    │    Mbps     vs base              │
Rcvlowat/size=64_KiB-12    47.44 ± 0%   47.32 ± 0%  -0.24% (p=0.015 n=6)
Rcvlowat/size=512_KiB-12   299.2 ± 0%   293.6 ± 0%  -1.90% (p=0.002 n=6)
Rcvlowat/size=1_MiB-12     482.1 ± 0%   468.1 ± 0%  -2.88% (p=0.002 n=6)
Rcvlowat/size=4_MiB-12     887.4 ± 1%   842.3 ± 0%  -5.08% (p=0.002 n=6)
geomean                    279.1        272.0       -2.54%

                         │    false     │                true                │
                         │ cpu-usec/op  │ cpu-usec/op  vs base               │
Rcvlowat/size=64_KiB-12      992.2 ± 1%    666.1 ± 1%  -32.87% (p=0.002 n=6)
Rcvlowat/size=512_KiB-12    7.431k ± 1%   4.660k ± 0%  -37.30% (p=0.002 n=6)
Rcvlowat/size=1_MiB-12     14.720k ± 1%   9.192k ± 0%  -37.56% (p=0.002 n=6)
Rcvlowat/size=4_MiB-12      59.19k ± 1%   37.50k ± 3%  -36.64% (p=0.002 n=6)
geomean                     8.953k        5.719k       -36.12%
```