### PR TITLE
transport: handle 1xx HTTP status HEADERS at the client side

### DIFF
--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -1513,7 +1513,6 @@ func (t *http2Client) operateHeaders(frame *http2.MetaHeadersFrame) {
 					t.closeStream(s, se.Err(), true, http2.ErrCodeProtocol, se, nil, endStream)
 					return
 				}
-				return
 			}
 			httpStatusCode = &statusCode
 			if hf.Value == "200" {

--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -1509,16 +1509,14 @@ func (t *http2Client) operateHeaders(frame *http2.MetaHeadersFrame) {
 			if statusCode >= 100 && statusCode < 200 {
 				if endStream {
 					se := status.New(codes.Internal, fmt.Sprintf(
-						"protocol error: received 1xx informational header with END_STREAM set: %d", statusCode))
+						"protocol error: informational header with status code %d must not have END_STREAM set", statusCode))
 					t.closeStream(s, se.Err(), true, http2.ErrCodeProtocol, se, nil, endStream)
 				}
 				return
 			}
 			httpStatusCode = &statusCode
-			if hf.Value == "200" {
+			if statusCode == 200 {
 				httpStatusErr = ""
-				statusCode := 200
-				httpStatusCode = &statusCode
 				break
 			}
 

--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -1511,8 +1511,8 @@ func (t *http2Client) operateHeaders(frame *http2.MetaHeadersFrame) {
 					se := status.New(codes.Internal, fmt.Sprintf(
 						"protocol error: received 1xx informational header with END_STREAM set: %d", statusCode))
 					t.closeStream(s, se.Err(), true, http2.ErrCodeProtocol, se, nil, endStream)
-					return
 				}
+				return
 			}
 			httpStatusCode = &statusCode
 			if hf.Value == "200" {

--- a/internal/transport/transport_test.go
+++ b/internal/transport/transport_test.go
@@ -3155,7 +3155,7 @@ func (s) TestClientTransport_Handle1xxHeaders(t *testing.T) {
 	for _, test := range []struct {
 		name            string
 		metaHeaderFrame *http2.MetaHeadersFrame
-		endStreamFlag   http2.Flags
+		httpFlags       http2.Flags
 		wantStatus      *status.Status
 	}{
 		{
@@ -3165,7 +3165,7 @@ func (s) TestClientTransport_Handle1xxHeaders(t *testing.T) {
 					{Name: ":status", Value: "100"},
 				},
 			},
-			endStreamFlag: http2.FlagHeadersEndStream,
+			httpFlags: http2.FlagHeadersEndStream,
 			wantStatus: status.New(
 				codes.Internal,
 				"protocol error: informational header with status code 100 must not have END_STREAM set",
@@ -3178,8 +3178,8 @@ func (s) TestClientTransport_Handle1xxHeaders(t *testing.T) {
 					{Name: ":status", Value: "100"},
 				},
 			},
-			endStreamFlag: 0,
-			wantStatus:    nil,
+			httpFlags:  0,
+			wantStatus: nil,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -3189,7 +3189,7 @@ func (s) TestClientTransport_Handle1xxHeaders(t *testing.T) {
 			test.metaHeaderFrame.HeadersFrame = &http2.HeadersFrame{
 				FrameHeader: http2.FrameHeader{
 					StreamID: 0,
-					Flags:    test.endStreamFlag,
+					Flags:    test.httpFlags,
 				},
 			}
 
@@ -3199,7 +3199,7 @@ func (s) TestClientTransport_Handle1xxHeaders(t *testing.T) {
 			want := test.wantStatus
 
 			if got.Code() != want.Code() || got.Message() != want.Message() {
-				t.Fatalf("operateHeaders(%v); status = \ngot: %v\nwant: %v", test.metaHeaderFrame, got, want)
+				t.Fatalf("operateHeaders(%v); status = %v, want %v", test.metaHeaderFrame, got, want)
 			}
 		})
 	}

--- a/internal/transport/transport_test.go
+++ b/internal/transport/transport_test.go
@@ -3126,9 +3126,8 @@ func (s) TestServerSendsRSTAfterDeadlineToMisbehavedClient(t *testing.T) {
 	}
 }
 
-// TestClientTransport_Handle1xxHeaders validates that 1xx HTTP status
-// headers are ignored unless END_STREAM is also set, which results in a
-// protocol error.
+// TestClientTransport_Handle1xxHeaders validates that 1xx HTTP status headers
+// are ignored and treated as a protocol error if END_STREAM is set.
 func (s) TestClientTransport_Handle1xxHeaders(t *testing.T) {
 	testStream := func() *ClientStream {
 		return &ClientStream{


### PR DESCRIPTION
Fixes: https://github.com/grpc/grpc-go/issues/8485

RELEASE NOTES:
* client: Ignore http headers with status 1xx and `END_STREAM` flag unset.
* client: Fail RPCs with status `INTERNAL` instead of `UNKNOWN` on receiving http headers with status 1xx and  `END_STREAM` flag set.