### PR TITLE
xds/resolver_test: fix flaky test ResolverBadServiceUpdate_NACKedWithoutCache

### DIFF
--- a/internal/xds/resolver/xds_resolver_test.go
+++ b/internal/xds/resolver/xds_resolver_test.go
@@ -42,7 +42,6 @@ import (
 	"google.golang.org/grpc/internal/xds/balancer/clustermanager"
 	"google.golang.org/grpc/internal/xds/bootstrap"
 	"google.golang.org/grpc/internal/xds/httpfilter"
-
 	rinternal "google.golang.org/grpc/internal/xds/resolver/internal"
 	"google.golang.org/grpc/internal/xds/xdsclient"
 	"google.golang.org/grpc/internal/xds/xdsclient/xdsresource/version"
@@ -325,17 +324,15 @@ func (s) TestResolverBadServiceUpdate_NACKedWithoutCache(t *testing.T) {
 	// Build the resolver inline (duplicating buildResolverForTarget internals)
 	// to avoid issues with blocked channel writes when NACKs occur.
 	target := resolver.Target{URL: *testutils.MustParseURL("xds:///" + defaultTestServiceName)}
-	var builder resolver.Builder
-	if bc != nil {
-		// Create an xDS resolver with the provided bootstrap configuration.
-		if internal.NewXDSResolverWithConfigForTesting == nil {
-			t.Fatalf("internal.NewXDSResolverWithConfigForTesting is nil")
-		}
-		var err error
-		builder, err = internal.NewXDSResolverWithConfigForTesting.(func([]byte) (resolver.Builder, error))(bc)
-		if err != nil {
-			t.Fatalf("Failed to create xDS resolver for testing: %v", err)
-		}
+
+	// Create an xDS resolver with the provided bootstrap configuration.
+	if internal.NewXDSResolverWithConfigForTesting == nil {
+		t.Fatalf("internal.NewXDSResolverWithConfigForTesting is nil")
+	}
+
+	builder, err := internal.NewXDSResolverWithConfigForTesting.(func([]byte) (resolver.Builder, error))(bc)
+	if err != nil {
+		t.Fatalf("Failed to create xDS resolver for testing: %v", err)
 	}
 
 	errCh := testutils.NewChannel()


### PR DESCRIPTION
Fixes: #8435 

### root cause of issue:
- I think there was a race condition when channel communicates between the xDS resolver and test infrastructure
  - insufficient buffer size: original channels (stateCh and errCh) had only buffer size of 1
  - blocking sends: When buffer is full, the resolver would block trying to send the next update
  - test deadlock: test infra might be waiting for a specific update while the resolver was blocked trying to send a different update, creating a deadlock

### Changes
1) Increased buffer size (1 → 10):
``` go
  stateCh := make(chan resolver.State, 10)
  errCh := make(chan error, 10)
```

2) Non-blocking send pattern:
 ``` go
  select {
  case stateCh <- s:  // the resolver try to send updates
  default:            // If channel is full, drain old message and retry
      select {
      case <-stateCh:
          stateCh <- s
      default:
      }
  }
```
- make it drain old messages preventing the resolver from blocking and just keeping the most latest updates.

3) Cleanup with draining goroutines:
``` go
  go func() {
      for range stateCh { }  // Drain any remaining messages
  }()
```
- it ensures the resolver never blocks on sends and prevents `goroutine leaks` during test cleanup.


RELEASE NOTES: N/A