### PR TITLE
xds/xdsclient: Fix race in SetWatchExpiryTimeoutForTesting

### DIFF
--- a/internal/xds/clients/xdsclient/xdsclient.go
+++ b/internal/xds/clients/xdsclient/xdsclient.go
@@ -119,6 +119,9 @@ func New(config Config) (*XDSClient, error) {
 // SetWatchExpiryTimeoutForTesting override the default watch expiry timeout
 // with provided timeout value.
 func (c *XDSClient) SetWatchExpiryTimeoutForTesting(watchExpiryTimeout time.Duration) {
+	if watchExpiryTimeout <= 0 {
+		watchExpiryTimeout = defaultWatchExpiryTimeout
+	}
 	c.watchExpiryTimeout = watchExpiryTimeout
 }
 


### PR DESCRIPTION
Fixes: #8525 

RELEASE NOTES: None

There is a race in [SetWatchExpiryTimeoutForTesting](https://github.com/grpc/grpc-go/blob/fa0d6583208033fe4f69d359f80286736fd121d0/internal/xds/clients/xdsclient/xdsclient.go#L121) which is used to override the watch expiry timeout of XDSClient for testing. Currently it just sets the watchExpiryTimeout of the XDSClient to the provided value without a mutex each time we call [NewClientForTesting](https://github.com/grpc/grpc-go/blob/fa0d6583208033fe4f69d359f80286736fd121d0/internal/xds/xdsclient/pool.go#L116C16-L116C35) which might of might not create a new XDSClient if one is already there.

Fix :  Set WatcherExpiryTimeout only once if creating a new XDSClient by moving the function call to [`newRefCounted`](https://github.com/grpc/grpc-go/blob/fa0d6583208033fe4f69d359f80286736fd121d0/internal/xds/xdsclient/pool.go#L255)