### PR TITLE
Keepalive

### DIFF
--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -992,6 +992,11 @@ func (t *http2Client) Close(err error) {
 	if err := t.conn.SetWriteDeadline(time.Now().Add(time.Second * 10)); err != nil {
 		logger.Warningf("Failed to set write deadline on t.conn during Close(): %s", err)
 	}
+	// For background on the deadline value chosen here, see
+	// https://github.com/grpc/grpc-go/issues/8425#issuecomment-3057938248 .
+	if err := t.conn.SetReadDeadline(time.Now().Add(time.Second)); err != nil {
+		logger.Warningf("Failed to set read deadline on t.conn during Close(): %s", err)
+	}
 	t.mu.Lock()
 	// Make sure we only close once.
 	if t.state == closing {

--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -989,7 +989,9 @@ func (t *http2Client) closeStream(s *ClientStream, err error, rst bool, rstCode 
 // only once on a transport. Once it is called, the transport should not be
 // accessed anymore.
 func (t *http2Client) Close(err error) {
-	t.conn.SetWriteDeadline(time.Now().Add(time.Second * 10))
+	if err := t.conn.SetWriteDeadline(time.Now().Add(time.Second * 10)); err != nil {
+		logger.Warningf("Failed to set write deadline on t.conn during Close(): %s", err)
+	}
 	t.mu.Lock()
 	// Make sure we only close once.
 	if t.state == closing {


### PR DESCRIPTION
This PR adds a call to `net.Conn.SetWriteDeadline`, as discussed in https://github.com/grpc/grpc-go/issues/8425#issuecomment-3057938248. Additionally, it updates the previous call to `SetReadDeadline` to log any non-nil error value (this doesn't affect behavior but proved helpful in some earlier debugging).
