### PR TITLE
transport: avoid slice reallocation during header creation

### DIFF
--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -557,6 +557,12 @@ func (t *http2Client) createHeaderFields(ctx context.Context, callHdr *CallHdr) 
 	hfLen := 7 // :method, :scheme, :path, :authority, content-type, user-agent, te
 	hfLen += len(authData) + len(callAuthData)
 	registeredCompressors := t.registeredCompressors
+	if callHdr.PreviousAttempts > 0 {
+		hfLen++
+	}
+	if callHdr.SendCompress != "" {
+		hfLen++
+	}
 	if registeredCompressors != "" {
 		hfLen++
 	}


### PR DESCRIPTION
This PR improves the size estimate while pre-allocating `headerFields` to avoid reallocations, which pprof showed were responsible for ~4% of total memory allocations. This change improves performance, increasing QPS by 1% while reducing bytes/op by 4% and latencies by 0.3-4%.

## Tested
```sh
go run benchmark/benchresult/main.go unary-before unary-after       
unary-networkMode_Local-bufConn_false-keepalive_false-benchTime_1m0s-trace_false-latency_0s-kbps_0-MTU_0-maxConcurrentCalls_120-reqSiz
e_1024B-respSize_1024B-compressor_off-channelz_false-preloader_false-clientReadBufferSize_-1-clientWriteBufferSize_-1-serverReadBuffer
Size_-1-serverWriteBufferSize_-1-sleepBetweenRPCs_0s-connections_1-recvBufferPool_simple-sharedWriteBuffer_false
               Title       Before        After Percentage
            TotalOps      6327736      6390728     1.00%
             SendOps            0            0      NaN%
             RecvOps            0            0      NaN%
            Bytes/op     13903.23     13354.55    -3.95%
           Allocs/op       156.22       155.23    -0.64%
             ReqT/op 863946888.53 872547396.27     1.00%
            RespT/op 863946888.53 872547396.27     1.00%
            50th-Lat    1.00991ms   1.006914ms    -0.30%
            90th-Lat   1.678329ms   1.610331ms    -4.05%
            99th-Lat   2.517556ms   2.497122ms    -0.81%
             Avg-Lat   1.136117ms   1.125311ms    -0.95%
           GoVersion     go1.24.4     go1.24.4
         GrpcVersion   1.76.0-dev   1.76.0-dev
```

RELEASE NOTES:
* client: Improve header slice length estimate to reduce re-allocations.