### PR TITLE
GoogleC2P: remove dependency on metadata server for IPv6 node metadata

### DIFF
--- a/xds/googledirectpath/googlec2p.go
+++ b/xds/googledirectpath/googlec2p.go
@@ -184,7 +184,7 @@ func newNodeConfig(zone string, ipv6Capable bool) map[string]any {
 	}
 	if envconfig.NewPickFirstEnabled {
 		// Enable dualstack endpoints in TD.
-		// TODO(apolcyn): remove IPv6 metadata server queries entirely after old pick first is removed.
+		// TODO(https://github.com/grpc/grpc-go/issues/8561): remove IPv6 metadata server queries entirely after old pick first is removed.
 		ipv6Capable = true
 	} else {
 		logger.Infof("GRPC_EXPERIMENTAL_ENABLE_NEW_PICK_FIRST is disabled, setting ipv6Capable node metadata based on metadata server query")

--- a/xds/googledirectpath/googlec2p_test.go
+++ b/xds/googledirectpath/googlec2p_test.go
@@ -103,8 +103,8 @@ func useCleanUniverseDomain(t *testing.T) {
 	})
 }
 
-// TODO(apolcyn): this content can be hardcoded directly in wanted bootstraps again after
-// old pick first is fully removed.
+// TODO(https://github.com/grpc/grpc-go/issues/8561): this content can be hardcoded directly
+// in wanted bootstraps again after old pick first is removed.
 func expectedNodeJSON(ipv6Capable bool) []byte {
 	if !envconfig.NewPickFirstEnabled && !ipv6Capable {
 		return []byte(`{


### PR DESCRIPTION
Remove reliance on metadata server since it's result is no longer needed, hardcode IPv6 support in node metadata instead.

Related c++ change: https://github.com/grpc/grpc/pull/40571

Note we preserve prior behavior in case experiment `NewPickFirstEnabled` is disabled, because our testing/qualification has not covered that being disabled.

Related: internal issue b/407587619

RELEASE NOTES: n/a
