### PR TITLE
github,test: fix internal CI build

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-Thank you for your PR.  Please read and follow
+Thank you for your PR. Please read and follow
 https://github.com/grpc/grpc-go/blob/master/CONTRIBUTING.md, especially the
 "Guidelines for Pull Requests" section, and then delete this text before
 entering your PR description.

--- a/test/transport_test.go
+++ b/test/transport_test.go
@@ -240,7 +240,7 @@ func (s) TestCancelWhileServerWaitingForFlowControl(t *testing.T) {
 	serverDoneCh := make(chan struct{}, 2)
 	const flowControlWindowSize = 65535
 	ss := &stubserver.StubServer{
-		StreamingOutputCallF: func(_ *testpb.StreamingOutputCallRequest, stream testpb.TestService_StreamingOutputCallServer) error {
+		StreamingOutputCallF: func(_ *testpb.StreamingOutputCallRequest, stream testgrpc.TestService_StreamingOutputCallServer) error {
 			// Send a large message to exhaust the client's flow control window.
 			stream.Send(&testpb.StreamingOutputCallResponse{
 				Payload: &testpb.Payload{


### PR DESCRIPTION
Fix the following errors:
* only use one space to separate words
* use service codedgen import name for stream type

RELEASE NOTES: N/A