### PR TITLE
priority: use new-style atomic APIs

### DIFF
--- a/internal/xds/balancer/priority/ignore_resolve_now.go
+++ b/internal/xds/balancer/priority/ignore_resolve_now.go
@@ -34,7 +34,7 @@ type ignoreResolveNowClientConn struct {
 
 func newIgnoreResolveNowClientConn(cc balancer.ClientConn, ignore bool) *ignoreResolveNowClientConn {
 	ret := &ignoreResolveNowClientConn{ClientConn: cc}
-	ret.ignoreResolveNow.Store(ignore)
+	ret.updateIgnoreResolveNow(ignore)
 	return ret
 }
 

--- a/internal/xds/balancer/priority/ignore_resolve_now.go
+++ b/internal/xds/balancer/priority/ignore_resolve_now.go
@@ -33,10 +33,7 @@ type ignoreResolveNowClientConn struct {
 }
 
 func newIgnoreResolveNowClientConn(cc balancer.ClientConn, ignore bool) *ignoreResolveNowClientConn {
-	ret := &ignoreResolveNowClientConn{
-		ClientConn:       cc,
-		ignoreResolveNow: atomic.Bool{},
-	}
+	ret := &ignoreResolveNowClientConn{ClientConn: cc}
 	ret.ignoreResolveNow.Store(ignore)
 	return ret
 }


### PR DESCRIPTION
Use new-style atomic APIs instead of the old ones in the `ignoreResolveNowClientConn` type.

The changes made in this PR improve the code in the following ways:
* Ergonomics: Method-based API vs function-based, no pointer management needed
* Safety: Type safety prevents mixing atomic/non-atomic operations, eliminates pointer errors
* Clarity: The `atomic.Uint32` type makes atomic intent explicit from declaration

RELEASE NOTES: none