### PR TITLE
Revert "stats/opentelemetry: record retry attempts from clientStream (#8342)"

### DIFF
--- a/stats/opentelemetry/opentelemetry.go
+++ b/stats/opentelemetry/opentelemetry.go
@@ -179,9 +179,6 @@ type callInfo struct {
 	// nameResolutionEventAdded is set when the resolver delay trace event
 	// is added. Prevents duplicate events, since it is reported per-attempt.
 	nameResolutionEventAdded atomic.Bool
-	// previousRPCAttempts holds the count of RPC attempts that have happened
-	// before current attempt. Transparent retries are excluded.
-	previousRPCAttempts atomic.Uint32
 }
 
 type callInfoKey struct{}
@@ -242,8 +239,9 @@ type attemptInfo struct {
 	// message counters for sent and received messages (used for
 	// generating message IDs), and the number of previous RPC attempts for the
 	// associated call.
-	countSentMsg uint32
-	countRecvMsg uint32
+	countSentMsg        uint32
+	countRecvMsg        uint32
+	previousRPCAttempts uint32
 }
 
 type clientMetrics struct {

--- a/stats/opentelemetry/trace.go
+++ b/stats/opentelemetry/trace.go
@@ -17,6 +17,8 @@
 package opentelemetry
 
 import (
+	"sync/atomic"
+
 	"go.opentelemetry.io/otel/attribute"
 	otelcodes "go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
@@ -38,6 +40,18 @@ func populateSpan(rs stats.RPCStats, ai *attemptInfo) {
 	span := ai.traceSpan
 
 	switch rs := rs.(type) {
+	case *stats.Begin:
+		// Note: Go always added Client and FailFast attributes even though they are not
+		// defined by the OpenCensus gRPC spec. Thus, they are unimportant for
+		// correctness.
+		span.SetAttributes(
+			attribute.Bool("Client", rs.Client),
+			attribute.Bool("FailFast", rs.FailFast),
+			attribute.Int64("previous-rpc-attempts", int64(ai.previousRPCAttempts)),
+			attribute.Bool("transparent-retry", rs.IsTransparentRetryAttempt),
+		)
+		// increment previous rpc attempts applicable for next attempt
+		atomic.AddUint32(&ai.previousRPCAttempts, 1)
 	case *stats.DelayedPickComplete:
 		span.AddEvent("Delayed LB pick complete")
 	case *stats.InPayload:


### PR DESCRIPTION
This introduced flakiness in a test - Test/TraceSpan_WithRetriesAndNameResolutionDelay
Failure: https://github.com/grpc/grpc-go/actions/runs/17614152882/job/50042942932?pr=8547

Related issue: https://github.com/grpc/grpc-go/issues/8299

RELEASE NOTES: None
