### PR TITLE
internal/buffer: set closed flag when closing channel in the Load method

### DIFF
--- a/internal/buffer/unbounded.go
+++ b/internal/buffer/unbounded.go
@@ -83,6 +83,7 @@ func (b *Unbounded) Load() {
 		default:
 		}
 	} else if b.closing && !b.closed {
+		b.closed = true
 		close(b.c)
 	}
 }


### PR DESCRIPTION
## Description

This PR fixes a bug in the `Unbounded.Load()` method where the `closed` flag was not being set to `true` when the channel was closed.

## Problem

In the `Load()` method, when the condition `b.closing && !b.closed` is met, the code closes the channel but doesn't update the `closed` flag. This creates an inconsistent state where:
- The channel is closed (no more data can be sent)
- But `b.closed` remains `false`

This inconsistency could potentially cause issues in code that relies on the `closed` flag to determine the buffer's state.

## Solution

Added `b.closed = true` before `close(b.c)` in the `else if` branch of the `Load()` method to ensure the closed flag accurately reflects the buffer's state.

## Changes

- **File**: `internal/buffer/unbounded.go`
- **Method**: `Load()`
- **Line**: 86
- **Change**: Added `b.closed = true` before closing the channel

## Testing

- ✅ All existing tests pass
- ✅ No linter errors introduced
- ✅ The fix ensures consistent state between channel closure and closed flag

## Impact

This is a bug fix that improves the correctness of the `Unbounded` buffer implementation without changing its public API or behavior from a user perspective.


Fixes: https://github.com/grpc/grpc-go/issues/8572

RELEASE NOTES: None
