### PR TITLE
flowcontrol: change variable names for better understanding

### DIFF
--- a/internal/transport/flowcontrol.go
+++ b/internal/transport/flowcontrol.go
@@ -67,9 +67,9 @@ func (w *writeQuota) get(sz int32) error {
 
 func (w *writeQuota) realReplenish(n int) {
 	sz := int32(n)
-	a := atomic.AddInt32(&w.quota, sz)
-	b := a - sz
-	if b <= 0 && a > 0 {
+	newQuota := atomic.AddInt32(&w.quota, sz)
+	previousQuota := newQuota - sz
+	if previousQuota <= 0 && newQuota > 0 {
 		select {
 		case w.ch <- struct{}{}:
 		default:


### PR DESCRIPTION
## Description

This PR aims to improve some variable names for better understanding. Before the change, it took time for users to think about why there's a `b` variable.

RELEASE NOTES: N/A