### PR TITLE
credentials: Remove TODO from public godoc

### DIFF
--- a/credentials/credentials.go
+++ b/credentials/credentials.go
@@ -44,8 +44,7 @@ type PerRPCCredentials interface {
 	// A54). uri is the URI of the entry point for the request.  When supported
 	// by the underlying implementation, ctx can be used for timeout and
 	// cancellation. Additionally, RequestInfo data will be available via ctx
-	// to this call.  TODO(zhaoq): Define the set of the qualified keys instead
-	// of leaving it as an arbitrary string.
+	// to this call.
 	GetRequestMetadata(ctx context.Context, uri ...string) (map[string]string, error)
 	// RequireTransportSecurity indicates whether the credentials requires
 	// transport security.


### PR DESCRIPTION
The TODO comment with a Github user's name shows up in the [public godoc](https://pkg.go.dev/google.golang.org/grpc@v1.75.1/credentials#PerRPCCredentials). Since this is a stable API, changing it now doesn't seem feasible, so this change removes it completely.

RELEASE NOTES: N/A