### PR TITLE
client: Add error log for missing health package import during health check

### DIFF
--- a/balancer_wrapper.go
+++ b/balancer_wrapper.go
@@ -450,13 +450,14 @@ func (acbw *acBalancerWrapper) healthListenerRegFn() func(context.Context, func(
 	if acbw.ccb.cc.dopts.disableHealthCheck {
 		return noOpRegisterHealthListenerFn
 	}
+	cfg := acbw.ac.cc.healthCheckConfig()
+	if cfg == nil {
+		return noOpRegisterHealthListenerFn
+	}
 	regHealthLisFn := internal.RegisterClientHealthCheckListener
 	if regHealthLisFn == nil {
 		// The health package is not imported.
-		return noOpRegisterHealthListenerFn
-	}
-	cfg := acbw.ac.cc.healthCheckConfig()
-	if cfg == nil {
+		channelz.Error(logger, acbw.ac.channelz, "Health check is requested but health package is not imported.")
 		return noOpRegisterHealthListenerFn
 	}
 	return func(ctx context.Context, listener func(balancer.SubConnState)) func() {


### PR DESCRIPTION
Addresses: https://github.com/grpc/grpc-go/issues/8590

When using the health producer for health checks, and the health package is not imported by the application, a no op health producer is used without logging any errors. This PR adds an error log similar to the one for the old health checks started by the subchannel.

https://github.com/grpc/grpc-go/blob/e35080456c7071b6d55887080ef78809c163640c/clientconn.go#L1475-L1481

RELEASE NOTES: N/A