### PR TITLE
benchmark: Hold read+write lock while updating server state

### DIFF
--- a/benchmark/worker/benchmark_server.go
+++ b/benchmark/worker/benchmark_server.go
@@ -44,10 +44,11 @@ var (
 )
 
 type benchmarkServer struct {
-	port            int
-	cores           int
-	closeFunc       func()
-	mu              sync.RWMutex
+	port      int
+	cores     int
+	closeFunc func()
+
+	mu              sync.Mutex
 	lastResetTime   time.Time
 	rusageLastReset *syscall.Rusage
 }
@@ -168,8 +169,8 @@ func startBenchmarkServer(config *testpb.ServerConfig, serverPort int) (*benchma
 // getStats returns the stats for benchmark server.
 // It resets lastResetTime if argument reset is true.
 func (bs *benchmarkServer) getStats(reset bool) *testpb.ServerStats {
-	bs.mu.RLock()
-	defer bs.mu.RUnlock()
+	bs.mu.Lock()
+	defer bs.mu.Unlock()
 	wallTimeElapsed := time.Since(bs.lastResetTime).Seconds()
 	rusageLatest := syscall.GetRusage()
 	uTimeElapsed, sTimeElapsed := syscall.CPUTimeDiff(bs.rusageLastReset, rusageLatest)


### PR DESCRIPTION
The `lastResetTime` and `rusageLastReset ` fields in the `benchmarkServer` are written while holding a read lock. This can result in concurrent modifications. This change replaces the `RWMutex` with a regular `Mutex` to avoid such problems. This lock is acquired a couple of times during the entire test run, so contention is not a major concern.

RELEASE NOTES: N/A