### PR TITLE
xdsclient: improve fallback test involving three servers

### DIFF
--- a/internal/xds/clients/xdsclient/authority.go
+++ b/internal/xds/clients/xdsclient/authority.go
@@ -570,10 +570,6 @@ func (a *authority) handleRevertingToPrimaryOnUpdate(serverConfig *ServerConfig)
 		return true
 	}
 
-	if a.logger.V(2) {
-		a.logger.Infof("Received update from non-active server %q", serverConfig)
-	}
-
 	// If the resource update is not from the current active server, it means
 	// that we have received an update either from:
 	// - a server that has a higher priority than the current active server and
@@ -586,7 +582,13 @@ func (a *authority) handleRevertingToPrimaryOnUpdate(serverConfig *ServerConfig)
 	serverIdx := a.serverIndexForConfig(serverConfig)
 	activeServerIdx := a.serverIndexForConfig(a.activeXDSChannel.serverConfig)
 	if activeServerIdx < serverIdx {
+		if a.logger.V(2) {
+			a.logger.Infof("Ignoring update from lower priority server [%d] %q", serverIdx, serverConfig)
+		}
 		return false
+	}
+	if a.logger.V(2) {
+		a.logger.Infof("Received update from higher priority server [%d] %q", serverIdx, serverConfig)
 	}
 
 	// At this point, we are guaranteed that we have received a response from a
@@ -622,7 +624,7 @@ func (a *authority) handleRevertingToPrimaryOnUpdate(serverConfig *ServerConfig)
 		// Release the reference to the channel.
 		if cfg.cleanup != nil {
 			if a.logger.V(2) {
-				a.logger.Infof("Closing lower priority server %q", cfg.serverConfig)
+				a.logger.Infof("Closing lower priority server [%d] %q", i, cfg.serverConfig)
 			}
 			cfg.cleanup()
 			cfg.cleanup = nil


### PR DESCRIPTION
The existing fallback test that involves three servers is flaky. The reason for the flake is because some of the resources have the same name in different servers. The listener resource is expected to have the same name across the different management servers, but we generally expect the other resources to have different names.

See the following from the gRFC:
- In https://github.com/grpc/proposal/blob/master/A71-xds-fallback.md#reservations-about-using-the-fallback-server-data, we have the following:
```
We have no guarantee that a combination of resources from different xDS servers form a valid cohesive 
configuration, so we cannot make this determination on a per-resource basis. We need any given gRPC 
channel or server listener to only use the resources from a single server.
```
- In https://github.com/grpc/proposal/blob/master/A71-xds-fallback.md#config-tears, we have the following:
```
Config tears happen when the client winds up using some combination of resources from the primary and 
fallback servers at the same time, even though that combination of resources was never validated to work 
together. In theory, this can cause correctness issues where we might send traffic to the wrong location or 
the wrong way, or it can cause RPCs to fail. Note that this can happen only when the primary and fallback 
server use the same resource names.
```

This PR ensures that all the different management servers have different resource names for all resources except the listener. Also, ran the test on forge 100K times with no failures.

This PR also improves a couple of logs that I found useful when debugging the failures.

RELEASE NOTES: none