### PR TITLE
opentelemetry: Remove chatty log in client

### DIFF
--- a/stats/opentelemetry/client_metrics.go
+++ b/stats/opentelemetry/client_metrics.go
@@ -72,9 +72,6 @@ func (h *clientMetricsHandler) initializeMetrics() {
 func getOrCreateCallInfo(ctx context.Context, cc *grpc.ClientConn, method string, opts ...grpc.CallOption) (context.Context, *callInfo) {
 	ci := getCallInfo(ctx)
 	if ci == nil {
-		if logger.V(2) {
-			logger.Info("Creating new CallInfo since its not present in context")
-		}
 		ci = &callInfo{
 			target: cc.CanonicalTarget(),
 			method: determineMethod(method, opts...),


### PR DESCRIPTION
Removing this debug log to reduce noise. This log fires on every RPC call but provides no useful debugging value. The action it logs (adding callInfo to the context) is part of the normal flow, and the message contains no helpful variables.

RELEASE NOTES: N/A