### PR TITLE
pickfirstleaf: Fix shuffling of addresses in resolver updates without endpoints

### DIFF
--- a/balancer/pickfirst/pickfirst.go
+++ b/balancer/pickfirst/pickfirst.go
@@ -169,7 +169,7 @@ func (b *pickfirstBalancer) UpdateClientConnState(state balancer.ClientConnState
 		addrs = state.ResolverState.Addresses
 		if cfg.ShuffleAddressList {
 			addrs = append([]resolver.Address{}, addrs...)
-			rand.Shuffle(len(addrs), func(i, j int) { addrs[i], addrs[j] = addrs[j], addrs[i] })
+			internal.RandShuffle(len(addrs), func(i, j int) { addrs[i], addrs[j] = addrs[j], addrs[i] })
 		}
 	}
 

--- a/balancer/pickfirst/pickfirst_ext_test.go
+++ b/balancer/pickfirst/pickfirst_ext_test.go
@@ -483,15 +483,15 @@ func (s) TestPickFirst_ShuffleAddressListNoEndpoints(t *testing.T) {
 	}
 
 	pfBuilder := balancer.Get(pfbalancer.Name)
-	shffleConfig, err := pfBuilder.(balancer.ConfigParser).ParseConfig(json.RawMessage(`{ "shuffleAddressList": true }`))
+	shuffleConfig, err := pfBuilder.(balancer.ConfigParser).ParseConfig(json.RawMessage(`{ "shuffleAddressList": true }`))
 	if err != nil {
 		t.Fatal(err)
 	}
-	noShffleConfig, err := pfBuilder.(balancer.ConfigParser).ParseConfig(json.RawMessage(`{ "shuffleAddressList": false }`))
+	noShuffleConfig, err := pfBuilder.(balancer.ConfigParser).ParseConfig(json.RawMessage(`{ "shuffleAddressList": false }`))
 	if err != nil {
 		t.Fatal(err)
 	}
-	activeCfg := noShffleConfig
+	var activeCfg serviceconfig.LoadBalancingConfig
 
 	bf := stub.BalancerFuncs{
 		Init: func(bd *stub.BalancerData) {
@@ -518,7 +518,7 @@ func (s) TestPickFirst_ShuffleAddressListNoEndpoints(t *testing.T) {
 
 	// Push an update with both addresses and shuffling disabled.  We should
 	// connect to backend 0.
-	activeCfg = noShffleConfig
+	activeCfg = noShuffleConfig
 	resolverState := resolver.State{Addresses: addrs}
 	r.UpdateState(resolverState)
 	if err := pickfirst.CheckRPCsToBackend(ctx, cc, addrs[0]); err != nil {
@@ -527,7 +527,7 @@ func (s) TestPickFirst_ShuffleAddressListNoEndpoints(t *testing.T) {
 
 	// Send a config with shuffling enabled.  This will reverse the addresses,
 	// but the channel should still be connected to backend 0.
-	activeCfg = shffleConfig
+	activeCfg = shuffleConfig
 	r.UpdateState(resolverState)
 	if err := pickfirst.CheckRPCsToBackend(ctx, cc, addrs[0]); err != nil {
 		t.Fatal(err)

--- a/balancer/pickfirst/pickfirstleaf/pickfirstleaf.go
+++ b/balancer/pickfirst/pickfirstleaf/pickfirstleaf.go
@@ -283,7 +283,7 @@ func (b *pickfirstBalancer) UpdateClientConnState(state balancer.ClientConnState
 		newAddrs = state.ResolverState.Addresses
 		if cfg.ShuffleAddressList {
 			newAddrs = append([]resolver.Address{}, newAddrs...)
-			internal.RandShuffle(len(endpoints), func(i, j int) { endpoints[i], endpoints[j] = endpoints[j], endpoints[i] })
+			internal.RandShuffle(len(newAddrs), func(i, j int) { newAddrs[i], newAddrs[j] = newAddrs[j], newAddrs[i] })
 		}
 	}
 


### PR DESCRIPTION
The new `pick_first`, which is the default, doesn't shuffle the addresses at all for resolver updates that are missing the `Endpoints` field. This change fixes that. Since [gRPC automatically sets the the missing `Endpoints`](https://github.com/grpc/grpc-go/blob/1059e84f885bf7ed65b3b1a4fbe914360d8ab5b1/resolver_wrapper.go#L136-L138), occurrence of this bug should be uncommon in practice.

RELEASE NOTES:
* balancer/pick_first: When configured, shuffle addresses in resolver updates that lack endpoints. Since gRPC automatically adds endpoints to resolver updates, this bug should only affect implementers of custom LB policies that use pick_first for delegation but don't forward the endpoints.