### PR TITLE
examples/health: fix markdown formatting and improve content

### DIFF
--- a/examples/features/health/README.md
+++ b/examples/features/health/README.md
@@ -1,10 +1,13 @@
 # Health
 
-gRPC provides a health library to communicate a system's health to their clients.
-It works by providing a service definition via the [health/v1](https://github.com/grpc/grpc-proto/blob/master/grpc/health/v1/health.proto) api.
+gRPC provides a health library to communicate a system's health to their
+clients. It works by providing a service definition via the
+[health/v1](https://github.com/grpc/grpc-proto/blob/master/grpc/health/v1/health.proto)
+api.
 
-By using the health library, clients can gracefully avoid using servers as they encounter issues.
-Most languages provide an implementation out of box, making it interoperable between systems.
+Clients use the health library to gracefully avoid servers that encounter
+issues. Most languages provide an out-of-box implementation, which makes it
+interoperable between systems.
 
 ## Try it
 
@@ -21,13 +24,17 @@ go run client/main.go
 
 ### Client
 
-Clients have two ways to monitor a servers health.
-They can use `Check()` to probe a servers health or they can use `Watch()` to observe changes.
+Clients have two ways to monitor a server's health. They use `Check()` to probe
+a server's health or `Watch()` to observe changes.
 
-In most cases, clients do not need to directly check backend servers.
-Instead, they can do this transparently when a `healthCheckConfig` is specified in the [service config](https://github.com/grpc/proposal/blob/master/A17-client-side-health-checking.md#service-config-changes) and the [health package](https://pkg.go.dev/google.golang.org/grpc/health) is imported.
-The `serviceName` in `healthCheckConfig` will be used in the health check when connections are established.
-An empty string (`""`) typically indicates the overall health of a server should be reported.
+In most cases, clients do not directly check backend servers. Instead, they do
+this transparently when you specify a `healthCheckConfig` in the [service
+config](https://github.com/grpc/proposal/blob/master/A17-client-side-health-checking.md#service-config-changes)
+and import the [health
+package](https://pkg.go.dev/google.golang.org/grpc/health). The `serviceName` in
+`healthCheckConfig` is used in the health check when connections are
+established. An empty string (`""`) typically indicates the overall health of a
+server.
 
 ```go
 // import grpc/health to enable transparent client side checking
@@ -43,21 +50,25 @@ serviceConfig := grpc.WithDefaultServiceConfig(`{
 conn, err := grpc.NewClient(..., serviceConfig)
 ```
 
-See [A17 - Client-Side Health Checking](https://github.com/grpc/proposal/blob/master/A17-client-side-health-checking.md) for more details.
+See [A17 - Client-Side Health
+Checking](https://github.com/grpc/proposal/blob/master/A17-client-side-health-checking.md)
+for more details.
 
 ### Server
 
-Servers control their serving status.
-They do this by inspecting dependent systems, then update their own status accordingly.
-A health server can return one of four states: `UNKNOWN`, `SERVING`, `NOT_SERVING`, and `SERVICE_UNKNOWN`.
+Servers control their serving status. They do this by inspecting dependent
+systems, then update their status accordingly. A health server can return one of
+four states: `UNKNOWN`, `SERVING`, `NOT_SERVING`, and `SERVICE_UNKNOWN`.
 
-`UNKNOWN` indicates the current state is not yet known.
-This state is often seen at the start up of a server instance.
+`UNKNOWN` indicates the system does not yet know the current state. Servers
+often show this state at startup.
 
 `SERVING` means that the system is healthy and ready to service requests.
-Conversely, `NOT_SERVING` indicates the system is unable to service requests at the time.
+Conversely, `NOT_SERVING` indicates the system is unable to service requests at
+the time.
 
-`SERVICE_UNKNOWN` communicates the `serviceName` requested by the client is not known by the server.
-This status is only reported by the `Watch()` call.
+`SERVICE_UNKNOWN` communicates the `serviceName` requested by the client is not
+known by the server. This status is only reported by the `Watch()` call.
 
-A server may toggle its health using `healthServer.SetServingStatus("serviceName", servingStatus)`.
+A server may toggle its health using
+`healthServer.SetServingStatus("serviceName", servingStatus)`.


### PR DESCRIPTION
This PR fixes some markdown formatting issues flagged by an internal tool (when attempting to import recent changes into google3). It also makes minor improvements to the content.

RELEASE NOTES: N/A