### PR TITLE
xdsclient: stop batching writes on the ADS stream

### DIFF
--- a/internal/xds/clients/internal/buffer/unbounded.go
+++ b/internal/xds/clients/internal/buffer/unbounded.go
@@ -115,23 +115,3 @@ func (b *Unbounded) Close() {
 		close(b.c)
 	}
 }
-
-// Reset clears all buffered data in the unbounded buffer. This does not close
-// the buffer, and new data may be Put() into it after a call to this method.
-//
-// It's expected to be used in scenarios where the buffered data is no longer
-// relevant, and needs to be cleared.
-func (b *Unbounded) Reset() {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-
-	if b.closing {
-		return
-	}
-
-	b.backlog = b.backlog[:0]
-	select {
-	case <-b.c:
-	default:
-	}
-}

--- a/internal/xds/clients/internal/buffer/unbounded.go
+++ b/internal/xds/clients/internal/buffer/unbounded.go
@@ -129,7 +129,7 @@ func (b *Unbounded) Reset() {
 		return
 	}
 
-	b.backlog = nil
+	b.backlog = b.backlog[:0]
 	select {
 	case <-b.c:
 	default:

--- a/internal/xds/clients/internal/buffer/unbounded_test.go
+++ b/internal/xds/clients/internal/buffer/unbounded_test.go
@@ -21,7 +21,6 @@ import (
 	"sort"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/grpc/internal/grpctest"
@@ -146,38 +145,4 @@ func (s) TestClose(t *testing.T) {
 		t.Fatalf("Unbounded.Put() = <nil>; want non-nil error")
 	}
 	ub.Close() // ignored
-}
-
-// TestReset resets the buffer and makes sure that the buffer can be used after
-// the reset.
-func (s) TestReset(t *testing.T) {
-	ub := NewUnbounded()
-	if err := ub.Put(1); err != nil {
-		t.Fatalf("Unbounded.Put() = %v; want nil", err)
-	}
-	if err := ub.Put(2); err != nil {
-		t.Fatalf("Unbounded.Put() = %v; want nil", err)
-	}
-	if v, ok := <-ub.Get(); !ok {
-		t.Errorf("Unbounded.Get() = %v, %v, want %v, %v", v, ok, 1, true)
-	}
-	ub.Load()
-	ub.Reset()
-
-	// Make sure the buffer is empty after the reset. Wait for a short duration
-	// to make sure that no value is received on the read channel.
-	select {
-	case v, ok := <-ub.Get():
-		t.Errorf("Unbounded.Get() = %v, %v; want no value", v, ok)
-	case <-time.After(10 * time.Millisecond):
-	}
-
-	// Make sure the buffer can be used after the reset.
-	if err := ub.Put(1); err != nil {
-		t.Fatalf("Unbounded.Put() = %v; want nil", err)
-	}
-	if v, ok := <-ub.Get(); !ok {
-		t.Errorf("Unbounded.Get() = %v, %v, want %v, %v", v, ok, 1, true)
-	}
-	ub.Load()
 }

--- a/internal/xds/clients/internal/buffer/unbounded_test.go
+++ b/internal/xds/clients/internal/buffer/unbounded_test.go
@@ -21,6 +21,7 @@ import (
 	"sort"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/grpc/internal/grpctest"
@@ -145,4 +146,38 @@ func (s) TestClose(t *testing.T) {
 		t.Fatalf("Unbounded.Put() = <nil>; want non-nil error")
 	}
 	ub.Close() // ignored
+}
+
+// TestReset resets the buffer and makes sure that the buffer can be used after
+// the reset.
+func (s) TestReset(t *testing.T) {
+	ub := NewUnbounded()
+	if err := ub.Put(1); err != nil {
+		t.Fatalf("Unbounded.Put() = %v; want nil", err)
+	}
+	if err := ub.Put(2); err != nil {
+		t.Fatalf("Unbounded.Put() = %v; want nil", err)
+	}
+	if v, ok := <-ub.Get(); !ok {
+		t.Errorf("Unbounded.Get() = %v, %v, want %v, %v", v, ok, 1, true)
+	}
+	ub.Load()
+	ub.Reset()
+
+	// Make sure the buffer is empty after the reset. Wait for a short duration
+	// to make sure that no value is received on the read channel.
+	select {
+	case v, ok := <-ub.Get():
+		t.Errorf("Unbounded.Get() = %v, %v; want no value", v, ok)
+	case <-time.After(10 * time.Millisecond):
+	}
+
+	// Make sure the buffer can be used after the reset.
+	if err := ub.Put(1); err != nil {
+		t.Fatalf("Unbounded.Put() = %v; want nil", err)
+	}
+	if v, ok := <-ub.Get(); !ok {
+		t.Errorf("Unbounded.Get() = %v, %v, want %v, %v", v, ok, 1, true)
+	}
+	ub.Load()
 }

--- a/internal/xds/clients/xdsclient/ads_stream.go
+++ b/internal/xds/clients/xdsclient/ads_stream.go
@@ -189,11 +189,11 @@ func (s *adsStreamImpl) subscribe(typ ResourceType, name string) {
 	s.requestCh.Put(request{typ: typ, resourceNames: resourceNames(state.subscribedResources)})
 }
 
-// Unsubscribe cancels the subscription to the given resource. It is a no-op if
+// unsubscribe cancels the subscription to the given resource. It is a no-op if
 // the given resource does not exist. The watch expiry timer associated with the
 // resource is stopped if one is active. A discovery request is sent out on the
 // stream for the resource type with the updated set of resource names.
-func (s *adsStreamImpl) Unsubscribe(typ ResourceType, name string) {
+func (s *adsStreamImpl) unsubscribe(typ ResourceType, name string) {
 	if s.logger.V(2) {
 		s.logger.Infof("Unsubscribing to resource %q of type %q", name, typ.TypeName)
 	}

--- a/internal/xds/clients/xdsclient/ads_stream.go
+++ b/internal/xds/clients/xdsclient/ads_stream.go
@@ -310,11 +310,7 @@ func (s *adsStreamImpl) sendNew(stream clients.Stream, typ ResourceType, names [
 		return nil
 	}
 
-	state, ok := s.resourceTypeState[typ]
-	if !ok {
-		// State is created when the first subscription for this type is made.
-		panic(fmt.Sprintf("no state exists for resource type %v", typ))
-	}
+	state := s.resourceTypeState[typ]
 	if err := s.sendMessageLocked(stream, names, typ.TypeURL, state.version, state.nonce, nil); err != nil {
 		return err
 	}

--- a/internal/xds/clients/xdsclient/channel.go
+++ b/internal/xds/clients/xdsclient/channel.go
@@ -163,7 +163,7 @@ func (xc *xdsChannel) unsubscribe(typ ResourceType, name string) {
 		}
 		return
 	}
-	xc.ads.Unsubscribe(typ, name)
+	xc.ads.unsubscribe(typ, name)
 }
 
 // The following onADSXxx() methods implement the StreamEventHandler interface


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc-go/issues/8125

#### The original race in the xDS client:
- Resource watch is cancelled by the user of the xdsClient (e.g. xdsResolver) 
- xdsClient removes the resource from its cache and queues an unsubscribe request to the ADS stream.
- A watch for the same resource is registered immediately, and the xdsClient instructs the ADS stream to subscribe (as it's not in cache).
- The ADS stream sends a redundant request (same resources, version, nonce) which the management server ignores.
- The new resource watch sees a "resource-not-found" error once the watch timer fires.

#### The original fix:
Delay the resource's removal from the cache until the unsubscribe request was transmitted over the wire, a change implemented in https://github.com/grpc/grpc-go/pull/8369. However, this solution introduced new complications:
- The resource's removal from the xdsClient's cache became an asynchronous operation, occurring while the unsubscribe request was being sent.
- This asynchronous behavior meant the state maintained within the ADS stream could still diverge from the cache's state.
- A critical section was absent between the ADS stream's message transmission logic and the xdsClient's cache access, which is performed during subscription/unsubscription by its users.

#### The root cause of the previous seen races can be put down two things:
- Batching of writes for subscribe and unsubscribe calls
  - After batching, it may appear that nothing has changed in the list of subscribed resources, even though a resource was removed and added again, and therefore the management server would not send any response. It is important that the management server see the exact sequence of subscribe and unsubscribe calls.
- State maintained in the ADS stream going out of sync with the state maintained in the resource cache

#### How does this PR address the above issue?
This PR simplifies the implementation of the ADS stream by removing two pieces of functionality
- Stop batching of writes on the ADS stream
  -  If the user registers multiple watches, e.g. resource `A`, `B`, and `C`, the stream would now send three requests: `[A]`, `[A B]`, `[A B C]`.
- Queue the exact request to be sent out based on the current state
  - As part of handling a subscribe/unsubscribe request, the ADS stream implementation will queue the exact request to be sent out. When asynchronously sending the request out, it will not use the current state, but instead just write the queued request on the wire.
- Don't buffer writes when waiting for flow control
  - Flow control is already blocking reads from the stream. Blocking writes as well during this period might provide some additional flow control, but not much, and removing this logic simplifies the stream implementation quite a bit.


RELEASE NOTES:
- xdsclient: fix a race in the xdsClient that could lead to resource-not-found errors