### PR TITLE
xds: check priority policy restarts timer on same CONNECTING -> CONNECTING transition

### DIFF
--- a/internal/xds/balancer/priority/balancer_priority.go
+++ b/internal/xds/balancer/priority/balancer_priority.go
@@ -186,6 +186,7 @@ func (b *priorityBalancer) handleChildStateUpdate(childName string, s balancer.S
 		b.logger.Warningf("Ignoring update from child policy %q which is not in started state: %+v", childName, s)
 		return
 	}
+	originalState := child.state
 	child.state = s
 
 	// We start/stop the init timer of this child based on the new connectivity
@@ -199,7 +200,7 @@ func (b *priorityBalancer) handleChildStateUpdate(childName string, s balancer.S
 		child.reportedTF = true
 		child.stopInitTimer()
 	case connectivity.Connecting:
-		if !child.reportedTF {
+		if !child.reportedTF && originalState.ConnectivityState != connectivity.Connecting {
 			child.startInitTimer()
 		}
 	default:


### PR DESCRIPTION
Fixes: #8516

The priority balancer's init timer was restarting when a child balancer received multiple CONNECTING state updates.
This caused unnecessary delays in failover to lower priority children.

RELEASE NOTES:
- priority: Fix a bug that was resulting in increased failover time
