### PR TITLE
grpc: Move channel to TRANSIENT_FAILURE on resolver creation failure

### DIFF
--- a/clientconn.go
+++ b/clientconn.go
@@ -357,9 +357,7 @@ func (cc *ClientConn) exitIdleMode() (err error) {
 	// This needs to be called without cc.mu because this builds a new resolver
 	// which might update state or report error inline, which would then need to
 	// acquire cc.mu.
-	if err := cc.resolverWrapper.start(); err != nil {
-		return err
-	}
+	cc.resolverWrapper.start()
 
 	cc.addTraceEvent("exiting idle mode")
 	return nil


### PR DESCRIPTION
When a resolver fails to be created, the current behavior is inconsistent and makes debugging difficult (see discussion on https://github.com/grpc/grpc-go/pull/8602#discussion_r2378263580):
* `Dial`: Immediately returns an error.
 * `NewClient`: Logs an `INFO` message only when an RPC is attempted, while the channel remains in an `IDLE` state. This can hide the underlying configuration issue.

This change unifies the behavior by transitioning the channel to `TRANSIENT_FAILURE` upon a resolver creation failure. As a result, RPCs will fail immediately with the specific error produced by the resolver builder, making the problem easier to diagnose.

RELEASE NOTES:
* client: When a resolver fails to be created, the channel now transitions to `TRANSIENT_FAILURE` instead of staying `IDLE`.
* client: The deprecated `Dial` function no longer returns an error on resolver creation failure, instead the channel is created and it enters `TRANSIENT_FAILURE` state.