### PR TITLE
outlierdetection: add metrics specified in gRFC A91

### DIFF
--- a/internal/xds/balancer/outlierdetection/balancer.go
+++ b/internal/xds/balancer/outlierdetection/balancer.go
@@ -57,7 +57,7 @@ var (
 	ejectionsEnforcedMetric = estats.RegisterInt64Count(estats.MetricDescriptor{
 		Name:        "grpc.lb.outlier_detection.ejections_enforced",
 		Description: "EXPERIMENTAL. Number of outlier ejections enforced by detection method",
-		Unit:        "ejection",
+		Unit:        "{ejection}",
 		Labels:      []string{"grpc.target", "grpc.lb.outlier_detection.detection_method"},
 		Default:     false,
 	})
@@ -65,7 +65,7 @@ var (
 	ejectionsUnenforcedMetric = estats.RegisterInt64Count(estats.MetricDescriptor{
 		Name:        "grpc.lb.outlier_detection.ejections_unenforced",
 		Description: "EXPERIMENTAL. Number of unenforced outlier ejections due to either `max_ejection_percentage` or `enforcement_percentage`",
-		Unit:        "ejection",
+		Unit:        "{ejection}",
 		Labels:      []string{"grpc.target", "grpc.lb.outlier_detection.detection_method", "grpc.lb.outlier_detection.unenforced_reason"},
 		Default:     false,
 	})


### PR DESCRIPTION
Implements gRFC A91: https://github.com/grpc/proposal/blob/master/A91-outlier-detection-metrics.md

### Notable implementation detals
* `grpc.lb.backend_service` is not implemented yet (marked as optional in the gRFC)
* modifies the tests to make sure we can cover all the cases for `enforced`/`unenforced` without repeating the test setup.


RELEASE NOTES:

* outlierdetection: add metrics for enforced (grpc.lb.outlier_detection.ejections_enforced) and unenforced (grpc.lb.outlier_detection.ejections_unenforced) outlier ejections.
