### PR TITLE
transport: Ensure stream context is cancelled in test

### DIFF
--- a/internal/transport/transport_test.go
+++ b/internal/transport/transport_test.go
@@ -3448,7 +3448,9 @@ func (s) TestDeleteStreamMetricsIncrementedOnlyOnce(t *testing.T) {
 				t.Fatalf("Server stream not found for client stream ID %d", clientStream.id)
 			}
 
-			// First call to deleteStream should remove the stream from activeStreams and update metrics
+			// First call to closeStream should remove the stream from
+			// the activeStreams and update metrics. closeStream will also
+			// cancel the stream, stopping the deadline timer.
 			serverTransport.closeStream(serverStream, false, 0, test.eosReceived)
 
 			// Check metrics after first deleteStream call


### PR DESCRIPTION
Fixes: #8646

The server stream's timer to monitor the deadline is closed when the stream's cancel method is invoked.
https://github.com/grpc/grpc-go/blob/2d922719c02bb46f34482d592c35e72dc4a9ad92/internal/transport/http2_server.go#L623-L637

The cancel method is called when `closeStream` is called, just before it calls `deleteStream`.
https://github.com/grpc/grpc-go/blob/2d922719c02bb46f34482d592c35e72dc4a9ad92/internal/transport/http2_server.go#L1347-L1357

The cancel method is not called in [`deleteStream`](https://github.com/grpc/grpc-go/blob/2d922719c02bb46f34482d592c35e72dc4a9ad92/internal/transport/http2_server.go#L1302). 

This change invokes `deleteStream` through `closeStream` in the flaking test to ensure the stream is always cancelled to avoid leaking timers.

RELEASE NOTES: N/A