### PR TITLE
xds/googlec2p: support custom bootstrap config per channel.

### DIFF
--- a/internal/xds/xdsclient/pool.go
+++ b/internal/xds/xdsclient/pool.go
@@ -49,7 +49,7 @@ type Pool struct {
 	// config.
 	mu             sync.Mutex
 	clients        map[string]*clientImpl
-	fallbackConfig *bootstrap.Config
+	fallbackConfig *bootstrap.Config // TODO(i/8661): remove fallbackConfig.
 	// getConfiguration is a sync.OnceValues that attempts to read the bootstrap
 	// configuration from environment variables once.
 	getConfiguration func() (*bootstrap.Config, error)
@@ -175,6 +175,7 @@ func (p *Pool) GetClientForTesting(name string) (XDSClient, func(), error) {
 // SetFallbackBootstrapConfig is used to specify a bootstrap configuration
 // that will be used as a fallback when the bootstrap environment variables
 // are not defined.
+// TODO(i/8661): remove SetFallbackBootstrapConfig function.
 func (p *Pool) SetFallbackBootstrapConfig(config *bootstrap.Config) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -214,6 +215,7 @@ func (p *Pool) BootstrapConfigForTesting() *bootstrap.Config {
 	if cfg != nil {
 		return cfg
 	}
+	// TODO(i/8661)
 	return p.fallbackConfig
 }
 
@@ -224,6 +226,7 @@ func (p *Pool) BootstrapConfigForTesting() *bootstrap.Config {
 func (p *Pool) UnsetBootstrapConfigForTesting() {
 	p.mu.Lock()
 	defer p.mu.Unlock()
+	// TODO(i/8661)
 	p.fallbackConfig = nil
 	p.getConfiguration = sync.OnceValues(bootstrap.GetConfiguration)
 }
@@ -284,6 +287,7 @@ func (p *Pool) newRefCounted(name string, metricsRecorder estats.MetricsRecorder
 			return nil, nil, fmt.Errorf("xds: failed to read xDS bootstrap config from env vars:  %v", err)
 		}
 		if config == nil {
+			// TODO(i/8661)
 			// If the environment variables are not set, then fallback bootstrap
 			// configuration should be set before attempting to create an xDS client,
 			// else xDS client creation will fail.

--- a/internal/xds/xdsclient/pool.go
+++ b/internal/xds/xdsclient/pool.go
@@ -215,7 +215,6 @@ func (p *Pool) BootstrapConfigForTesting() *bootstrap.Config {
 	if cfg != nil {
 		return cfg
 	}
-	// TODO(i/8661)
 	return p.fallbackConfig
 }
 
@@ -226,7 +225,6 @@ func (p *Pool) BootstrapConfigForTesting() *bootstrap.Config {
 func (p *Pool) UnsetBootstrapConfigForTesting() {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	// TODO(i/8661)
 	p.fallbackConfig = nil
 	p.getConfiguration = sync.OnceValues(bootstrap.GetConfiguration)
 }
@@ -287,7 +285,6 @@ func (p *Pool) newRefCounted(name string, metricsRecorder estats.MetricsRecorder
 			return nil, nil, fmt.Errorf("xds: failed to read xDS bootstrap config from env vars:  %v", err)
 		}
 		if config == nil {
-			// TODO(i/8661)
 			// If the environment variables are not set, then fallback bootstrap
 			// configuration should be set before attempting to create an xDS client,
 			// else xDS client creation will fail.

--- a/internal/xds/xdsclient/pool.go
+++ b/internal/xds/xdsclient/pool.go
@@ -73,6 +73,11 @@ type OptionsForTesting struct {
 	// MetricsRecorder is the metrics recorder the xDS Client will use. If
 	// unspecified, uses a no-op MetricsRecorder.
 	MetricsRecorder estats.MetricsRecorder
+
+	// Config is the xDS bootstrap configuration that will be used to initialize
+	// the client. If unset, the client will use the config provided by env
+	// variables.
+	Config *bootstrap.Config
 }
 
 // NewPool creates a new xDS client pool with the given bootstrap config.
@@ -91,6 +96,17 @@ func NewPool(config *bootstrap.Config) *Pool {
 	}
 }
 
+// NewClientWithConfig returns an xDS client with the given name from the pool. If the
+// client doesn't already exist, it creates a new xDS client and adds it to the
+// pool.
+//
+// The second return value represents a close function which the caller is
+// expected to invoke once they are done using the client.  It is safe for the
+// caller to invoke this close function multiple times.
+func (p *Pool) NewClientWithConfig(name string, metricsRecorder estats.MetricsRecorder, config *bootstrap.Config) (XDSClient, func(), error) {
+	return p.newRefCounted(name, metricsRecorder, defaultWatchExpiryTimeout, config)
+}
+
 // NewClient returns an xDS client with the given name from the pool. If the
 // client doesn't already exist, it creates a new xDS client and adds it to the
 // pool.
@@ -99,7 +115,7 @@ func NewPool(config *bootstrap.Config) *Pool {
 // expected to invoke once they are done using the client.  It is safe for the
 // caller to invoke this close function multiple times.
 func (p *Pool) NewClient(name string, metricsRecorder estats.MetricsRecorder) (XDSClient, func(), error) {
-	return p.newRefCounted(name, metricsRecorder, defaultWatchExpiryTimeout)
+	return p.newRefCounted(name, metricsRecorder, defaultWatchExpiryTimeout, nil)
 }
 
 // NewClientForTesting returns an xDS client configured with the provided
@@ -126,7 +142,7 @@ func (p *Pool) NewClientForTesting(opts OptionsForTesting) (XDSClient, func(), e
 	if opts.MetricsRecorder == nil {
 		opts.MetricsRecorder = istats.NewMetricsRecorderList(nil)
 	}
-	c, cancel, err := p.newRefCounted(opts.Name, opts.MetricsRecorder, opts.WatchExpiryTimeout)
+	c, cancel, err := p.newRefCounted(opts.Name, opts.MetricsRecorder, opts.WatchExpiryTimeout, opts.Config)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -251,28 +267,37 @@ func (p *Pool) clientRefCountedClose(name string) {
 // newRefCounted creates a new reference counted xDS client implementation for
 // name, if one does not exist already. If an xDS client for the given name
 // exists, it gets a reference to it and returns it.
-func (p *Pool) newRefCounted(name string, metricsRecorder estats.MetricsRecorder, watchExpiryTimeout time.Duration) (*clientImpl, func(), error) {
+func (p *Pool) newRefCounted(name string, metricsRecorder estats.MetricsRecorder, watchExpiryTimeout time.Duration, bConfig *bootstrap.Config) (*clientImpl, func(), error) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-
-	config, err := p.getConfiguration()
-	if err != nil {
-		return nil, nil, fmt.Errorf("xds: failed to read xDS bootstrap config from env vars:  %v", err)
-	}
-
-	if config == nil {
-		// If the environment variables are not set, then fallback bootstrap
-		// configuration should be set before attempting to create an xDS client,
-		// else xDS client creation will fail.
-		config = p.fallbackConfig
-	}
-	if config == nil {
-		return nil, nil, fmt.Errorf("failed to read xDS bootstrap config from env vars: bootstrap environment variables (%q or %q) not defined and fallback config not set", envconfig.XDSBootstrapFileNameEnv, envconfig.XDSBootstrapFileContentEnv)
-	}
 
 	if c := p.clients[name]; c != nil {
 		c.incrRef()
 		return c, sync.OnceFunc(func() { p.clientRefCountedClose(name) }), nil
+	}
+
+	var (
+		config *bootstrap.Config
+		err    error
+	)
+
+	if bConfig != nil {
+		config = bConfig
+	} else {
+		config, err = p.getConfiguration()
+		if err != nil {
+			return nil, nil, fmt.Errorf("xds: failed to read xDS bootstrap config from env vars:  %v", err)
+		}
+		if config == nil {
+			// If the environment variables are not set, then fallback bootstrap
+			// configuration should be set before attempting to create an xDS client,
+			// else xDS client creation will fail.
+			config = p.fallbackConfig
+		}
+	}
+
+	if config == nil {
+		return nil, nil, fmt.Errorf("failed to read xDS bootstrap config from env vars: bootstrap environment variables (%q or %q) not defined and fallback config not set", envconfig.XDSBootstrapFileNameEnv, envconfig.XDSBootstrapFileContentEnv)
 	}
 
 	c, err := newClientImpl(config, metricsRecorder, name, watchExpiryTimeout)

--- a/internal/xds/xdsclient/pool.go
+++ b/internal/xds/xdsclient/pool.go
@@ -276,14 +276,9 @@ func (p *Pool) newRefCounted(name string, metricsRecorder estats.MetricsRecorder
 		return c, sync.OnceFunc(func() { p.clientRefCountedClose(name) }), nil
 	}
 
-	var (
-		config *bootstrap.Config
-		err    error
-	)
-
-	if bConfig != nil {
-		config = bConfig
-	} else {
+	config := bConfig
+	if config == nil {
+		var err error
 		config, err = p.getConfiguration()
 		if err != nil {
 			return nil, nil, fmt.Errorf("xds: failed to read xDS bootstrap config from env vars:  %v", err)

--- a/xds/googledirectpath/googlec2p.go
+++ b/xds/googledirectpath/googlec2p.go
@@ -121,12 +121,12 @@ func getXdsServerURI() string {
 
 type c2pResolverWrapper struct {
 	resolver.Resolver
-	cancel func()
+	cancel func() // Release the reference to the xDS client that was created in Build().
 }
 
 func (r *c2pResolverWrapper) Close() {
 	r.Resolver.Close()
-	r.cancel() // Release the reference to the xDS client that was created in Build().
+	r.cancel()
 }
 
 type c2pResolverBuilder struct{}

--- a/xds/googledirectpath/googlec2p_test.go
+++ b/xds/googledirectpath/googlec2p_test.go
@@ -560,8 +560,8 @@ func (s) TestSetUniverseDomainEmptyString(t *testing.T) {
 }
 
 // TestCreateMultipleXDSClients validates that multiple xds clients with
-// different bootstrap config coexist in the same pool. It confirms
-// that a client created by the google-c2p resolver does not interfere with an
+// different bootstrap config coexist in the same pool. It confirms that
+// a client created by the google-c2p resolver does not interfere with an
 // explicitly created client using a different bootstrap configuration.
 func (s) TestCreateMultipleXDSClients(t *testing.T) {
 	replaceResolvers(t)
@@ -627,6 +627,7 @@ func (s) TestCreateMultipleXDSClients(t *testing.T) {
 		t.Fatalf("xdsClientPool.NewClientForTesting(%q) failed: %v", xdsTarget.String(), err)
 	}
 	defer closeGeneric()
+
 	clientGeneric := verifyXDSClientBootstrapConfig(t, xdsClientPool, xdsTarget.String(), genericXDSConfig)
 
 	// Build the google-c2p resolver.
@@ -638,12 +639,12 @@ func (s) TestCreateMultipleXDSClients(t *testing.T) {
 		t.Fatalf("Failed to build resolver: %v", err)
 	}
 	defer c2pRes.Close()
+
 	c2pXDSTarget := resolver.Target{URL: url.URL{Scheme: xdsName, Host: c2pAuthority, Path: c2pTarget.URL.Path}}
 	clientC2P := verifyXDSClientBootstrapConfig(t, xdsClientPool, c2pXDSTarget.String(), c2pConfig)
 
 	// Verify that the two clients are distinct instances.
 	if clientC2P == clientGeneric {
-		t.Fatal("Expected two distinct xDS clients, but got the same one for both")
+		t.Fatal("Expected two distinct xDS clients, but got same")
 	}
 }
-


### PR DESCRIPTION
This PR refactors the xdsclient pool and googlec2p resolver logic to support channel-specific bootstrap configuration, enabling use cases where applications need to create xDS clients with different configs.

Prior to this change, c2p resolver used SetFallbackBootstrapConfig to inject the directpath-specific bootstrap config, which became the singleton config for all xdsclients. This prevented users from running multiple xDS clients with distinct configs.

Key Changes:
- The xdsclient pool now accepts an optional bootstrap configuration when creating a client.
- When a client is requested for a target URI:
  * If an xdsclient instance for this URI already exists, it is reused.
  * If not, a new xdsclient is created:
    + If a bootstrap config is provided, it is used.
    + Otherwise, default config loading (env vars, file path) is used.
- The logic to check for and reuse existing clients for a given URI is performed before loading configuration.
- The c2p resolver is updated to stop using the global SetFallbackBootstrapConfig. Instead, it creates and retains an xdsclient for its channel target, supplying the required bootstrap config directly.
- The c2p resolver keeps its client until the c2p resolver is Closed.

RELEASE NOTES:

- xds/googlec2p: Fix channel-specific xDS bootstrap configurations by allowing xdsclient creation with per-target config. Removes global fallback config usage, enabling multiple distinct xDS clients to coexist in the same process.
 