### PR TITLE
docs: fix three typos in benchmark and auth docs

### DIFF
--- a/Documentation/benchmark.md
+++ b/Documentation/benchmark.md
@@ -24,7 +24,7 @@ that are supported.
 ## Varying Payload Sizes (Weighted Random Distribution)
 
 The `benchmain` utility supports two flags, `-reqPayloadCurveFiles` and
-`-respPayloadCurveFiles`, that can be used to specify a histograms representing
+`-respPayloadCurveFiles`, that can be used to specify a histogram representing
 a weighted random distribution of request and response payload sizes,
 respectively. This is useful to simulate workloads with arbitrary payload
 sizes.

--- a/Documentation/benchmark.md
+++ b/Documentation/benchmark.md
@@ -29,7 +29,7 @@ a weighted random distribution of request and response payload sizes,
 respectively. This is useful to simulate workloads with arbitrary payload
 sizes.
 
-The options takes a comma-separated list of file paths as value. Each file must
+The options take a comma-separated list of file paths as value. Each file must
 be a valid CSV file with three columns in each row. Each row represents a range
 of payload sizes (first two columns) and the weight associated with that range
 (third column). For example, consider the below file:

--- a/Documentation/grpc-auth-support.md
+++ b/Documentation/grpc-auth-support.md
@@ -33,7 +33,7 @@ Clients may use
 to store tokens and other authentication-related data. To gain access to the
 `metadata.MD` object, a server may use
 [metadata.FromIncomingContext](https://godoc.org/google.golang.org/grpc/metadata#FromIncomingContext).
-With a reference to `metadata.MD` on the server, one needs to simply lookup the
+With a reference to `metadata.MD` on the server, one needs to simply look up the
 `authorization` key. Note, all keys stored within `metadata.MD` are normalized
 to lowercase. See [here](https://godoc.org/google.golang.org/grpc/metadata#New).
 


### PR DESCRIPTION
This PR corrects three minor typos in documentation. It is strictly a grammar/wording cleanup with no behavioral or API changes. The changes are split into three commits (one per typo) for easier review.

### What changed
- `Documentation/benchmark.md`: “a histograms” → “a histogram”
- `Documentation/benchmark.md`: “The options takes …” → “The options take …”
- `Documentation/grpc-auth-support.md`: “… simply lookup the authorization key.” → “… simply look up the authorization key.”

### Rationale
Improve clarity and correctness of docs; typo-only edits with no content changes.

### Testing
N/A – documentation-only changes.

### Dependencies
No new dependencies and no code changes.

RELEASE NOTES: n/a