### PR TITLE
transport: Reduce heap allocations

### DIFF
--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -500,12 +500,10 @@ func (t *http2Client) newStream(ctx context.Context, callHdr *CallHdr) *ClientSt
 	s.ctx = ctx
 	s.trReader = transportReader{
 		reader: recvBufferReader{
-			ctx:     s.ctx,
-			ctxDone: s.ctx.Done(),
-			recv:    &s.buf,
-			closeStream: func(err error) {
-				s.Close(err)
-			},
+			ctx:          s.ctx,
+			ctxDone:      s.ctx.Done(),
+			recv:         &s.buf,
+			clientStream: s,
 		},
 		windowHandler: s,
 	}

--- a/internal/transport/transport.go
+++ b/internal/transport/transport.go
@@ -123,13 +123,13 @@ func (b *recvBuffer) get() <-chan recvMsg {
 // recvBufferReader implements io.Reader interface to read the data from
 // recvBuffer.
 type recvBufferReader struct {
-	_           noCopy
-	closeStream func(error) // Closes the client transport stream with the given error and nil trailer metadata.
-	ctx         context.Context
-	ctxDone     <-chan struct{} // cache of ctx.Done() (for performance).
-	recv        *recvBuffer
-	last        mem.Buffer // Stores the remaining data in the previous calls.
-	err         error
+	_            noCopy
+	clientStream *ClientStream // The client transport stream is closed with the given error and nil trailer metadata.
+	ctx          context.Context
+	ctxDone      <-chan struct{} // cache of ctx.Done() (for performance).
+	recv         *recvBuffer
+	last         mem.Buffer // Stores the remaining data in the previous calls.
+	err          error
 }
 
 func (r *recvBufferReader) ReadMessageHeader(header []byte) (n int, err error) {
@@ -140,7 +140,7 @@ func (r *recvBufferReader) ReadMessageHeader(header []byte) (n int, err error) {
 		n, r.last = mem.ReadUnsafe(header, r.last)
 		return n, nil
 	}
-	if r.closeStream != nil {
+	if r.clientStream != nil {
 		n, r.err = r.readMessageHeaderClient(header)
 	} else {
 		n, r.err = r.readMessageHeader(header)
@@ -165,7 +165,7 @@ func (r *recvBufferReader) Read(n int) (buf mem.Buffer, err error) {
 		}
 		return buf, nil
 	}
-	if r.closeStream != nil {
+	if r.clientStream != nil {
 		buf, r.err = r.readClient(n)
 	} else {
 		buf, r.err = r.read(n)
@@ -210,7 +210,7 @@ func (r *recvBufferReader) readMessageHeaderClient(header []byte) (n int, err er
 		// TODO: delaying ctx error seems like a unnecessary side effect. What
 		// we really want is to mark the stream as done, and return ctx error
 		// faster.
-		r.closeStream(ContextErr(r.ctx.Err()))
+		r.clientStream.Close(ContextErr(r.ctx.Err()))
 		m := <-r.recv.get()
 		return r.readMessageHeaderAdditional(m, header)
 	case m := <-r.recv.get():
@@ -237,7 +237,7 @@ func (r *recvBufferReader) readClient(n int) (buf mem.Buffer, err error) {
 		// TODO: delaying ctx error seems like a unnecessary side effect. What
 		// we really want is to mark the stream as done, and return ctx error
 		// faster.
-		r.closeStream(ContextErr(r.ctx.Err()))
+		r.clientStream.Close(ContextErr(r.ctx.Err()))
 		m := <-r.recv.get()
 		return r.readAdditional(m, n)
 	case m := <-r.recv.get():

--- a/internal/transport/transport.go
+++ b/internal/transport/transport.go
@@ -124,7 +124,7 @@ func (b *recvBuffer) get() <-chan recvMsg {
 // recvBuffer.
 type recvBufferReader struct {
 	_            noCopy
-	clientStream *ClientStream // The client transport stream is closed with the given error and nil trailer metadata.
+	clientStream *ClientStream // The client transport stream is closed with a status representing ctx.Err() and nil trailer metadata.
 	ctx          context.Context
 	ctxDone      <-chan struct{} // cache of ctx.Done() (for performance).
 	recv         *recvBuffer

--- a/preloader.go
+++ b/preloader.go
@@ -47,9 +47,6 @@ func (p *PreparedMsg) Encode(s Stream, msg any) error {
 	}
 
 	// check if the context has the relevant information to prepareMsg
-	if rpcInfo.preloaderInfo == nil {
-		return status.Errorf(codes.Internal, "grpc: rpcInfo.preloaderInfo is nil")
-	}
 	if rpcInfo.preloaderInfo.codec == nil {
 		return status.Errorf(codes.Internal, "grpc: rpcInfo.preloaderInfo.codec is nil")
 	}

--- a/rpc_util.go
+++ b/rpc_util.go
@@ -961,7 +961,7 @@ func recv(p *parser, c baseCodec, s recvCompressor, dc Decompressor, m any, maxR
 // Information about RPC
 type rpcInfo struct {
 	failfast      bool
-	preloaderInfo *compressorInfo
+	preloaderInfo compressorInfo
 }
 
 // Information about Preloader
@@ -980,7 +980,7 @@ type rpcInfoContextKey struct{}
 func newContextWithRPCInfo(ctx context.Context, failfast bool, codec baseCodec, cp Compressor, comp encoding.Compressor) context.Context {
 	return context.WithValue(ctx, rpcInfoContextKey{}, &rpcInfo{
 		failfast: failfast,
-		preloaderInfo: &compressorInfo{
+		preloaderInfo: compressorInfo{
 			codec: codec,
 			cp:    cp,
 			comp:  comp,


### PR DESCRIPTION
## Benchmarks
```sh
# Test command
$  go run benchmark/benchmain/main.go -benchtime=60s -workloads=unary \
   -compression=off -maxConcurrentCalls=200 -trace=off \
   -reqSizeBytes=100 -respSizeBytes=100 -networkMode=Local -resultFile="${RUN_NAME}"

$ go run benchmark/benchresult/main.go unary-before unary-after
               Title       Before        After Percentage
            TotalOps      7801951      7889246     1.12%
             SendOps            0            0      NaN%
             RecvOps            0            0      NaN%
            Bytes/op     10005.90      9911.48    -0.94%
           Allocs/op       146.91       143.91    -2.04%
             ReqT/op 104026013.33 105189946.67     1.12%
            RespT/op 104026013.33 105189946.67     1.12%
            50th-Lat   1.375183ms   1.360319ms    -1.08%
            90th-Lat   2.293816ms   2.249015ms    -1.95%
            99th-Lat   3.162307ms    3.13568ms    -0.84%
             Avg-Lat   1.536462ms   1.519465ms    -1.11%
           GoVersion     go1.24.8     go1.24.8
         GrpcVersion   1.77.0-dev   1.77.0-dev
```

RELEASE NOTES: N/A