### PR TITLE
mem: Remove Reader interface and export the concrete struct

### DIFF
--- a/internal/transport/controlbuf.go
+++ b/internal/transport/controlbuf.go
@@ -665,11 +665,10 @@ func (l *loopyWriter) incomingSettingsHandler(s *incomingSettings) error {
 
 func (l *loopyWriter) registerStreamHandler(h *registerStream) {
 	str := &outStream{
-		id:     h.streamID,
-		state:  empty,
-		itl:    &itemList{},
-		wq:     h.wq,
-		reader: mem.BufferSlice{}.Reader(),
+		id:    h.streamID,
+		state: empty,
+		itl:   &itemList{},
+		wq:    h.wq,
 	}
 	l.estdStreams[h.streamID] = str
 }
@@ -701,11 +700,10 @@ func (l *loopyWriter) headerHandler(h *headerFrame) error {
 	}
 	// Case 2: Client wants to originate stream.
 	str := &outStream{
-		id:     h.streamID,
-		state:  empty,
-		itl:    &itemList{},
-		wq:     h.wq,
-		reader: mem.BufferSlice{}.Reader(),
+		id:    h.streamID,
+		state: empty,
+		itl:   &itemList{},
+		wq:    h.wq,
 	}
 	return l.originateStream(str, h)
 }
@@ -948,11 +946,11 @@ func (l *loopyWriter) processData() (bool, error) {
 	if str == nil {
 		return true, nil
 	}
-	reader := str.reader
+	reader := &str.reader
 	dataItem := str.itl.peek().(*dataFrame) // Peek at the first data item this stream.
 	if !dataItem.processing {
 		dataItem.processing = true
-		str.reader.Reset(dataItem.data)
+		reader.Reset(dataItem.data)
 		dataItem.data.Free()
 	}
 	// A data item is represented by a dataFrame, since it later translates into

--- a/mem/buffer_slice.go
+++ b/mem/buffer_slice.go
@@ -129,6 +129,8 @@ func (s BufferSlice) Reader() *Reader {
 // with other parts systems. It also provides an additional convenience method
 // Remaining(), which returns the number of unread bytes remaining in the slice.
 // Buffers will be freed as they are read.
+// A Reader can be constructed from a BufferSlice; alternatively the zero value
+// of a Reader may be used after calling Reset on it.
 type Reader struct {
 	data BufferSlice
 	len  int

--- a/mem/buffer_slice.go
+++ b/mem/buffer_slice.go
@@ -117,9 +117,9 @@ func (s BufferSlice) MaterializeToBuffer(pool BufferPool) Buffer {
 
 // Reader returns a new Reader for the input slice after taking references to
 // each underlying buffer.
-func (s BufferSlice) Reader() Reader {
+func (s BufferSlice) Reader() *Reader {
 	s.Ref()
-	return &sliceReader{
+	return &Reader{
 		data: s,
 		len:  s.Len(),
 	}
@@ -129,31 +129,21 @@ func (s BufferSlice) Reader() Reader {
 // with other parts systems. It also provides an additional convenience method
 // Remaining(), which returns the number of unread bytes remaining in the slice.
 // Buffers will be freed as they are read.
-type Reader interface {
-	io.Reader
-	io.ByteReader
-	// Close frees the underlying BufferSlice and never returns an error. Subsequent
-	// calls to Read will return (0, io.EOF).
-	Close() error
-	// Remaining returns the number of unread bytes remaining in the slice.
-	Remaining() int
-	// Reset frees the currently held buffer slice and starts reading from the
-	// provided slice. This allows reusing the reader object.
-	Reset(s BufferSlice)
-}
-
-type sliceReader struct {
+type Reader struct {
 	data BufferSlice
 	len  int
 	// The index into data[0].ReadOnlyData().
 	bufferIdx int
 }
 
-func (r *sliceReader) Remaining() int {
+// Remaining returns the number of unread bytes remaining in the slice.
+func (r *Reader) Remaining() int {
 	return r.len
 }
 
-func (r *sliceReader) Reset(s BufferSlice) {
+// Reset frees the currently held buffer slice and starts reading from the
+// provided slice. This allows reusing the reader object.
+func (r *Reader) Reset(s BufferSlice) {
 	r.data.Free()
 	s.Ref()
 	r.data = s
@@ -161,14 +151,16 @@ func (r *sliceReader) Reset(s BufferSlice) {
 	r.bufferIdx = 0
 }
 
-func (r *sliceReader) Close() error {
+// Close frees the underlying BufferSlice and never returns an error. Subsequent
+// calls to Read will return (0, io.EOF).
+func (r *Reader) Close() error {
 	r.data.Free()
 	r.data = nil
 	r.len = 0
 	return nil
 }
 
-func (r *sliceReader) freeFirstBufferIfEmpty() bool {
+func (r *Reader) freeFirstBufferIfEmpty() bool {
 	if len(r.data) == 0 || r.bufferIdx != len(r.data[0].ReadOnlyData()) {
 		return false
 	}
@@ -179,7 +171,7 @@ func (r *sliceReader) freeFirstBufferIfEmpty() bool {
 	return true
 }
 
-func (r *sliceReader) Read(buf []byte) (n int, _ error) {
+func (r *Reader) Read(buf []byte) (n int, _ error) {
 	if r.len == 0 {
 		return 0, io.EOF
 	}
@@ -202,7 +194,8 @@ func (r *sliceReader) Read(buf []byte) (n int, _ error) {
 	return n, nil
 }
 
-func (r *sliceReader) ReadByte() (byte, error) {
+// ReadByte reads a single byte.
+func (r *Reader) ReadByte() (byte, error) {
 	if r.len == 0 {
 		return 0, io.EOF
 	}


### PR DESCRIPTION
This PR changes the exported slice reader from an interface to a concrete struct.

This approach follows the precedent set by standard library packages, such as [`bufio`'s `bufio.Reader`](https://pkg.go.dev/bufio#Reader). This interface was not intended for users to implement, and gRPC does not plan to provide alternative implementations. Users who require an interface for abstraction or testing can define one in their own packages.

This change provides two main advantages:

  * Performance: It avoids a couple of heap allocations per stream that were previously required to hold the interface value.
  * Maintainability: Adding new methods to the concrete struct is a backward-compatible change, whereas adding methods to an interface is a breaking change.

## Benchmarks
```sh
# test command
$ go run benchmark/benchmain/main.go -benchtime=60s -workloads=unary \
   -compression=off -maxConcurrentCalls=200 -trace=off \
   -reqSizeBytes=100 -respSizeBytes=100 -networkMode=Local -resultFile="${RUN_NAME}"

$ go run benchmark/benchresult/main.go unary-before unary-after
               Title       Before        After Percentage
            TotalOps      7801951      7883976     1.05%
             SendOps            0            0      NaN%
             RecvOps            0            0      NaN%
            Bytes/op     10005.90      9951.01    -0.54%
           Allocs/op       146.91       144.90    -1.36%
             ReqT/op 104026013.33 105119680.00     1.05%
            RespT/op 104026013.33 105119680.00     1.05%
            50th-Lat   1.375183ms   1.359194ms    -1.16%
            90th-Lat   2.293816ms   2.258941ms    -1.52%
            99th-Lat   3.162307ms   3.157381ms    -0.16%
             Avg-Lat   1.536462ms   1.520149ms    -1.06%
           GoVersion     go1.24.8     go1.24.8
         GrpcVersion   1.77.0-dev   1.77.0-dev
```

RELEASE NOTES:
* mem: Replace the `Reader` interface with a struct.