### PR TITLE
mem: Avoid clearing new buffers and clear buffers from simpleBufferPools

### DIFF
--- a/mem/buffer_pool.go
+++ b/mem/buffer_pool.go
@@ -158,6 +158,7 @@ type simpleBufferPool struct {
 func (p *simpleBufferPool) Get(size int) *[]byte {
 	bs, ok := p.pool.Get().(*[]byte)
 	if ok && cap(*bs) >= size {
+		clear((*bs)[:cap(*bs)])
 		*bs = (*bs)[:size]
 		return bs
 	}


### PR DESCRIPTION
RELEASE NOTES:
* mem:
  * Avoid clearing buffers which newly allocated.
  * Clear large buffers (> 1MB) before re-using.