### PR TITLE
internal/stats: Moved `Labels` to experimental/stats package

### DIFF
--- a/experimental/stats/labels.go
+++ b/experimental/stats/labels.go
@@ -16,7 +16,6 @@
  *
  */
 
-// Package stats provides internal stats related functionality.
 package stats
 
 import "context"

--- a/internal/stats/stats.go
+++ b/internal/stats/stats.go
@@ -16,6 +16,7 @@
  *
  */
 
+// Package stats provides internal stats related functionality.
 package stats
 
 import (

--- a/internal/xds/balancer/clusterimpl/picker.go
+++ b/internal/xds/balancer/clusterimpl/picker.go
@@ -26,7 +26,7 @@ import (
 	"google.golang.org/grpc/balancer"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/connectivity"
-	"google.golang.org/grpc/internal/stats"
+	estats "google.golang.org/grpc/experimental/stats"
 	"google.golang.org/grpc/internal/wrr"
 	xdsinternal "google.golang.org/grpc/internal/xds"
 	"google.golang.org/grpc/internal/xds/clients"
@@ -95,7 +95,7 @@ func telemetryLabels(ctx context.Context) map[string]string {
 	if ctx == nil {
 		return nil
 	}
-	labels := stats.GetLabels(ctx)
+	labels := estats.GetLabels(ctx)
 	if labels == nil {
 		return nil
 	}

--- a/stats/opentelemetry/client_metrics.go
+++ b/stats/opentelemetry/client_metrics.go
@@ -25,7 +25,6 @@ import (
 	otelmetric "go.opentelemetry.io/otel/metric"
 	"google.golang.org/grpc"
 	estats "google.golang.org/grpc/experimental/stats"
-	istats "google.golang.org/grpc/internal/stats"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/stats"
 	"google.golang.org/grpc/status"
@@ -167,9 +166,9 @@ func (h *clientMetricsHandler) TagRPC(ctx context.Context, info *stats.RPCTagInf
 	// impl balancer which writes to this will only write once, thus have this
 	// stats handler's per attempt scoped context point to the same optional
 	// labels map if set.
-	var labels *istats.Labels
-	if labels = istats.GetLabels(ctx); labels == nil {
-		labels = &istats.Labels{
+	var labels *estats.Labels
+	if labels = estats.GetLabels(ctx); labels == nil {
+		labels = &estats.Labels{
 			// The defaults for all the per call labels from a plugin that
 			// executes on the callpath that this OpenTelemetry component
 			// currently supports.
@@ -178,7 +177,7 @@ func (h *clientMetricsHandler) TagRPC(ctx context.Context, info *stats.RPCTagInf
 				"grpc.lb.backend_service": "",
 			},
 		}
-		ctx = istats.SetLabels(ctx, labels)
+		ctx = estats.SetLabels(ctx, labels)
 	}
 	ctx, ai := getOrCreateRPCAttemptInfo(ctx)
 	ai.startTime = time.Now()

--- a/stats/opentelemetry/csm/observability_test.go
+++ b/stats/opentelemetry/csm/observability_test.go
@@ -30,7 +30,7 @@ import (
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/encoding/gzip"
-	istats "google.golang.org/grpc/internal/stats"
+	estats "google.golang.org/grpc/experimental/stats"
 	"google.golang.org/grpc/internal/stubserver"
 	testgrpc "google.golang.org/grpc/interop/grpc_testing"
 	testpb "google.golang.org/grpc/interop/grpc_testing"
@@ -427,7 +427,7 @@ func (s) TestCSMPluginOptionStreaming(t *testing.T) {
 }
 
 func unaryInterceptorAttachXDSLabels(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
-	ctx = istats.SetLabels(ctx, &istats.Labels{
+	ctx = estats.SetLabels(ctx, &estats.Labels{
 		TelemetryLabels: map[string]string{
 			// mock what the cluster impl would write here ("csm." xDS Labels
 			// and locality label)

--- a/test/xds/xds_telemetry_labels_test.go
+++ b/test/xds/xds_telemetry_labels_test.go
@@ -24,7 +24,7 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
-	istats "google.golang.org/grpc/internal/stats"
+	estats "google.golang.org/grpc/experimental/stats"
 	"google.golang.org/grpc/internal/stubserver"
 	"google.golang.org/grpc/internal/testutils"
 	"google.golang.org/grpc/internal/testutils/xds/e2e"
@@ -103,7 +103,7 @@ func (s) TestTelemetryLabels(t *testing.T) {
 }
 
 type fakeStatsHandler struct {
-	labels *istats.Labels
+	labels *estats.Labels
 
 	t *testing.T
 }
@@ -115,11 +115,11 @@ func (fsh *fakeStatsHandler) TagConn(ctx context.Context, _ *stats.ConnTagInfo) 
 func (fsh *fakeStatsHandler) HandleConn(context.Context, stats.ConnStats) {}
 
 func (fsh *fakeStatsHandler) TagRPC(ctx context.Context, _ *stats.RPCTagInfo) context.Context {
-	labels := &istats.Labels{
+	labels := &estats.Labels{
 		TelemetryLabels: make(map[string]string),
 	}
 	fsh.labels = labels
-	ctx = istats.SetLabels(ctx, labels) // ctx passed is immutable, however cluster_impl writes to the map of Telemetry Labels on the heap.
+	ctx = estats.SetLabels(ctx, labels) // ctx passed is immutable, however cluster_impl writes to the map of Telemetry Labels on the heap.
 	return ctx
 }
 


### PR DESCRIPTION
Related to #8446

This follows up on the discussion [here](https://github.com/grpc/grpc-go/pull/8637#issuecomment-3392495948)

By moving `Labels` and the associated Get/Set functions to the exported `experimental/stats` package we give client/server implementations of `stats.Handler` access to telemetry labels, otherwise only accessible if instrumented using an OpenTelemetry provider. 

With this change, a handler implementation can start tracking telemetry labels by calling `SetLabels` in `TagRPC`/`Tag Conn`

RELEASE NOTES: 
  * internal/stats: Move `Labels` to experimental/stats package