### PR TITLE
advancedtls: Apply defaults before version check

### DIFF
--- a/security/advancedtls/advancedtls.go
+++ b/security/advancedtls/advancedtls.go
@@ -317,6 +317,14 @@ func (o *Options) serverConfig() (*tls.Config, error) {
 	if o.RequireClientCert && o.VerificationType == SkipVerification && o.AdditionalPeerVerification == nil {
 		return nil, fmt.Errorf("server needs to provide custom verification mechanism if choose to skip default verification, but require client certificate(s)")
 	}
+	// If the MinTLSVersion isn't set, default to 1.2
+	if o.MinTLSVersion == 0 {
+		o.MinTLSVersion = tls.VersionTLS12
+	}
+	// If the MaxTLSVersion isn't set, default to 1.3
+	if o.MaxTLSVersion == 0 {
+		o.MaxTLSVersion = tls.VersionTLS13
+	}
 	// Make sure users didn't specify more than one fields in
 	// RootCertificateOptions and IdentityCertificateOptions.
 	if num := o.RootOptions.nonNilFieldCount(); num > 1 {
@@ -337,14 +345,6 @@ func (o *Options) serverConfig() (*tls.Config, error) {
 		// TLS package to use the verification function we built from
 		// buildVerifyFunc.
 		clientAuth = tls.RequireAnyClientCert
-	}
-	// If the MinTLSVersion isn't set, default to 1.2
-	if o.MinTLSVersion == 0 {
-		o.MinTLSVersion = tls.VersionTLS12
-	}
-	// If the MaxTLSVersion isn't set, default to 1.3
-	if o.MaxTLSVersion == 0 {
-		o.MaxTLSVersion = tls.VersionTLS13
 	}
 	config := &tls.Config{
 		ClientAuth:   clientAuth,

--- a/security/advancedtls/advancedtls_test.go
+++ b/security/advancedtls/advancedtls_test.go
@@ -354,6 +354,17 @@ func (s) TestServerOptionsConfigSuccessCases(t *testing.T) {
 				tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
 			},
 		},
+		{
+			desc:                   "MaxVersion default is applied when only MinVersion is set",
+			serverVerificationType: CertVerification,
+			IdentityOptions: IdentityCertificateOptions{
+				Certificates: []tls.Certificate{},
+			},
+			RootOptions: RootCertificateOptions{
+				RootProvider: fakeProvider{},
+			},
+			MinVersion: tls.VersionTLS12,
+		},
 	}
 	for _, test := range tests {
 		test := test


### PR DESCRIPTION
Prior to this change, creating an Options like

    tlsOpts := &advancedtls.Options{
        IdentityOptions: advancedtls.IdentityCertificateOptions{IdentityProvider: certProvider},
        // Note: Only MinTLSVersion is set, not MaxTLSVersion
        MinTLSVersion: tls.VersionTLS13,
    }

Would result in error:

    the minimum TLS version is larger than the maximum TLS version

The documentation for the Options struct states that the default for MaxTLSVersion is TLS 1.3 but the default was being applied after checking whether MinTLSVersion > MaxTLSVersion.

The defaults are now applied first, prior to any checks.

Fixes #8649

Thank you for your PR. Please read and follow
https://github.com/grpc/grpc-go/blob/master/CONTRIBUTING.md, especially the
"Guidelines for Pull Requests" section, and then delete this text before
entering your PR description.

RELEASE NOTES: none
