### PR TITLE
protoc-gen-go-grpc: Update supported edition to 2024

### DIFF
--- a/cmd/protoc-gen-go-grpc/main.go
+++ b/cmd/protoc-gen-go-grpc/main.go
@@ -64,7 +64,7 @@ func main() {
 	}.Run(func(gen *protogen.Plugin) error {
 		gen.SupportedFeatures = uint64(pluginpb.CodeGeneratorResponse_FEATURE_PROTO3_OPTIONAL) | uint64(pluginpb.CodeGeneratorResponse_FEATURE_SUPPORTS_EDITIONS)
 		gen.SupportedEditionsMinimum = descriptorpb.Edition_EDITION_PROTO2
-		gen.SupportedEditionsMaximum = descriptorpb.Edition_EDITION_2023
+		gen.SupportedEditionsMaximum = descriptorpb.Edition_EDITION_2024
 		for _, f := range gen.Files {
 			if !f.Generate {
 				continue


### PR DESCRIPTION
Fixes: #8642

grpc-go isn't doing anything that should be affected by edition 2024, so it should already support it.  This simply advertises it so protoc will send it edition 2024 protos without requiring an `--experimental_editions` flag.

relnotes for cmd/protoc-gen-go-grpc:
* Add support for protobuf edition 2024.

RELEASE NOTES: N/A