### PR TITLE
balancer: provides resolver.State Attributes in PickerBuildInfo

### DIFF
--- a/balancer/base/base.go
+++ b/balancer/base/base.go
@@ -31,6 +31,7 @@
 package base
 
 import (
+	"google.golang.org/grpc/attributes"
 	"google.golang.org/grpc/balancer"
 	"google.golang.org/grpc/resolver"
 )
@@ -47,6 +48,10 @@ type PickerBuildInfo struct {
 	// ReadySCs is a map from all ready SubConns to the Addresses used to
 	// create them.
 	ReadySCs map[balancer.SubConn]SubConnInfo
+
+	// Attributes contains arbitrary data about the resolver intended for
+	// consumption by the load balancing policy. This is a pointer to resolver.State Attributes.
+	Attributes *attributes.Attributes
 }
 
 // SubConnInfo contains information about a SubConn created by the base


### PR DESCRIPTION
In gRPC you can [create](https://pkg.go.dev/google.golang.org/grpc@v1.76.0/resolver/manual#NewBuilderWithScheme) manual [Resolver](https://pkg.go.dev/google.golang.org/grpc@v1.76.0/resolver/manual#Resolver) for manual name resolution management. This resolver has an [UpdateState](https://pkg.go.dev/google.golang.org/grpc@v1.76.0/resolver/manual#Resolver.UpdateState) method, which receives a [State](https://pkg.go.dev/google.golang.org/grpc@v1.76.0/resolver#State) object. This object has an [Attributes](https://pkg.go.dev/google.golang.org/grpc@v1.76.0/attributes#Attributes) field, which is used to pass various parameters to load balancers.

The [PickerBuilder](https://pkg.go.dev/google.golang.org/grpc@v1.76.0/balancer/base#PickerBuilder) interface contains a build method that receives a [PickerBuildInfo](https://pkg.go.dev/google.golang.org/grpc@v1.76.0/balancer/base#PickerBuildInfo) object containing connection information, but lacking the Attributes that are passed when [updating](https://pkg.go.dev/google.golang.org/grpc@v1.76.0/resolver/manual#Resolver.UpdateState) the resolver state.

[PickerBuildInfo](https://pkg.go.dev/google.golang.org/grpc@v1.76.0/balancer/base#PickerBuildInfo) now contains a new Attributes field:
```go
// PickerBuildInfo contains information needed by the picker builder to
// construct a picker.
type PickerBuildInfo struct {
	// ReadySCs is a map from all ready SubConns to the Addresses used to
	// create them.
	ReadySCs map[balancer.SubConn]SubConnInfo

	// Attributes contains arbitrary data about the resolver intended for
	// consumption by the load balancing policy. This is a pointer to resolver.State Attributes.
	Attributes *attributes.Attributes
}
```

Now when implementing the [PickerBuilder](https://pkg.go.dev/google.golang.org/grpc@v1.76.0/balancer/base#PickerBuilder) interface you can get these Attributes (and based on their values, configure the load balancer's operating logic):
```go
type pickerBuilder struct{}

func (*pickerBuilder) Build(pickerInfo base.PickerBuildInfo) balancer.Picker {
	myKey := pickerInfo.Attributes.Value("myKey")
	...
}
```

This change does not change any external APIs and is fully backwards compatible.