### PR TITLE
test: Fix goroutine leak in TestParsedTarget_WithCustomDialer

### DIFF
--- a/clientconn_parsed_target_test.go
+++ b/clientconn_parsed_target_test.go
@@ -297,9 +297,13 @@ func (s) TestParsedTarget_WithCustomDialer(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.target, func(t *testing.T) {
 			addrCh := make(chan string, 1)
-			dialer := func(_ context.Context, address string) (net.Conn, error) {
-				addrCh <- address
-				return nil, errors.New("dialer error")
+			dialer := func(ctx context.Context, address string) (net.Conn, error) {
+				select {
+				case addrCh <- address:
+					return nil, errors.New("dialer error")
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				}
 			}
 
 			cc, err := NewClient(test.target, WithTransportCredentials(insecure.NewCredentials()), withDefaultScheme(defScheme), WithContextDialer(dialer))


### PR DESCRIPTION
Fixes #8695 

Fixes a goroutine leak in clientconn_parsed_target_test.go where TestParsedTarget_WithCustomDialer() could leave dialer goroutines blocked on sending to addrCh if the test finished early or stopped reading.

This change replaces the blocking channel send with a select statement using a timeout/context to ensure goroutines can always exit.

RELEASE NOTES: None
