### PR TITLE
transport/client: Return status code `Unknown` on missing grpc-status

### DIFF
--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -1464,7 +1464,7 @@ func (t *http2Client) operateHeaders(frame *http2.MetaHeadersFrame) {
 		recvCompress   string
 		httpStatusErr  string
 		// the code from the grpc-status header, if present
-		grpcStatusCode = codes.Internal
+		grpcStatusCode = codes.Unknown
 		// headerError is set if an error is encountered while parsing the headers
 		headerError string
 		httpStatus  string
@@ -1485,7 +1485,7 @@ func (t *http2Client) operateHeaders(frame *http2.MetaHeadersFrame) {
 		case "grpc-status":
 			code, err := strconv.ParseInt(hf.Value, 10, 32)
 			if err != nil {
-				se := status.New(codes.Internal, fmt.Sprintf("transport: malformed grpc-status: %v", err))
+				se := status.New(codes.Unknown, fmt.Sprintf("transport: malformed grpc-status: %v", err))
 				t.closeStream(s, se.Err(), true, http2.ErrCodeProtocol, se, nil, endStream)
 				return
 			}

--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -1485,7 +1485,7 @@ func (t *http2Client) operateHeaders(frame *http2.MetaHeadersFrame) {
 		case "grpc-status":
 			code, err := strconv.ParseInt(hf.Value, 10, 32)
 			if err != nil {
-				se := status.New(codes.Unknown, fmt.Sprintf("transport: malformed grpc-status: %v", err))
+				se := status.New(codes.Internal, fmt.Sprintf("transport: malformed grpc-status: %v", err))
 				t.closeStream(s, se.Err(), true, http2.ErrCodeProtocol, se, nil, endStream)
 				return
 			}

--- a/internal/transport/transport_test.go
+++ b/internal/transport/transport_test.go
@@ -2681,7 +2681,7 @@ func (s) TestClientDecodeHeader(t *testing.T) {
 				},
 			},
 			wantStatus: status.New(
-				codes.Internal,
+				codes.Unknown,
 				"transport: malformed grpc-status: strconv.ParseInt: parsing \"xxxx\": invalid syntax",
 			),
 		},
@@ -2813,7 +2813,7 @@ func (s) TestClientDecodeTrailer(t *testing.T) {
 				},
 			},
 			wantEndStreamStatus: status.New(
-				codes.Internal,
+				codes.Unknown,
 				"transport: malformed grpc-status: strconv.ParseInt: parsing \"xxxx\": invalid syntax",
 			),
 		},
@@ -2824,7 +2824,7 @@ func (s) TestClientDecodeTrailer(t *testing.T) {
 					{Name: ":status", Value: "xxxx"},
 				},
 			},
-			wantEndStreamStatus: status.New(codes.Internal, ""),
+			wantEndStreamStatus: status.New(codes.Unknown, ""),
 		},
 		{
 			name: "http2_frame_size_exceeds",
@@ -2843,7 +2843,7 @@ func (s) TestClientDecodeTrailer(t *testing.T) {
 					{Name: "content-type", Value: "application/grpc"},
 				},
 			},
-			wantEndStreamStatus: status.New(codes.Internal, ""),
+			wantEndStreamStatus: status.New(codes.Unknown, ""),
 		},
 		{
 			name: "deadline_exceeded_status",

--- a/internal/transport/transport_test.go
+++ b/internal/transport/transport_test.go
@@ -2681,7 +2681,7 @@ func (s) TestClientDecodeHeader(t *testing.T) {
 				},
 			},
 			wantStatus: status.New(
-				codes.Unknown,
+				codes.Internal,
 				"transport: malformed grpc-status: strconv.ParseInt: parsing \"xxxx\": invalid syntax",
 			),
 		},
@@ -2813,7 +2813,7 @@ func (s) TestClientDecodeTrailer(t *testing.T) {
 				},
 			},
 			wantEndStreamStatus: status.New(
-				codes.Unknown,
+				codes.Internal,
 				"transport: malformed grpc-status: strconv.ParseInt: parsing \"xxxx\": invalid syntax",
 			),
 		},

--- a/test/http_header_end2end_test.go
+++ b/test/http_header_end2end_test.go
@@ -116,7 +116,7 @@ func (s) TestHTTPHeaderFrameErrorHandlingInitialHeader(t *testing.T) {
 				"content-type", "application/grpc",
 				"grpc-status", "abc",
 			},
-			errCode: codes.Internal,
+			errCode: codes.Unknown,
 		},
 		{
 			name: "Malformed grpc-tags-bin field ignores http status",
@@ -169,7 +169,7 @@ func (s) TestHTTPHeaderFrameErrorHandlingNormalTrailer(t *testing.T) {
 				// trailer missing grpc-status
 				":status", "502",
 			},
-			errCode: codes.Internal,
+			errCode: codes.Unknown,
 		},
 		{
 			name: "malformed grpc-status-details-bin field with status 404 to be ignored due to content type",

--- a/test/http_header_end2end_test.go
+++ b/test/http_header_end2end_test.go
@@ -116,7 +116,7 @@ func (s) TestHTTPHeaderFrameErrorHandlingInitialHeader(t *testing.T) {
 				"content-type", "application/grpc",
 				"grpc-status", "abc",
 			},
-			errCode: codes.Unknown,
+			errCode: codes.Internal,
 		},
 		{
 			name: "Malformed grpc-tags-bin field ignores http status",


### PR DESCRIPTION
https://github.com/grpc/grpc-go/pull/8548 changed the grpc status code returned on missing `grpc-status` header to `Internal`. This PR changes it back to `Unknown` as that is the expected behavior.

See https://github.com/grpc/grpc/blob/master/doc/statuscodes.md for more details. Here `Unknown` is defined as follows:
```
Unknown error. For example, this error may be returned when a Status value received 
from another address space belongs to an error space that is not known in this 
address space. Also errors raised by APIs that do not return enough error information
may be converted to this error.
```

RELEASE NOTES:
* transport/client : Return status code `Unknown` on missing grpc-status.