### PR TITLE
Cherrypick #8702 to v1.77.x

### DIFF
--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -1464,7 +1464,7 @@ func (t *http2Client) operateHeaders(frame *http2.MetaHeadersFrame) {
 		recvCompress   string
 		httpStatusErr  string
 		// the code from the grpc-status header, if present
-		grpcStatusCode = codes.Internal
+		grpcStatusCode = codes.Unknown
 		// headerError is set if an error is encountered while parsing the headers
 		headerError string
 		httpStatus  string

--- a/internal/transport/transport_test.go
+++ b/internal/transport/transport_test.go
@@ -2794,7 +2794,7 @@ func (s) TestClientDecodeTrailer(t *testing.T) {
 					{Name: ":status", Value: "xxxx"},
 				},
 			},
-			wantEndStreamStatus: status.New(codes.Internal, ""),
+			wantEndStreamStatus: status.New(codes.Unknown, ""),
 		},
 		{
 			name: "http2_frame_size_exceeds",
@@ -2813,7 +2813,7 @@ func (s) TestClientDecodeTrailer(t *testing.T) {
 					{Name: "content-type", Value: "application/grpc"},
 				},
 			},
-			wantEndStreamStatus: status.New(codes.Internal, ""),
+			wantEndStreamStatus: status.New(codes.Unknown, ""),
 		},
 		{
 			name: "deadline_exceeded_status",

--- a/test/http_header_end2end_test.go
+++ b/test/http_header_end2end_test.go
@@ -169,7 +169,7 @@ func (s) TestHTTPHeaderFrameErrorHandlingNormalTrailer(t *testing.T) {
 				// trailer missing grpc-status
 				":status", "502",
 			},
-			errCode: codes.Internal,
+			errCode: codes.Unknown,
 		},
 		{
 			name: "malformed grpc-status-details-bin field with status 404 to be ignored due to content type",


### PR DESCRIPTION
https://github.com/grpc/grpc-go/pull/8548 changed the grpc status code returned on missing grpc-status header to Internal. This PR changes it back to Unknown as that is the expected behavior.

See [grpc/grpc@master/doc/statuscodes.md](https://github.com/grpc/grpc/blob/master/doc/statuscodes.md) for more details. Here Unknown is defined as follows:
```
Unknown error. For example, this error may be returned when a Status value received 
from another address space belongs to an error space that is not known in this 
address space. Also errors raised by APIs that do not return enough error information
may be converted to this error.
```

RELEASE NOTES:
- transport/client : Return status code Unknown on missing grpc-status.