### PR TITLE
dns: drop test depending on invalid URL "dns://::1/foo.bar.com"

### DIFF
--- a/internal/resolver/dns/dns_resolver_test.go
+++ b/internal/resolver/dns/dns_resolver_test.go
@@ -1052,11 +1052,6 @@ func (s) TestCustomAuthority(t *testing.T) {
 			wantAuthority: "4.3.2.1:53",
 		},
 		{
-			name:          "ipv6 authority with no port",
-			authority:     "::1",
-			wantAuthority: "[::1]:53",
-		},
-		{
 			name:          "ipv6 authority with brackets and no port",
 			authority:     "[::1]",
 			wantAuthority: "[::1]:53",


### PR DESCRIPTION
Go 1.26's url.Parse will reject invalid URLs containing unbracketed
colons in the hostname.

For example, Go 1.25 and earlier are willing to parse the URLs
"https://localhost:80:443" (hostname:"localhost:80", port:443)
and "https://::1" (hostname:":", port:1).

The test TestCustomAuthority contains a case which depends on
url.Parse("dns://::1/foo.bar.com") succeeding. In Go 1.26, this
case will fail.

Drop the test as not exercising a useful path: This URL is invalid
and earlier Go versions being willing to parse it was a bug.
The correct URL is "dns://[::1]/foo.bar.com" (which is also
exercised by TestCustomAuthority).

RELEASE NOTES:
* client: Reject target URLs containing unbracketed colons in the hostname in Go version 1.26+.
