### PR TITLE
xdsclient: call resourceError methods from serializer

### DIFF
--- a/internal/xds/clients/xdsclient/clientimpl_watchers.go
+++ b/internal/xds/clients/xdsclient/clientimpl_watchers.go
@@ -19,6 +19,7 @@
 package xdsclient
 
 import (
+	"context"
 	"fmt"
 
 	"google.golang.org/grpc/internal/xds/clients/xdsclient/internal/xdsresource"
@@ -41,9 +42,11 @@ func (w *wrappingWatcher) ResourceError(err error, done func()) {
 
 // WatchResource starts watching the specified resource.
 //
-// typeURL specifies the resource type implementation to use. The watch fails
-// if there is no resource type implementation for the given typeURL. See the
-// ResourceTypes field in the Config struct used to create the XDSClient.
+// typeURL specifies the resource type implementation to use. if there is no
+// resource type implementation for the given typeURL, or if authority is not
+// found for the resource name, no watch is started and a no-op cancel function
+// is returned. See the ResourceTypes field in the Config struct used to create
+// the XDSClient.
 //
 // The returned function cancels the watch and prevents future calls to the
 // watcher.
@@ -62,7 +65,9 @@ func (c *XDSClient) WatchResource(typeURL, resourceName string, watcher Resource
 	rType, ok := c.config.ResourceTypes[typeURL]
 	if !ok {
 		logger.Warningf("ResourceType implementation for resource type url %v is not found", rType.TypeURL)
-		watcher.ResourceError(fmt.Errorf("ResourceType implementation for resource type url %v is not found", rType.TypeURL), func() {})
+		c.serializer.TrySchedule(func(context.Context) {
+			watcher.ResourceError(fmt.Errorf("ResourceType implementation for resource type url %v is not found", rType.TypeURL), func() {})
+		})
 		return func() {}
 	}
 
@@ -70,7 +75,9 @@ func (c *XDSClient) WatchResource(typeURL, resourceName string, watcher Resource
 	a := c.getAuthorityForResource(n)
 	if a == nil {
 		logger.Warningf("Watch registered for name %q of type %q, authority %q is not found", rType.TypeName, resourceName, n.Authority)
-		watcher.ResourceError(fmt.Errorf("authority %q not found in bootstrap config for resource %q", n.Authority, resourceName), func() {})
+		c.serializer.TrySchedule(func(context.Context) {
+			watcher.ResourceError(fmt.Errorf("authority %q not found in the config for resource %q", n.Authority, resourceName), func() {})
+		})
 		return func() {}
 	}
 	// The watchResource method on the authority is invoked with n.String()

--- a/internal/xds/clients/xdsclient/clientimpl_watchers.go
+++ b/internal/xds/clients/xdsclient/clientimpl_watchers.go
@@ -42,11 +42,11 @@ func (w *wrappingWatcher) ResourceError(err error, done func()) {
 
 // WatchResource starts watching the specified resource.
 //
-// typeURL specifies the resource type implementation to use. if there is no
-// resource type implementation for the given typeURL, or if authority is not
-// found for the resource name, no watch is started and a no-op cancel function
-// is returned. See the ResourceTypes field in the Config struct used to create
-// the XDSClient.
+// The watch fails to start if:
+//   - There is no ResourceType implementation for the given typeURL in the
+//     ResourceTypes field of the Config struct used to create the XDSClient.
+//   - The provided resourceName contains an authority that is not present in the
+//     Authorities field.
 //
 // The returned function cancels the watch and prevents future calls to the
 // watcher.
@@ -64,9 +64,9 @@ func (c *XDSClient) WatchResource(typeURL, resourceName string, watcher Resource
 
 	rType, ok := c.config.ResourceTypes[typeURL]
 	if !ok {
-		logger.Warningf("ResourceType implementation for resource type url %v is not found", rType.TypeURL)
+		logger.Warningf("ResourceType implementation for resource type url %q is not found", rType.TypeURL)
 		c.serializer.TrySchedule(func(context.Context) {
-			watcher.ResourceError(fmt.Errorf("ResourceType implementation for resource type url %v is not found", rType.TypeURL), func() {})
+			watcher.ResourceError(fmt.Errorf("no ResourceType implementation found for typeURL %q", rType.TypeURL), func() {})
 		})
 		return func() {}
 	}

--- a/internal/xds/clients/xdsclient/resource_watcher.go
+++ b/internal/xds/clients/xdsclient/resource_watcher.go
@@ -21,6 +21,9 @@ package xdsclient
 // ResourceWatcher is notified of the resource updates and errors that are
 // received by the xDS client from the management server.
 //
+// All methods on this interface are guaranteed to be called serially by the xDS
+// client. Only one method will be executing for a specific watcher at a time.
+//
 // All methods contain a done parameter which should be called when processing
 // of the update has completed.  For example, if processing a resource requires
 // watching new resources, those watches should be completed before done is

--- a/internal/xds/clients/xdsclient/resource_watcher.go
+++ b/internal/xds/clients/xdsclient/resource_watcher.go
@@ -22,7 +22,7 @@ package xdsclient
 // received by the xDS client from the management server.
 //
 // All methods on this interface are guaranteed to be called serially by the xDS
-// client. Only one method will be executing for a specific watcher at a time.
+// client.
 //
 // All methods contain a done parameter which should be called when processing
 // of the update has completed.  For example, if processing a resource requires


### PR DESCRIPTION
Fixes an issue where ResourceError methods were incorrectly called outside of the serializer's scope.

Updates the documentation for the ResourceWatcher interface to explicitly state the guarantee that all its defined methods will always be called from the serializer.

RELEASE NOTES: None