### PR TITLE
stats/otel: add backend service attribute to weighted round robin metrics

### DIFF
--- a/balancer/weightedroundrobin/scheduler.go
+++ b/balancer/weightedroundrobin/scheduler.go
@@ -39,7 +39,7 @@ func (p *picker) newScheduler(recordMetrics bool) scheduler {
 	}
 	if n == 1 {
 		if recordMetrics {
-			rrFallbackMetric.Record(p.metricsRecorder, 1, p.target, p.locality)
+			rrFallbackMetric.Record(p.metricsRecorder, 1, p.target, p.locality, p.clusterName)
 		}
 		return &rrScheduler{numSCs: 1, inc: p.inc}
 	}
@@ -58,7 +58,7 @@ func (p *picker) newScheduler(recordMetrics bool) scheduler {
 
 	if numZero >= n-1 {
 		if recordMetrics {
-			rrFallbackMetric.Record(p.metricsRecorder, 1, p.target, p.locality)
+			rrFallbackMetric.Record(p.metricsRecorder, 1, p.target, p.locality, p.clusterName)
 		}
 		return &rrScheduler{numSCs: uint32(n), inc: p.inc}
 	}

--- a/stats/opentelemetry/e2e_test.go
+++ b/stats/opentelemetry/e2e_test.go
@@ -673,7 +673,7 @@ func (s) TestWRRMetrics(t *testing.T) {
 	mo := opentelemetry.MetricsOptions{
 		MeterProvider:  provider,
 		Metrics:        opentelemetry.DefaultMetrics().Add("grpc.lb.wrr.rr_fallback", "grpc.lb.wrr.endpoint_weight_not_yet_usable", "grpc.lb.wrr.endpoint_weight_stale", "grpc.lb.wrr.endpoint_weights"),
-		OptionalLabels: []string{"grpc.lb.locality"},
+		OptionalLabels: []string{"grpc.lb.locality", "grpc.lb.backend_service"},
 	}
 
 	target := fmt.Sprintf("xds:///%s", serviceName)
@@ -699,6 +699,7 @@ func (s) TestWRRMetrics(t *testing.T) {
 
 	targetAttr := attribute.String("grpc.target", target)
 	localityAttr := attribute.String("grpc.lb.locality", `{region="region-1", zone="zone-1", sub_zone="subzone-1"}`)
+	backendServiceAttr := attribute.String("grpc.lb.backend_service", clusterName)
 
 	wantMetrics := []metricdata.Metrics{
 		{
@@ -708,7 +709,7 @@ func (s) TestWRRMetrics(t *testing.T) {
 			Data: metricdata.Sum[int64]{
 				DataPoints: []metricdata.DataPoint[int64]{
 					{
-						Attributes: attribute.NewSet(targetAttr, localityAttr),
+						Attributes: attribute.NewSet(targetAttr, localityAttr, backendServiceAttr),
 						Value:      1, // value ignored
 					},
 				},
@@ -724,7 +725,7 @@ func (s) TestWRRMetrics(t *testing.T) {
 			Data: metricdata.Sum[int64]{
 				DataPoints: []metricdata.DataPoint[int64]{
 					{
-						Attributes: attribute.NewSet(targetAttr, localityAttr),
+						Attributes: attribute.NewSet(targetAttr, localityAttr, backendServiceAttr),
 						Value:      1, // value ignored
 					},
 				},
@@ -739,7 +740,7 @@ func (s) TestWRRMetrics(t *testing.T) {
 			Data: metricdata.Histogram[float64]{
 				DataPoints: []metricdata.HistogramDataPoint[float64]{
 					{
-						Attributes: attribute.NewSet(targetAttr, localityAttr),
+						Attributes: attribute.NewSet(targetAttr, localityAttr, backendServiceAttr),
 					},
 				},
 				Temporality: metricdata.CumulativeTemporality,
@@ -761,7 +762,7 @@ func (s) TestWRRMetrics(t *testing.T) {
 		Data: metricdata.Sum[int64]{
 			DataPoints: []metricdata.DataPoint[int64]{
 				{
-					Attributes: attribute.NewSet(targetAttr, localityAttr),
+					Attributes: attribute.NewSet(targetAttr, localityAttr, backendServiceAttr),
 					Value:      1, // value ignored
 				},
 			},


### PR DESCRIPTION
Addresses https://github.com/grpc/proposal/blob/master/A89-backend-service-metric-label.md
adding backend service label to weighted round robin metrics.
This PR makes available backend service (cluster name) label which is decided in clusterimpl (since we are pre-A75). It is added to weighted round robin per call metrics.

RELEASE NOTES:

*stats/otel: add backend service label to wrr metrics