### PR TITLE
xds: add CDS/EDS/DNS resource watcher to dependency manager

### DIFF
--- a/internal/xds/xdsdepmgr/watch_service.go
+++ b/internal/xds/xdsdepmgr/watch_service.go
@@ -157,8 +157,8 @@ func newEndpointWatcher(resourceName string, depMgr *DependencyManager) *endpoin
 	}
 }
 
-// dnsResolverState watches updates for the given DNS hostname.
-// It implements resolver.ClientConn interface to work with the DNS resolver.
+// dnsResolverState watches updates for the given DNS hostname. It implements
+// resolver.ClientConn interface to work with the DNS resolver.
 type dnsResolver struct {
 	target string
 	dnsR   resolver.Resolver

--- a/internal/xds/xdsdepmgr/xds_dependency_manager.go
+++ b/internal/xds/xdsdepmgr/xds_dependency_manager.go
@@ -157,9 +157,9 @@ func (m *DependencyManager) annotateErrorWithNodeID(err error) error {
 	return fmt.Errorf("[xDS node id: %v]: %v", m.nodeID, err)
 }
 
-// maybeSendUpdateLocked checks that all the resources have been received and sends
-// the current aggregated xDS configuration to the watcher if all the updates
-// are available.
+// maybeSendUpdateLocked checks that all the resources have been received and
+// sends the current aggregated xDS configuration to the watcher if all the
+// updates are available.
 func (m *DependencyManager) maybeSendUpdateLocked() {
 	config := &xdsresource.XDSConfig{
 		Listener:    m.currentListenerUpdate,


### PR DESCRIPTION
This PR is a part of A74 changes. It add the cluster resource, endpoint resource watchers to the dependency manager.

RELEASE NOTES: N/A
