### PR TITLE
grpc: initialize decompressor for health check streams

### DIFF
--- a/stream.go
+++ b/stream.go
@@ -1341,6 +1341,7 @@ func newNonRetryClientStream(ctx context.Context, desc *StreamDesc, method strin
 		codec:            c.codec,
 		sendCompressorV0: cp,
 		sendCompressorV1: comp,
+		decompressorV0:   ac.cc.dopts.dc,
 		transport:        t,
 	}
 


### PR DESCRIPTION
stream: initialize decompressor for health check streams

Fixes #8162

Health checks fail when using legacy compression options (WithDecompressor on client or RPCDecompressor on server). The health check stream created via newNonRetryClientStream does not initialize the decompressorV0 field with the legacy decompressor from dial options, causing an Internal error when attempting to decompress server responses.

This fix initializes the decompressorV0 field in addrConnStream with ac.cc.dopts.dc, matching the behavior of the regular clientStream path (line 492) to ensure health check streams can properly decompress responses when legacy compression options are configured.

RELEASE NOTES:
* health: Fixed health checks failing when using legacy compression options WithDecompressor or RPCDecompressor.