### PR TITLE
github: Verify PR description before labels

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -11,17 +11,6 @@ jobs:
     name: Validate PR
     runs-on: ubuntu-latest
     steps:
-      - name: Validate Label
-        uses: actions/github-script@v6
-        with:
-          script: |
-            const labels = context.payload.pull_request.labels.map(label => label.name);
-            const requiredRegex = new RegExp('^Type:');
-            const hasRequiredLabel = labels.some(label => requiredRegex.test(label));
-            if (!hasRequiredLabel) {
-              core.setFailed("This PR must have a label starting with 'Type:'.");
-            }
-
       - name: Validate Description
         uses: actions/github-script@v6
         with:
@@ -38,6 +27,17 @@ jobs:
                   RELEASE NOTES:
                   * my_package: Fix bug causing crash...
               `);
+            }
+
+      - name: Validate Label
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const labels = context.payload.pull_request.labels.map(label => label.name);
+            const requiredRegex = new RegExp('^Type:');
+            const hasRequiredLabel = labels.some(label => requiredRegex.test(label));
+            if (!hasRequiredLabel) {
+              core.setFailed("This PR must have a label starting with 'Type:'.");
             }
 
       - name: Validate Milestone


### PR DESCRIPTION
Release notes in the PR description must be added by authors, whereas labels can only be added by maintainers. Moving the description check to the top ensures authors can see and resolve errors before labels are applied.

RELEASE NOTES: N/A