### PR TITLE
mem: Add more tiers to the default buffer pool

### DIFF
--- a/mem/buffer_pool.go
+++ b/mem/buffer_pool.go
@@ -44,13 +44,13 @@ const goPageSize = 4 << 10 // 4KiB. N.B. this must be a power of 2.
 var defaultBufferPoolSizes = []int{
 	256,
 	goPageSize,
-	16 << 10,  // 16KB (max HTTP/2 frame size used by gRPC)
-	32 << 10,  // 32KB (default buffer size for io.Copy)
-	64 << 10,  // 64KB
-	128 << 10, // 128KB
-	256 << 10, // 256KB
-	512 << 10, // 512KB
-	1 << 20,   // 1MB
+	16 << 10,  // 16KiB (max HTTP/2 frame size used by gRPC)
+	32 << 10,  // 32KiB (default buffer size for io.Copy)
+	64 << 10,  // 64iB
+	128 << 10, // 128KiB
+	256 << 10, // 256KiB
+	512 << 10, // 512KiB
+	1 << 20,   // 1MiB
 }
 
 var defaultBufferPool BufferPool


### PR DESCRIPTION
Currently, performance is very sensitive to payload size. If the total payload is 32KiB+1byte, the code gets (or allocates) a 1MiB buffer. Then it clears the whole thing but only uses ~3% of it. Adding more tiers between 32KiB and 1MiB makes these requests 30% faster in your benchmarks, and speeds up 256KiB requests by 10% in my benchmarks.

Just adding the tiers causes a 1% regression for 1-byte requests, but switching to `slices.BinarySearch` more than recovers this. I confirmed that this has the same behavior with https://go.dev/play/p/i7Q9ItQVu5T.

Note that both the old and new search have a potential bug when calling `Put` with buffers that don't have a power of 2 capacity. For example, `getPool(4097)` will return the pool with size 16384, but that pool can't accept the buffer so it will just ignore it. This would only be a problem if some code reslices the capacity of a buffer.

## 33000 byte request and response benchmarks:
```
unary-networkMode_Local-bufConn_false-keepalive_false-benchTime_10s-trace_false-latency_0s-kbps_0-MTU_0-maxConcurrentCalls_1-reqSize_33000B-respSize_33000B-compressor_off-channelz_false-preloader_false-clientReadBufferSize_-1-clientWriteBufferSize_-1-serverReadBufferSize_-1-serverWriteBufferSize_-1-sleepBetweenRPCs_0s-connections_1-recvBufferPool_simple-sharedWriteBuffer_false
               Title       Before        After Percentage
            TotalOps        67198        89033    32.49%
             SendOps            0            0      NaN%
             RecvOps            0            0      NaN%
            Bytes/op    235034.69    188930.90   -19.62%
           Allocs/op       177.73       181.77     2.25%
             ReqT/op 1774027200.00 2350471200.00    32.49%
            RespT/op 1774027200.00 2350471200.00    32.49%
            50th-Lat    131.034µs     94.934µs   -27.55%
            90th-Lat    187.464µs    177.865µs    -5.12%
            99th-Lat    459.922µs    308.028µs   -33.03%
             Avg-Lat    148.645µs    112.131µs   -24.56%
           GoVersion     go1.25.5     go1.25.5
         GrpcVersion   1.79.0-dev   1.79.0-dev

streaming-networkMode_Local-bufConn_false-keepalive_false-benchTime_10s-trace_false-latency_0s-kbps_0-MTU_0-maxConcurrentCalls_1-reqSize_33000B-respSize_33000B-compressor_off-channelz_false-preloader_false-clientReadBufferSize_-1-clientWriteBufferSize_-1-serverReadBufferSize_-1-serverWriteBufferSize_-1-sleepBetweenRPCs_0s-connections_1-recvBufferPool_simple-sharedWriteBuffer_false
               Title       Before        After Percentage
            TotalOps        77039       116228    50.87%
             SendOps            0            0      NaN%
             RecvOps            0            0      NaN%
            Bytes/op    312723.99    184410.91   -41.03%
           Allocs/op        61.74        63.88     3.24%
             ReqT/op 2033829600.00 3068419200.00    50.87%
            RespT/op 2033829600.00 3068419200.00    50.87%
            50th-Lat     108.37µs       72.3µs   -33.28%
            90th-Lat    166.412µs    131.114µs   -21.21%
            99th-Lat     526.06µs    270.545µs   -48.57%
             Avg-Lat    129.656µs     85.868µs   -33.77%
           GoVersion     go1.25.5     go1.25.5
         GrpcVersion   1.79.0-dev   1.79.0-dev

unconstrained-networkMode_Local-bufConn_false-keepalive_false-benchTime_10s-trace_false-latency_0s-kbps_0-MTU_0-maxConcurrentCalls_1-reqSize_33000B-respSize_33000B-compressor_off-channelz_false-preloader_false-clientReadBufferSize_-1-clientWriteBufferSize_-1-serverReadBufferSize_-1-serverWriteBufferSize_-1-sleepBetweenRPCs_0s-connections_1-recvBufferPool_simple-sharedWriteBuffer_false
               Title       Before        After Percentage
            TotalOps            0            0      NaN%
             SendOps       376536       447734    18.91%
             RecvOps       413423       575729    39.26%
            Bytes/op    103263.42     89198.52   -13.62%
           Allocs/op        27.75        28.12     3.60%
             ReqT/op 9940550400.00 11820177600.00    18.91%
            RespT/op 10914367200.00 15199245600.00    39.26%
            50th-Lat           0s           0s      NaN%
            90th-Lat           0s           0s      NaN%
            99th-Lat           0s           0s      NaN%
             Avg-Lat           0s           0s      NaN%
           GoVersion     go1.25.5     go1.25.5
         GrpcVersion   1.79.0-dev   1.79.0-dev
```

## 1 byte request and response benchmarks:
```
unary-networkMode_Local-bufConn_false-keepalive_false-benchTime_10s-trace_false-latency_0s-kbps_0-MTU_0-maxConcurrentCalls_1-reqSize_1B-respSize_1B-compressor_off-channelz_false-preloader_false-clientReadBufferSize_-1-clientWriteBufferSize_-1-serverReadBufferSize_-1-serverWriteBufferSize_-1-sleepBetweenRPCs_0s-connections_1-recvBufferPool_simple-sharedWriteBuffer_false
               Title       Before        After Percentage
            TotalOps       230977       231843     0.37%
             SendOps            0            0      NaN%
             RecvOps            0            0      NaN%
            Bytes/op      9235.90      9235.57     0.00%
           Allocs/op       155.07       155.07     0.00%
             ReqT/op    184781.60    185474.40     0.38%
            RespT/op    184781.60    185474.40     0.38%
            50th-Lat      41.15µs     41.109µs    -0.10%
            90th-Lat     55.558µs     55.117µs    -0.79%
            99th-Lat     91.657µs     88.321µs    -3.64%
             Avg-Lat     43.152µs      42.98µs    -0.40%
           GoVersion     go1.25.5     go1.25.5
         GrpcVersion   1.79.0-dev   1.79.0-dev

streaming-networkMode_Local-bufConn_false-keepalive_false-benchTime_10s-trace_false-latency_0s-kbps_0-MTU_0-maxConcurrentCalls_1-reqSize_1B-respSize_1B-compressor_off-channelz_false-preloader_false-clientReadBufferSize_-1-clientWriteBufferSize_-1-serverReadBufferSize_-1-serverWriteBufferSize_-1-sleepBetweenRPCs_0s-connections_1-recvBufferPool_simple-sharedWriteBuffer_false
               Title       Before        After Percentage
            TotalOps       394925       395698     0.20%
             SendOps            0            0      NaN%
             RecvOps            0            0      NaN%
            Bytes/op      1260.37      1260.38     0.00%
           Allocs/op        41.01        41.01     0.00%
             ReqT/op    315940.00    316558.40     0.20%
            RespT/op    315940.00    316558.40     0.20%
            50th-Lat     24.087µs     23.987µs    -0.42%
            90th-Lat     31.861µs     31.861µs     0.00%
            99th-Lat      46.45µs     45.929µs    -1.12%
             Avg-Lat     25.205µs     25.138µs    -0.27%
           GoVersion     go1.25.5     go1.25.5
         GrpcVersion   1.79.0-dev   1.79.0-dev

unconstrained-networkMode_Local-bufConn_false-keepalive_false-benchTime_10s-trace_false-latency_0s-kbps_0-MTU_0-maxConcurrentCalls_1-reqSize_1B-respSize_1B-compressor_off-channelz_false-preloader_false-clientReadBufferSize_-1-clientWriteBufferSize_-1-serverReadBufferSize_-1-serverWriteBufferSize_-1-sleepBetweenRPCs_0s-connections_1-recvBufferPool_simple-sharedWriteBuffer_false
               Title       Before        After Percentage
            TotalOps            0            0      NaN%
             SendOps     12550620     11837068    -5.69%
             RecvOps     11448882     11193802    -2.23%
            Bytes/op      1075.81      1069.33    -0.56%
           Allocs/op        25.07        25.07     0.00%
             ReqT/op  10040496.00   9469654.40    -5.69%
            RespT/op   9159105.60   8955041.60    -2.23%
            50th-Lat           0s           0s      NaN%
            90th-Lat           0s           0s      NaN%
            99th-Lat           0s           0s      NaN%
             Avg-Lat           0s           0s      NaN%
           GoVersion     go1.25.5     go1.25.5
         GrpcVersion   1.79.0-dev   1.79.0-dev
```

## 32000 byte benchmarks:
```
streaming-networkMode_Local-bufConn_false-keepalive_false-benchTime_10s-trace_false-latency_0s-kbps_0-MTU_0-maxConcurrentCalls_1-reqSize_32000B-respSize_32000B-compressor_off-channelz_false-preloader_false-clientReadBufferSize_-1-clientWriteBufferSize_-1-serverReadBufferSize_-1-serverWriteBufferSize_-1-sleepBetweenRPCs_0s-connections_1-recvBufferPool_simple-sharedWriteBuffer_false
               Title       Before        After Percentage
            TotalOps       150481       150473    -0.01%
             SendOps            0            0      NaN%
             RecvOps            0            0      NaN%
            Bytes/op    139452.12    139517.62     0.05%
           Allocs/op        42.38        42.41     0.00%
             ReqT/op 3852313600.00 3852108800.00    -0.01%
            RespT/op 3852313600.00 3852108800.00    -0.01%
            50th-Lat     57.943µs     57.952µs     0.02%
            90th-Lat     89.133µs     89.744µs     0.69%
            99th-Lat    207.272µs    206.561µs    -0.34%
             Avg-Lat       66.3µs     66.293µs    -0.01%
           GoVersion     go1.25.5     go1.25.5
         GrpcVersion   1.79.0-dev   1.79.0-dev

unconstrained-networkMode_Local-bufConn_false-keepalive_false-benchTime_10s-trace_false-latency_0s-kbps_0-MTU_0-maxConcurrentCalls_1-reqSize_32000B-respSize_32000B-compressor_off-channelz_false-preloader_false-clientReadBufferSize_-1-clientWriteBufferSize_-1-serverReadBufferSize_-1-serverWriteBufferSize_-1-sleepBetweenRPCs_0s-connections_1-recvBufferPool_simple-sharedWriteBuffer_false
               Title       Before        After Percentage
            TotalOps            0            0      NaN%
             SendOps       774812       547494   -29.34%
             RecvOps       338049       615464    82.06%
            Bytes/op     70072.04     70303.21     0.33%
           Allocs/op        20.97        21.25     4.77%
             ReqT/op 19835187200.00 14015846400.00   -29.34%
            RespT/op 8654054400.00 15755878400.00    82.06%
            50th-Lat           0s           0s      NaN%
            90th-Lat           0s           0s      NaN%
            99th-Lat           0s           0s      NaN%
             Avg-Lat           0s           0s      NaN%
           GoVersion     go1.25.5     go1.25.5
         GrpcVersion   1.79.0-dev   1.79.0-dev

unary-networkMode_Local-bufConn_false-keepalive_false-benchTime_10s-trace_false-latency_0s-kbps_0-MTU_0-maxConcurrentCalls_1-reqSize_32000B-respSize_32000B-compressor_off-channelz_false-preloader_false-clientReadBufferSize_-1-clientWriteBufferSize_-1-serverReadBufferSize_-1-serverWriteBufferSize_-1-sleepBetweenRPCs_0s-connections_1-recvBufferPool_simple-sharedWriteBuffer_false
               Title       Before        After Percentage
            TotalOps       109196       110357     1.06%
             SendOps            0            0      NaN%
             RecvOps            0            0      NaN%
            Bytes/op    147410.90    147495.33     0.06%
           Allocs/op       160.25       160.28     0.00%
             ReqT/op 2795417600.00 2825139200.00     1.06%
            RespT/op 2795417600.00 2825139200.00     1.06%
            50th-Lat     78.342µs     77.651µs    -0.88%
            90th-Lat    140.242µs    138.779µs    -1.04%
            99th-Lat    267.018µs    264.033µs    -1.12%
             Avg-Lat     91.406µs     90.436µs    -1.06%
           GoVersion     go1.25.5     go1.25.5
         GrpcVersion   1.79.0-dev   1.79.0-dev
```

RELEASE NOTES:
* mem: add more tiers to the default buffer pool