### PR TITLE
mem: Add faster tiered buffer pool

### DIFF
--- a/mem/buffer_pool.go
+++ b/mem/buffer_pool.go
@@ -143,7 +143,7 @@ type binaryTieredBufferPool struct {
 // of 2), not the raw byte sizes. For example, to create a pool of 16KB buffers
 // (2^14 bytes), pass 14 as the argument.
 func NewBinaryTieredBufferPool(powerOfTwoExponents ...uint8) (BufferPool, error) {
-slices.Sort(powerOfTwoExponents)
+	slices.Sort(powerOfTwoExponents)
 	powerOfTwoExponents = slices.Compact(powerOfTwoExponents)
 
 	// Determine the maximum exponent we need to support. This depends on the

--- a/mem/buffer_pool_internal_test.go
+++ b/mem/buffer_pool_internal_test.go
@@ -63,17 +63,17 @@ func TestNewBinaryTieredBufferPool_WordSize(t *testing.T) {
 			uintSize = tt.wordSize
 			pool, err := NewBinaryTieredBufferPool(tt.exponents...)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("NewBinaryTieredBufferPool() error = %t, wantErr %t", err, tt.wantErr)
+				t.Fatalf("NewBinaryTieredBufferPool() error = %t, wantErr %t", err, tt.wantErr)
+			}
+			if err != nil {
 				return
 			}
-			if err == nil {
-				bp := pool.(*binaryTieredBufferPool)
-				if len(bp.exponentToNextLargestPoolMap) != tt.wordSize {
-					t.Errorf("exponentToNextLargestPoolMap length = %d, want %d", len(bp.exponentToNextLargestPoolMap), tt.wordSize)
-				}
-				if len(bp.exponentToPreviousLargestPoolMap) != tt.wordSize {
-					t.Errorf("exponentToPreviousLargestPoolMap length = %d, want %d", len(bp.exponentToPreviousLargestPoolMap), tt.wordSize)
-				}
+			bp := pool.(*binaryTieredBufferPool)
+			if len(bp.exponentToNextLargestPoolMap) != tt.wordSize {
+				t.Errorf("exponentToNextLargestPoolMap length = %d, want %d", len(bp.exponentToNextLargestPoolMap), tt.wordSize)
+			}
+			if len(bp.exponentToPreviousLargestPoolMap) != tt.wordSize {
+				t.Errorf("exponentToPreviousLargestPoolMap length = %d, want %d", len(bp.exponentToPreviousLargestPoolMap), tt.wordSize)
 			}
 		})
 	}
@@ -111,4 +111,16 @@ func BenchmarkTieredPool(b *testing.B) {
 			}
 		}
 	})
+}
+
+func TestNewBinaryTieredBufferPool_Duplicates(t *testing.T) {
+	exponents := []uint8{1, 2, 3, 4, 5, 6, 6, 5, 4, 3, 2, 1}
+	pool, err := NewBinaryTieredBufferPool(exponents...)
+	if err != nil {
+		t.Fatalf("NewBinaryTieredBufferPool() error = %v", err)
+	}
+	binaryPool := pool.(*binaryTieredBufferPool)
+	if len(binaryPool.sizedPools) != 6 {
+		t.Errorf("sized buffer pool count = %d, want %d", len(binaryPool.sizedPools), 6)
+	}
 }

--- a/mem/buffer_pool_test.go
+++ b/mem/buffer_pool_test.go
@@ -108,7 +108,7 @@ func (s) TestBufferPoolIgnoresShortBuffers(t *testing.T) {
 }
 
 func TestBinaryBufferPool(t *testing.T) {
-	poolSizes := []uint8{0, 2, 3, 4}
+	poolSizes := []uint8{0, 2, 3, 4, 2, 3, 4} // duplicates will be ignored.
 
 	testCases := []struct {
 		requestSize  int


### PR DESCRIPTION
This change adds a new tiered buffer pool that uses power-of-2 tier sizes. It reduces the lookup time for the relevant sizedBufferPool from $O(\log n)$ to $O(1)$, where n is the number of tiers. This creates constant-time lookups independent of the tier count, allowing users to add more tiers without performance overhead.

## Benchmarks

Micro-benchmark that measures only the pool query performance, ignoring the allocation time:
```go
func BenchmarkSearch(b *testing.B) {
	defaultBufferPoolSizes := make([]int, len(defaultBufferPoolSizeExponents))
	for i, exp := range defaultBufferPoolSizeExponents {
		defaultBufferPoolSizes[i] = 1 << exp
	}
	b.Run("pool=Tiered", func(b *testing.B) {
		p := NewTieredBufferPool(defaultBufferPoolSizes...).(*tieredBufferPool)
		for b.Loop() {
			for size := range 1 << 19 {
				// One for get, one for put.
				_ = p.getPool(size)
				_ = p.getPool(size)
			}
		}
	})

	b.Run("pool=BinaryTiered", func(b *testing.B) {
		p := NewBinaryTieredBufferPool(defaultBufferPoolSizeExponents...).(*binaryTieredBufferPool)
		for b.Loop() {
			for size := range 1 << 19 {
				_ = p.poolForGet(size)
				_ = p.poolForPut(size)
			}
		}
	})
}
```
With 5 tiers:
```sh
go test -bench=BenchmarkSearch -count=10 -benchmem | benchstat -col '/pool' -
goos: linux
goarch: amd64
pkg: google.golang.org/grpc/mem
cpu: Intel(R) Xeon(R) CPU @ 2.60GHz
          │   Tiered    │            BinaryTiered             │
          │   sec/op    │   sec/op     vs base                │
Search-48   5.353m ± 2%   2.036m ± 0%  -61.97% (p=0.000 n=10)

          │   Tiered   │          BinaryTiered          │
          │    B/op    │    B/op     vs base            │
Search-48   0.000 ± 0%   0.000 ± 0%  ~ (p=1.000 n=10) ¹
¹ all samples are equal

          │   Tiered   │          BinaryTiered          │
          │ allocs/op  │ allocs/op   vs base            │
Search-48   0.000 ± 0%   0.000 ± 0%  ~ (p=1.000 n=10) ¹
¹ all samples are equal
```
With 9 tiers:
```sh
go test -bench=BenchmarkSearch -count=10 -benchmem | benchstat -col '/pool' -
goos: linux
goarch: amd64
pkg: google.golang.org/grpc/mem
cpu: Intel(R) Xeon(R) CPU @ 2.60GHz
          │   Tiered    │            BinaryTiered             │
          │   sec/op    │   sec/op     vs base                │
Search-48   5.659m ± 0%   2.035m ± 0%  -64.04% (p=0.000 n=10)

          │   Tiered   │          BinaryTiered          │
          │    B/op    │    B/op     vs base            │
Search-48   0.000 ± 0%   0.000 ± 0%  ~ (p=1.000 n=10) ¹
¹ all samples are equal

          │   Tiered   │          BinaryTiered          │
          │ allocs/op  │ allocs/op   vs base            │
Search-48   0.000 ± 0%   0.000 ± 0%  ~ (p=1.000 n=10) ¹
¹ all samples are equal
```

RELEASE NOTES:
* mem: Add faster tiered buffer pool. Use `NewBinaryTieredBufferPool` to create such pools.