### PR TITLE
alts: Fix buffer alignment with 16KB records

### DIFF
--- a/credentials/alts/internal/conn/record.go
+++ b/credentials/alts/internal/conn/record.go
@@ -68,7 +68,9 @@ const (
 	// altsRecordDefaultLength.
 	altsWriteBufferMaxSize = 512 * 1024 // 512KiB
 	// The initial buffer used to read from the network.
-	altsReadBufferInitialSize = 32 * 1024 // 32KiB
+	// It includes an additional 512 Bytes to hold two 16KiB records plus
+	// small framing overheads.
+	altsReadBufferInitialSize = 32*1024 + 512 // 32.5KiB
 )
 
 var (


### PR DESCRIPTION
gRPC Go receives ALTS records of max 16KB under high load (see https://github.com/grpc/grpc-go/pull/8512#issuecomment-3193280949 for details). When the ALTS conn has a partial encrypted frame in its buffer, it attempts to copy the frame to the beginning of the buffer to read the remainder.
https://github.com/grpc/grpc-go/blob/40466769682557e7179b8c74ba3820cc78d49b4b/credentials/alts/internal/conn/record.go#L151-L159

When using a buffer of exactly 32KiB, almost the entire second frame of 16KiB is stored, but not the full frame. As a result, a large copy of ~16KiB is performed.

## Solution
This PR increases the read buffer length by 512 bytes to ensure two entire 16KiB frames can be stored. This ensures that usually, only ~512 bytes needs to be moved to the front.

## Benchmark
In a GCS directpath benchmark downloading files in a loop, the time spent on memory copies in the ALTS code is eliminated, saving ~3.7% of CPU time.

### Before
<img width="1532" height="480" alt="image" src="https://github.com/user-attachments/assets/c2051b7f-e828-44d6-a82a-0d444cace2df" />


### After
<img width="1550" height="690" alt="image" src="https://github.com/user-attachments/assets/5715c5b8-b163-474c-81a6-5bcc6808d2ff" />

RELEASE NOTES:
* credentials/alts: optimize read buffer alignment to reduce copies.