### PR TITLE
xds: Revert workaround to get SubConn locality

### DIFF
--- a/balancer/balancer.go
+++ b/balancer/balancer.go
@@ -75,8 +75,6 @@ func unregisterForTesting(name string) {
 
 func init() {
 	internal.BalancerUnregister = unregisterForTesting
-	internal.ConnectedAddress = connectedAddress
-	internal.SetConnectedAddress = setConnectedAddress
 }
 
 // Get returns the resolver builder registered with the given name.

--- a/balancer/subconn.go
+++ b/balancer/subconn.go
@@ -111,20 +111,6 @@ type SubConnState struct {
 	// ConnectionError is set if the ConnectivityState is TransientFailure,
 	// describing the reason the SubConn failed.  Otherwise, it is nil.
 	ConnectionError error
-	// connectedAddr contains the connected address when ConnectivityState is
-	// Ready. Otherwise, it is indeterminate.
-	connectedAddress resolver.Address
-}
-
-// connectedAddress returns the connected address for a SubConnState. The
-// address is only valid if the state is READY.
-func connectedAddress(scs SubConnState) resolver.Address {
-	return scs.connectedAddress
-}
-
-// setConnectedAddress sets the connected address for a SubConnState.
-func setConnectedAddress(scs *SubConnState, addr resolver.Address) {
-	scs.connectedAddress = addr
 }
 
 // A Producer is a type shared among potentially many consumers.  It is

--- a/balancer_wrapper.go
+++ b/balancer_wrapper.go
@@ -36,7 +36,6 @@ import (
 )
 
 var (
-	setConnectedAddress = internal.SetConnectedAddress.(func(*balancer.SubConnState, resolver.Address))
 	// noOpRegisterHealthListenerFn is used when client side health checking is
 	// disabled. It sends a single READY update on the registered listener.
 	noOpRegisterHealthListenerFn = func(_ context.Context, listener func(balancer.SubConnState)) func() {
@@ -305,7 +304,7 @@ func newHealthData(s connectivity.State) *healthData {
 
 // updateState is invoked by grpc to push a subConn state update to the
 // underlying balancer.
-func (acbw *acBalancerWrapper) updateState(s connectivity.State, curAddr resolver.Address, err error) {
+func (acbw *acBalancerWrapper) updateState(s connectivity.State, err error) {
 	acbw.ccb.serializer.TrySchedule(func(ctx context.Context) {
 		if ctx.Err() != nil || acbw.ccb.balancer == nil {
 			return
@@ -317,9 +316,6 @@ func (acbw *acBalancerWrapper) updateState(s connectivity.State, curAddr resolve
 		// opts.StateListener is set, so this cannot ever be nil.
 		// TODO: delete this comment when UpdateSubConnState is removed.
 		scs := balancer.SubConnState{ConnectivityState: s, ConnectionError: err}
-		if s == connectivity.Ready {
-			setConnectedAddress(&scs, curAddr)
-		}
 		// Invalidate the health listener by updating the healthData.
 		acbw.healthMu.Lock()
 		// A race may occur if a health listener is registered soon after the

--- a/clientconn.go
+++ b/clientconn.go
@@ -1297,7 +1297,7 @@ func (ac *addrConn) updateConnectivityState(s connectivity.State, lastErr error)
 	} else {
 		channelz.Infof(logger, ac.channelz, "Subchannel Connectivity change to %v, last error: %s", s, lastErr)
 	}
-	ac.acbw.updateState(s, ac.curAddr, lastErr)
+	ac.acbw.updateState(s, lastErr)
 }
 
 // adjustParams updates parameters used to create transports upon

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -211,13 +211,6 @@ var (
 	// default resolver scheme.
 	UserSetDefaultScheme = false
 
-	// ConnectedAddress returns the connected address for a SubConnState. The
-	// address is only valid if the state is READY.
-	ConnectedAddress any // func (scs SubConnState) resolver.Address
-
-	// SetConnectedAddress sets the connected address for a SubConnState.
-	SetConnectedAddress any // func(scs *SubConnState, addr resolver.Address)
-
 	// SnapshotMetricRegistryForTesting snapshots the global data of the metric
 	// registry. Returns a cleanup function that sets the metric registry to its
 	// original state. Only called in testing functions.

--- a/internal/xds/balancer/clusterimpl/clusterimpl.go
+++ b/internal/xds/balancer/clusterimpl/clusterimpl.go
@@ -29,13 +29,11 @@ import (
 	"fmt"
 	"slices"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"google.golang.org/grpc/balancer"
 	"google.golang.org/grpc/balancer/weightedroundrobin"
 	"google.golang.org/grpc/connectivity"
-	"google.golang.org/grpc/internal"
 	"google.golang.org/grpc/internal/balancer/gracefulswitch"
 	"google.golang.org/grpc/internal/grpclog"
 	"google.golang.org/grpc/internal/pretty"
@@ -58,7 +56,6 @@ const (
 )
 
 var (
-	connectedAddress = internal.ConnectedAddress.(func(balancer.SubConnState) resolver.Address)
 	// Below function is no-op in actual code, but can be overridden in
 	// tests to give tests visibility into exactly when certain events happen.
 	clientConnUpdateHook = func() {}
@@ -418,22 +415,9 @@ func (b *clusterImplBalancer) getClusterName() string {
 type scWrapper struct {
 	balancer.SubConn
 
-	// locality needs to be atomic because it can be updated while being read by
-	// the picker.
-	locality atomic.Pointer[clients.Locality]
+	localityID clients.Locality
+
 	hostname string
-}
-
-func (scw *scWrapper) updateLocalityID(lID clients.Locality) {
-	scw.locality.Store(&lID)
-}
-
-func (scw *scWrapper) localityID() clients.Locality {
-	lID := scw.locality.Load()
-	if lID == nil {
-		return clients.Locality{}
-	}
-	return *lID
 }
 
 func (b *clusterImplBalancer) NewSubConn(addrs []resolver.Address, opts balancer.NewSubConnOptions) (balancer.SubConn, error) {
@@ -446,27 +430,11 @@ func (b *clusterImplBalancer) NewSubConn(addrs []resolver.Address, opts balancer
 	scw := &scWrapper{}
 	if len(addrs) > 0 {
 		scw.hostname = xdsresource.Hostname(addrs[0])
+		scw.localityID = xdsinternal.GetLocalityID(addrs[0])
 	}
 	oldListener := opts.StateListener
 	opts.StateListener = func(state balancer.SubConnState) {
 		b.updateSubConnState(sc, state, oldListener)
-		if state.ConnectivityState != connectivity.Ready {
-			return
-		}
-		// Read connected address and call updateLocalityID() based on the connected
-		// address's locality. https://github.com/grpc/grpc-go/issues/7339
-		addr := connectedAddress(state)
-		lID := xdsinternal.GetLocalityID(addr)
-		if (lID == clients.Locality{}) {
-			if b.logger.V(2) {
-				// TODO: After A74, we should have the entire CDS config,
-				// allowing us to verify if this is indeed a Logical DNS cluster
-				// and avoid logging the message below.
-				b.logger.Infof("No Locality ID found for address %s. This is normal if %q is a Logical DNS cluster.", addr, clusterName)
-			}
-			return
-		}
-		scw.updateLocalityID(lID)
 	}
 	sc, err := b.ClientConn.NewSubConn(newAddrs, opts)
 	if err != nil {
@@ -480,19 +448,6 @@ func (b *clusterImplBalancer) RemoveSubConn(sc balancer.SubConn) {
 	b.logger.Errorf("RemoveSubConn(%v) called unexpectedly", sc)
 }
 
-func (b *clusterImplBalancer) UpdateAddresses(sc balancer.SubConn, addrs []resolver.Address) {
-	clusterName := b.getClusterName()
-	newAddrs := make([]resolver.Address, len(addrs))
-	var lID clients.Locality
-	for i, addr := range addrs {
-		newAddrs[i] = xdsinternal.SetXDSHandshakeClusterName(addr, clusterName)
-		lID = xdsinternal.GetLocalityID(newAddrs[i])
-	}
-	if scw, ok := sc.(*scWrapper); ok {
-		scw.updateLocalityID(lID)
-		// Need to get the original SubConn from the wrapper before calling
-		// parent ClientConn.
-		sc = scw.SubConn
-	}
-	b.ClientConn.UpdateAddresses(sc, newAddrs)
+func (b *clusterImplBalancer) UpdateAddresses(sc balancer.SubConn, _ []resolver.Address) {
+	b.logger.Errorf("UpdateAddresses(%v) called unexpectedly", sc)
 }

--- a/internal/xds/balancer/clusterimpl/picker.go
+++ b/internal/xds/balancer/clusterimpl/picker.go
@@ -145,7 +145,7 @@ func (d *picker) Pick(info balancer.PickInfo) (balancer.PickResult, error) {
 		pr.SubConn = scw.SubConn
 		// If locality ID isn't found in the wrapper, an empty locality ID will
 		// be used.
-		lID = scw.localityID()
+		lID = scw.localityID
 
 		if scw.hostname != "" && autoHostRewriteEnabled(info.Ctx) {
 			if pr.Metadata == nil {


### PR DESCRIPTION
#7378 added an internal API to propagate the locality ID of each address used by a subchannel. This was required because the legacy pick_first implementation created subchannels with multiple addresses, each with a potentially different locality. Since the legacy implementation has been removed, and the new pick_first creates subchannels with only a single address, this workaround is now redundant. This PR also make the `UpdateAddresses` method of `clusterImpl` balancer a no-op since none of the leaf policies use it anymore.

RELEASE NOTES: N/A
