### PR TITLE
xdsdepmgr: Avoid using actual DNS lookups and fix race during test failure

### DIFF
--- a/internal/xds/xdsdepmgr/xds_dependency_manager_test.go
+++ b/internal/xds/xdsdepmgr/xds_dependency_manager_test.go
@@ -109,7 +109,11 @@ func (w *testWatcher) Update(cfg *xdsresource.XDSConfig) {
 
 // Error sends the received error to the error channel.
 func (w *testWatcher) Error(err error) {
-	w.errorCh <- err
+	select {
+	case <-w.done:
+		return
+	case w.errorCh <- err:
+	}
 }
 
 // Closes the testWatcher.done channel which will stop the updates being pushed


### PR DESCRIPTION
Fixes: https://github.com/grpc/grpc-go/issues/8801

There were 2 problems here : 
1. The actual DNS lookup calls return different resolved addresses for "localhost" on different machines. Changed the code to replace the DNS resolver with a manual resolver in test to mock the DNS resolver.

2. In the case where the tests send a EDS or cluster error , the xds management server keeps sending resource error continuously which in turn triggers updates from dependency manager which pushes the [update to a channel.](https://github.com/grpc/grpc-go/blob/bccbb10454782f18ecdfd60ca39ef413357edb0b/internal/xds/xdsdepmgr/xds_dependency_manager_test.go#L97) To mitigate this situation we had a done channel , that we [close when the test ends](https://github.com/grpc/grpc-go/blob/bccbb10454782f18ecdfd60ca39ef413357edb0b/internal/xds/xdsdepmgr/xds_dependency_manager_test.go#L1273) and the update function [check](https://github.com/grpc/grpc-go/blob/bccbb10454782f18ecdfd60ca39ef413357edb0b/internal/xds/xdsdepmgr/xds_dependency_manager_test.go#L95) for the done channel , if it is close, it returns. In [TestAggregateCLusterChildError](https://github.com/grpc/grpc-go/blob/bccbb10454782f18ecdfd60ca39ef413357edb0b/internal/xds/xdsdepmgr/xds_dependency_manager_test.go#L1170) test , (and other tests too) , the channel was being closed at the end of the test , which meant it will close only when the test passes. And if the tests fails, the done channel was not getting closed , which made the update function to block.
Changed the close(done channel) to be a defer function , but this should be the first thing that happens after the test is done , before the dependency manager closes, so this is the last defer called in the test.

Also fixes `TestRouteConfigResourceError` flaking due to a similar error.

RELEASE NOTES: None
