### PR TITLE
test: add regression test for RecvMsg() error shadowing #7510

### DIFF
--- a/stream_test.go
+++ b/stream_test.go
@@ -20,9 +20,11 @@ package grpc_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/internal/grpctest"
 	"google.golang.org/grpc/internal/stubserver"
@@ -64,5 +66,81 @@ func (s) TestStream_Header_TrailersOnly(t *testing.T) {
 	}
 	if _, err := s.Recv(); status.Code(err) != codes.NotFound {
 		t.Fatalf("s.Recv() = _, %v; want _, err.Code()=codes.NotFound", err)
+	}
+}
+
+// TestUnaryClient_ServerStreamingMismatch ensures that the client's
+// non-streaming RecvMsg() logic correctly handles various error scenarios
+// from the server.
+//
+// The Client initiates a Unary RPC (Invoke), forcing it to use the
+// non-server-streaming `recvMsg` code path (where the bug was).
+// The Server handles it as a Streaming RPC (FullDuplexCall), allowing us to
+// send arbitrary sequences of messages and errors.
+func (s) TestUnaryClient_ServerStreamingMismatch(t *testing.T) {
+	tests := []struct {
+		name              string
+		fullDuplexCallF   func(testgrpc.TestService_FullDuplexCallServer) error
+		wantErrorContains string
+		wantCode          codes.Code
+		clientCallOptions []grpc.CallOption
+	}{
+		{
+			name: "server_sends_error_after_message",
+			fullDuplexCallF: func(stream testgrpc.TestService_FullDuplexCallServer) error {
+				if err := stream.Send(&testgrpc.StreamingOutputCallResponse{}); err != nil {
+					return err
+				}
+				return status.Error(codes.Internal, "server error after message")
+			},
+			wantErrorContains: "server error after message",
+			wantCode:          codes.Internal,
+		},
+		{
+			name: "server_sends_second_message_exceeding_limit",
+			fullDuplexCallF: func(stream testgrpc.TestService_FullDuplexCallServer) error {
+				if err := stream.Send(&testgrpc.StreamingOutputCallResponse{
+					Payload: &testgrpc.Payload{Body: make([]byte, 1)},
+				}); err != nil {
+					return err
+				}
+				return stream.Send(&testgrpc.StreamingOutputCallResponse{
+					Payload: &testgrpc.Payload{Body: make([]byte, 10)},
+				})
+			},
+			clientCallOptions: []grpc.CallOption{grpc.MaxCallRecvMsgSize(5)},
+			wantErrorContains: "received message larger than max",
+			wantCode:          codes.ResourceExhausted,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ss := &stubserver.StubServer{
+				FullDuplexCallF: test.fullDuplexCallF,
+			}
+			if err := ss.Start(nil); err != nil {
+				t.Fatal("Error starting server:", err)
+			}
+			defer ss.Stop()
+
+			ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+			defer cancel()
+
+			// Invoke the streaming RPC method as a Unary RPC. This forces the client
+			// to use the non-streaming RecvMsg path, while the server handles it as
+			// a stream (allowing it to send messages and errors in ways a standard
+			// Unary server cannot).
+			err := ss.CC.Invoke(ctx, "/grpc.testing.TestService/FullDuplexCall", &testgrpc.StreamingOutputCallRequest{}, &testgrpc.StreamingOutputCallResponse{}, test.clientCallOptions...)
+			if err == nil {
+				t.Fatal("Client.Invoke returned nil, want error")
+			}
+			if status.Code(err) != test.wantCode {
+				t.Errorf("Unexpected error code: got %v, want %v", status.Code(err), test.wantCode)
+			}
+			if !strings.Contains(err.Error(), test.wantErrorContains) {
+				t.Errorf("Unexpected error message: got %v, want %v", err.Error(), test.wantErrorContains)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Fixes: #7510 

This PR adds a regression test for a bug where `RecvMsg` could swallow errors in non-server-streaming RPCs (fixed in #7505).

Prior to the fix, a variable shadowing error in `csAttempt.recvMsg` caused errors to be ignored in specific scenarios. When `RecvMsg` called `recv` to check for an expected `EOF` after a successful message, any other error returned by `recv` was shadowed by the outer scope's `err` variable, leading `RecvMsg` to return `nil` instead of the actual error.

This test verifies that `RecvMsg` correctly propagates these errors instead of swallowing them, preventing future regressions of this logic.

RELEASE NOTES: N/A