### PR TITLE
xds: fix connection churn in priority balancer by making name generation deterministic

### DIFF
--- a/internal/xds/balancer/clusterresolver/configbuilder_childname_test.go
+++ b/internal/xds/balancer/clusterresolver/configbuilder_childname_test.go
@@ -96,12 +96,86 @@ func Test_nameGenerator_generate(t *testing.T) {
 			},
 			want: []string{"priority-0-0", "priority-0-2", "priority-0-1"},
 		},
+		{
+			name:   "merge priorities, pick lowest existing name",
+			prefix: 0,
+			// Initial state simulation:
+			// Update 1: P0=[A], P1=[B, C, D, E]
+			// We simulate this by input1.
+			// A has 0-0. B has 0-1.
+			input1: [][]xdsresource.Locality{
+				{{ID: clients.Locality{Zone: "A"}}},
+				{{ID: clients.Locality{Zone: "B"}}, {ID: clients.Locality{Zone: "C"}}, {ID: clients.Locality{Zone: "D"}}, {ID: clients.Locality{Zone: "E"}}},
+			},
+			// Update 2: P0=[B, A], P1=[C, D, E]
+			input2: [][]xdsresource.Locality{
+				// B comes first. Previous code picks 0-1. We want 0-0 (A's name).
+				{{ID: clients.Locality{Zone: "B"}}, {ID: clients.Locality{Zone: "A"}}},
+				{{ID: clients.Locality{Zone: "C"}}, {ID: clients.Locality{Zone: "D"}}, {ID: clients.Locality{Zone: "E"}}},
+			},
+			// We want P0 to be "priority-0-0" (stable with A).
+			// We want P1 to be "priority-0-1" (stable with C).
+			want: []string{"priority-0-0", "priority-0-1"},
+		},
+		{
+			name:   "complex shuffle, verify stability",
+			prefix: 0,
+			// Initial: P0=[A,B,C] (0-0), P1=[D,E] (0-1)
+			input1: [][]xdsresource.Locality{
+				{{ID: clients.Locality{Zone: "A"}}, {ID: clients.Locality{Zone: "B"}}, {ID: clients.Locality{Zone: "C"}}},
+				{{ID: clients.Locality{Zone: "D"}}, {ID: clients.Locality{Zone: "E"}}},
+			},
+			// Update: P0=[B,C], P1=[A,D,E]
+			// P0 takes 0-0 (from B,C).
+			// P1 takes 0-1 (from D,E). A's 0-0 is taken.
+			input2: [][]xdsresource.Locality{
+				{{ID: clients.Locality{Zone: "B"}}, {ID: clients.Locality{Zone: "C"}}},
+				{{ID: clients.Locality{Zone: "A"}}, {ID: clients.Locality{Zone: "D"}}, {ID: clients.Locality{Zone: "E"}}},
+			},
+			want: []string{"priority-0-0", "priority-0-1"},
+		},
+		{
+			name:   "traffic spillover reversal (sticky naming)",
+			prefix: 0,
+			// Initial: P0=[A] (0-0), P1=[B] (0-1)
+			input1: [][]xdsresource.Locality{
+				{{ID: clients.Locality{Zone: "A"}}},
+				{{ID: clients.Locality{Zone: "B"}}},
+			},
+			// Update 2: Recovery. P0=[B, A].
+			// Candidates for P0: [0-1 (from B), 0-0 (from A)].
+			// Sticky check: Ordered[0] (from Update 1) is 0-1.
+			// 0-1 IS in candidates.
+			// Pick 0-1.
+			// (Simple sort would pick 0-0, causing churn).
+			input2: [][]xdsresource.Locality{
+				{{ID: clients.Locality{Zone: "B"}}, {ID: clients.Locality{Zone: "A"}}},
+			},
+			want: []string{"priority-0-1"},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ng := newNameGenerator(tt.prefix)
 			got1 := ng.generate(tt.input1)
-			t.Logf("%v", got1)
+			t.Logf("Update 1: %v", got1)
+
+			// Special handling for the sticky test case to simulate the intermediate failover step
+			if tt.name == "traffic spillover reversal (sticky naming)" {
+				// Intermediate Failover Step: P0=[B]
+				failoverInput := [][]xdsresource.Locality{
+					{{ID: clients.Locality{Zone: "B"}}},
+				}
+				gotFailover := ng.generate(failoverInput)
+				t.Logf("Update Failover: %v", gotFailover)
+
+				// Verification of Failover state: P0 should take 0-1 (B's name)
+				// Because B (0-1) is the only candidate, and 0-0 (from A) is gone.
+				if diff := cmp.Diff(gotFailover, []string{"priority-0-1"}); diff != "" {
+					t.Errorf("Failover generate() = got: %v, want: %v, diff (-got +want): %s", gotFailover, []string{"priority-0-1"}, diff)
+				}
+			}
+
 			got := ng.generate(tt.input2)
 			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("generate() = got: %v, want: %v, diff (-got +want): %s", got, tt.want, diff)


### PR DESCRIPTION
Fixes #6441
This PR fixes an issue where the priority balancer would unnecessarily close and recreate child balancers (and their underlying connections) when localities moved between priority groups or when the priority configuration was updated.

**The Problem**: The nameGenerator previously assigned names to priority groups based on the first available name it found from the localities in that group. This made name assignment order-dependent. In scenarios where localities from different previous priorities were merged (e.g., "Traffic Spillover Reversal"), the priority group often ended up with a name different from the one used by the primary locality, causing the priority balancer to see it as a "new" child, leading to connection drops.

**The Solution**:
 - Deterministic Selection: The generator now collects all candidate names for a priority group and sorts them to ensure deterministic selection.
 - Sticky Naming: The generator tracks the name assigned to each priority index in the previous update. If that name is still valid (i.e., brought by one of the current localities), it is preferred over the sorted lowest-ID choice. This ensures that a priority group "sticks" to its existing balancer name during recovery or partial failover, preserving active connections.

RELEASE NOTES:
* xds: fix connection churn in the priority balancer by ensuring stable child balancer naming when localities move between priority groups.
