### PR TITLE
encoding: remove unused `DecompressedSize` API

### DIFF
--- a/encoding/encoding.go
+++ b/encoding/encoding.go
@@ -58,10 +58,6 @@ func init() {
 
 // Compressor is used for compressing and decompressing when sending or
 // receiving messages.
-//
-// If a Compressor implements `DecompressedSize(compressedBytes []byte) int`,
-// gRPC will invoke it to determine the size of the buffer allocated for the
-// result of decompression.  A return value of -1 indicates unknown size.
 type Compressor interface {
 	// Compress writes the data written to wc to w after compressing it.  If an
 	// error occurs while initializing the compressor, that error is returned

--- a/encoding/gzip/gzip.go
+++ b/encoding/gzip/gzip.go
@@ -27,7 +27,6 @@ package gzip
 
 import (
 	"compress/gzip"
-	"encoding/binary"
 	"fmt"
 	"io"
 	"sync"
@@ -109,17 +108,6 @@ func (z *reader) Read(p []byte) (n int, err error) {
 		z.pool.Put(z)
 	}
 	return n, err
-}
-
-// RFC1952 specifies that the last four bytes "contains the size of
-// the original (uncompressed) input data modulo 2^32."
-// gRPC has a max message size of 2GB so we don't need to worry about wraparound.
-func (c *compressor) DecompressedSize(buf []byte) int {
-	last := len(buf)
-	if last < 4 {
-		return -1
-	}
-	return int(binary.LittleEndian.Uint32(buf[last-4 : last]))
 }
 
 func (c *compressor) Name() string {


### PR DESCRIPTION
Fixes: #7788 

This change removes the unused `DecompressedSize` API from the gzip `compressor` and the corresponding documentation in the encoding package.

RELEASE NOTES: N/A