### PR TITLE
balancer: introduce env flag for case-sensitive registry

### DIFF
--- a/internal/envconfig/envconfig.go
+++ b/internal/envconfig/envconfig.go
@@ -78,6 +78,14 @@ var (
 	//   - The DNS resolver is being used.
 	EnableDefaultPortForProxyTarget = boolFromEnv("GRPC_EXPERIMENTAL_ENABLE_DEFAULT_PORT_FOR_PROXY_TARGET", true)
 
+	// CaseSensitiveBalancerRegistries is set if the balancer registry should be
+	// case-sensitive. This is disabled by default, but can be enabled by setting
+	// the env variable "GRPC_GO_EXPERIMENTAL_CASE_SENSITIVE_BALANCER_REGISTRIES"
+	// to "true".
+	//
+	// TODO: After 2 releases, we will enable the env var by default.
+	CaseSensitiveBalancerRegistries = boolFromEnv("GRPC_GO_EXPERIMENTAL_CASE_SENSITIVE_BALANCER_REGISTRIES", false)
+
 	// XDSAuthorityRewrite indicates whether xDS authority rewriting is enabled.
 	// This feature is defined in gRFC A81 and is enabled by setting the
 	// environment variable GRPC_EXPERIMENTAL_XDS_AUTHORITY_REWRITE to "true".


### PR DESCRIPTION
Part of #5288

Follow up of PR: #6647 

This PR introduces the `GRPC_GO_EXPERIMENTAL_CASE_SENSITIVE_BALANCER_REGISTRIES` environment variable to transition balancer registries to be case-sensitive. 
 
 **Default Behavior**: 
    *   The env var is disabled by default.
    *   The registry remains case-insensitive (legacy behavior) and  a warning is logged if a balancer name contains uppercase letters, notifying users of the upcoming change.

RELEASE NOTES:
* balancer: grpc will log a warning if balancer registries are used with uppercase letter(s).
