### PR TITLE
xds: authority rewrite literal

### DIFF
--- a/internal/envconfig/envconfig.go
+++ b/internal/envconfig/envconfig.go
@@ -82,6 +82,11 @@ var (
 	// This feature is defined in gRFC A81 and is enabled by setting the
 	// environment variable GRPC_EXPERIMENTAL_XDS_AUTHORITY_REWRITE to "true".
 	XDSAuthorityRewrite = boolFromEnv("GRPC_EXPERIMENTAL_XDS_AUTHORITY_REWRITE", false)
+
+	// XDSLiteralAuthorityRewrite indicates whether xDS host_rewrite_literal field
+	// is honored. This feature is defined in gRFC A111 and is enabled by setting the
+	// environment variable GRPC_EXPERIMENTAL_XDS_LITERAL_AUTHORITY_REWRITE to "true".
+	XDSLiteralAuthorityRewrite = boolFromEnv("GRPC_EXPERIMENTAL_XDS_LITERAL_AUTHORITY_REWRITE", false)
 )
 
 func boolFromEnv(envVar string, def bool) bool {

--- a/internal/xds/resolver/serviceconfig.go
+++ b/internal/xds/resolver/serviceconfig.go
@@ -109,13 +109,14 @@ type routeCluster struct {
 }
 
 type route struct {
-	m                 *xdsresource.CompositeMatcher // converted from route matchers
-	actionType        xdsresource.RouteActionType   // holds route action type
-	clusters          wrr.WRR                       // holds *routeCluster entries
-	maxStreamDuration time.Duration
-	retryConfig       *xdsresource.RetryConfig
-	hashPolicies      []*xdsresource.HashPolicy
-	autoHostRewrite   bool
+	m                  *xdsresource.CompositeMatcher // converted from route matchers
+	actionType         xdsresource.RouteActionType   // holds route action type
+	clusters           wrr.WRR                       // holds *routeCluster entries
+	maxStreamDuration  time.Duration
+	retryConfig        *xdsresource.RetryConfig
+	hashPolicies       []*xdsresource.HashPolicy
+	autoHostRewrite    bool
+	hostRewriteLiteral string
 }
 
 func (r route) String() string {
@@ -201,6 +202,9 @@ func (cs *configSelector) SelectConfig(rpcInfo iresolver.RPCInfo) (*iresolver.RP
 	lbCtx = iringhash.SetXDSRequestHash(lbCtx, cs.generateHash(rpcInfo, rt.hashPolicies))
 	if rt.autoHostRewrite {
 		lbCtx = clusterimpl.EnableAutoHostRewrite(lbCtx)
+	}
+	if rt.hostRewriteLiteral != "" {
+		lbCtx = clusterimpl.SetHostRewriteLiteral(lbCtx, rt.hostRewriteLiteral)
 	}
 
 	config := &iresolver.RPCConfig{

--- a/internal/xds/resolver/xds_resolver.go
+++ b/internal/xds/resolver/xds_resolver.go
@@ -397,6 +397,7 @@ func (r *xdsResolver) newConfigSelector() (*configSelector, error) {
 		cs.routes[i].retryConfig = rt.RetryConfig
 		cs.routes[i].hashPolicies = rt.HashPolicies
 		cs.routes[i].autoHostRewrite = rt.AutoHostRewrite
+		cs.routes[i].hostRewriteLiteral = rt.HostRewriteLiteral
 	}
 
 	// Account for this config selector's clusters.  Do this after no further

--- a/internal/xds/xdsclient/xdsresource/type_rds.go
+++ b/internal/xds/xdsclient/xdsresource/type_rds.go
@@ -150,9 +150,14 @@ type Route struct {
 	// ClusterSpecifierPlugin is the name of the Cluster Specifier Plugin that
 	// this Route is linked to, if specified by xDS.
 	ClusterSpecifierPlugin string
+
 	// AutoHostRewrite indicates that the ":authority" header can be rewritten
 	// to the hostname of the upstream endpoint.
 	AutoHostRewrite bool
+
+	// HostRewriteLiteral contains the Host override that is set by the Route
+	// Action host_rewrite_literal.
+	HostRewriteLiteral string
 }
 
 // WeightedCluster contains settings for an xds ActionType.WeightedCluster.

--- a/internal/xds/xdsclient/xdsresource/unmarshal_rds.go
+++ b/internal/xds/xdsclient/xdsresource/unmarshal_rds.go
@@ -304,9 +304,12 @@ func routesProtoToSlice(routes []*v3routepb.Route, csps map[string]clusterspecif
 		case *v3routepb.Route_Route:
 			action := r.GetRoute()
 
-			if envconfig.XDSAuthorityRewrite {
-				if opts != nil && opts.ServerConfig != nil && opts.ServerConfig.SupportsServerFeature(xdsclient.ServerFeatureTrustedXDSServer) {
+			if opts != nil && opts.ServerConfig != nil && opts.ServerConfig.SupportsServerFeature(xdsclient.ServerFeatureTrustedXDSServer) {
+				if envconfig.XDSAuthorityRewrite {
 					route.AutoHostRewrite = action.GetAutoHostRewrite().GetValue()
+				}
+				if envconfig.XDSLiteralAuthorityRewrite {
+					route.HostRewriteLiteral = action.GetHostRewriteLiteral()
 				}
 			}
 


### PR DESCRIPTION
This implements respecting the `host_rewrite` route action for grpc-xds clients. The grpc-proposal for this issue is [here](https://github.com/grpc/proposal/pull/533).

There was also an initial discussion [here](https://github.com/grpc/grpc/issues/38062)

RELEASE NOTES:
* xds: Adds support for `host_rewrite` route action for grpc-xds clients. gRFC A111