### PR TITLE
Fix flaky `TestServer_RedundantUpdateSuppression`.

### DIFF
--- a/xds/server_resource_ext_test.go
+++ b/xds/server_resource_ext_test.go
@@ -223,7 +223,7 @@ func (s) TestServer_RedundantUpdateSuppression(t *testing.T) {
 	testutils.AwaitState(ctx, t, cc, connectivity.Ready)
 	errCh := make(chan error, 1)
 	go func() {
-		prev := connectivity.Ready // We know we are READY since we just did an RPC.
+		prev := connectivity.Ready
 		for {
 			curr := cc.GetState()
 			if !(curr == connectivity.Ready || curr == connectivity.Idle) {


### PR DESCRIPTION
Fixes #7713

The `TestServer_RedundantUpdateSuppression` test was flaky because it began monitoring ClientConn state transitions before the connection had fully stabilized in the expected Ready state.

This created a race condition where the monitoring loop could capture initial setup transitions (e.g., Connecting) and falsely report them as unexpected failures caused by the redundant update.

Successfully run the test on forge for 1 million times without any flake.

RELEASE NOTES: N/A