### PR TITLE
documentation: improve proxy documentation

### DIFF
--- a/Documentation/proxy.md
+++ b/Documentation/proxy.md
@@ -4,17 +4,15 @@ HTTP CONNECT proxies are supported by default in gRPC. The proxy address can be
 specified by the environment variables `HTTPS_PROXY` and `NO_PROXY`.  (Note that
 these environment variables are case insensitive.)
 
-**NOTE**: Talking to CONNECT proxies using https is not supported. gRPC performs
-a plaintext CONNECT handshake to establish a tunnel and does not support the
+**NOTE**: Using CONNECT proxies via https is not supported. gRPC performs a
+plaintext CONNECT handshake to establish a tunnel and does not support the
 additional encryption required to secure the initial connection to the proxy
-itself. We have an open [feature
-request](https://github.com/grpc/grpc/issues/35372) for it and might support it
-in future.
+itself.
 
-Not using https to talk to CONNECT proxy does not compromise security.
-The gRPC traffic is encrypted end-to-end between the client and the destination
-server. The HTTP CONNECT proxy only sees the destination address and cannot
-intercept the encrypted gRPC data.
+When using TLS, the gRPC traffic is encrypted end-to-end between the client and
+the destination server. Even when using a CONNECT proxy without https, the
+security is not compromised, as the proxy only sees the destination address and
+cannot intercept the encrypted gRPC data.
 
 ## Custom proxy
 


### PR DESCRIPTION
Fixes: https://github.com/grpc/grpc-go/issues/8618

This PR improves the documentation for HTTP CONNECT proxy in `proxy.md` and clearly states that the connect from client to proxy through https is not supported and also mentioned that in case of TLS, it does not compromise security.

RELEASE NOTES: None
