### PR TITLE
balancer: remove deprecated metadata field from Address

### DIFF
--- a/balancer/pickfirst/pickfirst_ext_test.go
+++ b/balancer/pickfirst/pickfirst_ext_test.go
@@ -46,7 +46,6 @@ import (
 	"google.golang.org/grpc/internal/testutils"
 	"google.golang.org/grpc/internal/testutils/pickfirst"
 	"google.golang.org/grpc/internal/testutils/stats"
-	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/resolver"
 	"google.golang.org/grpc/resolver/manual"
 	"google.golang.org/grpc/serviceconfig"
@@ -2539,11 +2538,6 @@ func (s) TestPickFirstLeaf_AddressUpdateWithMetadata(t *testing.T) {
 	// Add a metadata to the addresses before pushing them to the pick_first LB
 	// policy through the manual resolver.
 	addrs := backends.resolverAddrs()
-	for i := range addrs {
-		addrs[i].Metadata = &metadata.MD{
-			"test-metadata-1": []string{fmt.Sprintf("%d", i)},
-		}
-	}
 	r.UpdateState(resolver.State{Addresses: addrs})
 
 	// Ensure that RPCs succeed to the expected backend.
@@ -2557,14 +2551,6 @@ func (s) TestPickFirstLeaf_AddressUpdateWithMetadata(t *testing.T) {
 	// is not re-established.
 	holds := backends.holds(dialer)
 
-	// Add metadata to the addresses before pushing them to the pick_first LB
-	// policy through the manual resolver. Leave the order of the addresses
-	// unchanged.
-	for i := range addrs {
-		addrs[i].Metadata = &metadata.MD{
-			"test-metadata-2": []string{fmt.Sprintf("%d", i)},
-		}
-	}
 	r.UpdateState(resolver.State{Addresses: addrs})
 
 	// Ensure that no new connection is established.
@@ -2580,13 +2566,6 @@ func (s) TestPickFirstLeaf_AddressUpdateWithMetadata(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Add metadata to the addresses before pushing them to the pick_first LB
-	// policy through the manual resolver. Reverse of the order of addresses.
-	for i := range addrs {
-		addrs[i].Metadata = &metadata.MD{
-			"test-metadata-3": []string{fmt.Sprintf("%d", i)},
-		}
-	}
 	addrs[0], addrs[1] = addrs[1], addrs[0]
 	r.UpdateState(resolver.State{Addresses: addrs})
 

--- a/clientconn.go
+++ b/clientconn.go
@@ -1003,8 +1003,7 @@ func (ac *addrConn) connect() {
 // that are meaningful to the subConn.
 func equalAddressIgnoringBalAttributes(a, b *resolver.Address) bool {
 	return a.Addr == b.Addr && a.ServerName == b.ServerName &&
-		a.Attributes.Equal(b.Attributes) &&
-		a.Metadata == b.Metadata
+		a.Attributes.Equal(b.Attributes)
 }
 
 func equalAddressesIgnoringBalAttributes(a, b []resolver.Address) bool {

--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -372,9 +372,7 @@ func NewHTTP2Client(connectCtx, ctx context.Context, addr resolver.Address, opts
 	// Add peer information to the http2client context.
 	t.ctx = peer.NewContext(t.ctx, t.Peer())
 
-	if md, ok := addr.Metadata.(*metadata.MD); ok {
-		t.md = *md
-	} else if md := imetadata.Get(addr); md != nil {
+	if md := imetadata.Get(addr); md != nil {
 		t.md = md
 	}
 	t.controlBuf = newControlBuffer(t.ctxDone)

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -113,12 +113,6 @@ type Address struct {
 	// Deprecated: when an Address is inside an Endpoint, this field should not
 	// be used, and it will eventually be removed entirely.
 	BalancerAttributes *attributes.Attributes
-
-	// Metadata is the information associated with Addr, which may be used
-	// to make load balancing decision.
-	//
-	// Deprecated: use Attributes instead.
-	Metadata any
 }
 
 // Equal returns whether a and o are identical.  Metadata is compared directly,
@@ -130,8 +124,7 @@ type Address struct {
 func (a Address) Equal(o Address) bool {
 	return a.Addr == o.Addr && a.ServerName == o.ServerName &&
 		a.Attributes.Equal(o.Attributes) &&
-		a.BalancerAttributes.Equal(o.BalancerAttributes) &&
-		a.Metadata == o.Metadata
+		a.BalancerAttributes.Equal(o.BalancerAttributes)
 }
 
 // String returns JSON formatted string representation of the address.


### PR DESCRIPTION
Fixes #3563
This is a cleanup PR which removes the deprecated `Metadata` field from Address struct. **This is a breaking change** and changes an experimental type.

RELEASE NOTES:
* balancer: remove deprecated metadata field from Address. **This is a breaking change** and changes an experimental type.
