### PR TITLE
xds: fix typo in log message

### DIFF
--- a/internal/xds/clients/xdsclient/authority.go
+++ b/internal/xds/clients/xdsclient/authority.go
@@ -784,7 +784,7 @@ func (a *authority) unwatchResource(rType ResourceType, resourceName string, wat
 			// reference to the xdsChannels.
 			if len(a.resources) == 0 {
 				if a.logger.V(2) {
-					a.logger.Infof("Removing last watch for for any resource type, releasing reference to the xdsChannel")
+					a.logger.Infof("Removing last watch for any resource type, releasing reference to the xdsChannel")
 				}
 				a.closeXDSChannels()
 			}


### PR DESCRIPTION
This PR fixes a minor typo in a log message.

## Change
- Fixed "for for" → "for" in `internal/xds/clients/xdsclient/authority.go`

This is a documentation-only change with no functional impact.

RELEASE NOTES: none