### PR TITLE
xds: remove `HashKey` field from `xdsresource.Endpoint` struct

### DIFF
--- a/internal/xds/balancer/clusterresolver/configbuilder.go
+++ b/internal/xds/balancer/clusterresolver/configbuilder.go
@@ -34,7 +34,6 @@ import (
 	"google.golang.org/grpc/internal/xds/balancer/wrrlocality"
 	"google.golang.org/grpc/internal/xds/xdsclient/xdsresource"
 	"google.golang.org/grpc/resolver"
-	"google.golang.org/grpc/resolver/ringhash"
 )
 
 const million = 1000000
@@ -286,7 +285,6 @@ func priorityLocalitiesToClusterImpl(localities []xdsresource.Locality, priority
 				ew = endpoint.Weight
 			}
 			resolverEndpoint = weight.Set(resolverEndpoint, weight.EndpointInfo{Weight: lw * ew})
-			resolverEndpoint = ringhash.SetHashKey(resolverEndpoint, endpoint.HashKey)
 			retEndpoints = append(retEndpoints, resolverEndpoint)
 		}
 	}

--- a/internal/xds/xdsclient/xdsresource/type_eds.go
+++ b/internal/xds/xdsclient/xdsresource/type_eds.go
@@ -54,7 +54,6 @@ type Endpoint struct {
 	ResolverEndpoint resolver.Endpoint
 	HealthStatus     EndpointHealthStatus
 	Weight           uint32
-	HashKey          string
 	Metadata         map[string]any
 }
 

--- a/internal/xds/xdsclient/xdsresource/unmarshal_eds.go
+++ b/internal/xds/xdsclient/xdsresource/unmarshal_eds.go
@@ -31,6 +31,7 @@ import (
 	xdsinternal "google.golang.org/grpc/internal/xds"
 	"google.golang.org/grpc/internal/xds/clients"
 	"google.golang.org/grpc/resolver"
+	"google.golang.org/grpc/resolver/ringhash"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 )
@@ -154,11 +155,11 @@ func parseEndpoints(lbEndpoints []*v3endpointpb.LbEndpoint, uniqueEndpointAddrs 
 		}
 		endpoint := resolver.Endpoint{Addresses: address}
 		endpoint = setHostname(endpoint, lbEndpoint.GetEndpoint().GetHostname())
+		endpoint = ringhash.SetHashKey(endpoint, hashKey)
 		endpoints = append(endpoints, Endpoint{
 			ResolverEndpoint: endpoint,
 			HealthStatus:     EndpointHealthStatus(lbEndpoint.GetHealthStatus()),
 			Weight:           weight,
-			HashKey:          hashKey,
 			Metadata:         endpointMetadata,
 		})
 	}

--- a/internal/xds/xdsclient/xdsresource/unmarshal_eds_test.go
+++ b/internal/xds/xdsclient/xdsresource/unmarshal_eds_test.go
@@ -35,6 +35,7 @@ import (
 	"google.golang.org/grpc/internal/xds/clients"
 	"google.golang.org/grpc/internal/xds/xdsclient/xdsresource/version"
 	"google.golang.org/grpc/resolver"
+	"google.golang.org/grpc/resolver/ringhash"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -477,7 +478,7 @@ func (s) TestUnmarshalEndpointHashKey(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unmarshalEndpointsResource() got error = %v, want success", err)
 			}
-			got := update.Localities[0].Endpoints[0].HashKey
+			got := ringhash.HashKey(update.Localities[0].Endpoints[0].ResolverEndpoint)
 			if got != test.wantHashKey {
 				t.Errorf("unmarshalEndpointResource() endpoint hash key: got %s, want %s", got, test.wantHashKey)
 			}


### PR DESCRIPTION
Part of : https://github.com/grpc/grpc-go/issues/8757

This PR removes the `HashKey` field from the `xdsresource.Endpoint` struct and adds it as an attribute while un-marshalling EDS instead of setting it as an attribute later on in cluster resolver balancer

RELEASE NOTES: None
