### PR TITLE
transport: warn when header list size exceeds 8KB

### DIFF
--- a/internal/transport/defaults.go
+++ b/internal/transport/defaults.go
@@ -46,6 +46,7 @@ const (
 	defaultWriteQuota              = 64 * 1024
 	defaultClientMaxHeaderListSize = uint32(16 << 20)
 	defaultServerMaxHeaderListSize = uint32(16 << 20)
+	upcomingDefaultHeaderListSize  = uint32(8 << 10)
 )
 
 // MaxStreamID is the upper bound for the stream ID before the current

--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -870,10 +870,14 @@ func (t *http2Client) NewStream(ctx context.Context, callHdr *CallHdr) (*ClientS
 		}
 		var sz int64
 		for _, f := range hdr.hf {
-			if sz += int64(f.Size()); sz > int64(*t.maxSendHeaderListSize) {
+			sz += int64(f.Size())
+			if sz > int64(*t.maxSendHeaderListSize) {
 				hdrListSizeErr = status.Errorf(codes.Internal, "header list size to send violates the maximum size (%d bytes) set by server", *t.maxSendHeaderListSize)
 				return false
 			}
+		}
+		if sz > int64(upcomingDefaultHeaderListSize) {
+			t.logger.Warningf("Header list size to send (%d bytes) is larger than the upcoming default limit (%d bytes). In a future release, this will be restricted to %d bytes.", sz, upcomingDefaultHeaderListSize, upcomingDefaultHeaderListSize)
 		}
 		return true
 	}

--- a/internal/transport/http2_server.go
+++ b/internal/transport/http2_server.go
@@ -940,12 +940,16 @@ func (t *http2Server) checkForHeaderListSize(hf []hpack.HeaderField) bool {
 	}
 	var sz int64
 	for _, f := range hf {
-		if sz += int64(f.Size()); sz > int64(*t.maxSendHeaderListSize) {
+		sz += int64(f.Size())
+		if sz > int64(*t.maxSendHeaderListSize) {
 			if t.logger.V(logLevel) {
 				t.logger.Infof("Header list size to send violates the maximum size (%d bytes) set by client", *t.maxSendHeaderListSize)
 			}
 			return false
 		}
+	}
+	if sz > int64(upcomingDefaultHeaderListSize) {
+		t.logger.Warningf("Header list size to send (%d bytes) is larger than the upcoming default limit (%d bytes). In a future release, this will be restricted to %d bytes.", sz, upcomingDefaultHeaderListSize, upcomingDefaultHeaderListSize)
 	}
 	return true
 }


### PR DESCRIPTION
Part of: #2308

This PR implements part 1 of the header list size limit rollout.

Currently, gRPC-Go defaults to a 16MB limit for the header list size. In a future release, this default will be reduced to 8KB to match other gRPC implementations.

This change introduces a warning log when outgoing headers exceed 8KB but are still within the current negotiated limit (16MB). This allows users to identify if their application will be affected by the future default change without breaking existing behavior.

RELEASE NOTES: N/A