### PR TITLE
balancer,fakegrpclb: Use log *f functions with format args

### DIFF
--- a/balancer/rls/config.go
+++ b/balancer/rls/config.go
@@ -265,7 +265,7 @@ func parseRLSProto(rlsProto *rlspb.RouteLookupConfig) (*lbConfig, error) {
 		return nil, fmt.Errorf("rls: cache_size_bytes must be set to a non-zero value: %+v", rlsProto)
 	}
 	if cacheSizeBytes > maxCacheSize {
-		logger.Info("rls: cache_size_bytes %v is too large, setting it to: %v", cacheSizeBytes, maxCacheSize)
+		logger.Infof("rls: cache_size_bytes %v is too large, setting it to: %v", cacheSizeBytes, maxCacheSize)
 		cacheSizeBytes = maxCacheSize
 	}
 	return &lbConfig{

--- a/internal/testutils/fakegrpclb/server.go
+++ b/internal/testutils/fakegrpclb/server.go
@@ -168,7 +168,7 @@ func (s *Server) BalanceLoad(stream lbgrpc.LoadBalancer_BalanceLoadServer) error
 		return nil
 	}
 	if err != nil {
-		logger.Warning("Failed to read LoadBalanceRequest from stream: %v", err)
+		logger.Warningf("Failed to read LoadBalanceRequest from stream: %v", err)
 		return err
 	}
 	logger.Infof("Received LoadBalancerRequest:\n%s", pretty.ToJSON(req))
@@ -191,16 +191,16 @@ func (s *Server) BalanceLoad(stream lbgrpc.LoadBalancer_BalanceLoadServer) error
 	} else {
 		p, err := strconv.Atoi(port)
 		if err != nil {
-			logger.Info("Failed to parse requested service port %q to integer", port)
+			logger.Infof("Failed to parse requested service port %q to integer", port)
 			return status.Error(codes.Unknown, "Bad requested service port number")
 		}
 		if p != s.servicePort {
-			logger.Info("Requested service port number %q does not match expected", port, s.servicePort)
+			logger.Infof("Requested service port number %d does not match expected %d", p, s.servicePort)
 			return status.Error(codes.Unknown, "Bad requested service port number")
 		}
 	}
 	if serviceName != s.serviceName {
-		logger.Info("Requested service name %q does not match expected %q", serviceName, s.serviceName)
+		logger.Infof("Requested service name %q does not match expected %q", serviceName, s.serviceName)
 		return status.Error(codes.NotFound, "Bad requested service name")
 	}
 


### PR DESCRIPTION
These log messages include format arguments, but were calling the variants that do not do formatting. Also replace the use of %q for integer arguments with %d.

balancer: logger.Info -> logger.Infof
fakegrpclb:
* Use Warningf/Infof
* Use %d with integers instead of %q

RELEASE NOTES: N/A
