### PR TITLE
xds: include weight=0 clusters in RDS unmarshal for ADS consistency

### DIFF
--- a/internal/xds/xdsclient/xdsresource/type_rds.go
+++ b/internal/xds/xdsclient/xdsresource/type_rds.go
@@ -159,7 +159,7 @@ type Route struct {
 type WeightedCluster struct {
 	// Name is the name of the cluster.
 	Name string
-	// Weight is the relative weight of the cluster.  It will never be zero.
+	// Weight is the relative weight of the cluster. Can be zero for 0% traffic.
 	Weight uint32
 	// HTTPFilterConfigOverride contains any HTTP filter config overrides for
 	// the weighted cluster which may be present.


### PR DESCRIPTION
## Summary

This PR fixes a bug in RDS unmarshal logic that skips clusters with `weight=0`, preventing gRPC clients from requesting them via CDS and causing ADS validation failures.

Fixes #8865

## Problem

Currently, `unmarshal_rds.go` skips clusters with `weight=0` during RDS parsing:

```go
for _, c := range wcs.Clusters {
    w := c.GetWeight().GetValue()
    if w == 0 {
        continue  // Skips weight=0 clusters
    }
    // ... add cluster to route.WeightedClusters
}
```

This causes the following issue flow:

1. **Control plane sends RDS** with clusters: `[{blue: 100}, {green: 0}]`
2. **gRPC client skips green** (weight=0) during unmarshal
3. **Client requests CDS** for only: `[blue]`
4. **go-control-plane ADS validation fails**: `"green" not listed` (CDS snapshot contains both clusters but client only requested blue)
5. **Client connection fails** with `TRANSIENT_FAILURE`

## Root Cause Analysis

From production logs:
```
I0129 01:06:50 [OnStreamResponse] RouteConfiguration:
  clusters:{name:"cluster-green" weight:{}}              ← weight=0
  clusters:{name:"cluster-blue" weight:{value:100}}

I0129 01:06:50 [grpc-debug] CDS Request: resourceNames=[cluster-blue]  ← green missing!

W0129 01:06:50 [go-control-plane] ADS mode: not responding to request:
  "cluster-green" not listed
```

## Why This is a Bug

According to the **Envoy xDS specification**:
- Cluster weight is "An integer **between 0 and total_weight**" (emphasis added)
- `weight=0` is explicitly allowed and means **0% traffic**
- The `weighted_target` load balancer already handles `weight=0` correctly

## Impact

Without this fix, production systems face a dilemma:

**Option A: Server-side skip weight=0** (single-cluster approach)
- ✅ Cold start works
- ❌ Fast rollback (100:0 → 0:100) causes connection churn and data plane disruption

**Option B: Server-side include weight=0** (dual-cluster approach)
- ✅ Fast rollback is smooth (critical for emergency rollback)
- ❌ New pods can't cold-start (ADS validation fails)

**Production scenario affected:**
- Blue-Green deployments requiring instant rollback (100:0 ↔ 0:100)
- Pod restarts/scaling during 100:0 or 0:100 configurations
- Emergency incident response requiring immediate traffic switch

## Solution

This PR makes two key changes:

### 1. Include weight=0 clusters
```go
for _, c := range wcs.Clusters {
    w := c.GetWeight().GetValue()
    // Include weight=0 clusters per xDS spec. Weight=0 means 0% traffic,
    // but the cluster must be tracked for ADS consistency.
    totalWeight += uint64(w)
    // ...
    route.WeightedClusters = append(route.WeightedClusters, wc)  // Always added
}
```

### 2. Keep validation for invalid configs
```go
// Still validate at least one cluster exists
if len(route.WeightedClusters) == 0 {
    return nil, nil, fmt.Errorf("has no cluster")
}

// IMPORTANT: Still reject all-zero weights per xDS spec
// (total_weight must be > 0)
if totalWeight == 0 {
    return nil, nil, fmt.Errorf("all weights are zero")
}
```

This preserves the xDS spec requirement that `total_weight` must be > 0 while allowing individual clusters to have weight=0.

## Testing

Added four new test cases:
1. **Blue-Green 100:0** - cluster-blue (100), cluster-green (0) → ✅ passes
2. **Blue-Green 0:100** - cluster-blue (0), cluster-green (100) → ✅ passes
3. **Invalid: All weights=0** - both clusters with weight=0 → ✅ correctly fails
4. **Invalid: Empty clusters array** - no clusters → ✅ correctly fails

All existing tests continue to pass.

## Verification

After this fix:
- ✅ Client includes weight=0 clusters in CDS request
- ✅ ADS validation passes
- ✅ `weighted_target` routes 0% traffic to weight=0 clusters (no behavior change)
- ✅ Cold start succeeds at 100:0 and 0:100
- ✅ Fast rollback works without data plane impact

## Breaking Changes

**None**. This is a bug fix that brings gRPC's behavior in line with the xDS specification.

The `weighted_target` load balancer already handles `weight=0` correctly - it just wasn't being given the opportunity because clusters were filtered out during unmarshal.

---

RELEASE NOTES:
* xds: Fix RDS unmarshal to include weight=0 clusters for ADS consistency and Blue-Green deployments. Previously, clusters with weight=0 were skipped during parsing, causing cold start failures and preventing smooth traffic rollback in production systems.