### PR TITLE
xds/googlec2p: Revert PR 8829 that removed `SetFallbackBootstrapConfig`

### DIFF
--- a/internal/xds/bootstrap/bootstrap.go
+++ b/internal/xds/bootstrap/bootstrap.go
@@ -658,7 +658,7 @@ func (c *Config) UnmarshalJSON(data []byte) error {
 // defaults.
 //
 // This function returns an error if it's unable to parse the contents of the
-// bootstrap config. It returns error if none of the env vars are set.
+// bootstrap config. It returns (nil, nil) if none of the env vars are set.
 func GetConfiguration() (*Config, error) {
 	fName := envconfig.XDSBootstrapFileName
 	fContent := envconfig.XDSBootstrapFileContent
@@ -681,7 +681,7 @@ func GetConfiguration() (*Config, error) {
 		return NewConfigFromContents([]byte(fContent))
 	}
 
-	return nil, fmt.Errorf("none of the bootstrap environment variables (%q or %q) are set", envconfig.XDSBootstrapFileNameEnv, envconfig.XDSBootstrapFileContentEnv)
+	return nil, nil
 }
 
 // NewConfigFromContents creates a new bootstrap configuration from the provided

--- a/internal/xds/bootstrap/bootstrap_test.go
+++ b/internal/xds/bootstrap/bootstrap_test.go
@@ -525,8 +525,9 @@ func (s) TestGetConfiguration_Failure(t *testing.T) {
 	const name = "empty"
 	t.Run(name, func(t *testing.T) {
 		testGetConfigurationWithFileNameEnv(t, name, true, nil)
-		// If both the env vars are empty, an error must be returned.
-		testGetConfigurationWithFileContentEnv(t, name, true, nil)
+		// If both the env vars are empty, a nil config with a nil error must be
+		// returned.
+		testGetConfigurationWithFileContentEnv(t, name, false, nil)
 	})
 }
 
@@ -664,9 +665,9 @@ func (s) TestGetConfiguration_BootstrapEnvPriority(t *testing.T) {
 	envconfig.XDSBootstrapFileContent = ""
 	defer func() { envconfig.XDSBootstrapFileContent = origBootstrapContent }()
 
-	// When both env variables are empty, GetConfiguration should return error.
-	if _, err := GetConfiguration(); err == nil {
-		t.Errorf("GetConfiguration() returned nil, want error")
+	// When both env variables are empty, GetConfiguration should return nil.
+	if cfg, err := GetConfiguration(); err != nil || cfg != nil {
+		t.Errorf("GetConfiguration() returned (%v, %v), want (<nil>, <nil>)", cfg, err)
 	}
 
 	// When one of them is set, it should be used.

--- a/internal/xds/xdsclient/pool/pool_ext_test.go
+++ b/internal/xds/xdsclient/pool/pool_ext_test.go
@@ -185,8 +185,11 @@ func (s) TestNestedXDSChannel(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create bootstrap configuration: %v", err)
 	}
-
-	testutils.CreateBootstrapFileForTesting(t, bootstrapContents)
+	config, err := bootstrap.NewConfigFromContents(bootstrapContents)
+	if err != nil {
+		t.Fatalf("Failed to parse bootstrap contents: %v", err)
+	}
+	xdsclient.DefaultPool.SetFallbackBootstrapConfig(config)
 	defer func() { xdsclient.DefaultPool.UnsetBootstrapConfigForTesting() }()
 
 	// Update the management server that holds resources for resolving the real

--- a/xds/csds/csds_e2e_test.go
+++ b/xds/csds/csds_e2e_test.go
@@ -35,6 +35,7 @@ import (
 	"google.golang.org/grpc/internal/pretty"
 	"google.golang.org/grpc/internal/testutils"
 	"google.golang.org/grpc/internal/testutils/xds/e2e"
+	"google.golang.org/grpc/internal/xds/bootstrap"
 	"google.golang.org/grpc/internal/xds/xdsclient"
 	"google.golang.org/grpc/internal/xds/xdsclient/xdsresource"
 	"google.golang.org/grpc/xds/csds"
@@ -220,10 +221,14 @@ func (s) TestCSDS(t *testing.T) {
 	// Create a bootstrap contents pointing to the above management server.
 	nodeID := uuid.New().String()
 	bootstrapContents := e2e.DefaultBootstrapContents(t, nodeID, mgmtServer.Address)
+	config, err := bootstrap.NewConfigFromContents(bootstrapContents)
+	if err != nil {
+		t.Fatalf("Failed to parse bootstrap contents: %s, %v", string(bootstrapContents), err)
+	}
 	// We use the default xDS client pool here because the CSDS service reports
 	// on the state of the default xDS client which is implicitly managed
 	// within the xdsclient.DefaultPool.
-	testutils.CreateBootstrapFileForTesting(t, bootstrapContents)
+	xdsclient.DefaultPool.SetFallbackBootstrapConfig(config)
 	defer func() { xdsclient.DefaultPool.UnsetBootstrapConfigForTesting() }()
 	// Create two xDS clients, with different names. These should end up
 	// creating two different xDS clients.
@@ -419,10 +424,14 @@ func (s) TestCSDS_NACK(t *testing.T) {
 	// Create a bootstrap contents pointing to the above management server.
 	nodeID := uuid.New().String()
 	bootstrapContents := e2e.DefaultBootstrapContents(t, nodeID, mgmtServer.Address)
+	config, err := bootstrap.NewConfigFromContents(bootstrapContents)
+	if err != nil {
+		t.Fatalf("Failed to parse bootstrap contents: %s, %v", string(bootstrapContents), err)
+	}
 	// We use the default xDS client pool here because the CSDS service reports
 	// on the state of the default xDS client which is implicitly managed
 	// within the xdsclient.DefaultPool.
-	testutils.CreateBootstrapFileForTesting(t, bootstrapContents)
+	xdsclient.DefaultPool.SetFallbackBootstrapConfig(config)
 	defer func() { xdsclient.DefaultPool.UnsetBootstrapConfigForTesting() }()
 	// Create two xDS clients, with different names. These should end up
 	// creating two different xDS clients.

--- a/xds/server_test.go
+++ b/xds/server_test.go
@@ -178,7 +178,7 @@ func (s) TestNewServer_Failure(t *testing.T) {
 		{
 			desc:       "bootstrap env var not set",
 			serverOpts: []grpc.ServerOption{grpc.Creds(xdsCreds), BootstrapContentsForTesting(nil)},
-			wantErr:    "failed to read xDS bootstrap config",
+			wantErr:    "failed to read xDS bootstrap config from env vars",
 		},
 		{
 			desc: "empty bootstrap config",


### PR DESCRIPTION
This API is still used internally in google3.

This reverts commit e6ca4177cf047664d84ee6f321800cb4c8f54646.

RELEASE NOTES: none