### PR TITLE
channelz: Regenerate proto

### DIFF
--- a/channelz/grpc_channelz_v1/channelz.pb.go
+++ b/channelz/grpc_channelz_v1/channelz.pb.go
@@ -396,8 +396,10 @@ type ChannelData struct {
 	CallsFailed int64 `protobuf:"varint,6,opt,name=calls_failed,json=callsFailed,proto3" json:"calls_failed,omitempty"`
 	// The last time a call was started on the channel.
 	LastCallStartedTimestamp *timestamppb.Timestamp `protobuf:"bytes,7,opt,name=last_call_started_timestamp,json=lastCallStartedTimestamp,proto3" json:"last_call_started_timestamp,omitempty"`
-	unknownFields            protoimpl.UnknownFields
-	sizeCache                protoimpl.SizeCache
+	// Populated for subchannels only.
+	MaxConnectionsPerSubchannel uint32 `protobuf:"varint,8,opt,name=max_connections_per_subchannel,json=maxConnectionsPerSubchannel,proto3" json:"max_connections_per_subchannel,omitempty"`
+	unknownFields               protoimpl.UnknownFields
+	sizeCache                   protoimpl.SizeCache
 }
 
 func (x *ChannelData) Reset() {
@@ -477,6 +479,13 @@ func (x *ChannelData) GetLastCallStartedTimestamp() *timestamppb.Timestamp {
 		return x.LastCallStartedTimestamp
 	}
 	return nil
+}
+
+func (x *ChannelData) GetMaxConnectionsPerSubchannel() uint32 {
+	if x != nil {
+		return x.MaxConnectionsPerSubchannel
+	}
+	return 0
 }
 
 // A trace event is an interesting thing that happened to a channel or
@@ -1164,9 +1173,15 @@ type SocketData struct {
 	RemoteFlowControlWindow *wrapperspb.Int64Value `protobuf:"bytes,12,opt,name=remote_flow_control_window,json=remoteFlowControlWindow,proto3" json:"remote_flow_control_window,omitempty"`
 	// Socket options set on this socket.  May be absent if 'summary' is set
 	// on GetSocketRequest.
-	Option        []*SocketOption `protobuf:"bytes,13,rep,name=option,proto3" json:"option,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	Option []*SocketOption `protobuf:"bytes,13,rep,name=option,proto3" json:"option,omitempty"`
+	// Populated if a GOAWAY has been received.  The value will be the
+	// HTTP/2 error code from the GOAWAY.
+	ReceivedGoawayError *wrapperspb.UInt32Value `protobuf:"bytes,14,opt,name=received_goaway_error,json=receivedGoawayError,proto3" json:"received_goaway_error,omitempty"`
+	// The value of MAX_CONCURRENT_STREAMS set by the peer.  Populated on
+	// client side only.
+	PeerMaxConcurrentStreams uint32 `protobuf:"varint,15,opt,name=peer_max_concurrent_streams,json=peerMaxConcurrentStreams,proto3" json:"peer_max_concurrent_streams,omitempty"`
+	unknownFields            protoimpl.UnknownFields
+	sizeCache                protoimpl.SizeCache
 }
 
 func (x *SocketData) Reset() {
@@ -1288,6 +1303,20 @@ func (x *SocketData) GetOption() []*SocketOption {
 		return x.Option
 	}
 	return nil
+}
+
+func (x *SocketData) GetReceivedGoawayError() *wrapperspb.UInt32Value {
+	if x != nil {
+		return x.ReceivedGoawayError
+	}
+	return nil
+}
+
+func (x *SocketData) GetPeerMaxConcurrentStreams() uint32 {
+	if x != nil {
+		return x.PeerMaxConcurrentStreams
+	}
+	return 0
 }
 
 // Address represents the address used to create the socket.
@@ -2993,7 +3022,7 @@ const file_grpc_channelz_v1_channelz_proto_rawDesc = "" +
 	"CONNECTING\x10\x02\x12\t\n" +
 	"\x05READY\x10\x03\x12\x15\n" +
 	"\x11TRANSIENT_FAILURE\x10\x04\x12\f\n" +
-	"\bSHUTDOWN\x10\x05\"\xe9\x02\n" +
+	"\bSHUTDOWN\x10\x05\"\xae\x03\n" +
 	"\vChannelData\x12@\n" +
 	"\x05state\x18\x01 \x01(\v2*.grpc.channelz.v1.ChannelConnectivityStateR\x05state\x12\x16\n" +
 	"\x06target\x18\x02 \x01(\tR\x06target\x124\n" +
@@ -3001,7 +3030,8 @@ const file_grpc_channelz_v1_channelz_proto_rawDesc = "" +
 	"\rcalls_started\x18\x04 \x01(\x03R\fcallsStarted\x12'\n" +
 	"\x0fcalls_succeeded\x18\x05 \x01(\x03R\x0ecallsSucceeded\x12!\n" +
 	"\fcalls_failed\x18\x06 \x01(\x03R\vcallsFailed\x12Y\n" +
-	"\x1blast_call_started_timestamp\x18\a \x01(\v2\x1a.google.protobuf.TimestampR\x18lastCallStartedTimestamp\"\x98\x03\n" +
+	"\x1blast_call_started_timestamp\x18\a \x01(\v2\x1a.google.protobuf.TimestampR\x18lastCallStartedTimestamp\x12C\n" +
+	"\x1emax_connections_per_subchannel\x18\b \x01(\rR\x1bmaxConnectionsPerSubchannel\"\x98\x03\n" +
 	"\x11ChannelTraceEvent\x12 \n" +
 	"\vdescription\x18\x01 \x01(\tR\vdescription\x12H\n" +
 	"\bseverity\x18\x02 \x01(\x0e2,.grpc.channelz.v1.ChannelTraceEvent.SeverityR\bseverity\x128\n" +
@@ -3053,7 +3083,7 @@ const file_grpc_channelz_v1_channelz_proto_rawDesc = "" +
 	"\x06remote\x18\x04 \x01(\v2\x19.grpc.channelz.v1.AddressR\x06remote\x126\n" +
 	"\bsecurity\x18\x05 \x01(\v2\x1a.grpc.channelz.v1.SecurityR\bsecurity\x12\x1f\n" +
 	"\vremote_name\x18\x06 \x01(\tR\n" +
-	"remoteName\"\x83\a\n" +
+	"remoteName\"\x94\b\n" +
 	"\n" +
 	"SocketData\x12'\n" +
 	"\x0fstreams_started\x18\x01 \x01(\x03R\x0estreamsStarted\x12+\n" +
@@ -3069,7 +3099,9 @@ const file_grpc_channelz_v1_channelz_proto_rawDesc = "" +
 	" \x01(\v2\x1a.google.protobuf.TimestampR\x1clastMessageReceivedTimestamp\x12V\n" +
 	"\x19local_flow_control_window\x18\v \x01(\v2\x1b.google.protobuf.Int64ValueR\x16localFlowControlWindow\x12X\n" +
 	"\x1aremote_flow_control_window\x18\f \x01(\v2\x1b.google.protobuf.Int64ValueR\x17remoteFlowControlWindow\x126\n" +
-	"\x06option\x18\r \x03(\v2\x1e.grpc.channelz.v1.SocketOptionR\x06option\"\xb8\x03\n" +
+	"\x06option\x18\r \x03(\v2\x1e.grpc.channelz.v1.SocketOptionR\x06option\x12P\n" +
+	"\x15received_goaway_error\x18\x0e \x01(\v2\x1c.google.protobuf.UInt32ValueR\x13receivedGoawayError\x12=\n" +
+	"\x1bpeer_max_concurrent_streams\x18\x0f \x01(\rR\x18peerMaxConcurrentStreams\"\xb8\x03\n" +
 	"\aAddress\x12M\n" +
 	"\rtcpip_address\x18\x01 \x01(\v2&.grpc.channelz.v1.Address.TcpIpAddressH\x00R\ftcpipAddress\x12G\n" +
 	"\vuds_address\x18\x02 \x01(\v2$.grpc.channelz.v1.Address.UdsAddressH\x00R\n" +
@@ -3262,8 +3294,9 @@ var file_grpc_channelz_v1_channelz_proto_goTypes = []any{
 	(*Security_OtherSecurity)(nil),      // 40: grpc.channelz.v1.Security.OtherSecurity
 	(*timestamppb.Timestamp)(nil),       // 41: google.protobuf.Timestamp
 	(*wrapperspb.Int64Value)(nil),       // 42: google.protobuf.Int64Value
-	(*anypb.Any)(nil),                   // 43: google.protobuf.Any
-	(*durationpb.Duration)(nil),         // 44: google.protobuf.Duration
+	(*wrapperspb.UInt32Value)(nil),      // 43: google.protobuf.UInt32Value
+	(*anypb.Any)(nil),                   // 44: google.protobuf.Any
+	(*durationpb.Duration)(nil),         // 45: google.protobuf.Duration
 }
 var file_grpc_channelz_v1_channelz_proto_depIdxs = []int32{
 	8,  // 0: grpc.channelz.v1.Channel.ref:type_name -> grpc.channelz.v1.ChannelRef
@@ -3303,42 +3336,43 @@ var file_grpc_channelz_v1_channelz_proto_depIdxs = []int32{
 	42, // 34: grpc.channelz.v1.SocketData.local_flow_control_window:type_name -> google.protobuf.Int64Value
 	42, // 35: grpc.channelz.v1.SocketData.remote_flow_control_window:type_name -> google.protobuf.Int64Value
 	18, // 36: grpc.channelz.v1.SocketData.option:type_name -> grpc.channelz.v1.SocketOption
-	36, // 37: grpc.channelz.v1.Address.tcpip_address:type_name -> grpc.channelz.v1.Address.TcpIpAddress
-	37, // 38: grpc.channelz.v1.Address.uds_address:type_name -> grpc.channelz.v1.Address.UdsAddress
-	38, // 39: grpc.channelz.v1.Address.other_address:type_name -> grpc.channelz.v1.Address.OtherAddress
-	39, // 40: grpc.channelz.v1.Security.tls:type_name -> grpc.channelz.v1.Security.Tls
-	40, // 41: grpc.channelz.v1.Security.other:type_name -> grpc.channelz.v1.Security.OtherSecurity
-	43, // 42: grpc.channelz.v1.SocketOption.additional:type_name -> google.protobuf.Any
-	44, // 43: grpc.channelz.v1.SocketOptionTimeout.duration:type_name -> google.protobuf.Duration
-	44, // 44: grpc.channelz.v1.SocketOptionLinger.duration:type_name -> google.protobuf.Duration
-	2,  // 45: grpc.channelz.v1.GetTopChannelsResponse.channel:type_name -> grpc.channelz.v1.Channel
-	12, // 46: grpc.channelz.v1.GetServersResponse.server:type_name -> grpc.channelz.v1.Server
-	12, // 47: grpc.channelz.v1.GetServerResponse.server:type_name -> grpc.channelz.v1.Server
-	10, // 48: grpc.channelz.v1.GetServerSocketsResponse.socket_ref:type_name -> grpc.channelz.v1.SocketRef
-	2,  // 49: grpc.channelz.v1.GetChannelResponse.channel:type_name -> grpc.channelz.v1.Channel
-	3,  // 50: grpc.channelz.v1.GetSubchannelResponse.subchannel:type_name -> grpc.channelz.v1.Subchannel
-	14, // 51: grpc.channelz.v1.GetSocketResponse.socket:type_name -> grpc.channelz.v1.Socket
-	43, // 52: grpc.channelz.v1.Address.OtherAddress.value:type_name -> google.protobuf.Any
-	43, // 53: grpc.channelz.v1.Security.OtherSecurity.value:type_name -> google.protobuf.Any
-	22, // 54: grpc.channelz.v1.Channelz.GetTopChannels:input_type -> grpc.channelz.v1.GetTopChannelsRequest
-	24, // 55: grpc.channelz.v1.Channelz.GetServers:input_type -> grpc.channelz.v1.GetServersRequest
-	26, // 56: grpc.channelz.v1.Channelz.GetServer:input_type -> grpc.channelz.v1.GetServerRequest
-	28, // 57: grpc.channelz.v1.Channelz.GetServerSockets:input_type -> grpc.channelz.v1.GetServerSocketsRequest
-	30, // 58: grpc.channelz.v1.Channelz.GetChannel:input_type -> grpc.channelz.v1.GetChannelRequest
-	32, // 59: grpc.channelz.v1.Channelz.GetSubchannel:input_type -> grpc.channelz.v1.GetSubchannelRequest
-	34, // 60: grpc.channelz.v1.Channelz.GetSocket:input_type -> grpc.channelz.v1.GetSocketRequest
-	23, // 61: grpc.channelz.v1.Channelz.GetTopChannels:output_type -> grpc.channelz.v1.GetTopChannelsResponse
-	25, // 62: grpc.channelz.v1.Channelz.GetServers:output_type -> grpc.channelz.v1.GetServersResponse
-	27, // 63: grpc.channelz.v1.Channelz.GetServer:output_type -> grpc.channelz.v1.GetServerResponse
-	29, // 64: grpc.channelz.v1.Channelz.GetServerSockets:output_type -> grpc.channelz.v1.GetServerSocketsResponse
-	31, // 65: grpc.channelz.v1.Channelz.GetChannel:output_type -> grpc.channelz.v1.GetChannelResponse
-	33, // 66: grpc.channelz.v1.Channelz.GetSubchannel:output_type -> grpc.channelz.v1.GetSubchannelResponse
-	35, // 67: grpc.channelz.v1.Channelz.GetSocket:output_type -> grpc.channelz.v1.GetSocketResponse
-	61, // [61:68] is the sub-list for method output_type
-	54, // [54:61] is the sub-list for method input_type
-	54, // [54:54] is the sub-list for extension type_name
-	54, // [54:54] is the sub-list for extension extendee
-	0,  // [0:54] is the sub-list for field type_name
+	43, // 37: grpc.channelz.v1.SocketData.received_goaway_error:type_name -> google.protobuf.UInt32Value
+	36, // 38: grpc.channelz.v1.Address.tcpip_address:type_name -> grpc.channelz.v1.Address.TcpIpAddress
+	37, // 39: grpc.channelz.v1.Address.uds_address:type_name -> grpc.channelz.v1.Address.UdsAddress
+	38, // 40: grpc.channelz.v1.Address.other_address:type_name -> grpc.channelz.v1.Address.OtherAddress
+	39, // 41: grpc.channelz.v1.Security.tls:type_name -> grpc.channelz.v1.Security.Tls
+	40, // 42: grpc.channelz.v1.Security.other:type_name -> grpc.channelz.v1.Security.OtherSecurity
+	44, // 43: grpc.channelz.v1.SocketOption.additional:type_name -> google.protobuf.Any
+	45, // 44: grpc.channelz.v1.SocketOptionTimeout.duration:type_name -> google.protobuf.Duration
+	45, // 45: grpc.channelz.v1.SocketOptionLinger.duration:type_name -> google.protobuf.Duration
+	2,  // 46: grpc.channelz.v1.GetTopChannelsResponse.channel:type_name -> grpc.channelz.v1.Channel
+	12, // 47: grpc.channelz.v1.GetServersResponse.server:type_name -> grpc.channelz.v1.Server
+	12, // 48: grpc.channelz.v1.GetServerResponse.server:type_name -> grpc.channelz.v1.Server
+	10, // 49: grpc.channelz.v1.GetServerSocketsResponse.socket_ref:type_name -> grpc.channelz.v1.SocketRef
+	2,  // 50: grpc.channelz.v1.GetChannelResponse.channel:type_name -> grpc.channelz.v1.Channel
+	3,  // 51: grpc.channelz.v1.GetSubchannelResponse.subchannel:type_name -> grpc.channelz.v1.Subchannel
+	14, // 52: grpc.channelz.v1.GetSocketResponse.socket:type_name -> grpc.channelz.v1.Socket
+	44, // 53: grpc.channelz.v1.Address.OtherAddress.value:type_name -> google.protobuf.Any
+	44, // 54: grpc.channelz.v1.Security.OtherSecurity.value:type_name -> google.protobuf.Any
+	22, // 55: grpc.channelz.v1.Channelz.GetTopChannels:input_type -> grpc.channelz.v1.GetTopChannelsRequest
+	24, // 56: grpc.channelz.v1.Channelz.GetServers:input_type -> grpc.channelz.v1.GetServersRequest
+	26, // 57: grpc.channelz.v1.Channelz.GetServer:input_type -> grpc.channelz.v1.GetServerRequest
+	28, // 58: grpc.channelz.v1.Channelz.GetServerSockets:input_type -> grpc.channelz.v1.GetServerSocketsRequest
+	30, // 59: grpc.channelz.v1.Channelz.GetChannel:input_type -> grpc.channelz.v1.GetChannelRequest
+	32, // 60: grpc.channelz.v1.Channelz.GetSubchannel:input_type -> grpc.channelz.v1.GetSubchannelRequest
+	34, // 61: grpc.channelz.v1.Channelz.GetSocket:input_type -> grpc.channelz.v1.GetSocketRequest
+	23, // 62: grpc.channelz.v1.Channelz.GetTopChannels:output_type -> grpc.channelz.v1.GetTopChannelsResponse
+	25, // 63: grpc.channelz.v1.Channelz.GetServers:output_type -> grpc.channelz.v1.GetServersResponse
+	27, // 64: grpc.channelz.v1.Channelz.GetServer:output_type -> grpc.channelz.v1.GetServerResponse
+	29, // 65: grpc.channelz.v1.Channelz.GetServerSockets:output_type -> grpc.channelz.v1.GetServerSocketsResponse
+	31, // 66: grpc.channelz.v1.Channelz.GetChannel:output_type -> grpc.channelz.v1.GetChannelResponse
+	33, // 67: grpc.channelz.v1.Channelz.GetSubchannel:output_type -> grpc.channelz.v1.GetSubchannelResponse
+	35, // 68: grpc.channelz.v1.Channelz.GetSocket:output_type -> grpc.channelz.v1.GetSocketResponse
+	62, // [62:69] is the sub-list for method output_type
+	55, // [55:62] is the sub-list for method input_type
+	55, // [55:55] is the sub-list for extension type_name
+	55, // [55:55] is the sub-list for extension extendee
+	0,  // [0:55] is the sub-list for field type_name
 }
 
 func init() { file_grpc_channelz_v1_channelz_proto_init() }


### PR DESCRIPTION
This change regenerated the protos using the command `go generate ./...` to fix the `vet-proto` CI test.

RELEASE NOTES: N/A