### PR TITLE
xds: decouple A76 and A86 EDS metadata parsing

### DIFF
--- a/internal/xds/xdsclient/xdsresource/metadata.go
+++ b/internal/xds/xdsclient/xdsresource/metadata.go
@@ -22,11 +22,14 @@ import (
 	"net/netip"
 
 	v3corepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	"google.golang.org/grpc/internal/envconfig"
 	"google.golang.org/protobuf/types/known/anypb"
 )
 
 func init() {
-	registerMetadataConverter("type.googleapis.com/envoy.config.core.v3.Address", proxyAddressConvertor{})
+	if envconfig.XDSHTTPConnectEnabled {
+		registerMetadataConverter("type.googleapis.com/envoy.config.core.v3.Address", proxyAddressConvertor{})
+	}
 }
 
 var (
@@ -51,6 +54,12 @@ func registerMetadataConverter(protoType string, c metadataConverter) {
 // metadataConverterForType retrieves a converter based on key given.
 func metadataConverterForType(typeURL string) metadataConverter {
 	return metdataRegistry[typeURL]
+}
+
+// unregisterMetadataConverterForTesting removes a converter from the registry.
+// For testing only.
+func unregisterMetadataConverterForTesting(typeURL string) {
+	delete(metdataRegistry, typeURL)
 }
 
 // StructMetadataValue stores the values in a google.protobuf.Struct from

--- a/internal/xds/xdsclient/xdsresource/metadata_test.go
+++ b/internal/xds/xdsclient/xdsresource/metadata_test.go
@@ -26,7 +26,15 @@ import (
 
 const proxyAddressTypeURL = "type.googleapis.com/envoy.config.core.v3.Address"
 
+func setupProxyAddressConverter(t *testing.T) {
+	registerMetadataConverter(proxyAddressTypeURL, proxyAddressConvertor{})
+	t.Cleanup(func() {
+		unregisterMetadataConverterForTesting(proxyAddressTypeURL)
+	})
+}
+
 func (s) TestProxyAddressConverterSuccess(t *testing.T) {
+	setupProxyAddressConverter(t)
 	converter := metadataConverterForType(proxyAddressTypeURL)
 	if converter == nil {
 		t.Fatalf("Converter for %q not found in registry", proxyAddressTypeURL)
@@ -133,6 +141,7 @@ func (s) TestProxyAddressConverterSuccess(t *testing.T) {
 }
 
 func (s) TestProxyAddressConverterFailure(t *testing.T) {
+	setupProxyAddressConverter(t)
 	converter := metadataConverterForType(proxyAddressTypeURL)
 	if converter == nil {
 		t.Fatalf("Converter for %q not found in registry", proxyAddressTypeURL)

--- a/internal/xds/xdsclient/xdsresource/unmarshal_eds.go
+++ b/internal/xds/xdsclient/xdsresource/unmarshal_eds.go
@@ -261,24 +261,19 @@ func validateAndConstructMetadata(metadataProto *v3corepb.Metadata) (map[string]
 		return nil, nil
 	}
 	metadata := make(map[string]any)
-	// First go through TypedFilterMetadata. Only process this when HTTP Connect
-	// is enabled, as the converters (e.g., for envoy.config.core.v3.Address)
-	// are specific to A86 and can fail validation. A76 only needs
-	// FilterMetadata for envoy.lb hash_key.
-	if envconfig.XDSHTTPConnectEnabled {
-		for key, anyProto := range metadataProto.GetTypedFilterMetadata() {
-			converter := metadataConverterForType(anyProto.GetTypeUrl())
-			// Ignore types we don't have a converter for.
-			if converter == nil {
-				continue
-			}
-			val, err := converter.convert(anyProto)
-			if err != nil {
-				// If the converter fails, nack the whole resource.
-				return nil, fmt.Errorf("metadata conversion for key %q and type %q failed: %v", key, anyProto.GetTypeUrl(), err)
-			}
-			metadata[key] = val
+	// First go through TypedFilterMetadata.
+	for key, anyProto := range metadataProto.GetTypedFilterMetadata() {
+		converter := metadataConverterForType(anyProto.GetTypeUrl())
+		// Ignore types we don't have a converter for.
+		if converter == nil {
+			continue
 		}
+		val, err := converter.convert(anyProto)
+		if err != nil {
+			// If the converter fails, nack the whole resource.
+			return nil, fmt.Errorf("metadata conversion for key %q and type %q failed: %v", key, anyProto.GetTypeUrl(), err)
+		}
+		metadata[key] = val
 	}
 
 	// Process FilterMetadata for any keys not already handled.


### PR DESCRIPTION
The EDS metadata parsing was inadvertently coupling the A76 (ring hash
endpoint hash key) and A86 (HTTP CONNECT) features. When either
GRPC_XDS_ENDPOINT_HASH_KEY_BACKWARD_COMPAT was false (A76 enabled) or
GRPC_EXPERIMENTAL_XDS_HTTP_CONNECT was true (A86 enabled), the code would
parse all metadata including TypedFilterMetadata with converters.

This caused issues because:
- A76 only needs FilterMetadata["envoy.lb"] for hash_key extraction
- A86 needs TypedFilterMetadata with converters (e.g., for
  envoy.config.core.v3.Address) which can fail validation

When A76 was enabled but A86 was disabled, invalid proxy addresses in
TypedFilterMetadata would still cause NACKs, even though the user didn't care
about HTTP CONNECT.

This change makes TypedFilterMetadata processing conditional on
GRPC_EXPERIMENTAL_XDS_HTTP_CONNECT, so that A76 can be enabled independently
without triggering A86-specific validation failures.

RELEASE NOTES: 
- Fix a bug where enabling A76 ring hash endpoint hash key feature
would cause EDS resources to be NACKed if they contained invalid proxy address
metadata, even when HTTP CONNECT (A86) was not enabled.

