### PR TITLE
mem: ensure `Reader` buffers are reused on early return

### DIFF
--- a/rpc_util.go
+++ b/rpc_util.go
@@ -970,18 +970,23 @@ func recvAndDecompress(p *parser, s recvCompressor, dc Decompressor, maxReceiveM
 // exceeds the size limit.
 func decompress(compressor encoding.Compressor, d mem.BufferSlice, dc Decompressor, maxReceiveMessageSize int, pool mem.BufferPool) (mem.BufferSlice, error) {
 	if dc != nil {
-		uncompressed, err := dc.Do(d.Reader())
+		r := d.Reader()
+		uncompressed, err := dc.Do(r)
 		if err != nil {
+			r.Close() // ensure buffers are reused
 			return nil, status.Errorf(codes.Internal, "grpc: failed to decompress the received message: %v", err)
 		}
 		if len(uncompressed) > maxReceiveMessageSize {
+			r.Close() // ensure buffers are reused
 			return nil, status.Errorf(codes.ResourceExhausted, "grpc: message after decompression larger than max (%d vs. %d)", len(uncompressed), maxReceiveMessageSize)
 		}
 		return mem.BufferSlice{mem.SliceBuffer(uncompressed)}, nil
 	}
 	if compressor != nil {
-		dcReader, err := compressor.Decompress(d.Reader())
+		r := d.Reader()
+		dcReader, err := compressor.Decompress(r)
 		if err != nil {
+			r.Close() // ensure buffers are reused
 			return nil, status.Errorf(codes.Internal, "grpc: failed to decompress the message: %v", err)
 		}
 
@@ -993,11 +998,13 @@ func decompress(compressor encoding.Compressor, d mem.BufferSlice, dc Decompress
 		}
 		out, err := mem.ReadAll(dcReader, pool)
 		if err != nil {
+			r.Close() // ensure buffers are reused
 			out.Free()
 			return nil, status.Errorf(codes.Internal, "grpc: failed to read decompressed data: %v", err)
 		}
 
 		if out.Len() > maxReceiveMessageSize {
+			r.Close() // ensure buffers are reused
 			out.Free()
 			return nil, status.Errorf(codes.ResourceExhausted, "grpc: received message after decompression larger than max %d", maxReceiveMessageSize)
 		}


### PR DESCRIPTION
If there was an error, e.g. while decompressing the data, we still want to return all buffers to the pool.

RELEASE NOTES: None