### PR TITLE
internal: fix typo in Fire method documentation

### DIFF
--- a/internal/grpcsync/event.go
+++ b/internal/grpcsync/event.go
@@ -31,7 +31,7 @@ type Event struct {
 }
 
 // Fire causes e to complete.  It is safe to call multiple times, and
-// concurrently.  It returns true iff this call to Fire caused the signaling
+// concurrently.  It returns true if this call to Fire caused the signaling
 // channel returned by Done to close. If Fire returns false, it is possible
 // the Done channel has not been closed yet.
 func (e *Event) Fire() bool {


### PR DESCRIPTION
RELEASE NOTES:
* This PR corrects a minor typo in interal/grpcsync/event.go

Type: comment