### PR TITLE
cdsbalancer: Increase timeout for test

### DIFF
--- a/internal/xds/balancer/cdsbalancer/e2e_test/eds_impl_test.go
+++ b/internal/xds/balancer/cdsbalancer/e2e_test/eds_impl_test.go
@@ -254,9 +254,9 @@ func (s) TestEDS_MultipleLocalities(t *testing.T) {
 			Backends: []e2e.BackendOptions{{Ports: []uint32{ports[1]}}},
 		},
 	})
-	// Use a 10 second timeout since validating WRR requires sending 500+ unary
+	// Use a 20 second timeout since validating WRR requires sending 500+ unary
 	// RPCs.
-	ctx, cancel := context.WithTimeout(context.Background(), 2*defaultTestTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	defer cancel()
 	if err := managementServer.Update(ctx, resources); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Fixes: #8883

This change doubles the timeout for `EDS_MultipleLocalities` as the test sends around 5000 RPCs and may time out on slow machines.

RELEASE NOTES: N/A