### PR TITLE
xds/testutils: add fakeTransport for testing.

### DIFF
--- a/internal/xds/clients/internal/testutils/fakeTransport/xds_fake_transport.go
+++ b/internal/xds/clients/internal/testutils/fakeTransport/xds_fake_transport.go
@@ -26,7 +26,6 @@ import (
 	"fmt"
 	"sync"
 
-	"google.golang.org/grpc/internal/grpcsync"
 	"google.golang.org/grpc/internal/xds/clients"
 	"google.golang.org/protobuf/proto"
 
@@ -113,13 +112,12 @@ func (b *Builder) Transport(ctx context.Context, serverURI string) (*ServerHandl
 type transport struct {
 	mu              sync.Mutex
 	activeADSStream *stream
-	closed          *grpcsync.Event
+	closed          bool
 	streamReady     func()
 }
 
 func newTransport(streamReady chan struct{}) *transport {
 	return &transport{
-		closed: grpcsync.NewEvent(),
 		streamReady: sync.OnceFunc(func() {
 			close(streamReady)
 		}),
@@ -141,7 +139,7 @@ func (t *transport) NewStream(ctx context.Context, _ string) (clients.Stream, er
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
-	if t.closed.HasFired() {
+	if t.closed {
 		return nil, fmt.Errorf("transport is closed")
 	}
 
@@ -154,7 +152,7 @@ func (t *transport) NewStream(ctx context.Context, _ string) (clients.Stream, er
 // Close closes the stream.
 func (t *transport) Close() {
 	t.mu.Lock()
-	t.closed.Fire()
+	t.closed = true
 	stream := t.activeADSStream
 	t.mu.Unlock()
 	if stream != nil {


### PR DESCRIPTION
This PR introduces `fakeTransport`, a deterministic transport layer designed to facilitate fuzz testing of the xDS client in `grpc-go`.

### Purpose
The `fakeTransport` decouples the xDS client from the actual network, allowing tests to simulate management server interactions without establishing real connections. This is a critical component for the upcoming google3-based xdsClient fuzzer, which requires a way to inject specific responses directly into the client.

### Design
This component implements the `clients.TransportBuilder`, `clients.Transport` and `clients.Stream` interfaces.

*  When the `xdsClient` attempts to create a stream, the `Builder` intercepts these calls. Instead of establishing a real connection, it returns a local `FakeTransport` object.
*   The `FakeStream` replaces the network socket. It exposes standard methods  (`Recv`, `Send`) for the xdsClient, and control hooks (`InjectResponse`, `ReadRequest`). Allows the fuzzer to drive the xdsclient's resource parsing by pushing `DiscoveryResponse` protos and inspecting `DiscoveryRequest` messages via buffered channels.

### Future Scope
While primarily added for fuzzing, this utility is placed in `internal/testutils` to allow that it can be used by standard unit and e2e tests in the future.
Reference: [go/grpc-go-xdsclient-fuzzing](http://goto.google.com/grpc-go-xdsclient-fuzzing)

Part of : #8749 

RELEASE NOTES: N/A