### PR TITLE
xds: add panic recovery in xdsclient resource unmarshalling.

### DIFF
--- a/internal/envconfig/envconfig.go
+++ b/internal/envconfig/envconfig.go
@@ -97,7 +97,7 @@ var (
 	// GRPC_EXPERIMENTAL_PF_WEIGHTED_SHUFFLING to "false".
 	PickFirstWeightedShuffling = boolFromEnv("GRPC_EXPERIMENTAL_PF_WEIGHTED_SHUFFLING", true)
 
-	// XDSRecoverPanicInResourceParsing indicates whether the xDS resolver should
+	// XDSRecoverPanicInResourceParsing indicates whether the xdsclient should
 	// recover from panics while parsing xDS resources.
 	//
 	// This feature can be disabled (e.g. for fuzz testing) by setting the

--- a/internal/xds/clients/xdsclient/channel.go
+++ b/internal/xds/clients/xdsclient/channel.go
@@ -21,7 +21,6 @@ package xdsclient
 import (
 	"errors"
 	"fmt"
-	"runtime/debug"
 	"strings"
 	"time"
 
@@ -259,7 +258,7 @@ func decodeResponse(opts *DecodeOptions, rType *ResourceType, resp response) (ma
 			defer func() {
 				if envconfig.XDSRecoverPanicInResourceParsing {
 					if p := recover(); p != nil {
-						err = fmt.Errorf("panic during %v resource decoding: %v\nstack: %s", rType.TypeName, p, debug.Stack())
+						err = fmt.Errorf("recovered from panic during resource parsing, resource: %v, panic: %v", r, p)
 					}
 				}
 			}()

--- a/internal/xds/clients/xdsclient/channel_test.go
+++ b/internal/xds/clients/xdsclient/channel_test.go
@@ -31,9 +31,10 @@ import (
 	"github.com/google/uuid"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/internal/envconfig"
+	"google.golang.org/grpc/internal/testutils"
 	"google.golang.org/grpc/internal/xds/clients"
 	"google.golang.org/grpc/internal/xds/clients/grpctransport"
-	"google.golang.org/grpc/internal/xds/clients/internal/testutils"
+	xdstestutils "google.golang.org/grpc/internal/xds/clients/internal/testutils"
 	"google.golang.org/grpc/internal/xds/clients/internal/testutils/e2e"
 	"google.golang.org/grpc/internal/xds/clients/internal/testutils/fakeserver"
 	"google.golang.org/grpc/internal/xds/clients/xdsclient/internal/xdsresource"
@@ -45,7 +46,6 @@ import (
 	v3routepb "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	v3httppb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	v3discoverypb "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
-	utils "google.golang.org/grpc/internal/testutils"
 )
 
 // xdsChannelForTest creates an xdsChannel to the specified serverURI for
@@ -186,18 +186,18 @@ func (s) TestChannel_ADS_HandleResponseFromManagementServer(t *testing.T) {
 			Value:   []byte{1, 2, 3, 4},
 		}
 		apiListener = &v3listenerpb.ApiListener{
-			ApiListener: testutils.MarshalAny(t, &v3httppb.HttpConnectionManager{
+			ApiListener: xdstestutils.MarshalAny(t, &v3httppb.HttpConnectionManager{
 				RouteSpecifier: &v3httppb.HttpConnectionManager_RouteConfig{
 					RouteConfig: &v3routepb.RouteConfiguration{
 						Name: routeName},
 				},
 			}),
 		}
-		listener1 = testutils.MarshalAny(t, &v3listenerpb.Listener{
+		listener1 = xdstestutils.MarshalAny(t, &v3listenerpb.Listener{
 			Name:        listenerName1,
 			ApiListener: apiListener,
 		})
-		listener2 = testutils.MarshalAny(t, &v3listenerpb.Listener{
+		listener2 = xdstestutils.MarshalAny(t, &v3listenerpb.Listener{
 			Name:        listenerName2,
 			ApiListener: apiListener,
 		})
@@ -236,10 +236,10 @@ func (s) TestChannel_ADS_HandleResponseFromManagementServer(t *testing.T) {
 			managementServerResponse: &v3discoverypb.DiscoveryResponse{
 				VersionInfo: "0",
 				TypeUrl:     "type.googleapis.com/envoy.config.listener.v3.Listener",
-				Resources: []*anypb.Any{testutils.MarshalAny(t, &v3listenerpb.Listener{
+				Resources: []*anypb.Any{xdstestutils.MarshalAny(t, &v3listenerpb.Listener{
 					Name: listenerName1,
 					ApiListener: &v3listenerpb.ApiListener{
-						ApiListener: testutils.MarshalAny(t, &v3httppb.HttpConnectionManager{
+						ApiListener: xdstestutils.MarshalAny(t, &v3httppb.HttpConnectionManager{
 							RouteSpecifier: &v3httppb.HttpConnectionManager_ScopedRoutes{},
 						}),
 					},
@@ -267,10 +267,10 @@ func (s) TestChannel_ADS_HandleResponseFromManagementServer(t *testing.T) {
 				TypeUrl:     "type.googleapis.com/envoy.config.listener.v3.Listener",
 				Resources: []*anypb.Any{
 					badlyMarshaledResource,
-					testutils.MarshalAny(t, &v3listenerpb.Listener{
+					xdstestutils.MarshalAny(t, &v3listenerpb.Listener{
 						Name: listenerName2,
 						ApiListener: &v3listenerpb.ApiListener{
-							ApiListener: testutils.MarshalAny(t, &v3httppb.HttpConnectionManager{
+							ApiListener: xdstestutils.MarshalAny(t, &v3httppb.HttpConnectionManager{
 								RouteSpecifier: &v3httppb.HttpConnectionManager_ScopedRoutes{},
 							}),
 						},
@@ -347,10 +347,10 @@ func (s) TestChannel_ADS_HandleResponseFromManagementServer(t *testing.T) {
 				VersionInfo: "0",
 				TypeUrl:     "type.googleapis.com/envoy.config.listener.v3.Listener",
 				Resources: []*anypb.Any{
-					testutils.MarshalAny(t, &v3listenerpb.Listener{
+					xdstestutils.MarshalAny(t, &v3listenerpb.Listener{
 						Name: listenerName1,
 						ApiListener: &v3listenerpb.ApiListener{
-							ApiListener: testutils.MarshalAny(t, &v3httppb.HttpConnectionManager{
+							ApiListener: xdstestutils.MarshalAny(t, &v3httppb.HttpConnectionManager{
 								RouteSpecifier: &v3httppb.HttpConnectionManager_ScopedRoutes{},
 							}),
 						},
@@ -515,7 +515,7 @@ func (s) TestChannel_ADS_StreamFailure(t *testing.T) {
 	if err != nil {
 		t.Fatalf("net.Listen() failed: %v", err)
 	}
-	lis := testutils.NewRestartableListener(l)
+	lis := xdstestutils.NewRestartableListener(l)
 	mgmtServer := e2e.StartManagementServer(t, e2e.ManagementServerOptions{Listener: lis})
 
 	// Configure a listener resource on the management server.
@@ -541,7 +541,7 @@ func (s) TestChannel_ADS_StreamFailure(t *testing.T) {
 
 	// Wait for an update callback on the event handler and verify the
 	// contents of the update and the metadata.
-	hcm := testutils.MarshalAny(t, &v3httppb.HttpConnectionManager{
+	hcm := xdstestutils.MarshalAny(t, &v3httppb.HttpConnectionManager{
 		RouteSpecifier: &v3httppb.HttpConnectionManager_Rds{Rds: &v3httppb.Rds{
 			ConfigSource: &v3corepb.ConfigSource{
 				ConfigSourceSpecifier: &v3corepb.ConfigSource_Ads{Ads: &v3corepb.AggregatedConfigSource{}},
@@ -781,53 +781,39 @@ func (panicDecoder) Decode(*AnyProto, DecodeOptions) (*DecodeResult, error) {
 	panic("simulate panic")
 }
 
-// TestDecodeResponse_PanicRecovery tests the panic recovery mechanism in
-// decodeResponse. It verifies that when XDSRecoverPanicInResourceParsing env
-// variable is enabled, panics during unmarshaling are caught and returned as
-// errors. When the env variable is disabled, it ensures the panic propagates.
-func (s) TestDecodeResponse_PanicRecovery(t *testing.T) {
-	tests := []struct {
-		name          string
-		enableRecover bool
-		wantPanic     bool
-		wantErr       string
-	}{
-		{
-			name:          "Enable_XDSRecoverPanic",
-			enableRecover: true,
-			wantErr:       "panic during resourceType resource decoding: simulate panic",
-		},
-		{
-			name:      "Disable_XDSRecoverPanic",
-			wantPanic: true,
-			wantErr:   "simulate panic",
-		},
+// TestDecodeResponse_PanicRecoveryEnabled tests the panic recovery mechanism
+// in decodeResponse. It verifies that if XDSRecoverPanicInResourceParsing
+// env variable is enabled, panics during unmarshaling are caught and returned
+// as errors.
+func (s) TestDecodeResponse_PanicRecoveryEnabled(t *testing.T) {
+	rType := &ResourceType{
+		TypeName: "resourceType",
+		Decoder:  panicDecoder{},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			utils.SetEnvConfig(t, &envconfig.XDSRecoverPanicInResourceParsing, tt.enableRecover)
+	resp := response{resources: []*anypb.Any{{Value: []byte("test")}}}
+	wantErr := "recovered from panic during resource parsing"
 
-			opts := &DecodeOptions{}
-			rType := &ResourceType{
-				TypeName: "resourceType",
-				Decoder:  panicDecoder{},
-			}
-			resp := response{
-				resources: []*anypb.Any{{Value: []byte("test")}},
-			}
-
-			if tt.wantPanic {
-				defer func() {
-					if r := recover(); r == nil || !strings.Contains(fmt.Sprint(r), tt.wantErr) {
-						t.Errorf("Expected panic got: %q, want: %q", r, tt.wantErr)
-					}
-				}()
-				decodeResponse(opts, rType, resp)
-				return
-			}
-			if _, _, err := decodeResponse(opts, rType, resp); err == nil || !strings.Contains(err.Error(), tt.wantErr) {
-				t.Fatalf("decodeResponse() failed with err: %v, want %q", err, tt.wantErr)
-			}
-		})
+	if _, _, err := decodeResponse(&DecodeOptions{}, rType, resp); err == nil || !strings.Contains(err.Error(), wantErr) {
+		t.Fatalf("decodeResponse() failed with err: %v, want %q", err, wantErr)
 	}
+}
+
+// TestDecodeResponse_PanicRecoveryDisabled tests the panic recovery mechanism
+// in decodeResponse. It verifies that when XDSRecoverPanicInResourceParsing
+// env variable is disabled, panics during unmarshaling propagate.
+func (s) TestDecodeResponse_PanicRecoveryDisabled(t *testing.T) {
+	testutils.SetEnvConfig(t, &envconfig.XDSRecoverPanicInResourceParsing, false)
+	rType := &ResourceType{
+		TypeName: "resourceType",
+		Decoder:  panicDecoder{},
+	}
+	resp := response{resources: []*anypb.Any{{Value: []byte("test")}}}
+	wantErr := "simulate panic"
+
+	defer func() {
+		if r := recover(); r == nil || !strings.Contains(fmt.Sprint(r), wantErr) {
+			t.Fatalf("Expected panic in decodeResponse, got: %v, want: %q", r, wantErr)
+		}
+	}()
+	decodeResponse(&DecodeOptions{}, rType, resp)
 }


### PR DESCRIPTION
This PR introduces panic recovery mechanisms to the xdsclient resource unmarshaling logic. 

Currently, a panic during the parsing of a malformed xDS update could crash the entire application. To improve resilience in production environments, this change wraps the resource parsing logic in a `defer recover()` block.

The recovery mechanism is controlled by the `GRPC_EXPERIMENTAL_XDS_PANIC_RECOVERY` environment variable, which defaults to `true`.
- When enabled, panics during unmarshaling are caught and returned as errors, preventing the application from crashing.
- When disabled, panics are allowed to propagate. This is required for fuzz testing, where crashing on unexpected input is the desired behavior to identify bugs: [go/grpc-go-xdsclient-fuzzing](http://goto.google.com/grpc-go-xdsclient-fuzzing)

Part of : #8749 

RELEASE NOTES: N/A