### PR TITLE
Cherry-pick #8874 to v1.79.x

### DIFF
--- a/internal/transport/client_stream.go
+++ b/internal/transport/client_stream.go
@@ -24,6 +24,7 @@ import (
 	"golang.org/x/net/http2"
 	"google.golang.org/grpc/mem"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/stats"
 	"google.golang.org/grpc/status"
 )
 
@@ -46,10 +47,11 @@ type ClientStream struct {
 	// meaningful after headerChan is closed (always call waitOnHeader() before
 	// reading its value).
 	headerValid      bool
-	noHeaders        bool        // set if the client never received headers (set only after the stream is done).
-	headerChanClosed uint32      // set when headerChan is closed. Used to avoid closing headerChan multiple times.
-	bytesReceived    atomic.Bool // indicates whether any bytes have been received on this stream
-	unprocessed      atomic.Bool // set if the server sends a refused stream or GOAWAY including this stream
+	noHeaders        bool          // set if the client never received headers (set only after the stream is done).
+	headerChanClosed uint32        // set when headerChan is closed. Used to avoid closing headerChan multiple times.
+	bytesReceived    atomic.Bool   // indicates whether any bytes have been received on this stream
+	unprocessed      atomic.Bool   // set if the server sends a refused stream or GOAWAY including this stream
+	statsHandler     stats.Handler // nil for internal streams (e.g., health check, ORCA) where telemetry is not supported.
 }
 
 // Read reads an n byte message from the input stream.

--- a/internal/transport/keepalive_test.go
+++ b/internal/transport/keepalive_test.go
@@ -69,7 +69,7 @@ func (s) TestMaxConnectionIdle(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
-	stream, err := client.NewStream(ctx, &CallHdr{})
+	stream, err := client.NewStream(ctx, &CallHdr{}, nil)
 	if err != nil {
 		t.Fatalf("client.NewStream() failed: %v", err)
 	}
@@ -111,7 +111,7 @@ func (s) TestMaxConnectionIdleBusyClient(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
-	_, err := client.NewStream(ctx, &CallHdr{})
+	_, err := client.NewStream(ctx, &CallHdr{}, nil)
 	if err != nil {
 		t.Fatalf("client.NewStream() failed: %v", err)
 	}
@@ -150,7 +150,7 @@ func (s) TestMaxConnectionAge(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
-	if _, err := client.NewStream(ctx, &CallHdr{}); err != nil {
+	if _, err := client.NewStream(ctx, &CallHdr{}, nil); err != nil {
 		t.Fatalf("client.NewStream() failed: %v", err)
 	}
 
@@ -372,7 +372,7 @@ func (s) TestKeepaliveClientClosesWithActiveStreams(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
 	// Create a stream, but send no data on it.
-	if _, err := client.NewStream(ctx, &CallHdr{}); err != nil {
+	if _, err := client.NewStream(ctx, &CallHdr{}, nil); err != nil {
 		t.Fatalf("Stream creation failed: %v", err)
 	}
 
@@ -514,7 +514,7 @@ func (s) TestKeepaliveServerEnforcementWithAbusiveClientWithRPC(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
-	if _, err := client.NewStream(ctx, &CallHdr{}); err != nil {
+	if _, err := client.NewStream(ctx, &CallHdr{}, nil); err != nil {
 		t.Fatalf("Stream creation failed: %v", err)
 	}
 
@@ -743,7 +743,7 @@ func (s) TestTCPUserTimeout(t *testing.T) {
 
 		ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 		defer cancel()
-		stream, err := client.NewStream(ctx, &CallHdr{})
+		stream, err := client.NewStream(ctx, &CallHdr{}, nil)
 		if err != nil {
 			t.Fatalf("client.NewStream() failed: %v", err)
 		}
@@ -810,7 +810,7 @@ func makeTLSCreds(t *testing.T, certPath, keyPath, rootsPath string) credentials
 func checkForHealthyStream(client *http2Client) error {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
-	stream, err := client.NewStream(ctx, &CallHdr{})
+	stream, err := client.NewStream(ctx, &CallHdr{}, nil)
 	stream.Close(err)
 	return err
 }
@@ -819,7 +819,7 @@ func pollForStreamCreationError(client *http2Client) error {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
 	for {
-		if _, err := client.NewStream(ctx, &CallHdr{}); err != nil {
+		if _, err := client.NewStream(ctx, &CallHdr{}, nil); err != nil {
 			break
 		}
 		time.Sleep(50 * time.Millisecond)
@@ -845,7 +845,7 @@ func waitForGoAwayTooManyPings(client *http2Client) error {
 		return fmt.Errorf("test timed out before getting GoAway with reason:GoAwayTooManyPings from server")
 	}
 
-	if _, err := client.NewStream(ctx, &CallHdr{}); err == nil {
+	if _, err := client.NewStream(ctx, &CallHdr{}, nil); err == nil {
 		return fmt.Errorf("stream creation succeeded after receiving a GoAway from the server")
 	}
 	return nil

--- a/internal/transport/transport.go
+++ b/internal/transport/transport.go
@@ -617,7 +617,7 @@ type ClientTransport interface {
 	GracefulClose()
 
 	// NewStream creates a Stream for an RPC.
-	NewStream(ctx context.Context, callHdr *CallHdr) (*ClientStream, error)
+	NewStream(ctx context.Context, callHdr *CallHdr, handler stats.Handler) (*ClientStream, error)
 
 	// Error returns a channel that is closed when some I/O error
 	// happens. Typically the caller should have a goroutine to monitor

--- a/internal/transport/transport_test.go
+++ b/internal/transport/transport_test.go
@@ -592,7 +592,7 @@ func (s) TestInflightStreamClosing(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
-	stream, err := client.NewStream(ctx, &CallHdr{})
+	stream, err := client.NewStream(ctx, &CallHdr{}, nil)
 	if err != nil {
 		t.Fatalf("Client failed to create RPC request: %v", err)
 	}
@@ -640,7 +640,7 @@ func (s) TestClientTransportDrainsAfterStreamIDExhausted(t *testing.T) {
 	ctx, ctxCancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer ctxCancel()
 
-	s, err := ct.NewStream(ctx, callHdr)
+	s, err := ct.NewStream(ctx, callHdr, nil)
 	if err != nil {
 		t.Fatalf("ct.NewStream() = %v", err)
 	}
@@ -653,7 +653,7 @@ func (s) TestClientTransportDrainsAfterStreamIDExhausted(t *testing.T) {
 	}
 
 	// The expected stream ID here is 3 since stream IDs are incremented by 2.
-	s, err = ct.NewStream(ctx, callHdr)
+	s, err = ct.NewStream(ctx, callHdr, nil)
 	if err != nil {
 		t.Fatalf("ct.NewStream() = %v", err)
 	}
@@ -676,14 +676,14 @@ func (s) TestClientSendAndReceive(t *testing.T) {
 	}
 	ctx, ctxCancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer ctxCancel()
-	s1, err1 := ct.NewStream(ctx, callHdr)
+	s1, err1 := ct.NewStream(ctx, callHdr, nil)
 	if err1 != nil {
 		t.Fatalf("failed to open stream: %v", err1)
 	}
 	if s1.id != 1 {
 		t.Fatalf("wrong stream id: %d", s1.id)
 	}
-	s2, err2 := ct.NewStream(ctx, callHdr)
+	s2, err2 := ct.NewStream(ctx, callHdr, nil)
 	if err2 != nil {
 		t.Fatalf("failed to open stream: %v", err2)
 	}
@@ -723,7 +723,7 @@ func performOneRPC(ct ClientTransport) {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
-	s, err := ct.NewStream(ctx, callHdr)
+	s, err := ct.NewStream(ctx, callHdr, nil)
 	if err != nil {
 		return
 	}
@@ -769,7 +769,7 @@ func (s) TestLargeMessage(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			s, err := ct.NewStream(ctx, callHdr)
+			s, err := ct.NewStream(ctx, callHdr, nil)
 			if err != nil {
 				t.Errorf("%v.NewStream(_, _) = _, %v, want _, <nil>", ct, err)
 			}
@@ -817,7 +817,7 @@ func (s) TestLargeMessageWithDelayRead(t *testing.T) {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 	defer cancel()
-	s, err := ct.NewStream(ctx, callHdr)
+	s, err := ct.NewStream(ctx, callHdr, nil)
 	if err != nil {
 		t.Fatalf("%v.NewStream(_, _) = _, %v, want _, <nil>", ct, err)
 		return
@@ -916,7 +916,7 @@ func (s) TestGracefulClose(t *testing.T) {
 
 	// Create a stream that will exist for this whole test and confirm basic
 	// functionality.
-	s, err := ct.NewStream(ctx, &CallHdr{})
+	s, err := ct.NewStream(ctx, &CallHdr{}, nil)
 	if err != nil {
 		t.Fatalf("NewStream(_, _) = _, %v, want _, <nil>", err)
 	}
@@ -948,7 +948,7 @@ func (s) TestGracefulClose(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			_, err := ct.NewStream(ctx, &CallHdr{})
+			_, err := ct.NewStream(ctx, &CallHdr{}, nil)
 			if err != nil && err.(*NewStreamError).Err == ErrConnClosing && err.(*NewStreamError).AllowTransparentRetry {
 				return
 			}
@@ -976,7 +976,7 @@ func (s) TestLargeMessageSuspension(t *testing.T) {
 	// Set a long enough timeout for writing a large message out.
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	s, err := ct.NewStream(ctx, callHdr)
+	s, err := ct.NewStream(ctx, callHdr, nil)
 	if err != nil {
 		t.Fatalf("failed to open stream: %v", err)
 	}
@@ -1016,7 +1016,7 @@ func (s) TestMaxStreams(t *testing.T) {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
-	s, err := ct.NewStream(ctx, callHdr)
+	s, err := ct.NewStream(ctx, callHdr, nil)
 	if err != nil {
 		t.Fatalf("Failed to open stream: %v", err)
 	}
@@ -1037,7 +1037,7 @@ func (s) TestMaxStreams(t *testing.T) {
 		// This is only to get rid of govet. All these context are based on a base
 		// context which is canceled at the end of the test.
 		defer cancel()
-		if str, err := ct.NewStream(ctx, callHdr); err == nil {
+		if str, err := ct.NewStream(ctx, callHdr, nil); err == nil {
 			slist = append(slist, str)
 			continue
 		} else if err.Error() != expectedErr.Error() {
@@ -1052,7 +1052,7 @@ func (s) TestMaxStreams(t *testing.T) {
 		defer close(done)
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 		defer cancel()
-		if _, err := ct.NewStream(ctx, callHdr); err != nil {
+		if _, err := ct.NewStream(ctx, callHdr, nil); err != nil {
 			t.Errorf("Failed to open stream: %v", err)
 		}
 	}()
@@ -1103,7 +1103,7 @@ func (s) TestServerContextCanceledOnClosedConnection(t *testing.T) {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
-	s, err := ct.NewStream(ctx, callHdr)
+	s, err := ct.NewStream(ctx, callHdr, nil)
 	if err != nil {
 		t.Fatalf("Failed to open stream: %v", err)
 	}
@@ -1173,7 +1173,7 @@ func (s) TestClientConnDecoupledFromApplicationRead(t *testing.T) {
 	server.mu.Unlock()
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
-	cstream1, err := client.NewStream(ctx, &CallHdr{})
+	cstream1, err := client.NewStream(ctx, &CallHdr{}, nil)
 	if err != nil {
 		t.Fatalf("Client failed to create first stream. Err: %v", err)
 	}
@@ -1200,7 +1200,7 @@ func (s) TestClientConnDecoupledFromApplicationRead(t *testing.T) {
 	server.h.notify = notifyChan
 	server.mu.Unlock()
 	// Create another stream on client.
-	cstream2, err := client.NewStream(ctx, &CallHdr{})
+	cstream2, err := client.NewStream(ctx, &CallHdr{}, nil)
 	if err != nil {
 		t.Fatalf("Client failed to create second stream. Err: %v", err)
 	}
@@ -1262,7 +1262,7 @@ func (s) TestServerConnDecoupledFromApplicationRead(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
 	server.mu.Unlock()
-	cstream1, err := client.NewStream(ctx, &CallHdr{})
+	cstream1, err := client.NewStream(ctx, &CallHdr{}, nil)
 	if err != nil {
 		t.Fatalf("Failed to create 1st stream. Err: %v", err)
 	}
@@ -1271,7 +1271,7 @@ func (s) TestServerConnDecoupledFromApplicationRead(t *testing.T) {
 		t.Fatalf("Client failed to write data. Err: %v", err)
 	}
 	// Client should be able to create another stream and send data on it.
-	cstream2, err := client.NewStream(ctx, &CallHdr{})
+	cstream2, err := client.NewStream(ctx, &CallHdr{}, nil)
 	if err != nil {
 		t.Fatalf("Failed to create 2nd stream. Err: %v", err)
 	}
@@ -1549,7 +1549,7 @@ func (s) TestClientWithMisbehavedServer(t *testing.T) {
 	}
 	defer ct.Close(fmt.Errorf("closed manually by test"))
 
-	str, err := ct.NewStream(connectCtx, &CallHdr{})
+	str, err := ct.NewStream(connectCtx, &CallHdr{}, nil)
 	if err != nil {
 		t.Fatalf("Error while creating stream: %v", err)
 	}
@@ -1579,7 +1579,7 @@ func (s) TestEncodingRequiredStatus(t *testing.T) {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
-	s, err := ct.NewStream(ctx, callHdr)
+	s, err := ct.NewStream(ctx, callHdr, nil)
 	if err != nil {
 		return
 	}
@@ -1609,7 +1609,7 @@ func (s) TestInvalidHeaderField(t *testing.T) {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
-	s, err := ct.NewStream(ctx, callHdr)
+	s, err := ct.NewStream(ctx, callHdr, nil)
 	if err != nil {
 		return
 	}
@@ -1629,7 +1629,7 @@ func (s) TestHeaderChanClosedAfterReceivingAnInvalidHeader(t *testing.T) {
 	defer ct.Close(fmt.Errorf("closed manually by test"))
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
-	s, err := ct.NewStream(ctx, &CallHdr{Host: "localhost", Method: "foo"})
+	s, err := ct.NewStream(ctx, &CallHdr{Host: "localhost", Method: "foo"}, nil)
 	if err != nil {
 		t.Fatalf("failed to create the stream")
 	}
@@ -1759,7 +1759,7 @@ func testFlowControlAccountCheck(t *testing.T, msgSize int, wc windowSizeConfig)
 	clientStreams := make([]*ClientStream, numStreams)
 	for i := 0; i < numStreams; i++ {
 		var err error
-		clientStreams[i], err = client.NewStream(ctx, &CallHdr{})
+		clientStreams[i], err = client.NewStream(ctx, &CallHdr{}, nil)
 		if err != nil {
 			t.Fatalf("Failed to create stream. Err: %v", err)
 		}
@@ -2310,7 +2310,7 @@ func (s) TestWriteHeaderConnectionError(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
-	cstream, err := client.NewStream(ctx, &CallHdr{})
+	cstream, err := client.NewStream(ctx, &CallHdr{}, nil)
 	if err != nil {
 		t.Fatalf("Client failed to create first stream. Err: %v", err)
 	}
@@ -2374,7 +2374,7 @@ func runPingPongTest(t *testing.T, msgSize int) {
 	})
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
-	stream, err := client.NewStream(ctx, &CallHdr{})
+	stream, err := client.NewStream(ctx, &CallHdr{}, nil)
 	if err != nil {
 		t.Fatalf("Failed to create stream. Err: %v", err)
 	}
@@ -2448,7 +2448,7 @@ func (s) TestHeaderTblSize(t *testing.T) {
 	defer server.stop()
 	ctx, ctxCancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer ctxCancel()
-	_, err := ct.NewStream(ctx, &CallHdr{})
+	_, err := ct.NewStream(ctx, &CallHdr{}, nil)
 	if err != nil {
 		t.Fatalf("failed to open stream: %v", err)
 	}
@@ -2967,7 +2967,7 @@ func (s) TestClientSendsAGoAwayFrame(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error while creating client transport: %v", err)
 	}
-	_, err = ct.NewStream(ctx, &CallHdr{})
+	_, err = ct.NewStream(ctx, &CallHdr{}, nil)
 	if err != nil {
 		t.Fatalf("failed to open stream: %v", err)
 	}
@@ -3037,7 +3037,7 @@ func (s) TestClientCloseReturnsAfterReaderCompletes(t *testing.T) {
 		t.Fatalf("Failed to create transport: %v", err)
 	}
 
-	if _, err := ct.NewStream(ctx, &CallHdr{}); err != nil {
+	if _, err := ct.NewStream(ctx, &CallHdr{}, nil); err != nil {
 		t.Fatalf("Failed to open stream: %v", err)
 	}
 
@@ -3129,7 +3129,7 @@ func (s) TestClientCloseReturnsEarlyWhenGoAwayWriteHangs(t *testing.T) {
 		t.Fatalf("failed to create transport: %v", connErr)
 	}
 
-	if _, err := ct.NewStream(ctx, &CallHdr{}); err != nil {
+	if _, err := ct.NewStream(ctx, &CallHdr{}, nil); err != nil {
 		t.Fatalf("Failed to open stream: %v", err)
 	}
 
@@ -3464,7 +3464,7 @@ func (s) TestDeleteStreamMetricsIncrementedOnlyOnce(t *testing.T) {
 				t.Fatal("Server transport not found")
 			}
 
-			clientStream, err := client.NewStream(ctx, &CallHdr{})
+			clientStream, err := client.NewStream(ctx, &CallHdr{}, nil)
 			if err != nil {
 				t.Fatalf("Failed to create stream: %v", err)
 			}

--- a/stream.go
+++ b/stream.go
@@ -548,7 +548,7 @@ func (a *csAttempt) newStream() error {
 			}
 		}
 	}
-	s, err := a.transport.NewStream(a.ctx, cs.callHdr)
+	s, err := a.transport.NewStream(a.ctx, cs.callHdr, a.statsHandler)
 	if err != nil {
 		nse, ok := err.(*transport.NewStreamError)
 		if !ok {
@@ -1354,7 +1354,8 @@ func newNonRetryClientStream(ctx context.Context, desc *StreamDesc, method strin
 		transport:        t,
 	}
 
-	s, err := as.transport.NewStream(as.ctx, as.callHdr)
+	// nil stats handler: internal streams like health and ORCA do not support telemetry.
+	s, err := as.transport.NewStream(as.ctx, as.callHdr, nil)
 	if err != nil {
 		err = toRPCErr(err)
 		return nil, err


### PR DESCRIPTION
Cherry picks [PR](https://github.com/grpc/grpc-go/pull/8874) into 1.79.x

RELEASE NOTES:
* stats: only process RPC stats/tracing in health and ORCA producers if a handler is configured, preventing unnecessary error logging
