### PR TITLE
correctly check nil stream

### DIFF
--- a/internal/transport/keepalive_test.go
+++ b/internal/transport/keepalive_test.go
@@ -816,10 +816,11 @@ func checkForHealthyStream(client *http2Client) error {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
 	stream, err := client.NewStream(ctx, &CallHdr{}, nil)
-	if stream != nil {
-		stream.Close(err)
+	if err != nil {
+		return err
 	}
-	return err
+	stream.Close(nil)
+	return nil
 }
 
 func pollForStreamCreationError(client *http2Client) error {


### PR DESCRIPTION
Fixes: https://github.com/grpc/grpc-go/issues/8893

This PR changes the `[checkForHealthyStream`](https://github.com/grpc/grpc-go/blob/944f0585ca8664eb8f09635531c3c9d52d1e8bbb/internal/transport/keepalive_test.go#L815) function in keepalive_test.go to check for nil stream before closing the stream. This will make sure the error is returned and logged correctly instead of throwing a panic when the stream creation fails.

RELEASE NOTES: None
