### PR TITLE
xds/rbac: replace legacy net to netip

### DIFF
--- a/internal/xds/rbac/matchers.go
+++ b/internal/xds/rbac/matchers.go
@@ -344,10 +344,7 @@ func newRemoteIPMatcher(cidrRange *v3corepb.CidrRange) (*remoteIPMatcher, error)
 }
 
 func (sim *remoteIPMatcher) match(data *rpcData) bool {
-	ip, err := netip.ParseAddr(data.peerInfo.Addr.String())
-	if err != nil {
-		return false
-	}
+	ip, _ := netip.ParseAddr(data.peerInfo.Addr.String())
 	return sim.ipNet.Contains(ip)
 }
 
@@ -365,10 +362,7 @@ func newLocalIPMatcher(cidrRange *v3corepb.CidrRange) (*localIPMatcher, error) {
 }
 
 func (dim *localIPMatcher) match(data *rpcData) bool {
-	ip, err := netip.ParseAddr(data.localAddr.String())
-	if err != nil {
-		return false
-	}
+	ip, _ := netip.ParseAddr(data.localAddr.String())
 	return dim.ipNet.Contains(ip)
 }
 


### PR DESCRIPTION
Updates #8884 

this PR replace net.IPNet with netip.Prefix in file `internal/xds/rbac/matchers.go`.
- Replaced internal matcher CIDR type from `*net.IPNet` to `netip.Prefix`
- Migrated CIDR parsing from `net.ParseCIDR` to `netip.ParsePrefix`, with .Masked() normalization to keep canonical network behavior


RELEASE NOTES: N/A