### PR TITLE
orca: fix goroutine leak in fakeORCAService.StreamCoreMetrics

### DIFF
--- a/orca/producer_test.go
+++ b/orca/producer_test.go
@@ -236,7 +236,11 @@ func (f *fakeORCAService) close() {
 }
 
 func (f *fakeORCAService) StreamCoreMetrics(req *v3orcaservicepb.OrcaLoadReportRequest, stream v3orcaservicegrpc.OpenRcaService_StreamCoreMetricsServer) error {
-	f.reqCh <- req
+	select {
+	case f.reqCh <- req:
+	case <-stream.Context().Done():
+		return stream.Context().Err()
+	}
 	for {
 		var resp any
 		select {


### PR DESCRIPTION
Fixes #8891

When a test context expires before `awaitRequest` reads from `reqCh`,
the goroutine running `StreamCoreMetrics` was permanently blocked on the
unbuffered channel send `f.reqCh <- req`, causing a goroutine leak.

Fix this by wrapping the send in a select that also listens to
`stream.Context().Done()`. When the gRPC connection is cleaned up via
deferred `cc.Close()`, the stream context is cancelled, which unblocks
the select and allows the goroutine to exit cleanly.

RELEASE NOTES: N/A
