### PR TITLE
credentials: remove GRPC_ENFORCE_ALPN_ENABLED env var and always enforce ALPN

### DIFF
--- a/credentials/tls.go
+++ b/credentials/tls.go
@@ -27,14 +27,10 @@ import (
 	"net/url"
 	"os"
 
-	"google.golang.org/grpc/grpclog"
 	credinternal "google.golang.org/grpc/internal/credentials"
-	"google.golang.org/grpc/internal/envconfig"
 )
 
 const alpnFailureHelpMessage = "If you upgraded from a grpc-go version earlier than 1.67, your TLS connections may have stopped working due to ALPN enforcement. For more details, see: https://github.com/grpc/grpc-go/issues/434"
-
-var logger = grpclog.Component("credentials")
 
 // TLSInfo contains the auth information for a TLS authenticated connection.
 // It implements the AuthInfo interface.
@@ -146,11 +142,8 @@ func (c *tlsCreds) ClientHandshake(ctx context.Context, authority string, rawCon
 	//    for using HTTP/2 over TLS. We can terminate the connection immediately.
 	np := conn.ConnectionState().NegotiatedProtocol
 	if np == "" {
-		if envconfig.EnforceALPNEnabled {
-			conn.Close()
-			return nil, nil, fmt.Errorf("credentials: cannot check peer: missing selected ALPN property. %s", alpnFailureHelpMessage)
-		}
-		logger.Warningf("Allowing TLS connection to server %q with ALPN disabled. TLS connections to servers with ALPN disabled will be disallowed in future grpc-go releases", cfg.ServerName)
+		conn.Close()
+		return nil, nil, fmt.Errorf("credentials: cannot check peer: missing selected ALPN property. %s", alpnFailureHelpMessage)
 	}
 	tlsInfo := TLSInfo{
 		State: conn.ConnectionState(),
@@ -176,12 +169,8 @@ func (c *tlsCreds) ServerHandshake(rawConn net.Conn) (net.Conn, AuthInfo, error)
 	// support ALPN. In such cases, we can close the connection since ALPN is required
 	// for using HTTP/2 over TLS.
 	if cs.NegotiatedProtocol == "" {
-		if envconfig.EnforceALPNEnabled {
-			conn.Close()
-			return nil, nil, fmt.Errorf("credentials: cannot check peer: missing selected ALPN property. %s", alpnFailureHelpMessage)
-		} else if logger.V(2) {
-			logger.Info("Allowing TLS connection from client with ALPN disabled. TLS connections with ALPN disabled will be disallowed in future grpc-go releases")
-		}
+		conn.Close()
+		return nil, nil, fmt.Errorf("credentials: cannot check peer: missing selected ALPN property. %s", alpnFailureHelpMessage)
 	}
 	tlsInfo := TLSInfo{
 		State: cs,

--- a/credentials/tls_ext_test.go
+++ b/credentials/tls_ext_test.go
@@ -32,7 +32,6 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
-	"google.golang.org/grpc/internal/envconfig"
 	"google.golang.org/grpc/internal/grpctest"
 	"google.golang.org/grpc/internal/stubserver"
 	"google.golang.org/grpc/status"
@@ -411,12 +410,6 @@ func (s) TestTLS_CipherSuitesOverridable(t *testing.T) {
 // correctly for a server that doesn't specify the NextProtos field and uses
 // GetConfigForClient to provide the TLS config during the handshake.
 func (s) TestTLS_ServerConfiguresALPNByDefault(t *testing.T) {
-	initialVal := envconfig.EnforceALPNEnabled
-	defer func() {
-		envconfig.EnforceALPNEnabled = initialVal
-	}()
-	envconfig.EnforceALPNEnabled = true
-
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
 
@@ -450,159 +443,107 @@ func (s) TestTLS_ServerConfiguresALPNByDefault(t *testing.T) {
 	}
 }
 
-// TestTLS_DisabledALPNClient tests the behaviour of TransportCredentials when
-// connecting to a server that doesn't support ALPN.
+// TestTLS_DisabledALPNClient tests that ClientHandshake rejects a server that
+// doesn't support ALPN.
 func (s) TestTLS_DisabledALPNClient(t *testing.T) {
-	initialVal := envconfig.EnforceALPNEnabled
-	defer func() {
-		envconfig.EnforceALPNEnabled = initialVal
-	}()
-
-	tests := []struct {
-		name         string
-		alpnEnforced bool
-		wantErr      bool
-	}{
-		{
-			name:         "enforced",
-			alpnEnforced: true,
-			wantErr:      true,
-		},
-		{
-			name: "not_enforced",
-		},
+	listener, err := tls.Listen("tcp", "localhost:0", &tls.Config{
+		Certificates: []tls.Certificate{serverCert},
+		NextProtos:   []string{}, // Empty list indicates ALPN is disabled.
+	})
+	if err != nil {
+		t.Fatalf("Error starting TLS server: %v", err)
 	}
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			envconfig.EnforceALPNEnabled = tc.alpnEnforced
+	errCh := make(chan error, 1)
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			errCh <- fmt.Errorf("listener.Accept returned error: %v", err)
+		} else {
+			// The first write to the TLS listener initiates the TLS handshake.
+			conn.Write([]byte("Hello, World!"))
+			conn.Close()
+		}
+		close(errCh)
+	}()
 
-			listener, err := tls.Listen("tcp", "localhost:0", &tls.Config{
-				Certificates: []tls.Certificate{serverCert},
-				NextProtos:   []string{}, // Empty list indicates ALPN is disabled.
-			})
-			if err != nil {
-				t.Fatalf("Error starting TLS server: %v", err)
-			}
+	serverAddr := listener.Addr().String()
+	conn, err := net.Dial("tcp", serverAddr)
+	if err != nil {
+		t.Fatalf("net.Dial(%s) failed: %v", serverAddr, err)
+	}
+	defer conn.Close()
 
-			errCh := make(chan error, 1)
-			go func() {
-				conn, err := listener.Accept()
-				if err != nil {
-					errCh <- fmt.Errorf("listener.Accept returned error: %v", err)
-				} else {
-					// The first write to the TLS listener initiates the TLS handshake.
-					conn.Write([]byte("Hello, World!"))
-					conn.Close()
-				}
-				close(errCh)
-			}()
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
 
-			serverAddr := listener.Addr().String()
-			conn, err := net.Dial("tcp", serverAddr)
-			if err != nil {
-				t.Fatalf("net.Dial(%s) failed: %v", serverAddr, err)
-			}
-			defer conn.Close()
+	clientCfg := tls.Config{
+		ServerName: serverName,
+		RootCAs:    certPool,
+		NextProtos: []string{"h2"},
+	}
+	_, _, err = credentials.NewTLS(&clientCfg).ClientHandshake(ctx, serverName, conn)
+	if err == nil {
+		t.Error("ClientHandshake succeeded; want error for missing ALPN")
+	}
 
-			ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
-			defer cancel()
-
-			clientCfg := tls.Config{
-				ServerName: serverName,
-				RootCAs:    certPool,
-				NextProtos: []string{"h2"},
-			}
-			_, _, err = credentials.NewTLS(&clientCfg).ClientHandshake(ctx, serverName, conn)
-
-			if gotErr := (err != nil); gotErr != tc.wantErr {
-				t.Errorf("ClientHandshake returned unexpected error: got=%v, want=%t", err, tc.wantErr)
-			}
-
-			select {
-			case err := <-errCh:
-				if err != nil {
-					t.Fatalf("Unexpected error received from server: %v", err)
-				}
-			case <-ctx.Done():
-				t.Fatalf("Timeout waiting for error from server")
-			}
-		})
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("Unexpected error received from server: %v", err)
+		}
+	case <-ctx.Done():
+		t.Fatalf("Timeout waiting for error from server")
 	}
 }
 
-// TestTLS_DisabledALPNServer tests the behaviour of TransportCredentials when
-// accepting a request from a client that doesn't support ALPN.
+// TestTLS_DisabledALPNServer tests that ServerHandshake rejects a client that
+// doesn't support ALPN.
 func (s) TestTLS_DisabledALPNServer(t *testing.T) {
-	initialVal := envconfig.EnforceALPNEnabled
-	defer func() {
-		envconfig.EnforceALPNEnabled = initialVal
-	}()
-
-	tests := []struct {
-		name         string
-		alpnEnforced bool
-		wantErr      bool
-	}{
-		{
-			name:         "enforced",
-			alpnEnforced: true,
-			wantErr:      true,
-		},
-		{
-			name: "not_enforced",
-		},
+	listener, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("Error starting server: %v", err)
 	}
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			envconfig.EnforceALPNEnabled = tc.alpnEnforced
+	errCh := make(chan error, 1)
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			errCh <- fmt.Errorf("listener.Accept returned error: %v", err)
+			return
+		}
+		defer conn.Close()
+		serverCfg := tls.Config{
+			Certificates: []tls.Certificate{serverCert},
+			NextProtos:   []string{"h2"},
+		}
+		_, _, err = credentials.NewTLS(&serverCfg).ServerHandshake(conn)
+		if err == nil {
+			errCh <- fmt.Errorf("ServerHandshake succeeded; want error for missing ALPN")
+			return
+		}
+		close(errCh)
+	}()
 
-			listener, err := net.Listen("tcp", "localhost:0")
-			if err != nil {
-				t.Fatalf("Error starting server: %v", err)
-			}
+	serverAddr := listener.Addr().String()
+	clientCfg := &tls.Config{
+		Certificates: []tls.Certificate{serverCert},
+		NextProtos:   []string{}, // Empty list indicates ALPN is disabled.
+		RootCAs:      certPool,
+		ServerName:   serverName,
+	}
+	conn, err := tls.Dial("tcp", serverAddr, clientCfg)
+	if err != nil {
+		t.Fatalf("tls.Dial(%s) failed: %v", serverAddr, err)
+	}
+	defer conn.Close()
 
-			errCh := make(chan error, 1)
-			go func() {
-				conn, err := listener.Accept()
-				if err != nil {
-					errCh <- fmt.Errorf("listener.Accept returned error: %v", err)
-					return
-				}
-				defer conn.Close()
-				serverCfg := tls.Config{
-					Certificates: []tls.Certificate{serverCert},
-					NextProtos:   []string{"h2"},
-				}
-				_, _, err = credentials.NewTLS(&serverCfg).ServerHandshake(conn)
-				if gotErr := (err != nil); gotErr != tc.wantErr {
-					t.Errorf("ServerHandshake returned unexpected error: got=%v, want=%t", err, tc.wantErr)
-				}
-				close(errCh)
-			}()
-
-			serverAddr := listener.Addr().String()
-			clientCfg := &tls.Config{
-				Certificates: []tls.Certificate{serverCert},
-				NextProtos:   []string{}, // Empty list indicates ALPN is disabled.
-				RootCAs:      certPool,
-				ServerName:   serverName,
-			}
-			conn, err := tls.Dial("tcp", serverAddr, clientCfg)
-			if err != nil {
-				t.Fatalf("tls.Dial(%s) failed: %v", serverAddr, err)
-			}
-			defer conn.Close()
-
-			select {
-			case <-time.After(defaultTestTimeout):
-				t.Fatal("Timed out waiting for completion")
-			case err := <-errCh:
-				if err != nil {
-					t.Fatalf("Unexpected server error: %v", err)
-				}
-			}
-		})
+	select {
+	case <-time.After(defaultTestTimeout):
+		t.Fatal("Timed out waiting for completion")
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("Unexpected server error: %v", err)
+		}
 	}
 }

--- a/internal/envconfig/envconfig.go
+++ b/internal/envconfig/envconfig.go
@@ -45,13 +45,6 @@ var (
 	// handshakes that can be performed.
 	ALTSMaxConcurrentHandshakes = uint64FromEnv("GRPC_ALTS_MAX_CONCURRENT_HANDSHAKES", 100, 1, 100)
 
-	// EnforceALPNEnabled is set if TLS connections to servers with ALPN disabled
-	// should be rejected. The HTTP/2 protocol requires ALPN to be enabled, this
-	// option is present for backward compatibility. This option may be overridden
-	// by setting the environment variable "GRPC_ENFORCE_ALPN_ENABLED" to "true"
-	// or "false".
-	EnforceALPNEnabled = boolFromEnv("GRPC_ENFORCE_ALPN_ENABLED", true)
-
 	// XDSEndpointHashKeyBackwardCompat controls the parsing of the endpoint hash
 	// key from EDS LbEndpoint metadata. Endpoint hash keys can be disabled by
 	// setting "GRPC_XDS_ENDPOINT_HASH_KEY_BACKWARD_COMPAT" to "true". When the


### PR DESCRIPTION
Fixes #434

## Background

In grpc-go v1.67, ALPN enforcement was introduced to comply with the
HTTP/2 spec (RFC 7540 §3.3), which requires TLS connections to negotiate
the `h2` protocol identifier via ALPN. A temporary escape hatch
`GRPC_ENFORCE_ALPN_ENABLED` env var was added for backward compatibility
with clients/servers that violate the HTTP/2 spec.

## Changes

This PR removes the `GRPC_ENFORCE_ALPN_ENABLED` environment variable and
makes ALPN enforcement unconditional:

- `internal/envconfig`: Remove `EnforceALPNEnabled` variable
- `credentials/tls.go`: Remove envconfig-guarded ALPN check; both
  `ClientHandshake` and `ServerHandshake` now always return an error when
  the negotiated ALPN protocol is empty
- `credentials/tls_ext_test.go`: Simplify tests to reflect that
  enforcement is always on (no more table-driven enforced/not-enforced
  variants)

Users who legitimately need to connect to non-ALPN servers should use
`experimental/credentials.NewTLSWithALPNDisabled`, which is the
sanctioned opt-out.
