### PR TITLE
interop/orcalb: Delegate SubConn management to pick_first

### DIFF
--- a/interop/orcalb.go
+++ b/interop/orcalb.go
@@ -49,7 +49,9 @@ func (orcabb) Build(cc balancer.ClientConn, bOpts balancer.BuildOptions) balance
 	b := &orcab{
 		ClientConn:       cc,
 		stopOOBListeners: make(map[balancer.SubConn]func()),
-		oobState:         &oobState{},
+		oobState: &oobState{
+			reports: make(map[balancer.SubConn]*v3orcapb.OrcaLoadReport),
+		},
 	}
 	b.logger = internalgrpclog.NewPrefixLogger(orcaLogger, fmt.Sprintf("[%p] ", b))
 	b.child = endpointsharding.NewBalancer(b, bOpts, balancer.Get(pickfirst.Name).Build, endpointsharding.Options{})
@@ -65,16 +67,16 @@ func (orcabb) Name() string {
 // It delegates SubConn management to endpointsharding + pick_first and
 // intercepts NewSubConn calls to register OOB listeners on READY SubConns.
 type orcab struct {
-	// Embeds balancer.ClientConn to intercept NewSubConn and UpdateState
-	// calls from child balancers.
-	balancer.ClientConn
-	child balancer.Balancer
-	// mu guards stopOOBListeners.
+	// The following fields are initialized at build time and read-only after
+	// that and therefore do not need to be guarded by a mutex.
+	balancer.ClientConn // Embeds to intercept NewSubConn and UpdateState calls
+	child               balancer.Balancer
+	oobState            *oobState
+	logger              *internalgrpclog.PrefixLogger
+
+	// mu guards the fields below.
 	mu               sync.Mutex
 	stopOOBListeners map[balancer.SubConn]func()
-
-	oobState *oobState
-	logger   *internalgrpclog.PrefixLogger
 }
 
 func (b *orcab) UpdateClientConnState(s balancer.ClientConnState) error {
@@ -137,29 +139,31 @@ func (b *orcab) updateSubConnState(sc balancer.SubConn, state balancer.SubConnSt
 	}
 
 	if state.ConnectivityState == connectivity.Ready {
-		oldStop, exists := b.stopOOBListeners[sc]
+		oldStop := b.stopOOBListeners[sc]
 		stop := orca.RegisterOOBListener(sc, &orcaOOBListener{subConn: sc, balancer: b}, orca.OOBListenerOptions{ReportInterval: time.Second})
 		b.stopOOBListeners[sc] = stop
 		b.mu.Unlock()
 
-		if exists {
+		if oldStop != nil {
 			oldStop()
 		}
 		return
 	}
 
-	stop, ok := b.stopOOBListeners[sc]
-	if ok {
+	stop := b.stopOOBListeners[sc]
+	if stop != nil {
 		delete(b.stopOOBListeners, sc)
 	}
 	b.mu.Unlock()
 
-	if ok {
+	if stop != nil {
 		stop()
 	}
 
 	if state.ConnectivityState == connectivity.Shutdown {
-		b.oobState.reports.Delete(sc)
+		b.oobState.mu.Lock()
+		delete(b.oobState.reports, sc)
+		b.oobState.mu.Unlock()
 	}
 }
 
@@ -187,11 +191,14 @@ func (l *orcaOOBListener) OnLoadReport(r *v3orcapb.OrcaLoadReport) {
 	if r == nil {
 		return
 	}
-	l.balancer.oobState.reports.Store(l.subConn, r)
+	l.balancer.oobState.mu.Lock()
+	defer l.balancer.oobState.mu.Unlock()
+	l.balancer.oobState.reports[l.subConn] = r
 }
 
 type oobState struct {
-	reports sync.Map // map[balancer.SubConn]*v3orcapb.OrcaLoadReport
+	mu      sync.Mutex
+	reports map[balancer.SubConn]*v3orcapb.OrcaLoadReport
 }
 type orcaPicker struct {
 	childPicker balancer.Picker
@@ -204,15 +211,18 @@ func (p *orcaPicker) Pick(info balancer.PickInfo) (balancer.PickResult, error) {
 		return res, err
 	}
 
-	var lr *v3orcapb.OrcaLoadReport
-	if val, ok := p.oobState.reports.Load(res.SubConn); ok {
-		lr = val.(*v3orcapb.OrcaLoadReport)
-	}
+	p.oobState.mu.Lock()
+	lr := p.oobState.reports[res.SubConn]
+	p.oobState.mu.Unlock()
 
 	origDone := res.Done
 	res.Done = func(di balancer.DoneInfo) {
-		if perRPCLR, _ := di.ServerLoad.(*v3orcapb.OrcaLoadReport); perRPCLR != nil &&
-			(perRPCLR.CpuUtilization != 0 || perRPCLR.MemUtilization != 0 || len(perRPCLR.Utilization) > 0 || len(perRPCLR.RequestCost) > 0) {
+		perRPCLR, _ := di.ServerLoad.(*v3orcapb.OrcaLoadReport)
+		hasMetrics := perRPCLR != nil && (perRPCLR.CpuUtilization != 0 ||
+			perRPCLR.MemUtilization != 0 ||
+			len(perRPCLR.Utilization) > 0 ||
+			len(perRPCLR.RequestCost) > 0)
+		if hasMetrics {
 			setContextCMR(info.Ctx, perRPCLR)
 		} else if lr != nil {
 			setContextCMR(info.Ctx, lr)

--- a/interop/orcalb.go
+++ b/interop/orcalb.go
@@ -99,11 +99,12 @@ func (b *orcab) ExitIdle() {
 
 func (b *orcab) Close() {
 	b.mu.Lock()
-	for _, stop := range b.stopOOBListeners {
-		stop()
-	}
+	listeners := b.stopOOBListeners
 	b.stopOOBListeners = nil
 	b.mu.Unlock()
+	for _, stop := range listeners {
+		stop()
+	}
 	b.child.Close()
 }
 

--- a/interop/orcalb.go
+++ b/interop/orcalb.go
@@ -130,22 +130,35 @@ func (b *orcab) NewSubConn(addrs []resolver.Address, opts balancer.NewSubConnOpt
 
 func (b *orcab) updateSubConnState(sc balancer.SubConn, state balancer.SubConnState) {
 	b.mu.Lock()
-	defer b.mu.Unlock()
 	if b.stopOOBListeners == nil {
-		// Already closed; drop the state update.
+		b.mu.Unlock()
 		return
 	}
+
 	if state.ConnectivityState == connectivity.Ready {
-		// Register an OOB listener when the SubConn becomes READY.
-		stop := orca.RegisterOOBListener(sc, b, orca.OOBListenerOptions{ReportInterval: time.Second})
+		oldStop, exists := b.stopOOBListeners[sc]
+		stop := orca.RegisterOOBListener(sc, &orcaOOBListener{subConn: sc, balancer: b}, orca.OOBListenerOptions{ReportInterval: time.Second})
 		b.stopOOBListeners[sc] = stop
+		b.mu.Unlock()
+
+		if exists {
+			oldStop()
+		}
 		return
 	}
-	// For any other state (including Shutdown), stop and remove the OOB
-	// listener if one was registered for this SubConn.
-	if stop, ok := b.stopOOBListeners[sc]; ok {
-		stop()
+
+	stop, ok := b.stopOOBListeners[sc]
+	if ok {
 		delete(b.stopOOBListeners, sc)
+	}
+	b.mu.Unlock()
+
+	if ok {
+		stop()
+	}
+
+	if state.ConnectivityState == connectivity.Shutdown {
+		b.oobState.reports.Delete(sc)
 	}
 }
 
@@ -163,17 +176,21 @@ func (b *orcab) UpdateState(state balancer.State) {
 	b.ClientConn.UpdateState(state)
 }
 
+type orcaOOBListener struct {
+	subConn  balancer.SubConn
+	balancer *orcab
+}
+
 // OnLoadReport implements orca.OOBListener.
-func (b *orcab) OnLoadReport(r *v3orcapb.OrcaLoadReport) {
-	b.oobState.mu.Lock()
-	defer b.oobState.mu.Unlock()
-	b.logger.Infof("Received OOB load report: %v", r)
-	b.oobState.report = r
+func (l *orcaOOBListener) OnLoadReport(r *v3orcapb.OrcaLoadReport) {
+	if r == nil {
+		return
+	}
+	l.balancer.oobState.reports.Store(l.subConn, r)
 }
 
 type oobState struct {
-	mu     sync.Mutex
-	report *v3orcapb.OrcaLoadReport
+	reports sync.Map // map[balancer.SubConn]*v3orcapb.OrcaLoadReport
 }
 type orcaPicker struct {
 	childPicker balancer.Picker
@@ -185,20 +202,19 @@ func (p *orcaPicker) Pick(info balancer.PickInfo) (balancer.PickResult, error) {
 	if err != nil {
 		return res, err
 	}
+
+	var lr *v3orcapb.OrcaLoadReport
+	if val, ok := p.oobState.reports.Load(res.SubConn); ok {
+		lr = val.(*v3orcapb.OrcaLoadReport)
+	}
+
 	origDone := res.Done
 	res.Done = func(di balancer.DoneInfo) {
-		if lr, _ := di.ServerLoad.(*v3orcapb.OrcaLoadReport); lr != nil &&
-			(lr.CpuUtilization != 0 || lr.MemUtilization != 0 || len(lr.Utilization) > 0 || len(lr.RequestCost) > 0) {
-			// Since all RPCs will respond with a load report due to the
-			// presence of the DialOption, we need to inspect every field and
-			// use the out-of-band report instead if all are unset/zero.
+		if perRPCLR, _ := di.ServerLoad.(*v3orcapb.OrcaLoadReport); perRPCLR != nil &&
+			(perRPCLR.CpuUtilization != 0 || perRPCLR.MemUtilization != 0 || len(perRPCLR.Utilization) > 0 || len(perRPCLR.RequestCost) > 0) {
+			setContextCMR(info.Ctx, perRPCLR)
+		} else if lr != nil {
 			setContextCMR(info.Ctx, lr)
-		} else {
-			p.oobState.mu.Lock()
-			defer p.oobState.mu.Unlock()
-			if lr := p.oobState.report; lr != nil {
-				setContextCMR(info.Ctx, lr)
-			}
 		}
 		if origDone != nil {
 			origDone(di)

--- a/interop/orcalb.go
+++ b/interop/orcalb.go
@@ -140,11 +140,9 @@ func (b *orcab) updateSubConnState(sc balancer.SubConn, state balancer.SubConnSt
 
 	if state.ConnectivityState == connectivity.Ready {
 		oldStop := b.stopOOBListeners[sc]
-		defer func() {
-			if oldStop != nil {
-				oldStop()
-			}
-		}()
+		if oldStop != nil {
+			oldStop()
+		}
 		stop := orca.RegisterOOBListener(sc, &orcaOOBListener{subConn: sc, balancer: b}, orca.OOBListenerOptions{ReportInterval: time.Second})
 		b.stopOOBListeners[sc] = stop
 		b.mu.Unlock()

--- a/interop/orcalb.go
+++ b/interop/orcalb.go
@@ -24,13 +24,19 @@ import (
 	"sync"
 	"time"
 
-	v3orcapb "github.com/cncf/xds/go/xds/data/orca/v3"
 	"google.golang.org/grpc/balancer"
-	"google.golang.org/grpc/balancer/base"
+	"google.golang.org/grpc/balancer/endpointsharding"
+	"google.golang.org/grpc/balancer/pickfirst"
 	"google.golang.org/grpc/connectivity"
+	"google.golang.org/grpc/grpclog"
+	internalgrpclog "google.golang.org/grpc/internal/grpclog"
 	"google.golang.org/grpc/orca"
 	"google.golang.org/grpc/resolver"
+
+	v3orcapb "github.com/cncf/xds/go/xds/data/orca/v3"
 )
+
+var orcaLogger = grpclog.Component("orca")
 
 func init() {
 	balancer.Register(orcabb{})
@@ -38,106 +44,149 @@ func init() {
 
 type orcabb struct{}
 
-func (orcabb) Build(cc balancer.ClientConn, _ balancer.BuildOptions) balancer.Balancer {
-	return &orcab{cc: cc}
+// Build creates a new orcab balancer.
+func (orcabb) Build(cc balancer.ClientConn, bOpts balancer.BuildOptions) balancer.Balancer {
+	b := &orcab{
+		ClientConn:       cc,
+		stopOOBListeners: make(map[balancer.SubConn]func()),
+		oobState:         &oobState{},
+	}
+	b.logger = internalgrpclog.NewPrefixLogger(orcaLogger, fmt.Sprintf("[%p] ", b))
+	b.child = endpointsharding.NewBalancer(b, bOpts, balancer.Get(pickfirst.Name).Build, endpointsharding.Options{})
+	b.logger.Infof("Created")
+	return b
 }
 
 func (orcabb) Name() string {
 	return "test_backend_metrics_load_balancer"
 }
 
+// orcab is the balancer for the test_backend_metrics_load_balancer policy.
+// It delegates SubConn management to endpointsharding + pick_first and
+// intercepts NewSubConn calls to register OOB listeners on READY SubConns.
 type orcab struct {
-	cc balancer.ClientConn
-	sc balancer.SubConn
+	// Embeds balancer.ClientConn to intercept NewSubConn and UpdateState
+	// calls from child balancers.
+	balancer.ClientConn
+	child balancer.Balancer
+	// mu guards stopOOBListeners.
+	mu               sync.Mutex
+	stopOOBListeners map[balancer.SubConn]func()
 
-	reportMu sync.Mutex
-	report   *v3orcapb.OrcaLoadReport
+	oobState *oobState
+	logger   *internalgrpclog.PrefixLogger
 }
 
-func (o *orcab) ExitIdle() {
-	if o.sc != nil {
-		o.sc.Connect()
+func (b *orcab) UpdateClientConnState(s balancer.ClientConnState) error {
+	// Delegate to the child endpoint sharding balancer, which distributes
+	// state updates to its pick_first children.
+	return b.child.UpdateClientConnState(s)
+}
+
+func (b *orcab) ResolverError(err error) {
+	// Will cause an inline picker update from endpoint sharding.
+	b.child.ResolverError(err)
+}
+
+func (b *orcab) UpdateSubConnState(sc balancer.SubConn, state balancer.SubConnState) {
+	orcaLogger.Errorf("UpdateSubConnState(%v, %+v) called unexpectedly", sc, state)
+}
+
+func (b *orcab) ExitIdle() {
+	// Propagate to the child endpoint sharding balancer.
+	b.child.ExitIdle()
+}
+
+func (b *orcab) Close() {
+	b.mu.Lock()
+	for _, stop := range b.stopOOBListeners {
+		stop()
 	}
+	b.stopOOBListeners = nil
+	b.mu.Unlock()
+	b.child.Close()
 }
 
-// endpointsToAddrs flattens a list of endpoints to addresses to maintain
-// existing behavior.
-// TODO: https://github.com/grpc/grpc-go/issues/8809 - delegate subchannel
-// management to the pickfirst balancer using the endpoint sharding balancer.
-func endpointsToAddrs(eps []resolver.Endpoint) []resolver.Address {
-	addrs := make([]resolver.Address, 0, len(eps))
-	for _, ep := range eps {
-		if len(ep.Addresses) == 0 {
-			continue
+// NewSubConn intercepts SubConn creation from pick_first children to wrap the
+// StateListener for OOB listener management on READY transitions.
+func (b *orcab) NewSubConn(addrs []resolver.Address, opts balancer.NewSubConnOptions) (balancer.SubConn, error) {
+	// The variable sc is declared before the closure so the closure captures
+	// the variable, not its (zero) value. After ClientConn.NewSubConn assigns
+	// to sc, the closure sees the real SubConn when invoked.
+	var sc balancer.SubConn
+	oldListener := opts.StateListener
+	opts.StateListener = func(state balancer.SubConnState) {
+		b.updateSubConnState(sc, state)
+		if oldListener != nil {
+			oldListener(state)
 		}
-		addrs = append(addrs, ep.Addresses[0])
 	}
-	return addrs
-}
-
-func (o *orcab) UpdateClientConnState(s balancer.ClientConnState) error {
-	if o.sc != nil {
-		o.sc.UpdateAddresses(endpointsToAddrs(s.ResolverState.Endpoints))
-		return nil
-	}
-
-	if len(s.ResolverState.Endpoints) == 0 {
-		o.ResolverError(fmt.Errorf("produced no endpoints"))
-		return fmt.Errorf("resolver produced no endpoints")
-	}
-	var err error
-	o.sc, err = o.cc.NewSubConn(endpointsToAddrs(s.ResolverState.Endpoints), balancer.NewSubConnOptions{StateListener: o.updateSubConnState})
+	sc, err := b.ClientConn.NewSubConn(addrs, opts)
 	if err != nil {
-		o.cc.UpdateState(balancer.State{ConnectivityState: connectivity.TransientFailure, Picker: base.NewErrPicker(fmt.Errorf("error creating subconn: %v", err))})
-		return nil
+		return nil, err
 	}
-	o.sc.Connect()
-	o.cc.UpdateState(balancer.State{ConnectivityState: connectivity.Connecting, Picker: base.NewErrPicker(balancer.ErrNoSubConnAvailable)})
-	return nil
+	return sc, nil
 }
 
-func (o *orcab) ResolverError(err error) {
-	if o.sc == nil {
-		o.cc.UpdateState(balancer.State{ConnectivityState: connectivity.TransientFailure, Picker: base.NewErrPicker(fmt.Errorf("resolver error: %v", err))})
+func (b *orcab) updateSubConnState(sc balancer.SubConn, state balancer.SubConnState) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.stopOOBListeners == nil {
+		// Already closed; drop the state update.
+		return
 	}
-}
-
-func (o *orcab) UpdateSubConnState(sc balancer.SubConn, state balancer.SubConnState) {
-	logger.Errorf("UpdateSubConnState(%v, %+v) called unexpectedly", sc, state)
-}
-
-func (o *orcab) updateSubConnState(state balancer.SubConnState) {
-	switch state.ConnectivityState {
-	case connectivity.Ready:
-		orca.RegisterOOBListener(o.sc, o, orca.OOBListenerOptions{ReportInterval: time.Second})
-		o.cc.UpdateState(balancer.State{ConnectivityState: connectivity.Ready, Picker: &orcaPicker{o: o}})
-	case connectivity.TransientFailure:
-		o.cc.UpdateState(balancer.State{ConnectivityState: connectivity.TransientFailure, Picker: base.NewErrPicker(fmt.Errorf("all subchannels in transient failure: %v", state.ConnectionError))})
-	case connectivity.Connecting:
-		// Ignore; picker already set to "connecting".
-	case connectivity.Idle:
-		o.sc.Connect()
-		o.cc.UpdateState(balancer.State{ConnectivityState: connectivity.Connecting, Picker: base.NewErrPicker(balancer.ErrNoSubConnAvailable)})
-	case connectivity.Shutdown:
-		// Ignore; we are closing but handle that in Close instead.
+	if state.ConnectivityState == connectivity.Ready {
+		// Register an OOB listener when the SubConn becomes READY.
+		stop := orca.RegisterOOBListener(sc, b, orca.OOBListenerOptions{ReportInterval: time.Second})
+		b.stopOOBListeners[sc] = stop
+		return
+	}
+	// For any other state (including Shutdown), stop and remove the OOB
+	// listener if one was registered for this SubConn.
+	if stop, ok := b.stopOOBListeners[sc]; ok {
+		stop()
+		delete(b.stopOOBListeners, sc)
 	}
 }
 
-func (o *orcab) Close() {}
-
-func (o *orcab) OnLoadReport(r *v3orcapb.OrcaLoadReport) {
-	o.reportMu.Lock()
-	defer o.reportMu.Unlock()
-	logger.Infof("received OOB load report: %v", r)
-	o.report = r
+// UpdateState intercepts state updates from endpointsharding to wrap the
+// picker with ORCA load report handling.
+func (b *orcab) UpdateState(state balancer.State) {
+	// If READY, wrap the picker to inject the ORCA Done callback; otherwise,
+	// pass through the child picker as-is.
+	if state.ConnectivityState == connectivity.Ready {
+		state = balancer.State{
+			ConnectivityState: state.ConnectivityState,
+			Picker:            &orcaPicker{childPicker: state.Picker, oobState: b.oobState},
+		}
+	}
+	b.ClientConn.UpdateState(state)
 }
 
+// OnLoadReport implements orca.OOBListener.
+func (b *orcab) OnLoadReport(r *v3orcapb.OrcaLoadReport) {
+	b.oobState.mu.Lock()
+	defer b.oobState.mu.Unlock()
+	b.logger.Infof("Received OOB load report: %v", r)
+	b.oobState.report = r
+}
+
+type oobState struct {
+	mu     sync.Mutex
+	report *v3orcapb.OrcaLoadReport
+}
 type orcaPicker struct {
-	o *orcab
+	childPicker balancer.Picker
+	oobState    *oobState
 }
 
 func (p *orcaPicker) Pick(info balancer.PickInfo) (balancer.PickResult, error) {
-	doneCB := func(di balancer.DoneInfo) {
+	res, err := p.childPicker.Pick(info)
+	if err != nil {
+		return res, err
+	}
+	origDone := res.Done
+	res.Done = func(di balancer.DoneInfo) {
 		if lr, _ := di.ServerLoad.(*v3orcapb.OrcaLoadReport); lr != nil &&
 			(lr.CpuUtilization != 0 || lr.MemUtilization != 0 || len(lr.Utilization) > 0 || len(lr.RequestCost) > 0) {
 			// Since all RPCs will respond with a load report due to the
@@ -145,14 +194,17 @@ func (p *orcaPicker) Pick(info balancer.PickInfo) (balancer.PickResult, error) {
 			// use the out-of-band report instead if all are unset/zero.
 			setContextCMR(info.Ctx, lr)
 		} else {
-			p.o.reportMu.Lock()
-			defer p.o.reportMu.Unlock()
-			if lr := p.o.report; lr != nil {
+			p.oobState.mu.Lock()
+			defer p.oobState.mu.Unlock()
+			if lr := p.oobState.report; lr != nil {
 				setContextCMR(info.Ctx, lr)
 			}
 		}
+		if origDone != nil {
+			origDone(di)
+		}
 	}
-	return balancer.PickResult{SubConn: p.o.sc, Done: doneCB}, nil
+	return res, nil
 }
 
 func setContextCMR(ctx context.Context, lr *v3orcapb.OrcaLoadReport) {

--- a/interop/orcalb.go
+++ b/interop/orcalb.go
@@ -140,25 +140,23 @@ func (b *orcab) updateSubConnState(sc balancer.SubConn, state balancer.SubConnSt
 
 	if state.ConnectivityState == connectivity.Ready {
 		oldStop := b.stopOOBListeners[sc]
+		defer func() {
+			if oldStop != nil {
+				oldStop()
+			}
+		}()
 		stop := orca.RegisterOOBListener(sc, &orcaOOBListener{subConn: sc, balancer: b}, orca.OOBListenerOptions{ReportInterval: time.Second})
 		b.stopOOBListeners[sc] = stop
 		b.mu.Unlock()
-
-		if oldStop != nil {
-			oldStop()
-		}
 		return
 	}
 
 	stop := b.stopOOBListeners[sc]
 	if stop != nil {
 		delete(b.stopOOBListeners, sc)
+		defer func() { stop() }()
 	}
 	b.mu.Unlock()
-
-	if stop != nil {
-		stop()
-	}
 
 	if state.ConnectivityState == connectivity.Shutdown {
 		b.oobState.mu.Lock()
@@ -188,9 +186,6 @@ type orcaOOBListener struct {
 
 // OnLoadReport implements orca.OOBListener.
 func (l *orcaOOBListener) OnLoadReport(r *v3orcapb.OrcaLoadReport) {
-	if r == nil {
-		return
-	}
 	l.balancer.oobState.mu.Lock()
 	defer l.balancer.oobState.mu.Unlock()
 	l.balancer.oobState.reports[l.subConn] = r
@@ -218,11 +213,7 @@ func (p *orcaPicker) Pick(info balancer.PickInfo) (balancer.PickResult, error) {
 	origDone := res.Done
 	res.Done = func(di balancer.DoneInfo) {
 		perRPCLR, _ := di.ServerLoad.(*v3orcapb.OrcaLoadReport)
-		hasMetrics := perRPCLR != nil && (perRPCLR.CpuUtilization != 0 ||
-			perRPCLR.MemUtilization != 0 ||
-			len(perRPCLR.Utilization) > 0 ||
-			len(perRPCLR.RequestCost) > 0)
-		if hasMetrics {
+		if perRPCLR != nil && (perRPCLR.CpuUtilization != 0 || perRPCLR.MemUtilization != 0 || len(perRPCLR.Utilization) > 0 || len(perRPCLR.RequestCost) > 0) {
 			setContextCMR(info.Ctx, perRPCLR)
 		} else if lr != nil {
 			setContextCMR(info.Ctx, lr)

--- a/interop/orcalb_test.go
+++ b/interop/orcalb_test.go
@@ -1,0 +1,361 @@
+/*
+ *
+ * Copyright 2026 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package interop
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	v3orcapb "github.com/cncf/xds/go/xds/data/orca/v3"
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/internal"
+	"google.golang.org/grpc/internal/grpctest"
+	"google.golang.org/grpc/internal/stubserver"
+	testgrpc "google.golang.org/grpc/interop/grpc_testing"
+	"google.golang.org/grpc/orca"
+	"google.golang.org/grpc/resolver"
+	"google.golang.org/grpc/resolver/manual"
+	"google.golang.org/protobuf/testing/protocmp"
+)
+
+type s struct {
+	grpctest.Tester
+}
+
+func Test(t *testing.T) {
+	grpctest.RunSubTests(t, s{})
+}
+
+const defaultTestTimeout = 30 * time.Second
+
+type orcaServer struct {
+	*stubserver.StubServer
+	metricsRecorder orca.ServerMetricsRecorder
+}
+
+func startORCAServer(t *testing.T) *orcaServer {
+	t.Helper()
+
+	smr := orca.NewServerMetricsRecorder()
+	ts := NewTestServer(NewTestServerOptions{MetricsRecorder: smr})
+
+	stub := &stubserver.StubServer{
+		UnaryCallF: func(ctx context.Context, in *testgrpc.SimpleRequest) (*testgrpc.SimpleResponse, error) {
+			return ts.UnaryCall(ctx, in)
+		},
+		FullDuplexCallF: func(stream testgrpc.TestService_FullDuplexCallServer) error {
+			return ts.FullDuplexCall(stream)
+		},
+	}
+
+	sopts := []grpc.ServerOption{orca.CallMetricsServerOption(nil)}
+
+	oso := orca.ServiceOptions{
+		ServerMetricsProvider: smr,
+		MinReportingInterval:  time.Second,
+	}
+	internal.ORCAAllowAnyMinReportingInterval.(func(so *orca.ServiceOptions))(&oso)
+	sopts = append(sopts, stubserver.RegisterServiceServerOption(func(s grpc.ServiceRegistrar) {
+		if err := orca.Register(s, oso); err != nil {
+			t.Fatalf("Failed to register ORCA service: %v", err)
+		}
+	}))
+
+	if err := stub.StartServer(sopts...); err != nil {
+		t.Fatalf("Error starting server: %v", err)
+	}
+	t.Cleanup(stub.Stop)
+
+	return &orcaServer{
+		StubServer:      stub,
+		metricsRecorder: smr,
+	}
+}
+
+func orcaSvcConfig() string {
+	return `{"loadBalancingConfig": [{"test_backend_metrics_load_balancer": {}}]}`
+}
+
+// TestORCAPerRPCReport verifies that per-call ORCA load reports flow from the
+// server through the orcaPicker's Done callback into the context.
+func (s) TestORCAPerRPCReport(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+
+	srv := startORCAServer(t)
+	if err := srv.StartClient(grpc.WithDefaultServiceConfig(orcaSvcConfig())); err != nil {
+		t.Fatalf("Error starting client: %v", err)
+	}
+
+	DoORCAPerRPCTest(ctx, srv.Client)
+}
+
+// TestORCAOOBReport verifies that OOB ORCA load reports flow through
+// OnLoadReport and are returned by the picker when no per-call report is
+// present.
+func (s) TestORCAOOBReport(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+
+	srv := startORCAServer(t)
+	if err := srv.StartClient(grpc.WithDefaultServiceConfig(orcaSvcConfig())); err != nil {
+		t.Fatalf("Error starting client: %v", err)
+	}
+
+	DoORCAOOBTest(ctx, srv.Client)
+}
+
+// TestORCAOOBFallback verifies the fallback behavior: when a per-call report
+// is present but has all zero fields, the picker uses the most recent OOB
+// report instead.
+func (s) TestORCAOOBFallback(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+
+	srv := startORCAServer(t)
+	if err := srv.StartClient(grpc.WithDefaultServiceConfig(orcaSvcConfig())); err != nil {
+		t.Fatalf("Error starting client: %v", err)
+	}
+
+	stream, err := srv.Client.FullDuplexCall(ctx)
+	if err != nil {
+		t.Fatalf("FullDuplexCall failed: %v", err)
+	}
+	req := &testgrpc.StreamingOutputCallRequest{
+		OrcaOobReport: &testgrpc.TestOrcaReport{
+			CpuUtilization:    0.73,
+			MemoryUtilization: 0.55,
+			Utilization:       map[string]float64{"util": 0.42},
+		},
+		ResponseParameters: []*testgrpc.ResponseParameters{{Size: 1}},
+	}
+	if err := stream.Send(req); err != nil {
+		t.Fatalf("stream.Send failed: %v", err)
+	}
+	if _, err := stream.Recv(); err != nil {
+		t.Fatalf("stream.Recv failed: %v", err)
+	}
+
+	oobWant := &v3orcapb.OrcaLoadReport{
+		CpuUtilization: 0.73,
+		MemUtilization: 0.55,
+		Utilization:    map[string]float64{"util": 0.42},
+	}
+	pollORCAResult(ctx, t, srv.Client, oobWant)
+
+	// OrcaPerQueryReport is nil: per-call report has all-zero fields,
+	// triggering the OOB fallback path in orcaPicker.
+	orcaRes := &v3orcapb.OrcaLoadReport{}
+	if _, err := srv.Client.UnaryCall(contextWithORCAResult(ctx, &orcaRes), &testgrpc.SimpleRequest{}); err != nil {
+		t.Fatalf("UnaryCall failed: %v", err)
+	}
+	if diff := cmp.Diff(orcaRes, oobWant, protocmp.Transform()); diff != "" {
+		t.Fatalf("ORCA load report with zero per-call mismatch (-got +want):\n%s", diff)
+	}
+}
+
+// TestEndpoints_MultipleAddresses verifies client behavior when an endpoint has
+// multiple addresses and the first is unreachable. It validates that the
+// pick_first falls through the address list and connects via the first
+// reachable address, so per-call ORCA reports flow correctly.
+func (s) TestEndpoints_MultipleAddresses(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+
+	srv := startORCAServer(t)
+	if err := srv.StartClient(grpc.WithDefaultServiceConfig(orcaSvcConfig())); err != nil {
+		t.Fatalf("Error starting client: %v", err)
+	}
+
+	// First address is unreachable; pick_first falls through to the good one.
+	state := resolver.State{
+		Endpoints: []resolver.Endpoint{
+			{Addresses: []resolver.Address{
+				{Addr: "bad-address"},
+				{Addr: srv.Address},
+			}},
+		},
+	}
+	srv.R.UpdateState(state)
+	// Transient errors while pick_first probes the bad address are expected.
+	want := &v3orcapb.OrcaLoadReport{CpuUtilization: 0.42, MemUtilization: 0.21}
+	for ; ctx.Err() == nil; <-time.After(100 * time.Millisecond) {
+		orcaRes := &v3orcapb.OrcaLoadReport{}
+		req := &testgrpc.SimpleRequest{
+			OrcaPerQueryReport: &testgrpc.TestOrcaReport{
+				CpuUtilization:    0.42,
+				MemoryUtilization: 0.21,
+			},
+		}
+		if _, err := srv.Client.UnaryCall(contextWithORCAResult(ctx, &orcaRes), req); err != nil {
+			continue
+		}
+		if diff := cmp.Diff(orcaRes, want, protocmp.Transform()); diff != "" {
+			t.Fatalf("Per-RPC ORCA mismatch (-got +want):\n%s", diff)
+		}
+		return
+	}
+	t.Fatalf("timed out waiting for connection through good address")
+}
+
+// TestMultipleEndpoints_OOBListeners verifies that N endpoints produce N
+// independent pick_first instances and N independent OOB listeners, each
+// receiving reports from its respective server.
+func (s) TestMultipleEndpoints_OOBListeners(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+
+	srvA := startORCAServer(t)
+	srvB := startORCAServer(t)
+
+	srvA.metricsRecorder.SetCPUUtilization(0.1)
+	srvB.metricsRecorder.SetCPUUtilization(0.9)
+
+	r := manual.NewBuilderWithScheme("test")
+	cc, err := grpc.Dial(r.Scheme()+":///test",
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithResolvers(r),
+		grpc.WithDefaultServiceConfig(orcaSvcConfig()),
+	)
+	if err != nil {
+		t.Fatalf("Failed to dial: %v", err)
+	}
+	defer cc.Close()
+	tc := testgrpc.NewTestServiceClient(cc)
+
+	// One endpoint per server: endpointsharding creates two independent
+	// pick_first children, each with its own OOB listener.
+	state := resolver.State{
+		Endpoints: []resolver.Endpoint{
+			{Addresses: []resolver.Address{{Addr: srvA.Address}}},
+			{Addresses: []resolver.Address{{Addr: srvB.Address}}},
+		},
+	}
+	r.UpdateState(state)
+	// No per-call report triggers OOB fallback. With two active listeners,
+	// b.report alternates between servers; both values must eventually appear.
+	wantA := &v3orcapb.OrcaLoadReport{CpuUtilization: 0.1}
+	wantB := &v3orcapb.OrcaLoadReport{CpuUtilization: 0.9}
+	seenA, seenB := false, false
+	for ; ctx.Err() == nil && (!seenA || !seenB); <-time.After(100 * time.Millisecond) {
+		orcaRes := &v3orcapb.OrcaLoadReport{}
+		if _, err := tc.UnaryCall(contextWithORCAResult(ctx, &orcaRes), &testgrpc.SimpleRequest{}); err != nil {
+			continue
+		}
+		if diff := cmp.Diff(orcaRes, wantA, protocmp.Transform()); diff == "" {
+			seenA = true
+		} else if diff := cmp.Diff(orcaRes, wantB, protocmp.Transform()); diff == "" {
+			seenB = true
+		}
+	}
+	if ctx.Err() != nil {
+		t.Fatalf("timed out waiting for OOB reports from both endpoints; seenA=%v seenB=%v", seenA, seenB)
+	}
+}
+
+// TestEndpointUpdate verifies client behavior in response to a resolver update
+// that changes an endpoint's address. It ensures that the client disconnects
+// from the old address and connects to the new address via pick_first. It
+// also validates that the OOB listener for the old connection is stopped,
+// and a new OOB listener is registered for the new connection once it becomes
+// READY.
+func (s) TestEndpointUpdate(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+
+	srvA := startORCAServer(t)
+	srvB := startORCAServer(t)
+
+	r := manual.NewBuilderWithScheme("test")
+	cc, err := grpc.Dial(r.Scheme()+":///test",
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithResolvers(r),
+		grpc.WithDefaultServiceConfig(orcaSvcConfig()),
+	)
+	if err != nil {
+		t.Fatalf("Failed to dial: %v", err)
+	}
+	defer cc.Close()
+	tc := testgrpc.NewTestServiceClient(cc)
+
+	state := resolver.State{
+		Endpoints: []resolver.Endpoint{
+			{Addresses: []resolver.Address{{Addr: srvA.Address}}},
+		},
+	}
+	r.UpdateState(state)
+
+	orcaRes := &v3orcapb.OrcaLoadReport{}
+	req := &testgrpc.SimpleRequest{
+		OrcaPerQueryReport: &testgrpc.TestOrcaReport{
+			CpuUtilization:    0.11,
+			MemoryUtilization: 0.22,
+		},
+	}
+	if _, err := tc.UnaryCall(contextWithORCAResult(ctx, &orcaRes), req); err != nil {
+		t.Fatalf("UnaryCall to srvA failed: %v", err)
+	}
+	wantA := &v3orcapb.OrcaLoadReport{CpuUtilization: 0.11, MemUtilization: 0.22}
+	if diff := cmp.Diff(orcaRes, wantA, protocmp.Transform()); diff != "" {
+		t.Fatalf("ORCA from srvA mismatch (-got +want):\n%s", diff)
+	}
+
+	// Distinctive OOB metric on srvB to confirm the switch via OOB fallback.
+	srvB.metricsRecorder.SetCPUUtilization(0.77)
+
+	state = resolver.State{
+		Endpoints: []resolver.Endpoint{
+			{Addresses: []resolver.Address{{Addr: srvB.Address}}},
+		},
+	}
+	r.UpdateState(state)
+	// No per-call report forces OOB fallback. Once srvB's metric appears,
+	// all three are confirmed: pick_first reconnected, new OOB listener
+	// registered for srvB, old one for srvA stopped.
+	wantB := &v3orcapb.OrcaLoadReport{CpuUtilization: 0.77}
+	for ; ctx.Err() == nil; <-time.After(100 * time.Millisecond) {
+		orcaRes := &v3orcapb.OrcaLoadReport{}
+		if _, err := tc.UnaryCall(contextWithORCAResult(ctx, &orcaRes), &testgrpc.SimpleRequest{}); err != nil {
+			continue
+		}
+		if diff := cmp.Diff(orcaRes, wantB, protocmp.Transform()); diff == "" {
+			return
+		}
+		t.Logf("ORCA after endpoint update = %v; want %v; retrying...", orcaRes, wantB)
+	}
+	t.Fatalf("timed out waiting for srvB OOB report after endpoint update")
+}
+
+func pollORCAResult(ctx context.Context, t *testing.T, tc testgrpc.TestServiceClient, want *v3orcapb.OrcaLoadReport) {
+	t.Helper()
+	for ; ctx.Err() == nil; <-time.After(time.Second) {
+		orcaRes := &v3orcapb.OrcaLoadReport{}
+		if _, err := tc.UnaryCall(contextWithORCAResult(ctx, &orcaRes), &testgrpc.SimpleRequest{}); err != nil {
+			t.Fatalf("UnaryCall failed: %v", err)
+		}
+		if diff := cmp.Diff(orcaRes, want, protocmp.Transform()); diff == "" {
+			return
+		}
+		t.Logf("ORCA load report = %v; want %v; retrying...", orcaRes, want)
+	}
+	t.Fatalf("Timed out waiting for expected ORCA load report %v", want)
+}

--- a/interop/orcalb_test.go
+++ b/interop/orcalb_test.go
@@ -23,7 +23,6 @@ import (
 	"testing"
 	"time"
 
-	v3orcapb "github.com/cncf/xds/go/xds/data/orca/v3"
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -31,9 +30,12 @@ import (
 	"google.golang.org/grpc/internal/grpctest"
 	"google.golang.org/grpc/internal/stubserver"
 	testgrpc "google.golang.org/grpc/interop/grpc_testing"
+	testpb "google.golang.org/grpc/interop/grpc_testing"
 	"google.golang.org/grpc/orca"
 	"google.golang.org/grpc/resolver"
 	"google.golang.org/grpc/resolver/manual"
+
+	v3orcapb "github.com/cncf/xds/go/xds/data/orca/v3"
 	"google.golang.org/protobuf/testing/protocmp"
 )
 
@@ -59,7 +61,7 @@ func startORCAServer(t *testing.T) *orcaServer {
 	ts := NewTestServer(NewTestServerOptions{MetricsRecorder: smr})
 
 	stub := &stubserver.StubServer{
-		UnaryCallF: func(ctx context.Context, in *testgrpc.SimpleRequest) (*testgrpc.SimpleResponse, error) {
+		UnaryCallF: func(ctx context.Context, in *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
 			return ts.UnaryCall(ctx, in)
 		},
 		FullDuplexCallF: func(stream testgrpc.TestService_FullDuplexCallServer) error {
@@ -140,13 +142,13 @@ func (s) TestORCAOOBFallback(t *testing.T) {
 	if err != nil {
 		t.Fatalf("FullDuplexCall failed: %v", err)
 	}
-	req := &testgrpc.StreamingOutputCallRequest{
-		OrcaOobReport: &testgrpc.TestOrcaReport{
+	req := &testpb.StreamingOutputCallRequest{
+		OrcaOobReport: &testpb.TestOrcaReport{
 			CpuUtilization:    0.73,
 			MemoryUtilization: 0.55,
 			Utilization:       map[string]float64{"util": 0.42},
 		},
-		ResponseParameters: []*testgrpc.ResponseParameters{{Size: 1}},
+		ResponseParameters: []*testpb.ResponseParameters{{Size: 1}},
 	}
 	if err := stream.Send(req); err != nil {
 		t.Fatalf("stream.Send failed: %v", err)
@@ -165,7 +167,7 @@ func (s) TestORCAOOBFallback(t *testing.T) {
 	// OrcaPerQueryReport is nil: per-call report has all-zero fields,
 	// triggering the OOB fallback path in orcaPicker.
 	orcaRes := &v3orcapb.OrcaLoadReport{}
-	if _, err := srv.Client.UnaryCall(contextWithORCAResult(ctx, &orcaRes), &testgrpc.SimpleRequest{}); err != nil {
+	if _, err := srv.Client.UnaryCall(contextWithORCAResult(ctx, &orcaRes), &testpb.SimpleRequest{}); err != nil {
 		t.Fatalf("UnaryCall failed: %v", err)
 	}
 	if diff := cmp.Diff(orcaRes, oobWant, protocmp.Transform()); diff != "" {
@@ -200,8 +202,8 @@ func (s) TestEndpoints_MultipleAddresses(t *testing.T) {
 	want := &v3orcapb.OrcaLoadReport{CpuUtilization: 0.42, MemUtilization: 0.21}
 	for ; ctx.Err() == nil; <-time.After(100 * time.Millisecond) {
 		orcaRes := &v3orcapb.OrcaLoadReport{}
-		req := &testgrpc.SimpleRequest{
-			OrcaPerQueryReport: &testgrpc.TestOrcaReport{
+		req := &testpb.SimpleRequest{
+			OrcaPerQueryReport: &testpb.TestOrcaReport{
 				CpuUtilization:    0.42,
 				MemoryUtilization: 0.21,
 			},
@@ -258,7 +260,7 @@ func (s) TestMultipleEndpoints_OOBListeners(t *testing.T) {
 	seenA, seenB := false, false
 	for ; ctx.Err() == nil && (!seenA || !seenB); <-time.After(100 * time.Millisecond) {
 		orcaRes := &v3orcapb.OrcaLoadReport{}
-		if _, err := tc.UnaryCall(contextWithORCAResult(ctx, &orcaRes), &testgrpc.SimpleRequest{}); err != nil {
+		if _, err := tc.UnaryCall(contextWithORCAResult(ctx, &orcaRes), &testpb.SimpleRequest{}); err != nil {
 			continue
 		}
 		if diff := cmp.Diff(orcaRes, wantA, protocmp.Transform()); diff == "" {
@@ -305,8 +307,8 @@ func (s) TestEndpointUpdate(t *testing.T) {
 	r.UpdateState(state)
 
 	orcaRes := &v3orcapb.OrcaLoadReport{}
-	req := &testgrpc.SimpleRequest{
-		OrcaPerQueryReport: &testgrpc.TestOrcaReport{
+	req := &testpb.SimpleRequest{
+		OrcaPerQueryReport: &testpb.TestOrcaReport{
 			CpuUtilization:    0.11,
 			MemoryUtilization: 0.22,
 		},
@@ -334,7 +336,7 @@ func (s) TestEndpointUpdate(t *testing.T) {
 	wantB := &v3orcapb.OrcaLoadReport{CpuUtilization: 0.77}
 	for ; ctx.Err() == nil; <-time.After(100 * time.Millisecond) {
 		orcaRes := &v3orcapb.OrcaLoadReport{}
-		if _, err := tc.UnaryCall(contextWithORCAResult(ctx, &orcaRes), &testgrpc.SimpleRequest{}); err != nil {
+		if _, err := tc.UnaryCall(contextWithORCAResult(ctx, &orcaRes), &testpb.SimpleRequest{}); err != nil {
 			continue
 		}
 		if diff := cmp.Diff(orcaRes, wantB, protocmp.Transform()); diff == "" {
@@ -349,7 +351,7 @@ func pollORCAResult(ctx context.Context, t *testing.T, tc testgrpc.TestServiceCl
 	t.Helper()
 	for ; ctx.Err() == nil; <-time.After(time.Second) {
 		orcaRes := &v3orcapb.OrcaLoadReport{}
-		if _, err := tc.UnaryCall(contextWithORCAResult(ctx, &orcaRes), &testgrpc.SimpleRequest{}); err != nil {
+		if _, err := tc.UnaryCall(contextWithORCAResult(ctx, &orcaRes), &testpb.SimpleRequest{}); err != nil {
 			t.Fatalf("UnaryCall failed: %v", err)
 		}
 		if diff := cmp.Diff(orcaRes, want, protocmp.Transform()); diff == "" {


### PR DESCRIPTION
This PR switches the interop ORCA test load balancer to delegate SubConn management to endpointsharding + pick_first instead of creating and handling SubConns itself As per [ gRFC A61](https://github.com/grpc/proposal/blob/master/A61-IPv4-IPv6-dualstack-backends.md#use-pick_first-as-the-universal-leaf-policy) .

Fixes [#8809](https://github.com/grpc/grpc-go/issues/8809)

RELEASE NOTES: N/A