### PR TITLE
grpclb: replace net.IP with netip.Addr

### DIFF
--- a/channelz/internal/protoconv/socket.go
+++ b/channelz/internal/protoconv/socket.go
@@ -67,8 +67,8 @@ func addrToProto(a net.Addr) *channelzpb.Address {
 		// Note mask info is discarded through the conversion.
 		return &channelzpb.Address{Address: &channelzpb.Address_TcpipAddress{TcpipAddress: &channelzpb.Address_TcpIpAddress{IpAddress: a.(*net.IPNet).IP}}}
 	case "tcp":
-		addrPort := a.(*net.TCPAddr).AddrPort()
-		return &channelzpb.Address{Address: &channelzpb.Address_TcpipAddress{TcpipAddress: &channelzpb.Address_TcpIpAddress{IpAddress: addrPort.Addr().AsSlice(), Port: int32(addrPort.Port())}}}
+		// Note zone info is discarded through the conversion.
+		return &channelzpb.Address{Address: &channelzpb.Address_TcpipAddress{TcpipAddress: &channelzpb.Address_TcpIpAddress{IpAddress: a.(*net.TCPAddr).IP, Port: int32(a.(*net.TCPAddr).Port)}}}
 	case "unix", "unixgram", "unixpacket":
 		return &channelzpb.Address{Address: &channelzpb.Address_UdsAddress_{UdsAddress: &channelzpb.Address_UdsAddress{Filename: a.String()}}}
 	default:


### PR DESCRIPTION
Contributes to #8884

This PR replaces deprecated `net.IP` usage with the modern `netip.Addr` API in two packages:

- **grpclb**: Replace `net.IP(s.IpAddress).String()` with `netip.AddrFromSlice()` in `processServerList`, adding proper error handling for invalid IP addresses instead of silently producing `"?"` from `net.IP.String()`.

Note: `x509.Certificate.IPAddresses` fields in test files (`internal/credentials/xds/handshake_info_test.go`, `security/advancedtls/crl_test.go`) are typed as `[]net.IP` by the standard library, so those cannot be migrated. The xds/server and xds/xdsclient packages are being addressed in #8909.

RELEASE NOTES: N/A