### PR TITLE
ringhash: enable behaviors of A76 by default

### DIFF
--- a/internal/envconfig/envconfig.go
+++ b/internal/envconfig/envconfig.go
@@ -54,17 +54,16 @@ var (
 
 	// XDSEndpointHashKeyBackwardCompat controls the parsing of the endpoint hash
 	// key from EDS LbEndpoint metadata. Endpoint hash keys can be disabled by
-	// setting "GRPC_XDS_ENDPOINT_HASH_KEY_BACKWARD_COMPAT" to "true". When the
-	// implementation of A76 is stable, we will flip the default value to false
-	// in a subsequent release. A final release will remove this environment
-	// variable, enabling the new behavior unconditionally.
-	XDSEndpointHashKeyBackwardCompat = boolFromEnv("GRPC_XDS_ENDPOINT_HASH_KEY_BACKWARD_COMPAT", true)
+	// setting "GRPC_XDS_ENDPOINT_HASH_KEY_BACKWARD_COMPAT" to "true". A future
+	// release will remove this environment variable, enabling the new behavior
+	// unconditionally.
+	XDSEndpointHashKeyBackwardCompat = boolFromEnv("GRPC_XDS_ENDPOINT_HASH_KEY_BACKWARD_COMPAT", false)
 
 	// RingHashSetRequestHashKey is set if the ring hash balancer can get the
 	// request hash header by setting the "requestHashHeader" field, according
-	// to gRFC A76. It can be enabled by setting the environment variable
-	// "GRPC_EXPERIMENTAL_RING_HASH_SET_REQUEST_HASH_KEY" to "true".
-	RingHashSetRequestHashKey = boolFromEnv("GRPC_EXPERIMENTAL_RING_HASH_SET_REQUEST_HASH_KEY", false)
+	// to gRFC A76. It can be disabled by setting the environment variable
+	// "GRPC_EXPERIMENTAL_RING_HASH_SET_REQUEST_HASH_KEY" to "false".
+	RingHashSetRequestHashKey = boolFromEnv("GRPC_EXPERIMENTAL_RING_HASH_SET_REQUEST_HASH_KEY", true)
 
 	// ALTSHandshakerKeepaliveParams is set if we should add the
 	// KeepaliveParams when dial the ALTS handshaker service.


### PR DESCRIPTION
Those features have been gated by environment variables since 1.73.0, and used in production at Datadog. They can be considered stable.

Change the defaults to enable using EDS `hash_key` lb metadata and `requestHashHeader` LB config field.

RELEASE NOTES:
- ringhash: Enable A76 ring hash improvements by default: EDS endpoint hash key parsing from LbEndpoint metadata and request hash header support via the "requestHashHeader" field. The previous behavior can be restored by setting GRPC_XDS_ENDPOINT_HASH_KEY_BACKWARD_COMPAT=true or GRPC_EXPERIMENTAL_RING_HASH_SET_REQUEST_HASH_KEY=false.
