### PR TITLE
cdsbalancer: Update comment about usage of BalancerAttributes

### DIFF
--- a/internal/xds/balancer/cdsbalancer/cdsbalancer.go
+++ b/internal/xds/balancer/cdsbalancer/cdsbalancer.go
@@ -424,14 +424,10 @@ func (b *cdsBalancer) updateChildConfig() error {
 		for j := range endpoints[i].Addresses {
 			addr := endpoints[i].Addresses[j]
 			addr.BalancerAttributes = endpoints[i].Attributes
-			// BalancerAttributes need to be present in endpoint addresses. This
-			// temporary workaround is required to make load reporting work
-			// with the old pickfirst policy which creates SubConns with multiple
-			// addresses. Since the addresses can be from different localities,
-			// an Address.BalancerAttribute is used to identify the locality of the
-			// address used by the transport. This workaround can be removed once
-			// the old pickfirst is removed.
-			// See https://github.com/grpc/grpc-go/issues/7339
+			// BalancerAttributes are used for the following:
+			// * Authority Override.
+			// * grpc.lb.backend_service metric label propagation.
+			// See https://github.com/grpc/grpc-go/issues/6472
 			endpoints[i].Addresses[j] = addr
 		}
 	}


### PR DESCRIPTION
The old `pick_first` has been removed, making the workaround for propagating locality no longer necessary. However, in the meantime, two additional usages of the deprecated field were introduced, which currently prevent the removal of this code. 

RELEASE NOTES: N/A