### PR TITLE
xds/resolver: remove unnecessary error check in test

### DIFF
--- a/internal/xds/resolver/xds_resolver_test.go
+++ b/internal/xds/resolver/xds_resolver_test.go
@@ -262,9 +262,6 @@ func (s) TestResolverCloseClosesXDSClient(t *testing.T) {
 			t.Fatalf("Failed to parse bootstrap contents: %s, %v", string(bc), err)
 		}
 		pool := xdsclient.NewPool(config)
-		if err != nil {
-			t.Fatalf("Failed to create an xDS client pool: %v", err)
-		}
 		c, cancel, err := pool.NewClientForTesting(xdsclient.OptionsForTesting{
 			Name:               t.Name(),
 			WatchExpiryTimeout: defaultTestTimeout,


### PR DESCRIPTION
`xdsclient.NewPool` does not return an error , but there is a check for error in the next line. This PR removes the unnecessary error check in test.

RELEASE NOTES: None
