### PR TITLE
xds/resolver: make service config human readable in the log

### DIFF
--- a/internal/xds/resolver/xds_resolver.go
+++ b/internal/xds/resolver/xds_resolver.go
@@ -347,7 +347,7 @@ func (r *xdsResolver) sendNewServiceConfig(cs stoppableConfigSelector) bool {
 
 	sc := serviceConfigJSON(r.activeClusters, r.activePlugins)
 	if r.logger.V(2) {
-		r.logger.Infof("For Listener resource %q and RouteConfiguration resource %q, generated service config: %+v", r.ldsResourceName, r.xdsConfig.Listener.APIListener.RouteConfigName, sc)
+		r.logger.Infof("For Listener resource %q and RouteConfiguration resource %q, generated service config: %s", r.ldsResourceName, r.xdsConfig.Listener.APIListener.RouteConfigName, string(sc))
 	}
 
 	// Send the update to the ClientConn.


### PR DESCRIPTION
#### Prior to this change, the log looked like this:
third_party/golang/grpc/internal/grpctest/tlogger.go:133: INFO xds_resolver.go:350 [xds] [xds-resolver 0xc000c185a0] For Listener resource "listener-my-service-client-side-xds" and RouteConfiguration resource "route-my-service-client-side-xds", generated service config: [123 34 108 111 97 100 66 97 108 97 110 99 105 110 103 67 111 110 102 105 103 34 58 91 123 34 120 100 115 95 99 108 117 115 116 101 114 95 109 97 110 97 103 101 114 95 101 120 112 101 114 105 109 101 110 116 97 108 34 58 123 34 99 104 105 108 100 114 101 110 34 58 123 34 99 108 117 115 116 101 114 58 99 108 117 115 116 101 114 45 109 121 45 115 101 114 118 105 99 101 45 99 108 105 101 110 116 45 115 105 100 101 45 120 100 115 34 58 123 34 99 104 105 108 100 80 111 108 105 99 121 34 58 91 123 34 99 100 115 95 101 120 112 101 114 105 109 101 110 116 97 108 34 58 123 34 99 108 117 115 116 101 114 34 58 34 99 108 117 115 116 101 114 45 109 121 45 115 101 114 118 105 99 101 45 99 108 105 101 110 116 45 115 105 100 101 45 120 100 115 34 125 125 93 125 125 125 125 93 125]  (t=+311.705869ms)

#### Post this change, it looks like this:
third_party/golang/grpc/internal/grpctest/tlogger.go:133: INFO xds_resolver.go:350 [xds] [xds-resolver 0xc000c72990] For Listener resource "listener-my-service-client-side-xds" and RouteConfiguration resource "route-my-service-client-side-xds", generated service config: {"loadBalancingConfig":[{"xds_cluster_manager_experimental":{"children":{"cluster:cluster-my-service-client-side-xds":{"childPolicy":[{"cds_experimental":{"cluster":"cluster-my-service-client-side-xds"}}]}}}}]}  (t=+220.184355ms)

RELEASE NOTES: none