### PR TITLE
cds: increase defaultTestTimeout to 10s for e2e tests

### DIFF
--- a/internal/xds/balancer/cdsbalancer/e2e_test/eds_impl_test.go
+++ b/internal/xds/balancer/cdsbalancer/e2e_test/eds_impl_test.go
@@ -68,7 +68,7 @@ const (
 	localityName2  = "my-locality-2"
 	localityName3  = "my-locality-3"
 
-	defaultTestTimeout            = 5 * time.Second
+	defaultTestTimeout            = 10 * time.Second
 	defaultTestShortTimeout       = 10 * time.Millisecond
 	defaultTestWatchExpiryTimeout = 500 * time.Millisecond
 )


### PR DESCRIPTION
I noticed a bunch of test failures in this package during local development. I traced down one of the tests `TestEDS_EndpointsHealth` and was able to confirm that the test was failing because of test timeout expiry. This test attempts to make 2000 RPCs to check the distribution of RPCs and this can easily go past the current `5s` deadline.

RELEASE NOTES: none