### PR TITLE
github: set testing CI names to be stable

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -36,6 +36,8 @@ jobs:
 
   # Run the main gRPC-Go tests.
   tests:
+    name: ${{ matrix.display_name }}
+
     # Use the matrix variable to set the runner, with 'ubuntu-latest' as the
     # default.
     runs-on: ${{ matrix.runner || 'ubuntu-latest' }}
@@ -46,28 +48,35 @@ jobs:
         include:
           - type: vet
             goversion: '1.25'
+            display_name: 'static checks (latest-1)'
 
           - type: extras
             goversion: '1.26'
+            display_name: 'extras (latest)'
 
           - type: tests
             goversion: '1.26'
+            display_name: 'tests (latest)'
 
           - type: tests
             goversion: '1.26'
             testflags: -race
+            display_name: 'tests (-race, latest)'
 
           - type: tests
             goversion: '1.26'
             goarch: 386
+            display_name: 'tests (i386, latest)'
 
           - type: tests
             goversion: '1.26'
             goarch: arm64
             runner: ubuntu-24.04-arm
+            display_name: 'tests (arm, latest)'
 
           - type: tests
             goversion: '1.25'
+            display_name: 'tests (latest-1)'
 
     steps:
       # Setup the environment.


### PR DESCRIPTION
This will make it so we don't have to pick the new tests every time we upgrade the Go version.

RELEASE NOTES: N/A