### PR TITLE
cdsbalancer: fix name generator stability for empty locality priorities

### DIFF
--- a/internal/xds/balancer/cdsbalancer/configbuilder_childname.go
+++ b/internal/xds/balancer/cdsbalancer/configbuilder_childname.go
@@ -32,8 +32,12 @@ import (
 // return names returned by the previous call.
 type nameGenerator struct {
 	existingNames map[clients.Locality]string
-	prefix        uint64
-	nextID        uint64
+	// existingEmptyPriorityNames stores names assigned to priorities with no
+	// localities in the previous update, so they can be reused in subsequent
+	// updates to maintain name stability.
+	existingEmptyPriorityNames []string
+	prefix                     uint64
+	nextID                     uint64
 }
 
 func newNameGenerator(prefix uint64) *nameGenerator {
@@ -56,6 +60,8 @@ func (ng *nameGenerator) generate(priorities [][]xdsresource.Locality) []string 
 	var ret []string
 	usedNames := make(map[string]bool)
 	newNames := make(map[clients.Locality]string)
+	var newEmptyPriorityNames []string
+	emptyPriorityIdx := 0
 	for _, priority := range priorities {
 		var nameFound string
 		for _, locality := range priority {
@@ -65,6 +71,28 @@ func (ng *nameGenerator) generate(priorities [][]xdsresource.Locality) []string 
 					// Found a name to use. No need to process the remaining
 					// localities.
 					break
+				}
+			}
+		}
+
+		if nameFound == "" {
+			// For priorities with no localities, try to reuse a name from the
+			// previous update's empty-priority names list (in order) to
+			// maintain stability across updates.
+			//
+			// If the candidate name is already in usedNames (e.g. due to a
+			// priority reorder where a non-empty priority claimed it first),
+			// emptyPriorityIdx does not advance and a new name is generated
+			// instead. xDS priority ordering guarantees that each priority is
+			// processed in index order, so a collision can only occur when a
+			// previously-empty priority now has localities — in that case
+			// falling through to generate a fresh name is the correct
+			// behaviour.
+			if len(priority) == 0 && emptyPriorityIdx < len(ng.existingEmptyPriorityNames) {
+				candidate := ng.existingEmptyPriorityNames[emptyPriorityIdx]
+				if !usedNames[candidate] {
+					nameFound = candidate
+					emptyPriorityIdx++
 				}
 			}
 		}
@@ -81,8 +109,12 @@ func (ng *nameGenerator) generate(priorities [][]xdsresource.Locality) []string 
 		for _, l := range priority {
 			newNames[l.ID] = nameFound
 		}
+		if len(priority) == 0 {
+			newEmptyPriorityNames = append(newEmptyPriorityNames, nameFound)
+		}
 		usedNames[nameFound] = true
 	}
 	ng.existingNames = newNames
+	ng.existingEmptyPriorityNames = newEmptyPriorityNames
 	return ret
 }

--- a/internal/xds/balancer/cdsbalancer/configbuilder_childname_test.go
+++ b/internal/xds/balancer/cdsbalancer/configbuilder_childname_test.go
@@ -109,3 +109,29 @@ func (s) Test_nameGenerator_generate(t *testing.T) {
 		})
 	}
 }
+
+func (s) TestNameGenerator_Generate_EmptyLocalities(t *testing.T) {
+	ng := newNameGenerator(0)
+	// Repeated calls to generate with an empty list of localities should
+	// generate the same single name.
+	input := [][]xdsresource.Locality{{}}
+	want := []string{"priority-0-0"}
+	for i := 0; i < 5; i++ {
+		got := ng.generate(input)
+		if diff := cmp.Diff(got, want); diff != "" {
+			t.Errorf("iteration %d: generate() = got: %v, want: %v, diff (-got +want): %s", i, got, want, diff)
+		}
+	}
+}
+
+func (s) TestNameGenerator_Generate_MultipleEmptyLocalities(t *testing.T) {
+	ng := newNameGenerator(0)
+	// Two empty priorities should get stable names across repeated calls.
+	want := []string{"priority-0-0", "priority-0-1"}
+	for i := 0; i < 5; i++ {
+		got := ng.generate([][]xdsresource.Locality{{}, {}})
+		if diff := cmp.Diff(got, want); diff != "" {
+			t.Errorf("iteration %d: generate() = got: %v, want: %v, diff (-got +want): %s", i, got, want, diff)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #8994

## Problem

When `nameGenerator.generate()` is called with a priority that has an empty locality list, the name assigned to that priority is not persisted in `existingNames` — because there are no locality keys to store under. As a result, `ng.existingNames` is reset to an empty map after each call, and subsequent calls generate new unique names instead of reusing the previously assigned one.

This causes instability in the priority LB configuration when an EDS resource returns priorities with no localities (e.g., during cluster warm-up or when all endpoints are unhealthy).

## Root Cause

In `generate()`:

```go
for _, l := range priority {   // never executes when priority is empty
    newNames[l.ID] = nameFound
}
// ... later:
ng.existingNames = newNames    // reset to empty!
```

Since `newNames` ends up empty, the state is lost.

## Fix

Track names assigned to empty-locality priorities separately in a new field `existingEmptyPriorityNames []string`. When a priority with no localities is encountered, reuse a previously assigned name from this list (in order) before generating a new one.

## Test

Added two new test cases:
- `TestNameGenerator_Generate_EmptyLocalities`: repeated calls with a single empty priority return the same name
- `TestNameGenerator_Generate_MultipleEmptyLocalities`: repeated calls with two empty priorities return stable names

RELEASE NOTES:
* cdsbalancer: Fix name generator assigning new names on every update when EDS resource has priorities with no localities.

Signed-off-by: Ilya Kiselev <kis-ilya-a@yandex.ru>