### PR TITLE
test: Fix flaky test `TestServerStreaming_ClientCallSendMsgTwice` in `end2end_test.go`.

### DIFF
--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -3964,8 +3964,7 @@ func (s) TestServerStreaming_ClientCallSendMsgTwice(t *testing.T) {
 			waitCtx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 			defer cancel()
 			for ; waitCtx.Err() == nil; <-time.After(time.Millisecond) {
-				err = stream.SendMsg(&testpb.StreamingOutputCallRequest{})
-				if err != nil {
+				if err = stream.SendMsg(&testpb.StreamingOutputCallRequest{}); err != nil {
 					break
 				}
 			}


### PR DESCRIPTION
Fixes: #8993 

This PR will fix the flaky test `TestServerStreaming_ClientCallSendMsgTwice` introduced in PR #8385 .

The test expected a single call to `stream.SendMsg()` to return a `codes.Canceled` error immediately after the stream's context was marked as done. 

Solution: Introduced a retry loop with a timeout for the `stream.SendMsg()` call. Instead of testing a single invocation, the server handler now continuously attempts to send a message until it either receives an error or timeout expired.

Successfully run the test on forge for 1 million times without any flake.

RELEASE NOTES: N/A
