### PR TITLE
xds/cdsbalancer: fix nameGenerator to reuse names for empty-locality priorities

### DIFF
--- a/internal/xds/balancer/cdsbalancer/configbuilder_childname.go
+++ b/internal/xds/balancer/cdsbalancer/configbuilder_childname.go
@@ -52,6 +52,11 @@ func newNameGenerator(prefix uint64) *nameGenerator {
 // - update 2: [[L1], [L2], [L3]] --> ["0", "1", "2"]
 // - update 3: [[L1, L2], [L3]] --> ["0", "2"]   (Two priorities were merged)
 // - update 4: [[L1], [L4]] --> ["0", "3",]      (A priority was split, and a new priority was added)
+// emptyLocalityKey is used as a sentinel map key to track names assigned to
+// priorities that contain no localities. This allows generate() to return a
+// stable name across repeated calls when an EDS resource has no localities.
+var emptyLocalityKey = clients.Locality{Region: "\x00"}
+
 func (ng *nameGenerator) generate(priorities [][]xdsresource.Locality) []string {
 	var ret []string
 	usedNames := make(map[string]bool)
@@ -69,6 +74,15 @@ func (ng *nameGenerator) generate(priorities [][]xdsresource.Locality) []string 
 			}
 		}
 
+		if nameFound == "" && len(priority) == 0 {
+			// For priorities with no localities, look up a previously assigned
+			// name via a sentinel key so that repeated calls with an empty
+			// locality list reuse the same name rather than generating a new one.
+			if name, ok := ng.existingNames[emptyLocalityKey]; ok && !usedNames[name] {
+				nameFound = name
+			}
+		}
+
 		if nameFound == "" {
 			// No appropriate used name is found. Make a new name.
 			nameFound = fmt.Sprintf("priority-%d-%d", ng.prefix, ng.nextID)
@@ -80,6 +94,10 @@ func (ng *nameGenerator) generate(priorities [][]xdsresource.Locality) []string 
 		// the new map.
 		for _, l := range priority {
 			newNames[l.ID] = nameFound
+		}
+		if len(priority) == 0 {
+			// Persist the name under the sentinel key so future calls can reuse it.
+			newNames[emptyLocalityKey] = nameFound
 		}
 		usedNames[nameFound] = true
 	}

--- a/internal/xds/balancer/cdsbalancer/configbuilder_childname_test.go
+++ b/internal/xds/balancer/cdsbalancer/configbuilder_childname_test.go
@@ -109,3 +109,14 @@ func (s) Test_nameGenerator_generate(t *testing.T) {
 		})
 	}
 }
+
+func (s) TestNameGenerator_Generate_EmptyLocalities(t *testing.T) {
+	ng := newNameGenerator(0)
+	// Repeated calls with an empty locality list should return the same name.
+	for i := 0; i < 5; i++ {
+		got := ng.generate([][]xdsresource.Locality{{}})
+		if diff := cmp.Diff(got, []string{"priority-0-0"}); diff != "" {
+			t.Errorf("iteration %d: generate() = got: %v, want: %v, diff (-got +want): %s", i, got, []string{"priority-0-0"}, diff)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

When `generate()` is called repeatedly with a priority containing no
localities (e.g. an EDS resource that has zero endpoints), the inner
locality-lookup loop never runs. No existing name can be found in
`existingNames`, so a new name is generated on every call. Since no
localities are added to `newNames` for an empty priority,
`existingNames` is reset to an empty map after each call, making the
problem persistent.

This causes the priority load balancer to unnecessarily rebuild its
state on every EDS update when localities are empty, because each call
to `generate()` produces a different priority name.

## Fix

Track names assigned to empty-locality priorities under a sentinel map
key. When a priority with no localities is processed, check for an
existing name under this key before generating a new one, and persist
the assigned name under the key for future calls.

A new unit test `TestNameGenerator_Generate_EmptyLocalities` is added
that directly reproduces the failure described in the issue.

Fixes #8994