### PR TITLE
server: Set a pprof label on new stream goroutines

### DIFF
--- a/server.go
+++ b/server.go
@@ -28,6 +28,7 @@ import (
 	"net/http"
 	"reflect"
 	"runtime"
+	"runtime/pprof"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -1787,6 +1788,10 @@ func (s *Server) handleMalformedMethodName(stream *transport.ServerStream, ti *t
 func (s *Server) handleStream(t transport.ServerTransport, stream *transport.ServerStream) {
 	ctx := stream.Context()
 	ctx = contextWithServer(ctx, s)
+	// This method always runs in its own goroutine, so we can set a
+	// goroutine label without needing to restore a previous context.
+	ctx = pprof.WithLabels(ctx, pprof.Labels("grpc.server.method", stream.Method()))
+	pprof.SetGoroutineLabels(ctx)
 	var ti *traceInfo
 	if EnableTracing {
 		tr := newTrace("grpc.Recv."+methodFamily(stream.Method()), stream.Method())


### PR DESCRIPTION
To make stack-traces and some profiles more useful, change sets goroutine labels indicating which gRPC method is being handled.

Goroutine labels are inherited by child goroutines, so this provides useful context in profiles and traces for work that's been farmed out to child goroutines.

These currently show up in three places:
 - trace labels in pprof CPU profiles
 - trace labels in runtime/pprof (and http/pprof) debug=0 goroutine profiles (which are pprof format)
 - debug=1 aggregated text-format goroutine profiles

For Go 1.27, golang/go#76349 adds goroutine labels to tracebacks and by extension debug=2 pprof text-based profiles for go 1.27+ modules.

The naming of the goroutine label currently matches the opencensus RPC method tag, and has some similarities to the current proposal for goroutine tag naming for tests in golang/go#75047. I.e. this uses `grpc.server.method`.

This change avoids setting anything on the client side due to the lower utility and goroutine lifetime issues.

Fixes #9010

RELEASE NOTES:
* Server: Set [runtime/pprof](https://pkg.go.dev/runtime/pprof) goroutine labels on new streams indicating the gRPC method name before invoking any registered handlers.

