### PR TITLE
transport: set default header list size to 8KB and guard behind an env variable.

### DIFF
--- a/internal/envconfig/envconfig.go
+++ b/internal/envconfig/envconfig.go
@@ -136,7 +136,7 @@ var (
 	// When enabled, RPCs with a total size of headers exceeding 8KB will fail
 	// unless explicitly configured otherwise by the user.
 	//
-	// TODO: After release v1.81.0, we will enable the env var by default.
+	// TODO: In release v1.82.0, env var will be enabled by default.
 	Enable8KBDefaultHeaderListSize = boolFromEnv("GRPC_GO_EXPERIMENTAL_ENABLE_8KB_DEFAULT_HEADER_LIST_SIZE", false)
 )
 

--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -885,7 +885,7 @@ func (t *http2Client) NewStream(ctx context.Context, callHdr *CallHdr, handler s
 			}
 		}
 		if !envconfig.Enable8KBDefaultHeaderListSize && sz > int64(upcomingDefaultHeaderListSize) {
-			t.logger.Warningf("Header list size to send (%d bytes) is larger than the upcoming default limit (%d bytes). In a future release, this will be restricted to %d bytes.", sz, upcomingDefaultHeaderListSize, upcomingDefaultHeaderListSize)
+			t.logger.Warningf("Header list size to send (%d bytes) is larger than the upcoming default limit (%d bytes). In release v1.82.0, GRPC_GO_EXPERIMENTAL_ENABLE_8KB_DEFAULT_HEADER_LIST_SIZE will be enabled by default, enforcing this limit.", sz, upcomingDefaultHeaderListSize)
 		}
 		return true
 	}

--- a/internal/transport/http2_server.go
+++ b/internal/transport/http2_server.go
@@ -956,7 +956,7 @@ func (t *http2Server) checkForHeaderListSize(hf []hpack.HeaderField) bool {
 		}
 	}
 	if !envconfig.Enable8KBDefaultHeaderListSize && sz > int64(upcomingDefaultHeaderListSize) {
-		t.logger.Warningf("Header list size to send (%d bytes) is larger than the upcoming default limit (%d bytes). In a future release, this will be restricted to %d bytes.", sz, upcomingDefaultHeaderListSize, upcomingDefaultHeaderListSize)
+		t.logger.Warningf("Header list size to send (%d bytes) is larger than the upcoming default limit (%d bytes). In release v1.82.0, GRPC_GO_EXPERIMENTAL_ENABLE_8KB_DEFAULT_HEADER_LIST_SIZE will be enabled by default, enforcing this limit.", sz, upcomingDefaultHeaderListSize)
 	}
 	return true
 }
@@ -965,7 +965,6 @@ func (t *http2Server) checkForHeaderListSize(hf []hpack.HeaderField) bool {
 // gRPC status. If the header list size exceeds the peer's limit, it sends a
 // RST_STREAM instead.
 func (t *http2Server) writeEarlyAbort(streamID uint32, contentSubtype string, stat *status.Status, httpStatus uint32, rst bool) {
-	fmt.Println("writeEarlyAbort")
 	hf := []hpack.HeaderField{
 		{Name: ":status", Value: strconv.Itoa(int(httpStatus))},
 		{Name: "content-type", Value: grpcutil.ContentType(contentSubtype)},

--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -7192,19 +7192,19 @@ func (s) TestRPCBlockingOnPickerStatsCall(t *testing.T) {
 // rejects the request and RPC will fail.
 func (s) TestEnable8KBDefaultHeaderListSize_ClientSendsLargeHeaders(t *testing.T) {
 	tests := []struct {
-		name    string
-		enable  bool
-		wantErr bool
+		name     string
+		enable   bool
+		wantCode codes.Code
 	}{
 		{
-			name:    "env_var_enabled",
-			enable:  true,
-			wantErr: true,
+			name:     "env_var_enabled",
+			enable:   true,
+			wantCode: codes.Unavailable,
 		},
 		{
-			name:    "env_var_disabled",
-			enable:  false,
-			wantErr: false,
+			name:     "env_var_disabled",
+			enable:   false,
+			wantCode: codes.OK,
 		},
 	}
 
@@ -7212,13 +7212,9 @@ func (s) TestEnable8KBDefaultHeaderListSize_ClientSendsLargeHeaders(t *testing.T
 		t.Run(tc.name, func(t *testing.T) {
 			testutils.SetEnvConfig(t, &envconfig.Enable8KBDefaultHeaderListSize, tc.enable)
 
-			ss := &stubserver.StubServer{
-				EmptyCallF: func(context.Context, *testpb.Empty) (*testpb.Empty, error) {
-					return &testpb.Empty{}, nil
-				},
-			}
-			if err := ss.Start(nil); err != nil {
-				t.Fatal("Error starting server:", err)
+			ss := stubserver.StartTestService(t, nil)
+			if err := ss.StartClient(); err != nil {
+				t.Fatal("Failed to create client to stub server:", err)
 			}
 			defer ss.Stop()
 
@@ -7228,14 +7224,8 @@ func (s) TestEnable8KBDefaultHeaderListSize_ClientSendsLargeHeaders(t *testing.T
 			ctx = metadata.NewOutgoingContext(ctx, md)
 
 			_, err := ss.Client.EmptyCall(ctx, &testpb.Empty{})
-			if tc.wantErr {
-				if err == nil || status.Code(err) != codes.Unavailable {
-					t.Fatalf("EmptyCall() failed with err: %v, want err: %v", err, codes.Unavailable)
-				}
-				return
-			}
-			if err != nil {
-				t.Fatalf("EmptyCall() failed unexpectedly: %v", err)
+			if got := status.Code(err); got != tc.wantCode {
+				t.Fatalf("EmptyCall() failed with code: %v, want: %v; full error: %v", got, tc.wantCode, err)
 			}
 		})
 	}
@@ -7246,20 +7236,21 @@ func (s) TestEnable8KBDefaultHeaderListSize_ClientSendsLargeHeaders(t *testing.T
 // sends metadata with a total size exceeding the 8KB default limit, the RPC
 // will fail.
 func (s) TestEnable8KBDefaultHeaderListSize_ServerSendsLargeHeaders(t *testing.T) {
+	const largeHeaderSize = 9000
 	tests := []struct {
-		name    string
-		enable  bool
-		wantErr bool
+		name     string
+		enable   bool
+		wantCode codes.Code
 	}{
 		{
-			name:    "env_var_enabled",
-			enable:  true,
-			wantErr: true,
+			name:     "env_var_enabled",
+			enable:   true,
+			wantCode: codes.Unavailable,
 		},
 		{
-			name:    "env_var_disabled",
-			enable:  false,
-			wantErr: false,
+			name:     "env_var_disabled",
+			enable:   false,
+			wantCode: codes.OK,
 		},
 	}
 	for _, tc := range tests {
@@ -7268,7 +7259,7 @@ func (s) TestEnable8KBDefaultHeaderListSize_ServerSendsLargeHeaders(t *testing.T
 
 			ss := &stubserver.StubServer{
 				EmptyCallF: func(ctx context.Context, _ *testpb.Empty) (*testpb.Empty, error) {
-					md := metadata.MD{"large-key": []string{strings.Repeat("a", 9000)}}
+					md := metadata.MD{"large-key": []string{strings.Repeat("a", largeHeaderSize)}}
 					grpc.SetHeader(ctx, md)
 					return &testpb.Empty{}, nil
 				},
@@ -7282,14 +7273,8 @@ func (s) TestEnable8KBDefaultHeaderListSize_ServerSendsLargeHeaders(t *testing.T
 			defer cancel()
 
 			_, err := ss.Client.EmptyCall(ctx, &testpb.Empty{})
-			if tc.wantErr {
-				if err == nil || status.Code(err) != codes.Unavailable {
-					t.Fatalf("EmptyCall() failed with err: %v, want err: %v", err, codes.Unavailable)
-				}
-				return
-			}
-			if err != nil {
-				t.Fatalf("EmptyCall() failed unexpectedly: %v", err)
+			if got := status.Code(err); got != tc.wantCode {
+				t.Fatalf("EmptyCall() failed with code: %v, want: %v; full error: %v", got, tc.wantCode, err)
 			}
 		})
 	}


### PR DESCRIPTION
Part of: https://github.com/grpc/grpc-go/issues/2308

Follow up of PR: https://github.com/grpc/grpc-go/pull/8845 

This PR implements a change to restrict the default maximum header list size to 8KB. The change is guarded by a new environment variable GRPC_GO_EXPERIMENTAL_DEFAULT_HEADER_LIST_SIZE, which is disabled by default.

When the environment variable is disabled (default), the legacy default of 16MB is used. When enabled, RPCs with a total size of headers exceeding 8KB will fail unless explicitly configured otherwise by the user.

## Changes

`internal/envconfig`
* Added DefaultHeaderListSize: A boolean flag controlled by the GRPC_GO_EXPERIMENTAL_DEFAULT_HEADER_LIST_SIZE environment variable.

`internal/transport/http2_client.go` and `internal/transport/http2_server.go`
*  Use upcomingDefaultHeaderListSize (8KB) as the default value if `DefaultHeaderListSize` is enabled. 
*  If env variable is disabled and header size is greater than upcomingDefaultHeaderListSize, log a warning.

RELEASE NOTES:
* transport: change default header list size from 16MB to 8KB and guard it behind `GRPC_GO_EXPERIMENTAL_DEFAULT_HEADER_LIST_SIZE` env var which is disabled by default. The env var will be enabled by default in v1.82.0 release.