### PR TITLE
test: Fix flaky test `TestServerStreaming_ClientCallRecvMsgTwice` in `end2end_test.go`.

### DIFF
--- a/test/end2end_test.go
+++ b/test/end2end_test.go
@@ -3909,6 +3909,9 @@ func (s) TestUnaryRPC_ServerCallSendMsgTwice(t *testing.T) {
 func (s) TestClientStreaming_ClientCallRecvMsgTwice(t *testing.T) {
 	ss := stubserver.StubServer{
 		StreamingInputCallF: func(stream testgrpc.TestService_StreamingInputCallServer) error {
+			if err := stream.RecvMsg(&testpb.StreamingInputCallRequest{}); err != nil {
+				t.Errorf("stream.RecvMsg() = %v, want <nil>", err)
+			}
 			if err := stream.SendAndClose(&testpb.StreamingInputCallResponse{}); err != nil {
 				t.Errorf("stream.SendAndClose(_) = %v, want <nil>", err)
 			}


### PR DESCRIPTION
Fixes: #9057 

**Problem**
The test `TestServerStreaming_ClientCallRecvMsgTwice` was flaky with the error `stream.Send(_) = EOF, want <nil>`. This occurred because the server-side handler for the client-streaming RPC (StreamingInputCallF) was immediately calling SendAndClose and returning without reading the message sent by the client.

This creates a race condition: if the server closes the stream before the client has finished sending its message, the client's Send operation can fail with io.EOF.

**Fix**
Added a call to `stream.RecvMsg` in the server handler to ensure that the server receives the client's message before it responds and closes the stream. This ensures proper synchronization between the client and server and prevents the stream from being closed prematurely during the Send operation.

Successfully run the test on forge for 1 million times without any flake: http://sponge2/7dff4ca4-9cf8-413c-9842-6ce562be8e4a

RELEASE NOTES: N/A