### PR TITLE
grpc: deprecate WithSharedWriteBuffer and SharedWriteBuffer

### DIFF
--- a/dialoptions.go
+++ b/dialoptions.go
@@ -173,10 +173,8 @@ func newJoinDialOption(opts ...DialOption) DialOption {
 // If this option is set to true every connection will release the buffer after
 // flushing the data on the wire.
 //
-// # Experimental
-//
-// Notice: This API is EXPERIMENTAL and may be changed or removed in a
-// later release.
+// Deprecated: shared write buffer is enabled by default. WithSharedWriteBuffer
+// will be removed in a future release.
 func WithSharedWriteBuffer(val bool) DialOption {
 	return newFuncDialOption(func(o *dialOptions) {
 		o.copts.SharedWriteBuffer = val

--- a/server.go
+++ b/server.go
@@ -250,10 +250,8 @@ func newJoinServerOption(opts ...ServerOption) ServerOption {
 // If this option is set to true every connection will release the buffer after
 // flushing the data on the wire.
 //
-// # Experimental
-//
-// Notice: This API is EXPERIMENTAL and may be changed or removed in a
-// later release.
+// Deprecated: shared write buffer is enabled by default. SharedWriteBuffer
+// will be removed in a future release.
 func SharedWriteBuffer(val bool) ServerOption {
 	return newFuncServerOption(func(o *serverOptions) {
 		o.sharedWriteBuffer = val


### PR DESCRIPTION
Since #8957 shared write buffers are always enabled by default and passing `false` is no longer beneficial. This PR deprecates both options per the request in #8966, replacing the `# Experimental` notice with a `Deprecated:` godoc comment consistent with the pattern used elsewhere in `dialoptions.go` and `server.go`.

The options are left functional for now; removal can follow in a subsequent release.

Fixes #8966

RELEASE NOTES:
* grpc: deprecate `WithSharedWriteBuffer` dial option and `SharedWriteBuffer` server option; shared write buffers are now always enabled.

Signed-off-by: Ali <alliasgher123@gmail.com>