### PR TITLE
internal/resolver: improve the docstring of ClientInterceptor.NewStream

### DIFF
--- a/internal/resolver/config_selector.go
+++ b/internal/resolver/config_selector.go
@@ -106,14 +106,24 @@ type ClientStream interface {
 
 // ClientInterceptor is an interceptor for gRPC client streams.
 type ClientInterceptor interface {
-	// NewStream produces a ClientStream for an RPC which may optionally use
-	// the provided function to produce a stream for delegation.  Note:
-	// RPCInfo.Context should not be used (will be nil).
+	// NewStream creates a ClientStream for an RPC.
 	//
-	// done is invoked when the RPC is finished using its connection, or could
-	// not be assigned a connection.  RPC operations may still occur on
-	// ClientStream after done is called, since the interceptor is invoked by
-	// application-layer operations.  done must never be nil when called.
+	// Implementations must delegate stream creation to the provided newStream
+	// function. To intercept or override stream behavior, implementations
+	// may wrap the ClientStream returned by the delegate.
+	//
+	// Note: RPCInfo.Context is currently unused and will be nil.
+	//
+	// The done function is invoked when the RPC has finished using its
+	// underlying connection or if a connection could not be assigned. Because
+	// interceptors operate at the application layer, RPC operations may
+	// continue on the ClientStream even after done has been called. The
+	// caller must ensure done is non-nil.
+	//
+	// To ensure RPC completion notifications propagate through the entire
+	// interceptor chain, implementations must ensure that the done function
+	// passed to the delegate newStream invokes the done function passed to
+	// NewStream.
 	NewStream(ctx context.Context, ri RPCInfo, done func(), newStream func(ctx context.Context, done func()) (ClientStream, error)) (ClientStream, error)
 	// Close closes the interceptor. Once called, no new calls to NewStream are
 	// accepted. Ongoing calls to NewStream are allowed to complete.


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc-go/issues/8925

This PR clarifies a couple of things in the docstring:
- The responsibility of the interceptor to delegate stream creation
- The responsibility of the interceptor to invoke the provided done function which its own is invoked

RELEASE NOTES: none