### PR TITLE
clusterimpl: fix test logic waiting for calls to ResolveNow

### DIFF
--- a/internal/xds/balancer/clusterimpl/tests/balancer_test.go
+++ b/internal/xds/balancer/clusterimpl/tests/balancer_test.go
@@ -960,7 +960,14 @@ func (s) TestReResolutionAfterTransientFailure(t *testing.T) {
 	defer cancel()
 
 	// Replace DNS resolver with a wrapped resolver to capture ResolveNow calls.
-	resolveNowCh := make(chan struct{})
+	// We expect two ResolveNow calls:
+	// 1. When the server goes down and the transport is closed on the client,
+	//    the gRPC channel invokes ResolveNow on the resolver.
+	// 2. Subsequently, the subchannel enters IDLE, reconnection attempt takes
+	//    place and since the server is down, the subchannel eventually moves
+	//    enters TRANSIENT_FAILURE, at which point the clusterimpl policy
+	//    invokes ResolveNow.
+	resolveNowCh := make(chan struct{}, 2)
 	dnsR := manual.NewBuilderWithScheme("dns")
 	dnsResolverBuilder := resolver.Get("dns")
 	resolver.Register(dnsR)
@@ -997,11 +1004,13 @@ func (s) TestReResolutionAfterTransientFailure(t *testing.T) {
 	lis.Stop()
 	testutils.AwaitState(ctx, t, conn, connectivity.TransientFailure)
 
-	// Expect resolver's ResolveNow to be called due to TF state.
-	select {
-	case <-resolveNowCh:
-	case <-ctx.Done():
-		t.Fatalf("Timed out waiting for ResolveNow call after TransientFailure")
+	// Expect two calls to the resolver's ResolveNow method.
+	for range 2 {
+		select {
+		case <-resolveNowCh:
+		case <-ctx.Done():
+			t.Fatalf("Timed out waiting for ResolveNow call after TransientFailure")
+		}
 	}
 
 	// Restart the listener and expected to reconnect on its own and come out


### PR DESCRIPTION
Addresses one test in https://github.com/grpc/grpc-go/issues/8995

This is the sequence of events happening in the test:
- gRPC channel moves to READY and is able to make an RPC.
- The server goes down, causing the client transport to close. This causes the gRPC channel to invoke `ResolveNow`. See: https://github.com/grpc/grpc-go/blob/06fc26a196350499dd0cf2dabdd5cf11bbee01a7/clientconn.go#L1517
- Subchannel moves to IDLE. 
- `pick_first` moves channel state to IDLE. `round_robin` reacts with a call to `ExitIdle`, causing `pick_first` to reconnect.
- Reconnection attempt fails as the server is still down, and the subchannel moves to TRANSIENT_FAILURE.
- This causes the `clusterimpl` policy to call `ResolveNow`

There are two calls to `ResolveNow`, but the test was only expecting one, and therefore the second one was blocking until the test context expires.

RELEASE NOTES: none