### PR TITLE
cleanup: replace net.IP with netip.Addr in tests

### DIFF
--- a/balancer/grpclb/grpclb_test.go
+++ b/balancer/grpclb/grpclb_test.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"net/netip"
 	"strconv"
 	"strings"
 	"sync"
@@ -343,7 +344,7 @@ type testServers struct {
 	ls       *remoteBalancer
 	lb       *grpc.Server
 	backends []*grpc.Server
-	beIPs    []net.IP
+	beIPs    []netip.Addr
 	bePorts  []int
 
 	lbListener  net.Listener
@@ -355,7 +356,7 @@ func startBackendsAndRemoteLoadBalancer(t *testing.T, numberOfBackends int, cust
 		beListeners []net.Listener
 		ls          *remoteBalancer
 		lb          *grpc.Server
-		beIPs       []net.IP
+		beIPs       []netip.Addr
 		bePorts     []int
 	)
 	for i := 0; i < numberOfBackends; i++ {
@@ -364,7 +365,7 @@ func startBackendsAndRemoteLoadBalancer(t *testing.T, numberOfBackends int, cust
 			err = fmt.Errorf("failed to listen %v", err)
 			return
 		}
-		beIPs = append(beIPs, beLis.Addr().(*net.TCPAddr).IP)
+		beIPs = append(beIPs, beLis.Addr().(*net.TCPAddr).AddrPort().Addr().Unmap())
 		bePorts = append(bePorts, beLis.Addr().(*net.TCPAddr).Port)
 
 		beListeners = append(beListeners, testutils.NewRestartableListener(beLis))
@@ -422,7 +423,7 @@ func (s) TestGRPCLB_Basic(t *testing.T) {
 	tss.ls.sls <- &lbpb.ServerList{
 		Servers: []*lbpb.Server{
 			{
-				IpAddress:        tss.beIPs[0],
+				IpAddress:        tss.beIPs[0].AsSlice(),
 				Port:             int32(tss.bePorts[0]),
 				LoadBalanceToken: lbToken,
 			},
@@ -478,11 +479,11 @@ func (s) TestGRPCLB_Weighted(t *testing.T) {
 	defer cleanup()
 
 	beServers := []*lbpb.Server{{
-		IpAddress:        tss.beIPs[0],
+		IpAddress:        tss.beIPs[0].AsSlice(),
 		Port:             int32(tss.bePorts[0]),
 		LoadBalanceToken: lbToken,
 	}, {
-		IpAddress:        tss.beIPs[1],
+		IpAddress:        tss.beIPs[1].AsSlice(),
 		Port:             int32(tss.bePorts[1]),
 		LoadBalanceToken: lbToken,
 	}}
@@ -553,12 +554,12 @@ func (s) TestGRPCLB_DropRequest(t *testing.T) {
 	defer cleanup()
 	tss.ls.sls <- &lbpb.ServerList{
 		Servers: []*lbpb.Server{{
-			IpAddress:        tss.beIPs[0],
+			IpAddress:        tss.beIPs[0].AsSlice(),
 			Port:             int32(tss.bePorts[0]),
 			LoadBalanceToken: lbToken,
 			Drop:             false,
 		}, {
-			IpAddress:        tss.beIPs[1],
+			IpAddress:        tss.beIPs[1].AsSlice(),
 			Port:             int32(tss.bePorts[1]),
 			LoadBalanceToken: lbToken,
 			Drop:             false,
@@ -725,7 +726,7 @@ func (s) TestGRPCLB_BalancerDisconnects(t *testing.T) {
 		tss.ls.sls <- &lbpb.ServerList{
 			Servers: []*lbpb.Server{
 				{
-					IpAddress:        tss.beIPs[0],
+					IpAddress:        tss.beIPs[0].AsSlice(),
 					Port:             int32(tss.bePorts[0]),
 					LoadBalanceToken: lbToken,
 				},
@@ -801,7 +802,7 @@ func (s) TestGRPCLB_Fallback(t *testing.T) {
 	sl := &lbpb.ServerList{
 		Servers: []*lbpb.Server{
 			{
-				IpAddress:        tss.beIPs[0],
+				IpAddress:        tss.beIPs[0].AsSlice(),
 				Port:             int32(tss.bePorts[0]),
 				LoadBalanceToken: lbToken,
 			},
@@ -896,7 +897,7 @@ func (s) TestGRPCLB_ExplicitFallback(t *testing.T) {
 	sl := &lbpb.ServerList{
 		Servers: []*lbpb.Server{
 			{
-				IpAddress:        tss.beIPs[0],
+				IpAddress:        tss.beIPs[0].AsSlice(),
 				Port:             int32(tss.bePorts[0]),
 				LoadBalanceToken: lbToken,
 			},
@@ -980,7 +981,7 @@ func (s) TestGRPCLB_FallBackWithNoServerAddress(t *testing.T) {
 	sl := &lbpb.ServerList{
 		Servers: []*lbpb.Server{
 			{
-				IpAddress:        tss.beIPs[0],
+				IpAddress:        tss.beIPs[0].AsSlice(),
 				Port:             int32(tss.bePorts[0]),
 				LoadBalanceToken: lbToken,
 			},
@@ -1072,15 +1073,15 @@ func (s) TestGRPCLB_PickFirst(t *testing.T) {
 	defer cleanup()
 
 	beServers := []*lbpb.Server{{
-		IpAddress:        tss.beIPs[0],
+		IpAddress:        tss.beIPs[0].AsSlice(),
 		Port:             int32(tss.bePorts[0]),
 		LoadBalanceToken: lbToken,
 	}, {
-		IpAddress:        tss.beIPs[1],
+		IpAddress:        tss.beIPs[1].AsSlice(),
 		Port:             int32(tss.bePorts[1]),
 		LoadBalanceToken: lbToken,
 	}, {
-		IpAddress:        tss.beIPs[2],
+		IpAddress:        tss.beIPs[2].AsSlice(),
 		Port:             int32(tss.bePorts[2]),
 		LoadBalanceToken: lbToken,
 	}}
@@ -1223,7 +1224,7 @@ func testGRPCLBEmptyServerList(t *testing.T, svcfg string) {
 	defer cleanup()
 
 	beServers := []*lbpb.Server{{
-		IpAddress:        tss.beIPs[0],
+		IpAddress:        tss.beIPs[0].AsSlice(),
 		Port:             int32(tss.bePorts[0]),
 		LoadBalanceToken: lbToken,
 	}}
@@ -1298,7 +1299,7 @@ func (s) TestGRPCLBWithTargetNameFieldInConfig(t *testing.T) {
 	sl := &lbpb.ServerList{
 		Servers: []*lbpb.Server{
 			{
-				IpAddress:        tss.beIPs[0],
+				IpAddress:        tss.beIPs[0].AsSlice(),
 				Port:             int32(tss.bePorts[0]),
 				LoadBalanceToken: lbToken,
 			},
@@ -1401,7 +1402,7 @@ func runAndCheckStats(t *testing.T, drop bool, statsChan chan *lbpb.ClientStats,
 	}
 	defer cleanup()
 	servers := []*lbpb.Server{{
-		IpAddress:        tss.beIPs[0],
+		IpAddress:        tss.beIPs[0].AsSlice(),
 		Port:             int32(tss.bePorts[0]),
 		LoadBalanceToken: lbToken,
 	}}

--- a/binarylog/binarylog_end2end_test.go
+++ b/binarylog/binarylog_end2end_test.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"net/netip"
 	"sort"
 	"sync"
 	"testing"
@@ -138,12 +139,12 @@ type test struct {
 	// ss and srvAddr are set once startServer is called.
 	ss      *stubserver.StubServer
 	srvAddr string // Server IP without port.
-	srvIP   net.IP
+	srvIP   netip.Addr
 	srvPort int
 
 	// Fields for client address. Set by the service handler.
 	clientAddrMu sync.Mutex
-	clientIP     net.IP
+	clientIP     netip.Addr
 	clientPort   int
 }
 
@@ -168,7 +169,7 @@ func (lw *listenerWrapper) Accept() (net.Conn, error) {
 		return nil, err
 	}
 	lw.te.clientAddrMu.Lock()
-	lw.te.clientIP = conn.RemoteAddr().(*net.TCPAddr).IP
+	lw.te.clientIP = conn.RemoteAddr().(*net.TCPAddr).AddrPort().Addr().Unmap()
 	lw.te.clientPort = conn.RemoteAddr().(*net.TCPAddr).Port
 	lw.te.clientAddrMu.Unlock()
 	return conn, nil
@@ -273,7 +274,7 @@ func (te *test) startServer() {
 		te.t.Fatalf("Failed to start server: %v", err)
 	}
 	te.srvAddr = lis.Addr().String()
-	te.srvIP = lis.Addr().(*net.TCPAddr).IP
+	te.srvIP = lis.Addr().(*net.TCPAddr).AddrPort().Addr().Unmap()
 	te.srvPort = lis.Addr().(*net.TCPAddr).Port
 }
 
@@ -447,7 +448,7 @@ func (ed *expectedData) newClientHeaderEntry(client bool, rpcID, inRPCID uint64)
 			Address: ed.te.clientIP.String(),
 			IpPort:  uint32(ed.te.clientPort),
 		}
-		if ed.te.clientIP.To4() != nil {
+		if ed.te.clientIP.Is4() {
 			peer.Type = binlogpb.Address_TYPE_IPV4
 		} else {
 			peer.Type = binlogpb.Address_TYPE_IPV6
@@ -480,7 +481,7 @@ func (ed *expectedData) newServerHeaderEntry(client bool, rpcID, inRPCID uint64)
 			Address: ed.te.srvIP.String(),
 			IpPort:  uint32(ed.te.srvPort),
 		}
-		if ed.te.srvIP.To4() != nil {
+		if ed.te.srvIP.Is4() {
 			peer.Type = binlogpb.Address_TYPE_IPV4
 		} else {
 			peer.Type = binlogpb.Address_TYPE_IPV6
@@ -573,7 +574,7 @@ func (ed *expectedData) newServerTrailerEntry(client bool, rpcID, inRPCID uint64
 			Address: ed.te.srvIP.String(),
 			IpPort:  uint32(ed.te.srvPort),
 		}
-		if ed.te.srvIP.To4() != nil {
+		if ed.te.srvIP.Is4() {
 			peer.Type = binlogpb.Address_TYPE_IPV4
 		} else {
 			peer.Type = binlogpb.Address_TYPE_IPV6


### PR DESCRIPTION
Fixes #8884

Replace usages of net.IP with netip.Addr in binarylog and grpclb test
files. This uses the more performant and ergonomic net/netip package
types introduced in Go 1.18:

- binarylog: change srvIP/clientIP fields from net.IP to netip.Addr,
  use AddrPort().Addr().Unmap() for extraction, and Is4() instead of
  To4() != nil for IPv4 detection.
- grpclb: change beIPs from []net.IP to []netip.Addr, use AsSlice()
  when assigning to proto []byte fields.

RELEASE NOTES: n/a