### PR TITLE
grpcsync: add ScheduleAndWait method to CallbackSerializer

### DIFF
--- a/internal/grpcsync/callback_serializer.go
+++ b/internal/grpcsync/callback_serializer.go
@@ -20,6 +20,7 @@ package grpcsync
 
 import (
 	"context"
+	"fmt"
 
 	"google.golang.org/grpc/internal/buffer"
 )
@@ -75,6 +76,29 @@ func (cs *CallbackSerializer) ScheduleOr(f func(ctx context.Context), onFailure 
 	if cs.callbacks.Put(f) != nil {
 		onFailure()
 	}
+}
+
+// ScheduleAndWait schedules the provided callback function f and blocks until
+// it is executed. If the serializer's context has been canceled before the
+// callback could be scheduled, an error is returned.
+//
+// Callbacks are expected to honor the context when performing any blocking
+// operations, and should return early when the context is canceled.
+func (cs *CallbackSerializer) ScheduleAndWait(f func(ctx context.Context)) error {
+	done := make(chan struct{})
+	closed := false
+	cs.ScheduleOr(func(ctx context.Context) {
+		defer close(done)
+		f(ctx)
+	}, func() {
+		closed = true
+		close(done)
+	})
+	<-done
+	if closed {
+		return fmt.Errorf("callback serializer is closed")
+	}
+	return nil
 }
 
 func (cs *CallbackSerializer) run(ctx context.Context) {

--- a/internal/grpcsync/callback_serializer_test.go
+++ b/internal/grpcsync/callback_serializer_test.go
@@ -204,3 +204,63 @@ func (s) TestCallbackSerializer_Schedule_Close(t *testing.T) {
 	case <-done:
 	}
 }
+
+// TestCallbackSerializer_ScheduleAndWait verifies that ScheduleAndWait blocks
+// until the callback is executed and returns nil on success.
+func (s) TestCallbackSerializer_ScheduleAndWait(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	cs := NewCallbackSerializer(ctx)
+	defer cancel()
+
+	var executed bool
+	err := cs.ScheduleAndWait(func(context.Context) {
+		executed = true
+	})
+	if err != nil {
+		t.Fatalf("ScheduleAndWait() returned error: %v, want nil", err)
+	}
+	if !executed {
+		t.Fatal("Callback was not executed")
+	}
+}
+
+// TestCallbackSerializer_ScheduleAndWait_Closed verifies that ScheduleAndWait
+// returns an error when the serializer is already closed.
+func (s) TestCallbackSerializer_ScheduleAndWait_Closed(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+
+	serializerCtx, serializerCancel := context.WithCancel(ctx)
+	cs := NewCallbackSerializer(serializerCtx)
+
+	serializerCancel()
+	<-cs.Done()
+
+	err := cs.ScheduleAndWait(func(context.Context) {
+		t.Fatal("Callback should not be executed on a closed serializer")
+	})
+	if err == nil {
+		t.Fatal("ScheduleAndWait() on closed serializer returned nil, want error")
+	}
+}
+
+// TestCallbackSerializer_ScheduleAndWait_FIFO verifies that ScheduleAndWait
+// respects the FIFO ordering with other scheduled callbacks.
+func (s) TestCallbackSerializer_ScheduleAndWait_FIFO(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	cs := NewCallbackSerializer(ctx)
+	defer cancel()
+
+	var order []int
+	cs.TrySchedule(func(context.Context) { order = append(order, 1) })
+	cs.TrySchedule(func(context.Context) { order = append(order, 2) })
+	err := cs.ScheduleAndWait(func(context.Context) { order = append(order, 3) })
+	if err != nil {
+		t.Fatalf("ScheduleAndWait() returned error: %v", err)
+	}
+
+	want := []int{1, 2, 3}
+	if diff := cmp.Diff(want, order); diff != "" {
+		t.Fatalf("Unexpected execution order (-want +got):\n%s", diff)
+	}
+}

--- a/internal/xds/clients/internal/syncutil/callback_serializer.go
+++ b/internal/xds/clients/internal/syncutil/callback_serializer.go
@@ -20,6 +20,7 @@ package syncutil
 
 import (
 	"context"
+	"fmt"
 
 	"google.golang.org/grpc/internal/xds/clients/internal/buffer"
 )
@@ -75,6 +76,29 @@ func (cs *CallbackSerializer) ScheduleOr(f func(ctx context.Context), onFailure 
 	if cs.callbacks.Put(f) != nil {
 		onFailure()
 	}
+}
+
+// ScheduleAndWait schedules the provided callback function f and blocks until
+// it is executed. If the serializer's context has been canceled before the
+// callback could be scheduled, an error is returned.
+//
+// Callbacks are expected to honor the context when performing any blocking
+// operations, and should return early when the context is canceled.
+func (cs *CallbackSerializer) ScheduleAndWait(f func(ctx context.Context)) error {
+	done := make(chan struct{})
+	closed := false
+	cs.ScheduleOr(func(ctx context.Context) {
+		defer close(done)
+		f(ctx)
+	}, func() {
+		closed = true
+		close(done)
+	})
+	<-done
+	if closed {
+		return fmt.Errorf("callback serializer is closed")
+	}
+	return nil
 }
 
 func (cs *CallbackSerializer) run(ctx context.Context) {

--- a/internal/xds/clients/internal/syncutil/callback_serializer_test.go
+++ b/internal/xds/clients/internal/syncutil/callback_serializer_test.go
@@ -204,3 +204,63 @@ func (s) TestCallbackSerializer_Schedule_Close(t *testing.T) {
 	case <-done:
 	}
 }
+
+// TestCallbackSerializer_ScheduleAndWait verifies that ScheduleAndWait blocks
+// until the callback is executed and returns nil on success.
+func (s) TestCallbackSerializer_ScheduleAndWait(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	cs := NewCallbackSerializer(ctx)
+	defer cancel()
+
+	var executed bool
+	err := cs.ScheduleAndWait(func(context.Context) {
+		executed = true
+	})
+	if err != nil {
+		t.Fatalf("ScheduleAndWait() returned error: %v, want nil", err)
+	}
+	if !executed {
+		t.Fatal("Callback was not executed")
+	}
+}
+
+// TestCallbackSerializer_ScheduleAndWait_Closed verifies that ScheduleAndWait
+// returns an error when the serializer is already closed.
+func (s) TestCallbackSerializer_ScheduleAndWait_Closed(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+
+	serializerCtx, serializerCancel := context.WithCancel(ctx)
+	cs := NewCallbackSerializer(serializerCtx)
+
+	serializerCancel()
+	<-cs.Done()
+
+	err := cs.ScheduleAndWait(func(context.Context) {
+		t.Fatal("Callback should not be executed on a closed serializer")
+	})
+	if err == nil {
+		t.Fatal("ScheduleAndWait() on closed serializer returned nil, want error")
+	}
+}
+
+// TestCallbackSerializer_ScheduleAndWait_FIFO verifies that ScheduleAndWait
+// respects the FIFO ordering with other scheduled callbacks.
+func (s) TestCallbackSerializer_ScheduleAndWait_FIFO(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	cs := NewCallbackSerializer(ctx)
+	defer cancel()
+
+	var order []int
+	cs.TrySchedule(func(context.Context) { order = append(order, 1) })
+	cs.TrySchedule(func(context.Context) { order = append(order, 2) })
+	err := cs.ScheduleAndWait(func(context.Context) { order = append(order, 3) })
+	if err != nil {
+		t.Fatalf("ScheduleAndWait() returned error: %v", err)
+	}
+
+	want := []int{1, 2, 3}
+	if diff := cmp.Diff(want, order); diff != "" {
+		t.Fatalf("Unexpected execution order (-want +got):\n%s", diff)
+	}
+}


### PR DESCRIPTION
Updates #8501

Add a ScheduleAndWait method to CallbackSerializer that schedules a
callback and blocks until it is executed. This eliminates the common
boilerplate pattern of creating a done channel, scheduling with
ScheduleOr, and waiting on the channel.

The method returns an error if the serializer is already closed and
the callback could not be scheduled.

The same method is added to both internal/grpcsync and the xds
syncutil copy of CallbackSerializer, along with tests covering
successful execution, closed serializer behavior, and FIFO ordering.

RELEASE NOTES: n/a