### PR TITLE
test: Fix flaky test TestRingHash_RequestHashKeyConnecting in ringhash_e2e_test.go.

### DIFF
--- a/balancer/ringhash/ringhash_e2e_test.go
+++ b/balancer/ringhash/ringhash_e2e_test.go
@@ -2884,13 +2884,17 @@ func (s) TestRingHash_RequestHashKeyConnecting(t *testing.T) {
 		t.Fatalf("Got %d connection attempts, want at most %d", nConn, wantMaxConn)
 	}
 
+	testutils.AwaitState(ctx, t, cc, connectivity.Connecting)
+
 	// Do a second RPC. Since there should already be a SubChannel in
 	// Connecting state, this should not trigger a connection attempt.
 	var firstConnectedBackend string
+	secondRPCStarted := make(chan struct{})
 
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
+		<-secondRPCStarted
 		// Give extra time for more connections to be attempted.
 		time.Sleep(defaultTestShortTimeout)
 		nConn = 0
@@ -2899,10 +2903,10 @@ func (s) TestRingHash_RequestHashKeyConnecting(t *testing.T) {
 				// Unblock the connection attempt. The SubChannel (and hence the
 				// channel) should transition to Ready. RPCs should succeed and
 				// be routed to this backend.
-				hold.Resume()
 				holds[i] = nil
 				firstConnectedBackend = backends[i]
 				nConn++
+				hold.Resume()
 			}
 		}
 		if wantMaxConn := 1; nConn > wantMaxConn {
@@ -2911,12 +2915,17 @@ func (s) TestRingHash_RequestHashKeyConnecting(t *testing.T) {
 	}()
 
 	// Do a second RPC. Since there should already be a SubChannel in
-	// Connecting state, this should not trigger a connection attempt.
-	// Use WaitForReady to block until the background goroutine resumes the hold.
-	_, err = client.EmptyCall(ctx, &testpb.Empty{}, grpc.WaitForReady(true))
-	if err != nil {
-		t.Fatalf("EmptyCall(): got %v, want success", err)
-	}
+	// Connecting state, this should not trigger a connection attempt
+	// and wait until the background goroutine resumes the hold.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		close(secondRPCStarted)
+		_, err = client.EmptyCall(ctx, &testpb.Empty{}, grpc.WaitForReady(true))
+		if err != nil {
+			t.Errorf("EmptyCall(): got %v, want success", err)
+		}
+	}()
 
 	testutils.AwaitState(ctx, t, cc, connectivity.Ready)
 	wg.Wait() // Make sure we're done with the first RPC.

--- a/balancer/ringhash/ringhash_e2e_test.go
+++ b/balancer/ringhash/ringhash_e2e_test.go
@@ -2888,7 +2888,9 @@ func (s) TestRingHash_RequestHashKeyConnecting(t *testing.T) {
 	// Connecting state, this should not trigger a connection attempt.
 	var firstConnectedBackend string
 
+	wg.Add(1)
 	go func() {
+		defer wg.Done()
 		// Give extra time for more connections to be attempted.
 		time.Sleep(defaultTestShortTimeout)
 		nConn = 0

--- a/balancer/ringhash/ringhash_e2e_test.go
+++ b/balancer/ringhash/ringhash_e2e_test.go
@@ -2886,46 +2886,39 @@ func (s) TestRingHash_RequestHashKeyConnecting(t *testing.T) {
 
 	testutils.AwaitState(ctx, t, cc, connectivity.Connecting)
 
-	// Do a second RPC. Since there should already be a SubChannel in
-	// Connecting state, this should not trigger a connection attempt.
+	// Do a second RPC with short timeout. Since there should already be a
+	// SubChannel in Connecting state, this should not trigger a connection
+	// attempt.
+	sCtx, sCancel := context.WithTimeout(ctx, defaultTestShortTimeout)
+	_, err = client.EmptyCall(sCtx, &testpb.Empty{}, grpc.WaitForReady(true))
+	sCancel()
+
+	// It should fail with DeadlineExceeded because the connection is blocked.
+	if status.Code(err) != codes.DeadlineExceeded {
+		t.Fatalf("EmptyCall(): got err %v, want DeadlineExceeded", err)
+	}
+
+	// Check connection counts before resuming any hold.
+	nConn = 0
+	for _, hold := range holds {
+		if hold != nil && hold.IsStarted() {
+			nConn++
+		}
+	}
+	if wantMaxConn := 1; nConn > wantMaxConn {
+		t.Errorf("Got %d connection attempts, want at most %d", nConn, wantMaxConn)
+	}
+
+	// Resume the hold in the main thread.
 	var firstConnectedBackend string
-	secondRPCStarted := make(chan struct{})
-
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		<-secondRPCStarted
-		// Give extra time for more connections to be attempted.
-		time.Sleep(defaultTestShortTimeout)
-		nConn = 0
-		for i, hold := range holds {
-			if hold.IsStarted() {
-				// Unblock the connection attempt. The SubChannel (and hence the
-				// channel) should transition to Ready. RPCs should succeed and
-				// be routed to this backend.
-				holds[i] = nil
-				firstConnectedBackend = backends[i]
-				nConn++
-				hold.Resume()
-			}
+	for i, hold := range holds {
+		if hold != nil && hold.IsStarted() {
+			hold.Resume()
+			firstConnectedBackend = backends[i]
+			holds[i] = nil
+			break
 		}
-		if wantMaxConn := 1; nConn > wantMaxConn {
-			t.Errorf("Got %d connection attempts, want at most %d", nConn, wantMaxConn)
-		}
-	}()
-
-	// Do a second RPC. Since there should already be a SubChannel in
-	// Connecting state, this should not trigger a connection attempt
-	// and wait until the background goroutine resumes the hold.
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		close(secondRPCStarted)
-		_, err = client.EmptyCall(ctx, &testpb.Empty{}, grpc.WaitForReady(true))
-		if err != nil {
-			t.Errorf("EmptyCall(): got %v, want success", err)
-		}
-	}()
+	}
 
 	testutils.AwaitState(ctx, t, cc, connectivity.Ready)
 	wg.Wait() // Make sure we're done with the first RPC.

--- a/balancer/ringhash/ringhash_e2e_test.go
+++ b/balancer/ringhash/ringhash_e2e_test.go
@@ -2886,36 +2886,38 @@ func (s) TestRingHash_RequestHashKeyConnecting(t *testing.T) {
 
 	// Do a second RPC. Since there should already be a SubChannel in
 	// Connecting state, this should not trigger a connection attempt.
-	wg.Add(1)
+	var firstConnectedBackend string
+
 	go func() {
-		_, err := client.EmptyCall(ctx, &testpb.Empty{})
-		if err != nil {
-			t.Errorf("EmptyCall(): got %v, want success", err)
+		// Give extra time for more connections to be attempted.
+		time.Sleep(defaultTestShortTimeout)
+		nConn = 0
+		for i, hold := range holds {
+			if hold.IsStarted() {
+				// Unblock the connection attempt. The SubChannel (and hence the
+				// channel) should transition to Ready. RPCs should succeed and
+				// be routed to this backend.
+				hold.Resume()
+				holds[i] = nil
+				firstConnectedBackend = backends[i]
+				nConn++
+			}
 		}
-		wg.Done()
+		if wantMaxConn := 1; nConn > wantMaxConn {
+			t.Errorf("Got %d connection attempts, want at most %d", nConn, wantMaxConn)
+		}
 	}()
 
-	// Give extra time for more connections to be attempted.
-	time.Sleep(defaultTestShortTimeout)
+	// Do a second RPC. Since there should already be a SubChannel in
+	// Connecting state, this should not trigger a connection attempt.
+	// Use WaitForReady to block until the background goroutine resumes the hold.
+	_, err = client.EmptyCall(ctx, &testpb.Empty{}, grpc.WaitForReady(true))
+	if err != nil {
+		t.Fatalf("EmptyCall(): got %v, want success", err)
+	}
 
-	var firstConnectedBackend string
-	nConn = 0
-	for i, hold := range holds {
-		if hold.IsStarted() {
-			// Unblock the connection attempt. The SubChannel (and hence the
-			// channel) should transition to Ready. RPCs should succeed and
-			// be routed to this backend.
-			hold.Resume()
-			holds[i] = nil
-			firstConnectedBackend = backends[i]
-			nConn++
-		}
-	}
-	if wantMaxConn := 1; nConn > wantMaxConn {
-		t.Fatalf("Got %d connection attempts, want at most %d", nConn, wantMaxConn)
-	}
 	testutils.AwaitState(ctx, t, cc, connectivity.Ready)
-	wg.Wait() // Make sure we're done with the 2 previous RPCs.
+	wg.Wait() // Make sure we're done with the first RPC.
 
 	// Now send RPCs until we have at least one more connection attempt, that
 	// is, the random hash did not land on the same backend on every pick (the


### PR DESCRIPTION
Fixes: #9030 

### Problem

The flakiness was caused by the following race condition in the test execution flow:
  * The test dispatched the second RPC in a background goroutine almost immediately after the first RPC call. Due to race, this second RPC would often execute *before* the balancer had finished updating its state to reflect that the first RPC was already connecting. Seeing no active connections in progress, the second RPC would trigger a redundant connection attempt, failing the test.
  * Another reason of flake is test relied on a background goroutine with a fixed sleep to release a connection hold. The hold was often released before the second RPC reached the picker, missing the CONNECTING state window we wanted to test.
  
### The Fix 

Refactored the test to use a deterministic negative assertion flow that eliminates background races:

The second RPC is now sent with a short timeout and WaitForReady(true). Because the first connection is held, the second RPC blocks and fails with DeadlineExceeded as expected. We verify the failure and assert that no new connection attempts were triggered during this time. Then, we resume the hold in the main thread to let the test finish.
  
Verified it on forge for a million times: [link](http://sponge2/e198bdf4-34fc-4e75-8513-eacc3fe14146)

RELEASE NOTES: N/A