### PR TITLE
xds/resolver: change int32 to atomic.int32

### DIFF
--- a/internal/xds/resolver/serviceconfig.go
+++ b/internal/xds/resolver/serviceconfig.go
@@ -195,12 +195,11 @@ func (cs *configSelector) SelectConfig(rpcInfo iresolver.RPCInfo) (*iresolver.RP
 		return nil, annotateErrorWithNodeID(status.Errorf(codes.Internal, "error retrieving cluster for match: %v (%T)", cluster, cluster), cs.xdsNodeID)
 	}
 
-	// Add a ref to the selected cluster, as this RPC needs this cluster until
-	// it is committed.
+	// Add a ref to the selected cluster/plugin, as this RPC needs this
+	// cluster/plugin until it is committed.
 	if info, ok := cs.clusters[cluster.name]; ok {
 		info.refCount.Add(1)
-	}
-	if info, ok := cs.plugins[cluster.name]; ok {
+	} else if info, ok := cs.plugins[cluster.name]; ok {
 		info.refCount.Add(1)
 	}
 

--- a/internal/xds/resolver/serviceconfig.go
+++ b/internal/xds/resolver/serviceconfig.go
@@ -24,7 +24,6 @@ import (
 	"math/bits"
 	rand "math/rand/v2"
 	"strings"
-	"sync/atomic"
 	"time"
 
 	xxhash "github.com/cespare/xxhash/v2"
@@ -198,14 +197,12 @@ func (cs *configSelector) SelectConfig(rpcInfo iresolver.RPCInfo) (*iresolver.RP
 
 	// Add a ref to the selected cluster, as this RPC needs this cluster until
 	// it is committed.
-	var ref *int32
 	if info, ok := cs.clusters[cluster.name]; ok {
-		ref = &info.refCount
+		info.refCount.Add(1)
 	}
 	if info, ok := cs.plugins[cluster.name]; ok {
-		ref = &info.refCount
+		info.refCount.Add(1)
 	}
-	atomic.AddInt32(ref, 1)
 
 	lbCtx := clustermanager.SetPickedCluster(rpcInfo.Context, cluster.name)
 	lbCtx = xdsresource.NewContextWithXDSConfig(lbCtx, cs.xdsConfig)
@@ -221,8 +218,7 @@ func (cs *configSelector) SelectConfig(rpcInfo iresolver.RPCInfo) (*iresolver.RP
 			// When the RPC is committed, the cluster is no longer required.
 			// Decrease its ref.
 			if info, ok := cs.clusters[cluster.name]; ok {
-				ref := &info.refCount
-				if v := atomic.AddInt32(ref, -1); v == 0 {
+				if v := info.refCount.Add(-1); v == 0 {
 					// We call unsubscribe rather than sendNewServiceConfig to
 					// prevent redundant updates. If the reference count in the
 					// dependency manager drops to zero, it will automatically
@@ -233,8 +229,7 @@ func (cs *configSelector) SelectConfig(rpcInfo iresolver.RPCInfo) (*iresolver.RP
 				}
 			}
 			if info, ok := cs.plugins[cluster.name]; ok {
-				ref := &info.refCount
-				if v := atomic.AddInt32(ref, -1); v == 0 {
+				if v := info.refCount.Add(-1); v == 0 {
 					// This entry will be removed from activePlugins when
 					// producing a new service config update.
 					cs.sendNewServiceConfig()
@@ -350,12 +345,12 @@ func (cs *configSelector) stop() {
 	// after a new one is active, we must trigger a subsequent update to delete
 	// the now-unused clusters.
 	for _, ci := range cs.clusters {
-		if v := atomic.AddInt32(&ci.refCount, -1); v == 0 {
+		if v := ci.refCount.Add(-1); v == 0 {
 			ci.unsubscribe()
 		}
 	}
 	for _, ci := range cs.plugins {
-		if v := atomic.AddInt32(&ci.refCount, -1); v == 0 {
+		if v := ci.refCount.Add(-1); v == 0 {
 			cs.sendNewServiceConfig()
 		}
 	}

--- a/internal/xds/resolver/serviceconfig_test.go
+++ b/internal/xds/resolver/serviceconfig_test.go
@@ -64,13 +64,13 @@ func (s) TestPruneActiveClusters(t *testing.T) {
 			"anotherzero": newClusterInfo(0, nil),
 		},
 	}
-	wantActiveClusters := map[string]*clusterInfo{
-		"one": newClusterInfo(1, nil),
-		"two": newClusterInfo(2, nil),
+	wantActiveClusters := map[string]int32{
+		"one": 1,
+		"two": 2,
 	}
-	wantActivePlugins := map[string]*clusterInfo{
-		"one": newClusterInfo(1, nil),
-		"two": newClusterInfo(2, nil),
+	wantActivePlugins := map[string]int32{
+		"one": 1,
+		"two": 2,
 	}
 	r.pruneActiveClustersAndPlugins()
 
@@ -82,10 +82,10 @@ func (s) TestPruneActiveClusters(t *testing.T) {
 		return res
 	}
 
-	if d := cmp.Diff(getRefCounts(r.activeClusters), getRefCounts(wantActiveClusters)); d != "" {
+	if d := cmp.Diff(getRefCounts(r.activeClusters), wantActiveClusters); d != "" {
 		t.Fatalf("r.activeClusters refCounts mismatch (-got +want):\n%s", d)
 	}
-	if d := cmp.Diff(getRefCounts(r.activePlugins), getRefCounts(wantActivePlugins)); d != "" {
+	if d := cmp.Diff(getRefCounts(r.activePlugins), wantActivePlugins); d != "" {
 		t.Fatalf("r.activePlugins refCounts mismatch (-got +want):\n%s", d)
 	}
 }

--- a/internal/xds/resolver/serviceconfig_test.go
+++ b/internal/xds/resolver/serviceconfig_test.go
@@ -26,7 +26,6 @@ import (
 
 	xxhash "github.com/cespare/xxhash/v2"
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"google.golang.org/grpc/internal/grpctest"
 	"google.golang.org/grpc/internal/grpcutil"
 	iresolver "google.golang.org/grpc/internal/resolver"
@@ -46,34 +45,48 @@ func Test(t *testing.T) {
 }
 
 func (s) TestPruneActiveClusters(t *testing.T) {
+	newClusterInfo := func(ref int32, unsubscribe func()) *clusterInfo {
+		ci := &clusterInfo{unsubscribe: unsubscribe}
+		ci.refCount.Store(ref)
+		return ci
+	}
 	r := &xdsResolver{
 		activeClusters: map[string]*clusterInfo{
-			"zero":        {refCount: 0, unsubscribe: func() {}},
-			"one":         {refCount: 1, unsubscribe: func() {}},
-			"two":         {refCount: 2, unsubscribe: func() {}},
-			"anotherzero": {refCount: 0, unsubscribe: func() {}},
+			"zero":        newClusterInfo(0, func() {}),
+			"one":         newClusterInfo(1, func() {}),
+			"two":         newClusterInfo(2, func() {}),
+			"anotherzero": newClusterInfo(0, func() {}),
 		},
 		activePlugins: map[string]*clusterInfo{
-			"zero":        {refCount: 0},
-			"one":         {refCount: 1},
-			"two":         {refCount: 2},
-			"anotherzero": {refCount: 0},
+			"zero":        newClusterInfo(0, nil),
+			"one":         newClusterInfo(1, nil),
+			"two":         newClusterInfo(2, nil),
+			"anotherzero": newClusterInfo(0, nil),
 		},
 	}
 	wantActiveClusters := map[string]*clusterInfo{
-		"one": {refCount: 1},
-		"two": {refCount: 2},
+		"one": newClusterInfo(1, nil),
+		"two": newClusterInfo(2, nil),
 	}
 	wantActivePlugins := map[string]*clusterInfo{
-		"one": {refCount: 1},
-		"two": {refCount: 2},
+		"one": newClusterInfo(1, nil),
+		"two": newClusterInfo(2, nil),
 	}
 	r.pruneActiveClustersAndPlugins()
-	if d := cmp.Diff(r.activeClusters, wantActiveClusters, cmp.AllowUnexported(clusterInfo{}), cmpopts.IgnoreFields(clusterInfo{}, "unsubscribe")); d != "" {
-		t.Errorf("r.activeClusters = %v; want %v\nDiffs: %v", r.activeClusters, wantActiveClusters, d)
+
+	getRefCounts := func(m map[string]*clusterInfo) map[string]int32 {
+		res := make(map[string]int32)
+		for k, v := range m {
+			res[k] = v.refCount.Load()
+		}
+		return res
 	}
-	if d := cmp.Diff(r.activePlugins, wantActivePlugins, cmp.AllowUnexported(clusterInfo{})); d != "" {
-		t.Fatalf("r.activePlugins = %v; want %v\nDiffs: %v", r.activePlugins, wantActivePlugins, d)
+
+	if d := cmp.Diff(getRefCounts(r.activeClusters), getRefCounts(wantActiveClusters)); d != "" {
+		t.Fatalf("r.activeClusters refCounts mismatch (-got +want):\n%s", d)
+	}
+	if d := cmp.Diff(getRefCounts(r.activePlugins), getRefCounts(wantActivePlugins)); d != "" {
+		t.Fatalf("r.activePlugins refCounts mismatch (-got +want):\n%s", d)
 	}
 }
 

--- a/internal/xds/resolver/xds_resolver.go
+++ b/internal/xds/resolver/xds_resolver.go
@@ -535,7 +535,7 @@ func (r *xdsResolver) addOrGetActiveClusterInfo(key string, name string) *cluste
 }
 
 type clusterInfo struct {
-	// number of references to this cluster; accessed atomically
+	// refCount is the number of references to this cluster.
 	refCount atomic.Int32
 	// cfg is the child configuration for this cluster, containing either the
 	// csp config or the cds cluster config.

--- a/internal/xds/resolver/xds_resolver.go
+++ b/internal/xds/resolver/xds_resolver.go
@@ -464,10 +464,10 @@ func (r *xdsResolver) newConfigSelector() (_ *configSelector, err error) {
 	// errors may occur. Note: cs.clusters are pointers to entries in
 	// activeClusters.
 	for _, ci := range cs.clusters {
-		atomic.AddInt32(&ci.refCount, 1)
+		ci.refCount.Add(1)
 	}
 	for _, ci := range cs.plugins {
-		atomic.AddInt32(&ci.refCount, 1)
+		ci.refCount.Add(1)
 	}
 
 	// Cleanup filter instances that are no longer specified in the current
@@ -496,13 +496,13 @@ func (r *xdsResolver) newConfigSelector() (_ *configSelector, err error) {
 // Only executed in the context of a serializer callback.
 func (r *xdsResolver) pruneActiveClustersAndPlugins() {
 	for cluster, ci := range r.activeClusters {
-		if atomic.LoadInt32(&ci.refCount) == 0 {
+		if ci.refCount.Load() == 0 {
 			ci.unsubscribe()
 			delete(r.activeClusters, cluster)
 		}
 	}
 	for cluster, ci := range r.activePlugins {
-		if atomic.LoadInt32(&ci.refCount) == 0 {
+		if ci.refCount.Load() == 0 {
 			delete(r.activePlugins, cluster)
 		}
 	}
@@ -536,7 +536,7 @@ func (r *xdsResolver) addOrGetActiveClusterInfo(key string, name string) *cluste
 
 type clusterInfo struct {
 	// number of references to this cluster; accessed atomically
-	refCount int32
+	refCount atomic.Int32
 	// cfg is the child configuration for this cluster, containing either the
 	// csp config or the cds cluster config.
 	cfg xdsChildConfig


### PR DESCRIPTION
Fixes point 6 of https://github.com/grpc/grpc-go/issues/8880

Changes the `refCount` used in `xds_resolver.go` to be atomic.Int32 instead of Int32 and updates the usages and test accordingly.

RELEASE NOTES: N/A