### PR TITLE
otel: Segregate client and server RPCInfo used for metrics and traces

### DIFF
--- a/stats/opentelemetry/client_metrics.go
+++ b/stats/opentelemetry/client_metrics.go
@@ -71,7 +71,7 @@ func (h *clientMetricsHandler) initializeMetrics() {
 // or creates and attaches a new one.
 func getOrCreateCallInfo(ctx context.Context, cc *grpc.ClientConn, method string, opts ...grpc.CallOption) (context.Context, *callInfo) {
 	ci := getCallInfo(ctx)
-	if ci == nil {
+	if ci == nil || ci.target != cc.CanonicalTarget() {
 		ci = &callInfo{
 			target: cc.CanonicalTarget(),
 			method: determineMethod(method, opts...),
@@ -157,17 +157,6 @@ func (h *clientMetricsHandler) TagConn(ctx context.Context, _ *stats.ConnTagInfo
 // HandleConn exists to satisfy stats.Handler.
 func (h *clientMetricsHandler) HandleConn(context.Context, stats.ConnStats) {}
 
-// getOrCreateRPCAttemptInfo retrieves or creates an rpc attemptInfo object
-// and ensures it is set in the context along with the rpcInfo.
-func getOrCreateRPCAttemptInfo(ctx context.Context) (context.Context, *attemptInfo) {
-	ri := getRPCInfo(ctx)
-	if ri != nil {
-		return ctx, ri.ai
-	}
-	ri = &rpcInfo{ai: &attemptInfo{}}
-	return setRPCInfo(ctx, ri), ri.ai
-}
-
 // TagRPC implements per RPC attempt context management for metrics.
 func (h *clientMetricsHandler) TagRPC(ctx context.Context, info *stats.RPCTagInfo) context.Context {
 	// Numerous stats handlers can be used for the same channel. The cluster
@@ -187,17 +176,17 @@ func (h *clientMetricsHandler) TagRPC(ctx context.Context, info *stats.RPCTagInf
 		}
 		ctx = istats.SetLabels(ctx, labels)
 	}
-	ctx, ai := getOrCreateRPCAttemptInfo(ctx)
+	ctx, ai := getOrCreateClientRPCAttemptInfo(ctx)
 	ai.startTime = time.Now()
 	ai.xdsLabels = labels.TelemetryLabels
 	ai.method = removeLeadingSlash(info.FullMethodName)
 
-	return setRPCInfo(ctx, &rpcInfo{ai: ai})
+	return setClientRPCInfo(ctx, &rpcInfo{ai: ai})
 }
 
 // HandleRPC handles per RPC stats implementation.
 func (h *clientMetricsHandler) HandleRPC(ctx context.Context, rs stats.RPCStats) {
-	ri := getRPCInfo(ctx)
+	ri := getClientRPCInfo(ctx)
 	if ri == nil {
 		logger.Error("ctx passed into client side stats handler metrics event handling has no client attempt data present")
 		return

--- a/stats/opentelemetry/client_metrics.go
+++ b/stats/opentelemetry/client_metrics.go
@@ -76,7 +76,7 @@ func getOrCreateCallInfo(ctx context.Context, cc *grpc.ClientConn, method string
 			target: cc.CanonicalTarget(),
 			method: determineMethod(method, opts...),
 		}
-		ctx = setCallInfo(ctx, ci)
+		ctx = context.WithValue(ctx, callInfoKey{}, ci)
 	}
 	return ctx, ci
 }
@@ -176,7 +176,8 @@ func (h *clientMetricsHandler) TagRPC(ctx context.Context, info *stats.RPCTagInf
 		}
 		ctx = istats.SetLabels(ctx, labels)
 	}
-	ctx, ai := getOrCreateClientRPCAttemptInfo(ctx)
+	ctx, ri := getOrCreateClientRPCInfo(ctx)
+	ai := ri.ai
 	ai.startTime = time.Now()
 	ai.xdsLabels = labels.TelemetryLabels
 	ai.method = removeLeadingSlash(info.FullMethodName)
@@ -186,7 +187,7 @@ func (h *clientMetricsHandler) TagRPC(ctx context.Context, info *stats.RPCTagInf
 
 // HandleRPC handles per RPC stats implementation.
 func (h *clientMetricsHandler) HandleRPC(ctx context.Context, rs stats.RPCStats) {
-	ri := getClientRPCInfo(ctx)
+	ri := clientRPCInfo(ctx)
 	if ri == nil {
 		logger.Error("ctx passed into client side stats handler metrics event handling has no client attempt data present")
 		return

--- a/stats/opentelemetry/client_metrics.go
+++ b/stats/opentelemetry/client_metrics.go
@@ -71,7 +71,7 @@ func (h *clientMetricsHandler) initializeMetrics() {
 // or creates and attaches a new one.
 func getOrCreateCallInfo(ctx context.Context, cc *grpc.ClientConn, method string, opts ...grpc.CallOption) (context.Context, *callInfo) {
 	ci := getCallInfo(ctx)
-	if ci == nil || ci.target != cc.CanonicalTarget() {
+	if ci == nil {
 		ci = &callInfo{
 			target: cc.CanonicalTarget(),
 			method: determineMethod(method, opts...),
@@ -181,7 +181,7 @@ func (h *clientMetricsHandler) TagRPC(ctx context.Context, info *stats.RPCTagInf
 	ai.xdsLabels = labels.TelemetryLabels
 	ai.method = removeLeadingSlash(info.FullMethodName)
 
-	return setClientRPCInfo(ctx, &rpcInfo{ai: ai})
+	return ctx
 }
 
 // HandleRPC handles per RPC stats implementation.

--- a/stats/opentelemetry/client_tracing.go
+++ b/stats/opentelemetry/client_tracing.go
@@ -121,8 +121,8 @@ func (h *clientTracingHandler) HandleConn(context.Context, stats.ConnStats) {}
 // TagRPC implements per RPC attempt context management for traces.
 func (h *clientTracingHandler) TagRPC(ctx context.Context, info *stats.RPCTagInfo) context.Context {
 	ctx, ai := getOrCreateClientRPCAttemptInfo(ctx)
-	ctx, ai = h.traceTagRPC(ctx, ai, info.NameResolutionDelay)
-	return setClientRPCInfo(ctx, &rpcInfo{ai: ai})
+	ctx, _ = h.traceTagRPC(ctx, ai, info.NameResolutionDelay)
+	return ctx
 }
 
 // HandleRPC handles per RPC tracing implementation.

--- a/stats/opentelemetry/client_tracing.go
+++ b/stats/opentelemetry/client_tracing.go
@@ -120,14 +120,14 @@ func (h *clientTracingHandler) HandleConn(context.Context, stats.ConnStats) {}
 
 // TagRPC implements per RPC attempt context management for traces.
 func (h *clientTracingHandler) TagRPC(ctx context.Context, info *stats.RPCTagInfo) context.Context {
-	ctx, ai := getOrCreateClientRPCAttemptInfo(ctx)
-	ctx, _ = h.traceTagRPC(ctx, ai, info.NameResolutionDelay)
+	ctx, ri := getOrCreateClientRPCInfo(ctx)
+	ctx, _ = h.traceTagRPC(ctx, ri.ai, info.NameResolutionDelay)
 	return ctx
 }
 
 // HandleRPC handles per RPC tracing implementation.
 func (h *clientTracingHandler) HandleRPC(ctx context.Context, rs stats.RPCStats) {
-	ri := getClientRPCInfo(ctx)
+	ri := clientRPCInfo(ctx)
 	if ri == nil {
 		logger.Error("ctx passed into client side tracing handler trace event handling has no client attempt data present")
 		return

--- a/stats/opentelemetry/client_tracing.go
+++ b/stats/opentelemetry/client_tracing.go
@@ -120,14 +120,14 @@ func (h *clientTracingHandler) HandleConn(context.Context, stats.ConnStats) {}
 
 // TagRPC implements per RPC attempt context management for traces.
 func (h *clientTracingHandler) TagRPC(ctx context.Context, info *stats.RPCTagInfo) context.Context {
-	ctx, ai := getOrCreateRPCAttemptInfo(ctx)
+	ctx, ai := getOrCreateClientRPCAttemptInfo(ctx)
 	ctx, ai = h.traceTagRPC(ctx, ai, info.NameResolutionDelay)
-	return setRPCInfo(ctx, &rpcInfo{ai: ai})
+	return setClientRPCInfo(ctx, &rpcInfo{ai: ai})
 }
 
 // HandleRPC handles per RPC tracing implementation.
 func (h *clientTracingHandler) HandleRPC(ctx context.Context, rs stats.RPCStats) {
-	ri := getRPCInfo(ctx)
+	ri := getClientRPCInfo(ctx)
 	if ri == nil {
 		logger.Error("ctx passed into client side tracing handler trace event handling has no client attempt data present")
 		return

--- a/stats/opentelemetry/e2e_test.go
+++ b/stats/opentelemetry/e2e_test.go
@@ -2211,13 +2211,16 @@ func runDisconnectScenario(t *testing.T, name, wantLabel string, action func(*st
 func (s) TestRelayContextCollisionMetrics(t *testing.T) {
 	backendMetricsOpts, _ := defaultMetricsOptions(t, nil)
 	backendServer := setupStubServer(t, backendMetricsOpts, nil)
+	backendServer.EmptyCallF = func(_ context.Context, _ *testpb.Empty) (*testpb.Empty, error) {
+		return nil, status.Error(codes.Unimplemented, "EmptyCall not implemented")
+	}
 	defer backendServer.Stop()
 
 	relayMetricsOpts, relayMetricsReader := defaultMetricsOptions(t, nil)
 	otelOpts := opentelemetry.Options{MetricsOptions: *relayMetricsOpts}
 
 	relayServer := &stubserver.StubServer{
-		UnaryCallF: func(ctx context.Context, in *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
+		UnaryCallF: func(ctx context.Context, _ *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
 			relayCC, err := grpc.NewClient(
 				backendServer.Address,
 				grpc.WithTransportCredentials(insecure.NewCredentials()),
@@ -2227,7 +2230,8 @@ func (s) TestRelayContextCollisionMetrics(t *testing.T) {
 				return nil, fmt.Errorf("failed to create relay client: %v", err)
 			}
 			defer relayCC.Close()
-			err = relayCC.Invoke(ctx, "/grpc.testing.TestService/UnregisteredCall", in, &testpb.SimpleResponse{})
+			client := testpb.NewTestServiceClient(relayCC)
+			_, err = client.EmptyCall(ctx, &testpb.Empty{})
 			if status.Code(err) != codes.Unimplemented {
 				t.Errorf("Expected Unimplemented error, got: %v", err)
 			}
@@ -2251,8 +2255,8 @@ func (s) TestRelayContextCollisionMetrics(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Verify Client Metric Identity correctly resolved to "other".
-	if err := checkMetricWithMethod(ctx, relayMetricsReader, "grpc.client.attempt.started", "other"); err != nil {
+	// Verify Client Metric Identity correctly resolved to "grpc.testing.TestService/EmptyCall".
+	if err := checkMetricWithMethod(ctx, relayMetricsReader, "grpc.client.attempt.started", "grpc.testing.TestService/EmptyCall"); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -2264,13 +2268,16 @@ func (s) TestRelayContextCollisionMetrics(t *testing.T) {
 func (s) TestRelayContextCollisionTracing(t *testing.T) {
 	backendTraceOpts, _ := defaultTraceOptions(t)
 	backendServer := setupStubServer(t, nil, backendTraceOpts)
+	backendServer.EmptyCallF = func(_ context.Context, _ *testpb.Empty) (*testpb.Empty, error) {
+		return nil, status.Error(codes.Unimplemented, "EmptyCall not implemented")
+	}
 	defer backendServer.Stop()
 
 	relayTraceOpts, relayTraceExporter := defaultTraceOptions(t)
 	otelOpts := opentelemetry.Options{TraceOptions: *relayTraceOpts}
 
 	relayServer := &stubserver.StubServer{
-		UnaryCallF: func(ctx context.Context, in *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
+		UnaryCallF: func(ctx context.Context, _ *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
 			relayCC, err := grpc.NewClient(
 				backendServer.Address,
 				grpc.WithTransportCredentials(insecure.NewCredentials()),
@@ -2280,7 +2287,8 @@ func (s) TestRelayContextCollisionTracing(t *testing.T) {
 				return nil, fmt.Errorf("failed to create relay client: %v", err)
 			}
 			defer relayCC.Close()
-			err = relayCC.Invoke(ctx, "/grpc.testing.TestService/UnregisteredCall", in, &testpb.SimpleResponse{})
+			client := testpb.NewTestServiceClient(relayCC)
+			_, err = client.EmptyCall(ctx, &testpb.Empty{})
 			if status.Code(err) != codes.Unimplemented {
 				t.Errorf("Expected Unimplemented error, got: %v", err)
 			}
@@ -2299,7 +2307,7 @@ func (s) TestRelayContextCollisionTracing(t *testing.T) {
 
 	wantSpans := []traceSpanInfo{
 		{name: "Recv.", spanKind: "server"},
-		{name: "Sent.grpc.testing.TestService.UnregisteredCall", spanKind: "client"},
+		{name: "Sent.grpc.testing.TestService.EmptyCall", spanKind: "client"},
 	}
 	spans, err := waitForTraceSpans(ctx, relayTraceExporter, wantSpans)
 	if err != nil {
@@ -2311,7 +2319,7 @@ func (s) TestRelayContextCollisionTracing(t *testing.T) {
 		if span.Name == "Recv." && span.SpanKind == oteltrace.SpanKindServer {
 			srvTraceID = span.SpanContext.TraceID()
 		}
-		if span.Name == "Sent.grpc.testing.TestService.UnregisteredCall" && span.SpanKind == oteltrace.SpanKindClient {
+		if span.Name == "Sent.grpc.testing.TestService.EmptyCall" && span.SpanKind == oteltrace.SpanKindClient {
 			cliTraceID = span.SpanContext.TraceID()
 		}
 	}

--- a/stats/opentelemetry/e2e_test.go
+++ b/stats/opentelemetry/e2e_test.go
@@ -2246,11 +2246,15 @@ func (s) TestRelayContextCollisionMetrics(t *testing.T) {
 		t.Fatalf("Unexpected UnaryCall error: %v", err)
 	}
 
-	// Verify Server Metric Identity is retained
-	checkMetricWithMethod(ctx, t, relayMetricsReader, "grpc.server.call.started", "grpc.testing.TestService/UnaryCall")
+	// Verify Server Metric Identity is retained.
+	if err := checkMetricWithMethod(ctx, relayMetricsReader, "grpc.server.call.started", "grpc.testing.TestService/UnaryCall"); err != nil {
+		t.Fatal(err)
+	}
 
-	// Verify Client Metric Identity correctly resolved to "other"
-	checkMetricWithMethod(ctx, t, relayMetricsReader, "grpc.client.attempt.started", "other")
+	// Verify Client Metric Identity correctly resolved to "other".
+	if err := checkMetricWithMethod(ctx, relayMetricsReader, "grpc.client.attempt.started", "other"); err != nil {
+		t.Fatal(err)
+	}
 }
 
 // TestRelayContextCollisionTracing verifies that span context is correctly
@@ -2322,17 +2326,16 @@ func (s) TestRelayContextCollisionTracing(t *testing.T) {
 
 // checkMetricWithMethod verifies that a metric with the specified name contains
 // a data point matching the target grpc.method. It does not poll.
-func checkMetricWithMethod(ctx context.Context, t *testing.T, reader *metric.ManualReader, metricName, method string) {
-	t.Helper()
+func checkMetricWithMethod(ctx context.Context, reader *metric.ManualReader, metricName, method string) error {
 	metrics := metricsDataFromReader(ctx, reader)
 	if m, ok := metrics[metricName]; ok {
 		if sum, ok := m.Data.(metricdata.Sum[int64]); ok {
 			for _, dp := range sum.DataPoints {
 				if val, ok := dp.Attributes.Value("grpc.method"); ok && val.AsString() == method {
-					return // Found
+					return nil
 				}
 			}
 		}
 	}
-	t.Errorf("Metric %q with method %q not found", metricName, method)
+	return fmt.Errorf("metric %q with method %q not found", metricName, method)
 }

--- a/stats/opentelemetry/e2e_test.go
+++ b/stats/opentelemetry/e2e_test.go
@@ -2205,9 +2205,9 @@ func runDisconnectScenario(t *testing.T, name, wantLabel string, action func(*st
 	}
 }
 
-// TestRelayContextCollisionMetrics verifies that when an application acts as both a
-// server and a client using the same context, the client metrics do not inherit or
-// overwrite the server's telemetry metadata (e.g., grpc.method).
+// TestRelayContextCollisionMetrics verifies that when an application acts as
+// both a server and a client using the same context, the client metrics do not
+// inherit or overwrite the server's telemetry metadata (e.g., grpc.method).
 func (s) TestRelayContextCollisionMetrics(t *testing.T) {
 	moC, _ := defaultMetricsOptions(t, nil)
 	ssC := setupStubServer(t, moC, nil)
@@ -2248,15 +2248,17 @@ func (s) TestRelayContextCollisionMetrics(t *testing.T) {
 	}
 
 	// Verify Server Metric Identity is retained
-	waitForMetricDataPoint(ctx, t, readerB, "grpc.server.call.started", "grpc.testing.TestService/UnaryCall")
+	pollForMetricWithMethod(ctx, t, readerB, "grpc.server.call.started", "grpc.testing.TestService/UnaryCall")
 
-	// Verify Client Metric Identity correctly resolved to "other" (Proves collision is fixed)
-	waitForMetricDataPoint(ctx, t, readerB, "grpc.client.attempt.started", "other")
+	// Verify Client Metric Identity correctly resolved to "other" (Proves
+	// collision is fixed)
+	pollForMetricWithMethod(ctx, t, readerB, "grpc.client.attempt.started", "other")
 }
 
-// TestRelayContextCollisionTracing verifies that span context is correctly propagated
-// from incoming server requests to outgoing client requests without the client span
-// accidentally adopting the server's identity or breaking the trace chain.
+// TestRelayContextCollisionTracing verifies that span context is correctly
+// propagated from incoming server requests to outgoing client requests without
+// the client span accidentally adopting the server's identity or breaking the
+// trace chain.
 func (s) TestRelayContextCollisionTracing(t *testing.T) {
 	toC, _ := defaultTraceOptions(t)
 	ssC := setupStubServer(t, nil, toC)
@@ -2294,26 +2296,43 @@ func (s) TestRelayContextCollisionTracing(t *testing.T) {
 
 	_, _ = ssB.Client.UnaryCall(ctx, &testpb.SimpleRequest{})
 
-	// Retrieve trace IDs directly via the polling helper
-	srvTraceID := waitForSpanTraceID(ctx, t, exporterB, oteltrace.SpanKindServer, "Recv.")
-	cliTraceID := waitForSpanTraceID(ctx, t, exporterB, oteltrace.SpanKindClient, "Sent.grpc.testing.TestService.UnregisteredCall")
+	wantSpans := []traceSpanInfo{
+		{name: "Recv.", spanKind: "server"},
+		{name: "Sent.grpc.testing.TestService.UnregisteredCall", spanKind: "client"},
+	}
+	spans, err := waitForTraceSpans(ctx, exporterB, wantSpans)
+	if err != nil {
+		t.Fatalf("Failed to wait for spans: %v", err)
+	}
 
-	// Ensure the trace chain is unbroken
+	var srvTraceID, cliTraceID oteltrace.TraceID
+	for _, span := range spans {
+		if span.Name == "Recv." && span.SpanKind == oteltrace.SpanKindServer {
+			srvTraceID = span.SpanContext.TraceID()
+		}
+		if span.Name == "Sent.grpc.testing.TestService.UnregisteredCall" && span.SpanKind == oteltrace.SpanKindClient {
+			cliTraceID = span.SpanContext.TraceID()
+		}
+	}
+	if !srvTraceID.IsValid() || !cliTraceID.IsValid() {
+		t.Fatalf("Invalid trace IDs found. Server: %s, Client: %s", srvTraceID, cliTraceID)
+	}
+
 	if srvTraceID != cliTraceID {
 		t.Errorf("Trace continuity broken: Server TraceID %s != Client TraceID %s", srvTraceID, cliTraceID)
 	}
 }
 
-// waitForMetricDataPoint polls the metric reader until it finds a metric with the 
-// specified name that contains a data point matching the target grpc.method.
-func waitForMetricDataPoint(ctx context.Context, t *testing.T, reader metric.Reader, metricName, method string) metricdata.DataPoint[int64] {
+// pollForMetricWithMethod polls the metric reader until it finds a metric with
+// the specified name that contains a data point matching the target grpc.method.
+func pollForMetricWithMethod(ctx context.Context, t *testing.T, reader *metric.ManualReader, metricName, method string) metricdata.DataPoint[int64] {
 	t.Helper()
 	for {
 		if ctx.Err() != nil {
 			t.Fatalf("Timeout waiting for metric %q with method %q", metricName, method)
 		}
 
-		metrics := metricsDataFromReader(ctx, reader.(*metric.ManualReader))
+		metrics := metricsDataFromReader(ctx, reader)
 		if m, ok := metrics[metricName]; ok {
 			if sum, ok := m.Data.(metricdata.Sum[int64]); ok {
 				for _, dp := range sum.DataPoints {
@@ -2321,24 +2340,6 @@ func waitForMetricDataPoint(ctx context.Context, t *testing.T, reader metric.Rea
 						return dp
 					}
 				}
-			}
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-}
-
-// waitForSpanTraceID polls the span exporter until it finds a span of the 
-// specified kind that matches the target span name, returning its TraceID.
-func waitForSpanTraceID(ctx context.Context, t *testing.T, exporter *tracetest.InMemoryExporter, kind oteltrace.SpanKind, name string) oteltrace.TraceID {
-	t.Helper()
-	for {
-		if ctx.Err() != nil {
-			t.Fatalf("Timeout waiting for span kind %v with name %q", kind, name)
-		}
-
-		for _, span := range exporter.GetSpans() {
-			if span.SpanKind == kind && span.Name == name {
-				return span.SpanContext.TraceID()
 			}
 		}
 		time.Sleep(10 * time.Millisecond)

--- a/stats/opentelemetry/e2e_test.go
+++ b/stats/opentelemetry/e2e_test.go
@@ -2209,50 +2209,48 @@ func runDisconnectScenario(t *testing.T, name, wantLabel string, action func(*st
 // both a server and a client using the same context, the client metrics do not
 // inherit or overwrite the server's telemetry metadata (e.g., grpc.method).
 func (s) TestRelayContextCollisionMetrics(t *testing.T) {
-	moC, _ := defaultMetricsOptions(t, nil)
-	ssC := setupStubServer(t, moC, nil)
-	defer ssC.Stop()
+	backendMetricsOpts, _ := defaultMetricsOptions(t, nil)
+	backendServer := setupStubServer(t, backendMetricsOpts, nil)
+	defer backendServer.Stop()
 
-	moB, readerB := defaultMetricsOptions(t, nil)
-	otelOpts := opentelemetry.Options{MetricsOptions: *moB}
+	relayMetricsOpts, relayMetricsReader := defaultMetricsOptions(t, nil)
+	otelOpts := opentelemetry.Options{MetricsOptions: *relayMetricsOpts}
 
-	relayCC, err := grpc.NewClient(
-		ssC.Address,
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		opentelemetry.DialOption(otelOpts),
-	)
-	if err != nil {
-		t.Fatalf("Failed to create relay client: %v", err)
-	}
-	defer relayCC.Close()
-
-	ssB := &stubserver.StubServer{
+	relayServer := &stubserver.StubServer{
 		UnaryCallF: func(ctx context.Context, in *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
-			err := relayCC.Invoke(ctx, "/grpc.testing.TestService/UnregisteredCall", in, &testpb.SimpleResponse{})
+			relayCC, err := grpc.NewClient(
+				backendServer.Address,
+				grpc.WithTransportCredentials(insecure.NewCredentials()),
+				opentelemetry.DialOption(otelOpts),
+			)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create relay client: %v", err)
+			}
+			defer relayCC.Close()
+			err = relayCC.Invoke(ctx, "/grpc.testing.TestService/UnregisteredCall", in, &testpb.SimpleResponse{})
 			if status.Code(err) != codes.Unimplemented {
 				t.Errorf("Expected Unimplemented error, got: %v", err)
 			}
 			return &testpb.SimpleResponse{}, nil
 		},
 	}
-	if err := ssB.Start([]grpc.ServerOption{opentelemetry.ServerOption(otelOpts)}, opentelemetry.DialOption(otelOpts)); err != nil {
+	if err := relayServer.Start([]grpc.ServerOption{opentelemetry.ServerOption(otelOpts)}, opentelemetry.DialOption(otelOpts)); err != nil {
 		t.Fatalf("Failed to start relay server: %v", err)
 	}
-	defer ssB.Stop()
+	defer relayServer.Stop()
 
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
 
-	if _, err := ssB.Client.UnaryCall(ctx, &testpb.SimpleRequest{}); err != nil {
+	if _, err := relayServer.Client.UnaryCall(ctx, &testpb.SimpleRequest{}); err != nil {
 		t.Fatalf("Unexpected UnaryCall error: %v", err)
 	}
 
 	// Verify Server Metric Identity is retained
-	pollForMetricWithMethod(ctx, t, readerB, "grpc.server.call.started", "grpc.testing.TestService/UnaryCall")
+	checkMetricWithMethod(ctx, t, relayMetricsReader, "grpc.server.call.started", "grpc.testing.TestService/UnaryCall")
 
-	// Verify Client Metric Identity correctly resolved to "other" (Proves
-	// collision is fixed)
-	pollForMetricWithMethod(ctx, t, readerB, "grpc.client.attempt.started", "other")
+	// Verify Client Metric Identity correctly resolved to "other"
+	checkMetricWithMethod(ctx, t, relayMetricsReader, "grpc.client.attempt.started", "other")
 }
 
 // TestRelayContextCollisionTracing verifies that span context is correctly
@@ -2260,47 +2258,46 @@ func (s) TestRelayContextCollisionMetrics(t *testing.T) {
 // the client span accidentally adopting the server's identity or breaking the
 // trace chain.
 func (s) TestRelayContextCollisionTracing(t *testing.T) {
-	toC, _ := defaultTraceOptions(t)
-	ssC := setupStubServer(t, nil, toC)
-	defer ssC.Stop()
+	backendTraceOpts, _ := defaultTraceOptions(t)
+	backendServer := setupStubServer(t, nil, backendTraceOpts)
+	defer backendServer.Stop()
 
-	toB, exporterB := defaultTraceOptions(t)
-	otelOpts := opentelemetry.Options{TraceOptions: *toB}
+	relayTraceOpts, relayTraceExporter := defaultTraceOptions(t)
+	otelOpts := opentelemetry.Options{TraceOptions: *relayTraceOpts}
 
-	relayCC, err := grpc.NewClient(
-		ssC.Address,
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		opentelemetry.DialOption(otelOpts),
-	)
-	if err != nil {
-		t.Fatalf("Failed to create relay client: %v", err)
-	}
-	defer relayCC.Close()
-
-	ssB := &stubserver.StubServer{
+	relayServer := &stubserver.StubServer{
 		UnaryCallF: func(ctx context.Context, in *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
-			err := relayCC.Invoke(ctx, "/grpc.testing.TestService/UnregisteredCall", in, &testpb.SimpleResponse{})
+			relayCC, err := grpc.NewClient(
+				backendServer.Address,
+				grpc.WithTransportCredentials(insecure.NewCredentials()),
+				opentelemetry.DialOption(otelOpts),
+			)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create relay client: %v", err)
+			}
+			defer relayCC.Close()
+			err = relayCC.Invoke(ctx, "/grpc.testing.TestService/UnregisteredCall", in, &testpb.SimpleResponse{})
 			if status.Code(err) != codes.Unimplemented {
 				t.Errorf("Expected Unimplemented error, got: %v", err)
 			}
 			return &testpb.SimpleResponse{}, nil
 		},
 	}
-	if err := ssB.Start([]grpc.ServerOption{opentelemetry.ServerOption(otelOpts)}, opentelemetry.DialOption(otelOpts)); err != nil {
+	if err := relayServer.Start([]grpc.ServerOption{opentelemetry.ServerOption(otelOpts)}, opentelemetry.DialOption(otelOpts)); err != nil {
 		t.Fatalf("Failed to start relay server: %v", err)
 	}
-	defer ssB.Stop()
+	defer relayServer.Stop()
 
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
 
-	_, _ = ssB.Client.UnaryCall(ctx, &testpb.SimpleRequest{})
+	_, _ = relayServer.Client.UnaryCall(ctx, &testpb.SimpleRequest{})
 
 	wantSpans := []traceSpanInfo{
 		{name: "Recv.", spanKind: "server"},
 		{name: "Sent.grpc.testing.TestService.UnregisteredCall", spanKind: "client"},
 	}
-	spans, err := waitForTraceSpans(ctx, exporterB, wantSpans)
+	spans, err := waitForTraceSpans(ctx, relayTraceExporter, wantSpans)
 	if err != nil {
 		t.Fatalf("Failed to wait for spans: %v", err)
 	}
@@ -2323,25 +2320,19 @@ func (s) TestRelayContextCollisionTracing(t *testing.T) {
 	}
 }
 
-// pollForMetricWithMethod polls the metric reader until it finds a metric with
-// the specified name that contains a data point matching the target grpc.method.
-func pollForMetricWithMethod(ctx context.Context, t *testing.T, reader *metric.ManualReader, metricName, method string) metricdata.DataPoint[int64] {
+// checkMetricWithMethod verifies that a metric with the specified name contains
+// a data point matching the target grpc.method. It does not poll.
+func checkMetricWithMethod(ctx context.Context, t *testing.T, reader *metric.ManualReader, metricName, method string) {
 	t.Helper()
-	for {
-		if ctx.Err() != nil {
-			t.Fatalf("Timeout waiting for metric %q with method %q", metricName, method)
-		}
-
-		metrics := metricsDataFromReader(ctx, reader)
-		if m, ok := metrics[metricName]; ok {
-			if sum, ok := m.Data.(metricdata.Sum[int64]); ok {
-				for _, dp := range sum.DataPoints {
-					if val, ok := dp.Attributes.Value("grpc.method"); ok && val.AsString() == method {
-						return dp
-					}
+	metrics := metricsDataFromReader(ctx, reader)
+	if m, ok := metrics[metricName]; ok {
+		if sum, ok := m.Data.(metricdata.Sum[int64]); ok {
+			for _, dp := range sum.DataPoints {
+				if val, ok := dp.Attributes.Value("grpc.method"); ok && val.AsString() == method {
+					return // Found
 				}
 			}
 		}
-		time.Sleep(10 * time.Millisecond)
 	}
+	t.Errorf("Metric %q with method %q not found", metricName, method)
 }

--- a/stats/opentelemetry/e2e_test.go
+++ b/stats/opentelemetry/e2e_test.go
@@ -2205,21 +2205,21 @@ func runDisconnectScenario(t *testing.T, name, wantLabel string, action func(*st
 	}
 }
 
-// TestRelayContextCollision verifies that context used to set RPC info in
-// opentelemetry doesn't cause overwriting when application acts as both
-// server and client.
-func (s) TestRelayContextCollision(t *testing.T) {
-	moC, readerC := defaultMetricsOptions(t, nil)
+// TestRelayContextCollisionMetrics verifies that when an application acts as both a
+// server and a client using the same context, the client metrics do not inherit or
+// overwrite the server's telemetry metadata (e.g., grpc.method).
+func (s) TestRelayContextCollisionMetrics(t *testing.T) {
+	moC, _ := defaultMetricsOptions(t, nil)
 	ssC := setupStubServer(t, moC, nil)
 	defer ssC.Stop()
 
 	moB, readerB := defaultMetricsOptions(t, nil)
-	otelOptions := opentelemetry.Options{MetricsOptions: *moB}
+	otelOpts := opentelemetry.Options{MetricsOptions: *moB}
 
 	relayCC, err := grpc.NewClient(
 		ssC.Address,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		opentelemetry.DialOption(otelOptions),
+		opentelemetry.DialOption(otelOpts),
 	)
 	if err != nil {
 		t.Fatalf("Failed to create relay client: %v", err)
@@ -2228,107 +2228,119 @@ func (s) TestRelayContextCollision(t *testing.T) {
 
 	ssB := &stubserver.StubServer{
 		UnaryCallF: func(ctx context.Context, in *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
-			time.Sleep(50 * time.Millisecond)
-
 			err := relayCC.Invoke(ctx, "/grpc.testing.TestService/UnregisteredCall", in, &testpb.SimpleResponse{})
-			if err == nil {
-				t.Error("Expected an error from UnregisteredCall")
+			if status.Code(err) != codes.Unimplemented {
+				t.Errorf("Expected Unimplemented error, got: %v", err)
 			}
 			return &testpb.SimpleResponse{}, nil
 		},
 	}
-
-	if err := ssB.Start(
-		[]grpc.ServerOption{opentelemetry.ServerOption(otelOptions)},
-		opentelemetry.DialOption(otelOptions),
-	); err != nil {
-		t.Fatalf("Error starting relay server: %v", err)
+	if err := ssB.Start([]grpc.ServerOption{opentelemetry.ServerOption(otelOpts)}, opentelemetry.DialOption(otelOpts)); err != nil {
+		t.Fatalf("Failed to start relay server: %v", err)
 	}
 	defer ssB.Stop()
 
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
 
-	if _, err := ssB.Client.UnaryCall(ctx, &testpb.SimpleRequest{Payload: &testpb.Payload{Body: []byte("hello")}}); err != nil {
-		t.Fatalf("Unexpected error from UnaryCall: %v", err)
+	if _, err := ssB.Client.UnaryCall(ctx, &testpb.SimpleRequest{}); err != nil {
+		t.Fatalf("Unexpected UnaryCall error: %v", err)
 	}
 
-	rmB := &metricdata.ResourceMetrics{}
-	if err := readerB.Collect(ctx, rmB); err != nil {
-		t.Fatalf("Failed to collect metrics from readerB: %v", err)
+	// Verify Server Metric Identity is retained
+	waitForMetricDataPoint(ctx, t, readerB, "grpc.server.call.started", "grpc.testing.TestService/UnaryCall")
+
+	// Verify Client Metric Identity correctly resolved to "other" (Proves collision is fixed)
+	waitForMetricDataPoint(ctx, t, readerB, "grpc.client.attempt.started", "other")
+}
+
+// TestRelayContextCollisionTracing verifies that span context is correctly propagated
+// from incoming server requests to outgoing client requests without the client span
+// accidentally adopting the server's identity or breaking the trace chain.
+func (s) TestRelayContextCollisionTracing(t *testing.T) {
+	toC, _ := defaultTraceOptions(t)
+	ssC := setupStubServer(t, nil, toC)
+	defer ssC.Stop()
+
+	toB, exporterB := defaultTraceOptions(t)
+	otelOpts := opentelemetry.Options{TraceOptions: *toB}
+
+	relayCC, err := grpc.NewClient(
+		ssC.Address,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		opentelemetry.DialOption(otelOpts),
+	)
+	if err != nil {
+		t.Fatalf("Failed to create relay client: %v", err)
 	}
+	defer relayCC.Close()
 
-	var gotServerStartedB, gotClientStartedB bool
-
-	for _, sm := range rmB.ScopeMetrics {
-		for _, m := range sm.Metrics {
-			sum, ok := m.Data.(metricdata.Sum[int64])
-			if !ok {
-				continue
+	ssB := &stubserver.StubServer{
+		UnaryCallF: func(ctx context.Context, in *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
+			err := relayCC.Invoke(ctx, "/grpc.testing.TestService/UnregisteredCall", in, &testpb.SimpleResponse{})
+			if status.Code(err) != codes.Unimplemented {
+				t.Errorf("Expected Unimplemented error, got: %v", err)
 			}
+			return &testpb.SimpleResponse{}, nil
+		},
+	}
+	if err := ssB.Start([]grpc.ServerOption{opentelemetry.ServerOption(otelOpts)}, opentelemetry.DialOption(otelOpts)); err != nil {
+		t.Fatalf("Failed to start relay server: %v", err)
+	}
+	defer ssB.Stop()
 
-			switch m.Name {
-			case "grpc.server.call.started":
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+
+	_, _ = ssB.Client.UnaryCall(ctx, &testpb.SimpleRequest{})
+
+	// Retrieve trace IDs directly via the polling helper
+	srvTraceID := waitForSpanTraceID(ctx, t, exporterB, oteltrace.SpanKindServer, "Recv.")
+	cliTraceID := waitForSpanTraceID(ctx, t, exporterB, oteltrace.SpanKindClient, "Sent.grpc.testing.TestService.UnregisteredCall")
+
+	// Ensure the trace chain is unbroken
+	if srvTraceID != cliTraceID {
+		t.Errorf("Trace continuity broken: Server TraceID %s != Client TraceID %s", srvTraceID, cliTraceID)
+	}
+}
+
+// waitForMetricDataPoint polls the metric reader until it finds a metric with the 
+// specified name that contains a data point matching the target grpc.method.
+func waitForMetricDataPoint(ctx context.Context, t *testing.T, reader metric.Reader, metricName, method string) metricdata.DataPoint[int64] {
+	t.Helper()
+	for {
+		if ctx.Err() != nil {
+			t.Fatalf("Timeout waiting for metric %q with method %q", metricName, method)
+		}
+
+		metrics := metricsDataFromReader(ctx, reader.(*metric.ManualReader))
+		if m, ok := metrics[metricName]; ok {
+			if sum, ok := m.Data.(metricdata.Sum[int64]); ok {
 				for _, dp := range sum.DataPoints {
-					gotServerStartedB = true
-					if val, ok := dp.Attributes.Value("grpc.method"); ok && val.AsString() != "grpc.testing.TestService/UnaryCall" {
-						t.Errorf("Expected Server B server metric 'grpc.testing.TestService/UnaryCall', got '%s'", val.AsString())
-					}
-				}
-			case "grpc.client.attempt.started":
-				for _, dp := range sum.DataPoints {
-					val, ok := dp.Attributes.Value("grpc.method")
-					if !ok {
-						continue
-					}
-
-					// Ignore the test framework's initial outbound call to Server B
-					if val.AsString() == "grpc.testing.TestService/UnaryCall" {
-						continue
-					}
-
-					gotClientStartedB = true
-					if val.AsString() != "other" {
-						t.Errorf("Expected Server B client metric 'other', got '%s'", val.AsString())
+					if val, ok := dp.Attributes.Value("grpc.method"); ok && val.AsString() == method {
+						return dp
 					}
 				}
 			}
 		}
+		time.Sleep(10 * time.Millisecond)
 	}
+}
 
-	if !gotServerStartedB {
-		t.Error("Missing metric: grpc.server.call.started on Server B")
-	}
-	if !gotClientStartedB {
-		t.Error("Missing metric: grpc.client.attempt.started on Server B")
-	}
+// waitForSpanTraceID polls the span exporter until it finds a span of the 
+// specified kind that matches the target span name, returning its TraceID.
+func waitForSpanTraceID(ctx context.Context, t *testing.T, exporter *tracetest.InMemoryExporter, kind oteltrace.SpanKind, name string) oteltrace.TraceID {
+	t.Helper()
+	for {
+		if ctx.Err() != nil {
+			t.Fatalf("Timeout waiting for span kind %v with name %q", kind, name)
+		}
 
-	rmC := &metricdata.ResourceMetrics{}
-	if err := readerC.Collect(ctx, rmC); err != nil {
-		t.Fatalf("Failed to collect metrics from readerC: %v", err)
-	}
-
-	var gotServerStartedC bool
-
-	for _, sm := range rmC.ScopeMetrics {
-		for _, m := range sm.Metrics {
-			sum, ok := m.Data.(metricdata.Sum[int64])
-			if !ok {
-				continue
-			}
-
-			if m.Name == "grpc.server.call.started" {
-				for _, dp := range sum.DataPoints {
-					gotServerStartedC = true
-					if val, ok := dp.Attributes.Value("grpc.method"); ok && val.AsString() != "other" {
-						t.Errorf("Expected Server C server metric 'other', got '%s'", val.AsString())
-					}
-				}
+		for _, span := range exporter.GetSpans() {
+			if span.SpanKind == kind && span.Name == name {
+				return span.SpanContext.TraceID()
 			}
 		}
-	}
-
-	if !gotServerStartedC {
-		t.Error("Missing metric: grpc.server.call.started on Server C")
+		time.Sleep(10 * time.Millisecond)
 	}
 }

--- a/stats/opentelemetry/e2e_test.go
+++ b/stats/opentelemetry/e2e_test.go
@@ -2204,3 +2204,131 @@ func runDisconnectScenario(t *testing.T, name, wantLabel string, action func(*st
 		t.Fatalf("Metric verification failed for case %s: %v", name, err)
 	}
 }
+
+// TestRelayContextCollision verifies that context used to set RPC info in
+// opentelemetry doesn't cause overwriting when application acts as both
+// server and client.
+func (s) TestRelayContextCollision(t *testing.T) {
+	moC, readerC := defaultMetricsOptions(t, nil)
+	ssC := setupStubServer(t, moC, nil)
+	defer ssC.Stop()
+
+	moB, readerB := defaultMetricsOptions(t, nil)
+	otelOptions := opentelemetry.Options{MetricsOptions: *moB}
+
+	relayCC, err := grpc.NewClient(
+		ssC.Address,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		opentelemetry.DialOption(otelOptions),
+	)
+	if err != nil {
+		t.Fatalf("Failed to create relay client: %v", err)
+	}
+	defer relayCC.Close()
+
+	ssB := &stubserver.StubServer{
+		UnaryCallF: func(ctx context.Context, in *testpb.SimpleRequest) (*testpb.SimpleResponse, error) {
+			time.Sleep(50 * time.Millisecond)
+
+			err := relayCC.Invoke(ctx, "/grpc.testing.TestService/UnregisteredCall", in, &testpb.SimpleResponse{})
+			if err == nil {
+				t.Error("Expected an error from UnregisteredCall")
+			}
+			return &testpb.SimpleResponse{}, nil
+		},
+	}
+
+	if err := ssB.Start(
+		[]grpc.ServerOption{opentelemetry.ServerOption(otelOptions)},
+		opentelemetry.DialOption(otelOptions),
+	); err != nil {
+		t.Fatalf("Error starting relay server: %v", err)
+	}
+	defer ssB.Stop()
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+
+	if _, err := ssB.Client.UnaryCall(ctx, &testpb.SimpleRequest{Payload: &testpb.Payload{Body: []byte("hello")}}); err != nil {
+		t.Fatalf("Unexpected error from UnaryCall: %v", err)
+	}
+
+	rmB := &metricdata.ResourceMetrics{}
+	if err := readerB.Collect(ctx, rmB); err != nil {
+		t.Fatalf("Failed to collect metrics from readerB: %v", err)
+	}
+
+	var gotServerStartedB, gotClientStartedB bool
+
+	for _, sm := range rmB.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			sum, ok := m.Data.(metricdata.Sum[int64])
+			if !ok {
+				continue
+			}
+
+			switch m.Name {
+			case "grpc.server.call.started":
+				for _, dp := range sum.DataPoints {
+					gotServerStartedB = true
+					if val, ok := dp.Attributes.Value("grpc.method"); ok && val.AsString() != "grpc.testing.TestService/UnaryCall" {
+						t.Errorf("Expected Server B server metric 'grpc.testing.TestService/UnaryCall', got '%s'", val.AsString())
+					}
+				}
+			case "grpc.client.attempt.started":
+				for _, dp := range sum.DataPoints {
+					val, ok := dp.Attributes.Value("grpc.method")
+					if !ok {
+						continue
+					}
+
+					// Ignore the test framework's initial outbound call to Server B
+					if val.AsString() == "grpc.testing.TestService/UnaryCall" {
+						continue
+					}
+
+					gotClientStartedB = true
+					if val.AsString() != "other" {
+						t.Errorf("Expected Server B client metric 'other', got '%s'", val.AsString())
+					}
+				}
+			}
+		}
+	}
+
+	if !gotServerStartedB {
+		t.Error("Missing metric: grpc.server.call.started on Server B")
+	}
+	if !gotClientStartedB {
+		t.Error("Missing metric: grpc.client.attempt.started on Server B")
+	}
+
+	rmC := &metricdata.ResourceMetrics{}
+	if err := readerC.Collect(ctx, rmC); err != nil {
+		t.Fatalf("Failed to collect metrics from readerC: %v", err)
+	}
+
+	var gotServerStartedC bool
+
+	for _, sm := range rmC.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			sum, ok := m.Data.(metricdata.Sum[int64])
+			if !ok {
+				continue
+			}
+
+			if m.Name == "grpc.server.call.started" {
+				for _, dp := range sum.DataPoints {
+					gotServerStartedC = true
+					if val, ok := dp.Attributes.Value("grpc.method"); ok && val.AsString() != "other" {
+						t.Errorf("Expected Server C server metric 'other', got '%s'", val.AsString())
+					}
+				}
+			}
+		}
+	}
+
+	if !gotServerStartedC {
+		t.Error("Missing metric: grpc.server.call.started on Server C")
+	}
+}

--- a/stats/opentelemetry/opentelemetry.go
+++ b/stats/opentelemetry/opentelemetry.go
@@ -181,16 +181,16 @@ type callInfo struct {
 	nameResolutionEventAdded atomic.Bool
 }
 
-type callInfoKey struct{}
+type clientCallInfoKey struct{}
 
 func setCallInfo(ctx context.Context, ci *callInfo) context.Context {
-	return context.WithValue(ctx, callInfoKey{}, ci)
+	return context.WithValue(ctx, clientCallInfoKey{}, ci)
 }
 
 // getCallInfo returns the callInfo stored in the context, or nil
 // if there isn't one.
 func getCallInfo(ctx context.Context) *callInfo {
-	ci, _ := ctx.Value(callInfoKey{}).(*callInfo)
+	ci, _ := ctx.Value(clientCallInfoKey{}).(*callInfo)
 	return ci
 }
 
@@ -200,17 +200,47 @@ type rpcInfo struct {
 	ai *attemptInfo
 }
 
-type rpcInfoKey struct{}
+type clientRPCInfoKey struct{}
+type serverRPCInfoKey struct{}
 
-func setRPCInfo(ctx context.Context, ri *rpcInfo) context.Context {
-	return context.WithValue(ctx, rpcInfoKey{}, ri)
+func setClientRPCInfo(ctx context.Context, ri *rpcInfo) context.Context {
+	return context.WithValue(ctx, clientRPCInfoKey{}, ri)
 }
 
-// getRPCInfo returns the rpcInfo stored in the context, or nil
+// getClientRPCInfo returns the rpcInfo stored in the context for client, or nil
 // if there isn't one.
-func getRPCInfo(ctx context.Context) *rpcInfo {
-	ri, _ := ctx.Value(rpcInfoKey{}).(*rpcInfo)
+func getClientRPCInfo(ctx context.Context) *rpcInfo {
+	ri, _ := ctx.Value(clientRPCInfoKey{}).(*rpcInfo)
 	return ri
+}
+
+func setServerRPCInfo(ctx context.Context, ri *rpcInfo) context.Context {
+	return context.WithValue(ctx, serverRPCInfoKey{}, ri)
+}
+
+// getServerRPCInfo returns the rpcInfo stored in the context for server, or nil
+// if there isn't one.
+func getServerRPCInfo(ctx context.Context) *rpcInfo {
+	ri, _ := ctx.Value(serverRPCInfoKey{}).(*rpcInfo)
+	return ri
+}
+
+func getOrCreateClientRPCAttemptInfo(ctx context.Context) (context.Context, *attemptInfo) {
+	ri := getClientRPCInfo(ctx)
+	if ri != nil {
+		return ctx, ri.ai
+	}
+	ri = &rpcInfo{ai: &attemptInfo{}}
+	return setClientRPCInfo(ctx, ri), ri.ai
+}
+
+func getOrCreateServerRPCAttemptInfo(ctx context.Context) (context.Context, *attemptInfo) {
+	ri := getServerRPCInfo(ctx)
+	if ri != nil {
+		return ctx, ri.ai
+	}
+	ri = &rpcInfo{ai: &attemptInfo{}}
+	return setServerRPCInfo(ctx, ri), ri.ai
 }
 
 func removeLeadingSlash(mn string) string {

--- a/stats/opentelemetry/opentelemetry.go
+++ b/stats/opentelemetry/opentelemetry.go
@@ -181,16 +181,12 @@ type callInfo struct {
 	nameResolutionEventAdded atomic.Bool
 }
 
-type clientCallInfoKey struct{}
-
-func setCallInfo(ctx context.Context, ci *callInfo) context.Context {
-	return context.WithValue(ctx, clientCallInfoKey{}, ci)
-}
+type callInfoKey struct{}
 
 // getCallInfo returns the callInfo stored in the context, or nil
 // if there isn't one.
 func getCallInfo(ctx context.Context) *callInfo {
-	ci, _ := ctx.Value(clientCallInfoKey{}).(*callInfo)
+	ci, _ := ctx.Value(callInfoKey{}).(*callInfo)
 	return ci
 }
 
@@ -203,44 +199,36 @@ type rpcInfo struct {
 type clientRPCInfoKey struct{}
 type serverRPCInfoKey struct{}
 
-func setClientRPCInfo(ctx context.Context, ri *rpcInfo) context.Context {
-	return context.WithValue(ctx, clientRPCInfoKey{}, ri)
-}
-
-// getClientRPCInfo returns the rpcInfo stored in the context for client, or nil
+// clientRPCInfo returns the rpcInfo stored in the context for client, or nil
 // if there isn't one.
-func getClientRPCInfo(ctx context.Context) *rpcInfo {
+func clientRPCInfo(ctx context.Context) *rpcInfo {
 	ri, _ := ctx.Value(clientRPCInfoKey{}).(*rpcInfo)
 	return ri
 }
 
-func setServerRPCInfo(ctx context.Context, ri *rpcInfo) context.Context {
-	return context.WithValue(ctx, serverRPCInfoKey{}, ri)
-}
-
-// getServerRPCInfo returns the rpcInfo stored in the context for server, or nil
+// serverRPCInfo returns the rpcInfo stored in the context for server, or nil
 // if there isn't one.
-func getServerRPCInfo(ctx context.Context) *rpcInfo {
+func serverRPCInfo(ctx context.Context) *rpcInfo {
 	ri, _ := ctx.Value(serverRPCInfoKey{}).(*rpcInfo)
 	return ri
 }
 
-func getOrCreateClientRPCAttemptInfo(ctx context.Context) (context.Context, *attemptInfo) {
-	ri := getClientRPCInfo(ctx)
+func getOrCreateClientRPCInfo(ctx context.Context) (context.Context, *rpcInfo) {
+	ri := clientRPCInfo(ctx)
 	if ri != nil {
-		return ctx, ri.ai
+		return ctx, ri
 	}
 	ri = &rpcInfo{ai: &attemptInfo{}}
-	return setClientRPCInfo(ctx, ri), ri.ai
+	return context.WithValue(ctx, clientRPCInfoKey{}, ri), ri
 }
 
-func getOrCreateServerRPCAttemptInfo(ctx context.Context) (context.Context, *attemptInfo) {
-	ri := getServerRPCInfo(ctx)
+func getOrCreateServerRPCInfo(ctx context.Context) (context.Context, *rpcInfo) {
+	ri := serverRPCInfo(ctx)
 	if ri != nil {
-		return ctx, ri.ai
+		return ctx, ri
 	}
 	ri = &rpcInfo{ai: &attemptInfo{}}
-	return setServerRPCInfo(ctx, ri), ri.ai
+	return context.WithValue(ctx, serverRPCInfoKey{}, ri), ri
 }
 
 func removeLeadingSlash(mn string) string {

--- a/stats/opentelemetry/server_metrics.go
+++ b/stats/opentelemetry/server_metrics.go
@@ -196,7 +196,8 @@ func (h *serverMetricsHandler) TagRPC(ctx context.Context, info *stats.RPCTagInf
 			method = "other"
 		}
 	}
-	ctx, ai := getOrCreateServerRPCAttemptInfo(ctx)
+	ctx, ri := getOrCreateServerRPCInfo(ctx)
+	ai := ri.ai
 	ai.startTime = time.Now()
 	ai.method = removeLeadingSlash(method)
 
@@ -205,7 +206,7 @@ func (h *serverMetricsHandler) TagRPC(ctx context.Context, info *stats.RPCTagInf
 
 // HandleRPC handles per RPC stats implementation.
 func (h *serverMetricsHandler) HandleRPC(ctx context.Context, rs stats.RPCStats) {
-	ri := getServerRPCInfo(ctx)
+	ri := serverRPCInfo(ctx)
 	if ri == nil {
 		logger.Error("ctx passed into server side stats handler metrics event handling has no server call data present")
 		return

--- a/stats/opentelemetry/server_metrics.go
+++ b/stats/opentelemetry/server_metrics.go
@@ -196,16 +196,16 @@ func (h *serverMetricsHandler) TagRPC(ctx context.Context, info *stats.RPCTagInf
 			method = "other"
 		}
 	}
-	ctx, ai := getOrCreateRPCAttemptInfo(ctx)
+	ctx, ai := getOrCreateServerRPCAttemptInfo(ctx)
 	ai.startTime = time.Now()
 	ai.method = removeLeadingSlash(method)
 
-	return setRPCInfo(ctx, &rpcInfo{ai: ai})
+	return setServerRPCInfo(ctx, &rpcInfo{ai: ai})
 }
 
 // HandleRPC handles per RPC stats implementation.
 func (h *serverMetricsHandler) HandleRPC(ctx context.Context, rs stats.RPCStats) {
-	ri := getRPCInfo(ctx)
+	ri := getServerRPCInfo(ctx)
 	if ri == nil {
 		logger.Error("ctx passed into server side stats handler metrics event handling has no server call data present")
 		return

--- a/stats/opentelemetry/server_metrics.go
+++ b/stats/opentelemetry/server_metrics.go
@@ -200,7 +200,7 @@ func (h *serverMetricsHandler) TagRPC(ctx context.Context, info *stats.RPCTagInf
 	ai.startTime = time.Now()
 	ai.method = removeLeadingSlash(method)
 
-	return setServerRPCInfo(ctx, &rpcInfo{ai: ai})
+	return ctx
 }
 
 // HandleRPC handles per RPC stats implementation.

--- a/stats/opentelemetry/server_tracing.go
+++ b/stats/opentelemetry/server_tracing.go
@@ -40,8 +40,8 @@ func (h *serverTracingHandler) initializeTraces() {
 
 // TagRPC implements per RPC attempt context management for traces.
 func (h *serverTracingHandler) TagRPC(ctx context.Context, _ *stats.RPCTagInfo) context.Context {
-	ctx, ai := getOrCreateServerRPCAttemptInfo(ctx)
-	ctx, _ = h.traceTagRPC(ctx, ai)
+	ctx, ri := getOrCreateServerRPCInfo(ctx)
+	ctx, _ = h.traceTagRPC(ctx, ri.ai)
 	return ctx
 }
 
@@ -67,7 +67,7 @@ func (h *serverTracingHandler) traceTagRPC(ctx context.Context, ai *attemptInfo)
 
 // HandleRPC handles per RPC tracing implementation.
 func (h *serverTracingHandler) HandleRPC(ctx context.Context, rs stats.RPCStats) {
-	ri := getServerRPCInfo(ctx)
+	ri := serverRPCInfo(ctx)
 	if ri == nil {
 		logger.Error("ctx passed into server side tracing handler trace event handling has no server call data present")
 		return

--- a/stats/opentelemetry/server_tracing.go
+++ b/stats/opentelemetry/server_tracing.go
@@ -40,9 +40,9 @@ func (h *serverTracingHandler) initializeTraces() {
 
 // TagRPC implements per RPC attempt context management for traces.
 func (h *serverTracingHandler) TagRPC(ctx context.Context, _ *stats.RPCTagInfo) context.Context {
-	ctx, ai := getOrCreateRPCAttemptInfo(ctx)
+	ctx, ai := getOrCreateServerRPCAttemptInfo(ctx)
 	ctx, ai = h.traceTagRPC(ctx, ai)
-	return setRPCInfo(ctx, &rpcInfo{ai: ai})
+	return setServerRPCInfo(ctx, &rpcInfo{ai: ai})
 }
 
 // traceTagRPC populates context with new span data using the TextMapPropagator
@@ -67,7 +67,7 @@ func (h *serverTracingHandler) traceTagRPC(ctx context.Context, ai *attemptInfo)
 
 // HandleRPC handles per RPC tracing implementation.
 func (h *serverTracingHandler) HandleRPC(ctx context.Context, rs stats.RPCStats) {
-	ri := getRPCInfo(ctx)
+	ri := getServerRPCInfo(ctx)
 	if ri == nil {
 		logger.Error("ctx passed into server side tracing handler trace event handling has no server call data present")
 		return

--- a/stats/opentelemetry/server_tracing.go
+++ b/stats/opentelemetry/server_tracing.go
@@ -41,8 +41,8 @@ func (h *serverTracingHandler) initializeTraces() {
 // TagRPC implements per RPC attempt context management for traces.
 func (h *serverTracingHandler) TagRPC(ctx context.Context, _ *stats.RPCTagInfo) context.Context {
 	ctx, ai := getOrCreateServerRPCAttemptInfo(ctx)
-	ctx, ai = h.traceTagRPC(ctx, ai)
-	return setServerRPCInfo(ctx, &rpcInfo{ai: ai})
+	ctx, _ = h.traceTagRPC(ctx, ai)
+	return ctx
 }
 
 // traceTagRPC populates context with new span data using the TextMapPropagator


### PR DESCRIPTION
Fixes #9053 
Client and Server metrics and traces handling code during RPC was using the same RPCInfo. This lead to overwriting of context when an application was acting as server and then initiating other grpc call as a client. This PR segregates the rpcInfoKey context key into clientRPCInfoKey and serverRPCInfoKey so that it is not reused/overwritten between server and client code.

RELEASE NOTES:
* otel: Segregate client and server RPCInfo used for metrics and traces.
