### PR TITLE
test/bufconn: Close connections when listener is closed

### DIFF
--- a/test/bufconn/bufconn.go
+++ b/test/bufconn/bufconn.go
@@ -32,10 +32,11 @@ import (
 // Listener implements a net.Listener that creates local, buffered net.Conns
 // via its Accept and Dial method.
 type Listener struct {
-	mu   sync.Mutex
-	sz   int
-	ch   chan net.Conn
-	done chan struct{}
+	mu    sync.Mutex
+	sz    int
+	ch    chan net.Conn
+	done  chan struct{}
+	conns []*conn
 }
 
 // Implementation of net.Error providing timeout
@@ -66,7 +67,7 @@ func (l *Listener) Accept() (net.Conn, error) {
 	}
 }
 
-// Close stops the listener.
+// Close stops the listener and closes all connections that were created by it.
 func (l *Listener) Close() error {
 	l.mu.Lock()
 	defer l.mu.Unlock()
@@ -76,7 +77,28 @@ func (l *Listener) Close() error {
 	default:
 		close(l.done)
 	}
+	for _, c := range l.conns {
+		c.Close()
+	}
+	l.conns = nil
 	return nil
+}
+
+func (l *Listener) trackConn(c *conn) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.conns = append(l.conns, c)
+}
+
+func (l *Listener) untrackConn(c *conn) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	for i, conn := range l.conns {
+		if conn == c {
+			l.conns = append(l.conns[:i], l.conns[i+1:]...)
+			return
+		}
+	}
 }
 
 // Addr reports the address of the listener.
@@ -94,12 +116,21 @@ func (l *Listener) Dial() (net.Conn, error) {
 // of the connection.  If ctx is Done, returns ctx.Err()
 func (l *Listener) DialContext(ctx context.Context) (net.Conn, error) {
 	p1, p2 := newPipe(l.sz), newPipe(l.sz)
+	s := &conn{p1, p2}
+	// Track the server half so it will be closed when the listener is closed.
+	// Tracking before the select ensures there is no race between DialContext
+	// and Close: Close always sees every conn in l.conns.
+	l.trackConn(s)
 	select {
 	case <-ctx.Done():
+		// The connection was never handed to Accept, so clean it up to
+		// avoid leaking an unused entry in l.conns.
+		l.untrackConn(s)
 		return nil, ctx.Err()
 	case <-l.done:
+		// No need to untrack; Close will close all tracked conns.
 		return nil, errClosed
-	case l.ch <- &conn{p1, p2}:
+	case l.ch <- s:
 		return &conn{p2, p1}, nil
 	}
 }

--- a/test/bufconn/bufconn_test.go
+++ b/test/bufconn/bufconn_test.go
@@ -19,6 +19,7 @@
 package bufconn
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net"
@@ -205,6 +206,77 @@ func (s) TestCloseWhileAccepting(t *testing.T) {
 	<-done
 	if c != nil || err != errClosed {
 		t.Fatalf("c, err = %v, %v; want nil, %v", c, err, errClosed)
+	}
+}
+
+func (s) TestListenerCloseClosesConns(t *testing.T) {
+	l := Listen(7)
+	const numConns = 5
+	sConns := make([]net.Conn, numConns)
+	cConns := make([]net.Conn, numConns)
+	for i := range numConns {
+		done := make(chan struct{})
+		go func(idx int) {
+			var err error
+			sConns[idx], err = l.Accept()
+			if err != nil {
+				t.Errorf("Accept error: %v", err)
+			}
+			close(done)
+		}(i)
+		var err error
+		cConns[i], err = l.Dial()
+		if err != nil {
+			t.Fatalf("Dial error: %v", err)
+		}
+		<-done
+	}
+
+	// Connections should work before listener close.
+	if _, err := cConns[0].Write([]byte("hello")); err != nil {
+		t.Fatalf("Write before close: %v", err)
+	}
+	buf := make([]byte, 5)
+	if _, err := sConns[0].Read(buf); err != nil {
+		t.Fatalf("Read before close: %v", err)
+	}
+
+	l.Close()
+
+	for i := range numConns {
+		// Server-side conn was closed by listener; reads should fail.
+		if _, err := sConns[i].Read(make([]byte, 1)); err != io.ErrClosedPipe {
+			t.Errorf("sConns[%d].Read = %v; want io.ErrClosedPipe", i, err)
+		}
+		// Client-side writes should fail because the server read pipe is closed.
+		if _, err := cConns[i].Write([]byte("hi")); err != io.ErrClosedPipe {
+			t.Errorf("cConns[%d].Write = %v; want io.ErrClosedPipe", i, err)
+		}
+		// Client-side reads should get EOF because the server write pipe was write-closed.
+		if _, err := cConns[i].Read(make([]byte, 1)); err != io.EOF {
+			t.Errorf("cConns[%d].Read = %v; want io.EOF", i, err)
+		}
+	}
+}
+
+func (s) TestDialContextCancelled(t *testing.T) {
+	l := Listen(7)
+	defer l.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := l.DialContext(ctx)
+	if err != context.Canceled {
+		t.Fatalf("DialContext with cancelled ctx = %v; want %v", err, context.Canceled)
+	}
+
+	// Ensure that the connection gets untracked. Since it's never sent to
+	// Accept, it shouldn't be tracked as an active connection, and the listener
+	// shouldn't hold on to it after DialContext returns.
+	n := len(l.conns)
+	if n != 0 {
+		t.Fatalf("listener has %d tracked conns after cancelled dial; want 0", n)
 	}
 }
 


### PR DESCRIPTION
If a Listener is closed while it has active connections, those connections should be closed as well. This is important for users of bufconn who want to use it as a test server that can be cleanly shut down without leaving clients hanging on connections that will never be accepted or closed.

Fixes #9084

RELEASE NOTES:
* test/bufconn: Close connections when listener is closed