### PR TITLE
docs: fix typo `recevied` → `received` in balancer_test.go

### DIFF
--- a/test/balancer_test.go
+++ b/test/balancer_test.go
@@ -1086,7 +1086,7 @@ func (s) TestSubConn_RegisterHealthListener(t *testing.T) {
 		}
 	}
 
-	// Make the SubConn enter IDLE and verify that health updates are recevied
+	// Make the SubConn enter IDLE and verify that health updates are received
 	// on registering a new listener.
 	backend.S.Stop()
 	backend.S = nil


### PR DESCRIPTION
Fixes a single-character typo in a comment.

- File: `test/balancer_test.go` (line ~1089)
- Change: `recevied` → `received`
- No code or behavior changes; comment-only edit.

Spotted with [`typos-cli`](https://github.com/crate-ci/typos). Happy to close if not useful.
