### PR TITLE
xds/rbac: handle errors returned from matcher evaluation

### DIFF
--- a/internal/xds/rbac/matchers.go
+++ b/internal/xds/rbac/matchers.go
@@ -31,9 +31,10 @@ import (
 )
 
 // matcher is an interface that takes data about incoming RPC's and returns
-// whether it matches with whatever matcher implements this interface.
+// whether it matches with whatever matcher implements this interface, or an
+// error if the evaluation fails.
 type matcher interface {
-	match(data *rpcData) bool
+	match(data *rpcData) (bool, error)
 }
 
 // policyMatcher helps determine whether an incoming RPC call matches a policy.
@@ -64,11 +65,22 @@ func newPolicyMatcher(policy *v3rbacpb.Policy) (*policyMatcher, error) {
 	}, nil
 }
 
-func (pm *policyMatcher) match(data *rpcData) bool {
+func (pm *policyMatcher) match(data *rpcData) (bool, error) {
 	// A policy matches if and only if at least one of its permissions match the
 	// action taking place AND at least one if its principals match the
 	// downstream peer.
-	return pm.permissions.match(data) && pm.principals.match(data)
+	permission, err := pm.permissions.match(data)
+	if err != nil {
+		return false, err
+	}
+	if !permission {
+		return false, nil
+	}
+	principal, err := pm.principals.match(data)
+	if err != nil {
+		return false, err
+	}
+	return principal, nil
 }
 
 // matchersFromPermissions takes a list of permissions (can also be
@@ -213,15 +225,24 @@ type orMatcher struct {
 	matchers []matcher
 }
 
-func (om *orMatcher) match(data *rpcData) bool {
+func (om *orMatcher) match(data *rpcData) (bool, error) {
 	// Range through child matchers and pass in data about incoming RPC, and
 	// only one child matcher has to match to be logically successful.
+	var lastErr error
 	for _, m := range om.matchers {
-		if m.match(data) {
-			return true
+		matched, err := m.match(data)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		if matched {
+			return true, nil
 		}
 	}
-	return false
+	if lastErr != nil {
+		return false, lastErr
+	}
+	return false, nil
 }
 
 // andMatcher is a matcher that is successful if every child matcher
@@ -230,13 +251,17 @@ type andMatcher struct {
 	matchers []matcher
 }
 
-func (am *andMatcher) match(data *rpcData) bool {
+func (am *andMatcher) match(data *rpcData) (bool, error) {
 	for _, m := range am.matchers {
-		if !m.match(data) {
-			return false
+		matched, err := m.match(data)
+		if err != nil {
+			return false, err
+		}
+		if !matched {
+			return false, nil
 		}
 	}
-	return true
+	return true, nil
 }
 
 // alwaysMatcher is a matcher that will always match. This logically
@@ -245,8 +270,8 @@ func (am *andMatcher) match(data *rpcData) bool {
 type alwaysMatcher struct {
 }
 
-func (am *alwaysMatcher) match(*rpcData) bool {
-	return true
+func (am *alwaysMatcher) match(*rpcData) (bool, error) {
+	return true, nil
 }
 
 // notMatcher is a matcher that nots an underlying matcher. notMatcher
@@ -255,8 +280,12 @@ type notMatcher struct {
 	matcherToNot matcher
 }
 
-func (nm *notMatcher) match(data *rpcData) bool {
-	return !nm.matcherToNot.match(data)
+func (nm *notMatcher) match(data *rpcData) (bool, error) {
+	matched, err := nm.matcherToNot.match(data)
+	if err != nil {
+		return false, err
+	}
+	return !matched, nil
 }
 
 // headerMatcher is a matcher that matches on incoming HTTP Headers present
@@ -298,8 +327,8 @@ func newHeaderMatcher(headerMatcherConfig *v3route_componentspb.HeaderMatcher) (
 	return &headerMatcher{matcher: m}, nil
 }
 
-func (hm *headerMatcher) match(data *rpcData) bool {
-	return hm.matcher.Match(data.md)
+func (hm *headerMatcher) match(data *rpcData) (bool, error) {
+	return hm.matcher.Match(data.md), nil
 }
 
 // urlPathMatcher matches on the URL Path of the incoming RPC. In gRPC, this
@@ -317,8 +346,8 @@ func newURLPathMatcher(pathMatcher *v3matcherpb.PathMatcher) (*urlPathMatcher, e
 	return &urlPathMatcher{stringMatcher: stringMatcher}, nil
 }
 
-func (upm *urlPathMatcher) match(data *rpcData) bool {
-	return upm.stringMatcher.Match(data.fullMethod)
+func (upm *urlPathMatcher) match(data *rpcData) (bool, error) {
+	return upm.stringMatcher.Match(data.fullMethod), nil
 }
 
 // remoteIPMatcher and localIPMatcher both are matchers that match against
@@ -344,7 +373,9 @@ func newRemoteIPMatcher(cidrRange *v3corepb.CidrRange) (*remoteIPMatcher, error)
 	return &remoteIPMatcher{ipNet: ipNet.Masked()}, nil
 }
 
-func (sim *remoteIPMatcher) match(data *rpcData) bool {
+// match returns true if the remote IP address falls within the configured
+// CIDR range. It returns an error if the remote IP address cannot be parsed.
+func (sim *remoteIPMatcher) match(data *rpcData) (bool, error) {
 	host, _, err := net.SplitHostPort(data.peerInfo.Addr.String())
 	if err != nil {
 		// Fallback for addresses without a port.
@@ -352,9 +383,9 @@ func (sim *remoteIPMatcher) match(data *rpcData) bool {
 	}
 	ip, err := netip.ParseAddr(host)
 	if err != nil {
-		return false
+		return false, err
 	}
-	return sim.ipNet.Contains(ip)
+	return sim.ipNet.Contains(ip), nil
 }
 
 type localIPMatcher struct {
@@ -370,7 +401,9 @@ func newLocalIPMatcher(cidrRange *v3corepb.CidrRange) (*localIPMatcher, error) {
 	return &localIPMatcher{ipNet: ipNet.Masked()}, nil
 }
 
-func (dim *localIPMatcher) match(data *rpcData) bool {
+// match returns true if the local IP address falls within the configured
+// CIDR range. It returns an error if the local IP address cannot be parsed.
+func (dim *localIPMatcher) match(data *rpcData) (bool, error) {
 	host, _, err := net.SplitHostPort(data.localAddr.String())
 	if err != nil {
 		// Fallback for addresses without a port.
@@ -378,9 +411,9 @@ func (dim *localIPMatcher) match(data *rpcData) bool {
 	}
 	ip, err := netip.ParseAddr(host)
 	if err != nil {
-		return false
+		return false, err
 	}
-	return dim.ipNet.Contains(ip)
+	return dim.ipNet.Contains(ip), nil
 }
 
 // portMatcher matches on whether the destination port of the RPC matches the
@@ -394,8 +427,8 @@ func newPortMatcher(destinationPort uint32) *portMatcher {
 	return &portMatcher{destinationPort: destinationPort}
 }
 
-func (pm *portMatcher) match(data *rpcData) bool {
-	return data.destinationPort == pm.destinationPort
+func (pm *portMatcher) match(data *rpcData) (bool, error) {
+	return data.destinationPort == pm.destinationPort, nil
 }
 
 // authenticatedMatcher matches on the name of the Principal. If set, the URI
@@ -419,33 +452,33 @@ func newAuthenticatedMatcher(authenticatedMatcherConfig *v3rbacpb.Principal_Auth
 	return &authenticatedMatcher{stringMatcher: &stringMatcher}, nil
 }
 
-func (am *authenticatedMatcher) match(data *rpcData) bool {
+func (am *authenticatedMatcher) match(data *rpcData) (bool, error) {
 	if data.authType != "tls" {
 		// Connection is not authenticated.
-		return false
+		return false, nil
 	}
 	if am.stringMatcher == nil {
 		// Allows any authenticated user.
-		return true
+		return true, nil
 	}
 	// "If there is no client certificate (thus no SAN nor Subject), check if ""
 	// (empty string) matches. If it matches, the principal_name is said to
 	// match" - A41
 	if len(data.certs) == 0 {
-		return am.stringMatcher.Match("")
+		return am.stringMatcher.Match(""), nil
 	}
 	cert := data.certs[0]
 	// The order of matching as per the RBAC documentation (see package-level comments)
 	// is as follows: URI SANs, DNS SANs, and then subject name.
 	for _, uriSAN := range cert.URIs {
 		if am.stringMatcher.Match(uriSAN.String()) {
-			return true
+			return true, nil
 		}
 	}
 	for _, dnsSAN := range cert.DNSNames {
 		if am.stringMatcher.Match(dnsSAN) {
-			return true
+			return true, nil
 		}
 	}
-	return am.stringMatcher.Match(cert.Subject.String())
+	return am.stringMatcher.Match(cert.Subject.String()), nil
 }

--- a/internal/xds/rbac/matchers.go
+++ b/internal/xds/rbac/matchers.go
@@ -69,18 +69,18 @@ func (pm *policyMatcher) match(data *rpcData) (bool, error) {
 	// A policy matches if and only if at least one of its permissions match the
 	// action taking place AND at least one if its principals match the
 	// downstream peer.
-	permission, err := pm.permissions.match(data)
+	permissionMatched, err := pm.permissions.match(data)
 	if err != nil {
 		return false, err
 	}
-	if !permission {
+	if !permissionMatched {
 		return false, nil
 	}
-	principal, err := pm.principals.match(data)
+	principalMatched, err := pm.principals.match(data)
 	if err != nil {
 		return false, err
 	}
-	return principal, nil
+	return principalMatched, nil
 }
 
 // matchersFromPermissions takes a list of permissions (can also be
@@ -239,10 +239,7 @@ func (om *orMatcher) match(data *rpcData) (bool, error) {
 			return true, nil
 		}
 	}
-	if lastErr != nil {
-		return false, lastErr
-	}
-	return false, nil
+	return false, lastErr
 }
 
 // andMatcher is a matcher that is successful if every child matcher

--- a/internal/xds/rbac/rbac_engine.go
+++ b/internal/xds/rbac/rbac_engine.go
@@ -88,7 +88,16 @@ func (cre *ChainEngine) IsAuthorized(ctx context.Context) error {
 		return status.Errorf(codes.Internal, "gRPC RBAC: %v", err)
 	}
 	for _, engine := range cre.chainedEngines {
-		matchingPolicyName, ok := engine.findMatchingPolicy(rpcData)
+		matchingPolicyName, ok, err := engine.findMatchingPolicy(rpcData)
+		if err != nil {
+			if engine.action == v3rbacpb.RBAC_DENY {
+				ok = true
+				logger.Errorf("RBAC engine failed for DENY policy: %v", err)
+			} else {
+				ok = false
+				logger.Errorf("RBAC engine failed for ALLOW policy: %v", err)
+			}
+		}
 		if logger.V(2) && ok {
 			logger.Infof("incoming RPC matched to policy %v in engine with action %v", matchingPolicyName, engine.action)
 		}
@@ -179,13 +188,27 @@ func parseAuditOptions(opts *v3rbacpb.RBAC_AuditLoggingOptions) ([]audit.Logger,
 // successful match, it returns the name of the matching policy and a true bool
 // to specify that there was a matching policy found.  It returns false in
 // the case of not finding a matching policy.
-func (e *engine) findMatchingPolicy(rpcData *rpcData) (string, bool) {
+func (e *engine) findMatchingPolicy(rpcData *rpcData) (string, bool, error) {
+	var lastErr error
 	for policy, matcher := range e.policies {
-		if matcher.match(rpcData) {
-			return policy, true
+		matched, err := matcher.match(rpcData)
+		if err != nil {
+			if e.action == v3rbacpb.RBAC_DENY {
+				// Fail closed immediately for DENY.
+				return policy, true, err
+			}
+			// For ALLOW, we continue searching. If another policy matches, we allow.
+			lastErr = err
+			continue
+		}
+		if matched {
+			return policy, true, nil
 		}
 	}
-	return "", false
+	if lastErr != nil {
+		return "", false, lastErr
+	}
+	return "", false, nil
 }
 
 // newRPCData takes an incoming context (should be a context representing state

--- a/internal/xds/rbac/rbac_engine.go
+++ b/internal/xds/rbac/rbac_engine.go
@@ -205,10 +205,7 @@ func (e *engine) findMatchingPolicy(rpcData *rpcData) (string, bool, error) {
 			return policy, true, nil
 		}
 	}
-	if lastErr != nil {
-		return "", false, lastErr
-	}
-	return "", false, nil
+	return "", false, lastErr
 }
 
 // newRPCData takes an incoming context (should be a context representing state

--- a/internal/xds/rbac/rbac_engine_test.go
+++ b/internal/xds/rbac/rbac_engine_test.go
@@ -701,6 +701,7 @@ func (s) TestChainEngine(t *testing.T) {
 		rbacConfigs []*v3rbacpb.RBAC
 		rbacQueries []rbacQuery
 		policyName  string
+		expectError string
 	}{
 		// SuccessCaseAnyMatch tests a single RBAC Engine instantiated with
 		// a config with a policy with any rules for both permissions and
@@ -772,6 +773,68 @@ func (s) TestChainEngine(t *testing.T) {
 					rpcData: &rpcData{
 						peerInfo: &peer.Peer{
 							Addr: &addr{ipAddress: "0.0.0.0"},
+						},
+					},
+					wantStatusCode: codes.PermissionDenied,
+				},
+			},
+		},
+		// FailClosedAllow tests that an ALLOW policy denies access if IP parsing fails.
+		{
+			name:        "FailClosed_Allow_Policy	",
+			expectError: "RBAC engine failed for ALLOW policy",
+			rbacConfigs: []*v3rbacpb.RBAC{
+				{
+					Action: v3rbacpb.RBAC_ALLOW,
+					Policies: map[string]*v3rbacpb.Policy{
+						"certain-source-ip": {
+							Permissions: []*v3rbacpb.Permission{
+								{Rule: &v3rbacpb.Permission_Any{Any: true}},
+							},
+							Principals: []*v3rbacpb.Principal{
+								{Identifier: &v3rbacpb.Principal_DirectRemoteIp{DirectRemoteIp: &v3corepb.CidrRange{AddressPrefix: "10.0.0.0", PrefixLen: &wrapperspb.UInt32Value{Value: uint32(8)}}}},
+							},
+						},
+					},
+				},
+			},
+			rbacQueries: []rbacQuery{
+				{
+					rpcData: &rpcData{
+						fullMethod: "some method",
+						peerInfo: &peer.Peer{
+							Addr: &addr{ipAddress: "invalid-ip"},
+						},
+					},
+					wantStatusCode: codes.PermissionDenied,
+				},
+			},
+		},
+		// FailClosedDeny tests that a DENY policy denies access if IP parsing fails.
+		{
+			name:        "FailClosed_Deny_Policy",
+			expectError: "RBAC engine failed for DENY policy",
+			rbacConfigs: []*v3rbacpb.RBAC{
+				{
+					Action: v3rbacpb.RBAC_DENY,
+					Policies: map[string]*v3rbacpb.Policy{
+						"certain-source-ip": {
+							Permissions: []*v3rbacpb.Permission{
+								{Rule: &v3rbacpb.Permission_Any{Any: true}},
+							},
+							Principals: []*v3rbacpb.Principal{
+								{Identifier: &v3rbacpb.Principal_DirectRemoteIp{DirectRemoteIp: &v3corepb.CidrRange{AddressPrefix: "10.0.0.0", PrefixLen: &wrapperspb.UInt32Value{Value: uint32(8)}}}},
+							},
+						},
+					},
+				},
+			},
+			rbacQueries: []rbacQuery{
+				{
+					rpcData: &rpcData{
+						fullMethod: "some method",
+						peerInfo: &peer.Peer{
+							Addr: &addr{ipAddress: "invalid-ip"},
 						},
 					},
 					wantStatusCode: codes.PermissionDenied,
@@ -1732,6 +1795,9 @@ func (s) TestChainEngine(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			if test.expectError != "" {
+				grpctest.ExpectError(test.expectError)
+			}
 			b := TestAuditLoggerBufferBuilder{testName: test.name}
 			audit.RegisterLoggerBuilder(&b)
 			b2 := TestAuditLoggerCustomConfigBuilder{testName: test.name}


### PR DESCRIPTION
This PR improves the error handling in the RBAC engine during policy evaluation. Matchers (such as the IP matcher) now propagate errors when they encounter invalid inputs. The engine in rbac_engine.go has been updated to process these errors and apply safe default behaviors that align with the intent of the specific policy action (ALLOW or DENY) being evaluated, ensuring predictable authorization decisions.

RELEASE NOTES: N/A