### PR TITLE
transport: Encode request timeouts concisely

### DIFF
--- a/internal/grpcutil/encode_duration.go
+++ b/internal/grpcutil/encode_duration.go
@@ -26,15 +26,25 @@ import (
 const maxTimeoutValue = 99_999_999
 
 var units = []struct {
-	duration time.Duration
 	symbol   byte
+	duration time.Duration
 }{
-	{time.Nanosecond, 'n'},
-	{time.Microsecond, 'u'},
-	{time.Millisecond, 'm'},
-	{time.Second, 'S'},
-	{time.Minute, 'M'},
-	{time.Hour, 'H'},
+	{'n', time.Nanosecond},
+	{'u', time.Microsecond},
+	{'m', time.Millisecond},
+	{'S', time.Second},
+	{'M', time.Minute},
+	{'H', time.Hour},
+}
+
+// div does integer division and round-up the result. Note that this is
+// equivalent to (d+r-1)/r but has less chance to overflow.
+func div(d, r time.Duration) int64 {
+	q := (int64)(d / r)
+	if d%r > 0 {
+		q++
+	}
+	return q
 }
 
 // EncodeDuration encodes the duration to the format grpc-timeout header
@@ -52,12 +62,12 @@ func EncodeDuration(t time.Duration) string {
 			break
 		}
 	}
-	value := (int64)(t / units[i].duration)
+	value := div(t, units[i].duration)
 	// Round to larger unit as needed to satisfy value limit.
 	// Note that the maximum value of Duration encodes properly in hours.
 	for value > maxTimeoutValue && i+1 < len(units) {
 		i++
-		value = (int64)(t/units[i].duration + 1)
+		value = div(t, units[i].duration)
 	}
 	return fmt.Sprintf("%d%c", value, units[i].symbol)
 }

--- a/internal/grpcutil/encode_duration.go
+++ b/internal/grpcutil/encode_duration.go
@@ -19,19 +19,22 @@
 package grpcutil
 
 import (
-	"strconv"
+	"fmt"
 	"time"
 )
 
-const maxTimeoutValue int64 = 100000000 - 1
+const maxTimeoutValue = 99_999_999
 
-// div does integer division and round-up the result. Note that this is
-// equivalent to (d+r-1)/r but has less chance to overflow.
-func div(d, r time.Duration) int64 {
-	if d%r > 0 {
-		return int64(d/r + 1)
-	}
-	return int64(d / r)
+var units = []struct {
+	duration time.Duration
+	symbol   byte
+}{
+	{time.Nanosecond, 'n'},
+	{time.Microsecond, 'u'},
+	{time.Millisecond, 'm'},
+	{time.Second, 'S'},
+	{time.Minute, 'M'},
+	{time.Hour, 'H'},
 }
 
 // EncodeDuration encodes the duration to the format grpc-timeout header
@@ -39,25 +42,22 @@ func div(d, r time.Duration) int64 {
 //
 // https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#requests
 func EncodeDuration(t time.Duration) string {
-	// TODO: This is simplistic and not bandwidth efficient. Improve it.
 	if t <= 0 {
-		return "0n"
+		return "0S"
 	}
-	if d := div(t, time.Nanosecond); d <= maxTimeoutValue {
-		return strconv.FormatInt(d, 10) + "n"
+	// Find the largest dividing unit.
+	var i int
+	for i = len(units) - 1; i > 0; i-- {
+		if t%units[i].duration == 0 {
+			break
+		}
 	}
-	if d := div(t, time.Microsecond); d <= maxTimeoutValue {
-		return strconv.FormatInt(d, 10) + "u"
+	value := (int64)(t / units[i].duration)
+	// Round to larger unit as needed to satisfy value limit.
+	// Note that the maximum value of Duration encodes properly in hours.
+	for value > maxTimeoutValue && i+1 < len(units) {
+		i++
+		value = (int64)(t/units[i].duration + 1)
 	}
-	if d := div(t, time.Millisecond); d <= maxTimeoutValue {
-		return strconv.FormatInt(d, 10) + "m"
-	}
-	if d := div(t, time.Second); d <= maxTimeoutValue {
-		return strconv.FormatInt(d, 10) + "S"
-	}
-	if d := div(t, time.Minute); d <= maxTimeoutValue {
-		return strconv.FormatInt(d, 10) + "M"
-	}
-	// Note that maxTimeoutValue * time.Hour > MaxInt64.
-	return strconv.FormatInt(div(t, time.Hour), 10) + "H"
+	return fmt.Sprintf("%d%c", value, units[i].symbol)
 }

--- a/internal/grpcutil/encode_duration_test.go
+++ b/internal/grpcutil/encode_duration_test.go
@@ -48,7 +48,7 @@ func TestEncodeDuration(t *testing.T) {
 
 		// Boundary conditions
 		{"-1ns", "0S"},
-		{"9223372036854775807ns", "2562048H"},
+		{"9223372036854775807ns", "2562048H"}, // maximum Duration
 	} {
 		d, err := time.ParseDuration(test.in)
 		if err != nil {

--- a/internal/grpcutil/encode_duration_test.go
+++ b/internal/grpcutil/encode_duration_test.go
@@ -24,20 +24,31 @@ import (
 )
 
 func TestEncodeDuration(t *testing.T) {
-	for _, test := range []struct {
-		in  string
-		out string
-	}{
-		{"12345678ns", "12345678n"},
-		{"123456789ns", "123457u"},
-		{"12345678us", "12345678u"},
-		{"123456789us", "123457m"},
-		{"12345678ms", "12345678m"},
-		{"123456789ms", "123457S"},
-		{"12345678s", "12345678S"},
-		{"123456789s", "2057614M"},
-		{"12345678m", "12345678M"},
-		{"123456789m", "2057614H"},
+	for _, test := range []struct{ in, out string }{
+		// Exact encoding
+		{"0ns", "0S"},
+		{"1ns", "1n"},
+		{"99999999ns", "99999999n"},
+		{"1us", "1u"},
+		{"99999999us", "99999999u"},
+		{"1ms", "1m"},
+		{"99999999ms", "99999999m"},
+		{"1s", "1S"},
+		{"99999999s", "99999999S"},
+		{"1m", "1M"},
+		{"99999999m", "99999999M"},
+		{"1h", "1H"},
+
+		// Rounding
+		{"100000001ns", "100001u"},
+		{"100000001us", "100001m"},
+		{"100000001ms", "100001S"},
+		{"100000000s", "1666667M"},
+		{"100000000m", "1666667H"},
+
+		// Boundary conditions
+		{"-1ns", "0S"},
+		{"9223372036854775807ns", "2562048H"},
 	} {
 		d, err := time.ParseDuration(test.in)
 		if err != nil {
@@ -45,7 +56,7 @@ func TestEncodeDuration(t *testing.T) {
 		}
 		out := EncodeDuration(d)
 		if out != test.out {
-			t.Fatalf("timeoutEncode(%s) = %s, want %s", test.in, out, test.out)
+			t.Fatalf("EncodeDuration(%s) = %s, want %s", test.in, out, test.out)
 		}
 	}
 }


### PR DESCRIPTION
For example, ten seconds as "10S" rather than "10000000u"

RELEASE NOTES:
* transport: Request timeouts are encoded more concisely.
