### PR TITLE
Cherry pick #9055, #9032 to v1.81.x

### DIFF
--- a/credentials/alts/internal/conn/record.go
+++ b/credentials/alts/internal/conn/record.go
@@ -27,8 +27,9 @@ import (
 	"net"
 
 	core "google.golang.org/grpc/credentials/alts/internal"
-	"google.golang.org/grpc/internal/mem"
+	imem "google.golang.org/grpc/internal/mem"
 	"google.golang.org/grpc/internal/transport/readyreader"
+	"google.golang.org/grpc/mem"
 )
 
 // ALTSRecordCrypto is the interface for gRPC ALTS record protocol.
@@ -75,16 +76,19 @@ const (
 
 var (
 	protocols    = make(map[string]ALTSRecordFunc)
-	writeBufPool *mem.BinaryTieredBufferPool
+	writeBufPool *imem.BinaryTieredBufferPool
 	// readBufPool pools buffers of at least `altsReadBufferInitialSize` size.
 	// Since the read buffer size is slightly larger than 32KB, using a regular
 	// BinaryTieredBufferPool results in allocating buffers of almost double the
 	// required length.
-	readBufPool = mem.NewDirtySimplePool()
+	readBufPool = imem.NewDirtySimplePool()
+
+	// Compile-time check to ensure conn implements ReadyReader.
+	_ readyreader.Reader = &conn{}
 )
 
 func init() {
-	pool, err := mem.NewDirtyBinaryTieredBufferPool(
+	pool, err := imem.NewDirtyBinaryTieredBufferPool(
 		8,
 		12, // Go page size, 4KB
 		14, // 16KB (max HTTP/2 frame size used by gRPC)
@@ -126,7 +130,8 @@ type conn struct {
 	// nextFrame stores the next frame (in protected buffer) info.
 	nextFrame []byte
 	// overhead is the calculated overhead of each frame.
-	overhead int
+	overhead  int
+	constPool constBufferPool // stored as a field to avoid heap allocations.
 }
 
 // NewConn creates a new secure channel instance given the other party role and
@@ -163,11 +168,27 @@ func NewConn(c net.Conn, side core.Side, recordProtocol string, key []byte, prot
 	return altsConn, nil
 }
 
+type constBufferPool struct {
+	buffer []byte
+}
+
+func (p *constBufferPool) Get(int) *[]byte {
+	return &p.buffer
+}
+
+func (p *constBufferPool) Put(*[]byte) {}
+
 // Read reads and decrypts a frame from the underlying connection, and copies the
 // decrypted payload into b. If the size of the payload is greater than len(b),
 // Read retains the remaining bytes in an internal buffer, and subsequent calls
 // to Read will read from this buffer until it is exhausted.
 func (p *conn) Read(b []byte) (n int, err error) {
+	p.constPool.buffer = b
+	_, n, err = p.ReadOnReady(len(b), &p.constPool)
+	return n, err
+}
+
+func (p *conn) ReadOnReady(bufSize int, pool mem.BufferPool) (*[]byte, int, error) {
 	if len(p.buf) == 0 {
 		var framedMsg []byte
 		var protected []byte
@@ -175,9 +196,10 @@ func (p *conn) Read(b []byte) (n int, err error) {
 			protected = *p.protectedHandle
 			protected = protected[:cap(protected)]
 		}
+		var err error
 		framedMsg, p.nextFrame, err = ParseFramedMsg(p.nextFrame, altsRecordLengthLimit)
 		if err != nil {
-			return 0, err
+			return nil, 0, err
 		}
 		// Check whether the next frame to be decrypted has been
 		// completely received yet.
@@ -217,40 +239,42 @@ func (p *conn) Read(b []byte) (n int, err error) {
 				// Connection was idle, need to re-allocate the read buffer.
 				newBuf, nRead, err := p.reader.ReadOnReady(altsReadBufferInitialSize, readBufPool)
 				if err != nil {
-					return 0, err
+					return nil, 0, err
 				}
 				p.protectedHandle = newBuf
 				protected = (*newBuf)[:nRead]
 			} else {
 				nRead, err := p.Conn.Read(protected[len(protected):cap(protected)])
 				if err != nil {
-					return 0, err
+					return nil, 0, err
 				}
 				protected = protected[:len(protected)+nRead]
 			}
 			framedMsg, p.nextFrame, err = ParseFramedMsg(protected, altsRecordLengthLimit)
 			if err != nil {
-				return 0, err
+				return nil, 0, err
 			}
 		}
 		// Now we have a complete frame, decrypted it.
 		msg := framedMsg[MsgLenFieldSize:]
 		msgType := binary.LittleEndian.Uint32(msg[:msgTypeFieldSize])
 		if msgType&0xff != altsRecordMsgType {
-			return 0, fmt.Errorf("received frame with incorrect message type %v, expected lower byte %v",
+			return nil, 0, fmt.Errorf("received frame with incorrect message type %v, expected lower byte %v",
 				msgType, altsRecordMsgType)
 		}
 		ciphertext := msg[msgTypeFieldSize:]
 
 		// Decrypt directly into the buffer, avoiding a copy from p.buf if
 		// possible.
-		if len(b) >= len(ciphertext) {
-			dec, err := p.crypto.Decrypt(b[:0], ciphertext)
+		if bufSize >= len(ciphertext) {
+			allocatedBuf := pool.Get(bufSize)
+			dec, err := p.crypto.Decrypt((*allocatedBuf)[:0], ciphertext)
 			if err != nil {
-				return 0, err
+				pool.Put(allocatedBuf)
+				return nil, 0, err
 			}
 			p.dropProtectedIfEmtpy()
-			return len(dec), nil
+			return allocatedBuf, len(dec), nil
 		}
 		// Decrypt requires that if the dst and ciphertext alias, they
 		// must alias exactly. Code here used to use msg[:0], but msg
@@ -261,14 +285,15 @@ func (p *conn) Read(b []byte) (n int, err error) {
 		// check: https://golang.org/pkg/crypto/cipher/#AEAD.
 		p.buf, err = p.crypto.Decrypt(ciphertext[:0], ciphertext)
 		if err != nil {
-			return 0, err
+			return nil, 0, err
 		}
 	}
 
-	n = copy(b, p.buf)
+	allocatedBuf := pool.Get(bufSize)
+	n := copy(*allocatedBuf, p.buf)
 	p.buf = p.buf[n:]
 	p.dropProtectedIfEmtpy()
-	return n, nil
+	return allocatedBuf, n, nil
 }
 
 func (p *conn) dropProtectedIfEmtpy() {

--- a/internal/envconfig/envconfig.go
+++ b/internal/envconfig/envconfig.go
@@ -126,6 +126,16 @@ var (
 	// enabled by setting the env variable
 	// GRPC_EXPERIMENTAL_ENABLE_PRIORITY_LB_CHILD_POLICY_CACHE to true.
 	EnablePriorityLBChildPolicyCache = boolFromEnv("GRPC_EXPERIMENTAL_ENABLE_PRIORITY_LB_CHILD_POLICY_CACHE", false)
+
+	// EnableHTTPFramerReadBufferPooling enables the use of the
+	// readyreader.Reader interface to perform non-memory-pinning reads,
+	// provided the underlying net.Conn supports it. This reduces memory usage
+	// when subchannels are idle.
+	//
+	// This environment variable serves as an escape hatch to disable the
+	// feature if unforeseen issues arise, and it will be removed in a future
+	// release.
+	EnableHTTPFramerReadBufferPooling = boolFromEnv("GRPC_GO_EXPERIMENTAL_HTTP_FRAMER_READ_BUFFER_POOLING", true)
 )
 
 func boolFromEnv(envVar string, def bool) bool {

--- a/internal/transport/http_util.go
+++ b/internal/transport/http_util.go
@@ -36,6 +36,9 @@ import (
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/hpack"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/internal/envconfig"
+	imem "google.golang.org/grpc/internal/mem"
+	"google.golang.org/grpc/internal/transport/readyreader"
 	"google.golang.org/grpc/mem"
 )
 
@@ -296,7 +299,7 @@ func decodeGrpcMessageUnchecked(msg string) string {
 }
 
 type bufWriter struct {
-	pool      *sync.Pool
+	pool      *imem.SimpleBufferPool
 	buf       []byte
 	offset    int
 	batchSize int
@@ -304,7 +307,7 @@ type bufWriter struct {
 	err       error
 }
 
-func newBufWriter(conn io.Writer, batchSize int, pool *sync.Pool) *bufWriter {
+func newBufWriter(conn io.Writer, batchSize int, pool *imem.SimpleBufferPool) *bufWriter {
 	w := &bufWriter{
 		batchSize: batchSize,
 		conn:      conn,
@@ -326,7 +329,7 @@ func (w *bufWriter) Write(b []byte) (int, error) {
 		return n, toIOError(err)
 	}
 	if w.buf == nil {
-		b := w.pool.Get().(*[]byte)
+		b := w.pool.Get(w.batchSize)
 		w.buf = *b
 	}
 	written := 0
@@ -407,22 +410,32 @@ type framer struct {
 	errDetail error
 }
 
-var writeBufferPoolMap = make(map[int]*sync.Pool)
-var writeBufferMutex sync.Mutex
+var ioBufferPoolMap = make(map[int]*imem.SimpleBufferPool)
+var ioBufferMutex sync.Mutex
+
+func bufferedReader(r io.Reader, bufSize int) io.Reader {
+	if bufSize <= 0 {
+		return r
+	}
+	if envconfig.EnableHTTPFramerReadBufferPooling {
+		if rr := readyreader.NewNonBlocking(r); rr != nil {
+			readPool := ioBufferPool(bufSize)
+			return readyreader.NewBuffered(rr, bufSize, readPool)
+		}
+	}
+	return bufio.NewReaderSize(r, bufSize)
+}
 
 func newFramer(conn io.ReadWriter, writeBufferSize, readBufferSize int, sharedWriteBuffer bool, maxHeaderListSize uint32, memPool mem.BufferPool) *framer {
 	if writeBufferSize < 0 {
 		writeBufferSize = 0
 	}
-	var r io.Reader = conn
-	if readBufferSize > 0 {
-		r = bufio.NewReaderSize(r, readBufferSize)
-	}
-	var pool *sync.Pool
+	r := bufferedReader(conn, readBufferSize)
+	var writePool *imem.SimpleBufferPool
 	if sharedWriteBuffer {
-		pool = getWriteBufferPool(writeBufferSize)
+		writePool = ioBufferPool(writeBufferSize)
 	}
-	w := newBufWriter(conn, writeBufferSize, pool)
+	w := newBufWriter(conn, writeBufferSize, writePool)
 	f := &framer{
 		writer: w,
 		fr:     http2.NewFramer(w, r),
@@ -578,20 +591,15 @@ func (df *parsedDataFrame) Header() http2.FrameHeader {
 	return df.FrameHeader
 }
 
-func getWriteBufferPool(size int) *sync.Pool {
-	writeBufferMutex.Lock()
-	defer writeBufferMutex.Unlock()
-	pool, ok := writeBufferPoolMap[size]
+func ioBufferPool(size int) *imem.SimpleBufferPool {
+	ioBufferMutex.Lock()
+	defer ioBufferMutex.Unlock()
+	pool, ok := ioBufferPoolMap[size]
 	if ok {
 		return pool
 	}
-	pool = &sync.Pool{
-		New: func() any {
-			b := make([]byte, size)
-			return &b
-		},
-	}
-	writeBufferPoolMap[size] = pool
+	pool = imem.NewDirtySimplePool()
+	ioBufferPoolMap[size] = pool
 	return pool
 }
 

--- a/internal/transport/http_util_test.go
+++ b/internal/transport/http_util_test.go
@@ -19,6 +19,7 @@
 package transport
 
 import (
+	"bufio"
 	"bytes"
 	"errors"
 	"fmt"
@@ -31,6 +32,9 @@ import (
 	"time"
 
 	"golang.org/x/net/http2"
+	"google.golang.org/grpc/internal/envconfig"
+	"google.golang.org/grpc/internal/testutils"
+	"google.golang.org/grpc/internal/transport/readyreader"
 	"google.golang.org/grpc/mem"
 )
 
@@ -259,7 +263,7 @@ func (s) TestWriteBadConnection(t *testing.T) {
 	// Configure the bufWriter with a batchsize that results in data being flushed
 	// to the underlying conn, midway through Write().
 	writeBufferSize := (len(data) - 1) / 2
-	writer := newBufWriter(&badNetworkConn{}, writeBufferSize, getWriteBufferPool(writeBufferSize))
+	writer := newBufWriter(&badNetworkConn{}, writeBufferSize, ioBufferPool(writeBufferSize))
 
 	errCh := make(chan error, 1)
 	go func() {
@@ -410,6 +414,77 @@ func (s) TestFramer_ParseDataFrame(t *testing.T) {
 				t.Fatalf("parsedDataFrame.Data() = %q, want %q", gotData, tc.wantData)
 			}
 			df.data.Free()
+		})
+	}
+}
+
+type testReadyReader struct {
+	readyreader.Reader
+}
+
+func (t *testReadyReader) Read([]byte) (int, error) {
+	return 0, io.EOF
+}
+
+func (s) TestBufferedReader(t *testing.T) {
+	normalReader := bytes.NewReader(nil)
+
+	tests := []struct {
+		name          string
+		reader        io.Reader
+		bufSize       int
+		enablePooling bool
+		wantTypeOf    any
+	}{
+		{
+			name:          "bufSize_0",
+			reader:        normalReader,
+			bufSize:       0,
+			enablePooling: true,
+			wantTypeOf:    (*bytes.Reader)(nil),
+		},
+		{
+			name:          "env_var_disabled_normal_reader",
+			reader:        normalReader,
+			bufSize:       10,
+			enablePooling: false,
+			wantTypeOf:    (*bufio.Reader)(nil),
+		},
+		{
+			name:          "env_var_disabled_ready_reader",
+			reader:        &testReadyReader{},
+			bufSize:       10,
+			enablePooling: false,
+			wantTypeOf:    (*bufio.Reader)(nil),
+		},
+		{
+			name:          "env_var_enabled_normal_reader",
+			reader:        normalReader,
+			bufSize:       10,
+			enablePooling: true,
+			wantTypeOf:    (*bufio.Reader)(nil),
+		},
+		{
+			name:          "env_var_enabled_ready_reader",
+			reader:        &testReadyReader{},
+			bufSize:       10,
+			enablePooling: true,
+			wantTypeOf:    readyreader.NewBuffered(nil, 10, mem.DefaultBufferPool()),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testutils.SetEnvConfig(t, &envconfig.EnableHTTPFramerReadBufferPooling, tt.enablePooling)
+
+			got := bufferedReader(tt.reader, tt.bufSize)
+
+			gotType := reflect.TypeOf(got)
+			wantType := reflect.TypeOf(tt.wantTypeOf)
+
+			if gotType != wantType {
+				t.Errorf("bufferedReader() type = %v, want %v", gotType, wantType)
+			}
 		})
 	}
 }

--- a/internal/transport/readyreader/raw_conn_linux.go
+++ b/internal/transport/readyreader/raw_conn_linux.go
@@ -18,20 +18,22 @@
 
 package readyreader
 
-import (
-	"golang.org/x/sys/unix"
-)
+import "syscall"
 
 func isRawConnSupported() bool {
 	return true
 }
 
-// sysRead uses the modern unix package for Unix-like systems.
+// sysRead uses the standard syscall package rather than the modern unix package
+// to avoid triggering the race detector. Because both packages perform sync
+// operations on a local variable to satisfy the race detector, mixing them
+// for read and write syscalls causes data races. We use syscall here to remain
+// consistent with net.Conn implementations in standard library.
 func sysRead(fd uintptr, p []byte) (int, error) {
-	return unix.Read(int(fd), p)
+	return syscall.Read(int(fd), p)
 }
 
 // wouldBlock checks standard Unix non-blocking errors.
 func wouldBlock(err error) bool {
-	return err == unix.EAGAIN || err == unix.EWOULDBLOCK
+	return err == syscall.EAGAIN || err == syscall.EWOULDBLOCK
 }

--- a/internal/transport/readyreader/ready_reader.go
+++ b/internal/transport/readyreader/ready_reader.go
@@ -63,9 +63,9 @@ type readState struct {
 	buf       *[]byte
 }
 
-// newNonBlocking returns a ReadyReader if the passed reader supports
+// NewNonBlocking returns a ReadyReader if the passed reader supports
 // non-memory-pinning reads, else nil.
-func newNonBlocking(r io.Reader) Reader {
+func NewNonBlocking(r io.Reader) Reader {
 	if rr, ok := r.(Reader); ok {
 		return rr
 	}
@@ -155,7 +155,7 @@ func (c *blockingReader) ReadOnReady(bufSize int, pool mem.BufferPool) (*[]byte,
 // If [syscall.RawConn] is unavailable, it falls back to using the simpler
 // [io.Reader] interface for reads.
 func New(r io.Reader) Reader {
-	if r := newNonBlocking(r); r != nil {
+	if r := NewNonBlocking(r); r != nil {
 		return r
 	}
 	return &blockingReader{reader: r}

--- a/internal/transport/readyreader/ready_reader.go
+++ b/internal/transport/readyreader/ready_reader.go
@@ -63,9 +63,9 @@ type readState struct {
 	buf       *[]byte
 }
 
-// newNonBlockingReader returns a ReadyReader if the passed reader supports
+// newNonBlocking returns a ReadyReader if the passed reader supports
 // non-memory-pinning reads, else nil.
-func newNonBlockingReader(r io.Reader) Reader {
+func newNonBlocking(r io.Reader) Reader {
 	if rr, ok := r.(Reader); ok {
 		return rr
 	}
@@ -153,10 +153,101 @@ func (c *blockingReader) ReadOnReady(bufSize int, pool mem.BufferPool) (*[]byte,
 
 // New detects if [syscall.RawConn] is available for non-memory-pinning reads.
 // If [syscall.RawConn] is unavailable, it falls back to using the simpler
-// [net.Conn] interface for reads.
+// [io.Reader] interface for reads.
 func New(r io.Reader) Reader {
-	if r := newNonBlockingReader(r); r != nil {
+	if r := newNonBlocking(r); r != nil {
 		return r
 	}
 	return &blockingReader{reader: r}
 }
+
+// bufReadyReader implements buffering for a ReadyReader object.
+// A new bufReadyReader is created by calling [NewBuffered].
+type bufReadyReader struct {
+	buf       *[]byte
+	pool      mem.BufferPool
+	bufSize   int
+	rd        Reader // reader provided by the caller
+	r, w      int    // buf read and write positions
+	err       error
+	constPool constBufferPool // stored as a field to avoid heap allocations.
+}
+
+// NewBuffered returns a new [io.Reader] with a buffer of the specified size
+// which is allocated from the provided pool.
+func NewBuffered(rd Reader, size int, pool mem.BufferPool) io.Reader {
+	return &bufReadyReader{
+		rd:      rd,
+		pool:    pool,
+		bufSize: size,
+	}
+}
+
+func (b *bufReadyReader) readErr() error {
+	err := b.err
+	b.err = nil
+	return err
+}
+
+func (b *bufReadyReader) buffered() int { return b.w - b.r }
+
+// Read reads data into p. It returns the number of bytes read into p. The
+// bytes are taken from at most one Read on the underlying [ReadyReader],
+// hence n may be less than len(p). If the underlying [ReadyReader] can return
+// a non-zero count with io.EOF, then this Read method can do so as well; see
+// the [io.Reader] docs.
+func (b *bufReadyReader) Read(p []byte) (n int, err error) {
+	n = len(p)
+	if n == 0 {
+		if b.buffered() > 0 {
+			return 0, nil
+		}
+		return 0, b.readErr()
+	}
+	if b.r == b.w {
+		if b.err != nil {
+			return 0, b.readErr()
+		}
+		if len(p) >= b.bufSize {
+			// Large read, empty buffer.
+			// Read directly into p to avoid copy.
+			b.constPool.buffer = p
+			_, n, b.err = b.rd.ReadOnReady(len(p), &b.constPool)
+			return n, b.readErr()
+		}
+		// One read.
+		b.r = 0
+		b.w = 0
+		b.buf, n, b.err = b.rd.ReadOnReady(b.bufSize, b.pool)
+		if n == 0 {
+			if b.buf != nil {
+				b.pool.Put(b.buf)
+				b.buf = nil
+			}
+			return 0, b.readErr()
+		}
+		b.w += n
+	}
+
+	// copy as much as we can
+	// b.buf must be non-nil since b.r != b.w.
+	buf := *b.buf
+	n = copy(p, buf[b.r:b.w])
+	b.r += n
+	if b.r == b.w {
+		// Consumed entire buffer, release it.
+		b.pool.Put(b.buf)
+		b.buf = nil
+	}
+	return n, nil
+}
+
+type constBufferPool struct {
+	buffer []byte
+}
+
+func (p *constBufferPool) Get(int) *[]byte {
+	return &p.buffer
+}
+
+func (p *constBufferPool) Put(*[]byte) {}

--- a/internal/transport/readyreader/ready_reader_ext_test.go
+++ b/internal/transport/readyreader/ready_reader_ext_test.go
@@ -21,9 +21,12 @@ package readyreader_test
 import (
 	"bytes"
 	"context"
+	"errors"
+	"fmt"
 	"io"
 	"net"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -124,81 +127,116 @@ func (s) TestReadyReader_TCP_Blocking(t *testing.T) {
 	if runtime.GOOS != "linux" {
 		t.Skip("This test is only applicable for Linux, as RawConn functionality is not implemented for non-linux platforms.")
 	}
-	ctx, cancel := context.WithTimeout(t.Context(), defaultTestTimeout)
-	defer cancel()
-	ln, err := net.Listen("tcp", "localhost:0")
-	if err != nil {
-		t.Fatalf("net.Listen failed: %v", err)
-	}
-	defer ln.Close()
-
-	data := []byte("hello tcp delayed")
-	connCh := make(chan net.Conn)
-	go func() {
-		conn, err := ln.Accept()
-		if err != nil {
-			return
-		}
-		connCh <- conn
-	}()
-
-	conn, err := net.Dial("tcp", ln.Addr().String())
-	if err != nil {
-		t.Fatalf("net.Dial failed: %v", err)
-	}
-	defer conn.Close()
-
-	serverConn := <-connCh
-	defer serverConn.Close()
-
-	pool := newTrackingPool(mem.DefaultBufferPool())
-	ac := readyreader.New(conn)
-
-	resCh := make(chan []byte)
-	const readBufSize = 1024
-
-	go func() {
-		bufHandle, n, err := ac.ReadOnReady(readBufSize, pool)
-		if err != nil {
-			t.Errorf("Failed to read: %v", err)
-			return
-		}
-		defer pool.Put(bufHandle)
-		resCh <- (*bufHandle)[:n]
-	}()
-
-	// Verify that no read buffer is allocated for a short while. If it is
-	// allocated (e.g. for a probe), it must be returned immediately.
-	sCtx, sCancel := context.WithTimeout(ctx, defaultTestShortTimeout)
-	defer sCancel()
-	if n, err := pool.requestChan.Receive(sCtx); err == nil {
-		if n != readBufSize {
-			t.Fatalf("Unexpected request buffer size: got %d, want %d", n, readBufSize)
-		}
-		if n, err := pool.putChan.Receive(ctx); err != nil {
-			t.Fatal("Read buffer allocated and NOT returned while idle.")
-		} else if n != readBufSize {
-			t.Fatalf("Unexpected returned buffer size: got %d, want %d", n, readBufSize)
-		}
+	tests := []struct {
+		name string
+		read func(conn net.Conn, pool *trackingBufferPool, readBufSize int) ([]byte, error)
+	}{
+		{
+			name: "ReadyReader",
+			read: func(conn net.Conn, pool *trackingBufferPool, readBufSize int) ([]byte, error) {
+				rr := readyreader.New(conn)
+				bufHandle, n, err := rr.ReadOnReady(readBufSize, pool)
+				if err != nil {
+					return nil, err
+				}
+				defer pool.Put(bufHandle)
+				res := make([]byte, n)
+				copy(res, (*bufHandle)[:n])
+				return res, nil
+			},
+		},
+		{
+			name: "BufReadyReader",
+			read: func(conn net.Conn, pool *trackingBufferPool, readBufSize int) ([]byte, error) {
+				rr := readyreader.New(conn)
+				bufRR := readyreader.NewBuffered(rr, readBufSize, pool)
+				buf := make([]byte, 100)
+				n, err := bufRR.Read(buf)
+				if err != nil {
+					return nil, err
+				}
+				return buf[:n], nil
+			},
+		},
 	}
 
-	// Write data to unblock.
-	serverConn.Write(data)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(t.Context(), defaultTestTimeout)
+			defer cancel()
+			ln, err := net.Listen("tcp", "localhost:0")
+			if err != nil {
+				t.Fatalf("net.Listen failed: %v", err)
+			}
+			defer ln.Close()
 
-	if n, err := pool.requestChan.Receive(ctx); err != nil {
-		t.Fatal("Context timed out while waiting for a read buffer to be allocated.")
-	} else if n != readBufSize {
-		t.Fatalf("Unexpected request buffer size: got %d, want %d", n, readBufSize)
-	}
+			data := []byte("hello tcp delayed")
+			connCh := make(chan net.Conn)
+			go func() {
+				conn, err := ln.Accept()
+				if err != nil {
+					return
+				}
+				connCh <- conn
+			}()
 
-	var res []byte
-	select {
-	case res = <-resCh:
-	case <-ctx.Done():
-		t.Fatal("Context timed out waiting for read to complete.")
-	}
-	if !bytes.Equal(res, data) {
-		t.Errorf("Read data = %s; want %s", string(res), string(data))
+			conn, err := net.Dial("tcp", ln.Addr().String())
+			if err != nil {
+				t.Fatalf("net.Dial failed: %v", err)
+			}
+			defer conn.Close()
+
+			serverConn := <-connCh
+			defer serverConn.Close()
+
+			pool := newTrackingPool(mem.DefaultBufferPool())
+			const readBufSize = 1024
+
+			resCh := make(chan []byte)
+
+			go func() {
+				res, err := tc.read(conn, pool, readBufSize)
+				if err != nil {
+					t.Errorf("Failed to read: %v", err)
+					return
+				}
+				resCh <- res
+			}()
+
+			// Verify that no read buffer is allocated for a short while. If it
+			// is allocated (e.g. for a probe), it must be returned immediately.
+			sCtx, sCancel := context.WithTimeout(ctx, defaultTestShortTimeout)
+			defer sCancel()
+			if n, err := pool.requestChan.Receive(sCtx); err == nil {
+				if n != readBufSize {
+					t.Fatalf("Unexpected request buffer size: got %d, want %d", n, readBufSize)
+				}
+				if n, err := pool.putChan.Receive(ctx); err != nil {
+					t.Fatal("Read buffer allocated and NOT returned while idle.")
+				} else if n != readBufSize {
+					t.Fatalf("Unexpected returned buffer size: got %d, want %d", n, readBufSize)
+				}
+			}
+
+			// Write data to unblock.
+			serverConn.Write(data)
+
+			if n, err := pool.requestChan.Receive(ctx); err != nil {
+				t.Fatal("Context timed out while waiting for a read buffer to be allocated.")
+			} else if n != readBufSize {
+				t.Fatalf("Unexpected request buffer size: got %d, want %d", n, readBufSize)
+			}
+
+			var res []byte
+			select {
+			case res = <-resCh:
+			case <-ctx.Done():
+				t.Fatal("Context timed out waiting for read to complete.")
+			}
+			if !bytes.Equal(res, data) {
+				t.Errorf("Read data = %s; want %s", string(res), string(data))
+			}
+		})
 	}
 }
 
@@ -227,4 +265,146 @@ func (p *trackingBufferPool) Get(size int) *[]byte {
 func (p *trackingBufferPool) Put(b *[]byte) {
 	p.putChan.Replace(len(*b))
 	p.BufferPool.Put(b)
+}
+
+// Call Read to accumulate the text of a file
+func reads(buf io.Reader, m int) string {
+	var b [1000]byte
+	nb := 0
+	for {
+		n, err := buf.Read(b[nb : nb+m])
+		nb += n
+		if err == io.EOF {
+			break
+		}
+	}
+	return string(b[0:nb])
+}
+
+type bufReader struct {
+	name string
+	fn   func(io.Reader) string
+}
+
+var bufreaders = []bufReader{
+	{"1", func(b io.Reader) string { return reads(b, 1) }},
+	{"2", func(b io.Reader) string { return reads(b, 2) }},
+	{"3", func(b io.Reader) string { return reads(b, 3) }},
+	{"4", func(b io.Reader) string { return reads(b, 4) }},
+	{"5", func(b io.Reader) string { return reads(b, 5) }},
+	{"7", func(b io.Reader) string { return reads(b, 7) }},
+}
+
+const minReadBufferSize = 16
+
+var bufsizes = []int{
+	0, minReadBufferSize, 23, 32, 46, 64, 93, 128, 1024, 4096,
+}
+
+func (s) TestBufReader(t *testing.T) {
+	var texts [31]string
+	str := ""
+	all := ""
+	for i := range len(texts) - 1 {
+		texts[i] = str + "\n"
+		all += texts[i]
+		str += string(rune(i%26 + 'a'))
+	}
+	texts[len(texts)-1] = all
+
+	for _, text := range texts {
+		for _, bufreader := range bufreaders {
+			for _, bufsize := range bufsizes {
+				// We don't use t.Run() here to avoid excessive logging due to
+				// the large number of subtests.
+				read := readyreader.New(strings.NewReader(text))
+				buf := readyreader.NewBuffered(read, bufsize, mem.DefaultBufferPool())
+				s := bufreader.fn(buf)
+				if s != text {
+					t.Errorf("fn=%s bufsize=%d want=%q got=%q", bufreader.name, bufsize, text, s)
+				}
+			}
+		}
+	}
+}
+
+func (s) TestBufReader_ReadEmptyBuffer(t *testing.T) {
+	rr := readyreader.New(new(bytes.Buffer))
+	l := readyreader.NewBuffered(rr, minReadBufferSize, mem.DefaultBufferPool())
+	b := make([]byte, 100)
+	n, err := l.Read(b)
+	if err != io.EOF {
+		t.Errorf("expected EOF from Read, got %q %v", b[:n], err)
+	}
+}
+
+type errorThenGoodReader struct {
+	didErr bool
+	nread  int
+}
+
+var errFake = errors.New("fake error")
+
+func (r *errorThenGoodReader) Read(p []byte) (int, error) {
+	r.nread++
+	if !r.didErr {
+		r.didErr = true
+		return 0, errFake
+	}
+	return len(p), nil
+}
+
+func (s) TestBufReader_ClearError(t *testing.T) {
+	r := &errorThenGoodReader{}
+	b := readyreader.NewBuffered(readyreader.New(r), minReadBufferSize, mem.DefaultBufferPool())
+	buf := make([]byte, 1)
+	if _, err := b.Read(nil); err != nil {
+		t.Fatalf("1st nil Read = %v; want nil", err)
+	}
+	if _, err := b.Read(buf); err != errFake {
+		t.Fatalf("1st Read = %v; want errFake", err)
+	}
+	if _, err := b.Read(nil); err != nil {
+		t.Fatalf("2nd nil Read = %v; want nil", err)
+	}
+	if _, err := b.Read(buf); err != nil {
+		t.Fatalf("3rd Read with buffer = %v; want nil", err)
+	}
+	if r.nread != 2 {
+		t.Errorf("num reads = %d; want 2", r.nread)
+	}
+}
+
+type emptyThenNonEmptyReader struct {
+	r io.Reader
+	n int
+}
+
+func (r *emptyThenNonEmptyReader) Read(p []byte) (int, error) {
+	if r.n <= 0 {
+		return r.r.Read(p)
+	}
+	r.n--
+	return 0, nil
+}
+
+func (s) TestBufReader_ReadZero(t *testing.T) {
+	for _, size := range []int{100, 2} {
+		t.Run(fmt.Sprintf("bufsize=%d", size), func(t *testing.T) {
+			r := io.MultiReader(strings.NewReader("abc"), &emptyThenNonEmptyReader{r: strings.NewReader("def"), n: 1})
+			br := readyreader.NewBuffered(readyreader.New(r), size, mem.DefaultBufferPool())
+			want := func(s string, wantErr error) {
+				p := make([]byte, 50)
+				n, err := br.Read(p)
+				if err != wantErr || n != len(s) || string(p[:n]) != s {
+					t.Fatalf("read(%d) = %q, %v, want %q, %v", len(p), string(p[:n]), err, s, wantErr)
+				}
+				t.Logf("read(%d) = %q, %v", len(p), string(p[:n]), err)
+			}
+			want("abc", nil)
+			want("", nil)
+			want("def", nil)
+			want("", io.EOF)
+		})
+	}
 }

--- a/internal/transport/readyreader/ready_reader_ext_test.go
+++ b/internal/transport/readyreader/ready_reader_ext_test.go
@@ -123,7 +123,11 @@ func (s) TestReadyReader_EOF(t *testing.T) {
 	}
 }
 
-func (s) TestReadyReader_TCP_Blocking(t *testing.T) {
+// Tests the behavior of readers wrapping TCP connections. It ensures that read
+// operations do not hold onto an allocated buffer while the connection is idle.
+// Buffers should only be permanently allocated from the pool when data is
+// actually ready on the socket, optimizing memory usage for idle connections.
+func (s) TestReadyReader_TCP(t *testing.T) {
 	if runtime.GOOS != "linux" {
 		t.Skip("This test is only applicable for Linux, as RawConn functionality is not implemented for non-linux platforms.")
 	}


### PR DESCRIPTION
Original PRs: #9055, #9032

RELEASE NOTES:
* transport: Pool HTTP/2 framer read buffers to reduce idle memory consumption. Currently limited to Linux for ALTS and non-encrypted transports (TCP, Unix). To disable, set `GRPC_GO_EXPERIMENTAL_HTTP_FRAMER_READ_BUFFER_POOLING=false` and report any issues.