### PR TITLE
h3/quic support when users provides own http server

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ The [Go][] implementation of [gRPC][]: A high performance, open source, general
 RPC framework that puts mobile and HTTP/2 first. For more information see the
 [Go gRPC docs][], or jump directly into the [quick start][].
 
+Transport support:
+
+- [x] HTTP/2 gRPC client and server transports
+- [x] HTTP/3 gRPC server transport through `Server.ServeHTTP`
+- [ ] HTTP/3 gRPC client transport
+
 ## Prerequisites
 
 - **[Go][]**: any one of the **two latest major** [releases][go-releases].

--- a/internal/transport/handler_server.go
+++ b/internal/transport/handler_server.go
@@ -16,10 +16,9 @@
  *
  */
 
-// This file is the implementation of a gRPC server using HTTP/2 which
-// uses the standard Go http2 Server implementation (via the
-// http.Handler interface), rather than speaking low-level HTTP/2
-// frames itself. It is the implementation of *grpc.Server.ServeHTTP.
+// This file is the implementation of a gRPC server using an http.Handler
+// interface, rather than speaking low-level HTTP frames itself. It is the
+// implementation of *grpc.Server.ServeHTTP.
 
 package transport
 
@@ -47,9 +46,9 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-// NewServerHandlerTransport returns a ServerTransport handling gRPC from
-// inside an http.Handler, or writes an HTTP error to w and returns an error.
-// It requires that the http Server supports HTTP/2.
+// NewServerHandlerTransport returns a ServerTransport handling gRPC from inside
+// an http.Handler, or writes an HTTP error to w and returns an error. It
+// requires that the HTTP server supports HTTP/2 or HTTP/3.
 func NewServerHandlerTransport(w http.ResponseWriter, r *http.Request, stats stats.Handler, bufferPool mem.BufferPool) (ServerTransport, error) {
 	if r.Method != http.MethodPost {
 		w.Header().Set("Allow", http.MethodPost)
@@ -65,8 +64,8 @@ func NewServerHandlerTransport(w http.ResponseWriter, r *http.Request, stats sta
 		http.Error(w, msg, http.StatusUnsupportedMediaType)
 		return nil, errors.New(msg)
 	}
-	if r.ProtoMajor != 2 {
-		msg := "gRPC requires HTTP/2"
+	if r.ProtoMajor != 2 && r.ProtoMajor != 3 {
+		msg := "gRPC requires HTTP/2 or HTTP/3"
 		http.Error(w, msg, http.StatusHTTPVersionNotSupported)
 		return nil, errors.New(msg)
 	}
@@ -139,9 +138,8 @@ func NewServerHandlerTransport(w http.ResponseWriter, r *http.Request, stats sta
 
 // serverHandlerTransport is an implementation of ServerTransport
 // which replies to exactly one gRPC request (exactly one HTTP request),
-// using the net/http.Handler interface. This http.Handler is guaranteed
-// at this point to be speaking over HTTP/2, so it's able to speak valid
-// gRPC.
+// using the net/http.Handler interface. This http.Handler is guaranteed at this
+// point to be speaking over HTTP/2 or HTTP/3, so it's able to speak valid gRPC.
 type serverHandlerTransport struct {
 	rw         http.ResponseWriter
 	req        *http.Request
@@ -266,9 +264,9 @@ func (ht *serverHandlerTransport) writeStatus(s *ServerStream, st *status.Status
 					continue
 				}
 				for _, v := range vv {
-					// http2 ResponseWriter mechanism to send undeclared Trailers after
+					// net/http ResponseWriter mechanism to send undeclared Trailers after
 					// the headers have possibly been written.
-					h.Add(http2.TrailerPrefix+k, encodeMetadataHeader(k, v))
+					h.Add(http.TrailerPrefix+k, encodeMetadataHeader(k, v))
 				}
 			}
 		}

--- a/internal/transport/handler_server_test.go
+++ b/internal/transport/handler_server_test.go
@@ -82,7 +82,7 @@ func (s) TestHandlerTransport_NewServerHandlerTransport(t *testing.T) {
 				Method:     "POST",
 				Header:     http.Header{"Content-Type": []string{"application/grpc"}},
 			},
-			wantErr:     "gRPC requires HTTP/2",
+			wantErr:     "gRPC requires HTTP/2 or HTTP/3",
 			wantErrCode: http.StatusHTTPVersionNotSupported,
 		},
 		{
@@ -108,6 +108,28 @@ func (s) TestHandlerTransport_NewServerHandlerTransport(t *testing.T) {
 			name: "valid",
 			req: &http.Request{
 				ProtoMajor: 2,
+				Method:     "POST",
+				Header: http.Header{
+					"Content-Type": {"application/grpc"},
+				},
+				URL: &url.URL{
+					Path: "/service/foo.bar",
+				},
+			},
+			check: func(t *serverHandlerTransport, tt *testCase) error {
+				if t.req != tt.req {
+					return fmt.Errorf("t.req = %p; want %p", t.req, tt.req)
+				}
+				if t.rw == nil {
+					return errors.New("t.rw = nil; want non-nil")
+				}
+				return nil
+			},
+		},
+		{
+			name: "valid http/3",
+			req: &http.Request{
+				ProtoMajor: 3,
 				Method:     "POST",
 				Header: http.Header{
 					"Content-Type": {"application/grpc"},

--- a/server.go
+++ b/server.go
@@ -1081,25 +1081,24 @@ var _ http.Handler = (*Server)(nil)
 // interface by responding to the gRPC request r, by looking up
 // the requested gRPC method in the gRPC server s.
 //
-// The provided HTTP request must have arrived on an HTTP/2
-// connection. When using the Go standard library's server,
-// practically this means that the Request must also have arrived
-// over TLS.
+// The provided HTTP request must have arrived on an HTTP/2 or HTTP/3
+// connection. When using the Go standard library's server for HTTP/2,
+// practically this means that the Request must also have arrived over TLS.
 //
 // To share one port (such as 443 for https) between gRPC and an
 // existing http.Handler, use a root http.Handler such as:
 //
-//	if r.ProtoMajor == 2 && strings.HasPrefix(
+//	if (r.ProtoMajor == 2 || r.ProtoMajor == 3) && strings.HasPrefix(
 //		r.Header.Get("Content-Type"), "application/grpc") {
 //		grpcServer.ServeHTTP(w, r)
 //	} else {
 //		yourMux.ServeHTTP(w, r)
 //	}
 //
-// Note that ServeHTTP uses Go's HTTP/2 server implementation which is totally
-// separate from grpc-go's HTTP/2 server. Performance and features may vary
-// between the two paths. ServeHTTP does not support some gRPC features
-// available through grpc-go's HTTP/2 server.
+// Note that ServeHTTP uses the HTTP server implementation that supplied w and
+// r, which is totally separate from grpc-go's HTTP/2 server. Performance and
+// features may vary between the paths. ServeHTTP does not support some gRPC
+// features available through grpc-go's HTTP/2 server.
 //
 // # Experimental
 //


### PR DESCRIPTION
Minimal h3/quic "support" by using the `ServeHTTP` path to accept HTTP/3 requests. This requires the user to supply their own server like the `quic-go` h3 server. Outside of that, preserves all existing HTTP/2 behavior.

Validation:
 - trivial tests for h3 server
 - exercised grpc-go `ServeHTTP` behind a real `quic-go` HTTP/3 server path in our own project
 - existing test suite not impacted
 
RELEASE NOTES:
- support h3 with user supported h3 server (ex. quic-go)