### PR TITLE
grpc: Remove ErrRetriesExhausted type in favor of error string

### DIFF
--- a/stream.go
+++ b/stream.go
@@ -148,15 +148,6 @@ type ClientStream interface {
 	RecvMsg(m any) error
 }
 
-// ErrRetriesExhausted is returned when an RPC exceeds its configured maximum
-// number of retry attempts.
-//
-// # Experimental
-//
-// Notice: This type is EXPERIMENTAL and may be changed or removed in a
-// later release.
-var ErrRetriesExhausted = errors.New("max retry attempts exhausted")
-
 // NewStream creates a new Stream for the client side. This is typically
 // called by generated code. ctx is used for the lifetime of the stream.
 //
@@ -759,7 +750,7 @@ func (a *csAttempt) shouldRetry(err error) (bool, error) {
 		return false, err
 	}
 	if cs.numRetries+1 >= rp.MaxAttempts {
-		return false, fmt.Errorf("stopped after %d attempts: %w: %w", cs.numRetries+1, ErrRetriesExhausted, err)
+		return false, fmt.Errorf("max retries exhausted: failed after %d attempts: %w", cs.numRetries+1, err)
 	}
 
 	var dur time.Duration

--- a/test/retry_test.go
+++ b/test/retry_test.go
@@ -20,7 +20,6 @@ package test
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -576,8 +575,8 @@ func (s) TestMaxCallAttempts(t *testing.T) {
 				t.Fatalf("client: Recv() = %s, %v; want <nil>, error", got, err)
 			} else if status.Code(err) != codes.Unavailable {
 				t.Fatalf("client: Recv() = _, %v; want _, Unavailable", err)
-			} else if !errors.Is(err, grpc.ErrRetriesExhausted) {
-				t.Fatalf("want: ErrRetriesExhausted, got: %v", err)
+			} else if !strings.Contains(err.Error(), "retries exhausted") {
+				t.Fatalf("want: retries exhausted, got: %v", err)
 			}
 
 			serverMu.Lock()
@@ -910,8 +909,8 @@ func (s) TestNoRetry(t *testing.T) {
 			if status.Code(err) != codes.Unavailable {
 				t.Fatalf("client: Recv() = _, %v; want _, Unavailable", err)
 			}
-			if errors.Is(err, grpc.ErrRetriesExhausted) {
-				t.Fatalf("client: Recv() error matches ErrRetriesExhausted, want not match")
+			if strings.Contains(err.Error(), "retries exhausted") {
+				t.Fatalf("client: EmptyCall() failed with an unexpected 'retries exhausted' error: %v", err)
 			}
 
 			// Test unary RPC
@@ -922,8 +921,9 @@ func (s) TestNoRetry(t *testing.T) {
 			if status.Code(err) != codes.Unavailable {
 				t.Fatalf("client: EmptyCall() = _, %v; want _, Unavailable", err)
 			}
-			if errors.Is(err, grpc.ErrRetriesExhausted) {
-				t.Fatalf("client: EmptyCall() error matches ErrRetriesExhausted, want not match")
+
+			if strings.Contains(err.Error(), "retries exhausted") {
+				t.Fatalf("client: EmptyCall() failed with an unexpected 'retries exhausted' error: %v", err)
 			}
 		})
 	}


### PR DESCRIPTION
Addresses: #7023

This change removes the `ErrRetriesExhausted` error type introduced in #8894. The original requirement was only to add information to the error message, not to provide the ability to programmatically inspect error types. This PR keeps the updated error message but removes the new error type. Since #7023 hasn't been released yet, this is not a breaking change.

RELEASE NOTES: N/A