### PR TITLE
internal/xds/rbac: fix authenticatedMatcher to evaluate principal rules for ALTS connections

### DIFF
--- a/internal/xds/rbac/matchers.go
+++ b/internal/xds/rbac/matchers.go
@@ -420,8 +420,18 @@ func newAuthenticatedMatcher(authenticatedMatcherConfig *v3rbacpb.Principal_Auth
 }
 
 func (am *authenticatedMatcher) match(data *rpcData) bool {
-	if data.authType != "tls" {
-		// Connection is not authenticated.
+	switch data.authType {
+	case "tls":
+		// TLS: match against the peer certificate's SANs and Subject.
+	case "alts":
+		// ALTS: the peer identity is the service account returned by the ALTS
+		// handshaker. Match directly against that string.
+		if am.stringMatcher == nil {
+			return true
+		}
+		return am.stringMatcher.Match(data.peerPrincipal)
+	default:
+		// Connection is not authenticated by a recognised transport.
 		return false
 	}
 	if am.stringMatcher == nil {

--- a/internal/xds/rbac/rbac_engine.go
+++ b/internal/xds/rbac/rbac_engine.go
@@ -32,6 +32,7 @@ import (
 	"google.golang.org/grpc/authz/audit"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/alts"
 	"google.golang.org/grpc/grpclog"
 	"google.golang.org/grpc/internal/transport"
 	"google.golang.org/grpc/metadata"
@@ -240,9 +241,16 @@ func newRPCData(ctx context.Context) (*rpcData, error) {
 
 	var authType string
 	var peerCertificates []*x509.Certificate
+	var peerPrincipal string
 	if tlsInfo, ok := pi.AuthInfo.(credentials.TLSInfo); ok {
 		authType = pi.AuthInfo.AuthType()
 		peerCertificates = tlsInfo.State.PeerCertificates
+	} else if altsInfo, ok := pi.AuthInfo.(alts.AuthInfo); ok {
+		// ALTS connections are mutually authenticated. Extract the peer
+		// service account so that authenticatedMatcher can evaluate principal
+		// rules against it, just as it would against TLS certificate SANs.
+		authType = pi.AuthInfo.AuthType()
+		peerPrincipal = altsInfo.PeerServiceAccount()
 	}
 
 	return &rpcData{
@@ -253,6 +261,7 @@ func newRPCData(ctx context.Context) (*rpcData, error) {
 		localAddr:       conn.LocalAddr(),
 		authType:        authType,
 		certs:           peerCertificates,
+		peerPrincipal:   peerPrincipal,
 	}, nil
 }
 
@@ -270,11 +279,14 @@ type rpcData struct {
 	destinationPort uint32
 	// localAddr is the address that the RPC is being sent to.
 	localAddr net.Addr
-	// authType is the type of authentication e.g. "tls".
+	// authType is the type of authentication e.g. "tls" or "alts".
 	authType string
 	// certs are the certificates presented by the peer during a TLS
 	// handshake.
 	certs []*x509.Certificate
+	// peerPrincipal is the authenticated peer identity for non-TLS transports
+	// that carry identity directly (e.g. ALTS service accounts).
+	peerPrincipal string
 }
 
 func (e *engine) doAuditLogging(rpcData *rpcData, rule string, authorized bool) {

--- a/internal/xds/rbac/rbac_engine_test.go
+++ b/internal/xds/rbac/rbac_engine_test.go
@@ -65,7 +65,7 @@ func Test(t *testing.T) {
 // Prior to the fix, the matcher checked data.authType == "tls" and returned
 // false for all ALTS connections, silently rendering every principal-based
 // DENY rule inoperative against ALTS peers.
-func TestAuthenticatedMatcherALTS(t *testing.T) {
+func (s) TestAuthenticatedMatcherALTS(t *testing.T) {
 	tests := []struct {
 		desc          string
 		peerPrincipal string

--- a/internal/xds/rbac/rbac_engine_test.go
+++ b/internal/xds/rbac/rbac_engine_test.go
@@ -59,6 +59,67 @@ func Test(t *testing.T) {
 	grpctest.RunSubTests(t, s{})
 }
 
+// TestAuthenticatedMatcherALTS verifies that authenticatedMatcher correctly
+// evaluates principal rules for ALTS-authenticated connections.
+//
+// Prior to the fix, the matcher checked data.authType == "tls" and returned
+// false for all ALTS connections, silently rendering every principal-based
+// DENY rule inoperative against ALTS peers.
+func TestAuthenticatedMatcherALTS(t *testing.T) {
+	tests := []struct {
+		desc          string
+		peerPrincipal string
+		matchExact    string // exact principal to match against
+		wantMatch     bool
+	}{
+		{
+			desc:          "matching ALTS service account",
+			peerPrincipal: "attacker@project.iam.gserviceaccount.com",
+			matchExact:    "attacker@project.iam.gserviceaccount.com",
+			wantMatch:     true,
+		},
+		{
+			desc:          "non-matching ALTS service account",
+			peerPrincipal: "other@project.iam.gserviceaccount.com",
+			matchExact:    "attacker@project.iam.gserviceaccount.com",
+			wantMatch:     false,
+		},
+		{
+			desc:          "unauthenticated connection rejected",
+			peerPrincipal: "",
+			matchExact:    "attacker@project.iam.gserviceaccount.com",
+			wantMatch:     false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			// Build an authenticatedMatcher with an exact string match.
+			authType := "alts"
+			if tc.peerPrincipal == "" {
+				authType = "" // simulate unauthenticated
+			}
+			data := &rpcData{
+				authType:      authType,
+				peerPrincipal: tc.peerPrincipal,
+			}
+			// Construct the matcher via the proto helper so we go through the
+			// same code path as production.
+			m, err := newAuthenticatedMatcher(&v3rbacpb.Principal_Authenticated{
+				PrincipalName: &v3matcherpb.StringMatcher{
+					MatchPattern: &v3matcherpb.StringMatcher_Exact{Exact: tc.matchExact},
+				},
+			})
+			if err != nil {
+				t.Fatalf("newAuthenticatedMatcher() failed: %v", err)
+			}
+			if got := m.match(data); got != tc.wantMatch {
+				t.Errorf("authenticatedMatcher.match() = %v, want %v (principal=%q, authType=%q)",
+					got, tc.wantMatch, tc.peerPrincipal, data.authType)
+			}
+		})
+	}
+}
+
 type addr struct {
 	ipAddress string
 }


### PR DESCRIPTION
## Summary

The RBAC `authenticatedMatcher` silently returned `false` for **all ALTS connections**, making every principal-based `DENY` rule inoperative against ALTS peers.

## Root Cause

`newRPCData()` only populated `authType` and `peerCertificates` when `pi.AuthInfo` was `credentials.TLSInfo`:

```go
var authType string
var peerCertificates []*x509.Certificate
if tlsInfo, ok := pi.AuthInfo.(credentials.TLSInfo); ok {
    authType = pi.AuthInfo.AuthType()
    peerCertificates = tlsInfo.State.PeerCertificates
}
// ALTS: assertion fails → authType = "", peerCertificates = nil
```

Then `authenticatedMatcher.match()` rejected all non-TLS connections:

```go
if data.authType != "tls" {
    return false  // always fires for ALTS ("" != "tls")
}
```

## Impact

A GCP service using ALTS transport credentials with an RBAC interceptor and a `DENY` rule based on `source.principals` — e.g., to block a specific service account — would **never** fire that rule. The denied service account bypasses the deny list with no error, warning, or log. ALLOW rules based on principals are equally affected.

ALTS + RBAC for identity-based access control is a natural and documented combination for internal GCP services. The silent no-op gives operators false confidence that their RBAC policy is enforced.

## Fix

1. **`newRPCData()`**: Also extract auth info when `pi.AuthInfo` implements `alts.AuthInfo`. Set `authType = "alts"` and `peerPrincipal = altsInfo.PeerServiceAccount()`. Add `peerPrincipal string` field to `rpcData`.

2. **`authenticatedMatcher.match()`**: Switch on `authType`; handle `"alts"` by matching the string matcher against `peerPrincipal` directly (ALTS carries identity as a service account string, not an X.509 certificate). Continue to reject unknown auth types.

## Tests

`TestAuthenticatedMatcherALTS` covers:
- Matching ALTS service account → `true`
- Non-matching ALTS service account → `false`
- Unauthenticated connection → `false`

RELEASE NOTES:
- TBD