### PR TITLE
test: incoming RPC that contains a path with double leading slashes

### DIFF
--- a/test/malformed_method_test.go
+++ b/test/malformed_method_test.go
@@ -41,18 +41,23 @@ func (s) TestMalformedMethodPath(t *testing.T) {
 		wantStatus string // string representation of codes.Code
 	}{
 		{
-			name:       "missing_leading_slash_disableStrictPathChecking_false",
+			name:       "missing_leading_slash",
 			path:       "grpc.testing.TestService/UnaryCall",
 			wantStatus: "12", // Unimplemented
 		},
 		{
-			name:       "empty_path_disableStrictPathChecking_false",
+			name:       "empty_path",
 			path:       "",
 			wantStatus: "12", // Unimplemented
 		},
 		{
-			name:       "just_slash_disableStrictPathChecking_false",
+			name:       "just_slash",
 			path:       "/",
+			wantStatus: "12", // Unimplemented
+		},
+		{
+			name:       "double_slash",
+			path:       "//grpc.testing.TestService/UnaryCall",
 			wantStatus: "12", // Unimplemented
 		},
 	}


### PR DESCRIPTION
Adding a test in response to a vulnerability report from a user claiming that we are allow an auth bypass for incoming paths that contain double leading slashes. We are already handling this correctly, and this PR simply adds a test for it.

RELEASE NOTES: none