### PR TITLE
xds/rbac: skip degenerate empty URI SANs in authenticatedMatcher

### DIFF
--- a/internal/xds/rbac/matchers.go
+++ b/internal/xds/rbac/matchers.go
@@ -437,7 +437,16 @@ func (am *authenticatedMatcher) match(data *rpcData) bool {
 	cert := data.certs[0]
 	// Use the first non-empty identity source in priority order:
 	// URI SANs, then DNS SANs, then Subject.
-	if len(cert.URIs) > 0 {
+	// Skip degenerate URI entries (empty url.URL{}) that serialize to ""
+	// to avoid treating them as a present identity source.
+	hasNonEmptyURI := false
+	for _, u := range cert.URIs {
+		if u.String() != "" {
+			hasNonEmptyURI = true
+			break
+		}
+	}
+	if hasNonEmptyURI {
 		for _, uriSAN := range cert.URIs {
 			if am.stringMatcher.Match(uriSAN.String()) {
 				return true

--- a/internal/xds/rbac/rbac_engine_test.go
+++ b/internal/xds/rbac/rbac_engine_test.go
@@ -2081,8 +2081,8 @@ func TestAuthenticatedMatcherEmptyURISAN(t *testing.T) {
 			wantMatch: true,
 		},
 		{
-			name: "mixedEmptyAndValidURISANNoFallthrough",
-			uris: []*url.URL{{}, mustParseURL("spiffe://corp.example/svc/other")},
+			name:     "mixedEmptyAndValidURISANNoFallthrough",
+			uris:     []*url.URL{{}, mustParseURL("spiffe://corp.example/svc/other")},
 			dnsNames: []string{"svc.legitimate.internal"},
 			matcher: &v3matcherpb.StringMatcher{
 				MatchPattern: &v3matcherpb.StringMatcher_Contains{

--- a/internal/xds/rbac/rbac_engine_test.go
+++ b/internal/xds/rbac/rbac_engine_test.go
@@ -2035,3 +2035,104 @@ func TestAuthenticatedMatcherIdentitySourcePrecedence(t *testing.T) {
 		})
 	}
 }
+
+// TestAuthenticatedMatcherEmptyURISAN verifies that a certificate containing
+// a degenerate (empty) URI SAN does not prevent fallthrough to DNS SANs.
+// An empty url.URL{} serializes to "" via String(), which should not be
+// treated as a meaningful identity source.
+func TestAuthenticatedMatcherEmptyURISAN(t *testing.T) {
+	tests := []struct {
+		name      string
+		uris      []*url.URL
+		dnsNames  []string
+		subjectCN string
+		matcher   *v3matcherpb.StringMatcher
+		wantMatch bool
+	}{
+		{
+			name:     "emptyURISANFallsThroughToDNS",
+			uris:     []*url.URL{{}},
+			dnsNames: []string{"svc.legitimate.internal"},
+			matcher: &v3matcherpb.StringMatcher{
+				MatchPattern: &v3matcherpb.StringMatcher_Contains{
+					Contains: "svc.legitimate.internal",
+				},
+			},
+			wantMatch: true,
+		},
+		{
+			name: "emptyURISANDoesNotMatchPrefix",
+			uris: []*url.URL{{}},
+			matcher: &v3matcherpb.StringMatcher{
+				MatchPattern: &v3matcherpb.StringMatcher_Prefix{
+					Prefix: "spiffe://corp.example/",
+				},
+			},
+			wantMatch: false,
+		},
+		{
+			name: "mixedEmptyAndValidURISAN",
+			uris: []*url.URL{{}, mustParseURL("spiffe://corp.example/svc/admin")},
+			matcher: &v3matcherpb.StringMatcher{
+				MatchPattern: &v3matcherpb.StringMatcher_Contains{
+					Contains: "spiffe://corp.example/svc/admin",
+				},
+			},
+			wantMatch: true,
+		},
+		{
+			name: "mixedEmptyAndValidURISANNoFallthrough",
+			uris: []*url.URL{{}, mustParseURL("spiffe://corp.example/svc/other")},
+			dnsNames: []string{"svc.legitimate.internal"},
+			matcher: &v3matcherpb.StringMatcher{
+				MatchPattern: &v3matcherpb.StringMatcher_Contains{
+					Contains: "svc.legitimate.internal",
+				},
+			},
+			wantMatch: false,
+		},
+		{
+			name:      "allEmptyURISANsFallThroughToSubject",
+			uris:      []*url.URL{{}, {}},
+			subjectCN: "svc.legitimate.internal",
+			matcher: &v3matcherpb.StringMatcher{
+				MatchPattern: &v3matcherpb.StringMatcher_Contains{
+					Contains: "svc.legitimate.internal",
+				},
+			},
+			wantMatch: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cert := &x509.Certificate{
+				URIs:     tt.uris,
+				DNSNames: tt.dnsNames,
+				Subject:  pkix.Name{CommonName: tt.subjectCN},
+			}
+			amConfig := &v3rbacpb.Principal_Authenticated{
+				PrincipalName: tt.matcher,
+			}
+			matcher, err := newAuthenticatedMatcher(amConfig)
+			if err != nil {
+				t.Fatalf("failed to create matcher: %v", err)
+			}
+			rpcData := &rpcData{
+				authType: "tls",
+				certs:    []*x509.Certificate{cert},
+			}
+			if got := matcher.match(rpcData); got != tt.wantMatch {
+				t.Errorf("match() = %v, want %v", got, tt.wantMatch)
+			}
+		})
+	}
+}
+
+func mustParseURL(s string) *url.URL {
+	u, err := url.Parse(s)
+	if err != nil {
+		panic(err)
+	}
+	return u
+}


### PR DESCRIPTION
## Summary

The `authenticatedMatcher` in the xDS RBAC engine treats `len(cert.URIs) > 0` as "URI SANs are present". However, a certificate can contain a degenerate empty URI SAN (`url.URL{}`) where `String()` returns `""`. This satisfies the length check but produces an empty-string identity, which:

- Does not match any SPIFFE-based DENY prefix rules, silently evading them
- Prevents fallthrough to DNS SANs or Subject DN per the precedence logic added in #9111

This PR adds a pre-scan to skip degenerate URI entries before deciding whether URI SANs constitute a present identity source.

## Root cause

Commit 94b9449 (#9111) correctly enforces strict identity source precedence per gRFC A41. But the `len(cert.URIs) > 0` check does not account for Go's `x509.Certificate.URIs` containing entries like `&url.URL{}`, which `x509.CreateCertificate()` accepts without error.

## Fix

Before treating URI SANs as "present", scan for at least one entry where `String() != ""`. If all URI entries are degenerate, fall through to DNS SANs as if no URI SANs existed.

## Test plan

- [x] New `TestAuthenticatedMatcherEmptyURISAN` with 5 cases covering empty URI SAN fallthrough, mixed empty/valid URIs, and no-fallthrough when valid URIs exist
- [x] All existing `TestAuthenticatedMatcherIdentitySourcePrecedence` tests pass (no regression)

RELEASE NOTES:
- xds/rbac: Fix `authenticatedMatcher` to skip degenerate empty URI SANs when determining the identity source, preventing silent DENY rule evasion.