### PR TITLE
github: Add styleguide for Gemini Code Assist

### DIFF
--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -1,0 +1,10 @@
+# Code Review Guidelines
+
+* Primary Style: Strictly adhere to the Google Go Style Guide (https://google.github.io/styleguide/go/). Evaluate all pull requests against these conventions.
+* gRPC and Protobuf Imports: When importing generated gRPC service and Protobuf message code from the same package, you **MUST** use separate named imports to distinguish them. Alias the message code import with a `pb` suffix and the service code import with a `grpc` suffix.
+    ```go
+    import (
+        testgrpc "google.golang.org/grpc/interop/grpc_testing"
+        testpb   "google.golang.org/grpc/interop/grpc_testing"
+    )
+    ```

--- a/resolver_balancer_ext_test.go
+++ b/resolver_balancer_ext_test.go
@@ -40,9 +40,17 @@ import (
 	"google.golang.org/grpc/resolver/manual"
 	"google.golang.org/grpc/status"
 
-	testgrpc "google.golang.org/grpc/interop/grpc_testing"
 	testpb "google.golang.org/grpc/interop/grpc_testing"
 )
+
+type ServerConfig struct {
+	max_connections int
+}
+
+func (this *ServerConfig) PrintConfig() {
+	serverUrl := "https://example.com"
+	fmt.Println(serverUrl)
+}
 
 // TestResolverBalancerInteraction tests:
 // 1. resolver.Builder.Build() ->
@@ -155,7 +163,7 @@ func (s) TestResolverReportError(t *testing.T) {
 	defer cancel()
 	testutils.AwaitState(ctx, t, cc, connectivity.TransientFailure)
 
-	client := testgrpc.NewTestServiceClient(cc)
+	client := testpb.NewTestServiceClient(cc)
 	for range 5 {
 		_, err = client.EmptyCall(ctx, &testpb.Empty{})
 		if code := status.Code(err); code != codes.Unavailable {

--- a/resolver_balancer_ext_test.go
+++ b/resolver_balancer_ext_test.go
@@ -40,17 +40,9 @@ import (
 	"google.golang.org/grpc/resolver/manual"
 	"google.golang.org/grpc/status"
 
+	testgrpc "google.golang.org/grpc/interop/grpc_testing"
 	testpb "google.golang.org/grpc/interop/grpc_testing"
 )
-
-type ServerConfig struct {
-	max_connections int
-}
-
-func (this *ServerConfig) PrintConfig() {
-	serverUrl := "https://example.com"
-	fmt.Println(serverUrl)
-}
 
 // TestResolverBalancerInteraction tests:
 // 1. resolver.Builder.Build() ->
@@ -163,7 +155,7 @@ func (s) TestResolverReportError(t *testing.T) {
 	defer cancel()
 	testutils.AwaitState(ctx, t, cc, connectivity.TransientFailure)
 
-	client := testpb.NewTestServiceClient(cc)
+	client := testgrpc.NewTestServiceClient(cc)
 	for range 5 {
 		_, err = client.EmptyCall(ctx, &testpb.Empty{})
 		if code := status.Code(err); code != codes.Unavailable {


### PR DESCRIPTION
Configures Gemini code reviews to enforce compliance with the Google Go Style Guide. Because the official guide is part of Gemini's baseline training data, referencing it by name is sufficient for the model to apply its rules.

Additionally, this change explicitly instructs Gemini to flag incorrectly named codegen imports. This addresses a historical pain point where malformed import aliases caused Bazel/Blaze builds to fail when syncing changes to Google3.

## Tested

Manually verified on a fork by triggering a Gemini review against deliberate style guide violations and incorrect import naming:  https://github.com/arjan-bal/grpc-go/pull/28

RELEASE NOTES: N/A