### PR TITLE
refactor(transport): extract shared stream state handling logic in `loopyWriter.processData()`

### DIFF
--- a/internal/transport/controlbuf.go
+++ b/internal/transport/controlbuf.go
@@ -956,30 +956,16 @@ func (l *loopyWriter) processData() (bool, error) {
 	// from data is copied to h to make as big as the maximum possible HTTP2 frame
 	// size.
 
-	if len(dataItem.h) == 0 && reader.Remaining() == 0 { // Empty data frame
-		// Client sends out empty data frame with endStream = true
-		if err := l.framer.writeData(dataItem.streamID, dataItem.endStream, nil); err != nil {
-			return false, err
-		}
-		str.itl.dequeue() // remove the empty data item from stream
-		reader.Close()
-		if err := l.updateStreamAfterWrite(str); err != nil {
-			return false, err
-		}
-		return false, nil
-	}
-
+	isEmpty := len(dataItem.h) == 0 && reader.Remaining() == 0
 	// Figure out the maximum size we can send
 	maxSize := http2MaxFrameLen
-	if strQuota := int(l.oiws) - str.bytesOutStanding; strQuota <= 0 { // stream-level flow control.
+	strQuota := int(l.oiws) - str.bytesOutStanding
+	if strQuota <= 0 && !isEmpty { // stream-level flow control.
 		str.state = waitingOnStreamQuota
 		return false, nil
-	} else if maxSize > strQuota {
-		maxSize = strQuota
 	}
-	if maxSize > int(l.sendQuota) { // connection-level flow control.
-		maxSize = int(l.sendQuota)
-	}
+	maxSize = min(maxSize, max(strQuota, 0))
+	maxSize = min(maxSize, int(l.sendQuota)) // connection-level flow control.
 	// Compute how much of the header and data we can send within quota and max frame length
 	hSize := min(maxSize, len(dataItem.h))
 	dSize := min(maxSize-hSize, reader.Remaining())
@@ -1009,7 +995,7 @@ func (l *loopyWriter) processData() (bool, error) {
 	if dataItem.endStream && remainingBytes == 0 {
 		endStream = true
 	}
-	if dataItem.onEachWrite != nil {
+	if dataItem.onEachWrite != nil && !isEmpty {
 		dataItem.onEachWrite()
 	}
 	err := l.framer.writeData(dataItem.streamID, endStream, l.writeBuf)
@@ -1030,10 +1016,7 @@ func (l *loopyWriter) processData() (bool, error) {
 		reader.Close()
 		str.itl.dequeue()
 	}
-	if err := l.updateStreamAfterWrite(str); err != nil {
-		return false, err
-	}
-	return false, nil
+	return false, l.updateStreamAfterWrite(str)
 }
 
 func (l *loopyWriter) updateStreamAfterWrite(str *outStream) error {
@@ -1048,7 +1031,7 @@ func (l *loopyWriter) updateStreamAfterWrite(str *outStream) error {
 		}
 	} else if int(l.oiws)-str.bytesOutStanding <= 0 { // Ran out of stream quota.
 		str.state = waitingOnStreamQuota
-	} else {
+	} else { // Otherwise add it back to the list of active streams.
 		l.activeStreams.enqueue(str)
 	}
 	return nil

--- a/internal/transport/controlbuf.go
+++ b/internal/transport/controlbuf.go
@@ -995,7 +995,7 @@ func (l *loopyWriter) processData() (bool, error) {
 	if dataItem.endStream && remainingBytes == 0 {
 		endStream = true
 	}
-	if dataItem.onEachWrite != nil && !isEmpty {
+	if dataItem.onEachWrite != nil {
 		dataItem.onEachWrite()
 	}
 	err := l.framer.writeData(dataItem.streamID, endStream, l.writeBuf)

--- a/internal/transport/controlbuf.go
+++ b/internal/transport/controlbuf.go
@@ -963,17 +963,8 @@ func (l *loopyWriter) processData() (bool, error) {
 		}
 		str.itl.dequeue() // remove the empty data item from stream
 		reader.Close()
-		if str.itl.isEmpty() {
-			str.state = empty
-		} else if trailer, ok := str.itl.peek().(*headerFrame); ok { // the next item is trailers.
-			if err := l.writeHeader(trailer.streamID, trailer.endStream, trailer.hf, trailer.onWrite); err != nil {
-				return false, err
-			}
-			if err := l.cleanupStreamHandler(trailer.cleanup); err != nil {
-				return false, err
-			}
-		} else {
-			l.activeStreams.enqueue(str)
+		if err := l.updateStreamAfterWrite(str); err != nil {
+			return false, err
 		}
 		return false, nil
 	}
@@ -1039,19 +1030,26 @@ func (l *loopyWriter) processData() (bool, error) {
 		reader.Close()
 		str.itl.dequeue()
 	}
+	if err := l.updateStreamAfterWrite(str); err != nil {
+		return false, err
+	}
+	return false, nil
+}
+
+func (l *loopyWriter) updateStreamAfterWrite(str *outStream) error {
 	if str.itl.isEmpty() {
 		str.state = empty
-	} else if trailer, ok := str.itl.peek().(*headerFrame); ok { // The next item is trailers.
+	} else if trailer, ok := str.itl.peek().(*headerFrame); ok { // the next item is trailers.
 		if err := l.writeHeader(trailer.streamID, trailer.endStream, trailer.hf, trailer.onWrite); err != nil {
-			return false, err
+			return err
 		}
 		if err := l.cleanupStreamHandler(trailer.cleanup); err != nil {
-			return false, err
+			return err
 		}
 	} else if int(l.oiws)-str.bytesOutStanding <= 0 { // Ran out of stream quota.
 		str.state = waitingOnStreamQuota
-	} else { // Otherwise add it back to the list of active streams.
+	} else {
 		l.activeStreams.enqueue(str)
 	}
-	return false, nil
+	return nil
 }


### PR DESCRIPTION
Fixes: #9117 

Refactors the duplicated post write stream state handling in `loopyWriter.processData()` present in `internal/transport/controlbuf.go` into a shared helper `l.updateStreamAfterWrite()`. Both empty and non empty DATA frame paths now share the same stream state handling logic.

This change also adds the stream quota check `(int(l.oiws) - str.bytesOutStanding)` to the empty frame path. This is safe because empty DATA frames send 0 bytes, so `bytesOutStanding` doesn't change.

RELEASE NOTES: n/a
