### PR TITLE
internal/xds: fix duplicated "the" in cdsbalancer_test comment

### DIFF
--- a/internal/xds/balancer/cdsbalancer/cdsbalancer_test.go
+++ b/internal/xds/balancer/cdsbalancer/cdsbalancer_test.go
@@ -990,7 +990,7 @@ func (s) TestClusterUpdate_ResourceNotFound(t *testing.T) {
 	}
 }
 
-// Tests that closing the cds LB policy results in the the child policy being
+// Tests that closing the cds LB policy results in the child policy being
 // closed.
 func (s) TestClose(t *testing.T) {
 	_, _, _, childPolicyCloseCh := registerWrappedPriorityPolicy(t)


### PR DESCRIPTION
One-line typo fix in `internal/xds/balancer/cdsbalancer/cdsbalancer_test.go`: "// Tests that closing the cds LB policy results in the the child policy being\n// closed." → "...results in the child policy being closed.". No code/behavior change.