### PR TITLE
metadata: replace added [][]string with O(1) delta linked list

### DIFF
--- a/internal/internal.go
+++ b/internal/internal.go
@@ -205,7 +205,7 @@ var (
 
 	// FromOutgoingContextRaw returns the un-merged, intermediary contents of
 	// metadata.rawMD.
-	FromOutgoingContextRaw any // func(context.Context) (metadata.MD, [][]string, bool)
+	FromOutgoingContextRaw any // func(context.Context) (metadata.MD, iter.Seq2[string, string], bool)
 
 	// UserSetDefaultScheme is set to true if the user has overridden the
 	// default resolver scheme.

--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"iter"
 	"math"
 	"net"
 	"net/http"
@@ -65,7 +66,7 @@ var clientConnectionCounter uint64
 
 var goAwayLoopyWriterTimeout = 5 * time.Second
 
-var metadataFromOutgoingContextRaw = internal.FromOutgoingContextRaw.(func(context.Context) (metadata.MD, [][]string, bool))
+var metadataFromOutgoingContextRaw = internal.FromOutgoingContextRaw.(func(context.Context) (metadata.MD, iter.Seq2[string, string], bool))
 
 // http2Client implements the ClientTransport interface with HTTP2.
 type http2Client struct {
@@ -621,7 +622,6 @@ func (t *http2Client) createHeaderFields(ctx context.Context, callHdr *CallHdr) 
 	}
 
 	if md, added, ok := metadataFromOutgoingContextRaw(ctx); ok {
-		var k string
 		for k, vv := range md {
 			// HTTP doesn't allow you to set pseudoheaders after non pseudoheaders were set.
 			if isReservedHeader(k) {
@@ -631,18 +631,12 @@ func (t *http2Client) createHeaderFields(ctx context.Context, callHdr *CallHdr) 
 				headerFields = append(headerFields, hpack.HeaderField{Name: k, Value: encodeMetadataHeader(k, v)})
 			}
 		}
-		for _, vv := range added {
-			for i, v := range vv {
-				if i%2 == 0 {
-					k = strings.ToLower(v)
-					continue
-				}
-				// HTTP doesn't allow you to set pseudoheaders after non pseudoheaders were set.
-				if isReservedHeader(k) {
-					continue
-				}
-				headerFields = append(headerFields, hpack.HeaderField{Name: k, Value: encodeMetadataHeader(k, v)})
+		for k, v := range added {
+			// HTTP doesn't allow you to set pseudoheaders after non pseudoheaders were set.
+			if isReservedHeader(k) {
+				continue
 			}
+			headerFields = append(headerFields, hpack.HeaderField{Name: k, Value: encodeMetadataHeader(k, v)})
 		}
 	}
 	for k, vv := range t.md {

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -279,7 +279,7 @@ func fromOutgoingContextRaw(ctx context.Context) (MD, iter.Seq2[string, string],
 
 // emptySeq2 is a no-op iterator returned when there are no appended key-value
 // pairs, avoiding nil-function panics at call sites that unconditionally range.
-var emptySeq2 iter.Seq2[string, string] = func(yield func(string, string) bool) {}
+var emptySeq2 iter.Seq2[string, string] = func(_ func(string, string) bool) {}
 
 // FromOutgoingContext returns the outgoing metadata in ctx if it exists.
 //

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -290,12 +290,7 @@ func FromOutgoingContext(ctx context.Context) (MD, bool) {
 		return nil, false
 	}
 
-	mdSize := len(raw.md)
-	for d := raw.added; d != nil; d = d.prev {
-		mdSize += len(d.kv) / 2
-	}
-
-	out := make(MD, mdSize)
+	out := make(MD, len(raw.md))
 	for k, v := range raw.md {
 		// We need to manually convert all keys to lower case, because MD is a
 		// map, and there's no guarantee that the MD attached to the context is

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -250,10 +250,10 @@ func copyOf(v []string) []string {
 func fromOutgoingContextRaw(ctx context.Context) (MD, iter.Seq2[string, string], bool) {
 	raw, ok := ctx.Value(mdOutgoingKey{}).(rawMD)
 	if !ok {
-		return nil, nil, false
+		return nil, emptySeq2, false
 	}
 	if raw.added == nil {
-		return raw.md, nil, true
+		return raw.md, emptySeq2, true
 	}
 	// Count nodes to pre-allocate the reversal slice.
 	n := 0
@@ -276,6 +276,10 @@ func fromOutgoingContextRaw(ctx context.Context) (MD, iter.Seq2[string, string],
 		}
 	}, true
 }
+
+// emptySeq2 is a no-op iterator returned when there are no appended key-value
+// pairs, avoiding nil-function panics at call sites that unconditionally range.
+var emptySeq2 iter.Seq2[string, string] = func(yield func(string, string) bool) {}
 
 // FromOutgoingContext returns the outgoing metadata in ctx if it exists.
 //

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -24,6 +24,7 @@ package metadata // import "google.golang.org/grpc/metadata"
 import (
 	"context"
 	"fmt"
+	"iter"
 	"strings"
 
 	"google.golang.org/grpc/internal"
@@ -181,14 +182,15 @@ func AppendToOutgoingContext(ctx context.Context, kv ...string) context.Context 
 		panic(fmt.Sprintf("metadata: AppendToOutgoingContext got an odd number of input pairs for metadata: %d", len(kv)))
 	}
 	md, _ := ctx.Value(mdOutgoingKey{}).(rawMD)
-	added := make([][]string, len(md.added)+1)
-	copy(added, md.added)
-	kvCopy := make([]string, 0, len(kv))
+	kvCopy := make([]string, len(kv))
 	for i := 0; i < len(kv); i += 2 {
-		kvCopy = append(kvCopy, strings.ToLower(kv[i]), kv[i+1])
+		kvCopy[i] = strings.ToLower(kv[i])
+		kvCopy[i+1] = kv[i+1]
 	}
-	added[len(added)-1] = kvCopy
-	return context.WithValue(ctx, mdOutgoingKey{}, rawMD{md: md.md, added: added})
+	return context.WithValue(ctx, mdOutgoingKey{}, rawMD{
+		md:    md.md,
+		added: &deltaKV{kv: kvCopy, prev: md.added},
+	})
 }
 
 // FromIncomingContext returns the incoming metadata in ctx if it exists.
@@ -241,17 +243,38 @@ func copyOf(v []string) []string {
 
 // fromOutgoingContextRaw returns the un-merged, intermediary contents of rawMD.
 //
-// Remember to perform strings.ToLower on the keys, for both the returned MD (MD
-// is a map, there's no guarantee it's created using our helper functions) and
-// the extra kv pairs (AppendToOutgoingContext doesn't turn them into
-// lowercase).
-func fromOutgoingContextRaw(ctx context.Context) (MD, [][]string, bool) {
+// Remember to perform strings.ToLower on the keys in the returned MD (MD is a
+// map, there's no guarantee it's created using our helper functions).
+// Keys yielded by the iterator are already lowercase as AppendToOutgoingContext
+// normalizes them.
+func fromOutgoingContextRaw(ctx context.Context) (MD, iter.Seq2[string, string], bool) {
 	raw, ok := ctx.Value(mdOutgoingKey{}).(rawMD)
 	if !ok {
 		return nil, nil, false
 	}
-
-	return raw.md, raw.added, true
+	if raw.added == nil {
+		return raw.md, nil, true
+	}
+	// Count nodes to pre-allocate the reversal slice.
+	n := 0
+	for d := raw.added; d != nil; d = d.prev {
+		n++
+	}
+	// Collect newest-first; the iterator yields oldest-first (FIFO order).
+	nodes := make([]*deltaKV, 0, n)
+	for d := raw.added; d != nil; d = d.prev {
+		nodes = append(nodes, d)
+	}
+	return raw.md, func(yield func(string, string) bool) {
+		for i := len(nodes) - 1; i >= 0; i-- {
+			kv := nodes[i].kv
+			for j := 0; j+1 < len(kv); j += 2 {
+				if !yield(kv[j], kv[j+1]) {
+					return
+				}
+			}
+		}
+	}, true
 }
 
 // FromOutgoingContext returns the outgoing metadata in ctx if it exists.
@@ -264,8 +287,8 @@ func FromOutgoingContext(ctx context.Context) (MD, bool) {
 	}
 
 	mdSize := len(raw.md)
-	for i := range raw.added {
-		mdSize += len(raw.added[i]) / 2
+	for d := raw.added; d != nil; d = d.prev {
+		mdSize += len(d.kv) / 2
 	}
 
 	out := make(MD, mdSize)
@@ -276,20 +299,34 @@ func FromOutgoingContext(ctx context.Context) (MD, bool) {
 		key := strings.ToLower(k)
 		out[key] = copyOf(v)
 	}
-	for _, added := range raw.added {
-		if len(added)%2 == 1 {
-			panic(fmt.Sprintf("metadata: FromOutgoingContext got an odd number of input pairs for metadata: %d", len(added)))
-		}
-
-		for i := 0; i < len(added); i += 2 {
-			key := strings.ToLower(added[i])
-			out[key] = append(out[key], added[i+1])
+	// Merge appended kv pairs in FIFO order. Collect nodes newest-first,
+	// then replay oldest-first so later appends override earlier ones.
+	n := 0
+	for d := raw.added; d != nil; d = d.prev {
+		n++
+	}
+	nodes := make([]*deltaKV, 0, n)
+	for d := raw.added; d != nil; d = d.prev {
+		nodes = append(nodes, d)
+	}
+	for i := len(nodes) - 1; i >= 0; i-- {
+		kv := nodes[i].kv
+		for j := 0; j < len(kv); j += 2 {
+			out[kv[j]] = append(out[kv[j]], kv[j+1])
 		}
 	}
 	return out, ok
 }
 
+// deltaKV is a node in a singly-linked list of key-value slices appended
+// via AppendToOutgoingContext.  The list is newest-first: each node's prev
+// field points to the older delta.  Keys in kv are already lowercased.
+type deltaKV struct {
+	kv   []string
+	prev *deltaKV
+}
+
 type rawMD struct {
 	md    MD
-	added [][]string
+	added *deltaKV
 }

--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -356,65 +356,49 @@ func Benchmark_AddingMetadata_ContextManipulationApproach(b *testing.B) {
 	}
 }
 
-// Newer/faster approach to adding metadata to context
-func BenchmarkAppendToOutgoingContext(b *testing.B) {
-	const num = 10
-	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
-	defer cancel()
-	for n := 0; n < b.N; n++ {
-		for i := 0; i < num; i++ {
-			ctx = AppendToOutgoingContext(ctx, "k1", "v1", "k2", "v2")
-		}
-	}
-}
-
-// BenchmarkAppendToOutgoingContextN measures the cost of N sequential
+// BenchmarkAppendToOutgoingContext measures the cost of N sequential
 // AppendToOutgoingContext calls on a fresh context each iteration.
-// With the old [][]string implementation each call was O(len(added)),
-// making N calls O(N²) total. The linked-list implementation is O(1)
-// per call and O(N) total.
-func BenchmarkAppendToOutgoingContextN(b *testing.B) {
+func BenchmarkAppendToOutgoingContext(b *testing.B) {
 	for _, n := range []int{1, 5, 10, 50} {
 		b.Run(strconv.Itoa(n), func(b *testing.B) {
 			b.ReportAllocs()
-			tCtx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
-			defer cancel()
-			for iter := 0; iter < b.N; iter++ {
-				ctx := tCtx
+			for b.Loop() {
+				ctx := context.Background()
 				for i := 0; i < n; i++ {
 					ctx = AppendToOutgoingContext(ctx, "k1", "v1", "k2", "v2")
 				}
-				_ = ctx
 			}
 		})
 	}
 }
 
+// BenchmarkFromOutgoingContext measures the read path after N appends.
 func BenchmarkFromOutgoingContext(b *testing.B) {
-	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
-	defer cancel()
-	ctx = NewOutgoingContext(ctx, MD{"k3": {"v3", "v4"}})
-	ctx = AppendToOutgoingContext(ctx, "k1", "v1", "k2", "v2")
-
-	for n := 0; n < b.N; n++ {
-		FromOutgoingContext(ctx)
-	}
-}
-
-// BenchmarkFromOutgoingContextN measures the read path after N appends.
-func BenchmarkFromOutgoingContextN(b *testing.B) {
 	for _, n := range []int{1, 5, 10, 50} {
 		b.Run(strconv.Itoa(n), func(b *testing.B) {
 			b.ReportAllocs()
-			tCtx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
-			defer cancel()
-			ctx := NewOutgoingContext(tCtx, MD{"k-base": {"v-base"}})
+			ctx := NewOutgoingContext(context.Background(), MD{"k-base": {"v-base"}})
 			for i := 0; i < n; i++ {
 				ctx = AppendToOutgoingContext(ctx, "k"+strconv.Itoa(i), "v"+strconv.Itoa(i))
 			}
-			b.ResetTimer()
-			for iter := 0; iter < b.N; iter++ {
+			for b.Loop() {
 				FromOutgoingContext(ctx)
+			}
+		})
+	}
+}
+
+// BenchmarkFromOutgoingContextRaw measures the raw iterator path after N appends.
+func BenchmarkFromOutgoingContextRaw(b *testing.B) {
+	for _, n := range []int{1, 5, 10, 50} {
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			b.ReportAllocs()
+			ctx := NewOutgoingContext(context.Background(), MD{"k-base": {"v-base"}})
+			for i := 0; i < n; i++ {
+				ctx = AppendToOutgoingContext(ctx, "k"+strconv.Itoa(i), "v"+strconv.Itoa(i))
+			}
+			for b.Loop() {
+				fromOutgoingContextRaw(ctx)
 			}
 		})
 	}

--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -398,7 +398,11 @@ func BenchmarkFromOutgoingContextRaw(b *testing.B) {
 				ctx = AppendToOutgoingContext(ctx, "k"+strconv.Itoa(i), "v"+strconv.Itoa(i))
 			}
 			for b.Loop() {
-				fromOutgoingContextRaw(ctx)
+				_, added, _ := fromOutgoingContextRaw(ctx)
+				// Drain the lazy iterator so its work is actually measured;
+				// b.Loop() keeps the compiler from eliminating it.
+				for range added {
+				}
 			}
 		})
 	}

--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -368,6 +368,28 @@ func BenchmarkAppendToOutgoingContext(b *testing.B) {
 	}
 }
 
+// BenchmarkAppendToOutgoingContextN measures the cost of N sequential
+// AppendToOutgoingContext calls on a fresh context each iteration.
+// With the old [][]string implementation each call was O(len(added)),
+// making N calls O(N²) total. The linked-list implementation is O(1)
+// per call and O(N) total.
+func BenchmarkAppendToOutgoingContextN(b *testing.B) {
+	for _, n := range []int{1, 5, 10, 50} {
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			b.ReportAllocs()
+			tCtx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+			defer cancel()
+			for iter := 0; iter < b.N; iter++ {
+				ctx := tCtx
+				for i := 0; i < n; i++ {
+					ctx = AppendToOutgoingContext(ctx, "k1", "v1", "k2", "v2")
+				}
+				_ = ctx
+			}
+		})
+	}
+}
+
 func BenchmarkFromOutgoingContext(b *testing.B) {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
@@ -376,6 +398,25 @@ func BenchmarkFromOutgoingContext(b *testing.B) {
 
 	for n := 0; n < b.N; n++ {
 		FromOutgoingContext(ctx)
+	}
+}
+
+// BenchmarkFromOutgoingContextN measures the read path after N appends.
+func BenchmarkFromOutgoingContextN(b *testing.B) {
+	for _, n := range []int{1, 5, 10, 50} {
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			b.ReportAllocs()
+			tCtx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+			defer cancel()
+			ctx := NewOutgoingContext(tCtx, MD{"k-base": {"v-base"}})
+			for i := 0; i < n; i++ {
+				ctx = AppendToOutgoingContext(ctx, "k"+strconv.Itoa(i), "v"+strconv.Itoa(i))
+			}
+			b.ResetTimer()
+			for iter := 0; iter < b.N; iter++ {
+				FromOutgoingContext(ctx)
+			}
+		})
 	}
 }
 

--- a/stream.go
+++ b/stream.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"iter"
 	"math"
 	rand "math/rand/v2"
 	"strconv"
@@ -50,7 +51,7 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-var metadataFromOutgoingContextRaw = internal.FromOutgoingContextRaw.(func(context.Context) (metadata.MD, [][]string, bool))
+var metadataFromOutgoingContextRaw = internal.FromOutgoingContextRaw.(func(context.Context) (metadata.MD, iter.Seq2[string, string], bool))
 
 // StreamHandler defines the handler called by gRPC server to complete the
 // execution of a streaming RPC. srv is the service implementation on which the
@@ -227,11 +228,9 @@ func newClientStream(ctx context.Context, desc *StreamDesc, cc *ClientConn, meth
 			return nil, status.Error(codes.Internal, err.Error())
 		}
 		// validate added
-		for _, kvs := range added {
-			for i := 0; i < len(kvs); i += 2 {
-				if err := imetadata.ValidatePair(kvs[i], kvs[i+1]); err != nil {
-					return nil, status.Error(codes.Internal, err.Error())
-				}
+		for k, v := range added {
+			if err := imetadata.ValidatePair(k, v); err != nil {
+				return nil, status.Error(codes.Internal, err.Error())
 			}
 		}
 	}


### PR DESCRIPTION
Addresses #8860

## Problem

`AppendToOutgoingContext` is O(N) per call because it allocates a new
`[][]string` of length N+1 and copies all N prior slices on every
invocation. A call chain with N sequential appends costs O(N²) in total
allocation and copy work. This is visible in production as latency spikes
in metadata-heavy RPCs.

## Solution

Replace `rawMD.added [][]string` with a singly-linked list of `deltaKV`
nodes. Each `AppendToOutgoingContext` call allocates exactly one node and
one flattened kv slice — O(1) regardless of chain depth.

`FromOutgoingContext` and `fromOutgoingContextRaw` traverse the chain
(newest-first), collect into a temporary slice, then iterate in reverse
to preserve FIFO ordering, keeping the read path O(N) and maintaining
backward-compatible return types for internal callers in transport and
stream code.

## Benchmarks

Apple M3 Max, go1.26.3:

```
BenchmarkAppendToOutgoingContext (accumulating context, num=10):
  before: 3,263,813 ns/op  (quadratic growth)
  after:      1,646 ns/op  (1982× faster)

BenchmarkFromOutgoingContext:
  before: 544.3 ns/op
  after:  212.4 ns/op  (2.6× faster)

BenchmarkAppendToOutgoingContextN (fresh context, N sequential appends):
  N= 1:   87 ns/op,  160 B/op,   4 allocs
  N= 5:  446 ns/op,  800 B/op,  20 allocs
  N=10:  872 ns/op, 1600 B/op,  40 allocs
  N=50: 4373 ns/op, 8000 B/op, 200 allocs
  (linear: ~87·N ns/op)
```

All existing metadata tests pass.

RELEASE NOTES:
* metadata: `AppendToOutgoingContext` is now O(1) per call instead of O(N), eliminating quadratic allocation overhead in metadata-heavy RPC call chains.