### PR TITLE
xds/googlec2p: enable DirectPath over Interconnect support for on-prem clients

### DIFF
--- a/xds/googledirectpath/googlec2p.go
+++ b/xds/googledirectpath/googlec2p.go
@@ -139,8 +139,8 @@ func (c2pResolverBuilder) Build(t resolver.Target, cc resolver.ClientConn, opts 
 	isGCE := onGCE()
 	// We check only for the presence of the "force-xds" query parameter key,
 	// and do not evaluate its value.
-	_, forceXds := t.URL.Query()["force-xds"]
-	if !forceXds && !isGCE {
+	_, forceXDS := t.URL.Query()["force-xds"]
+	if !forceXDS && !isGCE {
 		// If not xDS, fallback to DNS.
 		t.URL.Scheme = dnsName
 		return resolver.Get(dnsName).Build(t, cc, opts)
@@ -148,7 +148,7 @@ func (c2pResolverBuilder) Build(t resolver.Target, cc resolver.ClientConn, opts 
 
 	var zone string
 	var ipv6Capable bool
-	if forceXds {
+	if forceXDS {
 		// If the force-xds query parameter is present, GCE metadata server
 		// queries are bypassed.
 		zone = ""
@@ -160,14 +160,12 @@ func (c2pResolverBuilder) Build(t resolver.Target, cc resolver.ClientConn, opts 
 		// This should be fine in most of the cases. In certain error cases, this
 		// could block Dial() for up to 10 seconds (each blocking call has its own
 		// goroutine).
-		zoneCh, ipv6CapableCh := make(chan string, 1), make(chan bool, 1)
-		go func() { zoneCh <- getZone(httpReqTimeout) }()
-		go func() { ipv6CapableCh <- getIPv6Capable(httpReqTimeout) }()
-		zone, ipv6Capable = <-zoneCh, <-ipv6CapableCh
+		zone = getZone(httpReqTimeout)
+		ipv6Capable = getIPv6Capable(httpReqTimeout)
 	}
 
 	xdsServerURI := getXdsServerURI()
-	nodeCfg := newNodeConfig(zone, ipv6Capable, isGCE)
+	nodeCfg := newNodeConfig(zone, ipv6Capable, forceXDS)
 	xdsServerCfg := newXdsServerConfig(xdsServerURI)
 	authoritiesCfg := newAuthoritiesConfig(xdsServerCfg)
 
@@ -217,9 +215,9 @@ func (b c2pResolverBuilder) Scheme() string {
 	return c2pScheme
 }
 
-func newNodeConfig(zone string, ipv6Capable bool, isGCE bool) map[string]any {
+func newNodeConfig(zone string, ipv6Capable bool, forceXDS bool) map[string]any {
 	prefix := "C2P"
-	if !isGCE {
+	if forceXDS {
 		prefix = "C2P-non-gcp"
 	}
 	node := map[string]any{

--- a/xds/googledirectpath/googlec2p.go
+++ b/xds/googledirectpath/googlec2p.go
@@ -136,24 +136,39 @@ func (c2pResolverBuilder) Build(t resolver.Target, cc resolver.ClientConn, opts 
 		return nil, fmt.Errorf("google-c2p URI scheme does not support authorities")
 	}
 
-	if !runDirectPath() {
+	isGCE := onGCE()
+	_, forceXds := t.URL.Query()["force-xds"]
+	if !forceXds && !isGCE {
 		// If not xDS, fallback to DNS.
 		t.URL.Scheme = dnsName
 		return resolver.Get(dnsName).Build(t, cc, opts)
 	}
 
-	// Note that the following calls to getZone() and getIPv6Capable() does I/O,
-	// and has 10 seconds timeout each.
-	//
-	// This should be fine in most of the cases. In certain error cases, this
-	// could block Dial() for up to 10 seconds (each blocking call has its own
-	// goroutine).
-	zoneCh, ipv6CapableCh := make(chan string), make(chan bool)
-	go func() { zoneCh <- getZone(httpReqTimeout) }()
-	go func() { ipv6CapableCh <- getIPv6Capable(httpReqTimeout) }()
+	var zone string
+	var ipv6Capable bool
+	if isGCE {
+		// Note that the following calls to getZone() and getIPv6Capable() does I/O,
+		// and has 10 seconds timeout each.
+		//
+		// This should be fine in most of the cases. In certain error cases, this
+		// could block Dial() for up to 10 seconds (each blocking call has its own
+		// goroutine).
+		zoneCh, ipv6CapableCh := make(chan string), make(chan bool)
+		go func() { zoneCh <- getZone(httpReqTimeout) }()
+		go func() { ipv6CapableCh <- getIPv6Capable(httpReqTimeout) }()
+		zone, ipv6Capable = <-zoneCh, <-ipv6CapableCh
+	} else {
+		// When running off-GCP (for DirectPath over GCI), the GCE metadata
+		// server is not available.
+		// - Set zone to empty.
+		// - Set ipv6Capable to true because DirectPath over GCI supports
+		//   IPv6-capable on-premise clients.
+		zone = ""
+		ipv6Capable = true
+	}
 
 	xdsServerURI := getXdsServerURI()
-	nodeCfg := newNodeConfig(<-zoneCh, <-ipv6CapableCh)
+	nodeCfg := newNodeConfig(zone, ipv6Capable, isGCE)
 	xdsServerCfg := newXdsServerConfig(xdsServerURI)
 	authoritiesCfg := newAuthoritiesConfig(xdsServerCfg)
 
@@ -203,10 +218,16 @@ func (b c2pResolverBuilder) Scheme() string {
 	return c2pScheme
 }
 
-func newNodeConfig(zone string, ipv6Capable bool) map[string]any {
+func newNodeConfig(zone string, ipv6Capable bool, isGCE bool) map[string]any {
+	prefix := "C2P"
+	if !isGCE {
+		prefix = "C2P-non-gcp"
+	}
 	node := map[string]any{
-		"id":       fmt.Sprintf("C2P-%d", randInt()),
-		"locality": map[string]any{"zone": zone},
+		"id": fmt.Sprintf("%s-%d", prefix, randInt()),
+	}
+	if zone != "" {
+		node["locality"] = map[string]any{"zone": zone}
 	}
 	// Enable dualstack endpoints in TD.
 	if ipv6Capable {
@@ -227,11 +248,4 @@ func newXdsServerConfig(uri string) map[string]any {
 		"channel_creds":   []map[string]any{{"type": "google_default"}},
 		"server_features": []any{"ignore_resource_deletion"},
 	}
-}
-
-// runDirectPath returns whether this resolver should use direct path.
-//
-// direct path is enabled if this client is running on GCE.
-func runDirectPath() bool {
-	return onGCE()
 }

--- a/xds/googledirectpath/googlec2p.go
+++ b/xds/googledirectpath/googlec2p.go
@@ -153,7 +153,7 @@ func (c2pResolverBuilder) Build(t resolver.Target, cc resolver.ClientConn, opts 
 		// This should be fine in most of the cases. In certain error cases, this
 		// could block Dial() for up to 10 seconds (each blocking call has its own
 		// goroutine).
-		zoneCh, ipv6CapableCh := make(chan string), make(chan bool)
+		zoneCh, ipv6CapableCh := make(chan string, 1), make(chan bool, 1)
 		go func() { zoneCh <- getZone(httpReqTimeout) }()
 		go func() { ipv6CapableCh <- getIPv6Capable(httpReqTimeout) }()
 		zone, ipv6Capable = <-zoneCh, <-ipv6CapableCh

--- a/xds/googledirectpath/googlec2p.go
+++ b/xds/googledirectpath/googlec2p.go
@@ -160,8 +160,18 @@ func (c2pResolverBuilder) Build(t resolver.Target, cc resolver.ClientConn, opts 
 		// This should be fine in most of the cases. In certain error cases, this
 		// could block Dial() for up to 10 seconds (each blocking call has its own
 		// goroutine).
-		zone = getZone(httpReqTimeout)
-		ipv6Capable = getIPv6Capable(httpReqTimeout)
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			zone = getZone(httpReqTimeout)
+		}()
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			ipv6Capable = getIPv6Capable(httpReqTimeout)
+		}()
+		wg.Wait()
 	}
 
 	xdsServerURI := getXdsServerURI()

--- a/xds/googledirectpath/googlec2p.go
+++ b/xds/googledirectpath/googlec2p.go
@@ -161,16 +161,8 @@ func (c2pResolverBuilder) Build(t resolver.Target, cc resolver.ClientConn, opts 
 		// could block Dial() for up to 10 seconds (each blocking call has its own
 		// goroutine).
 		var wg sync.WaitGroup
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			zone = getZone(httpReqTimeout)
-		}()
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			ipv6Capable = getIPv6Capable(httpReqTimeout)
-		}()
+		wg.Go(func() { zone = getZone(httpReqTimeout) })
+		wg.Go(func() { ipv6Capable = getIPv6Capable(httpReqTimeout) })
 		wg.Wait()
 	}
 

--- a/xds/googledirectpath/googlec2p.go
+++ b/xds/googledirectpath/googlec2p.go
@@ -137,6 +137,8 @@ func (c2pResolverBuilder) Build(t resolver.Target, cc resolver.ClientConn, opts 
 	}
 
 	isGCE := onGCE()
+	// We check only for the presence of the "force-xds" query parameter key,
+	// and do not evaluate its value.
 	_, forceXds := t.URL.Query()["force-xds"]
 	if !forceXds && !isGCE {
 		// If not xDS, fallback to DNS.
@@ -146,7 +148,12 @@ func (c2pResolverBuilder) Build(t resolver.Target, cc resolver.ClientConn, opts 
 
 	var zone string
 	var ipv6Capable bool
-	if isGCE {
+	if forceXds {
+		// If the force-xds query parameter is present, GCE metadata server
+		// queries are bypassed.
+		zone = ""
+		ipv6Capable = true
+	} else {
 		// Note that the following calls to getZone() and getIPv6Capable() does I/O,
 		// and has 10 seconds timeout each.
 		//
@@ -157,14 +164,6 @@ func (c2pResolverBuilder) Build(t resolver.Target, cc resolver.ClientConn, opts 
 		go func() { zoneCh <- getZone(httpReqTimeout) }()
 		go func() { ipv6CapableCh <- getIPv6Capable(httpReqTimeout) }()
 		zone, ipv6Capable = <-zoneCh, <-ipv6CapableCh
-	} else {
-		// When running off-GCP (for DirectPath over GCI), the GCE metadata
-		// server is not available.
-		// - Set zone to empty.
-		// - Set ipv6Capable to true because DirectPath over GCI supports
-		//   IPv6-capable on-premise clients.
-		zone = ""
-		ipv6Capable = true
 	}
 
 	xdsServerURI := getXdsServerURI()

--- a/xds/googledirectpath/googlec2p_test.go
+++ b/xds/googledirectpath/googlec2p_test.go
@@ -655,3 +655,175 @@ func (s) TestCreateMultipleXDSClients(t *testing.T) {
 	c2pXDSTarget := resolver.Target{URL: url.URL{Scheme: xdsName, Host: c2pAuthority, Path: c2pTarget.URL.Path}}
 	verifyXDSClientBootstrapConfig(t, xdsClientPool, c2pXDSTarget.String(), c2pConfig)
 }
+
+// TestBuildXDSClientNotOnGCEWithForceXDS validates that the C2P resolver
+// handles not on GCP (Google Cloud Interconnect) clients correctly when the
+// force-xds query parameter is provided in various valid formats.
+// It verifies that:
+//   - GCE metadata server queries for zone and ipv6 capability are bypassed
+//     to prevent dial timeouts.
+//   - The node ID is formatted using the prefix ("C2P-non-gcp").
+//   - Zone information is completely omitted from the node config.
+//   - Dualstack IPv6 capability (TRAFFICDIRECTOR_DIRECTPATH_C2P_IPV6_CAPABLE)
+//     is set to true.
+func (s) TestBuildXDSClientNotOnGCEWithForceXDS(t *testing.T) {
+	tests := []struct {
+		desc     string
+		rawQuery string
+	}{
+		{
+			desc:     "query_param_key_only",
+			rawQuery: "force-xds",
+		},
+		{
+			desc:     "query_param_trailing_equals_value_empty",
+			rawQuery: "force-xds=",
+		},
+		{
+			desc:     "query_param_value_true",
+			rawQuery: "force-xds=true",
+		},
+		{
+			desc:     "query_param_value_false",
+			rawQuery: "force-xds=false",
+		},
+		{
+			desc:     "query_param_multiple_query_params",
+			rawQuery: "foo=bar&force-xds",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			replaceResolvers(t)
+			simulateRunningOnGCE(t, false)
+			useCleanUniverseDomain(t)
+
+			// Override the random func used in the node ID.
+			origRandInd := randInt
+			randInt = func() int { return 666 }
+			defer func() { randInt = origRandInd }()
+
+			// Override xDS client pool.
+			oldXdsClientPool := xdsClientPool
+			xdsClientPool = xdsclient.NewPool(nil)
+			defer func() { xdsClientPool = oldXdsClientPool }()
+
+			// Target URI with force-xds query parameter.
+			builder := resolver.Get(c2pScheme)
+			target := resolver.Target{URL: url.URL{
+				Scheme:   c2pScheme,
+				Path:     "test-path",
+				RawQuery: tt.rawQuery,
+			}}
+
+			// Build the google-c2p resolver.
+			res, err := builder.Build(target, nil, resolver.BuildOptions{})
+			if err != nil {
+				t.Fatalf("failed to build resolver: %v", err)
+			}
+			defer res.Close()
+
+			// Query parameters are omitted since the downstream xDS target is configured using only active fields.
+			xdsTarget := resolver.Target{URL: url.URL{Scheme: xdsName, Host: c2pAuthority, Path: target.URL.Path}}
+			wantBootstrapConfig := bootstrapConfig(t, bootstrap.ConfigOptionsForTesting{
+				Servers: []byte(`[{
+					"server_uri": "dns:///directpath-pa.googleapis.com",
+					"channel_creds": [{"type": "google_default"}],
+					"server_features": ["ignore_resource_deletion"]
+				}]`),
+				Authorities: map[string]json.RawMessage{
+					"traffic-director-c2p.xds.googleapis.com": []byte(`{
+						"xds_servers": [
+							{
+								"server_uri": "dns:///directpath-pa.googleapis.com",
+								"channel_creds": [{"type": "google_default"}],
+								"server_features": ["ignore_resource_deletion"]
+							}
+						]
+					}`),
+				},
+				Node: []byte(`{
+					"id": "C2P-non-gcp-666",
+					"metadata": {
+						"TRAFFICDIRECTOR_DIRECTPATH_C2P_IPV6_CAPABLE": true
+					}
+				}`),
+			})
+			verifyXDSClientBootstrapConfig(t, xdsClientPool, xdsTarget.String(), wantBootstrapConfig)
+		})
+	}
+}
+
+// TestBuildXDSClientOnGCEWithForceXDS validates that when running on GCE with
+// the force-xds query param, we successfully build an xDS client with standard
+// GCP Node ID format, locality zone, and dualstack capability.
+func (s) TestBuildXDSClientOnGCEWithForceXDS(t *testing.T) {
+	replaceResolvers(t)
+	simulateRunningOnGCE(t, true)
+	useCleanUniverseDomain(t)
+
+	// Override the zone returned by the metadata server.
+	oldGetZone := getZone
+	getZone = func(time.Duration) string { return "test-zone" }
+	defer func() { getZone = oldGetZone }()
+
+	// Override testing random node ID.
+	origRandInd := randInt
+	randInt = func() int { return 777 }
+	defer func() { randInt = origRandInd }()
+
+	// Override IPv6 capability.
+	oldGetIPv6Capable := getIPv6Capable
+	getIPv6Capable = func(time.Duration) bool { return true }
+	defer func() { getIPv6Capable = oldGetIPv6Capable }()
+
+	oldXdsClientPool := xdsClientPool
+	xdsClientPool = xdsclient.NewPool(nil)
+	defer func() { xdsClientPool = oldXdsClientPool }()
+
+	// Target URI with force-xds query parameter.
+	target := resolver.Target{URL: url.URL{
+		Scheme:   c2pScheme,
+		Path:     "test-path",
+		RawQuery: "force-xds",
+	}}
+
+	// Build the google-c2p resolver.
+	builder := resolver.Get(c2pScheme)
+	r, err := builder.Build(target, nil, resolver.BuildOptions{})
+	if err != nil {
+		t.Fatalf("failed to build resolver: %v", err)
+	}
+	defer r.Close()
+
+	xdsTarget := resolver.Target{URL: url.URL{Scheme: xdsName, Host: c2pAuthority, Path: target.URL.Path}}
+	wantBootstrapConfig := bootstrapConfig(t, bootstrap.ConfigOptionsForTesting{
+		Servers: []byte(`[{
+			"server_uri": "dns:///directpath-pa.googleapis.com",
+			"channel_creds": [{"type": "google_default"}],
+			"server_features": ["ignore_resource_deletion"]
+		}]`),
+		Authorities: map[string]json.RawMessage{
+			"traffic-director-c2p.xds.googleapis.com": []byte(`{
+				"xds_servers": [
+					{
+						"server_uri": "dns:///directpath-pa.googleapis.com",
+						"channel_creds": [{"type": "google_default"}],
+						"server_features": ["ignore_resource_deletion"]
+					}
+				]
+			}`),
+		},
+		Node: []byte(`{
+			"id": "C2P-777",
+			"locality": {
+				"zone": "test-zone"
+			},
+			"metadata": {
+				"TRAFFICDIRECTOR_DIRECTPATH_C2P_IPV6_CAPABLE": true
+			}
+		}`),
+	})
+	verifyXDSClientBootstrapConfig(t, xdsClientPool, xdsTarget.String(), wantBootstrapConfig)
+}

--- a/xds/googledirectpath/googlec2p_test.go
+++ b/xds/googledirectpath/googlec2p_test.go
@@ -756,8 +756,10 @@ func (s) TestBuildXDSClientNotOnGCEWithForceXDS(t *testing.T) {
 }
 
 // TestBuildXDSClientOnGCEWithForceXDS validates that when running on GCE with
-// the force-xds query param, we successfully build an xDS client with standard
-// GCP Node ID format, locality zone, and dualstack capability.
+// the force-xds query param, the force-xds behavior takes priority (bypassing
+// GCE metadata server queries), so we build an xDS client with standard GCE
+// Node ID format ("C2P-777" since isGCE is true) but without locality zone,
+// and with dualstack capability set to true.
 func (s) TestBuildXDSClientOnGCEWithForceXDS(t *testing.T) {
 	replaceResolvers(t)
 	simulateRunningOnGCE(t, true)
@@ -816,14 +818,11 @@ func (s) TestBuildXDSClientOnGCEWithForceXDS(t *testing.T) {
 			}`),
 		},
 		Node: []byte(`{
-			"id": "C2P-777",
-			"locality": {
-				"zone": "test-zone"
-			},
-			"metadata": {
-				"TRAFFICDIRECTOR_DIRECTPATH_C2P_IPV6_CAPABLE": true
-			}
-		}`),
+					"id": "C2P-777",
+					"metadata": {
+						"TRAFFICDIRECTOR_DIRECTPATH_C2P_IPV6_CAPABLE": true
+					}
+				}`),
 	})
 	verifyXDSClientBootstrapConfig(t, xdsClientPool, xdsTarget.String(), wantBootstrapConfig)
 }

--- a/xds/googledirectpath/googlec2p_test.go
+++ b/xds/googledirectpath/googlec2p_test.go
@@ -656,44 +656,44 @@ func (s) TestCreateMultipleXDSClients(t *testing.T) {
 	verifyXDSClientBootstrapConfig(t, xdsClientPool, c2pXDSTarget.String(), c2pConfig)
 }
 
-// TestBuildXDSClientNotOnGCEWithForceXDS validates that the C2P resolver
-// handles non-GCP (Google Cloud Interconnect) clients correctly when the
-// force-xds query parameter is provided in various valid formats.
+// Test validates that the C2P resolver handles non-GCP (Google Cloud
+// Interconnect) clients correctly when the force-xds query parameter is
+// provided in various valid formats.
 // It verifies that:
-//   - GCE metadata server queries for zone and ipv6 capability are bypassed
-//     to prevent dial timeouts.
+//   - GCE metadata server queries for zone and ipv6 capability are bypassed.
 //   - The node ID is formatted using the prefix ("C2P-non-gcp").
 //   - Zone information is completely omitted from the node config.
 //   - Dualstack IPv6 capability (TRAFFICDIRECTOR_DIRECTPATH_C2P_IPV6_CAPABLE)
 //     is set to true.
-func (s) TestBuildXDSClientNotOnGCEWithForceXDS(t *testing.T) {
+func (s) TestBuild_NotOnGCE_WithForceXDS(t *testing.T) {
 	wantBootstrapConfig := bootstrapConfig(t, bootstrap.ConfigOptionsForTesting{
 		Servers: []byte(`[{
-					"server_uri": "dns:///directpath-pa.googleapis.com",
-					"channel_creds": [{"type": "google_default"}],
-					"server_features": ["ignore_resource_deletion"]
-				}]`),
+			"server_uri": "dns:///directpath-pa.googleapis.com",
+			"channel_creds": [{"type": "google_default"}],
+			"server_features": ["ignore_resource_deletion"]
+		}]`),
 		Authorities: map[string]json.RawMessage{
 			"traffic-director-c2p.xds.googleapis.com": []byte(`{
-						"xds_servers": [
-							{
-								"server_uri": "dns:///directpath-pa.googleapis.com",
-								"channel_creds": [{"type": "google_default"}],
-								"server_features": ["ignore_resource_deletion"]
-							}
-						]
-					}`),
+				"xds_servers": [
+					{
+						"server_uri": "dns:///directpath-pa.googleapis.com",
+						"channel_creds": [{"type": "google_default"}],
+						"server_features": ["ignore_resource_deletion"]
+					}
+				]
+			}`),
 		},
 		Node: []byte(`{
-					"id": "C2P-non-gcp-666",
-					"metadata": {
-						"TRAFFICDIRECTOR_DIRECTPATH_C2P_IPV6_CAPABLE": true
-					}
-				}`),
+			"id": "C2P-non-gcp-666",
+			"metadata": {
+				"TRAFFICDIRECTOR_DIRECTPATH_C2P_IPV6_CAPABLE": true
+			}
+		}`),
 	})
 	tests := []struct {
 		desc     string
 		rawQuery string
+		onGCE    bool
 	}{
 		{
 			desc:     "query_param_key_only",
@@ -715,12 +715,17 @@ func (s) TestBuildXDSClientNotOnGCEWithForceXDS(t *testing.T) {
 			desc:     "query_param_multiple_query_params",
 			rawQuery: "foo=bar&force-xds",
 		},
+		{
+			desc:     "onGCE_with_force-xds",
+			rawQuery: "force-xds",
+			onGCE:    true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
 			replaceResolvers(t)
-			simulateRunningOnGCE(t, false)
+			simulateRunningOnGCE(t, tt.onGCE)
 			useCleanUniverseDomain(t)
 
 			// Override the random func used in the node ID.
@@ -744,85 +749,20 @@ func (s) TestBuildXDSClientNotOnGCEWithForceXDS(t *testing.T) {
 			// Build the google-c2p resolver.
 			res, err := builder.Build(target, nil, resolver.BuildOptions{})
 			if err != nil {
-				t.Fatalf("failed to build resolver: %v", err)
+				t.Fatalf("Failed to build resolver: %v", err)
 			}
 			defer res.Close()
 
-			// Query parameters are omitted since the downstream xDS target is configured using only active fields.
-			xdsTarget := resolver.Target{URL: url.URL{Scheme: xdsName, Host: c2pAuthority, Path: target.URL.Path}}
+			// Query parameters are omitted since the downstream xDS target is
+			// configured using only active fields.
+			xdsTarget := resolver.Target{
+				URL: url.URL{
+					Scheme: xdsName,
+					Host:   c2pAuthority,
+					Path:   target.URL.Path,
+				},
+			}
 			verifyXDSClientBootstrapConfig(t, xdsClientPool, xdsTarget.String(), wantBootstrapConfig)
 		})
 	}
-}
-
-// TestBuildXDSClientOnGCEWithForceXDS validates that when running on GCE with
-// the force-xds query param, the force-xds behavior takes priority (bypassing
-// GCE metadata server queries), so we build an xDS client with standard GCE
-// Node ID format ("C2P-777" since isGCE is true) but without locality zone,
-// and with dualstack capability set to true.
-func (s) TestBuildXDSClientOnGCEWithForceXDS(t *testing.T) {
-	replaceResolvers(t)
-	simulateRunningOnGCE(t, true)
-	useCleanUniverseDomain(t)
-
-	// Override the zone returned by the metadata server.
-	oldGetZone := getZone
-	getZone = func(time.Duration) string { return "test-zone" }
-	defer func() { getZone = oldGetZone }()
-
-	// Override testing random node ID.
-	origRandInd := randInt
-	randInt = func() int { return 777 }
-	defer func() { randInt = origRandInd }()
-
-	// Override IPv6 capability.
-	oldGetIPv6Capable := getIPv6Capable
-	getIPv6Capable = func(time.Duration) bool { return true }
-	defer func() { getIPv6Capable = oldGetIPv6Capable }()
-
-	oldXdsClientPool := xdsClientPool
-	xdsClientPool = xdsclient.NewPool(nil)
-	defer func() { xdsClientPool = oldXdsClientPool }()
-
-	// Target URI with force-xds query parameter.
-	target := resolver.Target{URL: url.URL{
-		Scheme:   c2pScheme,
-		Path:     "test-path",
-		RawQuery: "force-xds",
-	}}
-
-	// Build the google-c2p resolver.
-	builder := resolver.Get(c2pScheme)
-	r, err := builder.Build(target, nil, resolver.BuildOptions{})
-	if err != nil {
-		t.Fatalf("failed to build resolver: %v", err)
-	}
-	defer r.Close()
-
-	xdsTarget := resolver.Target{URL: url.URL{Scheme: xdsName, Host: c2pAuthority, Path: target.URL.Path}}
-	wantBootstrapConfig := bootstrapConfig(t, bootstrap.ConfigOptionsForTesting{
-		Servers: []byte(`[{
-			"server_uri": "dns:///directpath-pa.googleapis.com",
-			"channel_creds": [{"type": "google_default"}],
-			"server_features": ["ignore_resource_deletion"]
-		}]`),
-		Authorities: map[string]json.RawMessage{
-			"traffic-director-c2p.xds.googleapis.com": []byte(`{
-				"xds_servers": [
-					{
-						"server_uri": "dns:///directpath-pa.googleapis.com",
-						"channel_creds": [{"type": "google_default"}],
-						"server_features": ["ignore_resource_deletion"]
-					}
-				]
-			}`),
-		},
-		Node: []byte(`{
-					"id": "C2P-777",
-					"metadata": {
-						"TRAFFICDIRECTOR_DIRECTPATH_C2P_IPV6_CAPABLE": true
-					}
-				}`),
-	})
-	verifyXDSClientBootstrapConfig(t, xdsClientPool, xdsTarget.String(), wantBootstrapConfig)
 }

--- a/xds/googledirectpath/googlec2p_test.go
+++ b/xds/googledirectpath/googlec2p_test.go
@@ -657,7 +657,7 @@ func (s) TestCreateMultipleXDSClients(t *testing.T) {
 }
 
 // TestBuildXDSClientNotOnGCEWithForceXDS validates that the C2P resolver
-// handles not on GCP (Google Cloud Interconnect) clients correctly when the
+// handles non-GCP (Google Cloud Interconnect) clients correctly when the
 // force-xds query parameter is provided in various valid formats.
 // It verifies that:
 //   - GCE metadata server queries for zone and ipv6 capability are bypassed
@@ -667,6 +667,30 @@ func (s) TestCreateMultipleXDSClients(t *testing.T) {
 //   - Dualstack IPv6 capability (TRAFFICDIRECTOR_DIRECTPATH_C2P_IPV6_CAPABLE)
 //     is set to true.
 func (s) TestBuildXDSClientNotOnGCEWithForceXDS(t *testing.T) {
+	wantBootstrapConfig := bootstrapConfig(t, bootstrap.ConfigOptionsForTesting{
+		Servers: []byte(`[{
+					"server_uri": "dns:///directpath-pa.googleapis.com",
+					"channel_creds": [{"type": "google_default"}],
+					"server_features": ["ignore_resource_deletion"]
+				}]`),
+		Authorities: map[string]json.RawMessage{
+			"traffic-director-c2p.xds.googleapis.com": []byte(`{
+						"xds_servers": [
+							{
+								"server_uri": "dns:///directpath-pa.googleapis.com",
+								"channel_creds": [{"type": "google_default"}],
+								"server_features": ["ignore_resource_deletion"]
+							}
+						]
+					}`),
+		},
+		Node: []byte(`{
+					"id": "C2P-non-gcp-666",
+					"metadata": {
+						"TRAFFICDIRECTOR_DIRECTPATH_C2P_IPV6_CAPABLE": true
+					}
+				}`),
+	})
 	tests := []struct {
 		desc     string
 		rawQuery string
@@ -726,30 +750,6 @@ func (s) TestBuildXDSClientNotOnGCEWithForceXDS(t *testing.T) {
 
 			// Query parameters are omitted since the downstream xDS target is configured using only active fields.
 			xdsTarget := resolver.Target{URL: url.URL{Scheme: xdsName, Host: c2pAuthority, Path: target.URL.Path}}
-			wantBootstrapConfig := bootstrapConfig(t, bootstrap.ConfigOptionsForTesting{
-				Servers: []byte(`[{
-					"server_uri": "dns:///directpath-pa.googleapis.com",
-					"channel_creds": [{"type": "google_default"}],
-					"server_features": ["ignore_resource_deletion"]
-				}]`),
-				Authorities: map[string]json.RawMessage{
-					"traffic-director-c2p.xds.googleapis.com": []byte(`{
-						"xds_servers": [
-							{
-								"server_uri": "dns:///directpath-pa.googleapis.com",
-								"channel_creds": [{"type": "google_default"}],
-								"server_features": ["ignore_resource_deletion"]
-							}
-						]
-					}`),
-				},
-				Node: []byte(`{
-					"id": "C2P-non-gcp-666",
-					"metadata": {
-						"TRAFFICDIRECTOR_DIRECTPATH_C2P_IPV6_CAPABLE": true
-					}
-				}`),
-			})
 			verifyXDSClientBootstrapConfig(t, xdsClientPool, xdsTarget.String(), wantBootstrapConfig)
 		})
 	}


### PR DESCRIPTION
This PR add support for on-premises clients using Google Cloud Interconnect to connect to GCP services via DirectPath by enabling a forced xDS/C2P resolver path.
  
Changes:
  - **Query Parameter Handling:** Updates the `google-c2p` resolver to parse call target URLs for the `force-xds` query parameter.
  - **Metadata Server Bypass:** When executing off-GCP, GCE Metadata Server queries for locality zone and IPv6 capability are bypassed.
  - **Bootstrap Config:**
    - Omits the GCE locality zone structure from the bootstrap configuration.
    - Hardcodes the `TRAFFICDIRECTOR_DIRECTPATH_C2P_IPV6_CAPABLE` node metadata flag to `true` since Interconnect is planned exclusively for IPv6 clients.
    - Formats the xDS Client Node ID using a prefix: `"C2P-non-gcp-UUID"`.
    
RELEASE NOTES:
- xds/googlec2p: enable DirectPath over Interconnect support for on-premises clients via the `force-xds` query parameter in target URI.

