### PR TITLE
xds/server: Fix memory leak of ServerInterceptor instances during RDS updates

### DIFF
--- a/internal/xds/server/filter_chain_manager.go
+++ b/internal/xds/server/filter_chain_manager.go
@@ -122,17 +122,7 @@ func (fcm *filterChainManager) filterChainFromConfig(config *xdsresource.Network
 
 func (fcm *filterChainManager) stop() {
 	for _, fc := range fcm.filterChains {
-		urc := fc.usableRouteConfiguration.Load()
-		if urc.err != nil {
-			continue
-		}
-		for _, vh := range urc.vhs {
-			for _, r := range vh.routes {
-				if r.interceptor != nil {
-					r.interceptor.Close()
-				}
-			}
-		}
+		fc.usableRouteConfiguration.Load().stop()
 		fc.stop()
 	}
 }
@@ -172,11 +162,20 @@ type sourcePrefixEntry struct {
 // Listener resource. This struct contains the active state of a filter chain,
 // which includes the usable route configuration.
 type filterChain struct {
-	securityCfg              *xdsresource.SecurityConfig
-	httpFilters              []xdsresource.HTTPFilter
-	serverFilters            []httpfilter.ServerFilter // Server filters with reference counts, stored for cleanup purposes.
-	routeConfigName          string
-	inlineRouteConfig        *xdsresource.RouteConfigUpdate
+	// The following fields are set at initialization time, and are not
+	// updated afterwards.
+	securityCfg       *xdsresource.SecurityConfig
+	httpFilters       []xdsresource.HTTPFilter
+	routeConfigName   string
+	inlineRouteConfig *xdsresource.RouteConfigUpdate
+
+	// Server filters with reference counts. Is updated when a usable route
+	// configuration is set, and when the filter chain is stopped. Both these
+	// operations always happen with the listener wrapper's lock held.
+	serverFilters []httpfilter.ServerFilter
+
+	// The usable route configuration, is passed to the connWrapper, and is used
+	// to route incoming RPCs. Therefore, this needs to be accessed atomically.
 	usableRouteConfiguration *atomic.Pointer[usableRouteConfiguration]
 }
 
@@ -186,6 +185,16 @@ type usableRouteConfiguration struct {
 	vhs    []virtualHostWithInterceptors
 	err    error
 	nodeID string // For logging purposes. Populated by the listener wrapper.
+}
+
+func (rc *usableRouteConfiguration) stop() {
+	for _, vh := range rc.vhs {
+		for _, r := range vh.routes {
+			if r.interceptor != nil {
+				r.interceptor.Close()
+			}
+		}
+	}
 }
 
 // virtualHostWithInterceptors captures information present in a VirtualHost
@@ -397,32 +406,61 @@ func (fc *filterChain) stop() {
 // state across resource updates.
 type serverFilterProvider func(filter xdsresource.HTTPFilter) (httpfilter.ServerFilter, error)
 
-// constructUsableRouteConfiguration takes Route Configuration and converts it
+// updateUsableRouteConfiguration takes Route Configuration and converts it
 // into matchable route configuration, with instantiated HTTP Filters per route.
-func (fc *filterChain) constructUsableRouteConfiguration(config xdsresource.RouteConfigUpdate, provider serverFilterProvider) *usableRouteConfiguration {
-	vhs := make([]virtualHostWithInterceptors, 0, len(config.VirtualHosts))
+func (fc *filterChain) updateUsableRouteConfiguration(config *xdsresource.RouteConfigUpdate, updateErr error, provider serverFilterProvider, nodeID string) {
+	if updateErr != nil {
+		urc := &usableRouteConfiguration{err: updateErr, nodeID: nodeID}
+		fc.applyConfiguration(urc, nil)
+		return
+	}
+
 	var serverFilters []httpfilter.ServerFilter
+	vhs := make([]virtualHostWithInterceptors, 0, len(config.VirtualHosts))
 	for _, vh := range config.VirtualHosts {
 		vhwi, sfs, err := fc.convertVirtualHost(vh, provider)
 		if err != nil {
 			for _, sf := range serverFilters {
 				sf.Close()
 			}
+			// Close interceptors from successfully converted virtual hosts.
+			for _, v := range vhs {
+				for _, r := range v.routes {
+					if r.interceptor != nil {
+						r.interceptor.Close()
+						r.interceptor = nil
+					}
+				}
+			}
 			// Non nil if (lds + rds) fails, shouldn't happen since validated by
 			// xDS Client, treat as L7 error but shouldn't happen.
-			return &usableRouteConfiguration{err: fmt.Errorf("virtual host construction: %v", err)}
+			urc := &usableRouteConfiguration{err: fmt.Errorf("virtual host construction: %v", err), nodeID: nodeID}
+			fc.applyConfiguration(urc, nil)
+			return
 		}
 		vhs = append(vhs, vhwi)
 		serverFilters = append(serverFilters, sfs...)
 	}
 
-	// Release references to old server filters before replacing with new ones.
-	for _, sf := range fc.serverFilters {
-		sf.Close()
-	}
+	urc := &usableRouteConfiguration{vhs: vhs, nodeID: nodeID}
+	fc.applyConfiguration(urc, serverFilters)
+}
+
+func (fc *filterChain) applyConfiguration(urc *usableRouteConfiguration, serverFilters []httpfilter.ServerFilter) {
+	// Swap in the new configuration first so new RPCs use it immediately.
+	oldURC := fc.usableRouteConfiguration.Swap(urc)
+	oldFilters := fc.serverFilters
 	fc.serverFilters = serverFilters
 
-	return &usableRouteConfiguration{vhs: vhs}
+	// Stop the old interceptors before releasing the filters they might depend on.
+	if oldURC != nil {
+		oldURC.stop()
+	}
+
+	// Release references to old server filters.
+	for _, sf := range oldFilters {
+		sf.Close()
+	}
 }
 
 func (fc *filterChain) convertVirtualHost(virtualHost *xdsresource.VirtualHost, provider serverFilterProvider) (_ virtualHostWithInterceptors, _ []httpfilter.ServerFilter, err error) {
@@ -441,6 +479,13 @@ func (fc *filterChain) convertVirtualHost(virtualHost *xdsresource.VirtualHost, 
 		rs[i].matcher = xdsresource.RouteToMatcher(r)
 		interceptor, sfs, err := fc.newInterceptor(r.HTTPFilterConfigOverride, virtualHost.HTTPFilterConfigOverride, provider)
 		if err != nil {
+			// Close interceptors from successfully converted routes.
+			for _, route := range rs {
+				if route.interceptor != nil {
+					route.interceptor.Close()
+					route.interceptor = nil
+				}
+			}
 			return virtualHostWithInterceptors{}, nil, err
 		}
 		serverFilters = append(serverFilters, sfs...)

--- a/internal/xds/server/filter_chain_manager_test.go
+++ b/internal/xds/server/filter_chain_manager_test.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"net/netip"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -703,8 +704,10 @@ func (s) TestHTTPFilterInstantiation(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			fc := filterChain{
-				httpFilters: test.filters,
+				httpFilters:              test.filters,
+				usableRouteConfiguration: &atomic.Pointer[usableRouteConfiguration]{},
 			}
+			fc.usableRouteConfiguration.Store(&usableRouteConfiguration{})
 
 			filters := make(map[serverFilterKey]*refCountedServerFilter)
 			provider := func(filter xdsresource.HTTPFilter) (httpfilter.ServerFilter, error) {
@@ -714,7 +717,8 @@ func (s) TestHTTPFilterInstantiation(t *testing.T) {
 				}
 				return getOrCreateServerFilterWithMap(filters, builder, newServerFilterKey(&filter)), nil
 			}
-			urc := fc.constructUsableRouteConfiguration(test.routeConfig, provider)
+			fc.updateUsableRouteConfiguration(&test.routeConfig, nil, provider, "node-id")
+			urc := fc.usableRouteConfiguration.Load()
 			if urc.err != nil {
 				t.Fatalf("Error constructing usable route configuration: %v", urc.err)
 			}

--- a/internal/xds/server/listener_wrapper.go
+++ b/internal/xds/server/listener_wrapper.go
@@ -154,7 +154,6 @@ func (l *listenerWrapper) maybeUpdateFilterChains() {
 	}
 
 	l.mu.Lock()
-	l.switchModeLocked(connectivity.ServingModeServing, nil)
 	// "Updates to a Listener cause all older connections on that Listener to be
 	// gracefully shut down with a grace period of 10 minutes for long-lived
 	// RPC's, such that clients will reconnect and have the updated
@@ -189,6 +188,7 @@ func (l *listenerWrapper) maybeUpdateFilterChains() {
 			delete(l.httpFilters, key)
 		}
 	}
+	l.switchModeLocked(connectivity.ServingModeServing, nil)
 	l.mu.Unlock()
 
 	go func() {
@@ -210,14 +210,10 @@ func (l *listenerWrapper) handleRDSUpdate(routeName string, rcu rdsWatcherUpdate
 				continue
 			}
 			if rcu.err != nil && rcu.data == nil { // Either NACK before update, or resource not found triggers this conditional.
-				urc := &usableRouteConfiguration{err: rcu.err}
-				urc.nodeID = l.xdsNodeID
-				fc.usableRouteConfiguration.Store(urc)
+				fc.updateUsableRouteConfiguration(nil, rcu.err, l.getOrCreateServerFilterLocked, l.xdsNodeID)
 				continue
 			}
-			urc := fc.constructUsableRouteConfiguration(*rcu.data, l.getOrCreateServerFilterLocked)
-			urc.nodeID = l.xdsNodeID
-			fc.usableRouteConfiguration.Store(urc)
+			fc.updateUsableRouteConfiguration(rcu.data, nil, l.getOrCreateServerFilterLocked, l.xdsNodeID)
 		}
 	}
 	l.mu.Unlock()
@@ -235,21 +231,15 @@ func (l *listenerWrapper) handleRDSUpdate(routeName string, rcu rdsWatcherUpdate
 func (l *listenerWrapper) instantiateFilterChainRoutingConfigurationsLocked() {
 	for _, fc := range l.activeFilterChainManager.filterChains {
 		if fc.inlineRouteConfig != nil {
-			urc := fc.constructUsableRouteConfiguration(*fc.inlineRouteConfig, l.getOrCreateServerFilterLocked)
-			urc.nodeID = l.xdsNodeID
-			fc.usableRouteConfiguration.Store(urc) // Can't race with an RPC coming in but no harm making atomic.
+			fc.updateUsableRouteConfiguration(fc.inlineRouteConfig, nil, l.getOrCreateServerFilterLocked, l.xdsNodeID)
 			continue
 		} // Inline configuration constructed once here, will remain for lifetime of filter chain.
 		rcu := l.rdsHandler.updates[fc.routeConfigName]
 		if rcu.err != nil && rcu.data == nil {
-			urc := &usableRouteConfiguration{err: rcu.err}
-			urc.nodeID = l.xdsNodeID
-			fc.usableRouteConfiguration.Store(urc)
+			fc.updateUsableRouteConfiguration(nil, rcu.err, l.getOrCreateServerFilterLocked, l.xdsNodeID)
 			continue
 		}
-		urc := fc.constructUsableRouteConfiguration(*rcu.data, l.getOrCreateServerFilterLocked)
-		urc.nodeID = l.xdsNodeID
-		fc.usableRouteConfiguration.Store(urc) // Can't race with an RPC coming in but no harm making atomic.
+		fc.updateUsableRouteConfiguration(rcu.data, nil, l.getOrCreateServerFilterLocked, l.xdsNodeID)
 	}
 }
 

--- a/internal/xds/server/listener_wrapper_test.go
+++ b/internal/xds/server/listener_wrapper_test.go
@@ -1,0 +1,148 @@
+/*
+ *
+ * Copyright 2026 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package server
+
+import (
+	"errors"
+	"sync/atomic"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+// Test verifies that an error received from RDS before any valid update is
+// received is correctly propagated to the filter chains.
+func (s) TestHandleRDSUpdate_ErrorBeforeUpdate(t *testing.T) {
+	const routeName = "route-name"
+	nodeID := "node-id"
+	rdsErr := errors.New("rds error")
+
+	// Create a filter chain that points to routeName.
+	fc := &filterChain{
+		routeConfigName:          routeName,
+		usableRouteConfiguration: &atomic.Pointer[usableRouteConfiguration]{},
+	}
+	fc.usableRouteConfiguration.Store(&usableRouteConfiguration{}) // Initial state is an empty configuration with no error.
+
+	// Create a listener wrapper with the above filter chain. This simulates the
+	// state of the server after LDS has been processed, but before RDS has
+	// returned any response for the route configuration.
+	lw := &listenerWrapper{
+		xdsNodeID: nodeID,
+		activeFilterChainManager: &filterChainManager{
+			filterChains: []*filterChain{fc},
+		},
+		rdsHandler: &rdsHandler{
+			updates: make(map[string]rdsWatcherUpdate),
+			cancels: make(map[string]func()),
+		},
+	}
+
+	// Simulate an RDS update with an error for the route configuration.
+	lw.handleRDSUpdate(routeName, rdsWatcherUpdate{err: rdsErr})
+
+	// Verify that the error is propagated to the filter chain.
+	gotURC := fc.usableRouteConfiguration.Load()
+	wantURC := &usableRouteConfiguration{err: rdsErr, nodeID: nodeID}
+	if diff := cmp.Diff(gotURC, wantURC, cmp.AllowUnexported(usableRouteConfiguration{}), cmp.Comparer(func(x, y error) bool {
+		if x == nil || y == nil {
+			return x == y
+		}
+		return x.Error() == y.Error()
+	})); diff != "" {
+		t.Fatalf("Unexpected usableRouteConfiguration (-got, +want):\n%s", diff)
+	}
+}
+
+// Test verifies that a successful RDS update correctly populates the nodeID.
+func (s) TestHandleRDSUpdate_Success(t *testing.T) {
+	const routeName = "route-name"
+	nodeID := "node-id"
+
+	// Create a filter chain that points to routeName.
+	fc := &filterChain{
+		routeConfigName:          routeName,
+		usableRouteConfiguration: &atomic.Pointer[usableRouteConfiguration]{},
+	}
+	fc.usableRouteConfiguration.Store(&usableRouteConfiguration{})
+
+	lw := &listenerWrapper{
+		xdsNodeID: nodeID,
+		activeFilterChainManager: &filterChainManager{
+			filterChains: []*filterChain{fc},
+		},
+		rdsHandler: &rdsHandler{
+			updates: make(map[string]rdsWatcherUpdate),
+			cancels: make(map[string]func()),
+		},
+	}
+
+	// Simulate an RDS update with a valid route configuration for the routeName.
+	lw.handleRDSUpdate(routeName, rdsWatcherUpdate{data: inlineRouteConfig})
+
+	// Verify that the nodeID is populated in the resulting configuration.
+	gotURC := fc.usableRouteConfiguration.Load()
+	if gotURC.nodeID != nodeID {
+		t.Fatalf("gotURC.nodeID = %q, want %q", gotURC.nodeID, nodeID)
+	}
+}
+
+// Test verifies that an error received from RDS *after* a valid update is
+// received is correctly propagated, and does not result in the filter chain
+// keeping the "stale" successful configuration.
+func (s) TestHandleRDSUpdate_ErrorAfterSuccess(t *testing.T) {
+	const routeName = "route-name"
+	nodeID := "node-id"
+	rdsErr := errors.New("subsequent rds error")
+
+	fc := &filterChain{
+		routeConfigName:          routeName,
+		usableRouteConfiguration: &atomic.Pointer[usableRouteConfiguration]{},
+	}
+	fc.usableRouteConfiguration.Store(&usableRouteConfiguration{})
+
+	// Create a listener wrapper with the above filter chain. This simulates the
+	// state of the server after LDS has been processed, but before RDS has
+	// returned any response for the route configuration.
+	lw := &listenerWrapper{
+		xdsNodeID: nodeID,
+		activeFilterChainManager: &filterChainManager{
+			filterChains: []*filterChain{fc},
+		},
+		rdsHandler: &rdsHandler{
+			updates: make(map[string]rdsWatcherUpdate),
+			cancels: make(map[string]func()),
+		},
+	}
+
+	// Simulate an RDS update with a valid route configuration for the routeName.
+	lw.handleRDSUpdate(routeName, rdsWatcherUpdate{data: inlineRouteConfig})
+	if err := fc.usableRouteConfiguration.Load().err; err != nil {
+		t.Fatalf("Initial update failed: %v", err)
+	}
+
+	// Simulate an RDS update with an error for the route configuration.
+	lw.handleRDSUpdate(routeName, rdsWatcherUpdate{err: rdsErr})
+
+	// Verify that the error is propagated.
+	gotURC := fc.usableRouteConfiguration.Load()
+	if !errors.Is(gotURC.err, rdsErr) {
+		t.Fatalf("urc.err = %v, want %v", gotURC.err, rdsErr)
+	}
+}

--- a/test/xds/xds_server_interceptor_leak_test.go
+++ b/test/xds/xds_server_interceptor_leak_test.go
@@ -1,0 +1,284 @@
+/*
+ *
+ * Copyright 2026 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package xds_test
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/connectivity"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/internal/testutils"
+	"google.golang.org/grpc/internal/testutils/xds/e2e"
+	"google.golang.org/grpc/internal/testutils/xds/e2e/setup"
+	"google.golang.org/grpc/internal/xds/httpfilter"
+	"google.golang.org/grpc/xds"
+
+	v3corepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	v3listenerpb "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	v3routepb "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	v3routerpb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/router/v3"
+	v3httppb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+	testgrpc "google.golang.org/grpc/interop/grpc_testing"
+	testpb "google.golang.org/grpc/interop/grpc_testing"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+)
+
+// Tests that interceptor instances are properly closed when a new RDS
+// configuration is received for the same route configuration name.
+func (s) TestServerSideXDS_InterceptorLeak_RDSUpdate(t *testing.T) {
+	// Register a custom httpFilter builder for the test.
+	var filtersCreated, filtersDestroyed, interceptorsCreated, interceptorsDestroyed atomic.Int32
+	pathCh := make(chan string, 1)
+	testFilterTypeURL := t.Name()
+	fb := &trackingHTTPFilterBuilder{
+		filtersCreated:        &filtersCreated,
+		filtersDestroyed:      &filtersDestroyed,
+		interceptorsCreated:   &interceptorsCreated,
+		interceptorsDestroyed: &interceptorsDestroyed,
+		typeURL:               testFilterTypeURL,
+		pathCh:                pathCh,
+	}
+	httpfilter.Register(fb)
+	defer httpfilter.UnregisterForTesting(fb.typeURL)
+
+	managementServer, nodeID, bootstrapContents, xdsResolver := setup.ManagementServerAndResolver(t)
+
+	// Wait for the server to enter SERVING mode before making RPCs to avoid
+	// flakes due to the server closing connections.
+	servingCh := make(chan struct{})
+	opt := xds.ServingModeCallback(func(_ net.Addr, args xds.ServingModeChangeArgs) {
+		if args.Mode == connectivity.ServingModeServing {
+			close(servingCh)
+		}
+	})
+	lis, stopServer := setupGRPCServer(t, bootstrapContents, opt)
+	defer stopServer()
+
+	// Add xDS resources for the client.
+	host, port, err := hostPortFromListener(lis)
+	if err != nil {
+		t.Fatalf("failed to retrieve host and port of server: %v", err)
+	}
+	const serviceName = "my-service"
+	resources := e2e.DefaultClientResources(e2e.ResourceParams{
+		DialTarget: serviceName,
+		NodeID:     nodeID,
+		Host:       host,
+		Port:       port,
+		SecLevel:   e2e.SecurityLevelNone,
+	})
+
+	// Add xDS resources for the server.
+	vhs := []*v3routepb.VirtualHost{{
+		Domains: []string{"*"},
+		Routes: []*v3routepb.Route{{
+			Match: &v3routepb.RouteMatch{
+				PathSpecifier: &v3routepb.RouteMatch_Prefix{Prefix: "/grpc.testing.TestService/EmptyCall"},
+			},
+			Action: &v3routepb.Route_NonForwardingAction{},
+		}},
+	}}
+	const routeConfigName = "routeName"
+	rds1 := &v3routepb.RouteConfiguration{
+		Name:         routeConfigName,
+		VirtualHosts: vhs,
+	}
+	networkFilters := []*v3listenerpb.Filter{{
+		Name: "hcm",
+		ConfigType: &v3listenerpb.Filter_TypedConfig{
+			TypedConfig: testutils.MarshalAny(t, &v3httppb.HttpConnectionManager{
+				HttpFilters: []*v3httppb.HttpFilter{
+					newHTTPFilter(t, "tracker", testFilterTypeURL, "path1"),
+					e2e.HTTPFilter("router", &v3routerpb.Router{}),
+				},
+				RouteSpecifier: &v3httppb.HttpConnectionManager_Rds{
+					Rds: &v3httppb.Rds{
+						ConfigSource: &v3corepb.ConfigSource{
+							ConfigSourceSpecifier: &v3corepb.ConfigSource_Ads{Ads: &v3corepb.AggregatedConfigSource{}},
+						},
+						RouteConfigName: routeConfigName,
+					},
+				},
+			}),
+		},
+	}}
+	inboundLis := &v3listenerpb.Listener{
+		Name: fmt.Sprintf(e2e.ServerListenerResourceNameTemplate, net.JoinHostPort(host, strconv.Itoa(int(port)))),
+		Address: &v3corepb.Address{
+			Address: &v3corepb.Address_SocketAddress{
+				SocketAddress: &v3corepb.SocketAddress{
+					Address: host,
+					PortSpecifier: &v3corepb.SocketAddress_PortValue{
+						PortValue: port,
+					},
+				},
+			},
+		},
+		FilterChains: []*v3listenerpb.FilterChain{
+			{
+				Name: "v4-wildcard",
+				FilterChainMatch: &v3listenerpb.FilterChainMatch{
+					PrefixRanges: []*v3corepb.CidrRange{{
+						AddressPrefix: "0.0.0.0",
+						PrefixLen:     &wrapperspb.UInt32Value{Value: uint32(0)},
+					}},
+					SourceType: v3listenerpb.FilterChainMatch_SAME_IP_OR_LOOPBACK,
+					SourcePrefixRanges: []*v3corepb.CidrRange{{
+						AddressPrefix: "0.0.0.0",
+						PrefixLen:     &wrapperspb.UInt32Value{Value: uint32(0)},
+					}},
+				},
+				Filters: networkFilters,
+			},
+			{
+				Name: "v6-wildcard",
+				FilterChainMatch: &v3listenerpb.FilterChainMatch{
+					PrefixRanges: []*v3corepb.CidrRange{{
+						AddressPrefix: "::",
+						PrefixLen:     &wrapperspb.UInt32Value{Value: uint32(0)},
+					}},
+					SourceType: v3listenerpb.FilterChainMatch_SAME_IP_OR_LOOPBACK,
+					SourcePrefixRanges: []*v3corepb.CidrRange{{
+						AddressPrefix: "::",
+						PrefixLen:     &wrapperspb.UInt32Value{Value: uint32(0)},
+					}},
+				},
+				Filters: networkFilters,
+			},
+		},
+	}
+	resources.Listeners = append(resources.Listeners, inboundLis)
+	resources.Routes = append(resources.Routes, rds1)
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	if err := managementServer.Update(ctx, resources); err != nil {
+		t.Fatal(err)
+	}
+
+	cc, err := grpc.NewClient(fmt.Sprintf("xds:///%s", serviceName), grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithResolvers(xdsResolver))
+	if err != nil {
+		t.Fatalf("grpc.NewClient() failed: %v", err)
+	}
+	defer cc.Close()
+
+	select {
+	case <-servingCh:
+	case <-ctx.Done():
+		t.Fatalf("Timeout waiting for server to enter SERVING mode")
+	}
+
+	// Make an RPC and verify that one filter and two interceptors are created
+	// (one per filter chain).
+	client := testgrpc.NewTestServiceClient(cc)
+	if _, err := client.EmptyCall(ctx, &testpb.Empty{}); err != nil {
+		t.Fatalf("EmptyCall() failed: %v", err)
+	}
+
+	select {
+	case cfg := <-pathCh:
+		if got, want := cfg, "path1"; got != want {
+			t.Fatalf("Unexpected config sent to filter, got: %q, want: %q", got, want)
+		}
+	case <-ctx.Done():
+		t.Fatalf("Timeout waiting for interceptor to be invoked")
+	}
+	if got, want := filtersCreated.Load(), int32(1); got != want {
+		t.Fatalf("Created %d filter instances, want: %d", got, want)
+	}
+	if got, want := interceptorsCreated.Load(), int32(2); got != want {
+		t.Fatalf("Created %d interceptor instances, want: %d", got, want)
+	}
+
+	// Update the RDS configuration with a new route for the same route configuration
+	// name. This should result in a new interceptor instance being created for
+	// the new route.
+	rds2 := &v3routepb.RouteConfiguration{
+		Name: routeConfigName,
+		VirtualHosts: []*v3routepb.VirtualHost{{
+			Domains: []string{"*"},
+			Routes: []*v3routepb.Route{
+				{
+					Name: "EmptyCall",
+					Match: &v3routepb.RouteMatch{
+						PathSpecifier: &v3routepb.RouteMatch_Prefix{Prefix: "/grpc.testing.TestService/EmptyCall"},
+					},
+					Action: &v3routepb.Route_NonForwardingAction{},
+				},
+				{
+					Name: "Wildcard",
+					Match: &v3routepb.RouteMatch{
+						PathSpecifier: &v3routepb.RouteMatch_Prefix{Prefix: "/"},
+					},
+					Action: &v3routepb.Route_NonForwardingAction{},
+				},
+			},
+		}},
+	}
+	resources.Routes = []*v3routepb.RouteConfiguration{resources.Routes[0], rds2}
+	if err := managementServer.Update(ctx, resources); err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait for the updated config to be applied. Since the new configuration has
+	// two routes, we expect two interceptor instances to be created for each
+	// filter chain, for a total of 6 interceptor instances.
+	for ; ctx.Err() == nil; <-time.After(defaultTestShortTimeout) {
+		if _, err := client.EmptyCall(ctx, &testpb.Empty{}); err != nil {
+			t.Fatalf("EmptyCall() failed: %v", err)
+		}
+		select {
+		case <-pathCh:
+		default:
+		}
+		if interceptorsCreated.Load() == 6 {
+			break
+		}
+	}
+	if ctx.Err() != nil {
+		t.Fatalf("Timeout when waiting for updated config to be applied: %v", ctx.Err())
+	}
+
+	// Verify the filter instance is retained, while the interceptor instances
+	// are replaced with the updated config.
+	if got, want := filtersCreated.Load(), int32(1); got != want {
+		t.Fatalf("Created %d filter instances, want: %d", got, want)
+	}
+	if got, want := interceptorsCreated.Load(), int32(6); got != want {
+		t.Fatalf("Created %d interceptor instances, want: %d", got, want)
+	}
+	if got, want := interceptorsDestroyed.Load(), int32(2); got != want {
+		t.Fatalf("Destroyed %d interceptor instances, want: %d", got, want)
+	}
+
+	stopServer()
+	if got, want := filtersDestroyed.Load(), int32(1); got != want {
+		t.Fatalf("Destroyed %d filter instances, want: %d", got, want)
+	}
+	if got, want := interceptorsDestroyed.Load(), int32(6); got != want {
+		t.Fatalf("Destroyed %d interceptor instances, want: %d", got, want)
+	}
+}


### PR DESCRIPTION
This change addresses a memory leak where `ServerInterceptor` instances were getting leaked and never closed during in-place RDS updates (i.e., cases where an RDS update is received after the LDS and RDS updates have been received and the server is in SERVING mode).

Previously, interceptors were only closed when the entire `FilterChainManager` was stopped. This worked fine for LDS updates. However, every RDS update for an active listener triggers the creation of a new set of interceptors. The old `usableRouteConfiguration` (which holds these interceptors) was simply overwritten in an atomic pointer, leading to the leak of previous interceptor instances.

Summary of Changes:

* Added a `stop()` method to the `usableRouteConfiguration` to encapsulate the logic for closing all interceptors within its routes.
* Renamed `constructUsableRouteConfiguration` to `updateUsableRouteConfiguration` and refactored it to handle the atomic swap and cleanup of the old configuration internally.
* Ensured that any partially created interceptors are explicitly closed if an error occurs during virtual host or route construction.
* Updated `listenerWrapper` to use the newly added method.
* Added an end-to-end integration test in `xds_server_interceptor_leak_test.go` that verifies interceptors are closed upon replacement during RDS updates.

RELEASE NOTES:
* xds/server: Fix a possible memory leak of interceptors during in-place RDS updates