### PR TITLE
mem: add `Reader.PeekBuffer()`

### DIFF
--- a/mem/buffer_slice.go
+++ b/mem/buffer_slice.go
@@ -19,7 +19,7 @@
 package mem
 
 import (
-	"fmt"
+	"errors"
 	"io"
 )
 
@@ -296,12 +296,12 @@ nextBuffer:
 func (r *Reader) Discard(n int) (discarded int, err error) {
 	total := n
 	for n > 0 && r.len > 0 {
-		curData := r.data[0].ReadOnlyData()
-		curSize := min(n, len(curData)-r.bufferIdx)
+		curDataLen := r.data[0].Len()
+		curSize := min(n, curDataLen-r.bufferIdx)
 		n -= curSize
 		r.len -= curSize
 		r.bufferIdx += curSize
-		if r.bufferIdx >= len(curData) {
+		if r.bufferIdx >= curDataLen {
 			r.data[0].Free()
 			r.data = r.data[1:]
 			r.bufferIdx = 0
@@ -309,7 +309,7 @@ func (r *Reader) Discard(n int) (discarded int, err error) {
 	}
 	discarded = total - n
 	if n > 0 {
-		return discarded, fmt.Errorf("insufficient bytes in reader")
+		return discarded, errors.New("insufficient bytes in reader")
 	}
 	return discarded, nil
 }
@@ -339,7 +339,36 @@ func (r *Reader) Peek(n int, res [][]byte) ([][]byte, error) {
 		n -= curSize
 	}
 	if n > 0 {
-		return nil, fmt.Errorf("insufficient bytes in reader")
+		return nil, errors.New("insufficient bytes in reader")
+	}
+	return res, nil
+}
+
+// PeekBuffer returns the next n bytes without advancing the reader.
+//
+// PeekBuffer returns the result as a BufferSlice with its own
+// reference counts on the underlying buffers. The caller must call Free on the
+// returned BufferSlice when done.
+//
+// PeekBuffer returns an error if Reader does not have enough data.
+func (r *Reader) PeekBuffer(n int) (BufferSlice, error) {
+	var res BufferSlice
+	for i := 0; n > 0 && i < len(r.data); i++ {
+		curData := r.data[i]
+		start := 0
+		if i == 0 {
+			start = r.bufferIdx
+		}
+		curSize := min(n, curData.Len()-start)
+		if curSize == 0 {
+			continue
+		}
+		res = append(res, curData.Slice(start, start+curSize))
+		n -= curSize
+	}
+	if n > 0 {
+		res.Free()
+		return nil, errors.New("insufficient bytes in reader")
 	}
 	return res, nil
 }

--- a/mem/buffer_slice_test.go
+++ b/mem/buffer_slice_test.go
@@ -501,6 +501,10 @@ func (s) TestBufferSlice_Iteration(t *testing.T) {
 				if err == nil {
 					t.Fatalf("Peek(1) returned error <nil>, want non-nil")
 				}
+				_, err = r.PeekBuffer(1)
+				if err == nil {
+					t.Fatalf("PeekBuffer(1) returned error <nil>, want non-nil")
+				}
 				discarded, err := r.Discard(1)
 				if got, want := discarded, 0; got != want {
 					t.Fatalf("Discard(1) = %d, want %d", got, want)
@@ -532,6 +536,14 @@ func (s) TestBufferSlice_Iteration(t *testing.T) {
 				if cap(res) != 10 {
 					t.Fatalf("Peek(5) did not use the provided slice.")
 				}
+				bufRes, err := r.PeekBuffer(5)
+				if err != nil {
+					t.Fatalf("PeekBuffer(5) returned error %v, want <nil>", err)
+				}
+				if got, want := bufRes.Materialize(), bytes.Join(res, nil); !bytes.Equal(got, want) {
+					t.Fatalf("PeekBuffer(5) = %v, want %v", got, want)
+				}
+				bufRes.Free()
 
 				discarded, err := r.Discard(5)
 				if got, want := discarded, 5; got != want {
@@ -550,6 +562,14 @@ func (s) TestBufferSlice_Iteration(t *testing.T) {
 				if len(res) != 1 || !bytes.Equal(res[0], []byte("56789")) {
 					t.Fatalf("Peek(5) after Discard(5) = %v, want [[56789]]", res)
 				}
+				bufRes, err = r.PeekBuffer(5)
+				if err != nil {
+					t.Fatalf("PeekBuffer(5) after Discard(5) returned error %v, want <nil>", err)
+				}
+				if got, want := bufRes.Materialize(), bytes.Join(res, nil); !bytes.Equal(got, want) {
+					t.Fatalf("PeekBuffer(5) after Discard(5) = %v, want %v", got, want)
+				}
+				bufRes.Free()
 
 				discarded, err = r.Discard(100)
 				if got, want := discarded, 5; got != want {
@@ -578,6 +598,14 @@ func (s) TestBufferSlice_Iteration(t *testing.T) {
 				if len(res) != 2 || !bytes.Equal(res[0], []byte("012")) || !bytes.Equal(res[1], []byte("34")) {
 					t.Fatalf("Peek(5) = %v, want [[012] [34]]", res)
 				}
+				bufRes, err := r.PeekBuffer(5)
+				if err != nil {
+					t.Fatalf("PeekBuffer(5) returned error %v, want <nil>", err)
+				}
+				if got, want := bufRes.Materialize(), bytes.Join(res, nil); !bytes.Equal(got, want) {
+					t.Fatalf("PeekBuffer(5) = %v, want %v", got, want)
+				}
+				bufRes.Free()
 
 				discarded, err := r.Discard(5)
 				if got, want := discarded, 5; got != want {
@@ -597,6 +625,14 @@ func (s) TestBufferSlice_Iteration(t *testing.T) {
 				if len(res) != 2 || !bytes.Equal(res[0], []byte("5")) || !bytes.Equal(res[1], []byte("6789")) {
 					t.Fatalf("Peek(5) after advance = %v, want [[5] [6789]]", res)
 				}
+				bufRes, err = r.PeekBuffer(5)
+				if err != nil {
+					t.Fatalf("PeekBuffer(5) after Discard(5) returned error %v, want <nil>", err)
+				}
+				if got, want := bufRes.Materialize(), bytes.Join(res, nil); !bytes.Equal(got, want) {
+					t.Fatalf("PeekBuffer(5) after Discard(5) = %v, want %v", got, want)
+				}
+				bufRes.Free()
 			},
 		},
 		{
@@ -625,6 +661,14 @@ func (s) TestBufferSlice_Iteration(t *testing.T) {
 				if len(res) != 1 || !bytes.Equal(res[0], []byte("56789")) {
 					t.Fatalf("Peek(5) after Reset = %v, want [[56789]]", res)
 				}
+				bufRes, err := r.PeekBuffer(5)
+				if err != nil {
+					t.Fatalf("PeekBuffer(5) after Reset returned error %v, want <nil>", err)
+				}
+				if got, want := bufRes.Materialize(), bytes.Join(res, nil); !bytes.Equal(got, want) {
+					t.Fatalf("PeekBuffer(5) after Reset = %v, want %v", got, want)
+				}
+				bufRes.Free()
 			},
 		},
 		{
@@ -641,6 +685,14 @@ func (s) TestBufferSlice_Iteration(t *testing.T) {
 				if len(res) != 0 {
 					t.Fatalf("Peek(0) got slices: %v, want empty", res)
 				}
+				bufRes, err := c.PeekBuffer(0)
+				if err != nil {
+					t.Fatalf("PeekBuffer(0) returned error %v, want <nil>", err)
+				}
+				if got := bufRes.Materialize(); len(got) != 0 {
+					t.Fatalf("PeekBuffer(0) = %v, want empty", got)
+				}
+				bufRes.Free()
 				discarded, err := c.Discard(0)
 				if err != nil {
 					t.Fatalf("Discard(0) return error %v, want <nil>", err)


### PR DESCRIPTION
This is a follow up for https://github.com/grpc/grpc-go/pull/8977. See the description there for motivation.
> I want to use `BufferSlice.Reader` and implement a `Peek()`(or similar) to get a `BufferSlice` of the next N bytes. I don't want a `[]byte` or `[][]byte`, I'd like to return this `BufferSlice` from a codecv2 and let gRPC free the buffers when it no longer needs them (i.e. I don't want to wrap those individual `[]byte` into `BufferSlice`s).

RELEASE NOTES:
* mem: add `Reader.PeekBuffer()` - new method to peek data in a `Reader` as a `BufferSlice`.