### PR TITLE
xds: enable GRPC_EXPERIMENTAL_XDS_ORCA_LRS_PROPAGATION to true by default as part of A85

### DIFF
--- a/internal/envconfig/xds.go
+++ b/internal/envconfig/xds.go
@@ -88,7 +88,7 @@ var (
 	// XDSORCAToLRSPropEnabled controls whether ORCA metrics are explicitly
 	// filtered and prefix-propagated to the LRS server. For more details, see:
 	// https://github.com/grpc/proposal/blob/master/A85-lrs-custom-metrics-changes.md
-	XDSORCAToLRSPropEnabled = boolFromEnv("GRPC_EXPERIMENTAL_XDS_ORCA_LRS_PROPAGATION", false)
+	XDSORCAToLRSPropEnabled = boolFromEnv("GRPC_EXPERIMENTAL_XDS_ORCA_LRS_PROPAGATION", true)
 
 	// XDSClientExtProcEnabled indicates whether ExtProc filter is enabled on
 	// the client side. For more details, see:


### PR DESCRIPTION
This just turns on the flag by default to propagate ORCA metrics to LRS Server.

RELEASE NOTES:
* xds: Enable xDS configuration to control which fields get propagated from ORCA backend metric reports to LRS load reports.