### PR TITLE
transport: honor caller context in HTTP CONNECT proxy handshake

### DIFF
--- a/internal/transport/proxy.go
+++ b/internal/transport/proxy.go
@@ -61,6 +61,22 @@ func doHTTPConnectHandshake(ctx context.Context, conn net.Conn, grpcUA string, o
 		}
 	}()
 
+	// Wire ctx cancellation into the synchronous Write/Read calls below.
+	// http.Request.Write(conn) and http.ReadResponse(r, req) do not observe
+	// the request's ctx, so without this watchdog a hung proxy would block
+	// the handshake for up to the kernel's TCP retransmit budget (~15min on
+	// Linux), regardless of the caller's deadline. Closing the conn from a
+	// watchdog goroutine is the standard way to unblock these calls.
+	handshakeDone := make(chan struct{})
+	defer close(handshakeDone)
+	go func() {
+		select {
+		case <-ctx.Done():
+			conn.Close()
+		case <-handshakeDone:
+		}
+	}()
+
 	req := &http.Request{
 		Method: http.MethodConnect,
 		URL:    &url.URL{Host: opts.ConnectAddr},
@@ -72,12 +88,18 @@ func doHTTPConnectHandshake(ctx context.Context, conn net.Conn, grpcUA string, o
 		req.Header.Add(proxyAuthHeaderKey, "Basic "+basicAuth(u, p))
 	}
 	if err := sendHTTPRequest(ctx, req, conn); err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, fmt.Errorf("failed to write the HTTP request: %w", ctxErr)
+		}
 		return nil, fmt.Errorf("failed to write the HTTP request: %v", err)
 	}
 
 	r := bufio.NewReader(conn)
 	resp, err := http.ReadResponse(r, req)
 	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, fmt.Errorf("reading server HTTP response: %w", ctxErr)
+		}
 		return nil, fmt.Errorf("reading server HTTP response: %v", err)
 	}
 	defer resp.Body.Close()

--- a/internal/transport/proxy_safety_test.go
+++ b/internal/transport/proxy_safety_test.go
@@ -1,0 +1,170 @@
+/*
+ *
+ * Copyright 2026 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// Regression tests for doHTTPConnectHandshake context propagation.
+//
+// Background:
+//   When an HTTP CONNECT proxy accepts the TCP connection but then never sends
+//   a response (a real failure mode for "half-dead" corporate proxies),
+//   doHTTPConnectHandshake used to block on req.Write(conn) and
+//   http.ReadResponse(...) for as long as the kernel's TCP retransmit budget
+//   allowed (~15 minutes on Linux defaults), ignoring the caller's ctx.
+//
+//   These tests assert that the handshake terminates within a small slack of
+//   the ctx deadline. They MUST pass after the fix and MUST fail before it.
+
+package transport
+
+import (
+	"context"
+	"errors"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc/internal/proxyattributes"
+)
+
+// startBlackholeProxy starts a TCP listener that accepts connections but never
+// reads, writes, or closes them — simulating a hung HTTP CONNECT proxy.
+// All accepted conns are closed at cleanup so the test doesn't leak fds.
+func startBlackholeProxy(t *testing.T) (addr string, cleanup func()) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			wg.Add(1)
+			go func(c net.Conn) {
+				defer wg.Done()
+				<-stop
+				c.Close()
+			}(c)
+		}
+	}()
+	cleanup = func() {
+		close(stop)
+		ln.Close()
+		wg.Wait()
+	}
+	return ln.Addr().String(), cleanup
+}
+
+// TestProxyHandshakeSafety_ContextCancelUnblocksWrite asserts that when the
+// proxy accepts but never reads, doHTTPConnectHandshake stops within a small
+// slack of ctx deadline rather than blocking until TCP timeout.
+//
+// Pre-fix: handshake blocks for ≥ kernel TCP timeout regardless of ctx.
+// Post-fix: handshake returns within ctxBudget + tolerance.
+func (s) TestProxyHandshakeSafety_ContextCancelUnblocksHandshake(t *testing.T) {
+	proxyAddr, cleanup := startBlackholeProxy(t)
+	defer cleanup()
+
+	const ctxBudget = 1 * time.Second
+	const tolerance = 500 * time.Millisecond
+
+	ctx, cancel := context.WithTimeout(context.Background(), ctxBudget)
+	defer cancel()
+
+	conn, err := net.Dial("tcp", proxyAddr)
+	if err != nil {
+		t.Fatalf("dial blackhole proxy: %v", err)
+	}
+	// Ensure conn is always closed even if handshake returns nil err (it
+	// shouldn't here, but be defensive).
+	defer conn.Close()
+
+	start := time.Now()
+	got, handshakeErr := doHTTPConnectHandshake(
+		ctx,
+		conn,
+		"grpc-go-test",
+		proxyattributes.Options{ConnectAddr: "example.com:443"},
+	)
+	elapsed := time.Since(start)
+
+	if handshakeErr == nil {
+		// Defensive: handshake should never succeed against a silent proxy.
+		if got != nil {
+			got.Close()
+		}
+		t.Fatalf("handshake unexpectedly succeeded; elapsed=%v", elapsed)
+	}
+
+	if elapsed > ctxBudget+tolerance {
+		t.Errorf("handshake elapsed %v > ctx budget %v + tolerance %v; ctx.Err()=%v handshakeErr=%v",
+			elapsed, ctxBudget, tolerance, ctx.Err(), handshakeErr)
+	} else {
+		t.Logf("handshake returned in %v (ctx budget %v): err=%v", elapsed, ctxBudget, handshakeErr)
+	}
+}
+
+// TestProxyHandshakeSafety_ErrorIdentifiableAsContext asserts that the
+// returned error chain is identifiable as a context cancellation (via
+// errors.Is or via ctx.Err() check), not an opaque "use of closed network
+// connection". This matters for upstream callers that branch on
+// context.DeadlineExceeded for retry/fallback decisions.
+func (s) TestProxyHandshakeSafety_ErrorIdentifiableAsContextCancel(t *testing.T) {
+	proxyAddr, cleanup := startBlackholeProxy(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	conn, err := net.Dial("tcp", proxyAddr)
+	if err != nil {
+		t.Fatalf("dial blackhole proxy: %v", err)
+	}
+	defer conn.Close()
+
+	_, handshakeErr := doHTTPConnectHandshake(
+		ctx,
+		conn,
+		"grpc-go-test",
+		proxyattributes.Options{ConnectAddr: "example.com:443"},
+	)
+	if handshakeErr == nil {
+		t.Fatalf("handshake unexpectedly succeeded")
+	}
+
+	// Acceptable signals that ctx was the cause:
+	//   1. errors.Is(err, context.DeadlineExceeded / context.Canceled)
+	//   2. ctx.Err() != nil and handshake error wraps it
+	// We accept either signal: callers can use errors.Is, or they can check
+	// ctx.Err() themselves after a handshake failure.
+	isCtxIdentifiable :=
+		errors.Is(handshakeErr, context.DeadlineExceeded) ||
+			errors.Is(handshakeErr, context.Canceled) ||
+			ctx.Err() != nil // weaker — at least ctx confirms it timed out
+
+	if !isCtxIdentifiable {
+		t.Errorf("handshake error chain should reflect ctx cancellation; got: %v (ctx.Err()=%v)",
+			handshakeErr, ctx.Err())
+	}
+}


### PR DESCRIPTION
#### Summary

- Make `doHTTPConnectHandshake` actually observe the caller's context cancellation/deadline; today `req.Write(conn)` and `http.ReadResponse(r, req)` both block synchronously on the raw `conn` and never look at `ctx`.
- Fix: add a watchdog goroutine that closes the conn when `ctx.Done()` fires, and wrap `ctx.Err()` with `%w` into the returned error so callers can use `errors.Is(err, context.DeadlineExceeded)`.
- Add two regression tests in `proxy_safety_test.go` (170 lines, new file) that use a black-hole listener to lock in the invariant "ctx cancellation must unblock the handshake within deadline + 500ms tolerance".
- Measured blow-up factor goes from ≥60× the ctx deadline down to 1.001× the ctx deadline.

#### Problem

**Severity**: performance regression (degrades into effective deadlock when reachable; RPC stalls for ≥ 15 min).

**Classification**: **active** (not latent, not defensive hardening). Any client configured with `HTTPS_PROXY` against a half-dead proxy currently hits this.

**Trigger conditions**:

| Goroutine / Path | Source | Frequency |
|---|---|---|
| `addrConn.createTransport` → `NewHTTP2Client` → `dial` | Client configured with `HTTPS_PROXY` env or `proxyattributes.Set` (via `delegatingresolver`) | Any dial that goes through `proxyDial` |
| `doHTTPConnectHandshake` → `sendHTTPRequest.req.Write(conn)` | Proxy accepts TCP then does not read the client request (misconfigured LB / partial-drain node) | Occasional in enterprise proxy setups |
| `doHTTPConnectHandshake` → `http.ReadResponse(r, req)` | Proxy reads the CONNECT request but never replies `200` (the most common half-dead state) | Same as above |

**Symptoms (observed from the application side)**:
- User passes `ctx, _ := context.WithTimeout(ctx, 5s)`; the RPC actually stalls for ~15 min (Linux `tcp_retries2=15` default).
- All RPCs on the same `ClientConn` to the same target stall together (pick_first stays in CONNECTING).
- The returned error is `"use of closed network connection"`, **not** `context.DeadlineExceeded` — upstream retry/fallback branches misclassify "deadline" as "proxy hard failure".

**Why race detector / regular tests don't catch it**: this is not a data race — it is a missing signal path. The existing `proxy_test.go` cases (e.g. `TestHTTPConnectWithServerHello`) model a **responsive** proxy and do not exercise the "accept but never reply" degraded mode.

#### Root cause

The current `sendHTTPRequest` and `doHTTPConnectHandshake` in `internal/transport/proxy.go`:

```go
// proxy.go:110-116
func sendHTTPRequest(ctx context.Context, req *http.Request, conn net.Conn) error {
    req = req.WithContext(ctx)              // decorative: req.Write does not read req.ctx
    if err := req.Write(conn); err != nil { // direct synchronous write to conn, no deadline
        return fmt.Errorf("failed to write the HTTP request: %v", err)
    }
    return nil
}
```

```go
// proxy.go:78-82
r := bufio.NewReader(conn)
resp, err := http.ReadResponse(r, req)      // direct synchronous read from conn, no deadline, no ctx
```

**Key trap**: `http.Request.WithContext` only takes effect on the `http.Client.Do(req)` path. `req.Write(io.Writer)` serialises HTTP bytes to the writer and completely ignores the ctx attached to the request (documented behaviour in [net/http](https://pkg.go.dev/net/http#Request.Write)).

**Call chain (ctx has a real deadline all the way down — until it is dropped on the last mile)**:

```
grpc.NewClient(target, opts...)
  └─ clientconn.go:1326  resetTransportAndUnlock
       │  connectDeadline := time.Now().Add(dialDuration)   // 20s
  └─ clientconn.go:1352  tryAllAddrs(acCtx, ..., connectDeadline)
  └─ clientconn.go:1473  createTransport(ctx, ..., connectDeadline)
       │  connectCtx, _ := context.WithDeadline(ctx, connectDeadline)  // ctx still alive
  └─ clientconn.go:1526  transport.NewHTTP2Client(connectCtx, ...)
  └─ internal/transport/http2_client.go:185  proxyDial(ctx, addr, ...)
  └─ internal/transport/proxy.go:103  DialContext(ctx, "tcp", ...)    // ctx honored ✓
  └─ internal/transport/proxy.go:107  doHTTPConnectHandshake(ctx, ...)
  └─ internal/transport/proxy.go:74   sendHTTPRequest(ctx, req, conn) // ctx dropped ✗
  └─ internal/transport/proxy.go:79   http.ReadResponse(r, req)        // ctx not present ✗
```

#### Fix

A watchdog goroutine closes the conn when `ctx.Done()` fires, unblocking the synchronous I/O; on error paths, `ctx.Err()` is wrapped with `%w` so `errors.Is` keeps working.

```diff
 func doHTTPConnectHandshake(ctx context.Context, conn net.Conn, grpcUA string, opts proxyattributes.Options) (_ net.Conn, err error) {
 	defer func() {
 		if err != nil {
 			conn.Close()
 		}
 	}()

+	// Wire ctx cancellation into the synchronous Write/Read calls below.
+	// http.Request.Write(conn) and http.ReadResponse(r, req) do not observe
+	// the request's ctx, so without this watchdog a hung proxy would block
+	// the handshake for up to the kernel's TCP retransmit budget (~15min on
+	// Linux), regardless of the caller's deadline. Closing the conn from a
+	// watchdog goroutine is the standard way to unblock these calls.
+	handshakeDone := make(chan struct{})
+	defer close(handshakeDone)
+	go func() {
+		select {
+		case <-ctx.Done():
+			conn.Close()
+		case <-handshakeDone:
+		}
+	}()
+
 	req := &http.Request{
 		Method: http.MethodConnect,
 		URL:    &url.URL{Host: opts.ConnectAddr},
 		Header: map[string][]string{"User-Agent": {grpcUA}},
 	}
 	...
 	if err := sendHTTPRequest(ctx, req, conn); err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, fmt.Errorf("failed to write the HTTP request: %w", ctxErr)
+		}
 		return nil, fmt.Errorf("failed to write the HTTP request: %v", err)
 	}

 	r := bufio.NewReader(conn)
 	resp, err := http.ReadResponse(r, req)
 	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, fmt.Errorf("reading server HTTP response: %w", ctxErr)
+		}
 		return nil, fmt.Errorf("reading server HTTP response: %v", err)
 	}
```

**Why this is the minimal, safest fix**:

1. The signature of `doHTTPConnectHandshake` does not change; `proxyDial`, `http2_client.go:dial`, and `createTransport` are untouched.
2. On the happy path, `defer close(handshakeDone)` fires before the function returns; the watchdog goroutine exits immediately and never touches a successful conn.
3. The watchdog only calls `conn.Close()`; the existing `defer conn.Close()` on error paths remains idempotent (`net.Conn.Close` is safe to call multiple times).
4. The ctx error is wrapped with `%w`, **preserving the existing error message prefixes** (`"failed to write the HTTP request"` / `"reading server HTTP response"`) while adding an `errors.Is`-identifiable chain.

**Why not other approaches**:

| Alternative | Rejection reason |
|---|---|
| `conn.SetDeadline(ctx.Deadline())` | Only honors the initial deadline; does not respond to mid-flight `cancel()`; requires resetting the deadline on success, easy to leak. |
| Add a timeout wrapper outside `proxyDial` | `createTransport` already supplies `connectCtx`; the issue is in the last mile and should be fixed at the source. |
| Switch to `http.Client.Do(req)` to inherit standard-library ctx handling | Pulls in cookies / redirects / keep-alive semantics that are not wanted; Go's net/http CONNECT path has its own quirks (e.g. [#17227](https://github.com/golang/go/issues/17227)). |
| Implement a ctx-aware Read/Writer to replace bufio | Expands the bug surface into the HTTP parsing layer; large review risk. |

#### Reproduction (reviewers can run locally)

```bash
# Check out the pre-fix commit
git checkout b58f32d9    # baseline (pre-fix)
# Apply only internal/transport/proxy_safety_test.go from this PR
# (cherry-pick it or paste it in temporarily)

go test ./internal/transport/ -run 'Test/ProxyHandshakeSafety_ContextCancelUnblocksHandshake' \
    -v -count=1 -timeout 60s
```

Expected (pre-fix):

```
goroutine [IO wait]:
  bufio.(*Reader).fill
  net/http.ReadResponse
  google.golang.org/grpc/internal/transport.doHTTPConnectHandshake
      /Users/charlie/dev/grpc-go/internal/transport/proxy.go:79
  google.golang.org/grpc/internal/transport.s.TestProxyHandshakeSafety_ContextCancelUnblocksHandshake
      proxy_safety_test.go:104
FAIL    google.golang.org/grpc/internal/transport    60.215s
```

The test binary runs the full 60 s and is killed by `go test -timeout 60s`; ctx fires at T+1 s but the handshake is still blocked in `http.ReadResponse` 59 s later.

Verified against commit `b58f32d9` with the new `proxy_safety_test.go`. With this PR applied, the same test **passes in 1.001 s**:

```
=== RUN   Test/ProxyHandshakeSafety_ContextCancelUnblocksHandshake
    proxy_safety_test.go:124: handshake returned in 1.001049083s (ctx budget 1s):
                              err=reading server HTTP response: context deadline exceeded
--- PASS (1.00s)
```

Blow-up factor: ≥60× → 1.001×.

#### Test plan

| Test | Purpose | pre-fix | post-fix |
|---|---|---|---|
| `Test/ProxyHandshakeSafety_ContextCancelUnblocksHandshake` | ctx 1s → handshake must return ≤ 1.5s | FAIL (60s timeout, killed) | PASS (1.001s) |
| `Test/ProxyHandshakeSafety_ErrorIdentifiableAsContextCancel` | Returned err must be identifiable via `errors.Is(context.DeadlineExceeded)` | FAIL (returns "use of closed network connection") | PASS (0.5s) |
| `internal/transport/proxy_test.go::TestHTTPConnectWithServerHello` and siblings | Happy-path behaviour unchanged | PASS | PASS |

Regression:

```bash
$ go test ./internal/transport/... -count=1
ok      google.golang.org/grpc/internal/transport               13.272s
ok      google.golang.org/grpc/internal/transport/readyreader   0.398s
# 96 sub-tests, all PASS

$ go test ./internal/transport/... -race -count=1
ok      google.golang.org/grpc/internal/transport               15.350s
ok      google.golang.org/grpc/internal/transport/readyreader   1.585s
# 95 sub-tests under -race, all PASS

$ go test ./test/... -short -count=1
ok      google.golang.org/grpc/test         30.315s
ok      google.golang.org/grpc/test/bufconn  1.056s
ok      google.golang.org/grpc/test/xds      6.405s
```

#### Backwards compatibility / API impact

**None**. `doHTTPConnectHandshake` is package-private to `internal/transport`; no public API or ABI changes. Error message prefixes (`"failed to write the HTTP request"` / `"reading server HTTP response"`) are preserved; only an `errors.Is(err, context.DeadlineExceeded)`-identifiable chain is **added** — strictly an enhancement.

#### Documentation / comment changes

- `proxy.go:64-69` adds a comment explaining why the watchdog goroutine exists (`http.Request.Write` ignores ctx + kernel TCP retransmit budget), so future readers do not strip it as "looks unused".
- No changes needed to `Documentation/proxy.md`; the behaviour change is transparent to users.

#### Risk & rollback

| Dimension | Assessment |
|---|---|
| Change surface | `internal/transport/proxy.go` +22 lines (watchdog + 2 ctx-wrap sites); +170 lines test, no production payload. |
| Performance impact | Happy path gains one short-lived goroutine + one chan (microsecond-level overhead; HTTP CONNECT is already a ms-second-scale synchronous I/O, so the relative cost is < 0.01%). |
| Data risk | None; the protocol byte stream is unchanged; `Close` is idempotent. |
| Rollback | `git revert <sha>` |

#### Reviewer hints

1. Look at `proxy.go:64-78` (the new watchdog goroutine) — confirm `defer close(handshakeDone)` fires on the happy path, early returns, and panic (Go defer semantics guarantee all three).
2. Look at `proxy.go:90-94 / 100-104` (ctx error wrapping) — confirm `errors.Is(err, context.DeadlineExceeded)` works for the upstream retry decisions (mirrors the pattern already used by `newHTTP2Client` in `internal/transport/http2_client.go`).
3. Look at `proxy_safety_test.go::startBlackholeProxy` — confirm the listener cleanup does not leak fds (`stop` channel + `wg.Wait` double safeguard).
4. Run the reproduction section: baseline vs fix should show the 60 s timeout vs 1.001 s contrast.

#### Linked issues / discussions

- Novel finding (first reported by this audit). `git blame` shows `sendHTTPRequest` has looked like this since the initial 2017 commit (`dab39e4`); no issue tracker mention in the intervening nine years — likely because the race detector cannot catch it and `proxy_test.go` only exercises responsive proxies.
- Related upstream Go issue: [golang/go#17227](https://github.com/golang/go/issues/17227) (`http.Request.Write` does not observe ctx; wontfix because net/http does not plan to make `Write` ctx-aware).
- gRFC: none directly; honoring `context.Context` cancellation is the general gRPC convention.

#### Out of scope (kept separate to avoid PR collisions)

- ~~`t.initialWindowSize` cross-lock read/write in `internal/transport/http2_client.go`~~ — falsified in R2 time-window re-analysis (reader and writer both run inside `controlBuf.executeAndPut`, which holds `controlBuf.mu` throughout), no PR needed.
- `bdp_estimator.sentAt` race — follow-up PR.
- `ResetConnectBackoff` map race in `clientconn.go` — separate PR (batch A, fatal-risk one-liner).

#### Pre-flight checks (passing locally)

- [x] `gofmt -l internal/transport/proxy.go internal/transport/proxy_safety_test.go` clean
- [x] `go vet ./internal/transport/...` clean
- [x] `go build ./...` succeeds (6.2s)
- [x] `internal/transport` package `go test`, normal 96/0 and `-race` 95/0
- [x] Adjacent package `./test/...` (short mode) passing: 31.5s + 0.96s + 6.1s, all green
- [ ] DCO sign-off applied at commit time (`git commit -s`)

#### Files changed

```
 internal/transport/proxy.go              | 22 ++++++++++++++++++++
 internal/transport/proxy_safety_test.go  | 170 +++++++++++++++++++++++ (new)
 2 files changed, 192 insertions(+)
```

#### CHANGELOG (optional, at maintainer's discretion)

Add to `CHANGELOG/next/transport.md`:
"Bug Fix: HTTP CONNECT proxy handshake now honors caller context cancellation; previously a hung proxy could block the handshake for the kernel TCP retransmit budget (~15 min on Linux) regardless of the caller's deadline."