### PR TITLE
clientconn: snapshot cc.conns under lock in ResetConnectBackoff

### DIFF
--- a/clientconn.go
+++ b/clientconn.go
@@ -1179,10 +1179,21 @@ func (cc *ClientConn) resolveNowLocked(o resolver.ResolveNowOptions) {
 // Notice: This API is EXPERIMENTAL and may be changed or removed in a
 // later release.
 func (cc *ClientConn) ResetConnectBackoff() {
+	// Snapshot the addrConns into a slice while holding cc.mu so the iteration
+	// below cannot race with concurrent writers to cc.conns
+	// (e.g. removeAddrConn / newAddrConnLocked, both invoked from the
+	// balancer wrapper's serializer goroutine). The previous form took only
+	// a reference to the map and iterated it lock-free, which races with
+	// those writers and can trigger a Go runtime "concurrent map iteration
+	// and map write" fatal. Compare ClientConn.Close, which uses the same
+	// "copy out under lock, iterate outside" pattern.
 	cc.mu.Lock()
-	conns := cc.conns
+	conns := make([]*addrConn, 0, len(cc.conns))
+	for ac := range cc.conns {
+		conns = append(conns, ac)
+	}
 	cc.mu.Unlock()
-	for ac := range conns {
+	for _, ac := range conns {
 		ac.resetConnectBackoff()
 	}
 }

--- a/clientconn_reset_backoff_safety_test.go
+++ b/clientconn_reset_backoff_safety_test.go
@@ -1,0 +1,230 @@
+/*
+ *
+ * Copyright 2026 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// Regression test for ResetConnectBackoff() racing with balancer-driven
+// removeAddrConn() / newAddrConnLocked() on cc.conns.
+//
+// Background:
+//   clientconn.go:1181-1188 (pre-fix) reads cc.conns under cc.mu, releases the
+//   lock, and then iterates the map outside the lock. Meanwhile, the balancer
+//   wrapper's serializer goroutine may call cc.removeAddrConn()
+//   (delete cc.conns[ac]) or cc.newAddrConnLocked() (cc.conns[ac] = ...).
+//   The two paths race on the same map; under -race the runtime reports DATA
+//   RACE, and without -race the Go runtime may throw "fatal error: concurrent
+//   map iteration and map write".
+//
+//   The fix snapshots the keys to a slice while holding the lock and iterates
+//   the slice outside the lock, matching the existing safe pattern used by
+//   ClientConn.Close (clientconn.go:1207-1208 sets cc.conns = nil under lock,
+//   then iterates the saved local variable).
+//
+// This test MUST pass after the fix and MUST fail under -race before the fix.
+
+package grpc
+
+import (
+	"context"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/resolver"
+	"google.golang.org/grpc/resolver/manual"
+)
+
+// startBackoffSafetyBlackholes spawns N TCP listeners that accept connections
+// but never read or write, so the client's dial succeeds and the balancer
+// actually creates / shuts down SubConns (which is what drives the racy
+// removeAddrConn / newAddrConnLocked path).
+func startBackoffSafetyBlackholes(t *testing.T, n int) (addrs []string, cleanup func()) {
+	t.Helper()
+	var lns []net.Listener
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatalf("listen: %v", err)
+		}
+		lns = append(lns, ln)
+		addrs = append(addrs, ln.Addr().String())
+		wg.Add(1)
+		go func(ln net.Listener) {
+			defer wg.Done()
+			for {
+				c, err := ln.Accept()
+				if err != nil {
+					return
+				}
+				wg.Add(1)
+				go func(c net.Conn) {
+					defer wg.Done()
+					<-stop
+					c.Close()
+				}(c)
+			}
+		}(ln)
+	}
+	cleanup = func() {
+		close(stop)
+		for _, ln := range lns {
+			ln.Close()
+		}
+		wg.Wait()
+	}
+	return
+}
+
+// TestResetConnectBackoffSafety_ConcurrentWithResolverUpdates exercises the
+// documented use of ResetConnectBackoff (calling it on network-recovery to
+// wake up subchannels) while a resolver concurrently pushes endpoint updates
+// (the natural behaviour of DNS resolver after network recovery as well).
+//
+// The two paths share cc.conns. Under -race the pre-fix implementation
+// triggers a DATA RACE; after the fix it must run cleanly.
+func (s) TestResetConnectBackoffSafety_ConcurrentWithResolverUpdates(t *testing.T) {
+	const (
+		listenerCount = 4
+		duration      = 2 * time.Second
+	)
+
+	addrs, cleanup := startBackoffSafetyBlackholes(t, listenerCount)
+	defer cleanup()
+
+	r := manual.NewBuilderWithScheme("repro-p2-4")
+	r.InitialState(resolver.State{
+		Addresses: []resolver.Address{{Addr: addrs[0]}},
+	})
+
+	cc, err := NewClient(
+		"repro-p2-4:///dummy",
+		WithResolvers(r),
+		WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	defer cc.Close()
+
+	cc.Connect()
+
+	// Let the initial SubConn settle so the balancer is in a steady state
+	// before stressing concurrent map access.
+	time.Sleep(100 * time.Millisecond)
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	// Goroutine A: documented "network recovery" call site.
+	// User code per ResetConnectBackoff doc:
+	//   "if a previously unavailable network becomes available, this may
+	//    be used to trigger an immediate reconnect."
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				cc.ResetConnectBackoff()
+			}
+		}
+	}()
+
+	// Goroutine B: resolver pushes endpoint updates (the natural behaviour
+	// of a DNS resolver when the network recovers). Each update with a
+	// different address makes pick_first shut down the old SubConn and
+	// create a new one, hitting cc.removeAddrConn() and
+	// cc.newAddrConnLocked() on cc.conns.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		i := 0
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				addr := addrs[i%listenerCount]
+				r.UpdateState(resolver.State{
+					Addresses: []resolver.Address{{Addr: addr}},
+				})
+				i++
+				// A small sleep keeps the race window open without
+				// spinning the CPU completely.
+				time.Sleep(time.Microsecond)
+			}
+		}
+	}()
+
+	// Run the stress for a fixed window. Under -race, any concurrent
+	// access on cc.conns trips the detector; the test will be marked
+	// failed before this select returns.
+	timer := time.NewTimer(duration)
+	defer timer.Stop()
+	<-timer.C
+	close(stop)
+	wg.Wait()
+
+	// If we reach here under -race, no race fired. Without -race, the Go
+	// runtime would have already aborted with "fatal error: concurrent map
+	// iteration and map write" if the race actually realized, so reaching
+	// this point implies the fix held up.
+}
+
+// TestResetConnectBackoffSafety_HappyPath verifies that ResetConnectBackoff,
+// when called serially (no concurrent resolver updates), still does its job:
+// it iterates the live addrConns without panicking and returns normally even
+// after a Connect() has produced state. This guards against the fix
+// accidentally breaking the non-racy use case.
+func (s) TestResetConnectBackoffSafety_HappyPath(t *testing.T) {
+	addrs, cleanup := startBackoffSafetyBlackholes(t, 1)
+	defer cleanup()
+
+	r := manual.NewBuilderWithScheme("repro-p2-4-happy")
+	r.InitialState(resolver.State{
+		Addresses: []resolver.Address{{Addr: addrs[0]}},
+	})
+
+	cc, err := NewClient(
+		"repro-p2-4-happy:///dummy",
+		WithResolvers(r),
+		WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	defer cc.Close()
+
+	cc.Connect()
+	// Give the SubConn time to register in cc.conns.
+	time.Sleep(50 * time.Millisecond)
+
+	// Should be idempotent and safe to call repeatedly in a single goroutine.
+	for i := 0; i < 5; i++ {
+		cc.ResetConnectBackoff()
+	}
+
+	// Issue a quick state read to confirm cc is still healthy.
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	_ = cc.WaitForStateChange(ctx, cc.GetState())
+}


### PR DESCRIPTION
#### Summary

- `ClientConn.ResetConnectBackoff` releases `cc.mu` and then iterates the `cc.conns` map without the lock; the balancer wrapper's serializer goroutine concurrently calls `removeAddrConn` / `newAddrConnLocked` on the same map, which triggers the Go runtime `fatal error: concurrent map iteration and map write` — a non-recoverable process crash.
- Fix: snapshot the keys into a `[]*addrConn` slice while holding `cc.mu`, then iterate the slice outside the lock. Mirrors the existing safe "copy out under lock, iterate outside" pattern used by `ClientConn.Close`.
- Add two regression tests in `clientconn_reset_backoff_safety_test.go` (230 lines, new): concurrent stress (`ConcurrentWithResolverUpdates`) plus single-threaded happy path.
- Measured: 3/3 pre-fix runs FAIL (avg 1.79s to first trip); post-fix the same test passes in 2.26s under `-race`.

#### Problem

**Severity**: crash (Go runtime `fatal`; whole process dies, **does not enter `recover`**)

**Classification**: **active** (not latent, not defensive hardening). Any client that uses `ResetConnectBackoff` as documented hits this when the balancer is concurrently churning SubConns.

**Trigger conditions**:

| Goroutine / Path | Source | Frequency |
|---|---|---|
| User goroutine → `cc.ResetConnectBackoff()` → `clientconn.go:1185 for ac := range conns` | Documented use (`clientconn.go:1167-1180`): "if a previously unavailable network becomes available, this may be used to trigger an immediate reconnect" | Sentinel goroutine / periodic ticker on network-recovery events |
| `balancer_wrapper.serializer` goroutine → `acBalancerWrapper.Shutdown` → `cc.removeAddrConn` → `clientconn.go:945 delete(cc.conns, ac)` | Resolver pushes new endpoint list (DNS resolver does this on network recovery) → `pick_first.reconcileSubConnsLocked` shuts down old SubConns | Any endpoint-list change |
| Same goroutine → `cc.newAddrConnLocked` → `clientconn.go:933 cc.conns[ac] = ...` | Resolver pushes new endpoint list → balancer creates a new SubConn | Same as above |

**Symptoms (observed from the application side)**: A long-running client (e.g. a `metrics-collector` style service) with a network-recovery sentinel goroutine `fatal error`s the moment the sentinel and the DNS resolver fire together; systemd / Kubernetes restarts the process, and the same window can hit again.

**Why race detector / regular tests don't catch it**: The existing `TestResetConnectBackoff` (`clientconn_test.go:609`, in place since 2017) calls `ResetConnectBackoff` from a single goroutine and uses a stub dialer; it **does not** model concurrent resolver pushes. No issue tracker hit in the eight years since `d2aec4d7` introduced the function.

#### Root cause

`clientconn.go:1181-1188` (pre-fix):

```go
func (cc *ClientConn) ResetConnectBackoff() {
    cc.mu.Lock()
    conns := cc.conns      // map header copy, underlying hashmap is shared
    cc.mu.Unlock()
    for ac := range conns { // lock-free iteration races concurrent delete/insert
        ac.resetConnectBackoff()
    }
}
```

**Key trap**: in Go, `conns := cc.conns` copies the map *header* (a pointer plus length / capacity), but the underlying hashmap data is shared. Iterating that map without the lock is a lock-free read of the hashmap structure that the writers (`removeAddrConn` / `newAddrConnLocked`) modify under `cc.mu`.

**Compare the correct pattern** in `ClientConn.Close` (`clientconn.go:1207-1209`):

```go
cc.mu.Lock()
conns := cc.conns
cc.conns = nil          // Close nils the field
cc.mu.Unlock()
// Any concurrent removeAddrConn now sees cc.conns == nil and returns at
// line 941, so it never writes the old conns we're iterating.
for ac := range conns { ... }
```

`removeAddrConn` line 941 has a nil short-circuit (`if cc.conns == nil { return }`). **Close uses field-nilling to make all writers no-op the old map**, but `ResetConnectBackoff` cannot — `cc.conns` must remain valid after the reset, so the only safe option is a slice snapshot.

**Goroutine topology** (also documented in `docs/audit/whitelist.md` #2):

```
User goroutine                            balancer_wrapper.serializer goroutine
ResetConnectBackoff (1185 for-range) ←→  removeAddrConn (945 delete)
                                          newAddrConnLocked (933 mapassign)
```

A and B are necessarily different goroutines (B lives on the internal goroutine created by `grpcsync.NewCallbackSerializer`); **even if the user is strictly single-threaded, B is always running** and the race remains reachable.

#### Fix

Copy keys into a slice under the lock, iterate the slice outside. The comment references `Close`'s identical safe pattern:

```diff
 func (cc *ClientConn) ResetConnectBackoff() {
+	// Snapshot the addrConns into a slice while holding cc.mu so the iteration
+	// below cannot race with concurrent writers to cc.conns
+	// (e.g. removeAddrConn / newAddrConnLocked, both invoked from the
+	// balancer wrapper's serializer goroutine). The previous form took only
+	// a reference to the map and iterated it lock-free, which races with
+	// those writers and can trigger a Go runtime "concurrent map iteration
+	// and map write" fatal. Compare ClientConn.Close, which uses the same
+	// "copy out under lock, iterate outside" pattern.
 	cc.mu.Lock()
-	conns := cc.conns
+	conns := make([]*addrConn, 0, len(cc.conns))
+	for ac := range cc.conns {
+		conns = append(conns, ac)
+	}
 	cc.mu.Unlock()
-	for ac := range conns {
+	for _, ac := range conns {
 		ac.resetConnectBackoff()
 	}
 }
```

**Why this is the minimal, safest fix**:

1. Signature unchanged; observable contract unchanged (every addrConn that was registered at snapshot time still receives `resetConnectBackoff()` exactly once).
2. Lock now holds for one extra O(N) iteration plus a slice append; N = current SubConn count (typically < 10), microsecond-level overhead.
3. Mirrors the "copy out under lock, iterate outside" pattern already used by `ClientConn.Close`, **consistent with existing code style**.
4. The call to `ac.resetConnectBackoff()` (which takes `ac.mu`) still happens outside `cc.mu`, so no `cc.mu → ac.mu` nested-lock chain is required.

**Why not other approaches**:

| Alternative | Rejection reason |
|---|---|
| Iterate under lock (`defer cc.mu.Unlock` + `for ac := range cc.conns { ac.resetConnectBackoff() }`) | Holds `cc.mu` across N entries into `ac.mu` (the `cc.mu → ac.mu` order is allowed by whitelist #5, no deadlock), but blocks every other `cc.mu` user (dial, GetState, ...) for the duration. Snapshot is more predictable. |
| Nil out `cc.conns` Close-style and re-create | Close puts cc into a shut-down state; ResetConnectBackoff must leave cc fully usable. |
| Switch `cc.conns` to `sync.Map` | Large change affecting every `cc.conns` reader/writer; high review risk. |

#### Reproduction (reviewers can run locally)

```bash
git checkout b58f32d9  # baseline (pre-fix)
# Apply only clientconn_reset_backoff_safety_test.go from this PR

go test ./ -run 'Test/ResetConnectBackoffSafety_ConcurrentWithResolverUpdates' \
    -race -count=1 -timeout 30s
```

Expected (pre-fix; 3/3 measured runs FAIL):

```
fatal error: concurrent map iteration and map write

goroutine 50 [running]:
internal/runtime/maps.fatal(...)
internal/runtime/maps.(*Iter).Next(...)        ← Go hashmap iter hits hashWriting bit
google.golang.org/grpc.(*ClientConn).ResetConnectBackoff(...)
    /Users/charlie/dev/grpc-go/clientconn.go:1185 +0xc0
google.golang.org/grpc.s.TestResetConnectBackoffSafety_ConcurrentWithResolverUpdates.func1()
    clientconn_reset_backoff_safety_test.go:147 +0x8c
FAIL    google.golang.org/grpc    1.631s
```

**Three stability runs** (with the fix stashed, the same test was run three times):

| Run | Trip mode | Elapsed |
|---|---|---|
| 1 | Go runtime fatal | 0.727s |
| 2 | `testing.go:1712: race detected` | 2.470s |
| 3 | Go runtime fatal | 2.184s |

Average 1.79s to first trip, 100% reproducible. Both trip modes were observed, confirming the bug **does not require `-race` compilation** — production binaries crash too.

Verified against commit `b58f32d9`. With this PR applied, the same test passes in **2.26s under `-race`**.

#### Test plan

| Test | Purpose | pre-fix | post-fix |
|---|---|---|---|
| `Test/ResetConnectBackoffSafety_ConcurrentWithResolverUpdates` | Concurrent stress: user sentinel + resolver-driven endpoint updates → race must trip | FAIL (avg 1.79s; Go runtime fatal / race detector, both modes observed) | PASS (2.26s under `-race`) |
| `Test/ResetConnectBackoffSafety_HappyPath` | Single-thread serial calls preserve happy-path behaviour | PASS (0.20s) | PASS (same) |
| `Test/ResetConnectBackoff` (`clientconn_test.go:609`, eight-year existing test) | Single dialer / single goroutine behaviour unchanged | PASS | PASS (1.4s under `-race`) |

Regression:

```bash
$ go test ./ -short -count=1
ok  google.golang.org/grpc  12.901s
# root package: 94 sub-tests, all PASS

$ go test ./ -short -race -count=1
ok  google.golang.org/grpc  15.383s
# Same 94 sub-tests under -race, all PASS

$ go test ./internal/balancergroup/... ./internal/balancer/... -short -race
ok  internal/balancergroup           5.249s
ok  internal/balancer/gracefulswitch 1.956s

$ go test ./test/ -short
ok  google.golang.org/grpc/test  30.829s
```

#### Backwards compatibility / API impact

**None**. `ResetConnectBackoff` is a public ClientConn method; signature, doc comment, and observable contract are all unchanged — after the call, every addrConn that existed at the moment the snapshot was taken still receives `resetConnectBackoff()` exactly once. Only the race is removed — strictly an enhancement.

#### Documentation / comment changes

- Eight-line implementation comment added inside `ResetConnectBackoff` explaining the snapshot's purpose (Go runtime fatal + concurrent writers from the balancer serializer + reference to `Close`'s safe pattern) — so future readers do not simplify it back.
- No user-facing documentation changes; the `clientconn.go:1167-1180` doc comment and the behavioural contract are preserved verbatim.

#### Risk & rollback

| Dimension | Assessment |
|---|---|
| Change surface | `clientconn.go` +13/-2 lines (one function); +230 lines test, no production payload. |
| Performance impact | One extra O(N) map iteration plus a slice append while holding `cc.mu`. N = SubConn count, typically < 10, nanosecond-to-microsecond range. `ResetConnectBackoff` is a user-triggered network-recovery hook, not a hot path. |
| Data risk | None. The snapshot semantics match the prior "map header copy" semantics for the iteration window — addrConns added after the snapshot were not visited before either. |
| Rollback | `git revert <sha>` |

#### Reviewer hints

1. Look at `clientconn.go:1181-1199` (post-fix). Confirm the snapshot pattern matches `Close()` (1207-1208): `Close` nils the field plus relies on the `nil` short-circuit in `removeAddrConn`; this PR uses slice copy because the map must remain valid after the call.
2. Look at `clientconn.go:937-948 removeAddrConn` to see the `if cc.conns == nil { return }` short-circuit that makes `Close`'s pattern safe and explains why `ResetConnectBackoff` cannot reuse the same nil-out approach.
3. Look at `clientconn_reset_backoff_safety_test.go::startBackoffSafetyBlackholes` — confirm the listener cleanup is leak-free.
4. Run the reproduction section: `git stash` the fix, run the safety test under `-race` three times — expect 3/3 FAIL; restore the fix and the same test should pass.

#### Linked issues / discussions

- Novel finding (first reported by this audit). `git log clientconn.go --follow` shows `ResetConnectBackoff` has stayed implementation-identical since commit `d2aec4d7` (2017, PR #2273 "Add ClientConn.ResetConnectBackoff to force reconnections on demand"). No issue tracker hit in the intervening eight years because the existing `TestResetConnectBackoff` does not exercise concurrent resolver updates.
- gRFC: none directly; `Documentation/concurrency.md:8` ("A ClientConn can safely be accessed concurrently") is the contract being honored.

#### Out of scope (kept separate to avoid PR collisions)

- P1-1 `proxy.go` HTTP CONNECT ctx not propagated → already in PR-A1.
- ~~P2-1 `t.initialWindowSize` cross-lock read/write~~ → falsified in R2 time-window re-analysis, no PR needed.
- P2-2 `bdp_estimator.sentAt` race → follow-up PR.
- Whether other rarely-used public APIs (`Connect`, `GetState`, ...) have similar lock-free map iteration → separate audit round.

#### Pre-flight checks (passing locally)

- [x] `gofmt -l clientconn.go clientconn_reset_backoff_safety_test.go` clean
- [x] `go vet ./...` clean
- [x] `go build ./...` succeeds
- [x] Root package `go test ./ -short` normal 94/0 and `-race` 94/0
- [x] Adjacent `internal/balancergroup/...` and `internal/balancer/...` under `-race` all PASS
- [x] `./test/` integration in short mode, 30.8s, all PASS
- [ ] DCO sign-off applied at commit time (`git commit -s`)

#### Files changed

```
 clientconn.go                            | 15 +++++++++++++--
 clientconn_reset_backoff_safety_test.go  | 230 ++++++++++++++++++++++ (new)
 2 files changed, 241 insertions(+), 2 deletions(-)
```