### PR TITLE
orca: serialize ServerMetricsRecorder writers to prevent lost-update

### DIFF
--- a/orca/server_metrics.go
+++ b/orca/server_metrics.go
@@ -19,6 +19,7 @@
 package orca
 
 import (
+	"sync"
 	"sync/atomic"
 
 	v3orcapb "github.com/cncf/xds/go/xds/data/orca/v3"
@@ -141,7 +142,14 @@ type ServerMetricsRecorder interface {
 	DeleteNamedUtilization(name string)
 }
 
+// serverMetricsRecorder serialises writers via mu so that the
+// load/copy/mutate/store sequence inside each Set* / Delete* method is
+// atomic with respect to other writers (atomic.Pointer alone only
+// provides a single-op load and a single-op store, not a transactional
+// read-modify-write — concurrent writers would otherwise lose updates).
+// Readers (ServerMetrics()) remain lock-free via atomic.Pointer.Load.
 type serverMetricsRecorder struct {
+	mu    sync.Mutex
 	state atomic.Pointer[ServerMetrics] // the current metrics
 }
 
@@ -201,6 +209,8 @@ func (s *serverMetricsRecorder) SetCPUUtilization(val float64) {
 		}
 		return
 	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	smCopy := copyServerMetrics(s.state.Load())
 	smCopy.CPUUtilization = val
 	s.state.Store(smCopy)
@@ -209,6 +219,8 @@ func (s *serverMetricsRecorder) SetCPUUtilization(val float64) {
 // DeleteCPUUtilization deletes the relevant server metric to prevent it from
 // being sent.
 func (s *serverMetricsRecorder) DeleteCPUUtilization() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	smCopy := copyServerMetrics(s.state.Load())
 	smCopy.CPUUtilization = -1
 	s.state.Store(smCopy)
@@ -222,6 +234,8 @@ func (s *serverMetricsRecorder) SetMemoryUtilization(val float64) {
 		}
 		return
 	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	smCopy := copyServerMetrics(s.state.Load())
 	smCopy.MemUtilization = val
 	s.state.Store(smCopy)
@@ -230,6 +244,8 @@ func (s *serverMetricsRecorder) SetMemoryUtilization(val float64) {
 // DeleteMemoryUtilization deletes the relevant server metric to prevent it
 // from being sent.
 func (s *serverMetricsRecorder) DeleteMemoryUtilization() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	smCopy := copyServerMetrics(s.state.Load())
 	smCopy.MemUtilization = -1
 	s.state.Store(smCopy)
@@ -244,6 +260,8 @@ func (s *serverMetricsRecorder) SetApplicationUtilization(val float64) {
 		}
 		return
 	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	smCopy := copyServerMetrics(s.state.Load())
 	smCopy.AppUtilization = val
 	s.state.Store(smCopy)
@@ -252,6 +270,8 @@ func (s *serverMetricsRecorder) SetApplicationUtilization(val float64) {
 // DeleteApplicationUtilization deletes the relevant server metric to prevent
 // it from being sent.
 func (s *serverMetricsRecorder) DeleteApplicationUtilization() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	smCopy := copyServerMetrics(s.state.Load())
 	smCopy.AppUtilization = -1
 	s.state.Store(smCopy)
@@ -265,6 +285,8 @@ func (s *serverMetricsRecorder) SetQPS(val float64) {
 		}
 		return
 	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	smCopy := copyServerMetrics(s.state.Load())
 	smCopy.QPS = val
 	s.state.Store(smCopy)
@@ -272,6 +294,8 @@ func (s *serverMetricsRecorder) SetQPS(val float64) {
 
 // DeleteQPS deletes the relevant server metric to prevent it from being sent.
 func (s *serverMetricsRecorder) DeleteQPS() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	smCopy := copyServerMetrics(s.state.Load())
 	smCopy.QPS = -1
 	s.state.Store(smCopy)
@@ -285,6 +309,8 @@ func (s *serverMetricsRecorder) SetEPS(val float64) {
 		}
 		return
 	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	smCopy := copyServerMetrics(s.state.Load())
 	smCopy.EPS = val
 	s.state.Store(smCopy)
@@ -292,6 +318,8 @@ func (s *serverMetricsRecorder) SetEPS(val float64) {
 
 // DeleteEPS deletes the relevant server metric to prevent it from being sent.
 func (s *serverMetricsRecorder) DeleteEPS() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	smCopy := copyServerMetrics(s.state.Load())
 	smCopy.EPS = -1
 	s.state.Store(smCopy)
@@ -306,6 +334,8 @@ func (s *serverMetricsRecorder) SetNamedUtilization(name string, val float64) {
 		}
 		return
 	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	smCopy := copyServerMetrics(s.state.Load())
 	smCopy.Utilization[name] = val
 	s.state.Store(smCopy)
@@ -314,6 +344,8 @@ func (s *serverMetricsRecorder) SetNamedUtilization(name string, val float64) {
 // DeleteNamedUtilization deletes any previously recorded measurement for a
 // utilization metric uniquely identifiable by name.
 func (s *serverMetricsRecorder) DeleteNamedUtilization(name string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	smCopy := copyServerMetrics(s.state.Load())
 	delete(smCopy.Utilization, name)
 	s.state.Store(smCopy)
@@ -322,6 +354,8 @@ func (s *serverMetricsRecorder) DeleteNamedUtilization(name string) {
 // SetRequestCost records a measurement for a utilization metric uniquely
 // identifiable by name.
 func (s *serverMetricsRecorder) SetRequestCost(name string, val float64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	smCopy := copyServerMetrics(s.state.Load())
 	smCopy.RequestCost[name] = val
 	s.state.Store(smCopy)
@@ -330,6 +364,8 @@ func (s *serverMetricsRecorder) SetRequestCost(name string, val float64) {
 // DeleteRequestCost deletes any previously recorded measurement for a
 // utilization metric uniquely identifiable by name.
 func (s *serverMetricsRecorder) DeleteRequestCost(name string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	smCopy := copyServerMetrics(s.state.Load())
 	delete(smCopy.RequestCost, name)
 	s.state.Store(smCopy)
@@ -338,6 +374,8 @@ func (s *serverMetricsRecorder) DeleteRequestCost(name string) {
 // SetNamedMetric records a measurement for a utilization metric uniquely
 // identifiable by name.
 func (s *serverMetricsRecorder) SetNamedMetric(name string, val float64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	smCopy := copyServerMetrics(s.state.Load())
 	smCopy.NamedMetrics[name] = val
 	s.state.Store(smCopy)
@@ -346,6 +384,8 @@ func (s *serverMetricsRecorder) SetNamedMetric(name string, val float64) {
 // DeleteNamedMetric deletes any previously recorded measurement for a
 // utilization metric uniquely identifiable by name.
 func (s *serverMetricsRecorder) DeleteNamedMetric(name string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	smCopy := copyServerMetrics(s.state.Load())
 	delete(smCopy.NamedMetrics, name)
 	s.state.Store(smCopy)

--- a/orca/server_metrics_bench_test.go
+++ b/orca/server_metrics_bench_test.go
@@ -1,0 +1,176 @@
+/*
+ *
+ * Copyright 2026 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// Benchmarks for orca.ServerMetricsRecorder to compare the lock-free
+// atomic.Pointer-only implementation (PR #6799) against the mutex-serialised
+// writer implementation (PR-B1, lost-update fix).
+//
+// The benchmark surface covers the three workload shapes that matter:
+//   1. ReaderOnly       — what OOB stream / smProvider.ServerMetrics() does
+//                          (PR #6799's primary motivation; PR-B1 leaves this
+//                          path lock-free, so we expect ~0 regression)
+//   2. SingleWriter     — happy-path single sampler goroutine (PR #6799 saw
+//                          this as the relevant write path)
+//   3. ConcurrentWriters — N sampler goroutines (the workload PR #6799
+//                          allowed lost-update to slip through; PR-B1 makes
+//                          this correct at the cost of mutex contention)
+//   4. ReadHeavyMixed   — 1 writer + N readers (the realistic ORCA OOB
+//                          deployment: low write rate, many client OOB
+//                          streams polling)
+
+package orca
+
+import (
+	"sync/atomic"
+	"testing"
+)
+
+// BenchmarkServerMetricsRecorder_ServerMetrics_ReaderOnly measures the
+// reader path that ORCA's OOB stream invokes once per tick.
+//
+// Design intent: this must remain at parity with the pre-fix
+// (atomic.Pointer-only) implementation — PR-B1's reader path does not
+// acquire mu.
+func BenchmarkServerMetricsRecorder_ServerMetrics_ReaderOnly(b *testing.B) {
+	smr := NewServerMetricsRecorder()
+	smr.SetCPUUtilization(0.5)
+	smr.SetMemoryUtilization(0.4)
+	smr.SetApplicationUtilization(0.3)
+	smr.SetQPS(100)
+	smr.SetEPS(1)
+	smr.SetNamedUtilization("queue_depth", 0.2)
+	smr.SetNamedUtilization("error_rate", 0.01)
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			_ = smr.ServerMetrics()
+		}
+	})
+}
+
+// BenchmarkServerMetricsRecorder_SetCPUUtilization_SingleWriter measures
+// the single-writer happy path (one CPU sampler goroutine, no contention).
+//
+// PR-B1 adds an uncontended mutex acquire (~25ns) to this path. Expected
+// regression is small in absolute terms vs the copyServerMetrics map
+// allocations that dominate this path.
+func BenchmarkServerMetricsRecorder_SetCPUUtilization_SingleWriter(b *testing.B) {
+	smr := NewServerMetricsRecorder()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		smr.SetCPUUtilization(0.5)
+	}
+}
+
+// BenchmarkServerMetricsRecorder_SetNamedUtilization_SingleWriter measures
+// the map-write path (a per-RPC SetNamedUtilization call).
+func BenchmarkServerMetricsRecorder_SetNamedUtilization_SingleWriter(b *testing.B) {
+	smr := NewServerMetricsRecorder()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		smr.SetNamedUtilization("queue_depth", 0.5)
+	}
+}
+
+// BenchmarkServerMetricsRecorder_ConcurrentWriters_DistinctScalars measures
+// the N-writer-distinct-fields workload where lost-update was observed
+// (CPU/Mem/App/QPS/EPS samplers).
+//
+// PR-B1 serialises these via mu. Pre-fix is "faster" but incorrect (loses
+// updates). The right framing for this benchmark is "the cost of
+// correctness", not "PR-B1 vs PR #6799 raw speed".
+func BenchmarkServerMetricsRecorder_ConcurrentWriters_DistinctScalars(b *testing.B) {
+	smr := NewServerMetricsRecorder()
+	setters := []func(float64){
+		smr.SetCPUUtilization,
+		smr.SetMemoryUtilization,
+		smr.SetApplicationUtilization,
+		smr.SetQPS,
+		smr.SetEPS,
+	}
+	// Pick which setter to call based on a per-goroutine index so distinct
+	// goroutines hit distinct setter functions (matches the realistic
+	// "one sampler per metric family" deployment).
+	var idx atomic.Int64
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		setter := setters[idx.Add(1)%int64(len(setters))]
+		for pb.Next() {
+			setter(0.5)
+		}
+	})
+}
+
+// BenchmarkServerMetricsRecorder_ConcurrentWriters_NamedKeys measures the
+// concurrent-distinct-key NamedUtilization workload (per-RPC handlers
+// each writing their own custom metric).
+func BenchmarkServerMetricsRecorder_ConcurrentWriters_NamedKeys(b *testing.B) {
+	smr := NewServerMetricsRecorder()
+	var idx atomic.Int64
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		// Each goroutine writes its own dedicated key.
+		key := keyFor(int(idx.Add(1)) % 8)
+		for pb.Next() {
+			smr.SetNamedUtilization(key, 0.5)
+		}
+	})
+}
+
+// BenchmarkServerMetricsRecorder_ReadHeavyMixed_1Writer_NReaders measures
+// the realistic ORCA OOB deployment shape: one slow writer (CPU sampler
+// ticking at ~1-10 Hz logically; we hit it as fast as possible here to
+// stress the reader path) plus many readers (each OOB stream's tick).
+//
+// PR-B1's design property: readers do not block on writers (lock-free
+// reader path), so this benchmark should show parity for the reader path
+// regardless of writer contention.
+func BenchmarkServerMetricsRecorder_ReadHeavyMixed_1Writer_NReaders(b *testing.B) {
+	smr := NewServerMetricsRecorder()
+	smr.SetCPUUtilization(0.5)
+
+	stop := make(chan struct{})
+	writerDone := make(chan struct{})
+	go func() {
+		defer close(writerDone)
+		v := 0.0
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			v += 0.001
+			if v > 1 {
+				v = 0
+			}
+			smr.SetCPUUtilization(v)
+		}
+	}()
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			_ = smr.ServerMetrics()
+		}
+	})
+	b.StopTimer()
+	close(stop)
+	<-writerDone
+}

--- a/orca/server_metrics_safety_test.go
+++ b/orca/server_metrics_safety_test.go
@@ -1,0 +1,290 @@
+/*
+ *
+ * Copyright 2026 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// Safety / characterization tests for orca.ServerMetricsRecorder.
+//
+// These tests lock the concurrent invariants implied by the package-level
+// contract documented at server_metrics.go:148-150:
+//
+//   // NewServerMetricsRecorder returns an in-memory store for ServerMetrics
+//   // and allows for safe setting and retrieving of ServerMetrics.
+//
+// Go convention: "safe" without qualification means thread-safe for
+// concurrent use. The natural deployment pattern for ORCA OOB load
+// reporting is one sampler goroutine per metric family (CPU, Memory,
+// Application, plus per-RPC SetNamedUtilization for backpressure
+// signals), all writing concurrently to a single shared recorder.
+//
+// These tests must pass with -race both before and after any change to
+// orca/server_metrics.go.
+
+package orca
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestServerMetricsRecorderSafety_DistinctScalars_LastWriteSurvives asserts
+// that when N writer goroutines each monotonically write distinct scalar
+// fields, the final state reflects each writer's last value. This is the
+// most basic invariant of a thread-safe recorder.
+//
+// pre-fix expectation: FAIL — atomic.Pointer load/modify/store is not
+// transactional, so the last-storer overwrites every other concurrent
+// writer's final update with a stale snapshot.
+//
+// post-fix expectation: PASS.
+func (s) TestServerMetricsRecorderSafety_DistinctScalars_LastWriteSurvives(t *testing.T) {
+	const iters = 5_000
+	smr := NewServerMetricsRecorder()
+	// Initialise everything to 0 so the final-value assertion has a
+	// well-defined baseline (unset = -1 confuses the "max" comparison).
+	smr.SetCPUUtilization(0)
+	smr.SetMemoryUtilization(0)
+	smr.SetApplicationUtilization(0)
+	smr.SetQPS(0)
+	smr.SetEPS(0)
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	writer := func(set func(float64)) {
+		defer wg.Done()
+		<-start
+		for i := 1; i <= iters; i++ {
+			set(float64(i) / float64(iters)) // monotonic in (0, 1]
+		}
+	}
+	wg.Add(5)
+	go writer(smr.SetCPUUtilization)
+	// SetMemoryUtilization range is [0,1], rest are val >= 0.
+	go writer(smr.SetMemoryUtilization)
+	go writer(smr.SetApplicationUtilization)
+	go writer(smr.SetQPS)
+	go writer(smr.SetEPS)
+
+	close(start)
+	wg.Wait()
+
+	sm := smr.ServerMetrics()
+	const want = 1.0
+	for _, c := range []struct {
+		name string
+		got  float64
+	}{
+		{"CPUUtilization", sm.CPUUtilization},
+		{"MemUtilization", sm.MemUtilization},
+		{"AppUtilization", sm.AppUtilization},
+		{"QPS", sm.QPS},
+		{"EPS", sm.EPS},
+	} {
+		if c.got != want {
+			t.Errorf("lost-update: %s = %.6f, want %.6f (writer's last value)", c.name, c.got, want)
+		}
+	}
+}
+
+// TestServerMetricsRecorderSafety_NamedUtilization_DistinctKeys_LastWriteSurvives
+// asserts that concurrent SetNamedUtilization on distinct keys preserves
+// every writer's last value. Each key is written by exactly one goroutine,
+// so the per-key "last value" is well-defined.
+//
+// pre-fix expectation: FAIL — when one goroutine's load-modify-store overlaps
+// another's, the later store overwrites the former's whole map, including
+// the entry the former just added or just updated.
+//
+// post-fix expectation: PASS.
+func (s) TestServerMetricsRecorderSafety_NamedUtilization_DistinctKeys_LastWriteSurvives(t *testing.T) {
+	const (
+		writers = 8
+		iters   = 2_000
+	)
+	smr := NewServerMetricsRecorder()
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(writers)
+	for w := 0; w < writers; w++ {
+		key := keyFor(w)
+		go func() {
+			defer wg.Done()
+			<-start
+			for i := 1; i <= iters; i++ {
+				smr.SetNamedUtilization(key, float64(i)/float64(iters))
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	sm := smr.ServerMetrics()
+	for w := 0; w < writers; w++ {
+		k := keyFor(w)
+		v, ok := sm.Utilization[k]
+		if !ok {
+			t.Errorf("lost-update: NamedUtilization[%q] missing entirely", k)
+			continue
+		}
+		if v != 1.0 {
+			t.Errorf("lost-update: NamedUtilization[%q] = %.6f, want 1.0 (writer's last value)", k, v)
+		}
+	}
+}
+
+// TestServerMetricsRecorderSafety_Monotonicity_ReaderObservesNoRollback
+// asserts that, given N writer goroutines each monotonically increasing
+// distinct scalar fields, a concurrent reader of ServerMetrics() never
+// observes any single field move backwards.
+//
+// This invariant is strictly stronger than the previous two: even if the
+// final state happens to be correct, intermediate observations under
+// lost-update show fields rolling back to older values when one writer's
+// store carries a stale snapshot of other fields.
+//
+// pre-fix expectation: FAIL — thousands of rollbacks observed per second.
+//
+// post-fix expectation: PASS (0 rollbacks).
+func (s) TestServerMetricsRecorderSafety_Monotonicity_ReaderObservesNoRollback(t *testing.T) {
+	const iters = 10_000
+	smr := NewServerMetricsRecorder()
+	smr.SetCPUUtilization(0)
+	smr.SetMemoryUtilization(0)
+	smr.SetApplicationUtilization(0)
+
+	stop := make(chan struct{})
+	var rollbacks atomic.Int64
+	var firstViolation atomic.Pointer[string]
+
+	// Reader goroutine: polls and checks each scalar field never decreases.
+	readerDone := make(chan struct{})
+	go func() {
+		defer close(readerDone)
+		var maxCPU, maxMem, maxApp float64
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			sm := smr.ServerMetrics()
+			if sm.CPUUtilization < maxCPU {
+				rollbacks.Add(1)
+				recordFirstViolation(&firstViolation, "CPU", maxCPU, sm.CPUUtilization)
+			} else {
+				maxCPU = sm.CPUUtilization
+			}
+			if sm.MemUtilization < maxMem {
+				rollbacks.Add(1)
+				recordFirstViolation(&firstViolation, "Mem", maxMem, sm.MemUtilization)
+			} else {
+				maxMem = sm.MemUtilization
+			}
+			if sm.AppUtilization < maxApp {
+				rollbacks.Add(1)
+				recordFirstViolation(&firstViolation, "App", maxApp, sm.AppUtilization)
+			} else {
+				maxApp = sm.AppUtilization
+			}
+		}
+	}()
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(3)
+	for _, set := range []func(float64){
+		smr.SetCPUUtilization,
+		smr.SetMemoryUtilization,
+		smr.SetApplicationUtilization,
+	} {
+		set := set
+		go func() {
+			defer wg.Done()
+			<-start
+			for i := 1; i <= iters; i++ {
+				set(float64(i) / float64(iters))
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(stop)
+	<-readerDone
+
+	if n := rollbacks.Load(); n > 0 {
+		msg := "<none captured>"
+		if p := firstViolation.Load(); p != nil {
+			msg = *p
+		}
+		t.Errorf("lost-update detected: %d monotonicity rollbacks observed; first violation: %s", n, msg)
+	}
+}
+
+// --- helpers ---
+
+func keyFor(i int) string {
+	// Simple, stable key per writer; avoids fmt to keep the hot loop allocation-free.
+	return string([]byte{'k', '0' + byte(i)})
+}
+
+func recordFirstViolation(p *atomic.Pointer[string], field string, max, observed float64) {
+	if p.Load() != nil {
+		return
+	}
+	s := field + ": max=" + ftoa(max) + " observed=" + ftoa(observed) + " at " + time.Now().Format(time.RFC3339Nano)
+	p.CompareAndSwap(nil, &s)
+}
+
+func ftoa(f float64) string {
+	// Avoid fmt import dance; precision sufficient for diagnostics.
+	const prec = 1e9
+	if f < 0 {
+		return "-" + ftoa(-f)
+	}
+	whole := int64(f)
+	frac := int64((f - float64(whole)) * prec)
+	s := itoa(whole) + "."
+	digits := itoa(frac)
+	for len(digits) < 9 {
+		digits = "0" + digits
+	}
+	return s + digits
+}
+
+func itoa(n int64) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
+}


### PR DESCRIPTION

#### Summary

- `ServerMetricsRecorder`'s 16 `Set*` / `Delete*` methods run a three-step `s.state.Load() → copyServerMetrics → mutate → s.state.Store` sequence. `atomic.Pointer` makes each Load and each Store atomic, **but not the read-modify-write as a unit**: two writers that Load the same snapshot, each mutate one field, and each Store the result will see the later Store overwrite the other's update — a classic lost-update.
- Fix: add `mu sync.Mutex` to `serverMetricsRecorder` and wrap the load-modify-store sequence of the 16 write methods in `Lock` / `defer Unlock`. **The reader path `ServerMetrics()` stays lock-free** (still via `atomic.Pointer.Load`), preserving the read-side win from [PR #6799](https://github.com/grpc/grpc-go/pull/6799).
- Adds three regression tests (`server_metrics_safety_test.go`, 290 lines, new): the concurrent `DistinctScalars` / `NamedUtilization_DistinctKeys` / `Monotonicity` invariants.
- Adds a benchmark suite (`server_metrics_bench_test.go`, 170 lines, new) covering Reader / SingleWriter / ConcurrentWriters / ReadHeavyMixed workloads — the missing piece that let this regression slip through CI in the first place.
- Measured: pre-fix 2/2 race-mode runs FAIL (22526 monotonicity rollbacks; 7 of 8 `NamedUtilization` keys lose their final value); post-fix 3/3 race-mode runs PASS.

#### Problem

**Severity**: data-plane correctness regression. The lost values flow to ORCA-aware balancers (`weightedroundrobin`, `ringhash`) and skew endpoint weights, so traffic distribution drifts from real server load.

**Classification**: **active regression**. [PR #6799](https://github.com/grpc/grpc-go/pull/6799) "use atomic pointer instead of mutex in server metrics recorder to improve performance" (commit `02a4e93b`, merged 2023-10) replaced the original mutex implementation with `atomic.Pointer` to optimise the read path, but **did not preserve writer-writer mutual exclusion**. The original mutex version was correct; the new version is still correct for a single writer but degrades to a racy read-modify-write for multiple writers.

**Trigger conditions**:

| Goroutine / Path | Source | Frequency |
|---|---|---|
| Goroutine A → `smr.SetCPUUtilization(val)` → `orca/server_metrics.go:204-206` | Recommended use: periodic CPU sampler goroutine | Per sampler tick (typically 1-10s) |
| Goroutine B → `smr.SetMemoryUtilization(val)` → same file | Recommended use: periodic memory sampler goroutine | Same |
| Goroutine C → `smr.SetNamedUtilization(key, val)` | Recommended use: per-RPC handler writing backpressure signals | Per RPC |

**godoc contract** ([orca/server_metrics.go:156-158](orca/server_metrics.go#L156)):

> NewServerMetricsRecorder returns an in-memory store for ServerMetrics and **allows for safe setting and retrieving** of ServerMetrics.

By Go convention, an unqualified "safe" means thread-safe. The godoc promises multi-writer safety; the implementation has stopped honoring it since PR #6799.

**End-to-end user impact**:

1. **Typical race (N=3 writers)**:
   ```
   T0  state = {CPU=0.6, Mem=0.4, App=0.3}
   T1  A: smCpy  := load();      // smCpy  = {0.6, 0.4, 0.3}
   T2  B: smCpy' := load();      // smCpy' = {0.6, 0.4, 0.3}
   T3  A: smCpy.CPU = 0.8; store(smCpy);  // state = {0.8, 0.4, 0.3}
   T4  B: smCpy'.Mem = 0.5; store(smCpy'); // state = {0.6, 0.5, 0.3}  ← A's 0.8 lost
   ```
   The next OOB stream tick pushes `{CPU=0.6, Mem=0.5, App=0.3}` to the client. From the reader's perspective, CPU **rolls back** from 0.8 to 0.6.
2. **Client-side balancers compute weights from stale metrics**: `endpointWeight.weightVal = QPS / (utilization + errorRate * penalty)` ([balancer/weightedroundrobin/balancer.go:566](balancer/weightedroundrobin/balancer.go#L566)). A stale `utilization` produces a stale weight, so traffic distribution **stops tracking real load**.
2. **If the race lets CPU collapse to -1 (unset)**: `toLoadReportProto` omits the field, the proto3 zero value is 0 on the client, and `endpointWeight.OnLoadReport` line 555 — `if utilization == 0 || load.RpsFractional == 0 { return }` — **discards the entire OOB report**. The weight then stays at its previous value indefinitely until the next non-zero report.

**Why race detector / existing tests don't catch this**:

- `atomic.Pointer.Load/Store` are legitimate atomic ops and form happens-before edges, so the race detector stays silent. The accompanying tests confirm this by running under `-race` and observing zero `DATA RACE` output.
- The four existing tests in `orca/server_metrics_test.go` are all single-threaded sequential — no concurrent writer scenarios — so this class of logical race is out of their coverage.

#### Root cause

`orca/server_metrics.go:204-206` (pre-fix; all 16 `Set*` / `Delete*` methods share this pattern):

```go
func (s *serverMetricsRecorder) SetCPUUtilization(val float64) {
    if val < 0 { /* range check */ return }
    smCopy := copyServerMetrics(s.state.Load())   // ← atomic load of the old snapshot
    smCopy.CPUUtilization = val                   // ← non-atomic mutation
    s.state.Store(smCopy)                         // ← atomic store of the new snapshot
}
```

`atomic.Pointer[T]`'s Go memory-model contract ([sync/atomic doc](https://pkg.go.dev/sync/atomic#Pointer)): **each Load and each Store is atomic, but "Load then Store" is not a CAS**. Two concurrent writers both Load the same old pointer, each build a new snapshot, and each Store — last Store wins, the rest are silently overwritten.

#### Fix

Add `mu sync.Mutex` to `serverMetricsRecorder` and wrap the load-modify-store inside every write method with `Lock` / `defer Unlock`. The reader does not take `mu` and stays lock-free.

```diff
 type serverMetricsRecorder struct {
+	mu    sync.Mutex
 	state atomic.Pointer[ServerMetrics] // the current metrics
 }

 func (s *serverMetricsRecorder) SetCPUUtilization(val float64) {
 	if val < 0 { ... return }
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	smCopy := copyServerMetrics(s.state.Load())
 	smCopy.CPUUtilization = val
 	s.state.Store(smCopy)
 }
```

**Why this is the minimal, safest fix**:

1. The `ServerMetricsRecorder` interface, the `ServerMetrics` struct, and externally observable behaviour are all unchanged. The godoc already promised thread-safe behaviour; this PR simply makes the implementation honor it.
2. **The reader path is untouched.** PR #6799's core win — `ServerMetrics()` is a lock-free `atomic.Pointer.Load` followed by a copy, so high-frequency OOB stream readers never block on a writer — is fully preserved.
3. Writer overhead is negligible: an uncontended `sync.Mutex` acquire is ~25ns, far smaller than the `copyServerMetrics` map allocations that already dominate the path; contended writers simply queue (and the typical ORCA write rate of 1-10 Hz is well below mutex saturation).
4. The pattern is the pre-#6799 mutex implementation plus the post-#6799 `atomic.Pointer` for publication — a standard "writer-serialized, lock-free publish" arrangement (the same shape as RCU).

**Why not other approaches**:

| Alternative | Rejection reason |
|---|---|
| CAS retry loop | Under contention each retry redoes `copyServerMetrics` (map copies); coordinating with `defer s.state.Store` is awkward. The ORCA write rate does not need lock-free writes. |
| Split fields into individual atomics (`atomic.Uint64` for scalars + `sync.Map` for maps) | Loses the "atomic snapshot across fields" semantics readers rely on (a reader could see CPU updated but Mem not); large change surface, high regression risk. |
| Document a "writer must lock externally" requirement instead | Breaks the 5-year-old "safe setting" contract; impossible to notify every existing user; requires a deprecation cycle. |

#### Reproduction (reviewers can run locally)

```bash
# 1. Stash this PR's server_metrics.go fix (untracked safety / bench tests stay in place)
git stash push -- orca/server_metrics.go

# 2. Run the safety tests under -race
go test ./orca/ -run 'Test/ServerMetricsRecorderSafety_' -race -count=1 -timeout 120s
```

Expected (pre-fix):

```
--- FAIL: Test/ServerMetricsRecorderSafety_DistinctScalars_LastWriteSurvives
    lost-update: CPUUtilization = 0.988600, want 1.000000 (writer's last value)
    ...
--- FAIL: Test/ServerMetricsRecorderSafety_Monotonicity_ReaderObservesNoRollback
    lost-update detected: 22526 monotonicity rollbacks observed
...
FAIL  google.golang.org/grpc/orca  0.55s
```

The same `-race` invocation produces **no `DATA RACE` lines** — confirming this is a logical race, not a data race.

```bash
git stash pop
go test ./orca/ -run 'Test/ServerMetricsRecorderSafety_' -race -count=1
# ok  google.golang.org/grpc/orca  1.39s
```

Verified against `b58f32d9`. Pre-fix: 2/2 runs FAIL with the failure modes above. Post-fix: 3/3 runs PASS in ~1.4s each.

#### Test plan

| Test | Purpose | pre-fix | post-fix |
|---|---|---|---|
| `Test/ServerMetricsRecorderSafety_DistinctScalars_LastWriteSurvives` | 5 writers × 5k iters, all 5 scalar fields must equal 1.0 (each writer's last value) | FAIL (3-4 fields < 1.0) | PASS |
| `Test/ServerMetricsRecorderSafety_NamedUtilization_DistinctKeys_LastWriteSurvives` | 8 writers × 2k iters, all 8 keys must be present with value 1.0 | FAIL (6-7 keys lose last write) | PASS |
| `Test/ServerMetricsRecorderSafety_Monotonicity_ReaderObservesNoRollback` | 3 writers × 10k iters + 1 reader; no scalar may move backwards | FAIL (18000-22000 rollbacks) | PASS |
| `Test/ServerMetrics_Setters` / `_Deleters` / `_Setters_Range` / `_Merge` (existing) | Single-threaded happy path unchanged | PASS | PASS |

Regression:

```bash
$ go test ./orca/... -count=1
ok   google.golang.org/grpc/orca  0.504s

$ go test ./orca/... -race -count=1
ok   google.golang.org/grpc/orca  1.594s

$ go test ./balancer/weightedroundrobin/ -race -count=1
ok   google.golang.org/grpc/balancer/weightedroundrobin  3.943s
```

#### Backwards compatibility / API impact

**None.** The `ServerMetricsRecorder` interface is unchanged; `serverMetricsRecorder` only gains an unexported `mu` field. Observable behaviour becomes strictly stronger (writes are no longer lost) — no user can have depended on lost updates.

#### Documentation / comment changes

- A 5-line doc comment on `serverMetricsRecorder` explains why `mu` exists (`atomic.Pointer` is not transactional, PR #6799 regression history, reader path stays lock-free) so future readers do not simplify it away.
- No user-visible doc changes; `NewServerMetricsRecorder`'s "safe setting and retrieving" promise is preserved verbatim — this PR simply makes it true again.

#### Performance (pre-fix vs post-fix, measured)

PR #6799's stated motivation was "replace mutex with atomic.Pointer for performance". This PR has to show that **PR #6799's actual target — the reader path and the single-writer path — keep their wins, and that the price paid on the contended-writer path is acceptable**.

The new [`orca/server_metrics_bench_test.go`](orca/server_metrics_bench_test.go) (170 lines, 6 benchmarks across three workload shapes) was run with `benchstat -count=10 -benchtime=1s`, pre-fix (`git stash` the fix) vs post-fix:

| Workload | pre-fix (atomic.Pointer only) | post-fix (mu + atomic.Pointer) | Δ | Reading |
|---|---|---|---|---|
| `ServerMetrics_ReaderOnly` (pure read) | 92.5ns ± 2% | 96.1ns ± 7% | **+3.9%** (p=0.000) | A 4ns shift attributable to cache-line layout after adding the `mu` field; the ±7% post-fix variance puts this inside noise |
| `ReadHeavyMixed_1Writer_NReaders` (**realistic ORCA shape**) | 51.4ns ± 10% | 52.1ns ± 1% | **~ none** (p=0.105) | **No statistically significant difference** — this is the workload PR #6799 cared about |
| `SetCPUUtilization_SingleWriter` | 70.2ns ± 1% | 71.2ns ± 5% | **+1.5%** | Uncontended mutex acquire (~1ns), unobservable |
| `SetNamedUtilization_SingleWriter` | 140.5ns ± 2% | 140.6ns ± 1% | **~ none** | Map allocation dominates; mutex cost invisible |
| `ConcurrentWriters_DistinctScalars` | 72.6ns ± 2% | 196.8ns ± 1% | **+170%** | Mutex queueing — but the pre-fix path is **incorrect** in this workload (every concurrent Set loses updates), so this is not an apples-to-apples comparison |
| `ConcurrentWriters_NamedKeys` | 239ns ± 1% | 478ns ± 0% | **+100%** | Same as above |

**Memory / allocations**: identical across all 6 benchmarks (0% B/op, 0% allocs/op).

**Absolute overhead on the ORCA write path**:

- Recommended sampler write rate: **1-10 Hz** per metric family.
- Even with 10 concurrent writers at 10 Hz × 478 ns/op = **48 μs/sec** of total CPU per recorder — **0.0048% of one core**. Unmeasurable in production.
- Meanwhile the reader path and the realistic happy-path: **zero regression**.

**Correctness vs PR #6799's "fast" path**: PR #6799 was "fast" on the concurrent-writer path precisely because it dropped writer-writer mutual exclusion — which is the lost-update bug. Any correct implementation has to serialise that path (mutex, CAS retry, or split atomics); there is no design that keeps PR #6799's raw concurrent-writer speed *and* removes the lost-update. This PR picks `sync.Mutex` because:

1. It is the simplest, lowest review-risk option.
2. The uncontended fast path (~25ns) is invisible at 1-10 Hz write rates.
3. It restores the pattern that existed before PR #6799, so `git revert` is safe.
4. **The reader path stays lock-free**, preserving PR #6799's actual win.

#### Risk & rollback

| Dimension | Assessment |
|---|---|
| Change surface | `orca/server_metrics.go` +40 lines (`mu` field + 16 sites with Lock/defer Unlock); +460 lines of tests and benchmarks, none of which ship in production binaries |
| Performance impact | Reader path and realistic ORCA shape: **zero regression** (benchstat p ≥ 0.105). Single writer: +1.5% (~1ns, unobservable). Concurrent writers: +100-170% relative, but < 50μs/sec absolute — unmeasurable in production. See Performance section above. |
| Data risk | None. External observable contract is unchanged; this PR restores the writer-writer mutual exclusion that existed before PR #6799. |
| Rollback | `git revert <sha>` |

#### Reviewer hints

1. Read the new struct doc comment at `orca/server_metrics.go:145-154` — confirm the "writer-serialized, lock-free publish" intent is clearly documented.
2. Scan the `s.mu.Lock(); defer s.mu.Unlock()` placement in every `Set*` / `Delete*` — they sit *after* the range checks (`if val < 0 { return }`) so invalid inputs don't queue on the mutex.
3. `orca/server_metrics.go:178-181` `ServerMetrics()` — confirm it does **not** take `mu`, preserving PR #6799's lock-free reader.
4. `server_metrics_safety_test.go::TestServerMetricsRecorderSafety_Monotonicity_ReaderObservesNoRollback` — this is the strongest invariant: a reader observing a monotonic writer must never see the value roll back. It catches the logical race without relying on the race detector.
5. Run the Reproduction section: stash the fix, run under `-race`, expect deterministic FAIL with no `DATA RACE` output; restore the fix, expect deterministic PASS.

#### Linked issues / discussions

- Regression source: [PR #6799](https://github.com/grpc/grpc-go/pull/6799) "orca: use atomic pointer instead of mutex in server metrics recorder to improve performance" (commit `02a4e93b`, merged 2023-10). That PR replaced the mutex with `atomic.Pointer` to optimise the reader path but did not preserve writer-writer mutual exclusion. `git log orca/server_metrics.go` shows the implementation has been unchanged from PR #6799 through `b58f32d9`. No related issue has been filed in the intervening ~2 years — because the race detector cannot catch logical races and the existing tests are single-threaded.
- gRFC: [A51 Custom Backend Metrics](https://github.com/grpc/proposal/blob/master/A51-custom-backend-metrics.md) defines the ORCA protocol but **does not specify whether `ServerMetricsRecorder` must be thread-safe**. However, the deployment shape described by A51 (a CPU sampler, a memory sampler, and per-RPC handlers writing backpressure signals) is inherently multi-writer, and the Go implementation's godoc promise of "safe setting" must hold for this pattern.

#### Out of scope (kept separate to avoid PR collisions)

- Other R3 P2 candidates — outlierdetection timer revival, xDS server `pendingFilterChainManager`, bootstrap call-creds cleanup, fault `MaxActiveFaults`, xdsclient `requests_counter`, EDS placeholder, `mem.Reader.Reset`, `attributes.Equal` — each follows in its own PR.

#### Pre-flight checks (passing locally)

- [x] `gofmt -l orca/server_metrics.go orca/server_metrics_safety_test.go orca/server_metrics_bench_test.go` clean
- [x] `go vet ./orca/...` clean
- [x] `go build ./...` succeeds
- [x] `orca/` package `go test`, normal + `-race`, all PASS
- [x] Downstream `balancer/weightedroundrobin/` package `go test`, normal + `-race`, all PASS
- [x] Stash + re-run + restore reproduction: pre-fix 2/2 FAIL, post-fix 3/3 PASS
- [ ] DCO sign-off applied at commit time (`git commit -s`)

#### Files changed

```
 orca/server_metrics.go              |  40 ++++++++++++++++++++++++++++++++
 orca/server_metrics_safety_test.go  | 290 +++++++++++++++++++++ (new)
 orca/server_metrics_bench_test.go   | 170 +++++++++++++++++++ (new, perf regression guard)
 3 files changed, 500 insertions(+)
```
