### PR TITLE
otel: Populate method names for tracing-only spans

### DIFF
--- a/stats/opentelemetry/client_tracing.go
+++ b/stats/opentelemetry/client_tracing.go
@@ -130,6 +130,7 @@ func (h *clientTracingHandler) TagRPC(ctx context.Context, info *stats.RPCTagInf
 		logger.Error("context passed into client side stats handler (TagRPC) has no call info")
 		return ctx
 	}
+	ri.ai.method = removeLeadingSlash(info.FullMethodName)
 	ctx = h.traceTagRPC(ctx, ri.ai, info.NameResolutionDelay)
 	return ctx
 }

--- a/stats/opentelemetry/e2e_test.go
+++ b/stats/opentelemetry/e2e_test.go
@@ -2401,8 +2401,8 @@ func (s) TestRelayContextCollisionMetrics(t *testing.T) {
 
 // TestRelayContextCollisionTracing verifies that span context is correctly
 // propagated from incoming server requests to outgoing client requests without
-// the client span accidentally adopting the server's identity or breaking the
-// trace chain.
+// the client span accidentally adopting the server's identity, losing method
+// names, or breaking the trace chain.
 func (s) TestRelayContextCollisionTracing(t *testing.T) {
 	backendTraceOpts, _ := defaultTraceOptions(t)
 	backendServer := setupStubServer(t, nil, backendTraceOpts)
@@ -2444,7 +2444,8 @@ func (s) TestRelayContextCollisionTracing(t *testing.T) {
 	_, _ = relayServer.Client.UnaryCall(ctx, &testpb.SimpleRequest{})
 
 	wantSpans := []traceSpanInfo{
-		{name: "Recv.", spanKind: "server"},
+		{name: "Recv.grpc.testing.TestService.UnaryCall", spanKind: "server"},
+		{name: "Attempt.grpc.testing.TestService.EmptyCall", spanKind: "internal"},
 		{name: "Sent.grpc.testing.TestService.EmptyCall", spanKind: "client"},
 	}
 	spans, err := waitForTraceSpans(ctx, relayTraceExporter, wantSpans)
@@ -2454,7 +2455,7 @@ func (s) TestRelayContextCollisionTracing(t *testing.T) {
 
 	var srvTraceID, cliTraceID oteltrace.TraceID
 	for _, span := range spans {
-		if span.Name == "Recv." && span.SpanKind == oteltrace.SpanKindServer {
+		if span.Name == "Recv.grpc.testing.TestService.UnaryCall" && span.SpanKind == oteltrace.SpanKindServer {
 			srvTraceID = span.SpanContext.TraceID()
 		}
 		if span.Name == "Sent.grpc.testing.TestService.EmptyCall" && span.SpanKind == oteltrace.SpanKindClient {

--- a/stats/opentelemetry/server_tracing.go
+++ b/stats/opentelemetry/server_tracing.go
@@ -39,8 +39,9 @@ func (h *serverTracingHandler) initializeTraces() {
 }
 
 // TagRPC implements per RPC attempt context management for traces.
-func (h *serverTracingHandler) TagRPC(ctx context.Context, _ *stats.RPCTagInfo) context.Context {
+func (h *serverTracingHandler) TagRPC(ctx context.Context, info *stats.RPCTagInfo) context.Context {
 	ctx, ri := getOrCreateServerRPCInfo(ctx)
+	ri.ai.method = removeLeadingSlash(info.FullMethodName)
 	ctx, _ = h.traceTagRPC(ctx, ri.ai)
 	return ctx
 }


### PR DESCRIPTION
Fixes #9097

Tracing-only stats handlers currently start server and attempt spans before attemptInfo.method is populated. Metrics handlers populate that field, so the problem is hidden when metrics and tracing are enabled together.

This change populates the method in client and server tracing TagRPC directly, and tightens the relay tracing regression to require the expected server and attempt span names when only tracing is enabled.

Tests:
- go test ./stats/opentelemetry -run 'Test/RelayContextCollisionTracing' -count=1
- go test ./stats/opentelemetry -count=1
- git diff --check

RELEASE NOTES:
* otel: Fix tracing-only instrumentation to include RPC method names in server and attempt span names.