### PR TITLE
stats/opentelemetry: populate method name in server trace span via TagRPC info

### DIFF
--- a/stats/opentelemetry/e2e_test.go
+++ b/stats/opentelemetry/e2e_test.go
@@ -2444,7 +2444,7 @@ func (s) TestRelayContextCollisionTracing(t *testing.T) {
 	_, _ = relayServer.Client.UnaryCall(ctx, &testpb.SimpleRequest{})
 
 	wantSpans := []traceSpanInfo{
-		{name: "Recv.", spanKind: "server"},
+		{name: "Recv.grpc.testing.TestService.UnaryCall", spanKind: "server"},
 		{name: "Sent.grpc.testing.TestService.EmptyCall", spanKind: "client"},
 	}
 	spans, err := waitForTraceSpans(ctx, relayTraceExporter, wantSpans)
@@ -2454,7 +2454,7 @@ func (s) TestRelayContextCollisionTracing(t *testing.T) {
 
 	var srvTraceID, cliTraceID oteltrace.TraceID
 	for _, span := range spans {
-		if span.Name == "Recv." && span.SpanKind == oteltrace.SpanKindServer {
+		if span.Name == "Recv.grpc.testing.TestService.UnaryCall" && span.SpanKind == oteltrace.SpanKindServer {
 			srvTraceID = span.SpanContext.TraceID()
 		}
 		if span.Name == "Sent.grpc.testing.TestService.EmptyCall" && span.SpanKind == oteltrace.SpanKindClient {

--- a/stats/opentelemetry/server_tracing.go
+++ b/stats/opentelemetry/server_tracing.go
@@ -39,9 +39,9 @@ func (h *serverTracingHandler) initializeTraces() {
 }
 
 // TagRPC implements per RPC attempt context management for traces.
-func (h *serverTracingHandler) TagRPC(ctx context.Context, _ *stats.RPCTagInfo) context.Context {
+func (h *serverTracingHandler) TagRPC(ctx context.Context, info *stats.RPCTagInfo) context.Context {
 	ctx, ri := getOrCreateServerRPCInfo(ctx)
-	ctx, _ = h.traceTagRPC(ctx, ri.ai)
+	ctx, _ = h.traceTagRPC(ctx, ri.ai, info.FullMethodName)
 	return ctx
 }
 
@@ -52,8 +52,8 @@ func (h *serverTracingHandler) TagRPC(ctx context.Context, _ *stats.RPCTagInfo) 
 // is set as parent of the new span otherwise new span remains the root span.
 // If TextMapPropagator is not provided in the trace options, it returns context
 // as is.
-func (h *serverTracingHandler) traceTagRPC(ctx context.Context, ai *attemptInfo) (context.Context, *attemptInfo) {
-	mn := "Recv." + strings.Replace(ai.method, "/", ".", -1)
+func (h *serverTracingHandler) traceTagRPC(ctx context.Context, ai *attemptInfo, method string) (context.Context, *attemptInfo) {
+	mn := "Recv." + strings.Replace(method, "/", ".", -1)
 	var span trace.Span
 	tracer := h.options.TraceOptions.TracerProvider.Tracer(tracerName, trace.WithInstrumentationVersion(grpc.Version))
 	ctx = h.options.TraceOptions.TextMapPropagator.Extract(ctx, otelinternaltracing.NewIncomingCarrier(ctx))


### PR DESCRIPTION
## Problem

`serverTracingHandler.TagRPC` was ignoring `info.FullMethodName` (using `_` as the parameter name) and instead relied on `ai.method` being populated by `serverMetricsHandler.TagRPC`. This caused the server-side trace span to be named `"Recv."` (without a method name) whenever tracing is enabled but metrics are not, because `ai.method` is never set in that case.

The bug was introduced in the refactor that segregated client and server `RPCInfo` context keys — the tracing handler lost access to the method name it previously obtained indirectly through shared state.

Reported in #9097, referenced in the review of #9081.

## Root cause

```go
// Before: ignores info.FullMethodName; uses ai.method which is only set by metrics handler
func (h *serverTracingHandler) TagRPC(ctx context.Context, _ *stats.RPCTagInfo) context.Context {
    ctx, ri := getOrCreateServerRPCInfo(ctx)
    ctx, _ = h.traceTagRPC(ctx, ri.ai)  // ai.method is "" if metrics not enabled
    return ctx
}
```

## Fix

Pass `info.FullMethodName` directly to `traceTagRPC` so the span name is always constructed from the actual RPC method, independent of whether the metrics handler has run:

```go
func (h *serverTracingHandler) TagRPC(ctx context.Context, info *stats.RPCTagInfo) context.Context {
    ctx, ri := getOrCreateServerRPCInfo(ctx)
    ctx, _ = h.traceTagRPC(ctx, ri.ai, info.FullMethodName)
    return ctx
}
```

Also updates `TestRelayContextCollisionTracing` to expect the correct span name `"Recv.grpc.testing.TestService.UnaryCall"` instead of the buggy `"Recv."`.

Fixes #9097