### PR TITLE
otel: populate method name in tracing-only TagRPC handlers

### DIFF
--- a/stats/opentelemetry/client_tracing.go
+++ b/stats/opentelemetry/client_tracing.go
@@ -125,6 +125,7 @@ func (h *clientTracingHandler) HandleConn(context.Context, stats.ConnStats) {}
 // TagRPC implements per RPC attempt context management for traces.
 func (h *clientTracingHandler) TagRPC(ctx context.Context, info *stats.RPCTagInfo) context.Context {
 	ctx, ri := getOrCreateClientRPCInfo(ctx)
+	ri.ai.method = removeLeadingSlash(info.FullMethodName)
 	ci := getCallInfo(ctx)
 	if ci == nil {
 		logger.Error("context passed into client side stats handler (TagRPC) has no call info")

--- a/stats/opentelemetry/server_tracing.go
+++ b/stats/opentelemetry/server_tracing.go
@@ -39,8 +39,9 @@ func (h *serverTracingHandler) initializeTraces() {
 }
 
 // TagRPC implements per RPC attempt context management for traces.
-func (h *serverTracingHandler) TagRPC(ctx context.Context, _ *stats.RPCTagInfo) context.Context {
+func (h *serverTracingHandler) TagRPC(ctx context.Context, info *stats.RPCTagInfo) context.Context {
 	ctx, ri := getOrCreateServerRPCInfo(ctx)
+	ri.ai.method = removeLeadingSlash(info.FullMethodName)
 	ctx, _ = h.traceTagRPC(ctx, ri.ai)
 	return ctx
 }


### PR DESCRIPTION
When only the tracing handler is enabled (no metrics handler), span names
for both client and server were always missing the method name, producing
spans named `"Recv."` and `"Attempt."` instead of e.g.
`"Recv.grpc.testing.TestService.UnaryCall"`.

### Root cause

Both `clientTracingHandler.TagRPC` and `serverTracingHandler.TagRPC`
never set `ri.ai.method` from the incoming `stats.RPCTagInfo.FullMethodName`.
Before #9081 this worked incidentally: the client/server rpcInfo context
key was shared between the metrics and tracing handlers, so the metrics
handler's `TagRPC` populated `ai.method` and the tracing handler picked it
up from the same `attemptInfo`. After #9081 introduced separate context
keys (`clientRPCInfoKey` / `serverRPCInfoKey`), each handler holds its own
`rpcInfo`, so the tracing handlers must set the method name themselves.

### Fix

Read `FullMethodName` from `RPCTagInfo` in both tracing `TagRPC` methods
and assign it to `ri.ai.method` (normalised with `removeLeadingSlash`,
consistent with how the metrics handlers do it).

Fixes #9097